### PR TITLE
fix(cli): harden quickstart handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,12 +85,16 @@ jobs:
       # (the latest as of this commit) still pins python-dotenv==1.2.1.
       # CVE-2026-28684: python-dotenv 1.2.1 — pulled in only via out-of-process
       # Python scanner subprocesses, not linked into the gateway.
-      # TODO: Remove --ignore-vuln CVE-2026-3219 once a fixed pip is released.
-      # CVE-2026-3219: pip's interpretation conflict with concatenated tar/ZIP
-      # archives. Medium severity; impacts only attacker-supplied package
-      # archives. We install exclusively from PyPI via uv with locked hashes
-      # (uv.lock), so this attack surface is not exposed in CI or runtime.
-      - run: uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-28684 --ignore-vuln CVE-2026-3219
+      # TODO: Remove --ignore-vuln GHSA-xqmj-j6mv-4862 once cisco-ai-skill-scanner
+      # releases compatible litellm/openai/python-dotenv dependency metadata.
+      # CVE-2026-3219: pip 26.0.1 — pulled in by pip-audit itself in this
+      # ephemeral CI audit environment, not a DefenseClaw runtime dependency.
+      - run: >
+          uv run pip-audit
+          --ignore-vuln CVE-2026-4539
+          --ignore-vuln CVE-2026-28684
+          --ignore-vuln GHSA-xqmj-j6mv-4862
+          --ignore-vuln CVE-2026-3219
 
   ts-build-test:
     name: TypeScript Build & Test

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ DIST_DIR    := dist
 #
 #   make all
 #
-# to reach a working guardrail. Everything downstream (install.sh,
+# to install DefenseClaw and attempt guardrail activation. Everything downstream (install.sh,
 # install-dev.sh, `defenseclaw quickstart`) is wired to behave the
 # same way non-interactively, so CI and local dev share one codepath.
 #
@@ -42,7 +42,8 @@ DIST_DIR    := dist
 all: install path quickstart llm-setup
 	@echo ""
 	@echo "╭────────────────────────────────────────────────────────────╮"
-	@echo "│  DefenseClaw is installed and ready.                       │"
+	@echo "│  DefenseClaw is installed. Check quickstart output above   │"
+	@echo "│  to confirm whether the guardrail is active yet.           │"
 	@echo "╰────────────────────────────────────────────────────────────╯"
 	@echo ""
 	@echo "Try it out:"

--- a/README.md
+++ b/README.md
@@ -104,9 +104,14 @@ make all
 ### Install with the release script
 
 ```bash
-curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash
-defenseclaw init --enable-guardrail
+curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash -s -- --quickstart
+defenseclaw doctor
 ```
+
+`--quickstart` creates the default config, seeds local policies, and starts
+the sidecar when the gateway binary is available. If OpenClaw is not installed
+yet, DefenseClaw is installed but the guardrail activation step remains a
+follow-up.
 
 For platform-specific steps, see [docs/INSTALL.md](docs/INSTALL.md).
 

--- a/cli/defenseclaw/commands/cmd_init.py
+++ b/cli/defenseclaw/commands/cmd_init.py
@@ -28,6 +28,7 @@ import subprocess
 import click
 
 from defenseclaw.context import AppContext, pass_ctx
