### PR TITLE
Enrich Codex notify and hook spans for O11y correlation

### DIFF
--- a/internal/gateway/codex_hook.go
+++ b/internal/gateway/codex_hook.go
@@ -27,6 +27,9 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/defenseclaw/defenseclaw/internal/config"
 	"github.com/defenseclaw/defenseclaw/internal/redaction"
 	"github.com/defenseclaw/defenseclaw/internal/scanner"
@@ -100,11 +103,12 @@ func (a *APIServer) handleCodexHook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	req.CWD = sanitizeHookCWD(req.CWD)
+	ctx := enrichCodexHookContext(r.Context(), req)
 	rawEventIDs := a.rememberCodexRawHookEvents(req)
-	a.emitCodexHookLLMEvent(r.Context(), req, rawEventIDs, b)
+	a.emitCodexHookLLMEvent(ctx, req, rawEventIDs, b)
 
 	t0 := time.Now()
-	resp := a.evaluateCodexHook(r.Context(), req)
+	resp := a.evaluateCodexHook(ctx, req)
 	elapsed := time.Since(t0)
 
 	if a.health != nil {
@@ -122,9 +126,9 @@ func (a *APIServer) handleCodexHook(w http.ResponseWriter, r *http.Request) {
 		if resp.WouldBlock {
 			reason = "would_block"
 		}
-		a.otel.RecordConnectorHookInvocation(r.Context(), "codex", req.HookEventName, "ok", reason, float64(elapsed.Milliseconds()))
-		a.otel.RecordInspectEvaluation(r.Context(), "codex:"+req.HookEventName, resp.Action, resp.Severity)
-		a.otel.RecordInspectLatency(r.Context(), "codex:"+req.HookEventName, float64(elapsed.Milliseconds()))
+		a.otel.RecordConnectorHookInvocation(ctx, "codex", req.HookEventName, "ok", reason, float64(elapsed.Milliseconds()))
+		a.otel.RecordInspectEvaluation(ctx, "codex:"+req.HookEventName, resp.Action, resp.Severity)
+		a.otel.RecordInspectLatency(ctx, "codex:"+req.HookEventName, float64(elapsed.Milliseconds()))
 	}
 
 	if a.logger != nil {
@@ -132,10 +136,64 @@ func (a *APIServer) handleCodexHook(w http.ResponseWriter, r *http.Request) {
 			resp.Action, resp.Severity, resp.Mode, resp.WouldBlock, elapsed)
 		details = appendRawTelemetryDetails(details, "raw_payload", b)
 		details = appendRawTelemetryCanonicalDetails(details, "hook", true, rawEventIDs)
-		_ = a.logger.LogActionCtx(r.Context(), "codex-hook", req.HookEventName, details)
+		_ = a.logger.LogActionCtx(ctx, "codex-hook", req.HookEventName, details)
 	}
 
 	a.writeJSON(w, http.StatusOK, resp)
+}
+
+func enrichCodexHookContext(ctx context.Context, req codexHookRequest) context.Context {
+	ctx = ContextWithSessionID(ctx, req.SessionID)
+	agentName := strings.TrimSpace(req.AgentType)
+	if agentName == "" {
+		agentName = "codex"
+	}
+	ctx = ContextWithAgentIdentity(ctx, AgentIdentity{
+		AgentID:   strings.TrimSpace(req.AgentID),
+		AgentName: agentName,
+	})
+	enrichHTTPSpanFromContext(ctx)
+	enrichCodexHookSpan(ctx, req)
+	return ctx
+}
+
+func enrichCodexHookSpan(ctx context.Context, req codexHookRequest) {
+	span := trace.SpanFromContext(ctx)
+	if span == nil || !span.IsRecording() {
+		return
+	}
+	if req.SessionID != "" {
+		span.SetAttributes(
+			attribute.String("gen_ai.conversation.id", req.SessionID),
+			attribute.String("defenseclaw.session_id", req.SessionID),
+		)
+	}
+	agentName := strings.TrimSpace(req.AgentType)
+	if agentName == "" {
+		agentName = "codex"
+	}
+	span.SetAttributes(attribute.String("gen_ai.agent.name", agentName))
+	if req.AgentID != "" {
+		span.SetAttributes(attribute.String("gen_ai.agent.id", req.AgentID))
+	}
+	if req.HookEventName != "" {
+		span.SetAttributes(attribute.String("defenseclaw.codex.hook.event", req.HookEventName))
+	}
+	if req.TurnID != "" {
+		span.SetAttributes(
+			attribute.String("defenseclaw.turn_id", req.TurnID),
+			attribute.String("defenseclaw.codex.hook.turn_id", req.TurnID),
+		)
+	}
+	if req.Model != "" {
+		span.SetAttributes(attribute.String("gen_ai.request.model", req.Model))
+	}
+	if req.ToolName != "" {
+		span.SetAttributes(attribute.String("gen_ai.tool.name", req.ToolName))
+	}
+	if req.ToolUseID != "" {
+		span.SetAttributes(attribute.String("gen_ai.tool.call.id", req.ToolUseID))
+	}
 }
 
 func (a *APIServer) evaluateCodexHook(ctx context.Context, req codexHookRequest) codexHookResponse {

--- a/internal/gateway/codex_hook_test.go
+++ b/internal/gateway/codex_hook_test.go
@@ -17,12 +17,29 @@
 package gateway
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
+
+func attrByKey(kv []attribute.KeyValue, key string) (attribute.Value, bool) {
+	for _, a := range kv {
+		if string(a.Key) == key {
+			return a.Value, true
+		}
+	}
+	return attribute.Value{}, false
+}
 
 // trustExploitKeyword returns a CRITICAL-severity trigger phrase without
 // embedding the literal string in this source file — otherwise the
@@ -423,5 +440,72 @@ func TestSanitizeHookCWD_Traversal(t *testing.T) {
 	got := sanitizeHookCWD(t.TempDir())
 	if got == "" {
 		t.Error("sanitizeHookCWD(valid absolute dir) returned empty")
+	}
+}
+
+func TestHandleCodexHook_EnrichesHTTPSpan(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exp),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	defer otel.SetTracerProvider(prev)
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	api := &APIServer{}
+	handler := otelHTTPServerMiddleware("sidecar-api", http.HandlerFunc(api.handleCodexHook))
+
+	body, err := json.Marshal(codexHookRequest{
+		HookEventName: "PreToolUse",
+		SessionID:     "session-123",
+		TurnID:        "turn-123",
+		Model:         "gpt-5.5",
+		ToolName:      "Bash",
+		ToolUseID:     "tool-call-123",
+		AgentID:       "openai_codex",
+		AgentType:     "codex",
+		ToolInput: map[string]interface{}{
+			"command": "pwd",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/codex/hook", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200 body=%s", w.Code, w.Body.String())
+	}
+
+	spans := exp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans want 1", len(spans))
+	}
+	s := spans[0]
+	if s.Name != "POST /api/v1/codex/hook" {
+		t.Fatalf("span name=%q want POST /api/v1/codex/hook", s.Name)
+	}
+
+	for key, want := range map[string]string{
+		"gen_ai.conversation.id":         "session-123",
+		"defenseclaw.session_id":         "session-123",
+		"gen_ai.agent.name":              "codex",
+		"gen_ai.agent.id":                "openai_codex",
+		"defenseclaw.codex.hook.event":   "PreToolUse",
+		"defenseclaw.turn_id":            "turn-123",
+		"defenseclaw.codex.hook.turn_id": "turn-123",
+		"gen_ai.request.model":           "gpt-5.5",
+		"gen_ai.tool.name":               "Bash",
+		"gen_ai.tool.call.id":            "tool-call-123",
+	} {
+		got, ok := attrByKey(s.Attributes, key)
+		if !ok || got.AsString() != want {
+			t.Fatalf("%s=%q ok=%v want %q", key, got.AsString(), ok, want)
+		}
 	}
 }

