### PR TITLE
feat(audit): add structured network egress events to the audit store

### DIFF
--- a/internal/audit/network_egress.go
+++ b/internal/audit/network_egress.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package audit
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// NetworkEgressEvent describes a single outbound network call observed by the
+// agent runtime. It captures the destination, request shape, and policy
+// decision as first-class structured fields rather than embedding them inside
+// tool-argument text blobs.
+//
+// This makes it possible to answer questions like:
+//   - "Which sessions made calls to api.example.com?"
+//   - "How many egress calls were blocked in the last hour?"
+//   - "Did any agent call a non-allowlisted hostname?"
+//
+// without scraping free-text audit_events details columns.
+type NetworkEgressEvent struct {
+	// Timestamp is when the call was observed. Defaults to now if zero.
+	Timestamp time.Time `json:"timestamp"`
+
+	// SessionID correlates this event to a specific agent session.
+	// Empty when the session is not known (e.g. pre-session bootstrap calls).
+	SessionID string `json:"session_id,omitempty"`
+
+	// Hostname is the destination host (no port). Required.
+	Hostname string `json:"hostname"`
+
+	// URL is the full destination URL, truncated to 512 chars. Optional.
+	URL string `json:"url,omitempty"`
+
+	// HTTPMethod is the HTTP verb (GET, POST, …). Optional.
+	HTTPMethod string `json:"http_method,omitempty"`
+
+	// Protocol is "http" or "https". Optional.
+	Protocol string `json:"protocol,omitempty"`
+
+	// PolicyOutcome is a human-readable summary of the policy decision,
+	// e.g. "Allowed by pattern: *.example.com" or "Denied: not in allowlist".
+	PolicyOutcome string `json:"policy_outcome"`
+
+	// DecisionCode is a machine-readable outcome token, e.g.
+	// "NETWORK_ALLOW_PATTERN", "NETWORK_DENY_DEFAULT". Optional.
+	DecisionCode string `json:"decision_code,omitempty"`
+
+	// Blocked is true when the call was actively prevented by policy.
+	Blocked bool `json:"blocked"`
+
+	// Severity is INFO for allowed calls and HIGH for blocked calls.
+	// Defaults based on Blocked when empty.
+	Severity string `json:"severity,omitempty"`
+
+	// Details holds any additional context (e.g. the matching policy pattern).
+	Details string `json:"details,omitempty"`
+}
+
+// Validate returns an error if required fields are missing or invalid.
+func (e *NetworkEgressEvent) Validate() error {
+	if strings.TrimSpace(e.Hostname) == "" {
+		return fmt.Errorf("audit: network egress event: hostname is required")
+	}
+	if strings.TrimSpace(e.PolicyOutcome) == "" {
+		return fmt.Errorf("audit: network egress event: policy_outcome is required")
+	}
+	return nil
+}
+
+// effectiveSeverity returns the resolved severity, defaulting to HIGH for
+// blocked calls and INFO for allowed ones.
+func (e *NetworkEgressEvent) effectiveSeverity() string {
+	if e.Severity != "" {
+		return e.Severity
+	}
+	if e.Blocked {
+		return "HIGH"
+	}
+	return "INFO"
+}
+
+// toRow converts the event to the store's persisted shape.
+func (e *NetworkEgressEvent) toRow() NetworkEgressRow {
+	url := e.URL
+	if len(url) > 512 {
+		url = url[:512]
+	}
+	return NetworkEgressRow{
+		Timestamp:     e.Timestamp,
+		SessionID:     e.SessionID,
+		Hostname:      e.Hostname,
+		URL:           url,
+		HTTPMethod:    e.HTTPMethod,
+		Protocol:      e.Protocol,
+		PolicyOutcome: e.PolicyOutcome,
+		DecisionCode:  e.DecisionCode,
+		Blocked:       e.Blocked,
+		Severity:      e.effectiveSeverity(),
+		Details:       e.Details,
+	}
+}
+
+// LogNetworkEgress persists an outbound network call as a structured audit
+// row. For blocked calls it additionally:
+//   - writes a HIGH-severity entry to audit_events so the alert panel and
+//     /alerts endpoint surface it without a separate query;
+//   - forwards that alert to the Splunk HEC sink when configured;
+//   - emits an OTel alert counter.
+//
+// OTel audit-event counters are recorded for every call (allowed or blocked).
+func (l *Logger) LogNetworkEgress(ctx context.Context, e NetworkEgressEvent) error {
+	if err := e.Validate(); err != nil {
+		return err
+	}
+	if e.Timestamp.IsZero() {
+		e.Timestamp = time.Now().UTC()
+	}
+
+	row := e.toRow()
+	if err := l.store.InsertNetworkEgressEvent(row); err != nil {
+		if l.otel != nil {
+			l.otel.RecordAuditDBError(ctx, "insert_network_egress")
+		}
+		return err
+	}
+
+	// Record OTel audit-event counter for every egress observation.
+	if l.otel != nil {
+		l.otel.RecordAuditEvent(ctx, "network-egress", e.effectiveSeverity())
+	}
+
+	if !e.Blocked {
+		return nil
+	}
+
+	// Blocked call: raise an audit_events alert so the TUI and /alerts
+	// endpoint surface it without requiring a separate egress query.
+	alert := Event{
+		Timestamp: e.Timestamp,
+		Action:    "network-egress-blocked",
+		Target:    e.Hostname,
+		Details: fmt.Sprintf("url=%s method=%s decision=%s outcome=%s",
+			truncateStr(e.URL, 200), e.HTTPMethod, e.DecisionCode, e.PolicyOutcome),
+		Severity: "HIGH",
+	}
+	if err := l.store.LogEvent(alert); err != nil {
+		// Non-fatal: the primary egress row is already persisted.
+		fmt.Fprintf(os.Stderr, "[audit] network egress: alert event write failed: %v\n", err)
+	}
+
+	// Forward to Splunk HEC when configured.
+	l.forwardToSplunk(alert)
+
+	// Emit OTel alert counter.
+	if l.otel != nil {
+		l.otel.RecordAlert(ctx, "network-egress-blocked", "HIGH", "network-policy")
+	}
+
+	return nil
+}
+
+func truncateStr(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max]
+}

