### PR TITLE
schemas(otel): align defenseclaw.claw.mode enum with the four canonical connectors (S3.1 / F9)

### DIFF
--- a/cli/tests/test_check_schemas.py
+++ b/cli/tests/test_check_schemas.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for ``scripts/check_schemas.py``.
+
+Pins two contracts that downstream consumers (Splunk APM, OTLP collector
+validation, audit drill-down) silently depend on:
+
+1. The recursive walk of ``schemas/`` covers ``schemas/otel/*.json``.
+   A previous version of the script only globbed the top-level
+   directory, so OTel schemas drifted unchecked for months.
+
+2. ``schemas/otel/resource.schema.json``'s ``defenseclaw.claw.mode``
+   enum stays aligned with the four canonical connector names emitted
+   by ``Connector.Name()`` in ``internal/gateway/connector``.
+   Adding a connector and forgetting the schema means dashboards
+   silently start dropping records — and the fresh-install empty
+   placeholder ("") masks the failure on bench tests.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "check_schemas.py"
+SCHEMA_DIR = ROOT / "schemas"
+RESOURCE_SCHEMA = SCHEMA_DIR / "otel" / "resource.schema.json"
+
+
+class TestCheckSchemasResourceEnum(unittest.TestCase):
+    def test_resource_schema_has_canonical_claw_mode_enum(self) -> None:
+        """The released schema must list every connector emit() can produce."""
+        doc = json.loads(RESOURCE_SCHEMA.read_text(encoding="utf-8"))
+        enum = set(
+            doc["properties"]["defenseclaw.claw.mode"].get("enum", [])
+        )
+        # Connector names from internal/gateway/connector/{openclaw,
+        # zeptoclaw, claudecode, codex}.go plus the empty placeholder
+        # for fresh installs that haven't picked a connector yet.
+        self.assertEqual(
+            enum,
+            {"openclaw", "zeptoclaw", "claudecode", "codex", ""},
+            "drift in defenseclaw.claw.mode enum — update Connector.Name() "
+            "and the schema together; downstream APM dashboards pivot on this",
+        )
+
+    def test_legacy_modes_dropped(self) -> None:
+        """Legacy placeholders that were never emitted must stay dropped.
+
+        ``nemoclaw`` and ``opencode`` shipped in the schema before any
+        connector by those names existed; allowing them back masks
+        typos in operator config files and fails closed at the
+        downstream consumer (silent drop of the resource record).
+        """
+        doc = json.loads(RESOURCE_SCHEMA.read_text(encoding="utf-8"))
+        enum = set(
+            doc["properties"]["defenseclaw.claw.mode"].get("enum", [])
+        )
+        self.assertNotIn("nemoclaw", enum)
+        self.assertNotIn("opencode", enum)
+
+
+class TestCheckSchemasDriftDetection(unittest.TestCase):
+    """Run check_schemas.py against a tampered schema tree and assert it fails."""
+
+    def _run_against(self, schema_dir: Path) -> subprocess.CompletedProcess[str]:
+        # Re-execute the script with a swapped SCHEMA_DIR by injecting a
+        # tiny shim that monkey-patches the path before main() runs.
+        # This isolates the test from the real schemas/ tree.
+        shim = (
+            "import importlib.util, sys, pathlib\n"
+            f"spec = importlib.util.spec_from_file_location('check_schemas', r'{SCRIPT}')\n"
+            "mod = importlib.util.module_from_spec(spec)\n"
+            "spec.loader.exec_module(mod)\n"
+            f"mod.SCHEMA_DIR = pathlib.Path(r'{schema_dir}')\n"
+            "sys.exit(mod.main())\n"
+        )
+        return subprocess.run(
+            [sys.executable, "-c", shim],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+    def test_dropping_a_connector_mode_is_caught(self) -> None:
+        # Mirror schemas/ into a tempdir, drop "claudecode" from the
+        # resource schema's claw.mode enum, and assert the script
+        # exits non-zero with a drift-shaped error message.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            # rsync-equivalent copy preserving structure
+            for src in SCHEMA_DIR.rglob("*.json"):
+                rel = src.relative_to(SCHEMA_DIR)
+                dst = tmp_path / rel
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+
+            tampered = tmp_path / "otel" / "resource.schema.json"
+            doc = json.loads(tampered.read_text(encoding="utf-8"))
+            mode = doc["properties"]["defenseclaw.claw.mode"]
+            mode["enum"] = [m for m in mode["enum"] if m != "claudecode"]
+            tampered.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+            res = self._run_against(tmp_path)
+            self.assertNotEqual(
+                res.returncode, 0,
+                f"check_schemas should have flagged the dropped connector\n"
+                f"stdout={res.stdout}\nstderr={res.stderr}",
+            )
+            self.assertIn("defenseclaw.claw.mode", res.stderr)
+            self.assertIn("claudecode", res.stderr)
+
+    def test_adding_a_bogus_connector_mode_is_caught(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            for src in SCHEMA_DIR.rglob("*.json"):
+                rel = src.relative_to(SCHEMA_DIR)
+                dst = tmp_path / rel
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+
+            tampered = tmp_path / "otel" / "resource.schema.json"
+            doc = json.loads(tampered.read_text(encoding="utf-8"))
+            doc["properties"]["defenseclaw.claw.mode"]["enum"].append("nemoclaw")
+            tampered.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+            res = self._run_against(tmp_path)
+            self.assertNotEqual(
+                res.returncode, 0,
+                f"check_schemas should have flagged the legacy connector name\n"
+                f"stdout={res.stdout}\nstderr={res.stderr}",
+            )
+            self.assertIn("nemoclaw", res.stderr)
+
+
+class TestCheckSchemasCoversOtelTree(unittest.TestCase):
+    def test_otel_subdir_is_walked(self) -> None:
+        # Sanity: corrupt schemas/otel/metrics.schema.json and ensure
+        # the script catches it (proves rglob covers the subtree).
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            for src in SCHEMA_DIR.rglob("*.json"):
+                rel = src.relative_to(SCHEMA_DIR)
+                dst = tmp_path / rel
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+
+            corrupt = tmp_path / "otel" / "metrics.schema.json"
+            corrupt.write_text("{not json", encoding="utf-8")
+
+            shim = (
+                "import importlib.util, sys, pathlib\n"
+                f"spec = importlib.util.spec_from_file_location('check_schemas', r'{SCRIPT}')\n"
+                "mod = importlib.util.module_from_spec(spec)\n"
+                "spec.loader.exec_module(mod)\n"
+                f"mod.SCHEMA_DIR = pathlib.Path(r'{tmp_path}')\n"
+                "sys.exit(mod.main())\n"
+            )
+            res = subprocess.run(
+                [sys.executable, "-c", shim],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            self.assertNotEqual(res.returncode, 0)
+            self.assertIn("otel/metrics.schema.json", res.stderr)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -656,7 +656,7 @@ DefenseClaw supports multiple agent frameworks. Set the active mode in `~/.defen
 
 ```yaml
 claw:
-  mode: openclaw        # openclaw (default) | nemoclaw | opencode | claudecode (future)
+  mode: openclaw        # openclaw | zeptoclaw | claudecode | codex
   home_dir: ""          # auto-detected; override to use a custom path
 ```
 

--- a/docs/OTEL.md
+++ b/docs/OTEL.md
@@ -54,8 +54,8 @@ Set once at sidecar startup. Attached to every exported log, span, and metric.
 | `host.name` | string | `dgx-spark-01` | `os.Hostname()` |
 | `host.arch` | string | `arm64` | `runtime.GOARCH` |
 | `os.type` | string | `darwin` | `runtime.GOOS` |
-| `defenseclaw.claw.mode` | string | `openclaw` | `config.Claw.Mode` |
-| `defenseclaw.claw.home_dir` | string | `/home/user/.openclaw` | resolved at startup |
+| `defenseclaw.claw.mode` | string | `openclaw` \| `zeptoclaw` \| `claudecode` \| `codex` (or `""` before `defenseclaw setup connector`) | `config.Claw.Mode` |
+| `defenseclaw.claw.home_dir` | string | `/home/user/.openclaw`, `/home/user/.zeptoclaw`, `/home/user/.claude`, `/home/user/.codex` | resolved at startup |
 | `defenseclaw.device.id` | string | `a1b2c3...` | Ed25519 fingerprint |
 | `defenseclaw.gateway.host` | string | `127.0.0.1` | `config.Gateway.Host` |
 | `defenseclaw.gateway.port` | int | `18789` | `config.Gateway.Port` |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,7 +59,15 @@ type ClawMode string
 
 const (
 	ClawOpenClaw ClawMode = "openclaw"
-	// Future: ClawNemoClaw
+	// Other recognised connector names (kept in sync with
+	// Connector.Name() in internal/gateway/connector and with the
+	// `defenseclaw.claw.mode` enum in schemas/otel/resource.schema.json):
+	// "zeptoclaw", "claudecode", "codex". Constants for those modes
+	// are intentionally not introduced here yet — Config.Claw.Mode
+	// is currently only used by SkillDirsForMode (OpenClaw-specific)
+	// and by the OTel resource attribute. Promoting them to typed
+	// constants is part of S1.2 and tracked in the claw-agnostic
+	// refactor plan.
 )
 
 type ClawConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1232,7 +1232,11 @@ func TestConfig_Save_BumpsProvenance(t *testing.T) {
 	// Mutate the config and save again; both hash and generation
 	// must advance. Pinning this guards the "ContentHash stable
 	// across identical saves, fresh per mutation" invariant.
-	cfg.Claw.Mode = "nemoclaw"
+	// "zeptoclaw" matches Connector.Name() for the ZeptoClaw
+	// connector — kept aligned with the canonical four-connector
+	// enum in schemas/otel/resource.schema.json so this test
+	// doesn't bake a stale legacy mode string.
+	cfg.Claw.Mode = "zeptoclaw"
 	if err := cfg.Save(); err != nil {
 		t.Fatalf("Save() (2) returned error: %v", err)
 	}

--- a/schemas/otel/resource.schema.json
+++ b/schemas/otel/resource.schema.json
@@ -52,13 +52,18 @@
     },
     "defenseclaw.claw.mode": {
       "type": "string",
-      "enum": ["openclaw", "nemoclaw", "opencode", "codex"],
-      "description": "Active agent framework mode."
+      "enum": ["openclaw", "zeptoclaw", "claudecode", "codex", ""],
+      "description": "Active agent framework connector. Matches Connector.Name() in internal/gateway/connector. Empty string is permitted while no connector has been picked yet (fresh install before `defenseclaw setup connector`). Legacy values 'nemoclaw' and 'opencode' were never emitted by a released gateway; they were placeholders that became 'zeptoclaw' and 'claudecode' respectively, and have been dropped from the enum."
     },
     "defenseclaw.claw.home_dir": {
       "type": "string",
-      "description": "Resolved home directory of the active claw framework.",
-      "examples": ["/home/user/.openclaw"]
+      "description": "Resolved home directory of the active claw framework. Path layout is connector-specific: openclaw uses ~/.openclaw, zeptoclaw uses ~/.zeptoclaw, claudecode uses ~/.claude (or $CLAUDE_HOME), codex uses ~/.codex.",
+      "examples": [
+        "/home/user/.openclaw",
+        "/home/user/.zeptoclaw",
+        "/home/user/.claude",
+        "/home/user/.codex"
+      ]
     },
     "defenseclaw.device.id": {
       "type": "string",

--- a/schemas/otel/runtime-llm-span.schema.json
+++ b/schemas/otel/runtime-llm-span.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://defenseclaw.dev/schemas/otel/runtime-llm-span.schema.json",
   "title": "DefenseClaw Runtime LLM Call Span",
-  "description": "OTEL Span representing an LLM request/response lifecycle. Uses OTEL GenAI semantic conventions (gen_ai.* namespace). Emitted when OpenClaw hooks or the LLM gateway proxy capture LLM calls.",
+  "description": "OTEL Span representing an LLM request/response lifecycle. Uses OTEL GenAI semantic conventions (gen_ai.* namespace). Emitted when any connector's hook scripts (openclaw, zeptoclaw, claudecode, codex) or the LLM gateway proxy capture LLM calls.",
   "type": "object",
   "required": ["name", "kind", "startTimeUnixNano", "attributes"],
   "properties": {

--- a/scripts/check_schemas.py
+++ b/scripts/check_schemas.py
@@ -42,6 +42,15 @@ EXPECTED_PROVENANCE_FIELDS = {
     "schema_version", "content_hash", "generation", "binary_version",
 }
 
+# Connector names emitted by Connector.Name() in
+# internal/gateway/connector/{openclaw,zeptoclaw,claudecode,codex}.go.
+# The empty string is a legal "no connector picked yet" placeholder
+# emitted by the gateway before `defenseclaw setup connector` has run.
+# These four names are the contract every downstream consumer
+# (Splunk APM dashboards, OTLP collector validation, audit drill-down)
+# pivots on; drift here is a multi-week diagnostic rabbit-hole.
+EXPECTED_CLAW_MODE_ENUM = {"openclaw", "zeptoclaw", "claudecode", "codex", ""}
+
 
 def load_json(path: Path) -> dict:
     try:
@@ -110,18 +119,49 @@ def check_envelope(doc: dict) -> bool:
     return ok
 
 
+def check_resource(doc: dict) -> bool:
+    """Pin the claw.mode enum on schemas/otel/resource.schema.json.
+
+    Splunk APM dashboards, OTLP collector validation, and audit
+    drill-down all key off this attribute. If a developer adds a new
+    connector and forgets to update the schema, downstream consumers
+    silently start dropping records — and the empty-string fallback
+    masks it for fresh installs that haven't picked a connector yet.
+    Pin the enum here so the drift is caught at lint time, not at
+    incident time.
+    """
+    props = doc.get("properties", {})
+    mode = props.get("defenseclaw.claw.mode", {})
+    enum = set(mode.get("enum") or [])
+    missing = EXPECTED_CLAW_MODE_ENUM - enum
+    extra = enum - EXPECTED_CLAW_MODE_ENUM
+    if missing or extra:
+        print(
+            "check_schemas: otel/resource.schema.json: defenseclaw.claw.mode "
+            f"enum drift missing={sorted(missing)} extra={sorted(extra)}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
 def main() -> int:
     if not SCHEMA_DIR.is_dir():
         print(f"check_schemas: schema dir not found: {SCHEMA_DIR}", file=sys.stderr)
         return 2
 
     ok = True
-    for path in sorted(SCHEMA_DIR.glob("*.json")):
+    # Validate top-level schemas/*.json plus subtree schemas (e.g.
+    # schemas/otel/*.json). The recursive walk catches additions like
+    # the OTel resource/metrics/span schemas that ship in nested
+    # directories and would otherwise drift unchecked.
+    for path in sorted(SCHEMA_DIR.rglob("*.json")):
         doc = load_json(path)
         if not ensure_valid_meta(doc, path):
             ok = False
             continue
-        print(f"check_schemas: {path.name} OK")
+        rel = path.relative_to(SCHEMA_DIR)
+        print(f"check_schemas: {rel} OK")
 
     audit_path = SCHEMA_DIR / "audit-event.json"
     if audit_path.exists():
@@ -134,6 +174,14 @@ def main() -> int:
             ok = False
     else:
         print("check_schemas: gateway-event-envelope.json missing", file=sys.stderr)
+        ok = False
+
+    resource_path = SCHEMA_DIR / "otel" / "resource.schema.json"
+    if resource_path.exists():
+        if not check_resource(load_json(resource_path)):
+            ok = False
+    else:
+        print("check_schemas: schemas/otel/resource.schema.json missing", file=sys.stderr)
         ok = False
 
     return 0 if ok else 1


### PR DESCRIPTION
## Summary

\`schemas/otel/resource.schema.json\` shipped with
\`enum: [\"openclaw\", \"nemoclaw\", \"opencode\", \"codex\"]\`. Two of
those strings (\`nemoclaw\`, \`opencode\`) were forward-looking
placeholders that never matched a \`Connector.Name()\` value emitted
by a released gateway, while the two values that DO ship —
\`zeptoclaw\` and \`claudecode\` (see
\`internal/gateway/connector/{zeptoclaw,claudecode}.go\`) — were
missing entirely.

Splunk APM dashboards, OTLP collector validation, and audit
drill-down all pivot on this attribute, so a record produced by the
ZeptoClaw or Claude Code connector silently fails downstream schema
validation today.

## Changes

- **\`schemas/otel/resource.schema.json\`** — enum is now
  \`[\"openclaw\", \"zeptoclaw\", \"claudecode\", \"codex\", \"\"]\`.
  Empty string is explicit so fresh installs (no
  \`defenseclaw setup connector\` yet) are still schema-valid.
  \`defenseclaw.claw.home_dir\` description/examples now list each
  connector's path layout (\`~/.openclaw\`, \`~/.zeptoclaw\`,
  \`~/.claude\`, \`~/.codex\`) in one place.

- **\`schemas/otel/runtime-llm-span.schema.json\`** — description no
  longer pins only \"OpenClaw hooks\"; every connector emits LLM spans.

- **\`scripts/check_schemas.py\`**:
  - Recursive walk so \`schemas/otel/*.json\` gets meta-validated.
    The previous top-level glob was a long-standing gap that let
    OTel schemas drift unchecked for months.
  - New \`check_resource()\` pins the claw.mode enum at lint time —
    next connector addition has to update both sides together.

- **\`cli/tests/test_check_schemas.py\`** (new): 5 regression tests
  covering enum drift in both directions plus rglob coverage.

- **\`internal/config/config.go\`** — drop stale
  \"Future: ClawNemoClaw\" comment; replace with pointer to the real
  downstream contract (\`Connector.Name()\` + the OTel schema enum).
  Constants for the other three connectors are intentionally not
  introduced here; that's S1.2.

- **\`internal/config/config_test.go\`** — the
  \`cfg.Claw.Mode = \"nemoclaw\"\` mutation was using a stale name as
  an arbitrary distinct string for ContentHash testing. Replaced
  with \"zeptoclaw\" — keeps the test claw-agnostic and consistent
  with the canonical enum.

- **\`docs/INSTALL.md\`, \`docs/OTEL.md\`** — refresh the documented
  enum to the canonical four connector names.

## Why this is safe

- No code path emits \`nemoclaw\` or \`opencode\` today (only
  \`ClawOpenClaw = \"openclaw\"\` is a typed constant; everything else
  flows through \`Connector.Name()\`). Dropping them from the enum
  cannot break any in-flight record because none was ever produced.
- The Go \`Config.Claw.Mode\` is a free-form \`string\` type — no Go
  validation pinned to the schema enum, so this PR is purely a
  downstream consumer contract change plus tooling.

## Test plan

- [x] \`python3 scripts/check_schemas.py\` — all 16 schemas OK
  (top-level + \`schemas/otel/\`).
- [x] \`python3 -m pytest cli/tests/test_check_schemas.py -v\` — 5/5 pass
- [x] \`go test ./internal/config/...\` — ok (\`zeptoclaw\` mutation works)
- [x] \`go test ./internal/telemetry/...\` — ok (resource attribute still emits)
- [x] \`go build ./...\` — ok

## Stack

Stacked on \`feature/connector-architecture-v3\` (PR #141), independent
of #164 (S5.2 Makefile guard) and #165 (S7.1 hook sentinel) — can be
merged in any order.

Refs: claw-agnostic-refactor S3.1 / F9.