### PR TITLE
fix: reject path traversal in policy names, quarantine paths

### DIFF
--- a/cli/defenseclaw/commands/cmd_policy.py
+++ b/cli/defenseclaw/commands/cmd_policy.py
@@ -85,8 +85,19 @@ def _save_policy(path: str, data: dict) -> None:
         yaml.dump(data, f, default_flow_style=False, sort_keys=False)
 
 
+def _sanitize_policy_name(name: str) -> str:
+    """Strip path components from a policy name to prevent traversal."""
+    safe = os.path.basename(name)
+    if not safe or safe != name or ".." in name:
+        raise click.ClickException(
+            f"invalid policy name {name!r} — must be a simple name without path separators"
+        )
+    return safe
+
+
 def _find_policy(app: AppContext, name: str) -> str | None:
     """Find a policy file by name (without .yaml extension)."""
+    name = _sanitize_policy_name(name)
     user_dir = _policies_dir(app)
     candidate = os.path.join(user_dir, f"{name}.yaml")
     if os.path.isfile(candidate):
@@ -154,6 +165,8 @@ def create(
       defenseclaw policy create prod --critical-action block --high-action block --medium-action warn\n
       defenseclaw policy create dev --critical-action block --high-action warn --medium-action allow
     """
+    name = _sanitize_policy_name(name)
+
     if name in BUILTIN_POLICIES:
         click.echo(f"error: cannot overwrite built-in policy '{name}'", err=True)
         raise SystemExit(1)

--- a/cli/defenseclaw/commands/cmd_skill.py
+++ b/cli/defenseclaw/commands/cmd_skill.py
@@ -1331,8 +1331,25 @@ def quarantine(app: AppContext, name: str, reason: str) -> None:
     from defenseclaw.enforce.skill_enforcer import SkillEnforcer
 
     skill_name = os.path.basename(name)
+    if not skill_name or ".." in name:
+        click.echo(f"error: invalid skill name {name!r}", err=True)
+        raise SystemExit(1)
 
-    skill_path = name if os.path.isabs(name) else _resolve_path(app, skill_name)
+    if os.path.isabs(name):
+        # Validate absolute paths resolve inside a configured skill directory
+        real = os.path.realpath(name)
+        allowed_roots = [os.path.realpath(c) for c in app.cfg.skill_dirs()]
+        if not any(real.startswith(root + os.sep) or real == root for root in allowed_roots):
+            click.echo(
+                f"error: path {name!r} is not inside a configured skill directory\n"
+                f"  Allowed roots: {', '.join(allowed_roots)}",
+                err=True,
+            )
+            raise SystemExit(1)
+        skill_path: str | None = real
+    else:
+        skill_path = _resolve_path(app, skill_name)
+
     if not skill_path:
         click.echo(f"error: could not locate skill {skill_name!r} — provide an absolute path", err=True)
         raise SystemExit(1)

--- a/cli/defenseclaw/enforce/plugin_enforcer.py
+++ b/cli/defenseclaw/enforce/plugin_enforcer.py
@@ -32,12 +32,17 @@ class PluginEnforcer:
 
     def quarantine(self, plugin_name: str, source_path: str) -> str | None:
         """Move plugin directory to quarantine. Returns quarantine path or None."""
+        safe_name = os.path.basename(plugin_name)
+        if not safe_name or safe_name != plugin_name:
+            return None
         if os.path.islink(source_path):
             return None
         real_path = os.path.realpath(source_path)
         if not os.path.exists(real_path):
             return None
-        dest = os.path.join(self.quarantine_dir, plugin_name)
+        dest = os.path.join(self.quarantine_dir, safe_name)
+        if not os.path.realpath(dest).startswith(os.path.realpath(self.quarantine_dir) + os.sep):
+            return None
         if os.path.exists(dest):
             shutil.rmtree(dest)
         shutil.move(real_path, dest)
@@ -45,7 +50,12 @@ class PluginEnforcer:
 
     def restore(self, plugin_name: str, restore_path: str) -> bool:
         """Restore a quarantined plugin to its original location."""
-        src = os.path.join(self.quarantine_dir, plugin_name)
+        safe_name = os.path.basename(plugin_name)
+        if not safe_name or safe_name != plugin_name:
+            return False
+        src = os.path.join(self.quarantine_dir, safe_name)
+        if not os.path.realpath(src).startswith(os.path.realpath(self.quarantine_dir) + os.sep):
+            return False
         if not os.path.exists(src):
             return False
         os.makedirs(os.path.dirname(restore_path), exist_ok=True)

--- a/cli/defenseclaw/enforce/skill_enforcer.py
+++ b/cli/defenseclaw/enforce/skill_enforcer.py
@@ -32,12 +32,18 @@ class SkillEnforcer:
 
     def quarantine(self, skill_name: str, source_path: str) -> str | None:
         """Move skill directory to quarantine. Returns quarantine path or None."""
+        safe_name = os.path.basename(skill_name)
+        if not safe_name or safe_name != skill_name:
+            return None
         if os.path.islink(source_path):
             return None
         real_path = os.path.realpath(source_path)
         if not os.path.exists(real_path):
             return None
-        dest = os.path.join(self.quarantine_dir, skill_name)
+        dest = os.path.join(self.quarantine_dir, safe_name)
+        # Verify dest is still inside quarantine_dir
+        if not os.path.realpath(dest).startswith(os.path.realpath(self.quarantine_dir) + os.sep):
+            return None
         if os.path.exists(dest):
             shutil.rmtree(dest)
         shutil.move(real_path, dest)
@@ -45,7 +51,12 @@ class SkillEnforcer:
 
     def restore(self, skill_name: str, restore_path: str) -> bool:
         """Restore a quarantined skill to its original location."""
-        src = os.path.join(self.quarantine_dir, skill_name)
+        safe_name = os.path.basename(skill_name)
+        if not safe_name or safe_name != skill_name:
+            return False
+        src = os.path.join(self.quarantine_dir, safe_name)
+        if not os.path.realpath(src).startswith(os.path.realpath(self.quarantine_dir) + os.sep):
+            return False
         if not os.path.exists(src):
             return False
         os.makedirs(os.path.dirname(restore_path), exist_ok=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ default-groups = ["dev"]
 override-dependencies = [
     "rich>=13.7.1,<14.0.0",
     "cryptography>=46.0.7",   # CVE-2026-39892 fixed in 46.0.7
-    "litellm>=1.83.0",        # CVE-2026-35029, CVE-2026-35030
+    "litellm==1.83.0",        # CVE-2026-35029, CVE-2026-35030
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 [manifest]
 overrides = [
     { name = "cryptography", specifier = ">=46.0.7" },
-    { name = "litellm", specifier = ">=1.83.0" },
+    { name = "litellm", specifier = "==1.83.0" },
     { name = "rich", specifier = ">=13.7.1,<14.0.0" },
 ]
 


### PR DESCRIPTION
- policy create/edit: add _sanitize_policy_name() that rejects names with path separators or '..' before they reach os.path.join
- skill quarantine: validate absolute paths resolve inside configured skill directories; reject names containing '..'
- SkillEnforcer + PluginEnforcer: sanitize names with os.path.basename, verify quarantine dest stays inside quarantine_dir, same for restore