### PR TITLE
telemetry: stamp run id on request and runtime spans

### DIFF
--- a/internal/gateway/codex_hook_test.go
+++ b/internal/gateway/codex_hook_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/gatewaylog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -444,6 +445,9 @@ func TestSanitizeHookCWD_Traversal(t *testing.T) {
 }
 
 func TestHandleCodexHook_EnrichesHTTPSpan(t *testing.T) {
+	gatewaylog.SetProcessRunID("run-hook-123")
+	t.Cleanup(func() { gatewaylog.SetProcessRunID("") })
+
 	exp := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSyncer(exp),
@@ -493,6 +497,7 @@ func TestHandleCodexHook_EnrichesHTTPSpan(t *testing.T) {
 
 	for key, want := range map[string]string{
 		"gen_ai.conversation.id":         "session-123",
+		"defenseclaw.run.id":             "run-hook-123",
 		"gen_ai.agent.name":              "codex",
 		"gen_ai.agent.type":              "codex",
 		"gen_ai.agent.id":                "openai_codex",

--- a/internal/gateway/otel_ingest_test.go
+++ b/internal/gateway/otel_ingest_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/defenseclaw/defenseclaw/internal/audit"
+	"github.com/defenseclaw/defenseclaw/internal/gatewaylog"
 	"github.com/defenseclaw/defenseclaw/internal/redaction"
 	"github.com/defenseclaw/defenseclaw/internal/telemetry"
 	"go.opentelemetry.io/otel"
@@ -69,6 +70,9 @@ func TestOTLPIngest_Logs_AcceptsValidPayload(t *testing.T) {
 }
 
 func TestOTLPIngest_Logs_EnrichesHTTPSpanWithConversationID(t *testing.T) {
+	gatewaylog.SetProcessRunID("run-otlp-123")
+	t.Cleanup(func() { gatewaylog.SetProcessRunID("") })
+
 	exp := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSyncer(exp),
@@ -121,6 +125,7 @@ func TestOTLPIngest_Logs_EnrichesHTTPSpanWithConversationID(t *testing.T) {
 	for key, want := range map[string]string{
 		"gen_ai.conversation.id": "session-123",
 		"gen_ai.agent.type":      "codex",
+		"defenseclaw.run.id":     "run-otlp-123",
 	} {
 		got, ok := attrByKey(s.Attributes, key)
 		if !ok || got.AsString() != want {

--- a/internal/gateway/requestctx.go
+++ b/internal/gateway/requestctx.go
@@ -427,6 +427,9 @@ func enrichHTTPSpanFromContext(ctx context.Context) {
 	if span == nil || !span.IsRecording() {
 		return
 	}
+	if runID := gatewaylog.ProcessRunID(); runID != "" {
+		span.SetAttributes(attribute.String("defenseclaw.run.id", runID))
+	}
 	if id := RequestIDFromContext(ctx); id != "" {
 		span.SetAttributes(attribute.String("defenseclaw.request_id", id))
 	}

--- a/internal/telemetry/gateway_events.go
+++ b/internal/telemetry/gateway_events.go
@@ -197,7 +197,7 @@ func (p *Provider) EmitGatewayEventWithContext(ctx context.Context, e gatewaylog
 		log.String("defenseclaw.gateway.event_type", string(e.EventType)),
 	}
 	if e.RunID != "" {
-		attrs = append(attrs, log.String("defenseclaw.run_id", e.RunID))
+		attrs = append(attrs, log.String("defenseclaw.run.id", e.RunID))
 	}
 	if e.RequestID != "" {
 		attrs = append(attrs, log.String("defenseclaw.request_id", e.RequestID))

--- a/internal/telemetry/gateway_events_test.go
+++ b/internal/telemetry/gateway_events_test.go
@@ -162,7 +162,7 @@ func TestEmitGatewayEvent_VerdictLogAttributes(t *testing.T) {
 	if got := attrValue(rec, "defenseclaw.gateway.event_type"); got != "verdict" {
 		t.Fatalf("event_type attr=%q", got)
 	}
-	if got := attrValue(rec, "defenseclaw.run_id"); got != "run-1" {
+	if got := attrValue(rec, "defenseclaw.run.id"); got != "run-1" {
 		t.Fatalf("run_id attr=%q", got)
 	}
 	if got := attrValue(rec, "defenseclaw.llm.model"); got != "gpt-4" {
@@ -397,7 +397,7 @@ func TestEmitGatewayEvent_LogAttributeContract(t *testing.T) {
 
 	// String-typed envelope slots — assertAttrString both proves
 	// the key is present AND that the value round-tripped.
-	assertAttrString(t, rec, "defenseclaw.run_id", "run-contract")
+	assertAttrString(t, rec, "defenseclaw.run.id", "run-contract")
 	assertAttrString(t, rec, "defenseclaw.request_id", "req-contract")
 	assertAttrString(t, rec, "gen_ai.conversation.id", "sess-contract")
 	assertAttrString(t, rec, "defenseclaw.trace_id", "trace-contract")

--- a/internal/telemetry/provider_test.go
+++ b/internal/telemetry/provider_test.go
@@ -272,6 +272,42 @@ func TestStartApprovalSpan_RawCommandOnlyWhenRedactionDisabled(t *testing.T) {
 	}
 }
 
+func TestStartAgentSpan_EmitsRunID(t *testing.T) {
+	gatewaylog.SetProcessRunID("run-agent-123")
+	t.Cleanup(func() { gatewaylog.SetProcessRunID("") })
+
+	p, exp := newTracingProvider(t)
+	_, span := p.StartAgentSpan(context.Background(), "session-123", "codex", "codex", "openai_codex", "openai")
+	p.EndAgentSpan(span, "")
+
+	spans := exp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	got, ok := attrByKey(spans[0].Attributes, "defenseclaw.run.id")
+	if !ok || got.AsString() != "run-agent-123" {
+		t.Fatalf("defenseclaw.run.id=%q ok=%v want run-agent-123", got.AsString(), ok)
+	}
+}
+
+func TestStartLLMSpan_EmitsRunID(t *testing.T) {
+	gatewaylog.SetProcessRunID("run-llm-123")
+	t.Cleanup(func() { gatewaylog.SetProcessRunID("") })
+
+	p, exp := newTracingProvider(t)
+	_, span := p.StartLLMSpan(context.Background(), "openai", "gpt-5.5", "openai", 1024, 0.2)
+	p.EndLLMSpan(span, "gpt-5.5", 12, 34, []string{"stop"}, 0, "", "", "openai", time.Now(), "codex", "codex", "openai_codex")
+
+	spans := exp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	got, ok := attrByKey(spans[0].Attributes, "defenseclaw.run.id")
+	if !ok || got.AsString() != "run-llm-123" {
+		t.Fatalf("defenseclaw.run.id=%q ok=%v want run-llm-123", got.AsString(), ok)
+	}
+}
+
 func TestDisabledProvider_Metrics_NoPanic(t *testing.T) {
 	p, _ := NewProvider(context.Background(), disabledCfg(), "test")
 	ctx := context.Background()

--- a/internal/telemetry/runtime.go
+++ b/internal/telemetry/runtime.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/defenseclaw/defenseclaw/internal/gatewaylog"
 	"github.com/defenseclaw/defenseclaw/internal/redaction"
 )
 
@@ -246,6 +247,9 @@ func (p *Provider) StartAgentSpan(
 	}
 	if agentID != "" {
 		span.SetAttributes(attribute.String("gen_ai.agent.id", agentID))
+	}
+	if runID := gatewaylog.ProcessRunID(); runID != "" {
+		span.SetAttributes(attribute.String("defenseclaw.run.id", runID))
 	}
 	if inst := p.AgentInstanceID(); inst != "" {
 		span.SetAttributes(attribute.String("defenseclaw.agent.instance_id", inst))
@@ -576,6 +580,9 @@ func (p *Provider) StartLLMSpan(
 		attribute.Int("gen_ai.request.max_tokens", maxTokens),
 		attribute.Float64("gen_ai.request.temperature", temperature),
 	)
+	if runID := gatewaylog.ProcessRunID(); runID != "" {
+		span.SetAttributes(attribute.String("defenseclaw.run.id", runID))
+	}
 
 	return ctx, span
 }


### PR DESCRIPTION
## Summary

Makes `run_id` a consistent correlation key across DefenseClaw OTel traces and OTel logs by stamping it onto the request/runtime span paths that previously omitted it and normalizing the OTel log attribute name to `defenseclaw.run.id`.

## Changes

- add `defenseclaw.run.id` to request-bound HTTP span enrichment in:
  - `internal/gateway/requestctx.go`
- add `defenseclaw.run.id` to runtime agent spans in:
  - `internal/telemetry/runtime.go`
- add `defenseclaw.run.id` to runtime LLM spans in:
  - `internal/telemetry/runtime.go`
- normalize the OTel gateway log projection to emit:
  - `defenseclaw.run.id`
  instead of:
  - `defenseclaw.run_id`
- add regression coverage for:
  - agent spans carrying `defenseclaw.run.id`
  - LLM spans carrying `defenseclaw.run.id`
  - Codex hook HTTP spans carrying `defenseclaw.run.id`
  - OTLP `/v1/logs` HTTP spans carrying `defenseclaw.run.id`
  - gateway OTel logs carrying `defenseclaw.run.id`

## Why

Today, `run_id` is stamped reliably on gateway events, but it was not represented consistently across the OTel surfaces:

- some traces carried `defenseclaw.run.id`
- request-bound HTTP spans often did not
- gateway OTel logs used `defenseclaw.run_id` instead of `defenseclaw.run.id`

That made `run_id` a weaker cross-signal join/filter key than it should be and introduced avoidable normalization work downstream.

This change makes the OTel-facing representation consistent while preserving the existing JSON/event-envelope field names.

## Verification

- `go test ./internal/telemetry/...`
- `go test ./internal/gateway/...`

## Notes

- OTel traces and OTel logs now both use:
  - `defenseclaw.run.id`
- JSON event-envelope fields and related schemas still use:
  - `run_id`
- this PR intentionally normalizes the OTel attribute name without changing the JSON contract naming
