### PR TITLE
Add desktop agent OTel config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OC_EXT_DIR  := $(HOME)/.openclaw/extensions/defenseclaw
 
 DIST_DIR    := dist
 
-.PHONY: build install cli-install dev-install pycli dev-pycli gateway gateway-cross gateway-run start gateway-install \
+.PHONY: build install cli-install dev-install pycli dev-pycli gateway gateway-cross gateway-run start gateway-install agent-otel \
         plugin plugin-install test cli-test cli-test-cov gateway-test go-test-cov \
         test-verbose test-file lint py-lint go-lint ts-test rego-test clean \
         dist dist-cli dist-gateway dist-plugin dist-sandbox dist-test dist-checksums dist-clean
@@ -85,6 +85,12 @@ gateway-cross:
 
 gateway-run: gateway
 	./$(GATEWAY)
+
+agent-otel:
+	go build $(GOFLAGS) -o defenseclaw-agent-otel ./cmd/agentotel
+	@echo "Built defenseclaw-agent-otel"
+	@echo "  Configure direct Splunk export: ./defenseclaw-agent-otel configure --tool all --splunk-host us1 --token \"\$$SPLUNK_OBSERVABILITY_TOKEN\""
+	@echo "  Configure generic OTLP export: ./defenseclaw-agent-otel configure --tool all --endpoint http://collector:4318 --token \"\$$OTLP_AUTH_TOKEN\""
 
 start: gateway
 	@./scripts/start.sh $(ARGS)

