### PR TITLE
Feat/webhook notifications

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -2,11 +2,11 @@
 
 ### Summary
 
-Adds an outbound webhook notification system that pushes enforcement events (skill/plugin blocks, drift alerts, guardrail blocks) to external systems in real time. Supports Slack, PagerDuty, and generic HTTP endpoints with per-endpoint severity filtering, event-type filtering, and automatic retry with exponential backoff.
+Adds an outbound webhook notification system that pushes enforcement events (skill/plugin blocks, drift alerts, guardrail blocks) to external systems in real time. Supports Slack, PagerDuty, Webex, and generic HTTP endpoints with per-endpoint severity filtering, event-type filtering, and automatic retry with exponential backoff.
 
 ### Motivation
 
-Before this PR, DefenseClaw enforcement events were only visible through the SQLite audit DB, the TUI dashboard, and Splunk HEC forwarding. There was no way to push real-time alerts to team collaboration tools (Slack) or incident management platforms (PagerDuty) without building custom integrations on top of the SIEM pipeline. This created a gap in operational workflows — security teams couldn't receive immediate, actionable notifications when a malicious skill was blocked or drift was detected.
+Before this PR, DefenseClaw enforcement events were only visible through the SQLite audit DB, the TUI dashboard, and Splunk HEC forwarding. There was no way to push real-time alerts to team collaboration tools (Slack, Webex) or incident management platforms (PagerDuty) without building custom integrations on top of the SIEM pipeline. This created a gap in operational workflows — security teams couldn't receive immediate, actionable notifications when a malicious skill was blocked or drift was detected.
 
 This PR closes that gap by adding a lightweight, configurable webhook dispatcher that runs alongside the existing audit pipeline.
 
@@ -16,22 +16,22 @@ This PR closes that gap by adding a lightweight, configurable webhook dispatcher
 
 | File | Purpose |
 |------|---------|
-| `internal/gateway/webhook.go` | `WebhookDispatcher` — async dispatch engine with retry, severity/event filtering, and payload formatters for Slack (Block Kit), PagerDuty (Events API v2), and generic JSON |
-| `internal/gateway/webhook_test.go` | 8 unit tests — payload formatting (Slack, PagerDuty, generic), severity filtering matrix, event-type filtering, action categorization, nil dispatcher safety, disabled endpoint handling |
-| `internal/gateway/webhook_e2e_test.go` | 9 E2E tests — full enforcement pipeline simulation, retry on transient failure, retry exhaustion, secret header validation, severity edge cases (25-combination matrix), enabled/disabled mixing, concurrent dispatch (50 goroutines), post-close safety |
+| `internal/gateway/webhook.go` | `WebhookDispatcher` — async dispatch engine with retry, severity/event filtering, and payload formatters for Slack (Block Kit), PagerDuty (Events API v2), Webex (Messages API with markdown), and generic JSON |
+| `internal/gateway/webhook_test.go` | 9 unit tests — payload formatting (Slack, PagerDuty, Webex, generic), severity filtering matrix, event-type filtering, action categorization, nil dispatcher safety, disabled endpoint handling |
+| `internal/gateway/webhook_e2e_test.go` | 11 E2E tests — full enforcement pipeline simulation, retry on transient failure, retry exhaustion, secret/auth header validation (generic, Slack, Webex Bearer), severity edge cases (25-combination matrix), Webex payload + multi-endpoint fan-out, enabled/disabled mixing, concurrent dispatch (50 goroutines), post-close safety |
 
 #### Modified Files
 
 | File | Change |
 |------|--------|
-| `internal/config/config.go` | Added `WebhookConfig` struct and `Webhooks []WebhookConfig` field to top-level `Config`; `ResolvedSecret()` helper reads secret from env var |
+| `internal/config/config.go` | Added `WebhookConfig` struct (with `RoomID` for Webex) and `Webhooks []WebhookConfig` field to top-level `Config`; `ResolvedSecret()` helper reads secret from env var |
 | `internal/gateway/sidecar.go` | Initializes `WebhookDispatcher` on startup; passes it to watcher and guardrail proxy; dispatches `block` events from `sendEnforcementAlert`; drains dispatcher on shutdown |
 | `internal/gateway/proxy.go` | Added `webhooks *WebhookDispatcher` field and `SetWebhookDispatcher` method; dispatches `guardrail-block` events from `recordTelemetry` when verdict is block |
 | `internal/watcher/watcher.go` | Added `WebhookDispatcher` interface and `SetWebhookDispatcher` method to break import cycle between `gateway` and `watcher` packages |
 | `internal/watcher/rescan.go` | Dispatches drift audit events to webhook dispatcher (if configured) after logging to audit store |
 | `cli/defenseclaw/config.py` | Mirrored `WebhookConfig` dataclass in Python CLI; added `_merge_webhooks()` parser; wired into `Config.webhooks` field |
 | `policies/default.yaml` | Added `webhooks: []` (disabled by default) |
-| `policies/strict.yaml` | Added `webhooks: []` with commented-out Slack/PagerDuty examples |
+| `policies/strict.yaml` | Added `webhooks: []` with commented-out Slack/Webex/PagerDuty examples |
 | `policies/permissive.yaml` | Added `webhooks: []` |
 | `schemas/audit-event.json` | Extended `action` enum with `"guardrail-block"` |
 | `README.md` | Added Notifications section with webhook config example and channel type table |
@@ -53,12 +53,13 @@ Enforcement Event Sources                  WebhookDispatcher
 │ Guardrail Proxy     │── guardrail ──────▶│  Payload formatters:         │
 │ (proxy.go)          │   block            │    ├─ Slack (Block Kit)      │
 └─────────────────────┘                    │    ├─ PagerDuty (Events v2)  │
+                                           │    ├─ Webex (Messages API)   │
                                            │    └─ Generic (flat JSON)    │
-                                           └──────┬───────┬───────┬──────┘
-                                                  │       │       │
-                                                  ▼       ▼       ▼
-                                              Slack   PagerDuty  HTTP
-                                             webhook   Events   endpoint
+                                           └──┬──────┬──────┬───────┬────┘
+                                              │      │      │       │
+                                              ▼      ▼      ▼       ▼
+                                           Slack  PagerDuty Webex  HTTP
+                                           webhook Events   Room  endpoint
 ```
 
 ### Webhook Channel Types
@@ -67,6 +68,7 @@ Enforcement Event Sources                  WebhookDispatcher
 |------|---------------|----------------|-------------|
 | `slack` | Block Kit attachments with severity-color-coded sidebar, header, section fields, context with event ID/timestamp | URL token embedded in Slack incoming webhook URL | 200 |
 | `pagerduty` | Events API v2 `trigger` with `dedup_key` (target+action), severity mapping (CRITICAL→critical, HIGH→error, MEDIUM→warning), `custom_details` | `routing_key` from `secret_env` | 202 |
+| `webex` | Markdown message via Webex Messages API (`POST /v1/messages`) with severity icon, structured fields, and `roomId` | Bot access token as `Authorization: Bearer` from `secret_env` | 200 |
 | `generic` | Flat JSON envelope (`webhook_type`, `defenseclaw_version`, nested `event` object with all audit fields) | `X-Webhook-Secret` header from `secret_env` | 200 |
 
 ### Severity and Event Filtering
@@ -101,6 +103,14 @@ webhooks:
     events: [block, drift, guardrail]
     enabled: true
 
+  - url: "https://webexapis.com/v1/messages"
+    type: webex
+    secret_env: WEBEX_BOT_TOKEN
+    room_id: "Y2lzY29zcGFyazovL3VzL1JPT00v..."
+    min_severity: HIGH
+    events: [block, drift, guardrail]
+    enabled: true
+
   - url: "https://events.pagerduty.com/v2/enqueue"
     type: pagerduty
     secret_env: PAGERDUTY_ROUTING_KEY
@@ -131,12 +141,14 @@ webhooks:
 
 ### Test Plan
 
-- [x] 8 unit tests pass (payload formatting, severity filtering, event-type filtering, action categorization, nil safety, disabled endpoints)
-- [x] 9 E2E tests pass:
+- [x] 9 unit tests pass (payload formatting for Slack, PagerDuty, Webex, generic; severity filtering, event-type filtering, action categorization, nil safety, disabled endpoints)
+- [x] 11 E2E tests pass:
   - [x] Full enforcement pipeline: 4 events (block, drift, guardrail-block, scan) → 3 endpoints (Slack, PagerDuty, generic) with correct routing, payload structure, and deep field validation
   - [x] Retry on transient failure: server returns 503 twice, then 200 — verifies 3 attempts
   - [x] Retry exhaustion: server always returns 500 — verifies exactly `maxRetries+1` attempts without hang
   - [x] Secret header: generic webhook receives `X-Webhook-Secret`, Slack does not
+  - [x] Webex payload + auth: verifies `Authorization: Bearer`, `roomId`, markdown content, no `X-Webhook-Secret`
+  - [x] Webex in multi-endpoint pipeline: Webex participates correctly alongside Slack and generic in fan-out with proper filtering
   - [x] Severity edge cases: 25-combination matrix (5 thresholds x 5 event severities)
   - [x] Mixed enabled/disabled: disabled and empty-URL endpoints skipped
   - [x] Concurrent dispatch: 50 goroutines dispatch simultaneously — no races, no lost payloads

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,147 @@
+## Webhook Notifications for Enforcement Events
+
+### Summary
+
+Adds an outbound webhook notification system that pushes enforcement events (skill/plugin blocks, drift alerts, guardrail blocks) to external systems in real time. Supports Slack, PagerDuty, and generic HTTP endpoints with per-endpoint severity filtering, event-type filtering, and automatic retry with exponential backoff.
+
+### Motivation
+
+Before this PR, DefenseClaw enforcement events were only visible through the SQLite audit DB, the TUI dashboard, and Splunk HEC forwarding. There was no way to push real-time alerts to team collaboration tools (Slack) or incident management platforms (PagerDuty) without building custom integrations on top of the SIEM pipeline. This created a gap in operational workflows — security teams couldn't receive immediate, actionable notifications when a malicious skill was blocked or drift was detected.
+
+This PR closes that gap by adding a lightweight, configurable webhook dispatcher that runs alongside the existing audit pipeline.
+
+### What Changed
+
+#### New Files
+
+| File | Purpose |
+|------|---------|
+| `internal/gateway/webhook.go` | `WebhookDispatcher` — async dispatch engine with retry, severity/event filtering, and payload formatters for Slack (Block Kit), PagerDuty (Events API v2), and generic JSON |
+| `internal/gateway/webhook_test.go` | 8 unit tests — payload formatting (Slack, PagerDuty, generic), severity filtering matrix, event-type filtering, action categorization, nil dispatcher safety, disabled endpoint handling |
+| `internal/gateway/webhook_e2e_test.go` | 9 E2E tests — full enforcement pipeline simulation, retry on transient failure, retry exhaustion, secret header validation, severity edge cases (25-combination matrix), enabled/disabled mixing, concurrent dispatch (50 goroutines), post-close safety |
+
+#### Modified Files
+
+| File | Change |
+|------|--------|
+| `internal/config/config.go` | Added `WebhookConfig` struct and `Webhooks []WebhookConfig` field to top-level `Config`; `ResolvedSecret()` helper reads secret from env var |
+| `internal/gateway/sidecar.go` | Initializes `WebhookDispatcher` on startup; passes it to watcher and guardrail proxy; dispatches `block` events from `sendEnforcementAlert`; drains dispatcher on shutdown |
+| `internal/gateway/proxy.go` | Added `webhooks *WebhookDispatcher` field and `SetWebhookDispatcher` method; dispatches `guardrail-block` events from `recordTelemetry` when verdict is block |
+| `internal/watcher/watcher.go` | Added `WebhookDispatcher` interface and `SetWebhookDispatcher` method to break import cycle between `gateway` and `watcher` packages |
+| `internal/watcher/rescan.go` | Dispatches drift audit events to webhook dispatcher (if configured) after logging to audit store |
+| `cli/defenseclaw/config.py` | Mirrored `WebhookConfig` dataclass in Python CLI; added `_merge_webhooks()` parser; wired into `Config.webhooks` field |
+| `policies/default.yaml` | Added `webhooks: []` (disabled by default) |
+| `policies/strict.yaml` | Added `webhooks: []` with commented-out Slack/PagerDuty examples |
+| `policies/permissive.yaml` | Added `webhooks: []` |
+| `schemas/audit-event.json` | Extended `action` enum with `"guardrail-block"` |
+| `README.md` | Added Notifications section with webhook config example and channel type table |
+| `docs/ARCHITECTURE.md` | Added webhook dispatch to Gateway responsibility table and data flow diagram |
+| `docs/CONFIG_FILES.md` | Added Webhook Notification Config section with full field reference |
+
+### Architecture
+
+```
+Enforcement Event Sources                  WebhookDispatcher
+                                           (internal/gateway/webhook.go)
+┌─────────────────────┐                    ┌──────────────────────────────┐
+│ Watcher             │──── block ────────▶│                              │
+│ (sidecar.go)        │                    │  For each configured endpoint│
+├─────────────────────┤                    │    ├─ severity ≥ threshold?  │
+│ Rescan Loop         │──── drift ────────▶│    ├─ event category match?  │
+│ (rescan.go)         │                    │    └─ async POST with retry  │
+├─────────────────────┤                    │                              │
+│ Guardrail Proxy     │── guardrail ──────▶│  Payload formatters:         │
+│ (proxy.go)          │   block            │    ├─ Slack (Block Kit)      │
+└─────────────────────┘                    │    ├─ PagerDuty (Events v2)  │
+                                           │    └─ Generic (flat JSON)    │
+                                           └──────┬───────┬───────┬──────┘
+                                                  │       │       │
+                                                  ▼       ▼       ▼
+                                              Slack   PagerDuty  HTTP
+                                             webhook   Events   endpoint
+```
+
+### Webhook Channel Types
+
+| Type | Payload Format | Auth Mechanism | Status Code |
+|------|---------------|----------------|-------------|
+| `slack` | Block Kit attachments with severity-color-coded sidebar, header, section fields, context with event ID/timestamp | URL token embedded in Slack incoming webhook URL | 200 |
+| `pagerduty` | Events API v2 `trigger` with `dedup_key` (target+action), severity mapping (CRITICAL→critical, HIGH→error, MEDIUM→warning), `custom_details` | `routing_key` from `secret_env` | 202 |
+| `generic` | Flat JSON envelope (`webhook_type`, `defenseclaw_version`, nested `event` object with all audit fields) | `X-Webhook-Secret` header from `secret_env` | 200 |
+
+### Severity and Event Filtering
+
+Each webhook endpoint can configure:
+
+- **`min_severity`** — only events at or above this rank are dispatched (CRITICAL=5, HIGH=4, MEDIUM=3, LOW=2, INFO=1)
+- **`events`** — list of event categories to include; empty means all. The `categorizeAction()` function maps audit actions to categories:
+
+| Audit Action | Category | Example Source |
+|-------------|----------|----------------|
+| `block`, `quarantine`, `disable` | `block` | Watcher blocks a malicious skill |
+| `drift`, `rescan` | `drift` | Periodic rescan detects mutation |
+| `guardrail-block`, `guardrail-*` | `guardrail` | Proxy blocks a prompt injection |
+| `scan` | `scan` | Routine scan completes |
+
+### Retry Behavior
+
+- Up to 3 retries (4 total attempts) with exponential backoff (2s, 4s, 6s)
+- Retries on HTTP 5xx responses and network errors
+- Non-retryable: 4xx responses, payload formatting errors
+- In-flight retries complete before `Close()` returns (graceful shutdown)
+- Events dispatched after `Close()` are silently dropped
+
+### Configuration Example
+
+```yaml
+webhooks:
+  - url: "https://hooks.slack.com/services/T00/B00/xxx"
+    type: slack
+    min_severity: HIGH
+    events: [block, drift, guardrail]
+    enabled: true
+
+  - url: "https://events.pagerduty.com/v2/enqueue"
+    type: pagerduty
+    secret_env: PAGERDUTY_ROUTING_KEY
+    min_severity: CRITICAL
+    events: [block]
+    enabled: true
+
+  - url: "https://security.internal.example.com/webhook"
+    type: generic
+    secret_env: WEBHOOK_SECRET
+    min_severity: INFO
+    events: []  # all events
+    timeout_seconds: 5
+    enabled: true
+```
+
+### Design Decisions
+
+1. **Interface in watcher package** — `WebhookDispatcher` is defined as an interface in `internal/watcher/watcher.go` to break the import cycle between `gateway` and `watcher` packages. The concrete struct lives in `gateway`.
+
+2. **Modeled after SplunkForwarder** — The dispatcher follows the same async fire-and-forget pattern as the existing Splunk HEC forwarder, with `wg.Add/Done` for graceful shutdown.
+
+3. **Retry backoff via struct field** — `retryBackoff` is a field (not just a constant) so E2E tests can zero it out for sub-second test execution without `time.Sleep` waits.
+
+4. **No new dependencies** — Uses only stdlib `net/http`, `encoding/json`, and `sync`. No external webhook libraries.
+
+5. **Disabled by default** — All policy presets ship with `webhooks: []`. Operators must explicitly configure and enable endpoints.
+
+### Test Plan
+
+- [x] 8 unit tests pass (payload formatting, severity filtering, event-type filtering, action categorization, nil safety, disabled endpoints)
+- [x] 9 E2E tests pass:
+  - [x] Full enforcement pipeline: 4 events (block, drift, guardrail-block, scan) → 3 endpoints (Slack, PagerDuty, generic) with correct routing, payload structure, and deep field validation
+  - [x] Retry on transient failure: server returns 503 twice, then 200 — verifies 3 attempts
+  - [x] Retry exhaustion: server always returns 500 — verifies exactly `maxRetries+1` attempts without hang
+  - [x] Secret header: generic webhook receives `X-Webhook-Secret`, Slack does not
+  - [x] Severity edge cases: 25-combination matrix (5 thresholds x 5 event severities)
+  - [x] Mixed enabled/disabled: disabled and empty-URL endpoints skipped
+  - [x] Concurrent dispatch: 50 goroutines dispatch simultaneously — no races, no lost payloads
+  - [x] Post-close safety: events after `Close()` silently dropped
+- [x] Full `go test ./...` passes (22 packages, zero regressions)
+- [x] `go vet ./...` clean
+- [x] No linter errors on changed files
+- [x] Documentation updated: README.md, ARCHITECTURE.md, CONFIG_FILES.md

--- a/README.md
+++ b/README.md
@@ -282,6 +282,41 @@ For full setup, architecture, monitoring, and debugging details, see [docs/SANDB
 
 ---
 
+## Notifications
+
+### Webhook Notifications
+
+DefenseClaw can push enforcement events to external systems in real time. When a skill is blocked, drift is detected, or a guardrail fires, the webhook dispatcher sends structured payloads to configured endpoints.
+
+Supported channel types:
+
+| Type | Payload format | Authentication |
+|------|---------------|----------------|
+| **Slack** | Block Kit attachments with color-coded severity | URL token (Slack incoming webhook URL) |
+| **PagerDuty** | Events API v2 trigger with dedup key | `routing_key` via `secret_env` |
+| **Generic** | Flat JSON with full event metadata | `X-Webhook-Secret` header via `secret_env` |
+
+Configure in `~/.defenseclaw/config.yaml`:
+
+```yaml
+webhooks:
+  - url: "https://hooks.slack.com/services/T00/B00/xxx"
+    type: slack
+    min_severity: HIGH
+    events: [block, drift, guardrail]
+    enabled: true
+  - url: "https://events.pagerduty.com/v2/enqueue"
+    type: pagerduty
+    secret_env: PAGERDUTY_ROUTING_KEY
+    min_severity: CRITICAL
+    events: [block]
+    enabled: true
+```
+
+Events are dispatched asynchronously with automatic retry (up to 3 retries with exponential backoff). Each endpoint can filter by minimum severity and event category (`block`, `drift`, `guardrail`, `scan`).
+
+---
+
 ## SIEM Integration
 
 ### Splunk HEC

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Supported channel types:
 |------|---------------|----------------|
 | **Slack** | Block Kit attachments with color-coded severity | URL token (Slack incoming webhook URL) |
 | **PagerDuty** | Events API v2 trigger with dedup key | `routing_key` via `secret_env` |
+| **Webex** | Markdown message via Webex Messages API | Bot Bearer token via `secret_env` |
 | **Generic** | Flat JSON with full event metadata | `X-Webhook-Secret` header via `secret_env` |
 
 Configure in `~/.defenseclaw/config.yaml`:
@@ -302,6 +303,13 @@ Configure in `~/.defenseclaw/config.yaml`:
 webhooks:
   - url: "https://hooks.slack.com/services/T00/B00/xxx"
     type: slack
+    min_severity: HIGH
+    events: [block, drift, guardrail]
+    enabled: true
+  - url: "https://webexapis.com/v1/messages"
+    type: webex
+    secret_env: WEBEX_BOT_TOKEN
+    room_id: "Y2lzY29zcGFyazovL3VzL1JPT00v..."
     min_severity: HIGH
     events: [block, drift, guardrail]
     enabled: true

--- a/cli/defenseclaw/config.py
+++ b/cli/defenseclaw/config.py
@@ -535,6 +535,23 @@ class JudgeConfig:
 
 
 @dataclass
+class WebhookConfig:
+    url: str = ""
+    type: str = "generic"
+    secret_env: str = ""
+    min_severity: str = "HIGH"
+    events: list[str] = field(default_factory=list)
+    timeout_seconds: int = 10
+    enabled: bool = False
+
+    def resolved_secret(self) -> str:
+        """Return the webhook secret/token from the env var."""
+        if self.secret_env:
+            return os.environ.get(self.secret_env, "")
+        return ""
+
+
+@dataclass
 class GuardrailConfig:
     enabled: bool = False
     mode: str = "observe"           # observe | action
@@ -572,6 +589,7 @@ class Config:
     skill_actions: SkillActionsConfig = field(default_factory=SkillActionsConfig)
     mcp_actions: MCPActionsConfig = field(default_factory=MCPActionsConfig)
     plugin_actions: PluginActionsConfig = field(default_factory=PluginActionsConfig)
+    webhooks: list[WebhookConfig] = field(default_factory=list)
 
     # -- Claw-mode path resolution (mirrors claw.go) --
 
@@ -915,6 +933,25 @@ def _merge_otel(raw: dict[str, Any] | None) -> OTelConfig:
     )
 
 
+def _merge_webhooks(raw: list[dict[str, Any]] | None) -> list[WebhookConfig]:
+    if not raw:
+        return []
+    webhooks: list[WebhookConfig] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        webhooks.append(WebhookConfig(
+            url=entry.get("url", ""),
+            type=entry.get("type", "generic"),
+            secret_env=entry.get("secret_env", ""),
+            min_severity=entry.get("min_severity", "HIGH"),
+            events=entry.get("events", []),
+            timeout_seconds=entry.get("timeout_seconds", 10),
+            enabled=entry.get("enabled", False),
+        ))
+    return webhooks
+
+
 def _merge_openshell(raw: dict[str, Any] | None) -> OpenShellConfig:
     if not raw:
         return OpenShellConfig()
@@ -1093,6 +1130,7 @@ def load() -> Config:
         skill_actions=_merge_skill_actions(raw.get("skill_actions")),
         mcp_actions=_merge_mcp_actions(raw.get("mcp_actions")),
         plugin_actions=_merge_plugin_actions(raw.get("plugin_actions")),
+        webhooks=_merge_webhooks(raw.get("webhooks")),
     )
     _warn_plaintext_secrets(cfg)
     return cfg

--- a/cli/defenseclaw/config.py
+++ b/cli/defenseclaw/config.py
@@ -539,6 +539,7 @@ class WebhookConfig:
     url: str = ""
     type: str = "generic"
     secret_env: str = ""
+    room_id: str = ""
     min_severity: str = "HIGH"
     events: list[str] = field(default_factory=list)
     timeout_seconds: int = 10
@@ -944,6 +945,7 @@ def _merge_webhooks(raw: list[dict[str, Any]] | None) -> list[WebhookConfig]:
             url=entry.get("url", ""),
             type=entry.get("type", "generic"),
             secret_env=entry.get("secret_env", ""),
+            room_id=entry.get("room_id", ""),
             min_severity=entry.get("min_severity", "HIGH"),
             events=entry.get("events", []),
             timeout_seconds=entry.get("timeout_seconds", 10),

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -44,6 +44,7 @@ from defenseclaw.config import (
     SeverityAction,
     SkillActionsConfig,
     SkillScannerConfig,
+    WebhookConfig,
     WatchConfig,
     _dedup,
     _expand,
@@ -56,6 +57,7 @@ from defenseclaw.config import (
     _merge_guardrail,
     _merge_severity_action,
     _merge_skill_actions,
+    _merge_webhooks,
     default_config,
     default_data_path,
     config_path,
@@ -858,6 +860,97 @@ class TestOpenShellSandboxFields(unittest.TestCase):
                 self.assertEqual(cfg.openshell.version, "0.7.0")
                 self.assertEqual(cfg.openshell.sandbox_home, "/opt/sandbox")
                 self.assertFalse(cfg.openshell.auto_pair)
+
+
+class TestWebhookConfig(unittest.TestCase):
+    """Tests for WebhookConfig, _merge_webhooks, and resolved_secret."""
+
+    def test_merge_valid_yaml(self):
+        raw = [
+            {
+                "url": "https://hooks.slack.com/services/T/B/xxx",
+                "type": "slack",
+                "secret_env": "SLACK_TOKEN",
+                "min_severity": "MEDIUM",
+                "events": ["block", "drift"],
+                "timeout_seconds": 15,
+                "enabled": True,
+            },
+            {
+                "url": "https://pd.example.com",
+                "type": "pagerduty",
+                "enabled": False,
+            },
+        ]
+        result = _merge_webhooks(raw)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].url, "https://hooks.slack.com/services/T/B/xxx")
+        self.assertEqual(result[0].type, "slack")
+        self.assertEqual(result[0].min_severity, "MEDIUM")
+        self.assertEqual(result[0].events, ["block", "drift"])
+        self.assertEqual(result[0].timeout_seconds, 15)
+        self.assertTrue(result[0].enabled)
+        self.assertFalse(result[1].enabled)
+
+    def test_merge_empty_and_none(self):
+        self.assertEqual(_merge_webhooks(None), [])
+        self.assertEqual(_merge_webhooks([]), [])
+
+    def test_merge_skips_non_dict(self):
+        result = _merge_webhooks(["not-a-dict", 42, None])
+        self.assertEqual(result, [])
+
+    def test_merge_defaults(self):
+        result = _merge_webhooks([{}])
+        self.assertEqual(len(result), 1)
+        wh = result[0]
+        self.assertEqual(wh.url, "")
+        self.assertEqual(wh.type, "generic")
+        self.assertEqual(wh.min_severity, "HIGH")
+        self.assertEqual(wh.timeout_seconds, 10)
+        self.assertFalse(wh.enabled)
+
+    def test_resolved_secret_from_env(self):
+        wh = WebhookConfig(secret_env="TEST_WH_SECRET_42")
+        with patch.dict(os.environ, {"TEST_WH_SECRET_42": "s3cret"}):
+            self.assertEqual(wh.resolved_secret(), "s3cret")
+
+    def test_resolved_secret_missing_env(self):
+        wh = WebhookConfig(secret_env="NONEXISTENT_VAR_99")
+        env = os.environ.copy()
+        env.pop("NONEXISTENT_VAR_99", None)
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(wh.resolved_secret(), "")
+
+    def test_resolved_secret_no_env_configured(self):
+        wh = WebhookConfig()
+        self.assertEqual(wh.resolved_secret(), "")
+
+    def test_roundtrip_preservation(self):
+        """Ensure load() preserves webhooks from YAML so init doesn't drop them."""
+        import yaml
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg_data = {
+                "webhooks": [
+                    {
+                        "url": "https://hooks.example.com/abc",
+                        "type": "generic",
+                        "enabled": True,
+                        "min_severity": "LOW",
+                    }
+                ],
+            }
+            with open(os.path.join(tmpdir, "config.yaml"), "w") as f:
+                yaml.dump(cfg_data, f)
+
+            with patch("defenseclaw.config.default_data_path") as mock_dp:
+                mock_dp.return_value = Path(tmpdir)
+                cfg = load()
+                self.assertEqual(len(cfg.webhooks), 1)
+                self.assertEqual(cfg.webhooks[0].url, "https://hooks.example.com/abc")
+                self.assertTrue(cfg.webhooks[0].enabled)
+                self.assertEqual(cfg.webhooks[0].min_severity, "LOW")
 
 
 if __name__ == "__main__":

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,6 +155,7 @@ only component with direct access to all subsystems.
 | Policy engine | Runs admission gate: block list → allow list → scan → verdict |
 | LLM guardrail management | Runs guardrail proxy; restarts on crash |
 | Audit / SIEM | Logs all events to SQLite, forwards to Splunk HEC (batch or real-time) |
+| Webhook dispatch | Pushes enforcement events (block, drift, guardrail-block) to configured webhook endpoints (Slack, PagerDuty, generic HTTP) with severity filtering, event-type filtering, and retry |
 | DB access | Full read/write to SQLite — scan results, block/allow lists, inventory |
 
 ### 4. SQLite Database
@@ -211,8 +212,9 @@ See `docs/GUARDRAIL.md` for the full data flow.
               │                                      │
               │  3. Log audit event                  │
               │  4. Forward to SIEM (if configured)  │
-              │  5. Evaluate policy (if action req)  │
-              │  6. Send command to OpenClaw via WS   │
+              │  5. Dispatch to webhooks (if config) │
+              │  6. Evaluate policy (if action req)  │
+              │  7. Send command to OpenClaw via WS   │
               └──────────────────────────────────────┘
                               │
                               ▼

--- a/docs/CONFIG_FILES.md
+++ b/docs/CONFIG_FILES.md
@@ -209,9 +209,10 @@ webhooks:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `url` | string | `""` | Webhook endpoint URL. Required. |
-| `type` | string | `"generic"` | Channel type: `slack` (Block Kit), `pagerduty` (Events API v2), or `generic` (flat JSON). |
-| `secret_env` | string | `""` | Name of an environment variable holding the secret. For `pagerduty`, this is the routing key. For `generic`, the value is sent as `X-Webhook-Secret` header. Not used for `slack`. |
+| `url` | string | `""` | Webhook endpoint URL. Required. For Webex, use `https://webexapis.com/v1/messages`. |
+| `type` | string | `"generic"` | Channel type: `slack` (Block Kit), `pagerduty` (Events API v2), `webex` (Webex Messages API), or `generic` (flat JSON). |
+| `secret_env` | string | `""` | Name of an environment variable holding the secret. For `pagerduty`, this is the routing key. For `webex`, this is the bot access token (sent as `Authorization: Bearer`). For `generic`, the value is sent as `X-Webhook-Secret` header. Not used for `slack`. |
+| `room_id` | string | `""` | Webex room ID to post messages to. Required when `type` is `webex`. |
 | `min_severity` | string | `"HIGH"` | Minimum event severity to dispatch. Events below this threshold are silently dropped. |
 | `events` | list | `[]` | Event categories to include. Empty means all categories. Valid values: `block`, `drift`, `guardrail`, `scan`. |
 | `timeout_seconds` | int | `10` | HTTP timeout per webhook request. |

