### PR TITLE
feat: add verified publisher and skill signing with Ed25519

### DIFF
--- a/cli/defenseclaw/commands/cmd_sign.py
+++ b/cli/defenseclaw/commands/cmd_sign.py
@@ -1,0 +1,266 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""defenseclaw sign / trust — Cryptographic signing and trust management.
+
+Commands for generating Ed25519 signing keys, signing skill/MCP/plugin
+directories, verifying signatures, and managing the trusted publisher store.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+import click
+
+from defenseclaw.context import AppContext, pass_ctx
+
+
+def _sidecar_url(ctx: AppContext) -> str:
+    if ctx.cfg:
+        host = getattr(ctx.cfg, "gateway", None)
+        if host and getattr(host, "bind_addr", None):
+            return f"http://{host.bind_addr}"
+    return "http://127.0.0.1:18970"
+
+
+_API_HEADERS = {"X-DefenseClaw-Client": "cli", "Content-Type": "application/json"}
+
+
+# ──────────────────────────────────────────────────────────────────────
+# sign group
+# ──────────────────────────────────────────────────────────────────────
+
+
+@click.group()
+def sign() -> None:
+    """Sign skills, MCPs, or plugins with an Ed25519 key."""
+
+
+@sign.command("keygen")
+@click.option("--output", "-o", default=".", help="Directory to write keypair files")
+def sign_keygen(output: str) -> None:
+    """Generate an Ed25519 signing keypair."""
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        from cryptography.hazmat.primitives.serialization import (
+            Encoding,
+            NoEncryption,
+            PrivateFormat,
+            PublicFormat,
+        )
+    except ImportError:
+        click.echo("Error: 'cryptography' package required. Install with: pip install cryptography", err=True)
+        sys.exit(1)
+
+    private_key = Ed25519PrivateKey.generate()
+    priv_bytes = private_key.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
+    pub_bytes = private_key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+    os.makedirs(output, exist_ok=True)
+    priv_path = os.path.join(output, "publisher.key")
+    pub_path = os.path.join(output, "publisher.pub")
+
+    with open(priv_path, "w") as f:
+        f.write(priv_bytes.hex() + pub_bytes.hex() + "\n")
+    os.chmod(priv_path, 0o600)
+    with open(pub_path, "w") as f:
+        f.write(pub_bytes.hex() + "\n")
+
+    fp = hashlib.sha256(pub_bytes).hexdigest()
+    click.echo("Keypair generated:")
+    click.echo(f"  Private key: {priv_path}")
+    click.echo(f"  Public key:  {pub_path}")
+    click.echo(f"  Fingerprint: {fp}")
+
+
+@sign.command("skill")
+@click.argument("path")
+@click.option("--key", required=True, help="Path to Ed25519 private key file")
+@click.option("--publisher", required=True, help="Publisher name")
+@pass_ctx
+def sign_skill(ctx: AppContext, path: str, key: str, publisher: str) -> None:
+    """Sign a skill directory with an Ed25519 private key."""
+    import requests
+
+    base = _sidecar_url(ctx)
+    try:
+        resp = requests.post(
+            f"{base}/api/v1/verify",
+            json={"target_type": "skill", "target_name": os.path.basename(path), "path": path},
+            headers=_API_HEADERS,
+            timeout=5,
+        )
+        if resp.ok:
+            click.echo("Verified via sidecar API")
+            result = resp.json()
+            click.echo(f"  Signed:   {result.get('signed', False)}")
+            click.echo(f"  Verified: {result.get('verified', False)}")
+            click.echo(f"  Reason:   {result.get('reason', '')}")
+            return
+    except Exception:
+        pass
+
+    click.echo("Note: sidecar not reachable; use the Go gateway CLI for local signing", err=True)
+    click.echo(f"  defenseclaw-gateway sign skill {path} --key {key} --publisher {publisher}", err=True)
+
+
+@sign.command("verify")
+@click.argument("path")
+@click.option("--json-output", "as_json", is_flag=True, help="Output as JSON")
+@pass_ctx
+def sign_verify(ctx: AppContext, path: str, as_json: bool) -> None:
+    """Verify the signature of a skill, MCP, or plugin directory."""
+    import requests
+
+    base = _sidecar_url(ctx)
+    try:
+        resp = requests.post(
+            f"{base}/api/v1/verify",
+            json={"target_type": "skill", "target_name": os.path.basename(path), "path": path},
+            headers=_API_HEADERS,
+            timeout=5,
+        )
+        if resp.ok:
+            result = resp.json()
+            if as_json:
+                click.echo(json.dumps(result, indent=2))
+            else:
+                verified = result.get("verified", False)
+                signed = result.get("signed", False)
+                if verified:
+                    click.secho("VERIFIED", fg="green", bold=True)
+                elif signed:
+                    click.secho("SIGNED (not trusted)", fg="yellow")
+                else:
+                    click.secho("UNSIGNED", fg="red")
+                click.echo(f"  Publisher:   {result.get('publisher', '')}")
+                click.echo(f"  Fingerprint: {result.get('fingerprint', '')}")
+                click.echo(f"  Reason:      {result.get('reason', '')}")
+
+            if ctx.store:
+                ctx.store.set_signature_status(
+                    "skill",
+                    os.path.basename(path),
+                    result.get("publisher", ""),
+                    result.get("fingerprint", ""),
+                    result.get("verified", False),
+                    "",
+                    result.get("reason", ""),
+                )
+            return
+    except Exception as exc:
+        click.echo(f"Error contacting sidecar: {exc}", err=True)
+        sys.exit(1)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# trust group
+# ──────────────────────────────────────────────────────────────────────
+
+
+@click.group()
+def trust() -> None:
+    """Manage the trusted publisher store."""
+
+
+@trust.command("add")
+@click.option("--name", required=True, help="Publisher name")
+@click.option("--key", required=True, help="Path to Ed25519 public key file")
+@pass_ctx
+def trust_add(ctx: AppContext, name: str, key: str) -> None:
+    """Add a publisher public key to the trust store."""
+    import requests
+
+    pub_hex = Path(key).read_text().strip()
+    base = _sidecar_url(ctx)
+    try:
+        resp = requests.post(
+            f"{base}/api/v1/trust",
+            json={"name": name, "public_key": pub_hex},
+            headers=_API_HEADERS,
+            timeout=5,
+        )
+        if resp.ok:
+            result = resp.json()
+            click.echo("Added trusted publisher:")
+            click.echo(f"  Name:        {result.get('name', name)}")
+            click.echo(f"  Fingerprint: {result.get('fingerprint', '')}")
+        else:
+            click.echo(f"Error: {resp.json().get('error', resp.text)}", err=True)
+            sys.exit(1)
+    except Exception as exc:
+        click.echo(f"Error contacting sidecar: {exc}", err=True)
+        sys.exit(1)
+
+
+@trust.command("list")
+@click.option("--json-output", "as_json", is_flag=True, help="Output as JSON")
+@pass_ctx
+def trust_list(ctx: AppContext, as_json: bool) -> None:
+    """List trusted publishers."""
+    import requests
+
+    base = _sidecar_url(ctx)
+    try:
+        resp = requests.get(f"{base}/api/v1/trust", timeout=5)
+        if resp.ok:
+            publishers = resp.json()
+            if as_json:
+                click.echo(json.dumps(publishers, indent=2))
+            elif not publishers:
+                click.echo("No trusted publishers.")
+            else:
+                click.echo(f"{'NAME':<20} {'FINGERPRINT':<20} {'ADDED'}")
+                for p in publishers:
+                    fp = p.get("fingerprint", "")
+                    if len(fp) > 16:
+                        fp = fp[:16] + "..."
+                    click.echo(f"{p.get('name', ''):<20} {fp:<20} {p.get('added_at', '')}")
+        else:
+            click.echo(f"Error: {resp.text}", err=True)
+    except Exception as exc:
+        click.echo(f"Error contacting sidecar: {exc}", err=True)
+        sys.exit(1)
+
+
+@trust.command("remove")
+@click.option("--fingerprint", required=True, help="Publisher fingerprint to remove")
+@pass_ctx
+def trust_remove(ctx: AppContext, fingerprint: str) -> None:
+    """Remove a publisher from the trust store by fingerprint."""
+    import requests
+
+    base = _sidecar_url(ctx)
+    try:
+        resp = requests.delete(
+            f"{base}/api/v1/trust",
+            params={"fingerprint": fingerprint},
+            headers=_API_HEADERS,
+            timeout=5,
+        )
+        if resp.ok:
+            click.echo(f"Removed publisher with fingerprint: {fingerprint}")
+        else:
+            click.echo(f"Error: {resp.json().get('error', resp.text)}", err=True)
+            sys.exit(1)
+    except Exception as exc:
+        click.echo(f"Error contacting sidecar: {exc}", err=True)
+        sys.exit(1)

