### PR TITLE
fix(release): create GitHub release atomically for immutable releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,13 +26,6 @@ jobs:
 
       - uses: anchore/sbom-action/download-syft@v0
 
-      - uses: goreleaser/goreleaser-action@v6
-        with:
-          version: latest
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.13"
@@ -41,12 +34,52 @@ jobs:
         with:
           node-version: "20"
 
+      # GoReleaser builds, signs, generates SBOMs, and publishes the Homebrew
+      # cask, but does NOT create the GitHub release (release.disable: true in
+      # .goreleaser.yaml). This is required because the repository has
+      # "Immutable releases" enabled, which rejects post-create asset uploads.
+      - name: Build artifacts with GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build CLI wheel and plugin tarball
         run: |
           make dist-cli
           make dist-plugin
 
-      - name: Upload CLI and plugin to release
+      # Create the GitHub release atomically with every asset attached at
+      # creation time. Immutable releases freeze immediately on create, so all
+      # assets must be supplied in this single API call.
+      - name: Publish GitHub release with all assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${GITHUB_REF#refs/tags/}" dist/*.whl dist/defenseclaw-plugin-*.tar.gz
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+
+          shopt -s nullglob
+          assets=(
+            dist/*.tar.gz
+            dist/*.sbom.json
+            dist/checksums.txt
+            dist/checksums.txt.sig
+            dist/checksums.txt.pem
+            dist/*.whl
+          )
+
+          notes_args=()
+          if [ -f dist/CHANGELOG.md ]; then
+            notes_args=(--notes-file dist/CHANGELOG.md)
+          else
+            notes_args=(--generate-notes)
+          fi
+
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TAG" \
+            "${notes_args[@]}" \
+            "${assets[@]}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,6 +51,9 @@ changelog:
       - "^chore:"
       - "Merge pull request"
 
+release:
+  disable: "true"
+
 homebrew_casks:
   - repository:
       owner: cisco-ai-defense


### PR DESCRIPTION
## Summary

Fixes the `Release` workflow which has been failing on tag pushes because the repo has GitHub's **Immutable releases** feature enabled.

GoReleaser's default flow is *create release → upload assets in separate API calls*. Immutable releases freeze a release the moment it is created, so every subsequent asset upload returned:

```
422 Cannot upload assets to an immutable release
```

(See the failed run for `0.3.0`: https://github.com/cisco-ai-defense/defenseclaw/actions/runs/25070692367/job/73449852693)

### Changes
- `.goreleaser.yaml`: add `release.disable: "true"` so GoReleaser still builds binaries, signs checksums (cosign), generates SBOMs (syft), and publishes the Homebrew cask — but no longer creates the GitHub release itself.
- `.github/workflows/release.yaml`:
  - Reorder steps so all build tooling (Go, uv, Node) is set up before GoReleaser runs.
  - After GoReleaser produces `dist/`, run `make dist-cli` and `make dist-plugin` to add the wheel and plugin tarball.
  - Replace the post-hoc `gh release upload` with a single atomic `gh release create` that includes every asset (archives, SBOMs, `checksums.txt` + sigstore `.sig`/`.pem`, wheel, plugin tarball) in one API call. This is compatible with immutable releases because the release is frozen *with* its full asset set.
  - Pin `goreleaser-action` to `~> v2` to silence the "using latest" warning and make builds deterministic.

## Test plan
- [ ] Merge this PR.
- [ ] Either (a) delete the empty `0.3.0` release/tag and re-push `0.3.0`, or (b) push a new tag (e.g. `0.3.1`) — note that the existing immutable `0.3.0` release cannot be re-used.
- [ ] Verify the `Release` workflow completes successfully and the GitHub release is created with all assets attached at creation time:
  - `defenseclaw_<version>_{darwin,linux}_{amd64,arm64}.tar.gz` (×4)
  - `*.sbom.json` (×4)
  - `checksums.txt`, `checksums.txt.sig`, `checksums.txt.pem`
  - CLI wheel (`*.whl`)
  - `defenseclaw-plugin-<version>.tar.gz`
- [ ] Confirm the Homebrew cask in `cisco-ai-defense/homebrew-tap` is updated and `brew install --cask cisco-ai-defense/tap/defenseclaw` succeeds.