### PR TITLE
S6.5: per-connector health checks in defenseclaw doctor

### DIFF
--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -1028,15 +1028,28 @@ def doctor(app: AppContext, json_out: bool, do_fix: bool, assume_yes: bool) -> N
 
     _check_config(cfg, r)
     _check_audit_db(cfg, r)
+
+    # S6.5 — surface the active connector + its configured paths
+    # before any scanner runs. Operators routinely point doctor at a
+    # config that *thinks* it's running on (say) Codex but actually
+    # has stale openclaw.json paths under .openclaw/extensions; a
+    # per-connector inventory pass catches that drift.
+    if not json_out:
+        click.echo()
+        click.echo("  ── Connector ──")
+    active_connector = _active_connector(cfg)
+    _check_connector_inventory(cfg, active_connector, r)
+
     if not json_out:
         click.echo()
         click.echo("  ── Scanners ──")
     _check_scanners(cfg, r)
+    _check_scan_coverage(cfg, r)
+
     if not json_out:
         click.echo()
         click.echo("  ── Services ──")
     _check_sidecar(cfg, r)
-    active_connector = getattr(cfg.guardrail, "connector", "openclaw") or "openclaw"
     if active_connector == "openclaw":
         _check_openclaw_gateway(cfg, r)
     elif active_connector == "claudecode":
@@ -1172,6 +1185,126 @@ def _run_fixers(cfg, r: _DoctorResult, *, assume_yes: bool, json_out: bool) -> N
             _emit(tag, f"fix: {title}", detail=detail, r=r)
 
 