--- a/README.md
+++ b/README.md
@@ -223,6 +223,44 @@ codex exec --skip-git-repo-check --json "Reply with ok only"
 claude -p --model haiku --output-format json "Reply with ok only"
 ```
 
+For a single session without changing persistent desktop config, use `run`:
+
+```bash
+export CODEX_RUN_ENV="codex-run-test-$(date +%s)"
+
+./defenseclaw-agent-otel run \
+  --tool codex \
+  --splunk-host app.us1.observability.splunkcloud.com \
+  --token "$SPLUNK_OBSERVABILITY_TOKEN" \
+  --environment "$CODEX_RUN_ENV" \
+  --tenant-id demo-tenant \
+  --workspace-id defenseclaw \
+  --agent-name codex-desktop \
+  -- exec --skip-git-repo-check --json "Reply with ok only"
+```
+
+```bash
+export CLAUDE_RUN_ENV="claude-run-test-$(date +%s)"
+
+./defenseclaw-agent-otel run \
+  --tool claude \
+  --splunk-host app.us1.observability.splunkcloud.com \
+  --token "$SPLUNK_OBSERVABILITY_TOKEN" \
+  --claude-environment "$CLAUDE_RUN_ENV" \
+  --claude-tenant-id demo-tenant \
+  --claude-workspace-id defenseclaw \
+  --claude-agent-name claude-desktop \
+  -- -p --model haiku --output-format json "Reply with ok only"
+```
+
+For `Claude Code`, `run` injects OTEL settings through runtime environment
+variables only. For `Codex`, `run` injects OTEL settings through runtime
+environment variables and one-shot `otel.*` CLI overrides. It does not modify
+the real `~/.claude/settings.json` or `~/.codex/config.toml`.
+
+When verifying these one-shot runs in Splunk O11y, the trace-derived series can
+take a couple of minutes to appear after the command finishes.
+
 Remove the desktop config later with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -272,9 +272,9 @@ This writes:
 - `~/.claude/settings.json`
 - `~/.codex/config.toml`
 
-Current caveat: direct `Codex` export is flowing, but Splunk O11y is still
-showing `deployment.environment` / `sf_environment` as `unknown` in live
-verification, even when `--environment` is written to `~/.codex/config.toml`.
+Recent live verification showed the one-shot `run` flow publishing trace-derived
+series for both `Codex Desktop` and `claude-code`, with the requested
+`sf_environment` visible in Splunk O11y after a short ingestion delay.
 
 For the full desktop OTel details and caveats, see [docs/defenseclaw-agent-otel/README.md](docs/defenseclaw-agent-otel/README.md).
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,88 @@ defenseclaw init --enable-guardrail
 
 For platform-specific instructions (DGX Spark, macOS, cross-compilation), see [docs/INSTALL.md](docs/INSTALL.md).
 
+### Claude Code / Codex Desktop OTel Setup
+
+Build the desktop config writer:
+
+```bash
+make agent-otel
+```
+
+Or directly:
+
+```bash
+go build -ldflags "-X main.version=0.2.0" -o defenseclaw-agent-otel ./cmd/agentotel
+```
+
+Configure both `Claude Code` and `Codex` to send telemetry directly to Splunk Observability Cloud:
+
+```bash
+export SPLUNK_OBSERVABILITY_TOKEN="your-token-here"
+
+./defenseclaw-agent-otel configure \
+  --tool all \
+  --splunk-host app.us1.observability.splunkcloud.com \
+  --token "$SPLUNK_OBSERVABILITY_TOKEN" \
+  --environment defenseclaw-direct-test
+```
+
+If you want extra resource tags:
+
+```bash
+export SPLUNK_OBSERVABILITY_TOKEN="your-token-here"
+
+./defenseclaw-agent-otel configure \
+  --tool all \
+  --splunk-host app.us1.observability.splunkcloud.com \
+  --token "$SPLUNK_OBSERVABILITY_TOKEN" \
+  --environment defenseclaw-direct-test \
+  --tenant-id demo-tenant \
+  --workspace-id defenseclaw \
+  --agent-name desktop-agents
+```
+
+If `Claude Code` and `Codex` should be tracked as distinct desktop agents, use
+tool-specific overrides:
+
+```bash
+export SPLUNK_OBSERVABILITY_TOKEN="your-token-here"
+
+./defenseclaw-agent-otel configure \
+  --tool all \
+  --splunk-host app.us1.observability.splunkcloud.com \
+  --token "$SPLUNK_OBSERVABILITY_TOKEN" \
+  --environment desktop \
+  --claude-agent-name claude-desktop \
+  --claude-environment claude-dev \
+  --codex-agent-name codex-desktop \
+  --codex-environment codex-dev
+```
+
+After the one-time setup, users run the normal tools:
+
+```bash
+codex exec --skip-git-repo-check --json "Reply with ok only"
+claude -p --model haiku --output-format json "Reply with ok only"
+```
+
+Remove the desktop config later with:
+
+```bash
+./defenseclaw-agent-otel unconfigure --tool all
+```
+
+This writes:
+
+- `~/.claude/settings.json`
+- `~/.codex/config.toml`
+
+Current caveat: direct `Codex` export is flowing, but Splunk O11y is still
+showing `deployment.environment` / `sf_environment` as `unknown` in live
+verification, even when `--environment` is written to `~/.codex/config.toml`.
+
+For the full desktop OTel details and caveats, see [docs/defenseclaw-agent-otel/README.md](docs/defenseclaw-agent-otel/README.md).
+
 ---
 
 ## Quick Start

--- a/cmd/agentotel/main.go
+++ b/cmd/agentotel/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -15,11 +16,11 @@ var version = "dev"
 func main() {
 	root := &cobra.Command{
 		Use:     "defenseclaw-agent-otel",
-		Short:   "Persistent OTLP configuration helper for Claude Code and Codex",
+		Short:   "Direct OTLP launcher and config helper for Claude Code and Codex",
 		Version: version,
 	}
 
-	root.AddCommand(configureCmd(), unconfigureCmd())
+	root.AddCommand(configureCmd(), runCmd(), unconfigureCmd())
 
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
@@ -65,6 +66,75 @@ tracked as distinct desktop agents in the same command, for example
 	}
 	f := cmd.Flags()
 	f.StringVar(&opts.Tool, "tool", agentotel.ToolAll, "Tool to configure: claude, codex, or all")
+	f.StringVar(&opts.Endpoint, "endpoint", "", "Base OTLP/HTTP endpoint, for example http://collector:4318")
+	f.StringVar(&opts.Token, "token", "", "Auth token for direct OTLP export (or set OTLP_AUTH_TOKEN / SPLUNK_OBSERVABILITY_TOKEN)")
+	f.StringVar(&opts.DeprecatedSplunkToken, "splunk-token", "", "Deprecated alias for --token")
+	_ = f.MarkDeprecated("splunk-token", "use --token instead")
+	f.StringVar(&opts.HeaderName, "header-name", "", "HTTP header name for direct auth; defaults to Authorization or X-SF-Token")
+	f.StringVar(&opts.HeaderPrefix, "header-prefix", "", "Prefix added before --token, for example 'Bearer '")
+	f.StringVar(&opts.SplunkHost, "splunk-host", "", "Splunk Observability host or realm for direct Splunk mode")
+	f.StringVar(&opts.TenantID, "tenant-id", "", "Tenant identifier for resource attributes where supported")
+	f.StringVar(&opts.WorkspaceID, "workspace-id", "", "Workspace identifier for resource attributes where supported")
+	f.StringVar(&opts.AgentName, "agent-name", "", "Logical agent name for resource attributes where supported")
+	f.StringVar(&opts.Environment, "environment", "dev", "Environment tag")
+	f.StringVar(&opts.ClaudeTenantID, "claude-tenant-id", "", "Claude-specific tenant identifier override")
+	f.StringVar(&opts.ClaudeWorkspaceID, "claude-workspace-id", "", "Claude-specific workspace identifier override")
+	f.StringVar(&opts.ClaudeAgentName, "claude-agent-name", "", "Claude-specific agent name override")
+	f.StringVar(&opts.ClaudeEnvironment, "claude-environment", "", "Claude-specific environment override")
+	f.StringVar(&opts.CodexTenantID, "codex-tenant-id", "", "Codex-specific tenant identifier override")
+	f.StringVar(&opts.CodexWorkspaceID, "codex-workspace-id", "", "Codex-specific workspace identifier override")
+	f.StringVar(&opts.CodexAgentName, "codex-agent-name", "", "Codex-specific agent name override")
+	f.StringVar(&opts.CodexEnvironment, "codex-environment", "", "Codex-specific environment override")
+	return cmd
+}
+
+func runCmd() *cobra.Command {
+	var opts agentotel.RunOpts
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Launch Claude Code or Codex once with direct OTEL settings injected",
+		Long: `Runs Claude Code or Codex once with direct OTLP settings applied for the
+session.
+
+Claude uses runtime OTEL environment variables only in one-shot mode. Codex
+uses runtime OTEL environment variables plus one-shot otel.* command-line
+overrides. The command does not create a temporary home directory or persist
+changes into the user's real desktop settings files.
+
+Examples:
+
+  defenseclaw-agent-otel run \
+    --tool codex \
+    --splunk-host us1 \
+    --token "$SPLUNK_OBSERVABILITY_TOKEN" \
+    --environment defenseclaw-run-test \
+    -- exec --skip-git-repo-check --json "Reply with ok only"
+
+  defenseclaw-agent-otel run \
+    --tool claude \
+    --splunk-host us1 \
+    --token "$SPLUNK_OBSERVABILITY_TOKEN" \
+    --claude-agent-name claude-desktop \
+    -- -p --model haiku --output-format json "Reply with ok only"`,
+		Args: cobra.ArbitraryArgs,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateToolValue(opts.Tool); err != nil {
+				return err
+			}
+			switch strings.ToLower(strings.TrimSpace(opts.Tool)) {
+			case agentotel.ToolClaude, agentotel.ToolCodex:
+				return nil
+			default:
+				return fmt.Errorf("run requires --tool %q or %q", agentotel.ToolClaude, agentotel.ToolCodex)
+			}
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return agentotel.Run(context.Background(), opts, args)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&opts.Tool, "tool", "", "Tool to run: claude or codex")
+	f.StringVar(&opts.Binary, "binary", "", "Optional path to the claude/codex binary; defaults to the tool name")
 	f.StringVar(&opts.Endpoint, "endpoint", "", "Base OTLP/HTTP endpoint, for example http://collector:4318")
 	f.StringVar(&opts.Token, "token", "", "Auth token for direct OTLP export (or set OTLP_AUTH_TOKEN / SPLUNK_OBSERVABILITY_TOKEN)")
 	f.StringVar(&opts.DeprecatedSplunkToken, "splunk-token", "", "Deprecated alias for --token")

--- a/cmd/agentotel/main.go
+++ b/cmd/agentotel/main.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/defenseclaw/defenseclaw/internal/agentotel"
+)
+
+var version = "dev"
+
+func main() {
+	root := &cobra.Command{
+		Use:     "defenseclaw-agent-otel",
+		Short:   "Persistent OTLP configuration helper for Claude Code and Codex",
+		Version: version,
+	}
+
+	root.AddCommand(configureCmd(), unconfigureCmd())
+
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func configureCmd() *cobra.Command {
+	var opts agentotel.ConfigureOpts
+	cmd := &cobra.Command{
+		Use:   "configure",
+		Short: "Write persistent OTLP configuration for Claude Code and Codex",
+		Long: `Writes persistent configuration into ~/.claude/settings.json (for Claude Code)
+and ~/.codex/config.toml (for Codex) so normal desktop launches send telemetry
+directly to Splunk Observability Cloud or another OTLP/HTTP endpoint.
+
+Example:
+
+  defenseclaw-agent-otel configure \
+    --tool all \
+    --splunk-host us1 \
+    --token "$SPLUNK_OBSERVABILITY_TOKEN" \
+    --environment defenseclaw-direct-test
+
+Or configure a generic OTLP/HTTP endpoint:
+
+  defenseclaw-agent-otel configure \
+    --tool all \
+    --endpoint http://collector.internal:4318 \
+    --token "$OTLP_AUTH_TOKEN" \
+    --header-name Authorization \
+    --header-prefix "Bearer "
+
+Tool-specific overrides are also available when Claude and Codex should be
+tracked as distinct desktop agents in the same command, for example
+--claude-agent-name / --codex-agent-name and
+--claude-environment / --codex-environment.`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return validateToolValue(opts.Tool)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return agentotel.Configure(opts)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&opts.Tool, "tool", agentotel.ToolAll, "Tool to configure: claude, codex, or all")
+	f.StringVar(&opts.Endpoint, "endpoint", "", "Base OTLP/HTTP endpoint, for example http://collector:4318")
+	f.StringVar(&opts.Token, "token", "", "Auth token for direct OTLP export (or set OTLP_AUTH_TOKEN / SPLUNK_OBSERVABILITY_TOKEN)")
+	f.StringVar(&opts.DeprecatedSplunkToken, "splunk-token", "", "Deprecated alias for --token")
+	_ = f.MarkDeprecated("splunk-token", "use --token instead")
+	f.StringVar(&opts.HeaderName, "header-name", "", "HTTP header name for direct auth; defaults to Authorization or X-SF-Token")
+	f.StringVar(&opts.HeaderPrefix, "header-prefix", "", "Prefix added before --token, for example 'Bearer '")
+	f.StringVar(&opts.SplunkHost, "splunk-host", "", "Splunk Observability host or realm for direct Splunk mode")
+	f.StringVar(&opts.TenantID, "tenant-id", "", "Tenant identifier for resource attributes where supported")
+	f.StringVar(&opts.WorkspaceID, "workspace-id", "", "Workspace identifier for resource attributes where supported")
+	f.StringVar(&opts.AgentName, "agent-name", "", "Logical agent name for resource attributes where supported")
+	f.StringVar(&opts.Environment, "environment", "dev", "Environment tag")
+	f.StringVar(&opts.ClaudeTenantID, "claude-tenant-id", "", "Claude-specific tenant identifier override")
+	f.StringVar(&opts.ClaudeWorkspaceID, "claude-workspace-id", "", "Claude-specific workspace identifier override")
+	f.StringVar(&opts.ClaudeAgentName, "claude-agent-name", "", "Claude-specific agent name override")
+	f.StringVar(&opts.ClaudeEnvironment, "claude-environment", "", "Claude-specific environment override")
+	f.StringVar(&opts.CodexTenantID, "codex-tenant-id", "", "Codex-specific tenant identifier override")
+	f.StringVar(&opts.CodexWorkspaceID, "codex-workspace-id", "", "Codex-specific workspace identifier override")
+	f.StringVar(&opts.CodexAgentName, "codex-agent-name", "", "Codex-specific agent name override")
+	f.StringVar(&opts.CodexEnvironment, "codex-environment", "", "Codex-specific environment override")
+	return cmd
+}
+
+func unconfigureCmd() *cobra.Command {
+	var tool string
+	cmd := &cobra.Command{
+		Use:   "unconfigure",
+		Short: "Remove OTLP configuration previously written by configure",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return validateToolValue(tool)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return agentotel.Unconfigure(tool)
+		},
+	}
+	cmd.Flags().StringVar(&tool, "tool", agentotel.ToolAll, "Tool to unconfigure: claude, codex, or all")
+	return cmd
+}
+
+func validateToolValue(tool string) error {
+	switch strings.ToLower(strings.TrimSpace(tool)) {
+	case "", agentotel.ToolAll, agentotel.ToolClaude, agentotel.ToolCodex:
+		return nil
+	default:
+		return fmt.Errorf("unsupported --tool %q: expected %q, %q, or %q", tool, agentotel.ToolClaude, agentotel.ToolCodex, agentotel.ToolAll)
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ DefenseClaw is the enterprise governance layer for [OpenClaw](https://github.com
 - [Splunk App Guide](SPLUNK_APP.md) — local Splunk app purpose, dashboards, signals, and investigation flow
 - [TUI Guide](TUI.md) — dashboard usage, keybindings, navigation
 - [OpenTelemetry](OTEL.md) — OTEL signal spec, Splunk mapping
+- [DefenseClaw Agent OTel](defenseclaw-agent-otel/README.md) — configure Claude Code and Codex desktop OTLP export
 - [Config Files](CONFIG_FILES.md) — config files and environment variables
 - [Plugin Development](PLUGINS.md) — custom scanner plugin interface
 - [Testing](TESTING.md) — multi-language test guide (Python, Go, TypeScript, Rego)

--- a/docs/defenseclaw-agent-otel/README.md
+++ b/docs/defenseclaw-agent-otel/README.md
@@ -1,11 +1,18 @@
 # DefenseClaw Agent OTel
 
 `defenseclaw-agent-otel` writes persistent OTLP configuration for
-`Claude Code` and `Codex`.
+`Claude Code` and `Codex`, and can also launch one-shot sessions with direct
+OTEL settings applied at runtime.
 
 After a one-time configuration step, normal desktop launches of `claude` and
 `codex` send telemetry directly to Splunk Observability Cloud or another
 OTLP/HTTP endpoint. There is no local relay in this flow.
+
+It also supports a one-shot `run` mode that launches `claude` or `codex` with
+direct OTEL settings for that session only. `Claude Code` uses runtime OTEL
+environment variables only. `Codex` uses runtime OTEL environment variables
+plus one-shot `otel.*` command-line overrides. This mode does not create a
+temporary home directory or write per-run settings files.
 
 ## Build
 
@@ -73,6 +80,55 @@ Codex should appear as separate desktop agents.
 When both shared and tool-specific flags are present, the tool-specific value
 takes precedence for that tool.
 
+## Run a Single Session Without Persisting Desktop Config
+
+Use `run` when you want to start one `claude` or `codex` session with direct
+OTEL export and tags, without writing `~/.claude/settings.json` or
+`~/.codex/config.toml`.
+
+Codex example:
+
+```bash
+export CODEX_RUN_ENV="codex-run-test-$(date +%s)"
+
+./defenseclaw-agent-otel run \
+  --tool codex \
+  --splunk-host app.us1.observability.splunkcloud.com \
+  --token "$SPLUNK_OBSERVABILITY_TOKEN" \
+  --environment "$CODEX_RUN_ENV" \
+  --tenant-id tenant-a \
+  --workspace-id workspace-codex \
+  --agent-name codex-desktop \
+  -- exec --skip-git-repo-check --json "Reply with ok only"
+```
+
+Claude example:
+
+```bash
+export CLAUDE_RUN_ENV="claude-run-test-$(date +%s)"
+
+./defenseclaw-agent-otel run \
+  --tool claude \
+  --splunk-host app.us1.observability.splunkcloud.com \
+  --token "$SPLUNK_OBSERVABILITY_TOKEN" \
+  --claude-environment "$CLAUDE_RUN_ENV" \
+  --claude-tenant-id tenant-a \
+  --claude-workspace-id workspace-claude \
+  --claude-agent-name claude-desktop \
+  -- -p --model haiku --output-format json "Reply with ok only"
+```
+
+If you omit the arguments after `--`, the tool launches the interactive
+`claude` or `codex` session with OTEL config injected.
+
+For `Claude Code`, `run` injects OTEL settings through runtime environment
+variables only. For `Codex`, `run` injects OTEL settings through runtime
+environment variables and one-shot `otel.*` CLI overrides. It does not modify
+the real `~/.claude/settings.json` or `~/.codex/config.toml`.
+
+When verifying these one-shot runs in Splunk O11y, the trace-derived series can
+take a couple of minutes to appear after the command finishes.
+
 ## Configure a Generic OTLP/HTTP Endpoint
 
 Use this when you want Claude and Codex to send directly to your own collector
@@ -119,6 +175,9 @@ You can also target one tool:
   arbitrary OTEL resource attributes, so `--codex-agent-name`,
   `--codex-tenant-id`, and `--codex-workspace-id` are accepted as CLI
   overrides but are not persisted in direct mode today
+- Codex one-shot `run` mode injects the same resource tags through
+  `OTEL_RESOURCE_ATTRIBUTES` as best effort, but you should still verify which
+  dimensions your backend actually receives
 - In live verification, `Codex Desktop` traces reached Splunk O11y but still
   showed `deployment.environment` / `sf_environment` as `unknown`, so treat
   `--environment` as best-effort for Codex direct mode today

--- a/docs/defenseclaw-agent-otel/README.md
+++ b/docs/defenseclaw-agent-otel/README.md
@@ -178,6 +178,7 @@ You can also target one tool:
 - Codex one-shot `run` mode injects the same resource tags through
   `OTEL_RESOURCE_ATTRIBUTES` as best effort, but you should still verify which
   dimensions your backend actually receives
-- In live verification, `Codex Desktop` traces reached Splunk O11y but still
-  showed `deployment.environment` / `sf_environment` as `unknown`, so treat
-  `--environment` as best-effort for Codex direct mode today
+- Recent live verification showed the one-shot `run` flow publishing
+  trace-derived series for both `Codex Desktop` and `claude-code`, with the
+  requested `sf_environment` visible in Splunk O11y after a short ingestion
+  delay

--- a/docs/defenseclaw-agent-otel/README.md
+++ b/docs/defenseclaw-agent-otel/README.md
@@ -1,0 +1,124 @@
+# DefenseClaw Agent OTel
+
+`defenseclaw-agent-otel` writes persistent OTLP configuration for
+`Claude Code` and `Codex`.
+
+After a one-time configuration step, normal desktop launches of `claude` and
+`codex` send telemetry directly to Splunk Observability Cloud or another
+OTLP/HTTP endpoint. There is no local relay in this flow.
+
+## Build
+
+```bash
+make agent-otel
+```
+
+This produces:
+
+```bash
+./defenseclaw-agent-otel
+```
+
+## Configure Direct Splunk Observability Export
+
+```bash
+export SPLUNK_OBSERVABILITY_TOKEN="your-token-here"
+
+./defenseclaw-agent-otel configure \
+  --tool all \
+  --splunk-host app.us1.observability.splunkcloud.com \
+  --token "$SPLUNK_OBSERVABILITY_TOKEN" \
+  --environment defenseclaw-direct-test
+```
+
+This writes:
+
+- `~/.claude/settings.json`
+- `~/.codex/config.toml`
+
+The tool derives:
+
+- traces → `https://ingest.us1.signalfx.com/v2/trace/otlp`
+- metrics → `https://ingest.us1.signalfx.com/v2/datapoint/otlp`
+
+and uses the `X-SF-Token` header.
+
+For `Claude Code`, the tool also writes OTLP log-exporter settings pointed at
+`https://ingest.<realm>.signalfx.com/v1/logs`. Splunk O11y does not accept
+direct OTLP logs there, but current Claude desktop builds bootstrap trace
+export more reliably when the OTLP log exporter is present.
+
+## Configure Distinct Claude and Codex Agents
+
+Use shared flags such as `--environment` and `--agent-name` as defaults, then
+override them per tool with `--claude-*` and `--codex-*` flags when Claude and
+Codex should appear as separate desktop agents.
+
+```bash
+./defenseclaw-agent-otel configure \
+  --tool all \
+  --splunk-host app.us1.observability.splunkcloud.com \
+  --token "$SPLUNK_OBSERVABILITY_TOKEN" \
+  --environment desktop \
+  --claude-agent-name claude-desktop \
+  --claude-environment claude-dev \
+  --claude-tenant-id tenant-a \
+  --claude-workspace-id workspace-claude \
+  --codex-agent-name codex-desktop \
+  --codex-environment codex-dev \
+  --codex-tenant-id tenant-a \
+  --codex-workspace-id workspace-codex
+```
+
+When both shared and tool-specific flags are present, the tool-specific value
+takes precedence for that tool.
+
+## Configure a Generic OTLP/HTTP Endpoint
+
+Use this when you want Claude and Codex to send directly to your own collector
+or OTLP gateway instead of Splunk O11y’s ingest endpoints.
+
+```bash
+./defenseclaw-agent-otel configure \
+  --tool all \
+  --endpoint http://collector.internal:4318 \
+  --token "$OTLP_AUTH_TOKEN" \
+  --header-name Authorization \
+  --header-prefix "Bearer " \
+  --tenant-id demo-tenant \
+  --workspace-id defenseclaw \
+  --agent-name desktop-agents \
+  --environment dev
+```
+
+## Unconfigure
+
+```bash
+./defenseclaw-agent-otel unconfigure --tool all
+```
+
+You can also target one tool:
+
+```bash
+./defenseclaw-agent-otel unconfigure --tool claude
+./defenseclaw-agent-otel unconfigure --tool codex
+```
+
+## Notes
+
+- Direct Splunk Observability mode configures `traces` and `metrics`
+- `Claude Code` direct mode also writes OTLP log-exporter settings as a
+  bootstrap requirement for current desktop builds
+- Splunk Observability Cloud still does not accept direct OTLP logs on
+  `/v1/logs`, so those requests may 404 while traces and metrics continue to
+  work
+- Claude Code persistent config supports `OTEL_RESOURCE_ATTRIBUTES`, so
+  `tenant_id`, `workspace_id`, and `agent_name` are written there
+- Codex persistent config supports native OTEL exporter config in
+  `~/.codex/config.toml`, but does not expose a documented config key for
+  arbitrary OTEL resource attributes, so `--codex-agent-name`,
+  `--codex-tenant-id`, and `--codex-workspace-id` are accepted as CLI
+  overrides but are not persisted in direct mode today
+- In live verification, `Codex Desktop` traces reached Splunk O11y but still
+  showed `deployment.environment` / `sf_environment` as `unknown`, so treat
+  `--environment` as best-effort for Codex direct mode today

