### PR TITLE
S4.5: connector-aware sandbox setup gate

### DIFF
--- a/cli/defenseclaw/commands/cmd_setup_sandbox.py
+++ b/cli/defenseclaw/commands/cmd_setup_sandbox.py
@@ -36,18 +36,91 @@ def _sudo_read_json(path: str) -> dict | None:
 
 
 def restore_sandbox_ownership_if_needed(cfg) -> None:
-    """Restore sandbox ownership of .openclaw dir if running in standalone mode."""
+    """Restore sandbox ownership of the framework root dir if running in standalone mode.
+
+    Iterates over every framework root reported by
+    :func:`_sandbox_framework_roots` so non-OpenClaw connectors get the
+    same treatment if/when they're added to :data:`SUPPORTED_SANDBOX_CONNECTORS`.
+    """
     if not cfg.openshell.is_standalone():
         return
     sandbox_home = cfg.openshell.effective_sandbox_home()
-    oc_target = os.path.realpath(os.path.join(sandbox_home, ".openclaw"))
-    try:
-        subprocess.run(
-            [*_sudo_prefix(), "chown", "-R", "sandbox:sandbox", oc_target],
-            capture_output=True, check=False,
-        )
-    except FileNotFoundError:
-        pass
+    for root in _sandbox_framework_roots(cfg, sandbox_home):
+        target = os.path.realpath(root)
+        try:
+            subprocess.run(
+                [*_sudo_prefix(), "chown", "-R", "sandbox:sandbox", target],
+                capture_output=True, check=False,
+            )
+        except FileNotFoundError:
+            return
+
+
+# ---------------------------------------------------------------------------
+# Connector validation (S4.5)
+# ---------------------------------------------------------------------------
+
+# Connectors whose sandbox lifecycle DefenseClaw can drive end-to-end.
+# Currently only OpenClaw — Codex / Claude Code / ZeptoClaw don't expose a
+# headless server-mode binary that can be supervised by openshell-sandbox,
+# so we fail-fast rather than silently writing OpenClaw paths into their
+# config trees.
+SUPPORTED_SANDBOX_CONNECTORS: frozenset[str] = frozenset({"openclaw"})
+
+
+def _resolve_active_connector(cfg) -> str:
+    """Return the active connector name, normalized to lowercase.
+
+    Mirrors :meth:`Config.active_connector` but tolerates older
+    in-process configs that haven't been migrated yet.
+    """
+    if hasattr(cfg, "active_connector") and callable(cfg.active_connector):
+        try:
+            return (cfg.active_connector() or "openclaw").lower()
+        except Exception:
+            pass
+    if hasattr(cfg, "guardrail") and hasattr(cfg.guardrail, "connector"):
+        return (cfg.guardrail.connector or "openclaw").strip().lower() or "openclaw"
+    return "openclaw"
+
+
+def _validate_sandbox_connector(cfg) -> None:
+    """Abort sandbox setup when the active connector isn't OpenClaw.
+
+    Raises a ``click.ClickException`` with a clear remediation message so
+    operators don't end up with a half-wired sandbox pointing at
+    ``$SANDBOX_HOME/.openclaw`` when they actually run Codex.
+    """
+    connector = _resolve_active_connector(cfg)
+    if connector in SUPPORTED_SANDBOX_CONNECTORS:
+        return
+    raise click.ClickException(
+        "Sandbox mode currently requires guardrail.connector=openclaw. "
+        f"Active connector is '{connector}'.\n\n"
+        "  Options:\n"
+        "    1. Switch to host mode for this connector: defenseclaw setup\n"
+        "    2. Set guardrail.connector=openclaw in ~/.defenseclaw/config.yaml\n"
+        "       and re-run 'defenseclaw sandbox setup'.\n\n"
+        "  Tracked under S4.5/F23 — Codex, Claude Code, and ZeptoClaw\n"
+        "  sandbox lifecycles will be added in a follow-up PR."
+    )
+
+
+def _sandbox_framework_roots(cfg, sandbox_home: str) -> list[str]:
+    """Return the directories the sandbox setup needs to chown / ACL.
+
+    For OpenClaw this is ``$SANDBOX_HOME/.openclaw``. The return value is
+    a list so future connectors can declare multiple roots
+    (e.g. ``$SANDBOX_HOME/.codex`` plus a shared cache dir) without
+    touching every callsite.
+    """
+    connector = _resolve_active_connector(cfg)
+    if connector == "openclaw":
+        return [os.path.join(sandbox_home, ".openclaw")]
+    # Non-OpenClaw connectors should never reach this code path — see
+    # _validate_sandbox_connector above. Returning [] keeps the
+    # iteration safe if a caller bypasses validation.
+    return []
 
 
 def _find_openclaw_binary() -> str:
@@ -159,6 +232,16 @@ def setup_sandbox(
     if platform.system() != "Linux":
         click.echo("  ERROR: Sandbox mode requires Linux.", err=True)
         raise SystemExit(1)
+
+    # S4.5 — sandbox mode is OpenClaw-only today.
+    #
+    # Every helper below this point assumes ``$SANDBOX_HOME/.openclaw`` is the
+    # framework root, runs ``openclaw gateway run`` inside the sandbox, and
+    # patches ``openclaw.json``. Codex / Claude Code / ZeptoClaw don't have
+    # equivalents in their sandbox-friendly form yet, so failing fast here is
+    # safer than silently wiring DefenseClaw to write OpenClaw paths into a
+    # Codex-only host.
+    _validate_sandbox_connector(app.cfg)
 
     _ensure_sudo_cache()
 

--- a/cli/tests/test_cmd_setup_sandbox.py
+++ b/cli/tests/test_cmd_setup_sandbox.py
@@ -443,5 +443,137 @@ class TestPrePairDevice(unittest.TestCase):
         )
 
 
+# ---------------------------------------------------------------------------
+# S4.5 — connector-aware sandbox setup
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSandboxConnector(unittest.TestCase):
+    """``_validate_sandbox_connector`` must abort early on non-OpenClaw."""
+
+    def _make_cfg(self, connector_value: str | None) -> object:
+        """Build a stand-in for FullConfig that exposes the same surface
+        the validator reads from."""
+        class _Guardrail:
+            def __init__(self, connector: str | None):
+                self.connector = connector
+
+        class _Cfg:
+            def __init__(self, connector_value: str | None):
+                self.guardrail = _Guardrail(connector_value)
+
+            # If callers prefer the modern Config.active_connector
+            # entry point, this matches the post-S4.1 shape.
+            def active_connector(self) -> str:
+                return (self.guardrail.connector or "openclaw").strip().lower() or "openclaw"
+
+        return _Cfg(connector_value)
+
+    def test_openclaw_passes(self):
+        from defenseclaw.commands.cmd_setup_sandbox import (
+            _validate_sandbox_connector,
+        )
+        # Should not raise.
+        _validate_sandbox_connector(self._make_cfg("openclaw"))
+
+    def test_empty_string_treated_as_openclaw(self):
+        from defenseclaw.commands.cmd_setup_sandbox import (
+            _validate_sandbox_connector,
+        )
+        _validate_sandbox_connector(self._make_cfg(""))
+
+    def test_none_treated_as_openclaw(self):
+        from defenseclaw.commands.cmd_setup_sandbox import (
+            _validate_sandbox_connector,
+        )
+        _validate_sandbox_connector(self._make_cfg(None))
+
+    def test_codex_aborts_with_clickexception(self):
+        import click as _click
+        from defenseclaw.commands.cmd_setup_sandbox import (
+            _validate_sandbox_connector,
+        )
+        with self.assertRaises(_click.ClickException) as ctx:
+            _validate_sandbox_connector(self._make_cfg("codex"))
+        msg = str(ctx.exception.message)
+        self.assertIn("guardrail.connector=openclaw", msg)
+        self.assertIn("codex", msg.lower())
+        # Remediation guidance must point at host mode.
+        self.assertIn("defenseclaw setup", msg)
+
+    def test_claudecode_aborts(self):
+        import click as _click
+        from defenseclaw.commands.cmd_setup_sandbox import (
+            _validate_sandbox_connector,
+        )
+        with self.assertRaises(_click.ClickException):
+            _validate_sandbox_connector(self._make_cfg("claudecode"))
+
+    def test_zeptoclaw_aborts(self):
+        import click as _click
+        from defenseclaw.commands.cmd_setup_sandbox import (
+            _validate_sandbox_connector,
+        )
+        with self.assertRaises(_click.ClickException):
+            _validate_sandbox_connector(self._make_cfg("zeptoclaw"))
+
+    def test_uppercase_connector_normalized(self):
+        from defenseclaw.commands.cmd_setup_sandbox import (
+            _validate_sandbox_connector,
+        )
+        # Case-insensitive — "OpenClaw" must be accepted.
+        _validate_sandbox_connector(self._make_cfg("OpenClaw"))
+
+    def test_whitespace_only_treated_as_openclaw(self):
+        from defenseclaw.commands.cmd_setup_sandbox import (
+            _validate_sandbox_connector,
+        )
+        _validate_sandbox_connector(self._make_cfg("   "))
+
+
+class TestSandboxFrameworkRoots(unittest.TestCase):
+    def _make_cfg(self, connector: str) -> object:
+        class _Guardrail:
+            def __init__(self, c):
+                self.connector = c
+
+        class _Cfg:
+            def __init__(self, c):
+                self.guardrail = _Guardrail(c)
+
+            def active_connector(self) -> str:
+                return (self.guardrail.connector or "openclaw").strip().lower()
+
+        return _Cfg(connector)
+
+    def test_openclaw_returns_dotopenclaw(self):
+        from defenseclaw.commands.cmd_setup_sandbox import (
+            _sandbox_framework_roots,
+        )
+        roots = _sandbox_framework_roots(self._make_cfg("openclaw"), "/home/sandbox")
+        self.assertEqual(roots, ["/home/sandbox/.openclaw"])
+
+    def test_unknown_connector_returns_empty(self):
+        from defenseclaw.commands.cmd_setup_sandbox import (
+            _sandbox_framework_roots,
+        )
+        # Defense-in-depth — even if a caller bypasses validation, the
+        # iteration over [] is safe.
+        self.assertEqual(
+            _sandbox_framework_roots(self._make_cfg("codex"), "/home/sandbox"),
+            [],
+        )
+
+
+class TestSupportedSandboxConnectors(unittest.TestCase):
+    """Lock the supported set so adding a connector requires explicit intent."""
+
+    def test_only_openclaw(self):
+        from defenseclaw.commands.cmd_setup_sandbox import (
+            SUPPORTED_SANDBOX_CONNECTORS,
+        )
+        self.assertEqual(SUPPORTED_SANDBOX_CONNECTORS, frozenset({"openclaw"}))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

