### PR TITLE
refactor(cli): extract connector path discovery into connector_paths.py (S4.1)

### DIFF
--- a/cli/defenseclaw/config.py
+++ b/cli/defenseclaw/config.py
@@ -33,6 +33,19 @@ from typing import Any
 
 import yaml
 
+from defenseclaw import connector_paths
+from defenseclaw.connector_paths import MCPServerEntry  # re-export for back-compat
+# Back-compat re-exports — internal-but-imported-by-tests helpers that
+# moved to connector_paths in S4.1. Tests in cli/tests/test_config.py
+# still import them from defenseclaw.config; keeping the aliases avoids
+# touching unrelated test files in this PR.
+from defenseclaw.connector_paths import (
+    _dedup,
+    _parse_mcp_servers_dict,
+    _read_mcp_servers_from_openclaw_json as _read_mcp_servers_from_file,
+    _read_openclaw_json as _read_openclaw_config,
+)
+
 _log = logging.getLogger(__name__)
 
 DATA_DIR_NAME = ".defenseclaw"
@@ -164,14 +177,12 @@ def openclaw_bin() -> str:
 # Dataclasses — same YAML keys as Go structs
 # ---------------------------------------------------------------------------
 
-@dataclass
-class MCPServerEntry:
-    name: str = ""
-    command: str = ""
-    args: list[str] = field(default_factory=list)
-    env: dict[str, str] = field(default_factory=dict)
-    url: str = ""
-    transport: str = ""
+# MCPServerEntry now lives in defenseclaw.connector_paths so any caller
+# that imported it from defenseclaw.config keeps working — see the
+# `from defenseclaw.connector_paths import MCPServerEntry` re-export
+# at the top of this module. Keeping the dataclass next to the
+# connector-aware MCP readers means there's exactly one schema across
+# the four supported agent frameworks.
 
 
 @dataclass
@@ -819,56 +830,59 @@ class Config:
     def claw_home_dir(self) -> str:
         return _expand(self.claw.home_dir)
 
-    def skill_dirs(self) -> list[str]:
-        conn = self.guardrail.connector.lower()
-        if conn == "claudecode":
-            return _connector_skill_dirs_claudecode()
-        if conn == "codex":
-            return _connector_skill_dirs_codex()
-        if conn == "zeptoclaw":
-            return _connector_skill_dirs_zeptoclaw()
-        return self._skill_dirs_openclaw()
+    def active_connector(self) -> str:
+        """Return the canonical connector name for this config.
 
-    def _skill_dirs_openclaw(self) -> list[str]:
-        home = self.claw_home_dir()
-        dirs: list[str] = []
-        oc = _read_openclaw_config(self.claw.config_file)
-        workspace = os.path.join(home, "workspace")
-        if oc:
-            ws = oc.get("agents", {}).get("defaults", {}).get("workspace", "")
-            if ws:
-                workspace = _expand(ws)
-            dirs.append(os.path.join(workspace, "skills"))
-            for d in oc.get("skills", {}).get("load", {}).get("extraDirs", []):
-                dirs.append(_expand(d))
-        else:
-            dirs.append(os.path.join(workspace, "skills"))
-        dirs.append(os.path.join(home, "skills"))
-        return _dedup(dirs)
+        Mirrors ``Config.activeConnector`` in claw.go: precedence is
+        ``guardrail.connector`` → ``claw.mode`` → ``"openclaw"``,
+        whitespace-trimmed and lowercased. Public so cmd_doctor /
+        cmd_uninstall can answer "which framework is this install
+        running against?" without recomputing the rule.
+        """
+        if self.guardrail.connector.strip():
+            return connector_paths.normalize(self.guardrail.connector)
+        if self.claw.mode.strip():
+            return connector_paths.normalize(self.claw.mode)
+        return "openclaw"
+
+    def skill_dirs(self) -> list[str]:
+        """Return skill directories for the active connector.
+
+        Polymorphic — when ``guardrail.connector`` is set, the
+        connector-specific layout (e.g. ``~/.codex/skills``) is
+        returned; otherwise falls back to OpenClaw paths derived
+        from ``claw.home_dir`` and ``claw.config_file``.
+        """
+        return connector_paths.skill_dirs(
+            self.active_connector(),
+            openclaw_home=self.claw.home_dir,
+            openclaw_config=self.claw.config_file,
+        )
 
     def plugin_dirs(self) -> list[str]:
-        conn = self.guardrail.connector.lower()
-        if conn == "claudecode":
-            return _connector_plugin_dirs_claudecode()
-        if conn == "codex":
-            return _connector_plugin_dirs_codex()
-        if conn == "zeptoclaw":
-            return _connector_plugin_dirs_zeptoclaw()
-        home = self.claw_home_dir()
-        return [os.path.join(home, "extensions")]
+        """Return plugin/extension directories for the active connector.
+
+        See :meth:`skill_dirs` for dispatch semantics.
+        """
+        return connector_paths.plugin_dirs(
+            self.active_connector(),
+            openclaw_home=self.claw.home_dir,
+        )
 
     def mcp_servers(self) -> list[MCPServerEntry]:
-        conn = self.guardrail.connector.lower()
-        if conn == "claudecode":
-            return _read_mcp_servers_claudecode()
-        if conn == "codex":
-            return _read_mcp_servers_codex()
-        if conn == "zeptoclaw":
-            return _read_mcp_servers_zeptoclaw()
-        servers = _read_mcp_servers_via_cli()
-        if servers is not None:
-            return servers
-        return _read_mcp_servers_from_file(self.claw.config_file)
+        """Return MCP server registrations for the active connector.
+
+        For OpenClaw the lookup prefers ``openclaw config get
+        mcp.servers`` and falls back to a direct
+        ``openclaw.json`` parse (with ``sudo -u sandbox`` prefix when
+        running standalone-sandbox mode).
+        """
+        return connector_paths.mcp_servers(
+            self.active_connector(),
+            openclaw_config=self.claw.config_file,
+            openclaw_bin_resolver=openclaw_bin,
+            openclaw_cmd_prefix=openclaw_cmd_prefix(),
+        )
 
     def installed_skill_candidates(self, skill_name: str) -> list[str]:
         name = skill_name