--- a/internal/gateway/otel_ingest.go
+++ b/internal/gateway/otel_ingest.go
@@ -39,6 +39,7 @@
 package gateway
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -50,6 +51,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/defenseclaw/defenseclaw/internal/audit"
 	"github.com/defenseclaw/defenseclaw/internal/redaction"
@@ -1146,16 +1150,18 @@ func extractServiceName(resourceRaw json.RawMessage) string {
 
 // codexNotifyPayload mirrors the documented codex notify JSON shape
 // (https://developers.openai.com/codex/config-advanced). We capture
-// the fields the SIEM rollup needs (type, turn-id, model, status)
+// the fields the SIEM rollup and session correlation need (type,
+// thread-id, turn-id, model, status)
 // and intentionally do not persist unknown fields verbatim. The schema
 // is deliberately permissive: codex bumps the notify shape across
 // releases and we never want schema drift to make the gateway 400 a
 // real event.
 type codexNotifyPayload struct {
-	Type   string `json:"type"`
-	TurnID string `json:"turn_id"`
-	Model  string `json:"model,omitempty"`
-	Status string `json:"status,omitempty"`
+	Type     string `json:"type"`
+	ThreadID string `json:"thread-id,omitempty"`
+	TurnID   string `json:"turn-id,omitempty"`
+	Model    string `json:"model,omitempty"`
+	Status   string `json:"status,omitempty"`
 }
 
 // handleCodexNotify accepts agent-turn-complete events from the
@@ -1214,6 +1220,7 @@ func (a *APIServer) handleCodexNotify(w http.ResponseWriter, r *http.Request) {
 	}
 
 	details := codexNotifyAuditDetails(p, body, kind, result, parseErr)
+	sessionID := codexNotifySessionID(p)
 
 	ev := audit.Event{
 		Timestamp: time.Now().UTC(),
@@ -1223,7 +1230,7 @@ func (a *APIServer) handleCodexNotify(w http.ResponseWriter, r *http.Request) {
 		Details:   details,
 		Severity:  severity,
 		AgentName: "codex",
-		SessionID: p.TurnID,
+		SessionID: sessionID,
 	}
 	if err := persistAuditEvent(a.logger, a.store, ev); err != nil {
 		fmt.Fprintf(otelIngestLogSink(), "[codex-notify] persist failed: %v\n", err)
@@ -1233,13 +1240,52 @@ func (a *APIServer) handleCodexNotify(w http.ResponseWriter, r *http.Request) {
 	// record so the local-stack dashboards see codex turn-completes
 	// without configuring an audit OTLP sink. Cardinality is bounded
 	// by sanitizeNotifyType (max 64 chars, [a-z0-9._-]).
-	ctx := r.Context()
+	ctx := ContextWithSessionID(r.Context(), sessionID)
+	enrichHTTPSpanFromContext(ctx)
+	enrichCodexNotifySpan(ctx, p, kind, result)
 	a.otel.RecordCodexNotify(ctx, kind, p.Status, result)
 	a.otel.EmitCodexNotifyLog(ctx, kind, p.Status, result, p.TurnID, p.Model)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("{}"))
+}
+
+func codexNotifySessionID(p codexNotifyPayload) string {
+	if p.ThreadID != "" {
+		return p.ThreadID
+	}
+	return p.TurnID
+}
+
+func enrichCodexNotifySpan(ctx context.Context, p codexNotifyPayload, kind, result string) {
+	span := trace.SpanFromContext(ctx)
+	if span == nil || !span.IsRecording() {
+		return
+	}
+	sessionID := codexNotifySessionID(p)
+	if sessionID != "" {
+		span.SetAttributes(
+			attribute.String("gen_ai.conversation.id", sessionID),
+			attribute.String("defenseclaw.session_id", sessionID),
+		)
+	}
+	span.SetAttributes(attribute.String("gen_ai.agent.name", "codex"))
+	if p.TurnID != "" {
+		span.SetAttributes(attribute.String("defenseclaw.codex.notify.turn_id", p.TurnID))
+	}
+	if kind != "" {
+		span.SetAttributes(attribute.String("defenseclaw.codex.notify.type", kind))
+	}
+	if result != "" {
+		span.SetAttributes(attribute.String("defenseclaw.codex.notify.result", result))
+	}
+	if p.Status != "" {
+		span.SetAttributes(attribute.String("defenseclaw.codex.notify.status", p.Status))
+	}
+	if p.Model != "" {
+		span.SetAttributes(attribute.String("gen_ai.response.model", p.Model))
+	}
 }
 
 func codexNotifyAuditDetails(p codexNotifyPayload, body []byte, kind, result string, parseErr error) string {
@@ -1250,6 +1296,9 @@ func codexNotifyAuditDetails(p codexNotifyPayload, body []byte, kind, result str
 		"result=" + result,
 		fmt.Sprintf("body_len=%d", len(body)),
 		"body_sha256_prefix=" + sumHex[:16],
+	}
+	if p.ThreadID != "" {
+		parts = append(parts, "thread_id="+redaction.ForSinkEntity(p.ThreadID))
 	}
 	if p.TurnID != "" {
 		parts = append(parts, "turn_id="+redaction.ForSinkEntity(p.TurnID))

--- a/internal/gateway/otel_ingest_test.go
+++ b/internal/gateway/otel_ingest_test.go
@@ -727,7 +727,7 @@ func TestCodexNotify_PersistsDynamicSuffixAction(t *testing.T) {
 	store, logger := newOTLPIngestTestStore(t)
 	a := &APIServer{store: store, logger: logger}
 
-	body := `{"type": "agent-turn-complete", "turn_id": "turn-abc", "model": "gpt-5", "status": "success"}`
+	body := `{"type": "agent-turn-complete", "turn-id": "turn-abc", "model": "gpt-5", "status": "success"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/codex/notify", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -757,7 +757,7 @@ func TestCodexNotify_PersistsDynamicSuffixAction(t *testing.T) {
 		t.Errorf("audit Action %q matches neither IsKnownAction nor IsKnownActionPrefix", rows[0].Action)
 	}
 	if rows[0].SessionID != "turn-abc" {
-		t.Errorf("SessionID = %q, want %q (codex notify rows must carry turn_id for SIEM rollups)", rows[0].SessionID, "turn-abc")
+		t.Errorf("SessionID = %q, want %q (codex notify rows must fall back to turn-id when thread-id is absent)", rows[0].SessionID, "turn-abc")
 	}
 	if strings.Contains(rows[0].Details, body) {
 		t.Fatalf("Details stored raw notify body: %q", rows[0].Details)
@@ -771,7 +771,7 @@ func TestCodexNotifyAuditDetails_RedactsRawPayload(t *testing.T) {
 	redaction.SetDisableAll(false)
 	t.Cleanup(func() { redaction.SetDisableAll(false) })
 
-	body := []byte(`{"type":"agent-turn-complete","turn_id":"turn-secret-123","model":"gpt-5","status":"ok","prompt":"please leak sk-secret-token"}`)
+	body := []byte(`{"type":"agent-turn-complete","turn-id":"turn-secret-123","model":"gpt-5","status":"ok","prompt":"please leak sk-secret-token"}`)
 	details := codexNotifyAuditDetails(codexNotifyPayload{
 		Type:   "agent-turn-complete",
 		TurnID: "turn-secret-123",
@@ -813,7 +813,7 @@ func TestCodexNotify_NoTypePersistsBareAction(t *testing.T) {
 	store, logger := newOTLPIngestTestStore(t)
 	a := &APIServer{store: store, logger: logger}
 
-	body := `{"turn_id": "turn-xyz"}`
+	body := `{"turn-id": "turn-xyz"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/codex/notify", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -831,5 +831,40 @@ func TestCodexNotify_NoTypePersistsBareAction(t *testing.T) {
 	}
 	if got, want := rows[0].Action, string(audit.ActionCodexNotify); got != want {
 		t.Errorf("Action = %q, want %q (no type → bare codex.notify)", got, want)
+	}
+}
+
+func TestCodexNotify_PrefersThreadIDForSessionCorrelation(t *testing.T) {
+	store, logger := newOTLPIngestTestStore(t)
+	a := &APIServer{store: store, logger: logger}
+
+	body := `{"type":"agent-turn-complete","thread-id":"thread-123","turn-id":"turn-abc","model":"gpt-5","status":"success"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/codex/notify", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	a.handleCodexNotify(w, req)
+	logger.Close()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	rows, err := store.ListEvents(10)
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows=%d want 1", len(rows))
+	}
+	if got, want := rows[0].SessionID, "thread-123"; got != want {
+		t.Fatalf("SessionID = %q, want %q", got, want)
+	}
+	if !strings.Contains(rows[0].Details, "thread_id=") {
+		t.Fatalf("Details missing thread_id summary: %q", rows[0].Details)
+	}
+	if !strings.Contains(rows[0].Details, "turn_id=") {
+		t.Fatalf("Details missing turn_id summary: %q", rows[0].Details)
 	}
 }

--- a/internal/telemetry/provider_test.go
+++ b/internal/telemetry/provider_test.go
@@ -157,6 +157,44 @@ func TestStartToolSpan_RawArgsOnlyWhenRedactionDisabled(t *testing.T) {
 	}
 }
 
+func TestStartToolSpan_EmitsSessionToolPolicyCorrelation(t *testing.T) {
+	p, exp := newTracingProvider(t)
+	_, span := p.StartToolSpan(context.Background(), "shell", "running",
+		json.RawMessage(`{"cmd":"rg -n observed_agent_session ."}`), false, "", "builtin", "",
+		ToolSpanContext{
+			ToolID:         "tool-123",
+			SessionID:      "session-123",
+			RunID:          "run-123",
+			DestinationApp: "builtin",
+			PolicyID:       "policy-allow-shell",
+			AgentName:      "codex",
+			AgentID:        "openai_codex",
+		})
+	p.EndToolSpan(span, 0, 0, time.Now(), "shell", "builtin")
+
+	spans := exp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+
+	for key, want := range map[string]string{
+		"gen_ai.tool.call.id":         "tool-123",
+		"gen_ai.conversation.id":      "session-123",
+		"defenseclaw.run.id":          "run-123",
+		"defenseclaw.destination.app": "builtin",
+		"defenseclaw.policy.id":       "policy-allow-shell",
+		"gen_ai.agent.name":           "codex",
+		"gen_ai.agent.id":             "openai_codex",
+		"gen_ai.operation.name":       "execute_tool",
+		"gen_ai.tool.name":            "shell",
+	} {
+		got, ok := attrByKey(spans[0].Attributes, key)
+		if !ok || got.AsString() != want {
+			t.Fatalf("%s = %q ok=%v, want %q", key, got.AsString(), ok, want)
+		}
+	}
+}
+
 func TestStartApprovalSpan_RawCommandOnlyWhenRedactionDisabled(t *testing.T) {
 	redaction.SetDisableAll(false)
 	t.Cleanup(func() { redaction.SetDisableAll(false) })


### PR DESCRIPTION
## Summary

Promote richer Codex session and tool context onto DefenseClaw HTTP spans so O11y exports carry the correlation fields needed for the live trace path.

## Changes

### `/api/v1/codex/notify`
- update notify parsing to support `thread-id` / `turn-id`
- derive session correlation from `thread-id`, falling back to `turn-id`
- enrich the active HTTP span with:
  - `gen_ai.conversation.id`
  - `defenseclaw.session_id`
  - `gen_ai.agent.name`
  - `defenseclaw.codex.notify.turn_id`
  - `defenseclaw.codex.notify.type`
  - `defenseclaw.codex.notify.result`
  - `defenseclaw.codex.notify.status`
  - `gen_ai.response.model`

### `/api/v1/codex/hook`
- enrich the active HTTP span with:
  - `gen_ai.conversation.id`
  - `defenseclaw.session_id`
  - `gen_ai.agent.name`
  - `gen_ai.agent.id`
  - `defenseclaw.codex.hook.event`
  - `defenseclaw.turn_id`
  - `defenseclaw.codex.hook.turn_id`
  - `gen_ai.request.model`
  - `gen_ai.tool.name`
  - `gen_ai.tool.call.id`
- thread the enriched context through hook evaluation, OTel metrics/log emission, and audit logging

### Tests
- add notify session-correlation coverage
- add a regression test that verifies `/api/v1/codex/hook` exports the enriched HTTP span attributes
- add provider-level correlation coverage for tool spans

## Why

Before these changes, O11y traces for Codex notify/hook traffic were mostly thin route/request spans. After these changes, they carry session-level and tool-level context needed for downstream live-path correlation.

## Validation

```sh
go test ./internal/gateway -run 'TestHandleCodexHook_EnrichesHTTPSpan|TestCodexNotify_PersistsDynamicSuffixAction|TestCodexNotify_PrefersThreadIDForSessionCorrelation|TestCodexNotify_NoTypePersistsBareAction'
go test ./internal/telemetry -run 'TestStartToolSpan_EmitsSessionToolPolicyCorrelation|TestStartToolSpan_RawArgsOnlyWhenRedactionDisabled'
```

## Bug Fixes Included

This PR includes two concrete `codex/notify` instrumentation bug fixes, not just additional enrichment.

### 1. Incomplete notify payload parsing

`codexNotifyPayload` previously only parsed the turn field, but the real Codex notify payload uses:

- `thread-id`
- `turn-id`

As a result, DefenseClaw was missing the actual session identifier present in the payload.

### 2. Incorrect session mapping

`handleCodexNotify` previously treated the turn id as the session id, which was incorrect.

## Impact of the bug

Because of that:

- notify audit rows had incorrect session correlation
- notify HTTP spans could not be enriched with the real conversation/session id
- O11y traces for `/api/v1/codex/notify` stayed thinner than expected

## Fix

The notify changes in this PR fix both:

- a schema/parser bug
- a session correlation mapping bug

The handler now derives session correlation from `thread-id`, falling back to `turn-id` only when `thread-id` is absent.

