### PR TITLE
fix: warn on startup and in doctor when guardrail.model is empty

### DIFF
--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -192,6 +192,14 @@ def _check_guardrail_proxy(cfg, r: _DoctorResult) -> None:
         r.record("skip")
         return
 
+    if not cfg.guardrail.model:
+        _emit(
+            "fail", "Guardrail proxy",
+            "guardrail.model is empty — set it in ~/.defenseclaw/config.yaml",
+        )
+        r.record("fail")
+        return
+
     url = f"http://127.0.0.1:{cfg.guardrail.port}/health/liveliness"
     code, _ = _http_probe(url, timeout=5.0)
     if code == 200:

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -81,6 +81,11 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		s.cfg.Gateway.AutoApprove, s.cfg.Gateway.Watcher.Enabled, s.cfg.Gateway.APIPort, s.cfg.Guardrail.Enabled)
 	_ = s.logger.LogAction("sidecar-start", "", "starting all subsystems")
 
+	if s.cfg.Guardrail.Enabled && s.cfg.Guardrail.Model == "" {
+		fmt.Fprintf(os.Stderr, "[sidecar] WARNING: guardrail.enabled is true but guardrail.model is empty — guardrail proxy will fail.\n")
+		fmt.Fprintf(os.Stderr, "[sidecar]          Set guardrail.model in ~/.defenseclaw/config.yaml (e.g. anthropic/claude-sonnet-4-20250514)\n")
+	}
+
 	var wg sync.WaitGroup
 	errCh := make(chan error, 4)
 


### PR DESCRIPTION
When guardrail.enabled is true but guardrail.model is empty, the proxy enters ERROR state silently. Now the sidecar warns at startup and defenseclaw doctor reports it as a failure with a remediation hint.