### PR TITLE
S4.3: connector-agnostic AIBOM via filesystem adapter

### DIFF
--- a/cli/defenseclaw/inventory/claw_inventory.py
+++ b/cli/defenseclaw/inventory/claw_inventory.py
@@ -25,11 +25,13 @@ Commands are dispatched in parallel via ``ThreadPoolExecutor`` and deduplicated
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
 from typing import Any, NamedTuple
 
+from defenseclaw import connector_paths
 from defenseclaw.config import Config, SkillActionsConfig, _expand
 from defenseclaw.models import ActionEntry, Finding, ScanResult
 
@@ -79,13 +81,24 @@ def build_claw_aibom(
     live: bool = True,
     categories: set[str] | None = None,
 ) -> dict[str, Any]:
-    """Collect the OpenClaw inventory.
+    """Collect a connector-agnostic agent-framework inventory.
 
-    When *live* is True (default), runs ``openclaw … --json`` commands in
-    parallel and merges results.  Use *categories* to restrict which sections
-    are collected (default: all).
+    Dispatches via :meth:`Config.active_connector`. For OpenClaw —
+    the historical default — *live=True* shells out to ``openclaw …
+    --json`` commands in parallel; for Codex / Claude Code / ZeptoClaw
+    we walk the filesystem under :func:`connector_paths.skill_dirs`,
+    :func:`connector_paths.plugin_dirs`, and
+    :func:`connector_paths.mcp_servers`.
+
+    *categories* restricts which sections are collected (default: all).
+    *live=False* always returns the disk-only shape (no subprocess
+    calls, no filesystem walk).
     """
     cats = _resolve_categories(categories)
+    connector = cfg.active_connector()
+    if connector != "openclaw" and live:
+        return _build_aibom_from_filesystem(cfg, connector, cats)
+
     claw_home = cfg.claw_home_dir()
     now = datetime.now(timezone.utc).isoformat()
 
@@ -97,6 +110,7 @@ def build_claw_aibom(
     out: dict[str, Any] = {
         "version": INVENTORY_VERSION,
         "generated_at": now,
+        "connector": connector,
         "openclaw_config": _expand(cfg.claw.config_file),
         "claw_home": claw_home,
         "claw_mode": cfg.claw.mode,
@@ -1214,5 +1228,243 @@ def _parse_memory(raw: Any) -> list[dict[str, Any]]:
         vector = s.get("vector", {})
         if isinstance(vector, dict):
             row["vector_enabled"] = vector.get("enabled", False)
+        rows.append(row)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Non-OpenClaw filesystem adapter (S4.3)
+# ---------------------------------------------------------------------------
+#
+# Codex, Claude Code, and ZeptoClaw don't expose a ``<framework> …
+# --json`` style introspection CLI, so we discover their installed
+# components by walking the directory layouts documented in
+# defenseclaw.connector_paths. Categories that are OpenClaw-only
+# concepts (agents, models, memory, tools-as-plugin-export) come back
+# as empty lists with a clear "errors" entry pointing the reader at
+# the connector-specific surface that owns that concept.
+
+_FILESYSTEM_ONLY_CONNECTOR_NOTES: dict[str, str] = {
+    "agents": "agents are not a first-class concept on this connector",
+    "tools": "tool registry is owned by each plugin's manifest",
+    "models": "model providers are configured inside the framework",
+    "memory": "memory backend is private to the framework",
+}
+
+
+def _build_aibom_from_filesystem(
+    cfg: Config,
+    connector: str,
+    cats: frozenset[str],
+) -> dict[str, Any]:
+    """Build an inventory by walking the on-disk skill / plugin / MCP
+    layout for non-OpenClaw connectors.
+
+    Mirrors the schema produced by the OpenClaw CLI path so callers
+    (``defenseclaw aibom``, OPA enrichment, JSON serialization) can
+    treat the result uniformly.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    errors: list[dict[str, str]] = []
+
+    skills: list[dict[str, Any]] = []
+    if "skills" in cats:
+        skills = _enumerate_skills_filesystem(cfg)
+
+    plugins: list[dict[str, Any]] = []
+    if "plugins" in cats:
+        plugins = _enumerate_plugins_filesystem(cfg)
+
+    mcps: list[dict[str, Any]] = []
+    if "mcp" in cats:
+        mcps = _enumerate_mcp_filesystem(cfg)
+
+    # Populate "errors" with informational notes for categories that
+    # don't translate to non-OpenClaw connectors. This keeps the
+    # output schema stable while telling operators why those buckets
+    # are empty.
+    for cat_key, note in _FILESYSTEM_ONLY_CONNECTOR_NOTES.items():
+        if cat_key in cats:
+            errors.append({
+                "command": f"{connector}:{cat_key}",
+                "error": note,
+            })
+
+    out: dict[str, Any] = {
+        "version": INVENTORY_VERSION,
+        "generated_at": now,
+        "connector": connector,
+        "openclaw_config": _expand(cfg.claw.config_file),
+        "claw_home": cfg.claw_home_dir(),
+        "claw_mode": cfg.claw.mode,
+        "live": True,
+        "skills": skills,
+        "plugins": plugins,
+        "mcp": mcps,
+        "agents": [],
+        "tools": [],
+        "model_providers": [],
+        "memory": [],
+        "errors": errors,
+    }
+    out["summary"] = _build_summary(out)
+    return out
+
+
+def _enumerate_skills_filesystem(cfg: Config) -> list[dict[str, Any]]:
+    """Walk every directory in ``cfg.skill_dirs()`` and emit one row
+    per immediate subdirectory.
+
+    A skill is treated as the directory itself; its ``id`` is the
+    basename. ``eligible`` is True if the directory contains at
+    least one of: SKILL.md, skill.json, README.md (matches the
+    discovery contract used by the connector-specific OTel
+    component scanner).
+    """
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for skill_dir in cfg.skill_dirs():
+        if not os.path.isdir(skill_dir):
+            continue
+        try:
+            entries = os.listdir(skill_dir)
+        except OSError:
+            continue
+        for entry in sorted(entries):
+            full = os.path.join(skill_dir, entry)
+            if not os.path.isdir(full):
+                continue
+            if entry in seen:
+                continue
+            seen.add(entry)
+            row: dict[str, Any] = {
+                "id": entry,
+                "source": skill_dir,
+                "eligible": _skill_dir_is_eligible(full),
+                "enabled": True,
+                "bundled": False,
+                "path": full,
+            }
+            description = _read_skill_description(full)
+            if description:
+                row["description"] = description
+            rows.append(row)
+    return rows
+
+
+def _skill_dir_is_eligible(path: str) -> bool:
+    for marker in ("SKILL.md", "skill.json", "README.md"):
+        if os.path.isfile(os.path.join(path, marker)):
+            return True
+    return False
+
+
+def _read_skill_description(path: str) -> str:
+    """Return the first non-empty line of SKILL.md / README.md, if any.
+
+    Bounded to 2 KiB so we don't accidentally slurp a multi-MB README
+    into the inventory dict.
+    """
+    for marker in ("SKILL.md", "README.md"):
+        marker_path = os.path.join(path, marker)
+        if not os.path.isfile(marker_path):
+            continue
+        try:
+            with open(marker_path, encoding="utf-8", errors="replace") as f:
+                text = f.read(2048)
+        except OSError:
+            continue
+        for line in text.splitlines():
+            stripped = line.strip().lstrip("#").strip()
+            if stripped:
+                return stripped[:200]
+    return ""
+
+
+def _enumerate_plugins_filesystem(cfg: Config) -> list[dict[str, Any]]:
+    """One row per plugin directory under ``cfg.plugin_dirs()``.
+
+    A plugin is treated as a directory containing one of the
+    documented manifest names (matches plugin_scanner._MANIFEST_CANDIDATES
+    after S2.3): package.json, manifest.json, plugin.json,
+    openclaw.plugin.json, .codex-plugin/plugin.json,
+    .claude-plugin/plugin.json.
+    """
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for plugin_dir in cfg.plugin_dirs():
+        if not os.path.isdir(plugin_dir):
+            continue
+        try:
+            entries = os.listdir(plugin_dir)
+        except OSError:
+            continue
+        for entry in sorted(entries):
+            if entry == "cache":
+                # Codex / ZeptoClaw use a "cache" sibling for transient
+                # downloads; not a plugin in its own right.
+                continue
+            full = os.path.join(plugin_dir, entry)
+            if not os.path.isdir(full):
+                continue
+            if entry in seen:
+                continue
+            seen.add(entry)
+            manifest = _detect_plugin_manifest(full)
+            row: dict[str, Any] = {
+                "id": entry,
+                "name": entry,
+                "version": "",
+                "origin": plugin_dir,
+                "enabled": True,
+                "status": "loaded" if manifest else "no-manifest",
+                "path": full,
+            }
+            if manifest:
+                row["manifest"] = manifest
+            rows.append(row)
+    return rows
+
+
+_PLUGIN_MANIFEST_FILES: tuple[str, ...] = (
+    "package.json",
+    "manifest.json",
+    "plugin.json",
+    "openclaw.plugin.json",
+    os.path.join(".codex-plugin", "plugin.json"),
+    os.path.join(".claude-plugin", "plugin.json"),
+)
+
+
+def _detect_plugin_manifest(plugin_root: str) -> str:
+    for rel in _PLUGIN_MANIFEST_FILES:
+        candidate = os.path.join(plugin_root, rel)
+        if os.path.isfile(candidate):
+            return rel
+    return ""
+
+
+def _enumerate_mcp_filesystem(cfg: Config) -> list[dict[str, Any]]:
+    """Read MCP servers via the connector-aware
+    :meth:`Config.mcp_servers` helper and convert
+    :class:`MCPServerEntry` rows into the inventory dict shape used by
+    the OpenClaw CLI parser.
+    """
+    rows: list[dict[str, Any]] = []
+    for entry in cfg.mcp_servers():
+        row: dict[str, Any] = {
+            "id": entry.name,
+            "source": f"{cfg.active_connector()} mcp registry",
+        }
+        if entry.command:
+            row["command"] = entry.command
+        if entry.args:
+            row["args"] = list(entry.args)
+        if entry.url:
+            row["url"] = entry.url
+        if entry.transport:
+            row["transport"] = entry.transport
+        if entry.env:
+            row["env_keys"] = sorted(entry.env.keys())
         rows.append(row)
     return rows

