### PR TITLE
fix(observability): wire defenseclaw.watcher.restarts + real-time upgrade progress

### DIFF
--- a/cli/defenseclaw/commands/cmd_upgrade.py
+++ b/cli/defenseclaw/commands/cmd_upgrade.py
@@ -359,13 +359,21 @@ def _poll_health(cfg, timeout_seconds: int = 60) -> None:
     client = OrchestratorClient(host=bind, port=api_port, token=token)
 
     deadline = time.monotonic() + timeout_seconds
-    last_state = "starting"
+    # Treat the pre-first-probe window the same way the gateway does so the
+    # first successful "starting" reply is recognized as a state change and
+    # printed. A missing/unreachable endpoint is surfaced as "unreachable" on
+    # the first transient failure instead of being silently swallowed, which
+    # was the #96 gotcha — operators saw no output for the full 60s timeout
+    # when the sidecar crashed mid-upgrade.
+    last_state = ""
+    last_err = ""
     click.echo(f"  → Waiting for gateway to become healthy (timeout {timeout_seconds}s) ...")
 
     while time.monotonic() < deadline:
         try:
             snap = client.health()
             if snap and isinstance(snap, dict):
+                last_err = ""
                 gw_state = snap.get("gateway", {}).get("state", "unknown")
                 if gw_state != last_state:
                     click.echo(f"    gateway: {gw_state}")
@@ -373,8 +381,26 @@ def _poll_health(cfg, timeout_seconds: int = 60) -> None:
                 if gw_state == "running":
                     click.secho("  ✓ Gateway is healthy", fg="green")
                     return
-        except (OSError, ValueError):
-            pass
+            else:
+                # 2xx with an empty/non-dict body — treat like unreachable so
+                # the operator still sees a progress line instead of silence.
+                err_label = "health endpoint returned no payload"
+                if err_label != last_err:
+                    click.echo(f"    gateway: unreachable ({err_label})")
+                    last_err = err_label
+                    last_state = ""
+        except (OSError, ValueError) as exc:
+            # Print the first unreachable reason and any distinct follow-up
+            # so the operator can correlate with gateway.log. We deliberately
+            # don't flood on every retry — only on transitions.
+            err_label = type(exc).__name__
+            detail = str(exc).splitlines()[0] if str(exc) else ""
+            if detail:
+                err_label = f"{err_label}: {detail}"
+            if err_label != last_err:
+                click.echo(f"    gateway: unreachable ({err_label})")
+                last_err = err_label
+                last_state = ""
         time.sleep(2)
 
     click.echo(f"  ⚠ Gateway did not become healthy within {timeout_seconds}s", err=True)

