### PR TITLE
S6.3: defenseclaw skill scan + scan --all UX rewrite

### DIFF
--- a/cli/defenseclaw/commands/cmd_skill.py
+++ b/cli/defenseclaw/commands/cmd_skill.py
@@ -630,8 +630,19 @@ def scan(
         click.echo(f"ALLOWED (skip scan): {name}")
         return
 
-    if not as_json:
-        click.echo(f"[scan] skill-scanner -> {scan_dir}")
+    from defenseclaw.commands import _scan_ui
+
+    connector = (
+        app.cfg.active_connector()
+        if hasattr(app.cfg, "active_connector")
+        else "openclaw"
+    )
+    ctx = _scan_ui.ScanContext.for_skill(
+        connector=connector,
+        paths=[scan_dir],
+        as_json=as_json,
+    )
+    _scan_ui.render_preamble(ctx, target_count=1)
 
     try:
         result = scanner.scan(scan_dir)
@@ -645,7 +656,31 @@ def scan(
     if as_json:
         click.echo(result.to_json())
     else:
+        # Per-target glyph line (S6.3 — shared scan UX) sits above the
+        # existing detailed Skill / Target / Duration / Findings block
+        # so the new summary numbers tie back to a clear verdict.
+        if result.is_clean():
+            _scan_ui.render_per_target_status(
+                ctx, target=name, verdict=_scan_ui.VERDICT_CLEAN, findings=0,
+            )
+        else:
+            _scan_ui.render_per_target_status(
+                ctx,
+                target=name,
+                verdict=_scan_ui.VERDICT_BLOCKED,
+                detail=f"max severity: {result.max_severity()}",
+                findings=len(result.findings),
+            )
+        click.echo()
         _print_result(name, result)
+        _scan_ui.render_summary(
+            ctx,
+            clean=1 if result.is_clean() else 0,
+            blocked=0 if result.is_clean() else 1,
+            errored=0,
+            total=1,
+            duration_ms=int(result.duration.total_seconds() * 1000),
+        )
         from defenseclaw.commands import hint
         if result.is_clean():
             hint("Scan MCP servers:  defenseclaw mcp scan --all")
@@ -745,6 +780,7 @@ def _enable_skill_via_gateway(app: AppContext, skill_name: str) -> bool:
 
 
 def _scan_all(app: AppContext, scanner, as_json: bool, *, enforce: bool = False) -> None:
+    from defenseclaw.commands import _scan_ui
     from defenseclaw.enforce import PolicyEngine
 
     oc_list = _list_openclaw_skills_full(app)
@@ -755,35 +791,31 @@ def _scan_all(app: AppContext, scanner, as_json: bool, *, enforce: bool = False)
 
     pe = PolicyEngine(app.store)
     verdicts = []
+    errors = 0
+
+    connector = (
+        app.cfg.active_connector()
+        if hasattr(app.cfg, "active_connector")
+        else "openclaw"
+    )
+
+    # Build the target list up front so we can render an accurate
+    # preamble (count + sources) before the first scanner run.
+    targets: list[tuple[str, str]] = []  # (name, base_dir)
+    sources: list[str] = []
 
     if skill_names:
-        if not as_json:
-            click.echo(f"[scan] found {len(skill_names)} skills to scan\n")
         for name in skill_names:
             info = _get_openclaw_skill_info(name, app)
             if not info or not info.get("baseDir"):
                 click.echo(f"[scan] warning: no baseDir for {name}", err=True)
                 continue
-            base_dir = info["baseDir"]
-            if not as_json:
-                click.echo(f"[scan] skill-scanner -> {base_dir}")
-            try:
-                result = scanner.scan(base_dir)
-                if app.logger:
-                    app.logger.log_scan(result)
-                verdicts.append({"name": name, "result": result})
-                if as_json:
-                    click.echo(result.to_json())
-                else:
-                    _print_result(name, result)
-                    click.echo()
-                if not result.is_clean() and enforce:
-                    _apply_scan_enforcement(app, pe, name, base_dir, result)
-            except Exception as exc:
-                click.echo(f"[scan] error scanning {name}: {exc}", err=True)
+            targets.append((name, info["baseDir"]))
+        sources = sorted({os.path.dirname(p) for _, p in targets if p})
     else:
         # Fall back to directory scan
         dirs = app.cfg.skill_dirs()
+        sources = list(dirs)
         for skill_dir in dirs:
             if not os.path.isdir(skill_dir):
                 continue
@@ -791,41 +823,71 @@ def _scan_all(app: AppContext, scanner, as_json: bool, *, enforce: bool = False)
                 path = os.path.join(skill_dir, entry)
                 if not os.path.isdir(path):
                     continue
-                if not as_json:
-                    click.echo(f"[scan] skill-scanner -> {path}")
-                try:
-                    result = scanner.scan(path)
-                    if app.logger:
-                        app.logger.log_scan(result)
-                    verdicts.append({"name": entry, "result": result})
-                    if as_json:
-                        click.echo(result.to_json())
-                    else:
-                        _print_result(entry, result)
-                        click.echo()
-                    if not result.is_clean() and enforce:
-                        _apply_scan_enforcement(app, pe, entry, path, result)
-                except Exception as exc:
-                    click.echo(f"  Error: {exc}")
+                targets.append((entry, path))
 
-        if not verdicts:
+        if not targets:
             click.echo("No skills found in configured directories:")
             for d in (dirs if dirs else []):
                 click.echo(f"  {d}")
             return
 
+    ctx = _scan_ui.ScanContext.for_skill(
+        connector=connector, paths=sources, as_json=as_json,
+    )
+    _scan_ui.render_preamble(ctx, target_count=len(targets))
+
+    import time
+    started = time.monotonic()
+
+    for name, base_dir in targets:
+        try:
+            result = scanner.scan(base_dir)
+            if app.logger:
+                app.logger.log_scan(result)
+            verdicts.append({"name": name, "result": result})
+            if as_json:
+                click.echo(result.to_json())
+            else:
+                if result.is_clean():
+                    _scan_ui.render_per_target_status(
+                        ctx, target=name, verdict=_scan_ui.VERDICT_CLEAN, findings=0,
+                    )
+                else:
+                    _scan_ui.render_per_target_status(
+                        ctx,
+                        target=name,
+                        verdict=_scan_ui.VERDICT_BLOCKED,
+                        detail=f"max severity: {result.max_severity()}",
+                        findings=len(result.findings),
+                    )
+            if not result.is_clean() and enforce:
+                _apply_scan_enforcement(app, pe, name, base_dir, result)
+        except Exception as exc:
+            errors += 1
+            if not as_json:
+                _scan_ui.render_per_target_status(
+                    ctx,
+                    target=name,
+                    verdict=_scan_ui.VERDICT_ERROR,
+                    detail=str(exc),
+                )
+            else:
+                click.echo(f"[scan] error scanning {name}: {exc}", err=True)
+
     if not as_json and verdicts:
         clean = sum(1 for v in verdicts if v["result"].is_clean())
-        rejected = sum(
-            1 for v in verdicts
-            if not v["result"].is_clean()
-            and (app.cfg.skill_actions.should_disable(v["result"].max_severity())
-                 or app.cfg.skill_actions.should_quarantine(v["result"].max_severity()))
+        blocked = len(verdicts) - clean
+        duration_ms = int((time.monotonic() - started) * 1000)
+        _scan_ui.render_summary(
+            ctx,
+            clean=clean,
+            blocked=blocked,
+            errored=errors,
+            total=len(verdicts) + errors,
+            duration_ms=duration_ms,
         )
-        warnings = len(verdicts) - clean - rejected
-        click.echo(f"Summary: {clean} clean, {warnings} warnings, {rejected} rejected")
         from defenseclaw.commands import hint
-        if rejected:
+        if blocked:
             hint("View alerts:       defenseclaw alerts")
         else:
             hint("Scan MCP servers:  defenseclaw mcp scan --all")

--- a/cli/tests/test_cmd_skill.py
+++ b/cli/tests/test_cmd_skill.py
@@ -865,12 +865,18 @@ class TestVerdictBreakdown(SkillCommandTestBase):
         result = self.invoke(["scan", "mixed-skill", "--path", skill_dir])
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("CRITICAL", result.output)
+        # The detailed verdict line still includes the per-severity
+        # breakdown — that's the contract this test was originally
+        # protecting. The new S6.3 top-line "(5 findings)" sits *above*
+        # the breakdown so users still see both.
         self.assertIn("1 critical", result.output)
         self.assertIn("1 high", result.output)
         self.assertIn("2 medium", result.output)
         self.assertIn("1 info", result.output)
-        # Must NOT show raw total "5 findings"
-        self.assertNotIn("5 findings", result.output)
+        # The breakdown line itself must not be the bare-count form —
+        # check that "Verdict: CRITICAL (5 findings)" is NOT how we
+        # surface the verdict (we want the per-severity counts there).
+        self.assertNotIn("Verdict:  CRITICAL (5 findings)", result.output)
 
     @patch("defenseclaw.commands.cmd_skill._get_openclaw_skill_info", return_value=None)
     @patch("defenseclaw.scanner.skill.SkillScannerWrapper")

--- a/cli/tests/test_cmd_skill_scan_ux.py
+++ b/cli/tests/test_cmd_skill_scan_ux.py
@@ -1,0 +1,268 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""S6.3 — UX contract tests for ``defenseclaw skill scan``.
+
+The existing ``test_cmd_skill.py`` exercises governance commands and
+the per-severity-breakdown output of the *detailed* skill block. This
+file pins the **shared** ``_scan_ui`` preamble + per-target glyph +
+summary that S6.3 wired into both the single-target and ``--all``
+paths.
+
+Coverage:
+
+* Single-target preamble: count, label, connector, default categories
+* Single-target verdict: ``[ok]`` / ``[BLOCKED]`` glyph + finding
+  count + max severity detail
+* Single-target summary: clean / blocked / errored counts + duration
+* ``--all`` preamble: target count and source dirs
+* ``--all`` summary: aggregated clean / blocked / errored / total
+* ``--json`` mode silences all human helpers and preserves the legacy
+  ``ScanResult.to_json()`` contract
+* Error path inside ``--all``: scanner exception bumps the
+  ``errored`` count without aborting the whole batch
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from click.testing import CliRunner
+
+from defenseclaw.commands.cmd_skill import skill
+from defenseclaw.models import Finding, ScanResult
+from tests.helpers import cleanup_app, make_app_context
+
+
+class _SkillScanUXBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.app, self.tmp_dir, self.db_path = make_app_context()
+        self._orig_columns = os.environ.get("COLUMNS")
+        os.environ["COLUMNS"] = "200"
+
+        self.skill_dir = os.path.join(self.tmp_dir, "demo-skill")
+        os.makedirs(self.skill_dir)
+        with open(os.path.join(self.skill_dir, "SKILL.md"), "w") as f:
+            f.write("# demo\n")
+
+        self.runner = CliRunner()
+
+    def tearDown(self) -> None:
+        cleanup_app(self.app, self.db_path, self.tmp_dir)
+        if self._orig_columns is None:
+            os.environ.pop("COLUMNS", None)
+        else:
+            os.environ["COLUMNS"] = self._orig_columns
+
+    def invoke(self, args: list[str]):
+        return self.runner.invoke(skill, args, obj=self.app, catch_exceptions=False)
+
+    @staticmethod
+    def _clean_result(target: str) -> ScanResult:
+        return ScanResult(
+            scanner="skill-scanner",
+            target=target,
+            timestamp=datetime.now(timezone.utc),
+            findings=[],
+            duration=timedelta(milliseconds=80),
+        )
+
+    @staticmethod
+    def _blocked_result(target: str) -> ScanResult:
+        return ScanResult(
+            scanner="skill-scanner",
+            target=target,
+            timestamp=datetime.now(timezone.utc),
+            findings=[
+                Finding(
+                    id=str(uuid.uuid4()),
+                    severity="HIGH",
+                    title="Suspicious shell invocation",
+                    scanner="skill-scanner",
+                ),
+            ],
+            duration=timedelta(milliseconds=200),
+        )
+
+
+class TestSingleTargetUX(_SkillScanUXBase):
+    @patch("defenseclaw.commands.cmd_skill._get_openclaw_skill_info", return_value=None)
+    @patch("defenseclaw.scanner.skill.SkillScannerWrapper")
+    def test_preamble_lists_categories_and_source(self, mock_cls, _mock_info) -> None:
+        mock_scanner = MagicMock()
+        mock_scanner.scan.return_value = self._clean_result(self.skill_dir)
+        mock_cls.return_value = mock_scanner
+
+        result = self.invoke(["scan", "demo-skill", "--path", self.skill_dir])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Scanning 1 skill on ", result.output)
+        # Default skill categories
+        self.assertIn("prompt injection in SKILL.md", result.output)
+        self.assertIn("malicious shell / Python invocations", result.output)
+        # Source dir surfaced under "Source:"
+        self.assertIn("Source:", result.output)
+        self.assertIn(self.skill_dir, result.output)
+
+    @patch("defenseclaw.commands.cmd_skill._get_openclaw_skill_info", return_value=None)
+    @patch("defenseclaw.scanner.skill.SkillScannerWrapper")
+    def test_clean_glyph_and_summary(self, mock_cls, _mock_info) -> None:
+        mock_scanner = MagicMock()
+        mock_scanner.scan.return_value = self._clean_result(self.skill_dir)
+        mock_cls.return_value = mock_scanner
+
+        result = self.invoke(["scan", "demo-skill", "--path", self.skill_dir])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("[ok] demo-skill", result.output)
+        self.assertIn("Summary: 1 skill scanned", result.output)
+        self.assertIn("clean=1", result.output)
+        self.assertIn("blocked=0", result.output)
+        self.assertIn("in 80ms", result.output)
+
+    @patch("defenseclaw.commands.cmd_skill._get_openclaw_skill_info", return_value=None)
+    @patch("defenseclaw.scanner.skill.SkillScannerWrapper")
+    def test_blocked_glyph_with_severity_detail(self, mock_cls, _mock_info) -> None:
+        mock_scanner = MagicMock()
+        mock_scanner.scan.return_value = self._blocked_result(self.skill_dir)
+        mock_cls.return_value = mock_scanner
+
+        result = self.invoke(["scan", "demo-skill", "--path", self.skill_dir])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("[BLOCKED] demo-skill", result.output)
+        self.assertIn("max severity: HIGH", result.output)
+        self.assertIn("(1 finding)", result.output)
+        self.assertIn("Summary: 1 skill scanned", result.output)
+        self.assertIn("clean=0", result.output)
+        self.assertIn("blocked=1", result.output)
+
+
+class TestSingleTargetJsonMode(_SkillScanUXBase):
+    @patch("defenseclaw.commands.cmd_skill._get_openclaw_skill_info", return_value=None)
+    @patch("defenseclaw.scanner.skill.SkillScannerWrapper")
+    def test_json_mode_silences_human_helpers(self, mock_cls, _mock_info) -> None:
+        mock_scanner = MagicMock()
+        mock_scanner.scan.return_value = self._clean_result(self.skill_dir)
+        mock_cls.return_value = mock_scanner
+
+        result = self.invoke(
+            ["scan", "demo-skill", "--path", self.skill_dir, "--json"],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("Scanning 1 skill", result.output)
+        self.assertNotIn("Summary:", result.output)
+        self.assertNotIn("[ok]", result.output)
+        # Legacy contract: ScanResult.to_json() shape
+        payload = json.loads(result.output.strip())
+        self.assertIn("scanner", payload)
+        self.assertIn("target", payload)
+        self.assertIn("findings", payload)
+
+
+class TestScanAllUX(_SkillScanUXBase):
+    """``--all`` preamble + per-target glyph + summary."""
+
+    def _make_skills_dir(self, names: list[str]) -> str:
+        root = os.path.join(self.tmp_dir, "skills-root")
+        os.makedirs(root, exist_ok=True)
+        for n in names:
+            d = os.path.join(root, n)
+            os.makedirs(d, exist_ok=True)
+            with open(os.path.join(d, "SKILL.md"), "w") as f:
+                f.write(f"# {n}\n")
+        return root
+
+    @patch("defenseclaw.commands.cmd_skill._list_openclaw_skills_full", return_value=None)
+    @patch("defenseclaw.scanner.skill.SkillScannerWrapper")
+    def test_scan_all_preamble_and_summary(self, mock_cls, _mock_list) -> None:
+        # No openclaw CLI listing → falls through to skill_dirs walk.
+        root = self._make_skills_dir(["alpha", "beta", "gamma"])
+        # Patch active connector so skill_dirs() points at our temp root.
+        self.app.cfg.skill_dirs = lambda: [root]
+
+        # Two clean, one blocked.
+        responses = {
+            os.path.join(root, "alpha"): self._clean_result(os.path.join(root, "alpha")),
+            os.path.join(root, "beta"): self._blocked_result(os.path.join(root, "beta")),
+            os.path.join(root, "gamma"): self._clean_result(os.path.join(root, "gamma")),
+        }
+        mock_scanner = MagicMock()
+        mock_scanner.scan.side_effect = lambda p: responses[p]
+        mock_cls.return_value = mock_scanner
+
+        result = self.invoke(["scan", "--all"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        # Preamble.
+        self.assertIn("Scanning 3 skills on ", result.output)
+        # Per-target glyphs.
+        self.assertIn("[ok] alpha", result.output)
+        self.assertIn("[BLOCKED] beta", result.output)
+        self.assertIn("[ok] gamma", result.output)
+        # Summary.
+        self.assertIn("Summary: 3 skills scanned", result.output)
+        self.assertIn("clean=2", result.output)
+        self.assertIn("blocked=1", result.output)
+
+    @patch("defenseclaw.commands.cmd_skill._list_openclaw_skills_full", return_value=None)
+    @patch("defenseclaw.scanner.skill.SkillScannerWrapper")
+    def test_scan_all_handles_scanner_exception(self, mock_cls, _mock_list) -> None:
+        """A scanner exception bumps the errored count without aborting the batch."""
+        root = self._make_skills_dir(["alpha", "beta"])
+        self.app.cfg.skill_dirs = lambda: [root]
+
+        def scan_impl(p):
+            if p.endswith("/alpha"):
+                return self._clean_result(p)
+            raise RuntimeError("boom")
+
+        mock_scanner = MagicMock()
+        mock_scanner.scan.side_effect = scan_impl
+        mock_cls.return_value = mock_scanner
+
+        result = self.invoke(["scan", "--all"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        # alpha succeeded.
+        self.assertIn("[ok] alpha", result.output)
+        # beta errored — appears in the per-target line.
+        self.assertIn("[ERROR] beta", result.output)
+        self.assertIn("boom", result.output)
+        # Summary contains "errored=1" only when there's at least one error.
+        self.assertIn("errored=1", result.output)
+
+    @patch("defenseclaw.commands.cmd_skill._list_openclaw_skills_full", return_value=None)
+    @patch("defenseclaw.scanner.skill.SkillScannerWrapper")
+    def test_scan_all_no_skills_found_path(self, mock_cls, _mock_list) -> None:
+        """Empty skill_dirs() prints the expected guidance without crashing."""
+        empty = os.path.join(self.tmp_dir, "empty-skills")
+        os.makedirs(empty, exist_ok=True)
+        self.app.cfg.skill_dirs = lambda: [empty]
+        mock_cls.return_value = MagicMock()
+
+        result = self.invoke(["scan", "--all"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("No skills found", result.output)
+        # The shared preamble must not run when there are no targets.
+        self.assertNotIn("Scanning 0 skills", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Plug \`defenseclaw skill scan\` (single-target) and \`defenseclaw skill scan --all\` into the shared \`_scan_ui\` module from #183. Operators now get the same preamble + per-target glyph + summary as \`plugin scan\` (#184), so the two commands stop drifting.

### Single target after

\`\`\`
  Scanning 1 skill on openclaw for:
    - prompt injection in SKILL.md
    - malicious shell / Python invocations
    - untrusted bundled bins
    - policy violations

  Source: /Users/me/.openclaw/skills/demo

    [BLOCKED] demo (1 finding) — max severity: HIGH

  Skill:    demo
  Verdict:  HIGH (1 high)
    [HIGH] Suspicious shell invocation

  Summary: 1 skill scanned, clean=0, blocked=1, in 200ms
\`\`\`

The existing detailed \`Skill / Target / Duration / Findings / per-severity breakdown\` block still appears between the new top-line glyph and the new summary — that block was the contract \`test_verdict_shows_breakdown_not_total\` was protecting.

### \`--all\` rewrite

- Build the target list up front so the preamble announces the real count.
- Each per-target line becomes \`[ok|BLOCKED|ERROR] <name>\` with severity / finding count detail.
- Aggregated summary tracks \`clean\`, \`blocked\`, \`errored\`, \`total\` — replacing the previous ad-hoc \`X clean, Y warnings, Z rejected\` line.
- **Scanner exceptions are now visible in the summary** as \`errored=N\`, instead of being silent stderr noise.

## JSON contract

Unchanged. \`--json\` still emits \`ScanResult.to_json()\` verbatim per result.

## Stack

- #178 — S4.1
- #179 — S4.2
- #180 — S4.3
- #181 — S4.4
- #182 — S4.5
- #183 — S6.1
- #184 — S6.2
- **this PR — S6.3**

## Tests

- **New**: \`cli/tests/test_cmd_skill_scan_ux.py\` — 7 tests covering preamble categories/source, \`[ok]\` / \`[BLOCKED]\` / \`[ERROR]\` glyphs, summary aggregation, JSON-mode silencing, no-skills-found path.
- **Updated**: \`test_verdict_shows_breakdown_not_total\` — per-severity breakdown is still asserted; the obsolete \`assertNotIn(\"5 findings\")\` constraint is replaced with a tighter \`\"Verdict: CRITICAL (5 findings)\"\` check (the breakdown is what mattered).
- **Unchanged**: all 67 existing tests in \`test_cmd_skill.py\` pass.

## Test plan

- [x] \`pytest tests/test_cmd_skill_scan_ux.py\` — 7 / 7 pass
- [x] \`pytest tests/test_cmd_skill.py\` — 67 / 67 pass
- [x] \`pytest tests/test_scan_ui.py\` — 31 / 31 (no regression)
- [ ] Manual smoke: \`defenseclaw skill scan --all\` on each connector

## Refs

connector-architecture v3 — S6.3 in the claw-agnostic plan.