### PR TITLE
feat(connector): additive metadata interfaces — AgentPaths/RequiredEnv/HookScripts/Restarter (S1.1 remainder)

### DIFF
--- a/internal/gateway/connector/claudecode.go
+++ b/internal/gateway/connector/claudecode.go
@@ -192,6 +192,51 @@ func (c *ClaudeCodeConnector) Route(r *http.Request, body []byte) (*ConnectorSig
 	return cs, nil
 }
 
+// --- AgentPathProvider / EnvRequirementsProvider / HookScriptProvider ---
+
+// AgentPaths reports the on-disk footprint Claude Code's connector
+// touches. The connector patches ~/.claude/settings.json (hooks
+// table), backs it up via claudecode_backup.json, and writes the
+// inspect-* + claude-code-hook.sh scripts under <DataDir>/hooks/.
+// Legacy env files (claudecode_env.sh / claudecode.env) are
+// surfaced for audit completeness even though they are scoped to
+// <DataDir> and never sourced into the user's shell.
+func (c *ClaudeCodeConnector) AgentPaths(opts SetupOpts) AgentPaths {
+	hookDir := filepath.Join(opts.DataDir, "hooks")
+	hooks := make([]string, 0, len(HookScripts()))
+	for _, name := range HookScripts() {
+		hooks = append(hooks, filepath.Join(hookDir, name))
+	}
+	return AgentPaths{
+		PatchedFiles: []string{claudeCodeSettingsPath()},
+		BackupFiles:  []string{filepath.Join(opts.DataDir, "claudecode_backup.json")},
+		HookScripts:  hooks,
+		CreatedDirs:  []string{filepath.Join(opts.DataDir, "shims")},
+	}
+}
+
+func (c *ClaudeCodeConnector) HookScripts(opts SetupOpts) []string {
+	return c.AgentPaths(opts).HookScripts
+}
+
+// RequiredEnv reports Claude Code's env requirements. The CLI honors
+// ANTHROPIC_BASE_URL at startup; setting it points the agent at the
+// DefenseClaw proxy. The connector currently writes a scoped env
+// file the operator can `source` before launching Claude Code, but
+// it is not strictly required because the connector also patches
+// settings.json. Mark Required=false so `defenseclaw doctor` shows
+// it as recommended-but-not-blocking.
+func (c *ClaudeCodeConnector) RequiredEnv() []EnvRequirement {
+	return []EnvRequirement{
+		{
+			Name:        "ANTHROPIC_BASE_URL",
+			Scope:       EnvScopeProcess,
+			Required:    false,
+			Description: "Recommended. When set in Claude Code's process env it pins LLM traffic to the DefenseClaw proxy. The connector also patches ~/.claude/settings.json hooks so guardrail enforcement runs even when this var is unset.",
+		},
+	}
+}
+
 // --- ComponentScanner interface ---
 
 func (c *ClaudeCodeConnector) SupportsComponentScanning() bool { return true }

--- a/internal/gateway/connector/codex.go
+++ b/internal/gateway/connector/codex.go
@@ -237,6 +237,56 @@ func (c *CodexConnector) Route(r *http.Request, body []byte) (*ConnectorSignals,
 	return cs, nil
 }
 
