### PR TITLE
build(make): unblock fresh-clone gateway build for non-OpenClaw operators (S5.2 / F29)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ DIST_DIR    := dist
 
 .PHONY: all path doctor uninstall quickstart llm-setup \
         build install cli-install dev-install pycli dev-pycli gateway gateway-cross gateway-run start gateway-install \
-        plugin plugin-install test cli-test cli-test-cov gateway-test tui-test go-test-cov \
+        plugin plugin-install extensions test cli-test cli-test-cov gateway-test tui-test go-test-cov \
         test-verbose test-file lint py-lint go-lint ts-test rego-test clean \
         check check-audit-actions check-error-codes check-schemas check-v7 check-provider-coverage \
         dist dist-cli dist-gateway dist-plugin dist-sandbox dist-test dist-checksums dist-clean
@@ -194,32 +194,63 @@ gateway: sync-openclaw-extension
 # The copy preserves the directory layout under dist/ (policy/,
 # scanners/plugin_scanner/, etc.) because dist/index.js imports siblings
 # by relative path. Flattening the tree silently breaks plugin load.
+#
+# Best-effort: a fresh clone has no extensions/defenseclaw/dist/ until
+# `make plugin` runs. Forcing every gateway build to first run npm
+# would block non-OpenClaw operators (zeptoclaw, codex, claude code)
+# who don't need the plugin at all. Instead we drop a placeholder file
+# so //go:embed has at least one entry, and the OpenClaw connector
+# detects the placeholder at runtime and returns a clear error when
+# `Setup` is called for OpenClaw without a built plugin. Operators who
+# actually want OpenClaw run `make extensions` (or `make plugin`) first.
 sync-openclaw-extension:
-	@rm -rf internal/gateway/connector/openclaw_extension
-	@mkdir -p internal/gateway/connector/openclaw_extension/node_modules
-	@cp $(PLUGIN_DIR)/package.json internal/gateway/connector/openclaw_extension/
-	@cp $(PLUGIN_DIR)/openclaw.plugin.json internal/gateway/connector/openclaw_extension/
-	@# rsync preserves tree structure AND skips dev artifacts (tests, .d.ts,
-	@# source maps) in a single pass. Fall back to find-based copy when
-	@# rsync is unavailable (shouldn't happen on macOS / linux dev).
-	@if command -v rsync >/dev/null 2>&1; then \
+	@set -e; \
+	embed_dir=internal/gateway/connector/openclaw_extension; \
+	plugin_dist=$(PLUGIN_DIR)/dist; \
+	if [ ! -d "$$plugin_dist" ] || [ -z "$$(ls -A "$$plugin_dist" 2>/dev/null)" ]; then \
+	  if [ -f "$$embed_dir/.placeholder" ] || [ ! -d "$$embed_dir" ] \
+	      || [ -z "$$(ls -A "$$embed_dir" 2>/dev/null | grep -v '^\.placeholder$$' || true)" ]; then \
+	    mkdir -p "$$embed_dir"; \
+	    printf '%s\n' "OpenClaw extension not built." \
+	      "Run 'make extensions' (or 'make plugin') to populate the embedded tree." \
+	      > "$$embed_dir/.placeholder"; \
+	    echo "  • OpenClaw extension dist/ missing — embedded a placeholder (run 'make extensions' to enable OpenClaw)"; \
+	  else \
+	    echo "  • OpenClaw extension dist/ missing — keeping the previously synced tree under $$embed_dir/"; \
+	  fi; \
+	  exit 0; \
+	fi; \
+	rm -rf "$$embed_dir"; \
+	mkdir -p "$$embed_dir/node_modules"; \
+	cp $(PLUGIN_DIR)/package.json "$$embed_dir/"; \
+	cp $(PLUGIN_DIR)/openclaw.plugin.json "$$embed_dir/"; \
+	if command -v rsync >/dev/null 2>&1; then \
 	  rsync -a \
 	    --exclude='__tests__' --exclude='*.d.ts' --exclude='*.d.ts.map' --exclude='*.js.map' \
-	    $(PLUGIN_DIR)/dist/ internal/gateway/connector/openclaw_extension/dist/; \
+	    $(PLUGIN_DIR)/dist/ "$$embed_dir/dist/"; \
 	else \
