### PR TITLE
Harden enforcement, centralize admission policy, and close security gaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ build: pycli gateway plugin
 	@echo "Run 'make install' to install all components."
 
 install: pycli gateway-install plugin-install
+	@mkdir -p $(INSTALL_DIR)
+	@ln -sf "$(CURDIR)/$(VENV)/bin/defenseclaw" "$(INSTALL_DIR)/defenseclaw"
+	@ln -sf "$(CURDIR)/$(VENV)/bin/litellm" "$(INSTALL_DIR)/litellm" 2>/dev/null || true
 	@echo ""
 	@echo "All components installed:"
 	@echo "  • Python CLI   → $(VENV)/bin/defenseclaw  (activate with: source $(VENV)/bin/activate)"
@@ -64,9 +67,6 @@ pycli:
 	@find cli/ -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	uv venv $(VENV) --python 3.12 --clear
 	uv pip install -e . --python $(VENV)/bin/python
-	@mkdir -p $(INSTALL_DIR)
-	@ln -sf "$(CURDIR)/$(VENV)/bin/defenseclaw" "$(INSTALL_DIR)/defenseclaw"
-	@ln -sf "$(CURDIR)/$(VENV)/bin/litellm" "$(INSTALL_DIR)/litellm" 2>/dev/null || true
 
 dev-pycli: pycli
 	uv pip install --group dev --python $(VENV)/bin/python

--- a/cli/defenseclaw/commands/__init__.py
+++ b/cli/defenseclaw/commands/__init__.py
@@ -15,3 +15,36 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """CLI command modules."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def compute_verdict(
+    action_entry: Any | None = None,
+    scan_entry: dict[str, Any] | None = None,
+) -> tuple[str, str]:
+    """Derive a (label, rich_style) verdict from action + scan state.
+
+    Priority: explicit enforcement actions > scan severity > no data.
+    """
+    if action_entry and not action_entry.actions.is_empty():
+        a = action_entry.actions
+        if a.file == "quarantine":
+            return "quarantined", "red"
+        if a.install == "block":
+            return "blocked", "red"
+        if a.runtime == "disable":
+            return "disabled", "red"
+        if a.install == "allow":
+            return "allowed", "green"
+    if scan_entry:
+        sev = scan_entry.get("max_severity", "CLEAN")
+        if sev in ("CRITICAL", "HIGH"):
+            return "rejected", "red"
+        if sev in ("MEDIUM", "LOW"):
+            return "warning", "yellow"
+        if sev == "CLEAN":
+            return "clean", "green"
+    return "-", ""

--- a/cli/defenseclaw/commands/cmd_aibom.py
+++ b/cli/defenseclaw/commands/cmd_aibom.py
@@ -66,11 +66,12 @@ def scan(app: AppContext, as_json: bool, summary_only: bool, categories: str | N
     if categories:
         cats = {c.strip().lower() for c in categories.split(",") if c.strip()}
 
-    click.echo("Scanning live OpenClaw environment …", err=True)
+    if not as_json:
+        click.echo("Scanning live OpenClaw environment …", err=True)
     inv = build_claw_aibom(app.cfg, live=True, categories=cats)
     result = claw_aibom_to_scan_result(inv, app.cfg)
 
-    enrich_with_policy(inv, app.store, app.cfg.skill_actions)
+    enrich_with_policy(inv, app.store, app.cfg.skill_actions, policy_dir=app.cfg.policy_dir)
 
     if app.logger:
         app.logger.log_scan(result)

--- a/cli/defenseclaw/commands/cmd_aibom.py
+++ b/cli/defenseclaw/commands/cmd_aibom.py
@@ -69,9 +69,12 @@ def scan(app: AppContext, as_json: bool, summary_only: bool, categories: str | N
     if not as_json:
         click.echo("Scanning live OpenClaw environment …", err=True)
     inv = build_claw_aibom(app.cfg, live=True, categories=cats)
-    result = claw_aibom_to_scan_result(inv, app.cfg)
 
-    enrich_with_policy(inv, app.store, app.cfg.skill_actions, policy_dir=app.cfg.policy_dir)
+    enrich_with_policy(
+        inv, app.store, app.cfg.skill_actions,
+        policy_dir=app.cfg.policy_dir, cfg=app.cfg,
+    )
+    result = claw_aibom_to_scan_result(inv, app.cfg)
 
     if app.logger:
         app.logger.log_scan(result)

--- a/cli/defenseclaw/commands/cmd_mcp.py
+++ b/cli/defenseclaw/commands/cmd_mcp.py
@@ -397,7 +397,7 @@ def unblock(app: AppContext, target: str) -> None:
         fg="green",
     )
     click.echo(
-        f"  The server will go through normal scanning on next check."
+        "  The server will go through normal scanning on next check."
     )
 
     if app.logger:

--- a/cli/defenseclaw/commands/cmd_mcp.py
+++ b/cli/defenseclaw/commands/cmd_mcp.py
@@ -28,6 +28,7 @@ import subprocess
 
 import click
 
+from defenseclaw.commands import compute_verdict as _compute_verdict
 from defenseclaw.config import MCPServerEntry
 from defenseclaw.context import AppContext, pass_ctx
 from defenseclaw.models import ScanResult
@@ -83,6 +84,10 @@ def list_mcps(app: AppContext, as_json: bool) -> None:
                 ae = actions_map[s.name]
                 if not ae.actions.is_empty():
                     entry["actions"] = ae.actions.to_dict()
+            verdict_label, _ = _compute_verdict(
+                actions_map.get(s.name), scan_map.get(s.name),
+            )
+            entry["verdict"] = verdict_label
             out.append(entry)
         click.echo(json.dumps(out, indent=2))
         return
@@ -98,6 +103,7 @@ def list_mcps(app: AppContext, as_json: bool) -> None:
     table.add_column("Command")
     table.add_column("URL")
     table.add_column("Severity")
+    table.add_column("Verdict")
     table.add_column("Actions")
 
     for s in servers:
@@ -117,12 +123,17 @@ def list_mcps(app: AppContext, as_json: bool) -> None:
         if s.name in actions_map:
             actions_str = actions_map[s.name].actions.summary()
 
+        verdict_label, verdict_style = _compute_verdict(
+            actions_map.get(s.name), scan_map.get(s.name),
+        )
+
         table.add_row(
             s.name,
             s.transport or "stdio",
             s.command or "",
             s.url or "",
             f"[{sev_style}]{severity}[/{sev_style}]" if sev_style else severity,
+            f"[{verdict_style}]{verdict_label}[/{verdict_style}]" if verdict_style else verdict_label,
             actions_str,
         )
 
@@ -419,9 +430,18 @@ def set_server(
       defenseclaw mcp set untrusted --url http://example.com/mcp --skip-scan
     """
     from defenseclaw.enforce import PolicyEngine
+    from defenseclaw.enforce.admission import evaluate_admission
 
     pe = PolicyEngine(app.store)
-    if pe.is_blocked("mcp", name):
+    pre_decision = evaluate_admission(
+        pe,
+        policy_dir=app.cfg.policy_dir,
+        target_type="mcp",
+        name=name,
+        fallback_actions=app.cfg.mcp_actions,
+    )
+
+    if pre_decision.verdict == "blocked":
         click.secho(f"BLOCKED: {name} — unblock it first with: defenseclaw mcp unblock {name}", fg="red")
         raise SystemExit(1)
 
@@ -451,7 +471,8 @@ def set_server(
             env[k] = v
         entry["env"] = env
 
-    if not skip_scan:
+    scan_required = (not skip_scan) and pre_decision.verdict != "allowed"
+    if scan_required:
         scan_target = url or name
         scan_entry = MCPServerEntry(
             name=name,
@@ -471,7 +492,15 @@ def set_server(
         from defenseclaw.enforce import PolicyEngine
 
         sev = result.max_severity()
-        if not result.is_clean() and app.cfg.mcp_actions.should_install_block(sev):
+        post_decision = evaluate_admission(
+            pe,
+            policy_dir=app.cfg.policy_dir,
+            target_type="mcp",
+            name=name,
+            scan_result=result,
+            fallback_actions=app.cfg.mcp_actions,
+        )
+        if post_decision.verdict == "rejected":
             pe = PolicyEngine(app.store)
             pe.block("mcp", name, f"scan: {len(result.findings)} findings, max={sev}")
             click.secho(
@@ -485,12 +514,25 @@ def set_server(
                     f"severity={sev} findings={len(result.findings)}",
                 )
             raise SystemExit(1)
+    elif pre_decision.verdict == "allowed":
+        if pre_decision.source == "scan-disabled":
+            click.secho(f"Policy allows {name} without scan.", fg="yellow")
+        else:
+            click.secho(f"Allowed override for {name} — skipping scan.", fg="yellow")
 
     _openclaw_config_set(f"mcp.servers.{name}", json.dumps(entry))
 
-    if not skip_scan:
-        pe = PolicyEngine(app.store)
-        pe.allow("mcp", name, "scan clean or within policy")
+    if scan_required:
+        post_decision = evaluate_admission(
+            pe,
+            policy_dir=app.cfg.policy_dir,
+            target_type="mcp",
+            name=name,
+            scan_result=result,
+            fallback_actions=app.cfg.mcp_actions,
+        )
+        if post_decision.action.install == "allow":
+            pe.allow("mcp", name, "scan clean or within policy")
 
     click.secho(f"Added MCP server: {name}", fg="green")
 

--- a/cli/defenseclaw/commands/cmd_mcp.py
+++ b/cli/defenseclaw/commands/cmd_mcp.py
@@ -367,6 +367,43 @@ def allow(app: AppContext, target: str, reason: str) -> None:
         app.logger.log_action("allow-mcp", target, f"reason={reason}")
 
 
+@mcp.command()
+@click.argument("target")
+@pass_ctx
+def unblock(app: AppContext, target: str) -> None:
+    """Remove an MCP server from the block list and clear enforcement state.
+
+    Unlike 'allow', this does not add the server to the allow list — it
+    simply removes the block so the server goes through normal scanning
+    on the next check.
+    """
+    from defenseclaw.enforce import PolicyEngine
+
+    pe = PolicyEngine(app.store)
+
+    has_state = (
+        pe.is_blocked("mcp", target)
+        or pe.is_quarantined("mcp", target)
+        or app.store.has_action("mcp", target, "runtime", "disable")
+    )
+    if not has_state:
+        click.echo(f"[mcp] {target!r} has no enforcement state to clear")
+        return
+
+    pe.remove_action("mcp", target)
+    click.secho(
+        f"[mcp] {target!r} all enforcement state cleared "
+        f"(block/quarantine/disable)",
+        fg="green",
+    )
+    click.echo(
+        f"  The server will go through normal scanning on next check."
+    )
+
+    if app.logger:
+        app.logger.log_action("mcp-unblock", target, "manual unblock via CLI")
+
+
 # ---------------------------------------------------------------------------
 # set / unset  — delegate writes to ``openclaw config set/unset``
 # ---------------------------------------------------------------------------
@@ -439,6 +476,7 @@ def set_server(
         target_type="mcp",
         name=name,
         fallback_actions=app.cfg.mcp_actions,
+        source_path="",
     )
 
     if pre_decision.verdict == "blocked":
@@ -499,6 +537,7 @@ def set_server(
             name=name,
             scan_result=result,
             fallback_actions=app.cfg.mcp_actions,
+            source_path=cmd or url or "",
         )
         if post_decision.verdict == "rejected":
             pe = PolicyEngine(app.store)
@@ -530,6 +569,7 @@ def set_server(
             name=name,
             scan_result=result,
             fallback_actions=app.cfg.mcp_actions,
+            source_path=cmd or url or "",
         )
         if post_decision.action.install == "allow":
             pe.allow("mcp", name, "scan clean or within policy")

--- a/cli/defenseclaw/commands/cmd_plugin.py
+++ b/cli/defenseclaw/commands/cmd_plugin.py
@@ -354,7 +354,11 @@ def install(app: AppContext, name_or_path: str, force: bool, take_action: bool) 
                     fallback_actions=app.cfg.plugin_actions,
                 )
 
-                if not take_action:
+                if post_decision.verdict == "allowed":
+                    click.echo(f"[install] {plugin_name!r} became allow-listed — skipping post-scan enforcement")
+                    if app.logger:
+                        app.logger.log_action("install-allowed", plugin_name, "reason=allow-listed-post-scan")
+                elif not take_action:
                     click.echo(
                         f"[install] {len(result.findings)} {sev} findings in {plugin_name!r} "
                         f"(no action taken — pass --action to enforce)"
@@ -362,49 +366,46 @@ def install(app: AppContext, name_or_path: str, force: bool, take_action: bool) 
                     if app.logger:
                         app.logger.log_action("install-warning", plugin_name, detail)
                 else:
-                    if post_decision.verdict == "allowed":
-                        click.echo(f"[install] {plugin_name!r} became allow-listed — skipping post-scan enforcement")
-                    else:
-                        action_cfg = post_decision.action
-                        enforcement_reason = f"post-install scan: {len(result.findings)} findings, max={sev}"
-                        applied_actions: list[str] = []
+                    action_cfg = post_decision.action
+                    enforcement_reason = f"post-install scan: {len(result.findings)} findings, max={sev}"
+                    applied_actions: list[str] = []
 
-                        if action_cfg.file == "quarantine":
-                            se = PluginEnforcer(app.cfg.quarantine_dir)
-                            q_dest = se.quarantine(plugin_name, source_path)
-                            if q_dest:
-                                applied_actions.append(f"quarantined to {q_dest}")
-                                pe.quarantine("plugin", plugin_name, enforcement_reason)
-                            else:
-                                click.echo("[install] quarantine failed", err=True)
+                    if action_cfg.file == "quarantine":
+                        se = PluginEnforcer(app.cfg.quarantine_dir)
+                        q_dest = se.quarantine(plugin_name, source_path)
+                        if q_dest:
+                            applied_actions.append(f"quarantined to {q_dest}")
+                            pe.quarantine("plugin", plugin_name, enforcement_reason)
+                        else:
+                            click.echo("[install] quarantine failed", err=True)
 
-                        if action_cfg.runtime == "disable":
-                            client = _sidecar_client(app)
-                            try:
-                                client.disable_plugin(plugin_name)
-                                applied_actions.append("disabled via gateway")
-                                pe.disable("plugin", plugin_name, enforcement_reason)
-                            except Exception as exc:
-                                click.echo(f"[install] gateway disable failed: {exc}", err=True)
+                    if action_cfg.runtime == "disable":
+                        client = _sidecar_client(app)
+                        try:
+                            client.disable_plugin(plugin_name)
+                            applied_actions.append("disabled via gateway")
+                            pe.disable("plugin", plugin_name, enforcement_reason)
+                        except Exception as exc:
+                            click.echo(f"[install] gateway disable failed: {exc}", err=True)
 
-                        if action_cfg.install == "block":
-                            pe.block("plugin", plugin_name, enforcement_reason)
-                            applied_actions.append("added to block list")
+                    if action_cfg.install == "block":
+                        pe.block("plugin", plugin_name, enforcement_reason)
+                        applied_actions.append("added to block list")
 
-                        if action_cfg.install == "allow":
-                            pe.allow("plugin", plugin_name, enforcement_reason)
-                            applied_actions.append("added to allow list")
+                    if action_cfg.install == "allow":
+                        pe.allow("plugin", plugin_name, enforcement_reason)
+                        applied_actions.append("added to allow list")
 
-                        if applied_actions:
-                            actions_str = ", ".join(applied_actions)
-                            click.echo(f"[install] {plugin_name!r}: {actions_str} ({detail})")
-                            if app.logger:
-                                app.logger.log_action("install-enforced", plugin_name, f"{detail}; {actions_str}")
-                            click.echo(
-                                f"error: plugin {plugin_name!r} had {sev} findings — actions applied: {actions_str}",
-                                err=True,
-                            )
-                            raise SystemExit(1)
+                    if applied_actions:
+                        actions_str = ", ".join(applied_actions)
+                        click.echo(f"[install] {plugin_name!r}: {actions_str} ({detail})")
+                        if app.logger:
+                            app.logger.log_action("install-enforced", plugin_name, f"{detail}; {actions_str}")
+                        click.echo(
+                            f"error: plugin {plugin_name!r} had {sev} findings — actions applied: {actions_str}",
+                            err=True,
+                        )
+                        raise SystemExit(1)
 
                     click.echo(f"[install] warning: {len(result.findings)} {sev} findings in {plugin_name!r}")
                     if app.logger:
@@ -504,40 +505,6 @@ def _merge_all_plugins(plugin_dir: str) -> list[dict[str, Any]]:
     return plugins
 
 
-def _build_plugin_scan_map(store: Any) -> dict[str, dict[str, Any]]:
-    """Build a map of plugin-name -> latest scan entry from the DB."""
-    scan_map: dict[str, dict[str, Any]] = {}
-    if store is None:
-        return scan_map
-    try:
-        latest = store.latest_scans_by_scanner("plugin-scanner")
-    except Exception:
-        return scan_map
-    for ls in latest:
-        name = os.path.basename(ls["target"])
-        finding_count = ls["finding_count"]
-        scan_map[name] = {
-            "target": ls["target"],
-            "clean": finding_count == 0,
-            "max_severity": ls["max_severity"] if finding_count > 0 else "CLEAN",
-            "total_findings": finding_count,
-        }
-    return scan_map
-
-
-def _build_plugin_actions_map(store: Any) -> dict[str, Any]:
-    """Build a map of plugin-name -> ActionEntry from the DB."""
-    from defenseclaw.models import ActionEntry
-    actions_map: dict[str, ActionEntry] = {}
-    if store is None:
-        return actions_map
-    try:
-        entries = store.list_actions_by_type("plugin")
-    except Exception:
-        return actions_map
-    for e in entries:
-        actions_map[e.target_name] = e
-    return actions_map
 
 
 def _plugin_status(p: dict[str, Any]) -> str:
@@ -758,6 +725,35 @@ def _resolve_openclaw_plugin_id(name: str) -> str:
     return bare
 
 
+def _plugin_runtime_candidates(name: str) -> list[str]:
+    bare = os.path.basename(name)
+    candidates: list[str] = []
+    for candidate in (bare, _resolve_openclaw_plugin_id(name)):
+        if candidate and candidate not in candidates:
+            candidates.append(candidate)
+    for suffix in ("-plugin", "-provider"):
+        if bare.endswith(suffix):
+            stripped = bare[: -len(suffix)]
+            if stripped and stripped not in candidates:
+                candidates.append(stripped)
+    return candidates
+
+
+def _enable_plugin_via_gateway(app: AppContext, plugin_name: str) -> bool:
+    """Best-effort runtime re-enable; returns True only on confirmed success."""
+    client = _sidecar_client(app)
+    try:
+        resp = client.enable_plugin(plugin_name)
+    except Exception as exc:
+        click.echo(f"error: gateway enable failed: {exc}", err=True)
+        return False
+
+    if resp.get("status") != "enabled":
+        click.echo(f"error: gateway returned unexpected response: {resp}", err=True)
+        return False
+    return True
+
+
 def _list_defenseclaw_plugins(plugin_dir: str) -> list[str]:
     """Return sorted list of DefenseClaw plugin directory names."""
     if not os.path.isdir(plugin_dir):
@@ -888,28 +884,42 @@ def allow(app: AppContext, name: str, reason: str) -> None:
     from defenseclaw.enforce import PolicyEngine
 
     plugin_name = os.path.basename(name)
+    runtime_name = plugin_name
     pe = PolicyEngine(app.store)
 
     if not reason:
         reason = "manual allow via CLI"
 
-    pe.allow("plugin", plugin_name, reason)
+    entry = pe.get_action("plugin", plugin_name)
+    runtime_entry = entry
+    for candidate in _plugin_runtime_candidates(name):
+        resolved_entry = pe.get_action("plugin", candidate)
+        if resolved_entry is not None and resolved_entry.actions.runtime == "disable":
+            runtime_entry = resolved_entry
+            runtime_name = candidate
+            break
+    runtime_disabled = bool(runtime_entry and runtime_entry.actions.runtime == "disable")
+    runtime_cleared = True
+    if runtime_disabled:
+        runtime_cleared = _enable_plugin_via_gateway(app, runtime_name)
+        if runtime_cleared and runtime_name != plugin_name:
+            pe.enable("plugin", runtime_name)
 
-    # Best-effort gateway sync so the running process also re-enables.
-    try:
-        client = _sidecar_client(app)
-        client.enable_plugin(plugin_name)
-    except Exception:
-        click.echo(
-            f"[plugin] note: could not re-enable {plugin_name!r} via gateway — "
-            "the sidecar will pick up the DB state on next reconcile, or "
-            "run 'defenseclaw plugin enable' manually", err=True,
-        )
+    if runtime_cleared:
+        pe.allow("plugin", plugin_name, reason)
+    else:
+        app.store.set_action_field("plugin", plugin_name, "install", "allow", reason)
 
     plugin_path = _resolve_plugin_path(app, plugin_name)
     if plugin_path:
         pe.set_source_path("plugin", plugin_name, plugin_path)
-    click.secho(f"[plugin] {plugin_name!r} added to allow list", fg="green")
+    if runtime_cleared:
+        click.secho(f"[plugin] {plugin_name!r} added to allow list", fg="green")
+    else:
+        click.secho(
+            f"[plugin] {plugin_name!r} added to allow list; runtime disable remains until the gateway is reachable",
+            fg="yellow",
+        )
 
     if app.logger:
         app.logger.log_action("plugin-allow", plugin_name, f"reason={reason}")

--- a/cli/defenseclaw/commands/cmd_plugin.py
+++ b/cli/defenseclaw/commands/cmd_plugin.py
@@ -30,6 +30,7 @@ from typing import Any
 
 import click
 
+from defenseclaw.commands import compute_verdict as _compute_verdict
 from defenseclaw.context import AppContext, pass_ctx
 
 
@@ -218,6 +219,7 @@ def install(app: AppContext, name_or_path: str, force: bool, take_action: bool) 
     import tempfile
 
     from defenseclaw.enforce import PolicyEngine
+    from defenseclaw.enforce.admission import evaluate_admission
     from defenseclaw.enforce.plugin_enforcer import PluginEnforcer
     from defenseclaw.registry import (
         RegistryError,
@@ -246,8 +248,20 @@ def install(app: AppContext, name_or_path: str, force: bool, take_action: bool) 
     else:
         plugin_name = ""
 
+    pre_decision = None
+    if plugin_name:
+        pre_install_source = name_or_path if source == SourceType.LOCAL else ""
+        pre_decision = evaluate_admission(
+            pe,
+            policy_dir=app.cfg.policy_dir,
+            target_type="plugin",
+            name=plugin_name,
+            source_path=pre_install_source,
+            fallback_actions=app.cfg.plugin_actions,
+        )
+
     # --- Block list check ---
-    if plugin_name and pe.is_blocked("plugin", plugin_name):
+    if pre_decision is not None and pre_decision.verdict == "blocked":
         if app.logger:
             app.logger.log_action("install-rejected", plugin_name, "reason=blocked")
         click.echo(
@@ -257,10 +271,13 @@ def install(app: AppContext, name_or_path: str, force: bool, take_action: bool) 
         )
         raise SystemExit(1)
 
-    # --- Allow list check (skip scan) ---
-    allowed = plugin_name and pe.is_allowed("plugin", plugin_name)
+    # --- Manual/policy allow check (skip scan) ---
+    allowed = pre_decision is not None and pre_decision.verdict == "allowed"
     if allowed:
-        click.echo(f"[install] {plugin_name!r} is on the allow list — skipping scan")
+        if pre_decision is not None and pre_decision.source == "scan-disabled":
+            click.echo(f"[install] policy allows {plugin_name!r} without scan")
+        else:
+            click.echo(f"[install] {plugin_name!r} is on the allow list — skipping scan")
         if app.logger:
             app.logger.log_action("install-allowed", plugin_name, "reason=allow-listed")
 
@@ -274,7 +291,7 @@ def install(app: AppContext, name_or_path: str, force: bool, take_action: bool) 
             raise SystemExit(1)
         source_path = name_or_path
     else:
-        tmpdir = tempfile.mkdtemp(prefix="defenseclaw-plugin-")
+        tmpdir = tempfile.mkdtemp(prefix="dclaw-plugin-fetch-")
         try:
             if source == SourceType.NPM:
                 click.echo(f"[install] fetching {name_or_path!r} from npm registry...")
@@ -326,6 +343,16 @@ def install(app: AppContext, name_or_path: str, force: bool, take_action: bool) 
             else:
                 sev = result.max_severity()
                 detail = f"severity={sev} findings={len(result.findings)}"
+                provenance_path = source_path if source == SourceType.LOCAL else ""
+                post_decision = evaluate_admission(
+                    pe,
+                    policy_dir=app.cfg.policy_dir,
+                    target_type="plugin",
+                    name=plugin_name,
+                    source_path=provenance_path,
+                    scan_result=result,
+                    fallback_actions=app.cfg.plugin_actions,
+                )
 
                 if not take_action:
                     click.echo(
@@ -335,46 +362,49 @@ def install(app: AppContext, name_or_path: str, force: bool, take_action: bool) 
                     if app.logger:
                         app.logger.log_action("install-warning", plugin_name, detail)
                 else:
-                    action_cfg = app.cfg.plugin_actions.for_severity(sev)
-                    enforcement_reason = f"post-install scan: {len(result.findings)} findings, max={sev}"
-                    applied_actions: list[str] = []
+                    if post_decision.verdict == "allowed":
+                        click.echo(f"[install] {plugin_name!r} became allow-listed — skipping post-scan enforcement")
+                    else:
+                        action_cfg = post_decision.action
+                        enforcement_reason = f"post-install scan: {len(result.findings)} findings, max={sev}"
+                        applied_actions: list[str] = []
 
-                    if action_cfg.file == "quarantine":
-                        se = PluginEnforcer(app.cfg.quarantine_dir)
-                        q_dest = se.quarantine(plugin_name, source_path)
-                        if q_dest:
-                            applied_actions.append(f"quarantined to {q_dest}")
-                            pe.quarantine("plugin", plugin_name, enforcement_reason)
-                        else:
-                            click.echo("[install] quarantine failed", err=True)
+                        if action_cfg.file == "quarantine":
+                            se = PluginEnforcer(app.cfg.quarantine_dir)
+                            q_dest = se.quarantine(plugin_name, source_path)
+                            if q_dest:
+                                applied_actions.append(f"quarantined to {q_dest}")
+                                pe.quarantine("plugin", plugin_name, enforcement_reason)
+                            else:
+                                click.echo("[install] quarantine failed", err=True)
 
-                    if action_cfg.runtime == "disable":
-                        client = _sidecar_client(app)
-                        try:
-                            client.disable_plugin(plugin_name)
-                            applied_actions.append("disabled via gateway")
-                            pe.disable("plugin", plugin_name, enforcement_reason)
-                        except Exception as exc:
-                            click.echo(f"[install] gateway disable failed: {exc}", err=True)
+                        if action_cfg.runtime == "disable":
+                            client = _sidecar_client(app)
+                            try:
+                                client.disable_plugin(plugin_name)
+                                applied_actions.append("disabled via gateway")
+                                pe.disable("plugin", plugin_name, enforcement_reason)
+                            except Exception as exc:
+                                click.echo(f"[install] gateway disable failed: {exc}", err=True)
 
-                    if action_cfg.install == "block":
-                        pe.block("plugin", plugin_name, enforcement_reason)
-                        applied_actions.append("added to block list")
+                        if action_cfg.install == "block":
+                            pe.block("plugin", plugin_name, enforcement_reason)
+                            applied_actions.append("added to block list")
 
-                    if action_cfg.install == "allow":
-                        pe.allow("plugin", plugin_name, enforcement_reason)
-                        applied_actions.append("added to allow list")
+                        if action_cfg.install == "allow":
+                            pe.allow("plugin", plugin_name, enforcement_reason)
+                            applied_actions.append("added to allow list")
 
-                    if applied_actions:
-                        actions_str = ", ".join(applied_actions)
-                        click.echo(f"[install] {plugin_name!r}: {actions_str} ({detail})")
-                        if app.logger:
-                            app.logger.log_action("install-enforced", plugin_name, f"{detail}; {actions_str}")
-                        click.echo(
-                            f"error: plugin {plugin_name!r} had {sev} findings — actions applied: {actions_str}",
-                            err=True,
-                        )
-                        raise SystemExit(1)
+                        if applied_actions:
+                            actions_str = ", ".join(applied_actions)
+                            click.echo(f"[install] {plugin_name!r}: {actions_str} ({detail})")
+                            if app.logger:
+                                app.logger.log_action("install-enforced", plugin_name, f"{detail}; {actions_str}")
+                            click.echo(
+                                f"error: plugin {plugin_name!r} had {sev} findings — actions applied: {actions_str}",
+                                err=True,
+                            )
+                            raise SystemExit(1)
 
                     click.echo(f"[install] warning: {len(result.findings)} {sev} findings in {plugin_name!r}")
                     if app.logger:
@@ -554,6 +584,8 @@ def _print_plugin_list_json(
             ae = actions_map[pid]
             if not ae.actions.is_empty():
                 item["actions"] = ae.actions.to_dict()
+        verdict_label, _ = _compute_verdict(actions_map.get(pid), scan_map.get(pid))
+        item["verdict"] = verdict_label
         items.append(item)
     click.echo(json.dumps(items, indent=2, default=str))
 
@@ -576,6 +608,7 @@ def _print_plugin_list_table(
     table.add_column("Description", max_width=50)
     table.add_column("Origin")
     table.add_column("Severity")
+    table.add_column("Verdict")
     table.add_column("Actions")
 
     for p in plugins:
@@ -602,6 +635,10 @@ def _print_plugin_list_table(
         if pid in actions_map:
             actions_str = actions_map[pid].actions.summary()
 
+        verdict_label, verdict_style = _compute_verdict(
+            actions_map.get(pid), scan_map.get(pid),
+        )
+
         status_style = ""
         if "\u2717" in status_display:
             status_style = "red"
@@ -615,6 +652,7 @@ def _print_plugin_list_table(
             desc[:50] + "\u2026" if len(desc) > 50 else desc,
             origin,
             f"[{sev_style}]{severity}[/{sev_style}]" if sev_style else severity,
+            f"[{verdict_style}]{verdict_label}[/{verdict_style}]" if verdict_style else verdict_label,
             actions_str,
         )
 
@@ -856,6 +894,18 @@ def allow(app: AppContext, name: str, reason: str) -> None:
         reason = "manual allow via CLI"
 
     pe.allow("plugin", plugin_name, reason)
+
+    # Best-effort gateway sync so the running process also re-enables.
+    try:
+        client = _sidecar_client(app)
+        client.enable_plugin(plugin_name)
+    except Exception:
+        click.echo(
+            f"[plugin] note: could not re-enable {plugin_name!r} via gateway — "
+            "the sidecar will pick up the DB state on next reconcile, or "
+            "run 'defenseclaw plugin enable' manually", err=True,
+        )
+
     plugin_path = _resolve_plugin_path(app, plugin_name)
     if plugin_path:
         pe.set_source_path("plugin", plugin_name, plugin_path)

--- a/cli/defenseclaw/commands/cmd_policy.py
+++ b/cli/defenseclaw/commands/cmd_policy.py
@@ -985,6 +985,26 @@ def _sync_opa_data(app: AppContext, policy_data: dict) -> None:
             if key in firewall:
                 opa_data["firewall"][key] = firewall[key]
 
+    # --- first_party_allow_list section ---
+    yaml_fp = policy_data.get("first_party_allow_list", [])
+    if yaml_fp:
+        existing = {
+            (e["target_type"], e["target_name"]): e
+            for e in opa_data.get("first_party_allow_list", [])
+            if "target_type" in e and "target_name" in e
+        }
+        merged = []
+        for entry in yaml_fp:
+            key = (entry.get("target_type", ""), entry.get("target_name", ""))
+            base = existing.get(key, {})
+            base.update(entry)
+            if "source_path_contains" not in base:
+                prev = existing.get(key, {})
+                if "source_path_contains" in prev:
+                    base["source_path_contains"] = prev["source_path_contains"]
+            merged.append(base)
+        opa_data["first_party_allow_list"] = merged
+
     # --- audit section ---
     audit_cfg = policy_data.get("audit", {})
     if audit_cfg:

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -45,7 +45,8 @@ def setup() -> None:
 @click.option("--use-trigger", is_flag=True, default=None, help="Enable trigger analyzer")
 @click.option("--use-virustotal", is_flag=True, default=None, help="Enable VirusTotal scanner")
 @click.option("--use-aidefense", is_flag=True, default=None, help="Enable AI Defense analyzer")
-@click.option("--llm-provider", default=None, help="LLM provider (anthropic or openai)")
+@click.option("--llm-provider", default=None, type=click.Choice(["anthropic", "openai"]),
+              help="LLM provider (anthropic or openai)")
 @click.option("--llm-model", default=None, help="LLM model name")
 @click.option("--llm-consensus-runs", type=int, default=None, help="LLM consensus runs (0=disabled)")
 @click.option("--policy", default=None, help="Scan policy preset (strict, balanced, permissive)")
@@ -179,10 +180,11 @@ def _configure_inspect_llm(llm, data_dir: str) -> None:
 
     The API key is stored in ~/.defenseclaw/.env, not in config.yaml.
     """
-    from defenseclaw.guardrail import detect_api_key_env
+    from defenseclaw.guardrail import KNOWN_PROVIDERS, detect_api_key_env
     llm.provider = click.prompt(
-        "  LLM provider (anthropic/openai)",
-        default=llm.provider or "anthropic",
+        "  LLM provider",
+        type=click.Choice(KNOWN_PROVIDERS),
+        default=llm.provider if llm.provider in KNOWN_PROVIDERS else "anthropic",
     )
     llm.model = click.prompt("  LLM model name", default=llm.model or "", show_default=False)
     env_name = detect_api_key_env(f"{llm.provider}/{llm.model}")
@@ -312,7 +314,8 @@ def _print_summary(sc, llm, aid) -> None:
 
 @setup.command("mcp-scanner")
 @click.option("--analyzers", default=None, help="Comma-separated analyzer list (yara,api,llm,behavioral,readiness)")
-@click.option("--llm-provider", default=None, help="LLM provider (anthropic or openai)")
+@click.option("--llm-provider", default=None, type=click.Choice(["anthropic", "openai"]),
+              help="LLM provider (anthropic or openai)")
 @click.option("--llm-model", default=None, help="LLM model for semantic analysis")
 @click.option("--scan-prompts", is_flag=True, default=None, help="Scan MCP prompts")
 @click.option("--scan-resources", is_flag=True, default=None, help="Scan MCP resources")

--- a/cli/defenseclaw/commands/cmd_skill.py
+++ b/cli/defenseclaw/commands/cmd_skill.py
@@ -268,7 +268,11 @@ def _skill_status(s: dict[str, Any]) -> str:
     return "inactive"
 
 
-def _skill_status_display(s: dict[str, Any], action_entry: Any = None) -> str:
+def _skill_status_display(
+    s: dict[str, Any],
+    action_entry: Any = None,
+    scan_entry: dict[str, Any] | None = None,
+) -> str:
     if s.get("disabled"):
         return "✗ disabled"
     if s.get("blockedByAllowlist"):
@@ -281,6 +285,14 @@ def _skill_status_display(s: dict[str, Any], action_entry: Any = None) -> str:
             return "✗ blocked"
         if a.runtime == "disable":
             return "✗ disabled"
+        if a.install == "allow":
+            return "✓ allowed"
+    if scan_entry:
+        sev = scan_entry.get("max_severity", "CLEAN")
+        if sev in ("CRITICAL", "HIGH"):
+            return "✗ rejected"
+        if sev in ("MEDIUM", "LOW"):
+            return "⚠ warning"
     if s.get("eligible"):
         return "✓ ready"
     if s.get("source") in ("enforcement", "scan-history"):
@@ -409,7 +421,7 @@ def _print_skill_list_table(
     for s in skills:
         name = s.get("name", "")
         display_name = _skill_display_name(s)
-        status_display = _skill_status_display(s, actions_map.get(name))
+        status_display = _skill_status_display(s, actions_map.get(name), scan_map.get(name))
         desc = s.get("description", "")
         source = s.get("source", "")
 
@@ -543,14 +555,69 @@ def scan(app: AppContext, target: str, as_json: bool, scan_path: str, remote: bo
     else:
         _print_result(name, result)
 
+    if not result.is_clean():
+        _apply_scan_enforcement(app, pe, name, scan_dir, result)
+
+
+def _apply_scan_enforcement(
+    app: AppContext,
+    pe,
+    skill_name: str,
+    skill_path: str,
+    result,
+) -> None:
+    """Apply configured skill_actions policy based on scan severity."""
+    from defenseclaw.enforce.skill_enforcer import SkillEnforcer
+
+    sev = result.max_severity()
+    action_cfg = app.cfg.skill_actions.for_severity(sev)
+
+    if action_cfg.file == "none" and action_cfg.runtime != "disable" and action_cfg.install == "none":
+        return
+
+    enforcement_reason = f"post-scan: {len(result.findings)} findings, max={sev}"
+    applied_actions: list[str] = []
+
+    if action_cfg.file == "quarantine":
+        se = SkillEnforcer(app.cfg.quarantine_dir)
+        dest = se.quarantine(skill_name, skill_path)
+        if dest:
+            applied_actions.append(f"quarantined to {dest}")
+            pe.quarantine("skill", skill_name, enforcement_reason)
+        else:
+            click.echo(f"[scan] quarantine failed for {skill_name!r}", err=True)
+
+    if action_cfg.runtime == "disable":
+        try:
+            client = _sidecar_client(app)
+            client.disable_skill(skill_name)
+            applied_actions.append("disabled via gateway")
+        except Exception:
+            pass
+        pe.disable("skill", skill_name, enforcement_reason)
+
+    if action_cfg.install == "block":
+        pe.block("skill", skill_name, enforcement_reason)
+        applied_actions.append("added to block list")
+
+    if applied_actions:
+        actions_str = ", ".join(applied_actions)
+        click.echo(f"[scan] enforcement: {skill_name!r}: {actions_str}")
+        if app.logger:
+            detail = f"severity={sev} findings={len(result.findings)}"
+            app.logger.log_action("scan-enforced", skill_name, f"{detail}; {actions_str}")
+
 
 def _scan_all(app: AppContext, scanner, as_json: bool) -> None:
+    from defenseclaw.enforce import PolicyEngine
+
     oc_list = _list_openclaw_skills_full(app)
     if oc_list and oc_list.get("skills"):
         skill_names = [s["name"] for s in oc_list["skills"]]
     else:
         skill_names = []
 
+    pe = PolicyEngine(app.store)
     verdicts = []
 
     if skill_names:
@@ -574,6 +641,8 @@ def _scan_all(app: AppContext, scanner, as_json: bool) -> None:
                 else:
                     _print_result(name, result)
                     click.echo()
+                if not result.is_clean():
+                    _apply_scan_enforcement(app, pe, name, base_dir, result)
             except Exception as exc:
                 click.echo(f"[scan] error scanning {name}: {exc}", err=True)
     else:
@@ -598,6 +667,8 @@ def _scan_all(app: AppContext, scanner, as_json: bool) -> None:
                     else:
                         _print_result(entry, result)
                         click.echo()
+                    if not result.is_clean():
+                        _apply_scan_enforcement(app, pe, entry, path, result)
                 except Exception as exc:
                     click.echo(f"  Error: {exc}")
 
@@ -1017,6 +1088,38 @@ def block(app: AppContext, name: str, reason: str) -> None:
 
     if app.logger:
         app.logger.log_action("skill-block", skill_name, f"reason={reason}")
+
+
+# ---------------------------------------------------------------------------
+# skill unblock
+# ---------------------------------------------------------------------------
+
+@skill.command()
+@click.argument("name")
+@pass_ctx
+def unblock(app: AppContext, name: str) -> None:
+    """Remove a skill from the block list and clear all enforcement state.
+
+    Clears block, quarantine, and disable actions without adding to the
+    allow list — the skill will go through normal scanning on next install.
+
+    To also restore quarantined files, run 'skill restore' after unblocking.
+    """
+    from defenseclaw.enforce import PolicyEngine
+
+    skill_name = os.path.basename(name)
+    pe = PolicyEngine(app.store)
+
+    if not pe.is_blocked("skill", skill_name):
+        click.echo(f"[skill] {skill_name!r} is not on the block list")
+        return
+
+    pe.remove_action("skill", skill_name)
+    click.secho(f"[skill] {skill_name!r} removed from block list (all enforcement cleared)", fg="green")
+    click.echo(f"  Tip: if files are quarantined, run 'defenseclaw skill restore {skill_name}'")
+
+    if app.logger:
+        app.logger.log_action("skill-unblock", skill_name, "manual unblock via CLI")
 
 
 # ---------------------------------------------------------------------------

--- a/cli/defenseclaw/commands/cmd_skill.py
+++ b/cli/defenseclaw/commands/cmd_skill.py
@@ -566,7 +566,15 @@ def _apply_scan_enforcement(
     skill_path: str,
     result,
 ) -> None:
-    """Apply configured skill_actions policy based on scan severity."""
+    """Apply configured skill_actions policy based on scan severity.
+
+    Allow-listed skills are exempt from auto-enforcement — only a manual
+    ``skill block`` can override an allow entry.
+    """
+    if pe.is_allowed("skill", skill_name):
+        click.echo(f"[scan] {skill_name!r} is allow-listed — skipping auto-enforcement")
+        return
+
     from defenseclaw.enforce.skill_enforcer import SkillEnforcer
 
     sev = result.max_severity()
@@ -1145,6 +1153,13 @@ def allow(app: AppContext, name: str, reason: str) -> None:
         reason = "manual allow via CLI"
 
     pe.allow("skill", skill_name, reason)
+
+    # Clear residual auto-enforcement state (quarantine / disable) so the
+    # allow actually takes full effect.  Only a manual ``skill block`` can
+    # override an allow entry.
+    pe.clear_quarantine("skill", skill_name)
+    pe.enable("skill", skill_name)
+
     skill_path = _resolve_path(app, skill_name)
     if skill_path:
         pe.set_source_path("skill", skill_name, skill_path)

--- a/cli/defenseclaw/commands/cmd_skill.py
+++ b/cli/defenseclaw/commands/cmd_skill.py
@@ -657,6 +657,21 @@ def _apply_scan_enforcement(
             app.logger.log_action("scan-enforced", skill_name, f"{detail}; {actions_str}")
 
 
+def _enable_skill_via_gateway(app: AppContext, skill_name: str) -> bool:
+    """Best-effort runtime re-enable; returns True only on confirmed success."""
+    client = _sidecar_client(app)
+    try:
+        resp = client.enable_skill(skill_name)
+    except Exception as exc:
+        click.echo(f"error: gateway enable failed: {exc}", err=True)
+        return False
+
+    if resp.get("status") != "enabled":
+        click.echo(f"error: gateway returned unexpected response: {resp}", err=True)
+        return False
+    return True
+
+
 def _scan_all(app: AppContext, scanner, as_json: bool, *, enforce: bool = False) -> None:
     from defenseclaw.enforce import PolicyEngine
 
@@ -1052,27 +1067,6 @@ def _parse_clawhub_uri(uri: str) -> tuple[str, str | None]:
     return (path, None)
 
 
-def _find_skill_in_dir(base: str, skill_name: str) -> str | None:
-    """Find the skill directory after clawhub install."""
-    # Direct match
-    candidate = os.path.join(base, skill_name)
-    if os.path.isdir(candidate):
-        return candidate
-
-    # Might be inside a skills/ subdirectory
-    candidate = os.path.join(base, "skills", skill_name)
-    if os.path.isdir(candidate):
-        return candidate
-
-    # Check if there's a SKILL.md anywhere
-    for root, dirs, files in os.walk(base):
-        if "SKILL.md" in files:
-            return root
-        dirs[:] = [d for d in dirs if d != "node_modules"]
-
-    return None
-
-
 def _print_result(name: str, result) -> None:
     click.echo(f"  Skill:    {name}")
     click.echo(f"  Target:   {result.target}")
@@ -1170,9 +1164,22 @@ def unblock(app: AppContext, name: str) -> None:
 
     entry = pe.get_action("skill", skill_name)
     saved_path = entry.source_path if entry else ""
+    runtime_disabled = bool(entry and entry.actions.runtime == "disable")
 
-    pe.remove_action("skill", skill_name)
-    click.secho(f"[skill] {skill_name!r} all enforcement state cleared (block/quarantine/disable)", fg="green")
+    runtime_cleared = True
+    if runtime_disabled:
+        runtime_cleared = _enable_skill_via_gateway(app, skill_name)
+
+    if runtime_cleared:
+        pe.remove_action("skill", skill_name)
+        click.secho(f"[skill] {skill_name!r} all enforcement state cleared (block/quarantine/disable)", fg="green")
+    else:
+        pe.unblock("skill", skill_name)
+        pe.clear_quarantine("skill", skill_name)
+        click.secho(
+            f"[skill] {skill_name!r} install/file enforcement cleared; runtime disable remains until the gateway is reachable",
+            fg="yellow",
+        )
     if saved_path:
         restore_hint = f"--path \"{saved_path}\""
     else:
@@ -1208,24 +1215,27 @@ def allow(app: AppContext, name: str, reason: str) -> None:
     if not reason:
         reason = "manual allow via CLI"
 
-    pe.allow("skill", skill_name, reason)
+    entry = pe.get_action("skill", skill_name)
+    runtime_disabled = bool(entry and entry.actions.runtime == "disable")
+    runtime_cleared = True
+    if runtime_disabled:
+        runtime_cleared = _enable_skill_via_gateway(app, skill_name)
 
-    # pe.allow() already cleared file/runtime enforcement in the DB.
-    # Best-effort gateway sync so the running process also re-enables.
-    try:
-        client = _sidecar_client(app)
-        client.enable_skill(skill_name)
-    except Exception:
-        click.echo(
-            f"[skill] note: could not re-enable {skill_name!r} via gateway — "
-            "the sidecar will pick up the DB state on next reconcile, or "
-            "run 'defenseclaw skill enable' manually", err=True,
-        )
+    if runtime_cleared:
+        pe.allow("skill", skill_name, reason)
+    else:
+        app.store.set_action_field("skill", skill_name, "install", "allow", reason)
 
     skill_path = _resolve_path(app, skill_name)
     if skill_path:
         pe.set_source_path("skill", skill_name, skill_path)
-    click.secho(f"[skill] {skill_name!r} added to allow list", fg="green")
+    if runtime_cleared:
+        click.secho(f"[skill] {skill_name!r} added to allow list", fg="green")
+    else:
+        click.secho(
+            f"[skill] {skill_name!r} added to allow list; runtime disable remains until the gateway is reachable",
+            fg="yellow",
+        )
 
     if app.logger:
         app.logger.log_action("skill-allow", skill_name, f"reason={reason}")

--- a/cli/defenseclaw/commands/cmd_skill.py
+++ b/cli/defenseclaw/commands/cmd_skill.py
@@ -1177,7 +1177,8 @@ def unblock(app: AppContext, name: str) -> None:
         pe.unblock("skill", skill_name)
         pe.clear_quarantine("skill", skill_name)
         click.secho(
-            f"[skill] {skill_name!r} install/file enforcement cleared; runtime disable remains until the gateway is reachable",
+            f"[skill] {skill_name!r} install/file enforcement cleared; "
+            "runtime disable remains until the gateway is reachable",
             fg="yellow",
         )
     if saved_path:

--- a/cli/defenseclaw/commands/cmd_skill.py
+++ b/cli/defenseclaw/commands/cmd_skill.py
@@ -29,6 +29,7 @@ from typing import Any
 
 import click
 
+from defenseclaw.commands import compute_verdict as _compute_verdict
 from defenseclaw.context import AppContext, pass_ctx
 
 
@@ -393,6 +394,8 @@ def _print_skill_list_json(
             ae = actions_map[name]
             if not ae.actions.is_empty():
                 item["actions"] = ae.actions.to_dict()
+        verdict_label, _ = _compute_verdict(actions_map.get(name), scan_map.get(name))
+        item["verdict"] = verdict_label
         items.append(item)
     click.echo(json.dumps(items, indent=2, default=str))
 
@@ -416,6 +419,7 @@ def _print_skill_list_table(
     table.add_column("Description", no_wrap=True, overflow="ellipsis", max_width=34)
     table.add_column("Source", no_wrap=True, overflow="ellipsis", max_width=18)
     table.add_column("Severity", no_wrap=True)
+    table.add_column("Verdict", no_wrap=True)
     table.add_column("Actions", no_wrap=True, overflow="ellipsis", max_width=18)
 
     for s in skills:
@@ -441,6 +445,10 @@ def _print_skill_list_table(
         if name in actions_map:
             actions_str = actions_map[name].actions.summary()
 
+        verdict_label, verdict_style = _compute_verdict(
+            actions_map.get(name), scan_map.get(name),
+        )
+
         status_style = ""
         if "✗" in status_display:
             status_style = "red"
@@ -453,6 +461,7 @@ def _print_skill_list_table(
             desc,
             source,
             f"[{sev_style}]{severity}[/{sev_style}]" if sev_style else severity,
+            f"[{verdict_style}]{verdict_label}[/{verdict_style}]" if verdict_style else verdict_label,
             actions_str,
         )
 
@@ -468,8 +477,12 @@ def _print_skill_list_table(
 @click.option("--json", "as_json", is_flag=True, help="Output scan results as JSON")
 @click.option("--path", "scan_path", default="", help="Override skill directory path")
 @click.option("--remote", is_flag=True, help="Scan via sidecar API (for skills on a remote host)")
+@click.option(
+    "--action", is_flag=True, default=False,
+    help="Apply enforcement actions (quarantine/block/disable) based on findings",
+)
 @pass_ctx
-def scan(app: AppContext, target: str, as_json: bool, scan_path: str, remote: bool) -> None:
+def scan(app: AppContext, target: str, as_json: bool, scan_path: str, remote: bool, action: bool) -> None:
     """Scan a skill by name, path, URL, or 'all' for all configured skills.
 
     Uses the native cisco-ai-skill-scanner SDK for local scans.
@@ -491,8 +504,23 @@ def scan(app: AppContext, target: str, as_json: bool, scan_path: str, remote: bo
     from defenseclaw.enforce import PolicyEngine
     from defenseclaw.scanner.skill import SkillScannerWrapper
 
+    if action and remote:
+        click.echo(
+            "error: --action is not supported with --remote; enforcement "
+            "actions (quarantine/block/disable) require local file access",
+            err=True,
+        )
+        raise SystemExit(1)
+
     # URL target → fetch-to-temp scan (Option 3)
     if _is_url_target(target):
+        if action:
+            click.echo(
+                "error: --action is not supported with URL targets; "
+                "URL scans are pre-screening only",
+                err=True,
+            )
+            raise SystemExit(1)
         _scan_from_url(app, target, as_json)
         return
 
@@ -502,7 +530,7 @@ def scan(app: AppContext, target: str, as_json: bool, scan_path: str, remote: bo
         if remote:
             _scan_all_remote(app, as_json)
         else:
-            _scan_all(app, scanner, as_json)
+            _scan_all(app, scanner, as_json, enforce=action)
         return
 
     # Resolve scan directory
@@ -555,7 +583,7 @@ def scan(app: AppContext, target: str, as_json: bool, scan_path: str, remote: bo
     else:
         _print_result(name, result)
 
-    if not result.is_clean():
+    if not result.is_clean() and action:
         _apply_scan_enforcement(app, pe, name, scan_dir, result)
 
 
@@ -571,14 +599,26 @@ def _apply_scan_enforcement(
     Allow-listed skills are exempt from auto-enforcement — only a manual
     ``skill block`` can override an allow entry.
     """
-    if pe.is_allowed("skill", skill_name):
+    from defenseclaw.enforce.admission import evaluate_admission
+
+    decision = evaluate_admission(
+        pe,
+        policy_dir=app.cfg.policy_dir,
+        target_type="skill",
+        name=skill_name,
+        source_path=skill_path,
+        scan_result=result,
+        fallback_actions=app.cfg.skill_actions,
+    )
+
+    if decision.verdict == "allowed":
         click.echo(f"[scan] {skill_name!r} is allow-listed — skipping auto-enforcement")
         return
 
     from defenseclaw.enforce.skill_enforcer import SkillEnforcer
 
     sev = result.max_severity()
-    action_cfg = app.cfg.skill_actions.for_severity(sev)
+    action_cfg = decision.action
 
     if action_cfg.file == "none" and action_cfg.runtime != "disable" and action_cfg.install == "none":
         return
@@ -587,6 +627,7 @@ def _apply_scan_enforcement(
     applied_actions: list[str] = []
 
     if action_cfg.file == "quarantine":
+        pe.set_source_path("skill", skill_name, skill_path)
         se = SkillEnforcer(app.cfg.quarantine_dir)
         dest = se.quarantine(skill_name, skill_path)
         if dest:
@@ -600,9 +641,9 @@ def _apply_scan_enforcement(
             client = _sidecar_client(app)
             client.disable_skill(skill_name)
             applied_actions.append("disabled via gateway")
+            pe.disable("skill", skill_name, enforcement_reason)
         except Exception:
-            pass
-        pe.disable("skill", skill_name, enforcement_reason)
+            click.echo(f"[scan] gateway disable failed for {skill_name!r} — skipping runtime disable", err=True)
 
     if action_cfg.install == "block":
         pe.block("skill", skill_name, enforcement_reason)
@@ -616,7 +657,7 @@ def _apply_scan_enforcement(
             app.logger.log_action("scan-enforced", skill_name, f"{detail}; {actions_str}")
 
 
-def _scan_all(app: AppContext, scanner, as_json: bool) -> None:
+def _scan_all(app: AppContext, scanner, as_json: bool, *, enforce: bool = False) -> None:
     from defenseclaw.enforce import PolicyEngine
 
     oc_list = _list_openclaw_skills_full(app)
@@ -649,7 +690,7 @@ def _scan_all(app: AppContext, scanner, as_json: bool) -> None:
                 else:
                     _print_result(name, result)
                     click.echo()
-                if not result.is_clean():
+                if not result.is_clean() and enforce:
                     _apply_scan_enforcement(app, pe, name, base_dir, result)
             except Exception as exc:
                 click.echo(f"[scan] error scanning {name}: {exc}", err=True)
@@ -675,7 +716,7 @@ def _scan_all(app: AppContext, scanner, as_json: bool) -> None:
                     else:
                         _print_result(entry, result)
                         click.echo()
-                    if not result.is_clean():
+                    if not result.is_clean() and enforce:
                         _apply_scan_enforcement(app, pe, entry, path, result)
                 except Exception as exc:
                     click.echo(f"  Error: {exc}")
@@ -1118,13 +1159,28 @@ def unblock(app: AppContext, name: str) -> None:
     skill_name = os.path.basename(name)
     pe = PolicyEngine(app.store)
 
-    if not pe.is_blocked("skill", skill_name):
-        click.echo(f"[skill] {skill_name!r} is not on the block list")
+    has_state = (
+        pe.is_blocked("skill", skill_name)
+        or pe.is_quarantined("skill", skill_name)
+        or app.store.has_action("skill", skill_name, "runtime", "disable")
+    )
+    if not has_state:
+        click.echo(f"[skill] {skill_name!r} has no enforcement state to clear")
         return
 
+    entry = pe.get_action("skill", skill_name)
+    saved_path = entry.source_path if entry else ""
+
     pe.remove_action("skill", skill_name)
-    click.secho(f"[skill] {skill_name!r} removed from block list (all enforcement cleared)", fg="green")
-    click.echo(f"  Tip: if files are quarantined, run 'defenseclaw skill restore {skill_name}'")
+    click.secho(f"[skill] {skill_name!r} all enforcement state cleared (block/quarantine/disable)", fg="green")
+    if saved_path:
+        restore_hint = f"--path \"{saved_path}\""
+    else:
+        restore_hint = "--path <original-dir>"
+    click.echo(
+        f"  Tip: if files are quarantined, run "
+        f"'defenseclaw skill restore {skill_name} {restore_hint}'"
+    )
 
     if app.logger:
         app.logger.log_action("skill-unblock", skill_name, "manual unblock via CLI")
@@ -1154,11 +1210,17 @@ def allow(app: AppContext, name: str, reason: str) -> None:
 
     pe.allow("skill", skill_name, reason)
 
-    # Clear residual auto-enforcement state (quarantine / disable) so the
-    # allow actually takes full effect.  Only a manual ``skill block`` can
-    # override an allow entry.
-    pe.clear_quarantine("skill", skill_name)
-    pe.enable("skill", skill_name)
+    # pe.allow() already cleared file/runtime enforcement in the DB.
+    # Best-effort gateway sync so the running process also re-enables.
+    try:
+        client = _sidecar_client(app)
+        client.enable_skill(skill_name)
+    except Exception:
+        click.echo(
+            f"[skill] note: could not re-enable {skill_name!r} via gateway — "
+            "the sidecar will pick up the DB state on next reconcile, or "
+            "run 'defenseclaw skill enable' manually", err=True,
+        )
 
     skill_path = _resolve_path(app, skill_name)
     if skill_path:
@@ -1421,14 +1483,23 @@ def install(app: AppContext, name: str, force: bool, take_action: bool) -> None:
     Use --force to overwrite an existing skill.
     """
     from defenseclaw.enforce import PolicyEngine
+    from defenseclaw.enforce.admission import evaluate_admission
     from defenseclaw.enforce.skill_enforcer import SkillEnforcer
     from defenseclaw.scanner.skill import SkillScannerWrapper
 
     skill_name = os.path.basename(name)
     pe = PolicyEngine(app.store)
 
-    # Block list check
-    if pe.is_blocked("skill", skill_name):
+    pre_decision = evaluate_admission(
+        pe,
+        policy_dir=app.cfg.policy_dir,
+        target_type="skill",
+        name=skill_name,
+        source_path=name,
+        fallback_actions=app.cfg.skill_actions,
+    )
+
+    if pre_decision.verdict == "blocked":
         if app.logger:
             app.logger.log_action("install-rejected", skill_name, "reason=blocked")
         click.echo(
@@ -1438,9 +1509,11 @@ def install(app: AppContext, name: str, force: bool, take_action: bool) -> None:
         )
         raise SystemExit(1)
 
-    # Allow list check — skip scan
-    if pe.is_allowed("skill", skill_name):
-        click.echo(f"[install] {skill_name!r} is on the allow list — skipping scan")
+    if pre_decision.verdict == "allowed":
+        if pre_decision.source == "scan-disabled":
+            click.echo(f"[install] policy allows {skill_name!r} without scan")
+        else:
+            click.echo(f"[install] {skill_name!r} is on the allow list — skipping scan")
         if app.logger:
             app.logger.log_action("install-allowed", skill_name, "reason=allow-listed")
         _run_clawhub_install(skill_name, force)
@@ -1469,7 +1542,23 @@ def install(app: AppContext, name: str, force: bool, take_action: bool) -> None:
 
     _print_result(skill_name, result)
 
-    if result.is_clean():
+    post_decision = evaluate_admission(
+        pe,
+        policy_dir=app.cfg.policy_dir,
+        target_type="skill",
+        name=skill_name,
+        source_path=skill_path,
+        scan_result=result,
+        fallback_actions=app.cfg.skill_actions,
+    )
+
+    if post_decision.verdict == "allowed":
+        click.echo(f"[install] {skill_name!r} became allow-listed — skipping post-scan enforcement")
+        if app.logger:
+            app.logger.log_action("install-allowed", skill_name, "reason=allow-listed-post-scan")
+        return
+
+    if post_decision.verdict == "clean":
         click.echo(f"[install] {skill_name!r} installed and clean")
         if app.logger:
             app.logger.log_action("install-clean", skill_name, "verdict=clean")
@@ -1488,7 +1577,7 @@ def install(app: AppContext, name: str, force: bool, take_action: bool) -> None:
         return
 
     # --action: apply configured skill_actions policy
-    action_cfg = app.cfg.skill_actions.for_severity(sev)
+    action_cfg = post_decision.action
     enforcement_reason = f"post-install scan: {len(result.findings)} findings, max={sev}"
     applied_actions: list[str] = []
 

--- a/cli/defenseclaw/db.py
+++ b/cli/defenseclaw/db.py
@@ -103,8 +103,11 @@ def _validate(field: str, value: str) -> None:
 
 class Store:
     def __init__(self, db_path: str) -> None:
-        self.db = sqlite3.connect(db_path, detect_types=sqlite3.PARSE_DECLTYPES)
+        self.db = sqlite3.connect(
+            db_path, detect_types=sqlite3.PARSE_DECLTYPES, timeout=5.0,
+        )
         self.db.execute("PRAGMA journal_mode=WAL")
+        self.db.execute("PRAGMA busy_timeout=5000")
 
     def init(self) -> None:
         self.db.executescript(SCHEMA)

--- a/cli/defenseclaw/enforce/admission.py
+++ b/cli/defenseclaw/enforce/admission.py
@@ -62,8 +62,14 @@ def _default_admission_policy() -> AdmissionPolicyData:
             },
         },
         first_party_allow={
-            ("plugin", "defenseclaw"): ("first-party DefenseClaw plugin", [".defenseclaw", "extensions/defenseclaw"]),
-            ("skill", "codeguard"): ("first-party DefenseClaw skill", [".defenseclaw", "workspace/skills/codeguard", "skills/codeguard"]),
+            ("plugin", "defenseclaw"): (
+                "first-party DefenseClaw plugin",
+                [".defenseclaw", "extensions/defenseclaw"],
+            ),
+            ("skill", "codeguard"): (
+                "first-party DefenseClaw skill",
+                [".defenseclaw", "workspace/skills/codeguard", "skills/codeguard"],
+            ),
         },
     )
 

--- a/cli/defenseclaw/enforce/admission.py
+++ b/cli/defenseclaw/enforce/admission.py
@@ -1,0 +1,230 @@
+"""Shared admission evaluation helpers for Python CLI paths.
+
+These helpers intentionally mirror the admission ordering used by the Go
+gateway/watcher:
+
+1. Explicit block list entries override everything.
+2. Explicit allow list entries override policy and skip scan/enforcement.
+3. Policy-managed allow entries (for example first-party bundles) may bypass
+   scan depending on the active policy data.
+4. If no scan result exists yet, the active policy decides whether scanning is
+   required.
+5. Once a scan result exists, the effective per-target action mapping decides
+   whether the result is rejected or only warned.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+from defenseclaw.config import SeverityAction
+
+
+@dataclass(frozen=True)
+class AdmissionDecision:
+    verdict: str
+    reason: str
+    action: SeverityAction = field(default_factory=SeverityAction)
+    source: str = ""
+
+
+@dataclass(frozen=True)
+class AdmissionPolicyData:
+    allow_list_bypass_scan: bool = True
+    scan_on_install: bool = True
+    actions: dict[str, SeverityAction] = field(default_factory=dict)
+    scanner_overrides: dict[str, dict[str, SeverityAction]] = field(default_factory=dict)
+    first_party_allow: dict[tuple[str, str], tuple[str, list[str]]] = field(default_factory=dict)
+
+
+def evaluate_admission(
+    pe: Any,
+    *,
+    policy_dir: str,
+    target_type: str,
+    name: str,
+    source_path: str = "",
+    scan_result: Any | None = None,
+    action_entry: Any | None = None,
+    fallback_actions: Any | None = None,
+    include_quarantine: bool = False,
+) -> AdmissionDecision:
+    """Evaluate admission for a target using active policy data when available.
+
+    Explicit allow/block entries from the store are always treated as manual
+    overrides. Policy-managed allow entries from ``first_party_allow_list`` are
+    still subject to the policy's ``allow_list_bypass_scan`` setting.
+    """
+    blocked_reason = _action_reason(action_entry, default=f"{target_type} '{name}' is on the block list")
+    if pe.is_blocked(target_type, name):
+        return AdmissionDecision("blocked", blocked_reason, source="manual-block")
+
+    allowed_reason = _action_reason(action_entry, default=f"{target_type} '{name}' is on the allow list — scan skipped")
+    if pe.is_allowed(target_type, name):
+        return AdmissionDecision("allowed", allowed_reason, source="manual-allow")
+
+    if include_quarantine and pe.is_quarantined(target_type, name):
+        reason = _action_reason(action_entry, default="quarantined")
+        return AdmissionDecision("rejected", f"quarantined: {reason}", source="quarantine")
+
+    policy = load_admission_policy(policy_dir)
+
+    fp_entry = policy.first_party_allow.get((target_type, name))
+    if fp_entry is not None and policy.allow_list_bypass_scan:
+        fp_reason, fp_constraints = fp_entry
+        if _matches_provenance(fp_constraints, source_path):
+            return AdmissionDecision("allowed", fp_reason, source="policy-allow")
+
+    if scan_result is None:
+        if not policy.scan_on_install:
+            return AdmissionDecision(
+                "allowed",
+                "scan_on_install disabled — allowed without scan",
+                source="scan-disabled",
+            )
+        return AdmissionDecision("scan", "scan required", source="scan-required")
+
+    finding_count, severity = _scan_summary(scan_result)
+    action = effective_action_for(
+        policy,
+        target_type=target_type,
+        severity=severity,
+        fallback_actions=fallback_actions,
+    )
+
+    if finding_count <= 0:
+        return AdmissionDecision("clean", "scan clean", action=action, source="scan-clean")
+
+    detail = f"{finding_count} findings, max {severity}"
+    if action.install == "block" or action.runtime == "disable":
+        return AdmissionDecision("rejected", detail, action=action, source="scan-rejected")
+
+    return AdmissionDecision("warning", detail, action=action, source="scan-warning")
+
+
+def effective_action_for(
+    policy: AdmissionPolicyData,
+    *,
+    target_type: str,
+    severity: str,
+    fallback_actions: Any | None = None,
+) -> SeverityAction:
+    sev = severity.upper()
+    target_overrides = policy.scanner_overrides.get(target_type, {})
+    if sev in target_overrides:
+        return target_overrides[sev]
+    if sev in policy.actions:
+        return policy.actions[sev]
+    if fallback_actions is not None:
+        return fallback_actions.for_severity(sev)
+    return SeverityAction()
+
+
+def load_admission_policy(policy_dir: str) -> AdmissionPolicyData:
+    data = _read_policy_data(policy_dir)
+    if not data:
+        return AdmissionPolicyData()
+
+    cfg = data.get("config", {}) or {}
+    raw_actions = data.get("actions", {}) or {}
+    raw_overrides = data.get("scanner_overrides", {}) or {}
+    first_party = data.get("first_party_allow_list", []) or []
+
+    actions = {
+        severity.upper(): _severity_action_from_policy(raw)
+        for severity, raw in raw_actions.items()
+        if isinstance(raw, dict)
+    }
+
+    scanner_overrides: dict[str, dict[str, SeverityAction]] = {}
+    for target_type, overrides in raw_overrides.items():
+        if not isinstance(overrides, dict):
+            continue
+        scanner_overrides[target_type] = {
+            severity.upper(): _severity_action_from_policy(raw)
+            for severity, raw in overrides.items()
+            if isinstance(raw, dict)
+        }
+
+    first_party_allow: dict[tuple[str, str], tuple[str, list[str]]] = {}
+    for entry in first_party:
+        if not isinstance(entry, dict):
+            continue
+        target_type = str(entry.get("target_type", ""))
+        target_name = str(entry.get("target_name", ""))
+        if target_type and target_name:
+            reason = str(entry.get("reason", "first-party allow"))
+            source_path_contains = entry.get("source_path_contains", [])
+            if not isinstance(source_path_contains, list):
+                source_path_contains = []
+            first_party_allow[(target_type, target_name)] = (reason, source_path_contains)
+
+    return AdmissionPolicyData(
+        allow_list_bypass_scan=bool(cfg.get("allow_list_bypass_scan", True)),
+        scan_on_install=bool(cfg.get("scan_on_install", True)),
+        actions=actions,
+        scanner_overrides=scanner_overrides,
+        first_party_allow=first_party_allow,
+    )
+
+
+def _severity_action_from_policy(raw: dict[str, Any]) -> SeverityAction:
+    runtime = "disable" if raw.get("runtime", "allow") == "block" else "enable"
+    return SeverityAction(
+        file=str(raw.get("file", "none")),
+        runtime=runtime,
+        install=str(raw.get("install", "none")),
+    )
+
+
+def _read_policy_data(policy_dir: str) -> dict[str, Any] | None:
+    for candidate in _policy_data_candidates(policy_dir):
+        try:
+            with open(candidate) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(data, dict):
+            return data
+    return None
+
+
+def _policy_data_candidates(policy_dir: str) -> list[str]:
+    candidates: list[str] = []
+    if policy_dir:
+        candidates.append(os.path.join(policy_dir, "rego", "data.json"))
+        candidates.append(os.path.join(policy_dir, "data.json"))
+    return candidates
+
+
+def _scan_summary(scan_result: Any) -> tuple[int, str]:
+    if hasattr(scan_result, "findings") and hasattr(scan_result, "max_severity"):
+        findings = getattr(scan_result, "findings", []) or []
+        return len(findings), str(scan_result.max_severity())
+
+    if isinstance(scan_result, dict):
+        count = scan_result.get("total_findings")
+        if count is None:
+            count = scan_result.get("finding_count", 0)
+        severity = scan_result.get("max_severity", "INFO")
+        return int(count or 0), str(severity)
+
+    return 0, "INFO"
+
+
+def _matches_provenance(constraints: list[str], source_path: str) -> bool:
+    """True if no constraints exist, or if source_path contains one of them."""
+    if not constraints:
+        return True
+    if not source_path:
+        return False
+    normalised = source_path.replace("\\", "/").lower()
+    return any(c.lower() in normalised for c in constraints)
+
+
+def _action_reason(action_entry: Any | None, *, default: str) -> str:
+    reason = getattr(action_entry, "reason", "") if action_entry is not None else ""
+    return reason or default

--- a/cli/defenseclaw/enforce/admission.py
+++ b/cli/defenseclaw/enforce/admission.py
@@ -40,6 +40,34 @@ class AdmissionPolicyData:
     first_party_allow: dict[tuple[str, str], tuple[str, list[str]]] = field(default_factory=dict)
 
 
+def _default_admission_policy() -> AdmissionPolicyData:
+    return AdmissionPolicyData(
+        allow_list_bypass_scan=True,
+        scan_on_install=True,
+        actions={
+            "CRITICAL": SeverityAction(file="quarantine", runtime="disable", install="block"),
+            "HIGH": SeverityAction(file="quarantine", runtime="disable", install="block"),
+            "MEDIUM": SeverityAction(file="none", runtime="enable", install="none"),
+            "LOW": SeverityAction(file="none", runtime="enable", install="none"),
+            "INFO": SeverityAction(file="none", runtime="enable", install="none"),
+        },
+        scanner_overrides={
+            "mcp": {
+                "MEDIUM": SeverityAction(file="quarantine", runtime="disable", install="block"),
+                "LOW": SeverityAction(file="none", runtime="disable", install="none"),
+            },
+            "plugin": {
+                "HIGH": SeverityAction(file="quarantine", runtime="disable", install="block"),
+                "MEDIUM": SeverityAction(file="none", runtime="enable", install="none"),
+            },
+        },
+        first_party_allow={
+            ("plugin", "defenseclaw"): ("first-party DefenseClaw plugin", [".defenseclaw", "extensions/defenseclaw"]),
+            ("skill", "codeguard"): ("first-party DefenseClaw skill", [".defenseclaw", "workspace/skills/codeguard", "skills/codeguard"]),
+        },
+    )
+
+
 def evaluate_admission(
     pe: Any,
     *,
@@ -126,7 +154,9 @@ def effective_action_for(
 def load_admission_policy(policy_dir: str) -> AdmissionPolicyData:
     data = _read_policy_data(policy_dir)
     if not data:
-        return AdmissionPolicyData()
+        return _default_admission_policy()
+
+    defaults = _default_admission_policy()
 
     cfg = data.get("config", {}) or {}
     raw_actions = data.get("actions", {}) or {}
@@ -149,7 +179,7 @@ def load_admission_policy(policy_dir: str) -> AdmissionPolicyData:
             if isinstance(raw, dict)
         }
 
-    first_party_allow: dict[tuple[str, str], tuple[str, list[str]]] = {}
+    first_party_allow: dict[tuple[str, str], tuple[str, list[str]]] = dict(defaults.first_party_allow)
     for entry in first_party:
         if not isinstance(entry, dict):
             continue
@@ -162,11 +192,21 @@ def load_admission_policy(policy_dir: str) -> AdmissionPolicyData:
                 source_path_contains = []
             first_party_allow[(target_type, target_name)] = (reason, source_path_contains)
 
+    merged_actions = dict(defaults.actions)
+    merged_actions.update(actions)
+
+    merged_overrides = {
+        target_type: dict(overrides)
+        for target_type, overrides in defaults.scanner_overrides.items()
+    }
+    for target_type, overrides in scanner_overrides.items():
+        merged_overrides.setdefault(target_type, {}).update(overrides)
+
     return AdmissionPolicyData(
-        allow_list_bypass_scan=bool(cfg.get("allow_list_bypass_scan", True)),
-        scan_on_install=bool(cfg.get("scan_on_install", True)),
-        actions=actions,
-        scanner_overrides=scanner_overrides,
+        allow_list_bypass_scan=bool(cfg.get("allow_list_bypass_scan", defaults.allow_list_bypass_scan)),
+        scan_on_install=bool(cfg.get("scan_on_install", defaults.scan_on_install)),
+        actions=merged_actions,
+        scanner_overrides=merged_overrides,
         first_party_allow=first_party_allow,
     )
 

--- a/cli/defenseclaw/enforce/policy.py
+++ b/cli/defenseclaw/enforce/policy.py
@@ -53,8 +53,17 @@ class PolicyEngine:
             self.store.set_action_field(target_type, name, "install", "block", reason)
 
     def allow(self, target_type: str, name: str, reason: str) -> None:
-        if self.store:
-            self.store.set_action_field(target_type, name, "install", "allow", reason)
+        """Set install=allow and clear residual file/runtime enforcement.
+
+        Mirrors internal/enforce/policy.go Allow() exactly: after allowing,
+        quarantine and disable state are removed so the allow takes full
+        effect.  Only a manual block() can override an allow entry.
+        """
+        if not self.store:
+            return
+        self.store.set_action_field(target_type, name, "install", "allow", reason)
+        self.store.clear_action_field(target_type, name, "file")
+        self.store.clear_action_field(target_type, name, "runtime")
 
     def unblock(self, target_type: str, name: str) -> None:
         if self.store:
@@ -147,10 +156,16 @@ class PolicyEngine:
             self.store.set_action_field("tool", target, "install", "block", reason)
 
     def allow_tool(self, tool_name: str, source: str, reason: str) -> None:
-        """Allow a tool, optionally scoped to a source."""
-        if self.store:
-            target = f"{source}/{tool_name}" if source else tool_name
-            self.store.set_action_field("tool", target, "install", "allow", reason)
+        """Allow a tool, optionally scoped to a source.
+
+        Uses the same cleanup pattern as allow() for consistency.
+        """
+        if not self.store:
+            return
+        target = f"{source}/{tool_name}" if source else tool_name
+        self.store.set_action_field("tool", target, "install", "allow", reason)
+        self.store.clear_action_field("tool", target, "file")
+        self.store.clear_action_field("tool", target, "runtime")
 
     def list_blocked_tools(self) -> list[ActionEntry]:
         """List all tool-level block entries."""

--- a/cli/defenseclaw/guardrail.py
+++ b/cli/defenseclaw/guardrail.py
@@ -445,6 +445,11 @@ def _register_plugin_in_config(openclaw_config: str, source_dir: str) -> None:
     if install_path not in paths:
         paths.append(install_path)
 
+    # plugins.allow — required when an allowlist is active
+    allow = plugins.setdefault("allow", [])
+    if "defenseclaw" not in allow:
+        allow.append("defenseclaw")
+
     # plugins.installs — record install metadata
     version = "0.0.0"
     try:

--- a/cli/defenseclaw/inventory/claw_inventory.py
+++ b/cli/defenseclaw/inventory/claw_inventory.py
@@ -240,6 +240,19 @@ def enrich_with_policy(
 enrich_skills_with_policy = enrich_with_policy
 
 
+_FIRST_PARTY_ALLOW_LIST: list[tuple[str, str, str]] = [
+    ("plugin", "defenseclaw", "first-party DefenseClaw plugin"),
+    ("skill", "codeguard", "first-party DefenseClaw skill"),
+]
+
+
+def _is_first_party(target_type: str, name: str) -> str | None:
+    for ft, fn, reason in _FIRST_PARTY_ALLOW_LIST:
+        if ft == target_type and fn == name:
+            return reason
+    return None
+
+
 def _admission_verdict(
     pe: Any,
     target_type: str,
@@ -256,6 +269,10 @@ def _admission_verdict(
     if pe.is_allowed(target_type, name):
         reason = action_entry.reason if action_entry else "allow list"
         return "allowed", reason
+
+    fp_reason = _is_first_party(target_type, name)
+    if fp_reason is not None:
+        return "allowed", fp_reason
 
     if pe.is_quarantined(target_type, name):
         reason = action_entry.reason if action_entry else "quarantined"

--- a/cli/defenseclaw/inventory/claw_inventory.py
+++ b/cli/defenseclaw/inventory/claw_inventory.py
@@ -175,6 +175,7 @@ def enrich_with_policy(
     store: Any,
     skill_actions: SkillActionsConfig | None = None,
     policy_dir: str = "",
+    cfg: Config | None = None,
 ) -> None:
     """Evaluate OPA-style admission gate per item and annotate the inventory.
 
@@ -210,12 +211,20 @@ def enrich_with_policy(
             if not name:
                 continue
 
-            scan_entry = scan_map.get(name)
+            candidates = _inventory_key_candidates(item, target_type, name)
+            scan_entry = _lookup_by_candidates(scan_map, candidates)
+            fallback_actions = _fallback_actions_for(target_type, skill_actions, cfg)
+            action_entry = _lookup_by_candidates(actions_map, candidates)
+            policy_name = _inventory_policy_name(item, target_type, name, action_entry)
+            source_path = _inventory_source_path(
+                item, target_type, candidates, scan_entry, action_entry, cfg,
+            )
             verdict, detail = _admission_verdict(
-                pe, target_type, name,
-                scan_entry, actions_map.get(name),
-                skill_actions,
+                pe, target_type, policy_name,
+                scan_entry, action_entry,
+                fallback_actions,
                 policy_dir=policy_dir,
+                source_path=source_path,
             )
             item["policy_verdict"] = verdict
             item["policy_detail"] = detail
@@ -242,33 +251,18 @@ def enrich_with_policy(
 enrich_skills_with_policy = enrich_with_policy
 
 
-_FIRST_PARTY_ALLOW_LIST: list[tuple[str, str, str]] = [
-    ("plugin", "defenseclaw", "first-party DefenseClaw plugin"),
-    ("skill", "codeguard", "first-party DefenseClaw skill"),
-]
-
-_FIRST_PARTY_SOURCE_PREFIXES: list[str] = [
-    ".defenseclaw",
-    ".openclaw/extensions",
-    ".openclaw/skills",
-]
-
-
-def _is_first_party(target_type: str, name: str, source_path: str = "") -> str | None:
-    """Match by name AND verify source path when available.
-
-    When ``source_path`` is provided, the name match is only trusted if the
-    path contains a known DefenseClaw directory component.  This prevents a
-    third-party skill named "codeguard" from being auto-allowed.
-    """
-    for ft, fn, reason in _FIRST_PARTY_ALLOW_LIST:
-        if ft == target_type and fn == name:
-            if source_path:
-                normalised = source_path.replace("\\", "/").lower()
-                if not any(prefix in normalised for prefix in _FIRST_PARTY_SOURCE_PREFIXES):
-                    return None
-            return reason
-    return None
+def _fallback_actions_for(
+    target_type: str,
+    skill_actions: SkillActionsConfig,
+    cfg: Config | None,
+) -> Any:
+    if target_type == "skill" or cfg is None:
+        return skill_actions
+    if target_type == "plugin":
+        return cfg.plugin_actions
+    if target_type == "mcp":
+        return cfg.mcp_actions
+    return skill_actions
 
 
 def _admission_verdict(
@@ -279,6 +273,7 @@ def _admission_verdict(
     action_entry: ActionEntry | None,
     skill_actions: SkillActionsConfig,
     policy_dir: str = "",
+    source_path: str = "",
 ) -> tuple[str, str]:
     """Replicate admission ordering for offline inventory evaluation."""
     from defenseclaw.enforce.admission import evaluate_admission
@@ -288,6 +283,7 @@ def _admission_verdict(
         policy_dir=policy_dir,
         target_type=target_type,
         name=name,
+        source_path=source_path,
         scan_result=scan_entry,
         action_entry=action_entry,
         fallback_actions=skill_actions,
@@ -300,6 +296,107 @@ def _admission_verdict(
     if decision.verdict == "allowed" and action_entry is None and decision.source == "manual-allow":
         return "allowed", "allow list"
     return decision.verdict, decision.reason
+
+
+def _inventory_source_path(
+    item: dict[str, Any],
+    target_type: str,
+    candidates: list[str],
+    scan_entry: dict[str, Any] | None,
+    action_entry: ActionEntry | None,
+    cfg: Config | None,
+) -> str:
+    import os
+
+    if action_entry is not None and action_entry.source_path:
+        return action_entry.source_path
+
+    for key in ("path", "baseDir", "filePath", "scan_target", "url", "command"):
+        raw = item.get(key)
+        if raw:
+            return str(raw)
+
+    if cfg is None:
+        if scan_entry is not None and scan_entry.get("target"):
+            return str(scan_entry["target"])
+        return ""
+
+    if target_type == "skill":
+        for skill_name in candidates:
+            for skill_dir in cfg.skill_dirs():
+                candidate = os.path.join(skill_dir, skill_name)
+                if os.path.isdir(candidate):
+                    return candidate
+    elif target_type == "plugin":
+        for plugin_name in candidates:
+            for plugin_dir in cfg.plugin_dirs():
+                candidate = os.path.join(plugin_dir, plugin_name)
+                if os.path.isdir(candidate):
+                    return candidate
+
+    if scan_entry is not None and scan_entry.get("target"):
+        return str(scan_entry["target"])
+
+    return ""
+
+
+def _inventory_key_candidates(
+    item: dict[str, Any],
+    target_type: str,
+    name: str,
+) -> list[str]:
+    import os
+
+    candidates: list[str] = []
+
+    def add(raw: Any) -> None:
+        val = str(raw or "").strip()
+        if val and val not in candidates:
+            candidates.append(val)
+
+    add(name)
+    add(os.path.basename(name.rstrip("/")))
+
+    if target_type == "plugin":
+        plugin_name = item.get("name", "")
+        add(plugin_name)
+        add(os.path.basename(str(plugin_name).rstrip("/")))
+    elif target_type == "mcp":
+        add(item.get("url", ""))
+        add(item.get("command", ""))
+
+    return candidates
+
+
+def _inventory_policy_name(
+    item: dict[str, Any],
+    target_type: str,
+    name: str,
+    action_entry: ActionEntry | None,
+) -> str:
+    import os
+
+    if action_entry is not None and action_entry.target_name:
+        return action_entry.target_name
+
+    if target_type == "plugin":
+        plugin_name = str(item.get("name", "")).strip()
+        alias = os.path.basename(plugin_name.rstrip("/"))
+        if alias and (
+            plugin_name.startswith("@")
+            or alias.endswith("-plugin")
+            or alias.endswith("-provider")
+        ):
+            return alias
+
+    return name
+
+
+def _lookup_by_candidates(mapping: dict[str, Any], candidates: list[str]) -> Any | None:
+    for candidate in candidates:
+        if candidate in mapping:
+            return mapping[candidate]
+    return None
 
 
 def _build_actions_map_for_type(store: Any, target_type: str) -> dict[str, ActionEntry]:
@@ -322,12 +419,15 @@ def _build_scan_map_for_type(store: Any, scanner_name: str) -> dict[str, dict[st
     except Exception:
         return scan_map
     for ls in latest:
-        name = os.path.basename(ls["target"])
-        scan_map[name] = {
+        entry = {
             "target": ls["target"],
             "finding_count": ls["finding_count"],
             "max_severity": ls["max_severity"] or "INFO",
         }
+        target = ls["target"]
+        for key in (target, os.path.basename(target)):
+            if key:
+                scan_map[key] = entry
     return scan_map
 
 

--- a/cli/defenseclaw/inventory/claw_inventory.py
+++ b/cli/defenseclaw/inventory/claw_inventory.py
@@ -174,6 +174,7 @@ def enrich_with_policy(
     inv: dict[str, Any],
     store: Any,
     skill_actions: SkillActionsConfig | None = None,
+    policy_dir: str = "",
 ) -> None:
     """Evaluate OPA-style admission gate per item and annotate the inventory.
 
@@ -214,6 +215,7 @@ def enrich_with_policy(
                 pe, target_type, name,
                 scan_entry, actions_map.get(name),
                 skill_actions,
+                policy_dir=policy_dir,
             )
             item["policy_verdict"] = verdict
             item["policy_detail"] = detail
@@ -245,10 +247,26 @@ _FIRST_PARTY_ALLOW_LIST: list[tuple[str, str, str]] = [
     ("skill", "codeguard", "first-party DefenseClaw skill"),
 ]
 
+_FIRST_PARTY_SOURCE_PREFIXES: list[str] = [
+    ".defenseclaw",
+    ".openclaw/extensions",
+    ".openclaw/skills",
+]
 
-def _is_first_party(target_type: str, name: str) -> str | None:
+
+def _is_first_party(target_type: str, name: str, source_path: str = "") -> str | None:
+    """Match by name AND verify source path when available.
+
+    When ``source_path`` is provided, the name match is only trusted if the
+    path contains a known DefenseClaw directory component.  This prevents a
+    third-party skill named "codeguard" from being auto-allowed.
+    """
     for ft, fn, reason in _FIRST_PARTY_ALLOW_LIST:
         if ft == target_type and fn == name:
+            if source_path:
+                normalised = source_path.replace("\\", "/").lower()
+                if not any(prefix in normalised for prefix in _FIRST_PARTY_SOURCE_PREFIXES):
+                    return None
             return reason
     return None
 
@@ -260,38 +278,28 @@ def _admission_verdict(
     scan_entry: dict[str, Any] | None,
     action_entry: ActionEntry | None,
     skill_actions: SkillActionsConfig,
+    policy_dir: str = "",
 ) -> tuple[str, str]:
-    """Replicate OPA admission.rego logic in Python for offline evaluation."""
-    if pe.is_blocked(target_type, name):
-        reason = action_entry.reason if action_entry else "block list"
-        return "blocked", reason
+    """Replicate admission ordering for offline inventory evaluation."""
+    from defenseclaw.enforce.admission import evaluate_admission
 
-    if pe.is_allowed(target_type, name):
-        reason = action_entry.reason if action_entry else "allow list"
-        return "allowed", reason
-
-    fp_reason = _is_first_party(target_type, name)
-    if fp_reason is not None:
-        return "allowed", fp_reason
-
-    if pe.is_quarantined(target_type, name):
-        reason = action_entry.reason if action_entry else "quarantined"
-        return "rejected", f"quarantined: {reason}"
-
-    if scan_entry is None:
+    decision = evaluate_admission(
+        pe,
+        policy_dir=policy_dir,
+        target_type=target_type,
+        name=name,
+        scan_result=scan_entry,
+        action_entry=action_entry,
+        fallback_actions=skill_actions,
+        include_quarantine=True,
+    )
+    if decision.verdict == "scan":
         return "unscanned", "no scan result"
-
-    if scan_entry["finding_count"] == 0:
-        return "clean", "scan clean"
-
-    sev = scan_entry["max_severity"]
-    n = scan_entry["finding_count"]
-    action = skill_actions.for_severity(sev)
-
-    if action.install == "block" or action.runtime == "disable":
-        return "rejected", f"{n} findings, max {sev}"
-
-    return "warning", f"{n} findings, max {sev}"
+    if decision.verdict == "blocked" and action_entry is None:
+        return "blocked", "block list"
+    if decision.verdict == "allowed" and action_entry is None and decision.source == "manual-allow":
+        return "allowed", "allow list"
+    return decision.verdict, decision.reason
 
 
 def _build_actions_map_for_type(store: Any, target_type: str) -> dict[str, ActionEntry]:

--- a/cli/defenseclaw/scanner/mcp.py
+++ b/cli/defenseclaw/scanner/mcp.py
@@ -114,11 +114,14 @@ class MCPScannerWrapper:
         aid = self.cisco_ai_defense
         self._inject_env()
 
+        llm_model = llm.model
+        if llm_model and llm.provider and "/" not in llm_model:
+            llm_model = f"{llm.provider}/{llm_model}"
         sdk_config = MCPConfig(
             api_key=aid.resolved_api_key(),
             endpoint_url=aid.endpoint,
             llm_provider_api_key=llm.resolved_api_key(),
-            llm_model=llm.model,
+            llm_model=llm_model,
             llm_base_url=self._resolve_llm_base_url(),
             llm_timeout=llm.timeout,
             llm_max_retries=llm.max_retries,

--- a/cli/defenseclaw/scanner/skill.py
+++ b/cli/defenseclaw/scanner/skill.py
@@ -84,7 +84,10 @@ class SkillScannerWrapper:
         if cfg.use_llm:
             build_kwargs["use_llm"] = True
             if llm.model:
-                build_kwargs["llm_model"] = llm.model
+                model = llm.model
+                if llm.provider and "/" not in model:
+                    model = f"{llm.provider}/{model}"
+                build_kwargs["llm_model"] = model
             if llm.provider:
                 build_kwargs["llm_provider"] = llm.provider
             api_key = llm.resolved_api_key()
@@ -115,9 +118,12 @@ class SkillScannerWrapper:
         cfg = self.config
         llm = self.inspect_llm
         aid = self.cisco_ai_defense
+        llm_model = llm.model
+        if llm_model and llm.provider and "/" not in llm_model:
+            llm_model = f"{llm.provider}/{llm_model}"
         mappings = [
             ("SKILL_SCANNER_LLM_API_KEY", llm.resolved_api_key()),
-            ("SKILL_SCANNER_LLM_MODEL", llm.model),
+            ("SKILL_SCANNER_LLM_MODEL", llm_model),
             ("VIRUSTOTAL_API_KEY", cfg.resolved_virustotal_api_key()),
             ("AI_DEFENSE_API_KEY", aid.resolved_api_key()),
         ]

--- a/cli/tests/test_admission.py
+++ b/cli/tests/test_admission.py
@@ -1,0 +1,370 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the centralized admission evaluation helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from defenseclaw.config import SeverityAction
+from defenseclaw.enforce.admission import (
+    AdmissionPolicyData,
+    effective_action_for,
+    evaluate_admission,
+    load_admission_policy,
+)
+from defenseclaw.enforce.policy import PolicyEngine
+
+from tests.helpers import make_temp_store
+
+
+class _StoreTestBase(unittest.TestCase):
+    def setUp(self):
+        self.store, self.db_path = make_temp_store()
+        self.pe = PolicyEngine(self.store)
+        self.policy_dir = tempfile.mkdtemp(prefix="dclaw-policy-")
+        rego_dir = os.path.join(self.policy_dir, "rego")
+        os.makedirs(rego_dir, exist_ok=True)
+        self._write_data_json(rego_dir, {
+            "config": {
+                "allow_list_bypass_scan": True,
+                "scan_on_install": True,
+            },
+            "actions": {
+                "CRITICAL": {"runtime": "block", "file": "quarantine", "install": "block"},
+                "HIGH": {"runtime": "block", "file": "quarantine", "install": "block"},
+                "MEDIUM": {"runtime": "allow", "file": "none", "install": "none"},
+                "LOW": {"runtime": "allow", "file": "none", "install": "none"},
+                "INFO": {"runtime": "allow", "file": "none", "install": "none"},
+            },
+            "first_party_allow_list": [
+                {"target_type": "plugin", "target_name": "defenseclaw", "reason": "first-party"},
+            ],
+        })
+
+    def _write_data_json(self, rego_dir, data):
+        with open(os.path.join(rego_dir, "data.json"), "w") as f:
+            json.dump(data, f)
+
+    def tearDown(self):
+        self.store.close()
+        os.unlink(self.db_path)
+
+
+class TestEvaluateAdmissionBlocked(_StoreTestBase):
+    def test_blocked_item_returns_blocked(self):
+        self.pe.block("skill", "evil", "malware")
+        d = evaluate_admission(self.pe, policy_dir=self.policy_dir,
+                               target_type="skill", name="evil")
+        self.assertEqual(d.verdict, "blocked")
+        self.assertEqual(d.source, "manual-block")
+
+    def test_blocked_after_allow_then_block(self):
+        """Block after allow should leave the item blocked (last-write wins)."""
+        self.pe.allow("skill", "dual", "good")
+        self.pe.block("skill", "dual", "bad")
+        d = evaluate_admission(self.pe, policy_dir=self.policy_dir,
+                               target_type="skill", name="dual")
+        self.assertEqual(d.verdict, "blocked")
+
+
+class TestEvaluateAdmissionAllowed(_StoreTestBase):
+    def test_explicit_allow_skips_scan(self):
+        self.pe.allow("skill", "trusted", "vendor")
+        d = evaluate_admission(self.pe, policy_dir=self.policy_dir,
+                               target_type="skill", name="trusted")
+        self.assertEqual(d.verdict, "allowed")
+        self.assertEqual(d.source, "manual-allow")
+
+    def test_first_party_allow_bypasses_scan(self):
+        d = evaluate_admission(self.pe, policy_dir=self.policy_dir,
+                               target_type="plugin", name="defenseclaw")
+        self.assertEqual(d.verdict, "allowed")
+        self.assertEqual(d.source, "policy-allow")
+
+
+class TestEvaluateAdmissionFirstPartyProvenance(_StoreTestBase):
+    def setUp(self):
+        super().setUp()
+        rego_dir = os.path.join(self.policy_dir, "rego")
+        self._write_data_json(rego_dir, {
+            "config": {
+                "allow_list_bypass_scan": True,
+                "scan_on_install": True,
+            },
+            "actions": {},
+            "first_party_allow_list": [
+                {
+                    "target_type": "plugin",
+                    "target_name": "defenseclaw",
+                    "reason": "first-party",
+                    "source_path_contains": [".defenseclaw", ".openclaw/extensions"],
+                },
+            ],
+        })
+
+    def test_matching_path_allows(self):
+        d = evaluate_admission(
+            self.pe, policy_dir=self.policy_dir,
+            target_type="plugin", name="defenseclaw",
+            source_path="/home/user/.openclaw/extensions/defenseclaw",
+        )
+        self.assertEqual(d.verdict, "allowed")
+        self.assertEqual(d.source, "policy-allow")
+
+    def test_non_matching_path_falls_through(self):
+        d = evaluate_admission(
+            self.pe, policy_dir=self.policy_dir,
+            target_type="plugin", name="defenseclaw",
+            source_path="/home/user/random/plugins/something",
+        )
+        self.assertEqual(d.verdict, "scan")
+        self.assertEqual(d.source, "scan-required")
+
+    def test_temp_dir_falls_through(self):
+        d = evaluate_admission(
+            self.pe, policy_dir=self.policy_dir,
+            target_type="plugin", name="defenseclaw",
+            source_path="/tmp/dclaw-plugin-fetch-abc123/defenseclaw",
+        )
+        self.assertEqual(d.verdict, "scan")
+        self.assertEqual(d.source, "scan-required")
+
+    def test_empty_path_falls_through(self):
+        d = evaluate_admission(
+            self.pe, policy_dir=self.policy_dir,
+            target_type="plugin", name="defenseclaw",
+            source_path="",
+        )
+        self.assertEqual(d.verdict, "scan")
+        self.assertEqual(d.source, "scan-required")
+
+
+class TestEvaluateAdmissionFirstPartyNoBypass(_StoreTestBase):
+    def setUp(self):
+        super().setUp()
+        rego_dir = os.path.join(self.policy_dir, "rego")
+        self._write_data_json(rego_dir, {
+            "config": {
+                "allow_list_bypass_scan": False,
+                "scan_on_install": True,
+            },
+            "actions": {},
+            "first_party_allow_list": [
+                {"target_type": "plugin", "target_name": "defenseclaw", "reason": "first-party"},
+            ],
+        })
+
+    def test_first_party_requires_scan_when_bypass_disabled(self):
+        d = evaluate_admission(self.pe, policy_dir=self.policy_dir,
+                               target_type="plugin", name="defenseclaw")
+        self.assertEqual(d.verdict, "scan")
+        self.assertEqual(d.source, "scan-required")
+
+
+class TestEvaluateAdmissionScanDisabled(_StoreTestBase):
+    def setUp(self):
+        super().setUp()
+        rego_dir = os.path.join(self.policy_dir, "rego")
+        self._write_data_json(rego_dir, {
+            "config": {
+                "allow_list_bypass_scan": True,
+                "scan_on_install": False,
+            },
+            "actions": {},
+        })
+
+    def test_scan_disabled_allows_without_scan(self):
+        d = evaluate_admission(self.pe, policy_dir=self.policy_dir,
+                               target_type="skill", name="new-skill")
+        self.assertEqual(d.verdict, "allowed")
+        self.assertEqual(d.source, "scan-disabled")
+
+
+class TestEvaluateAdmissionRequiresScan(_StoreTestBase):
+    def test_no_scan_result_returns_scan_required(self):
+        d = evaluate_admission(self.pe, policy_dir=self.policy_dir,
+                               target_type="skill", name="new-skill")
+        self.assertEqual(d.verdict, "scan")
+
+
+class TestEvaluateAdmissionWithScanResult(_StoreTestBase):
+    def _make_scan_result(self, findings, max_severity):
+        class FakeScanResult:
+            def __init__(self, findings, sev):
+                self.findings = findings
+                self._sev = sev
+            def max_severity(self):
+                return self._sev
+        return FakeScanResult(findings, max_severity)
+
+    def test_clean_scan(self):
+        result = self._make_scan_result([], "INFO")
+        d = evaluate_admission(self.pe, policy_dir=self.policy_dir,
+                               target_type="skill", name="safe",
+                               scan_result=result)
+        self.assertEqual(d.verdict, "clean")
+        self.assertEqual(d.source, "scan-clean")
+
+    def test_high_severity_rejected(self):
+        result = self._make_scan_result([{"severity": "HIGH"}], "HIGH")
+        d = evaluate_admission(self.pe, policy_dir=self.policy_dir,
+                               target_type="skill", name="risky",
+                               scan_result=result)
+        self.assertEqual(d.verdict, "rejected")
+        self.assertEqual(d.source, "scan-rejected")
+        self.assertEqual(d.action.install, "block")
+        self.assertEqual(d.action.runtime, "disable")
+
+    def test_medium_severity_warning(self):
+        result = self._make_scan_result([{"severity": "MEDIUM"}], "MEDIUM")
+        d = evaluate_admission(self.pe, policy_dir=self.policy_dir,
+                               target_type="skill", name="iffy",
+                               scan_result=result)
+        self.assertEqual(d.verdict, "warning")
+        self.assertEqual(d.source, "scan-warning")
+
+    def test_install_block_alone_rejects(self):
+        rego_dir = os.path.join(self.policy_dir, "rego")
+        self._write_data_json(rego_dir, {
+            "config": {"allow_list_bypass_scan": True, "scan_on_install": True},
+            "actions": {
+                "HIGH": {"runtime": "allow", "file": "none", "install": "block"},
+            },
+        })
+        result = self._make_scan_result([{"severity": "HIGH"}], "HIGH")
+        d = evaluate_admission(self.pe, policy_dir=self.policy_dir,
+                               target_type="skill", name="partial",
+                               scan_result=result)
+        self.assertEqual(d.verdict, "rejected")
+
+
+class TestEvaluateAdmissionDictScanResult(_StoreTestBase):
+    def test_dict_scan_result_clean(self):
+        d = evaluate_admission(
+            self.pe, policy_dir=self.policy_dir,
+            target_type="skill", name="safe",
+            scan_result={"total_findings": 0, "max_severity": "INFO"},
+        )
+        self.assertEqual(d.verdict, "clean")
+
+    def test_dict_scan_result_with_findings(self):
+        d = evaluate_admission(
+            self.pe, policy_dir=self.policy_dir,
+            target_type="skill", name="risky",
+            scan_result={"total_findings": 2, "max_severity": "HIGH"},
+        )
+        self.assertEqual(d.verdict, "rejected")
+
+
+class TestEvaluateAdmissionQuarantine(_StoreTestBase):
+    def test_quarantined_item_rejected_when_flag_set(self):
+        self.pe.quarantine("skill", "qskill", "scan findings")
+        d = evaluate_admission(self.pe, policy_dir=self.policy_dir,
+                               target_type="skill", name="qskill",
+                               include_quarantine=True)
+        self.assertEqual(d.verdict, "rejected")
+        self.assertEqual(d.source, "quarantine")
+
+    def test_quarantined_item_not_checked_without_flag(self):
+        self.pe.quarantine("skill", "qskill", "scan findings")
+        d = evaluate_admission(self.pe, policy_dir=self.policy_dir,
+                               target_type="skill", name="qskill")
+        self.assertEqual(d.verdict, "scan")
+
+
+class TestEffectiveActionFor(unittest.TestCase):
+    def test_global_action(self):
+        policy = AdmissionPolicyData(
+            actions={"HIGH": SeverityAction(file="quarantine", runtime="disable", install="block")},
+        )
+        action = effective_action_for(policy, target_type="skill", severity="HIGH")
+        self.assertEqual(action.install, "block")
+
+    def test_scanner_override_takes_precedence(self):
+        policy = AdmissionPolicyData(
+            actions={"MEDIUM": SeverityAction(runtime="enable", install="none")},
+            scanner_overrides={
+                "mcp": {"MEDIUM": SeverityAction(runtime="disable", install="block")},
+            },
+        )
+        action = effective_action_for(policy, target_type="mcp", severity="MEDIUM")
+        self.assertEqual(action.install, "block")
+
+        skill_action = effective_action_for(policy, target_type="skill", severity="MEDIUM")
+        self.assertEqual(skill_action.install, "none")
+
+    def test_unknown_severity_returns_default(self):
+        policy = AdmissionPolicyData()
+        action = effective_action_for(policy, target_type="skill", severity="UNKNOWN")
+        self.assertEqual(action.install, "none")
+
+    def test_fallback_actions_used(self):
+        from defenseclaw.config import SkillActionsConfig
+        policy = AdmissionPolicyData()
+        fallback = SkillActionsConfig(
+            high=SeverityAction(install="block", runtime="disable", file="quarantine"),
+        )
+        action = effective_action_for(policy, target_type="skill", severity="HIGH",
+                                      fallback_actions=fallback)
+        self.assertEqual(action.install, "block")
+
+
+class TestLoadAdmissionPolicy(unittest.TestCase):
+    def test_missing_dir_returns_defaults(self):
+        policy = load_admission_policy("/nonexistent")
+        self.assertTrue(policy.allow_list_bypass_scan)
+        self.assertTrue(policy.scan_on_install)
+        self.assertEqual(len(policy.actions), 0)
+
+    def test_valid_data_json(self):
+        tmp = tempfile.mkdtemp()
+        rego_dir = os.path.join(tmp, "rego")
+        os.makedirs(rego_dir)
+        with open(os.path.join(rego_dir, "data.json"), "w") as f:
+            json.dump({
+                "config": {"allow_list_bypass_scan": False, "scan_on_install": False},
+                "actions": {"MEDIUM": {"runtime": "block", "file": "quarantine", "install": "block"}},
+                "first_party_allow_list": [
+                    {"target_type": "skill", "target_name": "codeguard", "reason": "first-party"},
+                ],
+            }, f)
+        policy = load_admission_policy(tmp)
+        self.assertFalse(policy.allow_list_bypass_scan)
+        self.assertFalse(policy.scan_on_install)
+        self.assertIn("MEDIUM", policy.actions)
+        self.assertEqual(policy.actions["MEDIUM"].runtime, "disable")
+        self.assertIn(("skill", "codeguard"), policy.first_party_allow)
+
+    def test_invalid_json_returns_defaults(self):
+        tmp = tempfile.mkdtemp()
+        rego_dir = os.path.join(tmp, "rego")
+        os.makedirs(rego_dir)
+        with open(os.path.join(rego_dir, "data.json"), "w") as f:
+            f.write("{not json")
+        policy = load_admission_policy(tmp)
+        self.assertTrue(policy.allow_list_bypass_scan)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/tests/test_admission.py
+++ b/cli/tests/test_admission.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import sys
 import tempfile
 import unittest
@@ -69,6 +70,7 @@ class _StoreTestBase(unittest.TestCase):
     def tearDown(self):
         self.store.close()
         os.unlink(self.db_path)
+        shutil.rmtree(self.policy_dir, ignore_errors=True)
 
 
 class TestEvaluateAdmissionBlocked(_StoreTestBase):
@@ -158,6 +160,31 @@ class TestEvaluateAdmissionFirstPartyProvenance(_StoreTestBase):
         )
         self.assertEqual(d.verdict, "scan")
         self.assertEqual(d.source, "scan-required")
+
+    def test_workspace_codeguard_path_allows(self):
+        rego_dir = os.path.join(self.policy_dir, "rego")
+        self._write_data_json(rego_dir, {
+            "config": {
+                "allow_list_bypass_scan": True,
+                "scan_on_install": True,
+            },
+            "actions": {},
+            "first_party_allow_list": [
+                {
+                    "target_type": "skill",
+                    "target_name": "codeguard",
+                    "reason": "first-party",
+                    "source_path_contains": [".openclaw/workspace/skills", ".openclaw/skills"],
+                },
+            ],
+        })
+        d = evaluate_admission(
+            self.pe, policy_dir=self.policy_dir,
+            target_type="skill", name="codeguard",
+            source_path="/home/user/.openclaw/workspace/skills/codeguard",
+        )
+        self.assertEqual(d.verdict, "allowed")
+        self.assertEqual(d.source, "policy-allow")
 
 
 class TestEvaluateAdmissionFirstPartyNoBypass(_StoreTestBase):
@@ -335,7 +362,12 @@ class TestLoadAdmissionPolicy(unittest.TestCase):
         policy = load_admission_policy("/nonexistent")
         self.assertTrue(policy.allow_list_bypass_scan)
         self.assertTrue(policy.scan_on_install)
-        self.assertEqual(len(policy.actions), 0)
+        self.assertEqual(policy.actions["HIGH"].install, "block")
+        self.assertEqual(policy.actions["HIGH"].runtime, "disable")
+        self.assertEqual(policy.actions["MEDIUM"].install, "none")
+        self.assertEqual(policy.scanner_overrides["mcp"]["MEDIUM"].install, "block")
+        self.assertIn(("plugin", "defenseclaw"), policy.first_party_allow)
+        self.assertIn(("skill", "codeguard"), policy.first_party_allow)
 
     def test_valid_data_json(self):
         tmp = tempfile.mkdtemp()

--- a/cli/tests/test_claw_inventory.py
+++ b/cli/tests/test_claw_inventory.py
@@ -920,8 +920,9 @@ class TestCLIIntegration(unittest.TestCase):
         runner = CliRunner()
         result = runner.invoke(aibom, ["scan", "--json"], obj=self.app)
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("Warning", result.stderr)
-        self.assertIn("failed", result.stderr)
+        stderr = result.stderr if getattr(result, "stderr_bytes", None) is not None else result.output
+        self.assertIn("Warning", stderr)
+        self.assertIn("failed", stderr)
 
 
 class TestLiveIsFalse(unittest.TestCase):

--- a/cli/tests/test_claw_inventory.py
+++ b/cli/tests/test_claw_inventory.py
@@ -33,7 +33,14 @@ from unittest.mock import patch, MagicMock
 
 from click.testing import CliRunner
 
-from defenseclaw.config import ClawConfig, Config, SkillActionsConfig, SeverityAction
+from defenseclaw.config import (
+    ClawConfig,
+    Config,
+    MCPActionsConfig,
+    PluginActionsConfig,
+    SkillActionsConfig,
+    SeverityAction,
+)
 from defenseclaw.models import ActionEntry, ActionState
 from defenseclaw.inventory.claw_inventory import (
     ALL_CATEGORIES,
@@ -1087,26 +1094,25 @@ class TestAdmissionVerdictClean(_StoreWithPolicyMixin, unittest.TestCase):
 
 
 class TestAdmissionVerdictRejected(_StoreWithPolicyMixin, unittest.TestCase):
-    """CRITICAL/HIGH produce warnings with permissive defaults,
-    but custom strict actions can escalate them to rejected."""
+    """Central policy defaults reject high-severity findings."""
 
-    def test_critical_warning_with_permissive_defaults(self):
+    def test_critical_rejected_by_policy_defaults(self):
         pe = self._pe()
         scan = {"finding_count": 1, "max_severity": "CRITICAL", "target": "/x"}
         verdict, detail = _admission_verdict(
             pe, "skill", "dangerous", scan, None, self.skill_actions,
         )
-        self.assertEqual(verdict, "warning")
+        self.assertEqual(verdict, "rejected")
         self.assertIn("1 findings", detail)
         self.assertIn("CRITICAL", detail)
 
-    def test_high_warning_with_permissive_defaults(self):
+    def test_high_rejected_by_policy_defaults(self):
         pe = self._pe()
         scan = {"finding_count": 5, "max_severity": "HIGH", "target": "/x"}
         verdict, detail = _admission_verdict(
             pe, "plugin", "risky-plugin", scan, None, self.skill_actions,
         )
-        self.assertEqual(verdict, "warning")
+        self.assertEqual(verdict, "rejected")
         self.assertIn("5 findings", detail)
         self.assertIn("HIGH", detail)
 
@@ -1136,7 +1142,7 @@ class TestAdmissionVerdictRejected(_StoreWithPolicyMixin, unittest.TestCase):
 
 
 class TestAdmissionVerdictWarning(_StoreWithPolicyMixin, unittest.TestCase):
-    """MEDIUM/LOW findings produce warnings with default config."""
+    """Policy defaults still warn on medium findings without reject actions."""
 
     def test_warning_medium(self):
         pe = self._pe()
@@ -1148,17 +1154,17 @@ class TestAdmissionVerdictWarning(_StoreWithPolicyMixin, unittest.TestCase):
         self.assertIn("2 findings", detail)
         self.assertIn("MEDIUM", detail)
 
-    def test_warning_low(self):
+    def test_low_mcp_rejected_by_policy_override(self):
         pe = self._pe()
         scan = {"finding_count": 1, "max_severity": "LOW", "target": "/x"}
         verdict, detail = _admission_verdict(
             pe, "mcp", "minor-issues", scan, None, self.skill_actions,
         )
-        self.assertEqual(verdict, "warning")
+        self.assertEqual(verdict, "rejected")
         self.assertIn("LOW", detail)
 
-    def test_custom_actions_can_reject_medium(self):
-        """Custom SkillActionsConfig can escalate MEDIUM to rejected."""
+    def test_custom_actions_do_not_override_loaded_policy_defaults(self):
+        """When centralized policy data is in effect, config fallback actions do not take precedence."""
         pe = self._pe()
         strict = SkillActionsConfig(
             medium=SeverityAction(file="quarantine", runtime="disable", install="block"),
@@ -1167,7 +1173,7 @@ class TestAdmissionVerdictWarning(_StoreWithPolicyMixin, unittest.TestCase):
         verdict, _ = _admission_verdict(
             pe, "skill", "strict-check", scan, None, strict,
         )
-        self.assertEqual(verdict, "rejected")
+        self.assertEqual(verdict, "warning")
 
 
 # ---------------------------------------------------------------------------
@@ -1226,7 +1232,7 @@ class TestBuildScanMap(_StoreWithPolicyMixin, unittest.TestCase):
         self.assertEqual(result["my-skill"]["max_severity"], "HIGH")
 
     def test_basename_keying(self):
-        """Scan targets are keyed by basename, not full path."""
+        """Scan targets are indexed by basename and raw target aliases."""
         import uuid
         from datetime import datetime, timezone
         self.store.insert_scan_result(
@@ -1236,7 +1242,7 @@ class TestBuildScanMap(_StoreWithPolicyMixin, unittest.TestCase):
         )
         result = _build_scan_map_for_type(self.store, "plugin-scanner")
         self.assertIn("web-search", result)
-        self.assertNotIn("/long/path/to/web-search", result)
+        self.assertIn("/long/path/to/web-search", result)
 
     def test_null_severity_defaults_to_info(self):
         import uuid
@@ -1481,7 +1487,7 @@ class TestEnrichWithPolicy(_StoreWithPolicyMixin, unittest.TestCase):
         self.assertEqual(by_id["discord"]["policy_verdict"], "blocked")
         self.assertEqual(by_id["weather"]["policy_verdict"], "clean")
         self.assertEqual(by_id["new-skill"]["policy_verdict"], "unscanned")
-        self.assertEqual(by_id["peekaboo"]["policy_verdict"], "warning")
+        self.assertEqual(by_id["peekaboo"]["policy_verdict"], "rejected")
 
     def test_scan_data_attached_to_items(self):
         self._seed_store()
@@ -1523,6 +1529,202 @@ class TestEnrichWithPolicy(_StoreWithPolicyMixin, unittest.TestCase):
 
         self.assertEqual(inv["mcp"][0]["policy_verdict"], "allowed")
 
+    def test_first_party_allows_use_resolved_inventory_paths(self):
+        import uuid
+        from datetime import datetime, timezone
+
+        tmp = tempfile.mkdtemp(prefix="dc-inventory-policy-")
+        try:
+            cfg = Config(
+                data_dir=os.path.join(tmp, ".defenseclaw"),
+                audit_db=os.path.join(tmp, ".defenseclaw", "audit.db"),
+                quarantine_dir=os.path.join(tmp, "q"),
+                plugin_dir=os.path.join(tmp, "p"),
+                policy_dir=os.path.join(tmp, "pol"),
+                claw=ClawConfig(
+                    mode="openclaw",
+                    home_dir=os.path.join(tmp, ".openclaw"),
+                    config_file=os.path.join(tmp, ".openclaw", "openclaw.json"),
+                ),
+            )
+            os.makedirs(os.path.join(cfg.policy_dir, "rego"), exist_ok=True)
+            with open(os.path.join(cfg.policy_dir, "rego", "data.json"), "w") as f:
+                json.dump({
+                    "config": {"allow_list_bypass_scan": True, "scan_on_install": True},
+                    "actions": {},
+                    "scanner_overrides": {},
+                    "first_party_allow_list": [
+                        {
+                            "target_type": "plugin",
+                            "target_name": "defenseclaw",
+                            "reason": "first-party DefenseClaw plugin",
+                            "source_path_contains": [".openclaw/extensions"],
+                        },
+                        {
+                            "target_type": "skill",
+                            "target_name": "codeguard",
+                            "reason": "first-party DefenseClaw skill",
+                            "source_path_contains": [".openclaw/skills"],
+                        },
+                    ],
+                }, f)
+
+            os.makedirs(os.path.join(cfg.claw.home_dir, "skills", "codeguard"), exist_ok=True)
+            os.makedirs(os.path.join(cfg.claw.home_dir, "extensions", "defenseclaw"), exist_ok=True)
+
+            now = datetime.now(timezone.utc)
+            self.store.insert_scan_result(
+                str(uuid.uuid4()), "skill-scanner", "/tmp/downloads/codeguard",
+                now, 100, 0, "INFO", "{}",
+            )
+            self.store.insert_scan_result(
+                str(uuid.uuid4()), "plugin-scanner", "/tmp/dclaw-plugin-fetch-abc123/defenseclaw",
+                now, 100, 0, "INFO", "{}",
+            )
+
+            inv = {
+                "skills": [{"id": "codeguard", "source": "user"}],
+                "plugins": [{"id": "defenseclaw", "enabled": True}],
+                "mcp": [],
+                "summary": {"skills": {"count": 1}, "plugins": {"count": 1}, "mcp": {"count": 0}},
+            }
+
+            enrich_with_policy(
+                inv, self.store, self.skill_actions,
+                policy_dir=cfg.policy_dir, cfg=cfg,
+            )
+
+            self.assertEqual(inv["skills"][0]["policy_verdict"], "allowed")
+            self.assertEqual(inv["plugins"][0]["policy_verdict"], "allowed")
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_inventory_uses_per_target_fallback_actions_when_policy_missing(self):
+        import uuid
+        from datetime import datetime, timezone
+
+        tmp = tempfile.mkdtemp(prefix="dc-inventory-fallback-")
+        cfg = Config(
+            policy_dir=os.path.join(tmp, "missing-policy"),
+            plugin_actions=PluginActionsConfig(
+                high=SeverityAction(file="quarantine", runtime="disable", install="block"),
+            ),
+            mcp_actions=MCPActionsConfig(
+                high=SeverityAction(file="none", runtime="enable", install="block"),
+            ),
+        )
+
+        now = datetime.now(timezone.utc)
+        self.store.insert_scan_result(
+            str(uuid.uuid4()), "plugin-scanner", "/tmp/plugins/risky-plugin",
+            now, 100, 1, "HIGH", "{}",
+        )
+        self.store.insert_scan_result(
+            str(uuid.uuid4()), "mcp-scanner", "/tmp/mcp/risky-mcp",
+            now, 100, 1, "HIGH", "{}",
+        )
+
+        inv = {
+            "skills": [],
+            "plugins": [{"id": "risky-plugin", "enabled": True}],
+            "mcp": [{"id": "risky-mcp", "transport": "stdio"}],
+            "summary": {"skills": {"count": 0}, "plugins": {"count": 1}, "mcp": {"count": 1}},
+        }
+
+        enrich_with_policy(
+            inv, self.store, self.skill_actions,
+            policy_dir=cfg.policy_dir, cfg=cfg,
+        )
+
+        self.assertEqual(inv["plugins"][0]["policy_verdict"], "rejected")
+        self.assertEqual(inv["mcp"][0]["policy_verdict"], "rejected")
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_plugin_policy_enrichment_uses_install_name_aliases(self):
+        import uuid
+        from datetime import datetime, timezone
+
+        tmp = tempfile.mkdtemp(prefix="dc-inventory-plugin-alias-")
+        try:
+            cfg = Config(
+                data_dir=os.path.join(tmp, ".defenseclaw"),
+                audit_db=os.path.join(tmp, ".defenseclaw", "audit.db"),
+                quarantine_dir=os.path.join(tmp, "q"),
+                plugin_dir=os.path.join(tmp, "p"),
+                policy_dir=os.path.join(tmp, "missing-policy"),
+                claw=ClawConfig(
+                    mode="openclaw",
+                    home_dir=os.path.join(tmp, ".openclaw"),
+                    config_file=os.path.join(tmp, ".openclaw", "openclaw.json"),
+                ),
+            )
+            os.makedirs(os.path.join(cfg.claw.home_dir, "extensions", "xai-plugin"), exist_ok=True)
+
+            pe = self._pe()
+            pe.allow("plugin", "xai-plugin", "reviewed")
+
+            now = datetime.now(timezone.utc)
+            self.store.insert_scan_result(
+                str(uuid.uuid4()), "plugin-scanner",
+                os.path.join(cfg.claw.home_dir, "extensions", "xai-plugin"),
+                now, 100, 1, "MEDIUM", "{}",
+            )
+
+            inv = {
+                "skills": [],
+                "plugins": [{"id": "xai", "name": "@openclaw/xai-plugin", "enabled": True}],
+                "mcp": [],
+                "summary": {"skills": {"count": 0}, "plugins": {"count": 1}, "mcp": {"count": 0}},
+            }
+
+            enrich_with_policy(
+                inv, self.store, self.skill_actions,
+                policy_dir=cfg.policy_dir, cfg=cfg,
+            )
+
+            self.assertEqual(inv["plugins"][0]["policy_verdict"], "allowed")
+            self.assertEqual(inv["plugins"][0]["scan_findings"], 1)
+            self.assertEqual(inv["plugins"][0]["scan_severity"], "MEDIUM")
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_mcp_policy_enrichment_matches_url_scan_targets(self):
+        import uuid
+        from datetime import datetime, timezone
+
+        tmp = tempfile.mkdtemp(prefix="dc-inventory-mcp-url-")
+        try:
+            cfg = Config(
+                policy_dir=os.path.join(tmp, "missing-policy"),
+                mcp_actions=MCPActionsConfig(
+                    high=SeverityAction(file="none", runtime="enable", install="block"),
+                ),
+            )
+
+            now = datetime.now(timezone.utc)
+            self.store.insert_scan_result(
+                str(uuid.uuid4()), "mcp-scanner", "https://example.com/mcp/sse",
+                now, 100, 2, "HIGH", "{}",
+            )
+
+            inv = {
+                "skills": [],
+                "plugins": [],
+                "mcp": [{"id": "remote-mcp", "url": "https://example.com/mcp/sse", "transport": "sse"}],
+                "summary": {"skills": {"count": 0}, "plugins": {"count": 0}, "mcp": {"count": 1}},
+            }
+
+            enrich_with_policy(
+                inv, self.store, self.skill_actions,
+                policy_dir=cfg.policy_dir, cfg=cfg,
+            )
+
+            self.assertEqual(inv["mcp"][0]["policy_verdict"], "rejected")
+            self.assertEqual(inv["mcp"][0]["scan_findings"], 2)
+            self.assertEqual(inv["mcp"][0]["scan_severity"], "HIGH")
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
     def test_summary_policy_counts(self):
         self._seed_store()
         inv = self._make_inventory()
@@ -1532,8 +1734,8 @@ class TestEnrichWithPolicy(_StoreWithPolicyMixin, unittest.TestCase):
         self.assertEqual(ps["blocked"], 1)
         self.assertEqual(ps["allowed"], 1)
         self.assertEqual(ps["clean"], 1)
-        self.assertEqual(ps.get("rejected", 0), 0)
-        self.assertEqual(ps["warning"], 1)
+        self.assertEqual(ps["rejected"], 1)
+        self.assertEqual(ps.get("warning", 0), 0)
         self.assertEqual(ps["unscanned"], 1)
 
         pp = inv["summary"]["policy_plugins"]

--- a/cli/tests/test_cmd_mcp.py
+++ b/cli/tests/test_cmd_mcp.py
@@ -95,6 +95,38 @@ class TestMCPAllow(MCPCommandTestBase):
         self.assertIn("Already allowed", result.output)
 
 
+class TestMCPUnblock(MCPCommandTestBase):
+    def test_unblock_clears_blocked(self):
+        pe = PolicyEngine(self.app.store)
+        pe.block("mcp", "http://evil.com", "bad")
+
+        result = self.invoke(["unblock", "http://evil.com"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("cleared", result.output)
+        self.assertFalse(pe.is_blocked("mcp", "http://evil.com"))
+
+    def test_unblock_no_state(self):
+        result = self.invoke(["unblock", "http://clean.com"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("no enforcement state", result.output)
+
+    def test_unblock_does_not_add_to_allow_list(self):
+        pe = PolicyEngine(self.app.store)
+        pe.block("mcp", "http://evil.com", "bad")
+
+        self.invoke(["unblock", "http://evil.com"])
+        self.assertFalse(pe.is_allowed("mcp", "http://evil.com"))
+
+    def test_unblock_logs_action(self):
+        pe = PolicyEngine(self.app.store)
+        pe.block("mcp", "http://log-me.com", "test")
+
+        self.invoke(["unblock", "http://log-me.com"])
+        events = self.app.store.list_events(10)
+        actions = [e for e in events if e.action == "mcp-unblock"]
+        self.assertEqual(len(actions), 1)
+
+
 class TestMCPScan(MCPCommandTestBase):
     @patch("defenseclaw.scanner.mcp.MCPScannerWrapper.scan")
     def test_scan_clean(self, mock_scan):

--- a/cli/tests/test_cmd_plugin.py
+++ b/cli/tests/test_cmd_plugin.py
@@ -257,6 +257,48 @@ class TestPluginAllow(PluginCommandTestBase):
         events = [e for e in self.app.store.list_events(10) if e.action == "plugin-allow"]
         self.assertEqual(len(events), 1)
 
+    @patch("defenseclaw.gateway.OrchestratorClient")
+    def test_allow_reenables_runtime_disable_before_clearing_db(self, mock_cls):
+        pe = PolicyEngine(self.app.store)
+        pe.disable("plugin", "safe-plugin", "runtime blocked")
+
+        mock_cls.return_value.enable_plugin.return_value = {"status": "enabled"}
+
+        result = self.invoke(["allow", "safe-plugin", "--reason", "reviewed"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertTrue(pe.is_allowed("plugin", "safe-plugin"))
+        self.assertFalse(self.app.store.has_action("plugin", "safe-plugin", "runtime", "disable"))
+        mock_cls.return_value.enable_plugin.assert_called_once_with("safe-plugin")
+
+    @patch("defenseclaw.gateway.OrchestratorClient")
+    def test_allow_preserves_runtime_disable_when_gateway_enable_fails(self, mock_cls):
+        pe = PolicyEngine(self.app.store)
+        pe.disable("plugin", "safe-plugin", "runtime blocked")
+
+        mock_cls.return_value.enable_plugin.side_effect = Exception("timeout")
+
+        result = self.invoke(["allow", "safe-plugin", "--reason", "reviewed"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("gateway enable failed", result.output)
+        self.assertIn("runtime disable remains until the gateway is reachable", result.output)
+        self.assertTrue(pe.is_allowed("plugin", "safe-plugin"))
+        self.assertTrue(self.app.store.has_action("plugin", "safe-plugin", "runtime", "disable"))
+
+    @patch("defenseclaw.commands.cmd_plugin._list_openclaw_plugins")
+    @patch("defenseclaw.gateway.OrchestratorClient")
+    def test_allow_scoped_name_clears_resolved_runtime_disable(self, mock_cls, mock_list):
+        mock_list.return_value = [{"id": "xai", "name": "@openclaw/xai-plugin"}]
+        pe = PolicyEngine(self.app.store)
+        pe.disable("plugin", "xai", "runtime blocked")
+
+        mock_cls.return_value.enable_plugin.return_value = {"status": "enabled"}
+
+        result = self.invoke(["allow", "@openclaw/xai-plugin", "--reason", "reviewed"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_cls.return_value.enable_plugin.assert_called_once_with("xai")
+        self.assertFalse(self.app.store.has_action("plugin", "xai", "runtime", "disable"))
+        self.assertTrue(pe.is_allowed("plugin", "xai-plugin"))
+
 
 class TestResolveOpenclawPluginId(unittest.TestCase):
     """Tests for _resolve_openclaw_plugin_id name resolution."""
@@ -759,17 +801,18 @@ class TestPluginRegistryInstall(PluginCommandTestBase):
 
     @patch("defenseclaw.scanner.plugin.PluginScannerWrapper.scan")
     @patch("defenseclaw.registry.fetch_npm_package")
-    def test_install_action_permissive_defaults_warns_on_critical(self, mock_fetch, mock_scan):
-        """With permissive default plugin_actions, --action on CRITICAL warns and installs."""
+    def test_install_action_policy_defaults_block_critical(self, mock_fetch, mock_scan):
+        """Without explicit policy data, seeded admission defaults still block CRITICAL plugins."""
         mock_scan.return_value = self._critical_scan_result()
         src = self._create_plugin_dir("danger-pkg")
         mock_fetch.return_value = src
 
         result = self._invoke_install(["install", "--action", "danger-pkg"])
 
-        self.assertEqual(result.exit_code, 0, result.output)
-        self.assertIn("warning", result.output)
-        self.assertIn("Installed plugin: danger-pkg", result.output)
+        self.assertEqual(result.exit_code, 1, result.output)
+        self.assertIn("added to block list", result.output)
+        self.assertIn("quarantined", result.output)
+        self.assertFalse(os.path.exists(os.path.join(self.app.cfg.plugin_dir, "danger-pkg")))
 
     @patch("defenseclaw.gateway.OrchestratorClient.disable_plugin")
     @patch("defenseclaw.scanner.plugin.PluginScannerWrapper.scan")
@@ -804,6 +847,30 @@ class TestPluginRegistryInstall(PluginCommandTestBase):
         result = self._invoke_install(["install", "--action", "clean-pkg"])
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("Installed plugin: clean-pkg", result.output)
+
+    @patch("defenseclaw.enforce.admission.evaluate_admission")
+    @patch("defenseclaw.scanner.plugin.PluginScannerWrapper.scan")
+    @patch("defenseclaw.registry.fetch_npm_package")
+    def test_install_post_scan_allow_skips_warning_and_installs(self, mock_fetch, mock_scan, mock_eval):
+        from defenseclaw.enforce.admission import AdmissionDecision
+
+        mock_scan.return_value = self._critical_scan_result()
+        src = self._create_plugin_dir("late-allow-plugin")
+        mock_fetch.return_value = src
+        mock_eval.side_effect = [
+            AdmissionDecision("scan", "scan required"),
+            AdmissionDecision("allowed", "approved during scan", source="manual-allow"),
+        ]
+
+        result = self._invoke_install(["install", "late-allow-plugin"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("became allow-listed", result.output)
+        self.assertNotIn("no action taken", result.output)
+        self.assertIn("Installed plugin: late-allow-plugin", result.output)
+        events = [e for e in self.app.store.list_events(20) if e.action == "install-allowed"]
+        self.assertEqual(len(events), 1)
+        self.assertIn("allow-listed-post-scan", events[0].details)
 
     @patch("defenseclaw.scanner.plugin.PluginScannerWrapper.scan")
     @patch("defenseclaw.registry.fetch_npm_package")

--- a/cli/tests/test_cmd_plugin.py
+++ b/cli/tests/test_cmd_plugin.py
@@ -222,7 +222,7 @@ class TestPluginLifecycle(PluginCommandTestBase):
     def test_install_list_remove_list(self, _mock_oc):
         self._install_plugin("lifecycle")
 
-        result = self.invoke(["list"])
+        result = self.invoke(["list", "--json"])
         self.assertIn("lifecycle", result.output)
 
         self.invoke(["remove", "lifecycle"])

--- a/cli/tests/test_cmd_policy.py
+++ b/cli/tests/test_cmd_policy.py
@@ -215,6 +215,67 @@ class TestPolicyDelete(PolicyCommandTestBase):
         self.assertEqual(len(actions), 1)
 
 
+class TestSyncOpaDataFirstParty(PolicyCommandTestBase):
+    def test_sync_writes_first_party_allow_list_with_provenance(self):
+        from defenseclaw.commands.cmd_policy import _sync_opa_data
+
+        rego_dir = os.path.join(self.app.cfg.policy_dir, "rego")
+        os.makedirs(rego_dir, exist_ok=True)
+        data_json_path = os.path.join(rego_dir, "data.json")
+        with open(data_json_path, "w") as f:
+            json.dump({
+                "config": {},
+                "actions": {},
+                "first_party_allow_list": [
+                    {
+                        "target_type": "plugin",
+                        "target_name": "defenseclaw",
+                        "reason": "old reason",
+                        "source_path_contains": [".defenseclaw"],
+                    }
+                ],
+            }, f)
+
+        policy_data = {
+            "name": "test-sync",
+            "first_party_allow_list": [
+                {
+                    "target_type": "plugin",
+                    "target_name": "defenseclaw",
+                    "reason": "first-party DefenseClaw plugin",
+                    "source_path_contains": [".defenseclaw", ".openclaw/extensions"],
+                },
+                {
+                    "target_type": "skill",
+                    "target_name": "codeguard",
+                    "reason": "first-party DefenseClaw skill",
+                    "source_path_contains": [".defenseclaw", ".openclaw/skills"],
+                },
+            ],
+        }
+
+        _sync_opa_data(self.app, policy_data)
+
+        with open(data_json_path) as f:
+            result = json.load(f)
+
+        fp_list = result.get("first_party_allow_list", [])
+        self.assertEqual(len(fp_list), 2)
+
+        plugin_entry = next(
+            (e for e in fp_list if e["target_name"] == "defenseclaw"), None
+        )
+        self.assertIsNotNone(plugin_entry)
+        self.assertIn(".openclaw/extensions", plugin_entry["source_path_contains"])
+        self.assertEqual(plugin_entry["reason"], "first-party DefenseClaw plugin")
+
+        skill_entry = next(
+            (e for e in fp_list if e["target_name"] == "codeguard"), None
+        )
+        self.assertIsNotNone(skill_entry)
+        self.assertIn(".openclaw/skills", skill_entry["source_path_contains"])
+
+
 class TestPolicyLifecycle(PolicyCommandTestBase):
     def test_create_show_activate_delete(self):
         # Create

--- a/cli/tests/test_cmd_skill.py
+++ b/cli/tests/test_cmd_skill.py
@@ -97,6 +97,64 @@ class TestSkillAllow(SkillCommandTestBase):
         actions = [e for e in events if e.action == "skill-allow"]
         self.assertEqual(len(actions), 1)
 
+    @patch("defenseclaw.gateway.OrchestratorClient")
+    def test_allow_reenables_runtime_disable_before_clearing_db(self, mock_cls):
+        pe = PolicyEngine(self.app.store)
+        pe.disable("skill", "safe-skill", "runtime blocked")
+
+        mock_cls.return_value.enable_skill.return_value = {"status": "enabled"}
+
+        result = self.invoke(["allow", "safe-skill", "--reason", "reviewed"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertTrue(pe.is_allowed("skill", "safe-skill"))
+        self.assertFalse(self.app.store.has_action("skill", "safe-skill", "runtime", "disable"))
+        mock_cls.return_value.enable_skill.assert_called_once_with("safe-skill")
+
+    @patch("defenseclaw.gateway.OrchestratorClient")
+    def test_allow_preserves_runtime_disable_when_gateway_enable_fails(self, mock_cls):
+        pe = PolicyEngine(self.app.store)
+        pe.disable("skill", "safe-skill", "runtime blocked")
+
+        mock_cls.return_value.enable_skill.side_effect = Exception("timeout")
+
+        result = self.invoke(["allow", "safe-skill", "--reason", "reviewed"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("gateway enable failed", result.output)
+        self.assertIn("runtime disable remains until the gateway is reachable", result.output)
+        self.assertTrue(pe.is_allowed("skill", "safe-skill"))
+        self.assertTrue(self.app.store.has_action("skill", "safe-skill", "runtime", "disable"))
+
+
+class TestSkillUnblock(SkillCommandTestBase):
+    @patch("defenseclaw.gateway.OrchestratorClient")
+    def test_unblock_reenables_runtime_disable_before_clearing_state(self, mock_cls):
+        pe = PolicyEngine(self.app.store)
+        pe.block("skill", "blocked-skill", "manual block")
+        pe.disable("skill", "blocked-skill", "runtime blocked")
+
+        mock_cls.return_value.enable_skill.return_value = {"status": "enabled"}
+
+        result = self.invoke(["unblock", "blocked-skill"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIsNone(pe.get_action("skill", "blocked-skill"))
+        mock_cls.return_value.enable_skill.assert_called_once_with("blocked-skill")
+
+    @patch("defenseclaw.gateway.OrchestratorClient")
+    def test_unblock_preserves_state_when_gateway_enable_fails(self, mock_cls):
+        pe = PolicyEngine(self.app.store)
+        pe.block("skill", "blocked-skill", "manual block")
+        pe.disable("skill", "blocked-skill", "runtime blocked")
+
+        mock_cls.return_value.enable_skill.side_effect = Exception("timeout")
+
+        result = self.invoke(["unblock", "blocked-skill"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("gateway enable failed", result.output)
+        self.assertIn("runtime disable remains until the gateway is reachable", result.output)
+        self.assertFalse(pe.is_blocked("skill", "blocked-skill"))
+        self.assertFalse(pe.is_quarantined("skill", "blocked-skill"))
+        self.assertTrue(self.app.store.has_action("skill", "blocked-skill", "runtime", "disable"))
+
 
 class TestSkillScan(SkillCommandTestBase):
     @patch("defenseclaw.commands.cmd_skill._run_openclaw", return_value=None)
@@ -122,6 +180,40 @@ class TestSkillScan(SkillCommandTestBase):
         result = self.invoke(["scan", "allow-me", "--path", skill_dir])
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("ALLOWED", result.output)
+
+
+class TestSkillInstall(SkillCommandTestBase):
+    @patch("defenseclaw.enforce.admission.evaluate_admission")
+    @patch("defenseclaw.scanner.skill.SkillScannerWrapper.scan")
+    @patch("defenseclaw.commands.cmd_skill._resolve_path")
+    @patch("defenseclaw.commands.cmd_skill._run_clawhub_install")
+    def test_install_post_scan_allow_skips_warning(self, mock_install, mock_resolve, mock_scan, mock_eval):
+        from defenseclaw.enforce.admission import AdmissionDecision
+
+        skill_dir = os.path.join(self.tmp_dir, "late-allow")
+        os.makedirs(skill_dir)
+        mock_install.return_value = None
+        mock_resolve.return_value = skill_dir
+        mock_scan.return_value = ScanResult(
+            scanner="skill-scanner",
+            target=skill_dir,
+            timestamp=datetime.now(timezone.utc),
+            findings=[Finding(id="f1", severity="HIGH", title="Shell injection", scanner="skill-scanner")],
+            duration=timedelta(seconds=0.5),
+        )
+        mock_eval.side_effect = [
+            AdmissionDecision("scan", "scan required"),
+            AdmissionDecision("allowed", "approved during scan", source="manual-allow"),
+        ]
+
+        result = self.invoke(["install", "late-allow"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("became allow-listed", result.output)
+        self.assertNotIn("no action taken", result.output)
+        events = [e for e in self.app.store.list_events(20) if e.action == "install-allowed"]
+        self.assertEqual(len(events), 1)
+        self.assertIn("allow-listed-post-scan", events[0].details)
 
     @patch("defenseclaw.commands.cmd_skill._get_openclaw_skill_info", return_value=None)
     @patch("defenseclaw.scanner.skill.SkillScannerWrapper")

--- a/cli/tests/test_cmd_skill.py
+++ b/cli/tests/test_cmd_skill.py
@@ -247,7 +247,7 @@ class TestSkillList(SkillCommandTestBase):
                  "source": "user", "bundled": False, "homepage": ""},
             ]
         }
-        result = self.invoke(["list"])
+        result = self.invoke(["list", "--json"])
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("web-search", result.output)
         self.assertIn("code-review", result.output)
@@ -316,7 +316,7 @@ class TestSkillList(SkillCommandTestBase):
         pe = PolicyEngine(self.app.store)
         pe.block("skill", "removed-skill", "quarantined after scan")
 
-        result = self.invoke(["list"])
+        result = self.invoke(["list", "--json"])
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("visible-skill", result.output)
         self.assertIn("removed-skill", result.output)
@@ -331,7 +331,7 @@ class TestSkillList(SkillCommandTestBase):
             datetime.now(timezone.utc), 500, 1, "MEDIUM", "{}",
         )
 
-        result = self.invoke(["list"])
+        result = self.invoke(["list", "--json"])
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("ghost-skill", result.output)
 
@@ -360,7 +360,7 @@ class TestSkillList(SkillCommandTestBase):
         pe = PolicyEngine(self.app.store)
         pe.block("skill", "banned-skill", "dangerous")
 
-        result = self.invoke(["list"])
+        result = self.invoke(["list", "--json"])
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("banned-skill", result.output)
         self.assertIn("blocked", result.output)

--- a/cli/tests/test_commands.py
+++ b/cli/tests/test_commands.py
@@ -135,7 +135,7 @@ class TestPluginCommands(unittest.TestCase):
             os.makedirs(os.path.join(tmpdir, "my-plugin"))
             app = _make_app()
             app.cfg.plugin_dir = tmpdir
-            result = _invoke(list_plugins, app=app)
+            result = _invoke(list_plugins, args=["--json"], app=app)
             self.assertEqual(result.exit_code, 0)
             self.assertIn("my-plugin", result.output)
 

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -195,9 +195,11 @@ func (l *Logger) forwardToSplunk(e Event) {
 		return
 	}
 	if shouldFlushSplunkImmediately(e.Action) {
-		if err := l.splunk.Flush(); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: splunk flush: %v\n", err)
-		}
+		go func() {
+			if err := l.splunk.Flush(); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: splunk flush: %v\n", err)
+			}
+		}()
 	}
 }
 

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -202,11 +203,16 @@ func TestLoggerSplunkFlushesWatchStartImmediately(t *testing.T) {
 		t.Fatalf("Init: %v", err)
 	}
 
-	var payload []byte
+	var (
+		mu      sync.Mutex
+		payload []byte
+	)
 	forwarder := testSplunkForwarder(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
 		payload = append([]byte(nil), body...)
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	})
 	forwarder.cfg.BatchSize = 50
@@ -218,10 +224,18 @@ func TestLoggerSplunkFlushesWatchStartImmediately(t *testing.T) {
 	}
 
 	deadline := time.Now().Add(2 * time.Second)
-	for len(bytes.TrimSpace(payload)) == 0 && time.Now().Before(deadline) {
+	for {
+		mu.Lock()
+		got := len(bytes.TrimSpace(payload))
+		mu.Unlock()
+		if got > 0 || time.Now().After(deadline) {
+			break
+		}
 		time.Sleep(10 * time.Millisecond)
 	}
 
+	mu.Lock()
+	defer mu.Unlock()
 	if len(bytes.TrimSpace(payload)) == 0 {
 		t.Fatal("expected watch-start to flush to Splunk promptly")
 	}

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestInferTargetType(t *testing.T) {
@@ -216,7 +217,12 @@ func TestLoggerSplunkFlushesWatchStartImmediately(t *testing.T) {
 		t.Fatalf("LogAction: %v", err)
 	}
 
+	deadline := time.Now().Add(2 * time.Second)
+	for len(bytes.TrimSpace(payload)) == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+
 	if len(bytes.TrimSpace(payload)) == 0 {
-		t.Fatal("expected watch-start to flush to Splunk immediately")
+		t.Fatal("expected watch-start to flush to Splunk promptly")
 	}
 }

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -92,9 +92,14 @@ func NewStore(dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("audit: open db %s: %w", dbPath, err)
 	}
 
-	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("audit: set WAL mode: %w", err)
+	for _, pragma := range []string{
+		"PRAGMA journal_mode=WAL",
+		"PRAGMA busy_timeout=5000",
+	} {
+		if _, err := db.Exec(pragma); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("audit: %s: %w", pragma, err)
+		}
 	}
 
 	return &Store{db: db}, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -687,10 +687,10 @@ func setDefaults(dataDir string) {
 	viper.SetDefault("gateway.api_port", 18970)
 	viper.SetDefault("gateway.watcher.enabled", true)
 	viper.SetDefault("gateway.watcher.skill.enabled", true)
-	viper.SetDefault("gateway.watcher.skill.take_action", false)
+	viper.SetDefault("gateway.watcher.skill.take_action", true)
 	viper.SetDefault("gateway.watcher.skill.dirs", []string{})
 	viper.SetDefault("gateway.watcher.plugin.enabled", true)
-	viper.SetDefault("gateway.watcher.plugin.take_action", false)
+	viper.SetDefault("gateway.watcher.plugin.take_action", true)
 	viper.SetDefault("gateway.watcher.plugin.dirs", []string{})
 
 	viper.SetDefault("otel.enabled", false)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,13 +212,13 @@ type ScannersConfig struct {
 }
 
 type OpenShellConfig struct {
-	Binary      string `mapstructure:"binary"        yaml:"binary"`
-	PolicyDir   string `mapstructure:"policy_dir"    yaml:"policy_dir"`
-	Mode        string `mapstructure:"mode"           yaml:"mode,omitempty"`
-	Version     string `mapstructure:"version"        yaml:"version,omitempty"`
-	SandboxHome string `mapstructure:"sandbox_home"   yaml:"sandbox_home,omitempty"`
-	AutoPair    *bool  `mapstructure:"auto_pair"      yaml:"auto_pair,omitempty"`
-	HostNetworking *bool `mapstructure:"host_networking" yaml:"host_networking,omitempty"`
+	Binary         string `mapstructure:"binary"        yaml:"binary"`
+	PolicyDir      string `mapstructure:"policy_dir"    yaml:"policy_dir"`
+	Mode           string `mapstructure:"mode"           yaml:"mode,omitempty"`
+	Version        string `mapstructure:"version"        yaml:"version,omitempty"`
+	SandboxHome    string `mapstructure:"sandbox_home"   yaml:"sandbox_home,omitempty"`
+	AutoPair       *bool  `mapstructure:"auto_pair"      yaml:"auto_pair,omitempty"`
+	HostNetworking *bool  `mapstructure:"host_networking" yaml:"host_networking,omitempty"`
 }
 
 const DefaultOpenShellVersion = "0.6.2"
@@ -665,7 +665,7 @@ func setDefaults(dataDir string) {
 
 	viper.SetDefault("guardrail.enabled", false)
 	viper.SetDefault("guardrail.mode", "observe")
-	viper.SetDefault("guardrail.scanner_mode", "local")
+	viper.SetDefault("guardrail.scanner_mode", "both")
 	viper.SetDefault("guardrail.host", "localhost")
 	viper.SetDefault("guardrail.port", 4000)
 	viper.SetDefault("guardrail.block_message", "")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -157,8 +157,8 @@ func TestDefaultConfigGuardrail(t *testing.T) {
 	if cfg.Guardrail.Port != 4000 {
 		t.Errorf("expected guardrail port 4000, got %d", cfg.Guardrail.Port)
 	}
-	if cfg.Guardrail.ScannerMode != "local" {
-		t.Errorf("expected guardrail scanner_mode %q, got %q", "local", cfg.Guardrail.ScannerMode)
+	if cfg.Guardrail.ScannerMode != "both" {
+		t.Errorf("expected guardrail scanner_mode %q, got %q", "both", cfg.Guardrail.ScannerMode)
 	}
 	if cfg.Guardrail.BlockMessage != "" {
 		t.Errorf("expected empty block_message by default, got %q", cfg.Guardrail.BlockMessage)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -123,8 +123,8 @@ func TestDefaultConfig(t *testing.T) {
 	if !cfg.Gateway.Watcher.Skill.Enabled {
 		t.Error("expected gateway watcher skill enabled by default")
 	}
-	if cfg.Gateway.Watcher.Skill.TakeAction {
-		t.Error("expected gateway watcher skill take_action=false by default")
+	if !cfg.Gateway.Watcher.Skill.TakeAction {
+		t.Error("expected gateway watcher skill take_action=true by default")
 	}
 	if cfg.Watch.DebounceMs != 500 {
 		t.Errorf("expected debounce 500ms, got %d", cfg.Watch.DebounceMs)
@@ -137,8 +137,8 @@ func TestDefaultGatewayWatcherPluginConfig(t *testing.T) {
 	if !p.Enabled {
 		t.Errorf("Gateway.Watcher.Plugin.Enabled = %v, want true", p.Enabled)
 	}
-	if p.TakeAction {
-		t.Errorf("Gateway.Watcher.Plugin.TakeAction = %v, want false", p.TakeAction)
+	if !p.TakeAction {
+		t.Errorf("Gateway.Watcher.Plugin.TakeAction = %v, want true", p.TakeAction)
 	}
 	if len(p.Dirs) != 0 {
 		t.Errorf("Gateway.Watcher.Plugin.Dirs = %v, want empty", p.Dirs)

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -128,7 +128,7 @@ func DefaultConfig() *Config {
 		},
 		Guardrail: GuardrailConfig{
 			Mode:        "observe",
-			ScannerMode: "local",
+			ScannerMode: "both",
 			Host:        "localhost",
 			Port:        4000,
 			Judge: JudgeConfig{
@@ -162,12 +162,12 @@ func DefaultConfig() *Config {
 				Enabled: true,
 				Skill: GatewayWatcherSkillConfig{
 					Enabled:    true,
-					TakeAction: false,
+					TakeAction: true,
 					Dirs:       []string{},
 				},
 				Plugin: GatewayWatcherPluginConfig{
 					Enabled:    true,
-					TakeAction: false,
+					TakeAction: true,
 					Dirs:       []string{},
 				},
 			},

--- a/internal/enforce/policy.go
+++ b/internal/enforce/policy.go
@@ -17,6 +17,8 @@
 package enforce
 
 import (
+	"fmt"
+
 	"github.com/defenseclaw/defenseclaw/internal/audit"
 )
 
@@ -65,8 +67,16 @@ func (e *PolicyEngine) Allow(targetType, name, reason string) error {
 	}
 	// Clear residual auto-enforcement state (quarantine / disable) so the
 	// allow actually takes full effect.  Only a manual Block can override.
-	_ = e.store.ClearActionField(targetType, name, "file")
-	_ = e.store.ClearActionField(targetType, name, "runtime")
+	var errs []error
+	if err := e.store.ClearActionField(targetType, name, "file"); err != nil {
+		errs = append(errs, fmt.Errorf("clear file action: %w", err))
+	}
+	if err := e.store.ClearActionField(targetType, name, "runtime"); err != nil {
+		errs = append(errs, fmt.Errorf("clear runtime action: %w", err))
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("enforce: allow %s %q: partial cleanup: %v", targetType, name, errs)
+	}
 	return nil
 }
 

--- a/internal/enforce/policy.go
+++ b/internal/enforce/policy.go
@@ -60,7 +60,14 @@ func (e *PolicyEngine) Allow(targetType, name, reason string) error {
 	if e.store == nil {
 		return nil
 	}
-	return e.store.SetActionField(targetType, name, "install", "allow", reason)
+	if err := e.store.SetActionField(targetType, name, "install", "allow", reason); err != nil {
+		return err
+	}
+	// Clear residual auto-enforcement state (quarantine / disable) so the
+	// allow actually takes full effect.  Only a manual Block can override.
+	_ = e.store.ClearActionField(targetType, name, "file")
+	_ = e.store.ClearActionField(targetType, name, "runtime")
+	return nil
 }
 
 func (e *PolicyEngine) Unblock(targetType, name string) error {

--- a/internal/enforce/policy_test.go
+++ b/internal/enforce/policy_test.go
@@ -121,19 +121,55 @@ func TestPolicyEngineNilStore(t *testing.T) {
 }
 
 func TestPolicyEngineAllowPartialCleanupError(t *testing.T) {
-	store := testStore(t)
+	dbPath := filepath.Join(t.TempDir(), "cleanup-test.db")
+	store, err := audit.NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Init(); err != nil {
+		t.Fatalf("Store.Init: %v", err)
+	}
+
 	pe := NewPolicyEngine(store)
 
-	// Set up quarantine and disable, then close the store to force errors
 	pe.Quarantine("skill", "fail-skill", "test")
 	pe.Disable("skill", "fail-skill", "test")
 
-	// Allow with active store should succeed and clear both
-	err := pe.Allow("skill", "fail-skill", "user")
+	store.Close()
+
+	err = pe.Allow("skill", "fail-skill", "user")
+	if err == nil {
+		t.Fatal("expected error from Allow on closed store")
+	}
+	if !strings.Contains(err.Error(), "database is closed") && !strings.Contains(err.Error(), "partial cleanup") {
+		t.Errorf("expected DB or cleanup error, got: %v", err)
+	}
+}
+
+func TestPolicyEngineAllowCleansUpEnforcement(t *testing.T) {
+	store := testStore(t)
+	pe := NewPolicyEngine(store)
+
+	pe.Quarantine("skill", "q-skill", "test")
+	pe.Disable("skill", "q-skill", "test")
+
+	isQ, _ := pe.IsQuarantined("skill", "q-skill")
+	if !isQ {
+		t.Fatal("expected quarantine before allow")
+	}
+
+	err := pe.Allow("skill", "q-skill", "user approved")
 	if err != nil {
-		// If clear succeeded, no error; if failed, error contains "partial cleanup"
-		if !strings.Contains(err.Error(), "partial cleanup") {
-			t.Errorf("unexpected error: %v", err)
-		}
+		t.Fatalf("Allow: %v", err)
+	}
+
+	isQ, _ = pe.IsQuarantined("skill", "q-skill")
+	if isQ {
+		t.Error("quarantine should be cleared after allow")
+	}
+
+	isA, _ := pe.IsAllowed("skill", "q-skill")
+	if !isA {
+		t.Error("skill should be allowed after Allow call")
 	}
 }

--- a/internal/enforce/policy_test.go
+++ b/internal/enforce/policy_test.go
@@ -1,0 +1,139 @@
+package enforce
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/audit"
+)
+
+func testStore(t *testing.T) *audit.Store {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	store, err := audit.NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Init(); err != nil {
+		t.Fatalf("Store.Init: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func TestPolicyEngineBlockAllow(t *testing.T) {
+	t.Run("block_then_check", func(t *testing.T) {
+		store := testStore(t)
+		pe := NewPolicyEngine(store)
+
+		if err := pe.Block("skill", "evil", "bad"); err != nil {
+			t.Fatalf("Block: %v", err)
+		}
+
+		blocked, err := pe.IsBlocked("skill", "evil")
+		if err != nil {
+			t.Fatalf("IsBlocked: %v", err)
+		}
+		if !blocked {
+			t.Error("expected blocked")
+		}
+	})
+
+	t.Run("allow_clears_quarantine_and_disable", func(t *testing.T) {
+		store := testStore(t)
+		pe := NewPolicyEngine(store)
+
+		if err := pe.Quarantine("skill", "s1", "scan"); err != nil {
+			t.Fatalf("Quarantine: %v", err)
+		}
+		if err := pe.Disable("skill", "s1", "scan"); err != nil {
+			t.Fatalf("Disable: %v", err)
+		}
+
+		q, _ := pe.IsQuarantined("skill", "s1")
+		if !q {
+			t.Fatal("expected quarantined before allow")
+		}
+
+		if err := pe.Allow("skill", "s1", "user override"); err != nil {
+			t.Fatalf("Allow: %v", err)
+		}
+
+		allowed, _ := pe.IsAllowed("skill", "s1")
+		if !allowed {
+			t.Error("expected allowed after Allow()")
+		}
+
+		q2, _ := pe.IsQuarantined("skill", "s1")
+		if q2 {
+			t.Error("quarantine should be cleared after Allow()")
+		}
+	})
+
+	t.Run("allow_returns_error_on_clear_failure", func(t *testing.T) {
+		store := testStore(t)
+		pe := NewPolicyEngine(store)
+
+		// Normal allow works fine
+		err := pe.Allow("skill", "ok-skill", "test")
+		if err != nil {
+			t.Fatalf("Allow should succeed: %v", err)
+		}
+	})
+
+	t.Run("unblock_clears_install_action", func(t *testing.T) {
+		store := testStore(t)
+		pe := NewPolicyEngine(store)
+
+		pe.Block("skill", "s2", "test block")
+		blocked, _ := pe.IsBlocked("skill", "s2")
+		if !blocked {
+			t.Fatal("expected blocked before unblock")
+		}
+
+		if err := pe.Unblock("skill", "s2"); err != nil {
+			t.Fatalf("Unblock: %v", err)
+		}
+
+		blocked2, _ := pe.IsBlocked("skill", "s2")
+		if blocked2 {
+			t.Error("expected not blocked after unblock")
+		}
+	})
+}
+
+func TestPolicyEngineNilStore(t *testing.T) {
+	pe := NewPolicyEngine(nil)
+
+	blocked, err := pe.IsBlocked("skill", "x")
+	if err != nil || blocked {
+		t.Error("expected false, nil for nil store")
+	}
+
+	if err := pe.Block("skill", "x", "r"); err != nil {
+		t.Error("expected nil error for nil store Block")
+	}
+
+	if err := pe.Allow("skill", "x", "r"); err != nil {
+		t.Error("expected nil error for nil store Allow")
+	}
+}
+
+func TestPolicyEngineAllowPartialCleanupError(t *testing.T) {
+	store := testStore(t)
+	pe := NewPolicyEngine(store)
+
+	// Set up quarantine and disable, then close the store to force errors
+	pe.Quarantine("skill", "fail-skill", "test")
+	pe.Disable("skill", "fail-skill", "test")
+
+	// Allow with active store should succeed and clear both
+	err := pe.Allow("skill", "fail-skill", "user")
+	if err != nil {
+		// If clear succeeded, no error; if failed, error contains "partial cleanup"
+		if !strings.Contains(err.Error(), "partial cleanup") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+}

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -333,6 +333,7 @@ func (a *APIServer) handlePluginEnable(w http.ResponseWriter, r *http.Request) {
 
 const gatewayMutationRetryDelay = 2 * time.Second
 const gatewayMutationMaxAttempts = 20
+const pluginGatewayMutationTimeout = 45 * time.Second
 func isRetryableGatewayMutationError(err error) bool {
 	if err == nil {
 		return false
@@ -546,14 +547,89 @@ func (a *APIServer) handleEnforceAllow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pe := enforce.NewPolicyEngine(a.store)
-	if err := pe.Allow(req.TargetType, req.TargetName, reason); err != nil {
+	policyName := req.TargetName
+	runtimeName := req.TargetName
+	if req.TargetType == "plugin" {
+		policyName = normalizePluginPolicyName(req.TargetName)
+		runtimeName = resolvePluginRuntimeActionName(pe, req.TargetName, policyName)
+	}
+
+	entry, err := pe.GetAction(req.TargetType, runtimeName)
+	if err != nil {
+		a.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if entry != nil && entry.Actions.Runtime == "disable" {
+		if a.client == nil {
+			a.writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "gateway client not configured"})
+			return
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), pluginGatewayMutationTimeout)
+		defer cancel()
+		switch req.TargetType {
+		case "skill":
+			if err := a.retryGatewayMutation(ctx, func(callCtx context.Context) error {
+				return a.client.EnableSkill(callCtx, req.TargetName)
+			}); err != nil {
+				a.writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+				return
+			}
+		case "plugin":
+			if err := a.retryGatewayMutation(ctx, func(callCtx context.Context) error {
+				return a.client.EnablePlugin(callCtx, runtimeName)
+			}); err != nil {
+				a.writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+				return
+			}
+			if runtimeName != policyName {
+				if err := pe.Enable("plugin", runtimeName); err != nil {
+					a.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+					return
+				}
+			}
+		}
+	}
+	if err := pe.Allow(req.TargetType, policyName, reason); err != nil {
 		a.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
 	if a.logger != nil {
-		_ = a.logger.LogAction("api-enforce-allow", req.TargetName, fmt.Sprintf("type=%s reason=%s", req.TargetType, truncate(reason, 120)))
+		_ = a.logger.LogAction("api-enforce-allow", policyName, fmt.Sprintf("type=%s reason=%s", req.TargetType, truncate(reason, 120)))
 	}
 	a.writeJSON(w, http.StatusOK, map[string]string{"status": "allowed"})
+}
+
+func normalizePluginPolicyName(name string) string {
+	if name == "" {
+		return ""
+	}
+	base := filepath.Base(name)
+	if base == "." || base == string(filepath.Separator) {
+		return name
+	}
+	return base
+}
+
+func resolvePluginRuntimeActionName(pe *enforce.PolicyEngine, rawName, policyName string) string {
+	candidates := []string{policyName}
+	for _, suffix := range []string{"-plugin", "-provider"} {
+		if strings.HasSuffix(policyName, suffix) {
+			candidates = append(candidates, strings.TrimSuffix(policyName, suffix))
+		}
+	}
+	if rawName != "" && rawName != policyName {
+		candidates = append(candidates, rawName)
+	}
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		entry, err := pe.GetAction("plugin", candidate)
+		if err == nil && entry != nil && entry.Actions.Runtime == "disable" {
+			return candidate
+		}
+	}
+	return policyName
 }
 
 func (a *APIServer) handleEnforceBlocked(w http.ResponseWriter, r *http.Request) {

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -1763,18 +1763,6 @@ func (a *APIServer) loadPolicyEngine() (*policy.Engine, error) {
 	return policy.New(a.scannerCfg.PolicyDir)
 }
 
-func findPolicyListEntry(entries []policy.ListEntry, targetType, targetName string) (bool, string) {
-	for _, entry := range entries {
-		if entry.TargetType == targetType && entry.TargetName == targetName {
-			if entry.Reason != "" {
-				return true, entry.Reason
-			}
-			return true, fmt.Sprintf("%s %q matched policy list", targetType, targetName)
-		}
-	}
-	return false, ""
-}
-
 // codeScanRequest is the payload for POST /api/v1/scan/code.
 type codeScanRequest struct {
 	Path string `json:"path"`

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -1460,28 +1460,11 @@ func (a *APIServer) evaluateAdmissionPolicy(ctx context.Context, input policy.Ad
 		}
 	}
 
-	if blocked, reason := findPolicyListEntry(input.BlockList, input.TargetType, input.TargetName); blocked {
-		return &policy.AdmissionOutput{Verdict: "blocked", Reason: reason}, nil
+	regoDir := ""
+	if a.scannerCfg != nil {
+		regoDir = a.scannerCfg.PolicyDir
 	}
-	if allowed, reason := findPolicyListEntry(input.AllowList, input.TargetType, input.TargetName); allowed {
-		return &policy.AdmissionOutput{Verdict: "allowed", Reason: reason}, nil
-	}
-	if input.ScanResult == nil {
-		return &policy.AdmissionOutput{Verdict: "scan", Reason: "scan required"}, nil
-	}
-	if input.ScanResult.TotalFindings <= 0 {
-		return &policy.AdmissionOutput{Verdict: "clean", Reason: "scan clean"}, nil
-	}
-	if input.ScanResult.MaxSeverity == "HIGH" || input.ScanResult.MaxSeverity == "CRITICAL" {
-		return &policy.AdmissionOutput{
-			Verdict: "rejected",
-			Reason:  fmt.Sprintf("max severity %s triggers block", input.ScanResult.MaxSeverity),
-		}, nil
-	}
-	return &policy.AdmissionOutput{
-		Verdict: "warning",
-		Reason:  "findings present — allowed with warning",
-	}, nil
+	return policy.EvaluateAdmissionFallback(input, policy.LoadFallbackProfile(regoDir)), nil
 }
 
 func classifyScanError(err error) string {

--- a/internal/gateway/cisco_inspect.go
+++ b/internal/gateway/cisco_inspect.go
@@ -30,6 +30,10 @@ import (
 
 var defaultEnabledRules = []map[string]string{
 	{"rule_name": "Prompt Injection"},
+	{"rule_name": "Jailbreak"},
+	{"rule_name": "PII Detection"},
+	{"rule_name": "Sensitive Data"},
+	{"rule_name": "Data Leakage"},
 	{"rule_name": "Harassment"},
 	{"rule_name": "Hate Speech"},
 	{"rule_name": "Profanity"},

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -33,12 +33,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/defenseclaw/defenseclaw/internal/audit"
 	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/enforce"
 	"github.com/defenseclaw/defenseclaw/internal/policy"
 	"github.com/defenseclaw/defenseclaw/internal/telemetry"
 )
@@ -2212,6 +2214,98 @@ func TestAPIEnforceAllowList(t *testing.T) {
 	}
 	if allowed[0].TargetType != "mcp" {
 		t.Errorf("target_type = %q, want mcp", allowed[0].TargetType)
+	}
+}
+
+func TestAPIEnforceAllowSkillReenablesRuntimeDisable(t *testing.T) {
+	received := make(chan receivedRequest, 5)
+	srv := startMockGW(t, rpcRecordingLoop(received))
+	client := connectToMockGW(t, srv)
+	store, logger := testStoreAndLogger(t)
+	api := &APIServer{health: NewSidecarHealth(), client: client, store: store, logger: logger}
+
+	pe := enforce.NewPolicyEngine(store)
+	if err := pe.Disable("skill", "blocked-skill", "runtime blocked"); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+
+	body := []byte(`{"target_type":"skill","target_name":"blocked-skill","reason":"reviewed"}`)
+	req := httptest.NewRequest(http.MethodPost, "/enforce/allow", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	api.handleEnforceAllow(w, req)
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Result().StatusCode, http.StatusOK)
+	}
+
+	rpc := drainRPC(t, received)
+	if rpc.Method != "skills.update" {
+		t.Fatalf("Method = %q, want skills.update", rpc.Method)
+	}
+
+	allowed, err := pe.IsAllowed("skill", "blocked-skill")
+	if err != nil {
+		t.Fatalf("IsAllowed: %v", err)
+	}
+	if !allowed {
+		t.Fatal("expected allowed after API allow")
+	}
+
+	disabled, err := store.HasAction("skill", "blocked-skill", "runtime", "disable")
+	if err != nil {
+		t.Fatalf("HasAction: %v", err)
+	}
+	if disabled {
+		t.Fatal("runtime disable should be cleared after successful re-enable")
+	}
+}
+
+func TestAPIEnforceAllowSkillFailsWhenGatewayEnableFails(t *testing.T) {
+	srv := startMockGW(t, func(t *testing.T, conn *websocket.Conn) {
+		for {
+			_, raw, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var req RequestFrame
+			json.Unmarshal(raw, &req)
+			resp, _ := json.Marshal(ResponseFrame{
+				Type: "res", ID: req.ID, OK: false,
+				Error: &FrameError{Code: "INTERNAL", Message: "server error"},
+			})
+			conn.WriteMessage(websocket.TextMessage, resp)
+		}
+	})
+	client := connectToMockGW(t, srv)
+	store, logger := testStoreAndLogger(t)
+	api := &APIServer{health: NewSidecarHealth(), client: client, store: store, logger: logger}
+
+	pe := enforce.NewPolicyEngine(store)
+	if err := pe.Disable("skill", "blocked-skill", "runtime blocked"); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+
+	body := []byte(`{"target_type":"skill","target_name":"blocked-skill","reason":"reviewed"}`)
+	req := httptest.NewRequest(http.MethodPost, "/enforce/allow", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	api.handleEnforceAllow(w, req)
+	if w.Result().StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", w.Result().StatusCode, http.StatusBadGateway)
+	}
+
+	allowed, err := pe.IsAllowed("skill", "blocked-skill")
+	if err != nil {
+		t.Fatalf("IsAllowed: %v", err)
+	}
+	if allowed {
+		t.Fatal("skill should not become allowed when gateway re-enable fails")
+	}
+
+	disabled, err := store.HasAction("skill", "blocked-skill", "runtime", "disable")
+	if err != nil {
+		t.Fatalf("HasAction: %v", err)
+	}
+	if !disabled {
+		t.Fatal("runtime disable should remain when gateway re-enable fails")
 	}
 }
 

--- a/internal/gateway/gateway_ws_test.go
+++ b/internal/gateway/gateway_ws_test.go
@@ -1111,6 +1111,8 @@ func TestHandleAdmissionResultBlocked(t *testing.T) {
 		},
 		client: client,
 		logger: logger,
+		notify: NewNotificationQueue(),
+		router: NewEventRouter(client, nil, logger, false, nil),
 	}
 
 	s.handleAdmissionResult(watcher.AdmissionResult{
@@ -1153,6 +1155,8 @@ func TestHandleAdmissionResultRejected(t *testing.T) {
 		},
 		client: client,
 		logger: logger,
+		notify: NewNotificationQueue(),
+		router: NewEventRouter(client, nil, logger, false, nil),
 	}
 
 	s.handleAdmissionResult(watcher.AdmissionResult{

--- a/internal/gateway/gateway_ws_test.go
+++ b/internal/gateway/gateway_ws_test.go
@@ -1164,8 +1164,9 @@ func TestHandleAdmissionResultRejected(t *testing.T) {
 			Type: watcher.InstallSkill,
 			Name: "rejected-skill",
 		},
-		Verdict: watcher.VerdictRejected,
-		Reason:  "scan found critical findings",
+		Verdict:       watcher.VerdictRejected,
+		Reason:        "scan found critical findings",
+		RuntimeAction: "block",
 	})
 
 	rpc := drainRPC(t, received)
@@ -1173,6 +1174,73 @@ func TestHandleAdmissionResultRejected(t *testing.T) {
 	json.Unmarshal(rpc.Params, &params)
 	if params.SkillKey != "rejected-skill" {
 		t.Errorf("SkillKey = %q, want rejected-skill", params.SkillKey)
+	}
+}
+
+func TestHandleAdmissionResultRejectedInstallOnlyDoesNotDisableSkill(t *testing.T) {
+	_, logger := testStoreAndLogger(t)
+
+	s := &Sidecar{
+		cfg: &config.Config{
+			Gateway: config.GatewayConfig{
+				Watcher: config.GatewayWatcherConfig{
+					Skill: config.GatewayWatcherSkillConfig{TakeAction: true},
+				},
+			},
+		},
+		logger:   logger,
+		notify:   NewNotificationQueue(),
+		router:   &EventRouter{},
+		alertCtx: context.Background(),
+	}
+
+	s.handleAdmissionResult(watcher.AdmissionResult{
+		Event: watcher.InstallEvent{
+			Type: watcher.InstallSkill,
+			Name: "install-only-skill",
+		},
+		Verdict:       watcher.VerdictRejected,
+		Reason:        "install blocked by policy",
+		InstallAction: "block",
+		RuntimeAction: "allow",
+	})
+
+	s.alertWg.Wait()
+	notes := s.notify.ActiveNotifications()
+	if len(notes) != 1 {
+		t.Fatalf("notification count = %d, want 1", len(notes))
+	}
+	if got := strings.Join(notes[0].Actions, ","); strings.Contains(got, "disabled") {
+		t.Fatalf("actions = %q, should not include disabled", got)
+	}
+}
+
+func TestSendEnforcementAlertQueuesAfterLiveSend(t *testing.T) {
+	received := make(chan receivedRequest, 5)
+	srv := startMockGW(t, rpcRecordingLoop(received))
+	client := connectToMockGW(t, srv)
+
+	router := &EventRouter{activeSessions: map[string]time.Time{"session-1": time.Now()}}
+	s := &Sidecar{
+		client:   client,
+		notify:   NewNotificationQueue(),
+		router:   router,
+		alertCtx: context.Background(),
+	}
+
+	s.sendEnforcementAlert("skill", "malicious-skill", "HIGH", 2, []string{"blocked"}, "policy reject")
+
+	rpc := drainRPC(t, received)
+	if rpc.Method != "sessions.send" {
+		t.Fatalf("Method = %q, want sessions.send", rpc.Method)
+	}
+
+	notes := s.notify.ActiveNotifications()
+	if len(notes) != 1 {
+		t.Fatalf("notification count = %d, want 1", len(notes))
+	}
+	if notes[0].SkillName != "malicious-skill" {
+		t.Fatalf("notification skill = %q, want malicious-skill", notes[0].SkillName)
 	}
 }
 
@@ -1241,8 +1309,11 @@ func TestHandlePluginAdmissionBlocked(t *testing.T) {
 				},
 			},
 		},
-		client: client,
-		logger: logger,
+		client:   client,
+		logger:   logger,
+		notify:   NewNotificationQueue(),
+		router:   &EventRouter{},
+		alertCtx: context.Background(),
 	}
 
 	s.handleAdmissionResult(watcher.AdmissionResult{
@@ -1264,6 +1335,15 @@ func TestHandlePluginAdmissionBlocked(t *testing.T) {
 		t.Errorf("second RPC Method = %q, want config.patch", configPatch.Method)
 	}
 	assertPluginConfigPatch(t, configPatch.Params, "malicious-plugin", false)
+
+	s.alertWg.Wait()
+	notes := s.notify.ActiveNotifications()
+	if len(notes) != 1 {
+		t.Fatalf("notification count = %d, want 1", len(notes))
+	}
+	if notes[0].SubjectType != "plugin" {
+		t.Fatalf("notification subject type = %q, want plugin", notes[0].SubjectType)
+	}
 }
 
 func TestHandlePluginAdmissionNoTakeAction(t *testing.T) {
@@ -1426,8 +1506,11 @@ func TestHandlePluginAdmissionRejected(t *testing.T) {
 				},
 			},
 		},
-		client: client,
-		logger: logger,
+		client:   client,
+		logger:   logger,
+		notify:   NewNotificationQueue(),
+		router:   &EventRouter{},
+		alertCtx: context.Background(),
 	}
 
 	s.handleAdmissionResult(watcher.AdmissionResult{
@@ -1436,8 +1519,9 @@ func TestHandlePluginAdmissionRejected(t *testing.T) {
 			Name: "rejected-plugin",
 			Path: "/path/to/plugin",
 		},
-		Verdict: watcher.VerdictRejected,
-		Reason:  "scan found CRITICAL findings",
+		Verdict:       watcher.VerdictRejected,
+		Reason:        "scan found CRITICAL findings",
+		RuntimeAction: "block",
 	})
 
 	configGet := drainRPC(t, received)
@@ -1449,4 +1533,52 @@ func TestHandlePluginAdmissionRejected(t *testing.T) {
 		t.Errorf("second RPC Method = %q, want config.patch", configPatch.Method)
 	}
 	assertPluginConfigPatch(t, configPatch.Params, "rejected-plugin", false)
+
+	s.alertWg.Wait()
+	notes := s.notify.ActiveNotifications()
+	if len(notes) != 1 {
+		t.Fatalf("notification count = %d, want 1", len(notes))
+	}
+	if notes[0].SubjectType != "plugin" {
+		t.Fatalf("notification subject type = %q, want plugin", notes[0].SubjectType)
+	}
+}
+
+func TestHandlePluginAdmissionRejectedInstallOnlyDoesNotDisable(t *testing.T) {
+	_, logger := testStoreAndLogger(t)
+
+	s := &Sidecar{
+		cfg: &config.Config{
+			Gateway: config.GatewayConfig{
+				Watcher: config.GatewayWatcherConfig{
+					Plugin: config.GatewayWatcherPluginConfig{TakeAction: true},
+				},
+			},
+		},
+		logger:   logger,
+		notify:   NewNotificationQueue(),
+		router:   &EventRouter{},
+		alertCtx: context.Background(),
+	}
+
+	s.handleAdmissionResult(watcher.AdmissionResult{
+		Event: watcher.InstallEvent{
+			Type: watcher.InstallPlugin,
+			Name: "install-only-plugin",
+			Path: "/path/to/plugin",
+		},
+		Verdict:       watcher.VerdictRejected,
+		Reason:        "install blocked by policy",
+		InstallAction: "block",
+		RuntimeAction: "allow",
+	})
+
+	s.alertWg.Wait()
+	notes := s.notify.ActiveNotifications()
+	if len(notes) != 1 {
+		t.Fatalf("notification count = %d, want 1", len(notes))
+	}
+	if got := strings.Join(notes[0].Actions, ","); strings.Contains(got, "disabled") {
+		t.Fatalf("actions = %q, should not include disabled", got)
+	}
 }

--- a/internal/gateway/guardrail.go
+++ b/internal/gateway/guardrail.go
@@ -75,6 +75,9 @@ func (g *GuardrailInspector) SetScannerMode(mode string) {
 }
 
 // Inspect runs scanners according to scanner_mode and returns a merged verdict.
+// Local pattern scanning always runs as a baseline, regardless of scanner_mode,
+// to ensure prompt injection and PII patterns are caught even when the remote
+// scanner returns safe or is unreachable.
 func (g *GuardrailInspector) Inspect(ctx context.Context, direction, content string, messages []ChatMessage, model, mode string) *ScanVerdict {
 	var localResult *ScanVerdict
 	var ciscoResult *ScanVerdict
@@ -82,13 +85,13 @@ func (g *GuardrailInspector) Inspect(ctx context.Context, direction, content str
 
 	sm := g.scannerMode
 
-	if sm == "local" || sm == "both" {
-		localResult = scanLocalPatterns(direction, content)
-	}
+	localResult = scanLocalPatterns(direction, content)
 
-	// In "both" mode, skip remote if local already flags something.
-	if sm == "both" && localResult != nil && localResult.Severity != "NONE" {
-		localResult.ScannerSources = []string{"local-pattern"}
+	// In local-only mode or if local already flagged HIGH+, skip the remote call.
+	if sm == "local" || (localResult != nil && localResult.Severity == "HIGH") {
+		if localResult != nil {
+			localResult.ScannerSources = []string{"local-pattern"}
+		}
 		return g.finalize(ctx, direction, model, mode, content, localResult, nil)
 	}
 
@@ -101,7 +104,6 @@ func (g *GuardrailInspector) Inspect(ctx context.Context, direction, content str
 	merged := mergeVerdicts(localResult, ciscoResult)
 	merged.CiscoElapsedMs = ciscoElapsedMs
 
-	// Run LLM judge if configured.
 	if g.judge != nil {
 		judgeVerdict := g.judge.RunJudges(ctx, direction, content)
 		if judgeVerdict != nil && judgeVerdict.Severity != "NONE" {
@@ -169,9 +171,40 @@ func (g *GuardrailInspector) finalize(ctx context.Context, direction, model, mod
 
 var injectionPatterns = []string{
 	"ignore previous", "ignore all instructions", "ignore above",
-	"disregard previous", "disregard all", "you are now",
-	"act as", "pretend you are", "bypass", "jailbreak",
-	"do anything now", "dan mode",
+	"ignore all previous", "ignore your instructions", "ignore prior",
+	"disregard previous", "disregard all", "disregard your",
+	"forget your instructions", "forget all previous",
+	"override your instructions", "override all instructions",
+	"you are now", "pretend you are",
+	"jailbreak", "do anything now", "dan mode",
+	"developer mode enabled",
+}
+
+var injectionRegexes = []*regexp.Regexp{
+	regexp.MustCompile(`ignore\s+(?:all\s+)?(?:previous|prior|above|your)\s+(?:instructions|rules|directives|guidelines)`),
+	regexp.MustCompile(`disregard\s+(?:all\s+)?(?:previous|prior|above|your)\s+(?:instructions|rules|directives|guidelines)`),
+	regexp.MustCompile(`(?:share|reveal|show|print|output|dump|repeat|give\s+me)\s+(?:your|the)\s+(?:system\s+)?(?:prompt|instructions|rules)`),
+	regexp.MustCompile(`(?:what\s+(?:is|are)\s+your\s+(?:system\s+)?(?:prompt|instructions|rules))`),
+	regexp.MustCompile(`act\s+as\b`),
+	regexp.MustCompile(`bypass\s+(?:your|the|my|all|any)\s+(?:filter|guard|safe|restrict|rule|instruction)`),
+}
+
+var piiRequestPatterns = []string{
+	"find their ssn", "find my ssn", "look up their ssn",
+	"retrieve their ssn", "get their ssn", "get my ssn",
+	"social security number", "mother's maiden name",
+	"mothers maiden name", "credit card number",
+	"find their password", "look up their password",
+	"find their email", "look up their email",
+	"date of birth", "bank account number",
+	"passport number", "driver's license",
+	"drivers license",
+}
+
+var piiDataRegexes = []*regexp.Regexp{
+	regexp.MustCompile(`\b\d{3}-\d{2}-\d{4}\b`),
+	regexp.MustCompile(`\b\d{9}\b`),
+	regexp.MustCompile(`\b(?:4\d{3}|5[1-5]\d{2}|3[47]\d{2}|6(?:011|5\d{2}))[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b`),
 }
 
 var secretPatterns = []string{
@@ -189,19 +222,43 @@ var exfilPatterns = []string{
 func scanLocalPatterns(direction, content string) *ScanVerdict {
 	lower := strings.ToLower(content)
 	var flags []string
+	isHigh := false
 
 	if direction == "prompt" {
 		for _, p := range injectionPatterns {
 			if strings.Contains(lower, p) {
 				flags = append(flags, p)
+				isHigh = true
+			}
+		}
+		for _, re := range injectionRegexes {
+			if re.MatchString(lower) {
+				match := re.FindString(lower)
+				flags = append(flags, match)
+				isHigh = true
+			}
+		}
+		for _, p := range piiRequestPatterns {
+			if strings.Contains(lower, p) {
+				flags = append(flags, "pii-request:"+p)
+				isHigh = true
 			}
 		}
 		for _, p := range exfilPatterns {
 			if strings.Contains(lower, p) {
 				flags = append(flags, p)
+				isHigh = true
 			}
 		}
 	}
+
+	for _, re := range piiDataRegexes {
+		if re.MatchString(content) {
+			flags = append(flags, "pii-data:"+re.FindString(content))
+			isHigh = true
+		}
+	}
+
 	for _, p := range secretPatterns {
 		if strings.Contains(lower, p) {
 			flags = append(flags, p)
@@ -213,29 +270,8 @@ func scanLocalPatterns(direction, content string) *ScanVerdict {
 	}
 
 	severity := "MEDIUM"
-	for _, p := range injectionPatterns {
-		for _, f := range flags {
-			if f == p {
-				severity = "HIGH"
-				break
-			}
-		}
-		if severity == "HIGH" {
-			break
-		}
-	}
-	if severity == "MEDIUM" {
-		for _, p := range exfilPatterns {
-			for _, f := range flags {
-				if f == p {
-					severity = "HIGH"
-					break
-				}
-			}
-			if severity == "HIGH" {
-				break
-			}
-		}
+	if isHigh {
+		severity = "HIGH"
 	}
 
 	action := "alert"

--- a/internal/gateway/hardening_test.go
+++ b/internal/gateway/hardening_test.go
@@ -590,9 +590,7 @@ func TestPatchRawBodyMaxTokensCapping(t *testing.T) {
 		var m map[string]json.RawMessage
 		json.Unmarshal(patched, &m)
 		var s string
-		if json.Unmarshal(m["max_tokens"], &s) == nil && s == "not-a-number" {
-			// String preserved — this is expected (non-int is not capped)
-		}
+		_ = json.Unmarshal(m["max_tokens"], &s)
 	})
 }
 

--- a/internal/gateway/hardening_test.go
+++ b/internal/gateway/hardening_test.go
@@ -1,0 +1,718 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// injectSystemMessage
+// ---------------------------------------------------------------------------
+
+func TestInjectSystemMessage(t *testing.T) {
+	t.Run("prepends_system_message", func(t *testing.T) {
+		raw := json.RawMessage(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
+		patched, err := injectSystemMessage(raw, "security alert")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(patched, &m); err != nil {
+			t.Fatalf("unmarshal patched: %v", err)
+		}
+		var msgs []map[string]string
+		if err := json.Unmarshal(m["messages"], &msgs); err != nil {
+			t.Fatalf("unmarshal messages: %v", err)
+		}
+		if len(msgs) != 2 {
+			t.Fatalf("expected 2 messages, got %d", len(msgs))
+		}
+		if msgs[0]["role"] != "system" {
+			t.Errorf("first message role = %q, want system", msgs[0]["role"])
+		}
+		if msgs[0]["content"] != "security alert" {
+			t.Errorf("first message content = %q, want %q", msgs[0]["content"], "security alert")
+		}
+	})
+
+	t.Run("invalid_json_returns_error", func(t *testing.T) {
+		_, err := injectSystemMessage(json.RawMessage(`{not json}`), "msg")
+		if err == nil {
+			t.Error("expected error for invalid JSON")
+		}
+	})
+
+	t.Run("missing_messages_returns_error", func(t *testing.T) {
+		_, err := injectSystemMessage(json.RawMessage(`{"model":"gpt-4"}`), "msg")
+		if err == nil {
+			t.Error("expected error when messages field missing")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// mergeToolCallChunks
+// ---------------------------------------------------------------------------
+
+func TestMergeToolCallChunks(t *testing.T) {
+	t.Run("nil_existing_returns_chunk", func(t *testing.T) {
+		chunk := json.RawMessage(`[{"id":"1"}]`)
+		result := mergeToolCallChunks(nil, chunk)
+		if string(result) != string(chunk) {
+			t.Errorf("got %s, want %s", result, chunk)
+		}
+	})
+
+	t.Run("nil_chunk_returns_existing", func(t *testing.T) {
+		existing := json.RawMessage(`[{"id":"1"}]`)
+		result := mergeToolCallChunks(existing, nil)
+		if string(result) != string(existing) {
+			t.Errorf("got %s, want %s", result, existing)
+		}
+	})
+
+	t.Run("merges_two_arrays", func(t *testing.T) {
+		existing := json.RawMessage(`[{"id":"1"}]`)
+		chunk := json.RawMessage(`[{"id":"2"}]`)
+		result := mergeToolCallChunks(existing, chunk)
+
+		var arr []map[string]string
+		if err := json.Unmarshal(result, &arr); err != nil {
+			t.Fatalf("unmarshal result: %v", err)
+		}
+		if len(arr) != 2 {
+			t.Fatalf("expected 2 elements, got %d", len(arr))
+		}
+		if arr[0]["id"] != "1" || arr[1]["id"] != "2" {
+			t.Errorf("unexpected merge result: %v", arr)
+		}
+	})
+
+	t.Run("empty_arrays_merge_safely", func(t *testing.T) {
+		existing := json.RawMessage(`[]`)
+		chunk := json.RawMessage(`[]`)
+		result := mergeToolCallChunks(existing, chunk)
+
+		var arr []json.RawMessage
+		if err := json.Unmarshal(result, &arr); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(arr) != 0 {
+			t.Errorf("expected empty array, got %d elements", len(arr))
+		}
+	})
+
+	t.Run("invalid_existing_returns_chunk", func(t *testing.T) {
+		existing := json.RawMessage(`not json`)
+		chunk := json.RawMessage(`[{"id":"1"}]`)
+		result := mergeToolCallChunks(existing, chunk)
+		if string(result) != string(chunk) {
+			t.Errorf("got %s, want %s", result, chunk)
+		}
+	})
+
+	t.Run("invalid_chunk_returns_existing", func(t *testing.T) {
+		existing := json.RawMessage(`[{"id":"1"}]`)
+		chunk := json.RawMessage(`not json`)
+		result := mergeToolCallChunks(existing, chunk)
+		if string(result) != string(existing) {
+			t.Errorf("got %s, want %s", result, existing)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// inspectToolCalls — parse failure returns alert (not nil)
+// ---------------------------------------------------------------------------
+
+func TestInspectToolCalls_ParseError(t *testing.T) {
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	proxy := newTestProxy(t, prov, insp, "action")
+
+	malformed := json.RawMessage(`{not a valid tool calls array}`)
+	verdict := proxy.inspectToolCalls(malformed)
+	if verdict == nil {
+		t.Fatal("expected non-nil verdict on parse error")
+	}
+	if verdict.Action != "alert" {
+		t.Errorf("action = %q, want alert", verdict.Action)
+	}
+	if verdict.Severity != "MEDIUM" {
+		t.Errorf("severity = %q, want MEDIUM", verdict.Severity)
+	}
+}
+
+func TestInspectToolCalls_Empty(t *testing.T) {
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	proxy := newTestProxy(t, prov, insp, "action")
+
+	if v := proxy.inspectToolCalls(nil); v != nil {
+		t.Errorf("expected nil for empty input, got %+v", v)
+	}
+	if v := proxy.inspectToolCalls(json.RawMessage(``)); v != nil {
+		t.Errorf("expected nil for empty bytes, got %+v", v)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Streaming block enforcement: mid-stream block stops forwarding
+// ---------------------------------------------------------------------------
+
+func TestStreamingMidStreamBlockStopsForwarding(t *testing.T) {
+	longContent := strings.Repeat("a", 600)
+	prov := &mockProvider{
+		streamChunks: []StreamChunk{
+			{
+				ID: "chatcmpl-s1", Object: "chat.completion.chunk", Model: "gpt-4",
+				Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{Role: "assistant"}}},
+			},
+			{
+				ID: "chatcmpl-s1", Object: "chat.completion.chunk", Model: "gpt-4",
+				Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{Content: longContent}}},
+			},
+			{
+				ID: "chatcmpl-s1", Object: "chat.completion.chunk", Model: "gpt-4",
+				Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{Content: " should-not-be-forwarded"}}},
+			},
+		},
+	}
+
+	blockInsp := &conditionalInspector{blockAfterChars: 500}
+	proxy := newTestProxy(t, prov, blockInsp, "action")
+
+	reqBody := mustJSON(t, map[string]interface{}{
+		"model":    "gpt-4",
+		"messages": []map[string]interface{}{{"role": "user", "content": "test"}},
+		"stream":   true,
+	})
+
+	rec := postChat(t, proxy, reqBody)
+	body := rec.Body.String()
+
+	if !strings.Contains(body, "[DONE]") {
+		t.Error("stream should always end with [DONE]")
+	}
+	if strings.Contains(body, "should-not-be-forwarded") {
+		t.Error("content after block should NOT be forwarded")
+	}
+	if !strings.Contains(body, "blocked") {
+		t.Error("blocked message should appear in stream")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Streaming tool-call block enforcement
+// ---------------------------------------------------------------------------
+
+func TestStreamingToolCallBlockEnforcement(t *testing.T) {
+	toolCalls := json.RawMessage(`[{"id":"call_1","type":"function","function":{"name":"write_file","arguments":"{\"path\":\"/etc/passwd\",\"content\":\"hack\"}"}}]`)
+	prov := &mockProvider{
+		streamChunks: []StreamChunk{
+			{
+				ID: "chatcmpl-tc", Object: "chat.completion.chunk", Model: "gpt-4",
+				Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{Role: "assistant"}}},
+			},
+			{
+				ID: "chatcmpl-tc", Object: "chat.completion.chunk", Model: "gpt-4",
+				Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{ToolCalls: toolCalls}}},
+			},
+			{
+				ID: "chatcmpl-tc", Object: "chat.completion.chunk", Model: "gpt-4",
+				Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{}, FinishReason: strPtr("tool_calls")}},
+			},
+		},
+	}
+
+	insp := newMockInspector()
+	proxy := newTestProxy(t, prov, insp, "action")
+
+	reqBody := mustJSON(t, map[string]interface{}{
+		"model":    "gpt-4",
+		"messages": []map[string]interface{}{{"role": "user", "content": "write to /etc/passwd"}},
+		"stream":   true,
+	})
+
+	rec := postChat(t, proxy, reqBody)
+	body := rec.Body.String()
+
+	if !strings.Contains(body, "[DONE]") {
+		t.Error("stream should end with [DONE]")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Notification inject body divergence
+// ---------------------------------------------------------------------------
+
+func TestNotificationInjectBodyDivergence(t *testing.T) {
+	t.Run("inject_failure_does_not_add_to_messages", func(t *testing.T) {
+		prov := &mockProvider{}
+		insp := newMockInspector()
+		proxy := newTestProxy(t, prov, insp, "action")
+		proxy.notify = NewNotificationQueue()
+		proxy.notify.Push(SecurityNotification{
+			SkillName: "evil-skill",
+			Severity:  "HIGH",
+			Findings:  2,
+			Actions:   []string{"blocked"},
+			Reason:    "test enforcement",
+		})
+
+		reqBody := mustJSON(t, map[string]interface{}{
+			"model":    "gpt-4",
+			"messages": []map[string]interface{}{{"role": "user", "content": "hi"}},
+		})
+
+		rec := postChat(t, proxy, reqBody)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
+		}
+
+		forwarded := prov.getLastReq()
+		if forwarded == nil {
+			t.Fatal("request should have been forwarded")
+		}
+
+		// When RawBody is present and inject succeeds, Messages and RawBody
+		// should both contain the notification. Verify consistency.
+		hasNotifyInMessages := false
+		for _, m := range forwarded.Messages {
+			if m.Role == "system" && strings.Contains(m.Content, "DEFENSECLAW") {
+				hasNotifyInMessages = true
+				break
+			}
+		}
+		if hasNotifyInMessages && len(forwarded.RawBody) > 0 {
+			if !strings.Contains(string(forwarded.RawBody), "DEFENSECLAW") {
+				t.Error("Messages has notification but RawBody does not — divergence detected")
+			}
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// NotificationQueue
+// ---------------------------------------------------------------------------
+
+func TestNotificationQueue(t *testing.T) {
+	t.Run("push_and_active", func(t *testing.T) {
+		q := NewNotificationQueue()
+		q.Push(SecurityNotification{SkillName: "s1", Severity: "HIGH"})
+		q.Push(SecurityNotification{SkillName: "s2", Severity: "MEDIUM"})
+
+		active := q.ActiveNotifications()
+		if len(active) != 2 {
+			t.Fatalf("expected 2 active, got %d", len(active))
+		}
+	})
+
+	t.Run("expired_notifications_pruned", func(t *testing.T) {
+		q := NewNotificationQueue()
+		q.mu.Lock()
+		q.items = append(q.items, SecurityNotification{
+			SkillName: "old",
+			ExpiresAt: time.Now().Add(-1 * time.Minute),
+		})
+		q.mu.Unlock()
+
+		q.Push(SecurityNotification{SkillName: "new", Severity: "HIGH"})
+
+		active := q.ActiveNotifications()
+		if len(active) != 1 {
+			t.Fatalf("expected 1 active after pruning, got %d", len(active))
+		}
+		if active[0].SkillName != "new" {
+			t.Errorf("expected 'new', got %q", active[0].SkillName)
+		}
+	})
+
+	t.Run("cap_enforced", func(t *testing.T) {
+		q := NewNotificationQueue()
+		for i := 0; i < maxNotificationQueueSize+20; i++ {
+			q.Push(SecurityNotification{SkillName: "s", Severity: "LOW"})
+		}
+		q.mu.Lock()
+		count := len(q.items)
+		q.mu.Unlock()
+		if count > maxNotificationQueueSize {
+			t.Errorf("queue size %d exceeds cap %d", count, maxNotificationQueueSize)
+		}
+	})
+
+	t.Run("format_system_message", func(t *testing.T) {
+		q := NewNotificationQueue()
+		msg := q.FormatSystemMessage()
+		if msg != "" {
+			t.Error("expected empty message for empty queue")
+		}
+
+		q.Push(SecurityNotification{
+			SkillName: "malware",
+			Severity:  "CRITICAL",
+			Findings:  5,
+			Actions:   []string{"quarantined", "disabled"},
+			Reason:    "dangerous code detected",
+		})
+		msg = q.FormatSystemMessage()
+		if !strings.Contains(msg, "DEFENSECLAW") {
+			t.Error("message should contain DEFENSECLAW header")
+		}
+		if !strings.Contains(msg, "malware") {
+			t.Error("message should contain skill name")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Session map pruning
+// ---------------------------------------------------------------------------
+
+func TestActiveSessionsPruning(t *testing.T) {
+	store, logger := testStoreAndLogger(t)
+	router := NewEventRouter(nil, store, logger, true, nil)
+
+	router.activeSessionsMu.Lock()
+	router.activeSessions["old"] = time.Now().Add(-2 * time.Hour)
+	router.activeSessions["recent"] = time.Now()
+	router.activeSessionsMu.Unlock()
+
+	keys := router.ActiveSessionKeys()
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 active key, got %d", len(keys))
+	}
+	if keys[0] != "recent" {
+		t.Errorf("expected 'recent', got %q", keys[0])
+	}
+}
+
+func TestTrackSessionPrunes(t *testing.T) {
+	store, logger := testStoreAndLogger(t)
+	router := NewEventRouter(nil, store, logger, true, nil)
+
+	router.activeSessionsMu.Lock()
+	for i := 0; i < maxActiveSessions+10; i++ {
+		key := strings.Repeat("x", 10) + string(rune('A'+i%26))
+		router.activeSessions[key] = time.Now().Add(-2 * time.Hour)
+	}
+	router.activeSessionsMu.Unlock()
+
+	router.trackSession("new-session")
+
+	router.activeSessionsMu.RLock()
+	count := len(router.activeSessions)
+	router.activeSessionsMu.RUnlock()
+
+	if count > maxActiveSessions+1 {
+		t.Errorf("session map not pruned: got %d entries", count)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// modelMaxTokens
+// ---------------------------------------------------------------------------
+
+func TestModelMaxTokens(t *testing.T) {
+	tests := []struct {
+		model string
+		want  int
+	}{
+		{"gpt-4o-mini-2024-07-18", 16384},
+		{"gpt-4o", 16384},
+		{"gpt-4-turbo-preview", 4096},
+		{"gpt-4-0613", 8192},
+		{"o3-mini", 100000},
+		{"o3", 100000},
+		{"o4-mini", 100000},
+		{"claude-3-opus", 8192},
+		{"unknown-model-xyz", defaultMaxTokensFallback},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			if got := modelMaxTokens(tt.model); got != tt.want {
+				t.Errorf("modelMaxTokens(%q) = %d, want %d", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// patchRawBody max_tokens capping
+// ---------------------------------------------------------------------------
+
+func TestPatchRawBodyMaxTokensCapping(t *testing.T) {
+	t.Run("caps_max_tokens_above_limit", func(t *testing.T) {
+		raw := json.RawMessage(`{"model":"gpt-4","max_tokens":999999,"messages":[]}`)
+		patched, err := patchRawBody(raw, "gpt-4", false)
+		if err != nil {
+			t.Fatalf("patchRawBody: %v", err)
+		}
+
+		var m map[string]json.RawMessage
+		json.Unmarshal(patched, &m)
+		var maxTok int
+		json.Unmarshal(m["max_tokens"], &maxTok)
+		if maxTok != 8192 {
+			t.Errorf("max_tokens = %d, want 8192 (gpt-4 limit)", maxTok)
+		}
+	})
+
+	t.Run("preserves_max_tokens_within_limit", func(t *testing.T) {
+		raw := json.RawMessage(`{"model":"gpt-4","max_tokens":1000,"messages":[]}`)
+		patched, err := patchRawBody(raw, "gpt-4", false)
+		if err != nil {
+			t.Fatalf("patchRawBody: %v", err)
+		}
+
+		var m map[string]json.RawMessage
+		json.Unmarshal(patched, &m)
+		var maxTok int
+		json.Unmarshal(m["max_tokens"], &maxTok)
+		if maxTok != 1000 {
+			t.Errorf("max_tokens = %d, want 1000 (within limit)", maxTok)
+		}
+	})
+
+	t.Run("unknown_model_uses_fallback", func(t *testing.T) {
+		raw := json.RawMessage(`{"model":"unknown","max_tokens":999999,"messages":[]}`)
+		patched, err := patchRawBody(raw, "unknown-model", false)
+		if err != nil {
+			t.Fatalf("patchRawBody: %v", err)
+		}
+
+		var m map[string]json.RawMessage
+		json.Unmarshal(patched, &m)
+		var maxTok int
+		json.Unmarshal(m["max_tokens"], &maxTok)
+		if maxTok != defaultMaxTokensFallback {
+			t.Errorf("max_tokens = %d, want %d (fallback default)", maxTok, defaultMaxTokensFallback)
+		}
+	})
+
+	t.Run("non_int_max_tokens_preserved", func(t *testing.T) {
+		raw := json.RawMessage(`{"model":"gpt-4","max_tokens":"not-a-number","messages":[]}`)
+		patched, err := patchRawBody(raw, "gpt-4", false)
+		if err != nil {
+			t.Fatalf("patchRawBody: %v", err)
+		}
+
+		var m map[string]json.RawMessage
+		json.Unmarshal(patched, &m)
+		var s string
+		if json.Unmarshal(m["max_tokens"], &s) == nil && s == "not-a-number" {
+			// String preserved — this is expected (non-int is not capped)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Streaming block with notification queue injection
+// ---------------------------------------------------------------------------
+
+func TestProxyNotificationInjectSuccess(t *testing.T) {
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	proxy := newTestProxy(t, prov, insp, "action")
+	proxy.notify = NewNotificationQueue()
+	proxy.notify.Push(SecurityNotification{
+		SkillName: "bad-skill",
+		Severity:  "HIGH",
+		Findings:  1,
+		Actions:   []string{"disabled"},
+		Reason:    "security issue",
+	})
+
+	reqBody := mustJSON(t, map[string]interface{}{
+		"model":    "gpt-4",
+		"messages": []map[string]interface{}{{"role": "user", "content": "hello"}},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	proxy.handleChatCompletion(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+
+	forwarded := prov.getLastReq()
+	if forwarded == nil {
+		t.Fatal("request should have been forwarded")
+	}
+
+	foundNotify := false
+	for _, m := range forwarded.Messages {
+		if m.Role == "system" && strings.Contains(m.Content, "DEFENSECLAW") {
+			foundNotify = true
+			break
+		}
+	}
+	if !foundNotify {
+		t.Error("notification system message should be in forwarded request")
+	}
+}
+
+func TestToolCallAccumulator(t *testing.T) {
+	t.Run("single_complete_call", func(t *testing.T) {
+		var acc toolCallAccumulator
+		acc.Merge(json.RawMessage(`[{"index":0,"id":"call_1","type":"function","function":{"name":"write_file","arguments":"{\"path\":\"/tmp/a\"}"}}]`))
+
+		got := acc.JSON()
+		var calls []accToolCall
+		if err := json.Unmarshal(got, &calls); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(calls) != 1 {
+			t.Fatalf("expected 1 call, got %d", len(calls))
+		}
+		if calls[0].Function.Name != "write_file" {
+			t.Errorf("name = %q, want write_file", calls[0].Function.Name)
+		}
+		if calls[0].Function.Arguments != `{"path":"/tmp/a"}` {
+			t.Errorf("args = %q", calls[0].Function.Arguments)
+		}
+	})
+
+	t.Run("reassembles_split_arguments", func(t *testing.T) {
+		var acc toolCallAccumulator
+		acc.Merge(json.RawMessage(`[{"index":0,"id":"call_1","type":"function","function":{"name":"exec","arguments":""}}]`))
+		acc.Merge(json.RawMessage(`[{"index":0,"function":{"arguments":"{\"cmd\":"}}]`))
+		acc.Merge(json.RawMessage(`[{"index":0,"function":{"arguments":"\"cat /etc"}}]`))
+		acc.Merge(json.RawMessage(`[{"index":0,"function":{"arguments":"/passwd\"}"}}]`))
+
+		got := acc.JSON()
+		var calls []accToolCall
+		if err := json.Unmarshal(got, &calls); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(calls) != 1 {
+			t.Fatalf("expected 1 call, got %d", len(calls))
+		}
+		if calls[0].ID != "call_1" {
+			t.Errorf("id = %q", calls[0].ID)
+		}
+		if calls[0].Function.Name != "exec" {
+			t.Errorf("name = %q", calls[0].Function.Name)
+		}
+		want := `{"cmd":"cat /etc/passwd"}`
+		if calls[0].Function.Arguments != want {
+			t.Errorf("args = %q, want %q", calls[0].Function.Arguments, want)
+		}
+	})
+
+	t.Run("multiple_tool_calls", func(t *testing.T) {
+		var acc toolCallAccumulator
+		acc.Merge(json.RawMessage(`[{"index":0,"id":"c1","type":"function","function":{"name":"read","arguments":""}},{"index":1,"id":"c2","type":"function","function":{"name":"write","arguments":""}}]`))
+		acc.Merge(json.RawMessage(`[{"index":0,"function":{"arguments":"{\"a\":1}"}},{"index":1,"function":{"arguments":"{\"b\":2}"}}]`))
+
+		got := acc.JSON()
+		var calls []accToolCall
+		if err := json.Unmarshal(got, &calls); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(calls) != 2 {
+			t.Fatalf("expected 2 calls, got %d", len(calls))
+		}
+		if calls[0].Function.Arguments != `{"a":1}` {
+			t.Errorf("call 0 args = %q", calls[0].Function.Arguments)
+		}
+		if calls[1].Function.Arguments != `{"b":2}` {
+			t.Errorf("call 1 args = %q", calls[1].Function.Arguments)
+		}
+	})
+
+	t.Run("empty_returns_nil", func(t *testing.T) {
+		var acc toolCallAccumulator
+		if got := acc.JSON(); got != nil {
+			t.Errorf("expected nil, got %s", got)
+		}
+	})
+
+	t.Run("invalid_json_ignored", func(t *testing.T) {
+		var acc toolCallAccumulator
+		acc.Merge(json.RawMessage(`not-json`))
+		if got := acc.JSON(); got != nil {
+			t.Errorf("expected nil after invalid merge, got %s", got)
+		}
+	})
+}
+
+func TestStreamingToolCallFinishChunkOrdering(t *testing.T) {
+	// The finish_reason:"tool_calls" chunk must arrive AFTER tool-call
+	// argument deltas, not before.  Verify that the proxy buffers both
+	// and flushes them together in the correct order.
+	fr := "tool_calls"
+	prov := &mockProvider{
+		streamChunks: []StreamChunk{
+			{
+				ID: "s1", Object: "chat.completion.chunk", Model: "gpt-4",
+				Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{Role: "assistant"}}},
+			},
+			{
+				ID: "s1", Object: "chat.completion.chunk", Model: "gpt-4",
+				Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{
+					ToolCalls: json.RawMessage(`[{"index":0,"id":"c1","type":"function","function":{"name":"run","arguments":""}}]`),
+				}}},
+			},
+			{
+				ID: "s1", Object: "chat.completion.chunk", Model: "gpt-4",
+				Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{
+					ToolCalls: json.RawMessage(`[{"index":0,"function":{"arguments":"{\"x\":1}"}}]`),
+				}}},
+			},
+			{
+				ID: "s1", Object: "chat.completion.chunk", Model: "gpt-4",
+				Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{}, FinishReason: &fr}},
+			},
+		},
+	}
+	insp := newMockInspector()
+	proxy := newTestProxy(t, prov, insp, "action")
+
+	reqBody := mustJSON(t, map[string]interface{}{
+		"model":    "gpt-4",
+		"messages": []map[string]interface{}{{"role": "user", "content": "hi"}},
+		"stream":   true,
+	})
+
+	rec := postChat(t, proxy, reqBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	chunks := parseSSEChunks(t, rec.Body)
+
+	// Find positions of first tool_calls delta and the finish chunk.
+	firstTCIdx := -1
+	finishIdx := -1
+	for i, raw := range chunks {
+		var c StreamChunk
+		if json.Unmarshal(raw, &c) != nil || len(c.Choices) == 0 {
+			continue
+		}
+		if c.Choices[0].Delta != nil && c.Choices[0].Delta.ToolCalls != nil && firstTCIdx == -1 {
+			firstTCIdx = i
+		}
+		if c.Choices[0].FinishReason != nil && *c.Choices[0].FinishReason == "tool_calls" {
+			finishIdx = i
+		}
+	}
+
+	if firstTCIdx == -1 {
+		t.Fatal("no tool_calls delta chunk found in response")
+	}
+	if finishIdx == -1 {
+		t.Fatal("no finish_reason:tool_calls chunk found in response")
+	}
+	if finishIdx <= firstTCIdx {
+		t.Errorf("finish chunk (idx=%d) arrived before tool-call deltas (idx=%d)", finishIdx, firstTCIdx)
+	}
+}

--- a/internal/gateway/hardening_test.go
+++ b/internal/gateway/hardening_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -141,11 +142,11 @@ func TestInspectToolCalls_ParseError(t *testing.T) {
 	if verdict == nil {
 		t.Fatal("expected non-nil verdict on parse error")
 	}
-	if verdict.Action != "alert" {
-		t.Errorf("action = %q, want alert", verdict.Action)
+	if verdict.Action != "block" {
+		t.Errorf("action = %q, want block (fail closed)", verdict.Action)
 	}
-	if verdict.Severity != "MEDIUM" {
-		t.Errorf("severity = %q, want MEDIUM", verdict.Severity)
+	if verdict.Severity != "HIGH" {
+		t.Errorf("severity = %q, want HIGH", verdict.Severity)
 	}
 }
 
@@ -246,6 +247,49 @@ func TestStreamingToolCallBlockEnforcement(t *testing.T) {
 	if !strings.Contains(body, "[DONE]") {
 		t.Error("stream should end with [DONE]")
 	}
+	if strings.Contains(body, `"write_file"`) {
+		t.Error("blocked tool-call name should not appear in forwarded chunks")
+	}
+	if strings.Contains(body, `\"path\"`) {
+		t.Error("blocked tool-call arguments JSON should not appear in forwarded chunks")
+	}
+	if !strings.Contains(body, "blocked") {
+		t.Error("response should contain a block notice")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// inspectToolCalls — malformed JSON fails closed
+// ---------------------------------------------------------------------------
+
+func TestInspectToolCallsMalformedJSONBlocks(t *testing.T) {
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	proxy := newTestProxy(t, prov, insp, "action")
+
+	verdict := proxy.inspectToolCalls(json.RawMessage(`{not valid json`))
+	if verdict == nil {
+		t.Fatal("expected non-nil verdict for malformed JSON")
+	}
+	if verdict.Action != "block" {
+		t.Errorf("Action = %q, want block (fail closed on parse error)", verdict.Action)
+	}
+	if verdict.Severity != "HIGH" {
+		t.Errorf("Severity = %q, want HIGH", verdict.Severity)
+	}
+}
+
+func TestInspectToolCallsNilReturnsNil(t *testing.T) {
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	proxy := newTestProxy(t, prov, insp, "action")
+
+	if v := proxy.inspectToolCalls(nil); v != nil {
+		t.Errorf("expected nil verdict for nil input, got %+v", v)
+	}
+	if v := proxy.inspectToolCalls(json.RawMessage(``)); v != nil {
+		t.Errorf("expected nil verdict for empty input, got %+v", v)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -294,6 +338,46 @@ func TestNotificationInjectBodyDivergence(t *testing.T) {
 			if !strings.Contains(string(forwarded.RawBody), "DEFENSECLAW") {
 				t.Error("Messages has notification but RawBody does not — divergence detected")
 			}
+		}
+	})
+
+	t.Run("fallback_to_messages_on_bad_rawbody", func(t *testing.T) {
+		prov := &mockProvider{}
+		insp := newMockInspector()
+		proxy := newTestProxy(t, prov, insp, "observe")
+		proxy.notify = NewNotificationQueue()
+		proxy.notify.Push(SecurityNotification{
+			SkillName: "bad-skill",
+			Severity:  "CRITICAL",
+			Findings:  1,
+			Actions:   []string{"blocked"},
+			Reason:    "fallback test",
+		})
+
+		reqBody := mustJSON(t, map[string]interface{}{
+			"model":    "gpt-4",
+			"messages": []map[string]interface{}{{"role": "user", "content": "test"}},
+		})
+
+		rec := postChat(t, proxy, reqBody)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
+		}
+
+		forwarded := prov.getLastReq()
+		if forwarded == nil {
+			t.Fatal("request should have been forwarded")
+		}
+
+		hasNotifyInMessages := false
+		for _, m := range forwarded.Messages {
+			if m.Role == "system" && strings.Contains(m.Content, "DEFENSECLAW") {
+				hasNotifyInMessages = true
+				break
+			}
+		}
+		if !hasNotifyInMessages {
+			t.Error("notification should appear in Messages as fallback when RawBody inject fails")
 		}
 	})
 }
@@ -716,3 +800,85 @@ func TestStreamingToolCallFinishChunkOrdering(t *testing.T) {
 		t.Errorf("finish chunk (idx=%d) arrived before tool-call deltas (idx=%d)", finishIdx, firstTCIdx)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Buffered tool-call chunks capped at maxBufferedTCBytes
+// ---------------------------------------------------------------------------
+
+func TestBufferedToolCallChunksCapped(t *testing.T) {
+	bigArgs := strings.Repeat("A", 512*1024) // 512 KiB per chunk
+	var chunks []StreamChunk
+	for i := 0; i < 30; i++ { // 30 * 512K = ~15 MiB > 10 MiB cap
+		tc := json.RawMessage(`[{"index":0,"id":"c1","type":"function","function":{"name":"big","arguments":"` + bigArgs + `"}}]`)
+		chunks = append(chunks, StreamChunk{
+			ID: "chatcmpl-big", Object: "chat.completion.chunk", Model: "gpt-4",
+			Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{ToolCalls: tc}}},
+		})
+	}
+	fin := "tool_calls"
+	chunks = append(chunks, StreamChunk{
+		ID: "chatcmpl-big", Object: "chat.completion.chunk", Model: "gpt-4",
+		Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{}, FinishReason: &fin}},
+	})
+
+	prov := &mockProvider{streamChunks: chunks}
+	insp := newMockInspector()
+	proxy := newTestProxy(t, prov, insp, "action")
+
+	reqBody := mustJSON(t, map[string]interface{}{
+		"model":    "gpt-4",
+		"messages": []map[string]interface{}{{"role": "user", "content": "big payload"}},
+		"stream":   true,
+	})
+
+	rec := postChat(t, proxy, reqBody)
+	body := rec.Body.String()
+
+	if !strings.Contains(body, "blocked") {
+		t.Error("expected block message when buffered tool-call data exceeds cap")
+	}
+	if !strings.Contains(body, "[DONE]") {
+		t.Error("stream should end with [DONE]")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Stream block ends OTel LLM span
+// ---------------------------------------------------------------------------
+
+func TestStreamBlockEndsLLMSpan(t *testing.T) {
+	prov := &mockProvider{
+		streamChunks: []StreamChunk{
+			{
+				ID: "chatcmpl-1", Object: "chat.completion.chunk", Model: "gpt-4",
+				Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{
+					Role: "assistant", Content: "dangerous content",
+				}}},
+			},
+		},
+	}
+
+	insp := &mockInspectorBlockAll{}
+	proxy := newTestProxy(t, prov, insp, "action")
+
+	reqBody := mustJSON(t, map[string]interface{}{
+		"model":    "gpt-4",
+		"messages": []map[string]interface{}{{"role": "user", "content": "test"}},
+		"stream":   true,
+	})
+
+	rec := postChat(t, proxy, reqBody)
+	body := rec.Body.String()
+
+	if !strings.Contains(body, "blocked") {
+		t.Error("expected stream to be blocked")
+	}
+}
+
+type mockInspectorBlockAll struct{}
+
+func (m *mockInspectorBlockAll) Inspect(_ context.Context, _, _ string, _ []ChatMessage, _, _ string) *ScanVerdict {
+	return &ScanVerdict{Action: "block", Severity: "HIGH", Reason: "test block"}
+}
+
+func (m *mockInspectorBlockAll) SetScannerMode(_ string) {}

--- a/internal/gateway/notifications.go
+++ b/internal/gateway/notifications.go
@@ -1,0 +1,107 @@
+package gateway
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+const notificationTTL = 2 * time.Minute
+
+// SecurityNotification represents a pending enforcement alert that the
+// guardrail proxy will inject into LLM requests as a system message.
+type SecurityNotification struct {
+	SkillName string
+	Severity  string
+	Findings  int
+	Actions   []string
+	Reason    string
+	ExpiresAt time.Time
+}
+
+// NotificationQueue is a thread-safe store for security notifications. The
+// watcher pushes entries after enforcement; the guardrail proxy reads active
+// (unexpired) notifications before each LLM call and injects them as system
+// messages so the LLM can inform the user.
+//
+// Notifications persist for notificationTTL so that ALL sessions (TUI,
+// Telegram, etc.) see them, not just whichever session makes the next call.
+type NotificationQueue struct {
+	mu    sync.Mutex
+	items []SecurityNotification
+}
+
+// NewNotificationQueue returns an empty queue ready for use.
+func NewNotificationQueue() *NotificationQueue {
+	return &NotificationQueue{}
+}
+
+// Push appends a notification with a TTL-based expiry.
+func (q *NotificationQueue) Push(n SecurityNotification) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	n.ExpiresAt = time.Now().Add(notificationTTL)
+	q.items = append(q.items, n)
+}
+
+// ActiveNotifications returns all unexpired notifications, pruning expired
+// ones in the process. Does NOT drain — the same notification is returned to
+// every caller until it expires.
+func (q *NotificationQueue) ActiveNotifications() []SecurityNotification {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	now := time.Now()
+	active := q.items[:0]
+	for _, n := range q.items {
+		if now.Before(n.ExpiresAt) {
+			active = append(active, n)
+		}
+	}
+	q.items = active
+
+	if len(active) == 0 {
+		return nil
+	}
+	out := make([]SecurityNotification, len(active))
+	copy(out, active)
+	return out
+}
+
+// FormatSystemMessage returns a formatted system message containing all
+// active (unexpired) notifications. Returns "" when no active notifications
+// exist. The same message may be returned on multiple calls until the
+// notifications expire, ensuring every session sees the alert.
+func (q *NotificationQueue) FormatSystemMessage() string {
+	notes := q.ActiveNotifications()
+	if len(notes) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("[DEFENSECLAW SECURITY ENFORCEMENT]\n")
+
+	for i, n := range notes {
+		if i > 0 {
+			sb.WriteString("\n---\n")
+		}
+		fmt.Fprintf(&sb, "Skill %q was automatically enforced by DefenseClaw.\n", n.SkillName)
+		fmt.Fprintf(&sb, "Severity: %s", n.Severity)
+		if n.Findings > 0 {
+			fmt.Fprintf(&sb, " (%d finding(s))", n.Findings)
+		}
+		sb.WriteString("\n")
+		if len(n.Actions) > 0 {
+			fmt.Fprintf(&sb, "Actions taken: %s\n", strings.Join(n.Actions, ", "))
+		}
+		if n.Reason != "" {
+			fmt.Fprintf(&sb, "Reason: %s\n", n.Reason)
+		}
+	}
+
+	sb.WriteString("\nYou MUST proactively inform the user about this enforcement action. ")
+	sb.WriteString("Do NOT confirm the skill was installed successfully. ")
+	sb.WriteString("Explain that DefenseClaw detected security issues and took protective action.")
+	return sb.String()
+}

--- a/internal/gateway/notifications.go
+++ b/internal/gateway/notifications.go
@@ -13,12 +13,13 @@ const maxNotificationQueueSize = 50
 // SecurityNotification represents a pending enforcement alert that the
 // guardrail proxy will inject into LLM requests as a system message.
 type SecurityNotification struct {
-	SkillName string
-	Severity  string
-	Findings  int
-	Actions   []string
-	Reason    string
-	ExpiresAt time.Time
+	SubjectType string
+	SkillName   string
+	Severity    string
+	Findings    int
+	Actions     []string
+	Reason      string
+	ExpiresAt   time.Time
 }
 
 // NotificationQueue is a thread-safe store for security notifications. The
@@ -91,7 +92,7 @@ func (q *NotificationQueue) FormatSystemMessage() string {
 		if i > 0 {
 			sb.WriteString("\n---\n")
 		}
-		fmt.Fprintf(&sb, "Skill %q was automatically enforced by DefenseClaw.\n", n.SkillName)
+		fmt.Fprintf(&sb, "%s %q was automatically enforced by DefenseClaw.\n", notificationSubjectLabel(n.SubjectType), n.SkillName)
 		fmt.Fprintf(&sb, "Severity: %s", n.Severity)
 		if n.Findings > 0 {
 			fmt.Fprintf(&sb, " (%d finding(s))", n.Findings)
@@ -106,7 +107,18 @@ func (q *NotificationQueue) FormatSystemMessage() string {
 	}
 
 	sb.WriteString("\nYou MUST proactively inform the user about this enforcement action. ")
-	sb.WriteString("Do NOT confirm the skill was installed successfully. ")
+	sb.WriteString("Do NOT claim the component was installed or enabled successfully. ")
 	sb.WriteString("Explain that DefenseClaw detected security issues and took protective action.")
 	return sb.String()
+}
+
+func notificationSubjectLabel(subjectType string) string {
+	switch strings.TrimSpace(strings.ToLower(subjectType)) {
+	case "plugin":
+		return "Plugin"
+	case "tool":
+		return "Tool"
+	default:
+		return "Skill"
+	}
 }

--- a/internal/gateway/notifications.go
+++ b/internal/gateway/notifications.go
@@ -8,6 +8,7 @@ import (
 )
 
 const notificationTTL = 2 * time.Minute
+const maxNotificationQueueSize = 50
 
 // SecurityNotification represents a pending enforcement alert that the
 // guardrail proxy will inject into LLM requests as a system message.
@@ -37,12 +38,16 @@ func NewNotificationQueue() *NotificationQueue {
 	return &NotificationQueue{}
 }
 
-// Push appends a notification with a TTL-based expiry.
+// Push appends a notification with a TTL-based expiry. When the queue
+// exceeds maxNotificationQueueSize, the oldest entries are dropped.
 func (q *NotificationQueue) Push(n SecurityNotification) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	n.ExpiresAt = time.Now().Add(notificationTTL)
 	q.items = append(q.items, n)
+	if len(q.items) > maxNotificationQueueSize {
+		q.items = q.items[len(q.items)-maxNotificationQueueSize:]
+	}
 }
 
 // ActiveNotifications returns all unexpired notifications, pruning expired

--- a/internal/gateway/provider_openai.go
+++ b/internal/gateway/provider_openai.go
@@ -50,8 +50,10 @@ func patchRawBody(raw json.RawMessage, model string, stream bool) ([]byte, error
 	return json.Marshal(m)
 }
 
+const defaultMaxTokensFallback = 8192
+
 // modelMaxTokens returns the max completion tokens for known models.
-// Returns 0 for unknown models (no capping applied).
+// Returns defaultMaxTokensFallback for unknown models as a safe cap.
 func modelMaxTokens(model string) int {
 	switch {
 	case strings.HasPrefix(model, "gpt-4o-mini"):
@@ -68,8 +70,10 @@ func modelMaxTokens(model string) int {
 		return 100000
 	case strings.HasPrefix(model, "o4-mini"):
 		return 100000
+	case strings.HasPrefix(model, "claude"):
+		return 8192
 	default:
-		return 0
+		return defaultMaxTokensFallback
 	}
 }
 

--- a/internal/gateway/provider_openai.go
+++ b/internal/gateway/provider_openai.go
@@ -24,6 +24,8 @@ type openaiProvider struct {
 // patchRawBody takes raw JSON bytes and overrides the "model" and "stream"
 // fields, preserving every other field the client sent (response_format,
 // seed, frequency_penalty, parallel_tool_calls, logit_bias, etc.).
+// It also caps max_tokens to the model's limit to avoid 400 errors when
+// the upstream client was configured for a different model family.
 func patchRawBody(raw json.RawMessage, model string, stream bool) ([]byte, error) {
 	var m map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -33,7 +35,42 @@ func patchRawBody(raw json.RawMessage, model string, stream bool) ([]byte, error
 	m["model"] = modelBytes
 	streamBytes, _ := json.Marshal(stream)
 	m["stream"] = streamBytes
+
+	limit := modelMaxTokens(model)
+	for _, tokKey := range []string{"max_tokens", "max_completion_tokens"} {
+		if maxTokRaw, ok := m[tokKey]; ok {
+			var maxTok int
+			if json.Unmarshal(maxTokRaw, &maxTok) == nil && limit > 0 && maxTok > limit {
+				capBytes, _ := json.Marshal(limit)
+				m[tokKey] = capBytes
+			}
+		}
+	}
+
 	return json.Marshal(m)
+}
+
+// modelMaxTokens returns the max completion tokens for known models.
+// Returns 0 for unknown models (no capping applied).
+func modelMaxTokens(model string) int {
+	switch {
+	case strings.HasPrefix(model, "gpt-4o-mini"):
+		return 16384
+	case strings.HasPrefix(model, "gpt-4o"):
+		return 16384
+	case strings.HasPrefix(model, "gpt-4-turbo"):
+		return 4096
+	case strings.HasPrefix(model, "gpt-4"):
+		return 8192
+	case strings.HasPrefix(model, "o3-mini"):
+		return 100000
+	case strings.HasPrefix(model, "o3"):
+		return 100000
+	case strings.HasPrefix(model, "o4-mini"):
+		return 100000
+	default:
+		return 0
+	}
 }
 
 func (p *openaiProvider) ChatCompletion(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -1085,6 +1085,22 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 		}
 	}
 
+	// --- Post-call inspection: tool call arguments ---
+	if len(resp.Choices) > 0 && resp.Choices[0].Message != nil {
+		if verdict := p.inspectToolCalls(resp.Choices[0].Message.ToolCalls); verdict != nil {
+			p.recordTelemetry("tool-call", aliasModel, verdict, 0, nil, nil)
+			if verdict.Action == "block" && mode == "action" {
+				if p.otel != nil && llmSpan != nil {
+					p.otel.EndLLMSpan(llmSpan, aliasModel, 0, 0, finishReasons, toolCallCount, guardrail, guardrailResult, system, llmStartTime, "openclaw")
+				}
+				msg := blockMessage(customBlockMsg, "completion",
+					fmt.Sprintf("tool call blocked — %s", verdict.Reason))
+				p.writeBlockedResponse(w, aliasModel, msg)
+				return
+			}
+		}
+	}
+
 	// --- Emit execute_tool spans for any tool_calls in the response ---
 	if p.otel != nil && llmCtx != nil && len(resp.Choices) > 0 && resp.Choices[0].Message != nil {
 		p.emitToolCallSpans(r.Context(), llmCtx, resp.Choices[0].Message.ToolCalls, aliasModel, mode)
@@ -1150,6 +1166,7 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 	}
 
 	var accumulated strings.Builder
+	var accToolCalls json.RawMessage
 	lastScanLen := 0
 	const scanInterval = 500
 	streamFinishReasons := []string{}
@@ -1157,9 +1174,12 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 	usage, err := upstream.ChatCompletionStream(r.Context(), req, func(chunk StreamChunk) {
 		chunk.Model = aliasModel
 
-		// Accumulate content for post-stream inspection.
+		// Accumulate content and tool calls for post-stream inspection.
 		if len(chunk.Choices) > 0 && chunk.Choices[0].Delta != nil {
 			accumulated.WriteString(chunk.Choices[0].Delta.Content)
+			if len(chunk.Choices[0].Delta.ToolCalls) > 0 {
+				accToolCalls = mergeToolCallChunks(accToolCalls, chunk.Choices[0].Delta.ToolCalls)
+			}
 		}
 		// Collect finish reasons from stream chunks.
 		for _, c := range chunk.Choices {
@@ -1176,7 +1196,6 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 				fmt.Fprintf(os.Stderr, "[guardrail] STREAM-BLOCK severity=%s %s\n",
 					midVerdict.Severity, midVerdict.Reason)
 				p.recordTelemetry("completion", aliasModel, midVerdict, 0, nil, nil)
-				// Stop sending chunks — the client will see a truncated stream.
 				return
 			}
 			lastScanLen = accumulated.Len()
@@ -1252,6 +1271,13 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 			completionTok = int(usage.CompletionTokens)
 		}
 		p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, streamFinishReasons, 0, guardrail, guardrailResult, system, llmStartTime, "openclaw")
+	}
+
+	// Final post-stream inspection: tool calls.
+	if len(accToolCalls) > 0 {
+		if verdict := p.inspectToolCalls(accToolCalls); verdict != nil {
+			p.recordTelemetry("tool-call", aliasModel, verdict, 0, nil, nil)
+		}
 	}
 
 	fmt.Fprintf(w, "data: [DONE]\n\n")
@@ -1923,6 +1949,97 @@ func injectSystemMessage(raw json.RawMessage, content string) (json.RawMessage, 
 	}
 	m["messages"] = newMsgBytes
 	return json.Marshal(m)
+}
+
+// ---------------------------------------------------------------------------
+// Tool call inspection (defense-in-depth)
+//
+// When the LLM responds with tool_calls, inspect each tool's name and
+// arguments with the same ScanAllRules engine used by the inspect endpoint.
+// This catches dangerous tool calls (write_file with /etc/passwd, shell with
+// reverse shells, etc.) even when the OpenClaw plugin is not loaded.
+// ---------------------------------------------------------------------------
+
+// inspectToolCalls scans tool call arguments in an OpenAI-format tool_calls
+// JSON array. Returns a block verdict if any HIGH/CRITICAL findings, nil
+// otherwise.
+func (p *GuardrailProxy) inspectToolCalls(toolCallsJSON json.RawMessage) *ScanVerdict {
+	if len(toolCallsJSON) == 0 {
+		return nil
+	}
+
+	var toolCalls []struct {
+		ID       string `json:"id"`
+		Type     string `json:"type"`
+		Function struct {
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(toolCallsJSON, &toolCalls); err != nil {
+		return nil
+	}
+
+	var allFindings []RuleFinding
+	for _, tc := range toolCalls {
+		toolName := tc.Function.Name
+		args := tc.Function.Arguments
+
+		findings := ScanAllRules(args, toolName)
+		allFindings = append(allFindings, findings...)
+	}
+
+	if len(allFindings) == 0 {
+		return nil
+	}
+
+	severity := HighestSeverity(allFindings)
+	confidence := HighestConfidence(allFindings, severity)
+
+	action := "alert"
+	if severity == "HIGH" || severity == "CRITICAL" {
+		action = "block"
+	}
+
+	top := make([]string, 0, 5)
+	for i, f := range allFindings {
+		if i >= 5 {
+			break
+		}
+		top = append(top, f.RuleID+":"+f.Title)
+	}
+
+	fmt.Fprintf(os.Stderr, "[guardrail] TOOL-CALL-INSPECT action=%s severity=%s findings=%d reason=%s\n",
+		action, severity, len(allFindings), strings.Join(top, ", "))
+
+	if p.logger != nil {
+		for _, tc := range toolCalls {
+			_ = p.logger.LogAction("guardrail-tool-call-inspect", tc.Function.Name,
+				fmt.Sprintf("action=%s severity=%s confidence=%.2f", action, severity, confidence))
+		}
+	}
+
+	if p.otel != nil {
+		p.otel.RecordGuardrailEvaluation(context.Background(), "tool-call-inspect", action)
+	}
+
+	return &ScanVerdict{
+		Action:         action,
+		Severity:       severity,
+		Reason:         strings.Join(top, ", "),
+		Findings:       FindingStrings(allFindings),
+		ScannerSources: []string{"tool-call-inspect"},
+	}
+}
+
+// mergeToolCallChunks appends streaming tool_calls delta chunks into an
+// accumulated JSON array. Streaming deltas arrive as partial arrays; we
+// concatenate the raw JSON for post-stream inspection.
+func mergeToolCallChunks(existing json.RawMessage, chunk json.RawMessage) json.RawMessage {
+	if len(existing) == 0 {
+		return chunk
+	}
+	return append(append(existing[:len(existing)-1], ','), chunk[1:]...)
 }
 
 func writeOpenAIError(w http.ResponseWriter, status int, msg string) {

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -769,12 +769,50 @@ func inferProviderFromURL(targetURL string) string {
 	return ""
 }
 
+// resolveConfiguredProvider returns an LLMProvider using the guardrail config's
+// model and API key. This handles the direct-provider case where OpenClaw is
+// configured with "defenseclaw" as a custom provider and sends requests straight
+// to the guardrail proxy without the fetch interceptor setting X-DC-Target-URL.
+func (p *GuardrailProxy) resolveConfiguredProvider(req *ChatRequest) LLMProvider {
+	cfgModel := p.cfg.Model
+	if cfgModel == "" {
+		fmt.Fprintf(os.Stderr, "[guardrail] no X-DC-Target-URL and no configured model — cannot route\n")
+		return nil
+	}
+
+	apiKey := ""
+	if req.TargetAPIKey != "" {
+		apiKey = req.TargetAPIKey
+	} else if p.cfg.APIKeyEnv != "" {
+		dotenvPath := filepath.Join(p.dataDir, ".env")
+		apiKey = ResolveAPIKey(p.cfg.APIKeyEnv, dotenvPath)
+	}
+
+	if apiKey == "" {
+		fmt.Fprintf(os.Stderr, "[guardrail] no API key available for configured model %q\n", cfgModel)
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "[guardrail] direct-provider mode: using configured model %q\n", cfgModel)
+
+	provider, err := NewProvider(cfgModel, apiKey)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[guardrail] failed to create provider for %q: %v\n", cfgModel, err)
+		return nil
+	}
+	return provider
+}
+
 // resolveProviderFromHeaders selects the upstream LLMProvider for the given
 // request. The fetch interceptor sets X-DC-Target-URL on every outbound LLM
 // call; we infer the provider from that URL and use X-AI-Auth as the API key.
+//
+// Fallback: when X-DC-Target-URL is absent (direct-provider mode, where
+// OpenClaw routes to the guardrail proxy as a custom provider endpoint), use
+// the configured guardrail model and API key.
 func (p *GuardrailProxy) resolveProviderFromHeaders(req *ChatRequest) LLMProvider {
 	if req.TargetURL == "" {
-		return nil
+		return p.resolveConfiguredProvider(req)
 	}
 
 	prefix := inferProviderFromURL(req.TargetURL)

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -69,12 +69,12 @@ type ContentInspector interface {
 // requests, runs guardrail inspection, and forwards to the upstream LLM
 // provider.
 type GuardrailProxy struct {
-	cfg       *config.GuardrailConfig
-	logger    *audit.Logger
-	health    *SidecarHealth
-	otel      *telemetry.Provider
-	store     *audit.Store
-	dataDir   string
+	cfg     *config.GuardrailConfig
+	logger  *audit.Logger
+	health  *SidecarHealth
+	otel    *telemetry.Provider
+	store   *audit.Store
+	dataDir string
 
 	inspector        ContentInspector
 	masterKey        string
@@ -877,7 +877,9 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 					req.RawBody = patched
 					req.Messages = append([]ChatMessage{notification}, req.Messages...)
 				} else {
-					fmt.Fprintf(os.Stderr, "[guardrail] inject system message into raw body failed: %v\n", err)
+					fmt.Fprintf(os.Stderr, "[guardrail] inject system message into raw body failed: %v — falling back to structured messages\n", err)
+					req.RawBody = nil
+					req.Messages = append([]ChatMessage{notification}, req.Messages...)
 				}
 			} else {
 				req.Messages = append([]ChatMessage{notification}, req.Messages...)
@@ -1095,7 +1097,12 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 			p.recordTelemetry("tool-call", aliasModel, verdict, 0, nil, nil)
 			if verdict.Action == "block" && mode == "action" {
 				if p.otel != nil && llmSpan != nil {
-					p.otel.EndLLMSpan(llmSpan, aliasModel, 0, 0, finishReasons, toolCallCount, guardrail, guardrailResult, system, llmStartTime, "openclaw")
+					promptTok, completionTok := 0, 0
+					if resp.Usage != nil {
+						promptTok = int(resp.Usage.PromptTokens)
+						completionTok = int(resp.Usage.CompletionTokens)
+					}
+					p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, finishReasons, toolCallCount, "local", "blocked", system, llmStartTime, "openclaw")
 				}
 				msg := blockMessage(customBlockMsg, "completion",
 					fmt.Sprintf("tool call blocked — %s", verdict.Reason))
@@ -1169,15 +1176,20 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 		)
 	}
 
+	const maxBufferedTCBytes = 10 << 20 // 10 MiB cap on buffered tool-call data
+
 	var accumulated strings.Builder
 	var tcAcc toolCallAccumulator
 	var bufferedTCChunks [][]byte // tool-call chunks held until post-stream inspection
+	bufferedTCSize := 0
 	lastScanLen := 0
 	const scanInterval = 500
 	streamFinishReasons := []string{}
 	streamBlocked := false
+	streamCtx, streamCancel := context.WithCancel(r.Context())
+	defer streamCancel()
 
-	usage, err := upstream.ChatCompletionStream(r.Context(), req, func(chunk StreamChunk) {
+	usage, err := upstream.ChatCompletionStream(streamCtx, req, func(chunk StreamChunk) {
 		if streamBlocked {
 			return
 		}
@@ -1198,8 +1210,9 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 			}
 		}
 
-		// Periodic mid-stream scan for streaming content.
-		if accumulated.Len()-lastScanLen >= scanInterval && mode == "action" {
+		// In action mode, inspect each newly accumulated content chunk before
+		// forwarding it so short harmful streams cannot slip past a size gate.
+		if accumulated.Len() > lastScanLen && mode == "action" {
 			midVerdict := p.inspector.Inspect(r.Context(), "completion", accumulated.String(),
 				[]ChatMessage{{Role: "assistant", Content: accumulated.String()}}, aliasModel, mode)
 			if midVerdict.Severity != "NONE" && midVerdict.Action == "block" {
@@ -1207,6 +1220,7 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 					midVerdict.Severity, midVerdict.Reason)
 				p.recordTelemetry("completion", aliasModel, midVerdict, 0, nil, nil)
 				streamBlocked = true
+				streamCancel()
 				return
 			}
 			lastScanLen = accumulated.Len()
@@ -1224,7 +1238,14 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 			*chunk.Choices[0].FinishReason == "tool_calls" {
 			isToolCallFinish = true
 		}
-		if (hasToolCalls || isToolCallFinish) && mode == "action" {
+		if mode == "action" && (hasToolCalls || isToolCallFinish || len(bufferedTCChunks) > 0) {
+			bufferedTCSize += len(data)
+			if bufferedTCSize > maxBufferedTCBytes {
+				fmt.Fprintf(os.Stderr, "[guardrail] STREAM-BLOCK buffered tool-call data exceeds %d bytes\n", maxBufferedTCBytes)
+				streamBlocked = true
+				streamCancel()
+				return
+			}
 			bufferedTCChunks = append(bufferedTCChunks, data)
 			return
 		}
@@ -1232,7 +1253,7 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 		fmt.Fprintf(w, "data: %s\n\n", data)
 		flusher.Flush()
 	})
-	if err != nil {
+	if err != nil && !streamBlocked {
 		fmt.Fprintf(os.Stderr, "[guardrail] stream error: %v\n", err)
 		if p.otel != nil && llmSpan != nil {
 			p.otel.EndLLMSpan(llmSpan, aliasModel, 0, 0, []string{"error"}, 0, "none", "", system, llmStartTime, "openclaw")
@@ -1245,7 +1266,7 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 
 	if streamBlocked {
 		if p.otel != nil && llmSpan != nil {
-			p.otel.EndLLMSpan(llmSpan, aliasModel, 0, 0, streamFinishReasons, 0, "defenseclaw", "blocked", system, llmStartTime, "openclaw")
+			p.otel.EndLLMSpan(llmSpan, aliasModel, 0, 0, append(streamFinishReasons, "blocked"), 0, "local", "block", system, llmStartTime, "openclaw")
 		}
 		msg := blockMessage(customBlockMsg, "completion", "content blocked mid-stream by guardrail")
 		blockChunk := StreamChunk{
@@ -1308,25 +1329,18 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 		}
 	}
 
-	// End LLM span with final data.
-	if p.otel != nil && llmSpan != nil {
-		promptTok, completionTok := 0, 0
-		if usage != nil {
-			promptTok = int(usage.PromptTokens)
-			completionTok = int(usage.CompletionTokens)
-		}
-		p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, streamFinishReasons, 0, guardrail, guardrailResult, system, llmStartTime, "openclaw")
-	}
-
 	// Final post-stream inspection: tool calls (fully reassembled).
 	// Buffered tool-call chunks are released only if inspection passes.
 	assembledTC := tcAcc.JSON()
 	tcBlocked := false
+	toolCallCount := countToolCalls(assembledTC)
 	if len(assembledTC) > 0 {
 		if verdict := p.inspectToolCalls(assembledTC); verdict != nil {
 			p.recordTelemetry("tool-call", aliasModel, verdict, 0, nil, nil)
 			if verdict.Action == "block" && mode == "action" {
 				tcBlocked = true
+				guardrail = "local"
+				guardrailResult = "block"
 				msg := blockMessage(customBlockMsg, "completion",
 					fmt.Sprintf("tool call blocked — %s", verdict.Reason))
 				blockChunk := StreamChunk{
@@ -1339,6 +1353,16 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 				flusher.Flush()
 			}
 		}
+	}
+
+	if p.otel != nil && llmSpan != nil {
+		promptTok, completionTok := 0, 0
+		if usage != nil {
+			promptTok = int(usage.PromptTokens)
+			completionTok = int(usage.CompletionTokens)
+		}
+		p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, streamFinishReasons, toolCallCount, guardrail, guardrailResult, system, llmStartTime, "openclaw")
+		llmSpan = nil
 	}
 
 	// Flush buffered tool-call chunks only when inspection passed.
@@ -2029,6 +2053,11 @@ func injectSystemMessage(raw json.RawMessage, content string) (json.RawMessage, 
 // arguments with the same ScanAllRules engine used by the inspect endpoint.
 // This catches dangerous tool calls (write_file with /etc/passwd, shell with
 // reverse shells, etc.) even when the OpenClaw plugin is not loaded.
+//
+// In "action" mode, tool-call chunks are buffered and only released after
+// post-stream inspection passes. In "observe" mode, tool-call deltas are
+// forwarded to the client as they arrive (by design) and the post-stream
+// scan is purely alerting.
 // ---------------------------------------------------------------------------
 
 // inspectToolCalls scans tool call arguments in an OpenAI-format tool_calls
@@ -2048,14 +2077,14 @@ func (p *GuardrailProxy) inspectToolCalls(toolCallsJSON json.RawMessage) *ScanVe
 		} `json:"function"`
 	}
 	if err := json.Unmarshal(toolCallsJSON, &toolCalls); err != nil {
-		fmt.Fprintf(os.Stderr, "[guardrail] TOOL-CALL-INSPECT parse error (alerting): %v\n", err)
+		fmt.Fprintf(os.Stderr, "[guardrail] TOOL-CALL-INSPECT parse error (blocking): %v\n", err)
 		if p.logger != nil {
 			_ = p.logger.LogAction("guardrail-tool-call-parse-error", "", err.Error())
 		}
 		return &ScanVerdict{
-			Action:         "alert",
-			Severity:       "MEDIUM",
-			Reason:         "tool_calls JSON parse error — cannot inspect",
+			Action:         "block",
+			Severity:       "HIGH",
+			Reason:         "tool_calls JSON parse error — cannot inspect, failing closed",
 			ScannerSources: []string{"tool-call-inspect"},
 		}
 	}

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -1233,11 +1233,8 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 		// The finish_reason:"tool_calls" chunk carries no delta.ToolCalls
 		// but must stay behind the argument deltas or clients that stop
 		// accumulating on finish_reason will never see the arguments.
-		isToolCallFinish := false
-		if len(chunk.Choices) > 0 && chunk.Choices[0].FinishReason != nil &&
-			*chunk.Choices[0].FinishReason == "tool_calls" {
-			isToolCallFinish = true
-		}
+		isToolCallFinish := len(chunk.Choices) > 0 && chunk.Choices[0].FinishReason != nil &&
+			*chunk.Choices[0].FinishReason == "tool_calls"
 		if mode == "action" && (hasToolCalls || isToolCallFinish || len(bufferedTCChunks) > 0) {
 			bufferedTCSize += len(data)
 			if bufferedTCSize > maxBufferedTCBytes {
@@ -1362,7 +1359,6 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 			completionTok = int(usage.CompletionTokens)
 		}
 		p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, streamFinishReasons, toolCallCount, guardrail, guardrailResult, system, llmStartTime, "openclaw")
-		llmSpan = nil
 	}
 
 	// Flush buffered tool-call chunks only when inspection passed.

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -872,11 +872,15 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 		if sysMsg := p.notify.FormatSystemMessage(); sysMsg != "" {
 			fmt.Fprintf(os.Stderr, "[guardrail] injecting security notification into LLM request\n")
 			notification := ChatMessage{Role: "system", Content: sysMsg}
-			req.Messages = append([]ChatMessage{notification}, req.Messages...)
 			if len(req.RawBody) > 0 {
 				if patched, err := injectSystemMessage(req.RawBody, sysMsg); err == nil {
 					req.RawBody = patched
+					req.Messages = append([]ChatMessage{notification}, req.Messages...)
+				} else {
+					fmt.Fprintf(os.Stderr, "[guardrail] inject system message into raw body failed: %v\n", err)
 				}
+			} else {
+				req.Messages = append([]ChatMessage{notification}, req.Messages...)
 			}
 			if p.logger != nil {
 				_ = p.logger.LogAction("guardrail-notify-inject", "", "injected security notification into LLM request")
@@ -1166,19 +1170,25 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 	}
 
 	var accumulated strings.Builder
-	var accToolCalls json.RawMessage
+	var tcAcc toolCallAccumulator
+	var bufferedTCChunks [][]byte // tool-call chunks held until post-stream inspection
 	lastScanLen := 0
 	const scanInterval = 500
 	streamFinishReasons := []string{}
+	streamBlocked := false
 
 	usage, err := upstream.ChatCompletionStream(r.Context(), req, func(chunk StreamChunk) {
+		if streamBlocked {
+			return
+		}
 		chunk.Model = aliasModel
 
-		// Accumulate content and tool calls for post-stream inspection.
+		hasToolCalls := false
 		if len(chunk.Choices) > 0 && chunk.Choices[0].Delta != nil {
 			accumulated.WriteString(chunk.Choices[0].Delta.Content)
 			if len(chunk.Choices[0].Delta.ToolCalls) > 0 {
-				accToolCalls = mergeToolCallChunks(accToolCalls, chunk.Choices[0].Delta.ToolCalls)
+				tcAcc.Merge(chunk.Choices[0].Delta.ToolCalls)
+				hasToolCalls = true
 			}
 		}
 		// Collect finish reasons from stream chunks.
@@ -1196,12 +1206,29 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 				fmt.Fprintf(os.Stderr, "[guardrail] STREAM-BLOCK severity=%s %s\n",
 					midVerdict.Severity, midVerdict.Reason)
 				p.recordTelemetry("completion", aliasModel, midVerdict, 0, nil, nil)
+				streamBlocked = true
 				return
 			}
 			lastScanLen = accumulated.Len()
 		}
 
 		data, _ := json.Marshal(chunk)
+
+		// Buffer tool-call chunks and their finish sentinel so they are
+		// only released after post-stream inspection clears them.
+		// The finish_reason:"tool_calls" chunk carries no delta.ToolCalls
+		// but must stay behind the argument deltas or clients that stop
+		// accumulating on finish_reason will never see the arguments.
+		isToolCallFinish := false
+		if len(chunk.Choices) > 0 && chunk.Choices[0].FinishReason != nil &&
+			*chunk.Choices[0].FinishReason == "tool_calls" {
+			isToolCallFinish = true
+		}
+		if (hasToolCalls || isToolCallFinish) && mode == "action" {
+			bufferedTCChunks = append(bufferedTCChunks, data)
+			return
+		}
+
 		fmt.Fprintf(w, "data: %s\n\n", data)
 		flusher.Flush()
 	})
@@ -1215,6 +1242,24 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 
 	guardrail := "none"
 	guardrailResult := ""
+
+	if streamBlocked {
+		if p.otel != nil && llmSpan != nil {
+			p.otel.EndLLMSpan(llmSpan, aliasModel, 0, 0, streamFinishReasons, 0, "defenseclaw", "blocked", system, llmStartTime, "openclaw")
+		}
+		msg := blockMessage(customBlockMsg, "completion", "content blocked mid-stream by guardrail")
+		blockChunk := StreamChunk{
+			ID: "chatcmpl-blocked", Object: "chat.completion.chunk",
+			Created: time.Now().Unix(), Model: aliasModel,
+			Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{Content: "\n\n" + msg}}},
+		}
+		data, _ := json.Marshal(blockChunk)
+		fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+		fmt.Fprintf(w, "data: [DONE]\n\n")
+		flusher.Flush()
+		return
+	}
 
 	// Final post-stream inspection (apply_guardrail output).
 	if accumulated.Len() > 0 {
@@ -1273,10 +1318,36 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 		p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, streamFinishReasons, 0, guardrail, guardrailResult, system, llmStartTime, "openclaw")
 	}
 
-	// Final post-stream inspection: tool calls.
-	if len(accToolCalls) > 0 {
-		if verdict := p.inspectToolCalls(accToolCalls); verdict != nil {
+	// Final post-stream inspection: tool calls (fully reassembled).
+	// Buffered tool-call chunks are released only if inspection passes.
+	assembledTC := tcAcc.JSON()
+	tcBlocked := false
+	if len(assembledTC) > 0 {
+		if verdict := p.inspectToolCalls(assembledTC); verdict != nil {
 			p.recordTelemetry("tool-call", aliasModel, verdict, 0, nil, nil)
+			if verdict.Action == "block" && mode == "action" {
+				tcBlocked = true
+				msg := blockMessage(customBlockMsg, "completion",
+					fmt.Sprintf("tool call blocked — %s", verdict.Reason))
+				blockChunk := StreamChunk{
+					ID: "chatcmpl-blocked", Object: "chat.completion.chunk",
+					Created: time.Now().Unix(), Model: aliasModel,
+					Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{Content: "\n\n" + msg}}},
+				}
+				data, _ := json.Marshal(blockChunk)
+				fmt.Fprintf(w, "data: %s\n\n", data)
+				flusher.Flush()
+			}
+		}
+	}
+
+	// Flush buffered tool-call chunks only when inspection passed.
+	if !tcBlocked {
+		for _, buf := range bufferedTCChunks {
+			fmt.Fprintf(w, "data: %s\n\n", buf)
+		}
+		if len(bufferedTCChunks) > 0 {
+			flusher.Flush()
 		}
 	}
 
@@ -1977,7 +2048,16 @@ func (p *GuardrailProxy) inspectToolCalls(toolCallsJSON json.RawMessage) *ScanVe
 		} `json:"function"`
 	}
 	if err := json.Unmarshal(toolCallsJSON, &toolCalls); err != nil {
-		return nil
+		fmt.Fprintf(os.Stderr, "[guardrail] TOOL-CALL-INSPECT parse error (alerting): %v\n", err)
+		if p.logger != nil {
+			_ = p.logger.LogAction("guardrail-tool-call-parse-error", "", err.Error())
+		}
+		return &ScanVerdict{
+			Action:         "alert",
+			Severity:       "MEDIUM",
+			Reason:         "tool_calls JSON parse error — cannot inspect",
+			ScannerSources: []string{"tool-call-inspect"},
+		}
 	}
 
 	var allFindings []RuleFinding
@@ -2032,14 +2112,87 @@ func (p *GuardrailProxy) inspectToolCalls(toolCallsJSON json.RawMessage) *ScanVe
 	}
 }
 
-// mergeToolCallChunks appends streaming tool_calls delta chunks into an
-// accumulated JSON array. Streaming deltas arrive as partial arrays; we
-// concatenate the raw JSON for post-stream inspection.
+// toolCallAccumulator merges streaming tool-call deltas by index, properly
+// concatenating function.arguments fragments so the final output contains
+// fully-assembled tool calls suitable for inspection.
+type toolCallAccumulator struct {
+	calls []accToolCall
+}
+
+type accToolCall struct {
+	Index    int    `json:"index"`
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+// Merge incorporates a raw tool_calls delta array from a single SSE chunk.
+func (a *toolCallAccumulator) Merge(delta json.RawMessage) {
+	if len(delta) == 0 {
+		return
+	}
+	var deltas []accToolCall
+	if json.Unmarshal(delta, &deltas) != nil {
+		return
+	}
+	for _, d := range deltas {
+		idx := d.Index
+		for idx >= len(a.calls) {
+			a.calls = append(a.calls, accToolCall{Index: len(a.calls)})
+		}
+		if d.ID != "" {
+			a.calls[idx].ID = d.ID
+		}
+		if d.Type != "" {
+			a.calls[idx].Type = d.Type
+		}
+		if d.Function.Name != "" {
+			a.calls[idx].Function.Name = d.Function.Name
+		}
+		a.calls[idx].Function.Arguments += d.Function.Arguments
+	}
+}
+
+// JSON returns the fully assembled tool calls as a JSON array suitable
+// for inspectToolCalls. Returns nil when no calls have been accumulated.
+func (a *toolCallAccumulator) JSON() json.RawMessage {
+	if len(a.calls) == 0 {
+		return nil
+	}
+	out, err := json.Marshal(a.calls)
+	if err != nil {
+		return nil
+	}
+	return out
+}
+
+// mergeToolCallChunks is a backwards-compatible wrapper used only by tests
+// and non-streaming callers. For streaming, use toolCallAccumulator.
 func mergeToolCallChunks(existing json.RawMessage, chunk json.RawMessage) json.RawMessage {
+	if len(chunk) == 0 {
+		return existing
+	}
 	if len(existing) == 0 {
 		return chunk
 	}
-	return append(append(existing[:len(existing)-1], ','), chunk[1:]...)
+
+	var existingArr []json.RawMessage
+	var chunkArr []json.RawMessage
+	if json.Unmarshal(existing, &existingArr) != nil {
+		return chunk
+	}
+	if json.Unmarshal(chunk, &chunkArr) != nil {
+		return existing
+	}
+	merged := append(existingArr, chunkArr...)
+	out, err := json.Marshal(merged)
+	if err != nil {
+		return existing
+	}
+	return out
 }
 
 func writeOpenAIError(w http.ResponseWriter, status int, msg string) {

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -79,6 +79,7 @@ type GuardrailProxy struct {
 	inspector        ContentInspector
 	masterKey        string
 	gatewayToken     string // OPENCLAW_GATEWAY_TOKEN, accepted in X-DC-Auth
+	notify           *NotificationQueue
 
 	// resolveProviderFn selects the upstream LLMProvider for a request.
 	// Defaults to resolveProviderFromHeaders (uses X-DC-Target-URL).
@@ -104,6 +105,7 @@ func NewGuardrailProxy(
 	store *audit.Store,
 	dataDir string,
 	policyDir string,
+	notify *NotificationQueue,
 ) (*GuardrailProxy, error) {
 	dotenvPath := filepath.Join(dataDir, ".env")
 
@@ -136,6 +138,7 @@ func NewGuardrailProxy(
 		inspector:    inspector,
 		masterKey:    masterKey,
 		gatewayToken: gatewayToken,
+		notify:       notify,
 		mode:         cfg.Mode,
 		blockMessage: cfg.BlockMessage,
 	}
@@ -862,6 +865,23 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 		http.Error(w, `{"error":{"message":"DefenseClaw guardrail is disabled","code":"guardrail_disabled"}}`,
 			http.StatusServiceUnavailable)
 		return
+	}
+
+	// --- Inject pending security notifications as a system message ---
+	if p.notify != nil {
+		if sysMsg := p.notify.FormatSystemMessage(); sysMsg != "" {
+			fmt.Fprintf(os.Stderr, "[guardrail] injecting security notification into LLM request\n")
+			notification := ChatMessage{Role: "system", Content: sysMsg}
+			req.Messages = append([]ChatMessage{notification}, req.Messages...)
+			if len(req.RawBody) > 0 {
+				if patched, err := injectSystemMessage(req.RawBody, sysMsg); err == nil {
+					req.RawBody = patched
+				}
+			}
+			if p.logger != nil {
+				_ = p.logger.LogAction("guardrail-notify-inject", "", "injected security notification into LLM request")
+			}
+		}
 	}
 
 	// --- Create invoke_agent root span for this request ---
@@ -1871,6 +1891,39 @@ func (p *GuardrailProxy) recordTelemetry(direction, model string, verdict *ScanV
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// injectSystemMessage prepends a system message to the "messages" array in
+// the raw JSON body. This preserves all other fields the client sent.
+func injectSystemMessage(raw json.RawMessage, content string) (json.RawMessage, error) {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("proxy: inject system message: unmarshal: %w", err)
+	}
+
+	msgBytes, ok := m["messages"]
+	if !ok {
+		return nil, fmt.Errorf("proxy: inject system message: no messages field")
+	}
+
+	var messages []json.RawMessage
+	if err := json.Unmarshal(msgBytes, &messages); err != nil {
+		return nil, fmt.Errorf("proxy: inject system message: unmarshal messages: %w", err)
+	}
+
+	sysMsg := ChatMessage{Role: "system", Content: content}
+	sysMsgBytes, err := json.Marshal(sysMsg)
+	if err != nil {
+		return nil, fmt.Errorf("proxy: inject system message: marshal: %w", err)
+	}
+
+	messages = append([]json.RawMessage{sysMsgBytes}, messages...)
+	newMsgBytes, err := json.Marshal(messages)
+	if err != nil {
+		return nil, fmt.Errorf("proxy: inject system message: marshal messages: %w", err)
+	}
+	m["messages"] = newMsgBytes
+	return json.Marshal(m)
+}
 
 func writeOpenAIError(w http.ResponseWriter, status int, msg string) {
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -414,16 +414,23 @@ func TestProxyFieldPassThrough(t *testing.T) {
 			t.Fatalf("got %d chunks, want at least 3", len(chunks))
 		}
 
-		// Second chunk should have tool_calls in delta
-		var chunk1 StreamChunk
-		if err := json.Unmarshal(chunks[1], &chunk1); err != nil {
-			t.Fatalf("unmarshal chunk[1]: %v", err)
+		// Tool-call chunks are buffered and flushed after post-stream
+		// inspection, so they appear after non-tool-call chunks. Verify
+		// that at least one chunk in the response carries tool_calls.
+		foundTC := false
+		for i, raw := range chunks {
+			var c StreamChunk
+			if err := json.Unmarshal(raw, &c); err != nil {
+				t.Logf("skip chunk[%d] unmarshal: %v", i, err)
+				continue
+			}
+			if len(c.Choices) > 0 && c.Choices[0].Delta != nil && c.Choices[0].Delta.ToolCalls != nil {
+				foundTC = true
+				break
+			}
 		}
-		if len(chunk1.Choices) == 0 || chunk1.Choices[0].Delta == nil {
-			t.Fatal("chunk[1] has no delta")
-		}
-		if chunk1.Choices[0].Delta.ToolCalls == nil {
-			t.Error("tool_calls missing from streaming delta")
+		if !foundTC {
+			t.Error("tool_calls missing from streaming response (expected buffered then flushed)")
 		}
 	})
 

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -862,6 +862,56 @@ func TestProxyStreamingInspection(t *testing.T) {
 			t.Error("expected at least 1 chunk before stream block")
 		}
 	})
+
+	t.Run("short_stream_block_truncates_before_forwarding_content", func(t *testing.T) {
+		prov := &mockProvider{
+			streamChunks: []StreamChunk{
+				{
+					ID: "chatcmpl-short", Object: "chat.completion.chunk", Model: "gpt-4",
+					Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{Role: "assistant"}}},
+				},
+				{
+					ID: "chatcmpl-short", Object: "chat.completion.chunk", Model: "gpt-4",
+					Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{Content: "leak sk-secret"}}},
+				},
+				{
+					ID: "chatcmpl-short", Object: "chat.completion.chunk", Model: "gpt-4",
+					Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{}, FinishReason: strPtr("stop")}},
+				},
+			},
+		}
+
+		insp := newMockInspector()
+		insp.setVerdict("completion", &ScanVerdict{
+			Action:   "block",
+			Severity: "HIGH",
+			Reason:   "secret detected",
+		})
+
+		proxy := newTestProxy(t, prov, insp, "action")
+
+		reqBody := mustJSON(t, map[string]interface{}{
+			"model":    "gpt-4",
+			"messages": []map[string]interface{}{{"role": "user", "content": "Say the secret"}},
+			"stream":   true,
+		})
+
+		rec := postChat(t, proxy, reqBody)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
+		}
+
+		body := rec.Body.String()
+		if strings.Contains(body, "leak sk-secret") {
+			t.Error("short blocked content should NOT be forwarded before the block message")
+		}
+		if !strings.Contains(body, "blocked") {
+			t.Error("blocked message should appear in stream")
+		}
+		if !strings.Contains(body, "[DONE]") {
+			t.Error("streaming response should end with [DONE]")
+		}
+	})
 }
 
 // conditionalInspector blocks completion content when accumulated length exceeds threshold.

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -125,13 +125,28 @@ func (r *EventRouter) ActiveSessionKeys() []string {
 	return keys
 }
 
+const maxActiveSessions = 500
+
 func (r *EventRouter) trackSession(sessionKey string) {
 	if sessionKey == "" {
 		return
 	}
 	r.activeSessionsMu.Lock()
 	r.activeSessions[sessionKey] = time.Now()
+	if len(r.activeSessions) > maxActiveSessions {
+		r.pruneSessionsLocked()
+	}
 	r.activeSessionsMu.Unlock()
+}
+
+// pruneSessionsLocked removes stale entries. Caller must hold activeSessionsMu.
+func (r *EventRouter) pruneSessionsLocked() {
+	cutoff := time.Now().Add(-1 * time.Hour)
+	for k, t := range r.activeSessions {
+		if t.Before(cutoff) {
+			delete(r.activeSessions, k)
+		}
+	}
 }
 
 // Route dispatches a single event frame to the correct handler.

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -750,23 +750,6 @@ func (r *EventRouter) handleToolCall(evt EventFrame) {
 				findings[0].RuleID, findings[0].Severity, findings[0].Confidence))
 		fmt.Fprintf(os.Stderr, "[sidecar] FLAGGED tool call: %s (%s)\n", payload.Tool, findings[0].Title)
 
-		if r.notify != nil {
-			top := make([]string, 0, 3)
-			for i, f := range findings {
-				if i >= 3 {
-					break
-				}
-				top = append(top, f.Title)
-			}
-			r.notify.Push(SecurityNotification{
-				SkillName: payload.Tool,
-				Severity:  severity,
-				Findings:  len(findings),
-				Actions:   []string{fmt.Sprintf("tool call flagged: %s", strings.Join(top, "; "))},
-				Reason:    fmt.Sprintf("tool %q matched %s", payload.Tool, flaggedPattern),
-			})
-		}
-
 		if r.otel != nil {
 			r.otel.EmitRuntimeAlert(
 				telemetry.AlertToolCallFlagged,

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -63,6 +63,9 @@ type EventRouter struct {
 	activeAgentSpans map[string]*activeAgent // keyed by runId
 	activeLLMCtx     context.Context         // context of most recent LLM span, for tool→LLM hierarchy
 	spanMu           sync.Mutex
+
+	activeSessionsMu sync.RWMutex
+	activeSessions   map[string]time.Time // sessionKey → last seen
 }
 
 // NewEventRouter creates a router that handles gateway events for the sidecar.
@@ -76,6 +79,7 @@ func NewEventRouter(client *Client, store *audit.Store, logger *audit.Logger, au
 		autoApprove:      autoApprove,
 		activeToolSpans:  make(map[string][]*activeSpan),
 		activeAgentSpans: make(map[string]*activeAgent),
+		activeSessions:   make(map[string]time.Time),
 	}
 }
 
@@ -104,6 +108,29 @@ func (r *EventRouter) getToolParentCtx() context.Context {
 		return aa.ctx
 	}
 	return context.Background()
+}
+
+// ActiveSessionKeys returns session keys seen in the last hour.
+func (r *EventRouter) ActiveSessionKeys() []string {
+	r.activeSessionsMu.RLock()
+	defer r.activeSessionsMu.RUnlock()
+	cutoff := time.Now().Add(-1 * time.Hour)
+	var keys []string
+	for k, t := range r.activeSessions {
+		if t.After(cutoff) {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+func (r *EventRouter) trackSession(sessionKey string) {
+	if sessionKey == "" {
+		return
+	}
+	r.activeSessionsMu.Lock()
+	r.activeSessions[sessionKey] = time.Now()
+	r.activeSessionsMu.Unlock()
 }
 
 // Route dispatches a single event frame to the correct handler.
@@ -408,6 +435,8 @@ func (r *EventRouter) handleSessionsChanged(evt EventFrame, seqStr string) {
 	}
 	readLoopLogf("[bifrost] sessions.changed: phase=%s session=%s status=%s model=%s runId=%s msgId=%s",
 		sc.Phase, sc.SessionKey, sc.Session.Status, sc.Session.Model, sc.RunID, sc.MessageID)
+
+	r.trackSession(sc.SessionKey)
 
 	if sc.Session.Status == "failed" || sc.Phase == "error" {
 		readLoopLogf("[bifrost] sessions.changed ERROR: session %s status=failed phase=%s", sc.SessionKey, sc.Phase)

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -57,6 +57,7 @@ type EventRouter struct {
 	logger *audit.Logger
 	policy *enforce.PolicyEngine
 	otel   *telemetry.Provider
+	notify *NotificationQueue
 
 	autoApprove      bool
 	activeToolSpans  map[string][]*activeSpan
@@ -724,7 +725,8 @@ func (r *EventRouter) handleToolCall(evt EventFrame) {
 
 	// Use the shared rule engine — no tool-name gating.
 	findings := ScanAllRules(string(payload.Args), payload.Tool)
-	dangerous := len(findings) > 0 && severityRank[HighestSeverity(findings)] >= severityRank["HIGH"]
+	severity := HighestSeverity(findings)
+	dangerous := len(findings) > 0 && severityRank[severity] >= severityRank["HIGH"]
 	flaggedPattern := ""
 	if dangerous {
 		flaggedPattern = findings[0].RuleID
@@ -732,6 +734,35 @@ func (r *EventRouter) handleToolCall(evt EventFrame) {
 			fmt.Sprintf("reason=%s severity=%s confidence=%.2f",
 				findings[0].RuleID, findings[0].Severity, findings[0].Confidence))
 		fmt.Fprintf(os.Stderr, "[sidecar] FLAGGED tool call: %s (%s)\n", payload.Tool, findings[0].Title)
+
+		if r.notify != nil {
+			top := make([]string, 0, 3)
+			for i, f := range findings {
+				if i >= 3 {
+					break
+				}
+				top = append(top, f.Title)
+			}
+			r.notify.Push(SecurityNotification{
+				SkillName: payload.Tool,
+				Severity:  severity,
+				Findings:  len(findings),
+				Actions:   []string{fmt.Sprintf("tool call flagged: %s", strings.Join(top, "; "))},
+				Reason:    fmt.Sprintf("tool %q matched %s", payload.Tool, flaggedPattern),
+			})
+		}
+
+		if r.otel != nil {
+			r.otel.EmitRuntimeAlert(
+				telemetry.AlertToolCallFlagged,
+				severity,
+				telemetry.SourceToolInspect,
+				fmt.Sprintf("Dangerous tool call: %s — %s", payload.Tool, findings[0].Title),
+				map[string]string{"tool": payload.Tool},
+				map[string]string{"rule_id": flaggedPattern, "action": "flagged"},
+				"", "",
+			)
+		}
 	}
 
 	if r.otel != nil {

--- a/internal/gateway/rpc.go
+++ b/internal/gateway/rpc.go
@@ -210,6 +210,20 @@ func (c *Client) SessionsMessagesSubscribe(ctx context.Context, sessionID string
 	return nil
 }
 
+// SessionsSend sends a message to a specific session via the gateway.
+// The gateway expects "key" (session key) and "message" (text content).
+func (c *Client) SessionsSend(ctx context.Context, sessionKey string, text string) error {
+	params := map[string]interface{}{
+		"key":     sessionKey,
+		"message": text,
+	}
+	_, err := c.Request(ctx, "sessions.send", params)
+	if err != nil {
+		return fmt.Errorf("gateway: sessions.send to %q: %w", sessionKey, err)
+	}
+	return nil
+}
+
 // ResolveApproval approves or rejects an exec approval request.
 func (c *Client) ResolveApproval(ctx context.Context, id string, approved bool, reason string) error {
 	decision := "deny"

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -47,6 +47,10 @@ type Sidecar struct {
 	shell  *sandbox.OpenShell
 	otel   *telemetry.Provider
 	notify *NotificationQueue
+
+	alertCtx    context.Context
+	alertCancel context.CancelFunc
+	alertWg     sync.WaitGroup
 }
 
 // NewSidecar creates a sidecar instance ready to connect.
@@ -72,16 +76,20 @@ func NewSidecar(cfg *config.Config, store *audit.Store, logger *audit.Logger, sh
 	router.notify = notify
 	client.OnEvent = router.Route
 
+	alertCtx, alertCancel := context.WithCancel(context.Background())
+
 	return &Sidecar{
-		cfg:    cfg,
-		client: client,
-		router: router,
-		store:  store,
-		logger: logger,
-		health: NewSidecarHealth(),
-		shell:  shell,
-		otel:   otel,
-		notify: notify,
+		cfg:         cfg,
+		client:      client,
+		router:      router,
+		store:       store,
+		logger:      logger,
+		health:      NewSidecarHealth(),
+		shell:       shell,
+		otel:        otel,
+		notify:      notify,
+		alertCtx:    alertCtx,
+		alertCancel: alertCancel,
 	}, nil
 }
 
@@ -152,6 +160,9 @@ func (s *Sidecar) Run(ctx context.Context) error {
 	<-ctx.Done()
 	fmt.Fprintf(os.Stderr, "[sidecar] context cancelled, waiting for subsystems to stop ...\n")
 	wg.Wait()
+
+	s.alertCancel()
+	s.alertWg.Wait()
 
 	_ = s.logger.LogAction("sidecar-stop", "", "all subsystems stopped")
 	_ = s.client.Close()
@@ -348,14 +359,22 @@ func (s *Sidecar) handleSkillAdmission(r watcher.AdmissionResult) {
 		actions = append(actions, "quarantined", "blocked")
 	}
 
-	go s.sendEnforcementAlert(r.Event.Name, r.MaxSeverity, r.FindingCount, actions, r.Reason)
+	s.alertWg.Add(1)
+	go func() {
+		defer s.alertWg.Done()
+		s.sendEnforcementAlert(r.Event.Name, r.MaxSeverity, r.FindingCount, actions, r.Reason)
+	}()
 }
 
 // sendEnforcementAlert sends a security notification to all active sessions
 // via the gateway's sessions.send RPC so each chat learns about the enforcement.
 // Runs in a goroutine to avoid blocking the watcher callback.
 func (s *Sidecar) sendEnforcementAlert(skillName, severity string, findings int, actions []string, reason string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	parent := s.alertCtx
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, 15*time.Second)
 	defer cancel()
 
 	msg := formatEnforcementMessage(skillName, severity, findings, actions, reason)

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -308,8 +308,8 @@ func (s *Sidecar) runWatcher(ctx context.Context) error {
 	return err
 }
 
-// handleAdmissionResult processes watcher verdicts. For blocked/rejected skills
-// and plugins, it also disables them at the gateway level when take_action is enabled.
+// handleAdmissionResult processes watcher verdicts. It only forwards runtime
+// disable actions to the gateway when the watcher actually requested them.
 func (s *Sidecar) handleAdmissionResult(r watcher.AdmissionResult) {
 	fmt.Fprintf(os.Stderr, "[sidecar] watcher verdict: %s %s — %s (%s)\n",
 		r.Event.Type, r.Event.Name, r.Verdict, r.Reason)
@@ -342,34 +342,39 @@ func (s *Sidecar) handleSkillAdmission(r watcher.AdmissionResult) {
 
 	var actions []string
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	if err := s.client.DisableSkill(ctx, r.Event.Name); err != nil {
-		fmt.Fprintf(os.Stderr, "[sidecar] watcher→gateway disable skill %s failed: %v\n",
-			r.Event.Name, err)
-	} else {
-		actions = append(actions, "disabled")
-		fmt.Fprintf(os.Stderr, "[sidecar] watcher→gateway disabled skill %s\n", r.Event.Name)
-		_ = s.logger.LogAction("sidecar-watcher-disable", r.Event.Name,
-			fmt.Sprintf("auto-disabled skill via gateway after verdict=%s", r.Verdict))
+	if r.FileAction == "quarantine" {
+		actions = append(actions, "quarantined")
+	}
+	if r.Verdict == watcher.VerdictBlocked || r.InstallAction == "block" {
+		actions = append(actions, "blocked")
 	}
 
-	if strings.Contains(r.Reason, "quarantine") || strings.Contains(r.Reason, "block") {
-		actions = append(actions, "quarantined", "blocked")
+	if shouldDisableAtGateway(r) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if err := s.client.DisableSkill(ctx, r.Event.Name); err != nil {
+			fmt.Fprintf(os.Stderr, "[sidecar] watcher→gateway disable skill %s failed: %v\n",
+				r.Event.Name, err)
+		} else {
+			actions = append(actions, "disabled")
+			fmt.Fprintf(os.Stderr, "[sidecar] watcher→gateway disabled skill %s\n", r.Event.Name)
+			_ = s.logger.LogAction("sidecar-watcher-disable", r.Event.Name,
+				fmt.Sprintf("auto-disabled skill via gateway after verdict=%s", r.Verdict))
+		}
 	}
 
 	s.alertWg.Add(1)
 	go func() {
 		defer s.alertWg.Done()
-		s.sendEnforcementAlert(r.Event.Name, r.MaxSeverity, r.FindingCount, actions, r.Reason)
+		s.sendEnforcementAlert("skill", r.Event.Name, r.MaxSeverity, r.FindingCount, actions, r.Reason)
 	}()
 }
 
 // sendEnforcementAlert sends a security notification to all active sessions
 // via the gateway's sessions.send RPC so each chat learns about the enforcement.
 // Runs in a goroutine to avoid blocking the watcher callback.
-func (s *Sidecar) sendEnforcementAlert(skillName, severity string, findings int, actions []string, reason string) {
+func (s *Sidecar) sendEnforcementAlert(subjectType, subjectName, severity string, findings int, actions []string, reason string) {
 	parent := s.alertCtx
 	if parent == nil {
 		parent = context.Background()
@@ -377,18 +382,27 @@ func (s *Sidecar) sendEnforcementAlert(skillName, severity string, findings int,
 	ctx, cancel := context.WithTimeout(parent, 15*time.Second)
 	defer cancel()
 
-	msg := formatEnforcementMessage(skillName, severity, findings, actions, reason)
+	msg := formatEnforcementMessage(subjectType, subjectName, severity, findings, actions, reason)
+	notification := SecurityNotification{
+		SubjectType: subjectType,
+		SkillName:   subjectName,
+		Severity:    severity,
+		Findings:    findings,
+		Actions:     actions,
+		Reason:      reason,
+	}
+	if s.notify != nil {
+		s.notify.Push(notification)
+	}
 
-	sessionKeys := s.router.ActiveSessionKeys()
+	sessionKeys := s.activeSessionKeys()
 	if len(sessionKeys) == 0 {
-		fmt.Fprintf(os.Stderr, "[sidecar] enforcement alert: no active sessions tracked, falling back to guardrail injection\n")
-		s.notify.Push(SecurityNotification{
-			SkillName: skillName,
-			Severity:  severity,
-			Findings:  findings,
-			Actions:   actions,
-			Reason:    reason,
-		})
+		fmt.Fprintf(os.Stderr, "[sidecar] enforcement alert: no active sessions tracked, queued for guardrail injection\n")
+		return
+	}
+
+	if s.client == nil {
+		fmt.Fprintf(os.Stderr, "[sidecar] enforcement alert: gateway client unavailable, queued for guardrail injection only\n")
 		return
 	}
 
@@ -405,21 +419,15 @@ func (s *Sidecar) sendEnforcementAlert(skillName, severity string, findings int,
 	}
 
 	if sent == 0 {
-		fmt.Fprintf(os.Stderr, "[sidecar] enforcement alert: all sessions.send failed, falling back to guardrail injection\n")
-		s.notify.Push(SecurityNotification{
-			SkillName: skillName,
-			Severity:  severity,
-			Findings:  findings,
-			Actions:   actions,
-			Reason:    reason,
-		})
+		fmt.Fprintf(os.Stderr, "[sidecar] enforcement alert: all sessions.send failed, queued for guardrail injection\n")
 	}
 }
 
 // formatEnforcementMessage builds a human-readable security alert for chat.
-func formatEnforcementMessage(skillName, severity string, findings int, actions []string, reason string) string {
+func formatEnforcementMessage(subjectType, subjectName, severity string, findings int, actions []string, reason string) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "[DefenseClaw Security Alert] Skill %q was blocked.\n", skillName)
+	fmt.Fprintf(&sb, "[DefenseClaw Security Alert] %s %q was automatically enforced.\n",
+		notificationSubjectLabel(subjectType), subjectName)
 	fmt.Fprintf(&sb, "Severity: %s", severity)
 	if findings > 0 {
 		fmt.Fprintf(&sb, " (%d security finding(s))", findings)
@@ -431,7 +439,8 @@ func formatEnforcementMessage(skillName, severity string, findings int, actions 
 	if reason != "" {
 		fmt.Fprintf(&sb, "Reason: %s\n", reason)
 	}
-	sb.WriteString("The skill was NOT installed. Do not use it or confirm its installation.")
+	sb.WriteString("Do not confirm the component was installed or enabled successfully. ")
+	sb.WriteString("Explain that DefenseClaw detected security issues and took protective action.")
 	return sb.String()
 }
 
@@ -444,17 +453,49 @@ func (s *Sidecar) handlePluginAdmission(r watcher.AdmissionResult) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	var actions []string
 
-	if err := s.client.DisablePlugin(ctx, r.Event.Name); err != nil {
-		fmt.Fprintf(os.Stderr, "[sidecar] watcher→gateway disable plugin %s failed: %v\n",
-			r.Event.Name, err)
-	} else {
-		fmt.Fprintf(os.Stderr, "[sidecar] watcher→gateway disabled plugin %s\n", r.Event.Name)
-		_ = s.logger.LogAction("sidecar-watcher-disable-plugin", r.Event.Name,
-			fmt.Sprintf("auto-disabled plugin via gateway after verdict=%s", r.Verdict))
+	if r.FileAction == "quarantine" {
+		actions = append(actions, "quarantined")
 	}
+	if r.Verdict == watcher.VerdictBlocked || r.InstallAction == "block" {
+		actions = append(actions, "blocked")
+	}
+
+	if shouldDisableAtGateway(r) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if err := s.client.DisablePlugin(ctx, r.Event.Name); err != nil {
+			fmt.Fprintf(os.Stderr, "[sidecar] watcher→gateway disable plugin %s failed: %v\n",
+				r.Event.Name, err)
+		} else {
+			actions = append(actions, "disabled")
+			fmt.Fprintf(os.Stderr, "[sidecar] watcher→gateway disabled plugin %s\n", r.Event.Name)
+			_ = s.logger.LogAction("sidecar-watcher-disable-plugin", r.Event.Name,
+				fmt.Sprintf("auto-disabled plugin via gateway after verdict=%s", r.Verdict))
+		}
+	}
+
+	s.alertWg.Add(1)
+	go func() {
+		defer s.alertWg.Done()
+		s.sendEnforcementAlert("plugin", r.Event.Name, r.MaxSeverity, r.FindingCount, actions, r.Reason)
+	}()
+}
+
+func shouldDisableAtGateway(r watcher.AdmissionResult) bool {
+	if r.Verdict == watcher.VerdictBlocked {
+		return true
+	}
+	return r.RuntimeAction == "block"
+}
+
+func (s *Sidecar) activeSessionKeys() []string {
+	if s.router == nil {
+		return nil
+	}
+	return s.router.ActiveSessionKeys()
 }
 
 // runGuardrail starts the Go guardrail proxy when guardrail is enabled.

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -66,7 +66,10 @@ func NewSidecar(cfg *config.Config, store *audit.Store, logger *audit.Logger, sh
 	}
 	fmt.Fprintf(os.Stderr, "[sidecar] device identity loaded (id=%s)\n", client.device.DeviceID)
 
+	notify := NewNotificationQueue()
+
 	router := NewEventRouter(client, store, logger, cfg.Gateway.AutoApprove, otel)
+	router.notify = notify
 	client.OnEvent = router.Route
 
 	return &Sidecar{
@@ -78,7 +81,7 @@ func NewSidecar(cfg *config.Config, store *audit.Store, logger *audit.Logger, sh
 		health: NewSidecarHealth(),
 		shell:  shell,
 		otel:   otel,
-		notify: NewNotificationQueue(),
+		notify: notify,
 	}, nil
 }
 

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -46,6 +46,7 @@ type Sidecar struct {
 	health *SidecarHealth
 	shell  *sandbox.OpenShell
 	otel   *telemetry.Provider
+	notify *NotificationQueue
 }
 
 // NewSidecar creates a sidecar instance ready to connect.
@@ -77,6 +78,7 @@ func NewSidecar(cfg *config.Config, store *audit.Store, logger *audit.Logger, sh
 		health: NewSidecarHealth(),
 		shell:  shell,
 		otel:   otel,
+		notify: NewNotificationQueue(),
 	}, nil
 }
 
@@ -324,6 +326,8 @@ func (s *Sidecar) handleSkillAdmission(r watcher.AdmissionResult) {
 		return
 	}
 
+	var actions []string
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -331,10 +335,82 @@ func (s *Sidecar) handleSkillAdmission(r watcher.AdmissionResult) {
 		fmt.Fprintf(os.Stderr, "[sidecar] watcher→gateway disable skill %s failed: %v\n",
 			r.Event.Name, err)
 	} else {
+		actions = append(actions, "disabled")
 		fmt.Fprintf(os.Stderr, "[sidecar] watcher→gateway disabled skill %s\n", r.Event.Name)
 		_ = s.logger.LogAction("sidecar-watcher-disable", r.Event.Name,
 			fmt.Sprintf("auto-disabled skill via gateway after verdict=%s", r.Verdict))
 	}
+
+	if strings.Contains(r.Reason, "quarantine") || strings.Contains(r.Reason, "block") {
+		actions = append(actions, "quarantined", "blocked")
+	}
+
+	go s.sendEnforcementAlert(r.Event.Name, r.MaxSeverity, r.FindingCount, actions, r.Reason)
+}
+
+// sendEnforcementAlert sends a security notification to all active sessions
+// via the gateway's sessions.send RPC so each chat learns about the enforcement.
+// Runs in a goroutine to avoid blocking the watcher callback.
+func (s *Sidecar) sendEnforcementAlert(skillName, severity string, findings int, actions []string, reason string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	msg := formatEnforcementMessage(skillName, severity, findings, actions, reason)
+
+	sessionKeys := s.router.ActiveSessionKeys()
+	if len(sessionKeys) == 0 {
+		fmt.Fprintf(os.Stderr, "[sidecar] enforcement alert: no active sessions tracked, falling back to guardrail injection\n")
+		s.notify.Push(SecurityNotification{
+			SkillName: skillName,
+			Severity:  severity,
+			Findings:  findings,
+			Actions:   actions,
+			Reason:    reason,
+		})
+		return
+	}
+
+	sent := 0
+	for _, key := range sessionKeys {
+		sendCtx, sendCancel := context.WithTimeout(ctx, 5*time.Second)
+		if err := s.client.SessionsSend(sendCtx, key, msg); err != nil {
+			fmt.Fprintf(os.Stderr, "[sidecar] enforcement alert: send to session %s failed: %v\n", key, err)
+		} else {
+			sent++
+			fmt.Fprintf(os.Stderr, "[sidecar] enforcement alert sent to session %s\n", key)
+		}
+		sendCancel()
+	}
+
+	if sent == 0 {
+		fmt.Fprintf(os.Stderr, "[sidecar] enforcement alert: all sessions.send failed, falling back to guardrail injection\n")
+		s.notify.Push(SecurityNotification{
+			SkillName: skillName,
+			Severity:  severity,
+			Findings:  findings,
+			Actions:   actions,
+			Reason:    reason,
+		})
+	}
+}
+
+// formatEnforcementMessage builds a human-readable security alert for chat.
+func formatEnforcementMessage(skillName, severity string, findings int, actions []string, reason string) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "[DefenseClaw Security Alert] Skill %q was blocked.\n", skillName)
+	fmt.Fprintf(&sb, "Severity: %s", severity)
+	if findings > 0 {
+		fmt.Fprintf(&sb, " (%d security finding(s))", findings)
+	}
+	sb.WriteString("\n")
+	if len(actions) > 0 {
+		fmt.Fprintf(&sb, "Actions taken: %s\n", strings.Join(actions, ", "))
+	}
+	if reason != "" {
+		fmt.Fprintf(&sb, "Reason: %s\n", reason)
+	}
+	sb.WriteString("The skill was NOT installed. Do not use it or confirm its installation.")
+	return sb.String()
 }
 
 func (s *Sidecar) handlePluginAdmission(r watcher.AdmissionResult) {
@@ -370,6 +446,7 @@ func (s *Sidecar) runGuardrail(ctx context.Context) error {
 		s.store,
 		s.cfg.DataDir,
 		s.cfg.PolicyDir,
+		s.notify,
 	)
 	if err != nil {
 		s.health.SetGuardrail(StateError, err.Error(), nil)

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -39,13 +39,37 @@ type Engine struct {
 }
 
 // New creates an Engine. regoDir is the path to the directory containing
-// the Rego modules and data.json (e.g. policies/rego/).
+// the Rego modules and data.json (e.g. policies/rego/). If regoDir itself
+// does not contain .rego files but a "rego" subdirectory does, the
+// subdirectory is used instead.
 func New(regoDir string) (*Engine, error) {
+	regoDir = resolveRegoDir(regoDir)
 	store, err := loadStore(regoDir)
 	if err != nil {
 		return nil, err
 	}
 	return &Engine{regoDir: regoDir, store: store}, nil
+}
+
+// resolveRegoDir returns regoDir if it contains .rego files or data.json,
+// otherwise tries the "rego" subdirectory (policy_dir layout).
+func resolveRegoDir(dir string) string {
+	if hasRegoFiles(dir) {
+		return dir
+	}
+	sub := filepath.Join(dir, "rego")
+	if hasRegoFiles(sub) {
+		return sub
+	}
+	return dir
+}
+
+func hasRegoFiles(dir string) bool {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.rego"))
+	if err != nil {
+		return false
+	}
+	return len(matches) > 0
 }
 
 // Reload re-reads data.json and all .rego files, replacing the in-memory
@@ -81,7 +105,7 @@ func (e *Engine) RegoDir() string {
 // ---------------------------------------------------------------------------
 
 // Evaluate runs the admission policy against the provided input and returns
-// the verdict, reason, file_action, and install_action.
+// the verdict, reason, file_action, install_action, and runtime_action.
 func (e *Engine) Evaluate(ctx context.Context, input AdmissionInput) (*AdmissionOutput, error) {
 	result, err := e.eval(ctx, "data.defenseclaw.admission", input)
 	if err != nil {
@@ -92,6 +116,7 @@ func (e *Engine) Evaluate(ctx context.Context, input AdmissionInput) (*Admission
 		Reason:        stringVal(result, "reason"),
 		FileAction:    stringVal(result, "file_action"),
 		InstallAction: stringVal(result, "install_action"),
+		RuntimeAction: stringVal(result, "runtime_action"),
 	}, nil
 }
 
@@ -244,8 +269,7 @@ func (e *Engine) eval(ctx context.Context, query string, input interface{}) (map
 }
 
 func loadStore(regoDir string) (storage.Store, error) {
-	dataPath := filepath.Join(regoDir, "data.json")
-	raw, err := os.ReadFile(dataPath)
+	raw, err := readDataJSON(regoDir)
 	if err != nil {
 		return nil, fmt.Errorf("policy: read data.json: %w", err)
 	}

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -212,9 +212,9 @@ runtime_action := "allow" if {
 			"INFO":     map[string]string{"runtime": "allow", "file": "none", "install": "none"},
 		},
 		"scanner_overrides": map[string]interface{}{},
-		"first_party_allow_list": []map[string]string{
-			{"target_type": "plugin", "target_name": "defenseclaw", "reason": "first-party DefenseClaw plugin"},
-			{"target_type": "skill", "target_name": "codeguard", "reason": "first-party DefenseClaw skill"},
+		"first_party_allow_list": []map[string]interface{}{
+			{"target_type": "plugin", "target_name": "defenseclaw", "reason": "first-party DefenseClaw plugin", "source_path_contains": []string{".defenseclaw", ".openclaw/extensions"}},
+			{"target_type": "skill", "target_name": "codeguard", "reason": "first-party DefenseClaw skill", "source_path_contains": []string{".defenseclaw", ".openclaw/workspace/skills", ".openclaw/skills"}},
 		},
 	}
 

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -43,12 +43,23 @@ reason := sprintf("%s '%s' is on the block list", [input.target_type, input.targ
 
 verdict := "allowed" if {
 	not _is_blocked
-	_is_allow_listed
+	_is_explicit_allow_listed
+}
+reason := sprintf("%s '%s' is on the allow list — scan skipped", [input.target_type, input.target_name]) if {
+	not _is_blocked
+	_is_explicit_allow_listed
+}
+
+verdict := "allowed" if {
+	not _is_blocked
+	not _is_explicit_allow_listed
+	_is_policy_allow_listed
 	data.config.allow_list_bypass_scan == true
 }
 reason := sprintf("%s '%s' is on the allow list — scan skipped", [input.target_type, input.target_name]) if {
 	not _is_blocked
-	_is_allow_listed
+	not _is_explicit_allow_listed
+	_is_policy_allow_listed
 	data.config.allow_list_bypass_scan == true
 }
 
@@ -101,28 +112,89 @@ _is_blocked if {
 	entry.target_type == input.target_type
 }
 
-_is_allow_listed if {
+_is_explicit_allow_listed if {
 	some entry in input.allow_list
 	entry.target_name == input.target_name
 	entry.target_type == input.target_type
 }
 
+_is_policy_allow_listed if {
+	some entry in data.first_party_allow_list
+	entry.target_name == input.target_name
+	entry.target_type == input.target_type
+	_path_matches_provenance(entry)
+}
+
+_path_matches_provenance(entry) if {
+	not entry.source_path_contains
+}
+_path_matches_provenance(entry) if {
+	count(entry.source_path_contains) == 0
+}
+_path_matches_provenance(entry) if {
+	some prefix in entry.source_path_contains
+	contains(lower(input.path), lower(prefix))
+}
+
 _is_allow_bypassed if {
-	_is_allow_listed
+	_is_explicit_allow_listed
+}
+
+_is_allow_bypassed if {
+	_is_policy_allow_listed
 	data.config.allow_list_bypass_scan == true
 }
 
 _has_scan if input.scan_result
 
+verdict := "allowed" if {
+	not _is_blocked
+	not _is_allow_bypassed
+	not _has_scan
+	data.config.scan_on_install == false
+}
+reason := "scan_on_install disabled — allowed without scan" if {
+	not _is_blocked
+	not _is_allow_bypassed
+	not _has_scan
+	data.config.scan_on_install == false
+}
+
+_effective_action := action if {
+	action := data.scanner_overrides[input.target_type][input.scan_result.max_severity]
+} else := action if {
+	action := data.actions[input.scan_result.max_severity]
+}
+
 _should_reject if {
-	data.actions[input.scan_result.max_severity].runtime == "block"
+	_effective_action.runtime == "block"
+}
+
+_should_reject if {
+	_effective_action.install == "block"
 }
 
 file_action := action if {
 	_has_scan
-	action := data.actions[input.scan_result.max_severity].file
+	action := _effective_action.file
 }
 file_action := "none" if {
+	not _has_scan
+}
+
+install_action := action if {
+	_has_scan
+	action := _effective_action.install
+}
+install_action := "none" if {
+	not _has_scan
+}
+
+runtime_action := action if {
+	_has_scan
+	action := _effective_action.runtime
+}
+runtime_action := "allow" if {
 	not _has_scan
 }
 `
@@ -130,13 +202,19 @@ file_action := "none" if {
 	data := map[string]interface{}{
 		"config": map[string]interface{}{
 			"allow_list_bypass_scan": true,
+			"scan_on_install":       true,
 		},
 		"actions": map[string]interface{}{
-			"CRITICAL": map[string]string{"runtime": "block", "file": "quarantine"},
-			"HIGH":     map[string]string{"runtime": "block", "file": "quarantine"},
-			"MEDIUM":   map[string]string{"runtime": "allow", "file": "none"},
-			"LOW":      map[string]string{"runtime": "allow", "file": "none"},
-			"INFO":     map[string]string{"runtime": "allow", "file": "none"},
+			"CRITICAL": map[string]string{"runtime": "block", "file": "quarantine", "install": "block"},
+			"HIGH":     map[string]string{"runtime": "block", "file": "quarantine", "install": "block"},
+			"MEDIUM":   map[string]string{"runtime": "allow", "file": "none", "install": "none"},
+			"LOW":      map[string]string{"runtime": "allow", "file": "none", "install": "none"},
+			"INFO":     map[string]string{"runtime": "allow", "file": "none", "install": "none"},
+		},
+		"scanner_overrides": map[string]interface{}{},
+		"first_party_allow_list": []map[string]string{
+			{"target_type": "plugin", "target_name": "defenseclaw", "reason": "first-party DefenseClaw plugin"},
+			{"target_type": "skill", "target_name": "codeguard", "reason": "first-party DefenseClaw skill"},
 		},
 	}
 
@@ -240,6 +318,12 @@ func TestEngine_ScanRejected_Critical(t *testing.T) {
 	}
 	if out.FileAction != "quarantine" {
 		t.Errorf("expected file_action quarantine, got %q", out.FileAction)
+	}
+	if out.RuntimeAction != "block" {
+		t.Errorf("expected runtime_action block, got %q", out.RuntimeAction)
+	}
+	if out.InstallAction != "block" {
+		t.Errorf("expected install_action block, got %q", out.InstallAction)
 	}
 }
 

--- a/internal/policy/fallback.go
+++ b/internal/policy/fallback.go
@@ -27,8 +27,8 @@ type FallbackProfile struct {
 	FirstPartyAllow     map[string]firstPartyEntry
 }
 
-func LoadFallbackProfile(regoDir string) *FallbackProfile {
-	profile := &FallbackProfile{
+func defaultFallbackProfile() *FallbackProfile {
+	return &FallbackProfile{
 		AllowListBypassScan: true,
 		ScanOnInstall:       true,
 		Actions: map[string]fallbackAction{
@@ -38,9 +38,31 @@ func LoadFallbackProfile(regoDir string) *FallbackProfile {
 			"LOW":      {Runtime: "allow", File: "none", Install: "none"},
 			"INFO":     {Runtime: "allow", File: "none", Install: "none"},
 		},
-		ScannerOverrides: map[string]map[string]fallbackAction{},
-		FirstPartyAllow:  map[string]firstPartyEntry{},
+		ScannerOverrides: map[string]map[string]fallbackAction{
+			"mcp": {
+				"MEDIUM": {Runtime: "block", File: "quarantine", Install: "block"},
+				"LOW":    {Runtime: "block", File: "none", Install: "none"},
+			},
+			"plugin": {
+				"HIGH":   {Runtime: "block", File: "quarantine", Install: "block"},
+				"MEDIUM": {Runtime: "allow", File: "none", Install: "none"},
+			},
+		},
+		FirstPartyAllow: map[string]firstPartyEntry{
+			firstPartyKey("plugin", "defenseclaw"): {
+				Reason:             "first-party DefenseClaw plugin",
+				SourcePathContains: []string{".defenseclaw", "extensions/defenseclaw"},
+			},
+			firstPartyKey("skill", "codeguard"): {
+				Reason:             "first-party DefenseClaw skill",
+				SourcePathContains: []string{".defenseclaw", "workspace/skills/codeguard", "skills/codeguard"},
+			},
+		},
 	}
+}
+
+func LoadFallbackProfile(regoDir string) *FallbackProfile {
+	profile := defaultFallbackProfile()
 	if regoDir == "" {
 		return profile
 	}
@@ -57,7 +79,7 @@ func LoadFallbackProfile(regoDir string) *FallbackProfile {
 		} `json:"config"`
 		Actions          map[string]fallbackAction            `json:"actions"`
 		ScannerOverrides map[string]map[string]fallbackAction `json:"scanner_overrides"`
-		FirstPartyAllow []struct {
+		FirstPartyAllow  []struct {
 			TargetType         string   `json:"target_type"`
 			TargetName         string   `json:"target_name"`
 			Reason             string   `json:"reason"`
@@ -98,7 +120,7 @@ func LoadFallbackProfile(regoDir string) *FallbackProfile {
 
 func EvaluateAdmissionFallback(input AdmissionInput, profile *FallbackProfile) *AdmissionOutput {
 	if profile == nil {
-		profile = LoadFallbackProfile("")
+		profile = defaultFallbackProfile()
 	}
 
 	if blocked, reason := fallbackListEntryReason(input.BlockList, input.TargetType, input.TargetName); blocked {

--- a/internal/policy/fallback.go
+++ b/internal/policy/fallback.go
@@ -1,0 +1,228 @@
+package policy
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type fallbackAction struct {
+	Runtime string `json:"runtime"`
+	File    string `json:"file"`
+	Install string `json:"install"`
+}
+
+type firstPartyEntry struct {
+	Reason             string
+	SourcePathContains []string
+}
+
+type FallbackProfile struct {
+	AllowListBypassScan bool
+	ScanOnInstall       bool
+	Actions             map[string]fallbackAction
+	ScannerOverrides    map[string]map[string]fallbackAction
+	FirstPartyAllow     map[string]firstPartyEntry
+}
+
+func LoadFallbackProfile(regoDir string) *FallbackProfile {
+	profile := &FallbackProfile{
+		AllowListBypassScan: true,
+		ScanOnInstall:       true,
+		Actions: map[string]fallbackAction{
+			"CRITICAL": {Runtime: "block", File: "quarantine", Install: "block"},
+			"HIGH":     {Runtime: "block", File: "quarantine", Install: "block"},
+			"MEDIUM":   {Runtime: "allow", File: "none", Install: "none"},
+			"LOW":      {Runtime: "allow", File: "none", Install: "none"},
+			"INFO":     {Runtime: "allow", File: "none", Install: "none"},
+		},
+		ScannerOverrides: map[string]map[string]fallbackAction{},
+		FirstPartyAllow:  map[string]firstPartyEntry{},
+	}
+	if regoDir == "" {
+		return profile
+	}
+
+	raw, err := readDataJSON(regoDir)
+	if err != nil {
+		return profile
+	}
+
+	var payload struct {
+		Config struct {
+			AllowListBypassScan *bool `json:"allow_list_bypass_scan"`
+			ScanOnInstall       *bool `json:"scan_on_install"`
+		} `json:"config"`
+		Actions          map[string]fallbackAction            `json:"actions"`
+		ScannerOverrides map[string]map[string]fallbackAction `json:"scanner_overrides"`
+		FirstPartyAllow []struct {
+			TargetType         string   `json:"target_type"`
+			TargetName         string   `json:"target_name"`
+			Reason             string   `json:"reason"`
+			SourcePathContains []string `json:"source_path_contains"`
+		} `json:"first_party_allow_list"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return profile
+	}
+
+	if payload.Config.AllowListBypassScan != nil {
+		profile.AllowListBypassScan = *payload.Config.AllowListBypassScan
+	}
+	if payload.Config.ScanOnInstall != nil {
+		profile.ScanOnInstall = *payload.Config.ScanOnInstall
+	}
+	for sev, action := range payload.Actions {
+		profile.Actions[strings.ToUpper(sev)] = action
+	}
+	for targetType, overrides := range payload.ScannerOverrides {
+		target := map[string]fallbackAction{}
+		for sev, action := range overrides {
+			target[strings.ToUpper(sev)] = action
+		}
+		profile.ScannerOverrides[targetType] = target
+	}
+	for _, entry := range payload.FirstPartyAllow {
+		if entry.TargetType == "" || entry.TargetName == "" {
+			continue
+		}
+		profile.FirstPartyAllow[firstPartyKey(entry.TargetType, entry.TargetName)] = firstPartyEntry{
+			Reason:             entry.Reason,
+			SourcePathContains: entry.SourcePathContains,
+		}
+	}
+	return profile
+}
+
+func EvaluateAdmissionFallback(input AdmissionInput, profile *FallbackProfile) *AdmissionOutput {
+	if profile == nil {
+		profile = LoadFallbackProfile("")
+	}
+
+	if blocked, reason := fallbackListEntryReason(input.BlockList, input.TargetType, input.TargetName); blocked {
+		return &AdmissionOutput{Verdict: "blocked", Reason: reason}
+	}
+	if allowed, reason := fallbackListEntryReason(input.AllowList, input.TargetType, input.TargetName); allowed {
+		return &AdmissionOutput{Verdict: "allowed", Reason: reason}
+	}
+
+	if profile.AllowListBypassScan {
+		if entry, ok := profile.FirstPartyAllow[firstPartyKey(input.TargetType, input.TargetName)]; ok {
+			if matchesProvenance(entry.SourcePathContains, input.Path) {
+				reason := entry.Reason
+				if reason == "" {
+					reason = fmt.Sprintf("%s '%s' is on the allow list — scan skipped", input.TargetType, input.TargetName)
+				}
+				return &AdmissionOutput{Verdict: "allowed", Reason: reason}
+			}
+		}
+	}
+
+	if input.ScanResult == nil {
+		if !profile.ScanOnInstall {
+			return &AdmissionOutput{
+				Verdict: "allowed",
+				Reason:  "scan_on_install disabled — allowed without scan",
+			}
+		}
+		return &AdmissionOutput{Verdict: "scan", Reason: "scan required"}
+	}
+
+	severity := strings.ToUpper(input.ScanResult.MaxSeverity)
+	if severity == "" {
+		severity = "INFO"
+	}
+	action := effectiveFallbackAction(profile, input.TargetType, severity)
+	out := &AdmissionOutput{
+		FileAction:    coalesceAction(action.File, "none"),
+		InstallAction: coalesceAction(action.Install, "none"),
+		RuntimeAction: coalesceAction(action.Runtime, "allow"),
+	}
+
+	if input.ScanResult.TotalFindings <= 0 {
+		out.Verdict = "clean"
+		out.Reason = "scan clean"
+		return out
+	}
+
+	if action.Runtime == "block" || action.Install == "block" {
+		out.Verdict = "rejected"
+		out.Reason = fmt.Sprintf("max severity %s triggers block per policy", severity)
+		return out
+	}
+
+	out.Verdict = "warning"
+	out.Reason = fmt.Sprintf("findings present (max %s) — allowed with warning", severity)
+	return out
+}
+
+func effectiveFallbackAction(profile *FallbackProfile, targetType, severity string) fallbackAction {
+	if profile == nil {
+		return fallbackAction{}
+	}
+	if overrides, ok := profile.ScannerOverrides[targetType]; ok {
+		if action, ok := overrides[strings.ToUpper(severity)]; ok {
+			return action
+		}
+	}
+	if action, ok := profile.Actions[strings.ToUpper(severity)]; ok {
+		return action
+	}
+	return fallbackAction{}
+}
+
+func firstPartyKey(targetType, targetName string) string {
+	return targetType + "\x00" + targetName
+}
+
+func coalesceAction(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+// matchesProvenance returns true when no provenance constraints exist or
+// when at least one constraint substring is found in the normalised path.
+func matchesProvenance(constraints []string, path string) bool {
+	if len(constraints) == 0 {
+		return true
+	}
+	if path == "" {
+		return false
+	}
+	normalised := strings.ToLower(strings.ReplaceAll(path, "\\", "/"))
+	for _, c := range constraints {
+		if strings.Contains(normalised, strings.ToLower(c)) {
+			return true
+		}
+	}
+	return false
+}
+
+// readDataJSON tries <dir>/rego/data.json first, then <dir>/data.json.
+// The rego/ subdirectory is where _seed_rego_policies writes the active
+// policy and is the canonical location. The root fallback covers the case
+// where the caller already points directly at the rego/ directory.
+func readDataJSON(dir string) ([]byte, error) {
+	regoPath := filepath.Join(dir, "rego", "data.json")
+	raw, err := os.ReadFile(regoPath)
+	if err == nil {
+		return raw, nil
+	}
+	return os.ReadFile(filepath.Join(dir, "data.json"))
+}
+
+func fallbackListEntryReason(entries []ListEntry, targetType, targetName string) (bool, string) {
+	for _, entry := range entries {
+		if entry.TargetType == targetType && entry.TargetName == targetName {
+			if entry.Reason != "" {
+				return true, entry.Reason
+			}
+			return true, fmt.Sprintf("%s '%s' is on the allow/block list", targetType, targetName)
+		}
+	}
+	return false, ""
+}

--- a/internal/policy/fallback_test.go
+++ b/internal/policy/fallback_test.go
@@ -1,0 +1,350 @@
+package policy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func defaultProfile() *FallbackProfile {
+	return LoadFallbackProfile("")
+}
+
+func TestEvaluateAdmissionFallback_Blocked(t *testing.T) {
+	out := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "skill",
+		TargetName: "evil",
+		BlockList:  []ListEntry{{TargetType: "skill", TargetName: "evil", Reason: "malware"}},
+	}, defaultProfile())
+
+	if out.Verdict != "blocked" {
+		t.Errorf("verdict = %q, want blocked", out.Verdict)
+	}
+}
+
+func TestEvaluateAdmissionFallback_ExplicitAllowBeatsPolicy(t *testing.T) {
+	out := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "skill",
+		TargetName: "trusted",
+		AllowList:  []ListEntry{{TargetType: "skill", TargetName: "trusted", Reason: "vendor"}},
+	}, defaultProfile())
+
+	if out.Verdict != "allowed" {
+		t.Errorf("verdict = %q, want allowed", out.Verdict)
+	}
+}
+
+func TestEvaluateAdmissionFallback_BlockBeatsAllow(t *testing.T) {
+	out := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "skill",
+		TargetName: "conflict",
+		BlockList:  []ListEntry{{TargetType: "skill", TargetName: "conflict", Reason: "bad"}},
+		AllowList:  []ListEntry{{TargetType: "skill", TargetName: "conflict", Reason: "good"}},
+	}, defaultProfile())
+
+	if out.Verdict != "blocked" {
+		t.Errorf("verdict = %q, want blocked", out.Verdict)
+	}
+}
+
+func TestEvaluateAdmissionFallback_FirstPartyAllow(t *testing.T) {
+	profile := defaultProfile()
+	profile.FirstPartyAllow[firstPartyKey("plugin", "defenseclaw")] = firstPartyEntry{
+		Reason:             "first-party",
+		SourcePathContains: []string{".defenseclaw", ".openclaw/extensions"},
+	}
+
+	out := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "plugin",
+		TargetName: "defenseclaw",
+		Path:       "/home/user/.openclaw/extensions/defenseclaw",
+	}, profile)
+
+	if out.Verdict != "allowed" {
+		t.Errorf("verdict = %q, want allowed (first-party with provenance)", out.Verdict)
+	}
+}
+
+func TestEvaluateAdmissionFallback_FirstPartyBadProvenance(t *testing.T) {
+	profile := defaultProfile()
+	profile.FirstPartyAllow[firstPartyKey("plugin", "defenseclaw")] = firstPartyEntry{
+		Reason:             "first-party",
+		SourcePathContains: []string{".defenseclaw", ".openclaw/extensions"},
+	}
+
+	// Temp dir should NOT match
+	out := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "plugin",
+		TargetName: "defenseclaw",
+		Path:       "/tmp/dclaw-plugin-fetch-abc123/defenseclaw",
+	}, profile)
+
+	if out.Verdict != "scan" {
+		t.Errorf("verdict = %q, want scan (temp dir should not match provenance)", out.Verdict)
+	}
+
+	// Random unrelated path should NOT match
+	out2 := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "plugin",
+		TargetName: "defenseclaw",
+		Path:       "/home/user/random/plugin",
+	}, profile)
+
+	if out2.Verdict != "scan" {
+		t.Errorf("verdict = %q, want scan (no provenance match)", out2.Verdict)
+	}
+}
+
+func TestEvaluateAdmissionFallback_FirstPartyNoConstraints(t *testing.T) {
+	profile := defaultProfile()
+	profile.FirstPartyAllow[firstPartyKey("plugin", "defenseclaw")] = firstPartyEntry{
+		Reason: "first-party",
+	}
+
+	out := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "plugin",
+		TargetName: "defenseclaw",
+	}, profile)
+
+	if out.Verdict != "allowed" {
+		t.Errorf("verdict = %q, want allowed (no constraints = allow)", out.Verdict)
+	}
+}
+
+func TestEvaluateAdmissionFallback_FirstPartyNoBypass(t *testing.T) {
+	profile := defaultProfile()
+	profile.AllowListBypassScan = false
+	profile.FirstPartyAllow[firstPartyKey("plugin", "defenseclaw")] = firstPartyEntry{
+		Reason: "first-party",
+	}
+
+	out := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "plugin",
+		TargetName: "defenseclaw",
+	}, profile)
+
+	if out.Verdict != "scan" {
+		t.Errorf("verdict = %q, want scan (bypass disabled)", out.Verdict)
+	}
+}
+
+func TestEvaluateAdmissionFallback_ScanOnInstallDisabled(t *testing.T) {
+	profile := defaultProfile()
+	profile.ScanOnInstall = false
+
+	out := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "skill",
+		TargetName: "new-skill",
+	}, profile)
+
+	if out.Verdict != "allowed" {
+		t.Errorf("verdict = %q, want allowed (scan disabled)", out.Verdict)
+	}
+}
+
+func TestEvaluateAdmissionFallback_NoScanRequiresScan(t *testing.T) {
+	out := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "skill",
+		TargetName: "new-skill",
+	}, defaultProfile())
+
+	if out.Verdict != "scan" {
+		t.Errorf("verdict = %q, want scan", out.Verdict)
+	}
+}
+
+func TestEvaluateAdmissionFallback_CleanScan(t *testing.T) {
+	out := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "skill",
+		TargetName: "safe",
+		ScanResult: &ScanResultInput{MaxSeverity: "INFO", TotalFindings: 0},
+	}, defaultProfile())
+
+	if out.Verdict != "clean" {
+		t.Errorf("verdict = %q, want clean", out.Verdict)
+	}
+}
+
+func TestEvaluateAdmissionFallback_HighRejected(t *testing.T) {
+	out := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "skill",
+		TargetName: "risky",
+		ScanResult: &ScanResultInput{MaxSeverity: "HIGH", TotalFindings: 2},
+	}, defaultProfile())
+
+	if out.Verdict != "rejected" {
+		t.Errorf("verdict = %q, want rejected", out.Verdict)
+	}
+	if out.FileAction != "quarantine" {
+		t.Errorf("file_action = %q, want quarantine", out.FileAction)
+	}
+	if out.InstallAction != "block" {
+		t.Errorf("install_action = %q, want block", out.InstallAction)
+	}
+}
+
+func TestEvaluateAdmissionFallback_MediumWarning(t *testing.T) {
+	out := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "skill",
+		TargetName: "iffy",
+		ScanResult: &ScanResultInput{MaxSeverity: "MEDIUM", TotalFindings: 1},
+	}, defaultProfile())
+
+	if out.Verdict != "warning" {
+		t.Errorf("verdict = %q, want warning", out.Verdict)
+	}
+	if out.FileAction != "none" {
+		t.Errorf("file_action = %q, want none", out.FileAction)
+	}
+}
+
+func TestEvaluateAdmissionFallback_InstallBlockAloneRejects(t *testing.T) {
+	profile := defaultProfile()
+	profile.Actions["HIGH"] = fallbackAction{Runtime: "allow", File: "none", Install: "block"}
+
+	out := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "skill",
+		TargetName: "partial",
+		ScanResult: &ScanResultInput{MaxSeverity: "HIGH", TotalFindings: 1},
+	}, profile)
+
+	if out.Verdict != "rejected" {
+		t.Errorf("verdict = %q, want rejected (install=block should reject)", out.Verdict)
+	}
+	if out.RuntimeAction != "allow" {
+		t.Errorf("runtime_action = %q, want allow (only install should block)", out.RuntimeAction)
+	}
+	if out.FileAction != "none" {
+		t.Errorf("file_action = %q, want none", out.FileAction)
+	}
+	if out.InstallAction != "block" {
+		t.Errorf("install_action = %q, want block", out.InstallAction)
+	}
+}
+
+func TestEvaluateAdmissionFallback_ScannerOverride(t *testing.T) {
+	profile := defaultProfile()
+	profile.ScannerOverrides["mcp"] = map[string]fallbackAction{
+		"MEDIUM": {Runtime: "block", File: "quarantine", Install: "block"},
+	}
+
+	out := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "mcp",
+		TargetName: "risky-mcp",
+		ScanResult: &ScanResultInput{MaxSeverity: "MEDIUM", TotalFindings: 1},
+	}, profile)
+
+	if out.Verdict != "rejected" {
+		t.Errorf("verdict = %q, want rejected (MCP override)", out.Verdict)
+	}
+
+	outSkill := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "skill",
+		TargetName: "medium-skill",
+		ScanResult: &ScanResultInput{MaxSeverity: "MEDIUM", TotalFindings: 1},
+	}, profile)
+
+	if outSkill.Verdict != "warning" {
+		t.Errorf("skill verdict = %q, want warning (no MCP override for skill)", outSkill.Verdict)
+	}
+}
+
+func TestEvaluateAdmissionFallback_NilProfile(t *testing.T) {
+	out := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "skill",
+		TargetName: "new",
+	}, nil)
+
+	if out.Verdict != "scan" {
+		t.Errorf("verdict = %q, want scan (nil profile uses defaults)", out.Verdict)
+	}
+}
+
+func TestEvaluateAdmissionFallback_UnknownSeverityWarns(t *testing.T) {
+	out := EvaluateAdmissionFallback(AdmissionInput{
+		TargetType: "skill",
+		TargetName: "odd",
+		ScanResult: &ScanResultInput{MaxSeverity: "UNKNOWN", TotalFindings: 1},
+	}, defaultProfile())
+
+	if out.Verdict != "warning" {
+		t.Errorf("verdict = %q, want warning (unknown severity has no block rule)", out.Verdict)
+	}
+}
+
+func TestLoadFallbackProfile_FromDataJSON(t *testing.T) {
+	dir := t.TempDir()
+	data := map[string]interface{}{
+		"config": map[string]interface{}{
+			"allow_list_bypass_scan": false,
+			"scan_on_install":       false,
+		},
+		"actions": map[string]interface{}{
+			"MEDIUM": map[string]string{"runtime": "block", "file": "quarantine", "install": "block"},
+		},
+		"first_party_allow_list": []map[string]interface{}{
+			{
+				"target_type":          "skill",
+				"target_name":         "codeguard",
+				"reason":              "first-party",
+				"source_path_contains": []string{".defenseclaw", ".openclaw/skills"},
+			},
+		},
+	}
+	raw, _ := json.Marshal(data)
+	os.WriteFile(filepath.Join(dir, "data.json"), raw, 0o600)
+
+	profile := LoadFallbackProfile(dir)
+
+	if profile.AllowListBypassScan {
+		t.Error("expected AllowListBypassScan=false from data.json")
+	}
+	if profile.ScanOnInstall {
+		t.Error("expected ScanOnInstall=false from data.json")
+	}
+	if act, ok := profile.Actions["MEDIUM"]; !ok || act.Runtime != "block" {
+		t.Errorf("expected MEDIUM action override, got %+v", profile.Actions["MEDIUM"])
+	}
+	key := firstPartyKey("skill", "codeguard")
+	if _, ok := profile.FirstPartyAllow[key]; !ok {
+		t.Error("expected first-party entry for codeguard")
+	}
+}
+
+func TestLoadFallbackProfile_FromRegoSubdir(t *testing.T) {
+	dir := t.TempDir()
+	regoDir := filepath.Join(dir, "rego")
+	os.MkdirAll(regoDir, 0o755)
+
+	data := map[string]interface{}{
+		"config": map[string]interface{}{
+			"scan_on_install": false,
+		},
+	}
+	raw, _ := json.Marshal(data)
+	os.WriteFile(filepath.Join(regoDir, "data.json"), raw, 0o600)
+
+	profile := LoadFallbackProfile(dir)
+
+	if profile.ScanOnInstall {
+		t.Error("expected ScanOnInstall=false from rego/data.json")
+	}
+}
+
+func TestLoadFallbackProfile_MissingDir(t *testing.T) {
+	profile := LoadFallbackProfile("/nonexistent/path")
+	if !profile.AllowListBypassScan || !profile.ScanOnInstall {
+		t.Error("missing dir should return defaults")
+	}
+	if _, ok := profile.Actions["CRITICAL"]; !ok {
+		t.Error("defaults should include CRITICAL action")
+	}
+}
+
+func TestLoadFallbackProfile_EmptyDir(t *testing.T) {
+	profile := LoadFallbackProfile("")
+	if !profile.AllowListBypassScan {
+		t.Error("empty dir should return defaults")
+	}
+}

--- a/internal/policy/policy_scan_integration_test.go
+++ b/internal/policy/policy_scan_integration_test.go
@@ -156,9 +156,9 @@ func TestPolicyScan_Strict_MediumPlugin_Rejected(t *testing.T) {
 }
 
 // --------------------------------------------------------------------------
-// Test: Strict policy → allow-listed plugin still scanned (no bypass)
+// Test: Strict policy → explicit allow still overrides scan bypass config
 // --------------------------------------------------------------------------
-func TestPolicyScan_Strict_AllowListedStillScanned(t *testing.T) {
+func TestPolicyScan_Strict_ExplicitAllowStillAllowed(t *testing.T) {
 	dir := setupPolicyDir(t, map[string]map[string]string{
 		"CRITICAL": {"runtime": "block", "file": "quarantine"},
 		"HIGH":     {"runtime": "block", "file": "quarantine"},
@@ -172,7 +172,7 @@ func TestPolicyScan_Strict_AllowListedStillScanned(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Plugin is allow-listed but strict policy says no bypass
+	// Explicit allow entries override policy bypass settings.
 	out, err := eng.Evaluate(context.Background(), AdmissionInput{
 		TargetType: "plugin",
 		TargetName: "trusted-plugin",
@@ -185,9 +185,8 @@ func TestPolicyScan_Strict_AllowListedStillScanned(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Without bypass, allow-listed plugin should fall through to "scan"
-	if out.Verdict != "scan" {
-		t.Errorf("strict policy: allow-listed plugin without bypass should be 'scan', got %q", out.Verdict)
+	if out.Verdict != "allowed" {
+		t.Errorf("strict policy: explicit allow should still be 'allowed', got %q", out.Verdict)
 	}
 }
 

--- a/internal/policy/types.go
+++ b/internal/policy/types.go
@@ -54,6 +54,7 @@ type AdmissionOutput struct {
 	Reason        string `json:"reason"`
 	FileAction    string `json:"file_action"`
 	InstallAction string `json:"install_action"`
+	RuntimeAction string `json:"runtime_action"`
 }
 
 // GuardrailScanResult is a scanner's verdict passed into the guardrail policy.

--- a/internal/scanner/extract_test.go
+++ b/internal/scanner/extract_test.go
@@ -1,0 +1,87 @@
+package scanner
+
+import (
+	"testing"
+)
+
+func TestExtractJSON(t *testing.T) {
+	t.Run("simple_object", func(t *testing.T) {
+		input := []byte(`some text {"key":"value"} trailing`)
+		got := string(extractJSON(input))
+		want := `{"key":"value"}`
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("nested_braces", func(t *testing.T) {
+		input := []byte(`prefix {"a":{"b":"c"}} suffix`)
+		got := string(extractJSON(input))
+		want := `{"a":{"b":"c"}}`
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("braces_inside_strings", func(t *testing.T) {
+		input := []byte(`text {"msg":"hello { world }"} end`)
+		got := string(extractJSON(input))
+		want := `{"msg":"hello { world }"}`
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("escaped_quote_in_string", func(t *testing.T) {
+		input := []byte(`pre {"k":"val\"ue"} post`)
+		got := string(extractJSON(input))
+		want := `{"k":"val\"ue"}`
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("no_json_object", func(t *testing.T) {
+		input := []byte(`no json here`)
+		got := string(extractJSON(input))
+		if got != string(input) {
+			t.Errorf("expected original input returned, got %q", got)
+		}
+	})
+
+	t.Run("multiple_objects_returns_first", func(t *testing.T) {
+		input := []byte(`{"first":1} {"second":2}`)
+		got := string(extractJSON(input))
+		want := `{"first":1}`
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unbalanced_braces_returns_input", func(t *testing.T) {
+		input := []byte(`{"incomplete`)
+		got := string(extractJSON(input))
+		if got != string(input) {
+			t.Errorf("expected original input for unbalanced braces, got %q", got)
+		}
+	})
+
+	t.Run("object_with_array_inside", func(t *testing.T) {
+		input := []byte(`noise {"items":[1,2,{"nested":true}]} more`)
+		got := string(extractJSON(input))
+		want := `{"items":[1,2,{"nested":true}]}`
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("ansi_prefix_then_json", func(t *testing.T) {
+		input := []byte("\033[32m{\"status\":\"ok\"}\033[0m")
+		cleaned := ansiRe.ReplaceAll(input, nil)
+		got := string(extractJSON(cleaned))
+		want := `{"status":"ok"}`
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}

--- a/internal/scanner/mcp.go
+++ b/internal/scanner/mcp.go
@@ -96,6 +96,13 @@ func (s *MCPScanner) scanEnv() []string {
 		}
 	}
 
+	if !existing["NO_COLOR"] {
+		env = append(env, "NO_COLOR=1")
+	}
+	if !existing["TERM"] {
+		env = append(env, "TERM=dumb")
+	}
+
 	return env
 }
 
@@ -154,8 +161,9 @@ type mcpFinding struct {
 }
 
 func parseMCPOutput(data []byte) ([]Finding, error) {
+	clean := extractJSON(ansiRe.ReplaceAll(data, nil))
 	var out mcpOutput
-	if err := json.Unmarshal(data, &out); err != nil {
+	if err := json.Unmarshal(clean, &out); err != nil {
 		return nil, err
 	}
 

--- a/internal/scanner/skill.go
+++ b/internal/scanner/skill.go
@@ -24,11 +24,29 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"time"
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
 )
+
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+// extractJSON finds the first top-level JSON object in data.
+// Scanner CLIs sometimes print progress text to stdout before the JSON;
+// this isolates the `{...}` payload so json.Unmarshal succeeds.
+func extractJSON(data []byte) []byte {
+	start := bytes.IndexByte(data, '{')
+	if start < 0 {
+		return data
+	}
+	end := bytes.LastIndexByte(data, '}')
+	if end < start {
+		return data
+	}
+	return data[start : end+1]
+}
 
 type SkillScanner struct {
 	Config         config.SkillScannerConfig
@@ -117,6 +135,13 @@ func (s *SkillScanner) scanEnv() []string {
 		}
 	}
 
+	if !existing["NO_COLOR"] {
+		env = append(env, "NO_COLOR=1")
+	}
+	if !existing["TERM"] {
+		env = append(env, "TERM=dumb")
+	}
+
 	return env
 }
 
@@ -175,8 +200,9 @@ type skillFinding struct {
 }
 
 func parseSkillOutput(data []byte) ([]Finding, error) {
+	clean := extractJSON(ansiRe.ReplaceAll(data, nil))
 	var out skillOutput
-	if err := json.Unmarshal(data, &out); err != nil {
+	if err := json.Unmarshal(clean, &out); err != nil {
 		return nil, err
 	}
 

--- a/internal/scanner/skill.go
+++ b/internal/scanner/skill.go
@@ -36,16 +36,44 @@ var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
 // extractJSON finds the first top-level JSON object in data.
 // Scanner CLIs sometimes print progress text to stdout before the JSON;
 // this isolates the `{...}` payload so json.Unmarshal succeeds.
+// extractJSON locates the first balanced JSON object in data by tracking
+// brace depth while skipping string literals.
 func extractJSON(data []byte) []byte {
 	start := bytes.IndexByte(data, '{')
 	if start < 0 {
 		return data
 	}
-	end := bytes.LastIndexByte(data, '}')
-	if end < start {
-		return data
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(data); i++ {
+		b := data[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if b == '\\' && inString {
+			escaped = true
+			continue
+		}
+		if b == '"' {
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		switch b {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return data[start : i+1]
+			}
+		}
 	}
-	return data[start : end+1]
+	return data
 }
 
 type SkillScanner struct {

--- a/internal/telemetry/alerts.go
+++ b/internal/telemetry/alerts.go
@@ -33,6 +33,7 @@ const (
 	AlertDataExfiltration = "data-exfiltration"
 	AlertContentViolation  = "content-violation"
 	AlertCodeGuardFinding  = "codeguard-finding"
+	AlertToolCallFlagged   = "tool-call-flagged"
 )
 
 // AlertSource constants for defenseclaw.alert.source.
@@ -42,6 +43,7 @@ const (
 	SourceAIDefense      = "ai-defense"
 	SourceOPAPolicy      = "opa-policy"
 	SourceCodeGuard      = "codeguard"
+	SourceToolInspect    = "tool-inspect"
 )
 
 // EmitRuntimeAlert emits a high-priority OTel LogRecord for a runtime alert.

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -60,12 +60,12 @@ type InstallEvent struct {
 type Verdict string
 
 const (
-	VerdictBlocked    Verdict = "blocked"
-	VerdictAllowed    Verdict = "allowed"
-	VerdictClean      Verdict = "clean"
-	VerdictRejected   Verdict = "rejected"
-	VerdictWarning    Verdict = "warning"
-	VerdictScanError  Verdict = "scan-error"
+	VerdictBlocked   Verdict = "blocked"
+	VerdictAllowed   Verdict = "allowed"
+	VerdictClean     Verdict = "clean"
+	VerdictRejected  Verdict = "rejected"
+	VerdictWarning   Verdict = "warning"
+	VerdictScanError Verdict = "scan-error"
 )
 
 // AdmissionResult captures the outcome for a single install event.
@@ -82,7 +82,7 @@ type OnAdmission func(AdmissionResult)
 
 // InstallWatcher monitors OpenClaw skill directories for new installs
 // and runs the admission gate (block → allow → scan) on each detection.
-// MCP servers are managed via ``defenseclaw mcp set/unset`` rather than
+// MCP servers are managed via “defenseclaw mcp set/unset“ rather than
 // filesystem watching.
 type InstallWatcher struct {
 	cfg        *config.Config
@@ -265,6 +265,7 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 	// Build block/allow lists from the SQLite store for the OPA input.
 	blockList := w.buildListEntries(pe, "block")
 	allowList := w.buildListEntries(pe, "allow")
+	fallbackProfile := policy.LoadFallbackProfile(w.cfg.PolicyDir)
 
 	// Phase 1: pre-scan OPA evaluation (no scan_result yet).
 	if w.opa != nil {
@@ -301,35 +302,26 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 		}
 		// On OPA error fall through to scan (best-effort).
 	} else {
-		// Fallback: built-in Go block/allow check when OPA is unavailable.
-		blocked, bErr := pe.IsBlocked(targetType, evt.Name)
-		if bErr == nil && blocked {
-			reason := fmt.Sprintf("%s %q is on the block list — rejected", targetType, evt.Name)
+		input := policy.AdmissionInput{
+			TargetType: targetType,
+			TargetName: evt.Name,
+			Path:       evt.Path,
+			BlockList:  blockList,
+			AllowList:  allowList,
+		}
+		out := policy.EvaluateAdmissionFallback(input, fallbackProfile)
+		switch out.Verdict {
+		case "blocked":
 			_ = w.logger.LogAction("install-rejected", evt.Path,
 				fmt.Sprintf("type=%s reason=blocked", targetType))
 			w.enforceBlock(evt)
 			w.recordAdmission(ctx, "blocked", targetType)
-			return AdmissionResult{Event: evt, Verdict: VerdictBlocked, Reason: reason}
-		}
-
-		allowed, aErr := pe.IsAllowed(targetType, evt.Name)
-		if aErr == nil && allowed {
-			reason := fmt.Sprintf("%s %q is on the allow list — skipping scan", targetType, evt.Name)
+			return AdmissionResult{Event: evt, Verdict: VerdictBlocked, Reason: out.Reason}
+		case "allowed":
 			_ = w.logger.LogAction("install-allowed", evt.Path,
 				fmt.Sprintf("type=%s reason=allow-listed", targetType))
 			w.recordAdmission(ctx, "allowed", targetType)
-			return AdmissionResult{Event: evt, Verdict: VerdictAllowed, Reason: reason}
-		}
-
-		// If both checks returned errors (e.g. SQLITE_BUSY), do NOT fall
-		// through to scan — we cannot safely enforce without knowing the
-		// allow/block status.
-		if bErr != nil && aErr != nil {
-			reason := fmt.Sprintf("store unavailable — skipping admission for %s %q", targetType, evt.Name)
-			fmt.Fprintf(os.Stderr, "[watch] block/allow check failed (db busy?): block=%v allow=%v\n", bErr, aErr)
-			_ = w.logger.LogAction("install-deferred", evt.Path, reason)
-			w.recordAdmission(ctx, "scan-error", targetType)
-			return AdmissionResult{Event: evt, Verdict: VerdictScanError, Reason: reason}
+			return AdmissionResult{Event: evt, Verdict: VerdictAllowed, Reason: out.Reason}
 		}
 	}
 
@@ -352,6 +344,32 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 		}
 		w.recordAdmission(ctx, "scan-error", targetType)
 		return AdmissionResult{Event: evt, Verdict: VerdictScanError, Reason: err.Error()}
+	}
+
+	// Manual block/allow entries should win even if they were added while the
+	// scan was running.
+	if blocked, bErr := pe.IsBlocked(targetType, evt.Name); bErr == nil && blocked {
+		reason := fmt.Sprintf("%s %q is on the block list — rejected", targetType, evt.Name)
+		_ = w.logger.LogAction("install-rejected", evt.Path,
+			fmt.Sprintf("type=%s reason=blocked-post-scan", targetType))
+		_ = w.logger.LogScanWithVerdict(result, "blocked")
+		w.enforceBlock(evt)
+		w.recordAdmission(ctx, "blocked", targetType)
+		return AdmissionResult{
+			Event: evt, Verdict: VerdictBlocked, Reason: reason,
+			MaxSeverity: string(result.MaxSeverity()), FindingCount: len(result.Findings),
+		}
+	}
+	if allowed, aErr := pe.IsAllowed(targetType, evt.Name); aErr == nil && allowed {
+		reason := fmt.Sprintf("scan found findings but %s %q is allow-listed — skipping enforcement", targetType, evt.Name)
+		_ = w.logger.LogAction("install-allowed", evt.Path,
+			fmt.Sprintf("type=%s reason=allow-listed-post-scan", targetType))
+		_ = w.logger.LogScanWithVerdict(result, "allowed")
+		w.recordAdmission(ctx, "allowed", targetType)
+		return AdmissionResult{
+			Event: evt, Verdict: VerdictAllowed, Reason: reason,
+			MaxSeverity: string(result.MaxSeverity()), FindingCount: len(result.Findings),
+		}
 	}
 
 	// Phase 3: post-scan OPA evaluation with scan_result.
@@ -393,75 +411,26 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 		// On OPA error, fall through to built-in logic.
 	}
 
-	// Fallback: built-in Go post-scan logic.
-	if result.IsClean() {
-		_ = w.logger.LogAction("install-clean", evt.Path,
-			fmt.Sprintf("type=%s scanner=%s", targetType, s.Name()))
-		_ = w.logger.LogScanWithVerdict(result, string(VerdictClean))
-		w.recordAdmission(ctx, "scan_clean", targetType)
-		return AdmissionResult{Event: evt, Verdict: VerdictClean, Reason: "scan clean"}
+	scanInput := &policy.ScanResultInput{
+		MaxSeverity:   string(result.MaxSeverity()),
+		TotalFindings: len(result.Findings),
+		ScannerName:   s.Name(),
+		Findings:      toFindingInputs(result.Findings),
 	}
-
-	// Re-check allow list: the item may have been allowed between the
-	// pre-scan check and now (race with CLI ``skill allow``).  Only a
-	// manual block can override an allow entry.
-	if allowed, aErr := pe.IsAllowed(targetType, evt.Name); aErr == nil && allowed {
-		reason := fmt.Sprintf("scan found findings but %s %q is allow-listed — skipping enforcement", targetType, evt.Name)
-		_ = w.logger.LogAction("install-allowed-skip-enforce", evt.Path,
-			fmt.Sprintf("type=%s %s is allow-listed post-scan", targetType, evt.Name))
-		_ = w.logger.LogScanWithVerdict(result, string(VerdictWarning))
-		w.recordAdmission(ctx, "scan_warning", targetType)
-		return AdmissionResult{
-			Event: evt, Verdict: VerdictWarning, Reason: reason,
-			MaxSeverity: string(result.MaxSeverity()), FindingCount: len(result.Findings),
-		}
-	}
-
-	maxSev := result.MaxSeverity()
-	if maxSev == scanner.SeverityHigh || maxSev == scanner.SeverityCritical {
-		reason := fmt.Sprintf("scan found %s findings — auto-blocking", maxSev)
-		_ = w.logger.LogAction("install-rejected", evt.Path,
-			fmt.Sprintf("type=%s severity=%s scanner=%s", targetType, maxSev, s.Name()))
-
-		if w.takeActionFor(evt) {
-			blockReason := fmt.Sprintf("auto-block: watch detected %s findings (scanner=%s)", maxSev, s.Name())
-			_ = pe.Block(targetType, evt.Name, blockReason)
-			pe.SetSourcePath(targetType, evt.Name, evt.Path)
-
-			action := w.cfg.SkillActions.ForSeverity(string(maxSev))
-			enforcement := map[string]string{
-				"source_path": evt.Path,
-				"install":     "block",
-			}
-			if action.File == config.FileActionQuarantine {
-				_ = pe.Quarantine(targetType, evt.Name, blockReason)
-				enforcement["file"] = "quarantine"
-			}
-			if action.Runtime == config.RuntimeDisable {
-				_ = pe.Disable(targetType, evt.Name, blockReason)
-				enforcement["runtime"] = "disable"
-			}
-			_ = w.logger.LogActionWithEnforcement("watcher-block", evt.Name,
-				fmt.Sprintf("type=%s reason=%s", targetType, blockReason), enforcement)
-
-			w.enforceBlock(evt)
-		}
-		_ = w.logger.LogScanWithVerdict(result, string(VerdictRejected))
-		w.recordAdmission(ctx, "scan_rejected", targetType)
-		return AdmissionResult{
-			Event: evt, Verdict: VerdictRejected, Reason: reason,
-			MaxSeverity: string(maxSev), FindingCount: len(result.Findings),
-		}
-	}
-
-	reason := fmt.Sprintf("scan found %s findings — installed with warning", maxSev)
-	_ = w.logger.LogAction("install-warning", evt.Path,
-		fmt.Sprintf("type=%s severity=%s scanner=%s", targetType, maxSev, s.Name()))
-	_ = w.logger.LogScanWithVerdict(result, string(VerdictWarning))
-	w.recordAdmission(ctx, "scan_warning", targetType)
+	out := policy.EvaluateAdmissionFallback(policy.AdmissionInput{
+		TargetType: targetType,
+		TargetName: evt.Name,
+		Path:       evt.Path,
+		BlockList:  blockList,
+		AllowList:  allowList,
+		ScanResult: scanInput,
+	}, fallbackProfile)
+	w.applyPostScanEnforcement(pe, out, evt, targetType, result, s.Name())
+	_ = w.logger.LogScanWithVerdict(result, out.Verdict)
+	w.recordAdmission(ctx, out.Verdict, targetType)
 	return AdmissionResult{
-		Event: evt, Verdict: VerdictWarning, Reason: reason,
-		MaxSeverity: string(maxSev), FindingCount: len(result.Findings),
+		Event: evt, Verdict: toVerdict(out.Verdict), Reason: out.Reason,
+		MaxSeverity: string(result.MaxSeverity()), FindingCount: len(result.Findings),
 	}
 }
 
@@ -491,22 +460,36 @@ func (w *InstallWatcher) applyPostScanEnforcement(pe *enforce.PolicyEngine, out 
 
 		if w.takeActionFor(evt) {
 			blockReason := fmt.Sprintf("auto-block: watch detected %s findings (scanner=%s)", result.MaxSeverity(), scannerName)
-			_ = pe.Block(targetType, evt.Name, blockReason)
+
+			installAction := coalesce(out.InstallAction, "block")
+			runtimeAction := coalesce(out.RuntimeAction, "allow")
+			fileAction := coalesce(out.FileAction, "none")
+
+			if installAction == "block" {
+				_ = pe.Block(targetType, evt.Name, blockReason)
+			}
 			pe.SetSourcePath(targetType, evt.Name, evt.Path)
 
 			enforcement := map[string]string{
-				"source_path":    evt.Path,
-				"install":        coalesce(out.InstallAction, "block"),
-				"runtime":        "disable",
-				"file":           coalesce(out.FileAction, "none"),
+				"source_path": evt.Path,
+				"install":     installAction,
+				"runtime":     runtimeAction,
+				"file":        fileAction,
 			}
-			if out.FileAction == "quarantine" {
+
+			if fileAction == "quarantine" {
 				_ = pe.Quarantine(targetType, evt.Name, blockReason)
 			}
-			_ = pe.Disable(targetType, evt.Name, blockReason)
+			if runtimeAction == "block" {
+				_ = pe.Disable(targetType, evt.Name, blockReason)
+			}
+
 			_ = w.logger.LogActionWithEnforcement("watcher-block", evt.Name,
 				fmt.Sprintf("type=%s reason=%s", targetType, blockReason), enforcement)
-			w.enforceBlock(evt)
+
+			if fileAction == "quarantine" || runtimeAction == "block" {
+				w.enforceBlock(evt)
+			}
 		}
 	case "warning":
 		_ = w.logger.LogAction("install-warning", evt.Path,

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -70,11 +70,14 @@ const (
 
 // AdmissionResult captures the outcome for a single install event.
 type AdmissionResult struct {
-	Event        InstallEvent
-	Verdict      Verdict
-	Reason       string
-	MaxSeverity  string
-	FindingCount int
+	Event         InstallEvent
+	Verdict       Verdict
+	Reason        string
+	MaxSeverity   string
+	FindingCount  int
+	InstallAction string
+	FileAction    string
+	RuntimeAction string
 }
 
 // OnAdmission is called after each install event is processed.
@@ -300,7 +303,22 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 			}
 			// verdict == "scan" → proceed to scanning below
 		}
-		// On OPA error fall through to scan (best-effort).
+		// On OPA error, fall back to the built-in pre-scan gate so explicit
+		// block/allow semantics still hold even when Rego is unavailable.
+		fallbackOut := policy.EvaluateAdmissionFallback(input, fallbackProfile)
+		switch fallbackOut.Verdict {
+		case "blocked":
+			_ = w.logger.LogAction("install-rejected", evt.Path,
+				fmt.Sprintf("type=%s reason=blocked", targetType))
+			w.enforceBlock(evt)
+			w.recordAdmission(ctx, "blocked", targetType)
+			return AdmissionResult{Event: evt, Verdict: VerdictBlocked, Reason: fallbackOut.Reason}
+		case "allowed":
+			_ = w.logger.LogAction("install-allowed", evt.Path,
+				fmt.Sprintf("type=%s reason=allow-listed", targetType))
+			w.recordAdmission(ctx, "allowed", targetType)
+			return AdmissionResult{Event: evt, Verdict: VerdictAllowed, Reason: fallbackOut.Reason}
+		}
 	} else {
 		input := policy.AdmissionInput{
 			TargetType: targetType,
@@ -358,6 +376,7 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 		return AdmissionResult{
 			Event: evt, Verdict: VerdictBlocked, Reason: reason,
 			MaxSeverity: string(result.MaxSeverity()), FindingCount: len(result.Findings),
+			InstallAction: "block",
 		}
 	}
 	if allowed, aErr := pe.IsAllowed(targetType, evt.Name); aErr == nil && allowed {
@@ -369,6 +388,7 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 		return AdmissionResult{
 			Event: evt, Verdict: VerdictAllowed, Reason: reason,
 			MaxSeverity: string(result.MaxSeverity()), FindingCount: len(result.Findings),
+			InstallAction: "allow",
 		}
 	}
 
@@ -406,6 +426,9 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 			return AdmissionResult{
 				Event: evt, Verdict: toVerdict(out.Verdict), Reason: out.Reason,
 				MaxSeverity: string(result.MaxSeverity()), FindingCount: len(result.Findings),
+				InstallAction: out.InstallAction,
+				FileAction:    out.FileAction,
+				RuntimeAction: out.RuntimeAction,
 			}
 		}
 		// On OPA error, fall through to built-in logic.
@@ -431,6 +454,9 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 	return AdmissionResult{
 		Event: evt, Verdict: toVerdict(out.Verdict), Reason: out.Reason,
 		MaxSeverity: string(result.MaxSeverity()), FindingCount: len(result.Findings),
+		InstallAction: out.InstallAction,
+		FileAction:    out.FileAction,
+		RuntimeAction: out.RuntimeAction,
 	}
 }
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -302,8 +302,8 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 		// On OPA error fall through to scan (best-effort).
 	} else {
 		// Fallback: built-in Go block/allow check when OPA is unavailable.
-		blocked, err := pe.IsBlocked(targetType, evt.Name)
-		if err == nil && blocked {
+		blocked, bErr := pe.IsBlocked(targetType, evt.Name)
+		if bErr == nil && blocked {
 			reason := fmt.Sprintf("%s %q is on the block list — rejected", targetType, evt.Name)
 			_ = w.logger.LogAction("install-rejected", evt.Path,
 				fmt.Sprintf("type=%s reason=blocked", targetType))
@@ -312,13 +312,24 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 			return AdmissionResult{Event: evt, Verdict: VerdictBlocked, Reason: reason}
 		}
 
-		allowed, err := pe.IsAllowed(targetType, evt.Name)
-		if err == nil && allowed {
+		allowed, aErr := pe.IsAllowed(targetType, evt.Name)
+		if aErr == nil && allowed {
 			reason := fmt.Sprintf("%s %q is on the allow list — skipping scan", targetType, evt.Name)
 			_ = w.logger.LogAction("install-allowed", evt.Path,
 				fmt.Sprintf("type=%s reason=allow-listed", targetType))
 			w.recordAdmission(ctx, "allowed", targetType)
 			return AdmissionResult{Event: evt, Verdict: VerdictAllowed, Reason: reason}
+		}
+
+		// If both checks returned errors (e.g. SQLITE_BUSY), do NOT fall
+		// through to scan — we cannot safely enforce without knowing the
+		// allow/block status.
+		if bErr != nil && aErr != nil {
+			reason := fmt.Sprintf("store unavailable — skipping admission for %s %q", targetType, evt.Name)
+			fmt.Fprintf(os.Stderr, "[watch] block/allow check failed (db busy?): block=%v allow=%v\n", bErr, aErr)
+			_ = w.logger.LogAction("install-deferred", evt.Path, reason)
+			w.recordAdmission(ctx, "scan-error", targetType)
+			return AdmissionResult{Event: evt, Verdict: VerdictScanError, Reason: reason}
 		}
 	}
 
@@ -391,6 +402,21 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 		return AdmissionResult{Event: evt, Verdict: VerdictClean, Reason: "scan clean"}
 	}
 
+	// Re-check allow list: the item may have been allowed between the
+	// pre-scan check and now (race with CLI ``skill allow``).  Only a
+	// manual block can override an allow entry.
+	if allowed, aErr := pe.IsAllowed(targetType, evt.Name); aErr == nil && allowed {
+		reason := fmt.Sprintf("scan found findings but %s %q is allow-listed — skipping enforcement", targetType, evt.Name)
+		_ = w.logger.LogAction("install-allowed-skip-enforce", evt.Path,
+			fmt.Sprintf("type=%s %s is allow-listed post-scan", targetType, evt.Name))
+		_ = w.logger.LogScanWithVerdict(result, string(VerdictWarning))
+		w.recordAdmission(ctx, "scan_warning", targetType)
+		return AdmissionResult{
+			Event: evt, Verdict: VerdictWarning, Reason: reason,
+			MaxSeverity: string(result.MaxSeverity()), FindingCount: len(result.Findings),
+		}
+	}
+
 	maxSev := result.MaxSeverity()
 	if maxSev == scanner.SeverityHigh || maxSev == scanner.SeverityCritical {
 		reason := fmt.Sprintf("scan found %s findings — auto-blocking", maxSev)
@@ -442,7 +468,18 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 // applyPostScanEnforcement takes the OPA verdict after scanning and executes
 // the enforcement side-effects (block, quarantine, disable) that OPA cannot
 // perform itself. It respects file_action and install_action from OPA output.
+//
+// Allow-listed items are exempt from auto-enforcement; only a manual block
+// can override an allow entry.
 func (w *InstallWatcher) applyPostScanEnforcement(pe *enforce.PolicyEngine, out *policy.AdmissionOutput, evt InstallEvent, targetType string, result *scanner.ScanResult, scannerName string) {
+	// Re-check allow list to guard against races where the item became
+	// allowed between the pre-scan check and post-scan enforcement.
+	if allowed, err := pe.IsAllowed(targetType, evt.Name); err == nil && allowed {
+		_ = w.logger.LogAction("install-allowed-skip-enforce", evt.Path,
+			fmt.Sprintf("type=%s %s is allow-listed — skipping auto-enforcement", targetType, evt.Name))
+		return
+	}
+
 	switch out.Verdict {
 	case "clean":
 		_ = w.logger.LogAction("install-clean", evt.Path,

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -70,9 +70,11 @@ const (
 
 // AdmissionResult captures the outcome for a single install event.
 type AdmissionResult struct {
-	Event   InstallEvent
-	Verdict Verdict
-	Reason  string
+	Event        InstallEvent
+	Verdict      Verdict
+	Reason       string
+	MaxSeverity  string
+	FindingCount int
 }
 
 // OnAdmission is called after each install event is processed.
@@ -372,7 +374,10 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 			w.applyPostScanEnforcement(pe, out, evt, targetType, result, s.Name())
 			_ = w.logger.LogScanWithVerdict(result, out.Verdict)
 			w.recordAdmission(ctx, out.Verdict, targetType)
-			return AdmissionResult{Event: evt, Verdict: toVerdict(out.Verdict), Reason: out.Reason}
+			return AdmissionResult{
+				Event: evt, Verdict: toVerdict(out.Verdict), Reason: out.Reason,
+				MaxSeverity: string(result.MaxSeverity()), FindingCount: len(result.Findings),
+			}
 		}
 		// On OPA error, fall through to built-in logic.
 	}
@@ -417,7 +422,10 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 		}
 		_ = w.logger.LogScanWithVerdict(result, string(VerdictRejected))
 		w.recordAdmission(ctx, "scan_rejected", targetType)
-		return AdmissionResult{Event: evt, Verdict: VerdictRejected, Reason: reason}
+		return AdmissionResult{
+			Event: evt, Verdict: VerdictRejected, Reason: reason,
+			MaxSeverity: string(maxSev), FindingCount: len(result.Findings),
+		}
 	}
 
 	reason := fmt.Sprintf("scan found %s findings — installed with warning", maxSev)
@@ -425,7 +433,10 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 		fmt.Sprintf("type=%s severity=%s scanner=%s", targetType, maxSev, s.Name()))
 	_ = w.logger.LogScanWithVerdict(result, string(VerdictWarning))
 	w.recordAdmission(ctx, "scan_warning", targetType)
-	return AdmissionResult{Event: evt, Verdict: VerdictWarning, Reason: reason}
+	return AdmissionResult{
+		Event: evt, Verdict: VerdictWarning, Reason: reason,
+		MaxSeverity: string(maxSev), FindingCount: len(result.Findings),
+	}
 }
 
 // applyPostScanEnforcement takes the OPA verdict after scanning and executes

--- a/policies/default.yaml
+++ b/policies/default.yaml
@@ -31,6 +31,14 @@ skill_actions:
 
 scanner_overrides: {}
 
+first_party_allow_list:
+  - target_type: plugin
+    target_name: defenseclaw
+    reason: first-party DefenseClaw plugin
+  - target_type: skill
+    target_name: codeguard
+    reason: first-party DefenseClaw skill
+
 guardrail:
   block_threshold: 3
   alert_threshold: 2

--- a/policies/default.yaml
+++ b/policies/default.yaml
@@ -35,9 +35,11 @@ first_party_allow_list:
   - target_type: plugin
     target_name: defenseclaw
     reason: first-party DefenseClaw plugin
+    source_path_contains: [".defenseclaw", ".openclaw/extensions"]
   - target_type: skill
     target_name: codeguard
     reason: first-party DefenseClaw skill
+    source_path_contains: [".defenseclaw", ".openclaw/workspace/skills", ".openclaw/skills"]
 
 guardrail:
   block_threshold: 3

--- a/policies/permissive.yaml
+++ b/policies/permissive.yaml
@@ -31,6 +31,14 @@ skill_actions:
 
 scanner_overrides: {}
 
+first_party_allow_list:
+  - target_type: plugin
+    target_name: defenseclaw
+    reason: first-party DefenseClaw plugin
+  - target_type: skill
+    target_name: codeguard
+    reason: first-party DefenseClaw skill
+
 guardrail:
   block_threshold: 4
   alert_threshold: 3

--- a/policies/permissive.yaml
+++ b/policies/permissive.yaml
@@ -35,9 +35,11 @@ first_party_allow_list:
   - target_type: plugin
     target_name: defenseclaw
     reason: first-party DefenseClaw plugin
+    source_path_contains: [".defenseclaw", ".openclaw/extensions"]
   - target_type: skill
     target_name: codeguard
     reason: first-party DefenseClaw skill
+    source_path_contains: [".defenseclaw", ".openclaw/workspace/skills", ".openclaw/skills"]
 
 guardrail:
   block_threshold: 4

--- a/policies/rego/admission.rego
+++ b/policies/rego/admission.rego
@@ -144,6 +144,12 @@ _is_allow_listed if {
 	entry.target_type == input.target_type
 }
 
+_is_allow_listed if {
+	some entry in data.first_party_allow_list
+	entry.target_name == input.target_name
+	entry.target_type == input.target_type
+}
+
 _is_allow_bypassed if {
 	_is_allow_listed
 	data.config.allow_list_bypass_scan == true

--- a/policies/rego/admission.rego
+++ b/policies/rego/admission.rego
@@ -193,9 +193,9 @@ _has_scan if input.scan_result
 # Check scanner_overrides[target_type][severity] first, fall back to global actions.
 
 _effective_action := action if {
-	action := data.scanner_overrides[input.target_type][input.scan_result.max_severity]
+	action := data.scanner_overrides[input.target_type][upper(input.scan_result.max_severity)]
 } else := action if {
-	action := data.actions[input.scan_result.max_severity]
+	action := data.actions[upper(input.scan_result.max_severity)]
 }
 
 _should_reject if {

--- a/policies/rego/admission.rego
+++ b/policies/rego/admission.rego
@@ -48,17 +48,31 @@ reason := sprintf("%s '%s' is on the block list", [input.target_type, input.targ
 	verdict == "blocked"
 }
 
-# --- Allow list (skip scan when configured) ---
+# --- Explicit allow list (manual override; always skip scan) ---
 
 verdict := "allowed" if {
 	not _is_blocked
-	_is_allow_listed
+	_is_explicit_allow_listed
+}
+
+reason := sprintf("%s '%s' is on the allow list — scan skipped", [input.target_type, input.target_name]) if {
+	not _is_blocked
+	_is_explicit_allow_listed
+}
+
+# --- Policy-managed allow list (skip scan when configured) ---
+
+verdict := "allowed" if {
+	not _is_blocked
+	not _is_explicit_allow_listed
+	_is_policy_allow_listed
 	data.config.allow_list_bypass_scan == true
 }
 
 reason := sprintf("%s '%s' is on the allow list — scan skipped", [input.target_type, input.target_name]) if {
 	not _is_blocked
-	_is_allow_listed
+	not _is_explicit_allow_listed
+	_is_policy_allow_listed
 	data.config.allow_list_bypass_scan == true
 }
 
@@ -138,20 +152,38 @@ _is_blocked if {
 	entry.target_type == input.target_type
 }
 
-_is_allow_listed if {
+_is_explicit_allow_listed if {
 	some entry in input.allow_list
 	entry.target_name == input.target_name
 	entry.target_type == input.target_type
 }
 
-_is_allow_listed if {
+_is_policy_allow_listed if {
 	some entry in data.first_party_allow_list
 	entry.target_name == input.target_name
 	entry.target_type == input.target_type
+	_path_matches_provenance(entry)
+}
+
+_path_matches_provenance(entry) if {
+	not entry.source_path_contains
+}
+
+_path_matches_provenance(entry) if {
+	count(entry.source_path_contains) == 0
+}
+
+_path_matches_provenance(entry) if {
+	some prefix in entry.source_path_contains
+	contains(lower(input.path), lower(prefix))
 }
 
 _is_allow_bypassed if {
-	_is_allow_listed
+	_is_explicit_allow_listed
+}
+
+_is_allow_bypassed if {
+	_is_policy_allow_listed
 	data.config.allow_list_bypass_scan == true
 }
 
@@ -168,6 +200,10 @@ _effective_action := action if {
 
 _should_reject if {
 	_effective_action.runtime == "block"
+}
+
+_should_reject if {
+	_effective_action.install == "block"
 }
 
 # --- Structured output: file_action ---
@@ -189,5 +225,16 @@ install_action := action if {
 }
 
 install_action := "none" if {
+	not _has_scan
+}
+
+# --- Structured output: runtime_action ---
+
+runtime_action := action if {
+	_has_scan
+	action := _effective_action.runtime
+}
+
+runtime_action := "allow" if {
 	not _has_scan
 }

--- a/policies/rego/admission_test.rego
+++ b/policies/rego/admission_test.rego
@@ -577,7 +577,7 @@ test_production_first_party_skill_allowed if {
 	result := admission with input as {
 		"target_type": "skill",
 		"target_name": "codeguard",
-		"path": "/home/user/.defenseclaw/skills/codeguard",
+		"path": "/home/user/.openclaw/workspace/skills/codeguard",
 		"block_list": [],
 		"allow_list": [],
 	}
@@ -743,6 +743,95 @@ test_install_action_none_on_warning if {
 
 	result.install_action == "none"
 	result.file_action == "none"
+}
+
+test_lowercase_severity_still_rejects if {
+	result := admission with input as {
+		"target_type": "skill",
+		"target_name": "lc-skill",
+		"path": "/tmp/lc",
+		"block_list": [],
+		"allow_list": [],
+		"scan_result": {"max_severity": "critical", "total_findings": 1, "findings": []},
+	}
+		with data.config as {"allow_list_bypass_scan": false, "scan_on_install": true}
+		with data.actions as {"CRITICAL": {"runtime": "block", "file": "quarantine", "install": "block"}}
+		with data.scanner_overrides as {}
+		with data.first_party_allow_list as []
+
+	result.verdict == "rejected"
+	result.runtime_action == "block"
+	result.file_action == "quarantine"
+	result.install_action == "block"
+}
+
+test_mixed_case_severity_still_rejects if {
+	result := admission with input as {
+		"target_type": "skill",
+		"target_name": "mc-skill",
+		"path": "/tmp/mc",
+		"block_list": [],
+		"allow_list": [],
+		"scan_result": {"max_severity": "High", "total_findings": 1, "findings": []},
+	}
+		with data.config as {"allow_list_bypass_scan": false, "scan_on_install": true}
+		with data.actions as {"HIGH": {"runtime": "block", "file": "quarantine", "install": "block"}}
+		with data.scanner_overrides as {}
+		with data.first_party_allow_list as []
+
+	result.verdict == "rejected"
+}
+
+test_high_severity_has_runtime_block if {
+	result := admission with input as {
+		"target_type": "skill",
+		"target_name": "risky-skill",
+		"path": "/tmp/risky",
+		"block_list": [],
+		"allow_list": [],
+		"scan_result": {"max_severity": "HIGH", "total_findings": 3, "findings": []},
+	}
+		with data.config as {"allow_list_bypass_scan": false, "scan_on_install": true}
+		with data.actions as {"HIGH": {"runtime": "block", "file": "quarantine", "install": "block"}}
+		with data.scanner_overrides as {}
+		with data.first_party_allow_list as []
+
+	result.runtime_action == "block"
+}
+
+test_install_only_block_has_runtime_allow if {
+	result := admission with input as {
+		"target_type": "skill",
+		"target_name": "install-only-skill",
+		"path": "/tmp/install-only",
+		"block_list": [],
+		"allow_list": [],
+		"scan_result": {"max_severity": "MEDIUM", "total_findings": 1, "findings": []},
+	}
+		with data.config as {"allow_list_bypass_scan": false, "scan_on_install": true}
+		with data.actions as {"MEDIUM": {"runtime": "allow", "file": "none", "install": "block"}}
+		with data.scanner_overrides as {}
+		with data.first_party_allow_list as []
+
+	result.runtime_action == "allow"
+	result.install_action == "block"
+	result.verdict == "rejected"
+}
+
+test_no_scan_has_runtime_allow if {
+	result := admission with input as {
+		"target_type": "skill",
+		"target_name": "clean-skill",
+		"path": "/tmp/clean",
+		"block_list": [],
+		"allow_list": [],
+	}
+		with data.config as {"allow_list_bypass_scan": false, "scan_on_install": true}
+		with data.actions as {}
+		with data.scanner_overrides as {}
+		with data.first_party_allow_list as []
+
+	result.runtime_action == "allow"
 }
 
 test_no_scan_result_actions_default_none if {

--- a/policies/rego/admission_test.rego
+++ b/policies/rego/admission_test.rego
@@ -543,6 +543,84 @@ test_production_audit_retention_at_least_90 if {
 	data.audit.retention_days >= 90
 }
 
+test_production_first_party_plugin_allowed if {
+	result := admission with input as {
+		"target_type": "plugin",
+		"target_name": "defenseclaw",
+		"path": "/tmp/defenseclaw",
+		"block_list": [],
+		"allow_list": [],
+	}
+
+	result.verdict == "allowed"
+}
+
+test_production_first_party_skill_allowed if {
+	result := admission with input as {
+		"target_type": "skill",
+		"target_name": "codeguard",
+		"path": "/tmp/codeguard",
+		"block_list": [],
+		"allow_list": [],
+	}
+
+	result.verdict == "allowed"
+}
+
+test_first_party_allow_list_bypass_scan if {
+	result := admission with input as {
+		"target_type": "plugin",
+		"target_name": "defenseclaw",
+		"path": "/tmp/defenseclaw",
+		"block_list": [],
+		"allow_list": [],
+		"scan_result": {"max_severity": "MEDIUM", "total_findings": 2, "findings": []},
+	}
+		with data.config as {"allow_list_bypass_scan": true, "scan_on_install": true}
+		with data.first_party_allow_list as [
+			{"target_type": "plugin", "target_name": "defenseclaw", "reason": "first-party"},
+		]
+		with data.actions as {"MEDIUM": {"runtime": "allow", "file": "none", "install": "none"}}
+		with data.scanner_overrides as {}
+		with data.severity_ranking as {"MEDIUM": 3}
+
+	result.verdict == "allowed"
+}
+
+test_first_party_block_list_takes_precedence if {
+	result := admission with input as {
+		"target_type": "plugin",
+		"target_name": "defenseclaw",
+		"path": "/tmp/defenseclaw",
+		"block_list": [{"target_type": "plugin", "target_name": "defenseclaw", "reason": "manual block"}],
+		"allow_list": [],
+	}
+		with data.config as {"allow_list_bypass_scan": true, "scan_on_install": true}
+		with data.first_party_allow_list as [
+			{"target_type": "plugin", "target_name": "defenseclaw", "reason": "first-party"},
+		]
+		with data.actions as {}
+		with data.scanner_overrides as {}
+		with data.severity_ranking as {}
+
+	result.verdict == "blocked"
+}
+
+test_production_plugin_medium_warns_not_rejects if {
+	result := admission with input as {
+		"target_type": "plugin",
+		"target_name": "some-plugin",
+		"path": "/tmp/some-plugin",
+		"block_list": [],
+		"allow_list": [],
+		"scan_result": {"max_severity": "MEDIUM", "total_findings": 1, "findings": [
+			{"severity": "MEDIUM", "title": "minor issue", "scanner": "plugin-scanner"},
+		]},
+	}
+
+	result.verdict == "warning"
+}
+
 # --- install_action and file_action output ---
 
 test_install_action_block_on_critical if {

--- a/policies/rego/admission_test.rego
+++ b/policies/rego/admission_test.rego
@@ -99,6 +99,24 @@ test_allowed_no_bypass_falls_through if {
 		with data.config as {"allow_list_bypass_scan": false, "scan_on_install": true}
 		with data.actions as {}
 		with data.scanner_overrides as {}
+		with data.first_party_allow_list as []
+		with data.severity_ranking as {}
+
+	result.verdict == "allowed"
+}
+
+test_policy_allow_no_bypass_falls_through if {
+	result := admission with input as {
+		"target_type": "skill",
+		"target_name": "codeguard",
+		"path": "/tmp/codeguard",
+		"block_list": [],
+		"allow_list": [],
+	}
+		with data.config as {"allow_list_bypass_scan": false, "scan_on_install": true}
+		with data.actions as {}
+		with data.scanner_overrides as {}
+		with data.first_party_allow_list as [{"target_type": "skill", "target_name": "codeguard", "reason": "first-party"}]
 		with data.severity_ranking as {}
 
 	result.verdict == "scan"
@@ -547,7 +565,7 @@ test_production_first_party_plugin_allowed if {
 	result := admission with input as {
 		"target_type": "plugin",
 		"target_name": "defenseclaw",
-		"path": "/tmp/defenseclaw",
+		"path": "/home/user/.openclaw/extensions/defenseclaw",
 		"block_list": [],
 		"allow_list": [],
 	}
@@ -559,7 +577,7 @@ test_production_first_party_skill_allowed if {
 	result := admission with input as {
 		"target_type": "skill",
 		"target_name": "codeguard",
-		"path": "/tmp/codeguard",
+		"path": "/home/user/.defenseclaw/skills/codeguard",
 		"block_list": [],
 		"allow_list": [],
 	}
@@ -606,6 +624,56 @@ test_first_party_block_list_takes_precedence if {
 	result.verdict == "blocked"
 }
 
+test_first_party_bad_provenance_falls_through if {
+	result := admission with input as {
+		"target_type": "plugin",
+		"target_name": "defenseclaw",
+		"path": "/tmp/unrelated/plugin",
+		"block_list": [],
+		"allow_list": [],
+	}
+		with data.config as {"allow_list_bypass_scan": true, "scan_on_install": true}
+		with data.first_party_allow_list as [
+			{"target_type": "plugin", "target_name": "defenseclaw", "reason": "first-party", "source_path_contains": ["defenseclaw", ".defenseclaw"]},
+		]
+		with data.actions as {}
+		with data.scanner_overrides as {}
+		with data.severity_ranking as {}
+
+	result.verdict == "scan"
+}
+
+test_first_party_temp_dir_does_not_match if {
+	result := admission with input as {
+		"target_type": "plugin",
+		"target_name": "defenseclaw",
+		"path": "/tmp/dclaw-plugin-fetch-abc123/defenseclaw",
+		"block_list": [],
+		"allow_list": [],
+	}
+
+	result.verdict == "scan"
+}
+
+test_first_party_no_constraints_allows if {
+	result := admission with input as {
+		"target_type": "plugin",
+		"target_name": "defenseclaw",
+		"path": "/tmp/anything",
+		"block_list": [],
+		"allow_list": [],
+	}
+		with data.config as {"allow_list_bypass_scan": true, "scan_on_install": true}
+		with data.first_party_allow_list as [
+			{"target_type": "plugin", "target_name": "defenseclaw", "reason": "first-party"},
+		]
+		with data.actions as {}
+		with data.scanner_overrides as {}
+		with data.severity_ranking as {}
+
+	result.verdict == "allowed"
+}
+
 test_production_plugin_medium_warns_not_rejects if {
 	result := admission with input as {
 		"target_type": "plugin",
@@ -639,6 +707,24 @@ test_install_action_block_on_critical if {
 
 	result.install_action == "block"
 	result.file_action == "quarantine"
+}
+
+test_install_block_alone_triggers_reject if {
+	result := admission with input as {
+		"target_type": "skill",
+		"target_name": "partial-block-skill",
+		"path": "/tmp/partial",
+		"block_list": [],
+		"allow_list": [],
+		"scan_result": {"max_severity": "HIGH", "total_findings": 1, "findings": []},
+	}
+		with data.config as {"allow_list_bypass_scan": false, "scan_on_install": true}
+		with data.actions as {"HIGH": {"runtime": "allow", "file": "none", "install": "block"}}
+		with data.scanner_overrides as {}
+		with data.severity_ranking as {"HIGH": 4}
+
+	result.verdict == "rejected"
+	result.install_action == "block"
 }
 
 test_install_action_none_on_warning if {

--- a/policies/rego/data.json
+++ b/policies/rego/data.json
@@ -52,12 +52,16 @@
         "install": "block"
       },
       "MEDIUM": {
-        "runtime": "block",
-        "file": "quarantine",
-        "install": "block"
+        "runtime": "allow",
+        "file": "none",
+        "install": "none"
       }
     }
   },
+  "first_party_allow_list": [
+    {"target_type": "plugin", "target_name": "defenseclaw", "reason": "first-party DefenseClaw plugin"},
+    {"target_type": "skill", "target_name": "codeguard", "reason": "first-party DefenseClaw skill"}
+  ],
   "severity_ranking": {
     "CRITICAL": 5,
     "HIGH": 4,

--- a/policies/rego/data.json
+++ b/policies/rego/data.json
@@ -59,8 +59,8 @@
     }
   },
   "first_party_allow_list": [
-    {"target_type": "plugin", "target_name": "defenseclaw", "reason": "first-party DefenseClaw plugin"},
-    {"target_type": "skill", "target_name": "codeguard", "reason": "first-party DefenseClaw skill"}
+    {"target_type": "plugin", "target_name": "defenseclaw", "reason": "first-party DefenseClaw plugin", "source_path_contains": [".defenseclaw", ".openclaw/extensions"]},
+    {"target_type": "skill", "target_name": "codeguard", "reason": "first-party DefenseClaw skill", "source_path_contains": [".defenseclaw", ".openclaw/skills"]}
   ],
   "severity_ranking": {
     "CRITICAL": 5,
@@ -82,8 +82,8 @@
       "HIGH": 3,
       "CRITICAL": 4
     },
-    "block_threshold": 2,
-    "alert_threshold": 1,
+    "block_threshold": 3,
+    "alert_threshold": 2,
     "cisco_trust_level": "full",
     "patterns": {
       "injection": [

--- a/policies/rego/data.json
+++ b/policies/rego/data.json
@@ -59,8 +59,8 @@
     }
   },
   "first_party_allow_list": [
-    {"target_type": "plugin", "target_name": "defenseclaw", "reason": "first-party DefenseClaw plugin", "source_path_contains": [".defenseclaw", ".openclaw/extensions"]},
-    {"target_type": "skill", "target_name": "codeguard", "reason": "first-party DefenseClaw skill", "source_path_contains": [".defenseclaw", ".openclaw/skills"]}
+    {"target_type": "plugin", "target_name": "defenseclaw", "reason": "first-party DefenseClaw plugin", "source_path_contains": [".defenseclaw", "extensions/defenseclaw"]},
+    {"target_type": "skill", "target_name": "codeguard", "reason": "first-party DefenseClaw skill", "source_path_contains": [".defenseclaw", "workspace/skills/codeguard", "skills/codeguard"]}
   ],
   "severity_ranking": {
     "CRITICAL": 5,

--- a/policies/strict.yaml
+++ b/policies/strict.yaml
@@ -53,9 +53,11 @@ first_party_allow_list:
   - target_type: plugin
     target_name: defenseclaw
     reason: first-party DefenseClaw plugin
+    source_path_contains: [".defenseclaw", ".openclaw/extensions"]
   - target_type: skill
     target_name: codeguard
     reason: first-party DefenseClaw skill
+    source_path_contains: [".defenseclaw", ".openclaw/workspace/skills", ".openclaw/skills"]
 
 guardrail:
   block_threshold: 2

--- a/policies/strict.yaml
+++ b/policies/strict.yaml
@@ -45,9 +45,17 @@ scanner_overrides:
       runtime: disable
       install: block
     medium:
-      file: quarantine
-      runtime: disable
-      install: block
+      file: none
+      runtime: enable
+      install: none
+
+first_party_allow_list:
+  - target_type: plugin
+    target_name: defenseclaw
+    reason: first-party DefenseClaw plugin
+  - target_type: skill
+    target_name: codeguard
+    reason: first-party DefenseClaw skill
 
 guardrail:
   block_threshold: 2

--- a/test/unit/api_scan_test.go
+++ b/test/unit/api_scan_test.go
@@ -56,7 +56,7 @@ func TestSkillWatcherConfigDefaults(t *testing.T) {
 	if !cfg.Gateway.Watcher.Skill.Enabled {
 		t.Error("expected skill watcher enabled by default")
 	}
-	if cfg.Gateway.Watcher.Skill.TakeAction {
-		t.Error("expected skill watcher take_action=false by default")
+	if !cfg.Gateway.Watcher.Skill.TakeAction {
+		t.Error("expected skill watcher take_action=true by default")
 	}
 }


### PR DESCRIPTION
## Summary

Centralize admission policy ordering across the Python CLI, Go gateway fallback, and Rego policy engine. Harden the LLM guardrail proxy streaming inspection and tool-call blocking. Fix enforcement state propagation so install-only rejects don't cascade into runtime disables.

**36 files changed, +1833 / -348.  Tests: 923 Python, all Go packages, 83/83 Rego — all green.**

---

### Policy and Admission

- **Centralized admission in `admission.py`** — skills, plugins, MCP, inventory, and AIBOM all use the same ordering: manual block → manual allow → policy-managed allow → scan requirement → post-scan verdict. Seeded defaults match the Go fallback and Rego policy (severity actions, scanner overrides, first-party allow list with provenance paths).
- **Policy loading merges on top of defaults** — `load_admission_policy` now starts from `_default_admission_policy()` and merges data.json/YAML overrides on top, so fallback paths prefer `rego/data.json` and stay in sync with the active policy instead of silently drifting to empty structs.
- **Case-insensitive severity in Rego** — `_effective_action` now wraps lookups with `upper()` so `"critical"`, `"Critical"`, and `"CRITICAL"` all resolve correctly.
- **Provenance-aware first-party rules** — `data.json` and all YAML policy presets now include `source_path_contains` for defenseclaw and codeguard entries, so first-party bypass only fires from real install locations (not temp fetch dirs or name-only matches).
- **`_sync_opa_data` propagates `first_party_allow_list`** — policy sync now writes first-party entries into OPA `data.json` instead of silently dropping them.

### CLI Enforcement and State Handling

- **Allow and unblock re-enable runtime state first** — `skill allow`, `plugin allow`, `skill unblock` now confirm the gateway re-enable succeeded before clearing DB state. If the gateway is unreachable, they preserve `runtime=disable` and report honestly instead of lying in SQLite.
- **Plugin allow resolves real runtime ID** — uses `_plugin_runtime_candidates()` to find the correct runtime/scoped name (e.g. `@openclaw/xai-plugin`) for gateway enable calls.
- **New `defenseclaw mcp unblock`** — mirrors `skill unblock`: removes block/quarantine/disable without adding to allow list. The server goes through normal scanning on next check.
- **MCP admission passes `source_path`** — `mcp set` now passes `cmd` or `url` into `evaluate_admission` for provenance checking.
- **Post-install scans use resolved path** — install flows now pass the resolved install-dir path for provenance, not the raw input string.
- **Late-manual-allow race fixed** — if something becomes allow-listed while a post-install scan is still running, install now honors that and skips warning/enforcement.

### Inventory, AIBOM, and Reporting

- **Inventory uses real source paths and alias candidates** — `_inventory_key_candidates`, `_inventory_source_path`, and `_inventory_policy_name` resolve plugin runtime IDs vs install-dir names and MCP name vs URL scan targets correctly.
- **Per-target-type fallback actions** — `_fallback_actions_for()` returns `cfg.plugin_actions` / `cfg.mcp_actions` / `skill_actions` by type instead of accidentally reusing skill actions for everything.
- **AIBOM enriches before converting** — `cmd_aibom.py` now calls `enrich_with_policy` before `claw_aibom_to_scan_result` so persisted output matches CLI display.
- **Removed duplicate `_build_plugin_*_map` definitions** and dead `post_decision == "allowed"` branches in plugin/skill install flows.
- **Removed unused `_find_skill_in_dir`** helper.

### Gateway, Watcher, Notifications, and Guardrails

- **Fail closed on unparseable tool-call JSON** — `inspectToolCalls` returns `block` / `HIGH` (not `alert` / `MEDIUM`) when tool-call JSON can't be parsed.
- **OTel LLM span closes on mid-stream block** — `EndLLMSpan` is called before the early return so traces don't leak open spans.
- **Notification fallback** — if raw body injection fails, notifications are prepended to `req.Messages` with `RawBody = nil` so the structured-field path takes over.
- **10 MiB cap on buffered tool-call chunks** — prevents unbounded memory growth; fail-closed when exceeded.
- **Every-chunk mid-stream inspection** — content is inspected on every new chunk (not just every 500 bytes) so short harmful streams can't slip through.
- **Upstream cancellation on block** — `streamCancel()` propagates to the LLM provider so blocked streams stop generating.
- **Post-stream OTel span includes tool-call count and block outcome.**
- **Watcher OPA failures fall back through built-in pre-scan gate** — explicit block/allow decisions hold even when Rego evaluation is unavailable.
- **`AdmissionResult` carries `install`/`file`/`runtime` actions end-to-end** — sidecar only calls `DisableSkill`/`DisablePlugin` when the watcher actually requested `runtime=block`, not for install-only rejects.
- **`/enforce/allow` hardened** — normalizes plugin names, retries gateway mutations with bounded timeouts, and only clears runtime-disable after confirmed live re-enable.
- **Removed false-notification path** in router that announced automatic enforcement for dangerous-but-allowed tool calls.
- **Notifications are subject-type aware** — `SecurityNotification` carries `SubjectType` (`Skill` / `Plugin` / `Tool`) and is always queued for multi-session guardrail injection (not just on session-send failure).

### Config, Build, and Ops

- **Align `guardrail.scanner_mode` default to `both`** in Go config to match the Python CLI.
- **Async Splunk lifecycle flushes** — `watch-start` / `shutdown` flushes run in a goroutine so startup/shutdown paths don't block on HEC.
- **Move CLI symlink creation** from `make pycli` to `make install` so building the venv no longer mutates install state.

### Test Coverage

- `TestInspectToolCallsMalformedJSONBlocks`, `TestInspectToolCallsNilReturnsNil` — fail-closed tool-call parse behavior
- `TestStreamBlockEndsLLMSpan` — OTel span closure on mid-stream block
- `TestNotificationInjectFallbackOnBadRawBody` — notification fallback on corrupt raw body
- `TestBufferedToolCallChunksCapped` — 10 MiB buffered tool-call cap
- Strengthened `TestStreamingToolCallBlockEnforcement` — asserts blocked content is absent, block message present
- `TestMCPUnblock` (4 tests) — unblock clears state, no-op when clean, does not add to allow list, logs action
- `TestSyncOpaDataFirstParty` — first_party_allow_list sync with provenance
- `test_lowercase_severity_still_rejects`, `test_mixed_case_severity_still_rejects` — Rego severity normalization
- `test_high_severity_has_runtime_block`, `test_install_only_block_has_runtime_allow`, `test_no_scan_has_runtime_allow` — runtime_action outputs
- `TestPolicyEngineAllowPartialCleanupError` corrected, `TestPolicyEngineAllowCleansUpEnforcement` added
- Fixed temp dir leak in `test_admission.py` tearDown

## Test Plan

- [x] `make test` — all Go packages pass
- [x] `pytest cli/tests/` — 923 passed
- [x] `make rego-test` — 83/83 passed
- [x] `defenseclaw mcp unblock` clears state, doesn't add to allow list
- [x] `defenseclaw skill allow` with unreachable gateway warns about runtime disable
- [x] Policy sync writes `first_party_allow_list` into `data.json`