### PR TITLE
S4.4: split guardrail.py + connector-aware skill list adapter

### DIFF
--- a/cli/defenseclaw/commands/cmd_skill.py
+++ b/cli/defenseclaw/commands/cmd_skill.py
@@ -183,14 +183,37 @@ def _list_skills_via_sidecar(app: AppContext) -> dict[str, Any] | None:
 
 
 def _list_openclaw_skills_full(app: AppContext | None = None) -> dict[str, Any] | None:
-    """Get the full skill list — tries sidecar API first, then local binary."""
+    """Get the full skill list, dispatching on the active connector.
+
+    For ``openclaw`` (the historical default) we keep the sidecar →
+    CLI fallback chain. For Codex / Claude Code / ZeptoClaw we walk
+    the connector-specific skill directories via
+    :func:`defenseclaw.skill_list.list_skills` (S4.4 adapter).
+
+    The returned shape stays ``{"skills": [...]}`` — same as
+    ``openclaw skills list --json`` — so every downstream caller in
+    this module continues to work unchanged.
+    """
     if app is not None:
+        connector = app.cfg.active_connector() if hasattr(app.cfg, "active_connector") else "openclaw"
+        if connector != "openclaw":
+            from defenseclaw.skill_list import list_skills as _adapter_list
+            return {"skills": _adapter_list(app.cfg)}
+
+        # OpenClaw: prefer the live sidecar — it sees runtime state
+        # the static CLI doesn't (recently-toggled skills, etc.).
         result = _list_skills_via_sidecar(app)
         if result is not None:
             return result
 
     out = _run_openclaw("skills", "list", "--json")
     if out is None:
+        # Last-ditch fallback: walk the OpenClaw filesystem layout so
+        # `defenseclaw skill list` doesn't go silent when the
+        # `openclaw` binary isn't on PATH (sandbox installs, CI, etc.).
+        if app is not None and hasattr(app.cfg, "skill_dirs"):
+            from defenseclaw.skill_list import list_skills as _adapter_list
+            return {"skills": _adapter_list(app.cfg, prefer_cli=False)}
         return None
     try:
         return json.loads(out)
@@ -199,8 +222,21 @@ def _list_openclaw_skills_full(app: AppContext | None = None) -> dict[str, Any] 
 
 
 def _get_openclaw_skill_info(name: str, app: AppContext | None = None) -> dict[str, Any] | None:
-    """Get info for a single skill — tries sidecar first, then local binary."""
+    """Get info for a single skill.
+
+    For OpenClaw, prefers the sidecar → CLI fallback chain. For
+    other connectors, walks the connector-specific skill
+    directories — there is no per-connector ``info`` subcommand.
+    """
     if app is not None:
+        connector = app.cfg.active_connector() if hasattr(app.cfg, "active_connector") else "openclaw"
+        if connector != "openclaw":
+            from defenseclaw.skill_list import list_skills as _adapter_list
+            for s in _adapter_list(app.cfg):
+                if s.get("name") == name:
+                    return s
+            return None
+
         full = _list_skills_via_sidecar(app)
         if full is not None:
             for s in full.get("skills", []):

--- a/cli/defenseclaw/guardrail.py
+++ b/cli/defenseclaw/guardrail.py
@@ -14,604 +14,92 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Guardrail integration — OpenClaw config patching for the Go guardrail proxy.
+"""Guardrail module — back-compat shim re-exporting connector-aware helpers.
 
-Patches ~/.openclaw/openclaw.json to route LLM traffic through the
-DefenseClaw guardrail proxy (a pure Go reverse proxy).
+This file used to mix three concerns: API-key/model detection,
+master-key derivation, and OpenClaw config patching. S4.4 of the
+claw-agnostic plan split it into two focused modules:
+
+* :mod:`defenseclaw.llm_keys` — connector-agnostic API-key + model
+  helpers (``detect_api_key_env``, ``model_to_proxy_name``,
+  ``derive_master_key``).
+* :mod:`defenseclaw.openclaw_guardrail` — OpenClaw-specific config
+  patching (``patch_openclaw_config``, ``restore_openclaw_config``,
+  ``uninstall_openclaw_plugin``, ``record_pristine_backup``,
+  ``pristine_backup_path``, ``detect_current_model``, plus the
+  internal ``_backup`` / ``_register_plugin_in_config`` /
+  ``_preserve_ownership`` helpers).
+
+Existing call sites — ``cmd_setup``, ``cmd_doctor``,
+``cmd_uninstall``, and ``tests/test_guardrail.py`` — continue to
+``from defenseclaw.guardrail import …`` exactly as before. New code
+that only needs the connector-agnostic surface should import from
+:mod:`defenseclaw.llm_keys` directly so it doesn't re-acquire a
+transitive OpenClaw dependency.
 """
 
 from __future__ import annotations
 
