### PR TITLE
fix(connector/codex): atomic + 0o600 writes for ~/.codex/config.toml (S0.11 / S0.15)

### DIFF
--- a/internal/gateway/connector/codex.go
+++ b/internal/gateway/connector/codex.go
@@ -508,10 +508,15 @@ func (c *CodexConnector) patchCodexConfig(opts SetupOpts, hookScript string) err
 	if err != nil {
 		return fmt.Errorf("marshal codex config: %w", err)
 	}
+	// Atomic + 0o600: a partial write of config.toml can brick Codex
+	// (it's the only file Codex reads at startup), and the file may
+	// carry env-var bindings that resolve to provider API keys at
+	// runtime. atomicWriteFile uses CreateTemp + Rename + Chmod so a
+	// crash mid-write leaves the previous config in place. See S0.11.
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		return fmt.Errorf("create codex config dir: %w", err)
 	}
-	if err := os.WriteFile(configPath, out, 0o644); err != nil {
+	if err := atomicWriteFile(configPath, out, 0o600); err != nil {
 		return fmt.Errorf("write codex config: %w", err)
 	}
 
@@ -629,7 +634,11 @@ func (c *CodexConnector) restoreCodexConfig(opts SetupOpts) {
 	}
 
 	if out, err := toml.Marshal(cfg); err == nil {
-		_ = os.WriteFile(configPath, out, 0o644)
+		// Best-effort restore path: if rewrite fails we leave the
+		// existing (already-patched) config in place rather than the
+		// half-written attempt. atomicWriteFile guarantees that
+		// invariant. See S0.11.
+		_ = atomicWriteFile(configPath, out, 0o600)
 	}
 
 	// Remove any stale hooks.json from an earlier version that

--- a/internal/gateway/connector/connector_test.go
+++ b/internal/gateway/connector/connector_test.go
@@ -1188,6 +1188,51 @@ env_key = "OPENAI_API_KEY"
 	}
 }
 
+// TestCodex_Setup_ConfigTomlIsModeChmod600 pins the file mode of
+// the patched ~/.codex/config.toml. Codex's config.toml carries
+// env_key bindings and (after Setup) the DefenseClaw proxy URL. On
+// shared dev hosts the historical 0o644 mode let any local user
+// read those bindings — which is enough to derive provider keys
+// from the matching env files. S0.15 / S0.11: the patcher must
+// write the file via atomicWriteFile at 0o600.
+//
+// Note: the test runs *after* Setup, so it asserts the mode of
+// the rewritten file (the input we wrote at 0o644 above is fine —
+// Setup must clobber both the contents and the mode).
+func TestCodex_Setup_ConfigTomlIsModeChmod600(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	original := `model_provider = "openai"
+
+[model_providers.openai]
+name = "openai"
+base_url = "https://api.openai.com/v1"
+env_key = "OPENAI_API_KEY"
+`
+	if err := os.WriteFile(configPath, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	CodexConfigPathOverride = configPath
+	defer func() { CodexConfigPathOverride = "" }()
+
+	c := NewCodexConnector()
+	opts := SetupOpts{DataDir: dir, ProxyAddr: "127.0.0.1:4000", APIAddr: "127.0.0.1:18970"}
+	if err := c.Setup(nil, opts); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat config.toml: %v", err)
+	}
+	// Mask off the file-type bits — only the permission bits matter
+	// here. We assert exactly 0o600: any group/world bit means a
+	// shared-host user can read provider env-var names + base URLs.
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("config.toml mode = %#o, want 0o600", mode)
+	}
+}
+
 // TestCodex_Setup_RegistersHooksInline verifies the Codex connector
 // writes an inline [hooks] HookEventsToml struct into config.toml
 // covering all five Codex events and pointing at the generated


### PR DESCRIPTION
## Summary

The four backup files (zeptoclaw_backup.json, codex_backup.json, codex_config_backup.json, claudecode_backup.json) already write at 0o600 via atomicWriteFile. The patchers for openclaw.json, zeptoclaw config.json, and Claude Code settings.json route through atomicWriteFile too. The two Codex config.toml writes were the last holdouts — non-atomic and 0o644.

This PR routes both Codex config.toml writes (Setup + Teardown) through atomicWriteFile at 0o600. Pins the contract with TestCodex_Setup_ConfigTomlIsModeChmod600.

## Test plan

- [x] `go test -count=1 ./internal/gateway/connector/...`
- [x] New `TestCodex_Setup_ConfigTomlIsModeChmod600` passes.

Refs: S0.11 / S0.15