--- a/internal/agentotel/config.go
+++ b/internal/agentotel/config.go
@@ -1,0 +1,620 @@
+package agentotel
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ConfigureOpts holds options for persistent Claude/Codex telemetry config.
+type ConfigureOpts struct {
+	Tool                  string
+	Endpoint              string
+	Token                 string
+	DeprecatedSplunkToken string
+	HeaderName            string
+	HeaderPrefix          string
+	SplunkHost            string
+	TenantID              string
+	WorkspaceID           string
+	AgentName             string
+	Environment           string
+	ClaudeTenantID        string
+	ClaudeWorkspaceID     string
+	ClaudeAgentName       string
+	ClaudeEnvironment     string
+	CodexTenantID         string
+	CodexWorkspaceID      string
+	CodexAgentName        string
+	CodexEnvironment      string
+}
+
+type telemetryTarget struct {
+	baseEndpoint             string
+	traceEndpoint            string
+	metricEndpoint           string
+	logEndpoint              string
+	logsEnabled              bool
+	claudeLogBootstrapNeeded bool
+	headerName               string
+	headerValue              string
+	warnings                 []string
+}
+
+const (
+	codexManagedBeginMarker = "# BEGIN DEFENSECLAW OTEL CONFIG"
+	codexManagedEndMarker   = "# END DEFENSECLAW OTEL CONFIG"
+)
+
+// otelEnvKeys is the set of keys the configure command manages in
+// ~/.claude/settings.json → env. Unconfigure removes exactly these.
+var otelEnvKeys = []string{
+	"BETA_TRACING_ENDPOINT",
+	"CLAUDE_CODE_ENABLE_TELEMETRY",
+	"CLAUDE_CODE_ENHANCED_TELEMETRY_BETA",
+	"ENABLE_BETA_TRACING_DETAILED",
+	"ENABLE_ENHANCED_TELEMETRY_BETA",
+	"OTEL_EXPORTER_OTLP_PROTOCOL",
+	"OTEL_EXPORTER_OTLP_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_HEADERS",
+	"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+	"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
+	"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
+	"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+	"OTEL_METRICS_EXPORTER",
+	"OTEL_LOGS_EXPORTER",
+	"OTEL_TRACES_EXPORTER",
+	"OTEL_METRIC_EXPORT_INTERVAL",
+	"OTEL_LOGS_EXPORT_INTERVAL",
+	"OTEL_TRACES_EXPORT_INTERVAL",
+	"OTEL_RESOURCE_ATTRIBUTES",
+}
+
+// Configure writes persistent OTEL configuration for Claude and/or Codex.
+func Configure(opts ConfigureOpts) error {
+	if err := normalizeConfigureOpts(&opts); err != nil {
+		return err
+	}
+	if err := validateToolSpecificOverrides(opts); err != nil {
+		return err
+	}
+
+	target, err := resolveTelemetryTarget(opts)
+	if err != nil {
+		return err
+	}
+
+	tool := normalizedTool(opts.Tool)
+	switch tool {
+	case ToolAll:
+		claudeOpts := effectiveToolConfigureOpts(opts, ToolClaude)
+		if err := configureClaude(claudeOpts, target); err != nil {
+			return err
+		}
+		codexOpts := effectiveToolConfigureOpts(opts, ToolCodex)
+		if err := configureCodex(codexOpts, target); err != nil {
+			return err
+		}
+	case ToolClaude:
+		if err := configureClaude(effectiveToolConfigureOpts(opts, ToolClaude), target); err != nil {
+			return err
+		}
+	case ToolCodex:
+		if err := configureCodex(effectiveToolConfigureOpts(opts, ToolCodex), target); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported tool %q: expected %q, %q, or %q", opts.Tool, ToolClaude, ToolCodex, ToolAll)
+	}
+
+	printConfigureSummary(tool, target)
+	return nil
+}
+
+// Unconfigure removes OTEL configuration previously written by Configure.
+func Unconfigure(tool string) error {
+	switch normalizedTool(tool) {
+	case ToolAll:
+		if err := unconfigureClaude(); err != nil {
+			return err
+		}
+		if err := unconfigureCodex(); err != nil {
+			return err
+		}
+		return nil
+	case ToolClaude:
+		return unconfigureClaude()
+	case ToolCodex:
+		return unconfigureCodex()
+	default:
+		return fmt.Errorf("unsupported tool %q: expected %q, %q, or %q", tool, ToolClaude, ToolCodex, ToolAll)
+	}
+}
+
+func normalizedTool(tool string) string {
+	tool = strings.ToLower(strings.TrimSpace(tool))
+	if tool == "" {
+		return ToolAll
+	}
+	return tool
+}
+
+func normalizeConfigureOpts(opts *ConfigureOpts) error {
+	token := strings.TrimSpace(opts.Token)
+	deprecated := strings.TrimSpace(opts.DeprecatedSplunkToken)
+	if token != "" && deprecated != "" && token != deprecated {
+		return fmt.Errorf("received conflicting values for --token and deprecated --splunk-token")
+	}
+	if token == "" {
+		opts.Token = deprecated
+	}
+	return nil
+}
+
+func validateToolSpecificOverrides(opts ConfigureOpts) error {
+	switch normalizedTool(opts.Tool) {
+	case ToolClaude:
+		if hasToolSpecificOverrides(opts, ToolCodex) {
+			return fmt.Errorf("received Codex-specific override flags with --tool %q", ToolClaude)
+		}
+	case ToolCodex:
+		if hasToolSpecificOverrides(opts, ToolClaude) {
+			return fmt.Errorf("received Claude-specific override flags with --tool %q", ToolCodex)
+		}
+	}
+	return nil
+}
+
+func hasToolSpecificOverrides(opts ConfigureOpts, tool string) bool {
+	switch tool {
+	case ToolClaude:
+		return strings.TrimSpace(opts.ClaudeTenantID) != "" ||
+			strings.TrimSpace(opts.ClaudeWorkspaceID) != "" ||
+			strings.TrimSpace(opts.ClaudeAgentName) != "" ||
+			strings.TrimSpace(opts.ClaudeEnvironment) != ""
+	case ToolCodex:
+		return strings.TrimSpace(opts.CodexTenantID) != "" ||
+			strings.TrimSpace(opts.CodexWorkspaceID) != "" ||
+			strings.TrimSpace(opts.CodexAgentName) != "" ||
+			strings.TrimSpace(opts.CodexEnvironment) != ""
+	default:
+		return false
+	}
+}
+
+func effectiveToolConfigureOpts(opts ConfigureOpts, tool string) ConfigureOpts {
+	effective := opts
+	effective.Tool = tool
+	switch tool {
+	case ToolClaude:
+		effective.TenantID = firstNonEmpty(opts.ClaudeTenantID, opts.TenantID)
+		effective.WorkspaceID = firstNonEmpty(opts.ClaudeWorkspaceID, opts.WorkspaceID)
+		effective.AgentName = firstNonEmpty(opts.ClaudeAgentName, opts.AgentName)
+		effective.Environment = firstNonEmpty(opts.ClaudeEnvironment, opts.Environment)
+	case ToolCodex:
+		effective.TenantID = firstNonEmpty(opts.CodexTenantID, opts.TenantID)
+		effective.WorkspaceID = firstNonEmpty(opts.CodexWorkspaceID, opts.WorkspaceID)
+		effective.AgentName = firstNonEmpty(opts.CodexAgentName, opts.AgentName)
+		effective.Environment = firstNonEmpty(opts.CodexEnvironment, opts.Environment)
+	}
+	return effective
+}
+
+func resolveTelemetryTarget(opts ConfigureOpts) (telemetryTarget, error) {
+	if strings.TrimSpace(opts.Endpoint) != "" {
+		return buildDirectTarget(opts)
+	}
+	if strings.TrimSpace(opts.SplunkHost) != "" {
+		return buildDirectSplunkTarget(opts)
+	}
+	return telemetryTarget{}, fmt.Errorf("configure requires --endpoint or --splunk-host")
+}
+
+func buildDirectTarget(opts ConfigureOpts) (telemetryTarget, error) {
+	base, warning, err := normalizeOTLPBaseEndpoint(opts.Endpoint)
+	if err != nil {
+		return telemetryTarget{}, err
+	}
+	headerName, headerValue := buildAuthHeader(opts, false)
+	target := telemetryTarget{
+		baseEndpoint:   base,
+		traceEndpoint:  base + "/v1/traces",
+		metricEndpoint: base + "/v1/metrics",
+		logEndpoint:    base + "/v1/logs",
+		logsEnabled:    true,
+		headerName:     headerName,
+		headerValue:    headerValue,
+	}
+	if warning != "" {
+		target.warnings = append(target.warnings, warning)
+	}
+	return target, nil
+}
+
+func buildDirectSplunkTarget(opts ConfigureOpts) (telemetryTarget, error) {
+	ingestHost, warning, err := deriveIngestHost(opts.SplunkHost)
+	if err != nil {
+		return telemetryTarget{}, err
+	}
+	headerName, headerValue := buildAuthHeader(opts, true)
+	target := telemetryTarget{
+		baseEndpoint:             "https://" + ingestHost,
+		traceEndpoint:            "https://" + ingestHost + "/v2/trace/otlp",
+		metricEndpoint:           "https://" + ingestHost + "/v2/datapoint/otlp",
+		logEndpoint:              "https://" + ingestHost + "/v1/logs",
+		logsEnabled:              false,
+		claudeLogBootstrapNeeded: true,
+		headerName:               headerName,
+		headerValue:              headerValue,
+		warnings: []string{
+			"Splunk direct mode configures traces and metrics directly; direct OTLP logs remain unsupported without a collector or relay",
+		},
+	}
+	if warning != "" {
+		target.warnings = append(target.warnings, warning)
+	}
+	return target, nil
+}
+
+func normalizeOTLPBaseEndpoint(raw string) (string, string, error) {
+	endpoint := strings.TrimSpace(raw)
+	endpoint = strings.TrimRight(endpoint, "/")
+	if endpoint == "" {
+		return "", "", fmt.Errorf("endpoint must not be empty")
+	}
+	for _, suffix := range []string{"/v1/traces", "/v1/metrics", "/v1/logs"} {
+		if strings.HasSuffix(endpoint, suffix) {
+			base := strings.TrimSuffix(endpoint, suffix)
+			return base, fmt.Sprintf("trimmed %q from endpoint and used base %q for all signals", suffix, base), nil
+		}
+	}
+	return endpoint, "", nil
+}
+
+func buildAuthHeader(opts ConfigureOpts, splunkDirect bool) (string, string) {
+	token := strings.TrimSpace(firstNonEmpty(
+		opts.Token,
+		os.Getenv("OTLP_AUTH_TOKEN"),
+		os.Getenv("SPLUNK_OBSERVABILITY_TOKEN"),
+		os.Getenv("SPLUNK_ACCESS_TOKEN"),
+	))
+	if token == "" {
+		return "", ""
+	}
+
+	headerName := strings.TrimSpace(opts.HeaderName)
+	headerPrefix := opts.HeaderPrefix
+	if headerName == "" {
+		if splunkDirect {
+			headerName = "X-SF-Token"
+		} else {
+			headerName = "Authorization"
+			if headerPrefix == "" {
+				headerPrefix = "Bearer "
+			}
+		}
+	}
+	if headerPrefix == "" {
+		return headerName, token
+	}
+	return headerName, headerPrefix + token
+}
+
+func printConfigureSummary(tool string, target telemetryTarget) {
+	switch tool {
+	case ToolAll:
+		fmt.Fprintf(os.Stderr, "[configure] updated Claude Code and Codex for direct telemetry export\n")
+	case ToolClaude:
+		fmt.Fprintf(os.Stderr, "[configure] updated Claude Code for direct telemetry export\n")
+	case ToolCodex:
+		fmt.Fprintf(os.Stderr, "[configure] updated Codex for direct telemetry export\n")
+	}
+	fmt.Fprintf(os.Stderr, "[configure] traces  → %s\n", target.traceEndpoint)
+	fmt.Fprintf(os.Stderr, "[configure] metrics → %s\n", target.metricEndpoint)
+	if target.logsEnabled {
+		fmt.Fprintf(os.Stderr, "[configure] logs    → %s\n", target.logEndpoint)
+	}
+
+	for _, warning := range target.warnings {
+		fmt.Fprintf(os.Stderr, "[configure] warning: %s\n", warning)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code — ~/.claude/settings.json
+// ---------------------------------------------------------------------------
+
+func claudeSettingsPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".claude", "settings.json"), nil
+}
+
+func configureClaude(opts ConfigureOpts, target telemetryTarget) error {
+	path, err := claudeSettingsPath()
+	if err != nil {
+		return err
+	}
+	settings, err := readJSONFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	if settings == nil {
+		settings = map[string]interface{}{}
+	}
+
+	env, _ := settings["env"].(map[string]interface{})
+	if env == nil {
+		env = map[string]interface{}{}
+	}
+	if shouldUseClaudeBedrockForConfig(env) {
+		env["CLAUDE_CODE_USE_BEDROCK"] = "1"
+	}
+
+	env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
+	env["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"] = "1"
+	delete(env, "BETA_TRACING_ENDPOINT")
+	delete(env, "ENABLE_BETA_TRACING_DETAILED")
+	delete(env, "ENABLE_ENHANCED_TELEMETRY_BETA")
+	env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf"
+	if target.baseEndpoint != "" {
+		env["OTEL_EXPORTER_OTLP_ENDPOINT"] = target.baseEndpoint
+	} else {
+		delete(env, "OTEL_EXPORTER_OTLP_ENDPOINT")
+	}
+	if target.headerName != "" && target.headerValue != "" {
+		env["OTEL_EXPORTER_OTLP_HEADERS"] = fmt.Sprintf("%s=%s", target.headerName, target.headerValue)
+	} else {
+		delete(env, "OTEL_EXPORTER_OTLP_HEADERS")
+	}
+
+	env["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"] = "http/protobuf"
+	env["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = target.traceEndpoint
+	env["OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"] = "http/protobuf"
+	env["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] = target.metricEndpoint
+
+	if target.logsEnabled || target.claudeLogBootstrapNeeded {
+		env["OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"] = "http/protobuf"
+		env["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] = target.logEndpoint
+		env["OTEL_LOGS_EXPORTER"] = "otlp"
+		env["OTEL_LOGS_EXPORT_INTERVAL"] = "1000"
+	} else {
+		delete(env, "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL")
+		delete(env, "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT")
+		delete(env, "OTEL_LOGS_EXPORTER")
+		delete(env, "OTEL_LOGS_EXPORT_INTERVAL")
+	}
+
+	env["OTEL_METRICS_EXPORTER"] = "otlp"
+	env["OTEL_TRACES_EXPORTER"] = "otlp"
+	env["OTEL_METRIC_EXPORT_INTERVAL"] = "1000"
+	env["OTEL_TRACES_EXPORT_INTERVAL"] = "1000"
+	env["OTEL_RESOURCE_ATTRIBUTES"] = buildConfigResourceAttrs(env, opts)
+
+	settings["env"] = env
+	if err := writeJSONFile(path, settings); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	fmt.Fprintf(os.Stderr, "[configure] wrote Claude Code OTEL config to %s\n", path)
+	return nil
+}
+
+func unconfigureClaude() error {
+	path, err := claudeSettingsPath()
+	if err != nil {
+		return err
+	}
+	settings, err := readJSONFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "[unconfigure] %s does not exist, nothing to do\n", path)
+			return nil
+		}
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	env, _ := settings["env"].(map[string]interface{})
+	if env == nil {
+		fmt.Fprintf(os.Stderr, "[unconfigure] no env section in %s, nothing to do\n", path)
+		return nil
+	}
+	removed := 0
+	for _, key := range otelEnvKeys {
+		if _, ok := env[key]; ok {
+			delete(env, key)
+			removed++
+		}
+	}
+	if removed == 0 {
+		fmt.Fprintf(os.Stderr, "[unconfigure] no OTEL keys found in %s, nothing to do\n", path)
+		return nil
+	}
+	settings["env"] = env
+	if err := writeJSONFile(path, settings); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	fmt.Fprintf(os.Stderr, "[unconfigure] removed %d OTEL keys from %s\n", removed, path)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Codex CLI — ~/.codex/config.toml
+// ---------------------------------------------------------------------------
+
+func codexConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".codex", "config.toml"), nil
+}
+
+func configureCodex(opts ConfigureOpts, target telemetryTarget) error {
+	path, err := codexConfigPath()
+	if err != nil {
+		return err
+	}
+
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	cleaned := stripManagedTOMLBlock(string(existing), codexManagedBeginMarker, codexManagedEndMarker)
+	if hasTOMLSection(cleaned, "otel") {
+		return fmt.Errorf("found unmanaged [otel] section in %s; merge manually before running configure", path)
+	}
+
+	var b strings.Builder
+	b.WriteString(strings.TrimRight(cleaned, "\n"))
+	if b.Len() > 0 {
+		b.WriteString("\n\n")
+	}
+	b.WriteString(codexManagedBeginMarker + "\n")
+	b.WriteString("[otel]\n")
+	if target.logsEnabled {
+		fmt.Fprintf(&b, "exporter = { \"otlp-http\" = { endpoint = %q, protocol = \"binary\"%s } }\n",
+			target.logEndpoint, formatTOMLHeaders(target))
+	} else {
+		b.WriteString("exporter = \"none\"\n")
+	}
+	fmt.Fprintf(&b, "metrics_exporter = { \"otlp-http\" = { endpoint = %q, protocol = \"binary\"%s } }\n",
+		target.metricEndpoint, formatTOMLHeaders(target))
+	fmt.Fprintf(&b, "trace_exporter = { \"otlp-http\" = { endpoint = %q, protocol = \"binary\"%s } }\n",
+		target.traceEndpoint, formatTOMLHeaders(target))
+	fmt.Fprintf(&b, "environment = %q\n", opts.Environment)
+	b.WriteString(codexManagedEndMarker + "\n")
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	fmt.Fprintf(os.Stderr, "[configure] wrote Codex OTEL config to %s\n", path)
+	if hasConfigTags(opts) {
+		fmt.Fprintf(os.Stderr, "[configure] warning: Codex config.toml has no documented key for arbitrary OTEL resource attributes; tenant/workspace/agent tags are not persisted in direct mode\n")
+	}
+	if strings.TrimSpace(opts.Environment) != "" {
+		fmt.Fprintf(os.Stderr, "[configure] warning: Codex environment tagging is best-effort in direct mode; verify trace dimensions in your backend\n")
+	}
+	return nil
+}
+
+func unconfigureCodex() error {
+	path, err := codexConfigPath()
+	if err != nil {
+		return err
+	}
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "[unconfigure] %s does not exist, nothing to do\n", path)
+			return nil
+		}
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	cleaned := stripManagedTOMLBlock(string(existing), codexManagedBeginMarker, codexManagedEndMarker)
+	cleaned = strings.TrimRight(cleaned, "\n")
+	if cleaned != "" {
+		cleaned += "\n"
+	}
+	if err := os.WriteFile(path, []byte(cleaned), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	fmt.Fprintf(os.Stderr, "[unconfigure] removed OTEL section from %s\n", path)
+	return nil
+}
+
+func formatTOMLHeaders(target telemetryTarget) string {
+	if target.headerName == "" || target.headerValue == "" {
+		return ""
+	}
+	return fmt.Sprintf(", headers = { %q = %q }", target.headerName, target.headerValue)
+}
+
+func hasConfigTags(opts ConfigureOpts) bool {
+	return strings.TrimSpace(opts.TenantID) != "" ||
+		strings.TrimSpace(opts.WorkspaceID) != "" ||
+		strings.TrimSpace(opts.AgentName) != ""
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func buildConfigResourceAttrs(env map[string]interface{}, opts ConfigureOpts) string {
+	existing, _ := env["OTEL_RESOURCE_ATTRIBUTES"].(string)
+	extra := map[string]string{
+		"tenant_id":              opts.TenantID,
+		"workspace_id":           opts.WorkspaceID,
+		"agent_name":             opts.AgentName,
+		"deployment.environment": opts.Environment,
+		"wrapped_cli":            opts.Tool,
+	}
+	return mergeResourceAttributes(existing, extra)
+}
+
+func readJSONFile(path string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func writeJSONFile(path string, data map[string]interface{}) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	out, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+	out = append(out, '\n')
+	return os.WriteFile(path, out, 0o644)
+}
+
+func hasTOMLSection(text, section string) bool {
+	header := "[" + section + "]"
+	lines := strings.Split(text, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == header {
+			return true
+		}
+	}
+	return false
+}
+
+// stripManagedTOMLBlock removes a marker-delimited block from TOML text.
+func stripManagedTOMLBlock(text, beginMarker, endMarker string) string {
+	lines := strings.Split(text, "\n")
+	out := make([]string, 0, len(lines))
+	inBlock := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case trimmed == beginMarker:
+			inBlock = true
+			continue
+		case inBlock && trimmed == endMarker:
+			inBlock = false
+			continue
+		case inBlock:
+			continue
+		default:
+			out = append(out, line)
+		}
+	}
+	return strings.Join(out, "\n")
+}

