### PR TITLE
docs: fix inaccuracies and add missing architecture details

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ DefenseClaw is a multi-component system with three runtimes that work together:
 | Component | Language | Role |
 |-----------|----------|------|
 | **CLI** | Python 3.11+ | Operator-facing tool — runs scanners, manages block/allow lists, TUI dashboard |
-| **Gateway** | Go 1.25+ | Central daemon — REST API, WebSocket bridge to OpenClaw, policy engine, inspection pipeline, SQLite audit store, SIEM export |
+| **Gateway** | Go 1.26+ | Central daemon — REST API, WebSocket bridge to OpenClaw, policy engine, inspection pipeline, SQLite audit store, SIEM export |
 | **Plugin** | TypeScript | Runs inside OpenClaw — fetch interceptor routes all LLM traffic through guardrail proxy, intercepts tool calls via `before_tool_call` hook, provides `/scan`, `/block`, `/allow` slash commands |
 
 The **CLI** and **Plugin** communicate with the **Gateway** over a local REST API. The Gateway connects to the OpenClaw Gateway over WebSocket (protocol v3) to subscribe to events and send enforcement commands. A built-in **guardrail proxy** inspects all LLM traffic in real time.
@@ -134,7 +134,7 @@ For the full system diagram, data flows, and component responsibilities, see [do
 | Requirement | Version | Check |
 |-------------|---------|-------|
 | Python | 3.10+ | `python3 --version` |
-| Go | 1.25+ | `go version` |
+| Go | 1.26.2+ | `go version` |
 | Node.js | 20+ (plugin only) | `node --version` |
 | Git | any | `git --version` |
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,7 +1,7 @@
 # DefenseClaw Sidecar REST API
 
 The sidecar exposes a localhost-only REST API on `127.0.0.1:{gateway.api_port}`
-(default `18790`). All responses are `application/json`. Mutating requests
+(default `18970`). All responses are `application/json`. Mutating requests
 (POST, PUT, PATCH, DELETE) require the `X-DefenseClaw-Client` header and
 `Content-Type: application/json` (CSRF protection).
 
@@ -29,7 +29,8 @@ Source: `internal/gateway/api.go`, `internal/gateway/inspect.go`
 | `/policy/evaluate/sandbox` | POST | OPA sandbox policy evaluation | No production callers |
 | `/policy/evaluate/audit` | POST | OPA audit retention policy evaluation | No production callers |
 | `/policy/evaluate/skill-actions` | POST | OPA skill-actions policy evaluation | No production callers |
-| `/policy/reload` | POST | Reload OPA policy engine from disk | No production callers |
+| `/policy/reload` | POST | Reload OPA policy engine from disk | Go CLI (`internal/cli/policy.go`) |
+| `/api/v1/network-egress` | GET/POST | Network egress policy management | Go CLI, TS plugin |
 | `/scan/result` | POST | Store scan result in audit log | TS plugin (`enforcer.ts`, `client.ts`) |
 | `/v1/skill/scan` | POST | Run skill scanner on a local path | Python CLI (`gateway.py`, `cmd_skill.py`) |
 | `/v1/mcp/scan` | POST | Run MCP scanner on a local path | No production callers |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,9 +38,13 @@ enforcement, and auditing across existing tools without replacing any component.
 │  │  └───────────┘ └───────────┘ └──────────┘ └────────┬────────┘       │    │
 │  │                                                     │               │    │
 │  │  ┌────────────────────────────────────────────┐     │               │    │
-│  │  │  Inspection Engine (Tool & CodeGuard)       │     │              │    │
+│  │  │  Inspection Engine (4-stage pipeline)        │     │              │    │
 │  │  │  /api/v1/inspect/tool                      │     │               │    │
-│  │  │  Block list → engine → CodeGuard           │     │               │    │
+│  │  │  1. Regex (113 rules, 6 categories)        │     │               │    │
+│  │  │  2. Cisco AI Defense (12 cloud rules)      │     │               │    │
+│  │  │  3. LLM Judge (injection/PII/tool-inj)     │     │               │    │
+│  │  │  4. OPA policy (7 Rego files)              │     │               │    │
+│  │  │  + CodeGuard for write/edit tools          │     │               │    │
 │  │  │  Verdict: allow / alert / block            │     │               │    │
 │  │  └────────────────────────────────────────────┘     │               │    │
 │  │                                                     │               │    │
@@ -148,15 +152,24 @@ only component with direct access to all subsystems.
 
 | Responsibility | Detail |
 |----------------|--------|
-| REST API server | Accepts requests from CLI and plugins |
-| OpenClaw WebSocket client | Connects via protocol v3, device-key auth, challenge-response |
-| Event subscription | Subscribes to all OpenClaw gateway events (`tool_call`, `tool_result`, `exec.approval.requested`, etc.) |
-| Command dispatch | Sends RPC commands to OpenClaw: `exec.approval.resolve`, `skills.update`, `config.patch` |
-| Policy engine | Runs admission gate: block list → allow list → scan → verdict |
-| LLM guardrail management | Runs guardrail proxy; restarts on crash |
-| Audit / SIEM | Logs all events to SQLite, forwards to Splunk HEC (batch or real-time) |
-| Webhook dispatch | Pushes enforcement events (block, drift, guardrail-block) to configured webhook endpoints (Slack, PagerDuty, generic HTTP) with severity filtering, event-type filtering, and retry |
-| DB access | Full read/write to SQLite — scan results, block/allow lists, inventory |
+| REST API server (`:18970`) | Accepts requests from CLI and plugins; CSRF-protected, localhost-bound |
+| Guardrail proxy (`:4000`) | HTTP reverse proxy that inspects all LLM traffic; rate-limited (100/s, burst 200) |
+| OpenClaw WebSocket client | Connects via protocol v3, HMAC-SHA256 challenge-response auth, sequence tracking |
+| Event router | Dispatches WebSocket events (`tool_call`, `tool_result`, `exec.approval.requested`, `session.message`, `agent`) with judge semaphore (cap 16) |
+| Command dispatch | Sends RPC commands to OpenClaw: `exec.approval.resolve`, `skills.update`, `config.get`, `config.patch`, `tools.catalog`, `sessions.list` |
+| Enforcement engine | Manages block/allow lists in SQLite (`internal/enforce/`) — separate from OPA |
+| OPA policy engine | Runs Rego policies for admission, guardrail verdicts, firewall, audit, sandbox, skill-actions — compiled once via `sync.Once` |
+| Inspection pipeline | 4-stage detection: (1) regex patterns → (2) Cisco AI Defense cloud scanner → (3) LLM judge → (4) OPA verdict aggregation |
+| Audit / SIEM | Logs all events to SQLite (WAL), rotating JSONL (50MB via lumberjack), Splunk HEC, OpenTelemetry |
+| Webhook dispatch | Pushes enforcement events to Slack (Block Kit), PagerDuty (Events v2), Webex, generic HMAC-SHA256 with severity/event filtering and retry |
+| Firewall | Kernel-level network filtering (iptables on Linux, pfctl on macOS) |
+| Watcher | File system monitoring for skill installation/removal events |
+| Inventory | Tracks installed skills/MCP servers (AIBOM) |
+| Daemon control | PID file management, process lifecycle (start/stop/restart), lumberjack log rotation |
+| Telemetry | OpenTelemetry tracing and metrics (spans for tools, approvals, LLM calls, guardrail stages, agent lifecycle) |
+| TUI dashboard | 12-panel Bubbletea terminal UI (Overview, Alerts, Skills, MCPs, Plugins, Inventory, Policy, Logs, Audit, Activity, Tools, Setup) |
+| PII redaction | Two-layer redaction: `<redacted len=N sha=8hex>` — sink layer always redacts regardless of reveal flag |
+| Hot reload | `guardrail_runtime.json` checked every 5s; updates mode and blockMessage under RWMutex |
 
 ### 4. SQLite Database
 
@@ -178,14 +191,16 @@ the Go guardrail reverse proxy regardless of which provider the user selects.
 
 | Responsibility | Detail |
 |----------------|--------|
-| Universal interception | Fetch interceptor covers all 7 providers (Anthropic, OpenAI, Azure, Gemini, OpenRouter, Ollama, Bedrock) |
-| Prompt inspection | Scans every prompt for injection attacks, secrets, PII, data exfiltration patterns before it reaches the LLM |
-| Response inspection | Scans every LLM response for leaked secrets, tool call anomalies |
-| Multi-provider routing | Proxy routes to the correct upstream based on `X-DC-Target-URL` header set by the interceptor |
-| Auth separation | `X-AI-Auth` header carries the real provider key; `Authorization` carries the DefenseClaw gateway key |
+| Universal interception | Fetch interceptor patches `globalThis.fetch` + `https.request`, covering 20+ providers via Bifrost SDK (v1.5.2) |
+| 4-stage inspection | (1) 113 regex rules across 6 categories → (2) Cisco AI Defense cloud scanner (12 rules) → (3) LLM Judge (Claude Sonnet, reentrancy-guarded) → (4) OPA policy verdict aggregation |
+| Detection strategies | `regex_only` (fastest), `regex_judge` (default — regex triages, judge verifies ambiguous), `judge_first` (most accurate, highest cost) |
+| Provider routing | Bifrost SDK routes to correct provider based on model format (`provider/model-name`) and API key prefix inference. Tenant-isolated: each `(provider, sha256(key), baseURL)` gets dedicated client |
+| Streaming inspection | Buffers first 8KB for tool call detection; `toolCallAccumulator` merges delta fragments; mid-stream inspection every 500 bytes; can terminate stream on CRITICAL finding |
+| Auth separation | `X-AI-Auth` header carries the real provider key; `X-DC-Auth` carries the DefenseClaw sidecar token |
 | Observe mode | Logs findings with colored output, never blocks (default, recommended to start) |
 | Action mode | Blocks prompts/responses that match security policies by raising exceptions |
 | Transparent proxy | No agent code changes required — the interceptor is invisible to OpenClaw |
+| Concurrency | RWMutexes (`rtMu`, `engineMu`, `spanMu`, `cfgMu`), judge semaphore (cap 16), rate limiter (100/s burst 200), connection pool (20 idle, 10/host) |
 
 **How it connects:**
 
@@ -325,4 +340,76 @@ requires only a new case in `internal/config/claw.go`.
                                                               ▼
                                                        LLM Provider
                                                     (Anthropic, OpenAI…)
+```
+
+## Internal Packages (Go Gateway)
+
+The Go gateway is organized into 19 internal packages:
+
+| Package | Purpose |
+|---------|---------|
+| `gateway/` | Core: GuardrailProxy (`:4000`), APIServer (`:18970`), WebSocket Client, Event Router, Inspection Engine, LLM Judge, Cisco AI Defense client, Bifrost provider integration |
+| `audit/` | SQLite WAL store — 8 tables, 5s busy timeout |
+| `cli/` | Go CLI (Cobra commands for gateway, policy, etc.) |
+| `config/` | Full config schema with LLM resolution, hot-reload support |
+| `daemon/` | PID file management, process lifecycle, lumberjack log rotation |
+| `enforce/` | Block/allow list PolicyEngine (SQLite JSON actions) — distinct from OPA |
+| `firewall/` | Kernel-level network filtering (iptables on Linux, pfctl on macOS) |
+| `gatewaylog/` | Structured JSONL event writer with fanout callbacks (rotating, 50MB) |
+| `guardrail/` | RulePack loading, JudgeYAML definitions, LRU-cached suppressions |
+| `inventory/` | Installed skills/MCP server tracking (AIBOM) |
+| `notify/` | Webhook and SIEM event dispatching with retry logic |
+| `policy/` | OPA engine — 7 Rego files (admission, guardrail, firewall, audit, skill_actions, sandbox, openshell), compiled once via `sync.Once` |
+| `redaction/` | Two-layer PII redaction: `<redacted len=N sha=8hex>`, ForSink variants always redact |
+| `sandbox/` | NVIDIA OpenShell sandbox policy enforcement |
+| `scanner/` | Scanner wrapper interfaces |
+| `telemetry/` | OpenTelemetry: resource attributes, spans (tool, approval, LLM, guardrail, agent), GenAI semconv metrics |
+| `tui/` | 12-panel Bubbletea dashboard (Lipgloss + Bubbles) |
+| `watcher/` | File system monitoring for skill installation/removal |
+
+## Dual Policy Engines
+
+DefenseClaw has two distinct policy evaluation systems — do not confuse them:
+
+| Engine | Package | Purpose | Data source |
+|--------|---------|---------|-------------|
+| **Enforcement Engine** | `internal/enforce/` | Block/allow list gate: checks SQLite `actions` table for explicit block/allow entries | SQLite JSON actions |
+| **OPA Policy Engine** | `internal/policy/` | Rego-based policy evaluation for admission, guardrail verdicts, firewall rules, sandbox controls | 7 `.rego` files in `policies/rego/` |
+
+The enforcement engine runs first (static block/allow lookup), and if the item is not explicitly listed, the OPA engine evaluates the appropriate Rego policy.
+
+## Inspection Pipeline Detail
+
+The guardrail proxy runs a 4-stage inspection pipeline on every LLM request (pre-call and post-call):
+
+```
+Stage 1: Regex Rules (microseconds)
+  113 compiled patterns across 6 categories:
+    secretRules, commandRules, sensitivePathRules,
+    c2Rules, cognitiveFileRules, trustExploitRules
+  Output: RuleFinding{RuleID, Severity, Confidence, Evidence}
+         │
+         ▼
+Stage 2: Cisco AI Defense (cloud, ~3s)
+  POST to us.api.inspect.aidefense.security.cisco.com
+  12 default rules (Prompt Injection, Jailbreak, PII, etc.)
+  Retry logic: 400 "already configured" → retry without rules
+         │
+         ▼
+Stage 3: LLM Judge (optional, model-dependent)
+  Three detection strategies:
+    regex_only  → skip judge entirely
+    regex_judge → judge verifies ambiguous regex findings only
+    judge_first → judge runs primary, regex as safety net
+  Judge types: injection, pii, tool-injection
+  Reentrancy guard: judgeCtxKey prevents infinite recursion
+  Suppression engine: LRU regex cache (1024), NANP phone heuristic
+         │
+         ▼
+Stage 4: OPA Policy (guardrail.rego)
+  Aggregates max severity across all scanners
+  block_threshold: HIGH (rank 3)
+  alert_threshold: MEDIUM (rank 2)
+  Observe mode: downgrades block → alert
+  Output: final verdict (allow / alert / block)
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -358,7 +358,7 @@ The Go gateway is organized into 19 internal packages:
 | `gatewaylog/` | Structured JSONL event writer with fanout callbacks (rotating, 50MB) |
 | `guardrail/` | RulePack loading, JudgeYAML definitions, LRU-cached suppressions |
 | `inventory/` | Installed skills/MCP server tracking (AIBOM) |
-| `notify/` | Webhook and SIEM event dispatching with retry logic |
+| `notify/` | Cross-platform desktop notifications (osascript on macOS, notify-send on Linux, stderr fallback) for watchdog alerts |
 | `policy/` | OPA engine — 7 Rego files (admission, guardrail, firewall, audit, skill_actions, sandbox, openshell), compiled once via `sync.Once` |
 | `redaction/` | Two-layer PII redaction: `<redacted len=N sha=8hex>`, ForSink variants always redact |
 | `sandbox/` | NVIDIA OpenShell sandbox policy enforcement |
@@ -366,6 +366,83 @@ The Go gateway is organized into 19 internal packages:
 | `telemetry/` | OpenTelemetry: resource attributes, spans (tool, approval, LLM, guardrail, agent), GenAI semconv metrics |
 | `tui/` | 12-panel Bubbletea dashboard (Lipgloss + Bubbles) |
 | `watcher/` | File system monitoring for skill installation/removal |
+
+## Multi-Turn Injection Detection
+
+The event router maintains a `ContextTracker` (`internal/gateway/context_tracker.go`)
+that buffers per-session conversation history and detects multi-turn prompt
+injection attacks — where an attacker spreads malicious instructions across
+several user messages to evade single-turn pattern matching.
+
+| Parameter | Default | Purpose |
+|-----------|---------|---------|
+| `maxTurns` | 10 | Messages retained per session (FIFO ring buffer) |
+| `maxSessions` | 200 | Total sessions tracked (LRU eviction when exceeded) |
+| `sessionTTL` | 30 min | Idle sessions are evicted after this period |
+| `staleSweepFrequency` | every 50 writes | Amortized sweep cost — no dedicated goroutine |
+
+**Detection flow:**
+
+1. Every `session.tool` / `session.message` event records the user turn via
+   `ContextTracker.Record(sessionKey, role, content)`.
+2. On each exec approval request, the router calls
+   `HasRepeatedInjection(sessionKey, threshold=3)`.
+3. `HasRepeatedInjection` scans all buffered user turns against the active
+   regex pattern set (honoring rule pack overrides). If 3+ turns contain
+   injection-like patterns, the request is denied automatically.
+4. The context buffer is also passed to the `GuardrailInspector` via
+   `RecentMessages()` so the LLM judge can evaluate multi-turn context.
+
+**Eviction strategy:** LRU by `LastSeen` timestamp. When `maxSessions` is
+exceeded, the oldest 25% of sessions are pruned in O(n log n) via a
+snapshot-and-sort pass. TTL-based eviction runs every 50 `Record` calls.
+
+## Security Notification Queue
+
+The guardrail proxy maintains a `NotificationQueue` (`internal/gateway/notifications.go`)
+that injects security enforcement alerts into LLM conversations as system
+messages, ensuring the AI informs the user about blocked or quarantined
+components.
+
+**How it works:**
+
+1. When the watcher detects and enforces a blocked skill/MCP/plugin, it pushes
+   a `SecurityNotification` to the queue with: subject type, skill name,
+   severity, finding count, actions taken, and reason.
+2. Each notification has a 2-minute TTL. The queue is capped at 50 entries.
+3. Before every LLM request, the proxy calls `FormatSystemMessage()` which
+   returns a formatted `[DEFENSECLAW SECURITY ENFORCEMENT]` block containing
+   all active (unexpired) notifications.
+4. This message is prepended to the LLM request as a system message, instructing
+   the model to proactively inform the user about the enforcement action.
+5. Notifications are not drained on read — every session sees them until expiry.
+
+## Audit Bridge
+
+The `auditBridge` (`internal/gateway/audit_bridge.go`) translates audit events
+from the SQLite store into the structured JSONL gateway log, providing a
+single correlated observability stream.
+
+- Registered as a callback on `audit.Logger` — fires on every persisted event.
+- Translates audit actions into `gatewaylog.EventLifecycle` with subsystem
+  inference (scanner, watcher, gateway, api, sinks, telemetry, enforcement).
+- Skips actions that already have dedicated structured emissions on the hot
+  path (`guardrail-verdict`, `llm-judge-response`) to avoid duplicate rows.
+- Stateless: relies on `audit.sanitizeEvent` for PII redaction — forwards
+  text verbatim without re-running detection.
+
+## Plugin Scanner Registry
+
+The `plugins/` package provides an extensible scanner plugin system:
+
+- **`Scanner` interface** (`plugins/plugin.go`): `Name()`, `Version()`,
+  `SupportedTargets()`, `Scan(ctx, target) (*ScanResult, error)`.
+- **`Registry`** (`plugins/registry.go`): discovers plugins from filesystem
+  directories by looking for `plugin.yaml` manifests in subdirectories.
+- **Custom scanners**: implement the `Scanner` interface as a Go binary.
+  See `plugins/examples/custom-scanner/main.go` for a working example.
+- **Integration**: the TUI Plugins panel shows installed plugins with
+  status and install/remove/quarantine actions.
 
 ## Dual Policy Engines
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -353,8 +353,8 @@ The Go gateway is organized into 19 internal packages:
 | `cli/` | Go CLI (Cobra commands for gateway, policy, etc.) |
 | `config/` | Full config schema with LLM resolution, hot-reload support |
 | `daemon/` | PID file management, process lifecycle, lumberjack log rotation |
-| `enforce/` | Block/allow list PolicyEngine (SQLite JSON actions) — distinct from OPA |
-| `firewall/` | Kernel-level network filtering (iptables on Linux, pfctl on macOS) |
+| `enforce/` | Block/allow list PolicyEngine (SQLite JSON actions) — distinct from OPA. SkillEnforcer/PluginEnforcer (quarantine), MCPEnforcer (endpoint blocking) |
+| `firewall/` | Kernel-level network filtering (iptables/pfctl). Compiler interface, `RulesHash` drift detection (SHA-256, 12-char hex), `Observe` subsystem (lsof + skill domain scanning) |
 | `gatewaylog/` | Structured JSONL event writer with fanout callbacks (rotating, 50MB) |
 | `guardrail/` | RulePack loading, JudgeYAML definitions, LRU-cached suppressions |
 | `inventory/` | Installed skills/MCP server tracking (AIBOM) |
@@ -362,10 +362,10 @@ The Go gateway is organized into 19 internal packages:
 | `policy/` | OPA engine — 7 Rego files (admission, guardrail, firewall, audit, skill_actions, sandbox, openshell), compiled once via `sync.Once` |
 | `redaction/` | Two-layer PII redaction: `<redacted len=N sha=8hex>`, ForSink variants always redact |
 | `sandbox/` | NVIDIA OpenShell sandbox policy enforcement |
-| `scanner/` | Scanner wrapper interfaces |
-| `telemetry/` | OpenTelemetry: resource attributes, spans (tool, approval, LLM, guardrail, agent), GenAI semconv metrics |
+| `scanner/` | 9 built-in scanner implementations: ClawShield (injection, malware, PII, secrets, vuln), CodeGuard, MCP scanner, Skill scanner, Plugin scanner. Common `Scanner` interface |
+| `telemetry/` | OpenTelemetry: `guardrail/{stage}` and `guardrail.{phase}` span hierarchy, `inspect/{tool}` spans, 20+ metric instruments (verdicts, judge latency, cache hits, sink delivery, stream lifecycle) |
 | `tui/` | 12-panel Bubbletea dashboard (Lipgloss + Bubbles) |
-| `watcher/` | File system monitoring for skill installation/removal |
+| `watcher/` | File system monitoring (fsnotify) with 500ms debounce, three-phase admission gate (pre-scan OPA → scan → post-scan OPA), periodic rescan (60-min default) with 8-type drift detection, policy file watching (2s poll) |
 
 ## Multi-Turn Injection Detection
 
@@ -444,6 +444,72 @@ The `plugins/` package provides an extensible scanner plugin system:
 - **Integration**: the TUI Plugins panel shows installed plugins with
   status and install/remove/quarantine actions.
 
+## Built-in Scanner Catalog
+
+The `internal/scanner/` package provides 9 scanner implementations sharing a
+common `Scanner` interface (`Name()`, `Version()`, `SupportedTargets()`,
+`Scan(ctx, target)`):
+
+| Scanner | File | Targets | Detection Method |
+|---------|------|---------|-----------------|
+| ClawShield Injection | `clawshield_injection.go` | skill, code | 3-tier: regex patterns, base64 + entropy analysis, Unicode analysis |
+| ClawShield Malware | `clawshield_malware.go` | skill, code | Magic bytes (ELF/PE/Mach-O/Java/WASM), reverse shells, cryptominers, C2 signatures, high-entropy blobs, zip-slip |
+| ClawShield PII | `clawshield_pii.go` | skill, code | 10 categories: credit cards (Luhn), SSN, email, phone, IPv4, DOB, passport, driver's license, bank account, medical ID |
+| ClawShield Secrets | `clawshield_secrets.go` | skill, code | 13+ providers: AWS, GCP, Azure, GitHub, GitLab, Slack, Stripe, Twilio, SendGrid, NPM, PyPI, private keys, JWT, bearer tokens |
+| ClawShield Vuln | `clawshield_vuln.go` | skill, code | SQL injection, SSRF, path traversal, command injection, XSS |
+| CodeGuard | `codeguard.go` | code | 10 built-in rules + custom YAML rules from `~/.defenseclaw/codeguard-rules/`. Hardcoded credentials, unsafe exec, network, deserialization, weak crypto |
+| MCP Scanner | `mcp.go` | mcp | Shells out to `cisco-ai-mcp-scanner` CLI. Config: `Analyzers`, `ScanPrompts`, `ScanResources`, `ScanInstructions`. Env: `MCP_SCANNER_*` |
+| Skill Scanner | `skill.go` | skill | Shells out to `cisco-ai-skill-scanner` CLI. Modes: LLM, behavioral, meta, trigger, VirusTotal, AI Defense. Env: `SKILL_SCANNER_*` |
+| Plugin Scanner | `plugin.go` | plugin | Shells out to `defenseclaw plugin scan` or direct binary. Config: `Policy`, `Profile` |
+
+Scanners are instantiated directly by constructors — there is no centralized
+registry in this package. The watcher selects the scanner by install type;
+the guardrail proxy uses the ClawShield and CodeGuard scanners for inline
+inspection.
+
+## Enforcement Engine
+
+The `internal/enforce/` package provides three enforcers for post-admission
+actions:
+
+| Enforcer | Action | Mechanism |
+|----------|--------|-----------|
+| `SkillEnforcer` | `Quarantine(path)` | Moves skill to `<quarantine>/skills/`, removes original. `Restore()` reverses. `IsQuarantined()` checks status |
+| `MCPEnforcer` | `BlockEndpoint(url)` | Adds URL to sandbox policy deny list. `AllowEndpoint()` reverses |
+| `PluginEnforcer` | `Quarantine(path)` | Same as SkillEnforcer but for `<quarantine>/plugins/` |
+
+This is separate from the OPA policy engine — it manages SQLite-backed
+block/allow lists and filesystem quarantine operations.
+
+## Firewall Subsystem
+
+The `internal/firewall/` package provides kernel-level network filtering:
+
+**Compiler interface:**
+
+| Method | Purpose |
+|--------|---------|
+| `Platform()` | Returns platform name (`pf` or `iptables`) |
+| `Compile(cfg)` | Generates firewall rules from `FirewallConfig` |
+| `ValidateArg(arg)` | Validates a rule argument |
+| `ApplyCommand(path)` | Returns the shell command to apply rules |
+| `RemoveCommand()` | Returns the shell command to remove rules |
+
+**Drift detection:** `RulesHash(rules)` returns a 12-character hex SHA-256
+fingerprint of the active ruleset (comments excluded). `GetStatus()` queries
+the running firewall and returns rule count, anchor name, active state, and
+last-checked timestamp.
+
+**Observation:** `Observe(ctx, skillDirs)` discovers active network
+connections via `lsof`, scans skill source files for URL patterns (`.py`,
+`.js`, `.go`, `.yaml`, `.json`, `.env`), and proposes a deny-by-default
+config with an allowlist. `findWouldBlock()` shows what existing connections
+would be blocked.
+
+**Config defaults:** Anchor name `com.defenseclaw`, default action `allow` or
+`deny`, only `outbound` direction supported. Pre-populated allowlist includes
+Anthropic, OpenAI, GitHub, and other known LLM provider domains.
+
 ## Dual Policy Engines
 
 DefenseClaw has two distinct policy evaluation systems — do not confuse them:
@@ -454,6 +520,32 @@ DefenseClaw has two distinct policy evaluation systems — do not confuse them:
 | **OPA Policy Engine** | `internal/policy/` | Rego-based policy evaluation for admission, guardrail verdicts, firewall rules, sandbox controls | 7 `.rego` files in `policies/rego/` |
 
 The enforcement engine runs first (static block/allow lookup), and if the item is not explicitly listed, the OPA engine evaluates the appropriate Rego policy.
+
+### OPA Admission Methods
+
+| Method | Policy path | Returns |
+|--------|------------|---------|
+| `EvaluateAdmission()` | `data.defenseclaw.admission` | verdict, reason, file_action, install_action, runtime_action |
+| `EvaluateGuardrail()` | `data.defenseclaw.guardrail` | action (allow/alert/block), severity, reason |
+| `EvaluateSkillActions()` | `data.defenseclaw.skill_actions` | runtime_action, file_action, install_action, should_block |
+| `EvaluateFirewall()` | `data.defenseclaw.firewall` | firewall rules output |
+| `EvaluateSandbox()` | `data.defenseclaw.sandbox` | sandbox policy output |
+| `EvaluateAudit()` | `data.defenseclaw.audit` | audit policy output |
+
+### OPA Fallback Profile
+
+When the OPA engine fails to load or evaluate, admission falls back to
+`EvaluateAdmissionFallback()` using a `FallbackProfile` loaded from the
+policy directory:
+
+- `AllowListBypassScan` — allow-listed items skip scanning entirely
+- `ScanOnInstall` — whether to scan on install events
+- `Actions` — maps severity (CRITICAL/HIGH/MEDIUM/LOW/INFO) to per-surface
+  actions (runtime, file, install)
+- `ScannerOverrides` — per-target-type severity overrides (MCP and plugin
+  scanners may have different thresholds than skill scanners)
+- `FirstPartyAllow` — built-in allowlist for DefenseClaw's own plugins/skills
+  with path provenance matching
 
 ## Inspection Pipeline Detail
 
@@ -490,3 +582,117 @@ Stage 4: OPA Policy (guardrail.rego)
   Observe mode: downgrades block → alert
   Output: final verdict (allow / alert / block)
 ```
+
+## Watcher Subsystem Detail
+
+The `internal/watcher/` package monitors skill, MCP, and plugin directories
+for installation events and runs a multi-phase admission gate.
+
+### Event Processing
+
+File system events from fsnotify are debounced via a pending map
+(`path → first-seen timestamp`). Default debounce: 500ms (configurable via
+`watch.debounce_ms`; values ≤ 0 fall back to 500ms). Events are classified
+by install type:
+
+| Type | Classification |
+|------|---------------|
+| `skill` | Default for paths under skill directories |
+| `plugin` | Paths under plugin directories |
+| `mcp` | Enumerated from `openclaw.json` during rescan |
+
+### Three-Phase Admission Gate
+
+```
+Phase 1: Pre-scan OPA
+  ├── Build block/allow lists from SQLite
+  ├── Load fallback profile from policy directory
+  ├── Evaluate pre-scan policy (OPA or fallback)
+  └── Verdict: blocked | rejected | allowed (skip scan) | scan (continue)
+         │
+Phase 2: Scanning (5-minute timeout)
+  ├── Select scanner by install type
+  │   ├── Skill → SkillScannerFromLLM
+  │   ├── MCP → MCPScannerFromLLM
+  │   └── Plugin → PluginScanner
+  └── Per-scanner LLM config overrides via cfg.ResolveLLM()
+         │
+Phase 3: Post-scan OPA
+  ├── Add scan findings to policy input (ScanResultInput)
+  ├── Re-evaluate with findings (OPA or fallback)
+  └── Apply enforcement: file_action, install_action, runtime_action
+```
+
+### Periodic Rescan and Drift Detection
+
+When `watch.rescan_enabled` is `true` (default), a rescan loop runs
+immediately on startup and then every `watch.rescan_interval_min` minutes
+(default: 60). Each cycle:
+
+1. Enumerates all installed targets (skill/plugin child directories + MCP
+   servers from `openclaw.json`).
+2. Takes a `TargetSnapshot` per target: content SHA-256 hash, dependency
+   file hashes (13 patterns: `requirements.txt`, `package.json`, `go.mod`,
+   etc.), config file hashes (10 patterns: `skill.yaml`, `.env`, etc.),
+   and extracted network endpoints.
+3. Compares against the stored baseline to produce drift deltas.
+
+Network endpoint extraction scans code files (`.py`, `.js`, `.ts`, `.go`,
+`.rb`, `.java`, `.rs`, `.php`, `.sh`) up to 512 KB per file, filtering
+localhost/example.com/0.0.0.0 prefixes. Directories `.git`, `node_modules`,
+`__pycache__`, `.venv`, `venv` are skipped.
+
+MCP servers have a special snapshot path: no filesystem walk — the snapshot
+is synthesized from the `openclaw.json` entry with a config hash and URL
+endpoint.
+
+### Policy File Watching
+
+`watchPolicyListsAndYAML` runs independently on a 2-second polling interval,
+monitoring:
+
+- `{datadir}/block_list.yaml` and `allow_list.yaml`
+- All `.yaml`, `.yml`, `.json`, `.rego` files in the policy directory
+
+Changes are detected by SHA-256 hash comparison. On change, the watcher
+records an `audit.ActionPolicyReload` event and bumps the version generation
+via `version.BumpGeneration()`.
+
+## Telemetry Span and Metric Hierarchy
+
+### Span Names
+
+| Span | Pattern | Attributes |
+|------|---------|-----------|
+| Stage-level guardrail | `guardrail/{stage}` | `defenseclaw.guardrail.{stage, direction, model, action, severity, reason, latency_ms}` |
+| Phase-level guardrail | `guardrail.{phase}` | `defenseclaw.guardrail.{phase, action, severity, latency_ms}` |
+| Tool inspection | `inspect/{tool}` | `defenseclaw.inspect.{tool, action, severity, latency_ms}` |
+| Sidecar startup | `defenseclaw/startup` | `defenseclaw.event = "sidecar_start"` |
+
+Guardrail phases: `regex`, `cisco_ai_defense`, `judge.pii`,
+`judge.prompt_injection`, `opa`, `finalize`.
+
+### Metric Instruments
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `defenseclaw.gateway.verdicts` | Counter | verdict.stage, verdict.action, verdict.severity, policy_id, destination_app |
+| `defenseclaw.gateway.judge.invocations` | Counter | judge.kind, judge.action, judge.severity |
+| `defenseclaw.gateway.judge.latency` | Histogram | judge.kind |
+| `defenseclaw.gateway.judge.errors` | Counter | judge.kind, judge.reason (provider \| parse) |
+| `defenseclaw.guardrail.evaluations` | Counter | guardrail.scanner, guardrail.action_taken |
+| `defenseclaw.guardrail.latency` | Histogram | guardrail.scanner |
+| `defenseclaw.guardrail.judge.latency` | Histogram | gen_ai.request.model, judge.kind |
+| `defenseclaw.guardrail.cache.hits` | Counter | scanner, verdict, ttl_bucket |
+| `defenseclaw.guardrail.cache.misses` | Counter | scanner, verdict, ttl_bucket |
+| `defenseclaw.redaction.applied` | Counter | detector, field |
+| `defenseclaw.egress.events` | Counter | branch (known \| shape \| passthrough), decision (allow \| block), source (go \| ts) |
+| `defenseclaw.audit.sink.batches.delivered` | Counter | sink, kind, status_code, retry_count |
+| `defenseclaw.audit.sink.batches.dropped` | Counter | sink, kind, status_code, retry_count |
+| `defenseclaw.audit.sink.queue.depth` | Gauge | sink.kind, sink.name |
+| `defenseclaw.audit.sink.circuit.state` | Gauge | sink.kind, sink.name (0=closed, 1=open, 2=half-open) |
+| `defenseclaw.audit.sink.delivery.latency` | Histogram | sink, kind, status_code, retry_count |
+| `defenseclaw.stream.lifecycle` | Counter | http.route, transition (open \| close), outcome |
+| `defenseclaw.stream.bytes_sent` | Counter | http.route, outcome |
+| `defenseclaw.stream.duration_ms` | Histogram | http.route, outcome |
+| `defenseclaw.schema.violations` | Counter | event_type, code |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for helping improve DefenseClaw.
 2. Build: `make build`
 3. Run tests: `make test`
 
-Ensure Go 1.25+ and Python 3.10+ are installed. For scanner integration, install
+Ensure Go 1.26+ and Python 3.10+ are installed. For scanner integration, install
 the external scanners via `defenseclaw init` or manually with
 `scripts/setup-scanners.sh`.
 

--- a/docs/GUARDRAIL.md
+++ b/docs/GUARDRAIL.md
@@ -517,6 +517,43 @@ to `NewGuardrailProxy` / `GuardrailInspector`; hot-reload via `guardrail_runtime
                             Final verdict
 ```
 
+## Built-in Scanner Catalog
+
+The `internal/scanner/` package implements 9 scanners used by the guardrail
+proxy (inline) and the watcher (admission gate). All share the `Scanner`
+interface: `Name()`, `Version()`, `SupportedTargets()`, `Scan(ctx, target)`.
+
+### ClawShield Scanners (5 built-in, no external dependencies)
+
+| Scanner | Targets | Detection |
+|---------|---------|-----------|
+| **Injection** | skill, code | 3-tier: regex patterns → base64 + entropy analysis → Unicode analysis |
+| **Malware** | skill, code | Magic bytes (ELF/PE/Mach-O/Java/WASM), shebangs, reverse shells, credential harvesters, cryptominers, C2 signatures, high-entropy blobs (threshold: 7.0), zip-slip, nested archives |
+| **PII** | skill, code | 10 categories: credit cards (Luhn validation), SSN, email, phone, IPv4, DOB, passport, driver's license, bank account, medical ID |
+| **Secrets** | skill, code | 13+ providers: AWS, GCP, Azure, GitHub, GitLab, Slack, Stripe, Twilio, SendGrid, Mailgun, NPM, PyPI. Also: private keys, JWT, basic auth, bearer tokens, passwords |
+| **Vuln** | skill, code | SQL injection, SSRF, path traversal, command injection, XSS |
+
+### CodeGuard Scanner
+
+Targets: `code`. Scans for hardcoded credentials, unsafe execution, network
+requests, deserialization, SQL injection, weak crypto, and path traversal.
+Ships 10 built-in rules; supports custom YAML rules from
+`~/.defenseclaw/codeguard-rules/` with fields: `id`, `severity`, `title`,
+`pattern`, `remediation`, `extensions`.
+
+### External Scanners (subprocess)
+
+| Scanner | Binary | Config keys | Environment variables |
+|---------|--------|-------------|----------------------|
+| **MCP** | `cisco-ai-mcp-scanner` | `Analyzers`, `ScanPrompts`, `ScanResources`, `ScanInstructions` | `MCP_SCANNER_API_KEY`, `MCP_SCANNER_ENDPOINT`, `MCP_SCANNER_LLM_*` |
+| **Skill** | `cisco-ai-skill-scanner` | `UseLLM`, `UseBehavioral`, `EnableMeta`, `UseTrigger`, `UseVirusTotal`, `UseAIDefense`, `LLMConsensus`, `Policy`, `Lenient` | `SKILL_SCANNER_LLM_*`, `VIRUSTOTAL_API_KEY`, `AI_DEFENSE_API_KEY` |
+| **Plugin** | `defenseclaw plugin scan` | `Policy`, `Profile` | *(none)* |
+
+MCP and Skill scanners have two constructors: a back-compat variant taking
+`InspectLLMConfig` and a preferred `FromLLM` variant taking unified
+`LLMConfig`. Per-scanner LLM config overrides are resolved via
+`cfg.ResolveLLM()`.
+
 ## Cisco AI Defense Integration
 
 The guardrail integrates with Cisco AI Defense's Chat Inspection API

--- a/docs/GUARDRAIL.md
+++ b/docs/GUARDRAIL.md
@@ -283,7 +283,7 @@ updates come from `guardrail_runtime.json`.
 Mode can be changed at runtime via hot-reload (no restart required):
 
 ```bash
-curl -X PATCH http://127.0.0.1:18790/v1/guardrail/config \
+curl -X PATCH http://127.0.0.1:18970/v1/guardrail/config \
   -H 'Content-Type: application/json' \
   -H 'X-DefenseClaw-Client: cli' \
   -d '{"mode": "action"}'
@@ -531,7 +531,7 @@ guardrail:
     endpoint: "https://us.api.inspect.aidefense.security.cisco.com"
     api_key_env: "CISCO_AI_DEFENSE_API_KEY"
     timeout_ms: 3000
-    enabled_rules: []  # empty = send 8 default rules (Prompt Injection, Harassment, etc.)
+    enabled_rules: []  # empty = send 12 default rules (see below)
 ```
 
 The API key is **never hardcoded** — it is read from the environment
@@ -539,17 +539,21 @@ variable specified in `api_key_env`.
 
 ### Default Enabled Rules
 
-When `enabled_rules` is empty (default), the client sends these 8 rules in
+When `enabled_rules` is empty (default), the client sends these 12 rules in
 every API request:
 
 1. Prompt Injection
-2. Harassment
-3. Hate Speech
-4. Profanity
-5. Sexual Content & Exploitation
-6. Social Division & Polarization
-7. Violence & Public Safety Threats
-8. Code Detection
+2. Jailbreak
+3. PII Detection
+4. Sensitive Data
+5. Data Leakage
+6. Harassment
+7. Hate Speech
+8. Profanity
+9. Sexual Content & Exploitation
+10. Social Division & Polarization
+11. Violence & Public Safety Threats
+12. Code Detection
 
 If the API key has pre-configured rules on the Cisco dashboard, the client
 detects the `400 Bad Request` ("already has rules configured") and
@@ -723,13 +727,13 @@ Mode and scanner_mode can be changed at runtime without restarting:
 
 ```bash
 # Switch from observe to action mode
-curl -X PATCH http://127.0.0.1:18790/v1/guardrail/config \
+curl -X PATCH http://127.0.0.1:18970/v1/guardrail/config \
   -H 'Content-Type: application/json' \
   -H 'X-DefenseClaw-Client: cli' \
   -d '{"mode": "action", "scanner_mode": "both"}'
 
 # Check current config
-curl http://127.0.0.1:18790/v1/guardrail/config
+curl http://127.0.0.1:18970/v1/guardrail/config
 ```
 
 The PATCH endpoint updates the in-memory config and writes

--- a/docs/GUARDRAIL.md
+++ b/docs/GUARDRAIL.md
@@ -236,6 +236,11 @@ X-DC-Auth:       Bearer <sidecar-token>     ← proxy authorization token
 │  ├── Streaming response inspection (mid-stream + final assembly)   │
 │  ├── OPA policy evaluation in-process (policy.Engine)              │
 │  ├── Hot-reload (proxy reads guardrail_runtime.json with TTL)      │
+│  ├── Multi-turn context tracking (ContextTracker)                  │
+│  ├── Security notification injection (NotificationQueue)           │
+│  ├── Rule pack + suppression engine (internal/guardrail/)          │
+│  ├── Provider fallback chain (Bifrost SDK)                         │
+│  ├── Rate limiting (100/s, burst 200)                              │
 │  ├── Block/allow decision per mode                                 │
 │  └── Audit + OTel via proxy telemetry helpers                      │
 │                                                                     │
@@ -580,6 +585,117 @@ in-process via `policy.Engine.EvaluateGuardrail`, which decides the final verdic
 The HTTP endpoint `POST /v1/guardrail/evaluate` exposes the same evaluation
 for external callers; the built-in proxy does not require it for normal operation.
 
+## Multi-Turn Injection Detection
+
+The guardrail proxy integrates with the event router's `ContextTracker`
+(`internal/gateway/context_tracker.go`) to detect injection attacks
+spread across multiple conversation turns.
+
+| Parameter | Default | Purpose |
+|-----------|---------|---------|
+| `maxTurns` | 10 | Messages per session (FIFO) |
+| `maxSessions` | 200 | Sessions tracked (LRU eviction) |
+| `sessionTTL` | 30 min | Idle session expiry |
+
+When a tool call or exec approval arrives, the router calls
+`HasRepeatedInjection(sessionKey, threshold=3)`. This scans all buffered
+user turns for the session against the active regex pattern set. If 3+
+turns trigger injection patterns, the request is automatically denied.
+
+The context buffer is also fed to the `GuardrailInspector` via
+`RecentMessages()` so the LLM judge can evaluate multi-turn context
+rather than isolated single prompts.
+
+## Security Notification Queue
+
+The proxy maintains a `NotificationQueue` (`internal/gateway/notifications.go`)
+that injects enforcement alerts into LLM requests as system messages.
+
+When the watcher blocks a skill/MCP/plugin, it pushes a
+`SecurityNotification` (subject type, name, severity, findings, actions,
+reason). Before each LLM call, the proxy calls `FormatSystemMessage()` and
+prepends a `[DEFENSECLAW SECURITY ENFORCEMENT]` system message instructing
+the model to inform the user about the action.
+
+- TTL: 2 minutes per notification (not drained on read — all sessions see it)
+- Queue cap: 50 entries (oldest dropped on overflow)
+- Subject types: `skill`, `plugin`, `mcp`, `tool`
+
+## Provider Fallback Chain
+
+The `ChatRequest` struct includes a `Fallbacks` field for model failover:
+
+```json
+{
+  "model": "anthropic/claude-opus-4-5",
+  "fallbacks": ["openai/gpt-4o", "bedrock/claude-3-sonnet"]
+}
+```
+
+When the primary provider returns an error, the proxy can route to fallback
+models in order. The Bifrost SDK handles provider-specific API differences
+for each fallback. Each `(provider, sha256(key), baseURL)` tuple gets a
+dedicated HTTP client with its own connection pool.
+
+Supported providers: openai, anthropic, azure, bedrock, amazon-bedrock,
+gemini, gemini-openai, openrouter, groq, mistral, ollama, vertex, cohere,
+perplexity, cerebras, fireworks, xai, huggingface, replicate, vllm.
+
+Provider inference (when no `provider/` prefix is given):
+- `ABSK` key prefix → bedrock
+- `claude` model prefix or `sk-ant-` key → anthropic
+- `gemini` model prefix or `AIza` key → gemini
+- Default: openai
+
+## Rule Pack System
+
+The `internal/guardrail/` package provides a rule pack system for
+customizing detection behavior:
+
+### RulePack Structure
+
+`LoadRulePack(dir)` loads a rule pack from a directory. Missing files are
+silently skipped; the embedded default pack is used when `dir` is empty.
+
+A rule pack contains:
+
+| Component | Purpose |
+|-----------|---------|
+| **JudgeYAML definitions** | Prompt templates for the LLM judge — `InjectionJudge`, `PIIJudge`, `ToolInjectionJudge` |
+| **Sensitive tool definitions** | Tools that require elevated scrutiny (looked up by `LookupSensitiveTool(name)`) |
+| **Finding suppressions** | Rules to suppress false positives (e.g. platform IDs vs phone numbers) |
+| **Tool suppressions** | Per-tool finding suppression (e.g. suppress PII findings for `read_file`) |
+| **Pre-judge strip rules** | Regex patterns to strip from content before sending to the LLM judge |
+
+### Suppression Engine
+
+The suppression engine (`internal/guardrail/suppress.go`) filters false
+positives from PII and tool-injection findings:
+
+- **Finding suppressions**: `FindingSuppression` matches by `finding_pattern`
+  (anchored regex) + `entity_pattern` (regex) + optional `condition`.
+- **Conditions**: `is_epoch` (Unix timestamp range 2001–2036), `is_platform_id`
+  (channel platform numeric IDs that look like phone numbers).
+- **NANP phone heuristic**: `IsPlatformID` distinguishes real North American
+  phone numbers (valid area/exchange codes) from platform IDs. Fails open
+  for real phones — a 10-digit number with valid NANP structure is surfaced
+  as PII, not suppressed.
+- **Tool suppressions**: `ToolSuppression` matches tool name by regex and
+  suppresses specific finding IDs for that tool.
+- **Pre-judge stripping**: removes noise patterns from content before the
+  LLM judge evaluates it, reducing false positives from code snippets.
+
+### LRU Regex Cache
+
+All suppression patterns are compiled through a global LRU regex cache
+(`compileRegex` in `suppress.go`):
+
+- Max entries: 1024 (far above realistic rule packs)
+- Negative caching: invalid patterns cache a `nil` result to avoid
+  re-compiling on every request
+- Thread-safe: `sync.Mutex` with double-check after reacquiring lock
+- LRU eviction: oldest entries removed when cache is full
+
 ## Component Ownership
 
 ```
@@ -615,6 +731,9 @@ for external callers; the built-in proxy does not require it for normal operatio
 │  ├── Cisco AI Defense client (HTTP, in gateway package)             │
 │  ├── OPA policy evaluation in-process (policy.Engine)              │
 │  ├── Verdict merging (mergeVerdicts, mergeWithJudge)               │
+│  ├── Multi-turn injection detection via ContextTracker             │
+│  ├── Security notification queue (inject warnings into LLM calls)  │
+│  ├── Rule pack loading + suppression engine (LRU regex cache)      │
 │  ├── Block/allow decision per mode                                 │
 │  └── Structured logging + audit / OTel via proxy telemetry         │
 └─────────────────────────────────────────────────────────────────────┘

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -86,7 +86,7 @@ This section covers building DefenseClaw from the repository.
 
 | Tool | Minimum | Check | Install |
 |------|---------|-------|---------|
-| Go | 1.25+ | `go version` | [go.dev/dl](https://go.dev/dl/) or `brew install go` |
+| Go | 1.26.2+ | `go version` | [go.dev/dl](https://go.dev/dl/) or `brew install go` |
 | Python | 3.10+ (3.12 recommended) | `python3 --version` | System package manager or [python.org](https://python.org) |
 | uv | latest | `uv --version` | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
 | Node.js / npm | 18+ | `node --version` | [nodejs.org](https://nodejs.org) or `brew install node` |
@@ -475,7 +475,7 @@ In local interactive mode, the setup can read the gateway token from
 
 ```bash
 # Local with explicit port
-defenseclaw setup gateway --host 127.0.0.1 --api-port 18790 --non-interactive
+defenseclaw setup gateway --host 127.0.0.1 --api-port 18970 --non-interactive
 
 # Remote with SSM token
 defenseclaw setup gateway --remote --ssm-param /prod/openclaw/token --ssm-region us-west-2 --non-interactive

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -31,7 +31,25 @@ Sink kinds:
 Sinks are independent: you can run zero, one, or many in parallel.
 A failing sink does **not** block a decision — audit remains local-first.
 
-### 1.2 OpenTelemetry
+### 1.2 Structured JSONL Event Log (gatewaylog)
+
+In addition to audit sinks, the gateway writes a structured JSONL event
+stream via `internal/gatewaylog/`. This is a local rotating log file
+(`gateway.jsonl`) managed by lumberjack:
+
+| Setting | Default |
+|---------|---------|
+| Max file size | 50 MB |
+| Max backups | 5 |
+| Max age | 30 days |
+| Compression | gzip |
+
+The gatewaylog writer uses fanout callbacks — each event is written to the
+JSONL file and simultaneously dispatched to registered listeners (audit
+store, sinks, webhooks). This is the primary structured event tier for
+local debugging and log forwarding pipelines that read files directly.
+
+### 1.3 OpenTelemetry
 
 `internal/telemetry` is a plain OTLP client — gRPC or HTTP, logs +
 metrics + traces, configurable via `otel:` in the config file or the

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -49,6 +49,38 @@ JSONL file and simultaneously dispatched to registered listeners (audit
 store, sinks, webhooks). This is the primary structured event tier for
 local debugging and log forwarding pipelines that read files directly.
 
+### 1.2.1 Audit Bridge
+
+The `auditBridge` (`internal/gateway/audit_bridge.go`) connects the SQLite
+audit store to the JSONL event stream, ensuring every scan verdict, watcher
+transition, and enforcement action appears in `gateway.jsonl` alongside
+guardrail verdicts — giving operators a single, correlated log instead of
+three partial ones (SQLite, OTel, JSONL).
+
+**Behavior:**
+
+- Registered as a callback on `audit.Logger` — fires on every persisted event.
+- Translates audit `Action` fields into `EventLifecycle` entries with
+  automatic subsystem inference:
+
+  | Action prefix | Subsystem |
+  |---------------|-----------|
+  | `scan` | `scanner` |
+  | `watcher-`, `watch-start`, `watch-stop` | `watcher` |
+  | `sidecar-`, `gateway-ready` | `gateway` |
+  | `api-` | `api` |
+  | `sink-`, `splunk-` | `sinks` |
+  | `otel-`, `telemetry-` | `telemetry` |
+  | `skill-`, `mcp-`, `block-`, `allow-`, `quarantine-` | `enforcement` |
+
+- **Deduplication**: skips `guardrail-verdict` and `llm-judge-response`
+  actions because those already have dedicated structured emissions
+  (`emitVerdict` / `emitJudge`) on the proxy hot path.
+- **Stateless**: relies on `audit.sanitizeEvent` for PII redaction — all
+  text is forwarded verbatim without re-running detection.
+- Details map preserves `target`, `actor`, `details`, `trace_id`,
+  `audit_id`, and `action` for pivot queries between JSONL and SQLite.
+
 ### 1.3 OpenTelemetry
 
 `internal/telemetry` is a plain OTLP client — gRPC or HTTP, logs +
@@ -321,8 +353,7 @@ defenseclaw setup webhook test    <name>   # dispatches a synthetic event
 ```
 
 All secrets are resolved from env vars (never written in `config.yaml`).
-URLs are validated against SSRF (private ranges, localhost, cloud
-metadata endpoints are rejected by default).
+URLs are validated against SSRF (see §7.5 below).
 
 ### 7.2 YAML schema
 
@@ -360,6 +391,62 @@ via single-key form fields).
 - `secret_env` / room_id presence for types that need it
 - reachability (HEAD/OPTIONS) — **never** dispatches live events; use
   `setup webhook test` for an end-to-end synthetic dispatch.
+
+### 7.5 SSRF Protection
+
+`validateWebhookURL` (`internal/gateway/webhook.go`) blocks outbound
+webhook delivery to unsafe destinations. Every webhook URL (at config
+load and at dispatch time) is checked against:
+
+| Blocked range | CIDR | Reason |
+|---------------|------|--------|
+| RFC1918 Class A | `10.0.0.0/8` | Private network |
+| RFC1918 Class B | `172.16.0.0/12` | Private network |
+| RFC1918 Class C | `192.168.0.0/16` | Private network |
+| Loopback | `127.0.0.0/8` | Localhost |
+| Link-local / cloud metadata | `169.254.0.0/16` | AWS/GCP/Azure metadata endpoint |
+| IPv6 loopback | `::1/128` | Localhost |
+| IPv6 unique local | `fc00::/7` | Private network |
+| IPv6 link-local | `fe80::/10` | Link-local |
+
+Additionally:
+- Non-HTTP(S) schemes are rejected.
+- Hostnames are DNS-resolved at config time; if any A/AAAA record points
+  to a private IP, the endpoint is rejected.
+- `localhost` is rejected unless `DEFENSECLAW_WEBHOOK_ALLOW_LOCALHOST=1`
+  (for local development only).
+
+### 7.6 HMAC Signing
+
+For `generic` webhook type, payloads are signed with HMAC-SHA256 using
+the secret from `secret_env`. The signature is sent in the
+`X-DefenseClaw-Signature` header as a hex-encoded digest:
+
+```
+X-DefenseClaw-Signature: <hex(HMAC-SHA256(payload, secret))>
+```
+
+Receivers should compute the same HMAC over the raw request body and
+compare using constant-time comparison.
+
+### 7.7 Dispatcher Internals
+
+The `WebhookDispatcher` (`internal/gateway/webhook.go`) manages delivery:
+
+| Parameter | Value | Purpose |
+|-----------|-------|---------|
+| Max retries | 3 | Per delivery attempt |
+| Retry backoff | 2s | Between retries |
+| Max concurrency | 20 | Bounded goroutine pool via semaphore |
+| Default timeout | 10s | Per HTTP request |
+| Default cooldown | 300s (5 min) | Debounce per (webhook, event-category) pair |
+| Retryable status codes | 429, 5xx | All others are terminal failures |
+
+Payload formatters per type:
+- **Slack**: Block Kit attachments with severity color coding
+- **PagerDuty**: Events API v2 format with routing key
+- **Webex**: Adaptive card with room ID targeting
+- **Generic**: Raw JSON audit event with HMAC signature
 
 ---
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -240,6 +240,80 @@ You can also drive the telemetry stack entirely through standard
 `OTEL_EXPORTER_OTLP_*` env vars — the SDK's defaults apply when the
 config is empty.
 
+### 4.1 Span naming hierarchy
+
+The telemetry runtime (`internal/telemetry/runtime.go`) creates nested spans
+for every guardrail evaluation:
+
+| Level | Span name pattern | Purpose |
+|-------|------------------|---------|
+| Stage | `guardrail/{stage}` | Top-level per-evaluation span. Stage = `regex_only`, `regex_judge`, `judge_first`, etc. |
+| Phase | `guardrail.{phase}` | Nested under stage. Phase = `regex`, `cisco_ai_defense`, `judge.pii`, `judge.prompt_injection`, `opa`, `finalize` |
+| Tool | `inspect/{tool}` | Tool call inspection span |
+| Startup | `defenseclaw/startup` | One-shot span emitted on sidecar start |
+
+Stage spans carry `defenseclaw.guardrail.{stage, direction, model, action,
+severity, reason, latency_ms}` attributes. Phase spans carry
+`defenseclaw.guardrail.{phase, action, severity, latency_ms}`.
+
+### 4.2 Metric instruments
+
+The gateway emits the following OTel metrics
+(`internal/telemetry/metrics.go`):
+
+**Verdict and judge:**
+
+| Metric | Labels |
+|--------|--------|
+| `defenseclaw.gateway.verdicts` | verdict.stage, verdict.action, verdict.severity, policy_id, destination_app |
+| `defenseclaw.gateway.judge.invocations` | judge.kind, judge.action, judge.severity |
+| `defenseclaw.gateway.judge.latency` | judge.kind |
+| `defenseclaw.gateway.judge.errors` | judge.kind, judge.reason (provider \| parse) |
+
+**Guardrail pipeline:**
+
+| Metric | Labels |
+|--------|--------|
+| `defenseclaw.guardrail.evaluations` | guardrail.scanner, guardrail.action_taken |
+| `defenseclaw.guardrail.latency` | guardrail.scanner |
+| `defenseclaw.guardrail.judge.latency` | gen_ai.request.model, judge.kind |
+| `defenseclaw.guardrail.cache.hits` | scanner, verdict, ttl_bucket |
+| `defenseclaw.guardrail.cache.misses` | scanner, verdict, ttl_bucket |
+
+**Redaction and egress:**
+
+| Metric | Labels |
+|--------|--------|
+| `defenseclaw.redaction.applied` | detector, field |
+| `defenseclaw.egress.events` | branch (known \| shape \| passthrough), decision (allow \| block), source (go \| ts) |
+
+**Sink delivery:**
+
+| Metric | Labels |
+|--------|--------|
+| `defenseclaw.audit.sink.batches.delivered` | sink, kind, status_code, retry_count |
+| `defenseclaw.audit.sink.batches.dropped` | sink, kind, status_code, retry_count |
+| `defenseclaw.audit.sink.queue.depth` | sink.kind, sink.name |
+| `defenseclaw.audit.sink.circuit.state` | sink.kind, sink.name (0=closed, 1=open, 2=half-open) |
+| `defenseclaw.audit.sink.delivery.latency` | sink, kind, status_code, retry_count |
+
+**Stream/SSE:**
+
+| Metric | Labels |
+|--------|--------|
+| `defenseclaw.stream.lifecycle` | http.route, transition (open \| close), outcome |
+| `defenseclaw.stream.bytes_sent` | http.route, outcome |
+| `defenseclaw.stream.duration_ms` | http.route, outcome |
+
+**Schema validation:** `defenseclaw.schema.violations` (event_type, code) —
+see §8.1 below.
+
+### 4.3 Verdict reason truncation
+
+OTel attribute values for `verdict.reason` are capped at 200 bytes
+(`maxReasonAttrBytes`) to avoid oversized span attributes. The full reason
+is always included in the OTLP log body.
+
 ---
 
 ## 5. Event shape (what every sink receives)
@@ -289,6 +363,27 @@ always receive the scrubbed copy.
 Masked placeholders are deterministic (they include a SHA-256 prefix of
 the literal), so SIEM/observability workflows can still correlate on
 identifier hash across events without handling the raw secret.
+
+### Redaction function variants
+
+The `internal/redaction` package provides two tiers of redaction functions:
+
+| Tier | Functions | When used |
+|------|-----------|-----------|
+| **Display** | `String()`, `Entity()`, `Reason()`, `Evidence()` | Stderr logs — respects `DEFENSECLAW_REVEAL_PII` |
+| **ForSink** | `ForSinkString()`, `ForSinkEntity()`, `ForSinkReason()`, `ForSinkEvidence()`, `ForSinkMessageContent()` | SQLite, Splunk HEC, OTLP, webhooks — **always** redacts regardless of reveal flag |
+
+ForSink functions are idempotent — already-placeholdered values are not
+re-redacted.
+
+**Placeholder format:**
+- Values ≥ 10 bytes: `<redacted len=N prefix="X" sha=8hex>`
+- Values < 5 bytes: `<redacted len=N>` (no SHA)
+- Evidence: `<redacted-evidence len=N match=[start:end] sha=8hex>`
+
+**Reason/evidence redaction** preserves safe metadata tokens (rule IDs like
+`SEC-ANTHROPIC`, status codes, severity labels) while masking literal values
+within semicolon/comma-delimited fields.
 
 To opt back into raw evidence for a single `/inspect` HTTP response, use
 the `X-DefenseClaw-Reveal-PII: 1` header documented in `docs/API.md`.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -24,7 +24,7 @@ for full details.
 
 ```bash
 curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash
-defenseclaw init --enable-guardrails
+defenseclaw init --enable-guardrail
 ```
 
 ## 2. Scan

--- a/internal/audit/sinks/sinks.go
+++ b/internal/audit/sinks/sinks.go
@@ -189,8 +189,11 @@ type Manager struct {
 	// for the same RLock and hammering the downstream sinks' Flush
 	// implementations. The single-flight flag keeps exactly one async
 	// flush in flight; subsequent immediate events within that window
-	// collapse into the already-scheduled flush.
+	// collapse into the already-scheduled flush. The goroutine re-flushes
+	// while the pending counter is non-zero, absorbing entire bursts
+	// without spawning new goroutines.
 	immediateFlushInFlight atomic.Bool
+	immediateFlushPending  atomic.Int64
 
 	// closed is set once Close() completes so Forward short-circuits
 	// even if a concurrent caller captured an older RLock-protected
@@ -315,11 +318,22 @@ func (m *Manager) Forward(ctx context.Context, e Event) map[string]error {
 		// window spawns a goroutine. High-frequency actions
 		// (guardrail-verdict fires on every block decision) would
 		// otherwise leak goroutines and thrash the downstream
-		// sinks' Flush paths.
+		// sinks' Flush paths. The goroutine holds the in-flight
+		// flag for the entire burst: it flushes, then re-checks
+		// the pending counter after a 1ms settle window to absorb
+		// follow-on events before releasing the flag.
+		m.immediateFlushPending.Add(1)
 		if m.immediateFlushInFlight.CompareAndSwap(false, true) {
 			go func() {
 				defer m.immediateFlushInFlight.Store(false)
-				_ = m.FlushAll(context.Background())
+				for {
+					m.immediateFlushPending.Store(0)
+					_ = m.FlushAll(context.Background())
+					time.Sleep(time.Millisecond)
+					if m.immediateFlushPending.Load() == 0 {
+						break
+					}
+				}
 			}()
 		}
 	}

--- a/internal/gateway/SPEC.md
+++ b/internal/gateway/SPEC.md
@@ -149,6 +149,12 @@ equal `lastSeq+1`, the client writes a warning to stderr:
 | `status` | *(none)* | Fetch gateway runtime status |
 | `tools.catalog` | *(none)* | Fetch the runtime tool catalog with provenance |
 | `exec.approval.resolve` | `{ id, approved, reason }` | Approve or reject an exec request |
+| `sessions.list` | *(none)* | Fetch active sessions |
+| `sessions.subscribe` | `{ sessionId }` | Subscribe to all events (including `session.tool`) for a session |
+| `sessions.messages.subscribe` | `{ sessionId }` | Subscribe to message-level events for a session |
+| `sessions.send` | `{ key, message }` | Send a message to a session (uses session key, not ID) |
+| `skills.status` | *(none)* | List installed skills with current enabled/disabled status |
+| `skills.bins` | *(none)* | List available skill binaries/entries |
 
 ### Event Types
 
@@ -219,6 +225,68 @@ but no gateway action is taken.
 
 Non-skill events (e.g. MCP installs) and non-blocking verdicts (clean,
 allowed, warning) are ignored by the admission handler.
+
+### Watcher Internals
+
+**Debounce:** File system events are debounced before processing. A pending
+map tracks `path → first-seen timestamp`. A ticker fires at the debounce
+interval; events older than the debounce window are processed. Default:
+500ms (configurable via `watch.debounce_ms`; values ≤ 0 fall back to 500ms).
+
+**Admission gate** runs in three phases:
+
+1. **Pre-scan OPA**: checks block/allow lists + fallback profile. Verdicts:
+   `blocked`, `rejected`, `allowed` (skip scan), `scan` (continue).
+2. **Scanning**: selects scanner by install type (skill / MCP / plugin).
+   Timeout: 5 minutes (hardcoded).
+3. **Post-scan OPA**: adds scan findings to policy input, re-evaluates.
+   Falls back to built-in severity logic when OPA is unavailable.
+
+**Verdict types:**
+
+| Verdict | Meaning |
+|---------|---------|
+| `blocked` | On the block list — rejected before scanning |
+| `allowed` | On the allow list — installed without scanning |
+| `clean` | Scan passed with no findings |
+| `rejected` | OPA policy rejected after scan |
+| `warning` | Medium/low findings — installed with warning |
+| `scan_error` | Scanner failed |
+
+**Periodic rescan and drift detection:** When `watch.rescan_enabled` is
+`true` (default), a `rescanLoop` runs every `watch.rescan_interval_min`
+minutes (default: 60). A bootstrap rescan also runs immediately on watcher
+startup. Each cycle snapshots installed targets (content hash, dependency
+hashes, config hashes, network endpoints) and compares against the baseline.
+
+Drift types:
+
+| DriftType | Trigger |
+|-----------|---------|
+| `DriftNewFinding` | New security finding detected |
+| `DriftRemovedFinding` | Finding resolved |
+| `DriftSeverityChange` | Finding severity escalated or downgraded |
+| `DriftContentChange` | Directory code changed outside tracked surfaces |
+| `DriftDependencyChange` | Dependency manifest modified (package.json, requirements.txt, go.mod, etc.) |
+| `DriftConfigMutation` | Config file modified (skill.yaml, .env, config.json, etc.) |
+| `DriftNewEndpoint` | New network endpoint detected in code |
+| `DriftRemovedEndpoint` | Network endpoint removed |
+
+**Policy file watching:** `watchPolicyListsAndYAML` polls block/allow lists
+and policy directory files every 2 seconds, tracking SHA-256 hashes. On
+change, it records an `audit.ActionPolicyReload` event and bumps the version
+generation.
+
+**Enforcement actions** per install type:
+
+| Type | Action | Method |
+|------|--------|--------|
+| Skill | Quarantine | Moves to `<quarantine>/skills/`, removes original |
+| MCP | Block endpoint | Adds to sandbox policy deny list |
+| Plugin | Quarantine | Moves to `<quarantine>/plugins/`, removes original |
+
+Enforcement requires `gateway.watcher.{skill,plugin,mcp}.take_action = true`
+(per-type config). Legacy `watch.auto_block` is a fallback.
 
 ## Guardrail
 

--- a/internal/gateway/SPEC.md
+++ b/internal/gateway/SPEC.md
@@ -62,6 +62,13 @@ cancellation.
 | `health.go` | Subsystem health tracker. Thread-safe state machine with snapshots for the API. |
 | `proxy.go` | Guardrail proxy. Builds `GuardrailProxy`, runs the OpenAI-compatible HTTP server, and supervises LLM traffic inspection. |
 | `guardrail.go` | `GuardrailInspector` — local patterns, Cisco AI Defense, LLM judge, OPA `EvaluateGuardrail`, verdict merge. |
+| `context_tracker.go` | Per-session conversation buffer for multi-turn injection detection. Bounded: 10 turns/session, 200 sessions, 30-min TTL. |
+| `notifications.go` | `NotificationQueue` — security enforcement alerts injected into LLM requests as system messages (2-min TTL, 50 cap). |
+| `audit_bridge.go` | Translates `audit.Event` records into structured `gatewaylog.Event` emissions for correlated JSONL output. |
+| `webhook.go` | `WebhookDispatcher` — Slack, PagerDuty, Webex, generic HMAC-signed webhook delivery with SSRF validation and retry. |
+| `events.go` | Structured event emission helpers (`emitVerdict`, `emitJudge`, `emitLifecycle`, `emitError`, `emitDiagnostic`). |
+| `provider.go` | `LLMProvider` interface and Bifrost SDK integration. Provider inference from model name/API key prefix. |
+| `dotenv.go` | `loadDotEnv` — loads `~/.defenseclaw/.env` for API key resolution when env vars are not set. |
 
 ## WebSocket Protocol (v3)
 
@@ -86,12 +93,15 @@ Client                              Gateway
 
 1. Client dials `ws://host:port`.
 2. Gateway sends a `connect.challenge` event containing a random `nonce`.
-3. Client builds a connect request with protocol version, role, scopes,
+3. Client starts the read loop and enables **handshake event buffering** —
+   events received before `hello-ok` are queued in memory (not dropped).
+4. Client builds a connect request with protocol version, role, scopes,
    auth token, and a device identity block containing the Ed25519 public
    key and a signature over a deterministic v3 payload (see below).
-4. Gateway verifies the signature, returns `hello-ok` with negotiated
+5. Gateway verifies the signature, returns `hello-ok` with negotiated
    features, auth confirmation, and policy (e.g. tick interval).
-5. Read loop starts dispatching events.
+6. Client disables buffering and replays all queued events in FIFO order.
+7. Read loop continues dispatching events normally.
 
 ### Device Authentication
 
@@ -123,7 +133,10 @@ Request/response pairs are correlated by UUID `id`. The client maintains a
 by matching IDs. Context cancellation cleans up pending entries.
 
 Events carry an optional monotonic `seq` number. The client tracks `lastSeq`
-and logs gaps for observability.
+and logs gaps for observability. When the received sequence number does not
+equal `lastSeq+1`, the client writes a warning to stderr:
+`[gateway] sequence gap: expected N, got M`. This signals dropped events
+(network issues, gateway restart) without failing the connection.
 
 ### RPC Methods
 
@@ -145,6 +158,9 @@ and logs gaps for observability.
 | `tool_call` | `{ tool, args, status }` | Logged to audit; flagged if tool is `shell`/`exec`/`system.run` with dangerous args |
 | `tool_result` | `{ tool, output, exit_code }` | Logged to audit |
 | `exec.approval.requested` | `{ id, systemRunPlan }` | Dangerous commands denied; safe commands optionally auto-approved |
+| `session.tool` | `{ type, tool, callId, data:{phase, name} }` | Dispatched to `handleToolCall` or `handleToolResult` based on type/phase. Supports two data shapes: top-level `{type, tool}` and nested `{data:{phase, name}}` |
+| `session.message` | Format A: `{ sessionKey, message }` / Format B: `{ stream:"tool", data:{phase, name}, runId }` | Format A (chat): logged as action only. Format B (tool stream): forwarded to `handleSessionTool()` for tool call/result processing |
+| `sessions.changed` | `{ sessions[] }` | Logged; errors trigger audit entry |
 | `tick` | *(empty)* | Keepalive, no action |
 
 ## Event Router

--- a/internal/gateway/SPEC.md
+++ b/internal/gateway/SPEC.md
@@ -335,7 +335,7 @@ gateway:
   reconnect_ms: 2000           # initial reconnect delay
   max_reconnect_ms: 30000      # max reconnect delay
   approval_timeout_s: 30       # unused in v1 (reserved)
-  api_port: 18790              # local REST API port
+  api_port: 18970              # local REST API port
   watcher:
     enabled: false
     skill:


### PR DESCRIPTION
## Updated PR Summary (3 commits, 9 files, +859 / -44 lines)

Comprehensive documentation audit: compared every Go source file against all doc files, fixed inaccuracies, and added documentation for every previously undocumented subsystem.

---

### Commit 1: `a475006` — Fix inaccuracies and add missing architecture details

- **API.md**: correct default port 18790→18970, add missing `/api/v1/network-egress` endpoint
- **GUARDRAIL.md**: Cisco AI Defense default rules 8→12, fix port references
- **ARCHITECTURE.md**: expand gateway responsibilities (9→18 entries), full 4-stage inspection pipeline, 19 internal packages, dual policy engines, Bifrost SDK, detection strategies, streaming inspection
- **OBSERVABILITY.md**: add missing gatewaylog JSONL structured event log section
- **INSTALL.md, README.md, CONTRIBUTING.md**: Go version 1.25→1.26.2
- **QUICKSTART.md**: fix `--enable-guardrails`→`--enable-guardrail`
- **internal/gateway/SPEC.md**: fix port 18790→18970

---

### Commit 2: `526d17a` — Add 14 undocumented features

- **Multi-turn injection detection** — `ContextTracker` (10-turn/200-session/30-min TTL, `HasRepeatedInjection` threshold=3)
- **Security notification queue** — `NotificationQueue` injecting `[DEFENSECLAW SECURITY ENFORCEMENT]` system messages (2-min TTL, 50 cap)
- **Audit bridge** — `auditBridge` translating SQLite events to JSONL with 7 action-prefix→subsystem mappings
- **Provider fallback chain** — `ChatRequest.Fallbacks`, Bifrost SDK routing to 20+ providers
- **Rule pack system** — JudgeYAML, sensitive tools, suppressions, LRU regex cache (1024), NANP phone heuristic
- **Plugin scanner registry** — `Scanner` interface, `Registry.Discover()` from `plugin.yaml`
- **WebSocket event buffering** — handshake buffer and replay after `hello-ok`
- **Sequence gap detection** — `lastSeq` tracking with stderr warning
- **Bifrost session events** — `session.tool`, `session.message` (Format A/B), `sessions.changed`
- **SSRF protection** — 8 blocked CIDR ranges with DNS resolution
- **HMAC signing** — `X-DefenseClaw-Signature` header
- **Webhook dispatcher internals** — retry/backoff/concurrency, 4 payload formatters
- **7 new gateway files** in SPEC.md Files table

---

### Commit 3: `b030737` — Watcher, scanner, firewall, telemetry, and RPC documentation

- **6 missing RPC methods** — `sessions.list`, `sessions.subscribe`, `sessions.messages.subscribe`, `sessions.send`, `skills.status`, `skills.bins`
- **Watcher subsystem** — 500ms debounce, three-phase admission gate, 6 verdict types, 8-type drift detection, periodic rescan (60-min), TargetSnapshot, policy file watching (2s poll), per-type enforcement
- **9 built-in scanners** — 5 ClawShield (injection/malware/PII/secrets/vuln), CodeGuard (10 rules + custom YAML), MCP/Skill/Plugin (config keys, env vars)
- **Enforcement engine** — `SkillEnforcer`/`PluginEnforcer` quarantine, `MCPEnforcer` endpoint blocking
- **Firewall subsystem** — Compiler interface (5 methods), `RulesHash` drift (SHA-256, 12-char hex), `Observe` (lsof + domain scanning)
- **OPA admission** — 6 evaluation methods, fallback profile (`AllowListBypassScan`, `ScannerOverrides`, `FirstPartyAllow`)
- **Telemetry spans** — `guardrail/{stage}`, `guardrail.{phase}` (6 phases), `inspect/{tool}`, `defenseclaw/startup`
- **20+ OTel metrics** — verdicts, judge, guardrail cache, redaction, egress, sink delivery/circuit, stream lifecycle
- **ForSink redaction** — two-tier functions (Display vs ForSink), placeholder format, idempotency

---

### Files changed

| File | Lines | What changed |
|------|-------|-------------|
| `docs/ARCHITECTURE.md` | +393 | 5 new sections (scanners, enforcement, firewall, watcher, telemetry), expanded package table, OPA fallback |
| `docs/GUARDRAIL.md` | +178 | Scanner catalog, multi-turn detection, notification queue, provider fallback, rule packs |
| `docs/OBSERVABILITY.md` | +199 | OTel span/metric reference, audit bridge, SSRF/HMAC/dispatcher, ForSink redaction |
| `internal/gateway/SPEC.md` | +89 | 6 RPC methods, 3 events, 7 files, watcher internals, handshake buffering |
| Minor fixes | — | API.md, INSTALL.md, QUICKSTART.md, README.md, CONTRIBUTING.md |
