### PR TITLE
feat(cli): setup/quickstart honor install-time picked_connector hint (S8.2 / F32)

### DIFF
--- a/cli/defenseclaw/commands/cmd_quickstart.py
+++ b/cli/defenseclaw/commands/cmd_quickstart.py
@@ -75,11 +75,14 @@ from defenseclaw.context import AppContext
     help="Re-run all steps even if the environment is already initialized.",
 )
 @click.option(
+    "--connector",
     "--agent",
     "agent_name",
     type=click.Choice(["openclaw", "zeptoclaw", "claudecode", "codex"], case_sensitive=False),
     default=None,
-    help="Agent framework connector (default: auto-detect or openclaw).",
+    help="Agent framework connector (alias: --agent). "
+         "Defaults to <data_dir>/picked_connector when set by the installer, "
+         "else auto-detect, else openclaw.",
 )
 @click.option(
     "--skip-gateway",
@@ -109,13 +112,31 @@ def quickstart_cmd(
     from defenseclaw.bootstrap import bootstrap_env
     from defenseclaw.commands.cmd_setup import (
         _detect_openclaw_gateway_token,
+        _read_picked_connector,
         execute_guardrail_setup,
     )
     from defenseclaw.credentials import mask
     from defenseclaw.db import Store
     from defenseclaw.logger import Logger
 
-    connector = agent_name or "openclaw"
+    # Connector resolution mirrors `setup guardrail --non-interactive`:
+    # explicit flag > install-time picked_connector hint > "openclaw".
+    # We deliberately skip filesystem auto-detect here because
+    # quickstart is a non-interactive flow used by `make all` and
+    # `install.sh --quickstart` — silently flipping the connector
+    # because ``~/.claude`` happens to exist on a developer's machine
+    # would surprise both the operator and CI. Resolving here (rather
+    # than inside execute_guardrail_setup) keeps the [3/5] / [4/5] log
+    # lines accurate so the operator sees which connector quickstart
+    # is actually configuring.
+    if agent_name:
+        connector = agent_name
+    else:
+        # We have not loaded the config yet, so use the canonical
+        # default data path. This matches the path the installer
+        # writes to (DEFENSECLAW_HOME or ~/.defenseclaw).
+        data_dir = str(cfg_mod.default_data_path())
+        connector = _read_picked_connector(data_dir) or "openclaw"
 
     click.echo()
     click.echo(f"  DefenseClaw v{__version__} — quickstart")

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -1189,8 +1189,54 @@ _CONNECTOR_META: dict[str, dict[str, str]] = {
 }
 
 
-def _detect_connector() -> str | None:
-    """Guess the active agent framework from filesystem indicators."""
+def _read_picked_connector(data_dir: str | None) -> str | None:
+    """Read the connector hint written by ``scripts/install.sh``.
+
+    The installer records the operator's chosen connector at
+    ``<data_dir>/picked_connector`` (a single-line plaintext file) so
+    that subsequent CLI invocations can default to it without
+    re-prompting. We treat the file as advisory: the canonical runtime
+    value lives in ``guardrail.connector`` once setup has run, but the
+    hint lets the *first* `defenseclaw setup guardrail` after install
+    pick up the operator's intent.
+
+    The function is intentionally tolerant — a missing file, an
+    unreadable file, or an unrecognized value all yield ``None`` so
+    callers can fall through to detection / defaults.
+    """
+    if not data_dir:
+        return None
+    path = os.path.join(data_dir, "picked_connector")
+    try:
+        # Bound the read to defend against a tampered or accidentally
+        # huge file: the legitimate contents are a 4-10 byte connector
+        # name. We never interpret the file as code.
+        with open(path, encoding="utf-8") as fh:
+            raw = fh.read(64)
+    except OSError:
+        return None
+    name = raw.strip().lower()
+    if name in _CONNECTOR_NAMES:
+        return name
+    return None
+
+
+def _detect_connector(data_dir: str | None = None) -> str | None:
+    """Guess the active agent framework, preferring the install-time hint.
+
+    Resolution order:
+      1. ``<data_dir>/picked_connector`` (written by ``scripts/install.sh
+         --connector ...``) — the operator's explicit choice at install
+         time.
+      2. Filesystem heuristics over the agent's own state directories
+         (``~/.claude``, ``~/.codex``, ``~/.zeptoclaw/config.json``).
+
+    Returns ``None`` when neither source is conclusive so the caller
+    can fall back to ``"openclaw"``.
+    """
+    picked = _read_picked_connector(data_dir)
+    if picked:
+        return picked
     home = os.path.expanduser("~")
     if os.path.isdir(os.path.join(home, ".claude")):
         return "claudecode"
@@ -1201,9 +1247,17 @@ def _detect_connector() -> str | None:
     return None
 
 
-def _select_connector_interactive(current: str) -> str:
-    """Present a numbered menu and return the selected connector name."""
-    detected = _detect_connector()
+def _select_connector_interactive(current: str, data_dir: str | None = None) -> str:
+    """Present a numbered menu and return the selected connector name.
+
+    ``data_dir`` is forwarded to ``_detect_connector`` so the install-time
+    ``picked_connector`` hint can seed the menu's default. We only
+    override ``current`` when it is empty or still the historical
+    fallback ("openclaw") — operators who already configured a non-
+    default connector should not see their choice silently flipped by
+    a leftover hint file.
+    """
+    detected = _detect_connector(data_dir)
     default = current
     if not default or default == "openclaw":
         default = detected or "openclaw"
@@ -1260,9 +1314,17 @@ def _print_connector_info(name: str) -> None:
 
 @setup.command("guardrail")
 @click.option("--disable", is_flag=True, help="Disable guardrail and revert OpenClaw config")
-@click.option("--agent", "agent_name",
+# ``--connector`` is the canonical name (matches scripts/install.sh and
+# /v1/connectors). ``--agent`` is kept as an alias for backward
+# compatibility with existing scripts and docs. Both bind to the same
+# ``agent_name`` parameter; supplying both flags will simply use the
+# last one parsed by Click, which is consistent with Click's standard
+# behavior for aliased options.
+@click.option("--connector", "--agent", "agent_name",
               type=click.Choice(_CONNECTOR_NAMES, case_sensitive=False), default=None,
-              help="Agent framework connector (e.g. openclaw, claudecode, codex)")
+              help="Agent framework connector (openclaw, claudecode, codex, zeptoclaw). "
+                   "Alias: --agent. Defaults to <data_dir>/picked_connector when set "
+                   "by the installer, else filesystem auto-detection, else openclaw.")
 @click.option("--mode", "guard_mode", type=click.Choice(["observe", "action"]), default=None,
               help="Guardrail mode")
 @click.option("--scanner-mode", type=click.Choice(["local", "remote"]), default=None,
@@ -1304,10 +1366,14 @@ def setup_guardrail(
     Every prompt and response is inspected for prompt injection, secrets,
     PII, and data exfiltration patterns.
 
-    Use --agent to select the agent framework connector (openclaw,
-    claudecode, codex, etc.). The connector determines how LLM traffic
-    is intercepted, how tool calls are inspected, and what subprocess
-    enforcement policy is applied.
+    Use --connector (alias: --agent) to select the agent framework
+    connector (openclaw, claudecode, codex, zeptoclaw). The connector
+    determines how LLM traffic is intercepted, how tool calls are
+    inspected, and what subprocess enforcement policy is applied. When
+    omitted, the value defaults to the install-time hint at
+    ``<data_dir>/picked_connector`` (written by ``scripts/install.sh
+    --connector ...``), then to any previously saved choice in
+    ``guardrail.connector``, then to ``openclaw``.
 
     Two modes:
       observe — log findings, never block (default, recommended to start)
@@ -1328,8 +1394,26 @@ def setup_guardrail(
     aid = app.cfg.cisco_ai_defense
 
     if non_interactive:
+        # Connector resolution order in non-interactive mode:
+        #   1. explicit --connector / --agent flag (operator intent always wins)
+        #   2. existing gc.connector if already set to a non-default value
+        #      (preserves prior `setup guardrail` choice across re-runs)
+        #   3. <data_dir>/picked_connector hint written by install.sh
+        #      (operator intent at install time)
+        #   4. fallback to "openclaw" (historical default)
+        # We deliberately do NOT run filesystem auto-detect (the
+        # ``~/.claude`` / ``~/.codex`` heuristic) in non-interactive mode:
+        # those directories often pre-exist on developer workstations
+        # and would silently flip the connector behind the operator's
+        # back during scripted installs. Filesystem detection is only
+        # used in the interactive picker where the operator can see and
+        # confirm the suggested default.
         if agent_name:
             gc.connector = agent_name
+        elif not gc.connector or gc.connector == "openclaw":
+            picked = _read_picked_connector(getattr(app.cfg, "data_dir", None))
+            if picked:
+                gc.connector = picked
         gc.mode = guard_mode or gc.mode or "observe"
         gc.scanner_mode = scanner_mode or gc.scanner_mode or "local"
         if cisco_endpoint is not None:
@@ -1537,7 +1621,10 @@ def _interactive_guardrail_setup(
     if agent_name and agent_name in _CONNECTOR_META:
         gc.connector = agent_name
     else:
-        gc.connector = _select_connector_interactive(gc.connector or "openclaw")
+        gc.connector = _select_connector_interactive(
+            gc.connector or "openclaw",
+            data_dir=getattr(app.cfg, "data_dir", None),
+        )
     click.echo()
     _print_connector_info(gc.connector)
     click.echo()

--- a/cli/tests/test_guardrail.py
+++ b/cli/tests/test_guardrail.py
@@ -732,6 +732,58 @@ class TestDetectApiKeyEnvEdgeCases(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# picked_connector hint helper (S8.2 / F32)
+# ---------------------------------------------------------------------------
+
+class TestReadPickedConnector(unittest.TestCase):
+    """Unit tests for _read_picked_connector — the install-time hint reader."""
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix="dclaw-picked-")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def _write(self, contents: str) -> None:
+        with open(os.path.join(self.tmp_dir, "picked_connector"), "w") as f:
+            f.write(contents)
+
+    def test_returns_value_when_file_exists(self):
+        from defenseclaw.commands.cmd_setup import _read_picked_connector
+        self._write("codex\n")
+        self.assertEqual(_read_picked_connector(self.tmp_dir), "codex")
+
+    def test_strips_whitespace_and_lowercases(self):
+        from defenseclaw.commands.cmd_setup import _read_picked_connector
+        self._write("  CODEX  \n")
+        self.assertEqual(_read_picked_connector(self.tmp_dir), "codex")
+
+    def test_returns_none_when_file_missing(self):
+        from defenseclaw.commands.cmd_setup import _read_picked_connector
+        self.assertIsNone(_read_picked_connector(self.tmp_dir))
+
+    def test_returns_none_for_empty_data_dir(self):
+        from defenseclaw.commands.cmd_setup import _read_picked_connector
+        self.assertIsNone(_read_picked_connector(""))
+        self.assertIsNone(_read_picked_connector(None))
+
+    def test_returns_none_for_unknown_value(self):
+        from defenseclaw.commands.cmd_setup import _read_picked_connector
+        self._write("malicious-rm-rf-slash\n")
+        self.assertIsNone(_read_picked_connector(self.tmp_dir))
+
+    def test_caps_read_size_against_huge_files(self):
+        """A pathologically large file must not be slurped into memory."""
+        from defenseclaw.commands.cmd_setup import _read_picked_connector
+        # Pad the file with garbage well beyond the legitimate name.
+        # The reader bounds to 64 bytes so the trailing junk is ignored,
+        # and the leading garbage will not match a connector name —
+        # i.e. we must get None, not a hang or OOM.
+        self._write("x" * (1024 * 1024))
+        self.assertIsNone(_read_picked_connector(self.tmp_dir))
+
+
+# ---------------------------------------------------------------------------
 # setup guardrail CLI command
 # ---------------------------------------------------------------------------
 
@@ -856,6 +908,92 @@ class TestSetupGuardrailCommand(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("Connector: OpenClaw (openclaw)", result.output)
         self.assertIn("Connector setup will run automatically", result.output)
+
+    # ----- picked_connector hint (S8.2 / F32) ----------------------------
+
+    def test_picked_connector_hint_drives_default(self):
+        """`<data_dir>/picked_connector` defaults gc.connector when no flag is given."""
+        from defenseclaw.commands.cmd_setup import setup
+        # Simulate scripts/install.sh --connector codex having recorded
+        # the operator's choice. The CLI should pick it up without
+        # requiring --connector / --agent on every subsequent setup call.
+        with open(os.path.join(self.tmp_dir, "picked_connector"), "w") as f:
+            f.write("codex\n")
+        self.app.cfg.guardrail.model = "anthropic/claude-opus-4-5"
+        self.app.cfg.claw.home_dir = self.tmp_dir
+        result = self.runner.invoke(
+            setup,
+            ["guardrail", "--non-interactive", "--mode", "observe", "--no-restart"],
+            obj=self.app,
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Connector: Codex (codex)", result.output)
+
+    def test_explicit_connector_flag_beats_picked_hint(self):
+        """--connector wins over the install-time picked_connector hint."""
+        from defenseclaw.commands.cmd_setup import setup
+        with open(os.path.join(self.tmp_dir, "picked_connector"), "w") as f:
+            f.write("codex\n")
+        self.app.cfg.guardrail.model = "anthropic/claude-opus-4-5"
+        self.app.cfg.claw.home_dir = self.tmp_dir
+        result = self.runner.invoke(
+            setup,
+            ["guardrail",
+             "--non-interactive", "--connector", "claudecode",
+             "--mode", "observe", "--no-restart"],
+            obj=self.app,
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Connector: Claude Code (claudecode)", result.output)
+
+    def test_agent_alias_still_works(self):
+        """--agent is preserved as an alias of --connector for backward compat."""
+        from defenseclaw.commands.cmd_setup import setup
+        self.app.cfg.guardrail.model = "anthropic/claude-opus-4-5"
+        self.app.cfg.claw.home_dir = self.tmp_dir
+        result = self.runner.invoke(
+            setup,
+            ["guardrail",
+             "--non-interactive", "--agent", "zeptoclaw",
+             "--mode", "observe", "--no-restart"],
+            obj=self.app,
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Connector: ZeptoClaw (zeptoclaw)", result.output)
+
+    def test_picked_connector_hint_invalid_value_is_ignored(self):
+        """Garbage in picked_connector falls back to openclaw, not a crash."""
+        from defenseclaw.commands.cmd_setup import setup
+        with open(os.path.join(self.tmp_dir, "picked_connector"), "w") as f:
+            f.write("not-a-connector\n")
+        self.app.cfg.guardrail.model = "anthropic/claude-opus-4-5"
+        self.app.cfg.claw.home_dir = self.tmp_dir
+        result = self.runner.invoke(
+            setup,
+            ["guardrail", "--non-interactive", "--mode", "observe", "--no-restart"],
+            obj=self.app,
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Connector: OpenClaw (openclaw)", result.output)
+
+    def test_picked_connector_hint_does_not_override_explicit_existing(self):
+        """If gc.connector is already a non-default value, the hint must not flip it."""
+        from defenseclaw.commands.cmd_setup import setup
+        with open(os.path.join(self.tmp_dir, "picked_connector"), "w") as f:
+            f.write("codex\n")
+        # Operator previously ran `setup guardrail --connector zeptoclaw`
+        # and saved it. The picked_connector hint must not silently
+        # downgrade their explicit choice on the next bare re-run.
+        self.app.cfg.guardrail.connector = "zeptoclaw"
+        self.app.cfg.guardrail.model = "anthropic/claude-opus-4-5"
+        self.app.cfg.claw.home_dir = self.tmp_dir
+        result = self.runner.invoke(
+            setup,
+            ["guardrail", "--non-interactive", "--mode", "observe", "--no-restart"],
+            obj=self.app,
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Connector: ZeptoClaw (zeptoclaw)", result.output)
 
     def test_shows_disable_instructions(self):
         from defenseclaw.commands.cmd_setup import setup


### PR DESCRIPTION
## Summary

Wire the install-time connector hint (`<data_dir>/picked_connector`, written by `scripts/install.sh --connector ...` from #170) into the Python CLI so `defenseclaw setup guardrail` and `defenseclaw quickstart` default to the operator's chosen connector without requiring a second flag pass.

- New `_read_picked_connector(data_dir)` helper validates against `_CONNECTOR_NAMES`, caps the read at 64 bytes (defense against a tampered / oversized file), and treats anything unreadable/unrecognized as advisory-only.
- Non-interactive precedence: `--connector` / `--agent` flag → existing non-default `guardrail.connector` → `picked_connector` hint → `openclaw`. Filesystem auto-detect (`~/.claude`, `~/.codex`, …) is intentionally **not** used in non-interactive flows to avoid silently flipping connectors on developer workstations / CI.
- Interactive picker still seeds its default from the hint (via `_detect_connector`) but the menu confirmation keeps auto-detect surprises opt-in.
- `--connector` added as the canonical flag on both `setup guardrail` and `quickstart`. `--agent` preserved as an alias for backward compat.

## Test plan

- [x] `cli/tests/test_guardrail.py::TestReadPickedConnector` — 6 unit tests (happy path, whitespace/case, missing file, empty `data_dir`, unknown value, 64-byte read cap).
- [x] `TestSetupGuardrailCommand` — 5 new integration tests:
  - hint defaults `gc.connector` when no flag given
  - explicit `--connector` beats the hint
  - `--agent` alias still resolves
  - garbage in hint falls back to openclaw, no crash
  - existing non-default `guardrail.connector` not overridden by hint
- [x] Full CLI suite: `1178 passed, 1 skipped` (was 1167, +11 new).

Refs: S8.2 / F32
Stacks on: #163 (parent), follow-up to #170 (install.sh `--connector`)