### PR TITLE
Clarify local Splunk trial and Free mode behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,10 +305,12 @@ Splunk General Terms and the local-mode scope guardrails documented in
 
 The bundled local runtime starts as a local Splunk Enterprise Trial. After the
 60-day trial period, you can continue using the same local single-instance
-workflow in Splunk Free mode unless you apply another valid Splunk Enterprise
-license. In Splunk Free mode, alerting is disabled, authentication and RBAC are
-removed, and the local user credentials printed by the setup command no longer
-apply. Existing Splunk license and ingest limits still apply in every mode.
+workflow in Splunk Free mode. In Splunk Free mode, alerting is disabled,
+authentication and RBAC are removed, and the local user credentials printed by
+the setup command no longer apply. Existing Splunk license and ingest limits
+still apply in every mode. To keep using full Splunk Enterprise features after
+the trial, apply a valid Splunk Enterprise license. For more details, see
+[About Splunk Free](https://help.splunk.com/en/splunk-enterprise/administer/admin-manual/10.2/configure-splunk-licenses/about-splunk-free).
 
 That command also installs the local Splunk app automatically. The app gives
 users a purpose-built investigation surface for DefenseClaw audit activity,

--- a/README.md
+++ b/README.md
@@ -303,6 +303,13 @@ Splunk runtime through this preset, local Splunk usage is subject to the
 Splunk General Terms and the local-mode scope guardrails documented in
 [docs/INSTALL.md](docs/INSTALL.md).
 
+The bundled local runtime starts as a local Splunk Enterprise Trial. After the
+60-day trial period, you can continue using the same local single-instance
+workflow in Splunk Free mode unless you apply another valid Splunk Enterprise
+license. In Splunk Free mode, alerting is disabled, authentication and RBAC are
+removed, and the local user credentials printed by the setup command no longer
+apply. Existing Splunk license and ingest limits still apply in every mode.
+
 That command also installs the local Splunk app automatically. The app gives
 users a purpose-built investigation surface for DefenseClaw audit activity,
 OpenClaw runtime evidence, diagnostics, metrics, traces, and saved searches.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -56,6 +56,12 @@ access, or use the software.
 Scope guardrails for the local Splunk preset:
 
 - use it only for local, single-instance workflows
+- expect the bundled runtime to start in a local Splunk Enterprise Trial mode
+- after the 60-day trial, continue using the same local single-instance setup
+  in Splunk Free mode unless you apply another valid Splunk Enterprise license
+- in Splunk Free mode, alerting is disabled
+- in Splunk Free mode, authentication and RBAC are removed, so the
+  setup-printed local user credentials no longer apply
 - assume existing Splunk license limits still apply
 - do not treat it as an endorsed path to multi-instance or long-term
   deployment
@@ -488,9 +494,12 @@ defenseclaw setup splunk
 | `--disable` | Disable integration(s); combine with `--o11y` / `--logs` to scope |
 | `--non-interactive` | Requires at least `--o11y` or `--logs` |
 
-The `--logs` option requires Docker and sets up a local Splunk
-Enterprise container with the DefenseClaw Splunk bridge
-(`splunk-claw-bridge`).
+The `--logs` option requires Docker and sets up a local Splunk runtime with the
+DefenseClaw Splunk bridge (`splunk-claw-bridge`). By default, that runtime
+starts in a local Splunk Enterprise Trial mode. After the 60-day trial period,
+you can continue using the same local single-instance workflow in Splunk Free
+mode unless you apply another valid Splunk Enterprise license. In Splunk Free
+mode, alerting is disabled and authentication is not required.
 
 ```bash
 # Enable Splunk Observability

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -58,10 +58,12 @@ Scope guardrails for the local Splunk preset:
 - use it only for local, single-instance workflows
 - expect the bundled runtime to start in a local Splunk Enterprise Trial mode
 - after the 60-day trial, continue using the same local single-instance setup
-  in Splunk Free mode unless you apply another valid Splunk Enterprise license
+  in Splunk Free mode
 - in Splunk Free mode, alerting is disabled
 - in Splunk Free mode, authentication and RBAC are removed, so the
   setup-printed local user credentials no longer apply
+- to keep using full Splunk Enterprise features after the trial, apply a valid
+  Splunk Enterprise license
 - assume existing Splunk license limits still apply
 - do not treat it as an endorsed path to multi-instance or long-term
   deployment
@@ -498,8 +500,10 @@ The `--logs` option requires Docker and sets up a local Splunk runtime with the
 DefenseClaw Splunk bridge (`splunk-claw-bridge`). By default, that runtime
 starts in a local Splunk Enterprise Trial mode. After the 60-day trial period,
 you can continue using the same local single-instance workflow in Splunk Free
-mode unless you apply another valid Splunk Enterprise license. In Splunk Free
-mode, alerting is disabled and authentication is not required.
+mode. In Splunk Free mode, alerting is disabled and authentication is not
+required. To keep using full Splunk Enterprise features after the trial, apply
+a valid Splunk Enterprise license. For more details, see
+https://help.splunk.com/en/splunk-enterprise/administer/admin-manual/10.2/configure-splunk-licenses/about-splunk-free
 
 ```bash
 # Enable Splunk Observability


### PR DESCRIPTION
## Summary
- document that the bundled local Splunk runtime starts in Enterprise Trial mode
- clarify the post-60-day local workflow in Splunk Free mode
- call out that alerting is disabled and login/RBAC no longer apply in Splunk Free mode

## Scope
- README local Splunk section
- INSTALL guide local Splunk terms and --logs behavior

## Notes
- this keeps the wording outcome-focused and does not overstate the exact transition mechanics between trial and free modes