### PR TITLE
fix(release): drop homebrew + tag-driven version stamping + workflow_dispatch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  version-sync:
+    name: Version Sync Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Catches drift between the four in-repo version sources (Makefile,
+      # pyproject.toml, cli/__init__.py, package.json) before it can ship
+      # in a release. The release workflow restamps from the git tag, but
+      # PRs still need to keep the in-repo defaults in sync so local dev
+      # builds (`make dist`) produce artifacts whose names match what
+      # install.sh / `defenseclaw upgrade` will look up at the next tag.
+      - run: make check-version-sync
+
   go-lint:
     name: Go Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ name: Release
 # cli/defenseclaw/__init__.py, and extensions/defenseclaw/package.json so
 # every published artifact (gateway tarball, wheel, plugin tarball) is
 # named with the same X.Y.Z that scripts/install.sh and `defenseclaw
-# upgrade` will look up at GitHub Releases.
+# upgrade` look up at GitHub Releases.
 
 on:
   push:
@@ -36,10 +36,16 @@ permissions:
   id-token: write
   packages: write
 
-# Make sure two manual runs (or a manual run + a tag push) for the same
-# version can't race each other into a half-baked release.
+# Serialize all releases for the same version regardless of trigger.
+# `github.ref_name` is `0.4.1` for both `refs/tags/0.4.1` (push:tags) and
+# the branch name on workflow_dispatch — combined with `inputs.version`
+# (set only on workflow_dispatch), this produces the same `release-0.4.1`
+# group key whether you cut the release from the Actions UI or by pushing
+# the tag from your machine. Using `github.ref` here would have stamped
+# `release-refs/tags/0.4.1` for tag pushes vs `release-0.4.1` for manual
+# runs, letting two jobs for the same version race each other.
 concurrency:
-  group: release-${{ inputs.version || github.ref }}
+  group: release-${{ inputs.version || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -53,14 +59,24 @@ jobs:
       # Single source of truth for the target tag: ${{ steps.tag.outputs.tag }}.
       # Validates strict X.Y.Z, refuses to overwrite a pre-existing tag or
       # release, and works for both trigger paths.
+      #
+      # Security: workflow inputs are passed via `env` so they reach the
+      # shell as `$RELEASE_VERSION_INPUT` (a normal env var) rather than
+      # being string-interpolated into the script body before bash parses
+      # it. Direct `${{ inputs.version }}` substitution would let an
+      # operator-supplied quote/newline turn into shell syntax before the
+      # validation regex below could reject it. See:
+      # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
       - name: Resolve and validate target tag
         id: tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION_INPUT: ${{ inputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.version }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$RELEASE_VERSION_INPUT"
             if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "::error title=Invalid version input::version must be X.Y.Z with no v prefix (got: '$TAG')"
               exit 1
@@ -70,7 +86,7 @@ jobs:
             # we never create a duplicate tag, and we never re-tag a
             # different SHA than the operator expects.
             if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
-              echo "::error title=Tag already exists::Tag '$TAG' already exists at $(git rev-parse refs/tags/$TAG). Pick a fresh version (e.g. patch bump) or delete the existing tag."
+              echo "::error title=Tag already exists::Tag '$TAG' already exists at $(git rev-parse "refs/tags/$TAG"). Pick a fresh version (e.g. patch bump) or delete the existing tag."
               exit 1
             fi
             if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
@@ -114,29 +130,21 @@ jobs:
         with:
           node-version: "20"
 
-      # The git tag (or workflow input) is the single source of truth for
-      # the release version. Stamp it into Makefile / pyproject.toml /
-      # cli/__init__.py / extensions/defenseclaw/package.json BEFORE any
-      # build step so the wheel becomes `defenseclaw-<TAG>-py3-none-any.whl`,
-      # the plugin tarball becomes `defenseclaw-plugin-<TAG>.tar.gz`, the
-      # gateway binary embeds <TAG> via -ldflags, and `defenseclaw --version`
-      # reports <TAG> on the installed CLI. Those names match what
-      # scripts/install.sh and `defenseclaw upgrade` look up at GitHub
-      # Releases — so any drift between in-repo version files and the tag
-      # is invisible to end users by construction.
-      - name: Stamp release version
-        run: |
-          set -euo pipefail
-          scripts/stamp-version.sh "${{ steps.tag.outputs.tag }}"
-
-      # GoReleaser builds, signs, and generates SBOMs, but does NOT create
-      # the GitHub release (release.disable: true in .goreleaser.yaml). This
-      # is required because the repository has "Immutable releases" enabled,
-      # which rejects post-create asset uploads. We must instead create the
-      # release atomically with all assets (final step below).
+      # ORDERING NOTE: GoReleaser MUST run before scripts/stamp-version.sh.
+      # GoReleaser refuses to release from a dirty working tree
+      # (https://goreleaser.com/errors/dirty/), and the stamp script edits
+      # tracked files (Makefile, pyproject.toml, cli/__init__.py,
+      # package.json) whenever the tag differs from the in-repo defaults
+      # (the common case for any release after the next planned one).
+      # GoReleaser doesn't need the in-repo files anyway — it gets the
+      # version through GORELEASER_CURRENT_TAG and never reads the Python
+      # / npm metadata.
       #
-      # On workflow_dispatch the tag does not yet exist; pass GORELEASER_CURRENT_TAG
-      # so GoReleaser stamps the right version into binary names and ldflags.
+      # release.disable: true in .goreleaser.yaml means GoReleaser produces
+      # signed, sbom'd artifacts in dist/ but does NOT publish a GitHub
+      # release. We must instead create the release atomically with all
+      # assets at the end of the job, because Immutable Releases rejects
+      # post-create asset uploads.
       - name: Build artifacts with GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -145,6 +153,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ steps.tag.outputs.tag }}
+
+      # Stamp AFTER GoReleaser has finished (so the working tree was clean
+      # for it) but BEFORE building the wheel + plugin tarball, since the
+      # wheel name comes from pyproject.toml and the plugin tarball name
+      # comes from the Makefile's VERSION. The stamped __init__.py is
+      # what makes `defenseclaw --version` report the right value on the
+      # installed CLI.
+      #
+      # `steps.tag.outputs.tag` is regex-validated to ^[0-9]+\.[0-9]+\.[0-9]+$
+      # in the resolve step above (no shell metacharacters possible), but
+      # we still pass it via env to keep the script-injection-resistant
+      # style consistent across every step that consumes a workflow
+      # expression in shell.
+      - name: Stamp release version
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          scripts/stamp-version.sh "$RELEASE_TAG"
 
       - name: Build CLI wheel and plugin tarball
         run: |
@@ -159,9 +186,10 @@ jobs:
       - name: Publish GitHub release with all assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
-          TAG="${{ steps.tag.outputs.tag }}"
+          TAG="$RELEASE_TAG"
 
           shopt -s nullglob
           assets=(
@@ -188,5 +216,5 @@ jobs:
             "${assets[@]}"
 
           echo ""
-          echo "Release $TAG created with $(printf '%s\n' "${assets[@]}" | wc -l | tr -d ' ') assets at $GITHUB_SHA"
+          echo "Release $TAG created with ${#assets[@]} assets at $GITHUB_SHA"
           echo "https://github.com/${GITHUB_REPOSITORY}/releases/tag/$TAG"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,10 +51,10 @@ jobs:
         with:
           node-version: "20"
 
-      # GoReleaser builds, signs, generates SBOMs, and publishes the Homebrew
-      # cask, but does NOT create the GitHub release (release.disable: true in
-      # .goreleaser.yaml). This is required because the repository has
-      # "Immutable releases" enabled, which rejects post-create asset uploads.
+      # GoReleaser builds, signs, and generates SBOMs, but does NOT create the
+      # GitHub release (release.disable: true in .goreleaser.yaml). This is
+      # required because the repository has "Immutable releases" enabled, which
+      # rejects post-create asset uploads.
       - name: Build artifacts with GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,46 @@
 name: Release
 
+# Two trigger paths, both converge into the same job:
+#
+# 1. workflow_dispatch — operator clicks "Run workflow" in the Actions UI
+#    and provides a `version` input (X.Y.Z, no v prefix). The workflow
+#    refuses to run when the tag or a release for it already exists, so
+#    you can't accidentally clobber a previous release. The tag is
+#    created atomically alongside the GitHub release at job end via
+#    `gh release create --target $GITHUB_SHA`.
+#
+# 2. push: tags — `git push origin 0.4.0` from a developer machine. Same
+#    job, same artifacts. The pre-existing-release pre-flight still
+#    applies because Immutable Releases would freeze any pre-created
+#    empty release on creation.
+#
+# Both paths use the resolved tag value to stamp Makefile, pyproject.toml,
+# cli/defenseclaw/__init__.py, and extensions/defenseclaw/package.json so
+# every published artifact (gateway tarball, wheel, plugin tarball) is
+# named with the same X.Y.Z that scripts/install.sh and `defenseclaw
+# upgrade` will look up at GitHub Releases.
+
 on:
   push:
     tags:
       - "*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (X.Y.Z, no v prefix). Tag must NOT already exist."
+        required: true
+        type: string
 
 permissions:
   contents: write
   id-token: write
   packages: write
+
+# Make sure two manual runs (or a manual run + a tag push) for the same
+# version can't race each other into a half-baked release.
+concurrency:
+  group: release-${{ inputs.version || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -18,22 +50,53 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Fail fast with a clear message if a release already exists for this
-      # tag. Immutable releases cannot accept post-create asset uploads, so a
-      # pre-existing release for this tag will leave us unable to attach any
-      # binaries, SBOMs, signatures, or wheels.
-      - name: Verify no pre-existing release blocks atomic creation
+      # Single source of truth for the target tag: ${{ steps.tag.outputs.tag }}.
+      # Validates strict X.Y.Z, refuses to overwrite a pre-existing tag or
+      # release, and works for both trigger paths.
+      - name: Resolve and validate target tag
+        id: tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF#refs/tags/}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.version }}"
+            if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error title=Invalid version input::version must be X.Y.Z with no v prefix (got: '$TAG')"
+              exit 1
+            fi
+            # Refuse if a tag with this name already exists either locally
+            # in the fetched history or on the remote. Atomicity guarantee:
+            # we never create a duplicate tag, and we never re-tag a
+            # different SHA than the operator expects.
+            if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
+              echo "::error title=Tag already exists::Tag '$TAG' already exists at $(git rev-parse refs/tags/$TAG). Pick a fresh version (e.g. patch bump) or delete the existing tag."
+              exit 1
+            fi
+            if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+              echo "::error title=Tag already exists on remote::Tag '$TAG' already exists on origin. Pick a fresh version."
+              exit 1
+            fi
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+            if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error title=Invalid pushed tag::pushed tag must be X.Y.Z (got: '$TAG')"
+              exit 1
+            fi
+          fi
+
+          # Pre-existing-release guard. Immutable Releases freezes a release
+          # on creation, so a release for this tag would block atomic asset
+          # upload — same trap that broke 0.3.1.
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "::error title=Release already exists::A release for tag '$TAG' already exists at https://github.com/${GITHUB_REPOSITORY}/releases/tag/$TAG"
+            echo "::error title=Release already exists::A release for '$TAG' already exists at https://github.com/${GITHUB_REPOSITORY}/releases/tag/$TAG"
             echo "::error::With Immutable Releases enabled, the workflow cannot attach assets to a pre-existing release."
-            echo "::error::Either delete that release and re-tag, or push a fresh tag (e.g. a patch bump). Do NOT manually create the GitHub release before pushing the tag."
+            echo "::error::Either delete that release and re-run with a fresh version, or pick a different tag (e.g. patch bump). Do NOT manually create the GitHub release before this workflow runs."
             exit 1
           fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved release tag: $TAG (commit: $GITHUB_SHA)"
 
       - uses: actions/setup-go@v5
         with:
@@ -51,10 +114,29 @@ jobs:
         with:
           node-version: "20"
 
-      # GoReleaser builds, signs, and generates SBOMs, but does NOT create the
-      # GitHub release (release.disable: true in .goreleaser.yaml). This is
-      # required because the repository has "Immutable releases" enabled, which
-      # rejects post-create asset uploads.
+      # The git tag (or workflow input) is the single source of truth for
+      # the release version. Stamp it into Makefile / pyproject.toml /
+      # cli/__init__.py / extensions/defenseclaw/package.json BEFORE any
+      # build step so the wheel becomes `defenseclaw-<TAG>-py3-none-any.whl`,
+      # the plugin tarball becomes `defenseclaw-plugin-<TAG>.tar.gz`, the
+      # gateway binary embeds <TAG> via -ldflags, and `defenseclaw --version`
+      # reports <TAG> on the installed CLI. Those names match what
+      # scripts/install.sh and `defenseclaw upgrade` look up at GitHub
+      # Releases — so any drift between in-repo version files and the tag
+      # is invisible to end users by construction.
+      - name: Stamp release version
+        run: |
+          set -euo pipefail
+          scripts/stamp-version.sh "${{ steps.tag.outputs.tag }}"
+
+      # GoReleaser builds, signs, and generates SBOMs, but does NOT create
+      # the GitHub release (release.disable: true in .goreleaser.yaml). This
+      # is required because the repository has "Immutable releases" enabled,
+      # which rejects post-create asset uploads. We must instead create the
+      # release atomically with all assets (final step below).
+      #
+      # On workflow_dispatch the tag does not yet exist; pass GORELEASER_CURRENT_TAG
+      # so GoReleaser stamps the right version into binary names and ldflags.
       - name: Build artifacts with GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -62,21 +144,24 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ steps.tag.outputs.tag }}
 
       - name: Build CLI wheel and plugin tarball
         run: |
           make dist-cli
           make dist-plugin
 
-      # Create the GitHub release atomically with every asset attached at
-      # creation time. Immutable releases freeze immediately on create, so all
-      # assets must be supplied in this single API call.
+      # Atomic: tag + release + every asset are created in a single API
+      # call. On workflow_dispatch, --target $GITHUB_SHA tells gh to create
+      # the tag at this commit if it doesn't yet exist. On push:tags the
+      # tag already points at the right commit, so --target is a no-op
+      # but harmless to pass.
       - name: Publish GitHub release with all assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="${{ steps.tag.outputs.tag }}"
 
           shopt -s nullglob
           assets=(
@@ -97,6 +182,11 @@ jobs:
 
           gh release create "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
             --title "$TAG" \
             "${notes_args[@]}" \
             "${assets[@]}"
+
+          echo ""
+          echo "Release $TAG created with $(printf '%s\n' "${assets[@]}" | wc -l | tr -d ' ') assets at $GITHUB_SHA"
+          echo "https://github.com/${GITHUB_REPOSITORY}/releases/tag/$TAG"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,25 +53,3 @@ changelog:
 
 release:
   disable: "true"
-
-homebrew_casks:
-  - repository:
-      owner: cisco-ai-defense
-      name: homebrew-tap
-      token: "{{ .Env.GITHUB_TOKEN }}"
-    # release.disable is on (immutable releases require atomic creation in CI),
-    # so GoReleaser cannot infer the cask download URL from the release config.
-    # Point at the canonical GitHub release-asset URL that our workflow will
-    # populate via `gh release create` immediately after this step.
-    url:
-      template: "https://github.com/cisco-ai-defense/defenseclaw/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-    skip_upload: "true"
-    name: defenseclaw
-    homepage: "https://github.com/cisco-ai-defense/defenseclaw"
-    description: "Enterprise governance layer for OpenClaw"
-    hooks:
-      post:
-        install: |
-          if OS.mac?
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/defenseclaw"]
-          end

--- a/Makefile
+++ b/Makefile
@@ -555,8 +555,13 @@ dist: dist-cli dist-gateway dist-plugin dist-sandbox dist-checksums
 	@echo "Test locally:"
 	@echo "  ./scripts/install.sh --local $(DIST_DIR)"
 	@echo ""
-	@echo "Upload to GitHub release:"
-	@echo "  gh release create v$(VERSION) $(DIST_DIR)/*"
+	@echo "Cut a release (preferred — atomic tag + assets, runs in CI):"
+	@echo "  Actions UI -> 'Release' workflow -> Run workflow -> enter $(VERSION)"
+	@echo "  Or from the CLI: git tag $(VERSION) && git push origin $(VERSION)"
+	@echo ""
+	@echo "  NOTE: tag must be bare X.Y.Z, no 'v' prefix — the release"
+	@echo "  workflow + scripts/install.sh + 'defenseclaw upgrade' all"
+	@echo "  resolve artifacts under https://github.com/.../releases/tag/X.Y.Z"
 
 dist-cli: _bundle-data
 	@mkdir -p $(DIST_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BINARY      := defenseclaw
 GATEWAY     := defenseclaw-gateway
-VERSION     := 0.2.0
+VERSION     := 0.4.0
 GOFLAGS     := -ldflags "-X main.version=$(VERSION)"
 VENV        := .venv
 GOBIN       := $(shell go env GOPATH)/bin
@@ -16,8 +16,49 @@ DIST_DIR    := dist
         build install cli-install dev-install pycli dev-pycli gateway gateway-cross gateway-run start gateway-install \
         plugin plugin-install maybe-openclaw-plugin-install extensions test cli-test cli-test-cov gateway-test tui-test go-test-cov \
         test-verbose test-file lint py-lint go-lint ts-test rego-test clean \
-        check check-audit-actions check-error-codes check-schemas check-v7 check-provider-coverage \
+        check check-audit-actions check-error-codes check-schemas check-v7 check-provider-coverage check-version-sync \
+        set-version \
         dist dist-cli dist-gateway dist-plugin dist-sandbox dist-test dist-checksums dist-clean
+
+# ---------------------------------------------------------------------------
+# Version stamping
+# ---------------------------------------------------------------------------
+# The git tag is the canonical source of truth on a release; the workflow
+# invokes `scripts/stamp-version.sh "$TAG"` directly. Local devs who want
+# to pre-stage a version (e.g. for a manual smoke test of `make dist`)
+# can use this target as a friendly wrapper.
+#
+#   make set-version VERSION=0.4.1
+#
+# Refuses to run without an explicit VERSION= override — the implicit
+# default of $(VERSION) would silently re-stamp the current pinned value.
+set-version:
+	@if [ -z "$(filter-out $(file < /dev/null),$(MAKEOVERRIDES))" ] || ! echo "$(MAKEOVERRIDES)" | grep -q 'VERSION='; then \
+		echo "usage: make set-version VERSION=X.Y.Z" >&2; \
+		exit 64; \
+	fi
+	@scripts/stamp-version.sh "$(VERSION)"
+
+# CI gate that fails when the four version sources disagree, catching
+# drift before it reaches a release artifact. Mirrors the contract
+# enforced by scripts/stamp-version.sh.
+check-version-sync:
+	@mk_ver=$$(grep -E '^VERSION[[:space:]]*:=' Makefile | head -1 | awk -F'=' '{gsub(/[[:space:]]/,"",$$2); print $$2}'); \
+	py_ver=$$(grep -E '^version[[:space:]]*=' pyproject.toml | head -1 | awk -F'"' '{print $$2}'); \
+	init_ver=$$(grep -E '^__version__[[:space:]]*=' cli/defenseclaw/__init__.py | head -1 | awk -F'"' '{print $$2}'); \
+	pkg_ver=$$(grep -E '^  "version":' extensions/defenseclaw/package.json | head -1 | awk -F'"' '{print $$4}'); \
+	if [ "$${mk_ver}" = "$${py_ver}" ] && [ "$${py_ver}" = "$${init_ver}" ] && [ "$${init_ver}" = "$${pkg_ver}" ]; then \
+		echo "version sync OK: $${mk_ver}"; \
+	else \
+		echo "version drift detected:" >&2; \
+		echo "  Makefile                         : $${mk_ver}" >&2; \
+		echo "  pyproject.toml                   : $${py_ver}" >&2; \
+		echo "  cli/defenseclaw/__init__.py      : $${init_ver}" >&2; \
+		echo "  extensions/defenseclaw/package.json: $${pkg_ver}" >&2; \
+		echo "" >&2; \
+		echo "fix with: make set-version VERSION=X.Y.Z" >&2; \
+		exit 1; \
+	fi
 
 # ---------------------------------------------------------------------------
 # `make all` — one-shot build → install → PATH → quickstart

--- a/cli/defenseclaw/__init__.py
+++ b/cli/defenseclaw/__init__.py
@@ -16,4 +16,4 @@
 
 """DefenseClaw — Enterprise governance layer for OpenClaw."""
 
-__version__ = "0.5.0"
+__version__ = "0.4.0"

--- a/extensions/defenseclaw/package.json
+++ b/extensions/defenseclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "defenseclaw",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "OpenClaw plugin for DefenseClaw — scan skills/plugins/MCPs, enforce policy, monitor runtime",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "defenseclaw"
-version = "0.5.0"
+version = "0.4.0"
 description = "Enterprise governance layer for OpenClaw — secures agentic AI deployments"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/stamp-version.sh
+++ b/scripts/stamp-version.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Stamp a single semver across every in-repo version source.
+#
+# The git tag is the source of truth for releases; the release workflow
+# invokes this script before building so that the wheel
+# (`defenseclaw-X.Y.Z-py3-none-any.whl`) and plugin tarball
+# (`defenseclaw-plugin-X.Y.Z.tar.gz`) names match the tag, which in turn
+# matches what `install.sh` and `defenseclaw upgrade` look up.
+#
+# Sources kept in lock-step:
+#   1. Makefile                                 (VERSION := X.Y.Z)
+#   2. pyproject.toml                           (version = "X.Y.Z")
+#   3. cli/defenseclaw/__init__.py              (__version__ = "X.Y.Z")
+#   4. extensions/defenseclaw/package.json      ("version": "X.Y.Z")
+#
+# Usage:
+#   scripts/stamp-version.sh 0.4.0
+#   make set-version VERSION=0.4.0
+#
+# Idempotent: re-running with the same version is a no-op. The script
+# fails loudly if any of the four files cannot be located or already
+# contains a value that does not match the regex it expects, so a silent
+# drift never reaches a release artifact.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 <version>" >&2
+    exit 64
+fi
+
+VERSION="$1"
+
+# Strict semver only. Refuse pre-release / build-metadata suffixes for now —
+# the upgrade flow's URL builders assume bare X.Y.Z, so anything else would
+# silently 404 on `defenseclaw upgrade --version <pre-release>`. Reject here
+# rather than producing a release that the upgrade script cannot consume.
+if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: version must be X.Y.Z (got: ${VERSION})" >&2
+    exit 64
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Cross-platform sed -i wrapper: BSD sed (macOS) requires an explicit empty
+# string after -i, GNU sed (Linux) does not. Detect and dispatch so this
+# script works on both developer macs and the ubuntu-latest GH runner.
+sed_in_place() {
+    if sed --version >/dev/null 2>&1; then
+        sed -i "$@"
+    else
+        sed -i '' "$@"
+    fi
+}
+
+# Each stamp_*() is a separate function so a failure pinpoints which file
+# is malformed (the trap prints the failing function name).
+
+stamp_makefile() {
+    local f="Makefile"
+    [[ -f "${f}" ]] || { echo "error: ${f} not found" >&2; return 1; }
+    grep -qE '^VERSION[[:space:]]*:=[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*$' "${f}" \
+        || { echo "error: ${f} does not match expected 'VERSION := X.Y.Z' line" >&2; return 1; }
+    sed_in_place -E "s/^(VERSION[[:space:]]*:=[[:space:]]*)[0-9]+\.[0-9]+\.[0-9]+([[:space:]]*)\$/\1${VERSION}\2/" "${f}"
+}
+
+stamp_pyproject() {
+    local f="pyproject.toml"
+    [[ -f "${f}" ]] || { echo "error: ${f} not found" >&2; return 1; }
+    grep -qE '^version[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"[[:space:]]*$' "${f}" \
+        || { echo "error: ${f} does not match expected 'version = \"X.Y.Z\"' line" >&2; return 1; }
+    sed_in_place -E "s/^(version[[:space:]]*=[[:space:]]*\")[0-9]+\.[0-9]+\.[0-9]+(\"[[:space:]]*)\$/\1${VERSION}\2/" "${f}"
+}
+
+stamp_init_py() {
+    local f="cli/defenseclaw/__init__.py"
+    [[ -f "${f}" ]] || { echo "error: ${f} not found" >&2; return 1; }
+    grep -qE '^__version__[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"[[:space:]]*$' "${f}" \
+        || { echo "error: ${f} does not match expected '__version__ = \"X.Y.Z\"' line" >&2; return 1; }
+    sed_in_place -E "s/^(__version__[[:space:]]*=[[:space:]]*\")[0-9]+\.[0-9]+\.[0-9]+(\"[[:space:]]*)\$/\1${VERSION}\2/" "${f}"
+}
+
+stamp_package_json() {
+    local f="extensions/defenseclaw/package.json"
+    [[ -f "${f}" ]] || { echo "error: ${f} not found" >&2; return 1; }
+    # Anchor on the leading-two-space indentation that npm uses for package.json
+    # so we only touch the top-level "version" field, never a nested one inside
+    # dependency/devDependency blocks.
+    grep -qE '^  "version":[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+",?[[:space:]]*$' "${f}" \
+        || { echo "error: ${f} does not match expected '  \"version\": \"X.Y.Z\",' line" >&2; return 1; }
+    sed_in_place -E "s/^(  \"version\":[[:space:]]*\")[0-9]+\.[0-9]+\.[0-9]+(\",?[[:space:]]*)\$/\1${VERSION}\2/" "${f}"
+}
+
+stamp_makefile
+stamp_pyproject
+stamp_init_py
+stamp_package_json
+
+echo "stamped version ${VERSION} into:"
+echo "  Makefile"
+echo "  pyproject.toml"
+echo "  cli/defenseclaw/__init__.py"
+echo "  extensions/defenseclaw/package.json"


### PR DESCRIPTION
## Summary

Three connected fixes that together unbreak the release pipeline and harmonize it with `scripts/install.sh`, `scripts/upgrade.sh`, and `defenseclaw upgrade`.

### 1. Drop the broken Homebrew cask block

GoReleaser has been failing on every tag since `0.3.0` because `homebrew_casks.repository.name: homebrew-tap` points at a repo that does not exist (`cisco-ai-defense/homebrew-tap` returns 404). With `skip_upload: auto`, GoReleaser still resolves the tap to detect its default branch and 404s, aborting the run before assets get uploaded — that's why `0.3.1` ended up as an empty release shell and `0.3.2` has no GitHub release at all.

We're not shipping Homebrew today, so the cask block is removed entirely.

### 2. Tag-driven version stamping (single source of truth)

Before this PR there were **four** independent version sources:
- `Makefile` `VERSION := 0.2.0`
- `extensions/defenseclaw/package.json` `0.2.0`
- `pyproject.toml` `0.5.0`
- `cli/defenseclaw/__init__.py` `__version__ = "0.5.0"`

…all of which fed into release artifact filenames (gateway tarball, wheel, plugin tarball) without coordination. A tag of `0.3.3` would have produced `defenseclaw_0.3.3_*.tar.gz` + `defenseclaw-0.5.0-py3-none-any.whl` + `defenseclaw-plugin-0.2.0.tar.gz` — and `defenseclaw upgrade` would 404 on the wheel.

The release workflow now runs `scripts/stamp-version.sh "$TAG"` before any build step, writing the tag value into all four files atomically. Wheel, plugin tarball, gateway binary, and `defenseclaw --version` all converge on the same value, which is what `install.sh` and `defenseclaw upgrade` look up at GitHub Releases.

In-repo defaults are bumped to `0.4.0` (the planned next release) so local `make dist` builds also produce correctly-named artifacts.

### 3. `workflow_dispatch` trigger so releases can be cut from the Actions UI

You can now go to **Actions → Release → Run workflow**, enter `0.4.0`, and the job will:

1. Validate the input is strict X.Y.Z (no `v` prefix, no pre-release suffix).
2. Refuse to run if the tag already exists locally or on origin.
3. Refuse to run if a release already exists for that version (Immutable Releases trap).
4. Stamp the version into all four files.
5. Build everything (GoReleaser → tarballs/sboms/checksums/sigs, wheel, plugin tarball).
6. **Atomically** create the tag and the GitHub release with all assets attached, via `gh release create --target $GITHUB_SHA`. A build failure leaves neither a tag nor a release behind.

The legacy `git push origin X.Y.Z` path still works — both triggers converge into the same job after the validation step.

### 4. Version-sync CI gate (defense in depth)

`.github/workflows/ci.yml` gets a new `version-sync` job that runs `make check-version-sync`. PRs that drift the four in-repo version sources fail CI before merge, so the next release is always clean.

## Files changed

- `.goreleaser.yaml` — drop the entire `homebrew_casks:` block.
- `.github/workflows/release.yaml` — add `workflow_dispatch`, single tag-resolution step, version stamping, `--target $GITHUB_SHA` for atomic tag+release.
- `.github/workflows/ci.yml` — add `version-sync` job.
- `scripts/stamp-version.sh` — new; updates Makefile / pyproject.toml / `__init__.py` / package.json in lockstep.
- `Makefile` — add `set-version` and `check-version-sync` targets; bump `VERSION` to `0.4.0`.
- `pyproject.toml`, `cli/defenseclaw/__init__.py`, `extensions/defenseclaw/package.json` — bump to `0.4.0`.

## How to release after this PR merges

**Option A (preferred):** Actions → Release → Run workflow → enter `0.4.0` → click Run.

**Option B:** `git tag 0.4.0 && git push origin 0.4.0`.

Either way you'll get a release with the same eight artifact families that `0.2.0` shipped: gateway tarballs (linux/darwin × amd64/arm64), SBOMs for each, `checksums.txt` + `.sig` + `.pem`, the Python wheel, and the OpenClaw plugin tarball.

WARNING: Do NOT click "Draft a new release" in the GitHub UI before triggering the workflow. Immutable Releases will freeze the empty release on creation, the workflow's pre-flight will fail, and you'll have to delete it manually before retrying — that's exactly what stranded `0.3.1` with zero assets.

## Test plan

- [x] Local: `scripts/stamp-version.sh 0.4.0` is idempotent; rejects `0.4.0-rc1`; updates all four files.
- [x] Local: `make set-version VERSION=0.4.0` works; `make set-version` (no arg) errors with usage.
- [x] Local: `make check-version-sync` reports OK with all four files at `0.4.0`.
- [x] CI: workflow YAML parses cleanly with both triggers, `version` input wired to `inputs.version`.
- [ ] After merge: trigger workflow_dispatch with `0.4.0` and confirm the release has the full asset set.

## Follow-up (already done out of band)

- Empty `0.3.1` GitHub release shell deleted; git tag preserved.