### PR TITLE
fix(guardrail): honor target base URL for intercepted providers

### DIFF
--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -1592,14 +1592,16 @@ func (p *GuardrailProxy) resolveProviderFromHeaders(req *ChatRequest) LLMProvide
 		return nil
 	}
 
+	// Fetch-intercepted requests carry the original upstream origin in
+	// X-DC-Target-URL. Use it as the provider base URL so self-hosted
+	// OpenAI-compatible endpoints, such as vLLM, are not routed to the
+	// provider's public default endpoint.
+	//
 	// Azure requires the specific resource endpoint as baseURL.
 	// Bedrock (ZeptoClaw / OpenClaw) uses regional bedrock-runtime URLs with
-	// ABSK bearer keys — Bifrost handles that path; pin BaseURL to the snapshot
-	// origin so the tenant routes to the correct region.
-	baseURL := ""
-	if prefix == "azure" {
-		baseURL = req.TargetURL
-	}
+	// ABSK bearer keys; keep the baseURL pinned to the snapshot origin so the
+	// tenant routes to the correct region.
+	baseURL := req.TargetURL
 	if prefix == "bedrock" {
 		baseURL = strings.TrimRight(req.TargetURL, "/")
 	}


### PR DESCRIPTION
## Summary

This PR makes the guardrail proxy honor `X-DC-Target-URL` as the custom upstream base URL for fetch-intercepted providers.

The change keeps the existing upstream handling for Azure and Bedrock, while extending the same base URL preservation behavior to self-hosted OpenAI-compatible providers such as vLLM.

## Motivation

The fetch interceptor forwards the original upstream origin via `X-DC-Target-URL`.

For self-hosted OpenAI-compatible providers, the guardrail proxy must preserve that origin when constructing the upstream provider. Without this, intercepted requests can fall back to a provider's public default endpoint, such as `https://api.openai.com`, and use the self-hosted provider token as an OpenAI API key.

## Changes

- Use `req.TargetURL` as the default provider base URL for fetch-intercepted provider resolution.
- Preserve the existing Bedrock-specific base URL normalization.
- Keep the change intentionally small and focused on provider base URL routing.

## Relationship to related issues and PRs

- Part of #200.
- Complementary to #201.
- #201 covers the direct-provider/config fallback path for #150.
- This PR covers the fetch-interceptor path where `X-DC-Target-URL` is present.

## Validation

- Rebased onto the latest upstream `main`.
- PR is mergeable after the rebase.