+def _active_connector(cfg) -> str:
+    """Return the active connector name in lowercase.
+
+    Prefer the unified ``Config.active_connector()`` from S4.1 — it
+    handles the legacy ``guardrail.connector`` field plus the
+    ``claw.mode`` fallback the same way the rest of the CLI does.
+    Falls back to ``"openclaw"`` for older configs that predate the
+    method.
+    """
+    if hasattr(cfg, "active_connector"):
+        try:
+            return (cfg.active_connector() or "openclaw").lower()
+        except Exception:
+            pass
+    return (getattr(getattr(cfg, "guardrail", None), "connector", "")
+            or "openclaw").lower()
+
+
+_CONNECTOR_LABELS = {
+    "openclaw": "OpenClaw",
+    "claudecode": "Claude Code",
+    "codex": "Codex",
+    "zeptoclaw": "ZeptoClaw",
+}
+
+
+def _check_connector_inventory(cfg, connector: str, r: _DoctorResult) -> None:
+    """Surface the active connector and the directories it points at.
+
+    Each connector has its own conventions for where skills, plugins,
+    and MCP server registrations live. ``Config.skill_dirs()`` /
+    ``plugin_dirs()`` / ``mcp_servers()`` are now polymorphic per
+    connector (S4.1), so this check makes that mapping visible to the
+    operator: if Codex is active but skill_dirs() still points at
+    ``~/.openclaw/skills``, that's a config bug doctor should flag.
+    """
+    label = _CONNECTOR_LABELS.get(connector, connector)
+    if connector not in _CONNECTOR_LABELS:
+        _emit(
+            "warn", "Active connector",
+            f"unknown connector {connector!r} — known: "
+            + ", ".join(sorted(_CONNECTOR_LABELS)),
+            r=r,
+        )
+    else:
+        _emit("pass", "Active connector", label, r=r)
+
+    # Skill dirs.
+    try:
+        sdirs = cfg.skill_dirs() if hasattr(cfg, "skill_dirs") else []
+    except Exception as exc:
+        _emit("warn", "Skill paths", f"could not enumerate: {exc}", r=r)
+        sdirs = []
+    if sdirs:
+        existing = sum(1 for d in sdirs if os.path.isdir(d))
+        detail = f"{existing}/{len(sdirs)} present — " + ", ".join(sdirs)
+        if existing == 0:
+            _emit("warn", "Skill paths", detail, r=r)
+        else:
+            _emit("pass", "Skill paths", detail, r=r)
+    else:
+        _emit("skip", "Skill paths", f"no skill dirs configured for {label}", r=r)
+
+    # Plugin dirs.
+    try:
+        pdirs = cfg.plugin_dirs() if hasattr(cfg, "plugin_dirs") else []
+    except Exception as exc:
+        _emit("warn", "Plugin paths", f"could not enumerate: {exc}", r=r)
+        pdirs = []
+    if pdirs:
+        existing = sum(1 for d in pdirs if os.path.isdir(d))
+        detail = f"{existing}/{len(pdirs)} present — " + ", ".join(pdirs)
+        if existing == 0:
+            _emit("warn", "Plugin paths", detail, r=r)
+        else:
+            _emit("pass", "Plugin paths", detail, r=r)
+    else:
+        _emit("skip", "Plugin paths", f"no plugin dirs configured for {label}", r=r)
+
+    # MCP servers.
+    try:
+        servers = cfg.mcp_servers() if hasattr(cfg, "mcp_servers") else []
+    except Exception as exc:
+        _emit("warn", "MCP servers", f"could not enumerate: {exc}", r=r)
+        servers = []
+    count = len(servers)
+    if count:
+        names = ", ".join(s.name for s in servers[:5])
+        more = f" (+{count - 5} more)" if count > 5 else ""
+        _emit("pass", "MCP servers", f"{count} configured: {names}{more}", r=r)
+    else:
+        _emit("skip", "MCP servers", "no MCP servers registered", r=r)
+
+
+def _check_scan_coverage(cfg, r: _DoctorResult) -> None:
+    """Advertise what each scanner will check.
+
+    Mirrors the bullet list rendered by ``_scan_ui.render_preamble``
+    so operators see the *same* category contract from doctor as
+    they see when they actually run the scanner. Anything we can't
+    look up via :func:`_scan_ui.categories_for` falls through as
+    SKIP — the helper is the source of truth.
+    """
+    del cfg  # unused: categories are static per component
+    from defenseclaw.commands import _scan_ui
+
+    for component in _scan_ui.supported_components():
+        cats = _scan_ui.categories_for(component)
+        label = _scan_ui._COMPONENT_LABELS.get(  # type: ignore[attr-defined]
+            component, (component, component + "s"),
+        )[0]
+        if cats:
+            _emit(
+                "pass", f"Scanner coverage ({label})",
+                "; ".join(cats), r=r,
+            )
+        else:
+            _emit("skip", f"Scanner coverage ({label})", "no categories registered", r=r)
+
+
 def _fix_stale_pid(cfg, *, assume_yes: bool) -> tuple[str, str]:
     """Remove a ``gateway.pid`` file whose recorded PID is no longer alive."""
     pid_file = os.path.join(cfg.data_dir, "gateway.pid")
@@ -1214,7 +1347,7 @@ def _fix_stale_pid(cfg, *, assume_yes: bool) -> tuple[str, str]:
 
 def _fix_gateway_token(cfg, *, assume_yes: bool) -> tuple[str, str]:
     """Re-sync gateway token from the active connector's config."""