-import contextlib
-import hashlib
-import json
-import os
-import shutil
-import subprocess
-from contextlib import contextmanager
-from pathlib import Path
-
-
-def patch_openclaw_config(
-    openclaw_config_file: str,
-    model_name: str,  # kept for API compat — no longer used (fetch interceptor handles routing)
-    proxy_port: int,  # kept for API compat — no longer used
-    master_key: str,  # kept for API compat — no longer used
-    original_model: str,
-    guardrail_host: str = "localhost",
-    data_dir: str = "",
-) -> str | None:
-    """Register the DefenseClaw plugin in openclaw.json.
-
-    The fetch interceptor handles all traffic routing transparently —
-    no provider entry or model redirection is needed. This function only
-    registers the plugin so OpenClaw loads it on startup.
-
-    When ``data_dir`` is provided we write a *pristine* timestamped
-    backup to ``<data_dir>/backups/`` the very first time DefenseClaw
-    touches this ``openclaw.json`` and record it in
-    ``<data_dir>/openclaw-backups.json``. That gives ``uninstall`` and
-    ``doctor --fix`` a deterministic rollback target even after many
-    ``.bak.N`` rotations have occurred.
-    """
-    _ = model_name, proxy_port, master_key  # unused — fetch interceptor handles routing
-    path = _expand(openclaw_config_file)
-
-    try:
-        with open(path) as f:
-            cfg = json.load(f)
-    except (OSError, json.JSONDecodeError):
-        return None
-
-    # Record pristine backup BEFORE any writes so we always capture the
-    # untouched file. ``record_pristine_backup`` is idempotent — once a
-    # pristine copy exists for this config path it will not be
-    # overwritten on subsequent patches.
-    if data_dir:
-        with contextlib.suppress(OSError):
-            record_pristine_backup(path, data_dir)
-
-    _backup(path)
-
-    prev_model = (
-        cfg.get("agents", {}).get("defaults", {}).get("model", {}).get("primary", "")
-    )
-
-    plugins = cfg.setdefault("plugins", {})
-    allow = plugins.setdefault("allow", [])
-    if "defenseclaw" not in allow:
-        allow.append("defenseclaw")
-
-    # Re-enable plugin entry (may have been disabled by restore_openclaw_config).
-    entries = plugins.setdefault("entries", {})
-    if "defenseclaw" not in entries:
-        entries["defenseclaw"] = {"enabled": True}
-    else:
-        entries["defenseclaw"]["enabled"] = True
-
-    oc_home = os.path.dirname(path)
-    install_path = os.path.join(oc_home, "extensions", "defenseclaw")
-    load = plugins.setdefault("load", {})
-    paths = load.setdefault("paths", [])
-    if install_path not in paths:
-        paths.append(install_path)
-
-    with _preserve_ownership(path):
-        with open(path, "w") as f:
-            json.dump(cfg, f, indent=2, ensure_ascii=False)
-            f.write("\n")
-
-    _install_codeguard_skill_deferred(openclaw_config_file)
-
-    return prev_model or original_model
-
-
-def restore_openclaw_config(openclaw_config_file: str, original_model: str) -> bool:
-    """Remove the DefenseClaw plugin registration from openclaw.json.
-
-    The fetch interceptor required no model or provider changes, so there is
-    nothing to revert — just remove the plugin entries.
-    """
-    path = _expand(openclaw_config_file)
-
-    try:
-        with open(path) as f:
-            cfg = json.load(f)
-    except (OSError, json.JSONDecodeError):
-        return False
-
-    _backup(path)
-
-    # Remove leftover defenseclaw provider entry if present from older setups.
-    if "models" in cfg and "providers" in cfg["models"]:
-        cfg["models"]["providers"].pop("defenseclaw", None)
-        cfg["models"]["providers"].pop("litellm", None)
-
-    if "plugins" in cfg:
-        plugins = cfg["plugins"]
-        # Remove from allow list
-        allow = plugins.get("allow", [])
-        if "defenseclaw" in allow:
-            allow.remove("defenseclaw")
-        # Disable in entries (stops fetch interceptor from loading)
-        entries = plugins.get("entries", {})
-        if "defenseclaw" in entries:
-            entries["defenseclaw"]["enabled"] = False
-        # Remove from load paths
-        oc_home = os.path.dirname(path)
-        install_path = os.path.join(oc_home, "extensions", "defenseclaw")
-        paths = plugins.get("load", {}).get("paths", [])
-        if install_path in paths:
-            paths.remove(install_path)
-
-    with _preserve_ownership(path):
-        with open(path, "w") as f:
-            json.dump(cfg, f, indent=2, ensure_ascii=False)
-            f.write("\n")
-
-    return True
-
-
-# NOTE: install_openclaw_plugin lived here previously. The gateway's
-# OpenClawConnector.Setup() now installs the embedded plugin directly
-# into ~/.openclaw/extensions/defenseclaw and patches openclaw.json on
-# every sidecar boot, so there is no separate Python-side install step.
-# `uninstall_openclaw_plugin` is kept for `defenseclaw uninstall`, which
-# has to revert the plugin even if the gateway is already gone.
-
-
-def uninstall_openclaw_plugin(openclaw_home: str) -> str:
-    """Uninstall the DefenseClaw plugin from OpenClaw.
-
-    Tries ``openclaw plugins uninstall defenseclaw`` first, falls back
-    to removing the extensions directory and config entries manually.
-
-    Returns:
-        "cli"    — uninstalled via openclaw CLI
-        "manual" — removed directory manually
-        ""       — plugin was not installed
-        "error"  — removal failed (permissions, etc.)
-    """
-    oc_home = _expand(openclaw_home)
-    target_dir = os.path.join(oc_home, "extensions", "defenseclaw")
-    oc_config = os.path.join(oc_home, "openclaw.json")
-    is_installed = os.path.isdir(target_dir) or os.path.islink(target_dir)
-
-    if not is_installed:
-        _unregister_plugin_from_config(oc_config)
-        return ""
-
-    _remove_from_plugins_allow(oc_config, "defenseclaw")
-
-    try:
-        from defenseclaw.config import openclaw_bin, openclaw_cmd_prefix
-        prefix = openclaw_cmd_prefix()
-        result = subprocess.run(
-            [*prefix, openclaw_bin(), "plugins", "uninstall", "defenseclaw"],
-            capture_output=True, text=True, timeout=30,
-        )
-        if result.returncode == 0:
-            return "cli"
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        pass
-
-    # Fallback: remove directory + config entries
-    try:
-        if os.path.islink(target_dir):
-            os.unlink(target_dir)
-        elif os.path.isdir(target_dir):
-            shutil.rmtree(target_dir)
-        _unregister_plugin_from_config(oc_config)
-        return "manual"
-    except OSError:
-        return "error"
-
-
-def detect_current_model(openclaw_config_file: str) -> tuple[str, str]:
-    """Read the current model from openclaw.json. Returns (model_id, provider_prefix)."""
-    path = _expand(openclaw_config_file)
-    try:
-        with open(path) as f:
-            cfg = json.load(f)
-    except (OSError, json.JSONDecodeError):
-        return "", ""
-
-    primary = (
-        cfg.get("agents", {}).get("defaults", {}).get("model", {}).get("primary", "")
-    )
-    if "/" in primary:
-        provider, model_id = primary.split("/", 1)
-        return primary, provider
-    return primary, ""
-
-
-
-def detect_api_key_env(model: str) -> str:
-    """Guess the API key env var from the model string.
-
-    Routing is prefix-first: a model written as ``"bedrock/us.anthropic.claude-…"``
-    must yield the *Bedrock* bearer env var, not ``ANTHROPIC_API_KEY``,
-    because that's the provider LiteLLM will actually call. Earlier
-    revisions substring-matched ``"claude"`` and got this wrong, so
-    every Bedrock Claude model silently wrote the key into the
-    Anthropic env var while the scanner read from ``AWS_BEARER_TOKEN_BEDROCK``
-    — i.e. an empty key. The prefix check runs before any substring
-    matching to prevent that regression.
-    """
-    lower = model.lower()
-    # Prefix routing (strongest signal). Order matters only within this
-    # block: bedrock before anthropic because bedrock/claude-* is a
-    # *Bedrock* call, not an Anthropic call.
-    if "/" in lower:
-        prefix = lower.split("/", 1)[0]
-        if prefix == "bedrock":
-            # LiteLLM reads the Bedrock short-term bearer token (ABSK…)
-            # from AWS_BEARER_TOKEN_BEDROCK; AWS_ACCESS_KEY_ID is the
-            # SigV4 key-id pair, which is a different auth flow.
-            # Suggesting the bearer env var keeps setup, doctor, and
-            # the Python scanner bridge (_llm_env.py) in lockstep —
-            # otherwise `setup llm` writes one env var and the
-            # scanners read another. Operators using long-term SigV4
-            # creds should override api_key_env by hand.
-            return "AWS_BEARER_TOKEN_BEDROCK"
-        if prefix == "anthropic":
-            return "ANTHROPIC_API_KEY"
-        if prefix == "azure":
-            return "AZURE_OPENAI_API_KEY"
-        if prefix == "openrouter":
-            return "OPENROUTER_API_KEY"
-        if prefix == "openai":
-            return "OPENAI_API_KEY"
-        if prefix in ("gemini", "google", "vertex_ai"):
-            return "GOOGLE_API_KEY"
-    # Substring fallback for bare model names (``claude-3``, ``gpt-4o``)
-    # — same behavior as before so existing configs without provider
-    # prefixes still resolve.
-    if "anthropic" in lower or "claude" in lower:
-        return "ANTHROPIC_API_KEY"
-    if "azure" in lower:
-        return "AZURE_OPENAI_API_KEY"
-    if "openrouter" in lower:
-        return "OPENROUTER_API_KEY"
-    if "openai" in lower or "gpt" in lower or "o1" in lower:
-        return "OPENAI_API_KEY"
-    if "gemini" in lower or "google" in lower:
-        return "GOOGLE_API_KEY"
-    if "bedrock" in lower:
-        return "AWS_BEARER_TOKEN_BEDROCK"
-    return "LLM_API_KEY"
-
-
-def model_to_proxy_name(model: str) -> str:
-    """Derive a short model alias from a full model string like 'anthropic/claude-opus-4-5'."""
-    name = model.split("/")[-1] if "/" in model else model
-    for prefix in ("anthropic-", "openai-", "google-", "azure-", "openrouter-", "gemini-", "gemini-openai-"):
-        name = name.removeprefix(prefix)
-    return name
-
-
-
-
-
-# ------------------------------------------------------------------
-# Internal helpers
-# ------------------------------------------------------------------
-
-def _derive_master_key(device_key_file: str) -> str:
-    """Derive a deterministic master key from the device key file.
-
-    Tries the given path first, then the default ~/.defenseclaw/device.key.
-    Only falls back to a static key if neither exists.
-    """
-    candidates = [device_key_file]
-    default_path = os.path.join(str(Path.home()), ".defenseclaw", "device.key")
-    if _expand(device_key_file) != default_path:
-        candidates.append(default_path)
-
-    import hmac
-
-    for candidate in candidates:
-        path = _expand(candidate)
-        try:
-            with open(path, "rb") as f:
-                data = f.read()
-            digest = hmac.new(b"defenseclaw-proxy-master-key", data, hashlib.sha256).hexdigest()[:32]
-            return f"sk-dc-{digest}"
-        except OSError:
-            continue
-    raise RuntimeError(
-        f"Device key not found: {device_key_file}\n"
-        f"  Run 'defenseclaw init' to generate a device key."
-    )
-
-
-def _unregister_plugin_from_config(openclaw_config: str) -> None:
-    """Remove defenseclaw plugin entries from openclaw.json."""
-    path = _expand(openclaw_config)
-    try:
-        with open(path) as f:
-            cfg = json.load(f)
-    except (OSError, json.JSONDecodeError):
-        return
-
-    plugins = cfg.get("plugins", {})
-    changed = False
-
-    entries = plugins.get("entries", {})
-    if "defenseclaw" in entries:
-        del entries["defenseclaw"]
-        changed = True
-
-    installs = plugins.get("installs", {})
-    if "defenseclaw" in installs:
-        install_path = installs["defenseclaw"].get("installPath", "")
-        del installs["defenseclaw"]
-        changed = True
-
-        paths = plugins.get("load", {}).get("paths", [])
-        if install_path in paths:
-            paths.remove(install_path)
-
-    if changed:
-        with _preserve_ownership(path):
-            with open(path, "w") as f:
-                json.dump(cfg, f, indent=2, ensure_ascii=False)
-                f.write("\n")
-
-
-def _register_plugin_in_config(openclaw_config: str, source_dir: str) -> None:
-    """Register the defenseclaw plugin in openclaw.json (manual fallback).
-
-    Mirrors what ``openclaw plugins install`` does: adds entries to
-    plugins.load.paths, plugins.installs, and plugins.entries so
-    OpenClaw discovers and loads the plugin.
-    """
-    path = _expand(openclaw_config)
-    try:
-        with open(path) as f:
-            cfg = json.load(f)
-    except (OSError, json.JSONDecodeError):
-        return
-
-    plugins = cfg.setdefault("plugins", {})
-
-    # plugins.entries — enable the plugin
-    entries = plugins.setdefault("entries", {})
-    if "defenseclaw" not in entries:
-        entries["defenseclaw"] = {"enabled": True}
-
-    # plugins.load.paths — tell OpenClaw where to find the code
-    oc_home = os.path.dirname(path)
-    install_path = os.path.join(oc_home, "extensions", "defenseclaw")
-    load = plugins.setdefault("load", {})
-    paths = load.setdefault("paths", [])
-    if install_path not in paths:
-        paths.append(install_path)
-
-    # plugins.allow — required when an allowlist is active
-    allow = plugins.setdefault("allow", [])
-    if "defenseclaw" not in allow:
-        allow.append("defenseclaw")
-
-    # plugins.installs — record install metadata
-    version = "0.0.0"
-    try:
-        pkg_json = os.path.join(source_dir, "package.json")
-        with open(pkg_json) as f:
-            version = json.load(f).get("version", version)
-    except (OSError, json.JSONDecodeError):
-        pass
-
-    from datetime import datetime, timezone
-    installs = plugins.setdefault("installs", {})
-    installs["defenseclaw"] = {
-        "source": "path",
-        "sourcePath": source_dir,
-        "installPath": install_path,
-        "version": version,
-        "installedAt": datetime.now(timezone.utc).isoformat(),
-    }
-
-    with _preserve_ownership(path):
-        with open(path, "w") as f:
-            json.dump(cfg, f, indent=2, ensure_ascii=False)
-            f.write("\n")
-
-
-def _remove_from_plugins_allow(openclaw_config: str, plugin_id: str) -> None:
-    """Remove a plugin id from plugins.allow in openclaw.json (if present)."""
-    path = _expand(openclaw_config)
-    try:
-        with open(path) as f:
-            cfg = json.load(f)
-    except (OSError, json.JSONDecodeError):
-        return
-
-    allow = cfg.get("plugins", {}).get("allow", [])
-    if plugin_id not in allow:
-        return
-
-    allow.remove(plugin_id)
-    with _preserve_ownership(path):
-        with open(path, "w") as f:
-            json.dump(cfg, f, indent=2, ensure_ascii=False)
-            f.write("\n")
-
-
-def _expand(p: str) -> str:
-    if p.startswith("~/"):
-        return str(Path.home() / p[2:])
-    return p
-
-
-@contextmanager
-def _preserve_ownership(path: str):
-    """Capture a file's uid/gid before a write and restore it afterwards.
-
-    Only relevant in standalone sandbox mode where setup commands run as
-    root and would otherwise re-create files owned by root, breaking
-    sandbox user access.  Skipped entirely for non-root callers since
-    os.chown requires elevated privileges.
-    """
-    if os.getuid() != 0:
-        yield
-        return
-
-    uid = gid = None
-    try:
-        st = os.stat(path)
-        uid, gid = st.st_uid, st.st_gid
-    except OSError:
-        pass
-
-    yield
-
-    if uid is not None:
-        with contextlib.suppress(OSError):
-            os.chown(path, uid, gid)
-
-
-BACKUP_INDEX_FILENAME = "openclaw-backups.json"
-BACKUP_SUBDIR = "backups"
-
-
-def _backup_index_path(data_dir: str) -> str:
-    return os.path.join(data_dir, BACKUP_INDEX_FILENAME)
-
-
-def _read_backup_index(data_dir: str) -> dict:
-    """Load the backup index, returning an empty doc on any failure.
-
-    Schema (v1)::
-
-        {
-          "version": 1,
-          "entries": {
-            "<abs openclaw.json path>": {
-              "pristine": "<abs path to timestamped copy>",
-              "captured_at": "<ISO-8601 UTC>"
-            }
-          }
-        }
-    """
-    path = _backup_index_path(data_dir)
-    try:
-        with open(path, encoding="utf-8") as fh:
-            data = json.load(fh)
-        if isinstance(data, dict):
-            return data
-    except (OSError, json.JSONDecodeError):
-        pass
-    return {"version": 1, "entries": {}}
-
-
-def _write_backup_index(data_dir: str, doc: dict) -> None:
-    """Atomically persist the backup index, creating *data_dir* as needed."""
-    os.makedirs(data_dir, exist_ok=True)
-    path = _backup_index_path(data_dir)
-    tmp = f"{path}.tmp"
-    with open(tmp, "w", encoding="utf-8") as fh:
-        json.dump(doc, fh, indent=2, sort_keys=True)
-        fh.write("\n")
-    os.replace(tmp, path)
-
-
-def record_pristine_backup(openclaw_config_file: str, data_dir: str) -> str | None:
-    """Capture a one-time pristine snapshot of *openclaw_config_file*.
-
-    This is idempotent: once an entry exists for this path in the
-    backup index, subsequent calls are no-ops. Returns the absolute
-    path to the pristine snapshot on first capture, or ``None`` when
-    no snapshot was taken (either no source file, already recorded,
-    or the copy failed).
-    """
-    src = _expand(openclaw_config_file)
-    if not os.path.isfile(src):
-        return None
-    if not data_dir:
-        return None
-
-    index = _read_backup_index(data_dir)
-    entries = index.setdefault("entries", {})
-    src_abs = os.path.abspath(src)
-    if src_abs in entries and os.path.isfile(entries[src_abs].get("pristine", "")):
-        return None  # already captured a valid snapshot
-
-    import datetime
-    backup_dir = os.path.join(data_dir, BACKUP_SUBDIR)
-    os.makedirs(backup_dir, exist_ok=True)
-
-    stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    basename = os.path.basename(src) or "openclaw.json"
-    dest = os.path.join(backup_dir, f"{basename}.{stamp}.pristine")
-    try:
-        shutil.copy2(src, dest)
-    except OSError:
-        return None
-
-    entries[src_abs] = {
-        "pristine": os.path.abspath(dest),
-        "captured_at": datetime.datetime.now(datetime.timezone.utc).isoformat(
-            timespec="seconds"
-        ),
-    }
-    index["version"] = 1
-    try:
-        _write_backup_index(data_dir, index)
-    except OSError:
-        # Best-effort: the snapshot exists on disk, but we couldn't
-        # index it. Uninstall will have to fall back to the .bak files.
-        with contextlib.suppress(OSError):
-            os.unlink(dest)
-        return None
-    return os.path.abspath(dest)
-
-
-def pristine_backup_path(openclaw_config_file: str, data_dir: str) -> str | None:
-    """Return the pristine snapshot path for *openclaw_config_file*, if any."""
-    if not data_dir:
-        return None
-    index = _read_backup_index(data_dir)
-    entry = index.get("entries", {}).get(os.path.abspath(_expand(openclaw_config_file)))
-    if not entry:
-        return None
-    pristine = entry.get("pristine", "")
-    return pristine if pristine and os.path.isfile(pristine) else None
-
-
-def _backup(path: str) -> None:
-    """Create a numbered backup of a file."""
-    if not os.path.isfile(path):
-        return
-    bak = path + ".bak"
-    if os.path.exists(bak):
-        found = False
-        for i in range(1, 100):
-            candidate = f"{path}.bak.{i}"
-            if not os.path.exists(candidate):
-                bak = candidate
-                found = True
-                break
-        if not found:
-            import time
-            bak = f"{path}.bak.{int(time.time() * 1000)}.{os.getpid()}"
-    st = os.stat(path)
-    shutil.copy2(path, bak)
-    with contextlib.suppress(OSError):
-        os.chown(bak, st.st_uid, st.st_gid)
-
-
-def _install_codeguard_skill_deferred(openclaw_config_file: str) -> None:
-    """Install the CodeGuard skill when guardrail connects to OpenClaw.
-
-    This handles the case where the user ran ``defenseclaw init`` before
-    OpenClaw was installed, then later runs ``defenseclaw guardrail enable``.
-    """
-    try:
-        from defenseclaw.codeguard_skill import ensure_codeguard_skill
-        from defenseclaw.config import load
-
-        cfg = load()
-        ensure_codeguard_skill(cfg.claw_home_dir(), openclaw_config_file)
-    except Exception:
-        pass
+# Public connector-agnostic surface.
+from defenseclaw.llm_keys import (
+    derive_master_key as _derive_master_key,
+    detect_api_key_env,
+    model_to_proxy_name,
+)
+
+# Public OpenClaw-specific surface.
+from defenseclaw.openclaw_guardrail import (
+    BACKUP_INDEX_FILENAME,
+    BACKUP_SUBDIR,
+    detect_current_model,
+    patch_openclaw_config,
+    pristine_backup_path,
+    record_pristine_backup,
+    restore_openclaw_config,
+    uninstall_openclaw_plugin,
+)
+
+# Underscore-prefixed helpers — kept exported for the legacy test
+# surface (tests/test_guardrail.py imports several of these directly).
+# NEW code should not import these from here; reach into
+# :mod:`defenseclaw.openclaw_guardrail` instead.
+from defenseclaw.openclaw_guardrail import (  # noqa: F401
+    _backup,
+    _backup_index_path,
+    _expand,
+    _install_codeguard_skill_deferred,
+    _preserve_ownership,
+    _read_backup_index,
+    _register_plugin_in_config,
+    _remove_from_plugins_allow,
+    _unregister_plugin_from_config,
+    _write_backup_index,
+)
+
+
+__all__ = [
+    # Connector-agnostic
+    "_derive_master_key",
+    "detect_api_key_env",
+    "model_to_proxy_name",
+    # OpenClaw-specific
+    "BACKUP_INDEX_FILENAME",
+    "BACKUP_SUBDIR",
+    "detect_current_model",
+    "patch_openclaw_config",
+    "pristine_backup_path",
+    "record_pristine_backup",
+    "restore_openclaw_config",
+    "uninstall_openclaw_plugin",
+    # Internal helpers (back-compat for tests)
+    "_backup",
+    "_backup_index_path",
+    "_expand",
+    "_install_codeguard_skill_deferred",
+    "_preserve_ownership",
+    "_read_backup_index",
+    "_register_plugin_in_config",
+    "_remove_from_plugins_allow",
+    "_unregister_plugin_from_config",
+    "_write_backup_index",
+]

