### PR TITLE
gateway: add opt-in extension points for external token resolution

### DIFF
--- a/internal/gateway/provider.go
+++ b/internal/gateway/provider.go
@@ -306,7 +306,12 @@ var providerHTTPClient = &http.Client{
 // ResolveAPIKey reads the API key from the named environment variable,
 // optionally loading a .env file first (for daemon contexts where the
 // user's shell env is not inherited).
+// Returns "" immediately when local key resolution has been disabled via
+// DisableLocalKeyResolution (enterprise credential-management mode).
 func ResolveAPIKey(envVar string, dotenvPath string) string {
+	if localKeyResolutionDisabled {
+		return ""
+	}
 	if v := os.Getenv(envVar); v != "" {
 		return v
 	}

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -1537,7 +1537,19 @@ func (p *GuardrailProxy) resolveConfiguredProvider(req *ChatRequest) LLMProvider
 	}
 
 	apiKey := ""
-	if req.TargetAPIKey != "" {
+	// If an external token resolver is registered, use it for direct-provider mode too.
+	if tokenResolver != nil {
+		providerPrefix, modelID := splitModel(cfgModel)
+		if providerPrefix == "" {
+			providerPrefix = inferProvider(modelID, "")
+		}
+		resolvedKey, err := tokenResolver(context.Background(), providerPrefix)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[guardrail] external token resolver error for configured model %q: %v\n", cfgModel, err)
+			return nil
+		}
+		apiKey = resolvedKey
+	} else if req.TargetAPIKey != "" {
 		apiKey = req.TargetAPIKey
 	} else if p.cfg.APIKeyEnv != "" {
 		dotenvPath := filepath.Join(p.dataDir, ".env")
@@ -1590,6 +1602,17 @@ func (p *GuardrailProxy) resolveProviderFromHeaders(req *ChatRequest) LLMProvide
 	prefix := inferProviderFromURL(req.TargetURL + req.TargetPath)
 	if prefix == "" {
 		return nil
+	}
+
+	// If an external token resolver is registered, use it to obtain the API key
+	// instead of relying on X-AI-Auth or local env resolution.
+	if tokenResolver != nil {
+		resolvedKey, err := tokenResolver(context.Background(), prefix)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[guardrail] external token resolver error for %q: %v\n", prefix, err)
+			return nil
+		}
+		req.TargetAPIKey = resolvedKey
 	}
 
 	// Azure requires the specific resource endpoint as baseURL.
@@ -1666,20 +1689,25 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 	// X-AI-Auth carries the real provider API key, normalized to
 	// "Bearer <key>" by the fetch interceptor regardless of which header
 	// the provider SDK originally used (Authorization, x-api-key, api-key).
-	if aiAuth := r.Header.Get("X-AI-Auth"); strings.HasPrefix(aiAuth, "Bearer ") {
-		req.TargetAPIKey = strings.TrimPrefix(aiAuth, "Bearer ")
+	// Skip extraction when local key resolution is disabled (enterprise mode).
+	if !localKeyResolutionDisabled {
+		if aiAuth := r.Header.Get("X-AI-Auth"); strings.HasPrefix(aiAuth, "Bearer ") {
+			req.TargetAPIKey = strings.TrimPrefix(aiAuth, "Bearer ")
+		}
 	}
 
 	// Native-binary connectors (zeptoclaw) have no fetch interceptor, so the
 	// request arrives without X-DC-Target-URL / X-AI-Auth. Ask the active
 	// connector to resolve them from its captured config snapshot. Existing
 	// header values win — fetch-interceptor paths are unchanged.
-	if connUpstream, connKey := hydrateConnectorSignals(p.connector, r, body); connUpstream != "" {
-		if req.TargetURL == "" {
-			req.TargetURL = connUpstream
-		}
-		if req.TargetAPIKey == "" {
-			req.TargetAPIKey = connKey
+	if !localKeyResolutionDisabled {
+		if connUpstream, connKey := hydrateConnectorSignals(p.connector, r, body); connUpstream != "" {
+			if req.TargetURL == "" {
+				req.TargetURL = connUpstream
+			}
+			if req.TargetAPIKey == "" {
+				req.TargetAPIKey = connKey
+			}
 		}
 	}
 

--- a/internal/gateway/token_resolver.go
+++ b/internal/gateway/token_resolver.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import "context"
+
+// TokenResolverFunc resolves an API key for a given provider.
+// When registered via SetTokenResolver, the gateway calls this function
+// instead of reading credentials from environment variables, dotenv files,
+// or the X-AI-Auth request header.
+//
+// Parameters:
+//   - ctx: request context
+//   - provider: LLM provider name (e.g., "openai", "anthropic")
+//
+// Returns the API key string or an error if resolution fails.
+type TokenResolverFunc func(ctx context.Context, provider string) (string, error)
+
+var tokenResolver TokenResolverFunc
+
+// SetTokenResolver registers an external token resolution function.
+// When set, the gateway uses this function to obtain API keys instead of
+// local resolution (env vars, dotenv, X-AI-Auth header).
+// Pass nil to revert to default behavior.
+func SetTokenResolver(fn TokenResolverFunc) {
+	tokenResolver = fn
+}
+
+var localKeyResolutionDisabled bool
+
+// DisableLocalKeyResolution prevents the gateway from reading API keys
+// from environment variables, dotenv files, or the X-AI-Auth request header.
+// When disabled, a TokenResolver must be registered or all LLM requests
+// will fail with an error.
+//
+// This is intended for enterprise deployments where credentials are managed
+// externally and must never be present in the gateway process.
+func DisableLocalKeyResolution() {
+	localKeyResolutionDisabled = true
+}
+
+// IsLocalKeyResolutionDisabled returns whether local key resolution is disabled.
+func IsLocalKeyResolutionDisabled() bool {
+	return localKeyResolutionDisabled
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ override-dependencies = [
     "click>=8.3.1",
     "importlib-metadata>=8.7.1",
     "jsonschema>=4.26.0",
-    "python-multipart>=0.0.26", # CVE-2026-40347 fixed in 0.0.26
+    "python-multipart>=0.0.27", # CVE-2026-42561 fixed in 0.0.27
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,7 @@ overrides = [
     { name = "litellm", specifier = "==1.83.7" },
     { name = "openai", specifier = "==2.30.0" },
     { name = "python-dotenv", specifier = "==1.2.1" },
-    { name = "python-multipart", specifier = ">=0.0.26" },
+    { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "rich", specifier = ">=13.7.1,<14.0.0" },
 ]
 
@@ -2484,11 +2484,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add TokenResolverFunc and DisableLocalKeyResolution hooks that allow enterprise distributions to plug in their own credential provider without modifying OSS behavior. When no resolver is registered (the default), all existing code paths remain unchanged.