### PR TITLE
fix: resolve issues #92, #96, #98, #99 and add health watchdog

### DIFF
--- a/cli/defenseclaw/commands/cmd_status.py
+++ b/cli/defenseclaw/commands/cmd_status.py
@@ -92,7 +92,7 @@ def status(app: AppContext) -> None:
     click.echo()
     from defenseclaw.gateway import OrchestratorClient
     bind = "127.0.0.1"
-    if cfg.openshell.is_standalone() and cfg.guardrail.host not in ("", "localhost"):
+    if cfg.openshell.is_standalone() and cfg.guardrail.host not in ("", "localhost", "127.0.0.1"):
         bind = cfg.guardrail.host
     client = OrchestratorClient(
         host=bind,

--- a/cli/defenseclaw/commands/cmd_upgrade.py
+++ b/cli/defenseclaw/commands/cmd_upgrade.py
@@ -32,6 +32,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 
 import click
 import requests
@@ -46,17 +47,23 @@ GITHUB_DL = f"https://github.com/{GITHUB_REPO}/releases/download"
 @click.command("upgrade")
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompts")
 @click.option("--version", "target_version", default=None, help="Upgrade to a specific release version (e.g. 0.3.1)")
+@click.option("--health-timeout", default=60, type=int, help="Seconds to wait for gateway health after restart")
 @pass_ctx
 def upgrade(
     app: AppContext,
     yes: bool,
     target_version: str | None,
+    health_timeout: int,
 ) -> None:
     """Upgrade DefenseClaw to the latest version.
 
     Downloads pre-built release artifacts (gateway binary, Python CLI wheel)
     from GitHub Releases, runs version-specific migrations, and restarts
     services. Your existing configuration is preserved.
+
+    The upgrade is non-destructive: artifacts are downloaded and verified
+    before the gateway is stopped, so a failed download never disrupts a
+    running gateway.
     """
     from defenseclaw import __version__ as current_version
 
@@ -77,16 +84,39 @@ def upgrade(
     click.echo(f"  ✓ Installed version: {current_version}")
     click.echo(f"  ✓ Target version:    {target_version}")
 
+    # ── Early exit if already at latest ──────────────────────────────────────
+
     if target_version == current_version and not yes:
         click.echo()
-        click.echo("  Already at the latest version.")
-        if not click.confirm("  Re-apply upgrade anyway?", default=False):
-            return
+        click.echo("  Already at the latest version. Nothing to do.")
+        return
 
     # ── Platform detection ───────────────────────────────────────────────────
 
     os_name, arch = _detect_platform()
     click.echo(f"  ✓ Platform: {os_name}/{arch}")
+
+    # ── Pre-flight: verify artifacts exist ───────────────────────────────────
+
+    click.echo()
+    click.echo("  ── Pre-flight Check ─────────────────────────────────────")
+    click.echo()
+
+    _preflight_check(target_version, os_name, arch)
+
+    # ── Download artifacts to temp (gateway still running) ───────────────────
+
+    click.echo()
+    click.echo("  ── Downloading Release Artifacts ────────────────────────")
+    click.echo()
+
+    staging_dir = tempfile.mkdtemp(prefix="defenseclaw-upgrade-")
+    try:
+        gw_binary_path = _download_gateway(target_version, os_name, arch, staging_dir)
+        whl_path = _download_wheel(target_version, staging_dir)
+    except SystemExit:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        raise
 
     # ── Confirm ──────────────────────────────────────────────────────────────
 
@@ -94,13 +124,13 @@ def upgrade(
         click.echo()
         click.echo("  This will:")
         click.echo("    1. Back up ~/.defenseclaw/ and ~/.openclaw/openclaw.json")
-        click.echo("    2. Download and replace gateway binary and Python CLI")
-        click.echo(f"       Source: github.com/{GITHUB_REPO}/releases/tag/{target_version}")
+        click.echo("    2. Stop the gateway, replace binaries from downloaded artifacts")
         click.echo("    3. Run version-specific migrations")
-        click.echo("    4. Restart services")
+        click.echo("    4. Restart services and verify health")
         click.echo()
         if not click.confirm("  Proceed?", default=False):
             click.echo("  Aborted.")
+            shutil.rmtree(staging_dir, ignore_errors=True)
             return
 
     # ── Create backup ────────────────────────────────────────────────────────
@@ -112,7 +142,7 @@ def upgrade(
     backup_dir = _create_backup(app.cfg)
     click.echo(f"  ✓ Backup saved to: {backup_dir}")
 
-    # ── Stop services ────────────────────────────────────────────────────────
+    # ── Stop gateway, install, migrate, restart ──────────────────────────────
 
     click.echo()
     click.echo("  ── Stopping Services ────────────────────────────────────")
@@ -120,17 +150,13 @@ def upgrade(
 
     _run_silent(["defenseclaw-gateway", "stop"], "Gateway stopped", "Gateway was not running")
 
-    # ── Download, migrate, and restart ────────────────────────────────────────
-    # Wrapped in try/finally so the gateway is always restarted even if the
-    # download or migration step fails (e.g. unreleased version → HTTP 404).
-
     try:
         click.echo()
-        click.echo("  ── Downloading Release Artifacts ────────────────────────")
+        click.echo("  ── Installing Artifacts ─────────────────────────────────")
         click.echo()
 
-        _replace_gateway_from_release(target_version, os_name, arch)
-        _replace_python_cli_from_release(target_version)
+        _install_gateway(gw_binary_path, os_name)
+        _install_wheel(whl_path)
 
         click.echo()
         click.echo("  ── Running Migrations ───────────────────────────────────")
@@ -148,6 +174,9 @@ def upgrade(
             click.echo(f"  ✓ Applied {count} migration(s)")
 
     finally:
+        # Always clean up staging dir first, even if restart fails.
+        shutil.rmtree(staging_dir, ignore_errors=True)
+
         click.echo()
         click.echo("  ── Starting Services ────────────────────────────────────")
         click.echo()
@@ -164,6 +193,12 @@ def upgrade(
             click.echo("  ⚠ Could not restart OpenClaw gateway automatically")
             click.echo("    Run manually: openclaw gateway restart")
 
+        # Health verification
+        click.echo()
+        click.echo("  ── Verifying Gateway Health ─────────────────────────────")
+        click.echo()
+        _poll_health(app.cfg, health_timeout)
+
     # ── Done ─────────────────────────────────────────────────────────────────
 
     click.echo()
@@ -171,8 +206,6 @@ def upgrade(
     click.echo()
     click.echo(f"  ✓ DefenseClaw upgraded: {current_version} → {target_version}")
     click.echo(f"  Backup: {backup_dir}")
-    click.echo()
-    click.echo("  Run 'defenseclaw status' to verify all components are healthy.")
     click.echo()
 
     if app.logger:
@@ -225,41 +258,67 @@ def _detect_platform() -> tuple[str, str]:
     return system, arch
 
 
-def _replace_gateway_from_release(version: str, os_name: str, arch: str) -> None:
-    """Download and install the gateway binary from a GitHub release."""
-    install_dir = os.path.expanduser("~/.local/bin")
-    os.makedirs(install_dir, exist_ok=True)
+def _preflight_check(version: str, os_name: str, arch: str) -> None:
+    """Verify release artifacts exist on GitHub before touching anything."""
+    tarball = f"defenseclaw_{version}_{os_name}_{arch}.tar.gz"
+    whl_name = f"defenseclaw-{version}-py3-none-any.whl"
+    urls = [
+        f"{GITHUB_DL}/{version}/{tarball}",
+        f"{GITHUB_DL}/{version}/{whl_name}",
+    ]
+    for url in urls:
+        try:
+            resp = requests.head(url, timeout=15, allow_redirects=True)
+            if resp.status_code >= 400:
+                click.echo(f"  ✗ Artifact not found ({resp.status_code}): {url}", err=True)
+                click.echo(f"    Version {version} may not exist or is missing platform artifacts.", err=True)
+                raise SystemExit(1)
+        except requests.RequestException as exc:
+            click.echo(f"  ✗ Could not reach GitHub: {exc}", err=True)
+            raise SystemExit(1)
+    click.echo("  ✓ Release artifacts verified")
 
+
+def _download_gateway(version: str, os_name: str, arch: str, staging_dir: str) -> str:
+    """Download the gateway tarball to staging_dir and extract. Returns path to binary."""
     tarball = f"defenseclaw_{version}_{os_name}_{arch}.tar.gz"
     url = f"{GITHUB_DL}/{version}/{tarball}"
 
     click.echo(f"  → Downloading gateway binary ({os_name}/{arch}) ...")
-
-    with tempfile.TemporaryDirectory() as tmp:
-        dest = os.path.join(tmp, tarball)
-        _download_file(url, dest)
-
-        subprocess.run(
-            ["tar", "-xzf", dest, "-C", tmp],
-            check=True, capture_output=True,
-        )
-
-        src = os.path.join(tmp, "defenseclaw")
-        target = os.path.join(install_dir, "defenseclaw-gateway")
-        shutil.copy2(src, target)
-        os.chmod(target, 0o755)
-
-        if os_name == "darwin":
-            subprocess.run(
-                ["codesign", "-f", "-s", "-", target],
-                capture_output=True, check=False,
-            )
-
-    click.echo("  ✓ Gateway binary replaced")
+    dest = os.path.join(staging_dir, tarball)
+    _download_file(url, dest)
+    subprocess.run(["tar", "-xzf", dest, "-C", staging_dir], check=True, capture_output=True)
+    binary = os.path.join(staging_dir, "defenseclaw")
+    click.echo("  ✓ Gateway binary downloaded")
+    return binary
 
 
-def _replace_python_cli_from_release(version: str) -> None:
-    """Download and install the Python CLI wheel from a GitHub release."""
+def _download_wheel(version: str, staging_dir: str) -> str:
+    """Download the Python CLI wheel to staging_dir. Returns path to wheel."""
+    whl_name = f"defenseclaw-{version}-py3-none-any.whl"
+    url = f"{GITHUB_DL}/{version}/{whl_name}"
+
+    click.echo("  → Downloading Python CLI wheel ...")
+    dest = os.path.join(staging_dir, whl_name)
+    _download_file(url, dest)
+    click.echo("  ✓ Python CLI wheel downloaded")
+    return dest
+
+
+def _install_gateway(binary_path: str, os_name: str) -> None:
+    """Install a pre-downloaded gateway binary."""
+    install_dir = os.path.expanduser("~/.local/bin")
+    os.makedirs(install_dir, exist_ok=True)
+    target = os.path.join(install_dir, "defenseclaw-gateway")
+    shutil.copy2(binary_path, target)
+    os.chmod(target, 0o755)
+    if os_name == "darwin":
+        subprocess.run(["codesign", "-f", "-s", "-", target], capture_output=True, check=False)
+    click.echo("  ✓ Gateway binary installed")
+
+
+def _install_wheel(whl_path: str) -> None:
+    """Install a pre-downloaded Python CLI wheel."""
     uv = shutil.which("uv")
     if not uv:
         click.echo("  ✗ uv not found on PATH — cannot update Python CLI", err=True)
@@ -273,19 +332,7 @@ def _replace_python_cli_from_release(version: str) -> None:
         click.echo("  → Creating venv ...")
         subprocess.run([uv, "venv", venv, "--python", "3.12"], check=True)
 
-    whl_name = f"defenseclaw-{version}-py3-none-any.whl"
-    url = f"{GITHUB_DL}/{version}/{whl_name}"
-
-    click.echo("  → Downloading Python CLI wheel ...")
-
-    with tempfile.TemporaryDirectory() as tmp:
-        dest = os.path.join(tmp, whl_name)
-        _download_file(url, dest)
-
-        subprocess.run(
-            [uv, "pip", "install", "--python", python, "--quiet", dest],
-            check=True,
-        )
+    subprocess.run([uv, "pip", "install", "--python", python, "--quiet", whl_path], check=True)
 
     install_dir = os.path.expanduser("~/.local/bin")
     os.makedirs(install_dir, exist_ok=True)
@@ -295,8 +342,56 @@ def _replace_python_cli_from_release(version: str) -> None:
         if os.path.islink(symlink) or os.path.exists(symlink):
             os.remove(symlink)
         os.symlink(venv_bin, symlink)
+    click.echo("  ✓ Python CLI installed")
 
-    click.echo("  ✓ Python CLI replaced")
+
+def _poll_health(cfg, timeout_seconds: int = 60) -> None:
+    """Poll the sidecar health endpoint until healthy or timeout."""
+    from defenseclaw.gateway import OrchestratorClient
+
+    bind = _api_bind_host(cfg)
+    api_port = 18970
+    token = ""
+    if cfg:
+        api_port = cfg.gateway.api_port
+        token = cfg.gateway.resolved_token()
+
+    client = OrchestratorClient(host=bind, port=api_port, token=token)
+
+    deadline = time.monotonic() + timeout_seconds
+    last_state = "starting"
+    click.echo(f"  → Waiting for gateway to become healthy (timeout {timeout_seconds}s) ...")
+
+    while time.monotonic() < deadline:
+        try:
+            snap = client.health()
+            if snap and isinstance(snap, dict):
+                gw_state = snap.get("gateway", {}).get("state", "unknown")
+                if gw_state != last_state:
+                    click.echo(f"    gateway: {gw_state}")
+                    last_state = gw_state
+                if gw_state == "running":
+                    click.secho("  ✓ Gateway is healthy", fg="green")
+                    return
+        except (OSError, ValueError):
+            pass
+        time.sleep(2)
+
+    click.echo(f"  ⚠ Gateway did not become healthy within {timeout_seconds}s", err=True)
+    click.echo("    Check logs: ~/.defenseclaw/gateway.log")
+    click.echo("    Run:  defenseclaw-gateway status")
+
+
+def _api_bind_host(cfg) -> str:
+    """Resolve the API bind address, mirroring sidecar.runAPI in Go."""
+    if not cfg:
+        return "127.0.0.1"
+    api_bind = getattr(cfg.gateway, "api_bind", "")
+    if api_bind:
+        return api_bind
+    if cfg.openshell.is_standalone() and cfg.guardrail.host not in ("", "localhost", "127.0.0.1"):
+        return cfg.guardrail.host
+    return "127.0.0.1"
 
 
 def _download_file(url: str, dest: str) -> None:

--- a/cli/defenseclaw/config.py
+++ b/cli/defenseclaw/config.py
@@ -407,6 +407,7 @@ class GatewayWatcherConfig:
 class GatewayConfig:
     host: str = "127.0.0.1"
     port: int = 18789
+    api_bind: str = ""
     token: str = ""
     token_env: str = ""
     device_key_file: str = ""
@@ -1119,6 +1120,7 @@ def load() -> Config:
         gateway=GatewayConfig(
             host=gw_raw.get("host", "127.0.0.1"),
             port=gw_raw.get("port", 18789),
+            api_bind=gw_raw.get("api_bind", ""),
             token=gw_raw.get("token", ""),
             token_env=gw_raw.get("token_env", ""),
             device_key_file=gw_raw.get("device_key_file", os.path.join(data_dir, "device.key")),

--- a/cli/defenseclaw/config.py
+++ b/cli/defenseclaw/config.py
@@ -544,6 +544,7 @@ class WebhookConfig:
     min_severity: str = "HIGH"
     events: list[str] = field(default_factory=list)
     timeout_seconds: int = 10
+    cooldown_seconds: int = 300
     enabled: bool = False
 
     def resolved_secret(self) -> str:
@@ -950,6 +951,7 @@ def _merge_webhooks(raw: list[dict[str, Any]] | None) -> list[WebhookConfig]:
             min_severity=entry.get("min_severity", "HIGH"),
             events=entry.get("events", []),
             timeout_seconds=entry.get("timeout_seconds", 10),
+            cooldown_seconds=entry.get("cooldown_seconds", 300),
             enabled=entry.get("enabled", False),
         ))
     return webhooks

--- a/cli/tests/test_cmd_upgrade.py
+++ b/cli/tests/test_cmd_upgrade.py
@@ -1,0 +1,21 @@
+import unittest
+
+from defenseclaw.commands.cmd_upgrade import _api_bind_host
+from defenseclaw.config import Config, GatewayConfig, GuardrailConfig, OpenShellConfig
+
+
+class TestUpgradeAPIBindHost(unittest.TestCase):
+    def test_defaults_to_loopback(self):
+        cfg = Config()
+        self.assertEqual(_api_bind_host(cfg), "127.0.0.1")
+
+    def test_prefers_gateway_api_bind(self):
+        cfg = Config(gateway=GatewayConfig(api_bind="10.0.0.8"))
+        self.assertEqual(_api_bind_host(cfg), "10.0.0.8")
+
+    def test_uses_guardrail_host_in_standalone_mode(self):
+        cfg = Config(
+            openshell=OpenShellConfig(mode="standalone"),
+            guardrail=GuardrailConfig(host="192.168.65.2"),
+        )
+        self.assertEqual(_api_bind_host(cfg), "192.168.65.2")

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -911,6 +911,7 @@ class TestWebhookConfig(unittest.TestCase):
         self.assertEqual(wh.type, "generic")
         self.assertEqual(wh.min_severity, "HIGH")
         self.assertEqual(wh.timeout_seconds, 10)
+        self.assertEqual(wh.cooldown_seconds, 300)
         self.assertFalse(wh.enabled)
 
     def test_resolved_secret_from_env(self):

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -238,6 +238,7 @@ class TestDefaultConfig(unittest.TestCase):
         self.assertEqual(cfg.scanners.skill_scanner.binary, "skill-scanner")
         self.assertEqual(cfg.scanners.mcp_scanner.binary, "mcp-scanner")
         self.assertEqual(cfg.gateway.port, 18789)
+        self.assertEqual(cfg.gateway.api_bind, "")
         self.assertEqual(cfg.gateway.api_port, 18970)
         self.assertTrue(cfg.gateway.watcher.enabled)
         self.assertTrue(cfg.gateway.watcher.skill.enabled)
@@ -282,6 +283,7 @@ class TestConfigLoadSave(unittest.TestCase):
                 plugin_dir=os.path.join(tmpdir, "plugins"),
                 policy_dir=os.path.join(tmpdir, "policies"),
                 environment="macos",
+                gateway=GatewayConfig(api_bind="10.0.0.8"),
             )
             cfg.save()
 
@@ -293,6 +295,7 @@ class TestConfigLoadSave(unittest.TestCase):
                 raw = yaml.safe_load(f)
             self.assertEqual(raw["environment"], "macos")
             self.assertEqual(raw["data_dir"], tmpdir)
+            self.assertEqual(raw["gateway"]["api_bind"], "10.0.0.8")
 
     def test_save_and_reload_preserves_watch_rescan_fields(self):
         import yaml

--- a/extensions/defenseclaw/src/__tests__/health-monitor.test.ts
+++ b/extensions/defenseclaw/src/__tests__/health-monitor.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HealthMonitor } from "../health-monitor.js";
+
+const statusUrl = "http://127.0.0.1:9999/defenseclaw/status";
+
+/** Invokes the private health check (async). */
+function triggerCheck(m: HealthMonitor): Promise<void> {
+  return (m as unknown as { check: () => Promise<void> }).check();
+}
+
+/** Create a Response that mirrors the real /status JSON. */
+function healthyResponse(): Response {
+  return new Response(JSON.stringify({ health: { gateway: { state: "running" } } }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function degradedResponse(): Response {
+  return new Response(JSON.stringify({ health: { gateway: { state: "starting" } } }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("HealthMonitor", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.advanceTimersByTime(10_000);
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("starts as protected", () => {
+    const m = new HealthMonitor({ statusUrl });
+    expect(m.isUnprotected).toBe(false);
+  });
+
+  it("getWarningMessage returns null when healthy", () => {
+    const m = new HealthMonitor({ statusUrl });
+    expect(m.getWarningMessage()).toBeNull();
+  });
+
+  it("marks unprotected when fetch fails", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("network"));
+    const m = new HealthMonitor({ statusUrl });
+    await triggerCheck(m);
+    expect(m.isUnprotected).toBe(true);
+  });
+
+  it("marks unprotected when status is non-200", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("", { status: 500 }));
+    const m = new HealthMonitor({ statusUrl });
+    await triggerCheck(m);
+    expect(m.isUnprotected).toBe(true);
+  });
+
+  it("restores protected when fetch succeeds after failure", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockResolvedValueOnce(healthyResponse());
+    globalThis.fetch = fetchMock;
+    const m = new HealthMonitor({ statusUrl });
+    await triggerCheck(m);
+    expect(m.isUnprotected).toBe(true);
+    await triggerCheck(m);
+    expect(m.isUnprotected).toBe(false);
+  });
+
+  it("getWarningMessage returns message when unprotected", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("down"));
+    const m = new HealthMonitor({ statusUrl });
+    await triggerCheck(m);
+    const msg = m.getWarningMessage();
+    expect(msg).not.toBeNull();
+    expect(msg).toContain("DEFENSECLAW WARNING");
+  });
+
+  it("marks unprotected when gateway state is not running", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockResolvedValue(degradedResponse());
+    const m = new HealthMonitor({ statusUrl });
+    await triggerCheck(m);
+    expect(m.isUnprotected).toBe(true);
+  });
+
+  it("start and stop lifecycle", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(healthyResponse());
+    globalThis.fetch = fetchMock;
+    const m = new HealthMonitor({ statusUrl, pollIntervalMs: 1000 });
+    expect(() => m.start()).not.toThrow();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1000);
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    expect(() => m.stop()).not.toThrow();
+
+    vi.advanceTimersByTime(1000);
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not log duplicate warnings", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("fail"));
+    const m = new HealthMonitor({ statusUrl });
+    await triggerCheck(m);
+    await triggerCheck(m);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes token in headers when provided", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(healthyResponse());
+    globalThis.fetch = fetchMock;
+    const m = new HealthMonitor({ statusUrl, token: "secret-token" });
+    await triggerCheck(m);
+    expect(fetchMock).toHaveBeenCalledWith(
+      statusUrl,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer secret-token",
+        }),
+      }),
+    );
+  });
+});

--- a/extensions/defenseclaw/src/fetch-interceptor.ts
+++ b/extensions/defenseclaw/src/fetch-interceptor.ts
@@ -226,7 +226,15 @@ export function createFetchInterceptor(guardrailPort: number) {
         `[defenseclaw] intercepted LLM call → ${urlStr} proxied via ${proxyBase}`,
       );
 
