### PR TITLE
Align OTel conventions for agent and tool telemetry

### DIFF
--- a/bundles/local_observability_stack/grafana/dashboards/defenseclaw-traffic.json
+++ b/bundles/local_observability_stack/grafana/dashboards/defenseclaw-traffic.json
@@ -112,14 +112,14 @@
       "title": "Tool invocations by tool + provider",
       "datasource": {"type": "prometheus", "uid": "defenseclaw-prometheus"},
       "gridPos": {"x": 0, "y": 40, "w": 12, "h": 8},
-      "targets": [{"expr": "sum by (tool_name, tool_provider) (rate(defenseclaw_tool_calls_total[$__rate_interval]))", "legendFormat": "{{tool_name}} · {{tool_provider}}", "refId": "A"}]
+      "targets": [{"expr": "sum by (gen_ai_tool_name, tool_provider) (rate(defenseclaw_tool_calls_total[$__rate_interval]))", "legendFormat": "{{gen_ai_tool_name}} · {{tool_provider}}", "refId": "A"}]
     },
     {
       "type": "timeseries",
       "title": "Tool duration p95",
       "datasource": {"type": "prometheus", "uid": "defenseclaw-prometheus"},
       "gridPos": {"x": 12, "y": 40, "w": 12, "h": 8},
-      "targets": [{"expr": "histogram_quantile(0.95, sum by (le, tool_name) (rate(defenseclaw_tool_duration_milliseconds_bucket[$__rate_interval])))", "legendFormat": "{{tool_name}} p95", "refId": "A"}],
+      "targets": [{"expr": "histogram_quantile(0.95, sum by (le, gen_ai_tool_name) (rate(defenseclaw_tool_duration_milliseconds_bucket[$__rate_interval])))", "legendFormat": "{{gen_ai_tool_name}} p95", "refId": "A"}],
       "fieldConfig": {"defaults": {"unit": "ms"}}
     },
     {
@@ -128,8 +128,8 @@
       "datasource": {"type": "prometheus", "uid": "defenseclaw-prometheus"},
       "gridPos": {"x": 0, "y": 48, "w": 12, "h": 8},
       "targets": [
-        {"expr": "sum by (tool_name) (rate(defenseclaw_tool_errors_total[$__rate_interval]))", "legendFormat": "err · {{tool_name}}", "refId": "A"},
-        {"expr": "sum by (tool_name) (rate(defenseclaw_tool_calls_total{dangerous=\"true\"}[$__rate_interval]))", "legendFormat": "dangerous · {{tool_name}}", "refId": "B"}
+        {"expr": "sum by (gen_ai_tool_name) (rate(defenseclaw_tool_errors_total[$__rate_interval]))", "legendFormat": "err · {{gen_ai_tool_name}}", "refId": "A"},
+        {"expr": "sum by (gen_ai_tool_name) (rate(defenseclaw_tool_calls_total{dangerous=\"true\"}[$__rate_interval]))", "legendFormat": "dangerous · {{gen_ai_tool_name}}", "refId": "B"}
       ]
     },
     {

--- a/docs/OTEL-IMPLEMENTATION-STATUS.md
+++ b/docs/OTEL-IMPLEMENTATION-STATUS.md
@@ -167,11 +167,14 @@ empty rather than being faked. **v7** adds `agent_id` and
 4. OTel spans — `StartToolSpan` and `StartApprovalSpan` take a
    `telemetry.ToolSpanContext` that carries the correlation fields
    onto span attributes (`gen_ai.tool.call.id`,
-   `defenseclaw.tool.id`, `gen_ai.conversation.id`,
-   `defenseclaw.session.id`, `defenseclaw.run.id`,
+   `gen_ai.conversation.id`, `defenseclaw.run.id`,
    `defenseclaw.destination.app`, `defenseclaw.policy.id`,
    `gen_ai.agent.name`, `gen_ai.agent.id`,
    `defenseclaw.agent.instance_id`).
+
+`gen_ai.agent.id` is intended to carry the logical stable `agent_id` when
+known. The session-scoped instance identity remains in
+`defenseclaw.agent.instance_id`.
 
 **Best-effort correlation for approvals:** exec approval events don't
 carry `run_id`/`session_id` on the wire. `EventRouter.activeAgentCorrelation()`

--- a/docs/OTEL.md
+++ b/docs/OTEL.md
@@ -274,7 +274,6 @@ tool/{tool_name}                            ✓ from tool_call → tool_result W
 | `gen_ai.operation.name` | string | `execute_tool` |
 | `gen_ai.tool.name` | string | tool name |
 | `gen_ai.tool.type` | string | `function` |
-| `defenseclaw.tool.name` | string | tool name (e.g. `shell`) |
 | `defenseclaw.tool.status` | string | status from `tool_call` payload |
 | `defenseclaw.tool.args_length` | int | byte length of arguments |
 | `defenseclaw.tool.exit_code` | int | from `tool_result` |
@@ -424,6 +423,7 @@ trace.
 | Attribute | Type | Description |
 |---|---|---|
 | `gen_ai.operation.name` | string | `invoke_agent` |
+| `gen_ai.agent.id` | string | logical stable agent id, when known |
 | `gen_ai.agent.name` | string | agent name (e.g. `openclaw`) |
 | `gen_ai.conversation.id` | string | conversation/session identifier |
 | `gen_ai.provider.name` | string | provider (if set) |
@@ -538,9 +538,9 @@ All metrics use the `defenseclaw.*` namespace.
 
 | Metric | Type | Unit | Attributes |
 |---|---|---|---|
-| `defenseclaw.tool.calls` | Counter | `{call}` | `tool.name`, `tool.provider`, `dangerous` |
-| `defenseclaw.tool.duration` | Histogram | `ms` | `tool.name`, `tool.provider` |
-| `defenseclaw.tool.errors` | Counter | `{error}` | `tool.name`, `exit_code` |
+| `defenseclaw.tool.calls` | Counter | `{call}` | `gen_ai.tool.name`, `tool.provider`, `dangerous` |
+| `defenseclaw.tool.duration` | Histogram | `ms` | `gen_ai.tool.name`, `tool.provider` |
+| `defenseclaw.tool.errors` | Counter | `{error}` | `gen_ai.tool.name`, `exit_code` |
 | `defenseclaw.approval.count` | Counter | `{request}` | `result`, `auto`, `dangerous` |
 
 ### GenAI Semconv Metrics
@@ -786,7 +786,7 @@ Observer jumps to the trace that triggered it.
 
 ### Cardinality Guidance
 
-- `defenseclaw.tool.name` — bounded by OpenClaw's tool catalog (typically < 50)
+- `gen_ai.tool.name` — bounded by OpenClaw's tool catalog (typically < 50)
 - `gen_ai.request.model` — bounded by provider model count (< 20)
 - `defenseclaw.scan.target` — can grow; use `target_type` for dashboard grouping
 - `defenseclaw.alert.type` — fixed enum (6 values)

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -1462,7 +1462,7 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 		agentName := p.agentNameForRequest(r.Header.Get("X-Agent-Name"))
 		agentCtx, agentSpan = p.otel.StartAgentSpan(
 			context.Background(),
-			conversationID, agentName, "",
+			conversationID, agentName, p.agentIDForRequest(), "",
 		)
 	}
 	if agentCtx == nil {
@@ -3544,6 +3544,7 @@ func (p *GuardrailProxy) emitToolCallSpans(reqCtx, llmCtx context.Context, raw j
 				DestinationApp: "builtin",
 				PolicyID:       p.defaultPolicyID,
 				AgentName:      agentName,
+				AgentID:        p.agentIDForRequest(),
 			},
 		)
 

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -1012,6 +1012,7 @@ func (r *EventRouter) handleAgentStreamEvent(se struct {
 					context.Background(),
 					conversationID,           // conversation.id
 					r.agentNameForStream(""), // agent name (claw mode fallback)
+					SharedAgentRegistry().AgentID(),
 					"",                       // provider filled on session.message
 				)
 				r.spanMu.Lock()
@@ -1199,6 +1200,7 @@ func (r *EventRouter) handleToolCall(evt EventFrame) {
 				DestinationApp: toolDestinationApp("builtin", ""),
 				PolicyID:       r.defaultPolicyID,
 				AgentName:      agentName,
+				AgentID:        SharedAgentRegistry().AgentID(),
 			},
 		)
 		r.spanMu.Lock()