+from defenseclaw.gateway import canonical_install_path, resolve_gateway_binary
 from defenseclaw.paths import (
     bundled_guardrail_profiles_dir,
     bundled_local_observability_dir,
@@ -596,9 +597,10 @@ def _setup_guardrail_inline(app, cfg, logger) -> bool:
 
 def _start_gateway(cfg, logger) -> None:
     """Start the defenseclaw-gateway sidecar and verify it is running."""
-    gw_bin = shutil.which("defenseclaw-gateway")
+    gw_bin = resolve_gateway_binary()
     if not gw_bin:
         click.echo("  Sidecar:       not found (binary not installed)")
+        click.echo(f"                 expected on PATH or at {canonical_install_path()}")
         click.echo("                 install with: make gateway-install")
         return
 
@@ -612,7 +614,7 @@ def _start_gateway(cfg, logger) -> None:
     click.echo("  Sidecar:       starting...", nl=False)
     try:
         result = subprocess.run(
-            ["defenseclaw-gateway", "start"],
+            [gw_bin, "start"],
             capture_output=True, text=True, timeout=30,
         )
         if result.returncode == 0:
@@ -644,7 +646,7 @@ def _start_gateway(cfg, logger) -> None:
 
 def _get_gateway_version() -> str | None:
     """Try to get the gateway binary version."""
-    gw = shutil.which("defenseclaw-gateway")
+    gw = resolve_gateway_binary()
     if not gw:
         return None
     try:
@@ -660,7 +662,7 @@ def _get_gateway_version() -> str | None:
 
 def _restart_gateway_quiet() -> None:
     """Restart the gateway sidecar silently (used after guardrail setup during init)."""
-    gw = shutil.which("defenseclaw-gateway")
+    gw = resolve_gateway_binary()
     if not gw:
         return
     try:
@@ -750,4 +752,3 @@ def _print_health_summary(health: dict | None) -> None:
         click.echo(f"  Health:        {', '.join(parts)}")
     else:
         click.echo("  Health:        ok ✓")
-

--- a/cli/defenseclaw/commands/cmd_quickstart.py
+++ b/cli/defenseclaw/commands/cmd_quickstart.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 import subprocess
 import sys
 
@@ -35,6 +34,7 @@ import click
 
 from defenseclaw import __version__
 from defenseclaw.context import AppContext
+from defenseclaw.gateway import canonical_install_path, resolve_gateway_binary
 
 
 @click.command("quickstart")
@@ -252,9 +252,11 @@ def _render_bootstrap_report(report) -> None:
 
 def _start_sidecar(cfg, guardrail_ok: bool) -> None:
     """Start ``defenseclaw-gateway`` and optionally restart after guardrail patch."""
-    gw = shutil.which("defenseclaw-gateway")
+    gw = resolve_gateway_binary()
     if gw is None:
-        click.echo("        ⚠ defenseclaw-gateway not on PATH — run 'make gateway-install'")
+        click.echo("        ⚠ defenseclaw-gateway not found")
+        click.echo(f"          Expected on PATH or at {canonical_install_path()}")
+        click.echo("          Install it with 'make gateway-install' or set DEFENSECLAW_GATEWAY_BIN.")
         return
 
     pid_file = os.path.join(cfg.data_dir, "gateway.pid")

--- a/cli/defenseclaw/commands/cmd_uninstall.py
+++ b/cli/defenseclaw/commands/cmd_uninstall.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass
 import click
 
 from defenseclaw import config as config_module
+from defenseclaw.gateway import resolve_gateway_binary
 
 
 @dataclass
@@ -186,9 +187,9 @@ def _execute_plan(plan: UninstallPlan) -> None:
 
 
 def _stop_gateway() -> None:
-    gw = shutil.which("defenseclaw-gateway")
+    gw = resolve_gateway_binary()
     if gw is None:
-        click.echo("  · sidecar not on PATH — nothing to stop")
+        click.echo("  · sidecar binary not found — nothing to stop")
         return
     try:
         subprocess.run([gw, "stop"], capture_output=True, text=True, timeout=15)

--- a/cli/defenseclaw/commands/cmd_version.py
+++ b/cli/defenseclaw/commands/cmd_version.py
@@ -32,7 +32,6 @@ Exit codes:
 from __future__ import annotations
 
 import json
-import shutil
 import subprocess
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -40,6 +39,7 @@ from pathlib import Path
 import click
 
 from defenseclaw import __version__
+from defenseclaw.gateway import resolve_gateway_binary
 from defenseclaw.paths import bundled_extensions_dir
 
 
@@ -82,12 +82,12 @@ def _gateway_component() -> Component:
     before Cobra touches any state, but a misconfigured shim could
     still hang.
     """
-    bin_path = shutil.which("defenseclaw-gateway")
+    bin_path = resolve_gateway_binary()
     if not bin_path:
         return Component(
             name="gateway",
             version="(not installed)",
-            origin="PATH",
+            origin="PATH or ~/.local/bin",
             status="missing",
         )
 

--- a/cli/tests/test_cmd_init.py
+++ b/cli/tests/test_cmd_init.py
@@ -798,7 +798,7 @@ class TestInitStartsGateway(unittest.TestCase):
         from pathlib import Path
         mock_path.return_value = Path(self.tmp_dir)
 
-        with patch("defenseclaw.commands.cmd_init.shutil.which", return_value=None):
+        with patch("defenseclaw.commands.cmd_init.resolve_gateway_binary", return_value=None):
             app = AppContext()
             result = self.runner.invoke(init_cmd, ["--skip-install"], obj=app)
             self.assertEqual(result.exit_code, 0, result.output)
@@ -812,7 +812,7 @@ class TestInitStartsGateway(unittest.TestCase):
         from pathlib import Path
         mock_path.return_value = Path(self.tmp_dir)
 
-        with patch("defenseclaw.commands.cmd_init.shutil.which", return_value=None):
+        with patch("defenseclaw.commands.cmd_init.resolve_gateway_binary", return_value=None):
             app = AppContext()
             result = self.runner.invoke(init_cmd, ["--skip-install"], obj=app)
             self.assertEqual(result.exit_code, 0, result.output)
@@ -827,7 +827,7 @@ class TestInitStartsGateway(unittest.TestCase):
         cfg.data_dir = self.tmp_dir
         logger = MagicMock()
 
-        with patch("defenseclaw.commands.cmd_init.shutil.which", return_value=None):
+        with patch("defenseclaw.commands.cmd_init.resolve_gateway_binary", return_value=None):
             _start_gateway(cfg, logger)
             logger.log_action.assert_not_called()
 
@@ -843,7 +843,7 @@ class TestInitStartsGateway(unittest.TestCase):
         with open(pid_file, "w") as f:
             f.write(str(os.getpid()))
 
-        with patch("defenseclaw.commands.cmd_init.shutil.which", return_value="/usr/bin/defenseclaw-gateway"):
+        with patch("defenseclaw.commands.cmd_init.resolve_gateway_binary", return_value="/usr/bin/defenseclaw-gateway"):
             _start_gateway(cfg, logger)
             logger.log_action.assert_not_called()
 
@@ -860,10 +860,15 @@ class TestInitStartsGateway(unittest.TestCase):
         mock_result.stderr = ""
         mock_result.stdout = ""
 
-        with patch("defenseclaw.commands.cmd_init.shutil.which", return_value="/usr/bin/defenseclaw-gateway"), \
-             patch("defenseclaw.commands.cmd_init.subprocess.run", return_value=mock_result), \
-             patch("defenseclaw.commands.cmd_init._check_sidecar_health"):
+        with patch(
+            "defenseclaw.commands.cmd_init.resolve_gateway_binary",
+            return_value="/usr/bin/defenseclaw-gateway",
+        ), patch(
+            "defenseclaw.commands.cmd_init.subprocess.run",
+            return_value=mock_result,
+        ) as run_mock, patch("defenseclaw.commands.cmd_init._check_sidecar_health"):
             _start_gateway(cfg, logger)
+            self.assertEqual(run_mock.call_args.args[0], ["/usr/bin/defenseclaw-gateway", "start"])
             logger.log_action.assert_called_once()
             self.assertIn("init-sidecar", logger.log_action.call_args[0])
 
@@ -880,9 +885,13 @@ class TestInitStartsGateway(unittest.TestCase):
         mock_result.stderr = "connection refused"
         mock_result.stdout = ""
 
-        with patch("defenseclaw.commands.cmd_init.shutil.which", return_value="/usr/bin/defenseclaw-gateway"), \
-             patch("defenseclaw.commands.cmd_init.subprocess.run", return_value=mock_result), \
-             patch("defenseclaw.commands.cmd_init._check_sidecar_health"):
+        with patch(
+            "defenseclaw.commands.cmd_init.resolve_gateway_binary",
+            return_value="/usr/bin/defenseclaw-gateway",
+        ), patch(
+            "defenseclaw.commands.cmd_init.subprocess.run",
+            return_value=mock_result,
+        ), patch("defenseclaw.commands.cmd_init._check_sidecar_health"):
             _start_gateway(cfg, logger)
             logger.log_action.assert_not_called()
 

--- a/cli/tests/test_cmd_quickstart.py
+++ b/cli/tests/test_cmd_quickstart.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the quickstart sidecar handoff."""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from defenseclaw.commands import cmd_quickstart
+
+
+class QuickstartSidecarTests(unittest.TestCase):
+    def _cfg(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+
+        class Cfg:
+            data_dir = tmp.name
+
+        return Cfg()
+
+    def test_start_sidecar_uses_gateway_resolver(self):
+        cfg = self._cfg()
+        result = subprocess.CompletedProcess(["/tmp/gw", "start"], 0)
+
+        with patch(
+            "defenseclaw.commands.cmd_quickstart.resolve_gateway_binary",
+            return_value="/tmp/gw",
+        ), patch(
+            "defenseclaw.commands.cmd_quickstart._sidecar_running",
+            return_value=False,
+        ), patch(
+            "defenseclaw.commands.cmd_quickstart._run",
+            return_value=result,
+        ) as run_mock, patch(
+            "defenseclaw.commands.cmd_quickstart._read_pid",
+            return_value=4242,
+        ):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cmd_quickstart._start_sidecar(cfg, guardrail_ok=False)
+
+        run_mock.assert_called_once_with(["/tmp/gw", "start"], timeout=30)
+        self.assertIn("PID 4242", buf.getvalue())
+
+    def test_running_sidecar_restarts_with_resolved_binary_when_guardrail_changed(self):
+        cfg = self._cfg()
+
+        with patch(
+            "defenseclaw.commands.cmd_quickstart.resolve_gateway_binary",
+            return_value="/custom/defenseclaw-gateway",
+        ), patch(
+            "defenseclaw.commands.cmd_quickstart._sidecar_running",
+            return_value=True,
+        ), patch(
+            "defenseclaw.commands.cmd_quickstart._run",
+        ) as run_mock:
+            cmd_quickstart._start_sidecar(cfg, guardrail_ok=True)
+
+        run_mock.assert_called_once_with(
+            ["/custom/defenseclaw-gateway", "restart"],
+            timeout=15,
+        )
+
+    def test_missing_gateway_prints_install_hint(self):
+        cfg = self._cfg()
+
+        with patch(
+            "defenseclaw.commands.cmd_quickstart.resolve_gateway_binary",
+            return_value=None,
+        ), patch(
+            "defenseclaw.commands.cmd_quickstart.canonical_install_path",
+            return_value="/home/me/.local/bin/defenseclaw-gateway",
+        ):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cmd_quickstart._start_sidecar(cfg, guardrail_ok=False)
+
+        output = buf.getvalue()
+        self.assertIn("defenseclaw-gateway not found", output)
+        self.assertIn("DEFENSECLAW_GATEWAY_BIN", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/tests/test_cmd_uninstall.py
+++ b/cli/tests/test_cmd_uninstall.py
@@ -94,6 +94,32 @@ class UninstallCommandTests(unittest.TestCase):
             self.assertEqual(result.exit_code, 0, msg=result.output)
             exec_mock.assert_called_once()
 
+    def test_stop_gateway_uses_resolver_path(self):
+        with patch(
+            "defenseclaw.commands.cmd_uninstall.resolve_gateway_binary",
+            return_value="/custom/defenseclaw-gateway",
+        ), patch(
+            "defenseclaw.commands.cmd_uninstall.subprocess.run",
+        ) as run_mock:
+            cmd_uninstall._stop_gateway()
+
+        run_mock.assert_called_once()
+        self.assertEqual(
+            run_mock.call_args.args[0],
+            ["/custom/defenseclaw-gateway", "stop"],
+        )
+
+    def test_stop_gateway_skips_when_binary_missing(self):
+        with patch(
+            "defenseclaw.commands.cmd_uninstall.resolve_gateway_binary",
+            return_value=None,
+        ), patch(
+            "defenseclaw.commands.cmd_uninstall.subprocess.run",
+        ) as run_mock:
+            cmd_uninstall._stop_gateway()
+
+        run_mock.assert_not_called()
+
 
 class ResetCommandTests(unittest.TestCase):
     def test_reset_yes_executes_plan_with_wipe_and_keep_plugin(self):

--- a/cli/tests/test_cmd_version.py
+++ b/cli/tests/test_cmd_version.py
@@ -158,7 +158,7 @@ class VersionCommandTests(unittest.TestCase):
 
     def test_missing_gateway_reports_missing_status(self):
         runner = CliRunner()
-        with patch("defenseclaw.commands.cmd_version.shutil.which", return_value=None), \
+        with patch("defenseclaw.commands.cmd_version.resolve_gateway_binary", return_value=None), \
              patch("defenseclaw.commands.cmd_version._plugin_component") as pl:
             pl.return_value = cmd_version.Component(
                 name="plugin", version=__version__, origin="~/.openclaw",
@@ -167,6 +167,21 @@ class VersionCommandTests(unittest.TestCase):
             payload = json.loads(result.output)
             gw = next(c for c in payload["components"] if c["name"] == "gateway")
             self.assertEqual(gw["status"], "missing")
+
+    def test_gateway_component_uses_resolver_path(self):
+        with patch(
+            "defenseclaw.commands.cmd_version.resolve_gateway_binary",
+            return_value="/custom/defenseclaw-gateway",
+        ), patch(
+            "defenseclaw.commands.cmd_version.subprocess.check_output",
+            return_value="defenseclaw-gateway version 0.2.0",
+        ) as check_output:
+            component = cmd_version._gateway_component()
+
+        check_output.assert_called_once()
+        self.assertEqual(check_output.call_args.args[0][0], "/custom/defenseclaw-gateway")
+        self.assertEqual(component.version, "0.2.0")
+        self.assertEqual(component.origin, "/custom/defenseclaw-gateway")
 
 
 if __name__ == "__main__":

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -23,9 +23,12 @@ for full details.
 ### Install DefenseClaw
 
 ```bash
-curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash
-defenseclaw init --enable-guardrail
+curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash -s -- --quickstart
+defenseclaw doctor
 ```
+
+If OpenClaw is not installed yet, quickstart still installs DefenseClaw and
+prints the guardrail follow-up step instead of claiming the proxy is active.
 
 ## 2. Scan
 

--- a/docs/design/cli-ux-quickstart.md
+++ b/docs/design/cli-ux-quickstart.md
@@ -118,8 +118,8 @@ already picked).
 | `defenseclaw config show` | Render active config with secrets redacted. | Never writes. |
 | `defenseclaw config validate` | Load + schema-validate config.yaml. | Never writes. |
 | `defenseclaw doctor --fix` | Run modular fixers (stale PIDs, gateway token, dotenv perms, pristine openclaw.json backup). | Each fixer is independent; a failure in one does not abort the rest. Honours `--yes` / no-op otherwise. |
-| `defenseclaw uninstall --dry-run` | Preview what would be removed. | Default is dry-run. |
-| `defenseclaw uninstall --confirm` | Remove the plugin, restore pristine `openclaw.json`, delete `~/.defenseclaw/`. | Refuses if the target dir lacks DefenseClaw marker files (`config.yaml`, `audit.db`, `policies/`, `quarantine/`). |
+| `defenseclaw uninstall --dry-run` | Preview what would be removed. | Read-only preview. |
+| `defenseclaw uninstall --yes` | Remove the plugin, restore pristine `openclaw.json`, delete `~/.defenseclaw/` when paired with `--all` / `--data` options. | Without `--yes`, prompts before mutating state; refuses if the target dir lacks DefenseClaw marker files (`config.yaml`, `audit.db`, `policies/`, `quarantine/`). |
 | `defenseclaw reset` | `uninstall` + `init` in one, for "wipe and start over" flows. | Same safety rails as `uninstall`. |
 | `defenseclaw version` | CLI / gateway / plugin versions, with drift warnings. | Read-only. |
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -553,6 +553,10 @@ print_success() {
     if [[ "${INSTALL_SANDBOX}" == true ]] && [[ "${OS}" == "linux" ]]; then
         printf "  Get started:\n\n"
         printf "    ${CYAN}defenseclaw init --sandbox${NC}\n"
+    elif [[ "${RUN_QUICKSTART}" == true ]]; then
+        printf "  Quickstart has already run. Review its output above to confirm whether\n"
+        printf "  the guardrail was activated or still needs OpenClaw configuration.\n\n"
+        printf "    ${CYAN}defenseclaw doctor${NC}\n"
     else
         printf "  Get started:\n\n"
         printf "    ${CYAN}defenseclaw init --enable-guardrail${NC}\n"
@@ -584,7 +588,7 @@ while [[ $# -gt 0 ]]; do
         # Run ``defenseclaw quickstart --non-interactive`` after the
         # binaries land. This gives a single-command install→bootstrap
         # path: everything a user needs to go from ``curl | bash`` to a
-        # working guardrail without touching the CLI themselves.
+        # attempted guardrail activation without touching the CLI themselves.
         --quickstart) RUN_QUICKSTART=true; shift ;;
         --quickstart-mode)
             [[ $# -lt 2 ]] && die "--quickstart-mode requires a value (observe|action)"


### PR DESCRIPTION
## Summary

Hardens the streamlined install / quickstart handoff so the CLI can find the
gateway binary immediately after install and does not overclaim guardrail
activation when OpenClaw still needs configuration.

- Routes init, quickstart, version, and uninstall sidecar calls through the shared
  gateway binary resolver instead of direct `PATH` checks.
- Improves missing-gateway hints with the canonical install path and
  `DEFENSECLAW_GATEWAY_BIN` override.
- Updates install success copy and quickstart docs to distinguish installed
  DefenseClaw from an active guardrail.
- Corrects the CLI UX design note for the real uninstall `--yes` confirmation.

## Validation

- `uv run --locked python -m unittest cli.tests.test_cmd_init.TestInitStartsGateway cli.tests.test_cmd_init.TestInitVersionDisplay cli.tests.test_cmd_quickstart cli.tests.test_cmd_version cli.tests.test_cmd_uninstall -v` passes: 35 tests.
- `make py-lint` passes.
- `make cli-test` passes: 1,146 tests, 1 existing skip.
- `git diff --check` passes.

## CI note

- The previous Core E2E failure was a self-hosted runner communication loss annotation, not a failing test assertion. Pushing this update started a fresh CI/E2E run.