-    active_connector = getattr(cfg.guardrail, "connector", "openclaw") or "openclaw"
+    active_connector = _active_connector(cfg)
 
     if active_connector == "openclaw":
         from defenseclaw.commands.cmd_setup import (
@@ -1281,7 +1414,7 @@ def _fix_pristine_backup(cfg, *, assume_yes: bool) -> tuple[str, str]:
     the data directory.
     """
     del assume_yes  # unused: capturing a snapshot is always safe
-    active_connector = getattr(cfg.guardrail, "connector", "openclaw") or "openclaw"
+    active_connector = _active_connector(cfg)
 
     if active_connector == "openclaw":
         from defenseclaw.guardrail import (

--- a/cli/tests/test_cmd_doctor_connector.py
+++ b/cli/tests/test_cmd_doctor_connector.py
@@ -1,0 +1,223 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""S6.5 — per-connector doctor checks.
+
+These tests pin the new per-connector inventory and scan-coverage
+sections that S6.5 added to ``defenseclaw doctor``. The checks are
+deliberately narrow: they exercise the helpers in isolation rather
+than the whole 1000-line doctor flow, so we can lock the contract
+without smoke-testing every probe.
+
+Coverage:
+
+* ``_active_connector`` resolves the connector name in the same
+  shape ``cfg.active_connector()`` exposes — including the
+  legacy-config fallback when the method isn't present.
+* ``_check_connector_inventory`` emits PASS for known connectors,
+  WARN for unknown connectors, and surfaces the per-connector
+  skill / plugin / MCP path lists.
+* ``_check_scan_coverage`` mirrors the bullet list from
+  ``_scan_ui.categories_for`` so the doctor and the scanner
+  preambles agree on what each scanner checks.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from defenseclaw.commands.cmd_doctor import (
+    _DoctorResult,
+    _active_connector,
+    _check_connector_inventory,
+    _check_scan_coverage,
+)
+
+
+class TestActiveConnectorResolver(unittest.TestCase):
+    """``_active_connector`` is the single source of truth used by every
+    per-connector doctor branch (inventory, fix_gateway_token,
+    fix_pristine_backup). A regression here cascades through all of
+    them, so the helper has its own tests.
+    """
+
+    def test_active_connector_uses_method_when_available(self) -> None:
+        cfg = MagicMock()
+        cfg.active_connector.return_value = "Codex"
+        self.assertEqual(_active_connector(cfg), "codex")
+
+    def test_active_connector_falls_back_to_guardrail_field(self) -> None:
+        cfg = MagicMock(spec=["guardrail"])  # no active_connector method
+        cfg.guardrail = MagicMock()
+        cfg.guardrail.connector = "claudecode"
+        self.assertEqual(_active_connector(cfg), "claudecode")
+
+    def test_active_connector_defaults_to_openclaw_when_unset(self) -> None:
+        cfg = MagicMock(spec=["guardrail"])
+        cfg.guardrail = MagicMock()
+        cfg.guardrail.connector = ""
+        self.assertEqual(_active_connector(cfg), "openclaw")
+
+    def test_active_connector_lowercases_method_result(self) -> None:
+        """ZeptoClaw, OpenClaw, etc. — display casing varies, but the
+        downstream connector switches all use lowercase.
+        """
+        cfg = MagicMock()
+        cfg.active_connector.return_value = "ZeptoClaw"
+        self.assertEqual(_active_connector(cfg), "zeptoclaw")
+
+    def test_active_connector_swallows_method_exception(self) -> None:
+        """A broken ``active_connector()`` must not abort the doctor —
+        fall back to the legacy field.
+        """
+        cfg = MagicMock()
+        cfg.active_connector.side_effect = RuntimeError("bad config")
+        cfg.guardrail = MagicMock()
+        cfg.guardrail.connector = "openclaw"
+        self.assertEqual(_active_connector(cfg), "openclaw")
+
+
+class TestCheckConnectorInventory(unittest.TestCase):
+    """The new "── Connector ──" section surfaces the active connector
+    plus the directories it points at."""
+
+    def _cfg(self, *, skill_dirs: list[str], plugin_dirs: list[str], servers: list) -> MagicMock:
+        cfg = MagicMock()
+        cfg.skill_dirs.return_value = skill_dirs
+        cfg.plugin_dirs.return_value = plugin_dirs
+        cfg.mcp_servers.return_value = servers
+        return cfg
+
+    def test_known_connector_passes(self) -> None:
+        cfg = self._cfg(skill_dirs=[], plugin_dirs=[], servers=[])
+        r = _DoctorResult()
+        _check_connector_inventory(cfg, "openclaw", r)
+        # First check is the connector label itself.
+        first = r.checks[0]
+        self.assertEqual(first["status"], "pass")
+        self.assertEqual(first["label"], "Active connector")
+        self.assertEqual(first["detail"], "OpenClaw")
+
+    def test_unknown_connector_warns(self) -> None:
+        cfg = self._cfg(skill_dirs=[], plugin_dirs=[], servers=[])
+        r = _DoctorResult()
+        _check_connector_inventory(cfg, "totallymadeupclaw", r)
+        first = r.checks[0]
+        self.assertEqual(first["status"], "warn")
+        self.assertEqual(first["label"], "Active connector")
+        self.assertIn("unknown connector", first["detail"])
+
+    def test_skill_paths_pass_when_directory_exists(self) -> None:
+        # Use the cwd as a guaranteed-real directory.
+        cfg = self._cfg(
+            skill_dirs=[os.getcwd()],
+            plugin_dirs=[],
+            servers=[],
+        )
+        r = _DoctorResult()
+        _check_connector_inventory(cfg, "openclaw", r)
+        skill_check = next(c for c in r.checks if c["label"] == "Skill paths")
+        self.assertEqual(skill_check["status"], "pass")
+        self.assertIn("1/1 present", skill_check["detail"])
+
+    def test_skill_paths_warn_when_no_directory_exists(self) -> None:
+        cfg = self._cfg(
+            skill_dirs=["/nonexistent/path/for/test"],
+            plugin_dirs=[],
+            servers=[],
+        )
+        r = _DoctorResult()
+        _check_connector_inventory(cfg, "codex", r)
+        skill_check = next(c for c in r.checks if c["label"] == "Skill paths")
+        self.assertEqual(skill_check["status"], "warn")
+        self.assertIn("0/1 present", skill_check["detail"])
+
+    def test_skill_paths_skip_when_empty_list(self) -> None:
+        cfg = self._cfg(skill_dirs=[], plugin_dirs=[], servers=[])
+        r = _DoctorResult()
+        _check_connector_inventory(cfg, "claudecode", r)
+        skill_check = next(c for c in r.checks if c["label"] == "Skill paths")
+        self.assertEqual(skill_check["status"], "skip")
+
+    def test_mcp_server_summary_truncates_after_five(self) -> None:
+        servers = [MagicMock(name=f"srv-{i}") for i in range(7)]
+        for i, s in enumerate(servers):
+            s.name = f"srv-{i}"
+        cfg = self._cfg(skill_dirs=[], plugin_dirs=[], servers=servers)
+        r = _DoctorResult()
+        _check_connector_inventory(cfg, "openclaw", r)
+        mcp_check = next(c for c in r.checks if c["label"] == "MCP servers")
+        self.assertEqual(mcp_check["status"], "pass")
+        self.assertIn("7 configured", mcp_check["detail"])
+        self.assertIn("(+2 more)", mcp_check["detail"])
+
+    def test_paths_swallow_exception_as_warn(self) -> None:
+        cfg = MagicMock()
+        cfg.skill_dirs.side_effect = RuntimeError("kaboom")
+        cfg.plugin_dirs.return_value = []
+        cfg.mcp_servers.return_value = []
+
+        r = _DoctorResult()
+        _check_connector_inventory(cfg, "openclaw", r)
+
+        skill_check = next(c for c in r.checks if c["label"] == "Skill paths")
+        self.assertEqual(skill_check["status"], "warn")
+        self.assertIn("kaboom", skill_check["detail"])
+
+
+class TestCheckScanCoverage(unittest.TestCase):
+    """``_check_scan_coverage`` advertises what each scanner will check.
+
+    The categories are owned by ``_scan_ui.categories_for``; this test
+    just locks the round-trip from doctor through to that helper, so a
+    drift between doctor and the scan preamble shows up in CI.
+    """
+
+    def test_all_components_emit_a_pass_check(self) -> None:
+        from defenseclaw.commands import _scan_ui
+
+        r = _DoctorResult()
+        _check_scan_coverage(MagicMock(), r)
+
+        labels_seen = {c["label"] for c in r.checks if c["status"] == "pass"}
+        # One Scanner-coverage row per supported component.
+        for component in _scan_ui.supported_components():
+            sing = _scan_ui._COMPONENT_LABELS[component][0]  # type: ignore[attr-defined]
+            self.assertIn(f"Scanner coverage ({sing})", labels_seen)
+
+    def test_categories_match_scan_ui_source_of_truth(self) -> None:
+        from defenseclaw.commands import _scan_ui
+
+        r = _DoctorResult()
+        _check_scan_coverage(MagicMock(), r)
+
+        # Plugin row should literally contain every plugin category from
+        # _scan_ui — locking the contract that doctor and the scanner
+        # preamble can never disagree on what's being checked.
+        plugin_row = next(
+            c for c in r.checks if c["label"] == "Scanner coverage (plugin)"
+        )
+        for cat in _scan_ui.categories_for("plugin"):
+            self.assertIn(cat, plugin_row["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add per-connector inventory + scanner-coverage sections to \`defenseclaw doctor\`. Each connector has its own conventions for where skills, plugins, and MCP servers live. \`Config.skill_dirs()\` / \`plugin_dirs()\` / \`mcp_servers()\` are now polymorphic per connector (#178), so this PR makes that mapping visible: if Codex is active but \`skill_dirs()\` still points at \`~/.openclaw/skills\`, doctor flags the drift instead of leaving the operator to find out at scan time.

### Output (excerpt)

\`\`\`
  ── Connector ──
    [PASS] Active connector  —  Codex
    [PASS] Skill paths       —  1/1 present — /Users/me/.codex/skills
    [PASS] Plugin paths      —  1/1 present — /Users/me/.codex/extensions
    [PASS] MCP servers       —  3 configured: srv-a, srv-b, srv-c

  ── Scanners ──
    [PASS] Scanner: skill-scanner         —  /usr/local/bin/skill-scanner
    [PASS] Scanner: mcp-scanner           —  /usr/local/bin/mcp-scanner
    [PASS] Scanner coverage (plugin)      —  malicious code patterns; prompt injection attempts; hardcoded secrets; supply-chain risk indicators
    [PASS] Scanner coverage (skill)       —  prompt injection in SKILL.md; malicious shell / Python invocations; untrusted bundled bins; policy violations
    [PASS] Scanner coverage (MCP server)  —  untrusted command paths; outbound URL allow-listing; tool-name spoofing; auth-token handling
\`\`\`

## Internals

- \`_active_connector(cfg)\` — single helper used by inventory + scan-coverage + fix_gateway_token + fix_pristine_backup. Uses \`Config.active_connector()\` when present, falls back to \`cfg.guardrail.connector\`, lowercase-normalized.
- \`_check_connector_inventory\` — PASS for known connectors, WARN for unknown ones; rolls up skill / plugin / MCP path lists with PASS / WARN / SKIP based on disk presence.
- \`_check_scan_coverage\` — pulls categories from \`_scan_ui.categories_for\` so doctor and scan preambles share the same source of truth.

## Stack

- #178 — S4.1
- #179 — S4.2
- #180 — S4.3
- #181 — S4.4
- #182 — S4.5
- #183 — S6.1
- #184 — S6.2
- #185 — S6.3
- #186 — S6.4
- **this PR — S6.5**

## Tests

- **New**: \`cli/tests/test_cmd_doctor_connector.py\` — 14 tests:
  - \`_active_connector\` (method + fallback + lowercase + exception swallow)
  - \`_check_connector_inventory\` (known + unknown connectors, skill paths PASS/WARN/SKIP, MCP truncation, exception surfacing)
  - \`_check_scan_coverage\` (component coverage, category alignment with \`_scan_ui\`)
- **Unchanged**: all 25 existing tests in \`test_cmd_doctor.py\` pass.

## Test plan

- [x] \`pytest tests/test_cmd_doctor_connector.py\` — 14 / 14 pass
- [x] \`pytest tests/test_cmd_doctor.py\` — 25 / 25 pass
- [ ] Manual smoke: \`defenseclaw doctor\` against each connector

## Refs

connector-architecture v3 — S6.5 in the claw-agnostic plan.