### PR TITLE
feat: add model & provider governance (allow/deny lists)

### DIFF
--- a/docs/CONFIG_FILES.md
+++ b/docs/CONFIG_FILES.md
@@ -326,3 +326,69 @@ webhooks:
 | **Set by** | `defenseclaw setup webhook` (preferred) or operator via `config.yaml`. |
 | **Read by** | **Go sidecar** at startup via `config.Load()`. **Python CLI** via `config.load()` (round-trips the cooldown tri-state, read-only for display). |
 | **Effect** | When enabled, the `WebhookDispatcher` in `internal/gateway/webhook.go` sends structured JSON payloads to each endpoint when enforcement events (block, drift, guardrail-block, …) occur. Retries up to 3 times with exponential backoff on transient failures (5xx, network errors); 4xx are treated as permanent. |
+
+## Model Governance Config
+
+The `model_governance` section controls which LLM models and providers are permitted through the guardrail proxy. When enabled, requests for disallowed models or providers are blocked before content inspection, preventing shadow AI and enforcing data residency.
+
+The `config.yaml` section controls runtime behavior (enabled, mode, messaging). The actual
+allow/deny lists live in the **OPA Rego data layer** (`policies/rego/data.json`), consistent
+with how all other policy decisions (admission, guardrail, firewall, skill_actions) are managed.
+
+**config.yaml — runtime knobs:**
+
+```yaml
+model_governance:
+  enabled: true
+  mode: enforce              # enforce | monitor (log-only)
+  block_message: "This model or provider is not authorized by your organization's policy."
+  log_allowed: false         # if true, log allowed requests too (verbose)
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `false` | Enable model/provider governance. |
+| `mode` | string | `"enforce"` | `enforce` blocks denied requests; `monitor` logs but does not block. |
+| `block_message` | string | `"This model or provider is not authorized by your organization's policy."` | User-facing message returned in the blocked response. |
+| `log_allowed` | bool | `false` | Log allowed requests for auditing. |
+
+**data.json — allow/deny policy (OPA Rego data layer):**
+
+The `model_governance` key in `policies/rego/data.json` defines the allow/deny lists:
+
+```json
+{
+  "model_governance": {
+    "providers": {
+      "allow": [],
+      "deny": ["openrouter", "bedrock"]
+    },
+    "models": {
+      "allow": ["gpt-4o", "gpt-4o-*", "claude-*"],
+      "deny": ["gpt-3.5-*"]
+    }
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `providers.allow` | []string | `[]` | If non-empty, only these providers are permitted. |
+| `providers.deny` | []string | `[]` | Providers to block. Deny overrides allow. |
+| `models.allow` | []string | `[]` | If non-empty, only these models are permitted. Supports glob patterns (e.g. `gpt-4o-*`, `claude-*`). |
+| `models.deny` | []string | `[]` | Models to block. Supports glob patterns. |
+
+**Semantics:**
+- Provider names match canonical names from `providers.json`: `openai`, `anthropic`, `azure`, `gemini`, `bedrock`, `openrouter`, `ollama`.
+- Allow lists are evaluated first; if non-empty, only listed items pass.
+- Deny lists are checked next; any match blocks. Deny overrides allow when both match.
+- Model patterns support glob matching via OPA's `glob.match` (e.g. `gpt-4o-*`, `claude-*`).
+- All matching is case-insensitive.
+- Policy decisions are made by the `model_governance.rego` Rego policy, evaluated by the OPA engine.
+- Denied requests emit a `model-governance-deny` audit event with severity HIGH, which is also dispatched to configured webhooks.
+
+| | |
+|---|---|
+| **Set by** | Operator — runtime config in `config.yaml`; allow/deny rules in `policies/rego/data.json`. Reloadable via the API policy reload endpoint. |
+| **Read by** | **Go sidecar** at startup. The `ModelGovernor` wraps the OPA `policy.Engine` and checks are applied before guardrail content inspection. |
+| **Effect** | In `enforce` mode, denied requests receive a blocked response (OpenAI-compatible format) and are logged as audit events. In `monitor` mode, denials are logged but requests proceed normally. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -168,8 +168,9 @@ type Config struct {
 	// It supports an arbitrary number of named sinks of any registered
 	// kind (splunk_hec, otlp_logs, http_jsonl). Legacy `splunk:` keys are
 	// detected at Load() and emit a hard migration error.
-	AuditSinks []AuditSink     `mapstructure:"audit_sinks"      yaml:"audit_sinks,omitempty"`
-	Webhooks   []WebhookConfig `mapstructure:"webhooks"         yaml:"webhooks"`
+	AuditSinks      []AuditSink           `mapstructure:"audit_sinks"      yaml:"audit_sinks,omitempty"`
+	Webhooks        []WebhookConfig       `mapstructure:"webhooks"         yaml:"webhooks"`
+	ModelGovernance ModelGovernanceConfig `mapstructure:"model_governance" yaml:"model_governance"`
 }
 
 // LLMConfig is the unified LLM configuration block used at the top level
@@ -581,6 +582,18 @@ type WebhookConfig struct {
 	TimeoutSeconds  int      `mapstructure:"timeout_seconds"  yaml:"timeout_seconds"`
 	CooldownSeconds *int     `mapstructure:"cooldown_seconds" yaml:"cooldown_seconds,omitempty"`
 	Enabled         bool     `mapstructure:"enabled"          yaml:"enabled"`
+}
+
+// ModelGovernanceConfig controls which LLM models and providers are
+// permitted through the guardrail proxy. When enabled, requests for
+// disallowed models or providers are blocked before content inspection.
+// Allow/deny lists are defined in the OPA Rego data layer (data.json),
+// not in config.yaml.
+type ModelGovernanceConfig struct {
+	Enabled      bool   `mapstructure:"enabled"       yaml:"enabled"`
+	Mode         string `mapstructure:"mode"           yaml:"mode"`
+	BlockMessage string `mapstructure:"block_message"  yaml:"block_message"`
+	LogAllowed   bool   `mapstructure:"log_allowed"    yaml:"log_allowed"`
 }
 
 // ResolvedSecret returns the webhook secret/token from the env var.
@@ -1802,4 +1815,9 @@ func setDefaults(dataDir string) {
 	_ = viper.BindEnv("otel.logs.endpoint", "DEFENSECLAW_OTEL_LOGS_ENDPOINT")
 	_ = viper.BindEnv("otel.logs.protocol", "DEFENSECLAW_OTEL_LOGS_PROTOCOL")
 	_ = viper.BindEnv("otel.logs.url_path", "DEFENSECLAW_OTEL_LOGS_URL_PATH")
+
+	viper.SetDefault("model_governance.enabled", false)
+	viper.SetDefault("model_governance.mode", "enforce")
+	viper.SetDefault("model_governance.block_message", "This model or provider is not authorized by your organization's policy.")
+	viper.SetDefault("model_governance.log_allowed", false)
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -176,5 +176,9 @@ func DefaultConfig() *Config {
 		SkillActions:  DefaultSkillActions(),
 		MCPActions:    DefaultMCPActions(),
 		PluginActions: DefaultPluginActions(),
+		ModelGovernance: ModelGovernanceConfig{
+			Mode:         "enforce",
+			BlockMessage: "This model or provider is not authorized by your organization's policy.",
+		},
 	}
 }

--- a/internal/gateway/model_governance.go
+++ b/internal/gateway/model_governance.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/policy"
+)
+
+// GovernanceVerdict is the result of a model/provider governance check.
+type GovernanceVerdict struct {
+	Allowed bool
+	Reason  string
+	Rule    string // "provider-allow", "provider-deny", "model-allow", "model-deny"
+}
+
+// ModelGovernor evaluates model and provider names against OPA policy.
+// A nil governor always allows (feature disabled).
+type ModelGovernor struct {
+	mode         string
+	blockMessage string
+	logAllowed   bool
+	opa          *policy.Engine
+}
+
+// NewModelGovernor creates a governor from config. Returns nil when
+// governance is disabled, so callers can nil-check for fast path.
+func NewModelGovernor(cfg config.ModelGovernanceConfig, opa *policy.Engine) *ModelGovernor {
+	if !cfg.Enabled {
+		return nil
+	}
+	return &ModelGovernor{
+		mode:         strings.ToLower(cfg.Mode),
+		blockMessage: cfg.BlockMessage,
+		logAllowed:   cfg.LogAllowed,
+		opa:          opa,
+	}
+}
+
+// Check evaluates the provider and model against OPA policy.
+// Returns a verdict with allow/deny and reason.
+func (g *ModelGovernor) Check(provider, model string) *GovernanceVerdict {
+	if g == nil {
+		return &GovernanceVerdict{Allowed: true}
+	}
+
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	model = strings.ToLower(strings.TrimSpace(model))
+
+	if g.opa == nil {
+		return &GovernanceVerdict{Allowed: true}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	out, err := g.opa.EvaluateModelGovernance(ctx, policy.ModelGovernanceInput{
+		Provider: provider,
+		Model:    model,
+	})
+	if err != nil {
+		return &GovernanceVerdict{
+			Allowed: true,
+			Reason:  fmt.Sprintf("policy eval error (fail-open): %v", err),
+		}
+	}
+
+	if out.Action == "deny" {
+		return &GovernanceVerdict{
+			Allowed: false,
+			Reason:  out.Reason,
+			Rule:    out.Rule,
+		}
+	}
+
+	return &GovernanceVerdict{Allowed: true}
+}
+
+// IsMonitorOnly returns true when denials should be logged but not enforced.
+func (g *ModelGovernor) IsMonitorOnly() bool {
+	if g == nil {
+		return false
+	}
+	return g.mode == "monitor"
+}
+
+// BlockMessage returns the user-facing denial message.
+func (g *ModelGovernor) BlockMessage() string {
+	if g == nil || g.blockMessage == "" {
+		return "This model or provider is not authorized by your organization's policy."
+	}
+	return g.blockMessage
+}
+
+// LogAllowed returns whether allowed requests should be logged.
+func (g *ModelGovernor) LogAllowed() bool {
+	return g != nil && g.logAllowed
+}

--- a/internal/gateway/model_governance_test.go
+++ b/internal/gateway/model_governance_test.go
@@ -1,0 +1,403 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/policy"
+)
+
+// newTestOPA creates a temporary OPA engine with the given model_governance
+// data and the production Rego policy.
+func newTestOPA(t *testing.T, govData map[string]interface{}) *policy.Engine {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	data := map[string]interface{}{
+		"model_governance": govData,
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal data.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "data.json"), raw, 0o644); err != nil {
+		t.Fatalf("write data.json: %v", err)
+	}
+
+	regoSrc, err := os.ReadFile("../../policies/rego/model_governance.rego")
+	if err != nil {
+		t.Fatalf("read model_governance.rego: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "model_governance.rego"), regoSrc, 0o644); err != nil {
+		t.Fatalf("write rego: %v", err)
+	}
+
+	engine, err := policy.New(dir)
+	if err != nil {
+		t.Fatalf("policy.New: %v", err)
+	}
+	return engine
+}
+
+func govCfg(mode string) config.ModelGovernanceConfig {
+	return config.ModelGovernanceConfig{
+		Enabled: true,
+		Mode:    mode,
+	}
+}
+
+func TestNilGovernorAllowsAll(t *testing.T) {
+	var g *ModelGovernor
+	v := g.Check("openai", "gpt-4o")
+	if !v.Allowed {
+		t.Fatalf("nil governor should allow all requests")
+	}
+}
+
+func TestDisabledGovernorReturnsNil(t *testing.T) {
+	g := NewModelGovernor(config.ModelGovernanceConfig{Enabled: false}, nil)
+	if g != nil {
+		t.Fatalf("disabled config should produce nil governor")
+	}
+}
+
+func TestNoOPAEngineAllowsAll(t *testing.T) {
+	g := NewModelGovernor(govCfg("enforce"), nil)
+	v := g.Check("openai", "gpt-4o")
+	if !v.Allowed {
+		t.Fatalf("nil OPA engine should allow all requests (fail-open)")
+	}
+}
+
+func TestProviderAllowList(t *testing.T) {
+	opa := newTestOPA(t, map[string]interface{}{
+		"providers": map[string]interface{}{
+			"allow": []string{"openai", "anthropic"},
+			"deny":  []string{},
+		},
+		"models": map[string]interface{}{
+			"allow": []string{},
+			"deny":  []string{},
+		},
+	})
+	g := NewModelGovernor(govCfg("enforce"), opa)
+
+	tests := []struct {
+		provider string
+		model    string
+		allowed  bool
+		rule     string
+	}{
+		{"openai", "gpt-4o", true, ""},
+		{"anthropic", "claude-3.5-sonnet", true, ""},
+		{"openrouter", "gpt-4o", false, "provider-allow"},
+		{"gemini", "gemini-pro", false, "provider-allow"},
+		{"", "gpt-4o", true, ""},
+	}
+
+	for _, tt := range tests {
+		v := g.Check(tt.provider, tt.model)
+		if v.Allowed != tt.allowed {
+			t.Errorf("Check(%q, %q): got allowed=%v, want %v (reason=%s)",
+				tt.provider, tt.model, v.Allowed, tt.allowed, v.Reason)
+		}
+		if !v.Allowed && v.Rule != tt.rule {
+			t.Errorf("Check(%q, %q): got rule=%q, want %q",
+				tt.provider, tt.model, v.Rule, tt.rule)
+		}
+	}
+}
+
+func TestProviderDenyList(t *testing.T) {
+	opa := newTestOPA(t, map[string]interface{}{
+		"providers": map[string]interface{}{
+			"allow": []string{},
+			"deny":  []string{"openrouter", "bedrock"},
+		},
+		"models": map[string]interface{}{
+			"allow": []string{},
+			"deny":  []string{},
+		},
+	})
+	g := NewModelGovernor(govCfg("enforce"), opa)
+
+	tests := []struct {
+		provider string
+		allowed  bool
+	}{
+		{"openai", true},
+		{"anthropic", true},
+		{"openrouter", false},
+		{"bedrock", false},
+		{"gemini", true},
+	}
+
+	for _, tt := range tests {
+		v := g.Check(tt.provider, "some-model")
+		if v.Allowed != tt.allowed {
+			t.Errorf("Check(%q, ...): got allowed=%v, want %v", tt.provider, v.Allowed, tt.allowed)
+		}
+		if !v.Allowed && v.Rule != "provider-deny" {
+			t.Errorf("Check(%q, ...): got rule=%q, want provider-deny", tt.provider, v.Rule)
+		}
+	}
+}
+
+func TestModelAllowListWithGlobs(t *testing.T) {
+	opa := newTestOPA(t, map[string]interface{}{
+		"providers": map[string]interface{}{
+			"allow": []string{},
+			"deny":  []string{},
+		},
+		"models": map[string]interface{}{
+			"allow": []string{"gpt-4o", "gpt-4o-*", "claude-*"},
+			"deny":  []string{},
+		},
+	})
+	g := NewModelGovernor(govCfg("enforce"), opa)
+
+	tests := []struct {
+		model   string
+		allowed bool
+	}{
+		{"gpt-4o", true},
+		{"gpt-4o-mini", true},
+		{"gpt-4o-2024-08-06", true},
+		{"claude-3.5-sonnet", true},
+		{"claude-3-opus", true},
+		{"gpt-3.5-turbo", false},
+		{"llama-3-70b", false},
+		{"gemini-pro", false},
+	}
+
+	for _, tt := range tests {
+		v := g.Check("openai", tt.model)
+		if v.Allowed != tt.allowed {
+			t.Errorf("Check(openai, %q): got allowed=%v, want %v (reason=%s)",
+				tt.model, v.Allowed, tt.allowed, v.Reason)
+		}
+	}
+}
+
+func TestModelDenyListWithGlobs(t *testing.T) {
+	opa := newTestOPA(t, map[string]interface{}{
+		"providers": map[string]interface{}{
+			"allow": []string{},
+			"deny":  []string{},
+		},
+		"models": map[string]interface{}{
+			"allow": []string{},
+			"deny":  []string{"gpt-3.5-*", "llama-*"},
+		},
+	})
+	g := NewModelGovernor(govCfg("enforce"), opa)
+
+	tests := []struct {
+		model   string
+		allowed bool
+	}{
+		{"gpt-4o", true},
+		{"claude-3.5-sonnet", true},
+		{"gpt-3.5-turbo", false},
+		{"gpt-3.5-turbo-16k", false},
+		{"llama-3-70b", false},
+		{"llama-2-13b", false},
+	}
+
+	for _, tt := range tests {
+		v := g.Check("openai", tt.model)
+		if v.Allowed != tt.allowed {
+			t.Errorf("Check(openai, %q): got allowed=%v, want %v", tt.model, v.Allowed, tt.allowed)
+		}
+	}
+}
+
+func TestCombinedProviderAllowedModelDenied(t *testing.T) {
+	opa := newTestOPA(t, map[string]interface{}{
+		"providers": map[string]interface{}{
+			"allow": []string{"openai"},
+			"deny":  []string{},
+		},
+		"models": map[string]interface{}{
+			"allow": []string{},
+			"deny":  []string{"gpt-3.5-*"},
+		},
+	})
+	g := NewModelGovernor(govCfg("enforce"), opa)
+
+	v := g.Check("openai", "gpt-4o")
+	if !v.Allowed {
+		t.Error("openai/gpt-4o should be allowed")
+	}
+
+	v = g.Check("openai", "gpt-3.5-turbo")
+	if v.Allowed {
+		t.Error("openai/gpt-3.5-turbo should be denied by model deny list")
+	}
+	if v.Rule != "model-deny" {
+		t.Errorf("got rule=%q, want model-deny", v.Rule)
+	}
+
+	v = g.Check("anthropic", "claude-3.5-sonnet")
+	if v.Allowed {
+		t.Error("anthropic should be denied by provider allow list")
+	}
+	if v.Rule != "provider-allow" {
+		t.Errorf("got rule=%q, want provider-allow", v.Rule)
+	}
+}
+
+func TestEmptyListsAllowAll(t *testing.T) {
+	opa := newTestOPA(t, map[string]interface{}{
+		"providers": map[string]interface{}{
+			"allow": []string{},
+			"deny":  []string{},
+		},
+		"models": map[string]interface{}{
+			"allow": []string{},
+			"deny":  []string{},
+		},
+	})
+	g := NewModelGovernor(govCfg("enforce"), opa)
+
+	v := g.Check("openai", "gpt-4o")
+	if !v.Allowed {
+		t.Error("empty lists should allow all")
+	}
+
+	v = g.Check("bedrock", "llama-3-70b")
+	if !v.Allowed {
+		t.Error("empty lists should allow all")
+	}
+}
+
+func TestCaseInsensitivity(t *testing.T) {
+	opa := newTestOPA(t, map[string]interface{}{
+		"providers": map[string]interface{}{
+			"allow": []string{"OpenAI", "Anthropic"},
+			"deny":  []string{},
+		},
+		"models": map[string]interface{}{
+			"allow": []string{},
+			"deny":  []string{"GPT-3.5-*"},
+		},
+	})
+	g := NewModelGovernor(govCfg("enforce"), opa)
+
+	v := g.Check("OPENAI", "gpt-4o")
+	if !v.Allowed {
+		t.Error("provider matching should be case-insensitive")
+	}
+
+	v = g.Check("openai", "gpt-4o")
+	if !v.Allowed {
+		t.Error("provider matching should be case-insensitive")
+	}
+
+	v = g.Check("openai", "GPT-3.5-turbo")
+	if v.Allowed {
+		t.Error("model matching should be case-insensitive")
+	}
+}
+
+func TestMonitorMode(t *testing.T) {
+	opa := newTestOPA(t, map[string]interface{}{
+		"providers": map[string]interface{}{
+			"allow": []string{},
+			"deny":  []string{"bedrock"},
+		},
+		"models": map[string]interface{}{
+			"allow": []string{},
+			"deny":  []string{},
+		},
+	})
+	g := NewModelGovernor(govCfg("monitor"), opa)
+
+	if !g.IsMonitorOnly() {
+		t.Error("should report monitor mode")
+	}
+
+	v := g.Check("bedrock", "some-model")
+	if v.Allowed {
+		t.Error("Check should still return denied even in monitor mode (caller decides enforcement)")
+	}
+}
+
+func TestGovernanceBlockMessage(t *testing.T) {
+	g := NewModelGovernor(config.ModelGovernanceConfig{
+		Enabled:      true,
+		BlockMessage: "Custom block message",
+	}, nil)
+	if g.BlockMessage() != "Custom block message" {
+		t.Error("should return custom block message")
+	}
+
+	g2 := NewModelGovernor(config.ModelGovernanceConfig{Enabled: true}, nil)
+	if g2.BlockMessage() == "" {
+		t.Error("should return default block message when empty")
+	}
+
+	var nilGov *ModelGovernor
+	if nilGov.BlockMessage() == "" {
+		t.Error("nil governor should return default block message")
+	}
+}
+
+func TestLogAllowed(t *testing.T) {
+	g := NewModelGovernor(config.ModelGovernanceConfig{
+		Enabled:    true,
+		LogAllowed: true,
+	}, nil)
+	if !g.LogAllowed() {
+		t.Error("should report log_allowed=true")
+	}
+
+	g2 := NewModelGovernor(config.ModelGovernanceConfig{Enabled: true}, nil)
+	if g2.LogAllowed() {
+		t.Error("should default to log_allowed=false")
+	}
+}
+
+func TestProviderAllowAndDenyCombined(t *testing.T) {
+	opa := newTestOPA(t, map[string]interface{}{
+		"providers": map[string]interface{}{
+			"allow": []string{"openai", "bedrock"},
+			"deny":  []string{"bedrock"},
+		},
+		"models": map[string]interface{}{
+			"allow": []string{},
+			"deny":  []string{},
+		},
+	})
+	g := NewModelGovernor(govCfg("enforce"), opa)
+
+	v := g.Check("openai", "gpt-4o")
+	if !v.Allowed {
+		t.Error("openai should be allowed")
+	}
+
+	v = g.Check("bedrock", "some-model")
+	if v.Allowed {
+		t.Error("bedrock should be denied by deny list even if in allow list")
+	}
+}

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -42,6 +42,7 @@ import (
 	"github.com/defenseclaw/defenseclaw/internal/configs"
 	"github.com/defenseclaw/defenseclaw/internal/gatewaylog"
 	"github.com/defenseclaw/defenseclaw/internal/guardrail"
+	"github.com/defenseclaw/defenseclaw/internal/policy"
 	"github.com/defenseclaw/defenseclaw/internal/redaction"
 	"github.com/defenseclaw/defenseclaw/internal/telemetry"
 	"github.com/google/uuid"
@@ -85,6 +86,7 @@ type GuardrailProxy struct {
 	dataDir string
 
 	inspector    ContentInspector
+	governor     *ModelGovernor
 	masterKey    string
 	gatewayToken string // OPENCLAW_GATEWAY_TOKEN, accepted in X-DC-Auth
 	notify       *NotificationQueue
@@ -174,6 +176,8 @@ func NewGuardrailProxy(
 	notify *NotificationQueue,
 	rp *guardrail.RulePack,
 	judgeLLM config.LLMConfig,
+	modelGov config.ModelGovernanceConfig,
+	opa *policy.Engine,
 ) (*GuardrailProxy, error) {
 	dotenvPath := filepath.Join(dataDir, ".env")
 
@@ -226,6 +230,8 @@ func NewGuardrailProxy(
 			"Set OPENCLAW_GATEWAY_TOKEN in ~/.defenseclaw/.env to require auth on all connections.\n")
 	}
 
+	governor := NewModelGovernor(modelGov, opa)
+
 	p := &GuardrailProxy{
 		cfg:          cfg,
 		logger:       logger,
@@ -234,6 +240,7 @@ func NewGuardrailProxy(
 		store:        store,
 		dataDir:      dataDir,
 		inspector:    inspector,
+		governor:     governor,
 		masterKey:    masterKey,
 		gatewayToken: gatewayToken,
 		notify:       notify,
@@ -248,6 +255,65 @@ func NewGuardrailProxy(
 // SetWebhookDispatcher attaches a webhook dispatcher for guardrail block notifications.
 func (p *GuardrailProxy) SetWebhookDispatcher(d *WebhookDispatcher) {
 	p.webhooks = d
+}
+
+// checkModelGovernance evaluates the model and provider against configured
+// governance rules. Returns true if the request was blocked (caller should
+// return). In monitor mode, denials are logged but not enforced.
+func (p *GuardrailProxy) checkModelGovernance(provider, model string) *GovernanceVerdict {
+	if p.governor == nil {
+		return nil
+	}
+
+	verdict := p.governor.Check(provider, model)
+
+	if verdict.Allowed {
+		if p.governor.LogAllowed() {
+			fmt.Fprintf(os.Stderr, "[governance] allowed: provider=%s model=%s\n", provider, model)
+		}
+		return nil
+	}
+
+	target := model
+	if provider != "" {
+		target = provider + "/" + model
+	}
+
+	fmt.Fprintf(os.Stderr, "[governance] denied: %s (rule=%s reason=%s mode=%s)\n",
+		target, verdict.Rule, verdict.Reason,
+		map[bool]string{true: "monitor", false: "enforce"}[p.governor.IsMonitorOnly()])
+
+	if p.logger != nil {
+		_ = p.logger.LogAction("model-governance-deny", target, verdict.Reason)
+	}
+	if p.store != nil {
+		evt := audit.Event{
+			Action:    "model-governance-deny",
+			Target:    target,
+			Actor:     "defenseclaw-governance",
+			Severity:  "HIGH",
+			Details:   fmt.Sprintf("rule=%s %s", verdict.Rule, verdict.Reason),
+			Timestamp: time.Now().UTC(),
+		}
+		_ = p.store.LogEvent(evt)
+	}
+	if p.webhooks != nil {
+		evt := audit.Event{
+			ID:        uuid.New().String(),
+			Timestamp: time.Now().UTC(),
+			Action:    "model-governance-deny",
+			Target:    target,
+			Actor:     "defenseclaw-governance",
+			Severity:  "HIGH",
+			Details:   fmt.Sprintf("rule=%s %s", verdict.Rule, verdict.Reason),
+		}
+		p.webhooks.Dispatch(evt)
+	}
+
+	if p.governor.IsMonitorOnly() {
+		return nil
+	}
+	return verdict
 }
 
 // Run starts the HTTP server and blocks until ctx is cancelled.
@@ -548,6 +614,15 @@ func (p *GuardrailProxy) handlePassthrough(w http.ResponseWriter, r *http.Reques
 
 	provider := inferProviderFromURL(targetForMatch)
 	label := provider + r.URL.Path // e.g. "anthropic/v1/messages"
+
+	// --- Model/provider governance (pre-inspection gate) ---
+	if p.governor != nil {
+		if gv := p.checkModelGovernance(provider, partial.Model); gv != nil {
+			msg := p.governor.BlockMessage()
+			p.writeBlockedPassthrough(w, r.URL.Path, provider, partial.Model, partial.Stream, msg)
+			return
+		}
+	}
 
 	userText := lastUserText(partial.Messages)
 	if userText == "" && partial.System != "" {
@@ -1384,6 +1459,20 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 	if len(req.Messages) == 0 {
 		writeOpenAIError(w, http.StatusBadRequest, "messages array is required and must not be empty")
 		return
+	}
+
+	// --- Model/provider governance (pre-inspection gate) ---
+	if p.governor != nil {
+		provider := inferProviderFromURL(req.TargetURL)
+		if gv := p.checkModelGovernance(provider, req.Model); gv != nil {
+			msg := p.governor.BlockMessage()
+			if req.Stream {
+				p.writeBlockedStream(w, req.Model, msg)
+			} else {
+				p.writeBlockedResponse(w, req.Model, msg)
+			}
+			return
+		}
 	}
 
 	p.reloadRuntimeConfig()

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -2541,7 +2541,6 @@ func TestRateLimitMiddleware(t *testing.T) {
 	insp := newMockInspector()
 	proxy := newTestProxy(t, prov, insp, "observe")
 
-	// Tight limiter: 1 req/s, burst 2
 	proxy.limiter = rate.NewLimiter(rate.Limit(1), 2)
 
 	body := mustJSON(t, map[string]interface{}{
@@ -2554,7 +2553,6 @@ func TestRateLimitMiddleware(t *testing.T) {
 	mux.HandleFunc("/v1/chat/completions", proxy.handleChatCompletion)
 	handler := proxy.rateLimitMiddleware(mux)
 
-	// Burst of 2 should succeed
 	for i := 0; i < 2; i++ {
 		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
@@ -2565,7 +2563,6 @@ func TestRateLimitMiddleware(t *testing.T) {
 		}
 	}
 
-	// Third request should be rate limited
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -3107,5 +3104,190 @@ func TestResponsesTextFromContent_PrettyPrintedArray(t *testing.T) {
 	got := responsesTextFromContent(content)
 	if got != "hello" {
 		t.Errorf("responsesTextFromContent with leading whitespace = %q, want %q", got, "hello")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Model governance integration tests
+// ---------------------------------------------------------------------------
+
+func newGovTestProxy(t *testing.T, gov config.ModelGovernanceConfig, govData map[string]interface{}, mode string) *GuardrailProxy {
+	t.Helper()
+	prov := &mockProvider{}
+	insp := newMockInspector()
+	p := newTestProxy(t, prov, insp, mode)
+	if govData != nil {
+		opa := newTestOPA(t, govData)
+		p.governor = NewModelGovernor(gov, opa)
+	} else {
+		p.governor = NewModelGovernor(gov, nil)
+	}
+	return p
+}
+
+func TestGovernanceDeniedModelReturnsBlock(t *testing.T) {
+	proxy := newGovTestProxy(t, config.ModelGovernanceConfig{
+		Enabled:      true,
+		Mode:         "enforce",
+		BlockMessage: "Blocked by governance",
+	}, map[string]interface{}{
+		"providers": map[string]interface{}{"allow": []string{}, "deny": []string{}},
+		"models":    map[string]interface{}{"allow": []string{}, "deny": []string{"gpt-3.5-*"}},
+	}, "observe")
+
+	body := mustJSON(t, map[string]interface{}{
+		"model": "gpt-3.5-turbo",
+		"messages": []map[string]string{
+			{"role": "user", "content": "hello"},
+		},
+	})
+
+	rec := postChat(t, proxy, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("X-DefenseClaw-Blocked"); got != "true" {
+		t.Fatalf("X-DefenseClaw-Blocked = %q, want true", got)
+	}
+	if !strings.Contains(rec.Body.String(), "Blocked by governance") {
+		t.Errorf("response body should contain governance block message, got: %s", rec.Body.String())
+	}
+}
+
+func TestGovernanceDeniedProviderReturnsBlock(t *testing.T) {
+	proxy := newGovTestProxy(t, config.ModelGovernanceConfig{
+		Enabled:      true,
+		Mode:         "enforce",
+		BlockMessage: "Provider not allowed",
+	}, map[string]interface{}{
+		"providers": map[string]interface{}{"allow": []string{}, "deny": []string{"bedrock"}},
+		"models":    map[string]interface{}{"allow": []string{}, "deny": []string{}},
+	}, "observe")
+
+	body := mustJSON(t, map[string]interface{}{
+		"model": "claude-3.5-sonnet",
+		"messages": []map[string]string{
+			{"role": "user", "content": "hello"},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-DC-Target-URL", "https://bedrock-runtime.us-east-1.amazonaws.com/model/invoke")
+	rec := httptest.NewRecorder()
+	proxy.handleChatCompletion(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("X-DefenseClaw-Blocked"); got != "true" {
+		t.Fatalf("X-DefenseClaw-Blocked = %q, want true", got)
+	}
+	if !strings.Contains(rec.Body.String(), "Provider not allowed") {
+		t.Errorf("response should contain block message, got: %s", rec.Body.String())
+	}
+}
+
+func TestGovernanceAllowedModelProceedsToInspection(t *testing.T) {
+	proxy := newGovTestProxy(t, config.ModelGovernanceConfig{
+		Enabled: true,
+		Mode:    "enforce",
+	}, map[string]interface{}{
+		"providers": map[string]interface{}{"allow": []string{}, "deny": []string{}},
+		"models":    map[string]interface{}{"allow": []string{"gpt-4o", "gpt-4o-*"}, "deny": []string{}},
+	}, "observe")
+
+	body := mustJSON(t, map[string]interface{}{
+		"model": "gpt-4o",
+		"messages": []map[string]string{
+			{"role": "user", "content": "hello"},
+		},
+	})
+
+	rec := postChat(t, proxy, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("X-DefenseClaw-Blocked"); got == "true" {
+		t.Fatal("allowed model should not be blocked")
+	}
+}
+
+func TestGovernanceMonitorModeDoesNotBlock(t *testing.T) {
+	proxy := newGovTestProxy(t, config.ModelGovernanceConfig{
+		Enabled:      true,
+		Mode:         "monitor",
+		BlockMessage: "Monitored block",
+	}, map[string]interface{}{
+		"providers": map[string]interface{}{"allow": []string{}, "deny": []string{}},
+		"models":    map[string]interface{}{"allow": []string{}, "deny": []string{"gpt-3.5-*"}},
+	}, "observe")
+
+	body := mustJSON(t, map[string]interface{}{
+		"model": "gpt-3.5-turbo",
+		"messages": []map[string]string{
+			{"role": "user", "content": "hello"},
+		},
+	})
+
+	rec := postChat(t, proxy, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("X-DefenseClaw-Blocked"); got == "true" {
+		t.Fatal("monitor mode should not block the request")
+	}
+}
+
+func TestGovernanceDisabledAllowsEverything(t *testing.T) {
+	proxy := newGovTestProxy(t, config.ModelGovernanceConfig{
+		Enabled: false,
+	}, nil, "observe")
+
+	body := mustJSON(t, map[string]interface{}{
+		"model": "gpt-3.5-turbo",
+		"messages": []map[string]string{
+			{"role": "user", "content": "hello"},
+		},
+	})
+
+	rec := postChat(t, proxy, body)
+
+	if got := rec.Header().Get("X-DefenseClaw-Blocked"); got == "true" {
+		t.Fatal("disabled governance should not block anything")
+	}
+}
+
+func TestGovernanceDeniedModelStreaming(t *testing.T) {
+	proxy := newGovTestProxy(t, config.ModelGovernanceConfig{
+		Enabled:      true,
+		Mode:         "enforce",
+		BlockMessage: "Streaming governance block",
+	}, map[string]interface{}{
+		"providers": map[string]interface{}{"allow": []string{}, "deny": []string{}},
+		"models":    map[string]interface{}{"allow": []string{}, "deny": []string{"gpt-3.5-*"}},
+	}, "observe")
+
+	body := mustJSON(t, map[string]interface{}{
+		"model":  "gpt-3.5-turbo",
+		"stream": true,
+		"messages": []map[string]string{
+			{"role": "user", "content": "hello"},
+		},
+	})
+
+	rec := postChat(t, proxy, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("X-DefenseClaw-Blocked"); got != "true" {
+		t.Fatalf("X-DefenseClaw-Blocked = %q, want true", got)
+	}
+	if !strings.Contains(rec.Body.String(), "Streaming governance block") {
+		t.Errorf("streaming response should contain governance block message, got: %s", rec.Body.String())
 	}
 }

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -937,6 +937,8 @@ func (s *Sidecar) runGuardrail(ctx context.Context) error {
 		s.notify,
 		rp,
 		s.cfg.ResolveLLM("guardrail.judge"),
+		s.cfg.ModelGovernance,
+		s.opa,
 	)
 	if err == nil && s.webhooks != nil {
 		proxy.SetWebhookDispatcher(s.webhooks)

--- a/internal/gateway/webhook.go
+++ b/internal/gateway/webhook.go
@@ -738,6 +738,8 @@ func webexSeverityIcon(severity string) string {
 
 func categorizeAction(action string) string {
 	switch {
+	case strings.Contains(action, "governance"):
+		return "governance"
 	case strings.Contains(action, "gateway-down"),
 		strings.Contains(action, "gateway-recovered"),
 		strings.Contains(action, "guardrail-degraded"):

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -241,6 +241,24 @@ func (e *Engine) EvaluateSkillActions(ctx context.Context, input SkillActionsInp
 }
 
 // ---------------------------------------------------------------------------
+// Model Governance
+// ---------------------------------------------------------------------------
+
+// EvaluateModelGovernance runs the model governance policy to determine if a
+// model/provider combination is allowed or denied.
+func (e *Engine) EvaluateModelGovernance(ctx context.Context, input ModelGovernanceInput) (*ModelGovernanceOutput, error) {
+	result, err := e.eval(ctx, "data.defenseclaw.model_governance", input)
+	if err != nil {
+		return nil, fmt.Errorf("policy: model_governance eval: %w", err)
+	}
+	return &ModelGovernanceOutput{
+		Action: stringVal(result, "action"),
+		Reason: stringVal(result, "reason"),
+		Rule:   stringVal(result, "rule"),
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
 // Compile
 // ---------------------------------------------------------------------------
 

--- a/internal/policy/types.go
+++ b/internal/policy/types.go
@@ -130,6 +130,19 @@ type AuditOutput struct {
 	ExportTo     []string `json:"export_to"`
 }
 
+// ModelGovernanceInput is the structured input passed to the OPA model_governance policy.
+type ModelGovernanceInput struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+}
+
+// ModelGovernanceOutput is the structured output from the OPA model_governance policy.
+type ModelGovernanceOutput struct {
+	Action string `json:"action"` // "allow" or "deny"
+	Reason string `json:"reason"`
+	Rule   string `json:"rule"` // "provider-allow", "provider-deny", "model-allow", "model-deny"
+}
+
 // SkillActionsInput is the structured input passed to the OPA skill_actions policy.
 type SkillActionsInput struct {
 	Severity   string `json:"severity"`

--- a/policies/default.yaml
+++ b/policies/default.yaml
@@ -131,6 +131,13 @@ watch:
 #     secret_env: SLACK_WEBHOOK_SECRET
 webhooks: []
 
+# Model & provider governance — blocks unauthorized models/providers before
+# guardrail content inspection. Allow/deny lists are configured in the OPA
+# Rego data layer (data.json), not here.
+model_governance:
+  enabled: false
+  mode: enforce
+
 enforcement:
   max_enforcement_delay_seconds: 2
 

--- a/policies/rego/data.json
+++ b/policies/rego/data.json
@@ -74,6 +74,16 @@
     "log_all_actions": true,
     "log_scan_results": true
   },
+  "model_governance": {
+    "providers": {
+      "allow": [],
+      "deny": []
+    },
+    "models": {
+      "allow": [],
+      "deny": []
+    }
+  },
   "guardrail": {
     "severity_rank": {
       "NONE": 0,

--- a/policies/rego/model_governance.rego
+++ b/policies/rego/model_governance.rego
@@ -1,0 +1,142 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+package defenseclaw.model_governance
+
+import rego.v1
+
+# Model & provider governance policy.
+# Input fields:
+#   provider  - inferred provider name (e.g. "openai", "bedrock")
+#   model     - model name from request body (e.g. "gpt-4o")
+#
+# Static data (data.model_governance in data.json):
+#   providers.allow  - list of allowed providers (empty = all allowed)
+#   providers.deny   - list of denied providers
+#   models.allow     - list of allowed model patterns (supports glob via *)
+#   models.deny      - list of denied model patterns (supports glob via *)
+
+default action := "allow"
+default reason := ""
+default rule := ""
+
+# --- Provider checks (evaluated first) ---
+
+# Deny if provider allow list is non-empty and provider is not in it
+action := "deny" if {
+	count(data.model_governance.providers.allow) > 0
+	input.provider != ""
+	not _provider_in_allow
+}
+
+rule := "provider-allow" if {
+	count(data.model_governance.providers.allow) > 0
+	input.provider != ""
+	not _provider_in_allow
+}
+
+reason := sprintf("provider %q is not in the allowed list", [input.provider]) if {
+	count(data.model_governance.providers.allow) > 0
+	input.provider != ""
+	not _provider_in_allow
+}
+
+# Deny if provider is explicitly in the deny list
+action := "deny" if {
+	_provider_in_deny
+}
+
+rule := "provider-deny" if {
+	_provider_in_deny
+}
+
+reason := sprintf("provider %q is explicitly denied", [input.provider]) if {
+	_provider_in_deny
+}
+
+# --- Model checks (evaluated after provider) ---
+
+# Deny if model allow list is non-empty and model is not in it
+action := "deny" if {
+	not _provider_denied
+	count(data.model_governance.models.allow) > 0
+	input.model != ""
+	not _model_in_allow
+}
+
+rule := "model-allow" if {
+	not _provider_denied
+	count(data.model_governance.models.allow) > 0
+	input.model != ""
+	not _model_in_allow
+}
+
+reason := sprintf("model %q is not in the allowed list", [input.model]) if {
+	not _provider_denied
+	count(data.model_governance.models.allow) > 0
+	input.model != ""
+	not _model_in_allow
+}
+
+# Deny if model is explicitly in the deny list
+action := "deny" if {
+	not _provider_denied
+	_model_in_deny
+}
+
+rule := "model-deny" if {
+	not _provider_denied
+	_model_in_deny
+}
+
+reason := sprintf("model %q is explicitly denied", [input.model]) if {
+	not _provider_denied
+	_model_in_deny
+}
+
+# --- Helper rules ---
+
+_provider_denied if {
+	count(data.model_governance.providers.allow) > 0
+	input.provider != ""
+	not _provider_in_allow
+}
+
+_provider_denied if {
+	_provider_in_deny
+}
+
+_provider_in_allow if {
+	some p in data.model_governance.providers.allow
+	lower(p) == lower(input.provider)
+}
+
+_provider_in_deny if {
+	input.provider != ""
+	some p in data.model_governance.providers.deny
+	lower(p) == lower(input.provider)
+}
+
+_model_in_allow if {
+	some pattern in data.model_governance.models.allow
+	glob.match(lower(pattern), ["/"], lower(input.model))
+}
+
+_model_in_deny if {
+	input.model != ""
+	some pattern in data.model_governance.models.deny
+	glob.match(lower(pattern), ["/"], lower(input.model))
+}

--- a/policies/rego/model_governance_test.rego
+++ b/policies/rego/model_governance_test.rego
@@ -1,0 +1,158 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+package defenseclaw.model_governance_test
+
+import rego.v1
+
+import data.defenseclaw.model_governance
+
+# ── Empty lists allow everything ──
+
+test_empty_lists_allow_all if {
+	result := model_governance with input as {"provider": "openai", "model": "gpt-4o"}
+		with data.model_governance as {
+			"providers": {"allow": [], "deny": []},
+			"models": {"allow": [], "deny": []},
+		}
+	result.action == "allow"
+}
+
+# ── Provider deny ──
+
+test_provider_deny if {
+	result := model_governance with input as {"provider": "bedrock", "model": "claude-3.5-sonnet"}
+		with data.model_governance as {
+			"providers": {"allow": [], "deny": ["bedrock"]},
+			"models": {"allow": [], "deny": []},
+		}
+	result.action == "deny"
+	result.rule == "provider-deny"
+}
+
+test_provider_not_denied_passes if {
+	result := model_governance with input as {"provider": "openai", "model": "gpt-4o"}
+		with data.model_governance as {
+			"providers": {"allow": [], "deny": ["bedrock"]},
+			"models": {"allow": [], "deny": []},
+		}
+	result.action == "allow"
+}
+
+# ── Provider allow ──
+
+test_provider_allow_blocks_unlisted if {
+	result := model_governance with input as {"provider": "gemini", "model": "gemini-pro"}
+		with data.model_governance as {
+			"providers": {"allow": ["openai", "anthropic"], "deny": []},
+			"models": {"allow": [], "deny": []},
+		}
+	result.action == "deny"
+	result.rule == "provider-allow"
+}
+
+test_provider_allow_passes_listed if {
+	result := model_governance with input as {"provider": "openai", "model": "gpt-4o"}
+		with data.model_governance as {
+			"providers": {"allow": ["openai", "anthropic"], "deny": []},
+			"models": {"allow": [], "deny": []},
+		}
+	result.action == "allow"
+}
+
+# ── Model deny with globs ──
+
+test_model_deny_glob if {
+	result := model_governance with input as {"provider": "openai", "model": "gpt-3.5-turbo"}
+		with data.model_governance as {
+			"providers": {"allow": [], "deny": []},
+			"models": {"allow": [], "deny": ["gpt-3.5-*"]},
+		}
+	result.action == "deny"
+	result.rule == "model-deny"
+}
+
+test_model_deny_exact if {
+	result := model_governance with input as {"provider": "openai", "model": "llama-2-13b"}
+		with data.model_governance as {
+			"providers": {"allow": [], "deny": []},
+			"models": {"allow": [], "deny": ["llama-2-13b"]},
+		}
+	result.action == "deny"
+	result.rule == "model-deny"
+}
+
+test_model_not_denied_passes if {
+	result := model_governance with input as {"provider": "openai", "model": "gpt-4o"}
+		with data.model_governance as {
+			"providers": {"allow": [], "deny": []},
+			"models": {"allow": [], "deny": ["gpt-3.5-*"]},
+		}
+	result.action == "allow"
+}
+
+# ── Model allow with globs ──
+
+test_model_allow_blocks_unlisted if {
+	result := model_governance with input as {"provider": "openai", "model": "llama-3-70b"}
+		with data.model_governance as {
+			"providers": {"allow": [], "deny": []},
+			"models": {"allow": ["gpt-4o*", "claude-*"], "deny": []},
+		}
+	result.action == "deny"
+	result.rule == "model-allow"
+}
+
+test_model_allow_passes_listed if {
+	result := model_governance with input as {"provider": "openai", "model": "gpt-4o-mini"}
+		with data.model_governance as {
+			"providers": {"allow": [], "deny": []},
+			"models": {"allow": ["gpt-4o*", "claude-*"], "deny": []},
+		}
+	result.action == "allow"
+}
+
+# ── Case insensitivity ──
+
+test_case_insensitive_provider if {
+	result := model_governance with input as {"provider": "OPENAI", "model": "gpt-4o"}
+		with data.model_governance as {
+			"providers": {"allow": ["openai"], "deny": []},
+			"models": {"allow": [], "deny": []},
+		}
+	result.action == "allow"
+}
+
+test_case_insensitive_model if {
+	result := model_governance with input as {"provider": "openai", "model": "GPT-3.5-TURBO"}
+		with data.model_governance as {
+			"providers": {"allow": [], "deny": []},
+			"models": {"allow": [], "deny": ["gpt-3.5-*"]},
+		}
+	result.action == "deny"
+}
+
+# ── Provider deny takes precedence over model checks ──
+
+test_provider_deny_short_circuits_model if {
+	result := model_governance with input as {"provider": "bedrock", "model": "gpt-4o"}
+		with data.model_governance as {
+			"providers": {"allow": [], "deny": ["bedrock"]},
+			"models": {"allow": ["gpt-4o"], "deny": []},
+		}
+	result.action == "deny"
+	result.rule == "provider-deny"
+}

--- a/policies/strict.yaml
+++ b/policies/strict.yaml
@@ -148,6 +148,14 @@ watch:
 #     enabled: true
 webhooks: []
 
+# Model & provider governance — strict mode. Allow/deny lists are in the OPA
+# Rego data layer (data.json). See policies/rego/data.json for the strict
+# example: deny openrouter/bedrock, allow only enterprise models.
+model_governance:
+  enabled: true
+  mode: enforce
+  block_message: "This model or provider is not authorized by your organization's security policy."
+
 enforcement:
   max_enforcement_delay_seconds: 1
 


### PR DESCRIPTION
# feat: Model & Provider Governance (OPA policy-based allow/deny)

## Motivation

As organizations adopt agentic AI platforms like OpenClaw, developers and agents can freely route requests to any LLM provider and model. This creates several enterprise risks:

- **Shadow AI** — developers use unapproved models (e.g. via OpenRouter or personal API keys) that haven't been vetted for compliance, accuracy, or cost, bypassing organizational oversight entirely
- **Data residency violations** — requests routed to providers like Bedrock in unapproved regions, or through third-party aggregators like OpenRouter, may violate data sovereignty requirements (GDPR, HIPAA, FedRAMP)
- **Cost control** — unrestricted access to expensive models (GPT-4o) or deprecated cheap models (GPT-3.5-turbo) with no visibility makes budgeting impossible
- **Model drift risk** — teams silently adopting newer model versions without validation can introduce regressions in downstream agent behavior

Today, DefenseClaw inspects *content* (prompt injection, PII, secrets) but has no gate on *which model or provider* is being called. This PR closes that gap by adding a governance layer backed by OPA Rego policy — consistent with how all other policy decisions (admission, guardrail, firewall, skill_actions) are made.

## Summary

Adds a **pre-inspection governance gate** to the guardrail proxy that enforces which LLM models and providers are permitted before any upstream call or content inspection occurs. Decisions are made by the OPA policy engine via a new `model_governance.rego` policy, with allow/deny lists stored in the Rego data layer (`data.json`).

### What it does

- **OPA-based allow/deny evaluation** — provider and model governance rules live in `data.json` (the Rego data layer), evaluated by `model_governance.rego` via the existing `policy.Engine`
- **Glob pattern matching** — model patterns support globs via OPA's `glob.match` (e.g. `gpt-4o-*`, `claude-*`)
- **Pre-inspection check** — governance runs *before* guardrail content inspection, failing fast and avoiding unnecessary scanner work
- **Enforce / Monitor modes** — `enforce` blocks denied requests; `monitor` logs denials but allows them through (shadow mode for safe rollout)
- **Audit & webhooks** — denied requests emit `model-governance-deny` audit events (severity HIGH) and are dispatched to configured webhook endpoints (Slack, Webex, PagerDuty, generic)
- **OpenAI-compatible responses** — blocked requests return proper chat completion responses (both streaming and non-streaming) with `defenseclaw_blocked: true` metadata

### Architecture

```
Incoming LLM Request → authenticateRequest → Parse model + provider
  → ModelGovernor.Check(provider, model)
    → policy.EvaluateModelGovernance() → OPA Rego evaluation
      → DENIED: 200 blocked response + audit event + webhook
      → ALLOWED: Guardrail Content Inspection → Forward to Upstream
```

The `ModelGovernor` wraps the OPA `policy.Engine` and is nil-safe — a nil governor (feature disabled or no OPA engine) always allows with zero overhead.

### Config

**config.yaml — runtime knobs:**

```yaml
model_governance:
  enabled: true
  mode: enforce              # enforce | monitor
  block_message: "This model or provider is not authorized by your organization's policy."
  log_allowed: false
```

**data.json — allow/deny rules (OPA Rego data layer):**

```json
{
  "model_governance": {
    "providers": {
      "allow": ["openai", "anthropic"],
      "deny": ["openrouter", "bedrock"]
    },
    "models": {
      "allow": [],
      "deny": ["gpt-3.5-*", "llama-*"]
    }
  }
}
```

### Files changed

| File | Change |
|------|--------|
| `policies/rego/model_governance.rego` | **NEW** — Rego policy evaluating provider/model allow/deny with `glob.match`, case-insensitive, deny-overrides-allow |
| `policies/rego/model_governance_test.rego` | **NEW** — 13 Rego-level unit tests for the policy |
| `policies/rego/data.json` | Added `model_governance` section with empty allow/deny lists (default) |
| `internal/policy/types.go` | `ModelGovernanceInput` and `ModelGovernanceOutput` structs |
| `internal/policy/engine.go` | `EvaluateModelGovernance()` method |
| `internal/gateway/model_governance.go` | `ModelGovernor` wrapping OPA engine, `Check()`, nil-safe |
| `internal/gateway/model_governance_test.go` | 14 unit tests with real OPA engine evaluation |
| `internal/config/config.go` | `ModelGovernanceConfig` (enabled, mode, block_message, log_allowed — no allow/deny fields) |
| `internal/config/defaults.go` | Default governance config in `DefaultConfig()` |
| `internal/gateway/proxy.go` | `governor` field, `checkModelGovernance()` helper, OPA engine passthrough to `NewModelGovernor` |
| `internal/gateway/proxy_test.go` | 6 integration tests with OPA-backed governance |
| `internal/gateway/sidecar.go` | Pass OPA engine + config to `NewGuardrailProxy` |
| `internal/gateway/webhook.go` | `"governance"` category in `categorizeAction` |
| `docs/CONFIG_FILES.md` | Split documentation: config.yaml (runtime) + data.json (policy rules) |
| `policies/default.yaml` | `model_governance` section (disabled) |
| `policies/strict.yaml` | `model_governance` section (enabled, points to data.json) |

### Design decisions

- **OPA-native** — allow/deny lists live in `data.json` and are evaluated by Rego, consistent with admission, guardrail, firewall, and skill_actions policy domains
- **Glob via `glob.match`** — OPA's built-in `glob.match` is safe, performant, and covers model naming patterns with no ReDoS risk
- **Provider checked before model** — if provider is denied, model checks are short-circuited (Rego `_provider_denied` guard)
- **Deny overrides allow** — when a provider/model appears in both allow and deny lists, deny wins
- **Case-insensitive matching** — all comparisons normalize to lowercase via Rego's `lower()`
- **Fail-open on OPA error** — if the OPA engine returns an error, the request is allowed (fail-open) to avoid breaking the proxy

## Test plan

- [x] 13 Rego unit tests (`opa test`) — provider allow/deny, model allow/deny with globs, case insensitivity, deny short-circuits model
- [x] 14 Go unit tests for `ModelGovernor` — nil/disabled governor, no OPA engine, provider/model allow/deny, globs, combined rules, empty lists, case insensitivity, monitor mode, block message, log_allowed
- [x] 6 proxy integration tests — denied model, denied provider, allowed model, monitor mode, disabled, streaming
- [x] 96/96 Rego tests pass (`opa test policies/rego/ -v`)
- [x] All Go tests pass (`internal/gateway/`, `internal/policy/`, `internal/config/`)
- [x] `go vet` + `go build` clean

### E2E verification

Live-tested against a running `defenseclaw-gateway` with OPA policy engine loaded:

| Test | Model/Provider | Mode | Expected | Result |
|------|---------------|------|----------|--------|
| Denied model | `gpt-3.5-turbo` (deny glob `gpt-3.5-*`) | enforce | Blocked | PASS |
| Denied provider | `gemini` (not in allow list `[openai, anthropic]`) | enforce | Blocked | PASS |
| Denied model | `llama-3-70b` (deny glob `llama-*`) | enforce | Blocked | PASS |
| Denied model streaming | `gpt-3.5-turbo` stream=true | enforce | Blocked SSE | PASS |
| Allowed model | `gpt-4o` via OpenAI (provider allowed) | enforce | Passes to upstream | PASS |
| Monitor mode | `gpt-3.5-turbo` (denied but monitor) | monitor | Logged, not blocked | PASS |

All denials recorded in SQLite audit store with `action=model-governance-deny`, `severity=HIGH`.

### Example: gateway log output (OPA-evaluated)

```
[sidecar] OPA policy engine loaded from /tmp/dc-e2e-opa/data/rego
[governance] denied: gemini/gemini-pro (rule=provider-allow reason=provider "gemini" is not in the allowed list mode=enforce)
[governance] denied: llama-3-70b (rule=model-deny reason=model "llama-3-70b" is explicitly denied mode=enforce)
[governance] denied: openai/gpt-3.5-turbo (rule=model-deny reason=model "gpt-3.5-turbo" is explicitly denied mode=monitor)
[governance] allowed: provider=openai model=gpt-4o
```

### Example: audit DB query

```sql
SELECT action, severity, target, details FROM audit_events
WHERE action LIKE '%governance%' ORDER BY timestamp DESC;

model-governance-deny|HIGH|openai/gpt-3.5-turbo|rule=model-deny model "gpt-3.5-turbo" is explicitly denied
model-governance-deny|HIGH|gpt-3.5-turbo|rule=model-deny model "gpt-3.5-turbo" is explicitly denied
```