@@ -1401,6 +1403,7 @@ func (r *EventRouter) handleApprovalRequest(evt EventFrame) {
 				DestinationApp: toolDestinationApp("builtin", ""),
 				PolicyID:       r.defaultPolicyID,
 				AgentName:      r.agentNameForStream(""),
+				AgentID:        SharedAgentRegistry().AgentID(),
 			},
 		)
 	}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -809,7 +809,7 @@ func (p *Provider) RecordToolCall(ctx context.Context, tool, provider string, da
 		return
 	}
 	p.metrics.toolCalls.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("tool.name", tool),
+		attribute.String("gen_ai.tool.name", tool),
 		attribute.String("tool.provider", provider),
 		attribute.Bool("dangerous", dangerous),
 	))
@@ -821,7 +821,7 @@ func (p *Provider) RecordToolDuration(ctx context.Context, tool, provider string
 		return
 	}
 	p.metrics.toolDuration.Record(ctx, durationMs, metric.WithAttributes(
-		attribute.String("tool.name", tool),
+		attribute.String("gen_ai.tool.name", tool),
 		attribute.String("tool.provider", provider),
 	))
 }
@@ -832,7 +832,7 @@ func (p *Provider) RecordToolError(ctx context.Context, tool string, exitCode in
 		return
 	}
 	p.metrics.toolErrors.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("tool.name", tool),