--- a/cli/defenseclaw/db.py
+++ b/cli/defenseclaw/db.py
@@ -29,7 +29,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from defenseclaw.models import ActionEntry, ActionState, Counts, Event
+from defenseclaw.models import ActionEntry, ActionState, Counts, Event, SignatureEntry
 
 SCHEMA = """\
 CREATE TABLE IF NOT EXISTS audit_events (
@@ -84,6 +84,21 @@ CREATE INDEX IF NOT EXISTS idx_scan_scanner ON scan_results(scanner);
 CREATE INDEX IF NOT EXISTS idx_finding_severity ON findings(severity);
 CREATE INDEX IF NOT EXISTS idx_finding_scan ON findings(scan_id);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_actions_type_name ON actions(target_type, target_name);
+
+CREATE TABLE IF NOT EXISTS signatures (
+    id TEXT PRIMARY KEY,
+    target_type TEXT NOT NULL,
+    target_name TEXT NOT NULL,
+    publisher TEXT NOT NULL,
+    fingerprint TEXT NOT NULL,
+    verified INTEGER NOT NULL DEFAULT 0,
+    verified_at DATETIME,
+    content_hash TEXT,
+    reason TEXT,
+    UNIQUE(target_type, target_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_signatures_target ON signatures(target_type, target_name);
 """
 
 _VALID_FIELDS: dict[str, set[str]] = {
@@ -117,13 +132,9 @@ class Store:
     # -- Old list migration (matches Go migrateOldLists) --
 
     def _migrate_old_lists(self) -> None:
-        cur = self.db.execute(
-            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='block_list'"
-        )
+        cur = self.db.execute("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='block_list'")
         block_exists = cur.fetchone()[0] > 0
-        cur = self.db.execute(
-            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='allow_list'"
-        )
+        cur = self.db.execute("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='allow_list'")
         allow_exists = cur.fetchone()[0] > 0
 
         if not block_exists and not allow_exists:
@@ -149,10 +160,7 @@ class Store:
 
     def _ensure_run_id_columns(self) -> None:
         for table in ("audit_events", "scan_results"):
-            columns = {
-                row[1]
-                for row in self.db.execute(f"PRAGMA table_info({table})").fetchall()
-            }
+            columns = {row[1] for row in self.db.execute(f"PRAGMA table_info({table})").fetchall()}
             if "run_id" in columns:
                 continue
             self.db.execute(f"ALTER TABLE {table} ADD COLUMN run_id TEXT")
@@ -174,9 +182,16 @@ class Store:
         self.db.execute(
             """INSERT INTO audit_events (id, timestamp, action, target, actor, details, severity, run_id)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-            (event.id, event.timestamp.isoformat(), event.action,
-             event.target or None, event.actor, event.details or None,
-             event.severity or None, event.run_id or None),
+            (
+                event.id,
+                event.timestamp.isoformat(),
+                event.action,
+                event.target or None,
+                event.actor,
+                event.details or None,
+                event.severity or None,
+                event.run_id or None,
+            ),
         )
         self.db.commit()
 
@@ -202,31 +217,52 @@ class Store:
     # -- Scan results --
 
     def insert_scan_result(
-        self, scan_id: str, scanner: str, target: str,
-        ts: datetime, duration_ms: int, finding_count: int,
-        max_severity: str, raw_json: str,
+        self,
+        scan_id: str,
+        scanner: str,
+        target: str,
+        ts: datetime,
+        duration_ms: int,
+        finding_count: int,
+        max_severity: str,
+        raw_json: str,
     ) -> None:
         run_id = _current_run_id()
         self.db.execute(
             """INSERT INTO scan_results
                (id, scanner, target, timestamp, duration_ms, finding_count, max_severity, raw_json, run_id)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (scan_id, scanner, target, ts.isoformat(), duration_ms,
-             finding_count, max_severity, raw_json, run_id or None),
+            (
+                scan_id,
+                scanner,
+                target,
+                ts.isoformat(),
+                duration_ms,
+                finding_count,
+                max_severity,
+                raw_json,
+                run_id or None,
+            ),
         )
         self.db.commit()
 
     def insert_finding(
-        self, finding_id: str, scan_id: str, severity: str,
-        title: str, description: str, location: str,
-        remediation: str, scanner: str, tags: str,
+        self,
+        finding_id: str,
+        scan_id: str,
+        severity: str,
+        title: str,
+        description: str,
+        location: str,
+        remediation: str,
+        scanner: str,
+        tags: str,
     ) -> None:
         self.db.execute(
             """INSERT INTO findings
                (id, scan_id, severity, title, description, location, remediation, scanner, tags)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (finding_id, scan_id, severity, title, description,
-             location, remediation, scanner, tags),
+            (finding_id, scan_id, severity, title, description, location, remediation, scanner, tags),
         )
         self.db.commit()
 
@@ -253,18 +289,22 @@ class Store:
         )
         results: list[dict[str, Any]] = []
         for row in cur.fetchall():
-            results.append({
-                "id": row[0],
-                "target": row[1],
-                "timestamp": _parse_ts(row[2]),
-                "finding_count": row[3] or 0,
-                "max_severity": row[4] or "INFO",
-                "raw_json": row[5] or "",
-            })
+            results.append(
+                {
+                    "id": row[0],
+                    "target": row[1],
+                    "timestamp": _parse_ts(row[2]),
+                    "finding_count": row[3] or 0,
+                    "max_severity": row[4] or "INFO",
+                    "raw_json": row[5] or "",
+                }
+            )
         return results
 
     def get_severity_counts_for_target(
-        self, target: str, scanner: str,
+        self,
+        target: str,
+        scanner: str,
     ) -> dict[str, int]:
         """Return {severity: count} from the most recent scan for target+scanner."""
         cur = self.db.execute(
@@ -282,7 +322,9 @@ class Store:
         return {row[0]: row[1] for row in cur.fetchall()}
 
     def get_findings_for_target(
-        self, target: str, scanner: str,
+        self,
+        target: str,
+        scanner: str,
     ) -> list[dict[str, Any]]:
         """Return findings from the most recent scan for target+scanner."""
         cur = self.db.execute(
@@ -299,16 +341,17 @@ class Store:
                    WHEN 'MEDIUM' THEN 3 WHEN 'LOW' THEN 4 ELSE 5 END""",
             (target, scanner),
         )
-        return [
-            {"severity": r[0], "title": r[1], "location": r[2] or ""}
-            for r in cur.fetchall()
-        ]
+        return [{"severity": r[0], "title": r[1], "location": r[2] or ""} for r in cur.fetchall()]
 
     # -- Actions --
 
     def set_action(
-        self, target_type: str, target_name: str,
-        source_path: str, state: ActionState, reason: str,
+        self,
+        target_type: str,
+        target_name: str,
+        source_path: str,
+        state: ActionState,
+        reason: str,
     ) -> None:
         actions_json = json.dumps(state.to_dict())
         aid = str(uuid.uuid4())
@@ -321,14 +364,17 @@ class Store:
                  reason = excluded.reason,
                  updated_at = excluded.updated_at,
                  source_path = COALESCE(excluded.source_path, source_path)""",
-            (aid, target_type, target_name, source_path or None,
-             actions_json, reason, now),
+            (aid, target_type, target_name, source_path or None, actions_json, reason, now),
         )
         self.db.commit()
 
     def set_action_field(
-        self, target_type: str, target_name: str,
-        field: str, value: str, reason: str,
+        self,
+        target_type: str,
+        target_name: str,
+        field: str,
+        value: str,
+        reason: str,
     ) -> None:
         _validate(field, value)
         aid = str(uuid.uuid4())
@@ -408,7 +454,10 @@ class Store:
         return [self._row_to_action(r) for r in cur.fetchall()]
 
     def list_by_action_and_type(
-        self, field: str, value: str, target_type: str,
+        self,
+        field: str,
+        value: str,
+        target_type: str,
     ) -> list[ActionEntry]:
         _validate(field, value)
         cur = self.db.execute(
@@ -445,9 +494,7 @@ class Store:
             allowed_skills=_count(q_skill + "'allow'"),
             blocked_mcps=_count(q_mcp + "'block'"),
             allowed_mcps=_count(q_mcp + "'allow'"),
-            alerts=_count(
-                "SELECT COUNT(*) FROM audit_events WHERE severity IN ('CRITICAL','HIGH','MEDIUM','LOW')"
-            ),
+            alerts=_count("SELECT COUNT(*) FROM audit_events WHERE severity IN ('CRITICAL','HIGH','MEDIUM','LOW')"),
             total_scans=_count("SELECT COUNT(*) FROM scan_results"),
         )
 
@@ -464,6 +511,72 @@ class Store:
             details=row[5] or "",
             severity=row[6] or "",
             run_id=row[7] or "",
+        )
+
+    # --- Signature status ---
+
+    def set_signature_status(
+        self,
+        target_type: str,
+        target_name: str,
+        publisher: str,
+        fingerprint: str,
+        verified: bool,
+        content_hash: str,
+        reason: str,
+    ) -> None:
+        sid = str(uuid.uuid4())
+        now = datetime.now(timezone.utc).isoformat()
+        cols = "id, target_type, target_name, publisher, fingerprint, verified, verified_at, content_hash, reason"
+        self.db.execute(
+            f"""INSERT INTO signatures ({cols})
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(target_type, target_name) DO UPDATE SET
+                publisher = excluded.publisher,
+                fingerprint = excluded.fingerprint,
+                verified = excluded.verified,
+                verified_at = excluded.verified_at,
+                content_hash = excluded.content_hash,
+                reason = excluded.reason""",
+            (sid, target_type, target_name, publisher, fingerprint, int(verified), now, content_hash, reason),
+        )
+        self.db.commit()
+
+    _SIG_COLS = "id, target_type, target_name, publisher, fingerprint, verified, verified_at, content_hash, reason"
+
+    def get_signature_status(self, target_type: str, target_name: str) -> SignatureEntry | None:
+        row = self.db.execute(
+            f"SELECT {self._SIG_COLS} FROM signatures WHERE target_type = ? AND target_name = ?",
+            (target_type, target_name),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_signature(row)
+
+    def list_signatures(self, target_type: str = "") -> list[SignatureEntry]:
+        if target_type:
+            rows = self.db.execute(
+                f"SELECT {self._SIG_COLS} FROM signatures WHERE target_type = ? ORDER BY verified_at DESC",
+                (target_type,),
+            ).fetchall()
+        else:
+            rows = self.db.execute(
+                f"SELECT {self._SIG_COLS} FROM signatures ORDER BY verified_at DESC",
+            ).fetchall()
+        return [self._row_to_signature(r) for r in rows]
+
+    @staticmethod
+    def _row_to_signature(row: tuple[Any, ...]) -> SignatureEntry:
+        return SignatureEntry(
+            id=row[0],
+            target_type=row[1],
+            target_name=row[2],
+            publisher=row[3] or "",
+            fingerprint=row[4] or "",
+            verified=bool(row[5]),
+            verified_at=_parse_ts(row[6]),
+            content_hash=row[7] or "",
+            reason=row[8] or "",
         )
 
     @staticmethod

--- a/cli/defenseclaw/main.py
+++ b/cli/defenseclaw/main.py
@@ -37,6 +37,7 @@ from defenseclaw.commands.cmd_plugin import plugin
 from defenseclaw.commands.cmd_policy import policy
 from defenseclaw.commands.cmd_sandbox import sandbox
 from defenseclaw.commands.cmd_setup import setup
+from defenseclaw.commands.cmd_sign import sign, trust
 from defenseclaw.commands.cmd_skill import skill
 from defenseclaw.commands.cmd_status import status
 from defenseclaw.commands.cmd_tool import tool
@@ -118,6 +119,8 @@ cli.add_command(alerts)
 cli.add_command(codeguard)
 cli.add_command(tool)
 cli.add_command(doctor)
+cli.add_command(sign)
+cli.add_command(trust)
 cli.add_command(sandbox)
 
 

--- a/cli/defenseclaw/models.py
+++ b/cli/defenseclaw/models.py
@@ -79,13 +79,16 @@ class ScanResult:
         return len(self.findings) == 0
 
     def to_json(self) -> str:
-        return json.dumps({
-            "scanner": self.scanner,
-            "target": self.target,
-            "timestamp": self.timestamp.isoformat(),
-            "findings": [f.to_dict() for f in self.findings],
-            "duration_ms": int(self.duration.total_seconds() * 1000),
-        }, indent=2)
+        return json.dumps(
+            {
+                "scanner": self.scanner,
+                "target": self.target,
+                "timestamp": self.timestamp.isoformat(),
+                "findings": [f.to_dict() for f in self.findings],
+                "duration_ms": int(self.duration.total_seconds() * 1000),
+            },
+            indent=2,
+        )
 
 
 def compare_severity(a: str, b: str) -> int:
@@ -93,6 +96,7 @@ def compare_severity(a: str, b: str) -> int:
 
 
 # --- Audit / enforcement models ---
+
 
 @dataclass
 class ActionState:
@@ -167,3 +171,16 @@ class Counts:
     allowed_mcps: int = 0
     alerts: int = 0
     total_scans: int = 0
+
+
+@dataclass
+class SignatureEntry:
+    id: str
+    target_type: str
+    target_name: str
+    publisher: str = ""
+    fingerprint: str = ""
+    verified: bool = False
+    verified_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    content_hash: str = ""
+    reason: str = ""

--- a/extensions/defenseclaw/src/index.ts
+++ b/extensions/defenseclaw/src/index.ts
@@ -177,6 +177,71 @@ export default function (api: PluginApi) {
     },
   });
 
+  // ─── Slash command: /verify ───
+
+  api.registerCommand({
+    name: "verify",
+    description: "Verify the cryptographic signature of a skill, MCP, or plugin directory",
+    args: [
+      { name: "path", description: "Path to skill/MCP/plugin directory", required: true },
+      { name: "type", description: "Target type: skill (default), mcp, plugin", required: false },
+    ],
+    handler: async ({ args }) => {
+      const targetPath = args.path as string | undefined;
+      if (!targetPath) {
+        return { text: "Usage: /verify <path> [skill|mcp|plugin]" };
+      }
+      const targetType = (args.type ?? "skill") as string;
+      const targetName = targetPath.split("/").pop() ?? targetPath;
+
+      try {
+        const headers: Record<string, string> = {
+          "Content-Type": "application/json",
+          "X-DefenseClaw-Client": "openclaw-plugin",
+        };
+        if (SIDECAR_TOKEN) {
+          headers["Authorization"] = `Bearer ${SIDECAR_TOKEN}`;
+        }
+        const res = await fetch(`${SIDECAR_API}/api/v1/verify`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            target_type: targetType,
+            target_name: targetName,
+            path: targetPath,
+          }),
+        });
+        const result = (await res.json()) as {
+          verified: boolean;
+          signed: boolean;
+          trusted: boolean;
+          publisher?: string;
+          fingerprint?: string;
+          reason: string;
+        };
+
+        const badge = result.verified
+          ? "VERIFIED"
+          : result.signed
+            ? "SIGNED (not trusted)"
+            : "UNSIGNED";
+
+        const lines = [
+          `**DefenseClaw Signature Verification: ${targetPath}**\n`,
+          `Status: **${badge}**`,
+          `Publisher: ${result.publisher ?? "—"}`,
+          `Fingerprint: \`${result.fingerprint ?? "—"}\``,
+          `Reason: ${result.reason}`,
+        ];
+        return { text: lines.join("\n") };
+      } catch (err) {
+        return {
+          text: `Verification failed: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    },
+  });
+
   // ─── Slash command: /block ───
 
   api.registerCommand({

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -154,6 +154,21 @@ func (s *Store) Init() error {
 	CREATE INDEX IF NOT EXISTS idx_finding_severity ON findings(severity);
 	CREATE INDEX IF NOT EXISTS idx_finding_scan ON findings(scan_id);
 	CREATE UNIQUE INDEX IF NOT EXISTS idx_actions_type_name ON actions(target_type, target_name);
+
+	CREATE TABLE IF NOT EXISTS signatures (
+		id TEXT PRIMARY KEY,
+		target_type TEXT NOT NULL,
+		target_name TEXT NOT NULL,
+		publisher TEXT NOT NULL,
+		fingerprint TEXT NOT NULL,
+		verified INTEGER NOT NULL DEFAULT 0,
+		verified_at DATETIME,
+		content_hash TEXT,
+		reason TEXT,
+		UNIQUE(target_type, target_name)
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_signatures_target ON signatures(target_type, target_name);
 	`
 
 	if _, err := s.db.Exec(schema); err != nil {
@@ -764,6 +779,144 @@ func (s *Store) LatestScansByScanner(scannerName string) ([]LatestScanInfo, erro
 		r.MaxSeverity = maxSev.String
 		r.RawJSON = rawJSON.String
 		results = append(results, r)
+	}
+	return results, rows.Err()
+}
+
+// --- Signature status ---
+
+type SignatureEntry struct {
+	ID          string    `json:"id"`
+	TargetType  string    `json:"target_type"`
+	TargetName  string    `json:"target_name"`
+	Publisher   string    `json:"publisher"`
+	Fingerprint string    `json:"fingerprint"`
+	Verified    bool      `json:"verified"`
+	VerifiedAt  time.Time `json:"verified_at"`
+	ContentHash string    `json:"content_hash"`
+	Reason      string    `json:"reason"`
+}
+
+func (s *Store) SetSignatureStatus(targetType, targetName, publisher, fingerprint string, verified bool, contentHash, reason string) error {
+	id := uuid.New().String()
+	now := time.Now().UTC()
+	v := 0
+	if verified {
+		v = 1
+	}
+	_, err := s.db.Exec(`
+		INSERT INTO signatures (id, target_type, target_name, publisher, fingerprint, verified, verified_at, content_hash, reason)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(target_type, target_name) DO UPDATE SET
+			publisher = excluded.publisher,
+			fingerprint = excluded.fingerprint,
+			verified = excluded.verified,
+			verified_at = excluded.verified_at,
+			content_hash = excluded.content_hash,
+			reason = excluded.reason`,
+		id, targetType, targetName, publisher, fingerprint, v, now, contentHash, reason,
+	)
+	if err != nil {
+		return fmt.Errorf("audit: set signature status: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetSignatureStatus(targetType, targetName string) (*SignatureEntry, error) {
+	row := s.db.QueryRow(`
+		SELECT id, target_type, target_name, publisher, fingerprint, verified, verified_at, content_hash, reason
+		FROM signatures WHERE target_type = ? AND target_name = ?`,
+		targetType, targetName,
+	)
+
+	var e SignatureEntry
+	var v int
+	var verAt sql.NullString
+	var cHash, reason sql.NullString
+	err := row.Scan(&e.ID, &e.TargetType, &e.TargetName, &e.Publisher, &e.Fingerprint, &v, &verAt, &cHash, &reason)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("audit: get signature status: %w", err)
+	}
+	e.Verified = v != 0
+	if verAt.Valid {
+		e.VerifiedAt, _ = time.Parse(time.RFC3339Nano, verAt.String)
+	}
+	e.ContentHash = cHash.String
+	e.Reason = reason.String
+	return &e, nil
+}
+
+func (s *Store) ListVerified(targetType string) ([]SignatureEntry, error) {
+	query := `SELECT id, target_type, target_name, publisher, fingerprint, verified, verified_at, content_hash, reason
+		FROM signatures WHERE verified = 1`
+	args := []any{}
+	if targetType != "" {
+		query += ` AND target_type = ?`
+		args = append(args, targetType)
+	}
+	query += ` ORDER BY verified_at DESC`
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("audit: list verified: %w", err)
+	}
+	defer rows.Close()
+
+	var results []SignatureEntry
+	for rows.Next() {
+		var e SignatureEntry
+		var v int
+		var verAt sql.NullString
+		var cHash, reason sql.NullString
+		if err := rows.Scan(&e.ID, &e.TargetType, &e.TargetName, &e.Publisher, &e.Fingerprint, &v, &verAt, &cHash, &reason); err != nil {
+			return nil, fmt.Errorf("audit: scan signature row: %w", err)
+		}
+		e.Verified = v != 0
+		if verAt.Valid {
+			e.VerifiedAt, _ = time.Parse(time.RFC3339Nano, verAt.String)
+		}
+		e.ContentHash = cHash.String
+		e.Reason = reason.String
+		results = append(results, e)
+	}
+	return results, rows.Err()
+}
+
+func (s *Store) ListSignatures(targetType string) ([]SignatureEntry, error) {
+	query := `SELECT id, target_type, target_name, publisher, fingerprint, verified, verified_at, content_hash, reason
+		FROM signatures`
+	args := []any{}
+	if targetType != "" {
+		query += ` WHERE target_type = ?`
+		args = append(args, targetType)
+	}
+	query += ` ORDER BY verified_at DESC`
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("audit: list signatures: %w", err)
+	}
+	defer rows.Close()
+
+	var results []SignatureEntry
+	for rows.Next() {
+		var e SignatureEntry
+		var v int
+		var verAt sql.NullString
+		var cHash, reason sql.NullString
+		if err := rows.Scan(&e.ID, &e.TargetType, &e.TargetName, &e.Publisher, &e.Fingerprint, &v, &verAt, &cHash, &reason); err != nil {
+			return nil, fmt.Errorf("audit: scan signature row: %w", err)
+		}
+		e.Verified = v != 0
+		if verAt.Valid {
+			e.VerifiedAt, _ = time.Parse(time.RFC3339Nano, verAt.String)
+		}
+		e.ContentHash = cHash.String
+		e.Reason = reason.String
+		results = append(results, e)
 	}
 	return results, rows.Err()
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -68,6 +68,9 @@ Run without arguments to start the sidecar daemon.`,
 		if err != nil {
 			return fmt.Errorf("failed to open audit store: %w", err)
 		}
+		if err := auditStore.Init(); err != nil {
+			return fmt.Errorf("failed to init audit store: %w", err)
+		}
 
 		auditLog = audit.NewLogger(auditStore)
 		loadDotEnvIntoOS(filepath.Join(cfg.DataDir, ".env"))

--- a/internal/cli/sign.go
+++ b/internal/cli/sign.go
@@ -1,0 +1,328 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/defenseclaw/defenseclaw/internal/signing"
+)
+
+var (
+	signKeyFile    string
+	signPublisher  string
+	signOutputDir  string
+	trustKeyFile   string
+	trustName      string
+	trustFP        string
+	signOutputJSON bool
+)
+
+var signCmd = &cobra.Command{
+	Use:   "sign",
+	Short: "Sign skills, MCPs, or plugins with an Ed25519 key",
+	Long:  "Cryptographically sign DefenseClaw assets to establish publisher trust.",
+}
+
+var signKeygenCmd = &cobra.Command{
+	Use:   "keygen",
+	Short: "Generate an Ed25519 signing keypair",
+	Long: `Generate a new Ed25519 keypair for signing skills, MCPs, and plugins.
+
+Writes publisher.key (private) and publisher.pub (public) to the output directory.
+Keep the private key secret. Distribute the public key to operators who need to
+verify your signatures.`,
+	RunE: runSignKeygen,
+}
+
+var signSkillCmd = &cobra.Command{
+	Use:   "skill <path>",
+	Short: "Sign a skill directory",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSignSkill,
+}
+
+var signVerifyCmd = &cobra.Command{
+	Use:   "verify <path>",
+	Short: "Verify the signature of a skill, MCP, or plugin directory",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSignVerify,
+}
+
+var trustCmd = &cobra.Command{
+	Use:   "trust",
+	Short: "Manage the trusted publisher store",
+	Long:  "Add, list, or remove trusted publisher public keys.",
+}
+
+var trustAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a publisher public key to the trust store",
+	RunE:  runTrustAdd,
+}
+
+var trustListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List trusted publishers",
+	RunE:  runTrustList,
+}
+
+var trustRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove a publisher from the trust store by fingerprint",
+	RunE:  runTrustRemove,
+}
+
+func init() {
+	signKeygenCmd.Flags().StringVar(&signOutputDir, "output", ".", "Directory to write keypair files")
+	signSkillCmd.Flags().StringVar(&signKeyFile, "key", "", "Path to Ed25519 private key file")
+	signSkillCmd.Flags().StringVar(&signPublisher, "publisher", "", "Publisher name")
+	_ = signSkillCmd.MarkFlagRequired("key")
+	_ = signSkillCmd.MarkFlagRequired("publisher")
+	signVerifyCmd.Flags().BoolVar(&signOutputJSON, "json", false, "Output result as JSON")
+
+	signCmd.AddCommand(signKeygenCmd)
+	signCmd.AddCommand(signSkillCmd)
+	signCmd.AddCommand(signVerifyCmd)
+	rootCmd.AddCommand(signCmd)
+
+	trustAddCmd.Flags().StringVar(&trustName, "name", "", "Publisher name")
+	trustAddCmd.Flags().StringVar(&trustKeyFile, "key", "", "Path to Ed25519 public key file")
+	_ = trustAddCmd.MarkFlagRequired("name")
+	_ = trustAddCmd.MarkFlagRequired("key")
+	trustRemoveCmd.Flags().StringVar(&trustFP, "fingerprint", "", "Publisher fingerprint to remove")
+	_ = trustRemoveCmd.MarkFlagRequired("fingerprint")
+	trustListCmd.Flags().BoolVar(&signOutputJSON, "json", false, "Output as JSON")
+
+	trustCmd.AddCommand(trustAddCmd)
+	trustCmd.AddCommand(trustListCmd)
+	trustCmd.AddCommand(trustRemoveCmd)
+	rootCmd.AddCommand(trustCmd)
+}
+
+func runSignKeygen(_ *cobra.Command, _ []string) error {
+	pub, priv, err := signing.GenerateKeyPair()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(signOutputDir, 0755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+
+	privPath := filepath.Join(signOutputDir, "publisher.key")
+	pubPath := filepath.Join(signOutputDir, "publisher.pub")
+
+	if err := os.WriteFile(privPath, []byte(hex.EncodeToString(priv)+"\n"), 0600); err != nil {
+		return fmt.Errorf("write private key: %w", err)
+	}
+	if err := os.WriteFile(pubPath, []byte(hex.EncodeToString(pub)+"\n"), 0644); err != nil {
+		return fmt.Errorf("write public key: %w", err)
+	}
+
+	fp := signing.Fingerprint(pub)
+	fmt.Fprintf(os.Stderr, "Keypair generated:\n")
+	fmt.Fprintf(os.Stderr, "  Private key: %s\n", privPath)
+	fmt.Fprintf(os.Stderr, "  Public key:  %s\n", pubPath)
+	fmt.Fprintf(os.Stderr, "  Fingerprint: %s\n", fp)
+	return nil
+}
+
+func runSignSkill(_ *cobra.Command, args []string) error {
+	dirPath := args[0]
+
+	keyData, err := os.ReadFile(signKeyFile)
+	if err != nil {
+		return fmt.Errorf("read private key: %w", err)
+	}
+	keyHex := trimHex(string(keyData))
+	keyBytes, err := hex.DecodeString(keyHex)
+	if err != nil || len(keyBytes) != ed25519.PrivateKeySize {
+		return fmt.Errorf("invalid Ed25519 private key (expected %d bytes, got %d)", ed25519.PrivateKeySize, len(keyBytes))
+	}
+	priv := ed25519.PrivateKey(keyBytes)
+
+	sig, err := signing.Sign(dirPath, priv, signPublisher)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "Signed: %s\n", dirPath)
+	fmt.Fprintf(os.Stderr, "  Publisher:    %s\n", sig.Publisher)
+	fmt.Fprintf(os.Stderr, "  Fingerprint:  %s\n", sig.Fingerprint)
+	fmt.Fprintf(os.Stderr, "  Content hash: %s\n", sig.ContentHash)
+	fmt.Fprintf(os.Stderr, "  Signature:    %s\n", filepath.Join(dirPath, signing.SignatureFileName))
+	return nil
+}
+
+func runSignVerify(_ *cobra.Command, args []string) error {
+	dirPath := args[0]
+
+	ts := loadTrustStore()
+	var trusted []signing.Publisher
+	if ts != nil {
+		trusted = ts.List()
+	}
+
+	result, err := signing.Verify(dirPath, trusted)
+	if err != nil {
+		return err
+	}
+
+	if signOutputJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+
+	if result.Verified {
+		fmt.Println("VERIFIED")
+	} else if result.Signed {
+		fmt.Println("SIGNED (not trusted)")
+	} else {
+		fmt.Println("UNSIGNED")
+	}
+	fmt.Printf("  Publisher:   %s\n", result.Publisher)
+	fmt.Printf("  Fingerprint: %s\n", result.Fingerprint)
+	fmt.Printf("  Reason:      %s\n", result.Reason)
+
+	if auditLog != nil {
+		_ = auditLog.LogAction("verify", dirPath, fmt.Sprintf(
+			"signed=%t trusted=%t publisher=%s", result.Signed, result.Trusted, result.Publisher))
+	}
+
+	if auditStore != nil {
+		name := filepath.Base(dirPath)
+		_ = auditStore.SetSignatureStatus("skill", name, result.Publisher, result.Fingerprint, result.Verified, "", result.Reason)
+	}
+
+	return nil
+}
+
+func runTrustAdd(_ *cobra.Command, _ []string) error {
+	ts := loadTrustStore()
+	if ts == nil {
+		return fmt.Errorf("trust store not configured")
+	}
+
+	keyData, err := os.ReadFile(trustKeyFile)
+	if err != nil {
+		return fmt.Errorf("read public key: %w", err)
+	}
+	keyHex := trimHex(string(keyData))
+
+	pub, err := ts.Add(trustName, keyHex)
+	if err != nil {
+		return err
+	}
+	if err := ts.Save(); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "Added trusted publisher:\n")
+	fmt.Fprintf(os.Stderr, "  Name:        %s\n", pub.Name)
+	fmt.Fprintf(os.Stderr, "  Fingerprint: %s\n", pub.Fingerprint)
+
+	if auditLog != nil {
+		_ = auditLog.LogAction("trust-add", trustName, fmt.Sprintf("fingerprint=%s", pub.Fingerprint))
+	}
+	return nil
+}
+
+func runTrustList(_ *cobra.Command, _ []string) error {
+	ts := loadTrustStore()
+	if ts == nil {
+		return fmt.Errorf("trust store not configured")
+	}
+
+	publishers := ts.List()
+
+	if signOutputJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(publishers)
+	}
+
+	if len(publishers) == 0 {
+		fmt.Println("No trusted publishers.")
+		return nil
+	}
+
+	fmt.Printf("%-20s %-64s %s\n", "NAME", "FINGERPRINT", "ADDED")
+	for _, p := range publishers {
+		fp := p.Fingerprint
+		if len(fp) > 16 {
+			fp = fp[:16] + "..."
+		}
+		fmt.Printf("%-20s %-64s %s\n", p.Name, fp, p.AddedAt)
+	}
+	return nil
+}
+
+func runTrustRemove(_ *cobra.Command, _ []string) error {
+	ts := loadTrustStore()
+	if ts == nil {
+		return fmt.Errorf("trust store not configured")
+	}
+
+	if err := ts.Remove(trustFP); err != nil {
+		return err
+	}
+	if err := ts.Save(); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "Removed publisher with fingerprint: %s\n", trustFP)
+
+	if auditLog != nil {
+		_ = auditLog.LogAction("trust-remove", trustFP, "publisher removed from trust store")
+	}
+	return nil
+}
+
+func loadTrustStore() *signing.TrustStore {
+	trustDir := ""
+	if cfg != nil {
+		trustDir = cfg.Signing.TrustDir
+	}
+	if trustDir == "" {
+		trustDir = filepath.Join(os.Getenv("HOME"), ".defenseclaw", "trust")
+	}
+	ts := signing.NewTrustStore(trustDir)
+	_ = ts.Load()
+	return ts
+}
+
+func trimHex(s string) string {
+	s = filepath.Clean(s)
+	// strip any whitespace/newlines
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c != '\n' && c != '\r' && c != ' ' && c != '\t' {
+			out = append(out, c)
+		}
+	}
+	return string(out)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	MCPActions     MCPActionsConfig     `mapstructure:"mcp_actions"      yaml:"mcp_actions"`
 	PluginActions  PluginActionsConfig  `mapstructure:"plugin_actions"   yaml:"plugin_actions"`
 	OTel           OTelConfig           `mapstructure:"otel"             yaml:"otel"`
+	Signing        SigningConfig        `mapstructure:"signing"          yaml:"signing"`
 }
 
 type OTelConfig struct {
@@ -114,6 +115,12 @@ type OTelBatchConfig struct {
 
 type OTelResourceConfig struct {
 	Attributes map[string]string `mapstructure:"attributes" yaml:"attributes"`
+}
+
+// SigningConfig controls cryptographic skill/MCP/plugin signing verification.
+type SigningConfig struct {
+	Mode     string `mapstructure:"mode"      yaml:"mode"`      // "enforce", "warn", "off"
+	TrustDir string `mapstructure:"trust_dir" yaml:"trust_dir"` // default ~/.defenseclaw/trust
 }
 
 type FirewallConfig struct {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -175,5 +175,9 @@ func DefaultConfig() *Config {
 		SkillActions:  DefaultSkillActions(),
 		MCPActions:    DefaultMCPActions(),
 		PluginActions: DefaultPluginActions(),
+		Signing: SigningConfig{
+			Mode:     "warn",
+			TrustDir: filepath.Join(dataDir, "trust"),
+		},
 	}
 }

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -39,6 +39,7 @@ import (
 	"github.com/defenseclaw/defenseclaw/internal/enforce"
 	"github.com/defenseclaw/defenseclaw/internal/policy"
 	"github.com/defenseclaw/defenseclaw/internal/scanner"
+	"github.com/defenseclaw/defenseclaw/internal/signing"
 	"github.com/defenseclaw/defenseclaw/internal/telemetry"
 )
 
@@ -53,10 +54,17 @@ type APIServer struct {
 	scannerCfg *config.Config
 	otel       *telemetry.Provider
 
+	trustStore *signing.TrustStore
+
 	// cfgMu protects mutable fields in scannerCfg.Guardrail (Mode,
 	// ScannerMode) which can be changed at runtime via the PATCH
 	// /v1/guardrail/config endpoint while other goroutines read them.
 	cfgMu sync.RWMutex
+}
+
+// SetTrustStore attaches the signing trust store for verify/trust API endpoints.
+func (a *APIServer) SetTrustStore(ts *signing.TrustStore) {
+	a.trustStore = ts
 }
 
 // SetOTelProvider attaches the OTel provider so guardrail events
@@ -113,6 +121,9 @@ func (a *APIServer) Run(ctx context.Context) error {
 	mux.HandleFunc("/v1/guardrail/config", a.handleGuardrailConfig)
 	mux.HandleFunc("/api/v1/inspect/tool", a.handleInspectTool)
 	mux.HandleFunc("/api/v1/scan/code", a.handleCodeScan)
+	mux.HandleFunc("/api/v1/verify", a.handleVerify)
+	mux.HandleFunc("/api/v1/trust", a.handleTrust)
+	mux.HandleFunc("/api/v1/signatures", a.handleSignatures)
 
 	handler := a.metricsMiddleware(csrfProtect(mux))
 	if a.scannerCfg != nil && a.scannerCfg.Gateway.Token != "" {
@@ -692,6 +703,22 @@ func (a *APIServer) handlePolicyEvaluate(w http.ResponseWriter, r *http.Request)
 		input.ScanResult = &policy.ScanResultInput{
 			MaxSeverity:   req.Input.ScanResult.MaxSeverity,
 			TotalFindings: req.Input.ScanResult.TotalFindings,
+		}
+	}
+	if req.Input.Path != "" && a.trustStore != nil {
+		vr, verErr := signing.Verify(req.Input.Path, a.trustStore.List())
+		if verErr == nil {
+			input.SigningStatus = &policy.SigningStatusInput{
+				Signed:      vr.Signed,
+				Trusted:     vr.Trusted,
+				Publisher:   vr.Publisher,
+				Fingerprint: vr.Fingerprint,
+			}
+			if a.store != nil && req.Input.TargetName != "" {
+				_ = a.store.SetSignatureStatus(
+					req.Input.TargetType, req.Input.TargetName,
+					vr.Publisher, vr.Fingerprint, vr.Verified, "", vr.Reason)
+			}
 		}
 	}
 
@@ -1761,4 +1788,136 @@ func (a *APIServer) handleCodeScan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	a.writeJSON(w, http.StatusOK, result)
+}
+
+// --- Signing endpoints ---
+
+type verifyRequest struct {
+	TargetType string `json:"target_type"`
+	TargetName string `json:"target_name"`
+	Path       string `json:"path"`
+}
+
+func (a *APIServer) handleVerify(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		a.writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "POST required"})
+		return
+	}
+	var req verifyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		a.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+		return
+	}
+	if req.Path == "" {
+		a.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path is required"})
+		return
+	}
+
+	var trusted []signing.Publisher
+	if a.trustStore != nil {
+		trusted = a.trustStore.List()
+	}
+
+	result, err := signing.Verify(req.Path, trusted)
+	if err != nil {
+		a.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	if a.store != nil && req.TargetName != "" {
+		_ = a.store.SetSignatureStatus(
+			req.TargetType, req.TargetName,
+			result.Publisher, result.Fingerprint,
+			result.Verified, "", result.Reason,
+		)
+	}
+
+	if a.logger != nil {
+		_ = a.logger.LogAction("verify", req.TargetName, fmt.Sprintf(
+			"signed=%t trusted=%t publisher=%s", result.Signed, result.Trusted, result.Publisher))
+	}
+
+	a.writeJSON(w, http.StatusOK, result)
+}
+
+type trustAddRequest struct {
+	Name      string `json:"name"`
+	PublicKey string `json:"public_key"`
+}
+
+func (a *APIServer) handleTrust(w http.ResponseWriter, r *http.Request) {
+	if a.trustStore == nil {
+		a.writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "trust store not configured"})
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		a.writeJSON(w, http.StatusOK, a.trustStore.List())
+
+	case http.MethodPost:
+		var req trustAddRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			a.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+			return
+		}
+		if req.Name == "" || req.PublicKey == "" {
+			a.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name and public_key are required"})
+			return
+		}
+		pub, err := a.trustStore.Add(req.Name, req.PublicKey)
+		if err != nil {
+			a.writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+			return
+		}
+		if err := a.trustStore.Save(); err != nil {
+			a.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		if a.logger != nil {
+			_ = a.logger.LogAction("trust-add", req.Name, fmt.Sprintf("fingerprint=%s", pub.Fingerprint))
+		}
+		a.writeJSON(w, http.StatusCreated, pub)
+
+	case http.MethodDelete:
+		fp := r.URL.Query().Get("fingerprint")
+		if fp == "" {
+			a.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "fingerprint query param required"})
+			return
+		}
+		if err := a.trustStore.Remove(fp); err != nil {
+			a.writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			return
+		}
+		if err := a.trustStore.Save(); err != nil {
+			a.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		if a.logger != nil {
+			_ = a.logger.LogAction("trust-remove", fp, "publisher removed from trust store")
+		}
+		a.writeJSON(w, http.StatusOK, map[string]string{"status": "removed"})
+
+	default:
+		a.writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "GET, POST, or DELETE required"})
+	}
+}
+
+func (a *APIServer) handleSignatures(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		a.writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "GET required"})
+		return
+	}
+	if a.store == nil {
+		a.writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "store not available"})
+		return
+	}
+
+	targetType := r.URL.Query().Get("target_type")
+	sigs, err := a.store.ListSignatures(targetType)
+	if err != nil {
+		a.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	a.writeJSON(w, http.StatusOK, sigs)
 }

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -31,6 +31,7 @@ import (
 	"github.com/defenseclaw/defenseclaw/internal/config"
 	"github.com/defenseclaw/defenseclaw/internal/policy"
 	"github.com/defenseclaw/defenseclaw/internal/sandbox"
+	"github.com/defenseclaw/defenseclaw/internal/signing"
 	"github.com/defenseclaw/defenseclaw/internal/telemetry"
 	"github.com/defenseclaw/defenseclaw/internal/watcher"
 )
@@ -276,6 +277,11 @@ func (s *Sidecar) runWatcher(ctx context.Context) error {
 	if s.otel != nil {
 		w.SetOTelProvider(s.otel)
 	}
+	if s.cfg.Signing.TrustDir != "" {
+		ts := signing.NewTrustStore(s.cfg.Signing.TrustDir)
+		_ = ts.Load()
+		w.SetTrustStore(ts)
+	}
 
 	fmt.Fprintf(os.Stderr, "[sidecar] watcher starting (%d skill dirs, %d plugin dirs, skill_take_action=%v, plugin_take_action=%v)\n",
 		len(skillDirs), len(pluginDirs), wcfg.Skill.TakeAction, wcfg.Plugin.TakeAction)
@@ -396,6 +402,13 @@ func (s *Sidecar) runAPI(ctx context.Context) error {
 	addr := fmt.Sprintf("%s:%d", bind, s.cfg.Gateway.APIPort)
 	api := NewAPIServer(addr, s.health, s.client, s.store, s.logger, s.cfg)
 	api.SetOTelProvider(s.otel)
+
+	if s.cfg.Signing.TrustDir != "" {
+		ts := signing.NewTrustStore(s.cfg.Signing.TrustDir)
+		_ = ts.Load()
+		api.SetTrustStore(ts)
+	}
+
 	return api.Run(ctx)
 }
 

--- a/internal/policy/types.go
+++ b/internal/policy/types.go
@@ -18,12 +18,21 @@ package policy
 
 // AdmissionInput is the structured input passed to the OPA admission policy.
 type AdmissionInput struct {
-	TargetType string           `json:"target_type"`
-	TargetName string           `json:"target_name"`
-	Path       string           `json:"path"`
-	BlockList  []ListEntry      `json:"block_list"`
-	AllowList  []ListEntry      `json:"allow_list"`
-	ScanResult *ScanResultInput `json:"scan_result,omitempty"`
+	TargetType    string              `json:"target_type"`
+	TargetName    string              `json:"target_name"`
+	Path          string              `json:"path"`
+	BlockList     []ListEntry         `json:"block_list"`
+	AllowList     []ListEntry         `json:"allow_list"`
+	ScanResult    *ScanResultInput    `json:"scan_result,omitempty"`
+	SigningStatus *SigningStatusInput  `json:"signing_status,omitempty"`
+}
+
+// SigningStatusInput conveys the signature verification result to OPA.
+type SigningStatusInput struct {
+	Signed      bool   `json:"signed"`
+	Trusted     bool   `json:"trusted"`
+	Publisher   string `json:"publisher,omitempty"`
+	Fingerprint string `json:"fingerprint,omitempty"`
 }
 
 // ListEntry represents one entry in the block or allow list.

--- a/internal/signing/manifest.go
+++ b/internal/signing/manifest.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// HashDirectory computes a deterministic SHA-256 digest over every file in dir.
+// Files are sorted by their path relative to dir. Each entry contributes
+// "relpath:sha256(content)\n" to the final hash. The signature file itself
+// is excluded so that the hash is stable before and after signing.
+func HashDirectory(dir string) (string, error) {
+	type entry struct {
+		rel  string
+		hash string
+	}
+
+	var entries []entry
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return fmt.Errorf("signing: rel path: %w", err)
+		}
+		rel = filepath.ToSlash(rel)
+
+		if rel == SignatureFileName {
+			return nil
+		}
+
+		h, err := hashFile(path)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, entry{rel: rel, hash: h})
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("signing: walk %s: %w", dir, err)
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].rel < entries[j].rel })
+
+	manifest := sha256.New()
+	for _, e := range entries {
+		fmt.Fprintf(manifest, "%s:%s\n", e.rel, e.hash)
+	}
+	return hex.EncodeToString(manifest.Sum(nil)), nil
+}
+
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("signing: open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("signing: read %s: %w", path, err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/signing/sign.go
+++ b/internal/signing/sign.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// GenerateKeyPair creates a new Ed25519 key pair.
+func GenerateKeyPair() (ed25519.PublicKey, ed25519.PrivateKey, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("signing: generate key pair: %w", err)
+	}
+	return pub, priv, nil
+}
+
+// Fingerprint returns the SHA-256 hex digest of a public key.
+func Fingerprint(pub ed25519.PublicKey) string {
+	h := sha256.Sum256(pub)
+	return hex.EncodeToString(h[:])
+}
+
+// Sign computes the manifest hash for dirPath, signs it with privateKey,
+// and writes .defenseclaw-sig.json into dirPath.
+func Sign(dirPath string, privateKey ed25519.PrivateKey, publisher string) (*Signature, error) {
+	contentHash, err := HashDirectory(dirPath)
+	if err != nil {
+		return nil, err
+	}
+
+	hashBytes, err := hex.DecodeString(contentHash)
+	if err != nil {
+		return nil, fmt.Errorf("signing: decode content hash: %w", err)
+	}
+
+	sig := ed25519.Sign(privateKey, hashBytes)
+	pub := privateKey.Public().(ed25519.PublicKey)
+
+	s := &Signature{
+		Version:     SignatureVersion,
+		Algorithm:   AlgorithmEd25519,
+		Publisher:   publisher,
+		PublicKey:   hex.EncodeToString(pub),
+		Fingerprint: Fingerprint(pub),
+		SignedAt:    time.Now().UTC().Format(time.RFC3339),
+		ContentHash: contentHash,
+		Sig:         hex.EncodeToString(sig),
+	}
+
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("signing: marshal signature: %w", err)
+	}
+	data = append(data, '\n')
+
+	sigPath := filepath.Join(dirPath, SignatureFileName)
+	if err := os.WriteFile(sigPath, data, 0644); err != nil {
+		return nil, fmt.Errorf("signing: write %s: %w", sigPath, err)
+	}
+
+	return s, nil
+}
+
+// ReadSignature reads and parses .defenseclaw-sig.json from dirPath.
+func ReadSignature(dirPath string) (*Signature, error) {
+	sigPath := filepath.Join(dirPath, SignatureFileName)
+	data, err := os.ReadFile(sigPath)
+	if err != nil {
+		return nil, err
+	}
+	var sig Signature
+	if err := json.Unmarshal(data, &sig); err != nil {
+		return nil, fmt.Errorf("signing: parse %s: %w", sigPath, err)
+	}
+	return &sig, nil
+}
+
+// Verify checks the signature in dirPath against the provided trusted publishers.
+// It re-computes the manifest hash, validates the Ed25519 signature, and checks
+// whether the signing key is in the trust set.
+func Verify(dirPath string, trustedKeys []Publisher) (*VerifyResult, error) {
+	sig, err := ReadSignature(dirPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &VerifyResult{
+				Signed:   false,
+				Verified: false,
+				Trusted:  false,
+				Reason:   "no signature file found",
+			}, nil
+		}
+		return nil, fmt.Errorf("signing: read signature: %w", err)
+	}
+
+	if sig.Version != SignatureVersion {
+		return &VerifyResult{
+			Signed: true,
+			Reason: fmt.Sprintf("unsupported signature version %d", sig.Version),
+		}, nil
+	}
+	if sig.Algorithm != AlgorithmEd25519 {
+		return &VerifyResult{
+			Signed: true,
+			Reason: fmt.Sprintf("unsupported algorithm %q", sig.Algorithm),
+		}, nil
+	}
+
+	pubKeyBytes, err := hex.DecodeString(sig.PublicKey)
+	if err != nil || len(pubKeyBytes) != ed25519.PublicKeySize {
+		return &VerifyResult{
+			Signed: true,
+			Reason: "invalid public key in signature file",
+		}, nil
+	}
+	pub := ed25519.PublicKey(pubKeyBytes)
+
+	actualFP := Fingerprint(pub)
+	if actualFP != sig.Fingerprint {
+		return &VerifyResult{
+			Signed: true,
+			Reason: "fingerprint mismatch in signature file",
+		}, nil
+	}
+
+	contentHash, err := HashDirectory(dirPath)
+	if err != nil {
+		return nil, err
+	}
+	if contentHash != sig.ContentHash {
+		return &VerifyResult{
+			Signed:      true,
+			Publisher:   sig.Publisher,
+			Fingerprint: sig.Fingerprint,
+			Reason:      "content has been modified since signing",
+		}, nil
+	}
+
+	hashBytes, err := hex.DecodeString(contentHash)
+	if err != nil {
+		return nil, fmt.Errorf("signing: decode content hash: %w", err)
+	}
+
+	sigBytes, err := hex.DecodeString(sig.Sig)
+	if err != nil {
+		return &VerifyResult{
+			Signed: true,
+			Reason: "invalid signature encoding",
+		}, nil
+	}
+
+	if !ed25519.Verify(pub, hashBytes, sigBytes) {
+		return &VerifyResult{
+			Signed:      true,
+			Publisher:   sig.Publisher,
+			Fingerprint: sig.Fingerprint,
+			Reason:      "signature verification failed",
+		}, nil
+	}
+
+	trusted := false
+	for _, tk := range trustedKeys {
+		if tk.Fingerprint == sig.Fingerprint {
+			trusted = true
+			break
+		}
+	}
+
+	reason := "signature valid"
+	if !trusted {
+		reason = "signature valid but publisher is not trusted"
+	}
+
+	return &VerifyResult{
+		Verified:    trusted,
+		Signed:      true,
+		Trusted:     trusted,
+		Publisher:   sig.Publisher,
+		Fingerprint: sig.Fingerprint,
+		Reason:      reason,
+	}, nil
+}

--- a/internal/signing/sign_test.go
+++ b/internal/signing/sign_test.go
@@ -1,0 +1,276 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setupSkillDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "skill.yaml"), []byte("name: test-skill\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.py"), []byte("print('hello')\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestSignAndVerifyRoundTrip(t *testing.T) {
+	dir := setupSkillDir(t)
+	pub, priv, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sig, err := Sign(dir, priv, "test-publisher")
+	if err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+	if sig.Publisher != "test-publisher" {
+		t.Errorf("publisher = %q, want %q", sig.Publisher, "test-publisher")
+	}
+	if sig.Algorithm != AlgorithmEd25519 {
+		t.Errorf("algorithm = %q, want %q", sig.Algorithm, AlgorithmEd25519)
+	}
+
+	trusted := []Publisher{{
+		Name:        "test-publisher",
+		PublicKey:   hex.EncodeToString(pub),
+		Fingerprint: Fingerprint(pub),
+	}}
+	result, err := Verify(dir, trusted)
+	if err != nil {
+		t.Fatalf("Verify failed: %v", err)
+	}
+	if !result.Verified {
+		t.Errorf("expected verified=true, got false: %s", result.Reason)
+	}
+	if !result.Signed {
+		t.Error("expected signed=true")
+	}
+	if !result.Trusted {
+		t.Error("expected trusted=true")
+	}
+}
+
+func TestVerifyDetectsTamperedContent(t *testing.T) {
+	dir := setupSkillDir(t)
+	pub, priv, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Sign(dir, priv, "publisher"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "main.py"), []byte("print('tampered')\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	trusted := []Publisher{{
+		Name:        "publisher",
+		PublicKey:   hex.EncodeToString(pub),
+		Fingerprint: Fingerprint(pub),
+	}}
+	result, err := Verify(dir, trusted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Verified {
+		t.Error("expected verified=false for tampered content")
+	}
+	if result.Reason != "content has been modified since signing" {
+		t.Errorf("unexpected reason: %s", result.Reason)
+	}
+}
+
+func TestVerifyRejectsUntrustedPublisher(t *testing.T) {
+	dir := setupSkillDir(t)
+	_, priv, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Sign(dir, priv, "unknown"); err != nil {
+		t.Fatal(err)
+	}
+
+	otherPub, _, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	trusted := []Publisher{{
+		Name:        "other",
+		PublicKey:   hex.EncodeToString(otherPub),
+		Fingerprint: Fingerprint(otherPub),
+	}}
+	result, err := Verify(dir, trusted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Verified {
+		t.Error("expected verified=false for untrusted publisher")
+	}
+	if result.Trusted {
+		t.Error("expected trusted=false")
+	}
+	if !result.Signed {
+		t.Error("expected signed=true")
+	}
+}
+
+func TestVerifyNoSignatureFile(t *testing.T) {
+	dir := setupSkillDir(t)
+	result, err := Verify(dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Signed {
+		t.Error("expected signed=false when no sig file")
+	}
+	if result.Verified {
+		t.Error("expected verified=false when no sig file")
+	}
+}
+
+func TestManifestHashDeterminism(t *testing.T) {
+	dir := setupSkillDir(t)
+	h1, err := HashDirectory(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, err := HashDirectory(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1 != h2 {
+		t.Errorf("manifest hash not deterministic: %s != %s", h1, h2)
+	}
+}
+
+func TestManifestHashExcludesSigFile(t *testing.T) {
+	dir := setupSkillDir(t)
+	h1, err := HashDirectory(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, priv, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Sign(dir, priv, "pub"); err != nil {
+		t.Fatal(err)
+	}
+
+	h2, err := HashDirectory(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1 != h2 {
+		t.Errorf("manifest hash changed after signing: %s != %s", h1, h2)
+	}
+}
+
+func TestTrustStoreAddListRemove(t *testing.T) {
+	dir := t.TempDir()
+	ts := NewTrustStore(dir)
+
+	pub, _, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubHex := hex.EncodeToString(pub)
+	fp := Fingerprint(pub)
+
+	p, err := ts.Add("cisco", pubHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Fingerprint != fp {
+		t.Errorf("fingerprint = %q, want %q", p.Fingerprint, fp)
+	}
+
+	if err := ts.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	ts2 := NewTrustStore(dir)
+	if err := ts2.Load(); err != nil {
+		t.Fatal(err)
+	}
+	list := ts2.List()
+	if len(list) != 1 {
+		t.Fatalf("expected 1 publisher, got %d", len(list))
+	}
+	if list[0].Name != "cisco" {
+		t.Errorf("name = %q, want %q", list[0].Name, "cisco")
+	}
+	if !ts2.IsTrusted(fp) {
+		t.Error("expected IsTrusted=true")
+	}
+
+	if err := ts2.Remove(fp); err != nil {
+		t.Fatal(err)
+	}
+	if ts2.IsTrusted(fp) {
+		t.Error("expected IsTrusted=false after remove")
+	}
+}
+
+func TestTrustStoreRejectsDuplicate(t *testing.T) {
+	ts := NewTrustStore(t.TempDir())
+	pub, _, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubHex := hex.EncodeToString(pub)
+
+	if _, err := ts.Add("first", pubHex); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ts.Add("second", pubHex); err == nil {
+		t.Error("expected error adding duplicate key")
+	}
+}
+
+func TestTrustStoreRejectsInvalidKey(t *testing.T) {
+	ts := NewTrustStore(t.TempDir())
+	if _, err := ts.Add("bad", "not-hex"); err == nil {
+		t.Error("expected error for invalid hex")
+	}
+	if _, err := ts.Add("bad", hex.EncodeToString([]byte("tooshort"))); err == nil {
+		t.Error("expected error for wrong key length")
+	}
+}
+
+func TestFingerprintConsistency(t *testing.T) {
+	pub := make(ed25519.PublicKey, ed25519.PublicKeySize)
+	fp1 := Fingerprint(pub)
+	fp2 := Fingerprint(pub)
+	if fp1 != fp2 {
+		t.Errorf("fingerprint not consistent: %s != %s", fp1, fp2)
+	}
+}

--- a/internal/signing/trust.go
+++ b/internal/signing/trust.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const publishersFile = "publishers.yaml"
+
+// TrustStore manages the set of trusted publisher public keys.
+type TrustStore struct {
+	dir        string
+	mu         sync.RWMutex
+	publishers []Publisher
+}
+
+// NewTrustStore creates a TrustStore backed by the given directory.
+func NewTrustStore(dir string) *TrustStore {
+	return &TrustStore{dir: dir}
+}
+
+// Load reads publishers.yaml from disk.
+func (ts *TrustStore) Load() error {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	path := filepath.Join(ts.dir, publishersFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			ts.publishers = nil
+			return nil
+		}
+		return fmt.Errorf("signing: read trust store: %w", err)
+	}
+
+	var pubs []Publisher
+	if err := yaml.Unmarshal(data, &pubs); err != nil {
+		return fmt.Errorf("signing: parse trust store: %w", err)
+	}
+	ts.publishers = pubs
+	return nil
+}
+
+// Save writes the current publishers list to publishers.yaml.
+func (ts *TrustStore) Save() error {
+	ts.mu.RLock()
+	defer ts.mu.RUnlock()
+
+	if err := os.MkdirAll(ts.dir, 0755); err != nil {
+		return fmt.Errorf("signing: create trust dir: %w", err)
+	}
+
+	data, err := yaml.Marshal(ts.publishers)
+	if err != nil {
+		return fmt.Errorf("signing: marshal trust store: %w", err)
+	}
+
+	path := filepath.Join(ts.dir, publishersFile)
+	return os.WriteFile(path, data, 0644)
+}
+
+// Add registers a new trusted publisher. pubKeyHex is the hex-encoded Ed25519
+// public key. Returns an error if the fingerprint is already trusted.
+func (ts *TrustStore) Add(name, pubKeyHex string) (Publisher, error) {
+	keyBytes, err := hex.DecodeString(pubKeyHex)
+	if err != nil || len(keyBytes) != ed25519.PublicKeySize {
+		return Publisher{}, fmt.Errorf("signing: invalid Ed25519 public key (expected %d bytes)", ed25519.PublicKeySize)
+	}
+
+	fp := sha256Hex(keyBytes)
+
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	for _, p := range ts.publishers {
+		if p.Fingerprint == fp {
+			return Publisher{}, fmt.Errorf("signing: publisher with fingerprint %s already trusted", fp)
+		}
+	}
+
+	pub := Publisher{
+		Name:        name,
+		PublicKey:   pubKeyHex,
+		Fingerprint: fp,
+		AddedAt:     time.Now().UTC().Format(time.RFC3339),
+	}
+	ts.publishers = append(ts.publishers, pub)
+	return pub, nil
+}
+
+// Remove deletes a publisher by fingerprint.
+func (ts *TrustStore) Remove(fingerprint string) error {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	for i, p := range ts.publishers {
+		if p.Fingerprint == fingerprint {
+			ts.publishers = append(ts.publishers[:i], ts.publishers[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("signing: fingerprint %s not found in trust store", fingerprint)
+}
+
+// List returns a copy of the trusted publishers.
+func (ts *TrustStore) List() []Publisher {
+	ts.mu.RLock()
+	defer ts.mu.RUnlock()
+
+	out := make([]Publisher, len(ts.publishers))
+	copy(out, ts.publishers)
+	return out
+}
+
+// IsTrusted checks whether a fingerprint is in the trust store.
+func (ts *TrustStore) IsTrusted(fingerprint string) bool {
+	ts.mu.RLock()
+	defer ts.mu.RUnlock()
+
+	for _, p := range ts.publishers {
+		if p.Fingerprint == fingerprint {
+			return true
+		}
+	}
+	return false
+}
+
+func sha256Hex(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}

--- a/internal/signing/types.go
+++ b/internal/signing/types.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package signing
+
+import "time"
+
+const (
+	SignatureFileName = ".defenseclaw-sig.json"
+	SignatureVersion  = 1
+	AlgorithmEd25519 = "ed25519"
+)
+
+// Signature is the on-disk representation stored in .defenseclaw-sig.json.
+type Signature struct {
+	Version     int    `json:"version"`
+	Algorithm   string `json:"algorithm"`
+	Publisher   string `json:"publisher"`
+	PublicKey   string `json:"public_key"`
+	Fingerprint string `json:"fingerprint"`
+	SignedAt    string `json:"signed_at"`
+	ContentHash string `json:"content_hash"`
+	Sig         string `json:"signature"`
+}
+
+// Publisher represents a trusted publisher in the trust store.
+type Publisher struct {
+	Name        string `json:"name"        yaml:"name"`
+	PublicKey   string `json:"public_key"  yaml:"public_key"`
+	Fingerprint string `json:"fingerprint" yaml:"fingerprint"`
+	AddedAt     string `json:"added_at"    yaml:"added_at"`
+}
+
+// VerifyResult is returned by Verify with the outcome of signature validation.
+type VerifyResult struct {
+	Verified    bool   `json:"verified"`
+	Signed      bool   `json:"signed"`
+	Trusted     bool   `json:"trusted"`
+	Publisher   string `json:"publisher,omitempty"`
+	Fingerprint string `json:"fingerprint,omitempty"`
+	Reason      string `json:"reason"`
+}
+
+// SignatureEntry is the DB-level record for a verified (or failed) signature.
+type SignatureEntry struct {
+	ID          string    `json:"id"`
+	TargetType  string    `json:"target_type"`
+	TargetName  string    `json:"target_name"`
+	Publisher   string    `json:"publisher"`
+	Fingerprint string    `json:"fingerprint"`
+	Verified    bool      `json:"verified"`
+	VerifiedAt  time.Time `json:"verified_at"`
+	ContentHash string    `json:"content_hash"`
+	Reason      string    `json:"reason"`
+}

--- a/internal/tui/mcps.go
+++ b/internal/tui/mcps.go
@@ -26,11 +26,13 @@ import (
 )
 
 type mcpItem struct {
-	URL     string
-	Status  string
-	Actions string
-	Reason  string
-	Time    string
+	URL       string
+	Status    string
+	Verified  bool
+	Publisher string
+	Actions   string
+	Reason    string
+	Time      string
 }
 
 type MCPsPanel struct {
@@ -68,13 +70,18 @@ func (p *MCPsPanel) Refresh() {
 		default:
 			status = "active"
 		}
-		p.items = append(p.items, mcpItem{
+		item := mcpItem{
 			URL:     e.TargetName,
 			Status:  status,
 			Actions: e.Actions.Summary(),
 			Reason:  e.Reason,
 			Time:    e.UpdatedAt.Format("2006-01-02 15:04"),
-		})
+		}
+		if sig, err := p.store.GetSignatureStatus("mcp", e.TargetName); err == nil && sig != nil {
+			item.Verified = sig.Verified
+			item.Publisher = sig.Publisher
+		}
+		p.items = append(p.items, item)
 	}
 
 	if p.cursor >= len(p.items) && len(p.items) > 0 {
@@ -133,7 +140,7 @@ func (p *MCPsPanel) View() string {
 	}
 
 	var b strings.Builder
-	header := fmt.Sprintf("  %-10s %-40s %-20s %-20s %-16s", "STATUS", "URL", "ACTIONS", "REASON", "SINCE")
+	header := fmt.Sprintf("  %-10s %-8s %-36s %-18s %-18s %-16s", "STATUS", "SIGNED", "URL", "ACTIONS", "REASON", "SINCE")
 	b.WriteString(HeaderStyle.Render(header))
 	b.WriteString("\n")
 
@@ -154,20 +161,28 @@ func (p *MCPsPanel) View() string {
 	for i := start; i < end; i++ {
 		item := p.items[i]
 		status := StatusStyle(item.Status).Render(fmt.Sprintf("%-10s", strings.ToUpper(item.Status)))
+		var badge string
+		if item.Verified {
+			badge = StyleVerified.Render("YES")
+			badge = fmt.Sprintf("%-8s", badge)
+		} else {
+			badge = StyleUnverified.Render("-")
+			badge = fmt.Sprintf("  %-6s", badge)
+		}
 		url := item.URL
-		if len(url) > 40 {
-			url = url[:37] + "..."
+		if len(url) > 36 {
+			url = url[:33] + "..."
 		}
 		actions := item.Actions
-		if len(actions) > 20 {
-			actions = actions[:17] + "..."
+		if len(actions) > 18 {
+			actions = actions[:15] + "..."
 		}
 		reason := item.Reason
-		if len(reason) > 20 {
-			reason = reason[:17] + "..."
+		if len(reason) > 18 {
+			reason = reason[:15] + "..."
 		}
 
-		line := fmt.Sprintf("  %s %-40s %-20s %-20s %-16s", status, url, actions, reason, item.Time)
+		line := fmt.Sprintf("  %s %s %-36s %-18s %-18s %-16s", status, badge, url, actions, reason, item.Time)
 
 		if i == p.cursor {
 			line = SelectedStyle.Width(p.width).Render(line)

--- a/internal/tui/skills.go
+++ b/internal/tui/skills.go
@@ -26,11 +26,13 @@ import (
 )
 
 type skillItem struct {
-	Name    string
-	Status  string
-	Actions string
-	Reason  string
-	Time    string
+	Name      string
+	Status    string
+	Verified  bool
+	Publisher string
+	Actions   string
+	Reason    string
+	Time      string
 }
 
 type SkillsPanel struct {
@@ -68,13 +70,18 @@ func (p *SkillsPanel) Refresh() {
 		default:
 			status = "active"
 		}
-		p.items = append(p.items, skillItem{
+		item := skillItem{
 			Name:    e.TargetName,
 			Status:  status,
 			Actions: e.Actions.Summary(),
 			Reason:  e.Reason,
 			Time:    e.UpdatedAt.Format("2006-01-02 15:04"),
-		})
+		}
+		if sig, err := p.store.GetSignatureStatus("skill", e.TargetName); err == nil && sig != nil {
+			item.Verified = sig.Verified
+			item.Publisher = sig.Publisher
+		}
+		p.items = append(p.items, item)
 	}
 
 	if p.cursor >= len(p.items) && len(p.items) > 0 {
@@ -133,7 +140,7 @@ func (p *SkillsPanel) View() string {
 	}
 
 	var b strings.Builder
-	header := fmt.Sprintf("  %-10s %-30s %-20s %-20s %-16s", "STATUS", "NAME", "ACTIONS", "REASON", "SINCE")
+	header := fmt.Sprintf("  %-10s %-8s %-28s %-18s %-18s %-16s", "STATUS", "SIGNED", "NAME", "ACTIONS", "REASON", "SINCE")
 	b.WriteString(HeaderStyle.Render(header))
 	b.WriteString("\n")
 
@@ -154,20 +161,28 @@ func (p *SkillsPanel) View() string {
 	for i := start; i < end; i++ {
 		item := p.items[i]
 		status := StatusStyle(item.Status).Render(fmt.Sprintf("%-10s", strings.ToUpper(item.Status)))
+		var badge string
+		if item.Verified {
+			badge = StyleVerified.Render("YES")
+			badge = fmt.Sprintf("%-8s", badge)
+		} else {
+			badge = StyleUnverified.Render("-")
+			badge = fmt.Sprintf("  %-6s", badge)
+		}
 		name := item.Name
-		if len(name) > 30 {
-			name = name[:27] + "..."
+		if len(name) > 28 {
+			name = name[:25] + "..."
 		}
 		actions := item.Actions
-		if len(actions) > 20 {
-			actions = actions[:17] + "..."
+		if len(actions) > 18 {
+			actions = actions[:15] + "..."
 		}
 		reason := item.Reason
-		if len(reason) > 20 {
-			reason = reason[:17] + "..."
+		if len(reason) > 18 {
+			reason = reason[:15] + "..."
 		}
 
-		line := fmt.Sprintf("  %s %-30s %-20s %-20s %-16s", status, name, actions, reason, item.Time)
+		line := fmt.Sprintf("  %s %s %-28s %-18s %-18s %-16s", status, badge, name, actions, reason, item.Time)
 
 		if i == p.cursor {
 			line = SelectedStyle.Width(p.width).Render(line)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -36,6 +36,10 @@ var (
 	StyleAllowed = lipgloss.NewStyle().Foreground(lipgloss.Color("46"))
 	StyleUnknown = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
 
+	// Signature verification
+	StyleVerified   = lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Bold(true)
+	StyleUnverified = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+
 	// List
 	SelectedStyle = lipgloss.NewStyle().Background(lipgloss.Color("237")).Bold(true)
 	NormalStyle   = lipgloss.NewStyle()

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -33,6 +33,7 @@ import (
 	"github.com/defenseclaw/defenseclaw/internal/policy"
 	"github.com/defenseclaw/defenseclaw/internal/sandbox"
 	"github.com/defenseclaw/defenseclaw/internal/scanner"
+	"github.com/defenseclaw/defenseclaw/internal/signing"
 	"github.com/defenseclaw/defenseclaw/internal/telemetry"
 )
 
@@ -91,6 +92,7 @@ type InstallWatcher struct {
 	shell      *sandbox.OpenShell
 	opa        *policy.Engine
 	otel       *telemetry.Provider
+	trustStore *signing.TrustStore
 	debounce   time.Duration
 	onAdmit    OnAdmission
 
@@ -124,6 +126,33 @@ func New(cfg *config.Config, skillDirs, pluginDirs []string, store *audit.Store,
 // SetOTelProvider attaches the OTel provider for watcher metrics.
 func (w *InstallWatcher) SetOTelProvider(p *telemetry.Provider) {
 	w.otel = p
+}
+
+// SetTrustStore attaches the signing trust store for admission gate verification.
+func (w *InstallWatcher) SetTrustStore(ts *signing.TrustStore) {
+	w.trustStore = ts
+}
+
+// signingStatus runs signature verification on a path and returns a
+// SigningStatusInput suitable for OPA admission input.
+func (w *InstallWatcher) signingStatus(path, targetType, targetName string) *policy.SigningStatusInput {
+	if w.trustStore == nil {
+		return nil
+	}
+	result, err := signing.Verify(path, w.trustStore.List())
+	if err != nil {
+		return nil
+	}
+	if w.store != nil {
+		_ = w.store.SetSignatureStatus(targetType, targetName,
+			result.Publisher, result.Fingerprint, result.Verified, "", result.Reason)
+	}
+	return &policy.SigningStatusInput{
+		Signed:      result.Signed,
+		Trusted:     result.Trusted,
+		Publisher:   result.Publisher,
+		Fingerprint: result.Fingerprint,
+	}
 }
 
 // Run starts watching configured directories. It blocks until ctx is cancelled.
@@ -264,14 +293,17 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 	blockList := w.buildListEntries(pe, "block")
 	allowList := w.buildListEntries(pe, "allow")
 
+	sigStatus := w.signingStatus(evt.Path, targetType, evt.Name)
+
 	// Phase 1: pre-scan OPA evaluation (no scan_result yet).
 	if w.opa != nil {
 		input := policy.AdmissionInput{
-			TargetType: targetType,
-			TargetName: evt.Name,
-			Path:       evt.Path,
-			BlockList:  blockList,
-			AllowList:  allowList,
+			TargetType:    targetType,
+			TargetName:    evt.Name,
+			Path:          evt.Path,
+			BlockList:     blockList,
+			AllowList:     allowList,
+			SigningStatus: sigStatus,
 		}
 		preScanStart := time.Now()
 		out, err := w.opa.Evaluate(ctx, input)
@@ -350,12 +382,13 @@ func (w *InstallWatcher) runAdmission(ctx context.Context, evt InstallEvent) Adm
 			Findings:      toFindingInputs(result.Findings),
 		}
 		input := policy.AdmissionInput{
-			TargetType: targetType,
-			TargetName: evt.Name,
-			Path:       evt.Path,
-			BlockList:  blockList,
-			AllowList:  allowList,
-			ScanResult: scanInput,
+			TargetType:    targetType,
+			TargetName:    evt.Name,
+			Path:          evt.Path,
+			BlockList:     blockList,
+			AllowList:     allowList,
+			ScanResult:    scanInput,
+			SigningStatus: sigStatus,
 		}
 		postScanStart := time.Now()
 		out, evalErr := w.opa.Evaluate(ctx, input)

--- a/policies/default.yaml
+++ b/policies/default.yaml
@@ -101,6 +101,9 @@ firewall:
 enforcement:
   max_enforcement_delay_seconds: 2
 
+signing:
+  mode: warn
+
 audit:
   log_all_actions: true
   log_scan_results: true

--- a/policies/permissive.yaml
+++ b/policies/permissive.yaml
@@ -64,6 +64,9 @@ firewall:
 enforcement:
   max_enforcement_delay_seconds: 5
 
+signing:
+  mode: "off"
+
 audit:
   log_all_actions: true
   log_scan_results: true

--- a/policies/rego/admission.rego
+++ b/policies/rego/admission.rego
@@ -48,6 +48,26 @@ reason := sprintf("%s '%s' is on the block list", [input.target_type, input.targ
 	verdict == "blocked"
 }
 
+# --- Signing enforcement (after block list, before allow list) ---
+
+verdict := "rejected" if {
+	not _is_blocked
+	data.signing.mode == "enforce"
+	not _is_signed
+}
+
+reason := "unsigned or untrusted — signing policy is 'enforce'" if {
+	not _is_blocked
+	data.signing.mode == "enforce"
+	not _is_signed
+}
+
+_is_signed if {
+	input.signing_status
+	input.signing_status.signed == true
+	input.signing_status.trusted == true
+}
+
 # --- Allow list (skip scan when configured) ---
 
 verdict := "allowed" if {

--- a/policies/rego/data.json
+++ b/policies/rego/data.json
@@ -65,6 +65,10 @@
     "LOW": 2,
     "INFO": 1
   },
+  "signing": {
+    "mode": "warn",
+    "require_trusted_publisher": true
+  },
   "audit": {
     "retention_days": 90,
     "log_all_actions": true,

--- a/policies/strict.yaml
+++ b/policies/strict.yaml
@@ -116,6 +116,9 @@ firewall:
 enforcement:
   max_enforcement_delay_seconds: 1
 
+signing:
+  mode: enforce
+
 audit:
   log_all_actions: true
   log_scan_results: true

--- a/schemas/audit-event.json
+++ b/schemas/audit-event.json
@@ -6,7 +6,7 @@
   "properties": {
     "id": { "type": "string", "format": "uuid" },
     "timestamp": { "type": "string", "format": "date-time" },
-    "action": { "type": "string", "enum": ["init", "scan", "block", "allow", "quarantine", "restore", "deploy", "stop"] },
+    "action": { "type": "string", "enum": ["init", "scan", "block", "allow", "quarantine", "restore", "deploy", "stop", "verify", "trust-add", "trust-remove"] },
     "target": { "type": "string" },
     "actor": { "type": "string", "default": "defenseclaw" },
     "details": { "type": "string" },

--- a/schemas/signature.json
+++ b/schemas/signature.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://defenseclaw.io/schemas/signature.json",
+  "title": "DefenseClaw Signature File",
+  "description": "Schema for .defenseclaw-sig.json — the on-disk cryptographic signature placed alongside a signed skill, MCP server, or plugin directory.",
+  "type": "object",
+  "required": [
+    "version",
+    "algorithm",
+    "publisher",
+    "public_key",
+    "fingerprint",
+    "signed_at",
+    "content_hash",
+    "signature"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version. Currently always 1."
+    },
+    "algorithm": {
+      "type": "string",
+      "const": "ed25519",
+      "description": "Signature algorithm. Currently only ed25519 is supported."
+    },
+    "publisher": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable name of the publisher who signed this asset."
+    },
+    "public_key": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "Hex-encoded Ed25519 public key (32 bytes = 64 hex chars)."
+    },
+    "fingerprint": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "SHA-256 hex digest of the public key, used as a stable identifier for the signing key."
+    },
+    "signed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 / RFC 3339 timestamp of when the signature was created (UTC)."
+    },
+    "content_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "SHA-256 hex digest of the canonical manifest (sorted file paths with per-file SHA-256 hashes)."
+    },
+    "signature": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{128}$",
+      "description": "Hex-encoded Ed25519 signature (64 bytes = 128 hex chars) over the raw content_hash bytes."
+    }
+  }
+}


### PR DESCRIPTION
## Verified Publisher / Skill Signing with Ed25519

### Summary

- Adds cryptographic signing for skills, MCPs, and plugins using Ed25519 digital signatures
- Publishers sign assets with private keys; operators manage trusted public keys via a local trust store
- OPA admission gate enforces signing policy (`enforce` / `warn` / `off`) before allowing installs or execution

### What changed

**New `internal/signing` package** — Ed25519 keygen, deterministic SHA-256 content hashing, sign/verify, YAML-backed trust store, and comprehensive unit tests.

**CLI commands** — `sign keygen`, `sign skill <path>`, `sign verify <path>`, `trust add/list/remove` available in both the Go gateway CLI and Python CLI (proxied via sidecar API).

**REST API** — `POST /api/v1/verify`, `GET/POST/DELETE /api/v1/trust`, `GET /api/v1/signatures` with CSRF protection.

**OPA admission policy** — New Rego rule rejects unsigned/untrusted assets when `signing.mode == "enforce"`. Passes through in `warn` mode. Block-list always takes priority.

**Admission gate wiring** — Both the install watcher and policy evaluator include `signing_status` in admission input.

**Audit persistence** — New `signatures` table tracks verification results (publisher, fingerprint, content hash, reason).

**TUI** — SIGNED column with green/gray badge in skills and MCPs views.

**OpenClaw plugin** — `/verify` slash command for in-chat signature checks.

**Schema** — `schemas/signature.json` documents the `.defenseclaw-sig.json` format.

### Policy presets

| Preset | Signing mode |
|--------|-------------|
| default.yaml | warn |
| strict.yaml | enforce |
| permissive.yaml | off |

### Files changed

29 files, +2101 / -49

### Test plan

- [x] `go test ./...` — 15 packages, all pass, zero regressions
- [x] `internal/signing` unit tests — sign/verify round-trip, tamper detection, untrusted rejection, manifest determinism, trust store CRUD
- [x] CLI E2E — keygen, sign, verify (trusted/untrusted/tampered/unsigned), trust add/list/remove, audit DB persistence
- [x] REST API E2E — all endpoints with CSRF headers
- [x] OPA Rego — enforce rejects unsigned, warn passes, block-list overrides signed
- [x] Python CLI E2E — keygen, verify via sidecar, trust lifecycle, DB layer CRUD/upsert
- [x] Python `pytest tests/` — 874 passed, 4 pre-existing failures unrelated to this change