### PR TITLE
OTel GenAI Semconv Spans, Metrics, and Delta Temporality

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Events are batched (default 50) and flushed every 5 seconds. Each event includes
 
 ### OTLP Export
 
-The daemon exports logs, spans, and metrics via OTLP HTTP to any compatible collector (Jaeger, Grafana, Datadog, etc.):
+The daemon exports logs, spans, and metrics via OTLP HTTP to any compatible collector (Splunk Observability Platform, Jaeger, Grafana, etc.):
 
 ```bash
 export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Events are batched (default 50) and flushed every 5 seconds. Each event includes
 
 ### OTLP Export
 
-The daemon exports logs, spans, and metrics via OTLP HTTP to any compatible collector (Splunk Observability Platform, Jaeger, Grafana, etc.):
+The daemon exports logs, spans, and metrics via OTLP HTTP to any compatible collector (Splunk Observability Cloud, Jaeger, Grafana, etc.):
 
 ```bash
 export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -1978,7 +1978,7 @@ def _print_splunk_status(app: AppContext) -> None:
     sc = app.cfg.splunk
 
     if otel.enabled:
-        click.echo("  Splunk Observability (OTLP):")
+        click.echo("  Splunk Observability Cloud (OTLP):")
         click.echo("    Status:      enabled")
         if otel.traces.endpoint:
             realm = otel.traces.endpoint.replace("ingest.", "").replace(".observability.splunkcloud.com", "")

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -506,7 +506,7 @@ a valid Splunk Enterprise license. For more details, see
 https://help.splunk.com/en/splunk-enterprise/administer/admin-manual/10.2/configure-splunk-licenses/about-splunk-free
 
 ```bash
-# Enable Splunk Observability
+# Enable Splunk Observability Cloud
 defenseclaw setup splunk --o11y --realm us1 --access-token $SPLUNK_TOKEN --non-interactive
 
 # Enable local Splunk logs (requires Docker)

--- a/docs/OTEL-IMPLEMENTATION-STATUS.md
+++ b/docs/OTEL-IMPLEMENTATION-STATUS.md
@@ -1,24 +1,64 @@
 # DefenseClaw OpenTelemetry — Implementation Status
 
-> Audit of `OTEL.md` spec vs actual implementation as of 2026-03-29.
+> Audit of `OTEL.md` spec vs actual implementation as of 2026-04-01.
 
 ---
 
 ## Summary
 
-The OTel implementation covers **3 of 4 signal categories** fully, with
-partial implementation of the fourth (Runtime Traces). Overall the
-telemetry foundation is mature — the main gap is **LLM call spans**,
-which are defined in code but never wired to any event source.
+The OTel implementation covers **all 4 signal categories** fully. The
+guardrail proxy path provides full GenAI semconv trace hierarchy with
+`invoke_agent`, `chat`, `apply_guardrail`, and `execute_tool` spans.
 
 | Category | Spec Section | Status | Notes |
 |----------|-------------|--------|-------|
 | Asset lifecycle events | §3 Logs | **COMPLETE** | All actions mapped and emitted |
 | Asset scan results | §4 Logs + Metrics | **COMPLETE** | Summary + individual findings + metrics |
-| Runtime events (Traces) | §5 Traces | **PARTIAL** | Tool + Approval spans wired; LLM spans dead code |
+| Runtime events (Traces) | §5 Traces | **COMPLETE** | Full proxy path + WS tool/approval spans |
 | Runtime alerts | §6 Logs | **COMPLETE** | All alert types emitted |
-| Metrics | §7 | **COMPLETE** | All counters/histograms registered, 28+ instruments |
+| Metrics | §7 | **COMPLETE** | `gen_ai.client.*` semconv + `defenseclaw.*` custom metrics |
 | Configuration | §8 | **COMPLETE** | Full config struct, env var overrides |
+
+---
+
+## Telemetry Paths
+
+DefenseClaw has **two distinct telemetry paths**:
+
+### Path 1: Guardrail Proxy (LLM Gateway)
+
+HTTP proxy on port 4000 intercepts OpenAI-compatible requests. Produces
+the full GenAI semconv trace hierarchy:
+
+```
+invoke_agent {agentName}                    root span (SpanKind=INTERNAL)
+├── apply_guardrail defenseclaw input       input inspection
+└── chat {model}                            LLM call (SpanKind=CLIENT)
+    ├── apply_guardrail defenseclaw output  output inspection
+    ├── execute_tool {toolName}             per tool_call in response
+    │   └── apply_guardrail defenseclaw tool_call  tool args inspection
+    └── execute_tool {toolName}
+        └── apply_guardrail defenseclaw tool_call
+```
+
+**Metrics emitted per LLM call:**
+- `gen_ai.client.token.usage` — histogram, `{token}`, with `gen_ai.token.type` = `input`/`output`
+- `gen_ai.client.operation.duration` — histogram, `s`
+
+**Common attributes on both metrics:**
+- `gen_ai.operation.name` (e.g. `chat`)
+- `gen_ai.provider.name` (e.g. `defenseclaw`)
+- `gen_ai.request.model` (e.g. `gpt-4o-mini`)
+
+### Path 2: WebSocket Event Router
+
+Gateway subscribes to OpenClaw WebSocket events. Tool/approval spans are
+emitted from real-time agent session events:
+
+```
+tool/{toolName}           from tool_call → tool_result WS events
+exec.approval/{id}        from exec.approval.requested WS events
+```
 
 ---
 
@@ -28,50 +68,14 @@ which are defined in code but never wired to any event source.
 
 | Method | File | Wired In Production? | Trigger |
 |--------|------|---------------------|---------|
-| `EmitStartupSpan` | `runtime.go:35` | **YES** | Gateway startup (once) |
-| `EmitInspectSpan` | `runtime.go:49` | **YES** | HTTP `/inspect/tool` (CodeGuard) |
-| `StartToolSpan` / `EndToolSpan` | `runtime.go:70–148` | **YES** | WS `tool_call` / `tool_result` via `router.go` |
-| `StartApprovalSpan` / `EndApprovalSpan` | `runtime.go:150–210` | **YES** | WS `exec.approval.requested` via `router.go` |
-| `StartLLMSpan` / `EndLLMSpan` | `runtime.go:212–280` | **NO — DEAD CODE** | No caller anywhere in codebase |
-| `StartPolicySpan` / `EndPolicySpan` | `policy.go:20–80` | **YES** | HTTP `/policy/evaluate/*` + watcher |
-
-#### LLM Span Gap Analysis
-
-`StartLLMSpan()` and `EndLLMSpan()` are fully implemented with correct
-GenAI semantic convention attributes (`gen_ai.system`, `gen_ai.request.model`,
-`gen_ai.usage.prompt_tokens`, etc.) but **zero production callers exist**.
-
-**Root cause**: OpenClaw does not emit `llm_call` / `llm_result` WebSocket
-events. The `OTEL.md` spec (§9c) documents these as "future":
-
-```
-### 9c. LLM Gateway Hooks (future)
-When OpenClaw provides `llm_call` / `llm_result` events: ...
-```
-
-The `EventRouter.Route()` switch in `router.go` handles these events:
-- `tool_call` → `handleToolCall()` → `StartToolSpan` ✓
-- `tool_result` → `handleToolResult()` → `EndToolSpan` ✓
-- `exec.approval.requested` → `handleApprovalRequest()` → `StartApprovalSpan` ✓
-- `session.tool` → normalizes to `tool_call`/`tool_result` ✓
-- `agent` (stream=tool) → normalizes to `session.tool` ✓
-- `session.message` (stream=tool) → normalizes to `session.tool` ✓
-
-**No handler exists for `llm_call` / `llm_result`**. The `session.message`
-handler (Format A) parses chat messages with `model` and `provider` fields
-but only logs them — it does not create LLM spans.
-
-#### What Would Be Needed for LLM Spans
-
-Two options:
-
-1. **Wait for OpenClaw** to emit explicit `llm_call` / `llm_result` events
-   and add handlers in `Route()` (the spec's stated plan).
-
-2. **Derive LLM spans from `session.message`** — the `handleSessionMessage()`
-   Format A handler already parses `role`, `model`, `provider`, `stopReason`,
-   and `content`, but no telemetry calls are made. An `assistant` message
-   with a `model` field could trigger `StartLLMSpan`/`EndLLMSpan`.
+| `EmitStartupSpan` | `runtime.go` | **YES** | Gateway startup (once) |
+| `EmitInspectSpan` | `runtime.go` | **YES** | HTTP `/inspect/tool` (CodeGuard) |
+| `StartAgentSpan` / `EndAgentSpan` | `runtime.go` | **YES** | Guardrail proxy — per HTTP request |
+| `StartLLMSpan` / `EndLLMSpan` | `runtime.go` | **YES** | Guardrail proxy — LLM forward + response |
+| `StartGuardrailSpan` / `EndGuardrailSpan` | `runtime.go` | **YES** | Guardrail proxy — input/output/tool_call inspection |
+| `StartToolSpan` / `EndToolSpan` | `runtime.go` | **YES** | Guardrail proxy (tool_calls in response) + WS events |
+| `StartApprovalSpan` / `EndApprovalSpan` | `runtime.go` | **YES** | WS `exec.approval.requested` via `router.go` |
+| `StartPolicySpan` / `EndPolicySpan` | `policy.go` | **YES** | HTTP `/policy/evaluate/*` + watcher |
 
 ### Logs
 
@@ -80,12 +84,16 @@ Two options:
 | `EmitLifecycleEvent` | `lifecycle.go` | **YES** | `audit.Logger.LogAction()` |
 | `EmitScanResult` | `scan.go` | **YES** | `audit.Logger.LogScan()` |
 | `EmitScanFinding` | `scan.go` | **YES** | Per-finding (opt-in `emit_individual_findings`) |
-| `EmitRuntimeAlert` | `alerts.go` | **YES** | `router.go` (dangerous commands, guardrails) + `inspect.go` (CodeGuard) |
+| `EmitRuntimeAlert` | `alerts.go` | **YES** | `router.go` + `inspect.go` + guardrail proxy |
 
-### Metrics
+### Metrics — GenAI Semconv
 
-All metric instruments are registered in `metrics.go` and recorded by their
-respective telemetry methods. **All spec'd metrics from §7 are implemented**:
+| Metric | Instrument | Unit | Buckets | Callers |
+|--------|-----------|------|---------|---------|
+| `gen_ai.client.token.usage` | Float64Histogram | `{token}` | 1,4,16,...,67M | `RecordLLMTokens()` ← `EndLLMSpan()` |
+| `gen_ai.client.operation.duration` | Float64Histogram | `s` | 0.01,...,81.92 | `RecordLLMDuration()` ← `EndLLMSpan()` |
+
+### Metrics — DefenseClaw Custom
 
 | Metric | Instrument | Callers |
 |--------|-----------|---------|
@@ -97,17 +105,61 @@ respective telemetry methods. **All spec'd metrics from §7 are implemented**:
 | `defenseclaw.tool.duration` | Histogram | `RecordToolDuration()` ← `EndToolSpan()` |
 | `defenseclaw.tool.errors` | Counter | `RecordToolError()` ← `EndToolSpan()` |
 | `defenseclaw.approval.count` | Counter | `RecordApproval()` ← `EndApprovalSpan()` |
-| `defenseclaw.llm.calls` | Counter | `RecordLLMCall()` ← `StartLLMSpan()` (**dead path**) |
-| `defenseclaw.llm.tokens` | Counter | `RecordLLMTokens()` ← `EndLLMSpan()` (**dead path**) |
-| `defenseclaw.llm.duration` | Histogram | `RecordLLMDuration()` ← `EndLLMSpan()` (**dead path**) |
 | `defenseclaw.alert.count` | Counter | `RecordAlert()` ← `EmitRuntimeAlert()` |
 | `defenseclaw.guardrail.evaluations` | Counter | `RecordGuardrailEvaluation()` |
 | `defenseclaw.guardrail.latency` | Histogram | `RecordGuardrailLatency()` |
 | `defenseclaw.policy.evaluations` | Counter | `RecordPolicyEvaluation()` ← `EndPolicySpan()` |
 | `defenseclaw.policy.latency` | Histogram | `RecordPolicyLatency()` ← `EndPolicySpan()` |
 
-**Note**: LLM metrics (`defenseclaw.llm.*`) instruments are registered but
-never called because the LLM span methods are dead code.
+---
+
+## Gaps and Recommendations
+
+### 1. `gen_ai.agent.name` propagation to metrics
+
+**Current state**: The `invoke_agent` span carries `gen_ai.agent.name` but
+`RecordLLMTokens()` and `RecordLLMDuration()` do not include it as a metric
+attribute. The SDOT Python utils (`MetricsEmitter`) propagate `gen_ai.agent.name`
+to all `gen_ai.client.*` metrics when `llm_invocation.agent_name` is set.
+
+**Action**: Add optional `agentName` parameter to `RecordLLMTokens()` and
+`RecordLLMDuration()`. Thread agent name from the proxy handler (known at
+`StartAgentSpan` time) through to `EndLLMSpan()` → metric recording.
+
+### 2. `gen_ai.workflow.name` support
+
+**Current state**: No workflow concept exists in DefenseClaw proxy path.
+The SDOT utils support `Workflow` as a parent span with `gen_ai.workflow.name`
+that propagates to all child LLM calls. DefenseClaw could treat the OpenClaw
+conversation/session as a workflow.
+
+**Action**: Optional for v1. Consider adding `gen_ai.workflow.name` to
+the `invoke_agent` span attributes and to metric dimensions when a workflow
+name is available (e.g. from OpenClaw config or conversation metadata).
+
+### 3. Span attributes alignment with SDOT semconv
+
+**Current state**: DefenseClaw spans use correct `gen_ai.*` attributes.
+Some attributes are DefenseClaw-specific (`defenseclaw.llm.tool_calls`,
+`defenseclaw.llm.guardrail`, etc.) — these are additive over semconv.
+
+The `execute_tool` spans from the proxy path use `gen_ai.operation.name`
+and `gen_ai.tool.name` matching semconv. The WS-path tool spans use
+`defenseclaw.tool.*` attributes (different naming, predates proxy path).
+
+**Action**: Consider aligning WS-path tool spans to also use `gen_ai.*`
+semconv attributes for consistency.
+
+### 4. `gen_ai.system` attribute on spans and metrics
+
+**Current state**: `StartLLMSpan` sets `gen_ai.system` on the span but
+`RecordLLMTokens`/`RecordLLMDuration` use `gen_ai.provider.name` instead.
+The SDOT utils include `gen_ai.system` in metrics via the `system` field
+on `GenAI` base type, separate from `provider`.
+
+**Action**: The proxy passes `"defenseclaw"` as `providerName` because it
+acts as a proxy, not the actual LLM provider. Consider also passing the
+underlying `gen_ai.system` (e.g. `openai`) for proper metric dimensioning.
 
 ---
 
@@ -140,24 +192,42 @@ OpenClaw WebSocket Events
 └── tick/health/presence/heartbeat ──────→ ignored
 ```
 
-**Key observation**: Tool calls reach `StartToolSpan`/`EndToolSpan` via
-5 different OpenClaw event formats (tool_call, session.tool, agent stream,
-agent legacy, session.message stream). The normalization is robust.
-
 ---
 
-## Runtime Span Prerequisites
+## Guardrail Proxy — Request Flow
 
-Tool, approval, and inspect spans **require a live OpenClaw WebSocket
-connection**. The gateway connects to OpenClaw at `wss://<host>:<port>` and
-receives events only when an agent session is actively running.
-
-Without OpenClaw:
-- `defenseclaw/startup` span — **always emitted** (verifies pipeline)
-- `tool/*` spans — **never emitted** (no `tool_call` events arrive)
-- `exec.approval/*` spans — **never emitted** (no approval events)
-- `inspect/*` spans — **emitted via HTTP** (CodeGuard, not WS-dependent)
-- `policy/*` spans — **emitted via HTTP** (REST API or watcher, not WS-dependent)
+```
+HTTP POST /v1/chat/completions
+│
+├── StartAgentSpan(conversationID, "openclaw")
+│
+├── Input Inspection
+│   ├── StartGuardrailSpan("defenseclaw", "input", model)
+│   ├── inspector.Inspect(direction="prompt")
+│   └── EndGuardrailSpan(decision, severity)
+│
+├── StartLLMSpan(system, model, provider, maxTokens, temperature)
+│
+├── ChatCompletion → upstream LLM provider
+│
+├── Output Inspection (if content present)
+│   ├── StartGuardrailSpan("defenseclaw", "output", model)
+│   ├── inspector.Inspect(direction="completion")
+│   └── EndGuardrailSpan(decision, severity)
+│
+├── Tool Call Spans (for each tool_call in response)
+│   ├── StartToolSpan(toolName)
+│   ├── StartGuardrailSpan("defenseclaw", "tool_call", model)
+│   ├── inspector.Inspect(direction="tool_call", content=args)
+│   ├── EndGuardrailSpan(decision, severity)
+│   └── EndToolSpan(toolName)
+│
+├── EndLLMSpan(model, tokens, finishReasons, toolCallCount, guardrail)
+│   ├── RecordLLMTokens → gen_ai.client.token.usage
+│   └── RecordLLMDuration → gen_ai.client.operation.duration
+│
+└── EndAgentSpan
+```
 
 ---
 
@@ -165,28 +235,19 @@ Without OpenClaw:
 
 | File | Purpose | Signal Types |
 |------|---------|-------------|
-| `internal/telemetry/provider.go` | OTel Provider, InitProvider, TracerProvider/LoggerProvider/MeterProvider | All |
-| `internal/telemetry/resource.go` | buildResource() with all resource attributes | All |
-| `internal/telemetry/lifecycle.go` | EmitLifecycleEvent() — asset install/block/allow/quarantine | Logs |
+| `internal/telemetry/provider.go` | OTel Provider, InitProvider | All |
+| `internal/telemetry/resource.go` | buildResource() | All |
+| `internal/telemetry/lifecycle.go` | EmitLifecycleEvent() | Logs |
 | `internal/telemetry/scan.go` | EmitScanResult(), EmitScanFinding() | Logs + Metrics |
-| `internal/telemetry/runtime.go` | StartToolSpan, EndToolSpan, StartLLMSpan (**dead**), EndLLMSpan (**dead**), StartApprovalSpan, EndApprovalSpan, EmitStartupSpan, EmitInspectSpan | Traces + Metrics |
+| `internal/telemetry/runtime.go` | Agent/LLM/Tool/Approval/Guardrail spans | Traces + Metrics |
 | `internal/telemetry/alerts.go` | EmitRuntimeAlert() | Logs + Metrics |
-| `internal/telemetry/metrics.go` | All metric instruments (28+ counters/histograms) | Metrics |
+| `internal/telemetry/metrics.go` | All metric instruments (28+) | Metrics |
 | `internal/telemetry/policy.go` | StartPolicySpan, EndPolicySpan | Traces + Metrics |
-| `internal/gateway/router.go` | EventRouter — WS event dispatch, tool/approval span lifecycle | Consumes telemetry |
-| `internal/gateway/inspect.go` | CodeGuard inspection — EmitInspectSpan, EmitRuntimeAlert | Consumes telemetry |
-| `internal/gateway/api.go` | REST API — StartPolicySpan/EndPolicySpan | Consumes telemetry |
+| `internal/gateway/router.go` | EventRouter — WS event dispatch | Consumes telemetry |
+| `internal/gateway/proxy.go` | Guardrail proxy — full GenAI trace hierarchy | Consumes telemetry |
+| `internal/gateway/inspect.go` | CodeGuard inspection | Consumes telemetry |
+| `internal/gateway/api.go` | REST API | Consumes telemetry |
 
 ---
 
-## Recommendations
-
-1. **Update OTEL.md §5d** to mark LLM Call Span as `(planned — awaiting OpenClaw llm_call/llm_result events)` instead of presenting it alongside implemented spans.
-
-2. **Consider deriving LLM spans from `session.message`** — the Format A handler already parses `model`, `provider`, `stopReason`, and `content`. Adding `StartLLMSpan`/`EndLLMSpan` calls for `role=assistant` messages with a `model` field would activate the existing dead code without waiting for OpenClaw.
-
-3. **Add `Agent Session Span`** — OTEL.md §5a shows a root `[Agent Session Span]` in the hierarchy but no implementation exists. The `handleAgentStreamEvent()` lifecycle handler (`start`/`end` events) could create this span.
-
----
-
-*Compiled: 2026-03-29 | Source: Code audit of DefenseClaw v0.2.0*
+*Compiled: 2026-04-01 | Source: Code audit of DefenseClaw*

--- a/docs/OTEL-IMPLEMENTATION-STATUS.md
+++ b/docs/OTEL-IMPLEMENTATION-STATUS.md
@@ -1,0 +1,192 @@
+# DefenseClaw OpenTelemetry — Implementation Status
+
+> Audit of `OTEL.md` spec vs actual implementation as of 2026-03-29.
+
+---
+
+## Summary
+
+The OTel implementation covers **3 of 4 signal categories** fully, with
+partial implementation of the fourth (Runtime Traces). Overall the
+telemetry foundation is mature — the main gap is **LLM call spans**,
+which are defined in code but never wired to any event source.
+
+| Category | Spec Section | Status | Notes |
+|----------|-------------|--------|-------|
+| Asset lifecycle events | §3 Logs | **COMPLETE** | All actions mapped and emitted |
+| Asset scan results | §4 Logs + Metrics | **COMPLETE** | Summary + individual findings + metrics |
+| Runtime events (Traces) | §5 Traces | **PARTIAL** | Tool + Approval spans wired; LLM spans dead code |
+| Runtime alerts | §6 Logs | **COMPLETE** | All alert types emitted |
+| Metrics | §7 | **COMPLETE** | All counters/histograms registered, 28+ instruments |
+| Configuration | §8 | **COMPLETE** | Full config struct, env var overrides |
+
+---
+
+## Detailed Status by Telemetry Method
+
+### Traces (Spans)
+
+| Method | File | Wired In Production? | Trigger |
+|--------|------|---------------------|---------|
+| `EmitStartupSpan` | `runtime.go:35` | **YES** | Gateway startup (once) |
+| `EmitInspectSpan` | `runtime.go:49` | **YES** | HTTP `/inspect/tool` (CodeGuard) |
+| `StartToolSpan` / `EndToolSpan` | `runtime.go:70–148` | **YES** | WS `tool_call` / `tool_result` via `router.go` |
+| `StartApprovalSpan` / `EndApprovalSpan` | `runtime.go:150–210` | **YES** | WS `exec.approval.requested` via `router.go` |
+| `StartLLMSpan` / `EndLLMSpan` | `runtime.go:212–280` | **NO — DEAD CODE** | No caller anywhere in codebase |
+| `StartPolicySpan` / `EndPolicySpan` | `policy.go:20–80` | **YES** | HTTP `/policy/evaluate/*` + watcher |
+
+#### LLM Span Gap Analysis
+
+`StartLLMSpan()` and `EndLLMSpan()` are fully implemented with correct
+GenAI semantic convention attributes (`gen_ai.system`, `gen_ai.request.model`,
+`gen_ai.usage.prompt_tokens`, etc.) but **zero production callers exist**.
+
+**Root cause**: OpenClaw does not emit `llm_call` / `llm_result` WebSocket
+events. The `OTEL.md` spec (§9c) documents these as "future":
+
+```
+### 9c. LLM Gateway Hooks (future)
+When OpenClaw provides `llm_call` / `llm_result` events: ...
+```
+
+The `EventRouter.Route()` switch in `router.go` handles these events:
+- `tool_call` → `handleToolCall()` → `StartToolSpan` ✓
+- `tool_result` → `handleToolResult()` → `EndToolSpan` ✓
+- `exec.approval.requested` → `handleApprovalRequest()` → `StartApprovalSpan` ✓
+- `session.tool` → normalizes to `tool_call`/`tool_result` ✓
+- `agent` (stream=tool) → normalizes to `session.tool` ✓
+- `session.message` (stream=tool) → normalizes to `session.tool` ✓
+
+**No handler exists for `llm_call` / `llm_result`**. The `session.message`
+handler (Format A) parses chat messages with `model` and `provider` fields
+but only logs them — it does not create LLM spans.
+
+#### What Would Be Needed for LLM Spans
+
+Two options:
+
+1. **Wait for OpenClaw** to emit explicit `llm_call` / `llm_result` events
+   and add handlers in `Route()` (the spec's stated plan).
+
+2. **Derive LLM spans from `session.message`** — the `handleSessionMessage()`
+   Format A handler already parses `role`, `model`, `provider`, `stopReason`,
+   and `content`, but no telemetry calls are made. An `assistant` message
+   with a `model` field could trigger `StartLLMSpan`/`EndLLMSpan`.
+
+### Logs
+
+| Method | File | Wired? | Trigger |
+|--------|------|--------|---------|
+| `EmitLifecycleEvent` | `lifecycle.go` | **YES** | `audit.Logger.LogAction()` |
+| `EmitScanResult` | `scan.go` | **YES** | `audit.Logger.LogScan()` |
+| `EmitScanFinding` | `scan.go` | **YES** | Per-finding (opt-in `emit_individual_findings`) |
+| `EmitRuntimeAlert` | `alerts.go` | **YES** | `router.go` (dangerous commands, guardrails) + `inspect.go` (CodeGuard) |
+
+### Metrics
+
+All metric instruments are registered in `metrics.go` and recorded by their
+respective telemetry methods. **All spec'd metrics from §7 are implemented**:
+
+| Metric | Instrument | Callers |
+|--------|-----------|---------|
+| `defenseclaw.scan.count` | Counter | `RecordScan()` ← `EmitScanResult()` |
+| `defenseclaw.scan.duration` | Histogram | `RecordScan()` |
+| `defenseclaw.scan.findings` | Counter | `RecordScan()` |
+| `defenseclaw.scan.findings.gauge` | UpDownCounter | `RecordScan()` |
+| `defenseclaw.tool.calls` | Counter | `RecordToolCall()` ← `StartToolSpan()` |
+| `defenseclaw.tool.duration` | Histogram | `RecordToolDuration()` ← `EndToolSpan()` |
+| `defenseclaw.tool.errors` | Counter | `RecordToolError()` ← `EndToolSpan()` |
+| `defenseclaw.approval.count` | Counter | `RecordApproval()` ← `EndApprovalSpan()` |
+| `defenseclaw.llm.calls` | Counter | `RecordLLMCall()` ← `StartLLMSpan()` (**dead path**) |
+| `defenseclaw.llm.tokens` | Counter | `RecordLLMTokens()` ← `EndLLMSpan()` (**dead path**) |
+| `defenseclaw.llm.duration` | Histogram | `RecordLLMDuration()` ← `EndLLMSpan()` (**dead path**) |
+| `defenseclaw.alert.count` | Counter | `RecordAlert()` ← `EmitRuntimeAlert()` |
+| `defenseclaw.guardrail.evaluations` | Counter | `RecordGuardrailEvaluation()` |
+| `defenseclaw.guardrail.latency` | Histogram | `RecordGuardrailLatency()` |
+| `defenseclaw.policy.evaluations` | Counter | `RecordPolicyEvaluation()` ← `EndPolicySpan()` |
+| `defenseclaw.policy.latency` | Histogram | `RecordPolicyLatency()` ← `EndPolicySpan()` |
+
+**Note**: LLM metrics (`defenseclaw.llm.*`) instruments are registered but
+never called because the LLM span methods are dead code.
+
+---
+
+## Event Router — Complete Event Flow
+
+The gateway's `EventRouter.Route()` handles all WebSocket events from
+OpenClaw. Tool call telemetry flows through multiple normalization layers:
+
+```
+OpenClaw WebSocket Events
+│
+├── tool_call ───────────────────────────→ handleToolCall() → StartToolSpan
+├── tool_result ─────────────────────────→ handleToolResult() → EndToolSpan
+├── exec.approval.requested ─────────────→ handleApprovalRequest() → StartApprovalSpan/EndApprovalSpan
+│
+├── session.tool ────────────────────────→ handleSessionTool()
+│   └── normalize phase → type             └──→ synthetic tool_call/tool_result → handleToolCall/Result
+│
+├── agent (stream=tool) ─────────────────→ handleAgentStreamEvent()
+│   └── wrap as session.tool                └──→ handleSessionTool() → handleToolCall/Result
+│
+├── agent (legacy: toolCall/toolResult) ─→ handleAgentEvent()
+│   └── wrap as tool_call/tool_result       └──→ handleToolCall/Result
+│
+├── session.message (stream=tool) ───────→ handleSessionTool() → handleToolCall/Result
+├── session.message (Format A: chat) ────→ LogAction only (NO TELEMETRY SPANS)
+│
+├── sessions.changed ────────────────────→ LogAction (errors only)
+├── chat ────────────────────────────────→ LogAction (errors only)
+└── tick/health/presence/heartbeat ──────→ ignored
+```
+
+**Key observation**: Tool calls reach `StartToolSpan`/`EndToolSpan` via
+5 different OpenClaw event formats (tool_call, session.tool, agent stream,
+agent legacy, session.message stream). The normalization is robust.
+
+---
+
+## Runtime Span Prerequisites
+
+Tool, approval, and inspect spans **require a live OpenClaw WebSocket
+connection**. The gateway connects to OpenClaw at `wss://<host>:<port>` and
+receives events only when an agent session is actively running.
+
+Without OpenClaw:
+- `defenseclaw/startup` span — **always emitted** (verifies pipeline)
+- `tool/*` spans — **never emitted** (no `tool_call` events arrive)
+- `exec.approval/*` spans — **never emitted** (no approval events)
+- `inspect/*` spans — **emitted via HTTP** (CodeGuard, not WS-dependent)
+- `policy/*` spans — **emitted via HTTP** (REST API or watcher, not WS-dependent)
+
+---
+
+## File Reference
+
+| File | Purpose | Signal Types |
+|------|---------|-------------|
+| `internal/telemetry/provider.go` | OTel Provider, InitProvider, TracerProvider/LoggerProvider/MeterProvider | All |
+| `internal/telemetry/resource.go` | buildResource() with all resource attributes | All |
+| `internal/telemetry/lifecycle.go` | EmitLifecycleEvent() — asset install/block/allow/quarantine | Logs |
+| `internal/telemetry/scan.go` | EmitScanResult(), EmitScanFinding() | Logs + Metrics |
+| `internal/telemetry/runtime.go` | StartToolSpan, EndToolSpan, StartLLMSpan (**dead**), EndLLMSpan (**dead**), StartApprovalSpan, EndApprovalSpan, EmitStartupSpan, EmitInspectSpan | Traces + Metrics |
+| `internal/telemetry/alerts.go` | EmitRuntimeAlert() | Logs + Metrics |
+| `internal/telemetry/metrics.go` | All metric instruments (28+ counters/histograms) | Metrics |
+| `internal/telemetry/policy.go` | StartPolicySpan, EndPolicySpan | Traces + Metrics |
+| `internal/gateway/router.go` | EventRouter — WS event dispatch, tool/approval span lifecycle | Consumes telemetry |
+| `internal/gateway/inspect.go` | CodeGuard inspection — EmitInspectSpan, EmitRuntimeAlert | Consumes telemetry |
+| `internal/gateway/api.go` | REST API — StartPolicySpan/EndPolicySpan | Consumes telemetry |
+
+---
+
+## Recommendations
+
+1. **Update OTEL.md §5d** to mark LLM Call Span as `(planned — awaiting OpenClaw llm_call/llm_result events)` instead of presenting it alongside implemented spans.
+
+2. **Consider deriving LLM spans from `session.message`** — the Format A handler already parses `model`, `provider`, `stopReason`, and `content`. Adding `StartLLMSpan`/`EndLLMSpan` calls for `role=assistant` messages with a `model` field would activate the existing dead code without waiting for OpenClaw.
+
+3. **Add `Agent Session Span`** — OTEL.md §5a shows a root `[Agent Session Span]` in the hierarchy but no implementation exists. The `handleAgentStreamEvent()` lifecycle handler (`start`/`end` events) could create this span.
+
+---
+
+*Compiled: 2026-03-29 | Source: Code audit of DefenseClaw v0.2.0*

--- a/docs/OTEL.md
+++ b/docs/OTEL.md
@@ -1,6 +1,6 @@
 # DefenseClaw OpenTelemetry Specification
 
-DefenseClaw exports four categories of telemetry to **Splunk Observability**
+DefenseClaw exports four categories of telemetry to **Splunk Observability Cloud**
 via OTLP (gRPC or HTTP/protobuf). This document is the canonical reference
 for attribute names, signal types, payload schemas, and configuration.
 
@@ -575,7 +575,7 @@ Add to `~/.defenseclaw/config.yaml` under the `otel` key:
 otel:
   enabled: false
   protocol: "grpc"                                      # "grpc" or "http"
-  endpoint: "https://ingest.us1.signalfx.com"           # Splunk Observability OTLP endpoint
+  endpoint: "https://ingest.us1.signalfx.com"           # Splunk Observability Cloud OTLP endpoint
   headers:
     "X-SF-TOKEN": "${SPLUNK_ACCESS_TOKEN}"              # env var substitution
   tls:
@@ -604,7 +604,7 @@ otel:
 
 | Variable | Purpose |
 |---|---|
-| `SPLUNK_ACCESS_TOKEN` | Splunk Observability ingest token |
+| `SPLUNK_ACCESS_TOKEN` | Splunk Observability Cloud ingest token |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Override `otel.endpoint` |
 | `OTEL_EXPORTER_OTLP_HEADERS` | Override `otel.headers` |
 | `OTEL_RESOURCE_ATTRIBUTES` | Additional resource attributes |
@@ -761,7 +761,7 @@ audit.Logger
 
 ### Attribute → Splunk Field
 
-| OTEL Concept | Splunk Observability |
+| OTEL Concept | Splunk Observability Cloud |
 |---|---|
 | Resource attributes | Indexed dimensions on all signals |
 | Log `SeverityText` | `severity` in Log Observer |

--- a/docs/OTEL.md
+++ b/docs/OTEL.md
@@ -231,10 +231,10 @@ Runtime events from the OpenClaw gateway (WebSocket events routed through
 ### 5a. Span Hierarchy
 
 ```
-[Agent Session Span]                       root span (long-lived)
-  ├── [LLM Call Span]                      from llm_call / llm_result hooks
-  │     └── [Tool Call Span]               from tool_call / tool_result events
-  │           └── [Exec Approval Span]     from exec.approval.requested / resolved
+[Agent Session Span]                       root span (planned — not yet implemented)
+  ├── [LLM Call Span]                      planned — awaiting OpenClaw llm_call/llm_result events
+  │     └── [Tool Call Span]               ✓ implemented — from tool_call / tool_result events
+  │           └── [Exec Approval Span]     ✓ implemented — from exec.approval.requested / resolved
   ├── [LLM Call Span]
   │     ├── [Tool Call Span]
   │     └── [Tool Call Span]
@@ -300,9 +300,14 @@ Nested under the tool call span, or standalone if no parent.
 | `defenseclaw.approval.auto` | bool | was auto-approved |
 | `defenseclaw.approval.dangerous` | bool | matched dangerous pattern |
 
-### 5d. LLM Call Span
+### 5d. LLM Call Span ⚠️ PLANNED
 
-Emitted when OpenClaw hooks or the LLM gateway interceptor capture
+> **Status**: Code implemented (`StartLLMSpan`/`EndLLMSpan` in
+> `internal/telemetry/runtime.go`) but **not wired** — OpenClaw does not
+> yet emit `llm_call`/`llm_result` WebSocket events. See §9c and
+> [OTEL-IMPLEMENTATION-STATUS.md](OTEL-IMPLEMENTATION-STATUS.md) for details.
+
+Will be emitted when OpenClaw hooks or the LLM gateway interceptor capture
 LLM request/response pairs.
 
 | Field | Value |

--- a/docs/OTEL.md
+++ b/docs/OTEL.md
@@ -230,23 +230,34 @@ Runtime events from the OpenClaw gateway (WebSocket events routed through
 
 ### 5a. Span Hierarchy
 
+#### Guardrail Proxy Path (LLM Gateway)
+
+The guardrail proxy intercepts OpenAI-compatible requests and produces the
+full GenAI semconv trace hierarchy:
+
 ```
-[Agent Session Span]                       root span (planned — not yet implemented)
-  ├── [LLM Call Span]                      planned — awaiting OpenClaw llm_call/llm_result events
-  │     └── [Tool Call Span]               ✓ implemented — from tool_call / tool_result events
-  │           └── [Exec Approval Span]     ✓ implemented — from exec.approval.requested / resolved
-  ├── [LLM Call Span]
-  │     ├── [Tool Call Span]
-  │     └── [Tool Call Span]
-  └── ...
+invoke_agent {agentName}                    ✓ root span — per HTTP request
+├── apply_guardrail defenseclaw input       ✓ input inspection
+└── chat {model}                            ✓ LLM call (SpanKind=CLIENT)
+    ├── apply_guardrail defenseclaw output  ✓ output inspection (if content present)
+    ├── execute_tool {toolName}             ✓ per tool_call in LLM response
+    │   └── apply_guardrail defenseclaw tool_call  ✓ tool args inspection
+    └── execute_tool {toolName}
+        └── apply_guardrail defenseclaw tool_call
 ```
 
-When session boundaries or LLM call pairing are not available from OpenClaw,
-each `tool_call → tool_result` pair is emitted as an independent span.
+#### WebSocket Event Router Path
+
+Tool and approval spans from real-time agent session events:
+
+```
+tool/{tool_name}                            ✓ from tool_call → tool_result WS events
+  └── exec.approval/{approval_id}           ✓ from exec.approval.requested WS events
+```
 
 ### 5b. Tool Call Span
 
-Created on `tool_call` event; ended on matching `tool_result`.
+**WS path**: Created on `tool_call` event; ended on matching `tool_result`.
 
 | Field | Value |
 |---|---|
@@ -256,13 +267,16 @@ Created on `tool_call` event; ended on matching `tool_result`.
 | `end_time` | `tool_result` event timestamp |
 | `status` | `OK` or `ERROR` (from `exit_code`) |
 
-#### Attributes
+#### Attributes (WS path)
 
 | Attribute | Type | Description |
 |---|---|---|
+| `gen_ai.operation.name` | string | `execute_tool` |
+| `gen_ai.tool.name` | string | tool name |
+| `gen_ai.tool.type` | string | `function` |
 | `defenseclaw.tool.name` | string | tool name (e.g. `shell`) |
 | `defenseclaw.tool.status` | string | status from `tool_call` payload |
-| `defenseclaw.tool.args` | string | truncated args JSON (max 2048 chars) |
+| `defenseclaw.tool.args_length` | int | byte length of arguments |
 | `defenseclaw.tool.exit_code` | int | from `tool_result` |
 | `defenseclaw.tool.output_length` | int | byte length of `tool_result` output |
 | `defenseclaw.tool.dangerous` | bool | matched dangerous pattern |
@@ -275,6 +289,23 @@ Created on `tool_call` event; ended on matching `tool_result`.
 | Event Name | Attributes |
 |---|---|
 | `tool.flagged` | `defenseclaw.flag.reason`, `defenseclaw.flag.pattern` |
+
+**Proxy path**: Created for each `tool_call` entry in the LLM response's
+`choices[0].message.tool_calls` array. Child of the `chat` span.
+
+| Field | Value |
+|---|---|
+| `name` | `execute_tool {tool_name}` |
+| `kind` | `INTERNAL` |
+| `status` | `OK` |
+
+#### Attributes (Proxy path)
+
+| Attribute | Type | Description |
+|---|---|---|
+| `gen_ai.operation.name` | string | `execute_tool` |
+| `gen_ai.tool.name` | string | tool function name |
+| `gen_ai.tool.type` | string | `function` |
 
 ### 5c. Exec Approval Span
 
@@ -300,22 +331,19 @@ Nested under the tool call span, or standalone if no parent.
 | `defenseclaw.approval.auto` | bool | was auto-approved |
 | `defenseclaw.approval.dangerous` | bool | matched dangerous pattern |
 
-### 5d. LLM Call Span ⚠️ PLANNED
+### 5d. LLM Call Span ✅ IMPLEMENTED
 
-> **Status**: Code implemented (`StartLLMSpan`/`EndLLMSpan` in
-> `internal/telemetry/runtime.go`) but **not wired** — OpenClaw does not
-> yet emit `llm_call`/`llm_result` WebSocket events. See §9c and
-> [OTEL-IMPLEMENTATION-STATUS.md](OTEL-IMPLEMENTATION-STATUS.md) for details.
-
-Will be emitted when OpenClaw hooks or the LLM gateway interceptor capture
-LLM request/response pairs.
+> **Status**: Implemented via guardrail proxy path. Created when an HTTP
+> request is forwarded to the upstream LLM provider (`handleNonStreamingRequest`
+> in `proxy.go`). Child of the `invoke_agent` span.
 
 | Field | Value |
 |---|---|
-| `name` | `llm/{model_name}` |
+| `name` | `chat {model}` |
 | `kind` | `CLIENT` |
-| `start_time` | LLM request sent |
-| `end_time` | LLM response received |
+| `start_time` | before upstream request |
+| `end_time` | after upstream response |
+| `status` | `OK` or `ERROR` (if guardrail blocked) |
 
 #### Attributes
 
@@ -323,18 +351,82 @@ Uses [OTEL GenAI semantic conventions](https://opentelemetry.io/docs/specs/semco
 
 | Attribute | Type | Description |
 |---|---|---|
+| `gen_ai.operation.name` | string | `chat` |
 | `gen_ai.system` | string | `openai` \| `anthropic` \| `nvidia-nim` \| ... |
+| `gen_ai.provider.name` | string | provider identifier (e.g. `defenseclaw`) |
 | `gen_ai.request.model` | string | requested model |
 | `gen_ai.response.model` | string | actual model used |
 | `gen_ai.request.max_tokens` | int | max tokens parameter |
 | `gen_ai.request.temperature` | float | temperature parameter |
-| `gen_ai.response.finish_reasons` | string[] | `["stop"]` \| `["tool_use"]` |
-| `gen_ai.usage.prompt_tokens` | int | input tokens |
-| `gen_ai.usage.completion_tokens` | int | output tokens |
-| `defenseclaw.llm.provider` | string | provider identifier |
+| `gen_ai.response.finish_reasons` | string[] | `["stop"]` \| `["tool_calls"]` |
+| `gen_ai.usage.input_tokens` | int | input tokens |
+| `gen_ai.usage.output_tokens` | int | output tokens |
 | `defenseclaw.llm.tool_calls` | int | number of tool_use blocks |
 | `defenseclaw.llm.guardrail` | string | `none` \| `local` \| `ai-defense` |
 | `defenseclaw.llm.guardrail.result` | string | `pass` \| `flagged` \| `blocked` |
+
+#### Metrics (emitted per LLM call)
+
+| Metric | Attributes |
+|---|---|
+| `gen_ai.client.token.usage` | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.token.type` (`input`/`output`) |
+| `gen_ai.client.operation.duration` | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model` |
+
+> **TODO**: Add `gen_ai.agent.name` to metric attributes when available
+> from the parent `invoke_agent` span. See
+> [OTEL-IMPLEMENTATION-STATUS.md](OTEL-IMPLEMENTATION-STATUS.md) §1.
+
+### 5e. Guardrail Span ✅ IMPLEMENTED
+
+Created by the guardrail proxy when inspecting input, output, or tool call
+arguments. Follows [OTel GenAI semconv PR #3233](https://github.com/open-telemetry/semantic-conventions/pull/3233).
+
+| Field | Value |
+|---|---|
+| `name` | `apply_guardrail {name} {targetType}` |
+| `kind` | `INTERNAL` |
+| `status` | `OK` or `ERROR` (if blocked) |
+
+#### Attributes
+
+| Attribute | Type | Description |
+|---|---|---|
+| `gen_ai.operation.name` | string | `apply_guardrail` |
+| `gen_ai.guardrail.name` | string | `defenseclaw` |
+| `gen_ai.security.target.type` | string | `input` \| `output` \| `tool_call` |
+| `gen_ai.request.model` | string | model being guarded |
+| `gen_ai.security.decision.type` | string | `allow` \| `warn` \| `deny` |
+| `defenseclaw.guardrail.severity` | string | severity from inspector |
+| `defenseclaw.guardrail.reason` | string | reason (truncated 256 chars) |
+
+#### Parent Relationships
+
+| Target Type | Parent Span |
+|---|---|
+| `input` | `invoke_agent` (root) |
+| `output` | `chat` (LLM span) |
+| `tool_call` | `execute_tool` (tool span) |
+
+### 5f. Invoke Agent Span ✅ IMPLEMENTED
+
+Root span for each guardrail proxy HTTP request. Groups all child spans
+(input guardrail, LLM call, output guardrail, tool calls) into a single
+trace.
+
+| Field | Value |
+|---|---|
+| `name` | `invoke_agent {agentName}` |
+| `kind` | `INTERNAL` |
+| `status` | `OK` or `ERROR` |
+
+#### Attributes
+
+| Attribute | Type | Description |
+|---|---|---|
+| `gen_ai.operation.name` | string | `invoke_agent` |
+| `gen_ai.agent.name` | string | agent name (e.g. `openclaw`) |
+| `gen_ai.conversation.id` | string | conversation/session identifier |
+| `gen_ai.provider.name` | string | provider (if set) |
 
 ---
 
@@ -450,9 +542,18 @@ All metrics use the `defenseclaw.*` namespace.
 | `defenseclaw.tool.duration` | Histogram | `ms` | `tool.name`, `tool.provider` |
 | `defenseclaw.tool.errors` | Counter | `{error}` | `tool.name`, `exit_code` |
 | `defenseclaw.approval.count` | Counter | `{request}` | `result`, `auto`, `dangerous` |
-| `defenseclaw.llm.calls` | Counter | `{call}` | `gen_ai.system`, `gen_ai.request.model` |
-| `defenseclaw.llm.tokens` | Counter | `{token}` | `gen_ai.system`, `token.type` (`prompt` / `completion`) |
-| `defenseclaw.llm.duration` | Histogram | `ms` | `gen_ai.system`, `gen_ai.request.model` |
+
+### GenAI Semconv Metrics
+
+| Metric | Type | Unit | Buckets | Attributes |
+|---|---|---|---|---|
+| `gen_ai.client.token.usage` | Histogram | `{token}` | 1,4,16,64,256,1K,4K,16K,64K,256K,1M,4M,16M,64M | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.token.type` |
+| `gen_ai.client.operation.duration` | Histogram | `s` | 0.01,0.02,0.04,...,81.92 | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model` |
+
+> **Note**: Buckets follow [OTel GenAI semconv metrics spec](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-metrics.md). `gen_ai.token.type` values are `input` and `output`.
+
+> **TODO**: Add `gen_ai.agent.name` attribute to these metrics when the
+> agent name is available from the parent `invoke_agent` span context.
 
 ### Alert Metrics
 
@@ -586,21 +687,34 @@ if span, ok := r.activeToolSpans[payload.Tool]; ok {
 r.otel.EmitRuntimeAlert(AlertDangerousCommand, payload, "denied")
 ```
 
-### 9c. LLM Gateway Hooks (future)
+### 9c. Guardrail Proxy — LLM Gateway ✅ IMPLEMENTED
 
-When OpenClaw provides `llm_call` / `llm_result` events:
+The guardrail proxy (`internal/gateway/proxy.go`) intercepts
+OpenAI-compatible `/v1/chat/completions` requests and produces the full
+GenAI semconv trace hierarchy:
 
 ```go
-case "llm_call":
-    span := r.otel.StartLLMSpan(model, provider, params)
-case "llm_result":
-    r.otel.EndLLMSpan(span, usage, finishReason)
-    if guardrailResult != nil {
-        r.otel.EmitRuntimeAlert(AlertGuardrail, guardrailResult)
-    }
+// In handleNonStreamingRequest():
+agentCtx, agentSpan := p.otel.StartAgentSpan(ctx, conversationID, "openclaw", "")
+grSpan := p.otel.StartGuardrailSpan(agentCtx, "defenseclaw", "input", model)
+// ... inspect input ...
+p.otel.EndGuardrailSpan(grSpan, decision, severity, reason, t0)
+llmCtx, llmSpan := p.otel.StartLLMSpan(agentCtx, system, model, provider, maxTokens, temp)
+// ... forward to upstream LLM ...
+grSpan = p.otel.StartGuardrailSpan(llmCtx, "defenseclaw", "output", model)
+// ... inspect output ...
+p.otel.EndGuardrailSpan(grSpan, decision, severity, reason, t0)
+p.emitToolCallSpans(reqCtx, llmCtx, toolCalls, model, mode) // tool_call + guardrail per tool
+p.otel.EndLLMSpan(llmSpan, model, tokens, finishReasons, toolCallCount, ...)
+p.otel.EndAgentSpan(agentSpan, "")
 ```
 
-### 9d. Proposed Package Structure
+### 9d. WebSocket Event Router — Tool/Approval Spans
+
+The router handles `tool_call`, `tool_result`, `exec.approval.requested`
+WebSocket events. See §5b and §5c for span details.
+
+### 9e. Package Structure
 
 ```
 internal/
@@ -609,13 +723,19 @@ internal/
     resource.go       # buildResource(cfg) — shared Resource with all attributes
     lifecycle.go      # EmitLifecycleEvent(...)
     scan.go           # EmitScanResult(...)
-    runtime.go        # ToolSpan, LLMSpan, ApprovalSpan
+    runtime.go        # Agent/LLM/Tool/Approval/Guardrail spans + metrics
     alerts.go         # EmitRuntimeAlert(...)
     metrics.go        # Counter/histogram registration and recording
+    policy.go         # PolicySpan + policy metrics
     shutdown.go       # Graceful flush + shutdown on context cancel
+  gateway/
+    proxy.go          # Guardrail proxy — full GenAI trace hierarchy
+    router.go         # WS EventRouter — tool/approval spans
+    inspect.go        # CodeGuard — inspect spans + alerts
+    api.go            # REST API — policy spans
 ```
 
-### 9e. Dual Export: Splunk HEC + OTEL
+### 9f. Dual Export: Splunk HEC + OTEL
 
 The existing `SplunkForwarder` (HEC-based) remains for backward
 compatibility. When both `splunk.enabled` and `otel.enabled` are true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,6 +100,7 @@ type OTelLogsConfig struct {
 type OTelMetricsConfig struct {
 	Enabled         bool   `mapstructure:"enabled"            yaml:"enabled"`
 	ExportIntervalS int    `mapstructure:"export_interval_s"  yaml:"export_interval_s"`
+	Temporality     string `mapstructure:"temporality"         yaml:"temporality"`
 	Endpoint        string `mapstructure:"endpoint"           yaml:"endpoint"`
 	Protocol        string `mapstructure:"protocol"           yaml:"protocol"`
 	URLPath         string `mapstructure:"url_path"           yaml:"url_path"`
@@ -709,6 +710,7 @@ func setDefaults(dataDir string) {
 	viper.SetDefault("otel.logs.url_path", "")
 	viper.SetDefault("otel.metrics.enabled", true)
 	viper.SetDefault("otel.metrics.export_interval_s", 60)
+	viper.SetDefault("otel.metrics.temporality", "delta")
 	viper.SetDefault("otel.metrics.endpoint", "")
 	viper.SetDefault("otel.metrics.protocol", "")
 	viper.SetDefault("otel.metrics.url_path", "")

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -1024,7 +1024,7 @@ func (a *APIServer) handleGuardrailEvent(w http.ResponseWriter, r *http.Request)
 			if req.TokensOut != nil {
 				tOut = *req.TokensOut
 			}
-			a.otel.RecordLLMTokens(ctx, "chat", "defenseclaw", req.Model, tIn, tOut)
+			a.otel.RecordLLMTokens(ctx, "chat", "defenseclaw", req.Model, "openclaw", tIn, tOut)
 		}
 	}
 

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -1024,7 +1024,7 @@ func (a *APIServer) handleGuardrailEvent(w http.ResponseWriter, r *http.Request)
 			if req.TokensOut != nil {
 				tOut = *req.TokensOut
 			}
-			a.otel.RecordLLMTokens(ctx, "guardrail-proxy", tIn, tOut)
+			a.otel.RecordLLMTokens(ctx, "chat", "defenseclaw", req.Model, tIn, tOut)
 		}
 	}
 

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -3161,21 +3161,32 @@ func TestHandleGuardrailEvent_OTelMetricsRecorded(t *testing.T) {
 		t.Errorf("latency sum = %f, want 12.5", latHist.DataPoints[0].Sum)
 	}
 
-	tokenMetric := findMetric(rm, "defenseclaw.llm.tokens")
+	tokenMetric := findMetric(rm, "gen_ai.client.token.usage")
 	if tokenMetric == nil {
-		t.Fatal("expected defenseclaw.llm.tokens metric")
+		t.Fatal("expected gen_ai.client.token.usage metric")
 	}
-	tokenSum, ok := tokenMetric.Data.(metricdata.Sum[int64])
+	tokenHist, ok := tokenMetric.Data.(metricdata.Histogram[float64])
 	if !ok {
-		t.Fatalf("expected Sum[int64], got %T", tokenMetric.Data)
+		t.Fatalf("expected Histogram[float64], got %T", tokenMetric.Data)
 	}
-	promptTok := counterByAttr(tokenSum, "token.type", "prompt")
-	compTok := counterByAttr(tokenSum, "token.type", "completion")
-	if promptTok != 250 {
-		t.Errorf("prompt tokens = %d, want 250", promptTok)
+	var inputSum, outputSum float64
+	for _, dp := range tokenHist.DataPoints {
+		for _, attr := range dp.Attributes.ToSlice() {
+			if string(attr.Key) == "gen_ai.token.type" {
+				switch attr.Value.AsString() {
+				case "input":
+					inputSum += dp.Sum
+				case "output":
+					outputSum += dp.Sum
+				}
+			}
+		}
 	}
-	if compTok != 120 {
-		t.Errorf("completion tokens = %d, want 120", compTok)
+	if inputSum != 250 {
+		t.Errorf("input token sum = %v, want 250", inputSum)
+	}
+	if outputSum != 120 {
+		t.Errorf("output token sum = %v, want 120", outputSum)
 	}
 }
 
@@ -3217,16 +3228,16 @@ func TestHandleGuardrailEvent_OTelNoTokensSkipsLLMMetric(t *testing.T) {
 		t.Fatal("expected defenseclaw.guardrail.evaluations metric")
 	}
 
-	tokenMetric := findMetric(rm, "defenseclaw.llm.tokens")
+	tokenMetric := findMetric(rm, "gen_ai.client.token.usage")
 	if tokenMetric != nil {
-		tokenSum, ok := tokenMetric.Data.(metricdata.Sum[int64])
+		tokenHist, ok := tokenMetric.Data.(metricdata.Histogram[float64])
 		if ok {
-			total := int64(0)
-			for _, dp := range tokenSum.DataPoints {
-				total += dp.Value
+			totalSum := 0.0
+			for _, dp := range tokenHist.DataPoints {
+				totalSum += dp.Sum
 			}
-			if total != 0 {
-				t.Errorf("expected 0 token metrics when tokens_in/out are nil, got %d", total)
+			if totalSum != 0 {
+				t.Errorf("expected 0 token metrics when tokens_in/out are nil, got %v", totalSum)
 			}
 		}
 	}

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -30,6 +30,8 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/defenseclaw/defenseclaw/internal/audit"
 	"github.com/defenseclaw/defenseclaw/internal/config"
 	"github.com/defenseclaw/defenseclaw/internal/telemetry"
@@ -331,9 +333,35 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *http.Request, req *ChatRequest, mode, customBlockMsg string) {
 	aliasModel := req.Model
 	fmt.Fprintf(os.Stderr, "[guardrail] → upstream (non-streaming) model=%q messages=%d\n", req.Model, len(req.Messages))
+
+	// Start LLM span before the upstream call.
+	llmStartTime := time.Now()
+	system, providerName := p.llmSystemAndProvider(req.Model)
+	maxTokens := 0
+	if req.MaxTokens != nil {
+		maxTokens = *req.MaxTokens
+	}
+	temperature := 0.0
+	if req.Temperature != nil {
+		temperature = *req.Temperature
+	}
+	var llmCtx context.Context
+	var llmSpan trace.Span
+	if p.otel != nil {
+		llmCtx, llmSpan = p.otel.StartLLMSpan(
+			context.Background(),
+			system, aliasModel, providerName,
+			maxTokens, temperature,
+		)
+		_ = llmCtx // parent context for future nested spans
+	}
+
 	resp, err := p.provider.ChatCompletion(r.Context(), req)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[guardrail] upstream error: %v\n", err)
+		if p.otel != nil && llmSpan != nil {
+			p.otel.EndLLMSpan(llmSpan, aliasModel, 0, 0, []string{"error"}, 0, "none", "", system, llmStartTime)
+		}
 		writeOpenAIError(w, http.StatusBadGateway, "upstream provider error: "+err.Error())
 		return
 	}
@@ -342,9 +370,19 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 
 	// --- Post-call inspection ---
 	content := ""
+	finishReasons := []string{}
+	toolCallCount := 0
 	if len(resp.Choices) > 0 && resp.Choices[0].Message != nil {
 		content = resp.Choices[0].Message.Content
 	}
+	for _, c := range resp.Choices {
+		if c.FinishReason != nil {
+			finishReasons = append(finishReasons, *c.FinishReason)
+		}
+	}
+
+	guardrail := "none"
+	guardrailResult := ""
 
 	if content != "" {
 		t0 := time.Now()
@@ -360,11 +398,34 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 		p.logPostCall(aliasModel, content, verdict, elapsed, resp.Usage)
 		p.recordTelemetry("completion", aliasModel, verdict, elapsed, tokIn, tokOut)
 
+		if verdict.Severity != "NONE" {
+			guardrail = "local"
+			guardrailResult = verdict.Action
+		}
+
 		if verdict.Action == "block" && mode == "action" {
+			if p.otel != nil && llmSpan != nil {
+				promptTok, completionTok := 0, 0
+				if resp.Usage != nil {
+					promptTok = int(resp.Usage.PromptTokens)
+					completionTok = int(resp.Usage.CompletionTokens)
+				}
+				p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, finishReasons, toolCallCount, guardrail, "blocked", system, llmStartTime)
+			}
 			msg := blockMessage(customBlockMsg, "completion", verdict.Reason)
 			p.writeBlockedResponse(w, aliasModel, msg)
 			return
 		}
+	}
+
+	// End LLM span with response data.
+	if p.otel != nil && llmSpan != nil {
+		promptTok, completionTok := 0, 0
+		if resp.Usage != nil {
+			promptTok = int(resp.Usage.PromptTokens)
+			completionTok = int(resp.Usage.CompletionTokens)
+		}
+		p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, finishReasons, toolCallCount, guardrail, guardrailResult, system, llmStartTime)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -395,9 +456,31 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 
 	aliasModel := req.Model
 	fmt.Fprintf(os.Stderr, "[guardrail] → upstream (streaming) model=%q messages=%d\n", req.Model, len(req.Messages))
+
+	// Start LLM span before the streaming call.
+	llmStartTime := time.Now()
+	system, providerName := p.llmSystemAndProvider(req.Model)
+	maxTokens := 0
+	if req.MaxTokens != nil {
+		maxTokens = *req.MaxTokens
+	}
+	temperature := 0.0
+	if req.Temperature != nil {
+		temperature = *req.Temperature
+	}
+	var llmSpan trace.Span
+	if p.otel != nil {
+		_, llmSpan = p.otel.StartLLMSpan(
+			context.Background(),
+			system, aliasModel, providerName,
+			maxTokens, temperature,
+		)
+	}
+
 	var accumulated strings.Builder
 	lastScanLen := 0
 	const scanInterval = 500
+	streamFinishReasons := []string{}
 
 	usage, err := p.provider.ChatCompletionStream(r.Context(), req, func(chunk StreamChunk) {
 		chunk.Model = aliasModel
@@ -405,6 +488,12 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 		// Accumulate content for post-stream inspection.
 		if len(chunk.Choices) > 0 && chunk.Choices[0].Delta != nil {
 			accumulated.WriteString(chunk.Choices[0].Delta.Content)
+		}
+		// Collect finish reasons from stream chunks.
+		for _, c := range chunk.Choices {
+			if c.FinishReason != nil && *c.FinishReason != "" {
+				streamFinishReasons = append(streamFinishReasons, *c.FinishReason)
+			}
 		}
 
 		// Periodic mid-stream scan for streaming content.
@@ -427,7 +516,14 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[guardrail] stream error: %v\n", err)
+		if p.otel != nil && llmSpan != nil {
+			p.otel.EndLLMSpan(llmSpan, aliasModel, 0, 0, []string{"error"}, 0, "none", "", system, llmStartTime)
+			llmSpan = nil
+		}
 	}
+
+	guardrail := "none"
+	guardrailResult := ""
 
 	// Final post-stream inspection.
 	if accumulated.Len() > 0 {
@@ -446,6 +542,21 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 			PromptTokens: ptrOr(tokIn, 0), CompletionTokens: ptrOr(tokOut, 0),
 		})
 		p.recordTelemetry("completion", aliasModel, verdict, elapsed, tokIn, tokOut)
+
+		if verdict.Severity != "NONE" {
+			guardrail = "local"
+			guardrailResult = verdict.Action
+		}
+	}
+
+	// End LLM span with final data.
+	if p.otel != nil && llmSpan != nil {
+		promptTok, completionTok := 0, 0
+		if usage != nil {
+			promptTok = int(usage.PromptTokens)
+			completionTok = int(usage.CompletionTokens)
+		}
+		p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, streamFinishReasons, 0, guardrail, guardrailResult, system, llmStartTime)
 	}
 
 	fmt.Fprintf(w, "data: [DONE]\n\n")
@@ -659,6 +770,20 @@ func (p *GuardrailProxy) logPostCall(model, content string, verdict *ScanVerdict
 		fmt.Fprintf(os.Stderr, "  verdict: \033[91m%s\033[0m  action=%s  %s\n", severity, action, verdict.Reason)
 	}
 	fmt.Fprintf(os.Stderr, "\033[92m%s\033[0m\n", strings.Repeat("─", 60))
+}
+
+// llmSystemAndProvider derives gen_ai.system and provider name from the model string.
+// Reuses the router's inferSystem for consistency.
+func (p *GuardrailProxy) llmSystemAndProvider(model string) (system, provider string) {
+	parts := strings.SplitN(model, "/", 2)
+	if len(parts) == 2 {
+		provider = parts[0]
+	}
+	system = inferSystem(provider, model)
+	if provider == "" {
+		provider = system
+	}
+	return system, provider
 }
 
 func truncateLog(s string, maxLen int) string {

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -405,7 +405,7 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[guardrail] upstream error: %v\n", err)
 		if p.otel != nil && llmSpan != nil {
-			p.otel.EndLLMSpan(llmSpan, aliasModel, 0, 0, []string{"error"}, 0, "none", "", system, llmStartTime)
+			p.otel.EndLLMSpan(llmSpan, aliasModel, 0, 0, []string{"error"}, 0, "none", "", system, llmStartTime, "openclaw")
 		}
 		writeOpenAIError(w, http.StatusBadGateway, "upstream provider error: "+err.Error())
 		return
@@ -478,7 +478,7 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 					promptTok = int(resp.Usage.PromptTokens)
 					completionTok = int(resp.Usage.CompletionTokens)
 				}
-				p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, finishReasons, toolCallCount, guardrail, "blocked", system, llmStartTime)
+				p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, finishReasons, toolCallCount, guardrail, "blocked", system, llmStartTime, "openclaw")
 			}
 			msg := blockMessage(customBlockMsg, "completion", verdict.Reason)
 			p.writeBlockedResponse(w, aliasModel, msg)
@@ -498,7 +498,7 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 			promptTok = int(resp.Usage.PromptTokens)
 			completionTok = int(resp.Usage.CompletionTokens)
 		}
-		p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, finishReasons, toolCallCount, guardrail, guardrailResult, system, llmStartTime)
+		p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, finishReasons, toolCallCount, guardrail, guardrailResult, system, llmStartTime, "openclaw")
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -590,7 +590,7 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[guardrail] stream error: %v\n", err)
 		if p.otel != nil && llmSpan != nil {
-			p.otel.EndLLMSpan(llmSpan, aliasModel, 0, 0, []string{"error"}, 0, "none", "", system, llmStartTime)
+			p.otel.EndLLMSpan(llmSpan, aliasModel, 0, 0, []string{"error"}, 0, "none", "", system, llmStartTime, "openclaw")
 			llmSpan = nil
 		}
 	}
@@ -652,7 +652,7 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 			promptTok = int(usage.PromptTokens)
 			completionTok = int(usage.CompletionTokens)
 		}
-		p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, streamFinishReasons, 0, guardrail, guardrailResult, system, llmStartTime)
+		p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, streamFinishReasons, 0, guardrail, guardrailResult, system, llmStartTime, "openclaw")
 	}
 
 	fmt.Fprintf(w, "data: [DONE]\n\n")
@@ -941,7 +941,7 @@ func (p *GuardrailProxy) recordTelemetry(direction, model string, verdict *ScanV
 			p.otel.RecordGuardrailEvaluation(ctx, "cisco-ai-defense", verdict.Action)
 		}
 		if tokIn != nil || tokOut != nil {
-			p.otel.RecordLLMTokens(ctx, "apply_guardrail", "defenseclaw", model, ptrOr(tokIn, 0), ptrOr(tokOut, 0))
+			p.otel.RecordLLMTokens(ctx, "apply_guardrail", "defenseclaw", model, "openclaw", ptrOr(tokIn, 0), ptrOr(tokOut, 0))
 		}
 	}
 }

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -301,17 +301,58 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 	customBlockMsg := p.blockMessage
 	p.rtMu.RUnlock()
 
-	// --- Pre-call inspection ---
+	// --- Create invoke_agent root span for this request ---
+	var agentCtx context.Context
+	var agentSpan trace.Span
+	if p.otel != nil {
+		conversationID := r.Header.Get("X-Conversation-ID")
+		if conversationID == "" {
+			conversationID = fmt.Sprintf("proxy-%d", time.Now().UnixNano())
+		}
+		agentCtx, agentSpan = p.otel.StartAgentSpan(
+			context.Background(),
+			conversationID, "openclaw", "",
+		)
+	}
+	if agentCtx == nil {
+		agentCtx = context.Background()
+	}
+
+	// --- Pre-call inspection (apply_guardrail input, child of invoke_agent) ---
 	userText := lastUserText(req.Messages)
 	if userText != "" {
 		t0 := time.Now()
+
+		// Start guardrail span for input inspection.
+		var grSpan trace.Span
+		if p.otel != nil {
+			_, grSpan = p.otel.StartGuardrailSpan(
+				agentCtx,
+				"defenseclaw", "input", req.Model,
+			)
+		}
+
 		verdict := p.inspector.Inspect(r.Context(), "prompt", userText, req.Messages, req.Model, mode)
 		elapsed := time.Since(t0)
+
+		// End guardrail span with decision.
+		if p.otel != nil && grSpan != nil {
+			decision := "allow"
+			if verdict.Action == "block" {
+				decision = "deny"
+			} else if verdict.Severity != "NONE" {
+				decision = "warn"
+			}
+			p.otel.EndGuardrailSpan(grSpan, decision, verdict.Severity, verdict.Reason, t0)
+		}
 
 		p.logPreCall(req.Model, req.Messages, verdict, elapsed)
 		p.recordTelemetry("prompt", req.Model, verdict, elapsed, nil, nil)
 
 		if verdict.Action == "block" && mode == "action" {
+			if p.otel != nil && agentSpan != nil {
+				p.otel.EndAgentSpan(agentSpan, "guardrail blocked")
+			}
 			msg := blockMessage(customBlockMsg, "prompt", verdict.Reason)
 			if req.Stream {
 				p.writeBlockedStream(w, req.Model, msg)
@@ -324,17 +365,22 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 
 	// --- Forward to upstream provider ---
 	if req.Stream {
-		p.handleStreamingRequest(w, r, &req, mode, customBlockMsg)
+		p.handleStreamingRequest(w, r, &req, mode, customBlockMsg, agentCtx)
 	} else {
-		p.handleNonStreamingRequest(w, r, &req, mode, customBlockMsg)
+		p.handleNonStreamingRequest(w, r, &req, mode, customBlockMsg, agentCtx)
+	}
+
+	// End invoke_agent span after the full request completes.
+	if p.otel != nil && agentSpan != nil {
+		p.otel.EndAgentSpan(agentSpan, "")
 	}
 }
 
-func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *http.Request, req *ChatRequest, mode, customBlockMsg string) {
+func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *http.Request, req *ChatRequest, mode, customBlockMsg string, agentCtx context.Context) {
 	aliasModel := req.Model
 	fmt.Fprintf(os.Stderr, "[guardrail] → upstream (non-streaming) model=%q messages=%d\n", req.Model, len(req.Messages))
 
-	// Start LLM span before the upstream call.
+	// Start LLM span as child of invoke_agent.
 	llmStartTime := time.Now()
 	system, providerName := p.llmSystemAndProvider(req.Model)
 	maxTokens := 0
@@ -349,11 +395,10 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 	var llmSpan trace.Span
 	if p.otel != nil {
 		llmCtx, llmSpan = p.otel.StartLLMSpan(
-			context.Background(),
+			agentCtx,
 			system, aliasModel, providerName,
 			maxTokens, temperature,
 		)
-		_ = llmCtx // parent context for future nested spans
 	}
 
 	resp, err := p.provider.ChatCompletion(r.Context(), req)
@@ -368,12 +413,13 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 	resp.Model = aliasModel
 	fmt.Fprintf(os.Stderr, "[guardrail] ← upstream response: choices=%d\n", len(resp.Choices))
 
-	// --- Post-call inspection ---
+	// --- Post-call inspection (apply_guardrail output) ---
 	content := ""
 	finishReasons := []string{}
 	toolCallCount := 0
 	if len(resp.Choices) > 0 && resp.Choices[0].Message != nil {
 		content = resp.Choices[0].Message.Content
+		toolCallCount = countToolCalls(resp.Choices[0].Message.ToolCalls)
 	}
 	for _, c := range resp.Choices {
 		if c.FinishReason != nil {
@@ -386,9 +432,31 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 
 	if content != "" {
 		t0 := time.Now()
+
+		// Start guardrail span as child of the LLM span.
+		var grSpan trace.Span
+		if p.otel != nil {
+			parentCtx := context.Background()
+			if llmCtx != nil {
+				parentCtx = llmCtx
+			}
+			_, grSpan = p.otel.StartGuardrailSpan(parentCtx, "defenseclaw", "output", aliasModel)
+		}
+
 		respMessages := []ChatMessage{{Role: "assistant", Content: content}}
 		verdict := p.inspector.Inspect(r.Context(), "completion", content, respMessages, aliasModel, mode)
 		elapsed := time.Since(t0)
+
+		// End guardrail span with decision.
+		if p.otel != nil && grSpan != nil {
+			decision := "allow"
+			if verdict.Action == "block" {
+				decision = "deny"
+			} else if verdict.Severity != "NONE" {
+				decision = "warn"
+			}
+			p.otel.EndGuardrailSpan(grSpan, decision, verdict.Severity, verdict.Reason, t0)
+		}
 
 		var tokIn, tokOut *int64
 		if resp.Usage != nil {
@@ -418,6 +486,11 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 		}
 	}
 
+	// --- Emit execute_tool spans for any tool_calls in the response ---
+	if p.otel != nil && llmCtx != nil && len(resp.Choices) > 0 && resp.Choices[0].Message != nil {
+		p.emitToolCallSpans(r.Context(), llmCtx, resp.Choices[0].Message.ToolCalls, aliasModel, mode)
+	}
+
 	// End LLM span with response data.
 	if p.otel != nil && llmSpan != nil {
 		promptTok, completionTok := 0, 0
@@ -442,7 +515,7 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.Request, req *ChatRequest, mode, customBlockMsg string) {
+func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.Request, req *ChatRequest, mode, customBlockMsg string, agentCtx context.Context) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		writeOpenAIError(w, http.StatusInternalServerError, "streaming not supported")
@@ -457,7 +530,7 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 	aliasModel := req.Model
 	fmt.Fprintf(os.Stderr, "[guardrail] → upstream (streaming) model=%q messages=%d\n", req.Model, len(req.Messages))
 
-	// Start LLM span before the streaming call.
+	// Start LLM span as child of invoke_agent.
 	llmStartTime := time.Now()
 	system, providerName := p.llmSystemAndProvider(req.Model)
 	maxTokens := 0
@@ -471,7 +544,7 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 	var llmSpan trace.Span
 	if p.otel != nil {
 		_, llmSpan = p.otel.StartLLMSpan(
-			context.Background(),
+			agentCtx,
 			system, aliasModel, providerName,
 			maxTokens, temperature,
 		)
@@ -525,13 +598,36 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 	guardrail := "none"
 	guardrailResult := ""
 
-	// Final post-stream inspection.
+	// Final post-stream inspection (apply_guardrail output).
 	if accumulated.Len() > 0 {
 		content := accumulated.String()
 		t0 := time.Now()
+
+		// Start guardrail span as child of the LLM span.
+		var grSpan trace.Span
+		if p.otel != nil {
+			parentCtx := context.Background()
+			if llmSpan != nil {
+				// Use the span's context for proper hierarchy.
+				parentCtx = trace.ContextWithSpan(context.Background(), llmSpan)
+			}
+			_, grSpan = p.otel.StartGuardrailSpan(parentCtx, "defenseclaw", "output", aliasModel)
+		}
+
 		respMessages := []ChatMessage{{Role: "assistant", Content: content}}
 		verdict := p.inspector.Inspect(r.Context(), "completion", content, respMessages, aliasModel, mode)
 		elapsed := time.Since(t0)
+
+		// End guardrail span with decision.
+		if p.otel != nil && grSpan != nil {
+			decision := "allow"
+			if verdict.Action == "block" {
+				decision = "deny"
+			} else if verdict.Severity != "NONE" {
+				decision = "warn"
+			}
+			p.otel.EndGuardrailSpan(grSpan, decision, verdict.Severity, verdict.Reason, t0)
+		}
 
 		var tokIn, tokOut *int64
 		if usage != nil {
@@ -845,7 +941,7 @@ func (p *GuardrailProxy) recordTelemetry(direction, model string, verdict *ScanV
 			p.otel.RecordGuardrailEvaluation(ctx, "cisco-ai-defense", verdict.Action)
 		}
 		if tokIn != nil || tokOut != nil {
-			p.otel.RecordLLMTokens(ctx, "guardrail-proxy", ptrOr(tokIn, 0), ptrOr(tokOut, 0))
+			p.otel.RecordLLMTokens(ctx, "apply_guardrail", "defenseclaw", model, ptrOr(tokIn, 0), ptrOr(tokOut, 0))
 		}
 	}
 }
@@ -871,4 +967,74 @@ func ptrOr(p *int64, def int64) int64 {
 		return *p
 	}
 	return def
+}
+
+// ---------------------------------------------------------------------------
+// Tool call helpers for execute_tool spans
+// ---------------------------------------------------------------------------
+
+// toolCallEntry represents a single tool_call in an OpenAI response.
+type toolCallEntry struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+// countToolCalls returns the number of tool calls in a raw JSON array.
+func countToolCalls(raw json.RawMessage) int {
+	if len(raw) == 0 {
+		return 0
+	}
+	var calls []toolCallEntry
+	if err := json.Unmarshal(raw, &calls); err != nil {
+		return 0
+	}
+	return len(calls)
+}
+
+// emitToolCallSpans creates execute_tool spans for each tool_call in the LLM
+// response, as children of the chat span context. Each tool call is also
+// inspected by the guardrail, producing a child apply_guardrail span.
+func (p *GuardrailProxy) emitToolCallSpans(reqCtx, llmCtx context.Context, raw json.RawMessage, model, mode string) {
+	if len(raw) == 0 {
+		return
+	}
+	var calls []toolCallEntry
+	if err := json.Unmarshal(raw, &calls); err != nil {
+		return
+	}
+	for _, tc := range calls {
+		name := tc.Function.Name
+		if name == "" {
+			name = "unknown"
+		}
+		toolCtx, span := p.otel.StartToolSpan(
+			llmCtx, name, "pending", nil, false, "", "", "",
+		)
+
+		// --- Guardrail inspection of tool call arguments ---
+		if toolCtx != nil && tc.Function.Arguments != "" {
+			t0 := time.Now()
+			_, grSpan := p.otel.StartGuardrailSpan(toolCtx, "defenseclaw", "tool_call", model)
+
+			inspectContent := fmt.Sprintf("tool:%s args:%s", name, tc.Function.Arguments)
+			msgs := []ChatMessage{{Role: "assistant", Content: inspectContent}}
+			verdict := p.inspector.Inspect(reqCtx, "tool_call", inspectContent, msgs, model, mode)
+
+			if grSpan != nil {
+				decision := "allow"
+				if verdict.Action == "block" {
+					decision = "deny"
+				} else if verdict.Severity != "NONE" {
+					decision = "warn"
+				}
+				p.otel.EndGuardrailSpan(grSpan, decision, verdict.Severity, verdict.Reason, t0)
+			}
+		}
+
+		p.otel.EndToolSpan(span, 0, 0, time.Now(), name, "")
+	}
 }

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -47,8 +47,6 @@ type activeAgent struct {
 	ctx        context.Context
 	startTime  time.Time
 	sessionKey string
-	provider   string
-	model      string
 }
 
 // EventRouter dispatches gateway events to the appropriate handlers and logs

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -371,6 +371,7 @@ func (r *EventRouter) handleSessionMessage(evt EventFrame) {
 				finishReasons, toolCallCount,
 				"none", "",
 				system, now,
+				"openclaw",
 			)
 
 			// Store LLM context so tool_call spans become children of this LLM span.

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -41,6 +41,16 @@ type activeSpan struct {
 	provider  string
 }
 
+// activeAgent tracks an invoke_agent span for a running agent session.
+type activeAgent struct {
+	span       trace.Span
+	ctx        context.Context
+	startTime  time.Time
+	sessionKey string
+	provider   string
+	model      string
+}
+
 // EventRouter dispatches gateway events to the appropriate handlers and logs
 // everything to the audit store.
 type EventRouter struct {
@@ -50,22 +60,52 @@ type EventRouter struct {
 	policy *enforce.PolicyEngine
 	otel   *telemetry.Provider
 
-	autoApprove     bool
-	activeToolSpans map[string][]*activeSpan
-	spanMu          sync.Mutex
+	autoApprove      bool
+	activeToolSpans  map[string][]*activeSpan
+	activeAgentSpans map[string]*activeAgent // keyed by runId
+	activeLLMCtx     context.Context         // context of most recent LLM span, for tool→LLM hierarchy
+	spanMu           sync.Mutex
 }
 
 // NewEventRouter creates a router that handles gateway events for the sidecar.
 func NewEventRouter(client *Client, store *audit.Store, logger *audit.Logger, autoApprove bool, otel *telemetry.Provider) *EventRouter {
 	return &EventRouter{
-		client:          client,
-		store:           store,
-		logger:          logger,
-		policy:          enforce.NewPolicyEngine(store),
-		otel:            otel,
-		autoApprove:     autoApprove,
-		activeToolSpans: make(map[string][]*activeSpan),
+		client:           client,
+		store:            store,
+		logger:           logger,
+		policy:           enforce.NewPolicyEngine(store),
+		otel:             otel,
+		autoApprove:      autoApprove,
+		activeToolSpans:  make(map[string][]*activeSpan),
+		activeAgentSpans: make(map[string]*activeAgent),
 	}
+}
+
+// getActiveAgentCtx returns the context from the currently active agent span,
+// providing parent-child hierarchy for LLM spans.
+// Falls back to context.Background() if no agent span is active.
+func (r *EventRouter) getActiveAgentCtx() context.Context {
+	r.spanMu.Lock()
+	defer r.spanMu.Unlock()
+	for _, aa := range r.activeAgentSpans {
+		return aa.ctx
+	}
+	return context.Background()
+}
+
+// getToolParentCtx returns the best parent context for tool/approval spans:
+// prefers the most recent LLM span context (for LLM→tool hierarchy),
+// falls back to agent context, then context.Background().
+func (r *EventRouter) getToolParentCtx() context.Context {
+	r.spanMu.Lock()
+	defer r.spanMu.Unlock()
+	if r.activeLLMCtx != nil {
+		return r.activeLLMCtx
+	}
+	for _, aa := range r.activeAgentSpans {
+		return aa.ctx
+	}
+	return context.Background()
 }
 
 // Route dispatches a single event frame to the correct handler.
@@ -302,6 +342,8 @@ func (r *EventRouter) handleSessionMessage(evt EventFrame) {
 		// Emit LLM span for assistant messages with a known model.
 		// This captures LLM invocations that arrive via the WebSocket
 		// (the direct OpenClaw → LLM path, not the guardrail proxy).
+		// Uses the active agent context as parent for proper hierarchy.
+		// Stores the LLM context so subsequent tool spans become children.
 		if r.otel != nil && msg.Role == "assistant" && msg.Model != "" {
 			system := inferSystem(msg.Provider, msg.Model)
 			promptTokens, completionTokens := 0, 0
@@ -316,9 +358,10 @@ func (r *EventRouter) handleSessionMessage(evt EventFrame) {
 			// Count tool_use blocks in content to populate tool_calls attribute.
 			toolCallCount := countToolUseBlocks(msg.Content)
 
+			parentCtx := r.getActiveAgentCtx()
 			now := time.Now()
-			_, span := r.otel.StartLLMSpan(
-				context.Background(),
+			llmCtx, span := r.otel.StartLLMSpan(
+				parentCtx,
 				system, msg.Model, msg.Provider,
 				0, 0.0,
 			)
@@ -329,6 +372,12 @@ func (r *EventRouter) handleSessionMessage(evt EventFrame) {
 				"none", "",
 				system, now,
 			)
+
+			// Store LLM context so tool_call spans become children of this LLM span.
+			r.spanMu.Lock()
+			r.activeLLMCtx = llmCtx
+			r.spanMu.Unlock()
+
 			readLoopLogf("[bifrost] session.message: emitted LLM span model=%s provider=%s system=%s tokens=%d/%d",
 				msg.Model, msg.Provider, system, promptTokens, completionTokens)
 		}
@@ -534,14 +583,66 @@ func (r *EventRouter) handleAgentStreamEvent(se struct {
 			readLoopLogf("[bifrost] agent lifecycle START runId=%s", se.RunID)
 			_ = r.logger.LogAction("gateway-agent-start", se.SessionKey,
 				fmt.Sprintf("runId=%s", se.RunID))
+
+			// Start invoke_agent span as root of this agent run.
+			if r.otel != nil && se.RunID != "" {
+				// Use sessionKey as conversation.id; fall back to runId.
+				conversationID := se.SessionKey
+				if conversationID == "" {
+					conversationID = se.RunID
+				}
+				agentCtx, agentSpan := r.otel.StartAgentSpan(
+					context.Background(),
+					conversationID, // conversation.id
+					"openclaw",     // agent name
+					"",             // provider filled on session.message
+				)
+				r.spanMu.Lock()
+				r.activeAgentSpans[se.RunID] = &activeAgent{
+					span:       agentSpan,
+					ctx:        agentCtx,
+					startTime:  time.Now(),
+					sessionKey: se.SessionKey,
+				}
+				r.spanMu.Unlock()
+			}
+
 		case "error":
 			readLoopLogf("[bifrost] agent lifecycle ERROR runId=%s error=%q", se.RunID, data.Error)
 			_ = r.logger.LogAction("gateway-agent-error", se.SessionKey,
 				fmt.Sprintf("runId=%s error=%s", se.RunID, truncate(data.Error, 200)))
+
+			// End invoke_agent span with error.
+			if r.otel != nil && se.RunID != "" {
+				r.spanMu.Lock()
+				r.activeLLMCtx = nil
+				if aa := r.activeAgentSpans[se.RunID]; aa != nil {
+					delete(r.activeAgentSpans, se.RunID)
+					r.spanMu.Unlock()
+					r.otel.EndAgentSpan(aa.span, truncate(data.Error, 256))
+				} else {
+					r.spanMu.Unlock()
+				}
+			}
+
 		case "end":
 			readLoopLogf("[bifrost] agent lifecycle END runId=%s", se.RunID)
 			_ = r.logger.LogAction("gateway-agent-end", se.SessionKey,
 				fmt.Sprintf("runId=%s", se.RunID))
+
+			// End invoke_agent span successfully.
+			if r.otel != nil && se.RunID != "" {
+				r.spanMu.Lock()
+				r.activeLLMCtx = nil
+				if aa := r.activeAgentSpans[se.RunID]; aa != nil {
+					delete(r.activeAgentSpans, se.RunID)
+					r.spanMu.Unlock()
+					r.otel.EndAgentSpan(aa.span, "")
+				} else {
+					r.spanMu.Unlock()
+				}
+			}
+
 		default:
 			readLoopLogf("[bifrost] agent lifecycle phase=%s runId=%s", data.Phase, se.RunID)
 		}
@@ -606,8 +707,9 @@ func (r *EventRouter) handleToolCall(evt EventFrame) {
 	}
 
 	if r.otel != nil {
+		parentCtx := r.getToolParentCtx()
 		ctx, span := r.otel.StartToolSpan(
-			context.Background(),
+			parentCtx,
 			payload.Tool, payload.Status, payload.Args,
 			dangerous, flaggedPattern, "builtin", "",
 		)
@@ -676,7 +778,8 @@ func (r *EventRouter) handleApprovalRequest(evt EventFrame) {
 
 	var approvalSpan trace.Span
 	if r.otel != nil {
-		_, approvalSpan = r.otel.StartApprovalSpan(context.Background(), payload.ID, rawCmd, argv, cwd)
+		parentCtx := r.getToolParentCtx()
+		_, approvalSpan = r.otel.StartApprovalSpan(parentCtx, payload.ID, rawCmd, argv, cwd)
 	}
 
 	cmdFindings := ScanAllRules(rawCmd, "shell")

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -270,6 +270,10 @@ func (r *EventRouter) handleSessionMessage(evt EventFrame) {
 			ErrorMessage string          `json:"errorMessage"`
 			Provider     string          `json:"provider"`
 			Model        string          `json:"model"`
+			Usage        *struct {
+				PromptTokens     int `json:"prompt_tokens"`
+				CompletionTokens int `json:"completion_tokens"`
+			} `json:"usage,omitempty"`
 		}
 		if err := json.Unmarshal(envelope.Message, &msg); err != nil {
 			readLoopLogf("[bifrost] session.message: has message field but failed to parse: %v", err)
@@ -293,6 +297,40 @@ func (r *EventRouter) handleSessionMessage(evt EventFrame) {
 		if msg.StopReason == "error" || msg.ErrorMessage != "" {
 			readLoopLogf("[bifrost] session.message ERROR: stopReason=%s error=%q provider=%s model=%s",
 				msg.StopReason, msg.ErrorMessage, msg.Provider, msg.Model)
+		}
+
+		// Emit LLM span for assistant messages with a known model.
+		// This captures LLM invocations that arrive via the WebSocket
+		// (the direct OpenClaw → LLM path, not the guardrail proxy).
+		if r.otel != nil && msg.Role == "assistant" && msg.Model != "" {
+			system := inferSystem(msg.Provider, msg.Model)
+			promptTokens, completionTokens := 0, 0
+			if msg.Usage != nil {
+				promptTokens = msg.Usage.PromptTokens
+				completionTokens = msg.Usage.CompletionTokens
+			}
+			finishReasons := []string{}
+			if msg.StopReason != "" {
+				finishReasons = []string{msg.StopReason}
+			}
+			// Count tool_use blocks in content to populate tool_calls attribute.
+			toolCallCount := countToolUseBlocks(msg.Content)
+
+			now := time.Now()
+			_, span := r.otel.StartLLMSpan(
+				context.Background(),
+				system, msg.Model, msg.Provider,
+				0, 0.0,
+			)
+			r.otel.EndLLMSpan(
+				span, msg.Model,
+				promptTokens, completionTokens,
+				finishReasons, toolCallCount,
+				"none", "",
+				system, now,
+			)
+			readLoopLogf("[bifrost] session.message: emitted LLM span model=%s provider=%s system=%s tokens=%d/%d",
+				msg.Model, msg.Provider, system, promptTokens, completionTokens)
 		}
 
 		_ = r.logger.LogAction("gateway-session-message", envelope.SessionKey,
@@ -804,4 +842,53 @@ func (r *EventRouter) isArgvDangerous(argv []string) bool {
 var dangerousBinaries = []string{
 	"curl", "wget", "nc", "ncat", "netcat",
 	"dd", "mkfs", "rm",
+}
+
+// inferSystem derives the gen_ai.system value from provider and model strings.
+func inferSystem(provider, model string) string {
+	p := strings.ToLower(provider)
+	switch {
+	case strings.Contains(p, "anthropic"):
+		return "anthropic"
+	case strings.Contains(p, "openai"):
+		return "openai"
+	case strings.Contains(p, "google"), strings.Contains(p, "vertex"):
+		return "google"
+	case strings.Contains(p, "nvidia"), strings.Contains(p, "nim"):
+		return "nvidia-nim"
+	}
+	m := strings.ToLower(model)
+	switch {
+	case strings.HasPrefix(m, "claude"):
+		return "anthropic"
+	case strings.HasPrefix(m, "gpt"), strings.HasPrefix(m, "o1"), strings.HasPrefix(m, "o3"), strings.HasPrefix(m, "o4"):
+		return "openai"
+	case strings.HasPrefix(m, "gemini"):
+		return "google"
+	}
+	if provider != "" {
+		return strings.ToLower(provider)
+	}
+	return "unknown"
+}
+
+// countToolUseBlocks counts tool_use content blocks in a JSON content field.
+// Content may be a string (0 tool calls) or an array of objects with "type" fields.
+func countToolUseBlocks(content json.RawMessage) int {
+	if len(content) == 0 || content[0] != '[' {
+		return 0
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		return 0
+	}
+	count := 0
+	for _, b := range blocks {
+		if b.Type == "tool_use" || b.Type == "tool_calls" {
+			count++
+		}
+	}
+	return count
 }

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -37,9 +37,10 @@ type metricsSet struct {
 	toolDuration  metric.Float64Histogram
 	toolErrors    metric.Int64Counter
 	approvalCount metric.Int64Counter
-	llmCalls      metric.Int64Counter
-	llmTokens     metric.Int64Counter
-	llmDuration   metric.Float64Histogram
+
+	// GenAI semconv metrics
+	genAITokenUsage       metric.Float64Histogram // gen_ai.client.token.usage
+	genAIOperationDuration metric.Float64Histogram // gen_ai.client.operation.duration
 
 	// Alert metrics
 	alertCount           metric.Int64Counter
@@ -135,23 +136,20 @@ func newMetricsSet(m metric.Meter) (*metricsSet, error) {
 		return nil, err
 	}
 
-	ms.llmCalls, err = m.Int64Counter("defenseclaw.llm.calls",
-		metric.WithUnit("{call}"),
-		metric.WithDescription("Total LLM calls observed"))
-	if err != nil {
-		return nil, err
-	}
-
-	ms.llmTokens, err = m.Int64Counter("defenseclaw.llm.tokens",
+	ms.genAITokenUsage, err = m.Float64Histogram("gen_ai.client.token.usage",
 		metric.WithUnit("{token}"),
-		metric.WithDescription("Total tokens consumed"))
+		metric.WithDescription("Number of input and output tokens used."),
+		metric.WithExplicitBucketBoundaries(1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864),
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	ms.llmDuration, err = m.Float64Histogram("defenseclaw.llm.duration",
-		metric.WithUnit("ms"),
-		metric.WithDescription("LLM call duration distribution"))
+	ms.genAIOperationDuration, err = m.Float64Histogram("gen_ai.client.operation.duration",
+		metric.WithUnit("s"),
+		metric.WithDescription("GenAI operation duration."),
+		metric.WithExplicitBucketBoundaries(0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -364,43 +362,36 @@ func (p *Provider) RecordApproval(ctx context.Context, result string, auto, dang
 	))
 }
 
-// RecordLLMCall records an LLM call metric.
-func (p *Provider) RecordLLMCall(ctx context.Context, system, model string) {
+// RecordLLMTokens records token consumption metrics per OTel GenAI semconv.
+// gen_ai.client.token.usage histogram with gen_ai.token.type = "input"/"output".
+func (p *Provider) RecordLLMTokens(ctx context.Context, operationName, providerName, model string, prompt, completion int64) {
 	if !p.Enabled() || p.metrics == nil {
 		return
 	}
-	p.metrics.llmCalls.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("gen_ai.system", system),
+	commonAttrs := []attribute.KeyValue{
+		attribute.String("gen_ai.operation.name", operationName),
+		attribute.String("gen_ai.provider.name", providerName),
 		attribute.String("gen_ai.request.model", model),
-	))
-}
-
-// RecordLLMTokens records token consumption metrics.
-func (p *Provider) RecordLLMTokens(ctx context.Context, system string, prompt, completion int64) {
-	if !p.Enabled() || p.metrics == nil {
-		return
 	}
 	if prompt > 0 {
-		p.metrics.llmTokens.Add(ctx, prompt, metric.WithAttributes(
-			attribute.String("gen_ai.system", system),
-			attribute.String("token.type", "prompt"),
-		))
+		attrs := append([]attribute.KeyValue{attribute.String("gen_ai.token.type", "input")}, commonAttrs...)
+		p.metrics.genAITokenUsage.Record(ctx, float64(prompt), metric.WithAttributes(attrs...))
 	}
 	if completion > 0 {
-		p.metrics.llmTokens.Add(ctx, completion, metric.WithAttributes(
-			attribute.String("gen_ai.system", system),
-			attribute.String("token.type", "completion"),
-		))
+		attrs := append([]attribute.KeyValue{attribute.String("gen_ai.token.type", "output")}, commonAttrs...)
+		p.metrics.genAITokenUsage.Record(ctx, float64(completion), metric.WithAttributes(attrs...))
 	}
 }
 
-// RecordLLMDuration records LLM call duration.
-func (p *Provider) RecordLLMDuration(ctx context.Context, system, model string, durationMs float64) {
+// RecordLLMDuration records LLM call duration per OTel GenAI semconv.
+// gen_ai.client.operation.duration histogram, unit=seconds.
+func (p *Provider) RecordLLMDuration(ctx context.Context, operationName, providerName, model string, durationSeconds float64) {
 	if !p.Enabled() || p.metrics == nil {
 		return
 	}
-	p.metrics.llmDuration.Record(ctx, durationMs, metric.WithAttributes(
-		attribute.String("gen_ai.system", system),
+	p.metrics.genAIOperationDuration.Record(ctx, durationSeconds, metric.WithAttributes(
+		attribute.String("gen_ai.operation.name", operationName),
+		attribute.String("gen_ai.provider.name", providerName),
 		attribute.String("gen_ai.request.model", model),
 	))
 }

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -364,7 +364,7 @@ func (p *Provider) RecordApproval(ctx context.Context, result string, auto, dang
 
 // RecordLLMTokens records token consumption metrics per OTel GenAI semconv.
 // gen_ai.client.token.usage histogram with gen_ai.token.type = "input"/"output".
-func (p *Provider) RecordLLMTokens(ctx context.Context, operationName, providerName, model string, prompt, completion int64) {
+func (p *Provider) RecordLLMTokens(ctx context.Context, operationName, providerName, model, agentName string, prompt, completion int64) {
 	if !p.Enabled() || p.metrics == nil {
 		return
 	}
@@ -372,6 +372,9 @@ func (p *Provider) RecordLLMTokens(ctx context.Context, operationName, providerN
 		attribute.String("gen_ai.operation.name", operationName),
 		attribute.String("gen_ai.provider.name", providerName),
 		attribute.String("gen_ai.request.model", model),
+	}
+	if agentName != "" {
+		commonAttrs = append(commonAttrs, attribute.String("gen_ai.agent.name", agentName))
 	}
 	if prompt > 0 {
 		attrs := append([]attribute.KeyValue{attribute.String("gen_ai.token.type", "input")}, commonAttrs...)
@@ -385,15 +388,19 @@ func (p *Provider) RecordLLMTokens(ctx context.Context, operationName, providerN
 
 // RecordLLMDuration records LLM call duration per OTel GenAI semconv.
 // gen_ai.client.operation.duration histogram, unit=seconds.
-func (p *Provider) RecordLLMDuration(ctx context.Context, operationName, providerName, model string, durationSeconds float64) {
+func (p *Provider) RecordLLMDuration(ctx context.Context, operationName, providerName, model, agentName string, durationSeconds float64) {
 	if !p.Enabled() || p.metrics == nil {
 		return
 	}
-	p.metrics.genAIOperationDuration.Record(ctx, durationSeconds, metric.WithAttributes(
+	attrs := []attribute.KeyValue{
 		attribute.String("gen_ai.operation.name", operationName),
 		attribute.String("gen_ai.provider.name", providerName),
 		attribute.String("gen_ai.request.model", model),
-	))
+	}
+	if agentName != "" {
+		attrs = append(attrs, attribute.String("gen_ai.agent.name", agentName))
+	}
+	p.metrics.genAIOperationDuration.Record(ctx, durationSeconds, metric.WithAttributes(attrs...))
 }
 
 // RecordAlert records a runtime alert metric.

--- a/internal/telemetry/provider.go
+++ b/internal/telemetry/provider.go
@@ -34,6 +34,7 @@ import (
 	metricNoop "go.opentelemetry.io/otel/metric/noop"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
@@ -293,17 +294,32 @@ func newLoggerProvider(ctx context.Context, cfg config.OTelConfig, res *resource
 	), nil
 }
 
+// temporalitySelector returns a TemporalitySelector based on the config value.
+// "delta" (default) prevents cumulative re-export of exemplars on every flush,
+// so each metric data point is exported exactly once.
+// "cumulative" preserves the Go SDK default behaviour.
+func temporalitySelector(mode string) sdkmetric.TemporalitySelector {
+	if strings.EqualFold(mode, "cumulative") {
+		return sdkmetric.DefaultTemporalitySelector
+	}
+	return func(sdkmetric.InstrumentKind) metricdata.Temporality {
+		return metricdata.DeltaTemporality
+	}
+}
+
 func newMeterProvider(ctx context.Context, cfg config.OTelConfig, res *resource.Resource, headers map[string]string) (*sdkmetric.MeterProvider, error) {
 	var exporter sdkmetric.Exporter
 	var err error
 
 	endpoint := resolveValue(cfg.Metrics.Endpoint, cfg.Endpoint)
 	protocol := resolveValue(cfg.Metrics.Protocol, cfg.Protocol)
+	tsel := temporalitySelector(cfg.Metrics.Temporality)
 
 	if protocol == "http" {
 		opts := []metrichttp.Option{
 			metrichttp.WithEndpoint(endpoint),
 			metrichttp.WithHeaders(headers),
+			metrichttp.WithTemporalitySelector(tsel),
 		}
 		if cfg.Metrics.URLPath != "" {
 			opts = append(opts, metrichttp.WithURLPath(cfg.Metrics.URLPath))
@@ -323,6 +339,7 @@ func newMeterProvider(ctx context.Context, cfg config.OTelConfig, res *resource.
 		opts := []metricgrpc.Option{
 			metricgrpc.WithEndpoint(endpoint),
 			metricgrpc.WithHeaders(headers),
+			metricgrpc.WithTemporalitySelector(tsel),
 		}
 		if cfg.TLS.Insecure {
 			opts = append(opts, metricgrpc.WithInsecure())

--- a/internal/telemetry/provider_test.go
+++ b/internal/telemetry/provider_test.go
@@ -128,9 +128,8 @@ func TestDisabledProvider_Metrics_NoPanic(t *testing.T) {
 	p.RecordToolDuration(ctx, "shell", "builtin", 50)
 	p.RecordToolError(ctx, "shell", 1)
 	p.RecordApproval(ctx, "approved", true, false)
-	p.RecordLLMCall(ctx, "openai", "gpt-4")
-	p.RecordLLMTokens(ctx, "openai", 100, 200)
-	p.RecordLLMDuration(ctx, "openai", "gpt-4", 500)
+	p.RecordLLMTokens(ctx, "chat", "openai", "gpt-4", 100, 200)
+	p.RecordLLMDuration(ctx, "chat", "openai", "gpt-4", 0.5)
 	p.RecordAlert(ctx, "dangerous-command", "HIGH", "local-pattern")
 	p.RecordGuardrailEvaluation(ctx, "ai-defense", "block")
 	p.RecordGuardrailLatency(ctx, "ai-defense", 100)
@@ -794,32 +793,42 @@ func TestRecordLLMTokens_EmitsMetric(t *testing.T) {
 	defer p.Shutdown(context.Background())
 
 	ctx := context.Background()
-	p.RecordLLMTokens(ctx, "guardrail-proxy", 150, 75)
-	p.RecordLLMTokens(ctx, "guardrail-proxy", 200, 0) // no completion tokens
+	p.RecordLLMTokens(ctx, "chat", "openai", "gpt-4", 150, 75)
+	p.RecordLLMTokens(ctx, "chat", "openai", "gpt-4", 200, 0) // no completion tokens
 
 	var rm metricdata.ResourceMetrics
 	if err := reader.Collect(ctx, &rm); err != nil {
 		t.Fatalf("Collect: %v", err)
 	}
 
-	found := findCounter(rm, "defenseclaw.llm.tokens")
+	found := findHistogram(rm, "gen_ai.client.token.usage")
 	if found == nil {
-		t.Fatal("metric defenseclaw.llm.tokens not found")
+		t.Fatal("metric gen_ai.client.token.usage not found")
 	}
 
-	sum, ok := found.Data.(metricdata.Sum[int64])
+	hist, ok := found.Data.(metricdata.Histogram[float64])
 	if !ok {
-		t.Fatalf("expected Sum[int64], got %T", found.Data)
+		t.Fatalf("expected Histogram[float64], got %T", found.Data)
 	}
 
-	promptTokens := counterValueByAttr(sum, "token.type", "prompt")
-	completionTokens := counterValueByAttr(sum, "token.type", "completion")
-
-	if promptTokens != 350 {
-		t.Errorf("prompt tokens = %d, want 350", promptTokens)
+	var inputSum, outputSum float64
+	for _, dp := range hist.DataPoints {
+		for _, attr := range dp.Attributes.ToSlice() {
+			if string(attr.Key) == "gen_ai.token.type" {
+				if attr.Value.AsString() == "input" {
+					inputSum += dp.Sum
+				} else if attr.Value.AsString() == "output" {
+					outputSum += dp.Sum
+				}
+			}
+		}
 	}
-	if completionTokens != 75 {
-		t.Errorf("completion tokens = %d, want 75", completionTokens)
+
+	if inputSum != 350 {
+		t.Errorf("input token sum = %v, want 350", inputSum)
+	}
+	if outputSum != 75 {
+		t.Errorf("output token sum = %v, want 75", outputSum)
 	}
 }
 

--- a/internal/telemetry/provider_test.go
+++ b/internal/telemetry/provider_test.go
@@ -213,6 +213,53 @@ func TestResolveValue(t *testing.T) {
 	}
 }
 
+func TestTemporalitySelector(t *testing.T) {
+	kinds := []sdkmetric.InstrumentKind{
+		sdkmetric.InstrumentKindCounter,
+		sdkmetric.InstrumentKindUpDownCounter,
+		sdkmetric.InstrumentKindHistogram,
+		sdkmetric.InstrumentKindGauge,
+		sdkmetric.InstrumentKindObservableCounter,
+		sdkmetric.InstrumentKindObservableUpDownCounter,
+		sdkmetric.InstrumentKindObservableGauge,
+	}
+
+	t.Run("delta", func(t *testing.T) {
+		sel := temporalitySelector("delta")
+		for _, k := range kinds {
+			if got := sel(k); got != metricdata.DeltaTemporality {
+				t.Errorf("temporalitySelector(\"delta\")(%v) = %v, want Delta", k, got)
+			}
+		}
+	})
+
+	t.Run("empty defaults to delta", func(t *testing.T) {
+		sel := temporalitySelector("")
+		for _, k := range kinds {
+			if got := sel(k); got != metricdata.DeltaTemporality {
+				t.Errorf("temporalitySelector(\"\")(%v) = %v, want Delta", k, got)
+			}
+		}
+	})
+
+	t.Run("cumulative", func(t *testing.T) {
+		sel := temporalitySelector("cumulative")
+		// Should return the SDK default (cumulative for all kinds).
+		for _, k := range kinds {
+			if got := sel(k); got != metricdata.CumulativeTemporality {
+				t.Errorf("temporalitySelector(\"cumulative\")(%v) = %v, want Cumulative", k, got)
+			}
+		}
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		sel := temporalitySelector("Cumulative")
+		if got := sel(sdkmetric.InstrumentKindHistogram); got != metricdata.CumulativeTemporality {
+			t.Errorf("temporalitySelector(\"Cumulative\") should be case-insensitive, got %v", got)
+		}
+	})
+}
+
 func TestBuildSampler(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/telemetry/provider_test.go
+++ b/internal/telemetry/provider_test.go
@@ -128,8 +128,8 @@ func TestDisabledProvider_Metrics_NoPanic(t *testing.T) {
 	p.RecordToolDuration(ctx, "shell", "builtin", 50)
 	p.RecordToolError(ctx, "shell", 1)
 	p.RecordApproval(ctx, "approved", true, false)
-	p.RecordLLMTokens(ctx, "chat", "openai", "gpt-4", 100, 200)
-	p.RecordLLMDuration(ctx, "chat", "openai", "gpt-4", 0.5)
+	p.RecordLLMTokens(ctx, "chat", "openai", "gpt-4", "", 100, 200)
+	p.RecordLLMDuration(ctx, "chat", "openai", "gpt-4", "", 0.5)
 	p.RecordAlert(ctx, "dangerous-command", "HIGH", "local-pattern")
 	p.RecordGuardrailEvaluation(ctx, "ai-defense", "block")
 	p.RecordGuardrailLatency(ctx, "ai-defense", 100)
@@ -793,8 +793,8 @@ func TestRecordLLMTokens_EmitsMetric(t *testing.T) {
 	defer p.Shutdown(context.Background())
 
 	ctx := context.Background()
-	p.RecordLLMTokens(ctx, "chat", "openai", "gpt-4", 150, 75)
-	p.RecordLLMTokens(ctx, "chat", "openai", "gpt-4", 200, 0) // no completion tokens
+	p.RecordLLMTokens(ctx, "chat", "openai", "gpt-4", "test-agent", 150, 75)
+	p.RecordLLMTokens(ctx, "chat", "openai", "gpt-4", "test-agent", 200, 0) // no completion tokens
 
 	var rm metricdata.ResourceMetrics
 	if err := reader.Collect(ctx, &rm); err != nil {
@@ -829,6 +829,14 @@ func TestRecordLLMTokens_EmitsMetric(t *testing.T) {
 	}
 	if outputSum != 75 {
 		t.Errorf("output token sum = %v, want 75", outputSum)
+	}
+
+	// Verify gen_ai.agent.name attribute is present on data points.
+	for _, dp := range hist.DataPoints {
+		hasAgentName := hasAttribute(dp.Attributes, "gen_ai.agent.name", "test-agent")
+		if !hasAgentName {
+			t.Error("histogram data point missing attribute gen_ai.agent.name=test-agent")
+		}
 	}
 }
 

--- a/internal/telemetry/runtime.go
+++ b/internal/telemetry/runtime.go
@@ -286,11 +286,12 @@ func (p *Provider) EndLLMSpan(
 	guardrail, guardrailResult string,
 	providerName string,
 	startTime time.Time,
+	agentName string,
 ) {
 	ctx := context.Background()
 	durationSec := time.Since(startTime).Seconds()
-	p.RecordLLMTokens(ctx, "chat", providerName, responseModel, int64(promptTokens), int64(completionTokens))
-	p.RecordLLMDuration(ctx, "chat", providerName, responseModel, durationSec)
+	p.RecordLLMTokens(ctx, "chat", providerName, responseModel, agentName, int64(promptTokens), int64(completionTokens))
+	p.RecordLLMDuration(ctx, "chat", providerName, responseModel, agentName, durationSec)
 
 	if span == nil {
 		return

--- a/internal/telemetry/runtime.go
+++ b/internal/telemetry/runtime.go
@@ -288,7 +288,12 @@ func (p *Provider) EndLLMSpan(
 	startTime time.Time,
 	agentName string,
 ) {
+	// Use the span's context so the SDK attaches exemplars (trace ID + span ID)
+	// to the histogram data points, linking metrics to traces.
 	ctx := context.Background()
+	if span != nil {
+		ctx = trace.ContextWithSpan(ctx, span)
+	}
 	durationSec := time.Since(startTime).Seconds()
 	p.RecordLLMTokens(ctx, "chat", providerName, responseModel, agentName, int64(promptTokens), int64(completionTokens))
 	p.RecordLLMDuration(ctx, "chat", providerName, responseModel, agentName, durationSec)

--- a/internal/telemetry/runtime.go
+++ b/internal/telemetry/runtime.go
@@ -68,7 +68,53 @@ func (p *Provider) EmitInspectSpan(ctx context.Context, tool, action, severity s
 	return traceID
 }
 
+// StartAgentSpan starts a new OTel span for an agent invocation session.
+// Follows OTel GenAI semconv: span name = "invoke_agent {agentName}".
+func (p *Provider) StartAgentSpan(
+	ctx context.Context,
+	conversationID, agentName, provider string,
+) (context.Context, trace.Span) {
+	if !p.TracesEnabled() {
+		return ctx, nil
+	}
+
+	spanName := "invoke_agent"
+	if agentName != "" {
+		spanName = fmt.Sprintf("invoke_agent %s", agentName)
+	}
+
+	ctx, span := p.tracer.Start(ctx, spanName,
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithTimestamp(time.Now()),
+	)
+
+	span.SetAttributes(
+		attribute.String("gen_ai.operation.name", "invoke_agent"),
+		attribute.String("gen_ai.agent.name", agentName),
+		attribute.String("gen_ai.conversation.id", conversationID),
+	)
+	if provider != "" {
+		span.SetAttributes(attribute.String("gen_ai.provider.name", provider))
+	}
+
+	return ctx, span
+}
+
+// EndAgentSpan ends an active agent invocation span.
+func (p *Provider) EndAgentSpan(span trace.Span, errMsg string) {
+	if span == nil {
+		return
+	}
+	if errMsg != "" {
+		span.SetStatus(codes.Error, errMsg)
+	} else {
+		span.SetStatus(codes.Ok, "")
+	}
+	span.End()
+}
+
 // StartToolSpan starts a new OTel span for a tool_call event.
+// Follows OTel GenAI semconv: span name = "execute_tool {toolName}".
 // Raw args are not exported to avoid leaking tokens, keys, or prompt content.
 // Metrics are always recorded when OTel is enabled, even if traces are off.
 func (p *Provider) StartToolSpan(
@@ -84,13 +130,16 @@ func (p *Provider) StartToolSpan(
 		return ctx, nil
 	}
 
-	ctx, span := p.tracer.Start(ctx, fmt.Sprintf("tool/%s", tool),
+	ctx, span := p.tracer.Start(ctx, fmt.Sprintf("execute_tool %s", tool),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithTimestamp(time.Now()),
 	)
 
 	span.SetAttributes(
-		attribute.String("defenseclaw.tool.name", tool),
+		attribute.String("gen_ai.operation.name", "execute_tool"),
+		attribute.String("gen_ai.tool.name", tool),
+		attribute.String("gen_ai.tool.type", "function"),
+		// DefenseClaw-specific attributes
 		attribute.String("defenseclaw.tool.status", status),
 		attribute.Int("defenseclaw.tool.args_length", len(args)),
 		attribute.Bool("defenseclaw.tool.dangerous", dangerous),
@@ -194,7 +243,8 @@ func (p *Provider) EndApprovalSpan(span trace.Span, result, reason string, auto,
 	span.End()
 }
 
-// StartLLMSpan starts a new OTel span for an LLM call (future-ready).
+// StartLLMSpan starts a new OTel span for an LLM inference call.
+// Follows OTel GenAI semconv: span name = "chat {model}".
 // Metrics are always recorded when OTel is enabled, even if traces are off.
 func (p *Provider) StartLLMSpan(
 	ctx context.Context,
@@ -202,29 +252,29 @@ func (p *Provider) StartLLMSpan(
 	maxTokens int,
 	temperature float64,
 ) (context.Context, trace.Span) {
-	p.RecordLLMCall(ctx, system, model)
-
 	if !p.TracesEnabled() {
 		return ctx, nil
 	}
 
-	ctx, span := p.tracer.Start(ctx, fmt.Sprintf("llm/%s", model),
+	ctx, span := p.tracer.Start(ctx, fmt.Sprintf("chat %s", model),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithTimestamp(time.Now()),
 	)
 
 	span.SetAttributes(
+		attribute.String("gen_ai.operation.name", "chat"),
 		attribute.String("gen_ai.system", system),
+		attribute.String("gen_ai.provider.name", provider),
 		attribute.String("gen_ai.request.model", model),
 		attribute.Int("gen_ai.request.max_tokens", maxTokens),
 		attribute.Float64("gen_ai.request.temperature", temperature),
-		attribute.String("defenseclaw.llm.provider", provider),
 	)
 
 	return ctx, span
 }
 
 // EndLLMSpan ends an active LLM call span with response data.
+// Follows OTel GenAI semconv for token attribute names.
 // Metrics are always recorded when OTel is enabled, even if the span is nil
 // (traces disabled).
 func (p *Provider) EndLLMSpan(
@@ -234,13 +284,13 @@ func (p *Provider) EndLLMSpan(
 	finishReasons []string,
 	toolCallCount int,
 	guardrail, guardrailResult string,
-	system string,
+	providerName string,
 	startTime time.Time,
 ) {
 	ctx := context.Background()
-	durationMs := float64(time.Since(startTime).Milliseconds())
-	p.RecordLLMTokens(ctx, system, int64(promptTokens), int64(completionTokens))
-	p.RecordLLMDuration(ctx, system, responseModel, durationMs)
+	durationSec := time.Since(startTime).Seconds()
+	p.RecordLLMTokens(ctx, "chat", providerName, responseModel, int64(promptTokens), int64(completionTokens))
+	p.RecordLLMDuration(ctx, "chat", providerName, responseModel, durationSec)
 
 	if span == nil {
 		return
@@ -249,14 +299,68 @@ func (p *Provider) EndLLMSpan(
 	span.SetAttributes(
 		attribute.String("gen_ai.response.model", responseModel),
 		attribute.StringSlice("gen_ai.response.finish_reasons", finishReasons),
-		attribute.Int("gen_ai.usage.prompt_tokens", promptTokens),
-		attribute.Int("gen_ai.usage.completion_tokens", completionTokens),
+		attribute.Int("gen_ai.usage.input_tokens", promptTokens),
+		attribute.Int("gen_ai.usage.output_tokens", completionTokens),
 		attribute.Int("defenseclaw.llm.tool_calls", toolCallCount),
 		attribute.String("defenseclaw.llm.guardrail", guardrail),
 		attribute.String("defenseclaw.llm.guardrail.result", guardrailResult),
 	)
 
 	if guardrailResult == "blocked" {
+		span.SetStatus(codes.Error, "guardrail blocked")
+	} else {
+		span.SetStatus(codes.Ok, "")
+	}
+
+	span.End()
+}
+
+// StartGuardrailSpan starts a new OTel span for a guardrail evaluation.
+// Follows OTel GenAI semconv PR #3233: span name = "apply_guardrail {name} {targetType}".
+func (p *Provider) StartGuardrailSpan(
+	ctx context.Context,
+	name, targetType, model string,
+) (context.Context, trace.Span) {
+	if !p.TracesEnabled() {
+		return ctx, nil
+	}
+
+	spanName := fmt.Sprintf("apply_guardrail %s %s", name, targetType)
+	ctx, span := p.tracer.Start(ctx, spanName,
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithTimestamp(time.Now()),
+	)
+
+	span.SetAttributes(
+		attribute.String("gen_ai.operation.name", "apply_guardrail"),
+		attribute.String("gen_ai.guardrail.name", name),
+		attribute.String("gen_ai.security.target.type", targetType),
+		attribute.String("gen_ai.request.model", model),
+	)
+
+	return ctx, span
+}
+
+// EndGuardrailSpan ends an active guardrail span with the security decision.
+func (p *Provider) EndGuardrailSpan(
+	span trace.Span,
+	decision, severity, reason string,
+	startTime time.Time,
+) {
+	if span == nil {
+		return
+	}
+
+	span.SetAttributes(
+		attribute.String("gen_ai.security.decision.type", decision),
+		attribute.String("defenseclaw.guardrail.severity", severity),
+	)
+
+	if reason != "" {
+		span.SetAttributes(attribute.String("defenseclaw.guardrail.reason", truncateStr(reason, 256)))
+	}
+
+	if decision == "deny" || decision == "block" {
 		span.SetStatus(codes.Error, "guardrail blocked")
 	} else {
 		span.SetStatus(codes.Ok, "")


### PR DESCRIPTION

This branch implements a full OTel GenAI semantic conventions span hierarchy
for DefenseClaw's guardrail proxy and WebSocket router, replaces custom
`defenseclaw.llm.*` metrics with the standard `gen_ai.client.*` semconv
histograms, adds exemplar linking from metrics to traces, and switches metric
export to delta temporality.

---

## Main Branch — Baseline

Both branches were deployed to a test env and the same 6-request integration
test suite was executed against each, with a clean OTel Collector restart
between runs.

### otelscope output — `main` branch

```
Trace ID: 724e9a2b2f048e3a11aff2ca8b13016b
└── defenseclaw/startup
```

**Total: 1 span, 0 metrics.**

Main produces only a `defenseclaw/startup` span. The guardrail proxy processes
all 6 requests correctly (functional test passes), but emits no spans or
metric exemplars for any of them. The existing `tool/{name}` and
`approval/{id}` spans only fire on the WebSocket router path (not triggered
by the test suite which uses HTTP proxy requests).

Existing LLM metric instruments on main:
- `defenseclaw.llm.calls` — Int64Counter, `gen_ai.system` + `gen_ai.request.model` attributes
- `defenseclaw.llm.tokens` — Int64Counter, `token.type` = `prompt`/`completion`
- `defenseclaw.llm.duration` — Float64Histogram, unit=ms

These metrics are recorded but have no exemplars (no span context propagated),
so otelscope cannot associate them with any trace.

---

## Feature Branch — After Changes

### otelscope output — `feat/llm-spans-from-session-messages`

```
════════════════════════════════════════════════════════════
║ Conversation: test-conv-1775089877-001
║ Traces: 3
════════════════════════════════════════════════════════════
  Trace ID: b1b3c8e75b6ea5346018d1117a65af8a
  └── invoke_agent openclaw [op:invoke_agent]
      ├── apply_guardrail defenseclaw input [op:apply_guardrail]
      └── chat gpt-4o-mini [op:chat]
          ├── Metric: gen_ai.client.operation.duration [op:chat]
          ├── Metric: gen_ai.client.token.usage (input) [op:chat]
          ├── Metric: gen_ai.client.token.usage (output) [op:chat]
          └── apply_guardrail defenseclaw output [op:apply_guardrail]

  Trace ID: dc1ee4337353e2a216d54bf1794c4c96
  └── invoke_agent openclaw [op:invoke_agent]
      ├── apply_guardrail defenseclaw input [op:apply_guardrail]
      └── chat gpt-4o-mini [op:chat]
          ├── Metric: defenseclaw.tool.calls
          ├── Metric: defenseclaw.tool.calls
          ├── apply_guardrail defenseclaw output [op:apply_guardrail]
          ├── execute_tool get_weather [op:execute_tool]
          │   └── apply_guardrail defenseclaw tool_call [op:apply_guardrail]
          └── execute_tool get_time [op:execute_tool]
              └── apply_guardrail defenseclaw tool_call [op:apply_guardrail]

  Trace ID: eb055f41a9d551c25a43f625dc90c1e9
  └── invoke_agent openclaw [op:invoke_agent]
      ├── apply_guardrail defenseclaw input [op:apply_guardrail]
      └── chat gpt-4o-mini [op:chat]
          ├── Metric: gen_ai.client.operation.duration [op:chat]
          ├── Metric: gen_ai.client.token.usage (input) [op:chat]
          ├── Metric: gen_ai.client.token.usage (output) [op:chat]
          └── apply_guardrail defenseclaw output [op:apply_guardrail]

════════════════════════════════════════════════════════════
║ Conversation: test-conv-1775089877-002
║ Traces: 3
════════════════════════════════════════════════════════════
  Trace ID: 14a3d1556851e9668e638b41cc456ca9
  └── invoke_agent openclaw [op:invoke_agent]
      ├── apply_guardrail defenseclaw input [op:apply_guardrail]
      └── chat gpt-4o-mini [op:chat]
          └── apply_guardrail defenseclaw output [op:apply_guardrail]

  Trace ID: 1fee6402040962b6e1b73ad53ad0d822
  └── invoke_agent openclaw [op:invoke_agent]
      ├── apply_guardrail defenseclaw input [op:apply_guardrail]
      └── chat gpt-4o-mini [op:chat]
          ├── Metric: gen_ai.client.operation.duration [op:chat]
          ├── Metric: gen_ai.client.token.usage (input) [op:chat]
          ├── Metric: gen_ai.client.token.usage (output) [op:chat]
          └── apply_guardrail defenseclaw output [op:apply_guardrail]

  Trace ID: d5c2304ac0ddb6dd5eecc31eaa39f81c
  └── invoke_agent openclaw [op:invoke_agent]
      ├── apply_guardrail defenseclaw input [op:apply_guardrail]
      └── chat gpt-4o-mini [op:chat]
          ├── Metric: gen_ai.client.operation.duration [op:chat]
          ├── Metric: gen_ai.client.token.usage (output) [op:chat]
          └── apply_guardrail defenseclaw output [op:apply_guardrail]

════════════════════════════════════════════════════════════
║ (No Conversation ID)
║ Traces: 1
════════════════════════════════════════════════════════════
  Trace ID: 1e28a163e5bcdc67d7967a2dd66f5ba0
  └── defenseclaw/startup
```
Sample screenshot of Splunk Observability Platform view
<img width="1429" height="815" alt="image" src="https://github.com/user-attachments/assets/3f170905-3830-4ecc-9f82-67394a5f80c4" />


**Total: 29 spans, 13 metrics.** Each metric appears exactly once per data point.

---

## Comparison

| Aspect                        | `main`                          | Feature branch                     |
|-------------------------------|---------------------------------|------------------------------------|
| Spans per test run            | 1 (`startup` only)              | 29 (full hierarchy)                |
| Metrics with exemplars        | 0                               | 13                                 |
| Span hierarchy                | flat, `context.Background()`    | `invoke_agent` → `chat` → `apply_guardrail` / `execute_tool` |
| Span names                    | `tool/{name}`, `llm/{model}`    | `execute_tool {name}`, `chat {model}`, `invoke_agent {agent}`, `apply_guardrail {name} {target}` |
| Metric names                  | `defenseclaw.llm.*`             | `gen_ai.client.*` (semconv)        |
| Token metric type             | Int64Counter                    | Float64Histogram (with buckets)    |
| Duration unit                 | ms                              | seconds                            |
| Exemplars (metric→trace link) | none                            | trace_id + span_id on each metric  |
| Temporality                   | cumulative (SDK default)        | delta (configurable)               |
| Conversations grouped         | no                              | yes, by `gen_ai.conversation.id`   |
| Tool call spans               | none from proxy                 | `execute_tool` per tool_call       |
| Guardrail spans               | none                            | `apply_guardrail` on input/output/tool_call |
| Blocked request trace         | nothing                         | `invoke_agent` → `apply_guardrail input` (no `chat`) |

---

## Commits

| Commit | Description |
|--------|-------------|
| `2949f85` | Wire LLM spans from session messages and guardrail proxy |
| `6fd66e7` | Update OTel spec and status for guardrail proxy, semconv metrics, full span hierarchy |
| `94e5c37` | Propagate `gen_ai.agent.name` to `token.usage` and `operation.duration` metrics |
| `f627dea` | Add exemplars to `gen_ai.client` metrics linking metrics to traces |
| `1af95da` | Switch metrics to delta temporality and add temporality config |

---

## Files Changed (11 files, +1203/−143)

| File | Delta | Summary |
|------|-------|---------|
| `internal/telemetry/runtime.go` | +136/−7 | New: `StartAgentSpan`, `EndAgentSpan`, `StartGuardrailSpan`, `EndGuardrailSpan`. Rename spans to semconv (`chat {model}`, `execute_tool {name}`). Exemplar context via `trace.ContextWithSpan` in `EndLLMSpan`. Rename token attrs `prompt_tokens`→`input_tokens`, `completion_tokens`→`output_tokens`. |
| `internal/telemetry/metrics.go` | +76/−49 | Replace `defenseclaw.llm.calls`/`tokens`/`duration` with `gen_ai.client.token.usage` (Float64Histogram) and `gen_ai.client.operation.duration` (Float64Histogram, unit=s). Semconv bucket boundaries. `gen_ai.agent.name` on all metrics. |
| `internal/telemetry/provider.go` | +17 | `temporalitySelector()` function; `metricdata` import; `WithTemporalitySelector` on HTTP and gRPC exporters. |
| `internal/telemetry/provider_test.go` | +94/−11 | `TestTemporalitySelector` (delta, cumulative, empty-default, case-insensitive). Update `RecordLLMTokens`/`RecordLLMDuration` tests to histogram assertions. `gen_ai.agent.name` attribute verification. |
| `internal/config/config.go` | +2 | `Temporality` field on `OTelMetricsConfig`; viper default `"delta"`. |
| `internal/gateway/proxy.go` | +307/−3 | Full span hierarchy in guardrail proxy: `invoke_agent` → `chat` → `apply_guardrail` (input/output/tool_call) → `execute_tool`. New helpers: `llmSystemAndProvider`, `emitToolCallSpans`, `countToolCalls`, `toolCallEntry`. |
| `internal/gateway/router.go` | +213/−15 | `activeAgent` map for agent lifecycle spans (start/error/end). `activeLLMCtx` for tool→LLM hierarchy. LLM spans from `session.message` assistant payloads. New helpers: `inferSystem`, `countToolUseBlocks`, `getActiveAgentCtx`, `getToolParentCtx`. |
| `internal/gateway/gateway_test.go` | +45/−20 | Update guardrail event tests: `defenseclaw.llm.tokens` (Sum[int64]) → `gen_ai.client.token.usage` (Histogram[float64]), `token.type` `prompt`/`completion` → `gen_ai.token.type` `input`/`output`. |
| `internal/gateway/api.go` | +1/−1 | Update `RecordLLMTokens` call signature to new semconv parameters. |
| `docs/OTEL-IMPLEMENTATION-STATUS.md` | +253 | New: comprehensive audit of OTel spec vs implementation status. |
| `docs/OTEL.md` | +201/−43 | Updated spec with GenAI semconv span hierarchy, metric definitions, and exemplar design. |

---

## Test Scenarios

Integration test suite: 6 requests across 2 conversations, run against both
`main` and the feature branch on the test container with real Cisco AI Defense +
local pattern guardrails. Guardrail mode set to `action` for blocking tests.

### Conversation 1 — Clean Multi-Turn

| Turn | Request | Expected Trace |
|------|---------|----------------|
| 1 | Simple greeting (`"Hello, how are you?"`) | `invoke_agent` → `apply_guardrail input` → `chat` (finish=length) → `apply_guardrail output` |
| 2 | Tool-calling (`"Weather in SF and time in Tokyo"`) | `invoke_agent` → `apply_guardrail input` → `chat` (finish=tool_calls, 2 tools) → `apply_guardrail output` → `execute_tool get_weather` → `apply_guardrail tool_call` → `execute_tool get_time` → `apply_guardrail tool_call` |
| 3 | Follow-up chat (`"Summarize what you said"`) | `invoke_agent` → `apply_guardrail input` → `chat` (finish=stop) → `apply_guardrail output` |

### Conversation 2 — Security Scenarios

| Turn | Request | Expected Trace |
|------|---------|----------------|
| 4 | Clean question (`"What is the capital of France?"`) | `invoke_agent` → `apply_guardrail input` → `chat` → `apply_guardrail output` |
| 5 | Prompt injection (`"Ignore all instructions..."`) | `invoke_agent` → `apply_guardrail input` → `chat` → `apply_guardrail output` (flagged, content rewritten by AI Defense) |
| 6 | Secret leak in prompt (AWS key) | `invoke_agent` → `apply_guardrail input` → `chat` → `apply_guardrail output` (flagged with severity) |

### Metric Exemplar Expectations

Each `chat` span has exactly:
- 1× `gen_ai.client.token.usage` (input) — if prompt_tokens > 0
- 1× `gen_ai.client.token.usage` (output) — if completion_tokens > 0
- 1× `gen_ai.client.operation.duration`

Tool-calling turn (Turn 2) additionally:
- 2× `defenseclaw.tool.calls` — one per tool in the response

All metrics carry exemplars (trace_id + span_id) linking to their parent `chat` span.

---

## Configuration

New config field added:

```yaml
otel:
  metrics:
    temporality: "delta"   # "delta" (default) or "cumulative"
```

---

## Validation

1. `go test ./...` — all packages pass
2. `make go-lint` — 0 issues
3. Integration test suite (6 requests, 2 conversations) — all pass on both branches
4. `main` baseline: 1 span, 0 metrics — confirmed via otelscope on the test container
5. Feature branch: 29 spans, 13 metrics — each metric appears exactly once
6. Span hierarchy matches expected shapes for all 6 test scenarios
7. Exemplars correctly link metrics to parent `chat` spans
8. Blocked request (Turn 5) correctly produces no `chat` span (only when Cisco AI Defense blocks at input)
9. Raw collector output confirms `gen_ai.operation.name: Str(invoke_agent)` on all invoke_agent spans