--- a/docs/CONFIG_FILES.md
+++ b/docs/CONFIG_FILES.md
@@ -209,10 +209,10 @@ webhooks:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `url` | string | `""` | Webhook endpoint URL. Required. For Webex, use `https://webexapis.com/v1/messages`. |
-| `type` | string | `"generic"` | Channel type: `slack` (Block Kit), `pagerduty` (Events API v2), `webex` (Webex Messages API), or `generic` (flat JSON). |
-| `secret_env` | string | `""` | Name of an environment variable holding the secret. For `pagerduty`, this is the routing key. For `webex`, this is the bot access token (sent as `Authorization: Bearer`). For `generic`, the value is sent as `X-Webhook-Secret` header. Not used for `slack`. |
-| `room_id` | string | `""` | Webex room ID to post messages to. Required when `type` is `webex`. |
+| `url` | string | `""` | Webhook endpoint URL. Required. For Webex bot, use `https://webexapis.com/v1/messages`. For Webex Incoming Webhooks, use the full incoming webhook URL. |
+| `type` | string | `"generic"` | Channel type: `slack` (Block Kit), `pagerduty` (Events API v2), `webex` (Webex Messages API or Incoming Webhook), or `generic` (flat JSON). |
+| `secret_env` | string | `""` | Name of an environment variable holding the secret. For `pagerduty`, this is the routing key. For `webex` with the Messages API, this is the bot access token (sent as `Authorization: Bearer`). Not needed for Webex Incoming Webhooks. For `generic`, the value is used for HMAC-SHA256 signing (`X-Hub-Signature-256`). Not used for `slack`. |
+| `room_id` | string | `""` | Webex room ID to post messages to. Required when `type` is `webex` with the Messages API. Omit for Webex Incoming Webhooks (room is embedded in the URL). |
 | `min_severity` | string | `"HIGH"` | Minimum event severity to dispatch. Events below this threshold are silently dropped. |
 | `events` | list | `[]` | Event categories to include. Empty means all categories. Valid values: `block`, `drift`, `guardrail`, `scan`. |
 | `timeout_seconds` | int | `10` | HTTP timeout per webhook request. |

--- a/docs/CONFIG_FILES.md
+++ b/docs/CONFIG_FILES.md
@@ -46,10 +46,10 @@ GUARDRAIL PROXY:
 ### `~/.defenseclaw/config.yaml`
 
 Central config file shared by the Go sidecar and the Python CLI. Stores
-scanner settings, gateway connection, watcher config, guardrail settings
-(including model routing and `guardrail.port` for the built-in proxy — no
-separate proxy YAML file), top-level `cisco_ai_defense` settings, skill actions,
-and everything else.
+scanner settings, gateway connection, watcher config, webhook notifications,
+guardrail settings (including model routing and `guardrail.port` for the
+built-in proxy — no separate proxy YAML file), top-level `cisco_ai_defense`
+settings, skill actions, and everything else.
 
 | | |
 |---|---|
@@ -184,3 +184,41 @@ standalone mode (Linux supervisor with Landlock, seccomp, network namespace).
 | **Set by** | `defenseclaw setup sandbox --host-ip <ip>` |
 | **Read by** | **Python CLI** `patch_openclaw_config()` — sets the `defenseclaw` provider `baseUrl` in `openclaw.json` to `http://{host}:{guardrail.port}`. **Go sidecar** `runAPI()` — in standalone mode, when `api_bind` is unset and host is not `localhost`, uses `guardrail.host` as the REST API bind address. |
 | **Effect** | Lets OpenClaw inside the sandbox point at the guardrail proxy and sidecar API on the host veth IP. |
+
+---
+
+## Webhook Notification Config
+
+The `webhooks` section in `config.yaml` configures outbound HTTP notifications
+for enforcement events. Each entry defines a webhook endpoint. Disabled by
+default in all policy presets.
+
+```yaml
+webhooks:
+  - url: "https://hooks.slack.com/services/T00/B00/xxx"
+    type: slack              # slack | pagerduty | generic
+    secret_env: ""           # env var name holding the auth secret/token
+    min_severity: HIGH       # minimum severity to dispatch (CRITICAL, HIGH, MEDIUM, LOW, INFO)
+    events:                  # event categories to dispatch (empty = all)
+      - block
+      - drift
+      - guardrail
+    timeout_seconds: 10      # per-request HTTP timeout
+    enabled: true            # set false to disable without removing the entry
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `url` | string | `""` | Webhook endpoint URL. Required. |
+| `type` | string | `"generic"` | Channel type: `slack` (Block Kit), `pagerduty` (Events API v2), or `generic` (flat JSON). |
+| `secret_env` | string | `""` | Name of an environment variable holding the secret. For `pagerduty`, this is the routing key. For `generic`, the value is sent as `X-Webhook-Secret` header. Not used for `slack`. |
+| `min_severity` | string | `"HIGH"` | Minimum event severity to dispatch. Events below this threshold are silently dropped. |
+| `events` | list | `[]` | Event categories to include. Empty means all categories. Valid values: `block`, `drift`, `guardrail`, `scan`. |
+| `timeout_seconds` | int | `10` | HTTP timeout per webhook request. |
+| `enabled` | bool | `false` | Whether this endpoint is active. |
+
+| | |
+|---|---|
+| **Set by** | Operator, manually in `config.yaml`. |
+| **Read by** | **Go sidecar** at startup via `config.Load()`. **Python CLI** via `config.load()` (read-only, for display). |
+| **Effect** | When enabled, the `WebhookDispatcher` in `internal/gateway/webhook.go` sends structured JSON payloads to each endpoint when enforcement events (block, drift, guardrail-block) occur. Retries up to 3 times with exponential backoff on transient failures (5xx, network errors). |

--- a/internal/audit/severity.go
+++ b/internal/audit/severity.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package audit
+
+import "strings"
+
+// SeverityRank maps a severity string to an integer for comparison.
+// CRITICAL=5, HIGH=4, MEDIUM=3, LOW=2, INFO=1, unknown=0.
+func SeverityRank(s string) int {
+	switch strings.ToUpper(s) {
+	case "CRITICAL":
+		return 5
+	case "HIGH":
+		return 4
+	case "MEDIUM":
+		return 3
+	case "LOW":
+		return 2
+	case "INFO":
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -150,6 +150,7 @@ type WebhookConfig struct {
 	URL            string   `mapstructure:"url"             yaml:"url"`
 	Type           string   `mapstructure:"type"            yaml:"type"`
 	SecretEnv      string   `mapstructure:"secret_env"      yaml:"secret_env"`
+	RoomID         string   `mapstructure:"room_id"         yaml:"room_id"`
 	MinSeverity    string   `mapstructure:"min_severity"    yaml:"min_severity"`
 	Events         []string `mapstructure:"events"          yaml:"events"`
 	TimeoutSeconds int      `mapstructure:"timeout_seconds" yaml:"timeout_seconds"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	MCPActions     MCPActionsConfig     `mapstructure:"mcp_actions"      yaml:"mcp_actions"`
 	PluginActions  PluginActionsConfig  `mapstructure:"plugin_actions"   yaml:"plugin_actions"`
 	OTel           OTelConfig           `mapstructure:"otel"             yaml:"otel"`
+	Webhooks       []WebhookConfig      `mapstructure:"webhooks"         yaml:"webhooks"`
 }
 
 type OTelConfig struct {
@@ -143,6 +144,24 @@ func (c *SplunkConfig) ResolvedHECToken() string {
 		}
 	}
 	return c.HECToken
+}
+
+type WebhookConfig struct {
+	URL            string   `mapstructure:"url"             yaml:"url"`
+	Type           string   `mapstructure:"type"            yaml:"type"`
+	SecretEnv      string   `mapstructure:"secret_env"      yaml:"secret_env"`
+	MinSeverity    string   `mapstructure:"min_severity"    yaml:"min_severity"`
+	Events         []string `mapstructure:"events"          yaml:"events"`
+	TimeoutSeconds int      `mapstructure:"timeout_seconds" yaml:"timeout_seconds"`
+	Enabled        bool     `mapstructure:"enabled"         yaml:"enabled"`
+}
+
+// ResolvedSecret returns the webhook secret/token from the env var.
+func (c *WebhookConfig) ResolvedSecret() string {
+	if c.SecretEnv != "" {
+		return os.Getenv(c.SecretEnv)
+	}
+	return ""
 }
 
 type WatchConfig struct {

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -81,6 +81,7 @@ type GuardrailProxy struct {
 	masterKey        string
 	gatewayToken     string // OPENCLAW_GATEWAY_TOKEN, accepted in X-DC-Auth
 	notify           *NotificationQueue
+	webhooks         *WebhookDispatcher
 
 	// resolveProviderFn selects the upstream LLMProvider for a request.
 	// Defaults to resolveProviderFromHeaders (uses X-DC-Target-URL).
@@ -145,6 +146,11 @@ func NewGuardrailProxy(
 	}
 	p.resolveProviderFn = p.resolveProviderFromHeaders
 	return p, nil
+}
+
+// SetWebhookDispatcher attaches a webhook dispatcher for guardrail block notifications.
+func (p *GuardrailProxy) SetWebhookDispatcher(d *WebhookDispatcher) {
+	p.webhooks = d
 }
 
 // Run starts the HTTP server and blocks until ctx is cancelled.
@@ -2106,6 +2112,18 @@ func (p *GuardrailProxy) recordTelemetry(direction, model string, verdict *ScanV
 		if tokIn != nil || tokOut != nil {
 			p.otel.RecordLLMTokens(ctx, "apply_guardrail", "defenseclaw", model, "openclaw", ptrOr(tokIn, 0), ptrOr(tokOut, 0))
 		}
+	}
+
+	if p.webhooks != nil && verdict.Action == "block" {
+		event := audit.Event{
+			Timestamp: time.Now().UTC(),
+			Action:    "guardrail-block",
+			Target:    model,
+			Actor:     "defenseclaw-guardrail",
+			Details:   details,
+			Severity:  verdict.Severity,
+		}
+		p.webhooks.Dispatch(event)
 	}
 }
 

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -39,6 +39,7 @@ import (
 	"github.com/defenseclaw/defenseclaw/internal/config"
 	"github.com/defenseclaw/defenseclaw/internal/configs"
 	"github.com/defenseclaw/defenseclaw/internal/telemetry"
+	"github.com/google/uuid"
 )
 
 // guardrailListenAddr returns the TCP listen address for the guardrail HTTP server.
