### PR TITLE
feat(install): --connector / --no-openclaw / interactive picker (S5.1 / F1)

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -296,6 +296,34 @@ Pin a specific version:
 VERSION=0.2.0 curl -LsSf .../install.sh | bash
 ```
 
+#### Picking an agent connector at install time
+
+By default the installer integrates with **OpenClaw** (installs the
+OpenClaw runtime and the DefenseClaw plugin). You can pick a different
+connector — or skip connector setup entirely — with `--connector`:
+
+```bash
+# Codex (no OpenClaw, no plugin tarball; patches ~/.codex/config.toml + hooks)
+curl -LsSf .../install.sh | bash -s -- --connector codex
+
+# Claude Code (no OpenClaw; patches ~/.claude/settings.json hooks)
+curl -LsSf .../install.sh | bash -s -- --connector claudecode
+
+# ZeptoClaw (no OpenClaw; patches ~/.zeptoclaw/config.json)
+curl -LsSf .../install.sh | bash -s -- --connector zeptoclaw
+
+# Lay binaries only — pick a connector later
+curl -LsSf .../install.sh | bash -s -- --connector none
+
+# Shortcut for "skip OpenClaw" without naming another connector
+curl -LsSf .../install.sh | bash -s -- --no-openclaw
+```
+
+Run interactively (without `--yes` and without `--connector`) and the
+installer prompts which connector to use. The picked connector is
+recorded at `~/.defenseclaw/picked_connector` so the CLI's `defenseclaw
+setup` defaults to it on the next invocation.
+
 ---
 
 ## Setup Commands Reference

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,10 +27,17 @@
 #   # From local dist/ directory (for testing):
 #   ./scripts/install.sh --local ./dist
 #
+#   # Pick a specific agent connector at install time:
+#   curl ... | bash -s -- --connector codex          # Codex (no OpenClaw install)
+#   curl ... | bash -s -- --connector openclaw       # OpenClaw + plugin (default)
+#   curl ... | bash -s -- --no-openclaw              # Skip OpenClaw entirely
+#
 # Options:
-#   --local <dir>  Install from a local dist directory instead of downloading
-#   --yes, -y      Skip confirmation prompts (for CI/automation)
-#   --help, -h     Show help
+#   --connector <name>  Pick agent connector (openclaw|codex|claudecode|zeptoclaw|none)
+#   --no-openclaw       Skip OpenClaw install (alias for --connector none when used alone)
+#   --local <dir>       Install from a local dist directory instead of downloading
+#   --yes, -y           Skip confirmation prompts (for CI/automation)
+#   --help, -h          Show help
 #
 set -euo pipefail
 
@@ -45,6 +52,11 @@ readonly DEFENSECLAW_VENV="${DEFENSECLAW_HOME}/.venv"
 readonly INSTALL_DIR="${HOME}/.local/bin"
 readonly REPO="cisco-ai-defense/defenseclaw"
 readonly OPENCLAW_VERSION="2026.3.24"
+
+# Supported connectors. Keep in sync with internal/gateway/connector/registry.go
+# DefaultRegistry. The "none" pseudo-value means "lay binaries only — pick a
+# connector later with `defenseclaw setup --connector ...`".
+readonly CONNECTOR_CHOICES=(openclaw codex claudecode zeptoclaw none)
 
 # ── Terminal Formatting ───────────────────────────────────────────────────────
 
@@ -113,6 +125,78 @@ detect_shell_rc() {
         */bash) echo "${HOME}/.bashrc" ;;
         *)      echo "${HOME}/.profile" ;;
     esac
+}
+
+# is_valid_connector NAME — returns 0 if NAME is in CONNECTOR_CHOICES.
+is_valid_connector() {
+    local n="$1" v
+    for v in "${CONNECTOR_CHOICES[@]}"; do
+        [[ "$v" == "$n" ]] && return 0
+    done
+    return 1
+}
+
+# pick_connector_interactive — prompt the user to pick a connector when
+# none was passed on the command line and we are not in --yes mode.
+# Sets global CONNECTOR. Defaults to openclaw to match prior installer
+# behavior so users running `curl | bash` interactively keep the same
+# default they had before this picker was added.
+pick_connector_interactive() {
+    if [[ -n "${CONNECTOR}" ]]; then
+        return
+    fi
+    if [[ "${YES_MODE}" == true ]]; then
+        # Headless install: keep the historical default (openclaw)
+        # unless the operator explicitly opted out via --no-openclaw
+        # or --connector. This preserves backward compatibility with
+        # CI pipelines that ran `curl ... | bash -s -- --yes`.
+        CONNECTOR="openclaw"
+        return
+    fi
+
+    step "Pick agent connector"
+    info "DefenseClaw can guard several agent frameworks. Pick one to integrate now;"
+    info "you can switch later with 'defenseclaw setup --connector <name>'."
+    echo ""
+    local i=1
+    for v in "${CONNECTOR_CHOICES[@]}"; do
+        case "$v" in
+            openclaw)   printf "    ${BOLD}%d)${NC} openclaw   — install OpenClaw runtime + DefenseClaw plugin\n" "$i" ;;
+            codex)      printf "    ${BOLD}%d)${NC} codex      — patch ~/.codex/config.toml + hooks (no OpenClaw)\n" "$i" ;;
+            claudecode) printf "    ${BOLD}%d)${NC} claudecode — patch ~/.claude/settings.json hooks (no OpenClaw)\n" "$i" ;;
+            zeptoclaw)  printf "    ${BOLD}%d)${NC} zeptoclaw  — patch ~/.zeptoclaw/config.json (no OpenClaw)\n" "$i" ;;
+            none)       printf "    ${BOLD}%d)${NC} none       — install gateway/CLI only; pick later\n" "$i" ;;
+        esac
+        i=$((i + 1))
+    done
+    echo ""
+
+    local default_idx=1   # openclaw
+    local choice
+    printf "  Choice [1-%d, default %d=openclaw]: " "${#CONNECTOR_CHOICES[@]}" "${default_idx}" >&2
+    read -r choice < /dev/tty 2>/dev/null || choice=""
+    choice="${choice:-${default_idx}}"
+    if ! [[ "${choice}" =~ ^[0-9]+$ ]] || (( choice < 1 || choice > ${#CONNECTOR_CHOICES[@]} )); then
+        warn "Invalid choice '${choice}', defaulting to openclaw"
+        CONNECTOR="openclaw"
+    else
+        CONNECTOR="${CONNECTOR_CHOICES[$((choice - 1))]}"
+    fi
+    ok "Picked connector: ${CONNECTOR}"
+}
+
+# record_picked_connector — write the picked connector name to
+# <DEFENSECLAW_HOME>/picked_connector so the CLI's `defenseclaw setup`
+# can default to it without re-prompting. The file is informational
+# only — the gateway's authoritative connector state lives in
+# active_connector.json after a successful Setup. We write it as text
+# (no JSON) to keep the file shell-readable for diagnostics.
+record_picked_connector() {
+    if [[ -z "${CONNECTOR}" ]] || [[ "${CONNECTOR}" == "none" ]]; then
+        return
+    fi
+    mkdir -p "${DEFENSECLAW_HOME}"
+    printf "%s\n" "${CONNECTOR}" > "${DEFENSECLAW_HOME}/picked_connector"
 }
 
 # ── Interrupt handler ─────────────────────────────────────────────────────────
@@ -550,13 +634,41 @@ print_success() {
     printf "${BOLD}${GREEN}║        DefenseClaw installed successfully!               ║${NC}\n"
     printf "${BOLD}${GREEN}╚══════════════════════════════════════════════════════════╝${NC}\n"
     echo ""
-    if [[ "${INSTALL_SANDBOX}" == true ]] && [[ "${OS}" == "linux" ]]; then
-        printf "  Get started:\n\n"
-        printf "    ${CYAN}defenseclaw init --sandbox${NC}\n"
-    else
-        printf "  Get started:\n\n"
-        printf "    ${CYAN}defenseclaw init --enable-guardrail${NC}\n"
-    fi
+
+    # Connector-specific next-step guidance. The picked connector
+    # determines which `defenseclaw` command to run next; surfacing
+    # this here means the operator does not have to read docs after
+    # `curl | bash` to find the right verb.
+    case "${CONNECTOR}" in
+        openclaw|"")
+            if [[ "${INSTALL_SANDBOX}" == true ]] && [[ "${OS}" == "linux" ]]; then
+                printf "  Get started:\n\n"
+                printf "    ${CYAN}defenseclaw init --sandbox${NC}\n"
+            else
+                printf "  Get started:\n\n"
+                printf "    ${CYAN}defenseclaw init --enable-guardrail${NC}\n"
+            fi
+            ;;
+        codex)
+            printf "  Get started (Codex):\n\n"
+            printf "    ${CYAN}defenseclaw setup --connector codex${NC}\n"
+            printf "    ${CYAN}defenseclaw guardrail enable${NC}\n"
+            ;;
+        claudecode)
+            printf "  Get started (Claude Code):\n\n"
+            printf "    ${CYAN}defenseclaw setup --connector claudecode${NC}\n"
+            printf "    ${CYAN}defenseclaw guardrail enable${NC}\n"
+            ;;
+        zeptoclaw)
+            printf "  Get started (ZeptoClaw):\n\n"
+            printf "    ${CYAN}defenseclaw setup --connector zeptoclaw${NC}\n"
+            printf "    ${CYAN}defenseclaw guardrail enable${NC}\n"
+            ;;
+        none)
+            printf "  Get started (pick a connector later):\n\n"
+            printf "    ${CYAN}defenseclaw setup --connector <openclaw|codex|claudecode|zeptoclaw>${NC}\n"
+            ;;
+    esac
     echo ""
 }
 
@@ -571,6 +683,8 @@ LOCAL_DIR=""
 INSTALL_SANDBOX=false
 RUN_QUICKSTART=false
 QUICKSTART_MODE="observe"
+CONNECTOR=""
+NO_OPENCLAW=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -581,6 +695,14 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --yes|-y) YES_MODE=true; shift ;;
+        --connector)
+            [[ $# -lt 2 ]] && die "--connector requires a value (openclaw|codex|claudecode|zeptoclaw|none)"
+            CONNECTOR="$2"
+            is_valid_connector "${CONNECTOR}" \
+                || die "Invalid --connector '${CONNECTOR}'. Choices: ${CONNECTOR_CHOICES[*]}"
+            shift 2
+            ;;
+        --no-openclaw) NO_OPENCLAW=true; shift ;;
         # Run ``defenseclaw quickstart --non-interactive`` after the
         # binaries land. This gives a single-command install→bootstrap
         # path: everything a user needs to go from ``curl | bash`` to a
@@ -606,6 +728,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --sandbox             Also install openshell-sandbox (Linux only)"
             echo "  --local <dir>         Install from a local dist directory"
             echo "  --yes, -y             Skip all confirmation prompts"
+            echo "  --connector <name>    Pick agent connector (openclaw|codex|claudecode|zeptoclaw|none)"
+            echo "  --no-openclaw         Skip OpenClaw runtime+plugin install (alias for --connector none)"
             echo "  --quickstart          Run 'defenseclaw quickstart --non-interactive' post-install"
             echo "  --quickstart-mode M   Pass --mode M to quickstart (observe|action; implies --quickstart)"
             echo "  --help, -h            Show this help"
@@ -625,6 +749,18 @@ while [[ $# -gt 0 ]]; do
 done
 export YES_MODE
 
+# Reconcile --no-openclaw and --connector. The two flags can be combined
+# coherently (e.g. --no-openclaw --connector codex), but conflicting use
+# (--no-openclaw --connector openclaw) is rejected to avoid silently
+# ignoring the operator's intent.
+if [[ "${NO_OPENCLAW}" == true ]]; then
+    if [[ -z "${CONNECTOR}" ]]; then
+        CONNECTOR="none"
+    elif [[ "${CONNECTOR}" == "openclaw" ]]; then
+        die "--no-openclaw is incompatible with --connector openclaw"
+    fi
+fi
+
 if [[ -n "${LOCAL_DIR}" ]]; then
     info "Installing from local directory: ${LOCAL_DIR}"
 fi
@@ -633,10 +769,29 @@ detect_platform
 ensure_uv
 ensure_python
 resolve_version
+pick_connector_interactive
 install_gateway
 install_python_cli
-install_plugin
-handle_openclaw
+
+# Only install the OpenClaw plugin and the OpenClaw runtime when the user
+# actually picked OpenClaw. Other connectors (Codex / Claude Code /
+# ZeptoClaw) integrate via config-file patching and need neither npm nor
+# the plugin tarball. For "none" we skip everything connector-specific
+# and let the user run `defenseclaw setup --connector <name>` later.
+case "${CONNECTOR}" in
+    openclaw)
+        install_plugin
+        handle_openclaw
+        ;;
+    codex|claudecode|zeptoclaw)
+        info "Skipping OpenClaw plugin/runtime install (connector: ${CONNECTOR})"
+        ;;
+    none|"")
+        info "Skipping connector setup — pick one later with 'defenseclaw setup --connector <name>'"
+        ;;
+esac
+
+record_picked_connector
 
 if [[ "${INSTALL_SANDBOX}" == true ]]; then
     if [[ "${OS}" != "linux" ]]; then


### PR DESCRIPTION
## Summary

Make agent connector choice explicit at install time so operators of Codex / Claude Code / ZeptoClaw don't pay the OpenClaw tax (`npm install -g openclaw@…` + plugin tarball + onboarding wizard).

- New `--connector <openclaw|codex|claudecode|zeptoclaw|none>` flag. Non-openclaw values skip `install_plugin` and `handle_openclaw`.
- New `--no-openclaw` shortcut. When used alone implies `--connector none`. Conflict with `--connector openclaw` is rejected up front.
- Interactive picker fires when neither `--connector` nor `--yes` is supplied; defaults to openclaw on TTY-less / invalid input.
- Picked connector recorded at `~/.defenseclaw/picked_connector` so PR-I (S8.2) can default `defenseclaw setup` to it.
- `print_success` emits connector-specific next-step guidance (`defenseclaw setup --connector <name>` for non-openclaw paths).
- `docs/INSTALL.md` documents the new flags.

Backward compatibility: bare `curl ... | bash` or `... --yes` still installs OpenClaw + plugin exactly as before.

## Test plan

- [x] `bash -n scripts/install.sh` (syntax OK)
- [x] `bash scripts/install.sh --help` shows new flags
- [x] `bash scripts/install.sh --connector bogus` exits with clear validation error
- [x] `bash scripts/install.sh --no-openclaw --connector openclaw` exits with conflict error
- [ ] Manual: `bash scripts/install.sh --local ./dist --connector codex --yes` lays binaries without npm/plugin (release artifact verification once dist/ available)
- [ ] Manual: `bash scripts/install.sh --local ./dist --connector none --yes` lays binaries only

Refs: S5.1 / F1 (claw-agnostic install)
Stacks on: #163 (parent connector-architecture-v3)