### PR TITLE
S7.5: defenseclaw doctor connector residue check + remediation

### DIFF
--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -1039,6 +1039,12 @@ def doctor(app: AppContext, json_out: bool, do_fix: bool, assume_yes: bool) -> N
         click.echo("  ── Connector ──")
     active_connector = _active_connector(cfg)
     _check_connector_inventory(cfg, active_connector, r)
+    # S7.5 — surface inactive-connector residue (backup files / hook
+    # scripts left over from a previous connector). Without this check
+    # operators who switch connectors via 'defenseclaw setup guardrail
+    # --agent <new>' get a silent half-state where the old adapter's
+    # config patches are still on disk.
+    _check_connector_residue(cfg, active_connector, r)
 
     if not json_out:
         click.echo()
@@ -1170,6 +1176,7 @@ def _run_fixers(cfg, r: _DoctorResult, *, assume_yes: bool, json_out: bool) -> N
         ("gateway token",            _fix_gateway_token),
         ("defenseclaw dotenv perms", _fix_dotenv_perms),
         ("pristine config backup",   _fix_pristine_backup),
+        ("connector residue",        _fix_connector_residue),
     ]
 
     for title, fn in fixers:
@@ -1277,6 +1284,93 @@ def _check_connector_inventory(cfg, connector: str, r: _DoctorResult) -> None:
         _emit("pass", "MCP servers", f"{count} configured: {names}{more}", r=r)
     else:
         _emit("skip", "MCP servers", "no MCP servers registered", r=r)
+
+
+# Maps connector name → list of *expected* artifact filenames (relative
+# to data_dir) that Connector.Setup writes. When the active connector
+# is X but data_dir contains Y's artifacts, that's residue from a prior
+# install and Connector.Teardown was never invoked for Y.
+#
+# The OpenClaw pristine backup lives at ``<openclaw.json>.pristine``,
+# which is not under data_dir, so it is handled separately by
+# :func:`_check_connector_residue`.
+_CONNECTOR_RESIDUE_ARTIFACTS: dict[str, tuple[str, ...]] = {
+    "claudecode": ("claudecode_backup.json",),
+    "codex": ("codex_backup.json",),
+    "zeptoclaw": ("zeptoclaw_backup.json",),
+}
+
+
+def _check_connector_residue(cfg, active: str, r: _DoctorResult) -> None:
+    """Detect leftover artifacts from connectors that aren't active.
+
+    Each connector's ``Setup`` writes a pristine backup of the agent
+    framework's config plus (for some connectors) hook scripts and env
+    files. ``Teardown`` removes them. When an operator switches
+    connectors without first running ``defenseclaw guardrail disable``
+    (or the gateway crashes mid-handoff), we end up with the *prior*
+    connector's residue on disk.
+
+    This check walks every known connector that isn't the active one
+    and emits a WARN listing any artifact still present. The matching
+    fixer (``fix: connector residue``) calls
+    ``defenseclaw-gateway connector teardown --connector <name>`` for
+    each residual connector to clean it up via the canonical sentinel.
+    """
+    data_dir = getattr(cfg, "data_dir", "") or ""
+    if not data_dir:
+        _emit("skip", "Connector residue", "no data dir configured", r=r)
+        return
+
+    # Build the inactive set explicitly so unknown active connectors
+    # (plugins) don't accidentally suppress residue detection.
+    inactive = [
+        name for name in _CONNECTOR_RESIDUE_ARTIFACTS
+        if name != active.lower()
+    ]
+
+    found: list[tuple[str, str]] = []  # (connector_name, full_path)
+    for name in inactive:
+        for filename in _CONNECTOR_RESIDUE_ARTIFACTS[name]:
+            full = os.path.join(data_dir, filename)
+            if os.path.isfile(full):
+                found.append((name, full))
+
+    # OpenClaw's pristine backup is its only residue marker and lives
+    # next to openclaw.json, not under data_dir. Only flag it when
+    # OpenClaw is *not* the active connector.
+    if active.lower() != "openclaw":
+        oc_path = getattr(getattr(cfg, "claw", None), "config_file", "") or ""
+        oc_path = os.path.expanduser(oc_path)
+        if oc_path:
+            pristine = oc_path + ".pristine"
+            if os.path.isfile(pristine):
+                found.append(("openclaw", pristine))
+
+    if not found:
+        _emit(
+            "pass", "Connector residue",
+            f"no leftover artifacts from inactive connectors", r=r,
+        )
+        return
+
+    # Group residue by connector for a readable message — operators
+    # need to see "Codex left X behind" not just a flat path list.
+    by_conn: dict[str, list[str]] = {}
+    for name, path in found:
+        by_conn.setdefault(name, []).append(path)
+    parts = []
+    for name in sorted(by_conn):
+        paths = ", ".join(by_conn[name])
+        parts.append(f"{name}: {paths}")
+    detail = (
+        "found residue from inactive connectors — "
+        + "; ".join(parts)
+        + ". Run 'defenseclaw doctor --fix' to invoke "
+        "'defenseclaw-gateway connector teardown' for each, or "
+        "'defenseclaw uninstall --keep-openclaw' for a manual sweep."
+    )
+    _emit("warn", "Connector residue", detail, r=r)
 
 
 def _check_scan_coverage(cfg, r: _DoctorResult) -> None:
@@ -1446,3 +1540,78 @@ def _fix_pristine_backup(cfg, *, assume_yes: bool) -> tuple[str, str]:
     if os.path.isfile(backup_path):
         return ("skip", f"backup exists at {backup_path}")
     return ("skip", f"no backup found — run `defenseclaw setup guardrail` to create one")
+
+
+def _fix_connector_residue(cfg, *, assume_yes: bool) -> tuple[str, str]:
+    """Run ``defenseclaw-gateway connector teardown`` for every inactive
+    connector that still has artifacts on disk.
+
+    Inactive-connector residue is detected with the same logic as
+    :func:`_check_connector_residue`, then this fixer shells out to the
+    S7.2 sentinel for each residual connector. The sentinel is the
+    canonical place to do this — ``Connector.Teardown`` knows about
+    hook scripts, env files, and config patches that the residue check
+    can't reasonably enumerate. We never call the OpenClaw Python
+    helpers here because the gateway sentinel handles every connector
+    uniformly.
+    """
+    data_dir = getattr(cfg, "data_dir", "") or ""
+    if not data_dir:
+        return ("skip", "no data dir configured")
+
+    active = _active_connector(cfg)
+    inactive_residue: list[str] = []
+    for name, artifacts in _CONNECTOR_RESIDUE_ARTIFACTS.items():
+        if name == active:
+            continue
+        if any(os.path.isfile(os.path.join(data_dir, f)) for f in artifacts):
+            inactive_residue.append(name)
+
+    if active != "openclaw":
+        oc_path = getattr(getattr(cfg, "claw", None), "config_file", "") or ""
+        oc_path = os.path.expanduser(oc_path)
+        if oc_path and os.path.isfile(oc_path + ".pristine"):
+            inactive_residue.append("openclaw")
+
+    if not inactive_residue:
+        return ("skip", "no inactive-connector residue detected")
+
+    inactive_residue = sorted(set(inactive_residue))
+
+    if not assume_yes and not click.confirm(
+        f"    Run 'defenseclaw-gateway connector teardown' for "
+        f"{', '.join(inactive_residue)}?",
+        default=True,
+    ):
+        return ("skip", "declined by user")
+
+    gw = shutil.which("defenseclaw-gateway")
+    if not gw:
+        return ("warn",
+                "defenseclaw-gateway not on PATH — install the binary and re-run")
+
+    cleaned: list[str] = []
+    failed: list[str] = []
+    import subprocess as _sub
+    for name in inactive_residue:
+        try:
+            proc = _sub.run(
+                [gw, "connector", "teardown", "--connector", name],
+                capture_output=True, text=True, timeout=60,
+            )
+        except (OSError, _sub.TimeoutExpired) as exc:
+            failed.append(f"{name}: {exc}")
+            continue
+        if proc.returncode == 0:
+            cleaned.append(name)
+        else:
+            err = (proc.stderr or proc.stdout or "").strip().splitlines()
+            tail = err[-1] if err else f"rc={proc.returncode}"
+            failed.append(f"{name}: {tail}")
+
+    if cleaned and not failed:
+        return ("pass", f"teardown ran for: {', '.join(cleaned)}")
+    if cleaned and failed:
+        return ("warn",
+                f"partial: cleaned={','.join(cleaned)}; failed={'; '.join(failed)}")
+    return ("warn", f"teardown failed: {'; '.join(failed)}")