--- a/internal/audit/network_egress_test.go
+++ b/internal/audit/network_egress_test.go
@@ -1,0 +1,400 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package audit
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) (*Store, func()) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	store, err := NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Init(); err != nil {
+		t.Fatalf("Store.Init: %v", err)
+	}
+	return store, func() { store.Close() }
+}
+
+// --- NetworkEgressEvent.Validate ---
+
+func TestNetworkEgressEvent_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		evt     NetworkEgressEvent
+		wantErr bool
+	}{
+		{
+			name:    "valid allowed event",
+			evt:     NetworkEgressEvent{Hostname: "api.example.com", PolicyOutcome: "Allowed by pattern: *.example.com"},
+			wantErr: false,
+		},
+		{
+			name:    "valid blocked event",
+			evt:     NetworkEgressEvent{Hostname: "evil.io", PolicyOutcome: "Denied: not in allowlist", Blocked: true},
+			wantErr: false,
+		},
+		{
+			name:    "missing hostname",
+			evt:     NetworkEgressEvent{PolicyOutcome: "Allowed by default"},
+			wantErr: true,
+		},
+		{
+			name:    "missing policy outcome",
+			evt:     NetworkEgressEvent{Hostname: "api.example.com"},
+			wantErr: true,
+		},
+		{
+			name:    "whitespace hostname",
+			evt:     NetworkEgressEvent{Hostname: "   ", PolicyOutcome: "ok"},
+			wantErr: true,
+		},
+		{
+			name:    "whitespace policy outcome",
+			evt:     NetworkEgressEvent{Hostname: "api.example.com", PolicyOutcome: "  "},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.evt.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// --- effectiveSeverity ---
+
+func TestNetworkEgressEvent_effectiveSeverity(t *testing.T) {
+	tests := []struct {
+		name     string
+		evt      NetworkEgressEvent
+		wantSev  string
+	}{
+		{"explicit severity wins", NetworkEgressEvent{Severity: "CRITICAL"}, "CRITICAL"},
+		{"blocked defaults HIGH", NetworkEgressEvent{Blocked: true}, "HIGH"},
+		{"allowed defaults INFO", NetworkEgressEvent{Blocked: false}, "INFO"},
+		{"explicit on blocked wins", NetworkEgressEvent{Blocked: true, Severity: "MEDIUM"}, "MEDIUM"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.evt.effectiveSeverity(); got != tt.wantSev {
+				t.Errorf("effectiveSeverity() = %q, want %q", got, tt.wantSev)
+			}
+		})
+	}
+}
+
+// --- Store: insert / list / query ---
+
+func TestStore_InsertAndListNetworkEgressEvents(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	base := time.Now().UTC().Truncate(time.Second)
+
+	fixtures := []NetworkEgressRow{
+		{
+			Timestamp:     base,
+			Hostname:      "api.example.com",
+			URL:           "https://api.example.com/v1/data",
+			HTTPMethod:    "POST",
+			Protocol:      "https",
+			PolicyOutcome: "Allowed by pattern: *.example.com",
+			DecisionCode:  "NETWORK_ALLOW_PATTERN",
+			Blocked:       false,
+			Severity:      "INFO",
+		},
+		{
+			Timestamp:     base.Add(-time.Minute),
+			SessionID:     "sess-abc123",
+			Hostname:      "malicious.io",
+			URL:           "http://malicious.io/exfil",
+			HTTPMethod:    "GET",
+			Protocol:      "http",
+			PolicyOutcome: "Denied: hostname on deny list",
+			DecisionCode:  "NETWORK_DENY_PATTERN",
+			Blocked:       true,
+			Severity:      "HIGH",
+		},
+		{
+			Timestamp:     base.Add(-2 * time.Minute),
+			SessionID:     "sess-abc123",
+			Hostname:      "api.example.com",
+			PolicyOutcome: "Allowed by default policy",
+			DecisionCode:  "NETWORK_DEFAULT_ALLOW",
+			Severity:      "INFO",
+		},
+	}
+
+	for _, e := range fixtures {
+		if err := store.InsertNetworkEgressEvent(e); err != nil {
+			t.Fatalf("InsertNetworkEgressEvent: %v", err)
+		}
+	}
+
+	t.Run("list all newest first", func(t *testing.T) {
+		rows, err := store.ListNetworkEgressEvents(100, "")
+		if err != nil {
+			t.Fatalf("ListNetworkEgressEvents: %v", err)
+		}
+		if len(rows) != 3 {
+			t.Errorf("got %d rows, want 3", len(rows))
+		}
+		if rows[0].Hostname != "api.example.com" || rows[0].HTTPMethod != "POST" {
+			t.Errorf("unexpected first row: %+v", rows[0])
+		}
+	})
+
+	t.Run("filter by hostname", func(t *testing.T) {
+		rows, err := store.ListNetworkEgressEvents(100, "api.example.com")
+		if err != nil {
+			t.Fatalf("ListNetworkEgressEvents: %v", err)
+		}
+		if len(rows) != 2 {
+			t.Errorf("got %d rows, want 2", len(rows))
+		}
+		for _, r := range rows {
+			if r.Hostname != "api.example.com" {
+				t.Errorf("unexpected hostname %q in filtered result", r.Hostname)
+			}
+		}
+	})
+
+	t.Run("blocked flag round-trips", func(t *testing.T) {
+		rows, err := store.ListNetworkEgressEvents(100, "malicious.io")
+		if err != nil || len(rows) != 1 {
+			t.Fatalf("expected 1 row, got %d (err=%v)", len(rows), err)
+		}
+		if !rows[0].Blocked {
+			t.Error("expected Blocked=true")
+		}
+		if rows[0].SessionID != "sess-abc123" {
+			t.Errorf("session_id round-trip failed: got %q", rows[0].SessionID)
+		}
+	})
+
+	t.Run("limit is honoured", func(t *testing.T) {
+		rows, err := store.ListNetworkEgressEvents(2, "")
+		if err != nil || len(rows) != 2 {
+			t.Errorf("got %d rows with limit=2 (err=%v)", len(rows), err)
+		}
+	})
+
+	t.Run("count blocked", func(t *testing.T) {
+		n, err := store.CountBlockedEgress()
+		if err != nil {
+			t.Fatalf("CountBlockedEgress: %v", err)
+		}
+		if n != 1 {
+			t.Errorf("got %d blocked, want 1", n)
+		}
+	})
+}
+
+func TestStore_QueryNetworkEgressEvents(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	base := time.Now().UTC().Truncate(time.Second)
+	boolTrue := true
+	boolFalse := false
+
+	fixtures := []NetworkEgressRow{
+		{Timestamp: base, Hostname: "a.example.com", SessionID: "s1", PolicyOutcome: "ok", Blocked: false, Severity: "INFO"},
+		{Timestamp: base.Add(-time.Minute), Hostname: "b.example.com", SessionID: "s1", PolicyOutcome: "ok", Blocked: false, Severity: "INFO"},
+		{Timestamp: base.Add(-2 * time.Minute), Hostname: "evil.io", SessionID: "s2", PolicyOutcome: "denied", Blocked: true, Severity: "HIGH"},
+		{Timestamp: base.Add(-3 * time.Minute), Hostname: "a.example.com", SessionID: "s2", PolicyOutcome: "ok", Blocked: false, Severity: "INFO"},
+	}
+	for _, e := range fixtures {
+		if err := store.InsertNetworkEgressEvent(e); err != nil {
+			t.Fatalf("InsertNetworkEgressEvent: %v", err)
+		}
+	}
+
+	tests := []struct {
+		name      string
+		filter    NetworkEgressFilter
+		wantCount int
+	}{
+		{"no filter returns all", NetworkEgressFilter{}, 4},
+		{"hostname filter", NetworkEgressFilter{Hostname: "a.example.com"}, 2},
+		{"session filter", NetworkEgressFilter{SessionID: "s1"}, 2},
+		{"blocked=true filter", NetworkEgressFilter{Blocked: &boolTrue}, 1},
+		{"blocked=false filter", NetworkEgressFilter{Blocked: &boolFalse}, 3},
+		{"since filter excludes old", NetworkEgressFilter{Since: base.Add(-90 * time.Second)}, 2},
+		{"hostname+session", NetworkEgressFilter{Hostname: "a.example.com", SessionID: "s1"}, 1},
+		{"limit 1", NetworkEgressFilter{Limit: 1}, 1},
+		{"hostname+blocked=true returns empty", NetworkEgressFilter{Hostname: "a.example.com", Blocked: &boolTrue}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := store.QueryNetworkEgressEvents(tt.filter)
+			if err != nil {
+				t.Fatalf("QueryNetworkEgressEvents: %v", err)
+			}
+			if len(rows) != tt.wantCount {
+				t.Errorf("got %d rows, want %d", len(rows), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestStore_GetCounts_IncludesBlockedEgress(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	for _, blocked := range []bool{true, true, false} {
+		row := NetworkEgressRow{
+			Hostname:      "example.com",
+			PolicyOutcome: "test",
+			Blocked:       blocked,
+			Severity:      "INFO",
+		}
+		if blocked {
+			row.Severity = "HIGH"
+		}
+		if err := store.InsertNetworkEgressEvent(row); err != nil {
+			t.Fatalf("InsertNetworkEgressEvent: %v", err)
+		}
+	}
+
+	counts, err := store.GetCounts()
+	if err != nil {
+		t.Fatalf("GetCounts: %v", err)
+	}
+	if counts.BlockedEgressCalls != 2 {
+		t.Errorf("BlockedEgressCalls = %d, want 2", counts.BlockedEgressCalls)
+	}
+}
+
+// --- Logger ---
+
+func TestLogger_LogNetworkEgress(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+	logger := NewLogger(store)
+	ctx := context.Background()
+
+	t.Run("allowed call stored, no alert", func(t *testing.T) {
+		evt := NetworkEgressEvent{
+			Hostname:      "api.example.com",
+			URL:           "https://api.example.com/completions",
+			HTTPMethod:    "POST",
+			Protocol:      "https",
+			PolicyOutcome: "Allowed by pattern: *.example.com",
+			DecisionCode:  "NETWORK_ALLOW_PATTERN",
+		}
+		if err := logger.LogNetworkEgress(ctx, evt); err != nil {
+			t.Fatalf("LogNetworkEgress: %v", err)
+		}
+		rows, err := store.ListNetworkEgressEvents(10, "api.example.com")
+		if err != nil || len(rows) != 1 {
+			t.Fatalf("expected 1 egress row, got %d (err=%v)", len(rows), err)
+		}
+		if rows[0].Severity != "INFO" {
+			t.Errorf("severity = %q, want INFO", rows[0].Severity)
+		}
+		alerts, _ := store.ListAlerts(10)
+		for _, a := range alerts {
+			if a.Action == "network-egress-blocked" {
+				t.Error("unexpected blocked alert for allowed egress call")
+			}
+		}
+	})
+
+	t.Run("blocked call stored and raises alert", func(t *testing.T) {
+		evt := NetworkEgressEvent{
+			Hostname:      "exfil.bad",
+			URL:           "http://exfil.bad/upload",
+			HTTPMethod:    "PUT",
+			Protocol:      "http",
+			PolicyOutcome: "Denied: hostname on deny list",
+			DecisionCode:  "NETWORK_DENY_PATTERN",
+			Blocked:       true,
+		}
+		if err := logger.LogNetworkEgress(ctx, evt); err != nil {
+			t.Fatalf("LogNetworkEgress: %v", err)
+		}
+		rows, err := store.ListNetworkEgressEvents(10, "exfil.bad")
+		if err != nil || len(rows) != 1 {
+			t.Fatalf("expected 1 egress row, got %d (err=%v)", len(rows), err)
+		}
+		if rows[0].Severity != "HIGH" {
+			t.Errorf("severity = %q, want HIGH", rows[0].Severity)
+		}
+		alerts, _ := store.ListAlerts(10)
+		var found bool
+		for _, a := range alerts {
+			if a.Action == "network-egress-blocked" && a.Target == "exfil.bad" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected a network-egress-blocked alert in audit_events")
+		}
+	})
+
+	t.Run("validation error propagates", func(t *testing.T) {
+		err := logger.LogNetworkEgress(ctx, NetworkEgressEvent{Hostname: "", PolicyOutcome: "x"})
+		if err == nil {
+			t.Error("expected validation error for empty hostname")
+		}
+	})
+
+	t.Run("url truncated to 512 bytes", func(t *testing.T) {
+		long := "https://api.example.com/" + string(make([]byte, 600))
+		if err := logger.LogNetworkEgress(ctx, NetworkEgressEvent{
+			Hostname:      "api.example.com",
+			URL:           long,
+			PolicyOutcome: "Allowed",
+		}); err != nil {
+			t.Fatalf("LogNetworkEgress: %v", err)
+		}
+		rows, _ := store.QueryNetworkEgressEvents(NetworkEgressFilter{Hostname: "api.example.com"})
+		for _, r := range rows {
+			if len(r.URL) > 512 {
+				t.Errorf("URL not truncated: len=%d", len(r.URL))
+			}
+		}
+	})
+
+	t.Run("timestamp defaults to now when zero", func(t *testing.T) {
+		before := time.Now().UTC().Add(-time.Second)
+		if err := logger.LogNetworkEgress(ctx, NetworkEgressEvent{
+			Hostname:      "ts.example.com",
+			PolicyOutcome: "ok",
+		}); err != nil {
+			t.Fatalf("LogNetworkEgress: %v", err)
+		}
+		rows, _ := store.ListNetworkEgressEvents(1, "ts.example.com")
+		if len(rows) == 0 {
+			t.Fatal("expected 1 row")
+		}
+		if rows[0].Timestamp.Before(before) {
+			t.Errorf("timestamp %v is before expected floor %v", rows[0].Timestamp, before)
+		}
+	})
+}

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -144,12 +144,31 @@ func (s *Store) Init() error {
 		updated_at DATETIME NOT NULL
 	);
 
+	CREATE TABLE IF NOT EXISTS network_egress_events (
+		id TEXT PRIMARY KEY,
+		timestamp DATETIME NOT NULL,
+		session_id TEXT,
+		hostname TEXT NOT NULL,
+		url TEXT,
+		http_method TEXT,
+		protocol TEXT,
+		policy_outcome TEXT NOT NULL,
+		decision_code TEXT,
+		blocked INTEGER NOT NULL DEFAULT 0,
+		severity TEXT NOT NULL DEFAULT 'INFO',
+		details TEXT
+	);
+
 	CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_events(timestamp);
 	CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_events(action);
 	CREATE INDEX IF NOT EXISTS idx_scan_scanner ON scan_results(scanner);
 	CREATE INDEX IF NOT EXISTS idx_finding_severity ON findings(severity);
 	CREATE INDEX IF NOT EXISTS idx_finding_scan ON findings(scan_id);
 	CREATE UNIQUE INDEX IF NOT EXISTS idx_actions_type_name ON actions(target_type, target_name);
+	CREATE INDEX IF NOT EXISTS idx_egress_timestamp ON network_egress_events(timestamp);
+	CREATE INDEX IF NOT EXISTS idx_egress_hostname ON network_egress_events(hostname);
+	CREATE INDEX IF NOT EXISTS idx_egress_blocked ON network_egress_events(blocked);
+	CREATE INDEX IF NOT EXISTS idx_egress_session ON network_egress_events(session_id);
 	`
 
 	if _, err := s.db.Exec(schema); err != nil {
@@ -620,12 +639,13 @@ func (s *Store) ListFindingsByScan(scanID string) ([]FindingRow, error) {
 }
 
 type Counts struct {
-	BlockedSkills int
-	AllowedSkills int
-	BlockedMCPs   int
-	AllowedMCPs   int
-	Alerts        int
-	TotalScans    int
+	BlockedSkills      int
+	AllowedSkills      int
+	BlockedMCPs        int
+	AllowedMCPs        int
+	Alerts             int
+	TotalScans         int
+	BlockedEgressCalls int // total outbound network calls blocked by policy
 }
 
 func (s *Store) GetCounts() (Counts, error) {
@@ -640,6 +660,7 @@ func (s *Store) GetCounts() (Counts, error) {
 		{`SELECT COUNT(*) FROM actions WHERE target_type = 'mcp' AND json_extract(actions_json, '$.install') = 'allow'`, &c.AllowedMCPs},
 		{`SELECT COUNT(*) FROM audit_events WHERE severity IN ('CRITICAL','HIGH','MEDIUM','LOW')`, &c.Alerts},
 		{`SELECT COUNT(*) FROM scan_results`, &c.TotalScans},
+		{`SELECT COUNT(*) FROM network_egress_events WHERE blocked = 1`, &c.BlockedEgressCalls},
 	}
 	for _, q := range queries {
 		if err := s.db.QueryRow(q.sql).Scan(q.dest); err != nil {
@@ -647,6 +668,80 @@ func (s *Store) GetCounts() (Counts, error) {
 		}
 	}
 	return c, nil
+}
+
+// NetworkEgressFilter parameterises QueryNetworkEgressEvents.
+// Zero values mean "no filter". Limit defaults to 100 when zero.
+type NetworkEgressFilter struct {
+	Hostname  string    // exact match; empty = all hosts
+	SessionID string    // exact match; empty = all sessions
+	Since     time.Time // only events at or after this time; zero = all time
+	Blocked   *bool     // nil = all; &true = blocked only; &false = allowed only
+	Limit     int       // defaults to 100
+}
+
+// QueryNetworkEgressEvents returns egress events matching the filter, newest first.
+func (s *Store) QueryNetworkEgressEvents(f NetworkEgressFilter) ([]NetworkEgressRow, error) {
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+
+	query := `SELECT id, timestamp, session_id, hostname, url, http_method, protocol,
+	                 policy_outcome, decision_code, blocked, severity, details
+	          FROM network_egress_events WHERE 1=1`
+	var args []any
+
+	if f.Hostname != "" {
+		query += " AND hostname = ?"
+		args = append(args, f.Hostname)
+	}
+	if f.SessionID != "" {
+		query += " AND session_id = ?"
+		args = append(args, f.SessionID)
+	}
+	if !f.Since.IsZero() {
+		query += " AND timestamp >= ?"
+		args = append(args, f.Since.UTC().Format(time.RFC3339Nano))
+	}
+	if f.Blocked != nil {
+		blocked := 0
+		if *f.Blocked {
+			blocked = 1
+		}
+		query += " AND blocked = ?"
+		args = append(args, blocked)
+	}
+	query += " ORDER BY timestamp DESC LIMIT ?"
+	args = append(args, limit)
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("audit: query network egress events: %w", err)
+	}
+	defer rows.Close()
+
+	var events []NetworkEgressRow
+	for rows.Next() {
+		var e NetworkEgressRow
+		var sessionID, url, httpMethod, protocol, decisionCode, details sql.NullString
+		var blocked int
+		if err := rows.Scan(
+			&e.ID, &e.Timestamp, &sessionID, &e.Hostname, &url, &httpMethod, &protocol,
+			&e.PolicyOutcome, &decisionCode, &blocked, &e.Severity, &details,
+		); err != nil {
+			return nil, fmt.Errorf("audit: scan egress row: %w", err)
+		}
+		e.SessionID = sessionID.String
+		e.URL = url.String
+		e.HTTPMethod = httpMethod.String
+		e.Protocol = protocol.String
+		e.DecisionCode = decisionCode.String
+		e.Details = details.String
+		e.Blocked = blocked != 0
+		events = append(events, e)
+	}
+	return events, rows.Err()
 }
 
 type LatestScanInfo struct {
@@ -687,6 +782,117 @@ func (s *Store) LatestScansByScanner(scannerName string) ([]LatestScanInfo, erro
 		results = append(results, r)
 	}
 	return results, rows.Err()
+}
+
+// --- Network Egress Events ---
+
+// NetworkEgressRow is the persisted shape of a network_egress_events row.
+type NetworkEgressRow struct {
+	ID           string    `json:"id"`
+	Timestamp    time.Time `json:"timestamp"`
+	SessionID    string    `json:"session_id,omitempty"`
+	Hostname     string    `json:"hostname"`
+	URL          string    `json:"url,omitempty"`
+	HTTPMethod   string    `json:"http_method,omitempty"`
+	Protocol     string    `json:"protocol,omitempty"`
+	PolicyOutcome string   `json:"policy_outcome"`
+	DecisionCode string    `json:"decision_code,omitempty"`
+	Blocked      bool      `json:"blocked"`
+	Severity     string    `json:"severity"`
+	Details      string    `json:"details,omitempty"`
+}
+
+// InsertNetworkEgressEvent persists one outbound network call as a structured row.
+func (s *Store) InsertNetworkEgressEvent(e NetworkEgressRow) error {
+	if e.ID == "" {
+		e.ID = uuid.New().String()
+	}
+	if e.Timestamp.IsZero() {
+		e.Timestamp = time.Now().UTC()
+	}
+	if e.Severity == "" {
+		e.Severity = "INFO"
+	}
+	ts := e.Timestamp.Format(time.RFC3339Nano)
+	blocked := 0
+	if e.Blocked {
+		blocked = 1
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO network_egress_events
+		 (id, timestamp, session_id, hostname, url, http_method, protocol, policy_outcome, decision_code, blocked, severity, details)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		e.ID, ts,
+		nullStr(e.SessionID), e.Hostname, nullStr(e.URL), nullStr(e.HTTPMethod), nullStr(e.Protocol),
+		e.PolicyOutcome, nullStr(e.DecisionCode), blocked, e.Severity, nullStr(e.Details),
+	)
+	if err != nil {
+		return fmt.Errorf("audit: insert network egress event: %w", err)
+	}
+	return nil
+}
+
+// ListNetworkEgressEvents returns recent egress events. Optionally filter by
+// hostname prefix (empty string returns all). Results are newest-first.
+func (s *Store) ListNetworkEgressEvents(limit int, hostname string) ([]NetworkEgressRow, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if hostname == "" {
+		rows, err = s.db.Query(
+			`SELECT id, timestamp, session_id, hostname, url, http_method, protocol,
+			        policy_outcome, decision_code, blocked, severity, details
+			 FROM network_egress_events ORDER BY timestamp DESC LIMIT ?`, limit,
+		)
+	} else {
+		rows, err = s.db.Query(
+			`SELECT id, timestamp, session_id, hostname, url, http_method, protocol,
+			        policy_outcome, decision_code, blocked, severity, details
+			 FROM network_egress_events WHERE hostname = ?
+			 ORDER BY timestamp DESC LIMIT ?`, hostname, limit,
+		)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("audit: list network egress events: %w", err)
+	}
+	defer rows.Close()
+
+	var events []NetworkEgressRow
+	for rows.Next() {
+		var e NetworkEgressRow
+		var sessionID, url, httpMethod, protocol, decisionCode, details sql.NullString
+		var blocked int
+		if err := rows.Scan(
+			&e.ID, &e.Timestamp, &sessionID, &e.Hostname, &url, &httpMethod, &protocol,
+			&e.PolicyOutcome, &decisionCode, &blocked, &e.Severity, &details,
+		); err != nil {
+			return nil, fmt.Errorf("audit: scan egress row: %w", err)
+		}
+		e.SessionID = sessionID.String
+		e.URL = url.String
+		e.HTTPMethod = httpMethod.String
+		e.Protocol = protocol.String
+		e.DecisionCode = decisionCode.String
+		e.Details = details.String
+		e.Blocked = blocked != 0
+		events = append(events, e)
+	}
+	return events, rows.Err()
+}
+
+// CountBlockedEgress returns the total number of blocked egress events.
+func (s *Store) CountBlockedEgress() (int, error) {
+	var count int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM network_egress_events WHERE blocked = 1`).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("audit: count blocked egress: %w", err)
+	}
+	return count, nil
 }
 
 func (s *Store) Close() error {

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -113,6 +113,7 @@ func (a *APIServer) Run(ctx context.Context) error {
 	mux.HandleFunc("/v1/guardrail/config", a.handleGuardrailConfig)
 	mux.HandleFunc("/api/v1/inspect/tool", a.handleInspectTool)
 	mux.HandleFunc("/api/v1/scan/code", a.handleCodeScan)
+	mux.HandleFunc("/api/v1/network-egress", a.handleNetworkEgress)
 
 	handler := a.metricsMiddleware(csrfProtect(mux))
 	if a.scannerCfg != nil && a.scannerCfg.Gateway.Token != "" {
@@ -1720,4 +1721,106 @@ func (a *APIServer) handleCodeScan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	a.writeJSON(w, http.StatusOK, result)
+}
+
+// handleNetworkEgress serves GET /api/v1/network-egress and
+// POST /api/v1/network-egress.
+//
+// GET  — list structured outbound network call records from the audit DB.
+//
+//	Query params:
+//	  limit=N    (default 50, max 500)
+//	  hostname=H (filter to exact hostname)
+//
+// POST — ingest a single egress event from an external observer (e.g. a
+//
+//	runtime hook running inside the agent process) so that it is
+//	persisted alongside tool-lifecycle events.
+func (a *APIServer) handleNetworkEgress(w http.ResponseWriter, r *http.Request) {
+	if a.store == nil {
+		a.writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "audit store not configured"})
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		a.handleNetworkEgressList(w, r)
+	case http.MethodPost:
+		a.handleNetworkEgressIngest(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (a *APIServer) handleNetworkEgressList(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	limit := 50
+	if raw := q.Get("limit"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed <= 0 || parsed > 500 {
+			a.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "limit must be 1–500"})
+			return
+		}
+		limit = parsed
+	}
+
+	f := audit.NetworkEgressFilter{
+		Hostname:  q.Get("hostname"),
+		SessionID: q.Get("session_id"),
+		Limit:     limit,
+	}
+
+	// ?blocked=true|false — optional boolean filter
+	if raw := q.Get("blocked"); raw != "" {
+		b := raw == "true" || raw == "1"
+		f.Blocked = &b
+	}
+
+	// ?since=<RFC3339> — optional time lower-bound filter
+	if raw := q.Get("since"); raw != "" {
+		t, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			a.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "since must be RFC3339 (e.g. 2026-01-02T15:04:05Z)"})
+			return
+		}
+		f.Since = t
+	}
+
+	events, err := a.store.QueryNetworkEgressEvents(f)
+	if err != nil {
+		a.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	type response struct {
+		Events []audit.NetworkEgressRow `json:"events"`
+		Count  int                      `json:"count"`
+	}
+	if events == nil {
+		events = []audit.NetworkEgressRow{}
+	}
+	a.writeJSON(w, http.StatusOK, response{Events: events, Count: len(events)})
+}
+
+func (a *APIServer) handleNetworkEgressIngest(w http.ResponseWriter, r *http.Request) {
+	var evt audit.NetworkEgressEvent
+	if err := json.NewDecoder(r.Body).Decode(&evt); err != nil {
+		a.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+		return
+	}
+	if err := evt.Validate(); err != nil {
+		a.writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	if a.logger == nil {
+		a.writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "audit logger not configured"})
+		return
+	}
+	if err := a.logger.LogNetworkEgress(r.Context(), evt); err != nil {
+		a.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	a.writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }

--- a/schemas/network-egress-event.json
+++ b/schemas/network-egress-event.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/cisco-ai-defense/defenseclaw/schemas/network-egress-event.json",
+  "title": "NetworkEgressEvent",
+  "description": "A single outbound network call observed by the agent runtime, with policy decision fields stored as first-class structured data.",
+  "type": "object",
+  "required": ["hostname", "policy_outcome"],
+  "properties": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the call was observed (RFC3339). Defaults to the ingestion time when omitted."
+    },
+    "session_id": {
+      "type": "string",
+      "description": "Agent session identifier. Correlates this event with tool_call/tool_result rows for the same session."
+    },
+    "hostname": {
+      "type": "string",
+      "description": "Destination hostname without port (e.g. 'api.example.com').",
+      "minLength": 1
+    },
+    "url": {
+      "type": "string",
+      "description": "Full destination URL. Stored at most 512 characters.",
+      "maxLength": 512
+    },
+    "http_method": {
+      "type": "string",
+      "description": "HTTP verb (GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS).",
+      "enum": ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
+    },
+    "protocol": {
+      "type": "string",
+      "description": "Transport protocol.",
+      "enum": ["http", "https"]
+    },
+    "policy_outcome": {
+      "type": "string",
+      "description": "Human-readable summary of the policy decision.",
+      "minLength": 1
+    },
+    "decision_code": {
+      "type": "string",
+      "description": "Machine-readable outcome token for programmatic filtering.",
+      "examples": [
+        "NETWORK_ALLOW_PATTERN",
+        "NETWORK_DENY_PATTERN",
+        "NETWORK_DEFAULT_ALLOW",
+        "NETWORK_DENY_DEFAULT"
+      ]
+    },
+    "blocked": {
+      "type": "boolean",
+      "description": "true when the call was actively prevented by policy."
+    },
+    "severity": {
+      "type": "string",
+      "description": "Event severity. Defaults to HIGH for blocked calls and INFO for allowed calls.",
+      "enum": ["INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL"]
+    },
+    "details": {
+      "type": "string",
+      "description": "Additional context such as the matched policy pattern."
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Context

DefenseClaw audits tool call lifecycle, skill and MCP admission, and shell command approvals well. One gap: outbound network calls made by the agent during a session are only visible as text embedded inside tool-argument blobs in the session JSONL. There is no dedicated, queryable row in the audit database for each egress event, which makes it difficult to answer basic questions like which hosts a session contacted or how many calls were blocked by policy.

This PR adds that missing layer.

## Changes

### internal/audit/store.go

Added a `network_egress_events` table with the following columns: `id`, `timestamp`, `session_id`, `hostname`, `url`, `http_method`, `protocol`, `policy_outcome`, `decision_code`, `blocked`, `severity`, `details`. Indexes cover `timestamp`, `hostname`, `blocked`, and `session_id` to support the common query patterns.

New store methods:

- `InsertNetworkEgressEvent` — writes one row.
- `ListNetworkEgressEvents(limit, hostname)` — simple list kept for backward compatibility.
- `QueryNetworkEgressEvents(NetworkEgressFilter)` — composable filter supporting `hostname`, `session_id`, `since` (time lower bound), and `blocked` (bool). Arguments are passed as positional parameters; no string interpolation.
- `CountBlockedEgress` — returns the total blocked call count.
- `Counts.BlockedEgressCalls` — added to the existing `GetCounts` struct so dashboard panels can include blocked egress in a single query.

### internal/audit/network_egress.go (new)

Defines `NetworkEgressEvent` with a `Validate()` method (hostname and policy_outcome are required). The `Logger.LogNetworkEgress` method is the single write path:

- Persists the structured egress row.
- Records an OTel audit-event counter for every call.
- For blocked calls, additionally writes a HIGH-severity entry to `audit_events` so it surfaces in the TUI alert panel and the `/alerts` endpoint without a separate query, forwards that alert to the Splunk HEC sink when configured, and emits an OTel alert counter.
- URL is capped at 512 bytes before storage.
- Timestamp defaults to the current UTC time when the caller leaves it zero.

### internal/gateway/api.go

Two new sub-handlers registered at `/api/v1/network-egress`:

`GET /api/v1/network-egress` accepts the following query parameters: `limit` (1-500, default 50), `hostname`, `session_id`, `blocked` (true or false), and `since` (RFC3339 timestamp). Returns a JSON object with an `events` array and a `count` field.

`POST /api/v1/network-egress` accepts a JSON body matching `NetworkEgressEvent`, validates it, and delegates to `Logger.LogNetworkEgress`. Intended for use by external observers such as a runtime hook preloaded into the agent process.

Both methods return a 503 when the store or logger is not configured rather than panicking.

### schemas/network-egress-event.json (new)

JSON Schema (draft-07) documenting the wire format for `NetworkEgressEvent`. Covers all fields, enumerates valid `http_method` and `protocol` values, and sets `additionalProperties: false`.

### internal/audit/network_egress_test.go (new)

Table-driven tests covering:

- `Validate` — required fields, whitespace trimming
- `effectiveSeverity` — explicit override, blocked default, allowed default
- `InsertNetworkEgressEvent` / `ListNetworkEgressEvents` — field round-trips, hostname filter, limit, blocked flag, session_id
- `QueryNetworkEgressEvents` — nine filter combinations including composite filters
- `GetCounts.BlockedEgressCalls` — verifies the new field is populated
- `Logger.LogNetworkEgress` — allowed path produces no alert, blocked path writes alert and audit_events entry, validation propagates, URL is truncated, timestamp defaults to now

## Test results

```
go build ./...            clean
go vet ./internal/...     clean
go test ./internal/...    all packages pass
```

## Notes

The `POST /api/v1/network-egress` endpoint is designed to receive events from a runtime hook running inside the agent process. That hook intercepts `http.request`, `https.request`, and `global.fetch` calls at the Node.js layer, checks each destination against the policy, and can forward structured egress records to the sidecar over localhost. The sidecar then persists them alongside the tool lifecycle events it already records, giving a unified audit view in `audit.db`.

No secrets, credentials, or internal identifiers appear in this diff. All test fixtures use generic hostnames.