### PR TITLE
S7.4: defenseclaw guardrail {enable,disable,status} connector-agnostic

### DIFF
--- a/cli/defenseclaw/commands/cmd_guardrail.py
+++ b/cli/defenseclaw/commands/cmd_guardrail.py
@@ -1,0 +1,247 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""``defenseclaw guardrail {enable,disable}`` — connector-agnostic toggle.
+
+Today operators have to use ``defenseclaw setup guardrail [--disable]``,
+which interleaves "I want to flip the enabled bit" with "I want to
+re-prompt for model / scanner-mode / Cisco endpoint / judge config".
+That works for first-time setup but feels heavy for the very common
+case of "the guardrail is acting up, give me a quick off switch".
+
+This command surfaces the toggle directly:
+
+  defenseclaw guardrail disable    # turn off + connector teardown
+  defenseclaw guardrail enable     # turn on + connector setup
+  defenseclaw guardrail status     # is it on, which connector, which mode
+
+Both ``enable`` and ``disable`` are connector-agnostic. They resolve
+the active connector from ``Config.active_connector()`` and delegate
+the actual config-patch work to the Go sidecar's ``Connector.Setup``
+/ ``Connector.Teardown`` (running at sidecar boot when the
+``guardrail.enabled`` flag flips). The Python side never has to know
+how Codex / Claude Code / ZeptoClaw configure themselves.
+"""
+
+from __future__ import annotations
+
+import click
+
+from defenseclaw.context import AppContext, pass_ctx
+
+
+_CONNECTOR_LABELS = {
+    "openclaw": "OpenClaw",
+    "claudecode": "Claude Code",
+    "codex": "Codex",
+    "zeptoclaw": "ZeptoClaw",
+}
+
+
+def _resolve_active_connector(cfg) -> str:
+    """Return the active connector for ``cfg``, lowercased.
+
+    Mirrors :meth:`Config.active_connector` but tolerates older
+    in-process configs that haven't been migrated yet.
+    """
+    if cfg is None:
+        return "openclaw"
+    if hasattr(cfg, "active_connector") and callable(cfg.active_connector):
+        try:
+            name = (cfg.active_connector() or "").strip().lower()
+            if name:
+                return name
+        except Exception:
+            pass
+    if hasattr(cfg, "guardrail") and hasattr(cfg.guardrail, "connector"):
+        name = (cfg.guardrail.connector or "").strip().lower()
+        if name:
+            return name
+    return "openclaw"
+
+
+def _connector_label(name: str) -> str:
+    return _CONNECTOR_LABELS.get(name, name)
+
+
+@click.group("guardrail")
+def guardrail() -> None:
+    """Toggle the LLM guardrail on or off.
+
+    Wraps ``defenseclaw setup guardrail`` with quick on/off subcommands
+    so day-to-day operators don't have to navigate the full setup flow
+    just to flip the ``guardrail.enabled`` switch.
+    """
+
+
+@guardrail.command("status")
+@pass_ctx
+def status_cmd(app: AppContext) -> None:
+    """Show whether the guardrail is enabled and which connector is active."""
+    gc = app.cfg.guardrail
+    connector = _resolve_active_connector(app.cfg)
+    click.echo()
+    click.echo("  Guardrail status")
+    click.echo("  ─────────────────")
+    click.echo(f"  • enabled:    {'yes' if gc.enabled else 'no'}")
+    click.echo(f"  • connector:  {_connector_label(connector)} ({connector})")
+    click.echo(f"  • mode:       {gc.mode or 'observe'}")
+    click.echo(f"  • port:       {gc.port}")
+    click.echo()
+    if gc.enabled:
+        click.echo("  Disable with:  defenseclaw guardrail disable")
+    else:
+        click.echo("  Enable with:   defenseclaw guardrail enable")
+    click.echo()
+
+
+@guardrail.command("disable")
+@click.option("--restart/--no-restart", default=True,
+              help="Restart the gateway after disabling (default: on; needed to run connector teardown).")
+@click.option("--yes", is_flag=True, help="Skip the confirmation prompt.")
+@pass_ctx
+def disable_cmd(app: AppContext, restart: bool, yes: bool) -> None:
+    """Disable the LLM guardrail and run connector teardown.
+
+    Sets ``guardrail.enabled = false`` in ~/.defenseclaw/config.yaml
+    and (when --restart is on, the default) restarts the gateway so the
+    sidecar boot path runs ``Connector.Teardown`` for the active
+    connector. The teardown removes hook scripts, env shims, and
+    config patches that ``Connector.Setup`` originally installed.
+    """
+    gc = app.cfg.guardrail
+    connector = _resolve_active_connector(app.cfg)
+
+    if not gc.enabled:
+        click.echo(f"  Guardrail is already disabled ({_connector_label(connector)} connector).")
+        return
+
+    click.echo()
+    click.echo(f"  Disabling guardrail for {_connector_label(connector)} ({connector})")
+    if restart:
+        click.echo("  Will restart the gateway so the connector teardown runs immediately.")
+    else:
+        click.echo("  --no-restart specified: gateway will continue running with the old policy")
+        click.echo("  until you restart it manually ('defenseclaw-gateway restart').")
+    click.echo()
+
+    if not yes and not click.confirm("  Proceed?", default=True):
+        click.echo("  Cancelled.")
+        raise SystemExit(1)
+
+    gc.enabled = False
+    try:
+        app.cfg.save()
+        click.echo("  ✓ Config saved (guardrail.enabled = false)")
+    except OSError as exc:
+        click.echo(f"  ✗ Failed to save config: {exc}", err=True)
+        click.echo("    Re-run after fixing the underlying I/O error.", err=True)
+        raise SystemExit(1)
+
+    if restart:
+        # Lazy import: cmd_setup pulls in heavy click trees we don't
+        # need when --no-restart is set, and we want this command to
+        # stay importable in environments where the operator has
+        # disabled some optional providers.
+        from defenseclaw.commands.cmd_setup import _restart_services
+
+        _restart_services(
+            app.cfg.data_dir,
+            app.cfg.gateway.host,
+            app.cfg.gateway.port,
+            connector=connector,
+        )
+        click.echo(f"  ✓ {_connector_label(connector)} connector teardown complete")
+        click.echo()
+
+    if app.logger:
+        app.logger.log_action(
+            "guardrail-disable", "config",
+            f"connector={connector} restart={restart}",
+        )
+
+
+@guardrail.command("enable")
+@click.option("--restart/--no-restart", default=True,
+              help="Restart the gateway after enabling (default: on; needed to run connector setup).")
+@click.option("--yes", is_flag=True, help="Skip the confirmation prompt.")
+@pass_ctx
+def enable_cmd(app: AppContext, restart: bool, yes: bool) -> None:
+    """Re-enable the LLM guardrail using the existing config.
+
+    This is the inverse of ``defenseclaw guardrail disable``: it sets
+    ``guardrail.enabled = true`` and (when --restart is on) restarts
+    the gateway so the sidecar runs ``Connector.Setup`` for the active
+    connector. Use ``defenseclaw setup guardrail`` instead when you
+    actually want to re-configure the model / scanner-mode / connector.
+    """
+    gc = app.cfg.guardrail
+    connector = _resolve_active_connector(app.cfg)
+
+    if gc.enabled:
+        click.echo(f"  Guardrail is already enabled ({_connector_label(connector)} connector).")
+        return
+
+    # Sanity-check that there's enough config for re-enable to actually
+    # work. If model / api_key_env are empty the connector would
+    # silently route real traffic through an unconfigured upstream, so
+    # we fail fast with a remediation pointer to the full setup flow.
+    if not (gc.model or app.cfg.llm.model):
+        click.echo(
+            "  ✗ Cannot enable: guardrail.model is not set.\n"
+            "    Run 'defenseclaw setup guardrail' to configure first.",
+            err=True,
+        )
+        raise SystemExit(1)
+
+    click.echo()
+    click.echo(f"  Enabling guardrail for {_connector_label(connector)} ({connector})")
+    if restart:
+        click.echo("  Will restart the gateway so the connector setup runs immediately.")
+    else:
+        click.echo("  --no-restart specified: enabled flag is persisted but the connector")
+        click.echo("  setup won't run until you restart the gateway manually.")
+    click.echo()
+
+    if not yes and not click.confirm("  Proceed?", default=True):
+        click.echo("  Cancelled.")
+        raise SystemExit(1)
+
+    gc.enabled = True
+    try:
+        app.cfg.save()
+        click.echo("  ✓ Config saved (guardrail.enabled = true)")
+    except OSError as exc:
+        click.echo(f"  ✗ Failed to save config: {exc}", err=True)
+        raise SystemExit(1)
+
+    if restart:
+        from defenseclaw.commands.cmd_setup import _restart_services
+
+        _restart_services(
+            app.cfg.data_dir,
+            app.cfg.gateway.host,
+            app.cfg.gateway.port,
+            connector=connector,
+        )
+        click.echo(f"  ✓ {_connector_label(connector)} connector setup complete")
+        click.echo()
+
+    if app.logger:
+        app.logger.log_action(
+            "guardrail-enable", "config",
+            f"connector={connector} restart={restart}",
+        )

--- a/cli/defenseclaw/main.py
+++ b/cli/defenseclaw/main.py
@@ -33,6 +33,7 @@ from defenseclaw.commands.cmd_audit import audit
 from defenseclaw.commands.cmd_codeguard import codeguard
 from defenseclaw.commands.cmd_config import config_cmd
 from defenseclaw.commands.cmd_doctor import doctor
+from defenseclaw.commands.cmd_guardrail import guardrail
 from defenseclaw.commands.cmd_init import init_cmd
 from defenseclaw.commands.cmd_keys import keys_cmd
 from defenseclaw.commands.cmd_mcp import mcp
@@ -153,6 +154,7 @@ cli.add_command(codeguard)
 cli.add_command(tool)
 cli.add_command(tui)
 cli.add_command(doctor)
+cli.add_command(guardrail)
 cli.add_command(sandbox)
 cli.add_command(upgrade)
 cli.add_command(keys_cmd, "keys")

--- a/cli/tests/test_cmd_guardrail.py
+++ b/cli/tests/test_cmd_guardrail.py
@@ -1,0 +1,219 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``defenseclaw guardrail {enable,disable,status}``.
+
+These commands are connector-agnostic: every code path that *modifies*
+state (config save, gateway restart) must work with all 4 built-in
+connectors and never silently corrupt config for a non-OpenClaw
+connector.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from defenseclaw.commands import cmd_guardrail
+from defenseclaw.context import AppContext
+
+
+def make_ctx(*, enabled: bool = True, connector: str = "openclaw",
+             model: str = "openai/gpt-4o", llm_model: str = ""):
+    """Build a minimal AppContext that the guardrail commands can drive."""
+    guardrail_cfg = SimpleNamespace(
+        enabled=enabled,
+        connector=connector,
+        mode="observe",
+        port=4000,
+        model=model,
+    )
+    cfg = SimpleNamespace(
+        guardrail=guardrail_cfg,
+        data_dir="/tmp/dc",
+        gateway=SimpleNamespace(host="127.0.0.1", port=18789),
+        llm=SimpleNamespace(model=llm_model, api_key_env=""),
+    )
+
+    def active_connector():
+        return guardrail_cfg.connector
+
+    cfg.active_connector = active_connector
+    cfg.save = MagicMock()
+
+    app = AppContext()
+    app.cfg = cfg
+    app.logger = MagicMock()
+    app.logger.log_action = MagicMock()
+    return app
+
+
+class ResolveActiveConnectorTests(unittest.TestCase):
+    def test_uses_active_connector_method(self):
+        cfg = SimpleNamespace()
+        cfg.active_connector = lambda: "Codex"
+        self.assertEqual(cmd_guardrail._resolve_active_connector(cfg), "codex")
+
+    def test_falls_back_to_guardrail_connector(self):
+        cfg = SimpleNamespace()
+        cfg.guardrail = SimpleNamespace(connector="claudecode")
+        self.assertEqual(cmd_guardrail._resolve_active_connector(cfg), "claudecode")
+
+    def test_method_exception_falls_back(self):
+        cfg = SimpleNamespace()
+        cfg.guardrail = SimpleNamespace(connector="zeptoclaw")
+        cfg.active_connector = lambda: (_ for _ in ()).throw(RuntimeError("x"))
+        self.assertEqual(cmd_guardrail._resolve_active_connector(cfg), "zeptoclaw")
+
+    def test_none_cfg_defaults_to_openclaw(self):
+        self.assertEqual(cmd_guardrail._resolve_active_connector(None), "openclaw")
+
+
+class StatusCommandTests(unittest.TestCase):
+    def test_status_enabled_openclaw(self):
+        runner = CliRunner()
+        app = make_ctx(enabled=True, connector="openclaw")
+        result = runner.invoke(cmd_guardrail.status_cmd, [], obj=app)
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("enabled:    yes", result.output)
+        self.assertIn("OpenClaw (openclaw)", result.output)
+        self.assertIn("disable", result.output)
+
+    def test_status_disabled_codex(self):
+        runner = CliRunner()
+        app = make_ctx(enabled=False, connector="codex")
+        result = runner.invoke(cmd_guardrail.status_cmd, [], obj=app)
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("enabled:    no", result.output)
+        self.assertIn("Codex (codex)", result.output)
+        self.assertIn("Enable with", result.output)
+
+
+class DisableCommandTests(unittest.TestCase):
+    def test_disable_already_disabled(self):
+        runner = CliRunner()
+        app = make_ctx(enabled=False, connector="codex")
+        result = runner.invoke(cmd_guardrail.disable_cmd, ["--yes"], obj=app)
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("already disabled", result.output)
+        app.cfg.save.assert_not_called()
+
+    def test_disable_persists_and_restarts_for_codex(self):
+        runner = CliRunner()
+        app = make_ctx(enabled=True, connector="codex")
+        with patch(
+            "defenseclaw.commands.cmd_setup._restart_services"
+        ) as restart_mock:
+            result = runner.invoke(cmd_guardrail.disable_cmd, ["--yes"], obj=app)
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertFalse(app.cfg.guardrail.enabled)
+        app.cfg.save.assert_called_once()
+        restart_mock.assert_called_once()
+        # Restart must propagate the active connector — otherwise the
+        # gateway would teardown the wrong adapter.
+        kwargs = restart_mock.call_args.kwargs
+        self.assertEqual(kwargs.get("connector"), "codex")
+        app.logger.log_action.assert_called_once()
+
+    def test_disable_no_restart_skips_gateway_call(self):
+        runner = CliRunner()
+        app = make_ctx(enabled=True, connector="claudecode")
+        with patch(
+            "defenseclaw.commands.cmd_setup._restart_services"
+        ) as restart_mock:
+            result = runner.invoke(
+                cmd_guardrail.disable_cmd, ["--yes", "--no-restart"], obj=app
+            )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertFalse(app.cfg.guardrail.enabled)
+        restart_mock.assert_not_called()
+        self.assertIn("--no-restart", result.output)
+
+    def test_disable_save_failure_aborts(self):
+        runner = CliRunner()
+        app = make_ctx(enabled=True, connector="zeptoclaw")
+        app.cfg.save.side_effect = OSError("disk full")
+        with patch(
+            "defenseclaw.commands.cmd_setup._restart_services"
+        ) as restart_mock:
+            result = runner.invoke(cmd_guardrail.disable_cmd, ["--yes"], obj=app)
+        self.assertNotEqual(result.exit_code, 0)
+        # When config save fails we must NOT restart the gateway, or
+        # the sidecar will see stale config and tear down a connector
+        # the operator hasn't actually disabled yet.
+        restart_mock.assert_not_called()
+
+    def test_disable_declined_aborts(self):
+        runner = CliRunner()
+        app = make_ctx(enabled=True, connector="openclaw")
+        result = runner.invoke(cmd_guardrail.disable_cmd, [], input="n\n", obj=app)
+        self.assertNotEqual(result.exit_code, 0)
+        # Must not have flipped enabled or saved.
+        self.assertTrue(app.cfg.guardrail.enabled)
+        app.cfg.save.assert_not_called()
+
+
+class EnableCommandTests(unittest.TestCase):
+    def test_enable_already_enabled(self):
+        runner = CliRunner()
+        app = make_ctx(enabled=True, connector="codex")
+        result = runner.invoke(cmd_guardrail.enable_cmd, ["--yes"], obj=app)
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("already enabled", result.output)
+        app.cfg.save.assert_not_called()
+
+    def test_enable_persists_and_restarts(self):
+        runner = CliRunner()
+        app = make_ctx(enabled=False, connector="codex")
+        with patch(
+            "defenseclaw.commands.cmd_setup._restart_services"
+        ) as restart_mock:
+            result = runner.invoke(cmd_guardrail.enable_cmd, ["--yes"], obj=app)
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertTrue(app.cfg.guardrail.enabled)
+        app.cfg.save.assert_called_once()
+        restart_mock.assert_called_once()
+        kwargs = restart_mock.call_args.kwargs
+        self.assertEqual(kwargs.get("connector"), "codex")
+
+    def test_enable_aborts_when_no_model_configured(self):
+        runner = CliRunner()
+        app = make_ctx(enabled=False, connector="openclaw", model="", llm_model="")
+        result = runner.invoke(cmd_guardrail.enable_cmd, ["--yes"], obj=app)
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("guardrail.model is not set", result.output)
+        # Must NOT silently flip enabled to True.
+        self.assertFalse(app.cfg.guardrail.enabled)
+        app.cfg.save.assert_not_called()
+
+    def test_enable_uses_top_level_llm_model_as_fallback(self):
+        runner = CliRunner()
+        app = make_ctx(enabled=False, connector="codex", model="", llm_model="openai/gpt-4o")
+        with patch("defenseclaw.commands.cmd_setup._restart_services"):
+            result = runner.invoke(cmd_guardrail.enable_cmd, ["--yes"], obj=app)
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertTrue(app.cfg.guardrail.enabled)
+
+
+class CommandRegistrationTests(unittest.TestCase):
+    def test_guardrail_group_exposes_three_subcommands(self):
+        names = set(cmd_guardrail.guardrail.commands.keys())
+        self.assertEqual(names, {"enable", "disable", "status"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add a top-level \`defenseclaw guardrail\` command group with three quick toggle subcommands so day-to-day operators have a fast on/off switch instead of re-running the full \`defenseclaw setup guardrail\` flow every time.

\`\`\`
defenseclaw guardrail status      # is it on, which connector, which mode
defenseclaw guardrail enable      # turn on  + connector setup
defenseclaw guardrail disable     # turn off + connector teardown
\`\`\`

## Connector polymorphism (S7 wave)

Both \`enable\` and \`disable\` resolve the active connector from \`Config.active_connector()\` and propagate the resolved name into \`_restart_services(connector=...)\`. The Go sidecar's boot path runs \`Connector.Setup\` / \`Connector.Teardown\` for the right adapter — so this CLI never has to know how Codex / Claude Code / ZeptoClaw configure themselves.

## Safety guarantees

- \`disable\` aborts before restarting if config save fails — otherwise the sidecar would tear down a connector the operator never actually disabled.
- \`enable\` refuses to flip the flag when \`guardrail.model\` and \`llm.model\` are both empty — re-enabling without a configured upstream would silently route real traffic through nothing.
- \`--no-restart\` is supported with explicit messaging that the setup/teardown won't run until the operator restarts the gateway manually.
- Confirmation prompt + \`--yes\` flag for non-interactive flows.

## Test plan

- [x] \`pytest cli/tests/test_cmd_guardrail.py\` — 16 cases
- [x] Active-connector resolution: method → guardrail.connector → \"openclaw\"
- [x] Status output for enabled vs disabled, openclaw vs codex
- [x] Disable for codex / claudecode / zeptoclaw / openclaw, including save-failure abort and decline-confirmation abort
- [x] \`--no-restart\` flag does NOT call \`_restart_services\`
- [x] Restart call propagates the resolved connector (the gateway must teardown the right adapter)
- [x] Enable refuses when both \`guardrail.model\` and \`llm.model\` are empty
- [x] Enable accepts \`llm.model\` as fallback when \`guardrail.model\` is empty
- [x] CLI registration smoke test confirms exactly {enable, disable, status} are exposed

Stacked on top of #190 (S7.3).