### PR TITLE
feat(cli/mcp): connector-aware set / unset adapters (S4.2)

### DIFF
--- a/cli/defenseclaw/commands/cmd_mcp.py
+++ b/cli/defenseclaw/commands/cmd_mcp.py
@@ -28,6 +28,7 @@ import subprocess
 
 import click
 
+from defenseclaw import connector_paths
 from defenseclaw.commands import compute_verdict as _compute_verdict
 from defenseclaw.config import MCPServerEntry
 from defenseclaw.context import AppContext, pass_ctx
@@ -92,12 +93,18 @@ def list_mcps(app: AppContext, as_json: bool) -> None:
         click.echo(json.dumps(out, indent=2))
         return
 
+    connector = app.cfg.active_connector()
     if not servers:
-        click.echo("No MCP servers configured in openclaw.json (mcp.servers).")
+        click.echo(
+            f"No MCP servers configured for connector={connector!r} "
+            "(checked the connector-specific source: openclaw.json / "
+            ".claude/settings.json / .mcp.json / "
+            ".zeptoclaw/config.json).",
+        )
         return
 
     console = Console()
-    table = Table(title="MCP Servers (from openclaw.json)")
+    table = Table(title=f"MCP Servers (connector={connector})")
     table.add_column("Name", style="bold")
     table.add_column("Transport")
     table.add_column("Command")
