### PR TITLE
fix(gateway): route requests to user-configured api_base in direct-pr…

### DIFF
--- a/internal/configs/providers.json
+++ b/internal/configs/providers.json
@@ -89,6 +89,17 @@
       "domains": ["bedrock-runtime."],
       "profile_id": null,
       "env_keys": []
+    },
+    {
+    "name": "openai",
+    "domains": [
+    "nemoclaw.",
+    "nemoclaw-nemoclaw."
+    ],
+    "profile_id": "openai:default",
+    "env_keys": [
+        "OPENCLAW_GATEWAY_TOKEN"
+    ]
     }
   ],
   "ollama_ports": [11434]

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -1273,7 +1273,7 @@ func (p *GuardrailProxy) resolveConfiguredProvider(req *ChatRequest) LLMProvider
 
 	fmt.Fprintf(os.Stderr, "[guardrail] direct-provider mode: using configured model %q\n", cfgModel)
 
-	provider, err := NewProvider(cfgModel, apiKey)
+	provider, err := NewProviderWithBase(cfgModel, apiKey, p.cfg.APIBase)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[guardrail] failed to create provider for %q: %v\n", cfgModel, err)
 		return nil


### PR DESCRIPTION
## Summary

Ensures the guardrail proxy routes requests to the user-configured `api_base` endpoint instead of ignoring it when no fetch interceptor is involved (direct-provider mode).

## Changes

- `internal/gateway/proxy.go`: `NewProvider()` → `NewProviderWithBase()` to honor configured `api_base`
- `internal/configs/providers.json`: Add NemoClaw domain prefixes (`nemoclaw.`, `nemoclaw-nemoclaw.`) for endpoint recognition

## Configuration Required

Users must set `guardrail.api_base` in `~/.defenseclaw/config.yaml` to point to their custom endpoint:

guardrail:
  api_base: https://my-custom-gateway.example.com

When `api_base` is not set, behavior is unchanged from the original `NewProvider()` call.

## Testing

- Tested on deployment server with Nemotron on OpenShift
- Guardrail proxy correctly routes to configured endpoint
- No regression for default routing when `api_base` is empty

Fixes #150