@@ -990,243 +1004,6 @@ class Config:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-def _read_openclaw_config(config_file: str) -> dict[str, Any] | None:
-    path = _expand(config_file)
-    try:
-        with open(path) as f:
-            return json.load(f)
-    except (OSError, json.JSONDecodeError):
-        return None
-
-
-def _read_mcp_servers_via_cli() -> list[MCPServerEntry] | None:
-    """Read mcp.servers via ``openclaw config get``.  Returns None on failure."""
-    try:
-        prefix = openclaw_cmd_prefix()
-        result = subprocess.run(
-            [*prefix, openclaw_bin(), "config", "get", "mcp.servers"],
-            capture_output=True, text=True, timeout=10,
-        )
-        if result.returncode != 0:
-            return None
-        return _parse_mcp_servers_json(result.stdout)
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        return None
-
-
-def _read_mcp_servers_from_file(config_file: str) -> list[MCPServerEntry]:
-    """Fallback: parse mcp.servers directly from openclaw.json."""
-    path = _expand(config_file)
-    try:
-        with open(path) as f:
-            raw = f.read()
-    except OSError:
-        return []
-
-    data: dict[str, Any] | None = None
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError:
-        try:
-            import json5  # type: ignore[import-untyped]
-            data = json5.loads(raw)
-        except Exception:
-            return []
-
-    if not isinstance(data, dict):
-        return []
-
-    servers = data.get("mcp", {}).get("servers")
-    if not isinstance(servers, dict):
-        return []
-
-    return _parse_mcp_servers_dict(servers)
-
-
-def _parse_mcp_servers_json(text: str) -> list[MCPServerEntry]:
-    text = text.strip()
-    if not text:
-        return []
-    try:
-        servers = json.loads(text)
-    except json.JSONDecodeError:
-        return []
-    if not isinstance(servers, dict):
-        return []
-    return _parse_mcp_servers_dict(servers)
-
-
-def _parse_mcp_servers_dict(servers: dict[str, Any]) -> list[MCPServerEntry]:
-    entries: list[MCPServerEntry] = []
-    for name, cfg in servers.items():
-        if not isinstance(cfg, dict):
-            continue
-        entries.append(MCPServerEntry(
-            name=name,
-            command=cfg.get("command", ""),
-            args=cfg.get("args", []),
-            env=cfg.get("env", {}),
-            url=cfg.get("url", ""),
-            transport=cfg.get("transport", ""),
-        ))
-    return entries
-
-
-def _dedup(paths: list[str]) -> list[str]:
-    seen: set[str] = set()
-    out: list[str] = []
-    for p in paths:
-        if p not in seen:
-            seen.add(p)
-            out.append(p)
-    return out
-
-
-# ---------------------------------------------------------------------------
-# Connector-specific helpers — skill dirs, plugin dirs, MCP server discovery.
-# Each set mirrors the Go-side ComponentTargets() for its connector.
-# ---------------------------------------------------------------------------
-
-def _connector_skill_dirs_claudecode() -> list[str]:
-    home = str(_home())
-    user_dir = os.path.join(home, ".claude")
-    cwd = os.getcwd()
-    return _dedup([
-        os.path.join(user_dir, "skills"),
-        os.path.join(cwd, ".claude", "skills"),
-    ])
-
-
-def _connector_skill_dirs_codex() -> list[str]:
-    home = str(_home())
-    codex_dir = os.path.join(home, ".codex")
-    cwd = os.getcwd()
-    return _dedup([
-        os.path.join(codex_dir, "skills"),
-        os.path.join(cwd, ".codex", "skills"),
-    ])
-
-
-def _connector_skill_dirs_zeptoclaw() -> list[str]:
-    home = str(_home())
-    zepto_dir = os.path.join(home, ".zeptoclaw")
-    cwd = os.getcwd()
-    return _dedup([
-        os.path.join(zepto_dir, "skills"),
-        os.path.join(cwd, ".zeptoclaw", "skills"),
-    ])
-
-
-def _connector_plugin_dirs_claudecode() -> list[str]:
-    home = str(_home())
-    user_dir = os.path.join(home, ".claude")
-    cwd = os.getcwd()
-    return _dedup([
-        os.path.join(user_dir, "plugins"),
-        os.path.join(cwd, ".claude", "plugins"),
-    ])
-
-
-def _connector_plugin_dirs_codex() -> list[str]:
-    home = str(_home())
-    codex_dir = os.path.join(home, ".codex")
-    return _dedup([
-        os.path.join(codex_dir, "plugins"),
-        os.path.join(codex_dir, "plugins", "cache"),
-    ])
-
-
-def _connector_plugin_dirs_zeptoclaw() -> list[str]:
-    home = str(_home())
-    zepto_dir = os.path.join(home, ".zeptoclaw")
-    return _dedup([
-        os.path.join(zepto_dir, "plugins"),
-        os.path.join(zepto_dir, "plugins", "cache"),
-    ])
-
-
-def _read_mcp_servers_claudecode() -> list[MCPServerEntry]:
-    home = str(_home())
-    cwd = os.getcwd()
-    servers: list[MCPServerEntry] = []
-    settings_path = os.path.join(home, ".claude", "settings.json")
-    try:
-        with open(settings_path) as f:
-            data = json.loads(f.read())
-        if isinstance(data, dict):
-            mcp = data.get("mcpServers")
-            if isinstance(mcp, dict):
-                servers.extend(_parse_mcp_servers_dict(mcp))
-    except (OSError, json.JSONDecodeError):
-        pass
-    mcp_json = os.path.join(cwd, ".mcp.json")
-    try:
-        with open(mcp_json) as f:
-            data = json.loads(f.read())
-        if isinstance(data, dict):
-            mcp = data.get("mcpServers", data)
-            if isinstance(mcp, dict):
-                servers.extend(_parse_mcp_servers_dict(mcp))
-    except (OSError, json.JSONDecodeError):
-        pass
-    seen: set[str] = set()
-    deduped: list[MCPServerEntry] = []
-    for s in servers:
-        if s.name not in seen:
-            seen.add(s.name)
-            deduped.append(s)
-    return deduped
-
-
-def _read_mcp_servers_codex() -> list[MCPServerEntry]:
-    cwd = os.getcwd()
-    servers: list[MCPServerEntry] = []
-    mcp_json = os.path.join(cwd, ".mcp.json")
-    try:
-        with open(mcp_json) as f:
-            data = json.loads(f.read())
-        if isinstance(data, dict):
-            mcp = data.get("mcpServers", data)
-            if isinstance(mcp, dict):
-                servers.extend(_parse_mcp_servers_dict(mcp))
-    except (OSError, json.JSONDecodeError):
-        pass
-    return servers
-
-
-def _read_mcp_servers_zeptoclaw() -> list[MCPServerEntry]:
-    home = str(_home())
-    cwd = os.getcwd()
-    servers: list[MCPServerEntry] = []
-    config_path = os.path.join(home, ".zeptoclaw", "config.json")
-    try:
-        with open(config_path) as f:
-            data = json.loads(f.read())
-        if isinstance(data, dict):
-            mcp = data.get("mcp", {}).get("servers")
-            if isinstance(mcp, dict):
-                servers.extend(_parse_mcp_servers_dict(mcp))
-    except (OSError, json.JSONDecodeError):
-        pass
-    mcp_json = os.path.join(cwd, ".mcp.json")
-    try:
-        with open(mcp_json) as f:
-            data = json.loads(f.read())
-        if isinstance(data, dict):
-            mcp = data.get("mcpServers", data)
-            if isinstance(mcp, dict):
-                servers.extend(_parse_mcp_servers_dict(mcp))
-    except (OSError, json.JSONDecodeError):
-        pass
-    seen: set[str] = set()
-    deduped: list[MCPServerEntry] = []
-    for s in servers:
-        if s.name not in seen:
-            seen.add(s.name)
-            deduped.append(s)
-    return deduped
-
 
 def _llm_is_empty(d: dict[str, Any] | None) -> bool:
     if not d:

--- a/cli/defenseclaw/connector_paths.py
+++ b/cli/defenseclaw/connector_paths.py
@@ -1,0 +1,523 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Connector-specific path discovery for DefenseClaw.
+
+This module is the single Python-side source of truth for "where does
+agent framework X keep its skills / plugins / MCP server registrations?"
+It mirrors:
+
+* ``internal/config/claw.go::SkillDirsForConnector``
+* ``internal/config/claw.go::PluginDirsForConnector``
+* ``internal/config/claw.go::ReadMCPServersForConnector``
+* ``internal/gateway/connector/<name>.go::ComponentTargets``
+
+Importing this module instead of reaching into private helpers in
+:mod:`defenseclaw.config` lets other CLI commands (``cmd_doctor``,
+``cmd_uninstall``, ``cmd_setup_sandbox``) walk the connector matrix
+without circular imports through ``Config``.
+
+Public surface
+--------------
+
+* :data:`KNOWN_CONNECTORS` — tuple of every name the dispatchers
+  recognize. Adding a fifth connector is a one-line change here plus
+  a matching dispatch arm in each ``*_for_connector`` function below
+  and a Go-side ``connector.NewDefaultRegistry`` registration.
+* :func:`normalize` — canonicalize an operator-supplied connector name
+  (trim, lowercase, default to ``"openclaw"``). Mirrors
+  ``Config.activeConnector`` semantics in claw.go.
+* :func:`is_known` — connector-name allow-list check.
+* :func:`skill_dirs` / :func:`plugin_dirs` / :func:`mcp_servers` —
+  polymorphic dispatchers; pass a connector name and they return the
+  paths or MCP entries for that connector.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+KNOWN_CONNECTORS: tuple[str, ...] = (
+    "openclaw",
+    "codex",
+    "claudecode",
+    "zeptoclaw",
+)
+"""Allow-list of recognized agent-framework connector names.
+
+Anything outside this set is treated as "unknown — fall back to
+OpenClaw". Keeping the list explicit (rather than discovering at
+import time) means a typo in ``guardrail.connector`` surfaces in
+:func:`is_known` and in setup-time validation, instead of silently
+producing wrong paths.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MCPServerEntry:
+    """One MCP server registration as discovered from disk.
+
+    The fields are a superset across every supported framework's
+    on-disk schema (Claude Code's ``settings.json``, Codex's
+    ``.mcp.json``, ZeptoClaw's ``config.json``, OpenClaw's
+    ``openclaw.json``). Optional fields default to empty so callers
+    can treat the struct uniformly.
+    """
+    name: str = ""
+    command: str = ""
+    args: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
+    url: str = ""
+    transport: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Connector-name normalization
+# ---------------------------------------------------------------------------
+
+def normalize(connector: str | None) -> str:
+    """Return the canonical lowercase connector name.
+
+    Empty / whitespace-only / None values default to ``"openclaw"`` for
+    backward compatibility with pre-S1.x deployments. Matches the
+    precedence rule in ``Config.activeConnector`` (Go).
+    """
+    if not connector:
+        return "openclaw"
+    name = connector.strip().lower()
+    return name or "openclaw"
+
+
+def is_known(connector: str | None) -> bool:
+    """Return True iff *connector* (after :func:`normalize`) is in
+    :data:`KNOWN_CONNECTORS`."""
+    return normalize(connector) in KNOWN_CONNECTORS
+
+
+# ---------------------------------------------------------------------------
+# Path expansion helper — kept private to avoid divergence from the
+# Go-side ``expandPath`` (which only handles a leading ``~/`` prefix).
+# ---------------------------------------------------------------------------
+
+def _expand(path: str) -> str:
+    if path.startswith("~/"):
+        return str(Path.home() / path[2:])
+    return path
+
+
+def _dedup(paths: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for p in paths:
+        if p not in seen:
+            seen.add(p)
+            out.append(p)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Public dispatchers
+# ---------------------------------------------------------------------------
+
+def skill_dirs(
+    connector: str | None,
+    *,
+    openclaw_home: str | None = None,
+    openclaw_config: str | None = None,
+) -> list[str]:
+    """Return the skill directory list for *connector*.
+
+    For Claude Code / Codex / ZeptoClaw the layout is fixed
+    (``$HOME/.<framework>/skills`` plus the project-local
+    ``./.<framework>/skills``). For OpenClaw — and any unknown
+    name — we walk ``openclaw.json`` to honor any ``skills.load.extraDirs``
+    overrides, then add the home_dir/skills fallback.
+
+    *openclaw_home* and *openclaw_config* are only consulted on the
+    OpenClaw branch. Callers that pass ``None`` get the documented
+    OpenClaw defaults (``~/.openclaw`` and
+    ``~/.openclaw/openclaw.json``).
+    """
+    name = normalize(connector)
+    if name == "claudecode":
+        return _claudecode_skill_dirs()
+    if name == "codex":
+        return _codex_skill_dirs()
+    if name == "zeptoclaw":
+        return _zeptoclaw_skill_dirs()
+    return _openclaw_skill_dirs(openclaw_home, openclaw_config)
+
+
+def plugin_dirs(
+    connector: str | None,
+    *,
+    openclaw_home: str | None = None,
+) -> list[str]:
+    """Return the plugin (extension) directory list for *connector*.
+
+    Uses each framework's documented plugin location:
+
+    * Claude Code: ``~/.claude/plugins`` and ``./.claude/plugins``
+    * Codex:       ``~/.codex/plugins`` (+ ``cache`` subdir)
+    * ZeptoClaw:   ``~/.zeptoclaw/plugins`` (+ ``cache`` subdir)
+    * OpenClaw:    ``<home_dir>/extensions``
+    """
+    name = normalize(connector)
+    if name == "claudecode":
+        return _claudecode_plugin_dirs()
+    if name == "codex":
+        return _codex_plugin_dirs()
+    if name == "zeptoclaw":
+        return _zeptoclaw_plugin_dirs()
+    return _openclaw_plugin_dirs(openclaw_home)
+
+
+def mcp_servers(
+    connector: str | None,
+    *,
+    openclaw_config: str | None = None,
+    openclaw_bin_resolver: Any = None,
+    openclaw_cmd_prefix: list[str] | None = None,
+) -> list[MCPServerEntry]:
+    """Return the MCP server registrations for *connector*.
+
+    Reads each framework's canonical config:
+
+    * Claude Code: ``~/.claude/settings.json`` then ``./.mcp.json``
+    * Codex:       ``./.mcp.json``
+    * ZeptoClaw:   ``~/.zeptoclaw/config.json`` then ``./.mcp.json``
+    * OpenClaw:    ``openclaw config get mcp.servers`` (preferred)
+                    falling back to direct ``openclaw.json`` parse
+
+    *openclaw_bin_resolver* and *openclaw_cmd_prefix* let callers
+    inject test doubles or sandbox-mode prefixes (``sudo -u sandbox``);
+    when omitted, lookups go through ``shutil.which`` and an empty
+    prefix.
+    """
+    name = normalize(connector)
+    if name == "claudecode":
+        return _claudecode_mcp_servers()
+    if name == "codex":
+        return _codex_mcp_servers()
+    if name == "zeptoclaw":
+        return _zeptoclaw_mcp_servers()
+    return _openclaw_mcp_servers(
+        openclaw_config,
+        openclaw_bin_resolver=openclaw_bin_resolver,
+        openclaw_cmd_prefix=openclaw_cmd_prefix,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-connector implementations
+# ---------------------------------------------------------------------------
+
+def _claudecode_skill_dirs() -> list[str]:
+    home = str(Path.home())
+    cwd = os.getcwd()
+    return _dedup([
+        os.path.join(home, ".claude", "skills"),
+        os.path.join(cwd, ".claude", "skills"),
+    ])
+
+
+def _codex_skill_dirs() -> list[str]:
+    home = str(Path.home())
+    cwd = os.getcwd()
+    return _dedup([
+        os.path.join(home, ".codex", "skills"),
+        os.path.join(cwd, ".codex", "skills"),
+    ])
+
+
+def _zeptoclaw_skill_dirs() -> list[str]:
+    home = str(Path.home())
+    cwd = os.getcwd()
+    return _dedup([
+        os.path.join(home, ".zeptoclaw", "skills"),
+        os.path.join(cwd, ".zeptoclaw", "skills"),
+    ])
+
+
+def _openclaw_skill_dirs(
+    openclaw_home: str | None,
+    openclaw_config: str | None,
+) -> list[str]:
+    home = _expand(openclaw_home or "~/.openclaw")
+    config_file = _expand(openclaw_config or "~/.openclaw/openclaw.json")
+    workspace = os.path.join(home, "workspace")
+    dirs: list[str] = []
+    oc = _read_openclaw_json(config_file)
+    if oc:
+        ws = oc.get("agents", {}).get("defaults", {}).get("workspace", "")
+        if ws:
+            workspace = _expand(ws)
+        dirs.append(os.path.join(workspace, "skills"))
+        for d in oc.get("skills", {}).get("load", {}).get("extraDirs", []) or []:
+            dirs.append(_expand(d))
+    else:
+        dirs.append(os.path.join(workspace, "skills"))
+    dirs.append(os.path.join(home, "skills"))
+    return _dedup(dirs)
+
+
+def _claudecode_plugin_dirs() -> list[str]:
+    home = str(Path.home())
+    cwd = os.getcwd()
+    return _dedup([
+        os.path.join(home, ".claude", "plugins"),
+        os.path.join(cwd, ".claude", "plugins"),
+    ])
+
+
+def _codex_plugin_dirs() -> list[str]:
+    home = str(Path.home())
+    base = os.path.join(home, ".codex", "plugins")
+    return _dedup([
+        base,
+        os.path.join(base, "cache"),
+    ])
+
+
+def _zeptoclaw_plugin_dirs() -> list[str]:
+    home = str(Path.home())
+    base = os.path.join(home, ".zeptoclaw", "plugins")
+    return _dedup([
+        base,
+        os.path.join(base, "cache"),
+    ])
+
+
+def _openclaw_plugin_dirs(openclaw_home: str | None) -> list[str]:
+    home = _expand(openclaw_home or "~/.openclaw")
+    return [os.path.join(home, "extensions")]
+
+
+# --- MCP readers -----------------------------------------------------------
+
+def _claudecode_mcp_servers() -> list[MCPServerEntry]:
+    home = str(Path.home())
+    cwd = os.getcwd()
+    entries: list[MCPServerEntry] = []
+    entries.extend(_read_mcp_settings_block(
+        os.path.join(home, ".claude", "settings.json"),
+        keys=("mcpServers",),
+    ))
+    entries.extend(_read_dotmcp_json(os.path.join(cwd, ".mcp.json")))
+    return _dedup_mcp_entries(entries)
+
+
+def _codex_mcp_servers() -> list[MCPServerEntry]:
+    return _read_dotmcp_json(os.path.join(os.getcwd(), ".mcp.json"))
+
+
+def _zeptoclaw_mcp_servers() -> list[MCPServerEntry]:
+    home = str(Path.home())
+    cwd = os.getcwd()
+    entries: list[MCPServerEntry] = []
+    entries.extend(_read_zepto_config(os.path.join(home, ".zeptoclaw", "config.json")))
+    entries.extend(_read_dotmcp_json(os.path.join(cwd, ".mcp.json")))
+    return _dedup_mcp_entries(entries)
+
+
+def _openclaw_mcp_servers(
+    openclaw_config: str | None,
+    *,
+    openclaw_bin_resolver: Any = None,
+    openclaw_cmd_prefix: list[str] | None = None,
+) -> list[MCPServerEntry]:
+    cli_entries = _read_mcp_servers_via_openclaw_cli(
+        openclaw_bin_resolver=openclaw_bin_resolver,
+        openclaw_cmd_prefix=openclaw_cmd_prefix,
+    )
+    if cli_entries is not None:
+        return cli_entries
+    return _read_mcp_servers_from_openclaw_json(
+        _expand(openclaw_config or "~/.openclaw/openclaw.json"),
+    )
+
+
+# --- Low-level file/CLI helpers --------------------------------------------
+
+def _read_openclaw_json(config_file: str) -> dict[str, Any] | None:
+    try:
+        with open(_expand(config_file)) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _read_mcp_settings_block(
+    path: str,
+    *,
+    keys: tuple[str, ...],
+) -> list[MCPServerEntry]:
+    """Read an MCP servers block out of a JSON settings file.
+
+    *keys* is a tuple of the dotted lookup path inside the JSON
+    document — e.g. ``("mcpServers",)`` for Claude Code's
+    settings.json or ``("mcp", "servers")`` for ZeptoClaw's
+    config.json. Returns an empty list when the file is missing,
+    invalid JSON, or the block isn't a mapping.
+    """
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    cursor: Any = data
+    for k in keys:
+        if not isinstance(cursor, dict):
+            return []
+        cursor = cursor.get(k)
+        if cursor is None:
+            return []
+    if not isinstance(cursor, dict):
+        return []
+    return _parse_mcp_servers_dict(cursor)
+
+
+def _read_dotmcp_json(path: str) -> list[MCPServerEntry]:
+    """Parse a project-local ``.mcp.json``.
+
+    The file may either wrap the servers under ``mcpServers`` (Claude
+    Code / Codex SDK convention) or be a top-level mapping of name →
+    server. Both are accepted.
+    """
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    inner = data.get("mcpServers")
+    if isinstance(inner, dict):
+        return _parse_mcp_servers_dict(inner)
+    return _parse_mcp_servers_dict(data)
+
+
+def _read_zepto_config(path: str) -> list[MCPServerEntry]:
+    return _read_mcp_settings_block(path, keys=("mcp", "servers"))
+
+
+def _read_mcp_servers_via_openclaw_cli(
+    *,
+    openclaw_bin_resolver: Any = None,
+    openclaw_cmd_prefix: list[str] | None = None,
+) -> list[MCPServerEntry] | None:
+    """Run ``openclaw config get mcp.servers`` and parse the JSON.
+
+    Returns ``None`` (not ``[]``) on any failure so callers can fall
+    back to direct ``openclaw.json`` parsing. Honors *openclaw_cmd_prefix*
+    so sandbox-mode setups can prepend ``sudo -u sandbox``.
+    """
+    if openclaw_bin_resolver is None:
+        import shutil
+        bin_path = shutil.which("openclaw") or "openclaw"
+    else:
+        bin_path = openclaw_bin_resolver()
+    prefix = list(openclaw_cmd_prefix or [])
+    try:
+        result = subprocess.run(
+            [*prefix, bin_path, "config", "get", "mcp.servers"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        return _parse_mcp_servers_text(result.stdout)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+
+def _read_mcp_servers_from_openclaw_json(path: str) -> list[MCPServerEntry]:
+    try:
+        with open(path) as f:
+            raw = f.read()
+    except OSError:
+        return []
+    data: dict[str, Any] | None = None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        try:
+            import json5  # type: ignore[import-untyped]
+            data = json5.loads(raw)
+        except Exception:
+            return []
+    if not isinstance(data, dict):
+        return []
+    servers = data.get("mcp", {}).get("servers")
+    if not isinstance(servers, dict):
+        return []
+    return _parse_mcp_servers_dict(servers)
+
+
+def _parse_mcp_servers_text(text: str) -> list[MCPServerEntry]:
+    text = text.strip()
+    if not text:
+        return []
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(parsed, dict):
+        return []
+    return _parse_mcp_servers_dict(parsed)
+
+
+def _parse_mcp_servers_dict(servers: dict[str, Any]) -> list[MCPServerEntry]:
+    out: list[MCPServerEntry] = []
+    for name, cfg in servers.items():
+        if not isinstance(cfg, dict):
+            continue
+        out.append(MCPServerEntry(
+            name=name,
+            command=cfg.get("command", "") or "",
+            args=list(cfg.get("args", []) or []),
+            env=dict(cfg.get("env", {}) or {}),
+            url=cfg.get("url", "") or "",
+            transport=cfg.get("transport", "") or "",
+        ))
+    return out
+
+
+def _dedup_mcp_entries(entries: list[MCPServerEntry]) -> list[MCPServerEntry]:
+    seen: set[str] = set()
+    out: list[MCPServerEntry] = []
+    for e in entries:
+        if e.name in seen:
+            continue
+        seen.add(e.name)
+        out.append(e)
+    return out

--- a/cli/tests/test_connector_paths.py
+++ b/cli/tests/test_connector_paths.py
@@ -1,0 +1,336 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for defenseclaw.connector_paths.
+
+Pin the connector dispatch contract end-to-end so adding a fifth
+framework remains a one-file change. Each test exercises a single
+public function and asserts the per-connector branch returns the
+documented paths.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from defenseclaw import connector_paths
+from defenseclaw.connector_paths import MCPServerEntry
+
+
+# ---------------------------------------------------------------------------
+# normalize / is_known
+# ---------------------------------------------------------------------------
+
+class TestNormalize:
+    @pytest.mark.parametrize("inp,expected", [
+        (None, "openclaw"),
+        ("", "openclaw"),
+        ("   ", "openclaw"),
+        ("openclaw", "openclaw"),
+        ("OpenClaw", "openclaw"),
+        ("  CODEX  ", "codex"),
+        ("Claudecode", "claudecode"),
+        ("zeptoclaw", "zeptoclaw"),
+        ("future-connector", "future-connector"),
+    ])
+    def test_normalizes(self, inp, expected):
+        assert connector_paths.normalize(inp) == expected
+
+
+class TestIsKnown:
+    def test_known_lowercase(self):
+        for name in ("openclaw", "codex", "claudecode", "zeptoclaw"):
+            assert connector_paths.is_known(name)
+
+    def test_known_mixed_case(self):
+        assert connector_paths.is_known("OpenClaw")
+        assert connector_paths.is_known("Codex")
+
+    def test_unknown(self):
+        assert not connector_paths.is_known("future-frame")
+        assert not connector_paths.is_known("openclaaaaw")
+
+    def test_none_falls_back_to_openclaw_and_is_known(self):
+        # Per normalize() contract — None resolves to "openclaw"
+        assert connector_paths.is_known(None)
+
+
+# ---------------------------------------------------------------------------
+# skill_dirs
+# ---------------------------------------------------------------------------
+
+class TestSkillDirs:
+    def test_claudecode(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        dirs = connector_paths.skill_dirs("claudecode")
+        home = str(Path.home())
+        assert os.path.join(home, ".claude", "skills") in dirs
+        assert os.path.join(str(tmp_path), ".claude", "skills") in dirs
+
+    def test_codex(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        dirs = connector_paths.skill_dirs("codex")
+        home = str(Path.home())
+        assert os.path.join(home, ".codex", "skills") in dirs
+
+    def test_zeptoclaw(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        dirs = connector_paths.skill_dirs("zeptoclaw")
+        home = str(Path.home())
+        assert os.path.join(home, ".zeptoclaw", "skills") in dirs
+
+    def test_openclaw_default_paths(self, tmp_path):
+        dirs = connector_paths.skill_dirs(
+            "openclaw",
+            openclaw_home=str(tmp_path),
+            openclaw_config=str(tmp_path / "openclaw.json"),
+        )
+        # workspace/skills is the documented OpenClaw default even
+        # when openclaw.json is missing.
+        assert os.path.join(str(tmp_path), "workspace", "skills") in dirs
+        assert os.path.join(str(tmp_path), "skills") in dirs
+
+    def test_openclaw_honors_extra_dirs(self, tmp_path):
+        cfg_path = tmp_path / "openclaw.json"
+        cfg_path.write_text(json.dumps({
+            "agents": {"defaults": {"workspace": str(tmp_path / "ws")}},
+            "skills": {"load": {"extraDirs": [str(tmp_path / "extra1")]}},
+        }))
+        dirs = connector_paths.skill_dirs(
+            "openclaw",
+            openclaw_home=str(tmp_path),
+            openclaw_config=str(cfg_path),
+        )
+        assert os.path.join(str(tmp_path / "ws"), "skills") in dirs
+        assert str(tmp_path / "extra1") in dirs
+        assert os.path.join(str(tmp_path), "skills") in dirs
+
+    def test_unknown_connector_falls_back_to_openclaw(self, tmp_path):
+        dirs = connector_paths.skill_dirs(
+            "totally-unknown",
+            openclaw_home=str(tmp_path),
+            openclaw_config=str(tmp_path / "openclaw.json"),
+        )
+        # Must not be empty and must include the OpenClaw home_dir/skills
+        # so "guardrail.connector got typo'd" doesn't silently swallow
+        # all skill discovery.
+        assert os.path.join(str(tmp_path), "skills") in dirs
+
+
+# ---------------------------------------------------------------------------
+# plugin_dirs
+# ---------------------------------------------------------------------------
+
+class TestPluginDirs:
+    def test_claudecode(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        dirs = connector_paths.plugin_dirs("claudecode")
+        home = str(Path.home())
+        assert os.path.join(home, ".claude", "plugins") in dirs
+
+    def test_codex(self):
+        dirs = connector_paths.plugin_dirs("codex")
+        home = str(Path.home())
+        # Codex plugins live at ~/.codex/plugins (with cache subdir)
+        assert os.path.join(home, ".codex", "plugins") in dirs
+
+    def test_zeptoclaw(self):
+        dirs = connector_paths.plugin_dirs("zeptoclaw")
+        home = str(Path.home())
+        assert os.path.join(home, ".zeptoclaw", "plugins") in dirs
+
+    def test_openclaw(self, tmp_path):
+        dirs = connector_paths.plugin_dirs(
+            "openclaw", openclaw_home=str(tmp_path),
+        )
+        assert dirs == [os.path.join(str(tmp_path), "extensions")]
+
+    def test_no_overlap_between_connectors(self, tmp_path, monkeypatch):
+        """Switching connectors must change the path set — pins the
+        contract that each framework owns its own filesystem footprint."""
+        monkeypatch.chdir(tmp_path)
+        codex = set(connector_paths.plugin_dirs("codex"))
+        claudecode = set(connector_paths.plugin_dirs("claudecode"))
+        zepto = set(connector_paths.plugin_dirs("zeptoclaw"))
+        assert codex.isdisjoint(claudecode)
+        assert codex.isdisjoint(zepto)
+        assert claudecode.isdisjoint(zepto)
+
+
+# ---------------------------------------------------------------------------
+# mcp_servers
+# ---------------------------------------------------------------------------
+
+class TestMCPServers:
+    def _write_mcp_json(self, dirpath: Path, servers: dict) -> Path:
+        path = dirpath / ".mcp.json"
+        path.write_text(json.dumps({"mcpServers": servers}))
+        return path
+
+    def test_codex_reads_dotmcp(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        self._write_mcp_json(tmp_path, {
+            "github": {"command": "gh", "args": ["mcp"]},
+        })
+        entries = connector_paths.mcp_servers("codex")
+        assert [e.name for e in entries] == ["github"]
+        assert entries[0].command == "gh"
+        assert entries[0].args == ["mcp"]
+
+    def test_codex_no_dotmcp_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert connector_paths.mcp_servers("codex") == []
+
+    def test_claudecode_merges_settings_and_dotmcp(
+        self, tmp_path, monkeypatch,
+    ):
+        # Override $HOME so we can write a fake .claude/settings.json
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        (fake_home / ".claude").mkdir()
+        (fake_home / ".claude" / "settings.json").write_text(json.dumps({
+            "mcpServers": {
+                "from-settings": {"command": "x"},
+            },
+        }))
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        cwd = tmp_path / "project"
+        cwd.mkdir()
+        self._write_mcp_json(cwd, {
+            "from-mcp-json": {"command": "y"},
+        })
+        monkeypatch.chdir(cwd)
+
+        entries = connector_paths.mcp_servers("claudecode")
+        names = [e.name for e in entries]
+        assert "from-settings" in names
+        assert "from-mcp-json" in names
+
+    def test_zeptoclaw_reads_config_json(self, tmp_path, monkeypatch):
+        fake_home = tmp_path / "home"
+        (fake_home / ".zeptoclaw").mkdir(parents=True)
+        (fake_home / ".zeptoclaw" / "config.json").write_text(json.dumps({
+            "mcp": {"servers": {
+                "zepto-srv": {"command": "z", "transport": "stdio"},
+            }},
+        }))
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.chdir(tmp_path)
+
+        entries = connector_paths.mcp_servers("zeptoclaw")
+        names = [e.name for e in entries]
+        assert "zepto-srv" in names
+        srv = next(e for e in entries if e.name == "zepto-srv")
+        assert srv.transport == "stdio"
+
+    def test_zeptoclaw_dedups_when_dotmcp_repeats_name(
+        self, tmp_path, monkeypatch,
+    ):
+        fake_home = tmp_path / "home"
+        (fake_home / ".zeptoclaw").mkdir(parents=True)
+        (fake_home / ".zeptoclaw" / "config.json").write_text(json.dumps({
+            "mcp": {"servers": {
+                "shared": {"command": "from-config"},
+            }},
+        }))
+        monkeypatch.setenv("HOME", str(fake_home))
+        cwd = tmp_path / "p"
+        cwd.mkdir()
+        self._write_mcp_json(cwd, {"shared": {"command": "from-mcp"}})
+        monkeypatch.chdir(cwd)
+
+        entries = connector_paths.mcp_servers("zeptoclaw")
+        # First-write-wins → config.json beats .mcp.json on dedup.
+        assert len(entries) == 1
+        assert entries[0].command == "from-config"
+
+    def test_openclaw_reads_openclaw_json_when_cli_unavailable(
+        self, tmp_path, monkeypatch,
+    ):
+        oc_path = tmp_path / "openclaw.json"
+        oc_path.write_text(json.dumps({
+            "mcp": {"servers": {
+                "oc-srv": {"command": "openclaw-mcp"},
+            }},
+        }))
+
+        # Force the CLI helper to return None (=> fallback to file).
+        monkeypatch.setattr(
+            connector_paths,
+            "_read_mcp_servers_via_openclaw_cli",
+            lambda **_kw: None,
+        )
+
+        entries = connector_paths.mcp_servers(
+            "openclaw", openclaw_config=str(oc_path),
+        )
+        assert [e.name for e in entries] == ["oc-srv"]
+
+
+# ---------------------------------------------------------------------------
+# Round-trip via Config.skill_dirs / plugin_dirs / mcp_servers
+# ---------------------------------------------------------------------------
+
+class TestConfigDispatch:
+    def test_config_skill_dirs_uses_active_connector(self):
+        from defenseclaw import config
+
+        cfg = config.default_config()
+        cfg.guardrail.connector = "codex"
+        dirs = cfg.skill_dirs()
+        home = str(Path.home())
+        assert os.path.join(home, ".codex", "skills") in dirs
+
+    def test_config_plugin_dirs_uses_active_connector(self):
+        from defenseclaw import config
+
+        cfg = config.default_config()
+        cfg.guardrail.connector = "claudecode"
+        dirs = cfg.plugin_dirs()
+        home = str(Path.home())
+        assert os.path.join(home, ".claude", "plugins") in dirs
+
+    def test_config_active_connector_precedence(self):
+        from defenseclaw import config
+
+        cfg = config.default_config()
+        cfg.guardrail.connector = "  codex  "
+        cfg.claw.mode = "openclaw"
+        assert cfg.active_connector() == "codex"
+
+        cfg.guardrail.connector = ""
+        cfg.claw.mode = "ZeptoClaw"
+        assert cfg.active_connector() == "zeptoclaw"
+
+        cfg.guardrail.connector = ""
+        cfg.claw.mode = ""
+        assert cfg.active_connector() == "openclaw"
+
+
+# ---------------------------------------------------------------------------
+# Re-export contract — MCPServerEntry must remain importable from
+# defenseclaw.config so downstream callers (cmd_mcp, tests) don't break.
+# ---------------------------------------------------------------------------
+
+class TestMCPServerEntryReExport:
+    def test_importable_from_config(self):
+        from defenseclaw.config import MCPServerEntry as MCPFromConfig
+        assert MCPFromConfig is MCPServerEntry


### PR DESCRIPTION
## Summary

Mirror the Go-side dispatch architecture
(\`internal/config/claw.go::SkillDirsForConnector\` /
\`PluginDirsForConnector\` / \`ReadMCPServersForConnector\`) on the
Python side, in a standalone module that has **no \`Config\`
dependency**. Pulls ~290 lines of private helpers out of \`config.py\`
and replaces them with thin delegators.

## Changes

\`cli/defenseclaw/connector_paths.py\` (new — single source of truth)

- \`KNOWN_CONNECTORS = (\"openclaw\", \"codex\", \"claudecode\", \"zeptoclaw\")\`
- \`normalize(name)\` — trim/lowercase/default-to-\`openclaw\`
- \`is_known(name)\` — allow-list check
- \`skill_dirs(connector, openclaw_home, openclaw_config)\`
- \`plugin_dirs(connector, openclaw_home)\`
- \`mcp_servers(connector, openclaw_config, openclaw_bin_resolver, openclaw_cmd_prefix)\`
- \`MCPServerEntry\` dataclass (re-exported from \`defenseclaw.config\`
  for back-compat with existing \`cmd_mcp\` and tests imports)

\`cli/defenseclaw/config.py\` (-290 lines)

- \`Config.active_connector()\` — Python parity for Go's
  \`Config.activeConnector\`: precedence
  \`guardrail.connector\` > \`claw.mode\` > \`\"openclaw\"\`.
- \`Config.skill_dirs()\` / \`plugin_dirs()\` / \`mcp_servers()\` —
  one-line delegators.
- Back-compat re-exports of \`_dedup\`, \`_parse_mcp_servers_dict\`,
  \`_read_openclaw_config\`, \`_read_mcp_servers_from_file\` so
  pre-existing \`tests/test_config.py\` imports keep working without a
  churn PR.

## Why

The downstream consumers in the next wave —
**cmd_doctor (S6.5)**, **cmd_uninstall (S7.3)**, **cmd_setup_sandbox
(S4.5)**, **claw_inventory (S4.3)** — all need to walk \"every
connector's footprint\" without instantiating a \`Config\`. Pulling
the dispatch into a standalone module (no circular import, no
side-effects on import) lets them iterate \`KNOWN_CONNECTORS\`
directly. It also localizes the \"add a fifth connector\" change to
one file.

## Tests

\`cli/tests/test_connector_paths.py\` (new — 22 cases)

- \`TestNormalize\`, \`TestIsKnown\` — None/empty/whitespace/mixed
  case.
- \`TestSkillDirs\` — every connector branch + OpenClaw \`extraDirs\`
  from \`openclaw.json\` + unknown-connector OpenClaw fallback.
- \`TestPluginDirs\` — every connector branch + cross-connector
  disjointness invariant (\"each framework owns its own paths\").
- \`TestMCPServers\` — Codex \`.mcp.json\`, Claude Code
  \`settings.json\`+\`.mcp.json\` merge, ZeptoClaw \`config.json\` +
  dedup, OpenClaw \`openclaw.json\` fallback when CLI unavailable.
- \`TestConfigDispatch\` — round-trips
  \`Config.skill_dirs\`/\`plugin_dirs\`/\`active_connector\` across
  connector switches.
- \`TestMCPServerEntryReExport\` — pins the back-compat alias.

## Test plan

- [x] \`pytest cli/tests/test_connector_paths.py\` — all green
- [x] \`pytest cli/tests/test_config.py cli/tests/test_cmd_mcp.py\` — 178/178 green
- [x] \`pytest cli/tests/ --ignore=test_cmd_plugin.py\` — 1106 passed, 1 skipped
- [x] \`go build ./...\` clean; \`go test ./internal/config/...\` green
- [x] \`test_cmd_plugin.py\` regression footprint matches parent SHA (only the pre-existing \`TestResolvePluginDir::test_resolves_root_when_source_is_file_in_dist_subdir\` fails)

## Refs

- S4.1 (claw-agnostic plan, Wave 2)
- Companion to #177 (Go-side polymorphic SkillDirs/PluginDirs)
- Stacks on top of #168 / #171 / #172 / #173 / #174 / #175 / #176 / #177