### PR TITLE
feat: add connector-based architecture for multi-framework guardrail …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,12 @@ internal/
   enforce/              Block/allow engine, quarantine, OpenShell policy sync
   tui/                  Bubbletea TUI (four panels: Alerts, Skills, MCP, Status)
   audit/                SQLite audit store + event logger + export + Splunk HEC
-  config/               Viper config loader + defaults + environment detection + claw mode
+  config/               Viper config loader + defaults + environment detection + claw mode + connectors
   inventory/            AIBOM integration
   sandbox/              OpenShell CLI wrapper + policy generation
+  gateway/
+    connector/          Connector interface, router, and per-framework connectors
+                        (OpenClaw, ZeptoClaw, Generic fallback)
 plugins/                Plugin interface, registry, examples
 policies/               Default/strict/permissive YAML policy templates
 schemas/                JSON schemas for audit events and scan results
@@ -62,6 +65,14 @@ test/                   E2E tests, unit tests, fixtures
 - `internal/audit/store.go` — SQLite schema and operations
 - `internal/enforce/policy.go` — Admission gate (block -> allow -> scan)
 - `internal/config/claw.go` — Claw mode resolver (skill dirs, MCP dirs per framework)
+- `internal/config/connectors.go` — Connector config types (OpenClaw, ZeptoClaw)
+- `internal/gateway/connector/connector.go` — Connector interface + RoutingDecision
+- `internal/gateway/connector/router.go` — ConnectorRouter (ordered detection)
+- `internal/gateway/connector/openclaw.go` — OpenClaw connector (X-DC-Target-URL headers)
+- `internal/gateway/connector/zeptoclaw.go` — ZeptoClaw connector (model prefix inference)
+- `internal/gateway/connector/generic.go` — Generic fallback connector
+- `internal/gateway/connector/helpers.go` — Shared utilities (SSRF check, provider inference)
+- `internal/gateway/connector/zeptoclaw_defaults.go` — Embedded provider URL table (19 providers)
 - `internal/tui/app.go` — TUI root model
 
 ## Claw Mode
@@ -75,6 +86,20 @@ All skill/MCP directory resolution derives from the active mode
 1. `~/.openclaw/workspace/skills/` — workspace/project skills
 2. Custom `skills_dir` from `~/.openclaw/openclaw.json` — user-configured path
 3. `~/.openclaw/skills/` — global user skills
+
+## Connector Architecture (LLM Guardrail)
+
+The guardrail proxy uses a connector-based architecture to support multiple
+agent frameworks on the same proxy port. Each framework has a dedicated
+Connector that translates its request format into a canonical `RoutingDecision`.
+
+**Detection order**: OpenClaw → ZeptoClaw → Generic (fallback).
+
+- **OpenClaw Connector** — detects `X-DC-Target-URL` header from fetch interceptor
+- **ZeptoClaw Connector** — detects `X-ZC-Provider` header or standard auth without DC headers; resolves upstream URL from config/defaults
+- **Generic Connector** — fallback for curl, future frameworks; infers provider from model name
+
+Config: `guardrail.connectors.openclaw` (enabled by default), `guardrail.connectors.zeptoclaw` (disabled by default). See `docs/GUARDRAIL.md` for full data flow.
 
 ## Conventions
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,8 @@
 # Architecture
 
-DefenseClaw is a governance layer for OpenClaw. It orchestrates scanning,
-enforcement, and auditing across existing tools without replacing any component.
+DefenseClaw is a governance layer for agent frameworks (OpenClaw, ZeptoClaw,
+and future frameworks). It orchestrates scanning, enforcement, and auditing
+across existing tools without replacing any component.
 
 ## System Diagram
 
@@ -48,9 +49,9 @@ enforcement, and auditing across existing tools without replacing any component.
 │  │  │  SQLite DB       │  │  Guardrail   │             │               │    │
 │  │  │                  │  │  Proxy       │             │               │    │
 │  │  │  Audit events    │  │              │             │               │    │
-│  │  │  Scan results    │  │  Runs        │             │               │    │
-│  │  │  Block/allow     │  │  guardrail   │             │               │    │
-│  │  │  Skill inventory │  │  proxy       │             │               │    │
+│  │  │  Scan results    │  │  Connector   │             │               │    │
+│  │  │  Block/allow     │  │  Router      │             │               │    │
+│  │  │  Skill inventory │  │  + Proxy     │             │               │    │
 │  │  └──────────────────┘  └──────┬───────┘             │               │    │
 │  └──────────────────────────────┼────────────────────┼─────────────────┘    │
 │                                 │                    │                      │
@@ -61,8 +62,11 @@ enforcement, and auditing across existing tools without replacing any component.
 │  │  Guardrail Proxy (port 4000)    │                 │                      │
 │  │                                  │                │                      │
 │  │  ┌────────────────────────────┐  │                │                      │
-│  │  │  DefenseClaw Guardrail     │  │                │                      │
-│  │  │  (built-in Go)             │  │                │                      │
+│  │  │  ConnectorRouter           │  │                │                      │
+│  │  │  OpenClaw → ZeptoClaw →    │  │                │                      │
+│  │  │  Generic (fallback)        │  │                │                      │
+│  │  ├────────────────────────────┤  │                │                      │
+│  │  │  Proxy Core (Go)           │  │                │                      │
 │  │  │                            │  │                │                      │
 │  │  │  pre_call:  prompt scan    │  │                │                      │
 │  │  │  post_call: response scan  │  │                │                      │
@@ -168,30 +172,32 @@ and plugins (read/write via gateway REST API).
 | Block/allow lists | CLI | Gateway (admission gate) |
 | Skill inventory (AIBOM) | CLI | Gateway, plugins, TUI |
 
-### 5. LLM Guardrail (Fetch Interceptor + Go Proxy)
+### 5. LLM Guardrail (Connector Architecture + Go Proxy)
 
-The guardrail intercepts all LLM traffic between OpenClaw and upstream
-providers. A TypeScript fetch interceptor plugin patches `globalThis.fetch`
-inside OpenClaw's Node.js process, routing all outbound LLM calls through
-the Go guardrail reverse proxy regardless of which provider the user selects.
+The guardrail intercepts all LLM traffic between agent frameworks and upstream
+providers using a **connector-based architecture**. Each framework has a
+dedicated Connector that translates its request format into a canonical
+`RoutingDecision` the proxy core processes uniformly.
 
 | Responsibility | Detail |
 |----------------|--------|
-| Universal interception | Fetch interceptor covers all 7 providers (Anthropic, OpenAI, Azure, Gemini, OpenRouter, Ollama, Bedrock) |
+| Multi-framework support | ConnectorRouter auto-detects framework: OpenClaw → ZeptoClaw → Generic |
+| Universal interception | OpenClaw: fetch interceptor covers 7 providers. ZeptoClaw: api_base redirect. Generic: any OpenAI-compatible client |
 | Prompt inspection | Scans every prompt for injection attacks, secrets, PII, data exfiltration patterns before it reaches the LLM |
 | Response inspection | Scans every LLM response for leaked secrets, tool call anomalies |
-| Multi-provider routing | Proxy routes to the correct upstream based on `X-DC-Target-URL` header set by the interceptor |
-| Auth separation | `X-AI-Auth` header carries the real provider key; `Authorization` carries the DefenseClaw gateway key |
+| Multi-provider routing | OpenClaw: `X-DC-Target-URL` header. ZeptoClaw/Generic: model-name prefix inference + config/defaults table |
+| Auth separation | Each connector handles auth extraction per framework convention |
 | Observe mode | Logs findings with colored output, never blocks (default, recommended to start) |
 | Action mode | Blocks prompts/responses that match security policies by raising exceptions |
-| Transparent proxy | No agent code changes required — the interceptor is invisible to OpenClaw |
+| Transparent proxy | No agent code changes required — connectors are invisible to frameworks |
+| Telemetry attribution | Each connector reports its name for per-framework metrics |
 
 **How it connects:**
 
-1. `defenseclaw setup guardrail` registers the plugin in `openclaw.json`
-2. On OpenClaw start, the fetch interceptor activates and patches `globalThis.fetch`
-3. All outbound LLM calls are routed through `localhost:4000` with auth headers injected
-4. The Go proxy inspects traffic, then forwards to the real upstream provider
+1. `defenseclaw setup guardrail [--claw openclaw|zeptoclaw]` configures the framework
+2. Sidecar builds ConnectorRouter from config (`buildConnectorRouter()` in `sidecar.go`)
+3. On request, ConnectorRouter auto-detects which connector handles it
+4. Connector produces RoutingDecision → proxy core inspects → forwards to upstream
 
 See `docs/GUARDRAIL.md` for the full data flow.
 
@@ -227,34 +233,36 @@ See `docs/GUARDRAIL.md` for the full data flow.
 ### LLM Traffic Inspection Flow
 
 ```
-  OpenClaw Agent       Fetch Interceptor       Guardrail Proxy        LLM Provider
-       │              (in-process plugin)     (localhost:4000)      (any provider)
-       │                      │                      │                    │
-       │  1. fetch(provider)  │                      │                    │
-       ├─────────────────────►│                      │                    │
-       │                      │                      │                    │
-       │               2. Redirect to localhost      │                    │
-       │                  + X-AI-Auth (provider key) │                    │
-       │                  + X-DC-Target-URL           │                    │
-       │                      ├─────────────────────►│                    │
-       │                      │                      │                    │
-       │                      │  3. pre_call scan    │                    │
-       │                      │     (injection,      │                    │
-       │                      │      secrets, PII)   │                    │
-       │                      │                      │                    │
-       │                      │  [action: block]     │                    │
-       │                      │                      │                    │
-       │                      │                      │  4. Forward        │
-       │                      │                      ├───────────────────►│
-       │                      │                      │◄───────────────────┤
-       │                      │                      │                    │
-       │                      │  5. post_call scan   │                    │
-       │                      │     (leaked secrets, │                    │
-       │                      │      tool anomalies) │                    │
-       │                      │                      │                    │
-       │  6. Response         │◄─────────────────────┤                    │
-       │◄─────────────────────┤                      │                    │
-       │                      │                      │                    │
+  Agent Framework    ConnectorRouter          Proxy Core           LLM Provider
+  (OpenClaw /       (auto-detect)           (inspect+forward)    (any provider)
+   ZeptoClaw / …)         │                      │                    │
+       │                  │                      │                    │
+       │  POST /v1/...   │                      │                    │
+       ├─────────────────►│                      │                    │
+       │                  │                      │                    │
+       │           1. Detect connector           │                    │
+       │           2. Authenticate               │                    │
+       │           3. Route → RoutingDecision    │                    │
+       │                  │                      │                    │
+       │                  ├─────────────────────►│                    │
+       │                  │                      │                    │
+       │                  │  4. pre_call scan    │                    │
+       │                  │     (injection,      │                    │
+       │                  │      secrets, PII)   │                    │
+       │                  │                      │                    │
+       │                  │  [action: block]     │                    │
+       │                  │                      │                    │
+       │                  │                      │  5. Forward        │
+       │                  │                      ├───────────────────►│
+       │                  │                      │◄───────────────────┤
+       │                  │                      │                    │
+       │                  │  6. post_call scan   │                    │
+       │                  │     (leaked secrets, │                    │
+       │                  │      tool anomalies) │                    │
+       │                  │                      │                    │
+       │  7. Response     │◄─────────────────────┤                    │
+       │◄─────────────────┤                      │                    │
+       │                  │                      │                    │
 ```
 
 ### Admission Gate
@@ -279,9 +287,9 @@ Allow list? ──YES──▶ skip scan, install, log to DB, audit event
 
 ## Claw Mode
 
-DefenseClaw supports multiple agent frameworks ("claw modes"). Currently only
-**OpenClaw** is supported; additional frameworks will be added soon. The active
-mode is set in `~/.defenseclaw/config.yaml`:
+DefenseClaw supports multiple agent frameworks ("claw modes"). Currently
+**OpenClaw** and **ZeptoClaw** are supported; additional frameworks will be
+added via connectors. The active mode is set in `~/.defenseclaw/config.yaml`:
 
 ```yaml
 claw:
@@ -292,6 +300,29 @@ claw:
 All skill and MCP directory resolution, watcher paths, scan targets, and install
 candidate lookups derive from the active claw mode. Adding a new framework
 requires only a new case in `internal/config/claw.go`.
+
+### Guardrail Connectors
+
+The LLM guardrail uses a separate **connector system** that runs independently
+of claw mode. Multiple connectors can be active simultaneously on the same
+proxy port:
+
+```yaml
+guardrail:
+  connectors:
+    openclaw:
+      enabled: true           # default: true (backward compatible)
+    zeptoclaw:
+      enabled: false          # enabled via: defenseclaw setup guardrail --claw zeptoclaw
+      providers:
+        openai:
+          upstream_url: https://api.openai.com
+          auth_header: Authorization
+          auth_scheme: Bearer
+```
+
+Both OpenClaw and ZeptoClaw agents can use the same guardrail proxy
+simultaneously — the ConnectorRouter detects the framework per-request.
 
 ### OpenClaw Skill Resolution Order
 
@@ -317,10 +348,16 @@ requires only a new case in `internal/config/claw.go`.
                         │   runs       │               ┌──────────────┐
                         │   ──────────────────────────▶│  Guardrail   │
                         └──────────────┘               │  Proxy       │
-                                                       │  + Guardrail │
+                                                       │  + Connector │
+                                                       │    Router    │
                                                        └──────┬───────┘
                                                               │
-                                                              ▼
-                                                       LLM Provider
-                                                    (Anthropic, OpenAI…)
+                                          ┌───────────────────┤
+                                          │                   │
+                                          ▼                   ▼
+                                   ┌──────────────┐   ┌──────────────┐
+                                   │  ZeptoClaw   │   │  LLM Provider│
+                                   │  (Rust)      │   │  (Anthropic, │
+                                   └──────────────┘   │   OpenAI…)   │
+                                                      └──────────────┘
 ```

--- a/docs/CONFIG_FILES.md
+++ b/docs/CONFIG_FILES.md
@@ -16,8 +16,14 @@ USER runs: defenseclaw setup guardrail
 
 GO SIDECAR boots: reads config.yaml once
   │
-  ├─ Runs guardrail proxy (goroutine; internal/gateway/sidecar.go:352–375):
+  ├─ Builds ConnectorRouter from guardrail.connectors.* config
+  │    ├─ OpenClaw connector (if connectors.openclaw.enabled)
+  │    ├─ ZeptoClaw connector (if connectors.zeptoclaw.enabled)
+  │    └─ Generic connector (always, as fallback)
+  │
+  ├─ Runs guardrail proxy (goroutine; internal/gateway/sidecar.go):
   │    ├─ Loads guardrail.* and cisco_ai_defense.* from in-memory config
+  │    ├─ Receives ConnectorRouter for multi-framework request detection
   │    ├─ Resolves API keys via ~/.defenseclaw/.env (ResolveAPIKey + loadDotEnv)
   │    └─ Listens on guardrail.port for OpenAI-compatible traffic
   │