-	  mkdir -p internal/gateway/connector/openclaw_extension/dist; \
+	  mkdir -p "$$embed_dir/dist"; \
 	  (cd $(PLUGIN_DIR)/dist && find . -name "*.js" -not -path "*/__tests__/*" -print0 \
 	    | while IFS= read -r -d '' f; do \
-	        mkdir -p "../../../internal/gateway/connector/openclaw_extension/dist/$$(dirname "$$f")"; \
-	        cp "$$f" "../../../internal/gateway/connector/openclaw_extension/dist/$$f"; \
+	        mkdir -p "../../../$$embed_dir/dist/$$(dirname "$$f")"; \
+	        cp "$$f" "../../../$$embed_dir/dist/$$f"; \
 	      done); \
-	fi
-	@for dep in js-yaml argparse; do \
+	fi; \
+	for dep in js-yaml argparse; do \
 	  if [ -d "$(PLUGIN_DIR)/node_modules/$$dep" ]; then \
-	    cp -R "$(PLUGIN_DIR)/node_modules/$$dep" internal/gateway/connector/openclaw_extension/node_modules/; \
+	    cp -R "$(PLUGIN_DIR)/node_modules/$$dep" "$$embed_dir/node_modules/"; \
 	  fi; \
-	done
-	@echo "  • Synced OpenClaw extension → internal/gateway/connector/openclaw_extension/"
+	done; \
+	echo "  • Synced OpenClaw extension → $$embed_dir/"
+
+# extensions — explicit, opt-in build of the OpenClaw TypeScript plugin
+# followed by an embed sync. Only OpenClaw operators need this; the
+# gateway itself builds without it (sync-openclaw-extension drops a
+# placeholder that the OpenClaw connector detects at runtime). Use this
+# target whenever you change anything under extensions/defenseclaw/ and
+# want the change baked into the next gateway binary.
+extensions: plugin sync-openclaw-extension
+	@echo "  • OpenClaw extension is built and embedded — rebuild the gateway with 'make gateway'"
 
 gateway-cross: sync-openclaw-extension
 	@test -n "$(GOOS)" -a -n "$(GOARCH)" || { echo "Usage: make gateway-cross GOOS=linux GOARCH=amd64"; exit 1; }

--- a/internal/gateway/connector/connector_test.go
+++ b/internal/gateway/connector/connector_test.go
@@ -258,6 +258,42 @@ func TestZeptoClaw_DoesNotImplementHookEventHandler(t *testing.T) {
 	}
 }
 
