### PR TITLE
S6.4: defenseclaw mcp scan + scan --all UX rewrite

### DIFF
--- a/cli/defenseclaw/commands/cmd_mcp.py
+++ b/cli/defenseclaw/commands/cmd_mcp.py
@@ -279,8 +279,11 @@ def _run_scan(app: AppContext, target: str, analyzers: str,
         app.cfg.cisco_ai_defense,
         llm=resolved_llm,
     )
-    if not quiet:
-        click.echo(f"Scanning MCP server: {target}")
+    # NOTE: pre-S6.4 this printed "Scanning MCP server: <target>"; the
+    # new shared scan UX renders that information once via
+    # ``_scan_ui.render_preamble`` + a per-target glyph line, so we
+    # no longer need a per-server announce-line here.
+    _ = quiet  # parameter kept for back-compat with existing callers
 
     try:
         result = scanner.scan(target, server_entry=server_entry)
@@ -296,29 +299,30 @@ def _run_scan(app: AppContext, target: str, analyzers: str,
 
 
 def _print_scan_result(result: ScanResult, as_json: bool) -> None:
+    """Print the *details* of a scan result.
+
+    The shared ``_scan_ui`` preamble + per-target glyph + summary is
+    rendered by the caller (S6.4); this function now only emits the
+    JSON payload, or — in human mode — the per-finding breakdown that
+    appears underneath the per-target line. Keeping the breakdown
+    here so call sites don't have to replicate the per-finding loop.
+    """
     if as_json:
         click.echo(result.to_json())
-    elif result.is_clean():
-        click.secho("  Status: CLEAN", fg="green")
-    else:
-        sev = result.max_severity()
-        color = {"CRITICAL": "red", "HIGH": "red", "MEDIUM": "yellow"}.get(sev, "white")
-        click.secho(
-            f"  Status: {sev} ({len(result.findings)} findings)",
-            fg=color,
-        )
-        click.echo()
-        for f in result.findings:
-            sev_color = {"CRITICAL": "red", "HIGH": "red", "MEDIUM": "yellow", "LOW": "cyan"}.get(f.severity, "white")
-            click.secho(f"    [{f.severity}]", fg=sev_color, nl=False)
-            click.echo(f" {f.title}")
-            if f.location:
-                click.echo(f"      Location: {f.location}")
-            if f.description:
-                desc = f.description[:120] + "..." if len(f.description) > 120 else f.description
-                click.echo(f"      {desc}")
-            if f.remediation:
-                click.echo(f"      Fix: {f.remediation}")
+        return
+    if result.is_clean():
+        return
+    for f in result.findings:
+        sev_color = {"CRITICAL": "red", "HIGH": "red", "MEDIUM": "yellow", "LOW": "cyan"}.get(f.severity, "white")
+        click.secho(f"    [{f.severity}]", fg=sev_color, nl=False)
+        click.echo(f" {f.title}")
+        if f.location:
+            click.echo(f"      Location: {f.location}")
+        if f.description:
+            desc = f.description[:120] + "..." if len(f.description) > 120 else f.description
+            click.echo(f"      {desc}")
+        if f.remediation:
+            click.echo(f"      Fix: {f.remediation}")
 
 
 @mcp.command()
@@ -345,28 +349,78 @@ def scan(
     TARGET can be a server name from openclaw.json or a direct URL.
     Use --all to scan every configured server.
     """
+    import time
+
+    from defenseclaw.commands import _scan_ui
     from defenseclaw.enforce import PolicyEngine
+
+    connector = (
+        app.cfg.active_connector()
+        if hasattr(app.cfg, "active_connector")
+        else "openclaw"
+    )
 
     if scan_all:
         servers = app.cfg.mcp_servers()
         if not servers:
-            click.echo("No MCP servers configured in openclaw.json.")
+            click.echo("No MCP servers configured.")
             return
-        has_findings = False
-        for s in servers:
-            scan_target = s.url or s.name
-            if not as_json:
-                click.echo(f"\n{'─' * 40}")
-            result = _run_scan(app, scan_target, analyzers,
-                               scan_prompts, scan_resources, scan_instructions,
-                               server_entry=s, quiet=as_json)
-            if result:
+
+        scan_targets = [(s, s.url or s.name) for s in servers]
+        ctx = _scan_ui.ScanContext.for_mcp(
+            connector=connector,
+            paths=sorted({t for _, t in scan_targets}),
+            as_json=as_json,
+        )
+        _scan_ui.render_preamble(ctx, target_count=len(scan_targets))
+
+        clean = blocked = errored = 0
+        started = time.monotonic()
+
+        for s, scan_target in scan_targets:
+            result = _run_scan(
+                app, scan_target, analyzers,
+                scan_prompts, scan_resources, scan_instructions,
+                server_entry=s, quiet=as_json,
+            )
+            if result is None:
+                errored += 1
+                _scan_ui.render_per_target_status(
+                    ctx, target=s.name, verdict=_scan_ui.VERDICT_ERROR,
+                    detail="see error log above",
+                )
+                continue
+            if as_json:
                 _print_scan_result(result, as_json)
-                if not result.is_clean():
-                    has_findings = True
+            else:
+                if result.is_clean():
+                    clean += 1
+                    _scan_ui.render_per_target_status(
+                        ctx, target=s.name, verdict=_scan_ui.VERDICT_CLEAN, findings=0,
+                    )
+                else:
+                    blocked += 1
+                    _scan_ui.render_per_target_status(
+                        ctx,
+                        target=s.name,
+                        verdict=_scan_ui.VERDICT_BLOCKED,
+                        detail=f"max severity: {result.max_severity()}",
+                        findings=len(result.findings),
+                    )
+                _print_scan_result(result, as_json)
+
         if not as_json:
+            duration_ms = int((time.monotonic() - started) * 1000)
+            _scan_ui.render_summary(
+                ctx,
+                clean=clean,
+                blocked=blocked,
+                errored=errored,
+                total=clean + blocked + errored,
+                duration_ms=duration_ms,
+            )
             from defenseclaw.commands import hint
-            if has_findings:
+            if blocked:
                 hint("View alerts:  defenseclaw alerts")
             else:
                 hint("Scan skills:  defenseclaw skill scan all")
@@ -382,11 +436,43 @@ def scan(
         click.echo(f"BLOCKED: {target} — remove from block list first", err=True)
         raise SystemExit(2)
 
+    ctx = _scan_ui.ScanContext.for_mcp(
+        connector=connector,
+        paths=[resolved],
+        as_json=as_json,
+    )
+    _scan_ui.render_preamble(ctx, target_count=1)
+
+    started = time.monotonic()
     result = _run_scan(app, resolved, analyzers,
                        scan_prompts, scan_resources, scan_instructions,
                        server_entry=entry, quiet=as_json)
     if result:
-        _print_scan_result(result, as_json)
+        if as_json:
+            _print_scan_result(result, as_json)
+        else:
+            if result.is_clean():
+                _scan_ui.render_per_target_status(
+                    ctx, target=target, verdict=_scan_ui.VERDICT_CLEAN, findings=0,
+                )
+            else:
+                _scan_ui.render_per_target_status(
+                    ctx,
+                    target=target,
+                    verdict=_scan_ui.VERDICT_BLOCKED,
+                    detail=f"max severity: {result.max_severity()}",
+                    findings=len(result.findings),
+                )
+            _print_scan_result(result, as_json)
+            duration_ms = int((time.monotonic() - started) * 1000)
+            _scan_ui.render_summary(
+                ctx,
+                clean=1 if result.is_clean() else 0,
+                blocked=0 if result.is_clean() else 1,
+                errored=0,
+                total=1,
+                duration_ms=duration_ms,
+            )
         if not as_json:
             from defenseclaw.commands import hint
             if result.is_clean():

--- a/cli/tests/test_cmd_mcp.py
+++ b/cli/tests/test_cmd_mcp.py
@@ -156,7 +156,11 @@ class TestMCPScan(MCPCommandTestBase):
 
         result = self.invoke(["scan", "http://localhost:3000"])
         self.assertEqual(result.exit_code, 0, result.output)
-        self.assertIn("CLEAN", result.output)
+        # S6.4 — the shared scan UX renders "[ok] <target>" instead of
+        # the old "Status: CLEAN" line. The summary line carries the
+        # canonical clean count.
+        self.assertIn("[ok] http://localhost:3000", result.output)
+        self.assertIn("clean=1", result.output)
 
     @patch("defenseclaw.scanner.mcp.MCPScannerWrapper.scan")
     def test_scan_with_findings(self, mock_scan):
@@ -225,7 +229,9 @@ class TestMCPScan(MCPCommandTestBase):
 
         result = self.invoke(["scan", "http://safe.com"])
         self.assertEqual(result.exit_code, 0, result.output)
-        self.assertIn("CLEAN", result.output)
+        # S6.4 — clean verdict shown via shared `[ok]` glyph + summary.
+        self.assertIn("[ok] http://safe.com", result.output)
+        self.assertIn("clean=1", result.output)
         self.assertNotIn("ALLOWED", result.output)
         mock_scan.assert_called_once()
 

--- a/cli/tests/test_cmd_mcp_scan_ux.py
+++ b/cli/tests/test_cmd_mcp_scan_ux.py
@@ -1,0 +1,213 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""S6.4 — UX contract tests for ``defenseclaw mcp scan``.
+
+The existing ``test_cmd_mcp.py`` covers the install / set / unset
+flows plus the basic scan happy path. This file pins the *shared*
+``_scan_ui`` preamble + per-target glyph + summary that S6.4 wired
+into both the single-target and ``--all`` paths.
+
+Coverage:
+
+* Single-target preamble: count, label ("MCP server"), connector,
+  default categories
+* Single-target verdict: ``[ok]`` / ``[BLOCKED]`` glyph + finding
+  count + max severity detail
+* Single-target summary: clean / blocked counts + duration
+* ``--all`` preamble: target count and source URLs
+* ``--all`` summary: aggregated clean / blocked / errored counts
+* ``--all`` no-servers path
+* ``--json`` mode silences all human helpers and preserves the
+  legacy ``ScanResult.to_json()`` contract
+* Error path: ``_run_scan`` returning None bumps the ``errored``
+  count visible in the summary
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from click.testing import CliRunner
+
+from defenseclaw.commands.cmd_mcp import mcp
+from defenseclaw.config import MCPServerEntry
+from defenseclaw.models import Finding, ScanResult
+from tests.helpers import cleanup_app, make_app_context
+
+
+class _MCPScanUXBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.app, self.tmp_dir, self.db_path = make_app_context()
+        self._orig_columns = os.environ.get("COLUMNS")
+        os.environ["COLUMNS"] = "200"
+        self.runner = CliRunner()
+
+    def tearDown(self) -> None:
+        cleanup_app(self.app, self.db_path, self.tmp_dir)
+        if self._orig_columns is None:
+            os.environ.pop("COLUMNS", None)
+        else:
+            os.environ["COLUMNS"] = self._orig_columns
+
+    def invoke(self, args: list[str]):
+        return self.runner.invoke(mcp, args, obj=self.app, catch_exceptions=False)
+
+    @staticmethod
+    def _clean_result(target: str) -> ScanResult:
+        return ScanResult(
+            scanner="mcp-scanner",
+            target=target,
+            timestamp=datetime.now(timezone.utc),
+            findings=[],
+        )
+
+    @staticmethod
+    def _blocked_result(target: str) -> ScanResult:
+        return ScanResult(
+            scanner="mcp-scanner",
+            target=target,
+            timestamp=datetime.now(timezone.utc),
+            findings=[
+                Finding(id="f1", severity="HIGH", title="No auth", scanner="mcp-scanner"),
+            ],
+        )
+
+
+class TestSingleTargetUX(_MCPScanUXBase):
+    @patch("defenseclaw.scanner.mcp.MCPScannerWrapper.scan")
+    def test_preamble_singular_label_and_categories(self, mock_scan) -> None:
+        mock_scan.return_value = self._clean_result("http://localhost:3000")
+        result = self.invoke(["scan", "http://localhost:3000"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        # Singular label.
+        self.assertIn("Scanning 1 MCP server on ", result.output)
+        # Default MCP categories from _scan_ui._DEFAULT_CATEGORIES.
+        self.assertIn("untrusted command paths", result.output)
+        self.assertIn("outbound URL allow-listing", result.output)
+        self.assertIn("tool-name spoofing", result.output)
+        self.assertIn("auth-token handling", result.output)
+
+    @patch("defenseclaw.scanner.mcp.MCPScannerWrapper.scan")
+    def test_clean_target_uses_ok_glyph(self, mock_scan) -> None:
+        mock_scan.return_value = self._clean_result("http://localhost:3000")
+        result = self.invoke(["scan", "http://localhost:3000"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("[ok] http://localhost:3000", result.output)
+        self.assertIn("Summary: 1 MCP server scanned", result.output)
+        self.assertIn("clean=1", result.output)
+        self.assertIn("blocked=0", result.output)
+
+    @patch("defenseclaw.scanner.mcp.MCPScannerWrapper.scan")
+    def test_blocked_target_shows_severity(self, mock_scan) -> None:
+        mock_scan.return_value = self._blocked_result("http://localhost:3000")
+        result = self.invoke(["scan", "http://localhost:3000"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("[BLOCKED] http://localhost:3000", result.output)
+        self.assertIn("max severity: HIGH", result.output)
+        self.assertIn("(1 finding)", result.output)
+        # Detailed finding still appears.
+        self.assertIn("[HIGH]", result.output)
+        self.assertIn("No auth", result.output)
+        # Summary.
+        self.assertIn("Summary: 1 MCP server scanned", result.output)
+        self.assertIn("clean=0", result.output)
+        self.assertIn("blocked=1", result.output)
+
+
+class TestSingleTargetJsonMode(_MCPScanUXBase):
+    @patch("defenseclaw.scanner.mcp.MCPScannerWrapper.scan")
+    def test_json_mode_silences_human_output(self, mock_scan) -> None:
+        mock_scan.return_value = self._clean_result("http://localhost:3000")
+        result = self.invoke(["scan", "http://localhost:3000", "--json"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        # Human banner suppressed.
+        self.assertNotIn("Scanning ", result.output)
+        self.assertNotIn("Summary:", result.output)
+        self.assertNotIn("[ok]", result.output)
+        # Legacy contract: JSON object with the canonical keys.
+        json_start = result.output.index("{")
+        import json as _json
+        payload = _json.loads(result.output[json_start:])
+        self.assertEqual(payload["scanner"], "mcp-scanner")
+
+
+class TestScanAllUX(_MCPScanUXBase):
+    """``--all`` builds the target list up front and aggregates results."""
+
+    def _patch_servers(self, names_urls: list[tuple[str, str]]) -> None:
+        servers = [
+            MCPServerEntry(name=n, url=u) for n, u in names_urls
+        ]
+        self.app.cfg.mcp_servers = lambda: servers
+
+    @patch("defenseclaw.scanner.mcp.MCPScannerWrapper.scan")
+    def test_scan_all_renders_preamble_and_summary(self, mock_scan) -> None:
+        self._patch_servers([
+            ("alpha", "http://a.example/mcp"),
+            ("beta", "http://b.example/mcp"),
+            ("gamma", "http://c.example/mcp"),
+        ])
+        responses = {
+            "http://a.example/mcp": self._clean_result("http://a.example/mcp"),
+            "http://b.example/mcp": self._blocked_result("http://b.example/mcp"),
+            "http://c.example/mcp": self._clean_result("http://c.example/mcp"),
+        }
+        mock_scan.side_effect = lambda target, server_entry=None: responses[target]
+
+        result = self.invoke(["scan", "--all"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        # Plural preamble.
+        self.assertIn("Scanning 3 MCP servers on ", result.output)
+        # Per-target glyphs.
+        self.assertIn("[ok] alpha", result.output)
+        self.assertIn("[BLOCKED] beta", result.output)
+        self.assertIn("[ok] gamma", result.output)
+        # Summary.
+        self.assertIn("Summary: 3 MCP servers scanned", result.output)
+        self.assertIn("clean=2", result.output)
+        self.assertIn("blocked=1", result.output)
+
+    @patch("defenseclaw.commands.cmd_mcp._run_scan", return_value=None)
+    def test_scan_all_counts_run_scan_failures_as_errored(self, _mock_run) -> None:
+        """``_run_scan`` returning None means a fatal error during the scan."""
+        self._patch_servers([
+            ("only", "http://only.example/mcp"),
+        ])
+        result = self.invoke(["scan", "--all"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("[ERROR] only", result.output)
+        # errored=N appears only when there's at least one error.
+        self.assertIn("errored=1", result.output)
+        self.assertIn("Summary: 1 MCP server scanned", result.output)
+
+    def test_scan_all_no_servers_message(self) -> None:
+        self.app.cfg.mcp_servers = lambda: []
+        result = self.invoke(["scan", "--all"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("No MCP servers configured", result.output)
+        # Preamble must not be rendered for an empty target list.
+        self.assertNotIn("Scanning 0", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Last leg of the S6.x scan-UX rewrite (#183 → #184 → #185 → this PR). \`defenseclaw mcp scan\` and \`defenseclaw mcp scan --all\` now share the preamble + per-target glyph + summary contract used by the plugin and skill scans.

### After

Single target:

\`\`\`
  Scanning 1 MCP server on openclaw for:
    - untrusted command paths
    - outbound URL allow-listing
    - tool-name spoofing
    - auth-token handling

  Source: http://localhost:3000

    [ok] http://localhost:3000

  Summary: 1 MCP server scanned, clean=1, blocked=0, in 12ms
\`\`\`

\`--all\`:

\`\`\`
  Scanning 3 MCP servers on openclaw for:
    - …

  Sources:
    - http://a.example/mcp
    - http://b.example/mcp
    - http://c.example/mcp

    [ok] alpha
    [BLOCKED] beta (1 finding) — max severity: HIGH
    [ok] gamma

  Summary: 3 MCP servers scanned, clean=2, blocked=1, in 47ms
\`\`\`

## Notable

- \`_run_scan\` returning None (fatal scanner error) now visibly bumps an \`errored=N\` count in the summary, instead of being silent stderr noise.
- Internal \`_print_scan_result\` drops its \`Status: CLEAN / Status: HIGH (N findings)\` header — the shared per-target glyph line covers that. It still emits per-finding details under the glyph for blocked verdicts, plus the JSON payload in \`--json\`.

## JSON contract

Unchanged. \`--json\` still emits \`ScanResult.to_json()\` verbatim per server.

## Stack

- #178 — S4.1
- #179 — S4.2
- #180 — S4.3
- #181 — S4.4
- #182 — S4.5
- #183 — S6.1
- #184 — S6.2
- #185 — S6.3
- **this PR — S6.4**

## Tests

- **New**: \`cli/tests/test_cmd_mcp_scan_ux.py\` — 7 tests: preamble singular/plural label, default categories, \`[ok]\` / \`[BLOCKED]\` / \`[ERROR]\` glyphs, summary aggregation, JSON-mode silencing, no-servers path.
- **Updated**: \`test_scan_clean\` and \`test_scan_allowed_url_still_scans\` — assertions migrated from the obsolete \`Status: CLEAN\` line to \`[ok] <target>\` + \`clean=1\`.
- **Unchanged**: all 36 existing tests in \`test_cmd_mcp.py\` pass.

## Test plan

- [x] \`pytest tests/test_cmd_mcp_scan_ux.py\` — 7 / 7 pass
- [x] \`pytest tests/test_cmd_mcp.py\` — 36 / 36 pass
- [x] Combined scan-UX run (mcp + skill + plugin + scan_ui): **158 / 158** pass
- [ ] Manual smoke: \`defenseclaw mcp scan --all\` on each connector

## Refs

connector-architecture v3 — S6.4 in the claw-agnostic plan.