### PR TITLE
fix: pristine-backup migration, upgrade docs, and release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "*.*.*"
+  release:
+    types: [published]
 
 permissions:
   contents: write
@@ -11,7 +10,10 @@ permissions:
   packages: write
 
 jobs:
-  release:
+  # -----------------------------------------------------------------
+  # Build Go gateway binaries for all platforms via goreleaser
+  # -----------------------------------------------------------------
+  gateway:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,24 +31,75 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --clean
+          args: release --clean --skip=publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/upload-artifact@v4
         with:
-          python-version: "3.13"
+          name: gateway-archives
+          path: dist/*.tar.gz
+
+  # -----------------------------------------------------------------
+  # Build Python CLI wheel
+  # -----------------------------------------------------------------
+  cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
 
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: npm
+          cache-dependency-path: extensions/defenseclaw/package-lock.json
 
-      - name: Build CLI wheel and plugin tarball
+      - name: Build CLI wheel
+        run: make dist-cli
+
+      - name: Build plugin tarball
+        run: make dist-plugin
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cli-and-plugin
+          path: |
+            dist/*.whl
+            dist/defenseclaw-plugin-*.tar.gz
+
+  # -----------------------------------------------------------------
+  # Upload all artifacts to the GitHub release
+  # -----------------------------------------------------------------
+  upload:
+    needs: [gateway, cli]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: gateway-archives
+          path: dist/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: cli-and-plugin
+          path: dist/
+
+      - name: Generate checksums
         run: |
-          make dist-cli
-          make dist-plugin
+          cd dist
+          shasum -a 256 *.tar.gz *.whl > checksums.txt
 
-      - name: Upload CLI and plugin to release
+      - name: Upload release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${GITHUB_REF#refs/tags/}" dist/*.whl dist/defenseclaw-plugin-*.tar.gz
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          gh release upload "$tag" \
+            dist/*.tar.gz \
+            dist/*.whl \
+            dist/checksums.txt \
+            --clobber

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,7 +65,7 @@ homebrew_casks:
     # populate via `gh release create` immediately after this step.
     url:
       template: "https://github.com/cisco-ai-defense/defenseclaw/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-    skip_upload: auto
+    skip_upload: "true"
     name: defenseclaw
     homepage: "https://github.com/cisco-ai-defense/defenseclaw"
     description: "Enterprise governance layer for OpenClaw"

--- a/cli/defenseclaw/migrations.py
+++ b/cli/defenseclaw/migrations.py
@@ -49,12 +49,70 @@ def _migrate_0_3_0(openclaw_home: str) -> None:
     The fetch interceptor introduced in 0.3.0 handles routing transparently,
     so these entries are no longer needed and must be cleaned up on upgrade.
 
-    Plugin registration is preserved.
+    Strategy: restore the pristine backup of openclaw.json that was captured
+    before DefenseClaw first touched the file, then re-apply only the plugin
+    registration that 0.3.0 needs. This is cleaner than surgically patching
+    individual keys and avoids leaving behind stale or unexpected entries.
+
+    Falls back to surgical removal if no pristine backup exists (e.g.
+    guardrail was never enabled, or the backup was deleted).
     """
     oc_json = os.path.join(openclaw_home, "openclaw.json")
     if not os.path.isfile(oc_json):
         return
 
+    from defenseclaw.guardrail import pristine_backup_path
+
+    data_dir = os.path.expanduser("~/.defenseclaw")
+    pristine = pristine_backup_path(oc_json, data_dir)
+
+    if pristine:
+        _migrate_0_3_0_from_pristine(oc_json, pristine)
+    else:
+        _migrate_0_3_0_surgical(oc_json)
+
+
+def _migrate_0_3_0_from_pristine(oc_json: str, pristine: str) -> None:
+    """Restore pristine openclaw.json and re-apply plugin registration."""
+    import shutil
+
+    try:
+        with open(pristine) as f:
+            cfg = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        click.echo(f"    pristine backup unreadable ({exc}), falling back to surgical fix")
+        _migrate_0_3_0_surgical(oc_json)
+        return
+
+    # Re-apply the minimal plugin registration that 0.3.0 needs.
+    plugins = cfg.setdefault("plugins", {})
+    allow = plugins.setdefault("allow", [])
+    if "defenseclaw" not in allow:
+        allow.append("defenseclaw")
+    entries = plugins.setdefault("entries", {})
+    if "defenseclaw" not in entries:
+        entries["defenseclaw"] = {"enabled": True}
+    else:
+        entries["defenseclaw"]["enabled"] = True
+    install_path = os.path.join(os.path.dirname(oc_json), "extensions", "defenseclaw")
+    load = plugins.setdefault("load", {})
+    paths = load.setdefault("paths", [])
+    if install_path not in paths:
+        paths.append(install_path)
+
+    # Write the restored + patched config
+    shutil.copy2(oc_json, oc_json + ".pre-0.3.0-migration")
+
+    with open(oc_json, "w") as f:
+        json.dump(cfg, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+    click.echo(f"    restored openclaw.json from pristine backup ({os.path.basename(pristine)})")
+    click.echo("    re-applied plugin registration for 0.3.0")
+
+
+def _migrate_0_3_0_surgical(oc_json: str) -> None:
+    """Fallback: surgically remove legacy entries when no pristine backup exists."""
     try:
         with open(oc_json) as f:
             cfg = json.load(f)
@@ -64,7 +122,6 @@ def _migrate_0_3_0(openclaw_home: str) -> None:
     changed = False
     changes = []
 
-    # Remove legacy provider entries
     providers = cfg.get("models", {}).get("providers", {})
     for key in ("defenseclaw", "litellm"):
         if key in providers:
@@ -72,11 +129,9 @@ def _migrate_0_3_0(openclaw_home: str) -> None:
             changes.append(f"removed providers.{key}")
             changed = True
 
-    # Restore model.primary if it was redirected through defenseclaw/litellm
     model = cfg.get("agents", {}).get("defaults", {}).get("model", {})
     primary = model.get("primary", "")
     if primary.startswith(("defenseclaw/", "litellm/")):
-        # Strip the defenseclaw/ or litellm/ prefix to restore the real model
         restored = primary.split("/", 1)[1]
         model["primary"] = restored
         changes.append(f"restored model.primary: {primary} → {restored}")
@@ -92,6 +147,7 @@ def _migrate_0_3_0(openclaw_home: str) -> None:
 
     for c in changes:
         click.echo(f"    {c}")
+    click.echo("    (no pristine backup found — applied surgical fix)")
 
 
 # ---------------------------------------------------------------------------

--- a/cli/tests/test_migrations.py
+++ b/cli/tests/test_migrations.py
@@ -1,0 +1,267 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from defenseclaw.migrations import (
+    _migrate_0_3_0,
+    _migrate_0_3_0_from_pristine,
+    _migrate_0_3_0_surgical,
+    run_migrations,
+)
+
+
+def _write_json(path: str, data: dict) -> None:
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+
+def _read_json(path: str) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+class TestMigrate030FromPristine(unittest.TestCase):
+    """Tests for the pristine-backup restore path."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="dclaw-mig-")
+        self.oc_json = os.path.join(self.tmp, "openclaw.json")
+        self.pristine = os.path.join(self.tmp, "openclaw.json.pristine")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp)
+
+    def test_restores_from_pristine_and_registers_plugin(self):
+        pristine_cfg = {
+            "models": {"providers": {"openai": {"key": "sk-test"}}},
+            "agents": {"defaults": {"model": {"primary": "claude-sonnet-4-20250514"}}},
+        }
+        _write_json(self.pristine, pristine_cfg)
+
+        current_cfg = {
+            "models": {
+                "providers": {
+                    "openai": {"key": "sk-test"},
+                    "defenseclaw": {"url": "http://localhost:8080"},
+                    "litellm": {"url": "http://localhost:8081"},
+                }
+            },
+            "agents": {"defaults": {"model": {"primary": "defenseclaw/claude-sonnet-4-20250514"}}},
+        }
+        _write_json(self.oc_json, current_cfg)
+
+        _migrate_0_3_0_from_pristine(self.oc_json, self.pristine)
+
+        result = _read_json(self.oc_json)
+        self.assertNotIn("defenseclaw", result.get("models", {}).get("providers", {}))
+        self.assertNotIn("litellm", result.get("models", {}).get("providers", {}))
+        self.assertEqual(
+            result["agents"]["defaults"]["model"]["primary"], "claude-sonnet-4-20250514"
+        )
+        self.assertIn("defenseclaw", result["plugins"]["allow"])
+        self.assertEqual(result["plugins"]["entries"]["defenseclaw"]["enabled"], True)
+        install_path = os.path.join(self.tmp, "extensions", "defenseclaw")
+        self.assertIn(install_path, result["plugins"]["load"]["paths"])
+
+    def test_creates_pre_migration_backup(self):
+        _write_json(self.pristine, {"plugins": {}})
+        _write_json(self.oc_json, {"old": True})
+
+        _migrate_0_3_0_from_pristine(self.oc_json, self.pristine)
+
+        backup = self.oc_json + ".pre-0.3.0-migration"
+        self.assertTrue(os.path.isfile(backup))
+        self.assertEqual(_read_json(backup), {"old": True})
+
+    def test_preserves_existing_plugin_entries(self):
+        pristine_cfg = {
+            "plugins": {
+                "allow": ["other-plugin"],
+                "entries": {"other-plugin": {"enabled": True}},
+                "load": {"paths": ["/some/path"]},
+            }
+        }
+        _write_json(self.pristine, pristine_cfg)
+        _write_json(self.oc_json, {})
+
+        _migrate_0_3_0_from_pristine(self.oc_json, self.pristine)
+
+        result = _read_json(self.oc_json)
+        self.assertIn("other-plugin", result["plugins"]["allow"])
+        self.assertIn("defenseclaw", result["plugins"]["allow"])
+        self.assertIn("other-plugin", result["plugins"]["entries"])
+
+    def test_falls_back_to_surgical_on_corrupted_pristine(self):
+        with open(self.pristine, "w") as f:
+            f.write("not valid json{{{")
+
+        current_cfg = {
+            "models": {
+                "providers": {"defenseclaw": {"url": "http://localhost:8080"}}
+            },
+        }
+        _write_json(self.oc_json, current_cfg)
+
+        _migrate_0_3_0_from_pristine(self.oc_json, self.pristine)
+
+        result = _read_json(self.oc_json)
+        self.assertNotIn("defenseclaw", result.get("models", {}).get("providers", {}))
+
+
+class TestMigrate030Surgical(unittest.TestCase):
+    """Tests for the surgical fallback path."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="dclaw-mig-")
+        self.oc_json = os.path.join(self.tmp, "openclaw.json")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp)
+
+    def test_removes_defenseclaw_and_litellm_providers(self):
+        cfg = {
+            "models": {
+                "providers": {
+                    "openai": {"key": "sk-test"},
+                    "defenseclaw": {"url": "http://localhost:8080"},
+                    "litellm": {"url": "http://localhost:8081"},
+                }
+            },
+        }
+        _write_json(self.oc_json, cfg)
+
+        _migrate_0_3_0_surgical(self.oc_json)
+
+        result = _read_json(self.oc_json)
+        providers = result["models"]["providers"]
+        self.assertNotIn("defenseclaw", providers)
+        self.assertNotIn("litellm", providers)
+        self.assertIn("openai", providers)
+
+    def test_restores_model_primary_defenseclaw_prefix(self):
+        cfg = {
+            "agents": {"defaults": {"model": {"primary": "defenseclaw/claude-sonnet-4-20250514"}}},
+        }
+        _write_json(self.oc_json, cfg)
+
+        _migrate_0_3_0_surgical(self.oc_json)
+
+        result = _read_json(self.oc_json)
+        self.assertEqual(
+            result["agents"]["defaults"]["model"]["primary"], "claude-sonnet-4-20250514"
+        )
+
+    def test_restores_model_primary_litellm_prefix(self):
+        cfg = {
+            "agents": {"defaults": {"model": {"primary": "litellm/gpt-4o"}}},
+        }
+        _write_json(self.oc_json, cfg)
+
+        _migrate_0_3_0_surgical(self.oc_json)
+
+        result = _read_json(self.oc_json)
+        self.assertEqual(result["agents"]["defaults"]["model"]["primary"], "gpt-4o")
+
+    def test_noop_when_no_legacy_entries(self):
+        cfg = {
+            "models": {"providers": {"openai": {"key": "sk-test"}}},
+            "agents": {"defaults": {"model": {"primary": "claude-sonnet-4-20250514"}}},
+        }
+        _write_json(self.oc_json, cfg)
+        mtime_before = os.path.getmtime(self.oc_json)
+
+        _migrate_0_3_0_surgical(self.oc_json)
+
+        mtime_after = os.path.getmtime(self.oc_json)
+        self.assertEqual(mtime_before, mtime_after)
+
+    def test_noop_when_file_missing(self):
+        _migrate_0_3_0_surgical(os.path.join(self.tmp, "nonexistent.json"))
+
+    def test_noop_when_file_is_invalid_json(self):
+        with open(self.oc_json, "w") as f:
+            f.write("{bad json")
+        _migrate_0_3_0_surgical(self.oc_json)
+
+
+class TestMigrate030Dispatch(unittest.TestCase):
+    """Tests for the top-level _migrate_0_3_0 dispatch logic."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="dclaw-mig-")
+        self.oc_home = self.tmp
+        self.oc_json = os.path.join(self.oc_home, "openclaw.json")
+        self.data_dir = os.path.join(self.tmp, ".defenseclaw")
+        os.makedirs(self.data_dir, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp)
+
+    def test_noop_when_no_openclaw_json(self):
+        _migrate_0_3_0(self.oc_home)
+
+    @patch("defenseclaw.guardrail.pristine_backup_path")
+    @patch("defenseclaw.migrations._migrate_0_3_0_from_pristine")
+    def test_uses_pristine_when_available(self, mock_from_pristine, mock_pristine_path):
+        _write_json(self.oc_json, {})
+        mock_pristine_path.return_value = "/some/pristine/backup"
+
+        _migrate_0_3_0(self.oc_home)
+
+        mock_from_pristine.assert_called_once_with(self.oc_json, "/some/pristine/backup")
+
+    @patch("defenseclaw.guardrail.pristine_backup_path")
+    @patch("defenseclaw.migrations._migrate_0_3_0_surgical")
+    def test_falls_back_to_surgical_when_no_pristine(self, mock_surgical, mock_pristine_path):
+        _write_json(self.oc_json, {})
+        mock_pristine_path.return_value = None
+
+        _migrate_0_3_0(self.oc_home)
+
+        mock_surgical.assert_called_once_with(self.oc_json)
+
+
+class TestRunMigrations(unittest.TestCase):
+    """Tests for the run_migrations orchestrator."""
+
+    def test_applies_migrations_in_range(self):
+        count = run_migrations("0.2.0", "0.3.0", tempfile.mkdtemp())
+        self.assertEqual(count, 1)
+
+    def test_applies_same_version_migrations(self):
+        count = run_migrations("0.3.0", "0.3.0", tempfile.mkdtemp())
+        self.assertEqual(count, 1)
+
+    def test_skips_already_applied_migrations(self):
+        count = run_migrations("0.3.0", "0.4.0", tempfile.mkdtemp())
+        self.assertEqual(count, 0)
+
+    def test_skips_future_migrations(self):
+        count = run_migrations("0.1.0", "0.2.0", tempfile.mkdtemp())
+        self.assertEqual(count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -555,6 +555,120 @@ running `defenseclaw doctor` for the full report.
 
 ---
 
+## Upgrading
+
+### Upgrading from 0.2.0 to 0.3.0
+
+Release 0.2.0 does not include the `defenseclaw upgrade` CLI command. Use the
+standalone upgrade shell script instead:
+
+```bash
+# Upgrade to 0.3.0 (downloads from GitHub Releases)
+curl -sSfL https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/upgrade.sh \
+  | bash -s -- --version 0.3.0
+```
+
+Or, if you have the repository cloned:
+
+```bash
+./scripts/upgrade.sh --version 0.3.0
+```
+
+Add `--yes` to skip the confirmation prompt.
+
+The script will:
+
+1. Verify release artifacts exist on GitHub before touching anything
+2. Download the gateway binary and Python CLI wheel to a temp directory
+3. Back up `~/.defenseclaw/` config files and `~/.openclaw/openclaw.json`
+4. Stop the gateway, install the new artifacts, run migrations
+5. Restart the gateway and verify health
+
+After this upgrade completes, the `defenseclaw upgrade` CLI command becomes
+available for all future upgrades.
+
+#### 0.3.0 migration: legacy model provider cleanup
+
+The 0.2.0 guardrail setup redirected LLM traffic by writing provider and model
+entries directly into `~/.openclaw/openclaw.json`:
+
+- `models.providers.defenseclaw` and/or `models.providers.litellm` — proxy
+  provider definitions that routed calls through the guardrail
+- `agents.defaults.model.primary` set to `defenseclaw/<model>` or
+  `litellm/<model>` — forced all agent calls through the proxy provider
+
+In 0.3.0, routing is handled transparently by a fetch interceptor in the
+OpenClaw plugin, so these entries are no longer needed.
+
+The migration uses a **pristine-backup restore** strategy. When DefenseClaw's
+guardrail was first enabled, it captured a one-time snapshot of the original
+`openclaw.json` (before any DefenseClaw modifications). The migration:
+
+1. Restores `openclaw.json` from that pristine backup — removing all
+   DefenseClaw-injected entries in one clean step
+2. Re-applies only the minimal plugin registration that 0.3.0 needs
+   (`plugins.allow`, `plugins.entries`, `plugins.load.paths`)
+3. Saves a `.pre-0.3.0-migration` backup of the current file before
+   overwriting, for safety
+
+If no pristine backup exists (e.g. guardrail was never enabled, or the backup
+was deleted), the migration falls back to **surgical removal**: it deletes
+`models.providers.defenseclaw` / `models.providers.litellm` and strips the
+proxy prefix from `agents.defaults.model.primary`.
+
+If none of these legacy entries exist, the migration is a no-op.
+
+### Upgrading from 0.3.0 and later
+
+Starting with 0.3.0, use the built-in CLI command:
+
+```bash
+# Upgrade to the latest release
+defenseclaw upgrade
+
+# Upgrade to a specific version
+defenseclaw upgrade --version 0.4.0
+
+# Skip confirmation prompt
+defenseclaw upgrade --yes
+```
+
+The CLI command performs the same steps as the shell script: pre-flight
+artifact verification, config backup, stop-install-migrate-restart, and
+health polling. See the [CLI Reference](CLI.md#upgrade) for full flag
+documentation.
+
+### What gets upgraded
+
+| Component | Updated by upgrade | Notes |
+|-----------|-------------------|-------|
+| Gateway binary (`defenseclaw-gateway`) | Yes | Replaced from release tarball |
+| Python CLI (`defenseclaw`) | Yes | Replaced from release wheel |
+| OpenClaw plugin | No | Plugin is release-specific; installed by `install.sh` only |
+| Config files | Preserved | Backed up before upgrade, migrations patch if needed |
+| Policies | Preserved | Backed up; not overwritten |
+
+### Rollback
+
+If an upgrade fails or causes issues, restore from the timestamped backup:
+
+```bash
+# Backups are saved to ~/.defenseclaw/backups/upgrade-<timestamp>/
+ls ~/.defenseclaw/backups/
+
+# Restore config files
+cp ~/.defenseclaw/backups/upgrade-20260429T120000/config.yaml ~/.defenseclaw/
+cp ~/.defenseclaw/backups/upgrade-20260429T120000/openclaw.json ~/.openclaw/
+
+# Downgrade to the previous version
+defenseclaw upgrade --version 0.2.0
+# Or use the shell script if the CLI is broken:
+curl -sSfL https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/upgrade.sh \
+  | bash -s -- --version 0.2.0
+```
+
+---
+
 ## Troubleshooting
 
 ### "defenseclaw: command not found"


### PR DESCRIPTION
Rewrite the 0.3.0 migration to restore openclaw.json from the pristine backup captured before DefenseClaw was installed, then re-apply only plugin registration. Falls back to surgical removal when no backup exists. Add 17 migration tests covering both paths, corrupted backups, no-ops, and version range logic.

Add upgrade documentation to INSTALL.md covering 0.2.0→0.3.0 (bash script), 0.3.0+ (CLI command), what gets upgraded, and rollback.

Rework the release workflow to trigger on release publish (not tag push), split into parallel gateway/cli/upload jobs, and upload checksums. Fixes the 0.3.1 empty-release scenario where creating a release via GitHub UI produced no artifacts.