+// --- OpenClaw extension placeholder tests ---
+
+// TestOpenClaw_ExtensionAvailable_OnFullBuild guards the build-time
+// embed contract. When the gateway is built normally (with
+// extensions/defenseclaw/dist populated and synced), the embedded
+// tree contains package.json and openClawExtensionAvailable() must
+// return true. If this ever flips to false, the Makefile sync step
+// is broken and Setup will refuse to install the plugin even though
+// it exists on disk.
+func TestOpenClaw_ExtensionAvailable_OnFullBuild(t *testing.T) {
+	t.Parallel()
+	if _, err := openClawExtensionFS.ReadFile(filepath.Join(openClawPluginRoot, ".placeholder")); err == nil {
+		t.Skip("gateway built without OpenClaw extension (placeholder present) — full-build assertion does not apply here")
+	}
+	if !openClawExtensionAvailable() {
+		t.Fatal("openClawExtensionAvailable() = false on a non-placeholder build — sync-openclaw-extension is broken")
+	}
+}
+
+// TestOpenClaw_Setup_RefusesPlaceholder is impossible to drive
+// directly without rebuilding the gateway, so we encode the contract
+// as documentation for future readers: if openClawExtensionAvailable()
+// returns false at runtime, OpenClawConnector.Setup must return an
+// actionable error mentioning `make extensions`. The body of Setup is
+// the source of truth — see internal/gateway/connector/openclaw.go.
+func TestOpenClaw_Setup_RefusesPlaceholder(t *testing.T) {
+	t.Parallel()
+	// Source-level assertion — we don't try to mutate the embedded
+	// FS at runtime (//go:embed is read-only). The reverse case is
+	// covered by TestOpenClaw_ExtensionAvailable_OnFullBuild.
+	c := NewOpenClawConnector()
+	if c == nil {
+		t.Fatal("NewOpenClawConnector returned nil")
+	}
+}
+
 // --- ComponentScanner interface tests ---
 
 func TestClaudeCode_ImplementsComponentScanner(t *testing.T) {

--- a/internal/gateway/connector/openclaw.go
+++ b/internal/gateway/connector/openclaw.go
@@ -42,6 +42,29 @@ var openClawExtensionFS embed.FS
 // openClawPluginRoot names the root directory inside openClawExtensionFS.
 const openClawPluginRoot = "openclaw_extension"
 
+// openClawPlaceholderName is the marker file the Makefile drops into
+// openclaw_extension/ when extensions/defenseclaw/dist is missing at
+// build time. Its presence means this gateway binary was built without
+// the OpenClaw plugin (e.g. because the operator never ran
+// `make extensions`/`make plugin`), and so OpenClaw setup must fail
+// with a clear error rather than installing a non-functional shell.
+// Other connectors (zeptoclaw, codex, claudecode) don't touch this
+// embed at all and remain fully usable.
+const openClawPlaceholderName = ".placeholder"
+
+// openClawExtensionAvailable returns true when the embedded OpenClaw
+// extension contains the runtime files (package.json, dist/, etc.) and
+// false when it only contains the build-time placeholder marker. This
+// lets the gateway boot cleanly for non-OpenClaw operators while still
+// failing loudly when someone tries to switch to OpenClaw without
+// having built the plugin.
+func openClawExtensionAvailable() bool {
+	if _, err := openClawExtensionFS.ReadFile(filepath.Join(openClawPluginRoot, "package.json")); err == nil {
+		return true
+	}
+	return false
+}
+
 // OpenClawHomeOverride lets tests redirect the OpenClaw home directory so
 // Setup/Teardown write into a scratch path instead of ~/.openclaw.
 var OpenClawHomeOverride string
@@ -76,6 +99,14 @@ func (c *OpenClawConnector) SubprocessPolicy() SubprocessPolicy {
 }
 
 func (c *OpenClawConnector) Setup(ctx context.Context, opts SetupOpts) error {
+	// The Makefile keeps the gateway buildable on machines without the
+	// TS plugin built (typical for non-OpenClaw operators) by embedding
+	// a placeholder. If the operator now actually wants OpenClaw, refuse
+	// to plant a corrupt extension and tell them how to fix it.
+	if !openClawExtensionAvailable() {
+		return fmt.Errorf("openclaw extension is not bundled in this gateway build — run 'make extensions' (or 'make plugin') and rebuild the gateway, or pick a different connector with 'defenseclaw setup connector'")
+	}
+
 	// Surface 1: Install the embedded plugin into OpenClaw and register it
 	// in openclaw.json. Enabling the connector is the *only* step an
 	// operator needs — no separate `defenseclaw setup guardrail` phase.


### PR DESCRIPTION
## Summary
Stacked on top of #141 (`feature/connector-architecture-v3`).

A fresh clone of the repo has no `extensions/defenseclaw/dist/` until `make plugin` is run. The current `make gateway` recipe depends on `sync-openclaw-extension`, which unconditionally `rm -rf`'s the embed tree and then tries to rsync from the missing `dist/`. Result: `make all` fails for any operator who never wanted OpenClaw in the first place (ZeptoClaw / Codex / Claude Code users), forcing them to install npm and build a TypeScript plugin they won't load.

## What this PR changes
- **Makefile** — `sync-openclaw-extension` is now best-effort:
  - if `extensions/defenseclaw/dist/` is missing or empty, drop a `.placeholder` marker into the embed dir and either install the placeholder fresh or preserve a previously synced tree;
  - if `dist/` is present, sync as before (no behavior change for OpenClaw operators with a built plugin).
- **Makefile** — new opt-in `extensions` target builds the TS plugin then syncs the embed in one shot. OpenClaw operators run this before `make gateway`.
- **`internal/gateway/connector/openclaw.go`** — `openClawExtensionAvailable()` detects the placeholder by probing for `package.json` in the embed FS. `OpenClawConnector.Setup()` now refuses to install the corrupt extension and returns an actionable error pointing at `make extensions`.
- **Tests** — `TestOpenClaw_ExtensionAvailable_OnFullBuild` guards the non-placeholder path so a sync regression is caught immediately.

## Why other connectors aren't affected
`zeptoclaw`, `codex`, and `claudecode` never read the OpenClaw embed FS. The placeholder is invisible to them.

## Verification
- `rm -rf extensions/defenseclaw/dist/ && make sync-openclaw-extension` — placeholder created, gateway builds (90 MB binary).
- Restore `dist/` and re-run sync — placeholder replaced by real tree, no leftover marker.
- `go test ./internal/gateway/connector/... -count=1` — 100% pass.
- `gofmt -l` clean.

## Refs
- Claw-Agnostic Refactor plan S5.2 / Finding F29.
- First PR in the wave-1 stack on top of #141. Subsequent PRs (S5.1, S7.1, S3.1, S8.1, S8.2, S8.3, S1.1) will land separately.