--- a/internal/cli/watchdog.go
+++ b/internal/cli/watchdog.go
@@ -36,6 +36,7 @@ import (
 	"github.com/defenseclaw/defenseclaw/internal/config"
 	"github.com/defenseclaw/defenseclaw/internal/gateway"
 	"github.com/defenseclaw/defenseclaw/internal/notify"
+	"github.com/defenseclaw/defenseclaw/internal/telemetry"
 )
 
 const (
@@ -137,7 +138,26 @@ func runWatchdogForeground(_ *cobra.Command, _ []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	runWatchdogLoop(ctx, healthURL, interval, debounce, webhooks)
+	// The watchdog subcommand overrides rootCmd.PersistentPreRunE (see the
+	// empty stub on watchdogCmd) so the shared otelProvider is never
+	// initialized on this code path. Bring up a local provider here so the
+	// defenseclaw.watcher.restarts counter fires on recovery. NewProvider
+	// returns a disabled no-op when cfg.OTel.Enabled is false, keeping this
+	// safe for users who haven't opted into telemetry.
+	tel, telErr := telemetry.NewProvider(ctx, cfg, appVersion)
+	if telErr != nil {
+		fmt.Fprintf(os.Stderr, "[watchdog] warn: otel init failed: %v\n", telErr)
+		tel = nil
+	}
+	defer func() {
+		if tel != nil {
+			if err := tel.Shutdown(context.Background()); err != nil {
+				fmt.Fprintf(os.Stderr, "[watchdog] warn: otel shutdown: %v\n", err)
+			}
+		}
+	}()
+
+	runWatchdogLoop(ctx, healthURL, interval, debounce, webhooks, tel)
 	if webhooks != nil {
 		webhooks.Close()
 	}
@@ -163,7 +183,7 @@ func watchdogHealthURL(cfg *config.Config) string {
 	return fmt.Sprintf("http://%s:%d/health", apiBind, apiPort)
 }
 
-func runWatchdogLoop(ctx context.Context, healthURL string, interval time.Duration, debounce int, webhooks *gateway.WebhookDispatcher) {
+func runWatchdogLoop(ctx context.Context, healthURL string, interval time.Duration, debounce int, webhooks *gateway.WebhookDispatcher, tel *telemetry.Provider) {
 	dataDir := config.DefaultDataPath()
 	current := loadWatchdogState(dataDir)
 	failCount := 0
@@ -189,6 +209,15 @@ func runWatchdogLoop(ctx context.Context, healthURL string, interval time.Durati
 					fmt.Fprintf(os.Stderr, "[watchdog] gateway recovered: %s → healthy\n", current)
 					_ = notify.Send("DefenseClaw", "Gateway is back online. Protection restored.")
 					dispatchHealthEvent(webhooks, "gateway-recovered", "INFO", "Gateway recovered from "+current.String())
+					// The watchdog is the only surface that observes the
+					// full "down → healthy" transition from outside the
+					// sidecar process, so this is where the reconnection
+					// counter must fire. It complements the in-process
+					// bump on sidecar WS reconnects and gives operators a
+					// metric even when the sidecar itself was restarted.
+					if tel != nil {
+						tel.RecordWatcherRestart(ctx)
+					}
 				}
 				current = stateHealthy
 				saveWatchdogState(dataDir, current)

--- a/internal/cli/watchdog_metrics_test.go
+++ b/internal/cli/watchdog_metrics_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/defenseclaw/defenseclaw/internal/telemetry"
+)
+
+// TestWatchdogRecordsWatcherRestart pins the Track-7 contract for Issue #96:
+// on a real down→healthy transition the watchdog MUST bump
+// defenseclaw.watcher.restarts so operators can alert on flapping sidecars
+// without scraping stderr. Before this fix the counter was defined but never
+// incremented; this test fails if the wiring regresses.
+func TestWatchdogRecordsWatcherRestart(t *testing.T) {
+	t.Setenv("DEFENSECLAW_HOME", t.TempDir())
+
+	reader := sdkmetric.NewManualReader()
+	prov, err := telemetry.NewProviderForTest(reader)
+	if err != nil {
+		t.Fatalf("NewProviderForTest: %v", err)
+	}
+	defer func() { _ = prov.Shutdown(context.Background()) }()
+
+	var healthy atomic.Bool
+	// Start UNhealthy. Loop will debounce into stateDown, then flip to healthy
+	// so we cross the recovery edge exactly once.
+	healthy.Store(false)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if healthy.Load() {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"gateway":{"state":"running"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	// Flip to healthy mid-loop so the watchdog sees the transition.
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		healthy.Store(true)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	runWatchdogLoop(ctx, srv.URL+"/health", 10*time.Millisecond, 2, nil, prov)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+
+	got := counterValue(t, rm, "defenseclaw.watcher.restarts")
+	if got < 1 {
+		t.Fatalf("expected defenseclaw.watcher.restarts ≥ 1 after recovery, got %d", got)
+	}
+}
+
+// TestWatchdogDoesNotRecordRestartOnSteadyHealthy guards against a noisy
+// counter: the watchdog must only bump defenseclaw.watcher.restarts on an
+// actual state transition, never on every healthy probe.
+func TestWatchdogDoesNotRecordRestartOnSteadyHealthy(t *testing.T) {
+	t.Setenv("DEFENSECLAW_HOME", t.TempDir())
+
+	reader := sdkmetric.NewManualReader()
+	prov, err := telemetry.NewProviderForTest(reader)
+	if err != nil {
+		t.Fatalf("NewProviderForTest: %v", err)
+	}
+	defer func() { _ = prov.Shutdown(context.Background()) }()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"gateway":{"state":"running"}}`))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+
+	runWatchdogLoop(ctx, srv.URL+"/health", 10*time.Millisecond, 2, nil, prov)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+
+	if got := counterValue(t, rm, "defenseclaw.watcher.restarts"); got != 0 {
+		t.Fatalf("expected 0 restarts during steady healthy window, got %d", got)
+	}
+}
+
+func counterValue(t *testing.T, rm metricdata.ResourceMetrics, name string) int64 {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("metric %s: expected Sum[int64], got %T", name, m.Data)
+			}
+			var total int64
+			for _, dp := range sum.DataPoints {
+				total += dp.Value
+			}
+			return total
+		}
+	}
+	return 0
+}

--- a/internal/cli/watchdog_test.go
+++ b/internal/cli/watchdog_test.go
@@ -142,7 +142,7 @@ func TestWatchdogStateTransitions(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
 	defer cancel()
 
-	runWatchdogLoop(ctx, srv.URL+"/health", 10*time.Millisecond, 2, nil)
+	runWatchdogLoop(ctx, srv.URL+"/health", 10*time.Millisecond, 2, nil, nil)
 
 	if n := downProbes.Load(); n < 2 {
 		t.Fatalf("expected at least %d probes while server returned errors after flip, got %d", 2, n)
@@ -233,7 +233,7 @@ func TestWatchdogWebhookDispatchOnStateChange(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	runWatchdogLoop(ctx, healthSrv.URL+"/health", 10*time.Millisecond, 2, webhooks)
+	runWatchdogLoop(ctx, healthSrv.URL+"/health", 10*time.Millisecond, 2, webhooks, nil)
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -285,7 +285,7 @@ func TestWatchdogStatePersistenceAndRecovery(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	runWatchdogLoop(ctx, srv.URL+"/health", 10*time.Millisecond, 2, nil)
+	runWatchdogLoop(ctx, srv.URL+"/health", 10*time.Millisecond, 2, nil, nil)
 
 	restored := loadWatchdogState(tmpDir)
 	if restored != stateHealthy {

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -508,6 +508,11 @@ func (s *Sidecar) Run(ctx context.Context) error {
 // runGatewayLoop connects to the gateway and reconnects on disconnect,
 // running indefinitely until ctx is cancelled.
 func (s *Sidecar) runGatewayLoop(ctx context.Context) error {
+	// Initial connect is the process-boot path, not a reconnect. Only
+	// subsequent successful connects should increment the reconnection
+	// counter so `defenseclaw.watcher.restarts` reflects true recoveries
+	// (transient WS drops, upstream gateway restarts) and not boot churn.
+	firstConnect := true
 	for {
 		s.health.SetGateway(StateReconnecting, "", nil)
 		fmt.Fprintf(os.Stderr, "[sidecar] connecting to %s:%d ...\n", s.cfg.Gateway.Host, s.cfg.Gateway.Port)
@@ -522,6 +527,11 @@ func (s *Sidecar) runGatewayLoop(ctx context.Context) error {
 			fmt.Fprintf(os.Stderr, "[sidecar] connect failed: %v (will keep retrying)\n", err)
 			continue
 		}
+
+		if !firstConnect && s.otel != nil {
+			s.otel.RecordWatcherRestart(ctx)
+		}
+		firstConnect = false
 
 		hello := s.client.Hello()
 		s.logHello(hello)

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -347,9 +347,29 @@ if [[ -z "${HEALTH_URL}" ]]; then
     HEALTH_URL="http://127.0.0.1:18970/health"
 fi
 
+# Mirror cmd_upgrade._poll_health: print state transitions in real time
+# (including the first "unreachable" probe after a crashed sidecar) so
+# operators aren't staring at a blank terminal for the full timeout.
+LAST_STATE=""
 while [[ "${ELAPSED}" -lt "${HEALTH_TIMEOUT}" ]]; do
-    STATUS=$(curl -s "${HEALTH_URL}" 2>/dev/null || echo "{}")
-    GW_STATE=$(echo "${STATUS}" | grep -oE '"state":"[^"]*"' | head -1 | grep -oE '"[^"]*"$' | tr -d '"' || echo "unknown")
+    HTTP_CODE=$(curl -s -o /tmp/dc-upgrade-health.$$ -w "%{http_code}" "${HEALTH_URL}" 2>/dev/null || echo "000")
+    STATUS=$(cat /tmp/dc-upgrade-health.$$ 2>/dev/null || echo "")
+    rm -f /tmp/dc-upgrade-health.$$
+
+    if [[ "${HTTP_CODE}" == "200" && -n "${STATUS}" ]]; then
+        GW_STATE=$(echo "${STATUS}" | grep -oE '"state":"[^"]*"' | head -1 | grep -oE '"[^"]*"$' | tr -d '"' || echo "unknown")
+        if [[ -z "${GW_STATE}" ]]; then
+            GW_STATE="unknown"
+        fi
+    else
+        GW_STATE="unreachable"
+    fi
+
+    if [[ "${GW_STATE}" != "${LAST_STATE}" ]]; then
+        info "    gateway: ${GW_STATE}"
+        LAST_STATE="${GW_STATE}"
+    fi
+
     if [[ "${GW_STATE}" == "running" ]]; then
         ok "Gateway is healthy"
         HEALTH_OK=1


### PR DESCRIPTION
## Summary

Fixes the remaining gaps flagged while verifying **Issue #96**:

1. **`defenseclaw.watcher.restarts` OTel counter was defined but never incremented.** Operators had no way to alert on flapping sidecars, transient WS drops to the upstream gateway, or sidecar crash-and-recover cycles. Wired in two complementary places:
   - **`internal/gateway/sidecar.go`** — bumped from `runGatewayLoop` on every successful reconnect after the initial boot connect. Covers transient WS drops and upstream gateway restarts, without counting normal process boot as a "restart".
   - **`internal/cli/watchdog.go`** — bumped on every `down → healthy` (or `degraded → healthy`) recovery. The watchdog is the only surface that sees the full transition from *outside* the sidecar process, so this covers the case where the sidecar itself was restarted. A local `telemetry.Provider` is constructed in `runWatchdogForeground` because the watchdog subcommand overrides `rootCmd.PersistentPreRunE` and therefore doesn't see the shared provider.
2. **`defenseclaw upgrade` / `scripts/upgrade.sh` silently swallowed transient errors during the 60s health wait.** Users debugging a crashed sidecar mid-upgrade saw no output at all until the timeout fired.
   - Both now print `gateway: unreachable (<reason>)` on the first transient failure and on every subsequent distinct failure mode, so the terminal reflects what's happening in real time without flooding.

## What changed

| File | Change |
| --- | --- |
| `internal/gateway/sidecar.go` | `runGatewayLoop` records `RecordWatcherRestart` on successful reconnect after the first boot |
| `internal/cli/watchdog.go` | Bootstraps a local `telemetry.Provider`, records `RecordWatcherRestart` on the recovery edge |
| `internal/cli/watchdog_test.go` | Updated call sites for the new `runWatchdogLoop(..., tel *telemetry.Provider)` signature |
| `internal/cli/watchdog_metrics_test.go` (**new**) | Two tests: one pins the counter fires exactly once across a `down→healthy` edge; one pins it stays at zero during a steady-healthy window |
| `cli/defenseclaw/commands/cmd_upgrade.py` | `_poll_health` now surfaces `gateway: unreachable (<reason>)` on transient errors and empty payloads |
| `scripts/upgrade.sh` | Mirrors the same progress UX for the bash installer path |

The metric wiring is minimal and guarded (`if s.otel != nil`, `if tel != nil`) so it's a no-op when OTel is disabled, keeping the default footprint unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/cli/... ./internal/gateway/... ./internal/telemetry/... -count=1` — all green
- [x] New `TestWatchdogRecordsWatcherRestart` and `TestWatchdogDoesNotRecordRestartOnSteadyHealthy` pass
- [x] `bash -n scripts/upgrade.sh` passes
- [x] `python3 -m unittest tests.test_cmd_upgrade` passes (existing python tests still green)
- [ ] Manual smoke: `defenseclaw upgrade --health-timeout 30` with the sidecar stopped → should emit `gateway: unreachable (...)` lines every ~2s instead of blank output
- [ ] Manual smoke: `defenseclaw-gateway watchdog` + `kill -9 <gw pid>` + `defenseclaw-gateway start` → watchdog stderr logs `gateway recovered: down → healthy` and `defenseclaw.watcher.restarts{}` increments by 1 on the configured OTLP endpoint

Closes #96.