### PR TITLE
docs: update install instructions to use curl one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,7 @@ Verify the gateway is up with `openclaw gateway status`. See the [OpenClaw Getti
 ### Install DefenseClaw
 
 ```bash
-git clone https://github.com/defenseclaw/defenseclaw.git
-cd defenseclaw
-make dist
-./scripts/install.sh --local dist/
+curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash
 defenseclaw init --enable-guardrail
 ```
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -23,10 +23,7 @@ for full details.
 ### Install DefenseClaw
 
 ```bash
-git clone https://github.com/defenseclaw/defenseclaw.git
-cd defenseclaw
-make build
-source .venv/bin/activate
+curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash
 defenseclaw init --enable-guardrails
 ```
 


### PR DESCRIPTION
Replace clone-and-build installation steps in README and QUICKSTART with the hosted install script for simpler end-user setup.