### PR TITLE
fix(connector): make ZeptoClaw routable end-to-end

### DIFF
--- a/internal/gateway/connector/connector_test.go
+++ b/internal/gateway/connector/connector_test.go
@@ -775,22 +775,43 @@ func TestZeptoClaw_Authenticate_Token(t *testing.T) {
 	c := NewZeptoClawConnector()
 	c.SetCredentials("my-token", "my-master")
 
+	// Loopback is trusted even when the gateway token is set, because
+	// ZeptoClaw is a native binary with no fetch interceptor to inject
+	// X-DC-Auth. Zeptoclaw forwards the real upstream provider key in
+	// Authorization (e.g. "Bearer sk-or-..."), which the connector
+	// deliberately ignores for auth purposes — it's an upstream key,
+	// not DefenseClaw's. The proxy binds loopback-only, which is the
+	// operative security boundary here.
 	r := httptest.NewRequest("POST", "/v1/chat/completions", nil)
 	r.RemoteAddr = "127.0.0.1:54321"
-	if c.Authenticate(r) {
-		t.Error("expected auth to fail without token when token configured")
+	r.Header.Set("Authorization", "Bearer sk-or-upstream-key")
+	if !c.Authenticate(r) {
+		t.Error("expected loopback auth to pass even when token configured (ZeptoClaw has no way to carry X-DC-Auth)")
 	}
 
+	// A valid X-DC-Auth still works on loopback.
 	r.Header.Set("X-DC-Auth", "my-token")
 	if !c.Authenticate(r) {
-		t.Error("expected auth to pass with correct token")
+		t.Error("expected auth to pass with correct X-DC-Auth token")
 	}
 
+	// The master key via Authorization still works (documented fallback
+	// for non-loopback sandbox/bridge deployments).
 	r2 := httptest.NewRequest("POST", "/v1/chat/completions", nil)
 	r2.RemoteAddr = "127.0.0.1:54321"
 	r2.Header.Set("Authorization", "Bearer my-master")
 	if !c.Authenticate(r2) {
 		t.Error("expected auth to pass with master key")
+	}
+
+	// Non-loopback must still be strict: without a valid X-DC-Auth or
+	// master-key bearer, reject. Protects sandbox / bridge deployments
+	// where the proxy is exposed beyond localhost.
+	r3 := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	r3.RemoteAddr = "10.0.0.5:54321"
+	r3.Header.Set("Authorization", "Bearer sk-or-upstream-key")
+	if c.Authenticate(r3) {
+		t.Error("expected non-loopback auth to fail with only an upstream bearer token")
 	}
 }
 
@@ -810,8 +831,163 @@ func TestZeptoClaw_Route(t *testing.T) {
 	if cs.RawAPIKey != "sk-openai-key" {
 		t.Errorf("RawAPIKey = %q", cs.RawAPIKey)
 	}
+	// No provider snapshot loaded → no upstream to resolve; proxy will fall
+	// back to configured-model / default-provider paths as before.
 	if cs.RawUpstream != "" {
-		t.Errorf("RawUpstream = %q, want empty", cs.RawUpstream)
+		t.Errorf("RawUpstream = %q, want empty when no provider snapshot", cs.RawUpstream)
+	}
+}
+
+func TestZeptoClaw_Route_MapsProviderPrefixToSnapshotUpstream(t *testing.T) {
+	// Zeptoclaw submits model="openrouter/deepseek/deepseek-chat" and only
+	// `openrouter` is configured in the user's zeptoclaw config. Route()
+	// must resolve the upstream to that provider's real api_base and its
+	// api_key so the proxy can forward.
+	c := NewZeptoClawConnector()
+	c.SetProviderSnapshot(map[string]ZeptoClawProviderEntry{
+		"openrouter": {APIBase: "https://openrouter.ai/api/v1", APIKey: "sk-or-test"},
+		"anthropic":  {APIBase: "https://api.anthropic.com", APIKey: "sk-ant-test"},
+	})
+	body := []byte(`{"model":"openrouter/deepseek/deepseek-chat","stream":true}`)
+	r := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	r.Header.Set("Authorization", "Bearer ignored-client-key")
+
+	cs, err := c.Route(r, body)
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if cs.RawUpstream != "https://openrouter.ai/api/v1" {
+		t.Errorf("RawUpstream = %q, want openrouter api_base", cs.RawUpstream)
+	}
+	if cs.RawAPIKey != "sk-or-test" {
+		t.Errorf("RawAPIKey = %q, want openrouter key from snapshot", cs.RawAPIKey)
+	}
+}
+
+func TestZeptoClaw_Route_FallsBackToSingleConfiguredProvider(t *testing.T) {
+	// The user's real zeptoclaw config only has `openrouter` configured, but
+	// zeptoclaw still sends model="anthropic/claude-sonnet-4.5" because
+	// anthropic is openrouter's upstream via its model router. When the
+	// model's provider prefix isn't in the snapshot, fall back to the sole
+	// configured provider so the request gets routed somewhere valid.
+	c := NewZeptoClawConnector()
+	c.SetProviderSnapshot(map[string]ZeptoClawProviderEntry{
+		"openrouter": {APIBase: "https://openrouter.ai/api/v1", APIKey: "sk-or-test"},
+	})
+	body := []byte(`{"model":"anthropic/claude-sonnet-4.5"}`)
+	r := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+
+	cs, err := c.Route(r, body)
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if cs.RawUpstream != "https://openrouter.ai/api/v1" {
+		t.Errorf("RawUpstream = %q, want fallback to openrouter", cs.RawUpstream)
+	}
+	if cs.RawAPIKey != "sk-or-test" {
+		t.Errorf("RawAPIKey = %q, want fallback openrouter key", cs.RawAPIKey)
+	}
+}
+
+func TestZeptoClaw_Route_SkipsEntriesWithNoAPIKey(t *testing.T) {
+	// ZeptoClaw's config seeds every provider slot with nulls (e.g.
+	// "anthropic": {"api_key": null}) even when the user has not configured
+	// that provider. Such entries must not count as "configured" for routing.
+	c := NewZeptoClawConnector()
+	c.SetProviderSnapshot(map[string]ZeptoClawProviderEntry{
+		"anthropic":  {APIBase: "", APIKey: ""},
+		"openrouter": {APIBase: "https://openrouter.ai/api/v1", APIKey: "sk-or-test"},
+	})
+	body := []byte(`{"model":"anthropic/claude-sonnet-4.5"}`)
+	r := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+
+	cs, err := c.Route(r, body)
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if cs.RawAPIKey != "sk-or-test" {
+		t.Errorf("RawAPIKey = %q, want fallback to openrouter (skipping keyless anthropic entry)", cs.RawAPIKey)
+	}
+}
+
+func TestZeptoClaw_Setup_IsIdempotent(t *testing.T) {
+	// On every sidecar boot, Setup runs. If it overwrites the backup each
+	// time, the second boot captures the already-patched api_base (the
+	// proxy URL) as the "original", losing the user's real upstream. The
+	// snapshot used by Route() must still point at the real upstream after
+	// a second Setup call.
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "zeptoclaw-config.json")
+	os.WriteFile(configPath, []byte(`{
+		"providers": {
+			"openrouter": {"api_key": "sk-or-pristine", "api_base": "https://openrouter.ai/api/v1"}
+		}
+	}`), 0o644)
+	ZeptoClawConfigPathOverride = configPath
+	defer func() { ZeptoClawConfigPathOverride = "" }()
+
+	opts := SetupOpts{DataDir: dir, ProxyAddr: "127.0.0.1:4000", APIAddr: "127.0.0.1:18970"}
+
+	// First Setup (simulates first boot).
+	c1 := NewZeptoClawConnector()
+	if err := c1.Setup(nil, opts); err != nil {
+		t.Fatalf("first Setup: %v", err)
+	}
+
+	// Second Setup on a fresh connector instance, same data dir. The
+	// config on disk is now patched (api_base=proxy URL). A naive Setup
+	// would read the patched config and record the proxy URL in the
+	// backup, but the snapshot must still reflect the pristine upstream.
+	c2 := NewZeptoClawConnector()
+	if err := c2.Setup(nil, opts); err != nil {
+		t.Fatalf("second Setup: %v", err)
+	}
+
+	snap := c2.ProviderSnapshot()
+	entry, ok := snap["openrouter"]
+	if !ok {
+		t.Fatal("openrouter missing from snapshot after second Setup")
+	}
+	if entry.APIBase != "https://openrouter.ai/api/v1" {
+		t.Errorf("APIBase = %q, want pristine upstream (not the proxy URL)", entry.APIBase)
+	}
+	if entry.APIKey != "sk-or-pristine" {
+		t.Errorf("APIKey = %q, want pristine key", entry.APIKey)
+	}
+}
+
+func TestZeptoClaw_Setup_LoadsProviderSnapshot(t *testing.T) {
+	// After Setup(), the connector must retain the user's provider table
+	// in memory so Route() can look up upstreams. Otherwise we'd have to
+	// re-read the (already-patched) config file on every request.
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "zeptoclaw-config.json")
+	os.WriteFile(configPath, []byte(`{
+		"providers": {
+			"openrouter": {"api_key": "sk-or-test", "api_base": null}
+		}
+	}`), 0o644)
+	ZeptoClawConfigPathOverride = configPath
+	defer func() { ZeptoClawConfigPathOverride = "" }()
+
+	c := NewZeptoClawConnector()
+	opts := SetupOpts{DataDir: dir, ProxyAddr: "127.0.0.1:4000", APIAddr: "127.0.0.1:18970"}
+	if err := c.Setup(nil, opts); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+
+	snap := c.ProviderSnapshot()
+	entry, ok := snap["openrouter"]
+	if !ok {
+		t.Fatal("openrouter not in snapshot after Setup")
+	}
+	if entry.APIKey != "sk-or-test" {
+		t.Errorf("APIKey = %q, want sk-or-test", entry.APIKey)
+	}
+	// api_base is null in the source config; the snapshot should fall back
+	// to the provider's well-known default so Route() has somewhere to send.
+	if entry.APIBase == "" {
+		t.Error("APIBase must default to the provider's well-known upstream when config has null")
 	}
 }
 
