### PR TITLE
fix(plugin-scanner): detect Codex + Claude Code plugin manifests (S2.3 / F8)

### DIFF
--- a/cli/defenseclaw/scanner/plugin_scanner/scanner.py
+++ b/cli/defenseclaw/scanner/plugin_scanner/scanner.py
@@ -101,9 +101,12 @@ def scan_plugin(
             confidence=1.0,
             title="No plugin manifest found",
             description=(
-                "Plugin directory lacks a package.json, manifest.json, plugin.json, "
-                "or openclaw.plugin.json. Cannot verify plugin identity, version, "
-                "or declared permissions. Source scanning will still run."
+                "Plugin directory lacks a recognised manifest "
+                "(package.json, manifest.json, plugin.json, "
+                "openclaw.plugin.json, .codex-plugin/plugin.json, "
+                "or .claude-plugin/plugin.json). Cannot verify plugin "
+                "identity, version, or declared permissions. Source "
+                "scanning will still run."
             ),
             location=target,
             remediation="Add a package.json with name, version, and permissions fields.",
@@ -176,13 +179,47 @@ def scan_plugin(
 # ---------------------------------------------------------------------------
 
 
+# Manifest candidates checked in order. The first hit wins. Each entry
+# is (relative_path, source_label):
+#
+#   * relative_path is the path relative to the plugin directory the
+#     scanner is targeting (e.g. ".codex-plugin/plugin.json" for the
+#     Codex per-plugin manifest convention).
+#   * source_label is what gets recorded in PluginManifest.source so
+#     downstream analyzers can reason about which schema produced
+#     the data.
+#
+# Order is "generic-first": package.json wins when both it and a
+# connector-specific manifest are present, because most plugins
+# bundle their node deps via npm and the npm schema has more useful
+# fields for security analysis (dependencies, scripts, etc.).
+# Connector-specific manifests are fallbacks that only kick in when
+# no generic packaging is present — that's how OpenClaw-only plugins
+# got rescued before this change, and Codex/Claude plugins follow
+# the same precedence so a future Codex plugin that ships a
+# package.json doesn't suddenly get scanned under a different
+# schema. See S2.3 / F8 and `test_package_json_still_takes_precedence`.
+_MANIFEST_CANDIDATES: tuple[tuple[str, str], ...] = (
+    # Generic packaging — preferred when present.
+    ("package.json", "package.json"),
+    ("manifest.json", "manifest.json"),
+    ("plugin.json", "plugin.json"),
+    # Connector-specific fallbacks. Order within this group is alpha
+    # for stability; none takes precedence over another in practice
+    # because each lives in a distinct plugin layout.
+    ("openclaw.plugin.json", "openclaw.plugin.json"),
+    (os.path.join(".claude-plugin", "plugin.json"), "claude.plugin.json"),
+    (os.path.join(".codex-plugin", "plugin.json"), "codex.plugin.json"),
+)
+
+
 def _load_manifest(directory: str) -> PluginManifest | None:
-    # Include openclaw.plugin.json so OpenClaw-only plugins get a full scan
-    for name in ("package.json", "manifest.json", "plugin.json", "openclaw.plugin.json"):
+    for rel_path, source_label in _MANIFEST_CANDIDATES:
+        candidate = os.path.join(directory, rel_path)
         try:
-            with open(os.path.join(directory, name), encoding="utf-8") as fh:
+            with open(candidate, encoding="utf-8") as fh:
                 raw = json.loads(fh.read())
-            return _normalize_manifest(raw, name)
+            return _normalize_manifest(raw, source_label)
         except (OSError, json.JSONDecodeError):
             continue
     return None

--- a/cli/tests/test_plugin_scanner_file_collection.py
+++ b/cli/tests/test_plugin_scanner_file_collection.py
@@ -245,6 +245,107 @@ class TestLoadManifestOpenClaw(unittest.TestCase):
         )
 
 
+class TestLoadManifestCodexAndClaude(unittest.TestCase):
+    """S2.3 / F8: _load_manifest must recognise the Codex per-plugin
+    manifest at .codex-plugin/plugin.json (and the matching Claude
+    Code .claude-plugin/plugin.json layout) so non-OpenClaw plugins
+    don't false-trigger MANIFEST-MISSING.
+
+    The contract this class pins down:
+      * a plugin with only .codex-plugin/plugin.json gets a manifest
+        and runs the full analyzer pipeline.
+      * the same for .claude-plugin/plugin.json.
+      * package.json still wins over either when both are present
+        (parity with the existing OpenClaw behaviour).
+      * the source label on the returned manifest is the connector-
+        specific tag, so downstream analyzers can route off it.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def _write_codex_plugin(self, root: str, name: str = "my-codex-plugin"):
+        os.makedirs(os.path.join(root, ".codex-plugin"))
+        with open(os.path.join(root, ".codex-plugin", "plugin.json"), "w") as f:
+            json.dump(
+                {
+                    "name": name,
+                    "version": "0.1.0",
+                    "description": "Codex plugin under test",
+                    "commands": [{"name": "ping", "exec": "echo pong"}],
+                },
+                f,
+            )
+
+    def _write_claude_plugin(self, root: str, name: str = "my-claude-plugin"):
+        os.makedirs(os.path.join(root, ".claude-plugin"))
+        with open(os.path.join(root, ".claude-plugin", "plugin.json"), "w") as f:
+            json.dump(
+                {
+                    "name": name,
+                    "version": "0.1.0",
+                    "description": "Claude Code plugin under test",
+                },
+                f,
+            )
+
+    def test_codex_plugin_manifest_is_loaded(self):
+        plugin_dir = os.path.join(self.tmp, "cx_plugin")
+        os.makedirs(plugin_dir)
+        self._write_codex_plugin(plugin_dir)
+
+        manifest = _load_manifest(plugin_dir)
+        self.assertIsNotNone(manifest)
+        self.assertEqual(manifest.name, "my-codex-plugin")
+        self.assertEqual(manifest.source, "codex.plugin.json")
+
+    def test_claude_plugin_manifest_is_loaded(self):
+        plugin_dir = os.path.join(self.tmp, "cl_plugin")
+        os.makedirs(plugin_dir)
+        self._write_claude_plugin(plugin_dir)
+
+        manifest = _load_manifest(plugin_dir)
+        self.assertIsNotNone(manifest)
+        self.assertEqual(manifest.name, "my-claude-plugin")
+        self.assertEqual(manifest.source, "claude.plugin.json")
+
+    def test_package_json_still_wins_over_codex_plugin(self):
+        plugin_dir = os.path.join(self.tmp, "dual_codex")
+        os.makedirs(plugin_dir)
+        with open(os.path.join(plugin_dir, "package.json"), "w") as f:
+            json.dump({"name": "from-pkg", "version": "1.0.0"}, f)
+        self._write_codex_plugin(plugin_dir, name="should-not-win")
+
+        manifest = _load_manifest(plugin_dir)
+        self.assertIsNotNone(manifest)
+        self.assertEqual(
+            manifest.name,
+            "from-pkg",
+            "package.json must continue to win over connector-specific manifests",
+        )
+
+    def test_codex_only_plugin_gets_full_scan(self):
+        """End-to-end: Codex-only plugin must NOT short-circuit on MANIFEST-MISSING."""
+        plugin_dir = os.path.join(self.tmp, "cx_full")
+        os.makedirs(os.path.join(plugin_dir, "src"))
+        self._write_codex_plugin(plugin_dir)
+        with open(os.path.join(plugin_dir, "src", "index.js"), "w") as f:
+            f.write("eval('malicious')")
+
+        result = scan_plugin(plugin_dir)
+        rule_ids = [f.rule_id for f in result.findings]
+        self.assertNotIn(
+            "MANIFEST-MISSING",
+            rule_ids,
+            f"Codex plugin should not trip MANIFEST-MISSING; got: {rule_ids}",
+        )
+        self.assertTrue(
+            any("EVAL" in rid for rid in rule_ids if rid),
+            f"Expected eval finding from Codex plugin scan, got: {rule_ids}",
+        )
+
+
 class TestNoManifestStillScans(unittest.TestCase):
     """A plugin with no manifest at all should still get source-scanned."""
 


### PR DESCRIPTION
## Summary

`defenseclaw plugin scan` only recognized the OpenClaw / npm flat-file
manifests (`package.json`, `manifest.json`, `plugin.json`,
`openclaw.plugin.json`). Codex plugins (`.codex-plugin/plugin.json`)
and Claude Code plugins (`.claude-plugin/plugin.json`) tripped
**MANIFEST-MISSING** — a HIGH-severity finding — even when the plugin
was perfectly well-formed for its target connector.

This PR teaches `_load_manifest` about the connector-specific layouts
without disturbing precedence for existing OpenClaw consumers.

## Changes

- `cli/defenseclaw/scanner/plugin_scanner/scanner.py`
  - Replace hard-coded name list with `_MANIFEST_CANDIDATES`: a tuple
    of `(relative_path, source_label)` pairs. Subdirectory manifests
    (`.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`) live
    in the same lookup mechanism as flat-file manifests.
  - **Generic-first ordering**: `package.json` / `manifest.json` /
    `plugin.json` win when present (preserves
    `test_package_json_still_takes_precedence`); connector-specific
    manifests are fallbacks. Shared bundles continue to behave as
    before.
  - Updated MANIFEST-MISSING description to list the Codex and Claude
    Code paths so publishers see the right remediation hint.

- `cli/tests/test_plugin_scanner_file_collection.py`
  - `test_codex_plugin_manifest_is_loaded`
  - `test_claude_plugin_manifest_is_loaded`
  - `test_package_json_still_wins_over_codex_plugin` (precedence)
  - `test_codex_only_plugin_gets_full_scan` (end-to-end: Codex-only
    plugin must **not** short-circuit on MANIFEST-MISSING)

## Why

Part of the Wave-2 _claw-agnostic_ work. Without this, every Codex
or Claude Code plugin would surface as a HIGH finding the moment a
user ran `defenseclaw plugin scan`, masking real signal and breaking
parity claims.

## Test plan

- [x] `pytest cli/tests/test_plugin_scanner_file_collection.py -q` — all green
- [x] `pytest cli/tests/test_meta_analyzer.py cli/tests/test_cmd_plugin.py -q` — only pre-existing parent-branch failure (`TestResolvePluginDir::test_resolves_root_when_source_is_file_in_dist_subdir`) remains; unrelated to this PR
- [x] OpenClaw fixtures unchanged (precedence test pinned)

## Refs

- S2.3 / F8 (claw-agnostic plan, Wave 2)
- Stacks on top of #168 / #171 / #172 / #173 / #174 / #175