### PR TITLE
fix(gateway): fail-fast on unknown guardrail.connector (S1.4 / F7)

### DIFF
--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -591,16 +591,21 @@ func (s *Sidecar) runWatcher(ctx context.Context) error {
 	// Resolve the active connector to get connector-specific component
 	// directories. Falls back to cfg.SkillDirs()/PluginDirs() (OpenClaw
 	// paths) when the connector does not implement ComponentScanner.
+	// Unlike runGuardrail, the watcher is best-effort discovery: a
+	// misspelled guardrail.connector here should still be caught at
+	// runGuardrail's fail-fast check (see S1.4), so we log the error
+	// and fall back rather than aborting the watcher loop. That keeps
+	// the watcher useful for the OpenClaw default flow even while a
+	// freshly-broken connector name is being debugged.
 	var compTargets map[string][]string
-	connectorName := s.cfg.Guardrail.Connector
-	if connectorName == "" {
-		connectorName = "openclaw"
-	}
 	reg := connector.NewDefaultRegistry()
-	if conn, ok := reg.Get(connectorName); ok {
+	conn, err := resolveActiveConnector(reg, s.cfg.Guardrail.Connector, "watcher")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[sidecar] watcher: connector resolution: %v\n", err)
+	} else if conn != nil {
 		if scanner, ok := conn.(connector.ComponentScanner); ok && scanner.SupportsComponentScanning() {
 			compTargets = scanner.ComponentTargets("")
-			fmt.Fprintf(os.Stderr, "[sidecar] watcher: using %s connector ComponentTargets\n", connectorName)
+			fmt.Fprintf(os.Stderr, "[sidecar] watcher: using %s connector ComponentTargets\n", conn.Name())
 		}
 	}
 
@@ -674,9 +679,9 @@ func (s *Sidecar) runWatcher(ctx context.Context) error {
 		"mcp_take_action":    wcfg.MCP.TakeAction,
 	})
 
-	err := w.Run(ctx)
+	runErr := w.Run(ctx)
 	s.health.SetWatcher(StateStopped, "", nil)
-	return err
+	return runErr
 }
 
 // handleAdmissionResult processes watcher verdicts. It only forwards runtime
@@ -937,6 +942,45 @@ func (s *Sidecar) activeSessionKeys() []string {
 	return s.router.ActiveSessionKeys()
 }
 