+		attribute.String("gen_ai.tool.name", tool),
 		attribute.Int("exit_code", exitCode),
 	))
 }

--- a/internal/telemetry/runtime.go
+++ b/internal/telemetry/runtime.go
@@ -164,16 +164,14 @@ func (p *Provider) EmitInspectSpan(ctx context.Context, tool, action, severity s
 // StartAgentSpan starts a new OTel span for an agent invocation session.
 // Follows OTel GenAI semconv: span name = "invoke_agent {agentName}".
 //
-// conversationID is mapped to both gen_ai.conversation.id (for OTel
-// semconv consumers) and defenseclaw.session.id (for our internal
-// SIEM dashboards which key on session_id across traces + logs).
-// agentInstanceID is additionally resolved from the process-level
-// default when the caller leaves it blank; this keeps every span
-// carrying a stable identifier even on the non-session code paths
-// (guardrail proxy bootstrap, diagnostic invocations).
+// conversationID is mapped to gen_ai.conversation.id.
+// agentID is the logical stable agent identity and maps to
+// gen_ai.agent.id when present. agentInstanceID is separately
+// resolved from the process-level default and emitted only via the
+// DefenseClaw-specific defenseclaw.agent.instance_id attribute.
 func (p *Provider) StartAgentSpan(
 	ctx context.Context,
-	conversationID, agentName, provider string,
+	conversationID, agentName, agentID, provider string,
 ) (context.Context, trace.Span) {
 	if !p.TracesEnabled() {
 		return ctx, nil
@@ -193,16 +191,15 @@ func (p *Provider) StartAgentSpan(
 		attribute.String("gen_ai.operation.name", "invoke_agent"),
 		attribute.String("gen_ai.agent.name", agentName),
 		attribute.String("gen_ai.conversation.id", conversationID),
-		attribute.String("defenseclaw.session.id", conversationID),
 	)
 	if provider != "" {
 		span.SetAttributes(attribute.String("gen_ai.provider.name", provider))
 	}
+	if agentID != "" {
+		span.SetAttributes(attribute.String("gen_ai.agent.id", agentID))
+	}
 	if inst := p.AgentInstanceID(); inst != "" {
-		span.SetAttributes(
-			attribute.String("gen_ai.agent.id", inst),
-			attribute.String("defenseclaw.agent.instance_id", inst),
-		)
+		span.SetAttributes(attribute.String("defenseclaw.agent.instance_id", inst))
 	}
 
 	return ctx, span
@@ -239,8 +236,7 @@ type ToolSpanContext struct {
 	ToolID string
 
 	// SessionID is the conversation / sessionKey this tool call
-	// belongs to. Mirrored to both the OTel conversation id and
-	// the DefenseClaw session id attributes.
+	// belongs to. It maps to gen_ai.conversation.id.
 	SessionID string
 
 	// RunID is the sidecar-process run identifier (DEFENSECLAW_RUN_ID).
@@ -261,6 +257,11 @@ type ToolSpanContext struct {
 	// Derived from the incoming stream event (if present) or from
 	// cfg.Claw.Mode.
 	AgentName string
+
+	// AgentID is the logical agent identity when known. Unlike
+	// AgentInstanceID, this is stable across restarts and sessions.
+	// It maps to gen_ai.agent.id when present.
+	AgentID string
 }
 
 // StartToolSpan starts a new OTel span for a tool_call event.
@@ -307,16 +308,10 @@ func (p *Provider) StartToolSpan(
 	}
 
 	if cor.ToolID != "" {
-		span.SetAttributes(
-			attribute.String("gen_ai.tool.call.id", cor.ToolID),
-			attribute.String("defenseclaw.tool.id", cor.ToolID),
-		)
+		span.SetAttributes(attribute.String("gen_ai.tool.call.id", cor.ToolID))
 	}
 	if cor.SessionID != "" {
-		span.SetAttributes(
-			attribute.String("gen_ai.conversation.id", cor.SessionID),
-			attribute.String("defenseclaw.session.id", cor.SessionID),
-		)
+		span.SetAttributes(attribute.String("gen_ai.conversation.id", cor.SessionID))
 	}
 	if cor.RunID != "" {
 		span.SetAttributes(attribute.String("defenseclaw.run.id", cor.RunID))
@@ -330,11 +325,11 @@ func (p *Provider) StartToolSpan(
 	if cor.AgentName != "" {
 		span.SetAttributes(attribute.String("gen_ai.agent.name", cor.AgentName))
 	}
+	if cor.AgentID != "" {
+		span.SetAttributes(attribute.String("gen_ai.agent.id", cor.AgentID))
+	}
 	if inst := p.AgentInstanceID(); inst != "" {
-		span.SetAttributes(
-			attribute.String("gen_ai.agent.id", inst),
-			attribute.String("defenseclaw.agent.instance_id", inst),
-		)
+		span.SetAttributes(attribute.String("defenseclaw.agent.instance_id", inst))
 	}
 
 	if flaggedPattern != "" {
@@ -406,16 +401,10 @@ func (p *Provider) StartApprovalSpan(
 		attribute.Int("defenseclaw.approval.argc", len(argv)),
 	)
 	if cor.ToolID != "" {
-		span.SetAttributes(
-			attribute.String("gen_ai.tool.call.id", cor.ToolID),
-			attribute.String("defenseclaw.tool.id", cor.ToolID),
-		)
+		span.SetAttributes(attribute.String("gen_ai.tool.call.id", cor.ToolID))
 	}
 	if cor.SessionID != "" {
-		span.SetAttributes(
-			attribute.String("gen_ai.conversation.id", cor.SessionID),
-			attribute.String("defenseclaw.session.id", cor.SessionID),
-		)
+		span.SetAttributes(attribute.String("gen_ai.conversation.id", cor.SessionID))
 	}
 	if cor.RunID != "" {
 		span.SetAttributes(attribute.String("defenseclaw.run.id", cor.RunID))
@@ -429,11 +418,11 @@ func (p *Provider) StartApprovalSpan(
 	if cor.AgentName != "" {
 		span.SetAttributes(attribute.String("gen_ai.agent.name", cor.AgentName))
 	}
+	if cor.AgentID != "" {
+		span.SetAttributes(attribute.String("gen_ai.agent.id", cor.AgentID))
+	}
 	if inst := p.AgentInstanceID(); inst != "" {
-		span.SetAttributes(
-			attribute.String("gen_ai.agent.id", inst),
-			attribute.String("defenseclaw.agent.instance_id", inst),
-		)
+		span.SetAttributes(attribute.String("defenseclaw.agent.instance_id", inst))
 	}
 
 	return ctx, span

--- a/schemas/otel/metrics.schema.json
+++ b/schemas/otel/metrics.schema.json
@@ -75,7 +75,7 @@
           "unit": "{call}",
           "description": "Total tool calls observed.",
           "attributes": {
-            "tool.name": { "type": "string", "description": "Tool name." },
+            "gen_ai.tool.name": { "type": "string", "description": "Tool name." },
             "tool.provider": { "type": "string", "enum": ["skill", "builtin", "mcp"] },
             "dangerous": { "type": "boolean" }
           }
@@ -86,7 +86,7 @@
           "unit": "ms",
           "description": "Tool call duration distribution.",
           "attributes": {
-            "tool.name": { "type": "string" },
+            "gen_ai.tool.name": { "type": "string" },
             "tool.provider": { "type": "string", "enum": ["skill", "builtin", "mcp"] }
           }
         },
@@ -96,7 +96,7 @@
           "unit": "{error}",
           "description": "Tool calls that returned non-zero exit codes.",
           "attributes": {
-            "tool.name": { "type": "string" },
+            "gen_ai.tool.name": { "type": "string" },
             "exit_code": { "type": "integer" }
           }
         },

--- a/schemas/otel/runtime-tool-span.schema.json
+++ b/schemas/otel/runtime-tool-span.schema.json
@@ -90,7 +90,7 @@
       "type": "object",
       "description": "Semantic definition of all span attributes.",
       "properties": {
-        "defenseclaw.tool.name": {
+        "gen_ai.tool.name": {
           "type": "string",
           "description": "Tool name as reported by the agent framework.",
           "examples": ["shell", "read_file", "web_search"]


### PR DESCRIPTION
This PR aligns a subset of DefenseClaw OTel fields with the conventions we want to use across sources.

Main changes:
- `gen_ai.agent.id` now carries the logical stable `agent_id` instead of the session-scoped `agent_instance_id`
- `defenseclaw.agent.instance_id` remains the session-scoped DefenseClaw identity
- `gen_ai.conversation.id` is now the canonical session field, so the redundant `defenseclaw.session.id` mirror was removed
- `gen_ai.tool.call.id` is now the canonical tool-call id field, so the redundant `defenseclaw.tool.id` mirror was removed
- tool metrics now use `gen_ai.tool.name` instead of `tool.name`

Implementation detail:
- the telemetry/runtime layer was updated so spans use logical `agent_id` for `gen_ai.agent.id`
- the gateway call sites were updated to actually pass logical `agent_id` into the proxy/runtime span helpers, so the new semantics reach real emitted spans
- OTel docs and schema files were updated to match the new emitted field shape

Why:
- this brings DefenseClaw closer to the Otel/GenAI conventions
- it keeps logical agent identity, session identity, and process identity distinct
- it reduces DefenseClaw-specific mirrors where a standard convention field already exists