@@ -1134,11 +1310,21 @@ func TestAllConnectors_Auth_Parity(t *testing.T) {
 			t.Errorf("%s: master key should authenticate", c.Name())
 		}
 
-		// No creds should fail
+		// No creds should fail — except for native-binary connectors
+		// that have no way to carry DefenseClaw credentials and must
+		// trust loopback. Gate the assertion off .Name() rather than
+		// silently weakening the invariant across the board.
 		r3 := httptest.NewRequest("POST", "/v1/chat/completions", nil)
 		r3.RemoteAddr = "127.0.0.1:54321"
-		if c.Authenticate(r3) {
-			t.Errorf("%s: should fail without credentials when token configured", c.Name())
+		switch c.Name() {
+		case "zeptoclaw":
+			if !c.Authenticate(r3) {
+				t.Errorf("%s: loopback must be trusted (no fetch interceptor to inject X-DC-Auth)", c.Name())
+			}
+		default:
+			if c.Authenticate(r3) {
+				t.Errorf("%s: should fail without credentials when token configured", c.Name())
+			}
 		}
 	}
 }
@@ -1429,9 +1615,57 @@ func TestZeptoClaw_Setup_Surface1_PatchesConfig(t *testing.T) {
 		t.Error("agents.model was clobbered")
 	}
 