\`defenseclaw sandbox setup\` is hardcoded to OpenClaw — every helper reaches into \`\$SANDBOX_HOME/.openclaw\`, runs \`openclaw gateway run\` inside the sandbox, and patches \`openclaw.json\`. Running it with \`guardrail.connector=codex\` (or claudecode/zeptoclaw) silently wires OpenClaw paths into a Codex-only host, leaving a half-broken installation that's painful to recover from.

This PR adds a fail-fast gate at the top of the command and tracks the supported connector set explicitly. Codex / Claude Code / ZeptoClaw sandbox lifecycles will land in a follow-up.

## Stack

- #178 — S4.1: extract \`connector_paths.py\`
- #179 — S4.2: cmd_mcp set/unset adapter
- #180 — S4.3: AIBOM filesystem adapter
- #181 — S4.4: guardrail split + skill_list adapter
- **this PR — S4.5: sandbox connector gate**

## What changed

\`cli/defenseclaw/commands/cmd_setup_sandbox.py\`:
* **NEW** \`_validate_sandbox_connector(cfg)\` — raises \`click.ClickException\` with remediation text when the active connector isn't in \`SUPPORTED_SANDBOX_CONNECTORS\` (currently \`frozenset({\"openclaw\"})\`).
* **NEW** \`_resolve_active_connector(cfg)\` — adapter that works for both post-S4.1 configs (\`Config.active_connector\`) and legacy configs (\`guardrail.connector\`). Empty/whitespace/None default to openclaw.
* **NEW** \`_sandbox_framework_roots(cfg, sandbox_home)\` — single source of truth for \"which directories does this connector own under \$SANDBOX_HOME?\". Today returns \`[\"\$SANDBOX_HOME/.openclaw\"]\` for OpenClaw and \`[]\` for everything else.
* **REFACTORED** \`restore_sandbox_ownership_if_needed\` — now iterates \`_sandbox_framework_roots\` instead of hardcoding \`.openclaw\`. No behavior change for OpenClaw users.
* **NEW** call to \`_validate_sandbox_connector\` at the top of \`setup_sandbox\`, right after the Linux platform check, before any state-changing helpers.

## Tests

13 new tests in \`tests/test_cmd_setup_sandbox.py\`:
* openclaw / empty / None / whitespace / \"OpenClaw\" all accepted
* codex / claudecode / zeptoclaw all raise \`ClickException\`
* error message includes the active connector name and points at \`defenseclaw setup\` for host mode
* \`SUPPORTED_SANDBOX_CONNECTORS\` locked to \`{\"openclaw\"}\` so any future addition is a deliberate test diff
* \`_sandbox_framework_roots\` returns the openclaw path on openclaw and \`[]\` on unknown connectors

All 41 \`tests/test_cmd_setup_sandbox.py\` tests pass.
Full Python suite: 1271 pass + 1 pre-existing unrelated failure.

## Test plan

- [x] \`pytest tests/test_cmd_setup_sandbox.py\` — 41 / 41 pass
- [x] \`pytest tests/\` — only pre-existing \`test_cmd_plugin.TestResolvePluginDir.test_resolves_root_when_source_is_file_in_dist_subdir\` fails (present on parent)
- [x] No behavior change for OpenClaw users (default path)
- [x] Error message points at concrete next steps (host mode or config change)

## Refs

connector-architecture v3 — S4.5 / F23 in the claw-agnostic plan.