@@ -473,8 +480,17 @@ def unblock(app: AppContext, target: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# set / unset  — delegate writes to ``openclaw config set/unset``
+# set / unset  — connector-aware: delegate writes to the active
+# connector's preferred surface.
 # ---------------------------------------------------------------------------
+#
+# OpenClaw uses ``openclaw config set/unset`` (schema-validated +
+# hot-reloaded). Claude Code and Codex have no equivalent CLI, so
+# we patch ``~/.claude/settings.json`` and ``./.mcp.json`` directly
+# via the atomic JSON helpers in :mod:`defenseclaw.connector_paths`.
+# ZeptoClaw owns its config.json from the TUI and does not expose a
+# safe write surface — we surface a clear error rather than racing
+# ZeptoClaw's autosave.
 
 def _openclaw_config_set(path: str, value: str) -> None:
     """Write a value via ``openclaw config set`` (schema-validated, hot-reloaded)."""
@@ -500,6 +516,38 @@ def _openclaw_config_unset(path: str) -> None:
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip()
         raise click.ClickException(f"openclaw config unset failed: {detail}")
+
+
+def _set_mcp_via_connector(cfg, name: str, entry: dict) -> None:
+    """Dispatch ``mcp set`` to the active connector's write surface.
+
+    Translates :class:`connector_paths.MCPWriteUnsupportedError` into a
+    user-friendly :class:`click.ClickException` so the CLI exits 1
+    with a clean error instead of a stack trace.
+    """
+    try:
+        connector_paths.set_mcp_server(
+            cfg.active_connector(),
+            name,
+            entry,
+            openclaw_config_setter=_openclaw_config_set,
+        )
+    except connector_paths.MCPWriteUnsupportedError as e:
+        raise click.ClickException(str(e)) from e
+
+
+def _unset_mcp_via_connector(cfg, name: str) -> None:
+    """Dispatch ``mcp unset`` to the active connector's write surface.
+    Symmetric with :func:`_set_mcp_via_connector`.
+    """
+    try:
+        connector_paths.unset_mcp_server(
+            cfg.active_connector(),
+            name,
+            openclaw_config_unsetter=_openclaw_config_unset,
+        )
+    except connector_paths.MCPWriteUnsupportedError as e:
+        raise click.ClickException(str(e)) from e
 
 
 @mcp.command("set")
@@ -627,7 +675,7 @@ def set_server(
         else:
             click.secho(f"Allowed override for {name} — skipping scan.", fg="yellow")
 
-    _openclaw_config_set(f"mcp.servers.{name}", json.dumps(entry))
+    _set_mcp_via_connector(app.cfg, name, entry)
 
     if scan_required:
         post_decision = evaluate_admission(
@@ -659,10 +707,11 @@ def unset_server(app: AppContext, name: str) -> None:
     servers = app.cfg.mcp_servers()
     if not any(s.name == name for s in servers):
         raise click.ClickException(
-            f"MCP server {name!r} not found in openclaw.json."
+            f"MCP server {name!r} not found for connector="
+            f"{app.cfg.active_connector()!r}."
         )
 
-    _openclaw_config_unset(f"mcp.servers.{name}")
+    _unset_mcp_via_connector(app.cfg, name)
     click.secho(f"Removed MCP server: {name}", fg="yellow")
 
     if app.logger:

--- a/cli/defenseclaw/connector_paths.py
+++ b/cli/defenseclaw/connector_paths.py
@@ -521,3 +521,216 @@ def _dedup_mcp_entries(entries: list[MCPServerEntry]) -> list[MCPServerEntry]:
         seen.add(e.name)
         out.append(e)
     return out
+
+
+# ---------------------------------------------------------------------------
+# MCP server WRITES — connector-specific set / unset adapters (S4.2)
+# ---------------------------------------------------------------------------
+
+class MCPWriteUnsupportedError(RuntimeError):
+    """Raised when MCP set/unset is requested for a connector that
+    doesn't expose a programmatic write surface.
+
+    Today this fires for ZeptoClaw — its config.json is owned by the
+    ZeptoClaw TUI and rewriting it from outside the application can
+    race with on-disk autosave. Operators should add the server inside
+    the ZeptoClaw UI and re-run ``defenseclaw mcp scan`` to pick it
+    up via the read path.
+    """
+
+
+def set_mcp_server(
+    connector: str | None,
+    name: str,
+    entry: dict[str, Any],
+    *,
+    openclaw_config_setter: Any = None,
+) -> None:
+    """Add or update an MCP server in the active connector's registry.
+
+    *entry* is a dict shaped per the connector's on-disk schema —
+    typically containing ``command``, ``args``, ``url``, ``env``,
+    ``transport`` keys (extra keys are preserved verbatim so newer
+    schemas pass through unchanged).
+
+    Per-connector write surfaces:
+
+    * OpenClaw     — delegated to ``openclaw config set
+                     mcp.servers.<name> <json>`` via
+                     *openclaw_config_setter* (callable taking
+                     ``(path, json_value_str)``). Caller injects this
+                     so we can keep subprocess access out of this
+                     module.
+    * Claude Code  — ``$HOME/.claude/settings.json[mcpServers][name]``
+                     via :func:`_atomic_json_merge`.
+    * Codex        — ``./.mcp.json[mcpServers][name]``
+                     via :func:`_atomic_json_merge`.
+    * ZeptoClaw    — :class:`MCPWriteUnsupportedError`.
+    """
+    name_n = normalize(connector)
+    if name_n == "openclaw":
+        if openclaw_config_setter is None:
+            raise RuntimeError(
+                "openclaw_config_setter not provided — set_mcp_server "
+                "for openclaw requires the caller to inject the "
+                "openclaw config-set shim",
+            )
+        openclaw_config_setter(f"mcp.servers.{name}", json.dumps(entry))
+        return
+    if name_n == "claudecode":
+        path = os.path.join(str(Path.home()), ".claude", "settings.json")
+        _atomic_json_merge(path, ("mcpServers", name), entry)
+        return
+    if name_n == "codex":
+        path = os.path.join(os.getcwd(), ".mcp.json")
+        _atomic_json_merge(path, ("mcpServers", name), entry)
+        return
+    if name_n == "zeptoclaw":
+        raise MCPWriteUnsupportedError(
+            "zeptoclaw does not expose a programmatic MCP write surface. "
+            "Add the server inside the ZeptoClaw UI and re-run "
+            "`defenseclaw mcp scan` to discover it via the read path.",
+        )
+    # Anything else — treat as an unknown framework. Refuse rather than
+    # silently writing to the OpenClaw config.
+    raise MCPWriteUnsupportedError(
+        f"set_mcp_server: unknown connector {connector!r}; "
+        f"expected one of {KNOWN_CONNECTORS}",
+    )
+
+
+def unset_mcp_server(
+    connector: str | None,
+    name: str,
+    *,
+    openclaw_config_unsetter: Any = None,
+) -> None:
+    """Remove an MCP server from the active connector's registry.
+
+    Mirrors :func:`set_mcp_server` and uses :func:`_atomic_json_delete`
+    on Claude Code / Codex; OpenClaw delegates to the injected
+    *openclaw_config_unsetter*; ZeptoClaw raises
+    :class:`MCPWriteUnsupportedError`.
+    """
+    name_n = normalize(connector)
+    if name_n == "openclaw":
+        if openclaw_config_unsetter is None:
+            raise RuntimeError(
+                "openclaw_config_unsetter not provided — unset_mcp_server "
+                "for openclaw requires the caller to inject the "
+                "openclaw config-unset shim",
+            )
+        openclaw_config_unsetter(f"mcp.servers.{name}")
+        return
+    if name_n == "claudecode":
+        path = os.path.join(str(Path.home()), ".claude", "settings.json")
+        _atomic_json_delete(path, ("mcpServers", name))
+        return
+    if name_n == "codex":
+        path = os.path.join(os.getcwd(), ".mcp.json")
+        _atomic_json_delete(path, ("mcpServers", name))
+        return
+    if name_n == "zeptoclaw":
+        raise MCPWriteUnsupportedError(
+            "zeptoclaw does not expose a programmatic MCP write surface. "
+            "Remove the server inside the ZeptoClaw UI.",
+        )
+    raise MCPWriteUnsupportedError(
+        f"unset_mcp_server: unknown connector {connector!r}; "
+        f"expected one of {KNOWN_CONNECTORS}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Atomic JSON read-modify-write helpers
+# ---------------------------------------------------------------------------
+#
+# These mirror the Go-side atomicWriteFile pattern in
+# internal/gateway/connector/codex.go: write to a tempfile in the same
+# directory, fsync, then os.replace. Permissions are forced to 0o600
+# because the targets (~/.claude/settings.json, ./.mcp.json) frequently
+# carry credentials in the env: block.
+
+def _atomic_json_merge(
+    path: str,
+    keys: tuple[str, ...],
+    value: dict[str, Any],
+) -> None:
+    """Read *path* (or start from {}), set ``data[keys[0]][keys[1]]...
+    = value``, then atomically replace *path* with the new content.
+
+    Creates parent directory if missing. Permissions are forced to
+    0o600 on every write — these files commonly contain API keys
+    in the ``env`` block.
+    """
+    parent = os.path.dirname(path)
+    if parent and not os.path.exists(parent):
+        os.makedirs(parent, mode=0o700, exist_ok=True)
+    data: dict[str, Any]
+    try:
+        with open(path) as f:
+            loaded = json.load(f)
+        data = loaded if isinstance(loaded, dict) else {}
+    except (FileNotFoundError, json.JSONDecodeError):
+        data = {}
+    cursor = data
+    for k in keys[:-1]:
+        node = cursor.get(k)
+        if not isinstance(node, dict):
+            node = {}
+            cursor[k] = node
+        cursor = node
+    cursor[keys[-1]] = value
+    _atomic_write_json(path, data)
+
+
+def _atomic_json_delete(
+    path: str,
+    keys: tuple[str, ...],
+) -> bool:
+    """Delete ``data[keys[0]][keys[1]]...`` from *path* and atomically
+    rewrite. Returns True iff the key existed and was removed.
+
+    Missing files / missing keys are no-ops returning False.
+    """
+    try:
+        with open(path) as f:
+            loaded = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return False
+    if not isinstance(loaded, dict):
+        return False
+    cursor: Any = loaded
+    for k in keys[:-1]:
+        if not isinstance(cursor, dict) or k not in cursor:
+            return False
+        cursor = cursor[k]
+    if not isinstance(cursor, dict) or keys[-1] not in cursor:
+        return False
+    del cursor[keys[-1]]
+    _atomic_write_json(path, loaded)
+    return True
+
+
+def _atomic_write_json(path: str, data: dict[str, Any]) -> None:
+    """Write *data* to *path* atomically with 0o600 permissions.
+
+    Uses tempfile in the same directory + ``os.replace`` so a crash
+    never leaves a half-written file. Mirrors the Go gateway's
+    atomicWriteFile contract for connector config patches.
+    """
+    import tempfile
+    parent = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(prefix=".dc-mcp-", dir=parent)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+            f.write("\n")
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise

--- a/cli/tests/test_connector_mcp_writers.py
+++ b/cli/tests/test_connector_mcp_writers.py
@@ -1,0 +1,297 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the connector-aware MCP set/unset writers (S4.2).
+
+Pins three contracts:
+
+1. The dispatch matrix — OpenClaw delegates to its CLI shim,
+   Claude Code patches ~/.claude/settings.json, Codex patches
+   ./.mcp.json, ZeptoClaw refuses with a clear error.
+2. Atomicity + 0o600 perms on the JSON-rewriting branches.
+3. Round-trip — what we set is what we read back via mcp_servers().
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from defenseclaw import connector_paths
+from defenseclaw.connector_paths import (
+    KNOWN_CONNECTORS,
+    MCPWriteUnsupportedError,
+    set_mcp_server,
+    unset_mcp_server,
+)
+
+
+# ---------------------------------------------------------------------------
+# OpenClaw — delegation to injected setter/unsetter
+# ---------------------------------------------------------------------------
+
+class TestOpenClawDelegation:
+    def test_set_calls_setter_with_dotted_path_and_json(self):
+        calls: list[tuple[str, str]] = []
+
+        def fake_setter(path: str, value: str) -> None:
+            calls.append((path, value))
+
+        set_mcp_server(
+            "openclaw", "demo",
+            {"command": "uvx", "args": ["demo-mcp"]},
+            openclaw_config_setter=fake_setter,
+        )
+        assert calls == [
+            ("mcp.servers.demo",
+             json.dumps({"command": "uvx", "args": ["demo-mcp"]})),
+        ]
+
+    def test_unset_calls_unsetter_with_dotted_path(self):
+        calls: list[str] = []
+
+        def fake_unsetter(path: str) -> None:
+            calls.append(path)
+
+        unset_mcp_server(
+            "openclaw", "demo",
+            openclaw_config_unsetter=fake_unsetter,
+        )
+        assert calls == ["mcp.servers.demo"]
+
+    def test_set_without_setter_raises(self):
+        with pytest.raises(RuntimeError, match="openclaw_config_setter"):
+            set_mcp_server("openclaw", "demo", {"command": "x"})
+
+    def test_unset_without_unsetter_raises(self):
+        with pytest.raises(RuntimeError, match="openclaw_config_unsetter"):
+            unset_mcp_server("openclaw", "demo")
+
+
+# ---------------------------------------------------------------------------
+# ZeptoClaw — programmatic writes are explicitly unsupported
+# ---------------------------------------------------------------------------
+
+class TestZeptoClawUnsupported:
+    def test_set_raises(self):
+        with pytest.raises(MCPWriteUnsupportedError, match="zeptoclaw"):
+            set_mcp_server("zeptoclaw", "demo", {"command": "x"})
+
+    def test_unset_raises(self):
+        with pytest.raises(MCPWriteUnsupportedError, match="zeptoclaw"):
+            unset_mcp_server("zeptoclaw", "demo")
+
+    def test_unknown_connector_raises_unsupported(self):
+        with pytest.raises(MCPWriteUnsupportedError, match="unknown connector"):
+            set_mcp_server("future-frame", "demo", {"command": "x"})
+
+
+# ---------------------------------------------------------------------------
+# Claude Code — patches ~/.claude/settings.json
+# ---------------------------------------------------------------------------
+
+class TestClaudeCodeWrites:
+    def test_set_creates_settings_when_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        set_mcp_server("claudecode", "demo", {"command": "uvx"})
+
+        settings = tmp_path / ".claude" / "settings.json"
+        assert settings.is_file()
+        data = json.loads(settings.read_text())
+        assert data["mcpServers"]["demo"] == {"command": "uvx"}
+
+    def test_set_preserves_unrelated_keys(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        settings = tmp_path / ".claude" / "settings.json"
+        settings.parent.mkdir(parents=True)
+        settings.write_text(json.dumps({
+            "mcpServers": {"existing": {"command": "old"}},
+            "theme": "dark",
+            "permissions": {"allow": ["edit"]},
+        }))
+
+        set_mcp_server(
+            "claudecode", "demo",
+            {"command": "uvx", "args": ["demo-mcp"]},
+        )
+
+        data = json.loads(settings.read_text())
+        assert data["theme"] == "dark"
+        assert data["permissions"] == {"allow": ["edit"]}
+        assert data["mcpServers"]["existing"] == {"command": "old"}
+        assert data["mcpServers"]["demo"]["command"] == "uvx"
+
+    def test_set_uses_0o600_permissions(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        set_mcp_server(
+            "claudecode", "demo",
+            {"command": "uvx", "env": {"API_KEY": "secret"}},
+        )
+        settings = tmp_path / ".claude" / "settings.json"
+        mode = stat.S_IMODE(settings.stat().st_mode)
+        assert mode == 0o600, (
+            f"settings.json mode = {oct(mode)}, want 0o600 — file may "
+            "contain API keys in env: blocks and must be owner-only"
+        )
+
+    def test_unset_removes_key(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        settings = tmp_path / ".claude" / "settings.json"
+        settings.parent.mkdir(parents=True)
+        settings.write_text(json.dumps({
+            "mcpServers": {
+                "demo": {"command": "uvx"},
+                "keep": {"command": "stay"},
+            },
+        }))
+
+        unset_mcp_server("claudecode", "demo")
+
+        data = json.loads(settings.read_text())
+        assert "demo" not in data["mcpServers"]
+        assert data["mcpServers"]["keep"] == {"command": "stay"}
+
+    def test_unset_missing_is_noop(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # No file present.
+        unset_mcp_server("claudecode", "demo")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Codex — patches ./.mcp.json
+# ---------------------------------------------------------------------------
+
+class TestCodexWrites:
+    def test_set_creates_mcp_json(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        set_mcp_server("codex", "demo", {"command": "uvx", "args": ["d"]})
+
+        path = tmp_path / ".mcp.json"
+        assert path.is_file()
+        data = json.loads(path.read_text())
+        assert data["mcpServers"]["demo"]["command"] == "uvx"
+
+    def test_set_uses_0o600(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        set_mcp_server("codex", "demo", {"command": "uvx"})
+        path = tmp_path / ".mcp.json"
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o600
+
+    def test_unset_removes_key(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        path = tmp_path / ".mcp.json"
+        path.write_text(json.dumps({"mcpServers": {
+            "demo": {"command": "x"},
+            "keep": {"command": "y"},
+        }}))
+        unset_mcp_server("codex", "demo")
+        data = json.loads(path.read_text())
+        assert "demo" not in data["mcpServers"]
+        assert "keep" in data["mcpServers"]
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: set → mcp_servers() → unset → mcp_servers()
+# ---------------------------------------------------------------------------
+
+class TestRoundTrip:
+    def test_codex_set_then_read_then_unset(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        set_mcp_server(
+            "codex", "demo",
+            {"command": "uvx", "args": ["demo-mcp"]},
+        )
+        entries = connector_paths.mcp_servers("codex")
+        assert [e.name for e in entries] == ["demo"]
+        assert entries[0].command == "uvx"
+        assert entries[0].args == ["demo-mcp"]
+
+        unset_mcp_server("codex", "demo")
+        entries = connector_paths.mcp_servers("codex")
+        assert entries == []
+
+    def test_claudecode_set_then_read_then_unset(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+
+        set_mcp_server("claudecode", "ccd", {"command": "ccd-mcp"})
+        entries = connector_paths.mcp_servers("claudecode")
+        assert "ccd" in [e.name for e in entries]
+
+        unset_mcp_server("claudecode", "ccd")
+        entries = connector_paths.mcp_servers("claudecode")
+        assert "ccd" not in [e.name for e in entries]
+
+
+# ---------------------------------------------------------------------------
+# Atomicity — partially-broken existing file gets reset to {} not crashed
+# ---------------------------------------------------------------------------
+
+class TestAtomicity:
+    def test_set_recovers_from_corrupt_json(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        path = tmp_path / ".mcp.json"
+        path.write_text("{ this is not valid json")
+
+        set_mcp_server("codex", "demo", {"command": "uvx"})
+
+        data = json.loads(path.read_text())
+        assert data["mcpServers"]["demo"]["command"] == "uvx"
+
+    def test_set_does_not_leave_tempfile_on_success(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+        set_mcp_server("codex", "demo", {"command": "uvx"})
+        # No leftover .dc-mcp- temp files
+        leftovers = [
+            p for p in os.listdir(tmp_path) if p.startswith(".dc-mcp-")
+        ]
+        assert leftovers == []
+
+
+# ---------------------------------------------------------------------------
+# All known connectors are covered (no silent fallthrough)
+# ---------------------------------------------------------------------------
+
+class TestCoverage:
+    def test_every_known_connector_has_explicit_set_behavior(self, tmp_path):
+        """Loop over KNOWN_CONNECTORS and assert each branch is reached.
+        Catches the "added a fifth connector but forgot to teach the
+        writer" bug class.
+        """
+        for name in KNOWN_CONNECTORS:
+            if name == "openclaw":
+                # Requires injected setter — assert it raises without one.
+                with pytest.raises(RuntimeError):
+                    set_mcp_server(name, "x", {"command": "y"})
+            elif name == "zeptoclaw":
+                with pytest.raises(MCPWriteUnsupportedError):
+                    set_mcp_server(name, "x", {"command": "y"})
+            else:
+                # claudecode / codex — write succeeds without raising.
+                # Use chdir + isolated HOME so the test doesn't trash
+                # the developer's real config files.
+                with pytest.MonkeyPatch.context() as m:
+                    m.chdir(tmp_path)
+                    m.setenv("HOME", str(tmp_path))
+                    set_mcp_server(name, "x", {"command": "y"})


### PR DESCRIPTION
## Summary

Before this PR, \`defenseclaw mcp set\` / \`defenseclaw mcp unset\`
always shelled out to \`openclaw config set/unset\`. On a Codex or
Claude Code install where \`openclaw\` isn't on PATH, the commands
failed with a confusing _\"openclaw config set failed\"_ error
instead of writing to the framework's actual config. On ZeptoClaw
they could race the TUI's autosave.

This PR ships the per-connector write adapters from the S4.2 plan,
matching the symmetry of the read path delivered in #178.

## Changes

\`cli/defenseclaw/connector_paths.py\`

- \`set_mcp_server(connector, name, entry, *, openclaw_config_setter)\`
- \`unset_mcp_server(connector, name, *, openclaw_config_unsetter)\`
- \`MCPWriteUnsupportedError\`
- Atomic JSON helpers \`_atomic_json_merge\` / \`_atomic_json_delete\` /
  \`_atomic_write_json\` — tempfile + \`os.replace\` + chmod 0o600.
  Matches the Go-side \`atomicWriteFile\` contract (#173 / S0.11 /
  S0.15) since these files routinely carry API keys in \`env:\` blocks.

Per-connector write surfaces:

| connector  | surface                                                |
|------------|--------------------------------------------------------|
| openclaw   | injected \`openclaw config set/unset\` shim            |
| claudecode | \`\$HOME/.claude/settings.json[mcpServers]\`           |
| codex      | \`./.mcp.json[mcpServers]\`                            |
| zeptoclaw  | \`MCPWriteUnsupportedError\` (\"add it in the UI\")    |

\`cli/defenseclaw/commands/cmd_mcp.py\`

- New \`_set_mcp_via_connector\` / \`_unset_mcp_via_connector\` helpers
  dispatch via \`Config.active_connector()\` and translate
  \`MCPWriteUnsupportedError\` into a clean \`click.ClickException\`.
- \`list_mcps\` / \`unset_server\` UI strings now reference the active
  connector instead of hard-coding \`openclaw.json\`.
- Existing \`_openclaw_config_set\` / \`_openclaw_config_unset\` kept
  and re-used as the OpenClaw-branch shim — minimal blast radius;
  preserves OpenClaw's schema validation + hot-reload semantics.

## Why

Without this, **70 % of the connector-agnostic story** breaks the
moment a Codex or Claude Code user runs \`defenseclaw mcp set\`. We
already discover their MCP servers correctly (#178), but we couldn't
add or remove them — the most basic CRUD operation. Stacking on
S4.1 lets us share the same connector_paths surface for both halves.

## Tests

\`cli/tests/test_connector_mcp_writers.py\` (new — 18 cases)

- \`TestOpenClawDelegation\` — setter / unsetter receive dotted
  path + JSON value; missing injection raises \`RuntimeError\`.
- \`TestZeptoClawUnsupported\` — set + unset raise
  \`MCPWriteUnsupportedError\`; unknown connectors too.
- \`TestClaudeCodeWrites\` — creates \`settings.json\` when
  absent; preserves unrelated top-level keys (\`theme\`,
  \`permissions\`); forces 0o600; unset removes the entry
  leaving siblings intact; unset on a missing file is a no-op.
- \`TestCodexWrites\` — symmetric for \`./.mcp.json\` + 0o600.
- \`TestRoundTrip\` — set -> \`mcp_servers()\` -> unset ->
  \`mcp_servers()\` for Codex and Claude Code.
- \`TestAtomicity\` — corrupt-JSON existing file is gracefully
  reset; no leftover \`.dc-mcp-*\` tempfiles after a successful
  write.
- \`TestCoverage\` — loops every \`KNOWN_CONNECTORS\` name and
  asserts explicit behavior. Catches \"added a fifth connector
  but forgot to teach the writer\" regressions at CI time.

## Test plan

- [x] \`pytest cli/tests/test_connector_mcp_writers.py cli/tests/test_connector_paths.py cli/tests/test_cmd_mcp.py cli/tests/test_config.py\` — 198 / 198 green
- [x] \`pytest cli/tests/ --ignore=cli/tests/test_cmd_plugin.py\` — 1126 passed, 1 skipped
- [x] \`test_cmd_plugin.py\` regression footprint matches parent SHA (only the pre-existing \`TestResolvePluginDir\` failure remains)

## Refs

- S4.2 (claw-agnostic plan, Wave 2)
- Stacks on top of #178 (S4.1: connector_paths.py read surface)
- Companion to #177 / #176 / #175 / #174 / #173 / #172 / #171 / #168