### PR TITLE
Make plugin build resilient to NODE_ENV=production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ start: gateway
 
 plugin:
 	@command -v npm >/dev/null 2>&1 || { echo "npm not found — install Node.js from https://nodejs.org/"; exit 1; }
-	cd $(PLUGIN_DIR) && npm install && npm run build
+	cd $(PLUGIN_DIR) && NODE_ENV=development npm ci --include=dev && npm run build
 	@echo ""
 	@echo "Built OpenClaw plugin → $(PLUGIN_DIR)/dist/"
 	@echo "  Install with: make plugin-install"


### PR DESCRIPTION
## Summary
- make the OpenClaw plugin build install dev dependencies explicitly
- stop `make plugin` and `make plugin-install` from failing when the shell or container sets `NODE_ENV=production`

## Why
A clean checkout of the published repo builds fine, but the current Makefile uses plain `npm install` for the plugin build. In environments that export `NODE_ENV=production`, npm omits dev dependencies such as `typescript` and `@types/node`, so the plugin build fails even though the repo itself is otherwise healthy.

## Validation
- `cd extensions/defenseclaw && rm -rf node_modules dist && NODE_ENV=production npm ci --include=dev && npm run build`
- `NODE_ENV=production make plugin`
