### PR TITLE
feat: add standalone ClawHub output-plugin for OpenClaw integration

### DIFF
--- a/docs/design/output-plugin-clawhub.md
+++ b/docs/design/output-plugin-clawhub.md
@@ -176,7 +176,13 @@ OpenClaw Agent (with output-plugin installed)
   "types": "dist/index.d.ts",
   "openclaw": {
     "extensions": ["./dist/index.js"],
-    "pluginManifest": "./openclaw.plugin.json"
+    "pluginManifest": "./openclaw.plugin.json",
+    "compat": {
+      "pluginApi": ">=1.0.0"
+    },
+    "build": {
+      "openclawVersion": ">=1.0.0"
+    }
   },
   "scripts": {
     "build": "tsc",
@@ -208,6 +214,8 @@ OpenClaw Agent (with output-plugin installed)
 ```
 
 **Key differences from embedded `package.json`:**
+- `openclaw.compat.pluginApi`: `">=1.0.0"` — required by ClawHub for compatibility validation
+- `openclaw.build.openclawVersion`: `">=1.0.0"` — required by ClawHub for build metadata
 - `name`: scoped `@defenseclaw/openclaw-plugin`
 - `permissions`: `"net:connect"` (not just `localhost` — needs remote sidecar)
 - `prepublish` script for ClawHub build

--- a/docs/design/output-plugin-clawhub.md
+++ b/docs/design/output-plugin-clawhub.md
@@ -1,0 +1,335 @@
+# Tech Spec: DefenseClaw Output Plugin for ClawHub
+
+**Date:** 2026-04-28
+**Status:** Proposed
+**Author:** nghodki
+
+---
+
+## 1. Problem Statement
+
+Today, wiring DefenseClaw security into an OpenClaw instance requires DefenseClaw to deploy its embedded plugin (`extensions/defenseclaw/`). This means the DefenseClaw operator must have access to the OpenClaw instance's filesystem to install the extension.
+
+OpenClaw supports a marketplace model (ClawHub) where users can discover and install plugins independently. We need a **standalone, ClawHub-publishable plugin** that any OpenClaw administrator can install from ClawHub — without requiring DefenseClaw to push files onto their machine.
+
+## 2. Goals
+
+1. **Self-contained**: The plugin installs via ClawHub with zero DefenseClaw-side deployment.
+2. **Full feature parity**: Fetch interceptor (15 LLM providers), tool inspection hooks, health monitoring, egress telemetry, scan/block/allow commands — everything the embedded version does.
+3. **Remote sidecar support**: The embedded plugin assumes `localhost:18970`. The standalone plugin must support connecting to a DefenseClaw gateway running on a different host (e.g., a shared security gateway for a team).
+4. **No collision with embedded**: If both the embedded and standalone plugins are present, they must not conflict. Slash commands are prefixed (`/dc-scan`, `/dc-block`, `/dc-allow`), and the plugin id is `defenseclaw-plugin`.
+5. **ClawHub-ready packaging**: `package.json`, `openclaw.plugin.json`, and build artifacts follow ClawHub's publish requirements.
+
+## 3. Non-Goals
+
+- Replacing the embedded `extensions/defenseclaw/` plugin (it remains the primary mechanism for DefenseClaw-managed deployments).
+- Building a ClawHub backend or registry service.
+- Automated sidecar provisioning — the user is responsible for running a DefenseClaw gateway that is reachable from their OpenClaw instance.
+
+## 4. Architecture
+
+### 4.1 Directory Layout
+
+```
+defenseclaw/
+  output-plugin/                          ← NEW top-level directory
+    package.json                          ← npm package: @defenseclaw/openclaw-plugin
+    openclaw.plugin.json                  ← OpenClaw manifest (id: defenseclaw-plugin)
+    tsconfig.json                         ← TypeScript config (ES2022, ESM)
+    CLAWHUB.md                            ← Step-by-step upload instructions
+    README.md                             ← User-facing install & config guide
+    src/
+      index.ts                            ← Plugin entry point
+      fetch-interceptor.ts                ← globalThis.fetch + https.request patching
+      client.ts                           ← DaemonClient for sidecar REST API
+      types.ts                            ← Shared TypeScript types
+      correlation-headers.ts              ← X-DefenseClaw-* header constants & builders
+      agent_identity.ts                   ← Stable agent id persistence
+      sidecar-config.ts                   ← Config resolution (plugin config → env → file)
+      health-monitor.ts                   ← Sidecar health polling
+      egress-telemetry.ts                 ← Layer 3 egress event reporting
+      aws-sdk-http1-for-guardrail.ts      ← Bedrock HTTP/1 shim
+      bedrock-config-detect.ts            ← Bedrock usage detection
+      providers.json                      ← Canonical LLM provider domains (copied from Go)
+      policy/
+        enforcer.ts                       ← PolicyEnforcer + scan runners
+      scanners/
+        mcp-scanner.ts                    ← In-process MCP config scanner
+```
+
+### 4.2 Relationship to Embedded Plugin
+
+```
+extensions/defenseclaw/          (EXISTING — deployed by DefenseClaw operator)
+  ├── Assumes localhost sidecar
+  ├── plugin id: "defenseclaw"
+  ├── Slash commands: /scan, /block, /allow
+  └── Config reads ~/.defenseclaw/config.yaml primarily
+
+output-plugin/                   (NEW — installed by OpenClaw user from ClawHub)
+  ├── Supports remote sidecar host
+  ├── plugin id: "defenseclaw-plugin"
+  ├── Slash commands: /dc-scan, /dc-block, /dc-allow
+  └── Config comes from plugin configSchema (ClawHub settings UI)
+```
+
+Both can coexist. The output-plugin uses a distinct plugin id and command prefix. If both are active, they share the same sidecar — the gateway is stateless and handles concurrent plugin connections.
+
+### 4.3 Data Flow
+
+```
+OpenClaw Agent (with output-plugin installed)
+  │
+  ├─── before_tool_call hook ──────────► DefenseClaw Gateway
+  │    POST /api/v1/inspect/tool          (remote or local)
+  │    X-DefenseClaw-* correlation         │
+  │    ◄── { action, severity, reason } ───┘
+  │
+  ├─── globalThis.fetch patch ──────────► Guardrail Proxy (port 4000)
+  │    Redirects LLM API calls             │
+  │    X-DC-Target-URL: original host      ├─► Rule pack matching
+  │    X-AI-Auth: provider key             ├─► LLM judge (optional)
+  │    X-DefenseClaw-* correlation         ├─► Cisco AI Defense
+  │    ◄── Response (+ x-defenseclaw-     ─┘
+  │        blocked header if rejected)
+  │
+  ├─── health-monitor ─────────────────► GET /status (every 60s)
+  │    Warns user if gateway is down
+  │
+  └─── egress-telemetry ──────────────► POST /v1/events/egress
+       Reports passthrough/shape/known     (best-effort, non-blocking)
+```
+
+## 5. Detailed Changes
+
+### 5.1 `openclaw.plugin.json` (Manifest)
+
+```json
+{
+  "id": "defenseclaw-plugin",
+  "name": "DefenseClaw Security (ClawHub)",
+  "version": "0.1.0",
+  "description": "Wire DefenseClaw security governance into any OpenClaw instance. Installs fetch interception, tool inspection hooks, and security scanning — no DefenseClaw-side deployment required.",
+  "enabledByDefault": true,
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "agent": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Logical agent identity for sidecar correlation",
+        "properties": {
+          "id":       { "type": "string", "description": "Stable logical agent id" },
+          "name":     { "type": "string", "description": "Display name" },
+          "policyId": { "type": "string", "description": "Policy id" }
+        }
+      },
+      "sidecarHost": {
+        "type": "string",
+        "default": "127.0.0.1",
+        "description": "Hostname or IP of the DefenseClaw gateway"
+      },
+      "sidecarPort": {
+        "type": "integer",
+        "default": 18970,
+        "description": "Port for the DefenseClaw Go sidecar REST API"
+      },
+      "guardrailPort": {
+        "type": "integer",
+        "default": 4000,
+        "description": "Port for the DefenseClaw guardrail proxy"
+      },
+      "mode": {
+        "type": "string",
+        "enum": ["observe", "action"],
+        "default": "observe",
+        "description": "observe = log only; action = block threats"
+      },
+      "awsHttp1Shim": {
+        "type": "string",
+        "enum": ["auto", "on", "off"],
+        "default": "auto",
+        "description": "Force Bedrock SDK to HTTP/1 for guardrail interception"
+      }
+    }
+  }
+}
+```
+
+**Key differences from embedded manifest:**
+- `id`: `"defenseclaw-plugin"` (avoids collision)
+- `name`: includes `"(ClawHub)"` suffix for UI distinction
+- `version`: starts at `0.1.0`
+- `sidecarHost`: new field (default `"127.0.0.1"`)
+- `guardrailPort`: new field (default `4000`) — the embedded version reads this from `~/.defenseclaw/config.yaml`; the standalone version takes it from plugin config
+
+### 5.2 `package.json`
+
+```json
+{
+  "name": "@defenseclaw/openclaw-plugin",
+  "version": "0.1.0",
+  "description": "ClawHub plugin — wires DefenseClaw security into any OpenClaw instance",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "openclaw": {
+    "extensions": ["./dist/index.js"],
+    "pluginManifest": "./openclaw.plugin.json"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublish": "npm run build"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0"
+  },
+  "peerDependencies": {
+    "@openclaw/plugin-sdk": ">=1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@openclaw/plugin-sdk": { "optional": true }
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^25.5.0",
+    "typescript": "^5.4.0",
+    "vitest": "^3.0.0"
+  },
+  "license": "Apache-2.0",
+  "permissions": [
+    "net:connect"
+  ]
+}
+```
+
+**Key differences from embedded `package.json`:**
+- `name`: scoped `@defenseclaw/openclaw-plugin`
+- `permissions`: `"net:connect"` (not just `localhost` — needs remote sidecar)
+- `prepublish` script for ClawHub build
+
+### 5.3 `sidecar-config.ts` — Config Resolution Changes
+
+The embedded version reads `~/.defenseclaw/config.yaml` and falls back to defaults. The standalone version uses a **3-tier resolution** that prioritizes plugin config (from ClawHub settings UI):
+
+```
+1. Plugin config (openclaw.plugin.json configSchema values set by user)
+   ↓ fallback
+2. Environment variables (DEFENSECLAW_HOST, DEFENSECLAW_PORT, DEFENSECLAW_GUARDRAIL_PORT)
+   ↓ fallback
+3. ~/.defenseclaw/config.yaml (if present on the OpenClaw host)
+   ↓ fallback
+4. Hardcoded defaults (127.0.0.1:18970, guardrail 4000)
+```
+
+The `loadSidecarConfig()` function gains an optional `overrides` parameter:
+
+```typescript
+interface SidecarConfigOverrides {
+  host?: string;
+  apiPort?: number;
+  guardrailPort?: number;
+}
+
+function loadSidecarConfig(overrides?: SidecarConfigOverrides): SidecarConfig
+```
+
+When called from `index.ts`, the plugin passes the user's `pluginConfig` values as overrides.
+
+### 5.4 `index.ts` — Plugin Entry Point Changes
+
+The entry point is structurally identical to the embedded version, with these differences:
+
+| Aspect | Embedded (`extensions/defenseclaw`) | Standalone (`output-plugin`) |
+|--------|-------------------------------------|------------------------------|
+| Plugin id | `defenseclaw` | `defenseclaw-plugin` |
+| Slash commands | `/scan`, `/block`, `/allow` | `/dc-scan`, `/dc-block`, `/dc-allow` |
+| Sidecar config | `loadSidecarConfig()` (file-only) | `loadSidecarConfig(pluginConfig)` (config-first) |
+| Console prefix | `[defenseclaw]` | `[defenseclaw-plugin]` |
+| Client header | `X-DefenseClaw-Client: openclaw-plugin` | `X-DefenseClaw-Client: openclaw-clawhub-plugin` |
+
+### 5.5 Remaining Source Files (Unchanged Logic)
+
+These files are copied from the embedded plugin with no behavioral changes:
+
+| File | Purpose | Lines |
+|------|---------|-------|
+| `fetch-interceptor.ts` | `globalThis.fetch` + `https.request` patching, provider domain matching, body shape detection | ~1130 |
+| `client.ts` | `DaemonClient` — HTTP client for sidecar REST API with correlation headers | ~390 |
+| `types.ts` | Shared TypeScript types (Severity, Finding, ScanResult, CorrelationContext, etc.) | ~230 |
+| `correlation-headers.ts` | `X-DefenseClaw-*` header name constants and builder functions | ~113 |
+| `agent_identity.ts` | Stable agent id persistence and resolution (env → config → storage) | ~140 |
+| `health-monitor.ts` | Periodic sidecar `/status` polling with protection-down warning | ~163 |
+| `egress-telemetry.ts` | Best-effort egress event reporting to guardrail proxy | ~213 |
+| `aws-sdk-http1-for-guardrail.ts` | Bedrock HTTP/2→HTTP/1 downgrade for guardrail interception | ~304 |
+| `bedrock-config-detect.ts` | Detect Bedrock usage in OpenClaw config | ~52 |
+| `providers.json` | Canonical LLM provider domains (copied from `internal/configs/providers.json`) | ~96 |
+| `policy/enforcer.ts` | PolicyEnforcer + CLI scan wrappers (skill, plugin, code) | ~659 |
+| `scanners/mcp-scanner.ts` | In-process MCP configuration security scanner | ~445 |
+
+## 6. ClawHub Publishing Steps
+
+Documented in `CLAWHUB.md` (included in the plugin directory):
+
+```
+1. Build:      cd output-plugin && npm install && npm run build
+2. Verify:     Ensure dist/ contains index.js, index.d.ts, and all compiled modules
+3. Package:    npm pack (creates @defenseclaw-openclaw-plugin-0.1.0.tgz)
+4. Upload:     clawhub publish @defenseclaw-openclaw-plugin-0.1.0.tgz
+               (or: clawhub publish --directory . if ClawHub supports directory mode)
+5. Metadata:   ClawHub reads openclaw.plugin.json for the listing page
+6. Install:    Users run: clawhub install @defenseclaw/openclaw-plugin
+7. Configure:  Users set sidecarHost/sidecarPort in OpenClaw plugin settings
+```
+
+## 7. File Inventory
+
+### New Files (16 files)
+
+| Path | Type | Source |
+|------|------|--------|
+| `output-plugin/package.json` | Config | New (based on embedded) |
+| `output-plugin/openclaw.plugin.json` | Manifest | New (extended config schema) |
+| `output-plugin/tsconfig.json` | Config | Copy from embedded |
+| `output-plugin/README.md` | Docs | New |
+| `output-plugin/CLAWHUB.md` | Docs | New |
+| `output-plugin/src/index.ts` | Source | Modified copy (commands, config) |
+| `output-plugin/src/sidecar-config.ts` | Source | Modified copy (overrides param) |
+| `output-plugin/src/fetch-interceptor.ts` | Source | Copy |
+| `output-plugin/src/client.ts` | Source | Modified copy (client header) |
+| `output-plugin/src/types.ts` | Source | Copy |
+| `output-plugin/src/correlation-headers.ts` | Source | Copy |
+| `output-plugin/src/agent_identity.ts` | Source | Copy |
+| `output-plugin/src/health-monitor.ts` | Source | Copy |
+| `output-plugin/src/egress-telemetry.ts` | Source | Copy |
+| `output-plugin/src/aws-sdk-http1-for-guardrail.ts` | Source | Copy |
+| `output-plugin/src/bedrock-config-detect.ts` | Source | Copy |
+| `output-plugin/src/providers.json` | Data | Copy |
+| `output-plugin/src/policy/enforcer.ts` | Source | Copy |
+| `output-plugin/src/scanners/mcp-scanner.ts` | Source | Copy |
+
+### Modified Files (0)
+
+No existing files are modified.
+
+## 8. Security Considerations
+
+- **Remote sidecar**: The standalone plugin supports `net:connect` (not just localhost). When `sidecarHost` is set to a remote address, sidecar REST traffic and guardrail proxy traffic traverse the network. The existing `X-DC-Auth` token mechanism provides authentication. Users should use TLS termination (reverse proxy) for production remote deployments.
+- **Token resolution**: The plugin respects `OPENCLAW_GATEWAY_TOKEN` env var and `~/.defenseclaw/.env` file, same as the embedded version.
+- **No new attack surface**: The plugin uses the same APIs, same correlation headers, same audit trail as the embedded version. The sidecar is the trust boundary.
+
+## 9. Testing Strategy
+
+- **Unit tests**: Not included in initial version — the embedded plugin's test suite (`extensions/defenseclaw/src/__tests__/`) validates the shared logic. Tests will be added in a follow-up.
+- **Manual verification**: Install from the built tarball, configure sidecar address, verify fetch interception and tool inspection work against a running DefenseClaw gateway.
+
+## 10. Rollout
+
+1. Merge PR with the `output-plugin/` directory.
+2. Build and publish to ClawHub staging.
+3. Test with a remote DefenseClaw gateway.
+4. Publish to ClawHub production.

--- a/output-plugin/CLAWHUB.md
+++ b/output-plugin/CLAWHUB.md
@@ -1,0 +1,88 @@
+# Publishing to ClawHub
+
+Steps to build, package, and publish the DefenseClaw plugin to ClawHub.
+
+## 1. Build
+
+```bash
+cd output-plugin
+npm install
+npm run build
+```
+
+Verify the `dist/` directory contains compiled output:
+
+```bash
+ls dist/
+# Should show: index.js, index.d.ts, and all compiled modules
+```
+
+## 2. Package
+
+Create a distributable tarball:
+
+```bash
+npm pack
+```
+
+This produces `defenseclaw-openclaw-plugin-0.1.0.tgz`.
+
+## 3. Publish to ClawHub
+
+### Option A: Tarball upload
+
+```bash
+clawhub publish defenseclaw-openclaw-plugin-0.1.0.tgz
+```
+
+### Option B: Directory publish
+
+```bash
+clawhub publish --directory .
+```
+
+ClawHub reads `openclaw.plugin.json` for the listing page metadata (name, description, config schema).
+
+## 4. Verify the Listing
+
+After publishing, confirm the plugin appears in ClawHub:
+
+```bash
+clawhub search defenseclaw
+```
+
+The listing should show:
+- **Name**: DefenseClaw Security (ClawHub)
+- **ID**: defenseclaw-plugin
+- **Version**: 0.1.0
+
+## 5. User Installation
+
+Users install the plugin with:
+
+```bash
+clawhub install @defenseclaw/openclaw-plugin
+```
+
+After installation, they configure `sidecarHost` and `sidecarPort` in OpenClaw plugin settings to point at their DefenseClaw gateway.
+
+## 6. Version Updates
+
+To publish an update:
+
+1. Bump version in both `package.json` and `openclaw.plugin.json`
+2. Rebuild: `npm run build`
+3. Repackage: `npm pack`
+4. Publish: `clawhub publish defenseclaw-openclaw-plugin-<version>.tgz`
+
+## Providers JSON
+
+The `src/providers.json` file contains the canonical list of LLM provider domains intercepted by the fetch interceptor. This file is copied from `internal/configs/providers.json` in the DefenseClaw gateway source.
+
+When updating provider domains, copy the latest version:
+
+```bash
+cp ../internal/configs/providers.json src/providers.json
+```
+
+Then rebuild and republish.

--- a/output-plugin/README.md
+++ b/output-plugin/README.md
@@ -1,0 +1,74 @@
+# DefenseClaw Security Plugin for OpenClaw (ClawHub)
+
+Standalone OpenClaw plugin that wires DefenseClaw security governance into any OpenClaw instance. Install from ClawHub — no DefenseClaw-side deployment required.
+
+## What It Does
+
+- **Fetch interception**: Patches `globalThis.fetch` and `https.request` to route all LLM API calls (15+ providers) through the DefenseClaw guardrail proxy for real-time inspection
+- **Tool inspection**: `before_tool_call` hook sends every tool invocation to the DefenseClaw sidecar for 6-category threat analysis (secrets, dangerous commands, sensitive paths, C2 patterns, cognitive file tampering, trust exploitation)
+- **Health monitoring**: Polls the DefenseClaw gateway every 60s and warns when protection is down
+- **Egress telemetry**: Reports intercepted/bypassed LLM calls for observability
+- **Slash commands**: `/dc-scan`, `/dc-block`, `/dc-allow` for on-demand security scanning and policy enforcement
+- **Bedrock HTTP/1 shim**: Automatically downgrades AWS Bedrock SDK from HTTP/2 to HTTP/1 so traffic hits the guardrail proxy
+
+## Prerequisites
+
+A running DefenseClaw gateway accessible from the OpenClaw instance. The gateway can be:
+- **Local**: Running on the same machine (default `127.0.0.1:18970`)
+- **Remote**: Running on a shared security server (configure `sidecarHost` and `sidecarPort`)
+
+## Install
+
+```bash
+clawhub install @defenseclaw/openclaw-plugin
+```
+
+## Configure
+
+After installation, configure the plugin in OpenClaw's plugin settings:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `sidecarHost` | `127.0.0.1` | DefenseClaw gateway hostname or IP |
+| `sidecarPort` | `18970` | DefenseClaw gateway REST API port |
+| `guardrailPort` | `4000` | DefenseClaw guardrail proxy port |
+| `mode` | `observe` | `observe` = log only, `action` = block threats |
+| `agent.id` | *(auto-generated)* | Stable agent identity for audit correlation |
+| `agent.name` | *(none)* | Display name in audit logs |
+| `agent.policyId` | *(none)* | Policy id for capability-based access control |
+| `awsHttp1Shim` | `auto` | Force Bedrock to HTTP/1: `auto`, `on`, or `off` |
+
+### Environment Variables
+
+These override `~/.defenseclaw/config.yaml` but are overridden by plugin config:
+
+| Variable | Description |
+|----------|-------------|
+| `DEFENSECLAW_HOST` | Gateway hostname |
+| `DEFENSECLAW_PORT` | Gateway REST API port |
+| `DEFENSECLAW_GUARDRAIL_PORT` | Guardrail proxy port |
+| `OPENCLAW_GATEWAY_TOKEN` | Authentication token for the gateway |
+
+## Slash Commands
+
+| Command | Description |
+|---------|-------------|
+| `/dc-scan <path> [type]` | Scan a skill, plugin, MCP config, or code (`type`: skill, plugin, mcp, code) |
+| `/dc-block <type> <name> [reason]` | Block a skill, MCP server, or plugin |
+| `/dc-allow <type> <name> [reason]` | Allow-list a skill, MCP server, or plugin |
+
+## Coexistence with Embedded Plugin
+
+This plugin (`defenseclaw-plugin`) can coexist with the embedded DefenseClaw plugin (`defenseclaw`) that ships with DefenseClaw itself. They use different plugin IDs and command prefixes, so there are no conflicts. Both connect to the same DefenseClaw gateway.
+
+## Build from Source
+
+```bash
+cd output-plugin
+npm install
+npm run build
+```
+
+## License
+
+Apache-2.0

--- a/output-plugin/openclaw.plugin.json
+++ b/output-plugin/openclaw.plugin.json
@@ -1,0 +1,59 @@
+{
+  "id": "defenseclaw-plugin",
+  "name": "DefenseClaw Security (ClawHub)",
+  "version": "0.1.0",
+  "description": "Wire DefenseClaw security governance into any OpenClaw instance. Installs fetch interception, tool inspection hooks, and security scanning — no DefenseClaw-side deployment required.",
+  "enabledByDefault": true,
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "agent": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Logical agent identity for sidecar correlation (X-DefenseClaw-Agent-Id)",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable logical agent id; overrides the persisted extension id when set"
+          },
+          "name": {
+            "type": "string",
+            "description": "Optional display name (X-DefenseClaw-Agent-Name)"
+          },
+          "policyId": {
+            "type": "string",
+            "description": "Optional policy id (X-DefenseClaw-Policy-Id)"
+          }
+        }
+      },
+      "sidecarHost": {
+        "type": "string",
+        "default": "127.0.0.1",
+        "description": "Hostname or IP of the DefenseClaw gateway"
+      },
+      "sidecarPort": {
+        "type": "integer",
+        "default": 18970,
+        "description": "Port for the DefenseClaw Go sidecar REST API"
+      },
+      "guardrailPort": {
+        "type": "integer",
+        "default": 4000,
+        "description": "Port for the DefenseClaw guardrail proxy"
+      },
+      "mode": {
+        "type": "string",
+        "enum": ["observe", "action"],
+        "default": "observe",
+        "description": "Guardrail mode: observe (log only) or action (block threats)"
+      },
+      "awsHttp1Shim": {
+        "type": "string",
+        "enum": ["auto", "on", "off"],
+        "default": "auto",
+        "description": "Amazon Bedrock: force HTTP/1 so LLM traffic hits the guardrail proxy. auto = on only if OpenClaw model config references Bedrock; on = always; off = never."
+      }
+    }
+  }
+}

--- a/output-plugin/package.json
+++ b/output-plugin/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@defenseclaw/openclaw-plugin",
+  "version": "0.1.0",
+  "description": "ClawHub plugin — wires DefenseClaw security into any OpenClaw instance",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "openclaw": {
+    "extensions": ["./dist/index.js"],
+    "pluginManifest": "./openclaw.plugin.json"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublish": "npm run build"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0"
+  },
+  "peerDependencies": {
+    "@openclaw/plugin-sdk": ">=1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@openclaw/plugin-sdk": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^25.5.0",
+    "typescript": "^5.4.0",
+    "vitest": "^3.0.0"
+  },
+  "license": "Apache-2.0",
+  "permissions": [
+    "net:connect"
+  ]
+}

--- a/output-plugin/package.json
+++ b/output-plugin/package.json
@@ -7,7 +7,13 @@
   "types": "dist/index.d.ts",
   "openclaw": {
     "extensions": ["./dist/index.js"],
-    "pluginManifest": "./openclaw.plugin.json"
+    "pluginManifest": "./openclaw.plugin.json",
+    "compat": {
+      "pluginApi": ">=1.0.0"
+    },
+    "build": {
+      "openclawVersion": ">=1.0.0"
+    }
   },
   "scripts": {
     "build": "tsc",

--- a/output-plugin/src/agent_identity.ts
+++ b/output-plugin/src/agent_identity.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { randomUUID } from "node:crypto";
+
+/** Extension `globalState` key for stable logical agent id across restarts. */
+export const STABLE_AGENT_ID_STORAGE_KEY = "defenseclaw.plugin.stableAgentId";
+
+export interface KeyValueStorage {
+  get(key: string): Promise<string | undefined>;
+  set(key: string, value: string): Promise<void>;
+}
+
+export function createInMemoryStorage(
+  seed?: Record<string, string>,
+): KeyValueStorage {
+  const map = new Map<string, string>(Object.entries(seed ?? {}));
+  return {
+    async get(key: string) {
+      return map.get(key);
+    },
+    async set(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+/**
+ * VS Code–compatible globalState adapter (OpenClaw may expose the same shape).
+ */
+export function createGlobalStateStorage(globalState: {
+  get(key: string): unknown;
+  update(key: string, value: unknown): Promise<void>;
+}): KeyValueStorage {
+  return {
+    async get(key: string) {
+      const v = globalState.get(key);
+      return typeof v === "string" && v.length > 0 ? v : undefined;
+    },
+    set(key: string, value: string) {
+      return globalState.update(key, value);
+    },
+  };
+}
+
+export function mintSessionAgentInstanceId(): string {
+  return randomUUID();
+}
+
+/**
+ * Returns a stable id persisted in extension storage, minting once if missing.
+ */
+export async function getOrCreateStableAgentId(
+  storage: KeyValueStorage,
+  mintUuid: () => string = randomUUID,
+): Promise<string> {
+  const existing = await storage.get(STABLE_AGENT_ID_STORAGE_KEY);
+  if (existing) return existing;
+  const created = mintUuid();
+  await storage.set(STABLE_AGENT_ID_STORAGE_KEY, created);
+  return created;
+}
+
+const ENV_AGENT_ID_KEYS = ["DEFENSECLAW_AGENT_ID", "DEFENSECLAW_PLUGIN_AGENT_ID"] as const;
+
+function readEnvAgentId(): string | undefined {
+  for (const k of ENV_AGENT_ID_KEYS) {
+    const v = process.env[k];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  return undefined;
+}
+
+export interface ResolveOutboundAgentIdInput {
+  /** OpenClaw plugin config `agent.id` (highest precedence after env). */
+  configAgentId?: string;
+  /** Persisted stable id from extension storage. */
+  stableAgentId: string;
+}
+
+/**
+ * Resolves the logical agent id for `X-DefenseClaw-Agent-Id`:
+ * env override → plugin config `agent.id` → persisted stable id.
+ */
+export function resolveOutboundAgentId(input: ResolveOutboundAgentIdInput): string {
+  const env = readEnvAgentId();
+  if (env) return env;
+  const cfg = input.configAgentId?.trim();
+  if (cfg) return cfg;
+  return input.stableAgentId;
+}
+
+export interface BootstrapPluginIdentityOptions {
+  storage: KeyValueStorage;
+  getConfigAgentId?: () => Promise<string | undefined>;
+  mintUuid?: () => string;
+}
+
+export interface BootstrapPluginIdentityResult {
+  agentId: string;
+  stableAgentId: string;
+  sessionAgentInstanceId: string;
+}
+
+/**
+ * Called on plugin activation: persist stable id, mint session instance id, resolve outbound agent id.
+ */
+export async function bootstrapPluginIdentity(
+  opts: BootstrapPluginIdentityOptions,
+): Promise<BootstrapPluginIdentityResult> {
+  const stableAgentId = await getOrCreateStableAgentId(
+    opts.storage,
+    opts.mintUuid ?? randomUUID,
+  );
+  const configAgentId = opts.getConfigAgentId
+    ? await opts.getConfigAgentId()
+    : undefined;
+  const agentId = resolveOutboundAgentId({ configAgentId, stableAgentId });
+  return {
+    agentId,
+    stableAgentId,
+    sessionAgentInstanceId: mintSessionAgentInstanceId(),
+  };
+}

--- a/output-plugin/src/aws-sdk-http1-for-guardrail.ts
+++ b/output-plugin/src/aws-sdk-http1-for-guardrail.ts
@@ -1,0 +1,303 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Amazon's JS SDK v3 defaults many services (including Bedrock Runtime) to
+ * {@link NodeHttp2Handler}, which uses `node:http2` and bypasses DefenseClaw's
+ * `https.request` / `fetch` hooks. Redirecting those calls through the local
+ * guardrail proxy requires HTTP/1.1 {@link NodeHttpHandler}.
+ *
+ * OpenClaw’s `@mariozechner/pi-ai` Bedrock provider reads **`AWS_BEDROCK_FORCE_HTTP1=1`**
+ * and switches the AWS SDK to `NodeHttpHandler` (HTTP/1). Without that,
+ * Bedrock stays on HTTP/2 and never hits our `https.request` / `fetch` hooks.
+ *
+ * This module sets that env when the shim is active, and also tries to replace
+ * `NodeHttp2Handler.create` with `NodeHttpHandler.create` on any resolvable
+ * `@smithy/node-http-handler` instance (fallback for other callers).
+ *
+ * **When it runs (default `awsHttp1Shim: auto` in plugin config):** only if
+ * OpenClaw config references Amazon Bedrock (see `bedrock-config-detect.ts`).
+ *
+ * **Overrides**
+ * - `plugins.entries.defenseclaw.awsHttp1Shim`: `"on"` | `"off"` | `"auto"`
+ * - `DEFENSECLAW_FORCE_AWS_HTTP1_SHIM=1` — always patch (escape hatch)
+ * - `DEFENSECLAW_DISABLE_AWS_HTTP1_SHIM=1` — never patch
+ * - `DEFENSECLAW_OPENCLAW_MAIN` — absolute path to `openclaw.mjs` (or any file under the
+ *   global `openclaw` install) used to resolve `@smithy/node-http-handler` when the gateway
+ *   process has no `process.argv[1]` (common for `openclaw-gateway` shims).
+ *
+ * **Trust model for `DEFENSECLAW_OPENCLAW_MAIN`:** this env var is read at gateway
+ * startup to locate OpenClaw's hoisted `node_modules`. Setting it to a path under an
+ * attacker-controlled tree would steer Smithy resolution (and therefore the
+ * `NodeHttp2Handler → NodeHttpHandler` monkey-patch) to attacker-supplied code. In
+ * practice anyone able to set this env var can already set `NODE_OPTIONS=--require …`
+ * or replace the `openclaw-gateway` binary outright, so the marginal new capability
+ * is small — but we still reject paths outside a fixed allow-list of roots (global
+ * npm prefix sibling of `process.execPath`, NVM / Volta / pnpm trees, and the
+ * plugin's own install tree) so a misconfigured supervisor or unprivileged shell env
+ * cannot widen the blast radius. Rejections are logged via `console.warn` and the
+ * override is silently dropped — resolution continues through the remaining
+ * candidates (`argv[1]`, `process.execPath` sibling, `import.meta.url`).
+ */
+
+import { existsSync, realpathSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { openClawConfigUsesAmazonBedrock } from "./bedrock-config-detect.js";
+
+const DONE_FLAG = "__defenseclawAwsHttp1ShimEvaluated";
+const PATCHED_FLAG = "__defenseclawAwsHttp1GuardrailPatch";
+
+export type AwsHttp1ShimMode = "auto" | "on" | "off";
+
+export interface PatchAwsSdkHttp1ForGuardrailOptions {
+  /** Full OpenClaw gateway config (`api.config`). */
+  openclawConfig?: unknown;
+  /** Validated `plugins.entries.defenseclaw` slice (`api.pluginConfig`). */
+  pluginConfig?: { awsHttp1Shim?: AwsHttp1ShimMode };
+}
+
+/**
+ * When the gateway is started as a bare `openclaw-gateway` name (argv has no script path),
+ * `createRequire(process.argv[1])` cannot load OpenClaw's hoisted deps. Global npm installs
+ * place `openclaw` next to the Node binary: `{prefix}/lib/node_modules/openclaw/openclaw.mjs`.
+ */
+function tryOpenclawEntryFromNodeExecPath(execPath: string): string | null {
+  const binDir = dirname(execPath);
+  const roots = [
+    join(binDir, "..", "lib", "node_modules", "openclaw", "openclaw.mjs"),
+    join(binDir, "..", "lib", "node_modules", "openclaw", "dist", "index.js"),
+  ];
+  for (const p of roots) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+/**
+ * Roots under which `DEFENSECLAW_OPENCLAW_MAIN` is considered trusted enough
+ * to drive `createRequire()`. Anything outside these trees will be ignored
+ * with a `console.warn` so a rogue environment variable cannot silently
+ * redirect Smithy resolution to an attacker-controlled `node_modules/`.
+ */
+function trustedOpenclawRoots(): string[] {
+  const roots = new Set<string>();
+
+  // 1. Global npm prefix sibling of process.execPath:
+  //    {prefix}/bin/node + {prefix}/lib/node_modules -> {prefix}
+  const execDir = dirname(process.execPath);
+  roots.add(resolve(execDir, ".."));
+
+  // 2. This module's own install tree (covers local `npm link`, monorepo checkout,
+  //    and distro packaging that drops the extension alongside the gateway).
+  try {
+    const self = fileURLToPath(import.meta.url);
+    // Walk up to the nearest `node_modules` ancestor, or fall back to 3 levels.
+    let dir = dirname(self);
+    for (let i = 0; i < 6; i++) {
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      if (dir.endsWith(`${sep}node_modules`)) {
+        roots.add(resolve(parent));
+        break;
+      }
+      dir = parent;
+    }
+    roots.add(resolve(dirname(self), "..", ".."));
+  } catch {
+    /* ignore */
+  }
+
+  // 3. Common user-local Node manager layouts — any of these being present on disk
+  //    already implies the user installed openclaw through that path, so resolving
+  //    through them is equivalent to running the gateway through them.
+  const home = process.env.HOME || process.env.USERPROFILE;
+  if (home) {
+    roots.add(resolve(home, ".nvm"));
+    roots.add(resolve(home, ".volta"));
+    roots.add(resolve(home, ".local", "share", "pnpm"));
+    roots.add(resolve(home, ".local", "share", "fnm"));
+    roots.add(resolve(home, "Library", "pnpm")); // macOS
+    roots.add(resolve(home, "AppData", "Roaming", "npm")); // Windows
+  }
+
+  return [...roots].filter((r) => r.length > 0);
+}
+
+function canonical(p: string): string | null {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+/**
+ * Returns `true` when `candidate` resolves to a file under one of the
+ * `trustedOpenclawRoots()`. We compare canonicalized absolute paths to defeat
+ * `../` traversal and symlink tricks (`realpath` is best-effort; if it fails we
+ * fall back to `resolve()` which still blocks literal traversal).
+ */
+export function isPermittedOpenclawMain(candidate: string): boolean {
+  if (typeof candidate !== "string" || candidate.length === 0) return false;
+  const target = canonical(candidate);
+  if (!target) return false;
+  const roots = trustedOpenclawRoots()
+    .map((r) => canonical(r))
+    .filter((r): r is string => Boolean(r));
+  for (const root of roots) {
+    const prefix = root.endsWith(sep) ? root : root + sep;
+    if (target === root || target.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+function resolveSmithyModule(): Record<string, unknown> | null {
+  const candidates: string[] = [];
+
+  const envMain = process.env.DEFENSECLAW_OPENCLAW_MAIN;
+  if (typeof envMain === "string" && envMain.length > 0) {
+    if (isPermittedOpenclawMain(envMain)) {
+      candidates.push(envMain);
+    } else {
+      console.warn(
+        `[defenseclaw] Ignoring DEFENSECLAW_OPENCLAW_MAIN=${envMain} — path is not under a trusted OpenClaw install root; falling back to argv/execPath-based resolution.`,
+      );
+    }
+  }
+
+  const argv1 = process.argv[1];
+  if (typeof argv1 === "string" && argv1.length > 0) {
+    candidates.push(argv1);
+  }
+
+  const fromExec = tryOpenclawEntryFromNodeExecPath(process.execPath);
+  if (fromExec) {
+    candidates.push(fromExec);
+  }
+
+  try {
+    candidates.push(fileURLToPath(import.meta.url));
+  } catch {
+    /* ignore */
+  }
+
+  for (const entry of candidates) {
+    try {
+      const req = createRequire(entry);
+      return req("@smithy/node-http-handler") as Record<string, unknown>;
+    } catch {
+      /* try next entry */
+    }
+  }
+  return null;
+}
+
+/**
+ * @returns whether the optional Smithy package monkey-patch was applied.
+ *   Bedrock HTTP/1 for pi-ai is driven by `AWS_BEDROCK_FORCE_HTTP1` (see `enableBedrockHttp1ForGuardrailProxy`).
+ */
+function applySmithyHttp1Patch(): boolean {
+  const smithy = resolveSmithyModule();
+  if (!smithy) {
+    console.log(
+      "[defenseclaw] Smithy package patch skipped (could not resolve @smithy/node-http-handler); pi-ai still uses HTTP/1 via AWS_BEDROCK_FORCE_HTTP1.",
+    );
+    return false;
+  }
+
+  const NodeHttp2Handler = smithy.NodeHttp2Handler as
+    | { create: (instanceOrOptions?: unknown) => unknown }
+    | undefined;
+  const NodeHttpHandler = smithy.NodeHttpHandler as
+    | { create: (instanceOrOptions?: unknown) => unknown }
+    | undefined;
+
+  if (
+    !NodeHttp2Handler ||
+    typeof NodeHttp2Handler.create !== "function" ||
+    !NodeHttpHandler ||
+    typeof NodeHttpHandler.create !== "function"
+  ) {
+    console.log(
+      "[defenseclaw] Smithy package patch skipped (missing NodeHttp2Handler/NodeHttpHandler exports); pi-ai still uses HTTP/1 via AWS_BEDROCK_FORCE_HTTP1.",
+    );
+    return false;
+  }
+
+  NodeHttp2Handler.create = ((instanceOrOptions?: unknown) => {
+    return NodeHttpHandler.create(instanceOrOptions);
+  }) as typeof NodeHttp2Handler.create;
+
+  const g = globalThis as typeof globalThis & Record<string, unknown>;
+  g[PATCHED_FLAG] = true;
+
+  return true;
+}
+
+/** Forces Bedrock over HTTP/1 so LLM traffic can reach the guardrail proxy (pi-ai + optional Smithy patch). */
+function enableBedrockHttp1ForGuardrailProxy(): void {
+  process.env.AWS_BEDROCK_FORCE_HTTP1 = "1";
+  const smithyPatched = applySmithyHttp1Patch();
+  console.log(
+    smithyPatched
+      ? "[defenseclaw] Amazon Bedrock → HTTP/1 for guardrail: AWS_BEDROCK_FORCE_HTTP1=1 (pi-ai) and Smithy NodeHttp2Handler→NodeHttpHandler patch."
+      : "[defenseclaw] Amazon Bedrock → HTTP/1 for guardrail: AWS_BEDROCK_FORCE_HTTP1=1 (pi-ai).",
+  );
+}
+
+/**
+ * Patches `@smithy/node-http-handler` when Bedrock is in use (or forced).
+ * Idempotent.
+ */
+export function patchAwsSdkHttp1ForGuardrail(
+  opts?: PatchAwsSdkHttp1ForGuardrailOptions,
+): void {
+  const g = globalThis as typeof globalThis & Record<string, unknown>;
+  if (g[DONE_FLAG]) return;
+  g[DONE_FLAG] = true;
+
+  if (process.env.DEFENSECLAW_DISABLE_AWS_HTTP1_SHIM === "1") {
+    console.log(
+      "[defenseclaw] AWS HTTP/1 shim skipped (DEFENSECLAW_DISABLE_AWS_HTTP1_SHIM=1)",
+    );
+    return;
+  }
+
+  if (process.env.DEFENSECLAW_FORCE_AWS_HTTP1_SHIM === "1") {
+    console.log(
+      "[defenseclaw] AWS HTTP/1 shim forced (DEFENSECLAW_FORCE_AWS_HTTP1_SHIM=1)",
+    );
+    enableBedrockHttp1ForGuardrailProxy();
+    return;
+  }
+
+  const mode: AwsHttp1ShimMode = opts?.pluginConfig?.awsHttp1Shim ?? "auto";
+
+  if (mode === "off") {
+    console.log(
+      "[defenseclaw] AWS HTTP/1 shim disabled (plugins.entries.defenseclaw.awsHttp1Shim=off)",
+    );
+    return;
+  }
+
+  if (mode === "on") {
+    enableBedrockHttp1ForGuardrailProxy();
+    return;
+  }
+
+  // auto
+  if (!openClawConfigUsesAmazonBedrock(opts?.openclawConfig)) {
+    console.log(
+      "[defenseclaw] AWS HTTP/1 shim skipped (no Amazon Bedrock in model config). Set plugins.entries.defenseclaw.awsHttp1Shim to \"on\" or DEFENSECLAW_FORCE_AWS_HTTP1_SHIM=1 if your setup needs it.",
+    );
+    return;
+  }
+
+  enableBedrockHttp1ForGuardrailProxy();
+}

--- a/output-plugin/src/bedrock-config-detect.ts
+++ b/output-plugin/src/bedrock-config-detect.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+function collectModelRelatedJson(config: unknown): string[] {
+  const chunks: string[] = [];
+  if (!config || typeof config !== "object") return chunks;
+  const c = config as Record<string, unknown>;
+
+  const models = c.models as Record<string, unknown> | undefined;
+  if (models?.providers) {
+    try {
+      chunks.push(JSON.stringify(models.providers));
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const agents = c.agents as Record<string, unknown> | undefined;
+  if (agents?.defaults) {
+    try {
+      chunks.push(JSON.stringify(agents.defaults));
+    } catch {
+      /* ignore */
+    }
+  }
+  if (typeof agents === "object" && agents) {
+    for (const [key, value] of Object.entries(agents)) {
+      if (key === "defaults") continue;
+      try {
+        chunks.push(JSON.stringify(value));
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  return chunks;
+}
+
+/**
+ * Whether OpenClaw config appears to use Amazon Bedrock for models.
+ * Only inspects `models.providers` and `agents` model-related subtrees
+ * (avoids scanning unrelated config like channel tokens).
+ */
+export function openClawConfigUsesAmazonBedrock(config: unknown): boolean {
+  const re = /amazon-bedrock|bedrock-converse-stream|bedrock-runtime\./i;
+  return collectModelRelatedJson(config).some((s) => re.test(s));
+}

--- a/output-plugin/src/client.ts
+++ b/output-plugin/src/client.ts
@@ -1,0 +1,392 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { randomUUID } from "node:crypto";
+import { request as httpRequest } from "node:http";
+import { URL } from "node:url";
+import {
+  HEADER_DEFENSECLAW_CLIENT,
+  buildSidecarCorrelationHeaders,
+  parseStickyHeadersFromNode,
+  parseStickyHeadersFromWebHeaders,
+} from "./correlation-headers.js";
+import type {
+  ScanResult,
+  BlockEntry,
+  AllowEntry,
+  DaemonStatus,
+  AdmissionResult,
+  CorrelationContext,
+  OutboundSidecarRequestLog,
+} from "./types.js";
+import { loadSidecarConfig } from "./sidecar-config.js";
+
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
+type RequestImpl = typeof httpRequest;
+
+export interface DaemonClientOptions {
+  baseUrl?: string;
+  token?: string;
+  timeoutMs?: number;
+  requestImpl?: RequestImpl;
+  /**
+   * Base correlation for every request; may be sync or async.
+   * Per-request overrides are merged in {@link buildOutboundHeaders}.
+   */
+  getCorrelation?: () => CorrelationContext | Promise<CorrelationContext>;
+  /** Optional per-request correlation merged on top of {@link getCorrelation}. */
+  correlationOverride?: Partial<CorrelationContext>;
+  identityReady?: Promise<unknown>;
+  logOutboundRequest?: (entry: OutboundSidecarRequestLog) => void;
+  onCorrelationContext?: (ctx: CorrelationContext) => void;
+}
+
+interface ApiResponse<T> {
+  ok: boolean;
+  data?: T;
+  error?: string;
+  status: number;
+}
+
+export class DaemonClient {
+  private readonly baseUrl: string;
+  private readonly token: string;
+  private readonly timeoutMs: number;
+  private readonly requestImpl: RequestImpl;
+  private readonly getCorrelation: () => CorrelationContext | Promise<CorrelationContext>;
+  private readonly correlationOverride: Partial<CorrelationContext>;
+  private readonly identityReady: Promise<unknown>;
+  private readonly logOutboundRequest?: (entry: OutboundSidecarRequestLog) => void;
+  private readonly onCorrelationContext?: (ctx: CorrelationContext) => void;
+
+  /** First sidecar echo wins for the session (sticky). */
+  private stickyOutboundAgentInstanceId?: string;
+  private sidecarInstanceIdEcho?: string;
+
+  constructor(opts?: DaemonClientOptions) {
+    const cfg = loadSidecarConfig();
+    this.baseUrl = opts?.baseUrl ?? cfg.baseUrl;
+    this.token = opts?.token ?? cfg.token;
+    this.timeoutMs = opts?.timeoutMs ?? REQUEST_TIMEOUT_MS;
+    this.requestImpl = opts?.requestImpl ?? httpRequest;
+    this.getCorrelation = opts?.getCorrelation ?? defaultCorrelation;
+    this.correlationOverride = opts?.correlationOverride ?? {};
+    this.identityReady = opts?.identityReady ?? Promise.resolve();
+    this.logOutboundRequest = opts?.logOutboundRequest;
+    this.onCorrelationContext = opts?.onCorrelationContext;
+  }
+
+  /**
+   * Sticky agent instance id from the sidecar (if any), else undefined.
+   */
+  getStickyAgentInstanceId(): string | undefined {
+    return this.stickyOutboundAgentInstanceId;
+  }
+
+  getEchoedSidecarInstanceId(): string | undefined {
+    return this.sidecarInstanceIdEcho;
+  }
+
+  /**
+   * Updates sticky correlation from a `fetch` Response (inspect, code scan, health poll, etc.).
+   */
+  applyStickyFromHttpResponse(res: { headers: Headers }): void {
+    const sticky = parseStickyHeadersFromWebHeaders(res.headers);
+    if (sticky.agentInstanceId) {
+      this.stickyOutboundAgentInstanceId = sticky.agentInstanceId;
+    }
+    if (sticky.sidecarInstanceId) {
+      this.sidecarInstanceIdEcho = sticky.sidecarInstanceId;
+    }
+    void Promise.resolve(this.getCorrelation()).then((base) => {
+      this.onCorrelationContext?.(this.mergeObservedContext(base));
+    });
+  }
+
+  private async resolveCorrelation(
+    partial?: Partial<CorrelationContext>,
+  ): Promise<CorrelationContext> {
+    await this.identityReady;
+    const base = await Promise.resolve(this.getCorrelation());
+    const merged: CorrelationContext = {
+      ...base,
+      ...this.correlationOverride,
+      ...partial,
+      agentId: partial?.agentId ?? this.correlationOverride.agentId ?? base.agentId,
+    };
+    if (!merged.traceId) merged.traceId = randomUUID();
+    return merged;
+  }
+
+  /**
+   * Headers for outbound sidecar HTTP requests (node `http` or `fetch`).
+   */
+  async buildOutboundHeaders(
+    partial?: Partial<CorrelationContext>,
+  ): Promise<Record<string, string>> {
+    const ctx = await this.resolveCorrelation(partial);
+    const outboundInstance =
+      this.stickyOutboundAgentInstanceId ?? ctx.agentInstanceId ?? "";
+    const corr = this.mergeObservedContext(ctx);
+    const h = buildSidecarCorrelationHeaders(corr, {
+      outboundAgentInstanceId: outboundInstance,
+    });
+    h[HEADER_DEFENSECLAW_CLIENT] = "openclaw-clawhub-plugin";
+    if (this.token) {
+      h.Authorization = `Bearer ${this.token}`;
+    }
+    return h;
+  }
+
+  private mergeObservedContext(base: CorrelationContext): CorrelationContext {
+    return {
+      ...base,
+      agentInstanceId:
+        this.stickyOutboundAgentInstanceId ?? base.agentInstanceId,
+      sidecarInstanceId:
+        this.sidecarInstanceIdEcho ?? base.sidecarInstanceId,
+    };
+  }
+
+  async status(): Promise<ApiResponse<DaemonStatus>> {
+    return this.get<DaemonStatus>("/status");
+  }
+
+  async submitScanResult(result: ScanResult): Promise<ApiResponse<void>> {
+    return this.post<void>("/scan/result", result);
+  }
+
+  async block(
+    targetType: string,
+    targetName: string,
+    reason: string,
+  ): Promise<ApiResponse<void>> {
+    return this.post<void>("/enforce/block", {
+      target_type: targetType,
+      target_name: targetName,
+      reason,
+    });
+  }
+
+  async allow(
+    targetType: string,
+    targetName: string,
+    reason: string,
+  ): Promise<ApiResponse<void>> {
+    return this.post<void>("/enforce/allow", {
+      target_type: targetType,
+      target_name: targetName,
+      reason,
+    });
+  }
+
+  async unblock(
+    targetType: string,
+    targetName: string,
+  ): Promise<ApiResponse<void>> {
+    return this.delete<void>("/enforce/block", {
+      target_type: targetType,
+      target_name: targetName,
+    });
+  }
+
+  async listAlerts(limit = 50): Promise<ApiResponse<AdmissionResult[]>> {
+    return this.get<AdmissionResult[]>(`/alerts?limit=${limit}`);
+  }
+
+  async listSkills(): Promise<ApiResponse<string[]>> {
+    return this.get<string[]>("/skills");
+  }
+
+  async listMCPs(): Promise<ApiResponse<string[]>> {
+    return this.get<string[]>("/mcps");
+  }
+
+  async listBlocked(): Promise<ApiResponse<BlockEntry[]>> {
+    return this.get<BlockEntry[]>("/enforce/blocked");
+  }
+
+  async listAllowed(): Promise<ApiResponse<AllowEntry[]>> {
+    return this.get<AllowEntry[]>("/enforce/allowed");
+  }
+
+  async logEvent(event: Record<string, unknown>): Promise<ApiResponse<void>> {
+    return this.post<void>("/audit/event", event);
+  }
+
+  async evaluatePolicy(
+    domain: string,
+    input: Record<string, unknown>,
+  ): Promise<ApiResponse<Record<string, unknown>>> {
+    return this.post<Record<string, unknown>>("/policy/evaluate", {
+      domain,
+      input,
+    });
+  }
+
+  private get<T>(path: string): Promise<ApiResponse<T>> {
+    return this.doRequest<T>("GET", path);
+  }
+
+  private post<T>(path: string, body: unknown): Promise<ApiResponse<T>> {
+    return this.doRequest<T>("POST", path, body);
+  }
+
+  private delete<T>(path: string, body: unknown): Promise<ApiResponse<T>> {
+    return this.doRequest<T>("DELETE", path, body);
+  }
+
+  private async doRequest<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    correlationPartial?: Partial<CorrelationContext>,
+  ): Promise<ApiResponse<T>> {
+    const started = performance.now();
+    const ctx = await this.resolveCorrelation(correlationPartial);
+    const outboundInstance =
+      this.stickyOutboundAgentInstanceId ?? ctx.agentInstanceId ?? "";
+    const corrForHeaders = this.mergeObservedContext(ctx);
+    const correlationHeaders = buildSidecarCorrelationHeaders(corrForHeaders, {
+      outboundAgentInstanceId: outboundInstance,
+    });
+
+    return new Promise((resolve) => {
+      const url = new URL(path, this.baseUrl);
+      const payload = body !== undefined ? JSON.stringify(body) : undefined;
+
+      const headers: Record<string, string | number> = {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        [HEADER_DEFENSECLAW_CLIENT]: "openclaw-clawhub-plugin",
+        ...correlationHeaders,
+      };
+      if (this.token) {
+        headers.Authorization = `Bearer ${this.token}`;
+      }
+      if (payload !== undefined) {
+        headers["Content-Length"] = Buffer.byteLength(payload);
+      }
+
+      const req = this.requestImpl(
+        {
+          hostname: url.hostname,
+          port: url.port,
+          path: url.pathname + url.search,
+          method,
+          timeout: this.timeoutMs,
+          headers,
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          let totalBytes = 0;
+
+          res.on("data", (chunk: Buffer) => {
+            totalBytes += chunk.length;
+            if (totalBytes <= MAX_RESPONSE_BYTES) {
+              chunks.push(chunk);
+            }
+          });
+
+          res.on("end", () => {
+            const raw = Buffer.concat(chunks).toString("utf-8");
+            const status = res.statusCode ?? 0;
+            const durationMs = Math.round(performance.now() - started);
+
+            const sticky = parseStickyHeadersFromNode(res.headers);
+            if (sticky.agentInstanceId) {
+              this.stickyOutboundAgentInstanceId = sticky.agentInstanceId;
+            }
+            if (sticky.sidecarInstanceId) {
+              this.sidecarInstanceIdEcho = sticky.sidecarInstanceId;
+            }
+
+            const observed = this.mergeObservedContext(ctx);
+            this.onCorrelationContext?.(observed);
+
+            this.logOutboundRequest?.({
+              runId: observed.runId,
+              sessionId: observed.sessionId,
+              agentId: observed.agentId,
+              status_code: status,
+              duration_ms: durationMs,
+            });
+
+            if (status >= 200 && status < 300) {
+              try {
+                const data = raw.length > 0 ? (JSON.parse(raw) as T) : undefined;
+                resolve({ ok: true, data, status });
+              } catch {
+                resolve({ ok: true, data: undefined, status });
+              }
+            } else {
+              resolve({ ok: false, error: raw || `HTTP ${status}`, status });
+            }
+          });
+
+          res.on("error", (err) => {
+            const durationMs = Math.round(performance.now() - started);
+            this.logOutboundRequest?.({
+              runId: ctx.runId,
+              sessionId: ctx.sessionId,
+              agentId: ctx.agentId,
+              status_code: 0,
+              duration_ms: durationMs,
+            });
+            resolve({ ok: false, error: err.message, status: 0 });
+          });
+        },
+      );
+
+      req.on("error", (err) => {
+        const durationMs = Math.round(performance.now() - started);
+        this.logOutboundRequest?.({
+          runId: ctx.runId,
+          sessionId: ctx.sessionId,
+          agentId: ctx.agentId,
+          status_code: 0,
+          duration_ms: durationMs,
+        });
+        resolve({ ok: false, error: err.message, status: 0 });
+      });
+
+      req.on("timeout", () => {
+        req.destroy();
+        const durationMs = Math.round(performance.now() - started);
+        this.logOutboundRequest?.({
+          runId: ctx.runId,
+          sessionId: ctx.sessionId,
+          agentId: ctx.agentId,
+          status_code: 0,
+          duration_ms: durationMs,
+        });
+        resolve({ ok: false, error: "request timed out", status: 0 });
+      });
+
+      if (payload !== undefined) {
+        req.write(payload);
+      }
+      req.end();
+    });
+  }
+}
+
+function defaultCorrelation(): CorrelationContext {
+  return { agentId: "unknown", traceId: randomUUID() };
+}

--- a/output-plugin/src/correlation-headers.ts
+++ b/output-plugin/src/correlation-headers.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IncomingHttpHeaders } from "node:http";
+import type { CorrelationContext } from "./types.js";
+
+/** Single module for DefenseClaw↔sidecar HTTP header names (no raw strings at call sites). */
+export const HEADER_HTTP_CONTENT_TYPE = "Content-Type";
+export const HEADER_DEFENSECLAW_RUN_ID = "X-DefenseClaw-Run-Id";
+export const HEADER_DEFENSECLAW_SESSION_ID = "X-DefenseClaw-Session-Id";
+export const HEADER_DEFENSECLAW_TRACE_ID = "X-DefenseClaw-Trace-Id";
+export const HEADER_DEFENSECLAW_AGENT_ID = "X-DefenseClaw-Agent-Id";
+export const HEADER_DEFENSECLAW_AGENT_INSTANCE_ID = "X-DefenseClaw-Agent-Instance-Id";
+export const HEADER_DEFENSECLAW_SIDECAR_INSTANCE_ID = "X-DefenseClaw-Sidecar-Instance-Id";
+export const HEADER_DEFENSECLAW_AGENT_NAME = "X-DefenseClaw-Agent-Name";
+export const HEADER_DEFENSECLAW_POLICY_ID = "X-DefenseClaw-Policy-Id";
+export const HEADER_DEFENSECLAW_CLIENT = "X-DefenseClaw-Client";
+
+export interface BuildCorrelationHeadersOptions {
+  /**
+   * Outbound value for {@link HEADER_DEFENSECLAW_AGENT_INSTANCE_ID}.
+   * Prefer the sidecar-echoed id when present so both ends converge.
+   */
+  outboundAgentInstanceId: string;
+}
+
+function setIfPresent(
+  out: Record<string, string>,
+  headerName: string,
+  value: string | undefined,
+): void {
+  if (value === undefined || value === "") return;
+  out[headerName] = value;
+}
+
+/**
+ * Builds correlation headers for outbound sidecar HTTP requests.
+ */
+export function buildSidecarCorrelationHeaders(
+  ctx: CorrelationContext,
+  opts: BuildCorrelationHeadersOptions,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  setIfPresent(out, HEADER_DEFENSECLAW_RUN_ID, ctx.runId);
+  setIfPresent(out, HEADER_DEFENSECLAW_SESSION_ID, ctx.sessionId);
+  setIfPresent(out, HEADER_DEFENSECLAW_TRACE_ID, ctx.traceId);
+  setIfPresent(out, HEADER_DEFENSECLAW_AGENT_ID, ctx.agentId);
+  setIfPresent(out, HEADER_DEFENSECLAW_AGENT_NAME, ctx.agentName);
+  setIfPresent(out, HEADER_DEFENSECLAW_POLICY_ID, ctx.policyId);
+  setIfPresent(
+    out,
+    HEADER_DEFENSECLAW_AGENT_INSTANCE_ID,
+    opts.outboundAgentInstanceId,
+  );
+  setIfPresent(out, HEADER_DEFENSECLAW_SIDECAR_INSTANCE_ID, ctx.sidecarInstanceId);
+  return out;
+}
+
+export interface ParsedStickyResponseHeaders {
+  agentInstanceId?: string;
+  sidecarInstanceId?: string;
+}
+
+function normalizeHeaderValue(
+  value: IncomingHttpHeaders[string],
+): string | undefined {
+  if (value === undefined) return undefined;
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+/**
+ * Reads sticky / echo headers from a sidecar response (Node or Fetch).
+ */
+export function parseStickyHeadersFromNode(
+  headers: IncomingHttpHeaders,
+): ParsedStickyResponseHeaders {
+  return {
+    agentInstanceId: normalizeHeaderValue(
+      headers[HEADER_DEFENSECLAW_AGENT_INSTANCE_ID.toLowerCase()],
+    ),
+    sidecarInstanceId: normalizeHeaderValue(
+      headers[HEADER_DEFENSECLAW_SIDECAR_INSTANCE_ID.toLowerCase()],
+    ),
+  };
+}
+
+/** Fetch `Headers` / `Headers`-like (get is case-insensitive). */
+export function parseStickyHeadersFromWebHeaders(headers: {
+  get(name: string): string | null;
+}): ParsedStickyResponseHeaders {
+  return {
+    agentInstanceId: headers.get(HEADER_DEFENSECLAW_AGENT_INSTANCE_ID) ?? undefined,
+    sidecarInstanceId:
+      headers.get(HEADER_DEFENSECLAW_SIDECAR_INSTANCE_ID) ?? undefined,
+  };
+}

--- a/output-plugin/src/egress-telemetry.ts
+++ b/output-plugin/src/egress-telemetry.ts
@@ -1,0 +1,212 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Layer 3 egress telemetry for the TS fetch interceptor.
+ *
+ * Every intercepted fetch (known-provider, shape-matched, or left to
+ * bypass after classification) reports a single {@link EgressEvent} to
+ * the guardrail proxy via POST /v1/events/egress. The proxy
+ * re-emits the event through the shared gatewaylog.Writer so SIEM,
+ * OTel, and the TUI Alerts panel all see the same silent-bypass /
+ * shape-match signal the Go side already reports.
+ *
+ * Design goals:
+ *   - Cheap and non-blocking: we never await on telemetry — a slow or
+ *     missing proxy must not stall or block the underlying LLM call.
+ *   - Resilient: errors are swallowed; telemetry is best-effort.
+ *   - Low cardinality: 60s per-(host,branch,decision) dedup window so
+ *     a chatty SDK cannot flood gateway.jsonl at request rates.
+ *   - Read-once safe: the caller already peeked the body for shape
+ *     classification, so we accept the shape as a parameter rather
+ *     than re-reading anything.
+ */
+
+import { loadSidecarConfig } from "./sidecar-config.js";
+
+// Kept in sync with fetch-interceptor.ts::DC_AUTH_HEADER. Inlined to
+// avoid an import cycle between the reporter and its consumer.
+const DC_AUTH_HEADER = "X-DC-Auth";
+
+/** Branch labels mirror the Go-side emitter in internal/gateway/events.go. */
+export type EgressBranch = "known" | "shape" | "passthrough";
+
+/** Allow/block decision at the guardrail edge. */
+export type EgressDecision = "allow" | "block";
+
+export interface EgressEvent {
+  /** Origin host of the outbound request (never the proxy itself). */
+  targetHost: string;
+  /** Request path — capped to 256 chars by the Go emitter. */
+  targetPath: string;
+  /**
+   * Classified LLM body shape ("messages" | "prompt" | "input" |
+   * "contents" | "none"). Pass the same value the interceptor already
+   * computed; don't re-peek.
+   */
+  bodyShape: string;
+  /**
+   * Whether either the path or body looked like an LLM call. A true
+   * value with decision="allow" + branch="passthrough" is the exact
+   * silent-bypass failure we want to catch.
+   */
+  looksLikeLLM: boolean;
+  /** Which rail fired: known-provider, shape-detected, or passthrough. */
+  branch: EgressBranch;
+  /** Operational outcome — allow (forwarded) or block (rejected). */
+  decision: EgressDecision;
+  /** Human-readable reason (optional). */
+  reason?: string;
+}
+
+/** Tunable — 60s is a balance between signal freshness and noise. */
+const DEFAULT_DEDUP_WINDOW_MS = 60_000;
+
+/**
+ * Dedup key shape mirrors the Go emitter so a single (host, branch,
+ * decision) triple maps to one event per minute per emitter. We don't
+ * dedup on body shape or reason on purpose — a host flipping from
+ * "passthrough" to "shape" is exactly the signal we want to see.
+ */
+function dedupKey(e: EgressEvent): string {
+  return `${e.targetHost}::${e.branch}::${e.decision}`;
+}
+
+export interface EgressReporter {
+  report(e: EgressEvent): void;
+  stop(): void;
+}
+
+export interface CreateEgressReporterOptions {
+  /** Guardrail proxy port — typically cfg.gateway.port. */
+  guardrailPort: number;
+  /** Override fetch for tests; defaults to globalThis.fetch. */
+  fetchImpl?: typeof fetch;
+  /** Override dedup window (ms). Default 60s. */
+  dedupWindowMs?: number;
+}
+
+/**
+ * Build a bounded-memory reporter. Each call to report() is:
+ *  - deduped against the last `dedupWindowMs` of events,
+ *  - scheduled with queueMicrotask so the caller's fetch resumes
+ *    immediately,
+ *  - wrapped in a try/catch + AbortSignal.timeout so a stuck proxy
+ *    never holds on to memory.
+ */
+export function createEgressReporter(
+  opts: CreateEgressReporterOptions,
+): EgressReporter {
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const dedupWindow = opts.dedupWindowMs ?? DEFAULT_DEDUP_WINDOW_MS;
+  const lastSeen = new Map<string, number>();
+  const endpoint = `http://127.0.0.1:${opts.guardrailPort}/v1/events/egress`;
+
+  function report(e: EgressEvent): void {
+    try {
+      const key = dedupKey(e);
+      const now = Date.now();
+      const seen = lastSeen.get(key) ?? 0;
+      if (now - seen < dedupWindow) return;
+      lastSeen.set(key, now);
+
+      // Periodically trim dead entries so a pathological long-running
+      // agent process that has touched thousands of unique (host,
+      // branch, decision) triples doesn't grow unbounded.
+      //
+      // Two-stage cleanup: first expire anything older than the
+      // dedup window; if that is still not enough (constant churn
+      // within the window), hard-cap at 4096 by deleting the oldest
+      // entries. Without the hard cap, a pathological agent that
+      // repeatedly hits 50k unique hosts inside a 60s window would
+      // grow the map without bound even after "periodic cleanup."
+      if (lastSeen.size > 4096) {
+        for (const [k, ts] of lastSeen) {
+          if (now - ts >= dedupWindow) lastSeen.delete(k);
+        }
+        if (lastSeen.size > 4096) {
+          // Map iteration order is insertion order, so the first N
+          // entries are the oldest. Evict until we're back under
+          // the cap.
+          const toEvict = lastSeen.size - 4096;
+          let evicted = 0;
+          for (const k of lastSeen.keys()) {
+            if (evicted >= toEvict) break;
+            lastSeen.delete(k);
+            evicted++;
+          }
+        }
+      }
+
+      // Truncate target_path to the same 256-byte ceiling the Go
+      // emitter enforces. Keeping the TS side within the same cap
+      // prevents a single pathological long URL from bloating the
+      // POST body (and therefore the gateway.jsonl row) when we
+      // could just as usefully truncate upstream. target_host is
+      // already bounded by DNS (253 chars) so we only cap the path.
+      const truncatedPath = e.targetPath.length > 256
+        ? e.targetPath.slice(0, 256)
+        : e.targetPath;
+      const payload = {
+        target_host: e.targetHost,
+        target_path: truncatedPath,
+        body_shape: e.bodyShape,
+        looks_like_llm: e.looksLikeLLM,
+        branch: e.branch,
+        decision: e.decision,
+        reason: e.reason ?? "",
+      };
+
+      queueMicrotask(() => {
+        const headers: Record<string, string> = {
+          "Content-Type": "application/json",
+        };
+        const token = loadSidecarConfig().token;
+        if (token) headers[DC_AUTH_HEADER] = `Bearer ${token}`;
+
+        // 2s ceiling — egress telemetry is disposable by design.
+        // Prefer AbortSignal.timeout when available; fall back to a
+        // plain AbortController + setTimeout so older runtimes still
+        // get a hard cap on the telemetry fetch (otherwise a hung
+        // sidecar leaks an unresolved fetch).
+        let signal: AbortSignal | undefined;
+        let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
+        if (typeof AbortSignal !== "undefined" && "timeout" in AbortSignal) {
+          signal = (AbortSignal as unknown as { timeout(ms: number): AbortSignal }).timeout(2_000);
+        } else if (typeof AbortController !== "undefined") {
+          const ctrl = new AbortController();
+          signal = ctrl.signal;
+          fallbackTimer = setTimeout(() => ctrl.abort(), 2_000);
+        }
+
+        fetchImpl(endpoint, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(payload),
+          signal,
+        })
+          .catch(() => {
+            // Telemetry is best-effort. Errors here never propagate.
+          })
+          .finally(() => {
+            if (fallbackTimer !== undefined) clearTimeout(fallbackTimer);
+          });
+      });
+    } catch {
+      // Belt-and-braces: the whole telemetry path is a no-op on any
+      // error so a telemetry bug cannot break LLM traffic.
+    }
+  }
+
+  function stop(): void {
+    lastSeen.clear();
+  }
+
+  return { report, stop };
+}