@@ -96,6 +102,69 @@ Example contents:
 | **Path derivation (writer)** | `filepath.Join(a.scannerCfg.DataDir, "guardrail_runtime.json")` — uses `DataDir` from Go config. |
 | **Path derivation (reader)** | `filepath.Join(p.dataDir, "guardrail_runtime.json")` — `dataDir` from sidecar config (`internal/gateway/proxy.go:559`). |
 | **Caveat** | The PATCH handler updates the in-memory Go config but does **not** call `cfg.Save()`, so `config.yaml` drifts out of sync after a PATCH. |
+
+---
+
+## Connector Configuration
+
+The guardrail proxy uses a connector-based architecture to support multiple
+agent frameworks. Connector config is under `guardrail.connectors` in
+`config.yaml`.
+
+### `guardrail.connectors.openclaw`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable OpenClaw connector (backward compatible default) |
+| `token_env` | string | `OPENCLAW_GATEWAY_TOKEN` | Env var name for the gateway auth token |
+
+### `guardrail.connectors.zeptoclaw`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable ZeptoClaw connector (must be explicitly enabled via setup) |
+| `token_env` | string | `""` | Env var name for the proxy auth token |
+| `providers` | map | `{}` | Map of provider name → upstream connection details |
+
+Each entry in `providers` has:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `upstream_url` | string | Real upstream URL (e.g. `https://api.openai.com`) |
+| `auth_header` | string | Header name for upstream auth (`Authorization`, `x-api-key`, `api-key`) |
+| `auth_scheme` | string | Auth prefix (`Bearer` or `""` for bare key) |
+
+Example config:
+
+```yaml
+guardrail:
+  connectors:
+    openclaw:
+      enabled: true
+      token_env: OPENCLAW_GATEWAY_TOKEN
+    zeptoclaw:
+      enabled: true
+      token_env: ""
+      providers:
+        openai:
+          upstream_url: https://api.openai.com
+          auth_header: Authorization
+          auth_scheme: Bearer
+        anthropic:
+          upstream_url: https://api.anthropic.com
+          auth_header: x-api-key
+          auth_scheme: ""
+        openrouter:
+          upstream_url: https://openrouter.ai/api/v1
+          auth_header: Authorization
+          auth_scheme: Bearer
+```
+
+| | |
+|---|---|
+| **Created by** | `defenseclaw setup guardrail --claw zeptoclaw` populates ZeptoClaw providers from `~/.zeptoclaw/config.json`. OpenClaw defaults are set by `DefaultConnectorsConfig()` in `internal/config/connectors.go`. |
+| **Read by** | **Go sidecar** `buildConnectorRouter()` (`internal/gateway/sidecar.go`) — builds `ConnectorRouter` from these settings at startup. |
+| **Defaults** | OpenClaw enabled with `OPENCLAW_GATEWAY_TOKEN`; ZeptoClaw disabled. If ZeptoClaw is enabled but a provider is missing from the config map, the connector falls back to the embedded default table (`internal/gateway/connector/zeptoclaw_defaults.go` — 19 providers). |
 
 ---
 

--- a/docs/GUARDRAIL.md
+++ b/docs/GUARDRAIL.md
@@ -1,30 +1,91 @@
 # LLM Guardrail — Data Flow & Architecture
 
-The LLM guardrail intercepts all traffic between OpenClaw and LLM providers.
-It combines a TypeScript fetch interceptor plugin (running inside OpenClaw's
-Node.js process) with a Go guardrail reverse proxy
-(`internal/gateway/proxy.go`, `internal/gateway/guardrail.go`) to inspect
-every prompt and response without requiring any changes to OpenClaw or agent
-code.
+The LLM guardrail intercepts all traffic between agent frameworks and LLM
+providers. It uses a **connector-based architecture** where each agent
+framework (OpenClaw, ZeptoClaw, future frameworks) has a dedicated Connector
+that translates its request format into a canonical `RoutingDecision` the
+proxy core processes uniformly.
 
-## Why a Fetch Interceptor + Proxy?
+The Go guardrail reverse proxy (`internal/gateway/proxy.go`,
+`internal/gateway/guardrail.go`) inspects every prompt and response without
+requiring changes to agent code.
+
+## Connector Architecture
+
+```
+                    +----------------------------------+
+                    |   Agent Framework                |
+                    |  (OpenClaw / ZeptoClaw / Future) |
+                    +---------------+------------------+
+                                    | HTTP POST
+                                    v
+                    +----------------------------------+
+                    |   GuardrailProxy HTTP Server      |
+                    +---------------+------------------+
+                                    |
+                           +--------v--------+
+                           | ConnectorRouter  |
+                           | (auto-detect)    |
+                           +--------+--------+
+                            /       |        \
+                  +---------+ +-----+-----+ +----------+
+                  | OpenClaw| | ZeptoClaw | | Generic  |
+                  |Connector| | Connector | |Connector |
+                  +---------+ +-----------+ +----------+
+                         \        |        /
+                          +-------v------+
+                          |RoutingDecision|  (canonical form)
+                          +-------+------+
+                                  |
+                  +---------------v----------------+
+                  |         Proxy Core              |
+                  | 1. Inspect input (rules/judge)  |
+                  | 2. Resolve LLMProvider adapter   |
+                  | 3. Forward to upstream          |
+                  | 4. Inspect output               |
+                  | 5. Return response              |
+                  +--------------------------------+
+```
+
+**Detection order**: OpenClaw (has `X-DC-Target-URL`) → ZeptoClaw (has `X-ZC-Provider` or standard auth without `X-DC-Target-URL`) → Generic (fallback).
+
+### Connector Interface
+
+Each connector implements (`internal/gateway/connector/connector.go`):
+
+| Method | Purpose |
+|--------|---------|
+| `Name()` | Canonical name for telemetry (`"openclaw"`, `"zeptoclaw"`, `"generic"`) |
+| `Detect(r)` | Does this request belong to this connector? First match wins |
+| `Authenticate(r)` | Is the request authorized? (token, master key, or loopback trust) |
+| `Route(r, body)` | Produce a `RoutingDecision` with upstream URL, provider, API key, etc. |
+
+### RoutingDecision (canonical form)
+
+Every connector produces a `RoutingDecision` containing:
+- `UpstreamURL` — full upstream URL (e.g. `https://api.openai.com/v1/chat/completions`)
+- `ProviderName` — canonical name: `"openai"`, `"anthropic"`, `"azure"`, etc.
+- `APIKey`, `AuthHeader`, `AuthScheme` — upstream auth details
+- `Model`, `Stream`, `RawBody` — request metadata
+- `PassthroughMode` — forward verbatim (provider-native paths like Anthropic `/v1/messages`)
+- `ExtraUpstreamHeaders` — additional headers (e.g., `anthropic-version`)
+- `ConnectorName` — source connector for telemetry attribution
+
+## OpenClaw Connector
+
+**File**: `internal/gateway/connector/openclaw.go`
+
+Uses the TypeScript fetch interceptor plugin (running inside OpenClaw's
+Node.js process) that patches `globalThis.fetch`, routing all outbound LLM
+calls through `localhost:4000`.
+
+### Why a Fetch Interceptor?
 
 OpenClaw's `message_sending` plugin hook is broken (issue #26422) — outbound
 messages never fire, making plugin-only interception impossible for LLM
 responses. Additionally, configuring a single proxy provider in
 `openclaw.json` only covers one model — switching to any other provider
-(Anthropic, Azure, Ollama, etc.) in OpenClaw's UI bypasses the proxy
-entirely.
-
-The solution is two-layered:
-
-1. **Fetch interceptor** (`plugins/defenseclaw/fetch-interceptor.ts`) —
-   patches `globalThis.fetch` inside OpenClaw's Node.js process, routing
-   **all** outbound LLM calls through `localhost:4000` regardless of which
-   provider the user selects.
-2. **Guardrail proxy** (`internal/gateway/proxy.go`) — inspects the
-   intercepted traffic, runs pre-call and post-call scanning, and forwards
-   to the real upstream provider.
+bypasses the proxy entirely.
 
 ### Auth Design (three-header contract)
 
@@ -44,6 +105,12 @@ X-DC-Auth:       Bearer <sidecar-token>     ← proxy authorization token
 - AWS SigV4 — Bedrock (multiple headers, pass-through)
 - No auth — Ollama
 
+| Aspect | Implementation |
+|--------|---------------|
+| **Detect** | `X-DC-Target-URL` header present |
+| **Authenticate** | `X-DC-Auth` token → master key (`sk-dc-*`) → loopback trust → open proxy |
+| **Route** | Extract `X-DC-Target-URL` → upstream URL, `X-AI-Auth` → API key, infer provider from URL domain via `providers.json`, SSRF check |
+
 ### Providers Covered
 
 | Provider | Interception | Format |
@@ -56,9 +123,83 @@ X-DC-Auth:       Bearer <sidecar-token>     ← proxy authorization token
 | Ollama | localhost:11434 | Pass-through (no key needed) |
 | Bedrock | *.amazonaws.com | AWS SigV4 pass-through |
 
+## ZeptoClaw Connector
+
+**File**: `internal/gateway/connector/zeptoclaw.go`
+
+Handles requests from ZeptoClaw, a Rust-based agent framework that sends
+standard HTTP with no DefenseClaw-specific headers. ZeptoClaw's `api_base`
+config is patched to redirect traffic through the proxy.
+
+| Aspect | Implementation |
+|--------|---------------|
+| **Detect** | `X-ZC-Provider` header present, OR (`X-DC-Target-URL` absent AND standard auth header present) |
+| **Authenticate** | `X-DC-Auth` token → master key → loopback trust → open proxy |
+| **Route** | Resolve provider from `X-ZC-Provider` → model prefix inference → `provider/model` format. Upstream URL from `X-ZC-Upstream` → config map → embedded defaults table |
+
+### Provider Inference from Model Name
+
+```
+"gpt-4o"                    → openai
+"claude-sonnet-4-20250514"  → anthropic
+"gemini-1.5-pro"            → gemini
+"anthropic/claude-3-haiku"  → anthropic (explicit prefix)
+"command-r-plus"            → cohere
+"deepseek-chat"             → deepseek
+```
+
+### Upstream URL Resolution
+
+Since ZeptoClaw replaces the real URL with `api_base: "http://127.0.0.1:4000"`,
+the connector reconstructs the original upstream:
+
+1. `X-ZC-Upstream` header (if ZeptoClaw sends it — optional)
+2. Config `providers` map (populated by `defenseclaw setup guardrail --claw zeptoclaw`)
+3. Embedded default table (`zeptoclaw_defaults.go` — 19 providers)
+
+### Embedded Default Provider Table
+
+Mirrored from ZeptoClaw's `PROVIDER_REGISTRY` — covers OpenAI, Anthropic,
+OpenRouter, Groq, Gemini, Ollama, NVIDIA, DeepSeek, Azure, Bedrock, xAI,
+and more. See `internal/gateway/connector/zeptoclaw_defaults.go`.
+
+## Generic / Fallback Connector
+
+**File**: `internal/gateway/connector/generic.go`
+
+Same model-based provider inference as ZeptoClaw but with relaxed auth
+(always authenticates). Serves as fallback for curl testing, future
+frameworks, or any OpenAI-compatible client.
+
 ## Data Flow
 
-### Fetch Interceptor Flow
+### Connector Router Flow
+
+```
+ ┌──────────────┐     ┌─────────────────────┐     ┌────────────────────┐     ┌──────────────┐
+ │  Agent        │     │  ConnectorRouter    │     │   Proxy Core       │     │  LLM Provider│
+ │  Framework    │     │  (auto-detect)      │     │  (inspect+forward) │     │              │
+ └──────┬───────┘     └──────────┬──────────┘     └──────────┬─────────┘     └──────┬───────┘
+        │                        │                           │                      │
+        │  POST /v1/chat/...     │                           │                      │
+        ├───────────────────────►│                           │                      │
+        │                        │                           │                      │
+        │                  Detect: which connector?          │                      │
+        │                  Authenticate: authorized?         │                      │
+        │                  Route: → RoutingDecision          │                      │
+        │                        │                           │                      │
+        │                        ├──────────────────────────►│                      │
+        │                        │                           │                      │
+        │                        │            PRE-CALL scan  │                      │
+        │                        │                           ├─────────────────────►│
+        │                        │                           │◄─────────────────────┤
+        │                        │            POST-CALL scan │                      │
+        │                        │                           │                      │
+        │  Response              │◄──────────────────────────┤                      │
+        │◄───────────────────────┤                           │                      │
+```
+
+### OpenClaw Fetch Interceptor Flow
 
 ```
  ┌──────────────┐     ┌─────────────────────┐     ┌────────────────────┐     ┌──────────────┐
@@ -74,6 +215,8 @@ X-DC-Auth:       Bearer <sidecar-token>     ← proxy authorization token
         │                        │  + adds X-DC-Target-URL   │                      │
         │                        ├──────────────────────────►│                      │
         │                        │                           │                      │
+        │                        │     OpenClaw connector    │                      │
+        │                        │     detects + routes      │                      │
         │                        │            PRE-CALL scan  │                      │
         │                        │                           ├─────────────────────►│
         │                        │                           │◄─────────────────────┤
@@ -81,6 +224,33 @@ X-DC-Auth:       Bearer <sidecar-token>     ← proxy authorization token
         │                        │                           │                      │
         │  Response              │◄──────────────────────────┤                      │
         │◄───────────────────────┤                           │                      │
+```
+
+### ZeptoClaw Flow
+
+```
+ ┌──────────────┐                ┌────────────────────┐     ┌──────────────┐
+ │   ZeptoClaw   │                │   Guardrail Proxy  │     │  LLM Provider│
+ │   Agent       │                │  (localhost:4000)  │     │              │
+ └──────┬───────┘                └──────────┬─────────┘     └──────┬───────┘
+        │                                   │                      │
+        │  POST /v1/chat/completions        │                      │
+        │  Authorization: Bearer sk-key     │                      │
+        │  (api_base patched to proxy)      │                      │
+        ├──────────────────────────────────►│                      │
+        │                                   │                      │
+        │                  ZeptoClaw connector detects              │
+        │                  Infers provider from model name         │
+        │                  Resolves upstream from config/defaults  │
+        │                  → RoutingDecision                       │
+        │                                   │                      │
+        │                     PRE-CALL scan │                      │
+        │                                   ├─────────────────────►│
+        │                                   │◄─────────────────────┤
+        │                    POST-CALL scan │                      │
+        │                                   │                      │
+        │  Response                         │                      │
+        │◄──────────────────────────────────┤                      │
 ```
 
 ### Normal Request (observe mode, clean)
@@ -202,7 +372,8 @@ X-DC-Auth:       Bearer <sidecar-token>     ← proxy authorization token
 │                                                                     │
 │  Owns:                                                              │
 │  ├── guardrail proxy process (start, monitor health, restart)        │
-│  ├── Config: guardrail.enabled, mode, port, model                  │
+│  ├── Config: guardrail.enabled, mode, port, connectors             │
+│  ├── Builds ConnectorRouter from config (sidecar.go:buildConnectorRouter) │
 │  ├── Loads guardrail.* from config; proxy hot-reloads mode from guardrail_runtime.json │
 │  └── Health tracking: guardrail subsystem state                    │
 │                                                                     │
@@ -212,13 +383,32 @@ X-DC-Auth:       Bearer <sidecar-token>     ← proxy authorization token
 └─────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────┐