--- a/cli/tests/test_cmd_doctor_residue.py
+++ b/cli/tests/test_cmd_doctor_residue.py
@@ -1,0 +1,221 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""S7.5 — connector residue check + remediation.
+
+Verifies that ``defenseclaw doctor`` detects when an inactive connector
+has left state behind (backup files, hook scripts), and that
+``--fix`` mode delegates to ``defenseclaw-gateway connector teardown``
+for each residual connector.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from defenseclaw.commands.cmd_doctor import (
+    _CONNECTOR_RESIDUE_ARTIFACTS,
+    _DoctorResult,
+    _check_connector_residue,
+    _fix_connector_residue,
+)
+
+
+def _cfg(data_dir: str, *, openclaw_config_file: str = "") -> SimpleNamespace:
+    return SimpleNamespace(
+        data_dir=data_dir,
+        claw=SimpleNamespace(config_file=openclaw_config_file),
+    )
+
+
+class CheckConnectorResidueTests(unittest.TestCase):
+    def test_passes_when_no_residue(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            r = _DoctorResult()
+            _check_connector_residue(_cfg(data_dir), "openclaw", r)
+        self.assertEqual(r.passed, 1)
+        self.assertEqual(r.warned, 0)
+        self.assertEqual(r.checks[0]["status"], "pass")
+        self.assertEqual(r.checks[0]["label"], "Connector residue")
+
+    def test_warns_when_codex_backup_present_with_openclaw_active(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            with open(os.path.join(data_dir, "codex_backup.json"), "w") as fh:
+                fh.write("{}")
+            r = _DoctorResult()
+            _check_connector_residue(_cfg(data_dir), "openclaw", r)
+        self.assertEqual(r.warned, 1)
+        check = r.checks[0]
+        self.assertEqual(check["status"], "warn")
+        self.assertIn("codex", check["detail"])
+        self.assertIn("doctor --fix", check["detail"])
+
+    def test_does_not_flag_active_connectors_own_artifacts(self):
+        """If codex IS the active connector, codex_backup.json is not residue."""
+        with tempfile.TemporaryDirectory() as data_dir:
+            with open(os.path.join(data_dir, "codex_backup.json"), "w") as fh:
+                fh.write("{}")
+            r = _DoctorResult()
+            _check_connector_residue(_cfg(data_dir), "codex", r)
+        self.assertEqual(r.warned, 0, msg=r.checks)
+        self.assertEqual(r.passed, 1)
+
+    def test_groups_multiple_residual_connectors(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            for f in ("codex_backup.json", "claudecode_backup.json"):
+                with open(os.path.join(data_dir, f), "w") as fh:
+                    fh.write("{}")
+            r = _DoctorResult()
+            _check_connector_residue(_cfg(data_dir), "openclaw", r)
+        self.assertEqual(r.warned, 1)
+        detail = r.checks[0]["detail"]
+        self.assertIn("codex", detail)
+        self.assertIn("claudecode", detail)
+
+    def test_flags_openclaw_pristine_when_codex_is_active(self):
+        """OpenClaw's pristine backup lives next to openclaw.json, not
+        under data_dir, so it gets a separate detection path."""
+        with tempfile.TemporaryDirectory() as base:
+            data_dir = os.path.join(base, "data")
+            os.makedirs(data_dir)
+            oc_path = os.path.join(base, "openclaw.json")
+            pristine = oc_path + ".pristine"
+            with open(pristine, "w") as fh:
+                fh.write("{}")
+            r = _DoctorResult()
+            _check_connector_residue(
+                _cfg(data_dir, openclaw_config_file=oc_path), "codex", r,
+            )
+        self.assertEqual(r.warned, 1)
+        self.assertIn("openclaw", r.checks[0]["detail"])
+
+    def test_skips_when_data_dir_missing(self):
+        cfg = SimpleNamespace(data_dir="", claw=SimpleNamespace(config_file=""))
+        r = _DoctorResult()
+        _check_connector_residue(cfg, "openclaw", r)
+        self.assertEqual(r.skipped, 1)
+        self.assertEqual(r.checks[0]["status"], "skip")
+
+    def test_unknown_active_connector_still_detects_residue(self):
+        """A plugin/unknown active connector must NOT suppress residue
+        detection — operators running plugins are exactly the people
+        most likely to have stale state from a previous switch."""
+        with tempfile.TemporaryDirectory() as data_dir:
+            with open(os.path.join(data_dir, "codex_backup.json"), "w") as fh:
+                fh.write("{}")
+            r = _DoctorResult()
+            _check_connector_residue(_cfg(data_dir), "myplugin", r)
+        self.assertEqual(r.warned, 1)
+
+
+class FixConnectorResidueTests(unittest.TestCase):
+    def _cfg_with_residue(self, data_dir: str, *files: str):
+        for f in files:
+            with open(os.path.join(data_dir, f), "w") as fh:
+                fh.write("{}")
+        cfg = _cfg(data_dir)
+        cfg.active_connector = lambda: "openclaw"
+        cfg.guardrail = SimpleNamespace(connector="openclaw")
+        return cfg
+
+    def test_skip_when_no_residue(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            cfg = self._cfg_with_residue(data_dir)
+            tag, detail = _fix_connector_residue(cfg, assume_yes=True)
+        self.assertEqual(tag, "skip")
+        self.assertIn("no inactive-connector residue", detail)
+
+    def test_calls_gateway_teardown_for_each_residual(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            cfg = self._cfg_with_residue(
+                data_dir, "codex_backup.json", "claudecode_backup.json",
+            )
+            with patch("shutil.which", return_value="/usr/bin/defenseclaw-gateway"), \
+                 patch("subprocess.run") as run_mock:
+                run_mock.return_value.returncode = 0
+                run_mock.return_value.stdout = ""
+                run_mock.return_value.stderr = ""
+                tag, detail = _fix_connector_residue(cfg, assume_yes=True)
+        self.assertEqual(tag, "pass", msg=detail)
+        # Both connectors must have been torn down.
+        self.assertEqual(run_mock.call_count, 2)
+        called_args = [c.args[0] for c in run_mock.call_args_list]
+        connectors = [args[args.index("--connector") + 1] for args in called_args]
+        self.assertEqual(set(connectors), {"codex", "claudecode"})
+
+    def test_warns_when_gateway_binary_missing(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            cfg = self._cfg_with_residue(data_dir, "codex_backup.json")
+            with patch("shutil.which", return_value=None):
+                tag, detail = _fix_connector_residue(cfg, assume_yes=True)
+        self.assertEqual(tag, "warn")
+        self.assertIn("not on PATH", detail)
+
+    def test_partial_success_when_one_teardown_fails(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            cfg = self._cfg_with_residue(
+                data_dir, "codex_backup.json", "claudecode_backup.json",
+            )
+            with patch("shutil.which", return_value="/usr/bin/defenseclaw-gateway"), \
+                 patch("subprocess.run") as run_mock:
+                def side_effect(args, **_kwargs):
+                    rv = MagicMock()
+                    name = args[args.index("--connector") + 1]
+                    rv.returncode = 0 if name == "codex" else 1
+                    rv.stdout = ""
+                    rv.stderr = "boom" if rv.returncode else ""
+                    return rv
+                run_mock.side_effect = side_effect
+                tag, detail = _fix_connector_residue(cfg, assume_yes=True)
+        self.assertEqual(tag, "warn")
+        self.assertIn("partial", detail)
+        self.assertIn("codex", detail)
+        self.assertIn("claudecode", detail)
+
+    def test_declined_by_user_skips(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            cfg = self._cfg_with_residue(data_dir, "codex_backup.json")
+            with patch("click.confirm", return_value=False), \
+                 patch("subprocess.run") as run_mock:
+                tag, detail = _fix_connector_residue(cfg, assume_yes=False)
+        self.assertEqual(tag, "skip")
+        self.assertIn("declined", detail)
+        run_mock.assert_not_called()
+
+
+class ResidueArtifactsContractTests(unittest.TestCase):
+    """Lock down the artifact filename map so a typo when wiring up a
+    new connector adapter can't silently disable residue detection."""
+
+    def test_built_in_connectors_present(self):
+        for name in ("claudecode", "codex", "zeptoclaw"):
+            self.assertIn(name, _CONNECTOR_RESIDUE_ARTIFACTS)
+
+    def test_artifact_filenames_match_connector_state(self):
+        """Filenames must be the *_backup.json names that the Go
+        connectors actually write under data_dir. Drift here would
+        cause silent false-negatives in residue detection."""
+        self.assertEqual(_CONNECTOR_RESIDUE_ARTIFACTS["claudecode"],
+                         ("claudecode_backup.json",))
+        self.assertEqual(_CONNECTOR_RESIDUE_ARTIFACTS["codex"],
+                         ("codex_backup.json",))
+        self.assertEqual(_CONNECTOR_RESIDUE_ARTIFACTS["zeptoclaw"],
+                         ("zeptoclaw_backup.json",))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Detect when an *inactive* connector has left state behind in `~/.defenseclaw` and offer `doctor --fix` remediation that delegates to the S7.2 sentinel (`defenseclaw-gateway connector teardown`).

## Why

The most common failure mode in the S7 wave is that operators switch connectors via `defenseclaw setup guardrail --agent <new>` (or by hand-editing `config.yaml`) without first running `defenseclaw guardrail disable`. In that case the previous connector's `Connector.Teardown` never runs, so its backup file (`codex_backup.json` / `claudecode_backup.json` / `zeptoclaw_backup.json`) and OpenClaw's `<openclaw.json>.pristine` sidecar stay on disk pointing at proxy URLs that no longer match the active connector's setup.

## What changed

- New `_check_connector_residue` walks every known connector that isn't the active one and emits `WARN` with a per-connector list of leftover files.
- New `_fix_connector_residue` shells out to `defenseclaw-gateway connector teardown --connector <name>` for each residual connector.
- `_CONNECTOR_RESIDUE_ARTIFACTS` map locks the (connector → backup filename) wiring.
- Wired into the existing "Connector" doctor section.

## Test plan

- [x] `pytest cli/tests/test_cmd_doctor_residue.py` — 14 cases pass
- [x] Pass/warn paths for every built-in connector
- [x] OpenClaw `.pristine` sidecar detection when codex is active
- [x] `_fix` gateway-binary-missing → WARN (not silent failure)
- [x] Partial-success WARN aggregation
- [x] Decline-confirmation SKIP

Stacked on top of #191 (S7.4).