--- a/cli/tests/test_claw_inventory.py
+++ b/cli/tests/test_claw_inventory.py
@@ -2001,5 +2001,313 @@ class TestRunOpenclawRawDecodeEdge(unittest.TestCase):
         self.assertTrue(result.data["ok"])
 
 
+# ---------------------------------------------------------------------------
+# S4.3 — Filesystem-adapter inventory for non-OpenClaw connectors
+# ---------------------------------------------------------------------------
+
+
+def _make_cfg_for_connector(tmp: str, connector: str) -> Config:
+    """Build a Config with ``guardrail.connector`` set to *connector*.
+
+    GuardrailConfig only lives on the FullConfig that the CLI builds at
+    runtime; the unit-test Config doesn't carry it. We work around this
+    by stubbing :meth:`Config.active_connector` on the instance below.
+    """
+    ddir = os.path.join(tmp, ".defenseclaw")
+    os.makedirs(ddir, exist_ok=True)
+    cfg = Config(
+        data_dir=ddir,
+        audit_db=os.path.join(ddir, "audit.db"),
+        quarantine_dir=os.path.join(tmp, "q"),
+        plugin_dir=os.path.join(tmp, "p"),
+        policy_dir=os.path.join(tmp, "pol"),
+        claw=ClawConfig(
+            mode="openclaw",
+            home_dir=os.path.join(tmp, "oc"),
+            config_file=os.path.join(tmp, "oc", "openclaw.json"),
+        ),
+    )
+    cfg.active_connector = lambda c=connector: c  # type: ignore[method-assign]
+    return cfg
+
+
+def _seed_skill(root: str, name: str, *, marker: str = "SKILL.md", body: str = "# A skill\n\nFirst paragraph.") -> str:
+    """Create ``<root>/<name>/<marker>`` with *body* and return the dir."""
+    path = os.path.join(root, name)
+    os.makedirs(path, exist_ok=True)
+    with open(os.path.join(path, marker), "w", encoding="utf-8") as f:
+        f.write(body)
+    return path
+
+
+def _seed_plugin(root: str, name: str, *, manifest: str | None = "package.json") -> str:
+    """Create ``<root>/<name>`` and optionally drop a manifest file."""
+    path = os.path.join(root, name)
+    os.makedirs(path, exist_ok=True)
+    if manifest is None:
+        return path
+    rel_dir = os.path.dirname(manifest)
+    if rel_dir:
+        os.makedirs(os.path.join(path, rel_dir), exist_ok=True)
+    with open(os.path.join(path, manifest), "w", encoding="utf-8") as f:
+        f.write("{}")
+    return path
+
+
+class TestBuildAibomFromFilesystem(unittest.TestCase):
+    """build_claw_aibom on non-OpenClaw connectors must walk the disk."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="dc-claw-fs-")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _patch_skill_dirs(self, dirs):
+        return patch(
+            "defenseclaw.config.Config.skill_dirs",
+            return_value=list(dirs),
+        )
+
+    def _patch_plugin_dirs(self, dirs):
+        return patch(
+            "defenseclaw.config.Config.plugin_dirs",
+            return_value=list(dirs),
+        )
+
+    def _patch_mcp(self, entries):
+        return patch(
+            "defenseclaw.config.Config.mcp_servers",
+            return_value=list(entries),
+        )
+
+    def test_codex_skips_subprocess_and_walks_disk(self):
+        """For connector=codex, build_claw_aibom must NOT shell out."""
+        cfg = _make_cfg_for_connector(self.tmp, "codex")
+        skill_root = os.path.join(self.tmp, ".codex", "skills")
+        os.makedirs(skill_root, exist_ok=True)
+        _seed_skill(skill_root, "alpha")
+        plugin_root = os.path.join(self.tmp, ".codex", "extensions")
+        os.makedirs(plugin_root, exist_ok=True)
+        _seed_plugin(plugin_root, "ext1", manifest=".codex-plugin/plugin.json")
+
+        with self._patch_skill_dirs([skill_root]), \
+             self._patch_plugin_dirs([plugin_root]), \
+             self._patch_mcp([]), \
+             patch("defenseclaw.inventory.claw_inventory.subprocess.run") as mock_sub:
+            inv = build_claw_aibom(cfg, live=True)
+            mock_sub.assert_not_called()
+
+        self.assertEqual(inv["connector"], "codex")
+        self.assertTrue(inv["live"])
+        self.assertEqual(len(inv["skills"]), 1)
+        self.assertEqual(inv["skills"][0]["id"], "alpha")
+        self.assertTrue(inv["skills"][0]["eligible"])
+        self.assertEqual(len(inv["plugins"]), 1)
+        self.assertEqual(inv["plugins"][0]["id"], "ext1")
+        self.assertEqual(inv["plugins"][0]["manifest"], ".codex-plugin/plugin.json")
+
+    def test_claudecode_walks_disk(self):
+        cfg = _make_cfg_for_connector(self.tmp, "claudecode")
+        skill_root = os.path.join(self.tmp, ".claude", "skills")
+        os.makedirs(skill_root, exist_ok=True)
+        _seed_skill(skill_root, "weather")
+        with self._patch_skill_dirs([skill_root]), \
+             self._patch_plugin_dirs([]), \
+             self._patch_mcp([]):
+            inv = build_claw_aibom(cfg, live=True)
+        self.assertEqual(inv["connector"], "claudecode")
+        ids = [s["id"] for s in inv["skills"]]
+        self.assertIn("weather", ids)
+
+    def test_zeptoclaw_walks_disk(self):
+        cfg = _make_cfg_for_connector(self.tmp, "zeptoclaw")
+        skill_root = os.path.join(self.tmp, ".zeptoclaw", "skills")
+        os.makedirs(skill_root, exist_ok=True)
+        _seed_skill(skill_root, "alpha", marker="skill.json", body="{}")
+        with self._patch_skill_dirs([skill_root]), \
+             self._patch_plugin_dirs([]), \
+             self._patch_mcp([]):
+            inv = build_claw_aibom(cfg, live=True)
+        self.assertEqual(inv["connector"], "zeptoclaw")
+        self.assertEqual(len(inv["skills"]), 1)
+        self.assertEqual(inv["skills"][0]["id"], "alpha")
+
+    def test_openclaw_only_categories_return_empty_with_notes(self):
+        cfg = _make_cfg_for_connector(self.tmp, "codex")
+        with self._patch_skill_dirs([]), \
+             self._patch_plugin_dirs([]), \
+             self._patch_mcp([]):
+            inv = build_claw_aibom(cfg, live=True)
+        self.assertEqual(inv["agents"], [])
+        self.assertEqual(inv["tools"], [])
+        self.assertEqual(inv["model_providers"], [])
+        self.assertEqual(inv["memory"], [])
+        commands = {e["command"] for e in inv["errors"]}
+        self.assertIn("codex:agents", commands)
+        self.assertIn("codex:tools", commands)
+        self.assertIn("codex:models", commands)
+        self.assertIn("codex:memory", commands)
+
+    def test_skill_eligibility_requires_marker(self):
+        cfg = _make_cfg_for_connector(self.tmp, "codex")
+        skill_root = os.path.join(self.tmp, "skills")
+        os.makedirs(skill_root, exist_ok=True)
+        empty_dir = os.path.join(skill_root, "empty")
+        os.makedirs(empty_dir, exist_ok=True)
+        _seed_skill(skill_root, "marked")
+        with self._patch_skill_dirs([skill_root]), \
+             self._patch_plugin_dirs([]), \
+             self._patch_mcp([]):
+            inv = build_claw_aibom(cfg, live=True)
+        by_id = {s["id"]: s for s in inv["skills"]}
+        self.assertTrue(by_id["marked"]["eligible"])
+        self.assertFalse(by_id["empty"]["eligible"])
+
+    def test_skill_description_extracted_from_skill_md(self):
+        cfg = _make_cfg_for_connector(self.tmp, "codex")
+        skill_root = os.path.join(self.tmp, "skills")
+        os.makedirs(skill_root, exist_ok=True)
+        _seed_skill(
+            skill_root,
+            "described",
+            body="# Skill Title\n\nA helpful skill that does X.\n",
+        )
+        with self._patch_skill_dirs([skill_root]), \
+             self._patch_plugin_dirs([]), \
+             self._patch_mcp([]):
+            inv = build_claw_aibom(cfg, live=True)
+        self.assertEqual(inv["skills"][0]["description"], "Skill Title")
+
+    def test_plugin_status_no_manifest(self):
+        cfg = _make_cfg_for_connector(self.tmp, "codex")
+        plugin_root = os.path.join(self.tmp, "plugins")
+        os.makedirs(plugin_root, exist_ok=True)
+        _seed_plugin(plugin_root, "no-mf", manifest=None)
+        _seed_plugin(plugin_root, "with-mf", manifest="plugin.json")
+        with self._patch_skill_dirs([]), \
+             self._patch_plugin_dirs([plugin_root]), \
+             self._patch_mcp([]):
+            inv = build_claw_aibom(cfg, live=True)
+        by_id = {p["id"]: p for p in inv["plugins"]}
+        self.assertEqual(by_id["no-mf"]["status"], "no-manifest")
+        self.assertEqual(by_id["with-mf"]["status"], "loaded")
+
+    def test_plugin_cache_dir_is_skipped(self):
+        """The "cache" sibling under Codex/ZeptoClaw is not a plugin."""
+        cfg = _make_cfg_for_connector(self.tmp, "codex")
+        plugin_root = os.path.join(self.tmp, "plugins")
+        os.makedirs(plugin_root, exist_ok=True)
+        _seed_plugin(plugin_root, "cache", manifest=None)
+        _seed_plugin(plugin_root, "real", manifest="plugin.json")
+        with self._patch_skill_dirs([]), \
+             self._patch_plugin_dirs([plugin_root]), \
+             self._patch_mcp([]):
+            inv = build_claw_aibom(cfg, live=True)
+        ids = [p["id"] for p in inv["plugins"]]
+        self.assertEqual(ids, ["real"])
+
+    def test_mcp_servers_passed_through(self):
+        from defenseclaw.connector_paths import MCPServerEntry
+        cfg = _make_cfg_for_connector(self.tmp, "codex")
+        entries = [
+            MCPServerEntry(
+                name="filesystem",
+                command="/usr/bin/mcp-fs",
+                args=["--root", "/tmp"],
+                env={"X_TOKEN": "redacted"},
+            ),
+            MCPServerEntry(name="http", url="https://example.com", transport="sse"),
+        ]
+        with self._patch_skill_dirs([]), \
+             self._patch_plugin_dirs([]), \
+             self._patch_mcp(entries):
+            inv = build_claw_aibom(cfg, live=True)
+        self.assertEqual(len(inv["mcp"]), 2)
+        first = inv["mcp"][0]
+        self.assertEqual(first["id"], "filesystem")
+        self.assertEqual(first["command"], "/usr/bin/mcp-fs")
+        self.assertEqual(first["args"], ["--root", "/tmp"])
+        # env values must be redacted from the inventory snapshot —
+        # only env_keys leak the *names* of env vars, never their values.
+        self.assertNotIn("env", first)
+        self.assertEqual(first["env_keys"], ["X_TOKEN"])
+        second = inv["mcp"][1]
+        self.assertEqual(second["url"], "https://example.com")
+        self.assertEqual(second["transport"], "sse")
+
+    def test_summary_total_matches_arrays_for_codex(self):
+        cfg = _make_cfg_for_connector(self.tmp, "codex")
+        skill_root = os.path.join(self.tmp, "skills")
+        os.makedirs(skill_root, exist_ok=True)
+        _seed_skill(skill_root, "a")
+        _seed_skill(skill_root, "b")
+        with self._patch_skill_dirs([skill_root]), \
+             self._patch_plugin_dirs([]), \
+             self._patch_mcp([]):
+            inv = build_claw_aibom(cfg, live=True)
+        self.assertEqual(inv["summary"]["total_items"], 2)
+        self.assertEqual(inv["summary"]["skills"]["count"], 2)
+        self.assertEqual(inv["summary"]["plugins"]["count"], 0)
+
+    def test_categories_filter_skills_only_skips_others(self):
+        cfg = _make_cfg_for_connector(self.tmp, "codex")
+        skill_root = os.path.join(self.tmp, "skills")
+        os.makedirs(skill_root, exist_ok=True)
+        _seed_skill(skill_root, "a")
+        plugin_root = os.path.join(self.tmp, "plugins")
+        os.makedirs(plugin_root, exist_ok=True)
+        _seed_plugin(plugin_root, "p1", manifest="plugin.json")
+        with self._patch_skill_dirs([skill_root]), \
+             self._patch_plugin_dirs([plugin_root]), \
+             self._patch_mcp([]):
+            inv = build_claw_aibom(cfg, live=True, categories={"skills"})
+        self.assertEqual(len(inv["skills"]), 1)
+        self.assertEqual(inv["plugins"], [])
+
+    def test_live_false_returns_disk_shape(self):
+        """``live=False`` keeps the legacy "no subprocess, no walk" path."""
+        cfg = _make_cfg_for_connector(self.tmp, "codex")
+        with patch("defenseclaw.inventory.claw_inventory.subprocess.run") as mock_sub:
+            inv = build_claw_aibom(cfg, live=False)
+            mock_sub.assert_not_called()
+        # connector annotated even on the legacy path
+        self.assertIn("connector", inv)
+        self.assertEqual(inv["connector"], "codex")
+        self.assertFalse(inv["live"])
+        self.assertEqual(inv["skills"], [])
+        self.assertEqual(inv["plugins"], [])
+
+    def test_openclaw_default_unchanged(self):
+        """Default connector "openclaw" must keep using subprocess."""
+        cfg = _make_cfg_for_connector(self.tmp, "openclaw")
+        with patch(
+            "defenseclaw.inventory.claw_inventory.subprocess.run",
+            side_effect=FileNotFoundError,
+        ) as mock_sub:
+            inv = build_claw_aibom(cfg, live=True)
+            self.assertGreater(mock_sub.call_count, 0)
+        self.assertEqual(inv["connector"], "openclaw")
+
+
+class TestBuildAibomConnectorPathSkippedForOpenClaw(unittest.TestCase):
+    """Ensure we keep dispatching via subprocess for OpenClaw."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="dc-claw-fs-oc-")
+        self.cfg = _make_cfg(self.tmp)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    @patch("defenseclaw.inventory.claw_inventory.subprocess.run", side_effect=_mock_run)
+    def test_openclaw_inventory_has_connector_field(self, _):
+        inv = build_claw_aibom(self.cfg, live=True)
+        self.assertEqual(inv["connector"], "openclaw")
+        # The full set of legacy fields must still be populated.
+        self.assertGreater(len(inv["skills"]), 0)
+        self.assertGreater(len(inv["plugins"]), 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Make `defenseclaw aibom scan` work for **Codex, Claude Code, and ZeptoClaw** — not just OpenClaw.

Today the inventory shells out to `openclaw … --json` unconditionally, so when `guardrail.connector` is anything else the BOM is silently empty (and the `errors[]` array fills up with "openclaw not found"). This PR adds a filesystem-walking adapter that produces the same dict shape from each connector's documented on-disk layout.

## Stack

- #178 — S4.1: extract `connector_paths.py`
- #179 — S4.2: cmd_mcp set/unset adapter
- **this PR — S4.3: AIBOM filesystem adapter**

## What changed

`cli/defenseclaw/inventory/claw_inventory.py`:
- `build_claw_aibom` now consults `Config.active_connector()`. For OpenClaw — and any unknown name — the original subprocess path is unchanged. For Codex / Claude Code / ZeptoClaw it routes to the new `_build_aibom_from_filesystem`.
- `_build_aibom_from_filesystem` walks `Config.skill_dirs()` and `Config.plugin_dirs()` (already polymorphic after #178) and reads MCP servers via `Config.mcp_servers()`.
- Skill rows carry `eligible` (any of SKILL.md / skill.json / README.md) plus a 200-char description.
- Plugin rows detect every manifest covered by the S2.3 plugin scanner: `package.json`, `manifest.json`, `plugin.json`, `openclaw.plugin.json`, `.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`. The `cache` sibling under Codex/ZeptoClaw plugin roots is skipped.
- MCP rows surface `command`, `args`, `url`, `transport`, and **`env_keys`** (just the names — values stay redacted, per `codeguard-0-logging`).
- Categories that don't translate (agents, tools, models, memory) come back as `[]` with an explicit informational entry in `errors[]` ("agents are not a first-class concept on this connector", etc.).
- Top-level inventory dict carries a `connector` field on every code path.
- `live=False` keeps producing the legacy "no subprocess, no walk" shape.

## Tests

`cli/tests/test_claw_inventory.py`:
- 14 new tests in `TestBuildAibomFromFilesystem` covering Codex/Claude Code/ZeptoClaw dispatch, skill eligibility, manifest detection, the cache-skip rule, MCP env-value redaction, summary totals, the category filter, the `live=False` legacy path, and the OpenClaw-default-unchanged contract.
- 1 new test in `TestBuildAibomConnectorPathSkippedForOpenClaw` asserts the OpenClaw path still hits subprocess and now carries the `connector` field.
- All 162 existing tests in this file still pass.

## Test plan

- [x] `pytest tests/test_claw_inventory.py` — 162 pass
- [x] `pytest tests/test_claw_inventory.py tests/test_connector_paths.py tests/test_connector_mcp_writers.py tests/test_config.py tests/test_cmd_mcp.py` — 360 pass
- [x] OpenClaw codepath unchanged (subprocess still called, `connector` field added)
- [x] No new `import os` inline calls (top-level only)
- [x] MCP env values redacted from BOM output

## Refs

connector-architecture v3 — S4.3 / F4 in the claw-agnostic plan.