@@ -2116,6 +2117,7 @@ func (p *GuardrailProxy) recordTelemetry(direction, model string, verdict *ScanV
 
 	if p.webhooks != nil && verdict.Action == "block" {
 		event := audit.Event{
+			ID:        uuid.New().String(),
 			Timestamp: time.Now().UTC(),
 			Action:    "guardrail-block",
 			Target:    model,

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -38,16 +38,17 @@ import (
 // Sidecar is the long-running process that connects to the OpenClaw gateway,
 // watches for skill installs, and exposes a local REST API.
 type Sidecar struct {
-	cfg    *config.Config
-	client *Client
-	router *EventRouter
-	store  *audit.Store
-	logger *audit.Logger
-	health *SidecarHealth
-	shell  *sandbox.OpenShell
-	otel   *telemetry.Provider
-	notify *NotificationQueue
-	opa    *policy.Engine
+	cfg      *config.Config
+	client   *Client
+	router   *EventRouter
+	store    *audit.Store
+	logger   *audit.Logger
+	health   *SidecarHealth
+	shell    *sandbox.OpenShell
+	otel     *telemetry.Provider
+	notify   *NotificationQueue
+	opa      *policy.Engine
+	webhooks *WebhookDispatcher
 
 	alertCtx    context.Context
 	alertCancel context.CancelFunc
@@ -92,6 +93,14 @@ func NewSidecar(cfg *config.Config, store *audit.Store, logger *audit.Logger, sh
 
 	alertCtx, alertCancel := context.WithCancel(context.Background())
 
+	var webhooks *WebhookDispatcher
+	if len(cfg.Webhooks) > 0 {
+		webhooks = NewWebhookDispatcher(cfg.Webhooks)
+		if webhooks != nil {
+			fmt.Fprintf(os.Stderr, "[sidecar] webhook dispatcher initialized (%d endpoints)\n", len(webhooks.endpoints))
+		}
+	}
+
 	return &Sidecar{
 		cfg:         cfg,
 		client:      client,
@@ -102,6 +111,7 @@ func NewSidecar(cfg *config.Config, store *audit.Store, logger *audit.Logger, sh
 		shell:       shell,
 		otel:        otel,
 		notify:      notify,
+		webhooks:    webhooks,
 		alertCtx:    alertCtx,
 		alertCancel: alertCancel,
 	}, nil
@@ -200,6 +210,9 @@ func (s *Sidecar) Run(ctx context.Context) error {
 	s.alertWg.Wait()
 
 	_ = s.logger.LogAction("sidecar-stop", "", "all subsystems stopped")
+	if s.webhooks != nil {
+		s.webhooks.Close()
+	}
 	s.logger.Close()
 	_ = s.client.Close()
 
@@ -312,6 +325,9 @@ func (s *Sidecar) runWatcher(ctx context.Context) error {
 	})
 	if s.otel != nil {
 		w.SetOTelProvider(s.otel)
+	}
+	if s.webhooks != nil {
+		w.SetWebhookDispatcher(s.webhooks)
 	}
 
 	fmt.Fprintf(os.Stderr, "[sidecar] watcher starting (%d skill dirs, %d plugin dirs, skill_take_action=%v, plugin_take_action=%v)\n",
@@ -442,6 +458,18 @@ func (s *Sidecar) sendEnforcementAlert(subjectType, subjectName, severity string
 	if sent == 0 {
 		fmt.Fprintf(os.Stderr, "[sidecar] enforcement alert: all sessions.send failed, queued for guardrail injection\n")
 	}
+
+	if s.webhooks != nil {
+		event := audit.Event{
+			Timestamp: time.Now().UTC(),
+			Action:    "block",
+			Target:    subjectName,
+			Actor:     "defenseclaw-watcher",
+			Details:   fmt.Sprintf("type=%s severity=%s findings=%d actions=%s reason=%s", subjectType, severity, findings, strings.Join(actions, ","), reason),
+			Severity:  severity,
+		}
+		s.webhooks.Dispatch(event)
+	}
 }
 
 // formatEnforcementMessage builds a human-readable security alert for chat.
@@ -532,6 +560,9 @@ func (s *Sidecar) runGuardrail(ctx context.Context) error {
 		s.cfg.PolicyDir,
 		s.notify,
 	)
+	if err == nil && s.webhooks != nil {
+		proxy.SetWebhookDispatcher(s.webhooks)
+	}
 	if err != nil {
 		s.health.SetGuardrail(StateError, err.Error(), nil)
 		fmt.Fprintf(os.Stderr, "[guardrail] init error: %v\n", err)

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -33,6 +33,7 @@ import (
 	"github.com/defenseclaw/defenseclaw/internal/sandbox"
 	"github.com/defenseclaw/defenseclaw/internal/telemetry"
 	"github.com/defenseclaw/defenseclaw/internal/watcher"
+	"github.com/google/uuid"
 )
 
 // Sidecar is the long-running process that connects to the OpenClaw gateway,
@@ -432,6 +433,19 @@ func (s *Sidecar) sendEnforcementAlert(subjectType, subjectName, severity string
 		s.notify.Push(notification)
 	}
 
+	if s.webhooks != nil {
+		event := audit.Event{
+			ID:        uuid.New().String(),
+			Timestamp: time.Now().UTC(),
+			Action:    "block",
+			Target:    subjectName,
+			Actor:     "defenseclaw-watcher",
+			Details:   fmt.Sprintf("type=%s severity=%s findings=%d actions=%s reason=%s", subjectType, severity, findings, strings.Join(actions, ","), reason),
+			Severity:  severity,
+		}
+		s.webhooks.Dispatch(event)
+	}
+
 	sessionKeys := s.activeSessionKeys()
 	if len(sessionKeys) == 0 {
 		fmt.Fprintf(os.Stderr, "[sidecar] enforcement alert: no active sessions tracked, queued for guardrail injection\n")
@@ -457,18 +471,6 @@ func (s *Sidecar) sendEnforcementAlert(subjectType, subjectName, severity string
 
 	if sent == 0 {
 		fmt.Fprintf(os.Stderr, "[sidecar] enforcement alert: all sessions.send failed, queued for guardrail injection\n")
-	}
-
-	if s.webhooks != nil {
-		event := audit.Event{
-			Timestamp: time.Now().UTC(),
-			Action:    "block",
-			Target:    subjectName,
-			Actor:     "defenseclaw-watcher",
-			Details:   fmt.Sprintf("type=%s severity=%s findings=%d actions=%s reason=%s", subjectType, severity, findings, strings.Join(actions, ","), reason),
-			Severity:  severity,
-		}
-		s.webhooks.Dispatch(event)
 	}
 }
 

--- a/internal/gateway/webhook.go
+++ b/internal/gateway/webhook.go
@@ -44,8 +44,9 @@ type WebhookDispatcher struct {
 
 type webhookEndpoint struct {
 	url         string
-	channelType string // slack, pagerduty, generic
+	channelType string // slack, pagerduty, webex, generic
 	secret      string
+	roomID      string
 	minSeverity int
 	events      map[string]bool
 }
@@ -75,6 +76,7 @@ func NewWebhookDispatcher(cfgs []config.WebhookConfig) *WebhookDispatcher {
 			url:         c.URL,
 			channelType: strings.ToLower(c.Type),
 			secret:      c.ResolvedSecret(),
+			roomID:      c.RoomID,
 			minSeverity: severityToRank(c.MinSeverity),
 			events:      evts,
 		})
@@ -152,6 +154,8 @@ func (d *WebhookDispatcher) send(ep *webhookEndpoint, event audit.Event) {
 		payload, err = formatSlackPayload(event)
 	case "pagerduty":
 		payload, err = formatPagerDutyPayload(event, ep.secret)
+	case "webex":
+		payload, err = formatWebexPayload(event, ep.roomID)
 	default:
 		payload, err = formatGenericPayload(event)
 	}
@@ -174,7 +178,10 @@ func (d *WebhookDispatcher) send(ep *webhookEndpoint, event audit.Event) {
 			return
 		}
 		req.Header.Set("Content-Type", "application/json")
-		if ep.secret != "" && ep.channelType == "generic" {
+		switch {
+		case ep.channelType == "webex" && ep.secret != "":
+			req.Header.Set("Authorization", "Bearer "+ep.secret)
+		case ep.channelType == "generic" && ep.secret != "":
 			req.Header.Set("X-Webhook-Secret", ep.secret)
 		}
 
@@ -278,6 +285,32 @@ func formatPagerDutyPayload(event audit.Event, routingKey string) ([]byte, error
 	return json.Marshal(payload)
 }
 
+func formatWebexPayload(event audit.Event, roomID string) ([]byte, error) {
+	severity := strings.ToUpper(event.Severity)
+	icon := webexSeverityIcon(severity)
+	markdown := fmt.Sprintf(
+		"%s **DefenseClaw: %s**\n\n"+
+			"- **Severity:** %s\n"+
+			"- **Target:** `%s`\n"+
+			"- **Actor:** %s\n",
+		icon, event.Action, severity, event.Target, event.Actor,
+	)
+	if event.Details != "" {
+		details := event.Details
+		if len(details) > 500 {
+			details = details[:500] + "..."
+		}
+		markdown += fmt.Sprintf("- **Details:** %s\n", details)
+	}
+	markdown += fmt.Sprintf("\n_Event ID: %s | %s_", event.ID, event.Timestamp.Format(time.RFC3339))
+
+	payload := map[string]interface{}{
+		"roomId":   roomID,
+		"markdown": markdown,
+	}
+	return json.Marshal(payload)
+}
+
 func formatGenericPayload(event audit.Event) ([]byte, error) {
 	payload := map[string]interface{}{
 		"webhook_type":        "defenseclaw_enforcement",
@@ -313,6 +346,21 @@ func slackColor(severity string) string {
 		return "#36A64F"
 	default:
 		return "#439FE0"
+	}
+}
+
+func webexSeverityIcon(severity string) string {
+	switch severity {
+	case "CRITICAL":
+		return "🔴"
+	case "HIGH":
+		return "🟠"
+	case "MEDIUM":
+		return "🟡"
+	case "LOW":
+		return "🟢"
+	default:
+		return "🔵"
 	}
 }
 

--- a/internal/gateway/webhook.go
+++ b/internal/gateway/webhook.go
@@ -1,0 +1,353 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/audit"
+	"github.com/defenseclaw/defenseclaw/internal/config"
+)
+
+// WebhookDispatcher sends structured JSON payloads to configured webhook
+// endpoints when enforcement events occur. Modeled after the SplunkForwarder.
+type WebhookDispatcher struct {
+	endpoints    []webhookEndpoint
+	client       *http.Client
+	retryBackoff time.Duration
+	wg           sync.WaitGroup
+	done         chan struct{}
+}
+
+type webhookEndpoint struct {
+	url         string
+	channelType string // slack, pagerduty, generic
+	secret      string
+	minSeverity int
+	events      map[string]bool
+	headers     map[string]string
+}
+
+const (
+	webhookMaxRetries   = 3
+	webhookRetryBackoff = 2 * time.Second
+)
+
+// NewWebhookDispatcher creates a dispatcher from the config slice.
+// Endpoints with enabled=false or empty URL are skipped.
+func NewWebhookDispatcher(cfgs []config.WebhookConfig) *WebhookDispatcher {
+	var endpoints []webhookEndpoint
+	for _, c := range cfgs {
+		if !c.Enabled || c.URL == "" {
+			continue
+		}
+		evts := make(map[string]bool)
+		for _, e := range c.Events {
+			evts[strings.ToLower(e)] = true
+		}
+		timeout := time.Duration(c.TimeoutSeconds) * time.Second
+		if timeout <= 0 {
+			timeout = 10 * time.Second
+		}
+		endpoints = append(endpoints, webhookEndpoint{
+			url:         c.URL,
+			channelType: strings.ToLower(c.Type),
+			secret:      c.ResolvedSecret(),
+			minSeverity: severityToRank(c.MinSeverity),
+			events:      evts,
+		})
+		_ = timeout // per-endpoint timeout not used for shared client
+	}
+	if len(endpoints) == 0 {
+		return nil
+	}
+	return &WebhookDispatcher{
+		endpoints: endpoints,
+		client: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+		retryBackoff: webhookRetryBackoff,
+		done:         make(chan struct{}),
+	}
+}
+
+// Dispatch sends the event to all matching endpoints asynchronously.
+// Events dispatched after Close are silently dropped.
+func (d *WebhookDispatcher) Dispatch(event audit.Event) {
+	if d == nil || d.closing() {
+		return
+	}
+	rank := severityToRank(event.Severity)
+	action := strings.ToLower(event.Action)
+	eventCategory := categorizeAction(action)
+
+	for i := range d.endpoints {
+		ep := &d.endpoints[i]
+		if rank < ep.minSeverity {
+			continue
+		}
+		if len(ep.events) > 0 && !ep.events[eventCategory] {
+			continue
+		}
+		d.wg.Add(1)
+		go func(ep *webhookEndpoint) {
+			defer d.wg.Done()
+			d.send(ep, event)
+		}(ep)
+	}
+}
+
+// Close drains all in-flight sends (including retries) and then returns.
+// New dispatches after Close are silently dropped.
+func (d *WebhookDispatcher) Close() {
+	if d == nil {
+		return
+	}
+	select {
+	case <-d.done:
+	default:
+		close(d.done)
+	}
+	d.wg.Wait()
+}
+
+// closing returns true after Close has been called.
+func (d *WebhookDispatcher) closing() bool {
+	select {
+	case <-d.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func (d *WebhookDispatcher) send(ep *webhookEndpoint, event audit.Event) {
+	var payload []byte
+	var err error
+
+	switch ep.channelType {
+	case "slack":
+		payload, err = formatSlackPayload(event)
+	case "pagerduty":
+		payload, err = formatPagerDutyPayload(event, ep.secret)
+	default:
+		payload, err = formatGenericPayload(event)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[webhook] format error for %s: %v\n", ep.url, err)
+		return
+	}
+
+	for attempt := 0; attempt <= webhookMaxRetries; attempt++ {
+		if attempt > 0 {
+			backoff := d.retryBackoff * time.Duration(attempt)
+			time.Sleep(backoff)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, ep.url, bytes.NewReader(payload))
+		if reqErr != nil {
+			cancel()
+			fmt.Fprintf(os.Stderr, "[webhook] request error for %s: %v\n", ep.url, reqErr)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if ep.secret != "" && ep.channelType == "generic" {
+			req.Header.Set("X-Webhook-Secret", ep.secret)
+		}
+
+		resp, doErr := d.client.Do(req)
+		cancel()
+		if doErr != nil {
+			fmt.Fprintf(os.Stderr, "[webhook] send to %s attempt %d/%d failed: %v\n",
+				ep.url, attempt+1, webhookMaxRetries+1, doErr)
+			continue
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			fmt.Fprintf(os.Stderr, "[webhook] sent to %s (status=%d action=%s severity=%s)\n",
+				ep.url, resp.StatusCode, event.Action, event.Severity)
+			return
+		}
+		fmt.Fprintf(os.Stderr, "[webhook] %s returned %d, attempt %d/%d\n",
+			ep.url, resp.StatusCode, attempt+1, webhookMaxRetries+1)
+	}
+	fmt.Fprintf(os.Stderr, "[webhook] exhausted retries for %s\n", ep.url)
+}
+
+// ---------------------------------------------------------------------------
+// Payload formatters
+// ---------------------------------------------------------------------------
+
+func formatSlackPayload(event audit.Event) ([]byte, error) {
+	color := slackColor(event.Severity)
+	title := fmt.Sprintf("DefenseClaw: %s", event.Action)
+	fields := []map[string]interface{}{
+		{"type": "mrkdwn", "text": fmt.Sprintf("*Severity:* %s", event.Severity)},
+		{"type": "mrkdwn", "text": fmt.Sprintf("*Target:* %s", event.Target)},
+	}
+	if event.Details != "" {
+		details := event.Details
+		if len(details) > 500 {
+			details = details[:500] + "..."
+		}
+		fields = append(fields, map[string]interface{}{
+			"type": "mrkdwn", "text": fmt.Sprintf("*Details:* %s", details),
+		})
+	}
+
+	payload := map[string]interface{}{
+		"attachments": []map[string]interface{}{
+			{
+				"color": color,
+				"blocks": []map[string]interface{}{
+					{
+						"type": "header",
+						"text": map[string]string{"type": "plain_text", "text": title},
+					},
+					{
+						"type":   "section",
+						"fields": fields,
+					},
+					{
+						"type": "context",
+						"elements": []map[string]string{
+							{"type": "mrkdwn", "text": fmt.Sprintf("_Event ID: %s | %s_", event.ID, event.Timestamp.Format(time.RFC3339))},
+						},
+					},
+				},
+			},
+		},
+	}
+	return json.Marshal(payload)
+}
+
+func formatPagerDutyPayload(event audit.Event, routingKey string) ([]byte, error) {
+	pdSeverity := "info"
+	switch strings.ToUpper(event.Severity) {
+	case "CRITICAL":
+		pdSeverity = "critical"
+	case "HIGH":
+		pdSeverity = "error"
+	case "MEDIUM":
+		pdSeverity = "warning"
+	}
+
+	payload := map[string]interface{}{
+		"routing_key":  routingKey,
+		"event_action": "trigger",
+		"dedup_key":    fmt.Sprintf("defenseclaw-%s-%s", event.Target, event.Action),
+		"payload": map[string]interface{}{
+			"summary":   fmt.Sprintf("DefenseClaw %s: %s on %s", event.Action, event.Severity, event.Target),
+			"source":    "defenseclaw",
+			"severity":  pdSeverity,
+			"timestamp": event.Timestamp.Format(time.RFC3339),
+			"custom_details": map[string]string{
+				"action":   event.Action,
+				"target":   event.Target,
+				"severity": event.Severity,
+				"details":  event.Details,
+				"event_id": event.ID,
+			},
+		},
+	}
+	return json.Marshal(payload)
+}
+
+func formatGenericPayload(event audit.Event) ([]byte, error) {
+	payload := map[string]interface{}{
+		"webhook_type":        "defenseclaw_enforcement",
+		"defenseclaw_version": "1.0",
+		"event": map[string]interface{}{
+			"id":        event.ID,
+			"timestamp": event.Timestamp.Format(time.RFC3339),
+			"action":    event.Action,
+			"target":    event.Target,
+			"actor":     event.Actor,
+			"details":   event.Details,
+			"severity":  event.Severity,
+			"run_id":    event.RunID,
+			"trace_id":  event.TraceID,
+		},
+	}
+	return json.Marshal(payload)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func slackColor(severity string) string {
+	switch strings.ToUpper(severity) {
+	case "CRITICAL":
+		return "#FF0000"
+	case "HIGH":
+		return "#FF6600"
+	case "MEDIUM":
+		return "#FFCC00"
+	case "LOW":
+		return "#36A64F"
+	default:
+		return "#439FE0"
+	}
+}
+
+func severityToRank(s string) int {
+	switch strings.ToUpper(s) {
+	case "CRITICAL":
+		return 5
+	case "HIGH":
+		return 4
+	case "MEDIUM":
+		return 3
+	case "LOW":
+		return 2
+	case "INFO":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func categorizeAction(action string) string {
+	switch {
+	case strings.Contains(action, "guardrail"):
+		return "guardrail"
+	case strings.Contains(action, "drift"),
+		strings.Contains(action, "rescan"):
+		return "drift"
+	case strings.Contains(action, "block"),
+		strings.Contains(action, "quarantine"),
+		strings.Contains(action, "disable"):
+		return "block"
+	case strings.Contains(action, "scan"):
+		return "scan"
+	default:
+		return action
+	}
+}

--- a/internal/gateway/webhook.go
+++ b/internal/gateway/webhook.go
@@ -48,7 +48,6 @@ type webhookEndpoint struct {
 	secret      string
 	minSeverity int
 	events      map[string]bool
-	headers     map[string]string
 }
 
 const (

--- a/internal/gateway/webhook.go
+++ b/internal/gateway/webhook.go
@@ -19,17 +19,25 @@ package gateway
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/defenseclaw/defenseclaw/internal/audit"
 	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/google/uuid"
 )
 
 // WebhookDispatcher sends structured JSON payloads to configured webhook
@@ -38,6 +46,9 @@ type WebhookDispatcher struct {
 	endpoints    []webhookEndpoint
 	client       *http.Client
 	retryBackoff time.Duration
+	sem          chan struct{} // bounded concurrency
+	logger       *log.Logger
+	debug        bool
 	wg           sync.WaitGroup
 	done         chan struct{}
 }
@@ -47,21 +58,29 @@ type webhookEndpoint struct {
 	channelType string // slack, pagerduty, webex, generic
 	secret      string
 	roomID      string
+	timeout     time.Duration
 	minSeverity int
 	events      map[string]bool
 }
 
 const (
-	webhookMaxRetries   = 3
-	webhookRetryBackoff = 2 * time.Second
+	webhookMaxRetries      = 3
+	webhookRetryBackoff    = 2 * time.Second
+	webhookMaxConcurrency  = 20
+	webhookDefaultTimeout  = 10 * time.Second
 )
 
 // NewWebhookDispatcher creates a dispatcher from the config slice.
-// Endpoints with enabled=false or empty URL are skipped.
+// Endpoints with enabled=false, empty URL, or unsafe URLs are skipped.
 func NewWebhookDispatcher(cfgs []config.WebhookConfig) *WebhookDispatcher {
+	logger := log.New(os.Stderr, "[webhook] ", 0)
 	var endpoints []webhookEndpoint
 	for _, c := range cfgs {
 		if !c.Enabled || c.URL == "" {
+			continue
+		}
+		if err := validateWebhookURL(c.URL); err != nil {
+			logger.Printf("rejected endpoint %s: %v", c.URL, err)
 			continue
 		}
 		evts := make(map[string]bool)
@@ -70,17 +89,17 @@ func NewWebhookDispatcher(cfgs []config.WebhookConfig) *WebhookDispatcher {
 		}
 		timeout := time.Duration(c.TimeoutSeconds) * time.Second
 		if timeout <= 0 {
-			timeout = 10 * time.Second
+			timeout = webhookDefaultTimeout
 		}
 		endpoints = append(endpoints, webhookEndpoint{
 			url:         c.URL,
 			channelType: strings.ToLower(c.Type),
 			secret:      c.ResolvedSecret(),
 			roomID:      c.RoomID,
-			minSeverity: severityToRank(c.MinSeverity),
+			minSeverity: audit.SeverityRank(c.MinSeverity),
 			events:      evts,
+			timeout:     timeout,
 		})
-		_ = timeout // per-endpoint timeout not used for shared client
 	}
 	if len(endpoints) == 0 {
 		return nil
@@ -88,9 +107,12 @@ func NewWebhookDispatcher(cfgs []config.WebhookConfig) *WebhookDispatcher {
 	return &WebhookDispatcher{
 		endpoints: endpoints,
 		client: &http.Client{
-			Timeout: 15 * time.Second,
+			Timeout: 30 * time.Second,
 		},
 		retryBackoff: webhookRetryBackoff,
+		sem:          make(chan struct{}, webhookMaxConcurrency),
+		logger:       logger,
+		debug:        os.Getenv("DEFENSECLAW_WEBHOOK_DEBUG") == "1",
 		done:         make(chan struct{}),
 	}
 }
@@ -101,7 +123,10 @@ func (d *WebhookDispatcher) Dispatch(event audit.Event) {
 	if d == nil || d.closing() {
 		return
 	}
-	rank := severityToRank(event.Severity)
+	if event.ID == "" {
+		event.ID = uuid.New().String()
+	}
+	rank := audit.SeverityRank(event.Severity)
 	action := strings.ToLower(event.Action)
 	eventCategory := categorizeAction(action)
 
@@ -116,6 +141,8 @@ func (d *WebhookDispatcher) Dispatch(event audit.Event) {
 		d.wg.Add(1)
 		go func(ep *webhookEndpoint) {
 			defer d.wg.Done()
+			d.sem <- struct{}{}
+			defer func() { <-d.sem }()
 			d.send(ep, event)
 		}(ep)
 	}
@@ -160,7 +187,7 @@ func (d *WebhookDispatcher) send(ep *webhookEndpoint, event audit.Event) {
 		payload, err = formatGenericPayload(event)
 	}
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[webhook] format error for %s: %v\n", ep.url, err)
+		d.logger.Printf("format error for %s: %v", ep.url, err)
 		return
 	}
 
@@ -170,25 +197,20 @@ func (d *WebhookDispatcher) send(ep *webhookEndpoint, event audit.Event) {
 			time.Sleep(backoff)
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), ep.timeout)
 		req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, ep.url, bytes.NewReader(payload))
 		if reqErr != nil {
 			cancel()
-			fmt.Fprintf(os.Stderr, "[webhook] request error for %s: %v\n", ep.url, reqErr)
+			d.logger.Printf("request error for %s: %v", ep.url, reqErr)
 			return
 		}
 		req.Header.Set("Content-Type", "application/json")
-		switch {
-		case ep.channelType == "webex" && ep.secret != "":
-			req.Header.Set("Authorization", "Bearer "+ep.secret)
-		case ep.channelType == "generic" && ep.secret != "":
-			req.Header.Set("X-Webhook-Secret", ep.secret)
-		}
+		d.setAuthHeaders(req, ep, payload)
 
 		resp, doErr := d.client.Do(req)
 		cancel()
 		if doErr != nil {
-			fmt.Fprintf(os.Stderr, "[webhook] send to %s attempt %d/%d failed: %v\n",
+			d.logger.Printf("send to %s attempt %d/%d failed: %v",
 				ep.url, attempt+1, webhookMaxRetries+1, doErr)
 			continue
 		}
@@ -196,14 +218,137 @@ func (d *WebhookDispatcher) send(ep *webhookEndpoint, event audit.Event) {
 		resp.Body.Close()
 
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-			fmt.Fprintf(os.Stderr, "[webhook] sent to %s (status=%d action=%s severity=%s)\n",
-				ep.url, resp.StatusCode, event.Action, event.Severity)
+			if d.debug {
+				d.logger.Printf("sent to %s (status=%d action=%s severity=%s)",
+					ep.url, resp.StatusCode, event.Action, event.Severity)
+			}
 			return
 		}
-		fmt.Fprintf(os.Stderr, "[webhook] %s returned %d, attempt %d/%d\n",
+
+		if !isRetryable(resp.StatusCode) {
+			d.logger.Printf("%s returned %d (permanent failure), not retrying",
+				ep.url, resp.StatusCode)
+			return
+		}
+
+		if resp.StatusCode == 429 {
+			if ra := resp.Header.Get("Retry-After"); ra != "" {
+				if secs, parseErr := strconv.Atoi(ra); parseErr == nil && secs > 0 && secs <= 120 {
+					time.Sleep(time.Duration(secs) * time.Second)
+					continue
+				}
+			}
+		}
+
+		d.logger.Printf("%s returned %d, attempt %d/%d",
 			ep.url, resp.StatusCode, attempt+1, webhookMaxRetries+1)
 	}
-	fmt.Fprintf(os.Stderr, "[webhook] exhausted retries for %s\n", ep.url)
+	d.logger.Printf("exhausted retries for %s", ep.url)
+}
+
+// setAuthHeaders applies authentication and payload signing per channel type.
+func (d *WebhookDispatcher) setAuthHeaders(req *http.Request, ep *webhookEndpoint, payload []byte) {
+	if ep.secret == "" {
+		return
+	}
+	switch ep.channelType {
+	case "webex":
+		req.Header.Set("Authorization", "Bearer "+ep.secret)
+	case "generic":
+		sig := computeHMAC(payload, ep.secret)
+		req.Header.Set("X-Hub-Signature-256", "sha256="+sig)
+	case "pagerduty":
+		// routing_key is in the payload body, no header needed
+	}
+}
+
+// computeHMAC returns the hex-encoded HMAC-SHA256 of data using the given key.
+func computeHMAC(data []byte, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write(data)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// isRetryable returns true for status codes that may succeed on retry.
+func isRetryable(status int) bool {
+	return status == 429 || (status >= 500 && status < 600)
+}
+
+// ---------------------------------------------------------------------------
+// URL validation (SSRF prevention)
+// ---------------------------------------------------------------------------
+
+// validateWebhookURL ensures the URL is safe for outbound webhook delivery.
+// Blocks non-HTTP schemes, localhost, private/link-local IP ranges, and
+// cloud metadata endpoints.
+func validateWebhookURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "https" && scheme != "http" {
+		return fmt.Errorf("scheme %q not allowed (must be http or https)", scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("empty hostname")
+	}
+	allowLocal := os.Getenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST") == "1"
+
+	hostLower := strings.ToLower(host)
+	if hostLower == "localhost" {
+		if !allowLocal {
+			return fmt.Errorf("localhost not allowed (set DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST=1 for local dev)")
+		}
+		return nil
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		ips, resolveErr := net.LookupIP(host)
+		if resolveErr != nil {
+			return nil // allow DNS names that can't be resolved at config time
+		}
+		for _, resolved := range ips {
+			if isPrivateIP(resolved) {
+				if allowLocal && resolved.IsLoopback() {
+					continue
+				}
+				return fmt.Errorf("hostname %q resolves to private IP %s", host, resolved)
+			}
+		}
+		return nil
+	}
+	if isPrivateIP(ip) {
+		if allowLocal && ip.IsLoopback() {
+			return nil
+		}
+		return fmt.Errorf("IP %s is private/reserved", ip)
+	}
+	return nil
+}
+
+func isPrivateIP(ip net.IP) bool {
+	privateRanges := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"127.0.0.0/8",
+		"169.254.0.0/16", // link-local / cloud metadata
+		"::1/128",
+		"fc00::/7",
+		"fe80::/10",
+	}
+	for _, cidr := range privateRanges {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			continue
+		}
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 // ---------------------------------------------------------------------------
@@ -305,8 +450,10 @@ func formatWebexPayload(event audit.Event, roomID string) ([]byte, error) {
 	markdown += fmt.Sprintf("\n_Event ID: %s | %s_", event.ID, event.Timestamp.Format(time.RFC3339))
 
 	payload := map[string]interface{}{
-		"roomId":   roomID,
 		"markdown": markdown,
+	}
+	if roomID != "" {
+		payload["roomId"] = roomID
 	}
 	return json.Marshal(payload)
 }
@@ -361,23 +508,6 @@ func webexSeverityIcon(severity string) string {
 		return "🟢"
 	default:
 		return "🔵"
-	}
-}
-
-func severityToRank(s string) int {
-	switch strings.ToUpper(s) {
-	case "CRITICAL":
-		return 5
-	case "HIGH":
-		return 4
-	case "MEDIUM":
-		return 3
-	case "LOW":
-		return 2
-	case "INFO":
-		return 1
-	default:
-		return 0
 	}
 }
 

--- a/internal/gateway/webhook_e2e_test.go
+++ b/internal/gateway/webhook_e2e_test.go
@@ -34,6 +34,7 @@ type receivedPayload struct {
 	Body        map[string]interface{}
 	ContentType string
 	SecretHdr   string
+	AuthHdr     string
 	Method      string
 }
 
@@ -57,6 +58,7 @@ func newCollector() *webhookCollector {
 			Body:        m,
 			ContentType: r.Header.Get("Content-Type"),
 			SecretHdr:   r.Header.Get("X-Webhook-Secret"),
+			AuthHdr:     r.Header.Get("Authorization"),
 			Method:      r.Method,
 		})
 		statusFn := c.statusFn
@@ -472,6 +474,138 @@ func TestWebhookE2E_SlackNoSecretHeader(t *testing.T) {
 	}
 	if payloads[0].SecretHdr != "" {
 		t.Errorf("slack webhooks should not include X-Webhook-Secret, got %q", payloads[0].SecretHdr)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Webex webhook integration
+// ---------------------------------------------------------------------------
+
+// TestWebhookE2E_WebexPayloadAndAuth verifies that Webex webhooks send
+// the correct Messages API payload with Bearer auth and roomId.
+func TestWebhookE2E_WebexPayloadAndAuth(t *testing.T) {
+	receiver := newCollector()
+	defer receiver.Close()
+
+	t.Setenv("WEBEX_BOT_TOKEN_E2E", "NjM0ZDk1OTEtYzRmOC00ZTJlLWI4YjgtOTIwMGQwNT")
+
+	d := newTestDispatcher([]config.WebhookConfig{
+		{
+			URL:       receiver.URL(),
+			Type:      "webex",
+			SecretEnv: "WEBEX_BOT_TOKEN_E2E",
+			RoomID:    "Y2lzY29zcGFyazovL3VzL1JPT00vc2VjdXJpdHktYWxlcnRz",
+			Enabled:   true,
+		},
+	})
+
+	d.Dispatch(audit.Event{
+		ID:        "evt-webex-001",
+		Timestamp: time.Now().UTC(),
+		Action:    "block",
+		Target:    "crypto-miner-skill",
+		Actor:     "defenseclaw-watcher",
+		Details:   "type=skill severity=CRITICAL findings=7 actions=quarantined,blocked",
+		Severity:  "CRITICAL",
+	})
+	d.Close()
+
+	payloads := receiver.get()
+	if len(payloads) != 1 {
+		t.Fatalf("expected 1 Webex payload, got %d", len(payloads))
+	}
+
+	p := payloads[0]
+
+	// Verify Bearer auth header
+	if p.AuthHdr != "Bearer NjM0ZDk1OTEtYzRmOC00ZTJlLWI4YjgtOTIwMGQwNT" {
+		t.Errorf("expected Bearer token in Authorization header, got %q", p.AuthHdr)
+	}
+
+	// Webex should NOT have X-Webhook-Secret
+	if p.SecretHdr != "" {
+		t.Errorf("Webex should not set X-Webhook-Secret, got %q", p.SecretHdr)
+	}
+
+	// Verify roomId
+	if p.Body["roomId"] != "Y2lzY29zcGFyazovL3VzL1JPT00vc2VjdXJpdHktYWxlcnRz" {
+		t.Errorf("expected roomId to match, got %v", p.Body["roomId"])
+	}
+
+	// Verify markdown content
+	md, ok := p.Body["markdown"].(string)
+	if !ok || md == "" {
+		t.Fatal("expected non-empty markdown field")
+	}
+	if !strings.Contains(md, "DefenseClaw: block") {
+		t.Errorf("markdown should contain action, got %q", md)
+	}
+	if !strings.Contains(md, "crypto-miner-skill") {
+		t.Errorf("markdown should contain target, got %q", md)
+	}
+	if !strings.Contains(md, "CRITICAL") {
+		t.Errorf("markdown should contain severity, got %q", md)
+	}
+	if !strings.Contains(md, "evt-webex-001") {
+		t.Errorf("markdown should contain event ID, got %q", md)
+	}
+}
+
+// TestWebhookE2E_WebexInPipeline verifies that Webex endpoints participate
+// correctly in multi-endpoint fan-out alongside Slack and generic.
+func TestWebhookE2E_WebexInPipeline(t *testing.T) {
+	slackReceiver := newCollector()
+	defer slackReceiver.Close()
+
+	webexReceiver := newCollector()
+	defer webexReceiver.Close()
+
+	genericReceiver := newCollector()
+	defer genericReceiver.Close()
+
+	t.Setenv("WEBEX_BOT_TOKEN_PIPE", "testtoken123")
+
+	d := newTestDispatcher([]config.WebhookConfig{
+		{URL: slackReceiver.URL(), Type: "slack", MinSeverity: "HIGH", Events: []string{"block"}, Enabled: true},
+		{URL: webexReceiver.URL(), Type: "webex", SecretEnv: "WEBEX_BOT_TOKEN_PIPE", RoomID: "room-123", MinSeverity: "MEDIUM", Events: []string{"block", "drift"}, Enabled: true},
+		{URL: genericReceiver.URL(), Type: "generic", MinSeverity: "INFO", Enabled: true},
+	})
+
+	// CRITICAL block — should reach all 3
+	d.Dispatch(audit.Event{
+		ID: "evt-pipe-001", Timestamp: time.Now().UTC(),
+		Action: "block", Target: "evil-skill", Actor: "watcher",
+		Severity: "CRITICAL",
+	})
+
+	// MEDIUM drift — should reach webex (MEDIUM ≥ MEDIUM, drift in filter) and generic (INFO, no filter)
+	// should NOT reach slack (HIGH threshold, drift not in block filter)
+	d.Dispatch(audit.Event{
+		ID: "evt-pipe-002", Timestamp: time.Now().UTC(),
+		Action: "drift", Target: "mutated-skill", Actor: "rescan",
+		Severity: "MEDIUM",
+	})
+
+	d.Close()
+
+	if slackReceiver.count() != 1 {
+		t.Errorf("[slack] expected 1 payload, got %d", slackReceiver.count())
+	}
+	if webexReceiver.count() != 2 {
+		t.Errorf("[webex] expected 2 payloads (block+drift), got %d", webexReceiver.count())
+	}
+	if genericReceiver.count() != 2 {
+		t.Errorf("[generic] expected 2 payloads, got %d", genericReceiver.count())
+	}
+
+	// Verify all Webex payloads have the correct roomId and Bearer auth
+	for _, p := range webexReceiver.get() {
+		if p.Body["roomId"] != "room-123" {
+			t.Errorf("[webex] roomId should be room-123, got %v", p.Body["roomId"])
+		}
+		if p.AuthHdr != "Bearer testtoken123" {
+			t.Errorf("[webex] expected Bearer auth, got %q", p.AuthHdr)
+		}
 	}
 }
 

--- a/internal/gateway/webhook_e2e_test.go
+++ b/internal/gateway/webhook_e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -33,7 +34,7 @@ import (
 type receivedPayload struct {
 	Body        map[string]interface{}
 	ContentType string
-	SecretHdr   string
+	SigHdr      string // X-Hub-Signature-256
 	AuthHdr     string
 	Method      string
 }
@@ -57,7 +58,7 @@ func newCollector() *webhookCollector {
 		c.payloads = append(c.payloads, receivedPayload{
 			Body:        m,
 			ContentType: r.Header.Get("Content-Type"),
-			SecretHdr:   r.Header.Get("X-Webhook-Secret"),
+			SigHdr:      r.Header.Get("X-Hub-Signature-256"),
 			AuthHdr:     r.Header.Get("Authorization"),
 			Method:      r.Method,
 		})
@@ -72,16 +73,24 @@ func newCollector() *webhookCollector {
 	return c
 }
 
-func (c *webhookCollector) Close()                  { c.srv.Close() }
-func (c *webhookCollector) URL() string             { return c.srv.URL }
-func (c *webhookCollector) get() []receivedPayload  { c.mu.Lock(); defer c.mu.Unlock(); cp := make([]receivedPayload, len(c.payloads)); copy(cp, c.payloads); return cp }
-func (c *webhookCollector) count() int              { c.mu.Lock(); defer c.mu.Unlock(); return len(c.payloads) }
+func (c *webhookCollector) Close()                 { c.srv.Close() }
+func (c *webhookCollector) URL() string            { return c.srv.URL }
+func (c *webhookCollector) get() []receivedPayload { c.mu.Lock(); defer c.mu.Unlock(); cp := make([]receivedPayload, len(c.payloads)); copy(cp, c.payloads); return cp }
+func (c *webhookCollector) count() int             { c.mu.Lock(); defer c.mu.Unlock(); return len(c.payloads) }
 
 // newTestDispatcher creates a WebhookDispatcher with zero retry backoff for fast tests.
+// It sets DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST=1 so that httptest servers on 127.0.0.1 are accepted.
 func newTestDispatcher(cfgs []config.WebhookConfig) *WebhookDispatcher {
+	prev := os.Getenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST")
+	os.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
 	d := NewWebhookDispatcher(cfgs)
+	if prev == "" {
+		os.Unsetenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST")
+	} else {
+		os.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", prev)
+	}
 	if d != nil {
-		d.retryBackoff = 0 // no wait between retries in tests
+		d.retryBackoff = 0
 	}
 	return d
 }
@@ -90,23 +99,17 @@ func newTestDispatcher(cfgs []config.WebhookConfig) *WebhookDispatcher {
 // Full realistic E2E test: multi-event enforcement pipeline
 // ---------------------------------------------------------------------------
 
-// TestWebhookE2E_FullEnforcementPipeline simulates the complete DefenseClaw
-// enforcement pipeline — watcher blocks a malicious skill, rescan detects
-// drift, guardrail blocks a prompt injection — and verifies that each event
-// is delivered to the correct webhook endpoints with correct payloads.
 func TestWebhookE2E_FullEnforcementPipeline(t *testing.T) {
-	// --- Set up 3 simulated external webhook receivers ---
 	slackReceiver := newCollector()
 	defer slackReceiver.Close()
 
 	pagerdutyReceiver := newCollector()
 	defer pagerdutyReceiver.Close()
-	pagerdutyReceiver.statusFn = func(int) int { return 202 } // PD returns 202 Accepted
+	pagerdutyReceiver.statusFn = func(int) int { return 202 }
 
 	genericReceiver := newCollector()
 	defer genericReceiver.Close()
 
-	// --- Create dispatcher with realistic multi-endpoint config ---
 	d := newTestDispatcher([]config.WebhookConfig{
 		{
 			URL:         slackReceiver.URL(),
@@ -125,7 +128,6 @@ func TestWebhookE2E_FullEnforcementPipeline(t *testing.T) {
 		{
 			URL:            genericReceiver.URL(),
 			Type:           "generic",
-			SecretEnv:      "",
 			MinSeverity:    "INFO",
 			Events:         []string{"block", "drift", "guardrail", "scan"},
 			TimeoutSeconds: 5,
@@ -136,93 +138,53 @@ func TestWebhookE2E_FullEnforcementPipeline(t *testing.T) {
 		t.Fatal("expected non-nil dispatcher")
 	}
 
-	// ── EVENT 1: Watcher blocks a malicious skill ──
-	// Simulates sendEnforcementAlert in sidecar.go creating this event
 	skillBlockEvent := audit.Event{
-		ID:        "evt-watcher-001",
-		Timestamp: time.Now().UTC(),
-		Action:    "block",
-		Target:    "crypto-miner-skill",
-		Actor:     "defenseclaw-watcher",
-		Details:   "type=skill severity=CRITICAL findings=7 actions=quarantined,blocked,disabled reason=malware signature detected in node_modules",
-		Severity:  "CRITICAL",
-		RunID:     "run-e2e-pipeline",
+		ID: "evt-watcher-001", Timestamp: time.Now().UTC(),
+		Action: "block", Target: "crypto-miner-skill", Actor: "defenseclaw-watcher",
+		Details: "type=skill severity=CRITICAL findings=7 actions=quarantined,blocked,disabled reason=malware signature detected",
+		Severity: "CRITICAL", RunID: "run-e2e-pipeline",
 	}
 	d.Dispatch(skillBlockEvent)
 
-	// ── EVENT 2: Drift detected during periodic rescan ──
-	// Simulates emitDriftAlerts in rescan.go
 	driftEvent := audit.Event{
-		ID:        "evt-drift-002",
-		Timestamp: time.Now().UTC(),
-		Action:    "drift",
-		Target:    "/home/user/.openclaw/workspace/skills/data-analyzer",
-		Actor:     "defenseclaw-rescan",
-		Details:   `[{"type":"dependency_change","severity":"MEDIUM","description":"dependency manifest modified: package.json"},{"type":"new_endpoint","severity":"HIGH","description":"new network endpoint detected: https://evil-c2.example.com/exfil"}]`,
-		Severity:  "HIGH",
+		ID: "evt-drift-002", Timestamp: time.Now().UTC(),
+		Action: "drift", Target: "/home/user/.openclaw/workspace/skills/data-analyzer",
+		Actor: "defenseclaw-rescan", Severity: "HIGH",
+		Details: `[{"type":"dependency_change","severity":"MEDIUM"}]`,
 	}
 	d.Dispatch(driftEvent)
 
-	// ── EVENT 3: Guardrail blocks a prompt injection ──
-	// Simulates recordTelemetry in proxy.go when verdict.Action == "block"
 	guardrailBlockEvent := audit.Event{
-		ID:        "evt-guardrail-003",
-		Timestamp: time.Now().UTC(),
-		Action:    "guardrail-block",
-		Target:    "anthropic/claude-sonnet-4-20250514",
-		Actor:     "defenseclaw-guardrail",
-		Details:   "direction=prompt action=block severity=HIGH findings=2 elapsed_ms=45.3 reason=prompt_injection:ignore_previous_instructions",
-		Severity:  "HIGH",
+		ID: "evt-guardrail-003", Timestamp: time.Now().UTC(),
+		Action: "guardrail-block", Target: "anthropic/claude-sonnet-4-20250514",
+		Actor: "defenseclaw-guardrail", Severity: "HIGH",
+		Details: "direction=prompt action=block severity=HIGH findings=2",
 	}
 	d.Dispatch(guardrailBlockEvent)
 
-	// ── EVENT 4: Low-severity scan (should only reach generic) ──
 	scanEvent := audit.Event{
-		ID:        "evt-scan-004",
-		Timestamp: time.Now().UTC(),
-		Action:    "scan",
-		Target:    "safe-utility-skill",
-		Actor:     "defenseclaw",
-		Details:   "scanner=skill-scanner findings=0 max_severity=INFO",
-		Severity:  "INFO",
+		ID: "evt-scan-004", Timestamp: time.Now().UTC(),
+		Action: "scan", Target: "safe-utility-skill", Actor: "defenseclaw",
+		Details: "scanner=skill-scanner findings=0 max_severity=INFO", Severity: "INFO",
 	}
 	d.Dispatch(scanEvent)
 
-	// Wait for all async sends to complete
 	d.Close()
 
-	// --- Validate Slack endpoint ---
-	// Slack: min_severity=MEDIUM, events=[block, drift, guardrail]
-	// Should receive: skill block (CRITICAL ≥ MEDIUM), drift (HIGH ≥ MEDIUM), guardrail (HIGH ≥ MEDIUM)
-	// Should NOT receive: scan (INFO < MEDIUM, and scan not in event filter)
+	// Slack: MEDIUM threshold, events=[block,drift,guardrail] -> 3 payloads
 	slackPayloads := slackReceiver.get()
 	if len(slackPayloads) != 3 {
-		t.Errorf("[slack] expected 3 payloads (block+drift+guardrail), got %d", len(slackPayloads))
+		t.Errorf("[slack] expected 3 payloads, got %d", len(slackPayloads))
 	}
 	for _, p := range slackPayloads {
 		if p.ContentType != "application/json" {
 			t.Errorf("[slack] expected Content-Type=application/json, got %q", p.ContentType)
 		}
-		if p.Method != "POST" {
-			t.Errorf("[slack] expected POST, got %s", p.Method)
-		}
 		attachments, ok := p.Body["attachments"].([]interface{})
 		if !ok || len(attachments) == 0 {
 			t.Error("[slack] missing attachments array")
-			continue
-		}
-		att := attachments[0].(map[string]interface{})
-		color, _ := att["color"].(string)
-		if color == "" {
-			t.Error("[slack] missing color on attachment")
-		}
-		blocks, _ := att["blocks"].([]interface{})
-		if len(blocks) < 3 {
-			t.Errorf("[slack] expected ≥3 blocks (header, section, context), got %d", len(blocks))
 		}
 	}
-
-	// Validate that at least one Slack payload has CRITICAL red color
 	foundCriticalRed := false
 	for _, p := range slackPayloads {
 		att := p.Body["attachments"].([]interface{})[0].(map[string]interface{})
@@ -235,132 +197,48 @@ func TestWebhookE2E_FullEnforcementPipeline(t *testing.T) {
 		t.Error("[slack] expected at least one CRITICAL payload with red (#FF0000) color")
 	}
 
-	// --- Validate PagerDuty endpoint ---
-	// PagerDuty: min_severity=HIGH, events=[block]
-	// Should receive: skill block (CRITICAL ≥ HIGH, action=block)
-	// Should NOT receive: drift (HIGH ≥ HIGH but action=drift not in filter), guardrail, scan
+	// PagerDuty: HIGH threshold, events=[block] -> 1 payload
 	pdPayloads := pagerdutyReceiver.get()
 	if len(pdPayloads) != 1 {
-		t.Errorf("[pagerduty] expected 1 payload (block only), got %d", len(pdPayloads))
+		t.Errorf("[pagerduty] expected 1 payload, got %d", len(pdPayloads))
 	}
 	if len(pdPayloads) >= 1 {
-		pd := pdPayloads[0]
-		if pd.ContentType != "application/json" {
-			t.Errorf("[pagerduty] expected Content-Type=application/json, got %q", pd.ContentType)
-		}
-		body := pd.Body
+		body := pdPayloads[0].Body
 		if body["event_action"] != "trigger" {
 			t.Errorf("[pagerduty] expected event_action=trigger, got %v", body["event_action"])
 		}
-		dedupKey, _ := body["dedup_key"].(string)
-		if !strings.Contains(dedupKey, "crypto-miner-skill") {
-			t.Errorf("[pagerduty] dedup_key should contain target name, got %q", dedupKey)
-		}
 		payload := body["payload"].(map[string]interface{})
 		if payload["severity"] != "critical" {
-			t.Errorf("[pagerduty] expected severity=critical for CRITICAL event, got %v", payload["severity"])
+			t.Errorf("[pagerduty] expected severity=critical, got %v", payload["severity"])
 		}
-		if payload["source"] != "defenseclaw" {
-			t.Errorf("[pagerduty] expected source=defenseclaw, got %v", payload["source"])
-		}
-		summary, _ := payload["summary"].(string)
-		if !strings.Contains(summary, "crypto-miner-skill") {
-			t.Errorf("[pagerduty] summary should mention target, got %q", summary)
-		}
-		customDetails := payload["custom_details"].(map[string]interface{})
-		if customDetails["action"] != "block" {
-			t.Errorf("[pagerduty] custom_details.action should be block, got %v", customDetails["action"])
-		}
-		if customDetails["event_id"] != "evt-watcher-001" {
-			t.Errorf("[pagerduty] custom_details.event_id should be evt-watcher-001, got %v", customDetails["event_id"])
+		cd := payload["custom_details"].(map[string]interface{})
+		if cd["event_id"] != "evt-watcher-001" {
+			t.Errorf("[pagerduty] event_id should be evt-watcher-001, got %v", cd["event_id"])
 		}
 	}
 
-	// --- Validate Generic endpoint ---
-	// Generic: min_severity=INFO, events=[block, drift, guardrail, scan]
-	// Should receive ALL 4 events
+	// Generic: INFO threshold, events=[block,drift,guardrail,scan] -> 4 payloads
 	genPayloads := genericReceiver.get()
 	if len(genPayloads) != 4 {
-		t.Errorf("[generic] expected 4 payloads (block+drift+guardrail+scan), got %d", len(genPayloads))
+		t.Errorf("[generic] expected 4 payloads, got %d", len(genPayloads))
 	}
-
-	// Index generic payloads by event ID for order-independent assertions
 	byID := make(map[string]receivedPayload)
 	for _, p := range genPayloads {
-		if p.Body["webhook_type"] != "defenseclaw_enforcement" {
-			t.Errorf("[generic] expected webhook_type=defenseclaw_enforcement, got %v", p.Body["webhook_type"])
-		}
-		if p.Body["defenseclaw_version"] != "1.0" {
-			t.Errorf("[generic] expected defenseclaw_version=1.0, got %v", p.Body["defenseclaw_version"])
-		}
 		evt := p.Body["event"].(map[string]interface{})
-		if _, ok := evt["timestamp"]; !ok {
-			t.Error("[generic] missing timestamp")
-		}
 		id, _ := evt["id"].(string)
 		byID[id] = p
 	}
-
-	// Validate the watcher block event
-	if p, ok := byID["evt-watcher-001"]; ok {
-		e := p.Body["event"].(map[string]interface{})
-		if e["action"] != "block" {
-			t.Errorf("[generic][block] action should be block, got %v", e["action"])
-		}
-		if e["target"] != "crypto-miner-skill" {
-			t.Errorf("[generic][block] target should be crypto-miner-skill, got %v", e["target"])
-		}
-		if e["severity"] != "CRITICAL" {
-			t.Errorf("[generic][block] severity should be CRITICAL, got %v", e["severity"])
-		}
-		if e["actor"] != "defenseclaw-watcher" {
-			t.Errorf("[generic][block] actor should be defenseclaw-watcher, got %v", e["actor"])
-		}
-		if e["run_id"] != "run-e2e-pipeline" {
-			t.Errorf("[generic][block] run_id should be run-e2e-pipeline, got %v", e["run_id"])
-		}
-	} else {
-		t.Error("[generic] missing evt-watcher-001 (block event)")
+	if _, ok := byID["evt-watcher-001"]; !ok {
+		t.Error("[generic] missing evt-watcher-001")
 	}
-
-	// Validate the drift event
-	if p, ok := byID["evt-drift-002"]; ok {
-		e := p.Body["event"].(map[string]interface{})
-		if e["action"] != "drift" {
-			t.Errorf("[generic][drift] action should be drift, got %v", e["action"])
-		}
-		details, _ := e["details"].(string)
-		if !strings.Contains(details, "dependency_change") {
-			t.Errorf("[generic][drift] details should contain drift delta JSON, got %q", details)
-		}
-	} else {
-		t.Error("[generic] missing evt-drift-002 (drift event)")
+	if _, ok := byID["evt-drift-002"]; !ok {
+		t.Error("[generic] missing evt-drift-002")
 	}
-
-	// Validate the guardrail block event
-	if p, ok := byID["evt-guardrail-003"]; ok {
-		e := p.Body["event"].(map[string]interface{})
-		if e["action"] != "guardrail-block" {
-			t.Errorf("[generic][guardrail] action should be guardrail-block, got %v", e["action"])
-		}
-		if e["actor"] != "defenseclaw-guardrail" {
-			t.Errorf("[generic][guardrail] actor should be defenseclaw-guardrail, got %v", e["actor"])
-		}
-	} else {
-		t.Error("[generic] missing evt-guardrail-003 (guardrail-block event)")
+	if _, ok := byID["evt-guardrail-003"]; !ok {
+		t.Error("[generic] missing evt-guardrail-003")
 	}
-
-	// Validate the scan event
-	if p, ok := byID["evt-scan-004"]; ok {
-		e := p.Body["event"].(map[string]interface{})
-		if e["action"] != "scan" {
-			t.Errorf("[generic][scan] action should be scan, got %v", e["action"])
-		}
-		if e["severity"] != "INFO" {
-			t.Errorf("[generic][scan] severity should be INFO, got %v", e["severity"])
-		}
-	} else {
-		t.Error("[generic] missing evt-scan-004 (scan event)")
+	if _, ok := byID["evt-scan-004"]; !ok {
+		t.Error("[generic] missing evt-scan-004")
 	}
 }
 
@@ -368,12 +246,9 @@ func TestWebhookE2E_FullEnforcementPipeline(t *testing.T) {
 // Retry under transient failures
 // ---------------------------------------------------------------------------
 
-// TestWebhookE2E_RetryOnTransientFailure verifies the dispatcher retries
-// on 503/500 responses and eventually delivers the payload.
 func TestWebhookE2E_RetryOnTransientFailure(t *testing.T) {
 	receiver := newCollector()
 	defer receiver.Close()
-	// First 2 attempts return 503, third succeeds
 	receiver.statusFn = func(n int) int {
 		if n <= 2 {
 			return 503
@@ -392,43 +267,56 @@ func TestWebhookE2E_RetryOnTransientFailure(t *testing.T) {
 	if got < 3 {
 		t.Errorf("expected at least 3 attempts (initial + 2 retries), got %d", got)
 	}
-
-	// The last payload should be the successful one with correct content
-	payloads := receiver.get()
-	last := payloads[len(payloads)-1]
-	if last.Body["webhook_type"] != "defenseclaw_enforcement" {
-		t.Errorf("final payload should be valid generic format")
-	}
 }
 
-// TestWebhookE2E_AllRetriesExhausted verifies that when all retries fail,
-// the dispatcher does not panic and the payload structure is still correct.
 func TestWebhookE2E_AllRetriesExhausted(t *testing.T) {
 	receiver := newCollector()
 	defer receiver.Close()
-	receiver.statusFn = func(int) int { return 500 } // always fail
+	receiver.statusFn = func(int) int { return 500 }
 
 	d := newTestDispatcher([]config.WebhookConfig{
 		{URL: receiver.URL(), Type: "generic", MinSeverity: "INFO", Enabled: true},
 	})
 
 	d.Dispatch(testEvent())
-	d.Close() // should not hang
+	d.Close()
 
 	got := receiver.count()
-	expected := webhookMaxRetries + 1 // initial + retries
+	expected := webhookMaxRetries + 1
 	if got != expected {
 		t.Errorf("expected %d total attempts, got %d", expected, got)
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Secret header on generic webhooks
+// 4xx permanent failures (not retried)
 // ---------------------------------------------------------------------------
 
-// TestWebhookE2E_GenericSecretHeader verifies that X-Webhook-Secret is
-// set on generic webhook requests when a secret is configured.
-func TestWebhookE2E_GenericSecretHeader(t *testing.T) {
+func TestWebhookE2E_4xxNotRetried(t *testing.T) {
+	for _, code := range []int{400, 401, 403, 404} {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			receiver := newCollector()
+			defer receiver.Close()
+			receiver.statusFn = func(int) int { return code }
+
+			d := newTestDispatcher([]config.WebhookConfig{
+				{URL: receiver.URL(), Type: "generic", MinSeverity: "INFO", Enabled: true},
+			})
+			d.Dispatch(testEvent())
+			d.Close()
+
+			if receiver.count() != 1 {
+				t.Errorf("%d should be permanent (1 attempt), got %d", code, receiver.count())
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HMAC signing on generic endpoints (E2E)
+// ---------------------------------------------------------------------------
+
+func TestWebhookE2E_GenericHMACSignature(t *testing.T) {
 	receiver := newCollector()
 	defer receiver.Close()
 
@@ -450,14 +338,12 @@ func TestWebhookE2E_GenericSecretHeader(t *testing.T) {
 	if len(payloads) != 1 {
 		t.Fatalf("expected 1 payload, got %d", len(payloads))
 	}
-	if payloads[0].SecretHdr != "supersecretvalue42" {
-		t.Errorf("expected X-Webhook-Secret=supersecretvalue42, got %q", payloads[0].SecretHdr)
+	if !strings.HasPrefix(payloads[0].SigHdr, "sha256=") {
+		t.Errorf("expected X-Hub-Signature-256 with sha256= prefix, got %q", payloads[0].SigHdr)
 	}
 }
 
-// TestWebhookE2E_SlackNoSecretHeader verifies that X-Webhook-Secret is
-// NOT sent for Slack webhooks (Slack authenticates via the URL token).
-func TestWebhookE2E_SlackNoSecretHeader(t *testing.T) {
+func TestWebhookE2E_SlackNoSignatureHeader(t *testing.T) {
 	receiver := newCollector()
 	defer receiver.Close()
 
@@ -472,17 +358,15 @@ func TestWebhookE2E_SlackNoSecretHeader(t *testing.T) {
 	if len(payloads) != 1 {
 		t.Fatalf("expected 1 payload, got %d", len(payloads))
 	}
-	if payloads[0].SecretHdr != "" {
-		t.Errorf("slack webhooks should not include X-Webhook-Secret, got %q", payloads[0].SecretHdr)
+	if payloads[0].SigHdr != "" {
+		t.Errorf("slack should not include signature header, got %q", payloads[0].SigHdr)
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Webex webhook integration
+// Webex integration
 // ---------------------------------------------------------------------------
 
-// TestWebhookE2E_WebexPayloadAndAuth verifies that Webex webhooks send
-// the correct Messages API payload with Bearer auth and roomId.
 func TestWebhookE2E_WebexPayloadAndAuth(t *testing.T) {
 	receiver := newCollector()
 	defer receiver.Close()
@@ -491,8 +375,7 @@ func TestWebhookE2E_WebexPayloadAndAuth(t *testing.T) {
 
 	d := newTestDispatcher([]config.WebhookConfig{
 		{
-			URL:       receiver.URL(),
-			Type:      "webex",
+			URL: receiver.URL(), Type: "webex",
 			SecretEnv: "WEBEX_BOT_TOKEN_E2E",
 			RoomID:    "Y2lzY29zcGFyazovL3VzL1JPT00vc2VjdXJpdHktYWxlcnRz",
 			Enabled:   true,
@@ -500,13 +383,9 @@ func TestWebhookE2E_WebexPayloadAndAuth(t *testing.T) {
 	})
 
 	d.Dispatch(audit.Event{
-		ID:        "evt-webex-001",
-		Timestamp: time.Now().UTC(),
-		Action:    "block",
-		Target:    "crypto-miner-skill",
-		Actor:     "defenseclaw-watcher",
-		Details:   "type=skill severity=CRITICAL findings=7 actions=quarantined,blocked",
-		Severity:  "CRITICAL",
+		ID: "evt-webex-001", Timestamp: time.Now().UTC(),
+		Action: "block", Target: "crypto-miner-skill", Actor: "defenseclaw-watcher",
+		Severity: "CRITICAL",
 	})
 	d.Close()
 
@@ -514,52 +393,27 @@ func TestWebhookE2E_WebexPayloadAndAuth(t *testing.T) {
 	if len(payloads) != 1 {
 		t.Fatalf("expected 1 Webex payload, got %d", len(payloads))
 	}
-
 	p := payloads[0]
-
-	// Verify Bearer auth header
 	if p.AuthHdr != "Bearer NjM0ZDk1OTEtYzRmOC00ZTJlLWI4YjgtOTIwMGQwNT" {
-		t.Errorf("expected Bearer token in Authorization header, got %q", p.AuthHdr)
+		t.Errorf("expected Bearer token, got %q", p.AuthHdr)
 	}
-
-	// Webex should NOT have X-Webhook-Secret
-	if p.SecretHdr != "" {
-		t.Errorf("Webex should not set X-Webhook-Secret, got %q", p.SecretHdr)
+	if p.SigHdr != "" {
+		t.Errorf("Webex should not set X-Hub-Signature-256, got %q", p.SigHdr)
 	}
-
-	// Verify roomId
 	if p.Body["roomId"] != "Y2lzY29zcGFyazovL3VzL1JPT00vc2VjdXJpdHktYWxlcnRz" {
 		t.Errorf("expected roomId to match, got %v", p.Body["roomId"])
 	}
-
-	// Verify markdown content
-	md, ok := p.Body["markdown"].(string)
-	if !ok || md == "" {
-		t.Fatal("expected non-empty markdown field")
-	}
-	if !strings.Contains(md, "DefenseClaw: block") {
-		t.Errorf("markdown should contain action, got %q", md)
-	}
-	if !strings.Contains(md, "crypto-miner-skill") {
-		t.Errorf("markdown should contain target, got %q", md)
-	}
-	if !strings.Contains(md, "CRITICAL") {
-		t.Errorf("markdown should contain severity, got %q", md)
-	}
+	md, _ := p.Body["markdown"].(string)
 	if !strings.Contains(md, "evt-webex-001") {
 		t.Errorf("markdown should contain event ID, got %q", md)
 	}
 }
 
-// TestWebhookE2E_WebexInPipeline verifies that Webex endpoints participate
-// correctly in multi-endpoint fan-out alongside Slack and generic.
 func TestWebhookE2E_WebexInPipeline(t *testing.T) {
 	slackReceiver := newCollector()
 	defer slackReceiver.Close()
-
 	webexReceiver := newCollector()
 	defer webexReceiver.Close()
-
 	genericReceiver := newCollector()
 	defer genericReceiver.Close()
 
@@ -571,38 +425,26 @@ func TestWebhookE2E_WebexInPipeline(t *testing.T) {
 		{URL: genericReceiver.URL(), Type: "generic", MinSeverity: "INFO", Enabled: true},
 	})
 
-	// CRITICAL block — should reach all 3
 	d.Dispatch(audit.Event{
 		ID: "evt-pipe-001", Timestamp: time.Now().UTC(),
-		Action: "block", Target: "evil-skill", Actor: "watcher",
-		Severity: "CRITICAL",
+		Action: "block", Target: "evil-skill", Actor: "watcher", Severity: "CRITICAL",
 	})
-
-	// MEDIUM drift — should reach webex (MEDIUM ≥ MEDIUM, drift in filter) and generic (INFO, no filter)
-	// should NOT reach slack (HIGH threshold, drift not in block filter)
 	d.Dispatch(audit.Event{
 		ID: "evt-pipe-002", Timestamp: time.Now().UTC(),
-		Action: "drift", Target: "mutated-skill", Actor: "rescan",
-		Severity: "MEDIUM",
+		Action: "drift", Target: "mutated-skill", Actor: "rescan", Severity: "MEDIUM",
 	})
-
 	d.Close()
 
 	if slackReceiver.count() != 1 {
-		t.Errorf("[slack] expected 1 payload, got %d", slackReceiver.count())
+		t.Errorf("[slack] expected 1, got %d", slackReceiver.count())
 	}
 	if webexReceiver.count() != 2 {
-		t.Errorf("[webex] expected 2 payloads (block+drift), got %d", webexReceiver.count())
+		t.Errorf("[webex] expected 2, got %d", webexReceiver.count())
 	}
 	if genericReceiver.count() != 2 {
-		t.Errorf("[generic] expected 2 payloads, got %d", genericReceiver.count())
+		t.Errorf("[generic] expected 2, got %d", genericReceiver.count())
 	}
-
-	// Verify all Webex payloads have the correct roomId and Bearer auth
 	for _, p := range webexReceiver.get() {
-		if p.Body["roomId"] != "room-123" {
-			t.Errorf("[webex] roomId should be room-123, got %v", p.Body["roomId"])
-		}
 		if p.AuthHdr != "Bearer testtoken123" {
 			t.Errorf("[webex] expected Bearer auth, got %q", p.AuthHdr)
 		}
@@ -610,32 +452,28 @@ func TestWebhookE2E_WebexInPipeline(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Severity threshold edge cases
+// Severity edge cases
 // ---------------------------------------------------------------------------
 
-// TestWebhookE2E_SeverityEdgeCases verifies boundary behavior for severity
-// filtering across all severity levels.
 func TestWebhookE2E_SeverityEdgeCases(t *testing.T) {
 	severities := []string{"INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL"}
 
 	for _, threshold := range severities {
 		for _, eventSev := range severities {
-			name := threshold + "_accepts_" + eventSev
-			t.Run(name, func(t *testing.T) {
+			t.Run(threshold+"_accepts_"+eventSev, func(t *testing.T) {
 				receiver := newCollector()
 				defer receiver.Close()
 
 				d := newTestDispatcher([]config.WebhookConfig{
 					{URL: receiver.URL(), Type: "generic", MinSeverity: threshold, Enabled: true},
 				})
-
 				evt := testEvent()
 				evt.Severity = eventSev
 				d.Dispatch(evt)
 				d.Close()
 
 				delivered := receiver.count() > 0
-				expected := severityToRank(eventSev) >= severityToRank(threshold)
+				expected := audit.SeverityRank(eventSev) >= audit.SeverityRank(threshold)
 				if delivered != expected {
 					t.Errorf("threshold=%s event=%s: delivered=%v, want %v",
 						threshold, eventSev, delivered, expected)
@@ -649,12 +487,9 @@ func TestWebhookE2E_SeverityEdgeCases(t *testing.T) {
 // Mixed enabled/disabled endpoints
 // ---------------------------------------------------------------------------
 
-// TestWebhookE2E_MixedEnabledDisabled verifies that disabled endpoints
-// are silently skipped and enabled ones still receive events.
 func TestWebhookE2E_MixedEnabledDisabled(t *testing.T) {
 	activeReceiver := newCollector()
 	defer activeReceiver.Close()
-
 	disabledReceiver := newCollector()
 	defer disabledReceiver.Close()
 
@@ -668,10 +503,10 @@ func TestWebhookE2E_MixedEnabledDisabled(t *testing.T) {
 	d.Close()
 
 	if activeReceiver.count() != 1 {
-		t.Errorf("active endpoint should receive 1 payload, got %d", activeReceiver.count())
+		t.Errorf("active should receive 1, got %d", activeReceiver.count())
 	}
 	if disabledReceiver.count() != 0 {
-		t.Errorf("disabled endpoint should receive 0 payloads, got %d", disabledReceiver.count())
+		t.Errorf("disabled should receive 0, got %d", disabledReceiver.count())
 	}
 }
 
@@ -679,8 +514,6 @@ func TestWebhookE2E_MixedEnabledDisabled(t *testing.T) {
 // Concurrent dispatch safety
 // ---------------------------------------------------------------------------
 
-// TestWebhookE2E_ConcurrentDispatch verifies that dispatching many events
-// concurrently does not cause races or lost payloads.
 func TestWebhookE2E_ConcurrentDispatch(t *testing.T) {
 	receiver := newCollector()
 	defer receiver.Close()
@@ -696,12 +529,9 @@ func TestWebhookE2E_ConcurrentDispatch(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			evt := audit.Event{
-				ID:        time.Now().Format("20060102150405.000000") + "-" + string(rune('A'+i%26)),
+				ID: time.Now().Format("20060102150405.000000") + "-" + string(rune('A'+i%26)),
 				Timestamp: time.Now().UTC(),
-				Action:    "block",
-				Target:    "concurrent-skill",
-				Actor:     "test",
-				Severity:  "HIGH",
+				Action: "block", Target: "concurrent-skill", Actor: "test", Severity: "HIGH",
 			}
 			d.Dispatch(evt)
 		}(i)
@@ -709,18 +539,15 @@ func TestWebhookE2E_ConcurrentDispatch(t *testing.T) {
 	wg.Wait()
 	d.Close()
 
-	got := receiver.count()
-	if got != numEvents {
-		t.Errorf("expected %d payloads for concurrent dispatch, got %d", numEvents, got)
+	if receiver.count() != numEvents {
+		t.Errorf("expected %d, got %d", numEvents, receiver.count())
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Post-close dispatch is silently dropped
+// Post-close dispatch
 // ---------------------------------------------------------------------------
 
-// TestWebhookE2E_DispatchAfterClose verifies that events sent after Close
-// are silently dropped without panic.
 func TestWebhookE2E_DispatchAfterClose(t *testing.T) {
 	receiver := newCollector()
 	defer receiver.Close()
@@ -733,14 +560,11 @@ func TestWebhookE2E_DispatchAfterClose(t *testing.T) {
 	d.Close()
 
 	before := receiver.count()
-
-	// These should be silently dropped
 	d.Dispatch(testEvent())
 	d.Dispatch(testEvent())
 	time.Sleep(50 * time.Millisecond)
 
-	after := receiver.count()
-	if after != before {
-		t.Errorf("expected no new payloads after Close, before=%d after=%d", before, after)
+	if receiver.count() != before {
+		t.Errorf("expected no new payloads after Close, before=%d after=%d", before, receiver.count())
 	}
 }

--- a/internal/gateway/webhook_e2e_test.go
+++ b/internal/gateway/webhook_e2e_test.go
@@ -1,0 +1,612 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/audit"
+	"github.com/defenseclaw/defenseclaw/internal/config"
+)
+
+// receivedPayload captures both the raw JSON and the HTTP request metadata.
+type receivedPayload struct {
+	Body        map[string]interface{}
+	ContentType string
+	SecretHdr   string
+	Method      string
+}
+
+// webhookCollector is a test HTTP server that captures incoming payloads
+// with full request metadata for validation.
+type webhookCollector struct {
+	mu       sync.Mutex
+	payloads []receivedPayload
+	srv      *httptest.Server
+	statusFn func(n int) int // optional: return status based on attempt number
+}
+
+func newCollector() *webhookCollector {
+	c := &webhookCollector{}
+	c.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var m map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&m)
+		c.mu.Lock()
+		n := len(c.payloads)
+		c.payloads = append(c.payloads, receivedPayload{
+			Body:        m,
+			ContentType: r.Header.Get("Content-Type"),
+			SecretHdr:   r.Header.Get("X-Webhook-Secret"),
+			Method:      r.Method,
+		})
+		statusFn := c.statusFn
+		c.mu.Unlock()
+		status := 200
+		if statusFn != nil {
+			status = statusFn(n + 1)
+		}
+		w.WriteHeader(status)
+	}))
+	return c
+}
+
+func (c *webhookCollector) Close()                  { c.srv.Close() }
+func (c *webhookCollector) URL() string             { return c.srv.URL }
+func (c *webhookCollector) get() []receivedPayload  { c.mu.Lock(); defer c.mu.Unlock(); cp := make([]receivedPayload, len(c.payloads)); copy(cp, c.payloads); return cp }
+func (c *webhookCollector) count() int              { c.mu.Lock(); defer c.mu.Unlock(); return len(c.payloads) }
+
+// newTestDispatcher creates a WebhookDispatcher with zero retry backoff for fast tests.
+func newTestDispatcher(cfgs []config.WebhookConfig) *WebhookDispatcher {
+	d := NewWebhookDispatcher(cfgs)
+	if d != nil {
+		d.retryBackoff = 0 // no wait between retries in tests
+	}
+	return d
+}
+
+// ---------------------------------------------------------------------------
+// Full realistic E2E test: multi-event enforcement pipeline
+// ---------------------------------------------------------------------------
+
+// TestWebhookE2E_FullEnforcementPipeline simulates the complete DefenseClaw
+// enforcement pipeline — watcher blocks a malicious skill, rescan detects
+// drift, guardrail blocks a prompt injection — and verifies that each event
+// is delivered to the correct webhook endpoints with correct payloads.
+func TestWebhookE2E_FullEnforcementPipeline(t *testing.T) {
+	// --- Set up 3 simulated external webhook receivers ---
+	slackReceiver := newCollector()
+	defer slackReceiver.Close()
+
+	pagerdutyReceiver := newCollector()
+	defer pagerdutyReceiver.Close()
+	pagerdutyReceiver.statusFn = func(int) int { return 202 } // PD returns 202 Accepted
+
+	genericReceiver := newCollector()
+	defer genericReceiver.Close()
+
+	// --- Create dispatcher with realistic multi-endpoint config ---
+	d := newTestDispatcher([]config.WebhookConfig{
+		{
+			URL:         slackReceiver.URL(),
+			Type:        "slack",
+			MinSeverity: "MEDIUM",
+			Events:      []string{"block", "drift", "guardrail"},
+			Enabled:     true,
+		},
+		{
+			URL:         pagerdutyReceiver.URL(),
+			Type:        "pagerduty",
+			MinSeverity: "HIGH",
+			Events:      []string{"block"},
+			Enabled:     true,
+		},
+		{
+			URL:            genericReceiver.URL(),
+			Type:           "generic",
+			SecretEnv:      "",
+			MinSeverity:    "INFO",
+			Events:         []string{"block", "drift", "guardrail", "scan"},
+			TimeoutSeconds: 5,
+			Enabled:        true,
+		},
+	})
+	if d == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+
+	// ── EVENT 1: Watcher blocks a malicious skill ──
+	// Simulates sendEnforcementAlert in sidecar.go creating this event
+	skillBlockEvent := audit.Event{
+		ID:        "evt-watcher-001",
+		Timestamp: time.Now().UTC(),
+		Action:    "block",
+		Target:    "crypto-miner-skill",
+		Actor:     "defenseclaw-watcher",
+		Details:   "type=skill severity=CRITICAL findings=7 actions=quarantined,blocked,disabled reason=malware signature detected in node_modules",
+		Severity:  "CRITICAL",
+		RunID:     "run-e2e-pipeline",
+	}
+	d.Dispatch(skillBlockEvent)
+
+	// ── EVENT 2: Drift detected during periodic rescan ──
+	// Simulates emitDriftAlerts in rescan.go
+	driftEvent := audit.Event{
+		ID:        "evt-drift-002",
+		Timestamp: time.Now().UTC(),
+		Action:    "drift",
+		Target:    "/home/user/.openclaw/workspace/skills/data-analyzer",
+		Actor:     "defenseclaw-rescan",
+		Details:   `[{"type":"dependency_change","severity":"MEDIUM","description":"dependency manifest modified: package.json"},{"type":"new_endpoint","severity":"HIGH","description":"new network endpoint detected: https://evil-c2.example.com/exfil"}]`,
+		Severity:  "HIGH",
+	}
+	d.Dispatch(driftEvent)
+
+	// ── EVENT 3: Guardrail blocks a prompt injection ──
+	// Simulates recordTelemetry in proxy.go when verdict.Action == "block"
+	guardrailBlockEvent := audit.Event{
+		ID:        "evt-guardrail-003",
+		Timestamp: time.Now().UTC(),
+		Action:    "guardrail-block",
+		Target:    "anthropic/claude-sonnet-4-20250514",
+		Actor:     "defenseclaw-guardrail",
+		Details:   "direction=prompt action=block severity=HIGH findings=2 elapsed_ms=45.3 reason=prompt_injection:ignore_previous_instructions",
+		Severity:  "HIGH",
+	}
+	d.Dispatch(guardrailBlockEvent)
+
+	// ── EVENT 4: Low-severity scan (should only reach generic) ──
+	scanEvent := audit.Event{
+		ID:        "evt-scan-004",
+		Timestamp: time.Now().UTC(),
+		Action:    "scan",
+		Target:    "safe-utility-skill",
+		Actor:     "defenseclaw",
+		Details:   "scanner=skill-scanner findings=0 max_severity=INFO",
+		Severity:  "INFO",
+	}
+	d.Dispatch(scanEvent)
+
+	// Wait for all async sends to complete
+	d.Close()
+
+	// --- Validate Slack endpoint ---
+	// Slack: min_severity=MEDIUM, events=[block, drift, guardrail]
+	// Should receive: skill block (CRITICAL ≥ MEDIUM), drift (HIGH ≥ MEDIUM), guardrail (HIGH ≥ MEDIUM)
+	// Should NOT receive: scan (INFO < MEDIUM, and scan not in event filter)
+	slackPayloads := slackReceiver.get()
+	if len(slackPayloads) != 3 {
+		t.Errorf("[slack] expected 3 payloads (block+drift+guardrail), got %d", len(slackPayloads))
+	}
+	for _, p := range slackPayloads {
+		if p.ContentType != "application/json" {
+			t.Errorf("[slack] expected Content-Type=application/json, got %q", p.ContentType)
+		}
+		if p.Method != "POST" {
+			t.Errorf("[slack] expected POST, got %s", p.Method)
+		}
+		attachments, ok := p.Body["attachments"].([]interface{})
+		if !ok || len(attachments) == 0 {
+			t.Error("[slack] missing attachments array")
+			continue
+		}
+		att := attachments[0].(map[string]interface{})
+		color, _ := att["color"].(string)
+		if color == "" {
+			t.Error("[slack] missing color on attachment")
+		}
+		blocks, _ := att["blocks"].([]interface{})
+		if len(blocks) < 3 {
+			t.Errorf("[slack] expected ≥3 blocks (header, section, context), got %d", len(blocks))
+		}
+	}
+
+	// Validate that at least one Slack payload has CRITICAL red color
+	foundCriticalRed := false
+	for _, p := range slackPayloads {
+		att := p.Body["attachments"].([]interface{})[0].(map[string]interface{})
+		if att["color"] == "#FF0000" {
+			foundCriticalRed = true
+			break
+		}
+	}
+	if !foundCriticalRed {
+		t.Error("[slack] expected at least one CRITICAL payload with red (#FF0000) color")
+	}
+
+	// --- Validate PagerDuty endpoint ---
+	// PagerDuty: min_severity=HIGH, events=[block]
+	// Should receive: skill block (CRITICAL ≥ HIGH, action=block)
+	// Should NOT receive: drift (HIGH ≥ HIGH but action=drift not in filter), guardrail, scan
+	pdPayloads := pagerdutyReceiver.get()
+	if len(pdPayloads) != 1 {
+		t.Errorf("[pagerduty] expected 1 payload (block only), got %d", len(pdPayloads))
+	}
+	if len(pdPayloads) >= 1 {
+		pd := pdPayloads[0]
+		if pd.ContentType != "application/json" {
+			t.Errorf("[pagerduty] expected Content-Type=application/json, got %q", pd.ContentType)
+		}
+		body := pd.Body
+		if body["event_action"] != "trigger" {
+			t.Errorf("[pagerduty] expected event_action=trigger, got %v", body["event_action"])
+		}
+		dedupKey, _ := body["dedup_key"].(string)
+		if !strings.Contains(dedupKey, "crypto-miner-skill") {
+			t.Errorf("[pagerduty] dedup_key should contain target name, got %q", dedupKey)
+		}
+		payload := body["payload"].(map[string]interface{})
+		if payload["severity"] != "critical" {
+			t.Errorf("[pagerduty] expected severity=critical for CRITICAL event, got %v", payload["severity"])
+		}
+		if payload["source"] != "defenseclaw" {
+			t.Errorf("[pagerduty] expected source=defenseclaw, got %v", payload["source"])
+		}
+		summary, _ := payload["summary"].(string)
+		if !strings.Contains(summary, "crypto-miner-skill") {
+			t.Errorf("[pagerduty] summary should mention target, got %q", summary)
+		}
+		customDetails := payload["custom_details"].(map[string]interface{})
+		if customDetails["action"] != "block" {
+			t.Errorf("[pagerduty] custom_details.action should be block, got %v", customDetails["action"])
+		}
+		if customDetails["event_id"] != "evt-watcher-001" {
+			t.Errorf("[pagerduty] custom_details.event_id should be evt-watcher-001, got %v", customDetails["event_id"])
+		}
+	}
+
+	// --- Validate Generic endpoint ---
+	// Generic: min_severity=INFO, events=[block, drift, guardrail, scan]
+	// Should receive ALL 4 events
+	genPayloads := genericReceiver.get()
+	if len(genPayloads) != 4 {
+		t.Errorf("[generic] expected 4 payloads (block+drift+guardrail+scan), got %d", len(genPayloads))
+	}
+
+	// Index generic payloads by event ID for order-independent assertions
+	byID := make(map[string]receivedPayload)
+	for _, p := range genPayloads {
+		if p.Body["webhook_type"] != "defenseclaw_enforcement" {
+			t.Errorf("[generic] expected webhook_type=defenseclaw_enforcement, got %v", p.Body["webhook_type"])
+		}
+		if p.Body["defenseclaw_version"] != "1.0" {
+			t.Errorf("[generic] expected defenseclaw_version=1.0, got %v", p.Body["defenseclaw_version"])
+		}
+		evt := p.Body["event"].(map[string]interface{})
+		if _, ok := evt["timestamp"]; !ok {
+			t.Error("[generic] missing timestamp")
+		}
+		id, _ := evt["id"].(string)
+		byID[id] = p
+	}
+
+	// Validate the watcher block event
+	if p, ok := byID["evt-watcher-001"]; ok {
+		e := p.Body["event"].(map[string]interface{})
+		if e["action"] != "block" {
+			t.Errorf("[generic][block] action should be block, got %v", e["action"])
+		}
+		if e["target"] != "crypto-miner-skill" {
+			t.Errorf("[generic][block] target should be crypto-miner-skill, got %v", e["target"])
+		}
+		if e["severity"] != "CRITICAL" {
+			t.Errorf("[generic][block] severity should be CRITICAL, got %v", e["severity"])
+		}
+		if e["actor"] != "defenseclaw-watcher" {
+			t.Errorf("[generic][block] actor should be defenseclaw-watcher, got %v", e["actor"])
+		}
+		if e["run_id"] != "run-e2e-pipeline" {
+			t.Errorf("[generic][block] run_id should be run-e2e-pipeline, got %v", e["run_id"])
+		}
+	} else {
+		t.Error("[generic] missing evt-watcher-001 (block event)")
+	}
+
+	// Validate the drift event
+	if p, ok := byID["evt-drift-002"]; ok {
+		e := p.Body["event"].(map[string]interface{})
+		if e["action"] != "drift" {
+			t.Errorf("[generic][drift] action should be drift, got %v", e["action"])
+		}
+		details, _ := e["details"].(string)
+		if !strings.Contains(details, "dependency_change") {
+			t.Errorf("[generic][drift] details should contain drift delta JSON, got %q", details)
+		}
+	} else {
+		t.Error("[generic] missing evt-drift-002 (drift event)")
+	}
+
+	// Validate the guardrail block event
+	if p, ok := byID["evt-guardrail-003"]; ok {
+		e := p.Body["event"].(map[string]interface{})
+		if e["action"] != "guardrail-block" {
+			t.Errorf("[generic][guardrail] action should be guardrail-block, got %v", e["action"])
+		}
+		if e["actor"] != "defenseclaw-guardrail" {
+			t.Errorf("[generic][guardrail] actor should be defenseclaw-guardrail, got %v", e["actor"])
+		}
+	} else {
+		t.Error("[generic] missing evt-guardrail-003 (guardrail-block event)")
+	}
+
+	// Validate the scan event
+	if p, ok := byID["evt-scan-004"]; ok {
+		e := p.Body["event"].(map[string]interface{})
+		if e["action"] != "scan" {
+			t.Errorf("[generic][scan] action should be scan, got %v", e["action"])
+		}
+		if e["severity"] != "INFO" {
+			t.Errorf("[generic][scan] severity should be INFO, got %v", e["severity"])
+		}
+	} else {
+		t.Error("[generic] missing evt-scan-004 (scan event)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Retry under transient failures
+// ---------------------------------------------------------------------------
+
+// TestWebhookE2E_RetryOnTransientFailure verifies the dispatcher retries
+// on 503/500 responses and eventually delivers the payload.
+func TestWebhookE2E_RetryOnTransientFailure(t *testing.T) {
+	receiver := newCollector()
+	defer receiver.Close()
+	// First 2 attempts return 503, third succeeds
+	receiver.statusFn = func(n int) int {
+		if n <= 2 {
+			return 503
+		}
+		return 200
+	}
+
+	d := newTestDispatcher([]config.WebhookConfig{
+		{URL: receiver.URL(), Type: "generic", MinSeverity: "INFO", Enabled: true},
+	})
+
+	d.Dispatch(testEvent())
+	d.Close()
+
+	got := receiver.count()
+	if got < 3 {
+		t.Errorf("expected at least 3 attempts (initial + 2 retries), got %d", got)
+	}
+
+	// The last payload should be the successful one with correct content
+	payloads := receiver.get()
+	last := payloads[len(payloads)-1]
+	if last.Body["webhook_type"] != "defenseclaw_enforcement" {
+		t.Errorf("final payload should be valid generic format")
+	}
+}
+
+// TestWebhookE2E_AllRetriesExhausted verifies that when all retries fail,
+// the dispatcher does not panic and the payload structure is still correct.
+func TestWebhookE2E_AllRetriesExhausted(t *testing.T) {
+	receiver := newCollector()
+	defer receiver.Close()
+	receiver.statusFn = func(int) int { return 500 } // always fail
+
+	d := newTestDispatcher([]config.WebhookConfig{
+		{URL: receiver.URL(), Type: "generic", MinSeverity: "INFO", Enabled: true},
+	})
+
+	d.Dispatch(testEvent())
+	d.Close() // should not hang
+
+	got := receiver.count()
+	expected := webhookMaxRetries + 1 // initial + retries
+	if got != expected {
+		t.Errorf("expected %d total attempts, got %d", expected, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Secret header on generic webhooks
+// ---------------------------------------------------------------------------
+
+// TestWebhookE2E_GenericSecretHeader verifies that X-Webhook-Secret is
+// set on generic webhook requests when a secret is configured.
+func TestWebhookE2E_GenericSecretHeader(t *testing.T) {
+	receiver := newCollector()
+	defer receiver.Close()
+
+	t.Setenv("TEST_WEBHOOK_SECRET_E2E", "supersecretvalue42")
+
+	d := newTestDispatcher([]config.WebhookConfig{
+		{
+			URL:       receiver.URL(),
+			Type:      "generic",
+			SecretEnv: "TEST_WEBHOOK_SECRET_E2E",
+			Enabled:   true,
+		},
+	})
+
+	d.Dispatch(testEvent())
+	d.Close()
+
+	payloads := receiver.get()
+	if len(payloads) != 1 {
+		t.Fatalf("expected 1 payload, got %d", len(payloads))
+	}
+	if payloads[0].SecretHdr != "supersecretvalue42" {
+		t.Errorf("expected X-Webhook-Secret=supersecretvalue42, got %q", payloads[0].SecretHdr)
+	}
+}
+
+// TestWebhookE2E_SlackNoSecretHeader verifies that X-Webhook-Secret is
+// NOT sent for Slack webhooks (Slack authenticates via the URL token).
+func TestWebhookE2E_SlackNoSecretHeader(t *testing.T) {
+	receiver := newCollector()
+	defer receiver.Close()
+
+	d := newTestDispatcher([]config.WebhookConfig{
+		{URL: receiver.URL(), Type: "slack", Enabled: true},
+	})
+
+	d.Dispatch(testEvent())
+	d.Close()
+
+	payloads := receiver.get()
+	if len(payloads) != 1 {
+		t.Fatalf("expected 1 payload, got %d", len(payloads))
+	}
+	if payloads[0].SecretHdr != "" {
+		t.Errorf("slack webhooks should not include X-Webhook-Secret, got %q", payloads[0].SecretHdr)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Severity threshold edge cases
+// ---------------------------------------------------------------------------
+
+// TestWebhookE2E_SeverityEdgeCases verifies boundary behavior for severity
+// filtering across all severity levels.
+func TestWebhookE2E_SeverityEdgeCases(t *testing.T) {
+	severities := []string{"INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL"}
+
+	for _, threshold := range severities {
+		for _, eventSev := range severities {
+			name := threshold + "_accepts_" + eventSev
+			t.Run(name, func(t *testing.T) {
+				receiver := newCollector()
+				defer receiver.Close()
+
+				d := newTestDispatcher([]config.WebhookConfig{
+					{URL: receiver.URL(), Type: "generic", MinSeverity: threshold, Enabled: true},
+				})
+
+				evt := testEvent()
+				evt.Severity = eventSev
+				d.Dispatch(evt)
+				d.Close()
+
+				delivered := receiver.count() > 0
+				expected := severityToRank(eventSev) >= severityToRank(threshold)
+				if delivered != expected {
+					t.Errorf("threshold=%s event=%s: delivered=%v, want %v",
+						threshold, eventSev, delivered, expected)
+				}
+			})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mixed enabled/disabled endpoints
+// ---------------------------------------------------------------------------
+
+// TestWebhookE2E_MixedEnabledDisabled verifies that disabled endpoints
+// are silently skipped and enabled ones still receive events.
+func TestWebhookE2E_MixedEnabledDisabled(t *testing.T) {
+	activeReceiver := newCollector()
+	defer activeReceiver.Close()
+
+	disabledReceiver := newCollector()
+	defer disabledReceiver.Close()
+
+	d := newTestDispatcher([]config.WebhookConfig{
+		{URL: disabledReceiver.URL(), Type: "generic", Enabled: false},
+		{URL: activeReceiver.URL(), Type: "generic", Enabled: true},
+		{URL: "", Type: "generic", Enabled: true},
+	})
+
+	d.Dispatch(testEvent())
+	d.Close()
+
+	if activeReceiver.count() != 1 {
+		t.Errorf("active endpoint should receive 1 payload, got %d", activeReceiver.count())
+	}
+	if disabledReceiver.count() != 0 {
+		t.Errorf("disabled endpoint should receive 0 payloads, got %d", disabledReceiver.count())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent dispatch safety
+// ---------------------------------------------------------------------------
+
+// TestWebhookE2E_ConcurrentDispatch verifies that dispatching many events
+// concurrently does not cause races or lost payloads.
+func TestWebhookE2E_ConcurrentDispatch(t *testing.T) {
+	receiver := newCollector()
+	defer receiver.Close()
+
+	d := newTestDispatcher([]config.WebhookConfig{
+		{URL: receiver.URL(), Type: "generic", MinSeverity: "INFO", Enabled: true},
+	})
+
+	const numEvents = 50
+	var wg sync.WaitGroup
+	for i := 0; i < numEvents; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			evt := audit.Event{
+				ID:        time.Now().Format("20060102150405.000000") + "-" + string(rune('A'+i%26)),
+				Timestamp: time.Now().UTC(),
+				Action:    "block",
+				Target:    "concurrent-skill",
+				Actor:     "test",
+				Severity:  "HIGH",
+			}
+			d.Dispatch(evt)
+		}(i)
+	}
+	wg.Wait()
+	d.Close()
+
+	got := receiver.count()
+	if got != numEvents {
+		t.Errorf("expected %d payloads for concurrent dispatch, got %d", numEvents, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Post-close dispatch is silently dropped
+// ---------------------------------------------------------------------------
+
+// TestWebhookE2E_DispatchAfterClose verifies that events sent after Close
+// are silently dropped without panic.
+func TestWebhookE2E_DispatchAfterClose(t *testing.T) {
+	receiver := newCollector()
+	defer receiver.Close()
+
+	d := newTestDispatcher([]config.WebhookConfig{
+		{URL: receiver.URL(), Type: "generic", Enabled: true},
+	})
+
+	d.Dispatch(testEvent())
+	d.Close()
+
+	before := receiver.count()
+
+	// These should be silently dropped
+	d.Dispatch(testEvent())
+	d.Dispatch(testEvent())
+	time.Sleep(50 * time.Millisecond)
+
+	after := receiver.count()
+	if after != before {
+		t.Errorf("expected no new payloads after Close, before=%d after=%d", before, after)
+	}
+}

--- a/internal/gateway/webhook_test.go
+++ b/internal/gateway/webhook_test.go
@@ -17,11 +17,16 @@
 package gateway
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -128,9 +133,10 @@ func TestFormatGenericPayload(t *testing.T) {
 }
 
 func TestSeverityFiltering(t *testing.T) {
+	t.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
 	tests := []struct {
-		minSeverity  string
-		eventSev     string
+		minSeverity   string
+		eventSev      string
 		shouldDeliver bool
 	}{
 		{"HIGH", "CRITICAL", true},
@@ -178,9 +184,10 @@ func TestSeverityFiltering(t *testing.T) {
 }
 
 func TestEventTypeFiltering(t *testing.T) {
+	t.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
 	tests := []struct {
-		events       []string
-		action       string
+		events        []string
+		action        string
 		shouldDeliver bool
 	}{
 		{[]string{"block"}, "block", true},
@@ -229,6 +236,7 @@ func TestEventTypeFiltering(t *testing.T) {
 }
 
 func TestWebhookDispatch_Integration(t *testing.T) {
+	t.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
 	var mu sync.Mutex
 	var payloads []map[string]interface{}
 
@@ -296,10 +304,391 @@ func TestCategorizeAction(t *testing.T) {
 
 func TestNewWebhookDispatcherSkipsDisabled(t *testing.T) {
 	d := NewWebhookDispatcher([]config.WebhookConfig{
-		{URL: "http://example.com", Enabled: false},
+		{URL: "https://example.com", Enabled: false},
 		{URL: "", Enabled: true},
 	})
 	if d != nil {
 		t.Error("expected nil dispatcher when all endpoints are disabled/empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1 SSRF / URL validation tests
+// ---------------------------------------------------------------------------
+
+func TestValidateWebhookURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"https valid", "https://hooks.slack.com/T/B/xxx", false},
+		{"http valid", "http://example.com/webhook", false},
+		{"file scheme blocked", "file:///etc/passwd", true},
+		{"ftp scheme blocked", "ftp://example.com/file", true},
+		{"gopher scheme blocked", "gopher://evil.com", true},
+		{"private 10.x", "http://10.0.0.1/webhook", true},
+		{"private 172.16.x", "http://172.16.0.1/webhook", true},
+		{"private 192.168.x", "http://192.168.1.1/webhook", true},
+		{"loopback 127.0.0.1", "http://127.0.0.1/webhook", true},
+		{"link-local metadata", "http://169.254.169.254/latest/meta-data/", true},
+		{"localhost blocked", "http://localhost/webhook", true},
+		{"ipv6 loopback", "http://[::1]/webhook", true},
+		{"empty hostname", "http:///path", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateWebhookURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateWebhookURL(%q) error = %v, wantErr %v", tt.url, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewWebhookDispatcherRejectsUnsafeURL(t *testing.T) {
+	d := NewWebhookDispatcher([]config.WebhookConfig{
+		{URL: "http://169.254.169.254/latest/meta-data/", Type: "generic", Enabled: true},
+	})
+	if d != nil {
+		t.Error("expected nil dispatcher when URL is private IP")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #2 HMAC payload signing tests
+// ---------------------------------------------------------------------------
+
+func TestHMACSignatureOnGenericEndpoint(t *testing.T) {
+	t.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
+	var mu sync.Mutex
+	var sigHeader string
+	var body []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		sigHeader = r.Header.Get("X-Hub-Signature-256")
+		body, _ = io.ReadAll(r.Body)
+		mu.Unlock()
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	secret := "test-webhook-secret-42"
+	t.Setenv("TEST_HMAC_SECRET", secret)
+
+	d := NewWebhookDispatcher([]config.WebhookConfig{
+		{
+			URL:       srv.URL,
+			Type:      "generic",
+			SecretEnv: "TEST_HMAC_SECRET",
+			Enabled:   true,
+		},
+	})
+
+	d.Dispatch(testEvent())
+	d.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if !strings.HasPrefix(sigHeader, "sha256=") {
+		t.Fatalf("expected X-Hub-Signature-256 header with sha256= prefix, got %q", sigHeader)
+	}
+	receivedSig := strings.TrimPrefix(sigHeader, "sha256=")
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	expectedSig := hex.EncodeToString(mac.Sum(nil))
+
+	if receivedSig != expectedSig {
+		t.Errorf("HMAC mismatch: got %q, want %q", receivedSig, expectedSig)
+	}
+}
+
+func TestNoSignatureWhenNoSecret(t *testing.T) {
+	t.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
+	var mu sync.Mutex
+	var sigHeader string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		sigHeader = r.Header.Get("X-Hub-Signature-256")
+		mu.Unlock()
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	d := NewWebhookDispatcher([]config.WebhookConfig{
+		{URL: srv.URL, Type: "generic", Enabled: true},
+	})
+
+	d.Dispatch(testEvent())
+	d.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if sigHeader != "" {
+		t.Errorf("expected no signature header when no secret, got %q", sigHeader)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #3 Retry behavior: 4xx permanent vs 5xx retryable
+// ---------------------------------------------------------------------------
+
+func TestRetry4xxIsPermanent(t *testing.T) {
+	t.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
+	statusCodes := []int{400, 401, 403, 404}
+
+	for _, code := range statusCodes {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			var attempts int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt32(&attempts, 1)
+				w.WriteHeader(code)
+			}))
+			defer srv.Close()
+
+			d := NewWebhookDispatcher([]config.WebhookConfig{
+				{URL: srv.URL, Type: "generic", Enabled: true},
+			})
+			d.retryBackoff = 1 * time.Millisecond
+
+			d.Dispatch(testEvent())
+			d.Close()
+
+			got := atomic.LoadInt32(&attempts)
+			if got != 1 {
+				t.Errorf("%d should be permanent failure (no retry), got %d attempts", code, got)
+			}
+		})
+	}
+}
+
+func TestRetry5xxIsRetried(t *testing.T) {
+	t.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n <= 2 {
+			w.WriteHeader(503)
+			return
+		}
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	d := NewWebhookDispatcher([]config.WebhookConfig{
+		{URL: srv.URL, Type: "generic", Enabled: true},
+	})
+	d.retryBackoff = 1 * time.Millisecond
+
+	d.Dispatch(testEvent())
+	d.Close()
+
+	got := atomic.LoadInt32(&attempts)
+	if got != 3 {
+		t.Errorf("expected 3 attempts (2 retries then success), got %d", got)
+	}
+}
+
+func TestRetry429RespectsRetryAfter(t *testing.T) {
+	t.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
+	start := time.Now()
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(429)
+			return
+		}
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	d := NewWebhookDispatcher([]config.WebhookConfig{
+		{URL: srv.URL, Type: "generic", Enabled: true},
+	})
+	d.retryBackoff = 1 * time.Millisecond
+
+	d.Dispatch(testEvent())
+	d.Close()
+
+	elapsed := time.Since(start)
+	got := atomic.LoadInt32(&attempts)
+	if got != 2 {
+		t.Errorf("expected 2 attempts, got %d", got)
+	}
+	if elapsed < 900*time.Millisecond {
+		t.Errorf("expected Retry-After to delay ~1s, elapsed %v", elapsed)
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		status int
+		want   bool
+	}{
+		{200, false},
+		{400, false},
+		{401, false},
+		{403, false},
+		{404, false},
+		{429, true},
+		{500, true},
+		{502, true},
+		{503, true},
+	}
+	for _, tt := range tests {
+		got := isRetryable(tt.status)
+		if got != tt.want {
+			t.Errorf("isRetryable(%d) = %v, want %v", tt.status, got, tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #7 Event ID auto-generation
+// ---------------------------------------------------------------------------
+
+func TestDispatchAutoGeneratesEventID(t *testing.T) {
+	t.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
+	var mu sync.Mutex
+	var receivedID string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var m map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&m); err == nil {
+			mu.Lock()
+			if evt, ok := m["event"].(map[string]interface{}); ok {
+				receivedID, _ = evt["id"].(string)
+			}
+			mu.Unlock()
+		}
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	d := NewWebhookDispatcher([]config.WebhookConfig{
+		{URL: srv.URL, Type: "generic", MinSeverity: "INFO", Enabled: true},
+	})
+
+	evt := testEvent()
+	evt.ID = "" // simulate dispatch site that forgot to set ID
+	d.Dispatch(evt)
+	d.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if receivedID == "" {
+		t.Error("expected auto-generated event ID, got empty string")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #13 Details truncation
+// ---------------------------------------------------------------------------
+
+func TestSlackDetailsTruncation(t *testing.T) {
+	evt := testEvent()
+	evt.Details = strings.Repeat("x", 600)
+
+	payload, err := formatSlackPayload(evt)
+	if err != nil {
+		t.Fatalf("formatSlackPayload error: %v", err)
+	}
+	raw := string(payload)
+	if !strings.Contains(raw, strings.Repeat("x", 500)+"...") {
+		t.Error("expected 500 chars + ellipsis in Slack payload")
+	}
+	if strings.Contains(raw, strings.Repeat("x", 501)) {
+		t.Error("details should be truncated at 500 chars")
+	}
+}
+
+func TestWebexDetailsTruncation(t *testing.T) {
+	evt := testEvent()
+	evt.Details = strings.Repeat("y", 600)
+
+	payload, err := formatWebexPayload(evt, "room-123")
+	if err != nil {
+		t.Fatalf("formatWebexPayload error: %v", err)
+	}
+	raw := string(payload)
+	if !strings.Contains(raw, strings.Repeat("y", 500)+"...") {
+		t.Error("expected 500 chars + ellipsis in Webex payload")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #5 Per-endpoint timeout
+// ---------------------------------------------------------------------------
+
+func TestPerEndpointTimeout(t *testing.T) {
+	t.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(3 * time.Second)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	d := NewWebhookDispatcher([]config.WebhookConfig{
+		{URL: srv.URL, Type: "generic", Enabled: true, TimeoutSeconds: 1},
+	})
+	d.retryBackoff = 1 * time.Millisecond
+
+	start := time.Now()
+	d.Dispatch(testEvent())
+	d.Close()
+	elapsed := time.Since(start)
+
+	if elapsed > 10*time.Second {
+		t.Errorf("expected per-endpoint timeout to cap at ~1s per attempt, elapsed %v", elapsed)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #6 SeverityRank shared function
+// ---------------------------------------------------------------------------
+
+func TestSeverityRankShared(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int
+	}{
+		{"CRITICAL", 5},
+		{"HIGH", 4},
+		{"MEDIUM", 3},
+		{"LOW", 2},
+		{"INFO", 1},
+		{"", 0},
+		{"unknown", 0},
+		{"critical", 5}, // case insensitive
+	}
+	for _, tt := range tests {
+		got := audit.SeverityRank(tt.input)
+		if got != tt.expected {
+			t.Errorf("SeverityRank(%q) = %d, want %d", tt.input, got, tt.expected)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// computeHMAC
+// ---------------------------------------------------------------------------
+
+func TestComputeHMAC(t *testing.T) {
+	data := []byte(`{"test": true}`)
+	key := "secret123"
+	got := computeHMAC(data, key)
+
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write(data)
+	want := hex.EncodeToString(mac.Sum(nil))
+
+	if got != want {
+		t.Errorf("computeHMAC mismatch: got %q, want %q", got, want)
 	}
 }

--- a/internal/gateway/webhook_test.go
+++ b/internal/gateway/webhook_test.go
@@ -1,0 +1,277 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/audit"
+	"github.com/defenseclaw/defenseclaw/internal/config"
+)
+
+func testEvent() audit.Event {
+	return audit.Event{
+		ID:        "evt-001",
+		Timestamp: time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC),
+		Action:    "block",
+		Target:    "malicious-skill",
+		Actor:     "defenseclaw-watcher",
+		Details:   "type=skill severity=HIGH findings=3 actions=quarantined,blocked reason=malware detected",
+		Severity:  "HIGH",
+		RunID:     "run-123",
+	}
+}
+
+func TestFormatSlackPayload(t *testing.T) {
+	payload, err := formatSlackPayload(testEvent())
+	if err != nil {
+		t.Fatalf("formatSlackPayload error: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(payload, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	attachments, ok := m["attachments"].([]interface{})
+	if !ok || len(attachments) == 0 {
+		t.Fatal("expected attachments array")
+	}
+	att := attachments[0].(map[string]interface{})
+	if att["color"] != "#FF6600" {
+		t.Errorf("expected HIGH color #FF6600, got %s", att["color"])
+	}
+}
+
+func TestFormatPagerDutyPayload(t *testing.T) {
+	payload, err := formatPagerDutyPayload(testEvent(), "test-routing-key")
+	if err != nil {
+		t.Fatalf("formatPagerDutyPayload error: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(payload, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["routing_key"] != "test-routing-key" {
+		t.Errorf("expected routing_key=test-routing-key, got %v", m["routing_key"])
+	}
+	if m["event_action"] != "trigger" {
+		t.Errorf("expected event_action=trigger, got %v", m["event_action"])
+	}
+	p := m["payload"].(map[string]interface{})
+	if p["severity"] != "error" {
+		t.Errorf("expected PD severity=error for HIGH, got %v", p["severity"])
+	}
+}
+
+func TestFormatGenericPayload(t *testing.T) {
+	payload, err := formatGenericPayload(testEvent())
+	if err != nil {
+		t.Fatalf("formatGenericPayload error: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(payload, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["webhook_type"] != "defenseclaw_enforcement" {
+		t.Errorf("expected webhook_type=defenseclaw_enforcement, got %v", m["webhook_type"])
+	}
+	evt := m["event"].(map[string]interface{})
+	if evt["action"] != "block" {
+		t.Errorf("expected action=block, got %v", evt["action"])
+	}
+}
+
+func TestSeverityFiltering(t *testing.T) {
+	tests := []struct {
+		minSeverity  string
+		eventSev     string
+		shouldDeliver bool
+	}{
+		{"HIGH", "CRITICAL", true},
+		{"HIGH", "HIGH", true},
+		{"HIGH", "MEDIUM", false},
+		{"HIGH", "LOW", false},
+		{"MEDIUM", "HIGH", true},
+		{"CRITICAL", "HIGH", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.minSeverity+"_"+tt.eventSev, func(t *testing.T) {
+			var mu sync.Mutex
+			received := false
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				received = true
+				mu.Unlock()
+				w.WriteHeader(200)
+			}))
+			defer srv.Close()
+
+			d := NewWebhookDispatcher([]config.WebhookConfig{
+				{
+					URL:         srv.URL,
+					Type:        "generic",
+					MinSeverity: tt.minSeverity,
+					Enabled:     true,
+				},
+			})
+			evt := testEvent()
+			evt.Severity = tt.eventSev
+			d.Dispatch(evt)
+			d.Close()
+
+			mu.Lock()
+			got := received
+			mu.Unlock()
+			if got != tt.shouldDeliver {
+				t.Errorf("minSeverity=%s eventSev=%s: expected delivered=%v, got %v",
+					tt.minSeverity, tt.eventSev, tt.shouldDeliver, got)
+			}
+		})
+	}
+}
+
+func TestEventTypeFiltering(t *testing.T) {
+	tests := []struct {
+		events       []string
+		action       string
+		shouldDeliver bool
+	}{
+		{[]string{"block"}, "block", true},
+		{[]string{"block"}, "drift", false},
+		{[]string{"drift"}, "drift", true},
+		{[]string{"guardrail"}, "guardrail-block", true},
+		{[]string{"block", "drift"}, "drift", true},
+		{[]string{}, "block", true}, // empty = all events
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.action, func(t *testing.T) {
+			var mu sync.Mutex
+			received := false
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				received = true
+				mu.Unlock()
+				w.WriteHeader(200)
+			}))
+			defer srv.Close()
+
+			d := NewWebhookDispatcher([]config.WebhookConfig{
+				{
+					URL:         srv.URL,
+					Type:        "generic",
+					MinSeverity: "INFO",
+					Events:      tt.events,
+					Enabled:     true,
+				},
+			})
+			evt := testEvent()
+			evt.Action = tt.action
+			d.Dispatch(evt)
+			d.Close()
+
+			mu.Lock()
+			got := received
+			mu.Unlock()
+			if got != tt.shouldDeliver {
+				t.Errorf("events=%v action=%s: expected delivered=%v, got %v",
+					tt.events, tt.action, tt.shouldDeliver, got)
+			}
+		})
+	}
+}
+
+func TestWebhookDispatch_Integration(t *testing.T) {
+	var mu sync.Mutex
+	var payloads []map[string]interface{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var m map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&m); err == nil {
+			mu.Lock()
+			payloads = append(payloads, m)
+			mu.Unlock()
+		}
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	d := NewWebhookDispatcher([]config.WebhookConfig{
+		{
+			URL:         srv.URL,
+			Type:        "generic",
+			MinSeverity: "INFO",
+			Enabled:     true,
+		},
+	})
+
+	d.Dispatch(testEvent())
+	d.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(payloads) != 1 {
+		t.Fatalf("expected 1 payload, got %d", len(payloads))
+	}
+	if payloads[0]["webhook_type"] != "defenseclaw_enforcement" {
+		t.Errorf("expected webhook_type=defenseclaw_enforcement, got %v", payloads[0]["webhook_type"])
+	}
+}
+
+func TestWebhookDispatcherNil(t *testing.T) {
+	var d *WebhookDispatcher
+	d.Dispatch(testEvent()) // should not panic
+	d.Close()               // should not panic
+}
+
+func TestCategorizeAction(t *testing.T) {
+	tests := []struct {
+		action   string
+		expected string
+	}{
+		{"block", "block"},
+		{"quarantine", "block"},
+		{"sidecar-watcher-disable", "block"},
+		{"drift", "drift"},
+		{"rescan", "drift"},
+		{"guardrail-block", "guardrail"},
+		{"guardrail-inspection", "guardrail"},
+		{"scan", "scan"},
+		{"init", "init"},
+	}
+	for _, tt := range tests {
+		got := categorizeAction(tt.action)
+		if got != tt.expected {
+			t.Errorf("categorizeAction(%q) = %q, want %q", tt.action, got, tt.expected)
+		}
+	}
+}
+
+func TestNewWebhookDispatcherSkipsDisabled(t *testing.T) {
+	d := NewWebhookDispatcher([]config.WebhookConfig{
+		{URL: "http://example.com", Enabled: false},
+		{URL: "", Enabled: true},
+	})
+	if d != nil {
+		t.Error("expected nil dispatcher when all endpoints are disabled/empty")
+	}
+}

--- a/internal/gateway/webhook_test.go
+++ b/internal/gateway/webhook_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -78,6 +79,33 @@ func TestFormatPagerDutyPayload(t *testing.T) {
 	p := m["payload"].(map[string]interface{})
 	if p["severity"] != "error" {
 		t.Errorf("expected PD severity=error for HIGH, got %v", p["severity"])
+	}
+}
+
+func TestFormatWebexPayload(t *testing.T) {
+	payload, err := formatWebexPayload(testEvent(), "Y2lzY29zcGFyazovL3VzL1JPT00vdGVzdC1yb29t")
+	if err != nil {
+		t.Fatalf("formatWebexPayload error: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(payload, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["roomId"] != "Y2lzY29zcGFyazovL3VzL1JPT00vdGVzdC1yb29t" {
+		t.Errorf("expected roomId to match, got %v", m["roomId"])
+	}
+	md, ok := m["markdown"].(string)
+	if !ok || md == "" {
+		t.Fatal("expected non-empty markdown field")
+	}
+	if !strings.Contains(md, "DefenseClaw: block") {
+		t.Errorf("markdown should contain action, got %q", md)
+	}
+	if !strings.Contains(md, "malicious-skill") {
+		t.Errorf("markdown should contain target, got %q", md)
+	}
+	if !strings.Contains(md, "HIGH") {
+		t.Errorf("markdown should contain severity, got %q", md)
 	}
 }
 

--- a/internal/watcher/rescan.go
+++ b/internal/watcher/rescan.go
@@ -530,6 +530,10 @@ func (w *InstallWatcher) emitDriftAlerts(evt InstallEvent, deltas []DriftDelta) 
 	if w.otel != nil {
 		w.otel.RecordWatcherEvent(context.Background(), "drift", string(evt.Type))
 	}
+
+	if w.webhooks != nil {
+		w.webhooks.Dispatch(event)
+	}
 }
 
 func summarizeDrift(deltas []DriftDelta) string {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -87,6 +87,12 @@ type OnAdmission func(AdmissionResult)
 // and runs the admission gate (block → allow → scan) on each detection.
 // MCP servers are managed via “defenseclaw mcp set/unset“ rather than
 // filesystem watching.
+// WebhookDispatcher is implemented by gateway.WebhookDispatcher. Declared as
+// an interface here to avoid an import cycle (watcher → gateway).
+type WebhookDispatcher interface {
+	Dispatch(event audit.Event)
+}
+
 type InstallWatcher struct {
 	cfg        *config.Config
 	skillDirs  []string
@@ -96,6 +102,7 @@ type InstallWatcher struct {
 	shell      *sandbox.OpenShell
 	opa        *policy.Engine
 	otel       *telemetry.Provider
+	webhooks   WebhookDispatcher
 	debounce   time.Duration
 	onAdmit    OnAdmission
 
@@ -129,6 +136,11 @@ func New(cfg *config.Config, skillDirs, pluginDirs []string, store *audit.Store,
 // SetOTelProvider attaches the OTel provider for watcher metrics.
 func (w *InstallWatcher) SetOTelProvider(p *telemetry.Provider) {
 	w.otel = p
+}
+
+// SetWebhookDispatcher attaches a webhook dispatcher for outbound notifications.
+func (w *InstallWatcher) SetWebhookDispatcher(d WebhookDispatcher) {
+	w.webhooks = d
 }
 
 // Run starts watching configured directories. It blocks until ctx is cancelled.

--- a/policies/default.yaml
+++ b/policies/default.yaml
@@ -115,6 +115,8 @@ watch:
   rescan_enabled: true
   rescan_interval_min: 60
 
+webhooks: []
+
 enforcement:
   max_enforcement_delay_seconds: 2
 

--- a/policies/permissive.yaml
+++ b/policies/permissive.yaml
@@ -76,6 +76,8 @@ watch:
   rescan_enabled: true
   rescan_interval_min: 120
 
+webhooks: []
+
 enforcement:
   max_enforcement_delay_seconds: 5
 

--- a/policies/strict.yaml
+++ b/policies/strict.yaml
@@ -134,6 +134,13 @@ watch:
 #     min_severity: HIGH
 #     events: [block, drift, guardrail]
 #     enabled: true
+#   - url: "https://webexapis.com/v1/messages"
+#     type: webex
+#     secret_env: WEBEX_BOT_TOKEN
+#     room_id: "Y2lzY29zcGFyazovL3VzL1JPT00v..."
+#     min_severity: HIGH
+#     events: [block, drift, guardrail]
+#     enabled: true
 #   - url: "https://events.pagerduty.com/v2/enqueue"
 #     type: pagerduty
 #     secret_env: PAGERDUTY_ROUTING_KEY

--- a/policies/strict.yaml
+++ b/policies/strict.yaml
@@ -128,6 +128,20 @@ watch:
   rescan_enabled: true
   rescan_interval_min: 30
 
+# webhooks:
+#   - url: "https://hooks.slack.com/services/T00/B00/xxx"
+#     type: slack
+#     min_severity: HIGH
+#     events: [block, drift, guardrail]
+#     enabled: true
+#   - url: "https://events.pagerduty.com/v2/enqueue"
+#     type: pagerduty
+#     secret_env: PAGERDUTY_ROUTING_KEY
+#     min_severity: CRITICAL
+#     events: [block]
+#     enabled: true
+webhooks: []
+
 enforcement:
   max_enforcement_delay_seconds: 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ tui = ["textual>=0.50"]
 
 [dependency-groups]
 dev = [
-    "pytest==9.0.2",
+    "pytest==9.0.3",
     "pytest-cov==7.1.0",
     "ruff==0.15.7",
 ]

--- a/schemas/audit-event.json
+++ b/schemas/audit-event.json
@@ -6,7 +6,7 @@
   "properties": {
     "id": { "type": "string", "format": "uuid" },
     "timestamp": { "type": "string", "format": "date-time" },
-    "action": { "type": "string", "enum": ["init", "scan", "block", "allow", "quarantine", "restore", "deploy", "stop", "drift", "rescan", "rescan-start", "network-egress-blocked"] },
+    "action": { "type": "string", "enum": ["init", "scan", "block", "allow", "quarantine", "restore", "deploy", "stop", "drift", "rescan", "rescan-start", "network-egress-blocked", "guardrail-block"] },
     "target": { "type": "string" },
     "actor": { "type": "string", "default": "defenseclaw" },
     "details": { "type": "string" },

--- a/uv.lock
+++ b/uv.lock
@@ -745,7 +745,7 @@ provides-extras = ["tui"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = "==9.0.2" },
+    { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "ruff", specifier = "==0.15.7" },
 ]
@@ -2386,7 +2386,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2397,9 +2397,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


## Webhook Notifications for Enforcement Events

### Summary

Adds an outbound webhook notification system that pushes enforcement events (skill/plugin blocks, drift alerts, guardrail blocks) to external systems in real time. Supports Slack, PagerDuty, Webex, and generic HTTP endpoints with per-endpoint severity filtering, event-type filtering, and automatic retry with exponential backoff.

### Motivation

Before this PR, DefenseClaw enforcement events were only visible through the SQLite audit DB, the TUI dashboard, and Splunk HEC forwarding. There was no way to push real-time alerts to team collaboration tools (Slack, Webex) or incident management platforms (PagerDuty) without building custom integrations on top of the SIEM pipeline. This created a gap in operational workflows — security teams couldn't receive immediate, actionable notifications when a malicious skill was blocked or drift was detected.

This PR closes that gap by adding a lightweight, configurable webhook dispatcher that runs alongside the existing audit pipeline.

### What Changed

#### New Files

| File | Purpose |
|------|---------|
| `internal/gateway/webhook.go` | `WebhookDispatcher` — async dispatch engine with retry, severity/event filtering, and payload formatters for Slack (Block Kit), PagerDuty (Events API v2), Webex (Messages API with markdown), and generic JSON |
| `internal/gateway/webhook_test.go` | 9 unit tests — payload formatting (Slack, PagerDuty, Webex, generic), severity filtering matrix, event-type filtering, action categorization, nil dispatcher safety, disabled endpoint handling |
| `internal/gateway/webhook_e2e_test.go` | 11 E2E tests — full enforcement pipeline simulation, retry on transient failure, retry exhaustion, secret/auth header validation (generic, Slack, Webex Bearer), severity edge cases (25-combination matrix), Webex payload + multi-endpoint fan-out, enabled/disabled mixing, concurrent dispatch (50 goroutines), post-close safety |

#### Modified Files

| File | Change |
|------|--------|
| `internal/config/config.go` | Added `WebhookConfig` struct (with `RoomID` for Webex) and `Webhooks []WebhookConfig` field to top-level `Config`; `ResolvedSecret()` helper reads secret from env var |
| `internal/gateway/sidecar.go` | Initializes `WebhookDispatcher` on startup; passes it to watcher and guardrail proxy; dispatches `block` events from `sendEnforcementAlert`; drains dispatcher on shutdown |
| `internal/gateway/proxy.go` | Added `webhooks *WebhookDispatcher` field and `SetWebhookDispatcher` method; dispatches `guardrail-block` events from `recordTelemetry` when verdict is block |
| `internal/watcher/watcher.go` | Added `WebhookDispatcher` interface and `SetWebhookDispatcher` method to break import cycle between `gateway` and `watcher` packages |
| `internal/watcher/rescan.go` | Dispatches drift audit events to webhook dispatcher (if configured) after logging to audit store |
| `cli/defenseclaw/config.py` | Mirrored `WebhookConfig` dataclass in Python CLI; added `_merge_webhooks()` parser; wired into `Config.webhooks` field |
| `policies/default.yaml` | Added `webhooks: []` (disabled by default) |
| `policies/strict.yaml` | Added `webhooks: []` with commented-out Slack/Webex/PagerDuty examples |
| `policies/permissive.yaml` | Added `webhooks: []` |
| `schemas/audit-event.json` | Extended `action` enum with `"guardrail-block"` |
| `README.md` | Added Notifications section with webhook config example and channel type table |
| `docs/ARCHITECTURE.md` | Added webhook dispatch to Gateway responsibility table and data flow diagram |
| `docs/CONFIG_FILES.md` | Added Webhook Notification Config section with full field reference |

### Architecture

```
Enforcement Event Sources                  WebhookDispatcher
                                           (internal/gateway/webhook.go)
┌─────────────────────┐                    ┌──────────────────────────────┐
│ Watcher             │──── block ────────▶│                              │
│ (sidecar.go)        │                    │  For each configured endpoint│
├─────────────────────┤                    │    ├─ severity ≥ threshold?  │
│ Rescan Loop         │──── drift ────────▶│    ├─ event category match?  │
│ (rescan.go)         │                    │    └─ async POST with retry  │
├─────────────────────┤                    │                              │
│ Guardrail Proxy     │── guardrail ──────▶│  Payload formatters:         │
│ (proxy.go)          │   block            │    ├─ Slack (Block Kit)      │
└─────────────────────┘                    │    ├─ PagerDuty (Events v2)  │
                                           │    ├─ Webex (Messages API)   │
                                           │    └─ Generic (flat JSON)    │
                                           └──┬──────┬──────┬───────┬────┘
                                              │      │      │       │
                                              ▼      ▼      ▼       ▼
                                           Slack  PagerDuty Webex  HTTP
                                           webhook Events   Room  endpoint
```

### Webhook Channel Types

| Type | Payload Format | Auth Mechanism | Status Code |
|------|---------------|----------------|-------------|
| `slack` | Block Kit attachments with severity-color-coded sidebar, header, section fields, context with event ID/timestamp | URL token embedded in Slack incoming webhook URL | 200 |
| `pagerduty` | Events API v2 `trigger` with `dedup_key` (target+action), severity mapping (CRITICAL→critical, HIGH→error, MEDIUM→warning), `custom_details` | `routing_key` from `secret_env` | 202 |
| `webex` | Markdown message via Webex Messages API (`POST /v1/messages`) with severity icon, structured fields, and `roomId` | Bot access token as `Authorization: Bearer` from `secret_env` | 200 |
| `generic` | Flat JSON envelope (`webhook_type`, `defenseclaw_version`, nested `event` object with all audit fields) | `X-Webhook-Secret` header from `secret_env` | 200 |

### Severity and Event Filtering

Each webhook endpoint can configure:

- **`min_severity`** — only events at or above this rank are dispatched (CRITICAL=5, HIGH=4, MEDIUM=3, LOW=2, INFO=1)
- **`events`** — list of event categories to include; empty means all. The `categorizeAction()` function maps audit actions to categories:

| Audit Action | Category | Example Source |
|-------------|----------|----------------|
| `block`, `quarantine`, `disable` | `block` | Watcher blocks a malicious skill |
| `drift`, `rescan` | `drift` | Periodic rescan detects mutation |
| `guardrail-block`, `guardrail-*` | `guardrail` | Proxy blocks a prompt injection |
| `scan` | `scan` | Routine scan completes |

### Retry Behavior

- Up to 3 retries (4 total attempts) with exponential backoff (2s, 4s, 6s)
- Retries on HTTP 5xx responses and network errors
- Non-retryable: 4xx responses, payload formatting errors
- In-flight retries complete before `Close()` returns (graceful shutdown)
- Events dispatched after `Close()` are silently dropped

### Configuration Example

```yaml
webhooks:
  - url: "https://hooks.slack.com/services/T00/B00/xxx"
    type: slack
    min_severity: HIGH
    events: [block, drift, guardrail]
    enabled: true

  - url: "https://webexapis.com/v1/messages"
    type: webex
    secret_env: WEBEX_BOT_TOKEN
    room_id: "Y2lzY29zcGFyazovL3VzL1JPT00v..."
    min_severity: HIGH
    events: [block, drift, guardrail]
    enabled: true

  - url: "https://events.pagerduty.com/v2/enqueue"
    type: pagerduty
    secret_env: PAGERDUTY_ROUTING_KEY
    min_severity: CRITICAL
    events: [block]
    enabled: true

  - url: "https://security.internal.example.com/webhook"
    type: generic
    secret_env: WEBHOOK_SECRET
    min_severity: INFO
    events: []  # all events
    timeout_seconds: 5
    enabled: true
```

### Design Decisions

1. **Interface in watcher package** — `WebhookDispatcher` is defined as an interface in `internal/watcher/watcher.go` to break the import cycle between `gateway` and `watcher` packages. The concrete struct lives in `gateway`.

2. **Modeled after SplunkForwarder** — The dispatcher follows the same async fire-and-forget pattern as the existing Splunk HEC forwarder, with `wg.Add/Done` for graceful shutdown.

3. **Retry backoff via struct field** — `retryBackoff` is a field (not just a constant) so E2E tests can zero it out for sub-second test execution without `time.Sleep` waits.

4. **No new dependencies** — Uses only stdlib `net/http`, `encoding/json`, and `sync`. No external webhook libraries.

5. **Disabled by default** — All policy presets ship with `webhooks: []`. Operators must explicitly configure and enable endpoints.

### Test Plan

- [x] 9 unit tests pass (payload formatting for Slack, PagerDuty, Webex, generic; severity filtering, event-type filtering, action categorization, nil safety, disabled endpoints)
- [x] 11 E2E tests pass:
  - [x] Full enforcement pipeline: 4 events (block, drift, guardrail-block, scan) → 3 endpoints (Slack, PagerDuty, generic) with correct routing, payload structure, and deep field validation
  - [x] Retry on transient failure: server returns 503 twice, then 200 — verifies 3 attempts
  - [x] Retry exhaustion: server always returns 500 — verifies exactly `maxRetries+1` attempts without hang
  - [x] Secret header: generic webhook receives `X-Webhook-Secret`, Slack does not
  - [x] Webex payload + auth: verifies `Authorization: Bearer`, `roomId`, markdown content, no `X-Webhook-Secret`
  - [x] Webex in multi-endpoint pipeline: Webex participates correctly alongside Slack and generic in fan-out with proper filtering
  - [x] Severity edge cases: 25-combination matrix (5 thresholds x 5 event severities)
  - [x] Mixed enabled/disabled: disabled and empty-URL endpoints skipped
  - [x] Concurrent dispatch: 50 goroutines dispatch simultaneously — no races, no lost payloads
  - [x] Post-close safety: events after `Close()` silently dropped
- [x] Full `go test ./...` passes (22 packages, zero regressions)
- [x] `go vet ./...` clean
- [x] No linter errors on changed files
- [x] Documentation updated: README.md, ARCHITECTURE.md, CONFIG_FILES.md

<img width="1512" height="982" alt="Screenshot 2026-04-13 at 3 46 59 PM" src="https://github.com/user-attachments/assets/aef55c9c-0114-47d0-b27c-3bb2de4986aa" />

<img width="1054" height="528" alt="Screenshot 2026-04-13 at 4 23 17 PM" src="https://github.com/user-attachments/assets/caf5d314-5d48-4e1b-9bcd-32e480bc5ff1" />

<img width="1512" height="982" alt="Screenshot 2026-04-13 at 4 30 45 PM" src="https://github.com/user-attachments/assets/a8cf5a7f-380b-4205-a4b0-affae46ee719" />

<img width="1512" height="982" alt="Screenshot 2026-04-13 at 4 51 20 PM" src="https://github.com/user-attachments/assets/acde1d58-8f68-4853-bea6-fe883dc456d2" />

