### PR TITLE
Deployment mode enum on telemetry

### DIFF
--- a/cli/defenseclaw/config.py
+++ b/cli/defenseclaw/config.py
@@ -68,6 +68,14 @@ _privacy_disable_redaction_warned = False
 DATA_DIR_NAME = ".defenseclaw"
 AUDIT_DB_NAME = "audit.db"
 CONFIG_FILE_NAME = "config.yaml"
+VALID_DEPLOYMENT_MODES = {
+    "managed_enterprise",
+    "unmanaged_byod",
+    "ci_cd",
+    "sandboxed",
+    "server",
+    "saas",
+}
 
 
 def _home() -> Path:
@@ -127,6 +135,17 @@ def detect_environment() -> str:
     except (FileNotFoundError, subprocess.CalledProcessError):
         pass
     return "linux"
+
+
+def _validate_deployment_mode(mode: str) -> str:
+    mode = (mode or "").strip()
+    if not mode:
+        return ""
+    if mode not in VALID_DEPLOYMENT_MODES:
+        raise ValueError(
+            "config: deployment_mode={!r} is invalid (allowed: managed_enterprise, unmanaged_byod, ci_cd, sandboxed, server, saas)".format(mode)
+        )
+    return mode
 
 
 _sandbox_mode_cache: bool | None = None
@@ -1849,7 +1868,7 @@ def load() -> Config:
         environment=raw.get("environment", detect_environment()),
         tenant_id=raw.get("tenant_id", ""),
         workspace_id=raw.get("workspace_id", ""),