-	hooks := config["hooks"].(map[string]interface{})
-	if !strings.Contains(hooks["before_tool"].(string), "inspect-tool.sh") {
-		t.Errorf("hooks.before_tool = %q", hooks["before_tool"])
+	// Setup must NOT write config["hooks"]. ZeptoClaw's hooks schema is a
+	// notification config (before_tool/after_tool = []HookRule, each with
+	// tools/level/target_channel fields), not a script-path map. Writing a
+	// string path there makes ZeptoClaw's deserializer fail with
+	// "expected a sequence". Tool-call inspection is handled by the proxy
+	// route (/c/zeptoclaw) via the LLM stream; no config hook is needed.
+	if _, exists := config["hooks"]; exists {
+		t.Errorf("hooks should not be written by zeptoclaw Setup, got %v", config["hooks"])
+	}
+}
+
+func TestZeptoClaw_Setup_PreservesExistingHooks(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "zeptoclaw-config.json")
+	// ZeptoClaw's real hooks schema: before_tool/after_tool are arrays.
+	original := `{
+		"providers": {"anthropic": {"api_key": "sk-ant-test"}},
+		"hooks": {
+			"enabled": false,
+			"before_tool": [],
+			"after_tool": [],
+			"on_error": []
+		}
+	}`
+	os.WriteFile(configPath, []byte(original), 0o644)
+
+	ZeptoClawConfigPathOverride = configPath
+	defer func() { ZeptoClawConfigPathOverride = "" }()
+
+	c := NewZeptoClawConnector()
+	opts := SetupOpts{DataDir: dir, ProxyAddr: "127.0.0.1:4000", APIAddr: "127.0.0.1:18970"}
+	if err := c.Setup(nil, opts); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+
+	data, _ := os.ReadFile(configPath)
+	var config map[string]interface{}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("config is not valid JSON after Setup: %v", err)
+	}
+
+	hooks, ok := config["hooks"].(map[string]interface{})
+	if !ok {
+		t.Fatal("existing hooks section was removed")
+	}
+	// before_tool must remain an array to satisfy ZeptoClaw's schema.
+	if _, ok := hooks["before_tool"].([]interface{}); !ok {
+		t.Errorf("hooks.before_tool must stay a sequence, got %T", hooks["before_tool"])
+	}
+	if _, ok := hooks["after_tool"].([]interface{}); !ok {
+		t.Errorf("hooks.after_tool must stay a sequence, got %T", hooks["after_tool"])
 	}
 }
 
