### PR TITLE
fix(release): set homebrew cask url template + pre-flight existing release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Fail fast with a clear message if a release already exists for this
+      # tag. Immutable releases cannot accept post-create asset uploads, so a
+      # pre-existing release for this tag will leave us unable to attach any
+      # binaries, SBOMs, signatures, or wheels.
+      - name: Verify no pre-existing release blocks atomic creation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error title=Release already exists::A release for tag '$TAG' already exists at https://github.com/${GITHUB_REPOSITORY}/releases/tag/$TAG"
+            echo "::error::With Immutable Releases enabled, the workflow cannot attach assets to a pre-existing release."
+            echo "::error::Either delete that release and re-tag, or push a fresh tag (e.g. a patch bump). Do NOT manually create the GitHub release before pushing the tag."
+            exit 1
+          fi
+
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -59,6 +59,12 @@ homebrew_casks:
       owner: cisco-ai-defense
       name: homebrew-tap
       token: "{{ .Env.GITHUB_TOKEN }}"
+    # release.disable is on (immutable releases require atomic creation in CI),
+    # so GoReleaser cannot infer the cask download URL from the release config.
+    # Point at the canonical GitHub release-asset URL that our workflow will
+    # populate via `gh release create` immediately after this step.
+    url:
+      template: "https://github.com/cisco-ai-defense/defenseclaw/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     skip_upload: auto
     name: defenseclaw
     homepage: "https://github.com/cisco-ai-defense/defenseclaw"


### PR DESCRIPTION
## Summary

Follow-up to #202 (atomic immutable-release creation). The first run after #202 — https://github.com/cisco-ai-defense/defenseclaw/actions/runs/25143241078 — failed with:

```
release failed after 4m42s
  error=release is disabled, cannot use default url_template
```

The error comes from the Homebrew cask pipe: with `release.disable: "true"` set, GoReleaser has no source from which to derive the default cask download URL.

### Changes

1. `.goreleaser.yaml`: explicitly set the Homebrew cask `url.template` to the canonical GitHub release-asset URL that the workflow's `gh release create` step populates immediately after GoReleaser runs.
2. `.github/workflows/release.yaml`: add an early pre-flight that hard-fails with a clear message if a release already exists for the tag. With Immutable Releases enabled, a pre-existing release blocks atomic creation forever, so it's much better to surface that before spending 5 minutes building all four platform binaries (which is what happened on the failing run — a manually pre-created `0.3.1` release plus the homebrew issue compounded the failure).

### Test plan

- [ ] Merge.
- [ ] Push a fresh tag (e.g. `0.3.2`) — do NOT pre-create the GitHub release.
- [ ] Verify the workflow completes and the release is created with all assets attached:
  - 4 × `defenseclaw_<version>_<os>_<arch>.tar.gz`
  - 4 × `*.sbom.json`
  - `checksums.txt`, `checksums.txt.sig`, `checksums.txt.pem`
  - `*.whl`
  - `defenseclaw-plugin-<version>.tar.gz`
- [ ] Verify the Homebrew cask in `cisco-ai-defense/homebrew-tap` references `https://github.com/cisco-ai-defense/defenseclaw/releases/download/<tag>/...` URLs.