-        deployment_mode=raw.get("deployment_mode", ""),
+        deployment_mode=_validate_deployment_mode(raw.get("deployment_mode", "")),
         discovery_source=raw.get("discovery_source", ""),
         claw=ClawConfig(
             mode=raw.get("claw", {}).get("mode", "openclaw"),

--- a/cli/defenseclaw/config.py
+++ b/cli/defenseclaw/config.py
@@ -143,7 +143,9 @@ def _validate_deployment_mode(mode: str) -> str:
         return ""
     if mode not in VALID_DEPLOYMENT_MODES:
         raise ValueError(
-            "config: deployment_mode={!r} is invalid (allowed: managed_enterprise, unmanaged_byod, ci_cd, sandboxed, server, saas)".format(mode)
+            f"config: deployment_mode={mode!r} is invalid "
+            "(allowed: managed_enterprise, unmanaged_byod, "
+            "ci_cd, sandboxed, server, saas)"
         )
     return mode
 

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -86,6 +86,16 @@ class TestHelpers(unittest.TestCase):
     def test_dedup_empty(self):
         self.assertEqual(_dedup([]), [])
 
+    def test_validate_deployment_mode_empty_allowed(self):
+        self.assertEqual(config_mod._validate_deployment_mode(""), "")
+
+    def test_validate_deployment_mode_valid(self):
+        self.assertEqual(config_mod._validate_deployment_mode("managed_enterprise"), "managed_enterprise")
+
+    def test_validate_deployment_mode_invalid(self):
+        with self.assertRaises(ValueError):
+            config_mod._validate_deployment_mode("managed")
+
 
 class TestPaths(unittest.TestCase):
     def test_default_data_path(self):

--- a/docs/OTEL.md
+++ b/docs/OTEL.md
@@ -53,7 +53,7 @@ Set once at sidecar startup. Attached to every exported log, span, and metric.
 | `deployment.environment` | string | `macos` | `config.Environment` |
 | `tenant.id` | string | `tenant-a` | `config.tenant_id` when set |
 | `workspace.id` | string | `workspace-1` | `config.workspace_id` when set |
-| `deployment.mode` | string | `standalone` | `config.deployment_mode` when set |
+| `deployment.mode` | string | `managed_enterprise` | `config.deployment_mode` when set. Allowed values: `managed_enterprise`, `unmanaged_byod`, `ci_cd`, `sandboxed`, `server`, `saas` |
 | `discovery.source` | string | `registry` | `config.discovery_source` when set |
 | `host.name` | string | `dgx-spark-01` | `os.Hostname()` |
 | `host.arch` | string | `arm64` | `runtime.GOARCH` |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1413,6 +1413,13 @@ func Load() (*Config, error) {
 	migrateConfig(&cfg)
 	warnDisableRedactionConfig(&cfg)
 
+	if err := validateDeploymentMode(cfg.DeploymentMode); err != nil {
+		if ReportConfigLoadError != nil {
+			ReportConfigLoadError(context.Background(), "deployment_mode_invalid")
+		}
+		return nil, err
+	}
+
 	for i := range cfg.AuditSinks {
 		if err := cfg.AuditSinks[i].Validate(); err != nil {
 			if ReportConfigLoadError != nil {
@@ -1848,6 +1855,17 @@ func warnPlaintextSecrets(cfg *Config) {
 				"prefer bearer_env to keep secrets out of config.yaml", s.Name)
 		}
 	}
+}
+
+func validateDeploymentMode(mode string) error {
+	mode = strings.TrimSpace(mode)
+	if mode == "" {
+		return nil
+	}
+	if _, ok := validDeploymentModes[mode]; ok {
+		return nil
+	}
+	return fmt.Errorf("config: deployment_mode=%q is invalid (allowed: managed_enterprise, unmanaged_byod, ci_cd, sandboxed, server, saas)", mode)
 }
 
 func (c *Config) Save() error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -323,6 +323,35 @@ func TestValidate_InvalidInstall(t *testing.T) {
 	}
 }
 
+func TestValidateDeploymentMode_EmptyAllowed(t *testing.T) {
+	if err := validateDeploymentMode(""); err != nil {
+		t.Fatalf("validateDeploymentMode(empty) returned unexpected error: %v", err)
+	}
+}
+
+func TestValidateDeploymentMode_Valid(t *testing.T) {
+	for _, mode := range []string{
+		string(DeploymentModeManagedEnterprise),
+		string(DeploymentModeUnmanagedBYOD),
+		string(DeploymentModeCICD),
+		string(DeploymentModeSandboxed),
+		string(DeploymentModeServer),
+		string(DeploymentModeSaaS),
+	} {
+		t.Run(mode, func(t *testing.T) {
+			if err := validateDeploymentMode(mode); err != nil {
+				t.Fatalf("validateDeploymentMode(%q) returned unexpected error: %v", mode, err)
+			}
+		})
+	}
+}
+
+func TestValidateDeploymentMode_Invalid(t *testing.T) {
+	if err := validateDeploymentMode("managed"); err == nil {
+		t.Fatal("expected validateDeploymentMode to reject free-form value")
+	}
+}
+
 func TestExpandPath(t *testing.T) {
 	home, _ := os.UserHomeDir()
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -32,6 +32,26 @@ const (
 	EnvLinux    Environment = "linux"
 )
 
+type DeploymentMode string
+
+const (
+	DeploymentModeManagedEnterprise DeploymentMode = "managed_enterprise"
+	DeploymentModeUnmanagedBYOD     DeploymentMode = "unmanaged_byod"
+	DeploymentModeCICD              DeploymentMode = "ci_cd"
+	DeploymentModeSandboxed         DeploymentMode = "sandboxed"
+	DeploymentModeServer            DeploymentMode = "server"
+	DeploymentModeSaaS              DeploymentMode = "saas"
+)
+
+var validDeploymentModes = map[string]struct{}{
+	string(DeploymentModeManagedEnterprise): {},
+	string(DeploymentModeUnmanagedBYOD):     {},
+	string(DeploymentModeCICD):              {},
+	string(DeploymentModeSandboxed):         {},
+	string(DeploymentModeServer):            {},
+	string(DeploymentModeSaaS):              {},
+}
+
 const (
 	DefaultDataDirName = ".defenseclaw"
 	DefaultAuditDBName = "audit.db"

--- a/internal/gatewaylog/schemas/gateway-event-envelope.json
+++ b/internal/gatewaylog/schemas/gateway-event-envelope.json
@@ -43,7 +43,13 @@
     "tenant_id":        { "type": ["string", "null"], "description": "Logical tenancy boundary for hosted/SaaS deployments. Populated from config tenant_id when set." },
     "workspace_id":     { "type": ["string", "null"], "description": "Sub-tenant workspace, organization, or team scope. Populated from config workspace_id when set." },
     "environment":      { "type": ["string", "null"], "description": "Deployment environment. Populated from config environment when set." },
-    "deployment_mode":  { "type": ["string", "null"], "description": "Sidecar deployment mode such as standalone, managed, edge, or ci. Populated from config deployment_mode when set." },
+    "deployment_mode":  {
+      "anyOf": [
+        { "type": "string", "enum": ["managed_enterprise", "unmanaged_byod", "ci_cd", "sandboxed", "server", "saas"] },
+        { "type": "null" }
+      ],
+      "description": "Sidecar deployment mode. Populated from config deployment_mode when set."
+    },
     "discovery_source": { "type": ["string", "null"], "description": "How the monitored agent or tool was discovered. Populated from config discovery_source when set." },
 
     "verdict":         { "$ref": "#/$defs/VerdictPayload" },

--- a/schemas/gateway-event-envelope.json
+++ b/schemas/gateway-event-envelope.json
@@ -43,7 +43,13 @@
     "tenant_id":        { "type": ["string", "null"], "description": "Logical tenancy boundary for hosted/SaaS deployments. Populated from config tenant_id when set." },
     "workspace_id":     { "type": ["string", "null"], "description": "Sub-tenant workspace, organization, or team scope. Populated from config workspace_id when set." },
     "environment":      { "type": ["string", "null"], "description": "Deployment environment. Populated from config environment when set." },
-    "deployment_mode":  { "type": ["string", "null"], "description": "Sidecar deployment mode such as standalone, managed, edge, or ci. Populated from config deployment_mode when set." },
+    "deployment_mode":  {
+      "anyOf": [
+        { "type": "string", "enum": ["managed_enterprise", "unmanaged_byod", "ci_cd", "sandboxed", "server", "saas"] },
+        { "type": "null" }
+      ],
+      "description": "Sidecar deployment mode. Populated from config deployment_mode when set."
+    },
     "discovery_source": { "type": ["string", "null"], "description": "How the monitored agent or tool was discovered. Populated from config discovery_source when set." },
 
     "verdict":         { "$ref": "#/$defs/VerdictPayload" },

--- a/schemas/otel/resource.schema.json
+++ b/schemas/otel/resource.schema.json
@@ -46,6 +46,7 @@
     },
     "deployment.mode": {
       "type": "string",
+      "enum": ["managed_enterprise", "unmanaged_byod", "ci_cd", "sandboxed", "server", "saas"],
       "description": "Deployment mode when configured."
     },
     "discovery.source": {
@@ -65,6 +66,11 @@
       "type": "string",
       "enum": ["darwin", "linux"],
       "description": "Operating system (runtime.GOOS)."
+    },
+    "deployment.mode": {
+      "type": "string",
+      "enum": ["managed_enterprise", "unmanaged_byod", "ci_cd", "sandboxed", "server", "saas"],
+      "description": "Deployment mode when configured."
     },
     "defenseclaw.claw.mode": {
       "type": "string",


### PR DESCRIPTION
## Summary

Constrains `deployment_mode` in DefenseClaw to an explicit nullable enum instead of allowing arbitrary free-form values.

## Changes

- define the allowed `deployment_mode` values in DefenseClaw config:
  - `managed_enterprise`
  - `unmanaged_byod`
  - `ci_cd`
  - `sandboxed`
  - `server`
  - `saas`
- keep `deployment_mode` nullable / unset when no meaningful classification is available
- validate `deployment_mode` during Go config load and reject invalid free-form values
- apply the same validation in the Python CLI config loader
- add config tests for:
  - empty value allowed
  - valid enum values accepted
  - invalid values rejected
- update the OTel resource schema and gateway event schemas so `deployment_mode` is enum-backed there as well
- update `docs/OTEL.md` to document the allowed values

## Why

`deployment_mode` is intended to be a stable join/filter field across telemetry surfaces. Leaving it unconstrained would allow producer-specific free-form strings to drift over time, making downstream filtering and cross-source normalization less reliable.

## Verification

- `go test ./internal/config/...`

## Notes

- `deployment_mode` remains optional; unset/unknown stays null/empty rather than introducing an `unknown` catch-all enum value