--- a/internal/agentotel/config.go
+++ b/internal/agentotel/config.go
@@ -37,7 +37,7 @@ type telemetryTarget struct {
 	metricEndpoint           string
 	logEndpoint              string
 	logsEnabled              bool
-	claudeLogBootstrapNeeded bool
+	logBootstrapNeeded       bool
 	headerName               string
 	headerValue              string
 	warnings                 []string
@@ -242,16 +242,16 @@ func buildDirectSplunkTarget(opts ConfigureOpts) (telemetryTarget, error) {
 	}
 	headerName, headerValue := buildAuthHeader(opts, true)
 	target := telemetryTarget{
-		baseEndpoint:             "https://" + ingestHost,
-		traceEndpoint:            "https://" + ingestHost + "/v2/trace/otlp",
-		metricEndpoint:           "https://" + ingestHost + "/v2/datapoint/otlp",
-		logEndpoint:              "https://" + ingestHost + "/v1/logs",
-		logsEnabled:              false,
-		claudeLogBootstrapNeeded: true,
-		headerName:               headerName,
-		headerValue:              headerValue,
+		baseEndpoint:       "https://" + ingestHost,
+		traceEndpoint:      "https://" + ingestHost + "/v2/trace/otlp",
+		metricEndpoint:     "https://" + ingestHost + "/v2/datapoint/otlp",
+		logEndpoint:        "https://" + ingestHost + "/v1/logs",
+		logsEnabled:        false,
+		logBootstrapNeeded: true,
+		headerName:         headerName,
+		headerValue:        headerValue,
 		warnings: []string{
-			"Splunk direct mode configures traces and metrics directly; direct OTLP logs remain unsupported without a collector or relay",
+			"Splunk direct mode configures traces and metrics directly; OTLP logs may return 404 without a collector or relay",
 		},
 	}
 	if warning != "" {
@@ -359,9 +359,9 @@ func configureClaude(opts ConfigureOpts, target telemetryTarget) error {
 
 	env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
 	env["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"] = "1"
+	env["ENABLE_ENHANCED_TELEMETRY_BETA"] = "1"
 	delete(env, "BETA_TRACING_ENDPOINT")
 	delete(env, "ENABLE_BETA_TRACING_DETAILED")
-	delete(env, "ENABLE_ENHANCED_TELEMETRY_BETA")
 	env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf"
 	if target.baseEndpoint != "" {
 		env["OTEL_EXPORTER_OTLP_ENDPOINT"] = target.baseEndpoint
@@ -379,7 +379,7 @@ func configureClaude(opts ConfigureOpts, target telemetryTarget) error {
 	env["OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"] = "http/protobuf"
 	env["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] = target.metricEndpoint
 
-	if target.logsEnabled || target.claudeLogBootstrapNeeded {
+	if target.logsEnabled || target.logBootstrapNeeded {
 		env["OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"] = "http/protobuf"
 		env["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] = target.logEndpoint
 		env["OTEL_LOGS_EXPORTER"] = "otlp"
@@ -477,7 +477,7 @@ func configureCodex(opts ConfigureOpts, target telemetryTarget) error {
 	}
 	b.WriteString(codexManagedBeginMarker + "\n")
 	b.WriteString("[otel]\n")
-	if target.logsEnabled {
+	if target.logsEnabled || target.logBootstrapNeeded {
 		fmt.Fprintf(&b, "exporter = { \"otlp-http\" = { endpoint = %q, protocol = \"binary\"%s } }\n",
 			target.logEndpoint, formatTOMLHeaders(target))
 	} else {

--- a/internal/agentotel/config.go
+++ b/internal/agentotel/config.go
@@ -32,15 +32,15 @@ type ConfigureOpts struct {
 }
 
 type telemetryTarget struct {
-	baseEndpoint             string
-	traceEndpoint            string
-	metricEndpoint           string
-	logEndpoint              string
-	logsEnabled              bool
-	logBootstrapNeeded       bool
-	headerName               string
-	headerValue              string
-	warnings                 []string
+	baseEndpoint       string
+	traceEndpoint      string
+	metricEndpoint     string
+	logEndpoint        string
+	logsEnabled        bool
+	logBootstrapNeeded bool
+	headerName         string
+	headerValue        string
+	warnings           []string
 }
 
 const (
@@ -320,6 +320,9 @@ func printConfigureSummary(tool string, target telemetryTarget) {
 	}
 
 	for _, warning := range target.warnings {
+		if normalizedTool(tool) == ToolCodex && !target.logsEnabled && strings.Contains(warning, "OTLP logs") {
+			continue
+		}
 		fmt.Fprintf(os.Stderr, "[configure] warning: %s\n", warning)
 	}
 }
@@ -477,7 +480,7 @@ func configureCodex(opts ConfigureOpts, target telemetryTarget) error {
 	}
 	b.WriteString(codexManagedBeginMarker + "\n")
 	b.WriteString("[otel]\n")
-	if target.logsEnabled || target.logBootstrapNeeded {
+	if target.logsEnabled {
 		fmt.Fprintf(&b, "exporter = { \"otlp-http\" = { endpoint = %q, protocol = \"binary\"%s } }\n",
 			target.logEndpoint, formatTOMLHeaders(target))
 	} else {

--- a/internal/agentotel/config_test.go
+++ b/internal/agentotel/config_test.go
@@ -302,7 +302,7 @@ func TestConfigureCodexDirectWritesHeaders(t *testing.T) {
 	}
 }
 
-func TestConfigureCodexSplunkDirectBootstrapsLogs(t *testing.T) {
+func TestConfigureCodexSplunkDirectDisablesLogs(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -321,8 +321,8 @@ func TestConfigureCodexSplunkDirectBootstrapsLogs(t *testing.T) {
 	}
 	content := string(data)
 
-	if !strings.Contains(content, `endpoint = "https://ingest.us1.signalfx.com/v1/logs"`) {
-		t.Fatal("logs exporter should bootstrap the shared OTEL provider in direct Splunk mode")
+	if !strings.Contains(content, `exporter = "none"`) {
+		t.Fatal("logs exporter should be disabled in direct Splunk mode")
 	}
 	for _, want := range []string{
 		`endpoint = "https://ingest.us1.signalfx.com/v2/datapoint/otlp"`,

--- a/internal/agentotel/config_test.go
+++ b/internal/agentotel/config_test.go
@@ -1,0 +1,669 @@
+package agentotel
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConfigureClaudeDirectWritesOTELEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"),
+		[]byte(`{"permissions":{"allow":["Bash(*)"]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := ConfigureOpts{
+		Tool:         ToolClaude,
+		Endpoint:     "http://collector.internal:4318",
+		Token:        "secret-token",
+		HeaderName:   "Authorization",
+		HeaderPrefix: "Bearer ",
+		TenantID:     "t1",
+		WorkspaceID:  "w1",
+		AgentName:    "test-agent",
+		Environment:  "ci",
+	}
+	if err := Configure(opts); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if _, ok := settings["permissions"]; !ok {
+		t.Error("permissions key was lost")
+	}
+
+	env, ok := settings["env"].(map[string]interface{})
+	if !ok {
+		t.Fatal("env section missing")
+	}
+
+	checks := map[string]string{
+		"CLAUDE_CODE_ENABLE_TELEMETRY":        "1",
+		"OTEL_EXPORTER_OTLP_PROTOCOL":         "http/protobuf",
+		"OTEL_EXPORTER_OTLP_ENDPOINT":         "http://collector.internal:4318",
+		"OTEL_EXPORTER_OTLP_HEADERS":          "Authorization=Bearer secret-token",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT":  "http://collector.internal:4318/v1/traces",
+		"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://collector.internal:4318/v1/metrics",
+		"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT":    "http://collector.internal:4318/v1/logs",
+		"OTEL_METRICS_EXPORTER":               "otlp",
+		"OTEL_TRACES_EXPORTER":                "otlp",
+		"OTEL_LOGS_EXPORTER":                  "otlp",
+	}
+	for key, want := range checks {
+		got, ok := env[key].(string)
+		if !ok || got != want {
+			t.Errorf("env[%q] = %q, want %q", key, got, want)
+		}
+	}
+	for _, key := range []string{
+		"BETA_TRACING_ENDPOINT",
+		"ENABLE_BETA_TRACING_DETAILED",
+		"ENABLE_ENHANCED_TELEMETRY_BETA",
+	} {
+		if _, ok := env[key]; ok {
+			t.Errorf("env[%q] should not be set in direct OTLP mode", key)
+		}
+	}
+
+	attrs, _ := env["OTEL_RESOURCE_ATTRIBUTES"].(string)
+	for _, want := range []string{
+		"tenant_id=t1",
+		"workspace_id=w1",
+		"agent_name=test-agent",
+		"wrapped_cli=claude",
+	} {
+		if !strings.Contains(attrs, want) {
+			t.Errorf("resource attrs missing %q in %q", want, attrs)
+		}
+	}
+}
+
+func TestConfigureClaudeSetsBedrockWhenAWSHelperDetected(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(`{"userID":"abc"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".aws-bedrock-cc-creds.json"), []byte(`{"Credentials":{"AccessKeyId":"x"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"),
+		[]byte(`{"env":{"awsCredentialExport":"cat ~/.aws-bedrock-cc-creds.json"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := ConfigureOpts{
+		Tool:       ToolClaude,
+		SplunkHost: "us1",
+		Token:      "splunk-token",
+	}
+	if err := Configure(opts); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	env := settings["env"].(map[string]interface{})
+	if got := env["CLAUDE_CODE_USE_BEDROCK"]; got != "1" {
+		t.Fatalf("CLAUDE_CODE_USE_BEDROCK = %v", got)
+	}
+}
+
+func TestConfigureClaudeSplunkDirectBootstrapsLogs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	opts := ConfigureOpts{
+		Tool:        ToolClaude,
+		SplunkHost:  "app.us1.observability.splunkcloud.com",
+		Token:       "splunk-token",
+		Environment: "prod",
+	}
+	if err := Configure(opts); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	env := settings["env"].(map[string]interface{})
+
+	if got := env["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"]; got != "https://ingest.us1.signalfx.com/v2/trace/otlp" {
+		t.Fatalf("trace endpoint = %v", got)
+	}
+	if got := env["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"]; got != "https://ingest.us1.signalfx.com/v2/datapoint/otlp" {
+		t.Fatalf("metrics endpoint = %v", got)
+	}
+	if got := env["OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"]; got != "http/protobuf" {
+		t.Fatalf("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL = %v", got)
+	}
+	if got := env["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"]; got != "https://ingest.us1.signalfx.com/v1/logs" {
+		t.Fatalf("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = %v", got)
+	}
+	if got := env["OTEL_LOGS_EXPORTER"]; got != "otlp" {
+		t.Fatalf("OTEL_LOGS_EXPORTER = %v", got)
+	}
+	if got := env["OTEL_EXPORTER_OTLP_HEADERS"]; got != "X-SF-Token=splunk-token" {
+		t.Fatalf("OTEL_EXPORTER_OTLP_HEADERS = %v", got)
+	}
+	for _, key := range []string{
+		"BETA_TRACING_ENDPOINT",
+		"ENABLE_BETA_TRACING_DETAILED",
+		"ENABLE_ENHANCED_TELEMETRY_BETA",
+	} {
+		if _, ok := env[key]; ok {
+			t.Fatalf("%s should be absent in direct Splunk mode", key)
+		}
+	}
+}
+
+func TestUnconfigureClaudeRemovesOTELEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	initial := map[string]interface{}{
+		"permissions": map[string]interface{}{"allow": []string{"Bash(*)"}},
+		"env": map[string]interface{}{
+			"BETA_TRACING_ENDPOINT":          "https://example.invalid",
+			"CLAUDE_CODE_ENABLE_TELEMETRY":   "1",
+			"ENABLE_BETA_TRACING_DETAILED":   "1",
+			"ENABLE_ENHANCED_TELEMETRY_BETA": "1",
+			"OTEL_EXPORTER_OTLP_ENDPOINT":    "http://127.0.0.1:4318",
+			"OTEL_EXPORTER_OTLP_HEADERS":     "Authorization=Bearer keep-out",
+			"OTEL_METRICS_EXPORTER":          "otlp",
+			"MY_CUSTOM_VAR":                  "keep-me",
+		},
+	}
+	data, _ := json.MarshalIndent(initial, "", "  ")
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Unconfigure(ToolClaude); err != nil {
+		t.Fatalf("Unconfigure: %v", err)
+	}
+
+	after, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var settings map[string]interface{}
+	if err := json.Unmarshal(after, &settings); err != nil {
+		t.Fatal(err)
+	}
+
+	env, _ := settings["env"].(map[string]interface{})
+	if _, ok := env["OTEL_EXPORTER_OTLP_ENDPOINT"]; ok {
+		t.Error("OTEL_EXPORTER_OTLP_ENDPOINT should have been removed")
+	}
+	if _, ok := env["BETA_TRACING_ENDPOINT"]; ok {
+		t.Error("BETA_TRACING_ENDPOINT should have been removed")
+	}
+	if _, ok := env["ENABLE_BETA_TRACING_DETAILED"]; ok {
+		t.Error("ENABLE_BETA_TRACING_DETAILED should have been removed")
+	}
+	if _, ok := env["ENABLE_ENHANCED_TELEMETRY_BETA"]; ok {
+		t.Error("ENABLE_ENHANCED_TELEMETRY_BETA should have been removed")
+	}
+	if _, ok := env["OTEL_EXPORTER_OTLP_HEADERS"]; ok {
+		t.Error("OTEL_EXPORTER_OTLP_HEADERS should have been removed")
+	}
+	if _, ok := env["OTEL_METRICS_EXPORTER"]; ok {
+		t.Error("OTEL_METRICS_EXPORTER should have been removed")
+	}
+	if v, ok := env["MY_CUSTOM_VAR"].(string); !ok || v != "keep-me" {
+		t.Error("MY_CUSTOM_VAR should have been preserved")
+	}
+}
+
+func TestConfigureCodexDirectWritesHeaders(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := "personality = \"pragmatic\"\nmodel = \"gpt-5.4\"\n"
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := ConfigureOpts{
+		Tool:         ToolCodex,
+		Endpoint:     "http://collector.internal:4318",
+		Token:        "token-1",
+		HeaderName:   "Authorization",
+		HeaderPrefix: "Bearer ",
+		Environment:  "prod",
+	}
+	if err := Configure(opts); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexDir, "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, `personality = "pragmatic"`) {
+		t.Error("existing config was lost")
+	}
+	for _, want := range []string{
+		`[otel]`,
+		`endpoint = "http://collector.internal:4318/v1/logs"`,
+		`endpoint = "http://collector.internal:4318/v1/metrics"`,
+		`endpoint = "http://collector.internal:4318/v1/traces"`,
+		`headers = { "Authorization" = "Bearer token-1" }`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("config missing %q", want)
+		}
+	}
+}
+
+func TestConfigureCodexSplunkDirectDisablesLogs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	opts := ConfigureOpts{
+		Tool:       ToolCodex,
+		SplunkHost: "us1",
+		Token:      "splunk-token",
+	}
+	if err := Configure(opts); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, `exporter = "none"`) {
+		t.Fatal("logs exporter should be disabled in direct Splunk mode")
+	}
+	for _, want := range []string{
+		`endpoint = "https://ingest.us1.signalfx.com/v2/datapoint/otlp"`,
+		`endpoint = "https://ingest.us1.signalfx.com/v2/trace/otlp"`,
+		`headers = { "X-SF-Token" = "splunk-token" }`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("config missing %q", want)
+		}
+	}
+}
+
+func TestConfigureCodexReplacesManagedBlockWithoutDuplicatingMarkers(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := `model = "gpt-5.4"
+
+# BEGIN DEFENSECLAW OTEL CONFIG
+[otel]
+exporter = "none"
+# END DEFENSECLAW OTEL CONFIG
+`
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := ConfigureOpts{
+		Tool:        ToolCodex,
+		SplunkHost:  "us1",
+		Token:       "splunk-token",
+		Environment: "prod",
+	}
+	if err := Configure(opts); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexDir, "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if got := strings.Count(content, codexManagedBeginMarker); got != 1 {
+		t.Fatalf("begin marker count = %d\n%s", got, content)
+	}
+	if got := strings.Count(content, codexManagedEndMarker); got != 1 {
+		t.Fatalf("end marker count = %d\n%s", got, content)
+	}
+}
+
+func TestConfigureCodexRejectsUnmanagedOtelSection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := `model = "gpt-5.4"
+
+[otel]
+environment = "custom"
+`
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Configure(ConfigureOpts{
+		Tool:       ToolCodex,
+		SplunkHost: "us1",
+		Token:      "splunk-token",
+	})
+	if err == nil || !strings.Contains(err.Error(), "unmanaged [otel] section") {
+		t.Fatalf("Configure error = %v", err)
+	}
+}
+
+func TestConfigureAllWritesBothFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	opts := ConfigureOpts{
+		Tool:        ToolAll,
+		SplunkHost:  "us1",
+		Token:       "splunk-token",
+		Environment: "ci",
+	}
+	if err := Configure(opts); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(home, ".claude", "settings.json")); err != nil {
+		t.Fatalf("Claude config missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "config.toml")); err != nil {
+		t.Fatalf("Codex config missing: %v", err)
+	}
+}
+
+func TestConfigureAllAppliesToolSpecificOverrides(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	opts := ConfigureOpts{
+		Tool:              ToolAll,
+		SplunkHost:        "us1",
+		Token:             "splunk-token",
+		Environment:       "shared-env",
+		AgentName:         "shared-agent",
+		ClaudeAgentName:   "claude-agent",
+		ClaudeEnvironment: "claude-env",
+		CodexAgentName:    "codex-agent",
+		CodexEnvironment:  "codex-env",
+		ClaudeWorkspaceID: "claude-workspace",
+		CodexWorkspaceID:  "codex-workspace",
+		ClaudeTenantID:    "claude-tenant",
+		CodexTenantID:     "codex-tenant",
+	}
+	if err := Configure(opts); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	claudeData, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var claudeSettings map[string]interface{}
+	if err := json.Unmarshal(claudeData, &claudeSettings); err != nil {
+		t.Fatal(err)
+	}
+	claudeEnv := claudeSettings["env"].(map[string]interface{})
+	attrs, _ := claudeEnv["OTEL_RESOURCE_ATTRIBUTES"].(string)
+	for _, want := range []string{
+		"agent_name=claude-agent",
+		"deployment.environment=claude-env",
+		"tenant_id=claude-tenant",
+		"workspace_id=claude-workspace",
+		"wrapped_cli=claude",
+	} {
+		if !strings.Contains(attrs, want) {
+			t.Fatalf("Claude attrs missing %q in %q", want, attrs)
+		}
+	}
+
+	codexData, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	codexConfig := string(codexData)
+	if !strings.Contains(codexConfig, `environment = "codex-env"`) {
+		t.Fatalf("Codex config missing codex-specific environment:\n%s", codexConfig)
+	}
+}
+
+func TestConfigureRejectsIrrelevantToolSpecificOverrides(t *testing.T) {
+	err := Configure(ConfigureOpts{
+		Tool:            ToolCodex,
+		SplunkHost:      "us1",
+		Token:           "splunk-token",
+		ClaudeAgentName: "claude-only",
+	})
+	if err == nil || !strings.Contains(err.Error(), "Codex-specific") && !strings.Contains(err.Error(), "Claude-specific") {
+		t.Fatalf("Configure error = %v", err)
+	}
+}
+
+func TestUnconfigureCodexRemovesOTELSection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := `personality = "pragmatic"
+
+# BEGIN DEFENSECLAW OTEL CONFIG
+[otel]
+exporter = "none"
+# END DEFENSECLAW OTEL CONFIG
+`
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Unconfigure(ToolCodex); err != nil {
+		t.Fatalf("Unconfigure: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexDir, "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := string(data)
+
+	if strings.Contains(result, "[otel]") {
+		t.Error("[otel] section should have been removed")
+	}
+	if !strings.Contains(result, `personality = "pragmatic"`) {
+		t.Error("existing config was lost")
+	}
+}
+
+func TestStripManagedTOMLBlock(t *testing.T) {
+	input := `key1 = "val1"
+
+# BEGIN DEFENSECLAW OTEL CONFIG
+[otel]
+exporter = "foo"
+# END DEFENSECLAW OTEL CONFIG
+
+[other]
+x = 1
+`
+	got := stripManagedTOMLBlock(input, codexManagedBeginMarker, codexManagedEndMarker)
+	if strings.Contains(got, codexManagedBeginMarker) || strings.Contains(got, "[otel]") {
+		t.Error("managed block should be removed")
+	}
+	if !strings.Contains(got, "[other]") {
+		t.Error("other section should remain")
+	}
+	if !strings.Contains(got, `key1 = "val1"`) {
+		t.Error("top-level key should remain")
+	}
+}
+
+func TestHasTOMLSection(t *testing.T) {
+	if !hasTOMLSection("[otel]\nexporter = \"none\"\n", "otel") {
+		t.Fatal("expected otel section to be found")
+	}
+	if hasTOMLSection("model = \"gpt-5.4\"\n", "otel") {
+		t.Fatal("did not expect otel section to be found")
+	}
+}
+
+func TestNormalizeOTLPBaseEndpointTrimsSignalSuffix(t *testing.T) {
+	base, warning, err := normalizeOTLPBaseEndpoint("http://collector:4318/v1/traces")
+	if err != nil {
+		t.Fatalf("normalizeOTLPBaseEndpoint: %v", err)
+	}
+	if base != "http://collector:4318" {
+		t.Fatalf("base = %q", base)
+	}
+	if !strings.Contains(warning, "trimmed") {
+		t.Fatalf("warning = %q", warning)
+	}
+}
+
+func TestBuildAuthHeaderDefaults(t *testing.T) {
+	headerName, headerValue := buildAuthHeader(ConfigureOpts{Token: "abc"}, false)
+	if headerName != "Authorization" {
+		t.Fatalf("headerName = %q", headerName)
+	}
+	if headerValue != "Bearer abc" {
+		t.Fatalf("headerValue = %q", headerValue)
+	}
+
+	headerName, headerValue = buildAuthHeader(ConfigureOpts{Token: "abc"}, true)
+	if headerName != "X-SF-Token" {
+		t.Fatalf("headerName = %q", headerName)
+	}
+	if headerValue != "abc" {
+		t.Fatalf("headerValue = %q", headerValue)
+	}
+}
+
+func TestConfigureRejectsConflictingDeprecatedToken(t *testing.T) {
+	err := Configure(ConfigureOpts{
+		Tool:                  ToolClaude,
+		Endpoint:              "http://collector.internal:4318",
+		Token:                 "token-a",
+		DeprecatedSplunkToken: "token-b",
+	})
+	if err == nil || !strings.Contains(err.Error(), "conflicting values") {
+		t.Fatalf("Configure error = %v", err)
+	}
+}
+
+func TestConfigEnvValueFallsBackToOSEnv(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+	if got := configEnvValue(map[string]interface{}{}, "CLAUDE_CODE_USE_BEDROCK"); got != "1" {
+		t.Fatalf("configEnvValue fallback = %q", got)
+	}
+}
+
+func TestHasClaudeFirstPartyAuthParsesJSONKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude.json")
+	if err := os.WriteFile(path, []byte(`{"profile":{"oauthAccount":{"email":"user@example.com"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !hasClaudeFirstPartyAuth(path) {
+		t.Fatal("expected parsed oauthAccount key to be detected")
+	}
+}
+
+func TestSettingsEnableClaudeBedrockParsesJSONKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte(`{"env":{"awsCredentialExport":"cat ~/.aws-bedrock-cc-creds.json"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !settingsEnableClaudeBedrock(path) {
+		t.Fatal("expected awsCredentialExport key to be detected")
+	}
+}
+
+func TestDeriveIngestHostFromAppHost(t *testing.T) {
+	host, warning, err := deriveIngestHost("app.us1.observability.splunkcloud.com")
+	if err != nil {
+		t.Fatalf("deriveIngestHost: %v", err)
+	}
+	if host != "ingest.us1.signalfx.com" {
+		t.Fatalf("host = %q, want ingest.us1.signalfx.com", host)
+	}
+	if !strings.Contains(warning, "derived ingest host") {
+		t.Fatalf("warning = %q", warning)
+	}
+}
+
+func TestMergeResourceAttributes(t *testing.T) {
+	got := mergeResourceAttributes("service.name=codex,team=platform", map[string]string{
+		"tenant_id":    "tenant-1",
+		"workspace_id": "workspace-a",
+		"agent_name":   "demo agent",
+	})
+	for _, want := range []string{
+		"service.name=codex",
+		"team=platform",
+		"tenant_id=tenant-1",
+		"workspace_id=workspace-a",
+		"agent_name=demo%20agent",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("merged attrs missing %q in %q", want, got)
+		}
+	}
+}

--- a/internal/agentotel/config_test.go
+++ b/internal/agentotel/config_test.go
@@ -76,7 +76,6 @@ func TestConfigureClaudeDirectWritesOTELEnv(t *testing.T) {
 	for _, key := range []string{
 		"BETA_TRACING_ENDPOINT",
 		"ENABLE_BETA_TRACING_DETAILED",
-		"ENABLE_ENHANCED_TELEMETRY_BETA",
 	} {
 		if _, ok := env[key]; ok {
 			t.Errorf("env[%q] should not be set in direct OTLP mode", key)
@@ -184,7 +183,6 @@ func TestConfigureClaudeSplunkDirectBootstrapsLogs(t *testing.T) {
 	for _, key := range []string{
 		"BETA_TRACING_ENDPOINT",
 		"ENABLE_BETA_TRACING_DETAILED",
-		"ENABLE_ENHANCED_TELEMETRY_BETA",
 	} {
 		if _, ok := env[key]; ok {
 			t.Fatalf("%s should be absent in direct Splunk mode", key)
@@ -304,7 +302,7 @@ func TestConfigureCodexDirectWritesHeaders(t *testing.T) {
 	}
 }
 
-func TestConfigureCodexSplunkDirectDisablesLogs(t *testing.T) {
+func TestConfigureCodexSplunkDirectBootstrapsLogs(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -323,8 +321,8 @@ func TestConfigureCodexSplunkDirectDisablesLogs(t *testing.T) {
 	}
 	content := string(data)
 
-	if !strings.Contains(content, `exporter = "none"`) {
-		t.Fatal("logs exporter should be disabled in direct Splunk mode")
+	if !strings.Contains(content, `endpoint = "https://ingest.us1.signalfx.com/v1/logs"`) {
+		t.Fatal("logs exporter should bootstrap the shared OTEL provider in direct Splunk mode")
 	}
 	for _, want := range []string{
 		`endpoint = "https://ingest.us1.signalfx.com/v2/datapoint/otlp"`,

--- a/internal/agentotel/run.go
+++ b/internal/agentotel/run.go
@@ -1,0 +1,349 @@
+package agentotel
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// RunOpts holds options for one-shot Claude/Codex launches with direct OTEL config.
+type RunOpts struct {
+	ConfigureOpts
+	Binary string
+}
+
+type runSpec struct {
+	binary string
+	args   []string
+	env    []string
+}
+
+// Run launches Claude Code or Codex with OTEL configuration injected for this
+// process only. It does not persist changes into the user's real desktop
+// settings files.
+func Run(ctx context.Context, opts RunOpts, toolArgs []string) error {
+	if err := normalizeConfigureOpts(&opts.ConfigureOpts); err != nil {
+		return err
+	}
+	if err := validateToolSpecificOverrides(opts.ConfigureOpts); err != nil {
+		return err
+	}
+
+	tool := normalizedTool(opts.Tool)
+	if tool != ToolClaude && tool != ToolCodex {
+		return fmt.Errorf("run requires --tool %q or %q", ToolClaude, ToolCodex)
+	}
+
+	effective := effectiveToolConfigureOpts(opts.ConfigureOpts, tool)
+	target, err := resolveTelemetryTarget(effective)
+	if err != nil {
+		return err
+	}
+
+	spec, err := buildRunSpec(effective, strings.TrimSpace(opts.Binary), toolArgs, target)
+	if err != nil {
+		return err
+	}
+	printRunSummary(spec, target, effective)
+
+	cmd := exec.CommandContext(ctx, spec.binary, spec.args...)
+	cmd.Env = spec.env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func buildRunSpec(opts ConfigureOpts, binary string, toolArgs []string, target telemetryTarget) (runSpec, error) {
+	if binary == "" {
+		binary = opts.Tool
+	}
+
+	switch normalizedTool(opts.Tool) {
+	case ToolClaude:
+		return buildClaudeRunSpec(opts, binary, toolArgs, target)
+	case ToolCodex:
+		return buildCodexRunSpec(opts, binary, toolArgs, target)
+	default:
+		return runSpec{}, fmt.Errorf("unsupported tool %q", opts.Tool)
+	}
+}
+
+func buildClaudeRunSpec(opts ConfigureOpts, binary string, toolArgs []string, target telemetryTarget) (runSpec, error) {
+	env := envSliceToMap(os.Environ())
+	settingsEnv, err := currentClaudeSettingsEnv()
+	if err != nil && !os.IsNotExist(err) {
+		return runSpec{}, err
+	}
+	claudeSettingsEnv := sanitizedClaudeRunSettingsEnv(settingsEnv)
+	if shouldUseClaudeBedrockForConfig(settingsEnv) {
+		claudeSettingsEnv["CLAUDE_CODE_USE_BEDROCK"] = "1"
+	}
+
+	claudeSettingsEnv["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
+	claudeSettingsEnv["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"] = "1"
+	claudeSettingsEnv["ENABLE_ENHANCED_TELEMETRY_BETA"] = "1"
+	claudeSettingsEnv["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf"
+	if target.baseEndpoint != "" {
+		claudeSettingsEnv["OTEL_EXPORTER_OTLP_ENDPOINT"] = target.baseEndpoint
+	} else {
+		delete(claudeSettingsEnv, "OTEL_EXPORTER_OTLP_ENDPOINT")
+	}
+	if target.headerName != "" && target.headerValue != "" {
+		claudeSettingsEnv["OTEL_EXPORTER_OTLP_HEADERS"] = fmt.Sprintf("%s=%s", target.headerName, target.headerValue)
+		claudeSettingsEnv["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = fmt.Sprintf("%s=%s", target.headerName, target.headerValue)
+		claudeSettingsEnv["OTEL_EXPORTER_OTLP_METRICS_HEADERS"] = fmt.Sprintf("%s=%s", target.headerName, target.headerValue)
+	} else {
+		delete(claudeSettingsEnv, "OTEL_EXPORTER_OTLP_HEADERS")
+		delete(claudeSettingsEnv, "OTEL_EXPORTER_OTLP_TRACES_HEADERS")
+		delete(claudeSettingsEnv, "OTEL_EXPORTER_OTLP_METRICS_HEADERS")
+	}
+
+	claudeSettingsEnv["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"] = "http/protobuf"
+	claudeSettingsEnv["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = target.traceEndpoint
+	claudeSettingsEnv["OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"] = "http/protobuf"
+	claudeSettingsEnv["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] = target.metricEndpoint
+	if target.logsEnabled || target.logBootstrapNeeded {
+		claudeSettingsEnv["OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"] = "http/protobuf"
+		claudeSettingsEnv["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] = target.logEndpoint
+		if target.headerName != "" && target.headerValue != "" {
+			claudeSettingsEnv["OTEL_EXPORTER_OTLP_LOGS_HEADERS"] = fmt.Sprintf("%s=%s", target.headerName, target.headerValue)
+		} else {
+			delete(claudeSettingsEnv, "OTEL_EXPORTER_OTLP_LOGS_HEADERS")
+		}
+		claudeSettingsEnv["OTEL_LOGS_EXPORTER"] = "otlp"
+		claudeSettingsEnv["OTEL_LOGS_EXPORT_INTERVAL"] = "1000"
+	} else {
+		delete(claudeSettingsEnv, "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL")
+		delete(claudeSettingsEnv, "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT")
+		delete(claudeSettingsEnv, "OTEL_EXPORTER_OTLP_LOGS_HEADERS")
+		delete(claudeSettingsEnv, "OTEL_LOGS_EXPORTER")
+		delete(claudeSettingsEnv, "OTEL_LOGS_EXPORT_INTERVAL")
+	}
+	claudeSettingsEnv["OTEL_METRICS_EXPORTER"] = "otlp"
+	claudeSettingsEnv["OTEL_TRACES_EXPORTER"] = "otlp"
+	claudeSettingsEnv["OTEL_METRIC_EXPORT_INTERVAL"] = "1000"
+	claudeSettingsEnv["OTEL_TRACES_EXPORT_INTERVAL"] = "1000"
+	claudeSettingsEnv["OTEL_LOG_TOOL_DETAILS"] = "1"
+	claudeSettingsEnv["OTEL_METRICS_INCLUDE_VERSION"] = "true"
+	claudeSettingsEnv["OTEL_RESOURCE_ATTRIBUTES"] = buildRuntimeResourceAttrs(stringValue(settingsEnv["OTEL_RESOURCE_ATTRIBUTES"]), opts)
+	delete(claudeSettingsEnv, "BETA_TRACING_ENDPOINT")
+	delete(claudeSettingsEnv, "ENABLE_BETA_TRACING_DETAILED")
+	delete(env, "BETA_TRACING_ENDPOINT")
+	delete(env, "ENABLE_BETA_TRACING_DETAILED")
+	delete(env, "ENABLE_ENHANCED_TELEMETRY_BETA")
+
+	for _, key := range otelEnvKeys {
+		delete(env, key)
+	}
+	delete(env, "BETA_TRACING_ENDPOINT")
+	delete(env, "ENABLE_BETA_TRACING_DETAILED")
+	delete(env, "ENABLE_ENHANCED_TELEMETRY_BETA")
+	for key, value := range claudeSettingsEnv {
+		env[key] = value
+	}
+
+	return runSpec{
+		binary: binary,
+		args:   append([]string(nil), toolArgs...),
+		env:    envMapToSlice(env),
+	}, nil
+}
+
+func buildCodexRunSpec(opts ConfigureOpts, binary string, toolArgs []string, target telemetryTarget) (runSpec, error) {
+	env := envSliceToMap(os.Environ())
+	for _, key := range otelEnvKeys {
+		delete(env, key)
+	}
+	delete(env, "OTEL_EXPORTER_OTLP_TRACES_HEADERS")
+	delete(env, "OTEL_EXPORTER_OTLP_METRICS_HEADERS")
+	delete(env, "OTEL_EXPORTER_OTLP_LOGS_HEADERS")
+	env["OTEL_RESOURCE_ATTRIBUTES"] = buildRuntimeResourceAttrs(env["OTEL_RESOURCE_ATTRIBUTES"], opts)
+	if target.baseEndpoint != "" {
+		env["OTEL_EXPORTER_OTLP_ENDPOINT"] = target.baseEndpoint
+	} else {
+		delete(env, "OTEL_EXPORTER_OTLP_ENDPOINT")
+	}
+	env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf"
+	if target.headerName != "" && target.headerValue != "" {
+		env["OTEL_EXPORTER_OTLP_HEADERS"] = fmt.Sprintf("%s=%s", target.headerName, target.headerValue)
+	} else {
+		delete(env, "OTEL_EXPORTER_OTLP_HEADERS")
+	}
+	env["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"] = "http/protobuf"
+	env["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = target.traceEndpoint
+	if target.headerName != "" && target.headerValue != "" {
+		env["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = fmt.Sprintf("%s=%s", target.headerName, target.headerValue)
+	} else {
+		delete(env, "OTEL_EXPORTER_OTLP_TRACES_HEADERS")
+	}
+	env["OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"] = "http/protobuf"
+	env["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] = target.metricEndpoint
+	if target.headerName != "" && target.headerValue != "" {
+		env["OTEL_EXPORTER_OTLP_METRICS_HEADERS"] = fmt.Sprintf("%s=%s", target.headerName, target.headerValue)
+	} else {
+		delete(env, "OTEL_EXPORTER_OTLP_METRICS_HEADERS")
+	}
+	env["OTEL_METRICS_EXPORTER"] = "otlp"
+	env["OTEL_TRACES_EXPORTER"] = "otlp"
+	env["OTEL_METRIC_EXPORT_INTERVAL"] = "1000"
+	env["OTEL_TRACES_EXPORT_INTERVAL"] = "1000"
+	if target.logsEnabled || target.logBootstrapNeeded {
+		env["OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"] = "http/protobuf"
+		env["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] = target.logEndpoint
+		if target.headerName != "" && target.headerValue != "" {
+			env["OTEL_EXPORTER_OTLP_LOGS_HEADERS"] = fmt.Sprintf("%s=%s", target.headerName, target.headerValue)
+		} else {
+			delete(env, "OTEL_EXPORTER_OTLP_LOGS_HEADERS")
+		}
+		env["OTEL_LOGS_EXPORTER"] = "otlp"
+		env["OTEL_LOGS_EXPORT_INTERVAL"] = "1000"
+	} else {
+		delete(env, "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL")
+		delete(env, "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT")
+		delete(env, "OTEL_EXPORTER_OTLP_LOGS_HEADERS")
+		delete(env, "OTEL_LOGS_EXPORTER")
+		delete(env, "OTEL_LOGS_EXPORT_INTERVAL")
+	}
+
+	overrides := make([]string, 0, 8)
+	if strings.TrimSpace(opts.Environment) != "" {
+		overrides = append(overrides, "-c", fmt.Sprintf("otel.environment=%q", opts.Environment))
+	}
+	if target.logsEnabled || target.logBootstrapNeeded {
+		overrides = append(overrides, "-c", "otel.exporter="+buildCodexExporterValue(target.logEndpoint, target))
+	}
+	overrides = append(overrides, "-c", "otel.metrics_exporter="+buildCodexExporterValue(target.metricEndpoint, target))
+	overrides = append(overrides, "-c", "otel.trace_exporter="+buildCodexExporterValue(target.traceEndpoint, target))
+
+	args := make([]string, 0, len(toolArgs)+len(overrides))
+	if len(toolArgs) > 0 && !strings.HasPrefix(toolArgs[0], "-") {
+		args = append(args, toolArgs[0])
+		args = append(args, overrides...)
+		args = append(args, toolArgs[1:]...)
+	} else {
+		args = append(args, overrides...)
+		args = append(args, toolArgs...)
+	}
+
+	return runSpec{
+		binary: binary,
+		args:   args,
+		env:    envMapToSlice(env),
+	}, nil
+}
+
+func sanitizedClaudeRunSettingsEnv(env map[string]interface{}) map[string]string {
+	out := make(map[string]string, len(env))
+	for key, raw := range env {
+		s, ok := raw.(string)
+		if !ok {
+			continue
+		}
+		if managedClaudeTelemetryKey(key) {
+			continue
+		}
+		out[key] = s
+	}
+	return out
+}
+
+func managedClaudeTelemetryKey(key string) bool {
+	for _, managed := range otelEnvKeys {
+		if managed == key {
+			return true
+		}
+	}
+	switch key {
+	case "BETA_TRACING_ENDPOINT", "ENABLE_BETA_TRACING_DETAILED", "ENABLE_ENHANCED_TELEMETRY_BETA":
+		return true
+	default:
+		return false
+	}
+}
+
+func stringValue(v interface{}) string {
+	s, _ := v.(string)
+	return s
+}
+
+func currentClaudeSettingsEnv() (map[string]interface{}, error) {
+	path, err := claudeSettingsPath()
+	if err != nil {
+		return nil, err
+	}
+	settings, err := readJSONFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]interface{}{}, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	env, _ := settings["env"].(map[string]interface{})
+	if env == nil {
+		return map[string]interface{}{}, nil
+	}
+	return env, nil
+}
+
+func buildRuntimeResourceAttrs(existing string, opts ConfigureOpts) string {
+	extra := map[string]string{
+		"tenant_id":              opts.TenantID,
+		"workspace_id":           opts.WorkspaceID,
+		"agent_name":             opts.AgentName,
+		"deployment.environment": opts.Environment,
+		"wrapped_cli":            opts.Tool,
+	}
+	return mergeResourceAttributes(existing, extra)
+}
+
+func buildCodexExporterValue(endpoint string, target telemetryTarget) string {
+	if target.headerName == "" || target.headerValue == "" {
+		return fmt.Sprintf(`{ "otlp-http" = { endpoint = %q, protocol = "binary" } }`, endpoint)
+	}
+	return fmt.Sprintf(`{ "otlp-http" = { endpoint = %q, protocol = "binary", headers = { %q = %q } } }`,
+		endpoint, target.headerName, target.headerValue)
+}
+
+func envSliceToMap(env []string) map[string]string {
+	out := make(map[string]string, len(env))
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func envMapToSlice(env map[string]string) []string {
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, key+"="+env[key])
+	}
+	return out
+}
+
+func printRunSummary(spec runSpec, target telemetryTarget, opts ConfigureOpts) {
+	fmt.Fprintf(os.Stderr, "[run] launching %s via %s\n", opts.Tool, spec.binary)
+	fmt.Fprintf(os.Stderr, "[run] traces  → %s\n", target.traceEndpoint)
+	fmt.Fprintf(os.Stderr, "[run] metrics → %s\n", target.metricEndpoint)
+	if target.logsEnabled {
+		fmt.Fprintf(os.Stderr, "[run] logs    → %s\n", target.logEndpoint)
+	}
+	for _, warning := range target.warnings {
+		fmt.Fprintf(os.Stderr, "[run] warning: %s\n", warning)
+	}
+	if normalizedTool(opts.Tool) == ToolCodex && hasConfigTags(opts) {
+		fmt.Fprintf(os.Stderr, "[run] warning: Codex resource tags are best-effort in one-shot mode; verify tenant/workspace/agent dimensions in your backend\n")
+	}
+}

--- a/internal/agentotel/run.go
+++ b/internal/agentotel/run.go
@@ -191,7 +191,7 @@ func buildCodexRunSpec(opts ConfigureOpts, binary string, toolArgs []string, tar
 	env["OTEL_TRACES_EXPORTER"] = "otlp"
 	env["OTEL_METRIC_EXPORT_INTERVAL"] = "1000"
 	env["OTEL_TRACES_EXPORT_INTERVAL"] = "1000"
-	if target.logsEnabled || target.logBootstrapNeeded {
+	if target.logsEnabled {
 		env["OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"] = "http/protobuf"
 		env["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] = target.logEndpoint
 		if target.headerName != "" && target.headerValue != "" {
@@ -213,7 +213,7 @@ func buildCodexRunSpec(opts ConfigureOpts, binary string, toolArgs []string, tar
 	if strings.TrimSpace(opts.Environment) != "" {
 		overrides = append(overrides, "-c", fmt.Sprintf("otel.environment=%q", opts.Environment))
 	}
-	if target.logsEnabled || target.logBootstrapNeeded {
+	if target.logsEnabled {
 		overrides = append(overrides, "-c", "otel.exporter="+buildCodexExporterValue(target.logEndpoint, target))
 	}
 	overrides = append(overrides, "-c", "otel.metrics_exporter="+buildCodexExporterValue(target.metricEndpoint, target))
@@ -341,6 +341,9 @@ func printRunSummary(spec runSpec, target telemetryTarget, opts ConfigureOpts) {
 		fmt.Fprintf(os.Stderr, "[run] logs    → %s\n", target.logEndpoint)
 	}
 	for _, warning := range target.warnings {
+		if normalizedTool(opts.Tool) == ToolCodex && !target.logsEnabled && strings.Contains(warning, "OTLP logs") {
+			continue
+		}
 		fmt.Fprintf(os.Stderr, "[run] warning: %s\n", warning)
 	}
 	if normalizedTool(opts.Tool) == ToolCodex && hasConfigTags(opts) {

--- a/internal/agentotel/run_test.go
+++ b/internal/agentotel/run_test.go
@@ -1,0 +1,230 @@
+package agentotel
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildClaudeRunSpecSetsRuntimeEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".aws-bedrock-cc-creds.json"), []byte(`{"token":"bedrock"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude", "settings.json"), []byte(`{
+  "permissions": {
+    "allow": ["Read"]
+  },
+  "env": {
+    "EXISTING_KEY": "existing-value"
+  }
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := ConfigureOpts{
+		Tool:        ToolClaude,
+		SplunkHost:  "us1",
+		Token:       "splunk-token",
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-claude",
+		AgentName:   "claude-desktop",
+		Environment: "claude-dev",
+	}
+	target, err := resolveTelemetryTarget(opts)
+	if err != nil {
+		t.Fatalf("resolveTelemetryTarget: %v", err)
+	}
+
+	spec, err := buildRunSpec(opts, "", []string{"-p", "--model", "haiku"}, target)
+	if err != nil {
+		t.Fatalf("buildRunSpec: %v", err)
+	}
+	if spec.binary != "claude" {
+		t.Fatalf("binary = %q", spec.binary)
+	}
+	if got := strings.Join(spec.args, " "); got != "-p --model haiku" {
+		t.Fatalf("args = %q", got)
+	}
+
+	env := envSliceToMap(spec.env)
+	if got := env["HOME"]; got != home {
+		t.Fatalf("HOME = %q, want %q", got, home)
+	}
+	if got := spec.binary; got != "claude" {
+		t.Fatalf("binary = %q", got)
+	}
+	if got, ok := env["EXISTING_KEY"]; !ok || got != "existing-value" {
+		t.Fatalf("EXISTING_KEY = %q", got)
+	}
+	if _, ok := env["permissions"]; ok {
+		t.Fatal("unexpected settings JSON key leaked into env")
+	}
+	if got := env["CLAUDE_CODE_USE_BEDROCK"]; got != "1" {
+		t.Fatalf("CLAUDE_CODE_USE_BEDROCK = %q", got)
+	}
+	if got := env["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"]; got != "https://ingest.us1.signalfx.com/v2/trace/otlp" {
+		t.Fatalf("trace endpoint = %q", got)
+	}
+	if got := env["OTEL_EXPORTER_OTLP_TRACES_HEADERS"]; got != "X-SF-Token=splunk-token" {
+		t.Fatalf("trace headers = %q", got)
+	}
+	if got := env["OTEL_LOGS_EXPORTER"]; got != "otlp" {
+		t.Fatalf("OTEL_LOGS_EXPORTER = %q", got)
+	}
+	attrs := env["OTEL_RESOURCE_ATTRIBUTES"]
+	for _, want := range []string{
+		"tenant_id=tenant-a",
+		"workspace_id=workspace-claude",
+		"agent_name=claude-desktop",
+		"deployment.environment=claude-dev",
+		"wrapped_cli=claude",
+	} {
+		if !strings.Contains(attrs, want) {
+			t.Fatalf("missing %q in %q", want, attrs)
+		}
+	}
+}
+
+func TestBuildCodexRunSpecSetsRuntimeEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	opts := ConfigureOpts{
+		Tool:        ToolCodex,
+		SplunkHost:  "us1",
+		Token:       "splunk-token",
+		TenantID:    "tenant-a",
+		WorkspaceID: "workspace-codex",
+		AgentName:   "codex-desktop",
+		Environment: "codex-dev",
+	}
+	target, err := resolveTelemetryTarget(opts)
+	if err != nil {
+		t.Fatalf("resolveTelemetryTarget: %v", err)
+	}
+
+	spec, err := buildRunSpec(opts, "", []string{"exec", "--skip-git-repo-check", "--json", "Reply with ok only"}, target)
+	if err != nil {
+		t.Fatalf("buildRunSpec: %v", err)
+	}
+	if spec.binary != "codex" {
+		t.Fatalf("binary = %q", spec.binary)
+	}
+	args := strings.Join(spec.args, " ")
+	for _, want := range []string{
+		`exec -c otel.environment="codex-dev"`,
+		`-c otel.exporter={ "otlp-http" = { endpoint = "https://ingest.us1.signalfx.com/v1/logs", protocol = "binary", headers = { "X-SF-Token" = "splunk-token" } } }`,
+		`-c otel.metrics_exporter={ "otlp-http" = { endpoint = "https://ingest.us1.signalfx.com/v2/datapoint/otlp", protocol = "binary", headers = { "X-SF-Token" = "splunk-token" } } }`,
+		`-c otel.trace_exporter={ "otlp-http" = { endpoint = "https://ingest.us1.signalfx.com/v2/trace/otlp", protocol = "binary", headers = { "X-SF-Token" = "splunk-token" } } }`,
+		`--skip-git-repo-check --json Reply with ok only`,
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("args missing %q in %q", want, args)
+		}
+	}
+	env := envSliceToMap(spec.env)
+	if got := env["HOME"]; got != home {
+		t.Fatalf("HOME = %q, want %q", got, home)
+	}
+	if got := env["OTEL_EXPORTER_OTLP_HEADERS"]; got != "X-SF-Token=splunk-token" {
+		t.Fatalf("OTEL_EXPORTER_OTLP_HEADERS = %q", got)
+	}
+	for _, want := range []string{
+		"https://ingest.us1.signalfx.com/v2/trace/otlp",
+		"https://ingest.us1.signalfx.com/v2/datapoint/otlp",
+		"https://ingest.us1.signalfx.com/v1/logs",
+	} {
+		if !strings.Contains(strings.Join(spec.env, "\n"), want) {
+			t.Fatalf("env missing %q in:\n%s", want, strings.Join(spec.env, "\n"))
+		}
+	}
+	attrs := env["OTEL_RESOURCE_ATTRIBUTES"]
+	for _, want := range []string{
+		"tenant_id=tenant-a",
+		"workspace_id=workspace-codex",
+		"agent_name=codex-desktop",
+		"deployment.environment=codex-dev",
+		"wrapped_cli=codex",
+	} {
+		if !strings.Contains(attrs, want) {
+			t.Fatalf("missing %q in %q", want, attrs)
+		}
+	}
+}
+
+func TestRunLaunchesBinaryWithInjectedTelemetry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	outFile := filepath.Join(home, "capture.txt")
+	script := filepath.Join(home, "fake-codex.sh")
+	scriptBody := "#!/bin/sh\n" +
+		"printf 'ARGS=%s\\n' \"$*\" > \"$CAPTURE_FILE\"\n" +
+		"printf 'TRACE=%s\\n' \"$OTEL_EXPORTER_OTLP_TRACES_ENDPOINT\" >> \"$CAPTURE_FILE\"\n" +
+		"printf 'METRICS=%s\\n' \"$OTEL_EXPORTER_OTLP_METRICS_ENDPOINT\" >> \"$CAPTURE_FILE\"\n" +
+		"printf 'LOGS=%s\\n' \"$OTEL_EXPORTER_OTLP_LOGS_ENDPOINT\" >> \"$CAPTURE_FILE\"\n" +
+		"printf 'ATTRS=%s\\n' \"$OTEL_RESOURCE_ATTRIBUTES\" >> \"$CAPTURE_FILE\"\n"
+	if err := os.WriteFile(script, []byte(scriptBody), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CAPTURE_FILE", outFile)
+
+	opts := RunOpts{
+		ConfigureOpts: ConfigureOpts{
+			Tool:        ToolCodex,
+			SplunkHost:  "us1",
+			Token:       "splunk-token",
+			TenantID:    "tenant-a",
+			WorkspaceID: "workspace-codex",
+			AgentName:   "codex-desktop",
+			Environment: "codex-dev",
+		},
+		Binary: script,
+	}
+	if err := Run(context.Background(), opts, []string{"exec", "--skip-git-repo-check", "--json", "Reply with ok only"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		`ARGS=exec -c otel.environment="codex-dev"`,
+		`otel.exporter={ "otlp-http" = { endpoint = "https://ingest.us1.signalfx.com/v1/logs", protocol = "binary", headers = { "X-SF-Token" = "splunk-token" } } }`,
+		`otel.metrics_exporter={ "otlp-http" = { endpoint = "https://ingest.us1.signalfx.com/v2/datapoint/otlp", protocol = "binary", headers = { "X-SF-Token" = "splunk-token" } } }`,
+		`otel.trace_exporter={ "otlp-http" = { endpoint = "https://ingest.us1.signalfx.com/v2/trace/otlp", protocol = "binary", headers = { "X-SF-Token" = "splunk-token" } } }`,
+		`--skip-git-repo-check --json Reply with ok only`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("captured args missing %q:\n%s", want, content)
+		}
+	}
+	for _, want := range []string{
+		`TRACE=https://ingest.us1.signalfx.com/v2/trace/otlp`,
+		`METRICS=https://ingest.us1.signalfx.com/v2/datapoint/otlp`,
+		`LOGS=https://ingest.us1.signalfx.com/v1/logs`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("captured env missing %q:\n%s", want, content)
+		}
+	}
+	for _, want := range []string{
+		"tenant_id=tenant-a",
+		"workspace_id=workspace-codex",
+		"agent_name=codex-desktop",
+		"deployment.environment=codex-dev",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("captured attrs missing %q:\n%s", want, content)
+		}
+	}
+}

--- a/internal/agentotel/run_test.go
+++ b/internal/agentotel/run_test.go
@@ -120,7 +120,6 @@ func TestBuildCodexRunSpecSetsRuntimeEnv(t *testing.T) {
 	args := strings.Join(spec.args, " ")
 	for _, want := range []string{
 		`exec -c otel.environment="codex-dev"`,
-		`-c otel.exporter={ "otlp-http" = { endpoint = "https://ingest.us1.signalfx.com/v1/logs", protocol = "binary", headers = { "X-SF-Token" = "splunk-token" } } }`,
 		`-c otel.metrics_exporter={ "otlp-http" = { endpoint = "https://ingest.us1.signalfx.com/v2/datapoint/otlp", protocol = "binary", headers = { "X-SF-Token" = "splunk-token" } } }`,
 		`-c otel.trace_exporter={ "otlp-http" = { endpoint = "https://ingest.us1.signalfx.com/v2/trace/otlp", protocol = "binary", headers = { "X-SF-Token" = "splunk-token" } } }`,
 		`--skip-git-repo-check --json Reply with ok only`,
@@ -139,11 +138,13 @@ func TestBuildCodexRunSpecSetsRuntimeEnv(t *testing.T) {
 	for _, want := range []string{
 		"https://ingest.us1.signalfx.com/v2/trace/otlp",
 		"https://ingest.us1.signalfx.com/v2/datapoint/otlp",
-		"https://ingest.us1.signalfx.com/v1/logs",
 	} {
 		if !strings.Contains(strings.Join(spec.env, "\n"), want) {
 			t.Fatalf("env missing %q in:\n%s", want, strings.Join(spec.env, "\n"))
 		}
+	}
+	if strings.Contains(strings.Join(spec.env, "\n"), "https://ingest.us1.signalfx.com/v1/logs") {
+		t.Fatalf("did not expect direct Codex logs endpoint in:\n%s", strings.Join(spec.env, "\n"))
 	}
 	attrs := env["OTEL_RESOURCE_ATTRIBUTES"]
 	for _, want := range []string{
@@ -199,7 +200,6 @@ func TestRunLaunchesBinaryWithInjectedTelemetry(t *testing.T) {
 	content := string(data)
 	for _, want := range []string{
 		`ARGS=exec -c otel.environment="codex-dev"`,
-		`otel.exporter={ "otlp-http" = { endpoint = "https://ingest.us1.signalfx.com/v1/logs", protocol = "binary", headers = { "X-SF-Token" = "splunk-token" } } }`,
 		`otel.metrics_exporter={ "otlp-http" = { endpoint = "https://ingest.us1.signalfx.com/v2/datapoint/otlp", protocol = "binary", headers = { "X-SF-Token" = "splunk-token" } } }`,
 		`otel.trace_exporter={ "otlp-http" = { endpoint = "https://ingest.us1.signalfx.com/v2/trace/otlp", protocol = "binary", headers = { "X-SF-Token" = "splunk-token" } } }`,
 		`--skip-git-repo-check --json Reply with ok only`,
@@ -211,11 +211,13 @@ func TestRunLaunchesBinaryWithInjectedTelemetry(t *testing.T) {
 	for _, want := range []string{
 		`TRACE=https://ingest.us1.signalfx.com/v2/trace/otlp`,
 		`METRICS=https://ingest.us1.signalfx.com/v2/datapoint/otlp`,
-		`LOGS=https://ingest.us1.signalfx.com/v1/logs`,
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("captured env missing %q:\n%s", want, content)
 		}
+	}
+	if strings.Contains(content, `LOGS=https://ingest.us1.signalfx.com/v1/logs`) {
+		t.Fatalf("did not expect direct Codex logs endpoint:\n%s", content)
 	}
 	for _, want := range []string{
 		"tenant_id=tenant-a",

--- a/internal/agentotel/util.go
+++ b/internal/agentotel/util.go
@@ -1,0 +1,240 @@
+package agentotel
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	ToolClaude = "claude"
+	ToolCodex  = "codex"
+	ToolAll    = "all"
+)
+
+func deriveIngestHost(raw string) (string, string, error) {
+	host := strings.TrimSpace(raw)
+	host = strings.TrimPrefix(host, "https://")
+	host = strings.TrimPrefix(host, "http://")
+	host = strings.TrimRight(host, "/")
+	if host == "" {
+		return "", "", fmt.Errorf("splunk host must not be empty")
+	}
+
+	if realm := extractRealm(host); realm != "" {
+		ingest := fmt.Sprintf("ingest.%s.signalfx.com", realm)
+		return ingest, fmt.Sprintf("derived ingest host %q from %q (realm %s)", ingest, raw, realm), nil
+	}
+
+	if strings.HasPrefix(host, "ingest.") && strings.HasSuffix(host, ".signalfx.com") {
+		return host, "", nil
+	}
+
+	if !strings.Contains(host, ".") {
+		ingest := fmt.Sprintf("ingest.%s.signalfx.com", host)
+		return ingest, fmt.Sprintf("interpreted %q as realm and derived ingest host %q", raw, ingest), nil
+	}
+
+	return host, "", nil
+}
+
+func extractRealm(host string) string {
+	const suffix = ".observability.splunkcloud.com"
+	if !strings.HasSuffix(host, suffix) {
+		return ""
+	}
+	prefix := strings.TrimSuffix(host, suffix)
+	if strings.HasPrefix(prefix, "app.") {
+		return strings.TrimPrefix(prefix, "app.")
+	}
+	if strings.HasPrefix(prefix, "ingest.") {
+		return strings.TrimPrefix(prefix, "ingest.")
+	}
+	if prefix != "" && !strings.Contains(prefix, ".") {
+		return prefix
+	}
+	return ""
+}
+
+func mergeResourceAttributes(existing string, extra map[string]string) string {
+	attrs := map[string]string{}
+	for _, part := range strings.Split(existing, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		attrs[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	for k, v := range extra {
+		if strings.TrimSpace(v) == "" {
+			continue
+		}
+		attrs[k] = sanitizeResourceValue(v)
+	}
+	if len(attrs) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, k+"="+attrs[k])
+	}
+	return strings.Join(out, ",")
+}
+
+func sanitizeResourceValue(v string) string {
+	var b strings.Builder
+	for _, r := range v {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case strings.ContainsRune("._:-/", r):
+			b.WriteRune(r)
+		default:
+			for _, by := range []byte(string(r)) {
+				fmt.Fprintf(&b, "%%%02X", by)
+			}
+		}
+	}
+	return b.String()
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func shouldUseClaudeBedrockForConfig(env map[string]interface{}) bool {
+	if isTruthy(configEnvValue(env, "CLAUDE_CODE_USE_BEDROCK")) {
+		return true
+	}
+	if strings.TrimSpace(firstNonEmpty(
+		configEnvValue(env, "ANTHROPIC_API_KEY"),
+		configEnvValue(env, "ANTHROPIC_AUTH_TOKEN"),
+		configEnvValue(env, "CLAUDE_CODE_OAUTH_TOKEN"),
+	)) != "" {
+		return false
+	}
+	if strings.TrimSpace(configEnvValue(env, "AWS_BEARER_TOKEN_BEDROCK")) != "" {
+		return true
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(homeDir) == "" {
+		return false
+	}
+	if hasClaudeFirstPartyAuth(filepath.Join(homeDir, ".claude.json")) {
+		return false
+	}
+	if fileExists(filepath.Join(homeDir, ".aws-bedrock-cc-creds.json")) {
+		return true
+	}
+	return settingsEnableClaudeBedrock(
+		filepath.Join(homeDir, ".claude", "settings.json"),
+		filepath.Join(homeDir, ".claude", "settings.local.json"),
+	)
+}
+
+func configEnvValue(env map[string]interface{}, key string) string {
+	value, ok := env[key]
+	if ok {
+		switch v := value.(type) {
+		case string:
+			if strings.TrimSpace(v) != "" {
+				return v
+			}
+		}
+	}
+	return os.Getenv(key)
+}
+
+func hasClaudeFirstPartyAuth(path string) bool {
+	return jsonFileContainsAnyKey(path,
+		"oauthAccount",
+		"accessToken",
+		"refreshToken",
+		"customApiKeyResponses",
+	)
+}
+
+func settingsEnableClaudeBedrock(paths ...string) bool {
+	for _, path := range paths {
+		if jsonFileContainsAnyKey(path, "awsCredentialExport", "awsAuthRefresh") {
+			return true
+		}
+	}
+	return false
+}
+
+func jsonFileContainsAnyKey(path string, keys ...string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var decoded interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return false
+	}
+	keySet := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		keySet[key] = struct{}{}
+	}
+	return containsAnyJSONKey(decoded, keySet)
+}
+
+func containsAnyJSONKey(value interface{}, keys map[string]struct{}) bool {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		for key, child := range v {
+			if _, ok := keys[key]; ok {
+				return true
+			}
+			if containsAnyJSONKey(child, keys) {
+				return true
+			}
+		}
+	case []interface{}:
+		for _, child := range v {
+			if containsAnyJSONKey(child, keys) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func isTruthy(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## Summary
- add defenseclaw-agent-otel for persistent Claude Code and Codex OTLP config
- add per-tool Claude and Codex overrides for distinct desktop agent identities
- document desktop setup, caveats, and direct-export behavior

## Verification
- env GOCACHE=/tmp/go-build go test ./internal/agentotel/...
- env GOCACHE=/tmp/go-build go vet ./cmd/agentotel ./internal/agentotel
- make agent-otel
- verified Codex direct export reaches Splunk O11y trace-derived signals

## Caveats
- Codex direct mode still shows environment as unknown in Splunk O11y trace-derived series, so environment tagging is best-effort today
- Codex direct mode does not persist arbitrary OTEL resource attributes in config.toml today