### PR TITLE
Sync bundled Splunk product telemetry to deployment.app

### DIFF
--- a/bundles/splunk_local_bridge/bin/splunk-claw-bridge
+++ b/bundles/splunk_local_bridge/bin/splunk-claw-bridge
@@ -21,7 +21,6 @@ IMAGE_OVERRIDE=""
 RUN_LABEL="bridge-smoke"
 QUERY_STRING=""
 AUTH_ROLE="local"
-PRODUCT_TELEMETRY_INSTANCE_PATH="/opt/splunk/etc/apps/defenseclaw_local_mode/local/.product_telemetry_instance_id"
 
 usage() {
   cat <<'EOF'
@@ -34,6 +33,7 @@ Actions:
   status   Show compose status for the selected profile
   logs     Show compose logs for the selected profile
   query    Run a SPL search through the public local query interface
+  telemetry-trigger  Submit one immediate deployment.app product-telemetry event for this app
   smoke    Run the runtime smoke harness for the selected profile
   help     Show this help
 
@@ -59,7 +59,7 @@ fail() {
 
 is_truthy() {
   local value
-  value="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  value="${1,,}"
   case "${value}" in
     1|true|yes|on) return 0 ;;
     *) return 1 ;;
@@ -225,6 +225,7 @@ require_running_service() {
 package_app() {
   (
     cd "${ROOT_DIR}"
+    python3 splunk/bin/render_product_telemetry_context.py >/dev/null
     bash splunk/package_local_mode_app.sh
   )
 }
@@ -327,59 +328,16 @@ run_query_helper() {
     --query "${QUERY_STRING}"
 }
 
-service_is_running() {
-  local services
-  services="$(run_compose ps --status running --services 2>/dev/null || true)"
-  printf '%s\n' "${services}" | grep -qx "splunk"
-}
-
-ensure_product_telemetry_instance_id() {
-  run_compose exec -T -u splunk splunk sh -lc "
-    umask 077
-    mkdir -p \"\$(dirname '${PRODUCT_TELEMETRY_INSTANCE_PATH}')\"
-    if [ ! -s '${PRODUCT_TELEMETRY_INSTANCE_PATH}' ]; then
-      cat /proc/sys/kernel/random/uuid > '${PRODUCT_TELEMETRY_INSTANCE_PATH}'
-    fi
-    tr -d '\r\n' < '${PRODUCT_TELEMETRY_INSTANCE_PATH}'
-  "
-}
-
-read_splunk_version() {
-  run_compose exec -T -u splunk splunk sh -lc \
-    "/opt/splunk/bin/splunk version 2>/dev/null | sed -n 's/^Splunk \\([^ ]*\\).*/\\1/p' | head -n 1"
-}
-
-emit_product_telemetry() {
-  local event_type="$1"
-  local integration_enabled="${DEFENSECLAW_INTEGRATION_ENABLED:-false}"
-  local instance_id="unknown"
-  local splunk_version="unknown"
-
-  if ! service_is_running; then
-    return 0
-  fi
-
-  instance_id="$(ensure_product_telemetry_instance_id || true)"
-  splunk_version="$(read_splunk_version || true)"
-  if [[ -z "${instance_id}" ]]; then
-    instance_id="unknown"
-  fi
-  if [[ -z "${splunk_version}" ]]; then
-    splunk_version="unknown"
-  fi
-
-  run_compose exec -T \
-    -u splunk \
-    -e "DEFENSECLAW_INTEGRATION_ENABLED=${integration_enabled}" \
-    -e "SPLUNK_VERSION=${splunk_version}" \
-    -e "PHONE_HOME_INSTANCE_ID=${instance_id}" \
-    splunk \
-    /opt/splunk/bin/splunk cmd python /opt/splunk-claw-bridge/splunk/apps/defenseclaw_local_mode/bin/send_product_telemetry.py \
-    --event-type "${event_type}" \
-    --instance-id "${instance_id}" \
-    --splunk-version "${splunk_version}" \
-    --defenseclaw-integration-enabled "${integration_enabled}" \
-    --output json >/dev/null
+telemetry_trigger_query() {
+  cat <<'EOF'
+| rest splunk_server=local /services/apps/local
+| search title="defenseclaw_local_mode"
+| fields splunk_server title version disabled
+| eval data="{\"host\":\""+splunk_server+"\",\"name\":\""+title+"\",\"version\":\""+coalesce(version, "")+"\",\"enabled\":"+if(disabled=0, "true", "false")+"}"
+| eval _time=now(), date=strftime(_time, "%Y-%m-%d")
+| fields data _time date
+| outputtelemetry component=deployment.app type=event input=data anonymous=true support=true license=false optinrequired=2
+EOF
 }
 
 cmd_up() {
@@ -388,10 +346,6 @@ cmd_up() {
   cleanup_stopped_service_containers
   run_compose up -d --remove-orphans
   wait_for_hec_ready || fail "timed out waiting for HEC readiness on ${DEFENSECLAW_HEC_URL}"
-  emit_product_telemetry startup
-  if is_truthy "${DEFENSECLAW_INTEGRATION_ENABLED:-false}"; then
-    emit_product_telemetry integration_configured
-  fi
 
   if [[ "${OUTPUT}" == "json" ]]; then
     export PROFILE
@@ -405,9 +359,6 @@ cmd_up() {
 cmd_down() {
   local -a down_args
   down_args=(down)
-  if service_is_running; then
-    emit_product_telemetry shutdown
-  fi
   if [[ "${REMOVE_VOLUMES}" == "true" || "${PROFILE}" == "ci" ]]; then
     down_args+=(-v)
   fi
@@ -438,6 +389,15 @@ cmd_query() {
   require_running_service
   resolve_query_credentials
   run_query_helper
+}
+
+cmd_telemetry_trigger() {
+  local telemetry_query
+  require_running_service
+  telemetry_query="$(telemetry_trigger_query)"
+  run_compose exec -T -u splunk splunk \
+    /opt/splunk/bin/splunk search "${telemetry_query}" \
+    -auth "admin:${SPLUNK_PASSWORD}"
 }
 
 cmd_smoke() {
@@ -472,6 +432,7 @@ case "${ACTION}" in
   status) cmd_status ;;
   logs) cmd_logs ;;
   query) cmd_query ;;
+  telemetry-trigger) cmd_telemetry_trigger ;;
   smoke) cmd_smoke ;;
   help) usage ;;
   *) fail "unsupported action: ${ACTION}" ;;

--- a/bundles/splunk_local_bridge/env/.env.example
+++ b/bundles/splunk_local_bridge/env/.env.example
@@ -26,7 +26,6 @@ NEMOCLAW_LOCAL_POLICY_MODE=skip
 NEMOCLAW_LOCAL_OLLAMA_HOST=0.0.0.0:11434
 
 # Product telemetry follows a default-on, explicit opt-out model.
-# Public repo defaults still use placeholder destination values and must fail closed until a named environment injects real ones.
+# Set PHONE_HOME_ENABLED=false if the customer disables product telemetry.
+# The shipped path uses Splunk's built-in deployment.app collection.
 PHONE_HOME_ENABLED=true
-PHONE_HOME_HEC_URL=https://example.invalid/services/collector/event
-PHONE_HOME_HEC_TOKEN=replace-me-in-named-environments

--- a/bundles/splunk_local_bridge/splunk/README.md
+++ b/bundles/splunk_local_bridge/splunk/README.md
@@ -45,12 +45,19 @@ mode, and it does not proxy or replace a direct O11y integration.
   - assigns the restricted role
   - sets `defaultApp=defenseclaw_local_mode`
 
+## Product Telemetry
+
+- product telemetry is enabled by default and can be disabled with `PHONE_HOME_ENABLED=false`
+- the shipped path uses Splunk's built-in `deployment.app` collection rather than the older custom daily sender
+- `bin/splunk-claw-bridge telemetry-trigger` can be used for immediate validation without waiting for the built-in collection window
+- the bundled app only marks install state and inventory metadata; it does not patch the built-in `splunk_instrumentation` app and it does not send customer event content
+
 ## Supported Pattern
 
 This repo uses the native `docker-splunk` / `splunk-ansible` bootstrap path first:
 
 - app installation uses `splunk.apps_location`
 - config files are emitted from `default.yml`
-- the remaining custom Ansible is limited to the restricted local user bootstrap
+- the remaining custom Ansible is limited to the restricted local user bootstrap and product-telemetry install-state sync
 
 That is intentional. If a future change can be expressed through `docker-splunk` or `splunk-ansible` configuration, prefer that over new custom tasks.

--- a/bundles/splunk_local_bridge/splunk/ansible/configure_product_telemetry.yml
+++ b/bundles/splunk_local_bridge/splunk/ansible/configure_product_telemetry.yml
@@ -6,12 +6,21 @@
     group: splunk
     mode: "0700"
 
-- name: Configure DefenseClaw product telemetry scheduled-search override
+- name: Read DefenseClaw product telemetry generated context
+  slurp:
+    src: /opt/splunk-claw-bridge/splunk/build/defenseclaw_product_telemetry_context.json
+  register: defenseclaw_product_telemetry_context_raw
+
+- name: Parse DefenseClaw product telemetry generated context
+  set_fact:
+    defenseclaw_product_telemetry_context: "{{ defenseclaw_product_telemetry_context_raw.content | b64decode | from_json }}"
+
+- name: Configure DefenseClaw product telemetry install state override
   copy:
-    dest: /opt/splunk/etc/apps/defenseclaw_local_mode/local/savedsearches.conf
+    dest: /opt/splunk/etc/apps/defenseclaw_local_mode/local/app.conf
     owner: splunk
     group: splunk
     mode: "0600"
     content: |
-      [DefenseClaw Internal - Daily Product Telemetry Usage Summary]
-      disabled = {{ '0' if (lookup('env', 'PHONE_HOME_ENABLED') | default('true', true) | lower) in ['1', 'true', 'yes', 'on'] else '1' }}
+      [install]
+      is_configured = {{ '1' if defenseclaw_product_telemetry_context.phone_home_enabled | default(true) else '0' }}

--- a/bundles/splunk_local_bridge/splunk/apps/defenseclaw_local_mode/bin/emit_product_telemetry_usage_summary.py
+++ b/bundles/splunk_local_bridge/splunk/apps/defenseclaw_local_mode/bin/emit_product_telemetry_usage_summary.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+
 # Copyright 2026 Cisco Systems, Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-
 
 import argparse
 import csv
@@ -34,7 +34,7 @@ BIN_DIR = Path(__file__).resolve().parent
 if str(BIN_DIR) not in sys.path:
     sys.path.insert(0, str(BIN_DIR))
 
-from product_telemetry_sender import emit_event, emit_result
+from product_telemetry_sender import DEFAULT_DESTINATION_URL, emit_event, emit_result
 
 
 INSTANCE_ID_PATH = Path("/opt/splunk/etc/apps/defenseclaw_local_mode/local/.product_telemetry_instance_id")
@@ -168,7 +168,7 @@ def main() -> int:
         defenseclaw_integration_enabled="true" if parse_bool(os.environ.get("DEFENSECLAW_INTEGRATION_ENABLED", "false")) else "false",
         event_details_json=summary,
         output=args.output,
-        hec_url=os.environ.get("PHONE_HOME_HEC_URL", ""),
+        hec_url=os.environ.get("PHONE_HOME_HEC_URL", DEFAULT_DESTINATION_URL),
         hec_token=os.environ.get("PHONE_HOME_HEC_TOKEN", ""),
         enabled=os.environ.get("PHONE_HOME_ENABLED", "true"),
         timeout=10,

--- a/bundles/splunk_local_bridge/splunk/apps/defenseclaw_local_mode/bin/product_telemetry_sender.py
+++ b/bundles/splunk_local_bridge/splunk/apps/defenseclaw_local_mode/bin/product_telemetry_sender.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+
 # Copyright 2026 Cisco Systems, Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
 import argparse
 import configparser
 import json
@@ -29,10 +29,10 @@ from urllib import error, request
 
 APP_ID = "defenseclaw_local_mode"
 DEPLOYMENT_MODE = "defenseclaw_local_mode"
+DEPLOYMENT_NAME = "defenseclaw_local_mode"
 DEFAULT_SOURCE = "splunk-claw-bridge"
 DEFAULT_SOURCETYPE = "defenseclaw:producttelemetry"
-PLACEHOLDER_URL = "https://example.invalid/services/collector/event"
-PLACEHOLDER_TOKEN = "replace-me-in-named-environments"
+DEFAULT_DESTINATION_URL = "https://quickdraw.splunk.com/telemetry/destination"
 ALLOWED_EVENT_TYPES = {
     "install",
     "startup",
@@ -56,8 +56,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--defenseclaw-integration-enabled", choices=["true", "false"], default="false")
     parser.add_argument("--event-details-json", type=parse_event_details_arg, default=None)
     parser.add_argument("--output", choices=["json", "text"], default="json")
-    parser.add_argument("--hec-url", default=os.environ.get("PHONE_HOME_HEC_URL", PLACEHOLDER_URL))
-    parser.add_argument("--hec-token", default=os.environ.get("PHONE_HOME_HEC_TOKEN", PLACEHOLDER_TOKEN))
+    parser.add_argument("--hec-url", default=os.environ.get("PHONE_HOME_HEC_URL", DEFAULT_DESTINATION_URL))
+    parser.add_argument("--hec-token", default=os.environ.get("PHONE_HOME_HEC_TOKEN", ""))
     parser.add_argument("--enabled", default=os.environ.get("PHONE_HOME_ENABLED", "true"))
     parser.add_argument("--timeout", type=int, default=10)
     return parser
@@ -94,13 +94,20 @@ def parse_bool(value: str) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def normalize_arch(machine: str) -> str:
+    value = machine.strip().lower()
+    if value in {"x86_64", "amd64"}:
+        return "amd64"
+    if value in {"aarch64", "arm64"}:
+        return "arm64"
+    return value or "unknown"
+
+
 def should_skip_delivery(enabled_raw: str, hec_url: str, hec_token: str) -> Optional[str]:
     if not parse_bool(enabled_raw):
         return "disabled"
-    if not hec_url or hec_url == PLACEHOLDER_URL:
+    if not hec_url:
         return "skipped_no_destination"
-    if not hec_token or hec_token == PLACEHOLDER_TOKEN:
-        return "skipped_no_token"
     return None
 
 
@@ -123,12 +130,12 @@ def normalize_usage_summary_event_details(event_details: Dict[str, Any]) -> Dict
         value = event_details["query_interface_used_24h"]
         if not isinstance(value, bool):
             raise ValueError("usage_summary query_interface_used_24h must be a boolean")
-        normalized["query_interface_used_24h"] = value
+        normalized["queryInterfaceUsed24h"] = value
 
     if "alerts_enabled_count" in event_details:
         value = event_details["alerts_enabled_count"]
         try:
-            normalized["alerts_enabled_count"] = int(value)
+            normalized["alertsEnabledCount"] = int(value)
         except (TypeError, ValueError) as exc:
             raise ValueError("usage_summary alerts_enabled_count must be an integer") from exc
 
@@ -140,7 +147,7 @@ def normalize_usage_summary_event_details(event_details: Dict[str, Any]) -> Dict
             families = [str(item).strip() for item in raw_families if str(item).strip()]
         else:
             raise ValueError("usage_summary signal_families_seen_24h must be a string or list")
-        normalized["signal_families_seen_24h"] = families
+        normalized["signalFamiliesSeen24h"] = families
 
     return normalized
 
@@ -161,30 +168,31 @@ def build_payload(args: argparse.Namespace) -> Dict[str, Any]:
 
     bridge_version = read_bridge_version()
     payload: Dict[str, Any] = {
-        "schema_version": "v1",
-        "app_id": APP_ID,
-        "app_version": bridge_version,
-        "bridge_version": bridge_version,
-        "instance_id": instance_id,
-        "deployment_mode": DEPLOYMENT_MODE,
-        "event_type": args.event_type,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "splunk_version": args.splunk_version,
-        "platform_arch": f"{platform.system().lower()}/{platform.machine().lower()}",
-        "splunk_image": os.environ.get("SPLUNK_IMAGE", "unknown"),
-        "defenseclaw_integration_enabled": args.defenseclaw_integration_enabled == "true",
+        "deploymentID": instance_id,
+        "instanceID": instance_id,
+        "name": DEPLOYMENT_NAME,
+        "appID": APP_ID,
+        "appVersion": bridge_version,
+        "bridgeVersion": bridge_version,
+        "deploymentMode": DEPLOYMENT_MODE,
+        "eventType": args.event_type,
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "splunkVersion": args.splunk_version,
+        "platformArch": f"{platform.system().lower()}/{normalize_arch(platform.machine())}",
+        "splunkImage": os.environ.get("SPLUNK_IMAGE", "unknown"),
+        "defenseclawIntegrationEnabled": args.defenseclaw_integration_enabled == "true",
     }
 
     nemoclaw_ref = normalize_known_ref(os.environ.get("NEMOCLAW_REF"))
     if nemoclaw_ref is not None:
-        payload["nemoclaw_ref"] = nemoclaw_ref
+        payload["nemoclawRef"] = nemoclaw_ref
 
     defenseclaw_ref = normalize_known_ref(os.environ.get("DEFENSECLAW_REF"))
     if defenseclaw_ref is not None:
-        payload["defenseclaw_ref"] = defenseclaw_ref
+        payload["defenseclawRef"] = defenseclaw_ref
 
     if event_details:
-        payload["event_details"] = event_details
+        payload.update(event_details)
 
     return payload
 
@@ -197,15 +205,10 @@ def post_event(hec_url: str, hec_token: str, payload: Dict[str, Any], timeout: i
             "event": payload,
         }
     ).encode("utf-8")
-    req = request.Request(
-        hec_url,
-        data=body,
-        headers={
-            "Authorization": f"Splunk {hec_token}",
-            "Content-Type": "application/json",
-        },
-        method="POST",
-    )
+    headers = {"Content-Type": "application/json"}
+    if hec_token:
+        headers["Authorization"] = f"Splunk {hec_token}"
+    req = request.Request(hec_url, data=body, headers=headers, method="POST")
     with request.urlopen(req, timeout=timeout) as response:
         response_body = response.read().decode("utf-8")
         return {
@@ -247,8 +250,8 @@ def emit_result(payload: Dict[str, Any], result: Dict[str, Any], output: str) ->
         print(json.dumps(full, indent=2, sort_keys=True))
     else:
         print(f"status: {result['status']}")
-        print(f"event_type: {payload['event_type']}")
-        print(f"instance_id: {payload['instance_id']}")
+        print(f"event_type: {payload['eventType']}")
+        print(f"instance_id: {payload['instanceID']}")
     return 0
 
 

--- a/bundles/splunk_local_bridge/splunk/apps/defenseclaw_local_mode/bin/send_product_telemetry.py
+++ b/bundles/splunk_local_bridge/splunk/apps/defenseclaw_local_mode/bin/send_product_telemetry.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+
 # Copyright 2026 Cisco Systems, Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-
 
 import sys
 from pathlib import Path

--- a/bundles/splunk_local_bridge/splunk/apps/defenseclaw_local_mode/default/app.conf
+++ b/bundles/splunk_local_bridge/splunk/apps/defenseclaw_local_mode/default/app.conf
@@ -1,6 +1,7 @@
 [install]
 state = enabled
 build = 1
+is_configured = 1
 
 [ui]
 is_visible = true

--- a/bundles/splunk_local_bridge/splunk/apps/defenseclaw_local_mode/default/savedsearches.conf
+++ b/bundles/splunk_local_bridge/splunk/apps/defenseclaw_local_mode/default/savedsearches.conf
@@ -152,23 +152,6 @@ is_visible = 1
 disabled = 0
 is_scheduled = 0
 
-[DefenseClaw Internal - Daily Product Telemetry Usage Summary]
-description = Internal bounded daily product-telemetry summary for DefenseClaw local mode.
-search = | makeresults | fields - _time | appendcols [ search index=defenseclaw_local source=defenseclaw sourcetype="defenseclaw:json" | stats count as audit_events_24h ] | appendcols [ search index=defenseclaw_local sourcetype="openclaw:gateway:json" | stats count as gateway_events_24h ] | appendcols [ search index=defenseclaw_local sourcetype="openclaw:diagnostics:json" | stats count as diagnostics_events_24h ] | appendcols [ search index=defenseclaw_local sourcetype="otel:metric" | stats count as metric_events_24h ] | appendcols [ search index=defenseclaw_local sourcetype="otel:trace" | stats count as trace_events_24h ] | appendcols [ | rest /servicesNS/nobody/defenseclaw_local_mode/saved/searches splunk_server=local | search title="DefenseClaw Alert *" OR title="OpenClaw Alert *" OR title="DefenseClaw Security Ops -*" | stats count(eval(disabled="0")) as alerts_enabled_count ] | eval alerts_enabled_count=coalesce(alerts_enabled_count, 0) | eval signal_families_seen_24h=mvappend(if(coalesce(audit_events_24h, 0)>0, "audit", null()), if(coalesce(gateway_events_24h, 0)>0, "gateway_log", null()), if(coalesce(diagnostics_events_24h, 0)>0, "diagnostics", null()), if(coalesce(metric_events_24h, 0)>0, "metric", null()), if(coalesce(trace_events_24h, 0)>0, "trace", null())) | eval signal_families_seen_24h=if(mvcount(signal_families_seen_24h)=0, "", mvjoin(signal_families_seen_24h, ",")) | fields alerts_enabled_count signal_families_seen_24h
-is_visible = 0
-disabled = 1
-is_scheduled = 1
-cron_schedule = 17 3 * * *
-dispatch.earliest_time = -24h@h
-dispatch.latest_time = now
-alert_type = number of events
-alert_comparator = greater than
-alert_threshold = 0
-action.email = 0
-action.script = 1
-action.script.filename = emit_product_telemetry_usage_summary.py
-action.webhook = 0
-
 [DefenseClaw Security Ops - Repeated Deny Activity]
 description = Disabled-by-default security-operations detection for repeated deny activity on a correlated run or session.
 search = `dcso_detection_repeated_deny_activity`

--- a/bundles/splunk_local_bridge/splunk/bin/render_product_telemetry_context.py
+++ b/bundles/splunk_local_bridge/splunk/bin/render_product_telemetry_context.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+import platform
+from pathlib import Path
+
+
+def normalize_arch(machine: str) -> str:
+    value = machine.strip().lower()
+    if value in {"x86_64", "amd64"}:
+        return "amd64"
+    if value in {"aarch64", "arm64"}:
+        return "arm64"
+    return value or "unknown"
+
+
+def parse_bool(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    root = repo_root()
+    build_dir = root / "splunk" / "build"
+    build_dir.mkdir(parents=True, exist_ok=True)
+    output_path = build_dir / "defenseclaw_product_telemetry_context.json"
+
+    payload = {
+        "platform_arch": f"{platform.system().lower()}/{normalize_arch(platform.machine())}",
+        "splunk_image": os.environ.get("SPLUNK_IMAGE", "unknown") or "unknown",
+        "phone_home_enabled": parse_bool(os.environ.get("PHONE_HOME_ENABLED", "true")),
+        "defenseclaw_integration_enabled": parse_bool(os.environ.get("DEFENSECLAW_INTEGRATION_ENABLED", "false")),
+        "nemoclaw_ref": os.environ.get("NEMOCLAW_REF", "unknown") or "unknown",
+        "defenseclaw_ref": os.environ.get("DEFENSECLAW_REF", "unknown") or "unknown",
+    }
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(str(output_path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- sync the bundled  telemetry path to match the current  implementation
- switch the shipped bundle from the older custom daily sender model to Splunk's built-in  path
- keep the built-in  app untouched and use only supported app-owned config plus  for validation

## What changed
- add generated product telemetry context rendering during app packaging
- change bundled product telemetry install-state override to  with 
- remove the old  shipped saved search
- add  for immediate validation
- sync the bundled telemetry helper scripts and env contract to the current bridge slice
- document the default-on, explicit opt-out model in the bundled Splunk README

## Validation
- 
-  on the synced telemetry scripts
- local bundle runtime check:  app inventory row present and  wrote 
- immediate trigger check returned  with metricValueID 
- opt-out runtime check with  wrote 

## Notes
- this PR does not modify Splunk's built-in product telemetry app
- this PR is intentionally separate from the Free-from-day-1 licensing branch