### PR TITLE
S7.3: defenseclaw uninstall polymorphic per-connector teardown

### DIFF
--- a/cli/defenseclaw/commands/cmd_uninstall.py
+++ b/cli/defenseclaw/commands/cmd_uninstall.py
@@ -19,8 +19,23 @@
 Removes DefenseClaw artifacts from the system in a predictable,
 scriptable way so operators aren't left with a mess after evaluating
 the tool. ``reset`` is the "lose my data" button — it wipes
-``~/.defenseclaw`` but keeps the binaries and the OpenClaw plugin
-in place so ``defenseclaw quickstart`` can reinstall cleanly.
+``~/.defenseclaw`` but keeps the binaries and the agent framework's
+plugin in place so ``defenseclaw quickstart`` can reinstall cleanly.
+
+Connector polymorphism (S7.3)
+-----------------------------
+Removal of the agent framework's defenseclaw artifacts is delegated to
+``defenseclaw-gateway connector teardown`` — the canonical sentinel that
+each connector adapter implements (S7.2). This keeps the Python flow
+honest: it never has to know how Codex / Claude Code / ZeptoClaw
+configure themselves, which previously meant the OpenClaw teardown was
+the only one that worked.
+
+The Python side still owns OpenClaw-specific revert paths as a fallback
+for very old gateway binaries (pre-S7.2) where the ``connector teardown``
+subcommand is not available. The fallback only ever runs against
+OpenClaw, never against the other adapters — calling
+``restore_openclaw_config`` against a Codex install would corrupt it.
 """
 
 from __future__ import annotations
@@ -35,6 +50,13 @@ import click
 from defenseclaw import config as config_module
 
 
+# Connectors whose teardown the Python CLI knows how to perform locally
+# without going through ``defenseclaw-gateway connector teardown``. This
+# is the conservative fallback path used when the gateway binary is too
+# old to expose the connector subcommand.
+_PYTHON_FALLBACK_CONNECTORS: frozenset[str] = frozenset({"openclaw"})
+
+
 @dataclass
 class UninstallPlan:
     """Aggregated summary of what an uninstall/reset intends to do."""
@@ -47,6 +69,10 @@ class UninstallPlan:
     data_dir: str = ""
     openclaw_config_file: str = ""
     openclaw_home: str = ""
+    # connector is the active framework adapter to tear down. Resolved
+    # from cfg.active_connector() at plan-build time and surfaced in
+    # _render_plan so the operator sees what's about to be touched.
+    connector: str = "openclaw"
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +151,31 @@ def reset_cmd(yes: bool) -> None:
 # Planning + execution
 # ---------------------------------------------------------------------------
 
+def _resolve_active_connector(cfg) -> str:
+    """Return the active connector for ``cfg``, lowercased.
+
+    Mirrors :meth:`Config.active_connector` but tolerates older
+    in-process configs that haven't been migrated yet — the same
+    pattern used in :mod:`cmd_setup_sandbox`. We can't rely on
+    ``Config.active_connector`` existing because ``_build_plan`` is
+    called even when config loading raised.
+    """
+    if cfg is None:
+        return "openclaw"
+    if hasattr(cfg, "active_connector") and callable(cfg.active_connector):
+        try:
+            name = (cfg.active_connector() or "").strip().lower()
+            if name:
+                return name
+        except Exception:
+            pass
+    if hasattr(cfg, "guardrail") and hasattr(cfg.guardrail, "connector"):
+        name = (cfg.guardrail.connector or "").strip().lower()
+        if name:
+            return name
+    return "openclaw"
+
+
 def _build_plan(
     *,
     wipe_data: bool,
@@ -139,6 +190,7 @@ def _build_plan(
     # rather than blocking the uninstall.
     openclaw_config_file = ""
     openclaw_home = ""
+    cfg = None
     try:
         cfg = config_module.load()
         openclaw_config_file = cfg.claw.config_file
@@ -146,6 +198,8 @@ def _build_plan(
     except Exception:
         openclaw_home = os.path.expanduser("~/.openclaw")
         openclaw_config_file = os.path.join(openclaw_home, "openclaw.json")
+
+    connector = _resolve_active_connector(cfg)
 
     return UninstallPlan(
         stop_gateway=True,
@@ -156,6 +210,7 @@ def _build_plan(
         data_dir=data_dir,
         openclaw_config_file=openclaw_config_file,
         openclaw_home=openclaw_home,
+        connector=connector,
     )
 
 
@@ -163,10 +218,19 @@ def _render_plan(plan: UninstallPlan, *, dry_run: bool) -> None:
     click.echo()
     click.echo("  ── Uninstall plan ────────────────────────────────────")
     click.echo()
+    click.echo(f"  • active connector:    {plan.connector}")
     click.echo(f"  • stop sidecar:        {'yes' if plan.stop_gateway else 'no'}")
-    click.echo(f"  • revert openclaw.json: {'yes' if plan.revert_openclaw else 'no'} "
-               f"({plan.openclaw_config_file})")
-    click.echo(f"  • remove plugin:        {'yes' if plan.remove_plugin else 'no'}")
+    if plan.connector == "openclaw":
+        click.echo(
+            f"  • revert openclaw.json: {'yes' if plan.revert_openclaw else 'no'} "
+            f"({plan.openclaw_config_file})"
+        )
+        click.echo(f"  • remove plugin:        {'yes' if plan.remove_plugin else 'no'}")
+    else:
+        click.echo(
+            f"  • teardown {plan.connector}:    "
+            f"{'yes (via gateway connector teardown)' if plan.revert_openclaw else 'no'}"
+        )
     click.echo(f"  • wipe {plan.data_dir}: {'yes' if plan.remove_data_dir else 'no'}")
     click.echo(f"  • remove binaries:     {'yes' if plan.remove_binaries else 'no'}")
     click.echo()
@@ -176,8 +240,12 @@ def _execute_plan(plan: UninstallPlan) -> None:
     if plan.stop_gateway:
         _stop_gateway()
     if plan.revert_openclaw:
-        _revert_openclaw(plan)
-    if plan.remove_plugin:
+        _connector_teardown(plan)
+    if plan.remove_plugin and plan.connector == "openclaw":
+        # Plugin removal is OpenClaw-specific. For other connectors the
+        # gateway sentinel teardown above already removed the
+        # connector's hook scripts and config patches, so there is
+        # nothing additional to do here.
         _remove_plugin(plan)
     if plan.remove_data_dir:
         _remove_data_dir(plan.data_dir)
@@ -197,8 +265,99 @@ def _stop_gateway() -> None:
         click.echo(f"  ⚠ could not stop sidecar: {exc}")
 
 
-def _revert_openclaw(plan: UninstallPlan) -> None:
-    """Restore openclaw.json, preferring the pristine backup if we have it."""
+def _gateway_supports_connector_teardown() -> bool:
+    """Return True iff the local ``defenseclaw-gateway`` exposes the
+    ``connector teardown`` subcommand introduced in S7.2.
+
+    Older binaries print a usage error that includes ``unknown command``
+    on stderr; the subprocess returncode is also non-zero. We detect
+    by asking for ``--help`` on the ``connector`` subcommand — which is
+    a non-destructive probe — and checking exit code + output.
+    """
+    gw = shutil.which("defenseclaw-gateway")
+    if gw is None:
+        return False
+    try:
+        proc = subprocess.run(
+            [gw, "connector", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if proc.returncode != 0:
+        return False
+    combined = (proc.stdout or "") + (proc.stderr or "")
+    return "teardown" in combined and "list-backups" in combined
+
+
+def _connector_teardown(plan: UninstallPlan) -> None:
+    """Run connector teardown via the canonical sentinel, falling back
+    to the OpenClaw-specific Python helpers when the gateway binary
+    is too old (pre-S7.2) or the connector isn't OpenClaw.
+
+    For non-OpenClaw connectors the Python fallback path is **not**
+    safe — calling ``restore_openclaw_config`` against a Codex install
+    would corrupt it — so we hard-fail in that case with a clear
+    remediation pointing at the gateway upgrade path.
+    """
+    if _gateway_supports_connector_teardown():
+        if _run_gateway_connector_teardown(plan.connector):
+            return
+        click.echo(
+            f"  ⚠ gateway connector teardown for {plan.connector} reported errors — "
+            f"see output above"
+        )
+        if plan.connector != "openclaw":
+            return
+
+    if plan.connector in _PYTHON_FALLBACK_CONNECTORS:
+        _revert_openclaw_python(plan)
+        return
+
+    click.echo(
+        f"  ⚠ no Python fallback for connector '{plan.connector}'.\n"
+        f"     Upgrade defenseclaw-gateway to v0.7+ (introduces "
+        f"'connector teardown') and re-run 'defenseclaw uninstall'."
+    )
+
+
+def _run_gateway_connector_teardown(connector: str) -> bool:
+    """Invoke ``defenseclaw-gateway connector teardown --connector <name>``.
+
+    Returns True on success (rc == 0), False on any error. stdout/stderr
+    is forwarded to the operator so they can see exactly what each
+    adapter restored.
+    """
+    gw = shutil.which("defenseclaw-gateway")
+    if gw is None:
+        return False
+    try:
+        proc = subprocess.run(
+            [gw, "connector", "teardown", "--connector", connector],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        click.echo(f"  ⚠ gateway connector teardown failed to launch: {exc}")
+        return False
+    if proc.stdout:
+        for line in proc.stdout.splitlines():
+            click.echo(f"  · {line}")
+    if proc.stderr and proc.returncode != 0:
+        for line in proc.stderr.splitlines():
+            click.echo(f"  ⚠ {line}")
+    if proc.returncode == 0:
+        click.echo(f"  ✓ {connector} teardown via gateway sentinel")
+        return True
+    return False
+
+
+def _revert_openclaw_python(plan: UninstallPlan) -> None:
+    """OpenClaw-specific revert path used as a fallback when the gateway
+    sentinel is unavailable. NOT safe for other connectors."""
     from defenseclaw.guardrail import (
         pristine_backup_path,
         restore_openclaw_config,

--- a/cli/tests/test_cmd_uninstall.py
+++ b/cli/tests/test_cmd_uninstall.py
@@ -18,12 +18,29 @@ own tests elsewhere.
 
 from __future__ import annotations
 
+import contextlib
+import io
 import os
 import sys
 import unittest
 from unittest.mock import patch
 
 from click.testing import CliRunner
+
+
+@contextlib.contextmanager
+def capture_click_output():
+    """Capture click.echo output for direct (non-CliRunner) calls.
+
+    click.echo writes to ``sys.stdout`` by default unless an explicit file
+    is given, so swapping the stream is enough for our render-only
+    assertions and avoids the version-skew between CliRunner.isolation()
+    return shapes (Click 8.0 returns (stdout, stderr); Click 8.1+ adds
+    a third element).
+    """
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        yield buf
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -112,6 +129,230 @@ class ResetCommandTests(unittest.TestCase):
             self.assertTrue(plan.remove_data_dir)
             self.assertFalse(plan.remove_plugin)
             self.assertFalse(plan.remove_binaries)
+
+
+class ResolveActiveConnectorTests(unittest.TestCase):
+    def test_uses_active_connector_method(self):
+        class Cfg:
+            def active_connector(self):
+                return "Codex"
+        self.assertEqual(cmd_uninstall._resolve_active_connector(Cfg()), "codex")
+
+    def test_falls_back_to_guardrail_connector(self):
+        class Guardrail:
+            connector = "claudecode"
+        class Cfg:
+            guardrail = Guardrail()
+        self.assertEqual(cmd_uninstall._resolve_active_connector(Cfg()), "claudecode")
+
+    def test_method_exception_falls_back(self):
+        class Guardrail:
+            connector = "zeptoclaw"
+        class Cfg:
+            guardrail = Guardrail()
+            def active_connector(self):
+                raise RuntimeError("boom")
+        self.assertEqual(cmd_uninstall._resolve_active_connector(Cfg()), "zeptoclaw")
+
+    def test_none_cfg_defaults_to_openclaw(self):
+        self.assertEqual(cmd_uninstall._resolve_active_connector(None), "openclaw")
+
+
+class BuildPlanConnectorTests(unittest.TestCase):
+    def test_plan_records_active_connector(self):
+        class Guardrail:
+            connector = "codex"
+        class Claw:
+            home_dir = "~/.codex"
+            config_file = "~/.codex/config.toml"
+        class Cfg:
+            guardrail = Guardrail()
+            claw = Claw()
+
+        with patch("defenseclaw.commands.cmd_uninstall.config_module.load",
+                   return_value=Cfg()):
+            plan = cmd_uninstall._build_plan(
+                wipe_data=False,
+                binaries=False,
+                revert_openclaw=True,
+                remove_plugin=True,
+            )
+        self.assertEqual(plan.connector, "codex")
+
+    def test_plan_defaults_to_openclaw_when_load_fails(self):
+        with patch("defenseclaw.commands.cmd_uninstall.config_module.load",
+                   side_effect=Exception("boom")):
+            plan = cmd_uninstall._build_plan(
+                wipe_data=False,
+                binaries=False,
+                revert_openclaw=True,
+                remove_plugin=True,
+            )
+        self.assertEqual(plan.connector, "openclaw")
+
+
+class RenderPlanConnectorTests(unittest.TestCase):
+    def test_render_shows_connector_specific_line_for_codex(self):
+        plan = cmd_uninstall.UninstallPlan(connector="codex", data_dir="/tmp/dc")
+        with capture_click_output() as buf:
+            cmd_uninstall._render_plan(plan, dry_run=True)
+        text = buf.getvalue()
+        self.assertIn("active connector:    codex", text)
+        self.assertIn("teardown codex", text)
+        self.assertNotIn("revert openclaw.json", text)
+
+    def test_render_shows_openclaw_revert_for_openclaw(self):
+        plan = cmd_uninstall.UninstallPlan(
+            connector="openclaw",
+            data_dir="/tmp/dc",
+            openclaw_config_file="/tmp/openclaw.json",
+        )
+        with capture_click_output() as buf:
+            cmd_uninstall._render_plan(plan, dry_run=True)
+        text = buf.getvalue()
+        self.assertIn("revert openclaw.json", text)
+
+
+class ConnectorTeardownDispatchTests(unittest.TestCase):
+    def _plan(self, connector: str) -> cmd_uninstall.UninstallPlan:
+        return cmd_uninstall.UninstallPlan(
+            connector=connector,
+            data_dir="/tmp/dc",
+            openclaw_config_file="/tmp/openclaw.json",
+            openclaw_home="/tmp/.openclaw",
+        )
+
+    def test_uses_gateway_sentinel_when_supported(self):
+        with patch.object(cmd_uninstall, "_gateway_supports_connector_teardown",
+                          return_value=True), \
+             patch.object(cmd_uninstall, "_run_gateway_connector_teardown",
+                          return_value=True) as run_mock, \
+             patch.object(cmd_uninstall, "_revert_openclaw_python") as fallback:
+            cmd_uninstall._connector_teardown(self._plan("codex"))
+            run_mock.assert_called_once_with("codex")
+            fallback.assert_not_called()
+
+    def test_falls_back_to_python_for_openclaw_when_gateway_old(self):
+        with patch.object(cmd_uninstall, "_gateway_supports_connector_teardown",
+                          return_value=False), \
+             patch.object(cmd_uninstall, "_revert_openclaw_python") as fallback:
+            cmd_uninstall._connector_teardown(self._plan("openclaw"))
+            fallback.assert_called_once()
+
+    def test_hard_fails_when_non_openclaw_and_gateway_old(self):
+        with capture_click_output() as buf, \
+             patch.object(cmd_uninstall, "_gateway_supports_connector_teardown",
+                          return_value=False), \
+             patch.object(cmd_uninstall, "_revert_openclaw_python") as fallback:
+            cmd_uninstall._connector_teardown(self._plan("codex"))
+        text = buf.getvalue()
+        fallback.assert_not_called()
+        self.assertIn("no Python fallback", text)
+        self.assertIn("codex", text)
+        self.assertIn("connector teardown", text)
+
+    def test_falls_back_when_gateway_sentinel_errors_for_openclaw(self):
+        with patch.object(cmd_uninstall, "_gateway_supports_connector_teardown",
+                          return_value=True), \
+             patch.object(cmd_uninstall, "_run_gateway_connector_teardown",
+                          return_value=False), \
+             patch.object(cmd_uninstall, "_revert_openclaw_python") as fallback:
+            cmd_uninstall._connector_teardown(self._plan("openclaw"))
+            fallback.assert_called_once()
+
+    def test_does_not_fall_back_for_codex_when_sentinel_errors(self):
+        with capture_click_output() as buf, \
+             patch.object(cmd_uninstall, "_gateway_supports_connector_teardown",
+                          return_value=True), \
+             patch.object(cmd_uninstall, "_run_gateway_connector_teardown",
+                          return_value=False), \
+             patch.object(cmd_uninstall, "_revert_openclaw_python") as fallback:
+            cmd_uninstall._connector_teardown(self._plan("codex"))
+        fallback.assert_not_called()
+        self.assertIn("reported errors", buf.getvalue())
+
+
+class GatewaySupportProbeTests(unittest.TestCase):
+    def test_returns_false_when_gateway_missing(self):
+        with patch("shutil.which", return_value=None):
+            self.assertFalse(cmd_uninstall._gateway_supports_connector_teardown())
+
+    def test_returns_true_for_modern_gateway(self):
+        with patch("shutil.which", return_value="/usr/bin/defenseclaw-gateway"), \
+             patch("subprocess.run") as run_mock:
+            run_mock.return_value.returncode = 0
+            run_mock.return_value.stdout = (
+                "Available Commands:\n  list-backups ...\n  teardown ...\n  verify ...\n"
+            )
+            run_mock.return_value.stderr = ""
+            self.assertTrue(cmd_uninstall._gateway_supports_connector_teardown())
+
+    def test_returns_false_when_help_lacks_subcommand(self):
+        with patch("shutil.which", return_value="/usr/bin/defenseclaw-gateway"), \
+             patch("subprocess.run") as run_mock:
+            run_mock.return_value.returncode = 0
+            run_mock.return_value.stdout = "Usage:\n  defenseclaw-gateway [command]\n"
+            run_mock.return_value.stderr = ""
+            self.assertFalse(cmd_uninstall._gateway_supports_connector_teardown())
+
+    def test_returns_false_when_help_exits_nonzero(self):
+        with patch("shutil.which", return_value="/usr/bin/defenseclaw-gateway"), \
+             patch("subprocess.run") as run_mock:
+            run_mock.return_value.returncode = 1
+            run_mock.return_value.stdout = ""
+            run_mock.return_value.stderr = "unknown command \"connector\""
+            self.assertFalse(cmd_uninstall._gateway_supports_connector_teardown())
+
+
+class ExecutePlanConnectorTests(unittest.TestCase):
+    """Lock down the polymorphic _execute_plan ordering: stop → teardown
+    → (openclaw plugin remove only when openclaw) → wipe → binaries.
+    """
+
+    def _common_patches(self):
+        return [
+            patch.object(cmd_uninstall, "_stop_gateway"),
+            patch.object(cmd_uninstall, "_connector_teardown"),
+            patch.object(cmd_uninstall, "_remove_plugin"),
+            patch.object(cmd_uninstall, "_remove_data_dir"),
+            patch.object(cmd_uninstall, "_remove_binaries"),
+        ]
+
+    def test_codex_skips_remove_plugin_step(self):
+        plan = cmd_uninstall.UninstallPlan(
+            connector="codex",
+            data_dir="/tmp/dc",
+        )
+        ctx_mgrs = self._common_patches()
+        try:
+            mocks = [c.__enter__() for c in ctx_mgrs]
+            stop_mock, teardown_mock, plugin_mock, wipe_mock, bin_mock = mocks
+            cmd_uninstall._execute_plan(plan)
+            stop_mock.assert_called_once()
+            teardown_mock.assert_called_once_with(plan)
+            plugin_mock.assert_not_called()
+            wipe_mock.assert_not_called()
+            bin_mock.assert_not_called()
+        finally:
+            for c in ctx_mgrs:
+                c.__exit__(None, None, None)
+
+    def test_openclaw_runs_remove_plugin_step(self):
+        plan = cmd_uninstall.UninstallPlan(
+            connector="openclaw",
+            data_dir="/tmp/dc",
+            remove_plugin=True,
+        )
+        ctx_mgrs = self._common_patches()
+        try:
+            mocks = [c.__enter__() for c in ctx_mgrs]
+            _, teardown_mock, plugin_mock, _, _ = mocks
+            cmd_uninstall._execute_plan(plan)
+            teardown_mock.assert_called_once()
+            plugin_mock.assert_called_once_with(plan)
+        finally:
+            for c in ctx_mgrs:
+                c.__exit__(None, None, None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Route ``defenseclaw uninstall`` through the S7.2 ``defenseclaw-gateway connector teardown`` sentinel so each connector adapter owns its own rollback path. Today the Python flow always calls ``restore_openclaw_config()`` regardless of which framework is active — which would silently corrupt a Codex / Claude Code / ZeptoClaw install.

## What changed

| Step | Before                                                                   | After                                                                                 |
| ---- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
| Plan | Always ``revert openclaw.json`` + ``remove plugin``                       | Resolves ``Config.active_connector()`` and surfaces it in the plan                    |
| Render | Single OpenClaw-shaped line                                            | Per-connector wording: ``revert openclaw.json`` only for openclaw; ``teardown <name>`` for everything else |
| Execute | Direct calls to OpenClaw Python helpers                                | Sentinel-first: ``defenseclaw-gateway connector teardown --connector <name>`` (S7.2). Fallback to Python helpers **only** for OpenClaw on legacy gateways |
| Plugin | Always called ``_remove_plugin``                                       | Only called for OpenClaw. Other connectors had their hooks/shims removed by the sentinel |

## Safety guarantees

- Non-OpenClaw connectors **never** silently call ``restore_openclaw_config``. If the gateway is too old to expose the sentinel, the flow logs an explicit remediation (\"upgrade gateway to v0.7+\") and aborts the destructive step.
- Sentinel availability is detected with a non-destructive ``connector --help`` probe checking for ``teardown`` and ``list-backups`` in the output; the probe is bounded by a 10s timeout.

## Test plan

- [x] ``pytest tests/test_cmd_uninstall.py`` (25 cases, +19 new)
- [x] Build plan resolves connector from ``Config.active_connector``, ``guardrail.connector``, falls back to ``openclaw``
- [x] Render output is connector-specific (``codex`` shows ``teardown codex``, ``openclaw`` shows ``revert openclaw.json``)
- [x] Sentinel dispatch covers: modern gateway, missing gateway, gateway help missing the subcommand, gateway help exiting non-zero
- [x] Execute plan: codex skips ``_remove_plugin``; openclaw still calls it
- [x] Codex hard-fails (no Python fallback) when sentinel unavailable

Stacked on top of #189 (S7.2).