### PR TITLE
Promote OTLP conversation id into ingest correlation

### DIFF
--- a/internal/gateway/otel_ingest.go
+++ b/internal/gateway/otel_ingest.go
@@ -164,8 +164,13 @@ func (a *APIServer) handleOTLPSignal(w http.ResponseWriter, r *http.Request, sig
 		// validated the credential.
 		source = "unknown"
 	}
-
 	ctx := r.Context()
+	sessionID := extractOTLPSessionID(body, signal)
+	if sessionID != "" {
+		ctx = ContextWithSessionID(ctx, sessionID)
+		enrichHTTPSpanFromContext(ctx)
+		enrichOTLPIngestSpan(ctx, sessionID)
+	}
 	bodyBytes := int64(len(body))
 	summary, stats, parseErr := summarizeOTLPPayload(body, signal)
 	if parseErr != nil {
@@ -184,6 +189,7 @@ func (a *APIServer) handleOTLPSignal(w http.ResponseWriter, r *http.Request, sig
 			Details:   details,
 			Severity:  "WARN",
 			AgentName: source,
+			SessionID: sessionID,
 		}
 		_ = persistAuditEvent(a.logger, a.store, ev)
 		// Record metrics + emit OTel log for the malformed branch.
@@ -205,6 +211,7 @@ func (a *APIServer) handleOTLPSignal(w http.ResponseWriter, r *http.Request, sig
 		Details:   summary,
 		Severity:  "INFO",
 		AgentName: source,
+		SessionID: sessionID,
 	}
 	if err := persistAuditEvent(a.logger, a.store, ev); err != nil {
 		// Best-effort: failing to persist must NOT cause the
@@ -228,6 +235,77 @@ func (a *APIServer) handleOTLPSignal(w http.ResponseWriter, r *http.Request, sig
 	a.otel.EmitConnectorTelemetryLog(ctx, string(signal), source, "ok", stats.Records, bodyBytes, summary)
 
 	writeOTLPSuccess(w)
+}
+
+func enrichOTLPIngestSpan(ctx context.Context, sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if span == nil || !span.IsRecording() {
+		return
+	}
+	span.SetAttributes(attribute.String("gen_ai.conversation.id", sessionID))
+}
+
+func extractOTLPSessionID(body []byte, signal otelIngestSignal) string {
+	if len(body) == 0 {
+		return ""
+	}
+	switch signal {
+	case otelSignalLogs:
+		return extractOTLPLogSessionID(body)
+	default:
+		return ""
+	}
+}
+
+func extractOTLPLogSessionID(body []byte) string {
+	var envelope struct {
+		ResourceLogs []struct {
+			Resource struct {
+				Attributes []otlpAttribute `json:"attributes"`
+			} `json:"resource"`
+			ScopeLogs []struct {
+				LogRecords []struct {
+					Attributes []otlpAttribute `json:"attributes"`
+				} `json:"logRecords"`
+			} `json:"scopeLogs"`
+		} `json:"resourceLogs"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return ""
+	}
+
+	for _, resource := range envelope.ResourceLogs {
+		resourceAttrs := otlpAttributesToMap(resource.Resource.Attributes)
+		if sessionID := otlpSessionID(resourceAttrs); sessionID != "" {
+			return sessionID
+		}
+		for _, scope := range resource.ScopeLogs {
+			for _, rec := range scope.LogRecords {
+				attrs := otlpAttributesToMap(rec.Attributes)
+				for k, v := range resourceAttrs {
+					if _, exists := attrs[k]; !exists {
+						attrs[k] = v
+					}
+				}
+				if sessionID := otlpSessionID(attrs); sessionID != "" {
+					return sessionID
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func otlpSessionID(attrs map[string]interface{}) string {
+	return firstNonEmpty(
+		otlpString(attrs, "session.id"),
+		otlpString(attrs, "session_id"),
+		otlpString(attrs, "gen_ai.conversation.id"),
+		otlpString(attrs, "conversation.id"),
+	)
 }
 
 type otelTokenUsage struct {

--- a/internal/gateway/otel_ingest_test.go
+++ b/internal/gateway/otel_ingest_test.go
@@ -22,8 +22,11 @@ import (
 	"github.com/defenseclaw/defenseclaw/internal/audit"
 	"github.com/defenseclaw/defenseclaw/internal/redaction"
 	"github.com/defenseclaw/defenseclaw/internal/telemetry"
+	"go.opentelemetry.io/otel"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // TestOTLPIngest_Logs_AcceptsValidPayload pins the success path: a
@@ -62,6 +65,67 @@ func TestOTLPIngest_Logs_AcceptsValidPayload(t *testing.T) {
 	}
 	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
 		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+}
+
+func TestOTLPIngest_Logs_EnrichesHTTPSpanWithConversationID(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exp),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	defer otel.SetTracerProvider(prev)
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	api := &APIServer{}
+	handler := otelHTTPServerMiddleware("sidecar-api", http.HandlerFunc(api.handleOTLPLogs))
+
+	body := `{
+		"resourceLogs": [{
+			"resource": {
+				"attributes": [{"key": "service.name", "value": {"stringValue": "codex-cli"}}]
+			},
+			"scopeLogs": [{
+				"logRecords": [{
+					"attributes": [
+						{"key": "event.name", "value": {"stringValue": "codex.sse_event"}},
+						{"key": "event.kind", "value": {"stringValue": "response.completed"}},
+						{"key": "conversation.id", "value": {"stringValue": "session-123"}},
+						{"key": "input_token_count", "value": {"stringValue": "123"}},
+						{"key": "output_token_count", "value": {"stringValue": "45"}}
+					]
+				}]
+			}]
+		}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/logs", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-defenseclaw-source", "codex")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200 body=%s", w.Code, w.Body.String())
+	}
+
+	spans := exp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans want 1", len(spans))
+	}
+	s := spans[0]
+	if s.Name != "POST /v1/logs" {
+		t.Fatalf("span name=%q want POST /v1/logs", s.Name)
+	}
+	for key, want := range map[string]string{
+		"gen_ai.conversation.id": "session-123",
+		"defenseclaw.session_id": "session-123",
+	} {
+		got, ok := attrByKey(s.Attributes, key)
+		if !ok || got.AsString() != want {
+			t.Fatalf("%s=%q ok=%v want %q", key, got.AsString(), ok, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Promote OTLP `conversation.id` into first-class DefenseClaw session correlation on the `/v1/logs` ingest path.

## Changes

- extract session identity from raw OTLP log payloads using:
  - `session.id`
  - `session_id`
  - `gen_ai.conversation.id`
  - `conversation.id`
- thread the extracted session id into the OTLP ingest request context
- enrich the active `/v1/logs` HTTP span with:
  - `defenseclaw.session_id`
  - `gen_ai.conversation.id`
- persist the extracted session id on OTLP ingest audit events
- add a regression test proving `/v1/logs` span enrichment from `conversation.id`

## Why

Codex token-bearing OTEL `response.completed` records already carry `conversation.id`, but before this change that value was not promoted directly by DefenseClaw on the OTLP ingest path.

As a result:
- session correlation on the OTEL log path was weaker than it should be
- downstream consumers had to recover session identity indirectly from raw OTLP attributes
- token-bearing OTEL records did not contribute first-class session correlation through DefenseClaw itself

This change makes the OTEL log path more explicit and consistent by promoting `conversation.id` into DefenseClaw correlation fields as early as ingest.

## Scope

This PR improves session-level correlation only. It does **not** solve the full response-level token merge problem, because the token-bearing OTEL records still do not appear to expose a deterministic response-level key such as `turn_id` or `response_id`.

## Validation

Ran:

```sh
go test ./internal/gateway -run 'TestOTLPIngest_Logs_EnrichesHTTPSpanWithConversationID|TestOTLPIngest_Logs_PromotesCodexTokenUsage|TestCodexNotify_PrefersThreadIDForSessionCorrelation'