+// resolveActiveConnector looks up the active connector in the registry
+// with a strict-but-friendly contract:
+//
+//   - Empty name: log INFO and return the openclaw default. This
+//     preserves backward compatibility with installs that predate the
+//     guardrail.connector field while still announcing the choice in
+//     the log so operators can see what was actually picked.
+//   - Non-empty name that the registry knows: return it.
+//   - Non-empty name that the registry does NOT know: return an error.
+//     This is the operator-typo case the silent "fall back to openclaw"
+//     branch used to mask. Returning an error lets callers decide
+//     whether the failure mode is "abort" (runGuardrail) or "log and
+//     continue with reduced functionality" (the watcher) without
+//     losing the typo signal in either case.
+//
+// surface is a short label included in log messages so operators can
+// tell which subsystem (runGuardrail / watcher / etc.) emitted the
+// resolution event.
+func resolveActiveConnector(reg *connector.Registry, name, surface string) (connector.Connector, error) {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		conn, ok := reg.Get("openclaw")
+		if !ok {
+			// The default connector is registered by NewDefaultRegistry,
+			// so the only way to get here is if a custom registry was
+			// passed in without it. Surface as an error rather than
+			// returning nil to avoid silent behavior downstream.
+			return nil, fmt.Errorf("[%s] no openclaw default in registry; pass an explicit guardrail.connector", surface)
+		}
+		fmt.Fprintf(os.Stderr, "[%s] guardrail.connector unset; defaulting to openclaw\n", surface)
+		return conn, nil
+	}
+	conn, ok := reg.Get(trimmed)
+	if !ok {
+		return nil, fmt.Errorf("[%s] guardrail.connector=%q not found in registry — set guardrail.connector to one of the registered connectors (openclaw, codex, claudecode, zeptoclaw) or remove the field to default to openclaw", surface, trimmed)
+	}
+	return conn, nil
+}
+
 // runGuardrail starts the Go guardrail proxy when guardrail is enabled.
 func (s *Sidecar) runGuardrail(ctx context.Context) error {
 	// Reuse the rule pack already loaded by NewSidecar and stored on the
@@ -949,22 +993,28 @@ func (s *Sidecar) runGuardrail(ctx context.Context) error {
 	}
 
 	// Load the active connector from the registry. The connector name is
-	// written by `defenseclaw setup` into guardrail.connector (defaults
-	// to "openclaw" for backward compat).
+	// written by `defenseclaw setup` into guardrail.connector. When the
+	// field is empty we treat that as "operator did not pick anything"
+	// and fall back to openclaw for backward compatibility (and log it
+	// at INFO so the operator can see what happened). When the field is
+	// set to a value the registry does not know about, we fail fast
+	// rather than silently substituting openclaw — silent substitution
+	// would let a typo in `guardrail.connector` route Codex / Claude
+	// Code traffic through the OpenClaw connector and patch the wrong
+	// agent's config files. See S1.4 / F7.
 	registry := connector.NewDefaultRegistry()
 	if s.cfg.PluginDir != "" {
 		if err := registry.DiscoverPlugins(s.cfg.PluginDir); err != nil {
 			fmt.Fprintf(os.Stderr, "[guardrail] plugin discovery: %v\n", err)
 		}
 	}
-	connectorName := s.cfg.Guardrail.Connector
-	if connectorName == "" {
-		connectorName = "openclaw"
-	}
-	conn, ok := registry.Get(connectorName)
-	if !ok {
-		fmt.Fprintf(os.Stderr, "[guardrail] WARNING: connector %q not found in registry, falling back to openclaw\n", connectorName)
-		conn, _ = registry.Get("openclaw")
+	conn, err := resolveActiveConnector(registry, s.cfg.Guardrail.Connector, "guardrail")
+	if err != nil {
+		// Fail fast: the operator explicitly set a connector that does
+		// not exist. Returning here aborts sidecar boot so the operator
+		// notices the typo immediately instead of seeing a "running but
+		// somehow not blocking anything" sidecar.
+		return err
 	}
 	proxyAddr := guardrailListenAddr(s.cfg.Guardrail.Port, s.cfg.Guardrail.Host)
 	apiBind := "127.0.0.1"
@@ -986,33 +1036,35 @@ func (s *Sidecar) runGuardrail(ctx context.Context) error {
 		APIToken: s.cfg.Gateway.ResolvedToken(),
 	}
 
-	if conn != nil {
-		fmt.Fprintf(os.Stderr, "[guardrail] active connector: %s (%s)\n", conn.Name(), conn.Description())
+	// resolveActiveConnector guarantees a non-nil connector — either the
+	// operator-selected one or the openclaw default. We can therefore
+	// drop the historical nil-guard and treat this as the canonical
+	// path; any "no active connector" condition is now a hard error.
+	fmt.Fprintf(os.Stderr, "[guardrail] active connector: %s (%s)\n", conn.Name(), conn.Description())
 
-		if !s.cfg.Guardrail.Enabled {
-			fmt.Fprintf(os.Stderr, "[guardrail] guardrail disabled — running connector teardown for %s\n", conn.Name())
-			if err := conn.Teardown(ctx, setupOpts); err != nil {
-				fmt.Fprintf(os.Stderr, "[guardrail] connector teardown: %v\n", err)
-			}
-			if err := conn.VerifyClean(setupOpts); err != nil {
-				fmt.Fprintf(os.Stderr, "[guardrail] WARNING: teardown of %s left stale state: %v\n", conn.Name(), err)
-			}
-			connector.ClearActiveConnector(s.cfg.DataDir)
+	if !s.cfg.Guardrail.Enabled {
+		fmt.Fprintf(os.Stderr, "[guardrail] guardrail disabled — running connector teardown for %s\n", conn.Name())
+		if err := conn.Teardown(ctx, setupOpts); err != nil {
+			fmt.Fprintf(os.Stderr, "[guardrail] connector teardown: %v\n", err)
+		}
+		if err := conn.VerifyClean(setupOpts); err != nil {
+			fmt.Fprintf(os.Stderr, "[guardrail] WARNING: teardown of %s left stale state: %v\n", conn.Name(), err)
+		}
+		connector.ClearActiveConnector(s.cfg.DataDir)
+	} else {
+		if err := teardownPreviousConnector(registry, conn.Name(), setupOpts, ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "[guardrail] WARNING: proceeding with %s setup despite stale state from previous connector\n", conn.Name())
+		}
+		if err := conn.Setup(ctx, setupOpts); err != nil {
+			fmt.Fprintf(os.Stderr, "[guardrail] connector setup %s failed: %v — connector may not be fully initialized\n", conn.Name(), err)
 		} else {
-			if err := teardownPreviousConnector(registry, conn.Name(), setupOpts, ctx); err != nil {
-				fmt.Fprintf(os.Stderr, "[guardrail] WARNING: proceeding with %s setup despite stale state from previous connector\n", conn.Name())
-			}
-			if err := conn.Setup(ctx, setupOpts); err != nil {
-				fmt.Fprintf(os.Stderr, "[guardrail] connector setup %s failed: %v — connector may not be fully initialized\n", conn.Name(), err)
-			} else {
-				if err := connector.SaveActiveConnector(s.cfg.DataDir, conn.Name()); err != nil {
-					fmt.Fprintf(os.Stderr, "[guardrail] save active connector state: %v\n", err)
-				}
+			if err := connector.SaveActiveConnector(s.cfg.DataDir, conn.Name()); err != nil {
+				fmt.Fprintf(os.Stderr, "[guardrail] save active connector state: %v\n", err)
 			}
 		}
-
-		s.health.SetConnector(conn.Name(), conn.ToolInspectionMode(), conn.SubprocessPolicy())
 	}
+
+	s.health.SetConnector(conn.Name(), conn.ToolInspectionMode(), conn.SubprocessPolicy())
 
 	proxy, err := NewGuardrailProxy(
 		&s.cfg.Guardrail,

--- a/internal/gateway/sidecar_test.go
+++ b/internal/gateway/sidecar_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
+)
+
+// TestResolveActiveConnector_EmptyDefaultsToOpenClaw verifies the
+// "operator did not pick anything" branch of S1.4: an empty
+// guardrail.connector still works (back-compat) but emits an audible
+// "defaulting to openclaw" log line. The test asserts the resolver
+// returns the openclaw entry rather than nil so callers can rely on
+// the contract.
+func TestResolveActiveConnector_EmptyDefaultsToOpenClaw(t *testing.T) {
+	t.Parallel()
+	reg := connector.NewDefaultRegistry()
+
+	conn, err := resolveActiveConnector(reg, "", "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if conn == nil {
+		t.Fatalf("expected non-nil openclaw default, got nil")
+	}
+	if got := conn.Name(); got != "openclaw" {
+		t.Errorf("connector name = %q, want %q", got, "openclaw")
+	}
+}
+
+// TestResolveActiveConnector_WhitespaceTreatedAsEmpty pins the
+// "trim before lookup" behavior. Without this, a stray space in
+// guardrail.connector ("   " from a hand-edited config) would hit
+// the unknown-connector error path and abort the sidecar even
+// though the operator intent is clearly "use the default".
+func TestResolveActiveConnector_WhitespaceTreatedAsEmpty(t *testing.T) {
+	t.Parallel()
+	reg := connector.NewDefaultRegistry()
+
+	conn, err := resolveActiveConnector(reg, "   ", "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if conn == nil || conn.Name() != "openclaw" {
+		t.Fatalf("whitespace name should default to openclaw, got %v", conn)
+	}
+}
+
+// TestResolveActiveConnector_KnownNameReturnsConnector covers the
+// happy path for each of the four built-in connectors. We don't
+// just spot-check one — the registry contract for S1.4 is "every
+// name DefaultRegistry advertises must resolve cleanly", so we
+// drive the assertion off the same list the registry exposes.
+func TestResolveActiveConnector_KnownNameReturnsConnector(t *testing.T) {
+	t.Parallel()
+	reg := connector.NewDefaultRegistry()
+
+	for _, name := range []string{"openclaw", "codex", "claudecode", "zeptoclaw"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			conn, err := resolveActiveConnector(reg, name, "test")
+			if err != nil {
+				t.Fatalf("resolveActiveConnector(%q) err: %v", name, err)
+			}
+			if conn == nil {
+				t.Fatalf("resolveActiveConnector(%q) returned nil", name)
+			}
+			if got := conn.Name(); got != name {
+				t.Errorf("Name() = %q, want %q", got, name)
+			}
+		})
+	}
+}
+
+// TestResolveActiveConnector_UnknownNameReturnsError is the core
+// security-relevant assertion of S1.4: a misspelled connector
+// name (e.g. "claud-code", "code", "zclaw") must NOT silently
+// substitute openclaw. Doing so would patch the wrong agent's
+// config files and route Codex / Claude Code traffic through the
+// OpenClaw connector — exactly the kind of confused-deputy
+// behavior F7 was filed for.
+func TestResolveActiveConnector_UnknownNameReturnsError(t *testing.T) {
+	t.Parallel()
+	reg := connector.NewDefaultRegistry()
+
+	// NOTE: "openclaw " (trailing space) is intentionally NOT here —
+	// resolveActiveConnector trims whitespace before lookup so a
+	// stray space in a hand-edited config still resolves to the
+	// expected connector. Add only values that should be rejected
+	// after trimming.
+	for _, bad := range []string{"claud-code", "openclaws", "codeX", "rm -rf /"} {
+		bad := bad
+		t.Run(bad, func(t *testing.T) {
+			t.Parallel()
+			conn, err := resolveActiveConnector(reg, bad, "test")
+			if err == nil {
+				t.Fatalf("resolveActiveConnector(%q) expected error, got conn=%v", bad, conn)
+			}
+			if conn != nil {
+				t.Fatalf("resolveActiveConnector(%q) must return nil connector on error, got %s", bad, conn.Name())
+			}
+			// Error text must name the bad value so operators can find
+			// it in logs. We also explicitly call out openclaw as the
+			// remediation default — the message is part of the
+			// operator-facing contract for S1.4.
+			if !strings.Contains(err.Error(), "openclaw") {
+				t.Errorf("error message should mention the openclaw default, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestResolveActiveConnector_SurfaceTagInError ensures the surface
+// label flows into both the success log line and the error message.
+// A future refactor that drops the parameter would lose the ability
+// to distinguish runGuardrail-level failures from watcher-level
+// failures in operator logs; this test pins the contract.
+func TestResolveActiveConnector_SurfaceTagInError(t *testing.T) {
+	t.Parallel()
+	reg := connector.NewDefaultRegistry()
+
+	_, err := resolveActiveConnector(reg, "definitely-not-a-connector", "watcher")
+	if err == nil {
+		t.Fatalf("expected error for unknown connector")
+	}
+	if !strings.Contains(err.Error(), "watcher") {
+		t.Errorf("error should be tagged with surface 'watcher', got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Replace silent "fall back to openclaw" behavior with strict-but-friendly resolution at the two sidecar sites that read `guardrail.connector`:

- New `resolveActiveConnector(reg, name, surface)` helper.
- Empty / whitespace input → logs and returns openclaw default (back-compat).
- Known input → returns it.
- Unknown input → returns an error naming the bad value and the remediation options. `runGuardrail` aborts on this; the watcher logs and continues with no `ComponentTargets`.
- Drops the now-dead `if conn != nil` nil-guard in `runGuardrail`.

Without this, a typo in `guardrail.connector` (e.g. "claud-code" instead of "claudecode") silently routes Codex / Claude Code traffic through the OpenClaw connector and patches the wrong agent's config files.

## Test plan

- [x] `internal/gateway/sidecar_test.go::TestResolveActiveConnector_*` — 5 new cases covering empty, whitespace, known, unknown, and surface-tagged error.
- [x] All existing connector + sidecar tests pass.

Refs: S1.4 / F7
Stacks on: #163