@@ -1493,7 +1727,12 @@ func TestZeptoClaw_Teardown_Surface1_RestoresConfig(t *testing.T) {
 	}
 }
 
-func TestZeptoClaw_Setup_WritesAllHookPaths(t *testing.T) {
+func TestZeptoClaw_Setup_ProducesValidZeptoClawConfig(t *testing.T) {
+	// Regression test: before the fix, Setup wrote config["hooks"] as
+	// {before_tool: <string path>, ...}, which ZeptoClaw rejected with
+	// "expected a sequence" because its HooksConfig defines before_tool as
+	// Vec<HookRule>. The connector must leave the hooks section alone so
+	// ZeptoClaw's own defaults remain valid.
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "zeptoclaw-config.json")
 	os.WriteFile(configPath, []byte(`{}`), 0o644)
@@ -1512,22 +1751,20 @@ func TestZeptoClaw_Setup_WritesAllHookPaths(t *testing.T) {
 
 	data, _ := os.ReadFile(configPath)
 	var config map[string]interface{}
-	json.Unmarshal(data, &config)
-
-	hooks, ok := config["hooks"].(map[string]interface{})
-	if !ok {
-		t.Fatal("hooks not set in config")
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("Setup produced invalid JSON: %v", err)
 	}
-	expectedHooks := []string{"before_tool", "before_request", "after_response", "after_tool"}
-	for _, hk := range expectedHooks {
-		v, ok := hooks[hk]
-		if !ok {
-			t.Errorf("missing hook %s in config", hk)
-			continue
-		}
-		path, _ := v.(string)
-		if !strings.Contains(path, "hooks/") {
-			t.Errorf("hook %s does not point to hooks dir: %s", hk, path)
+
+	// If hooks is written, every before_*/after_* entry must be a sequence
+	// (ZeptoClaw's HookRule array), never a string path.
+	if hooks, ok := config["hooks"].(map[string]interface{}); ok {
+		for k, v := range hooks {
+			if k == "enabled" {
+				continue
+			}
+			if _, isString := v.(string); isString {
+				t.Errorf("hooks[%q] = string %v — ZeptoClaw expects a sequence", k, v)
+			}
 		}
 	}
 }

--- a/internal/gateway/connector/zeptoclaw.go
+++ b/internal/gateway/connector/zeptoclaw.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 // ZeptoClawConnector handles LLM traffic routing and tool inspection for ZeptoClaw.
@@ -33,6 +34,35 @@ import (
 type ZeptoClawConnector struct {
 	gatewayToken string
 	masterKey    string
+
+	// snapshotMu protects providers.
+	snapshotMu sync.RWMutex
+	providers  map[string]ZeptoClawProviderEntry
+}
+
+// ZeptoClawProviderEntry is a resolved provider record captured at Setup time
+// from ~/.zeptoclaw/config.json. ZeptoClaw is a native binary with no fetch
+// interceptor, so the connector must synthesize the X-DC-Target-URL /
+// X-AI-Auth that the proxy's provider-resolution chain expects. The snapshot
+// holds the real upstream and key for every provider the user configured.
+type ZeptoClawProviderEntry struct {
+	APIBase string
+	APIKey  string
+}
+
+// zeptoClawDefaultAPIBase maps provider names to well-known upstream URLs so a
+// snapshot entry whose api_base was null in the source config can still be
+// routed. Kept intentionally small — only providers ZeptoClaw lists as
+// top-level keys in its config schema.
+var zeptoClawDefaultAPIBase = map[string]string{
+	"anthropic":  "https://api.anthropic.com",
+	"openai":     "https://api.openai.com/v1",
+	"openrouter": "https://openrouter.ai/api/v1",
+	"groq":       "https://api.groq.com/openai/v1",
+	"deepseek":   "https://api.deepseek.com",
+	"gemini":     "https://generativelanguage.googleapis.com/v1beta",
+	"xai":        "https://api.x.ai/v1",
+	"novita":     "https://api.novita.ai/v3/openai",
 }
 
 // NewZeptoClawConnector creates a new ZeptoClaw connector.
@@ -91,7 +121,13 @@ func (c *ZeptoClawConnector) Authenticate(r *http.Request) bool {
 		}
 	}
 
-	if isLoopback && c.gatewayToken == "" {
+	// Loopback clients are trusted unconditionally. ZeptoClaw is a native
+	// binary with no fetch interceptor, so it cannot inject X-DC-Auth and
+	// the Authorization bearer it sends is the *upstream* provider key,
+	// not DefenseClaw's. The proxy binds 127.0.0.1 only, so loopback is
+	// the effective boundary; out-of-loopback callers (sandbox / bridge)
+	// still have to present X-DC-Auth or the master key above.
+	if isLoopback {
 		return true
 	}
 
@@ -108,6 +144,86 @@ func (c *ZeptoClawConnector) SetCredentials(gatewayToken, masterKey string) {
 	c.masterKey = masterKey
 }
 
+// SetProviderSnapshot stores the user's resolved provider table. Called by
+// Setup() after reading ~/.zeptoclaw/config.json, and exposed so tests can
+// seed it directly.
+func (c *ZeptoClawConnector) SetProviderSnapshot(snap map[string]ZeptoClawProviderEntry) {
+	c.snapshotMu.Lock()
+	defer c.snapshotMu.Unlock()
+	c.providers = snap
+}
+
+// ProviderSnapshot returns a copy of the provider table.
+func (c *ZeptoClawConnector) ProviderSnapshot() map[string]ZeptoClawProviderEntry {
+	c.snapshotMu.RLock()
+	defer c.snapshotMu.RUnlock()
+	out := make(map[string]ZeptoClawProviderEntry, len(c.providers))
+	for k, v := range c.providers {
+		out[k] = v
+	}
+	return out
+}
+
+// resolveUpstream picks the upstream api_base and key for a given model.
+//
+//   - Model strings look like "anthropic/claude-sonnet-4.5" or plain
+//     "gpt-4o". If the prefix matches a configured provider with a usable
+//     key, use it directly.
+//   - Otherwise (no prefix, unknown prefix, or the matching entry has no
+//     key because the user never configured that slot), fall back to the
+//     single configured provider. ZeptoClaw's built-in model router takes
+//     a "provider/model" string that crosses its configured providers, so
+//     an OpenRouter-only config can still legitimately send
+//     "anthropic/claude-*" — that request must go to OpenRouter upstream.
+//
+// Returns ("", "") when no usable provider is configured; the caller then
+// leaves RawUpstream empty and the proxy's default resolver kicks in.
+func (c *ZeptoClawConnector) resolveUpstream(model string) (string, string) {
+	c.snapshotMu.RLock()
+	defer c.snapshotMu.RUnlock()
+
+	if prefix, _, ok := splitZeptoClawModel(model); ok {
+		if e, found := c.providers[prefix]; found && e.APIKey != "" {
+			return zeptoClawBaseOrDefault(prefix, e.APIBase), e.APIKey
+		}
+	}
+
+	// No direct hit; fall back to the sole configured provider. If the
+	// user has configured several, we have no preference — return the
+	// first one with a key. A richer policy (e.g. rotation order from the
+	// config) would go here.
+	for name, e := range c.providers {
+		if e.APIKey == "" {
+			continue
+		}
+		return zeptoClawBaseOrDefault(name, e.APIBase), e.APIKey
+	}
+
+	return "", ""
+}
+
+// splitZeptoClawModel splits "prefix/tail" into ("prefix", "tail", true) if
+// the prefix is a ZeptoClaw-known provider name. Returns ("", model, false)
+// otherwise so plain model strings like "gpt-4o" are treated as unprefixed.
+func splitZeptoClawModel(model string) (prefix, tail string, ok bool) {
+	i := strings.IndexByte(model, '/')
+	if i < 0 {
+		return "", model, false
+	}
+	p := model[:i]
+	if _, known := zeptoClawDefaultAPIBase[p]; !known {
+		return "", model, false
+	}
+	return p, model[i+1:], true
+}
+
+func zeptoClawBaseOrDefault(provider, configured string) string {
+	if configured != "" {
+		return configured
+	}
+	return zeptoClawDefaultAPIBase[provider]
+}
+
 func (c *ZeptoClawConnector) Route(r *http.Request, body []byte) (*ConnectorSignals, error) {
 	cs := &ConnectorSignals{
 		ConnectorName: "zeptoclaw",
@@ -116,6 +232,18 @@ func (c *ZeptoClawConnector) Route(r *http.Request, body []byte) (*ConnectorSign
 		RawModel:      ParseModelFromBody(body),
 		Stream:        ParseStreamFromBody(body),
 		ExtraHeaders:  map[string]string{},
+	}
+
+	// ZeptoClaw is a native binary with no fetch interceptor to set
+	// X-DC-Target-URL / X-AI-Auth. Resolve the real upstream from the
+	// provider snapshot captured at Setup; the request that actually
+	// hits the proxy then carries the inbound client key, so prefer the
+	// snapshot key when present and fall back to the inbound header.
+	if upstream, key := c.resolveUpstream(cs.RawModel); upstream != "" {
+		cs.RawUpstream = upstream
+		if key != "" {
+			cs.RawAPIKey = key
+		}
 	}
 
 	if !isChatPath(r.URL.Path) {
@@ -128,7 +256,6 @@ func (c *ZeptoClawConnector) Route(r *http.Request, body []byte) (*ConnectorSign
 // zeptoClawBackup stores the original config for teardown.
 type zeptoClawBackup struct {
 	OriginalProviders json.RawMessage `json:"original_providers"`
-	OriginalHooks     json.RawMessage `json:"original_hooks"`
 	OriginalSafety    json.RawMessage `json:"original_safety,omitempty"`
 }
 
@@ -163,6 +290,11 @@ func zeptoClawConfigPath() string {
 // provider, hook, and safety settings, then patches each provider's api_base to
 // route through the proxy and sets safety.allow_private_endpoints so the
 // localhost proxy URL passes SSRF validation.
+//
+// Idempotency: on re-entry (second sidecar boot), the on-disk config already
+// contains the patched api_base. Writing a fresh backup from that state would
+// lose the user's pristine upstream forever. We therefore keep the first
+// backup we wrote and source the snapshot from it when it exists.
 func (c *ZeptoClawConnector) patchZeptoClawConfig(opts SetupOpts) error {
 	configPath := zeptoClawConfigPath()
 
@@ -177,25 +309,66 @@ func (c *ZeptoClawConnector) patchZeptoClawConfig(opts SetupOpts) error {
 		}
 	}
 
-	backup := zeptoClawBackup{}
-	if providers, ok := config["providers"]; ok {
-		raw, _ := json.Marshal(providers)
-		backup.OriginalProviders = raw
-	}
-	if hooks, ok := config["hooks"]; ok {
-		raw, _ := json.Marshal(hooks)
-		backup.OriginalHooks = raw
-	}
-	if safety, ok := config["safety"]; ok {
-		raw, _ := json.Marshal(safety)
-		backup.OriginalSafety = raw
+	backupPath := filepath.Join(opts.DataDir, "zeptoclaw_backup.json")
+	_, backupStatErr := os.Stat(backupPath)
+	backupExists := backupStatErr == nil
+
+	// pristineProviders is the source of truth for the snapshot: the
+	// existing backup on re-entry, or the current config on first boot.
+	pristineProviders := map[string]interface{}{}
+	if backupExists {
+		if bk, err := c.loadBackup(opts.DataDir); err == nil && len(bk.OriginalProviders) > 0 {
+			_ = json.Unmarshal(bk.OriginalProviders, &pristineProviders)
+		}
+	} else {
+		if p, ok := config["providers"].(map[string]interface{}); ok {
+			pristineProviders = p
+		}
 	}
 
-	if err := c.saveBackup(opts.DataDir, backup); err != nil {
-		return fmt.Errorf("save zeptoclaw backup: %w", err)
+	// Only write the backup once. Subsequent boots keep the first one.
+	if !backupExists {
+		backup := zeptoClawBackup{}
+		if providers, ok := config["providers"]; ok {
+			raw, _ := json.Marshal(providers)
+			backup.OriginalProviders = raw
+		}
+		if safety, ok := config["safety"]; ok {
+			raw, _ := json.Marshal(safety)
+			backup.OriginalSafety = raw
+		}
+		if err := c.saveBackup(opts.DataDir, backup); err != nil {
+			return fmt.Errorf("save zeptoclaw backup: %w", err)
+		}
 	}
 
 	proxyURL := "http://" + opts.ProxyAddr + "/c/zeptoclaw"
+
+	// Build the in-memory snapshot from the pristine providers (either the
+	// first-boot config or the saved backup). Route() uses this to map
+	// model prefixes to real upstream URLs and keys.
+	snapshot := map[string]ZeptoClawProviderEntry{}
+	for name, val := range pristineProviders {
+		prov, ok := val.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		switch name {
+		case "retry", "fallback", "rotation", "plugins":
+			continue
+		}
+		entry := ZeptoClawProviderEntry{
+			APIBase: zeptoClawDefaultAPIBase[name],
+		}
+		if base, ok := prov["api_base"].(string); ok && base != "" {
+			entry.APIBase = base
+		}
+		if key, ok := prov["api_key"].(string); ok {
+			entry.APIKey = key
+		}
+		snapshot[name] = entry
+	}
+	c.SetProviderSnapshot(snapshot)
 
 	// Patch each configured provider's api_base to route through proxy.
 	providers, _ := config["providers"].(map[string]interface{})
@@ -207,7 +380,6 @@ func (c *ZeptoClawConnector) patchZeptoClawConfig(opts SetupOpts) error {
 		if !ok {
 			continue
 		}
-		// Skip non-provider keys (retry, fallback, rotation, plugins).
 		switch name {
 		case "retry", "fallback", "rotation", "plugins":
 			continue
@@ -224,13 +396,10 @@ func (c *ZeptoClawConnector) patchZeptoClawConfig(opts SetupOpts) error {
 	safety["allow_private_endpoints"] = true
 	config["safety"] = safety
 
-	hookDir := filepath.Join(opts.DataDir, "hooks")
-	config["hooks"] = map[string]interface{}{
-		"before_tool":    filepath.Join(hookDir, "inspect-tool.sh"),
-		"before_request": filepath.Join(hookDir, "inspect-request.sh"),
-		"after_response": filepath.Join(hookDir, "inspect-response.sh"),
-		"after_tool":     filepath.Join(hookDir, "inspect-tool-response.sh"),
-	}
+	// ZeptoClaw's hooks config is a notification system (before_tool/after_tool
+	// are []HookRule with channel/level fields), not a script-runner. Tool-call
+	// inspection is performed at the proxy (/c/zeptoclaw) by observing tool_use
+	// messages in the LLM stream, so no config["hooks"] mutation is needed.
 
 	out, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
@@ -267,14 +436,6 @@ func (c *ZeptoClawConnector) restoreZeptoClawConfig(opts SetupOpts) {
 		config["providers"] = orig
 	} else {
 		delete(config, "providers")
-	}
-
-	if len(backup.OriginalHooks) > 0 && string(backup.OriginalHooks) != "null" {
-		var orig interface{}
-		json.Unmarshal(backup.OriginalHooks, &orig)
-		config["hooks"] = orig
-	} else {
-		delete(config, "hooks")
 	}
 
 	if len(backup.OriginalSafety) > 0 && string(backup.OriginalSafety) != "null" {

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -1344,6 +1344,22 @@ func (p *GuardrailProxy) resolveConfiguredProvider(req *ChatRequest) LLMProvider
 	return provider
 }
 
+// hydrateConnectorSignals lets a connector whose agent has no fetch
+// interceptor (native binaries like ZeptoClaw) supply the upstream URL and
+// provider key that X-DC-Target-URL / X-AI-Auth would otherwise carry.
+// Returning ("", "") means "no opinion" — the caller must leave req.TargetURL
+// / req.TargetAPIKey alone so fetch-interceptor paths still work.
+func hydrateConnectorSignals(conn connector.Connector, r *http.Request, body []byte) (string, string) {
+	if conn == nil {
+		return "", ""
+	}
+	cs, err := conn.Route(r, body)
+	if err != nil || cs == nil {
+		return "", ""
+	}
+	return cs.RawUpstream, cs.RawAPIKey
+}
+
 // resolveProviderFromHeaders selects the upstream LLMProvider for the given
 // request. The fetch interceptor sets X-DC-Target-URL on every outbound LLM
 // call; we infer the provider from that URL and use X-AI-Auth as the API key.
@@ -1439,6 +1455,19 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 	// the provider SDK originally used (Authorization, x-api-key, api-key).
 	if aiAuth := r.Header.Get("X-AI-Auth"); strings.HasPrefix(aiAuth, "Bearer ") {
 		req.TargetAPIKey = strings.TrimPrefix(aiAuth, "Bearer ")
+	}
+
+	// Native-binary connectors (zeptoclaw) have no fetch interceptor, so the
+	// request arrives without X-DC-Target-URL / X-AI-Auth. Ask the active
+	// connector to resolve them from its captured config snapshot. Existing
+	// header values win — fetch-interceptor paths are unchanged.
+	if connUpstream, connKey := hydrateConnectorSignals(p.connector, r, body); connUpstream != "" {
+		if req.TargetURL == "" {
+			req.TargetURL = connUpstream
+		}
+		if req.TargetAPIKey == "" {
+			req.TargetAPIKey = connKey
+		}
 	}
 
 	fmt.Fprintf(os.Stderr, "[guardrail] parsed: model=%q stream=%v messages=%d\n",

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
 	"golang.org/x/time/rate"
 )
 
@@ -3107,6 +3108,48 @@ func TestResponsesTextFromContent_PrettyPrintedArray(t *testing.T) {
 	got := responsesTextFromContent(content)
 	if got != "hello" {
 		t.Errorf("responsesTextFromContent with leading whitespace = %q, want %q", got, "hello")
+	}
+}
+
+// hydrateConnectorSignals must let a native-binary connector (zeptoclaw —
+// no fetch interceptor) supply the upstream URL and provider key that the
+// rest of the proxy's header-based resolver needs. Returning empty strings
+// means "leave req.TargetURL / req.TargetAPIKey alone", so fetch-interceptor
+// paths are not affected.
+func TestHydrateConnectorSignals_UsesConnectorRoute(t *testing.T) {
+	conn := connector.NewZeptoClawConnector()
+	conn.SetProviderSnapshot(map[string]connector.ZeptoClawProviderEntry{
+		"openrouter": {APIBase: "https://openrouter.ai/api/v1", APIKey: "sk-or-test"},
+	})
+
+	r := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewReader([]byte(`{"model":"anthropic/claude-sonnet-4.5"}`)))
+	body := []byte(`{"model":"anthropic/claude-sonnet-4.5"}`)
+
+	upstream, key := hydrateConnectorSignals(conn, r, body)
+	if upstream != "https://openrouter.ai/api/v1" {
+		t.Errorf("upstream = %q, want openrouter fallback", upstream)
+	}
+	if key != "sk-or-test" {
+		t.Errorf("key = %q, want openrouter snapshot key", key)
+	}
+}
+
+func TestHydrateConnectorSignals_NilConnectorIsNoOp(t *testing.T) {
+	r := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewReader([]byte(`{}`)))
+	upstream, key := hydrateConnectorSignals(nil, r, []byte(`{}`))
+	if upstream != "" || key != "" {
+		t.Errorf("nil connector should return empty, got upstream=%q key=%q", upstream, key)
+	}
+}
+
+func TestHydrateConnectorSignals_NoSnapshotIsNoOp(t *testing.T) {
+	// OpenClaw uses fetch-interceptor headers; its Route() does not emit
+	// RawUpstream. Hydration must leave req.TargetURL alone in that case.
+	conn := connector.NewOpenClawConnector()
+	r := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewReader([]byte(`{"model":"gpt-4"}`)))
+	upstream, key := hydrateConnectorSignals(conn, r, []byte(`{"model":"gpt-4"}`))
+	if upstream != "" || key != "" {
+		t.Errorf("fetch-interceptor connector should emit no upstream, got upstream=%q key=%q", upstream, key)
 	}
 }
 


### PR DESCRIPTION
ZeptoClaw is a native binary with no fetch interceptor, so the proxy never received X-DC-Target-URL / X-AI-Auth and returned an "invalid API key" for every request. Four coupled fixes needed for end-to-end flow:

- hooks schema: stop writing config["hooks"]; ZeptoClaw's HooksConfig defines before_tool/after_tool as []HookRule (a notification system), not string paths. Writing a string caused "expected a sequence" on every zeptoclaw start.
- provider snapshot: capture pristine api_base + api_key at first Setup so Route() can synthesize upstream/key at request time. Fall back to the provider's well-known default when api_base is null, and to the sole configured provider when the requested model's prefix has no matching snapshot entry (zeptoclaw routes cross-provider models through whatever provider is configured).
- idempotent Setup: only write zeptoclaw_backup.json once. Subsequent boots read the patched config, so overwriting the backup replaces the pristine upstream with the proxy URL — losing the real target permanently. Load the snapshot from the existing backup when it is present.
- loopback auth: trust loopback unconditionally for ZeptoClaw. It cannot inject X-DC-Auth and its Authorization bearer is an upstream provider key, not DefenseClaw's. The proxy binds 127.0.0.1 only, so loopback is the effective boundary; non-loopback deployments still require X-DC-Auth or the master key.

Wire a small hydrateConnectorSignals helper into handleChatCompletion so the connector's Route() result populates req.TargetURL / req.TargetAPIKey only when X-DC-Target-URL is absent — fetch-interceptor paths are unchanged.