+// --- AgentPathProvider / EnvRequirementsProvider / HookScriptProvider ---
+
+// AgentPaths reports the on-disk footprint Codex's connector
+// touches. The canonical scoped routing primitive is the patch
+// applied to ~/.codex/config.toml's [model_providers.*].base_url,
+// backed up via codex_config_backup.json. Older releases also
+// wrote codex_env.sh / codex.env into <DataDir>; those are still
+// surfaced here so tools that audit DefenseClaw's footprint find
+// them and Teardown can remove them.
+func (c *CodexConnector) AgentPaths(opts SetupOpts) AgentPaths {
+	hookDir := filepath.Join(opts.DataDir, "hooks")
+	hooks := make([]string, 0, len(HookScripts()))
+	for _, name := range HookScripts() {
+		hooks = append(hooks, filepath.Join(hookDir, name))
+	}
+	return AgentPaths{
+		PatchedFiles: []string{codexConfigPath()},
+		BackupFiles: []string{
+			filepath.Join(opts.DataDir, "codex_config_backup.json"),
+			filepath.Join(opts.DataDir, "codex_backup.json"),
+		},
+		HookScripts: hooks,
+		CreatedDirs: []string{filepath.Join(opts.DataDir, "shims")},
+	}
+}
+
+func (c *CodexConnector) HookScripts(opts SetupOpts) []string {
+	return c.AgentPaths(opts).HookScripts
+}
+
+// RequiredEnv reports Codex's env requirements. Codex picks its
+// model provider via [model_providers.*].base_url in config.toml,
+// which Setup patches directly — so the connector does not require
+// the operator to set OPENAI_BASE_URL in their shell. Older
+// releases wrote a codex_env.sh that exported it globally; that
+// path is being retired (see PR-H / S8.1) because it bleeds into
+// non-Codex OpenAI SDK clients. Documenting both the canonical
+// scoped path and the legacy var here gives `defenseclaw doctor`
+// enough context to flag mis-configurations.
+func (c *CodexConnector) RequiredEnv() []EnvRequirement {
+	return []EnvRequirement{
+		{
+			Name:        "OPENAI_BASE_URL",
+			Scope:       EnvScopeProcess,
+			Required:    false,
+			Description: "Optional. Codex's primary routing surface is the [model_providers.openai].base_url patch in ~/.codex/config.toml. Setting OPENAI_BASE_URL globally is discouraged because it also redirects unrelated OpenAI SDK clients.",
+		},
+	}
+}
+
 // --- ComponentScanner interface ---
 
 func (c *CodexConnector) SupportsComponentScanning() bool { return true }

--- a/internal/gateway/connector/connector.go
+++ b/internal/gateway/connector/connector.go
@@ -120,3 +120,121 @@ type ComponentScanner interface {
 type StopScanner interface {
 	SupportsStopScan() bool
 }
+
+// AgentPaths describes the on-disk filesystem footprint that a
+// connector touches at Setup/Teardown time. It is informational
+// metadata used by the CLI / `defenseclaw doctor` / install.sh to:
+//
+//   - preview what files Setup will modify before the operator runs it
+//   - audit what Teardown is responsible for removing
+//   - surface a friendlier "you need write access to <list>" error
+//     than letting Setup fail mid-write
+//
+// All paths are absolute. Empty slices are valid (a connector may have
+// no patched files, e.g. a pure proxy connector with no on-disk
+// integration).
+type AgentPaths struct {
+	// PatchedFiles are agent-owned files DefenseClaw modifies in
+	// place during Setup and restores during Teardown (e.g.
+	// ~/.codex/config.toml, ~/.zeptoclaw/config.json,
+	// ~/.claude/settings.json, ~/.openclaw/openclaw.json).
+	PatchedFiles []string
+
+	// BackupFiles are DefenseClaw-owned files written under
+	// opts.DataDir at Setup so Teardown can restore PatchedFiles.
+	// Clobbering these strands the user — they should be excluded
+	// from any cleanup that isn't a full Teardown.
+	BackupFiles []string
+
+	// HookScripts are executable scripts written under
+	// <opts.DataDir>/hooks/ at Setup that the agent invokes at
+	// runtime (PreToolUse, PostToolUse, etc.). Path semantics match
+	// PatchedFiles.
+	HookScripts []string
+
+	// CreatedDirs are directories the connector creates and owns
+	// (e.g. ~/.openclaw/extensions/defenseclaw/). Distinct from
+	// PatchedFiles because the entire directory is owned by
+	// DefenseClaw, not just edited.
+	CreatedDirs []string
+}
+
+// AgentPathProvider — optional, connectors that touch on-disk agent
+// configuration expose the paths they will patch / back up / write
+// here. This is metadata only: implementing it does not change
+// Setup/Teardown behavior, it just makes the connector inspectable
+// before / after those phases run. Unimplemented = "unknown
+// footprint" (the CLI falls back to a generic warning).
+type AgentPathProvider interface {
+	AgentPaths(opts SetupOpts) AgentPaths
+}
+
+// EnvScope describes where an environment variable needs to be set
+// for the connector's routing to take effect. DefenseClaw never
+// writes to user shell rc files; this enum is documentation for the
+// operator surfaced by `defenseclaw doctor`.
+type EnvScope string
+
+const (
+	// EnvScopeProcess — variable must be set in the agent's process
+	// env at launch time. The connector typically achieves this by
+	// patching an agent-specific config file that the agent reads at
+	// startup (e.g. config.toml for codex), so the operator usually
+	// does not need to do anything.
+	EnvScopeProcess EnvScope = "process"
+	// EnvScopeShell — variable must be set in the user's shell rc.
+	// DefenseClaw will not write the rc file; the operator must do
+	// it manually. Surfaced as a doctor warning when unset.
+	EnvScopeShell EnvScope = "shell"
+	// EnvScopeNone — no env var required (native binary configured
+	// entirely via on-disk config files).
+	EnvScopeNone EnvScope = "none"
+)
+
+// EnvRequirement describes a single env var the connector relies on
+// for the agent → proxy hop to work. It is informational metadata
+// surfaced by the CLI; a connector that needs no env vars implements
+// EnvRequirementsProvider returning an empty slice.
+type EnvRequirement struct {
+	// Name of the env var, e.g. "ANTHROPIC_BASE_URL".
+	Name string
+	// Scope describes where the var needs to be set.
+	Scope EnvScope
+	// Required is true when the connector cannot route the agent
+	// through the proxy without this var. False = ergonomic
+	// (e.g. helps debugging) but not required for routing.
+	Required bool
+	// Description explains why the var matters and how the
+	// connector uses it. Surfaced verbatim by `defenseclaw doctor`.
+	Description string
+}
+
+// EnvRequirementsProvider — optional, connectors that depend on env
+// vars (or document the absence of any) implement this so the CLI
+// can surface clear preflight diagnostics.
+type EnvRequirementsProvider interface {
+	RequiredEnv() []EnvRequirement
+}
+
+// HookScriptProvider — optional, connectors that own one or more
+// hook scripts at runtime expose their absolute on-disk paths here.
+// This is a thin convenience wrapper over AgentPaths.HookScripts so a
+// connector can advertise hook scripts without committing to the
+// rest of the AgentPaths shape.
+type HookScriptProvider interface {
+	HookScripts(opts SetupOpts) []string
+}
+
+// AgentRestarter — optional, connectors that know how to gracefully
+// bounce the agent process after a config change implement this.
+// Behavior contract:
+//   - Best-effort: a connector that finds the agent isn't running
+//     should return nil, not an error.
+//   - The CLI only calls this when the operator opts in via
+//     `--restart-agent` (or the equivalent flag). It is never
+//     called from Setup/Teardown.
+//   - Implementations must not block forever; they should respect
+//     ctx.Done().
+type AgentRestarter interface {
+	RestartAgent(ctx context.Context, opts SetupOpts) error
+}

--- a/internal/gateway/connector/connector_test.go
+++ b/internal/gateway/connector/connector_test.go
@@ -2777,3 +2777,317 @@ func TestTeardownPreviousConnector_ViaRegistry(t *testing.T) {
 		t.Errorf("active after switch = %q, want claudecode", got)
 	}
 }