--- a/cli/defenseclaw/llm_keys.py
+++ b/cli/defenseclaw/llm_keys.py
@@ -1,0 +1,161 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Connector-agnostic LLM key + model helpers.
+
+This module is the home for the small set of helpers that map a
+``provider/model`` string (``"anthropic/claude-3-5-sonnet"``,
+``"bedrock/us.anthropic.claude-3-haiku"``, ``"gpt-4o"``, …) to:
+
+* the environment variable holding the matching API key
+* a short alias used as a per-provider proxy name
+* a deterministic master-key derivation rooted at ``device.key``
+
+These primitives are used by ``defenseclaw setup``, ``defenseclaw
+doctor``, the LiteLLM bridge, and the per-connector guardrail
+modules. They contain *no* OpenClaw-specific behavior — splitting
+them out from the historical ``guardrail.py`` (S4.4) is what lets
+Codex / Claude Code / ZeptoClaw guardrail flows reuse them without
+inheriting the OpenClaw config-patch logic.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+from pathlib import Path
+
+
+def detect_api_key_env(model: str) -> str:
+    """Guess the API key env var from the model string.
+
+    Routing is prefix-first: a model written as
+    ``"bedrock/us.anthropic.claude-…"`` must yield the *Bedrock*
+    bearer env var, not ``ANTHROPIC_API_KEY``, because that's the
+    provider LiteLLM will actually call. Earlier revisions
+    substring-matched ``"claude"`` and got this wrong, so every
+    Bedrock Claude model silently wrote the key into the Anthropic
+    env var while the scanner read from ``AWS_BEARER_TOKEN_BEDROCK``
+    — i.e. an empty key. The prefix check runs before any substring
+    matching to prevent that regression.
+    """
+    lower = model.lower()
+    # Prefix routing (strongest signal). Order matters only within
+    # this block: bedrock before anthropic because bedrock/claude-* is
+    # a *Bedrock* call, not an Anthropic call.
+    if "/" in lower:
+        prefix = lower.split("/", 1)[0]
+        if prefix == "bedrock":
+            # LiteLLM reads the Bedrock short-term bearer token
+            # (ABSK…) from AWS_BEARER_TOKEN_BEDROCK; AWS_ACCESS_KEY_ID
+            # is the SigV4 key-id pair, which is a different auth
+            # flow. Suggesting the bearer env var keeps setup,
+            # doctor, and the Python scanner bridge (_llm_env.py) in
+            # lockstep — otherwise `setup llm` writes one env var and
+            # the scanners read another. Operators using long-term
+            # SigV4 creds should override api_key_env by hand.
+            return "AWS_BEARER_TOKEN_BEDROCK"
+        if prefix == "anthropic":
+            return "ANTHROPIC_API_KEY"
+        if prefix == "azure":
+            return "AZURE_OPENAI_API_KEY"
+        if prefix == "openrouter":
+            return "OPENROUTER_API_KEY"
+        if prefix == "openai":
+            return "OPENAI_API_KEY"
+        if prefix in ("gemini", "google", "vertex_ai"):
+            return "GOOGLE_API_KEY"
+    # Substring fallback for bare model names (``claude-3``, ``gpt-4o``)
+    # — same behavior as before so existing configs without provider
+    # prefixes still resolve.
+    if "anthropic" in lower or "claude" in lower:
+        return "ANTHROPIC_API_KEY"
+    if "azure" in lower:
+        return "AZURE_OPENAI_API_KEY"
+    if "openrouter" in lower:
+        return "OPENROUTER_API_KEY"
+    if "openai" in lower or "gpt" in lower or "o1" in lower:
+        return "OPENAI_API_KEY"
+    if "gemini" in lower or "google" in lower:
+        return "GOOGLE_API_KEY"
+    if "bedrock" in lower:
+        return "AWS_BEARER_TOKEN_BEDROCK"
+    return "LLM_API_KEY"
+
+
+def model_to_proxy_name(model: str) -> str:
+    """Derive a short model alias from a full model string like
+    ``'anthropic/claude-opus-4-5'``."""
+    name = model.split("/")[-1] if "/" in model else model
+    for prefix in (
+        "anthropic-",
+        "openai-",
+        "google-",
+        "azure-",
+        "openrouter-",
+        "gemini-",
+        "gemini-openai-",
+    ):
+        name = name.removeprefix(prefix)
+    return name
+
+
+def derive_master_key(device_key_file: str) -> str:
+    """Derive a deterministic master key from the device key file.
+
+    Tries the given path first, then the default
+    ``~/.defenseclaw/device.key``. Raises
+    :class:`RuntimeError` if neither exists — we no longer fall back
+    to a static key because that produces predictable proxy
+    credentials (a credential-stuffing oracle).
+
+    Implementation note: ``hmac.new`` over the raw key bytes with a
+    fixed string label is intentional — we want determinism across
+    sidecar restarts so the gateway can re-issue the same proxy
+    bearer without forcing every scanner to re-fetch a new value.
+    """
+    candidates = [device_key_file]
+    default_path = os.path.join(str(Path.home()), ".defenseclaw", "device.key")
+    if _expand(device_key_file) != default_path:
+        candidates.append(default_path)
+
+    for candidate in candidates:
+        path = _expand(candidate)
+        try:
+            with open(path, "rb") as f:
+                data = f.read()
+            digest = hmac.new(
+                b"defenseclaw-proxy-master-key", data, hashlib.sha256
+            ).hexdigest()[:32]
+            return f"sk-dc-{digest}"
+        except OSError:
+            continue
+    raise RuntimeError(
+        f"Device key not found: {device_key_file}\n"
+        f"  Run 'defenseclaw init' to generate a device key."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helper — kept private to avoid divergence from the path
+# expansion contract used elsewhere in the CLI (``connector_paths._expand``).
+# ---------------------------------------------------------------------------
+
+def _expand(p: str) -> str:
+    if p.startswith("~/"):
+        return str(Path.home() / p[2:])
+    return p

--- a/cli/defenseclaw/openclaw_guardrail.py
+++ b/cli/defenseclaw/openclaw_guardrail.py
@@ -1,0 +1,545 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenClaw-specific guardrail wiring.
+
+This module is the home for the on-disk patching that connects the
+DefenseClaw guardrail proxy to OpenClaw via ``~/.openclaw/openclaw.json``.
+It was extracted from the historical ``guardrail.py`` (S4.4) so the
+common connector machinery in :mod:`defenseclaw.guardrail` could shed
+its hard dependency on OpenClaw. The other connectors (Codex, Claude
+Code, ZeptoClaw) carry their wiring in their own modules — see
+:mod:`defenseclaw.connector_paths` and the Go-side ``Connector.Setup``.
+
+Public surface (call this module via ``from defenseclaw.guardrail
+import …`` for back-compat — :mod:`defenseclaw.guardrail` re-exports
+every name listed here):
+
+* :func:`patch_openclaw_config`
+* :func:`restore_openclaw_config`
+* :func:`uninstall_openclaw_plugin`
+* :func:`detect_current_model`
+* :func:`record_pristine_backup`
+* :func:`pristine_backup_path`
+
+Everything else is treated as private to OpenClaw flows; the test
+suite still reaches in for ``_backup`` /
+``_register_plugin_in_config`` etc. via the back-compat
+re-export, so the leading-underscore helpers below stay public to
+the package.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import shutil
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+
+
+def patch_openclaw_config(
+    openclaw_config_file: str,
+    model_name: str,  # kept for API compat — no longer used (fetch interceptor handles routing)
+    proxy_port: int,  # kept for API compat — no longer used
+    master_key: str,  # kept for API compat — no longer used
+    original_model: str,
+    guardrail_host: str = "localhost",
+    data_dir: str = "",
+) -> str | None:
+    """Register the DefenseClaw plugin in openclaw.json.
+
+    The fetch interceptor handles all traffic routing transparently —
+    no provider entry or model redirection is needed. This function only
+    registers the plugin so OpenClaw loads it on startup.
+
+    When ``data_dir`` is provided we write a *pristine* timestamped
+    backup to ``<data_dir>/backups/`` the very first time DefenseClaw
+    touches this ``openclaw.json`` and record it in
+    ``<data_dir>/openclaw-backups.json``. That gives ``uninstall`` and
+    ``doctor --fix`` a deterministic rollback target even after many
+    ``.bak.N`` rotations have occurred.
+    """
+    _ = model_name, proxy_port, master_key, guardrail_host  # unused — fetch interceptor handles routing
+    path = _expand(openclaw_config_file)
+
+    try:
+        with open(path) as f:
+            cfg = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    # Record pristine backup BEFORE any writes so we always capture the
+    # untouched file. ``record_pristine_backup`` is idempotent — once a
+    # pristine copy exists for this config path it will not be
+    # overwritten on subsequent patches.
+    if data_dir:
+        with contextlib.suppress(OSError):
+            record_pristine_backup(path, data_dir)
+
+    _backup(path)
+
+    prev_model = (
+        cfg.get("agents", {}).get("defaults", {}).get("model", {}).get("primary", "")
+    )
+
+    plugins = cfg.setdefault("plugins", {})
+    allow = plugins.setdefault("allow", [])
+    if "defenseclaw" not in allow:
+        allow.append("defenseclaw")
+
+    # Re-enable plugin entry (may have been disabled by restore_openclaw_config).
+    entries = plugins.setdefault("entries", {})
+    if "defenseclaw" not in entries:
+        entries["defenseclaw"] = {"enabled": True}
+    else:
+        entries["defenseclaw"]["enabled"] = True
+
+    oc_home = os.path.dirname(path)
+    install_path = os.path.join(oc_home, "extensions", "defenseclaw")
+    load = plugins.setdefault("load", {})
+    paths = load.setdefault("paths", [])
+    if install_path not in paths:
+        paths.append(install_path)
+
+    with _preserve_ownership(path):
+        with open(path, "w") as f:
+            json.dump(cfg, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+
+    _install_codeguard_skill_deferred(openclaw_config_file)
+
+    return prev_model or original_model
+
+
+def restore_openclaw_config(openclaw_config_file: str, original_model: str) -> bool:
+    """Remove the DefenseClaw plugin registration from openclaw.json.
+
+    The fetch interceptor required no model or provider changes, so there is
+    nothing to revert — just remove the plugin entries.
+    """
+    _ = original_model  # unused — kept for API compat
+    path = _expand(openclaw_config_file)
+
+    try:
+        with open(path) as f:
+            cfg = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return False
+
+    _backup(path)
+
+    # Remove leftover defenseclaw provider entry if present from older setups.
+    if "models" in cfg and "providers" in cfg["models"]:
+        cfg["models"]["providers"].pop("defenseclaw", None)
+        cfg["models"]["providers"].pop("litellm", None)
+
+    if "plugins" in cfg:
+        plugins = cfg["plugins"]
+        allow = plugins.get("allow", [])
+        if "defenseclaw" in allow:
+            allow.remove("defenseclaw")
+        entries = plugins.get("entries", {})
+        if "defenseclaw" in entries:
+            entries["defenseclaw"]["enabled"] = False
+        oc_home = os.path.dirname(path)
+        install_path = os.path.join(oc_home, "extensions", "defenseclaw")
+        paths = plugins.get("load", {}).get("paths", [])
+        if install_path in paths:
+            paths.remove(install_path)
+
+    with _preserve_ownership(path):
+        with open(path, "w") as f:
+            json.dump(cfg, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+
+    return True
+
+
+# NOTE: install_openclaw_plugin lived here previously. The gateway's
+# OpenClawConnector.Setup() now installs the embedded plugin directly
+# into ~/.openclaw/extensions/defenseclaw and patches openclaw.json on
+# every sidecar boot, so there is no separate Python-side install step.
+# `uninstall_openclaw_plugin` is kept for `defenseclaw uninstall`, which
+# has to revert the plugin even if the gateway is already gone.
+
+
+def uninstall_openclaw_plugin(openclaw_home: str) -> str:
+    """Uninstall the DefenseClaw plugin from OpenClaw.
+
+    Tries ``openclaw plugins uninstall defenseclaw`` first, falls back
+    to removing the extensions directory and config entries manually.
+
+    Returns:
+        ``"cli"``    — uninstalled via openclaw CLI
+        ``"manual"`` — removed directory manually
+        ``""``       — plugin was not installed
+        ``"error"``  — removal failed (permissions, etc.)
+    """
+    oc_home = _expand(openclaw_home)
+    target_dir = os.path.join(oc_home, "extensions", "defenseclaw")
+    oc_config = os.path.join(oc_home, "openclaw.json")
+    is_installed = os.path.isdir(target_dir) or os.path.islink(target_dir)
+
+    if not is_installed:
+        _unregister_plugin_from_config(oc_config)
+        return ""
+
+    _remove_from_plugins_allow(oc_config, "defenseclaw")
+
+    try:
+        from defenseclaw.config import openclaw_bin, openclaw_cmd_prefix
+        prefix = openclaw_cmd_prefix()
+        result = subprocess.run(
+            [*prefix, openclaw_bin(), "plugins", "uninstall", "defenseclaw"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode == 0:
+            return "cli"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    try:
+        if os.path.islink(target_dir):
+            os.unlink(target_dir)
+        elif os.path.isdir(target_dir):
+            shutil.rmtree(target_dir)
+        _unregister_plugin_from_config(oc_config)
+        return "manual"
+    except OSError:
+        return "error"
+
+
+def detect_current_model(openclaw_config_file: str) -> tuple[str, str]:
+    """Read the current model from openclaw.json. Returns
+    ``(model_id, provider_prefix)``."""
+    path = _expand(openclaw_config_file)
+    try:
+        with open(path) as f:
+            cfg = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return "", ""
+
+    primary = (
+        cfg.get("agents", {}).get("defaults", {}).get("model", {}).get("primary", "")
+    )
+    if "/" in primary:
+        provider, _model_id = primary.split("/", 1)
+        return primary, provider
+    return primary, ""
+
+
+# ------------------------------------------------------------------
+# Internal helpers (still public to the package — exercised by the
+# legacy test_guardrail.py via the back-compat re-export shim).
+# ------------------------------------------------------------------
+
+
+def _unregister_plugin_from_config(openclaw_config: str) -> None:
+    """Remove defenseclaw plugin entries from openclaw.json."""
+    path = _expand(openclaw_config)
+    try:
+        with open(path) as f:
+            cfg = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return
+
+    plugins = cfg.get("plugins", {})
+    changed = False
+
+    entries = plugins.get("entries", {})
+    if "defenseclaw" in entries:
+        del entries["defenseclaw"]
+        changed = True
+
+    installs = plugins.get("installs", {})
+    if "defenseclaw" in installs:
+        install_path = installs["defenseclaw"].get("installPath", "")
+        del installs["defenseclaw"]
+        changed = True
+
+        paths = plugins.get("load", {}).get("paths", [])
+        if install_path in paths:
+            paths.remove(install_path)
+
+    if changed:
+        with _preserve_ownership(path):
+            with open(path, "w") as f:
+                json.dump(cfg, f, indent=2, ensure_ascii=False)
+                f.write("\n")
+
+
+def _register_plugin_in_config(openclaw_config: str, source_dir: str) -> None:
+    """Register the defenseclaw plugin in openclaw.json (manual fallback).
+
+    Mirrors what ``openclaw plugins install`` does: adds entries to
+    plugins.load.paths, plugins.installs, and plugins.entries so
+    OpenClaw discovers and loads the plugin.
+    """
+    path = _expand(openclaw_config)
+    try:
+        with open(path) as f:
+            cfg = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return
+
+    plugins = cfg.setdefault("plugins", {})
+
+    entries = plugins.setdefault("entries", {})
+    if "defenseclaw" not in entries:
+        entries["defenseclaw"] = {"enabled": True}
+
+    oc_home = os.path.dirname(path)
+    install_path = os.path.join(oc_home, "extensions", "defenseclaw")
+    load = plugins.setdefault("load", {})
+    paths = load.setdefault("paths", [])
+    if install_path not in paths:
+        paths.append(install_path)
+
+    allow = plugins.setdefault("allow", [])
+    if "defenseclaw" not in allow:
+        allow.append("defenseclaw")
+
+    version = "0.0.0"
+    try:
+        pkg_json = os.path.join(source_dir, "package.json")
+        with open(pkg_json) as f:
+            version = json.load(f).get("version", version)
+    except (OSError, json.JSONDecodeError):
+        pass
+
+    from datetime import datetime, timezone
+    installs = plugins.setdefault("installs", {})
+    installs["defenseclaw"] = {
+        "source": "path",
+        "sourcePath": source_dir,
+        "installPath": install_path,
+        "version": version,
+        "installedAt": datetime.now(timezone.utc).isoformat(),
+    }
+
+    with _preserve_ownership(path):
+        with open(path, "w") as f:
+            json.dump(cfg, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+
+
+def _remove_from_plugins_allow(openclaw_config: str, plugin_id: str) -> None:
+    """Remove a plugin id from plugins.allow in openclaw.json (if present)."""
+    path = _expand(openclaw_config)
+    try:
+        with open(path) as f:
+            cfg = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return
+
+    allow = cfg.get("plugins", {}).get("allow", [])
+    if plugin_id not in allow:
+        return
+
+    allow.remove(plugin_id)
+    with _preserve_ownership(path):
+        with open(path, "w") as f:
+            json.dump(cfg, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+
+
+def _expand(p: str) -> str:
+    if p.startswith("~/"):
+        return str(Path.home() / p[2:])
+    return p
+
+
+@contextmanager
+def _preserve_ownership(path: str):
+    """Capture a file's uid/gid before a write and restore it afterwards.
+
+    Only relevant in standalone sandbox mode where setup commands run
+    as root and would otherwise re-create files owned by root,
+    breaking sandbox user access. Skipped entirely for non-root
+    callers since ``os.chown`` requires elevated privileges.
+    """
+    if os.getuid() != 0:
+        yield
+        return
+
+    uid = gid = None
+    try:
+        st = os.stat(path)
+        uid, gid = st.st_uid, st.st_gid
+    except OSError:
+        pass
+
+    yield
+
+    if uid is not None:
+        with contextlib.suppress(OSError):
+            os.chown(path, uid, gid)
+
+
+# ---------------------------------------------------------------------------
+# Pristine backup index — keeps a one-time snapshot of openclaw.json
+# at first DefenseClaw write so uninstall/doctor have a known-good
+# rollback target.
+# ---------------------------------------------------------------------------
+
+BACKUP_INDEX_FILENAME = "openclaw-backups.json"
+BACKUP_SUBDIR = "backups"
+
+
+def _backup_index_path(data_dir: str) -> str:
+    return os.path.join(data_dir, BACKUP_INDEX_FILENAME)
+
+
+def _read_backup_index(data_dir: str) -> dict:
+    """Load the backup index, returning an empty doc on any failure.
+
+    Schema (v1)::
+
+        {
+          "version": 1,
+          "entries": {
+            "<abs openclaw.json path>": {
+              "pristine": "<abs path to timestamped copy>",
+              "captured_at": "<ISO-8601 UTC>"
+            }
+          }
+        }
+    """
+    path = _backup_index_path(data_dir)
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict):
+            return data
+    except (OSError, json.JSONDecodeError):
+        pass
+    return {"version": 1, "entries": {}}
+
+
+def _write_backup_index(data_dir: str, doc: dict) -> None:
+    """Atomically persist the backup index, creating *data_dir* as needed."""
+    os.makedirs(data_dir, exist_ok=True)
+    path = _backup_index_path(data_dir)
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump(doc, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+    os.replace(tmp, path)
+
+
+def record_pristine_backup(openclaw_config_file: str, data_dir: str) -> str | None:
+    """Capture a one-time pristine snapshot of *openclaw_config_file*.
+
+    This is idempotent: once an entry exists for this path in the
+    backup index, subsequent calls are no-ops. Returns the absolute
+    path to the pristine snapshot on first capture, or ``None`` when
+    no snapshot was taken (either no source file, already recorded,
+    or the copy failed).
+    """
+    src = _expand(openclaw_config_file)
+    if not os.path.isfile(src):
+        return None
+    if not data_dir:
+        return None
+
+    index = _read_backup_index(data_dir)
+    entries = index.setdefault("entries", {})
+    src_abs = os.path.abspath(src)
+    if src_abs in entries and os.path.isfile(entries[src_abs].get("pristine", "")):
+        return None  # already captured a valid snapshot
+
+    import datetime
+    backup_dir = os.path.join(data_dir, BACKUP_SUBDIR)
+    os.makedirs(backup_dir, exist_ok=True)
+
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    basename = os.path.basename(src) or "openclaw.json"
+    dest = os.path.join(backup_dir, f"{basename}.{stamp}.pristine")
+    try:
+        shutil.copy2(src, dest)
+    except OSError:
+        return None
+
+    entries[src_abs] = {
+        "pristine": os.path.abspath(dest),
+        "captured_at": datetime.datetime.now(datetime.timezone.utc).isoformat(
+            timespec="seconds"
+        ),
+    }
+    index["version"] = 1
+    try:
+        _write_backup_index(data_dir, index)
+    except OSError:
+        # Best-effort: the snapshot exists on disk, but we couldn't
+        # index it. Uninstall will have to fall back to the .bak files.
+        with contextlib.suppress(OSError):
+            os.unlink(dest)
+        return None
+    return os.path.abspath(dest)
+
+
+def pristine_backup_path(openclaw_config_file: str, data_dir: str) -> str | None:
+    """Return the pristine snapshot path for *openclaw_config_file*, if any."""
+    if not data_dir:
+        return None
+    index = _read_backup_index(data_dir)
+    entry = index.get("entries", {}).get(os.path.abspath(_expand(openclaw_config_file)))
+    if not entry:
+        return None
+    pristine = entry.get("pristine", "")
+    return pristine if pristine and os.path.isfile(pristine) else None
+
+
+def _backup(path: str) -> None:
+    """Create a numbered backup of a file."""
+    if not os.path.isfile(path):
+        return
+    bak = path + ".bak"
+    if os.path.exists(bak):
+        found = False
+        for i in range(1, 100):
+            candidate = f"{path}.bak.{i}"
+            if not os.path.exists(candidate):
+                bak = candidate
+                found = True
+                break
+        if not found:
+            import time
+            bak = f"{path}.bak.{int(time.time() * 1000)}.{os.getpid()}"
+    st = os.stat(path)
+    shutil.copy2(path, bak)
+    with contextlib.suppress(OSError):
+        os.chown(bak, st.st_uid, st.st_gid)
+
+
+def _install_codeguard_skill_deferred(openclaw_config_file: str) -> None:
+    """Install the CodeGuard skill when guardrail connects to OpenClaw.
+
+    This handles the case where the user ran ``defenseclaw init``
+    before OpenClaw was installed, then later runs ``defenseclaw
+    guardrail enable``.
+    """
+    try:
+        from defenseclaw.codeguard_skill import ensure_codeguard_skill
+        from defenseclaw.config import load
+
+        cfg = load()
+        ensure_codeguard_skill(cfg.claw_home_dir(), openclaw_config_file)
+    except Exception:
+        pass

--- a/cli/defenseclaw/skill_list.py
+++ b/cli/defenseclaw/skill_list.py
@@ -1,0 +1,213 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Connector-agnostic skill enumeration.
+
+Provides :func:`list_skills`, the canonical way to ask "what skills
+are installed?" without caring which agent framework is active.
+
+For OpenClaw the answer comes from the ``openclaw skills list
+--json`` CLI (and falls back to walking ``Config.skill_dirs()``
+when the binary isn't available). For Codex / Claude Code /
+ZeptoClaw — none of which have a comparable JSON CLI — we walk
+``Config.skill_dirs()`` directly. This mirrors the AIBOM filesystem
+adapter in :mod:`defenseclaw.inventory.claw_inventory` (S4.3); the
+two pieces share the same eligibility / description rules so the
+``defenseclaw skill list`` and ``defenseclaw aibom scan`` outputs
+agree on which skills exist.
+
+Schema returned: a list of dicts, each with::
+
+    {
+        "name": "<skill id>",         # required
+        "description": "<one-line>",  # may be ""
+        "eligible": True/False,        # has SKILL.md / skill.json / README.md
+        "disabled": False,             # filesystem walks always return False
+        "source": "<directory path>", # where the skill lives
+        "bundled": False,              # filesystem walks always return False
+        "path": "<full path>",        # absolute path to the skill dir
+    }
+
+OpenClaw rows additionally include the original ``openclaw skills
+list`` payload (``emoji``, ``missing``, etc.).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from defenseclaw.config import Config
+
+
+def list_skills(cfg: Config, *, prefer_cli: bool = True) -> list[dict[str, Any]]:
+    """Return the connector-aware skill list.
+
+    Parameters
+    ----------
+    cfg
+        The :class:`defenseclaw.config.Config` carrying the active
+        connector (via :meth:`Config.active_connector`).
+    prefer_cli
+        For ``openclaw`` only — when True (default) we shell out to
+        ``openclaw skills list --json`` first and only walk the
+        filesystem when the CLI isn't available. When False we always
+        walk the filesystem; useful in tests and inside sandboxes
+        that don't have an ``openclaw`` binary on $PATH.
+    """
+    connector = cfg.active_connector()
+    if connector == "openclaw" and prefer_cli:
+        rows = _list_skills_via_openclaw_cli()
+        if rows is not None:
+            return rows
+    return _list_skills_from_filesystem(cfg)
+
+
+# ---------------------------------------------------------------------------
+# OpenClaw CLI adapter
+# ---------------------------------------------------------------------------
+
+
+def _list_skills_via_openclaw_cli() -> list[dict[str, Any]] | None:
+    """Invoke ``openclaw skills list --json`` and parse the response.
+
+    Returns ``None`` (so the caller falls back to the filesystem
+    walk) when the binary is missing, exits non-zero, or emits
+    non-JSON.
+    """
+    try:
+        from defenseclaw.config import openclaw_bin, openclaw_cmd_prefix
+        prefix = openclaw_cmd_prefix()
+    except Exception:
+        return None
+
+    try:
+        result = subprocess.run(
+            [*prefix, openclaw_bin(), "skills", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+
+    raw_skills = payload.get("skills") if isinstance(payload, dict) else None
+    if not isinstance(raw_skills, list):
+        return []
+
+    # Normalize the OpenClaw payload into the shared schema.
+    rows: list[dict[str, Any]] = []
+    for s in raw_skills:
+        if not isinstance(s, dict):
+            continue
+        name = s.get("name", "")
+        if not name:
+            continue
+        rows.append({
+            "name": name,
+            "description": s.get("description", ""),
+            "eligible": bool(s.get("eligible", True)),
+            "disabled": bool(s.get("disabled", False)),
+            "source": s.get("source", ""),
+            "bundled": bool(s.get("bundled", False)),
+            "path": s.get("path", ""),
+            **{
+                k: s[k] for k in ("emoji", "missing")
+                if k in s
+            },
+        })
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Filesystem adapter (Codex / Claude Code / ZeptoClaw / OpenClaw fallback)
+# ---------------------------------------------------------------------------
+
+
+def _list_skills_from_filesystem(cfg: Config) -> list[dict[str, Any]]:
+    """Walk every directory in ``cfg.skill_dirs()`` and return one
+    row per immediate subdirectory.
+
+    Mirrors the rules used by
+    :func:`defenseclaw.inventory.claw_inventory._enumerate_skills_filesystem`
+    so ``skill list`` and ``aibom scan`` agree on which skills exist.
+    """
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for skill_dir in cfg.skill_dirs():
+        if not os.path.isdir(skill_dir):
+            continue
+        try:
+            entries = os.listdir(skill_dir)
+        except OSError:
+            continue
+        for entry in sorted(entries):
+            full = os.path.join(skill_dir, entry)
+            if not os.path.isdir(full):
+                continue
+            if entry in seen:
+                continue
+            seen.add(entry)
+            row: dict[str, Any] = {
+                "name": entry,
+                "description": _read_skill_description(full),
+                "eligible": _skill_dir_is_eligible(full),
+                "disabled": False,
+                "source": skill_dir,
+                "bundled": False,
+                "path": full,
+            }
+            rows.append(row)
+    return rows
+
+
+def _skill_dir_is_eligible(path: str) -> bool:
+    for marker in ("SKILL.md", "skill.json", "README.md"):
+        if os.path.isfile(os.path.join(path, marker)):
+            return True
+    return False
+
+
+def _read_skill_description(path: str) -> str:
+    """Return the first non-empty stripped line of SKILL.md / README.md.
+
+    Bounded to 2 KiB so we don't accidentally slurp a multi-MB README
+    into the listing.
+    """
+    for marker in ("SKILL.md", "README.md"):
+        marker_path = os.path.join(path, marker)
+        if not os.path.isfile(marker_path):
+            continue
+        try:
+            with open(marker_path, encoding="utf-8", errors="replace") as f:
+                text = f.read(2048)
+        except OSError:
+            continue
+        for line in text.splitlines():
+            stripped = line.strip().lstrip("#").strip()
+            if stripped:
+                return stripped[:200]
+    return ""

--- a/cli/tests/test_guardrail.py
+++ b/cli/tests/test_guardrail.py
@@ -208,7 +208,7 @@ class TestUninstallOpenclawPlugin(unittest.TestCase):
             }, f)
         return oc_home
 
-    @patch("defenseclaw.guardrail.subprocess.run")
+    @patch("defenseclaw.openclaw_guardrail.subprocess.run")
     @patch("defenseclaw.config.openclaw_bin", return_value="openclaw")
     def test_cli_uninstall_when_openclaw_available(self, _mock_bin, mock_run):
         mock_run.return_value = MagicMock(returncode=0)
@@ -222,7 +222,7 @@ class TestUninstallOpenclawPlugin(unittest.TestCase):
             cmd = mock_run.call_args[0][0]
             self.assertEqual(cmd, ["openclaw", "plugins", "uninstall", "defenseclaw"])
 
-    @patch("defenseclaw.guardrail.subprocess.run", side_effect=FileNotFoundError)
+    @patch("defenseclaw.openclaw_guardrail.subprocess.run", side_effect=FileNotFoundError)
     def test_manual_fallback_removes_directory(self, _mock_run):
         with tempfile.TemporaryDirectory() as tmpdir:
             self._make_oc_home_with_plugin(tmpdir)
@@ -233,7 +233,7 @@ class TestUninstallOpenclawPlugin(unittest.TestCase):
             ext = os.path.join(tmpdir, "extensions", "defenseclaw")
             self.assertFalse(os.path.exists(ext))
 
-    @patch("defenseclaw.guardrail.subprocess.run", side_effect=FileNotFoundError)
+    @patch("defenseclaw.openclaw_guardrail.subprocess.run", side_effect=FileNotFoundError)
     def test_manual_fallback_cleans_config(self, _mock_run):
         with tempfile.TemporaryDirectory() as tmpdir:
             self._make_oc_home_with_plugin(tmpdir)
@@ -252,7 +252,7 @@ class TestUninstallOpenclawPlugin(unittest.TestCase):
         os.name == "nt" and not os.environ.get("CI"),
         "os.symlink requires admin or Developer Mode on Windows",
     )
-    @patch("defenseclaw.guardrail.subprocess.run", side_effect=FileNotFoundError)
+    @patch("defenseclaw.openclaw_guardrail.subprocess.run", side_effect=FileNotFoundError)
     def test_manual_fallback_removes_symlink(self, _mock_run):
         with tempfile.TemporaryDirectory() as tmpdir:
             ext_parent = os.path.join(tmpdir, "extensions")
@@ -273,7 +273,7 @@ class TestUninstallOpenclawPlugin(unittest.TestCase):
             result = uninstall_openclaw_plugin(tmpdir)
             self.assertEqual(result, "")
 
-    @patch("defenseclaw.guardrail.subprocess.run")
+    @patch("defenseclaw.openclaw_guardrail.subprocess.run")
     def test_cli_failure_falls_back_to_manual(self, mock_run):
         mock_run.return_value = MagicMock(returncode=1, stderr="error", stdout="")
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -285,7 +285,7 @@ class TestUninstallOpenclawPlugin(unittest.TestCase):
             ext = os.path.join(tmpdir, "extensions", "defenseclaw")
             self.assertFalse(os.path.exists(ext))
 
-    @patch("defenseclaw.guardrail.subprocess.run", side_effect=FileNotFoundError)
+    @patch("defenseclaw.openclaw_guardrail.subprocess.run", side_effect=FileNotFoundError)
     def test_removes_from_plugins_allow(self, _mock_run):
         with tempfile.TemporaryDirectory() as tmpdir:
             self._make_oc_home_with_plugin(tmpdir)
@@ -297,7 +297,7 @@ class TestUninstallOpenclawPlugin(unittest.TestCase):
             self.assertNotIn("defenseclaw", cfg["plugins"]["allow"])
             self.assertIn("other", cfg["plugins"]["allow"])
 
-    @patch("defenseclaw.guardrail.subprocess.run", side_effect=FileNotFoundError)
+    @patch("defenseclaw.openclaw_guardrail.subprocess.run", side_effect=FileNotFoundError)
     def test_timeout_on_cli_falls_back_to_manual(self, _mock_run):
         _mock_run.side_effect = subprocess.TimeoutExpired(cmd="openclaw", timeout=30)
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -640,7 +640,7 @@ class TestDeriveMasterKey(unittest.TestCase):
             key2 = _derive_master_key(key_file)
             self.assertEqual(key1, key2)
 
-    @patch("defenseclaw.guardrail.Path")
+    @patch("defenseclaw.llm_keys.Path")
     def test_raises_when_file_missing(self, mock_path):
         mock_path.home.return_value = Path("/nonexistent-home")
         with self.assertRaises(RuntimeError):

--- a/cli/tests/test_llm_keys.py
+++ b/cli/tests/test_llm_keys.py
@@ -1,0 +1,205 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct unit tests for the new connector-agnostic ``llm_keys`` module.
+
+The legacy tests in ``test_guardrail.py`` continue to exercise the
+back-compat shim via ``defenseclaw.guardrail import …``. These tests
+exercise the post-S4.4 module directly so we lock in the contract
+that downstream code (Codex / Claude Code / ZeptoClaw guardrail
+flows) can import without dragging in OpenClaw paperwork.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from defenseclaw import llm_keys
+
+
+class TestDetectApiKeyEnv(unittest.TestCase):
+    """Prefix-first routing — see codeguard-1-hardcoded-credentials."""
+
+    def test_bedrock_anthropic_routes_to_bedrock(self):
+        self.assertEqual(
+            llm_keys.detect_api_key_env(
+                "bedrock/us.anthropic.claude-3-5-sonnet-20241022"
+            ),
+            "AWS_BEARER_TOKEN_BEDROCK",
+        )
+
+    def test_anthropic_prefix(self):
+        self.assertEqual(
+            llm_keys.detect_api_key_env("anthropic/claude-3-5-sonnet"),
+            "ANTHROPIC_API_KEY",
+        )
+
+    def test_openai_prefix(self):
+        self.assertEqual(
+            llm_keys.detect_api_key_env("openai/gpt-4o"),
+            "OPENAI_API_KEY",
+        )
+
+    def test_azure_prefix(self):
+        self.assertEqual(
+            llm_keys.detect_api_key_env("azure/my-deployment"),
+            "AZURE_OPENAI_API_KEY",
+        )
+
+    def test_openrouter_prefix(self):
+        self.assertEqual(
+            llm_keys.detect_api_key_env("openrouter/anthropic/claude-3"),
+            "OPENROUTER_API_KEY",
+        )
+
+    def test_google_prefixes(self):
+        for model in (
+            "gemini/pro",
+            "google/text-bison",
+            "vertex_ai/text-bison",
+        ):
+            self.assertEqual(
+                llm_keys.detect_api_key_env(model),
+                "GOOGLE_API_KEY",
+            )
+
+    def test_substring_fallback_claude(self):
+        self.assertEqual(
+            llm_keys.detect_api_key_env("claude-3-5"),
+            "ANTHROPIC_API_KEY",
+        )
+
+    def test_substring_fallback_gpt(self):
+        self.assertEqual(
+            llm_keys.detect_api_key_env("gpt-4o"),
+            "OPENAI_API_KEY",
+        )
+
+    def test_unknown_returns_generic(self):
+        self.assertEqual(
+            llm_keys.detect_api_key_env("totally-made-up"),
+            "LLM_API_KEY",
+        )
+
+
+class TestModelToProxyName(unittest.TestCase):
+    def test_strips_provider_prefix(self):
+        self.assertEqual(
+            llm_keys.model_to_proxy_name("anthropic/claude-opus-4-5"),
+            "claude-opus-4-5",
+        )
+
+    def test_strips_anthropic_dash(self):
+        # ``model_to_proxy_name`` must also strip ``anthropic-`` after
+        # the slash split — operators routinely paste full provider
+        # qualifiers and we need a clean alias.
+        self.assertEqual(
+            llm_keys.model_to_proxy_name("anthropic/anthropic-claude-3"),
+            "claude-3",
+        )
+
+    def test_passthrough_when_no_slash(self):
+        self.assertEqual(
+            llm_keys.model_to_proxy_name("gpt-4o"),
+            "gpt-4o",
+        )
+
+
+class TestDeriveMasterKey(unittest.TestCase):
+    """Direct module-level test for ``derive_master_key``.
+
+    The legacy back-compat name ``_derive_master_key`` is covered in
+    ``test_guardrail.py``; here we assert the public name resolves to
+    the same implementation.
+    """
+
+    def test_deterministic(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            key_path = os.path.join(tmp, "device.key")
+            with open(key_path, "wb") as f:
+                f.write(b"some-random-bytes")
+            k1 = llm_keys.derive_master_key(key_path)
+            k2 = llm_keys.derive_master_key(key_path)
+            self.assertEqual(k1, k2)
+            self.assertTrue(k1.startswith("sk-dc-"))
+            self.assertEqual(len(k1), 6 + 32)
+
+    def test_raises_on_missing(self):
+        # Patch Path so the fallback ``~/.defenseclaw/device.key``
+        # also points at a non-existent location. Otherwise this
+        # test fails on developer machines that already have a real
+        # device.key from previous ``defenseclaw init`` runs.
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch("defenseclaw.llm_keys.Path") as mock_path:
+            from pathlib import Path as RealPath
+            mock_path.home.return_value = RealPath(tmp)
+            with self.assertRaises(RuntimeError):
+                llm_keys.derive_master_key("/nonexistent/device.key")
+
+
+class TestBackCompatShim(unittest.TestCase):
+    """``defenseclaw.guardrail`` must re-export every public name.
+
+    Catches accidental breakage of the back-compat surface.  If you
+    move a symbol out of ``llm_keys`` or ``openclaw_guardrail``, make
+    sure the shim still re-exports it; otherwise downstream callers
+    (cmd_setup, cmd_doctor, cmd_uninstall, third-party plugins) will
+    silently break.
+    """
+
+    def test_shim_exports_llm_keys_surface(self):
+        from defenseclaw import guardrail
+        self.assertIs(
+            guardrail.detect_api_key_env,
+            llm_keys.detect_api_key_env,
+        )
+        self.assertIs(
+            guardrail.model_to_proxy_name,
+            llm_keys.model_to_proxy_name,
+        )
+        # Legacy underscore-prefixed name is preserved.
+        self.assertIs(
+            guardrail._derive_master_key,
+            llm_keys.derive_master_key,
+        )
+
+    def test_shim_exports_openclaw_surface(self):
+        from defenseclaw import guardrail, openclaw_guardrail
+        for name in (
+            "patch_openclaw_config",
+            "restore_openclaw_config",
+            "uninstall_openclaw_plugin",
+            "detect_current_model",
+            "record_pristine_backup",
+            "pristine_backup_path",
+            "_backup",
+            "_register_plugin_in_config",
+            "_unregister_plugin_from_config",
+            "_remove_from_plugins_allow",
+            "_preserve_ownership",
+        ):
+            self.assertIs(
+                getattr(guardrail, name),
+                getattr(openclaw_guardrail, name),
+                f"shim re-export drift: {name}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/tests/test_skill_list.py
+++ b/cli/tests/test_skill_list.py
@@ -1,0 +1,240 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the connector-agnostic ``skill_list.list_skills`` adapter (S4.4)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from defenseclaw import skill_list
+from defenseclaw.config import ClawConfig, Config
+
+
+def _make_cfg(tmp: str, connector: str = "openclaw") -> Config:
+    ddir = os.path.join(tmp, ".defenseclaw")
+    os.makedirs(ddir, exist_ok=True)
+    cfg = Config(
+        data_dir=ddir,
+        audit_db=os.path.join(ddir, "audit.db"),
+        quarantine_dir=os.path.join(tmp, "q"),
+        plugin_dir=os.path.join(tmp, "p"),
+        policy_dir=os.path.join(tmp, "pol"),
+        claw=ClawConfig(
+            mode="openclaw",
+            home_dir=os.path.join(tmp, "oc"),
+            config_file=os.path.join(tmp, "oc", "openclaw.json"),
+        ),
+    )
+    cfg.active_connector = lambda c=connector: c  # type: ignore[method-assign]
+    return cfg
+
+
+def _seed_skill(root: str, name: str, *, marker: str = "SKILL.md", body: str = "# Skill\n") -> str:
+    path = os.path.join(root, name)
+    os.makedirs(path, exist_ok=True)
+    with open(os.path.join(path, marker), "w", encoding="utf-8") as f:
+        f.write(body)
+    return path
+
+
+class TestListSkillsForNonOpenClawConnector(unittest.TestCase):
+    """Each non-OpenClaw connector must walk its skill_dirs() output."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="dc-skill-list-")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _patch_skill_dirs(self, dirs):
+        return patch(
+            "defenseclaw.config.Config.skill_dirs",
+            return_value=list(dirs),
+        )
+
+    def test_codex_walks_disk_and_skips_subprocess(self):
+        cfg = _make_cfg(self.tmp, "codex")
+        skill_root = os.path.join(self.tmp, ".codex", "skills")
+        os.makedirs(skill_root, exist_ok=True)
+        _seed_skill(skill_root, "alpha")
+        _seed_skill(skill_root, "beta", body="# Beta\n\nBeta does X.")
+
+        with self._patch_skill_dirs([skill_root]), \
+             patch("defenseclaw.skill_list.subprocess.run") as mock_run:
+            rows = skill_list.list_skills(cfg)
+            mock_run.assert_not_called()
+
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["name"], "alpha")
+        self.assertEqual(rows[1]["name"], "beta")
+        self.assertEqual(rows[1]["description"], "Beta")
+        for r in rows:
+            self.assertTrue(r["eligible"])
+            self.assertFalse(r["disabled"])
+            self.assertFalse(r["bundled"])
+            self.assertEqual(r["source"], skill_root)
+
+    def test_claudecode_walks_disk(self):
+        cfg = _make_cfg(self.tmp, "claudecode")
+        skill_root = os.path.join(self.tmp, ".claude", "skills")
+        os.makedirs(skill_root, exist_ok=True)
+        _seed_skill(skill_root, "weather")
+        with self._patch_skill_dirs([skill_root]):
+            rows = skill_list.list_skills(cfg)
+        self.assertEqual([r["name"] for r in rows], ["weather"])
+
+    def test_zeptoclaw_walks_disk_with_skill_json(self):
+        cfg = _make_cfg(self.tmp, "zeptoclaw")
+        skill_root = os.path.join(self.tmp, ".zeptoclaw", "skills")
+        os.makedirs(skill_root, exist_ok=True)
+        _seed_skill(skill_root, "alpha", marker="skill.json", body="{}")
+        with self._patch_skill_dirs([skill_root]):
+            rows = skill_list.list_skills(cfg)
+        self.assertEqual(rows[0]["name"], "alpha")
+        self.assertTrue(rows[0]["eligible"])
+
+    def test_directory_without_marker_is_ineligible(self):
+        cfg = _make_cfg(self.tmp, "codex")
+        skill_root = os.path.join(self.tmp, "skills")
+        os.makedirs(os.path.join(skill_root, "marked"), exist_ok=True)
+        with open(os.path.join(skill_root, "marked", "SKILL.md"), "w") as f:
+            f.write("# X")
+        os.makedirs(os.path.join(skill_root, "empty"), exist_ok=True)
+        with self._patch_skill_dirs([skill_root]):
+            rows = skill_list.list_skills(cfg)
+        by_name = {r["name"]: r for r in rows}
+        self.assertTrue(by_name["marked"]["eligible"])
+        self.assertFalse(by_name["empty"]["eligible"])
+
+    def test_dedup_across_skill_dirs(self):
+        cfg = _make_cfg(self.tmp, "codex")
+        a = os.path.join(self.tmp, "a")
+        b = os.path.join(self.tmp, "b")
+        os.makedirs(a, exist_ok=True)
+        os.makedirs(b, exist_ok=True)
+        _seed_skill(a, "shared")
+        _seed_skill(b, "shared")
+        with self._patch_skill_dirs([a, b]):
+            rows = skill_list.list_skills(cfg)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["source"], a)
+
+    def test_missing_skill_dir_is_skipped(self):
+        cfg = _make_cfg(self.tmp, "codex")
+        with self._patch_skill_dirs(["/nonexistent/path"]):
+            rows = skill_list.list_skills(cfg)
+        self.assertEqual(rows, [])
+
+
+class TestListSkillsForOpenClaw(unittest.TestCase):
+    """OpenClaw default keeps the subprocess-first behavior."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="dc-skill-list-oc-")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_uses_openclaw_cli_when_available(self):
+        cfg = _make_cfg(self.tmp, "openclaw")
+        payload = {
+            "skills": [
+                {
+                    "name": "github",
+                    "description": "GitHub integration",
+                    "eligible": True,
+                    "disabled": False,
+                    "source": "openclaw-bundled",
+                    "bundled": True,
+                },
+            ],
+        }
+        with patch("defenseclaw.skill_list.subprocess.run") as mock_run, \
+             patch(
+                 "defenseclaw.config.openclaw_cmd_prefix",
+                 return_value=[],
+             ), \
+             patch(
+                 "defenseclaw.config.openclaw_bin",
+                 return_value="openclaw",
+             ):
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=json.dumps(payload), stderr=""
+            )
+            rows = skill_list.list_skills(cfg)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["name"], "github")
+        self.assertTrue(rows[0]["bundled"])
+
+    def test_falls_back_to_filesystem_when_cli_missing(self):
+        cfg = _make_cfg(self.tmp, "openclaw")
+        skill_root = os.path.join(self.tmp, "fallback-skills")
+        os.makedirs(skill_root, exist_ok=True)
+        _seed_skill(skill_root, "fs-only")
+        with patch(
+            "defenseclaw.skill_list.subprocess.run",
+            side_effect=FileNotFoundError,
+        ), patch(
+            "defenseclaw.config.Config.skill_dirs",
+            return_value=[skill_root],
+        ):
+            rows = skill_list.list_skills(cfg)
+        self.assertEqual(rows[0]["name"], "fs-only")
+
+    def test_prefer_cli_false_skips_subprocess(self):
+        cfg = _make_cfg(self.tmp, "openclaw")
+        skill_root = os.path.join(self.tmp, "fs-only-skills")
+        os.makedirs(skill_root, exist_ok=True)
+        _seed_skill(skill_root, "alpha")
+        with patch("defenseclaw.skill_list.subprocess.run") as mock_run, \
+             patch(
+                 "defenseclaw.config.Config.skill_dirs",
+                 return_value=[skill_root],
+             ):
+            rows = skill_list.list_skills(cfg, prefer_cli=False)
+            mock_run.assert_not_called()
+        self.assertEqual(rows[0]["name"], "alpha")
+
+    def test_returns_empty_when_cli_returns_non_dict(self):
+        cfg = _make_cfg(self.tmp, "openclaw")
+        with patch("defenseclaw.skill_list.subprocess.run") as mock_run, \
+             patch(
+                 "defenseclaw.config.openclaw_cmd_prefix",
+                 return_value=[],
+             ), \
+             patch(
+                 "defenseclaw.config.openclaw_bin",
+                 return_value="openclaw",
+             ):
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="[]", stderr=""
+            )
+            rows = skill_list.list_skills(cfg)
+        # ``[]`` parses as a list, not a dict — so the parser treats
+        # it as "no skills key" and returns []. Crucially we must NOT
+        # crash and we must NOT fall back to the filesystem (the CLI
+        # returned a successful response).
+        self.assertEqual(rows, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two related changes that together unblock non-OpenClaw guardrail flows.

### 1. guardrail.py split

The legacy `cli/defenseclaw/guardrail.py` mixes three concerns: connector-agnostic API-key/model detection, deterministic master-key derivation, and OpenClaw-specific patching of `~/.openclaw/openclaw.json`. Codex / Claude Code / ZeptoClaw flows need (1) and (2) but must not pull (3) along with them.

* **NEW** `cli/defenseclaw/llm_keys.py` — `detect_api_key_env`, `model_to_proxy_name`, `derive_master_key`. Pure, no I/O outside the device.key read.
* **NEW** `cli/defenseclaw/openclaw_guardrail.py` — `patch_openclaw_config`, `restore_openclaw_config`, `uninstall_openclaw_plugin`, `detect_current_model`, `record_pristine_backup`, `pristine_backup_path`, plus the underscore-prefixed helpers the existing test suite reaches in for.
* **REWRITTEN** `cli/defenseclaw/guardrail.py` — back-compat shim that re-exports both module surfaces. Every existing call site (`cmd_setup`, `cmd_doctor`, `cmd_uninstall`, `tests/test_guardrail.py`) keeps working unchanged.

### 2. skill_list adapter

`defenseclaw skill list` and `defenseclaw skill info` were hardcoded to `openclaw skills list/info`. On non-OpenClaw connectors that returns nothing, so users saw "no skills installed" even with `~/.codex/skills` full.

* **NEW** `cli/defenseclaw/skill_list.py` — `list_skills(cfg)` adapter.
  * OpenClaw: sidecar → CLI fallback chain, **plus** a new filesystem fallback when the binary isn't on PATH (sandbox installs, CI).
  * Codex / Claude Code / ZeptoClaw: walks `Config.skill_dirs()` with the same eligibility / description rules as the AIBOM filesystem adapter from #180. Single source of truth — \`skill list\` and \`aibom scan\` always agree.
* `cli/defenseclaw/commands/cmd_skill.py` — `_list_openclaw_skills_full` and `_get_openclaw_skill_info` dispatch on `Config.active_connector()`. Function names preserved to avoid a cascade of renames in this 1700-line file.

## Stack

- #178 — S4.1: extract \`connector_paths.py\`
- #179 — S4.2: cmd_mcp set/unset adapter
- #180 — S4.3: AIBOM filesystem adapter
- **this PR — S4.4: guardrail split + skill_list adapter**

## Tests

* \`tests/test_guardrail.py\` — only mock-patch paths updated (`defenseclaw.openclaw_guardrail.subprocess`, `defenseclaw.llm_keys.Path`). Functional assertions unchanged. **127 / 127 pass.**
* **NEW** \`tests/test_llm_keys.py\` — direct tests for the connector-agnostic surface plus a back-compat-shim drift detector.
* **NEW** \`tests/test_skill_list.py\` — 12 tests covering Codex / Claude Code / ZeptoClaw walks, multi-skill_dir dedup, missing dirs, eligibility, and the OpenClaw subprocess-first contract.
* \`tests/test_cmd_skill.py\` — **67 / 67 pass** unchanged.
* \`tests/test_llm_env.py\` — unchanged, **all pass**.
* Full Python suite: 1260 pass + 1 pre-existing unrelated failure (\`test_cmd_plugin.TestResolvePluginDir.test_resolves_root_when_source_is_file_in_dist_subdir\`, present on parent).

## Test plan

- [x] \`pytest tests/test_guardrail.py tests/test_llm_keys.py tests/test_skill_list.py tests/test_cmd_skill.py tests/test_llm_env.py\` — all green
- [x] \`pytest tests/\` — only known pre-existing fail
- [x] No new \`import os\` / \`import subprocess\` inline calls in production code
- [x] guardrail.py shim re-exports every legacy public + underscore-prefixed name
- [x] No code in cmd_setup, cmd_doctor, cmd_uninstall touched (back-compat shim works)

## Refs

connector-architecture v3 — S4.4 in the claw-agnostic plan.