--- a/output-plugin/src/fetch-interceptor.ts
+++ b/output-plugin/src/fetch-interceptor.ts
@@ -1,0 +1,1132 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * LLM Fetch Interceptor
+ *
+ * Patches globalThis.fetch to redirect outbound LLM API calls through the
+ * DefenseClaw guardrail proxy at localhost:{guardrailPort}, regardless of
+ * which provider or model the user selected in OpenClaw.
+ *
+ * The original upstream URL is preserved in the X-DC-Target-URL header so
+ * the proxy can route to the correct upstream after inspection.
+ */
+
+import { createRequire } from "node:module";
+import { createEgressReporter, type EgressReporter } from "./egress-telemetry.js";
+import { loadSidecarConfig } from "./sidecar-config.js";
+import {
+  HEADER_DEFENSECLAW_AGENT_ID,
+  HEADER_DEFENSECLAW_AGENT_INSTANCE_ID,
+  HEADER_DEFENSECLAW_AGENT_NAME,
+  HEADER_DEFENSECLAW_POLICY_ID,
+  HEADER_DEFENSECLAW_RUN_ID,
+  HEADER_DEFENSECLAW_SESSION_ID,
+  HEADER_DEFENSECLAW_SIDECAR_INSTANCE_ID,
+  HEADER_DEFENSECLAW_TRACE_ID,
+} from "./correlation-headers.js";
+// Canonical provider config — single source of truth shared with the Go proxy.
+// Copied from internal/configs/providers.json by `make plugin`.
+import providersConfig from "./providers.json" with { type: "json" };
+const _require = createRequire(import.meta.url);
+// Use CommonJS require() for https/http — ESM module objects are frozen and
+// cannot have properties reassigned, but the CJS exports object is mutable.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const https = _require("https") as typeof import("https");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const http = _require("http") as typeof import("http");
+
+/**
+ * Domains that should be intercepted. Seeded from the embedded
+ * providers.json at import time; can be extended at runtime by
+ * `bootstrapProviderOverlay()` once the sidecar's
+ * GET /v1/config/providers endpoint is reachable. Declared `let` so
+ * the overlay can grow the list in place without the rest of the
+ * module holding a stale snapshot.
+ */
+let LLM_DOMAINS: string[] = providersConfig.providers.flatMap(
+  (p: { domains: string[] }) => p.domains,
+);
+
+/**
+ * Ollama runs locally — intercept by matching its default port.
+ * Seeded from providers.json; can be extended at runtime by the
+ * overlay fetch so new Ollama deployments on non-standard ports do
+ * not silently bypass the guardrail.
+ */
+let OLLAMA_PORTS: string[] = providersConfig.ollama_ports.map(String);
+
+/**
+ * Apply a merged provider registry from the Go sidecar. Additive
+ * only — we never drop a built-in domain or port because the
+ * interceptor MUST default to the safer (more intercepting) choice
+ * when the overlay is absent or malformed. Kept tiny and exported
+ * so unit tests can exercise the merge without running a live
+ * sidecar.
+ */
+export function applyProviderRegistry(reg: {
+  providers?: Array<{ domains?: string[] | null }>;
+  ollama_ports?: number[] | null;
+}): void {
+  // Tolerate a sidecar that returns a shape we don't recognize (e.g.
+  // older schema, corrupted response). Silently no-op rather than
+  // throw: the built-in list still provides full coverage for every
+  // provider we ship with.
+  if (!reg || typeof reg !== "object") return;
+  // Domain matching downstream (isLLMUrl, isLLMHost) lower-cases the
+  // request host but compares to the raw entry. Normalize here so an
+  // overlay entry hand-edited to "Api.OpenAI.com" still matches
+  // traffic to api.openai.com.
+  const seenDomains = new Set(LLM_DOMAINS.map((d) => d.toLowerCase()));
+  const seenPorts = new Set(OLLAMA_PORTS);
+  // Cap the number of additions to guard against a runaway /
+  // corrupted sidecar response (defense-in-depth; the Go side already
+  // bounds the overlay file size).
+  const MAX_ADDITIONS = 1024;
+  let added = 0;
+  for (const p of reg.providers ?? []) {
+    if (added >= MAX_ADDITIONS) break;
+    for (const d of p?.domains ?? []) {
+      if (added >= MAX_ADDITIONS) break;
+      if (typeof d !== "string") continue;
+      const norm = d.trim().toLowerCase();
+      // Reject obviously malformed entries: empty, contains whitespace,
+      // a scheme, or a path. The Python CLI normalizes these already;
+      // this is the defensive server-side filter for hand-edits.
+      if (norm === "" || /[\s/\\]/.test(norm) || norm.includes("://")) continue;
+      if (seenDomains.has(norm)) continue;
+      seenDomains.add(norm);
+      LLM_DOMAINS.push(norm);
+      added++;
+    }
+  }
+  // Cap port additions independently of domains: a runaway overlay
+  // with tens of thousands of bogus ports would otherwise turn every
+  // isLLMUrl call into a linear scan through garbage. Real-world
+  // Ollama deployments have 1-2 ports.
+  const MAX_PORT_ADDITIONS = 64;
+  let portsAdded = 0;
+  for (const port of reg.ollama_ports ?? []) {
+    if (portsAdded >= MAX_PORT_ADDITIONS) break;
+    // Require integer (not float, not NaN, not Infinity). 3.14 would
+    // otherwise stringify to "3.14" and sit in OLLAMA_PORTS as a
+    // dead entry, a sure sign of operator error.
+    if (typeof port !== "number" || !Number.isInteger(port)) continue;
+    if (port <= 0 || port > 65535) continue;
+    const s = String(port);
+    if (seenPorts.has(s)) continue;
+    seenPorts.add(s);
+    OLLAMA_PORTS.push(s);
+    portsAdded++;
+  }
+}
+
+/**
+ * Fetch the merged provider registry from the local sidecar. Runs
+ * once at interceptor startup on a best-effort basis. Failures are
+ * swallowed so a sidecar that does not yet serve the endpoint (or
+ * that is slow to boot) cannot hold up the plugin's own start-up —
+ * the built-in list still provides full coverage for every provider
+ * we ship with.
+ *
+ * A tight 2s timeout prevents a misbehaving sidecar from blocking
+ * the extension host indefinitely.
+ */
+export async function bootstrapProviderOverlay(
+  guardrailPort: number,
+  options?: { timeoutMs?: number; fetchImpl?: typeof fetch },
+): Promise<void> {
+  const timeoutMs = options?.timeoutMs ?? 2000;
+  const doFetch = options?.fetchImpl ?? globalThis.fetch;
+  if (typeof doFetch !== "function") return;
+  // Mirror the Go-side 1 MiB overlay cap. The merged registry is
+  // tiny (a few KB) but a compromised or buggy sidecar must not be
+  // able to exhaust the extension host's memory just by serving a
+  // giant response body. 2 MiB gives 2x headroom over Go's 1 MiB
+  // ceiling without leaving room for abuse.
+  const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await doFetch(
+      `http://127.0.0.1:${guardrailPort}/v1/config/providers`,
+      { method: "GET", signal: ctrl.signal, cache: "no-store" },
+    );
+    if (!res.ok) return;
+    // If Content-Length advertises more than the cap, bail early —
+    // no sense allocating a 100 MiB buffer just to reject it. A
+    // missing or lying Content-Length is still defended by the
+    // streaming read below, which bounds actual bytes consumed.
+    const lenHdr = res.headers?.get?.("content-length");
+    if (lenHdr) {
+      const n = parseInt(lenHdr, 10);
+      if (Number.isFinite(n) && n > MAX_RESPONSE_BYTES) return;
+    }
+    // Prefer a true streaming read capped at MAX_RESPONSE_BYTES so
+    // a lying Content-Length header (or a hostile sidecar) cannot
+    // force us to allocate past the cap. We only fall back to
+    // res.text() for mock-based environments where res.body is not
+    // exposed (e.g. older Node shims used in tests).
+    let text: string | null = null;
+    const resBody = (res as unknown as { body?: ReadableStream<Uint8Array> }).body;
+    if (resBody && typeof resBody.getReader === "function") {
+      const bytes = await readStreamBounded(resBody, MAX_RESPONSE_BYTES);
+      if (bytes.byteLength > MAX_RESPONSE_BYTES) return;
+      text = decodeUtf8Safe(bytes);
+    } else if (typeof (res as Response).text === "function") {
+      const t = await (res as Response).text();
+      if (t.length > MAX_RESPONSE_BYTES) return;
+      text = t;
+    } else {
+      // Last-resort: older shim without text() nor body. res.json()
+      // has no native byte cap, so we only reach here if every
+      // better path is unavailable.
+      const body = await res.json();
+      applyProviderRegistry(
+        body as {
+          providers?: Array<{ domains?: string[] | null }>;
+          ollama_ports?: number[] | null;
+        },
+      );
+      return;
+    }
+    if (text == null) return;
+    const body: unknown = JSON.parse(text);
+    applyProviderRegistry(
+      body as {
+        providers?: Array<{ domains?: string[] | null }>;
+        ollama_ports?: number[] | null;
+      },
+    );
+  } catch {
+    // Sidecar unreachable / malformed body — we stay on the built-in
+    // list. The Go side logs the failure via its own stderr alert.
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Header name the proxy reads to determine the real upstream URL. */
+export const TARGET_URL_HEADER = "X-DC-Target-URL";
+
+/**
+ * Header carrying the real LLM provider key to the proxy.
+ * Kept separate from Authorization so the original Authorization header
+ * (which may carry a different token) is preserved verbatim.
+ */
+export const AI_AUTH_HEADER = "X-AI-Auth";
+
+/**
+ * Header carrying the defenseclaw proxy authentication token (the openclaw
+ * gateway token from OPENCLAW_GATEWAY_TOKEN / gateway.token in config.yaml).
+ * The proxy validates this for non-loopback connections; loopback connections
+ * are trusted by network topology alone.
+ */
+export const DC_AUTH_HEADER = "X-DC-Auth";
+
+/**
+ * Extract the lower-cased hostname from a URL string. Returns "" for
+ * inputs that do not parse as absolute URLs (options-bag callers,
+ * relative URLs, malformed inputs); isLLMUrl then falls through to
+ * the Ollama port rules so a relative URL to a local Ollama still
+ * gets intercepted.
+ */
+function extractHost(urlStr: string): string {
+  try {
+    return new URL(urlStr).hostname.toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Host-boundary domain match. A registered entry "api.openai.com"
+ * matches the exact host "api.openai.com" and any subdomain
+ * ("staging.api.openai.com") but NOT a suffix injection like
+ * "api.openai.com.evil.test" or a substring match somewhere inside
+ * the query string. Entries are stored lower-cased (see
+ * applyProviderRegistry + providers.json build step).
+ */
+function matchesLLMDomain(host: string): boolean {
+  if (!host) return false;
+  for (const domain of LLM_DOMAINS) {
+    // Path-style entries (e.g. "googleapis.com/v1/projects") are
+    // legacy compatibility — they can never match a hostname, so
+    // skip them. Host-based matching uses only the host-prefix of
+    // such entries.
+    const slash = domain.indexOf("/");
+    const bare = slash >= 0 ? domain.slice(0, slash) : domain;
+    if (!bare) continue;
+    if (host === bare) return true;
+    if (host.endsWith("." + bare)) return true;
+  }
+  return false;
+}
+
+export function isLLMUrl(url: string, guardrailPort: number): boolean {
+  const host = extractHost(url);
+  if (matchesLLMDomain(host)) return true;
+  // Ollama: localhost or 127.0.0.1 on known Ollama ports, but NOT the proxy port.
+  // Host-boundary matched so an attacker-controlled hostname with
+  // "localhost:11434" embedded cannot forge a hit.
+  if (host === "localhost" || host === "127.0.0.1" || host === "::1") {
+    let port = "";
+    try {
+      port = new URL(url).port;
+    } catch {
+      port = "";
+    }
+    if (!port) return false;
+    if (port === String(guardrailPort)) return false;
+    return OLLAMA_PORTS.includes(port);
+  }
+  return false;
+}
+
+function isAlreadyProxied(url: string, guardrailPort: number): boolean {
+  // Only skip requests already targeting the guardrail proxy itself.
+  return (
+    url.includes(`127.0.0.1:${guardrailPort}`) ||
+    url.includes(`localhost:${guardrailPort}`)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Layer 1: request-shape detection
+//
+// The providers.json allowlist catches the major providers by hostname, but
+// any LLM whose endpoint we have not yet learned about would slip through
+// (the "silent bypass" failure mode). Layer 1 adds a second rail that
+// inspects the *shape* of each outbound HTTP request — path suffix, body
+// schema, method, destination classification — and forces the request
+// through the guardrail proxy whenever it walks like an LLM call, even
+// when we have never seen the host before.
+//
+// This is intentionally cheap: no network, no parsing beyond a best-effort
+// JSON peek, and we return "none" on any error so a broken heuristic never
+// blocks real traffic.
+// ---------------------------------------------------------------------------
+
+/** Path fragments that identify LLM or agent APIs across providers. */
+export const LLM_PATH_SUFFIXES: ReadonlyArray<string> = [
+  "/chat/completions",
+  "/completions",
+  "/messages",
+  ":generateContent",
+  ":streamGenerateContent",
+  "/converse",
+  "/converse-stream",
+  "/api/chat",
+  "/api/generate",
+  "/responses",
+  "/backend-api/codex/responses",
+];
+
+/** Top-level JSON body keys that identify an LLM request payload. */
+export const LLM_BODY_KEYS: ReadonlyArray<string> = [
+  "messages",
+  "contents",
+  "input",
+  "prompt",
+  "inputs",
+];
+
+/**
+ * Domains we *never* want to intercept: package registries, artifact
+ * mirrors, telemetry, loopback control planes. Soft-allow branches in the
+ * proxy consult the same list on the Go side (see internal/gateway/shape.go).
+ */
+export const KNOWN_SAFE_DOMAINS: ReadonlyArray<string> = [
+  "github.com",
+  "raw.githubusercontent.com",
+  "codeload.github.com",
+  "objects.githubusercontent.com",
+  "registry.npmjs.org",
+  "npmjs.org",
+  "yarnpkg.com",
+  "pypi.org",
+  "files.pythonhosted.org",
+  "crates.io",
+  "rubygems.org",
+  "sentry.io",
+  "datadoghq.com",
+  "segment.io",
+  "segment.com",
+];
+
+export type LLMBodyShape = "messages" | "prompt" | "input" | "contents" | "none";
+
+/** Classify a parsed JSON body into one of the known LLM shapes. */
+export function classifyBodyShape(body: unknown): LLMBodyShape {
+  if (!body || typeof body !== "object") return "none";
+  const obj = body as Record<string, unknown>;
+  if (Array.isArray(obj.messages)) return "messages";
+  if (Array.isArray(obj.contents)) return "contents";
+  if (typeof obj.input === "string" || Array.isArray(obj.input)) return "input";
+  if (Array.isArray(obj.inputs)) return "input";
+  if (typeof obj.prompt === "string") return "prompt";
+  return "none";
+}
+
+function extractPath(urlStr: string): string {
+  try {
+    return new URL(urlStr).pathname;
+  } catch {
+    // options-bag style without an absolute URL; treat the raw path as-is
+    return urlStr;
+  }
+}
+
+/** Returns true when the URL ends with (or contains) a known LLM path fragment. */
+export function hasLLMPathSuffix(urlStr: string): boolean {
+  const path = extractPath(urlStr);
+  return LLM_PATH_SUFFIXES.some(s => path.endsWith(s) || path.includes(s));
+}
+
+/** Returns true when the hostname is on the package-registry / telemetry allowlist. */
+export function isKnownSafeDomain(urlStr: string): boolean {
+  let host = "";
+  try {
+    host = new URL(urlStr).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  if (!host) return false;
+  return KNOWN_SAFE_DOMAINS.some(d => host === d || host.endsWith("." + d));
+}
+
+/**
+ * Request-shape test: does this look like an LLM call even though the
+ * hostname is not in providers.json? We require either an LLM-looking
+ * path or an LLM-looking body key, and we always skip GET requests and
+ * known-safe hostnames.
+ *
+ * Callers pass the best body shape they could cheaply compute — when no
+ * body was available (e.g. https.request, streaming body) that degrades
+ * to path-only detection, which is still better than fail-open.
+ */
+export function isLLMShapedRequest(
+  urlStr: string,
+  method: string,
+  bodyShape: LLMBodyShape,
+  guardrailPort: number,
+): boolean {
+  if (!urlStr) return false;
+  if (isAlreadyProxied(urlStr, guardrailPort)) return false;
+  const m = (method || "GET").toUpperCase();
+  if (m === "GET" || m === "HEAD" || m === "OPTIONS") return false;
+  if (isKnownSafeDomain(urlStr)) return false;
+  if (hasLLMPathSuffix(urlStr)) return true;
+  if (bodyShape !== "none") return true;
+  return false;
+}
+
+/**
+ * Best-effort, read-once-safe body peek. Inputs we know how to sniff
+ * cheaply (string, Uint8Array, ArrayBuffer, Request) are decoded and
+ * JSON-parsed; anything else (ReadableStream, FormData, Blob) returns
+ * "none" rather than consuming the stream and breaking the downstream
+ * fetch.
+ *
+ * Limit is 64 KiB: an LLM payload's shape is always visible in the
+ * first page of JSON, and capping the peek prevents a hostile caller
+ * from fouling heap via a multi-GB body.
+ */
+const BODY_PEEK_CAP_BYTES = 64 * 1024;
+
+/**
+ * Safe UTF-8 decode that never throws on a mid-codepoint slice. Used
+ * by peekBodyForShape so a body cap that lands inside a multibyte
+ * sequence does not produce a parse error that misclassifies the
+ * shape.
+ */
+function decodeUtf8Safe(buf: ArrayBufferView): string {
+  return new TextDecoder("utf-8", { fatal: false }).decode(buf);
+}
+
+/**
+ * Read at most `cap` bytes from a stream without consuming beyond
+ * that cap. The stream is released early if the first chunks exceed
+ * the cap; subsequent chunks are never read, so a pathological body
+ * (GBs) never allocates past `cap` bytes. Returns the raw byte
+ * sequence so the caller can decide on encoding.
+ */
+async function readStreamBounded(
+  stream: ReadableStream<Uint8Array>,
+  cap: number,
+): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (total < cap) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      if (total + value.byteLength > cap) {
+        chunks.push(value.subarray(0, cap - total));
+        total = cap;
+        break;
+      }
+      chunks.push(value);
+      total += value.byteLength;
+    }
+  } finally {
+    // Cancel the rest of the stream so the underlying transport
+    // does not keep delivering bytes we will never consume.
+    try {
+      await reader.cancel();
+    } catch {
+      /* ignore */
+    }
+    try {
+      reader.releaseLock();
+    } catch {
+      /* ignore */
+    }
+  }
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    out.set(c, off);
+    off += c.byteLength;
+  }
+  return out;
+}
+
+export async function peekBodyForShape(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<LLMBodyShape> {
+  try {
+    if (input instanceof Request) {
+      // input.clone() keeps the caller's Request body intact for the
+      // downstream originalFetch call. Prefer a streaming read
+      // capped at BODY_PEEK_CAP_BYTES so a multi-GB body cannot
+      // exhaust the extension host's memory; only fall back to a
+      // full-body .text() if the runtime does not expose
+      // Request.body (older Node / test mocks).
+      const cloned = input.clone();
+      const stream = (cloned as unknown as { body?: ReadableStream<Uint8Array> })
+        .body;
+      let bytes: Uint8Array;
+      if (stream && typeof stream.getReader === "function") {
+        bytes = await readStreamBounded(stream, BODY_PEEK_CAP_BYTES);
+      } else {
+        const text = await cloned.text().catch(() => "");
+        if (!text) return "none";
+        // Text path: cap on character count as a byte upper-bound
+        // (UTF-16 char count ≥ UTF-8 byte count in practice for
+        // typical ASCII-dominant LLM payloads; worst case 4-byte
+        // codepoints still fit well under 64 KiB).
+        const capped = text.length > BODY_PEEK_CAP_BYTES
+          ? text.slice(0, BODY_PEEK_CAP_BYTES)
+          : text;
+        try {
+          return classifyBodyShape(JSON.parse(capped));
+        } catch {
+          return "none";
+        }
+      }
+      if (bytes.byteLength === 0) return "none";
+      try {
+        return classifyBodyShape(JSON.parse(decodeUtf8Safe(bytes)));
+      } catch {
+        return "none";
+      }
+    }
+    const body = init?.body as unknown;
+    if (body == null) return "none";
+    if (typeof body === "string") {
+      try {
+        return classifyBodyShape(JSON.parse(body.slice(0, BODY_PEEK_CAP_BYTES)));
+      } catch {
+        return "none";
+      }
+    }
+    if (body instanceof Uint8Array) {
+      const slice = body.subarray(0, BODY_PEEK_CAP_BYTES);
+      try {
+        return classifyBodyShape(JSON.parse(decodeUtf8Safe(slice)));
+      } catch {
+        return "none";
+      }
+    }
+    if (body instanceof ArrayBuffer) {
+      const view = new Uint8Array(body).subarray(0, BODY_PEEK_CAP_BYTES);
+      try {
+        return classifyBodyShape(JSON.parse(decodeUtf8Safe(view)));
+      } catch {
+        return "none";
+      }
+    }
+    // ReadableStream, FormData, Blob, etc. — consuming them would break
+    // the downstream fetch. Fall back to path-only detection.
+    return "none";
+  } catch {
+    return "none";
+  }
+}
+
+/**
+ * Extract the provider API key from whichever header the provider SDK uses.
+ * Different providers use different auth mechanisms:
+ *   - OpenAI / OpenRouter / Gemini compat: Authorization: Bearer <key>
+ *   - Anthropic: x-api-key: <key>
+ *   - Azure OpenAI: api-key: <key>
+ *   - Gemini native: ?key= query param (handled separately, not in headers)
+ *   - Bedrock: AWS SigV4 (multiple headers, not a simple key)
+ *   - Ollama: no auth
+ *
+ * Returns the key prefixed with "Bearer " for consistency, or empty string.
+ */
+function extractProviderKey(headers: Headers): string {
+  // Authorization: Bearer <key> — most providers
+  const auth = headers.get("Authorization") ?? "";
+  if (auth && !auth.startsWith("Bearer sk-dc-")) {
+    return auth;
+  }
+  // x-api-key — Anthropic
+  const xApiKey = headers.get("x-api-key") ?? "";
+  if (xApiKey) {
+    return `Bearer ${xApiKey}`;
+  }
+  // api-key — Azure OpenAI
+  const apiKey = headers.get("api-key") ?? "";
+  if (apiKey) {
+    return `Bearer ${apiKey}`;
+  }
+  return "";
+}
+
+/**
+ * Same as extractProviderKey but for Node http.request headers (plain object,
+ * case-sensitive keys).
+ */
+function extractProviderKeyFromRecord(hdrs: Record<string, string>): string {
+  const auth = hdrs["Authorization"] ?? hdrs["authorization"] ?? "";
+  if (auth && !auth.startsWith("Bearer sk-dc-")) {
+    return auth;
+  }
+  const xApiKey = hdrs["x-api-key"] ?? hdrs["X-Api-Key"] ?? "";
+  if (xApiKey) {
+    return `Bearer ${xApiKey}`;
+  }
+  const apiKey = hdrs["api-key"] ?? hdrs["Api-Key"] ?? "";
+  if (apiKey) {
+    return `Bearer ${apiKey}`;
+  }
+  return "";
+}
+
+/**
+ * Synchronous snapshot of DefenseClaw correlation headers injected onto
+ * every intercepted LLM request. Returning an empty object is legal: the
+ * Go side treats any missing header as "unknown". Anything the getter
+ * does return is forwarded verbatim to the guardrail proxy so the audit /
+ * gateway.jsonl / OTel surfaces all see the same keys at once.
+ */
+export type CorrelationHeadersGetter = () => Record<string, string>;
+
+/**
+ * Build the proxy-hop headers (X-DC-Target-URL, X-AI-Auth, X-DC-Auth) plus
+ * any caller-supplied correlation headers (X-DefenseClaw-*) the guardrail
+ * proxy's CorrelationMiddleware stamps onto the audit envelope.
+ *
+ * OpenClaw already resolves the real provider API key and sets it in the
+ * appropriate header for each provider SDK. We extract it from whichever
+ * header is used and forward it as X-AI-Auth for uniform proxy handling.
+ */
+function buildProxyHeaders(
+  targetOrigin: string,
+  providerKey: string,
+  getCorrelationHeaders: CorrelationHeadersGetter,
+): Record<string, string> {
+  const hdrs: Record<string, string> = {
+    [TARGET_URL_HEADER]: targetOrigin,
+  };
+
+  if (providerKey) {
+    hdrs[AI_AUTH_HEADER] = providerKey;
+  }
+
+  // X-DC-Auth: proxy authentication token for remote deployments.
+  const sidecarToken = loadSidecarConfig().token;
+  if (sidecarToken) {
+    hdrs[DC_AUTH_HEADER] = `Bearer ${sidecarToken}`;
+  }
+
+  // v7 correlation: inject X-DefenseClaw-* headers so the proxy's
+  // CorrelationMiddleware can stamp agent_id / session_id / run_id /
+  // trace_id / policy_id on every guardrail-* audit row. Without this,
+  // every LLM request emitted via the fetch interceptor landed in
+  // SQLite with those columns NULL because the proxy has no other way
+  // to learn plugin-side identity on an intercepted hop.
+  let corr: Record<string, string> | undefined;
+  try {
+    corr = getCorrelationHeaders();
+  } catch {
+    // Never let a misbehaving getter break LLM traffic — missing
+    // correlation headers are recoverable, blocked LLM calls are not.
+  }
+  if (corr) {
+    for (const [k, v] of Object.entries(corr)) {
+      if (v !== undefined && v !== "") hdrs[k] = v;
+    }
+  }
+
+  return hdrs;
+}
+
+/**
+ * Default getter that returns nothing. Used when callers construct an
+ * interceptor without wiring identity — keeps older call sites working.
+ */
+const emptyCorrelationHeaders: CorrelationHeadersGetter = () => ({});
+
+/** Canonical header-name set so callers outside this module can stay DRY. */
+export const DEFENSECLAW_CORRELATION_HEADER_NAMES = [
+  HEADER_DEFENSECLAW_AGENT_ID,
+  HEADER_DEFENSECLAW_AGENT_INSTANCE_ID,
+  HEADER_DEFENSECLAW_AGENT_NAME,
+  HEADER_DEFENSECLAW_POLICY_ID,
+  HEADER_DEFENSECLAW_RUN_ID,
+  HEADER_DEFENSECLAW_SESSION_ID,
+  HEADER_DEFENSECLAW_SIDECAR_INSTANCE_ID,
+  HEADER_DEFENSECLAW_TRACE_ID,
+] as const;
+
+export interface CreateFetchInterceptorOptions {
+  guardrailPort: number;
+  /**
+   * Synchronous snapshot of DefenseClaw X-DefenseClaw-* correlation
+   * headers to stamp on every intercepted LLM request. Called once per
+   * request — implementations should return cached values rather than
+   * performing I/O.
+   */
+  getCorrelationHeaders?: CorrelationHeadersGetter;
+}
+
+/**
+ * Creates an interceptor that, when started, patches globalThis.fetch to
+ * redirect LLM API calls through the guardrail proxy.
+ * Call stop() to restore the original fetch.
+ *
+ * Accepts either a legacy `guardrailPort` number (backwards-compatible
+ * with existing tests) or a structured options bag that additionally
+ * carries a correlation-headers getter.
+ */
+export function createFetchInterceptor(
+  portOrOpts: number | CreateFetchInterceptorOptions,
+) {
+  const interceptorOpts: CreateFetchInterceptorOptions =
+    typeof portOrOpts === "number"
+      ? { guardrailPort: portOrOpts }
+      : portOrOpts;
+  const guardrailPort = interceptorOpts.guardrailPort;
+  const getCorrelationHeaders =
+    interceptorOpts.getCorrelationHeaders ?? emptyCorrelationHeaders;
+  const proxyBase = `http://127.0.0.1:${guardrailPort}`;
+  let originalFetch: typeof globalThis.fetch | null = null;
+  let originalHttpsRequest: typeof https.request | null = null;
+  let egressReporter: EgressReporter | null = null;
+
+  // Extract { host, path } from a URL string without throwing. Missing
+  // pieces are tolerated so the caller's downstream fetch is never
+  // perturbed by a malformed URL in telemetry.
+  function extractHostPath(urlStr: string): { host: string; path: string } {
+    try {
+      const u = new URL(urlStr);
+      return { host: u.hostname, path: `${u.pathname}${u.search}` };
+    } catch {
+      return { host: "", path: urlStr };
+    }
+  }
+
+  function start(): void {
+    if (originalFetch) return; // already started
+    originalFetch = globalThis.fetch;
+    egressReporter = createEgressReporter({ guardrailPort });
+
+    // Layer 4 (governance): pull the sidecar's merged provider
+    // registry so operator-added domains (via `defenseclaw setup
+    // provider add` or a hand-edited custom-providers.json) take
+    // effect without rebuilding the plugin. Best-effort, short
+    // timeout; we use the process-supplied fetch BEFORE we swap it
+    // out below so the bootstrap call is not intercepted by the
+    // wrapper we're about to install.
+    void bootstrapProviderOverlay(guardrailPort, {
+      fetchImpl: originalFetch,
+    });
+
+    globalThis.fetch = async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const urlStr = String(input instanceof Request ? input.url : input);
+
+      // Never self-loop: a request already aimed at the guardrail proxy
+      // short-circuits before any shape inspection so we don't peek its body.
+      if (isAlreadyProxied(urlStr, guardrailPort)) {
+        return originalFetch!(input, init);
+      }
+
+      // Layer 0: the known-provider allowlist is cheap and path-free.
+      const knownLLM = isLLMUrl(urlStr, guardrailPort);
+      let shouldIntercept = knownLLM;
+      let shapeBranch: "known" | "shape" | "passthrough" = knownLLM ? "known" : "passthrough";
+      let bodyShape: LLMBodyShape = "none";
+
+      // Layer 1: request-shape detection. Only peek the body when the
+      // allowlist didn't already match — peeking costs a clone().
+      if (!knownLLM) {
+        const method = (input instanceof Request ? input.method : init?.method) ?? "GET";
+        bodyShape = await peekBodyForShape(input, init);
+        if (isLLMShapedRequest(urlStr, method, bodyShape, guardrailPort)) {
+          shouldIntercept = true;
+          shapeBranch = "shape";
+        }
+      }
+
+      if (!shouldIntercept) {
+        // Layer 3: silent-bypass telemetry. Report every request that
+        // left our interceptor without being rewritten so operators
+        // can spot "known LLM-shaped call to unknown host" cases.
+        const hp = extractHostPath(urlStr);
+        egressReporter?.report({
+          targetHost: hp.host,
+          targetPath: hp.path,
+          bodyShape,
+          looksLikeLLM: bodyShape !== "none" || hasLLMPathSuffix(urlStr),
+          branch: "passthrough",
+          decision: "allow",
+          reason: "no-match",
+        });
+        return originalFetch!(input, init);
+      }
+
+      let original: URL;
+      try {
+        original = new URL(urlStr);
+      } catch {
+        return originalFetch!(input, init);
+      }
+
+      // Rewrite: keep path + query, replace scheme://host with proxy.
+      const proxied = `${proxyBase}${original.pathname}${original.search}`;
+
+      // Merge all original headers and add proxy-hop headers.
+      const headers = new Headers(
+        input instanceof Request ? input.headers : (init?.headers as HeadersInit | undefined),
+      );
+      const providerKey = extractProviderKey(headers);
+      const proxyHdrs = buildProxyHeaders(
+        original.origin,
+        providerKey,
+        getCorrelationHeaders,
+      );
+      for (const [k, v] of Object.entries(proxyHdrs)) {
+        headers.set(k, v);
+      }
+
+      // Build new init, preserving all original properties.
+      const newInit: RequestInit =
+        input instanceof Request
+          ? { method: input.method, body: input.body, headers }
+          : { ...(init ?? {}), headers };
+
+      if (shapeBranch === "shape") {
+        console.log(
+          `[defenseclaw] intercepted LLM-shaped call → ${urlStr} (body_shape=${bodyShape}) proxied via ${proxyBase}`,
+        );
+      } else {
+        console.log(
+          `[defenseclaw] intercepted LLM call → ${urlStr} proxied via ${proxyBase}`,
+        );
+      }
+
+      const response = await originalFetch!(proxied, newInit);
+
+      const blocked = response.headers.get("x-defenseclaw-blocked") === "true";
+      if (blocked) {
+        console.warn(
+          "[defenseclaw] REQUEST BLOCKED by guardrail policy",
+        );
+      }
+
+      // Report the routed-through-proxy call so egress telemetry
+      // reflects both the "known" and "shape" branches the Go
+      // passthrough reports for server-originated traffic.
+      const hp = extractHostPath(urlStr);
+      egressReporter?.report({
+        targetHost: hp.host,
+        targetPath: hp.path,
+        bodyShape,
+        looksLikeLLM: true,
+        branch: shapeBranch === "shape" ? "shape" : "known",
+        decision: blocked ? "block" : "allow",
+        reason: shapeBranch === "shape" ? "shape-match" : "known-provider",
+      });
+
+      return response;
+    };
+
+    // Also patch https.request so axios, undici, and other non-fetch HTTP
+    // clients are intercepted. All of them ultimately use node:https.request.
+    originalHttpsRequest = https.request.bind(https);
+    const originalHttpRequest = http.request.bind(http);
+
+    type NodeRequestOptions = Record<string, unknown>;
+    type NodeIncomingMessage = unknown;
+    type NodeClientRequest = ReturnType<typeof http.request>;
+
+    /**
+     * Normalize the varied `https.request` call shapes into a single URL string
+     * we can match against LLM provider domains. Callers may pass:
+     *   - request(url: string)
+     *   - request(url: URL)
+     *   - request(options)                   // { host|hostname, port, path, protocol }
+     *   - request(url, options)              // URL first, then extra options
+     * @smithy/node-http-handler v4 passes an options object with `host` (NOT
+     * `hostname`), separate `port`, and separate `path`, so we must read both
+     * `host` and `hostname` and fold `path` back in to match on domain + path.
+     */
+    function buildUrlStringFromArgs(
+      urlOrOptions: string | URL | NodeRequestOptions,
+      secondArg: NodeRequestOptions | ((res: NodeIncomingMessage) => void) | undefined,
+    ): string {
+      if (typeof urlOrOptions === "string") return urlOrOptions;
+      if (urlOrOptions instanceof URL) return urlOrOptions.toString();
+
+      const opts = urlOrOptions as {
+        host?: unknown;
+        hostname?: unknown;
+        port?: unknown;
+        path?: unknown;
+        protocol?: unknown;
+      };
+      const overlay = (typeof secondArg === "object" && secondArg !== null
+        ? (secondArg as typeof opts)
+        : {});
+
+      const host =
+        (typeof overlay.hostname === "string" && overlay.hostname) ||
+        (typeof overlay.host === "string" && overlay.host) ||
+        (typeof opts.hostname === "string" && opts.hostname) ||
+        (typeof opts.host === "string" && opts.host) ||
+        "";
+      const port =
+        (overlay.port !== undefined ? String(overlay.port) : "") ||
+        (opts.port !== undefined ? String(opts.port) : "");
+      const path =
+        (typeof overlay.path === "string" && overlay.path) ||
+        (typeof opts.path === "string" && opts.path) ||
+        "/";
+      const proto =
+        (typeof overlay.protocol === "string" && overlay.protocol) ||
+        (typeof opts.protocol === "string" && opts.protocol) ||
+        "https:";
+
+      if (!host) return "";
+      const hostPart = port ? `${host}:${port}` : host;
+      return `${proto}//${hostPart}${path}`;
+    }
+
+    function patchedHttpsRequest(
+      urlOrOptions: string | URL | NodeRequestOptions,
+      optionsOrCallback?: NodeRequestOptions | ((res: NodeIncomingMessage) => void),
+      callback?: (res: NodeIncomingMessage) => void,
+    ): NodeClientRequest {
+      const urlStr = buildUrlStringFromArgs(urlOrOptions, optionsOrCallback);
+
+      // Path-only shape detection for https.request — the body is
+      // written via req.write after this call returns, so peeking is
+      // not an option. hasLLMPathSuffix still catches the overwhelming
+      // majority of unknown-provider SDKs (Bedrock converse-stream,
+      // Anthropic /messages, Gemini :generateContent, ollama /api/chat).
+      const shapedForHTTPS = Boolean(
+        urlStr &&
+          !isKnownSafeDomain(urlStr) &&
+          !isAlreadyProxied(urlStr, guardrailPort) &&
+          hasLLMPathSuffix(urlStr),
+      );
+      const knownForHTTPS = Boolean(
+        urlStr && isLLMUrl(urlStr, guardrailPort) && !isAlreadyProxied(urlStr, guardrailPort),
+      );
+
+      if (urlStr && (knownForHTTPS || shapedForHTTPS)) {
+        let opts: NodeRequestOptions = {};
+        let cb = callback;
+
+        if (typeof optionsOrCallback === "function") {
+          cb = optionsOrCallback;
+          opts = typeof urlOrOptions === "string" || urlOrOptions instanceof URL
+            ? {} : urlOrOptions as NodeRequestOptions;
+        } else if (optionsOrCallback && typeof optionsOrCallback === "object") {
+          opts = optionsOrCallback as NodeRequestOptions;
+        }
+
+        let originalUrl: URL;
+        try {
+          originalUrl = new URL(urlStr);
+        } catch {
+          return originalHttpsRequest!(urlOrOptions as string, optionsOrCallback as NodeRequestOptions, callback);
+        }
+
+        const hdrs = opts.headers as Record<string, string> ?? {};
+        const providerKey = extractProviderKeyFromRecord(hdrs);
+        const proxyHdrs = buildProxyHeaders(
+          originalUrl.origin,
+          providerKey,
+          getCorrelationHeaders,
+        );
+
+        // Spread `opts` first, then overwrite target fields. Crucially, drop:
+        //
+        //  - `host` (smithy passes `host` not `hostname`; Node's `host` wins
+        //    over `hostname` in some paths, which would send traffic to the
+        //    original LLM domain instead of the proxy);
+        //  - `agent` (callers like @smithy/node-http-handler pass an
+        //    `https.Agent`. Node's `http.request` rejects an agent whose
+        //    `protocol === "https:"` with `ERR_INVALID_PROTOCOL`: "Protocol
+        //    'http:' not supported. Expected 'https:'". We want Node to use
+        //    the default http agent for the proxy hop, so set `agent: false`);
+        //  - TLS-only options (`ca`, `cert`, `key`, ...) which have no meaning
+        //    on a plain http.request and could still drag protocol checks in.
+        const {
+          host: _legacyHost,
+          agent: _legacyAgent,
+          ca: _ca,
+          cert: _cert,
+          key: _key,
+          pfx: _pfx,
+          passphrase: _passphrase,
+          servername: _servername,
+          ciphers: _ciphers,
+          ecdhCurve: _ecdhCurve,
+          secureProtocol: _secureProtocol,
+          minVersion: _minVersion,
+          maxVersion: _maxVersion,
+          sigalgs: _sigalgs,
+          crl: _crl,
+          dhparam: _dhparam,
+          rejectUnauthorized: _rejectUnauthorized,
+          checkServerIdentity: _checkServerIdentity,
+          session: _session,
+          allowPartialTrustChain: _allowPartialTrustChain,
+          ...restOpts
+        } = opts as { host?: unknown; agent?: unknown } & Record<string, unknown>;
+        void _legacyHost;
+        void _legacyAgent;
+        void _ca;
+        void _cert;
+        void _key;
+        void _pfx;
+        void _passphrase;
+        void _servername;
+        void _ciphers;
+        void _ecdhCurve;
+        void _secureProtocol;
+        void _minVersion;
+        void _maxVersion;
+        void _sigalgs;
+        void _crl;
+        void _dhparam;
+        void _rejectUnauthorized;
+        void _checkServerIdentity;
+        void _session;
+        void _allowPartialTrustChain;
+        const newOpts: NodeRequestOptions = {
+          ...restOpts,
+          hostname: "127.0.0.1",
+          port: guardrailPort,
+          protocol: "http:",
+          path: `${originalUrl.pathname}${originalUrl.search}`,
+          headers: { ...hdrs, ...proxyHdrs },
+          // Force Node to pick a default http.Agent for this request. Leaving
+          // the caller's https.Agent in place would throw at socket allocation.
+          agent: false,
+        };
+
+        if (!knownForHTTPS && shapedForHTTPS) {
+          console.log(`[defenseclaw] intercepted LLM-shaped call (https.request) → ${urlStr} (path-match) proxied via ${proxyBase}`);
+        } else {
+          console.log(`[defenseclaw] intercepted LLM call (https.request) → ${urlStr} proxied via ${proxyBase}`);
+        }
+        // Egress telemetry for the https.request branches. body_shape
+        // is intentionally "none" because req.write happens after we
+        // return — the body is not observable here.
+        {
+          const hp = extractHostPath(urlStr);
+          egressReporter?.report({
+            targetHost: hp.host,
+            targetPath: hp.path,
+            bodyShape: "none",
+            looksLikeLLM: true,
+            branch: !knownForHTTPS && shapedForHTTPS ? "shape" : "known",
+            decision: "allow",
+            reason: !knownForHTTPS && shapedForHTTPS ? "shape-match" : "known-provider",
+          });
+        }
+        return http.request(newOpts as unknown as Parameters<typeof http.request>[0], cb as Parameters<typeof http.request>[1]);
+      }
+
+      // Non-intercepted https.request — report silent passthrough so
+      // the TUI/egress event log sees LLM-looking calls slipping past
+      // the known-provider + shape rails (e.g. an unknown SDK we
+      // have never classified).
+      if (urlStr) {
+        const hp = extractHostPath(urlStr);
+        egressReporter?.report({
+          targetHost: hp.host,
+          targetPath: hp.path,
+          bodyShape: "none",
+          looksLikeLLM: hasLLMPathSuffix(urlStr),
+          branch: "passthrough",
+          decision: "allow",
+          reason: "no-match",
+        });
+      }
+      return originalHttpsRequest!(urlOrOptions as string, optionsOrCallback as NodeRequestOptions, callback);
+    }
+
+    https.request = patchedHttpsRequest as typeof https.request;
+
+    console.log(
+      `[defenseclaw] LLM fetch interceptor active (proxy: ${proxyBase})`,
+    );
+  }
+
+  function stop(): void {
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+      originalFetch = null;
+    }
+    // Restore https.request (safe because we used CJS require, not frozen ESM)
+    if (originalHttpsRequest) {
+      https.request = originalHttpsRequest;
+    }
+    if (egressReporter) {
+      egressReporter.stop();
+      egressReporter = null;
+    }
+    console.log("[defenseclaw] LLM fetch interceptor stopped");
+  }
+
+  return { start, stop };
+}

--- a/output-plugin/src/health-monitor.ts
+++ b/output-plugin/src/health-monitor.ts
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Health monitor that periodically checks the DefenseClaw sidecar and
+ * exposes an `isUnprotected` flag for the fetch interceptor to query.
+ *
+ * The monitor does NOT block LLM calls — it only warns.
+ */
+
+import type { OutboundSidecarRequestLog } from "./types.js";
+
+const POLL_INTERVAL_MS = 60_000;
+
+export interface HealthMonitorOptions {
+  statusUrl: string;
+  token?: string;
+  pollIntervalMs?: number;
+  /** Correlation headers for sidecar observability (optional). */
+  buildSidecarHeaders?: () => Promise<Record<string, string>>;
+  /** Sticky echo headers from the sidecar (optional). */
+  onFetchResponse?: (res: Response) => void;
+  /** Structured outbound request logging (optional). */
+  logOutboundRequest?: (entry: OutboundSidecarRequestLog) => void;
+  getLogAgentId?: () => string;
+}
+
+export class HealthMonitor {
+  private readonly statusUrl: string;
+  private readonly token: string;
+  private readonly pollIntervalMs: number;
+  private readonly buildSidecarHeaders?: () => Promise<Record<string, string>>;
+  private readonly onFetchResponse?: (res: Response) => void;
+  private readonly logOutboundRequest?: (entry: OutboundSidecarRequestLog) => void;
+  private readonly getLogAgentId?: () => string;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private _unprotected = false;
+  private _wasUnprotected = false;
+
+  constructor(opts: HealthMonitorOptions) {
+    this.statusUrl = opts.statusUrl;
+    this.token = opts.token ?? "";
+    this.pollIntervalMs = opts.pollIntervalMs ?? POLL_INTERVAL_MS;
+    this.buildSidecarHeaders = opts.buildSidecarHeaders;
+    this.onFetchResponse = opts.onFetchResponse;
+    this.logOutboundRequest = opts.logOutboundRequest;
+    this.getLogAgentId = opts.getLogAgentId;
+  }
+
+  get isUnprotected(): boolean {
+    return this._unprotected;
+  }
+
+  start(): void {
+    if (this.timer) return;
+
+    // Run an initial check immediately.
+    void this.check();
+
+    this.timer = setInterval(() => void this.check(), this.pollIntervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private async check(): Promise<void> {
+    const started = performance.now();
+    try {
+      const extra = this.buildSidecarHeaders
+        ? await this.buildSidecarHeaders()
+        : {};
+      const headers: Record<string, string> = { ...extra };
+      if (this.token && !headers.Authorization) {
+        headers.Authorization = `Bearer ${this.token}`;
+      }
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 5_000);
+      const resp = await fetch(this.statusUrl, {
+        signal: controller.signal,
+        headers,
+      });
+      clearTimeout(timeout);
+
+      this.onFetchResponse?.(resp);
+
+      const duration_ms = Math.round(performance.now() - started);
+      this.logOutboundRequest?.({
+        agentId: this.getLogAgentId?.() ?? "unknown",
+        status_code: resp.status,
+        duration_ms,
+      });
+
+      if (resp.ok) {
+        const body = await resp.json();
+        const gwState = body?.health?.gateway?.state ?? "";
+        if (gwState === "running") {
+          if (this._unprotected) {
+            console.log("[defenseclaw] Gateway is back online. Protection restored.");
+          }
+          this._unprotected = false;
+          this._wasUnprotected = false;
+        } else {
+          this.markUnprotected();
+        }
+      } else {
+        this.markUnprotected();
+      }
+    } catch {
+      const duration_ms = Math.round(performance.now() - started);
+      this.logOutboundRequest?.({
+        agentId: this.getLogAgentId?.() ?? "unknown",
+        status_code: 0,
+        duration_ms,
+      });
+      this.markUnprotected();
+    }
+  }
+
+  private markUnprotected(): void {
+    this._unprotected = true;
+    if (!this._wasUnprotected) {
+      this._wasUnprotected = true;
+      console.warn(
+        "[defenseclaw] WARNING: The DefenseClaw security gateway is not running. " +
+          "Your prompts and responses are NOT being scanned for security threats. " +
+          "Run 'defenseclaw-gateway start' to restore protection.",
+      );
+    }
+  }
+
+  /**
+   * Returns a warning message if the sidecar is unreachable, or null if healthy.
+   * The fetch interceptor can prepend this to LLM requests as a system message.
+   */
+  getWarningMessage(): string | null {
+    if (!this._unprotected) return null;
+    return (
+      "[DEFENSECLAW WARNING] The DefenseClaw security gateway is not running. " +
+      "Your prompts and responses are NOT being scanned for security threats. " +
+      "Run 'defenseclaw-gateway start' to restore protection."
+    );
+  }
+}

--- a/output-plugin/src/index.ts
+++ b/output-plugin/src/index.ts
@@ -1,0 +1,561 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * DefenseClaw OpenClaw Plugin — ClawHub standalone edition
+ *
+ * Integrates DefenseClaw security into the OpenClaw plugin lifecycle.
+ * This is the standalone version installable from ClawHub; it does not
+ * require DefenseClaw to deploy the plugin — any OpenClaw user can
+ * install it and point it at a DefenseClaw gateway.
+ *
+ * Runtime:
+ *  - before_tool_call: intercepts tool calls via the Go sidecar inspect API
+ *
+ * Slash commands (prefixed to avoid collision with embedded plugin):
+ *  - /dc-scan <path>: scan a skill directory
+ *  - /dc-block <type> <name> [reason]: block a skill, MCP, or plugin
+ *  - /dc-allow <type> <name> [reason]: allow-list a skill, MCP, or plugin
+ *
+ * The plugin uses:
+ *  1. CLI shell-out to `defenseclaw` for plugin/skill/code scans (full scanner suite)
+ *  2. Native TS scanner for MCP configs (in-process, fast)
+ *  3. REST API to the Go sidecar for tool inspection and audit logging
+ */
+
+import { randomUUID } from "node:crypto";
+import type { PluginApi, ToolContext } from "@openclaw/plugin-sdk";
+import {
+  bootstrapPluginIdentity,
+  createGlobalStateStorage,
+  createInMemoryStorage,
+  type BootstrapPluginIdentityResult,
+  type KeyValueStorage,
+} from "./agent_identity.js";
+import { DaemonClient } from "./client.js";
+import {
+  HEADER_DEFENSECLAW_AGENT_ID,
+  HEADER_DEFENSECLAW_AGENT_INSTANCE_ID,
+  HEADER_DEFENSECLAW_AGENT_NAME,
+  HEADER_DEFENSECLAW_POLICY_ID,
+  HEADER_DEFENSECLAW_RUN_ID,
+  HEADER_DEFENSECLAW_SESSION_ID,
+  HEADER_DEFENSECLAW_SIDECAR_INSTANCE_ID,
+  HEADER_DEFENSECLAW_TRACE_ID,
+  HEADER_HTTP_CONTENT_TYPE,
+} from "./correlation-headers.js";
+
+/** OpenClaw passes full gateway config and the defenseclaw-plugin entry config. */
+type DefenseClawPluginHost = PluginApi & {
+  config?: unknown;
+  pluginConfig?: {
+    awsHttp1Shim?: "auto" | "on" | "off";
+    sidecarHost?: string;
+    sidecarPort?: number;
+    guardrailPort?: number;
+  };
+};
+import { PolicyEnforcer, runSkillScan, runPluginScan, runCodeScan } from "./policy/enforcer.js";
+import { scanMCPServer } from "./scanners/mcp-scanner.js";
+import type {
+  ScanResult,
+  Finding,
+  InstallType,
+  OutboundSidecarRequestLog,
+} from "./types.js";
+import { compareSeverity, maxSeverity } from "./types.js";
+import { patchAwsSdkHttp1ForGuardrail } from "./aws-sdk-http1-for-guardrail.js";
+import { loadSidecarConfig } from "./sidecar-config.js";
+import { createFetchInterceptor } from "./fetch-interceptor.js";
+import { HealthMonitor } from "./health-monitor.js";
+
+const LOG_PREFIX = "[defenseclaw-plugin]";
+
+async function readPluginAgentSection(api: PluginApi): Promise<{
+  id?: string;
+  name?: string;
+  policyId?: string;
+}> {
+  const ext = api as PluginApi & {
+    getPluginConfig?: () => Promise<Record<string, unknown>>;
+  };
+  if (typeof ext.getPluginConfig !== "function") return {};
+  try {
+    const c = await ext.getPluginConfig();
+    const agent = c?.agent as Record<string, unknown> | undefined;
+    if (!agent || typeof agent !== "object") return {};
+    const id = agent.id;
+    const name = agent.name;
+    const policyId = agent.policyId;
+    return {
+      id: typeof id === "string" && id.trim() ? id.trim() : undefined,
+      name: typeof name === "string" && name ? name : undefined,
+      policyId:
+        typeof policyId === "string" && policyId ? policyId : undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
+function resolveIdentityStorage(api: PluginApi): KeyValueStorage {
+  const ext = api as PluginApi & {
+    globalState?: {
+      get(key: string): unknown;
+      update(key: string, value: unknown): Promise<void>;
+    };
+  };
+  if (ext.globalState && typeof ext.globalState.get === "function") {
+    return createGlobalStateStorage(ext.globalState);
+  }
+  return createInMemoryStorage();
+}
+
+function formatFindings(findings: Finding[], limit = 15): string[] {
+  const lines: string[] = [];
+  const sorted = [...findings].sort(
+    (a, b) => compareSeverity(b.severity, a.severity),
+  );
+
+  for (const f of sorted.slice(0, limit)) {
+    const loc = f.location ? ` (${f.location})` : "";
+    lines.push(`- **[${f.severity}]** ${f.title}${loc}`);
+  }
+
+  if (findings.length > limit) {
+    lines.push(`- ... and ${findings.length - limit} more`);
+  }
+
+  return lines;
+}
+
+export default function (api: DefenseClawPluginHost) {
+  // Resolve sidecar config from plugin configSchema (ClawHub settings)
+  const pluginOverrides = {
+    host: api.pluginConfig?.sidecarHost,
+    apiPort: api.pluginConfig?.sidecarPort,
+    guardrailPort: api.pluginConfig?.guardrailPort,
+  };
+
+  // Before any BedrockRuntimeClient: AWS SDK v3 uses HTTP/2 unless
+  // AWS_BEDROCK_FORCE_HTTP1=1; we set that plus an optional Smithy patch so
+  // Bedrock traffic hits our https.request hook (the guardrail proxy).
+  patchAwsSdkHttp1ForGuardrail({
+    openclawConfig: api.config,
+    pluginConfig: api.pluginConfig,
+  });
+
+  // ─── Runtime: tool call interception ───
+
+  const sidecarConfig = loadSidecarConfig(pluginOverrides);
+  const SIDECAR_API = sidecarConfig.baseUrl;
+  const SIDECAR_TOKEN = sidecarConfig.token;
+  const INSPECT_TIMEOUT_MS = 2_000;
+
+  let identityCache: BootstrapPluginIdentityResult | undefined;
+  let pluginAgentExtras: { name?: string; policyId?: string } = {};
+
+  const identityReady = (async () => {
+    const section = await readPluginAgentSection(api);
+    pluginAgentExtras = { name: section.name, policyId: section.policyId };
+    const result = await bootstrapPluginIdentity({
+      storage: resolveIdentityStorage(api),
+      getConfigAgentId: async () => section.id,
+    });
+    identityCache = result;
+    return result;
+  })();
+
+  const logOutboundRequest = (entry: OutboundSidecarRequestLog): void => {
+    console.log(
+      JSON.stringify({
+        message: "defenseclaw.plugin.sidecar_request",
+        ...entry,
+      }),
+    );
+  };
+
+  const daemonClient = new DaemonClient({
+    baseUrl: sidecarConfig.baseUrl,
+    token: sidecarConfig.token,
+    identityReady,
+    getCorrelation: () => ({
+      agentId: identityCache?.agentId ?? "unknown",
+      agentInstanceId: identityCache?.sessionAgentInstanceId,
+      agentName: pluginAgentExtras.name,
+      policyId: pluginAgentExtras.policyId,
+      traceId: randomUUID(),
+    }),
+    logOutboundRequest,
+  });
+
+  const enforcer = new PolicyEnforcer(
+    { daemonUrl: sidecarConfig.baseUrl },
+    daemonClient,
+  );
+
+  // ─── Health monitor ───
+  const healthMonitor = new HealthMonitor({
+    statusUrl: `${SIDECAR_API}/status`,
+    token: SIDECAR_TOKEN,
+    buildSidecarHeaders: () => daemonClient.buildOutboundHeaders(),
+    onFetchResponse: (res) => daemonClient.applyStickyFromHttpResponse(res),
+    logOutboundRequest,
+    getLogAgentId: () => identityCache?.agentId ?? "unknown",
+  });
+
+  let currentToolContext: { sessionId?: string; runId?: string } = {};
+
+  const trackToolContext = (ctx?: ToolContext): void => {
+    if (!ctx) return;
+    const sessionId = ctx.sessionId ?? ctx.sessionKey;
+    const runId = ctx.runId;
+    if (sessionId || runId) {
+      currentToolContext = { sessionId, runId };
+    }
+  };
+
+  const getFetchCorrelationHeaders = (): Record<string, string> => {
+    const h: Record<string, string> = {};
+    const agentId = identityCache?.agentId;
+    if (agentId) h[HEADER_DEFENSECLAW_AGENT_ID] = agentId;
+
+    const agentInstanceId =
+      daemonClient.getStickyAgentInstanceId() ??
+      identityCache?.sessionAgentInstanceId;
+    if (agentInstanceId) {
+      h[HEADER_DEFENSECLAW_AGENT_INSTANCE_ID] = agentInstanceId;
+    }
+
+    const sidecarInstanceId = daemonClient.getEchoedSidecarInstanceId();
+    if (sidecarInstanceId) {
+      h[HEADER_DEFENSECLAW_SIDECAR_INSTANCE_ID] = sidecarInstanceId;
+    }
+
+    if (pluginAgentExtras.name) {
+      h[HEADER_DEFENSECLAW_AGENT_NAME] = pluginAgentExtras.name;
+    }
+    if (pluginAgentExtras.policyId) {
+      h[HEADER_DEFENSECLAW_POLICY_ID] = pluginAgentExtras.policyId;
+    }
+
+    if (currentToolContext.sessionId) {
+      h[HEADER_DEFENSECLAW_SESSION_ID] = currentToolContext.sessionId;
+    }
+    if (currentToolContext.runId) {
+      h[HEADER_DEFENSECLAW_RUN_ID] = currentToolContext.runId;
+    }
+
+    h[HEADER_DEFENSECLAW_TRACE_ID] = randomUUID();
+    return h;
+  };
+
+  // ─── LLM fetch interceptor ───
+  const interceptor = createFetchInterceptor({
+    guardrailPort: sidecarConfig.guardrailPort,
+    getCorrelationHeaders: getFetchCorrelationHeaders,
+  });
+  interceptor.start();
+
+  api.registerService({
+    id: "llm-interceptor",
+    start: async () => {
+      interceptor.start();
+      healthMonitor.start();
+      return {
+        stop: () => {
+          interceptor.stop();
+          healthMonitor.stop();
+        },
+      };
+    },
+  });
+
+  async function inspectTool(
+    payload: Record<string, unknown>,
+    toolCtx?: ToolContext,
+  ): Promise<{ action: string; severity: string; reason: string; mode: string }> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), INSPECT_TIMEOUT_MS);
+    const started = performance.now();
+    try {
+      const base = await daemonClient.buildOutboundHeaders({
+        runId: toolCtx?.runId,
+        sessionId: toolCtx?.sessionId ?? toolCtx?.sessionKey,
+      });
+      const headers: Record<string, string> = {
+        ...base,
+        [HEADER_HTTP_CONTENT_TYPE]: "application/json",
+      };
+      const res = await fetch(`${SIDECAR_API}/api/v1/inspect/tool`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+      daemonClient.applyStickyFromHttpResponse(res);
+      const duration_ms = Math.round(performance.now() - started);
+      logOutboundRequest({
+        runId: toolCtx?.runId,
+        sessionId: toolCtx?.sessionId ?? toolCtx?.sessionKey,
+        agentId: identityCache?.agentId ?? "unknown",
+        status_code: res.status,
+        duration_ms,
+      });
+      if (!res.ok) {
+        return { action: "allow", severity: "NONE", reason: `sidecar returned ${res.status}`, mode: "observe" };
+      }
+      return (await res.json()) as {
+        action: string;
+        severity: string;
+        reason: string;
+        mode: string;
+      };
+    } catch {
+      const duration_ms = Math.round(performance.now() - started);
+      logOutboundRequest({
+        runId: toolCtx?.runId,
+        sessionId: toolCtx?.sessionId ?? toolCtx?.sessionKey,
+        agentId: identityCache?.agentId ?? "unknown",
+        status_code: 0,
+        duration_ms,
+      });
+      return { action: "allow", severity: "NONE", reason: "sidecar unreachable", mode: "observe" };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  api.on("before_tool_call", async (event, ctx) => {
+    trackToolContext(ctx);
+
+    if (event.toolName === "message") {
+      const content =
+        (event.params?.content as string) || (event.params?.body as string) || "";
+      if (!content) return;
+
+      const verdict = await inspectTool(
+        {
+          tool: "message",
+          args: event.params,
+          content,
+          direction: "outbound",
+        },
+        ctx,
+      );
+
+      console.log(
+        `${LOG_PREFIX} message-tool verdict:${verdict.action} severity:${verdict.severity}`,
+      );
+
+      if (verdict.action === "block" && verdict.mode === "action") {
+        return { block: true, blockReason: `DefenseClaw: outbound blocked — ${verdict.reason}` };
+      }
+      return;
+    }
+
+    const verdict = await inspectTool(
+      {
+        tool: event.toolName,
+        args: event.params,
+      },
+      ctx,
+    );
+
+    console.log(
+      `${LOG_PREFIX} tool:${event.toolName} verdict:${verdict.action} severity:${verdict.severity}`,
+    );
+
+    if (verdict.action === "block" && verdict.mode === "action") {
+      return { block: true, blockReason: `DefenseClaw: ${verdict.reason}` };
+    }
+  });
+
+  // ─── Slash command: /dc-scan ───
+
+  api.registerCommand({
+    name: "dc-scan",
+    description: "Scan a skill, plugin, MCP config, or source code with DefenseClaw",
+    args: [
+      { name: "target", description: "Path to skill/plugin directory, MCP config, or source code", required: true },
+      { name: "type", description: "Scan type: skill (default), plugin, mcp, code", required: false },
+    ],
+    handler: async ({ args }) => {
+      const target = args.target as string | undefined;
+      if (!target) {
+        return { text: "Usage: /dc-scan <path> [skill|plugin|mcp|code]" };
+      }
+
+      const scanType = (args.type ?? "skill") as string;
+
+      if (scanType === "plugin") {
+        return handlePluginScan(target);
+      }
+
+      if (scanType === "mcp") {
+        return handleMCPScan(target);
+      }
+
+      if (scanType === "code") {
+        return handleCodeScan(
+          target,
+          SIDECAR_API,
+          SIDECAR_TOKEN,
+          daemonClient,
+          logOutboundRequest,
+          () => identityCache?.agentId ?? "unknown",
+        );
+      }
+
+      return handleSkillScan(target);
+    },
+  });
+
+  // ─── Slash command: /dc-block ───
+
+  api.registerCommand({
+    name: "dc-block",
+    description: "Block a skill, MCP server, or plugin",
+    args: [
+      { name: "type", description: "Target type: skill, mcp, plugin", required: true },
+      { name: "name", description: "Name of the target to block", required: true },
+      { name: "reason", description: "Reason for blocking", required: false },
+    ],
+    handler: async ({ args }) => {
+      const targetType = args.type as InstallType | undefined;
+      const name = args.name as string | undefined;
+      if (!targetType || !name) {
+        return { text: "Usage: /dc-block <skill|mcp|plugin> <name> [reason]" };
+      }
+
+      const reason = (args.reason as string) || "Blocked via /dc-block command";
+
+      await enforcer.block(targetType, name, reason);
+      return {
+        text: `Blocked ${targetType} **${name}**: ${reason}`,
+      };
+    },
+  });
+
+  // ─── Slash command: /dc-allow ───
+
+  api.registerCommand({
+    name: "dc-allow",
+    description: "Allow-list a skill, MCP server, or plugin",
+    args: [
+      { name: "type", description: "Target type: skill, mcp, plugin", required: true },
+      { name: "name", description: "Name of the target to allow", required: true },
+      { name: "reason", description: "Reason for allowing", required: false },
+    ],
+    handler: async ({ args }) => {
+      const targetType = args.type as InstallType | undefined;
+      const name = args.name as string | undefined;
+      if (!targetType || !name) {
+        return { text: "Usage: /dc-allow <skill|mcp|plugin> <name> [reason]" };
+      }
+
+      const reason = (args.reason as string) || "Allowed via /dc-allow command";
+
+      await enforcer.allow(targetType, name, reason);
+      return {
+        text: `Allow-listed ${targetType} **${name}**: ${reason}`,
+      };
+    },
+  });
+}
+
+// ─── Scan handlers ───
+
+async function handlePluginScan(
+  target: string,
+): Promise<{ text: string }> {
+  try {
+    const result = await runPluginScan(target);
+    return { text: formatScanOutput("Plugin", target, result) };
+  } catch (err) {
+    return {
+      text: `Plugin scan failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+async function handleMCPScan(target: string): Promise<{ text: string }> {
+  try {
+    const result = await scanMCPServer(target);
+    return { text: formatScanOutput("MCP", target, result) };
+  } catch (err) {
+    return {
+      text: `MCP scan failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+async function handleCodeScan(
+  target: string,
+  sidecarApi: string,
+  sidecarToken: string,
+  client: DaemonClient,
+  logOutboundRequestFn: (entry: OutboundSidecarRequestLog) => void,
+  getLogAgentId: () => string,
+): Promise<{ text: string }> {
+  try {
+    const result = await runCodeScan(target, sidecarApi, sidecarToken, {
+      buildSidecarHeaders: () => client.buildOutboundHeaders(),
+      onSidecarResponse: (res) => client.applyStickyFromHttpResponse(res),
+      logOutboundRequest: logOutboundRequestFn,
+      getLogAgentId,
+    });
+    return { text: formatScanOutput("Code", target, result) };
+  } catch (err) {
+    return {
+      text: `Code scan failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+async function handleSkillScan(target: string): Promise<{ text: string }> {
+  try {
+    const result = await runSkillScan(target);
+    return { text: formatScanOutput("Skill", target, result) };
+  } catch (err) {
+    return {
+      text: `Skill scan failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+function formatScanOutput(
+  scanType: string,
+  target: string,
+  result: ScanResult,
+): string {
+  const lines: string[] = [`**DefenseClaw ${scanType} Scan: ${target}**\n`];
+
+  if (result.findings.length === 0) {
+    lines.push("Verdict: **CLEAN** — no findings");
+    return lines.join("\n");
+  }
+
+  const max = maxSeverity(result.findings.map((f) => f.severity));
+  lines.push(
+    `Verdict: **${max}** (${result.findings.length} finding${result.findings.length === 1 ? "" : "s"})\n`,
+  );
+  lines.push(...formatFindings(result.findings));
+
+  return lines.join("\n");
+}

--- a/output-plugin/src/policy/enforcer.ts
+++ b/output-plugin/src/policy/enforcer.ts
@@ -1,0 +1,658 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFile } from "node:child_process";
+import { HEADER_DEFENSECLAW_CLIENT } from "../correlation-headers.js";
+import { DaemonClient } from "../client.js";
+import { scanMCPServer } from "../scanners/mcp-scanner.js";
+import type {
+  ScanResult,
+  Finding,
+  Verdict,
+  AdmissionResult,
+  InstallType,
+  Severity,
+  OutboundSidecarRequestLog,
+} from "../types.js";
+import { compareSeverity, maxSeverity } from "../types.js";
+
+export function runSkillScan(
+  target: string,
+  timeoutMs = 120_000,
+): Promise<ScanResult> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "defenseclaw",
+      ["skill", "scan", target, "--json"],
+      { timeout: timeoutMs, maxBuffer: 10 * 1024 * 1024 },
+      (error, stdout, stderr) => {
+        const code = error && "code" in error ? (error.code as number) : 0;
+        if (code !== 0) {
+          reject(
+            new Error(
+              `defenseclaw skill scan exited ${code}: ${stderr.trim().slice(0, 200)}`,
+            ),
+          );
+          return;
+        }
+        try {
+          const data = JSON.parse(stdout);
+          if (data.findings != null && !Array.isArray(data.findings)) {
+            reject(new Error("skill scan returned malformed findings (not an array)"));
+            return;
+          }
+          const findings: Finding[] = (data.findings ?? []).map(
+            (f: Record<string, unknown>) => ({
+              id: (f.id as string) ?? "",
+              severity: (f.severity as string) ?? "INFO",
+              title: (f.title as string) ?? "",
+              description: (f.description as string) ?? "",
+              location: (f.location as string) ?? "",
+              remediation: (f.remediation as string) ?? "",
+              scanner: (f.scanner as string) ?? "skill-scanner",
+              tags: (f.tags as string[]) ?? [],
+            }),
+          );
+          resolve({
+            scanner: "skill-scanner",
+            target,
+            timestamp: new Date().toISOString(),
+            findings,
+          });
+        } catch {
+          reject(new Error("failed to parse skill scan output"));
+        }
+      },
+    );
+  });
+}
+
+export function runPluginScan(
+  target: string,
+  timeoutMs = 120_000,
+): Promise<ScanResult> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "defenseclaw",
+      ["plugin", "scan", target, "--json"],
+      { timeout: timeoutMs, maxBuffer: 10 * 1024 * 1024 },
+      (error, stdout, stderr) => {
+        const code = error && "code" in error ? (error.code as number) : 0;
+        if (code !== 0) {
+          reject(
+            new Error(
+              `defenseclaw plugin scan exited ${code}: ${stderr.trim().slice(0, 200)}`,
+            ),
+          );
+          return;
+        }
+        try {
+          const data = JSON.parse(stdout);
+          if (data.findings != null && !Array.isArray(data.findings)) {
+            reject(new Error("plugin scan returned malformed findings (not an array)"));
+            return;
+          }
+          const findings: Finding[] = (data.findings ?? []).map(
+            (f: Record<string, unknown>) => ({
+              id: (f.id as string) ?? "",
+              severity: (f.severity as string) ?? "INFO",
+              title: (f.title as string) ?? "",
+              description: (f.description as string) ?? "",
+              location: (f.location as string) ?? "",
+              remediation: (f.remediation as string) ?? "",
+              scanner: (f.scanner as string) ?? "plugin-scanner",
+              tags: (f.tags as string[]) ?? [],
+            }),
+          );
+          resolve({
+            scanner: "plugin-scanner",
+            target,
+            timestamp: new Date().toISOString(),
+            findings,
+          });
+        } catch {
+          reject(new Error("failed to parse plugin scan output"));
+        }
+      },
+    );
+  });
+}
+
+export async function runRemotePluginScan(
+  target: string,
+  sidecarBaseUrl: string,
+  sidecarToken = "",
+  options?: {
+    timeoutMs?: number;
+    buildSidecarHeaders?: () => Promise<Record<string, string>>;
+    onSidecarResponse?: (res: Response) => void;
+    logOutboundRequest?: (entry: OutboundSidecarRequestLog) => void;
+    getLogAgentId?: () => string;
+  },
+): Promise<ScanResult> {
+  const timeoutMs = options?.timeoutMs ?? 120_000;
+  const started = performance.now();
+  let responseLogged = false;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const baseHeaders: Record<string, string> = {
+      "Content-Type": "application/json",
+      [HEADER_DEFENSECLAW_CLIENT]: "openclaw-plugin",
+    };
+    if (sidecarToken) {
+      baseHeaders.Authorization = `Bearer ${sidecarToken}`;
+    }
+    const merged = options?.buildSidecarHeaders
+      ? { ...baseHeaders, ...(await options.buildSidecarHeaders()) }
+      : baseHeaders;
+
+    const res = await fetch(`${sidecarBaseUrl}/v1/plugin/scan`, {
+      method: "POST",
+      headers: merged,
+      body: JSON.stringify({ target }),
+      signal: controller.signal,
+    });
+
+    options?.onSidecarResponse?.(res);
+
+    const duration_ms = Math.round(performance.now() - started);
+    responseLogged = true;
+    options?.logOutboundRequest?.({
+      agentId: options.getLogAgentId?.() ?? "unknown",
+      status_code: res.status,
+      duration_ms,
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`sidecar returned HTTP ${res.status}: ${body.slice(0, 200)}`);
+    }
+
+    const data = (await res.json()) as Record<string, unknown>;
+    if (data.findings != null && !Array.isArray(data.findings)) {
+      throw new Error("remote plugin scan returned malformed findings (not an array)");
+    }
+    const findings: Finding[] = ((data.findings ?? []) as Record<string, unknown>[]).map((f) => ({
+      id: (f.id as string) ?? "",
+      severity: ((f.severity as string) ?? "INFO") as Severity,
+      title: (f.title as string) ?? "",
+      description: (f.description as string) ?? "",
+      location: (f.location as string) ?? "",
+      remediation: (f.remediation as string) ?? "",
+      scanner: (f.scanner as string) ?? "plugin-scanner",
+      tags: (f.tags as string[]) ?? [],
+    }));
+
+    return {
+      scanner: "plugin-scanner",
+      target,
+      timestamp: new Date().toISOString(),
+      findings,
+    };
+  } catch (err) {
+    if (!responseLogged) {
+      const duration_ms = Math.round(performance.now() - started);
+      options?.logOutboundRequest?.({
+        agentId: options?.getLogAgentId?.() ?? "unknown",
+        status_code: 0,
+        duration_ms,
+      });
+    }
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error("plugin scan timed out");
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Run a CodeGuard code scan via the Go sidecar API.
+ * Unlike skill scans (which shell out), CodeGuard is built into the sidecar binary.
+ */
+export async function runCodeScan(
+  target: string,
+  sidecarBaseUrl: string,
+  sidecarToken = "",
+  options?: {
+    timeoutMs?: number;
+    buildSidecarHeaders?: () => Promise<Record<string, string>>;
+    onSidecarResponse?: (res: Response) => void;
+    logOutboundRequest?: (entry: OutboundSidecarRequestLog) => void;
+    getLogAgentId?: () => string;
+  },
+): Promise<ScanResult> {
+  const timeoutMs = options?.timeoutMs ?? 30_000;
+  const started = performance.now();
+  let responseLogged = false;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const baseHeaders: Record<string, string> = {
+      "Content-Type": "application/json",
+      [HEADER_DEFENSECLAW_CLIENT]: "openclaw-plugin",
+    };
+    if (sidecarToken) {
+      baseHeaders.Authorization = `Bearer ${sidecarToken}`;
+    }
+    const merged = options?.buildSidecarHeaders
+      ? { ...baseHeaders, ...(await options.buildSidecarHeaders()) }
+      : baseHeaders;
+
+    const res = await fetch(`${sidecarBaseUrl}/api/v1/scan/code`, {
+      method: "POST",
+      headers: merged,
+      body: JSON.stringify({ path: target }),
+      signal: controller.signal,
+    });
+
+    options?.onSidecarResponse?.(res);
+
+    const duration_ms = Math.round(performance.now() - started);
+    responseLogged = true;
+    options?.logOutboundRequest?.({
+      agentId: options.getLogAgentId?.() ?? "unknown",
+      status_code: res.status,
+      duration_ms,
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`sidecar returned HTTP ${res.status}: ${body.slice(0, 200)}`);
+    }
+
+    const data = (await res.json()) as Record<string, unknown>;
+    if (data.findings != null && !Array.isArray(data.findings)) {
+      throw new Error("code scan returned malformed findings (not an array)");
+    }
+    const findings: Finding[] = ((data.findings ?? []) as Record<string, unknown>[]).map((f) => ({
+      id: (f.id as string) ?? "",
+      severity: ((f.severity as string) ?? "INFO") as Severity,
+      title: (f.title as string) ?? "",
+      description: (f.description as string) ?? "",
+      location: (f.location as string) ?? "",
+      remediation: (f.remediation as string) ?? "",
+      scanner: (f.scanner as string) ?? "codeguard",
+      tags: (f.tags as string[]) ?? [],
+    }));
+
+    return {
+      scanner: "codeguard",
+      target,
+      timestamp: new Date().toISOString(),
+      findings,
+    };
+  } catch (err) {
+    if (!responseLogged) {
+      const duration_ms = Math.round(performance.now() - started);
+      options?.logOutboundRequest?.({
+        agentId: options?.getLogAgentId?.() ?? "unknown",
+        status_code: 0,
+        duration_ms,
+      });
+    }
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error("code scan timed out");
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface EnforcerConfig {
+  blockOnSeverity: Severity;
+  warnOnSeverity: Severity;
+  daemonUrl?: string;
+}
+
+const DEFAULT_CONFIG: EnforcerConfig = {
+  blockOnSeverity: "HIGH",
+  warnOnSeverity: "MEDIUM",
+};
+
+/**
+ * PolicyEnforcer delegates admission verdicts to the Go daemon's OPA
+ * engine via POST /policy/evaluate. Local block/allow caches provide a
+ * fast-path negative check when the daemon is unreachable.
+ */
+export class PolicyEnforcer {
+  private readonly client: DaemonClient;
+  private readonly config: EnforcerConfig;
+
+  private readonly localBlockList = new Map<string, string>();
+  private readonly localAllowList = new Map<string, string>();
+
+  constructor(config?: Partial<EnforcerConfig>, client?: DaemonClient) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.client =
+      client ?? new DaemonClient({ baseUrl: this.config.daemonUrl });
+  }
+
+  async evaluatePlugin(
+    pluginDir: string,
+    pluginName: string,
+  ): Promise<AdmissionResult> {
+    return this.evaluate("plugin", pluginName, pluginDir, () =>
+      runPluginScan(pluginDir),
+    );
+  }
+
+  async evaluateSkill(
+    skillDir: string,
+    skillName: string,
+  ): Promise<AdmissionResult> {
+    return this.evaluate("skill", skillName, skillDir, () =>
+      runSkillScan(skillDir),
+    );
+  }
+
+  async evaluateMCPServer(
+    configPath: string,
+    serverName: string,
+  ): Promise<AdmissionResult> {
+    return this.evaluate("mcp", serverName, configPath, () =>
+      scanMCPServer(configPath),
+    );
+  }
+
+  async block(
+    targetType: InstallType,
+    name: string,
+    reason: string,
+  ): Promise<void> {
+    const key = `${targetType}:${name}`;
+    this.localBlockList.set(key, reason);
+    this.localAllowList.delete(key);
+
+    await this.client.block(targetType, name, reason).catch(() => {});
+  }
+
+  async allow(
+    targetType: InstallType,
+    name: string,
+    reason: string,
+  ): Promise<void> {
+    const key = `${targetType}:${name}`;
+    this.localAllowList.set(key, reason);
+    this.localBlockList.delete(key);
+
+    await this.client.allow(targetType, name, reason).catch(() => {});
+  }
+
+  async unblock(targetType: InstallType, name: string): Promise<void> {
+    const key = `${targetType}:${name}`;
+    this.localBlockList.delete(key);
+
+    await this.client.unblock(targetType, name).catch(() => {});
+  }
+
+  isBlockedLocally(targetType: InstallType, name: string): boolean {
+    return this.localBlockList.has(`${targetType}:${name}`);
+  }
+
+  isAllowedLocally(targetType: InstallType, name: string): boolean {
+    return this.localAllowList.has(`${targetType}:${name}`);
+  }
+
+  async syncFromDaemon(): Promise<void> {
+    const [blocked, allowed] = await Promise.all([
+      this.client.listBlocked(),
+      this.client.listAllowed(),
+    ]);
+
+    if (blocked.ok && blocked.data) {
+      const freshKeys = new Set<string>();
+      for (const entry of blocked.data) {
+        const key = `${entry.target_type}:${entry.target_name}`;
+        this.localBlockList.set(key, entry.reason);
+        freshKeys.add(key);
+      }
+      for (const key of this.localBlockList.keys()) {
+        if (!freshKeys.has(key)) this.localBlockList.delete(key);
+      }
+    }
+
+    if (allowed.ok && allowed.data) {
+      const freshKeys = new Set<string>();
+      for (const entry of allowed.data) {
+        const key = `${entry.target_type}:${entry.target_name}`;
+        this.localAllowList.set(key, entry.reason);
+        freshKeys.add(key);
+      }
+      for (const key of this.localAllowList.keys()) {
+        if (!freshKeys.has(key)) this.localAllowList.delete(key);
+      }
+    }
+  }
+
+  private async evaluate(
+    targetType: InstallType,
+    name: string,
+    path: string,
+    scan: () => Promise<ScanResult>,
+  ): Promise<AdmissionResult> {
+    const key = `${targetType}:${name}`;
+    const now = new Date().toISOString();
+
+    if (this.localBlockList.has(key)) {
+      const result: AdmissionResult = {
+        type: targetType,
+        name,
+        path,
+        verdict: "blocked",
+        reason: `Block list: ${this.localBlockList.get(key)}`,
+        timestamp: now,
+      };
+      await this.reportToDaemon(result);
+      return result;
+    }
+
+    if (this.localAllowList.has(key)) {
+      const result: AdmissionResult = {
+        type: targetType,
+        name,
+        path,
+        verdict: "allowed",
+        reason: `Allow list: ${this.localAllowList.get(key)}`,
+        timestamp: now,
+      };
+      await this.reportToDaemon(result);
+      return result;
+    }
+
+    let scanResult: ScanResult | undefined;
+    try {
+      scanResult = await scan();
+    } catch (err) {
+      const result: AdmissionResult = {
+        type: targetType,
+        name,
+        path,
+        verdict: "scan-error",
+        reason: `Scan failed: ${err instanceof Error ? err.message : String(err)}`,
+        timestamp: now,
+      };
+      await this.reportToDaemon(result);
+      return result;
+    }
+
+    await this.client.submitScanResult(scanResult).catch(() => {});
+
+    const opaResult = await this.evaluateViaOPA(
+      targetType,
+      name,
+      path,
+      scanResult,
+    );
+
+    if (opaResult) {
+      const result: AdmissionResult = {
+        type: targetType,
+        name,
+        path,
+        verdict: mapOPAVerdict(opaResult.verdict),
+        reason: opaResult.reason || "policy decision",
+        timestamp: now,
+      };
+      await this.reportToDaemon(result);
+      return result;
+    }
+
+    const verdict = this.localDetermineVerdict(scanResult);
+    const result: AdmissionResult = {
+      type: targetType,
+      name,
+      path,
+      verdict: verdict.verdict,
+      reason: verdict.reason,
+      timestamp: now,
+    };
+
+    await this.reportToDaemon(result);
+    return result;
+  }
+
+  private async evaluateViaOPA(
+    targetType: InstallType,
+    name: string,
+    path: string,
+    scanResult: ScanResult,
+  ): Promise<{ verdict: string; reason: string } | null> {
+    try {
+      const input: Record<string, unknown> = {
+        target_type: targetType,
+        target_name: name,
+        path,
+        scan_result: {
+          max_severity: maxSeverity(scanResult.findings.map((f) => f.severity)),
+          total_findings: scanResult.findings.length,
+          findings: scanResult.findings.map((f) => ({
+            severity: f.severity,
+            title: f.title,
+            scanner: f.scanner,
+          })),
+        },
+      };
+
+      const resp = await this.client.evaluatePolicy("admission", input);
+
+      if (resp.ok && resp.data) {
+        const wrapper = resp.data as Record<string, unknown>;
+        const inner = (wrapper.data ?? wrapper) as Record<string, unknown>;
+        const verdict = typeof inner.verdict === "string" ? inner.verdict : null;
+        const reason = typeof inner.reason === "string" ? inner.reason : "";
+
+        if (verdict) {
+          return { verdict, reason };
+        }
+      }
+    } catch {
+      // Fall through to local evaluation.
+    }
+    return null;
+  }
+
+  /**
+   * Local fallback when the daemon is unreachable. Mirrors the hardcoded
+   * severity-threshold logic that existed before OPA integration.
+   */
+  private localDetermineVerdict(scanResult: ScanResult): {
+    verdict: Verdict;
+    reason: string;
+  } {
+    if (scanResult.findings.length === 0) {
+      return { verdict: "clean", reason: "No findings" };
+    }
+
+    const severities = scanResult.findings.map((f) => f.severity);
+    const max = maxSeverity(severities);
+
+    if (compareSeverity(max, this.config.blockOnSeverity) >= 0) {
+      const count = scanResult.findings.filter(
+        (f) => compareSeverity(f.severity, this.config.blockOnSeverity) >= 0,
+      ).length;
+      return {
+        verdict: "rejected",
+        reason: `${count} finding(s) at ${this.config.blockOnSeverity} or above (max: ${max})`,
+      };
+    }
+
+    if (compareSeverity(max, this.config.warnOnSeverity) >= 0) {
+      const count = scanResult.findings.filter(
+        (f) => compareSeverity(f.severity, this.config.warnOnSeverity) >= 0,
+      ).length;
+      return {
+        verdict: "warning",
+        reason: `${count} finding(s) at ${this.config.warnOnSeverity} or above (max: ${max})`,
+      };
+    }
+
+    return {
+      verdict: "clean",
+      reason: `${scanResult.findings.length} finding(s), all below ${this.config.warnOnSeverity}`,
+    };
+  }
+
+  private async reportToDaemon(result: AdmissionResult): Promise<void> {
+    await this.client
+      .logEvent({
+        action: "admission",
+        target: result.path,
+        actor: "defenseclaw-plugin",
+        severity: verdictToSeverity(result.verdict),
+        details: JSON.stringify(result),
+      })
+      .catch(() => {});
+  }
+}
+
+function mapOPAVerdict(v: string): Verdict {
+  switch (v) {
+    case "blocked":
+      return "blocked";
+    case "rejected":
+      return "rejected";
+    case "warning":
+      return "warning";
+    case "allowed":
+      return "allowed";
+    case "clean":
+      return "clean";
+    default:
+      return "scan-error";
+  }
+}
+
+function verdictToSeverity(verdict: Verdict): string {
+  switch (verdict) {
+    case "blocked":
+      return "CRITICAL";
+    case "rejected":
+      return "HIGH";
+    case "scan-error":
+      return "ERROR";
+    case "warning":
+      return "MEDIUM";
+    case "allowed":
+    case "clean":
+      return "INFO";
+  }
+}

--- a/output-plugin/src/providers.json
+++ b/output-plugin/src/providers.json
@@ -1,0 +1,95 @@
+{
+  "providers": [
+    {
+      "name": "anthropic",
+      "domains": ["api.anthropic.com"],
+      "profile_id": "anthropic:default",
+      "env_keys": ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"]
+    },
+    {
+      "name": "openrouter",
+      "domains": ["openrouter.ai"],
+      "profile_id": "openrouter:default",
+      "env_keys": ["OPENROUTER_API_KEY"]
+    },
+    {
+      "name": "openai",
+      "domains": ["api.openai.com"],
+      "profile_id": "openai:default",
+      "env_keys": ["OPENAI_API_KEY"]
+    },
+    {
+      "name": "openai-codex",
+      "domains": ["chatgpt.com/backend-api"],
+      "profile_id": null,
+      "env_keys": []
+    },
+    {
+      "name": "groq",
+      "domains": ["api.groq.com"],
+      "profile_id": "groq:default",
+      "env_keys": ["GROQ_API_KEY"]
+    },
+    {
+      "name": "mistral",
+      "domains": ["api.mistral.ai"],
+      "profile_id": "mistral:default",
+      "env_keys": ["MISTRAL_API_KEY"]
+    },
+    {
+      "name": "cohere",
+      "domains": ["api.cohere.com", "api.cohere.ai"],
+      "profile_id": "cohere:default",
+      "env_keys": ["COHERE_API_KEY"]
+    },
+    {
+      "name": "deepseek",
+      "domains": ["api.deepseek.com"],
+      "profile_id": "deepseek:default",
+      "env_keys": ["DEEPSEEK_API_KEY"]
+    },
+    {
+      "name": "perplexity",
+      "domains": ["api.perplexity.ai"],
+      "profile_id": "perplexity:default",
+      "env_keys": ["PERPLEXITY_API_KEY"]
+    },
+    {
+      "name": "together",
+      "domains": ["api.together.xyz"],
+      "profile_id": "together:default",
+      "env_keys": ["TOGETHER_API_KEY"]
+    },
+    {
+      "name": "xai",
+      "domains": ["api.x.ai"],
+      "profile_id": "xai:default",
+      "env_keys": ["XAI_API_KEY"]
+    },
+    {
+      "name": "vertex",
+      "domains": ["aiplatform.googleapis.com"],
+      "profile_id": null,
+      "env_keys": []
+    },
+    {
+      "name": "azure",
+      "domains": ["openai.azure.com"],
+      "profile_id": "azure:default",
+      "env_keys": ["AZURE_OPENAI_API_KEY"]
+    },
+    {
+      "name": "gemini",
+      "domains": ["generativelanguage.googleapis.com", "googleapis.com/v1/projects"],
+      "profile_id": "google:default",
+      "env_keys": ["GOOGLE_API_KEY", "GEMINI_API_KEY"]
+    },
+    {
+      "name": "bedrock",
+      "domains": ["bedrock-runtime."],
+      "profile_id": null,
+      "env_keys": []
+    }
+  ],
+  "ollama_ports": [11434]
+}

--- a/output-plugin/src/scanners/mcp-scanner.ts
+++ b/output-plugin/src/scanners/mcp-scanner.ts
@@ -1,0 +1,444 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFile, readdir, stat } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import type {
+  Finding,
+  ScanResult,
+  Severity,
+  MCPServerConfig,
+} from "../types.js";
+
+const SCANNER_NAME = "defenseclaw-mcp-scanner";
+
+const DANGEROUS_ENV_KEYS = new Set([
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "GITHUB_TOKEN",
+  "DATABASE_URL",
+  "DB_PASSWORD",
+  "SECRET_KEY",
+  "PRIVATE_KEY",
+]);
+
+const DANGEROUS_COMMANDS = new Set([
+  "bash",
+  "sh",
+  "zsh",
+  "cmd",
+  "powershell",
+  "pwsh",
+  "curl",
+  "wget",
+]);
+
+const SUSPICIOUS_ARG_PATTERNS = [
+  { pattern: /--no-sandbox/i, title: "MCP server disables sandboxing" },
+  { pattern: /--allow-all/i, title: "MCP server requests unrestricted access" },
+  { pattern: /--privileged/i, title: "MCP server runs with elevated privileges" },
+  { pattern: /--disable-security/i, title: "MCP server disables security controls" },
+];
+
+export async function scanMCPServer(
+  configPathOrDir: string,
+): Promise<ScanResult> {
+  const start = Date.now();
+  const target = resolve(configPathOrDir);
+  const findings: Finding[] = [];
+
+  const configs = await loadMCPConfigs(target);
+
+  if (configs.length === 0) {
+    findings.push(
+      makeFinding(1, "INFO", "No MCP server configurations found", {
+        description: `No MCP server configs found at "${target}".`,
+        location: target,
+      }),
+    );
+    return buildResult(target, findings, start);
+  }
+
+  for (const config of configs) {
+    checkMCPConfig(config, findings, target);
+  }
+
+  return buildResult(target, findings, start);
+}
+
+async function loadMCPConfigs(target: string): Promise<MCPServerConfig[]> {
+  const configs: MCPServerConfig[] = [];
+
+  try {
+    const info = await stat(target);
+
+    if (info.isFile()) {
+      const parsed = await parseConfigFile(target);
+      configs.push(...parsed);
+    } else if (info.isDirectory()) {
+      const entries = await readdir(target);
+      for (const entry of entries) {
+        if (!entry.endsWith(".json") && !entry.endsWith(".yaml") && !entry.endsWith(".yml"))
+          continue;
+
+        const fullPath = join(target, entry);
+        const parsed = await parseConfigFile(fullPath);
+        configs.push(...parsed);
+      }
+    }
+  } catch {
+    return configs;
+  }
+
+  return configs;
+}
+
+async function parseConfigFile(filePath: string): Promise<MCPServerConfig[]> {
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    let parsed: Record<string, unknown>;
+    if (filePath.endsWith(".yaml") || filePath.endsWith(".yml")) {
+      const yaml = await import("js-yaml");
+      const loaded = yaml.load(raw, { schema: yaml.JSON_SCHEMA });
+      parsed =
+        loaded !== null && typeof loaded === "object" && !Array.isArray(loaded)
+          ? (loaded as Record<string, unknown>)
+          : {};
+    } else {
+      parsed = JSON.parse(raw) as Record<string, unknown>;
+    }
+    return extractMCPServers(parsed, filePath);
+  } catch {
+    return [];
+  }
+}
+
+function extractMCPServers(
+  data: Record<string, unknown>,
+  source: string,
+): MCPServerConfig[] {
+  const servers: MCPServerConfig[] = [];
+
+  const mcpServers =
+    (data["mcpServers"] as Record<string, unknown>) ??
+    (data["mcp_servers"] as Record<string, unknown>) ??
+    (data["mcp-servers"] as Record<string, unknown>);
+
+  if (mcpServers && typeof mcpServers === "object") {
+    for (const [name, value] of Object.entries(mcpServers)) {
+      if (value && typeof value === "object") {
+        const cfg = value as Record<string, unknown>;
+        servers.push({
+          name,
+          command: cfg["command"] as string | undefined,
+          args: cfg["args"] as string[] | undefined,
+          env: cfg["env"] as Record<string, string> | undefined,
+          url: cfg["url"] as string | undefined,
+          transport: cfg["transport"] as MCPServerConfig["transport"],
+          tools: cfg["tools"] as MCPServerConfig["tools"],
+          enabled: cfg["enabled"] !== false,
+        });
+      }
+    }
+  }
+
+  if (servers.length === 0 && data["command"]) {
+    servers.push({
+      name: source.split("/").pop() ?? "unknown",
+      command: data["command"] as string,
+      args: data["args"] as string[] | undefined,
+      env: data["env"] as Record<string, string> | undefined,
+      url: data["url"] as string | undefined,
+      transport: data["transport"] as MCPServerConfig["transport"],
+    });
+  }
+
+  return servers;
+}
+
+function checkMCPConfig(
+  config: MCPServerConfig,
+  findings: Finding[],
+  target: string,
+): void {
+  checkCommand(config, findings, target);
+  checkArgs(config, findings, target);
+  checkEnvVars(config, findings, target);
+  checkTransport(config, findings, target);
+  checkTools(config, findings, target);
+}
+
+function checkCommand(
+  config: MCPServerConfig,
+  findings: Finding[],
+  target: string,
+): void {
+  if (!config.command) return;
+
+  const cmd = config.command.split("/").pop() ?? config.command;
+
+  if (DANGEROUS_COMMANDS.has(cmd)) {
+    findings.push(
+      makeFinding(findings.length + 1, "HIGH", `MCP server "${config.name}" uses shell as command`, {
+        description:
+          `Server "${config.name}" launches "${cmd}" directly. ` +
+          "Running a bare shell as an MCP server enables arbitrary command execution.",
+        location: `${target} → mcp:${config.name}`,
+        remediation:
+          "Use a purpose-built MCP server binary instead of a shell. " +
+          "If a shell wrapper is required, validate all inputs and restrict available commands.",
+      }),
+    );
+  }
+}
+
+function checkArgs(
+  config: MCPServerConfig,
+  findings: Finding[],
+  target: string,
+): void {
+  if (!config.args) return;
+
+  const argStr = config.args.join(" ");
+
+  for (const { pattern, title } of SUSPICIOUS_ARG_PATTERNS) {
+    if (pattern.test(argStr)) {
+      findings.push(
+        makeFinding(findings.length + 1, "HIGH", `${title} (${config.name})`, {
+          description:
+            `MCP server "${config.name}" uses argument matching "${pattern.source}" ` +
+            "which weakens security controls.",
+          location: `${target} → mcp:${config.name}`,
+          remediation:
+            "Remove security-weakening arguments. Use scoped permissions instead.",
+        }),
+      );
+    }
+  }
+}
+
+function checkEnvVars(
+  config: MCPServerConfig,
+  findings: Finding[],
+  target: string,
+): void {
+  if (!config.env) return;
+
+  for (const [key, value] of Object.entries(config.env)) {
+    if (DANGEROUS_ENV_KEYS.has(key.toUpperCase())) {
+      const hasInlineValue =
+        typeof value === "string" && value.length > 0 && !value.startsWith("${");
+
+      if (hasInlineValue) {
+        findings.push(
+          makeFinding(
+            findings.length + 1,
+            "CRITICAL",
+            `Hardcoded secret in MCP config: ${key}`,
+            {
+              description:
+                `MCP server "${config.name}" has sensitive environment variable "${key}" ` +
+                "with a hardcoded value in the configuration file. " +
+                "Credentials in config files are considered compromised.",
+              location: `${target} → mcp:${config.name} → env.${key}`,
+              remediation:
+                "Remove the hardcoded value. Use environment variable references " +
+                '(e.g., "${ENV_VAR}") or a secrets manager instead.',
+            },
+          ),
+        );
+      } else {
+        findings.push(
+          makeFinding(
+            findings.length + 1,
+            "INFO",
+            `MCP server passes sensitive env var: ${key}`,
+            {
+              description:
+                `MCP server "${config.name}" passes sensitive environment variable "${key}". ` +
+                "Ensure this follows the principle of least privilege.",
+              location: `${target} → mcp:${config.name} → env.${key}`,
+              remediation:
+                "Verify the MCP server requires this credential and that it is scoped minimally.",
+            },
+          ),
+        );
+      }
+    }
+  }
+}
+
+function checkTransport(
+  config: MCPServerConfig,
+  findings: Finding[],
+  target: string,
+): void {
+  if (config.url) {
+    try {
+      const url = new URL(config.url);
+
+      if (url.protocol === "http:") {
+        findings.push(
+          makeFinding(
+            findings.length + 1,
+            "HIGH",
+            `MCP server "${config.name}" uses unencrypted HTTP`,
+            {
+              description:
+                `Server "${config.name}" connects via plain HTTP (${config.url}). ` +
+                "MCP traffic may contain sensitive data and tool invocations.",
+              location: `${target} → mcp:${config.name}`,
+              remediation:
+                "Use HTTPS (TLS 1.2+) for all MCP server connections. " +
+                "For local development, use stdio transport instead.",
+            },
+          ),
+        );
+      }
+
+      if (
+        url.hostname !== "localhost" &&
+        url.hostname !== "127.0.0.1" &&
+        url.hostname !== "::1" &&
+        url.protocol !== "https:"
+      ) {
+        findings.push(
+          makeFinding(
+            findings.length + 1,
+            "CRITICAL",
+            `MCP server "${config.name}" connects to remote host over HTTP`,
+            {
+              description:
+                `Server "${config.name}" connects to remote host "${url.hostname}" without TLS. ` +
+                "This exposes all MCP traffic to interception.",
+              location: `${target} → mcp:${config.name}`,
+              remediation: "Use HTTPS for all remote MCP connections.",
+            },
+          ),
+        );
+      }
+    } catch {
+      findings.push(
+        makeFinding(findings.length + 1, "MEDIUM", `Invalid URL for MCP server "${config.name}"`, {
+          description: `Cannot parse URL "${config.url}" for server "${config.name}".`,
+          location: `${target} → mcp:${config.name}`,
+          remediation: "Provide a valid URL for the MCP server.",
+        }),
+      );
+    }
+  }
+
+  if (config.transport === "http" && !config.url) {
+    findings.push(
+      makeFinding(
+        findings.length + 1,
+        "MEDIUM",
+        `MCP server "${config.name}" uses HTTP transport without URL`,
+        {
+          description:
+            `Server "${config.name}" declares HTTP transport but no URL is configured.`,
+          location: `${target} → mcp:${config.name}`,
+          remediation: "Configure the server URL with HTTPS endpoint.",
+        },
+      ),
+    );
+  }
+}
+
+function checkTools(
+  config: MCPServerConfig,
+  findings: Finding[],
+  target: string,
+): void {
+  if (!config.tools) return;
+
+  for (const tool of config.tools) {
+    if (!tool.description) {
+      findings.push(
+        makeFinding(
+          findings.length + 1,
+          "LOW",
+          `MCP tool "${tool.name}" on "${config.name}" lacks description`,
+          {
+            description:
+              "Tools without descriptions cannot be reviewed for safety by users.",
+            location: `${target} → mcp:${config.name} → tool:${tool.name}`,
+            remediation: "Add a description to every MCP tool.",
+          },
+        ),
+      );
+    }
+
+    if (tool.permissions) {
+      for (const perm of tool.permissions) {
+        if (perm.endsWith(":*") || perm === "*") {
+          findings.push(
+            makeFinding(
+              findings.length + 1,
+              "HIGH",
+              `MCP tool "${tool.name}" requests wildcard permission`,
+              {
+                description:
+                  `Tool "${tool.name}" on server "${config.name}" requests wildcard permission "${perm}".`,
+                location: `${target} → mcp:${config.name} → tool:${tool.name}`,
+                remediation: "Scope tool permissions to specific resources.",
+              },
+            ),
+          );
+        }
+      }
+    }
+  }
+}
+
+function makeFinding(
+  id: number,
+  severity: Severity,
+  title: string,
+  opts: {
+    description: string;
+    location?: string;
+    remediation?: string;
+  },
+): Finding {
+  return {
+    id: `mcp-${id}`,
+    severity,
+    title,
+    description: opts.description,
+    location: opts.location,
+    remediation: opts.remediation,
+    scanner: SCANNER_NAME,
+  };
+}
+
+function buildResult(
+  target: string,
+  findings: Finding[],
+  startMs: number,
+): ScanResult {
+  return {
+    scanner: SCANNER_NAME,
+    target,
+    timestamp: new Date().toISOString(),
+    findings,
+    duration_ns: (Date.now() - startMs) * 1_000_000,
+  };
+}

--- a/output-plugin/src/sidecar-config.ts
+++ b/output-plugin/src/sidecar-config.ts
@@ -1,0 +1,169 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import yaml from "js-yaml";
+
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_API_PORT = 18970;
+const DEFAULT_GUARDRAIL_PORT = 4000;
+const DEFAULT_TOKEN_ENV = "OPENCLAW_GATEWAY_TOKEN";
+
+interface SidecarConfig {
+  host: string;
+  apiPort: number;
+  baseUrl: string;
+  token: string;
+  guardrailPort: number;
+}
+
+/**
+ * Overrides from the OpenClaw plugin configSchema (ClawHub settings UI).
+ * These take highest precedence when provided.
+ */
+export interface SidecarConfigOverrides {
+  host?: string;
+  apiPort?: number;
+  guardrailPort?: number;
+}
+
+let cached: SidecarConfig | undefined;
+let cachedOverridesKey: string | undefined;
+
+function overridesKey(o?: SidecarConfigOverrides): string {
+  if (!o) return "";
+  return `${o.host ?? ""}:${o.apiPort ?? ""}:${o.guardrailPort ?? ""}`;
+}
+
+/**
+ * Resolves sidecar connection config with a 3-tier precedence:
+ *
+ * 1. Plugin config overrides (from ClawHub settings UI / openclaw.plugin.json)
+ * 2. Environment variables (DEFENSECLAW_HOST, DEFENSECLAW_PORT, DEFENSECLAW_GUARDRAIL_PORT)
+ * 3. ~/.defenseclaw/config.yaml (if present on the host)
+ * 4. Hardcoded defaults (127.0.0.1:18970, guardrail 4000)
+ *
+ * Token resolution mirrors the Go sidecar:
+ * env var (gateway.token_env, default OPENCLAW_GATEWAY_TOKEN) wins over
+ * the direct gateway.token value.
+ *
+ * Result is cached for the lifetime of the process (cache is invalidated
+ * if overrides change).
+ */
+export function loadSidecarConfig(overrides?: SidecarConfigOverrides): SidecarConfig {
+  const key = overridesKey(overrides);
+  if (cached && cachedOverridesKey === key) return cached;
+
+  let host = DEFAULT_HOST;
+  let apiPort = DEFAULT_API_PORT;
+  let guardrailPort = DEFAULT_GUARDRAIL_PORT;
+  let token = "";
+
+  // Tier 3: ~/.defenseclaw/config.yaml
+  try {
+    const cfgPath = join(homedir(), ".defenseclaw", "config.yaml");
+    const raw = yaml.load(readFileSync(cfgPath, "utf8")) as Record<string, unknown> | null;
+    if (raw && typeof raw === "object") {
+      const gw = raw["gateway"] as Record<string, unknown> | undefined;
+      if (gw && typeof gw === "object") {
+        if (typeof gw["host"] === "string" && gw["host"]) host = gw["host"];
+        if (typeof gw["api_port"] === "number") apiPort = gw["api_port"];
+        if (typeof gw["token"] === "string" && gw["token"]) token = gw["token"];
+        const tokenEnv =
+          typeof gw["token_env"] === "string" && gw["token_env"]
+            ? gw["token_env"]
+            : DEFAULT_TOKEN_ENV;
+        const envVal = process.env[tokenEnv];
+        if (envVal) token = envVal;
+      }
+      const gr = raw["guardrail"] as Record<string, unknown> | undefined;
+      if (gr && typeof gr === "object") {
+        if (typeof gr["port"] === "number") guardrailPort = gr["port"];
+      }
+    }
+  } catch {
+    // Config missing or unreadable — use defaults
+  }
+
+  // Tier 2: Environment variables
+  const envHost = process.env.DEFENSECLAW_HOST;
+  if (typeof envHost === "string" && envHost) host = envHost;
+
+  const envPort = process.env.DEFENSECLAW_PORT;
+  if (typeof envPort === "string" && envPort) {
+    const parsed = parseInt(envPort, 10);
+    if (Number.isFinite(parsed) && parsed > 0) apiPort = parsed;
+  }
+
+  const envGuardrailPort = process.env.DEFENSECLAW_GUARDRAIL_PORT;
+  if (typeof envGuardrailPort === "string" && envGuardrailPort) {
+    const parsed = parseInt(envGuardrailPort, 10);
+    if (Number.isFinite(parsed) && parsed > 0) guardrailPort = parsed;
+  }
+
+  // Tier 1: Plugin config overrides (highest precedence)
+  if (overrides?.host) host = overrides.host;
+  if (overrides?.apiPort) apiPort = overrides.apiPort;
+  if (overrides?.guardrailPort) guardrailPort = overrides.guardrailPort;
+
+  // Token fallbacks (same as embedded plugin)
+  if (!token) {
+    const envVal = process.env[DEFAULT_TOKEN_ENV];
+    if (envVal) token = envVal;
+  }
+
+  if (!token) {
+    token = readDotEnvToken(DEFAULT_TOKEN_ENV);
+  }
+
+  cached = { host, apiPort, baseUrl: `http://${host}:${apiPort}`, token, guardrailPort };
+  cachedOverridesKey = key;
+  return cached;
+}
+
+/**
+ * Read a KEY=VALUE token from ~/.defenseclaw/.env.
+ * The Go sidecar loads this file into its own process env, but the
+ * OpenClaw Node.js process is separate and won't have it.
+ */
+function readDotEnvToken(key: string): string {
+  try {
+    const envPath = join(homedir(), ".defenseclaw", ".env");
+    const content = readFileSync(envPath, "utf8");
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("#") || !trimmed.includes("=")) continue;
+      const eqIdx = trimmed.indexOf("=");
+      const k = trimmed.slice(0, eqIdx).trim();
+      if (k === key) {
+        return trimmed.slice(eqIdx + 1).trim();
+      }
+    }
+  } catch {
+    // .env missing or unreadable
+  }
+  return "";
+}
+
+/** Clear cached config (for testing). */
+export function _resetSidecarConfigCache(): void {
+  cached = undefined;
+  cachedOverridesKey = undefined;
+}