-│                     Guardrail Proxy (Go)                            │
+│                 ConnectorRouter + Connectors (Go)                    │
+│                 internal/gateway/connector/                          │
 │                                                                     │
 │  Owns:                                                              │
-│  ├── Model routing (config.yaml)                                   │
-│  ├── API key management (reads from env var)                       │
+│  ├── Framework detection (ordered: OpenClaw → ZeptoClaw → Generic)  │
+│  ├── Request authentication (token, master key, loopback trust)    │
+│  ├── Routing decision (upstream URL, provider, API key, auth)       │
+│  ├── Provider inference from URL domain (OpenClaw) or model name   │
+│  │   (ZeptoClaw/Generic)                                            │
+│  ├── Embedded default provider URL table (19 providers)            │
+│  ├── SSRF protection (IsKnownProviderDomain)                       │
+│  └── Telemetry attribution via ConnectorName                       │
+│                                                                     │
+│  Does NOT:                                                          │
+│  ├── Inspect LLM content (proxy core handles inspection)           │
+│  └── Forward requests (proxy core handles upstream communication)  │
+└─────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────┐
+│                     Guardrail Proxy Core (Go)                       │
+│                                                                     │
+│  Owns:                                                              │
+│  ├── Receives RoutingDecision from connector and processes it       │
 │  ├── Protocol translation (OpenAI ↔ Anthropic/Google/etc.)         │
-│  └── Inspection pipeline + upstream LLM forwarding                 │
+│  ├── Inspection pipeline + upstream LLM forwarding                 │
+│  └── Falls back to legacy auth when no ConnectorRouter is set      │
 │                                                                     │
 │  Does NOT:                                                          │
 │  ├── Load its own YAML (receives config from sidecar / NewGuardrailProxy) │
@@ -249,14 +439,16 @@ X-DC-Auth:       Bearer <sidecar-token>     ← proxy authorization token
 │                                                                     │
 │  Owns:                                                              │
 │  ├── `defenseclaw init` — seeds config, policies, optional guardrail setup │
-│  ├── `defenseclaw setup guardrail` — config wizard (plugin-only, no model changes) │
+│  ├── `defenseclaw setup guardrail [--claw openclaw|zeptoclaw]`     │
+│  │   OpenClaw: plugin install + openclaw.json patching             │
+│  │   ZeptoClaw: api_base patching + provider config population     │
 │  ├── `defenseclaw upgrade` — in-place upgrade with backup/restore  │
-│  ├── openclaw.json patching (plugin registration only)             │
-│  └── openclaw.json revert + plugin uninstall on --disable          │
+│  └── --disable: revert patched configs + uninstall plugins         │
 └─────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────┐
 │                 Fetch Interceptor Plugin (TypeScript)                │
+│                 (OpenClaw only)                                      │
 │                                                                     │
 │  Owns:                                                              │
 │  ├── Patches globalThis.fetch inside OpenClaw's Node.js process    │
@@ -337,18 +529,11 @@ internal/gateway/
 
 ## Setup Flow
 
+### OpenClaw Setup (default)
+
 ```
 ┌──────────────────────────────────────────────────────────────────┐
-│  defenseclaw init                                                │
-│                                                                  │
-│  1. Install uv (if needed)                                      │
-│  2. Install scanners (skill-scanner, mcp-scanner, aibom)        │
-│  3. Configure guardrail proxy (Go binary)                       │
-└──────────────────────────┬───────────────────────────────────────┘
-                           │
-                           ▼
-┌──────────────────────────────────────────────────────────────────┐
-│  defenseclaw setup guardrail                                     │
+│  defenseclaw setup guardrail [--claw openclaw]                   │
 │                                                                  │
 │  Interactive wizard:                                             │
 │  1. Enable guardrail? → yes                                     │
@@ -359,26 +544,11 @@ internal/gateway/
 │  provider detection and key injection automatically.            │
 │                                                                  │
 │  Generates:                                                      │
-│  ├── ~/.defenseclaw/config.yaml (guardrail section)             │
+│  ├── ~/.defenseclaw/config.yaml (guardrail section + connectors)│
+│  ├── Sets connectors.openclaw.enabled = true                    │
 │  └── Patches ~/.openclaw/openclaw.json                          │
 │      ├── Registers defenseclaw in plugins.allow                 │
 │      └── Enables plugin entry (fetch interceptor loads on start)│
-└──────────────────────────┬───────────────────────────────────────┘
-                           │
-                           ▼
-┌──────────────────────────────────────────────────────────────────┐
-│  defenseclaw-gateway  (or: defenseclaw sidecar)                  │
-│                                                                  │
-│  Starts all subsystems:                                          │
-│  1. Gateway WS connection loop                                   │
-│  2. Skill/MCP watcher                                           │
-│  3. REST API server                                              │
-│  4. Spawns and supervises guardrail proxy (if enabled)          │
-│     ├── Locates guardrail binary                                │
-│     ├── Verifies guardrail settings in config.yaml              │
-│     ├── Starts guardrail proxy with mode + scanner env vars     │
-│     ├── Polls /health/liveliness until 200                      │
-│     └── Restarts on crash (exponential backoff)                 │
 └──────────────────────────────────────────────────────────────────┘
 
 When OpenClaw starts, the fetch interceptor plugin activates and routes
@@ -386,14 +556,66 @@ all outbound LLM calls through the guardrail proxy — regardless of
 which provider the user selects in the UI.
 ```
 
+### ZeptoClaw Setup
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  defenseclaw setup guardrail --claw zeptoclaw                    │
+│                                                                  │
+│  1. Read ~/.zeptoclaw/config.json (discover providers)           │
+│  2. Save original provider configs to                           │
+│     ~/.defenseclaw/zeptoclaw_original_providers.json            │
+│  3. Patch api_base for each provider to                         │
+│     http://127.0.0.1:4000/v1                                   │
+│  4. Write connector config to config.yaml:                       │
+│     connectors.zeptoclaw.enabled = true                          │
+│     connectors.zeptoclaw.providers = {provider → upstream map}  │
+│  5. Restart ZeptoClaw (picks up new api_base)                   │
+└──────────────────────────────────────────────────────────────────┘
+
+No plugin install needed — ZeptoClaw uses api_base redirect, which is
+simpler and less invasive than a fetch interceptor.
+```
+
+### Sidecar Startup (both connectors)
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  defenseclaw-gateway  (or: defenseclaw sidecar)                  │
+│                                                                  │
+│  Starts all subsystems:                                          │
+│  1. Gateway WS connection loop                                   │
+│  2. Skill/MCP watcher                                           │
+│  3. REST API server                                              │
+│  4. Builds ConnectorRouter from config:                          │
+│     ├── If connectors.openclaw.enabled → add OpenClawConnector  │
+│     ├── If connectors.zeptoclaw.enabled → add ZeptoClawConnector│
+│     └── Always set GenericConnector as fallback                 │
+│  5. Spawns guardrail proxy with ConnectorRouter (if enabled)    │
+│     ├── Verifies guardrail settings in config.yaml              │
+│     ├── Starts proxy with mode + scanner env vars               │
+│     ├── Polls /health/liveliness until 200                      │
+│     └── Restarts on crash (exponential backoff)                 │
+└──────────────────────────────────────────────────────────────────┘
+```
+
 ## Teardown
 
 ```
+# OpenClaw teardown (default)
 defenseclaw setup guardrail --disable
+defenseclaw setup guardrail --claw openclaw --disable
   1. Remove defenseclaw plugin entries from openclaw.json
   2. Uninstall plugin from ~/.openclaw/extensions/defenseclaw/
-  3. Set guardrail.enabled = false in config.yaml
+  3. Set connectors.openclaw.enabled = false in config.yaml
   4. Restart OpenClaw gateway (fetch interceptor unloads)
+
+# ZeptoClaw teardown
+defenseclaw setup guardrail --claw zeptoclaw --disable
+  1. Read ~/.defenseclaw/zeptoclaw_original_providers.json
+  2. Restore original api_base values in ~/.zeptoclaw/config.json
+  3. Set connectors.zeptoclaw.enabled = false in config.yaml
+  4. Restart ZeptoClaw (restores direct provider access)
 ```
 
 ## Upgrade
@@ -633,15 +855,24 @@ extensions/defenseclaw/src/
   sidecar-config.ts                 # Reads guardrail.port from config
 
 internal/config/
-  config.go                         # GuardrailConfig + CiscoAIDefenseConfig Go structs
+  config.go                         # GuardrailConfig + CiscoAIDefenseConfig + ConnectorsConfig Go structs
+  connectors.go                     # ConnectorsConfig, OpenClawConnectorConfig, ZeptoClawConnectorConfig
 
 internal/policy/
   types.go                          # GuardrailInput / GuardrailOutput types
   engine.go                         # EvaluateGuardrail method
 
 internal/gateway/
+  connector/                        # Connector architecture (NEW)
+    connector.go                    # Connector interface + RoutingDecision struct
+    router.go                       # ConnectorRouter — ordered detection, first match wins
+    openclaw.go                     # OpenClaw connector (X-DC-Target-URL + fetch interceptor)
+    zeptoclaw.go                    # ZeptoClaw connector (model inference + api_base redirect)
+    zeptoclaw_defaults.go           # Embedded default provider table (19 providers)
+    generic.go                      # Generic fallback connector (curl, future frameworks)
+    helpers.go                      # InferProviderFromURL, IsKnownProviderDomain, ExtractAPIKey, IsLoopback
   guardrail.go                      # GuardrailInspector — scanners + OPA finalize
-  proxy.go                          # GuardrailProxy — reverse proxy + passthrough + inspection
+  proxy.go                          # GuardrailProxy — connector-aware reverse proxy + inspection
   provider.go                       # Provider routing (splitModel, inferProvider)
   provider_openai.go                # OpenAI provider
   provider_anthropic.go             # Anthropic provider (passthrough /v1/messages)
@@ -649,14 +880,14 @@ internal/gateway/
   provider_gemini.go                # Gemini (native + OpenAI-compatible)
   provider_openrouter.go            # OpenRouter (attribution headers)
   api.go                            # POST /v1/guardrail/evaluate, /v1/guardrail/event
-  sidecar.go                        # runGuardrail() goroutine
+  sidecar.go                        # runGuardrail() + buildConnectorRouter()
   health.go                         # guardrail subsystem health tracking
 
 scripts/
   upgrade.sh                        # Shell-based upgrade (mirrors `defenseclaw upgrade`)
 
 ~/.defenseclaw/                     # runtime (generated, not in repo)
