### PR TITLE
Add destination app to hook metrics

### DIFF
--- a/internal/gateway/claude_code_hook.go
+++ b/internal/gateway/claude_code_hook.go
@@ -83,7 +83,7 @@ type claudeCodeHookResponse struct {
 func (a *APIServer) handleClaudeCodeHook(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		if a.otel != nil {
-			a.otel.RecordConnectorHookInvocation(r.Context(), "claudecode", "unknown", "rejected", "method", 0)
+			a.otel.RecordConnectorHookInvocation(r.Context(), "claudecode", "unknown", "rejected", "method", "", 0)
 		}
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -92,7 +92,7 @@ func (a *APIServer) handleClaudeCodeHook(w http.ResponseWriter, r *http.Request)
 	var payload map[string]interface{}
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 		if a.otel != nil {
-			a.otel.RecordConnectorHookInvocation(r.Context(), "claudecode", "unknown", "rejected", "invalid_json", 0)
+			a.otel.RecordConnectorHookInvocation(r.Context(), "claudecode", "unknown", "rejected", "invalid_json", "", 0)
 		}
 		a.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
 		return
@@ -101,7 +101,7 @@ func (a *APIServer) handleClaudeCodeHook(w http.ResponseWriter, r *http.Request)
 	var req claudeCodeHookRequest
 	if err := json.Unmarshal(b, &req); err != nil {
 		if a.otel != nil {
-			a.otel.RecordConnectorHookInvocation(r.Context(), "claudecode", "unknown", "rejected", "invalid_payload", 0)
+			a.otel.RecordConnectorHookInvocation(r.Context(), "claudecode", "unknown", "rejected", "invalid_payload", "", 0)
 		}
 		a.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid Claude Code hook payload"})
 		return
@@ -109,7 +109,7 @@ func (a *APIServer) handleClaudeCodeHook(w http.ResponseWriter, r *http.Request)
 	req.Payload = payload
 	if req.HookEventName == "" {
 		if a.otel != nil {
-			a.otel.RecordConnectorHookInvocation(r.Context(), "claudecode", "unknown", "rejected", "missing_event", 0)
+			a.otel.RecordConnectorHookInvocation(r.Context(), "claudecode", "unknown", "rejected", "missing_event", "", 0)
 		}
 		a.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "hook_event_name is required"})
 		return
@@ -139,8 +139,12 @@ func (a *APIServer) handleClaudeCodeHook(w http.ResponseWriter, r *http.Request)
 		if resp.WouldBlock {
 			reason = "would_block"
 		}
-		a.otel.RecordConnectorHookInvocation(r.Context(), "claudecode", req.HookEventName, "ok", reason, float64(elapsed.Milliseconds()))
-		a.otel.RecordInspectEvaluation(r.Context(), "claudecode:"+req.HookEventName, resp.Action, resp.Severity)
+		destinationApp := ""
+		if isToolInspectionEvent(req.HookEventName) {
+			destinationApp = hookToolDestinationApp(req.MCPServerName, claudeCodeToolName(req))
+		}
+		a.otel.RecordConnectorHookInvocation(r.Context(), "claudecode", req.HookEventName, "ok", reason, destinationApp, float64(elapsed.Milliseconds()))
+		a.otel.RecordInspectEvaluation(r.Context(), "claudecode:"+req.HookEventName, resp.Action, resp.Severity, destinationApp)
 		a.otel.RecordInspectLatency(r.Context(), "claudecode:"+req.HookEventName, float64(elapsed.Milliseconds()))
 	}
 

--- a/internal/gateway/codex_hook.go
+++ b/internal/gateway/codex_hook.go
@@ -72,7 +72,7 @@ type codexHookResponse struct {
 func (a *APIServer) handleCodexHook(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		if a.otel != nil {
-			a.otel.RecordConnectorHookInvocation(r.Context(), "codex", "unknown", "rejected", "method", 0)
+			a.otel.RecordConnectorHookInvocation(r.Context(), "codex", "unknown", "rejected", "method", "", 0)
 		}
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -81,7 +81,7 @@ func (a *APIServer) handleCodexHook(w http.ResponseWriter, r *http.Request) {
 	payload, b, err := rawPayloadFromJSONDecoder(json.NewDecoder(r.Body))
 	if err != nil {
 		if a.otel != nil {
-			a.otel.RecordConnectorHookInvocation(r.Context(), "codex", "unknown", "rejected", "invalid_json", 0)
+			a.otel.RecordConnectorHookInvocation(r.Context(), "codex", "unknown", "rejected", "invalid_json", "", 0)
 		}
 		a.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
 		return
@@ -89,7 +89,7 @@ func (a *APIServer) handleCodexHook(w http.ResponseWriter, r *http.Request) {
 	var req codexHookRequest
 	if err := json.Unmarshal(b, &req); err != nil {
 		if a.otel != nil {
-			a.otel.RecordConnectorHookInvocation(r.Context(), "codex", "unknown", "rejected", "invalid_payload", 0)
+			a.otel.RecordConnectorHookInvocation(r.Context(), "codex", "unknown", "rejected", "invalid_payload", "", 0)
 		}
 		a.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid Codex hook payload"})
 		return
@@ -97,7 +97,7 @@ func (a *APIServer) handleCodexHook(w http.ResponseWriter, r *http.Request) {
 	req.Payload = payload
 	if req.HookEventName == "" {
 		if a.otel != nil {
-			a.otel.RecordConnectorHookInvocation(r.Context(), "codex", "unknown", "rejected", "missing_event", 0)
+			a.otel.RecordConnectorHookInvocation(r.Context(), "codex", "unknown", "rejected", "missing_event", "", 0)
 		}
 		a.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "hook_event_name is required"})
 		return
@@ -126,8 +126,12 @@ func (a *APIServer) handleCodexHook(w http.ResponseWriter, r *http.Request) {
 		if resp.WouldBlock {
 			reason = "would_block"
 		}
-		a.otel.RecordConnectorHookInvocation(ctx, "codex", req.HookEventName, "ok", reason, float64(elapsed.Milliseconds()))
-		a.otel.RecordInspectEvaluation(ctx, "codex:"+req.HookEventName, resp.Action, resp.Severity)
+		destinationApp := ""
+		if req.HookEventName == "PreToolUse" || req.HookEventName == "PermissionRequest" || req.HookEventName == "PostToolUse" {
+			destinationApp = hookToolDestinationApp(payloadString(req.Payload, "mcp_server_name"), codexToolName(req))
+		}
+		a.otel.RecordConnectorHookInvocation(ctx, "codex", req.HookEventName, "ok", reason, destinationApp, float64(elapsed.Milliseconds()))
+		a.otel.RecordInspectEvaluation(ctx, "codex:"+req.HookEventName, resp.Action, resp.Severity, destinationApp)
 		a.otel.RecordInspectLatency(ctx, "codex:"+req.HookEventName, float64(elapsed.Milliseconds()))
 	}
 

--- a/internal/gateway/inspect.go
+++ b/internal/gateway/inspect.go
@@ -402,7 +402,7 @@ func (a *APIServer) handleInspectTool(w http.ResponseWriter, r *http.Request) {
 	if a.otel != nil {
 		elapsedMs := float64(elapsed.Milliseconds())
 		tool := a.connectorName() + ":" + req.Tool
-		a.otel.RecordInspectEvaluation(context.Background(), tool, verdict.Action, verdict.Severity)
+		a.otel.RecordInspectEvaluation(context.Background(), tool, verdict.Action, verdict.Severity, "")
 		a.otel.RecordInspectLatency(context.Background(), tool, elapsedMs)
 		a.otel.RecordGuardrailEvaluation(context.Background(), a.connectorName()+":policy-rules", verdict.Action)
 		a.otel.RecordGuardrailLatency(context.Background(), a.connectorName()+":policy-rules", elapsedMs)

--- a/internal/gateway/inspect_hooks.go
+++ b/internal/gateway/inspect_hooks.go
@@ -166,7 +166,7 @@ func (a *APIServer) handleInspectRequest(w http.ResponseWriter, r *http.Request)
 	if a.otel != nil {
 		elapsedMs := float64(elapsed.Milliseconds())
 		tool := a.connectorName() + ":pre-request"
-		a.otel.RecordInspectEvaluation(context.Background(), tool, verdict.Action, verdict.Severity)
+		a.otel.RecordInspectEvaluation(context.Background(), tool, verdict.Action, verdict.Severity, "")
 		a.otel.RecordInspectLatency(context.Background(), tool, elapsedMs)
 	}
 
@@ -232,7 +232,7 @@ func (a *APIServer) handleInspectResponse(w http.ResponseWriter, r *http.Request
 	if a.otel != nil {
 		elapsedMs := float64(elapsed.Milliseconds())
 		tool := a.connectorName() + ":post-response"
-		a.otel.RecordInspectEvaluation(context.Background(), tool, verdict.Action, verdict.Severity)
+		a.otel.RecordInspectEvaluation(context.Background(), tool, verdict.Action, verdict.Severity, "")
 		a.otel.RecordInspectLatency(context.Background(), tool, elapsedMs)
 	}
 
@@ -299,7 +299,7 @@ func (a *APIServer) handleInspectToolResponse(w http.ResponseWriter, r *http.Req
 	if a.otel != nil {
 		elapsedMs := float64(elapsed.Milliseconds())
 		tool := a.connectorName() + ":post-tool-" + req.Tool
-		a.otel.RecordInspectEvaluation(context.Background(), tool, verdict.Action, verdict.Severity)
+		a.otel.RecordInspectEvaluation(context.Background(), tool, verdict.Action, verdict.Severity, "")
 		a.otel.RecordInspectLatency(context.Background(), tool, elapsedMs)
 	}
 

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -1166,7 +1166,7 @@ func (r *EventRouter) handleToolCall(evt EventFrame) {
 				"block", "static block list",
 				gatewaylog.SeverityHigh, []string{"policy:block", "surface:tool_call"}, 0)
 			if r.otel != nil {
-				r.otel.RecordInspectEvaluation(context.Background(), payload.Tool, "block", "HIGH")
+				r.otel.RecordInspectEvaluation(context.Background(), payload.Tool, "block", "HIGH", "")
 			}
 			return
 		}
@@ -1222,7 +1222,7 @@ func (r *EventRouter) handleToolCall(evt EventFrame) {
 						verdict.Severity, len(verdict.Findings),
 						redaction.ForSinkReason(verdict.Reason)))
 				if r.otel != nil {
-					r.otel.RecordInspectEvaluation(ctx, tool, verdict.Action, verdict.Severity)
+					r.otel.RecordInspectEvaluation(ctx, tool, verdict.Action, verdict.Severity, "")
 				}
 			}
 		}(payload.Tool, payload.SessionID, payload.ID, payload.Args)

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -1115,15 +1115,19 @@ func (p *Provider) RecordWatcherRestart(ctx context.Context) {
 }
 
 // RecordInspectEvaluation records a tool/message inspect evaluation.
-func (p *Provider) RecordInspectEvaluation(ctx context.Context, tool, action, severity string) {
+func (p *Provider) RecordInspectEvaluation(ctx context.Context, tool, action, severity, destinationApp string) {
 	if !p.Enabled() || p.metrics == nil {
 		return
 	}
-	p.metrics.inspectEvaluations.Add(ctx, 1, metric.WithAttributes(
+	attrs := []attribute.KeyValue{
 		attribute.String("tool", tool),
 		attribute.String("action", action),
 		attribute.String("severity", severity),
-	))
+	}
+	if destinationApp = strings.TrimSpace(destinationApp); destinationApp != "" {
+		attrs = append(attrs, attribute.String("destination_app", destinationApp))
+	}
+	p.metrics.inspectEvaluations.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
 // RecordInspectLatency records tool/message inspect latency.
@@ -1140,7 +1144,7 @@ func (p *Provider) RecordInspectLatency(ctx context.Context, tool string, durati
 // gateway. Client-side spawn failures happen before this point, but this metric
 // gives dashboards a durable count of handled hooks, gateway rejections, and
 // handler latency.
-func (p *Provider) RecordConnectorHookInvocation(ctx context.Context, connector, eventType, result, reason string, durationMs float64) {
+func (p *Provider) RecordConnectorHookInvocation(ctx context.Context, connector, eventType, result, reason, destinationApp string, durationMs float64) {
 	if !p.Enabled() || p.metrics == nil {
 		return
 	}
@@ -1165,6 +1169,9 @@ func (p *Provider) RecordConnectorHookInvocation(ctx context.Context, connector,
 		attribute.String("event_type", eventType),
 		attribute.String("result", result),
 		attribute.String("reason", reason),
+	}
+	if destinationApp = strings.TrimSpace(destinationApp); destinationApp != "" {
+		attrs = append(attrs, attribute.String("destination_app", destinationApp))
 	}
 	p.metrics.hookInvocations.Add(ctx, 1, metric.WithAttributes(attrs...))
 	p.metrics.hookLatency.Record(ctx, durationMs, metric.WithAttributes(attrs...))

--- a/internal/telemetry/provider_test.go
+++ b/internal/telemetry/provider_test.go
@@ -1170,6 +1170,82 @@ func TestRecordLLMTokens_EmitsMetric(t *testing.T) {
 	}
 }
 
+func TestRecordInspectEvaluation_IncludesDestinationApp(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	p, err := NewProviderForTest(reader)
+	if err != nil {
+		t.Fatalf("NewProviderForTest: %v", err)
+	}
+	defer p.Shutdown(context.Background())
+
+	ctx := context.Background()
+	p.RecordInspectEvaluation(ctx, "codex:PreToolUse", "block", "CRITICAL", "mcp:github")
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+
+	found := findCounter(rm, "defenseclaw.inspect.evaluations")
+	if found == nil {
+		t.Fatal("metric defenseclaw.inspect.evaluations not found")
+	}
+
+	sum, ok := found.Data.(metricdata.Sum[int64])
+	if !ok {
+		t.Fatalf("expected Sum[int64], got %T", found.Data)
+	}
+	if len(sum.DataPoints) != 1 {
+		t.Fatalf("inspect datapoints = %d, want 1", len(sum.DataPoints))
+	}
+
+	dp := sum.DataPoints[0]
+	if !hasAttribute(dp.Attributes, "tool", "codex:PreToolUse") {
+		t.Fatal("inspect counter missing tool=codex:PreToolUse")
+	}
+	if !hasAttribute(dp.Attributes, "destination_app", "mcp:github") {
+		t.Fatal("inspect counter missing destination_app=mcp:github")
+	}
+}
+
+func TestRecordConnectorHookInvocation_IncludesDestinationApp(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	p, err := NewProviderForTest(reader)
+	if err != nil {
+		t.Fatalf("NewProviderForTest: %v", err)
+	}
+	defer p.Shutdown(context.Background())
+
+	ctx := context.Background()
+	p.RecordConnectorHookInvocation(ctx, "codex", "PreToolUse", "ok", "would_block", "builtin", 12)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+
+	found := findCounter(rm, "defenseclaw.connector.hook.invocations")
+	if found == nil {
+		t.Fatal("metric defenseclaw.connector.hook.invocations not found")
+	}
+
+	sum, ok := found.Data.(metricdata.Sum[int64])
+	if !ok {
+		t.Fatalf("expected Sum[int64], got %T", found.Data)
+	}
+	if len(sum.DataPoints) != 1 {
+		t.Fatalf("hook datapoints = %d, want 1", len(sum.DataPoints))
+	}
+
+	dp := sum.DataPoints[0]
+	if !hasAttribute(dp.Attributes, "connector", "codex") {
+		t.Fatal("hook counter missing connector=codex")
+	}
+	if !hasAttribute(dp.Attributes, "destination_app", "builtin") {
+		t.Fatal("hook counter missing destination_app=builtin")
+	}
+}
+
 func TestRecordGuardrailEvaluation_DisabledProvider_NoOp(t *testing.T) {
 	p, _ := NewProvider(context.Background(), disabledCfg(), "test")
 	p.RecordGuardrailEvaluation(context.Background(), "test", "block")


### PR DESCRIPTION
## Summary

- Add optional `destination_app` attributes to inspect evaluation and connector hook invocation metrics.
- Populate `destination_app` for Codex tool hook events using the existing MCP/tool destination helper.
- Populate `destination_app` for Claude Code tool inspection hook events using the same destination helper.
- Keep non-hook inspect metric call sites compatible by passing an empty destination app.

## Why

Hook summary metrics need to distinguish app-routed MCP traffic from builtin tool traffic

## Validation

- `go test ./internal/telemetry ./internal/gateway`