### PR TITLE
[codex] Teardown all connectors on uninstall

### DIFF
--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -1368,7 +1368,7 @@ def _check_connector_residue(cfg, active: str, r: _DoctorResult) -> None:
         + "; ".join(parts)
         + ". Run 'defenseclaw doctor --fix' to invoke "
         "'defenseclaw-gateway connector teardown' for each, or "
-        "'defenseclaw uninstall --keep-openclaw' for a manual sweep."
+        "'defenseclaw uninstall' for a full connector sweep."
     )
     _emit("warn", "Connector residue", detail, r=r)
 

--- a/cli/defenseclaw/commands/cmd_uninstall.py
+++ b/cli/defenseclaw/commands/cmd_uninstall.py
@@ -26,10 +26,9 @@ Connector polymorphism (S7.3)
 -----------------------------
 Removal of the agent framework's defenseclaw artifacts is delegated to
 ``defenseclaw-gateway connector teardown`` — the canonical sentinel that
-each connector adapter implements (S7.2). This keeps the Python flow
-honest: it never has to know how Codex / Claude Code / ZeptoClaw
-configure themselves, which previously meant the OpenClaw teardown was
-the only one that worked.
+each connector adapter implements (S7.2). Uninstall fans that sentinel
+out across every known connector, not just the active one, so switching
+connectors cannot leave stale hooks or backups behind.
 
 The Python side still owns OpenClaw-specific revert paths as a fallback
 for very old gateway binaries (pre-S7.2) where the ``connector teardown``
@@ -41,6 +40,7 @@ OpenClaw, never against the other adapters — calling
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -48,6 +48,7 @@ from dataclasses import dataclass
 import click
 
 from defenseclaw import config as config_module
+from defenseclaw import connector_paths
 
 # Connectors whose teardown the Python CLI knows how to perform locally
 # without going through ``defenseclaw-gateway connector teardown``. This
@@ -55,23 +56,29 @@ from defenseclaw import config as config_module
 # old to expose the connector subcommand.
 _PYTHON_FALLBACK_CONNECTORS: frozenset[str] = frozenset({"openclaw"})
 
+# Connector names are normally sourced from connector_paths.KNOWN_CONNECTORS.
+# The active connector may still be a plugin connector, so validate it before
+# passing it to the gateway as a subprocess argument.
+_CONNECTOR_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+
 
 @dataclass
 class UninstallPlan:
     """Aggregated summary of what an uninstall/reset intends to do."""
 
     stop_gateway: bool = True
-    revert_openclaw: bool = True
     remove_plugin: bool = True
     remove_data_dir: bool = False
     remove_binaries: bool = False
     data_dir: str = ""
     openclaw_config_file: str = ""
     openclaw_home: str = ""
-    # connector is the active framework adapter to tear down. Resolved
-    # from cfg.active_connector() at plan-build time and surfaced in
-    # _render_plan so the operator sees what's about to be touched.
+    # connector is the active framework adapter. It is kept for display
+    # and backwards-compatible direct test construction; connectors is
+    # the ordered teardown set. When connectors is empty, helpers fall
+    # back to the singleton active connector.
     connector: str = "openclaw"
+    connectors: tuple[str, ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -85,13 +92,11 @@ class UninstallPlan:
     is_flag=True,
     help="Additionally remove the defenseclaw + defenseclaw-gateway binaries from ~/.local/bin.",
 )
-@click.option("--keep-openclaw", is_flag=True, help="Do NOT revert ~/.openclaw/openclaw.json or remove the plugin.")
 @click.option("--dry-run", is_flag=True, help="Show what would happen without touching the system.")
 @click.option("--yes", is_flag=True, help="Skip the confirmation prompt.")
 def uninstall_cmd(
     wipe_data: bool,
     binaries: bool,
-    keep_openclaw: bool,
     dry_run: bool,
     yes: bool,
 ) -> None:
@@ -99,8 +104,7 @@ def uninstall_cmd(
     plan = _build_plan(
         wipe_data=wipe_data,
         binaries=binaries,
-        revert_openclaw=not keep_openclaw,
-        remove_plugin=not keep_openclaw,
+        remove_plugin=True,
     )
     _render_plan(plan, dry_run=dry_run)
 
@@ -124,15 +128,14 @@ def uninstall_cmd(
 def reset_cmd(yes: bool) -> None:
     """Wipe ~/.defenseclaw so 'defenseclaw quickstart' starts clean.
 
-    Keeps binaries and the OpenClaw plugin installed so reinstall is
-    fast. For a full uninstall use 'defenseclaw uninstall --all
-    --binaries'.
+    Keeps binaries installed, but restores connector configs to their
+    pre-DefenseClaw state. For a full uninstall use 'defenseclaw
+    uninstall --all --binaries'.
     """
     plan = _build_plan(
         wipe_data=True,
         binaries=False,
-        revert_openclaw=True,
-        remove_plugin=False,  # keep plugin around for quick re-enable
+        remove_plugin=True,
     )
     _render_plan(plan, dry_run=False)
 
@@ -179,7 +182,6 @@ def _build_plan(
     *,
     wipe_data: bool,
     binaries: bool,
-    revert_openclaw: bool,
     remove_plugin: bool,
 ) -> UninstallPlan:
     data_dir = str(config_module.default_data_path())
@@ -199,10 +201,10 @@ def _build_plan(
         openclaw_config_file = os.path.join(openclaw_home, "openclaw.json")
 
     connector = _resolve_active_connector(cfg)
+    connectors = _planned_teardown_connectors(connector)
 
     return UninstallPlan(
         stop_gateway=True,
-        revert_openclaw=revert_openclaw,
         remove_plugin=remove_plugin,
         remove_data_dir=wipe_data,
         remove_binaries=binaries,
@@ -210,37 +212,44 @@ def _build_plan(
         openclaw_config_file=openclaw_config_file,
         openclaw_home=openclaw_home,
         connector=connector,
+        connectors=connectors,
     )
 
 
 def _render_plan(plan: UninstallPlan, *, dry_run: bool) -> None:
+    connectors = _connectors_to_teardown(plan)
     click.echo()
     click.echo("  ── Uninstall plan ────────────────────────────────────")
     click.echo()
     click.echo(f"  • active connector:    {plan.connector}")
     click.echo(f"  • stop sidecar:        {'yes' if plan.stop_gateway else 'no'}")
-    if plan.connector == "openclaw":
+    if connectors:
         click.echo(
-            f"  • revert openclaw.json: {'yes' if plan.revert_openclaw else 'no'} "
-            f"({plan.openclaw_config_file})"
+            "  • teardown connectors: "
+            f"yes ({', '.join(connectors)} via gateway connector teardown)"
         )
-        click.echo(f"  • remove plugin:        {'yes' if plan.remove_plugin else 'no'}")
     else:
-        click.echo(
-            f"  • teardown {plan.connector}:    "
-            f"{'yes (via gateway connector teardown)' if plan.revert_openclaw else 'no'}"
-        )
+        click.echo("  • teardown connectors: no")
+    click.echo(
+        f"  • revert openclaw.json: {'yes' if 'openclaw' in connectors else 'no'} "
+        f"({plan.openclaw_config_file})"
+    )
+    click.echo(
+        "  • remove OpenClaw plugin: "
+        f"{'yes' if plan.remove_plugin and 'openclaw' in connectors else 'no'}"
+    )
     click.echo(f"  • wipe {plan.data_dir}: {'yes' if plan.remove_data_dir else 'no'}")
     click.echo(f"  • remove binaries:     {'yes' if plan.remove_binaries else 'no'}")
     click.echo()
 
 
 def _execute_plan(plan: UninstallPlan) -> None:
+    connectors = _connectors_to_teardown(plan)
     if plan.stop_gateway:
         _stop_gateway()
-    if plan.revert_openclaw:
+    if connectors:
         _connector_teardown(plan)
-    if plan.remove_plugin and plan.connector == "openclaw":
+    if plan.remove_plugin and "openclaw" in connectors:
         # Plugin removal is OpenClaw-specific. For other connectors the
         # gateway sentinel teardown above already removed the
         # connector's hook scripts and config patches, so there is
@@ -291,35 +300,79 @@ def _gateway_supports_connector_teardown() -> bool:
     return "teardown" in combined and "list-backups" in combined
 
 
-def _connector_teardown(plan: UninstallPlan) -> None:
-    """Run connector teardown via the canonical sentinel, falling back
-    to the OpenClaw-specific Python helpers when the gateway binary
-    is too old (pre-S7.2) or the connector isn't OpenClaw.
+def _planned_teardown_connectors(
+    active_connector: str,
+) -> tuple[str, ...]:
+    """Return the ordered connector set for uninstall teardown.
 
-    For non-OpenClaw connectors the Python fallback path is **not**
-    safe — calling ``restore_openclaw_config`` against a Codex install
-    would corrupt it — so we hard-fail in that case with a clear
-    remediation pointing at the gateway upgrade path.
+    Built-ins come from the shared connector path registry so the Python
+    CLI stays in lockstep with the other connector-aware commands. A
+    safe active plugin connector is appended because it may not appear
+    in the static built-in list.
     """
-    if _gateway_supports_connector_teardown():
-        if _run_gateway_connector_teardown(plan.connector):
-            return
-        click.echo(
-            f"  ⚠ gateway connector teardown for {plan.connector} reported errors — "
-            f"see output above"
-        )
-        if plan.connector != "openclaw":
-            return
+    names: list[str] = []
+    for name in connector_paths.KNOWN_CONNECTORS:
+        normalized = connector_paths.normalize(name)
+        names.append(normalized)
 
-    if plan.connector in _PYTHON_FALLBACK_CONNECTORS:
-        _revert_openclaw_python(plan)
+    active = connector_paths.normalize(active_connector)
+    if _is_safe_connector_name(active) and active not in names:
+        names.append(active)
+    return tuple(dict.fromkeys(names))
+
+
+def _connectors_to_teardown(plan: UninstallPlan) -> tuple[str, ...]:
+    """Return a de-duplicated, validated teardown list for *plan*."""
+    candidates = plan.connectors or (plan.connector,)
+    names: list[str] = []
+    for candidate in candidates:
+        name = connector_paths.normalize(candidate)
+        if not _is_safe_connector_name(name):
+            click.echo(f"  ⚠ skipping invalid connector name {candidate!r}")
+            continue
+        if name not in names:
+            names.append(name)
+    return tuple(names)
+
+
+def _is_safe_connector_name(name: str) -> bool:
+    return bool(_CONNECTOR_NAME_RE.fullmatch(name))
+
+
+def _connector_teardown(plan: UninstallPlan) -> None:
+    """Run planned connector teardowns via the canonical sentinel.
+
+    For non-OpenClaw connectors the Python fallback path is **not** safe
+    — calling ``restore_openclaw_config`` against a Codex install would
+    corrupt it — so unsupported connectors get a clear warning while the
+    uninstall continues with the rest of the plan.
+    """
+    connectors = _connectors_to_teardown(plan)
+    if not connectors:
+        click.echo("  · no connector teardown requested")
         return
 
-    click.echo(
-        f"  ⚠ no Python fallback for connector '{plan.connector}'.\n"
-        f"     Upgrade defenseclaw-gateway to v0.7+ (introduces "
-        f"'connector teardown') and re-run 'defenseclaw uninstall'."
-    )
+    gateway_supported = _gateway_supports_connector_teardown()
+    for connector in connectors:
+        if gateway_supported:
+            if _run_gateway_connector_teardown(connector):
+                continue
+            click.echo(
+                f"  ⚠ gateway connector teardown for {connector} reported errors — "
+                f"see output above"
+            )
+            if connector != "openclaw":
+                continue
+
+        if connector in _PYTHON_FALLBACK_CONNECTORS:
+            _revert_openclaw_python(plan)
+            continue
+
+        click.echo(
+            f"  ⚠ no Python fallback for connector '{connector}'.\n"
+            f"     Upgrade defenseclaw-gateway to v0.7+ (introduces "
+            f"'connector teardown') and re-run 'defenseclaw uninstall'."
+        )
 
 
 def _run_gateway_connector_teardown(connector: str) -> bool:
@@ -329,6 +382,11 @@ def _run_gateway_connector_teardown(connector: str) -> bool:
     is forwarded to the operator so they can see exactly what each
     adapter restored.
     """
+    connector = connector_paths.normalize(connector)
+    if not _is_safe_connector_name(connector):
+        click.echo(f"  ⚠ refusing invalid connector name {connector!r}")
+        return False
+
     gw = shutil.which("defenseclaw-gateway")
     if gw is None:
         return False

--- a/cli/tests/test_cmd_uninstall.py
+++ b/cli/tests/test_cmd_uninstall.py
@@ -44,7 +44,7 @@ def capture_click_output():
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from defenseclaw.commands import cmd_uninstall
+from defenseclaw.commands import cmd_uninstall  # noqa: E402
 
 
 class BuildPlanTests(unittest.TestCase):
@@ -52,29 +52,33 @@ class BuildPlanTests(unittest.TestCase):
         plan = cmd_uninstall._build_plan(
             wipe_data=False,
             binaries=False,
-            revert_openclaw=True,
             remove_plugin=True,
         )
         self.assertFalse(plan.remove_data_dir)
         self.assertFalse(plan.remove_binaries)
-        self.assertTrue(plan.revert_openclaw)
         self.assertTrue(plan.remove_plugin)
+        self.assertEqual(
+            plan.connectors,
+            ("openclaw", "codex", "claudecode", "zeptoclaw"),
+        )
         # Defaults should always fill in data_dir / openclaw paths so
         # renderers never hit an empty string.
         self.assertTrue(plan.data_dir)
         self.assertTrue(plan.openclaw_config_file)
 
-    def test_keep_openclaw_leaves_plugin_alone(self):
+    def test_all_and_binaries_do_not_change_connector_teardown_set(self):
         plan = cmd_uninstall._build_plan(
             wipe_data=True,
             binaries=True,
-            revert_openclaw=False,
-            remove_plugin=False,
+            remove_plugin=True,
         )
         self.assertTrue(plan.remove_data_dir)
         self.assertTrue(plan.remove_binaries)
-        self.assertFalse(plan.revert_openclaw)
-        self.assertFalse(plan.remove_plugin)
+        self.assertTrue(plan.remove_plugin)
+        self.assertEqual(
+            plan.connectors,
+            ("openclaw", "codex", "claudecode", "zeptoclaw"),
+        )
 
 
 class UninstallCommandTests(unittest.TestCase):
@@ -113,7 +117,7 @@ class UninstallCommandTests(unittest.TestCase):
 
 
 class ResetCommandTests(unittest.TestCase):
-    def test_reset_yes_executes_plan_with_wipe_and_keep_plugin(self):
+    def test_reset_yes_executes_plan_with_wipe_and_connector_teardown(self):
         runner = CliRunner()
         captured = {}
 
@@ -125,9 +129,9 @@ class ResetCommandTests(unittest.TestCase):
             result = runner.invoke(cmd_uninstall.reset_cmd, ["--yes"])
             self.assertEqual(result.exit_code, 0, msg=result.output)
             plan = captured["plan"]
-            # reset = wipe data + keep plugin, don't touch binaries.
+            # reset = wipe data + connector teardown, don't touch binaries.
             self.assertTrue(plan.remove_data_dir)
-            self.assertFalse(plan.remove_plugin)
+            self.assertTrue(plan.remove_plugin)
             self.assertFalse(plan.remove_binaries)
 
 
@@ -174,10 +178,27 @@ class BuildPlanConnectorTests(unittest.TestCase):
             plan = cmd_uninstall._build_plan(
                 wipe_data=False,
                 binaries=False,
-                revert_openclaw=True,
                 remove_plugin=True,
             )
         self.assertEqual(plan.connector, "codex")
+        self.assertEqual(
+            plan.connectors,
+            ("openclaw", "codex", "claudecode", "zeptoclaw"),
+        )
+
+    def test_safe_active_plugin_connector_is_appended(self):
+        connectors = cmd_uninstall._planned_teardown_connectors("myplugin")
+        self.assertEqual(
+            connectors,
+            ("openclaw", "codex", "claudecode", "zeptoclaw", "myplugin"),
+        )
+
+    def test_invalid_active_plugin_connector_is_skipped(self):
+        connectors = cmd_uninstall._planned_teardown_connectors("bad connector")
+        self.assertEqual(
+            connectors,
+            ("openclaw", "codex", "claudecode", "zeptoclaw"),
+        )
 
     def test_plan_defaults_to_openclaw_when_load_fails(self):
         with patch("defenseclaw.commands.cmd_uninstall.config_module.load",
@@ -185,25 +206,34 @@ class BuildPlanConnectorTests(unittest.TestCase):
             plan = cmd_uninstall._build_plan(
                 wipe_data=False,
                 binaries=False,
-                revert_openclaw=True,
                 remove_plugin=True,
             )
         self.assertEqual(plan.connector, "openclaw")
+        self.assertEqual(
+            plan.connectors,
+            ("openclaw", "codex", "claudecode", "zeptoclaw"),
+        )
 
 
 class RenderPlanConnectorTests(unittest.TestCase):
     def test_render_shows_connector_specific_line_for_codex(self):
-        plan = cmd_uninstall.UninstallPlan(connector="codex", data_dir="/tmp/dc")
+        plan = cmd_uninstall.UninstallPlan(
+            connector="codex",
+            connectors=("openclaw", "codex", "claudecode", "zeptoclaw"),
+            data_dir="/tmp/dc",
+        )
         with capture_click_output() as buf:
             cmd_uninstall._render_plan(plan, dry_run=True)
         text = buf.getvalue()
         self.assertIn("active connector:    codex", text)
-        self.assertIn("teardown codex", text)
-        self.assertNotIn("revert openclaw.json", text)
+        self.assertIn("teardown connectors: yes", text)
+        self.assertIn("openclaw, codex, claudecode, zeptoclaw", text)
+        self.assertIn("revert openclaw.json: yes", text)
 
     def test_render_shows_openclaw_revert_for_openclaw(self):
         plan = cmd_uninstall.UninstallPlan(
             connector="openclaw",
+            connectors=("openclaw",),
             data_dir="/tmp/dc",
             openclaw_config_file="/tmp/openclaw.json",
         )
@@ -217,6 +247,7 @@ class ConnectorTeardownDispatchTests(unittest.TestCase):
     def _plan(self, connector: str) -> cmd_uninstall.UninstallPlan:
         return cmd_uninstall.UninstallPlan(
             connector=connector,
+            connectors=(connector,),
             data_dir="/tmp/dc",
             openclaw_config_file="/tmp/openclaw.json",
             openclaw_home="/tmp/.openclaw",
@@ -231,6 +262,26 @@ class ConnectorTeardownDispatchTests(unittest.TestCase):
             cmd_uninstall._connector_teardown(self._plan("codex"))
             run_mock.assert_called_once_with("codex")
             fallback.assert_not_called()
+
+    def test_uses_gateway_sentinel_for_each_planned_connector(self):
+        plan = cmd_uninstall.UninstallPlan(
+            connector="codex",
+            connectors=("openclaw", "codex", "claudecode", "zeptoclaw"),
+            data_dir="/tmp/dc",
+            openclaw_config_file="/tmp/openclaw.json",
+            openclaw_home="/tmp/.openclaw",
+        )
+        with patch.object(cmd_uninstall, "_gateway_supports_connector_teardown",
+                          return_value=True), \
+             patch.object(cmd_uninstall, "_run_gateway_connector_teardown",
+                          return_value=True) as run_mock, \
+             patch.object(cmd_uninstall, "_revert_openclaw_python") as fallback:
+            cmd_uninstall._connector_teardown(plan)
+        self.assertEqual(
+            [c.args[0] for c in run_mock.call_args_list],
+            ["openclaw", "codex", "claudecode", "zeptoclaw"],
+        )
+        fallback.assert_not_called()
 
     def test_falls_back_to_python_for_openclaw_when_gateway_old(self):
         with patch.object(cmd_uninstall, "_gateway_supports_connector_teardown",
@@ -303,6 +354,15 @@ class GatewaySupportProbeTests(unittest.TestCase):
             run_mock.return_value.stderr = "unknown command \"connector\""
             self.assertFalse(cmd_uninstall._gateway_supports_connector_teardown())
 
+    def test_gateway_teardown_rejects_invalid_connector_name(self):
+        with capture_click_output() as buf, \
+             patch("subprocess.run") as run_mock:
+            self.assertFalse(
+                cmd_uninstall._run_gateway_connector_teardown("bad connector")
+            )
+        run_mock.assert_not_called()
+        self.assertIn("refusing invalid connector name", buf.getvalue())
+
 
 class ExecutePlanConnectorTests(unittest.TestCase):
     """Lock down the polymorphic _execute_plan ordering: stop → teardown
@@ -321,6 +381,7 @@ class ExecutePlanConnectorTests(unittest.TestCase):
     def test_codex_skips_remove_plugin_step(self):
         plan = cmd_uninstall.UninstallPlan(
             connector="codex",
+            connectors=("codex",),
             data_dir="/tmp/dc",
         )
         ctx_mgrs = self._common_patches()
@@ -340,6 +401,25 @@ class ExecutePlanConnectorTests(unittest.TestCase):
     def test_openclaw_runs_remove_plugin_step(self):
         plan = cmd_uninstall.UninstallPlan(
             connector="openclaw",
+            connectors=("openclaw",),
+            data_dir="/tmp/dc",
+            remove_plugin=True,
+        )
+        ctx_mgrs = self._common_patches()
+        try:
+            mocks = [c.__enter__() for c in ctx_mgrs]
+            _, teardown_mock, plugin_mock, _, _ = mocks
+            cmd_uninstall._execute_plan(plan)
+            teardown_mock.assert_called_once()
+            plugin_mock.assert_called_once_with(plan)
+        finally:
+            for c in ctx_mgrs:
+                c.__exit__(None, None, None)
+
+    def test_all_connector_plan_runs_openclaw_plugin_step(self):
+        plan = cmd_uninstall.UninstallPlan(
+            connector="codex",
+            connectors=("openclaw", "codex", "claudecode", "zeptoclaw"),
             data_dir="/tmp/dc",
             remove_plugin=True,
         )

--- a/cli/tests/test_install_smoke.py
+++ b/cli/tests/test_install_smoke.py
@@ -109,8 +109,8 @@ class InstallSmokeMatrixTests(unittest.TestCase):
     """Per-connector lifecycle round-trip smoke tests."""
 
     def _run_setup_disable_uninstall_for(self, connector_name: str) -> None:
-        from defenseclaw.commands.cmd_setup import execute_guardrail_setup
         from defenseclaw.commands import cmd_uninstall
+        from defenseclaw.commands.cmd_setup import execute_guardrail_setup
 
         with _IsolatedHome() as home:
             app = _build_app_with_connector(home, connector_name)
@@ -152,7 +152,7 @@ class InstallSmokeMatrixTests(unittest.TestCase):
 
             # 3. The uninstall planner produces a coherent dry-run plan
             #    rooted under the tmp data dir.  We use the safe defaults
-            #    (no binary removal, no openclaw revert).
+            #    (no binary removal; connector teardown is reversible).
             with patch.dict(
                 os.environ,
                 {"DEFENSECLAW_HOME": os.path.join(home, ".defenseclaw")},
@@ -161,8 +161,7 @@ class InstallSmokeMatrixTests(unittest.TestCase):
                 plan = cmd_uninstall._build_plan(
                     wipe_data=False,
                     binaries=False,
-                    revert_openclaw=False,
-                    remove_plugin=False,
+                    remove_plugin=True,
                 )
             self.assertTrue(
                 plan.data_dir,


### PR DESCRIPTION
## Summary

- Make `defenseclaw uninstall` fan out connector teardown across all known connectors instead of only the active connector.
- Remove the `--keep-openclaw` option now that connector teardown restores framework config to the original state.
- Update reset/uninstall planning, doctor residue guidance, and the Python tests for the all-connector teardown contract.

## Why

Uninstall previously cleaned only the active connector, which could leave stale DefenseClaw hooks, backups, or config patches behind after connector switches. The gateway teardown sentinel is already the canonical reversible cleanup path, so uninstall should invoke it for the full connector set.

## Validation

- `uv run pytest cli/tests/test_cmd_uninstall.py cli/tests/test_install_smoke.py cli/tests/test_cmd_doctor_residue.py`
- `uv run ruff check cli/defenseclaw/commands/cmd_uninstall.py cli/defenseclaw/commands/cmd_doctor.py cli/tests/test_cmd_uninstall.py cli/tests/test_install_smoke.py`
- `uv run defenseclaw uninstall --help`