-  config.yaml                       # guardrail section (incl. scanner_mode, cisco_ai_defense)
+  config.yaml                       # guardrail section (incl. connectors, scanner_mode, cisco_ai_defense)
   backups/                          # timestamped upgrade backups
 ```
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -302,18 +302,19 @@ func (c *CiscoAIDefenseConfig) ResolvedAPIKey() string {
 }
 
 type GuardrailConfig struct {
-	Enabled       bool        `mapstructure:"enabled"        yaml:"enabled"`
-	Mode          string      `mapstructure:"mode"            yaml:"mode"`
-	ScannerMode   string      `mapstructure:"scanner_mode"    yaml:"scanner_mode"`
-	Host          string      `mapstructure:"host"             yaml:"host,omitempty"`
-	Port          int         `mapstructure:"port"            yaml:"port"`
-	Model         string      `mapstructure:"model"           yaml:"model"`
-	ModelName     string      `mapstructure:"model_name"      yaml:"model_name"`
-	APIKeyEnv     string      `mapstructure:"api_key_env"     yaml:"api_key_env"`
-	OriginalModel string      `mapstructure:"original_model"  yaml:"original_model"`
-	BlockMessage  string      `mapstructure:"block_message"   yaml:"block_message"`
-	APIBase       string      `mapstructure:"api_base"        yaml:"api_base"`
-	Judge         JudgeConfig `mapstructure:"judge"           yaml:"judge"`
+	Enabled       bool             `mapstructure:"enabled"        yaml:"enabled"`
+	Mode          string           `mapstructure:"mode"            yaml:"mode"`
+	ScannerMode   string           `mapstructure:"scanner_mode"    yaml:"scanner_mode"`
+	Host          string           `mapstructure:"host"             yaml:"host,omitempty"`
+	Port          int              `mapstructure:"port"            yaml:"port"`
+	Model         string           `mapstructure:"model"           yaml:"model"`
+	ModelName     string           `mapstructure:"model_name"      yaml:"model_name"`
+	APIKeyEnv     string           `mapstructure:"api_key_env"     yaml:"api_key_env"`
+	OriginalModel string           `mapstructure:"original_model"  yaml:"original_model"`
+	BlockMessage  string           `mapstructure:"block_message"   yaml:"block_message"`
+	APIBase       string           `mapstructure:"api_base"        yaml:"api_base"`
+	Judge         JudgeConfig      `mapstructure:"judge"           yaml:"judge"`
+	Connectors    ConnectorsConfig `mapstructure:"connectors"      yaml:"connectors"`
 }
 
 // JudgeConfig controls the LLM-as-a-Judge guardrail scanners that use
@@ -675,6 +676,11 @@ func setDefaults(dataDir string) {
 	viper.SetDefault("guardrail.judge.pii_prompt", true)
 	viper.SetDefault("guardrail.judge.pii_completion", true)
 	viper.SetDefault("guardrail.judge.timeout", 30.0)
+
+	// Connector defaults: OpenClaw enabled (backward compat), ZeptoClaw disabled.
+	viper.SetDefault("guardrail.connectors.openclaw.enabled", true)
+	viper.SetDefault("guardrail.connectors.openclaw.token_env", "OPENCLAW_GATEWAY_TOKEN")
+	viper.SetDefault("guardrail.connectors.zeptoclaw.enabled", false)
 
 	viper.SetDefault("gateway.host", "127.0.0.1")
 	viper.SetDefault("gateway.port", 18789)

--- a/internal/config/connectors.go
+++ b/internal/config/connectors.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+// ConnectorsConfig holds configuration for each agent framework connector.
+type ConnectorsConfig struct {
+	OpenClaw  OpenClawConnectorConfig  `mapstructure:"openclaw"  yaml:"openclaw"`
+	ZeptoClaw ZeptoClawConnectorConfig `mapstructure:"zeptoclaw" yaml:"zeptoclaw"`
+}
+
+// OpenClawConnectorConfig configures the OpenClaw connector.
+type OpenClawConnectorConfig struct {
+	// Enabled controls whether the OpenClaw connector is active.
+	// Default: true (backward compatible with existing deployments).
+	Enabled bool `mapstructure:"enabled" yaml:"enabled"`
+	// TokenEnv is the environment variable name for the gateway token.
+	// Default: OPENCLAW_GATEWAY_TOKEN.
+	TokenEnv string `mapstructure:"token_env" yaml:"token_env"`
+}
+
+// ZeptoClawConnectorConfig configures the ZeptoClaw connector.
+type ZeptoClawConnectorConfig struct {
+	// Enabled controls whether the ZeptoClaw connector is active.
+	// Default: false (must be explicitly enabled via setup).
+	Enabled bool `mapstructure:"enabled" yaml:"enabled"`
+	// TokenEnv is the environment variable name for the proxy auth token.
+	TokenEnv string `mapstructure:"token_env" yaml:"token_env"`
+	// Providers maps provider name to upstream connection details.
+	// Populated by `defenseclaw setup guardrail --claw zeptoclaw`.
+	Providers map[string]ZCProviderConfig `mapstructure:"providers" yaml:"providers"`
+}
+
+// ZCProviderConfig describes a single upstream LLM provider for ZeptoClaw.
+type ZCProviderConfig struct {
+	UpstreamURL string `mapstructure:"upstream_url" yaml:"upstream_url"`
+	AuthHeader  string `mapstructure:"auth_header"  yaml:"auth_header"`
+	AuthScheme  string `mapstructure:"auth_scheme"  yaml:"auth_scheme"`
+}
+
+// DefaultConnectorsConfig returns the default connector configuration.
+// OpenClaw is enabled by default for backward compatibility; ZeptoClaw
+// is disabled until explicitly enabled.
+func DefaultConnectorsConfig() ConnectorsConfig {
+	return ConnectorsConfig{
+		OpenClaw: OpenClawConnectorConfig{
+			Enabled:  true,
+			TokenEnv: "OPENCLAW_GATEWAY_TOKEN",
+		},
+		ZeptoClaw: ZeptoClawConnectorConfig{
+			Enabled: false,
+		},
+	}
+}

--- a/internal/gateway/connector/connector.go
+++ b/internal/gateway/connector/connector.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package connector defines the Connector interface and RoutingDecision type
+// that allow the guardrail proxy to support multiple agent frameworks
+// (OpenClaw, ZeptoClaw, future frameworks) through a single HTTP server.
+//
+// Each Connector translates framework-specific HTTP requests into a canonical
+// RoutingDecision that the proxy core processes uniformly.
+package connector
+
+import (
+	"net/http"
+)
+
+// RoutingDecision is the canonical output every connector produces. It contains
+// everything the proxy core needs to forward the request to the upstream LLM
+// provider and inspect it.
+type RoutingDecision struct {
+	// UpstreamURL is the full upstream URL (e.g. https://api.openai.com/v1/chat/completions).
+	UpstreamURL string
+
+	// ProviderName is the canonical provider name: "openai", "anthropic", "azure", etc.
+	ProviderName string
+
+	// APIKey is the real upstream API key extracted from the request.
+	APIKey string
+
+	// AuthHeader is the header name for upstream auth ("Authorization", "x-api-key", "api-key").
+	AuthHeader string
+
+	// AuthScheme is the prefix for the auth value ("Bearer" or "" for bare key).
+	AuthScheme string
+
+	// Model is the resolved model ID from the request body.
+	Model string
+
+	// Stream indicates whether SSE streaming was requested.
+	Stream bool
+
+	// RawBody is the original request body bytes.
+	RawBody []byte
+
+	// PassthroughMode indicates the request should be forwarded verbatim
+	// (provider-native paths like /v1/messages for Anthropic).
+	PassthroughMode bool
+
+	// ExtraUpstreamHeaders are additional headers to set on the upstream request
+	// (e.g. anthropic-version, x-goog-api-key).
+	ExtraUpstreamHeaders map[string]string
+
+	// ConnectorName identifies which connector produced this decision
+	// ("openclaw", "zeptoclaw", "generic") — used for telemetry.
+	ConnectorName string
+}
+
+// Connector translates framework-specific HTTP requests into a RoutingDecision.
+// Each agent framework (OpenClaw, ZeptoClaw, etc.) has a dedicated Connector
+// implementation.
+type Connector interface {
+	// Name returns the connector identifier (e.g. "openclaw", "zeptoclaw", "generic").
+	Name() string
+
+	// Detect returns true if this connector should handle the given request.
+	// Connectors are checked in priority order; the first one returning true wins.
+	Detect(r *http.Request) bool
+
+	// Authenticate checks whether the request is authorized to use this connector.
+	// Returns true if authentication passes.
+	Authenticate(r *http.Request) bool
+
+	// Route extracts routing information from the request and produces a
+	// canonical RoutingDecision. The body parameter contains the already-read
+	// request body bytes.
+	Route(r *http.Request, body []byte) (*RoutingDecision, error)
+}

--- a/internal/gateway/connector/generic.go
+++ b/internal/gateway/connector/generic.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// GenericConnector is the fallback connector that handles requests from
+// any OpenAI-compatible client (curl, future frameworks, etc.).
+//
+// It uses the same provider resolution logic as ZeptoClaw (model prefix
+// inference) but with relaxed authentication: loopback is always allowed
+// regardless of gateway token configuration.
+type GenericConnector struct {
+	// providers maps provider name → upstream entry.
+	providers map[string]ZCProviderEntry
+}
+
+// NewGenericConnector creates a Generic fallback connector.
+// It reuses ZeptoClaw's provider defaults and config providers.
+func NewGenericConnector(providers map[string]ZCProviderEntry) *GenericConnector {
+	if providers == nil {
+		providers = make(map[string]ZCProviderEntry)
+	}
+	return &GenericConnector{
+		providers: providers,
+	}
+}
+
+func (c *GenericConnector) Name() string { return "generic" }
+
+// Detect always returns true — this is the fallback connector.
+func (c *GenericConnector) Detect(*http.Request) bool { return true }
+
+// Authenticate allows all loopback requests. Non-loopback requests are
+// also allowed (the generic connector is intentionally permissive for
+// development/testing use cases like curl).
+func (c *GenericConnector) Authenticate(r *http.Request) bool {
+	// Always allow loopback.
+	if IsLoopback(r) {
+		return true
+	}
+	// Allow non-loopback too — generic is permissive.
+	// Operators who want stricter auth should use a specific connector.
+	return true
+}
+
+// Route resolves the upstream URL using the same logic as ZeptoClaw:
+// model prefix inference → config map → default provider table.
+func (c *GenericConnector) Route(r *http.Request, body []byte) (*RoutingDecision, error) {
+	var partial struct {
+		Model  string `json:"model"`
+		Stream bool   `json:"stream"`
+	}
+	_ = json.Unmarshal(body, &partial)
+
+	providerName := InferProviderFromModel(partial.Model)
+	if providerName == "" {
+		return nil, fmt.Errorf("connector: generic: cannot determine provider from model %q", partial.Model)
+	}
+
+	entry, ok := c.providers[providerName]
+	if !ok {
+		entry, ok = ZeptoClawDefaultProviders[providerName]
+		if !ok {
+			return nil, fmt.Errorf("connector: generic: unknown provider %q", providerName)
+		}
+	}
+
+	apiKey, _, _ := ExtractAPIKey(r, "sk-dc-")
+
+	authHeader := entry.AuthHeader
+	authScheme := entry.AuthScheme
+	if authHeader == "" {
+		authHeader = "Authorization"
+		authScheme = "Bearer"
+	}
+
+	fullUpstreamURL := entry.UpstreamURL + r.URL.RequestURI()
+
+	return &RoutingDecision{
+		UpstreamURL:          fullUpstreamURL,
+		ProviderName:         providerName,
+		APIKey:               apiKey,
+		AuthHeader:           authHeader,
+		AuthScheme:           authScheme,
+		Model:                partial.Model,
+		Stream:               partial.Stream,
+		RawBody:              body,
+		PassthroughMode:      false,
+		ExtraUpstreamHeaders: make(map[string]string),
+		ConnectorName:        "generic",
+	}, nil
+}

--- a/internal/gateway/connector/generic_test.go
+++ b/internal/gateway/connector/generic_test.go
@@ -1,0 +1,70 @@
+package connector
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGenericDetect(t *testing.T) {
+	c := NewGenericConnector(nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	if !c.Detect(req) {
+		t.Error("Generic connector should always detect")
+	}
+}
+
+func TestGenericAuthenticate(t *testing.T) {
+	c := NewGenericConnector(nil)
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		want       bool
+	}{
+		{"loopback", "127.0.0.1:1234", true},
+		{"non-loopback", "192.168.1.1:1234", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if got := c.Authenticate(req); got != tt.want {
+				t.Errorf("Authenticate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenericRoute(t *testing.T) {
+	c := NewGenericConnector(nil)
+
+	t.Run("infer openai from model", func(t *testing.T) {
+		body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer sk-key")
+
+		decision, err := c.Route(req, []byte(body))
+		if err != nil {
+			t.Fatalf("Route() error: %v", err)
+		}
+		if decision.ProviderName != "openai" {
+			t.Errorf("ProviderName = %q, want openai", decision.ProviderName)
+		}
+		if decision.ConnectorName != "generic" {
+			t.Errorf("ConnectorName = %q, want generic", decision.ConnectorName)
+		}
+	})
+
+	t.Run("unknown model errors", func(t *testing.T) {
+		body := `{"model":"unknown-thing","messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer sk-key")
+
+		_, err := c.Route(req, []byte(body))
+		if err == nil {
+			t.Fatal("expected error for unknown model")
+		}
+	})
+}