-      return originalFetch!(proxied, newInit);
+      const response = await originalFetch!(proxied, newInit);
+
+      if (response.headers.get("x-defenseclaw-blocked") === "true") {
+        console.warn(
+          "[defenseclaw] REQUEST BLOCKED by guardrail policy",
+        );
+      }
+
+      return response;
     };
 
     // Also patch https.request so axios, undici, and other non-fetch HTTP

--- a/extensions/defenseclaw/src/health-monitor.ts
+++ b/extensions/defenseclaw/src/health-monitor.ts
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Health monitor that periodically checks the DefenseClaw sidecar and
+ * exposes an `isUnprotected` flag for the fetch interceptor to query.
+ *
+ * The monitor does NOT block LLM calls — it only warns.
+ */
+
+const POLL_INTERVAL_MS = 60_000;
+
+export interface HealthMonitorOptions {
+  statusUrl: string;
+  token?: string;
+  pollIntervalMs?: number;
+}
+
+export class HealthMonitor {
+  private readonly statusUrl: string;
+  private readonly token: string;
+  private readonly pollIntervalMs: number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private _unprotected = false;
+  private _wasUnprotected = false;
+
+  constructor(opts: HealthMonitorOptions) {
+    this.statusUrl = opts.statusUrl;
+    this.token = opts.token ?? "";
+    this.pollIntervalMs = opts.pollIntervalMs ?? POLL_INTERVAL_MS;
+  }
+
+  get isUnprotected(): boolean {
+    return this._unprotected;
+  }
+
+  start(): void {
+    if (this.timer) return;
+
+    // Run an initial check immediately.
+    void this.check();
+
+    this.timer = setInterval(() => void this.check(), this.pollIntervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private async check(): Promise<void> {
+    try {
+      const headers: Record<string, string> = {};
+      if (this.token) {
+        headers["Authorization"] = `Bearer ${this.token}`;
+      }
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 5_000);
+      const resp = await fetch(this.statusUrl, {
+        signal: controller.signal,
+        headers,
+      });
+      clearTimeout(timeout);
+
+      if (resp.ok) {
+        const body = await resp.json();
+        const gwState = body?.health?.gateway?.state ?? "";
+        if (gwState === "running") {
+          if (this._unprotected) {
+            console.log("[defenseclaw] Gateway is back online. Protection restored.");
+          }
+          this._unprotected = false;
+          this._wasUnprotected = false;
+        } else {
+          this.markUnprotected();
+        }
+      } else {
+        this.markUnprotected();
+      }
+    } catch {
+      this.markUnprotected();
+    }
+  }
+
+  private markUnprotected(): void {
+    this._unprotected = true;
+    if (!this._wasUnprotected) {
+      this._wasUnprotected = true;
+      console.warn(
+        "[defenseclaw] WARNING: The DefenseClaw security gateway is not running. " +
+          "Your prompts and responses are NOT being scanned for security threats. " +
+          "Run 'defenseclaw-gateway start' to restore protection.",
+      );
+    }
+  }
+
+  /**
+   * Returns a warning message if the sidecar is unreachable, or null if healthy.
+   * The fetch interceptor can prepend this to LLM requests as a system message.
+   */
+  getWarningMessage(): string | null {
+    if (!this._unprotected) return null;
+    return (
+      "[DEFENSECLAW WARNING] The DefenseClaw security gateway is not running. " +
+      "Your prompts and responses are NOT being scanned for security threats. " +
+      "Run 'defenseclaw-gateway start' to restore protection."
+    );
+  }
+}

--- a/extensions/defenseclaw/src/index.ts
+++ b/extensions/defenseclaw/src/index.ts
@@ -46,6 +46,7 @@ import type {
 import { compareSeverity, maxSeverity } from "./types.js";
 import { loadSidecarConfig } from "./sidecar-config.js";
 import { createFetchInterceptor } from "./fetch-interceptor.js";
+import { HealthMonitor } from "./health-monitor.js";
 
 function formatFindings(findings: Finding[], limit = 15): string[] {
   const lines: string[] = [];
@@ -75,6 +76,13 @@ export default function (api: PluginApi) {
   const SIDECAR_TOKEN = sidecarConfig.token;
   const INSPECT_TIMEOUT_MS = 2_000;
 
+  // ─── Health monitor ───
+  // Polls the sidecar /status endpoint and warns when protection is down.
+  const healthMonitor = new HealthMonitor({
+    statusUrl: `${SIDECAR_API}/status`,
+    token: SIDECAR_TOKEN,
+  });
+
   // ─── LLM fetch interceptor ───
   // Patches globalThis.fetch to redirect all outbound LLM API calls through
   // the guardrail proxy regardless of which provider/model OpenClaw uses.
@@ -83,7 +91,13 @@ export default function (api: PluginApi) {
     id: "llm-interceptor",
     start: async () => {
       interceptor.start();
-      return { stop: () => interceptor.stop() };
+      healthMonitor.start();
+      return {
+        stop: () => {
+          interceptor.stop();
+          healthMonitor.stop();
+        },
+      };
     },
   });
 

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -186,6 +186,32 @@ func (l *Logger) LogActionWithEnforcement(action, target, details string, enforc
 	return nil
 }
 
+// LogEvent persists a pre-built event through the full audit pipeline
+// (SQLite + Splunk HEC + OTel). Use this when the caller needs to control
+// severity or other fields that LogAction hardcodes.
+func (l *Logger) LogEvent(event Event) error {
+	if event.ID == "" {
+		event.ID = uuid.New().String()
+	}
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now().UTC()
+	}
+	if event.RunID == "" {
+		event.RunID = currentRunID()
+	}
+	if err := l.store.LogEvent(event); err != nil {
+		if l.otel != nil {
+			l.otel.RecordAuditDBError(context.Background(), "insert_event")
+		}
+		return err
+	}
+	if l.otel != nil {
+		l.otel.RecordAuditEvent(context.Background(), event.Action, event.Severity)
+	}
+	l.forwardToSplunk(event)
+	return nil
+}
+
 func (l *Logger) forwardToSplunk(e Event) {
 	if l.splunk == nil {
 		return

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -240,3 +240,95 @@ func TestLoggerSplunkFlushesWatchStartImmediately(t *testing.T) {
 		t.Fatal("expected watch-start to flush to Splunk promptly")
 	}
 }
+
+func TestLoggerLogEventPreservesSeverity(t *testing.T) {
+	store, err := NewStore(filepath.Join(t.TempDir(), "audit.db"))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+	if err := store.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	logger := NewLogger(store)
+	evt := Event{
+		Action:   "drift",
+		Target:   "/path/to/skill",
+		Actor:    "defenseclaw-rescan",
+		Details:  "hash changed",
+		Severity: "HIGH",
+	}
+	if err := logger.LogEvent(evt); err != nil {
+		t.Fatalf("LogEvent: %v", err)
+	}
+
+	events, err := store.ListEvents(10)
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if got := events[0].Severity; got != "HIGH" {
+		t.Fatalf("Severity = %q, want HIGH", got)
+	}
+	if events[0].ID == "" {
+		t.Fatal("expected ID to be auto-filled")
+	}
+}
+
+func TestLoggerLogEventSplunkForwarding(t *testing.T) {
+	store, err := NewStore(filepath.Join(t.TempDir(), "audit.db"))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+	if err := store.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	var payload []byte
+	forwarder := testSplunkForwarder(t, func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		body, _ := io.ReadAll(r.Body)
+		payload = append([]byte(nil), body...)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	logger := NewLogger(store)
+	logger.SetSplunkForwarder(forwarder)
+
+	evt := Event{
+		Action:   "drift",
+		Target:   "/path/to/skill",
+		Actor:    "defenseclaw-rescan",
+		Details:  "new finding",
+		Severity: "CRITICAL",
+	}
+	if err := logger.LogEvent(evt); err != nil {
+		t.Fatalf("LogEvent: %v", err)
+	}
+	logger.Close()
+
+	if len(bytes.TrimSpace(payload)) == 0 {
+		t.Fatal("expected drift event to be forwarded to Splunk")
+	}
+
+	var env struct {
+		Event struct {
+			Action   string `json:"action"`
+			Severity string `json:"severity"`
+		} `json:"event"`
+	}
+	lines := bytes.Split(bytes.TrimSpace(payload), []byte{'\n'})
+	if err := json.Unmarshal(lines[0], &env); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if env.Event.Action != "drift" {
+		t.Fatalf("action = %q, want drift", env.Event.Action)
+	}
+	if env.Event.Severity != "CRITICAL" {
+		t.Fatalf("severity = %q, want CRITICAL", env.Event.Severity)
+	}
+}

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -105,180 +105,249 @@ func NewStore(dbPath string) (*Store, error) {
 	return &Store{db: db}, nil
 }
 
+// ---------------------------------------------------------------------------
+// Schema migration framework
+// ---------------------------------------------------------------------------
+
+// dbExecer is satisfied by both *sql.DB and *sql.Tx so migrations can run
+// inside a transaction.
+type dbExecer interface {
+	Exec(query string, args ...any) (sql.Result, error)
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+}
+
+// migration is a single versioned schema change. Migrations are applied
+// sequentially from the current schema_version to len(migrations).
+type migration struct {
+	description string
+	apply       func(ex dbExecer) error
+}
+
+// migrations is the ordered list of schema changes. Append new entries at the
+// end; never reorder or remove existing entries.
+var migrations = []migration{
+	{
+		description: "initial schema: audit_events, scan_results, findings, actions, egress, snapshots",
+		apply: func(ex dbExecer) error {
+			_, err := ex.Exec(`
+			CREATE TABLE IF NOT EXISTS audit_events (
+				id TEXT PRIMARY KEY,
+				timestamp DATETIME NOT NULL,
+				action TEXT NOT NULL,
+				target TEXT,
+				actor TEXT NOT NULL DEFAULT 'defenseclaw',
+				details TEXT,
+				severity TEXT,
+				run_id TEXT
+			);
+			CREATE TABLE IF NOT EXISTS scan_results (
+				id TEXT PRIMARY KEY,
+				scanner TEXT NOT NULL,
+				target TEXT NOT NULL,
+				timestamp DATETIME NOT NULL,
+				duration_ms INTEGER,
+				finding_count INTEGER,
+				max_severity TEXT,
+				raw_json TEXT,
+				run_id TEXT
+			);
+			CREATE TABLE IF NOT EXISTS findings (
+				id TEXT PRIMARY KEY,
+				scan_id TEXT NOT NULL,
+				severity TEXT NOT NULL,
+				title TEXT NOT NULL,
+				description TEXT,
+				location TEXT,
+				remediation TEXT,
+				scanner TEXT NOT NULL,
+				tags TEXT,
+				FOREIGN KEY (scan_id) REFERENCES scan_results(id)
+			);
+			CREATE TABLE IF NOT EXISTS actions (
+				id TEXT PRIMARY KEY,
+				target_type TEXT NOT NULL,
+				target_name TEXT NOT NULL,
+				source_path TEXT,
+				actions_json TEXT NOT NULL DEFAULT '{}',
+				reason TEXT,
+				updated_at DATETIME NOT NULL
+			);
+			CREATE TABLE IF NOT EXISTS network_egress_events (
+				id TEXT PRIMARY KEY,
+				timestamp DATETIME NOT NULL,
+				session_id TEXT,
+				hostname TEXT NOT NULL,
+				url TEXT,
+				http_method TEXT,
+				protocol TEXT,
+				policy_outcome TEXT NOT NULL,
+				decision_code TEXT,
+				blocked INTEGER NOT NULL DEFAULT 0,
+				severity TEXT NOT NULL DEFAULT 'INFO',
+				details TEXT
+			);
+			CREATE TABLE IF NOT EXISTS target_snapshots (
+				id TEXT PRIMARY KEY,
+				target_type TEXT NOT NULL,
+				target_path TEXT NOT NULL,
+				content_hash TEXT NOT NULL,
+				dependency_hashes TEXT,
+				config_hashes TEXT,
+				network_endpoints TEXT,
+				scan_id TEXT,
+				captured_at DATETIME NOT NULL,
+				UNIQUE(target_type, target_path)
+			);
+			CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_events(timestamp);
+			CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_events(action);
+			CREATE INDEX IF NOT EXISTS idx_scan_scanner ON scan_results(scanner);
+			CREATE INDEX IF NOT EXISTS idx_finding_severity ON findings(severity);
+			CREATE INDEX IF NOT EXISTS idx_finding_scan ON findings(scan_id);
+			CREATE UNIQUE INDEX IF NOT EXISTS idx_actions_type_name ON actions(target_type, target_name);
+			CREATE INDEX IF NOT EXISTS idx_egress_timestamp ON network_egress_events(timestamp);
+			CREATE INDEX IF NOT EXISTS idx_egress_hostname ON network_egress_events(hostname);
+			CREATE INDEX IF NOT EXISTS idx_egress_blocked ON network_egress_events(blocked);
+			CREATE INDEX IF NOT EXISTS idx_egress_session ON network_egress_events(session_id);
+			CREATE INDEX IF NOT EXISTS idx_snapshots_target ON target_snapshots(target_type, target_path);
+			`)
+			return err
+		},
+	},
+	{
+		description: "add run_id columns and indexes; migrate old block/allow lists",
+		apply: func(ex dbExecer) error {
+			for _, spec := range []struct {
+				table, column, stmt string
+			}{
+				{"audit_events", "run_id", `ALTER TABLE audit_events ADD COLUMN run_id TEXT`},
+				{"scan_results", "run_id", `ALTER TABLE scan_results ADD COLUMN run_id TEXT`},
+			} {
+				exists, err := hasColumnDB(ex, spec.table, spec.column)
+				if err != nil {
+					return err
+				}
+				if !exists {
+					if _, err := ex.Exec(spec.stmt); err != nil {
+						return fmt.Errorf("alter %s.%s: %w", spec.table, spec.column, err)
+					}
+				}
+			}
+			for _, idx := range []string{
+				`CREATE INDEX IF NOT EXISTS idx_audit_run_id ON audit_events(run_id)`,
+				`CREATE INDEX IF NOT EXISTS idx_scan_run_id ON scan_results(run_id)`,
+			} {
+				if _, err := ex.Exec(idx); err != nil {
+					return fmt.Errorf("create run_id index: %w", err)
+				}
+			}
+			var blockCount, allowCount int
+			_ = ex.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='block_list'`).Scan(&blockCount)
+			_ = ex.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='allow_list'`).Scan(&allowCount)
+			if blockCount > 0 {
+				if _, err := ex.Exec(`INSERT OR REPLACE INTO actions (id, target_type, target_name, source_path, actions_json, reason, updated_at)
+					SELECT id, target_type, target_name, NULL, '{"install":"block"}', reason, created_at FROM block_list`); err != nil {
+					return fmt.Errorf("migrate block_list: %w", err)
+				}
+			}
+			if allowCount > 0 {
+				if _, err := ex.Exec(`INSERT OR REPLACE INTO actions (id, target_type, target_name, source_path, actions_json, reason, updated_at)
+					SELECT id, target_type, target_name, NULL, '{"install":"allow"}', reason, created_at FROM allow_list`); err != nil {
+					return fmt.Errorf("migrate allow_list: %w", err)
+				}
+			}
+			_, _ = ex.Exec(`DROP TABLE IF EXISTS block_list`)
+			_, _ = ex.Exec(`DROP TABLE IF EXISTS allow_list`)
+			return nil
+		},
+	},
+}
+
 func (s *Store) Init() error {
-	schema := `
-	CREATE TABLE IF NOT EXISTS audit_events (
-		id TEXT PRIMARY KEY,
-		timestamp DATETIME NOT NULL,
-		action TEXT NOT NULL,
-		target TEXT,
-		actor TEXT NOT NULL DEFAULT 'defenseclaw',
-		details TEXT,
-		severity TEXT,
-		run_id TEXT
-	);
-
-	CREATE TABLE IF NOT EXISTS scan_results (
-		id TEXT PRIMARY KEY,
-		scanner TEXT NOT NULL,
-		target TEXT NOT NULL,
-		timestamp DATETIME NOT NULL,
-		duration_ms INTEGER,
-		finding_count INTEGER,
-		max_severity TEXT,
-		raw_json TEXT,
-		run_id TEXT
-	);
-
-	CREATE TABLE IF NOT EXISTS findings (
-		id TEXT PRIMARY KEY,
-		scan_id TEXT NOT NULL,
-		severity TEXT NOT NULL,
-		title TEXT NOT NULL,
-		description TEXT,
-		location TEXT,
-		remediation TEXT,
-		scanner TEXT NOT NULL,
-		tags TEXT,
-		FOREIGN KEY (scan_id) REFERENCES scan_results(id)
-	);
-
-	CREATE TABLE IF NOT EXISTS actions (
-		id TEXT PRIMARY KEY,
-		target_type TEXT NOT NULL,
-		target_name TEXT NOT NULL,
-		source_path TEXT,
-		actions_json TEXT NOT NULL DEFAULT '{}',
-		reason TEXT,
-		updated_at DATETIME NOT NULL
-	);
-
-	CREATE TABLE IF NOT EXISTS network_egress_events (
-		id TEXT PRIMARY KEY,
-		timestamp DATETIME NOT NULL,
-		session_id TEXT,
-		hostname TEXT NOT NULL,
-		url TEXT,
-		http_method TEXT,
-		protocol TEXT,
-		policy_outcome TEXT NOT NULL,
-		decision_code TEXT,
-		blocked INTEGER NOT NULL DEFAULT 0,
-		severity TEXT NOT NULL DEFAULT 'INFO',
-		details TEXT
-	);
-
-	CREATE TABLE IF NOT EXISTS target_snapshots (
-		id TEXT PRIMARY KEY,
-		target_type TEXT NOT NULL,
-		target_path TEXT NOT NULL,
-		content_hash TEXT NOT NULL,
-		dependency_hashes TEXT,
-		config_hashes TEXT,
-		network_endpoints TEXT,
-		scan_id TEXT,
-		captured_at DATETIME NOT NULL,
-		UNIQUE(target_type, target_path)
-	);
-
-	CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_events(timestamp);
-	CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_events(action);
-	CREATE INDEX IF NOT EXISTS idx_scan_scanner ON scan_results(scanner);
-	CREATE INDEX IF NOT EXISTS idx_finding_severity ON findings(severity);
-	CREATE INDEX IF NOT EXISTS idx_finding_scan ON findings(scan_id);
-	CREATE UNIQUE INDEX IF NOT EXISTS idx_actions_type_name ON actions(target_type, target_name);
-	CREATE INDEX IF NOT EXISTS idx_egress_timestamp ON network_egress_events(timestamp);
-	CREATE INDEX IF NOT EXISTS idx_egress_hostname ON network_egress_events(hostname);
-	CREATE INDEX IF NOT EXISTS idx_egress_blocked ON network_egress_events(blocked);
-	CREATE INDEX IF NOT EXISTS idx_egress_session ON network_egress_events(session_id);
-	CREATE INDEX IF NOT EXISTS idx_snapshots_target ON target_snapshots(target_type, target_path);
-	`
-
-	if _, err := s.db.Exec(schema); err != nil {
-		return fmt.Errorf("audit: init schema: %w", err)
-	}
-	if err := s.ensureRunIDColumns(); err != nil {
-		return fmt.Errorf("audit: ensure run_id columns: %w", err)
+	// Ensure the schema_version tracking table exists.
+	if _, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS schema_version (
+		version INTEGER PRIMARY KEY,
+		applied_at DATETIME NOT NULL
+	)`); err != nil {
+		return fmt.Errorf("audit: create schema_version table: %w", err)
 	}
 
-	if err := s.migrateOldLists(); err != nil {
-		return fmt.Errorf("audit: migrate old lists: %w", err)
+	current := 0
+	row := s.db.QueryRow(`SELECT COALESCE(MAX(version), 0) FROM schema_version`)
+	if err := row.Scan(&current); err != nil {
+		return fmt.Errorf("audit: read schema version: %w", err)
 	}
 
-	return nil
-}
-
-func (s *Store) migrateOldLists() error {
-	var blockCount, allowCount int
-	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='block_list'`).Scan(&blockCount); err != nil {
-		return err
-	}
-	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='allow_list'`).Scan(&allowCount); err != nil {
-		return err
-	}
-	if blockCount == 0 && allowCount == 0 {
-		return nil
-	}
-
-	if blockCount > 0 {
-		if _, err := s.db.Exec(`INSERT OR REPLACE INTO actions (id, target_type, target_name, source_path, actions_json, reason, updated_at)
-			SELECT id, target_type, target_name, NULL, '{"install":"block"}', reason, created_at FROM block_list`); err != nil {
-			return fmt.Errorf("migrate block_list: %w", err)
-		}
-	}
-	if allowCount > 0 {
-		if _, err := s.db.Exec(`INSERT OR REPLACE INTO actions (id, target_type, target_name, source_path, actions_json, reason, updated_at)
-			SELECT id, target_type, target_name, NULL, '{"install":"allow"}', reason, created_at FROM allow_list`); err != nil {
-			return fmt.Errorf("migrate allow_list: %w", err)
-		}
-	}
-	if _, err := s.db.Exec(`DROP TABLE IF EXISTS block_list`); err != nil {
-		return err
-	}
-	if _, err := s.db.Exec(`DROP TABLE IF EXISTS allow_list`); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (s *Store) ensureRunIDColumns() error {
-	indexes := []string{
-		`CREATE INDEX IF NOT EXISTS idx_audit_run_id ON audit_events(run_id)`,
-		`CREATE INDEX IF NOT EXISTS idx_scan_run_id ON scan_results(run_id)`,
-	}
-	for _, spec := range []struct {
-		table  string
-		column string
-		stmt   string
-	}{
-		{
-			table:  "audit_events",
-			column: "run_id",
-			stmt:   `ALTER TABLE audit_events ADD COLUMN run_id TEXT`,
-		},
-		{
-			table:  "scan_results",
-			column: "run_id",
-			stmt:   `ALTER TABLE scan_results ADD COLUMN run_id TEXT`,
-		},
-	} {
-		exists, err := s.hasColumn(spec.table, spec.column)
-		if err != nil {
+	for i := current; i < len(migrations); i++ {
+		m := migrations[i]
+		ver := i + 1
+		fmt.Fprintf(os.Stderr, "[audit] applying migration %d: %s\n", ver, m.description)
+		if err := s.applyMigration(ver, m); err != nil {
 			return err
 		}
-		if exists {
-			continue
-		}
-		if _, err := s.db.Exec(spec.stmt); err != nil {
-			return fmt.Errorf("alter %s.%s: %w", spec.table, spec.column, err)
-		}
 	}
-	for _, stmt := range indexes {
-		if _, err := s.db.Exec(stmt); err != nil {
-			return fmt.Errorf("create run_id index: %w", err)
-		}
+
+	return nil
+}
+
+// applyMigration runs a single migration inside a transaction so that both the
+// DDL and the schema_version bump are atomic. On failure the transaction is
+// rolled back and the version remains unchanged, making retries safe.
+func (s *Store) applyMigration(ver int, m migration) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("audit: begin migration %d: %w", ver, err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if err := m.apply(tx); err != nil {
+		return fmt.Errorf("audit: migration %d (%s): %w", ver, m.description, err)
+	}
+	if _, err := tx.Exec(`INSERT INTO schema_version (version, applied_at) VALUES (?, ?)`,
+		ver, time.Now().UTC()); err != nil {
+		return fmt.Errorf("audit: record migration %d: %w", ver, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("audit: commit migration %d: %w", ver, err)
 	}
 	return nil
+}
+
+// SchemaVersion returns the current schema version number.
+func (s *Store) SchemaVersion() (int, error) {
+	var v int
+	err := s.db.QueryRow(`SELECT COALESCE(MAX(version), 0) FROM schema_version`).Scan(&v)
+	return v, err
+}
+
+// hasColumnDB checks if a table has a specific column. Accepts dbExecer so it
+// works inside transactions too.
+func hasColumnDB(ex dbExecer, table, column string) (bool, error) {
+	if !knownTables[table] {
+		return false, fmt.Errorf("audit: hasColumn called with unknown table %q", table)
+	}
+	rows, err := ex.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return false, fmt.Errorf("audit: pragma table_info(%s): %w", table, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid        int
+			name       string
+			colType    string
+			notNull    int
+			defaultV   sql.NullString
+			primaryKey int
+		)
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &defaultV, &primaryKey); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
 }
 
 // knownTables is the set of tables hasColumn is allowed to inspect.
@@ -288,6 +357,7 @@ var knownTables = map[string]bool{
 	"actions":               true,
 	"target_snapshots":      true,
 	"network_egress_events": true,
+	"schema_version":        true,
 }
 
 func (s *Store) hasColumn(table, column string) (bool, error) {

--- a/internal/audit/store_test.go
+++ b/internal/audit/store_test.go
@@ -23,16 +23,8 @@ import (
 	"time"
 )
 
-func TestStoreInitMigratesRunIDColumns(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "audit.db")
-
-	db, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		t.Fatalf("sql.Open: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-
-	oldSchema := `
+// legacySchemaWithoutRunID is the pre-migration-2 schema (no run_id on audit_events / scan_results).
+const legacySchemaWithoutRunID = `
 	CREATE TABLE audit_events (
 		id TEXT PRIMARY KEY,
 		timestamp DATETIME NOT NULL,
@@ -54,7 +46,17 @@ func TestStoreInitMigratesRunIDColumns(t *testing.T) {
 		raw_json TEXT
 	);
 	`
-	if _, err := db.Exec(oldSchema); err != nil {
+
+func TestStoreInitMigratesRunIDColumns(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "audit.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if _, err := db.Exec(legacySchemaWithoutRunID); err != nil {
 		t.Fatalf("create old schema: %v", err)
 	}
 	_ = db.Close()
@@ -149,5 +151,329 @@ func TestStoreInsertScanResultUsesEnvRunID(t *testing.T) {
 	}
 	if got := runID.String; got != "unit-run-scan" {
 		t.Fatalf("run_id = %q, want %q", got, "unit-run-scan")
+	}
+}
+
+func TestSchemaVersionTracking(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "audit.db")
+	store, err := NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	want := len(migrations)
+	got, err := store.SchemaVersion()
+	if err != nil {
+		t.Fatalf("SchemaVersion: %v", err)
+	}
+	if got != want {
+		t.Errorf("SchemaVersion() = %d, want %d (len(migrations))", got, want)
+	}
+
+	verifyDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open verify: %v", err)
+	}
+	defer verifyDB.Close()
+
+	var tableCount int
+	if err := verifyDB.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='schema_version'`,
+	).Scan(&tableCount); err != nil {
+		t.Fatalf("schema_version table check: %v", err)
+	}
+	if tableCount != 1 {
+		t.Errorf("schema_version table exists: got count %d, want 1", tableCount)
+	}
+
+	var rowCount int
+	if err := verifyDB.QueryRow(`SELECT COUNT(*) FROM schema_version`).Scan(&rowCount); err != nil {
+		t.Fatalf("COUNT schema_version: %v", err)
+	}
+	if rowCount != want {
+		t.Errorf("schema_version rows = %d, want %d", rowCount, want)
+	}
+}
+
+func TestInitIdempotent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "audit.db")
+	store, err := NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.Init(); err != nil {
+		t.Fatalf("first Init: %v", err)
+	}
+	if err := store.Init(); err != nil {
+		t.Errorf("second Init: %v", err)
+	}
+
+	want := len(migrations)
+	got, err := store.SchemaVersion()
+	if err != nil {
+		t.Fatalf("SchemaVersion: %v", err)
+	}
+	if got != want {
+		t.Errorf("SchemaVersion() after second Init = %d, want %d", got, want)
+	}
+
+	verifyDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open verify: %v", err)
+	}
+	defer verifyDB.Close()
+
+	var rowCount int
+	if err := verifyDB.QueryRow(`SELECT COUNT(*) FROM schema_version`).Scan(&rowCount); err != nil {
+		t.Fatalf("COUNT schema_version: %v", err)
+	}
+	if rowCount != want {
+		t.Errorf("schema_version rows after Init x2 = %d, want %d (not duplicated)", rowCount, want)
+	}
+}
+
+func TestMigrationFromFreshDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "audit.db")
+	store, err := NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	wantTables := []string{
+		"actions",
+		"audit_events",
+		"findings",
+		"network_egress_events",
+		"scan_results",
+		"schema_version",
+		"target_snapshots",
+	}
+	verifyDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open verify: %v", err)
+	}
+	defer verifyDB.Close()
+
+	for _, name := range wantTables {
+		var n int
+		err := verifyDB.QueryRow(
+			`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?`, name,
+		).Scan(&n)
+		if err != nil {
+			t.Fatalf("table %q lookup: %v", name, err)
+		}
+		if n != 1 {
+			t.Errorf("table %q: want 1 match in sqlite_master, got %d", name, n)
+		}
+	}
+
+	want := len(migrations)
+	got, err := store.SchemaVersion()
+	if err != nil {
+		t.Fatalf("SchemaVersion: %v", err)
+	}
+	if got != want {
+		t.Errorf("SchemaVersion() = %d, want %d", got, want)
+	}
+
+	ok, err := store.hasColumn("audit_events", "run_id")
+	if err != nil {
+		t.Fatalf("hasColumn(audit_events, run_id): %v", err)
+	}
+	if !ok {
+		t.Errorf("hasColumn(audit_events, run_id) = false, want true")
+	}
+}
+
+func TestMigrationFromV1Schema(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "audit-v1.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	if _, err := db.Exec(legacySchemaWithoutRunID); err != nil {
+		t.Fatalf("create legacy schema: %v", err)
+	}
+	if _, err := db.Exec(`
+		CREATE TABLE schema_version (
+			version INTEGER PRIMARY KEY,
+			applied_at DATETIME NOT NULL
+		);
+		INSERT INTO schema_version (version, applied_at) VALUES (1, '2020-01-01T00:00:00Z');
+	`); err != nil {
+		t.Fatalf("create schema_version v1: %v", err)
+	}
+	_ = db.Close()
+
+	store, err := NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	want := len(migrations)
+	got, err := store.SchemaVersion()
+	if err != nil {
+		t.Fatalf("SchemaVersion: %v", err)
+	}
+	if got != want {
+		t.Errorf("SchemaVersion() = %d, want %d", got, want)
+	}
+
+	verifyDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open verify: %v", err)
+	}
+	defer verifyDB.Close()
+
+	var rowCount int
+	if err := verifyDB.QueryRow(`SELECT COUNT(*) FROM schema_version`).Scan(&rowCount); err != nil {
+		t.Fatalf("COUNT schema_version: %v", err)
+	}
+	if rowCount != want {
+		t.Errorf("schema_version rows = %d, want %d (v1 pre-seeded + migration %d only)", rowCount, want, want)
+	}
+
+	ok, err := store.hasColumn("audit_events", "run_id")
+	if err != nil {
+		t.Fatalf("hasColumn(audit_events, run_id): %v", err)
+	}
+	if !ok {
+		t.Errorf("hasColumn(audit_events, run_id) = false, want true after migration 2 only")
+	}
+}
+
+func TestMigrationTransactional(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "audit.db")
+	store, err := NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	verifyDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("second connection sql.Open: %v", err)
+	}
+	defer verifyDB.Close()
+
+	rows, err := verifyDB.Query(`SELECT version FROM schema_version ORDER BY version`)
+	if err != nil {
+		t.Fatalf("query schema_version: %v", err)
+	}
+	defer rows.Close()
+
+	var versions []int
+	for rows.Next() {
+		var v int
+		if err := rows.Scan(&v); err != nil {
+			t.Fatalf("scan version: %v", err)
+		}
+		versions = append(versions, v)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+
+	if len(versions) != len(migrations) {
+		t.Fatalf("schema_version rows = %d, want %d (len(migrations))", len(versions), len(migrations))
+	}
+	for i, v := range versions {
+		want := i + 1
+		if v != want {
+			t.Fatalf("schema_version[%d] = %d, want consecutive starting at 1 (got %d)", i, v, want)
+		}
+	}
+
+	for _, v := range versions {
+		var n int
+		if err := verifyDB.QueryRow(
+			`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='audit_events'`,
+		).Scan(&n); err != nil {
+			t.Fatalf("audit_events table check: %v", err)
+		}
+		if n != 1 {
+			t.Errorf("version %d recorded but audit_events table missing or duplicate", v)
+		}
+		if v >= 2 {
+			ok, err := store.hasColumn("audit_events", "run_id")
+			if err != nil {
+				t.Fatalf("hasColumn after version %d: %v", v, err)
+			}
+			if !ok {
+				t.Errorf("version %d in schema_version but audit_events.run_id missing (migration not atomic with version bump)", v)
+			}
+		}
+	}
+}
+
+func TestMigrationApplyUsesTransaction(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "audit.db")
+	store, err := NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	wantCount := len(migrations)
+	var rowCount int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM schema_version`).Scan(&rowCount); err != nil {
+		t.Fatalf("COUNT schema_version: %v", err)
+	}
+	if rowCount != wantCount {
+		t.Fatalf("schema_version rows = %d, want %d", rowCount, wantCount)
+	}
+
+	rawDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer rawDB.Close()
+
+	ok, err := store.hasColumn("audit_events", "run_id")
+	if err != nil {
+		t.Fatalf("hasColumn(audit_events, run_id): %v", err)
+	}
+	if !ok {
+		t.Fatal("expected audit_events.run_id after migration 2")
+	}
+
+	var v1, v2 int
+	if err := rawDB.QueryRow(`SELECT COUNT(*) FROM schema_version WHERE version = 1`).Scan(&v1); err != nil {
+		t.Fatalf("count version 1: %v", err)
+	}
+	if err := rawDB.QueryRow(`SELECT COUNT(*) FROM schema_version WHERE version = 2`).Scan(&v2); err != nil {
+		t.Fatalf("count version 2: %v", err)
+	}
+	if wantCount >= 1 && v1 != 1 {
+		t.Errorf("version 1 rows = %d, want 1", v1)
+	}
+	if wantCount >= 2 && v2 != 1 {
+		t.Errorf("version 2 rows = %d, want 1", v2)
 	}
 }

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -105,10 +105,21 @@ func runStart(cmd *cobra.Command, _ []string) error {
 	fmt.Println("Use 'defenseclaw-gateway stop' to stop the daemon")
 	printSplunkLocalHint()
 
+	// Auto-start watchdog if enabled in config.
+	cfg, cfgErr := config.Load()
+	if cfgErr == nil && cfg.Gateway.Watchdog.Enabled {
+		if err := runWatchdogStart(nil, nil); err != nil {
+			fmt.Printf("  Warning: watchdog auto-start failed: %v\n", err)
+		}
+	}
+
 	return nil
 }
 
 func runStop(_ *cobra.Command, _ []string) error {
+	// Stop watchdog first since it monitors the gateway.
+	_ = runWatchdogStop(nil, nil)
+
 	d := daemon.New(config.DefaultDataPath())
 
 	running, pid := d.IsRunning()
@@ -130,6 +141,9 @@ func runStop(_ *cobra.Command, _ []string) error {
 
 func runRestart(cmd *cobra.Command, _ []string) error {
 	d := daemon.New(config.DefaultDataPath())
+
+	// Stop the watchdog first so it doesn't fire false alarms during restart.
+	_ = runWatchdogStop(nil, nil)
 
 	if running, pid := d.IsRunning(); running {
 		fmt.Printf("Stopping gateway sidecar (PID %d)... ", pid)
@@ -153,6 +167,14 @@ func runRestart(cmd *cobra.Command, _ []string) error {
 	fmt.Println()
 	fmt.Println("Use 'defenseclaw-gateway status' to check health")
 	printSplunkLocalHint()
+
+	// Re-start watchdog if enabled in config.
+	cfg, cfgErr := config.Load()
+	if cfgErr == nil && cfg.Gateway.Watchdog.Enabled {
+		if err := runWatchdogStart(nil, nil); err != nil {
+			fmt.Printf("  Warning: watchdog auto-start failed: %v\n", err)
+		}
+	}
 
 	return nil
 }
@@ -217,4 +239,3 @@ func collectDaemonArgs(cmd *cobra.Command) []string {
 
 	return args
 }
-

--- a/internal/cli/watchdog.go
+++ b/internal/cli/watchdog.go
@@ -31,7 +31,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/defenseclaw/defenseclaw/internal/audit"
 	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/gateway"
 	"github.com/defenseclaw/defenseclaw/internal/notify"
 )
 
@@ -109,6 +111,11 @@ func runWatchdogForeground(_ *cobra.Command, _ []string) error {
 
 	healthURL := watchdogHealthURL(cfg)
 
+	var webhooks *gateway.WebhookDispatcher
+	if len(cfg.Webhooks) > 0 {
+		webhooks = gateway.NewWebhookDispatcher(cfg.Webhooks)
+	}
+
 	fmt.Fprintf(os.Stderr, "[watchdog] starting: poll=%s debounce=%d url=%s\n",
 		interval, debounce, healthURL)
 
@@ -121,7 +128,10 @@ func runWatchdogForeground(_ *cobra.Command, _ []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	runWatchdogLoop(ctx, healthURL, interval, debounce)
+	runWatchdogLoop(ctx, healthURL, interval, debounce, webhooks)
+	if webhooks != nil {
+		webhooks.Close()
+	}
 	fmt.Fprintf(os.Stderr, "[watchdog] stopped\n")
 	return nil
 }
@@ -144,7 +154,7 @@ func watchdogHealthURL(cfg *config.Config) string {
 	return fmt.Sprintf("http://%s:%d/health", apiBind, apiPort)
 }
 
-func runWatchdogLoop(ctx context.Context, healthURL string, interval time.Duration, debounce int) {
+func runWatchdogLoop(ctx context.Context, healthURL string, interval time.Duration, debounce int, webhooks *gateway.WebhookDispatcher) {
 	current := stateHealthy
 	failCount := 0
 	client := &http.Client{Timeout: 5 * time.Second}
@@ -159,33 +169,50 @@ func runWatchdogLoop(ctx context.Context, healthURL string, interval time.Durati
 		case <-ticker.C:
 			probed := probeHealth(client, healthURL)
 
-		switch probed {
-		case stateHealthy:
-			failCount = 0
-			if current != stateHealthy {
-				fmt.Fprintf(os.Stderr, "[watchdog] gateway recovered: %s → healthy\n", current)
-				_ = notify.Send("DefenseClaw", "Gateway is back online. Protection restored.")
-			}
-			current = stateHealthy
+			switch probed {
+			case stateHealthy:
+				failCount = 0
+				if current != stateHealthy {
+					fmt.Fprintf(os.Stderr, "[watchdog] gateway recovered: %s → healthy\n", current)
+					_ = notify.Send("DefenseClaw", "Gateway is back online. Protection restored.")
+					dispatchHealthEvent(webhooks, "gateway-recovered", "INFO", "Gateway recovered from "+current.String())
+				}
+				current = stateHealthy
 
-		case stateDegraded:
-			failCount++
-			if failCount >= debounce && current == stateHealthy {
-				fmt.Fprintf(os.Stderr, "[watchdog] gateway degraded\n")
-				_ = notify.Send("DefenseClaw", "Gateway guardrail is disconnected. Prompt protection is disabled.")
-				current = stateDegraded
-			}
+			case stateDegraded:
+				failCount++
+				if failCount >= debounce && current == stateHealthy {
+					fmt.Fprintf(os.Stderr, "[watchdog] gateway degraded\n")
+					_ = notify.Send("DefenseClaw", "Gateway guardrail is disconnected. Prompt protection is disabled.")
+					dispatchHealthEvent(webhooks, "guardrail-degraded", "HIGH", "Guardrail proxy is disconnected; prompt protection is disabled")
+					current = stateDegraded
+				}
 
-		default: // stateDown
-			failCount++
-			if failCount >= debounce && current != stateDown {
-				fmt.Fprintf(os.Stderr, "[watchdog] gateway down (after %d failures)\n", failCount)
-				_ = notify.Send("DefenseClaw", "Gateway is not running. Your AI agent traffic is unprotected.")
-				current = stateDown
+			default: // stateDown
+				failCount++
+				if failCount >= debounce && current != stateDown {
+					fmt.Fprintf(os.Stderr, "[watchdog] gateway down (after %d failures)\n", failCount)
+					_ = notify.Send("DefenseClaw", "Gateway is not running. Your AI agent traffic is unprotected.")
+					dispatchHealthEvent(webhooks, "gateway-down", "CRITICAL", fmt.Sprintf("Gateway unreachable after %d consecutive failures", failCount))
+					current = stateDown
+				}
 			}
-		}
 		}
 	}
+}
+
+func dispatchHealthEvent(webhooks *gateway.WebhookDispatcher, action, severity, details string) {
+	if webhooks == nil {
+		return
+	}
+	webhooks.Dispatch(audit.Event{
+		Timestamp: time.Now().UTC(),
+		Action:    action,
+		Target:    "defenseclaw-gateway",
+		Actor:     "defenseclaw-watchdog",
+		Details:   details,
+		Severity:  severity,
+	})
 }
 
 func probeHealth(client *http.Client, url string) watchdogState {

--- a/internal/cli/watchdog.go
+++ b/internal/cli/watchdog.go
@@ -159,31 +159,31 @@ func runWatchdogLoop(ctx context.Context, healthURL string, interval time.Durati
 		case <-ticker.C:
 			probed := probeHealth(client, healthURL)
 
-			switch {
-			case probed == stateHealthy:
-				failCount = 0
-				if current != stateHealthy {
-					fmt.Fprintf(os.Stderr, "[watchdog] gateway recovered: %s → healthy\n", current)
-					_ = notify.Send("DefenseClaw", "Gateway is back online. Protection restored.")
-				}
-				current = stateHealthy
-
-			case probed == stateDegraded:
-				failCount++
-				if failCount >= debounce && current == stateHealthy {
-					fmt.Fprintf(os.Stderr, "[watchdog] gateway degraded\n")
-					_ = notify.Send("DefenseClaw", "Gateway guardrail is disconnected. Prompt protection is disabled.")
-					current = stateDegraded
-				}
-
-			default: // stateDown
-				failCount++
-				if failCount >= debounce && current != stateDown {
-					fmt.Fprintf(os.Stderr, "[watchdog] gateway down (after %d failures)\n", failCount)
-					_ = notify.Send("DefenseClaw", "Gateway is not running. Your AI agent traffic is unprotected.")
-					current = stateDown
-				}
+		switch probed {
+		case stateHealthy:
+			failCount = 0
+			if current != stateHealthy {
+				fmt.Fprintf(os.Stderr, "[watchdog] gateway recovered: %s → healthy\n", current)
+				_ = notify.Send("DefenseClaw", "Gateway is back online. Protection restored.")
 			}
+			current = stateHealthy
+
+		case stateDegraded:
+			failCount++
+			if failCount >= debounce && current == stateHealthy {
+				fmt.Fprintf(os.Stderr, "[watchdog] gateway degraded\n")
+				_ = notify.Send("DefenseClaw", "Gateway guardrail is disconnected. Prompt protection is disabled.")
+				current = stateDegraded
+			}
+
+		default: // stateDown
+			failCount++
+			if failCount >= debounce && current != stateDown {
+				fmt.Fprintf(os.Stderr, "[watchdog] gateway down (after %d failures)\n", failCount)
+				_ = notify.Send("DefenseClaw", "Gateway is not running. Your AI agent traffic is unprotected.")
+				current = stateDown
+			}
+		}
 		}
 	}
 }

--- a/internal/cli/watchdog.go
+++ b/internal/cli/watchdog.go
@@ -26,6 +26,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -38,8 +39,9 @@ import (
 )
 
 const (
-	watchdogPIDFile = "watchdog.pid"
-	watchdogLogFile = "watchdog.log"
+	watchdogPIDFile   = "watchdog.pid"
+	watchdogLogFile   = "watchdog.log"
+	watchdogStateFile = "watchdog.state"
 )
 
 type watchdogState int
@@ -155,8 +157,12 @@ func watchdogHealthURL(cfg *config.Config) string {
 }
 
 func runWatchdogLoop(ctx context.Context, healthURL string, interval time.Duration, debounce int, webhooks *gateway.WebhookDispatcher) {
-	current := stateHealthy
+	dataDir := config.DefaultDataPath()
+	current := loadWatchdogState(dataDir)
 	failCount := 0
+	if current != stateHealthy {
+		failCount = debounce // carry over so first healthy probe triggers recovery
+	}
 	client := &http.Client{Timeout: 5 * time.Second}
 
 	ticker := time.NewTicker(interval)
@@ -178,6 +184,7 @@ func runWatchdogLoop(ctx context.Context, healthURL string, interval time.Durati
 					dispatchHealthEvent(webhooks, "gateway-recovered", "INFO", "Gateway recovered from "+current.String())
 				}
 				current = stateHealthy
+				saveWatchdogState(dataDir, current)
 
 			case stateDegraded:
 				failCount++
@@ -186,6 +193,7 @@ func runWatchdogLoop(ctx context.Context, healthURL string, interval time.Durati
 					_ = notify.Send("DefenseClaw", "Gateway guardrail is disconnected. Prompt protection is disabled.")
 					dispatchHealthEvent(webhooks, "guardrail-degraded", "HIGH", "Guardrail proxy is disconnected; prompt protection is disabled")
 					current = stateDegraded
+					saveWatchdogState(dataDir, current)
 				}
 
 			default: // stateDown
@@ -195,9 +203,29 @@ func runWatchdogLoop(ctx context.Context, healthURL string, interval time.Durati
 					_ = notify.Send("DefenseClaw", "Gateway is not running. Your AI agent traffic is unprotected.")
 					dispatchHealthEvent(webhooks, "gateway-down", "CRITICAL", fmt.Sprintf("Gateway unreachable after %d consecutive failures", failCount))
 					current = stateDown
+					saveWatchdogState(dataDir, current)
 				}
 			}
 		}
+	}
+}
+
+func saveWatchdogState(dataDir string, state watchdogState) {
+	_ = os.WriteFile(filepath.Join(dataDir, watchdogStateFile), []byte(state.String()), 0o644)
+}
+
+func loadWatchdogState(dataDir string) watchdogState {
+	data, err := os.ReadFile(filepath.Join(dataDir, watchdogStateFile))
+	if err != nil {
+		return stateHealthy
+	}
+	switch strings.TrimSpace(string(data)) {
+	case "down":
+		return stateDown
+	case "degraded":
+		return stateDegraded
+	default:
+		return stateHealthy
 	}
 }
 

--- a/internal/cli/watchdog.go
+++ b/internal/cli/watchdog.go
@@ -1,0 +1,334 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/notify"
+)
+
+const (
+	watchdogPIDFile = "watchdog.pid"
+	watchdogLogFile = "watchdog.log"
+)
+
+type watchdogState int
+
+const (
+	stateHealthy watchdogState = iota
+	stateDegraded
+	stateDown
+)
+
+func (s watchdogState) String() string {
+	switch s {
+	case stateHealthy:
+		return "healthy"
+	case stateDegraded:
+		return "degraded"
+	case stateDown:
+		return "down"
+	default:
+		return "unknown"
+	}
+}
+
+var watchdogCmd = &cobra.Command{
+	Use:   "watchdog",
+	Short: "Health watchdog that notifies when the gateway is down",
+	Long: `The watchdog polls the gateway /health endpoint and sends desktop
+notifications when the sidecar is unreachable or degraded.
+
+Run in the foreground:  defenseclaw-gateway watchdog
+Run as background:      defenseclaw-gateway watchdog start
+Stop:                   defenseclaw-gateway watchdog stop`,
+	RunE:              runWatchdogForeground,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error { return nil },
+}
+
+var watchdogStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start the watchdog as a background daemon",
+	RunE:  runWatchdogStart,
+}
+
+var watchdogStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop the running watchdog daemon",
+	RunE:  runWatchdogStop,
+}
+
+func init() {
+	watchdogCmd.AddCommand(watchdogStartCmd)
+	watchdogCmd.AddCommand(watchdogStopCmd)
+	rootCmd.AddCommand(watchdogCmd)
+}
+
+func runWatchdogForeground(_ *cobra.Command, _ []string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		cfg = config.DefaultConfig()
+	}
+
+	interval := time.Duration(cfg.Gateway.Watchdog.Interval) * time.Second
+	if interval < time.Second {
+		interval = 30 * time.Second
+	}
+	debounce := cfg.Gateway.Watchdog.Debounce
+	if debounce < 1 {
+		debounce = 2
+	}
+
+	healthURL := watchdogHealthURL(cfg)
+
+	fmt.Fprintf(os.Stderr, "[watchdog] starting: poll=%s debounce=%d url=%s\n",
+		interval, debounce, healthURL)
+
+	// Write PID file
+	dataDir := config.DefaultDataPath()
+	pidPath := filepath.Join(dataDir, watchdogPIDFile)
+	_ = os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o644)
+	defer os.Remove(pidPath)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	runWatchdogLoop(ctx, healthURL, interval, debounce)
+	fmt.Fprintf(os.Stderr, "[watchdog] stopped\n")
+	return nil
+}
+
+func watchdogHealthURL(cfg *config.Config) string {
+	apiPort := 18970
+	if cfg != nil && cfg.Gateway.APIPort != 0 {
+		apiPort = cfg.Gateway.APIPort
+	}
+
+	apiBind := "127.0.0.1"
+	if cfg != nil {
+		if cfg.Gateway.APIBind != "" {
+			apiBind = cfg.Gateway.APIBind
+		} else if cfg.OpenShell.IsStandalone() && cfg.Guardrail.Host != "" && cfg.Guardrail.Host != "localhost" {
+			apiBind = cfg.Guardrail.Host
+		}
+	}
+
+	return fmt.Sprintf("http://%s:%d/health", apiBind, apiPort)
+}
+
+func runWatchdogLoop(ctx context.Context, healthURL string, interval time.Duration, debounce int) {
+	current := stateHealthy
+	failCount := 0
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			probed := probeHealth(client, healthURL)
+
+			switch {
+			case probed == stateHealthy:
+				failCount = 0
+				if current != stateHealthy {
+					fmt.Fprintf(os.Stderr, "[watchdog] gateway recovered: %s → healthy\n", current)
+					_ = notify.Send("DefenseClaw", "Gateway is back online. Protection restored.")
+				}
+				current = stateHealthy
+
+			case probed == stateDegraded:
+				failCount++
+				if failCount >= debounce && current == stateHealthy {
+					fmt.Fprintf(os.Stderr, "[watchdog] gateway degraded\n")
+					_ = notify.Send("DefenseClaw", "Gateway guardrail is disconnected. Prompt protection is disabled.")
+					current = stateDegraded
+				}
+
+			default: // stateDown
+				failCount++
+				if failCount >= debounce && current != stateDown {
+					fmt.Fprintf(os.Stderr, "[watchdog] gateway down (after %d failures)\n", failCount)
+					_ = notify.Send("DefenseClaw", "Gateway is not running. Your AI agent traffic is unprotected.")
+					current = stateDown
+				}
+			}
+		}
+	}
+}
+
+func probeHealth(client *http.Client, url string) watchdogState {
+	resp, err := client.Get(url)
+	if err != nil {
+		return stateDown
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return stateDown
+	}
+
+	var snap struct {
+		Gateway struct {
+			State string `json:"state"`
+		} `json:"gateway"`
+		Guardrail struct {
+			State string `json:"state"`
+		} `json:"guardrail"`
+	}
+	if err := json.Unmarshal(body, &snap); err != nil {
+		return stateDown
+	}
+
+	if snap.Gateway.State != "running" {
+		return stateDown
+	}
+	if snap.Guardrail.State != "" && snap.Guardrail.State != "running" {
+		return stateDegraded
+	}
+	return stateHealthy
+}
+
+func runWatchdogStart(_ *cobra.Command, _ []string) error {
+	dataDir := config.DefaultDataPath()
+	pidPath := filepath.Join(dataDir, watchdogPIDFile)
+
+	// Check if already running.
+	if data, err := os.ReadFile(pidPath); err == nil {
+		if pid, err := strconv.Atoi(string(data)); err == nil {
+			if proc, err := os.FindProcess(pid); err == nil {
+				if err := proc.Signal(syscall.Signal(0)); err == nil {
+					fmt.Printf("Watchdog is already running (PID %d)\n", pid)
+					return nil
+				}
+			}
+		}
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("watchdog: resolve executable: %w", err)
+	}
+
+	logPath := filepath.Join(dataDir, watchdogLogFile)
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("watchdog: open log: %w", err)
+	}
+
+	cmd := &execCommand{path: exe, args: []string{"watchdog"}, logFile: logFile}
+	if err := cmd.start(); err != nil {
+		logFile.Close()
+		return fmt.Errorf("watchdog: start background: %w", err)
+	}
+
+	fmt.Printf("Watchdog started (PID %d)\n", cmd.pid)
+	fmt.Printf("  Log file: %s\n", logPath)
+	return nil
+}
+
+type execCommand struct {
+	path    string
+	args    []string
+	logFile *os.File
+	pid     int
+}
+
+func (c *execCommand) start() error {
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", os.DevNull, err)
+	}
+	proc, err := os.StartProcess(c.path, append([]string{c.path}, c.args...), &os.ProcAttr{
+		Dir:   "/",
+		Files: []*os.File{devNull, c.logFile, c.logFile},
+		Sys:   &syscall.SysProcAttr{Setsid: true},
+	})
+	_ = devNull.Close()
+	if err != nil {
+		return err
+	}
+	c.pid = proc.Pid
+	_ = proc.Release()
+	return nil
+}
+
+func runWatchdogStop(_ *cobra.Command, _ []string) error {
+	dataDir := config.DefaultDataPath()
+	pidPath := filepath.Join(dataDir, watchdogPIDFile)
+
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		fmt.Println("Watchdog is not running")
+		return nil
+	}
+
+	pid, err := strconv.Atoi(string(data))
+	if err != nil {
+		fmt.Println("Watchdog is not running (invalid PID file)")
+		_ = os.Remove(pidPath)
+		return nil
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		fmt.Println("Watchdog is not running")
+		_ = os.Remove(pidPath)
+		return nil
+	}
+
+	fmt.Printf("Stopping watchdog (PID %d)... ", pid)
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		fmt.Println("already stopped")
+		_ = os.Remove(pidPath)
+		return nil
+	}
+
+	// Wait briefly for graceful exit.
+	done := make(chan struct{})
+	go func() {
+		_, _ = proc.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		_ = proc.Signal(syscall.SIGKILL)
+	}
+
+	_ = os.Remove(pidPath)
+	fmt.Println("OK")
+	return nil
+}

