### PR TITLE
gateway: Add destination app on hook events

### DIFF
--- a/internal/gateway/llm_event_emit.go
+++ b/internal/gateway/llm_event_emit.go
@@ -234,10 +234,12 @@ func (a *APIServer) emitCodexHookLLMEvent(ctx context.Context, req codexHookRequ
 	case "PreToolUse", "PermissionRequest":
 		meta.PromptID = firstNonEmpty(a.lastHookPromptIDForTurn("codex", req.SessionID, req.TurnID), a.lastHookPromptID("codex", req.SessionID), promptIDForTurn("codex", req.SessionID, req.TurnID))
 		meta.ToolID = req.ToolUseID
+		meta.DestinationApp = hookToolDestinationApp(payloadString(req.Payload, "mcp_server_name"), codexToolName(req))
 		emitToolInvocationEvent(ctx, meta, "call", codexToolName(req), stringFromJSONRaw(codexToolArgs(req)), "", nil)
 	case "PostToolUse":
 		meta.PromptID = firstNonEmpty(a.lastHookPromptIDForTurn("codex", req.SessionID, req.TurnID), a.lastHookPromptID("codex", req.SessionID), promptIDForTurn("codex", req.SessionID, req.TurnID))
 		meta.ToolID = req.ToolUseID
+		meta.DestinationApp = hookToolDestinationApp(payloadString(req.Payload, "mcp_server_name"), codexToolName(req))
 		emitToolInvocationEvent(ctx, meta, "result", codexToolName(req), "", codexToolResponseString(req.ToolResponse), nil)
 	case "Stop":
 		if strings.TrimSpace(req.LastAssistantMessage) == "" {
@@ -260,10 +262,12 @@ func (a *APIServer) emitClaudeCodeHookLLMEvent(ctx context.Context, req claudeCo
 	case "PreToolUse", "PermissionRequest", "PermissionDenied":
 		meta.PromptID = a.lastHookPromptID("claudecode", req.SessionID)
 		meta.ToolID = req.ToolUseID
+		meta.DestinationApp = hookToolDestinationApp(req.MCPServerName, claudeCodeToolName(req))
 		emitToolInvocationEvent(ctx, meta, "call", claudeCodeToolName(req), stringFromJSONRaw(claudeCodeToolArgs(req)), "", nil)
 	case "PostToolUse", "PostToolUseFailure", "PostToolBatch":
 		meta.PromptID = a.lastHookPromptID("claudecode", req.SessionID)
 		meta.ToolID = req.ToolUseID
+		meta.DestinationApp = hookToolDestinationApp(req.MCPServerName, claudeCodeToolName(req))
 		emitToolInvocationEvent(ctx, meta, "result", claudeCodeToolName(req), "", claudeCodeToolOutput(req), nil)
 	case "Stop", "SubagentStop", "SessionEnd":
 		if strings.TrimSpace(req.LastAssistantMessage) == "" {
@@ -293,6 +297,19 @@ func hookLLMEventMeta(source, sessionID, turnID, model, hookSource, agentID, age
 		UserID:    userID,
 		UserName:  userName,
 	}
+}
+
+func hookToolDestinationApp(serverName, toolName string) string {
+	if server := strings.TrimSpace(serverName); server != "" {
+		return toolDestinationApp("mcp", server)
+	}
+	if server := serverFromMCPToolName(toolName); server != "" {
+		return toolDestinationApp("mcp", server)
+	}
+	if strings.TrimSpace(toolName) == "" {
+		return ""
+	}
+	return toolDestinationApp("builtin", "")
 }
 
 func (a *APIServer) rememberHookPromptID(source, sessionID, turnID, promptID string) {

--- a/internal/gateway/llm_event_emit_test.go
+++ b/internal/gateway/llm_event_emit_test.go
@@ -177,6 +177,36 @@ func TestCodexHookSameTurnPromptsGetDistinctIDsAndCorrelateToLatest(t *testing.T
 	if got := (*events)[1].UserID; got != "alice-id" {
 		t.Fatalf("user_id=%q want alice-id", got)
 	}
+	if got := (*events)[2].DestinationApp; got != "builtin" {
+		t.Fatalf("destination_app=%q want builtin", got)
+	}
+}
+
+func TestCodexHookMCPToolSetsDestinationApp(t *testing.T) {
+	events := captureGatewayEvents(t)
+	t.Cleanup(func() { redaction.SetDisableAll(false) })
+	redaction.SetDisableAll(true)
+
+	api := &APIServer{}
+	req := codexHookRequest{
+		HookEventName: "PreToolUse",
+		SessionID:     "sess-codex",
+		TurnID:        "turn-1",
+		Model:         "gpt-5.5",
+		ToolName:      "mcp__github__search_issues",
+		ToolUseID:     "tool-1",
+		Payload: map[string]interface{}{
+			"mcp_server_name": "github",
+		},
+	}
+	api.emitCodexHookLLMEvent(context.Background(), req, nil, []byte(`{"hook_event_name":"PreToolUse"}`))
+
+	if len(*events) != 1 {
+		t.Fatalf("events=%d want 1", len(*events))
+	}
+	if got := (*events)[0].DestinationApp; got != "mcp:github" {
+		t.Fatalf("destination_app=%q want mcp:github", got)
+	}
 }
 
 func TestHookLLMEventMetaFallsBackToLocalUser(t *testing.T) {
@@ -188,5 +218,26 @@ func TestHookLLMEventMetaFallsBackToLocalUser(t *testing.T) {
 	meta := hookLLMEventMeta("codex", "sess", "turn", "gpt-5.5", "openai", "", "codex", map[string]interface{}{})
 	if meta.UserID == "" && meta.UserName == "" {
 		t.Fatalf("expected local user fallback, got user_id=%q user_name=%q", meta.UserID, meta.UserName)
+	}
+}
+
+func TestHookToolDestinationApp(t *testing.T) {
+	cases := []struct {
+		name       string
+		serverName string
+		toolName   string
+		want       string
+	}{
+		{name: "explicit server", serverName: "github", toolName: "Bash", want: "mcp:github"},
+		{name: "mcp tool name", toolName: "mcp__filesystem__read_file", want: "mcp:filesystem"},
+		{name: "builtin tool", toolName: "apply_patch", want: "builtin"},
+		{name: "empty tool", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hookToolDestinationApp(tc.serverName, tc.toolName); got != tc.want {
+				t.Fatalf("hookToolDestinationApp(%q, %q) = %q, want %q", tc.serverName, tc.toolName, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Add `destination_app` on hook-derived gateway events so Codex and Claude Code tool activity carries a concrete downstream app classification in DefenseClaw logs and downstream telemetry.

## Changes

- add hook-side `destination_app` classification for tool events in:
  - `internal/gateway/llm_event_emit.go`
- classify hook tool events as:
  - `mcp:<server>` when the hook payload provides an MCP server name
  - `mcp:<server>` when the tool name itself implies an MCP tool (for example `mcp__github__...`)
  - `builtin` for normal builtin tools such as `Bash` and `apply_patch`
- apply that classification to:
  - Codex hook tool call events
  - Codex hook tool result events
  - Claude Code hook tool call events
  - Claude Code hook tool result events
- add regression coverage for:
  - Codex builtin tool events emitting `destination_app=builtin`
  - Codex MCP tool events emitting `destination_app=mcp:github`
  - the shared hook destination-app helper classification logic

## Why

The downstream telemetry/log projection still supports `destination_app`, but the current hook event builders were not populating it on the Codex/Claude hook path. As a result:

- real hook-derived `tool_invocation` rows emitted with `destination_app=null`

This change restores the field at the source by deriving it from the tool context already present on hook events.

## Verification

- `go test ./internal/gateway/...`

## Notes

- this PR restores hook-path population only; it does not change the existing downstream `destination_app` field name or schema