--- a/internal/gateway/connector/helpers.go
+++ b/internal/gateway/connector/helpers.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/defenseclaw/defenseclaw/internal/configs"
+)
+
+// ProviderDomain maps a domain substring to a canonical provider name.
+type ProviderDomain struct {
+	Domain string
+	Name   string
+}
+
+// providerDomains is built once from the embedded providers.json.
+var providerDomains []ProviderDomain
+
+func init() {
+	cfg, err := configs.LoadProviders()
+	if err != nil {
+		panic("connector: failed to load embedded providers.json: " + err.Error())
+	}
+	for _, p := range cfg.Providers {
+		for _, d := range p.Domains {
+			providerDomains = append(providerDomains, ProviderDomain{Domain: d, Name: p.Name})
+		}
+	}
+}
+
+// InferProviderFromURL maps a target URL to a provider name by checking
+// domain substrings from the embedded providers.json.
+func InferProviderFromURL(targetURL string) string {
+	for _, pd := range providerDomains {
+		if strings.Contains(targetURL, pd.Domain) {
+			return pd.Name
+		}
+	}
+	return ""
+}
+
+// IsKnownProviderDomain returns true when the hostname of targetURL contains
+// a domain substring from the embedded providers.json list. Only the parsed
+// hostname is checked — query strings and path components are ignored to
+// prevent bypass via crafted URLs like https://evil.com/?foo=api.openai.com.
+func IsKnownProviderDomain(targetURL string) bool {
+	u, err := url.Parse(targetURL)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	for _, pd := range providerDomains {
+		if strings.Contains(host, pd.Domain) {
+			return true
+		}
+	}
+	return false
+}
+
+// ScrubURLSecrets removes sensitive query parameters (key, api-key, apikey,
+// token) from a URL string before logging. Returns the original string
+// unmodified when it contains no query string.
+func ScrubURLSecrets(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.RawQuery == "" {
+		return raw
+	}
+	q := u.Query()
+	for _, k := range []string{"key", "api-key", "apikey", "token"} {
+		if q.Has(k) {
+			q.Set(k, "REDACTED")
+		}
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+// ExtractAPIKey extracts the API key from the request headers, checking
+// multiple header patterns used by different providers:
+//   - X-AI-Auth: "Bearer <key>" (set by OpenClaw fetch interceptor)
+//   - Authorization: "Bearer <key>" (standard)
+//   - x-api-key: "<key>" (Anthropic)
+//   - api-key: "<key>" (Azure)
+//
+// The masterKeyPrefix parameter (e.g. "sk-dc-") is used to skip proxy
+// master keys that shouldn't be forwarded upstream.
+func ExtractAPIKey(r *http.Request, masterKeyPrefix string) (key string, headerName string, scheme string) {
+	// Priority 1: X-AI-Auth from the fetch interceptor.
+	if aiAuth := r.Header.Get("X-AI-Auth"); aiAuth != "" {
+		if strings.HasPrefix(aiAuth, "Bearer ") {
+			k := strings.TrimPrefix(aiAuth, "Bearer ")
+			if !strings.HasPrefix(k, masterKeyPrefix) {
+				return k, "Authorization", "Bearer"
+			}
+		}
+	}
+
+	// Priority 2: api-key (Azure).
+	if azKey := r.Header.Get("api-key"); azKey != "" {
+		return azKey, "api-key", ""
+	}
+
+	// Priority 3: x-api-key (Anthropic).
+	if xKey := r.Header.Get("x-api-key"); xKey != "" {
+		return xKey, "x-api-key", ""
+	}
+
+	// Priority 4: Authorization (standard Bearer).
+	if auth := r.Header.Get("Authorization"); auth != "" {
+		if strings.HasPrefix(auth, "Bearer ") {
+			k := strings.TrimPrefix(auth, "Bearer ")
+			if !strings.HasPrefix(k, masterKeyPrefix) {
+				return k, "Authorization", "Bearer"
+			}
+		}
+	}
+
+	return "", "", ""
+}
+
+// IsLoopback returns true if the request originates from the loopback interface.
+func IsLoopback(r *http.Request) bool {
+	return strings.HasPrefix(r.RemoteAddr, "127.0.0.1:") || strings.HasPrefix(r.RemoteAddr, "[::1]:")
+}

--- a/internal/gateway/connector/helpers_test.go
+++ b/internal/gateway/connector/helpers_test.go
@@ -1,0 +1,186 @@
+package connector
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestInferProviderFromURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"openai", "https://api.openai.com/v1/chat/completions", "openai"},
+		{"anthropic", "https://api.anthropic.com/v1/messages", "anthropic"},
+		{"empty for unknown", "https://evil.example.com/foo", ""},
+		{"empty string", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := InferProviderFromURL(tt.url)
+			if got != tt.want {
+				t.Errorf("InferProviderFromURL(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsKnownProviderDomain(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"openai", "https://api.openai.com/v1/chat/completions", true},
+		{"anthropic", "https://api.anthropic.com/v1/messages", true},
+		{"unknown domain", "https://evil.example.com/foo", false},
+		{"SSRF bypass attempt", "https://evil.com/?foo=api.openai.com", false},
+		{"empty", "", false},
+		{"invalid url", "://bad", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsKnownProviderDomain(tt.url)
+			if got != tt.want {
+				t.Errorf("IsKnownProviderDomain(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScrubURLSecrets(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string // check that sensitive params are REDACTED
+	}{
+		{"no query string", "https://api.openai.com/v1", "https://api.openai.com/v1"},
+		{"key param", "https://api.example.com/v1?key=secret123", ""},
+		{"no sensitive params", "https://api.example.com/v1?model=gpt4", "https://api.example.com/v1?model=gpt4"},
+		{"invalid url", "://bad", "://bad"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ScrubURLSecrets(tt.raw)
+			if tt.want != "" {
+				if got != tt.want {
+					t.Errorf("ScrubURLSecrets(%q) = %q, want %q", tt.raw, got, tt.want)
+				}
+			} else {
+				// For "key param" case, just verify the secret is redacted
+				if got == tt.raw {
+					t.Errorf("ScrubURLSecrets(%q) should have redacted secrets but returned unchanged", tt.raw)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractAPIKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		headers    map[string]string
+		wantKey    string
+		wantHeader string
+		wantScheme string
+	}{
+		{
+			name:       "X-AI-Auth Bearer",
+			headers:    map[string]string{"X-AI-Auth": "Bearer sk-test-key"},
+			wantKey:    "sk-test-key",
+			wantHeader: "Authorization",
+			wantScheme: "Bearer",
+		},
+		{
+			name:       "api-key (Azure)",
+			headers:    map[string]string{"api-key": "azure-key-123"},
+			wantKey:    "azure-key-123",
+			wantHeader: "api-key",
+			wantScheme: "",
+		},
+		{
+			name:       "x-api-key (Anthropic)",
+			headers:    map[string]string{"x-api-key": "sk-ant-key"},
+			wantKey:    "sk-ant-key",
+			wantHeader: "x-api-key",
+			wantScheme: "",
+		},
+		{
+			name:       "Authorization Bearer",
+			headers:    map[string]string{"Authorization": "Bearer sk-real-key"},
+			wantKey:    "sk-real-key",
+			wantHeader: "Authorization",
+			wantScheme: "Bearer",
+		},
+		{
+			name:       "skip master key in X-AI-Auth",
+			headers:    map[string]string{"X-AI-Auth": "Bearer sk-dc-masterkey", "Authorization": "Bearer sk-real"},
+			wantKey:    "sk-real",
+			wantHeader: "Authorization",
+			wantScheme: "Bearer",
+		},
+		{
+			name:       "skip master key in Authorization",
+			headers:    map[string]string{"Authorization": "Bearer sk-dc-masterkey"},
+			wantKey:    "",
+			wantHeader: "",
+			wantScheme: "",
+		},
+		{
+			name:       "no auth headers",
+			headers:    map[string]string{},
+			wantKey:    "",
+			wantHeader: "",
+			wantScheme: "",
+		},
+		{
+			name:       "priority: X-AI-Auth over Authorization",
+			headers:    map[string]string{"X-AI-Auth": "Bearer sk-priority", "Authorization": "Bearer sk-other"},
+			wantKey:    "sk-priority",
+			wantHeader: "Authorization",
+			wantScheme: "Bearer",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+			key, hdr, scheme := ExtractAPIKey(req, "sk-dc-")
+			if key != tt.wantKey {
+				t.Errorf("key = %q, want %q", key, tt.wantKey)
+			}
+			if hdr != tt.wantHeader {
+				t.Errorf("header = %q, want %q", hdr, tt.wantHeader)
+			}
+			if scheme != tt.wantScheme {
+				t.Errorf("scheme = %q, want %q", scheme, tt.wantScheme)
+			}
+		})
+	}
+}
+
+func TestIsLoopback(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		want       bool
+	}{
+		{"IPv4 loopback", "127.0.0.1:12345", true},
+		{"IPv6 loopback", "[::1]:12345", true},
+		{"non-loopback", "192.168.1.100:12345", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if got := IsLoopback(req); got != tt.want {
+				t.Errorf("IsLoopback(%q) = %v, want %v", tt.remoteAddr, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/gateway/connector/openclaw.go
+++ b/internal/gateway/connector/openclaw.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// OpenClawConnector handles requests from OpenClaw's fetch interceptor which
+// sets X-DC-Target-URL and X-AI-Auth headers on every outbound LLM call.
+type OpenClawConnector struct {
+	// gatewayToken is the OPENCLAW_GATEWAY_TOKEN accepted in X-DC-Auth.
+	gatewayToken string
+	// masterKey is the deterministic key derived from device.key.
+	masterKey string
+}
+
+// NewOpenClawConnector creates an OpenClaw connector with the given auth credentials.
+func NewOpenClawConnector(gatewayToken, masterKey string) *OpenClawConnector {
+	return &OpenClawConnector{
+		gatewayToken: gatewayToken,
+		masterKey:    masterKey,
+	}
+}
+
+func (c *OpenClawConnector) Name() string { return "openclaw" }
+
+// Detect returns true if the request has the X-DC-Target-URL header,
+// which is set by OpenClaw's fetch interceptor.
+func (c *OpenClawConnector) Detect(r *http.Request) bool {
+	return r.Header.Get("X-DC-Target-URL") != ""
+}
+
+// Authenticate checks the request against:
+//  1. X-DC-Auth token (gateway token set by the fetch interceptor)
+//  2. Authorization with master key (sk-dc-*)
+//  3. Loopback fallback (when no gateway token is configured)
+//  4. No auth configured (initial state before setup)
+func (c *OpenClawConnector) Authenticate(r *http.Request) bool {
+	// Check X-DC-Auth token (set by the fetch interceptor).
+	if dcAuth := r.Header.Get("X-DC-Auth"); dcAuth != "" {
+		token := strings.TrimPrefix(dcAuth, "Bearer ")
+		if c.gatewayToken != "" && token == c.gatewayToken {
+			return true
+		}
+	}
+
+	// Check Authorization with the proxy master key.
+	if c.masterKey != "" {
+		auth := r.Header.Get("Authorization")
+		if strings.HasPrefix(auth, "Bearer ") && strings.TrimPrefix(auth, "Bearer ") == c.masterKey {
+			return true
+		}
+	}
+
+	isLoopback := IsLoopback(r)
+
+	// Loopback fallback: allow when no gatewayToken is configured (legacy / first-run).
+	if isLoopback && c.gatewayToken == "" {
+		return true
+	}
+
+	// No auth configured at all — proxy is open (initial state before setup).
+	if c.gatewayToken == "" && c.masterKey == "" {
+		return true
+	}
+
+	return false
+}
+
+// Route extracts routing information from OpenClaw's fetch interceptor headers:
+//   - X-DC-Target-URL → upstream URL and provider inference
+//   - X-AI-Auth → API key (normalized to "Bearer <key>" by the interceptor)
+//
+// For non-chat-completions paths, PassthroughMode is set to forward verbatim.
+func (c *OpenClawConnector) Route(r *http.Request, body []byte) (*RoutingDecision, error) {
+	targetURL := r.Header.Get("X-DC-Target-URL")
+	if targetURL == "" {
+		return nil, fmt.Errorf("connector: openclaw: missing X-DC-Target-URL header")
+	}
+
+	// SSRF protection: only forward to domains listed in providers.json.
+	if !IsKnownProviderDomain(targetURL) {
+		return nil, fmt.Errorf("connector: openclaw: target URL does not match any known LLM provider domain: %s", ScrubURLSecrets(targetURL))
+	}
+
+	providerName := InferProviderFromURL(targetURL)
+
+	// Extract the real API key from X-AI-Auth (normalized by the fetch interceptor).
+	apiKey := ""
+	if aiAuth := r.Header.Get("X-AI-Auth"); strings.HasPrefix(aiAuth, "Bearer ") {
+		apiKey = strings.TrimPrefix(aiAuth, "Bearer ")
+	}
+
+	// Determine auth header and scheme for the upstream provider.
+	authHeader := "Authorization"
+	authScheme := "Bearer"
+	switch providerName {
+	case "anthropic":
+		authHeader = "x-api-key"
+		authScheme = ""
+	case "azure":
+		authHeader = "api-key"
+		authScheme = ""
+	}
+
+	// Extract model from body.
+	var partial struct {
+		Model  string `json:"model"`
+		Stream bool   `json:"stream"`
+	}
+	_ = json.Unmarshal(body, &partial)
+
+	// Determine if passthrough mode (non-chat-completions paths).
+	passthrough := !strings.HasSuffix(r.URL.Path, "/chat/completions")
+
+	// Build extra upstream headers (e.g. anthropic-version).
+	extraHeaders := make(map[string]string)
+	if v := r.Header.Get("anthropic-version"); v != "" {
+		extraHeaders["anthropic-version"] = v
+	}
+
+	return &RoutingDecision{
+		UpstreamURL:          targetURL,
+		ProviderName:         providerName,
+		APIKey:               apiKey,
+		AuthHeader:           authHeader,
+		AuthScheme:           authScheme,
+		Model:                partial.Model,
+		Stream:               partial.Stream,
+		RawBody:              body,
+		PassthroughMode:      passthrough,
+		ExtraUpstreamHeaders: extraHeaders,
+		ConnectorName:        "openclaw",
+	}, nil
+}

--- a/internal/gateway/connector/openclaw_test.go
+++ b/internal/gateway/connector/openclaw_test.go
@@ -1,0 +1,212 @@
+package connector
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestOpenClawDetect(t *testing.T) {
+	c := NewOpenClawConnector("", "")
+
+	tests := []struct {
+		name   string
+		header string
+		want   bool
+	}{
+		{"with X-DC-Target-URL", "https://api.openai.com/v1/chat/completions", true},
+		{"without header", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			if tt.header != "" {
+				req.Header.Set("X-DC-Target-URL", tt.header)
+			}
+			if got := c.Detect(req); got != tt.want {
+				t.Errorf("Detect() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenClawAuthenticate(t *testing.T) {
+	tests := []struct {
+		name         string
+		gatewayToken string
+		masterKey    string
+		headers      map[string]string
+		remoteAddr   string
+		want         bool
+	}{
+		{
+			name:         "valid X-DC-Auth token",
+			gatewayToken: "gw-token-123",
+			headers:      map[string]string{"X-DC-Auth": "Bearer gw-token-123"},
+			remoteAddr:   "192.168.1.1:1234",
+			want:         true,
+		},
+		{
+			name:         "invalid X-DC-Auth token",
+			gatewayToken: "gw-token-123",
+			headers:      map[string]string{"X-DC-Auth": "Bearer wrong-token"},
+			remoteAddr:   "192.168.1.1:1234",
+			want:         false,
+		},
+		{
+			name:       "valid master key",
+			masterKey:  "sk-dc-master123",
+			headers:    map[string]string{"Authorization": "Bearer sk-dc-master123"},
+			remoteAddr: "192.168.1.1:1234",
+			want:       true,
+		},
+		{
+			name:       "loopback without gateway token",
+			remoteAddr: "127.0.0.1:1234",
+			want:       true,
+		},
+		{
+			name:         "loopback with gateway token requires auth",
+			gatewayToken: "gw-token-123",
+			remoteAddr:   "127.0.0.1:1234",
+			want:         false,
+		},
+		{
+			name:       "no auth configured (open proxy)",
+			remoteAddr: "192.168.1.1:1234",
+			want:       true,
+		},
+		{
+			name:         "non-loopback without token",
+			gatewayToken: "gw-token-123",
+			remoteAddr:   "192.168.1.1:1234",
+			want:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewOpenClawConnector(tt.gatewayToken, tt.masterKey)
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			req.RemoteAddr = tt.remoteAddr
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+			if got := c.Authenticate(req); got != tt.want {
+				t.Errorf("Authenticate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenClawRoute(t *testing.T) {
+	c := NewOpenClawConnector("", "")
+
+	t.Run("chat completions path", func(t *testing.T) {
+		body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}],"stream":true}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("X-DC-Target-URL", "https://api.openai.com/v1/chat/completions")
+		req.Header.Set("X-AI-Auth", "Bearer sk-test-key")
+
+		decision, err := c.Route(req, []byte(body))
+		if err != nil {
+			t.Fatalf("Route() error: %v", err)
+		}
+
+		if decision.UpstreamURL != "https://api.openai.com/v1/chat/completions" {
+			t.Errorf("UpstreamURL = %q", decision.UpstreamURL)
+		}
+		if decision.ProviderName != "openai" {
+			t.Errorf("ProviderName = %q, want openai", decision.ProviderName)
+		}
+		if decision.APIKey != "sk-test-key" {
+			t.Errorf("APIKey = %q", decision.APIKey)
+		}
+		if decision.AuthHeader != "Authorization" {
+			t.Errorf("AuthHeader = %q, want Authorization", decision.AuthHeader)
+		}
+		if decision.AuthScheme != "Bearer" {
+			t.Errorf("AuthScheme = %q, want Bearer", decision.AuthScheme)
+		}
+		if decision.Model != "gpt-4o" {
+			t.Errorf("Model = %q, want gpt-4o", decision.Model)
+		}
+		if !decision.Stream {
+			t.Error("Stream should be true")
+		}
+		if decision.PassthroughMode {
+			t.Error("PassthroughMode should be false for chat completions")
+		}
+		if decision.ConnectorName != "openclaw" {
+			t.Errorf("ConnectorName = %q, want openclaw", decision.ConnectorName)
+		}
+	})
+
+	t.Run("passthrough path (Anthropic)", func(t *testing.T) {
+		body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+		req.Header.Set("X-DC-Target-URL", "https://api.anthropic.com/v1/messages")
+		req.Header.Set("X-AI-Auth", "Bearer sk-ant-key")
+		req.Header.Set("anthropic-version", "2023-06-01")
+
+		decision, err := c.Route(req, []byte(body))
+		if err != nil {
+			t.Fatalf("Route() error: %v", err)
+		}
+
+		if decision.ProviderName != "anthropic" {
+			t.Errorf("ProviderName = %q, want anthropic", decision.ProviderName)
+		}
+		if decision.AuthHeader != "x-api-key" {
+			t.Errorf("AuthHeader = %q, want x-api-key", decision.AuthHeader)
+		}
+		if decision.AuthScheme != "" {
+			t.Errorf("AuthScheme = %q, want empty", decision.AuthScheme)
+		}
+		if !decision.PassthroughMode {
+			t.Error("PassthroughMode should be true for /v1/messages")
+		}
+		if decision.ExtraUpstreamHeaders["anthropic-version"] != "2023-06-01" {
+			t.Errorf("missing anthropic-version header")
+		}
+	})
+
+	t.Run("Azure route", func(t *testing.T) {
+		body := `{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("X-DC-Target-URL", "https://myresource.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2024-02-01")
+		req.Header.Set("X-AI-Auth", "Bearer az-key-123")
+
+		decision, err := c.Route(req, []byte(body))
+		if err != nil {
+			t.Fatalf("Route() error: %v", err)
+		}
+
+		if decision.ProviderName != "azure" {
+			t.Errorf("ProviderName = %q, want azure", decision.ProviderName)
+		}
+		if decision.AuthHeader != "api-key" {
+			t.Errorf("AuthHeader = %q, want api-key", decision.AuthHeader)
+		}
+	})
+
+	t.Run("missing X-DC-Target-URL", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+		_, err := c.Route(req, []byte(`{}`))
+		if err == nil {
+			t.Fatal("expected error for missing X-DC-Target-URL")
+		}
+	})
+
+	t.Run("SSRF blocked", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+		req.Header.Set("X-DC-Target-URL", "http://169.254.169.254/latest/meta-data")
+		_, err := c.Route(req, []byte(`{}`))
+		if err == nil {
+			t.Fatal("expected error for SSRF attempt")
+		}
+		if !strings.Contains(err.Error(), "known LLM provider domain") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/gateway/connector/router.go
+++ b/internal/gateway/connector/router.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"net/http"
+)
+
+// Router holds an ordered list of connectors and resolves incoming requests
+// to the first matching connector. If no connector matches, the fallback is used.
+type Router struct {
+	connectors []Connector
+	fallback   Connector
+}
+
+// NewRouter creates a Router with the given connectors checked in order.
+// Detection order matters: more specific connectors (OpenClaw with its
+// X-DC-Target-URL header) should come before more general ones (ZeptoClaw,
+// Generic).
+func NewRouter(connectors ...Connector) *Router {
+	return &Router{
+		connectors: connectors,
+	}
+}
+
+// SetFallback sets the fallback connector used when no other connector
+// matches the request. Typically this is the Generic connector.
+func (r *Router) SetFallback(c Connector) {
+	r.fallback = c
+}
+
+// Resolve returns the first connector whose Detect method returns true for
+// the given request. If no connector matches, the fallback is returned.
+// Returns nil only if no connectors are registered and no fallback is set.
+func (r *Router) Resolve(req *http.Request) Connector {
+	for _, c := range r.connectors {
+		if c.Detect(req) {
+			return c
+		}
+	}
+	return r.fallback
+}
+
+// ConnectorNames returns the names of all registered connectors (including
+// the fallback) for diagnostic/logging purposes.
+func (r *Router) ConnectorNames() []string {
+	names := make([]string, 0, len(r.connectors)+1)
+	for _, c := range r.connectors {
+		names = append(names, c.Name())
+	}
+	if r.fallback != nil {
+		names = append(names, r.fallback.Name()+" (fallback)")
+	}
+	return names
+}

--- a/internal/gateway/connector/router_test.go
+++ b/internal/gateway/connector/router_test.go
@@ -1,0 +1,88 @@
+package connector
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// stubConnector is a test double that matches when detectFn returns true.
+type stubConnector struct {
+	name     string
+	detectFn func(r *http.Request) bool
+	authOK   bool
+}
+
+func (s *stubConnector) Name() string                  { return s.name }
+func (s *stubConnector) Detect(r *http.Request) bool   { return s.detectFn(r) }
+func (s *stubConnector) Authenticate(*http.Request) bool { return s.authOK }
+func (s *stubConnector) Route(*http.Request, []byte) (*RoutingDecision, error) {
+	return &RoutingDecision{ConnectorName: s.name}, nil
+}
+
+func TestRouterResolveFirstMatch(t *testing.T) {
+	first := &stubConnector{name: "first", detectFn: func(*http.Request) bool { return true }}
+	second := &stubConnector{name: "second", detectFn: func(*http.Request) bool { return true }}
+
+	router := NewRouter(first, second)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	got := router.Resolve(req)
+	if got == nil || got.Name() != "first" {
+		t.Fatalf("expected first connector, got %v", got)
+	}
+}
+
+func TestRouterResolveFallback(t *testing.T) {
+	never := &stubConnector{name: "never", detectFn: func(*http.Request) bool { return false }}
+	fallback := &stubConnector{name: "fallback", detectFn: func(*http.Request) bool { return true }}
+
+	router := NewRouter(never)
+	router.SetFallback(fallback)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	got := router.Resolve(req)
+	if got == nil || got.Name() != "fallback" {
+		t.Fatalf("expected fallback connector, got %v", got)
+	}
+}
+
+func TestRouterResolveNilWhenEmpty(t *testing.T) {
+	router := NewRouter()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	got := router.Resolve(req)
+	if got != nil {
+		t.Fatalf("expected nil, got %v", got.Name())
+	}
+}
+
+func TestRouterResolveSkipsNonMatching(t *testing.T) {
+	noMatch := &stubConnector{name: "nope", detectFn: func(*http.Request) bool { return false }}
+	match := &stubConnector{name: "yes", detectFn: func(*http.Request) bool { return true }}
+
+	router := NewRouter(noMatch, match)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	got := router.Resolve(req)
+	if got == nil || got.Name() != "yes" {
+		t.Fatalf("expected 'yes' connector, got %v", got)
+	}
+}
+
+func TestRouterConnectorNames(t *testing.T) {
+	a := &stubConnector{name: "openclaw", detectFn: func(*http.Request) bool { return false }}
+	b := &stubConnector{name: "zeptoclaw", detectFn: func(*http.Request) bool { return false }}
+	fb := &stubConnector{name: "generic", detectFn: func(*http.Request) bool { return true }}
+
+	router := NewRouter(a, b)
+	router.SetFallback(fb)
+
+	names := router.ConnectorNames()
+	if len(names) != 3 {
+		t.Fatalf("expected 3 names, got %d: %v", len(names), names)
+	}
+	if names[0] != "openclaw" || names[1] != "zeptoclaw" || names[2] != "generic (fallback)" {
+		t.Fatalf("unexpected names: %v", names)
+	}
+}

--- a/internal/gateway/connector/zeptoclaw.go
+++ b/internal/gateway/connector/zeptoclaw.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// ZeptoClawConnector handles requests from ZeptoClaw where traffic is routed
+// through the proxy via api_base config patching. ZeptoClaw sends standard
+// HTTP with no DefenseClaw-specific headers (no X-DC-Target-URL).
+//
+// Detection: X-ZC-Provider header present, OR absence of X-DC-Target-URL
+// combined with standard auth headers.
+//
+// Upstream URL resolution: uses config-provided provider map, falling back
+// to the embedded ZeptoClawDefaultProviders table.
+type ZeptoClawConnector struct {
+	// gatewayToken is an optional proxy auth token accepted in X-DC-Auth.
+	gatewayToken string
+	// masterKey is the deterministic key derived from device.key.
+	masterKey string
+	// providers maps provider name → upstream entry (from config.yaml).
+	// Falls back to ZeptoClawDefaultProviders for unknown providers.
+	providers map[string]ZCProviderEntry
+}
+
+// NewZeptoClawConnector creates a ZeptoClaw connector.
+// The providers map comes from config.yaml's guardrail.connectors.zeptoclaw.providers.
+// If nil, only the embedded default table is used.
+func NewZeptoClawConnector(gatewayToken, masterKey string, providers map[string]ZCProviderEntry) *ZeptoClawConnector {
+	if providers == nil {
+		providers = make(map[string]ZCProviderEntry)
+	}
+	return &ZeptoClawConnector{
+		gatewayToken: gatewayToken,
+		masterKey:    masterKey,
+		providers:    providers,
+	}
+}
+
+func (c *ZeptoClawConnector) Name() string { return "zeptoclaw" }
+
+// Detect returns true if the request looks like it came from ZeptoClaw:
+//   - Has X-ZC-Provider header (explicit hint), OR
+//   - Does NOT have X-DC-Target-URL (not from OpenClaw) AND has standard auth headers.
+func (c *ZeptoClawConnector) Detect(r *http.Request) bool {
+	// Explicit ZeptoClaw header.
+	if r.Header.Get("X-ZC-Provider") != "" {
+		return true
+	}
+
+	// Not from OpenClaw (no X-DC-Target-URL) and has standard auth.
+	if r.Header.Get("X-DC-Target-URL") == "" {
+		if r.Header.Get("Authorization") != "" ||
+			r.Header.Get("x-api-key") != "" ||
+			r.Header.Get("api-key") != "" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Authenticate checks the request:
+//  1. X-DC-Auth token (optional proxy auth)
+//  2. Loopback trust (ZeptoClaw typically runs on same machine)
+//  3. No auth configured (initial state)
+func (c *ZeptoClawConnector) Authenticate(r *http.Request) bool {
+	// Check X-DC-Auth token (optional proxy auth for ZeptoClaw).
+	if dcAuth := r.Header.Get("X-DC-Auth"); dcAuth != "" {
+		token := strings.TrimPrefix(dcAuth, "Bearer ")
+		if c.gatewayToken != "" && token == c.gatewayToken {
+			return true
+		}
+	}
+
+	// Check Authorization with master key.
+	if c.masterKey != "" {
+		auth := r.Header.Get("Authorization")
+		if strings.HasPrefix(auth, "Bearer ") && strings.TrimPrefix(auth, "Bearer ") == c.masterKey {
+			return true
+		}
+	}
+
+	isLoopback := IsLoopback(r)
+
+	// Loopback fallback: allow when no gatewayToken is configured.
+	if isLoopback && c.gatewayToken == "" {
+		return true
+	}
+
+	// No auth configured at all — proxy is open.
+	if c.gatewayToken == "" && c.masterKey == "" {
+		return true
+	}
+
+	return false
+}
+
+// Route resolves the upstream URL and provider from the request.
+//
+// Provider is determined by (in priority order):
+//  1. X-ZC-Provider header (explicit hint from ZeptoClaw)
+//  2. Model name prefix inference (gpt-* → openai, claude-* → anthropic)
+//
+// Upstream URL is resolved from:
+//  1. X-ZC-Upstream header (optional, set by ZeptoClaw if configured)
+//  2. Config-provided providers map (from setup command)
+//  3. Embedded ZeptoClawDefaultProviders table (fallback)
+func (c *ZeptoClawConnector) Route(r *http.Request, body []byte) (*RoutingDecision, error) {
+	// Parse model and stream from body.
+	var partial struct {
+		Model  string `json:"model"`
+		Stream bool   `json:"stream"`
+	}
+	_ = json.Unmarshal(body, &partial)
+
+	// Resolve provider name.
+	providerName := r.Header.Get("X-ZC-Provider")
+	if providerName == "" {
+		providerName = InferProviderFromModel(partial.Model)
+	}
+	if providerName == "" {
+		return nil, fmt.Errorf("connector: zeptoclaw: cannot determine provider from model %q — set X-ZC-Provider header or use a known model prefix", partial.Model)
+	}
+
+	// Resolve upstream entry: config → defaults.
+	entry, ok := c.providers[providerName]
+	if !ok {
+		entry, ok = ZeptoClawDefaultProviders[providerName]
+		if !ok {
+			return nil, fmt.Errorf("connector: zeptoclaw: unknown provider %q — add it to guardrail.connectors.zeptoclaw.providers in config.yaml", providerName)
+		}
+	}
+
+	// Optional upstream URL override from header.
+	upstreamURL := entry.UpstreamURL
+	if hint := r.Header.Get("X-ZC-Upstream"); hint != "" {
+		upstreamURL = hint
+	}
+
+	// Reconstruct full upstream URL by appending the request path.
+	// ZeptoClaw sends to the proxy as e.g. POST /v1/chat/completions,
+	// so we combine the base URL with the request path.
+	fullUpstreamURL := strings.TrimRight(upstreamURL, "/") + r.URL.RequestURI()
+
+	// Extract API key from standard auth headers.
+	apiKey, _, _ := ExtractAPIKey(r, "sk-dc-")
+
+	// Use the provider entry's auth header/scheme for upstream.
+	authHeader := entry.AuthHeader
+	authScheme := entry.AuthScheme
+	if authHeader == "" {
+		authHeader = "Authorization"
+		authScheme = "Bearer"
+	}
+
+	return &RoutingDecision{
+		UpstreamURL:          fullUpstreamURL,
+		ProviderName:         providerName,
+		APIKey:               apiKey,
+		AuthHeader:           authHeader,
+		AuthScheme:           authScheme,
+		Model:                partial.Model,
+		Stream:               partial.Stream,
+		RawBody:              body,
+		PassthroughMode:      false,
+		ExtraUpstreamHeaders: make(map[string]string),
+		ConnectorName:        "zeptoclaw",
+	}, nil
+}

--- a/internal/gateway/connector/zeptoclaw_defaults.go
+++ b/internal/gateway/connector/zeptoclaw_defaults.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+// ZCProviderEntry describes how to reach an upstream LLM provider.
+type ZCProviderEntry struct {
+	UpstreamURL string
+	AuthHeader  string
+	AuthScheme  string
+}
+
+// defaultModelPrefixes maps model name prefixes to provider names.
+// Used to infer the provider when no explicit X-ZC-Provider header is present.
+var defaultModelPrefixes = []struct {
+	prefix   string
+	provider string
+}{
+	{"claude-", "anthropic"},
+	{"gpt-", "openai"},
+	{"o1-", "openai"},
+	{"o3-", "openai"},
+	{"o4-", "openai"},
+	{"chatgpt-", "openai"},
+	{"gemini-", "gemini"},
+	{"command-", "cohere"},
+	{"mistral-", "mistral"},
+	{"llama-", "meta"},
+	{"deepseek-", "deepseek"},
+}
+
+// InferProviderFromModel maps a model name to a provider name by checking
+// for well-known prefixes. Returns "" if no match is found.
+//
+// Also handles "provider/model" format (e.g. "anthropic/claude-sonnet-4-20250514")
+// where the provider is explicit before the slash.
+func InferProviderFromModel(model string) string {
+	// Check for explicit "provider/model" format.
+	if idx := findSlash(model); idx >= 0 {
+		return model[:idx]
+	}
+
+	for _, entry := range defaultModelPrefixes {
+		if len(model) >= len(entry.prefix) && model[:len(entry.prefix)] == entry.prefix {
+			return entry.provider
+		}
+	}
+	return ""
+}
+
+// findSlash returns the index of the first '/' in s, or -1.
+func findSlash(s string) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '/' {
+			return i
+		}
+	}
+	return -1
+}
+
+// ZeptoClawDefaultProviders maps provider names to their default upstream
+// URLs, auth headers, and auth schemes. Mirrored from ZeptoClaw's
+// PROVIDER_REGISTRY in src/providers/registry.rs.
+var ZeptoClawDefaultProviders = map[string]ZCProviderEntry{
+	"openai":     {UpstreamURL: "https://api.openai.com/v1", AuthHeader: "Authorization", AuthScheme: "Bearer"},
+	"anthropic":  {UpstreamURL: "https://api.anthropic.com/v1", AuthHeader: "x-api-key", AuthScheme: ""},
+	"openrouter": {UpstreamURL: "https://openrouter.ai/api/v1", AuthHeader: "Authorization", AuthScheme: "Bearer"},
+	"groq":       {UpstreamURL: "https://api.groq.com/openai/v1", AuthHeader: "Authorization", AuthScheme: "Bearer"},
+	"gemini":     {UpstreamURL: "https://generativelanguage.googleapis.com/v1beta/openai", AuthHeader: "Authorization", AuthScheme: "Bearer"},
+	"ollama":     {UpstreamURL: "http://localhost:11434/v1", AuthHeader: "", AuthScheme: ""},
+	"nvidia":     {UpstreamURL: "https://integrate.api.nvidia.com/v1", AuthHeader: "Authorization", AuthScheme: "Bearer"},
+	"deepseek":   {UpstreamURL: "https://api.deepseek.com/v1", AuthHeader: "Authorization", AuthScheme: "Bearer"},
+	"kimi":       {UpstreamURL: "https://api.moonshot.cn/v1", AuthHeader: "Authorization", AuthScheme: "Bearer"},
+	"azure":      {UpstreamURL: "", AuthHeader: "api-key", AuthScheme: ""},
+	"bedrock":    {UpstreamURL: "", AuthHeader: "", AuthScheme: ""},
+	"vllm":       {UpstreamURL: "http://localhost:8000/v1", AuthHeader: "Authorization", AuthScheme: "Bearer"},
+	"zhipu":      {UpstreamURL: "https://open.bigmodel.cn/api/paas/v4", AuthHeader: "Authorization", AuthScheme: "Bearer"},
+	"xai":        {UpstreamURL: "https://api.x.ai/v1", AuthHeader: "Authorization", AuthScheme: "Bearer"},
+	"novita":     {UpstreamURL: "https://api.novita.ai/v3/openai", AuthHeader: "Authorization", AuthScheme: "Bearer"},
+	"qianfan":    {UpstreamURL: "https://aip.baidubce.com/rpc/2.0", AuthHeader: "Authorization", AuthScheme: "Bearer"},
+	"cohere":     {UpstreamURL: "https://api.cohere.com/v2", AuthHeader: "Authorization", AuthScheme: "Bearer"},
+	"mistral":    {UpstreamURL: "https://api.mistral.ai/v1", AuthHeader: "Authorization", AuthScheme: "Bearer"},
+	"meta":       {UpstreamURL: "https://api.llama.com/v1", AuthHeader: "Authorization", AuthScheme: "Bearer"},
+}

--- a/internal/gateway/connector/zeptoclaw_test.go
+++ b/internal/gateway/connector/zeptoclaw_test.go
@@ -1,0 +1,301 @@
+package connector
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestInferProviderFromModel(t *testing.T) {
+	tests := []struct {
+		model string
+		want  string
+	}{
+		{"gpt-4o", "openai"},
+		{"gpt-4o-mini", "openai"},
+		{"o1-preview", "openai"},
+		{"o3-mini", "openai"},
+		{"o4-mini", "openai"},
+		{"claude-sonnet-4-20250514", "anthropic"},
+		{"claude-opus-4-20250514", "anthropic"},
+		{"gemini-2.0-flash", "gemini"},
+		{"command-r-plus", "cohere"},
+		{"mistral-large-latest", "mistral"},
+		{"llama-3.1-70b", "meta"},
+		{"deepseek-chat", "deepseek"},
+		{"chatgpt-4o-latest", "openai"},
+		// Explicit provider/model format.
+		{"anthropic/claude-sonnet-4-20250514", "anthropic"},
+		{"openai/gpt-4o", "openai"},
+		{"openrouter/auto", "openrouter"},
+		// Unknown model.
+		{"unknown-model", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			got := InferProviderFromModel(tt.model)
+			if got != tt.want {
+				t.Errorf("InferProviderFromModel(%q) = %q, want %q", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestZeptoClawDetect(t *testing.T) {
+	c := NewZeptoClawConnector("", "", nil)
+
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    bool
+	}{
+		{
+			name:    "X-ZC-Provider header",
+			headers: map[string]string{"X-ZC-Provider": "openai"},
+			want:    true,
+		},
+		{
+			name:    "standard Authorization (no X-DC-Target-URL)",
+			headers: map[string]string{"Authorization": "Bearer sk-test"},
+			want:    true,
+		},
+		{
+			name:    "x-api-key (Anthropic style, no X-DC-Target-URL)",
+			headers: map[string]string{"x-api-key": "sk-ant-key"},
+			want:    true,
+		},
+		{
+			name:    "api-key (Azure style, no X-DC-Target-URL)",
+			headers: map[string]string{"api-key": "az-key"},
+			want:    true,
+		},
+		{
+			name:    "has X-DC-Target-URL — belongs to OpenClaw",
+			headers: map[string]string{"X-DC-Target-URL": "https://api.openai.com", "Authorization": "Bearer sk-test"},
+			want:    false,
+		},
+		{
+			name:    "no auth headers at all",
+			headers: map[string]string{},
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+			if got := c.Detect(req); got != tt.want {
+				t.Errorf("Detect() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestZeptoClawAuthenticate(t *testing.T) {
+	tests := []struct {
+		name         string
+		gatewayToken string
+		masterKey    string
+		headers      map[string]string
+		remoteAddr   string
+		want         bool
+	}{
+		{
+			name:         "valid X-DC-Auth token",
+			gatewayToken: "zc-token",
+			headers:      map[string]string{"X-DC-Auth": "Bearer zc-token"},
+			remoteAddr:   "192.168.1.1:1234",
+			want:         true,
+		},
+		{
+			name:       "loopback without token",
+			remoteAddr: "127.0.0.1:1234",
+			want:       true,
+		},
+		{
+			name:         "loopback with token requires auth",
+			gatewayToken: "zc-token",
+			remoteAddr:   "127.0.0.1:1234",
+			want:         false,
+		},
+		{
+			name:       "no auth configured (open)",
+			remoteAddr: "192.168.1.1:1234",
+			want:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewZeptoClawConnector(tt.gatewayToken, tt.masterKey, nil)
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			req.RemoteAddr = tt.remoteAddr
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+			if got := c.Authenticate(req); got != tt.want {
+				t.Errorf("Authenticate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestZeptoClawRoute(t *testing.T) {
+	t.Run("infer provider from model prefix", func(t *testing.T) {
+		c := NewZeptoClawConnector("", "", nil)
+		body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}],"stream":true}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer sk-real-key")
+
+		decision, err := c.Route(req, []byte(body))
+		if err != nil {
+			t.Fatalf("Route() error: %v", err)
+		}
+
+		if decision.ProviderName != "openai" {
+			t.Errorf("ProviderName = %q, want openai", decision.ProviderName)
+		}
+		if !strings.Contains(decision.UpstreamURL, "api.openai.com") {
+			t.Errorf("UpstreamURL = %q, want to contain api.openai.com", decision.UpstreamURL)
+		}
+		if !strings.HasSuffix(decision.UpstreamURL, "/v1/chat/completions") {
+			t.Errorf("UpstreamURL = %q, want to end with /v1/chat/completions", decision.UpstreamURL)
+		}
+		if decision.APIKey != "sk-real-key" {
+			t.Errorf("APIKey = %q, want sk-real-key", decision.APIKey)
+		}
+		if decision.Model != "gpt-4o" {
+			t.Errorf("Model = %q, want gpt-4o", decision.Model)
+		}
+		if !decision.Stream {
+			t.Error("Stream should be true")
+		}
+		if decision.ConnectorName != "zeptoclaw" {
+			t.Errorf("ConnectorName = %q", decision.ConnectorName)
+		}
+	})
+
+	t.Run("explicit X-ZC-Provider header", func(t *testing.T) {
+		c := NewZeptoClawConnector("", "", nil)
+		body := `{"model":"my-custom-model","messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer sk-key")
+		req.Header.Set("X-ZC-Provider", "openai")
+
+		decision, err := c.Route(req, []byte(body))
+		if err != nil {
+			t.Fatalf("Route() error: %v", err)
+		}
+		if decision.ProviderName != "openai" {
+			t.Errorf("ProviderName = %q, want openai", decision.ProviderName)
+		}
+	})
+
+	t.Run("X-ZC-Upstream overrides default URL", func(t *testing.T) {
+		c := NewZeptoClawConnector("", "", nil)
+		body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer sk-key")
+		req.Header.Set("X-ZC-Upstream", "https://custom-proxy.example.com/v1")
+
+		decision, err := c.Route(req, []byte(body))
+		if err != nil {
+			t.Fatalf("Route() error: %v", err)
+		}
+		if !strings.HasPrefix(decision.UpstreamURL, "https://custom-proxy.example.com/v1") {
+			t.Errorf("UpstreamURL = %q, want custom-proxy prefix", decision.UpstreamURL)
+		}
+	})
+
+	t.Run("config providers override defaults", func(t *testing.T) {
+		customProviders := map[string]ZCProviderEntry{
+			"openai": {
+				UpstreamURL: "https://my-private-openai.example.com/v1",
+				AuthHeader:  "Authorization",
+				AuthScheme:  "Bearer",
+			},
+		}
+		c := NewZeptoClawConnector("", "", customProviders)
+		body := `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer sk-key")
+
+		decision, err := c.Route(req, []byte(body))
+		if err != nil {
+			t.Fatalf("Route() error: %v", err)
+		}
+		if !strings.Contains(decision.UpstreamURL, "my-private-openai.example.com") {
+			t.Errorf("UpstreamURL = %q, want custom URL", decision.UpstreamURL)
+		}
+	})
+
+	t.Run("Anthropic auth header resolution", func(t *testing.T) {
+		c := NewZeptoClawConnector("", "", nil)
+		body := `{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("x-api-key", "sk-ant-key")
+
+		decision, err := c.Route(req, []byte(body))
+		if err != nil {
+			t.Fatalf("Route() error: %v", err)
+		}
+		if decision.ProviderName != "anthropic" {
+			t.Errorf("ProviderName = %q, want anthropic", decision.ProviderName)
+		}
+		if decision.AuthHeader != "x-api-key" {
+			t.Errorf("AuthHeader = %q, want x-api-key", decision.AuthHeader)
+		}
+		if decision.AuthScheme != "" {
+			t.Errorf("AuthScheme = %q, want empty", decision.AuthScheme)
+		}
+	})
+
+	t.Run("provider/model format", func(t *testing.T) {
+		c := NewZeptoClawConnector("", "", nil)
+		body := `{"model":"anthropic/claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer sk-key")
+
+		decision, err := c.Route(req, []byte(body))
+		if err != nil {
+			t.Fatalf("Route() error: %v", err)
+		}
+		if decision.ProviderName != "anthropic" {
+			t.Errorf("ProviderName = %q, want anthropic", decision.ProviderName)
+		}
+	})
+
+	t.Run("unknown model without header errors", func(t *testing.T) {
+		c := NewZeptoClawConnector("", "", nil)
+		body := `{"model":"totally-unknown-model","messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer sk-key")
+
+		_, err := c.Route(req, []byte(body))
+		if err == nil {
+			t.Fatal("expected error for unknown model")
+		}
+		if !strings.Contains(err.Error(), "cannot determine provider") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("unknown provider errors", func(t *testing.T) {
+		c := NewZeptoClawConnector("", "", nil)
+		body := `{"model":"totally-unknown-model","messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer sk-key")
+		req.Header.Set("X-ZC-Provider", "nonexistent-provider")
+
+		_, err := c.Route(req, []byte(body))
+		if err == nil {
+			t.Fatal("expected error for unknown provider")
+		}
+		if !strings.Contains(err.Error(), "unknown provider") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -37,6 +37,7 @@ import (
 	"github.com/defenseclaw/defenseclaw/internal/audit"
 	"github.com/defenseclaw/defenseclaw/internal/config"
 	"github.com/defenseclaw/defenseclaw/internal/configs"
+	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
 	"github.com/defenseclaw/defenseclaw/internal/telemetry"
 )
 
@@ -81,6 +82,11 @@ type GuardrailProxy struct {
 	gatewayToken     string // OPENCLAW_GATEWAY_TOKEN, accepted in X-DC-Auth
 	notify           *NotificationQueue
 
+	// connectorRouter resolves incoming requests to the appropriate connector
+	// (OpenClaw, ZeptoClaw, Generic). When set, the proxy delegates auth and
+	// routing to the matched connector instead of using the legacy header logic.
+	connectorRouter *connector.Router
+
 	// resolveProviderFn selects the upstream LLMProvider for a request.
 	// Defaults to resolveProviderFromHeaders (uses X-DC-Target-URL).
 	// Tests can override this to inject a mock provider.
@@ -94,8 +100,10 @@ type GuardrailProxy struct {
 	blockMessage string
 }
 
-// NewGuardrailProxy constructs and wires a proxy. All provider routing is
-// handled by the fetch interceptor's X-DC-Target-URL and X-AI-Auth headers.
+// NewGuardrailProxy constructs and wires a proxy. The optional connectorRouter
+// delegates authentication and routing to the matched connector (OpenClaw,
+// ZeptoClaw, Generic). When nil, the proxy falls back to the legacy
+// X-DC-Target-URL header-based routing.
 func NewGuardrailProxy(
 	cfg *config.GuardrailConfig,
 	ciscoAID *config.CiscoAIDefenseConfig,
@@ -106,6 +114,7 @@ func NewGuardrailProxy(
 	dataDir string,
 	policyDir string,
 	notify *NotificationQueue,
+	connRouter *connector.Router,
 ) (*GuardrailProxy, error) {
 	dotenvPath := filepath.Join(dataDir, ".env")
 
@@ -129,18 +138,19 @@ func NewGuardrailProxy(
 	}
 
 	p := &GuardrailProxy{
-		cfg:          cfg,
-		logger:       logger,
-		health:       health,
-		otel:         otel,
-		store:        store,
-		dataDir:      dataDir,
-		inspector:    inspector,
-		masterKey:    masterKey,
-		gatewayToken: gatewayToken,
-		notify:       notify,
-		mode:         cfg.Mode,
-		blockMessage: cfg.BlockMessage,
+		cfg:             cfg,
+		logger:          logger,
+		health:          health,
+		otel:            otel,
+		store:           store,
+		dataDir:         dataDir,
+		inspector:       inspector,
+		masterKey:       masterKey,
+		gatewayToken:    gatewayToken,
+		notify:          notify,
+		connectorRouter: connRouter,
+		mode:            cfg.Mode,
+		blockMessage:    cfg.BlockMessage,
 	}
 	p.resolveProviderFn = p.resolveProviderFromHeaders
 	return p, nil
@@ -252,12 +262,26 @@ func (p *GuardrailProxy) handlePassthrough(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if !p.authenticateRequest(r) {
+	// Connector-based authentication when available.
+	connectorName := "openclaw"
+	if p.connectorRouter != nil {
+		conn := p.connectorRouter.Resolve(r)
+		if conn != nil {
+			connectorName = conn.Name()
+			if !conn.Authenticate(r) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":{"message":"invalid API key","type":"authentication_error","code":"invalid_api_key"}}`))
+				return
+			}
+		}
+	} else if !p.authenticateRequest(r) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = w.Write([]byte(`{"error":{"message":"invalid API key","type":"authentication_error","code":"invalid_api_key"}}`))
 		return
 	}
+	_ = connectorName // used in recordTelemetry calls below
 
 	// OpenAI-compatible paths (e.g. /api/v1/chat/completions from OpenRouter)
 	// must use handleChatCompletion which has proper streaming SSE support.
@@ -844,7 +868,24 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if !p.authenticateRequest(r) {
+	// Connector-based authentication: delegate to the matched connector
+	// when a connector router is configured, otherwise fall back to legacy auth.
+	connectorName := "openclaw" // default for backward compat
+	var decision *connector.RoutingDecision
+	if p.connectorRouter != nil {
+		conn := p.connectorRouter.Resolve(r)
+		if conn == nil {
+			writeOpenAIError(w, http.StatusBadRequest, "no connector matched this request")
+			return
+		}
+		connectorName = conn.Name()
+		if !conn.Authenticate(r) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":{"message":"invalid API key","type":"authentication_error","code":"invalid_api_key"}}`))
+			return
+		}
+	} else if !p.authenticateRequest(r) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = w.Write([]byte(`{"error":{"message":"invalid API key","type":"authentication_error","code":"invalid_api_key"}}`))
@@ -857,12 +898,28 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	fmt.Fprintf(os.Stderr, "[guardrail] ── INCOMING REQUEST ──────────────────────────────────\n")
+	fmt.Fprintf(os.Stderr, "[guardrail] ── INCOMING REQUEST (%s) ──────────────────────────────────\n", connectorName)
 	fmt.Fprintf(os.Stderr, "[guardrail] headers: Authorization=%s api-key=%s X-DC-Target-URL=%s\n",
 		truncateLog(r.Header.Get("Authorization"), 20),
 		truncateLog(r.Header.Get("api-key"), 20),
 		r.Header.Get("X-DC-Target-URL"))
 	fmt.Fprintf(os.Stderr, "[guardrail] raw body (%d bytes): %s\n", len(body), truncateLog(string(body), 2000))
+
+	// When a connector router is available, route through the connector
+	// to resolve upstream URL, provider, and API key.
+	if p.connectorRouter != nil {
+		conn := p.connectorRouter.Resolve(r)
+		if conn != nil {
+			var routeErr error
+			decision, routeErr = conn.Route(r, body)
+			if routeErr != nil {
+				fmt.Fprintf(os.Stderr, "[guardrail] connector route error: %v\n", routeErr)
+				writeOpenAIError(w, http.StatusBadRequest, routeErr.Error())
+				return
+			}
+			connectorName = decision.ConnectorName
+		}
+	}
 
 	var req ChatRequest
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -872,19 +929,20 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 	}
 	req.RawBody = body
 
-	// X-DC-Target-URL is set by the plugin's fetch interceptor and tells the
-	// proxy the real upstream URL the request was originally destined for.
-	req.TargetURL = r.Header.Get("X-DC-Target-URL")
-
-	// X-AI-Auth carries the real provider API key, normalized to
-	// "Bearer <key>" by the fetch interceptor regardless of which header
-	// the provider SDK originally used (Authorization, x-api-key, api-key).
-	if aiAuth := r.Header.Get("X-AI-Auth"); strings.HasPrefix(aiAuth, "Bearer ") {
-		req.TargetAPIKey = strings.TrimPrefix(aiAuth, "Bearer ")
+	// Apply connector routing decision to ChatRequest fields.
+	if decision != nil {
+		req.TargetURL = decision.UpstreamURL
+		req.TargetAPIKey = decision.APIKey
+	} else {
+		// Legacy path: extract from OpenClaw-specific headers.
+		req.TargetURL = r.Header.Get("X-DC-Target-URL")
+		if aiAuth := r.Header.Get("X-AI-Auth"); strings.HasPrefix(aiAuth, "Bearer ") {
+			req.TargetAPIKey = strings.TrimPrefix(aiAuth, "Bearer ")
+		}
 	}
 
-	fmt.Fprintf(os.Stderr, "[guardrail] parsed: model=%q stream=%v messages=%d\n",
-		req.Model, req.Stream, len(req.Messages))
+	fmt.Fprintf(os.Stderr, "[guardrail] parsed: model=%q stream=%v messages=%d connector=%s\n",
+		req.Model, req.Stream, len(req.Messages), connectorName)
 
 	if len(req.Messages) == 0 {
 		writeOpenAIError(w, http.StatusBadRequest, "messages array is required and must not be empty")
@@ -938,7 +996,7 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 		}
 		agentCtx, agentSpan = p.otel.StartAgentSpan(
 			context.Background(),
-			conversationID, "openclaw", "",
+			conversationID, connectorName, "",
 		)
 	}
 	if agentCtx == nil {
@@ -974,7 +1032,7 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 		}
 
 		p.logPreCall(req.Model, req.Messages, verdict, elapsed)
-		p.recordTelemetry("prompt", req.Model, verdict, elapsed, nil, nil)
+		p.recordTelemetry("prompt", req.Model, verdict, elapsed, nil, nil, connectorName)
 
 		if verdict.Action == "block" && mode == "action" {
 			if p.otel != nil && agentSpan != nil {
@@ -1008,9 +1066,9 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 	}
 
 	if req.Stream {
-		p.handleStreamingRequest(w, r, &req, mode, customBlockMsg, upstream, agentCtx)
+		p.handleStreamingRequest(w, r, &req, mode, customBlockMsg, upstream, agentCtx, connectorName)
 	} else {
-		p.handleNonStreamingRequest(w, r, &req, mode, customBlockMsg, upstream, agentCtx)
+		p.handleNonStreamingRequest(w, r, &req, mode, customBlockMsg, upstream, agentCtx, connectorName)
 	}
 
 	// End invoke_agent span after the full request completes.
@@ -1019,7 +1077,7 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 	}
 }
 
-func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *http.Request, req *ChatRequest, mode, customBlockMsg string, upstream LLMProvider, agentCtx context.Context) {
+func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *http.Request, req *ChatRequest, mode, customBlockMsg string, upstream LLMProvider, agentCtx context.Context, connectorName string) {
 	aliasModel := req.Model
 	fmt.Fprintf(os.Stderr, "[guardrail] → upstream (non-streaming) model=%q messages=%d\n", req.Model, len(req.Messages))
 
@@ -1048,7 +1106,7 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[guardrail] upstream error: %v\n", err)
 		if p.otel != nil && llmSpan != nil {
-			p.otel.EndLLMSpan(llmSpan, aliasModel, 0, 0, []string{"error"}, 0, "none", "", system, llmStartTime, "openclaw")
+			p.otel.EndLLMSpan(llmSpan, aliasModel, 0, 0, []string{"error"}, 0, "none", "", system, llmStartTime, connectorName)
 		}
 		writeOpenAIError(w, http.StatusBadGateway, "upstream provider error: "+err.Error())
 		return
@@ -1107,7 +1165,7 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 			tokOut = &resp.Usage.CompletionTokens
 		}
 		p.logPostCall(aliasModel, content, verdict, elapsed, resp.Usage)
-		p.recordTelemetry("completion", aliasModel, verdict, elapsed, tokIn, tokOut)
+		p.recordTelemetry("completion", aliasModel, verdict, elapsed, tokIn, tokOut, connectorName)
 
 		if verdict.Severity != "NONE" {
 			guardrail = "local"
@@ -1121,7 +1179,7 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 					promptTok = int(resp.Usage.PromptTokens)
 					completionTok = int(resp.Usage.CompletionTokens)
 				}
-				p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, finishReasons, toolCallCount, guardrail, "blocked", system, llmStartTime, "openclaw")
+				p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, finishReasons, toolCallCount, guardrail, "blocked", system, llmStartTime, connectorName)
 			}
 			msg := blockMessage(customBlockMsg, "completion", verdict.Reason)
 			p.writeBlockedResponse(w, aliasModel, msg)
@@ -1162,7 +1220,7 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 			promptTok = int(resp.Usage.PromptTokens)
 			completionTok = int(resp.Usage.CompletionTokens)
 		}
-		p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, finishReasons, toolCallCount, guardrail, guardrailResult, system, llmStartTime, "openclaw")
+		p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, finishReasons, toolCallCount, guardrail, guardrailResult, system, llmStartTime, connectorName)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -1179,7 +1237,7 @@ func (p *GuardrailProxy) handleNonStreamingRequest(w http.ResponseWriter, r *htt
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.Request, req *ChatRequest, mode, customBlockMsg string, upstream LLMProvider, agentCtx context.Context) {
+func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.Request, req *ChatRequest, mode, customBlockMsg string, upstream LLMProvider, agentCtx context.Context, connectorName string) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		writeOpenAIError(w, http.StatusInternalServerError, "streaming not supported")
@@ -1256,7 +1314,7 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 			if midVerdict.Severity != "NONE" && midVerdict.Action == "block" {
 				fmt.Fprintf(os.Stderr, "[guardrail] STREAM-BLOCK severity=%s %s\n",
 					midVerdict.Severity, midVerdict.Reason)
-				p.recordTelemetry("completion", aliasModel, midVerdict, 0, nil, nil)
+				p.recordTelemetry("completion", aliasModel, midVerdict, 0, nil, nil, connectorName)
 				streamBlocked = true
 				streamCancel()
 				return
@@ -1291,7 +1349,7 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 	if err != nil && !streamBlocked {
 		fmt.Fprintf(os.Stderr, "[guardrail] stream error: %v\n", err)
 		if p.otel != nil && llmSpan != nil {
-			p.otel.EndLLMSpan(llmSpan, aliasModel, 0, 0, []string{"error"}, 0, "none", "", system, llmStartTime, "openclaw")
+			p.otel.EndLLMSpan(llmSpan, aliasModel, 0, 0, []string{"error"}, 0, "none", "", system, llmStartTime, connectorName)
 			llmSpan = nil
 		}
 	}
@@ -1356,7 +1414,7 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 		p.logPostCall(aliasModel, content, verdict, elapsed, &ChatUsage{
 			PromptTokens: ptrOr(tokIn, 0), CompletionTokens: ptrOr(tokOut, 0),
 		})
-		p.recordTelemetry("completion", aliasModel, verdict, elapsed, tokIn, tokOut)
+		p.recordTelemetry("completion", aliasModel, verdict, elapsed, tokIn, tokOut, connectorName)
 
 		if verdict.Severity != "NONE" {
 			guardrail = "local"
@@ -1396,7 +1454,7 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 			promptTok = int(usage.PromptTokens)
 			completionTok = int(usage.CompletionTokens)
 		}
-		p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, streamFinishReasons, toolCallCount, guardrail, guardrailResult, system, llmStartTime, "openclaw")
+		p.otel.EndLLMSpan(llmSpan, aliasModel, promptTok, completionTok, streamFinishReasons, toolCallCount, guardrail, guardrailResult, system, llmStartTime, connectorName)
 	}
 
 	// Flush buffered tool-call chunks only when inspection passed.
@@ -2002,7 +2060,7 @@ func patchRawResponseModel(raw json.RawMessage, model string) ([]byte, error) {
 // Telemetry
 // ---------------------------------------------------------------------------
 
-func (p *GuardrailProxy) recordTelemetry(direction, model string, verdict *ScanVerdict, elapsed time.Duration, tokIn, tokOut *int64) {
+func (p *GuardrailProxy) recordTelemetry(direction, model string, verdict *ScanVerdict, elapsed time.Duration, tokIn, tokOut *int64, connNames ...string) {
 	elapsedMs := float64(elapsed.Milliseconds())
 
 	details := fmt.Sprintf("direction=%s action=%s severity=%s findings=%d elapsed_ms=%.1f",
@@ -2038,7 +2096,11 @@ func (p *GuardrailProxy) recordTelemetry(direction, model string, verdict *ScanV
 			p.otel.RecordGuardrailEvaluation(ctx, "cisco-ai-defense", verdict.Action)
 		}
 		if tokIn != nil || tokOut != nil {
-			p.otel.RecordLLMTokens(ctx, "apply_guardrail", "defenseclaw", model, "openclaw", ptrOr(tokIn, 0), ptrOr(tokOut, 0))
+			cn := "openclaw"
+			if len(connNames) > 0 && connNames[0] != "" {
+				cn = connNames[0]
+			}
+			p.otel.RecordLLMTokens(ctx, "apply_guardrail", "defenseclaw", model, cn, ptrOr(tokIn, 0), ptrOr(tokOut, 0))
 		}
 	}
 }

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -1215,7 +1215,7 @@ func TestResolveProvider_FetchInterceptor(t *testing.T) {
 			targetURL: "",
 			apiKey:    "sk-key",
 			model:     "gpt-4",
-			wantNil:   true,
+			wantType:  "*gateway.openaiProvider", // direct-provider fallback uses configured model
 		},
 		{
 			name:      "unknown_domain",

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/defenseclaw/defenseclaw/internal/audit"
 	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
 	"github.com/defenseclaw/defenseclaw/internal/policy"
 	"github.com/defenseclaw/defenseclaw/internal/sandbox"
 	"github.com/defenseclaw/defenseclaw/internal/telemetry"
@@ -498,8 +499,55 @@ func (s *Sidecar) activeSessionKeys() []string {
 	return s.router.ActiveSessionKeys()
 }
 
+// buildConnectorRouter creates a connector.Router from the guardrail config.
+// OpenClaw connector is registered first (highest priority — detects via
+// X-DC-Target-URL), then ZeptoClaw if enabled, with Generic as fallback.
+func (s *Sidecar) buildConnectorRouter() *connector.Router {
+	dotenvPath := filepath.Join(s.cfg.DataDir, ".env")
+	masterKey := deriveMasterKey(s.cfg.DataDir)
+
+	connCfg := s.cfg.Guardrail.Connectors
+	var connectors []connector.Connector
+
+	// OpenClaw connector.
+	if connCfg.OpenClaw.Enabled {
+		tokenEnv := connCfg.OpenClaw.TokenEnv
+		if tokenEnv == "" {
+			tokenEnv = "OPENCLAW_GATEWAY_TOKEN"
+		}
+		gwToken := ResolveAPIKey(tokenEnv, dotenvPath)
+		connectors = append(connectors, connector.NewOpenClawConnector(gwToken, masterKey))
+	}
+
+	// ZeptoClaw connector.
+	if connCfg.ZeptoClaw.Enabled {
+		var zcToken string
+		if connCfg.ZeptoClaw.TokenEnv != "" {
+			zcToken = ResolveAPIKey(connCfg.ZeptoClaw.TokenEnv, dotenvPath)
+		}
+		// Convert config providers to connector.ZCProviderEntry map.
+		providers := make(map[string]connector.ZCProviderEntry)
+		for name, p := range connCfg.ZeptoClaw.Providers {
+			providers[name] = connector.ZCProviderEntry{
+				UpstreamURL: p.UpstreamURL,
+				AuthHeader:  p.AuthHeader,
+				AuthScheme:  p.AuthScheme,
+			}
+		}
+		connectors = append(connectors, connector.NewZeptoClawConnector(zcToken, masterKey, providers))
+	}
+
+	router := connector.NewRouter(connectors...)
+	router.SetFallback(connector.NewGenericConnector(nil))
+
+	fmt.Fprintf(os.Stderr, "[guardrail] connector router: %v\n", router.ConnectorNames())
+	return router
+}
+
 // runGuardrail starts the Go guardrail proxy when guardrail is enabled.
 func (s *Sidecar) runGuardrail(ctx context.Context) error {
+	connRouter := s.buildConnectorRouter()
+
 	proxy, err := NewGuardrailProxy(
 		&s.cfg.Guardrail,
 		&s.cfg.CiscoAIDefense,
@@ -510,6 +558,7 @@ func (s *Sidecar) runGuardrail(ctx context.Context) error {
 		s.cfg.DataDir,
 		s.cfg.PolicyDir,
 		s.notify,
+		connRouter,
 	)
 	if err != nil {
 		s.health.SetGuardrail(StateError, err.Error(), nil)


### PR DESCRIPTION
…proxy

Refactor the guardrail proxy from OpenClaw-only to a connector-based architecture where each agent framework (OpenClaw, ZeptoClaw, future frameworks) has a dedicated Connector that translates its request format into a canonical RoutingDecision the proxy core processes uniformly.

New connector package (internal/gateway/connector/):
- Connector interface: Name(), Detect(), Authenticate(), Route()
- ConnectorRouter: ordered detection (OpenClaw -> ZeptoClaw -> Generic)
- OpenClaw connector: X-DC-Target-URL header, fetch interceptor auth
- ZeptoClaw connector: model prefix inference, config/defaults URL resolution
- Generic connector: fallback for curl/future frameworks
- Shared helpers: SSRF check, provider inference, API key extraction
- Embedded default provider table (19 providers from ZeptoClaw registry)

Config changes:
- ConnectorsConfig in internal/config/connectors.go
- guardrail.connectors.openclaw (enabled by default)
- guardrail.connectors.zeptoclaw (disabled by default)

Proxy changes:
- proxy.go: connector-aware auth path with legacy fallback
- sidecar.go: buildConnectorRouter() from config
- Telemetry: connector name attribution (replaces hardcoded "openclaw")

Documentation updated:
- CLAUDE.md, GUARDRAIL.md, ARCHITECTURE.md, CONFIG_FILES.md

67 new tests across 6 test files. All existing tests pass.