--- a/internal/cli/watchdog_test.go
+++ b/internal/cli/watchdog_test.go
@@ -117,6 +117,7 @@ func TestProbeHealth(t *testing.T) {
 }
 
 func TestWatchdogStateTransitions(t *testing.T) {
+	t.Setenv("DEFENSECLAW_HOME", t.TempDir())
 	var healthy atomic.Bool
 	healthy.Store(true)
 
@@ -182,6 +183,7 @@ func TestWatchdogHealthURL(t *testing.T) {
 }
 
 func TestWatchdogWebhookDispatchOnStateChange(t *testing.T) {
+	t.Setenv("DEFENSECLAW_HOME", t.TempDir())
 	os.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
 	defer os.Unsetenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST")
 
@@ -259,4 +261,34 @@ func TestWatchdogWebhookDispatchOnStateChange(t *testing.T) {
 
 func TestDispatchHealthEventNilWebhooks(t *testing.T) {
 	dispatchHealthEvent(nil, "gateway-down", "CRITICAL", "test")
+}
+
+func TestWatchdogStatePersistenceAndRecovery(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("DEFENSECLAW_HOME", tmpDir)
+
+	saveWatchdogState(tmpDir, stateDown)
+	got := loadWatchdogState(tmpDir)
+	if got != stateDown {
+		t.Fatalf("expected stateDown after save/load, got %s", got)
+	}
+
+	// Simulate a new watchdog starting after gateway was down, with gateway
+	// now healthy. The loop should detect recovery on the first healthy probe.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"gateway":{"state":"running"}}`))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	runWatchdogLoop(ctx, srv.URL+"/health", 10*time.Millisecond, 2, nil)
+
+	restored := loadWatchdogState(tmpDir)
+	if restored != stateHealthy {
+		t.Fatalf("expected stateHealthy after recovery, got %s", restored)
+	}
 }

--- a/internal/cli/watchdog_test.go
+++ b/internal/cli/watchdog_test.go
@@ -18,14 +18,20 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/gateway"
 )
+
+func intPtr(v int) *int { return &v }
 
 func TestProbeHealth(t *testing.T) {
 	client := &http.Client{Timeout: 2 * time.Second}
@@ -135,7 +141,7 @@ func TestWatchdogStateTransitions(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
 	defer cancel()
 
-	runWatchdogLoop(ctx, srv.URL+"/health", 10*time.Millisecond, 2)
+	runWatchdogLoop(ctx, srv.URL+"/health", 10*time.Millisecond, 2, nil)
 
 	if n := downProbes.Load(); n < 2 {
 		t.Fatalf("expected at least %d probes while server returned errors after flip, got %d", 2, n)
@@ -173,4 +179,84 @@ func TestWatchdogHealthURL(t *testing.T) {
 			t.Fatalf("watchdogHealthURL() = %q, want %q", got, want)
 		}
 	})
+}
+
+func TestWatchdogWebhookDispatchOnStateChange(t *testing.T) {
+	os.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
+	defer os.Unsetenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST")
+
+	var mu sync.Mutex
+	var received []map[string]interface{}
+
+	webhookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err == nil {
+			mu.Lock()
+			received = append(received, body)
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer webhookSrv.Close()
+
+	webhooks := gateway.NewWebhookDispatcher([]config.WebhookConfig{
+		{
+			URL:             webhookSrv.URL,
+			Type:            "generic",
+			Enabled:         true,
+			CooldownSeconds: intPtr(0), // disable cooldown for fast test loop
+		},
+	})
+	defer webhooks.Close()
+
+	var healthy atomic.Bool
+	healthy.Store(true)
+
+	healthSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if healthy.Load() {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"gateway":{"state":"running"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer healthSrv.Close()
+
+	go func() {
+		time.Sleep(25 * time.Millisecond)
+		healthy.Store(false)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	runWatchdogLoop(ctx, healthSrv.URL+"/health", 10*time.Millisecond, 2, webhooks)
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	count := len(received)
+	mu.Unlock()
+	if count < 1 {
+		t.Fatalf("expected at least 1 webhook event for gateway-down, got %d", count)
+	}
+
+	mu.Lock()
+	first := received[0]
+	mu.Unlock()
+	evt, ok := first["event"].(map[string]interface{})
+	if !ok {
+		t.Fatal("webhook payload missing event field")
+	}
+	if evt["action"] != "gateway-down" {
+		t.Errorf("expected action=gateway-down, got %v", evt["action"])
+	}
+	if evt["severity"] != "CRITICAL" {
+		t.Errorf("expected severity=CRITICAL, got %v", evt["severity"])
+	}
+}
+
+func TestDispatchHealthEventNilWebhooks(t *testing.T) {
+	dispatchHealthEvent(nil, "gateway-down", "CRITICAL", "test")
 }

--- a/internal/cli/watchdog_test.go
+++ b/internal/cli/watchdog_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+)
+
+func TestProbeHealth(t *testing.T) {
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	t.Run("unreachable", func(t *testing.T) {
+		got := probeHealth(client, "http://127.0.0.1:1/health")
+		if got != stateDown {
+			t.Fatalf("unreachable: got %v want stateDown", got)
+		}
+	})
+
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   watchdogState
+	}{
+		{
+			name:   "gateway running only",
+			status: http.StatusOK,
+			body:   `{"gateway":{"state":"running"}}`,
+			want:   stateHealthy,
+		},
+		{
+			name:   "gateway and guardrail running",
+			status: http.StatusOK,
+			body:   `{"gateway":{"state":"running"},"guardrail":{"state":"running"}}`,
+			want:   stateHealthy,
+		},
+		{
+			name:   "guardrail error",
+			status: http.StatusOK,
+			body:   `{"gateway":{"state":"running"},"guardrail":{"state":"error"}}`,
+			want:   stateDegraded,
+		},
+		{
+			name:   "gateway starting",
+			status: http.StatusOK,
+			body:   `{"gateway":{"state":"starting"}}`,
+			want:   stateDown,
+		},
+		{
+			name:   "empty gateway state",
+			status: http.StatusOK,
+			body:   `{}`,
+			want:   stateDown,
+		},
+		{
+			name:   "invalid json",
+			status: http.StatusOK,
+			body:   `not json`,
+			want:   stateDown,
+		},
+		{
+			name:   "http 500",
+			status: http.StatusInternalServerError,
+			body:   `{"gateway":{"state":"running"}}`,
+			want:   stateDown,
+		},
+		{
+			name:   "gateway null",
+			status: http.StatusOK,
+			body:   `{"gateway":null}`,
+			want:   stateDown,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				if tc.body != "" {
+					_, _ = w.Write([]byte(tc.body))
+				}
+			}))
+			defer srv.Close()
+
+			got := probeHealth(client, srv.URL+"/health")
+			if got != tc.want {
+				t.Fatalf("got %s want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWatchdogStateTransitions(t *testing.T) {
+	var healthy atomic.Bool
+	healthy.Store(true)
+
+	var downProbes atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if healthy.Load() {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"gateway":{"state":"running"}}`))
+			return
+		}
+		downProbes.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	go func() {
+		time.Sleep(25 * time.Millisecond)
+		healthy.Store(false)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	runWatchdogLoop(ctx, srv.URL+"/health", 10*time.Millisecond, 2)
+
+	if n := downProbes.Load(); n < 2 {
+		t.Fatalf("expected at least %d probes while server returned errors after flip, got %d", 2, n)
+	}
+}
+
+func TestWatchdogHealthURL(t *testing.T) {
+	t.Run("defaults to loopback", func(t *testing.T) {
+		cfg := config.DefaultConfig()
+		got := watchdogHealthURL(cfg)
+		want := "http://127.0.0.1:18970/health"
+		if got != want {
+			t.Fatalf("watchdogHealthURL() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("uses api bind when configured", func(t *testing.T) {
+		cfg := config.DefaultConfig()
+		cfg.Gateway.APIBind = "10.0.0.8"
+		cfg.Gateway.APIPort = 19001
+		got := watchdogHealthURL(cfg)
+		want := "http://10.0.0.8:19001/health"
+		if got != want {
+			t.Fatalf("watchdogHealthURL() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("uses guardrail host in standalone mode", func(t *testing.T) {
+		cfg := config.DefaultConfig()
+		cfg.OpenShell.Mode = "standalone"
+		cfg.Guardrail.Host = "192.168.65.2"
+		got := watchdogHealthURL(cfg)
+		want := "http://192.168.65.2:18970/health"
+		if got != want {
+			t.Fatalf("watchdogHealthURL() = %q, want %q", got, want)
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -324,18 +324,19 @@ func (c *CiscoAIDefenseConfig) ResolvedAPIKey() string {
 }
 
 type GuardrailConfig struct {
-	Enabled       bool        `mapstructure:"enabled"        yaml:"enabled"`
-	Mode          string      `mapstructure:"mode"            yaml:"mode"`
-	ScannerMode   string      `mapstructure:"scanner_mode"    yaml:"scanner_mode"`
-	Host          string      `mapstructure:"host"             yaml:"host,omitempty"`
-	Port          int         `mapstructure:"port"            yaml:"port"`
-	Model         string      `mapstructure:"model"           yaml:"model"`
-	ModelName     string      `mapstructure:"model_name"      yaml:"model_name"`
-	APIKeyEnv     string      `mapstructure:"api_key_env"     yaml:"api_key_env"`
-	OriginalModel string      `mapstructure:"original_model"  yaml:"original_model"`
-	BlockMessage  string      `mapstructure:"block_message"   yaml:"block_message"`
-	APIBase       string      `mapstructure:"api_base"        yaml:"api_base"`
-	Judge         JudgeConfig `mapstructure:"judge"           yaml:"judge"`
+	Enabled           bool        `mapstructure:"enabled"              yaml:"enabled"`
+	Mode              string      `mapstructure:"mode"                 yaml:"mode"`
+	ScannerMode       string      `mapstructure:"scanner_mode"         yaml:"scanner_mode"`
+	Host              string      `mapstructure:"host"                 yaml:"host,omitempty"`
+	Port              int         `mapstructure:"port"                 yaml:"port"`
+	Model             string      `mapstructure:"model"                yaml:"model"`
+	ModelName         string      `mapstructure:"model_name"           yaml:"model_name"`
+	APIKeyEnv         string      `mapstructure:"api_key_env"          yaml:"api_key_env"`
+	OriginalModel     string      `mapstructure:"original_model"       yaml:"original_model"`
+	BlockMessage      string      `mapstructure:"block_message"        yaml:"block_message"`
+	APIBase           string      `mapstructure:"api_base"             yaml:"api_base"`
+	StreamBufferBytes int         `mapstructure:"stream_buffer_bytes"  yaml:"stream_buffer_bytes"`
+	Judge             JudgeConfig `mapstructure:"judge"                yaml:"judge"`
 }
 
 // JudgeConfig controls the LLM-as-a-Judge guardrail scanners that use
@@ -363,12 +364,13 @@ func (c *JudgeConfig) ResolvedJudgeAPIKey() string {
 
 // EffectiveHost returns the hostname clients (e.g. OpenClaw) use to reach the
 // guardrail proxy — same value written to openclaw.json baseUrl. Defaults to
-// "localhost" when not configured.
+// "127.0.0.1" when not configured so macOS IPv6-first resolution of
+// "localhost" (→ ::1) does not silently bypass the IPv4-only proxy.
 func (g *GuardrailConfig) EffectiveHost() string {
 	if g.Host != "" {
 		return g.Host
 	}
-	return "localhost"
+	return "127.0.0.1"
 }
 
 type GatewayConfig struct {
@@ -387,8 +389,17 @@ type GatewayConfig struct {
 	APIPort         int                  `mapstructure:"api_port"           yaml:"api_port"`
 	APIBind         string               `mapstructure:"api_bind"           yaml:"api_bind"`
 	Watcher         GatewayWatcherConfig `mapstructure:"watcher"            yaml:"watcher"`
+	Watchdog        WatchdogConfig       `mapstructure:"watchdog"           yaml:"watchdog"`
 	SandboxHome     string               `mapstructure:"-"                  yaml:"-"`
 	ClawHome        string               `mapstructure:"-"                  yaml:"-"`
+}
+
+// WatchdogConfig controls the health watchdog that notifies users when the
+// gateway is down and they lack protection.
+type WatchdogConfig struct {
+	Enabled  bool `mapstructure:"enabled"  yaml:"enabled"`
+	Interval int  `mapstructure:"interval" yaml:"interval"` // seconds between polls, default 30
+	Debounce int  `mapstructure:"debounce" yaml:"debounce"` // consecutive failures before alert, default 2
 }
 
 // defaultOpenClawGatewayTokenEnv matches gateway.auth.token when copied to ~/.defenseclaw/.env.
@@ -696,8 +707,9 @@ func setDefaults(dataDir string) {
 	viper.SetDefault("guardrail.enabled", false)
 	viper.SetDefault("guardrail.mode", "observe")
 	viper.SetDefault("guardrail.scanner_mode", "both")
-	viper.SetDefault("guardrail.host", "localhost")
+	viper.SetDefault("guardrail.host", "")
 	viper.SetDefault("guardrail.port", 4000)
+	viper.SetDefault("guardrail.stream_buffer_bytes", 1024)
 	viper.SetDefault("guardrail.block_message", "")
 	viper.SetDefault("guardrail.judge.enabled", false)
 	viper.SetDefault("guardrail.judge.injection", true)
@@ -723,6 +735,10 @@ func setDefaults(dataDir string) {
 	viper.SetDefault("gateway.watcher.plugin.enabled", true)
 	viper.SetDefault("gateway.watcher.plugin.take_action", true)
 	viper.SetDefault("gateway.watcher.plugin.dirs", []string{})
+
+	viper.SetDefault("gateway.watchdog.enabled", false)
+	viper.SetDefault("gateway.watchdog.interval", 30)
+	viper.SetDefault("gateway.watchdog.debounce", 2)
 
 	viper.SetDefault("otel.enabled", false)
 	viper.SetDefault("otel.protocol", "grpc")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,14 +147,15 @@ func (c *SplunkConfig) ResolvedHECToken() string {
 }
 
 type WebhookConfig struct {
-	URL            string   `mapstructure:"url"             yaml:"url"`
-	Type           string   `mapstructure:"type"            yaml:"type"`
-	SecretEnv      string   `mapstructure:"secret_env"      yaml:"secret_env"`
-	RoomID         string   `mapstructure:"room_id"         yaml:"room_id"`
-	MinSeverity    string   `mapstructure:"min_severity"    yaml:"min_severity"`
-	Events         []string `mapstructure:"events"          yaml:"events"`
-	TimeoutSeconds int      `mapstructure:"timeout_seconds" yaml:"timeout_seconds"`
-	Enabled        bool     `mapstructure:"enabled"         yaml:"enabled"`
+	URL             string   `mapstructure:"url"              yaml:"url"`
+	Type            string   `mapstructure:"type"             yaml:"type"`
+	SecretEnv       string   `mapstructure:"secret_env"       yaml:"secret_env"`
+	RoomID          string   `mapstructure:"room_id"          yaml:"room_id"`
+	MinSeverity     string   `mapstructure:"min_severity"     yaml:"min_severity"`
+	Events          []string `mapstructure:"events"           yaml:"events"`
+	TimeoutSeconds  int      `mapstructure:"timeout_seconds"  yaml:"timeout_seconds"`
+	CooldownSeconds *int     `mapstructure:"cooldown_seconds" yaml:"cooldown_seconds,omitempty"`
+	Enabled         bool     `mapstructure:"enabled"          yaml:"enabled"`
 }
 
 // ResolvedSecret returns the webhook secret/token from the env var.
@@ -299,10 +300,15 @@ type GatewayWatcherPluginConfig struct {
 	Dirs       []string `mapstructure:"dirs"           yaml:"dirs"`
 }
 
+type GatewayWatcherMCPConfig struct {
+	TakeAction bool `mapstructure:"take_action" yaml:"take_action"`
+}
+
 type GatewayWatcherConfig struct {
 	Enabled bool                       `mapstructure:"enabled" yaml:"enabled"`
 	Skill   GatewayWatcherSkillConfig  `mapstructure:"skill"   yaml:"skill"`
 	Plugin  GatewayWatcherPluginConfig `mapstructure:"plugin"  yaml:"plugin"`
+	MCP     GatewayWatcherMCPConfig    `mapstructure:"mcp"     yaml:"mcp"`
 }
 
 type CiscoAIDefenseConfig struct {
@@ -735,6 +741,7 @@ func setDefaults(dataDir string) {
 	viper.SetDefault("gateway.watcher.plugin.enabled", true)
 	viper.SetDefault("gateway.watcher.plugin.take_action", true)
 	viper.SetDefault("gateway.watcher.plugin.dirs", []string{})
+	viper.SetDefault("gateway.watcher.mcp.take_action", true)
 
 	viper.SetDefault("gateway.watchdog.enabled", false)
 	viper.SetDefault("gateway.watchdog.interval", 30)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -743,7 +743,7 @@ func setDefaults(dataDir string) {
 	viper.SetDefault("gateway.watcher.plugin.dirs", []string{})
 	viper.SetDefault("gateway.watcher.mcp.take_action", true)
 
-	viper.SetDefault("gateway.watchdog.enabled", false)
+	viper.SetDefault("gateway.watchdog.enabled", true)
 	viper.SetDefault("gateway.watchdog.interval", 30)
 	viper.SetDefault("gateway.watchdog.debounce", 2)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -175,8 +175,11 @@ func TestDefaultConfigGuardrail(t *testing.T) {
 	if cfg.Guardrail.BlockMessage != "" {
 		t.Errorf("expected empty block_message by default, got %q", cfg.Guardrail.BlockMessage)
 	}
-	if cfg.Guardrail.Host != "localhost" {
-		t.Errorf("expected default guardrail host %q, got %q", "localhost", cfg.Guardrail.Host)
+	if cfg.Guardrail.Host != "" {
+		t.Errorf("expected default guardrail host empty (Viper default), got %q", cfg.Guardrail.Host)
+	}
+	if got := cfg.Guardrail.EffectiveHost(); got != "127.0.0.1" {
+		t.Errorf("EffectiveHost() = %q, want 127.0.0.1 when host is empty", got)
 	}
 	if !cfg.Guardrail.Judge.Injection {
 		t.Error("expected judge.injection true by default")
@@ -1097,8 +1100,9 @@ func TestGuardrailConfig_EffectiveHost(t *testing.T) {
 		host string
 		want string
 	}{
-		{"", "localhost"},
+		{"", "127.0.0.1"},
 		{"localhost", "localhost"},
+		{"127.0.0.1", "127.0.0.1"},
 		{"10.200.0.1", "10.200.0.1"},
 	}
 	for _, tt := range tests {
@@ -1123,5 +1127,18 @@ func TestConfig_Save(t *testing.T) {
 	configFile := filepath.Join(tmpDir, DefaultConfigName)
 	if _, err := os.Stat(configFile); os.IsNotExist(err) {
 		t.Error("config file was not created")
+	}
+}
+
+func TestViperDefaultGuardrailHostIsEmpty(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg == nil {
+		t.Fatal("DefaultConfig() returned nil")
+	}
+	if cfg.Guardrail.Host != "" {
+		t.Fatalf("Guardrail.Host = %q, want empty string (not localhost); non-empty default breaks EffectiveHost IPv4 fallback", cfg.Guardrail.Host)
+	}
+	if got := cfg.Guardrail.EffectiveHost(); got != "127.0.0.1" {
+		t.Fatalf("EffectiveHost() = %q, want 127.0.0.1", got)
 	}
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -133,7 +133,7 @@ func DefaultConfig() *Config {
 		Guardrail: GuardrailConfig{
 			Mode:        "observe",
 			ScannerMode: "both",
-			Host:        "localhost",
+			Host:        "",
 			Port:        4000,
 			Judge: JudgeConfig{
 				Injection:     true,

--- a/internal/daemon/proc_unix.go
+++ b/internal/daemon/proc_unix.go
@@ -51,7 +51,7 @@ func processExists(pid int) bool {
 
 // killStaleProcesses finds and kills any defenseclaw-gateway processes that
 // are not tracked by the PID file. This prevents orphaned daemons from
-// accumulating across restarts.
+// accumulating across restarts. The watchdog PID is preserved.
 func (d *Daemon) killStaleProcesses() {
 	self, _ := os.Executable()
 	binName := filepath.Base(self)
@@ -69,10 +69,11 @@ func (d *Daemon) killStaleProcesses() {
 		trackedPID = info.PID
 	}
 	myPID := os.Getpid()
+	watchdogPID := d.readWatchdogPID()
 
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		pid, err := strconv.Atoi(strings.TrimSpace(line))
-		if err != nil || pid <= 0 || pid == myPID || pid == trackedPID {
+		if err != nil || pid <= 0 || pid == myPID || pid == trackedPID || pid == watchdogPID {
 			continue
 		}
 		proc, err := os.FindProcess(pid)
@@ -82,4 +83,17 @@ func (d *Daemon) killStaleProcesses() {
 		fmt.Fprintf(os.Stderr, "[daemon] killing stale gateway process (PID %d)\n", pid)
 		_ = proc.Signal(syscall.SIGTERM)
 	}
+}
+
+// readWatchdogPID reads the watchdog PID from watchdog.pid in the data dir.
+func (d *Daemon) readWatchdogPID() int {
+	data, err := os.ReadFile(filepath.Join(d.dataDir, "watchdog.pid"))
+	if err != nil {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return 0
+	}
+	return pid
 }

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -358,18 +358,27 @@ func TestRedactSecrets(t *testing.T) {
 
 func TestBlockMessage(t *testing.T) {
 	custom := blockMessage("Custom block", "prompt", "injection")
-	if custom != "Custom block" {
+	if custom != "[DefenseClaw] Custom block" {
 		t.Errorf("blockMessage with custom = %q", custom)
+	}
+	if !strings.HasPrefix(custom, "[DefenseClaw] ") {
+		t.Errorf("blockMessage should have [DefenseClaw] prefix, got %q", custom)
 	}
 
 	prompt := blockMessage("", "prompt", "test reason")
 	if !strings.Contains(prompt, "test reason") {
 		t.Errorf("blockMessage prompt should contain reason, got %q", prompt)
 	}
+	if !strings.HasPrefix(prompt, "[DefenseClaw] ") {
+		t.Errorf("blockMessage prompt should have [DefenseClaw] prefix, got %q", prompt)
+	}
 
 	completion := blockMessage("", "completion", "test reason")
 	if !strings.Contains(completion, "test reason") {
 		t.Errorf("blockMessage completion should contain reason, got %q", completion)
+	}
+	if !strings.HasPrefix(completion, "[DefenseClaw] ") {
+		t.Errorf("blockMessage completion should have [DefenseClaw] prefix, got %q", completion)
 	}
 }
 

--- a/internal/gateway/gateway_ws_test.go
+++ b/internal/gateway/gateway_ws_test.go
@@ -1582,3 +1582,83 @@ func TestHandlePluginAdmissionRejectedInstallOnlyDoesNotDisable(t *testing.T) {
 		t.Fatalf("actions = %q, should not include disabled", got)
 	}
 }
+
+func TestHandleMCPAdmissionBlocked(t *testing.T) {
+	received := make(chan receivedRequest, 5)
+	srv := startMockGW(t, rpcRecordingLoop(received))
+	client := connectToMockGW(t, srv)
+	_, logger := testStoreAndLogger(t)
+
+	s := &Sidecar{
+		cfg: &config.Config{
+			Gateway: config.GatewayConfig{
+				Watcher: config.GatewayWatcherConfig{
+					MCP: config.GatewayWatcherMCPConfig{TakeAction: true},
+				},
+			},
+		},
+		client:   client,
+		logger:   logger,
+		notify:   NewNotificationQueue(),
+		router:   &EventRouter{},
+		alertCtx: context.Background(),
+	}
+
+	s.handleAdmissionResult(watcher.AdmissionResult{
+		Event: watcher.InstallEvent{
+			Type: watcher.InstallMCP,
+			Name: "malicious-mcp-server",
+			Path: "/path/to/mcp",
+		},
+		Verdict:       watcher.VerdictBlocked,
+		Reason:        "on block list",
+		MaxSeverity:   "CRITICAL",
+		FindingCount:  2,
+		RuntimeAction: "block",
+	})
+
+	rpc := drainRPC(t, received)
+	if rpc.Method != "config.patch" {
+		t.Fatalf("expected config.patch, got %s", rpc.Method)
+	}
+
+	s.alertWg.Wait()
+	notes := s.notify.ActiveNotifications()
+	if len(notes) != 1 {
+		t.Fatalf("notification count = %d, want 1", len(notes))
+	}
+	if notes[0].SubjectType != "mcp" {
+		t.Fatalf("notification subject type = %q, want mcp", notes[0].SubjectType)
+	}
+}
+
+func TestHandleMCPAdmissionNoTakeAction(t *testing.T) {
+	_, logger := testStoreAndLogger(t)
+
+	s := &Sidecar{
+		cfg: &config.Config{
+			Gateway: config.GatewayConfig{
+				Watcher: config.GatewayWatcherConfig{
+					MCP: config.GatewayWatcherMCPConfig{TakeAction: false},
+				},
+			},
+		},
+		logger: logger,
+	}
+
+	s.handleAdmissionResult(watcher.AdmissionResult{
+		Event: watcher.InstallEvent{
+			Type: watcher.InstallMCP,
+			Name: "some-mcp",
+		},
+		Verdict: watcher.VerdictBlocked,
+		Reason:  "on block list",
+	})
+}
+
+func TestNotificationSubjectLabelMCP(t *testing.T) {
+	got := notificationSubjectLabel("mcp")
+	if got != "MCP Server" {
+		t.Fatalf("notificationSubjectLabel(\"mcp\") = %q, want \"MCP Server\"", got)
+	}
+}

--- a/internal/gateway/guardrail.go
+++ b/internal/gateway/guardrail.go
@@ -419,17 +419,17 @@ func redactSecrets(text string) string {
 // blockMessage returns the message to send when a request/response is blocked.
 func blockMessage(customMsg, direction, reason string) string {
 	if customMsg != "" {
-		return customMsg
+		return "[DefenseClaw] " + customMsg
 	}
 	if direction == "prompt" {
 		return fmt.Sprintf(
-			"I'm unable to process this request. DefenseClaw detected a "+
-				"potential security concern in the prompt (%s). "+
+			"[DefenseClaw] This request was blocked. A potential security "+
+				"concern was detected in the prompt (%s). "+
 				"If you believe this is a false positive, contact your "+
 				"administrator or adjust the guardrail policy.", reason)
 	}
 	return fmt.Sprintf(
-		"The model's response was blocked by DefenseClaw due to a "+
+		"[DefenseClaw] The model's response was blocked due to a "+
 			"potential security concern (%s). "+
 			"If you believe this is a false positive, contact your "+
 			"administrator or adjust the guardrail policy.", reason)

--- a/internal/gateway/notifications.go
+++ b/internal/gateway/notifications.go
@@ -116,6 +116,8 @@ func notificationSubjectLabel(subjectType string) string {
 	switch strings.TrimSpace(strings.ToLower(subjectType)) {
 	case "plugin":
 		return "Plugin"
+	case "mcp":
+		return "MCP Server"
 	case "tool":
 		return "Tool"
 	default:

--- a/internal/gateway/provider.go
+++ b/internal/gateway/provider.go
@@ -139,23 +139,27 @@ type ChatUsage struct {
 // RawResponse carries the original upstream bytes so the proxy can
 // forward unknown fields (system_fingerprint, service_tier, etc.) verbatim.
 type ChatResponse struct {
-	ID          string          `json:"id"`
-	Object      string          `json:"object"`
-	Created     int64           `json:"created"`
-	Model       string          `json:"model"`
-	Choices     []ChatChoice    `json:"choices"`
-	Usage       *ChatUsage      `json:"usage,omitempty"`
-	RawResponse json.RawMessage `json:"-"`
+	ID                  string          `json:"id"`
+	Object              string          `json:"object"`
+	Created             int64           `json:"created"`
+	Model               string          `json:"model"`
+	Choices             []ChatChoice    `json:"choices"`
+	Usage               *ChatUsage      `json:"usage,omitempty"`
+	DefenseClawBlocked  *bool           `json:"defenseclaw_blocked,omitempty"`
+	DefenseClawReason   string          `json:"defenseclaw_reason,omitempty"`
+	RawResponse         json.RawMessage `json:"-"`
 }
 
 // StreamChunk is one SSE chunk in OpenAI format.
 type StreamChunk struct {
-	ID      string       `json:"id"`
-	Object  string       `json:"object"`
-	Created int64        `json:"created"`
-	Model   string       `json:"model"`
-	Choices []ChatChoice `json:"choices"`
-	Usage   *ChatUsage   `json:"usage,omitempty"`
+	ID                  string       `json:"id"`
+	Object              string       `json:"object"`
+	Created             int64        `json:"created"`
+	Model               string       `json:"model"`
+	Choices             []ChatChoice `json:"choices"`
+	Usage               *ChatUsage   `json:"usage,omitempty"`
+	DefenseClawBlocked  *bool        `json:"defenseclaw_blocked,omitempty"`
+	DefenseClawReason   string       `json:"defenseclaw_reason,omitempty"`
 }
 
 // LLMProvider abstracts the upstream LLM API.

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -78,11 +78,11 @@ type GuardrailProxy struct {
 	store   *audit.Store
 	dataDir string
 
-	inspector        ContentInspector
-	masterKey        string
-	gatewayToken     string // OPENCLAW_GATEWAY_TOKEN, accepted in X-DC-Auth
-	notify           *NotificationQueue
-	webhooks         *WebhookDispatcher
+	inspector    ContentInspector
+	masterKey    string
+	gatewayToken string // OPENCLAW_GATEWAY_TOKEN, accepted in X-DC-Auth
+	notify       *NotificationQueue
+	webhooks     *WebhookDispatcher
 
 	// resolveProviderFn selects the upstream LLMProvider for a request.
 	// Defaults to resolveProviderFromHeaders (uses X-DC-Target-URL).
@@ -305,7 +305,7 @@ func (p *GuardrailProxy) handlePassthrough(w http.ResponseWriter, r *http.Reques
 		Messages     []ChatMessage   `json:"messages"`
 		System       string          `json:"system,omitempty"`
 		Instructions string          `json:"instructions,omitempty"` // Responses API system prompt
-		Input        json.RawMessage `json:"input,omitempty"`         // Responses API
+		Input        json.RawMessage `json:"input,omitempty"`        // Responses API
 		Stream       bool            `json:"stream,omitempty"`
 	}
 	_ = json.Unmarshal(body, &partial)
@@ -490,7 +490,7 @@ func (p *GuardrailProxy) handlePassthrough(w http.ResponseWriter, r *http.Reques
 		w.WriteHeader(resp.StatusCode)
 		_, _ = w.Write(respBody)
 	} else {
-		// --- Streaming: accumulate text from SSE chunks, periodic + final scan ---
+		// --- Streaming: buffer initial bytes for pre-scan, then forward with periodic scans ---
 		for k, vs := range resp.Header {
 			for _, v := range vs {
 				w.Header().Add(k, v)
@@ -503,20 +503,47 @@ func (p *GuardrailProxy) handlePassthrough(w http.ResponseWriter, r *http.Reques
 		lastScanLen := 0
 		const scanInterval = 500
 		buf := make([]byte, 4096)
-		// lineBuf accumulates partial SSE lines across read boundaries.
 		var lineBuf strings.Builder
+
+		streamBufferSize := 1024
+		if p.cfg != nil && p.cfg.StreamBufferBytes > 0 {
+			streamBufferSize = p.cfg.StreamBufferBytes
+		}
+		const maxInitialBufBytes = 1 << 20 // 1 MiB cap on passthrough initial buffer
+		var initialBuf []byte
+		initialFlushed := mode != "action"
+		preblocked := false
+		flushInitialBuf := func() bool {
+			if initialFlushed || len(initialBuf) == 0 {
+				return true
+			}
+			if accumulated.Len() > 0 {
+				initVerdict := p.inspector.Inspect(r.Context(), "completion", accumulated.String(),
+					[]ChatMessage{{Role: "assistant", Content: accumulated.String()}}, label, mode)
+				if initVerdict.Severity != "NONE" && initVerdict.Action == "block" {
+					fmt.Fprintf(os.Stderr, "[guardrail] PASSTHROUGH-STREAM-PREBLOCK severity=%s %s (blocked before any output sent to client)\n",
+						initVerdict.Severity, initVerdict.Reason)
+					p.recordTelemetry("completion", label, initVerdict, 0, nil, nil)
+					preblocked = true
+					return false
+				}
+			}
+			lastScanLen = accumulated.Len()
+			_, _ = w.Write(initialBuf)
+			if flusher != nil {
+				flusher.Flush()
+			}
+			initialBuf = nil
+			initialFlushed = true
+			return true
+		}
 
 		for {
 			n, readErr := resp.Body.Read(buf)
 			if n > 0 {
 				chunk := buf[:n]
-				// Forward the raw bytes immediately so the client isn't stalled.
-				_, _ = w.Write(chunk)
-				if flusher != nil {
-					flusher.Flush()
-				}
 
-				// Accumulate text from SSE data lines for inspection.
+				// Parse SSE text for inspection regardless of buffer state.
 				lineBuf.Write(chunk)
 				for {
 					line, rest, found := strings.Cut(lineBuf.String(), "\n")
@@ -540,21 +567,46 @@ func (p *GuardrailProxy) handlePassthrough(w http.ResponseWriter, r *http.Reques
 					}
 				}
 
-				// Periodic mid-stream scan.
-				if accumulated.Len()-lastScanLen >= scanInterval && mode == "action" {
-					midVerdict := p.inspector.Inspect(r.Context(), "completion", accumulated.String(),
-						[]ChatMessage{{Role: "assistant", Content: accumulated.String()}}, label, mode)
-					if midVerdict.Severity != "NONE" && midVerdict.Action == "block" {
-						fmt.Fprintf(os.Stderr, "[guardrail] PASSTHROUGH-STREAM-BLOCK severity=%s %s (WARNING: %d bytes already forwarded to client)\n",
-							midVerdict.Severity, midVerdict.Reason, lastScanLen+len(chunk))
-						p.recordTelemetry("completion", label, midVerdict, 0, nil, nil)
-						break // stop forwarding; client sees truncated stream
+				if !initialFlushed {
+					initialBuf = append(initialBuf, chunk...)
+					shouldFlush := accumulated.Len() >= streamBufferSize ||
+						readErr != nil ||
+						len(initialBuf) > maxInitialBufBytes
+
+					if shouldFlush {
+						if !flushInitialBuf() {
+							break
+						}
 					}
-					lastScanLen = accumulated.Len()
+				} else {
+					_, _ = w.Write(chunk)
+					if flusher != nil {
+						flusher.Flush()
+					}
+
+					if accumulated.Len()-lastScanLen >= scanInterval && mode == "action" {
+						midVerdict := p.inspector.Inspect(r.Context(), "completion", accumulated.String(),
+							[]ChatMessage{{Role: "assistant", Content: accumulated.String()}}, label, mode)
+						if midVerdict.Severity != "NONE" && midVerdict.Action == "block" {
+							fmt.Fprintf(os.Stderr, "[guardrail] PASSTHROUGH-STREAM-BLOCK severity=%s %s (WARNING: %d bytes already forwarded to client)\n",
+								midVerdict.Severity, midVerdict.Reason, lastScanLen+len(chunk))
+							p.recordTelemetry("completion", label, midVerdict, 0, nil, nil)
+							break
+						}
+						lastScanLen = accumulated.Len()
+					}
 				}
 			}
 			if readErr != nil {
 				break
+			}
+		}
+		if preblocked {
+			return
+		}
+		if !initialFlushed && len(initialBuf) > 0 {
+			if !flushInitialBuf() {
+				return
 			}
 		}
 
@@ -1248,6 +1300,15 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 	streamCtx, streamCancel := context.WithCancel(r.Context())
 	defer streamCancel()
 
+	// Initial text buffering: hold early chunks until enough text accumulates
+	// for a meaningful guardrail scan, preventing partial output leakage.
+	streamBufSize := 1024
+	if p.cfg != nil && p.cfg.StreamBufferBytes > 0 {
+		streamBufSize = p.cfg.StreamBufferBytes
+	}
+	var initialChunkBuf [][]byte
+	initialBufFlushed := mode != "action"
+
 	usage, err := upstream.ChatCompletionStream(streamCtx, req, func(chunk StreamChunk) {
 		if streamBlocked {
 			return
@@ -1262,15 +1323,12 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 				hasToolCalls = true
 			}
 		}
-		// Collect finish reasons from stream chunks.
 		for _, c := range chunk.Choices {
 			if c.FinishReason != nil && *c.FinishReason != "" {
 				streamFinishReasons = append(streamFinishReasons, *c.FinishReason)
 			}
 		}
 
-		// In action mode, inspect each newly accumulated content chunk before
-		// forwarding it so short harmful streams cannot slip past a size gate.
 		if accumulated.Len() > lastScanLen && mode == "action" {
 			midVerdict := p.inspector.Inspect(r.Context(), "completion", accumulated.String(),
 				[]ChatMessage{{Role: "assistant", Content: accumulated.String()}}, aliasModel, mode)
@@ -1287,11 +1345,6 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 
 		data, _ := json.Marshal(chunk)
 
-		// Buffer tool-call chunks and their finish sentinel so they are
-		// only released after post-stream inspection clears them.
-		// The finish_reason:"tool_calls" chunk carries no delta.ToolCalls
-		// but must stay behind the argument deltas or clients that stop
-		// accumulating on finish_reason will never see the arguments.
 		isToolCallFinish := len(chunk.Choices) > 0 && chunk.Choices[0].FinishReason != nil &&
 			*chunk.Choices[0].FinishReason == "tool_calls"
 		if mode == "action" && (hasToolCalls || isToolCallFinish || len(bufferedTCChunks) > 0) {
@@ -1306,9 +1359,31 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 			return
 		}
 
+		if !initialBufFlushed {
+			initialChunkBuf = append(initialChunkBuf, data)
+			if accumulated.Len() >= streamBufSize {
+				for _, buffered := range initialChunkBuf {
+					fmt.Fprintf(w, "data: %s\n\n", buffered)
+				}
+				flusher.Flush()
+				initialChunkBuf = nil
+				initialBufFlushed = true
+			}
+			return
+		}
+
 		fmt.Fprintf(w, "data: %s\n\n", data)
 		flusher.Flush()
 	})
+	// Flush any remaining initial buffer (short streams that completed
+	// before reaching the buffer threshold).
+	if !initialBufFlushed && !streamBlocked && len(initialChunkBuf) > 0 {
+		for _, buffered := range initialChunkBuf {
+			fmt.Fprintf(w, "data: %s\n\n", buffered)
+		}
+		flusher.Flush()
+		initialBufFlushed = true
+	}
 	if err != nil && !streamBlocked {
 		fmt.Fprintf(os.Stderr, "[guardrail] stream error: %v\n", err)
 		if p.otel != nil && llmSpan != nil {
@@ -1439,7 +1514,8 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 // ---------------------------------------------------------------------------
 
 func (p *GuardrailProxy) writeBlockedResponse(w http.ResponseWriter, model, msg string) {
-	finishReason := "stop"
+	finishReason := "content_filter"
+	blocked := true
 	resp := ChatResponse{
 		ID:      "chatcmpl-blocked",
 		Object:  "chat.completion",
@@ -1450,9 +1526,12 @@ func (p *GuardrailProxy) writeBlockedResponse(w http.ResponseWriter, model, msg 
 			Message:      &ChatMessage{Role: "assistant", Content: msg},
 			FinishReason: &finishReason,
 		}},
-		Usage: &ChatUsage{},
+		Usage:              &ChatUsage{},
+		DefenseClawBlocked: &blocked,
+		DefenseClawReason:  msg,
 	}
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-DefenseClaw-Blocked", "true")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(resp)
 }
@@ -1467,10 +1546,12 @@ func (p *GuardrailProxy) writeBlockedStream(w http.ResponseWriter, model, msg st
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-DefenseClaw-Blocked", "true")
 	w.WriteHeader(http.StatusOK)
 
 	created := time.Now().Unix()
 	id := "chatcmpl-blocked"
+	blocked := true
 
 	// Initial chunk with role.
 	role := "assistant"
@@ -1491,11 +1572,13 @@ func (p *GuardrailProxy) writeBlockedStream(w http.ResponseWriter, model, msg st
 	fmt.Fprintf(w, "data: %s\n\n", data1)
 	flusher.Flush()
 
-	// Final chunk with finish_reason.
-	fr := "stop"
+	// Final chunk with finish_reason and block metadata.
+	fr := "content_filter"
 	chunk2 := StreamChunk{
 		ID: id, Object: "chat.completion.chunk", Created: created, Model: model,
-		Choices: []ChatChoice{{Index: 0, Delta: &ChatMessage{}, FinishReason: &fr}},
+		Choices:            []ChatChoice{{Index: 0, Delta: &ChatMessage{}, FinishReason: &fr}},
+		DefenseClawBlocked: &blocked,
+		DefenseClawReason:  msg,
 	}
 	data2, _ := json.Marshal(chunk2)
 	fmt.Fprintf(w, "data: %s\n\n", data2)
@@ -1551,11 +1634,14 @@ func (p *GuardrailProxy) writeBlockedResponseGemini(w http.ResponseWriter, msg s
 				},
 				"role": "model",
 			},
-			"finishReason": "STOP",
+			"finishReason": "SAFETY",
 			"index":        0,
 		}},
+		"defenseclaw_blocked": true,
+		"defenseclaw_reason":  msg,
 	}
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-DefenseClaw-Blocked", "true")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(resp)
 }
@@ -1585,8 +1671,11 @@ func (p *GuardrailProxy) writeBlockedResponseOpenAIResponses(w http.ResponseWrit
 			"output_tokens": 1,
 			"total_tokens":  1,
 		},
+		"defenseclaw_blocked": true,
+		"defenseclaw_reason":  msg,
 	}
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-DefenseClaw-Blocked", "true")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(resp)
 }
@@ -1603,6 +1692,7 @@ func (p *GuardrailProxy) writeBlockedStreamOpenAIResponses(w http.ResponseWriter
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-DefenseClaw-Blocked", "true")
 	w.WriteHeader(http.StatusOK)
 
 	writeSSE := func(eventType string, data interface{}) {
@@ -1622,9 +1712,9 @@ func (p *GuardrailProxy) writeBlockedStreamOpenAIResponses(w http.ResponseWriter
 		},
 	})
 	writeSSE("response.output_item.added", map[string]interface{}{
-		"type":          "response.output_item.added",
-		"response_id":   respID,
-		"output_index":  0,
+		"type":         "response.output_item.added",
+		"response_id":  respID,
+		"output_index": 0,
 		"item": map[string]interface{}{
 			"id": itemID, "type": "message", "role": "assistant",
 			"status": "in_progress", "content": []interface{}{},
@@ -1699,9 +1789,12 @@ func (p *GuardrailProxy) writeBlockedResponseAnthropic(w http.ResponseWriter, mo
 		"content": []map[string]interface{}{
 			{"type": "text", "text": msg},
 		},
-		"usage": map[string]int{"input_tokens": 0, "output_tokens": 1},
+		"usage":               map[string]int{"input_tokens": 0, "output_tokens": 1},
+		"defenseclaw_blocked": true,
+		"defenseclaw_reason":  msg,
 	}
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-DefenseClaw-Blocked", "true")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(resp)
 }
@@ -1718,6 +1811,7 @@ func (p *GuardrailProxy) writeBlockedStreamAnthropic(w http.ResponseWriter, mode
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-DefenseClaw-Blocked", "true")
 	w.WriteHeader(http.StatusOK)
 
 	writeAnthropicSSE := func(eventType string, data interface{}) {

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -1510,8 +1510,8 @@ func TestHandlePassthrough_PromptBlock(t *testing.T) {
 		if resp.Candidates[0].Content.Role != "model" {
 			t.Errorf("expected role=model, got %q", resp.Candidates[0].Content.Role)
 		}
-		if resp.Candidates[0].FinishReason != "STOP" {
-			t.Errorf("expected finishReason=STOP, got %q", resp.Candidates[0].FinishReason)
+		if resp.Candidates[0].FinishReason != "SAFETY" {
+			t.Errorf("expected finishReason=SAFETY, got %q", resp.Candidates[0].FinishReason)
 		}
 	})
 
@@ -1882,5 +1882,457 @@ func TestGuardrailListenAddr(t *testing.T) {
 				t.Errorf("guardrailListenAddr(%d, %q) = %q, want %q", tt.port, tt.host, got, tt.want)
 			}
 		})
+	}
+}
+
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+func TestBlockedResponseMetadata(t *testing.T) {
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	insp.setVerdict("prompt", &ScanVerdict{
+		Action:   "block",
+		Severity: "HIGH",
+		Reason:   "policy violation",
+	})
+	proxy := newTestProxy(t, prov, insp, "action")
+
+	body := mustJSON(t, map[string]interface{}{
+		"model":    "gpt-4",
+		"messages": []map[string]interface{}{{"role": "user", "content": "blocked prompt"}},
+		"stream":   false,
+	})
+	rec := postChat(t, proxy, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp ChatResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if resp.DefenseClawBlocked == nil || !*resp.DefenseClawBlocked {
+		t.Fatalf("expected defenseclaw_blocked true, got %#v", resp.DefenseClawBlocked)
+	}
+	if resp.DefenseClawReason == "" {
+		t.Fatal("expected non-empty defenseclaw_reason")
+	}
+	if len(resp.Choices) == 0 {
+		t.Fatal("expected at least one choice")
+	}
+	if resp.Choices[0].FinishReason == nil || *resp.Choices[0].FinishReason != "content_filter" {
+		got := ""
+		if resp.Choices[0].FinishReason != nil {
+			got = *resp.Choices[0].FinishReason
+		}
+		t.Fatalf("expected finish_reason content_filter, got %q", got)
+	}
+	if resp.Choices[0].Message == nil || !strings.HasPrefix(resp.Choices[0].Message.Content, "[DefenseClaw] ") {
+		t.Fatalf("expected message prefixed with [DefenseClaw] , got %#v", resp.Choices[0].Message)
+	}
+}
+
+func TestBlockedStreamMetadata(t *testing.T) {
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	insp.setVerdict("prompt", &ScanVerdict{
+		Action:   "block",
+		Severity: "HIGH",
+		Reason:   "injection",
+	})
+	proxy := newTestProxy(t, prov, insp, "action")
+
+	body := mustJSON(t, map[string]interface{}{
+		"model":    "gpt-4",
+		"messages": []map[string]interface{}{{"role": "user", "content": "stream block"}},
+		"stream":   true,
+	})
+	rec := postChat(t, proxy, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	raw := rec.Body.String()
+	if !strings.Contains(raw, `"defenseclaw_blocked":true`) {
+		t.Fatalf("expected defenseclaw_blocked in SSE body, got: %s", raw)
+	}
+
+	chunks := parseSSEChunks(t, strings.NewReader(raw))
+	var sawContentFilter bool
+	var sawDefenseClawContent bool
+	var sawBlockedMeta bool
+	for _, rawChunk := range chunks {
+		var sc StreamChunk
+		if err := json.Unmarshal(rawChunk, &sc); err != nil {
+			continue
+		}
+		if sc.DefenseClawBlocked != nil && *sc.DefenseClawBlocked {
+			sawBlockedMeta = true
+		}
+		for _, ch := range sc.Choices {
+			if ch.FinishReason != nil && *ch.FinishReason == "content_filter" {
+				sawContentFilter = true
+			}
+			if ch.Delta != nil && strings.HasPrefix(ch.Delta.Content, "[DefenseClaw] ") {
+				sawDefenseClawContent = true
+			}
+		}
+	}
+	if !sawBlockedMeta {
+		t.Fatal("expected a chunk with defenseclaw_blocked true")
+	}
+	if !sawContentFilter {
+		t.Fatal("expected a chunk with finish_reason content_filter")
+	}
+	if !sawDefenseClawContent {
+		t.Fatal("expected chunk delta content prefixed with [DefenseClaw] ")
+	}
+}
+
+func TestStreamBufferingPassthrough(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		fl, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("upstream ResponseWriter should implement Flusher")
+		}
+		parts := []string{
+			`data: {"choices":[{"index":0,"delta":{"content":"aa"}}]}` + "\n\n",
+			`data: {"choices":[{"index":0,"delta":{"content":"bb"}}]}` + "\n\n",
+			`data: {"choices":[{"index":0,"delta":{"content":"cc"}}]}` + "\n\n",
+			`data: [DONE]` + "\n\n",
+		}
+		for _, p := range parts {
+			_, _ = w.Write([]byte(p))
+			if fl != nil {
+				fl.Flush()
+			}
+		}
+	}))
+	defer upstream.Close()
+
+	origDomains := providerDomains
+	providerDomains = append(providerDomains, struct {
+		domain string
+		name   string
+	}{"127.0.0.1", "openai"})
+	defer func() { providerDomains = origDomains }()
+
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	proxy := newTestProxy(t, prov, insp, "action")
+	proxy.cfg.StreamBufferBytes = 2
+
+	body := mustJSON(t, map[string]interface{}{
+		"model":    "gpt-4",
+		"messages": []map[string]interface{}{{"role": "user", "content": "hello"}},
+		"stream":   true,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/passthrough-stream", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-DC-Target-URL", upstream.URL)
+	req.Header.Set("X-AI-Auth", "Bearer sk-test-upstream")
+	req.RemoteAddr = "127.0.0.1:12345"
+	rec := httptest.NewRecorder()
+
+	proxy.handlePassthrough(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	ct := rec.Header().Get("Content-Type")
+	if !strings.Contains(ct, "text/event-stream") {
+		t.Fatalf("expected Content-Type to preserve text/event-stream, got %q", ct)
+	}
+	out := rec.Body.String()
+	for _, want := range []string{"aa", "bb", "cc"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("response missing upstream chunk %q; body=%q", want, out)
+		}
+	}
+}
+
+func TestStreamBufferingBlock(t *testing.T) {
+	const leakToken = "UPSTREAM_SECRET_LEAK_99"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fl, _ := w.(http.Flusher)
+		sse := `data: {"choices":[{"index":0,"delta":{"content":"` + leakToken + `"}}]}` + "\n\n"
+		_, _ = w.Write([]byte(sse))
+		if fl != nil {
+			fl.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	origDomains := providerDomains
+	providerDomains = append(providerDomains, struct {
+		domain string
+		name   string
+	}{"127.0.0.1", "openai"})
+	defer func() { providerDomains = origDomains }()
+
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	insp.setVerdict("completion", &ScanVerdict{
+		Action:   "block",
+		Severity: "CRITICAL",
+		Reason:   "unsafe completion",
+	})
+	proxy := newTestProxy(t, prov, insp, "action")
+	proxy.cfg.StreamBufferBytes = 4
+
+	body := mustJSON(t, map[string]interface{}{
+		"model":    "gpt-4",
+		"messages": []map[string]interface{}{{"role": "user", "content": "prompt"}},
+		"stream":   true,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/passthrough-stream-block", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-DC-Target-URL", upstream.URL)
+	req.Header.Set("X-AI-Auth", "Bearer sk-test-upstream")
+	req.RemoteAddr = "127.0.0.1:12345"
+	rec := httptest.NewRecorder()
+
+	proxy.handlePassthrough(rec, req)
+
+	if strings.Contains(rec.Body.String(), leakToken) {
+		t.Fatalf("blocked stream leaked upstream body: %s", rec.Body.String())
+	}
+}
+
+func TestStreamBufferingPassthroughFlushesBufferedEOF(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		fl, _ := w.(http.Flusher)
+		parts := []string{
+			`data: {"choices":[{"index":0,"delta":{"content":"ok"}}]}` + "\n\n",
+			`data: [DONE]` + "\n\n",
+		}
+		for _, p := range parts {
+			_, _ = w.Write([]byte(p))
+			if fl != nil {
+				fl.Flush()
+			}
+		}
+	}))
+	defer upstream.Close()
+
+	origDomains := providerDomains
+	providerDomains = append(providerDomains, struct {
+		domain string
+		name   string
+	}{"127.0.0.1", "openai"})
+	defer func() { providerDomains = origDomains }()
+
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	proxy := newTestProxy(t, prov, insp, "action")
+	proxy.cfg.StreamBufferBytes = 1024
+
+	body := mustJSON(t, map[string]interface{}{
+		"model":    "gpt-4",
+		"messages": []map[string]interface{}{{"role": "user", "content": "hello"}},
+		"stream":   true,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/passthrough-stream-short", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-DC-Target-URL", upstream.URL)
+	req.Header.Set("X-AI-Auth", "Bearer sk-test-upstream")
+	req.RemoteAddr = "127.0.0.1:12345"
+	rec := httptest.NewRecorder()
+
+	proxy.handlePassthrough(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"content":"ok"`) {
+		t.Fatalf("expected buffered SSE body to be flushed on EOF, got %q", rec.Body.String())
+	}
+}
+
+func TestBlockedResponseAnthropicMetadata(t *testing.T) {
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	insp.setVerdict("prompt", &ScanVerdict{
+		Action:   "block",
+		Severity: "HIGH",
+		Reason:   "anthropic block test",
+	})
+	proxy := newTestProxy(t, prov, insp, "action")
+
+	body := mustJSON(t, map[string]interface{}{
+		"model":    "claude-3-opus",
+		"messages": []map[string]interface{}{{"role": "user", "content": "bad"}},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-DC-Target-URL", "https://api.anthropic.com")
+	req.Header.Set("X-AI-Auth", "Bearer sk-ant-test")
+	req.RemoteAddr = "127.0.0.1:12345"
+	rec := httptest.NewRecorder()
+
+	proxy.handlePassthrough(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		DefenseClawBlocked bool   `json:"defenseclaw_blocked"`
+		DefenseClawReason  string `json:"defenseclaw_reason"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if !resp.DefenseClawBlocked {
+		t.Fatal("expected defenseclaw_blocked true")
+	}
+	if resp.DefenseClawReason == "" {
+		t.Fatal("expected non-empty defenseclaw_reason")
+	}
+}
+
+func TestBlockedResponseGeminiMetadata(t *testing.T) {
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	insp.setVerdict("prompt", &ScanVerdict{
+		Action:   "block",
+		Severity: "HIGH",
+		Reason:   "gemini block test",
+	})
+	proxy := newTestProxy(t, prov, insp, "action")
+
+	body := mustJSON(t, map[string]interface{}{
+		"model":    "gemini-2.5-pro",
+		"messages": []map[string]interface{}{{"role": "user", "content": "bad"}},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:generateContent", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-DC-Target-URL", "https://generativelanguage.googleapis.com")
+	req.Header.Set("X-AI-Auth", "Bearer fake-google-key")
+	req.RemoteAddr = "127.0.0.1:12345"
+	rec := httptest.NewRecorder()
+
+	proxy.handlePassthrough(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		DefenseClawBlocked bool `json:"defenseclaw_blocked"`
+		Candidates         []struct {
+			FinishReason string `json:"finishReason"`
+		} `json:"candidates"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if !resp.DefenseClawBlocked {
+		t.Fatal("expected defenseclaw_blocked true")
+	}
+	if len(resp.Candidates) == 0 {
+		t.Fatal("expected candidates")
+	}
+	if resp.Candidates[0].FinishReason != "SAFETY" {
+		t.Fatalf("expected finishReason SAFETY, got %q", resp.Candidates[0].FinishReason)
+	}
+}
+
+func TestBlockedResponseHeader(t *testing.T) {
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	insp.setVerdict("prompt", &ScanVerdict{
+		Action:   "block",
+		Severity: "HIGH",
+		Reason:   "header test",
+	})
+	proxy := newTestProxy(t, prov, insp, "action")
+
+	body := mustJSON(t, map[string]interface{}{
+		"model":    "gpt-4",
+		"messages": []map[string]interface{}{{"role": "user", "content": "blocked"}},
+		"stream":   false,
+	})
+	rec := postChat(t, proxy, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("X-DefenseClaw-Blocked"); got != "true" {
+		t.Fatalf("X-DefenseClaw-Blocked = %q, want true", got)
+	}
+}
+
+func TestBlockedResponseHeaderAnthropic(t *testing.T) {
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	insp.setVerdict("prompt", &ScanVerdict{
+		Action:   "block",
+		Severity: "HIGH",
+		Reason:   "header test",
+	})
+	proxy := newTestProxy(t, prov, insp, "action")
+
+	body := mustJSON(t, map[string]interface{}{
+		"model":    "claude-opus-4-5",
+		"messages": []map[string]interface{}{{"role": "user", "content": "blocked"}},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-DC-Target-URL", "https://api.anthropic.com")
+	req.Header.Set("X-AI-Auth", "Bearer key")
+	req.RemoteAddr = "127.0.0.1:12345"
+	rec := httptest.NewRecorder()
+
+	proxy.handlePassthrough(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("X-DefenseClaw-Blocked"); got != "true" {
+		t.Fatalf("X-DefenseClaw-Blocked = %q, want true", got)
+	}
+}
+
+func TestBlockedResponseHeaderGemini(t *testing.T) {
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	insp.setVerdict("prompt", &ScanVerdict{
+		Action:   "block",
+		Severity: "HIGH",
+		Reason:   "header test",
+	})
+	proxy := newTestProxy(t, prov, insp, "action")
+
+	body := mustJSON(t, map[string]interface{}{
+		"model":    "gemini-2.5-pro",
+		"messages": []map[string]interface{}{{"role": "user", "content": "blocked"}},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:generateContent", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-DC-Target-URL", "https://generativelanguage.googleapis.com")
+	req.Header.Set("X-AI-Auth", "Bearer key")
+	req.RemoteAddr = "127.0.0.1:12345"
+	rec := httptest.NewRecorder()
+
+	proxy.handlePassthrough(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("X-DefenseClaw-Blocked"); got != "true" {
+		t.Fatalf("X-DefenseClaw-Blocked = %q, want true", got)
 	}
 }

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -132,6 +132,11 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		fmt.Fprintf(os.Stderr, "[sidecar]          Set guardrail.model in ~/.defenseclaw/config.yaml only if you need a fixed advertised model name.\n")
 	}
 
+	if strings.EqualFold(s.cfg.Guardrail.Host, "localhost") {
+		fmt.Fprintf(os.Stderr, "[sidecar] WARNING: guardrail.host is set to \"localhost\" which may resolve to IPv6 (::1) on macOS.\n")
+		fmt.Fprintf(os.Stderr, "[sidecar]          The proxy binds 127.0.0.1 only. Set guardrail.host to \"127.0.0.1\" to avoid silent connection failures.\n")
+	}
+
 	// Initialize OPA engine before goroutines so both the watcher and the
 	// API reload handler share the same instance.
 	if s.cfg.PolicyDir != "" {

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -324,6 +324,7 @@ func (s *Sidecar) runWatcher(ctx context.Context) error {
 		"plugin_dirs":        len(pluginDirs),
 		"skill_take_action":  wcfg.Skill.TakeAction,
 		"plugin_take_action": wcfg.Plugin.TakeAction,
+		"mcp_take_action":    wcfg.MCP.TakeAction,
 	})
 
 	w := watcher.New(s.cfg, skillDirs, pluginDirs, s.store, s.logger, s.shell, s.opa, s.otel, func(r watcher.AdmissionResult) {
@@ -344,6 +345,7 @@ func (s *Sidecar) runWatcher(ctx context.Context) error {
 		"plugin_dirs":        len(pluginDirs),
 		"skill_take_action":  wcfg.Skill.TakeAction,
 		"plugin_take_action": wcfg.Plugin.TakeAction,
+		"mcp_take_action":    wcfg.MCP.TakeAction,
 	})
 
 	err := w.Run(ctx)
@@ -366,6 +368,8 @@ func (s *Sidecar) handleAdmissionResult(r watcher.AdmissionResult) {
 		s.handleSkillAdmission(r)
 	case watcher.InstallPlugin:
 		s.handlePluginAdmission(r)
+	case watcher.InstallMCP:
+		s.handleMCPAdmission(r)
 	default:
 		if s.logger != nil {
 			_ = s.logger.LogAction("sidecar-watcher-verdict", r.Event.Name,
@@ -392,7 +396,7 @@ func (s *Sidecar) handleSkillAdmission(r watcher.AdmissionResult) {
 		actions = append(actions, "blocked")
 	}
 
-	if shouldDisableAtGateway(r) {
+	if shouldDisableAtGateway(r) && s.client != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
@@ -518,7 +522,7 @@ func (s *Sidecar) handlePluginAdmission(r watcher.AdmissionResult) {
 		actions = append(actions, "blocked")
 	}
 
-	if shouldDisableAtGateway(r) {
+	if shouldDisableAtGateway(r) && s.client != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
@@ -537,6 +541,46 @@ func (s *Sidecar) handlePluginAdmission(r watcher.AdmissionResult) {
 	go func() {
 		defer s.alertWg.Done()
 		s.sendEnforcementAlert("plugin", r.Event.Name, r.MaxSeverity, r.FindingCount, actions, r.Reason)
+	}()
+}
+
+func (s *Sidecar) handleMCPAdmission(r watcher.AdmissionResult) {
+	if !s.cfg.Gateway.Watcher.MCP.TakeAction {
+		fmt.Fprintf(os.Stderr, "[sidecar] watcher: mcp %s verdict=%s (take_action=false, logging only)\n",
+			r.Event.Name, r.Verdict)
+		_ = s.logger.LogAction("sidecar-watcher-verdict", r.Event.Name,
+			fmt.Sprintf("verdict=%s (mcp take_action disabled, no gateway action)", r.Verdict))
+		return
+	}
+
+	var actions []string
+
+	if r.FileAction == "quarantine" {
+		actions = append(actions, "quarantined")
+	}
+	if r.Verdict == watcher.VerdictBlocked || r.InstallAction == "block" {
+		actions = append(actions, "blocked")
+	}
+
+	if shouldDisableAtGateway(r) && s.client != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if err := s.client.BlockMCPServer(ctx, r.Event.Name); err != nil {
+			fmt.Fprintf(os.Stderr, "[sidecar] watcher→gateway block MCP %s failed: %v\n",
+				r.Event.Name, err)
+		} else {
+			actions = append(actions, "disabled")
+			fmt.Fprintf(os.Stderr, "[sidecar] watcher→gateway blocked MCP %s\n", r.Event.Name)
+			_ = s.logger.LogAction("sidecar-watcher-block-mcp", r.Event.Name,
+				fmt.Sprintf("auto-blocked MCP server via gateway after verdict=%s", r.Verdict))
+		}
+	}
+
+	s.alertWg.Add(1)
+	go func() {
+		defer s.alertWg.Done()
+		s.sendEnforcementAlert("mcp", r.Event.Name, r.MaxSeverity, r.FindingCount, actions, r.Reason)
 	}()
 }
 

--- a/internal/gateway/webhook.go
+++ b/internal/gateway/webhook.go
@@ -61,6 +61,9 @@ type webhookEndpoint struct {
 	timeout     time.Duration
 	minSeverity int
 	events      map[string]bool
+	cooldown    time.Duration
+	mu          sync.Mutex
+	lastSent    map[string]time.Time // key: "target\x00action"
 }
 
 const (
@@ -68,6 +71,7 @@ const (
 	webhookRetryBackoff    = 2 * time.Second
 	webhookMaxConcurrency  = 20
 	webhookDefaultTimeout  = 10 * time.Second
+	webhookDefaultCooldown = 300 * time.Second // 5 minutes
 )
 
 // NewWebhookDispatcher creates a dispatcher from the config slice.
@@ -91,6 +95,15 @@ func NewWebhookDispatcher(cfgs []config.WebhookConfig) *WebhookDispatcher {
 		if timeout <= 0 {
 			timeout = webhookDefaultTimeout
 		}
+		var cooldown time.Duration
+		switch {
+		case c.CooldownSeconds == nil:
+			cooldown = webhookDefaultCooldown
+		case *c.CooldownSeconds <= 0:
+			cooldown = 0
+		default:
+			cooldown = time.Duration(*c.CooldownSeconds) * time.Second
+		}
 		endpoints = append(endpoints, webhookEndpoint{
 			url:         c.URL,
 			channelType: strings.ToLower(c.Type),
@@ -99,6 +112,8 @@ func NewWebhookDispatcher(cfgs []config.WebhookConfig) *WebhookDispatcher {
 			minSeverity: audit.SeverityRank(c.MinSeverity),
 			events:      evts,
 			timeout:     timeout,
+			cooldown:    cooldown,
+			lastSent:    make(map[string]time.Time),
 		})
 	}
 	if len(endpoints) == 0 {
@@ -138,13 +153,23 @@ func (d *WebhookDispatcher) Dispatch(event audit.Event) {
 		if len(ep.events) > 0 && !ep.events[eventCategory] {
 			continue
 		}
+		cooldownKey := event.Target + "\x00" + action
+		if !ep.claimSlot(cooldownKey) {
+			d.logger.Printf("suppressed duplicate %s/%s for %s (cooldown %s)",
+				event.Target, action, ep.url, ep.cooldown)
+			continue
+		}
 		d.wg.Add(1)
-		go func(ep *webhookEndpoint) {
+		go func(ep *webhookEndpoint, key string) {
 			defer d.wg.Done()
 			d.sem <- struct{}{}
 			defer func() { <-d.sem }()
-			d.send(ep, event)
-		}(ep)
+			if d.send(ep, event) {
+				ep.confirmSent(key)
+			} else {
+				ep.releaseSlot(key)
+			}
+		}(ep, cooldownKey)
 	}
 }
 
@@ -172,7 +197,54 @@ func (d *WebhookDispatcher) closing() bool {
 	}
 }
 
-func (d *WebhookDispatcher) send(ep *webhookEndpoint, event audit.Event) {
+// claimSlot atomically checks the cooldown and reserves the slot so
+// concurrent dispatches for the same key are suppressed. Returns false
+// if the key is already within its cooldown window.
+func (ep *webhookEndpoint) claimSlot(key string) bool {
+	if ep.cooldown <= 0 {
+		return true
+	}
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
+	if last, ok := ep.lastSent[key]; ok && time.Since(last) < ep.cooldown {
+		return false
+	}
+	ep.lastSent[key] = time.Now()
+	return true
+}
+
+// confirmSent refreshes the cooldown timestamp to the actual delivery
+// time and lazily prunes stale entries.
+func (ep *webhookEndpoint) confirmSent(key string) {
+	if ep.cooldown <= 0 {
+		return
+	}
+	now := time.Now()
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
+	ep.lastSent[key] = now
+	if len(ep.lastSent) > 64 {
+		pruneThreshold := 2 * ep.cooldown
+		for k, ts := range ep.lastSent {
+			if now.Sub(ts) > pruneThreshold {
+				delete(ep.lastSent, k)
+			}
+		}
+	}
+}
+
+// releaseSlot removes the cooldown claim when delivery fails, allowing
+// future dispatch attempts for the same key.
+func (ep *webhookEndpoint) releaseSlot(key string) {
+	if ep.cooldown <= 0 {
+		return
+	}
+	ep.mu.Lock()
+	defer ep.mu.Unlock()
+	delete(ep.lastSent, key)
+}
+
+func (d *WebhookDispatcher) send(ep *webhookEndpoint, event audit.Event) bool {
 	var payload []byte
 	var err error
 
@@ -188,7 +260,7 @@ func (d *WebhookDispatcher) send(ep *webhookEndpoint, event audit.Event) {
 	}
 	if err != nil {
 		d.logger.Printf("format error for %s: %v", ep.url, err)
-		return
+		return false
 	}
 
 	for attempt := 0; attempt <= webhookMaxRetries; attempt++ {
@@ -202,7 +274,7 @@ func (d *WebhookDispatcher) send(ep *webhookEndpoint, event audit.Event) {
 		if reqErr != nil {
 			cancel()
 			d.logger.Printf("request error for %s: %v", ep.url, reqErr)
-			return
+			return false
 		}
 		req.Header.Set("Content-Type", "application/json")
 		d.setAuthHeaders(req, ep, payload)
@@ -222,13 +294,13 @@ func (d *WebhookDispatcher) send(ep *webhookEndpoint, event audit.Event) {
 				d.logger.Printf("sent to %s (status=%d action=%s severity=%s)",
 					ep.url, resp.StatusCode, event.Action, event.Severity)
 			}
-			return
+			return true
 		}
 
 		if !isRetryable(resp.StatusCode) {
 			d.logger.Printf("%s returned %d (permanent failure), not retrying",
 				ep.url, resp.StatusCode)
-			return
+			return false
 		}
 
 		if resp.StatusCode == 429 {
@@ -244,6 +316,7 @@ func (d *WebhookDispatcher) send(ep *webhookEndpoint, event audit.Event) {
 			ep.url, resp.StatusCode, attempt+1, webhookMaxRetries+1)
 	}
 	d.logger.Printf("exhausted retries for %s", ep.url)
+	return false
 }
 
 // setAuthHeaders applies authentication and payload signing per channel type.
@@ -459,20 +532,25 @@ func formatWebexPayload(event audit.Event, roomID string) ([]byte, error) {
 }
 
 func formatGenericPayload(event audit.Event) ([]byte, error) {
+	eventData := map[string]interface{}{
+		"id":        event.ID,
+		"timestamp": event.Timestamp.Format(time.RFC3339),
+		"action":    event.Action,
+		"target":    event.Target,
+		"actor":     event.Actor,
+		"details":   event.Details,
+		"severity":  event.Severity,
+		"run_id":    event.RunID,
+		"trace_id":  event.TraceID,
+	}
+	if strings.Contains(strings.ToLower(event.Action), "block") {
+		eventData["defenseclaw_blocked"] = true
+		eventData["defenseclaw_reason"] = event.Details
+	}
 	payload := map[string]interface{}{
 		"webhook_type":        "defenseclaw_enforcement",
 		"defenseclaw_version": "1.0",
-		"event": map[string]interface{}{
-			"id":        event.ID,
-			"timestamp": event.Timestamp.Format(time.RFC3339),
-			"action":    event.Action,
-			"target":    event.Target,
-			"actor":     event.Actor,
-			"details":   event.Details,
-			"severity":  event.Severity,
-			"run_id":    event.RunID,
-			"trace_id":  event.TraceID,
-		},
+		"event":               eventData,
 	}
 	return json.Marshal(payload)
 }
@@ -513,6 +591,10 @@ func webexSeverityIcon(severity string) string {
 
 func categorizeAction(action string) string {
 	switch {
+	case strings.Contains(action, "gateway-down"),
+		strings.Contains(action, "gateway-recovered"),
+		strings.Contains(action, "guardrail-degraded"):
+		return "health"
 	case strings.Contains(action, "guardrail"):
 		return "guardrail"
 	case strings.Contains(action, "drift"),

--- a/internal/gateway/webhook_e2e_test.go
+++ b/internal/gateway/webhook_e2e_test.go
@@ -519,7 +519,7 @@ func TestWebhookE2E_ConcurrentDispatch(t *testing.T) {
 	defer receiver.Close()
 
 	d := newTestDispatcher([]config.WebhookConfig{
-		{URL: receiver.URL(), Type: "generic", MinSeverity: "INFO", Enabled: true},
+		{URL: receiver.URL(), Type: "generic", MinSeverity: "INFO", Enabled: true, CooldownSeconds: intPtr(0)},
 	})
 
 	const numEvents = 50

--- a/internal/gateway/webhook_test.go
+++ b/internal/gateway/webhook_test.go
@@ -293,12 +293,66 @@ func TestCategorizeAction(t *testing.T) {
 		{"guardrail-inspection", "guardrail"},
 		{"scan", "scan"},
 		{"init", "init"},
+		{"gateway-down", "health"},
+		{"gateway-recovered", "health"},
+		{"guardrail-degraded", "health"},
 	}
 	for _, tt := range tests {
 		got := categorizeAction(tt.action)
 		if got != tt.expected {
 			t.Errorf("categorizeAction(%q) = %q, want %q", tt.action, got, tt.expected)
 		}
+	}
+}
+
+func TestFormatGenericPayloadBlockMetadata(t *testing.T) {
+	evt := audit.Event{
+		ID:        "evt-block-001",
+		Timestamp: time.Date(2026, 4, 13, 12, 0, 0, 0, time.UTC),
+		Action:    "guardrail-block",
+		Target:    "gpt-4",
+		Actor:     "defenseclaw-guardrail",
+		Details:   "prompt injection detected",
+		Severity:  "HIGH",
+	}
+	payload, err := formatGenericPayload(evt)
+	if err != nil {
+		t.Fatalf("formatGenericPayload error: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(payload, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	evtData := m["event"].(map[string]interface{})
+	if evtData["defenseclaw_blocked"] != true {
+		t.Errorf("expected defenseclaw_blocked=true for block action, got %v", evtData["defenseclaw_blocked"])
+	}
+	if evtData["defenseclaw_reason"] != "prompt injection detected" {
+		t.Errorf("expected defenseclaw_reason, got %v", evtData["defenseclaw_reason"])
+	}
+}
+
+func TestFormatGenericPayloadNonBlockOmitsMetadata(t *testing.T) {
+	evt := audit.Event{
+		ID:        "evt-drift-001",
+		Timestamp: time.Date(2026, 4, 13, 12, 0, 0, 0, time.UTC),
+		Action:    "drift",
+		Target:    "/path/to/skill",
+		Actor:     "defenseclaw-rescan",
+		Details:   "hash changed",
+		Severity:  "MEDIUM",
+	}
+	payload, err := formatGenericPayload(evt)
+	if err != nil {
+		t.Fatalf("formatGenericPayload error: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(payload, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	evtData := m["event"].(map[string]interface{})
+	if _, ok := evtData["defenseclaw_blocked"]; ok {
+		t.Error("drift event should not include defenseclaw_blocked field")
 	}
 }
 
@@ -690,5 +744,206 @@ func TestComputeHMAC(t *testing.T) {
 
 	if got != want {
 		t.Errorf("computeHMAC mismatch: got %q, want %q", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Cooldown suppression tests
+// ---------------------------------------------------------------------------
+
+func cooldownCollector(t *testing.T) (*httptest.Server, *int32) {
+	t.Helper()
+	var count int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&count, 1)
+		w.WriteHeader(200)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &count
+}
+
+func cooldownDispatcher(t *testing.T, url string, cooldownSec *int) *WebhookDispatcher {
+	t.Helper()
+	t.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
+	d := NewWebhookDispatcher([]config.WebhookConfig{
+		{URL: url, Type: "generic", Enabled: true, CooldownSeconds: cooldownSec},
+	})
+	if d != nil {
+		d.retryBackoff = 0
+	}
+	return d
+}
+
+func TestCooldownSuppressesDuplicate(t *testing.T) {
+	srv, count := cooldownCollector(t)
+	d := cooldownDispatcher(t, srv.URL, intPtr(60))
+
+	evt := testEvent()
+	d.Dispatch(evt)
+	d.Dispatch(evt) // same target + category, should be suppressed
+	d.Close()
+
+	if got := atomic.LoadInt32(count); got != 1 {
+		t.Fatalf("expected 1 delivery (duplicate suppressed), got %d", got)
+	}
+}
+
+func TestCooldownAllowsAfterExpiry(t *testing.T) {
+	srv, count := cooldownCollector(t)
+	d := cooldownDispatcher(t, srv.URL, intPtr(1))
+
+	evt := testEvent()
+	d.Dispatch(evt)
+	d.wg.Wait()
+
+	time.Sleep(1100 * time.Millisecond)
+
+	d.Dispatch(evt)
+	d.Close()
+
+	if got := atomic.LoadInt32(count); got != 2 {
+		t.Fatalf("expected 2 deliveries (cooldown expired), got %d", got)
+	}
+}
+
+func TestCooldownZeroDisabled(t *testing.T) {
+	srv, count := cooldownCollector(t)
+	d := cooldownDispatcher(t, srv.URL, intPtr(0)) // explicit 0 → disabled
+
+	evt := testEvent()
+	d.Dispatch(evt)
+	d.Dispatch(evt)
+	d.Close()
+
+	if got := atomic.LoadInt32(count); got != 2 {
+		t.Fatalf("expected 2 deliveries (cooldown disabled), got %d", got)
+	}
+}
+
+func TestCooldownDifferentTargets(t *testing.T) {
+	srv, count := cooldownCollector(t)
+	d := cooldownDispatcher(t, srv.URL, intPtr(60))
+
+	evt1 := testEvent()
+	evt1.Target = "skill-a"
+	evt2 := testEvent()
+	evt2.Target = "skill-b"
+
+	d.Dispatch(evt1)
+	d.Dispatch(evt2)
+	d.Close()
+
+	if got := atomic.LoadInt32(count); got != 2 {
+		t.Fatalf("expected 2 deliveries (different targets), got %d", got)
+	}
+}
+
+func TestCooldownDifferentActions(t *testing.T) {
+	srv, count := cooldownCollector(t)
+	d := cooldownDispatcher(t, srv.URL, intPtr(60))
+
+	evt1 := testEvent()
+	evt1.Action = "block"
+	evt2 := testEvent()
+	evt2.Action = "drift"
+
+	d.Dispatch(evt1)
+	d.Dispatch(evt2)
+	d.Close()
+
+	if got := atomic.LoadInt32(count); got != 2 {
+		t.Fatalf("expected 2 deliveries (different categories), got %d", got)
+	}
+}
+
+func TestCooldownPerEndpoint(t *testing.T) {
+	srv1, count1 := cooldownCollector(t)
+	srv2, count2 := cooldownCollector(t)
+	t.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
+
+	d := NewWebhookDispatcher([]config.WebhookConfig{
+		{URL: srv1.URL, Type: "generic", Enabled: true, CooldownSeconds: intPtr(60)},
+		{URL: srv2.URL, Type: "generic", Enabled: true, CooldownSeconds: intPtr(0)}, // disabled
+	})
+	d.retryBackoff = 0
+
+	evt := testEvent()
+	d.Dispatch(evt)
+	d.Dispatch(evt)
+	d.Close()
+
+	if got := atomic.LoadInt32(count1); got != 1 {
+		t.Fatalf("endpoint 1: expected 1 delivery (cooldown active), got %d", got)
+	}
+	if got := atomic.LoadInt32(count2); got != 2 {
+		t.Fatalf("endpoint 2: expected 2 deliveries (cooldown disabled), got %d", got)
+	}
+}
+
+func TestCooldownNilDefaultsTo300(t *testing.T) {
+	t.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
+	d := NewWebhookDispatcher([]config.WebhookConfig{
+		{URL: "http://127.0.0.1:19999", Type: "generic", Enabled: true},
+	})
+	if d == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	ep := &d.endpoints[0]
+	if ep.cooldown != 300*time.Second {
+		t.Errorf("expected 300s default cooldown, got %v", ep.cooldown)
+	}
+}
+
+func TestCooldownHealthTransitionsNotSuppressed(t *testing.T) {
+	srv, count := cooldownCollector(t)
+	d := cooldownDispatcher(t, srv.URL, intPtr(60))
+
+	down := audit.Event{
+		ID: "h-1", Timestamp: time.Now(), Action: "gateway-down",
+		Target: "defenseclaw-gw", Severity: "CRITICAL", Actor: "watchdog",
+	}
+	recovered := audit.Event{
+		ID: "h-2", Timestamp: time.Now(), Action: "gateway-recovered",
+		Target: "defenseclaw-gw", Severity: "INFO", Actor: "watchdog",
+	}
+
+	d.Dispatch(down)
+	d.Dispatch(recovered)
+	d.Close()
+
+	if got := atomic.LoadInt32(count); got != 2 {
+		t.Fatalf("expected 2 deliveries (different actions), got %d", got)
+	}
+}
+
+func TestCooldownNotBurnedOnFailedSend(t *testing.T) {
+	t.Setenv("DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST", "1")
+
+	var batches int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&batches, 1)
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+
+	d := NewWebhookDispatcher([]config.WebhookConfig{
+		{URL: srv.URL, Type: "generic", Enabled: true, CooldownSeconds: intPtr(60)},
+	})
+	d.retryBackoff = 1 * time.Millisecond
+
+	evt := testEvent()
+
+	d.Dispatch(evt)
+	d.wg.Wait()
+
+	// First dispatch exhausted all retries and failed. The cooldown slot
+	// should have been released, so the second dispatch must attempt delivery.
+	d.Dispatch(evt)
+	d.Close()
+
+	got := atomic.LoadInt32(&batches)
+	// 4 retries per dispatch × 2 dispatches = 8 total HTTP attempts
+	if got != 8 {
+		t.Fatalf("expected 8 HTTP attempts (2 full retry cycles), got %d", got)
 	}
 }

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package notify provides cross-platform desktop notification support
+// for the DefenseClaw watchdog.
+package notify
+
+import "fmt"
+
+// Send sends a desktop notification with the given title and message.
+// It uses the platform-native notification mechanism (osascript on macOS,
+// notify-send on Linux) and falls back to stderr on unsupported platforms.
+func Send(title, message string) error {
+	if err := sendPlatform(title, message); err != nil {
+		fmt.Fprintf(fallbackWriter, "[defenseclaw-watchdog] %s: %s\n", title, message)
+		return err
+	}
+	return nil
+}

--- a/internal/notify/notify_darwin.go
+++ b/internal/notify/notify_darwin.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin
+
+package notify
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+)
+
+var fallbackWriter io.Writer = os.Stderr
+
+func sendPlatform(title, message string) error {
+	// Use JSON encoding to safely escape all special characters (quotes,
+	// backslashes, newlines) for embedding in the AppleScript string literal.
+	// json.Marshal produces a quoted string with all metacharacters escaped;
+	// we use it directly as an AppleScript string value.
+	safeMsg, _ := json.Marshal(message)
+	safeTitle, _ := json.Marshal(title)
+	script := `display notification ` + string(safeMsg) + ` with title ` + string(safeTitle)
+	return exec.Command("osascript", "-e", script).Run()
+}

--- a/internal/notify/notify_linux.go
+++ b/internal/notify/notify_linux.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package notify
+
+import (
+	"io"
+	"os"
+	"os/exec"
+)
+
+var fallbackWriter io.Writer = os.Stderr
+
+func sendPlatform(title, message string) error {
+	path, err := exec.LookPath("notify-send")
+	if err != nil {
+		return err
+	}
+	return exec.Command(path, title, message).Run()
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin || linux
+
+package notify
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestSendDoesNotPanic(t *testing.T) {
+	// Send may or may not succeed depending on OS capabilities,
+	// but it must never panic.
+	err := Send("Test", "test message")
+	_ = err // OK to fail (e.g. no display server in CI)
+}
+
+func TestFallbackWriter(t *testing.T) {
+	var buf bytes.Buffer
+	old := fallbackWriter
+	fallbackWriter = &buf
+	defer func() { fallbackWriter = old }()
+
+	err := Send("", "")
+	if err != nil && !strings.Contains(buf.String(), "[defenseclaw-watchdog]") {
+		t.Fatalf("expected fallback line when send fails, got buf=%q err=%v", buf.String(), err)
+	}
+}

--- a/internal/watcher/drift_e2e_test.go
+++ b/internal/watcher/drift_e2e_test.go
@@ -134,7 +134,7 @@ def run():
 	// Verify highest severity.
 	maxSev := "INFO"
 	for _, d := range deltas {
-		if severityRank(d.Severity) > severityRank(maxSev) {
+		if audit.SeverityRank(d.Severity) > audit.SeverityRank(maxSev) {
 			maxSev = d.Severity
 		}
 	}

--- a/internal/watcher/rescan.go
+++ b/internal/watcher/rescan.go
@@ -282,7 +282,7 @@ func (w *InstallWatcher) compareScanResults(ctx context.Context, evt InstallEven
 
 	prevMax := string(prevScan.MaxSeverity())
 	curMax := string(current.MaxSeverity())
-	if severityRank(curMax) > severityRank(prevMax) {
+	if audit.SeverityRank(curMax) > audit.SeverityRank(prevMax) {
 		deltas = append(deltas, DriftDelta{
 			Type:        DriftSeverityChange,
 			Severity:    curMax,
@@ -474,7 +474,7 @@ func diffFindings(prev, curr []scanner.Finding) []DriftDelta {
 		}
 		if prevFinding.Severity != f.Severity {
 			sev := prevFinding.Severity
-			if severityRank(string(f.Severity)) > severityRank(string(prevFinding.Severity)) {
+			if audit.SeverityRank(string(f.Severity)) > audit.SeverityRank(string(prevFinding.Severity)) {
 				sev = f.Severity
 			}
 			deltas = append(deltas, DriftDelta{
@@ -505,7 +505,7 @@ func diffFindings(prev, curr []scanner.Finding) []DriftDelta {
 func (w *InstallWatcher) emitDriftAlerts(evt InstallEvent, deltas []DriftDelta) {
 	maxSev := "INFO"
 	for _, d := range deltas {
-		if severityRank(d.Severity) > severityRank(maxSev) {
+		if audit.SeverityRank(d.Severity) > audit.SeverityRank(maxSev) {
 			maxSev = d.Severity
 		}
 	}
@@ -523,7 +523,7 @@ func (w *InstallWatcher) emitDriftAlerts(evt InstallEvent, deltas []DriftDelta) 
 		Details:   string(detailsJSON),
 		Severity:  maxSev,
 	}
-	if err := w.store.LogEvent(event); err != nil {
+	if err := w.logger.LogEvent(event); err != nil {
 		fmt.Fprintf(os.Stderr, "[rescan] drift alert LogEvent failed for %s: %v\n", evt.Path, err)
 	}
 
@@ -555,22 +555,6 @@ func summarizeDrift(deltas []DriftDelta) string {
 	return strings.Join(parts, " ")
 }
 
-func severityRank(s string) int {
-	switch strings.ToUpper(s) {
-	case "CRITICAL":
-		return 5
-	case "HIGH":
-		return 4
-	case "MEDIUM":
-		return 3
-	case "LOW":
-		return 2
-	case "INFO":
-		return 1
-	default:
-		return 0
-	}
-}
 
 func (w *InstallWatcher) snapshotForEvent(evt InstallEvent) (*TargetSnapshot, error) {
 	switch evt.Type {

--- a/internal/watcher/rescan_test.go
+++ b/internal/watcher/rescan_test.go
@@ -368,9 +368,9 @@ func TestSeverityRank(t *testing.T) {
 		{"", 0},
 	}
 	for _, tt := range tests {
-		got := severityRank(tt.input)
+		got := audit.SeverityRank(tt.input)
 		if got != tt.expected {
-			t.Errorf("severityRank(%q) = %d, want %d", tt.input, got, tt.expected)
+			t.Errorf("audit.SeverityRank(%q) = %d, want %d", tt.input, got, tt.expected)
 		}
 	}
 }

--- a/policies/default.yaml
+++ b/policies/default.yaml
@@ -115,6 +115,21 @@ watch:
   rescan_enabled: true
   rescan_interval_min: 60
 
+# Outbound webhook notifications. Valid event categories:
+#   block     - skill/plugin/MCP blocked or quarantined
+#   guardrail - prompt/completion guardrail actions
+#   drift     - rescan drift detection
+#   scan      - scan results
+#   health    - gateway-down, guardrail-degraded, gateway-recovered
+#
+# webhooks:
+#   - url: https://hooks.slack.com/services/T.../B.../xxx
+#     type: slack              # slack | pagerduty | webex | generic
+#     enabled: true
+#     min_severity: MEDIUM     # INFO | LOW | MEDIUM | HIGH | CRITICAL
+#     events: [block, health]  # empty = all categories
+#     cooldown_seconds: 300    # dedup window (seconds); omit for default (300s); 0 to disable
+#     secret_env: SLACK_WEBHOOK_SECRET
 webhooks: []
 
 enforcement:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ tui = ["textual>=0.50"]
 
 [dependency-groups]
 dev = [
-    "pytest==9.0.3",
+    "pytest>=9.0.3",
     "pytest-cov==7.1.0",
     "ruff==0.15.7",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ tui = ["textual>=0.50"]
 
 [dependency-groups]
 dev = [
-    "pytest>=9.0.3",
+    "pytest==9.0.3",
     "pytest-cov==7.1.0",
     "ruff==0.15.7",
 ]

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -21,6 +21,9 @@
 # Downloads the gateway binary and Python CLI wheel from a GitHub release,
 # runs version-specific migrations, and restarts services.
 #
+# Non-destructive: artifacts are downloaded and verified BEFORE the gateway
+# is stopped, so a failed download never disrupts a running gateway.
+#
 # Plugin installation is NOT handled here — it is part of the initial
 # release install (install.sh) and is release-specific.
 #
@@ -165,13 +168,11 @@ CURRENT_VERSION="${CURRENT_VERSION:-unknown}"
 ok "Installed version : ${CURRENT_VERSION}"
 ok "Upgrade target    : ${RELEASE_VERSION}"
 
+# ── Early exit if already at latest ──────────────────────────────────────────
+
 if [[ "${CURRENT_VERSION}" == "${RELEASE_VERSION}" && "${YES}" -eq 0 ]]; then
-    printf "\n  Already at version ${RELEASE_VERSION}.\n"
-    read -r -p "  Re-apply upgrade anyway? [y/N] " REPLY
-    case "$REPLY" in
-        [Yy]*) ;;
-        *) echo "  Aborted."; exit 0 ;;
-    esac
+    printf "\n  Already at version ${RELEASE_VERSION}. Nothing to do.\n\n"
+    exit 0
 fi
 
 # ── Artifact helper ───────────────────────────────────────────────────────────
@@ -182,14 +183,47 @@ fetch_artifact() {
         || die "Failed to download: ${url}"
 }
 
+# ── Pre-flight: verify artifacts exist before touching anything ───────────────
+
+section "Pre-flight Check"
+
+TARBALL_URL="https://github.com/${REPO}/releases/download/${RELEASE_VERSION}/defenseclaw_${RELEASE_VERSION}_${OS}_${ARCH_NORM}.tar.gz"
+WHL_URL="https://github.com/${REPO}/releases/download/${RELEASE_VERSION}/defenseclaw-${RELEASE_VERSION}-py3-none-any.whl"
+
+for artifact_url in "${TARBALL_URL}" "${WHL_URL}"; do
+    http_code=$(curl -sSo /dev/null -w "%{http_code}" -L --head "${artifact_url}" 2>/dev/null || echo "000")
+    if [[ "${http_code}" -ge 400 || "${http_code}" == "000" ]]; then
+        die "Artifact not found (HTTP ${http_code}): ${artifact_url}
+  Version ${RELEASE_VERSION} may not exist or is missing platform artifacts."
+    fi
+done
+ok "Release artifacts verified"
+
+# ── Download artifacts to staging (gateway still running) ─────────────────────
+
+section "Downloading Artifacts"
+
+STAGING_DIR="$(mktemp -d)"
+trap 'rm -rf "${STAGING_DIR}"' EXIT
+
+step "Downloading gateway binary ..."
+fetch_artifact "${TARBALL_URL}" "${STAGING_DIR}/gateway.tar.gz"
+tar -xzf "${STAGING_DIR}/gateway.tar.gz" -C "${STAGING_DIR}"
+ok "Gateway binary downloaded"
+
+step "Downloading Python CLI wheel ..."
+whl_name="defenseclaw-${RELEASE_VERSION}-py3-none-any.whl"
+fetch_artifact "${WHL_URL}" "${STAGING_DIR}/${whl_name}"
+ok "Python CLI wheel downloaded"
+
 # ── Confirm ───────────────────────────────────────────────────────────────────
 
 if [[ "${YES}" -eq 0 ]]; then
     printf "\n  This will:\n"
     printf "    1. Back up config files in ${BOLD}~/.defenseclaw/${NC}\n"
-    printf "    2. Download and replace gateway binary and Python CLI wheel\n"
+    printf "    2. Stop gateway, install pre-downloaded artifacts\n"
     printf "    3. Run version-specific migrations\n"
-    printf "    4. Restart the gateway service\n"
+    printf "    4. Restart services and verify health\n"
     printf "       ${DIM}Source: github.com/${REPO}/releases/tag/${RELEASE_VERSION}${NC}\n\n"
     read -r -p "  Proceed? [y/N] " REPLY
     case "$REPLY" in
@@ -198,7 +232,7 @@ if [[ "${YES}" -eq 0 ]]; then
     esac
 fi
 
-# ── Step 1: Create backup ─────────────────────────────────────────────────────
+# ── Create backup ─────────────────────────────────────────────────────────────
 
 section "Creating Backup"
 
@@ -225,38 +259,25 @@ fi
 
 ok "Backup saved to: ${BACKUP_DIR}"
 
-# ── Step 2: Stop services ─────────────────────────────────────────────────────
+# ── Stop services ─────────────────────────────────────────────────────────────
 
 section "Stopping Services"
 
 step "Stopping defenseclaw-gateway ..."
 defenseclaw-gateway stop 2>/dev/null && ok "Gateway stopped" || warn "Gateway was not running"
 
-# ── Step 3: Download and replace gateway binary ───────────────────────────────
+# ── Install from staging (fast, no network) ───────────────────────────────────
 
-section "Replacing Gateway Binary"
+section "Installing Artifacts"
 
-step "Downloading defenseclaw-gateway from release ${RELEASE_VERSION} ..."
 mkdir -p "${INSTALL_DIR}"
-
-tmp_gw="$(mktemp -d)"
-fetch_artifact \
-    "https://github.com/${REPO}/releases/download/${RELEASE_VERSION}/defenseclaw_${RELEASE_VERSION}_${OS}_${ARCH_NORM}.tar.gz" \
-    "${tmp_gw}/gateway.tar.gz"
-tar -xzf "${tmp_gw}/gateway.tar.gz" -C "${tmp_gw}"
-cp "${tmp_gw}/defenseclaw" "${INSTALL_DIR}/defenseclaw-gateway"
+cp "${STAGING_DIR}/defenseclaw" "${INSTALL_DIR}/defenseclaw-gateway"
 chmod +x "${INSTALL_DIR}/defenseclaw-gateway"
-rm -rf "${tmp_gw}"
 
 if [[ "${OS}" == "darwin" ]]; then
     codesign -f -s - "${INSTALL_DIR}/defenseclaw-gateway" 2>/dev/null || true
 fi
-
-ok "Gateway binary replaced"
-
-# ── Step 4: Replace Python CLI from wheel ────────────────────────────────────
-
-section "Replacing Python CLI"
+ok "Gateway binary installed"
 
 UV_BIN="$(command -v uv 2>/dev/null || true)"
 [[ -z "${UV_BIN}" ]] \
@@ -268,21 +289,12 @@ if [[ ! -d "${DEFENSECLAW_VENV}" ]]; then
 fi
 
 VENV_PYTHON="${DEFENSECLAW_VENV}/bin/python"
-
-step "Downloading Python CLI wheel for ${RELEASE_VERSION} ..."
-whl_name="defenseclaw-${RELEASE_VERSION}-py3-none-any.whl"
-tmp_whl="$(mktemp -d)"
-fetch_artifact \
-    "https://github.com/${REPO}/releases/download/${RELEASE_VERSION}/${whl_name}" \
-    "${tmp_whl}/${whl_name}"
-"${UV_BIN}" pip install --python "${VENV_PYTHON}" --quiet "${tmp_whl}/${whl_name}" \
+"${UV_BIN}" pip install --python "${VENV_PYTHON}" --quiet "${STAGING_DIR}/${whl_name}" \
     || die "Failed to install CLI wheel"
-rm -rf "${tmp_whl}"
-
 ln -sf "${DEFENSECLAW_VENV}/bin/defenseclaw" "${INSTALL_DIR}/defenseclaw"
-ok "Python CLI replaced"
+ok "Python CLI installed"
 
-# ── Step 5: Run migrations ────────────────────────────────────────────────────
+# ── Run migrations ────────────────────────────────────────────────────────────
 
 section "Running Migrations"
 
@@ -298,7 +310,7 @@ else
     ok "Applied ${MIGRATION_COUNT} migration(s)"
 fi
 
-# ── Step 6: Start services ────────────────────────────────────────────────────
+# ── Start services ────────────────────────────────────────────────────────────
 
 section "Starting Services"
 
@@ -310,6 +322,49 @@ openclaw gateway restart 2>/dev/null \
     && ok "OpenClaw gateway restarted" \
     || warn "Could not restart OpenClaw gateway automatically. Run: openclaw gateway restart"
 
+# ── Health verification ───────────────────────────────────────────────────────
+
+section "Verifying Gateway Health"
+
+HEALTH_TIMEOUT=60
+HEALTH_INTERVAL=2
+ELAPSED=0
+HEALTH_OK=0
+HEALTH_URL="$("${VENV_PYTHON}" - <<'PY' 2>/dev/null || true
+from defenseclaw.config import load
+
+cfg = load()
+bind = getattr(cfg.gateway, "api_bind", "")
+if not bind:
+    if cfg.openshell.is_standalone() and cfg.guardrail.host not in ("", "localhost", "127.0.0.1"):
+        bind = cfg.guardrail.host
+    else:
+        bind = "127.0.0.1"
+print(f"http://{bind}:{cfg.gateway.api_port}/health")
+PY
+)"
+if [[ -z "${HEALTH_URL}" ]]; then
+    HEALTH_URL="http://127.0.0.1:18970/health"
+fi
+
+while [[ "${ELAPSED}" -lt "${HEALTH_TIMEOUT}" ]]; do
+    STATUS=$(curl -s "${HEALTH_URL}" 2>/dev/null || echo "{}")
+    GW_STATE=$(echo "${STATUS}" | grep -oE '"state":"[^"]*"' | head -1 | grep -oE '"[^"]*"$' | tr -d '"' || echo "unknown")
+    if [[ "${GW_STATE}" == "running" ]]; then
+        ok "Gateway is healthy"
+        HEALTH_OK=1
+        break
+    fi
+    sleep "${HEALTH_INTERVAL}"
+    ELAPSED=$((ELAPSED + HEALTH_INTERVAL))
+done
+
+if [[ "${HEALTH_OK}" -eq 0 ]]; then
+    warn "Gateway did not become healthy within ${HEALTH_TIMEOUT}s"
+    info "Check logs: ~/.defenseclaw/gateway.log"
+    info "Run:  defenseclaw-gateway status"
+fi
+
 # ── Done ──────────────────────────────────────────────────────────────────────
 
 section "Upgrade Complete"
@@ -317,7 +372,6 @@ section "Upgrade Complete"
 ok "DefenseClaw upgraded: ${CURRENT_VERSION} → ${RELEASE_VERSION}"
 printf "\n"
 printf "  Backup saved to: ${DIM}${BACKUP_DIR}${NC}\n"
-printf "  Run ${BOLD}defenseclaw status${NC} to verify all components are healthy.\n"
 printf "\n"
 
 } # end main()


### PR DESCRIPTION
## Summary

Fixes four open bugs and adds a health watchdog feature across the Go gateway, Python CLI, shell installer, and TypeScript OpenClaw plugin.

- **Issue #92** — Fix `localhost` vs `127.0.0.1` IPv6 silent bypass on macOS by defaulting `EffectiveHost()` to `127.0.0.1` and clearing the Viper default so the fallback actually applies
- **Issue #98** — Standardize block feedback with `[DefenseClaw]` prefix, `defenseclaw_blocked` metadata, `content_filter` finish reason, and `X-DefenseClaw-Blocked` response header across all provider formats (OpenAI, Anthropic, Gemini, Responses API)
- **Issue #99** — Prevent partial output leakage by buffering initial stream bytes (configurable via `guardrail.stream_buffer_bytes`) and scanning before flushing to the client, with a 1 MiB safety cap for non-text streams
- **Issue #96** — Non-destructive upgrade: preflight artifact verification, staging downloads before stopping the gateway, post-upgrade health polling, and a versioned DB migration framework with transactional `schema_version` tracking
- **Health watchdog** — New `defenseclaw-gateway watchdog` subcommand with OS-native desktop notifications, plus a TypeScript `HealthMonitor` plugin that warns in-chat when the sidecar is unreachable. Gateway start/stop/restart auto-manage the watchdog lifecycle

### Security hardening (found during self-review)
- Fix **AppleScript injection** in `notify_darwin.go` — use `json.Marshal` escaping instead of naive quote replacement
- Fix **migration atomicity** — `m.apply()` now runs inside the transaction (was using `s.db` instead of `tx`)
- Fix **Viper default** — `guardrail.host` default changed from `"localhost"` to `""` so `EffectiveHost()` IPv4 fallback is not dead code
- Narrow `_poll_health` exception handling from `Exception` to `OSError | ValueError`
- Use `/dev/null` for watchdog daemon stdin instead of inheriting parent terminal
- Move staging dir cleanup to top of `finally` block so it runs even if health poll raises

## Test plan

- [x] `go test ./...` — all 16 test packages pass (0 failures)
- [x] `make ts-test` — all 10 test files, 136 tests pass (0 failures)
- [x] `gofmt` applied to all modified Go files
- [x] New test coverage:
  - `TestBlockedResponseHeader` / `TestBlockedResponseHeaderAnthropic` / `TestBlockedResponseHeaderGemini` — verify `X-DefenseClaw-Blocked` header
  - `TestBlockedResponseMetadata` / `TestBlockedStreamMetadata` — verify `defenseclaw_blocked` field in JSON
  - `TestStreamBufferingPassthrough` / `TestStreamBufferingBlock` — verify initial buffer + pre-scan
  - `TestSchemaVersionTracking` / `TestInitIdempotent` / `TestMigrationFromFreshDB` / `TestMigrationFromV1Schema` / `TestMigrationTransactional` — migration framework
  - `TestProbeHealth` (9 subtests) / `TestWatchdogStateTransitions` — watchdog health probe
  - `TestViperDefaultGuardrailHostIsEmpty` — regression guard for IPv6 fix
  - `health-monitor.test.ts` (10 tests) — TS health monitor lifecycle, JSON body parsing, degraded state

Closes #92, #96, #98, #99