### PR TITLE
S6.1: shared scan-UI module

### DIFF
--- a/cli/defenseclaw/commands/_scan_ui.py
+++ b/cli/defenseclaw/commands/_scan_ui.py
@@ -1,0 +1,372 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared UI helpers for ``defenseclaw <component> scan`` commands.
+
+The scan commands (``defenseclaw plugin scan``, ``defenseclaw skill
+scan``, ``defenseclaw mcp scan``, ``defenseclaw scan --all``) all
+share the same UX shape: announce *what* is being scanned and *for*
+what (so users see "Scanning 3 plugins for malware, prompt
+injection, secrets" instead of an opaque "Scanning..."), then print
+either a per-target verdict line or a JSON document. Today each
+command rolls its own preamble, scan-table, and summary; small drift
+between them confuses operators who are paging through several at
+once.
+
+This module is the canonical home for those helpers. S6.1
+introduces the data structures and primitives; S6.2 / S6.3 / S6.4
+will replace the per-command UX with calls into this module.
+
+Public surface:
+
+* :class:`ScanContext` — bundles the per-invocation context every
+  helper needs (component label, active connector, paths, scan
+  categories, --json flag, click context). Built by
+  :meth:`ScanContext.for_plugin` / :meth:`ScanContext.for_skill` /
+  :meth:`ScanContext.for_mcp`.
+* :func:`render_preamble` — prints the "Scanning N <component>s on
+  <connector>" banner, with concrete bullet points for the scan
+  categories.
+* :func:`render_per_target_status` — prints a single result line.
+* :func:`render_summary` — prints the final tally (clean / blocked /
+  errored / total).
+* :func:`render_json_payload` — emits a stable JSON shape; locked
+  by snapshot tests in S6.6.
+
+All helpers tolerate ``ctx.as_json`` and emit nothing in JSON mode
+except the final document — per
+:doc:`docs/cli-ux-contract` (the JSON shape is the
+machine-readable contract; humans see the table only on the human
+output path).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+import click
+
+# ---------------------------------------------------------------------------
+# Component / category definitions
+# ---------------------------------------------------------------------------
+
+# Stable component IDs mirroring the inventory categories from S4.3.
+COMPONENT_PLUGIN = "plugin"
+COMPONENT_SKILL = "skill"
+COMPONENT_MCP = "mcp"
+
+# Human labels and pluralization. Kept in one place so the wording
+# stays consistent across `scan`, `aibom`, `doctor`, and the help
+# text.
+_COMPONENT_LABELS: dict[str, tuple[str, str]] = {
+    COMPONENT_PLUGIN: ("plugin", "plugins"),
+    COMPONENT_SKILL: ("skill", "skills"),
+    COMPONENT_MCP: ("MCP server", "MCP servers"),
+}
+
+# Default per-component scan categories — the bullet list under the
+# preamble. Concrete enough to set expectations, abstract enough that
+# we don't have to re-version every time a scanner adds a check.
+_DEFAULT_CATEGORIES: dict[str, tuple[str, ...]] = {
+    COMPONENT_PLUGIN: (
+        "malicious code patterns",
+        "prompt injection attempts",
+        "hardcoded secrets",
+        "supply-chain risk indicators",
+    ),
+    COMPONENT_SKILL: (
+        "prompt injection in SKILL.md",
+        "malicious shell / Python invocations",
+        "untrusted bundled bins",
+        "policy violations",
+    ),
+    COMPONENT_MCP: (
+        "untrusted command paths",
+        "outbound URL allow-listing",
+        "tool-name spoofing",
+        "auth-token handling",
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Verdict states
+# ---------------------------------------------------------------------------
+
+VERDICT_CLEAN = "clean"
+VERDICT_BLOCKED = "blocked"
+VERDICT_QUARANTINED = "quarantined"
+VERDICT_ERROR = "error"
+VERDICT_SKIPPED = "skipped"
+
+_VERDICT_GLYPH: dict[str, str] = {
+    VERDICT_CLEAN: "ok",
+    VERDICT_BLOCKED: "BLOCKED",
+    VERDICT_QUARANTINED: "QUARANTINED",
+    VERDICT_ERROR: "ERROR",
+    VERDICT_SKIPPED: "skip",
+}
+
+
+# ---------------------------------------------------------------------------
+# ScanContext
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ScanContext:
+    """Per-invocation context passed to every render helper.
+
+    Built once at the top of a scan command via the convenience
+    constructors below, then threaded through. Keeping a dataclass
+    (instead of separate positional args) means we can add new
+    fields — e.g. ``severity_threshold``, ``offline``, ``policy_id``
+    — without breaking call sites.
+
+    Attributes
+    ----------
+    component
+        One of :data:`COMPONENT_PLUGIN`, :data:`COMPONENT_SKILL`,
+        :data:`COMPONENT_MCP`.
+    connector
+        The active connector name (e.g. ``"openclaw"``,
+        ``"codex"``). Lowercase, never empty — defaults to
+        ``"openclaw"`` when unset, mirroring
+        ``Config.active_connector``.
+    paths
+        The directories or files being scanned. Used for the
+        preamble (``Scanning N plugins under ~/.codex/extensions``)
+        and the JSON ``targets[]`` array.
+    categories
+        The scan categories listed under the preamble bullet
+        points. Defaults to the per-component list in
+        :data:`_DEFAULT_CATEGORIES`.
+    as_json
+        When True, no human output is emitted before the final JSON
+        document. Mirrors the ``--json`` flag wired into every scan
+        command.
+    click_ctx
+        Optional click context, used to short-circuit on
+        ``--quiet`` / ``--no-color`` flags. May be None in unit
+        tests.
+    """
+
+    component: str
+    connector: str
+    paths: list[str] = field(default_factory=list)
+    categories: tuple[str, ...] = ()
+    as_json: bool = False
+    click_ctx: click.Context | None = None
+
+    def __post_init__(self) -> None:
+        # Normalize. Operators routinely paste connector names with
+        # weird casing or trailing whitespace.
+        self.connector = (self.connector or "openclaw").strip().lower() or "openclaw"
+        if not self.categories:
+            self.categories = _DEFAULT_CATEGORIES.get(self.component, ())
+
+    # -- convenience constructors -------------------------------------
+
+    @classmethod
+    def for_plugin(cls, *, connector: str, paths: Iterable[str], as_json: bool = False) -> ScanContext:
+        return cls(
+            component=COMPONENT_PLUGIN,
+            connector=connector,
+            paths=list(paths),
+            as_json=as_json,
+        )
+
+    @classmethod
+    def for_skill(cls, *, connector: str, paths: Iterable[str], as_json: bool = False) -> ScanContext:
+        return cls(
+            component=COMPONENT_SKILL,
+            connector=connector,
+            paths=list(paths),
+            as_json=as_json,
+        )
+
+    @classmethod
+    def for_mcp(cls, *, connector: str, paths: Iterable[str], as_json: bool = False) -> ScanContext:
+        return cls(
+            component=COMPONENT_MCP,
+            connector=connector,
+            paths=list(paths),
+            as_json=as_json,
+        )
+
+    # -- helpers ------------------------------------------------------
+
+    def label(self, *, plural: bool = False) -> str:
+        """Return the human-readable component label, optionally pluralized."""
+        sing, plur = _COMPONENT_LABELS.get(self.component, (self.component, self.component + "s"))
+        return plur if plural else sing
+
+
+# ---------------------------------------------------------------------------
+# Render helpers
+# ---------------------------------------------------------------------------
+
+
+def render_preamble(ctx: ScanContext, target_count: int) -> None:
+    """Print the "Scanning N <components> on <connector> for ..." banner.
+
+    Skipped entirely when ``ctx.as_json`` is True — JSON callers
+    care only about the final document.
+    """
+    if ctx.as_json:
+        return
+    label = ctx.label(plural=target_count != 1)
+    click.echo()
+    click.echo(
+        f"  Scanning {target_count} {label} on {ctx.connector} for:"
+    )
+    for cat in ctx.categories:
+        click.echo(f"    - {cat}")
+    if ctx.paths:
+        click.echo()
+        if len(ctx.paths) == 1:
+            click.echo(f"  Source: {ctx.paths[0]}")
+        else:
+            click.echo("  Sources:")
+            for p in ctx.paths:
+                click.echo(f"    - {p}")
+    click.echo()
+
+
+def render_per_target_status(
+    ctx: ScanContext,
+    *,
+    target: str,
+    verdict: str,
+    detail: str = "",
+    findings: int = 0,
+) -> None:
+    """Print one ``<glyph> <target> [<finding count>] <detail>`` line.
+
+    No-ops in JSON mode.
+    """
+    if ctx.as_json:
+        return
+    glyph = _VERDICT_GLYPH.get(verdict, "?")
+    finding_part = ""
+    if findings > 0:
+        finding_part = f" ({findings} finding{'s' if findings != 1 else ''})"
+    detail_part = f" — {detail}" if detail else ""
+    click.echo(f"    [{glyph}] {target}{finding_part}{detail_part}")
+
+
+def render_summary(
+    ctx: ScanContext,
+    *,
+    clean: int,
+    blocked: int,
+    errored: int,
+    total: int,
+    duration_ms: int | None = None,
+) -> None:
+    """Print the final tally line.
+
+    No-ops in JSON mode (the JSON document carries the same numbers
+    in its ``summary`` block).
+    """
+    if ctx.as_json:
+        return
+    click.echo()
+    parts = [
+        f"  Summary: {total} {ctx.label(plural=total != 1)} scanned",
+        f"clean={clean}",
+        f"blocked={blocked}",
+    ]
+    if errored:
+        parts.append(f"errored={errored}")
+    if duration_ms is not None and duration_ms >= 0:
+        parts.append(f"in {duration_ms}ms")
+    click.echo(", ".join(parts))
+
+
+# ---------------------------------------------------------------------------
+# JSON payload
+# ---------------------------------------------------------------------------
+
+
+def render_json_payload(
+    ctx: ScanContext,
+    *,
+    results: list[dict[str, Any]],
+    clean: int,
+    blocked: int,
+    errored: int,
+    duration_ms: int | None = None,
+    extra: dict[str, Any] | None = None,
+) -> str:
+    """Build the canonical JSON payload for a scan command.
+
+    The shape is locked here — call sites must not invent their own
+    keys. S6.6 will add a snapshot test that hashes this payload
+    schema (without values) so any drift produces a CI failure.
+
+    Returns the serialized string; caller is responsible for echo /
+    write. We don't emit directly so unit tests can inspect the
+    structure without parsing ``capsys`` output.
+    """
+    payload: dict[str, Any] = {
+        "version": 1,
+        "component": ctx.component,
+        "connector": ctx.connector,
+        "scanned_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "paths": list(ctx.paths),
+        "categories": list(ctx.categories),
+        "results": results,
+        "summary": {
+            "total": len(results),
+            "clean": clean,
+            "blocked": blocked,
+            "errored": errored,
+        },
+    }
+    if duration_ms is not None and duration_ms >= 0:
+        payload["summary"]["duration_ms"] = duration_ms
+    if extra:
+        # Allow callers to attach component-specific extras (e.g.
+        # plugin scanner's "checked_for_signatures": True). Never
+        # let them clobber the locked top-level keys.
+        for k, v in extra.items():
+            if k not in payload:
+                payload[k] = v
+    return json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=False)
+
+
+# ---------------------------------------------------------------------------
+# Helpers consumed by unit tests / cmd_doctor (S6.5)
+# ---------------------------------------------------------------------------
+
+
+def categories_for(component: str) -> tuple[str, ...]:
+    """Return the default category bullet list for *component*.
+
+    Useful for ``defenseclaw doctor`` (S6.5) which lists the
+    categories each scanner advertises so operators see what they
+    get before running anything.
+    """
+    return _DEFAULT_CATEGORIES.get(component, ())
+
+
+def supported_components() -> tuple[str, ...]:
+    """Return the stable list of scan components."""
+    return (COMPONENT_PLUGIN, COMPONENT_SKILL, COMPONENT_MCP)

--- a/cli/tests/test_scan_ui.py
+++ b/cli/tests/test_scan_ui.py
@@ -1,0 +1,344 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the shared scan-UI helpers (S6.1).
+
+These tests lock the shape of the contract that
+``cmd_plugin scan`` / ``cmd_skill scan`` / ``cmd_mcp scan`` will
+plug into in S6.2 / S6.3 / S6.4. The schema of
+:func:`render_json_payload` in particular is the public CLI
+contract — automation parses it — so any drift here is a breaking
+change.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+from click.testing import CliRunner
+
+from defenseclaw.commands import _scan_ui
+
+
+class TestScanContextNormalization(unittest.TestCase):
+    """ScanContext smooths over user-input quirks before any helper sees it."""
+
+    def test_lowercases_connector(self):
+        ctx = _scan_ui.ScanContext.for_plugin(connector="OpenClaw", paths=[])
+        self.assertEqual(ctx.connector, "openclaw")
+
+    def test_strips_whitespace(self):
+        ctx = _scan_ui.ScanContext.for_plugin(connector="  Codex  ", paths=[])
+        self.assertEqual(ctx.connector, "codex")
+
+    def test_empty_connector_defaults_to_openclaw(self):
+        ctx = _scan_ui.ScanContext.for_plugin(connector="", paths=[])
+        self.assertEqual(ctx.connector, "openclaw")
+
+    def test_whitespace_connector_defaults_to_openclaw(self):
+        ctx = _scan_ui.ScanContext.for_plugin(connector="   ", paths=[])
+        self.assertEqual(ctx.connector, "openclaw")
+
+    def test_default_categories_per_component(self):
+        for ctor, comp in (
+            (_scan_ui.ScanContext.for_plugin, _scan_ui.COMPONENT_PLUGIN),
+            (_scan_ui.ScanContext.for_skill, _scan_ui.COMPONENT_SKILL),
+            (_scan_ui.ScanContext.for_mcp, _scan_ui.COMPONENT_MCP),
+        ):
+            ctx = ctor(connector="openclaw", paths=[])
+            self.assertEqual(ctx.component, comp)
+            self.assertGreater(len(ctx.categories), 0)
+            for entry in ctx.categories:
+                self.assertIsInstance(entry, str)
+                self.assertGreater(len(entry), 0)
+
+
+class TestRenderPreamble(unittest.TestCase):
+    def _capture(self, cb):
+        runner = CliRunner()
+        # Use Click's runner just to capture stdout from `click.echo`.
+        result = runner.invoke(_make_cli(cb))
+        return result.stdout
+
+    def test_emits_count_label_and_connector(self):
+        ctx = _scan_ui.ScanContext.for_plugin(
+            connector="codex",
+            paths=["/home/me/.codex/extensions"],
+        )
+        out = self._capture(lambda: _scan_ui.render_preamble(ctx, 3))
+        self.assertIn("Scanning 3 plugins on codex for:", out)
+
+    def test_singular_when_one(self):
+        ctx = _scan_ui.ScanContext.for_skill(connector="claudecode", paths=[])
+        out = self._capture(lambda: _scan_ui.render_preamble(ctx, 1))
+        self.assertIn("Scanning 1 skill on claudecode for:", out)
+
+    def test_lists_each_category(self):
+        ctx = _scan_ui.ScanContext.for_mcp(connector="openclaw", paths=[])
+        out = self._capture(lambda: _scan_ui.render_preamble(ctx, 2))
+        for cat in ctx.categories:
+            self.assertIn(cat, out)
+
+    def test_no_output_in_json_mode(self):
+        ctx = _scan_ui.ScanContext.for_plugin(
+            connector="codex",
+            paths=["/x"],
+            as_json=True,
+        )
+        out = self._capture(lambda: _scan_ui.render_preamble(ctx, 5))
+        self.assertEqual(out, "")
+
+    def test_single_source_label(self):
+        ctx = _scan_ui.ScanContext.for_plugin(
+            connector="codex",
+            paths=["/home/me/.codex/extensions"],
+        )
+        out = self._capture(lambda: _scan_ui.render_preamble(ctx, 1))
+        self.assertIn("Source: /home/me/.codex/extensions", out)
+
+    def test_multiple_sources_label(self):
+        ctx = _scan_ui.ScanContext.for_plugin(
+            connector="openclaw",
+            paths=["/a", "/b"],
+        )
+        out = self._capture(lambda: _scan_ui.render_preamble(ctx, 2))
+        self.assertIn("Sources:", out)
+        self.assertIn("/a", out)
+        self.assertIn("/b", out)
+
+
+class TestRenderPerTargetStatus(unittest.TestCase):
+    def _capture(self, cb):
+        runner = CliRunner()
+        result = runner.invoke(_make_cli(cb))
+        return result.stdout
+
+    def test_clean_glyph(self):
+        ctx = _scan_ui.ScanContext.for_plugin(connector="codex", paths=[])
+        out = self._capture(
+            lambda: _scan_ui.render_per_target_status(
+                ctx, target="alpha", verdict=_scan_ui.VERDICT_CLEAN
+            )
+        )
+        self.assertIn("[ok] alpha", out)
+
+    def test_blocked_glyph_with_findings_plural(self):
+        ctx = _scan_ui.ScanContext.for_plugin(connector="codex", paths=[])
+        out = self._capture(
+            lambda: _scan_ui.render_per_target_status(
+                ctx, target="evil",
+                verdict=_scan_ui.VERDICT_BLOCKED, findings=3,
+            )
+        )
+        self.assertIn("[BLOCKED] evil (3 findings)", out)
+
+    def test_blocked_with_one_finding_singular(self):
+        ctx = _scan_ui.ScanContext.for_plugin(connector="codex", paths=[])
+        out = self._capture(
+            lambda: _scan_ui.render_per_target_status(
+                ctx, target="x", verdict=_scan_ui.VERDICT_BLOCKED, findings=1,
+            )
+        )
+        self.assertIn("(1 finding)", out)
+        self.assertNotIn("findings", out)
+
+    def test_detail_appended(self):
+        ctx = _scan_ui.ScanContext.for_plugin(connector="codex", paths=[])
+        out = self._capture(
+            lambda: _scan_ui.render_per_target_status(
+                ctx, target="x",
+                verdict=_scan_ui.VERDICT_ERROR,
+                detail="manifest unreadable",
+            )
+        )
+        self.assertIn("manifest unreadable", out)
+
+    def test_no_output_in_json_mode(self):
+        ctx = _scan_ui.ScanContext.for_plugin(
+            connector="codex", paths=[], as_json=True,
+        )
+        out = self._capture(
+            lambda: _scan_ui.render_per_target_status(
+                ctx, target="x", verdict=_scan_ui.VERDICT_CLEAN,
+            )
+        )
+        self.assertEqual(out, "")
+
+
+class TestRenderSummary(unittest.TestCase):
+    def _capture(self, cb):
+        runner = CliRunner()
+        result = runner.invoke(_make_cli(cb))
+        return result.stdout
+
+    def test_basic_counts(self):
+        ctx = _scan_ui.ScanContext.for_plugin(connector="codex", paths=[])
+        out = self._capture(
+            lambda: _scan_ui.render_summary(
+                ctx, clean=2, blocked=1, errored=0, total=3,
+            )
+        )
+        self.assertIn("Summary: 3 plugins scanned", out)
+        self.assertIn("clean=2", out)
+        self.assertIn("blocked=1", out)
+
+    def test_errored_only_shown_when_nonzero(self):
+        ctx = _scan_ui.ScanContext.for_plugin(connector="codex", paths=[])
+        out = self._capture(
+            lambda: _scan_ui.render_summary(
+                ctx, clean=2, blocked=0, errored=0, total=2,
+            )
+        )
+        self.assertNotIn("errored=", out)
+
+    def test_errored_shown_when_positive(self):
+        ctx = _scan_ui.ScanContext.for_plugin(connector="codex", paths=[])
+        out = self._capture(
+            lambda: _scan_ui.render_summary(
+                ctx, clean=1, blocked=0, errored=1, total=2,
+            )
+        )
+        self.assertIn("errored=1", out)
+
+    def test_singular_when_one(self):
+        ctx = _scan_ui.ScanContext.for_mcp(connector="openclaw", paths=[])
+        out = self._capture(
+            lambda: _scan_ui.render_summary(
+                ctx, clean=1, blocked=0, errored=0, total=1,
+            )
+        )
+        self.assertIn("Summary: 1 MCP server scanned", out)
+
+    def test_no_output_in_json_mode(self):
+        ctx = _scan_ui.ScanContext.for_plugin(
+            connector="codex", paths=[], as_json=True,
+        )
+        out = self._capture(
+            lambda: _scan_ui.render_summary(
+                ctx, clean=1, blocked=0, errored=0, total=1,
+            )
+        )
+        self.assertEqual(out, "")
+
+    def test_duration_appended(self):
+        ctx = _scan_ui.ScanContext.for_plugin(connector="codex", paths=[])
+        out = self._capture(
+            lambda: _scan_ui.render_summary(
+                ctx, clean=1, blocked=0, errored=0, total=1, duration_ms=42,
+            )
+        )
+        self.assertIn("in 42ms", out)
+
+
+class TestRenderJsonPayload(unittest.TestCase):
+    """The JSON shape is the public CLI contract."""
+
+    def _build(self, **kw):
+        ctx = _scan_ui.ScanContext.for_plugin(
+            connector="codex",
+            paths=["/x"],
+            as_json=True,
+        )
+        return json.loads(_scan_ui.render_json_payload(ctx, **kw))
+
+    def test_top_level_keys(self):
+        payload = self._build(
+            results=[],
+            clean=0, blocked=0, errored=0,
+        )
+        self.assertEqual(payload["version"], 1)
+        self.assertEqual(payload["component"], "plugin")
+        self.assertEqual(payload["connector"], "codex")
+        self.assertEqual(payload["paths"], ["/x"])
+        self.assertIn("scanned_at", payload)
+        self.assertGreater(len(payload["categories"]), 0)
+
+    def test_summary_block(self):
+        payload = self._build(
+            results=[{"id": "a"}, {"id": "b"}, {"id": "c"}],
+            clean=2, blocked=1, errored=0,
+        )
+        self.assertEqual(payload["summary"]["total"], 3)
+        self.assertEqual(payload["summary"]["clean"], 2)
+        self.assertEqual(payload["summary"]["blocked"], 1)
+        self.assertEqual(payload["summary"]["errored"], 0)
+
+    def test_duration_in_summary_when_passed(self):
+        payload = self._build(
+            results=[],
+            clean=0, blocked=0, errored=0,
+            duration_ms=128,
+        )
+        self.assertEqual(payload["summary"]["duration_ms"], 128)
+
+    def test_duration_omitted_when_unset(self):
+        payload = self._build(
+            results=[],
+            clean=0, blocked=0, errored=0,
+        )
+        self.assertNotIn("duration_ms", payload["summary"])
+
+    def test_extras_attached_without_clobbering(self):
+        payload = self._build(
+            results=[],
+            clean=0, blocked=0, errored=0,
+            extra={"checked_for_signatures": True, "version": 999},
+        )
+        # ``checked_for_signatures`` is passed through, but the
+        # caller-supplied ``version=999`` must NOT overwrite the
+        # locked top-level ``version=1``.
+        self.assertTrue(payload["checked_for_signatures"])
+        self.assertEqual(payload["version"], 1)
+
+    def test_results_are_passed_through_unchanged(self):
+        rows = [{"id": "alpha", "verdict": "clean"}, {"id": "beta", "verdict": "blocked"}]
+        payload = self._build(
+            results=rows,
+            clean=1, blocked=1, errored=0,
+        )
+        self.assertEqual(payload["results"], rows)
+
+
+class TestSchemaIntrospection(unittest.TestCase):
+    def test_supported_components(self):
+        self.assertEqual(
+            _scan_ui.supported_components(),
+            ("plugin", "skill", "mcp"),
+        )
+
+    def test_categories_for_known_component(self):
+        cats = _scan_ui.categories_for("plugin")
+        self.assertGreater(len(cats), 0)
+
+    def test_categories_for_unknown_component(self):
+        self.assertEqual(_scan_ui.categories_for("widget"), ())
+
+
+def _make_cli(cb):
+    """Build a tiny click command that invokes *cb* — used to capture
+    output from the render helpers without spinning up a full CLI app."""
+    import click as _click
+
+    @_click.command()
+    def _cmd():
+        cb()
+
+    return _cmd
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add \`cli/defenseclaw/commands/_scan_ui.py\` as the canonical home for the scan-command UX. Today \`defenseclaw plugin scan\`, \`defenseclaw skill scan\`, \`defenseclaw mcp scan\`, and \`defenseclaw scan --all\` each roll their own preamble, per-target line, and summary; small drift between them confuses operators paging through several at once.

This PR introduces the data structures and primitives. **S6.2 / S6.3 / S6.4 will replace the per-command output with calls into this module** — wiring is a follow-up so this PR is small and the regression surface is minimal.

## Stack

- #178 — S4.1
- #179 — S4.2
- #180 — S4.3
- #181 — S4.4
- #182 — S4.5
- **this PR — S6.1**

## Public surface

- \`ScanContext\` — bundles per-invocation context (component, connector, paths, categories, --json flag). Convenience constructors: \`for_plugin\`, \`for_skill\`, \`for_mcp\` carry the right defaults and label pluralization.
- \`render_preamble\` — \"Scanning N <plural> on <connector> for: <bullets>\". Prints nothing in JSON mode.
- \`render_per_target_status\` — \"[ok|BLOCKED|ERROR] <name> (N findings) — <detail>\". Singular/plural finding handling.
- \`render_summary\` — \"Summary: N <plural> scanned, clean=X, blocked=Y, errored=Z, in Wms\". Omits \`errored=\` when zero.
- \`render_json_payload\` — builds the canonical JSON document. Schema is locked here; caller-supplied \`extra={}\` can attach component-specific extras but cannot clobber the locked top-level keys.

## Tests

31 new unit tests in \`tests/test_scan_ui.py\`:
- ScanContext normalization (case, whitespace, empty defaults)
- default categories per component
- preamble emits count, label, connector, categories, sources
- singular vs plural in preamble and summary
- per-target glyphs (clean/blocked/error)
- finding-count singular/plural
- JSON-mode silences all human helpers
- JSON shape: top-level keys, summary block, duration handling, extras passthrough, locked-keys protection
- schema introspection (\`supported_components\`, \`categories_for\`)

S6.6 will add a snapshot test that hashes the JSON schema (without values) so any drift produces a CI failure. Until then, \`TestRenderJsonPayload\` exercises the full shape key by key.

## Test plan

- [x] \`pytest tests/test_scan_ui.py\` — 31 / 31 pass
- [x] No call sites changed yet — pure additive
- [x] No \`import os\` / \`import subprocess\` inside functions

## Refs

connector-architecture v3 — S6.1 in the claw-agnostic plan.