--- a/output-plugin/src/types.ts
+++ b/output-plugin/src/types.ts
@@ -1,0 +1,227 @@
+/**
+ * Copyright 2026 Cisco Systems, Inc. and its affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type Severity = "CRITICAL" | "HIGH" | "MEDIUM" | "LOW" | "INFO";
+
+const SEVERITY_RANK: Record<Severity, number> = {
+  CRITICAL: 5,
+  HIGH: 4,
+  MEDIUM: 3,
+  LOW: 2,
+  INFO: 1,
+};
+
+export function compareSeverity(a: Severity, b: Severity): number {
+  return (SEVERITY_RANK[a] ?? 0) - (SEVERITY_RANK[b] ?? 0);
+}
+
+export function maxSeverity(items: readonly Severity[]): Severity {
+  let max: Severity = "INFO";
+  for (const s of items) {
+    if (compareSeverity(s, max) > 0) max = s;
+  }
+  return max;
+}
+
+export interface TaxonomyRef {
+  objective: string;      // e.g. "OB-009"
+  technique: string;      // e.g. "AITech-9.3"
+  sub_technique?: string; // e.g. "AISubtech-9.3.1"
+}
+
+export interface Finding {
+  id: string;
+  rule_id?: string;
+  severity: Severity;
+  confidence?: number;
+  title: string;
+  description: string;
+  evidence?: string;
+  location?: string;
+  remediation?: string;
+  scanner: string;
+  tags?: string[];
+  taxonomy?: TaxonomyRef;
+  occurrence_count?: number;
+  suppressed?: boolean;
+  suppression_reason?: string;
+}
+
+export interface ScanMetadata {
+  manifest_name?: string;
+  manifest_version?: string;
+  file_count: number;
+  total_size_bytes: number;
+  has_lockfile: boolean;
+  has_install_scripts: boolean;
+  detected_capabilities: string[];
+}
+
+export type CategoryStatus = "pass" | "info" | "warn" | "fail";
+
+export interface AssessmentCategory {
+  name: string;
+  status: CategoryStatus;
+  summary: string;
+}
+
+export type ScanVerdict = "benign" | "suspicious" | "malicious" | "unknown";
+
+export interface Assessment {
+  verdict: ScanVerdict;
+  confidence: number;
+  summary: string;
+  categories: AssessmentCategory[];
+}
+
+export interface ScanResult {
+  scanner: string;
+  target: string;
+  timestamp: string;
+  findings: Finding[];
+  duration_ns?: number;
+  metadata?: ScanMetadata;
+  assessment?: Assessment;
+}
+
+export interface ScanReport {
+  results: ScanResult[];
+  max_severity: Severity;
+  total_findings: number;
+  clean: boolean;
+  errors?: string[];
+}
+
+export type InstallType = "skill" | "mcp" | "plugin";
+
+export type Verdict =
+  | "blocked"
+  | "allowed"
+  | "clean"
+  | "rejected"
+  | "warning"
+  | "scan-error";
+
+export interface AdmissionResult {
+  type: InstallType;
+  name: string;
+  path: string;
+  verdict: Verdict;
+  reason: string;
+  timestamp: string;
+}
+
+export interface BlockEntry {
+  id: string;
+  target_type: string;
+  target_name: string;
+  reason: string;
+  updated_at: string;
+}
+
+export interface AllowEntry {
+  id: string;
+  target_type: string;
+  target_name: string;
+  reason: string;
+  updated_at: string;
+}
+
+export interface DaemonStatus {
+  running: boolean;
+  uptime_seconds?: number;
+  connectors?: Record<string, ConnectorHealth>;
+}
+
+export interface ConnectorHealth {
+  name: string;
+  status: "healthy" | "degraded" | "unhealthy" | "stopped";
+  message?: string;
+  last_check?: string;
+}
+
+export interface PluginManifest {
+  name: string;
+  version?: string;
+  description?: string;
+  permissions?: string[];
+  tools?: ToolManifest[];
+  commands?: CommandManifest[];
+  dependencies?: Record<string, string>;
+  scripts?: Record<string, string>;
+  source?: string;
+}
+
+export interface ToolManifest {
+  name: string;
+  description?: string;
+  parameters?: Record<string, unknown>;
+  permissions?: string[];
+}
+
+export interface CommandManifest {
+  name: string;
+  description?: string;
+  args?: Array<{ name: string; required?: boolean }>;
+}
+
+export interface MCPServerConfig {
+  name: string;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  transport?: "stdio" | "http" | "sse";
+  tools?: ToolManifest[];
+  enabled?: boolean;
+}
+
+export type ScanProfile = "default" | "strict";
+
+export interface PluginScanOptions {
+  profile?: ScanProfile;
+  /** Policy preset name ("default", "strict", "permissive") or path to YAML policy file. */
+  policy?: string;
+}
+
+/**
+ * Correlates plugin↔sidecar traffic for observability and agent registry mapping.
+ * Field names use camelCase; HTTP headers use the X-DefenseClaw-* spellings.
+ */
+export interface CorrelationContext {
+  runId?: string;
+  sessionId?: string;
+  /** Logical agent id for `X-DefenseClaw-Agent-Id` (config, env, or persisted stable id). */
+  agentId: string;
+  /** Per–extension-session instance id minted by the plugin; may converge with the sidecar echo. */
+  agentInstanceId?: string;
+  /** Echoed from the sidecar (`X-DefenseClaw-Sidecar-Instance-Id` response header). */
+  sidecarInstanceId?: string;
+  traceId?: string;
+  agentName?: string;
+  policyId?: string;
+}
+
+/** Structured log line for outbound sidecar HTTP requests (retain_plugin_logs). */
+export interface OutboundSidecarRequestLog {
+  runId?: string;
+  sessionId?: string;
+  agentId: string;
+  status_code: number;
+  duration_ms: number;
+}

--- a/output-plugin/tsconfig.json
+++ b/output-plugin/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__/fixtures"]
+}


### PR DESCRIPTION
Adds a self-contained OpenClaw plugin (output-plugin/) that can be installed from ClawHub without requiring DefenseClaw-side deployment. Includes fetch interception for 15+ LLM providers, tool inspection hooks, health monitoring, egress telemetry, and /dc-scan /dc-block /dc-allow slash commands. Supports remote sidecar via configurable sidecarHost/sidecarPort. Plugin id: defenseclaw-plugin.