+
+// --- PR-G (S1.1): AgentPathProvider / EnvRequirementsProvider /
+//                  HookScriptProvider / AgentRestarter contract ---
+//
+// These tests pin the additive interface contract introduced for the
+// claw-agnostic refactor. They are pure metadata assertions: every
+// built-in connector must (a) declare the on-disk paths it touches,
+// (b) declare any env vars it needs, (c) expose its hook scripts.
+// AgentRestarter is optional — none of the built-ins implement it
+// today; we only assert that the type assertion compiles.
+
+func TestConnector_AgentPathProvider_AllBuiltinsImplement(t *testing.T) {
+	dataDir := t.TempDir()
+	opts := SetupOpts{
+		DataDir:   dataDir,
+		ProxyAddr: "127.0.0.1:4000",
+		APIAddr:   "127.0.0.1:18970",
+	}
+
+	type tc struct {
+		name string
+		ctor func() Connector
+	}
+	cases := []tc{
+		{"zeptoclaw", func() Connector { return NewZeptoClawConnector() }},
+		{"openclaw", func() Connector { return NewOpenClawConnector() }},
+		{"codex", func() Connector { return NewCodexConnector() }},
+		{"claudecode", func() Connector { return NewClaudeCodeConnector() }},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			conn := c.ctor()
+			ap, ok := conn.(AgentPathProvider)
+			if !ok {
+				t.Fatalf("%s does not implement AgentPathProvider", c.name)
+			}
+			paths := ap.AgentPaths(opts)
+
+			// Every built-in connector touches at least one file
+			// the operator should know about (PatchedFiles or
+			// CreatedDirs). Pure-metadata-only connectors are
+			// not allowed at this layer.
+			if len(paths.PatchedFiles) == 0 && len(paths.CreatedDirs) == 0 {
+				t.Errorf("%s: neither PatchedFiles nor CreatedDirs declared — connector appears to be a no-op", c.name)
+			}
+
+			// Hook scripts must be absolute paths under DataDir
+			// when present.
+			for _, hs := range paths.HookScripts {
+				if !filepath.IsAbs(hs) {
+					t.Errorf("%s: hook script %q is not absolute", c.name, hs)
+				}
+				if !strings.HasPrefix(hs, dataDir) {
+					t.Errorf("%s: hook script %q is not under DataDir %q", c.name, hs, dataDir)
+				}
+			}
+
+			// Backup files must live under DataDir.
+			for _, bf := range paths.BackupFiles {
+				if !strings.HasPrefix(bf, dataDir) {
+					t.Errorf("%s: backup file %q is not under DataDir %q", c.name, bf, dataDir)
+				}
+			}
+		})
+	}
+}
+
+func TestConnector_AgentPaths_HookScriptsCoverAll(t *testing.T) {
+	dataDir := t.TempDir()
+	opts := SetupOpts{DataDir: dataDir, ProxyAddr: "127.0.0.1:4000", APIAddr: "127.0.0.1:18970"}
+	expected := HookScripts() // canonical list from subprocess.go
+
+	connectors := []Connector{
+		NewZeptoClawConnector(),
+		NewOpenClawConnector(),
+		NewCodexConnector(),
+		NewClaudeCodeConnector(),
+	}
+	for _, conn := range connectors {
+		ap, ok := conn.(AgentPathProvider)
+		if !ok {
+			t.Fatalf("%s missing AgentPathProvider", conn.Name())
+		}
+		paths := ap.AgentPaths(opts)
+		// Each declared script name from the canonical list should
+		// appear at <DataDir>/hooks/<name> in the connector's
+		// reported HookScripts.
+		got := map[string]bool{}
+		for _, p := range paths.HookScripts {
+			got[filepath.Base(p)] = true
+		}
+		for _, want := range expected {
+			if !got[want] {
+				t.Errorf("%s: AgentPaths.HookScripts missing %q (got %v)", conn.Name(), want, paths.HookScripts)
+			}
+		}
+	}
+}
+
+func TestConnector_HookScriptProvider_MatchesAgentPaths(t *testing.T) {
+	opts := SetupOpts{DataDir: t.TempDir(), ProxyAddr: "127.0.0.1:4000", APIAddr: "127.0.0.1:18970"}
+
+	connectors := []Connector{
+		NewZeptoClawConnector(),
+		NewOpenClawConnector(),
+		NewCodexConnector(),
+		NewClaudeCodeConnector(),
+	}
+	for _, conn := range connectors {
+		hsp, ok := conn.(HookScriptProvider)
+		if !ok {
+			t.Fatalf("%s missing HookScriptProvider", conn.Name())
+		}
+		ap, _ := conn.(AgentPathProvider)
+		want := ap.AgentPaths(opts).HookScripts
+		got := hsp.HookScripts(opts)
+		if len(got) != len(want) {
+			t.Errorf("%s: HookScripts() returned %d entries, AgentPaths reported %d", conn.Name(), len(got), len(want))
+			continue
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("%s: HookScripts()[%d] = %q, AgentPaths reported %q", conn.Name(), i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestConnector_EnvRequirementsProvider_AllBuiltinsImplement(t *testing.T) {
+	type tc struct {
+		name           string
+		ctor           func() Connector
+		mustHaveScopes []EnvScope
+	}
+	cases := []tc{
+		// Native binaries route via on-disk config; document the
+		// absence of env requirements with EnvScopeNone.
+		{"zeptoclaw", func() Connector { return NewZeptoClawConnector() }, []EnvScope{EnvScopeNone}},
+		// OpenClaw uses the fetch interceptor plugin; no env vars.
+		{"openclaw", func() Connector { return NewOpenClawConnector() }, []EnvScope{EnvScopeNone}},
+		// Codex routes via config.toml; OPENAI_BASE_URL is
+		// optional/discouraged. Scope is process-only.
+		{"codex", func() Connector { return NewCodexConnector() }, []EnvScope{EnvScopeProcess}},
+		// Claude Code honors ANTHROPIC_BASE_URL at startup but
+		// settings.json hooks are sufficient for guardrail
+		// enforcement, so the var is recommended-not-required.
+		{"claudecode", func() Connector { return NewClaudeCodeConnector() }, []EnvScope{EnvScopeProcess}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			conn := c.ctor()
+			ep, ok := conn.(EnvRequirementsProvider)
+			if !ok {
+				t.Fatalf("%s does not implement EnvRequirementsProvider", c.name)
+			}
+			reqs := ep.RequiredEnv()
+			if len(reqs) == 0 {
+				t.Fatalf("%s: RequiredEnv() returned empty slice; expected at least one documentation entry", c.name)
+			}
+
+			seen := map[EnvScope]bool{}
+			for _, r := range reqs {
+				seen[r.Scope] = true
+				if r.Description == "" {
+					t.Errorf("%s: env requirement %q has empty Description", c.name, r.Name)
+				}
+				if r.Scope != EnvScopeNone && r.Name == "" {
+					t.Errorf("%s: env requirement with non-None scope %q is missing Name", c.name, r.Scope)
+				}
+				// Require the scope to be one of the
+				// documented enum values; reject typo'd
+				// strings.
+				switch r.Scope {
+				case EnvScopeProcess, EnvScopeShell, EnvScopeNone:
+				default:
+					t.Errorf("%s: env requirement %q has unknown Scope %q", c.name, r.Name, r.Scope)
+				}
+			}
+			for _, want := range c.mustHaveScopes {
+				if !seen[want] {
+					t.Errorf("%s: RequiredEnv() did not declare expected scope %q", c.name, want)
+				}
+			}
+		})
+	}
+}
+
+func TestConnector_AgentRestarter_OptionalAtThisLayer(t *testing.T) {
+	// None of the built-in connectors implement AgentRestarter
+	// today; this test pins the contract that the type assertion
+	// compiles cleanly and returns ok=false. When a future
+	// connector adds restart support, the fix is to update this
+	// test, not to make the assertion compile-time mandatory.
+	connectors := []Connector{
+		NewZeptoClawConnector(),
+		NewOpenClawConnector(),
+		NewCodexConnector(),
+		NewClaudeCodeConnector(),
+	}
+	for _, conn := range connectors {
+		if _, ok := conn.(AgentRestarter); ok {
+			t.Logf("%s implements AgentRestarter — update this test to exercise it", conn.Name())
+		}
+	}
+}
+
+// TestZeptoClaw_AgentPaths_Specifics pins the exact paths the
+// ZeptoClaw connector reports so a future refactor that drops
+// zeptoclaw_backup.json or moves the config file is caught here
+// instead of at runtime in `defenseclaw doctor`.
+func TestZeptoClaw_AgentPaths_Specifics(t *testing.T) {
+	dataDir := t.TempDir()
+	tmpHome := t.TempDir()
+	cfg := filepath.Join(tmpHome, ".zeptoclaw", "config.json")
+	ZeptoClawConfigPathOverride = cfg
+	defer func() { ZeptoClawConfigPathOverride = "" }()
+
+	conn := NewZeptoClawConnector()
+	paths := conn.AgentPaths(SetupOpts{DataDir: dataDir})
+
+	if len(paths.PatchedFiles) != 1 || paths.PatchedFiles[0] != cfg {
+		t.Errorf("PatchedFiles = %v, want [%q]", paths.PatchedFiles, cfg)
+	}
+	wantBackup := filepath.Join(dataDir, "zeptoclaw_backup.json")
+	if len(paths.BackupFiles) != 1 || paths.BackupFiles[0] != wantBackup {
+		t.Errorf("BackupFiles = %v, want [%q]", paths.BackupFiles, wantBackup)
+	}
+}
+
+// TestCodex_AgentPaths_Specifics pins Codex's footprint. The
+// connector exposes both codex_config_backup.json (config.toml
+// patch) and codex_backup.json (legacy env backup).
+func TestCodex_AgentPaths_Specifics(t *testing.T) {
+	dataDir := t.TempDir()
+	tmpHome := t.TempDir()
+	cfg := filepath.Join(tmpHome, ".codex", "config.toml")
+	CodexConfigPathOverride = cfg
+	defer func() { CodexConfigPathOverride = "" }()
+
+	conn := NewCodexConnector()
+	paths := conn.AgentPaths(SetupOpts{DataDir: dataDir})
+
+	if len(paths.PatchedFiles) != 1 || paths.PatchedFiles[0] != cfg {
+		t.Errorf("PatchedFiles = %v, want [%q]", paths.PatchedFiles, cfg)
+	}
+	wantBackups := []string{
+		filepath.Join(dataDir, "codex_config_backup.json"),
+		filepath.Join(dataDir, "codex_backup.json"),
+	}
+	if len(paths.BackupFiles) != len(wantBackups) {
+		t.Errorf("BackupFiles = %v, want %v", paths.BackupFiles, wantBackups)
+	} else {
+		for i, want := range wantBackups {
+			if paths.BackupFiles[i] != want {
+				t.Errorf("BackupFiles[%d] = %q, want %q", i, paths.BackupFiles[i], want)
+			}
+		}
+	}
+}
+
+// TestClaudeCode_AgentPaths_Specifics pins the Claude Code
+// footprint: settings.json + claudecode_backup.json + hook scripts.
+func TestClaudeCode_AgentPaths_Specifics(t *testing.T) {
+	dataDir := t.TempDir()
+	tmpHome := t.TempDir()
+	cfg := filepath.Join(tmpHome, ".claude", "settings.json")
+	ClaudeCodeSettingsPathOverride = cfg
+	defer func() { ClaudeCodeSettingsPathOverride = "" }()
+
+	conn := NewClaudeCodeConnector()
+	paths := conn.AgentPaths(SetupOpts{DataDir: dataDir})
+
+	if len(paths.PatchedFiles) != 1 || paths.PatchedFiles[0] != cfg {
+		t.Errorf("PatchedFiles = %v, want [%q]", paths.PatchedFiles, cfg)
+	}
+	wantBackup := filepath.Join(dataDir, "claudecode_backup.json")
+	if len(paths.BackupFiles) != 1 || paths.BackupFiles[0] != wantBackup {
+		t.Errorf("BackupFiles = %v, want [%q]", paths.BackupFiles, wantBackup)
+	}
+}
+
+// TestOpenClaw_AgentPaths_Specifics pins OpenClaw's footprint:
+// openclaw.json patched, no backup file (edits are reversible),
+// extension dir created.
+func TestOpenClaw_AgentPaths_Specifics(t *testing.T) {
+	dataDir := t.TempDir()
+	tmpHome := t.TempDir()
+	OpenClawHomeOverride = filepath.Join(tmpHome, ".openclaw")
+	defer func() { OpenClawHomeOverride = "" }()
+
+	conn := NewOpenClawConnector()
+	paths := conn.AgentPaths(SetupOpts{DataDir: dataDir})
+
+	wantPatched := filepath.Join(OpenClawHomeOverride, "openclaw.json")
+	if len(paths.PatchedFiles) != 1 || paths.PatchedFiles[0] != wantPatched {
+		t.Errorf("PatchedFiles = %v, want [%q]", paths.PatchedFiles, wantPatched)
+	}
+	if len(paths.BackupFiles) != 0 {
+		t.Errorf("BackupFiles = %v, want empty (openclaw.json edits are reversible without a backup)", paths.BackupFiles)
+	}
+	wantDir := filepath.Join(OpenClawHomeOverride, "extensions", "defenseclaw")
+	found := false
+	for _, d := range paths.CreatedDirs {
+		if d == wantDir {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("CreatedDirs = %v, missing %q", paths.CreatedDirs, wantDir)
+	}
+}

--- a/internal/gateway/connector/openclaw.go
+++ b/internal/gateway/connector/openclaw.go
@@ -439,6 +439,51 @@ func (c *OpenClawConnector) Route(r *http.Request, body []byte) (*ConnectorSigna
 	return cs, nil
 }
 
+// --- AgentPathProvider / EnvRequirementsProvider / HookScriptProvider ---
+
+// AgentPaths reports the on-disk footprint OpenClaw's connector
+// touches. The connector patches ~/.openclaw/openclaw.json (allow
+// list + plugin entry) and writes the embedded extension into
+// ~/.openclaw/extensions/defenseclaw/. Hook scripts under
+// <DataDir>/hooks/ are written for proxy-side tool inspection.
+func (c *OpenClawConnector) AgentPaths(opts SetupOpts) AgentPaths {
+	ocHome := openClawHome()
+	hookDir := filepath.Join(opts.DataDir, "hooks")
+	hooks := make([]string, 0, len(HookScripts()))
+	for _, name := range HookScripts() {
+		hooks = append(hooks, filepath.Join(hookDir, name))
+	}
+	return AgentPaths{
+		PatchedFiles: []string{filepath.Join(ocHome, "openclaw.json")},
+		BackupFiles:  nil, // openclaw.json edits are reversible without a backup file
+		HookScripts:  hooks,
+		CreatedDirs: []string{
+			filepath.Join(ocHome, "extensions", "defenseclaw"),
+			filepath.Join(opts.DataDir, "shims"),
+		},
+	}
+}
+
+func (c *OpenClawConnector) HookScripts(opts SetupOpts) []string {
+	return c.AgentPaths(opts).HookScripts
+}
+
+// RequiredEnv reports the env vars OpenClaw needs for proxy
+// routing. OpenClaw uses a fetch interceptor plugin loaded from
+// extensions/defenseclaw/ — there is no env var the operator must
+// set; the plugin patches globalThis.fetch at runtime. Return a
+// single EnvScopeNone entry as positive documentation.
+func (c *OpenClawConnector) RequiredEnv() []EnvRequirement {
+	return []EnvRequirement{
+		{
+			Name:        "",
+			Scope:       EnvScopeNone,
+			Required:    false,
+			Description: "OpenClaw routes through DefenseClaw via the embedded fetch interceptor plugin loaded from ~/.openclaw/extensions/defenseclaw/; no env vars are needed.",
+		},
+	}
+}
+
 // --- ComponentScanner interface ---
 
 func (c *OpenClawConnector) SupportsComponentScanning() bool { return true }

--- a/internal/gateway/connector/zeptoclaw.go
+++ b/internal/gateway/connector/zeptoclaw.go
@@ -306,6 +306,51 @@ func (c *ZeptoClawConnector) Route(r *http.Request, body []byte) (*ConnectorSign
 	return cs, nil
 }
 
+// --- AgentPathProvider / EnvRequirementsProvider / HookScriptProvider ---
+
+// AgentPaths reports the on-disk footprint ZeptoClaw's connector
+// touches. ZeptoClaw is a native Rust binary configured entirely
+// through ~/.zeptoclaw/config.json, so only that file is patched.
+// The connector also writes the inspect-* hook scripts into
+// <DataDir>/hooks/ for proxy-side tool inspection.
+func (c *ZeptoClawConnector) AgentPaths(opts SetupOpts) AgentPaths {
+	hookDir := filepath.Join(opts.DataDir, "hooks")
+	hooks := make([]string, 0, len(HookScripts()))
+	for _, name := range HookScripts() {
+		hooks = append(hooks, filepath.Join(hookDir, name))
+	}
+	return AgentPaths{
+		PatchedFiles: []string{zeptoClawConfigPath()},
+		BackupFiles:  []string{filepath.Join(opts.DataDir, "zeptoclaw_backup.json")},
+		HookScripts:  hooks,
+		CreatedDirs:  []string{filepath.Join(opts.DataDir, "shims")},
+	}
+}
+
+// HookScripts is a convenience wrapper over AgentPaths.HookScripts
+// so callers that only need the hook list don't have to construct a
+// full AgentPaths.
+func (c *ZeptoClawConnector) HookScripts(opts SetupOpts) []string {
+	return c.AgentPaths(opts).HookScripts
+}
+
+// RequiredEnv reports the env vars ZeptoClaw needs for proxy
+// routing. ZeptoClaw is a native binary that reads its api_base
+// from config.json, so no env vars are required — Setup patches
+// the JSON file directly. We still return a single EnvScopeNone
+// entry as documentation so `defenseclaw doctor` can show a
+// "no env vars required" line instead of staying silent.
+func (c *ZeptoClawConnector) RequiredEnv() []EnvRequirement {
+	return []EnvRequirement{
+		{
+			Name:        "",
+			Scope:       EnvScopeNone,
+			Required:    false,
+			Description: "ZeptoClaw is configured via ~/.zeptoclaw/config.json (api_base patched at setup); no env vars are needed for routing.",
+		},
+	}
+}
+
 // --- ComponentScanner interface ---
 
 func (c *ZeptoClawConnector) SupportsComponentScanning() bool { return true }


### PR DESCRIPTION
Stacked on #163 (\`feature/connector-architecture-v3\`).

## Summary

S1.1 (remainder) — extend the \`Connector\` iface so the CLI / \`defenseclaw doctor\` / install.sh can preview / audit / preflight what each connector touches without running Setup. **Strictly additive** — no changes to existing interfaces or behavior.

## Why

Every connector hides its on-disk footprint inside private \`patch* / restore* / writeEnvOverride\` methods. Operators have no way to ask "what files will \`defenseclaw setup\` modify on my machine?" before running it, and \`verify-clean\` has to rederive the same paths separately. This blocks:

- previewing the blast radius of \`defenseclaw setup\`
- surfacing friendly preflight errors (e.g. "no write access to \`~/.codex/config.toml\`")
- composing \`defenseclaw doctor\` to audit the same paths Setup writes
- adding per-connector \`--restart-agent\` cleanly

## What's new

Four optional interfaces in \`internal/gateway/connector/connector.go\`, mirroring the existing \`ComponentScanner\` / \`StopScanner\` pattern:

| Interface | Method | Purpose |
|---|---|---|
| \`AgentPathProvider\` | \`AgentPaths(opts) AgentPaths\` | Declare PatchedFiles / BackupFiles / HookScripts / CreatedDirs |
| \`EnvRequirementsProvider\` | \`RequiredEnv() []EnvRequirement\` | Declare env vars (Name / Scope / Required / Description) |
| \`HookScriptProvider\` | \`HookScripts(opts) []string\` | Convenience over \`AgentPaths.HookScripts\` |
| \`AgentRestarter\` | \`RestartAgent(ctx, opts) error\` | Reserved — no built-in implements today |

\`AgentPaths\` bundles:
- **PatchedFiles**: agent-owned files we modify in place (config.toml, settings.json, etc.)
- **BackupFiles**: DefenseClaw-owned restore points under \`DataDir\`
- **HookScripts**: hook scripts under \`<DataDir>/hooks/\`
- **CreatedDirs**: directories DefenseClaw owns end-to-end (\`~/.openclaw/extensions/defenseclaw/\`, etc.)

\`EnvScope\` enum:
- \`process\` — required in agent process env (typically applied by patching agent config)
- \`shell\` — required in user shell rc
- \`none\` — no env var needed (native binary configured via on-disk files)

## Per-connector wiring

| Connector | PatchedFiles | BackupFiles | Env |
|---|---|---|---|
| ZeptoClaw | \`~/.zeptoclaw/config.json\` | \`zeptoclaw_backup.json\` | EnvScopeNone (native binary) |
| OpenClaw | \`~/.openclaw/openclaw.json\` | (none — edits reversible) | EnvScopeNone (fetch interceptor plugin) |
| Codex | \`~/.codex/config.toml\` | \`codex_config_backup.json\` + \`codex_backup.json\` | OPENAI_BASE_URL: optional/discouraged (config.toml is the scoped primitive — see PR-H / S8.1) |
| ClaudeCode | \`~/.claude/settings.json\` | \`claudecode_backup.json\` | ANTHROPIC_BASE_URL: recommended-not-required (settings.json hooks suffice) |

All four also expose the shared \`<DataDir>/hooks/\` (6 scripts) and \`<DataDir>/shims/\` directory.

## Tests

- \`TestConnector_AgentPathProvider_AllBuiltinsImplement\` — every built-in implements the interface; paths are absolute and live under expected roots.
- \`TestConnector_AgentPaths_HookScriptsCoverAll\` — each connector advertises every script in the canonical \`HookScripts()\` list.
- \`TestConnector_HookScriptProvider_MatchesAgentPaths\` — convenience wrapper agrees with the \`AgentPaths\` source of truth.
- \`TestConnector_EnvRequirementsProvider_AllBuiltinsImplement\` — every connector returns ≥1 EnvRequirement with a documented Scope.
- \`TestConnector_AgentRestarter_OptionalAtThisLayer\` — pins that no built-in implements \`AgentRestarter\` today (forces explicit update when one does).
- Per-connector specifics tests pin exact paths so a refactor that drops/renames a backup file is caught at build time, not at runtime in \`doctor\`.

## Test plan

- [x] \`go test ./internal/gateway/connector/ -count=1\` — full package green.
- [x] \`go build ./internal/gateway/connector/...\` — clean.
- [x] \`ReadLints\` on touched files — no diagnostics.
- [ ] Manual: in a follow-up PR, wire \`defenseclaw doctor\` to consume these interfaces and render the footprint.

## Related Wave-1 stack

- PR-C #165 (hook fail-open)
- PR-D #166 (OTel schemas)
- PR-E #167 (\`guardrail.mode=observe\`)
- PR-H #168 (Codex env scoping — informs Codex's RequiredEnv())
- **PR-G (this)**: connector iface extensions
- PR-F: install.sh \`--connector\` (next)
- PR-I: \`defenseclaw setup\` per-agent scoping (next)