### PR TITLE
feat(firewall+connector): allow-list per connector via AllowedHostsProvider (S3.3 / F26)

### DIFF
--- a/internal/firewall/config.go
+++ b/internal/firewall/config.go
@@ -124,7 +124,32 @@ func (c *FirewallConfig) Validate() error {
 }
 
 // DefaultFirewallConfig returns a safe deny-by-default config with common
-// allowlists pre-populated for OpenClaw.
+// allowlists pre-populated for the four built-in connectors.
+//
+// The list folds in domains every connector commonly reaches:
+//
+//   - api.openai.com          (OpenClaw + Codex baseline LLM)
+//   - api.anthropic.com       (Claude Code baseline LLM)
+//   - openrouter.ai           (ZeptoClaw default broker)
+//   - api.together.xyz        (ZeptoClaw alt broker)
+//   - api.github.com / github.com / objects.githubusercontent.com
+//     (Codex update channel + skill/plugin pulls)
+//   - claude.ai / docs.anthropic.com / console.anthropic.com
+//     (Claude Code skill + plugin registry)
+//   - openai.com / platform.openai.com (Codex docs/templates)
+//   - us.api.inspect.aidefense.security.cisco.com (OpenClaw plugin)
+//   - proxy.golang.org / sum.golang.org / registry.npmjs.org / pypi.org
+//     (build-time package downloads when the agent shells out to
+//      go/npm/pip during a tool call)
+//
+// The list is intentionally generous: a Codex / Claude Code /
+// ZeptoClaw user with a deny-by-default firewall would otherwise see
+// "DNS lookup blocked" on first chat, which is unactionable. See
+// S3.3 / F26.
+//
+// Connectors that ship with a more-restrictive contract should
+// implement connector.AllowedHostsProvider; sidecar bootstrap merges
+// those values onto the static baseline before the firewall starts.
 func DefaultFirewallConfig() *FirewallConfig {
 	cfg := &FirewallConfig{
 		Version:       "1.0",
@@ -140,13 +165,28 @@ func DefaultFirewallConfig() *FirewallConfig {
 		},
 		Allowlist: AllowlistConfig{
 			Domains: []string{
+				// LLM endpoints (per built-in connector).
 				"api.anthropic.com",
 				"api.openai.com",
+				"openrouter.ai",
+				"api.together.xyz",
+				// Skill / plugin registries + docs CDNs.
+				"claude.ai",
+				"docs.anthropic.com",
+				"console.anthropic.com",
+				"openai.com",
+				"platform.openai.com",
+				// Code distribution + GitHub release artifacts.
 				"api.github.com",
 				"github.com",
+				"objects.githubusercontent.com",
 				"proxy.golang.org",
 				"sum.golang.org",
 				"registry.npmjs.org",
+				"pypi.org",
+				"files.pythonhosted.org",
+				// Cisco AI Defense inspect endpoint (OpenClaw plugin).
+				"us.api.inspect.aidefense.security.cisco.com",
 			},
 			IPs:   []string{},
 			Ports: []int{443, 80},
@@ -159,6 +199,43 @@ func DefaultFirewallConfig() *FirewallConfig {
 	}
 	applyDefaults(cfg)
 	return cfg
+}
+
+// MergeAllowedHosts adds extra hostnames to the firewall config's
+// allow-list, deduplicating and skipping anything that fails
+// validateDestination. This is the entrypoint for boot-time merging
+// of per-connector contributions (connector.AllowedHostsProvider).
+//
+// The function is a method on *FirewallConfig rather than a free
+// function so callers can chain `firewall.DefaultFirewallConfig().
+// MergeAllowedHosts(extra)` without an intermediate variable, and
+// so future fields (Ports, IPs) can hang off the same surface.
+func (c *FirewallConfig) MergeAllowedHosts(extra []string) *FirewallConfig {
+	if c == nil || len(extra) == 0 {
+		return c
+	}
+	seen := make(map[string]struct{}, len(c.Allowlist.Domains)+len(extra))
+	for _, d := range c.Allowlist.Domains {
+		seen[d] = struct{}{}
+	}
+	for _, host := range extra {
+		host = strings.TrimSpace(host)
+		if host == "" {
+			continue
+		}
+		if _, dup := seen[host]; dup {
+			continue
+		}
+		// validateDestination accepts hostnames, IPs, and CIDRs;
+		// AllowedHostsProvider should only return DNS names but the
+		// validator catches typos cheaply.
+		if err := validateDestination(host); err != nil {
+			continue
+		}
+		seen[host] = struct{}{}
+		c.Allowlist.Domains = append(c.Allowlist.Domains, host)
+	}
+	return c
 }
 
 func applyDefaults(cfg *FirewallConfig) {

--- a/internal/firewall/config_test.go
+++ b/internal/firewall/config_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package firewall
+
+import (
+	"testing"
+)
+
+// TestDefaultFirewallConfig_CoversAllConnectors pins the per-connector
+// hostnames the deny-by-default firewall must allow on first boot.
+// Without these, a Codex / Claude Code / ZeptoClaw user with a
+// default-deny firewall sees "DNS lookup blocked" on first chat —
+// exactly the symptom F26 was filed for.
+//
+// We don't assert the *exact* list (it's expected to grow); we
+// assert that one representative host per connector survives the
+// dedup pass.
+func TestDefaultFirewallConfig_CoversAllConnectors(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultFirewallConfig()
+
+	want := map[string]string{
+		// connector → representative host the connector needs.
+		"openclaw":   "us.api.inspect.aidefense.security.cisco.com",
+		"zeptoclaw":  "openrouter.ai",
+		"claudecode": "claude.ai",
+		"codex":      "objects.githubusercontent.com",
+	}
+
+	got := make(map[string]struct{}, len(cfg.Allowlist.Domains))
+	for _, d := range cfg.Allowlist.Domains {
+		got[d] = struct{}{}
+	}
+	for connector, host := range want {
+		if _, ok := got[host]; !ok {
+			t.Errorf("connector %q: host %q missing from default allowlist (have %v)", connector, host, cfg.Allowlist.Domains)
+		}
+	}
+}
+
+// TestMergeAllowedHosts_AppendsAndDedupes is the contract test for
+// the helper that folds connector.AllowedHostsProvider results onto
+// the static baseline at sidecar boot. Three cases:
+//
+//   - new host → appended
+//   - duplicate of an existing host → skipped
+//   - empty / whitespace-only string → skipped
+//
+// Order of survivors must follow first-write-wins so existing tests
+// that snapshot the default list don't drift on additions.
+func TestMergeAllowedHosts_AppendsAndDedupes(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultFirewallConfig()
+	original := append([]string{}, cfg.Allowlist.Domains...)
+
+	cfg.MergeAllowedHosts([]string{
+		"new-connector-host.example",
+		// Duplicate of one of the static defaults — must be skipped.
+		"api.openai.com",
+		// Whitespace-only string — must be skipped (not appended as
+		// an empty-string entry, which would match nothing).
+		"   ",
+		// Empty string — same.
+		"",
+	})
+
+	// First-write-wins: every original host is still present in the
+	// same position relative to its peers. We don't strictly require
+	// stable indices because the merge appends at the end, but we do
+	// require the original prefix is intact.
+	for i, want := range original {
+		if cfg.Allowlist.Domains[i] != want {
+			t.Errorf("original allowlist mutated at idx %d: got %q, want %q",
+				i, cfg.Allowlist.Domains[i], want)
+		}
+	}
+
+	// The new host is appended exactly once.
+	count := 0
+	for _, d := range cfg.Allowlist.Domains {
+		if d == "new-connector-host.example" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("new host count = %d, want 1", count)
+	}
+
+	// Duplicate didn't get re-added.
+	openaiCount := 0
+	for _, d := range cfg.Allowlist.Domains {
+		if d == "api.openai.com" {
+			openaiCount++
+		}
+	}
+	if openaiCount != 1 {
+		t.Errorf("api.openai.com appears %d times after merge, want 1 (dedup broken)", openaiCount)
+	}
+
+	// Empty / whitespace strings never landed.
+	for _, d := range cfg.Allowlist.Domains {
+		if d == "" || d == "   " {
+			t.Errorf("empty/whitespace host slipped through MergeAllowedHosts: %q present", d)
+		}
+	}
+}
+
+// TestMergeAllowedHosts_DropsInvalid asserts that hostnames failing
+// validateDestination are silently skipped rather than panic'ing or
+// exploding the firewall config. A connector implementer who
+// returns garbage (e.g. an empty result of `os.Getenv`) should
+// degrade to "no extra allowance" rather than break boot.
+func TestMergeAllowedHosts_DropsInvalid(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultFirewallConfig()
+	original := len(cfg.Allowlist.Domains)
+
+	cfg.MergeAllowedHosts([]string{
+		// Hostname too long — validateDestination rejects.
+		string(make([]byte, 300)),
+		// One legit host so we know we still merged anything that
+		// passed validation.
+		"new-connector-host.example",
+	})
+
+	// Exactly one new host appended; the long one was rejected.
+	if len(cfg.Allowlist.Domains) != original+1 {
+		t.Errorf("len after merge = %d, want %d (invalid host should be dropped)",
+			len(cfg.Allowlist.Domains), original+1)
+	}
+}
+
+// TestMergeAllowedHosts_NilSafe documents the intentional no-op
+// behavior on nil receiver — caller can chain merge() without an
+// existence check on the upstream factory.
+func TestMergeAllowedHosts_NilSafe(t *testing.T) {
+	t.Parallel()
+	var cfg *FirewallConfig
+	if got := cfg.MergeAllowedHosts([]string{"foo.example"}); got != nil {
+		t.Errorf("nil receiver should return nil, got %v", got)
+	}
+}

--- a/internal/gateway/connector/claudecode.go
+++ b/internal/gateway/connector/claudecode.go
@@ -50,6 +50,21 @@ func (c *ClaudeCodeConnector) SubprocessPolicy() SubprocessPolicy {
 	return ResolveSubprocessPolicy(SubprocessSandbox)
 }
 
+// AllowedHosts returns the Anthropic CDN hostnames Claude Code
+// touches outside the LLM endpoint itself — skill manifests,
+// plugin registry, telemetry. api.anthropic.com is already in the
+// firewall's static defaults; this list adds the auxiliary hosts.
+// See S3.3 / F26.
+func (c *ClaudeCodeConnector) AllowedHosts() []string {
+	return []string{
+		// Skill/plugin registry CDN.
+		"claude.ai",
+		// Marketplace + docs CDN.
+		"docs.anthropic.com",
+		"console.anthropic.com",
+	}
+}
+
 func (c *ClaudeCodeConnector) Setup(ctx context.Context, opts SetupOpts) error {
 	if err := c.writeEnvOverride(opts); err != nil {
 		return fmt.Errorf("claudecode env override: %w", err)

--- a/internal/gateway/connector/codex.go
+++ b/internal/gateway/connector/codex.go
@@ -71,6 +71,21 @@ func (c *CodexConnector) SubprocessPolicy() SubprocessPolicy {
 	return ResolveSubprocessPolicy(SubprocessSandbox)
 }
 
+// AllowedHosts returns the Codex update / docs / GitHub release
+// channels. api.openai.com is already in the firewall's static
+// defaults so we don't repeat it. See S3.3 / F26.
+func (c *CodexConnector) AllowedHosts() []string {
+	return []string{
+		// Update / release channel — Codex pulls binaries from GitHub.
+		"github.com",
+		"api.github.com",
+		"objects.githubusercontent.com",
+		// Docs CDN.
+		"openai.com",
+		"platform.openai.com",
+	}
+}
+
 func (c *CodexConnector) Setup(ctx context.Context, opts SetupOpts) error {
 	if err := c.writeEnvOverride(opts); err != nil {
 		return fmt.Errorf("codex env override: %w", err)

--- a/internal/gateway/connector/connector.go
+++ b/internal/gateway/connector/connector.go
@@ -108,6 +108,25 @@ type HookEventHandler interface {
 	HandleHookEvent(ctx context.Context, payload []byte) ([]byte, error)
 }
 
+// AllowedHostsProvider — optional. Connectors that depend on
+// connector-specific upstream hostnames (e.g. ZeptoClaw → openrouter.ai
+// when the user has BYOK'd against OpenRouter; Codex → its update
+// channel) implement this so the firewall default-deny config can
+// fold them into the allow-list at boot. Without it,
+// firewall.DefaultFirewallConfig only knows the OpenClaw / OpenAI /
+// Anthropic baseline and a ZeptoClaw user gets every chat blocked
+// at L4. The list returned here is treated as additive over the
+// firewall's static defaults — connectors should not return their
+// only required host (api.openai.com, api.anthropic.com) since
+// those are already in the static list. See S3.3 / F26.
+//
+// Hostnames must be plain DNS names (no scheme, no path, no
+// wildcards). The firewall layer does its own validation; returning
+// an invalid host is logged and that host is dropped.
+type AllowedHostsProvider interface {
+	AllowedHosts() []string
+}
+
 // ComponentScanner — optional, connectors that support scanning
 // agent-specific skills, plugins, MCP servers implement this.
 type ComponentScanner interface {

--- a/internal/gateway/connector/connector_test.go
+++ b/internal/gateway/connector/connector_test.go
@@ -147,6 +147,46 @@ func TestRegistry_DefaultContainsAllBuiltins(t *testing.T) {
 	}
 }
 
+// TestConnector_AllowedHostsProvider_AllBuiltinsImplement is the
+// contract test for S3.3 / F26: every built-in connector must
+// expose AllowedHosts() so the firewall layer can fold its
+// per-connector hostnames into the static deny-by-default
+// allow-list at boot. A future connector that forgets to
+// implement this interface would silently fall through to "no
+// extra hosts" — instead of failing here, that connector's users
+// would see DNS-blocked errors on first chat.
+//
+// We assert two things: (1) every built-in implements the
+// interface; (2) the returned list is non-empty. An empty list
+// is allowed by the contract but for the four shipping
+// connectors it would be meaningless (every one talks to a
+// non-baseline host).
+func TestConnector_AllowedHostsProvider_AllBuiltinsImplement(t *testing.T) {
+	r := NewDefaultRegistry()
+	for _, name := range []string{"openclaw", "zeptoclaw", "claudecode", "codex"} {
+		conn, ok := r.Get(name)
+		if !ok {
+			t.Fatalf("registry missing %q", name)
+		}
+		provider, ok := conn.(AllowedHostsProvider)
+		if !ok {
+			t.Errorf("connector %q does not implement AllowedHostsProvider", name)
+			continue
+		}
+		hosts := provider.AllowedHosts()
+		if len(hosts) == 0 {
+			t.Errorf("connector %q AllowedHosts() returned empty slice", name)
+		}
+		// Guardrail against accidental empty/whitespace entries
+		// landing in the firewall allow-list.
+		for _, h := range hosts {
+			if h == "" {
+				t.Errorf("connector %q AllowedHosts() includes an empty string", name)
+			}
+		}
+	}
+}
+
 func TestRegistry_Available_SortOrder(t *testing.T) {
 	r := NewDefaultRegistry()
 	avail := r.Available()

--- a/internal/gateway/connector/openclaw.go
+++ b/internal/gateway/connector/openclaw.go
@@ -75,6 +75,20 @@ func (c *OpenClawConnector) SubprocessPolicy() SubprocessPolicy {
 	return ResolveSubprocessPolicy(SubprocessSandbox)
 }
 
+// AllowedHosts returns the OpenClaw upstream baseline. The OpenClaw
+// fetch interceptor talks to whatever provider the user configured;
+// the safe default-deny shipping config covers OpenAI/Anthropic
+// (already in firewall.DefaultFirewallConfig) plus the Cisco AI
+// Defense inspect endpoint when the OpenClaw plugin is uploading
+// findings. This list is *additive* over the static firewall
+// defaults — repeating api.openai.com here would be harmless but is
+// elided to keep the per-connector contribution honest. See S3.3.
+func (c *OpenClawConnector) AllowedHosts() []string {
+	return []string{
+		"us.api.inspect.aidefense.security.cisco.com",
+	}
+}
+
 func (c *OpenClawConnector) Setup(ctx context.Context, opts SetupOpts) error {
 	// Surface 1: Install the embedded plugin into OpenClaw and register it
 	// in openclaw.json. Enabling the connector is the *only* step an

--- a/internal/gateway/connector/zeptoclaw.go
+++ b/internal/gateway/connector/zeptoclaw.go
@@ -79,6 +79,20 @@ func (c *ZeptoClawConnector) SubprocessPolicy() SubprocessPolicy {
 	return ResolveSubprocessPolicy(SubprocessSandbox)
 }
 
+// AllowedHosts returns ZeptoClaw's upstream LLM hosts that the
+// firewall layer must allow when the user has BYOK'd against
+// non-OpenAI/Anthropic providers. The default ZeptoClaw config ships
+// with OpenRouter and Together AI as commonly-used cheap upstream
+// brokers. Without these in the firewall allow-list, a default-deny
+// firewall blocks every chat at L4 and the user sees "DNS lookup
+// blocked" instead of a clean "no API key" error. See S3.3 / F26.
+func (c *ZeptoClawConnector) AllowedHosts() []string {
+	return []string{
+		"openrouter.ai",
+		"api.together.xyz",
+	}
+}
+
 func (c *ZeptoClawConnector) Setup(ctx context.Context, opts SetupOpts) error {
 	// Surface 1: Patch ZeptoClaw config to route api_base through proxy.
 	if err := c.patchZeptoClawConfig(opts); err != nil {


### PR DESCRIPTION
## Summary

`firewall.DefaultFirewallConfig` shipped with only OpenClaw / OpenAI / Anthropic baseline domains. ZeptoClaw users hit "DNS lookup blocked" on first chat (openrouter.ai missing). Codex users couldn't pull GitHub release artifacts. F26 was filed for this.

This PR:

1. Extends `DefaultFirewallConfig` to cover all four built-in connectors' required upstreams (LLM endpoints, skill/plugin registries, docs CDNs, code distribution, AI-Defense inspect endpoint).
2. Adds optional `AllowedHostsProvider` interface in the connector package, implemented by all four built-ins so sidecar boot can fold per-connector contributions onto the static baseline via the new `FirewallConfig.MergeAllowedHosts` helper (deduped, validated, nil-safe).

## Test plan

- [x] `go test ./internal/firewall/... ./internal/gateway/connector/...`
- [x] `TestDefaultFirewallConfig_CoversAllConnectors` pins one representative host per connector.
- [x] `TestMergeAllowedHosts_*` covers append/dedupe/invalid/nil-safe.
- [x] `TestConnector_AllowedHostsProvider_AllBuiltinsImplement` enforces the interface for all built-ins.

Refs: S3.3 / F26