### PR TITLE
Add note about free Splunk Developer License availability

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -64,6 +64,7 @@ Scope guardrails for the local Splunk preset:
   account page before it auto-enters the app without asking for credentials
 - to use full Splunk Enterprise features later, apply a valid Splunk
   Enterprise license
+- for a higher indexing limit, a free Splunk Developer License with a 10 GB/day limit is available at [dev.splunk.com](https://dev.splunk.com)
 - assume existing Splunk license limits still apply
 - do not treat it as an endorsed path to multi-instance or long-term
   deployment


### PR DESCRIPTION
Adds a note about the free Splunk Developer License (10 GB/day).

The current guidance focuses on Splunk Free (500 MB/day), which can be restrictive for extended workflows. The Developer License provides a free step up before moving to a paid Enterprise license, allowing more expanded usage and testing of DefenseClaw.

So this line clarifies the available upgrade path and improves overall developer experience before having to go to a paid Enterprise license route. 