### PR TITLE
feat(registries+notify): catalog ingest pipeline + OS desktop notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  version-sync:
+    name: Version Sync Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Catches drift between the four in-repo version sources (Makefile,
+      # pyproject.toml, cli/__init__.py, package.json) before it can ship
+      # in a release. The release workflow restamps from the git tag, but
+      # PRs still need to keep the in-repo defaults in sync so local dev
+      # builds (`make dist`) produce artifacts whose names match what
+      # install.sh / `defenseclaw upgrade` will look up at the next tag.
+      - run: make check-version-sync
+
   go-lint:
     name: Go Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ name: Release
 # cli/defenseclaw/__init__.py, and extensions/defenseclaw/package.json so
 # every published artifact (gateway tarball, wheel, plugin tarball) is
 # named with the same X.Y.Z that scripts/install.sh and `defenseclaw
-# upgrade` will look up at GitHub Releases.
+# upgrade` look up at GitHub Releases.
 
 on:
   push:
@@ -36,10 +36,16 @@ permissions:
   id-token: write
   packages: write
 
-# Make sure two manual runs (or a manual run + a tag push) for the same
-# version can't race each other into a half-baked release.
+# Serialize all releases for the same version regardless of trigger.
+# `github.ref_name` is `0.4.1` for both `refs/tags/0.4.1` (push:tags) and
+# the branch name on workflow_dispatch — combined with `inputs.version`
+# (set only on workflow_dispatch), this produces the same `release-0.4.1`
+# group key whether you cut the release from the Actions UI or by pushing
+# the tag from your machine. Using `github.ref` here would have stamped
+# `release-refs/tags/0.4.1` for tag pushes vs `release-0.4.1` for manual
+# runs, letting two jobs for the same version race each other.
 concurrency:
-  group: release-${{ inputs.version || github.ref }}
+  group: release-${{ inputs.version || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -53,14 +59,24 @@ jobs:
       # Single source of truth for the target tag: ${{ steps.tag.outputs.tag }}.
       # Validates strict X.Y.Z, refuses to overwrite a pre-existing tag or
       # release, and works for both trigger paths.
+      #
+      # Security: workflow inputs are passed via `env` so they reach the
+      # shell as `$RELEASE_VERSION_INPUT` (a normal env var) rather than
+      # being string-interpolated into the script body before bash parses
+      # it. Direct `${{ inputs.version }}` substitution would let an
+      # operator-supplied quote/newline turn into shell syntax before the
+      # validation regex below could reject it. See:
+      # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
       - name: Resolve and validate target tag
         id: tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION_INPUT: ${{ inputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.version }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$RELEASE_VERSION_INPUT"
             if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "::error title=Invalid version input::version must be X.Y.Z with no v prefix (got: '$TAG')"
               exit 1
@@ -70,7 +86,7 @@ jobs:
             # we never create a duplicate tag, and we never re-tag a
             # different SHA than the operator expects.
             if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
-              echo "::error title=Tag already exists::Tag '$TAG' already exists at $(git rev-parse refs/tags/$TAG). Pick a fresh version (e.g. patch bump) or delete the existing tag."
+              echo "::error title=Tag already exists::Tag '$TAG' already exists at $(git rev-parse "refs/tags/$TAG"). Pick a fresh version (e.g. patch bump) or delete the existing tag."
               exit 1
             fi
             if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
@@ -114,29 +130,21 @@ jobs:
         with:
           node-version: "20"
 
-      # The git tag (or workflow input) is the single source of truth for
-      # the release version. Stamp it into Makefile / pyproject.toml /
-      # cli/__init__.py / extensions/defenseclaw/package.json BEFORE any
-      # build step so the wheel becomes `defenseclaw-<TAG>-py3-none-any.whl`,
-      # the plugin tarball becomes `defenseclaw-plugin-<TAG>.tar.gz`, the
-      # gateway binary embeds <TAG> via -ldflags, and `defenseclaw --version`
-      # reports <TAG> on the installed CLI. Those names match what
-      # scripts/install.sh and `defenseclaw upgrade` look up at GitHub
-      # Releases — so any drift between in-repo version files and the tag
-      # is invisible to end users by construction.
-      - name: Stamp release version
-        run: |
-          set -euo pipefail
-          scripts/stamp-version.sh "${{ steps.tag.outputs.tag }}"
-
-      # GoReleaser builds, signs, and generates SBOMs, but does NOT create
-      # the GitHub release (release.disable: true in .goreleaser.yaml). This
-      # is required because the repository has "Immutable releases" enabled,
-      # which rejects post-create asset uploads. We must instead create the
-      # release atomically with all assets (final step below).
+      # ORDERING NOTE: GoReleaser MUST run before scripts/stamp-version.sh.
+      # GoReleaser refuses to release from a dirty working tree
+      # (https://goreleaser.com/errors/dirty/), and the stamp script edits
+      # tracked files (Makefile, pyproject.toml, cli/__init__.py,
+      # package.json) whenever the tag differs from the in-repo defaults
+      # (the common case for any release after the next planned one).
+      # GoReleaser doesn't need the in-repo files anyway — it gets the
+      # version through GORELEASER_CURRENT_TAG and never reads the Python
+      # / npm metadata.
       #
-      # On workflow_dispatch the tag does not yet exist; pass GORELEASER_CURRENT_TAG
-      # so GoReleaser stamps the right version into binary names and ldflags.
+      # release.disable: true in .goreleaser.yaml means GoReleaser produces
+      # signed, sbom'd artifacts in dist/ but does NOT publish a GitHub
+      # release. We must instead create the release atomically with all
+      # assets at the end of the job, because Immutable Releases rejects
+      # post-create asset uploads.
       - name: Build artifacts with GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -145,6 +153,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ steps.tag.outputs.tag }}
+
+      # Stamp AFTER GoReleaser has finished (so the working tree was clean
+      # for it) but BEFORE building the wheel + plugin tarball, since the
+      # wheel name comes from pyproject.toml and the plugin tarball name
+      # comes from the Makefile's VERSION. The stamped __init__.py is
+      # what makes `defenseclaw --version` report the right value on the
+      # installed CLI.
+      #
+      # `steps.tag.outputs.tag` is regex-validated to ^[0-9]+\.[0-9]+\.[0-9]+$
+      # in the resolve step above (no shell metacharacters possible), but
+      # we still pass it via env to keep the script-injection-resistant
+      # style consistent across every step that consumes a workflow
+      # expression in shell.
+      - name: Stamp release version
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          scripts/stamp-version.sh "$RELEASE_TAG"
 
       - name: Build CLI wheel and plugin tarball
         run: |
@@ -159,9 +186,10 @@ jobs:
       - name: Publish GitHub release with all assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
-          TAG="${{ steps.tag.outputs.tag }}"
+          TAG="$RELEASE_TAG"
 
           shopt -s nullglob
           assets=(
@@ -188,5 +216,5 @@ jobs:
             "${assets[@]}"
 
           echo ""
-          echo "Release $TAG created with $(printf '%s\n' "${assets[@]}" | wc -l | tr -d ' ') assets at $GITHUB_SHA"
+          echo "Release $TAG created with ${#assets[@]} assets at $GITHUB_SHA"
           echo "https://github.com/${GITHUB_REPOSITORY}/releases/tag/$TAG"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,10 +51,10 @@ jobs:
         with:
           node-version: "20"
 
-      # GoReleaser builds, signs, generates SBOMs, and publishes the Homebrew
-      # cask, but does NOT create the GitHub release (release.disable: true in
-      # .goreleaser.yaml). This is required because the repository has
-      # "Immutable releases" enabled, which rejects post-create asset uploads.
+      # GoReleaser builds, signs, and generates SBOMs, but does NOT create the
+      # GitHub release (release.disable: true in .goreleaser.yaml). This is
+      # required because the repository has "Immutable releases" enabled, which
+      # rejects post-create asset uploads.
       - name: Build artifacts with GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,6 +114,35 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Resolved release tag: $TAG (commit: $GITHUB_SHA)"
 
+      # workflow_dispatch path only: create a local lightweight tag at HEAD
+      # so GoReleaser sees a real tag pointing at the commit it's releasing.
+      # This is the canonical pattern documented by the GoReleaser author:
+      # https://carlosbecker.com/posts/goreleaser-create-tag-action/
+      #
+      # Why not GORELEASER_CURRENT_TAG: that env var is documented as a
+      # selector when one commit has multiple tags, not a substitute for a
+      # missing tag. It's also been buggy across goreleaser-action versions
+      # (e.g. ignored entirely in v2.4 — goreleaser/goreleaser-action#260),
+      # whereas a real local tag is unambiguous.
+      #
+      # The tag is local-only — it's never pushed to origin in this step.
+      # If anything later in the job fails, the workflow VM is destroyed
+      # and no remote tag is left dangling. The remote tag is created
+      # atomically alongside the GitHub release in the final step via
+      # `gh release create --target $GITHUB_SHA`, so a failed run leaves
+      # neither a remote tag nor an empty release behind.
+      #
+      # Skipped on push:tags because the tag is already in the fetched
+      # history (GITHUB_REF resolves it).
+      - name: Create local tag for GoReleaser (workflow_dispatch only)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git tag "$RELEASE_TAG"
+          echo "Created local tag $RELEASE_TAG at $(git rev-parse HEAD)"
+
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -134,11 +163,16 @@ jobs:
       # GoReleaser refuses to release from a dirty working tree
       # (https://goreleaser.com/errors/dirty/), and the stamp script edits
       # tracked files (Makefile, pyproject.toml, cli/__init__.py,
-      # package.json) whenever the tag differs from the in-repo defaults
-      # (the common case for any release after the next planned one).
-      # GoReleaser doesn't need the in-repo files anyway — it gets the
-      # version through GORELEASER_CURRENT_TAG and never reads the Python
-      # / npm metadata.
+      # package.json) whenever the tag differs from the in-repo defaults —
+      # the common case for any release after the next planned one. So we
+      # run GoReleaser first against the clean checkout, then stamp, then
+      # build the wheel + plugin tarball (which DO need the stamped
+      # metadata for filenames and embedded __version__).
+      #
+      # GoReleaser picks the version from the local tag (created above on
+      # workflow_dispatch, or already present from push:tags). It never
+      # reads pyproject.toml / package.json / the Makefile, so leaving
+      # those at their in-repo defaults during this step is fine.
       #
       # release.disable: true in .goreleaser.yaml means GoReleaser produces
       # signed, sbom'd artifacts in dist/ but does NOT publish a GitHub
@@ -152,14 +186,13 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_CURRENT_TAG: ${{ steps.tag.outputs.tag }}
 
       # Stamp AFTER GoReleaser has finished (so the working tree was clean
       # for it) but BEFORE building the wheel + plugin tarball, since the
-      # wheel name comes from pyproject.toml and the plugin tarball name
-      # comes from the Makefile's VERSION. The stamped __init__.py is
-      # what makes `defenseclaw --version` report the right value on the
-      # installed CLI.
+      # wheel filename comes from pyproject.toml and the plugin tarball
+      # filename comes from the Makefile's VERSION. The stamped
+      # __init__.py is what makes `defenseclaw --version` report the
+      # right value on the installed CLI.
       #
       # `steps.tag.outputs.tag` is regex-validated to ^[0-9]+\.[0-9]+\.[0-9]+$
       # in the resolve step above (no shell metacharacters possible), but

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,46 @@
 name: Release
 
+# Two trigger paths, both converge into the same job:
+#
+# 1. workflow_dispatch — operator clicks "Run workflow" in the Actions UI
+#    and provides a `version` input (X.Y.Z, no v prefix). The workflow
+#    refuses to run when the tag or a release for it already exists, so
+#    you can't accidentally clobber a previous release. The tag is
+#    created atomically alongside the GitHub release at job end via
+#    `gh release create --target $GITHUB_SHA`.
+#
+# 2. push: tags — `git push origin 0.4.0` from a developer machine. Same
+#    job, same artifacts. The pre-existing-release pre-flight still
+#    applies because Immutable Releases would freeze any pre-created
+#    empty release on creation.
+#
+# Both paths use the resolved tag value to stamp Makefile, pyproject.toml,
+# cli/defenseclaw/__init__.py, and extensions/defenseclaw/package.json so
+# every published artifact (gateway tarball, wheel, plugin tarball) is
+# named with the same X.Y.Z that scripts/install.sh and `defenseclaw
+# upgrade` will look up at GitHub Releases.
+
 on:
   push:
     tags:
       - "*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (X.Y.Z, no v prefix). Tag must NOT already exist."
+        required: true
+        type: string
 
 permissions:
   contents: write
   id-token: write
   packages: write
+
+# Make sure two manual runs (or a manual run + a tag push) for the same
+# version can't race each other into a half-baked release.
+concurrency:
+  group: release-${{ inputs.version || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -18,22 +50,53 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Fail fast with a clear message if a release already exists for this
-      # tag. Immutable releases cannot accept post-create asset uploads, so a
-      # pre-existing release for this tag will leave us unable to attach any
-      # binaries, SBOMs, signatures, or wheels.
-      - name: Verify no pre-existing release blocks atomic creation
+      # Single source of truth for the target tag: ${{ steps.tag.outputs.tag }}.
+      # Validates strict X.Y.Z, refuses to overwrite a pre-existing tag or
+      # release, and works for both trigger paths.
+      - name: Resolve and validate target tag
+        id: tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF#refs/tags/}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.version }}"
+            if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error title=Invalid version input::version must be X.Y.Z with no v prefix (got: '$TAG')"
+              exit 1
+            fi
+            # Refuse if a tag with this name already exists either locally
+            # in the fetched history or on the remote. Atomicity guarantee:
+            # we never create a duplicate tag, and we never re-tag a
+            # different SHA than the operator expects.
+            if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
+              echo "::error title=Tag already exists::Tag '$TAG' already exists at $(git rev-parse refs/tags/$TAG). Pick a fresh version (e.g. patch bump) or delete the existing tag."
+              exit 1
+            fi
+            if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+              echo "::error title=Tag already exists on remote::Tag '$TAG' already exists on origin. Pick a fresh version."
+              exit 1
+            fi
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+            if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error title=Invalid pushed tag::pushed tag must be X.Y.Z (got: '$TAG')"
+              exit 1
+            fi
+          fi
+
+          # Pre-existing-release guard. Immutable Releases freezes a release
+          # on creation, so a release for this tag would block atomic asset
+          # upload — same trap that broke 0.3.1.
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "::error title=Release already exists::A release for tag '$TAG' already exists at https://github.com/${GITHUB_REPOSITORY}/releases/tag/$TAG"
+            echo "::error title=Release already exists::A release for '$TAG' already exists at https://github.com/${GITHUB_REPOSITORY}/releases/tag/$TAG"
             echo "::error::With Immutable Releases enabled, the workflow cannot attach assets to a pre-existing release."
-            echo "::error::Either delete that release and re-tag, or push a fresh tag (e.g. a patch bump). Do NOT manually create the GitHub release before pushing the tag."
+            echo "::error::Either delete that release and re-run with a fresh version, or pick a different tag (e.g. patch bump). Do NOT manually create the GitHub release before this workflow runs."
             exit 1
           fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved release tag: $TAG (commit: $GITHUB_SHA)"
 
       - uses: actions/setup-go@v5
         with:
@@ -51,10 +114,29 @@ jobs:
         with:
           node-version: "20"
 
-      # GoReleaser builds, signs, and generates SBOMs, but does NOT create the
-      # GitHub release (release.disable: true in .goreleaser.yaml). This is
-      # required because the repository has "Immutable releases" enabled, which
-      # rejects post-create asset uploads.
+      # The git tag (or workflow input) is the single source of truth for
+      # the release version. Stamp it into Makefile / pyproject.toml /
+      # cli/__init__.py / extensions/defenseclaw/package.json BEFORE any
+      # build step so the wheel becomes `defenseclaw-<TAG>-py3-none-any.whl`,
+      # the plugin tarball becomes `defenseclaw-plugin-<TAG>.tar.gz`, the
+      # gateway binary embeds <TAG> via -ldflags, and `defenseclaw --version`
+      # reports <TAG> on the installed CLI. Those names match what
+      # scripts/install.sh and `defenseclaw upgrade` look up at GitHub
+      # Releases — so any drift between in-repo version files and the tag
+      # is invisible to end users by construction.
+      - name: Stamp release version
+        run: |
+          set -euo pipefail
+          scripts/stamp-version.sh "${{ steps.tag.outputs.tag }}"
+
+      # GoReleaser builds, signs, and generates SBOMs, but does NOT create
+      # the GitHub release (release.disable: true in .goreleaser.yaml). This
+      # is required because the repository has "Immutable releases" enabled,
+      # which rejects post-create asset uploads. We must instead create the
+      # release atomically with all assets (final step below).
+      #
+      # On workflow_dispatch the tag does not yet exist; pass GORELEASER_CURRENT_TAG
+      # so GoReleaser stamps the right version into binary names and ldflags.
       - name: Build artifacts with GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -62,21 +144,24 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ steps.tag.outputs.tag }}
 
       - name: Build CLI wheel and plugin tarball
         run: |
           make dist-cli
           make dist-plugin
 
-      # Create the GitHub release atomically with every asset attached at
-      # creation time. Immutable releases freeze immediately on create, so all
-      # assets must be supplied in this single API call.
+      # Atomic: tag + release + every asset are created in a single API
+      # call. On workflow_dispatch, --target $GITHUB_SHA tells gh to create
+      # the tag at this commit if it doesn't yet exist. On push:tags the
+      # tag already points at the right commit, so --target is a no-op
+      # but harmless to pass.
       - name: Publish GitHub release with all assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="${{ steps.tag.outputs.tag }}"
 
           shopt -s nullglob
           assets=(
@@ -97,6 +182,11 @@ jobs:
 
           gh release create "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
             --title "$TAG" \
             "${notes_args[@]}" \
             "${assets[@]}"
+
+          echo ""
+          echo "Release $TAG created with $(printf '%s\n' "${assets[@]}" | wc -l | tr -d ' ') assets at $GITHUB_SHA"
+          echo "https://github.com/${GITHUB_REPOSITORY}/releases/tag/$TAG"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,25 +53,3 @@ changelog:
 
 release:
   disable: "true"
-
-homebrew_casks:
-  - repository:
-      owner: cisco-ai-defense
-      name: homebrew-tap
-      token: "{{ .Env.GITHUB_TOKEN }}"
-    # release.disable is on (immutable releases require atomic creation in CI),
-    # so GoReleaser cannot infer the cask download URL from the release config.
-    # Point at the canonical GitHub release-asset URL that our workflow will
-    # populate via `gh release create` immediately after this step.
-    url:
-      template: "https://github.com/cisco-ai-defense/defenseclaw/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-    skip_upload: "true"
-    name: defenseclaw
-    homepage: "https://github.com/cisco-ai-defense/defenseclaw"
-    description: "Enterprise governance layer for OpenClaw"
-    hooks:
-      post:
-        install: |
-          if OS.mac?
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/defenseclaw"]
-          end

--- a/Makefile
+++ b/Makefile
@@ -555,8 +555,13 @@ dist: dist-cli dist-gateway dist-plugin dist-sandbox dist-checksums
 	@echo "Test locally:"
 	@echo "  ./scripts/install.sh --local $(DIST_DIR)"
 	@echo ""
-	@echo "Upload to GitHub release:"
-	@echo "  gh release create v$(VERSION) $(DIST_DIR)/*"
+	@echo "Cut a release (preferred — atomic tag + assets, runs in CI):"
+	@echo "  Actions UI -> 'Release' workflow -> Run workflow -> enter $(VERSION)"
+	@echo "  Or from the CLI: git tag $(VERSION) && git push origin $(VERSION)"
+	@echo ""
+	@echo "  NOTE: tag must be bare X.Y.Z, no 'v' prefix — the release"
+	@echo "  workflow + scripts/install.sh + 'defenseclaw upgrade' all"
+	@echo "  resolve artifacts under https://github.com/.../releases/tag/X.Y.Z"
 
 dist-cli: _bundle-data
 	@mkdir -p $(DIST_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BINARY      := defenseclaw
 GATEWAY     := defenseclaw-gateway
-VERSION     := 0.2.0
+VERSION     := 0.4.0
 GOFLAGS     := -ldflags "-X main.version=$(VERSION)"
 VENV        := .venv
 GOBIN       := $(shell go env GOPATH)/bin
@@ -16,8 +16,49 @@ DIST_DIR    := dist
         build install cli-install dev-install pycli dev-pycli gateway gateway-cross gateway-run start gateway-install \
         plugin plugin-install maybe-openclaw-plugin-install extensions test cli-test cli-test-cov gateway-test tui-test go-test-cov \
         test-verbose test-file lint py-lint go-lint ts-test rego-test clean \
-        check check-audit-actions check-error-codes check-schemas check-v7 check-provider-coverage \
+        check check-audit-actions check-error-codes check-schemas check-v7 check-provider-coverage check-version-sync \
+        set-version \
         dist dist-cli dist-gateway dist-plugin dist-sandbox dist-test dist-checksums dist-clean
+
+# ---------------------------------------------------------------------------
+# Version stamping
+# ---------------------------------------------------------------------------
+# The git tag is the canonical source of truth on a release; the workflow
+# invokes `scripts/stamp-version.sh "$TAG"` directly. Local devs who want
+# to pre-stage a version (e.g. for a manual smoke test of `make dist`)
+# can use this target as a friendly wrapper.
+#
+#   make set-version VERSION=0.4.1
+#
+# Refuses to run without an explicit VERSION= override — the implicit
+# default of $(VERSION) would silently re-stamp the current pinned value.
+set-version:
+	@if [ -z "$(filter-out $(file < /dev/null),$(MAKEOVERRIDES))" ] || ! echo "$(MAKEOVERRIDES)" | grep -q 'VERSION='; then \
+		echo "usage: make set-version VERSION=X.Y.Z" >&2; \
+		exit 64; \
+	fi
+	@scripts/stamp-version.sh "$(VERSION)"
+
+# CI gate that fails when the four version sources disagree, catching
+# drift before it reaches a release artifact. Mirrors the contract
+# enforced by scripts/stamp-version.sh.
+check-version-sync:
+	@mk_ver=$$(grep -E '^VERSION[[:space:]]*:=' Makefile | head -1 | awk -F'=' '{gsub(/[[:space:]]/,"",$$2); print $$2}'); \
+	py_ver=$$(grep -E '^version[[:space:]]*=' pyproject.toml | head -1 | awk -F'"' '{print $$2}'); \
+	init_ver=$$(grep -E '^__version__[[:space:]]*=' cli/defenseclaw/__init__.py | head -1 | awk -F'"' '{print $$2}'); \
+	pkg_ver=$$(grep -E '^  "version":' extensions/defenseclaw/package.json | head -1 | awk -F'"' '{print $$4}'); \
+	if [ "$${mk_ver}" = "$${py_ver}" ] && [ "$${py_ver}" = "$${init_ver}" ] && [ "$${init_ver}" = "$${pkg_ver}" ]; then \
+		echo "version sync OK: $${mk_ver}"; \
+	else \
+		echo "version drift detected:" >&2; \
+		echo "  Makefile                         : $${mk_ver}" >&2; \
+		echo "  pyproject.toml                   : $${py_ver}" >&2; \
+		echo "  cli/defenseclaw/__init__.py      : $${init_ver}" >&2; \
+		echo "  extensions/defenseclaw/package.json: $${pkg_ver}" >&2; \
+		echo "" >&2; \
+		echo "fix with: make set-version VERSION=X.Y.Z" >&2; \
+		exit 1; \
+	fi
 
 # ---------------------------------------------------------------------------
 # `make all` — one-shot build → install → PATH → quickstart

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ DefenseClaw combines a Python operator CLI, a Go gateway sidecar, and an OpenCla
 - **Runtime guardrails** - inspect prompts, completions, and tool calls with regex rules, policy, optional LLM judge, and Cisco AI Defense inspection.
 - **CodeGuard** - built-in static checks for secrets, dangerous execution, unsafe deserialization, weak crypto, injection patterns, and risky file access.
 - **OpenShell sandbox support** - Linux sandbox setup with network, filesystem, syscall, and policy controls.
+- **Registries** - ingest external skill / MCP catalogs (corporate HTTPS YAML, [smithery.ai](https://smithery.ai/), [skills.sh](https://skills.sh/), git, ClawHub) with SSRF guards, scanner-driven verdicts, and auto-promotion into asset policy. See [docs/REGISTRIES.md](docs/REGISTRIES.md).
 - **Audit and observability** - SQLite audit store, JSONL gateway logs, OTLP export, Splunk HEC, webhooks, and local Grafana/Splunk bundles.
 - **Operator UX** - a CLI and TUI for setup, health checks, alerts, block/allow lists, scanner results, and policy workflows.
 
@@ -72,6 +73,7 @@ High-risk deployments should pair DefenseClaw with human review, least-privilege
 | [Splunk App](docs/SPLUNK_APP.md) | Local Splunk app dashboards and investigation flow |
 | [TUI](docs/TUI.md) | Terminal dashboard panels and navigation |
 | [Config Files](docs/CONFIG_FILES.md) | Config locations, environment variables, and policy files |
+| [Registries](docs/REGISTRIES.md) | External skill / MCP catalog ingestion (clawhub, smithery, skills.sh, http, git, file) |
 | [Plugin Development](docs/PLUGINS.md) | Custom scanner plugin workflow and example |
 | [Testing](docs/TESTING.md) | Python, Go, TypeScript, Rego, docs, and CI checks |
 | [Developer Spec](docs/development/DEVELOPER_SPEC.md) | Historical product/developer spec |

--- a/bundles/registries/example-mcp-catalog.yaml
+++ b/bundles/registries/example-mcp-catalog.yaml
@@ -1,0 +1,39 @@
+# Example DefenseClaw registry manifest — MCP servers only.
+#
+# Publish this file at a stable HTTPS URL and register it with:
+#
+#   defenseclaw registry add corp-mcp \
+#     --kind http_yaml \
+#     --url https://catalog.example.com/mcp.yaml \
+#     --content mcp --non-interactive
+#   defenseclaw registry sync corp-mcp
+#
+# Schema: schemas/registry-manifest.schema.json (validated at sync time).
+schema_version: 1
+generated_at: "2026-05-07T00:00:00Z"
+publisher: example-corp
+entries:
+  - name: filesystem
+    type: mcp
+    transport: stdio
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/srv/shared"]
+    publisher: anthropic
+    license: MIT
+    description: Bounded filesystem read access scoped to a single root.
+    tags: [reference]
+  - name: postgres-readonly
+    type: mcp
+    transport: stdio
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-postgres"]
+    env_required: [PGHOST, PGUSER, PGDATABASE]
+    publisher: anthropic
+    description: Read-only Postgres queries; restrict via PG-side roles.
+  - name: corp-knowledge
+    type: mcp
+    transport: streamable-http
+    url: https://mcp.example.com/v1/knowledge
+    publisher: example-corp
+    description: Internal knowledge base via streamable-HTTP MCP.
+    tags: [internal]

--- a/bundles/registries/example-skill-catalog.yaml
+++ b/bundles/registries/example-skill-catalog.yaml
@@ -1,0 +1,33 @@
+# Example DefenseClaw registry manifest — skills only.
+#
+# Publish this file at a stable HTTPS URL and register it with:
+#
+#   defenseclaw registry add corp-skills \
+#     --kind http_yaml \
+#     --url https://catalog.example.com/skills.yaml \
+#     --content skill --non-interactive
+#   defenseclaw registry sync corp-skills
+#
+# Schema: schemas/registry-manifest.schema.json (validated at sync time).
+schema_version: 1
+generated_at: "2026-05-07T00:00:00Z"
+publisher: example-corp
+default_connector: openclaw
+entries:
+  - name: github-summarizer
+    type: skill
+    source_url: clawhub://github-summarizer
+    license: Apache-2.0
+    publisher: example-corp
+    description: Summarise pull requests from any GitHub repository.
+    homepage: https://github.com/example/openclaw-skills
+    tags: [productivity, github]
+  - name: corp-runbook
+    type: skill
+    source_url: https://artifacts.example.com/skills/corp-runbook-1.4.0.tar.gz
+    sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+    version: "1.4.0"
+    license: Internal
+    publisher: example-corp
+    description: Read-only access to the corporate runbook collection.
+    tags: [internal, ops]

--- a/cli/defenseclaw/__init__.py
+++ b/cli/defenseclaw/__init__.py
@@ -16,4 +16,4 @@
 
 """DefenseClaw — Enterprise governance layer for OpenClaw."""
 
-__version__ = "0.5.0"
+__version__ = "0.4.0"

--- a/cli/defenseclaw/commands/cmd_init.py
+++ b/cli/defenseclaw/commands/cmd_init.py
@@ -292,6 +292,14 @@ def init_cmd(  # noqa: PLR0913 - first-run CLI mirrors the setup surface.
     else:
         _install_codeguard_skill(cfg, logger)
 
+    ux.banner("Notifications")
+    _onboard_notifications(
+        cfg, logger,
+        non_interactive=non_interactive,
+        yes=yes,
+        is_new_config=is_new_config,
+    )
+
     cfg.save()
 
     # Sandbox setup (Linux only)
@@ -1026,6 +1034,98 @@ def _install_codeguard_skill(cfg, logger) -> None:
     else:
         click.echo(f" {status}")
     logger.log_action("install-skill", "codeguard", f"status={status}")
+
+
+def _onboard_notifications(
+    cfg,
+    logger,
+    *,
+    non_interactive: bool,
+    yes: bool,
+    is_new_config: bool,
+) -> None:
+    """Surface the desktop-notifications opt-in prompt on first run.
+
+    Mirrors the single-question contract documented in the
+    ``macos-block-and-hitl-notifications`` plan: a fresh install is
+    asked once, the answer is persisted to
+    ``notifications.enabled``, and subsequent ``defenseclaw init``
+    invocations stay quiet (the operator can rerun
+    ``defenseclaw setup notifications`` to flip it).
+
+    Decision tree:
+      * Existing config (``is_new_config=False``) → never prompt;
+        print the current state for visibility. Re-running ``init``
+        on a configured install must not re-litigate onboarding.
+      * ``--non-interactive`` or ``--yes`` or non-TTY stdin (CI) →
+        keep platform default, print a one-liner pointing at
+        ``setup notifications``.
+      * Otherwise → ``click.confirm`` with the platform-aware
+        default.
+
+    The ``cfg`` mutation is in-memory; the caller does the
+    ``cfg.save()`` so this helper composes with whatever else
+    ``init`` decides to write.
+    """
+    nc = cfg.notifications
+
+    if not is_new_config:
+        # Re-run of ``init`` against an existing config. We can't
+        # safely tell "operator said no last time" from "operator
+        # never saw the prompt" without a separate sentinel, and
+        # re-prompting on every init would be irritating, so the
+        # rule is: ask only at first-install. Operators flip the
+        # toggle later via ``defenseclaw setup notifications``.
+        state = "ON" if nc.enabled else "OFF"
+        click.echo(
+            f"  Notifications: {ux.dim('preserving current setting')} ({state})"
+        )
+        click.echo("  " + ux.dim("Toggle later with: defenseclaw setup notifications"))
+        return
+
+    if non_interactive or yes or not _stdin_is_tty():
+        state = "ON" if nc.enabled else "OFF"
+        click.echo(
+            f"  Notifications: {ux.dim('platform default')} ({state})"
+        )
+        click.echo("  " + ux.dim("Toggle later with: defenseclaw setup notifications"))
+        return
+
+    desired = click.confirm(
+        "  Show desktop notifications for blocks and approval requests?",
+        default=bool(nc.enabled),
+    )
+
+    if desired == bool(nc.enabled):
+        state = "ON" if desired else "OFF"
+        click.echo("  Notifications: " + ux._style(state, fg="green") +
+                   ux.dim(" (unchanged)"))
+        return
+
+    nc.enabled = desired
+    state = "ON" if desired else "OFF"
+    click.echo("  Notifications: " + ux._style(state, fg="green"))
+    click.echo("  " + ux.dim("Re-run: defenseclaw setup notifications"))
+    logger.log_action(
+        "init-notifications-toggle",
+        "config",
+        f"enabled={desired!s}",
+    )
+
+
+def _stdin_is_tty() -> bool:
+    """Best-effort TTY probe used by the notifications onboarding.
+
+    Wrapped so unit tests can monkey-patch a single point. ``init``
+    already routes around interactive prompts when ``--non-interactive``
+    or ``--yes`` is set, so this is the last-mile guard for piped /
+    redirected stdin.
+    """
+    import sys
+    try:
+        return sys.stdin.isatty()
+    except (AttributeError, ValueError, OSError):
+        return False
 
 
 def _setup_guardrail_inline(app, cfg, logger) -> bool:

--- a/cli/defenseclaw/commands/cmd_registry.py
+++ b/cli/defenseclaw/commands/cmd_registry.py
@@ -158,7 +158,7 @@ def _require_cfg(app: AppContext) -> Config:
         an unbootstrapped context, the failure is loud rather than a
         confusing AttributeError on ``.registries`` half a stack down.
     """
-    cfg = _require_cfg(app)
+    cfg = app.cfg
     if cfg is None:
         # Should not happen in normal CLI flow — main() always loads cfg
         # before dispatching. Keep the message terse and operator-facing.

--- a/cli/defenseclaw/commands/cmd_registry.py
+++ b/cli/defenseclaw/commands/cmd_registry.py
@@ -1,0 +1,1142 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""``defenseclaw registry`` — manage external skill / MCP catalog sources.
+
+The group has two layers:
+
+* **Non-interactive primitives** (the bulk of this file): every
+  subcommand accepts the full operator-facing flag surface, validates
+  inputs strictly when ``--non-interactive`` is set, and emits
+  stable JSON with ``--json``. These are what the TUI and CI/CD
+  pipelines call.
+* **Interactive prompts** layered on top of the same callbacks via
+  :func:`click.prompt` / :func:`click.confirm` (mirrors
+  ``cmd_setup_webhook.py``). When stdin is a TTY and the operator
+  hasn't passed ``--non-interactive``, missing required inputs are
+  filled in via prompt; otherwise the command fails with exit code
+  2 and ``error: --foo is required``.
+
+The :command:`wizard` shortcut at the bottom of this module bundles the
+add+sync flow with prompts so first-run discoverability is a single
+command.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import os
+import re
+import sys
+from dataclasses import asdict
+from typing import Any
+
+import click
+
+from defenseclaw import ux
+from defenseclaw.config import (
+    REGISTRY_CONTENT_TYPES,
+    REGISTRY_KINDS,
+    Config,
+    RegistrySource,
+)
+from defenseclaw.context import AppContext, pass_ctx
+from defenseclaw.registries import (
+    EntryVerdict,
+    SourceIndex,
+    SyncReport,
+    load_index,
+    sync_all,
+    sync_source,
+)
+from defenseclaw.registries import (
+    remove_source as remove_source_cache,
+)
+from defenseclaw.registries.manifest import ManifestEntry
+from defenseclaw.registries.sync import (
+    ScanCallback,
+    manual_set_verdict,
+    promote_from_cache,
+)
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+# Conservative kebab-case identifier — keeps source ids safe to use as
+# a directory name under ~/.defenseclaw/registries/<id> and as part of
+# the AssetPolicyRule.Reason field "registry:<id>".
+_SOURCE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{1,63}$")
+_ENV_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,127}$")
+
+
+def _require(value: Any, flag: str, *, non_interactive: bool) -> Any:
+    """Either return *value* unchanged or raise SystemExit(2).
+
+    When ``non_interactive`` is True we treat a missing value as a
+    hard error (matches the rule "exits non-zero on missing required
+    input when --non-interactive is set"). Interactive callers fill
+    the value with :func:`click.prompt` *before* calling this.
+    """
+    if value is None or value == "":
+        if non_interactive:
+            click.echo(f"error: {flag} is required", err=True)
+            raise SystemExit(2)
+        click.echo(f"error: {flag} is required", err=True)
+        raise SystemExit(2)
+    return value
+
+
+def _validate_source_id(sid: str) -> str:
+    sid = sid.strip().lower()
+    if not _SOURCE_ID_RE.match(sid):
+        raise click.BadParameter(
+            f"id {sid!r} must match {_SOURCE_ID_RE.pattern!r} "
+            "(lowercase letters, digits, dot, dash, underscore; 2-64 chars)"
+        )
+    return sid
+
+
+def _validate_kind(kind: str) -> str:
+    kind = kind.strip().lower()
+    if kind not in REGISTRY_KINDS:
+        raise click.BadParameter(
+            f"kind must be one of {', '.join(REGISTRY_KINDS)} (got {kind!r})"
+        )
+    return kind
+
+
+def _validate_content(content: str) -> str:
+    c = content.strip().lower()
+    if c not in REGISTRY_CONTENT_TYPES:
+        raise click.BadParameter(
+            f"content must be one of {', '.join(REGISTRY_CONTENT_TYPES)} (got {content!r})"
+        )
+    return c
+
+
+def _validate_auth_env(env: str) -> str:
+    env = env.strip()
+    if not env:
+        return ""
+    if not _ENV_NAME_RE.match(env):
+        raise click.BadParameter(
+            f"auth-env must be an env var NAME, not a value (got {env!r}). "
+            "Set the actual token via: export DEFENSECLAW_REGISTRY_TOKEN=...",
+        )
+    return env
+
+
+def _find_source(cfg: Config, sid: str) -> RegistrySource:
+    sid = sid.strip().lower()
+    for s in cfg.registries.sources:
+        if s.id == sid:
+            return s
+    click.echo(f"error: no registry source named {sid!r}", err=True)
+    raise SystemExit(2)
+
+
+def _require_cfg(app: AppContext) -> Config:
+    """Return ``app.cfg`` after asserting it is loaded.
+
+    AppContext.cfg is typed as ``Optional[Config]`` because the
+    bootstrapper instantiates the context before parsing config. By the
+    time any registry subcommand runs, ``main.py`` has already filled
+    ``cfg`` in (or aborted with an error), so the None case here is
+    impossible in practice. We still guard explicitly so that:
+
+      * mypy can narrow the type for every downstream attribute access
+        without a per-callsite ``assert``;
+      * if a future refactor accidentally invokes a registry command on
+        an unbootstrapped context, the failure is loud rather than a
+        confusing AttributeError on ``.registries`` half a stack down.
+    """
+    cfg = _require_cfg(app)
+    if cfg is None:
+        # Should not happen in normal CLI flow — main() always loads cfg
+        # before dispatching. Keep the message terse and operator-facing.
+        raise click.ClickException(
+            "internal: configuration is not loaded; run `defenseclaw setup` first"
+        )
+    return cfg
+
+
+def _emit_json(payload: Any) -> None:
+    click.echo(_json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _source_to_dict(source: RegistrySource) -> dict[str, Any]:
+    return {
+        "id": source.id,
+        "kind": source.kind,
+        "url": source.url,
+        "content": source.content,
+        "auth_env": source.auth_env,
+        "enabled": source.enabled,
+        "auto_sync": source.auto_sync,
+        "sync_interval_hours": source.sync_interval_hours,
+        "last_sync": source.last_sync,
+        "last_status": source.last_status,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Group + add / edit
+# ---------------------------------------------------------------------------
+
+@click.group("registry")
+def registry() -> None:
+    """Manage external skill / MCP catalog sources.
+
+    A "registry source" is a fetchable manifest (corporate HTTPS YAML,
+    smithery.ai, a git repo containing ``defenseclaw-registry.yaml``,
+    etc.) that DefenseClaw ingests on demand. Synced entries are
+    scanned with the existing skill / MCP scanners and clean ones are
+    auto-promoted into ``asset_policy.{skill,mcp}.registry`` so
+    admission decisions can attribute the rule back to its source.
+
+    \b
+    Subcommands:
+      add       Register a new source (interactive or flag-only).
+      edit      Update an existing source.
+      list      Show every configured source.
+      show      Pretty-print a single source.
+      remove    Delete a source and its cache.
+      sync      Fetch + scan + promote one or all sources.
+      entries   Show cached entries (after sync).
+      approve   Mark an entry approved (forces promotion next sync).
+      reject    Mark an entry rejected (always blocked).
+      require   Toggle ``asset_policy.{type}.registry_required``.
+      wizard    First-run interactive add+sync convenience flow.
+    """
+
+
+@registry.command("add")
+@click.argument("source_id", required=False)
+@click.option("--kind", type=click.Choice(REGISTRY_KINDS, case_sensitive=False),
+              default=None, help="Source kind (clawhub / smithery / http_yaml / ...)")
+@click.option("--url", default=None, help="Manifest URL or git repo URL")
+@click.option("--content", type=click.Choice(REGISTRY_CONTENT_TYPES, case_sensitive=False),
+              default=None, help="Declared content type (skill / mcp / both)")
+@click.option("--auth-env", default=None,
+              help="ENV VAR NAME holding a bearer token (never the literal token)")
+@click.option("--enabled/--disabled", default=True, help="Mark source enabled or disabled")
+@click.option("--auto-sync/--no-auto-sync", default=False,
+              help="RESERVED: scheduled sync is not implemented yet. "
+                   "The flag is persisted so a future release can pick it "
+                   "up without a config rewrite. Run `defenseclaw registry "
+                   "sync --all` (or schedule it via cron) for now.")
+@click.option("--sync-interval-hours", type=int, default=24,
+              help="RESERVED: paired with --auto-sync above; ignored at "
+                   "runtime today.")
+@click.option("--non-interactive", is_flag=True,
+              help="Skip prompts; required flags must be present")
+@click.option("--json", "emit_json", is_flag=True, help="Emit JSON")
+@pass_ctx
+def add_cmd(  # noqa: PLR0913 - mirrors the prompt surface
+    app: AppContext,
+    source_id: str | None,
+    kind: str | None,
+    url: str | None,
+    content: str | None,
+    auth_env: str | None,
+    enabled: bool,
+    auto_sync: bool,
+    sync_interval_hours: int,
+    non_interactive: bool,
+    emit_json: bool,
+) -> None:
+    """Register a new registry source.
+
+    Interactive (default): prompts for any missing required field.
+
+    Non-interactive: ``--non-interactive`` plus all required flags.
+
+    Examples:
+
+    \b
+      defenseclaw registry add corp-skills \\
+          --kind http_yaml \\
+          --url https://catalog.example.com/skills.yaml \\
+          --content skill \\
+          --non-interactive
+
+    \b
+      defenseclaw registry add smithery-public \\
+          --kind smithery --content mcp --non-interactive
+
+    \b
+      defenseclaw registry add clawhub --kind clawhub --content skill --non-interactive
+    """
+    cfg = _require_cfg(app)
+
+    if not non_interactive:
+        if not source_id:
+            source_id = click.prompt("Source id (kebab-case)", default="corp-skills")
+        if not kind:
+            kind = click.prompt(
+                f"Kind ({'/'.join(REGISTRY_KINDS)})",
+                default="http_yaml",
+            )
+        if not content:
+            content = click.prompt(
+                f"Content ({'/'.join(REGISTRY_CONTENT_TYPES)})",
+                default="skill",
+            )
+        # URL is optional for clawhub (defaults to npmjs) and for
+        # skills_sh (defaults to https://skills.sh curated view). The
+        # adapter parses the URL field permissively — empty string,
+        # a bare view keyword (curated/all-time/trending/hot), or a
+        # full https URL with query params are all accepted.
+        if kind not in ("clawhub", "skills_sh") and not url:
+            url = click.prompt("Manifest URL", default="")
+        if not auth_env and click.confirm(
+            "Use an auth token (read from an env var)?", default=False,
+        ):
+            auth_env = click.prompt("Env var name", default="DEFENSECLAW_REGISTRY_TOKEN")
+
+    source_id = _require(source_id, "--id", non_interactive=non_interactive)
+    kind = _require(kind, "--kind", non_interactive=non_interactive)
+    content = _require(content, "--content", non_interactive=non_interactive)
+
+    sid = _validate_source_id(source_id)
+    kind = _validate_kind(kind)
+    content = _validate_content(content)
+    auth_env = _validate_auth_env(auth_env or "")
+    url = (url or "").strip()
+    if kind in ("http_yaml", "http_json", "git", "file") and not url:
+        click.echo(
+            f"error: --url is required for kind={kind}",
+            err=True,
+        )
+        raise SystemExit(2)
+
+    if any(s.id == sid for s in cfg.registries.sources):
+        click.echo(f"error: source {sid!r} already exists; use 'registry edit'", err=True)
+        raise SystemExit(2)
+
+    new_source = RegistrySource(
+        id=sid,
+        kind=kind,
+        url=url,
+        content=content,
+        auth_env=auth_env,
+        enabled=enabled,
+        auto_sync=auto_sync,
+        sync_interval_hours=max(0, int(sync_interval_hours or 0)),
+    )
+    cfg.registries.sources.append(new_source)
+    cfg.save()
+
+    if app.logger:
+        app.logger.log_action(
+            "registry-add", "config",
+            f"id={sid} kind={kind} content={content} url={url}",
+        )
+
+    if emit_json:
+        _emit_json({"action": "add", "source": _source_to_dict(new_source)})
+        return
+    ux.ok(f"Registered registry source {sid!r}.")
+    ux.subhead(
+        f"Run `defenseclaw registry sync {sid}` to fetch + scan + promote entries."
+    )
+
+
+@registry.command("edit")
+@click.argument("source_id")
+@click.option("--kind", type=click.Choice(REGISTRY_KINDS, case_sensitive=False),
+              default=None)
+@click.option("--url", default=None)
+@click.option("--content", type=click.Choice(REGISTRY_CONTENT_TYPES, case_sensitive=False),
+              default=None)
+@click.option("--auth-env", default=None,
+              help="Env var NAME (use --clear-auth-env to remove)")
+@click.option("--clear-auth-env", is_flag=True, help="Drop auth_env back to empty")
+@click.option("--enabled/--disabled", default=None,
+              help="Toggle the enabled flag")
+@click.option("--auto-sync/--no-auto-sync", default=None,
+              help="RESERVED: scheduled sync is not implemented yet.")
+@click.option("--sync-interval-hours", type=int, default=None,
+              help="RESERVED: paired with --auto-sync; ignored today.")
+@click.option("--non-interactive", is_flag=True)
+@click.option("--json", "emit_json", is_flag=True)
+@pass_ctx
+def edit_cmd(  # noqa: PLR0913
+    app: AppContext,
+    source_id: str,
+    kind: str | None,
+    url: str | None,
+    content: str | None,
+    auth_env: str | None,
+    clear_auth_env: bool,
+    enabled: bool | None,
+    auto_sync: bool | None,
+    sync_interval_hours: int | None,
+    non_interactive: bool,
+    emit_json: bool,
+) -> None:
+    """Update an existing source. Only the flags you pass are changed."""
+    cfg = _require_cfg(app)
+    source = _find_source(cfg, source_id)
+
+    if not non_interactive:
+        if kind is None:
+            new = click.prompt("Kind", default=source.kind)
+            kind = new if new != source.kind else None
+        if content is None:
+            new = click.prompt("Content", default=source.content)
+            content = new if new != source.content else None
+        if url is None:
+            new = click.prompt("URL", default=source.url or "")
+            url = new if new != source.url else None
+        if auth_env is None and not clear_auth_env:
+            cur = source.auth_env or "(none)"
+            new = click.prompt(
+                "Auth env (or 'none' to clear)", default=cur,
+            )
+            if new == "none" or new == "":
+                clear_auth_env = True
+            elif new != cur:
+                auth_env = new
+
+    if kind is not None:
+        source.kind = _validate_kind(kind)
+    if content is not None:
+        source.content = _validate_content(content)
+    if url is not None:
+        source.url = (url or "").strip()
+    if clear_auth_env:
+        source.auth_env = ""
+    elif auth_env is not None:
+        source.auth_env = _validate_auth_env(auth_env)
+    if enabled is not None:
+        source.enabled = enabled
+    if auto_sync is not None:
+        source.auto_sync = auto_sync
+    if sync_interval_hours is not None:
+        source.sync_interval_hours = max(0, int(sync_interval_hours))
+
+    cfg.save()
+    if app.logger:
+        app.logger.log_action(
+            "registry-edit", "config", f"id={source.id}",
+        )
+
+    if emit_json:
+        _emit_json({"action": "edit", "source": _source_to_dict(source)})
+        return
+    ux.ok(f"Updated registry source {source.id!r}.")
+
+
+# ---------------------------------------------------------------------------
+# list / show / remove
+# ---------------------------------------------------------------------------
+
+@registry.command("list")
+@click.option("--json", "emit_json", is_flag=True)
+@pass_ctx
+def list_cmd(app: AppContext, emit_json: bool) -> None:
+    """List configured registry sources."""
+    cfg = _require_cfg(app)
+    sources = list(cfg.registries.sources)
+    if emit_json:
+        _emit_json([_source_to_dict(s) for s in sources])
+        return
+    if not sources:
+        ux.subhead("No registry sources configured.")
+        ux.subhead("Add one with: defenseclaw registry add <id> ...")
+        return
+    click.echo()
+    ux.section("Registry sources")
+    click.echo(
+        f"  {'ID':<24} {'KIND':<12} {'CONTENT':<8} {'ON':<3} {'LAST SYNC':<22} URL"
+    )
+    click.echo(
+        f"  {'-' * 24} {'-' * 12} {'-' * 8} {'-' * 3} {'-' * 22} {'-' * 32}"
+    )
+    for s in sources:
+        on = "yes" if s.enabled else "no"
+        last = s.last_sync or "-"
+        url = s.url or ""
+        if len(url) > 36:
+            url = url[:33] + "..."
+        click.echo(
+            f"  {s.id:<24} {s.kind:<12} {s.content:<8} {on:<3} {last:<22} {url}"
+        )
+    click.echo()
+
+
+@registry.command("show")
+@click.argument("source_id")
+@click.option("--json", "emit_json", is_flag=True)
+@pass_ctx
+def show_cmd(app: AppContext, source_id: str, emit_json: bool) -> None:
+    """Pretty-print a single source plus a quick verdict summary."""
+    cfg = _require_cfg(app)
+    source = _find_source(cfg, source_id)
+    idx = load_index(cfg.data_dir, source.id)
+    if emit_json:
+        _emit_json({
+            "source": _source_to_dict(source),
+            "index": idx.to_dict(),
+        })
+        return
+    click.echo()
+    state = ux._style("enabled", fg="green") if source.enabled else ux.dim("disabled")
+    click.echo(f"  {ux.bold(source.id)} [{source.kind}/{source.content}] {state}")
+    click.echo(f"    {ux.dim('URL:')}            {source.url or '(none)'}")
+    if source.auth_env:
+        click.echo(f"    {ux.dim('Auth env:')}       {source.auth_env} (value not shown)")
+    click.echo(f"    {ux.dim('Last sync:')}      {source.last_sync or '(never)'}")
+    click.echo(f"    {ux.dim('Last status:')}    {source.last_status or '-'}")
+    click.echo(f"    {ux.dim('Entries:')}        {idx.entry_count}")
+    click.echo(
+        f"    {ux.dim('Verdicts:')}       "
+        f"{idx.clean_count} clean, {idx.warning_count} warning, "
+        f"{idx.blocked_count} blocked, {idx.error_count} error",
+    )
+    click.echo()
+
+
+@registry.command("remove")
+@click.argument("source_id")
+@click.option("--keep-cache", is_flag=True,
+              help="Keep ~/.defenseclaw/registries/<id> on disk")
+@click.option("--non-interactive", is_flag=True)
+@click.option("--json", "emit_json", is_flag=True)
+@pass_ctx
+def remove_cmd(
+    app: AppContext,
+    source_id: str,
+    keep_cache: bool,
+    non_interactive: bool,
+    emit_json: bool,
+) -> None:
+    """Delete a source and (by default) drop its on-disk cache.
+
+    Promoted ``asset_policy`` rules whose ``Reason="registry:<id>"``
+    are removed from config too — the registry source is the source
+    of truth for those entries.
+    """
+    cfg = _require_cfg(app)
+    source = _find_source(cfg, source_id)
+    sid = source.id
+
+    if not non_interactive and not click.confirm(
+        f"Remove registry source {sid!r}?", default=False,
+    ):
+        ux.subhead("Aborted.")
+        return
+
+    cfg.registries.sources = [s for s in cfg.registries.sources if s.id != sid]
+    reason = f"registry:{sid}"
+    cfg.asset_policy.skill.registry = [
+        r for r in cfg.asset_policy.skill.registry if r.reason != reason
+    ]
+    cfg.asset_policy.mcp.registry = [
+        r for r in cfg.asset_policy.mcp.registry if r.reason != reason
+    ]
+    cfg.save()
+
+    if not keep_cache:
+        remove_source_cache(cfg.data_dir, sid)
+
+    if app.logger:
+        app.logger.log_action("registry-remove", "config", f"id={sid}")
+
+    if emit_json:
+        _emit_json({"action": "remove", "source_id": sid})
+        return
+    ux.ok(f"Removed registry source {sid!r}.")
+
+
+# ---------------------------------------------------------------------------
+# sync
+# ---------------------------------------------------------------------------
+
+@registry.command("sync")
+@click.argument("source_ids", nargs=-1)
+@click.option("--all", "sync_all_flag", is_flag=True, help="Sync every enabled source")
+@click.option("--include-disabled", is_flag=True,
+              help="With --all, also sync disabled sources")
+@click.option("--scan/--no-scan", default=True,
+              help="Run skill/MCP scanners on each entry (default: yes)")
+@click.option("--allow-private", is_flag=True,
+              help="Permit RFC1918 / ULA destinations (off by default)")
+@click.option("--no-promote", is_flag=True,
+              help="Don't append promoted rules to asset_policy")
+@click.option("--json", "emit_json", is_flag=True)
+@pass_ctx
+def sync_cmd(  # noqa: PLR0913
+    app: AppContext,
+    source_ids: tuple[str, ...],
+    sync_all_flag: bool,
+    include_disabled: bool,
+    scan: bool,
+    allow_private: bool,
+    no_promote: bool,
+    emit_json: bool,
+) -> None:
+    """Fetch, scan, and promote entries from one or more sources.
+
+    Examples:
+
+    \b
+      defenseclaw registry sync corp-skills
+      defenseclaw registry sync --all
+      defenseclaw registry sync --all --no-scan       # metadata-only refresh
+      defenseclaw registry sync corp-skills --no-promote   # preview
+    """
+    cfg = _require_cfg(app)
+
+    callback: ScanCallback | None = (
+        _make_scan_callback(app) if scan else None
+    )
+
+    if sync_all_flag:
+        if source_ids:
+            click.echo(
+                "error: pass either --all or explicit source ids, not both",
+                err=True,
+            )
+            raise SystemExit(2)
+        reports = sync_all(
+            cfg,
+            cfg.data_dir,
+            scan_callback=callback,
+            allow_private=allow_private,
+            auto_promote=not no_promote,
+            include_disabled=include_disabled,
+        )
+    else:
+        if not source_ids:
+            click.echo(
+                "error: pass at least one source id, or --all",
+                err=True,
+            )
+            raise SystemExit(2)
+        reports = []
+        for sid in source_ids:
+            source = _find_source(cfg, sid)
+            reports.append(sync_source(
+                cfg,
+                cfg.data_dir,
+                source,
+                scan_callback=callback,
+                allow_private=allow_private,
+                auto_promote=not no_promote,
+                save=False,
+            ))
+        cfg.save()
+
+    if emit_json:
+        _emit_json([r.to_dict() for r in reports])
+        return
+    _print_sync_reports(reports)
+
+
+def _print_sync_reports(reports: list[SyncReport]) -> None:
+    if not reports:
+        ux.subhead("Nothing to sync.")
+        return
+    click.echo()
+    ux.section("Sync results")
+    click.echo(
+        f"  {'SOURCE':<24} {'FETCHED':<8} {'SCANNED':<8} {'PROMOTED':<10} {'STATUS'}"
+    )
+    click.echo(
+        f"  {'-' * 24} {'-' * 8} {'-' * 8} {'-' * 10} {'-' * 32}"
+    )
+    for r in reports:
+        promoted = f"{r.promoted_skills}/{r.promoted_mcps}"
+        status = "ok" if r.ok() else "error"
+        click.echo(
+            f"  {r.source_id:<24} {r.fetched:<8} {r.scanned:<8} {promoted:<10} {status}"
+        )
+    for r in reports:
+        for err in r.errors:
+            click.echo(f"  {ux.dim('!')} {r.source_id}: {err}")
+    click.echo()
+
+
+# Lazy scanner factory — keeps the heavy SDK import off the hot path
+# of `registry list` / `registry show`. Returns None when scanner SDKs
+# aren't installed so the operator still gets a metadata-only sync.
+def _make_scan_callback(app: AppContext) -> ScanCallback:
+    cfg = _require_cfg(app)
+
+    def _scan(source: RegistrySource, entry: ManifestEntry):  # type: ignore[no-untyped-def]
+        if entry.is_skill():
+            return _run_skill_scan(app, cfg, source, entry)
+        if entry.is_mcp():
+            return _run_mcp_scan(app, cfg, source, entry)
+        return None
+
+    return _scan
+
+
+def _run_skill_scan(app: AppContext, cfg: Config, source: RegistrySource, entry: ManifestEntry):  # type: ignore[no-untyped-def]
+    """Best-effort skill scan via the SDK wrapper.
+
+    The full clawhub:// / https:// download flow is delegated to the
+    existing helpers in :mod:`cmd_skill` so we don't duplicate the
+    archive-extraction logic. Failures fall through to a None return,
+    which leaves the entry at status="pending" — operators can then
+    use ``registry approve`` to promote it manually.
+    """
+    # Optional dep: the skill scanner SDK ships separately from the
+    # CLI so on a stripped install (operator without the scanner
+    # extras) we degrade to "leave the entry pending" instead of
+    # crashing the whole sync. The import is purely a presence
+    # check; the actual scan goes through cmd_skill below.
+    try:
+        from defenseclaw.scanner.skill import SkillScannerWrapper  # noqa: F401
+    except ImportError:
+        return None
+    if not entry.source_url:
+        return None
+    try:
+        from defenseclaw.commands import cmd_skill  # local import to avoid cycle
+    except ImportError:
+        return None
+
+    target = entry.source_url
+    if target.startswith("clawhub://"):
+        return _scan_skill_via_clawhub(cmd_skill, app, target)
+    if target.startswith(("http://", "https://")):
+        return _scan_skill_via_http(cmd_skill, app, target)
+    return None
+
+
+def _scan_skill_via_clawhub(cmd_skill_module, app: AppContext, uri: str):  # type: ignore[no-untyped-def]
+    # Reuse the existing helper so policy/option behaviour stays in
+    # lockstep. The helper exits the process on hard errors; we wrap
+    # that in a try so a single failure doesn't kill `registry sync`.
+    try:
+        cmd_skill_module._scan_from_clawhub(app, uri, as_json=True)  # type: ignore[attr-defined]
+    except SystemExit:
+        return None
+    except Exception:  # noqa: BLE001 - keep the loop alive
+        return None
+    return None
+
+
+def _scan_skill_via_http(cmd_skill_module, app: AppContext, url: str):  # type: ignore[no-untyped-def]
+    try:
+        cmd_skill_module._scan_from_http(app, url, as_json=True)  # type: ignore[attr-defined]
+    except SystemExit:
+        return None
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _run_mcp_scan(app: AppContext, cfg: Config, source: RegistrySource, entry: ManifestEntry):  # type: ignore[no-untyped-def]
+    """Best-effort MCP scan via the SDK wrapper."""
+    try:
+        from defenseclaw.config import MCPServerEntry
+        from defenseclaw.scanner.mcp import MCPScannerWrapper
+    except ImportError:
+        return None
+    try:
+        scanner = MCPScannerWrapper(
+            cfg.scanners.mcp_scanner,
+            cfg.effective_inspect_llm(),
+            cfg.cisco_ai_defense,
+            llm=cfg.resolve_llm("scanners.mcp"),
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+    transport = entry.transport or "stdio"
+    if transport == "stdio":
+        if not entry.command:
+            return None
+        server = MCPServerEntry(
+            name=entry.name,
+            command=entry.command,
+            args=list(entry.args),
+            env={k: os.environ.get(k, "") for k in entry.env_required},
+        )
+        try:
+            return scanner.scan(entry.name, server_entry=server)
+        except SystemExit:
+            return None
+        except Exception:  # noqa: BLE001
+            return None
+    if not entry.url:
+        return None
+    try:
+        return scanner.scan(entry.url)
+    except SystemExit:
+        return None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ---------------------------------------------------------------------------
+# entries / approve / reject
+# ---------------------------------------------------------------------------
+
+@registry.command("entries")
+@click.argument("source_id")
+@click.option("--type", "entry_type",
+              type=click.Choice(["skill", "mcp", "all"], case_sensitive=False),
+              default="all")
+@click.option("--status",
+              type=click.Choice(["pending", "clean", "warning", "blocked", "error", "all"],
+                                case_sensitive=False),
+              default="all")
+@click.option("--json", "emit_json", is_flag=True)
+@pass_ctx
+def entries_cmd(
+    app: AppContext,
+    source_id: str,
+    entry_type: str,
+    status: str,
+    emit_json: bool,
+) -> None:
+    """Show cached entries for a source. Run after ``registry sync``."""
+    cfg = _require_cfg(app)
+    source = _find_source(cfg, source_id)
+    idx = load_index(cfg.data_dir, source.id)
+    rows = _filter_verdicts(idx, entry_type, status)
+    if emit_json:
+        _emit_json([v.to_dict() for v in rows])
+        return
+    if not rows:
+        ux.subhead(f"No matching entries (type={entry_type}, status={status}).")
+        return
+    click.echo()
+    ux.section(f"Entries for {source.id}")
+    click.echo(
+        f"  {'NAME':<32} {'TYPE':<6} {'STATUS':<10} {'SEV':<8} {'A/R'}"
+    )
+    click.echo(f"  {'-' * 32} {'-' * 6} {'-' * 10} {'-' * 8} {'-' * 3}")
+    for v in rows:
+        a = "A" if v.approved else "-"
+        r = "R" if v.rejected else "-"
+        click.echo(
+            f"  {v.name:<32} {v.type:<6} {v.status:<10} {(v.severity or '-'):<8} {a}{r}",
+        )
+    click.echo()
+
+
+def _filter_verdicts(idx: SourceIndex, type_: str, status: str) -> list[EntryVerdict]:
+    out: list[EntryVerdict] = []
+    type_ = type_.lower()
+    status = status.lower()
+    for v in idx.verdicts:
+        if type_ != "all" and v.type != type_:
+            continue
+        if status != "all" and v.status != status:
+            continue
+        out.append(v)
+    return out
+
+
+@registry.command("approve")
+@click.argument("source_id")
+@click.argument("entry_name")
+@click.option("--type", "entry_type",
+              type=click.Choice(["skill", "mcp"], case_sensitive=False),
+              required=True)
+@click.option("--repromote/--no-repromote", default=True,
+              help="Re-run asset_policy promotion against the cached "
+                   "manifest immediately (no network call).")
+@click.option("--json", "emit_json", is_flag=True)
+@pass_ctx
+def approve_cmd(
+    app: AppContext,
+    source_id: str,
+    entry_name: str,
+    entry_type: str,
+    repromote: bool,
+    emit_json: bool,
+) -> None:
+    """Mark an entry approved. Approved entries promote even if the
+    scanner hasn't run, and are preserved across syncs.
+
+    By default the asset_policy promotion is re-run immediately
+    against the cached manifest so the new rule lands without a
+    network round-trip. Use ``--no-repromote`` if you want to defer
+    the update to the next ``registry sync``.
+    """
+    _do_manual_verdict(
+        app, source_id, entry_name, entry_type,
+        approved=True, rejected=False,
+        action_label="approve", repromote=repromote, emit_json=emit_json,
+    )
+
+
+@registry.command("reject")
+@click.argument("source_id")
+@click.argument("entry_name")
+@click.option("--type", "entry_type",
+              type=click.Choice(["skill", "mcp"], case_sensitive=False),
+              required=True)
+@click.option("--repromote/--no-repromote", default=True,
+              help="Re-run asset_policy promotion against the cached "
+                   "manifest immediately (no network call).")
+@click.option("--json", "emit_json", is_flag=True)
+@pass_ctx
+def reject_cmd(
+    app: AppContext,
+    source_id: str,
+    entry_name: str,
+    entry_type: str,
+    repromote: bool,
+    emit_json: bool,
+) -> None:
+    """Mark an entry rejected. Rejected entries are NEVER promoted.
+
+    By default the asset_policy promotion is re-run immediately
+    against the cached manifest so any prior rule for this entry is
+    cleared. Use ``--no-repromote`` to defer to the next sync.
+    """
+    _do_manual_verdict(
+        app, source_id, entry_name, entry_type,
+        approved=False, rejected=True,
+        action_label="reject", repromote=repromote, emit_json=emit_json,
+    )
+
+
+def _do_manual_verdict(
+    app: AppContext,
+    source_id: str,
+    entry_name: str,
+    entry_type: str,
+    *,
+    approved: bool,
+    rejected: bool,
+    action_label: str,
+    repromote: bool,
+    emit_json: bool,
+) -> None:
+    """Shared implementation for approve_cmd / reject_cmd.
+
+    Toggles the cached verdict bit, then re-runs promotion against
+    the cached manifest (no network). Falls back to surfacing a
+    clear error when there's no cached manifest yet — the previous
+    implementation would silently swallow a fetch failure here and
+    leave the operator believing the rule had landed.
+    """
+    cfg = _require_cfg(app)
+    source = _find_source(cfg, source_id)
+    verdict = manual_set_verdict(
+        cfg.data_dir, source.id, entry_type.lower(), entry_name,
+        approved=approved, rejected=rejected,
+    )
+    if verdict is None:
+        click.echo(
+            f"error: no cached entry {entry_type}:{entry_name} in {source.id} "
+            "(run `registry sync` first)",
+            err=True,
+        )
+        raise SystemExit(2)
+
+    promoted: tuple[int, int] | None = None
+    if repromote:
+        promoted = promote_from_cache(
+            cfg, cfg.data_dir, source, save=True,
+        )
+
+    if app.logger:
+        app.logger.log_action(
+            f"registry-{action_label}", "config",
+            f"id={source.id} {entry_type}:{entry_name}",
+        )
+
+    if emit_json:
+        out: dict[str, Any] = {
+            "action": action_label,
+            "verdict": verdict.to_dict(),
+        }
+        if promoted is not None:
+            out["promoted_skills"] = promoted[0]
+            out["promoted_mcps"] = promoted[1]
+        elif repromote:
+            out["warning"] = (
+                "no cached manifest; rule will land on next "
+                "`registry sync`"
+            )
+        _emit_json(out)
+        return
+
+    label = "Approved" if approved else "Rejected"
+    ux.ok(f"{label} {entry_type}:{entry_name} from {source.id}.")
+    if repromote and promoted is None:
+        ux.subhead(
+            "No cached manifest yet — run `defenseclaw registry sync "
+            f"{source.id}` to fetch and promote.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# require — toggle asset_policy.{type}.registry_required
+# ---------------------------------------------------------------------------
+
+@registry.command("require")
+@click.option("--type", "asset_type",
+              type=click.Choice(["skill", "mcp", "plugin"], case_sensitive=False),
+              required=True)
+@click.option("--enabled/--disabled", required=True,
+              help="Flip asset_policy.<type>.registry_required")
+@click.option("--json", "emit_json", is_flag=True)
+@pass_ctx
+def require_cmd(
+    app: AppContext,
+    asset_type: str,
+    enabled: bool,
+    emit_json: bool,
+) -> None:
+    """Toggle ``asset_policy.<type>.registry_required``.
+
+    When enabled, an asset must match a rule in the (type) registry
+    list to bypass the default deny — otherwise the configured
+    ``default`` action applies. The flag is fail-closed by default at
+    the gateway: an empty registry list with require=on means "no
+    asset is approved".
+    """
+    cfg = _require_cfg(app)
+    target = getattr(cfg.asset_policy, asset_type.lower())
+    target.registry_required = bool(enabled)
+    cfg.save()
+    asset = asset_type.lower()
+    empty_registry = len(target.registry) == 0
+    empty_action = getattr(target, "registry_empty_action", "deny")
+
+    if emit_json:
+        _emit_json({
+            "asset_type": asset,
+            "registry_required": target.registry_required,
+            "registry_size": len(target.registry),
+            "registry_empty_action": empty_action,
+        })
+        return
+
+    state = "required" if enabled else "optional"
+    ux.ok(f"asset_policy.{asset}.registry is now {state}.")
+    if not enabled:
+        return
+
+    # Operators routinely flip require=on without realising the
+    # downstream gateway will deny every asset whose name isn't on
+    # the (often-empty) registry list. Spell that out, in colour, so
+    # the next `claw run` doesn't surprise them. The empty-action is
+    # configurable (deny / warn / allow) but defaults to "deny" — we
+    # surface whichever value is live.
+    if empty_registry:
+        if empty_action == "deny":
+            ux.warn(
+                f"registries.{asset}.registry is EMPTY and "
+                f"registry_empty_action='deny' — every {asset} will be "
+                "blocked at admission until you `registry sync` (or add "
+                "manual rules).",
+            )
+        elif empty_action == "warn":
+            ux.warn(
+                f"registries.{asset}.registry is empty and "
+                "registry_empty_action='warn' — assets will be allowed "
+                "but flagged in the audit log. Run `registry sync` to "
+                "populate the list.",
+            )
+        else:
+            ux.subhead(
+                f"registries.{asset}.registry is empty and "
+                f"registry_empty_action={empty_action!r} — admission "
+                "will fall back to the configured default action.",
+            )
+    else:
+        ux.subhead(
+            f"registry has {len(target.registry)} entries; "
+            f"registry_empty_action={empty_action!r} (only matters when "
+            "the list is empty).",
+        )
+
+
+# ---------------------------------------------------------------------------
+# wizard — convenience flow that bundles add + immediate sync
+# ---------------------------------------------------------------------------
+
+@registry.command("wizard")
+@pass_ctx
+@click.pass_context
+def wizard_cmd(ctx: click.Context, app: AppContext) -> None:
+    """Interactive add+sync flow for first-run discoverability."""
+    if not sys.stdin.isatty():
+        click.echo("error: wizard requires an interactive terminal", err=True)
+        raise SystemExit(2)
+
+    click.echo()
+    ux.section("Register a new registry source")
+    sid = click.prompt("Source id (kebab-case)", default="corp-skills")
+    kind = click.prompt(
+        f"Kind ({'/'.join(REGISTRY_KINDS)})", default="http_yaml",
+    )
+    content = click.prompt(
+        f"Content ({'/'.join(REGISTRY_CONTENT_TYPES)})", default="skill",
+    )
+    url = ""
+    if kind == "skills_sh":
+        url = click.prompt(
+            "Manifest URL or view (curated/all-time/trending/hot)",
+            default="curated",
+        )
+    elif kind != "clawhub":
+        url = click.prompt("Manifest URL")
+    auth_env = ""
+    if click.confirm("Use an auth token (read from an env var)?", default=False):
+        auth_env = click.prompt("Env var name", default="DEFENSECLAW_REGISTRY_TOKEN")
+
+    ctx.invoke(
+        add_cmd,
+        source_id=sid,
+        kind=kind,
+        url=url,
+        content=content,
+        auth_env=auth_env or None,
+        enabled=True,
+        auto_sync=False,
+        sync_interval_hours=24,
+        non_interactive=True,
+        emit_json=False,
+    )
+
+    if click.confirm("Sync now?", default=True):
+        scan = click.confirm("Run scanners during sync?", default=True)
+        ctx.invoke(
+            sync_cmd,
+            source_ids=(sid,),
+            sync_all_flag=False,
+            include_disabled=False,
+            scan=scan,
+            allow_private=False,
+            no_promote=False,
+            emit_json=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers exposed for tests
+# ---------------------------------------------------------------------------
+
+def _config_dump_for_test(cfg: Config) -> dict[str, Any]:
+    """Test helper — return the config slice the registry CLI mutates."""
+    return {
+        "registries": [_source_to_dict(s) for s in cfg.registries.sources],
+        "asset_policy.skill.registry": [
+            asdict(r) for r in cfg.asset_policy.skill.registry
+        ],
+        "asset_policy.mcp.registry": [
+            asdict(r) for r in cfg.asset_policy.mcp.registry
+        ],
+    }

--- a/cli/defenseclaw/commands/cmd_registry.py
+++ b/cli/defenseclaw/commands/cmd_registry.py
@@ -59,7 +59,8 @@ from defenseclaw.registries import (
 from defenseclaw.registries import (
     remove_source as remove_source_cache,
 )
-from defenseclaw.registries.manifest import ManifestEntry
+from defenseclaw.registries.adapters import IngestError, fetch_manifest
+from defenseclaw.registries.manifest import ManifestEntry, ManifestError
 from defenseclaw.registries.sync import (
     ScanCallback,
     manual_set_verdict,
@@ -134,6 +135,35 @@ def _validate_auth_env(env: str) -> str:
     return env
 
 
+def _validate_file_url(kind: str, url: str) -> None:
+    """For ``kind=file``, fail fast at add/edit time if the path isn't
+    absolute.
+
+    The file adapter rejects relative paths at sync time (because
+    ``~/.defenseclaw`` and the operator's CWD aren't guaranteed to
+    line up at admission), but discovering that ten minutes later
+    when the cron job fires is poor UX. Catch the same condition at
+    config-write time so the operator gets the error before they
+    walk away.
+    """
+    if kind != "file":
+        return
+    val = (url or "").strip()
+    # Tolerate a leading file:// scheme — the adapter strips it
+    # before checking, so we should accept the same form here.
+    bare = val[len("file://"):] if val.lower().startswith("file://") else val
+    if not bare:
+        # The caller (add/edit) already enforces a non-empty URL for
+        # kind=file via _require / the per-kind url-required block.
+        return
+    expanded = os.path.expanduser(bare)
+    if not os.path.isabs(expanded):
+        raise click.BadParameter(
+            f"--url for kind=file must be an absolute path (got {url!r}). "
+            "Use $PWD/manifest.yaml or a fully-qualified path.",
+        )
+
+
 def _find_source(cfg: Config, sid: str) -> RegistrySource:
     sid = sid.strip().lower()
     for s in cfg.registries.sources:
@@ -206,9 +236,10 @@ def registry() -> None:
     Subcommands:
       add       Register a new source (interactive or flag-only).
       edit      Update an existing source.
-      list      Show every configured source.
+      list      Show every configured source (with entry counts).
       show      Pretty-print a single source.
       remove    Delete a source and its cache.
+      test      Dry-run fetch + parse — no cache or policy writes.
       sync      Fetch + scan + promote one or all sources.
       entries   Show cached entries (after sync).
       approve   Mark an entry approved (forces promotion next sync).
@@ -317,6 +348,7 @@ def add_cmd(  # noqa: PLR0913 - mirrors the prompt surface
             err=True,
         )
         raise SystemExit(2)
+    _validate_file_url(kind, url)
 
     if any(s.id == sid for s in cfg.registries.sources):
         click.echo(f"error: source {sid!r} already exists; use 'registry edit'", err=True)
@@ -383,11 +415,27 @@ def edit_cmd(  # noqa: PLR0913
     non_interactive: bool,
     emit_json: bool,
 ) -> None:
-    """Update an existing source. Only the flags you pass are changed."""
+    """Update an existing source. Only the flags you pass are changed.
+
+    With no mutating flags, the command falls into an interactive
+    prompt that walks every editable field with the current value as
+    the default. As soon as **any** mutating flag is passed
+    (``--kind`` / ``--url`` / ``--content`` / ``--auth-env`` /
+    ``--clear-auth-env`` / ``--enabled`` / ``--disabled`` /
+    ``--auto-sync`` / ``--no-auto-sync`` / ``--sync-interval-hours``
+    / ``--non-interactive``), prompts are suppressed entirely so the
+    docstring promise — "only the flags you pass are changed" —
+    holds. Use the bare form (no flags) when you want to re-confirm
+    every field.
+    """
     cfg = _require_cfg(app)
     source = _find_source(cfg, source_id)
 
-    if not non_interactive:
+    any_mutating = any(v is not None for v in (
+        kind, content, url, auth_env, enabled, auto_sync, sync_interval_hours,
+    )) or clear_auth_env
+
+    if not non_interactive and not any_mutating:
         if kind is None:
             new = click.prompt("Kind", default=source.kind)
             kind = new if new != source.kind else None
@@ -424,6 +472,11 @@ def edit_cmd(  # noqa: PLR0913
     if sync_interval_hours is not None:
         source.sync_interval_hours = max(0, int(sync_interval_hours))
 
+    # Validate the post-edit (kind, url) pair so flipping an
+    # ``http_yaml`` source to ``kind=file`` without re-supplying the
+    # ``--url`` (or vice versa) fails before the next sync.
+    _validate_file_url(source.kind, source.url)
+
     cfg.save()
     if app.logger:
         app.logger.log_action(
@@ -444,11 +497,36 @@ def edit_cmd(  # noqa: PLR0913
 @click.option("--json", "emit_json", is_flag=True)
 @pass_ctx
 def list_cmd(app: AppContext, emit_json: bool) -> None:
-    """List configured registry sources."""
+    """List configured registry sources.
+
+    The ``ENTRIES`` column reports cached counts as
+    ``total (clean/warning/blocked)`` from the on-disk index — a
+    dash means the source has never been synced. Counts are
+    deliberately read fresh from ``index.json`` rather than the
+    config file so manual ``approve`` / ``reject`` calls (which
+    rewrite the index) are reflected without forcing an additional
+    config write.
+    """
     cfg = _require_cfg(app)
     sources = list(cfg.registries.sources)
+    indices: dict[str, SourceIndex] = {
+        s.id: load_index(cfg.data_dir, s.id) for s in sources
+    }
     if emit_json:
-        _emit_json([_source_to_dict(s) for s in sources])
+        out: list[dict[str, Any]] = []
+        for s in sources:
+            d = _source_to_dict(s)
+            idx = indices.get(s.id)
+            if idx is not None:
+                d["entries"] = {
+                    "total": idx.entry_count,
+                    "clean": idx.clean_count,
+                    "warning": idx.warning_count,
+                    "blocked": idx.blocked_count,
+                    "error": idx.error_count,
+                }
+            out.append(d)
+        _emit_json(out)
         return
     if not sources:
         ux.subhead("No registry sources configured.")
@@ -457,21 +535,33 @@ def list_cmd(app: AppContext, emit_json: bool) -> None:
     click.echo()
     ux.section("Registry sources")
     click.echo(
-        f"  {'ID':<24} {'KIND':<12} {'CONTENT':<8} {'ON':<3} {'LAST SYNC':<22} URL"
+        f"  {'ID':<24} {'KIND':<12} {'CONTENT':<8} {'ON':<3} "
+        f"{'ENTRIES':<18} {'LAST SYNC':<22} URL"
     )
     click.echo(
-        f"  {'-' * 24} {'-' * 12} {'-' * 8} {'-' * 3} {'-' * 22} {'-' * 32}"
+        f"  {'-' * 24} {'-' * 12} {'-' * 8} {'-' * 3} "
+        f"{'-' * 18} {'-' * 22} {'-' * 32}"
     )
     for s in sources:
         on = "yes" if s.enabled else "no"
         last = s.last_sync or "-"
         url = s.url or ""
-        if len(url) > 36:
-            url = url[:33] + "..."
+        if len(url) > 32:
+            url = url[:29] + "..."
+        idx = indices.get(s.id)
+        if idx is None or idx.entry_count == 0 and not s.last_sync:
+            entries = "-"
+        else:
+            entries = (
+                f"{idx.entry_count} "
+                f"({idx.clean_count}/{idx.warning_count}/{idx.blocked_count})"
+            )
         click.echo(
-            f"  {s.id:<24} {s.kind:<12} {s.content:<8} {on:<3} {last:<22} {url}"
+            f"  {s.id:<24} {s.kind:<12} {s.content:<8} {on:<3} "
+            f"{entries:<18} {last:<22} {url}"
         )
     click.echo()
+    ux.subhead("ENTRIES column: total (clean/warning/blocked)")
 
 
 @registry.command("show")
@@ -556,6 +646,120 @@ def remove_cmd(
         _emit_json({"action": "remove", "source_id": sid})
         return
     ux.ok(f"Removed registry source {sid!r}.")
+
+
+# ---------------------------------------------------------------------------
+# test — dry-run fetch + parse, no cache / no asset_policy mutation
+# ---------------------------------------------------------------------------
+
+@registry.command("test")
+@click.argument("source_id")
+@click.option("--allow-private", is_flag=True,
+              help="Permit RFC1918 / ULA destinations (off by default)")
+@click.option("--show-entries", "-e", is_flag=True,
+              help="Print every entry name + type instead of just summary")
+@click.option("--limit", type=int, default=20,
+              help="With --show-entries, cap the row count (default 20)")
+@click.option("--json", "emit_json", is_flag=True)
+@pass_ctx
+def test_cmd(
+    app: AppContext,
+    source_id: str,
+    allow_private: bool,
+    show_entries: bool,
+    limit: int,
+    emit_json: bool,
+) -> None:
+    """Dry-run a source: fetch + parse the manifest, no cache writes.
+
+    Useful before ``registry sync`` to confirm credentials and
+    the manifest's shape without touching ``index.json``,
+    ``manifest.yaml``, or ``asset_policy``. The SSRF guard, size
+    cap, redirect policy, and content-type filter all apply
+    exactly as they do in the real sync path so a successful
+    ``registry test`` is a strong signal that the next sync will
+    behave the same way.
+    """
+    cfg = _require_cfg(app)
+    source = _find_source(cfg, source_id)
+
+    try:
+        manifest, raw = fetch_manifest(source, allow_private=allow_private)
+    except (IngestError, ManifestError) as exc:
+        # Mirror the wording of sync_source's report.errors so log
+        # consumers don't have to special-case test-vs-sync.
+        msg = f"fetch failed: {exc}"
+        if emit_json:
+            _emit_json({
+                "ok": False,
+                "source_id": source.id,
+                "error": str(exc),
+            })
+        else:
+            click.echo(f"error: {msg}", err=True)
+        raise SystemExit(2) from exc
+
+    # Apply the same content filter sync_source does so the dry-run
+    # exactly matches what would land in the cache.
+    filtered = manifest.filter_by_content(source.content)
+
+    skill_count = sum(1 for e in filtered if e.is_skill())
+    mcp_count = sum(1 for e in filtered if e.is_mcp())
+
+    payload: dict[str, Any] = {
+        "ok": True,
+        "source_id": source.id,
+        "publisher": manifest.publisher,
+        "schema_version": manifest.schema_version,
+        "generated_at": manifest.generated_at,
+        "fetched_bytes": len(raw),
+        "entries": {
+            "total": len(filtered),
+            "skills": skill_count,
+            "mcps": mcp_count,
+        },
+    }
+
+    if show_entries:
+        rows = []
+        for entry in filtered[: max(0, int(limit))]:
+            rows.append({
+                "name": entry.name,
+                "type": entry.type,
+                "version": entry.version,
+                "publisher": entry.publisher or manifest.publisher,
+            })
+        payload["entries"]["rows"] = rows
+        payload["entries"]["truncated"] = len(filtered) > len(rows)
+
+    if emit_json:
+        _emit_json(payload)
+        return
+
+    click.echo()
+    ux.section(f"Dry-run: {source.id}")
+    click.echo(f"  {ux.dim('Publisher:')}      {manifest.publisher or '(none)'}")
+    click.echo(f"  {ux.dim('Schema:')}         v{manifest.schema_version}")
+    if manifest.generated_at:
+        click.echo(f"  {ux.dim('Generated at:')}   {manifest.generated_at}")
+    click.echo(f"  {ux.dim('Bytes fetched:')}  {len(raw):,}")
+    click.echo(
+        f"  {ux.dim('Entries:')}        {len(filtered)} "
+        f"({skill_count} skills, {mcp_count} mcps)"
+    )
+    if show_entries and filtered:
+        click.echo()
+        ux.subhead(f"First {min(limit, len(filtered))} entries:")
+        for entry in filtered[: max(0, int(limit))]:
+            ver = f" v{entry.version}" if entry.version else ""
+            click.echo(f"    [{entry.type}] {entry.name}{ver}")
+        if len(filtered) > limit:
+            ux.subhead(f"  … {len(filtered) - limit} more (raise --limit to see)")
+    click.echo()
+    ux.ok(
+        f"Dry-run successful — run `defenseclaw registry sync {source.id}` "
+        "to persist + scan + promote.",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -795,6 +999,10 @@ def _run_mcp_scan(app: AppContext, cfg: Config, source: RegistrySource, entry: M
               type=click.Choice(["pending", "clean", "warning", "blocked", "error", "all"],
                                 case_sensitive=False),
               default="all")
+@click.option("--approved", is_flag=True,
+              help="Show only operator-approved entries")
+@click.option("--rejected", is_flag=True,
+              help="Show only operator-rejected entries")
 @click.option("--json", "emit_json", is_flag=True)
 @pass_ctx
 def entries_cmd(
@@ -802,18 +1010,37 @@ def entries_cmd(
     source_id: str,
     entry_type: str,
     status: str,
+    approved: bool,
+    rejected: bool,
     emit_json: bool,
 ) -> None:
-    """Show cached entries for a source. Run after ``registry sync``."""
+    """Show cached entries for a source. Run after ``registry sync``.
+
+    The ``--approved`` / ``--rejected`` flags filter on the
+    operator-override bits stored alongside the scanner verdict;
+    these are independent of ``--status`` so combinations like
+    ``--rejected --status warning`` still work (operator rejected
+    an entry the scanner had only warned about). Both flags
+    together returns the empty set by definition because
+    ``approve`` clears ``rejected`` and vice versa.
+    """
     cfg = _require_cfg(app)
     source = _find_source(cfg, source_id)
     idx = load_index(cfg.data_dir, source.id)
-    rows = _filter_verdicts(idx, entry_type, status)
+    rows = _filter_verdicts(
+        idx, entry_type, status,
+        only_approved=approved, only_rejected=rejected,
+    )
     if emit_json:
         _emit_json([v.to_dict() for v in rows])
         return
     if not rows:
-        ux.subhead(f"No matching entries (type={entry_type}, status={status}).")
+        bits = [f"type={entry_type}", f"status={status}"]
+        if approved:
+            bits.append("approved")
+        if rejected:
+            bits.append("rejected")
+        ux.subhead(f"No matching entries ({', '.join(bits)}).")
         return
     click.echo()
     ux.section(f"Entries for {source.id}")
@@ -830,7 +1057,14 @@ def entries_cmd(
     click.echo()
 
 
-def _filter_verdicts(idx: SourceIndex, type_: str, status: str) -> list[EntryVerdict]:
+def _filter_verdicts(
+    idx: SourceIndex,
+    type_: str,
+    status: str,
+    *,
+    only_approved: bool = False,
+    only_rejected: bool = False,
+) -> list[EntryVerdict]:
     out: list[EntryVerdict] = []
     type_ = type_.lower()
     status = status.lower()
@@ -838,6 +1072,10 @@ def _filter_verdicts(idx: SourceIndex, type_: str, status: str) -> list[EntryVer
         if type_ != "all" and v.type != type_:
             continue
         if status != "all" and v.status != status:
+            continue
+        if only_approved and not v.approved:
+            continue
+        if only_rejected and not v.rejected:
             continue
         out.append(v)
     return out

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -2873,6 +2873,167 @@ def setup_notifications(
         )
 
 
+# ``setup notifications`` is already a one-shot command (action is a
+# positional argument, not a subgroup) so we can't attach
+# ``set <key> <value>`` to it without breaking the existing
+# ``defenseclaw setup notifications on`` form. A flat sibling command
+# keeps the new surface discoverable (``setup --help`` lists it next
+# to ``notifications``) and avoids click's argument-vs-subcommand
+# parsing ambiguity.
+_NOTIFICATION_SLOTS: dict[str, tuple[str, str]] = {
+    # slot name (operator-typed)  ->  (object_path, attr)
+    # Categories (event types) live on the NotificationsConfig itself.
+    "block_enforced":     ("",        "block_enforced"),
+    "block_would_block":  ("",        "block_would_block"),
+    "hitl_approval":      ("",        "hitl_approval"),
+    # Sources live on the nested NotificationSourceFilter struct.
+    "sources.hook":       ("sources", "hook"),
+    "sources.guardrail":  ("sources", "guardrail"),
+    "sources.asset_policy": ("sources", "asset_policy"),
+    # Friendlier short forms for the source toggles. Keep both so
+    # ``--help`` callers and operators copying from ``status`` output
+    # land on a working invocation either way.
+    "hook":               ("sources", "hook"),
+    "guardrail":          ("sources", "guardrail"),
+    "asset_policy":       ("sources", "asset_policy"),
+}
+
+
+@setup.command("notifications-set")
+@click.argument(
+    "slot",
+    type=click.Choice(sorted(set(_NOTIFICATION_SLOTS.keys())), case_sensitive=False),
+)
+@click.argument(
+    "value",
+    type=click.Choice(("on", "off"), case_sensitive=False),
+)
+@click.option(
+    "--restart/--no-restart", default=True, show_default=True,
+    help=(
+        "Restart defenseclaw-gateway after the toggle. The notifier "
+        "dispatcher reads its filters at sidecar boot, so a flip "
+        "without restart leaves the running process on the previous "
+        "filter set."
+    ),
+)
+@pass_ctx
+def setup_notifications_set(
+    app: AppContext,
+    slot: str,
+    value: str,
+    restart: bool,
+) -> None:
+    """Toggle a single notifications category or source.
+
+    ``slot`` is one of the dotted paths below; ``value`` is ``on`` or
+    ``off``. The master switch (``notifications.enabled``) is left
+    alone — use ``defenseclaw setup notifications on/off`` for that.
+
+    \b
+    Categories (event types):
+      block_enforced       Real blocks (default: on).
+      block_would_block    Audit-mode blocks (default: on).
+      hitl_approval        Human-in-the-loop prompts (default: on).
+
+    \b
+    Sources (subsystem of origin):
+      sources.hook         Per-tool hooks (claude_code / codex / ...).
+      sources.guardrail    Guardrail verdicts.
+      sources.asset_policy Skill / MCP allow-list blocks.
+
+    \b
+    Examples:
+      defenseclaw setup notifications-set sources.hook off
+      defenseclaw setup notifications-set hitl_approval on --no-restart
+      defenseclaw setup notifications-set guardrail off  # short form
+    """
+    cfg = app.cfg
+    nc = cfg.notifications
+
+    obj_path, attr = _NOTIFICATION_SLOTS[slot.lower()]
+    target = nc if not obj_path else getattr(nc, obj_path)
+    current = bool(getattr(target, attr))
+    desired = value.lower() == "on"
+
+    if current == desired:
+        ux.subhead(
+            f"notifications.{slot} already {value.lower()}; nothing to change.",
+        )
+        return
+
+    setattr(target, attr, desired)
+    try:
+        cfg.save()
+    except OSError as exc:
+        ux.err(f"Failed to save config: {exc}")
+        raise click.ClickException("config save failed") from exc
+
+    ux.ok(f"notifications.{slot} = {value.lower()}")
+    if not nc.enabled:
+        # The dispatcher checks the master switch first, so flipping a
+        # sub-toggle with the master OFF is harmless but invisible —
+        # surface that so operators don't think their change had no
+        # effect.
+        ux.warn(
+            "notifications.enabled is OFF — this toggle won't have any "
+            "user-visible effect until you run "
+            "`defenseclaw setup notifications on`.",
+        )
+
+    if restart:
+        ux.subhead("Restarting gateway so the dispatcher picks up the new filter…")
+        _restart_services(
+            cfg.data_dir,
+            cfg.gateway.host,
+            cfg.gateway.port,
+            connector=cfg.active_connector(),
+        )
+    else:
+        ctx = click.get_current_context(silent=True)
+        if ctx is not None:
+            ctx.meta[_SETUP_RESTART_HANDLED_KEY] = True
+        ux.subhead(
+            "Skipped restart (--no-restart). Run `defenseclaw-gateway "
+            "restart` when ready.",
+        )
+
+    if app.logger:
+        app.logger.log_action(
+            "setup-notifications-set",
+            "config",
+            f"slot={slot} value={value.lower()}",
+        )
+
+
+# ``setup registry`` — discoverable shortcut that drops the operator
+# straight into the registry wizard. The full ``defenseclaw registry``
+# group remains the canonical surface for non-onboarding flows
+# (``add`` / ``edit`` / ``sync`` / ...); this wrapper exists so a
+# first-time operator working through ``defenseclaw setup --help``
+# doesn't have to know that registries live in their own top-level
+# group.
+@setup.command("registry")
+@click.pass_context
+def setup_registry(ctx: click.Context) -> None:
+    """Register an external skill / MCP catalog (interactive wizard).
+
+    Wraps ``defenseclaw registry wizard`` so first-run operators
+    discover the registry feature inside ``defenseclaw setup --help``.
+    For non-interactive usage and the full subcommand surface
+    (``add`` / ``edit`` / ``sync`` / ``approve`` / ``reject`` /
+    ``test`` / ``list`` / ``show`` / ``remove`` / ``require``), use
+    the top-level ``defenseclaw registry`` group directly.
+    """
+    # Lazy import to avoid pulling the registry HTTP / YAML deps into
+    # setup commands that don't need them, and to dodge a potential
+    # circular import (cmd_registry imports config -> ... -> setup
+    # in some lint configurations).
+    from defenseclaw.commands.cmd_registry import wizard_cmd
+
+    return ctx.invoke(wizard_cmd)
+
+
 def execute_guardrail_setup(
     app: AppContext,
     *,

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -1343,7 +1343,7 @@ _CONNECTOR_CHANGE_SURFACES: dict[str, tuple[str, ...]] = {
         "~/.defenseclaw/hooks/ and subprocess policy files",
     ),
     "codex": (
-        "~/.codex/config.toml hooks / features.codex_hooks",
+        "~/.codex/config.toml hooks / features.hooks / hook trust state",
         "~/.codex/config.toml otel / notify",
         "~/.codex/skills/software-security Project CodeGuard skill (installed once and left enabled)",
         "~/.defenseclaw/hooks/ and notify bridge files",
@@ -2702,6 +2702,174 @@ def setup_redaction(app: AppContext, action: str, restart: bool, yes: bool) -> N
             "setup-redaction-toggle",
             "config",
             f"disable_redaction={desired!s}",
+        )
+
+
+@setup.command("notifications")
+@click.argument(
+    "action",
+    type=click.Choice(("on", "off", "status"), case_sensitive=False),
+    required=False,
+)
+@click.option(
+    "--yes", "-y", "yes", is_flag=True,
+    help=(
+        "Skip the interactive confirmation prompt and accept the "
+        "default answer. Required for non-TTY callers (CI, scripts, "
+        "TUI shell-outs); without it the command may hang waiting "
+        "on stdin when invoked without an explicit on/off/status "
+        "argument."
+    ),
+)
+@click.option(
+    "--restart/--no-restart", default=True, show_default=True,
+    help=(
+        "Restart defenseclaw-gateway after toggling. The notification "
+        "dispatcher is built once at sidecar boot from "
+        "``notifications.*`` so a flip without restart leaves the "
+        "previous state in effect for the running process. Use "
+        "``--no-restart`` only when the sidecar is offline; the "
+        "``setup`` group's auto-restart hook will not double-bounce "
+        "the gateway because this command marks the restart as "
+        "handled."
+    ),
+)
+@pass_ctx
+def setup_notifications(
+    app: AppContext,
+    action: str | None,
+    yes: bool,
+    restart: bool,
+) -> None:
+    """Toggle user-session desktop notifications for blocks and HITL approvals.
+
+    \b
+    DefenseClaw can surface a desktop notification whenever a hook,
+    guardrail verdict, or asset policy blocks a tool call, or when a
+    Human-in-the-Loop approval is pending in the chat / TUI. The
+    notification is informational only — clicking it does not approve
+    or deny anything; the operator still replies in the existing
+    chat/CLI surface.
+    \b
+    With no argument this command is a one-shot Y/n onboarding
+    prompt:
+    \b
+      Show desktop notifications for blocks and approval requests? [Y/n]
+    \b
+    Use ``on`` / ``off`` to flip ``notifications.enabled`` directly,
+    and ``status`` to print the resolved configuration without
+    mutating it.
+    \b
+    Examples:
+      defenseclaw setup notifications
+      defenseclaw setup notifications on
+      defenseclaw setup notifications off --yes
+      defenseclaw setup notifications status
+    """
+    cfg = app.cfg
+    nc = cfg.notifications
+    current = bool(nc.enabled)
+
+    normalized = action.strip().lower() if action else None
+
+    if normalized == "status":
+        ux.section("Notifications state")
+        click.echo(
+            f"    {ux.dim('config (notifications.enabled):')} "
+            f"{'ON' if current else 'OFF'}"
+        )
+        click.echo(
+            f"    {ux.dim('block_enforced:')} {'on' if nc.block_enforced else 'off'}"
+        )
+        click.echo(
+            f"    {ux.dim('block_would_block:')} {'on' if nc.block_would_block else 'off'}"
+        )
+        click.echo(
+            f"    {ux.dim('hitl_approval:')} {'on' if nc.hitl_approval else 'off'}"
+        )
+        click.echo(
+            f"    {ux.dim('sources.hook:')} {'on' if nc.sources.hook else 'off'}"
+        )
+        click.echo(
+            f"    {ux.dim('sources.guardrail:')} "
+            f"{'on' if nc.sources.guardrail else 'off'}"
+        )
+        click.echo(
+            f"    {ux.dim('sources.asset_policy:')} "
+            f"{'on' if nc.sources.asset_policy else 'off'}"
+        )
+        click.echo(
+            f"    {ux.dim('dedup_window:')} {nc.dedup_window or '30s'}"
+        )
+        click.echo(
+            f"    {ux.dim('max_per_minute:')} {nc.max_per_minute}"
+        )
+        return
+
+    if normalized in ("on", "off"):
+        desired = normalized == "on"
+    else:
+        # No explicit action -> interactive Y/n onboarding prompt.
+        # ``--yes`` short-circuits to the prompt's default (True).
+        if yes:
+            desired = True
+        else:
+            desired = click.confirm(
+                "  Show desktop notifications for blocks and approval requests?",
+                default=True,
+            )
+
+    if desired == current:
+        state = "ON" if current else "OFF"
+        click.echo(f"  • Notifications are already {state}; nothing to change.")
+        return
+
+    nc.enabled = desired
+
+    try:
+        cfg.save()
+    except OSError as exc:
+        ux.err(f"Failed to save config: {exc}")
+        raise click.ClickException("config save failed") from exc
+
+    ux.ok(
+        f"notifications.enabled set to {desired!s} "
+        f"({'ON' if desired else 'OFF'})"
+    )
+
+    if restart:
+        ux.subhead(
+            "Restarting gateway so the notification dispatcher picks up the new state..."
+        )
+        # _restart_defense_gateway sets the per-context "restart
+        # already handled" flag, so the setup group's
+        # _auto_restart_sidecar_after_setup result callback won't
+        # bounce the gateway a second time after this one returns.
+        _restart_services(
+            cfg.data_dir,
+            cfg.gateway.host,
+            cfg.gateway.port,
+            connector=cfg.active_connector(),
+        )
+    else:
+        # Operator opted out of the restart explicitly; suppress the
+        # group-level auto-restart hook too so the operator sees one
+        # consistent "do it yourself" message instead of the hook
+        # contradicting us by bouncing the gateway anyway.
+        ctx = click.get_current_context(silent=True)
+        if ctx is not None:
+            ctx.meta[_SETUP_RESTART_HANDLED_KEY] = True
+        ux.warn(
+            "Skipped restart (--no-restart). The running sidecar still "
+            "uses the previous notification state. Restart manually:"
+        )
+        ux.subhead("   defenseclaw-gateway restart")
+
+    if app.logger:
+        app.logger.log_action(
+            "setup-notifications-toggle",
+            "config",
+            f"enabled={desired!s}",
         )
 
 

--- a/cli/defenseclaw/config.py
+++ b/cli/defenseclaw/config.py
@@ -748,6 +748,14 @@ class AssetTypePolicy:
     allowed: list[AssetPolicyRule] = field(default_factory=list)
     denied: list[AssetPolicyRule] = field(default_factory=list)
     runtime_detection: AssetRuntimeDetectionConfig = field(default_factory=AssetRuntimeDetectionConfig)
+    # registry_empty_action mirrors the Go-side
+    # AssetTypePolicy.RegistryEmptyAction. When `registry_required`
+    # is on AND `registry` is empty, this controls admission:
+    # "deny" (default, fail-closed) / "warn" / "allow". The Python
+    # CLI doesn't make admission decisions but surfaces the field
+    # in `registry require` so operators see the implication of an
+    # empty list before the gateway starts denying traffic.
+    registry_empty_action: str = "deny"
 
 
 def _default_runtime_asset_type_policy() -> AssetTypePolicy:
@@ -771,6 +779,92 @@ class AssetPolicyConfig:
     mcp: AssetTypePolicy = field(default_factory=_default_runtime_asset_type_policy)
     skill: AssetTypePolicy = field(default_factory=_default_nonruntime_asset_type_policy)
     plugin: AssetTypePolicy = field(default_factory=_default_nonruntime_asset_type_policy)
+
+
+# ---------------------------------------------------------------------------
+# Registries — external skill / MCP catalog sources that feed
+# ``asset_policy.{skill,mcp}.registry`` via the `defenseclaw registry sync`
+# pipeline. The block is round-tripped through load/save so operator-added
+# sources survive process restarts; the on-disk index lives separately
+# under ``~/.defenseclaw/registries/<id>/index.json`` (see
+# defenseclaw.registries.cache).
+# ---------------------------------------------------------------------------
+
+REGISTRY_KINDS: tuple[str, ...] = (
+    "clawhub",
+    "smithery",
+    "skills_sh",
+    "http_yaml",
+    "http_json",
+    "git",
+    "file",
+)
+"""Allow-list of recognised registry source kinds.
+
+Anything outside this set is rejected at validation time by both the
+CLI (``registry add --kind ...``) and the loader. Adding a new kind
+requires a matching adapter under ``cli/defenseclaw/registries/`` and a
+corresponding match in :func:`registries.adapters.dispatch`.
+"""
+
+REGISTRY_CONTENT_TYPES: tuple[str, ...] = ("skill", "mcp", "both")
+
+
+@dataclass
+class RegistrySource:
+    """One registry source entry inside ``registries.sources[]``.
+
+    Mirrors the Go-side ``internal/config.RegistrySource``. Field
+    semantics:
+
+    * ``id``                  — operator-chosen identifier (unique,
+                                kebab-case recommended). Used as the
+                                ``Reason: "registry:<id>"`` provenance
+                                tag on every promoted ``AssetPolicyRule``
+                                and as the cache directory name.
+    * ``kind``                — one of :data:`REGISTRY_KINDS`. Selects
+                                which adapter handles ``fetch()``.
+    * ``url``                 — manifest URL / git URL / local path.
+                                Empty for ``kind="clawhub"`` (uses the
+                                npm openclaw package by convention).
+    * ``content``             — declared content type — must be one of
+                                :data:`REGISTRY_CONTENT_TYPES`. Adapters
+                                that publish only one type (clawhub /
+                                smithery) ignore this field.
+    * ``auth_env``            — env var holding a bearer token, never
+                                the literal token. Empty disables auth.
+    * ``enabled``             — when False the source is preserved in
+                                config but skipped by ``sync --all``.
+    * ``auto_sync``           — RESERVED. Scheduled sync is not yet
+                                implemented; setting this to True today
+                                does NOT cause periodic ingest.
+                                Persisted so a v1 -> v2 operator config
+                                doesn't lose the bit. Run
+                                ``defenseclaw registry sync --all`` (or
+                                schedule it via cron) until the v2
+                                scheduler ships.
+    * ``sync_interval_hours`` — RESERVED. Paired with ``auto_sync``;
+                                ignored at runtime today.
+    * ``last_sync``           — ISO-8601 UTC timestamp; populated by
+                                the sync command on success.
+    * ``last_status``         — ``ok`` or ``error: <reason>``.
+    """
+
+    id: str = ""
+    kind: str = "http_yaml"
+    url: str = ""
+    content: str = "skill"
+    auth_env: str = ""
+    enabled: bool = True
+    auto_sync: bool = False
+    sync_interval_hours: int = 24
+    last_sync: str = ""
+    last_status: str = ""
+
+
+@dataclass
+class RegistriesConfig:
+    sources: list[RegistrySource] = field(default_factory=list)
 
 
 @dataclass
@@ -946,6 +1040,63 @@ class GuardrailConfig:
 
 
 @dataclass
+class NotificationSourceFilter:
+    """Per-source toggles for the user-session notifier dispatcher.
+
+    Mirrors :class:`config.NotificationSourceFilter` in
+    ``internal/config/notifications.go``. Defaults are all True so a
+    fresh ``notifications.enabled: true`` install reports every
+    block surface; operators dial down by flipping individual
+    sub-fields off.
+    """
+
+    hook: bool = True
+    guardrail: bool = True
+    asset_policy: bool = True
+
+
+def _default_notifications_enabled() -> bool:
+    """Mirror Go's ``config.DefaultNotificationsEnabled``.
+
+    Darwin is the only platform with a consumer-grade desktop
+    notification surface that every user already has running, so it
+    opts in by default. Every other OS waits for an explicit
+    ``defenseclaw setup notifications on`` opt-in. Implemented as a
+    free function (not a literal default) so the platform check is
+    evaluated at config-construction time, not module-import time —
+    important for unit tests that monkey-patch ``platform.system``.
+    """
+    return platform.system() == "Darwin"
+
+
+@dataclass
+class NotificationsConfig:
+    """User-session OS notifications. Mirrors internal/config.NotificationsConfig.
+
+    Master switch ``enabled`` defaults to ``True`` on darwin and
+    ``False`` elsewhere — same matrix as Go's
+    ``DefaultNotificationsEnabled``. ``defenseclaw setup
+    notifications`` (the single-prompt onboarding wizard) is still
+    the canonical opt-in path; operators dialing noise back down can
+    flip individual category / source / throttle fields.
+
+    Throttle defaults match the Go side
+    (``dedup_window=30s``, ``max_per_minute=12``); zero values are
+    interpreted as "use the default" rather than "no throttle".
+    """
+
+    enabled: bool = field(default_factory=_default_notifications_enabled)
+    block_enforced: bool = True
+    block_would_block: bool = True
+    hitl_approval: bool = True
+    sources: NotificationSourceFilter = field(default_factory=NotificationSourceFilter)
+    # Stored as the same string viper accepts on the Go side so the
+    # YAML round-trips through both ends without translation.
+    dedup_window: str = "30s"
+    max_per_minute: int = 12
+
+
+@dataclass
 class PrivacyConfig:
     """Privacy / redaction toggles. Mirrors internal/config.PrivacyConfig.
 
@@ -998,8 +1149,10 @@ class Config:
     mcp_actions: MCPActionsConfig = field(default_factory=MCPActionsConfig)
     plugin_actions: PluginActionsConfig = field(default_factory=PluginActionsConfig)
     asset_policy: AssetPolicyConfig = field(default_factory=AssetPolicyConfig)
+    registries: RegistriesConfig = field(default_factory=RegistriesConfig)
     webhooks: list[WebhookConfig] = field(default_factory=list)
     privacy: PrivacyConfig = field(default_factory=lambda: PrivacyConfig())
+    notifications: NotificationsConfig = field(default_factory=lambda: NotificationsConfig())
 
     # -- Claw-mode path resolution (mirrors claw.go) --
 
@@ -1245,9 +1398,32 @@ def _config_to_dict(cfg: Config) -> dict[str, Any]:
     privacy = d.get("privacy")
     if isinstance(privacy, dict) and not any(privacy.values()):
         d.pop("privacy", None)
+    # Mirror Go's ``yaml:"notifications,omitempty"`` — when the
+    # block is at full defaults (master switch off, every category /
+    # source still on, default throttles) drop it so legacy configs
+    # that never opted in stay byte-identical after a load/save
+    # round-trip. The block reappears the moment any field is
+    # touched (e.g. ``setup notifications`` flipping ``enabled:
+    # true``).
+    notifications = d.get("notifications")
+    if isinstance(notifications, dict) and notifications == _default_notifications_dict():
+        d.pop("notifications", None)
     if d.get("asset_policy") == _default_asset_policy_dict():
         d.pop("asset_policy", None)
+    # Drop the registries: block when no sources are configured so an
+    # operator-untouched config stays byte-identical after a load/save
+    # round-trip. The block reappears the moment any source is added.
+    registries = d.get("registries")
+    if isinstance(registries, dict):
+        sources = registries.get("sources") or []
+        if not sources:
+            d.pop("registries", None)
     return d
+
+
+def _default_notifications_dict() -> dict[str, Any]:
+    from dataclasses import asdict
+    return asdict(NotificationsConfig())
 
 
 def _default_asset_policy_dict() -> dict[str, Any]:
@@ -1437,6 +1613,9 @@ def _merge_asset_type_policy(raw: dict[str, Any] | None, *, runtime: bool) -> As
             allowed=_merge_asset_rules(raw.get("allowed")),
             denied=_merge_asset_rules(raw.get("denied")),
             runtime_detection=_merge_asset_runtime_detection(raw.get("runtime_detection")),
+            registry_empty_action=str(
+                raw.get("registry_empty_action", "deny") or "deny",
+            ).strip().lower(),
         )
     if not runtime:
         base.runtime_detection = AssetRuntimeDetectionConfig(
@@ -1455,6 +1634,78 @@ def _merge_asset_runtime_detection(raw: dict[str, Any] | None) -> AssetRuntimeDe
         terminal_commands=bool(raw.get("terminal_commands", True)),
         unknown_terminal_mcp=str(raw.get("unknown_terminal_mcp", "observe") or "observe"),
     )
+
+
+def _merge_registries(raw: Any) -> RegistriesConfig:
+    """Build a :class:`RegistriesConfig` from the YAML ``registries:`` block.
+
+    Unknown ``kind`` / ``content`` values are coerced to safe defaults
+    (``http_yaml`` / ``skill``) rather than raising — the loader has to
+    survive on best-effort because corrupted config files are recoverable
+    only if every other section still loads. The CLI's ``registry add``
+    flow validates strictly so user-driven entries always land in the
+    canonical shape.
+
+    Coercions are logged at WARNING via :mod:`logging` (also written
+    to stderr at startup) so a typo in ``kind:`` doesn't sit hidden
+    inside the loader; without the warning operators previously hit
+    cryptic "no entries returned" failures during sync because the
+    coerced ``http_yaml`` adapter would fetch the wrong URL shape.
+
+    Sources with an empty ``id`` are silently skipped — they cannot be
+    addressed by ``registry sync <id>`` anyway and would only confuse
+    downstream code.
+    """
+    if not isinstance(raw, dict):
+        return RegistriesConfig()
+    raw_sources = raw.get("sources")
+    if not isinstance(raw_sources, list):
+        return RegistriesConfig()
+    sources: list[RegistrySource] = []
+    seen_ids: set[str] = set()
+    for entry in raw_sources:
+        if not isinstance(entry, dict):
+            continue
+        sid = str(entry.get("id", "") or "").strip()
+        if not sid or sid in seen_ids:
+            continue
+        seen_ids.add(sid)
+        raw_kind = str(entry.get("kind", "http_yaml") or "http_yaml").strip()
+        kind = raw_kind.lower()
+        if kind not in REGISTRY_KINDS:
+            _log.warning(
+                "registries.sources[id=%r]: unknown kind %r; coercing to "
+                "'http_yaml'. Valid kinds: %s",
+                sid, raw_kind, ", ".join(REGISTRY_KINDS),
+            )
+            kind = "http_yaml"
+        raw_content = str(entry.get("content", "skill") or "skill").strip()
+        content = raw_content.lower()
+        if content not in REGISTRY_CONTENT_TYPES:
+            _log.warning(
+                "registries.sources[id=%r]: unknown content %r; coercing to "
+                "'skill'. Valid content types: %s",
+                sid, raw_content, ", ".join(REGISTRY_CONTENT_TYPES),
+            )
+            content = "skill"
+        sync_interval = entry.get("sync_interval_hours", 24)
+        try:
+            sync_interval_int = max(0, int(sync_interval))
+        except (TypeError, ValueError):
+            sync_interval_int = 24
+        sources.append(RegistrySource(
+            id=sid,
+            kind=kind,
+            url=str(entry.get("url", "") or ""),
+            content=content,
+            auth_env=str(entry.get("auth_env", "") or ""),
+            enabled=bool(entry.get("enabled", True)),
+            auto_sync=bool(entry.get("auto_sync", False)),
+            sync_interval_hours=sync_interval_int,
+            last_sync=str(entry.get("last_sync", "") or ""),
+            last_status=str(entry.get("last_status", "") or ""),
+        ))
+    return RegistriesConfig(sources=sources)
 
 
 def _merge_asset_rules(raw: Any) -> list[AssetPolicyRule]:
@@ -1945,8 +2196,10 @@ def load() -> Config:
         mcp_actions=_merge_mcp_actions(raw.get("mcp_actions")),
         plugin_actions=_merge_plugin_actions(raw.get("plugin_actions")),
         asset_policy=_merge_asset_policy(raw.get("asset_policy")),
+        registries=_merge_registries(raw.get("registries")),
         webhooks=_merge_webhooks(raw.get("webhooks")),
         privacy=_merge_privacy(raw.get("privacy")),
+        notifications=_merge_notifications(raw.get("notifications")),
     )
     _migrate_llm_fields(cfg)
     _warn_disable_redaction_config(cfg)
@@ -1965,6 +2218,61 @@ def _merge_privacy(raw: dict[str, Any] | None) -> PrivacyConfig:
         return PrivacyConfig()
     return PrivacyConfig(
         disable_redaction=bool(raw.get("disable_redaction", False)),
+    )
+
+
+def _merge_notifications(raw: dict[str, Any] | None) -> NotificationsConfig:
+    """Build a :class:`NotificationsConfig` from the YAML ``notifications:`` block.
+
+    Defaults are platform-conditional for the master switch (true on
+    darwin, false elsewhere — see :func:`_default_notifications_enabled`)
+    and on for every category and source so that once an operator
+    opts in via ``defenseclaw setup notifications`` they immediately
+    see every block surface; tuning down is then a matter of
+    flipping the explicit per-category / per-source keys.
+
+    Throttle defaults (``dedup_window=30s``, ``max_per_minute=12``)
+    mirror :data:`NotificationsDefaultDedupWindow` /
+    :data:`NotificationsDefaultMaxPerMinute` in the Go config so a
+    YAML file written from either end loads identically on the
+    other.
+    """
+    defaults = NotificationsConfig()
+    if not isinstance(raw, dict):
+        return defaults
+
+    sources_raw = raw.get("sources")
+    if isinstance(sources_raw, dict):
+        sources = NotificationSourceFilter(
+            hook=bool(sources_raw.get("hook", defaults.sources.hook)),
+            guardrail=bool(sources_raw.get("guardrail", defaults.sources.guardrail)),
+            asset_policy=bool(
+                sources_raw.get("asset_policy", defaults.sources.asset_policy),
+            ),
+        )
+    else:
+        sources = NotificationSourceFilter()
+
+    dedup_raw = raw.get("dedup_window", defaults.dedup_window)
+    dedup_window = (
+        str(dedup_raw).strip() if dedup_raw not in (None, "") else defaults.dedup_window
+    )
+
+    try:
+        max_per_minute = int(raw.get("max_per_minute", defaults.max_per_minute))
+    except (TypeError, ValueError):
+        max_per_minute = defaults.max_per_minute
+    if max_per_minute < 0:
+        max_per_minute = defaults.max_per_minute
+
+    return NotificationsConfig(
+        enabled=bool(raw.get("enabled", defaults.enabled)),
+        block_enforced=bool(raw.get("block_enforced", defaults.block_enforced)),
+        block_would_block=bool(raw.get("block_would_block", defaults.block_would_block)),
+        hitl_approval=bool(raw.get("hitl_approval", defaults.hitl_approval)),
+        sources=sources,
+        dedup_window=dedup_window,
+        max_per_minute=max_per_minute,
     )
 
 

--- a/cli/defenseclaw/main.py
+++ b/cli/defenseclaw/main.py
@@ -41,6 +41,7 @@ from defenseclaw.commands.cmd_migrations import migrations_cmd
 from defenseclaw.commands.cmd_plugin import plugin
 from defenseclaw.commands.cmd_policy import policy
 from defenseclaw.commands.cmd_quickstart import quickstart_cmd
+from defenseclaw.commands.cmd_registry import registry
 from defenseclaw.commands.cmd_sandbox import sandbox
 from defenseclaw.commands.cmd_settings import settings_cmd
 from defenseclaw.commands.cmd_setup import setup
@@ -152,6 +153,7 @@ cli.add_command(setup)
 cli.add_command(skill)
 cli.add_command(plugin)
 cli.add_command(policy)
+cli.add_command(registry)
 cli.add_command(mcp)
 cli.add_command(aibom)
 cli.add_command(status)

--- a/cli/defenseclaw/registries/__init__.py
+++ b/cli/defenseclaw/registries/__init__.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Registry ingest pipeline.
+
+Public surface:
+
+* :func:`fetch_manifest`           — adapter dispatch
+* :class:`Manifest` /
+  :class:`ManifestEntry`           — parsed manifest shape
+* :class:`SourceIndex` /
+  :class:`EntryVerdict`            — on-disk per-source state
+* :class:`SyncReport`              — return value of
+                                     :func:`sync_source`
+* :func:`sync_source` /
+  :func:`sync_all`                 — drive ingest -> scan -> cache ->
+                                     asset_policy promotion
+* :func:`ManifestError` /
+  :class:`IngestError` /
+  :class:`SSRFError`               — typed errors
+"""
+
+from defenseclaw.registries.adapters import IngestError, fetch_manifest
+from defenseclaw.registries.cache import (
+    EntryVerdict,
+    SourceIndex,
+    cache_root,
+    index_path,
+    load_cached_manifest,
+    load_index,
+    manifest_path,
+    remove_source,
+    save_index,
+    save_manifest,
+    source_dir,
+)
+from defenseclaw.registries.manifest import (
+    Manifest,
+    ManifestEntry,
+    ManifestError,
+    parse_manifest,
+)
+from defenseclaw.registries.ssrf import SSRFError, guard_url
+from defenseclaw.registries.sync import SyncReport, sync_all, sync_source
+
+__all__ = [
+    "EntryVerdict",
+    "IngestError",
+    "Manifest",
+    "ManifestEntry",
+    "ManifestError",
+    "SSRFError",
+    "SourceIndex",
+    "SyncReport",
+    "cache_root",
+    "fetch_manifest",
+    "guard_url",
+    "index_path",
+    "load_cached_manifest",
+    "load_index",
+    "manifest_path",
+    "parse_manifest",
+    "remove_source",
+    "save_index",
+    "save_manifest",
+    "source_dir",
+    "sync_all",
+    "sync_source",
+]

--- a/cli/defenseclaw/registries/adapters/__init__.py
+++ b/cli/defenseclaw/registries/adapters/__init__.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Source adapters — each one knows how to turn a :class:`RegistrySource`
+into a parsed :class:`Manifest`.
+
+The dispatch entry point is :func:`fetch_manifest`. Adapters live in
+sibling modules so each source kind can be unit-tested in isolation
+with a mocked HTTP client; this module is a thin façade over them.
+"""
+
+from __future__ import annotations
+
+from defenseclaw.config import RegistrySource
+from defenseclaw.registries.adapters._base import IngestError
+from defenseclaw.registries.adapters.clawhub import fetch_clawhub
+from defenseclaw.registries.adapters.file import fetch_file
+from defenseclaw.registries.adapters.git import fetch_git
+from defenseclaw.registries.adapters.http_manifest import fetch_http
+from defenseclaw.registries.adapters.skills_sh import fetch_skills_sh
+from defenseclaw.registries.adapters.smithery import fetch_smithery
+from defenseclaw.registries.manifest import Manifest
+from defenseclaw.registries.ssrf import Resolver
+
+
+def fetch_manifest(
+    source: RegistrySource,
+    *,
+    allow_private: bool = False,
+    resolver: Resolver | None = None,
+) -> tuple[Manifest, bytes]:
+    """Resolve *source* to a parsed manifest + the raw fetched bytes.
+
+    Returns ``(manifest, raw_bytes)`` so the caller can persist the
+    fetched bytes verbatim alongside the parsed view (see
+    :mod:`defenseclaw.registries.cache`). Raises
+    :class:`IngestError` on any fetch / parse / SSRF failure.
+
+    The optional ``resolver`` is plumbed through to every adapter so
+    test suites can stub DNS without hitting the network. Production
+    callers leave it None.
+    """
+    kind = source.kind
+    if kind == "clawhub":
+        return fetch_clawhub(
+            source, allow_private=allow_private, resolver=resolver,
+        )
+    if kind == "smithery":
+        return fetch_smithery(
+            source, allow_private=allow_private, resolver=resolver,
+        )
+    if kind == "skills_sh":
+        return fetch_skills_sh(
+            source, allow_private=allow_private, resolver=resolver,
+        )
+    if kind in ("http_yaml", "http_json"):
+        return fetch_http(
+            source, allow_private=allow_private, resolver=resolver,
+        )
+    if kind == "git":
+        return fetch_git(
+            source, allow_private=allow_private, resolver=resolver,
+        )
+    if kind == "file":
+        return fetch_file(source)
+    raise IngestError(f"unknown registry kind: {kind!r}")
+
+
+__all__ = [
+    "IngestError",
+    "fetch_manifest",
+    "fetch_clawhub",
+    "fetch_file",
+    "fetch_git",
+    "fetch_http",
+    "fetch_skills_sh",
+    "fetch_smithery",
+]

--- a/cli/defenseclaw/registries/adapters/_base.py
+++ b/cli/defenseclaw/registries/adapters/_base.py
@@ -1,0 +1,238 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared HTTP helpers for registry adapters.
+
+We deliberately keep this layer paper-thin so the security-relevant
+guards stay visible and uniform across every adapter:
+
+* :func:`http_get` performs an SSRF check against the URL, rejects
+  redirects to disallowed hosts, caps the response body at
+  :data:`MAX_MANIFEST_BYTES`, and applies a fixed timeout.
+* :func:`auth_header` reads the auth token from the env var named on
+  the source (never the literal token), strips whitespace, and refuses
+  to pass through control characters.
+
+All adapters call :func:`http_get` rather than :mod:`requests` directly
+so a single point of audit covers the whole ingest path.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from urllib.parse import urljoin, urlparse
+
+import requests
+
+from defenseclaw.config import RegistrySource
+from defenseclaw.registries.ssrf import Resolver, SSRFError, guard_url
+
+MAX_MANIFEST_BYTES = 8 * 1024 * 1024
+"""Hard cap on a fetched manifest payload (8 MiB).
+
+A vendor-neutral catalog with 10k entries fits easily inside this
+budget. Anything larger almost certainly indicates an attack
+(zip-bomb-style nested structures), a misconfigured server, or a
+runaway publisher; we'd rather refuse and force a config fix than
+balloon the operator's RAM during sync.
+"""
+
+DEFAULT_TIMEOUT = 30.0
+"""Per-request timeout (seconds) for adapter HTTP calls."""
+
+USER_AGENT = "defenseclaw-registry-sync/1"
+
+_CTL_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+class IngestError(RuntimeError):
+    """Raised when an adapter fails to fetch or parse a manifest."""
+
+
+def http_get(
+    url: str,
+    *,
+    auth_env: str = "",
+    accept: str = "application/json, application/yaml, text/yaml, text/plain;q=0.9, */*;q=0.5",
+    allow_private: bool = False,
+    timeout: float = DEFAULT_TIMEOUT,
+    resolver: Resolver | None = None,
+) -> bytes:
+    """Fetch *url* with the SSRF / size / redirect guards applied.
+
+    Raises :class:`IngestError` on any of:
+
+    * the URL fails :func:`defenseclaw.registries.ssrf.guard_url`;
+    * a redirect points to a host that fails the SSRF guard (we
+      validate every hop, not just the original URL);
+    * the response body exceeds :data:`MAX_MANIFEST_BYTES`;
+    * the underlying :mod:`requests` call raises.
+
+    The optional ``resolver`` is plumbed through to :func:`guard_url`
+    so tests can stub DNS without hitting the network. Production
+    callers leave it None — the guard then falls back to
+    :func:`socket.getaddrinfo`.
+    """
+    try:
+        guard_url(url, allow_private=allow_private, resolver=resolver)
+    except SSRFError as exc:
+        raise IngestError(str(exc)) from exc
+
+    base_headers = {"User-Agent": USER_AGENT, "Accept": accept}
+    auth = auth_header(auth_env)
+    request_headers = dict(base_headers)
+    if auth:
+        request_headers["Authorization"] = auth
+
+    try:
+        with requests.get(
+            url,
+            headers=request_headers,
+            timeout=timeout,
+            stream=True,
+            allow_redirects=False,
+        ) as resp:
+            # Manual redirect handling so we can validate every hop
+            # against the SSRF policy. Cap at 5 hops to bound work.
+            current_url = url
+            hops = 0
+            while resp.is_redirect and hops < 5:
+                location = resp.headers.get("Location")
+                if not location:
+                    raise IngestError(
+                        "redirect with empty Location header from "
+                        f"{current_url}"
+                    )
+                if not location.lower().startswith(("http://", "https://")):
+                    # Relative redirect — resolve against the previous URL.
+                    location = urljoin(current_url, location)
+                try:
+                    guard_url(
+                        location,
+                        allow_private=allow_private,
+                        resolver=resolver,
+                    )
+                except SSRFError as exc:
+                    raise IngestError(
+                        f"redirect blocked by SSRF guard: {exc}"
+                    ) from exc
+                # Defence in depth: drop Authorization on cross-origin
+                # redirects so a publisher (or compromised CDN edge)
+                # that issues a 30x to an attacker-controlled host
+                # can't harvest the operator's registry token. We
+                # match browser/curl behaviour: same scheme + host +
+                # port keeps the header, anything else strips it.
+                next_headers = dict(base_headers)
+                if auth and _same_origin(current_url, location):
+                    next_headers["Authorization"] = auth
+                resp.close()
+                resp = requests.get(  # noqa: PLW2901  - intentional reassign
+                    location,
+                    headers=next_headers,
+                    timeout=timeout,
+                    stream=True,
+                    allow_redirects=False,
+                )
+                current_url = location
+                hops += 1
+            if resp.is_redirect:
+                raise IngestError(
+                    f"too many redirects ({hops}) starting from {url}"
+                )
+            resp.raise_for_status()
+
+            # Content-Length is advisory but if the publisher claims
+            # something larger than our cap, refuse before we read a
+            # byte. Real bodies still get the streaming check below.
+            cl = resp.headers.get("Content-Length")
+            if cl:
+                try:
+                    if int(cl) > MAX_MANIFEST_BYTES:
+                        raise IngestError(
+                            f"manifest is {cl} bytes (max {MAX_MANIFEST_BYTES})"
+                        )
+                except ValueError:
+                    pass
+
+            buf = bytearray()
+            for chunk in resp.iter_content(chunk_size=65536):
+                buf.extend(chunk)
+                if len(buf) > MAX_MANIFEST_BYTES:
+                    raise IngestError(
+                        f"manifest exceeds {MAX_MANIFEST_BYTES} bytes"
+                    )
+            return bytes(buf)
+    except requests.RequestException as exc:
+        raise IngestError(f"fetch failed: {exc}") from exc
+
+
+def _same_origin(a: str, b: str) -> bool:
+    """Return True when *a* and *b* share scheme, host, and port.
+
+    Used by :func:`http_get` to decide whether the ``Authorization``
+    header survives a redirect. Any URL that fails to parse, lacks a
+    scheme, or lacks a host is treated as a different origin (fail
+    closed) so a malformed Location can't trick us into preserving
+    credentials.
+    """
+    try:
+        ap = urlparse(a)
+        bp = urlparse(b)
+    except (TypeError, ValueError):
+        return False
+    if not ap.scheme or not bp.scheme:
+        return False
+    if not ap.hostname or not bp.hostname:
+        return False
+    if ap.scheme.lower() != bp.scheme.lower():
+        return False
+    if ap.hostname.lower() != bp.hostname.lower():
+        return False
+    # urlparse normalises an absent port to None; treat None as the
+    # scheme default so http://host -> http://host:80 still matches.
+    default_a = 443 if ap.scheme.lower() == "https" else 80
+    default_b = 443 if bp.scheme.lower() == "https" else 80
+    return (ap.port or default_a) == (bp.port or default_b)
+
+
+def auth_header(auth_env: str) -> str:
+    """Build a Bearer auth header from the env var named *auth_env*.
+
+    Returns an empty string when *auth_env* is empty or unset. The
+    token is stripped of leading/trailing whitespace; ASCII control
+    characters cause a refusal so a corrupted env value can't smuggle
+    a header injection.
+    """
+    if not auth_env:
+        return ""
+    raw = os.environ.get(auth_env, "")
+    if not raw:
+        return ""
+    token = raw.strip()
+    if not token:
+        return ""
+    if _CTL_RE.search(token):
+        raise IngestError(
+            f"auth token from ${auth_env} contains control characters"
+        )
+    if token.lower().startswith(("bearer ", "token ")):
+        return token
+    return f"Bearer {token}"
+
+
+def normalize_url(source: RegistrySource) -> str:
+    """Return the source URL after stripping whitespace.
+
+    Centralised so adapters never accidentally read a raw, untrimmed
+    config field — copy-paste config edits frequently leave trailing
+    newlines that break the SSRF guard's host extraction.
+    """
+    return (source.url or "").strip()

--- a/cli/defenseclaw/registries/adapters/clawhub.py
+++ b/cli/defenseclaw/registries/adapters/clawhub.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""ClawHub manifest adapter — kind=clawhub.
+
+Reads the ``openclaw`` npm package metadata from
+``https://registry.npmjs.org/openclaw/latest`` and synthesises a
+:class:`Manifest` listing every plugin under ``package/plugins/`` as a
+:class:`ManifestEntry` with ``source_url=clawhub://<name>``.
+
+We do this server-side metadata read rather than streaming the whole
+tarball at sync time so that ``registry sync clawhub`` is fast (one
+HTTP call) and so the sync pipeline doesn't fight the existing
+``defenseclaw plugin install clawhub://...`` flow that already knows
+how to download the actual tarball at install time.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from defenseclaw.config import RegistrySource
+from defenseclaw.registries.adapters._base import (
+    IngestError,
+    http_get,
+)
+from defenseclaw.registries.manifest import (
+    NAME_RE,
+    Manifest,
+    ManifestEntry,
+)
+from defenseclaw.registries.ssrf import Resolver
+
+DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org"
+
+
+def fetch_clawhub(
+    source: RegistrySource,
+    *,
+    allow_private: bool = False,
+    resolver: Resolver | None = None,
+) -> tuple[Manifest, bytes]:
+    """Synthesize a :class:`Manifest` from the openclaw npm package.
+
+    The fetch goes through :func:`http_get` so the SSRF guard, response
+    size cap, and redirect-rebound-against-the-allow-list checks apply
+    to operator-overridden npm registries the same way they do to
+    every other adapter — historically this adapter called
+    :func:`requests.get` directly, which left a hole when ``--url``
+    pointed at internal infra.
+    """
+    registry = (source.url or "").strip() or DEFAULT_NPM_REGISTRY
+    if not registry.startswith(("http://", "https://")):
+        raise IngestError(
+            f"clawhub source URL must be http(s); got {registry!r}"
+        )
+    raw = http_get(
+        f"{registry}/openclaw/latest",
+        auth_env=source.auth_env,
+        accept="application/json",
+        allow_private=allow_private,
+        resolver=resolver,
+    )
+    try:
+        meta: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise IngestError(f"npm metadata is not valid JSON: {exc}") from exc
+
+    plugins = (
+        meta.get("openclaw", {}).get("plugins")
+        or meta.get("plugins")
+        or {}
+    )
+    if not isinstance(plugins, dict):
+        raise IngestError(
+            "openclaw package metadata is missing the plugins map; "
+            "either upgrade openclaw or use kind=http_yaml against "
+            "your own catalog"
+        )
+
+    entries: list[ManifestEntry] = []
+    for plugin_name, plugin_meta in sorted(plugins.items()):
+        if not isinstance(plugin_name, str) or not NAME_RE.match(plugin_name):
+            continue
+        if not isinstance(plugin_meta, dict):
+            plugin_meta = {}
+        entries.append(ManifestEntry(
+            name=plugin_name,
+            type="skill",
+            source_url=f"clawhub://{plugin_name}",
+            version=str(plugin_meta.get("version", "") or ""),
+            license=str(plugin_meta.get("license", "") or ""),
+            publisher="clawhub",
+            description=str(plugin_meta.get("description", "") or "")[:2048],
+            homepage=str(plugin_meta.get("homepage", "") or "")[:2048],
+        ))
+
+    manifest = Manifest(
+        schema_version=1,
+        publisher="clawhub",
+        generated_at=str(meta.get("time", {}).get("modified", "") or ""),
+        entries=entries,
+    )
+    return manifest, raw

--- a/cli/defenseclaw/registries/adapters/file.py
+++ b/cli/defenseclaw/registries/adapters/file.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Local-file manifest adapter — kind=file.
+
+Reads ``source.url`` as a filesystem path. Useful for air-gapped
+deployments, regression tests, and the TUI dry-run flow that lets an
+operator preview a manifest before promoting it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from defenseclaw.config import RegistrySource
+from defenseclaw.registries.adapters._base import (
+    MAX_MANIFEST_BYTES,
+    IngestError,
+    normalize_url,
+)
+from defenseclaw.registries.manifest import Manifest, parse_manifest
+
+
+def fetch_file(source: RegistrySource) -> tuple[Manifest, bytes]:
+    url = normalize_url(source)
+    if not url:
+        raise IngestError(f"source {source.id!r} has no path")
+    if url.lower().startswith("file://"):
+        url = url[len("file://"):]
+    p = Path(url).expanduser()
+    if not p.is_absolute():
+        raise IngestError(
+            f"source {source.id!r} path must be absolute (got {url!r})"
+        )
+    if not p.exists():
+        raise IngestError(f"manifest file does not exist: {p}")
+    if not p.is_file():
+        raise IngestError(f"manifest path is not a regular file: {p}")
+    try:
+        size = p.stat().st_size
+    except OSError as exc:
+        raise IngestError(f"could not stat {p}: {exc}") from exc
+    if size > MAX_MANIFEST_BYTES:
+        raise IngestError(
+            f"manifest file is {size} bytes (max {MAX_MANIFEST_BYTES})"
+        )
+    raw = p.read_bytes()
+    manifest = parse_manifest(raw)
+    return manifest, raw

--- a/cli/defenseclaw/registries/adapters/git.py
+++ b/cli/defenseclaw/registries/adapters/git.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Git-clone manifest adapter — kind=git.
+
+Performs a shallow ``git clone --depth 1`` of *source.url* into a
+tempdir, then reads ``defenseclaw-registry.yaml`` (or
+``defenseclaw-registry.json``) from the repo root.
+
+Refuses anything that isn't an HTTP(S) URL — see
+:func:`defenseclaw.registries.ssrf.guard_git_url`. SSH-based git is
+intentionally out of scope: it requires private key material and
+host-key trust decisions that don't belong in an automated ingest
+pipeline.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import tempfile
+from pathlib import Path
+
+from defenseclaw.config import RegistrySource
+from defenseclaw.registries.adapters._base import (
+    MAX_MANIFEST_BYTES,
+    IngestError,
+    normalize_url,
+)
+from defenseclaw.registries.manifest import Manifest, parse_manifest
+from defenseclaw.registries.ssrf import Resolver, SSRFError, guard_git_url
+
+CLONE_TIMEOUT = 60.0
+MANIFEST_NAMES = (
+    "defenseclaw-registry.yaml",
+    "defenseclaw-registry.yml",
+    "defenseclaw-registry.json",
+)
+
+
+def fetch_git(
+    source: RegistrySource,
+    *,
+    allow_private: bool = False,
+    resolver: Resolver | None = None,
+) -> tuple[Manifest, bytes]:
+    url = normalize_url(source)
+    if not url:
+        raise IngestError(f"source {source.id!r} has no URL")
+    try:
+        guard_git_url(url, allow_private=allow_private, resolver=resolver)
+    except SSRFError as exc:
+        raise IngestError(str(exc)) from exc
+
+    # Token-in-URL injection is a real footgun (e.g. ``https://x:tok@host``)
+    # — refuse so operators always go through the auth_env path. The guard
+    # also blocks shell metacharacters that could escape into the subprocess
+    # call below in case `git` ever forwards them to a helper.
+    if "@" in url.split("//", 1)[-1].split("/", 1)[0]:
+        raise IngestError(
+            "git URL must not embed credentials; use --auth-env to pass a token"
+        )
+    if any(c in url for c in (" ", "`", "$")):
+        raise IngestError("git URL contains disallowed shell metacharacters")
+
+    env = os.environ.copy()
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    if source.auth_env:
+        token = os.environ.get(source.auth_env, "")
+        if token:
+            env["GIT_ASKPASS"] = "echo"
+            env["GIT_HTTP_EXTRAHEADER"] = f"Authorization: Bearer {token}"
+
+    with tempfile.TemporaryDirectory(prefix="dc-reg-git-") as tmp:
+        cmd = [
+            "git", "clone",
+            "--depth", "1",
+            "--no-tags",
+            "--single-branch",
+            "--",
+            url,
+            tmp,
+        ]
+        try:
+            result = subprocess.run(  # noqa: S603 - argv list, no shell
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=CLONE_TIMEOUT,
+                env=env,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise IngestError(
+                "git binary not found; install git or use kind=http_yaml"
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise IngestError(
+                f"git clone timed out after {CLONE_TIMEOUT}s for "
+                f"{shlex.quote(url)}"
+            ) from exc
+        if result.returncode != 0:
+            raise IngestError(
+                f"git clone failed (exit {result.returncode}): "
+                f"{result.stderr.strip()[:240]}"
+            )
+
+        for name in MANIFEST_NAMES:
+            candidate = Path(tmp) / name
+            if candidate.is_file():
+                size = candidate.stat().st_size
+                if size > MAX_MANIFEST_BYTES:
+                    raise IngestError(
+                        f"manifest {name} is {size} bytes (max {MAX_MANIFEST_BYTES})"
+                    )
+                raw = candidate.read_bytes()
+                manifest = parse_manifest(raw)
+                return manifest, raw
+
+        raise IngestError(
+            f"no defenseclaw-registry manifest at repo root "
+            f"(looked for {', '.join(MANIFEST_NAMES)})"
+        )

--- a/cli/defenseclaw/registries/adapters/http_manifest.py
+++ b/cli/defenseclaw/registries/adapters/http_manifest.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic HTTPS manifest adapter — kind=http_yaml / http_json.
+
+The fetch is identical regardless of declared content type; the parser
+auto-detects YAML vs JSON. The ``http_yaml`` / ``http_json`` split in
+the source kind is purely advisory (it lets the TUI render a friendlier
+hint, and a future cron scheduler could pick different mime hints) —
+the adapter doesn't care which one came in.
+"""
+
+from __future__ import annotations
+
+from defenseclaw.config import RegistrySource
+from defenseclaw.registries.adapters._base import (
+    IngestError,
+    http_get,
+    normalize_url,
+)
+from defenseclaw.registries.manifest import Manifest, parse_manifest
+from defenseclaw.registries.ssrf import Resolver
+
+
+def fetch_http(
+    source: RegistrySource,
+    *,
+    allow_private: bool = False,
+    resolver: Resolver | None = None,
+) -> tuple[Manifest, bytes]:
+    url = normalize_url(source)
+    if not url:
+        raise IngestError(
+            f"source {source.id!r} has no URL — set --url to register the catalog"
+        )
+    raw = http_get(
+        url,
+        auth_env=source.auth_env,
+        allow_private=allow_private,
+        resolver=resolver,
+    )
+    manifest = parse_manifest(raw)
+    return manifest, raw

--- a/cli/defenseclaw/registries/adapters/skills_sh.py
+++ b/cli/defenseclaw/registries/adapters/skills_sh.py
@@ -1,0 +1,385 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""skills.sh manifest adapter — kind=skills_sh.
+
+Maps the skills.sh public catalog (`https://skills.sh/api/v1/`) into a
+vendor-neutral :class:`Manifest`. skills.sh is the open agent skills
+directory maintained by Vercel that aggregates GitHub-hosted skill
+repos — every entry on the leaderboard ultimately resolves to a
+``github.com/<owner>/<repo>`` install URL.
+
+The adapter intentionally keeps the surface small:
+
+* ``view=curated``   — calls ``/api/v1/skills/curated`` once.
+                       Matches the "Official" tab on skills.sh; the
+                       safest default for a high-trust environment
+                       since these are publisher-vetted skills.
+* ``view=all-time``  — paginated ``/api/v1/skills``, sorted by total
+                       installs. Use when an operator wants to mirror
+                       broad popular usage and let the scanner +
+                       approve workflow filter.
+* ``view=trending``  — same endpoint with ``view=trending`` for recent
+                       growth.
+* ``view=hot``       — same endpoint with ``view=hot`` (last hour vs
+                       same hour yesterday).
+
+URL format the operator passes to ``--url`` (all optional):
+
+* Empty                                   → ``view=curated``
+* ``curated`` / ``all-time`` / ``trending`` / ``hot`` → fetch that view
+* ``https://skills.sh?view=trending&max=200`` → explicit override
+
+Caps:
+
+* ``max`` (default 200)  — hard cap on entries returned, applied
+                           after pagination. We refuse anything over
+                           :data:`MAX_SKILLS_RESULTS` so a runaway
+                           query can't OOM the scanner subprocess.
+* ``per_page`` (50)      — page size for listing endpoints. The API
+                           supports up to 500 but smaller pages let
+                           us bail early if the server starts
+                           returning malformed rows.
+
+isDuplicate entries are filtered out — skills.sh flags forks/copies
+and we want one canonical row per skill.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+from defenseclaw.config import RegistrySource
+from defenseclaw.registries.adapters._base import (
+    IngestError,
+    http_get,
+)
+from defenseclaw.registries.manifest import (
+    NAME_RE,
+    Manifest,
+    ManifestEntry,
+)
+from defenseclaw.registries.ssrf import Resolver
+
+DEFAULT_BASE_URL = "https://skills.sh"
+"""Default skills.sh base URL.
+
+Operators on a private mirror that re-serves the same JSON shape can
+override via ``--url https://mirror.example.com``; the adapter only
+calls ``GET /api/v1/skills*`` so any endpoint conforming to the
+public skills.sh API works.
+"""
+
+DEFAULT_VIEW = "curated"
+DEFAULT_PER_PAGE = 50
+DEFAULT_MAX_RESULTS = 200
+
+MAX_SKILLS_RESULTS = 2000
+"""Hard upper bound on entries returned to the sync pipeline.
+
+The API itself supports paging up to ``per_page=500`` and arbitrary
+page counts, but the scanner runs one subprocess per skill at promote
+time. 2k entries is already an aggressive ceiling; anything larger
+should be sliced into multiple narrower sources (e.g. one per
+publisher) so an operator's approve queue stays manageable.
+"""
+
+KNOWN_VIEWS = ("all-time", "trending", "hot", "curated")
+
+# Tightly scoped slug pattern — skills.sh uses lowercase kebab-case for
+# slugs and ``owner/repo`` for sources. We rebuild the manifest entry
+# name from these and refuse anything that wouldn't survive
+# :data:`NAME_RE`. The slash in source names becomes a dash in the
+# manifest name so the value is safe for filesystem and audit-store
+# use (matches the smithery adapter's normalisation).
+_SOURCE_SAFE_RE = re.compile(r"[^a-zA-Z0-9._-]")
+
+
+def fetch_skills_sh(
+    source: RegistrySource,
+    *,
+    allow_private: bool = False,
+    resolver: Resolver | None = None,
+) -> tuple[Manifest, bytes]:
+    """Fetch the configured skills.sh view and return a Manifest."""
+    base_url, view, per_page, max_results = _parse_source_url(
+        source.url or "",
+    )
+
+    if view == "curated":
+        entries, raw = _fetch_curated(
+            base_url, source, allow_private, resolver, max_results,
+        )
+    else:
+        entries, raw = _fetch_paginated(
+            base_url, view, per_page, max_results,
+            source, allow_private, resolver,
+        )
+
+    manifest = Manifest(
+        schema_version=1,
+        publisher="skills.sh",
+        entries=entries,
+    )
+    return manifest, raw
+
+
+# ---------------------------------------------------------------------------
+# URL parsing
+# ---------------------------------------------------------------------------
+
+def _parse_source_url(raw: str) -> tuple[str, str, int, int]:
+    """Return (base_url, view, per_page, max_results) from *raw*.
+
+    *raw* is the operator-supplied ``source.url`` and is intentionally
+    permissive: empty / a bare view keyword / a full https URL with
+    query params are all accepted, with caps enforced after parsing.
+    """
+    raw = (raw or "").strip()
+    if not raw:
+        return DEFAULT_BASE_URL, DEFAULT_VIEW, DEFAULT_PER_PAGE, DEFAULT_MAX_RESULTS
+    if raw in KNOWN_VIEWS:
+        return DEFAULT_BASE_URL, raw, DEFAULT_PER_PAGE, DEFAULT_MAX_RESULTS
+
+    if not raw.startswith(("http://", "https://")):
+        raise IngestError(
+            "skills_sh source URL must be empty, one of "
+            f"{KNOWN_VIEWS}, or a full https URL (got {raw!r})"
+        )
+
+    parsed = urlparse(raw)
+    base = urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
+    qs = parse_qs(parsed.query)
+
+    view = (qs.get("view", [DEFAULT_VIEW])[0] or DEFAULT_VIEW).lower()
+    if view not in KNOWN_VIEWS:
+        raise IngestError(
+            f"skills_sh view must be one of {KNOWN_VIEWS} (got {view!r})"
+        )
+
+    per_page = _parse_pos_int(
+        qs.get("per_page", [str(DEFAULT_PER_PAGE)])[0], "per_page",
+        default=DEFAULT_PER_PAGE,
+    )
+    if per_page < 1 or per_page > 500:
+        raise IngestError(
+            f"skills_sh per_page must be 1..500 (got {per_page})"
+        )
+
+    max_results = _parse_pos_int(
+        qs.get("max", [str(DEFAULT_MAX_RESULTS)])[0], "max",
+        default=DEFAULT_MAX_RESULTS,
+    )
+    if max_results < 1 or max_results > MAX_SKILLS_RESULTS:
+        raise IngestError(
+            f"skills_sh max must be 1..{MAX_SKILLS_RESULTS} (got {max_results})"
+        )
+
+    return base, view, per_page, max_results
+
+
+def _parse_pos_int(value: str, label: str, *, default: int) -> int:
+    s = (value or "").strip()
+    if not s:
+        return default
+    try:
+        return int(s)
+    except ValueError as exc:
+        raise IngestError(f"skills_sh {label} must be an integer (got {value!r})") from exc
+
+
+# ---------------------------------------------------------------------------
+# Endpoint fetchers
+# ---------------------------------------------------------------------------
+
+def _fetch_curated(
+    base_url: str,
+    source: RegistrySource,
+    allow_private: bool,
+    resolver: Resolver | None,
+    max_results: int,
+) -> tuple[list[ManifestEntry], bytes]:
+    url = f"{base_url}/api/v1/skills/curated"
+    raw = http_get(
+        url,
+        auth_env=source.auth_env,
+        accept="application/json",
+        allow_private=allow_private,
+        resolver=resolver,
+    )
+    payload = _decode_json(raw)
+    owners = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(owners, list):
+        raise IngestError(
+            "skills.sh curated response missing 'data' array"
+        )
+
+    entries: list[ManifestEntry] = []
+    seen: set[str] = set()
+    for owner in owners:
+        if not isinstance(owner, dict):
+            continue
+        skills = owner.get("skills")
+        if not isinstance(skills, list):
+            continue
+        for skill in skills:
+            entry = _skill_to_entry(skill)
+            if entry is None or entry.name in seen:
+                continue
+            seen.add(entry.name)
+            entries.append(entry)
+            if len(entries) >= max_results:
+                return entries, raw
+    return entries, raw
+
+
+def _fetch_paginated(
+    base_url: str,
+    view: str,
+    per_page: int,
+    max_results: int,
+    source: RegistrySource,
+    allow_private: bool,
+    resolver: Resolver | None,
+) -> tuple[list[ManifestEntry], bytes]:
+    """Walk ``/api/v1/skills`` until *max_results* or pagination ends.
+
+    The first page's raw bytes are kept as the canonical "raw manifest"
+    for cache persistence — operators inspecting
+    ``~/.defenseclaw/registries/<id>/manifest.json`` will see the
+    server-shaped response, not our re-stitched view, which makes
+    drift between API versions easier to spot.
+    """
+    entries: list[ManifestEntry] = []
+    seen: set[str] = set()
+    first_raw: bytes | None = None
+    page = 0
+    safety_pages = (max_results // max(per_page, 1)) + 2
+    while len(entries) < max_results and page < safety_pages:
+        params = urlencode({
+            "view": view,
+            "page": page,
+            "per_page": min(per_page, max_results - len(entries)),
+        })
+        url = f"{base_url}/api/v1/skills?{params}"
+        raw = http_get(
+            url,
+            auth_env=source.auth_env,
+            accept="application/json",
+            allow_private=allow_private,
+            resolver=resolver,
+        )
+        if first_raw is None:
+            first_raw = raw
+        payload = _decode_json(raw)
+        if not isinstance(payload, dict):
+            raise IngestError("skills.sh response was not a JSON object")
+        rows = payload.get("data")
+        if not isinstance(rows, list):
+            raise IngestError("skills.sh response missing 'data' array")
+        if not rows:
+            break
+        for row in rows:
+            entry = _skill_to_entry(row)
+            if entry is None or entry.name in seen:
+                continue
+            seen.add(entry.name)
+            entries.append(entry)
+            if len(entries) >= max_results:
+                break
+        pagination = payload.get("pagination")
+        if not isinstance(pagination, dict) or not pagination.get("hasMore"):
+            break
+        page += 1
+
+    if first_raw is None:
+        first_raw = b'{"data":[]}'
+    return entries, first_raw
+
+
+# ---------------------------------------------------------------------------
+# Mapping
+# ---------------------------------------------------------------------------
+
+def _skill_to_entry(row: Any) -> ManifestEntry | None:
+    """Convert a skills.sh ``V1Skill`` object into a :class:`ManifestEntry`.
+
+    Returns None for malformed rows or known forks/copies — the
+    sync pipeline already logs structured errors at a higher layer,
+    so silently dropping a single bad row keeps the rest of the
+    catalog usable.
+    """
+    if not isinstance(row, dict):
+        return None
+    if row.get("isDuplicate") is True:
+        return None
+
+    skill_id = str(row.get("id") or "").strip()
+    slug = str(row.get("slug") or "").strip()
+    skill_source = str(row.get("source") or "").strip()
+    if not skill_id or not slug or not skill_source:
+        return None
+
+    # Manifest names must match NAME_RE — collapse "owner/repo/slug"
+    # into "owner-repo-slug" with non-allowed chars replaced by dashes,
+    # then truncate to the 128-char cap. Skills.sh slugs and sources
+    # are already kebab-cased so this rarely changes anything; the
+    # collapse defends against future schema additions that might
+    # introduce other characters.
+    name = _SOURCE_SAFE_RE.sub("-", skill_id.replace("/", "-"))
+    name = name.strip("-").strip(".")[:128]
+    if not name or not NAME_RE.match(name):
+        return None
+
+    install_url = str(row.get("installUrl") or "").strip()
+    source_type = str(row.get("sourceType") or "github").strip().lower()
+
+    # GitHub repos are by far the most common case. We pass the repo
+    # URL through verbatim — the existing skill scanner treats
+    # ``https://github.com/owner/repo`` as a tarball download
+    # candidate via the registry-side install flow. Well-known
+    # sources are passed through unchanged for a future
+    # ``.well-known/skills`` scan path.
+    #
+    # HTTPS-only on purpose: skills.sh is a TLS-only public catalog
+    # and accepting plain ``http://`` would let an on-path attacker
+    # downgrade a skill download. The scanner happily fetches the
+    # URL later, so this guard is the only place we can refuse the
+    # install before it lands in cache.
+    if not install_url.startswith("https://"):
+        return None
+    if source_type == "github" and "github.com" not in install_url:
+        return None
+
+    publisher = skill_source.split("/", 1)[0] if "/" in skill_source else skill_source
+    description = str(row.get("name") or "")[:256]
+    homepage = str(row.get("url") or "")
+    if homepage and not homepage.startswith("https://"):
+        homepage = ""
+
+    return ManifestEntry(
+        name=name,
+        type="skill",
+        source_url=install_url,
+        publisher=publisher,
+        description=description,
+        homepage=homepage,
+        tags=[source_type] if source_type else [],
+    )
+
+
+def _decode_json(raw: bytes) -> Any:
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise IngestError(f"skills.sh response is not valid JSON: {exc}") from exc

--- a/cli/defenseclaw/registries/adapters/smithery.py
+++ b/cli/defenseclaw/registries/adapters/smithery.py
@@ -1,0 +1,191 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smithery.ai manifest adapter — kind=smithery.
+
+Maps the Smithery catalog API response into a vendor-neutral
+:class:`Manifest`. The default endpoint is
+``https://registry.smithery.ai/servers``; operators on a private
+mirror can override the URL.
+
+The adapter intentionally exposes a minimal subset of Smithery
+metadata — the goal is to surface enough fields for the scanner to
+run and for the operator to make an approve/reject decision in the
+TUI, not to mirror Smithery's full schema.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from defenseclaw.config import RegistrySource
+from defenseclaw.registries.adapters._base import (
+    IngestError,
+    http_get,
+)
+from defenseclaw.registries.manifest import (
+    COMMAND_RE,
+    NAME_RE,
+    Manifest,
+    ManifestEntry,
+)
+from defenseclaw.registries.ssrf import Resolver, SSRFError, guard_url
+
+DEFAULT_SMITHERY_URL = "https://registry.smithery.ai/servers"
+
+
+def fetch_smithery(
+    source: RegistrySource,
+    *,
+    allow_private: bool = False,
+    resolver: Resolver | None = None,
+) -> tuple[Manifest, bytes]:
+    url = (source.url or "").strip() or DEFAULT_SMITHERY_URL
+    raw = http_get(
+        url,
+        auth_env=source.auth_env,
+        accept="application/json",
+        allow_private=allow_private,
+        resolver=resolver,
+    )
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise IngestError(f"smithery response is not valid JSON: {exc}") from exc
+
+    servers = _extract_servers(payload)
+    entries: list[ManifestEntry] = []
+    for server in servers:
+        if not isinstance(server, dict):
+            continue
+        try:
+            entry = _server_to_entry(
+                server,
+                allow_private=allow_private,
+                resolver=resolver,
+            )
+        except IngestError:
+            # Skip individual bad rows — a single malformed server
+            # shouldn't break the whole sync. Operators can still see
+            # what was rejected via the structured log.
+            continue
+        if entry is None:
+            continue
+        entries.append(entry)
+
+    manifest = Manifest(
+        schema_version=1,
+        publisher="smithery",
+        entries=entries,
+    )
+    return manifest, raw
+
+
+def _extract_servers(payload: Any) -> list[dict[str, Any]]:
+    """Return the server array from a Smithery response.
+
+    Smithery uses a few historical envelope shapes; we accept the
+    common ones and bail with a clear error otherwise so a future API
+    change is easy to spot.
+    """
+    if isinstance(payload, list):
+        return [s for s in payload if isinstance(s, dict)]
+    if not isinstance(payload, dict):
+        raise IngestError("smithery response was neither array nor object")
+    for key in ("servers", "data", "items", "results"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            return [s for s in value if isinstance(s, dict)]
+    raise IngestError(
+        "smithery response is missing a servers array (looked for "
+        "'servers', 'data', 'items', 'results')"
+    )
+
+
+def _server_to_entry(
+    server: dict[str, Any],
+    *,
+    allow_private: bool = False,
+    resolver: Resolver | None = None,
+) -> ManifestEntry | None:
+    name = str(
+        server.get("qualifiedName")
+        or server.get("name")
+        or server.get("id")
+        or "",
+    )
+    name = name.replace("/", "-").replace("@", "").strip()
+    if not NAME_RE.match(name):
+        return None
+
+    deployment = server.get("deployment") or {}
+    if not isinstance(deployment, dict):
+        deployment = {}
+
+    transport = str(deployment.get("transport") or server.get("transport") or "stdio")
+    transport = transport.strip().lower()
+
+    command = str(deployment.get("command") or "")
+    if command and not COMMAND_RE.match(command):
+        return None
+
+    args_raw = deployment.get("args") or []
+    if not isinstance(args_raw, list):
+        args_raw = []
+    args = [str(a) for a in args_raw[:64]]
+
+    env_raw = deployment.get("env") or []
+    if isinstance(env_raw, dict):
+        env_raw = list(env_raw.keys())
+    if not isinstance(env_raw, list):
+        env_raw = []
+    env_required = [str(e) for e in env_raw[:32] if isinstance(e, str)]
+
+    url = str(deployment.get("url") or "")
+    if transport == "stdio" and not command:
+        return None
+    if transport != "stdio":
+        if not url:
+            return None
+        # Network-bound MCP transports go straight from the
+        # registry into ``asset_policy.mcp.registry`` and are then
+        # opened by the gateway connector. A malicious smithery
+        # entry could publish ``url: http://internal.corp/admin``;
+        # the scanner is unlikely to flag the URL itself, so we
+        # gate it here:
+        # * HTTPS-only — no plaintext MCP transports.
+        # * SSRF guard — same allow-list and private-IP policy
+        #   as the registry fetch path. ``allow_private`` is
+        #   forwarded so an operator who explicitly opted in for
+        #   the ingest also opts in for the published targets.
+        if not url.startswith("https://"):
+            return None
+        try:
+            guard_url(url, allow_private=allow_private, resolver=resolver)
+        except SSRFError:
+            return None
+
+    return ManifestEntry(
+        name=name,
+        type="mcp",
+        transport=transport if transport in (
+            "stdio", "http", "sse", "streamable-http", "websocket",
+        ) else "stdio",
+        command=command,
+        args=args,
+        env_required=env_required,
+        url=url,
+        version=str(server.get("version") or ""),
+        license=str(server.get("license") or ""),
+        publisher=str(server.get("publisher") or "smithery"),
+        description=str(server.get("description") or "")[:2048],
+        homepage=str(server.get("homepage") or "")[:2048],
+    )

--- a/cli/defenseclaw/registries/cache.py
+++ b/cli/defenseclaw/registries/cache.py
@@ -1,0 +1,339 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""On-disk cache of fetched manifests + per-entry scan verdicts.
+
+Layout::
+
+    ~/.defenseclaw/registries/<source-id>/index.json
+    ~/.defenseclaw/registries/<source-id>/manifest.yaml   # last raw fetch
+
+``index.json`` is the structured artefact the TUI and ``registry
+entries`` consume. ``manifest.yaml`` is kept verbatim alongside it for
+forensic inspection — operators occasionally need to diff what the
+publisher served vs what made it through the validator.
+
+All files are written via :func:`_atomic_write` (tempfile + rename) at
+mode 0o600. ``manifest.yaml`` may legitimately contain ingest tokens
+embedded in URLs and we don't want a half-written read leaking through
+a concurrent ``registry list``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from defenseclaw.registries.manifest import Manifest, ManifestEntry, parse_manifest
+
+
+@dataclass
+class EntryVerdict:
+    """Per-entry scan outcome cached for fast TUI rendering."""
+
+    name: str
+    type: str
+    status: str = "pending"   # pending | clean | warning | blocked | error
+    severity: str = ""
+    findings: int = 0
+    scan_id: str = ""
+    target: str = ""
+    error: str = ""
+    last_scanned_at: str = ""
+    approved: bool = False
+    rejected: bool = False
+    source_url: str = ""
+    transport: str = ""
+    command: str = ""
+    args: list[str] = field(default_factory=list)
+    url: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        out = {
+            "name": self.name,
+            "type": self.type,
+            "status": self.status,
+            "approved": self.approved,
+            "rejected": self.rejected,
+        }
+        for key in (
+            "severity", "scan_id", "target", "error", "last_scanned_at",
+            "source_url", "transport", "command", "url",
+        ):
+            value = getattr(self, key)
+            if value:
+                out[key] = value
+        if self.findings:
+            out["findings"] = self.findings
+        if self.args:
+            out["args"] = list(self.args)
+        return out
+
+
+@dataclass
+class SourceIndex:
+    """Cached state for one registry source."""
+
+    source_id: str = ""
+    schema_version: int = 1
+    fetched_at: str = ""
+    publisher: str = ""
+    entry_count: int = 0
+    clean_count: int = 0
+    warning_count: int = 0
+    blocked_count: int = 0
+    error_count: int = 0
+    verdicts: list[EntryVerdict] = field(default_factory=list)
+
+    def recount(self) -> None:
+        self.entry_count = len(self.verdicts)
+        self.clean_count = sum(1 for v in self.verdicts if v.status == "clean")
+        self.warning_count = sum(1 for v in self.verdicts if v.status == "warning")
+        self.blocked_count = sum(1 for v in self.verdicts if v.status == "blocked")
+        self.error_count = sum(1 for v in self.verdicts if v.status == "error")
+
+    def find(self, type_: str, name: str) -> EntryVerdict | None:
+        for v in self.verdicts:
+            if v.type == type_ and v.name == name:
+                return v
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        out = asdict(self)
+        out["verdicts"] = [v.to_dict() for v in self.verdicts]
+        return out
+
+
+def cache_root(data_dir: str) -> Path:
+    """Return ``~/.defenseclaw/registries`` (creating it lazily)."""
+    base = Path(data_dir) / "registries"
+    base.mkdir(mode=0o700, exist_ok=True, parents=True)
+    return base
+
+
+def source_dir(data_dir: str, source_id: str) -> Path:
+    """Per-source directory under :func:`cache_root`."""
+    if not source_id or "/" in source_id or ".." in source_id:
+        raise ValueError(f"invalid source id: {source_id!r}")
+    d = cache_root(data_dir) / source_id
+    d.mkdir(mode=0o700, exist_ok=True)
+    return d
+
+
+def index_path(data_dir: str, source_id: str) -> Path:
+    return source_dir(data_dir, source_id) / "index.json"
+
+
+def manifest_path(data_dir: str, source_id: str) -> Path:
+    return source_dir(data_dir, source_id) / "manifest.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Index read / write
+# ---------------------------------------------------------------------------
+
+def load_index(data_dir: str, source_id: str) -> SourceIndex:
+    """Load the cached :class:`SourceIndex` for *source_id*.
+
+    Missing / corrupt files return a fresh, zero-valued
+    :class:`SourceIndex` so the caller can build it up on first sync
+    without a guard pyramid.
+    """
+    path = index_path(data_dir, source_id)
+    if not path.exists():
+        return SourceIndex(source_id=source_id)
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return SourceIndex(source_id=source_id)
+    if not isinstance(data, dict):
+        return SourceIndex(source_id=source_id)
+    verdicts: list[EntryVerdict] = []
+    for raw in data.get("verdicts") or []:
+        if not isinstance(raw, dict):
+            continue
+        verdicts.append(EntryVerdict(
+            name=str(raw.get("name", "")),
+            type=str(raw.get("type", "")),
+            status=str(raw.get("status", "pending")),
+            severity=str(raw.get("severity", "")),
+            findings=int(raw.get("findings", 0) or 0),
+            scan_id=str(raw.get("scan_id", "")),
+            target=str(raw.get("target", "")),
+            error=str(raw.get("error", "")),
+            last_scanned_at=str(raw.get("last_scanned_at", "")),
+            approved=bool(raw.get("approved", False)),
+            rejected=bool(raw.get("rejected", False)),
+            source_url=str(raw.get("source_url", "")),
+            transport=str(raw.get("transport", "")),
+            command=str(raw.get("command", "")),
+            args=[str(a) for a in (raw.get("args") or [])],
+            url=str(raw.get("url", "")),
+        ))
+    idx = SourceIndex(
+        source_id=str(data.get("source_id", source_id)),
+        schema_version=int(data.get("schema_version", 1) or 1),
+        fetched_at=str(data.get("fetched_at", "")),
+        publisher=str(data.get("publisher", "")),
+        verdicts=verdicts,
+    )
+    idx.recount()
+    return idx
+
+
+def save_index(data_dir: str, source_id: str, idx: SourceIndex) -> None:
+    """Write *idx* atomically to ``index.json`` (mode 0o600)."""
+    idx.recount()
+    path = index_path(data_dir, source_id)
+    payload = json.dumps(idx.to_dict(), indent=2, sort_keys=True) + "\n"
+    _atomic_write(path, payload.encode("utf-8"))
+
+
+def save_manifest(data_dir: str, source_id: str, raw: bytes | str) -> None:
+    """Persist the raw fetched manifest bytes for forensic inspection."""
+    if isinstance(raw, str):
+        raw = raw.encode("utf-8")
+    _atomic_write(manifest_path(data_dir, source_id), raw)
+
+
+def remove_source(data_dir: str, source_id: str) -> None:
+    """Delete the cache directory for *source_id*.
+
+    Best-effort: missing directories are ignored so this is safe to
+    call from ``registry remove`` regardless of prior sync state.
+
+    Uses :func:`shutil.rmtree` so the cache layout can grow nested
+    directories (e.g. a future ``manifests/`` history folder) without
+    leaving orphaned files when the operator removes the source. The
+    earlier per-file unlink loop would silently succeed and then
+    refuse to delete the parent directory, leaving stale state behind.
+    """
+    try:
+        d = source_dir(data_dir, source_id)
+    except ValueError:
+        return
+    if not d.exists():
+        return
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def index_from_manifest(source_id: str, manifest: Manifest) -> SourceIndex:
+    """Project a fresh manifest into a :class:`SourceIndex` skeleton.
+
+    Used at the start of a sync — every entry starts at
+    ``status="pending"`` and gets updated as the scanner returns.
+    """
+    verdicts: list[EntryVerdict] = []
+    for entry in manifest.entries:
+        verdicts.append(_verdict_from_entry(entry))
+    idx = SourceIndex(
+        source_id=source_id,
+        schema_version=manifest.schema_version,
+        publisher=manifest.publisher,
+        verdicts=verdicts,
+    )
+    idx.recount()
+    return idx
+
+
+def merge_manifest_into_index(
+    idx: SourceIndex, manifest: Manifest,
+) -> SourceIndex:
+    """Apply a freshly-fetched manifest to an existing index.
+
+    Preserves prior verdicts where the (type, name) tuple still
+    appears; drops verdicts for entries that have been removed; adds
+    new placeholders for new entries. Approved / rejected flags are
+    preserved across syncs so an operator's manual override survives a
+    publisher refresh.
+    """
+    keep: dict[tuple[str, str], EntryVerdict] = {
+        (v.type, v.name): v for v in idx.verdicts
+    }
+    new_verdicts: list[EntryVerdict] = []
+    for entry in manifest.entries:
+        key = (entry.type, entry.name)
+        prior = keep.get(key)
+        fresh = _verdict_from_entry(entry)
+        if prior is not None:
+            # Preserve operator overrides + last successful scan.
+            fresh.approved = prior.approved
+            fresh.rejected = prior.rejected
+            if prior.status in {"clean", "warning", "blocked"}:
+                fresh.status = prior.status
+                fresh.severity = prior.severity
+                fresh.findings = prior.findings
+                fresh.scan_id = prior.scan_id
+                fresh.target = prior.target
+                fresh.last_scanned_at = prior.last_scanned_at
+        new_verdicts.append(fresh)
+    idx.verdicts = new_verdicts
+    idx.publisher = manifest.publisher
+    idx.schema_version = manifest.schema_version
+    idx.recount()
+    return idx
+
+
+def _verdict_from_entry(entry: ManifestEntry) -> EntryVerdict:
+    return EntryVerdict(
+        name=entry.name,
+        type=entry.type,
+        status="pending",
+        source_url=entry.source_url,
+        transport=entry.transport,
+        command=entry.command,
+        args=list(entry.args),
+        url=entry.url,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Manifest reload helper — useful for the TUI to re-read an existing
+# cached manifest without a fresh fetch.
+# ---------------------------------------------------------------------------
+
+def load_cached_manifest(data_dir: str, source_id: str) -> Manifest | None:
+    path = manifest_path(data_dir, source_id)
+    if not path.exists():
+        return None
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return None
+    try:
+        return parse_manifest(raw)
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Atomic write — same pattern as connector_paths._atomic_write_json.
+# ---------------------------------------------------------------------------
+
+def _atomic_write(path: Path, data: bytes) -> None:
+    parent = path.parent
+    parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".dc-reg-", dir=str(parent))
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, str(path))
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise

--- a/cli/defenseclaw/registries/manifest.py
+++ b/cli/defenseclaw/registries/manifest.py
@@ -34,6 +34,7 @@ uniformly to every fetch path.
 
 from __future__ import annotations
 
+import datetime as _dt
 import json
 import re
 from dataclasses import dataclass, field
@@ -396,11 +397,56 @@ def _build_entry(raw: Any, default_connector: str) -> ManifestEntry:
 # Tiny string helpers — keep length / type validation tight and uniform.
 # ---------------------------------------------------------------------------
 
+def _coerce_yaml_scalar(value: Any, label: str) -> str:
+    """Coerce a YAML-auto-typed scalar to its string surface form.
+
+    PyYAML's safe_load resolves common patterns even when the publisher
+    didn't quote them: ``2026-05-07T20:00:00Z`` becomes ``datetime``,
+    ``1.0`` becomes ``float``, ``42`` becomes ``int``. The manifest
+    schema declares every text field as a string, so without coercion
+    a publisher who emits perfectly valid YAML hits a hard parse
+    failure on first sync. We accept the lossless scalar types and
+    render them with the syntax YAML used (``isoformat``-style for
+    timestamps; ``repr``-equivalent for ints/floats); structured
+    values (mapping / sequence / bytes) and ``bool`` (which would
+    silently coerce ``True`` to a misleading ``"True"`` token in fields
+    like ``version``) remain hard errors so manifest poisoning still
+    fails closed.
+    """
+    if isinstance(value, _dt.datetime):
+        # datetime.isoformat keeps offset / microseconds; we strip
+        # microseconds so the surface matches the typical
+        # publisher-written ``YYYY-MM-DDTHH:MM:SSZ`` form. Naive
+        # datetimes (no tzinfo) are emitted without a 'Z' since
+        # tagging them as UTC would be a lie.
+        if value.microsecond:
+            value = value.replace(microsecond=0)
+        s = value.isoformat()
+        if value.tzinfo is None:
+            return s
+        return s.replace("+00:00", "Z")
+    if isinstance(value, _dt.date):
+        return value.isoformat()
+    # Reject bool BEFORE int (bool is a subclass of int) so
+    # ``version: yes`` doesn't silently become "True".
+    if isinstance(value, bool):
+        raise ManifestError(
+            f"{label} must be a string (got bool — quote the value, e.g. \"true\")"
+        )
+    if isinstance(value, int | float):
+        # repr() avoids YAML's int(1) → "1" + float(1.0) → "1.0"
+        # both rendering identically; preserves the operator's intent.
+        return repr(value) if isinstance(value, float) else str(value)
+    raise ManifestError(
+        f"{label} must be a string (got {type(value).__name__})"
+    )
+
+
 def _opt_str(value: Any, label: str, *, max_len: int) -> str:
     if value is None:
         return ""
     if not isinstance(value, str):
-        raise ManifestError(f"{label} must be a string (got {type(value).__name__})")
+        value = _coerce_yaml_scalar(value, label)
     if len(value) > max_len:
         raise ManifestError(f"{label} exceeds {max_len} chars")
     return value
@@ -423,9 +469,7 @@ def _opt_str_list(value: Any, label: str, *, max_items: int, max_len: int) -> li
     out: list[str] = []
     for i, item in enumerate(value):
         if not isinstance(item, str):
-            raise ManifestError(
-                f"{label}[{i}] must be a string (got {type(item).__name__})"
-            )
+            item = _coerce_yaml_scalar(item, f"{label}[{i}]")
         if len(item) > max_len:
             raise ManifestError(f"{label}[{i}] exceeds {max_len} chars")
         out.append(item)

--- a/cli/defenseclaw/registries/manifest.py
+++ b/cli/defenseclaw/registries/manifest.py
@@ -1,0 +1,463 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Registry manifest dataclasses + schema validation.
+
+A manifest is the vendor-neutral document published by an external
+catalog source (corporate HTTPS YAML/JSON, smithery.ai, a git repo with
+``defenseclaw-registry.yaml`` at the root, etc.). Its schema is pinned
+in :mod:`schemas/registry-manifest.schema.json`. This module owns:
+
+* the in-memory representation (:class:`Manifest`,
+  :class:`ManifestEntry`) used throughout the ingest pipeline;
+* loose-tolerant parsing from YAML or JSON byte strings, with strict
+  validation against the JSON Schema (when available — the dependency
+  is optional so that ``defenseclaw registry list`` doesn't fail in
+  reduced-deps installs);
+* a hand-written fallback validator that enforces the same set of
+  invariants the JSON Schema declares — name/command character class,
+  enum membership, length caps — so the security-relevant guards are
+  always on.
+
+The character-class constraints intentionally match those in
+``cli/defenseclaw/registry.py::_CLAWHUB_NAME_RE`` and the existing
+``_safe_tar_extract`` helper so the same untrusted-input rules apply
+uniformly to every fetch path.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Shared regexes — kept as module-level compiled patterns so adapters and
+# tests can reuse them without re-importing this module's internals.
+# ---------------------------------------------------------------------------
+
+NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._\-]{0,127}$")
+"""Stable identifier for skills / MCP servers in a manifest.
+
+Matches the schema's ``pattern`` and the existing CLAWHUB regex in
+``cli/defenseclaw/registry.py``. Restrictive on purpose — the value is
+pasted into tar prefixes, scanner subprocess argv, and audit-store
+queries so anything outside ``[A-Za-z0-9._-]`` is rejected.
+"""
+
+COMMAND_RE = re.compile(r"^[A-Za-z0-9_./@-]*$")
+"""Allowed character class for an MCP entry's ``command`` field.
+
+Conservative on purpose — anything outside this class can smuggle
+shell metacharacters into the scanner subprocess.
+"""
+
+ENV_VAR_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,127}$")
+SOURCE_URL_RE = re.compile(r"^(clawhub://|https?://)")
+HTTP_URL_RE = re.compile(r"^https?://")
+SHA256_RE = re.compile(r"^[a-fA-F0-9]{64}$")
+
+KNOWN_TRANSPORTS = {"stdio", "http", "sse", "streamable-http", "websocket"}
+KNOWN_CONNECTORS = {"openclaw", "claudecode", "codex", "zeptoclaw"}
+KNOWN_TYPES = {"skill", "mcp"}
+
+MAX_ENTRIES = 10000
+MAX_ARGS = 64
+MAX_ENV_VARS = 32
+MAX_TAGS = 64
+MAX_STRING = 2048
+
+
+class ManifestError(ValueError):
+    """Raised when a manifest fails to load or validate."""
+
+
+@dataclass
+class ManifestEntry:
+    """One skill / MCP entry in a registry manifest.
+
+    Field semantics mirror the JSON Schema. Empty strings stand in for
+    missing optional fields so callers can use ``if entry.url`` cheaply
+    without juggling :data:`None`.
+    """
+
+    name: str
+    type: str
+    source_url: str = ""
+    sha256: str = ""
+    version: str = ""
+    license: str = ""
+    publisher: str = ""
+    description: str = ""
+    homepage: str = ""
+    connector: str = ""
+    tags: list[str] = field(default_factory=list)
+
+    transport: str = ""
+    command: str = ""
+    args: list[str] = field(default_factory=list)
+    env_required: list[str] = field(default_factory=list)
+    url: str = ""
+
+    def is_skill(self) -> bool:
+        return self.type == "skill"
+
+    def is_mcp(self) -> bool:
+        return self.type == "mcp"
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"name": self.name, "type": self.type}
+        for key in (
+            "source_url", "sha256", "version", "license", "publisher",
+            "description", "homepage", "connector", "transport",
+            "command", "url",
+        ):
+            value = getattr(self, key)
+            if value:
+                out[key] = value
+        if self.args:
+            out["args"] = list(self.args)
+        if self.env_required:
+            out["env_required"] = list(self.env_required)
+        if self.tags:
+            out["tags"] = list(self.tags)
+        return out
+
+
+@dataclass
+class Manifest:
+    """Parsed + validated catalog manifest."""
+
+    schema_version: int = 1
+    generated_at: str = ""
+    publisher: str = ""
+    default_connector: str = ""
+    entries: list[ManifestEntry] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"schema_version": self.schema_version}
+        if self.generated_at:
+            out["generated_at"] = self.generated_at
+        if self.publisher:
+            out["publisher"] = self.publisher
+        if self.default_connector:
+            out["default_connector"] = self.default_connector
+        out["entries"] = [e.to_dict() for e in self.entries]
+        return out
+
+    def filter_by_content(self, content: str) -> list[ManifestEntry]:
+        """Return entries matching the source's declared content type.
+
+        ``content`` is one of ``skill``, ``mcp``, ``both``. ``both``
+        returns everything; the others filter on :attr:`ManifestEntry.type`.
+        """
+        c = content.strip().lower()
+        if c == "both":
+            return list(self.entries)
+        if c == "skill":
+            return [e for e in self.entries if e.is_skill()]
+        if c == "mcp":
+            return [e for e in self.entries if e.is_mcp()]
+        return list(self.entries)
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+def parse_manifest(raw: str | bytes) -> Manifest:
+    """Parse *raw* as JSON or YAML and return a validated :class:`Manifest`.
+
+    YAML parsing uses :func:`yaml.safe_load` (no arbitrary-type
+    deserialization) and JSON parsing uses :func:`json.loads`. Either
+    representation is accepted because publishers may serve YAML for
+    humans and JSON for machines from the same endpoint.
+
+    Raises :class:`ManifestError` on parse / schema / invariant failures.
+    """
+    if isinstance(raw, bytes):
+        try:
+            raw = raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ManifestError("manifest is not valid UTF-8") from exc
+
+    text = raw.strip()
+    if not text:
+        raise ManifestError("manifest is empty")
+
+    data: Any
+    if text[0] in "{[":
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ManifestError(f"invalid JSON manifest: {exc}") from exc
+    else:
+        try:
+            data = yaml.safe_load(text)
+        except yaml.YAMLError as exc:
+            raise ManifestError(f"invalid YAML manifest: {exc}") from exc
+
+    return _build_manifest(data)
+
+
+def load_manifest_file(path: str | Path) -> Manifest:
+    """Read *path* from disk and return a validated :class:`Manifest`."""
+    p = Path(path)
+    try:
+        raw = p.read_bytes()
+    except OSError as exc:
+        raise ManifestError(f"could not read manifest {p}: {exc}") from exc
+    return parse_manifest(raw)
+
+
+# ---------------------------------------------------------------------------
+# Validation — hand-written so the security guards stay on even when the
+# optional jsonschema package is missing. When jsonschema IS available we
+# also run it for full schema fidelity (extra errors / better messages).
+# ---------------------------------------------------------------------------
+
+def _build_manifest(data: Any) -> Manifest:
+    if not isinstance(data, dict):
+        raise ManifestError("manifest must be a mapping at the top level")
+
+    schema_version = data.get("schema_version")
+    if schema_version != 1:
+        raise ManifestError(
+            f"unsupported schema_version {schema_version!r} (expected 1)"
+        )
+
+    publisher = _opt_str(data.get("publisher"), "publisher", max_len=256)
+    generated_at = _opt_str(data.get("generated_at"), "generated_at", max_len=64)
+    default_connector = _opt_str(
+        data.get("default_connector"), "default_connector", max_len=64,
+    )
+    if default_connector and default_connector not in KNOWN_CONNECTORS:
+        raise ManifestError(
+            f"default_connector {default_connector!r} is not one of "
+            f"{sorted(KNOWN_CONNECTORS)}"
+        )
+
+    raw_entries = data.get("entries")
+    if not isinstance(raw_entries, list):
+        raise ManifestError("entries must be a list")
+    if len(raw_entries) > MAX_ENTRIES:
+        raise ManifestError(
+            f"manifest has {len(raw_entries)} entries (max {MAX_ENTRIES})"
+        )
+
+    seen: set[tuple[str, str]] = set()
+    entries: list[ManifestEntry] = []
+    for idx, raw_entry in enumerate(raw_entries):
+        try:
+            entry = _build_entry(raw_entry, default_connector)
+        except ManifestError as exc:
+            raise ManifestError(f"entries[{idx}]: {exc}") from exc
+        key = (entry.type, entry.name)
+        if key in seen:
+            raise ManifestError(
+                f"entries[{idx}]: duplicate {entry.type} entry "
+                f"{entry.name!r}"
+            )
+        seen.add(key)
+        entries.append(entry)
+
+    manifest = Manifest(
+        schema_version=schema_version,
+        generated_at=generated_at,
+        publisher=publisher,
+        default_connector=default_connector,
+        entries=entries,
+    )
+
+    # Optional belt-and-suspenders pass via jsonschema when available.
+    # Failures here surface to callers but the hand-written checks above
+    # already covered the security-relevant invariants.
+    _maybe_jsonschema_validate(manifest.to_dict())
+
+    return manifest
+
+
+def _build_entry(raw: Any, default_connector: str) -> ManifestEntry:
+    if not isinstance(raw, dict):
+        raise ManifestError("entry must be a mapping")
+    type_ = raw.get("type")
+    if type_ not in KNOWN_TYPES:
+        raise ManifestError(
+            f"type must be one of {sorted(KNOWN_TYPES)} (got {type_!r})"
+        )
+    name = raw.get("name")
+    if not isinstance(name, str) or not NAME_RE.match(name):
+        raise ManifestError(
+            f"name must match {NAME_RE.pattern!r} (got {name!r})"
+        )
+
+    connector = _opt_str(raw.get("connector"), "connector", max_len=64)
+    if not connector:
+        connector = default_connector
+    if connector and connector not in KNOWN_CONNECTORS:
+        raise ManifestError(
+            f"connector {connector!r} is not one of {sorted(KNOWN_CONNECTORS)}"
+        )
+
+    publisher = _opt_str(raw.get("publisher"), "publisher", max_len=256)
+    license_ = _opt_str(raw.get("license"), "license", max_len=128)
+    description = _opt_str(raw.get("description"), "description", max_len=MAX_STRING)
+    homepage = _opt_str(raw.get("homepage"), "homepage", max_len=MAX_STRING)
+    if homepage and not HTTP_URL_RE.match(homepage):
+        raise ManifestError(f"homepage must be http(s) URL (got {homepage!r})")
+    version = _opt_str(raw.get("version"), "version", max_len=64)
+    tags = _opt_str_list(raw.get("tags"), "tags", max_items=MAX_TAGS, max_len=64)
+
+    if type_ == "skill":
+        source_url = _req_str(raw.get("source_url"), "source_url", max_len=MAX_STRING)
+        if not SOURCE_URL_RE.match(source_url):
+            raise ManifestError(
+                f"source_url must start with clawhub://, https://, or http:// "
+                f"(got {source_url!r})"
+            )
+        sha256 = _opt_str(raw.get("sha256"), "sha256", max_len=64)
+        if sha256 and not SHA256_RE.match(sha256):
+            raise ManifestError(f"sha256 must be 64 hex chars (got {sha256!r})")
+        return ManifestEntry(
+            name=name,
+            type="skill",
+            source_url=source_url,
+            sha256=sha256,
+            version=version,
+            license=license_,
+            publisher=publisher,
+            description=description,
+            homepage=homepage,
+            connector=connector,
+            tags=tags,
+        )
+
+    transport = _opt_str(raw.get("transport"), "transport", max_len=32) or "stdio"
+    if transport not in KNOWN_TRANSPORTS:
+        raise ManifestError(
+            f"transport {transport!r} is not one of {sorted(KNOWN_TRANSPORTS)}"
+        )
+
+    command = _opt_str(raw.get("command"), "command", max_len=256)
+    if command and not COMMAND_RE.match(command):
+        raise ManifestError(
+            f"command {command!r} contains characters outside the allow-list "
+            f"({COMMAND_RE.pattern})"
+        )
+    args = _opt_str_list(raw.get("args"), "args", max_items=MAX_ARGS, max_len=1024)
+    env_required = _opt_str_list(
+        raw.get("env_required"), "env_required",
+        max_items=MAX_ENV_VARS, max_len=128,
+    )
+    for env in env_required:
+        if not ENV_VAR_RE.match(env):
+            raise ManifestError(
+                f"env_required entry {env!r} must match {ENV_VAR_RE.pattern!r}"
+            )
+    url = _opt_str(raw.get("url"), "url", max_len=MAX_STRING)
+
+    if transport == "stdio" and not command:
+        raise ManifestError("stdio transport requires a non-empty command")
+    if transport != "stdio" and not url:
+        raise ManifestError(
+            f"transport {transport!r} requires a non-empty url"
+        )
+
+    return ManifestEntry(
+        name=name,
+        type="mcp",
+        transport=transport,
+        command=command,
+        args=args,
+        env_required=env_required,
+        url=url,
+        version=version,
+        license=license_,
+        publisher=publisher,
+        description=description,
+        homepage=homepage,
+        connector=connector,
+        tags=tags,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tiny string helpers — keep length / type validation tight and uniform.
+# ---------------------------------------------------------------------------
+
+def _opt_str(value: Any, label: str, *, max_len: int) -> str:
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ManifestError(f"{label} must be a string (got {type(value).__name__})")
+    if len(value) > max_len:
+        raise ManifestError(f"{label} exceeds {max_len} chars")
+    return value
+
+
+def _req_str(value: Any, label: str, *, max_len: int) -> str:
+    out = _opt_str(value, label, max_len=max_len)
+    if not out:
+        raise ManifestError(f"{label} is required")
+    return out
+
+
+def _opt_str_list(value: Any, label: str, *, max_items: int, max_len: int) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ManifestError(f"{label} must be a list (got {type(value).__name__})")
+    if len(value) > max_items:
+        raise ManifestError(f"{label} has {len(value)} items (max {max_items})")
+    out: list[str] = []
+    for i, item in enumerate(value):
+        if not isinstance(item, str):
+            raise ManifestError(
+                f"{label}[{i}] must be a string (got {type(item).__name__})"
+            )
+        if len(item) > max_len:
+            raise ManifestError(f"{label}[{i}] exceeds {max_len} chars")
+        out.append(item)
+    return out
+
+
+def _maybe_jsonschema_validate(payload: dict[str, Any]) -> None:
+    """Run optional jsonschema validation when the package is installed.
+
+    The package is **not** a runtime requirement — every security
+    invariant is also enforced by the hand-written validator above. We
+    use jsonschema only when present, and surface its richer error
+    messages to the operator.
+    """
+    try:
+        import jsonschema
+    except ImportError:
+        return
+    schema_path = (
+        Path(__file__).resolve().parents[3]
+        / "schemas"
+        / "registry-manifest.schema.json"
+    )
+    if not schema_path.exists():
+        return
+    try:
+        schema = json.loads(schema_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return
+    try:
+        jsonschema.validate(payload, schema)
+    except jsonschema.ValidationError as exc:
+        path = ".".join(str(p) for p in exc.absolute_path)
+        loc = f" at {path}" if path else ""
+        raise ManifestError(f"manifest schema violation{loc}: {exc.message}") from exc

--- a/cli/defenseclaw/registries/ssrf.py
+++ b/cli/defenseclaw/registries/ssrf.py
@@ -1,0 +1,160 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""URL safety guards for registry adapters.
+
+Registry sources are operator-provided URLs that DefenseClaw will fetch
+on the operator's behalf — exactly the pattern that earns a finding in
+:mod:`policies.guardrail` and the codebase rules. We refuse to fetch
+anything that resolves to localhost, link-local, multicast, or
+RFC1918/ULA private addresses by default. Operators that genuinely
+need to ingest from a private host must opt in with ``--allow-private``;
+the flag is plumbed all the way through the CLI surface so an
+"oops, my URL was internal" mistake stays explicit.
+
+This module is intentionally pure-Python and stdlib-only so it can be
+unit-tested without network access — :func:`guard_url` performs DNS
+resolution via :func:`socket.getaddrinfo`, but that lookup can be
+mocked in tests by passing a custom ``resolver`` callback.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from collections.abc import Callable
+from urllib.parse import urlparse
+
+ALLOWED_SCHEMES = frozenset({"http", "https"})
+"""Schemes accepted for HTTP-style fetches.
+
+``file://`` URLs are intentionally NOT allowed in published manifests
+or in HTTP-kind sources — operators that want to ingest local files
+register the source with ``kind=file`` and a filesystem path instead,
+which routes through a dedicated adapter that doesn't go through this
+module.
+"""
+
+
+class SSRFError(ValueError):
+    """Raised when a URL fails the SSRF guard."""
+
+
+# Dependency-injected resolver type so tests can avoid hitting DNS.
+Resolver = Callable[[str], list[str]]
+
+
+def _default_resolver(host: str) -> list[str]:
+    """Resolve *host* via getaddrinfo, returning a list of literal IPs.
+
+    Returns ``[host]`` if *host* is already an IP literal so callers
+    can pass IPs through without a DNS query. Empty list on failure —
+    callers should treat that as "could not validate, refuse".
+    """
+    try:
+        ipaddress.ip_address(host)
+        return [host]
+    except ValueError:
+        pass
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except OSError:
+        return []
+    # info[4] is a sockaddr tuple; the first element is always the host
+    # for both AF_INET (str) and AF_INET6 (str). Cast explicitly so the
+    # set is typed as Set[str] for mypy — getaddrinfo()'s stub returns
+    # Tuple[Any, ...] which leaks an Any/int union otherwise.
+    return list({str(info[4][0]) for info in infos})
+
+
+def guard_url(
+    url: str,
+    *,
+    allow_private: bool = False,
+    resolver: Resolver | None = None,
+) -> None:
+    """Validate *url* against the SSRF policy.
+
+    Raises :class:`SSRFError` on any of:
+
+    * scheme outside :data:`ALLOWED_SCHEMES`
+    * empty / non-DNS-resolvable host
+    * resolved IP in the loopback / link-local / multicast / unspecified
+      range (always blocked)
+    * resolved IP in RFC1918 / ULA / shared-CGNAT / RFC6598 ranges
+      when *allow_private* is False (the default).
+
+    The default fail-closed posture matches the project guidance for
+    operator-provided URLs (codeguard-0-api-web-services).
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in ALLOWED_SCHEMES:
+        raise SSRFError(
+            f"unsupported URL scheme {scheme!r}; expected http or https"
+        )
+    host = (parsed.hostname or "").strip().lower()
+    if not host:
+        raise SSRFError("URL is missing a host component")
+
+    if host in {"localhost", "ip6-localhost"}:
+        raise SSRFError("refusing to fetch from localhost")
+
+    resolve = resolver or _default_resolver
+    addrs = resolve(host)
+    if not addrs:
+        raise SSRFError(f"could not resolve host {host!r}")
+
+    for addr in addrs:
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            continue
+        if (
+            ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_unspecified
+            or ip.is_reserved
+        ):
+            raise SSRFError(
+                f"host {host!r} resolves to disallowed address {addr}"
+            )
+        if not allow_private and ip.is_private:
+            raise SSRFError(
+                f"host {host!r} resolves to private address {addr} "
+                "(use --allow-private to opt in)"
+            )
+
+
+def guard_git_url(
+    url: str,
+    *,
+    allow_private: bool = False,
+    resolver: Resolver | None = None,
+) -> None:
+    """Validate a git clone URL.
+
+    Accepts ``https://`` and ``http://`` URLs (delegates to
+    :func:`guard_url`) and rejects ``ssh://`` / ``git://`` / ``file://``
+    / shell-shorthand forms entirely. SSH-based git is intentionally
+    out of scope: it requires private key material and key trust
+    decisions that don't belong in an automated ingest pipeline.
+
+    The ``resolver`` parameter is plumbed through to :func:`guard_url`
+    so tests can stub DNS without hitting the network.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in ALLOWED_SCHEMES:
+        raise SSRFError(
+            f"git URL scheme {scheme!r} not allowed; use http(s) for catalog clones"
+        )
+    guard_url(url, allow_private=allow_private, resolver=resolver)

--- a/cli/defenseclaw/registries/sync.py
+++ b/cli/defenseclaw/registries/sync.py
@@ -1,0 +1,467 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Registry sync pipeline.
+
+The sync command stitches three concerns together:
+
+1. **Ingest** — call the appropriate adapter to fetch + parse the
+   manifest, with SSRF / size guards already applied.
+2. **Cache** — persist the parsed manifest + per-entry placeholders to
+   ``~/.defenseclaw/registries/<id>/index.json`` so the TUI and
+   ``registry entries`` can render fast without re-fetching.
+3. **Promote** — for each entry that passes scanning (or that the
+   operator has manually approved), append a matching
+   :class:`AssetPolicyRule` to ``asset_policy.{skill,mcp}.registry``
+   with ``Reason="registry:<id>"`` so admission can attribute the rule
+   back to its source. Manual operator overrides
+   (``approved`` / ``rejected``) win over scanner verdict.
+
+The scanning step is **optional and pluggable**. The default
+implementation (in this module) only runs scanners when
+``scan_callback`` is provided, leaving status=``pending`` otherwise.
+This keeps unit tests fast and lets the CLI inject a real scanner
+factory without coupling the package to the heavy SDK dependencies.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from defenseclaw.config import (
+    AssetPolicyRule,
+    Config,
+    RegistrySource,
+)
+from defenseclaw.registries.adapters import IngestError, fetch_manifest
+from defenseclaw.registries.cache import (
+    EntryVerdict,
+    SourceIndex,
+    load_index,
+    merge_manifest_into_index,
+    save_index,
+    save_manifest,
+)
+from defenseclaw.registries.manifest import (
+    Manifest,
+    ManifestEntry,
+    ManifestError,
+)
+
+if TYPE_CHECKING:
+    from defenseclaw.models import ScanResult
+
+
+# Severity rank — entries with HIGH or worse are blocked, MEDIUM is
+# treated as a warning that the operator must explicitly approve, LOW
+# / INFO findings are treated as clean. This matches the existing
+# scanner default policy in ``cli/defenseclaw/scanner/skill.py``.
+_BLOCKING_SEVERITIES = {"CRITICAL", "HIGH"}
+_WARNING_SEVERITIES = {"MEDIUM"}
+
+
+ScanCallback = Callable[[RegistrySource, ManifestEntry], "ScanResult | None"]
+"""Callable that runs the appropriate scanner on a single manifest entry.
+
+Returns ``None`` to mark the entry as ``status="pending"`` (e.g. when
+the scanner can't run because the operator hasn't installed the heavy
+SDKs yet, or when the source is metadata-only). Otherwise returns a
+:class:`defenseclaw.models.ScanResult` whose findings drive the
+verdict transition.
+
+Tests can pass in a stub callback to exercise the full pipeline
+without spawning a scanner subprocess.
+"""
+
+
+@dataclass
+class SyncReport:
+    """Result of a single ``registry sync`` run."""
+
+    source_id: str = ""
+    fetched: int = 0
+    scanned: int = 0
+    promoted_skills: int = 0
+    promoted_mcps: int = 0
+    blocked: int = 0
+    warnings: int = 0
+    errors: list[str] = field(default_factory=list)
+    started_at: str = ""
+    finished_at: str = ""
+
+    def ok(self) -> bool:
+        return not self.errors
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "source_id": self.source_id,
+            "fetched": self.fetched,
+            "scanned": self.scanned,
+            "promoted_skills": self.promoted_skills,
+            "promoted_mcps": self.promoted_mcps,
+            "blocked": self.blocked,
+            "warnings": self.warnings,
+            "errors": list(self.errors),
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "ok": self.ok(),
+        }
+
+
+def sync_source(
+    cfg: Config,
+    data_dir: str,
+    source: RegistrySource,
+    *,
+    scan_callback: ScanCallback | None = None,
+    allow_private: bool = False,
+    auto_promote: bool = True,
+    save: bool = True,
+) -> SyncReport:
+    """Sync a single :class:`RegistrySource`.
+
+    Args:
+        cfg: live :class:`Config`. Mutated in-place — promoted entries
+            are appended to ``cfg.asset_policy.{skill,mcp}.registry``
+            and ``source.last_sync`` / ``source.last_status`` are
+            updated. The caller is responsible for persisting the
+            mutated config (or pass ``save=True`` for the standard
+            atomic-write flow).
+        data_dir: ``cfg.data_dir`` — kept as a separate argument so
+            unit tests can point at a tmp dir without copying the
+            entire config.
+        source: the source to sync. Must already exist in
+            ``cfg.registries.sources``.
+        scan_callback: optional callback that runs the appropriate
+            scanner on each :class:`ManifestEntry`. See
+            :data:`ScanCallback`.
+        allow_private: when True, the SSRF guard accepts RFC1918 / ULA
+            destinations. Operators opt in explicitly via
+            ``--allow-private``.
+        auto_promote: when True, clean entries are appended to
+            ``asset_policy.{skill,mcp}.registry``. Set to False for a
+            preview ("scan only, don't touch policy") flow.
+        save: when True, :func:`defenseclaw.config.save_config` is
+            called at the end. Tests can disable this and inspect the
+            mutated config object directly.
+
+    Returns:
+        :class:`SyncReport` — never raises. Errors are collected on
+        ``report.errors`` so a flaky source doesn't break a multi-source
+        ``sync --all`` run.
+    """
+    report = SyncReport(source_id=source.id, started_at=_now_iso())
+
+    if not source.id:
+        report.errors.append("source has no id")
+        report.finished_at = _now_iso()
+        return report
+
+    try:
+        manifest, raw = fetch_manifest(source, allow_private=allow_private)
+    except (IngestError, ManifestError) as exc:
+        report.errors.append(f"fetch failed: {exc}")
+        source.last_status = f"error: {exc}"[:240]
+        source.last_sync = report.started_at
+        report.finished_at = _now_iso()
+        if save:
+            cfg.save()
+        return report
+
+    save_manifest(data_dir, source.id, raw)
+
+    # Honour the operator's declared content type before anything else
+    # touches the manifest. Adapters that publish a single type
+    # (clawhub / smithery / skills_sh) ignore the field by convention,
+    # but for mixed manifests (http_*, git, file) declaring
+    # ``content: skill`` MUST prevent MCP entries from being scanned,
+    # cached, or promoted into ``asset_policy.mcp.registry``. Filtering
+    # at this single point keeps the rest of the pipeline content-
+    # agnostic and avoids parallel filter logic in scan / promote.
+    filtered = manifest.filter_by_content(source.content)
+    manifest = Manifest(
+        schema_version=manifest.schema_version,
+        generated_at=manifest.generated_at,
+        publisher=manifest.publisher,
+        default_connector=manifest.default_connector,
+        entries=filtered,
+    )
+    report.fetched = len(manifest.entries)
+
+    idx = load_index(data_dir, source.id)
+    idx.fetched_at = report.started_at
+    idx = merge_manifest_into_index(idx, manifest)
+
+    if scan_callback is not None:
+        _run_scans(source, manifest, idx, scan_callback, report)
+    save_index(data_dir, source.id, idx)
+
+    if auto_promote:
+        promoted_skills, promoted_mcps = _promote_to_asset_policy(
+            cfg, source, manifest, idx,
+        )
+        report.promoted_skills = promoted_skills
+        report.promoted_mcps = promoted_mcps
+
+    source.last_sync = report.started_at
+    source.last_status = "ok" if not report.errors else f"error: {report.errors[0]}"[:240]
+
+    report.blocked = sum(1 for v in idx.verdicts if v.status == "blocked")
+    report.warnings = sum(1 for v in idx.verdicts if v.status == "warning")
+    report.finished_at = _now_iso()
+
+    if save:
+        cfg.save()
+    return report
+
+
+def sync_all(
+    cfg: Config,
+    data_dir: str,
+    *,
+    scan_callback: ScanCallback | None = None,
+    allow_private: bool = False,
+    auto_promote: bool = True,
+    only: Iterable[str] | None = None,
+    include_disabled: bool = False,
+) -> list[SyncReport]:
+    """Sync every enabled :class:`RegistrySource`.
+
+    Args:
+        only: optional iterable of source ids to restrict the run to.
+            Useful for the TUI's "sync this source" action.
+        include_disabled: when True, disabled sources are synced too
+            (matches ``--all-including-disabled`` on the CLI).
+
+    Returns:
+        One :class:`SyncReport` per source, in config order.
+    """
+    only_set = set(only) if only is not None else None
+    reports: list[SyncReport] = []
+    for source in cfg.registries.sources:
+        if only_set is not None and source.id not in only_set:
+            continue
+        if not source.enabled and not include_disabled:
+            continue
+        report = sync_source(
+            cfg,
+            data_dir,
+            source,
+            scan_callback=scan_callback,
+            allow_private=allow_private,
+            auto_promote=auto_promote,
+            save=False,  # save once at the end of the loop
+        )
+        reports.append(report)
+    cfg.save()
+    return reports
+
+
+# ---------------------------------------------------------------------------
+# Scan + promotion helpers
+# ---------------------------------------------------------------------------
+
+def _run_scans(
+    source: RegistrySource,
+    manifest: Manifest,
+    idx: SourceIndex,
+    scan_callback: ScanCallback,
+    report: SyncReport,
+) -> None:
+    for entry in manifest.entries:
+        verdict = idx.find(entry.type, entry.name)
+        if verdict is None:
+            continue
+        if verdict.rejected:
+            verdict.status = "blocked"
+            continue
+        try:
+            scan_result = scan_callback(source, entry)
+        except Exception as exc:  # noqa: BLE001 - keep the loop alive
+            verdict.status = "error"
+            verdict.error = str(exc)[:240]
+            report.errors.append(f"scan({entry.type}:{entry.name}): {exc}")
+            continue
+        report.scanned += 1
+        if scan_result is None:
+            verdict.status = "pending"
+            continue
+        verdict.scan_id = getattr(scan_result, "scan_id", "") or ""
+        verdict.target = scan_result.target
+        verdict.findings = len(scan_result.findings)
+        verdict.last_scanned_at = _now_iso()
+        verdict.severity = scan_result.max_severity()
+        verdict.error = ""
+        if scan_result.is_clean():
+            verdict.status = "clean"
+        elif verdict.severity in _BLOCKING_SEVERITIES:
+            verdict.status = "blocked"
+        elif verdict.severity in _WARNING_SEVERITIES:
+            verdict.status = "warning"
+        else:
+            verdict.status = "clean"
+
+
+def _promote_to_asset_policy(
+    cfg: Config,
+    source: RegistrySource,
+    manifest: Manifest,
+    idx: SourceIndex,
+) -> tuple[int, int]:
+    """Append rules for clean / approved entries to asset_policy.
+
+    Returns ``(promoted_skill_count, promoted_mcp_count)``.
+
+    Behaviour:
+
+    * Existing rules with the same ``Reason="registry:<id>"`` for this
+      source are wiped first so a remove-from-manifest cleanly removes
+      the rule.
+    * Skills are matched by ``name``; MCPs by ``(name, command,
+      args_prefix, transport)`` so two servers that differ only in
+      args produce distinct rules.
+    * Operator-rejected entries are NEVER promoted, even if the scanner
+      reports clean.
+    * Operator-approved entries ARE promoted, even if the scanner
+      hasn't run yet.
+    """
+    reason = f"registry:{source.id}"
+
+    # Wipe stale rules whose Reason matches this source so we re-emit a
+    # fresh set in lockstep with the current manifest. Rules from other
+    # sources / manual rules are preserved.
+    cfg.asset_policy.skill.registry = [
+        r for r in cfg.asset_policy.skill.registry if r.reason != reason
+    ]
+    cfg.asset_policy.mcp.registry = [
+        r for r in cfg.asset_policy.mcp.registry if r.reason != reason
+    ]
+
+    promoted_skills = 0
+    promoted_mcps = 0
+
+    for entry in manifest.entries:
+        verdict = idx.find(entry.type, entry.name)
+        if verdict is None:
+            continue
+        # Operator overrides. ``approved`` always wins over the scanner;
+        # ``rejected`` always loses.
+        if verdict.rejected:
+            continue
+        if not verdict.approved:
+            if verdict.status not in ("clean",):
+                continue
+        if entry.is_skill():
+            cfg.asset_policy.skill.registry.append(AssetPolicyRule(
+                name=entry.name,
+                connector=entry.connector,
+                reason=reason,
+                url=entry.source_url,
+            ))
+            promoted_skills += 1
+        elif entry.is_mcp():
+            cfg.asset_policy.mcp.registry.append(AssetPolicyRule(
+                name=entry.name,
+                connector=entry.connector,
+                reason=reason,
+                url=entry.url,
+                command=entry.command,
+                args_prefix=list(entry.args),
+                transport=entry.transport,
+            ))
+            promoted_mcps += 1
+    return promoted_skills, promoted_mcps
+
+
+def manual_set_verdict(
+    data_dir: str,
+    source_id: str,
+    entry_type: str,
+    name: str,
+    *,
+    approved: bool | None = None,
+    rejected: bool | None = None,
+) -> EntryVerdict | None:
+    """Apply an operator approve/reject decision to a cached verdict.
+
+    Returns the updated :class:`EntryVerdict` (or ``None`` if the
+    entry is not in the cache yet). The caller is responsible for
+    re-running :func:`promote_from_cache` (or :func:`sync_source`)
+    so the decision is reflected in ``asset_policy``; this helper
+    only persists the bit on disk.
+    """
+    idx = load_index(data_dir, source_id)
+    verdict = idx.find(entry_type, name)
+    if verdict is None:
+        return None
+    if approved is not None:
+        verdict.approved = approved
+        if approved:
+            verdict.rejected = False
+    if rejected is not None:
+        verdict.rejected = rejected
+        if rejected:
+            verdict.approved = False
+    save_index(data_dir, source_id, idx)
+    return verdict
+
+
+def promote_from_cache(
+    cfg: Config,
+    data_dir: str,
+    source: RegistrySource,
+    *,
+    save: bool = True,
+) -> tuple[int, int] | None:
+    """Re-run promotion against the cached manifest.
+
+    Used by ``registry approve`` / ``registry reject`` so an operator
+    flipping a bit doesn't pay a network round-trip and — more
+    importantly — doesn't silently lose the promotion when the
+    publisher is offline. The on-disk ``index.json`` already reflects
+    the freshly-toggled approved/rejected flag (from
+    :func:`manual_set_verdict`), so we just re-load the cached
+    manifest and run :func:`_promote_to_asset_policy` against it.
+
+    Returns ``(promoted_skills, promoted_mcps)`` on success, or
+    ``None`` when there's no cached manifest yet (the caller should
+    fall back to a full :func:`sync_source` in that case).
+    """
+    # Local import keeps cache.py free of a sync import cycle.
+    from defenseclaw.registries.cache import load_cached_manifest
+
+    manifest = load_cached_manifest(data_dir, source.id)
+    if manifest is None:
+        return None
+    # Honour the same content filter sync_source applies so an
+    # approve doesn't accidentally promote an MCP entry the operator
+    # never wanted by setting content="skill".
+    filtered = manifest.filter_by_content(source.content)
+    manifest = Manifest(
+        schema_version=manifest.schema_version,
+        generated_at=manifest.generated_at,
+        publisher=manifest.publisher,
+        default_connector=manifest.default_connector,
+        entries=filtered,
+    )
+    idx = load_index(data_dir, source.id)
+    promoted_skills, promoted_mcps = _promote_to_asset_policy(
+        cfg, source, manifest, idx,
+    )
+    if save:
+        cfg.save()
+    return promoted_skills, promoted_mcps
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/cli/defenseclaw/registries/sync.py
+++ b/cli/defenseclaw/registries/sync.py
@@ -408,10 +408,26 @@ def manual_set_verdict(
         verdict.approved = approved
         if approved:
             verdict.rejected = False
+            # Approving a previously-blocked entry should land in
+            # ``status`` so list filters and the TUI badge reflect
+            # the decision before the next scan run.
+            if verdict.status == "blocked":
+                verdict.status = "pending"
     if rejected is not None:
         verdict.rejected = rejected
         if rejected:
             verdict.approved = False
+            # Reject is the strongest negative verdict the operator
+            # can express. Surface it through ``status`` so
+            # ``registry entries --status blocked`` and the TUI's
+            # rendering both show the row as blocked, not pending.
+            verdict.status = "blocked"
+        else:
+            # Operator un-rejected — drop the synthetic 'blocked'
+            # so a subsequent scan can write a real verdict without
+            # an explicit re-approve.
+            if verdict.status == "blocked":
+                verdict.status = "pending"
     save_index(data_dir, source_id, idx)
     return verdict
 

--- a/cli/tests/test_cmd_registry.py
+++ b/cli/tests/test_cmd_registry.py
@@ -442,5 +442,310 @@ class TestRegistryRequire(RegistryCommandTestBase):
         self.assertFalse(self.app.cfg.asset_policy.mcp.registry_required)
 
 
+class TestFileAdapterPathValidation(RegistryCommandTestBase):
+    """``kind=file`` requires an absolute path so ``manifest.yaml`` is
+    found regardless of the gateway's CWD. The check must fire at
+    add/edit time so a misconfigured source is caught up-front rather
+    than ten minutes later when cron tries to sync.
+    """
+
+    def test_add_file_kind_rejects_relative_path(self):
+        result = self.runner.invoke(registry, [
+            "add", "local",
+            "--kind", "file",
+            "--content", "skill",
+            "--url", "manifest.yaml",
+            "--non-interactive",
+        ], obj=self.app, catch_exceptions=True)
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("absolute", str(result.output) + str(result.exception))
+
+    def test_add_file_kind_accepts_absolute_path(self):
+        result = self.invoke([
+            "add", "local",
+            "--kind", "file",
+            "--content", "skill",
+            "--url", "/tmp/manifest.yaml",
+            "--non-interactive",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_add_file_kind_accepts_tilde_expansion(self):
+        # ``~/manifest.yaml`` expands to an absolute path so it should
+        # pass; the file adapter does the same expansion on read.
+        result = self.invoke([
+            "add", "local",
+            "--kind", "file",
+            "--content", "skill",
+            "--url", "~/manifest.yaml",
+            "--non-interactive",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_edit_to_file_kind_rejects_relative_url(self):
+        # Start with an http_yaml source, then flip to kind=file with
+        # a relative URL — the post-edit pair is invalid and must be
+        # rejected before save().
+        self.invoke([
+            "add", "local",
+            "--kind", "http_yaml",
+            "--content", "skill",
+            "--url", "https://catalog.example.com/skills.yaml",
+            "--non-interactive",
+        ])
+        result = self.runner.invoke(registry, [
+            "edit", "local",
+            "--kind", "file",
+            "--url", "relative/path.yaml",
+            "--non-interactive",
+        ], obj=self.app, catch_exceptions=True)
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestRegistryEntriesFilters(RegistryCommandTestBase):
+    """``entries --approved`` / ``--rejected`` filter on the operator
+    override bits independently of ``--status``. Both filters together
+    return the empty set because approve/reject are mutually exclusive.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.invoke([
+            "add", "corp-skills",
+            "--kind", "http_yaml",
+            "--content", "skill",
+            "--url", "https://catalog.example.com/skills.yaml",
+            "--non-interactive",
+        ])
+        # Populate two entries, one to approve and one to reject.
+        manifest = parse_manifest(json.dumps({
+            "schema_version": 1,
+            "entries": [
+                {"name": "approved-one", "type": "skill",
+                 "source_url": "https://x/1"},
+                {"name": "rejected-one", "type": "skill",
+                 "source_url": "https://x/2"},
+            ],
+        }))
+        raw = json.dumps(manifest.to_dict()).encode("utf-8")
+        with patch(
+            "defenseclaw.registries.sync.fetch_manifest",
+            lambda src, *, allow_private=False: (manifest, raw),
+        ), patch(
+            "defenseclaw.commands.cmd_registry._make_scan_callback",
+            return_value=lambda src, entry: _scan_clean(entry.name),
+        ):
+            self.invoke(["sync", "corp-skills"])
+
+        # Approve one, reject the other (no repromote so we don't
+        # need the scanner stub here).
+        self.invoke([
+            "approve", "corp-skills", "approved-one",
+            "--type", "skill", "--no-repromote",
+        ])
+        self.invoke([
+            "reject", "corp-skills", "rejected-one",
+            "--type", "skill", "--no-repromote",
+        ])
+
+    def test_entries_approved_only(self):
+        result = self.invoke([
+            "entries", "corp-skills", "--approved", "--json",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output)
+        names = {row["name"] for row in json.loads(result.output)}
+        self.assertEqual(names, {"approved-one"})
+
+    def test_entries_rejected_only(self):
+        result = self.invoke([
+            "entries", "corp-skills", "--rejected", "--json",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output)
+        rows = json.loads(result.output)
+        names = {row["name"] for row in rows}
+        self.assertEqual(names, {"rejected-one"})
+        # The reject path also flips ``status`` to ``blocked`` so the
+        # operator's call survives both filter shapes.
+        self.assertEqual(rows[0]["status"], "blocked")
+
+    def test_entries_status_blocked_includes_rejected(self):
+        # Cross-check: the reject above should land on the
+        # ``--status blocked`` filter as well, not just on
+        # ``--rejected``. This is the regression the
+        # ``manual_set_verdict`` fix targets.
+        result = self.invoke([
+            "entries", "corp-skills",
+            "--status", "blocked",
+            "--json",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output)
+        names = {row["name"] for row in json.loads(result.output)}
+        self.assertEqual(names, {"rejected-one"})
+
+    def test_entries_approved_and_rejected_returns_empty(self):
+        # Mutual exclusivity by definition.
+        result = self.invoke([
+            "entries", "corp-skills",
+            "--approved", "--rejected",
+            "--json",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(json.loads(result.output), [])
+
+
+class TestRegistryListEntryCounts(RegistryCommandTestBase):
+    """``registry list --json`` should embed the cached entry count
+    summary so the TUI / CI can show "10 (8/1/1)" without hitting the
+    network. A source that has never synced reports no ``entries``
+    sub-block.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.invoke([
+            "add", "corp-skills",
+            "--kind", "http_yaml",
+            "--content", "skill",
+            "--url", "https://catalog.example.com/skills.yaml",
+            "--non-interactive",
+        ])
+
+    def test_list_json_includes_entry_summary_after_sync(self):
+        manifest = _make_skill_manifest()
+        raw = json.dumps(manifest.to_dict()).encode("utf-8")
+        with patch(
+            "defenseclaw.registries.sync.fetch_manifest",
+            lambda src, *, allow_private=False: (manifest, raw),
+        ), patch(
+            "defenseclaw.commands.cmd_registry._make_scan_callback",
+            return_value=lambda src, entry: _scan_clean(entry.name),
+        ):
+            self.invoke(["sync", "corp-skills"])
+
+        result = self.invoke(["list", "--json"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(len(payload), 1)
+        self.assertIn("entries", payload[0])
+        self.assertEqual(payload[0]["entries"]["total"], 1)
+        self.assertEqual(payload[0]["entries"]["clean"], 1)
+
+
+class TestRegistryTest(RegistryCommandTestBase):
+    """``registry test`` should fetch + parse without writing any
+    cache or asset_policy state, and surface a structured summary
+    so CI checks can gate a sync on a clean dry-run.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.invoke([
+            "add", "corp-skills",
+            "--kind", "http_yaml",
+            "--content", "skill",
+            "--url", "https://catalog.example.com/skills.yaml",
+            "--non-interactive",
+        ])
+
+    def test_test_does_not_write_cache_or_policy(self):
+        from defenseclaw.registries.cache import index_path, manifest_path
+
+        manifest = _make_skill_manifest()
+        raw = json.dumps(manifest.to_dict()).encode("utf-8")
+
+        def _fetch(_source, *, allow_private=False):
+            return manifest, raw
+
+        with patch("defenseclaw.registries.adapters.fetch_manifest", _fetch):
+            with patch(
+                "defenseclaw.commands.cmd_registry.fetch_manifest", _fetch,
+            ):
+                result = self.invoke(["test", "corp-skills", "--json"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["entries"]["total"], 1)
+        self.assertEqual(payload["entries"]["skills"], 1)
+        # Critical: no on-disk side effects.
+        self.assertFalse(index_path(self.app.cfg.data_dir, "corp-skills").exists())
+        self.assertFalse(manifest_path(self.app.cfg.data_dir, "corp-skills").exists())
+        # And asset_policy is untouched.
+        self.assertEqual(self.app.cfg.asset_policy.skill.registry, [])
+
+    def test_test_surfaces_fetch_error_with_nonzero_exit(self):
+        from defenseclaw.registries.adapters import IngestError
+
+        def _bad(_source, *, allow_private=False):
+            raise IngestError("synthetic")
+
+        with patch(
+            "defenseclaw.commands.cmd_registry.fetch_manifest", _bad,
+        ):
+            result = self.runner.invoke(registry, [
+                "test", "corp-skills", "--json",
+            ], obj=self.app, catch_exceptions=True)
+        self.assertNotEqual(result.exit_code, 0)
+        # Output may be on stdout (--json branch) or stderr.
+        stream = result.output or ""
+        if stream.strip().startswith("{"):
+            payload = json.loads(stream)
+            self.assertFalse(payload["ok"])
+            self.assertIn("synthetic", payload["error"])
+
+    def test_test_show_entries_lists_rows(self):
+        manifest = _make_skill_manifest()
+        raw = json.dumps(manifest.to_dict()).encode("utf-8")
+        with patch(
+            "defenseclaw.commands.cmd_registry.fetch_manifest",
+            lambda src, *, allow_private=False: (manifest, raw),
+        ):
+            result = self.invoke([
+                "test", "corp-skills",
+                "--show-entries", "--limit", "5", "--json",
+            ])
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertIn("rows", payload["entries"])
+        self.assertEqual(len(payload["entries"]["rows"]), 1)
+        self.assertEqual(payload["entries"]["rows"][0]["name"], "demo-skill")
+
+
+class TestRegistryEditPromptShortCircuit(RegistryCommandTestBase):
+    """Per the ``edit`` docstring, only the flags you pass are changed.
+    When **any** mutating flag is provided we must skip the interactive
+    prompts entirely so a non-TTY caller (TUI, cron, CI) doesn't hang
+    waiting for stdin even without ``--non-interactive``.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.invoke([
+            "add", "corp-skills",
+            "--kind", "http_yaml",
+            "--content", "skill",
+            "--url", "https://catalog.example.com/skills.yaml",
+            "--non-interactive",
+        ])
+
+    def test_edit_with_single_flag_does_not_prompt(self):
+        # Run without --non-interactive but with a mutating flag. The
+        # CliRunner's stdin is closed by default; if the command tries
+        # to prompt for any other field, the click.prompt call would
+        # raise and the exit code would be non-zero.
+        result = self.invoke([
+            "edit", "corp-skills",
+            "--disabled",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output)
+        src = next(
+            s for s in self.app.cfg.registries.sources
+            if s.id == "corp-skills"
+        )
+        self.assertFalse(src.enabled)
+        # And nothing else changed.
+        self.assertEqual(src.kind, "http_yaml")
+        self.assertEqual(src.url, "https://catalog.example.com/skills.yaml")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/cli/tests/test_cmd_registry.py
+++ b/cli/tests/test_cmd_registry.py
@@ -1,0 +1,446 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``defenseclaw registry`` CLI subcommands.
+
+Covers:
+
+* non-interactive add / edit / list / show / remove (the surface the
+  TUI and CI/CD pipelines call)
+* validation of source ids, kinds, content types, and auth env names
+* sync end-to-end with a stubbed adapter (no real HTTP)
+* approve / reject / require admin verbs
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from click.testing import CliRunner
+from defenseclaw.commands.cmd_registry import registry
+from defenseclaw.models import Finding, ScanResult
+from defenseclaw.registries.manifest import parse_manifest
+
+from tests.helpers import cleanup_app, make_app_context
+
+
+def _scan_clean(name: str) -> ScanResult:
+    return ScanResult(
+        scanner="test", target=name,
+        timestamp=datetime.now(timezone.utc),
+        findings=[],
+    )
+
+
+def _scan_high(name: str) -> ScanResult:
+    return ScanResult(
+        scanner="test", target=name,
+        timestamp=datetime.now(timezone.utc),
+        findings=[Finding(id="bad", severity="HIGH", title="bad",
+                          scanner="test")],
+    )
+
+
+def _make_skill_manifest():
+    return parse_manifest(json.dumps({
+        "schema_version": 1,
+        "publisher": "acme",
+        "entries": [
+            {
+                "name": "demo-skill",
+                "type": "skill",
+                "source_url": "https://catalog.example.com/demo.tgz",
+                "connector": "openclaw",
+                "sha256": "a" * 64,
+            }
+        ],
+    }))
+
+
+class RegistryCommandTestBase(unittest.TestCase):
+    def setUp(self):
+        self.app, self.tmp_dir, self.db_path = make_app_context()
+        self.runner = CliRunner()
+        # Make sure save() actually has a path.
+        self.app.cfg.config_path = os.path.join(self.tmp_dir, "config.yaml")
+        # Save once so subsequent saves succeed.
+        self.app.cfg.save()
+        self._orig_columns = os.environ.get("COLUMNS")
+        os.environ["COLUMNS"] = "200"
+
+    def tearDown(self):
+        cleanup_app(self.app, self.db_path, self.tmp_dir)
+        if self._orig_columns is None:
+            os.environ.pop("COLUMNS", None)
+        else:
+            os.environ["COLUMNS"] = self._orig_columns
+
+    def invoke(self, args):
+        return self.runner.invoke(
+            registry, args, obj=self.app, catch_exceptions=False,
+        )
+
+
+class TestRegistryAdd(RegistryCommandTestBase):
+    def test_add_non_interactive_minimal(self):
+        result = self.invoke([
+            "add", "corp-skills",
+            "--kind", "http_yaml",
+            "--content", "skill",
+            "--url", "https://catalog.example.com/skills.yaml",
+            "--non-interactive",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output)
+        ids = [s.id for s in self.app.cfg.registries.sources]
+        self.assertIn("corp-skills", ids)
+
+    def test_add_clawhub_does_not_require_url(self):
+        result = self.invoke([
+            "add", "clawhub",
+            "--kind", "clawhub",
+            "--content", "skill",
+            "--non-interactive",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_add_smithery_does_not_require_url(self):
+        result = self.invoke([
+            "add", "smithery-public",
+            "--kind", "smithery",
+            "--content", "mcp",
+            "--non-interactive",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_add_http_yaml_requires_url(self):
+        result = self.invoke([
+            "add", "missing",
+            "--kind", "http_yaml",
+            "--content", "skill",
+            "--non-interactive",
+        ])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("--url is required", result.output)
+
+    def test_add_rejects_invalid_id(self):
+        result = self.runner.invoke(registry, [
+            "add", "Bad/ID",
+            "--kind", "clawhub",
+            "--content", "skill",
+            "--non-interactive",
+        ], obj=self.app, catch_exceptions=True)
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_add_rejects_unknown_kind(self):
+        result = self.runner.invoke(registry, [
+            "add", "x",
+            "--kind", "made-up",
+            "--content", "skill",
+            "--non-interactive",
+        ], obj=self.app, catch_exceptions=True)
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_add_rejects_invalid_auth_env(self):
+        # auth_env must be an UPPERCASE_NAME, not a literal token.
+        result = self.runner.invoke(registry, [
+            "add", "corp-skills",
+            "--kind", "http_yaml",
+            "--content", "skill",
+            "--url", "https://x/y.yaml",
+            "--auth-env", "actual-secret-token-value",
+            "--non-interactive",
+        ], obj=self.app, catch_exceptions=True)
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_add_duplicate_rejected(self):
+        self.invoke([
+            "add", "dup",
+            "--kind", "clawhub",
+            "--content", "skill",
+            "--non-interactive",
+        ])
+        result = self.invoke([
+            "add", "dup",
+            "--kind", "clawhub",
+            "--content", "skill",
+            "--non-interactive",
+        ])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("already exists", result.output)
+
+    def test_add_emits_json(self):
+        result = self.invoke([
+            "add", "corp-skills",
+            "--kind", "clawhub",
+            "--content", "skill",
+            "--non-interactive",
+            "--json",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["action"], "add")
+        self.assertEqual(payload["source"]["id"], "corp-skills")
+
+
+class TestRegistryListShow(RegistryCommandTestBase):
+    def setUp(self):
+        super().setUp()
+        self.invoke([
+            "add", "corp-skills",
+            "--kind", "clawhub",
+            "--content", "skill",
+            "--non-interactive",
+        ])
+
+    def test_list_json(self):
+        result = self.invoke(["list", "--json"])
+        self.assertEqual(result.exit_code, 0)
+        payload = json.loads(result.output)
+        self.assertEqual(len(payload), 1)
+        self.assertEqual(payload[0]["id"], "corp-skills")
+
+    def test_show_json_includes_index_block(self):
+        result = self.invoke(["show", "corp-skills", "--json"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertIn("source", payload)
+        self.assertIn("index", payload)
+
+    def test_show_unknown_source_errors(self):
+        result = self.runner.invoke(
+            registry, ["show", "nope"],
+            obj=self.app, catch_exceptions=True,
+        )
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestRegistryEdit(RegistryCommandTestBase):
+    def setUp(self):
+        super().setUp()
+        self.invoke([
+            "add", "corp-skills",
+            "--kind", "http_yaml",
+            "--content", "skill",
+            "--url", "https://catalog.example.com/skills.yaml",
+            "--non-interactive",
+        ])
+
+    def test_edit_changes_kind(self):
+        result = self.invoke([
+            "edit", "corp-skills",
+            "--kind", "http_json",
+            "--non-interactive",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output)
+        src = next(s for s in self.app.cfg.registries.sources if s.id == "corp-skills")
+        self.assertEqual(src.kind, "http_json")
+
+    def test_edit_disable(self):
+        self.invoke([
+            "edit", "corp-skills",
+            "--disabled",
+            "--non-interactive",
+        ])
+        src = next(s for s in self.app.cfg.registries.sources if s.id == "corp-skills")
+        self.assertFalse(src.enabled)
+
+    def test_edit_clear_auth_env(self):
+        self.invoke([
+            "edit", "corp-skills",
+            "--auth-env", "DEFENSECLAW_TOKEN",
+            "--non-interactive",
+        ])
+        self.invoke([
+            "edit", "corp-skills",
+            "--clear-auth-env",
+            "--non-interactive",
+        ])
+        src = next(s for s in self.app.cfg.registries.sources if s.id == "corp-skills")
+        self.assertEqual(src.auth_env, "")
+
+
+class TestRegistryRemove(RegistryCommandTestBase):
+    def setUp(self):
+        super().setUp()
+        self.invoke([
+            "add", "corp-skills",
+            "--kind", "clawhub",
+            "--content", "skill",
+            "--non-interactive",
+        ])
+
+    def test_remove_drops_source(self):
+        result = self.invoke([
+            "remove", "corp-skills", "--non-interactive",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output)
+        ids = [s.id for s in self.app.cfg.registries.sources]
+        self.assertNotIn("corp-skills", ids)
+
+    def test_remove_clears_associated_asset_policy_rules(self):
+        from defenseclaw.config import AssetPolicyRule
+
+        # Pretend a prior sync had promoted a rule with our source's
+        # reason. The remove command must wipe it.
+        self.app.cfg.asset_policy.skill.registry.append(AssetPolicyRule(
+            name="demo-skill",
+            reason="registry:corp-skills",
+        ))
+        self.app.cfg.asset_policy.skill.registry.append(AssetPolicyRule(
+            name="other",
+            reason="registry:other-source",
+        ))
+        self.app.cfg.save()
+
+        self.invoke(["remove", "corp-skills", "--non-interactive"])
+        names = [r.name for r in self.app.cfg.asset_policy.skill.registry]
+        self.assertNotIn("demo-skill", names)
+        self.assertIn("other", names)
+
+
+class TestRegistrySync(RegistryCommandTestBase):
+    def setUp(self):
+        super().setUp()
+        self.invoke([
+            "add", "corp-skills",
+            "--kind", "http_yaml",
+            "--content", "skill",
+            "--url", "https://catalog.example.com/skills.yaml",
+            "--non-interactive",
+        ])
+
+    def test_sync_promotes_clean_entry(self):
+        manifest = _make_skill_manifest()
+        raw = json.dumps(manifest.to_dict()).encode("utf-8")
+
+        def _fetch(_source, *, allow_private=False):
+            return manifest, raw
+
+        with patch("defenseclaw.registries.sync.fetch_manifest", _fetch):
+            with patch(
+                "defenseclaw.commands.cmd_registry._make_scan_callback",
+                return_value=lambda src, entry: _scan_clean(entry.name),
+            ):
+                result = self.invoke([
+                    "sync", "corp-skills", "--json",
+                ])
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(len(payload), 1)
+        self.assertEqual(payload[0]["promoted_skills"], 1)
+        names = {r.name for r in self.app.cfg.asset_policy.skill.registry}
+        self.assertEqual(names, {"demo-skill"})
+
+    def test_sync_no_promote_skips_asset_policy(self):
+        manifest = _make_skill_manifest()
+        raw = json.dumps(manifest.to_dict()).encode("utf-8")
+
+        def _fetch(_source, *, allow_private=False):
+            return manifest, raw
+
+        with patch("defenseclaw.registries.sync.fetch_manifest", _fetch):
+            with patch(
+                "defenseclaw.commands.cmd_registry._make_scan_callback",
+                return_value=lambda src, entry: _scan_clean(entry.name),
+            ):
+                result = self.invoke([
+                    "sync", "corp-skills", "--no-promote", "--json",
+                ])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertFalse(self.app.cfg.asset_policy.skill.registry)
+
+    def test_sync_all_and_explicit_id_mutually_exclusive(self):
+        result = self.invoke([
+            "sync", "corp-skills", "--all",
+        ])
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestRegistryApproveReject(RegistryCommandTestBase):
+    def setUp(self):
+        super().setUp()
+        self.invoke([
+            "add", "corp-skills",
+            "--kind", "http_yaml",
+            "--content", "skill",
+            "--url", "https://catalog.example.com/skills.yaml",
+            "--non-interactive",
+        ])
+        # Populate the cache via a sync first.
+        manifest = _make_skill_manifest()
+        raw = json.dumps(manifest.to_dict()).encode("utf-8")
+
+        def _fetch(_source, *, allow_private=False):
+            return manifest, raw
+
+        with patch("defenseclaw.registries.sync.fetch_manifest", _fetch):
+            with patch(
+                "defenseclaw.commands.cmd_registry._make_scan_callback",
+                return_value=lambda src, entry: _scan_clean(entry.name),
+            ):
+                self.invoke(["sync", "corp-skills"])
+
+    def test_approve_marks_entry(self):
+        result = self.invoke([
+            "approve", "corp-skills", "demo-skill",
+            "--type", "skill",
+            "--no-repromote",
+            "--json",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertTrue(payload["verdict"]["approved"])
+
+    def test_reject_marks_entry(self):
+        result = self.invoke([
+            "reject", "corp-skills", "demo-skill",
+            "--type", "skill",
+            "--no-repromote",
+            "--json",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertTrue(payload["verdict"]["rejected"])
+
+    def test_approve_unknown_entry_errors(self):
+        result = self.runner.invoke(registry, [
+            "approve", "corp-skills", "missing",
+            "--type", "skill", "--no-repromote",
+        ], obj=self.app, catch_exceptions=True)
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestRegistryRequire(RegistryCommandTestBase):
+    def test_require_skill(self):
+        result = self.invoke([
+            "require", "--type", "skill", "--enabled", "--json",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertTrue(self.app.cfg.asset_policy.skill.registry_required)
+
+    def test_require_disable(self):
+        self.app.cfg.asset_policy.mcp.registry_required = True
+        self.app.cfg.save()
+        result = self.invoke([
+            "require", "--type", "mcp", "--disabled", "--json",
+        ])
+        self.assertEqual(result.exit_code, 0)
+        self.assertFalse(self.app.cfg.asset_policy.mcp.registry_required)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/tests/test_cmd_setup_notifications_set.py
+++ b/cli/tests/test_cmd_setup_notifications_set.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``defenseclaw setup notifications-set`` and
+``defenseclaw setup registry``.
+
+The two commands cover the "tweak notification scope without flipping
+the master switch" and "drop into the registry wizard from the setup
+group" UX gaps surfaced during the registries+notifications review.
+Both wrap existing primitives, so the tests focus on the integration
+points: argument parsing, config-mutation correctness for every
+slot, the master-switch warning, and the wizard delegation path.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from click.testing import CliRunner  # noqa: E402,I001
+from defenseclaw.commands.cmd_setup import setup as setup_group  # noqa: E402,I001
+from tests.helpers import cleanup_app, make_app_context  # noqa: E402,I001
+
+
+class _NotificationsSetBase(unittest.TestCase):
+    def setUp(self):
+        self.app, self.tmp_dir, self.db_path = make_app_context()
+        # The CLI calls cfg.save() — point at a real path so the
+        # write succeeds, but we don't actually care about the
+        # bytes on disk for these tests.
+        self.app.cfg.config_path = os.path.join(self.tmp_dir, "config.yaml")
+        self.app.cfg.save()
+        # Default master switch so platform-specific defaults don't
+        # cloud the warn-message assertion.
+        self.app.cfg.notifications.enabled = True
+
+    def tearDown(self):
+        cleanup_app(self.app, self.db_path, self.tmp_dir)
+
+    def _run(self, *args):
+        runner = CliRunner()
+        with patch(
+            "defenseclaw.commands.cmd_setup._restart_services",
+            return_value=None,
+        ):
+            return runner.invoke(
+                setup_group, list(args),
+                obj=self.app, catch_exceptions=False,
+            )
+
+
+class TestNotificationsSetCategory(_NotificationsSetBase):
+    """Categories live on the NotificationsConfig object directly.
+    Flipping one must persist to the typed attribute and surface a
+    confirmation in the output.
+    """
+
+    def test_set_block_enforced_off(self):
+        self.app.cfg.notifications.block_enforced = True
+        result = self._run(
+            "notifications-set", "block_enforced", "off",
+            "--no-restart",
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertFalse(self.app.cfg.notifications.block_enforced)
+        self.assertIn("notifications.block_enforced", result.output)
+
+    def test_set_hitl_approval_on_idempotent(self):
+        # The default is True; setting it to ``on`` must short-circuit
+        # without surfacing a misleading "changed" message.
+        self.app.cfg.notifications.hitl_approval = True
+        result = self._run(
+            "notifications-set", "hitl_approval", "on",
+            "--no-restart",
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("already on", result.output)
+
+
+class TestNotificationsSetSource(_NotificationsSetBase):
+    """Sources live under the nested ``sources`` filter struct. The
+    dotted form (``sources.hook``) and the friendlier short alias
+    (``hook``) must both land on the same attribute so an operator
+    copying from ``status`` output and an operator typing the short
+    form get the same outcome.
+    """
+
+    def test_dotted_form_flips_source(self):
+        self.app.cfg.notifications.sources.hook = True
+        result = self._run(
+            "notifications-set", "sources.hook", "off",
+            "--no-restart",
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertFalse(self.app.cfg.notifications.sources.hook)
+
+    def test_short_form_flips_source(self):
+        self.app.cfg.notifications.sources.guardrail = True
+        result = self._run(
+            "notifications-set", "guardrail", "off",
+            "--no-restart",
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertFalse(self.app.cfg.notifications.sources.guardrail)
+
+    def test_asset_policy_short_form(self):
+        self.app.cfg.notifications.sources.asset_policy = True
+        result = self._run(
+            "notifications-set", "asset_policy", "off",
+            "--no-restart",
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertFalse(self.app.cfg.notifications.sources.asset_policy)
+
+
+class TestNotificationsSetMasterSwitchWarning(_NotificationsSetBase):
+    def test_warns_when_master_off(self):
+        self.app.cfg.notifications.enabled = False
+        result = self._run(
+            "notifications-set", "hook", "off",
+            "--no-restart",
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        # Operator-friendly hint that the change is invisible until
+        # they flip the master switch back on.
+        self.assertIn("notifications.enabled is OFF", result.output)
+
+
+class TestNotificationsSetUnknownSlot(_NotificationsSetBase):
+    def test_unknown_slot_rejected_by_choice(self):
+        # click's Choice catches typos before our handler runs so the
+        # error message lists the legal values.
+        runner = CliRunner()
+        result = runner.invoke(
+            setup_group,
+            ["notifications-set", "made_up", "on", "--no-restart"],
+            obj=self.app, catch_exceptions=True,
+        )
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestSetupRegistryWizard(_NotificationsSetBase):
+    """``setup registry`` wraps ``registry wizard`` so first-run
+    operators discover registries inside the setup help. We don't
+    drive the interactive wizard here; we just confirm the
+    delegation lands on the underlying command and produces the
+    expected non-TTY error.
+    """
+
+    def test_setup_registry_delegates_to_wizard(self):
+        # Wizard refuses non-TTY input — perfect smoke for delegation:
+        # if the wrapper is wired wrong the test would see a click
+        # ``no such command`` error instead.
+        with patch("defenseclaw.commands.cmd_registry.sys.stdin") as stdin:
+            stdin.isatty.return_value = False
+            result = self._run("registry")
+        self.assertNotEqual(result.exit_code, 0, result.output)
+        self.assertIn("interactive terminal", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/tests/test_cmd_uninstall.py
+++ b/cli/tests/test_cmd_uninstall.py
@@ -46,10 +46,23 @@ def capture_click_output():
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from defenseclaw.commands import cmd_uninstall
+from defenseclaw.commands import cmd_uninstall  # noqa: E402  (sys.path tweak above)
 
 
 class BuildPlanTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Same isolation rationale as BuildPlanConnectorTests: keep
+        # `_teardown_connectors` from picking up backup markers that
+        # only exist on the developer's machine.
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        patcher = patch(
+            "defenseclaw.commands.cmd_uninstall.config_module.default_data_path",
+            return_value=self._tmp.name,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_defaults_preserve_data_and_binaries(self):
         plan = cmd_uninstall._build_plan(
             wipe_data=False,
@@ -163,6 +176,32 @@ class ResolveActiveConnectorTests(unittest.TestCase):
 
 
 class BuildPlanConnectorTests(unittest.TestCase):
+    """`_build_plan` connector resolution.
+
+    These tests exercise the data-dir-walking branch of
+    ``_teardown_connectors`` (it scans for backup-marker files like
+    ``connector_backups/claudecode/settings.json.json`` to detect
+    inactive connectors that DefenseClaw has touched in the past).
+    Without an isolated ``data_dir`` the test inherits whatever the
+    developer happens to have on disk under ``~/.defenseclaw`` —
+    that's how the suite started failing on machines where claudecode
+    had ever been wired up.
+
+    setUp() therefore points ``default_data_path`` at a fresh tempdir
+    so every test sees an empty marker tree and the assertions are
+    deterministic regardless of the real home directory.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        patcher = patch(
+            "defenseclaw.commands.cmd_uninstall.config_module.default_data_path",
+            return_value=self._tmp.name,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_plan_records_active_connector(self):
         class Guardrail:
             connector = "codex"

--- a/cli/tests/test_registry_adapters.py
+++ b/cli/tests/test_registry_adapters.py
@@ -1,0 +1,1125 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for every registry adapter — clawhub, smithery, http_yaml /
+http_json, file, git, skills_sh.
+
+These complement ``test_registry_sync.py`` (which stubs
+``fetch_manifest`` to test promotion logic) by exercising each adapter's
+HTTP / git / parsing behaviour against fixture responses. We mock at
+the ``_base.requests`` boundary (so the SSRF + size + redirect guards
+in ``_base.http_get`` actually run) and stub DNS via the ``resolver``
+parameter so the suite never touches real network.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from defenseclaw.config import RegistrySource
+from defenseclaw.registries.adapters import IngestError, fetch_manifest
+from defenseclaw.registries.adapters import _base as adapter_base
+from defenseclaw.registries.adapters.clawhub import fetch_clawhub
+from defenseclaw.registries.adapters.file import fetch_file
+from defenseclaw.registries.adapters.git import fetch_git
+from defenseclaw.registries.adapters.http_manifest import fetch_http
+from defenseclaw.registries.adapters.skills_sh import (
+    DEFAULT_BASE_URL,
+    KNOWN_VIEWS,
+    fetch_skills_sh,
+)
+from defenseclaw.registries.adapters.smithery import fetch_smithery
+
+# ---------------------------------------------------------------------------
+# requests.get mock
+# ---------------------------------------------------------------------------
+
+class _FakeResp:
+    """Tiny shim mirroring the requests.Response surface http_get touches.
+
+    We only emulate the bits actually called inside _base.http_get:
+    ``__enter__`` / ``__exit__``, ``close``, ``raise_for_status``,
+    ``iter_content``, ``headers``, ``is_redirect``. Each fake response
+    is single-use because http_get streams once.
+    """
+
+    def __init__(
+        self,
+        body: bytes = b"",
+        *,
+        status: int = 200,
+        headers: dict[str, str] | None = None,
+        redirect_to: str | None = None,
+    ):
+        self._body = body
+        self.status_code = status
+        self.headers = dict(headers or {})
+        self.is_redirect = redirect_to is not None
+        if redirect_to:
+            self.headers.setdefault("Location", redirect_to)
+        self._closed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def close(self):
+        self._closed = True
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import requests
+
+            raise requests.HTTPError(f"HTTP {self.status_code}")
+
+    def iter_content(self, chunk_size: int = 65536):
+        # Yield as a single chunk — _base.http_get treats the stream
+        # as opaque so the chunk boundary doesn't matter for behaviour.
+        if self._body:
+            yield self._body
+
+
+class _MockTransport:
+    """Sequence-aware mock for requests.get.
+
+    Each call to ``requests.get`` consumes one response from the
+    ``responses`` list. If a route map is supplied we look up by URL
+    instead so tests with retries / pagination don't need to stack
+    responses in call order.
+    """
+
+    def __init__(
+        self,
+        *,
+        responses: list[_FakeResp] | None = None,
+        routes: dict[str, _FakeResp] | None = None,
+    ):
+        self._responses = list(responses or [])
+        self._routes = dict(routes or {})
+        self.calls: list[dict] = []
+
+    def __call__(self, url, *, headers=None, timeout=None, stream=None,
+                 allow_redirects=None):
+        self.calls.append({
+            "url": url,
+            "headers": dict(headers or {}),
+            "timeout": timeout,
+            "stream": stream,
+            "allow_redirects": allow_redirects,
+        })
+        if url in self._routes:
+            return self._routes[url]
+        if not self._responses:
+            raise AssertionError(f"unexpected request to {url}")
+        return self._responses.pop(0)
+
+
+def _stub_resolver():
+    """Resolver that maps known public-looking hosts to 8.8.8.8.
+
+    Hosts not in the table return [] — _base.http_get's SSRF guard
+    treats that as "could not validate", so unknown hosts get rejected
+    just like in production. 8.8.8.8 is globally routable and not
+    flagged as ``is_reserved`` (unlike RFC5737 ranges) so it passes
+    every guard.
+    """
+    table = {
+        "catalog.example.com": ["8.8.8.8"],
+        "registry.example.com": ["8.8.8.8"],
+        "registry.npmjs.org": ["8.8.8.8"],
+        "registry.smithery.ai": ["8.8.8.8"],
+        "server.example.com": ["8.8.8.8"],
+        "skills.sh": ["8.8.8.8"],
+        "mirror.example.com": ["8.8.8.8"],
+        "evil.invalid": ["127.0.0.1"],
+        "internal.invalid": ["10.0.0.5"],
+    }
+
+    def _resolve(host):
+        return list(table.get(host, []))
+    return _resolve
+
+
+# ---------------------------------------------------------------------------
+# clawhub
+# ---------------------------------------------------------------------------
+
+class TestClawhubAdapter(unittest.TestCase):
+    """Verifies the npm-metadata path produces a valid Manifest and that
+    the SSRF / size guards are now wired through (they were skipped in
+    the previous direct-requests.get implementation)."""
+
+    def _src(self, url: str = "") -> RegistrySource:
+        return RegistrySource(id="ch", kind="clawhub", url=url, content="skill")
+
+    def test_default_npmjs_extracts_plugins(self):
+        body = json.dumps({
+            "openclaw": {
+                "plugins": {
+                    "demo-skill": {
+                        "version": "1.2.3",
+                        "license": "Apache-2.0",
+                        "description": "desc",
+                        "homepage": "https://example.com",
+                    },
+                    "another-one": {"version": "0.0.1"},
+                },
+            },
+            "time": {"modified": "2026-01-01T00:00:00Z"},
+        }).encode("utf-8")
+
+        transport = _MockTransport(responses=[_FakeResp(body)])
+        with patch.object(adapter_base.requests, "get", transport):
+            manifest, raw = fetch_clawhub(
+                self._src(), resolver=_stub_resolver(),
+            )
+
+        self.assertEqual(manifest.publisher, "clawhub")
+        self.assertEqual(manifest.generated_at, "2026-01-01T00:00:00Z")
+        names = sorted(e.name for e in manifest.entries)
+        self.assertEqual(names, ["another-one", "demo-skill"])
+        self.assertEqual(raw, body)
+        self.assertTrue(transport.calls[0]["url"].endswith("/openclaw/latest"))
+        self.assertEqual(
+            transport.calls[0]["headers"]["Accept"], "application/json",
+        )
+
+    def test_top_level_plugins_fallback(self):
+        body = json.dumps({
+            "plugins": {"top-level-only": {}},
+        }).encode("utf-8")
+        with patch.object(
+            adapter_base.requests, "get",
+            _MockTransport(responses=[_FakeResp(body)]),
+        ):
+            manifest, _ = fetch_clawhub(self._src(), resolver=_stub_resolver())
+        self.assertEqual([e.name for e in manifest.entries], ["top-level-only"])
+
+    def test_invalid_plugin_names_skipped(self):
+        body = json.dumps({
+            "openclaw": {
+                "plugins": {
+                    "ok-name": {},
+                    "../escape": {},        # rejected by NAME_RE
+                    "x" * 200: {},          # too long
+                },
+            },
+        }).encode("utf-8")
+        with patch.object(
+            adapter_base.requests, "get",
+            _MockTransport(responses=[_FakeResp(body)]),
+        ):
+            manifest, _ = fetch_clawhub(self._src(), resolver=_stub_resolver())
+        self.assertEqual([e.name for e in manifest.entries], ["ok-name"])
+
+    def test_missing_plugins_map_yields_empty_manifest(self):
+        # An openclaw package without a plugins map is a valid (if
+        # unusual) state — it means "no skills published". We surface
+        # that as an empty manifest rather than an error so a
+        # mid-bootstrap registry doesn't permanently fail sync.
+        body = b'{"name":"openclaw"}'
+        with patch.object(
+            adapter_base.requests, "get",
+            _MockTransport(responses=[_FakeResp(body)]),
+        ):
+            manifest, _ = fetch_clawhub(self._src(), resolver=_stub_resolver())
+        self.assertEqual(manifest.entries, [])
+
+    def test_non_dict_plugins_field_raises(self):
+        # An older / mis-published openclaw package that ships
+        # `plugins: ["a","b"]` instead of a dict — the adapter
+        # explicitly refuses so an operator's `registry sync` fails
+        # loudly instead of silently importing zero entries.
+        body = b'{"openclaw":{"plugins":["bad"]}}'
+        with patch.object(
+            adapter_base.requests, "get",
+            _MockTransport(responses=[_FakeResp(body)]),
+        ), self.assertRaises(IngestError) as cm:
+            fetch_clawhub(self._src(), resolver=_stub_resolver())
+        self.assertIn("plugins map", str(cm.exception))
+
+    def test_non_json_body_raises(self):
+        with patch.object(
+            adapter_base.requests, "get",
+            _MockTransport(responses=[_FakeResp(b"<html>oops</html>")]),
+        ), self.assertRaises(IngestError) as cm:
+            fetch_clawhub(self._src(), resolver=_stub_resolver())
+        self.assertIn("not valid JSON", str(cm.exception))
+
+    def test_http_error_propagates_as_ingest_error(self):
+        with patch.object(
+            adapter_base.requests, "get",
+            _MockTransport(responses=[_FakeResp(b"", status=503)]),
+        ), self.assertRaises(IngestError):
+            fetch_clawhub(self._src(), resolver=_stub_resolver())
+
+    def test_ssrf_guard_rejects_internal_registry(self):
+        # No requests.get patch is needed — the SSRF guard fires
+        # before we ever try the network. This is the key regression
+        # test: the previous direct-requests implementation silently
+        # allowed http://internal.invalid as a registry URL.
+        with self.assertRaises(IngestError) as cm:
+            fetch_clawhub(
+                self._src(url="http://internal.invalid"),
+                resolver=_stub_resolver(),
+            )
+        self.assertIn("private", str(cm.exception))
+
+    def test_non_http_registry_url_rejected(self):
+        with self.assertRaises(IngestError) as cm:
+            fetch_clawhub(
+                self._src(url="ftp://example.com"),
+                resolver=_stub_resolver(),
+            )
+        self.assertIn("http(s)", str(cm.exception))
+
+
+# ---------------------------------------------------------------------------
+# smithery
+# ---------------------------------------------------------------------------
+
+class TestSmitheryAdapter(unittest.TestCase):
+    def _src(self, url: str = "") -> RegistrySource:
+        return RegistrySource(id="sm", kind="smithery", url=url, content="mcp")
+
+    def _post(self, body: bytes, url: str = "https://registry.smithery.ai/servers"):
+        transport = _MockTransport(responses=[_FakeResp(body)])
+        with patch.object(adapter_base.requests, "get", transport):
+            manifest, raw = fetch_smithery(
+                self._src(url=url), resolver=_stub_resolver(),
+            )
+        return manifest, raw, transport
+
+    def test_servers_envelope_extracted(self):
+        body = json.dumps({
+            "servers": [
+                {
+                    "qualifiedName": "demo-server",
+                    "version": "0.1.0",
+                    "license": "MIT",
+                    "deployment": {
+                        "transport": "stdio",
+                        "command": "/usr/bin/demo",
+                        "args": ["--mcp"],
+                        "env": {"DEMO_TOKEN": ""},
+                    },
+                },
+            ],
+        }).encode("utf-8")
+        manifest, _, _ = self._post(body)
+        self.assertEqual([e.name for e in manifest.entries], ["demo-server"])
+        e = manifest.entries[0]
+        self.assertEqual(e.transport, "stdio")
+        self.assertEqual(e.command, "/usr/bin/demo")
+        self.assertEqual(e.args, ["--mcp"])
+        self.assertEqual(e.env_required, ["DEMO_TOKEN"])
+
+    def test_data_envelope_also_supported(self):
+        body = json.dumps({
+            "data": [
+                {
+                    "name": "@scope/something",
+                    "deployment": {
+                        "transport": "http",
+                        "url": "https://server.example.com/mcp",
+                    },
+                },
+            ],
+        }).encode("utf-8")
+        manifest, _, _ = self._post(body)
+        # Slash and @ get normalised into a NAME_RE-compatible value.
+        self.assertEqual([e.name for e in manifest.entries], ["scope-something"])
+        self.assertEqual(manifest.entries[0].transport, "http")
+        self.assertEqual(
+            manifest.entries[0].url, "https://server.example.com/mcp",
+        )
+
+    def test_top_level_array_supported(self):
+        body = json.dumps([
+            {
+                "name": "bare-array-form",
+                "deployment": {
+                    "transport": "stdio",
+                    "command": "/bin/echo",
+                },
+            },
+        ]).encode("utf-8")
+        manifest, _, _ = self._post(body)
+        self.assertEqual([e.name for e in manifest.entries], ["bare-array-form"])
+
+    def test_unknown_envelope_raises(self):
+        body = b'{"foo":"bar"}'
+        transport = _MockTransport(responses=[_FakeResp(body)])
+        with patch.object(adapter_base.requests, "get", transport), \
+                self.assertRaises(IngestError) as cm:
+            fetch_smithery(self._src(), resolver=_stub_resolver())
+        self.assertIn("missing a servers array", str(cm.exception))
+
+    def test_non_json_response_raises(self):
+        transport = _MockTransport(responses=[_FakeResp(b"yaml: not-json")])
+        with patch.object(adapter_base.requests, "get", transport), \
+                self.assertRaises(IngestError) as cm:
+            fetch_smithery(self._src(), resolver=_stub_resolver())
+        self.assertIn("not valid JSON", str(cm.exception))
+
+    def test_malformed_rows_silently_skipped(self):
+        body = json.dumps({
+            "servers": [
+                None,
+                "string-row",
+                {},                     # empty dict — missing name → skip
+                {                       # bad command chars → skip
+                    "name": "bad-cmd",
+                    "deployment": {
+                        "transport": "stdio",
+                        "command": "echo;rm -rf /",
+                    },
+                },
+                {                       # stdio with no command → skip
+                    "name": "no-cmd",
+                    "deployment": {"transport": "stdio"},
+                },
+                {                       # non-stdio with no url → skip
+                    "name": "no-url",
+                    "deployment": {"transport": "http"},
+                },
+                {                       # ok row
+                    "name": "good",
+                    "deployment": {
+                        "transport": "stdio", "command": "/bin/ok",
+                    },
+                },
+            ],
+        }).encode("utf-8")
+        manifest, _, _ = self._post(body)
+        self.assertEqual([e.name for e in manifest.entries], ["good"])
+
+    def test_non_stdio_url_must_be_https_and_public(self):
+        # smithery entries with http:// URLs or URLs that resolve to
+        # internal IPs go straight into asset_policy.mcp.registry once
+        # promoted, so they must be filtered at ingest time. The
+        # adapter rejects each row but keeps clean ones.
+        body = json.dumps({
+            "servers": [
+                {
+                    "name": "plain-http",
+                    "deployment": {
+                        "transport": "http",
+                        "url": "http://server.example.com/mcp",
+                    },
+                },
+                {
+                    "name": "internal",
+                    "deployment": {
+                        "transport": "http",
+                        "url": "https://internal.invalid/mcp",
+                    },
+                },
+                {
+                    "name": "ok",
+                    "deployment": {
+                        "transport": "http",
+                        "url": "https://server.example.com/mcp",
+                    },
+                },
+            ],
+        }).encode("utf-8")
+        manifest, _, _ = self._post(body)
+        self.assertEqual([e.name for e in manifest.entries], ["ok"])
+
+    def test_unknown_transport_falls_back_to_stdio(self):
+        # Unknown transport with a URL provided: the adapter accepts
+        # the row but normalises the transport to "stdio" so the
+        # downstream scanner doesn't crash on a value outside
+        # KNOWN_TRANSPORTS. Note: an unknown transport with NO url
+        # would be rejected (URL is required for non-stdio
+        # transports), which is also the behaviour we want.
+        body = json.dumps({
+            "servers": [
+                {
+                    "name": "weird",
+                    "deployment": {
+                        "transport": "carrier-pigeon",
+                        "command": "/bin/ok",
+                        "url": "https://server.example.com/mcp",
+                    },
+                },
+            ],
+        }).encode("utf-8")
+        manifest, _, _ = self._post(body)
+        self.assertEqual(len(manifest.entries), 1)
+        self.assertEqual(manifest.entries[0].transport, "stdio")
+
+    def test_auth_env_passed_as_bearer(self):
+        body = b'{"servers":[]}'
+        transport = _MockTransport(responses=[_FakeResp(body)])
+        try:
+            os.environ["TEST_SMITHERY_TOK"] = "  abc123  "
+            src = RegistrySource(
+                id="sm", kind="smithery", auth_env="TEST_SMITHERY_TOK",
+            )
+            with patch.object(adapter_base.requests, "get", transport):
+                fetch_smithery(src, resolver=_stub_resolver())
+        finally:
+            os.environ.pop("TEST_SMITHERY_TOK", None)
+        self.assertEqual(
+            transport.calls[0]["headers"]["Authorization"], "Bearer abc123",
+        )
+
+    def test_size_cap_aborts_huge_response(self):
+        # Synthesise a body bigger than MAX_MANIFEST_BYTES (8 MiB).
+        big = b'{"servers":[]}' + b" " * (
+            adapter_base.MAX_MANIFEST_BYTES + 1024
+        )
+        transport = _MockTransport(
+            responses=[_FakeResp(big, headers={
+                "Content-Length": str(len(big)),
+            })],
+        )
+        with patch.object(adapter_base.requests, "get", transport), \
+                self.assertRaises(IngestError) as cm:
+            fetch_smithery(self._src(), resolver=_stub_resolver())
+        self.assertIn("max", str(cm.exception))
+
+
+# ---------------------------------------------------------------------------
+# http_yaml / http_json
+# ---------------------------------------------------------------------------
+
+class TestHTTPManifestAdapter(unittest.TestCase):
+    def _src(self, url: str, kind: str = "http_yaml") -> RegistrySource:
+        return RegistrySource(id="h", kind=kind, url=url, content="skill")
+
+    def test_yaml_body_parses(self):
+        body = (
+            b"schema_version: 1\n"
+            b"publisher: corp\n"
+            b"entries:\n"
+            b"  - {name: my-skill, type: skill, "
+            b"source_url: 'https://example.com/x.tgz'}\n"
+        )
+        transport = _MockTransport(responses=[_FakeResp(body)])
+        with patch.object(adapter_base.requests, "get", transport):
+            manifest, raw = fetch_http(
+                self._src("https://catalog.example.com/skills.yaml"),
+                resolver=_stub_resolver(),
+            )
+        self.assertEqual(manifest.publisher, "corp")
+        self.assertEqual(manifest.entries[0].name, "my-skill")
+        self.assertEqual(raw, body)
+
+    def test_json_body_parses(self):
+        body = json.dumps({
+            "schema_version": 1,
+            "entries": [
+                {
+                    "name": "from-json",
+                    "type": "skill",
+                    "source_url": "clawhub://from-json",
+                },
+            ],
+        }).encode("utf-8")
+        with patch.object(
+            adapter_base.requests, "get",
+            _MockTransport(responses=[_FakeResp(body)]),
+        ):
+            manifest, _ = fetch_http(
+                self._src("https://catalog.example.com/x.json", "http_json"),
+                resolver=_stub_resolver(),
+            )
+        self.assertEqual(manifest.entries[0].name, "from-json")
+
+    def test_redirect_chain_revalidated(self):
+        # Server returns a redirect; http_get must call guard_url on
+        # the new Location, then issue a second request. We simulate
+        # by routing the redirect target back through requests.get.
+        first = _FakeResp(b"", status=302, redirect_to="https://mirror.example.com/x.json")
+        second = _FakeResp(b'{"schema_version":1,"entries":[]}')
+        transport = _MockTransport(responses=[first, second])
+        with patch.object(adapter_base.requests, "get", transport):
+            manifest, _ = fetch_http(
+                self._src("https://catalog.example.com/x.json", "http_json"),
+                resolver=_stub_resolver(),
+            )
+        self.assertEqual(manifest.entries, [])
+        self.assertEqual(len(transport.calls), 2)
+        self.assertEqual(
+            transport.calls[1]["url"], "https://mirror.example.com/x.json",
+        )
+
+    def test_redirect_to_private_blocked(self):
+        first = _FakeResp(
+            b"", status=302,
+            redirect_to="https://internal.invalid/x.json",
+        )
+        transport = _MockTransport(responses=[first])
+        with patch.object(adapter_base.requests, "get", transport), \
+                self.assertRaises(IngestError) as cm:
+            fetch_http(
+                self._src("https://catalog.example.com/x.json", "http_json"),
+                resolver=_stub_resolver(),
+            )
+        self.assertIn("redirect blocked", str(cm.exception))
+
+    def test_empty_url_rejected(self):
+        with self.assertRaises(IngestError):
+            fetch_http(self._src(""), resolver=_stub_resolver())
+
+    def test_huge_content_length_aborts_before_read(self):
+        body = b'{"x":1}'
+        resp = _FakeResp(body, headers={
+            "Content-Length": str(adapter_base.MAX_MANIFEST_BYTES + 100),
+        })
+        with patch.object(
+            adapter_base.requests, "get",
+            _MockTransport(responses=[resp]),
+        ), self.assertRaises(IngestError):
+            fetch_http(
+                self._src("https://catalog.example.com/big.yaml"),
+                resolver=_stub_resolver(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# file
+# ---------------------------------------------------------------------------
+
+class TestFileAdapter(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="dc-file-adapter-")
+        self.path = Path(self.tmp) / "manifest.yaml"
+        self.path.write_text(
+            "schema_version: 1\n"
+            "entries:\n"
+            "  - {name: from-file, type: skill, source_url: 'https://x.example/s'}\n"
+        )
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_absolute_path_loads(self):
+        src = RegistrySource(
+            id="f", kind="file", url=str(self.path), content="skill",
+        )
+        manifest, _ = fetch_file(src)
+        self.assertEqual([e.name for e in manifest.entries], ["from-file"])
+
+    def test_file_scheme_stripped(self):
+        src = RegistrySource(
+            id="f", kind="file", url=f"file://{self.path}", content="skill",
+        )
+        manifest, _ = fetch_file(src)
+        self.assertEqual(manifest.entries[0].name, "from-file")
+
+    def test_relative_path_rejected(self):
+        src = RegistrySource(
+            id="f", kind="file", url="manifest.yaml", content="skill",
+        )
+        with self.assertRaises(IngestError) as cm:
+            fetch_file(src)
+        self.assertIn("absolute", str(cm.exception))
+
+    def test_missing_file_rejected(self):
+        src = RegistrySource(
+            id="f", kind="file",
+            url=str(Path(self.tmp) / "nope.yaml"), content="skill",
+        )
+        with self.assertRaises(IngestError):
+            fetch_file(src)
+
+    def test_directory_rejected(self):
+        src = RegistrySource(
+            id="f", kind="file", url=self.tmp, content="skill",
+        )
+        with self.assertRaises(IngestError) as cm:
+            fetch_file(src)
+        self.assertIn("not a regular file", str(cm.exception))
+
+    def test_size_cap_enforced(self):
+        big = self.path.with_name("big.yaml")
+        big.write_bytes(b" " * (adapter_base.MAX_MANIFEST_BYTES + 1))
+        src = RegistrySource(
+            id="f", kind="file", url=str(big), content="skill",
+        )
+        with self.assertRaises(IngestError):
+            fetch_file(src)
+
+
+# ---------------------------------------------------------------------------
+# git
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(
+    subprocess.run(  # noqa: S603,S607 - intentional path lookup
+        ["which", "git"], capture_output=True, check=False,
+    ).returncode == 0,
+    "git not available",
+)
+class TestGitAdapter(unittest.TestCase):
+    """End-to-end test against a local file:// repo via http(s) shim.
+
+    Because the SSRF guard rejects file:// schemes outright, we can't
+    point fetch_git at a tempdir. Instead we monkeypatch
+    ``subprocess.run`` to write the expected manifest into the
+    tempdir the adapter passes as the clone target, simulating a
+    successful clone without going to the network.
+    """
+
+    def _src(self, url: str = "https://catalog.example.com/registry.git"):
+        return RegistrySource(id="g", kind="git", url=url, content="skill")
+
+    def _fake_clone(self, manifest: bytes, name: str = "defenseclaw-registry.yaml"):
+        def _run(cmd, **kwargs):
+            # cmd = ["git", "clone", "--depth", "1", "--no-tags",
+            #        "--single-branch", "--", url, tmp]
+            tmp = cmd[-1]
+            (Path(tmp) / name).write_bytes(manifest)
+
+            class _R:
+                returncode = 0
+                stderr = ""
+
+            return _R()
+        return _run
+
+    def test_success_loads_yaml(self):
+        body = (
+            b"schema_version: 1\n"
+            b"entries:\n"
+            b"  - {name: git-skill, type: skill, source_url: 'https://x/y'}\n"
+        )
+        with patch("subprocess.run", side_effect=self._fake_clone(body)):
+            manifest, raw = fetch_git(self._src(), resolver=_stub_resolver())
+        self.assertEqual([e.name for e in manifest.entries], ["git-skill"])
+        self.assertEqual(raw, body)
+
+    def test_yml_filename_also_picked_up(self):
+        body = b'{"schema_version":1,"entries":[]}'
+        with patch(
+            "subprocess.run",
+            side_effect=self._fake_clone(body, name="defenseclaw-registry.yml"),
+        ):
+            manifest, _ = fetch_git(self._src(), resolver=_stub_resolver())
+        self.assertEqual(manifest.entries, [])
+
+    def test_clone_failure_reports_stderr(self):
+        def _fail(cmd, **kwargs):
+            class _R:
+                returncode = 128
+                stderr = "fatal: bad refs"
+            return _R()
+
+        with patch("subprocess.run", side_effect=_fail), \
+                self.assertRaises(IngestError) as cm:
+            fetch_git(self._src(), resolver=_stub_resolver())
+        self.assertIn("fatal: bad refs", str(cm.exception))
+
+    def test_no_manifest_at_root_rejected(self):
+        def _empty(cmd, **kwargs):
+            class _R:
+                returncode = 0
+                stderr = ""
+            return _R()
+
+        with patch("subprocess.run", side_effect=_empty), \
+                self.assertRaises(IngestError) as cm:
+            fetch_git(self._src(), resolver=_stub_resolver())
+        self.assertIn("no defenseclaw-registry manifest", str(cm.exception))
+
+    def test_ssh_url_rejected(self):
+        with self.assertRaises(IngestError):
+            fetch_git(
+                self._src(url="git@github.com:owner/repo.git"),
+                resolver=_stub_resolver(),
+            )
+
+    def test_credentials_in_url_rejected(self):
+        with self.assertRaises(IngestError):
+            fetch_git(self._src(
+                url="https://user:secret@catalog.example.com/repo.git",
+            ), resolver=_stub_resolver())
+
+    def test_shell_metacharacters_rejected(self):
+        with self.assertRaises(IngestError):
+            fetch_git(self._src(
+                url="https://catalog.example.com/repo;rm -rf /.git",
+            ), resolver=_stub_resolver())
+
+    def test_empty_url_rejected(self):
+        with self.assertRaises(IngestError):
+            fetch_git(self._src(url=""), resolver=_stub_resolver())
+
+    def test_private_host_rejected_by_ssrf(self):
+        # The git URL should run through guard_git_url → guard_url, so
+        # an internal host fails before we ever exec git. Without
+        # this guard the operator could point a registry at internal
+        # infra and trigger an outbound git clone the gateway would
+        # otherwise refuse for HTTP fetches.
+        with self.assertRaises(IngestError) as cm:
+            fetch_git(
+                self._src(url="https://internal.invalid/repo.git"),
+                resolver=_stub_resolver(),
+            )
+        self.assertIn("private", str(cm.exception))
+
+
+# ---------------------------------------------------------------------------
+# skills.sh
+# ---------------------------------------------------------------------------
+
+class TestSkillsShAdapter(unittest.TestCase):
+    """Tests for the skills.sh adapter against fixture API responses.
+
+    Rather than hand-rolling JSON in every test we reuse the shape
+    documented at https://skills.sh/docs/api so a future schema drift
+    surfaces here first.
+    """
+
+    def _src(self, url: str = "") -> RegistrySource:
+        return RegistrySource(id="ss", kind="skills_sh", url=url, content="skill")
+
+    def _curated_payload(self):
+        return {
+            "data": [
+                {
+                    "owner": "vercel-labs",
+                    "totalInstalls": 89240,
+                    "featuredRepo": "agent-skills",
+                    "featuredSkill": "Next.js Development",
+                    "skills": [
+                        {
+                            "id": "vercel-labs/agent-skills/next-js-development",
+                            "slug": "next-js-development",
+                            "name": "Next.js Development",
+                            "source": "vercel-labs/agent-skills",
+                            "installs": 24531,
+                            "sourceType": "github",
+                            "installUrl": "https://github.com/vercel-labs/agent-skills",
+                            "url": "https://skills.sh/vercel-labs/agent-skills/next-js-development",
+                        },
+                        {
+                            # Duplicate fork — must be filtered out.
+                            "id": "vercel-labs/agent-skills/copy-of-it",
+                            "slug": "copy-of-it",
+                            "name": "Copy",
+                            "source": "vercel-labs/agent-skills",
+                            "installs": 0,
+                            "sourceType": "github",
+                            "installUrl": "https://github.com/vercel-labs/agent-skills",
+                            "url": "https://skills.sh/vercel-labs/agent-skills/copy-of-it",
+                            "isDuplicate": True,
+                        },
+                    ],
+                },
+                {
+                    "owner": "anthropics",
+                    "totalInstalls": 50000,
+                    "skills": [
+                        {
+                            "id": "anthropics/skills/frontend-design",
+                            "slug": "frontend-design",
+                            "name": "Frontend Design",
+                            "source": "anthropics/skills",
+                            "installs": 379000,
+                            "sourceType": "github",
+                            "installUrl": "https://github.com/anthropics/skills",
+                            "url": "https://skills.sh/anthropics/skills/frontend-design",
+                        },
+                    ],
+                },
+            ],
+            "totalOwners": 87,
+            "totalSkills": 342,
+            "generatedAt": "2026-03-31T08:00:00.000Z",
+        }
+
+    def _list_payload(self, view: str, items: list[dict], has_more: bool = False):
+        return {
+            "data": items,
+            "pagination": {
+                "page": 0, "perPage": len(items),
+                "total": len(items), "hasMore": has_more,
+            },
+            "view": view,
+        }
+
+    def _skill(self, owner: str, repo: str, slug: str):
+        return {
+            "id": f"{owner}/{repo}/{slug}",
+            "slug": slug,
+            "name": slug.replace("-", " ").title(),
+            "source": f"{owner}/{repo}",
+            "installs": 1,
+            "sourceType": "github",
+            "installUrl": f"https://github.com/{owner}/{repo}",
+            "url": f"https://skills.sh/{owner}/{repo}/{slug}",
+        }
+
+    def test_default_url_uses_curated_view(self):
+        body = json.dumps(self._curated_payload()).encode("utf-8")
+        transport = _MockTransport(responses=[_FakeResp(body)])
+        with patch.object(adapter_base.requests, "get", transport):
+            manifest, _ = fetch_skills_sh(
+                self._src(), resolver=_stub_resolver(),
+            )
+        self.assertEqual(transport.calls[0]["url"],
+                         f"{DEFAULT_BASE_URL}/api/v1/skills/curated")
+        names = sorted(e.name for e in manifest.entries)
+        # Two distinct skills survive; the duplicate is dropped.
+        self.assertEqual(names, [
+            "anthropics-skills-frontend-design",
+            "vercel-labs-agent-skills-next-js-development",
+        ])
+        e = next(x for x in manifest.entries if "next-js" in x.name)
+        self.assertEqual(e.type, "skill")
+        self.assertEqual(e.publisher, "vercel-labs")
+        self.assertEqual(e.source_url, "https://github.com/vercel-labs/agent-skills")
+        self.assertEqual(e.tags, ["github"])
+
+    def test_view_keyword_url(self):
+        body = json.dumps(self._curated_payload()).encode("utf-8")
+        transport = _MockTransport(responses=[_FakeResp(body)])
+        with patch.object(adapter_base.requests, "get", transport):
+            fetch_skills_sh(self._src(url="curated"), resolver=_stub_resolver())
+        self.assertEqual(
+            transport.calls[0]["url"],
+            f"{DEFAULT_BASE_URL}/api/v1/skills/curated",
+        )
+
+    def test_paginated_all_time_walks_pages(self):
+        page0 = self._list_payload("all-time", [
+            self._skill("a", "b", "one"),
+            self._skill("a", "b", "two"),
+        ], has_more=True)
+        page1 = self._list_payload("all-time", [
+            self._skill("c", "d", "three"),
+        ], has_more=False)
+        transport = _MockTransport(responses=[
+            _FakeResp(json.dumps(page0).encode("utf-8")),
+            _FakeResp(json.dumps(page1).encode("utf-8")),
+        ])
+        with patch.object(adapter_base.requests, "get", transport):
+            manifest, raw = fetch_skills_sh(
+                self._src(url="all-time"), resolver=_stub_resolver(),
+            )
+        self.assertEqual([e.name for e in manifest.entries], [
+            "a-b-one", "a-b-two", "c-d-three",
+        ])
+        # The cached "raw" bytes must be the FIRST page's body so an
+        # operator inspecting manifest.json sees real server output,
+        # not a stitched-together view.
+        self.assertEqual(raw, json.dumps(page0).encode("utf-8"))
+        # We sent ?view=all-time in the query string.
+        self.assertIn("view=all-time", transport.calls[0]["url"])
+        self.assertIn("page=0", transport.calls[0]["url"])
+        self.assertIn("page=1", transport.calls[1]["url"])
+
+    def test_max_caps_paged_results(self):
+        page = self._list_payload("trending", [
+            self._skill("a", "b", f"slug-{i}") for i in range(20)
+        ], has_more=True)
+        transport = _MockTransport(responses=[
+            _FakeResp(json.dumps(page).encode("utf-8")),
+        ])
+        with patch.object(adapter_base.requests, "get", transport):
+            manifest, _ = fetch_skills_sh(
+                self._src(url="https://skills.sh?view=trending&max=5"),
+                resolver=_stub_resolver(),
+            )
+        self.assertEqual(len(manifest.entries), 5)
+
+    def test_invalid_view_rejected(self):
+        with self.assertRaises(IngestError) as cm:
+            fetch_skills_sh(
+                self._src(url="https://skills.sh?view=carrier-pigeon"),
+                resolver=_stub_resolver(),
+            )
+        self.assertIn("view must be one of", str(cm.exception))
+
+    def test_invalid_per_page_rejected(self):
+        with self.assertRaises(IngestError):
+            fetch_skills_sh(
+                self._src(url="https://skills.sh?view=all-time&per_page=999"),
+                resolver=_stub_resolver(),
+            )
+
+    def test_invalid_max_rejected(self):
+        with self.assertRaises(IngestError):
+            fetch_skills_sh(
+                self._src(url="https://skills.sh?view=all-time&max=999999"),
+                resolver=_stub_resolver(),
+            )
+
+    def test_non_https_source_url_rejected(self):
+        with self.assertRaises(IngestError):
+            fetch_skills_sh(
+                self._src(url="ftp://skills.sh/api"),
+                resolver=_stub_resolver(),
+            )
+
+    def test_non_github_install_url_dropped(self):
+        page = self._list_payload("trending", [
+            {
+                **self._skill("a", "b", "ok"),
+                "installUrl": "https://github.com/a/b",
+            },
+            {
+                **self._skill("a", "b", "weird"),
+                "installUrl": "ftp://example.com/x",
+            },
+            {
+                **self._skill("a", "b", "spoofed"),
+                "sourceType": "github",
+                # github-typed but pointing at a non-github URL → drop.
+                "installUrl": "https://evil.example.com/repo",
+            },
+            {
+                **self._skill("a", "b", "downgrade"),
+                # http:// install URL is rejected even though the
+                # host is github.com — TLS downgrade must not be
+                # silently accepted.
+                "installUrl": "http://github.com/a/b",
+            },
+        ], has_more=False)
+        transport = _MockTransport(responses=[
+            _FakeResp(json.dumps(page).encode("utf-8")),
+        ])
+        with patch.object(adapter_base.requests, "get", transport):
+            manifest, _ = fetch_skills_sh(
+                self._src(url="trending"),
+                resolver=_stub_resolver(),
+            )
+        self.assertEqual([e.name for e in manifest.entries], ["a-b-ok"])
+
+    def test_well_known_source_type_kept(self):
+        # well-known sources skip the "github.com in URL" check.
+        page = self._list_payload("all-time", [
+            {
+                "id": "mintlify.com/mintlify",
+                "slug": "mintlify",
+                "name": "Mintlify",
+                "source": "mintlify.com",
+                "installs": 9,
+                "sourceType": "well-known",
+                "installUrl": "https://mintlify.com",
+                "url": "https://skills.sh/mintlify.com/mintlify",
+            },
+        ], has_more=False)
+        transport = _MockTransport(responses=[
+            _FakeResp(json.dumps(page).encode("utf-8")),
+        ])
+        with patch.object(adapter_base.requests, "get", transport):
+            manifest, _ = fetch_skills_sh(
+                self._src(url="all-time"),
+                resolver=_stub_resolver(),
+            )
+        self.assertEqual([e.name for e in manifest.entries],
+                         ["mintlify.com-mintlify"])
+        self.assertEqual(manifest.entries[0].tags, ["well-known"])
+
+    def test_malformed_rows_silently_skipped(self):
+        page = self._list_payload("hot", [
+            None,
+            "string-row",
+            {},                                          # missing id
+            {"id": "x"},                                 # missing slug/source
+            {                                            # missing slug
+                "id": "owner/repo/",
+                "slug": "",
+                "source": "owner/repo",
+                "installUrl": "https://github.com/owner/repo",
+                "sourceType": "github",
+            },
+            {                                            # name strips to empty
+                "id": "----",
+                "slug": "----",
+                "source": "----",
+                "installUrl": "https://github.com/x/y",
+                "sourceType": "github",
+            },
+            self._skill("good", "repo", "ok"),
+        ], has_more=False)
+        transport = _MockTransport(responses=[
+            _FakeResp(json.dumps(page).encode("utf-8")),
+        ])
+        with patch.object(adapter_base.requests, "get", transport):
+            manifest, _ = fetch_skills_sh(
+                self._src(url="hot"),
+                resolver=_stub_resolver(),
+            )
+        self.assertEqual([e.name for e in manifest.entries], ["good-repo-ok"])
+
+    def test_auth_token_from_env(self):
+        body = json.dumps(self._curated_payload()).encode("utf-8")
+        transport = _MockTransport(responses=[_FakeResp(body)])
+        try:
+            os.environ["TEST_SKILLSSH_TOK"] = "sk_live_xxxxxxxxxx"
+            src = RegistrySource(
+                id="ss", kind="skills_sh", auth_env="TEST_SKILLSSH_TOK",
+                content="skill",
+            )
+            with patch.object(adapter_base.requests, "get", transport):
+                fetch_skills_sh(src, resolver=_stub_resolver())
+        finally:
+            os.environ.pop("TEST_SKILLSSH_TOK", None)
+        self.assertEqual(
+            transport.calls[0]["headers"]["Authorization"],
+            "Bearer sk_live_xxxxxxxxxx",
+        )
+
+    def test_known_views_complete(self):
+        # If the upstream API ever publishes a new view we want this
+        # constant to fail loudly so the adapter gets an explicit
+        # opt-in rather than silently dropping the operator request.
+        self.assertEqual(
+            set(KNOWN_VIEWS), {"all-time", "trending", "hot", "curated"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# fetch_manifest dispatch
+# ---------------------------------------------------------------------------
+
+class TestDispatch(unittest.TestCase):
+    """The dispatcher must hand work to the right adapter and reject
+    unknown kinds. We pre-mock requests so the HTTPS adapters succeed."""
+
+    def test_skills_sh_routed_to_adapter(self):
+        body = json.dumps({"data": []}).encode("utf-8")
+        transport = _MockTransport(responses=[_FakeResp(body)])
+        src = RegistrySource(
+            id="ss", kind="skills_sh", url="curated", content="skill",
+        )
+        with patch.object(adapter_base.requests, "get", transport):
+            manifest, _ = fetch_manifest(src, resolver=_stub_resolver())
+        self.assertEqual(manifest.publisher, "skills.sh")
+
+    def test_unknown_kind_rejected(self):
+        with self.assertRaises(IngestError):
+            fetch_manifest(
+                RegistrySource(id="x", kind="totally-fake", content="skill"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/tests/test_registry_manifest.py
+++ b/cli/tests/test_registry_manifest.py
@@ -1,0 +1,265 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the registry manifest parser/validator.
+
+These tests pin the *security-relevant* invariants — name / command
+character classes, URL scheme allow-list, length caps, duplicate
+rejection — so the ingest pipeline cannot silently accept a poisoned
+catalog. They run without the optional ``jsonschema`` package, so the
+hand-written validator is exercised end-to-end on every CI run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from defenseclaw.registries.manifest import (
+    KNOWN_CONNECTORS,
+    KNOWN_TRANSPORTS,
+    KNOWN_TYPES,
+    NAME_RE,
+    ManifestError,
+    parse_manifest,
+)
+
+
+def _wrap(*entries):
+    return {"schema_version": 1, "entries": list(entries)}
+
+
+class TestSchemaVersion(unittest.TestCase):
+    def test_missing_schema_version_rejected(self):
+        with self.assertRaises(ManifestError):
+            parse_manifest(json.dumps({"entries": []}))
+
+    def test_unsupported_schema_version_rejected(self):
+        with self.assertRaises(ManifestError):
+            parse_manifest(json.dumps({"schema_version": 2, "entries": []}))
+
+    def test_v1_with_no_entries_ok(self):
+        m = parse_manifest(json.dumps({"schema_version": 1, "entries": []}))
+        self.assertEqual(m.schema_version, 1)
+        self.assertEqual(m.entries, [])
+
+    def test_top_level_must_be_mapping(self):
+        with self.assertRaises(ManifestError):
+            parse_manifest("[]")
+
+
+class TestSkillEntries(unittest.TestCase):
+    def test_minimal_skill_entry(self):
+        m = parse_manifest(json.dumps(_wrap({
+            "name": "demo-skill",
+            "type": "skill",
+            "source_url": "clawhub://demo-skill",
+        })))
+        self.assertEqual(len(m.entries), 1)
+        self.assertTrue(m.entries[0].is_skill())
+
+    def test_skill_requires_source_url(self):
+        with self.assertRaises(ManifestError):
+            parse_manifest(json.dumps(_wrap({
+                "name": "demo-skill", "type": "skill",
+            })))
+
+    def test_skill_source_url_scheme_locked(self):
+        for bad in ("file:///etc/passwd", "ftp://example.com", "ssh://x"):
+            with self.subTest(url=bad):
+                with self.assertRaises(ManifestError):
+                    parse_manifest(json.dumps(_wrap({
+                        "name": "demo", "type": "skill", "source_url": bad,
+                    })))
+
+    def test_skill_sha256_must_be_64_hex(self):
+        with self.assertRaises(ManifestError):
+            parse_manifest(json.dumps(_wrap({
+                "name": "demo", "type": "skill",
+                "source_url": "https://example.com/x.tgz",
+                "sha256": "not-hex",
+            })))
+
+    def test_skill_sha256_accepted_when_valid(self):
+        m = parse_manifest(json.dumps(_wrap({
+            "name": "demo", "type": "skill",
+            "source_url": "https://example.com/x.tgz",
+            "sha256": "a" * 64,
+        })))
+        self.assertEqual(m.entries[0].sha256, "a" * 64)
+
+    def test_skill_homepage_must_be_http(self):
+        with self.assertRaises(ManifestError):
+            parse_manifest(json.dumps(_wrap({
+                "name": "demo", "type": "skill",
+                "source_url": "https://x/y",
+                "homepage": "javascript:alert(1)",
+            })))
+
+
+class TestMcpEntries(unittest.TestCase):
+    def test_stdio_requires_command(self):
+        with self.assertRaises(ManifestError):
+            parse_manifest(json.dumps(_wrap({
+                "name": "stdio-srv", "type": "mcp", "transport": "stdio",
+            })))
+
+    def test_command_character_class_locked(self):
+        # The ; here would let a poisoned manifest smuggle a shell
+        # metacharacter into the scanner subprocess if we ever invoked
+        # via a shell. Refuse at parse time.
+        with self.assertRaises(ManifestError):
+            parse_manifest(json.dumps(_wrap({
+                "name": "evil", "type": "mcp",
+                "transport": "stdio",
+                "command": "rm; sleep 5",
+            })))
+
+    def test_command_dot_slash_allowed(self):
+        # Operators do legitimately point at ./bin/foo or relative
+        # paths under repo roots — the allow-list covers that case.
+        m = parse_manifest(json.dumps(_wrap({
+            "name": "bin", "type": "mcp",
+            "transport": "stdio",
+            "command": "./bin/foo",
+        })))
+        self.assertEqual(m.entries[0].command, "./bin/foo")
+
+    def test_env_required_must_be_uppercase(self):
+        with self.assertRaises(ManifestError):
+            parse_manifest(json.dumps(_wrap({
+                "name": "srv", "type": "mcp",
+                "transport": "stdio", "command": "x",
+                "env_required": ["lowercase"],
+            })))
+
+    def test_remote_transport_requires_url(self):
+        with self.assertRaises(ManifestError):
+            parse_manifest(json.dumps(_wrap({
+                "name": "srv", "type": "mcp",
+                "transport": "streamable-http",
+            })))
+
+    def test_unknown_transport_rejected(self):
+        with self.assertRaises(ManifestError):
+            parse_manifest(json.dumps(_wrap({
+                "name": "srv", "type": "mcp",
+                "transport": "unicorn", "command": "x",
+            })))
+
+    def test_unknown_connector_rejected(self):
+        with self.assertRaises(ManifestError):
+            parse_manifest(json.dumps(_wrap({
+                "name": "srv", "type": "mcp",
+                "transport": "stdio", "command": "x",
+                "connector": "fake",
+            })))
+
+
+class TestNamesAndDuplicates(unittest.TestCase):
+    def test_name_must_match_regex(self):
+        for bad in ("../escape", "with space", "$inject", ""):
+            with self.subTest(name=bad):
+                self.assertFalse(NAME_RE.match(bad))
+                with self.assertRaises(ManifestError):
+                    parse_manifest(json.dumps(_wrap({
+                        "name": bad, "type": "skill",
+                        "source_url": "https://x/y",
+                    })))
+
+    def test_duplicate_entry_rejected(self):
+        with self.assertRaises(ManifestError):
+            parse_manifest(json.dumps(_wrap(
+                {"name": "dup", "type": "skill", "source_url": "https://x/y"},
+                {"name": "dup", "type": "skill", "source_url": "https://x/y"},
+            )))
+
+    def test_duplicate_across_types_allowed(self):
+        # A skill named "foo" and an MCP named "foo" are *different*
+        # assets — both are allowed in the same manifest.
+        m = parse_manifest(json.dumps(_wrap(
+            {"name": "foo", "type": "skill", "source_url": "https://x/y"},
+            {"name": "foo", "type": "mcp",
+             "transport": "stdio", "command": "f"},
+        )))
+        self.assertEqual(len(m.entries), 2)
+
+
+class TestParseFormats(unittest.TestCase):
+    def test_yaml_accepted(self):
+        body = (
+            "schema_version: 1\n"
+            "entries:\n"
+            "  - name: yaml-demo\n"
+            "    type: skill\n"
+            "    source_url: clawhub://yaml-demo\n"
+        )
+        m = parse_manifest(body)
+        self.assertEqual(m.entries[0].name, "yaml-demo")
+
+    def test_bytes_accepted(self):
+        m = parse_manifest(b'{"schema_version": 1, "entries": []}')
+        self.assertEqual(m.entries, [])
+
+    def test_invalid_utf8_rejected(self):
+        with self.assertRaises(ManifestError):
+            parse_manifest(b"\xff\xfe\xfc")
+
+    def test_empty_payload_rejected(self):
+        with self.assertRaises(ManifestError):
+            parse_manifest("")
+
+
+class TestFilterByContent(unittest.TestCase):
+    def setUp(self):
+        self.manifest = parse_manifest(json.dumps(_wrap(
+            {"name": "s1", "type": "skill", "source_url": "https://x/1"},
+            {"name": "m1", "type": "mcp",
+             "transport": "stdio", "command": "x"},
+        )))
+
+    def test_skill_only(self):
+        only = self.manifest.filter_by_content("skill")
+        self.assertEqual([e.name for e in only], ["s1"])
+
+    def test_mcp_only(self):
+        only = self.manifest.filter_by_content("mcp")
+        self.assertEqual([e.name for e in only], ["m1"])
+
+    def test_both(self):
+        both = self.manifest.filter_by_content("both")
+        self.assertEqual({e.name for e in both}, {"s1", "m1"})
+
+
+class TestKnownConstants(unittest.TestCase):
+    """Regression: keep the KNOWN_* sets aligned with the schema."""
+
+    def test_known_types_match_schema(self):
+        self.assertEqual(KNOWN_TYPES, {"skill", "mcp"})
+
+    def test_known_transports_match_schema(self):
+        self.assertEqual(
+            KNOWN_TRANSPORTS,
+            {"stdio", "http", "sse", "streamable-http", "websocket"},
+        )
+
+    def test_known_connectors_match_schema(self):
+        self.assertEqual(
+            KNOWN_CONNECTORS,
+            {"openclaw", "claudecode", "codex", "zeptoclaw"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/tests/test_registry_manifest.py
+++ b/cli/tests/test_registry_manifest.py
@@ -242,6 +242,86 @@ class TestFilterByContent(unittest.TestCase):
         self.assertEqual({e.name for e in both}, {"s1", "m1"})
 
 
+class TestYAMLAutoTypingCoercion(unittest.TestCase):
+    """PyYAML's safe_load auto-types unquoted scalars (datetime, int,
+    float). The manifest schema declares every text field as a string,
+    so the parser is supposed to coerce these losslessly back to their
+    surface form before validation kicks in. A regression here turns
+    perfectly valid catalog YAML into a hard failure on first sync.
+    """
+
+    def test_unquoted_datetime_generated_at_accepted(self):
+        body = (
+            "schema_version: 1\n"
+            "publisher: vendor\n"
+            "generated_at: 2026-05-07T20:00:00Z\n"
+            "entries: []\n"
+        )
+        m = parse_manifest(body)
+        self.assertEqual(m.generated_at, "2026-05-07T20:00:00Z")
+
+    def test_unquoted_date_generated_at_accepted(self):
+        body = (
+            "schema_version: 1\n"
+            "generated_at: 2026-05-07\n"
+            "entries: []\n"
+        )
+        m = parse_manifest(body)
+        self.assertEqual(m.generated_at, "2026-05-07")
+
+    def test_unquoted_float_version_accepted(self):
+        body = (
+            "schema_version: 1\n"
+            "entries:\n"
+            "  - name: hello\n"
+            "    type: skill\n"
+            "    source_url: clawhub://hello\n"
+            "    version: 1.0\n"
+        )
+        m = parse_manifest(body)
+        self.assertEqual(m.entries[0].version, "1.0")
+
+    def test_unquoted_int_version_accepted(self):
+        body = (
+            "schema_version: 1\n"
+            "entries:\n"
+            "  - name: hello\n"
+            "    type: skill\n"
+            "    source_url: clawhub://hello\n"
+            "    version: 7\n"
+        )
+        m = parse_manifest(body)
+        self.assertEqual(m.entries[0].version, "7")
+
+    def test_bool_in_string_field_still_rejected(self):
+        # A bare YAML ``yes`` should NOT silently become "True" in
+        # generated_at — the operator either typed something they
+        # didn't mean or the manifest is corrupted, and we want a
+        # loud error either way.
+        body = (
+            "schema_version: 1\n"
+            "generated_at: yes\n"
+            "entries: []\n"
+        )
+        with self.assertRaises(ManifestError) as cm:
+            parse_manifest(body)
+        self.assertIn("bool", str(cm.exception))
+
+    def test_dict_in_string_field_still_rejected(self):
+        # Nested mappings can't be coerced to a string in any
+        # lossless way; reject so the operator notices their
+        # publisher emitted a structural value where a scalar was
+        # expected.
+        body = (
+            "schema_version: 1\n"
+            "publisher:\n"
+            "  name: nested\n"
+            "entries: []\n"
+        )
+        with self.assertRaises(ManifestError):
+            parse_manifest(body)
+
+
 class TestKnownConstants(unittest.TestCase):
     """Regression: keep the KNOWN_* sets aligned with the schema."""
 

--- a/cli/tests/test_registry_ssrf.py
+++ b/cli/tests/test_registry_ssrf.py
@@ -1,0 +1,168 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the registry SSRF guard.
+
+The guard's job is fail-closed by default: every operator-supplied URL
+must resolve to a publicly routable host before we hand it to
+:mod:`requests`. These tests exercise the guard with a stub resolver
+so the suite never touches real DNS.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from defenseclaw.registries.ssrf import SSRFError, guard_git_url, guard_url
+
+
+def stub(addr_map):
+    def _resolve(host):
+        return list(addr_map.get(host, []))
+    return _resolve
+
+
+class TestSchemes(unittest.TestCase):
+    # 8.8.8.8 is globally routable and not in any of the
+    # private/reserved/loopback/link-local/multicast/unspecified
+    # ranges that the guard rejects, so it's a stable "public" stand-in
+    # for tests. RFC5737 documentation prefixes (192.0.2.0/24,
+    # 198.51.100.0/24, 203.0.113.0/24) are flagged as `is_reserved`
+    # by Python's ipaddress module and would be rejected here.
+    PUBLIC_IP = "8.8.8.8"
+
+    def test_https_public_ok(self):
+        guard_url(
+            "https://catalog.example.com/manifest.yaml",
+            resolver=stub({"catalog.example.com": [self.PUBLIC_IP]}),
+        )
+
+    def test_http_public_ok_but_caller_should_warn(self):
+        # HTTP is allowed by the guard (publishers occasionally serve
+        # plain HTTP behind a corporate WAF); the surrounding
+        # CLI/adapter is expected to surface a warning. The guard
+        # itself must accept it so policy-driven downgrades don't
+        # break ingest.
+        guard_url(
+            "http://catalog.example.com/manifest.yaml",
+            resolver=stub({"catalog.example.com": [self.PUBLIC_IP]}),
+        )
+
+    def test_file_scheme_rejected(self):
+        with self.assertRaises(SSRFError):
+            guard_url("file:///etc/passwd")
+
+    def test_ftp_scheme_rejected(self):
+        with self.assertRaises(SSRFError):
+            guard_url("ftp://example.com/x")
+
+    def test_javascript_scheme_rejected(self):
+        with self.assertRaises(SSRFError):
+            guard_url("javascript:alert(1)")
+
+
+class TestHostShape(unittest.TestCase):
+    def test_missing_host_rejected(self):
+        with self.assertRaises(SSRFError):
+            guard_url("https:///foo")
+
+    def test_localhost_literal_rejected(self):
+        with self.assertRaises(SSRFError):
+            guard_url("https://localhost/manifest")
+
+    def test_unresolvable_host_rejected(self):
+        with self.assertRaises(SSRFError):
+            guard_url(
+                "https://nope.example",
+                resolver=stub({}),
+            )
+
+
+class TestPrivateRanges(unittest.TestCase):
+    def test_loopback_blocked(self):
+        for ip in ("127.0.0.1", "::1"):
+            with self.subTest(ip=ip):
+                with self.assertRaises(SSRFError):
+                    guard_url(
+                        "https://loop.example/m",
+                        resolver=stub({"loop.example": [ip]}),
+                    )
+
+    def test_link_local_blocked(self):
+        with self.assertRaises(SSRFError):
+            guard_url(
+                "https://ll.example/m",
+                resolver=stub({"ll.example": ["169.254.169.254"]}),
+            )
+
+    def test_rfc1918_blocked_by_default(self):
+        for ip in ("10.0.0.1", "192.168.1.1", "172.16.0.1"):
+            with self.subTest(ip=ip):
+                with self.assertRaises(SSRFError):
+                    guard_url(
+                        "https://corp.example/m",
+                        resolver=stub({"corp.example": [ip]}),
+                    )
+
+    def test_rfc1918_allowed_when_opted_in(self):
+        # Operators with on-prem registries set --allow-private. The
+        # guard accepts the *same* URL it would reject without the
+        # flag — no behavioural drift between the two paths.
+        guard_url(
+            "https://corp.example/m",
+            allow_private=True,
+            resolver=stub({"corp.example": ["10.0.0.1"]}),
+        )
+
+    def test_dual_stack_resolves_one_private_one_public(self):
+        # An attacker can publish a hostname whose A record is public
+        # but whose AAAA record is link-local — guard must reject if
+        # *any* address is disallowed.
+        with self.assertRaises(SSRFError):
+            guard_url(
+                "https://mixed.example/m",
+                resolver=stub({"mixed.example": ["8.8.8.8", "fe80::1"]}),
+            )
+
+    def test_unspecified_blocked(self):
+        with self.assertRaises(SSRFError):
+            guard_url(
+                "https://zero.example/m",
+                resolver=stub({"zero.example": ["0.0.0.0"]}),
+            )
+
+
+class TestGitGuard(unittest.TestCase):
+    def test_https_git_url_passes(self):
+        guard_git_url(
+            "https://example.com/acme/registry.git",
+            allow_private=False,
+            resolver=stub({"example.com": ["8.8.8.8"]}),
+        )
+
+    def test_ssh_git_url_rejected(self):
+        with self.assertRaises(SSRFError):
+            guard_git_url("ssh://git@github.com/acme/registry.git")
+
+    def test_git_protocol_rejected(self):
+        with self.assertRaises(SSRFError):
+            guard_git_url("git://github.com/acme/registry.git")
+
+    def test_file_url_rejected(self):
+        with self.assertRaises(SSRFError):
+            guard_git_url("file:///srv/registry.git")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/tests/test_registry_sync.py
+++ b/cli/tests/test_registry_sync.py
@@ -1,0 +1,374 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end tests for the registry sync pipeline.
+
+We bypass the live HTTP / git adapters by injecting a stub
+``fetch_manifest`` so the tests are hermetic. The verdict-promotion
+logic, manual approve/reject overrides, and ``asset_policy`` mutation
+are all exercised against an in-memory :class:`Config` and a temp
+``data_dir``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# All imports live below the sys.path tweak above so the test runner
+# resolves `defenseclaw.*` against the repo source rather than any
+# globally-installed copy. The E402 noqa keeps ruff quiet about the
+# intentional ordering — see the BuildPlanTests block in
+# test_cmd_uninstall.py for the same idiom.
+from defenseclaw.config import RegistrySource  # noqa: E402
+from defenseclaw.models import Finding, ScanResult  # noqa: E402
+from defenseclaw.registries.cache import (  # noqa: E402
+    EntryVerdict,
+    SourceIndex,
+    load_index,
+    save_index,
+)
+from defenseclaw.registries.manifest import parse_manifest  # noqa: E402
+from defenseclaw.registries.sync import (  # noqa: E402
+    manual_set_verdict,
+    sync_all,
+    sync_source,
+)
+
+from tests.helpers import make_temp_config  # noqa: E402
+
+
+def _scan_result(target: str, findings=None) -> ScanResult:
+    return ScanResult(
+        scanner="test",
+        target=target,
+        timestamp=datetime.now(timezone.utc),
+        findings=list(findings or []),
+    )
+
+
+def _finding(severity: str, target: str = "x") -> Finding:
+    return Finding(
+        id=f"FND-{target}-{severity}",
+        severity=severity,
+        title=f"{severity} demo",
+        scanner="test",
+    )
+
+
+def _fresh_skill_manifest():
+    return parse_manifest(json.dumps({
+        "schema_version": 1,
+        "publisher": "acme",
+        "entries": [
+            {
+                "name": "demo-skill",
+                "type": "skill",
+                "source_url": "clawhub://demo-skill",
+                "connector": "openclaw",
+            },
+            {
+                "name": "another-skill",
+                "type": "skill",
+                "source_url": "clawhub://another-skill",
+            },
+        ],
+    }))
+
+
+def _fresh_mcp_manifest():
+    return parse_manifest(json.dumps({
+        "schema_version": 1,
+        "entries": [
+            {
+                "name": "demo-mcp",
+                "type": "mcp",
+                "transport": "stdio",
+                "command": "npx",
+                "args": ["-y", "@scope/server"],
+            }
+        ],
+    }))
+
+
+def _patch_fetch(monkeypatch, manifest):
+    """Inject a stub fetch_manifest that returns *manifest* every time."""
+    raw = json.dumps(manifest.to_dict()).encode("utf-8")
+
+    def _stub(_source, *, allow_private=False):
+        return manifest, raw
+
+    monkeypatch.setattr(
+        "defenseclaw.registries.sync.fetch_manifest",
+        _stub,
+    )
+
+
+class SyncTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix="dclaw-reg-test-")
+        self.cfg = make_temp_config(self.tmp_dir)
+        self.source = RegistrySource(
+            id="demo",
+            kind="http_yaml",
+            url="https://catalog.example.com/m.yaml",
+            content="both",
+            enabled=True,
+        )
+        self.cfg.registries.sources.append(self.source)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def stub_fetch(self, manifest):
+        raw = json.dumps(manifest.to_dict()).encode("utf-8")
+        patcher = patch(
+            "defenseclaw.registries.sync.fetch_manifest",
+            lambda source, *, allow_private=False: (manifest, raw),
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+
+class TestPromotion(SyncTestBase):
+    def test_clean_skill_promoted_to_asset_policy(self):
+        self.stub_fetch(_fresh_skill_manifest())
+        report = sync_source(
+            self.cfg, self.cfg.data_dir, self.source,
+            scan_callback=None,
+            auto_promote=True,
+            save=False,
+        )
+        # No scanner attached → entries stay pending → not promoted.
+        self.assertEqual(report.promoted_skills, 0)
+
+    def test_clean_scan_result_drives_promotion(self):
+        manifest = _fresh_skill_manifest()
+        self.stub_fetch(manifest)
+
+        def _scan(_src, entry):
+            return _scan_result(entry.name)
+
+        report = sync_source(
+            self.cfg, self.cfg.data_dir, self.source,
+            scan_callback=_scan,
+            auto_promote=True,
+            save=False,
+        )
+        self.assertEqual(report.promoted_skills, 2)
+        self.assertEqual(report.scanned, 2)
+        self.assertEqual(report.blocked, 0)
+        self.assertEqual(
+            {r.name for r in self.cfg.asset_policy.skill.registry},
+            {"demo-skill", "another-skill"},
+        )
+        for rule in self.cfg.asset_policy.skill.registry:
+            self.assertEqual(rule.reason, f"registry:{self.source.id}")
+
+    def test_high_severity_blocks_entry(self):
+        manifest = _fresh_skill_manifest()
+        self.stub_fetch(manifest)
+
+        def _scan(_src, entry):
+            findings = []
+            if entry.name == "demo-skill":
+                findings = [_finding("HIGH", entry.name)]
+            return _scan_result(entry.name, findings)
+
+        report = sync_source(
+            self.cfg, self.cfg.data_dir, self.source,
+            scan_callback=_scan,
+            auto_promote=True,
+            save=False,
+        )
+        # Only the clean entry promoted, the HIGH one blocked.
+        self.assertEqual(report.promoted_skills, 1)
+        self.assertEqual(report.blocked, 1)
+        names = {r.name for r in self.cfg.asset_policy.skill.registry}
+        self.assertEqual(names, {"another-skill"})
+
+    def test_rejected_entry_never_promoted(self):
+        manifest = _fresh_skill_manifest()
+        self.stub_fetch(manifest)
+
+        def _scan(_src, entry):
+            return _scan_result(entry.name)
+
+        # First sync to populate the index, then reject one entry.
+        sync_source(self.cfg, self.cfg.data_dir, self.source,
+                    scan_callback=_scan, auto_promote=False, save=False)
+        manual_set_verdict(
+            self.cfg.data_dir, self.source.id, "skill", "demo-skill",
+            rejected=True,
+        )
+
+        report = sync_source(
+            self.cfg, self.cfg.data_dir, self.source,
+            scan_callback=_scan,
+            auto_promote=True,
+            save=False,
+        )
+        self.assertEqual(report.promoted_skills, 1)
+        names = {r.name for r in self.cfg.asset_policy.skill.registry}
+        self.assertEqual(names, {"another-skill"})
+
+    def test_approved_entry_promoted_without_scanner(self):
+        manifest = _fresh_skill_manifest()
+        self.stub_fetch(manifest)
+
+        # First, baseline sync with no scanner — entries stay pending.
+        sync_source(self.cfg, self.cfg.data_dir, self.source,
+                    scan_callback=None, auto_promote=True, save=False)
+        # Operator manually approves one entry.
+        manual_set_verdict(
+            self.cfg.data_dir, self.source.id, "skill", "demo-skill",
+            approved=True,
+        )
+
+        report = sync_source(
+            self.cfg, self.cfg.data_dir, self.source,
+            scan_callback=None,
+            auto_promote=True,
+            save=False,
+        )
+        self.assertEqual(report.promoted_skills, 1)
+        names = {r.name for r in self.cfg.asset_policy.skill.registry}
+        self.assertEqual(names, {"demo-skill"})
+
+
+class TestPromotionWipeBeforeReplace(SyncTestBase):
+    def test_remove_from_manifest_clears_old_rule(self):
+        manifest_v1 = _fresh_skill_manifest()
+        manifest_v2 = parse_manifest(json.dumps({
+            "schema_version": 1,
+            "entries": [{
+                "name": "another-skill", "type": "skill",
+                "source_url": "clawhub://another-skill",
+            }],
+        }))
+
+        # Switchable stub — drive the same patch through two phases so
+        # we don't have to juggle cleanup callbacks.
+        state = {"manifest": manifest_v1}
+
+        def _stub(_source, *, allow_private=False):
+            m = state["manifest"]
+            return m, json.dumps(m.to_dict()).encode("utf-8")
+
+        with patch("defenseclaw.registries.sync.fetch_manifest", _stub):
+            def _scan(_src, entry):
+                return _scan_result(entry.name)
+
+            sync_source(self.cfg, self.cfg.data_dir, self.source,
+                        scan_callback=_scan, auto_promote=True, save=False)
+            self.assertEqual(len(self.cfg.asset_policy.skill.registry), 2)
+
+            state["manifest"] = manifest_v2
+            sync_source(self.cfg, self.cfg.data_dir, self.source,
+                        scan_callback=_scan, auto_promote=True, save=False)
+            names = {r.name for r in self.cfg.asset_policy.skill.registry}
+            self.assertEqual(names, {"another-skill"})
+
+
+class TestErrorPath(SyncTestBase):
+    def test_fetch_failure_recorded_on_source(self):
+        from defenseclaw.registries.adapters import IngestError
+
+        def _bad_fetch(_source, *, allow_private=False):
+            raise IngestError("boom")
+
+        with patch("defenseclaw.registries.sync.fetch_manifest", _bad_fetch):
+            report = sync_source(
+                self.cfg, self.cfg.data_dir, self.source,
+                scan_callback=None,
+                auto_promote=True,
+                save=False,
+            )
+        self.assertFalse(report.ok())
+        self.assertTrue(report.errors)
+        self.assertIn("error:", self.source.last_status)
+
+
+class TestSyncAll(SyncTestBase):
+    def test_disabled_sources_skipped_by_default(self):
+        self.source.enabled = False
+        manifest = _fresh_skill_manifest()
+        self.stub_fetch(manifest)
+        reports = sync_all(self.cfg, self.cfg.data_dir, scan_callback=None)
+        self.assertEqual(reports, [])
+
+    def test_include_disabled_runs_them(self):
+        self.source.enabled = False
+        manifest = _fresh_skill_manifest()
+        self.stub_fetch(manifest)
+        reports = sync_all(
+            self.cfg, self.cfg.data_dir,
+            scan_callback=None, include_disabled=True,
+        )
+        self.assertEqual(len(reports), 1)
+
+
+class TestCacheIO(unittest.TestCase):
+    def test_save_then_load_round_trip(self):
+        tmp_dir = tempfile.mkdtemp(prefix="dclaw-reg-cache-")
+        try:
+            idx = SourceIndex(
+                source_id="demo",
+                fetched_at="2026-05-07T00:00:00Z",
+                publisher="acme",
+                verdicts=[
+                    EntryVerdict(name="x", type="skill", status="clean"),
+                    EntryVerdict(name="y", type="mcp", status="warning",
+                                 severity="MEDIUM", findings=2),
+                ],
+            )
+            save_index(tmp_dir, "demo", idx)
+            loaded = load_index(tmp_dir, "demo")
+            self.assertEqual(loaded.source_id, "demo")
+            self.assertEqual(loaded.publisher, "acme")
+            self.assertEqual(loaded.entry_count, 2)
+            self.assertEqual(loaded.clean_count, 1)
+            self.assertEqual(loaded.warning_count, 1)
+            self.assertEqual({v.name for v in loaded.verdicts}, {"x", "y"})
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    def test_corrupt_index_returns_empty(self):
+        tmp_dir = tempfile.mkdtemp(prefix="dclaw-reg-cache-")
+        try:
+            d = os.path.join(tmp_dir, "registries", "demo")
+            os.makedirs(d, mode=0o700, exist_ok=True)
+            with open(os.path.join(d, "index.json"), "w") as f:
+                f.write("not json")
+            idx = load_index(tmp_dir, "demo")
+            self.assertEqual(idx.entry_count, 0)
+            self.assertEqual(idx.source_id, "demo")
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    def test_unsafe_source_id_rejected(self):
+        from defenseclaw.registries.cache import source_dir
+
+        with self.assertRaises(ValueError):
+            source_dir(tempfile.gettempdir(), "../escape")
+        with self.assertRaises(ValueError):
+            source_dir(tempfile.gettempdir(), "a/b")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/tests/test_registry_sync.py
+++ b/cli/tests/test_registry_sync.py
@@ -251,6 +251,92 @@ class TestPromotion(SyncTestBase):
         self.assertEqual(names, {"demo-skill"})
 
 
+class TestManualVerdictStatusFlip(SyncTestBase):
+    """``manual_set_verdict`` must flip ``status`` alongside the
+    boolean override so ``registry entries --status blocked`` and
+    the TUI badges reflect the operator's call. The original
+    implementation only touched ``approved`` / ``rejected`` and
+    left ``status="pending"`` after a reject, so the operator had
+    to wait for the next scan run to see the row turn red.
+    """
+
+    def test_reject_flips_status_to_blocked(self):
+        manifest = _fresh_skill_manifest()
+        self.stub_fetch(manifest)
+
+        sync_source(
+            self.cfg, self.cfg.data_dir, self.source,
+            scan_callback=None, auto_promote=False, save=False,
+        )
+
+        verdict = manual_set_verdict(
+            self.cfg.data_dir, self.source.id, "skill", "demo-skill",
+            rejected=True,
+        )
+        self.assertIsNotNone(verdict)
+        self.assertTrue(verdict.rejected)
+        self.assertEqual(verdict.status, "blocked")
+
+        # And it survives a reload from disk.
+        idx = load_index(self.cfg.data_dir, self.source.id)
+        v = idx.find("skill", "demo-skill")
+        self.assertEqual(v.status, "blocked")
+
+    def test_unreject_clears_synthetic_blocked_status(self):
+        # Reject then un-reject. The synthetic ``status="blocked"``
+        # should drop back to ``"pending"`` so a subsequent scan
+        # writes the real verdict instead of inheriting the manual
+        # override.
+        manifest = _fresh_skill_manifest()
+        self.stub_fetch(manifest)
+        sync_source(
+            self.cfg, self.cfg.data_dir, self.source,
+            scan_callback=None, auto_promote=False, save=False,
+        )
+        manual_set_verdict(
+            self.cfg.data_dir, self.source.id, "skill", "demo-skill",
+            rejected=True,
+        )
+        verdict = manual_set_verdict(
+            self.cfg.data_dir, self.source.id, "skill", "demo-skill",
+            rejected=False,
+        )
+        self.assertIsNotNone(verdict)
+        self.assertFalse(verdict.rejected)
+        self.assertEqual(verdict.status, "pending")
+
+    def test_approve_clears_blocked_status(self):
+        # An approve on an entry the scanner had marked blocked
+        # should pull the row out of the ``blocked`` filter so the
+        # operator's intent is reflected immediately. The next
+        # scan run can re-write the verdict if the underlying
+        # finding is still present.
+        manifest = _fresh_skill_manifest()
+        self.stub_fetch(manifest)
+
+        def _scan(_src, entry):
+            findings = []
+            if entry.name == "demo-skill":
+                findings = [_finding("HIGH", entry.name)]
+            return _scan_result(entry.name, findings)
+
+        sync_source(
+            self.cfg, self.cfg.data_dir, self.source,
+            scan_callback=_scan, auto_promote=False, save=False,
+        )
+        idx = load_index(self.cfg.data_dir, self.source.id)
+        self.assertEqual(idx.find("skill", "demo-skill").status, "blocked")
+
+        verdict = manual_set_verdict(
+            self.cfg.data_dir, self.source.id, "skill", "demo-skill",
+            approved=True,
+        )
+        self.assertIsNotNone(verdict)
+        self.assertTrue(verdict.approved)
+        self.assertFalse(verdict.rejected)
+        self.assertEqual(verdict.status, "pending")
+
+
 class TestPromotionWipeBeforeReplace(SyncTestBase):
     def test_remove_from_manifest_clears_old_rule(self):
         manifest_v1 = _fresh_skill_manifest()

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -73,16 +73,18 @@ External skill / MCP catalog ingestion. See
 | Command | Description |
 |---------|-------------|
 | `registry add <id>` | Register a new external catalog source (clawhub, smithery, skills_sh, http_yaml, http_json, git, file) |
-| `registry edit <id>` | Update an existing source |
-| `registry list` | List configured registry sources |
+| `registry edit <id>` | Update an existing source (only the flags you pass are changed) |
+| `registry list` | List configured registry sources with cached `total (clean/warning/blocked)` entry counts |
 | `registry show <id>` | Pretty-print one source plus its verdict summary |
 | `registry remove <id>` | Delete a source and its on-disk cache |
+| `registry test <id>` | Dry-run fetch + parse — no cache or asset_policy writes |
 | `registry sync [<id>...] [--all]` | Fetch + scan + auto-promote clean entries into `asset_policy.{skill,mcp}.registry` |
-| `registry entries <id>` | Show cached entries (after sync) |
-| `registry approve <id> <name> --type {skill|mcp}` | Manually approve an entry |
-| `registry reject <id> <name> --type {skill|mcp}` | Manually reject an entry |
+| `registry entries <id> [--approved\|--rejected]` | Show cached entries (after sync); operator-override filters |
+| `registry approve <id> <name> --type {skill\|mcp}` | Manually approve an entry |
+| `registry reject <id> <name> --type {skill\|mcp}` | Manually reject an entry (sets status to `blocked`) |
 | `registry require --type <t> --enabled/--disabled` | Toggle `asset_policy.<t>.registry_required` |
 | `registry wizard` | Interactive add+sync convenience flow |
+| `setup registry` | Wrapper for `registry wizard` so it shows up in `setup --help` |
 
 All `registry` subcommands accept `--non-interactive` (skip prompts;
 required flags must be present) and `--json` (stable machine-readable

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -65,6 +65,29 @@ Use `<binary> --help` for any command.
 | `plugin install <name-or-path>` | Install a plugin from a local path |
 | `plugin remove <name>` | Remove an installed plugin |
 
+### registry
+
+External skill / MCP catalog ingestion. See
+[`docs/REGISTRIES.md`](./REGISTRIES.md) for the full pipeline.
+
+| Command | Description |
+|---------|-------------|
+| `registry add <id>` | Register a new external catalog source (clawhub, smithery, skills_sh, http_yaml, http_json, git, file) |
+| `registry edit <id>` | Update an existing source |
+| `registry list` | List configured registry sources |
+| `registry show <id>` | Pretty-print one source plus its verdict summary |
+| `registry remove <id>` | Delete a source and its on-disk cache |
+| `registry sync [<id>...] [--all]` | Fetch + scan + auto-promote clean entries into `asset_policy.{skill,mcp}.registry` |
+| `registry entries <id>` | Show cached entries (after sync) |
+| `registry approve <id> <name> --type {skill|mcp}` | Manually approve an entry |
+| `registry reject <id> <name> --type {skill|mcp}` | Manually reject an entry |
+| `registry require --type <t> --enabled/--disabled` | Toggle `asset_policy.<t>.registry_required` |
+| `registry wizard` | Interactive add+sync convenience flow |
+
+All `registry` subcommands accept `--non-interactive` (skip prompts;
+required flags must be present) and `--json` (stable machine-readable
+output) so they're safe to call from the TUI and CI/CD pipelines.
+
 ### tool
 
 | Command | Description |

--- a/docs/CONFIG_FILES.md
+++ b/docs/CONFIG_FILES.md
@@ -428,8 +428,25 @@ defenseclaw setup notifications status
 defenseclaw setup notifications on --restart
 ```
 
-Per-category, per-source, and throttle fields are not exposed as
-flags; flip them in `config.yaml` and restart the gateway.
+Per-category and per-source fields are exposed via
+`defenseclaw setup notifications-set <slot> <on|off>` so you can
+silence one surface (e.g. asset-policy blocks) without flipping the
+master switch:
+
+```bash
+# Categories
+defenseclaw setup notifications-set block_enforced off
+defenseclaw setup notifications-set block_would_block on
+defenseclaw setup notifications-set hitl_approval on
+
+# Sources (dotted form or short alias)
+defenseclaw setup notifications-set sources.hook off
+defenseclaw setup notifications-set guardrail off
+defenseclaw setup notifications-set asset_policy off
+```
+
+Throttle fields (`dedup_window`, `max_per_minute`) remain config-only
+— flip them in `config.yaml` and restart the gateway.
 
 ### YAML
 

--- a/docs/CONFIG_FILES.md
+++ b/docs/CONFIG_FILES.md
@@ -62,6 +62,59 @@ active rule-pack directory. This is separate from `defenseclaw policy activate`
 and controls which `judge/*.yaml`, `sensitive_tools.yaml`, and
 `suppressions.yaml` files the sidecar loads.
 
+The `registries:` block holds external skill / MCP catalog sources
+managed by `defenseclaw registry add` / `edit` / `remove`. Each entry
+mirrors `internal/config/registries.go::RegistrySource` and
+`cli/defenseclaw/config.py::RegistrySource`. See
+[`docs/REGISTRIES.md`](./REGISTRIES.md) for the full pipeline.
+
+```yaml
+registries:
+  sources:
+    - id: corp-skills
+      kind: http_yaml         # clawhub | smithery | skills_sh | http_yaml | http_json | git | file
+      url: https://catalog.example.com/skills.yaml
+      content: skill          # skill | mcp | both
+      auth_env: DEFENSECLAW_REGISTRY_TOKEN  # NAME of env var holding the token
+      enabled: true
+      # auto_sync / sync_interval_hours are RESERVED for v2.
+      # No scheduler reads them today — run `defenseclaw registry
+      # sync --all` (or wire it into cron / systemd-timer) for now.
+      auto_sync: false
+      sync_interval_hours: 24
+    - id: skills-sh-public
+      kind: skills_sh         # https://skills.sh public catalog
+      url: ""                 # empty == curated/official view; or 'all-time' / 'trending' / 'hot'
+      content: skill
+      enabled: true
+```
+
+Sync runs persist verdicts to
+`~/.defenseclaw/registries/<id>/index.json` and auto-promote clean
+entries into `asset_policy.{skill,mcp}.registry` with
+`Reason="registry:<id>"` so admission can attribute the rule back to
+its source.
+
+> **Note on `auto_sync`** — This field is persisted but **not yet
+> honoured at runtime**. There is no in-process scheduler that
+> periodically calls `registry sync` today; setting `auto_sync: true`
+> only preserves the bit for a future release. Until then, schedule
+> `defenseclaw registry sync --all` from cron / a systemd timer / your
+> CI loop.
+
+---
+
+### `~/.defenseclaw/registries/<source-id>/`
+
+Per-registry on-disk cache, populated by `defenseclaw registry sync`:
+
+| File | Purpose |
+|------|---------|
+| `index.json` | Per-entry verdicts (status, severity, approved/rejected). Read by the Python CLI's `registry entries` / `registry show` and by the TUI's Registries panel. |
+| `manifest.yaml` | Raw fetched manifest bytes, kept for forensic inspection (diff what the publisher served vs what made it through the validator). |
+
+Both files are written atomically (temp + rename, mode 0o600).
+
 ---
 
 ### `~/.defenseclaw/policies/guardrail/<profile>/`
@@ -326,3 +379,89 @@ webhooks:
 | **Set by** | `defenseclaw setup webhook` (preferred) or operator via `config.yaml`. |
 | **Read by** | **Go sidecar** at startup via `config.Load()`. **Python CLI** via `config.load()` (round-trips the cooldown tri-state, read-only for display). |
 | **Effect** | When enabled, the `WebhookDispatcher` in `internal/gateway/webhook.go` sends structured JSON payloads to each endpoint when enforcement events (block, drift, guardrail-block, …) occur. Retries up to 3 times with exponential backoff on transient failures (5xx, network errors); 4xx are treated as permanent. |
+
+## Desktop Notifications Config
+
+> **Local-only.** `notifications.*` fires user-session OS toasts
+> (macOS `osascript`, Linux `notify-send`) for blocks and pending HITL
+> approvals. It is **not** an audit sink and **not** a remote
+> notification channel — for chat / incident routing use `webhooks[]`
+> above, and for downstream forwarding see
+> [docs/OBSERVABILITY.md](OBSERVABILITY.md).
+
+The `notifications` block in `config.yaml` controls a single
+in-process dispatcher (`internal/gateway/notifier`) that surfaces a
+desktop toast whenever:
+
+1. A hook (Claude Code, Codex), the guardrail proxy, or asset policy
+   **blocks** a tool call.
+2. The same component **would have blocked** the call but is in
+   observe / would-block mode.
+3. A **Human-in-the-Loop approval** is pending in the chat / TUI
+   (informational only — clicking the notification does not approve
+   anything; the operator still replies in the existing surface).
+
+The dispatcher applies a global token-bucket rate limit, an LRU
+dedup window, and a per-category / per-source filter so it can be
+dialed down without losing every signal.
+
+### CLI
+
+Use `defenseclaw setup notifications` to flip the master switch.
+Defaults are platform-conditional: **on** on darwin (every macOS
+user already has Notification Center running) and **off**
+elsewhere (Linux operators opt in explicitly so a `notify-send`
+that fails on a headless box does not fire on every block):
+
+```bash
+# One-shot Y/n onboarding prompt (defaults to Yes):
+defenseclaw setup notifications
+
+# Direct toggles
+defenseclaw setup notifications on
+defenseclaw setup notifications off --yes
+defenseclaw setup notifications status
+
+# Apply immediately to the running sidecar (the dispatcher is
+# constructed once at boot from notifications.*, so a flip without
+# --restart leaves the previous state in effect for the live process).
+defenseclaw setup notifications on --restart
+```
+
+Per-category, per-source, and throttle fields are not exposed as
+flags; flip them in `config.yaml` and restart the gateway.
+
+### YAML
+
+```yaml
+notifications:
+  enabled: true              # master switch (default: true on darwin, false elsewhere)
+  block_enforced: true       # action-mode block events
+  block_would_block: true    # observe-mode "would have blocked" events
+  hitl_approval: true        # informational toasts for pending approvals
+  sources:
+    hook: true               # claude_code_hook + codex_hook decisions
+    guardrail: true          # GuardrailProxy verdicts
+    asset_policy: true       # asset_policy_runtime decisions
+  dedup_window: 30s          # default 30s; "" / 0s falls back to default
+  max_per_minute: 12         # default 12; 0 falls back to default
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` on darwin, `false` elsewhere | Master switch (see `config.DefaultNotificationsEnabled` / Python `_default_notifications_enabled`). When `false` the dispatcher is short-circuited and no other field has any effect. |
+| `block_enforced` | bool | `true` | Surface a toast for action-mode blocks (`action == "block"`). |
+| `block_would_block` | bool | `true` | Surface a toast for observe-mode would-block events (verdict was a block but the runtime mode degraded it to alert). |
+| `hitl_approval` | bool | `true` | Surface an **informational** toast at the start of `HILTApprovalManager.Request`. The notification has no buttons; the operator replies in chat / TUI as today. |
+| `sources.hook` | bool | `true` | Allow notifications from `evaluateClaudeCodeHook` / `evaluateCodexHook`. |
+| `sources.guardrail` | bool | `true` | Allow notifications from `GuardrailProxy` block / would-block branches. |
+| `sources.asset_policy` | bool | `true` | Allow notifications from `evaluateRuntimeMCPAssetPolicy` / `evaluateRuntimeSkillAssetPolicy`. |
+| `dedup_window` | duration | `30s` | LRU dedup window keyed on `sha256(category|source|target|reason)`. Identical events seen inside the window are suppressed. Empty string or `0s` resolves to the default. |
+| `max_per_minute` | int | `12` | Global token-bucket cap across **all** categories. When exhausted, the dispatcher emits a single roll-up toast per minute (`"DefenseClaw suppressed N notifications"`) and silently drops the rest until the bucket refills. `0` resolves to the default. |
+
+| | |
+|---|---|
+| **Set by** | `defenseclaw setup notifications` (preferred) or operator via `config.yaml`. |
+| **Read by** | **Go sidecar** at startup via `config.Load()` → `notifier.New(cfg.Notifications)` (wired into hooks, proxy, asset runtime, and `HILTApprovalManager`). **Python CLI** via `config.load()` for round-trip preservation; the Python side does not emit notifications itself. |
+| **Effect** | The dispatcher fires `internal/notify.SendNotification` in a goroutine so request latency is unaffected. On macOS this calls `osascript` (`display notification … with title …`); on Linux it calls `notify-send`; on unsupported platforms it falls back to a structured stderr log line. State (dedup LRU + token bucket) is per-process and resets on gateway restart. |
+

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -265,11 +265,33 @@ Test the release artifacts locally using the install script:
 This installs the gateway binary, Python CLI wheel (into
 `~/.defenseclaw/.venv`), and plugin without downloading anything.
 
-### Upload to GitHub Release
+### Cut a GitHub Release
+
+The `Release` GitHub Actions workflow is the only supported way to cut a
+release. It validates the tag, builds and signs all artifacts, and
+creates the GitHub release atomically so Immutable Releases can't strand
+half-built assets.
+
+Preferred — from the Actions UI:
+
+```
+Actions -> Release -> Run workflow -> version: 0.4.0
+```
+
+Or from the CLI by pushing the tag (workflow runs automatically):
 
 ```bash
-gh release create v0.2.0 dist/*
+git tag 0.4.0 && git push origin 0.4.0
 ```
+
+> The tag MUST be bare `X.Y.Z` with no `v` prefix. `scripts/install.sh`,
+> `scripts/upgrade.sh`, and `defenseclaw upgrade` all build URLs of the
+> form `releases/download/X.Y.Z/...`, and the workflow rejects any tag
+> that doesn't match `^[0-9]+\.[0-9]+\.[0-9]+$`.
+
+Do NOT manually `gh release create` — it would create an empty Immutable
+Release that the workflow can't attach assets to (this is what broke the
+0.3.1 release).
 
 ### Clean Dist
 

--- a/docs/REGISTRIES.md
+++ b/docs/REGISTRIES.md
@@ -155,16 +155,18 @@ and CI/CD pipelines call, with `--json` for machine-readable output.
 | Command | Description |
 |---------|-------------|
 | `registry add <id>` | Register a new registry source |
-| `registry edit <id>` | Update an existing source |
-| `registry list` | List configured registry sources |
+| `registry edit <id>` | Update an existing source (only the flags you pass are changed) |
+| `registry list` | List configured registry sources, with cached `total (clean/warning/blocked)` entry counts |
 | `registry show <id>` | Show details + verdict summary for one source |
 | `registry remove <id>` | Delete a source and its on-disk cache |
+| `registry test <id>` | Dry-run fetch + parse — no cache or asset_policy writes |
 | `registry sync [<id>...] [--all]` | Fetch + scan + promote |
-| `registry entries <id>` | Show cached entries (after sync) |
-| `registry approve <id> <name> --type {skill|mcp}` | Mark approved |
-| `registry reject <id> <name> --type {skill|mcp}` | Mark rejected |
+| `registry entries <id> [--approved/--rejected]` | Show cached entries (after sync) |
+| `registry approve <id> <name> --type {skill\|mcp}` | Mark approved |
+| `registry reject <id> <name> --type {skill\|mcp}` | Mark rejected (sets status to `blocked`) |
 | `registry require --type <t> --enabled/--disabled` | Toggle `asset_policy.<t>.registry_required` |
 | `registry wizard` | Interactive add+sync convenience flow |
+| `setup registry` | Discoverable shortcut from `defenseclaw setup` that drops into the wizard |
 
 ### Examples
 
@@ -212,6 +214,15 @@ defenseclaw registry sync --all --json
 > `defenseclaw registry sync --all` from cron / a systemd timer / your
 > existing CI cadence; v1 is intentionally a manual ingest pipeline so
 > the operator stays in the loop on every promotion.
+
+Dry-run a source before the first sync so credentials and the
+manifest's shape are validated without touching `index.json`,
+`manifest.yaml`, or `asset_policy`:
+
+```bash
+defenseclaw registry test corp-skills --json
+defenseclaw registry test corp-skills --show-entries --limit 50
+```
 
 Operator preview (scan + show what would be promoted, without touching
 asset_policy):

--- a/docs/REGISTRIES.md
+++ b/docs/REGISTRIES.md
@@ -1,0 +1,342 @@
+# Registries
+
+DefenseClaw operators use **registries** to bring an external catalog
+of skills and MCP servers under admission control without paving over
+their existing vendor relationships. A registry is a fetchable
+manifest — corporate HTTPS YAML, smithery.ai, a git repo, ClawHub —
+that DefenseClaw ingests, scans, and (when clean) auto-promotes into
+`asset_policy.{skill,mcp}.registry` so the gateway treats every
+matching asset as an approved entry.
+
+This page covers the v1 surface: skills and MCPs only. Plugins follow
+the same pattern but are scaffolded behind the existing
+`asset_policy.plugin.*` block until the v2 plugin manifest lands.
+
+---
+
+## Mental model
+
+```
+┌──────────────────┐   fetch + size cap   ┌──────────────────┐
+│ external catalog │ ───────────────────► │ DefenseClaw CLI  │
+│ (https / smithery│                      │ registries/      │
+│  / git / file /  │ ◄─── SSRF guard ──── │ adapters         │
+│  clawhub)        │                      └────────┬─────────┘
+└──────────────────┘                               │
+                                                   │ parse + validate
+                                                   ▼
+                                          ┌──────────────────┐
+                                          │ JSON Schema +    │
+                                          │ hand-written     │
+                                          │ invariants       │
+                                          └────────┬─────────┘
+                                                   │
+                       scan via existing skill /   │
+                       mcp scanners (or skipped    │
+                       with --no-scan)             ▼
+                                          ┌──────────────────┐
+                                          │ ~/.defenseclaw/  │
+                                          │ registries/<id>/ │
+                                          │ index.json       │
+                                          └────────┬─────────┘
+                                                   │ promote clean
+                                                   │ entries
+                                                   ▼
+                                          ┌──────────────────┐
+                                          │ asset_policy.    │
+                                          │ {skill,mcp}.     │
+                                          │ registry         │
+                                          │ Reason="registry:│
+                                          │  <id>"           │
+                                          └──────────────────┘
+```
+
+Every promoted rule carries `Reason="registry:<source-id>"`. The
+gateway preserves this on `AssetPolicyDecision.RegistrySource` so
+audit events and the TUI can attribute the rule back to the source
+that promoted it.
+
+---
+
+## Source kinds
+
+| Kind | Description | Required URL? |
+|------|-------------|---------------|
+| `clawhub` | Synthesises a manifest from the npm `openclaw` package metadata | No (defaults to npm) |
+| `smithery` | Public smithery.ai catalog API | No (defaults to `https://registry.smithery.ai`) |
+| `skills_sh` | [skills.sh](https://skills.sh/) public catalog (Vercel-maintained, GitHub-hosted skills) | No (defaults to curated view) |
+| `http_yaml` | Corporate HTTPS YAML manifest | Yes |
+| `http_json` | Corporate HTTPS JSON manifest | Yes |
+| `git` | Git repo containing `defenseclaw-registry.yaml` at root (HTTPS clones only) | Yes |
+| `file` | Local manifest file (air-gapped, regression tests) | Yes (absolute path) |
+
+`http://` is accepted but flagged. `file://`, `ssh://`, `git://` are
+intentionally rejected by the SSRF guard — see the [security
+notes](#security-notes) below.
+
+### skills.sh views
+
+The `skills_sh` adapter accepts an empty URL (defaults to the
+curated/official view), one of the bare keywords below, or a full
+`https://skills.sh?view=...&per_page=...&max=...` URL with caps:
+
+| URL value | Endpoint | Use case |
+|-----------|----------|----------|
+| `` (empty) or `curated` | `/api/v1/skills/curated` | Default. Publisher-vetted official skills only |
+| `all-time` | `/api/v1/skills?view=all-time` | Mirror broad popular usage |
+| `trending` | `/api/v1/skills?view=trending` | Recent-growth feed |
+| `hot` | `/api/v1/skills?view=hot` | Last-hour vs same-hour-yesterday |
+
+Caps: `per_page` 1..500 (default 50), `max` 1..2000 (default 200).
+Entries flagged `isDuplicate=true` by skills.sh are filtered out.
+Auth tokens are read from `auth_env` (env var **name**, never the
+literal token) and sent as `Authorization: Bearer <token>` —
+`mailto:skills-api@vercel.com` to obtain an API key for higher rate
+limits.
+
+---
+
+## Manifest schema
+
+Manifests are validated against
+[`schemas/registry-manifest.schema.json`](../schemas/registry-manifest.schema.json).
+Sample manifests live in [`bundles/registries/`](../bundles/registries/):
+
+* [`example-skill-catalog.yaml`](../bundles/registries/example-skill-catalog.yaml)
+* [`example-mcp-catalog.yaml`](../bundles/registries/example-mcp-catalog.yaml)
+
+Top-level shape:
+
+```yaml
+schema_version: 1
+publisher: "acme"        # optional
+generated_at: "2026-05-07T00:00:00Z"  # optional
+default_connector: openclaw  # optional fallback
+entries:
+  - name: my-skill
+    type: skill
+    source_url: clawhub://my-skill
+    sha256: "<64 hex>"   # required for https:// skills, optional for clawhub://
+    connector: openclaw
+  - name: my-mcp
+    type: mcp
+    transport: stdio
+    command: npx
+    args: ["-y", "@scope/server"]
+    env_required: ["MY_API_KEY"]   # NAMES only, never values
+```
+
+Security-relevant invariants enforced by the parser (and by the JSON
+Schema when the optional `jsonschema` package is installed):
+
+* `name` must match `^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$` — keeps the
+  identifier safe to use as a directory name, scanner subprocess
+  argv, audit query.
+* `command` must match `^[A-Za-z0-9_./@-]*$` — refuses shell
+  metacharacters at parse time.
+* `source_url` for skills must start with `clawhub://`, `https://`,
+  or `http://`. `file://` is intentionally NOT accepted in published
+  manifests; operators that want to ingest local catalogs register
+  the source itself with `kind=file`.
+* `env_required` lists ENV VAR **names** (uppercase only) — DefenseClaw
+  never copies tokens through a manifest.
+* Per-field length caps; a hard cap of 10 000 entries per manifest.
+* Manifest payload capped at 8 MiB during fetch.
+
+---
+
+## CLI
+
+All commands sit under `defenseclaw registry`. Every subcommand
+supports both interactive (default) and non-interactive
+(`--non-interactive`) modes; the non-interactive form is what the TUI
+and CI/CD pipelines call, with `--json` for machine-readable output.
+
+| Command | Description |
+|---------|-------------|
+| `registry add <id>` | Register a new registry source |
+| `registry edit <id>` | Update an existing source |
+| `registry list` | List configured registry sources |
+| `registry show <id>` | Show details + verdict summary for one source |
+| `registry remove <id>` | Delete a source and its on-disk cache |
+| `registry sync [<id>...] [--all]` | Fetch + scan + promote |
+| `registry entries <id>` | Show cached entries (after sync) |
+| `registry approve <id> <name> --type {skill|mcp}` | Mark approved |
+| `registry reject <id> <name> --type {skill|mcp}` | Mark rejected |
+| `registry require --type <t> --enabled/--disabled` | Toggle `asset_policy.<t>.registry_required` |
+| `registry wizard` | Interactive add+sync convenience flow |
+
+### Examples
+
+Register a corporate catalog non-interactively:
+
+```bash
+defenseclaw registry add corp-skills \
+    --kind http_yaml \
+    --url https://catalog.example.com/skills.yaml \
+    --content skill \
+    --auth-env DEFENSECLAW_REGISTRY_TOKEN \
+    --non-interactive
+```
+
+Register the skills.sh public catalog (no URL = curated/official view):
+
+```bash
+defenseclaw registry add skills-sh-public \
+    --kind skills_sh \
+    --content skill \
+    --non-interactive
+```
+
+Mirror the trending feed with a higher cap and a custom auth env var:
+
+```bash
+export DEFENSECLAW_SKILLSSH_TOKEN="sk_live_..."
+defenseclaw registry add skills-sh-trending \
+    --kind skills_sh \
+    --url 'https://skills.sh?view=trending&max=500' \
+    --content skill \
+    --auth-env DEFENSECLAW_SKILLSSH_TOKEN \
+    --non-interactive
+```
+
+Sync everything that's enabled (the typical CI/CD pattern):
+
+```bash
+defenseclaw registry sync --all --json
+```
+
+> **No built-in scheduler today.** The `auto_sync` and
+> `sync_interval_hours` fields on `RegistrySource` are persisted for a
+> future release but no runtime component reads them. Run
+> `defenseclaw registry sync --all` from cron / a systemd timer / your
+> existing CI cadence; v1 is intentionally a manual ingest pipeline so
+> the operator stays in the loop on every promotion.
+
+Operator preview (scan + show what would be promoted, without touching
+asset_policy):
+
+```bash
+defenseclaw registry sync corp-skills --no-promote --json
+```
+
+Manually approve an entry that the scanner can't reach (e.g. a
+network-isolated MCP server):
+
+```bash
+defenseclaw registry approve corp-mcps internal-server --type mcp
+```
+
+Tighten admission so only registry-approved skills are allowed:
+
+```bash
+defenseclaw registry require --type skill --enabled
+```
+
+---
+
+## TUI
+
+A new top-level **Registries** panel sits between Tools and Setup.
+Open it with `R` (capital R; tools is `T`, registries is `R`).
+
+The panel has three sub-tabs (`1` / `2` / `3`):
+
+* **Sources** — every configured registry source with last sync,
+  status, kind, content. `s` syncs the highlighted source; `S` syncs
+  all enabled sources; `d` removes; `r` refreshes.
+* **Entries** — the union of cached verdicts from every source.
+  `a` approves, `x` rejects, `s` re-syncs the source the cursor is on.
+* **Approved** — same view filtered to entries the operator has
+  manually approved.
+
+The Skills and MCPs panels both grow an `R` keybind that jumps to the
+Registries panel with the cursor focused on the highlighted entry —
+useful for quickly answering "which registry approved this skill?".
+
+For the first-run flow, the Setup panel includes a **Registries**
+wizard that wraps `defenseclaw registry add --non-interactive` so an
+operator can register a catalog without leaving the TUI.
+
+---
+
+## On-disk layout
+
+```
+~/.defenseclaw/
+└── registries/
+    └── <source-id>/
+        ├── index.json     # SourceIndex — verdicts the TUI / CLI render
+        └── manifest.yaml  # raw fetched payload, kept for forensics
+```
+
+Both files are written atomically (temp + rename, mode 0o600). The
+JSON index is the contract between the Python ingest pipeline and the
+Go TUI panel; the raw manifest is kept for diff-based forensics when a
+publisher's served bytes drift from what the validator accepted.
+
+---
+
+## Security notes
+
+The ingest pipeline is operator-supplied URLs feeding scanner
+subprocesses, so the security guards are layered:
+
+* **SSRF guard.** Every URL is validated by
+  `cli/defenseclaw/registries/ssrf.py::guard_url` before any HTTP call.
+  Loopback, link-local, multicast, RFC1918, and ULA addresses are
+  blocked by default. Operators with on-prem registries pass
+  `--allow-private`.
+* **Schema + invariant check.** Manifests are validated against the
+  JSON Schema (when `jsonschema` is installed) **and** by a
+  hand-written validator that enforces the same name / command /
+  scheme / length / size invariants. The hand-written path is the
+  source of truth so the security guards stay on even in
+  reduced-deps installs.
+* **Auth tokens.** `auth_env` accepts an env var **name**, never a
+  literal token. The CLI's `_validate_auth_env` rejects anything that
+  looks like a value.
+* **Manifest size cap.** Fetches are streamed and aborted at 8 MiB to
+  prevent zip-bomb-style payloads.
+* **Subprocess isolation.** The git adapter shells out via
+  `subprocess.run` with `shell=False` and a fixed argv; the manifest
+  schema's `command` regex blocks shell metacharacters at parse time
+  so a poisoned manifest can't smuggle them through.
+* **Atomic writes.** `index.json` and `manifest.yaml` are written via
+  temp + rename so a concurrent `registry list` never sees a
+  half-written file.
+* **Operator overrides win.** A `rejected` verdict is never promoted,
+  even when the scanner reports clean; an `approved` verdict is
+  always promoted, even when the scanner hasn't run.
+
+The matched rule's `Reason="registry:<id>"` is preserved through
+admission as `AssetPolicyDecision.RegistrySource` so audit events and
+TUI badges can attribute the decision back to its source.
+
+---
+
+## Migration / back-compat
+
+* Configs without a `registries:` block load with an empty source
+  list — no migration step required.
+* Removing a source deletes only that source's promoted rules
+  (matched by `Reason="registry:<id>"`); rules from other sources or
+  hand-written rules are preserved.
+* Re-syncing a source first wipes its previous promoted rules, then
+  re-emits them in lockstep with the current manifest. Removing an
+  entry from a manifest cleanly removes its promoted rule on the next
+  sync.
+
+---
+
+## Related docs
+
+* [`docs/CLI.md`](./CLI.md) — CLI command index, including
+  `defenseclaw registry`.
+* [`docs/TUI.md`](./TUI.md) — TUI panels, including the Registries
+  panel and Setup wizard.
+* [`docs/CONFIG_FILES.md`](./CONFIG_FILES.md) — `registries:` and
+  `asset_policy:` schema.
+* [`schemas/registry-manifest.schema.json`](../schemas/registry-manifest.schema.json)
+  — manifest JSON Schema.
+* [`bundles/registries/`](../bundles/registries/) — sample manifests.

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -44,7 +44,8 @@ Panels are addressable by number (1–9, 0 for Setup) and by `Tab` /
 | 9 | Audit | `audit.go` | Append-only audit store. Every block/allow/scan/config-change is here. |
 | - | Activity | `activity.go` | Live tail of TUI-launched commands (output stream, exit codes). |
 | - | Tools | `tools.go` | Tool block/allow/unblock surface. |
-| 0 | Setup | `setup.go` | All editable config — scanner endpoints, gateway watcher/watchdog, OTel signals, observability sinks, webhooks, guardrail tuning, OpenShell sandbox. |
+| - | Registries | `registries.go` | External skill / MCP catalog sources (corporate HTTPS YAML, smithery.ai, git, ClawHub, file). Sources / Entries / Approved sub-tabs (`1` / `2` / `3`). `s` syncs a single source, `S` syncs all enabled, `a` / `x` approve / reject. Reachable via `R`. See [`docs/REGISTRIES.md`](./REGISTRIES.md). |
+| 0 | Setup | `setup.go` | All editable config — scanner endpoints, gateway watcher/watchdog, OTel signals, observability sinks, webhooks, guardrail tuning, OpenShell sandbox. The Registries wizard wraps `defenseclaw registry add --non-interactive` for first-run discovery. |
 
 ---
 
@@ -53,6 +54,8 @@ Panels are addressable by number (1–9, 0 for Setup) and by `Tab` /
 | Key | Action |
 |-----|--------|
 | `1`–`9`, `0` | Jump to panel by number |
+| `T` | Jump to Tools panel |
+| `R` | Jump to Registries panel (Skills / MCPs panels: jumps with cursor focused on the highlighted entry) |
 | `Tab` / `Shift+Tab` | Cycle panels forward / back |
 | `:` or `Ctrl+K` | Open command palette (any registry entry) |
 | `/` | Filter the active list |

--- a/extensions/defenseclaw/package.json
+++ b/extensions/defenseclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "defenseclaw",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "OpenClaw plugin for DefenseClaw — scan skills/plugins/MCPs, enforce policy, monitor runtime",
   "type": "module",
   "main": "dist/index.js",

--- a/internal/cli/watchdog_metrics_test.go
+++ b/internal/cli/watchdog_metrics_test.go
@@ -35,6 +35,21 @@ import (
 // defenseclaw.watcher.restarts so operators can alert on flapping sidecars
 // without scraping stderr. Before this fix the counter was defined but never
 // incremented; this test fails if the wiring regresses.
+//
+// The previous version of this test wall-clocked the flip from "unhealthy"
+// to "healthy" 40ms after the loop started and gave the loop only 200ms to
+// observe both transitions. On a loaded test runner the first probe can
+// take 30+ms (DNS + httptest server warm-up + Go's TLS-less HTTP machinery),
+// which compressed the post-flip observation window below the
+// debounce-then-recover requirement and produced an ~5% flake rate. The
+// rewrite below removes the wall-clock dependency entirely:
+//
+//   - Probe count, not elapsed time, drives the flip — once the loop has
+//     done at least `debounce` failed probes (so it is definitely in
+//     stateDown), the test marks the server healthy and waits for the
+//     recovery counter to land via a polling assertion.
+//   - The deadline is 5s purely as an upper bound for "the build server
+//     is wedged"; a healthy run completes in tens of milliseconds.
 func TestWatchdogRecordsWatcherRestart(t *testing.T) {
 	t.Setenv("DEFENSECLAW_HOME", t.TempDir())
 
@@ -45,12 +60,16 @@ func TestWatchdogRecordsWatcherRestart(t *testing.T) {
 	}
 	defer func() { _ = prov.Shutdown(context.Background()) }()
 
-	var healthy atomic.Bool
-	// Start UNhealthy. Loop will debounce into stateDown, then flip to healthy
-	// so we cross the recovery edge exactly once.
+	var (
+		healthy atomic.Bool
+		probes  atomic.Int64
+	)
+	// Start UNhealthy. Loop will debounce into stateDown, then we flip to
+	// healthy so it crosses the recovery edge exactly once.
 	healthy.Store(false)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		probes.Add(1)
 		if healthy.Load() {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
@@ -61,25 +80,54 @@ func TestWatchdogRecordsWatcherRestart(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// Flip to healthy mid-loop so the watchdog sees the transition.
+	// Drive the flip off the actual probe count, not a sleep. We need at
+	// least `debounce` (=2) failed probes before the loop is allowed to
+	// move into stateDown, plus one more so we are certain the down edge
+	// has been observed by the watchdog before we flip the server
+	// healthy. After that, the very next probe should see stateHealthy
+	// and increment the restart counter.
+	const debounce = 2
 	go func() {
-		time.Sleep(40 * time.Millisecond)
-		healthy.Store(true)
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if probes.Load() >= debounce+1 {
+				healthy.Store(true)
+				return
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	runWatchdogLoop(ctx, srv.URL+"/health", 10*time.Millisecond, 2, nil, prov)
+	loopDone := make(chan struct{})
+	go func() {
+		runWatchdogLoop(ctx, srv.URL+"/health", 10*time.Millisecond, debounce, nil, prov)
+		close(loopDone)
+	}()
 
-	var rm metricdata.ResourceMetrics
-	if err := reader.Collect(context.Background(), &rm); err != nil {
-		t.Fatalf("Collect: %v", err)
-	}
-
-	got := counterValue(t, rm, "defenseclaw.watcher.restarts")
-	if got < 1 {
-		t.Fatalf("expected defenseclaw.watcher.restarts ≥ 1 after recovery, got %d", got)
+	// Poll the counter rather than wait for runWatchdogLoop to return —
+	// the loop only exits on ctx cancellation, but our assertion needs
+	// just one observed recovery.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		var rm metricdata.ResourceMetrics
+		if err := reader.Collect(context.Background(), &rm); err != nil {
+			t.Fatalf("Collect: %v", err)
+		}
+		if got := counterValue(t, rm, "defenseclaw.watcher.restarts"); got >= 1 {
+			cancel()
+			<-loopDone
+			return
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			<-loopDone
+			t.Fatalf("expected defenseclaw.watcher.restarts ≥ 1 after recovery, got 0 "+
+				"(probes=%d, healthy=%v)", probes.Load(), healthy.Load())
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }
 

--- a/internal/config/asset_policy.go
+++ b/internal/config/asset_policy.go
@@ -33,13 +33,26 @@ type AssetPolicyConfig struct {
 }
 
 type AssetTypePolicy struct {
-	Default          string                `mapstructure:"default"           yaml:"default"`
-	RegistryRequired bool                  `mapstructure:"registry_required" yaml:"registry_required"`
-	Registry         []AssetPolicyRule     `mapstructure:"registry"          yaml:"registry"`
-	Allowed          []AssetPolicyRule     `mapstructure:"allowed"           yaml:"allowed"`
-	Denied           []AssetPolicyRule     `mapstructure:"denied"            yaml:"denied"`
-	RuntimeDetection AssetRuntimeDetection `mapstructure:"runtime_detection" yaml:"runtime_detection,omitempty"`
+	Default          string `mapstructure:"default"           yaml:"default"`
+	RegistryRequired bool   `mapstructure:"registry_required" yaml:"registry_required"`
+	// RegistryEmptyAction selects the failure mode when RegistryRequired is
+	// true but Registry is empty (e.g., the operator hasn't populated the
+	// allowlist yet, or YAML parse silently produced zero rules). It is
+	// deliberately fail-closed by default ("deny") so that an empty
+	// registry behaves like "no asset is approved" rather than silently
+	// disabling the requirement. Set to "allow" to opt into the looser
+	// behavior of falling through to Default when the registry is empty.
+	RegistryEmptyAction string                `mapstructure:"registry_empty_action" yaml:"registry_empty_action,omitempty"`
+	Registry            []AssetPolicyRule     `mapstructure:"registry"              yaml:"registry"`
+	Allowed             []AssetPolicyRule     `mapstructure:"allowed"               yaml:"allowed"`
+	Denied              []AssetPolicyRule     `mapstructure:"denied"                yaml:"denied"`
+	RuntimeDetection    AssetRuntimeDetection `mapstructure:"runtime_detection"     yaml:"runtime_detection,omitempty"`
 }
+
+const (
+	registryEmptyActionDeny  = "deny"
+	registryEmptyActionAllow = "allow"
+)
 
 type AssetRuntimeDetection struct {
 	Enabled            bool   `mapstructure:"enabled"              yaml:"enabled"`
@@ -74,16 +87,26 @@ type AssetPolicyInput struct {
 }
 
 type AssetPolicyDecision struct {
-	Enabled        bool
-	Mode           string
-	Action         string // allow | block
-	RawAction      string // allow | block
-	WouldBlock     bool
-	Reason         string
-	Source         string
-	RegistryStatus string // registered | unregistered | unknown
+	Enabled            bool
+	Mode               string
+	Action             string // allow | block
+	RawAction          string // allow | block
+	WouldBlock         bool
+	Reason             string
+	Source             string
+	RegistryStatus     string // registered | unregistered | unknown
+	RegistryConfigured bool
+	// RegistrySource is the id of the registry source that promoted
+	// the matched rule (read from AssetPolicyRule.Reason when it's
+	// "registry:<id>"). Empty when the matched rule was added by
+	// an operator directly. Surfaced in audit events and the TUI's
+	// "approved-by: registry:<id>" badge so cross-links can
+	// attribute the promotion back to its source.
+	RegistrySource string
 	TargetType     string
 	TargetName     string
+	Connector      string
+	RuntimeSurface string
 }
 
 func DefaultAssetPolicy() AssetPolicyConfig {
@@ -123,6 +146,8 @@ func (c *Config) EvaluateAssetPolicy(in AssetPolicyInput) AssetPolicyDecision {
 		RegistryStatus: "unknown",
 		TargetType:     targetType,
 		TargetName:     name,
+		Connector:      strings.TrimSpace(in.Connector),
+		RuntimeSurface: strings.TrimSpace(in.RuntimeSurface),
 	}
 	if c == nil || !c.AssetPolicy.Enabled {
 		return out
@@ -136,9 +161,11 @@ func (c *Config) EvaluateAssetPolicy(in AssetPolicyInput) AssetPolicyDecision {
 	}
 
 	mode := normalizeAssetMode(c.AssetPolicy.Mode)
+	registryConfigured := assetRegistryConfigured(p.Registry)
 	out.Enabled = true
 	out.Mode = mode
 	out.Source = "asset-policy"
+	out.RegistryConfigured = registryConfigured
 
 	if rule, ok := findAssetRule(p.Denied, in); ok {
 		return assetPolicyViolation(out, mode, ruleReason(rule, fmt.Sprintf("%s %q is denied by asset policy", targetType, name)), "admin-deny")
@@ -155,11 +182,26 @@ func (c *Config) EvaluateAssetPolicy(in AssetPolicyInput) AssetPolicyDecision {
 	if regStatus == "registered" {
 		out.Source = "registry"
 		out.Reason = fmt.Sprintf("%s %q is registered", targetType, name)
+		// Surface the registry source id (parsed out of the matched
+		// rule's Reason="registry:<id>") so the gateway audit event
+		// and the TUI cross-link badge can point operators back to
+		// the source that promoted the asset.
+		if rule, ok := findAssetRule(p.Registry, in); ok {
+			out.RegistrySource = ParseRegistrySourceID(rule.Reason)
+		}
 		return out
 	}
 
 	if p.RegistryRequired {
-		return assetPolicyViolation(out, mode, fmt.Sprintf("%s %q is not in the approved registry", targetType, name), "registry-required")
+		if registryConfigured {
+			return assetPolicyViolation(out, mode, fmt.Sprintf("%s %q is not in the approved registry", targetType, name), "registry-required")
+		}
+		// Registry is required but empty. Fail closed by default so that
+		// the absence of approved assets does not silently downgrade to
+		// allow-all. Operators can opt out via registry_empty_action="allow".
+		if normalizeRegistryEmptyAction(p.RegistryEmptyAction) == registryEmptyActionDeny {
+			return assetPolicyViolation(out, mode, fmt.Sprintf("%s %q is blocked because asset policy requires a registry but none is configured", targetType, name), "registry-required-empty")
+		}
 	}
 	if normalizeAssetDefault(p.Default) == "deny" {
 		return assetPolicyViolation(out, mode, fmt.Sprintf("%s %q is denied by default asset policy", targetType, name), "default-deny")
@@ -168,6 +210,10 @@ func (c *Config) EvaluateAssetPolicy(in AssetPolicyInput) AssetPolicyDecision {
 	out.Source = "default-allow"
 	out.Reason = fmt.Sprintf("%s %q allowed by default asset policy", targetType, name)
 	return out
+}
+
+func assetRegistryConfigured(rules []AssetPolicyRule) bool {
+	return len(rules) > 0
 }
 
 func (c *Config) assetPolicyFor(targetType string) (AssetTypePolicy, bool) {
@@ -335,6 +381,22 @@ func normalizeAssetDefault(value string) string {
 	}
 }
 
+// normalizeRegistryEmptyAction returns the configured action when
+// RegistryRequired is true and the registry is empty. Default is "deny"
+// (fail-closed): an unconfigured allowlist is treated as "no asset is
+// approved" rather than silently relaxing the requirement. Operators
+// must explicitly opt into "allow" to get fall-through-to-default.
+func normalizeRegistryEmptyAction(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "allow":
+		return registryEmptyActionAllow
+	case "deny", "block", "":
+		return registryEmptyActionDeny
+	default:
+		return registryEmptyActionDeny
+	}
+}
+
 func normalizeAssetToken(value string) string {
 	return strings.ToLower(strings.TrimSpace(value))
 }
@@ -344,4 +406,23 @@ func coalesceString(v, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// ParseRegistrySourceID extracts the source id from a rule reason of
+// the form "registry:<id>". Returns "" for any other shape (e.g. an
+// operator-authored rule with a free-form Reason).
+//
+// The convention is owned by cli/defenseclaw/registries/sync.py —
+// keep the prefix and validation in lockstep with both sides.
+//
+// Exported so the TUI ([internal/tui]) can rebuild "name -> source"
+// attribution maps from the same Reason format the audit + admission
+// paths emit.
+func ParseRegistrySourceID(reason string) string {
+	const prefix = "registry:"
+	r := strings.TrimSpace(reason)
+	if !strings.HasPrefix(r, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(r[len(prefix):])
 }

--- a/internal/config/asset_policy_test.go
+++ b/internal/config/asset_policy_test.go
@@ -111,6 +111,140 @@ func TestEvaluateAssetPolicyRegistryRequiredBlocksUnknown(t *testing.T) {
 	if decision.RegistryStatus != "unregistered" {
 		t.Fatalf("registry_status=%q, want unregistered", decision.RegistryStatus)
 	}
+	if !decision.RegistryConfigured {
+		t.Fatal("RegistryConfigured = false, want true")
+	}
+}
+
+// TestEvaluateAssetPolicyRegistryRequiredEmptyDeniesByDefault pins the
+// safer fail-closed semantics for registry_required. When an operator
+// declares the registry is required but has not (yet) populated it,
+// the default behavior is to block all unregistered assets rather
+// than silently downgrade to the type policy's Default. Operators must
+// explicitly opt into the looser behavior via registry_empty_action.
+func TestEvaluateAssetPolicyRegistryRequiredEmptyDeniesByDefault(t *testing.T) {
+	cfg := &Config{AssetPolicy: DefaultAssetPolicy()}
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = AssetPolicyModeAction
+	cfg.AssetPolicy.MCP.RegistryRequired = true
+	// Default is "allow", and yet the empty-registry guard must still
+	// block — that is the whole point of the fail-closed default.
+
+	decision := cfg.EvaluateAssetPolicy(AssetPolicyInput{
+		TargetType: "mcp",
+		Name:       "rogue",
+	})
+
+	if decision.Action != "block" || decision.RawAction != "block" {
+		t.Fatalf("decision action=%q raw=%q, want block/block", decision.Action, decision.RawAction)
+	}
+	if decision.Source != "registry-required-empty" {
+		t.Fatalf("source=%q, want registry-required-empty", decision.Source)
+	}
+	if decision.RegistryConfigured {
+		t.Fatal("RegistryConfigured = true, want false")
+	}
+}
+
+func TestEvaluateAssetPolicyRegistryRequiredEmptyAllowOptIn(t *testing.T) {
+	cfg := &Config{AssetPolicy: DefaultAssetPolicy()}
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = AssetPolicyModeAction
+	cfg.AssetPolicy.MCP.RegistryRequired = true
+	cfg.AssetPolicy.MCP.RegistryEmptyAction = "allow"
+
+	decision := cfg.EvaluateAssetPolicy(AssetPolicyInput{
+		TargetType: "mcp",
+		Name:       "rogue",
+	})
+
+	if decision.Action != "allow" || decision.RawAction != "allow" {
+		t.Fatalf("decision action=%q raw=%q, want allow/allow", decision.Action, decision.RawAction)
+	}
+	if decision.Source != "default-allow" {
+		t.Fatalf("source=%q, want default-allow", decision.Source)
+	}
+	if decision.RegistryStatus != "unknown" {
+		t.Fatalf("registry_status=%q, want unknown", decision.RegistryStatus)
+	}
+	if decision.RegistryConfigured {
+		t.Fatal("RegistryConfigured = true, want false")
+	}
+}
+
+// TestEvaluateAssetPolicyRegistryRequiredEmptyAllowOptInRespectsDefaultDeny
+// proves the opt-in only relaxes the empty-registry guard — the
+// type policy's Default still applies. Without the opt-in this test
+// would block at the registry-required-empty step; with it, evaluation
+// continues and Default=deny is what produces the block.
+func TestEvaluateAssetPolicyRegistryRequiredEmptyAllowOptInRespectsDefaultDeny(t *testing.T) {
+	cfg := &Config{AssetPolicy: DefaultAssetPolicy()}
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = AssetPolicyModeAction
+	cfg.AssetPolicy.Skill.RegistryRequired = true
+	cfg.AssetPolicy.Skill.RegistryEmptyAction = "allow"
+	cfg.AssetPolicy.Skill.Default = "deny"
+
+	decision := cfg.EvaluateAssetPolicy(AssetPolicyInput{
+		TargetType: "skill",
+		Name:       "rogue-skill",
+	})
+
+	if decision.Action != "block" || decision.RawAction != "block" {
+		t.Fatalf("decision action=%q raw=%q, want block/block", decision.Action, decision.RawAction)
+	}
+	if decision.Source != "default-deny" {
+		t.Fatalf("source=%q, want default-deny", decision.Source)
+	}
+	if decision.RegistryConfigured {
+		t.Fatal("RegistryConfigured = true, want false")
+	}
+}
+
+// TestEvaluateAssetPolicyRegistryRequiredEmptyMCPDefaultDenyFallsThroughToEmptyGuard
+// is the MCP-side companion to the Skill test above for the default
+// (no opt-in) case. With registry_required=true + Default=deny + empty
+// registry + no opt-in, the empty-registry guard must fire first and
+// expose source=registry-required-empty in telemetry — operators
+// debugging "why is everything blocked?" need this signal to identify
+// that the registry itself is the missing piece.
+func TestEvaluateAssetPolicyRegistryRequiredEmptyMCPDefaultDenyFallsThroughToEmptyGuard(t *testing.T) {
+	cfg := &Config{AssetPolicy: DefaultAssetPolicy()}
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = AssetPolicyModeAction
+	cfg.AssetPolicy.MCP.RegistryRequired = true
+	cfg.AssetPolicy.MCP.Default = "deny"
+
+	decision := cfg.EvaluateAssetPolicy(AssetPolicyInput{
+		TargetType: "mcp",
+		Name:       "rogue",
+	})
+
+	if decision.Action != "block" || decision.RawAction != "block" {
+		t.Fatalf("decision action=%q raw=%q, want block/block", decision.Action, decision.RawAction)
+	}
+	if decision.Source != "registry-required-empty" {
+		t.Fatalf("source=%q, want registry-required-empty (the empty-registry guard takes precedence over default-deny so operators can distinguish the two failure modes)", decision.Source)
+	}
+}
+
+func TestNormalizeRegistryEmptyActionDefaultsToDeny(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{"", registryEmptyActionDeny},
+		{"deny", registryEmptyActionDeny},
+		{"DENY", registryEmptyActionDeny},
+		{"block", registryEmptyActionDeny},
+		{"allow", registryEmptyActionAllow},
+		{"ALLOW", registryEmptyActionAllow},
+		{"unsupported-value", registryEmptyActionDeny},
+	} {
+		if got := normalizeRegistryEmptyAction(tc.input); got != tc.want {
+			t.Errorf("normalizeRegistryEmptyAction(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
 }
 
 func TestEvaluateAssetPolicyRegistryMatchAllows(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -179,6 +179,7 @@ type Config struct {
 	MCPActions      MCPActionsConfig           `mapstructure:"mcp_actions"      yaml:"mcp_actions"`
 	PluginActions   PluginActionsConfig        `mapstructure:"plugin_actions"   yaml:"plugin_actions"`
 	AssetPolicy     AssetPolicyConfig          `mapstructure:"asset_policy"     yaml:"asset_policy"`
+	Registries      RegistriesConfig           `mapstructure:"registries"       yaml:"registries,omitempty"`
 	OTel            OTelConfig                 `mapstructure:"otel"             yaml:"otel"`
 	ClaudeCode      AgentHookConfig            `mapstructure:"claude_code"      yaml:"claude_code,omitempty"`
 	Codex           AgentHookConfig            `mapstructure:"codex"            yaml:"codex,omitempty"`
@@ -187,9 +188,10 @@ type Config struct {
 	// It supports an arbitrary number of named sinks of any registered
 	// kind (splunk_hec, otlp_logs, http_jsonl). Legacy `splunk:` keys are
 	// detected at Load() and emit a hard migration error.
-	AuditSinks []AuditSink     `mapstructure:"audit_sinks"      yaml:"audit_sinks,omitempty"`
-	Webhooks   []WebhookConfig `mapstructure:"webhooks"         yaml:"webhooks"`
-	Privacy    PrivacyConfig   `mapstructure:"privacy"          yaml:"privacy,omitempty"`
+	AuditSinks    []AuditSink         `mapstructure:"audit_sinks"      yaml:"audit_sinks,omitempty"`
+	Webhooks      []WebhookConfig     `mapstructure:"webhooks"         yaml:"webhooks"`
+	Privacy       PrivacyConfig       `mapstructure:"privacy"          yaml:"privacy,omitempty"`
+	Notifications NotificationsConfig `mapstructure:"notifications"    yaml:"notifications,omitempty"`
 }
 
 // PrivacyConfig groups privacy/redaction toggles. Today it carries
@@ -1447,6 +1449,39 @@ func Load() (*Config, error) {
 		}
 		return nil, err
 	}
+
+	// Validate registry source kind/content shapes. The Python CLI
+	// is the authoritative writer for ``registries.sources`` (it
+	// drives ``defenseclaw registry add/edit``), but any operator
+	// hand-edit of config.yaml lands in the Go gateway too and a
+	// typo'd ``kind: htttp_yaml`` should fail loud at startup
+	// rather than be silently accepted and bypass admission. We
+	// keep the check additive: empty kind/content is tolerated for
+	// upgrade-in-place from older configs.
+	for i := range cfg.Registries.Sources {
+		src := &cfg.Registries.Sources[i]
+		if src.Kind != "" && !IsKnownRegistryKind(src.Kind) {
+			if ReportConfigLoadError != nil {
+				ReportConfigLoadError(context.Background(), "registry_kind_invalid")
+			}
+			return nil, fmt.Errorf(
+				"config: registries.sources[%d] (id=%q): unknown kind %q "+
+					"(want one of %v)",
+				i, src.ID, src.Kind, KnownRegistryKinds,
+			)
+		}
+		if src.Content != "" && !IsKnownRegistryContent(src.Content) {
+			if ReportConfigLoadError != nil {
+				ReportConfigLoadError(context.Background(), "registry_content_invalid")
+			}
+			return nil, fmt.Errorf(
+				"config: registries.sources[%d] (id=%q): unknown content %q "+
+					"(want one of %v)",
+				i, src.ID, src.Content, KnownRegistryContentTypes,
+			)
+		}
+	}
+
 	if cfg.OpenShell.IsStandalone() {
 		cfg.Gateway.SandboxHome = cfg.OpenShell.EffectiveSandboxHome()
 	}
@@ -2116,6 +2151,21 @@ func setDefaults(dataDir string) {
 	viper.SetDefault("gateway.watchdog.enabled", true)
 	viper.SetDefault("gateway.watchdog.interval", 30)
 	viper.SetDefault("gateway.watchdog.debounce", 2)
+
+	// User-session OS notifications. Master switch defaults to true
+	// on darwin and false elsewhere — see DefaultNotificationsEnabled
+	// in notifications.go for the rationale. Sub-toggles default ON
+	// so a single yes-answer (or the macOS auto-opt-in) gives full
+	// coverage; operators dial down by flipping individual fields.
+	viper.SetDefault("notifications.enabled", DefaultNotificationsEnabled)
+	viper.SetDefault("notifications.block_enforced", true)
+	viper.SetDefault("notifications.block_would_block", true)
+	viper.SetDefault("notifications.hitl_approval", true)
+	viper.SetDefault("notifications.sources.hook", true)
+	viper.SetDefault("notifications.sources.guardrail", true)
+	viper.SetDefault("notifications.sources.asset_policy", true)
+	viper.SetDefault("notifications.dedup_window", NotificationsDefaultDedupWindow)
+	viper.SetDefault("notifications.max_per_minute", NotificationsDefaultMaxPerMinute)
 
 	viper.SetDefault("otel.enabled", false)
 	viper.SetDefault("otel.protocol", "")

--- a/internal/config/notifications.go
+++ b/internal/config/notifications.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"runtime"
+	"time"
+)
+
+// NotificationsConfig controls user-session OS notifications fired
+// by the gateway when blocks happen or HITL approval is requested.
+//
+// The notifier dispatcher in internal/gateway/notifier consumes this
+// struct directly. Defaults are intentionally permissive (all
+// categories on, modest throttle) so that operators who turn the
+// feature on with a single Y/n at setup get useful coverage without
+// further tuning. Operators dialing noise down can disable
+// individual categories or sources.
+//
+// All durations are expressed in seconds in YAML (mapstructure
+// decodes time.Duration from strings like "30s" — but we keep the
+// Go field as a Duration so callers do not deal with units).
+type NotificationsConfig struct {
+	// Enabled is the master switch. When false, the dispatcher is a
+	// total no-op regardless of category settings. The setup wizard
+	// flips this to true after asking the user.
+	Enabled bool `mapstructure:"enabled" yaml:"enabled"`
+
+	// BlockEnforced fires a notification when a request is actually
+	// denied (mode=action, action=block).
+	BlockEnforced bool `mapstructure:"block_enforced" yaml:"block_enforced"`
+
+	// BlockWouldBlock fires a notification when a verdict would have
+	// blocked under enforcement but observe mode let it through.
+	// Helpful while tuning policy.
+	BlockWouldBlock bool `mapstructure:"block_would_block" yaml:"block_would_block"`
+
+	// HITLApproval fires a notification when a HITL/confirm prompt
+	// is awaiting a user reply on the chat surface.
+	HITLApproval bool `mapstructure:"hitl_approval" yaml:"hitl_approval"`
+
+	// Sources gates events by emission source so an operator can,
+	// e.g., keep guardrail notifications and silence the chatty
+	// asset-policy ones while a registry is being filled in.
+	Sources NotificationSourceFilter `mapstructure:"sources" yaml:"sources,omitempty"`
+
+	// DedupWindow suppresses identical notifications (same
+	// category/source/target/reason hash) seen within this window.
+	// Zero or negative falls back to NotificationsDefaultDedupWindow.
+	DedupWindow time.Duration `mapstructure:"dedup_window" yaml:"dedup_window,omitempty"`
+
+	// MaxPerMinute caps the global rate of delivered notifications.
+	// When exhausted within the minute, the dispatcher emits a
+	// single roll-up ("DefenseClaw suppressed N notifications") at
+	// minute boundaries. Zero or negative falls back to
+	// NotificationsDefaultMaxPerMinute.
+	MaxPerMinute int `mapstructure:"max_per_minute" yaml:"max_per_minute,omitempty"`
+}
+
+// NotificationSourceFilter toggles the three block-decision sources.
+// All default to true so a fresh enable reports everything, and
+// operators turn off only what's noisy.
+type NotificationSourceFilter struct {
+	Hook        bool `mapstructure:"hook"         yaml:"hook"`
+	Guardrail   bool `mapstructure:"guardrail"    yaml:"guardrail"`
+	AssetPolicy bool `mapstructure:"asset_policy" yaml:"asset_policy"`
+}
+
+// NotificationsDefaultDedupWindow is the dedup window applied when
+// the operator did not set one. Identical (category, source, target,
+// reason) tuples within this window are collapsed into a single
+// notification.
+const NotificationsDefaultDedupWindow = 30 * time.Second
+
+// NotificationsDefaultMaxPerMinute is the global rate cap applied
+// when the operator did not set one. The dispatcher emits at most
+// this many notifications per minute and rolls excess into a single
+// summary line at the minute boundary.
+const NotificationsDefaultMaxPerMinute = 12
+
+// DefaultNotificationsEnabled is the platform-conditional master
+// default for the notification dispatcher. Per the rollout step 1
+// of macos-block-and-hitl-notifications, darwin (the only platform
+// with a consumer-grade desktop notification surface every user
+// already has running) opts in by default; every other GOOS waits
+// for an explicit operator opt-in via `defenseclaw setup
+// notifications on`. Exposed as a package-level var (not a const
+// or runtime check) so tests and the Python config helper can
+// pin the matrix without taking a build-tag dependency.
+var DefaultNotificationsEnabled = runtime.GOOS == "darwin"
+
+// DefaultNotificationsConfig returns the recommended starting point
+// for fresh installs: master switch defaults to true on darwin and
+// false elsewhere (see DefaultNotificationsEnabled), and every
+// category and source is enabled so a single yes-answer gives full
+// coverage with no further tuning.
+func DefaultNotificationsConfig() NotificationsConfig {
+	return NotificationsConfig{
+		Enabled:         DefaultNotificationsEnabled,
+		BlockEnforced:   true,
+		BlockWouldBlock: true,
+		HITLApproval:    true,
+		Sources: NotificationSourceFilter{
+			Hook:        true,
+			Guardrail:   true,
+			AssetPolicy: true,
+		},
+		DedupWindow:  NotificationsDefaultDedupWindow,
+		MaxPerMinute: NotificationsDefaultMaxPerMinute,
+	}
+}
+
+// EffectiveDedupWindow returns DedupWindow when set, otherwise the
+// package default. Used by the dispatcher so callers do not
+// distinguish unset from explicit-zero (zero is interpreted as
+// "use the default" rather than "do not dedup at all" — operators
+// who genuinely want no dedup can set a tiny value like 1ms).
+func (n NotificationsConfig) EffectiveDedupWindow() time.Duration {
+	if n.DedupWindow > 0 {
+		return n.DedupWindow
+	}
+	return NotificationsDefaultDedupWindow
+}
+
+// EffectiveMaxPerMinute mirrors EffectiveDedupWindow for the rate cap.
+func (n NotificationsConfig) EffectiveMaxPerMinute() int {
+	if n.MaxPerMinute > 0 {
+		return n.MaxPerMinute
+	}
+	return NotificationsDefaultMaxPerMinute
+}

--- a/internal/config/registries.go
+++ b/internal/config/registries.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import "strings"
+
+// RegistrySource describes one external skill / MCP catalog source the
+// operator has registered with `defenseclaw registry add`. Sync runs
+// fetch + scan against the source's manifest, persists per-entry
+// verdicts under ~/.defenseclaw/registries/<id>/index.json, and
+// auto-promotes clean entries into AssetPolicy.{Skill,MCP}.Registry
+// with Reason="registry:<id>" so admission can attribute the rule
+// back to its source. The on-disk YAML is owned by the Python CLI's
+// _config_to_dict / _merge_registries pair (see
+// cli/defenseclaw/config.py); the Go side mirrors the shape so the
+// gateway can read operator-edited registries without going through
+// the CLI.
+//
+// Field semantics match cli/defenseclaw/config.py::RegistrySource —
+// keep the two in lockstep when extending the schema.
+type RegistrySource struct {
+	ID      string `mapstructure:"id"       yaml:"id"`
+	Kind    string `mapstructure:"kind"     yaml:"kind"`
+	URL     string `mapstructure:"url"      yaml:"url,omitempty"`
+	Content string `mapstructure:"content"  yaml:"content"`
+	AuthEnv string `mapstructure:"auth_env" yaml:"auth_env,omitempty"`
+	Enabled bool   `mapstructure:"enabled"  yaml:"enabled"`
+	// AutoSync and SyncIntervalHours are RESERVED for a future
+	// scheduled-sync implementation. Persisted today so an operator
+	// config rewrite is not needed when v2 lands, but no runtime
+	// component reads them — `defenseclaw registry sync --all`
+	// (cron-driven if needed) is the only ingest path right now.
+	AutoSync          bool   `mapstructure:"auto_sync"           yaml:"auto_sync,omitempty"`
+	SyncIntervalHours int    `mapstructure:"sync_interval_hours" yaml:"sync_interval_hours,omitempty"`
+	LastSync          string `mapstructure:"last_sync"           yaml:"last_sync,omitempty"`
+	LastStatus        string `mapstructure:"last_status"         yaml:"last_status,omitempty"`
+}
+
+// RegistriesConfig groups every registered registry source. Stored at
+// the top level under `registries:` so future fields (cron schedule,
+// global timeouts, signature verification mode) land alongside
+// sources without breaking back-compat for existing configs.
+type RegistriesConfig struct {
+	Sources []RegistrySource `mapstructure:"sources" yaml:"sources,omitempty"`
+}
+
+// KnownRegistryKinds is the allow-list of recognised source kinds.
+// Anything outside this set is rejected at validation time so a typo
+// in `kind:` surfaces immediately rather than silently producing an
+// empty manifest at sync time. Kept in sync with REGISTRY_KINDS in
+// cli/defenseclaw/config.py.
+var KnownRegistryKinds = []string{
+	"clawhub",
+	"smithery",
+	"skills_sh",
+	"http_yaml",
+	"http_json",
+	"git",
+	"file",
+}
+
+// KnownRegistryContentTypes is the allow-list of declared content
+// types — clawhub publishes skills, smithery publishes MCPs, and the
+// generic adapters can serve either or both.
+var KnownRegistryContentTypes = []string{"skill", "mcp", "both"}
+
+// IsKnownRegistryKind reports whether kind is one of the recognised
+// source kinds. Comparison is case-insensitive after trimming.
+func IsKnownRegistryKind(kind string) bool {
+	k := strings.ToLower(strings.TrimSpace(kind))
+	for _, known := range KnownRegistryKinds {
+		if known == k {
+			return true
+		}
+	}
+	return false
+}
+
+// IsKnownRegistryContent reports whether content is one of the
+// recognised content types.
+func IsKnownRegistryContent(content string) bool {
+	c := strings.ToLower(strings.TrimSpace(content))
+	for _, known := range KnownRegistryContentTypes {
+		if known == c {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/registries_test.go
+++ b/internal/config/registries_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadRegistriesFromYAML verifies the gateway can read a config
+// produced by the Python CLI's `defenseclaw registry add`. The two
+// sides serialise the same RegistrySource shape (mapstructure tags on
+// Go, dataclass field order on Python); a regression here is a sign
+// the lockstep contract has drifted.
+func TestLoadRegistriesFromYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("DEFENSECLAW_HOME", tmpDir)
+
+	configFile := filepath.Join(tmpDir, DefaultConfigName)
+	data := []byte(`registries:
+  sources:
+    - id: corp-skills
+      kind: http_yaml
+      url: https://catalog.example.com/skills.yaml
+      content: skill
+      auth_env: DEFENSECLAW_REGISTRY_TOKEN
+      enabled: true
+      sync_interval_hours: 12
+    - id: smithery-public
+      kind: smithery
+      content: mcp
+      enabled: false
+`)
+	if err := os.WriteFile(configFile, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := len(cfg.Registries.Sources); got != 2 {
+		t.Fatalf("len(Registries.Sources) = %d, want 2", got)
+	}
+
+	first := cfg.Registries.Sources[0]
+	if first.ID != "corp-skills" {
+		t.Errorf("Sources[0].ID = %q, want corp-skills", first.ID)
+	}
+	if first.Kind != "http_yaml" {
+		t.Errorf("Sources[0].Kind = %q, want http_yaml", first.Kind)
+	}
+	if first.URL != "https://catalog.example.com/skills.yaml" {
+		t.Errorf("Sources[0].URL = %q", first.URL)
+	}
+	if first.Content != "skill" {
+		t.Errorf("Sources[0].Content = %q", first.Content)
+	}
+	if first.AuthEnv != "DEFENSECLAW_REGISTRY_TOKEN" {
+		t.Errorf("Sources[0].AuthEnv = %q", first.AuthEnv)
+	}
+	if !first.Enabled {
+		t.Error("Sources[0].Enabled should be true")
+	}
+	if first.SyncIntervalHours != 12 {
+		t.Errorf("Sources[0].SyncIntervalHours = %d, want 12", first.SyncIntervalHours)
+	}
+
+	second := cfg.Registries.Sources[1]
+	if second.ID != "smithery-public" {
+		t.Errorf("Sources[1].ID = %q", second.ID)
+	}
+	if second.Kind != "smithery" {
+		t.Errorf("Sources[1].Kind = %q", second.Kind)
+	}
+	if second.Enabled {
+		t.Error("Sources[1].Enabled should be false")
+	}
+}
+
+// TestLoadEmptyRegistriesIsZeroValue exercises the back-compat path —
+// older configs without a `registries:` block must still load with an
+// empty sources slice (not a parse error, not a panic).
+func TestLoadEmptyRegistriesIsZeroValue(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("DEFENSECLAW_HOME", tmpDir)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Registries.Sources == nil {
+		// Sources is allowed to be nil OR an empty slice — both are
+		// "no registries configured". Just assert len.
+	}
+	if got := len(cfg.Registries.Sources); got != 0 {
+		t.Fatalf("expected zero registry sources, got %d", got)
+	}
+}
+
+func TestIsKnownRegistryKind(t *testing.T) {
+	cases := []struct {
+		kind string
+		want bool
+	}{
+		{"clawhub", true},
+		{"  http_yaml  ", true}, // trim+lowercase tolerated
+		{"HTTP_JSON", true},
+		{"git", true},
+		{"file", true},
+		{"smithery", true},
+		{"npm", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			if got := IsKnownRegistryKind(tc.kind); got != tc.want {
+				t.Errorf("IsKnownRegistryKind(%q) = %v, want %v",
+					tc.kind, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsKnownRegistryContent(t *testing.T) {
+	cases := []struct {
+		content string
+		want    bool
+	}{
+		{"skill", true},
+		{"mcp", true},
+		{"both", true},
+		{"BOTH", true},
+		{"plugin", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.content, func(t *testing.T) {
+			if got := IsKnownRegistryContent(tc.content); got != tc.want {
+				t.Errorf("IsKnownRegistryContent(%q) = %v, want %v",
+					tc.content, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPromotedRulesAttributedToRegistry asserts the asset-policy
+// admission engine attributes a registry-promoted rule back to its
+// source via AssetPolicyDecision.RegistrySource. Without this,
+// the TUI cross-link badge and the gateway audit event have no way
+// to point an operator at the source that promoted the asset.
+func TestPromotedRulesAttributedToRegistry(t *testing.T) {
+	cfg := &Config{AssetPolicy: DefaultAssetPolicy()}
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = AssetPolicyModeAction
+	cfg.AssetPolicy.Skill.Default = "deny"
+	cfg.AssetPolicy.Skill.Registry = []AssetPolicyRule{{
+		Name:   "demo-skill",
+		Reason: "registry:corp-skills",
+	}}
+
+	decision := cfg.EvaluateAssetPolicy(AssetPolicyInput{
+		TargetType: "skill",
+		Name:       "demo-skill",
+	})
+	if decision.Action != "allow" {
+		t.Fatalf("expected allow, got %q (raw=%q)",
+			decision.Action, decision.RawAction)
+	}
+	if decision.Source != "registry" {
+		t.Fatalf("Source = %q, want registry", decision.Source)
+	}
+	if decision.RegistrySource != "corp-skills" {
+		t.Fatalf("RegistrySource = %q, want corp-skills", decision.RegistrySource)
+	}
+}
+
+func TestParseRegistrySourceID(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"registry:corp-skills", "corp-skills"},
+		{"  registry:corp  ", "corp"},
+		{"REGISTRY:corp", ""}, // case-sensitive prefix
+		{"admin: trust me", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := ParseRegistrySourceID(tc.in); got != tc.want {
+				t.Errorf("ParseRegistrySourceID(%q) = %q, want %q",
+					tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -43,6 +43,7 @@ import (
 	"github.com/defenseclaw/defenseclaw/internal/config"
 	"github.com/defenseclaw/defenseclaw/internal/enforce"
 	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
+	"github.com/defenseclaw/defenseclaw/internal/gateway/notifier"
 	"github.com/defenseclaw/defenseclaw/internal/gatewaylog"
 	"github.com/defenseclaw/defenseclaw/internal/policy"
 	"github.com/defenseclaw/defenseclaw/internal/redaction"
@@ -62,6 +63,7 @@ type APIServer struct {
 	scannerCfg *config.Config
 	otel       *telemetry.Provider
 	hilt       *HILTApprovalManager
+	notifier   *notifier.Dispatcher
 
 	// cfgMu protects mutable fields in scannerCfg.Guardrail (Mode,
 	// ScannerMode) which can be changed at runtime via the PATCH
@@ -93,6 +95,14 @@ func (a *APIServer) SetOTelProvider(p *telemetry.Provider) {
 
 func (a *APIServer) SetHILTApprovalManager(m *HILTApprovalManager) {
 	a.hilt = m
+}
+
+// SetNotifier wires the user-session OS notifier dispatcher used by
+// the hook handlers to surface block / would-block / approval-pending
+// events. Safe to call with nil — the dispatcher's methods short-
+// circuit on nil so callers do not need to guard each emission site.
+func (a *APIServer) SetNotifier(n *notifier.Dispatcher) {
+	a.notifier = n
 }
 
 func (a *APIServer) connectorName() string {

--- a/internal/gateway/asset_policy_runtime.go
+++ b/internal/gateway/asset_policy_runtime.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/gateway/notifier"
+	"github.com/defenseclaw/defenseclaw/internal/redaction"
 )
 
 type mcpRuntimeProbe struct {
@@ -29,6 +31,30 @@ type mcpRuntimeProbe struct {
 	Matched    bool
 }
 
+type skillRuntimeProbe struct {
+	SkillName string
+	ToolName  string
+	// SourcePath is the raw, agent-supplied skill path (when present).
+	// It is preserved verbatim — including any path traversal segments —
+	// so audit telemetry can show the difference between "trusted-skill"
+	// and "/tmp/attacker/trusted-skill/SKILL.md". Asset policy matches
+	// on SkillName by default; operators wanting to constrain by path
+	// must use AssetPolicyRule.SourcePathContains.
+	SourcePath string
+	// RawName preserves the unnormalized input the SkillName was
+	// derived from when path-stripping occurred (e.g. SkillName came
+	// from filepath.Base on a "/path/to/<name>/SKILL.md"). Empty when
+	// SkillName == raw input.
+	RawName string
+	Surface string
+	Matched bool
+}
+
+type runtimeAssetDecision struct {
+	targetType string
+	decision   config.AssetPolicyDecision
+}
+
 func (a *APIServer) claudeCodeMCPAssetDecision(ctx context.Context, req claudeCodeHookRequest) (config.AssetPolicyDecision, bool) {
 	probe := mcpProbeFromFields(req.MCPServerName, req.ToolName, req.ToolInput)
 	return a.evaluateRuntimeMCPAssetPolicy(ctx, "claudecode", req.HookEventName, probe)
@@ -37,6 +63,65 @@ func (a *APIServer) claudeCodeMCPAssetDecision(ctx context.Context, req claudeCo
 func (a *APIServer) codexMCPAssetDecision(ctx context.Context, req codexHookRequest) (config.AssetPolicyDecision, bool) {
 	probe := mcpProbeFromFields(payloadString(req.Payload, "mcp_server_name"), req.ToolName, req.ToolInput)
 	return a.evaluateRuntimeMCPAssetPolicy(ctx, "codex", req.HookEventName, probe)
+}
+
+func (a *APIServer) claudeCodeSkillAssetDecision(ctx context.Context, req claudeCodeHookRequest) (config.AssetPolicyDecision, bool) {
+	probe := skillProbeFromFields(req.ToolName, req.ToolInput, req.Payload)
+	return a.evaluateRuntimeSkillAssetPolicy(ctx, "claudecode", req.HookEventName, probe)
+}
+
+func (a *APIServer) claudeCodePromptExpansionAssetDecisions(ctx context.Context, req claudeCodeHookRequest) []runtimeAssetDecision {
+	switch strings.ToLower(strings.TrimSpace(req.ExpansionType)) {
+	case "slash_command":
+		return a.claudeCodeSlashCommandAssetDecisions(ctx, req)
+	case "mcp_prompt":
+		return a.claudeCodeMCPPromptAssetDecisions(ctx, req)
+	default:
+		return nil
+	}
+}
+
+func (a *APIServer) claudeCodeSlashCommandAssetDecisions(ctx context.Context, req claudeCodeHookRequest) []runtimeAssetDecision {
+	if !slashCommandLooksSkill(req.CommandSource) {
+		return nil
+	}
+	name := normalizeSkillRuntimeName(req.CommandName)
+	if name == "" {
+		return nil
+	}
+	probe := skillRuntimeProbe{
+		SkillName:  name,
+		ToolName:   strings.TrimSpace(req.CommandName),
+		SourcePath: strings.TrimSpace(req.CommandSource),
+		Surface:    "prompt_expansion",
+		Matched:    true,
+	}
+	if decision, matched := a.evaluateRuntimeSkillAssetPolicy(ctx, "claudecode", req.HookEventName, probe); matched {
+		return []runtimeAssetDecision{{targetType: "skill", decision: decision}}
+	}
+	return nil
+}
+
+func (a *APIServer) claudeCodeMCPPromptAssetDecisions(ctx context.Context, req claudeCodeHookRequest) []runtimeAssetDecision {
+	server := mcpPromptServerName(req.CommandSource, req.CommandName)
+	if server == "" {
+		return nil
+	}
+	probe := mcpRuntimeProbe{
+		ServerName: server,
+		ToolName:   strings.TrimSpace(req.CommandName),
+		Surface:    "prompt_expansion",
+		Matched:    true,
+	}
+	if decision, matched := a.evaluateRuntimeMCPAssetPolicy(ctx, "claudecode", req.HookEventName, probe); matched {
+		return []runtimeAssetDecision{{targetType: "mcp", decision: decision}}
+	}
+	return nil
+}
+
+func (a *APIServer) codexSkillAssetDecision(ctx context.Context, req codexHookRequest) (config.AssetPolicyDecision, bool) {
+	probe := skillProbeFromFields(req.ToolName, req.ToolInput, req.Payload)
+	return a.evaluateRuntimeSkillAssetPolicy(ctx, "codex", req.HookEventName, probe)
 }
 
 func (a *APIServer) evaluateRuntimeMCPAssetPolicy(ctx context.Context, connector, hookEvent string, probe mcpRuntimeProbe) (config.AssetPolicyDecision, bool) {
@@ -68,21 +153,107 @@ func (a *APIServer) evaluateRuntimeMCPAssetPolicy(ctx context.Context, connector
 	}
 	if a.otel != nil {
 		a.otel.EmitPolicyDecision("asset-policy", decision.Action, decision.TargetName, "mcp", decision.Reason, map[string]string{
-			"source":          decision.Source,
-			"registry_status": decision.RegistryStatus,
-			"runtime_surface": coalesceRuntimeSurface(probe.Surface, "hook"),
-			"hook_event_name": hookEvent,
-			"tool_name":       probe.ToolName,
-			"mcp_server_name": probe.ServerName,
-			"would_block":     fmt.Sprintf("%t", decision.WouldBlock),
+			"source":              decision.Source,
+			"registry_status":     decision.RegistryStatus,
+			"registry_configured": fmt.Sprintf("%t", decision.RegistryConfigured),
+			"runtime_surface":     coalesceRuntimeSurface(probe.Surface, "hook"),
+			"hook_event_name":     hookEvent,
+			"tool_name":           probe.ToolName,
+			"mcp_server_name":     probe.ServerName,
+			"would_block":         fmt.Sprintf("%t", decision.WouldBlock),
 		})
 	}
 	if a.logger != nil {
 		_ = a.logger.LogActionCtx(ctx, "asset-policy", "mcp:"+decision.TargetName,
-			fmt.Sprintf("action=%s source=%s registry_status=%s surface=%s hook=%s tool=%s would_block=%v reason=%s",
-				decision.Action, decision.Source, decision.RegistryStatus, probe.Surface, hookEvent, probe.ToolName, decision.WouldBlock, decision.Reason))
+			fmt.Sprintf("action=%s source=%s registry_status=%s registry_configured=%v surface=%s hook=%s tool=%s would_block=%v reason=%s",
+				decision.Action, decision.Source, decision.RegistryStatus, decision.RegistryConfigured, probe.Surface, hookEvent, probe.ToolName, decision.WouldBlock, decision.Reason))
 	}
+	a.dispatchAssetPolicyNotification(decision, "mcp", connector, hookEvent)
 	return decision, true
+}
+
+func (a *APIServer) evaluateRuntimeSkillAssetPolicy(ctx context.Context, connector, hookEvent string, probe skillRuntimeProbe) (config.AssetPolicyDecision, bool) {
+	if a.scannerCfg == nil || !probe.Matched {
+		return config.AssetPolicyDecision{}, false
+	}
+	decision := a.scannerCfg.EvaluateAssetPolicy(config.AssetPolicyInput{
+		TargetType:     "skill",
+		Name:           probe.SkillName,
+		Connector:      connector,
+		SourcePath:     probe.SourcePath,
+		RuntimeSurface: coalesceRuntimeSurface(probe.Surface, "hook"),
+	})
+	if !decision.Enabled || decision.RawAction != "block" {
+		return decision, false
+	}
+	if a.otel != nil {
+		attrs := map[string]string{
+			"source":              decision.Source,
+			"registry_status":     decision.RegistryStatus,
+			"registry_configured": fmt.Sprintf("%t", decision.RegistryConfigured),
+			"runtime_surface":     coalesceRuntimeSurface(probe.Surface, "hook"),
+			"hook_event_name":     hookEvent,
+			"tool_name":           probe.ToolName,
+			"skill_name":          probe.SkillName,
+			"would_block":         fmt.Sprintf("%t", decision.WouldBlock),
+		}
+		// Surface raw inputs whenever path-stripping or other
+		// normalization changed the agent's literal value into a
+		// different registry-matching name. This is the audit
+		// signal for "agent passed /tmp/x/<approved>/SKILL.md to
+		// match an approved name" attempts.
+		if probe.RawName != "" {
+			attrs["skill_name_raw"] = probe.RawName
+		}
+		if probe.SourcePath != "" {
+			attrs["skill_source_path"] = probe.SourcePath
+		}
+		a.otel.EmitPolicyDecision("asset-policy", decision.Action, decision.TargetName, "skill", decision.Reason, attrs)
+	}
+	if a.logger != nil {
+		_ = a.logger.LogActionCtx(ctx, "asset-policy", "skill:"+decision.TargetName,
+			fmt.Sprintf("action=%s source=%s registry_status=%s registry_configured=%v surface=%s hook=%s tool=%s skill_name_raw=%q source_path=%q would_block=%v reason=%s",
+				decision.Action, decision.Source, decision.RegistryStatus, decision.RegistryConfigured, probe.Surface, hookEvent, probe.ToolName, probe.RawName, probe.SourcePath, decision.WouldBlock, decision.Reason))
+	}
+	a.dispatchAssetPolicyNotification(decision, "skill", connector, hookEvent)
+	return decision, true
+}
+
+// dispatchAssetPolicyNotification fires an OS toast for an asset
+// policy block / would-block decision. Only the runtime evaluators
+// call this helper, and only after they have already decided the
+// decision is blocking (RawAction == "block" + matched). The
+// dispatcher's per-source gate keeps it silent when an operator
+// turns off `notifications.sources.asset_policy` even with the
+// master switch on. Reason is run through redaction.ForSinkReason
+// for parity with the hook / proxy / HILT helpers — the toast is
+// rendered locally but a screenshot or screen recording is still a
+// data-exfil surface.
+func (a *APIServer) dispatchAssetPolicyNotification(decision config.AssetPolicyDecision, targetKind, connectorName, hookEvent string) {
+	if a == nil || a.notifier == nil {
+		return
+	}
+	target := strings.TrimSpace(decision.TargetName)
+	if target == "" {
+		target = strings.ToLower(strings.TrimSpace(targetKind))
+	} else {
+		target = strings.ToLower(strings.TrimSpace(targetKind)) + ":" + target
+	}
+	ev := notifier.BlockEvent{
+		Source:    notifier.SourceAssetPolicy,
+		Target:    target,
+		Reason:    string(redaction.ForSinkReason(decision.Reason)),
+		Severity:  "HIGH",
+		Connector: connectorName,
+		Event:     hookEvent,
+	}
+	if decision.Action == "block" {
+		a.notifier.OnBlock(ev)
+		return
+	}
+	if decision.WouldBlock {
+		a.notifier.OnWouldBlock(ev)
+	}
 }
 
 func isUnknownTerminalMCP(probe mcpRuntimeProbe) bool {
@@ -121,6 +292,231 @@ func mcpProbeFromFields(serverName, toolName string, toolInput map[string]interf
 	return mcpRuntimeProbe{ToolName: toolName}
 }
 
+func slashCommandLooksSkill(commandSource string) bool {
+	switch strings.ToLower(strings.TrimSpace(commandSource)) {
+	case "skill", "plugin":
+		return true
+	default:
+		return false
+	}
+}
+
+func mcpPromptServerName(commandSource, commandName string) string {
+	for _, value := range []string{commandSource, commandName} {
+		if server := mcpServerNameFromPromptField(value); server != "" {
+			return server
+		}
+	}
+	return ""
+}
+
+// mcpServerNameFromPromptField extracts an MCP server name from one of
+// the prompt-expansion fields ("command_source"/"command_name") emitted
+// by Claude Code for /mcp prompt invocations. Recognized shapes:
+//   - "mcp:<server>:<prompt>"
+//   - "mcp__<server>__<prompt>"
+//   - "mcp/<server>/<prompt>"
+//   - "<server>__<prompt>" (when the connector already stripped the prefix)
+//   - "<server>"            (bare server name)
+//
+// The bare-name case is intentional: Claude Code's CommandSource
+// frequently arrives as just the server identifier (e.g. "github"). To
+// avoid false matches on the literal placeholder "mcp"/"mcp_prompt"/
+// "prompt", we filter those out before falling through.
+//
+// Repeated "mcp" prefixes are stripped iteratively rather than once so
+// that pathological inputs like "mcp__mcp__server" do not collapse to
+// "mcp" (which would then be filtered) — they collapse to "server".
+func mcpServerNameFromPromptField(value string) string {
+	value = strings.Trim(strings.TrimSpace(value), `"'`)
+	if value == "" {
+		return ""
+	}
+	// Strip any number of "mcp:" / "mcp__" / "mcp/" prefixes, in any
+	// order. Loops because chained prefixes ("mcp:mcp__foo") otherwise
+	// only get one prefix removed. Bound the loop iterations as a
+	// belt-and-braces guard against pathological inputs.
+	for i := 0; i < 8; i++ {
+		stripped := false
+		lower := strings.ToLower(value)
+		for _, prefix := range []string{"mcp:", "mcp__", "mcp/"} {
+			if strings.HasPrefix(lower, prefix) {
+				value = value[len(prefix):]
+				stripped = true
+				break
+			}
+		}
+		if !stripped {
+			break
+		}
+	}
+	if value == "" {
+		return ""
+	}
+	for _, sep := range []string{"__", ":", "/", "."} {
+		if idx := strings.Index(value, sep); idx > 0 {
+			candidate := strings.TrimSpace(value[:idx])
+			if isMCPPromptPlaceholder(candidate) {
+				return ""
+			}
+			return candidate
+		}
+	}
+	value = strings.TrimSpace(value)
+	if isMCPPromptPlaceholder(value) {
+		return ""
+	}
+	return value
+}
+
+func isMCPPromptPlaceholder(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "mcp", "mcp_prompt", "prompt":
+		return true
+	default:
+		return false
+	}
+}
+
+func skillProbeFromFields(toolName string, toolInput, payload map[string]interface{}) skillRuntimeProbe {
+	toolName = strings.TrimSpace(toolName)
+	if name, sourcePath, rawName := skillFromMap(payload); name != "" {
+		return skillRuntimeProbe{
+			SkillName:  name,
+			RawName:    rawName,
+			ToolName:   toolName,
+			SourcePath: sourcePath,
+			Surface:    "hook",
+			Matched:    true,
+		}
+	}
+	if name, sourcePath, rawName := skillFromMap(toolInput); name != "" {
+		return skillRuntimeProbe{
+			SkillName:  name,
+			RawName:    rawName,
+			ToolName:   toolName,
+			SourcePath: sourcePath,
+			Surface:    "hook",
+			Matched:    true,
+		}
+	}
+	if name := skillFromToolName(toolName); name != "" {
+		return skillRuntimeProbe{
+			SkillName: name,
+			ToolName:  toolName,
+			Surface:   "hook",
+			Matched:   true,
+		}
+	}
+	return skillRuntimeProbe{ToolName: toolName}
+}
+
+// skillFromMap returns (normalizedName, sourcePath, rawName).
+// rawName is the original input string when normalization stripped a
+// path (e.g. "/path/to/foo/SKILL.md" -> "foo"); empty otherwise.
+// Callers propagate this so audit/OTel can show the agent's literal
+// input alongside the registry-matching name.
+func skillFromMap(values map[string]interface{}) (string, string, string) {
+	if values == nil {
+		return "", "", ""
+	}
+	sourcePath := firstMapString(values, "skill_path", "skillPath", "source_path", "sourcePath")
+	rawName := firstMapString(values, "skill_name", "skillName", "skill_key", "skillKey", "skill_id", "skillId")
+	if rawName != "" {
+		normalized := normalizeSkillRuntimeName(rawName)
+		return normalized, sourcePath, skillRawNameIfNormalized(rawName, normalized)
+	}
+	for _, key := range []string{"skill", "skill_info", "skillInfo", "source_skill", "sourceSkill"} {
+		if v, ok := values[key]; ok {
+			if nestedName, nestedPath, nestedRaw := skillFromValue(v); nestedName != "" {
+				if sourcePath == "" {
+					sourcePath = nestedPath
+				}
+				return nestedName, sourcePath, nestedRaw
+			}
+		}
+	}
+	if sourcePath != "" {
+		normalized := normalizeSkillRuntimeName(sourcePath)
+		return normalized, sourcePath, skillRawNameIfNormalized(sourcePath, normalized)
+	}
+	return "", "", ""
+}
+
+func skillFromValue(value interface{}) (string, string, string) {
+	switch v := value.(type) {
+	case string:
+		normalized := normalizeSkillRuntimeName(v)
+		return normalized, pathIfLooksLikePath(v), skillRawNameIfNormalized(v, normalized)
+	case map[string]interface{}:
+		sourcePath := firstMapString(v, "path", "source_path", "sourcePath", "skill_path", "skillPath")
+		raw := firstMapString(v, "name", "key", "id", "skill_name", "skillName", "skill_key", "skillKey", "skill_id", "skillId")
+		if raw == "" && sourcePath != "" {
+			raw = sourcePath
+		}
+		normalized := normalizeSkillRuntimeName(raw)
+		return normalized, sourcePath, skillRawNameIfNormalized(raw, normalized)
+	default:
+		return "", "", ""
+	}
+}
+
+// skillRawNameIfNormalized returns raw only when normalization changed
+// the input (path-stripping, quote-stripping, "@" prefix removal). The
+// caller uses a non-empty rawName to flag "agent supplied a value that
+// did not match the registry verbatim — audit may want to see the raw
+// form to detect allowlist-bypass attempts via crafted skill paths".
+func skillRawNameIfNormalized(raw, normalized string) string {
+	if strings.TrimSpace(raw) == "" {
+		return ""
+	}
+	if raw == normalized {
+		return ""
+	}
+	return raw
+}
+
+func skillFromToolName(toolName string) string {
+	toolName = strings.TrimSpace(toolName)
+	if strings.HasPrefix(toolName, "skill__") {
+		parts := strings.Split(toolName, "__")
+		if len(parts) >= 3 && strings.TrimSpace(parts[1]) != "" {
+			return normalizeSkillRuntimeName(parts[1])
+		}
+	}
+	if strings.HasPrefix(toolName, "skill:") {
+		parts := strings.SplitN(toolName, ":", 3)
+		if len(parts) >= 2 && strings.TrimSpace(parts[1]) != "" {
+			return normalizeSkillRuntimeName(parts[1])
+		}
+	}
+	return ""
+}
+
+func normalizeSkillRuntimeName(value string) string {
+	name := strings.Trim(strings.TrimSpace(value), `"'`)
+	if name == "" {
+		return ""
+	}
+	if strings.ContainsAny(name, `/\`) {
+		path := filepath.Clean(name)
+		if strings.EqualFold(filepath.Base(path), "SKILL.md") {
+			path = filepath.Dir(path)
+		}
+		name = filepath.Base(path)
+	}
+	name = strings.TrimPrefix(name, "@")
+	return strings.TrimSpace(name)
+}
+
+func pathIfLooksLikePath(value string) string {
+	value = strings.Trim(strings.TrimSpace(value), `"'`)
+	if strings.ContainsAny(value, `/\`) {
+		return value
+	}
+	return ""
+}
+
 func serverFromMCPToolName(toolName string) string {
 	toolName = strings.TrimSpace(toolName)
 	if strings.HasPrefix(toolName, "mcp__") {
@@ -140,10 +536,8 @@ func serverFromMCPToolName(toolName string) string {
 
 func commandFromToolInput(input map[string]interface{}) string {
 	for _, key := range []string{"command", "cmd", "input", "script"} {
-		if v, ok := input[key]; ok {
-			if s := strings.TrimSpace(fmt.Sprint(v)); s != "" {
-				return s
-			}
+		if s := firstMapString(input, key); s != "" {
+			return s
 		}
 	}
 	return ""
@@ -218,19 +612,65 @@ func splitCommandLine(command string) (string, []string) {
 	return fields[0], fields[1:]
 }
 
+// payloadString is a thin alias retained for symmetry with the older
+// single-key helper used by codex/claude hooks. Prefer firstMapString
+// for new call sites.
 func payloadString(payload map[string]interface{}, key string) string {
-	if payload == nil {
+	return firstMapString(payload, key)
+}
+
+// firstMapString returns the first non-empty string-valued field for
+// the given keys. It deliberately rejects non-string values rather than
+// stringifying them: agent-controlled hook payloads can carry numbers,
+// booleans, nested maps, etc., and silently coercing those into
+// "asset names" via fmt.Sprint widens the registry-match surface (e.g.
+// a boolean false becoming the literal string "false") and produces
+// nonsense names like "map[a:b]" that bypass intent. Callers that need
+// to handle structured values should branch on type explicitly.
+func firstMapString(values map[string]interface{}, keys ...string) string {
+	if values == nil {
 		return ""
 	}
-	if v, ok := payload[key]; ok {
-		return strings.TrimSpace(fmt.Sprint(v))
+	for _, key := range keys {
+		v, ok := values[key]
+		if !ok {
+			continue
+		}
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		if t := strings.TrimSpace(s); t != "" {
+			return t
+		}
 	}
 	return ""
 }
 
+// mergeAssetDecision folds a single asset-policy decision into the
+// running hook verdict. Contract:
+//
+//   - matched=false (or non-blocking decision) is a no-op — caller's
+//     existing verdict is returned unchanged with wouldBlock=false.
+//   - matched=true with a blocking decision always sets rawAction=block
+//     and severity>=HIGH, regardless of whether enforcement runs.
+//   - When the current hook event is enforceable (PreToolUse,
+//     PermissionRequest, UserPromptExpansion), action=block and the
+//     returned wouldBlock=false (because the action IS the block —
+//     "would" only makes sense in observe mode / non-enforceable events).
+//   - Otherwise the merge stays in advisory mode: action stays "allow"
+//     (or "block" if a prior asset already blocked), and wouldBlock=true
+//     so callers know the request would have been blocked under
+//     enforceable events.
+//
+// Callers must filter to blocking-only decisions before invoking this
+// (evaluateRuntime{MCP,Skill}AssetPolicy already does); a non-blocking
+// decision reaching this function is treated as a no-op rather than an
+// error so the hook flow degrades gracefully.
 func mergeAssetDecision(
 	decision config.AssetPolicyDecision,
 	matched bool,
+	targetType string,
 	event string,
 	action, rawAction, severity, reason string,
 	findings []string,
@@ -244,26 +684,120 @@ func mergeAssetDecision(
 		severity = "HIGH"
 	}
 	if decision.Reason != "" && !alreadyBlocking {
-		reason = decision.Reason
+		reason = assetPolicyResponseReason(decision)
 	}
-	findings = append(findings, "ASSET-POLICY-MCP")
-	canBlock := decision.Action == "block" && runtimeMCPAssetCanEnforce(event)
+	finding := "ASSET-POLICY-" + strings.ToUpper(strings.TrimSpace(targetType))
+	if finding == "ASSET-POLICY-" {
+		finding = "ASSET-POLICY-ASSET"
+	}
+	findings = append(findings, finding)
+	canBlock := decision.Action == "block" && runtimeAssetCanEnforce(event)
 	if canBlock {
 		if decision.Reason != "" {
-			reason = decision.Reason
+			reason = assetPolicyResponseReason(decision)
 		}
 		action = "block"
+		// wouldBlock=false: the block is happening for real, so
+		// "would-have-blocked" is no longer the relevant signal.
 		return action, rawAction, severity, reason, findings, false
 	}
 	if !alreadyBlocking {
 		action = "allow"
 	}
+	// wouldBlock=true: matched + raw=block + non-enforceable event ⇒
+	// downstream observability should record that this would have been
+	// blocked under enforcement. Operators rely on this to size the
+	// false-positive rate before flipping a connector to action mode.
 	return action, rawAction, severity, reason, findings, true
 }
 
-func runtimeMCPAssetCanEnforce(event string) bool {
+// assetPolicyResponseReason renders a structured, machine-parseable
+// reason string for downstream consumers (Claude Code / Codex hook
+// reason field, gateway logs, OTel attributes).
+//
+// Layout choices:
+//
+//   - All values are emitted as plain key=value with no quoting. The
+//     gateway's redaction layer (internal/redaction.ForSinkReason) is
+//     the canonical place for value-safety: it walks key=value tokens
+//     and redacts any value that isn't in its rule-id-style allow-list.
+//     If we wrapped values in quotes here, the value would no longer
+//     match the redactor's safe-value pattern and every routine
+//     allowlist-style asset_name would be redacted into
+//     "<redacted len=N sha=...>" — making operator audit useless.
+//
+//   - The structured fields (reason_code, source, asset_type,
+//     asset_name, connector, registry_status, registry_configured,
+//     surface) are sufficient for SIEM correlation, so we deliberately
+//     do NOT also append the human-readable decision.Reason: it would
+//     duplicate the same information, contains free-form spaces, and
+//     would always be redacted away anyway.
+//
+//   - Empty fields are skipped to keep reasons short, except
+//     registry_configured which is always emitted because telemetry
+//     filtering on its boolean value (`registry_configured=false`) is a
+//     strong signal that an operator forgot to populate the registry.
+//
+//   - Asset names with characters that fall outside the redactor's
+//     safe charset are passed through as-is and the redactor will
+//     scrub them — this is the desired behavior because such names are
+//     necessarily attacker-controlled.
+func assetPolicyResponseReason(decision config.AssetPolicyDecision) string {
+	parts := []string{"ASSET-POLICY"}
+	if decision.Source != "" {
+		parts = append(parts, "reason_code="+assetPolicyReasonCode(decision.Source))
+		parts = append(parts, "source="+decision.Source)
+	}
+	if decision.TargetType != "" {
+		parts = append(parts, "asset_type="+decision.TargetType)
+	}
+	if decision.TargetName != "" {
+		parts = append(parts, "asset_name="+decision.TargetName)
+	}
+	if decision.Connector != "" {
+		parts = append(parts, "connector="+decision.Connector)
+	}
+	if decision.RegistryStatus != "" {
+		parts = append(parts, "registry_status="+assetPolicyRegistryStatusForReason(decision.RegistryStatus))
+	}
+	parts = append(parts, fmt.Sprintf("registry_configured=%t", decision.RegistryConfigured))
+	if decision.RuntimeSurface != "" {
+		parts = append(parts, "surface="+decision.RuntimeSurface)
+	}
+	return strings.Join(parts, " ")
+}
+
+func assetPolicyReasonCode(source string) string {
+	switch strings.TrimSpace(source) {
+	case "registry-required":
+		return "not-in-approved-registry"
+	case "registry-required-empty":
+		// Distinct from registry-required so operators can tell
+		// "you tried to use an unregistered asset" apart from
+		// "the registry itself is unconfigured / fail-closed
+		// guard tripped". Same family of failure, different fix.
+		return "registry-required-but-empty"
+	case "default-deny":
+		return "default-deny"
+	case "admin-deny":
+		return "admin-deny"
+	default:
+		return source
+	}
+}
+
+func assetPolicyRegistryStatusForReason(status string) string {
+	switch strings.TrimSpace(status) {
+	case "unregistered":
+		return "not-registered"
+	default:
+		return status
+	}
+}
+
+func runtimeAssetCanEnforce(event string) bool {
 	switch event {
-	case "PreToolUse", "PermissionRequest":
+	case "UserPromptExpansion", "PreToolUse", "PermissionRequest":
 		return true
 	default:
 		return false

--- a/internal/gateway/asset_policy_runtime_test.go
+++ b/internal/gateway/asset_policy_runtime_test.go
@@ -1,0 +1,336 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+)
+
+// TestFirstMapStringRejectsNonStringValues pins the strict-string
+// semantics the helper relies on. Earlier versions used fmt.Sprint
+// which silently coerced bools/numbers/nested maps into strings like
+// "false" / "0" / "map[a:b]" — this widened the registry-match surface
+// because an agent could plant a non-string skill_name and have it
+// stringified into a recognized identifier.
+func TestFirstMapStringRejectsNonStringValues(t *testing.T) {
+	cases := []struct {
+		name   string
+		values map[string]interface{}
+		keys   []string
+		want   string
+	}{
+		{
+			name:   "string value passes through and is trimmed",
+			values: map[string]interface{}{"k": "  hello  "},
+			keys:   []string{"k"},
+			want:   "hello",
+		},
+		{
+			name:   "boolean value is rejected (not coerced to \"false\")",
+			values: map[string]interface{}{"k": false},
+			keys:   []string{"k"},
+			want:   "",
+		},
+		{
+			name:   "numeric value is rejected (not coerced to \"0\")",
+			values: map[string]interface{}{"k": 0},
+			keys:   []string{"k"},
+			want:   "",
+		},
+		{
+			name:   "nested map is rejected (not coerced to map[...] string)",
+			values: map[string]interface{}{"k": map[string]interface{}{"a": "b"}},
+			keys:   []string{"k"},
+			want:   "",
+		},
+		{
+			name:   "slice value is rejected (not joined into a fake command)",
+			values: map[string]interface{}{"command": []interface{}{"bash", "-c", "rm -rf /"}},
+			keys:   []string{"command"},
+			want:   "",
+		},
+		{
+			name:   "nil value is rejected (not coerced to \"<nil>\")",
+			values: map[string]interface{}{"k": nil},
+			keys:   []string{"k"},
+			want:   "",
+		},
+		{
+			name:   "empty string skips to next key",
+			values: map[string]interface{}{"a": "", "b": "found"},
+			keys:   []string{"a", "b"},
+			want:   "found",
+		},
+		{
+			name:   "missing keys return empty",
+			values: map[string]interface{}{},
+			keys:   []string{"a"},
+			want:   "",
+		},
+		{
+			name:   "nil map returns empty",
+			values: nil,
+			keys:   []string{"a"},
+			want:   "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := firstMapString(tc.values, tc.keys...); got != tc.want {
+				t.Errorf("firstMapString(...) = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMCPServerNameFromPromptFieldParsing pins the parsing semantics
+// for the "command_source" / "command_name" prompt-expansion fields.
+// These are agent-controlled, so any drift in this parser changes the
+// asset-policy match surface (e.g. whether "/mcp/rogue/foo" maps to
+// the registry name "rogue").
+func TestMCPServerNameFromPromptFieldParsing(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{"   ", ""},
+		{"mcp", ""},
+		{"MCP", ""},
+		{"mcp_prompt", ""},
+		{"prompt", ""},
+
+		// Bare server name (Claude Code's common shape).
+		{"github", "github"},
+		{"  github  ", "github"},
+		{`"github"`, "github"},
+		{"'github'", "github"},
+
+		// Standard prefixed shapes.
+		{"mcp:rogue:foo", "rogue"},
+		{"mcp__rogue__foo", "rogue"},
+		{"mcp/rogue/foo", "rogue"},
+		{"MCP:rogue:foo", "rogue"},
+		{"Mcp__Rogue__Foo", "Rogue"},
+
+		// Single segment after stripping prefix.
+		{"mcp:rogue", "rogue"},
+		{"mcp__rogue", "rogue"},
+
+		// Pathological doubled prefixes — must collapse all the way,
+		// not just one prefix worth, otherwise these would falsely
+		// resolve to the literal "mcp" placeholder.
+		{"mcp:mcp:server", "server"},
+		{"mcp__mcp__server", "server"},
+		{"mcp/mcp/server", "server"},
+
+		// Hyphenated names without a recognized separator should
+		// return the entire bare value, not be split arbitrarily.
+		{"my-org-server", "my-org-server"},
+
+		// Dotted names (Claude Code occasionally emits these).
+		{"rogue.search", "rogue"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			if got := mcpServerNameFromPromptField(tc.input); got != tc.want {
+				t.Errorf("mcpServerNameFromPromptField(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeSkillRuntimeNameDocumentsPathBehavior documents and
+// pins the asset-policy-relevant behavior of skill name normalization:
+// when an agent supplies a path-shaped value, normalization collapses
+// to the basename. This is by design (the registry matches by name,
+// not path), but it also means an agent CAN match an approved name
+// using a crafted path. Any audit-detection effort relies on the raw
+// input being preserved (see RawName / SourcePath), so this test
+// pins the normalization contract.
+func TestNormalizeSkillRuntimeNameDocumentsPathBehavior(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{"   ", ""},
+		{"foo", "foo"},
+		{"@foo", "foo"},
+		{`"foo"`, "foo"},
+		{"'foo'", "foo"},
+
+		// SKILL.md trailing component is stripped to expose the
+		// directory name as the skill identifier.
+		{"/path/to/foo/SKILL.md", "foo"},
+		{"/path/to/foo/skill.md", "foo"},
+		{"path/to/foo", "foo"},
+
+		// Path traversal segments collapse via filepath.Base. This
+		// is the behavior to flag/audit — it means an agent passing
+		// "/tmp/x/<approved>/SKILL.md" matches "<approved>" if it
+		// is in the registry. Operators must rely on RawName /
+		// SourcePath in telemetry to detect crafted-path bypass.
+		{"../../../trusted-skill", "trusted-skill"},
+		{"/tmp/attacker/trusted-skill/SKILL.md", "trusted-skill"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			if got := normalizeSkillRuntimeName(tc.input); got != tc.want {
+				t.Errorf("normalizeSkillRuntimeName(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSkillProbePreservesRawNameWhenPathStripped is the audit-trail
+// pin: when path normalization changed the agent's literal input
+// into a different registry-matching name, the probe must still carry
+// the original input so OTel/logs can show the discrepancy. Without
+// this, a "trusted-skill" allow decision in the audit log is
+// indistinguishable from one triggered by "/tmp/attacker/trusted-skill/SKILL.md".
+func TestSkillProbePreservesRawNameWhenPathStripped(t *testing.T) {
+	probe := skillProbeFromFields("Skill", map[string]interface{}{
+		"skill_name": "/tmp/attacker/trusted-skill/SKILL.md",
+	}, nil)
+	if probe.SkillName != "trusted-skill" {
+		t.Fatalf("SkillName = %q, want trusted-skill", probe.SkillName)
+	}
+	if probe.RawName != "/tmp/attacker/trusted-skill/SKILL.md" {
+		t.Fatalf("RawName = %q, want full agent-supplied path", probe.RawName)
+	}
+
+	// When the agent supplies a literal name that already matches the
+	// registry-canonical form, RawName must be empty so we don't spam
+	// every legitimate request with a noisy "raw differs" annotation.
+	probe = skillProbeFromFields("Skill", map[string]interface{}{
+		"skill_name": "trusted-skill",
+	}, nil)
+	if probe.SkillName != "trusted-skill" {
+		t.Fatalf("SkillName = %q, want trusted-skill", probe.SkillName)
+	}
+	if probe.RawName != "" {
+		t.Fatalf("RawName = %q, want empty (no normalization happened)", probe.RawName)
+	}
+}
+
+// TestAssetPolicyResponseReasonEmitsAllStructuredFields pins the
+// structured-field layout of the response reason. The downstream
+// redaction layer (internal/redaction.ForSinkReason) parses these as
+// "key=value" tokens and applies its own value safety policy — that
+// is why we deliberately do NOT quote values here, and why the
+// decision.Reason free-form string is intentionally NOT appended:
+// quoting or appending free-form prose would defeat the redactor's
+// allow-list and replace every routine asset_name with a
+// "<redacted len=N sha=...>" placeholder.
+func TestAssetPolicyResponseReasonEmitsAllStructuredFields(t *testing.T) {
+	decision := config.AssetPolicyDecision{
+		Source:             "registry-required",
+		TargetType:         "mcp",
+		TargetName:         "rogue",
+		Connector:          "claudecode",
+		RegistryStatus:     "unregistered",
+		RegistryConfigured: true,
+		RuntimeSurface:     "hook",
+		Reason:             "intentionally ignored — see doc comment on assetPolicyResponseReason",
+	}
+	got := assetPolicyResponseReason(decision)
+	for _, want := range []string{
+		"reason_code=not-in-approved-registry",
+		"source=registry-required",
+		"asset_type=mcp",
+		"asset_name=rogue",
+		"connector=claudecode",
+		"registry_status=not-registered",
+		"registry_configured=true",
+		"surface=hook",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("response reason %q missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "detail=") {
+		t.Errorf("response reason should NOT include detail= field; redactor would scrub it anyway: %q", got)
+	}
+}
+
+// TestAssetPolicyResponseReasonRegistryRequiredEmptyHasOwnReasonCode
+// pins the new "registry-required-but-empty" reason code so that
+// dashboards / alerting filtering on reason_code can distinguish
+// "you used an unapproved asset" (registry populated, target not in it)
+// from "fail-closed because the registry itself was empty" (operator
+// forgot to populate it). Same family of failure, different remediation.
+func TestAssetPolicyResponseReasonRegistryRequiredEmptyHasOwnReasonCode(t *testing.T) {
+	decision := config.AssetPolicyDecision{
+		Source:             "registry-required-empty",
+		TargetType:         "skill",
+		TargetName:         "rogue-skill",
+		Connector:          "codex",
+		RegistryStatus:     "unregistered",
+		RegistryConfigured: false,
+	}
+	got := assetPolicyResponseReason(decision)
+	if !strings.Contains(got, "reason_code=registry-required-but-empty") {
+		t.Errorf("response reason %q missing reason_code=registry-required-but-empty", got)
+	}
+	if !strings.Contains(got, "registry_configured=false") {
+		t.Errorf("response reason %q missing registry_configured=false", got)
+	}
+}
+
+// TestMergeAssetDecisionNonBlockingDecisionIsNoop ensures the merge
+// function handles the (defensive) case where a non-blocking decision
+// reaches it — earlier code shapes risked appending a finding even
+// though no policy violation actually occurred.
+func TestMergeAssetDecisionNonBlockingDecisionIsNoop(t *testing.T) {
+	decision := config.AssetPolicyDecision{
+		Action:    "allow",
+		RawAction: "allow",
+	}
+	action, raw, sev, reason, findings, wouldBlock := mergeAssetDecision(
+		decision, true, "mcp", "PreToolUse",
+		"allow", "allow", "NONE", "ok", []string{"PRE-EXISTING"},
+	)
+	if action != "allow" || raw != "allow" || sev != "NONE" || reason != "ok" {
+		t.Fatalf("merge mutated verdict on non-blocking decision: action=%q raw=%q sev=%q reason=%q",
+			action, raw, sev, reason)
+	}
+	if wouldBlock {
+		t.Fatal("wouldBlock=true on non-blocking decision")
+	}
+	if len(findings) != 1 || findings[0] != "PRE-EXISTING" {
+		t.Fatalf("findings mutated: %v", findings)
+	}
+}
+
+// TestMergeAssetDecisionDefaultsTargetTypeToASSET prevents the merge
+// from emitting a malformed finding ID like "ASSET-POLICY-" when the
+// caller forgot to populate targetType. Downstream SIEMs filter on
+// "ASSET-POLICY-MCP" / "ASSET-POLICY-SKILL"; the empty form would
+// silently disappear.
+func TestMergeAssetDecisionDefaultsTargetTypeToASSET(t *testing.T) {
+	decision := config.AssetPolicyDecision{
+		Action:    "block",
+		RawAction: "block",
+		Reason:    "blocked",
+		Source:    "default-deny",
+	}
+	_, _, _, _, findings, _ := mergeAssetDecision(
+		decision, true, "  ", "PreToolUse",
+		"allow", "allow", "NONE", "", nil,
+	)
+	if len(findings) == 0 || findings[len(findings)-1] != "ASSET-POLICY-ASSET" {
+		t.Fatalf("findings = %v, want trailing ASSET-POLICY-ASSET fallback", findings)
+	}
+}

--- a/internal/gateway/claude_code_hook.go
+++ b/internal/gateway/claude_code_hook.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/gateway/notifier"
 	"github.com/defenseclaw/defenseclaw/internal/redaction"
 	"github.com/defenseclaw/defenseclaw/internal/scanner"
 )
@@ -49,8 +49,10 @@ type claudeCodeHookRequest struct {
 	ToolResponse         interface{}            `json:"tool_response,omitempty"`
 	ToolCalls            interface{}            `json:"tool_calls,omitempty"`
 	Prompt               string                 `json:"prompt,omitempty"`
+	ExpansionType        string                 `json:"expansion_type,omitempty"`
 	CommandName          string                 `json:"command_name,omitempty"`
 	CommandArgs          string                 `json:"command_args,omitempty"`
+	CommandSource        string                 `json:"command_source,omitempty"`
 	StopHookActive       bool                   `json:"stop_hook_active,omitempty"`
 	LastAssistantMessage string                 `json:"last_assistant_message,omitempty"`
 	Error                string                 `json:"error,omitempty"`
@@ -170,8 +172,7 @@ func (a *APIServer) evaluateClaudeCodeHook(ctx context.Context, req claudeCodeHo
 	}
 
 	verdict := &ToolInspectVerdict{Action: "allow", Severity: "NONE", Findings: []string{}}
-	assetDecision := config.AssetPolicyDecision{}
-	assetMatched := false
+	var assetDecisions []runtimeAssetDecision
 	switch req.HookEventName {
 	case "SessionStart":
 		if req.ScanComponents || (a.scannerCfg != nil && a.scannerCfg.ConnectorHookConfig("claudecode").ScanOnSessionStart) {
@@ -187,12 +188,25 @@ func (a *APIServer) evaluateClaudeCodeHook(ctx context.Context, req claudeCodeHo
 		}
 	case "UserPromptSubmit", "UserPromptExpansion":
 		verdict = a.inspectMessageContent(&ToolInspectRequest{Tool: "message", Content: claudeCodePromptContent(req), Direction: "prompt"})
+		if req.HookEventName == "UserPromptExpansion" {
+			assetDecisions = append(assetDecisions, a.claudeCodePromptExpansionAssetDecisions(ctx, req)...)
+		}
 	case "PreToolUse", "PermissionRequest", "PermissionDenied":
 		verdict = a.inspectToolPolicy(&ToolInspectRequest{Tool: claudeCodeToolName(req), Args: claudeCodeToolArgs(req), Direction: "tool_call"})
-		assetDecision, assetMatched = a.claudeCodeMCPAssetDecision(ctx, req)
+		if decision, matched := a.claudeCodeMCPAssetDecision(ctx, req); matched {
+			assetDecisions = append(assetDecisions, runtimeAssetDecision{targetType: "mcp", decision: decision})
+		}
+		if decision, matched := a.claudeCodeSkillAssetDecision(ctx, req); matched {
+			assetDecisions = append(assetDecisions, runtimeAssetDecision{targetType: "skill", decision: decision})
+		}
 	case "PostToolUse", "PostToolUseFailure", "PostToolBatch":
 		verdict = a.inspectMessageContent(&ToolInspectRequest{Tool: "message", Content: claudeCodeToolOutput(req), Direction: "tool_result"})
-		assetDecision, assetMatched = a.claudeCodeMCPAssetDecision(ctx, req)
+		if decision, matched := a.claudeCodeMCPAssetDecision(ctx, req); matched {
+			assetDecisions = append(assetDecisions, runtimeAssetDecision{targetType: "mcp", decision: decision})
+		}
+		if decision, matched := a.claudeCodeSkillAssetDecision(ctx, req); matched {
+			assetDecisions = append(assetDecisions, runtimeAssetDecision{targetType: "skill", decision: decision})
+		}
 	case "Stop", "SubagentStop", "SessionEnd":
 		if !req.StopHookActive && a.scannerCfg != nil && a.scannerCfg.ConnectorHookConfig("claudecode").ScanOnStop {
 			verdict = a.scanClaudeCodeChangedFiles(ctx, req)
@@ -222,18 +236,74 @@ func (a *APIServer) evaluateClaudeCodeHook(ctx context.Context, req claudeCodeHo
 	if mode == "action" && rawAction == "confirm" && req.HookEventName != "PreToolUse" {
 		action = "alert"
 	}
-	mergedAction, mergedRawAction, mergedSeverity, mergedReason, mergedFindings, assetWouldBlock := mergeAssetDecision(
-		assetDecision, assetMatched, req.HookEventName, action, rawAction, verdict.Severity, verdict.Reason, verdict.Findings,
-	)
-	action = mergedAction
-	rawAction = mergedRawAction
-	verdict.Severity = mergedSeverity
-	verdict.Reason = mergedReason
-	verdict.Findings = mergedFindings
-	if assetWouldBlock {
-		wouldBlock = true
+	for _, asset := range assetDecisions {
+		mergedAction, mergedRawAction, mergedSeverity, mergedReason, mergedFindings, assetWouldBlock := mergeAssetDecision(
+			asset.decision, true, asset.targetType, req.HookEventName, action, rawAction, verdict.Severity, verdict.Reason, verdict.Findings,
+		)
+		action = mergedAction
+		rawAction = mergedRawAction
+		verdict.Severity = mergedSeverity
+		verdict.Reason = mergedReason
+		verdict.Findings = mergedFindings
+		if assetWouldBlock {
+			wouldBlock = true
+		}
 	}
+	a.dispatchClaudeCodeHookNotification(req, action, rawAction, verdict.Severity, verdict.Reason, wouldBlock)
 	return claudeCodeResponseFor(req, action, rawAction, verdict.Severity, verdict.Reason, verdict.Findings, mode, wouldBlock)
+}
+
+// dispatchClaudeCodeHookNotification fires a user-session OS toast
+// for any non-allow verdict the hook produced. Routing is:
+//
+//   - action=="block"            → notifier.OnBlock
+//   - rawAction=="block" and we did not actually enforce (observe
+//     mode, or the hook event is not enforceable) → OnWouldBlock
+//   - rawAction=="confirm"       → OnApprovalPending
+//
+// All callers receive the same audit-shaped subtitle (source +
+// severity + connector + hook event) so operators can tell the
+// surface from the toast without opening the audit log. The reason
+// is run through redaction.ForSinkReason before display so a
+// regex-match verdict carrying echoed user content (PII, secrets)
+// does not land verbatim on the screen — this matches how proxy.go
+// and hilt.go feed the same dispatcher.
+func (a *APIServer) dispatchClaudeCodeHookNotification(req claudeCodeHookRequest, action, rawAction, severity, reason string, wouldBlock bool) {
+	if a == nil || a.notifier == nil {
+		return
+	}
+	target := strings.TrimSpace(req.ToolName)
+	if target == "" {
+		target = req.HookEventName
+	}
+	safeReason := string(redaction.ForSinkReason(reason))
+	switch {
+	case action == "block":
+		a.notifier.OnBlock(notifier.BlockEvent{
+			Source:    notifier.SourceHook,
+			Target:    target,
+			Reason:    safeReason,
+			Severity:  severity,
+			Connector: "claudecode",
+			Event:     req.HookEventName,
+		})
+	case rawAction == "block" && (wouldBlock || action != "block"):
+		a.notifier.OnWouldBlock(notifier.BlockEvent{
+			Source:    notifier.SourceHook,
+			Target:    target,
+			Reason:    safeReason,
+			Severity:  severity,
+			Connector: "claudecode",
+			Event:     req.HookEventName,
+		})
+	case rawAction == "confirm":
+		a.notifier.OnApprovalPending(notifier.ApprovalEvent{
+			Subject:  fmt.Sprintf("%s (%s)", target, req.HookEventName),
+			Reason:   safeReason,
+			Severity: severity,
+			Source:   notifier.SourceHook,
+		})
+	}
 }
 
 // claudeCodeEnabled returns true when the claude-code hook handler

--- a/internal/gateway/claude_code_hook_test.go
+++ b/internal/gateway/claude_code_hook_test.go
@@ -18,6 +18,7 @@ package gateway
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
@@ -158,6 +159,378 @@ func TestEvaluateClaudeCodeHook_BlocksUnregisteredMCPPreToolUse(t *testing.T) {
 	}
 	if !containsString(resp.Findings, "ASSET-POLICY-MCP") {
 		t.Fatalf("findings=%v, want ASSET-POLICY-MCP", resp.Findings)
+	}
+}
+
+func TestEvaluateClaudeCodeHook_BlocksUnregisteredMCPPermissionRequest(t *testing.T) {
+	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
+	cfg.Guardrail.Mode = "action"
+	cfg.Guardrail.Connector = "claudecode"
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = "action"
+	cfg.AssetPolicy.MCP.RegistryRequired = true
+	cfg.AssetPolicy.MCP.Registry = []config.AssetPolicyRule{{Name: "github"}}
+
+	api := &APIServer{scannerCfg: cfg}
+
+	req := claudeCodeHookRequest{
+		HookEventName: "PermissionRequest",
+		ToolName:      "mcp__rogue__search",
+		ToolInput:     map[string]interface{}{"query": "status"},
+	}
+	resp := api.evaluateClaudeCodeHook(context.Background(), req)
+
+	if resp.Action != "block" || resp.RawAction != "block" {
+		t.Fatalf("action=%q raw=%q, want block/block", resp.Action, resp.RawAction)
+	}
+	if !containsString(resp.Findings, "ASSET-POLICY-MCP") {
+		t.Fatalf("findings=%v, want ASSET-POLICY-MCP", resp.Findings)
+	}
+	hook, ok := resp.ClaudeCodeOutput["hookSpecificOutput"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("claude output = %+v, want hookSpecificOutput", resp.ClaudeCodeOutput)
+	}
+	decision, ok := hook["decision"].(map[string]interface{})
+	if !ok || decision["behavior"] != "deny" {
+		t.Fatalf("permission decision = %+v, want behavior=deny", hook["decision"])
+	}
+	for _, want := range []string{"reason_code=not-in-approved-registry", "asset_type=mcp", "asset_name=rogue", "connector=claudecode", "source=registry-required", "registry_status=not-registered", "registry_configured=true"} {
+		if !strings.Contains(resp.Reason, want) {
+			t.Fatalf("reason %q missing %q", resp.Reason, want)
+		}
+	}
+}
+
+func TestEvaluateClaudeCodeHook_BlocksUnregisteredSkillPreToolUse(t *testing.T) {
+	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
+	cfg.Guardrail.Mode = "action"
+	cfg.Guardrail.Connector = "claudecode"
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = "action"
+	cfg.AssetPolicy.Skill.RegistryRequired = true
+	cfg.AssetPolicy.Skill.Registry = []config.AssetPolicyRule{{Name: "trusted-skill"}}
+
+	api := &APIServer{scannerCfg: cfg}
+
+	req := claudeCodeHookRequest{
+		HookEventName: "PreToolUse",
+		ToolName:      "Skill",
+		ToolInput:     map[string]interface{}{"skill_name": "rogue-skill"},
+	}
+	resp := api.evaluateClaudeCodeHook(context.Background(), req)
+
+	if resp.Action != "block" || resp.RawAction != "block" {
+		t.Fatalf("action=%q raw=%q, want block/block", resp.Action, resp.RawAction)
+	}
+	if resp.Severity != "HIGH" {
+		t.Fatalf("severity=%q, want HIGH", resp.Severity)
+	}
+	if !containsString(resp.Findings, "ASSET-POLICY-SKILL") {
+		t.Fatalf("findings=%v, want ASSET-POLICY-SKILL", resp.Findings)
+	}
+	for _, want := range []string{"reason_code=not-in-approved-registry", "asset_type=skill", "asset_name=rogue-skill", "connector=claudecode", "source=registry-required", "registry_status=not-registered", "registry_configured=true"} {
+		if !strings.Contains(resp.Reason, want) {
+			t.Fatalf("reason %q missing %q", resp.Reason, want)
+		}
+	}
+}
+
+func TestEvaluateClaudeCodeHook_BlocksUnregisteredSkillUserPromptExpansion(t *testing.T) {
+	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
+	cfg.Guardrail.Mode = "action"
+	cfg.Guardrail.Connector = "claudecode"
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = "action"
+	cfg.AssetPolicy.Skill.RegistryRequired = true
+	cfg.AssetPolicy.Skill.Registry = []config.AssetPolicyRule{{Name: "trusted-skill"}}
+
+	api := &APIServer{scannerCfg: cfg}
+
+	req := claudeCodeHookRequest{
+		HookEventName: "UserPromptExpansion",
+		ExpansionType: "slash_command",
+		CommandName:   "rogue-skill",
+		CommandSource: "plugin",
+		Prompt:        "/rogue-skill check",
+	}
+	resp := api.evaluateClaudeCodeHook(context.Background(), req)
+
+	if resp.Action != "block" || resp.RawAction != "block" {
+		t.Fatalf("action=%q raw=%q, want block/block", resp.Action, resp.RawAction)
+	}
+	if !containsString(resp.Findings, "ASSET-POLICY-SKILL") {
+		t.Fatalf("findings=%v, want ASSET-POLICY-SKILL", resp.Findings)
+	}
+	if resp.ClaudeCodeOutput["decision"] != "block" {
+		t.Fatalf("claude output = %+v, want decision=block", resp.ClaudeCodeOutput)
+	}
+	for _, want := range []string{"reason_code=not-in-approved-registry", "asset_type=skill", "asset_name=rogue-skill", "connector=claudecode", "source=registry-required", "registry_status=not-registered", "registry_configured=true", "surface=prompt_expansion"} {
+		if !strings.Contains(resp.Reason, want) {
+			t.Fatalf("reason %q missing %q", resp.Reason, want)
+		}
+	}
+}
+
+func TestEvaluateClaudeCodeHook_BlocksUnregisteredMCPPromptExpansion(t *testing.T) {
+	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
+	cfg.Guardrail.Mode = "action"
+	cfg.Guardrail.Connector = "claudecode"
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = "action"
+	cfg.AssetPolicy.MCP.RegistryRequired = true
+	cfg.AssetPolicy.MCP.Registry = []config.AssetPolicyRule{{Name: "github"}}
+
+	api := &APIServer{scannerCfg: cfg}
+
+	req := claudeCodeHookRequest{
+		HookEventName: "UserPromptExpansion",
+		ExpansionType: "mcp_prompt",
+		CommandName:   "search",
+		CommandSource: "rogue",
+		Prompt:        "/mcp/rogue/search status",
+	}
+	resp := api.evaluateClaudeCodeHook(context.Background(), req)
+
+	if resp.Action != "block" || resp.RawAction != "block" {
+		t.Fatalf("action=%q raw=%q, want block/block", resp.Action, resp.RawAction)
+	}
+	if !containsString(resp.Findings, "ASSET-POLICY-MCP") {
+		t.Fatalf("findings=%v, want ASSET-POLICY-MCP", resp.Findings)
+	}
+	if resp.ClaudeCodeOutput["decision"] != "block" {
+		t.Fatalf("claude output = %+v, want decision=block", resp.ClaudeCodeOutput)
+	}
+	for _, want := range []string{"reason_code=not-in-approved-registry", "asset_type=mcp", "asset_name=rogue", "connector=claudecode", "source=registry-required", "registry_status=not-registered", "registry_configured=true", "surface=prompt_expansion"} {
+		if !strings.Contains(resp.Reason, want) {
+			t.Fatalf("reason %q missing %q", resp.Reason, want)
+		}
+	}
+}
+
+// TestEvaluateClaudeCodeHook_RegistryRequiredEmptyDeniesByDefault pins
+// the new fail-closed default at the hook layer: registry_required=true
+// with an empty registry now blocks unregistered MCPs even when the
+// type policy's Default is "allow". This is the safer default for a
+// security-critical knob — operators who haven't populated the
+// registry should not silently get fall-through-to-allow behavior.
+func TestEvaluateClaudeCodeHook_RegistryRequiredEmptyDeniesByDefault(t *testing.T) {
+	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
+	cfg.Guardrail.Mode = "action"
+	cfg.Guardrail.Connector = "claudecode"
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = "action"
+	cfg.AssetPolicy.MCP.RegistryRequired = true
+	// Default "allow" is intentionally left in place so the test
+	// proves the empty-registry guard kicks in BEFORE Default is
+	// consulted.
+
+	api := &APIServer{scannerCfg: cfg}
+
+	req := claudeCodeHookRequest{
+		HookEventName: "PermissionRequest",
+		ToolName:      "mcp__rogue__search",
+		ToolInput:     map[string]interface{}{"query": "status"},
+	}
+	resp := api.evaluateClaudeCodeHook(context.Background(), req)
+
+	if resp.Action != "block" || resp.RawAction != "block" {
+		t.Fatalf("action=%q raw=%q, want block/block", resp.Action, resp.RawAction)
+	}
+	if !containsString(resp.Findings, "ASSET-POLICY-MCP") {
+		t.Fatalf("findings=%v, want ASSET-POLICY-MCP", resp.Findings)
+	}
+	if !strings.Contains(resp.Reason, "reason_code=registry-required-but-empty") {
+		t.Fatalf("reason %q missing registry-required-but-empty reason_code", resp.Reason)
+	}
+}
+
+// TestEvaluateClaudeCodeHook_RegistryRequiredEmptyAllowOptInPermits pins
+// the explicit opt-in path: setting registry_empty_action="allow" gets
+// the previous (looser) behavior of falling through to Default. This
+// test asserts the knob actually works end-to-end through the hook
+// layer, not just at the config-evaluation layer.
+func TestEvaluateClaudeCodeHook_RegistryRequiredEmptyAllowOptInPermits(t *testing.T) {
+	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
+	cfg.Guardrail.Mode = "action"
+	cfg.Guardrail.Connector = "claudecode"
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = "action"
+	cfg.AssetPolicy.MCP.RegistryRequired = true
+	cfg.AssetPolicy.MCP.RegistryEmptyAction = "allow"
+
+	api := &APIServer{scannerCfg: cfg}
+
+	req := claudeCodeHookRequest{
+		HookEventName: "PermissionRequest",
+		ToolName:      "mcp__rogue__search",
+		ToolInput:     map[string]interface{}{"query": "status"},
+	}
+	resp := api.evaluateClaudeCodeHook(context.Background(), req)
+
+	if resp.Action != "allow" || resp.RawAction != "allow" {
+		t.Fatalf("action=%q raw=%q, want allow/allow", resp.Action, resp.RawAction)
+	}
+	if containsString(resp.Findings, "ASSET-POLICY-MCP") {
+		t.Fatalf("findings=%v, did not expect ASSET-POLICY-MCP", resp.Findings)
+	}
+}
+
+func TestEvaluateClaudeCodeHook_UserPromptExpansionRegistryRequiredEmptyDeniesByDefault(t *testing.T) {
+	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
+	cfg.Guardrail.Mode = "action"
+	cfg.Guardrail.Connector = "claudecode"
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = "action"
+	cfg.AssetPolicy.Skill.RegistryRequired = true
+
+	api := &APIServer{scannerCfg: cfg}
+
+	req := claudeCodeHookRequest{
+		HookEventName: "UserPromptExpansion",
+		ExpansionType: "slash_command",
+		CommandName:   "rogue-skill",
+		CommandSource: "plugin",
+		Prompt:        "/rogue-skill check",
+	}
+	resp := api.evaluateClaudeCodeHook(context.Background(), req)
+
+	if resp.Action != "block" || resp.RawAction != "block" {
+		t.Fatalf("action=%q raw=%q, want block/block", resp.Action, resp.RawAction)
+	}
+	if !containsString(resp.Findings, "ASSET-POLICY-SKILL") {
+		t.Fatalf("findings=%v, want ASSET-POLICY-SKILL", resp.Findings)
+	}
+	if !strings.Contains(resp.Reason, "reason_code=registry-required-but-empty") {
+		t.Fatalf("reason %q missing registry-required-but-empty reason_code", resp.Reason)
+	}
+}
+
+func TestEvaluateClaudeCodeHook_UserPromptExpansionRegistryRequiredEmptyAllowOptInPermits(t *testing.T) {
+	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
+	cfg.Guardrail.Mode = "action"
+	cfg.Guardrail.Connector = "claudecode"
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = "action"
+	cfg.AssetPolicy.Skill.RegistryRequired = true
+	cfg.AssetPolicy.Skill.RegistryEmptyAction = "allow"
+
+	api := &APIServer{scannerCfg: cfg}
+
+	req := claudeCodeHookRequest{
+		HookEventName: "UserPromptExpansion",
+		ExpansionType: "slash_command",
+		CommandName:   "rogue-skill",
+		CommandSource: "plugin",
+		Prompt:        "/rogue-skill check",
+	}
+	resp := api.evaluateClaudeCodeHook(context.Background(), req)
+
+	if resp.Action != "allow" || resp.RawAction != "allow" {
+		t.Fatalf("action=%q raw=%q, want allow/allow", resp.Action, resp.RawAction)
+	}
+	if containsString(resp.Findings, "ASSET-POLICY-SKILL") {
+		t.Fatalf("findings=%v, did not expect ASSET-POLICY-SKILL", resp.Findings)
+	}
+}
+
+// TestEvaluateClaudeCodeHook_SkillCraftedPathStillBlocksWhenUnregistered
+// is a security regression test for the skill-name normalization
+// behavior: an agent passing a path-shaped value can match an approved
+// name only via filepath.Base, but a path that doesn't end at an
+// approved basename must still be blocked. This covers the "raw
+// input != normalized" code path that audit telemetry relies on.
+func TestEvaluateClaudeCodeHook_SkillCraftedPathStillBlocksWhenUnregistered(t *testing.T) {
+	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
+	cfg.Guardrail.Mode = "action"
+	cfg.Guardrail.Connector = "claudecode"
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = "action"
+	cfg.AssetPolicy.Skill.RegistryRequired = true
+	cfg.AssetPolicy.Skill.Registry = []config.AssetPolicyRule{{Name: "trusted-skill"}}
+
+	api := &APIServer{scannerCfg: cfg}
+
+	req := claudeCodeHookRequest{
+		HookEventName: "PermissionRequest",
+		ToolName:      "Skill",
+		ToolInput: map[string]interface{}{
+			// basename collapses to "evil-skill", which is NOT in the registry.
+			"skill_name": "/tmp/attacker/evil-skill/SKILL.md",
+		},
+	}
+	resp := api.evaluateClaudeCodeHook(context.Background(), req)
+
+	if resp.Action != "block" || resp.RawAction != "block" {
+		t.Fatalf("action=%q raw=%q, want block/block", resp.Action, resp.RawAction)
+	}
+	if !containsString(resp.Findings, "ASSET-POLICY-SKILL") {
+		t.Fatalf("findings=%v, want ASSET-POLICY-SKILL", resp.Findings)
+	}
+	if !strings.Contains(resp.Reason, "asset_name=evil-skill") {
+		t.Fatalf("reason %q must surface the normalized basename so audit can see what was matched", resp.Reason)
+	}
+}
+
+// TestEvaluateClaudeCodeHook_SkillCraftedPathMatchesApprovedBasename
+// documents (and therefore pins as a known behavior) the fact that
+// an agent supplying "/tmp/x/<approved>/SKILL.md" allows when
+// "<approved>" is in the registry. This is by design — the registry
+// matches by name, not by path — but the test exists so the next
+// person changing skill name parsing has to opt in or out of this
+// behavior consciously, with full audit context (RawName/SourcePath)
+// reaching telemetry.
+func TestEvaluateClaudeCodeHook_SkillCraftedPathMatchesApprovedBasename(t *testing.T) {
+	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
+	cfg.Guardrail.Mode = "action"
+	cfg.Guardrail.Connector = "claudecode"
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = "action"
+	cfg.AssetPolicy.Skill.RegistryRequired = true
+	cfg.AssetPolicy.Skill.Registry = []config.AssetPolicyRule{{Name: "trusted-skill"}}
+
+	api := &APIServer{scannerCfg: cfg}
+
+	req := claudeCodeHookRequest{
+		HookEventName: "PermissionRequest",
+		ToolName:      "Skill",
+		ToolInput: map[string]interface{}{
+			"skill_name": "/tmp/attacker/trusted-skill/SKILL.md",
+		},
+	}
+	resp := api.evaluateClaudeCodeHook(context.Background(), req)
+
+	if resp.Action != "allow" || resp.RawAction != "allow" {
+		t.Fatalf("action=%q raw=%q, want allow/allow (registry matches by basename — see RawName/SourcePath in telemetry to detect bypass attempts)", resp.Action, resp.RawAction)
+	}
+}
+
+func TestEvaluateClaudeCodeHook_SkillDefaultDenyBlocksWithoutRegistry(t *testing.T) {
+	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
+	cfg.Guardrail.Mode = "action"
+	cfg.Guardrail.Connector = "claudecode"
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = "action"
+	cfg.AssetPolicy.Skill.Default = "deny"
+
+	api := &APIServer{scannerCfg: cfg}
+
+	req := claudeCodeHookRequest{
+		HookEventName: "PermissionRequest",
+		ToolName:      "Skill",
+		ToolInput:     map[string]interface{}{"skill_name": "rogue-skill"},
+	}
+	resp := api.evaluateClaudeCodeHook(context.Background(), req)
+
+	if resp.Action != "block" || resp.RawAction != "block" {
+		t.Fatalf("action=%q raw=%q, want block/block", resp.Action, resp.RawAction)
+	}
+	if !containsString(resp.Findings, "ASSET-POLICY-SKILL") {
+		t.Fatalf("findings=%v, want ASSET-POLICY-SKILL", resp.Findings)
+	}
+	for _, want := range []string{"reason_code=default-deny", "source=default-deny", "asset_type=skill", "asset_name=rogue-skill", "connector=claudecode", "registry_status=unknown", "registry_configured=false"} {
+		if !strings.Contains(resp.Reason, want) {
+			t.Fatalf("reason %q missing %q", resp.Reason, want)
+		}
 	}
 }
 

--- a/internal/gateway/codex_hook.go
+++ b/internal/gateway/codex_hook.go
@@ -30,7 +30,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/gateway/notifier"
 	"github.com/defenseclaw/defenseclaw/internal/redaction"
 	"github.com/defenseclaw/defenseclaw/internal/scanner"
 )
@@ -202,8 +202,7 @@ func (a *APIServer) evaluateCodexHook(ctx context.Context, req codexHookRequest)
 	}
 
 	verdict := &ToolInspectVerdict{Action: "allow", Severity: "NONE", Findings: []string{}}
-	assetDecision := config.AssetPolicyDecision{}
-	assetMatched := false
+	var assetDecisions []runtimeAssetDecision
 	switch req.HookEventName {
 	case "SessionStart":
 		if req.ScanComponents || (a.scannerCfg != nil && a.scannerCfg.ConnectorHookConfig("codex").ScanOnSessionStart) {
@@ -229,14 +228,24 @@ func (a *APIServer) evaluateCodexHook(ctx context.Context, req codexHookRequest)
 			Args:      codexToolArgs(req),
 			Direction: "tool_call",
 		})
-		assetDecision, assetMatched = a.codexMCPAssetDecision(ctx, req)
+		if decision, matched := a.codexMCPAssetDecision(ctx, req); matched {
+			assetDecisions = append(assetDecisions, runtimeAssetDecision{targetType: "mcp", decision: decision})
+		}
+		if decision, matched := a.codexSkillAssetDecision(ctx, req); matched {
+			assetDecisions = append(assetDecisions, runtimeAssetDecision{targetType: "skill", decision: decision})
+		}
 	case "PostToolUse":
 		verdict = a.inspectMessageContent(&ToolInspectRequest{
 			Tool:      "message",
 			Content:   codexToolResponseString(req.ToolResponse),
 			Direction: "tool_result",
 		})
-		assetDecision, assetMatched = a.codexMCPAssetDecision(ctx, req)
+		if decision, matched := a.codexMCPAssetDecision(ctx, req); matched {
+			assetDecisions = append(assetDecisions, runtimeAssetDecision{targetType: "mcp", decision: decision})
+		}
+		if decision, matched := a.codexSkillAssetDecision(ctx, req); matched {
+			assetDecisions = append(assetDecisions, runtimeAssetDecision{targetType: "skill", decision: decision})
+		}
 	case "Stop":
 		if !req.StopHookActive && a.scannerCfg != nil && a.scannerCfg.ConnectorHookConfig("codex").ScanOnStop {
 			verdict = a.scanCodexChangedFiles(ctx, req)
@@ -255,18 +264,62 @@ func (a *APIServer) evaluateCodexHook(ctx context.Context, req codexHookRequest)
 	if mode == "action" && rawAction == "confirm" {
 		action = "alert"
 	}
-	mergedAction, mergedRawAction, mergedSeverity, mergedReason, mergedFindings, assetWouldBlock := mergeAssetDecision(
-		assetDecision, assetMatched, req.HookEventName, action, rawAction, verdict.Severity, verdict.Reason, verdict.Findings,
-	)
-	action = mergedAction
-	rawAction = mergedRawAction
-	verdict.Severity = mergedSeverity
-	verdict.Reason = mergedReason
-	verdict.Findings = mergedFindings
-	if assetWouldBlock {
-		wouldBlock = true
+	for _, asset := range assetDecisions {
+		mergedAction, mergedRawAction, mergedSeverity, mergedReason, mergedFindings, assetWouldBlock := mergeAssetDecision(
+			asset.decision, true, asset.targetType, req.HookEventName, action, rawAction, verdict.Severity, verdict.Reason, verdict.Findings,
+		)
+		action = mergedAction
+		rawAction = mergedRawAction
+		verdict.Severity = mergedSeverity
+		verdict.Reason = mergedReason
+		verdict.Findings = mergedFindings
+		if assetWouldBlock {
+			wouldBlock = true
+		}
 	}
+	a.dispatchCodexHookNotification(req, action, rawAction, verdict.Severity, verdict.Reason, wouldBlock)
 	return codexResponseFor(req.HookEventName, action, rawAction, verdict.Severity, verdict.Reason, verdict.Findings, mode, wouldBlock)
+}
+
+// dispatchCodexHookNotification mirrors the Claude Code path —
+// see dispatchClaudeCodeHookNotification for the routing contract,
+// including the redaction.ForSinkReason scrub on the reason string.
+func (a *APIServer) dispatchCodexHookNotification(req codexHookRequest, action, rawAction, severity, reason string, wouldBlock bool) {
+	if a == nil || a.notifier == nil {
+		return
+	}
+	target := strings.TrimSpace(req.ToolName)
+	if target == "" {
+		target = req.HookEventName
+	}
+	safeReason := string(redaction.ForSinkReason(reason))
+	switch {
+	case action == "block":
+		a.notifier.OnBlock(notifier.BlockEvent{
+			Source:    notifier.SourceHook,
+			Target:    target,
+			Reason:    safeReason,
+			Severity:  severity,
+			Connector: "codex",
+			Event:     req.HookEventName,
+		})
+	case rawAction == "block" && (wouldBlock || action != "block"):
+		a.notifier.OnWouldBlock(notifier.BlockEvent{
+			Source:    notifier.SourceHook,
+			Target:    target,
+			Reason:    safeReason,
+			Severity:  severity,
+			Connector: "codex",
+			Event:     req.HookEventName,
+		})
+	case rawAction == "confirm":
+		a.notifier.OnApprovalPending(notifier.ApprovalEvent{
+			Subject:  fmt.Sprintf("%s (%s)", target, req.HookEventName),
+			Reason:   safeReason,
+			Severity: severity,
+			Source:   notifier.SourceHook,
+		})
+	}
 }
 
 // codexEnabled mirrors claudeCodeEnabled: selecting the codex connector

--- a/internal/gateway/codex_hook_test.go
+++ b/internal/gateway/codex_hook_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
@@ -233,6 +234,166 @@ func TestEvaluateCodexHook_DirectMCPAddBlocked(t *testing.T) {
 	}
 }
 
+func TestEvaluateCodexHook_BlocksUnregisteredMCPPermissionRequest(t *testing.T) {
+	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
+	cfg.Guardrail.Mode = "action"
+	cfg.Guardrail.Connector = "codex"
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = "action"
+	cfg.AssetPolicy.MCP.RegistryRequired = true
+	cfg.AssetPolicy.MCP.Registry = []config.AssetPolicyRule{{Name: "github"}}
+
+	api := &APIServer{scannerCfg: cfg}
+
+	resp := api.evaluateCodexHook(context.Background(), codexHookRequest{
+		HookEventName: "PermissionRequest",
+		ToolName:      "mcp__rogue__search",
+		ToolInput:     map[string]interface{}{"query": "status"},
+	})
+
+	if resp.Action != "block" || resp.RawAction != "block" {
+		t.Fatalf("action=%q raw=%q, want block/block", resp.Action, resp.RawAction)
+	}
+	if !containsString(resp.Findings, "ASSET-POLICY-MCP") {
+		t.Fatalf("findings=%v, want ASSET-POLICY-MCP", resp.Findings)
+	}
+	hook, ok := resp.CodexOutput["hookSpecificOutput"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("codex output = %+v, want hookSpecificOutput", resp.CodexOutput)
+	}
+	decision, ok := hook["decision"].(map[string]interface{})
+	if !ok || decision["behavior"] != "deny" {
+		t.Fatalf("permission decision = %+v, want behavior=deny", hook["decision"])
+	}
+}
+
+func TestEvaluateCodexHook_BlocksUnregisteredSkillPermissionRequest(t *testing.T) {
+	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
+	cfg.Guardrail.Mode = "action"
+	cfg.Guardrail.Connector = "codex"
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = "action"
+	cfg.AssetPolicy.Skill.RegistryRequired = true
+	cfg.AssetPolicy.Skill.Registry = []config.AssetPolicyRule{{Name: "trusted-skill"}}
+
+	api := &APIServer{scannerCfg: cfg}
+
+	resp := api.evaluateCodexHook(context.Background(), codexHookRequest{
+		HookEventName: "PermissionRequest",
+		ToolName:      "Skill",
+		ToolInput:     map[string]interface{}{"skill_name": "rogue-skill"},
+	})
+
+	if resp.Action != "block" || resp.RawAction != "block" {
+		t.Fatalf("action=%q raw=%q, want block/block", resp.Action, resp.RawAction)
+	}
+	if resp.Severity != "HIGH" {
+		t.Fatalf("severity=%q, want HIGH", resp.Severity)
+	}
+	if !containsString(resp.Findings, "ASSET-POLICY-SKILL") {
+		t.Fatalf("findings=%v, want ASSET-POLICY-SKILL", resp.Findings)
+	}
+	if resp.Reason == "" {
+		t.Fatal("expected skill asset-policy block reason")
+	}
+	hook, ok := resp.CodexOutput["hookSpecificOutput"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("codex output = %+v, want hookSpecificOutput", resp.CodexOutput)
+	}
+	decision, ok := hook["decision"].(map[string]interface{})
+	if !ok || decision["behavior"] != "deny" {
+		t.Fatalf("permission decision = %+v, want behavior=deny", hook["decision"])
+	}
+	for _, want := range []string{"reason_code=not-in-approved-registry", "asset_type=skill", "asset_name=rogue-skill", "connector=codex", "source=registry-required", "registry_status=not-registered", "registry_configured=true"} {
+		if !strings.Contains(resp.Reason, want) {
+			t.Fatalf("reason %q missing %q", resp.Reason, want)
+		}
+	}
+}
+
+// TestEvaluateCodexHook_RegistryRequiredEmptyDeniesByDefault is the
+// Codex-side mirror of the Claude Code test. Empty registry +
+// registry_required=true must block under the new fail-closed default,
+// regardless of MCP.Default. Operators must opt into the looser
+// behavior via registry_empty_action="allow".
+func TestEvaluateCodexHook_RegistryRequiredEmptyDeniesByDefault(t *testing.T) {
+	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
+	cfg.Guardrail.Mode = "action"
+	cfg.Guardrail.Connector = "codex"
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = "action"
+	cfg.AssetPolicy.MCP.RegistryRequired = true
+
+	api := &APIServer{scannerCfg: cfg}
+
+	resp := api.evaluateCodexHook(context.Background(), codexHookRequest{
+		HookEventName: "PermissionRequest",
+		ToolName:      "mcp__rogue__search",
+		ToolInput:     map[string]interface{}{"query": "status"},
+	})
+
+	if resp.Action != "block" || resp.RawAction != "block" {
+		t.Fatalf("action=%q raw=%q, want block/block", resp.Action, resp.RawAction)
+	}
+	if !containsString(resp.Findings, "ASSET-POLICY-MCP") {
+		t.Fatalf("findings=%v, want ASSET-POLICY-MCP", resp.Findings)
+	}
+	if !strings.Contains(resp.Reason, "reason_code=registry-required-but-empty") {
+		t.Fatalf("reason %q missing registry-required-but-empty reason_code", resp.Reason)
+	}
+}
+
+func TestEvaluateCodexHook_RegistryRequiredEmptyAllowOptInPermits(t *testing.T) {
+	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
+	cfg.Guardrail.Mode = "action"
+	cfg.Guardrail.Connector = "codex"
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = "action"
+	cfg.AssetPolicy.MCP.RegistryRequired = true
+	cfg.AssetPolicy.MCP.RegistryEmptyAction = "allow"
+
+	api := &APIServer{scannerCfg: cfg}
+
+	resp := api.evaluateCodexHook(context.Background(), codexHookRequest{
+		HookEventName: "PermissionRequest",
+		ToolName:      "mcp__rogue__search",
+		ToolInput:     map[string]interface{}{"query": "status"},
+	})
+
+	if resp.Action != "allow" || resp.RawAction != "allow" {
+		t.Fatalf("action=%q raw=%q, want allow/allow", resp.Action, resp.RawAction)
+	}
+	if containsString(resp.Findings, "ASSET-POLICY-MCP") {
+		t.Fatalf("findings=%v, did not expect ASSET-POLICY-MCP", resp.Findings)
+	}
+}
+
+func TestEvaluateCodexHook_SkillDefaultDenyBlocksWithoutRegistry(t *testing.T) {
+	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
+	cfg.Guardrail.Mode = "action"
+	cfg.Guardrail.Connector = "codex"
+	cfg.AssetPolicy.Enabled = true
+	cfg.AssetPolicy.Mode = "action"
+	cfg.AssetPolicy.Skill.Default = "deny"
+
+	api := &APIServer{scannerCfg: cfg}
+
+	resp := api.evaluateCodexHook(context.Background(), codexHookRequest{
+		HookEventName: "PermissionRequest",
+		ToolName:      "Skill",
+		ToolInput:     map[string]interface{}{"skill_name": "rogue-skill"},
+	})
+
+	if resp.Action != "block" || resp.RawAction != "block" {
+		t.Fatalf("action=%q raw=%q, want block/block", resp.Action, resp.RawAction)
+	}
+	for _, want := range []string{"reason_code=default-deny", "source=default-deny", "registry_status=unknown", "registry_configured=false"} {
+		if !strings.Contains(resp.Reason, want) {
+			t.Fatalf("reason %q missing %q", resp.Reason, want)
+		}
+	}
+}
+
 func TestEvaluateCodexHook_ObserveAssetPolicyWouldBlock(t *testing.T) {
 	cfg := &config.Config{AssetPolicy: config.DefaultAssetPolicy()}
 	cfg.Guardrail.Mode = "action"
@@ -348,6 +509,7 @@ func TestMergeAssetDecision_ObserveDoesNotDowngradeExistingBlock(t *testing.T) {
 	action, rawAction, severity, reason, findings, wouldBlock := mergeAssetDecision(
 		decision,
 		true,
+		"mcp",
 		"PreToolUse",
 		"block",
 		"block",

--- a/internal/gateway/connector/claudecode.go
+++ b/internal/gateway/connector/claudecode.go
@@ -710,18 +710,6 @@ func (c *ClaudeCodeConnector) patchClaudeCodeOtelEnv(opts SetupOpts) error {
 	})
 }
 
-// isClaudeCodeOtelKey reports whether an env-var name belongs to the
-// OTel-related set this connector manages. Used both for backup-time
-// filtering and for Teardown stripping.
-func isClaudeCodeOtelKey(name string) bool {
-	for _, k := range claudeCodeOtelEnvKeys {
-		if name == k {
-			return true
-		}
-	}
-	return false
-}
-
 func claudeCodeOtelValueLooksManaged(key string, value interface{}, managed string) bool {
 	got, _ := value.(string)
 	if got == "" {

--- a/internal/gateway/connector/codex.go
+++ b/internal/gateway/connector/codex.go
@@ -17,7 +17,9 @@
 package connector
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -563,10 +565,10 @@ func (c *CodexConnector) cleanupLegacyEnvFiles(opts SetupOpts) {
 // lmstudio, etc.). To guarantee every model provider flows through
 // DefenseClaw, rewrite each [model_providers.*].base_url to the proxy.
 //
-// Hooks are loaded from a sibling hooks.json referenced by
-// config.toml's top-level `hooks` key. The feature flag
-// features.codex_hooks must be true for hooks to actually run — that
-// flag defaults to off.
+// Hooks are loaded from config.toml's inline [hooks] table. The
+// feature flag [features].hooks enables the hook engine; older
+// [features].codex_hooks entries are deprecated by Codex and should be
+// removed so the TUI does not warn on startup.
 
 // CodexConfigPathOverride allows tests to redirect the config path.
 var CodexConfigPathOverride string
@@ -660,9 +662,18 @@ type codexConfigBackup struct {
 	// holds the inline HookEventsToml struct when present.
 	HadHooksKey   bool            `json:"had_hooks_key"`
 	OriginalHooks json.RawMessage `json:"original_hooks,omitempty"`
-	// AddedCodexHooksFlag is true if we flipped features.codex_hooks on
-	// during Setup. Teardown only clears the flag if we were the ones
-	// who set it.
+	// AddedCodexHooksFlag is a legacy backup field name. It now tracks
+	// whether Setup flipped [features].hooks on; Teardown only clears
+	// the flag if we were the ones who set it.
+	//
+	// IMPORTANT: the JSON tag must remain "added_codex_hooks_flag"
+	// for on-disk backwards compatibility with previously written
+	// codex.json backups. Renaming the Go field is fine; renaming
+	// the tag would silently lose the flag for every existing
+	// install at upgrade time, and Teardown would then refuse to
+	// strip the [features].hooks/codex_hooks block we added — leaving
+	// hook fan-out enabled even after the operator removed
+	// DefenseClaw.
 	AddedCodexHooksFlag bool `json:"added_codex_hooks_flag"`
 
 	// HadOtelBlock / OriginalOtel back up the operator's pristine
@@ -712,6 +723,7 @@ var codexHookGroups = []struct {
 	{"SessionStart", "startup|resume|clear", 30},
 	{"UserPromptSubmit", "", 30},
 	{"PreToolUse", "*", 30},
+	{"PermissionRequest", "*", 30},
 	{"PostToolUse", "*", 30},
 	{"Stop", "", 90},
 }
@@ -965,22 +977,24 @@ func (c *CodexConnector) patchCodexConfig(opts SetupOpts, hookScript string) err
 	// passing a string triggers a TOML parse error at codex startup.
 	// Always installed, regardless of enforcement mode: hooks are the
 	// entry point for tool-call telemetry into /api/v1/codex/hook
-	// (UserPromptSubmit, PreToolUse, PostToolUse, PermissionRequest,
-	// Stop). In observability mode the hook handler logs but never
+	// (SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest,
+	// PostToolUse, Stop).
+	// In observability mode the hook handler logs but never
 	// blocks; in enforcement mode it can also block based on the
 	// subprocess sandbox policy.
-	cfg["hooks"] = buildCodexHooksTable(hookScript)
+	cfg["hooks"] = buildCodexHooksTable(configPath, hookScript)
 
 	features, _ := cfg["features"].(map[string]interface{})
 	if features == nil {
 		features = map[string]interface{}{}
 	}
-	if v, ok := features["codex_hooks"].(bool); !ok || !v {
+	if v, ok := features["hooks"].(bool); !ok || !v {
 		if !backupExists {
 			backup.AddedCodexHooksFlag = true
 		}
 	}
-	features["codex_hooks"] = true
+	features["hooks"] = true
+	delete(features, "codex_hooks")
 	cfg["features"] = features
 
 	// Native OTel exporter — runs on every install regardless of
@@ -1080,8 +1094,10 @@ func codexActiveProviderFromConfig(cfg map[string]interface{}) string {
 // The generated hook script decides fail-open vs fail-closed from
 // SetupOpts: observability-only installs allow the tool when the
 // gateway is unavailable, while enforcement installs can block.
-func buildCodexHooksTable(hookScript string) map[string]interface{} {
+func buildCodexHooksTable(configPath, hookScript string) map[string]interface{} {
 	out := map[string]interface{}{}
+	state := map[string]interface{}{}
+	keySource := codexHookStateKeySource(configPath)
 	for _, group := range codexHookGroups {
 		matcherGroup := map[string]interface{}{
 			"hooks": []interface{}{
@@ -1096,8 +1112,109 @@ func buildCodexHooksTable(hookScript string) map[string]interface{} {
 			matcherGroup["matcher"] = group.matcher
 		}
 		out[group.eventType] = []interface{}{matcherGroup}
+		eventKey := codexHookEventKeyLabel(group.eventType)
+		state[codexHookStateKey(keySource, eventKey, 0, 0)] = map[string]interface{}{
+			"trusted_hash": codexCommandHookHash(eventKey, group.matcher, hookScript, group.timeout),
+		}
 	}
+	out["state"] = state
 	return out
+}
+
+func codexHookEventKeyLabel(eventType string) string {
+	switch eventType {
+	case "PreToolUse":
+		return "pre_tool_use"
+	case "PermissionRequest":
+		return "permission_request"
+	case "PostToolUse":
+		return "post_tool_use"
+	case "PreCompact":
+		return "pre_compact"
+	case "PostCompact":
+		return "post_compact"
+	case "SessionStart":
+		return "session_start"
+	case "UserPromptSubmit":
+		return "user_prompt_submit"
+	case "Stop":
+		return "stop"
+	default:
+		return eventType
+	}
+}
+
+func codexHookStateKeySource(configPath string) string {
+	abs, err := filepath.Abs(configPath)
+	if err != nil {
+		return configPath
+	}
+	return abs
+}
+
+func codexHookStateKey(keySource, eventKey string, groupIndex, handlerIndex int) string {
+	return fmt.Sprintf("%s:%s:%d:%d", keySource, eventKey, groupIndex, handlerIndex)
+}
+
+// codexCommandHookHash produces the value Codex stores under
+// hooks.state[<key>].trusted_hash to suppress the "DefenseClaw inserted
+// a hook, do you trust it?" prompt on Codex startup.
+//
+// SECURITY MODEL — this is NOT tamper detection.
+//
+// Anyone with write access to ~/.codex/config.toml can recompute a
+// matching hash for arbitrary hook content using the same algorithm,
+// because the inputs are written next to the output. The "sha256:"
+// prefix is a Codex format requirement, not an integrity claim. The
+// hash exists solely so DefenseClaw's teardown logic
+// (removeOwnedCodexHookState) can recognize the entries it inserted
+// and leave operator-edited entries alone — that is, it is a
+// self-fingerprint for ownership, not a security boundary.
+//
+// Determinism note: codexCanonicalJSON relies on encoding/json's
+// alphabetical key ordering for map[string]interface{} (stable since
+// Go 1.12). Tests pin a known hash to catch any future drift in the
+// canonical form, which would otherwise re-prompt every existing
+// installation on the next Codex launch.
+func codexCommandHookHash(eventKey, matcher, command string, timeout int) string {
+	hook := map[string]interface{}{
+		"async":   false,
+		"command": command,
+		"timeout": timeout,
+		"type":    "command",
+	}
+	identity := map[string]interface{}{
+		"event_name": eventKey,
+		"hooks":      []interface{}{hook},
+	}
+	if matcher != "" {
+		identity["matcher"] = matcher
+	}
+	return codexVersionForTOML(identity)
+}
+
+// codexVersionForTOML returns the "sha256:<hex>" fingerprint Codex
+// expects in hooks.state.<key>.trusted_hash. See codexCommandHookHash
+// for why this is a self-recognition fingerprint and not an integrity
+// check.
+func codexVersionForTOML(v interface{}) string {
+	serialized := codexCanonicalJSON(v)
+	hash := sha256.Sum256(serialized)
+	return fmt.Sprintf("sha256:%x", hash[:])
+}
+
+// codexCanonicalJSON serializes v with stable map-key ordering. This
+// determinism is required so that codexCommandHookHash produces the
+// same value across runs and across goroutines for the same logical
+// hook identity.
+func codexCanonicalJSON(v interface{}) []byte {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return []byte("null")
+	}
+	return bytes.TrimSuffix(buf.Bytes(), []byte("\n"))
 }
 
 // buildCodexOtelBlock returns the [otel] table that points codex's
@@ -1341,10 +1458,13 @@ func (c *CodexConnector) restoreCodexConfig(opts SetupOpts) {
 	}
 
 	removedOwnedHooks := false
-	hooksRemain := false
+	hookEventsRemain := false
 	if hooks, ok := cfg["hooks"].(map[string]interface{}); ok {
 		hooksDir := filepath.Join(opts.DataDir, "hooks")
 		for eventType, val := range hooks {
+			if eventType == "state" {
+				continue
+			}
 			before := codexHookEntryCount(val)
 			remaining := removeOwnedHooks(val, hooksDir)
 			if before != len(remaining) {
@@ -1354,20 +1474,25 @@ func (c *CodexConnector) restoreCodexConfig(opts SetupOpts) {
 				delete(hooks, eventType)
 			} else {
 				hooks[eventType] = remaining
+				hookEventsRemain = true
 			}
+		}
+		hookScript := filepath.Join(opts.DataDir, "hooks", "codex-hook.sh")
+		if removeOwnedCodexHookState(hooks, configPath, hookScript) {
+			removedOwnedHooks = true
 		}
 		if len(hooks) == 0 {
 			delete(cfg, "hooks")
 		} else {
-			hooksRemain = true
 			cfg["hooks"] = hooks
 		}
 	} else if !backup.HadHooksKey {
 		delete(cfg, "hooks")
 	}
 
-	if backup.AddedCodexHooksFlag || (removedOwnedHooks && !hooksRemain) {
+	if backup.AddedCodexHooksFlag || (removedOwnedHooks && !hookEventsRemain) {
 		if features, ok := cfg["features"].(map[string]interface{}); ok {
+			delete(features, "hooks")
 			delete(features, "codex_hooks")
 			if len(features) == 0 {
 				delete(cfg, "features")
@@ -1438,6 +1563,34 @@ func codexHookEntryCount(v interface{}) int {
 		return 0
 	}
 	return len(list)
+}
+
+func removeOwnedCodexHookState(hooks map[string]interface{}, configPath, hookScript string) bool {
+	state, ok := hooks["state"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	removed := false
+	keySource := codexHookStateKeySource(configPath)
+	for _, group := range codexHookGroups {
+		eventKey := codexHookEventKeyLabel(group.eventType)
+		key := codexHookStateKey(keySource, eventKey, 0, 0)
+		entry, ok := state[key].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		expectedHash := codexCommandHookHash(eventKey, group.matcher, hookScript, group.timeout)
+		if trustedHash, _ := entry["trusted_hash"].(string); trustedHash == expectedHash {
+			delete(state, key)
+			removed = true
+		}
+	}
+	if len(state) == 0 {
+		delete(hooks, "state")
+	} else {
+		hooks["state"] = state
+	}
+	return removed
 }
 
 func codexValueMatches(a, b interface{}) bool {

--- a/internal/gateway/connector/connector_test.go
+++ b/internal/gateway/connector/connector_test.go
@@ -1785,7 +1785,7 @@ env_key = "OPENAI_API_KEY"
 
 // TestCodex_Setup_RegistersHooksInline verifies the Codex connector
 // writes an inline [hooks] HookEventsToml struct into config.toml
-// covering all five Codex events and pointing at the generated
+// covering all six Codex events and pointing at the generated
 // codex-hook.sh. The hooks key is NOT a path to a hooks.json file —
 // that would trigger a TOML parse error at codex startup.
 func TestCodex_Setup_RegistersHooksInline(t *testing.T) {
@@ -1813,9 +1813,9 @@ func TestCodex_Setup_RegistersHooksInline(t *testing.T) {
 	raw, _ := os.ReadFile(configPath)
 	content := string(raw)
 
-	// The [hooks] table must be present with each of the five events
+	// The [hooks] table must be present with each of the six events
 	// listed as sub-tables.
-	for _, evt := range []string{"SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop"} {
+	for _, evt := range []string{"SessionStart", "UserPromptSubmit", "PreToolUse", "PermissionRequest", "PostToolUse", "Stop"} {
 		if !strings.Contains(content, "hooks."+evt) && !strings.Contains(content, "hooks\n"+evt) {
 			// Accept either dotted or nested rendering.
 			if !strings.Contains(content, evt) {
@@ -1839,12 +1839,45 @@ func TestCodex_Setup_RegistersHooksInline(t *testing.T) {
 	if _, isTable := parsed["hooks"].(map[string]interface{}); !isTable {
 		t.Errorf("hooks key is not a table, got %T", parsed["hooks"])
 	}
+	hooks := parsed["hooks"].(map[string]interface{})
+	state, ok := hooks["state"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("hooks.state missing — Codex would ask the user to review DefenseClaw hooks")
+	}
+	hookPath := filepath.Join(dir, "hooks", "codex-hook.sh")
+	for _, tc := range []struct {
+		eventType string
+		eventKey  string
+		matcher   string
+		timeout   int
+	}{
+		{"SessionStart", "session_start", "startup|resume|clear", 30},
+		{"UserPromptSubmit", "user_prompt_submit", "", 30},
+		{"PreToolUse", "pre_tool_use", "*", 30},
+		{"PermissionRequest", "permission_request", "*", 30},
+		{"PostToolUse", "post_tool_use", "*", 30},
+		{"Stop", "stop", "", 90},
+	} {
+		key := fmt.Sprintf("%s:%s:0:0", configPath, tc.eventKey)
+		entry, ok := state[key].(map[string]interface{})
+		if !ok {
+			t.Fatalf("hooks.state missing trusted entry for %s (%s); state=%v", tc.eventType, key, state)
+		}
+		gotHash, _ := entry["trusted_hash"].(string)
+		wantHash := codexCommandHookHash(tc.eventKey, tc.matcher, hookPath, tc.timeout)
+		if gotHash != wantHash {
+			t.Errorf("trusted_hash for %s = %q, want %q", tc.eventType, gotHash, wantHash)
+		}
+		if _, ok := entry["enabled"]; ok {
+			t.Errorf("trusted state for %s should not force enabled; got %v", tc.eventType, entry)
+		}
+	}
 }
 
 // TestCodex_Setup_DefaultObservability_NoProxyRewrite is the headline
 // regression test for the codex/claude-code observability-only
 // architecture. With CodexEnforcement=false (the default), Setup must
-// install the [hooks] table and features.codex_hooks=true (so the
+// install the [hooks] table and features.hooks=true (so the
 // codex-hook.sh script fires for tool-call telemetry) but must NOT:
 //   - rewrite cfg["openai_base_url"] to the proxy URL (codex talks
 //     directly to its native upstream — api.openai.com or
@@ -1948,8 +1981,11 @@ env_key = "OPENROUTER_API_KEY"
 		t.Error("hooks.PostToolUse missing — tool-result telemetry lost")
 	}
 	features, _ := parsed["features"].(map[string]interface{})
-	if v, _ := features["codex_hooks"].(bool); !v {
-		t.Errorf("features.codex_hooks must be true in observability mode (hooks would otherwise be ignored by codex), got=%v", features)
+	if v, _ := features["hooks"].(bool); !v {
+		t.Errorf("features.hooks must be true in observability mode (hooks would otherwise be ignored by codex), got=%v", features)
+	}
+	if _, legacy := features["codex_hooks"]; legacy {
+		t.Errorf("deprecated features.codex_hooks should be removed to avoid Codex startup warnings, got=%v", features)
 	}
 
 	// Subprocess sandbox JSON must NOT be created — that's
@@ -2221,7 +2257,7 @@ func TestCodex_Setup_WiresNotifyBridge(t *testing.T) {
 }
 
 // TestCodex_Setup_EnablesHooksFeature confirms the connector writes
-// features.codex_hooks = true into config.toml. Without this, Codex
+// features.hooks = true into config.toml. Without this, Codex
 // ignores any registered hooks because the feature gate defaults to
 // off.
 func TestCodex_Setup_EnablesHooksFeature(t *testing.T) {
@@ -2239,9 +2275,167 @@ func TestCodex_Setup_EnablesHooksFeature(t *testing.T) {
 	}
 
 	data, _ := os.ReadFile(configPath)
-	content := string(data)
-	if !strings.Contains(content, "codex_hooks") {
-		t.Errorf("config.toml missing codex_hooks feature flag\nfile:\n%s", content)
+	var parsed map[string]interface{}
+	if err := toml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid TOML after Setup: %v", err)
+	}
+	features, _ := parsed["features"].(map[string]interface{})
+	if v, _ := features["hooks"].(bool); !v {
+		t.Errorf("config.toml missing hooks feature flag; features=%v\nfile:\n%s", features, data)
+	}
+	if _, legacy := features["codex_hooks"]; legacy {
+		t.Errorf("config.toml still contains deprecated codex_hooks feature flag\nfile:\n%s", data)
+	}
+}
+
+func TestCodexCommandHookHashMatchesCodexCanonicalIdentity(t *testing.T) {
+	got := codexCommandHookHash("pre_tool_use", "*", "/tmp/hook.sh", 30)
+	want := "sha256:73ec4bb1ffa348f02fcca6c5c0725cc825ba47aa298a7e72eab4e47856cbadbc"
+	if got != want {
+		t.Fatalf("codexCommandHookHash = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveOwnedCodexHookStatePreservesUserReplacementTrust(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	hookPath := filepath.Join(dir, "hooks", "codex-hook.sh")
+	key := codexHookStateKey(codexHookStateKeySource(configPath), "pre_tool_use", 0, 0)
+	otherKey := codexHookStateKey(codexHookStateKeySource(configPath), "post_tool_use", 2, 0)
+
+	state := map[string]interface{}{
+		key: map[string]interface{}{
+			"trusted_hash": "sha256:user-replacement",
+		},
+		otherKey: map[string]interface{}{
+			"trusted_hash": "sha256:unrelated",
+		},
+	}
+	hooks := map[string]interface{}{"state": state}
+	if removeOwnedCodexHookState(hooks, configPath, hookPath) {
+		t.Fatalf("user replacement trust state was removed: %v", hooks)
+	}
+	if _, ok := state[key]; !ok {
+		t.Fatalf("user replacement trust entry missing: %v", state)
+	}
+
+	state[key] = map[string]interface{}{
+		"trusted_hash": codexCommandHookHash("pre_tool_use", "*", hookPath, 30),
+	}
+	if !removeOwnedCodexHookState(hooks, configPath, hookPath) {
+		t.Fatal("DefenseClaw-owned trust state was not removed")
+	}
+	if _, ok := state[key]; ok {
+		t.Fatalf("DefenseClaw-owned trust entry still present: %v", state)
+	}
+	if _, ok := state[otherKey]; !ok {
+		t.Fatalf("unrelated trust entry removed: %v", state)
+	}
+}
+
+// TestCodex_SetupTeardownRoundtripPreservesUserModifiedHookTrust is
+// the end-to-end pin for the "user replaced our hook script with their
+// own" workflow: after Setup, the operator may swap the hook command
+// out (or change the timeout/matcher) for any of the events. On
+// Teardown, DefenseClaw must NOT delete those entries because the
+// trusted_hash no longer matches what we wrote. Removing them would
+// silently re-prompt the user to trust their own hooks on next Codex
+// launch — a confusing security UX failure.
+func TestCodex_SetupTeardownRoundtripPreservesUserModifiedHookTrust(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(`model_provider = "openai"
+`), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	CodexConfigPathOverride = configPath
+	t.Cleanup(func() { CodexConfigPathOverride = "" })
+
+	c := NewCodexConnector()
+	opts := SetupOpts{
+		DataDir:   dir,
+		ProxyAddr: "127.0.0.1:4000",
+		APIAddr:   "127.0.0.1:18970",
+		APIToken:  "tok-test",
+	}
+	if err := c.Setup(context.Background(), opts); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// Operator simulates editing config.toml to register their own
+	// PreToolUse hook in place of (or alongside) ours. We model this
+	// by overwriting only the trust-state entry for that event. The
+	// real hook command stays whatever Setup wrote; what matters is
+	// that the trusted_hash diverges from codexCommandHookHash().
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after setup: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := toml.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	hooks, _ := parsed["hooks"].(map[string]interface{})
+	if hooks == nil {
+		t.Fatalf("hooks block missing after Setup; cannot exercise user-modified branch")
+	}
+	state, _ := hooks["state"].(map[string]interface{})
+	if state == nil {
+		t.Fatalf("hooks.state missing after Setup; cannot exercise user-modified branch")
+	}
+	preToolUseKey := codexHookStateKey(codexHookStateKeySource(configPath), "pre_tool_use", 0, 0)
+	if _, ok := state[preToolUseKey]; !ok {
+		t.Fatalf("expected DefenseClaw to install pre_tool_use trust entry at %q; state=%v", preToolUseKey, state)
+	}
+	state[preToolUseKey] = map[string]interface{}{
+		"trusted_hash": "sha256:user-replacement-do-not-touch",
+	}
+	rewritten, err := toml.Marshal(parsed)
+	if err != nil {
+		t.Fatalf("re-marshal config: %v", err)
+	}
+	if err := os.WriteFile(configPath, rewritten, 0o600); err != nil {
+		t.Fatalf("write user-modified config: %v", err)
+	}
+
+	if err := c.Teardown(context.Background(), opts); err != nil {
+		t.Fatalf("teardown: %v", err)
+	}
+
+	postRaw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after teardown: %v", err)
+	}
+	var post map[string]interface{}
+	if err := toml.Unmarshal(postRaw, &post); err != nil {
+		t.Fatalf("unmarshal post-teardown config: %v", err)
+	}
+
+	postHooks, _ := post["hooks"].(map[string]interface{})
+	if postHooks == nil {
+		t.Fatalf("teardown deleted entire hooks block even though user edits remain:\n%s", postRaw)
+	}
+	postState, _ := postHooks["state"].(map[string]interface{})
+	if postState == nil {
+		t.Fatalf("teardown deleted hooks.state even though user edit at %q must be preserved", preToolUseKey)
+	}
+	entry, ok := postState[preToolUseKey].(map[string]interface{})
+	if !ok {
+		t.Fatalf("teardown removed user trust entry at %q; state=%v", preToolUseKey, postState)
+	}
+	if got, _ := entry["trusted_hash"].(string); got != "sha256:user-replacement-do-not-touch" {
+		t.Fatalf("teardown clobbered user trusted_hash: got=%q want=sha256:user-replacement-do-not-touch", got)
+	}
+
+	// Untouched DefenseClaw entries (other events) must be removed,
+	// since their trusted_hash still matches what we wrote — that's
+	// the recognition signal teardown relies on.
+	for _, eventKey := range []string{"session_start", "user_prompt_submit", "permission_request", "post_tool_use", "stop"} {
+		key := codexHookStateKey(codexHookStateKeySource(configPath), eventKey, 0, 0)
+		if _, present := postState[key]; present {
+			t.Errorf("teardown failed to remove DefenseClaw-owned trust entry for %s at %q", eventKey, key)
+		}
 	}
 }
 
@@ -2433,6 +2627,7 @@ func TestCodex_TeardownWithoutBackup_RemovesManagedConfig(t *testing.T) {
 		"codex-hook.sh",
 		"notify-bridge.sh",
 		"codex_hooks",
+		"trusted_hash",
 		"x-defenseclaw-token",
 		"x-defenseclaw-client",
 		"[otel]",
@@ -2457,7 +2652,7 @@ func TestCodex_VerifyCleanDetectsConfigResidue(t *testing.T) {
 		t.Fatalf("write hook: %v", err)
 	}
 	cfg := map[string]interface{}{
-		"hooks": buildCodexHooksTable(hookPath),
+		"hooks": buildCodexHooksTable(configPath, hookPath),
 		"otel":  buildCodexOtelBlock(SetupOpts{APIAddr: "127.0.0.1:18970", APIToken: "tok-test"}),
 		"notify": []interface{}{
 			"bash",
@@ -6090,25 +6285,3 @@ func mustNotExist(t *testing.T, path string) {
 	}
 }
 
-// stringSlicesEqual is the order-sensitive equivalent of
-// reflect.DeepEqual for two []string. We use it (rather than
-// reflect.DeepEqual) when the test's *intent* is to communicate
-// "compare two ordered string slices"; reflect.DeepEqual would
-// work but obscures the contract for readers. Equality requires
-// identical lengths and pairwise element equality at every index.
-//
-// Defined here as a local helper rather than imported from a util
-// package because the connector test suite is the only consumer
-// today, and adding a public helper would invite the test-only
-// helper to leak into production code.
-func stringSlicesEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}

--- a/internal/gateway/connector/connector_test.go
+++ b/internal/gateway/connector/connector_test.go
@@ -6284,4 +6284,3 @@ func mustNotExist(t *testing.T, path string) {
 		t.Fatalf("expected %s to NOT exist, got err=%v", path, err)
 	}
 }
-

--- a/internal/gateway/hilt.go
+++ b/internal/gateway/hilt.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/defenseclaw/defenseclaw/internal/audit"
+	"github.com/defenseclaw/defenseclaw/internal/gateway/notifier"
 	"github.com/defenseclaw/defenseclaw/internal/redaction"
 	"github.com/defenseclaw/defenseclaw/internal/telemetry"
 	"github.com/google/uuid"
@@ -47,9 +48,10 @@ type pendingHILTApproval struct {
 // Connector-native approval surfaces such as Claude Code PreToolUse do not use
 // this manager; they emit the connector's native "ask" decision instead.
 type HILTApprovalManager struct {
-	client *Client
-	logger *audit.Logger
-	otel   *telemetry.Provider
+	client   *Client
+	logger   *audit.Logger
+	otel     *telemetry.Provider
+	notifier *notifier.Dispatcher
 
 	mu             sync.Mutex
 	pending        map[string]*pendingHILTApproval
@@ -65,6 +67,16 @@ func NewHILTApprovalManager(client *Client, logger *audit.Logger, otel *telemetr
 		pending:        make(map[string]*pendingHILTApproval),
 		activeSessions: make(map[string]time.Time),
 	}
+}
+
+// SetNotifier wires the user-session OS notifier dispatcher used to
+// surface "approval needed" toasts when a HILT prompt is dispatched.
+// Safe to call with nil.
+func (m *HILTApprovalManager) SetNotifier(n *notifier.Dispatcher) {
+	if m == nil {
+		return
+	}
+	m.notifier = n
 }
 
 func (m *HILTApprovalManager) Request(ctx context.Context, sessionID, subject, severity, reason string, timeout time.Duration) (bool, string, error) {
@@ -118,6 +130,26 @@ func (m *HILTApprovalManager) Request(ctx context.Context, sessionID, subject, s
 		return false, hiltStatusUnsupported, fmt.Errorf("hilt approval unavailable: %s", details)
 	}
 	m.record(ctx, hiltStatusRequested, subject, severity, safeReason)
+	// Fire a user-session toast as soon as the chat-side prompt has
+	// been delivered. This is the single chokepoint covering every
+	// HILT path — guardrail confirm verdicts, OpenClaw inspect
+	// confirm, and exec approval prompts all funnel through here —
+	// so a per-call dispatcher injection at each surface is not
+	// needed. The notification is purely informational ("reply in
+	// chat"); approve/deny still happens via the chat session.
+	if m.notifier != nil {
+		m.notifier.OnApprovalPending(notifier.ApprovalEvent{
+			Subject:  subject,
+			Reason:   safeReason,
+			Severity: severity,
+			// Source is left empty because HILT does not know which
+			// upstream surface emitted the confirm verdict — the
+			// dispatcher's allowSource lets unspecified sources
+			// through under the master Enabled gate, which keeps
+			// approval coverage independent of the per-source
+			// filter that operators use to silence chatty blocks.
+		})
+	}
 
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()

--- a/internal/gateway/notifier/notifier.go
+++ b/internal/gateway/notifier/notifier.go
@@ -1,0 +1,460 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package notifier centralizes user-session OS notification dispatch
+// for hook blocks, guardrail blocks, asset-policy denials, and HITL
+// approval requests.
+//
+// All block-decision sites in the gateway (claude_code_hook,
+// codex_hook, GuardrailProxy, asset_policy_runtime,
+// HILTApprovalManager) call OnBlock / OnWouldBlock / OnApprovalPending
+// instead of dialing the OS notification API directly. The Dispatcher
+// applies four layers of filtering before anything is delivered:
+//
+//  1. Master switch (config.NotificationsConfig.Enabled).
+//  2. Per-category gate (BlockEnforced / BlockWouldBlock / HITLApproval).
+//  3. Per-source gate (Sources.Hook / Sources.Guardrail / Sources.AssetPolicy).
+//  4. Dedup window + global rate limit.
+//
+// Delivery itself is delegated to internal/notify (osascript on
+// darwin, notify-send on linux) and runs in a goroutine so request
+// latency on the block path is unaffected by the OS call. Failures
+// are deliberately swallowed: the audit/webhook/system-message
+// channels are the authoritative records of every block, and a
+// missing toast is never a security event.
+package notifier
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/notify"
+)
+
+// Source identifies which subsystem decided the block / approval.
+// Used by Sources gating in NotificationsConfig and rendered in the
+// notification subtitle so operators can tell at a glance which
+// surface tripped.
+type Source string
+
+const (
+	SourceHook        Source = "hook"
+	SourceGuardrail   Source = "guardrail"
+	SourceAssetPolicy Source = "asset_policy"
+)
+
+// Category labels the kind of event for per-category gating and
+// dedup keying.
+type Category string
+
+const (
+	CategoryBlock      Category = "block"
+	CategoryWouldBlock Category = "would_block"
+	CategoryApproval   Category = "approval"
+)
+
+// BlockEvent describes a single block / would-block decision.
+//
+// Target is the most user-meaningful identifier available for the
+// blocked thing — typically a tool name (PreToolUse), the model
+// name (LLM proxy block), or a typed asset id like "mcp:github" /
+// "skill:my-helper". Connector and Event are optional context that
+// flows into the audit-friendly subtitle but never appears in the
+// dedup hash (so the same rule fired across many sessions still
+// collapses to one notification per dedup window).
+type BlockEvent struct {
+	Source    Source
+	Target    string
+	Reason    string
+	Severity  string
+	Connector string
+	Event     string
+}
+
+// ApprovalEvent describes a HITL/confirm prompt that is now waiting
+// for the user. The user-visible Subject reads naturally in a toast
+// title ("Approval needed: LLM tool call for gpt-4o").
+type ApprovalEvent struct {
+	Subject  string
+	Reason   string
+	Severity string
+	Source   Source
+}
+
+// Dispatcher is the single fan-in point for OS notifications.
+// Construct one per gateway with New(cfg) and pass it to every block
+// emission site. Concurrency-safe — methods can be called from any
+// number of request-handling goroutines.
+type Dispatcher struct {
+	cfg config.NotificationsConfig
+
+	// sender delivers a Notification to the OS. Tests inject a fake
+	// to assert what would have been shown without touching a real
+	// display server. Production wiring uses notify.SendNotification.
+	sender func(notify.Notification) error
+
+	// nowFn lets tests advance time deterministically. Production
+	// wiring uses time.Now.
+	nowFn func() time.Time
+
+	mu              sync.Mutex
+	seen            map[string]time.Time
+	bucketWindowEnd time.Time
+	bucketRemaining int
+	suppressedInWin int
+	rollupAnnounced bool
+	lastSweep       time.Time
+}
+
+// New constructs a Dispatcher wired to the production OS notifier.
+// The dispatcher is safe to keep enabled even when notifications are
+// disabled in cfg — the master-switch check is the cheapest path and
+// short-circuits before any allocation or locking.
+func New(cfg config.NotificationsConfig) *Dispatcher {
+	return NewWithSender(cfg, notify.SendNotification)
+}
+
+// NewWithSender allows tests (and any future non-OS sink) to inject
+// the delivery channel. Pass nil to fall back to the production
+// notify.SendNotification path.
+func NewWithSender(cfg config.NotificationsConfig, sender func(notify.Notification) error) *Dispatcher {
+	if sender == nil {
+		sender = notify.SendNotification
+	}
+	return &Dispatcher{
+		cfg:    cfg,
+		sender: sender,
+		nowFn:  time.Now,
+		seen:   make(map[string]time.Time),
+	}
+}
+
+// SetClock replaces the time source. Tests use this to make dedup +
+// rate-limit windows deterministic.
+func (d *Dispatcher) SetClock(now func() time.Time) {
+	if d == nil || now == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.nowFn = now
+}
+
+// OnBlock fires for an enforced (mode=action, action=block) decision.
+// Returns silently when the dispatcher is nil or notifications are
+// disabled — callers do not need to guard at the call site.
+func (d *Dispatcher) OnBlock(ev BlockEvent) {
+	if d == nil || !d.cfg.Enabled || !d.cfg.BlockEnforced {
+		return
+	}
+	if !d.allowSource(ev.Source) {
+		return
+	}
+	n := blockNotification(ev, false)
+	d.dispatch(CategoryBlock, ev.Source, ev.Target, ev.Reason, n)
+}
+
+// OnWouldBlock fires for an observe-mode "would have blocked"
+// decision. Silenced when BlockWouldBlock is off in config so
+// operators tuning a strict policy in observe mode can opt out
+// without disabling the rest of the dispatcher.
+func (d *Dispatcher) OnWouldBlock(ev BlockEvent) {
+	if d == nil || !d.cfg.Enabled || !d.cfg.BlockWouldBlock {
+		return
+	}
+	if !d.allowSource(ev.Source) {
+		return
+	}
+	n := blockNotification(ev, true)
+	d.dispatch(CategoryWouldBlock, ev.Source, ev.Target, ev.Reason, n)
+}
+
+// OnApprovalPending fires when a HITL/confirm prompt has been issued
+// to the user via the chat surface. The notification is purely
+// informational ("reply in chat") — it does not provide
+// approve/deny buttons; that requires a bundled helper app that is
+// out of scope for v1.
+func (d *Dispatcher) OnApprovalPending(ev ApprovalEvent) {
+	if d == nil || !d.cfg.Enabled || !d.cfg.HITLApproval {
+		return
+	}
+	if !d.allowSource(ev.Source) {
+		return
+	}
+	n := approvalNotification(ev)
+	d.dispatch(CategoryApproval, ev.Source, ev.Subject, ev.Reason, n)
+}
+
+func (d *Dispatcher) allowSource(s Source) bool {
+	switch s {
+	case SourceHook:
+		return d.cfg.Sources.Hook
+	case SourceGuardrail:
+		return d.cfg.Sources.Guardrail
+	case SourceAssetPolicy:
+		return d.cfg.Sources.AssetPolicy
+	case "":
+		// Unspecified source — let it through. The dispatcher is
+		// behind the master Enabled gate already, and silent-drop
+		// for unrouted events would mask wiring bugs.
+		return true
+	default:
+		return true
+	}
+}
+
+// dispatch is the choke point that applies dedup + rate limit and
+// hands off to the goroutine sender. All counter / map mutation
+// happens under d.mu; the actual sender.Run is dispatched outside
+// the lock so a slow osascript invocation cannot serialize block
+// requests.
+func (d *Dispatcher) dispatch(cat Category, src Source, target, reason string, n notify.Notification) {
+	if d == nil || d.sender == nil {
+		return
+	}
+	now := d.now()
+	key := dedupKey(cat, src, target, reason)
+	dedupWindow := d.cfg.EffectiveDedupWindow()
+	maxPerMin := d.cfg.EffectiveMaxPerMinute()
+
+	var toSend []notify.Notification
+
+	d.mu.Lock()
+	d.sweepLocked(now, dedupWindow)
+	if last, ok := d.seen[key]; ok && now.Sub(last) < dedupWindow {
+		d.mu.Unlock()
+		return
+	}
+	d.seen[key] = now
+
+	d.advanceBucketLocked(now, maxPerMin)
+	if d.bucketRemaining <= 0 {
+		d.suppressedInWin++
+		// Allow exactly one rollup per minute window so operators
+		// see "the dispatcher is throttling" without flooding.
+		if !d.rollupAnnounced && d.suppressedInWin == 1 {
+			// Reserve a slot for the rollup at window roll. We do not
+			// emit it now — a real notification might still be more
+			// useful than a count — but the announce flag prevents
+			// double rollups inside the same minute.
+			d.rollupAnnounced = true
+		}
+		d.mu.Unlock()
+		return
+	}
+	d.bucketRemaining--
+	toSend = append(toSend, n)
+	d.mu.Unlock()
+
+	for _, item := range toSend {
+		go d.send(item)
+	}
+}
+
+// sweepLocked drops dedup entries older than the window so the
+// map cannot grow without bound under sustained traffic.
+// Called inside dispatch under d.mu.
+func (d *Dispatcher) sweepLocked(now time.Time, window time.Duration) {
+	if now.Sub(d.lastSweep) < window {
+		return
+	}
+	d.lastSweep = now
+	cutoff := now.Add(-window)
+	for k, t := range d.seen {
+		if t.Before(cutoff) {
+			delete(d.seen, k)
+		}
+	}
+}
+
+// advanceBucketLocked rolls the per-minute token bucket forward and
+// emits a single rollup notification when the previous window saw
+// any suppressed events. Called inside dispatch under d.mu.
+func (d *Dispatcher) advanceBucketLocked(now time.Time, maxPerMin int) {
+	if maxPerMin <= 0 {
+		// Defensive: EffectiveMaxPerMinute already enforces a floor,
+		// but a hostile config or a future change could regress this.
+		// Treat zero as "unlimited" — never suppress.
+		d.bucketRemaining = 1<<31 - 1
+		return
+	}
+	if d.bucketWindowEnd.IsZero() || !now.Before(d.bucketWindowEnd) {
+		// New minute window. If we suppressed anything in the
+		// previous window, schedule a rollup notification on the
+		// caller side via toSend; we do this by piggy-backing in
+		// the calling dispatch — but emitting here keeps the
+		// rollup decoupled from the caller's notification.
+		if d.suppressedInWin > 0 {
+			suppressed := d.suppressedInWin
+			rollup := rollupNotification(suppressed)
+			// Send the rollup outside the lock to keep dispatch
+			// fast. Doing the goroutine spawn here avoids forcing
+			// every dispatch caller to think about it.
+			go d.send(rollup)
+		}
+		d.bucketWindowEnd = now.Add(time.Minute)
+		d.bucketRemaining = maxPerMin
+		d.suppressedInWin = 0
+		d.rollupAnnounced = false
+	}
+}
+
+func (d *Dispatcher) send(n notify.Notification) {
+	if d == nil || d.sender == nil {
+		return
+	}
+	// We deliberately drop the error: notify failures are noisy on
+	// CI machines without display servers, and the audit pipeline
+	// is the authoritative log for blocks. Surface stays quiet.
+	_ = d.sender(n)
+}
+
+func (d *Dispatcher) now() time.Time {
+	if d == nil {
+		return time.Now()
+	}
+	d.mu.Lock()
+	fn := d.nowFn
+	d.mu.Unlock()
+	if fn == nil {
+		return time.Now()
+	}
+	return fn()
+}
+
+// blockNotification renders a block / would-block toast.
+// Body is truncated to keep the toast readable; the full reason is
+// always present in the audit log.
+func blockNotification(ev BlockEvent, wouldBlock bool) notify.Notification {
+	target := strings.TrimSpace(ev.Target)
+	if target == "" {
+		target = "request"
+	}
+	verb := "blocked"
+	if wouldBlock {
+		verb = "would block"
+	}
+	title := fmt.Sprintf("DefenseClaw %s %s", verb, target)
+	subtitle := buildSubtitle(string(ev.Source), ev.Severity, ev.Connector, ev.Event, wouldBlock)
+	return notify.Notification{
+		Title:    title,
+		Subtitle: subtitle,
+		Body:     truncateReason(ev.Reason),
+	}
+}
+
+func approvalNotification(ev ApprovalEvent) notify.Notification {
+	subject := strings.TrimSpace(ev.Subject)
+	if subject == "" {
+		subject = "agent action"
+	}
+	subtitle := buildSubtitle(string(ev.Source), ev.Severity, "", "", false)
+	if subtitle == "" {
+		subtitle = "reply in chat"
+	} else {
+		subtitle += " · reply in chat"
+	}
+	return notify.Notification{
+		Title:    "Approval needed: " + subject,
+		Subtitle: subtitle,
+		Body:     truncateReason(ev.Reason),
+	}
+}
+
+func rollupNotification(suppressed int) notify.Notification {
+	return notify.Notification{
+		Title:    "DefenseClaw notifications throttled",
+		Subtitle: "rate limit",
+		Body:     fmt.Sprintf("Suppressed %d notification(s) in the last minute. Tune notifications.max_per_minute or sources.* to dial down.", suppressed),
+	}
+}
+
+func buildSubtitle(source, severity, connector, event string, wouldBlock bool) string {
+	parts := make([]string, 0, 4)
+	if source != "" {
+		parts = append(parts, source)
+	}
+	if severity != "" && !strings.EqualFold(severity, "NONE") {
+		parts = append(parts, severity)
+	}
+	if connector != "" {
+		parts = append(parts, connector)
+	}
+	if event != "" {
+		parts = append(parts, event)
+	}
+	subtitle := strings.Join(parts, " · ")
+	if wouldBlock {
+		if subtitle == "" {
+			return "observe mode"
+		}
+		return subtitle + " · observe"
+	}
+	return subtitle
+}
+
+func truncateReason(reason string) string {
+	// Collapse CR/LF/TAB into a single space before sizing. AppleScript
+	// (osascript on darwin) renders an embedded "\n" as the literal two
+	// characters because json.Marshal escapes the byte; libnotify on
+	// linux honors \n but a multi-line body in a toast is awkward
+	// regardless. One pass of normalisation here keeps the toast
+	// readable on every back-end without each caller having to know.
+	r := strings.NewReplacer("\r\n", " ", "\r", " ", "\n", " ", "\t", " ").Replace(reason)
+	r = strings.TrimSpace(r)
+	if r == "" {
+		return ""
+	}
+	const maxLen = 140
+	if len(r) <= maxLen {
+		return r
+	}
+	// Truncate on a rune boundary to avoid producing invalid UTF-8
+	// when the reason contains multi-byte characters near the cap.
+	if maxLen-3 < 0 {
+		return r[:maxLen]
+	}
+	end := maxLen - 3
+	for end > 0 && !validRuneStart(r[end]) {
+		end--
+	}
+	return r[:end] + "..."
+}
+
+// validRuneStart reports whether the byte is the leading byte of a
+// UTF-8 sequence (ASCII or 11xxxxxx). Used by truncateReason to
+// avoid splitting a multi-byte rune.
+func validRuneStart(b byte) bool {
+	return b < 0x80 || b >= 0xC0
+}
+
+func dedupKey(cat Category, src Source, target, reason string) string {
+	h := sha256.New()
+	h.Write([]byte(string(cat)))
+	h.Write([]byte{0})
+	h.Write([]byte(string(src)))
+	h.Write([]byte{0})
+	h.Write([]byte(strings.ToLower(target)))
+	h.Write([]byte{0})
+	h.Write([]byte(strings.ToLower(reason)))
+	sum := h.Sum(nil)
+	return hex.EncodeToString(sum[:8])
+}

--- a/internal/gateway/notifier/notifier_test.go
+++ b/internal/gateway/notifier/notifier_test.go
@@ -1,0 +1,323 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package notifier
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/notify"
+)
+
+// recorder is a synchronous test sender that captures every
+// Notification the dispatcher hands off. send() is invoked from a
+// goroutine inside the dispatcher, so the recorder serializes
+// access on a mutex and surfaces a Drain helper that waits up to a
+// short timeout for the expected count.
+type recorder struct {
+	mu    sync.Mutex
+	items []notify.Notification
+	err   error
+}
+
+func (r *recorder) Send(n notify.Notification) error {
+	r.mu.Lock()
+	r.items = append(r.items, n)
+	err := r.err
+	r.mu.Unlock()
+	return err
+}
+
+func (r *recorder) Snapshot() []notify.Notification {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]notify.Notification, len(r.items))
+	copy(out, r.items)
+	return out
+}
+
+// Drain waits until the recorder has at least want items or
+// timeout elapses, then returns the snapshot. Used to bridge the
+// dispatcher's fire-and-forget goroutine into deterministic tests
+// without sleeping on a fixed interval.
+func (r *recorder) Drain(want int, timeout time.Duration) []notify.Notification {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		got := r.Snapshot()
+		if len(got) >= want {
+			return got
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return r.Snapshot()
+}
+
+func enabledConfig() config.NotificationsConfig {
+	c := config.DefaultNotificationsConfig()
+	c.Enabled = true
+	return c
+}
+
+func TestDispatcher_DisabledIsNoOp(t *testing.T) {
+	rec := &recorder{}
+	cfg := config.DefaultNotificationsConfig()
+	cfg.Enabled = false
+	d := NewWithSender(cfg, rec.Send)
+
+	d.OnBlock(BlockEvent{Source: SourceHook, Target: "Bash", Reason: "denied"})
+	d.OnWouldBlock(BlockEvent{Source: SourceHook, Target: "Bash"})
+	d.OnApprovalPending(ApprovalEvent{Subject: "tool"})
+
+	if got := rec.Drain(1, 50*time.Millisecond); len(got) != 0 {
+		t.Fatalf("disabled dispatcher emitted %d notifications: %#v", len(got), got)
+	}
+}
+
+func TestDispatcher_CategoryGate(t *testing.T) {
+	rec := &recorder{}
+	cfg := enabledConfig()
+	cfg.BlockEnforced = false
+	cfg.BlockWouldBlock = false
+	cfg.HITLApproval = true
+	d := NewWithSender(cfg, rec.Send)
+
+	d.OnBlock(BlockEvent{Source: SourceHook, Target: "Bash", Reason: "denied"})
+	d.OnWouldBlock(BlockEvent{Source: SourceHook, Target: "Bash"})
+	d.OnApprovalPending(ApprovalEvent{Subject: "tool", Source: SourceHook})
+
+	got := rec.Drain(1, 100*time.Millisecond)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 notification (approval only), got %d: %#v", len(got), got)
+	}
+	if !strings.Contains(got[0].Title, "Approval needed") {
+		t.Fatalf("expected approval title, got %q", got[0].Title)
+	}
+}
+
+func TestDispatcher_SourceFilter(t *testing.T) {
+	rec := &recorder{}
+	cfg := enabledConfig()
+	cfg.Sources.Hook = false
+	cfg.Sources.Guardrail = true
+	cfg.Sources.AssetPolicy = false
+	d := NewWithSender(cfg, rec.Send)
+
+	d.OnBlock(BlockEvent{Source: SourceHook, Target: "Bash"})
+	d.OnBlock(BlockEvent{Source: SourceAssetPolicy, Target: "mcp:github"})
+	d.OnBlock(BlockEvent{Source: SourceGuardrail, Target: "gpt-4o"})
+
+	got := rec.Drain(1, 100*time.Millisecond)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 notification (guardrail only), got %d: %#v", len(got), got)
+	}
+	if !strings.Contains(got[0].Title, "gpt-4o") {
+		t.Fatalf("expected gpt-4o in title, got %q", got[0].Title)
+	}
+}
+
+func TestDispatcher_DedupWithinWindow(t *testing.T) {
+	rec := &recorder{}
+	cfg := enabledConfig()
+	cfg.DedupWindow = 30 * time.Second
+	cfg.MaxPerMinute = 100
+	d := NewWithSender(cfg, rec.Send)
+
+	now := time.Unix(0, 0)
+	d.SetClock(func() time.Time { return now })
+
+	for i := 0; i < 5; i++ {
+		d.OnBlock(BlockEvent{
+			Source: SourceHook,
+			Target: "Bash",
+			Reason: "policy denied dangerous command",
+		})
+	}
+
+	got := rec.Drain(1, 100*time.Millisecond)
+	if len(got) != 1 {
+		t.Fatalf("expected dedup to collapse 5 identical events to 1, got %d: %#v", len(got), got)
+	}
+
+	// Advance past the dedup window — a follow-up event must fire.
+	now = now.Add(31 * time.Second)
+	d.OnBlock(BlockEvent{
+		Source: SourceHook,
+		Target: "Bash",
+		Reason: "policy denied dangerous command",
+	})
+	got = rec.Drain(2, 100*time.Millisecond)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 notifications after dedup window, got %d: %#v", len(got), got)
+	}
+}
+
+func TestDispatcher_RateLimitAndRollup(t *testing.T) {
+	rec := &recorder{}
+	cfg := enabledConfig()
+	cfg.DedupWindow = time.Millisecond // effectively no dedup
+	cfg.MaxPerMinute = 3
+	d := NewWithSender(cfg, rec.Send)
+
+	now := time.Unix(0, 0)
+	d.SetClock(func() time.Time { return now })
+
+	// Each event has a unique target so dedup never kicks in. We
+	// emit 6 events with a max of 3/min; expect 3 delivered + 3
+	// suppressed in the first window, then a single rollup at the
+	// minute boundary.
+	for i := 0; i < 6; i++ {
+		d.OnBlock(BlockEvent{
+			Source: SourceHook,
+			Target: "Tool" + string(rune('A'+i)),
+			Reason: "denied",
+		})
+	}
+	got := rec.Drain(3, 100*time.Millisecond)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 delivered notifications under rate limit, got %d", len(got))
+	}
+
+	// Roll the minute window. The next OnBlock should emit a
+	// rollup AND the new event (unique target so dedup is skipped).
+	now = now.Add(61 * time.Second)
+	d.OnBlock(BlockEvent{Source: SourceHook, Target: "ToolZ", Reason: "denied"})
+	got = rec.Drain(5, 250*time.Millisecond)
+	if len(got) < 5 {
+		t.Fatalf("expected rollup + new event after window roll, got %d: %#v", len(got), got)
+	}
+	rollupSeen := false
+	for _, n := range got {
+		if strings.Contains(n.Title, "throttled") {
+			rollupSeen = true
+			if !strings.Contains(n.Body, "3") {
+				t.Fatalf("expected rollup body to mention 3 suppressed events, got %q", n.Body)
+			}
+			break
+		}
+	}
+	if !rollupSeen {
+		t.Fatalf("expected rollup notification after window roll, got %#v", got)
+	}
+}
+
+func TestDispatcher_SenderErrorIsSwallowed(t *testing.T) {
+	rec := &recorder{err: errors.New("display server missing")}
+	cfg := enabledConfig()
+	d := NewWithSender(cfg, rec.Send)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("dispatcher panicked on sender error: %v", r)
+		}
+	}()
+	d.OnBlock(BlockEvent{Source: SourceHook, Target: "Bash", Reason: "denied"})
+
+	got := rec.Drain(1, 100*time.Millisecond)
+	if len(got) != 1 {
+		t.Fatalf("expected sender to be invoked once, got %d", len(got))
+	}
+}
+
+func TestDispatcher_NilReceiverIsSafe(t *testing.T) {
+	var d *Dispatcher
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("nil dispatcher panicked: %v", r)
+		}
+	}()
+	d.OnBlock(BlockEvent{Target: "Bash"})
+	d.OnWouldBlock(BlockEvent{Target: "Bash"})
+	d.OnApprovalPending(ApprovalEvent{Subject: "tool"})
+}
+
+func TestBlockNotification_Subtitle(t *testing.T) {
+	n := blockNotification(BlockEvent{
+		Source:    SourceGuardrail,
+		Target:    "gpt-4o",
+		Severity:  "HIGH",
+		Connector: "openclaw",
+		Event:     "completion",
+		Reason:    "secret found in completion",
+	}, false)
+	if !strings.Contains(n.Title, "blocked gpt-4o") {
+		t.Fatalf("expected blocked title, got %q", n.Title)
+	}
+	if !strings.Contains(n.Subtitle, "guardrail") || !strings.Contains(n.Subtitle, "HIGH") {
+		t.Fatalf("expected subtitle to carry source + severity, got %q", n.Subtitle)
+	}
+	if strings.Contains(n.Subtitle, "observe") {
+		t.Fatalf("would_block=false but subtitle says observe: %q", n.Subtitle)
+	}
+}
+
+func TestBlockNotification_WouldBlockTagsObserve(t *testing.T) {
+	n := blockNotification(BlockEvent{
+		Source:   SourceHook,
+		Target:   "Bash",
+		Severity: "MEDIUM",
+		Reason:   "policy match",
+	}, true)
+	if !strings.Contains(n.Title, "would block") {
+		t.Fatalf("expected 'would block' in title, got %q", n.Title)
+	}
+	if !strings.Contains(n.Subtitle, "observe") {
+		t.Fatalf("expected observe tag in subtitle, got %q", n.Subtitle)
+	}
+}
+
+func TestTruncateReason_Boundaries(t *testing.T) {
+	short := "tiny reason"
+	if got := truncateReason(short); got != short {
+		t.Fatalf("short reason mutated: %q -> %q", short, got)
+	}
+	long := strings.Repeat("a", 200)
+	got := truncateReason(long)
+	if len(got) > 141 { // 138 chars + "..."
+		t.Fatalf("truncated reason too long: %d", len(got))
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("expected ellipsis suffix, got %q", got)
+	}
+}
+
+// TestTruncateReason_StripsNewlines pins the contract that the toast
+// body never contains literal CR / LF / TAB. The macOS osascript
+// path encodes the body via json.Marshal which renders "\n" as the
+// two-character escape; without normalisation the operator sees
+// "regex matched\nrule:..." instead of clean text.
+func TestTruncateReason_StripsNewlines(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"unix", "regex match\nrule: foo", "regex match rule: foo"},
+		{"windows", "line1\r\nline2", "line1 line2"},
+		{"tabs", "field1\tfield2", "field1 field2"},
+		{"mixed", "a\nb\tc\rd", "a b c d"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := truncateReason(tc.in); got != tc.want {
+				t.Fatalf("truncateReason(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/gateway/notifier_wiring_test.go
+++ b/internal/gateway/notifier_wiring_test.go
@@ -1,0 +1,533 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/gateway/notifier"
+	"github.com/defenseclaw/defenseclaw/internal/notify"
+)
+
+// recordingSender captures every notification that the dispatcher
+// would deliver to the OS so test assertions can introspect title,
+// subtitle, and body without touching osascript / notify-send.
+//
+// The dispatcher delivers via a goroutine, so the recorder waits on
+// a counted WaitGroup-style channel rather than a slice append on
+// the calling goroutine — “WaitFor(n)“ blocks up to a deadline so
+// the wiring tests don't flake on a slow scheduler.
+type recordingSender struct {
+	mu     sync.Mutex
+	sent   []notify.Notification
+	signal chan struct{}
+}
+
+func newRecordingSender() *recordingSender {
+	return &recordingSender{signal: make(chan struct{}, 64)}
+}
+
+func (r *recordingSender) Send(n notify.Notification) error {
+	r.mu.Lock()
+	r.sent = append(r.sent, n)
+	r.mu.Unlock()
+	select {
+	case r.signal <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+// WaitFor blocks until at least n notifications have been recorded
+// or 1s has elapsed. Returns the captured notifications in arrival
+// order; the deadline failure mode is a test fail rather than a
+// silent empty slice so a wiring regression surfaces a useful name.
+func (r *recordingSender) WaitFor(t *testing.T, n int) []notify.Notification {
+	t.Helper()
+	deadline := time.After(1 * time.Second)
+	for {
+		r.mu.Lock()
+		got := len(r.sent)
+		r.mu.Unlock()
+		if got >= n {
+			r.mu.Lock()
+			out := append([]notify.Notification(nil), r.sent...)
+			r.mu.Unlock()
+			return out
+		}
+		select {
+		case <-r.signal:
+		case <-deadline:
+			r.mu.Lock()
+			out := append([]notify.Notification(nil), r.sent...)
+			r.mu.Unlock()
+			t.Fatalf("waited 1s for %d notifications, got %d: %+v",
+				n, got, out)
+			return nil
+		}
+	}
+}
+
+// fullyEnabledNotificationsConfig builds a NotificationsConfig that
+// won't suppress anything, so a wiring test sees every emit. We
+// deliberately do NOT call config.DefaultNotificationsConfig() here
+// because that returns a platform-conditional Enabled — and on a
+// linux CI runner that would silently disable the dispatcher.
+func fullyEnabledNotificationsConfig() config.NotificationsConfig {
+	return config.NotificationsConfig{
+		Enabled:         true,
+		BlockEnforced:   true,
+		BlockWouldBlock: true,
+		HITLApproval:    true,
+		Sources: config.NotificationSourceFilter{
+			Hook:        true,
+			Guardrail:   true,
+			AssetPolicy: true,
+		},
+		DedupWindow:  time.Second,
+		MaxPerMinute: 1000,
+	}
+}
+
+// newWiringDispatcher returns a dispatcher with a recording sender
+// and a frozen clock so the dedup window in the test config never
+// expires mid-test.
+func newWiringDispatcher() (*notifier.Dispatcher, *recordingSender) {
+	rec := newRecordingSender()
+	d := notifier.NewWithSender(fullyEnabledNotificationsConfig(), rec.Send)
+	frozen := time.Now()
+	d.SetClock(func() time.Time { return frozen })
+	return d, rec
+}
+
+// TestClaudeHookDispatch_BlockFiresOnBlock pins that the hook
+// helper calls OnBlock and routes the right Source/Connector/Event
+// fields onto the toast. A regression here would mean a successful
+// block decision goes silent at the OS layer even when the operator
+// has notifications enabled.
+func TestClaudeHookDispatch_BlockFiresOnBlock(t *testing.T) {
+	d, rec := newWiringDispatcher()
+	api := &APIServer{}
+	api.SetNotifier(d)
+
+	req := claudeCodeHookRequest{
+		HookEventName: "PreToolUse",
+		ToolName:      "Bash",
+	}
+	api.dispatchClaudeCodeHookNotification(
+		req, "block", "block", "HIGH",
+		"matched policy: deny-rm-rf", false,
+	)
+
+	got := rec.WaitFor(t, 1)
+	if len(got) != 1 {
+		t.Fatalf("want 1 notification, got %d", len(got))
+	}
+	n := got[0]
+	if !strings.Contains(strings.ToLower(n.Title), "block") {
+		t.Errorf("title should mention 'block', got %q", n.Title)
+	}
+	// The dispatcher renders the target tool into the TITLE
+	// ("DefenseClaw blocked Bash") rather than the body, which
+	// holds the redacted reason. Pinning that here so a refactor
+	// that flips title <-> body fields doesn't go unnoticed.
+	if !strings.Contains(n.Title, "Bash") {
+		t.Errorf("title should reference target tool 'Bash', got %q", n.Title)
+	}
+	if !strings.Contains(n.Subtitle, "claudecode") {
+		t.Errorf("subtitle should carry connector 'claudecode', got %q", n.Subtitle)
+	}
+	if !strings.Contains(n.Subtitle, "PreToolUse") {
+		t.Errorf("subtitle should carry hook event 'PreToolUse', got %q", n.Subtitle)
+	}
+}
+
+// TestClaudeHookDispatch_WouldBlockFiresOnWouldBlock guards that
+// observe-mode (rawAction=block, action!=block OR wouldBlock=true)
+// routes through OnWouldBlock so the toast carries the "would have
+// blocked" framing rather than implying the call was actually
+// stopped.
+func TestClaudeHookDispatch_WouldBlockFiresOnWouldBlock(t *testing.T) {
+	d, rec := newWiringDispatcher()
+	api := &APIServer{}
+	api.SetNotifier(d)
+
+	api.dispatchClaudeCodeHookNotification(
+		claudeCodeHookRequest{HookEventName: "PreToolUse", ToolName: "Bash"},
+		"allow", "block", "MEDIUM", "observe-mode trial", true,
+	)
+
+	got := rec.WaitFor(t, 1)
+	if len(got) != 1 {
+		t.Fatalf("want 1 notification, got %d", len(got))
+	}
+	if !strings.Contains(strings.ToLower(got[0].Title), "would") {
+		t.Errorf("title should mention 'would', got %q", got[0].Title)
+	}
+}
+
+// TestClaudeHookDispatch_ConfirmFiresOnApprovalPending guards the
+// HITL/confirm route. A regression here would surface as missing
+// approval-pending toasts even though the chat surface correctly
+// asks for an answer.
+func TestClaudeHookDispatch_ConfirmFiresOnApprovalPending(t *testing.T) {
+	d, rec := newWiringDispatcher()
+	api := &APIServer{}
+	api.SetNotifier(d)
+
+	api.dispatchClaudeCodeHookNotification(
+		claudeCodeHookRequest{HookEventName: "PreToolUse", ToolName: "Edit"},
+		"confirm", "confirm", "LOW",
+		"approval needed for write outside workspace", false,
+	)
+
+	got := rec.WaitFor(t, 1)
+	if len(got) != 1 {
+		t.Fatalf("want 1 notification, got %d", len(got))
+	}
+	if !strings.Contains(strings.ToLower(got[0].Title), "approval") {
+		t.Errorf("title should mention 'approval', got %q", got[0].Title)
+	}
+	// approvalNotification puts the subject ("Edit (PreToolUse)")
+	// in the title; the body holds the redacted reason.
+	if !strings.Contains(got[0].Title, "Edit") {
+		t.Errorf("title should reference subject 'Edit', got %q", got[0].Title)
+	}
+}
+
+// TestClaudeHookDispatch_RedactsReason pins the redaction contract:
+// reasons that look like echoed user content (PII / secrets) must
+// not land verbatim in the toast body. The dispatcher itself does
+// not redact — the helper does — so a regression that drops the
+// redaction.ForSinkReason call would silently leak content here.
+func TestClaudeHookDispatch_RedactsReason(t *testing.T) {
+	d, rec := newWiringDispatcher()
+	api := &APIServer{}
+	api.SetNotifier(d)
+
+	rawSecret := "matched on user message: my-aws-key=AKIAIOSFODNN7EXAMPLE"
+	api.dispatchClaudeCodeHookNotification(
+		claudeCodeHookRequest{HookEventName: "PreToolUse", ToolName: "Bash"},
+		"block", "block", "HIGH", rawSecret, false,
+	)
+	got := rec.WaitFor(t, 1)
+	if strings.Contains(got[0].Body, "AKIAIOSFODNN7EXAMPLE") {
+		t.Errorf("toast body must not contain the raw AWS-key-shaped secret; "+
+			"got %q", got[0].Body)
+	}
+}
+
+// TestCodexHookDispatch_BlockFiresOnBlock mirrors the Claude Code
+// happy-path test for the Codex helper. The two helpers carry the
+// same routing contract — diverging on connector tag only — so a
+// regression on either side surfaces here vs. the Claude test.
+func TestCodexHookDispatch_BlockFiresOnBlock(t *testing.T) {
+	d, rec := newWiringDispatcher()
+	api := &APIServer{}
+	api.SetNotifier(d)
+
+	api.dispatchCodexHookNotification(
+		codexHookRequest{HookEventName: "PreToolUse", ToolName: "shell"},
+		"block", "block", "HIGH", "matched: blocked-shell", false,
+	)
+	got := rec.WaitFor(t, 1)
+	if !strings.Contains(got[0].Subtitle, "codex") {
+		t.Errorf("subtitle should carry connector 'codex', got %q", got[0].Subtitle)
+	}
+}
+
+// TestCodexHookDispatch_RedactsReason mirrors the redaction guard
+// on the Codex helper — both sites must scrub before handing to the
+// dispatcher so the privacy posture is symmetric across connectors.
+func TestCodexHookDispatch_RedactsReason(t *testing.T) {
+	d, rec := newWiringDispatcher()
+	api := &APIServer{}
+	api.SetNotifier(d)
+
+	api.dispatchCodexHookNotification(
+		codexHookRequest{HookEventName: "PreToolUse", ToolName: "shell"},
+		"block", "block", "HIGH",
+		"prompt contained AKIAIOSFODNN7EXAMPLE", false,
+	)
+	got := rec.WaitFor(t, 1)
+	if strings.Contains(got[0].Body, "AKIAIOSFODNN7EXAMPLE") {
+		t.Errorf("toast body must not contain the raw AWS-key-shaped secret; "+
+			"got %q", got[0].Body)
+	}
+}
+
+// TestAssetPolicyDispatch_BlockFiresOnBlock verifies the asset
+// policy runtime helper routes a block decision to OnBlock with
+// SourceAssetPolicy carried through. The asset policy surface is
+// the only one of the four with default-HIGH severity (which is
+// also asserted here as part of the fan-out contract).
+func TestAssetPolicyDispatch_BlockFiresOnBlock(t *testing.T) {
+	d, rec := newWiringDispatcher()
+	api := &APIServer{}
+	api.SetNotifier(d)
+
+	decision := config.AssetPolicyDecision{
+		Action:     "block",
+		RawAction:  "block",
+		Reason:     "skill 'spy' is on the deny list",
+		TargetName: "spy",
+	}
+	api.dispatchAssetPolicyNotification(decision, "skill", "claudecode", "PreToolUse")
+
+	got := rec.WaitFor(t, 1)
+	if !strings.Contains(got[0].Subtitle, "HIGH") {
+		t.Errorf("asset-policy toast should carry severity 'HIGH', got %q",
+			got[0].Subtitle)
+	}
+	// Composite target ("skill:spy") is rendered into the title
+	// because blockNotification wires Target into the title slot.
+	if !strings.Contains(got[0].Title, "skill:spy") {
+		t.Errorf("title should carry composite target 'skill:spy', got %q",
+			got[0].Title)
+	}
+}
+
+// TestAssetPolicyDispatch_RedactsReason guards the redaction
+// scrub on the asset-policy helper — added at the same time as the
+// hook helpers so the privacy posture is consistent across every
+// dispatch site.
+func TestAssetPolicyDispatch_RedactsReason(t *testing.T) {
+	d, rec := newWiringDispatcher()
+	api := &APIServer{}
+	api.SetNotifier(d)
+
+	decision := config.AssetPolicyDecision{
+		Action:     "block",
+		RawAction:  "block",
+		Reason:     "user prompt mentioned AKIAIOSFODNN7EXAMPLE",
+		TargetName: "demo",
+	}
+	api.dispatchAssetPolicyNotification(decision, "mcp", "codex", "PreToolUse")
+	got := rec.WaitFor(t, 1)
+	if strings.Contains(got[0].Body, "AKIAIOSFODNN7EXAMPLE") {
+		t.Errorf("asset-policy toast must not leak raw AWS-key-shaped string; "+
+			"got %q", got[0].Body)
+	}
+}
+
+// TestNotifierDisabled_NoEmit checks the master kill-switch: with
+// notifications disabled in cfg, the dispatch helpers MUST NOT
+// surface anything, even when the per-source toggle is on. This
+// is the audit-trail-only mode an operator picks when they don't
+// want a desktop toaster but still need every block recorded.
+func TestNotifierDisabled_NoEmit(t *testing.T) {
+	cfg := fullyEnabledNotificationsConfig()
+	cfg.Enabled = false
+	rec := newRecordingSender()
+	d := notifier.NewWithSender(cfg, rec.Send)
+	api := &APIServer{}
+	api.SetNotifier(d)
+
+	api.dispatchClaudeCodeHookNotification(
+		claudeCodeHookRequest{HookEventName: "PreToolUse", ToolName: "Bash"},
+		"block", "block", "HIGH", "any reason", false,
+	)
+	api.dispatchCodexHookNotification(
+		codexHookRequest{HookEventName: "PreToolUse", ToolName: "shell"},
+		"block", "block", "HIGH", "any reason", false,
+	)
+	api.dispatchAssetPolicyNotification(
+		config.AssetPolicyDecision{
+			Action:     "block",
+			RawAction:  "block",
+			Reason:     "any",
+			TargetName: "x",
+		},
+		"skill", "claudecode", "PreToolUse",
+	)
+
+	// Give any (errant) goroutine a tick to land before asserting
+	// silence — we WANT zero, but a 0ms wait would race with the
+	// production code path that defers the OS send to a goroutine.
+	time.Sleep(50 * time.Millisecond)
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.sent) != 0 {
+		t.Fatalf("expected zero notifications when cfg.Enabled=false, got %d: %+v",
+			len(rec.sent), rec.sent)
+	}
+}
+
+// TestHILTDispatch_RequestFiresApprovalPending exercises the only
+// remaining wiring site (HILTApprovalManager.Request) end-to-end:
+// once the chat-side prompt is delivered, the manager must call
+// notifier.OnApprovalPending so the operator gets a toast pointing
+// them at chat. The test wires a recording dispatcher into the
+// manager and a mock chat gateway that always succeeds the
+// sessions.send call so Request() reaches the post-send branch.
+//
+// We use a short approval timeout so Request() returns promptly
+// once the approval-pending toast has been emitted (we don't need
+// to wait for the actual approve/deny round-trip — the toast
+// surfaces immediately after sessions.send returns).
+func TestHILTDispatch_RequestFiresApprovalPending(t *testing.T) {
+	received := make(chan receivedRequest, 5)
+	srv := startMockGW(t, rpcRecordingLoop(received))
+	client := connectToMockGW(t, srv)
+
+	m := NewHILTApprovalManager(client, nil, nil)
+	m.TrackSession("session-A")
+
+	d, rec := newWiringDispatcher()
+	m.SetNotifier(d)
+
+	done := make(chan string, 1)
+	go func() {
+		_, status, _ := m.Request(
+			context.Background(),
+			"",
+			"exec",
+			"HIGH",
+			"approval needed: matched test policy",
+			20*time.Millisecond,
+		)
+		done <- status
+	}()
+
+	rpc := drainRPC(t, received)
+	if rpc.Method != "sessions.send" {
+		t.Fatalf("expected sessions.send first, got %q", rpc.Method)
+	}
+
+	got := rec.WaitFor(t, 1)
+	if !strings.Contains(strings.ToLower(got[0].Title), "approval") {
+		t.Errorf("HILT toast title should mention 'approval', got %q", got[0].Title)
+	}
+	if !strings.Contains(got[0].Title, "exec") {
+		t.Errorf("HILT toast title should reference subject 'exec', got %q", got[0].Title)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("approval request did not finish")
+	}
+}
+
+// TestProxyDispatch_BlockEnqueuesGuardrailToast pins the guardrail
+// surface: a verdict that lands at enqueueBlockNotification must
+// reach the dispatcher with Source=Guardrail and the model name
+// carried into the toast title. This is the surface every chat-
+// completion block goes through, so a wiring regression here
+// silences the most common toast in production.
+func TestProxyDispatch_BlockEnqueuesGuardrailToast(t *testing.T) {
+	d, rec := newWiringDispatcher()
+	p := &GuardrailProxy{}
+	p.SetNotifier(d)
+
+	verdict := &ScanVerdict{
+		Action:   "block",
+		Reason:   "test verdict reason",
+		Severity: "HIGH",
+	}
+	p.enqueueBlockNotification(verdict, "prompt", "claude-3.5-sonnet")
+
+	got := rec.WaitFor(t, 1)
+	if !strings.Contains(got[0].Title, "claude-3.5-sonnet") {
+		t.Errorf("title should reference model name, got %q", got[0].Title)
+	}
+	if !strings.Contains(got[0].Subtitle, "guardrail") {
+		t.Errorf("subtitle should carry source 'guardrail', got %q", got[0].Subtitle)
+	}
+}
+
+// TestProxyDispatch_WouldBlockEnqueuesObserveToast guards the
+// observe-mode path — the operator who flips guardrail to observe
+// to measure false positives still wants to see toasts. The body
+// must say "would block" not "blocked" so the operator doesn't
+// chase a nonexistent enforcement incident.
+func TestProxyDispatch_WouldBlockEnqueuesObserveToast(t *testing.T) {
+	d, rec := newWiringDispatcher()
+	p := &GuardrailProxy{}
+	p.SetNotifier(d)
+
+	verdict := &ScanVerdict{
+		Action:   "block",
+		Reason:   "would-block sample",
+		Severity: "MEDIUM",
+	}
+	p.enqueueWouldBlockNotification(verdict, "completion", "gpt-4o")
+
+	got := rec.WaitFor(t, 1)
+	if !strings.Contains(strings.ToLower(got[0].Title), "would") {
+		t.Errorf("would-block toast title should mention 'would', got %q",
+			got[0].Title)
+	}
+}
+
+// TestProxyDispatch_RedactsReason locks down the privacy posture
+// for the guardrail surface specifically — the regex_match path
+// can mint reasons from echoed user content, which is exactly the
+// shape that would leak secrets onto the lock screen.
+func TestProxyDispatch_RedactsReason(t *testing.T) {
+	d, rec := newWiringDispatcher()
+	p := &GuardrailProxy{}
+	p.SetNotifier(d)
+
+	verdict := &ScanVerdict{
+		Action:   "block",
+		Reason:   "regex hit on AKIAIOSFODNN7EXAMPLE in user input",
+		Severity: "HIGH",
+	}
+	p.enqueueBlockNotification(verdict, "prompt", "claude-3.5-sonnet")
+	got := rec.WaitFor(t, 1)
+	if strings.Contains(got[0].Body, "AKIAIOSFODNN7EXAMPLE") {
+		t.Errorf("guardrail toast must not leak raw AWS-key-shaped string; "+
+			"got %q", got[0].Body)
+	}
+}
+
+// TestNotifierSourceFilter_AssetPolicyOff verifies the per-source
+// toggle gates a category cleanly: with asset_policy off but hook
+// on, the hook helper still emits but the asset policy helper does
+// not. This is the noise-floor knob an operator turns down when
+// asset policy spam is the issue.
+func TestNotifierSourceFilter_AssetPolicyOff(t *testing.T) {
+	cfg := fullyEnabledNotificationsConfig()
+	cfg.Sources.AssetPolicy = false
+	rec := newRecordingSender()
+	d := notifier.NewWithSender(cfg, rec.Send)
+	api := &APIServer{}
+	api.SetNotifier(d)
+
+	api.dispatchAssetPolicyNotification(
+		config.AssetPolicyDecision{
+			Action:     "block",
+			RawAction:  "block",
+			Reason:     "blocked",
+			TargetName: "demo",
+		},
+		"skill", "claudecode", "PreToolUse",
+	)
+	api.dispatchClaudeCodeHookNotification(
+		claudeCodeHookRequest{HookEventName: "PreToolUse", ToolName: "Bash"},
+		"block", "block", "HIGH", "hook block", false,
+	)
+
+	got := rec.WaitFor(t, 1)
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 notification (hook only), got %d", len(got))
+	}
+	if !strings.Contains(got[0].Subtitle, "claudecode") {
+		t.Errorf("the only notification should be the hook (claudecode), got %q",
+			got[0].Subtitle)
+	}
+}

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -42,6 +42,7 @@ import (
 	"github.com/defenseclaw/defenseclaw/internal/config"
 	"github.com/defenseclaw/defenseclaw/internal/configs"
 	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
+	"github.com/defenseclaw/defenseclaw/internal/gateway/notifier"
 	"github.com/defenseclaw/defenseclaw/internal/gatewaylog"
 	"github.com/defenseclaw/defenseclaw/internal/guardrail"
 	"github.com/defenseclaw/defenseclaw/internal/redaction"
@@ -102,6 +103,7 @@ type GuardrailProxy struct {
 	notify       *NotificationQueue
 	webhooks     *WebhookDispatcher
 	hilt         *HILTApprovalManager
+	notifier     *notifier.Dispatcher
 
 	// resolveProviderFn selects the upstream LLMProvider for a request.
 	// Defaults to resolveProviderFromHeaders (uses X-DC-Target-URL).
@@ -161,6 +163,15 @@ func (p *GuardrailProxy) SetDefaultPolicyID(id string) {
 // confirm verdicts.
 func (p *GuardrailProxy) SetHILTApprovalManager(m *HILTApprovalManager) {
 	p.hilt = m
+}
+
+// SetNotifier wires the user-session OS notifier dispatcher used by
+// the proxy to surface block / would-block events alongside the
+// existing webhooks/audit fan-out. Safe to call with nil — the
+// dispatcher's methods short-circuit on nil so the per-call site
+// stays clean.
+func (p *GuardrailProxy) SetNotifier(n *notifier.Dispatcher) {
+	p.notifier = n
 }
 
 // agentNameForRequest picks the most specific agent name available.
@@ -2386,7 +2397,7 @@ func (p *GuardrailProxy) handleStreamingRequest(w http.ResponseWriter, r *http.R
 // site. No-op when notify is nil or verdict is nil so callers don't
 // need a guard at each site.
 func (p *GuardrailProxy) enqueueBlockNotification(verdict *ScanVerdict, direction, model string) {
-	if p.notify == nil || verdict == nil {
+	if verdict == nil {
 		return
 	}
 	// SubjectType drives the "Skill"/"Plugin"/"MCP"/"Tool" label in
@@ -2402,21 +2413,57 @@ func (p *GuardrailProxy) enqueueBlockNotification(verdict *ScanVerdict, directio
 	if verdict.Findings != nil {
 		findings = len(verdict.Findings)
 	}
-	p.notify.Push(SecurityNotification{
-		SubjectType: subject,
-		// SkillName is rendered verbatim in the enforcement notice.
-		// Use the model name so operators and the LLM both see which
-		// target the block applied to; not sensitive and always
-		// present at block time.
-		SkillName: model,
+	if p.notify != nil {
+		p.notify.Push(SecurityNotification{
+			SubjectType: subject,
+			// SkillName is rendered verbatim in the enforcement notice.
+			// Use the model name so operators and the LLM both see which
+			// target the block applied to; not sensitive and always
+			// present at block time.
+			SkillName: model,
+			Severity:  verdict.Severity,
+			Findings:  findings,
+			Actions:   []string{"block"},
+			// verdict.Reason is minted from user content in the regex
+			// path and can carry literal secrets/PII. Always scrub
+			// before the text lands in a system message that gets
+			// shipped off-box to the LLM provider.
+			Reason: redaction.ForSinkReason(verdict.Reason),
+		})
+	}
+	// Also fire a user-session OS notification so the operator sees
+	// the enforcement event without polling the audit log. The
+	// dispatcher applies its own per-category gate, dedup window,
+	// and rate limit before delivery.
+	p.notifier.OnBlock(notifier.BlockEvent{
+		Source:    notifier.SourceGuardrail,
+		Target:    model,
+		Reason:    string(redaction.ForSinkReason(verdict.Reason)),
 		Severity:  verdict.Severity,
-		Findings:  findings,
-		Actions:   []string{"block"},
-		// verdict.Reason is minted from user content in the regex
-		// path and can carry literal secrets/PII. Always scrub
-		// before the text lands in a system message that gets
-		// shipped off-box to the LLM provider.
-		Reason: redaction.ForSinkReason(verdict.Reason),
+		Connector: p.connectorName(),
+		Event:     direction,
+	})
+}
+
+// enqueueWouldBlockNotification fires only the OS notifier toast for
+// observe-mode verdicts that would have blocked under enforcement.
+// It deliberately does NOT push to the LLM-facing NotificationQueue
+// (that channel is reserved for *enforced* blocks; the LLM gets a
+// "your last request was blocked" system message there) and it does
+// NOT dispatch a webhook (the existing webhooks.Dispatch site is
+// gated on verdict.Action == "block" and already covers the would-
+// block-but-not-enforced case via the same branch).
+func (p *GuardrailProxy) enqueueWouldBlockNotification(verdict *ScanVerdict, direction, model string) {
+	if verdict == nil {
+		return
+	}
+	p.notifier.OnWouldBlock(notifier.BlockEvent{
+		Source:    notifier.SourceGuardrail,
+		Target:    model,
+		Reason:    string(redaction.ForSinkReason(verdict.Reason)),
+		Severity:  verdict.Severity,
+		Connector: p.connectorName(),
+		Event:     direction,
 	})
 }
 
@@ -3527,6 +3574,21 @@ func (p *GuardrailProxy) recordTelemetry(ctx context.Context, direction, model s
 		// webhook body in lockstep with the matching logger/store rows.
 		audit.ApplyEnvelope(&event, audit.EnvelopeFromContext(ctx))
 		p.webhooks.Dispatch(event)
+	}
+
+	// Surface observe-mode would-blocks to the operator via the OS
+	// notifier. Enforced blocks are reported by the matching
+	// enqueueBlockNotification call at the request handler's
+	// "if verdict.Action == block && mode == action" branch — the
+	// dispatcher's per-category gating keeps these two channels
+	// from double-firing for the same event.
+	if verdict.Action == "block" && p.notifier != nil {
+		p.rtMu.RLock()
+		curMode := p.mode
+		p.rtMu.RUnlock()
+		if curMode != "action" {
+			p.enqueueWouldBlockNotification(verdict, direction, model)
+		}
 	}
 }
 

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -194,29 +194,6 @@ func mustJSON(t *testing.T, v interface{}) []byte {
 	return b
 }
 
-func hiltIDFromApprovalMessage(t *testing.T, msg string) string {
-	t.Helper()
-	const marker = "approve "
-	idx := strings.Index(msg, marker+"hilt-")
-	if idx < 0 {
-		t.Fatalf("approval message %q does not contain approve hilt-* instruction", msg)
-	}
-	rest := msg[idx+len(marker):]
-	end := 0
-	for end < len(rest) {
-		c := rest[end]
-		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' {
-			end++
-			continue
-		}
-		break
-	}
-	if end == 0 {
-		t.Fatalf("approval message %q does not contain a HILT id", msg)
-	}
-	return rest[:end]
-}
-
 // parseSSEChunks reads SSE data lines from the response body.
 func parseSSEChunks(t *testing.T, body io.Reader) []json.RawMessage {
 	t.Helper()

--- a/internal/gateway/requestctx_test.go
+++ b/internal/gateway/requestctx_test.go
@@ -42,8 +42,14 @@ func TestContextWithRequestID_RoundTrip(t *testing.T) {
 
 func TestRequestIDFromContext_NilCtx(t *testing.T) {
 	// A nil ctx must not panic. Prod code doesn't pass one but we've
-	// seen tests do it via background helpers.
-	if got := RequestIDFromContext(nil); got != "" { //nolint:staticcheck // intentional nil ctx test
+	// seen tests do it via background helpers, so we explicitly
+	// pin the contract here. We launder the nil through an
+	// untyped-nil variable so newer staticcheck versions stop
+	// flagging the call site (SA1012); the `//nolint:staticcheck`
+	// directive used to be enough on older releases. The semantics
+	// are unchanged — RequestIDFromContext receives a nil ctx.
+	var ctx context.Context //nolint:staticcheck
+	if got := RequestIDFromContext(ctx); got != "" {
 		t.Fatalf("nil ctx must return empty; got %q", got)
 	}
 }

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -30,6 +30,7 @@ import (
 	"github.com/defenseclaw/defenseclaw/internal/audit"
 	"github.com/defenseclaw/defenseclaw/internal/config"
 	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
+	"github.com/defenseclaw/defenseclaw/internal/gateway/notifier"
 	"github.com/defenseclaw/defenseclaw/internal/gatewaylog"
 	"github.com/defenseclaw/defenseclaw/internal/guardrail"
 	"github.com/defenseclaw/defenseclaw/internal/policy"
@@ -43,18 +44,19 @@ import (
 // Sidecar is the long-running process that connects to the agent gateway,
 // watches for skill installs, and exposes a local REST API.
 type Sidecar struct {
-	cfg      *config.Config
-	client   *Client
-	router   *EventRouter
-	store    *audit.Store
-	logger   *audit.Logger
-	health   *SidecarHealth
-	shell    *sandbox.OpenShell
-	otel     *telemetry.Provider
-	notify   *NotificationQueue
-	opa      *policy.Engine
-	hilt     *HILTApprovalManager
-	webhooks *WebhookDispatcher
+	cfg        *config.Config
+	client     *Client
+	router     *EventRouter
+	store      *audit.Store
+	logger     *audit.Logger
+	health     *SidecarHealth
+	shell      *sandbox.OpenShell
+	otel       *telemetry.Provider
+	notify     *NotificationQueue
+	opa        *policy.Engine
+	hilt       *HILTApprovalManager
+	webhooks   *WebhookDispatcher
+	osNotifier *notifier.Dispatcher
 
 	alertCtx    context.Context
 	alertCancel context.CancelFunc
@@ -155,10 +157,19 @@ func NewSidecar(cfg *config.Config, store *audit.Store, logger *audit.Logger, sh
 
 	notify := NewNotificationQueue()
 
+	// User-session OS notifier dispatcher. Constructed unconditionally
+	// so every block / approval site can call into it without nil
+	// checks; the dispatcher's master Enabled gate keeps it silent
+	// when the operator hasn't opted in (or is on a platform without
+	// a display server). The setup wizard flips Enabled=true after
+	// asking the user — see cli/defenseclaw/commands/cmd_setup.py.
+	osNotifier := notifier.New(cfg.Notifications)
+
 	router := NewEventRouter(client, store, logger, cfg.Gateway.AutoApprove, otel)
 	router.notify = notify
 	router.SetGuardrailConfig(&cfg.Guardrail)
 	hilt := NewHILTApprovalManager(client, logger, otel)
+	hilt.SetNotifier(osNotifier)
 	router.SetHILTApprovalManager(hilt)
 	// Seed defaults for the observability contract so every span /
 	// audit row knows which agent (framework mode) and policy
@@ -382,6 +393,7 @@ func NewSidecar(cfg *config.Config, store *audit.Store, logger *audit.Logger, sh
 		notify:      notify,
 		webhooks:    webhooks,
 		hilt:        hilt,
+		osNotifier:  osNotifier,
 		alertCtx:    alertCtx,
 		alertCancel: alertCancel,
 		events:      events,
@@ -1304,6 +1316,7 @@ func (s *Sidecar) runGuardrail(ctx context.Context) error {
 		proxy.SetDefaultPolicyID(s.cfg.Guardrail.Mode)
 		proxy.SetConnectorSwitchState(registry, setupOpts)
 		proxy.SetHILTApprovalManager(s.hilt)
+		proxy.SetNotifier(s.osNotifier)
 	}
 	if err != nil {
 		s.health.SetGuardrail(StateError, err.Error(), nil)
@@ -1573,6 +1586,7 @@ func (s *Sidecar) runAPI(ctx context.Context) error {
 	api := NewAPIServer(addr, s.health, s.client, s.store, s.logger, s.cfg)
 	api.SetOTelProvider(s.otel)
 	api.SetHILTApprovalManager(s.hilt)
+	api.SetNotifier(s.osNotifier)
 	if s.opa != nil {
 		api.SetPolicyReloader(s.opa.Reload)
 	}

--- a/internal/gateway/sidecar_test.go
+++ b/internal/gateway/sidecar_test.go
@@ -11,8 +11,13 @@
 package gateway
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/pelletier/go-toml/v2"
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
 	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
@@ -37,6 +42,74 @@ func TestResolveActiveConnector_EmptyDefaultsToOpenClaw(t *testing.T) {
 	}
 	if got := conn.Name(); got != "openclaw" {
 		t.Errorf("connector name = %q, want %q", got, "openclaw")
+	}
+}
+
+func TestTeardownPreviousConnector_CleansCodexTrustedHookState(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir codex config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`model_provider = "openai"
+`), 0o600); err != nil {
+		t.Fatalf("write codex config: %v", err)
+	}
+
+	connector.CodexConfigPathOverride = configPath
+	t.Cleanup(func() { connector.CodexConfigPathOverride = "" })
+
+	opts := connector.SetupOpts{
+		DataDir:   dir,
+		ProxyAddr: "127.0.0.1:4000",
+		APIAddr:   "127.0.0.1:18970",
+		APIToken:  "tok-test",
+	}
+	codex := connector.NewCodexConnector()
+	if err := codex.Setup(context.Background(), opts); err != nil {
+		t.Fatalf("codex setup: %v", err)
+	}
+	if err := connector.SaveActiveConnector(dir, "codex"); err != nil {
+		t.Fatalf("save active connector: %v", err)
+	}
+
+	registry := connector.NewDefaultRegistry()
+	if err := teardownPreviousConnector(registry, "claudecode", opts, context.Background()); err != nil {
+		t.Fatalf("teardown previous connector: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read restored codex config: %v", err)
+	}
+
+	// Parse TOML and check for residue at the key level rather than via
+	// substring matching. Substring matching is brittle: future Codex
+	// config formats might legitimately contain "hooks" inside an
+	// unrelated key (e.g. "webhook_url") or in a comment, and the test
+	// would start failing on cosmetic changes. Key-level checks pin the
+	// invariant that actually matters — DefenseClaw's hook plumbing
+	// must not survive a connector switch.
+	var parsed map[string]interface{}
+	if err := toml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid TOML after teardown: %v\nfile:\n%s", err, data)
+	}
+	for _, forbidden := range []string{"hooks", "features"} {
+		if _, present := parsed[forbidden]; present {
+			t.Fatalf("connector switch left top-level %q key in restored config:\n%s", forbidden, data)
+		}
+	}
+	if got, _ := parsed["model_provider"].(string); got != "openai" {
+		t.Errorf("teardown clobbered original model_provider: got=%q want=openai\nfile:\n%s", got, data)
+	}
+	// Also assert no DefenseClaw-installed hook script path leaked into
+	// any string value (covers the "fragment lurking inside a TOML
+	// inline string" case that key-level checks alone would miss).
+	if strings.Contains(string(data), "codex-hook.sh") {
+		t.Fatalf("teardown left codex-hook.sh path in config:\n%s", data)
+	}
+	if strings.Contains(string(data), "trusted_hash") {
+		t.Fatalf("teardown left trusted_hash entry in config:\n%s", data)
 	}
 }
 

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -15,18 +15,59 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package notify provides cross-platform desktop notification support
-// for the DefenseClaw watchdog.
+// for DefenseClaw.
+//
+// Two entry points are exposed:
+//
+//   - Send(title, message): the historical two-arg form used by the
+//     watchdog. It maps directly onto a Notification with no subtitle.
+//
+//   - SendNotification(Notification): the richer form used by the
+//     gateway notifier dispatcher. It exposes a subtitle so block /
+//     would-block / approval-pending UX can render the source and
+//     severity inline without packing them into the body string.
+//
+// Platform-native delivery happens in sendPlatform (osascript on
+// macOS, notify-send on Linux); on platforms without sendPlatform the
+// package falls back to writing a structured line on fallbackWriter.
 package notify
 
 import "fmt"
 
-// Send sends a desktop notification with the given title and message.
-// It uses the platform-native notification mechanism (osascript on macOS,
-// notify-send on Linux) and falls back to stderr on unsupported platforms.
+// Notification is a structured, multi-line desktop notification.
+// All fields are optional; empty Title/Subtitle/Body are skipped by
+// the platform back-ends so callers do not need to gate empty values.
+type Notification struct {
+	Title    string
+	Subtitle string
+	Body     string
+}
+
+// Send sends a desktop notification with the given title and body.
+// Retained as a thin wrapper for the watchdog which has historically
+// called Send(title, message). New callers should use
+// SendNotification with a structured Notification value.
 func Send(title, message string) error {
-	if err := sendPlatform(title, message); err != nil {
-		fmt.Fprintf(fallbackWriter, "[defenseclaw-watchdog] %s: %s\n", title, message)
+	return SendNotification(Notification{Title: title, Body: message})
+}
+
+// SendNotification delivers a structured Notification through the
+// platform-native channel. On failure it emits a single fallback line
+// to fallbackWriter that includes title/subtitle/body so operators
+// running with no display server still see what would have been
+// shown.
+func SendNotification(n Notification) error {
+	if err := sendPlatform(n); err != nil {
+		fmt.Fprintf(fallbackWriter, "[defenseclaw] %s%s: %s\n",
+			n.Title, formatSubtitle(n.Subtitle), n.Body)
 		return err
 	}
 	return nil
+}
+
+func formatSubtitle(subtitle string) string {
+	if subtitle == "" {
+		return ""
+	}
+	return " (" + subtitle + ")"
 }

--- a/internal/notify/notify_darwin.go
+++ b/internal/notify/notify_darwin.go
@@ -27,13 +27,19 @@ import (
 
 var fallbackWriter io.Writer = os.Stderr
 
-func sendPlatform(title, message string) error {
-	// Use JSON encoding to safely escape all special characters (quotes,
-	// backslashes, newlines) for embedding in the AppleScript string literal.
-	// json.Marshal produces a quoted string with all metacharacters escaped;
-	// we use it directly as an AppleScript string value.
-	safeMsg, _ := json.Marshal(message)
-	safeTitle, _ := json.Marshal(title)
-	script := `display notification ` + string(safeMsg) + ` with title ` + string(safeTitle)
+// sendPlatform delivers the notification via osascript's
+// "display notification" verb. JSON encoding is used to safely escape
+// every field for embedding in the AppleScript string literals so
+// payload content (verdict reason, tool name, etc.) cannot break out
+// of the script — json.Marshal already produces a quoted string with
+// quotes, backslashes, and newlines escaped.
+func sendPlatform(n Notification) error {
+	body, _ := json.Marshal(n.Body)
+	title, _ := json.Marshal(n.Title)
+	script := "display notification " + string(body) + " with title " + string(title)
+	if n.Subtitle != "" {
+		subtitle, _ := json.Marshal(n.Subtitle)
+		script += " subtitle " + string(subtitle)
+	}
 	return exec.Command("osascript", "-e", script).Run()
 }

--- a/internal/notify/notify_linux.go
+++ b/internal/notify/notify_linux.go
@@ -26,10 +26,23 @@ import (
 
 var fallbackWriter io.Writer = os.Stderr
 
-func sendPlatform(title, message string) error {
+// sendPlatform delivers the notification via libnotify's notify-send
+// CLI. notify-send has no native subtitle field, so when one is set
+// it is folded into the body separated by an em-dash. The fallback
+// writer in notify.go already preserves the structured form for
+// non-display environments.
+func sendPlatform(n Notification) error {
 	path, err := exec.LookPath("notify-send")
 	if err != nil {
 		return err
 	}
-	return exec.Command(path, title, message).Run()
+	body := n.Body
+	if n.Subtitle != "" {
+		if body == "" {
+			body = n.Subtitle
+		} else {
+			body = n.Subtitle + " — " + body
+		}
+	}
+	return exec.Command(path, n.Title, body).Run()
 }

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -31,6 +31,15 @@ func TestSendDoesNotPanic(t *testing.T) {
 	_ = err // OK to fail (e.g. no display server in CI)
 }
 
+func TestSendNotificationDoesNotPanic(t *testing.T) {
+	err := SendNotification(Notification{
+		Title:    "Test",
+		Subtitle: "subtitle",
+		Body:     "body",
+	})
+	_ = err // OK to fail in CI without a display server
+}
+
 func TestFallbackWriter(t *testing.T) {
 	var buf bytes.Buffer
 	old := fallbackWriter
@@ -38,7 +47,28 @@ func TestFallbackWriter(t *testing.T) {
 	defer func() { fallbackWriter = old }()
 
 	err := Send("", "")
-	if err != nil && !strings.Contains(buf.String(), "[defenseclaw-watchdog]") {
+	if err != nil && !strings.Contains(buf.String(), "[defenseclaw]") {
 		t.Fatalf("expected fallback line when send fails, got buf=%q err=%v", buf.String(), err)
+	}
+}
+
+func TestFallbackIncludesSubtitle(t *testing.T) {
+	var buf bytes.Buffer
+	old := fallbackWriter
+	fallbackWriter = &buf
+	defer func() { fallbackWriter = old }()
+
+	err := SendNotification(Notification{
+		Title:    "DefenseClaw",
+		Subtitle: "guardrail · HIGH",
+		Body:     "blocked tool call",
+	})
+	if err == nil {
+		// Send succeeded (e.g. display server present); nothing more
+		// to assert — the platform path took ownership of delivery.
+		return
+	}
+	if !strings.Contains(buf.String(), "guardrail · HIGH") {
+		t.Fatalf("expected subtitle in fallback line, got %q", buf.String())
 	}
 }

--- a/internal/sandbox/openshell_test.go
+++ b/internal/sandbox/openshell_test.go
@@ -87,24 +87,35 @@ func TestOpenShell_StartNonZeroExitEmitted(t *testing.T) {
 	if err := o.Start(filepath.Join(dir, "p.yaml")); err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(200 * time.Millisecond)
-	var rm metricdata.ResourceMetrics
-	if err := r.Collect(context.Background(), &rm); err != nil {
-		t.Fatal(err)
-	}
+	// OpenShell.Start launches a goroutine that calls cmd.Wait() and then
+	// records the exit metric. There's no synchronisation hook, so we
+	// poll the manual reader instead of sleeping a fixed window — the
+	// previous 200ms wait was not enough on loaded test runners and
+	// produced an intermittent flake (n=0). 5s is a safety net; a
+	// healthy run completes within tens of milliseconds.
+	deadline := time.Now().Add(5 * time.Second)
 	var n int64
-	for _, sm := range rm.ScopeMetrics {
-		for _, m := range sm.Metrics {
-			if m.Name != "defenseclaw.openshell.exit" {
-				continue
-			}
-			sum := m.Data.(metricdata.Sum[int64])
-			for _, dp := range sum.DataPoints {
-				n += dp.Value
+	for time.Now().Before(deadline) {
+		var rm metricdata.ResourceMetrics
+		if err := r.Collect(context.Background(), &rm); err != nil {
+			t.Fatal(err)
+		}
+		n = 0
+		for _, sm := range rm.ScopeMetrics {
+			for _, m := range sm.Metrics {
+				if m.Name != "defenseclaw.openshell.exit" {
+					continue
+				}
+				sum := m.Data.(metricdata.Sum[int64])
+				for _, dp := range sum.DataPoints {
+					n += dp.Value
+				}
 			}
 		}
+		if n >= 1 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
-	if n < 1 {
-		t.Fatalf("expected openshell exit metric, got %d", n)
-	}
+	t.Fatalf("expected openshell exit metric, got %d", n)
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2110,18 +2110,17 @@ func (m Model) showNotificationsModal() (tea.Model, tea.Cmd) {
 // command does for us via _restart_services + the auto-restart
 // hook). We always pass --yes because the modal is the
 // confirmation step.
+//
+// We deliberately do NOT optimistically mutate m.cfg before the
+// subprocess returns. The successful-completion path runs through
+// reloadConfigAfterSetupCommand (see Update's commandFinishedMsg
+// branch), which re-reads config.yaml and rebuilds the in-memory
+// snapshot from disk. A subprocess failure leaves the in-memory
+// cfg untouched, so reopening the modal still reflects ground
+// truth instead of an aspirational state that the CLI never wrote.
 func (m Model) confirmNotificationsToggle() (tea.Model, tea.Cmd) {
 	action := m.notificationsModal.DesiredAction()
 	m.notificationsModal.Hide()
-
-	// Mirror the operator's intent in the in-memory cfg snapshot
-	// so subsequent paints (e.g. an immediate re-open of the modal)
-	// see the new state without waiting for the subprocess to
-	// finish writing config.yaml. The actual persistence is owned
-	// by setup_notifications in the Python CLI.
-	if m.cfg != nil {
-		m.cfg.Notifications.Enabled = action == "on"
-	}
 
 	cmd := m.executor.Execute(
 		"defenseclaw",

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -53,13 +53,21 @@ const (
 	// tab navigation. Re-ordering would silently change muscle
 	// memory for every operator — don't do it without a migration.
 	PanelTools
+	// PanelRegistries surfaces external skill / MCP catalog sources
+	// registered via `defenseclaw registry add`. Same convention as
+	// PanelTools — letter-only ('R') shortcut so we don't shift the
+	// existing 1–9 / 0 numeric bindings. Sources / Entries / Approved
+	// sub-tabs render the on-disk index.json verdicts cached by
+	// cli/defenseclaw/registries/cache.py.
+	PanelRegistries
 	PanelSetup
 	panelCount
 )
 
 var panelNames = [panelCount]string{
 	"Overview", "Alerts", "Skills", "MCPs", "Plugins",
-	"Inventory", "Policy", "Logs", "Audit", "Activity", "Tools", "Setup",
+	"Inventory", "Policy", "Logs", "Audit", "Activity", "Tools",
+	"Registries", "Setup",
 }
 
 const refreshInterval = 5 * time.Second
@@ -126,29 +134,31 @@ type Model struct {
 	height      int
 
 	// Panels (stubs that will be filled in later phases)
-	overview  OverviewPanel
-	alerts    AlertsPanel
-	skills    SkillsPanel
-	mcps      MCPsPanel
-	plugins   PluginsPanel
-	inventory InventoryPanel
-	policy    PolicyPanel
-	logs      LogsPanel
-	auditHist AuditPanel
-	activity  ActivityPanel
-	tools     ToolsPanel
-	setup     SetupPanel
-	firstRun  FirstRunPanel
+	overview   OverviewPanel
+	alerts     AlertsPanel
+	skills     SkillsPanel
+	mcps       MCPsPanel
+	plugins    PluginsPanel
+	inventory  InventoryPanel
+	policy     PolicyPanel
+	logs       LogsPanel
+	auditHist  AuditPanel
+	activity   ActivityPanel
+	tools      ToolsPanel
+	registries RegistriesPanel
+	setup      SetupPanel
+	firstRun   FirstRunPanel
 
 	// Overlays
 	detail     DetailModal
 	palette    PaletteModel
 	actionMenu ActionMenu
 
-	mcpSetForm     MCPSetForm
-	modePicker     ModePickerModal
-	redactionModal RedactionToggleModal
-	uninstallModal UninstallModal
+	mcpSetForm         MCPSetForm
+	modePicker         ModePickerModal
+	redactionModal     RedactionToggleModal
+	notificationsModal NotificationsToggleModal
+	uninstallModal     UninstallModal
 
 	helpOpen bool
 
@@ -219,26 +229,28 @@ func New(deps Deps) Model {
 	ti.SetStyles(s)
 
 	m := Model{
-		overview:       NewOverviewPanel(theme, deps.Config, deps.Version),
-		alerts:         NewAlertsPanel(deps.Store, dataDir),
-		skills:         NewSkillsPanel(deps.Store),
-		mcps:           NewMCPsPanel(deps.Store),
-		plugins:        NewPluginsPanel(theme, deps.Store),
-		inventory:      NewInventoryPanel(theme, executor, deps.Store),
-		policy:         NewPolicyPanel(theme, deps.Config),
-		logs:           NewLogsPanel(theme, deps.Config),
-		auditHist:      NewAuditPanel(theme, deps.Store),
-		activity:       NewActivityPanel(theme, dataDir),
-		tools:          NewToolsPanel(deps.Store),
-		setup:          NewSetupPanel(theme, deps.Config, executor),
-		firstRun:       NewFirstRunPanel(theme, deps.FirstRun),
-		detail:         NewDetailModal(),
-		palette:        NewPaletteModel(theme, registry, executor),
-		actionMenu:     NewActionMenu(theme),
-		mcpSetForm:     NewMCPSetForm(),
-		modePicker:     NewModePickerModal(theme),
-		redactionModal: NewRedactionToggleModal(theme),
-		uninstallModal: NewUninstallModal(theme),
+		overview:           NewOverviewPanel(theme, deps.Config, deps.Version),
+		alerts:             NewAlertsPanel(deps.Store, dataDir),
+		skills:             NewSkillsPanel(deps.Store),
+		mcps:               NewMCPsPanel(deps.Store),
+		plugins:            NewPluginsPanel(theme, deps.Store),
+		inventory:          NewInventoryPanel(theme, executor, deps.Store),
+		policy:             NewPolicyPanel(theme, deps.Config),
+		logs:               NewLogsPanel(theme, deps.Config),
+		auditHist:          NewAuditPanel(theme, deps.Store),
+		activity:           NewActivityPanel(theme, dataDir),
+		tools:              NewToolsPanel(deps.Store),
+		registries:         NewRegistriesPanel(deps.Config, executor),
+		setup:              NewSetupPanel(theme, deps.Config, executor),
+		firstRun:           NewFirstRunPanel(theme, deps.FirstRun),
+		detail:             NewDetailModal(),
+		palette:            NewPaletteModel(theme, registry, executor),
+		actionMenu:         NewActionMenu(theme),
+		mcpSetForm:         NewMCPSetForm(),
+		modePicker:         NewModePickerModal(theme),
+		redactionModal:     NewRedactionToggleModal(theme),
+		notificationsModal: NewNotificationsToggleModal(theme),
+		uninstallModal:     NewUninstallModal(theme),
 
 		cmdInput: ti,
 
@@ -293,6 +305,52 @@ func (m *Model) propagateConnector() {
 	m.mcps.SetConnector(name)
 	m.plugins.SetConnector(name)
 	m.inventory.SetConnector(name)
+	m.propagateRegistryAttribution()
+}
+
+// propagateRegistryAttribution rebuilds the per-panel "name -> registry
+// source id" maps used to render the "registry:<id>" badge on Skills /
+// MCPs rows and the "Approved by" line in detail view. Built fresh
+// from cfg.AssetPolicy.{Skill,MCP}.Registry every time cfg changes —
+// the registry list mutates on every `registry sync` / `approve` /
+// `reject`, and a stale map would silently mis-attribute. The
+// indirection through SetRegistryAttribution keeps the panels free of
+// any direct config dependency, which makes them cheap to test.
+func (m *Model) propagateRegistryAttribution() {
+	if m.cfg == nil {
+		m.skills.SetRegistryAttribution(nil)
+		m.mcps.SetRegistryAttribution(nil)
+		return
+	}
+	skillAttr := registryAttributionFromRules(m.cfg.AssetPolicy.Skill.Registry)
+	mcpAttr := registryAttributionFromRules(m.cfg.AssetPolicy.MCP.Registry)
+	m.skills.SetRegistryAttribution(skillAttr)
+	m.mcps.SetRegistryAttribution(mcpAttr)
+}
+
+// registryAttributionFromRules walks an asset_policy registry list
+// and returns a name -> source-id map for every rule whose Reason
+// matches the "registry:<id>" provenance tag. Rules with no name or
+// a non-registry reason (e.g. operator-authored allow-list entries)
+// are skipped so the badge surfaces *only* registry-promoted assets.
+// Returns nil when the input is empty so the caller can pass the
+// result straight to SetRegistryAttribution(nil).
+func registryAttributionFromRules(rules []config.AssetPolicyRule) map[string]string {
+	if len(rules) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(rules))
+	for _, rule := range rules {
+		sid := config.ParseRegistrySourceID(rule.Reason)
+		if sid == "" || rule.Name == "" {
+			continue
+		}
+		out[rule.Name] = sid
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // isDoctorCommand reports whether the display-name passed to
@@ -629,7 +687,7 @@ func (m Model) handleMouseClick(mouse tea.Mouse) (tea.Model, tea.Cmd) {
 		m.detail.Hide()
 		return m, nil
 	}
-	if m.modePicker.IsVisible() || m.redactionModal.IsVisible() || m.uninstallModal.IsVisible() {
+	if m.modePicker.IsVisible() || m.redactionModal.IsVisible() || m.notificationsModal.IsVisible() || m.uninstallModal.IsVisible() {
 		return m, nil
 	}
 	// If a panel has an in-panel overlay/form/editor open, don't let
@@ -790,6 +848,8 @@ func (m Model) handlePanelClick(x, y int) (tea.Model, tea.Cmd) {
 					return m, nil
 				case "R":
 					return m.showRedactionModal()
+				case "N":
+					return m.showNotificationsModal()
 				case "p":
 					m.activePanel = PanelPolicy
 				case "l":
@@ -1125,6 +1185,9 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.redactionModal.IsVisible() {
 		return m.handleRedactionModalKey(msg)
 	}
+	if m.notificationsModal.IsVisible() {
+		return m.handleNotificationsModalKey(msg)
+	}
 	if m.uninstallModal.IsVisible() {
 		return m.handleUninstallModalKey(msg)
 	}
@@ -1245,6 +1308,16 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		// with the lowercase 't' most panels use for in-panel
 		// actions; it's mnemonic for the panel name.
 		if cmd := m.switchPanel(PanelTools); cmd != nil {
+			return m, cmd
+		}
+	case "R":
+		// Registries panel uses the same letter-only convention as
+		// Tools (see PanelRegistries comment). Mnemonic: 'R' for
+		// Registries; uppercase to avoid clashing with lowercase 'r'
+		// (refresh / reject) used by various sub-panels. Skills and
+		// MCPs panels also bind 'R' to "open Registries filtered to
+		// the highlighted entry" — see registries_links.go.
+		if cmd := m.switchPanel(PanelRegistries); cmd != nil {
 			return m, cmd
 		}
 
@@ -1687,6 +1760,8 @@ func (m Model) handlePanelKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.handleActivityKey(msg)
 	case PanelTools:
 		return m.handleToolsKey(msg)
+	case PanelRegistries:
+		return m.handleRegistriesKey(msg)
 	case PanelSetup:
 		return m.handleSetupKey(msg)
 	}
@@ -1708,6 +1783,46 @@ func (m Model) handlePolicyKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, m.executor.Execute(bin, args, name)
 	}
 	return m, nil
+}
+
+// handleRegistriesKey routes panel-local keystrokes for the
+// Registries panel. The panel itself decides which keys it owns (1/2/3
+// tabs, r refresh, s/S sync, a/x approve/reject, d delete) and
+// returns the argv we should hand to the shared CommandExecutor for
+// any mutation. j/k/up/down stay here so list navigation lines up
+// with every other panel.
+func (m Model) handleRegistriesKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	key := msg.String()
+	switch key {
+	case "j", "down":
+		m.registries.CursorDown()
+		return m, nil
+	case "k", "up":
+		m.registries.CursorUp()
+		return m, nil
+	case "pgdown":
+		m.registries.ScrollBy(10)
+		return m, nil
+	case "pgup":
+		m.registries.ScrollBy(-10)
+		return m, nil
+	}
+	handled, label, args, hint := m.registries.HandleKey(key)
+	if !handled {
+		return m, nil
+	}
+	if hint != "" {
+		m.toasts.Push(ToastInfo, hint)
+	}
+	if label == "" || len(args) == 0 {
+		return m, nil
+	}
+	if m.executor.IsRunning() {
+		m.toasts.Push(ToastWarn, "Another command is running — wait or press Ctrl+C first")
+		return m, nil
+	}
+	m.activePanel = PanelActivity
+	return m, m.executor.Execute("defenseclaw", args, label)
 }
 
 func (m Model) handleSetupKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
@@ -1864,6 +1979,8 @@ func (m Model) handleOverviewKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "R":
 		return m.showRedactionModal()
+	case "N":
+		return m.showNotificationsModal()
 	case "p":
 		m.activePanel = PanelPolicy
 	case "l":
@@ -1943,6 +2060,76 @@ func (m Model) showRedactionModal() (tea.Model, tea.Cmd) {
 	m.redactionModal.SetSize(m.width, m.height)
 	m.redactionModal.Show(redactionDisabledForLogsBadge())
 	return m, nil
+}
+
+// handleNotificationsModalKey runs while the [N]-from-Overview/Logs
+// overlay is open. The contract mirrors the redaction modal:
+//
+//   - esc / q: close without changing anything
+//   - enter:   dispatch `defenseclaw setup notifications <on|off> --yes`
+//     and switch to the Activity panel so the operator
+//     watches the restart progress.
+//
+// Hotkeys (e.g. "y") are deliberately not supported so a stray
+// keystroke can't flip the dispatcher state in either direction.
+func (m Model) handleNotificationsModalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "q":
+		m.notificationsModal.Hide()
+		return m, nil
+	case "enter":
+		return m.confirmNotificationsToggle()
+	}
+	return m, nil
+}
+
+// showNotificationsModal opens the [N]-from-Overview/Logs overlay
+// pre-populated with the cached “notifications.enabled“ state.
+//
+// We read the flag from the loaded config (m.cfg) rather than
+// re-shelling out to “defenseclaw setup notifications status“
+// because the TUI is already config-aware and a subprocess for a
+// boolean read would add latency to a keystroke. If config is nil
+// (test harness) the modal opens against a default-false state,
+// matching what a fresh install on a non-darwin host would see.
+func (m Model) showNotificationsModal() (tea.Model, tea.Cmd) {
+	enabled := false
+	if m.cfg != nil {
+		enabled = m.cfg.Notifications.Enabled
+	}
+	m.notificationsModal.SetSize(m.width, m.height)
+	m.notificationsModal.Show(enabled)
+	return m, nil
+}
+
+// confirmNotificationsToggle dispatches the chosen action through
+// the Python CLI. Unlike confirmRedactionToggle there is no
+// in-process state to flip first — the dispatcher is constructed
+// once at sidecar boot from cfg.Notifications, so the toast
+// behaviour catches up when the gateway restarts (which the CLI
+// command does for us via _restart_services + the auto-restart
+// hook). We always pass --yes because the modal is the
+// confirmation step.
+func (m Model) confirmNotificationsToggle() (tea.Model, tea.Cmd) {
+	action := m.notificationsModal.DesiredAction()
+	m.notificationsModal.Hide()
+
+	// Mirror the operator's intent in the in-memory cfg snapshot
+	// so subsequent paints (e.g. an immediate re-open of the modal)
+	// see the new state without waiting for the subprocess to
+	// finish writing config.yaml. The actual persistence is owned
+	// by setup_notifications in the Python CLI.
+	if m.cfg != nil {
+		m.cfg.Notifications.Enabled = action == "on"
+	}
+
+	cmd := m.executor.Execute(
+		"defenseclaw",
+		[]string{"setup", "notifications", action, "--yes"},
+		"setup notifications "+action,
+	)
+	m.activePanel = PanelActivity
+	return m, cmd
 }
 
 func (m Model) handleUninstallModalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
@@ -2217,6 +2404,19 @@ func (m Model) handleSkillsKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		// in memory, which is why operators kept seeing stale
 		// data after an out-of-process `defenseclaw skill …`.
 		return m, m.skills.LoadCmd()
+	case "R":
+		// Cross-link to Registries panel — when the highlighted
+		// skill was promoted from a registry source (Reason starts
+		// with "registry:"), jump straight to the Entries tab
+		// filtered to that name. Otherwise switch to the panel
+		// without a filter so the operator can browse sources.
+		if sel := m.skills.Selected(); sel != nil {
+			m.registries.FocusEntry("skill", sel.Name)
+		}
+		if cmd := m.switchPanel(PanelRegistries); cmd != nil {
+			return m, cmd
+		}
+		return m, nil
 	}
 	return m, nil
 }
@@ -2298,6 +2498,20 @@ func (m Model) handleMCPsKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		// catalog from the CLI instead of re-filtering the
 		// already-loaded rows.
 		return m, m.mcps.LoadCmd()
+	case "R":
+		// Cross-link to Registries panel — same rationale as the
+		// Skills handler. We pass the URL as the entry name because
+		// MCPs in the registry adapter pipeline are keyed by URL or
+		// command depending on transport. The panel's FocusEntry
+		// performs a best-effort name match and falls back to an
+		// unfiltered view when nothing matches.
+		if sel := m.mcps.Selected(); sel != nil {
+			m.registries.FocusEntry("mcp", sel.URL)
+		}
+		if cmd := m.switchPanel(PanelRegistries); cmd != nil {
+			return m, cmd
+		}
+		return m, nil
 	}
 	return m, nil
 }
@@ -2405,6 +2619,9 @@ func (m Model) handleLogsKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.redactionModal.IsVisible() {
 		return m.handleRedactionModalKey(msg)
 	}
+	if m.notificationsModal.IsVisible() {
+		return m.handleNotificationsModalKey(msg)
+	}
 	// `R` (uppercase — lowercase is reserved for "regex search later"
 	// and stays untouched) opens the redaction kill-switch modal.
 	// Available regardless of the active log source because every
@@ -2412,6 +2629,13 @@ func (m Model) handleLogsKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// pipeline; flipping the switch affects them uniformly.
 	if key == "R" && !m.logs.searching {
 		return m.showRedactionModal()
+	}
+	// `N` is the same shape: opens the notifications toggle modal
+	// from anywhere on the Logs panel that's not in search mode.
+	// The notifications dispatcher operates orthogonally to the
+	// redaction pipeline so flipping it doesn't affect log content.
+	if key == "N" && !m.logs.searching {
+		return m.showNotificationsModal()
 	}
 	// On structured log sources, Enter opens a detail modal for the
 	// most-recent visible event. We intercept before handing the
@@ -2843,6 +3067,15 @@ func (m Model) View() tea.View {
 		return m.tuiShellView(m.redactionModal.View())
 	}
 
+	// Desktop-notifications toggle overlay ([N]). Mirrors the
+	// redaction modal pattern — a blocking confirmation rather
+	// than an inline switch, so a stray keystroke can't flip the
+	// dispatcher state.
+	if m.notificationsModal.IsVisible() {
+		m.notificationsModal.SetSize(m.width, m.height)
+		return m.tuiShellView(m.notificationsModal.View())
+	}
+
 	if m.uninstallModal.IsVisible() {
 		m.uninstallModal.SetSize(m.width, m.height)
 		return m.tuiShellView(m.uninstallModal.View())
@@ -2971,6 +3204,7 @@ func (m *Model) reloadRuntimeAfterInit() error {
 	m.logs = NewLogsPanel(m.theme, cfg)
 	m.auditHist = NewAuditPanel(m.theme, store)
 	m.tools = NewToolsPanel(store)
+	m.registries = NewRegistriesPanel(cfg, m.executor)
 	m.setup = NewSetupPanel(m.theme, cfg, m.executor)
 	m.activity.dataDir = dataDir
 	m.resizePanels()
@@ -3032,6 +3266,11 @@ func (m *Model) switchPanel(panel int) tea.Cmd {
 		// jumping in via 'T' sees fresh rows even if the periodic
 		// refresh hasn't fired yet.
 		m.tools.Refresh()
+	case PanelRegistries:
+		// Registries reads from cfg + on-disk index files; both
+		// are cheap so we re-read on every panel entry to avoid
+		// stale rows after a sync.
+		m.registries.Refresh()
 	}
 	return nil
 }
@@ -3045,6 +3284,7 @@ func (m *Model) resizePanels() {
 	m.skills.SetSize(m.width, panelH)
 	m.mcps.SetSize(m.width, panelH)
 	m.tools.SetSize(m.width, panelH)
+	m.registries.SetSize(m.width, panelH)
 	m.detail.SetSize(m.width, m.height)
 	m.actionMenu.SetSize(m.width, m.height)
 	m.firstRun.SetSize(m.width, m.height)
@@ -3255,6 +3495,8 @@ func (m Model) renderActivePanel() string {
 		return m.activity.View()
 	case PanelTools:
 		return m.tools.View()
+	case PanelRegistries:
+		return m.registries.View(m.width, m.height-5)
 	case PanelSetup:
 		return m.setup.View(m.width, m.height-5)
 	default:

--- a/internal/tui/command.go
+++ b/internal/tui/command.go
@@ -538,6 +538,7 @@ func BuildRegistry() []CmdEntry {
 		{TUIName: "setup gateway", CLIBinary: dc, CLIArgs: []string{"setup", "gateway"}, Description: "Configure gateway connection (interactive)", Category: "setup"},
 		{TUIName: "setup guardrail", CLIBinary: dc, CLIArgs: []string{"setup", "guardrail"}, Description: "Configure LLM guardrail", Category: "setup"},
 		{TUIName: "setup redaction", CLIBinary: dc, CLIArgs: []string{"setup", "redaction"}, Description: "Show/toggle redaction state", Category: "setup", NeedsArg: true, ArgHint: "<status|on|off> [--yes]"},
+		{TUIName: "setup notifications", CLIBinary: dc, CLIArgs: []string{"setup", "notifications"}, Description: "Show/toggle desktop notifications", Category: "setup", NeedsArg: true, ArgHint: "<status|on|off> [--yes]"},
 		{TUIName: "setup splunk", CLIBinary: dc, CLIArgs: []string{"setup", "splunk"}, Description: "Configure Splunk / O11y", Category: "setup"},
 		{TUIName: "setup local-observability up", CLIBinary: dc, CLIArgs: []string{"setup", "local-observability", "up"}, Description: "Start local Prom/Loki/Tempo/Grafana stack", Category: "setup"},
 		{TUIName: "setup local-observability down", CLIBinary: dc, CLIArgs: []string{"setup", "local-observability", "down"}, Description: "Stop local observability stack", Category: "setup"},

--- a/internal/tui/configedit.go
+++ b/internal/tui/configedit.go
@@ -19,6 +19,7 @@ package tui
 import (
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
 )
@@ -28,6 +29,39 @@ func normalizeHookModeForSave(val string) string {
 		return "observe"
 	}
 	return val
+}
+
+// parseDurationOrSeconds accepts either a Go duration string
+// ("30s", "1m", "500ms") or a bare integer interpreted as seconds.
+// Empty / unparseable -> 0, which downstream
+// EffectiveDedupWindow()-style helpers resolve to the package
+// default. Used by the Notifications setup-tab section so an
+// operator typing "30" gets the same behaviour as the Privacy
+// modal's status output (which prints "30s").
+func parseDurationOrSeconds(val string) time.Duration {
+	v := strings.TrimSpace(val)
+	if v == "" {
+		return 0
+	}
+	if d, err := time.ParseDuration(v); err == nil {
+		return d
+	}
+	if n, err := strconv.Atoi(v); err == nil {
+		return time.Duration(n) * time.Second
+	}
+	return 0
+}
+
+// fmtNotificationsDedupWindow renders a time.Duration for the
+// Setup-tab field. Zero -> "" (so the field reads as "use default"
+// rather than "0s", matching how the YAML treats it). Non-zero
+// values use Go's canonical String() ("30s", "1m500ms") which
+// round-trips cleanly back through parseDurationOrSeconds.
+func fmtNotificationsDedupWindow(d time.Duration) string {
+	if d <= 0 {
+		return ""
+	}
+	return d.String()
 }
 
 // applyConfigField writes a single field value back to the Config struct
@@ -56,6 +90,35 @@ func applyConfigField(c *config.Config, key, val string) {
 		c.Agent.Name = val
 	case "privacy.disable_redaction":
 		c.Privacy.DisableRedaction = boolVal
+	// Desktop notifications: master switch + per-category + per-source +
+	// throttle. The dispatcher (internal/gateway/notifier) snapshots
+	// cfg.Notifications once at sidecar boot, so an edit here is a
+	// "restart required" change — the Setup-tab save banner already
+	// surfaces that, and the [N]-modal sibling toggles ``enabled``
+	// via the auditing CLI path which restarts for us.
+	case "notifications.enabled":
+		c.Notifications.Enabled = boolVal
+	case "notifications.block_enforced":
+		c.Notifications.BlockEnforced = boolVal
+	case "notifications.block_would_block":
+		c.Notifications.BlockWouldBlock = boolVal
+	case "notifications.hitl_approval":
+		c.Notifications.HITLApproval = boolVal
+	case "notifications.sources.hook":
+		c.Notifications.Sources.Hook = boolVal
+	case "notifications.sources.guardrail":
+		c.Notifications.Sources.Guardrail = boolVal
+	case "notifications.sources.asset_policy":
+		c.Notifications.Sources.AssetPolicy = boolVal
+	case "notifications.dedup_window":
+		// time.Duration field: accept either a Go duration string
+		// ("30s", "1m", "500ms") or a bare integer interpreted as
+		// seconds (matches how Approval Timeout treats its int
+		// kind). Empty / unparseable -> 0, which the dispatcher's
+		// EffectiveDedupWindow() resolves to the default.
+		c.Notifications.DedupWindow = parseDurationOrSeconds(val)
+	case "notifications.max_per_minute":
+		c.Notifications.MaxPerMinute = intVal
 	// Unified top-level llm: block — the single source of truth
 	// consumed by guardrail (Bifrost), MCP scanner, skill scanner,
 	// and plugin scanner via Config.ResolveLLM(...). Writes here

--- a/internal/tui/configedit_test.go
+++ b/internal/tui/configedit_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+)
+
+// TestParseDurationOrSeconds pins the Notifications-section round-trip
+// contract. The Setup-tab field accepts either a Go duration string
+// ("30s", "1m", "500ms") or a bare integer interpreted as seconds.
+// Empty or malformed input must resolve to 0 (which the dispatcher's
+// EffectiveDedupWindow() reads as "use default") rather than to a
+// surprising 0.25s — that would silently disable dedup.
+func TestParseDurationOrSeconds(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"", 0},
+		{"   ", 0},
+		{"30s", 30 * time.Second},
+		{"1m", time.Minute},
+		{"500ms", 500 * time.Millisecond},
+		{"1m30s", 90 * time.Second},
+		{"30", 30 * time.Second},  // bare-int seconds
+		{"0", 0},                  // bare-zero stays zero (default)
+		{"banana", 0},             // unparseable falls back to zero
+		{"-5s", -5 * time.Second}, // negatives are accepted by Go's parser
+	}
+	for _, tc := range cases {
+		got := parseDurationOrSeconds(tc.in)
+		if got != tc.want {
+			t.Errorf("parseDurationOrSeconds(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestFmtNotificationsDedupWindow guards the display side of the
+// round-trip. Zero MUST render as "" so the operator sees an empty
+// field meaning "use default" — printing "0s" would imply dedup is
+// off, which is the opposite of what zero means in the dispatcher.
+func TestFmtNotificationsDedupWindow(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{0, ""},
+		{-1 * time.Second, ""},
+		{30 * time.Second, "30s"},
+		{time.Minute, "1m0s"},
+		{500 * time.Millisecond, "500ms"},
+	}
+	for _, tc := range cases {
+		got := fmtNotificationsDedupWindow(tc.in)
+		if got != tc.want {
+			t.Errorf("fmtNotificationsDedupWindow(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestApplyConfigField_NotificationsSection exercises every key the
+// Setup-tab Notifications section emits, verifying writes land on the
+// matching field of cfg.Notifications. A regression here would mean
+// the form silently swallows edits — exactly the failure mode the
+// section is supposed to fix relative to hand-editing config.yaml.
+func TestApplyConfigField_NotificationsSection(t *testing.T) {
+	c := &config.Config{}
+
+	// Categories + sources start zero; flipping to "true" must land.
+	applyConfigField(c, "notifications.enabled", "true")
+	applyConfigField(c, "notifications.block_enforced", "true")
+	applyConfigField(c, "notifications.block_would_block", "true")
+	applyConfigField(c, "notifications.hitl_approval", "true")
+	applyConfigField(c, "notifications.sources.hook", "true")
+	applyConfigField(c, "notifications.sources.guardrail", "true")
+	applyConfigField(c, "notifications.sources.asset_policy", "true")
+	applyConfigField(c, "notifications.dedup_window", "45s")
+	applyConfigField(c, "notifications.max_per_minute", "20")
+
+	if !c.Notifications.Enabled {
+		t.Error("notifications.enabled didn't persist")
+	}
+	if !c.Notifications.BlockEnforced {
+		t.Error("notifications.block_enforced didn't persist")
+	}
+	if !c.Notifications.BlockWouldBlock {
+		t.Error("notifications.block_would_block didn't persist")
+	}
+	if !c.Notifications.HITLApproval {
+		t.Error("notifications.hitl_approval didn't persist")
+	}
+	if !c.Notifications.Sources.Hook {
+		t.Error("notifications.sources.hook didn't persist")
+	}
+	if !c.Notifications.Sources.Guardrail {
+		t.Error("notifications.sources.guardrail didn't persist")
+	}
+	if !c.Notifications.Sources.AssetPolicy {
+		t.Error("notifications.sources.asset_policy didn't persist")
+	}
+	if c.Notifications.DedupWindow != 45*time.Second {
+		t.Errorf("notifications.dedup_window = %v, want 45s",
+			c.Notifications.DedupWindow)
+	}
+	if c.Notifications.MaxPerMinute != 20 {
+		t.Errorf("notifications.max_per_minute = %d, want 20",
+			c.Notifications.MaxPerMinute)
+	}
+
+	// Flipping back to "false" / "" must clear the same fields so the
+	// form can express both directions of every toggle (the failure
+	// mode for a one-way write is silent and only surfaces when an
+	// operator tries to dial down notifications and the field stays
+	// stuck on).
+	applyConfigField(c, "notifications.enabled", "false")
+	applyConfigField(c, "notifications.sources.guardrail", "false")
+	applyConfigField(c, "notifications.dedup_window", "")
+	applyConfigField(c, "notifications.max_per_minute", "0")
+
+	if c.Notifications.Enabled {
+		t.Error("notifications.enabled didn't clear back to false")
+	}
+	if c.Notifications.Sources.Guardrail {
+		t.Error("notifications.sources.guardrail didn't clear back to false")
+	}
+	if c.Notifications.DedupWindow != 0 {
+		t.Errorf("notifications.dedup_window cleared to %v, want 0",
+			c.Notifications.DedupWindow)
+	}
+	if c.Notifications.MaxPerMinute != 0 {
+		t.Errorf("notifications.max_per_minute cleared to %d, want 0",
+			c.Notifications.MaxPerMinute)
+	}
+}

--- a/internal/tui/first_run.go
+++ b/internal/tui/first_run.go
@@ -151,15 +151,6 @@ func (p *FirstRunPanel) cycle(delta int) {
 	}
 }
 
-func (p *FirstRunPanel) setValue(label, value string) {
-	for i := range p.fields {
-		if p.fields[i].Label == label {
-			p.fields[i].Value = value
-			return
-		}
-	}
-}
-
 func (p FirstRunPanel) View() string {
 	var b strings.Builder
 	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230")).Render("DefenseClaw first-run setup")

--- a/internal/tui/mcps.go
+++ b/internal/tui/mcps.go
@@ -61,6 +61,11 @@ type mcpItem struct {
 	ServerURL string
 	Severity  string
 	Verdict   string
+	// RegistrySource is the id of the registry source whose
+	// asset_policy rule covers this MCP server. See the
+	// SkillsPanel docstring — same semantics. Empty when the
+	// server isn't registry-backed.
+	RegistrySource string
 }
 
 type MCPDetailInfo struct {
@@ -92,10 +97,30 @@ type MCPsPanel struct {
 	// "Source: …" banner so operators know which agent's MCP
 	// config their list reflects.
 	connector string
+
+	// registryByName maps an MCP server name (the value the audit
+	// store and asset_policy keys on) to its registry source id.
+	// Populated by SetRegistryAttribution. nil-safe.
+	registryByName map[string]string
 }
 
 // SetConnector updates the active connector for source labelling.
 func (p *MCPsPanel) SetConnector(name string) { p.connector = name }
+
+// SetRegistryAttribution replaces the in-memory map of MCP server
+// name -> registry source id used to render the "registry:<id>"
+// badge. Callers (app.go's propagateConnector / cfg-reload path)
+// build the map from cfg.AssetPolicy.MCP.Registry. nil-safe — pass
+// nil to clear all attributions.
+func (p *MCPsPanel) SetRegistryAttribution(attr map[string]string) {
+	p.registryByName = attr
+	for i := range p.items {
+		p.items[i].RegistrySource = attr[p.items[i].URL]
+	}
+	for i := range p.filtered {
+		p.filtered[i].RegistrySource = attr[p.filtered[i].URL]
+	}
+}
 
 // ActiveConnector returns the currently labelled connector name —
 // used by app.go to gate connector-specific UX (e.g. ZeptoClaw MCP
@@ -179,6 +204,11 @@ func (p *MCPsPanel) ApplyLoaded(msg MCPsLoadedMsg) {
 		return
 	}
 	p.items = msg.Items
+	if p.registryByName != nil {
+		for i := range p.items {
+			p.items[i].RegistrySource = p.registryByName[p.items[i].URL]
+		}
+	}
 	p.loaded = true
 	p.message = ""
 	p.applyFilter()
@@ -487,6 +517,9 @@ func (p *MCPsPanel) View() string {
 		}
 
 		line := fmt.Sprintf("%s%s %-22s %-10s %s %-18s", pointer, badge, name, transport, sev, actions)
+		if rb := registryBadge(item.RegistrySource); rb != "" {
+			line += " " + rb
+		}
 
 		if i == p.cursor {
 			line = lipgloss.NewStyle().Background(lipgloss.Color("236")).Width(p.width).Render(line)
@@ -577,6 +610,11 @@ func (p *MCPsPanel) renderDetail() string {
 	}
 	if info.Item.Command != "" {
 		d.WriteString(labelStyle.Render("  Command: ") + valStyle.Render(info.Item.Command) + "\n")
+	}
+	if info.Item.RegistrySource != "" {
+		d.WriteString(labelStyle.Render("  Approved by: ") +
+			valStyle.Render("registry:"+info.Item.RegistrySource) +
+			labelStyle.Render("   (press R for registry view)") + "\n")
 	}
 
 	if info.Action != nil {

--- a/internal/tui/notifications_modal.go
+++ b/internal/tui/notifications_modal.go
@@ -1,0 +1,179 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// NotificationsToggleModal is the [N]-from-Overview/Logs confirmation
+// overlay for the user-session OS notifier. Lighter-weight than
+// RedactionToggleModal because the privacy implications are
+// symmetric (both directions are reversible and never alter
+// persisted audit content) — the modal exists so the operator
+// confirms the change explicitly rather than triggering it on a
+// stray keystroke, and to surface what the dispatcher actually
+// covers (block / would-block / approval) so a "yes" answer is
+// informed.
+//
+// Like RedactionToggleModal, the modal is stateful only over its
+// visibility + the cached "currently-enabled" flag; the actual flip
+// is dispatched by the owning Model so the subprocess plumbing
+// (defenseclaw setup notifications <on|off> --yes) lives next to
+// the other CLI dispatches in app.go.
+type NotificationsToggleModal struct {
+	visible          bool
+	width, height    int
+	theme            *Theme
+	currentlyEnabled bool
+}
+
+// NewNotificationsToggleModal allocates a hidden modal bound to theme.
+// Reusable: Show / Hide may be called any number of times.
+func NewNotificationsToggleModal(theme *Theme) NotificationsToggleModal {
+	return NotificationsToggleModal{theme: theme}
+}
+
+// Show opens the modal with the current notifications state captured
+// so the caller can decide which CLI subcommand to dispatch on
+// confirm. “currentlyEnabled“ mirrors the “notifications.enabled“
+// config field at the moment of the keypress; we cache rather than
+// re-poll so the modal copy stays consistent across the prompt.
+func (n *NotificationsToggleModal) Show(currentlyEnabled bool) {
+	n.visible = true
+	n.currentlyEnabled = currentlyEnabled
+}
+
+// Hide closes the modal without dispatching anything.
+func (n *NotificationsToggleModal) Hide() { n.visible = false }
+
+// IsVisible reports whether the modal should consume keys / paint.
+func (n *NotificationsToggleModal) IsVisible() bool { return n.visible }
+
+// SetSize plumbs surrounding TUI dimensions so the View() box can
+// pick a sensible width.
+func (n *NotificationsToggleModal) SetSize(w, h int) {
+	n.width = w
+	n.height = h
+}
+
+// CurrentlyEnabled reports the cached state at Show() time.
+// Owning Model uses this to pick the "on" or "off" subcommand.
+func (n *NotificationsToggleModal) CurrentlyEnabled() bool { return n.currentlyEnabled }
+
+// DesiredAction returns the CLI subcommand (“on“ or “off“)
+// that flipping the current state would produce. Caller passes
+// this directly to “defenseclaw setup notifications <action> --yes“.
+func (n *NotificationsToggleModal) DesiredAction() string {
+	if n.currentlyEnabled {
+		return "off"
+	}
+	return "on"
+}
+
+// View renders the modal box. Layout intentionally parallels
+// RedactionToggleModal so an operator who's seen one immediately
+// understands the other.
+func (n *NotificationsToggleModal) View() string {
+	if !n.visible {
+		return ""
+	}
+
+	desired := n.DesiredAction()
+	currentLabel := "ON  (toasts on every block / approval)"
+	desiredLabel := "OFF (no toasts; audit log unchanged)"
+	if !n.currentlyEnabled {
+		currentLabel = "OFF (no toasts; audit log unchanged)"
+		desiredLabel = "ON  (toasts on every block / approval)"
+	}
+
+	green := lipgloss.NewStyle().Foreground(lipgloss.Color("46")).Bold(true)
+	yellow := lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true)
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230"))
+
+	currentStyled := green.Render(currentLabel)
+	desiredStyled := yellow.Render(desiredLabel)
+	if !n.currentlyEnabled {
+		currentStyled = yellow.Render(currentLabel)
+		desiredStyled = green.Render(desiredLabel)
+	}
+
+	var body strings.Builder
+	body.WriteString(headerStyle.Render("Desktop notifications"))
+	body.WriteString("\n\n")
+	body.WriteString("Current state: " + currentStyled)
+	body.WriteString("\n")
+	body.WriteString("Will become:   " + desiredStyled)
+	body.WriteString("\n\n")
+
+	if desired == "on" {
+		body.WriteString(green.Render("Turning notifications ON") + " surfaces:")
+		body.WriteString("\n")
+		body.WriteString(dim.Render("    • Hook / guardrail / asset-policy blocks"))
+		body.WriteString("\n")
+		body.WriteString(dim.Render("    • Observe-mode would-blocks"))
+		body.WriteString("\n")
+		body.WriteString(dim.Render("    • Pending HITL approval prompts"))
+		body.WriteString("\n\n")
+		body.WriteString(dim.Render("Toasts are informational — clicking does not"))
+		body.WriteString("\n")
+		body.WriteString(dim.Render("approve anything. Reply in chat / TUI as today."))
+	} else {
+		body.WriteString(yellow.Render("Turning notifications OFF") + " stops the toaster.")
+		body.WriteString("\n")
+		body.WriteString(dim.Render("Audit DB / Splunk / OTel / webhooks are NOT affected;"))
+		body.WriteString("\n")
+		body.WriteString(dim.Render("they continue to record blocks and approvals."))
+		body.WriteString("\n\n")
+		body.WriteString(dim.Render("Per-category and per-source filters in"))
+		body.WriteString("\n")
+		body.WriteString(dim.Render("notifications.* let you keep some toasts and silence"))
+		body.WriteString("\n")
+		body.WriteString(dim.Render("others without flipping the master switch."))
+	}
+	body.WriteString("\n\n")
+	body.WriteString(dim.Render("[Enter] confirm    [esc] cancel"))
+
+	w := n.width - 8
+	if w < 56 {
+		w = 56
+	}
+	if w > 80 {
+		w = 80
+	}
+
+	// Off→On (operator opting in)  → green border (positive action).
+	// On→Off (operator opting out) → yellow border (cautionary, but
+	// not red — flipping notifications off is fully reversible and
+	// never alters audit trails, unlike the redaction kill-switch).
+	border := lipgloss.Color("46")
+	if n.currentlyEnabled {
+		border = lipgloss.Color("214")
+	}
+
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(border).
+		Padding(1, 2).
+		Width(w).
+		Render(body.String())
+
+	return box
+}

--- a/internal/tui/notifications_modal_test.go
+++ b/internal/tui/notifications_modal_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNotificationsToggleModal_DesiredAction pins the contract
+// that the modal computes the destination action from the cached
+// "currently enabled" flag. A bug here means [Enter] dispatches
+// the wrong CLI subcommand — flipping the dispatcher state in the
+// opposite direction of what the operator confirmed.
+func TestNotificationsToggleModal_DesiredAction(t *testing.T) {
+	cases := []struct {
+		name    string
+		enabled bool
+		want    string
+	}{
+		{name: "currently_on_flips_to_off", enabled: true, want: "off"},
+		{name: "currently_off_flips_to_on", enabled: false, want: "on"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewNotificationsToggleModal(DefaultTheme())
+			m.Show(tc.enabled)
+			if got := m.DesiredAction(); got != tc.want {
+				t.Fatalf("DesiredAction()=%q, want %q", got, tc.want)
+			}
+			if !m.IsVisible() {
+				t.Fatal("Show() must mark the modal visible")
+			}
+			if m.CurrentlyEnabled() != tc.enabled {
+				t.Fatalf("CurrentlyEnabled()=%v, want %v",
+					m.CurrentlyEnabled(), tc.enabled)
+			}
+			m.Hide()
+			if m.IsVisible() {
+				t.Fatal("Hide() must clear visibility")
+			}
+		})
+	}
+}
+
+// TestNotificationsToggleModal_View_OnBranch guards the wording an
+// operator sees when flipping notifications ON. The modal must
+// describe what categories the dispatcher actually surfaces (block,
+// would-block, HITL approval) so a "yes" answer is informed —
+// dropping that list defeats the purpose of the confirmation step.
+func TestNotificationsToggleModal_View_OnBranch(t *testing.T) {
+	m := NewNotificationsToggleModal(DefaultTheme())
+	m.SetSize(80, 24)
+	m.Show(false) // currently OFF → modal offers to flip ON
+
+	v := m.View()
+	for _, want := range []string{
+		"Desktop notifications",
+		"blocks",
+		"approval",
+	} {
+		if !strings.Contains(v, want) {
+			t.Errorf("View() missing required substring %q\n--- view ---\n%s",
+				want, v)
+		}
+	}
+}
+
+// TestNotificationsToggleModal_View_OffBranch checks the OFF
+// transition surfaces the audit-trail invariant: the toaster
+// silences, but the audit DB / SIEM / webhook sinks keep working.
+// Operators who turn off toasts because they're noisy must not
+// mistakenly think they've also turned off compliance logging.
+func TestNotificationsToggleModal_View_OffBranch(t *testing.T) {
+	m := NewNotificationsToggleModal(DefaultTheme())
+	m.SetSize(80, 24)
+	m.Show(true) // currently ON → modal offers to flip OFF
+
+	v := m.View()
+	for _, want := range []string{
+		"Desktop notifications",
+		"Audit",
+		"NOT affected",
+	} {
+		if !strings.Contains(v, want) {
+			t.Errorf("View() missing required substring %q\n--- view ---\n%s",
+				want, v)
+		}
+	}
+}
+
+// TestNotificationsToggleModal_View_HiddenWhenNotVisible pins the
+// invariant that View() returns empty when the modal is hidden,
+// matching the redaction modal contract. Owning Model relies on
+// this so it never overlays a stale modal frame on the active
+// panel after Hide().
+func TestNotificationsToggleModal_View_HiddenWhenNotVisible(t *testing.T) {
+	m := NewNotificationsToggleModal(DefaultTheme())
+	m.SetSize(80, 24)
+	if got := m.View(); got != "" {
+		t.Fatalf("View() on hidden modal returned %q, want empty", got)
+	}
+	m.Show(false)
+	if m.View() == "" {
+		t.Fatal("View() returned empty after Show()")
+	}
+	m.Hide()
+	if got := m.View(); got != "" {
+		t.Fatalf("View() after Hide() returned %q, want empty", got)
+	}
+}

--- a/internal/tui/overview.go
+++ b/internal/tui/overview.go
@@ -968,6 +968,7 @@ func (p *OverviewPanel) renderQuickActions(width int) string {
 		key.Render("[p]") + dim.Render(" Policy"),
 		key.Render("[l]") + dim.Render(" Logs"),
 		key.Render("[R]") + dim.Render(" Redaction"),
+		key.Render("[N]") + dim.Render(" Notify"),
 		key.Render("[u]") + dim.Render(" Upgrade"),
 		dangerKey.Render("[X]") + dangerText.Render(" Uninstall"),
 		key.Render("[?]") + dim.Render(" Help"),
@@ -995,6 +996,7 @@ var quickActionDefs = []struct {
 	{"p", 10}, // "[p] Policy"
 	{"l", 8},  // "[l] Logs"
 	{"R", 13}, // "[R] Redaction"
+	{"N", 10}, // "[N] Notify"
 	{"u", 11}, // "[u] Upgrade"
 	{"X", 13}, // "[X] Uninstall"
 	{"?", 8},  // "[?] Help"

--- a/internal/tui/registries.go
+++ b/internal/tui/registries.go
@@ -1,0 +1,715 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+)
+
+// Registries panel sub-tabs. The numbering matches the in-panel
+// 1/2/3 keybindings so the constants double as positional indices in
+// the View() rendering.
+const (
+	registriesTabSources = iota
+	registriesTabEntries
+	registriesTabApproved
+	registriesTabCount
+)
+
+var registriesTabNames = [registriesTabCount]string{
+	"Sources", "Entries", "Approved",
+}
+
+// registryEntryRow is one verdict row read from
+// ~/.defenseclaw/registries/<id>/index.json. The struct is intentionally
+// loose-typed strings so we can render it without a hard dependency on
+// the cli/defenseclaw/registries Python types — the JSON file is the
+// contract between the two sides.
+type registryEntryRow struct {
+	SourceID  string `json:"source_id"`
+	Type      string `json:"type"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Severity  string `json:"severity"`
+	Findings  int    `json:"findings"`
+	Approved  bool   `json:"approved"`
+	Rejected  bool   `json:"rejected"`
+	Transport string `json:"transport"`
+	Command   string `json:"command"`
+	URL       string `json:"url"`
+	SourceURL string `json:"source_url"`
+}
+
+// indexFile mirrors the cache.SourceIndex JSON shape — only the
+// fields the TUI actually renders. New fields can land in the JSON
+// without forcing a TUI release; we ignore unknown keys.
+type indexFile struct {
+	SourceID     string           `json:"source_id"`
+	FetchedAt    string           `json:"fetched_at"`
+	Publisher    string           `json:"publisher"`
+	EntryCount   int              `json:"entry_count"`
+	CleanCount   int              `json:"clean_count"`
+	WarningCount int              `json:"warning_count"`
+	BlockedCount int              `json:"blocked_count"`
+	ErrorCount   int              `json:"error_count"`
+	Verdicts     []map[string]any `json:"verdicts"`
+}
+
+// RegistriesPanel surfaces external skill / MCP catalog sources to
+// operators. It mirrors the SkillsPanel/ToolsPanel surface (Refresh,
+// CursorUp/Down, Selected, ScrollBy, View) so the same router code in
+// app.go can drive it. Sub-tabs are switched with 1/2/3.
+//
+// The panel is read-only by design: every mutation (sync, approve,
+// reject, edit, remove) is a shell-out to `defenseclaw registry ...`
+// dispatched via the shared CommandExecutor. That keeps the
+// CLI/TUI behaviour identical and means tests for the underlying
+// behaviour live in cli/tests/test_cmd_registry.py.
+type RegistriesPanel struct {
+	cfg      *config.Config
+	executor *CommandExecutor
+	dataDir  string
+
+	tab     int
+	cursor  int
+	width   int
+	height  int
+	message string
+
+	// filterEntryName is set when an external caller (Skills /
+	// MCPs panel cross-link) wants the Entries tab to focus on a
+	// single named entry. Cleared on tab change so it doesn't
+	// silently filter unrelated views.
+	filterEntryName string
+
+	// Loaded data — recomputed on each Refresh().
+	sources []config.RegistrySource
+	indexes map[string]indexFile
+}
+
+// NewRegistriesPanel constructs the panel bound to a live config (for
+// the source list) and the data dir (for the on-disk index files).
+func NewRegistriesPanel(cfg *config.Config, executor *CommandExecutor) RegistriesPanel {
+	dataDir := ""
+	if cfg != nil {
+		dataDir = cfg.DataDir
+	}
+	p := RegistriesPanel{
+		cfg:      cfg,
+		executor: executor,
+		dataDir:  dataDir,
+		indexes:  map[string]indexFile{},
+	}
+	p.Refresh()
+	return p
+}
+
+// SetSize is the standard panel-API hook so the resize router can
+// keep the list viewport aligned with the terminal.
+func (p *RegistriesPanel) SetSize(w, h int) {
+	p.width = w
+	p.height = h
+}
+
+// SetTab jumps directly to a sub-tab; used by external callers
+// (Skills / MCPs panels) that want to land on Entries with a filter
+// already applied.
+func (p *RegistriesPanel) SetTab(tab int) {
+	if tab < 0 || tab >= registriesTabCount {
+		return
+	}
+	if tab != p.tab {
+		p.cursor = 0
+		p.filterEntryName = ""
+	}
+	p.tab = tab
+}
+
+// FocusEntry pre-loads the Entries tab and pins the cursor on the
+// requested (type, name). Used by the Skills / MCPs panels' 'R'
+// keybind so muscle memory carries over.
+//
+// On a hit: the filter is set so the operator only sees rows for
+// that name (useful when a skill is approved by multiple sources).
+// On a miss: the filter is cleared so the operator lands on the
+// full Entries table instead of an empty filtered view — naming
+// conventions differ between local installs and registry manifests
+// (e.g. smithery normalises “@scope/name“ to “scope-name“), and
+// we'd rather show the operator something useful than nothing.
+func (p *RegistriesPanel) FocusEntry(entryType, name string) {
+	p.tab = registriesTabEntries
+
+	// Try the filtered view first. Build rows directly so the
+	// match check doesn't see a stale filterEntryName.
+	p.filterEntryName = ""
+	rows := p.entryRows()
+	for i, r := range rows {
+		if r.Type == entryType && r.Name == name {
+			p.cursor = i
+			p.filterEntryName = entryType + ":" + name
+			// Re-fetch with the filter in place so cursor maps
+			// onto the post-filter index — entryRows() returns a
+			// stable order so the existing match still wins.
+			filtered := p.entryRows()
+			for j, fr := range filtered {
+				if fr.Type == entryType && fr.Name == name {
+					p.cursor = j
+					return
+				}
+			}
+			return
+		}
+	}
+	// No match — leave the filter cleared so the operator sees the
+	// full table and can pick the correct row themselves.
+	p.cursor = 0
+}
+
+// Refresh re-reads the source list from cfg and the on-disk indexes.
+// Cheap (one file per source) so we call it on tab changes too.
+func (p *RegistriesPanel) Refresh() {
+	if p.cfg == nil {
+		return
+	}
+	p.sources = append(p.sources[:0], p.cfg.Registries.Sources...)
+	sort.SliceStable(p.sources, func(i, j int) bool {
+		return p.sources[i].ID < p.sources[j].ID
+	})
+
+	p.indexes = map[string]indexFile{}
+	for _, s := range p.sources {
+		idx, err := loadRegistryIndex(p.dataDir, s.ID)
+		if err == nil {
+			p.indexes[s.ID] = idx
+		}
+	}
+	p.message = ""
+	if p.cursor < 0 {
+		p.cursor = 0
+	}
+	max := p.rowCount() - 1
+	if p.cursor > max && max >= 0 {
+		p.cursor = max
+	}
+}
+
+// CursorUp / CursorDown / ScrollBy keep the panel responsive to the
+// shared list-navigation keys handled in app.go.
+func (p *RegistriesPanel) CursorUp() {
+	if p.cursor > 0 {
+		p.cursor--
+	}
+}
+
+func (p *RegistriesPanel) CursorDown() {
+	if p.cursor < p.rowCount()-1 {
+		p.cursor++
+	}
+}
+
+func (p *RegistriesPanel) ScrollBy(delta int) {
+	p.cursor += delta
+	if p.cursor < 0 {
+		p.cursor = 0
+	}
+	if p.cursor >= p.rowCount() {
+		p.cursor = p.rowCount() - 1
+		if p.cursor < 0 {
+			p.cursor = 0
+		}
+	}
+}
+
+// CurrentTab returns the active sub-tab index (used by tests).
+func (p *RegistriesPanel) CurrentTab() int { return p.tab }
+
+// Cursor / RowCount accessors for tests.
+func (p *RegistriesPanel) Cursor() int   { return p.cursor }
+func (p *RegistriesPanel) RowCount() int { return p.rowCount() }
+
+// SelectedSource returns the highlighted source on the Sources tab,
+// or nil if the tab/cursor combination doesn't address a source.
+func (p *RegistriesPanel) SelectedSource() *config.RegistrySource {
+	if p.tab != registriesTabSources {
+		return nil
+	}
+	if p.cursor < 0 || p.cursor >= len(p.sources) {
+		return nil
+	}
+	return &p.sources[p.cursor]
+}
+
+// SelectedEntry returns the highlighted entry on the Entries / Approved
+// tabs. Nil when the tab is Sources or the row count is zero.
+func (p *RegistriesPanel) SelectedEntry() *registryEntryRow {
+	rows := p.entryRows()
+	if p.cursor < 0 || p.cursor >= len(rows) {
+		return nil
+	}
+	return &rows[p.cursor]
+}
+
+// HandleKey processes a panel-local keystroke. Returns (handled, label,
+// argv, hint). When `handled` is false the global router falls
+// through to its standard handlers.
+func (p *RegistriesPanel) HandleKey(key string) (bool, string, []string, string) {
+	switch key {
+	case "1":
+		p.SetTab(registriesTabSources)
+		return true, "", nil, ""
+	case "2":
+		p.SetTab(registriesTabEntries)
+		return true, "", nil, ""
+	case "3":
+		p.SetTab(registriesTabApproved)
+		return true, "", nil, ""
+	case "r":
+		p.Refresh()
+		return true, "", nil, "Refreshed."
+	case "s":
+		// 's' on the Sources tab triggers `registry sync <id>`. On
+		// Entries / Approved, it syncs the source the cursor is on.
+		sid := p.cursorSourceID()
+		if sid == "" {
+			return true, "", nil, "(no source selected)"
+		}
+		return true, "registry sync " + sid,
+			[]string{"registry", "sync", sid, "--json"},
+			fmt.Sprintf("Syncing %s ...", sid)
+	case "S":
+		return true, "registry sync --all",
+			[]string{"registry", "sync", "--all", "--json"},
+			"Syncing all enabled sources ..."
+	case "a":
+		// approve highlighted entry
+		row := p.SelectedEntry()
+		if row == nil {
+			return true, "", nil, "(no entry selected)"
+		}
+		return true, fmt.Sprintf("registry approve %s %s", row.SourceID, row.Name),
+			[]string{
+				"registry", "approve", row.SourceID, row.Name,
+				"--type", row.Type, "--json",
+			},
+			"Approving " + row.Name
+	case "x":
+		row := p.SelectedEntry()
+		if row == nil {
+			return true, "", nil, "(no entry selected)"
+		}
+		return true, fmt.Sprintf("registry reject %s %s", row.SourceID, row.Name),
+			[]string{
+				"registry", "reject", row.SourceID, row.Name,
+				"--type", row.Type, "--json",
+			},
+			"Rejecting " + row.Name
+	case "d":
+		// `d` removes the highlighted source — mirrors the Skills /
+		// MCPs unblock convention. Only fires on Sources tab to
+		// avoid accidental deletes from Entries.
+		if p.tab != registriesTabSources {
+			return false, "", nil, ""
+		}
+		src := p.SelectedSource()
+		if src == nil {
+			return true, "", nil, "(no source selected)"
+		}
+		return true, "registry remove " + src.ID,
+			[]string{
+				"registry", "remove", src.ID,
+				"--non-interactive", "--json",
+			},
+			"Removing " + src.ID
+	}
+	return false, "", nil, ""
+}
+
+// View renders the panel. Layout: header (tab bar + filter hint) →
+// table → footer (per-tab keybind cheatsheet).
+func (p *RegistriesPanel) View(width, height int) string {
+	if width > 0 {
+		p.width = width
+	}
+	if height > 0 {
+		p.height = height
+	}
+	if p.message != "" {
+		return p.message
+	}
+
+	var b strings.Builder
+	b.WriteString(p.renderTabBar())
+	b.WriteString("\n")
+	b.WriteString(strings.Repeat("─", maxInt(20, p.width-2)))
+	b.WriteString("\n")
+
+	switch p.tab {
+	case registriesTabSources:
+		b.WriteString(p.renderSourcesTable())
+	case registriesTabEntries:
+		b.WriteString(p.renderEntriesTable(false))
+	case registriesTabApproved:
+		b.WriteString(p.renderEntriesTable(true))
+	}
+
+	b.WriteString("\n")
+	b.WriteString(p.renderFooter())
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// Rendering helpers
+// ---------------------------------------------------------------------------
+
+func (p *RegistriesPanel) renderTabBar() string {
+	parts := make([]string, 0, registriesTabCount)
+	for i := 0; i < registriesTabCount; i++ {
+		label := fmt.Sprintf("[%d] %s", i+1, registriesTabNames[i])
+		if i == p.tab {
+			label = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("213")).
+				Bold(true).
+				Render(label)
+		} else {
+			label = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("242")).
+				Render(label)
+		}
+		parts = append(parts, label)
+	}
+	return strings.Join(parts, "  ")
+}
+
+func (p *RegistriesPanel) renderFooter() string {
+	hints := []string{}
+	switch p.tab {
+	case registriesTabSources:
+		hints = []string{
+			"[s]ync", "[S]ync all", "[d]elete", "[r]efresh",
+			"[1-3] tabs",
+		}
+	case registriesTabEntries:
+		hints = []string{
+			"[a]pprove", "[x] reject", "[s]ync source",
+			"[r]efresh", "[1-3] tabs",
+		}
+	case registriesTabApproved:
+		hints = []string{
+			"[x] reject", "[s]ync source", "[r]efresh", "[1-3] tabs",
+		}
+	}
+	return lipgloss.NewStyle().
+		Foreground(lipgloss.Color("242")).
+		Render(strings.Join(hints, "  "))
+}
+
+func (p *RegistriesPanel) renderSourcesTable() string {
+	if len(p.sources) == 0 {
+		return lipgloss.NewStyle().
+			Foreground(lipgloss.Color("242")).
+			Render("No registry sources configured. Run `defenseclaw registry add` or use the Setup wizard.")
+	}
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf(
+		"  %-22s %-10s %-7s %-3s %-22s %s\n",
+		"ID", "KIND", "CONTENT", "ON", "LAST SYNC", "STATUS",
+	))
+	for i, s := range p.sources {
+		marker := "  "
+		if i == p.cursor {
+			marker = "» "
+		}
+		on := "no"
+		if s.Enabled {
+			on = "yes"
+		}
+		last := s.LastSync
+		if last == "" {
+			last = "(never)"
+		}
+		status := s.LastStatus
+		if status == "" {
+			status = "-"
+		}
+		row := fmt.Sprintf(
+			"%s%-22s %-10s %-7s %-3s %-22s %s",
+			marker, truncate(s.ID, 22), s.Kind, s.Content, on, last,
+			truncate(status, maxInt(8, p.width-72)),
+		)
+		if i == p.cursor {
+			row = lipgloss.NewStyle().Bold(true).Render(row)
+		}
+		b.WriteString(row + "\n")
+	}
+	return b.String()
+}
+
+func (p *RegistriesPanel) renderEntriesTable(approvedOnly bool) string {
+	rows := p.entryRowsFiltered(approvedOnly)
+	if len(rows) == 0 {
+		hint := "Sync a source to populate this view."
+		if approvedOnly {
+			hint = "No entries approved yet. Press 'a' on the Entries tab to approve one."
+		}
+		return lipgloss.NewStyle().
+			Foreground(lipgloss.Color("242")).
+			Render(hint)
+	}
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf(
+		"  %-20s %-22s %-6s %-9s %-7s %-3s %s\n",
+		"SOURCE", "NAME", "TYPE", "STATUS", "SEV", "A/R", "LOCATION",
+	))
+	for i, r := range rows {
+		marker := "  "
+		if i == p.cursor {
+			marker = "» "
+		}
+		ar := "--"
+		switch {
+		case r.Approved:
+			ar = "A-"
+		case r.Rejected:
+			ar = "-R"
+		}
+		loc := r.URL
+		if loc == "" {
+			loc = r.Command
+			if loc == "" {
+				loc = r.SourceURL
+			}
+		}
+		row := fmt.Sprintf(
+			"%s%-20s %-22s %-6s %-9s %-7s %-3s %s",
+			marker,
+			truncate(r.SourceID, 20),
+			truncate(r.Name, 22),
+			r.Type, statusLabel(r.Status), defaultStr(r.Severity, "-"),
+			ar, truncate(loc, maxInt(16, p.width-90)),
+		)
+		if i == p.cursor {
+			row = lipgloss.NewStyle().Bold(true).Render(row)
+		}
+		b.WriteString(row + "\n")
+	}
+	return b.String()
+}
+
+// statusLabel colourises the status string. Hot colours for blocked /
+// error so an operator scanning the table sees them at a glance.
+func statusLabel(status string) string {
+	switch status {
+	case "clean":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("34")).Render("clean")
+	case "warning":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render("warning")
+	case "blocked":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render("blocked")
+	case "error":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("160")).Render("error")
+	case "":
+		return "-"
+	default:
+		return status
+	}
+}
+
+func defaultStr(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+// registryBadge formats a small "registry:<id>" pill for use on
+// Skills / MCPs panel rows. Returns the empty string when *sourceID*
+// is empty so the caller can append it unconditionally without an
+// extra guard. Truncates long ids so a verbose source name doesn't
+// blow out the row width budget; the detail view shows the untrimmed
+// value when the operator opens it.
+func registryBadge(sourceID string) string {
+	id := strings.TrimSpace(sourceID)
+	if id == "" {
+		return ""
+	}
+	if len(id) > 18 {
+		id = id[:15] + "…"
+	}
+	return lipgloss.NewStyle().
+		Foreground(lipgloss.Color("117")).
+		Render("registry:" + id)
+}
+
+// ---------------------------------------------------------------------------
+// Cursor / row helpers
+// ---------------------------------------------------------------------------
+
+func (p *RegistriesPanel) rowCount() int {
+	switch p.tab {
+	case registriesTabSources:
+		return len(p.sources)
+	case registriesTabEntries:
+		return len(p.entryRowsFiltered(false))
+	case registriesTabApproved:
+		return len(p.entryRowsFiltered(true))
+	}
+	return 0
+}
+
+// entryRows returns the union of every cached source's verdicts so
+// the Entries tab is a single table the operator can scroll. Sources
+// are interleaved by id so all rows for one source stay together.
+func (p *RegistriesPanel) entryRows() []registryEntryRow {
+	var out []registryEntryRow
+	for _, s := range p.sources {
+		idx, ok := p.indexes[s.ID]
+		if !ok {
+			continue
+		}
+		for _, raw := range idx.Verdicts {
+			row := verdictToRow(s.ID, raw)
+			out = append(out, row)
+		}
+	}
+	if p.filterEntryName != "" {
+		want := p.filterEntryName
+		filtered := out[:0]
+		for _, r := range out {
+			if r.Type+":"+r.Name == want {
+				filtered = append(filtered, r)
+			}
+		}
+		out = filtered
+	}
+	return out
+}
+
+func (p *RegistriesPanel) entryRowsFiltered(approvedOnly bool) []registryEntryRow {
+	rows := p.entryRows()
+	if !approvedOnly {
+		return rows
+	}
+	out := rows[:0]
+	for _, r := range rows {
+		if r.Approved {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (p *RegistriesPanel) cursorSourceID() string {
+	switch p.tab {
+	case registriesTabSources:
+		if src := p.SelectedSource(); src != nil {
+			return src.ID
+		}
+	case registriesTabEntries, registriesTabApproved:
+		if row := p.SelectedEntry(); row != nil {
+			return row.SourceID
+		}
+	}
+	return ""
+}
+
+func verdictToRow(sourceID string, raw map[string]any) registryEntryRow {
+	getStr := func(k string) string {
+		if v, ok := raw[k]; ok {
+			if s, ok := v.(string); ok {
+				return s
+			}
+		}
+		return ""
+	}
+	getBool := func(k string) bool {
+		if v, ok := raw[k]; ok {
+			if b, ok := v.(bool); ok {
+				return b
+			}
+		}
+		return false
+	}
+	getInt := func(k string) int {
+		if v, ok := raw[k]; ok {
+			switch n := v.(type) {
+			case float64:
+				return int(n)
+			case int:
+				return n
+			}
+		}
+		return 0
+	}
+	return registryEntryRow{
+		SourceID:  sourceID,
+		Type:      getStr("type"),
+		Name:      getStr("name"),
+		Status:    getStr("status"),
+		Severity:  getStr("severity"),
+		Findings:  getInt("findings"),
+		Approved:  getBool("approved"),
+		Rejected:  getBool("rejected"),
+		Transport: getStr("transport"),
+		Command:   getStr("command"),
+		URL:       getStr("url"),
+		SourceURL: getStr("source_url"),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Disk I/O
+// ---------------------------------------------------------------------------
+
+// loadRegistryIndex reads the on-disk index.json for *sourceID* under
+// *dataDir*. Returns an empty :class:`indexFile` and a non-nil error
+// when the file is missing or corrupt — both are non-fatal: the
+// Sources table renders fine without an index, the Entries tab just
+// shows a "sync to populate" hint.
+func loadRegistryIndex(dataDir, sourceID string) (indexFile, error) {
+	if dataDir == "" || sourceID == "" {
+		return indexFile{}, fmt.Errorf("missing dataDir or sourceID")
+	}
+	if strings.ContainsAny(sourceID, "/\\.") {
+		// Defence-in-depth: cli/defenseclaw/registries/cache.py
+		// also rejects these. Block paths that would escape the
+		// cache root regardless of how they got into config.
+		return indexFile{}, fmt.Errorf("unsafe source id: %q", sourceID)
+	}
+	path := filepath.Join(dataDir, "registries", sourceID, "index.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return indexFile{}, err
+	}
+	var out indexFile
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return indexFile{}, err
+	}
+	if out.SourceID == "" {
+		out.SourceID = sourceID
+	}
+	return out, nil
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/tui/registries_test.go
+++ b/internal/tui/registries_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+)
+
+// writeIndex creates a fake on-disk verdict index for sourceID under
+// dataDir, mirroring the layout written by
+// cli/defenseclaw/registries/cache.py::save_index.
+func writeIndex(t *testing.T, dataDir, sourceID string, index map[string]any) {
+	t.Helper()
+	dir := filepath.Join(dataDir, "registries", sourceID)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	path := filepath.Join(dir, "index.json")
+	data, err := json.Marshal(index)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func newRegistriesPanelForTest(t *testing.T) (*RegistriesPanel, string) {
+	t.Helper()
+	dataDir := t.TempDir()
+	cfg := &config.Config{
+		DataDir: dataDir,
+		Registries: config.RegistriesConfig{
+			Sources: []config.RegistrySource{
+				{
+					ID:      "corp-skills",
+					Kind:    "http_yaml",
+					URL:     "https://catalog.example.com/skills.yaml",
+					Content: "skill",
+					Enabled: true,
+				},
+				{
+					ID:      "smithery-public",
+					Kind:    "smithery",
+					Content: "mcp",
+					Enabled: false,
+				},
+			},
+		},
+	}
+	p := NewRegistriesPanel(cfg, nil)
+	p.SetSize(120, 40)
+	return &p, dataDir
+}
+
+func TestRegistriesPanelLoadsSources(t *testing.T) {
+	p, _ := newRegistriesPanelForTest(t)
+	if got := p.RowCount(); got != 2 {
+		t.Fatalf("RowCount = %d, want 2 (sources tab)", got)
+	}
+	src := p.SelectedSource()
+	if src == nil {
+		t.Fatal("SelectedSource returned nil on Sources tab")
+	}
+	// Sources are sorted by id, so corp-skills sorts before
+	// smithery-public.
+	if src.ID != "corp-skills" {
+		t.Fatalf("first source id = %q, want corp-skills", src.ID)
+	}
+}
+
+func TestRegistriesPanelTabSwitchResetsCursor(t *testing.T) {
+	p, _ := newRegistriesPanelForTest(t)
+	p.CursorDown()
+	if p.Cursor() != 1 {
+		t.Fatalf("Cursor() = %d, want 1", p.Cursor())
+	}
+	p.SetTab(registriesTabEntries)
+	if p.Cursor() != 0 {
+		t.Fatalf("tab change should reset cursor; got %d", p.Cursor())
+	}
+	if p.CurrentTab() != registriesTabEntries {
+		t.Fatalf("CurrentTab = %d, want %d", p.CurrentTab(), registriesTabEntries)
+	}
+}
+
+func TestRegistriesPanelEntriesTabReadsIndex(t *testing.T) {
+	p, dataDir := newRegistriesPanelForTest(t)
+	writeIndex(t, dataDir, "corp-skills", map[string]any{
+		"source_id": "corp-skills",
+		"verdicts": []map[string]any{
+			{
+				"name":     "demo-skill",
+				"type":     "skill",
+				"status":   "clean",
+				"approved": false,
+			},
+			{
+				"name":     "blocked-skill",
+				"type":     "skill",
+				"status":   "blocked",
+				"severity": "HIGH",
+			},
+		},
+	})
+	p.Refresh()
+	p.SetTab(registriesTabEntries)
+	if p.RowCount() != 2 {
+		t.Fatalf("entries RowCount = %d, want 2", p.RowCount())
+	}
+	row := p.SelectedEntry()
+	if row == nil {
+		t.Fatal("SelectedEntry returned nil")
+	}
+	if row.SourceID != "corp-skills" {
+		t.Errorf("SourceID = %q", row.SourceID)
+	}
+}
+
+func TestRegistriesPanelApprovedFilter(t *testing.T) {
+	p, dataDir := newRegistriesPanelForTest(t)
+	writeIndex(t, dataDir, "corp-skills", map[string]any{
+		"verdicts": []map[string]any{
+			{"name": "a", "type": "skill", "status": "clean", "approved": true},
+			{"name": "b", "type": "skill", "status": "clean", "approved": false},
+		},
+	})
+	p.Refresh()
+	p.SetTab(registriesTabApproved)
+	if p.RowCount() != 1 {
+		t.Fatalf("approved RowCount = %d, want 1", p.RowCount())
+	}
+	row := p.SelectedEntry()
+	if row == nil || row.Name != "a" {
+		t.Fatalf("approved row = %+v, want name=a", row)
+	}
+}
+
+func TestRegistriesPanelFocusEntry(t *testing.T) {
+	p, dataDir := newRegistriesPanelForTest(t)
+	writeIndex(t, dataDir, "corp-skills", map[string]any{
+		"verdicts": []map[string]any{
+			{"name": "a", "type": "skill", "status": "clean"},
+			{"name": "b", "type": "skill", "status": "clean"},
+		},
+	})
+	p.Refresh()
+	p.FocusEntry("skill", "b")
+	if p.CurrentTab() != registriesTabEntries {
+		t.Fatalf("FocusEntry should switch to Entries tab")
+	}
+	row := p.SelectedEntry()
+	if row == nil || row.Name != "b" {
+		t.Fatalf("FocusEntry didn't land on requested entry: %+v", row)
+	}
+}
+
+func TestRegistriesPanelHandleKeyTabs(t *testing.T) {
+	p, _ := newRegistriesPanelForTest(t)
+	if handled, _, _, _ := p.HandleKey("2"); !handled {
+		t.Fatal("'2' should switch to Entries tab")
+	}
+	if p.CurrentTab() != registriesTabEntries {
+		t.Fatalf("after '2', CurrentTab = %d", p.CurrentTab())
+	}
+	if handled, _, _, _ := p.HandleKey("3"); !handled {
+		t.Fatal("'3' should switch to Approved tab")
+	}
+	if p.CurrentTab() != registriesTabApproved {
+		t.Fatalf("after '3', CurrentTab = %d", p.CurrentTab())
+	}
+}
+
+func TestRegistriesPanelHandleKeySync(t *testing.T) {
+	p, _ := newRegistriesPanelForTest(t)
+	handled, label, args, _ := p.HandleKey("s")
+	if !handled {
+		t.Fatal("'s' should be handled")
+	}
+	if !strings.Contains(label, "registry sync") {
+		t.Fatalf("label = %q", label)
+	}
+	if len(args) < 3 || args[0] != "registry" || args[1] != "sync" {
+		t.Fatalf("args = %v, want [registry sync corp-skills ...]", args)
+	}
+}
+
+func TestRegistriesPanelHandleKeyApproveRequiresSelection(t *testing.T) {
+	p, _ := newRegistriesPanelForTest(t)
+	p.SetTab(registriesTabEntries)
+	handled, label, args, hint := p.HandleKey("a")
+	if !handled {
+		t.Fatal("'a' on Entries tab should be handled")
+	}
+	if label != "" || args != nil {
+		t.Fatalf("approve with no rows should not dispatch a command (label=%q, args=%v)",
+			label, args)
+	}
+	if !strings.Contains(hint, "no entry selected") {
+		t.Fatalf("hint = %q", hint)
+	}
+}
+
+func TestLoadRegistryIndexRejectsUnsafeIDs(t *testing.T) {
+	dir := t.TempDir()
+	for _, bad := range []string{"../escape", "a/b", "x.y"} {
+		t.Run(bad, func(t *testing.T) {
+			if _, err := loadRegistryIndex(dir, bad); err == nil {
+				t.Errorf("loadRegistryIndex(%q) should fail", bad)
+			}
+		})
+	}
+}
+
+func TestLoadRegistryIndexMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := loadRegistryIndex(dir, "no-such"); err == nil {
+		t.Fatal("missing index file should produce an error")
+	}
+}

--- a/internal/tui/setup.go
+++ b/internal/tui/setup.go
@@ -45,12 +45,19 @@ const (
 	wizardObservability
 	wizardWebhook
 	wizardSandbox
+	// wizardRegistries (slot 9) registers a new external skill / MCP
+	// catalog source via `defenseclaw registry add --non-interactive`.
+	// The full management surface (sync / approve / reject / require) lives
+	// on the dedicated Registries panel — this wizard is intentionally
+	// just the discoverability hook for first-run users.
+	wizardRegistries
 	wizardCount
 )
 
 var wizardNames = [wizardCount]string{
 	"Skill Scanner", "MCP Scanner", "Gateway",
 	"Guardrail", "Splunk", "Observability", "Webhooks", "Sandbox",
+	"Registries",
 }
 
 var wizardCommands = [wizardCount][]string{
@@ -66,6 +73,9 @@ var wizardCommands = [wizardCount][]string{
 	// "type" field. See buildWizardArgs + webhookWizardFields.
 	{"setup", "webhook", "add"},
 	{"sandbox", "setup"},
+	// Registries: the source id is injected positionally from the
+	// "id" field by buildWizardArgs.
+	{"registry", "add"},
 }
 
 var wizardDescriptions = [wizardCount]string{
@@ -77,6 +87,7 @@ var wizardDescriptions = [wizardCount]string{
 	"Unified OTel + audit sink setup. Pick a preset (Splunk O11y, Splunk HEC, Splunk Enterprise, Datadog, Honeycomb, New Relic, Grafana Cloud, generic OTLP, Generic HTTP JSONL) and fill the prompts. Shells out to `setup observability add`.",
 	"Configure chat/incident notifier webhooks (Slack, PagerDuty, Webex, generic HMAC). Distinct from the observability HTTP JSONL audit-log forwarder. Shells out to `setup webhook add`.",
 	"Initialize and configure sandbox environment (OpenShell policy, networking).",
+	"Register an external skill / MCP catalog source (corp HTTPS YAML, smithery.ai, skills.sh, ClawHub, git repo). The full management surface lives on the Registries panel; this wizard is for first-run discoverability.",
 }
 
 // wizardHowTo gives operators a quick "what this wizard will actually
@@ -117,6 +128,10 @@ var wizardHowTo = [wizardCount]string{
 	"Runs: defenseclaw sandbox setup\n" +
 		"What you'll need: OpenShell binary on PATH (Linux), optional sandbox home directory.\n" +
 		"Tip: macOS has no OpenShell — the wizard will skip runtime checks but still write policy YAML.",
+	// Registries
+	"Runs: defenseclaw registry add <id> --non-interactive\n" +
+		"What you'll need: a kebab-case source id, the source kind (clawhub / smithery / skills_sh / http_yaml / http_json / git / file), the manifest URL (or empty for clawhub/skills_sh defaults), and optionally an env var holding an auth token.\n" +
+		"Tip: Press 'y' on the Registries panel to run a sync immediately after the wizard exits.",
 }
 
 // observabilityPresets mirrors cli/defenseclaw/observability/presets.py::preset_choices().
@@ -379,6 +394,43 @@ func (p *SetupPanel) loadSections() {
 			Fields: []configField{
 				{Label: "Disable Redaction", Key: "privacy.disable_redaction", Kind: "bool", Value: fmt.Sprintf("%v", c.Privacy.DisableRedaction),
 					Hint: "true stores raw content in all sinks. Only use inside a single trusted boundary."},
+			},
+		},
+		// Desktop notifications: master switch + per-category +
+		// per-source + throttle. The [N] modal flips only `enabled`;
+		// dialing in the rest is what this section is for. Save +
+		// gateway restart is needed for any change to take effect
+		// because internal/gateway/notifier.New(cfg.Notifications)
+		// snapshots the config once at sidecar boot.
+		{
+			Name: "Notifications",
+			Summary: "User-session desktop toasts for blocks, would-blocks, and HITL approvals. " +
+				"Local-only — see webhooks[] for chat/incident routing.",
+			Help: "enabled is the master switch. Categories gate event types; sources gate the subsystem that emitted them. " +
+				"dedup_window collapses repeats; max_per_minute caps the global rate (excess rolled into one summary toast). " +
+				"Restart the gateway after editing — the dispatcher snapshots cfg at boot.",
+			Fields: []configField{
+				{Label: "Enabled", Key: "notifications.enabled", Kind: "bool", Value: fmt.Sprintf("%v", c.Notifications.Enabled),
+					Hint: "Master switch. Default: ON on macOS, OFF elsewhere. When false, every other field below is a no-op."},
+				{Label: "── Categories ──", Kind: "header"},
+				{Label: "Block (enforced)", Key: "notifications.block_enforced", Kind: "bool", Value: fmt.Sprintf("%v", c.Notifications.BlockEnforced),
+					Hint: "Toast when a request is actually denied (mode=action, action=block)."},
+				{Label: "Block (would-block)", Key: "notifications.block_would_block", Kind: "bool", Value: fmt.Sprintf("%v", c.Notifications.BlockWouldBlock),
+					Hint: "Toast for observe-mode 'would have blocked' verdicts. Useful while tuning policy; turn off once posture is stable."},
+				{Label: "HITL Approval", Key: "notifications.hitl_approval", Kind: "bool", Value: fmt.Sprintf("%v", c.Notifications.HITLApproval),
+					Hint: "Informational toast when a HILT/confirm prompt is awaiting a user reply in chat / TUI. Click does NOT approve — operator still replies in chat."},
+				{Label: "── Sources ──", Kind: "header"},
+				{Label: "Source: Hook", Key: "notifications.sources.hook", Kind: "bool", Value: fmt.Sprintf("%v", c.Notifications.Sources.Hook),
+					Hint: "Allow notifications from claude_code_hook + codex_hook decisions."},
+				{Label: "Source: Guardrail", Key: "notifications.sources.guardrail", Kind: "bool", Value: fmt.Sprintf("%v", c.Notifications.Sources.Guardrail),
+					Hint: "Allow notifications from GuardrailProxy block / would-block branches (LLM egress proxy)."},
+				{Label: "Source: Asset Policy", Key: "notifications.sources.asset_policy", Kind: "bool", Value: fmt.Sprintf("%v", c.Notifications.Sources.AssetPolicy),
+					Hint: "Allow notifications from asset-policy runtime decisions (skill/MCP allow-list/deny-list)."},
+				{Label: "── Throttle ──", Kind: "header"},
+				{Label: "Dedup Window", Key: "notifications.dedup_window", Kind: "string", Value: fmtNotificationsDedupWindow(c.Notifications.DedupWindow),
+					Hint: "Duration string (e.g. '30s', '1m', '500ms'). Identical (category|source|target|reason) tuples seen inside the window are suppressed. Empty = use default (30s)."},
+				{Label: "Max Per Minute", Key: "notifications.max_per_minute", Kind: "int", Value: fmt.Sprintf("%d", c.Notifications.MaxPerMinute),
+					Hint: "Global rate cap across all categories. Excess collapses into one 'suppressed N notifications' toast per minute. 0 = use default (12)."},
 			},
 		},
 		{
@@ -1323,6 +1375,22 @@ func (p *SetupPanel) buildWizardArgs(idx int) []string {
 		}
 	}
 
+	// Registries: extract the source id from the "regid" picker and
+	// insert it positionally after ``add``. The CLI surface is
+	// ``defenseclaw registry add <id> ...``.
+	if idx == wizardRegistries {
+		regID := ""
+		for _, f := range p.wizFormFields {
+			if f.Kind == "regid" {
+				regID = strings.TrimSpace(f.Value)
+				break
+			}
+		}
+		if regID != "" {
+			base = append(base, regID)
+		}
+	}
+
 	base = append(base, "--non-interactive")
 
 	// For guardrail wizard, combine Provider + Model into
@@ -1348,8 +1416,8 @@ func (p *SetupPanel) buildWizardArgs(idx int) []string {
 
 	for _, f := range p.wizFormFields {
 		switch f.Kind {
-		case "section", "preset", "whtype":
-			// Section dividers are cosmetic; preset/whtype are
+		case "section", "preset", "whtype", "regid":
+			// Section dividers are cosmetic; preset/whtype/regid are
 			// already consumed as positionals above.
 			continue
 		}
@@ -1796,6 +1864,8 @@ func (p *SetupPanel) wizardFormDefs(idx int) []wizardFormField {
 		return observabilityWizardFields("splunk-o11y")
 	case wizardWebhook:
 		return webhookWizardFields("slack")
+	case wizardRegistries:
+		return registryWizardFields()
 	case wizardSandbox:
 		return []wizardFormField{
 			{Label: "Sandbox IP", Flag: "--sandbox-ip", Kind: "string", Default: "10.200.0.2", Value: "10.200.0.2"},
@@ -1939,6 +2009,82 @@ var webhookTypes = [][2]string{
 // Webex additionally requires “room-id“. These line up with
 // webhooks/writer.py::apply_webhook's server-side validation so the
 // TUI catches missing fields before the CLI ever runs.
+// registryKindOptions / registryContentOptions mirror REGISTRY_KINDS /
+// REGISTRY_CONTENT_TYPES in cli/defenseclaw/config.py and
+// internal/config/registries.go::KnownRegistryKinds. Drift would show
+// up as "kind X is not one of …" errors from the CLI — keep them in
+// strict lockstep.
+var registryKindOptions = []string{
+	"clawhub", "smithery", "skills_sh", "http_yaml", "http_json", "git", "file",
+}
+
+var registryContentOptions = []string{"skill", "mcp", "both"}
+
+// registryWizardFields builds the Registries wizard form. The form
+// shells out to `defenseclaw registry add <id> --non-interactive`
+// (the source id is injected positionally by buildWizardArgs from
+// the "regid" Kind field). Required=true is reserved for inputs the
+// CLI's --non-interactive path will reject as missing: the source
+// id, kind, content, and (for non-clawhub kinds) the manifest URL.
+//
+// auth_env carries the env var NAME, never the token itself — the
+// CLI's _validate_auth_env enforces the same rule, and the TUI hint
+// makes that contract obvious to operators who would otherwise paste
+// a literal token.
+func registryWizardFields() []wizardFormField {
+	return []wizardFormField{
+		{
+			Label:    "Source id",
+			Flag:     "", // positional — injected in buildWizardArgs
+			Kind:     "regid",
+			Value:    "corp-skills",
+			Default:  "corp-skills",
+			Required: true,
+			Hint:     "Kebab-case identifier; used as the asset_policy reason tag (registry:<id>).",
+		},
+		{
+			Label:    "Kind",
+			Flag:     "--kind",
+			Kind:     "choice",
+			Options:  registryKindOptions,
+			Value:    "http_yaml",
+			Default:  "http_yaml",
+			Required: true,
+			Hint:     "clawhub=npm openclaw, smithery=registry.smithery.ai, skills_sh=skills.sh public catalog, http_*=corporate manifest, git=clone-and-read.",
+		},
+		{
+			Label:    "Content",
+			Flag:     "--content",
+			Kind:     "choice",
+			Options:  registryContentOptions,
+			Value:    "skill",
+			Default:  "skill",
+			Required: true,
+			Hint:     "Filters which entries promote into asset_policy.{skill,mcp}.registry.",
+		},
+		{
+			Label: "Manifest URL",
+			Flag:  "--url",
+			Kind:  "string",
+			Hint:  "Required for http_yaml / http_json / git / file. Optional for clawhub (defaults to npmjs.org).",
+		},
+		{
+			Label: "Auth env (optional)",
+			Flag:  "--auth-env",
+			Kind:  "string",
+			Hint:  "Env var NAME holding a Bearer token. Never paste the token itself.",
+		},
+		{
+			Label:   "Enabled",
+			Flag:    "--enabled",
+			NoFlag:  "--disabled",
+			Kind:    "bool",
+			Default: "yes",
+			Value:   "yes",
+		},
+	}
+}
+
 func webhookWizardFields(channelType string) []wizardFormField {
 	typeOpts := make([]string, 0, len(webhookTypes))
 	for _, t := range webhookTypes {

--- a/internal/tui/skills.go
+++ b/internal/tui/skills.go
@@ -67,6 +67,15 @@ type skillItem struct {
 	Source      string
 	Verdict     string
 	Severity    string
+	// RegistrySource is the id of the registry source whose
+	// asset_policy rule covers this skill (set by the panel from
+	// cfg.AssetPolicy.Skill.Registry — see SetRegistryAttribution).
+	// Empty when the skill is not registry-backed (manual rule,
+	// admin-allow, or asset_policy disabled). Surfaced as a small
+	// "registry:<id>" badge on the row + a "Approved by" line in
+	// detail view so operators can attribute the rule back to its
+	// source without context-switching.
+	RegistrySource string
 }
 
 type SkillDetailInfo struct {
@@ -98,11 +107,37 @@ type SkillsPanel struct {
 	// "Source: …" banner so operators see where listed skills
 	// came from. Empty string falls back to the OpenClaw label.
 	connector string
+
+	// registryByName maps a skill name to the registry source id
+	// that covers it via cfg.AssetPolicy.Skill.Registry. Populated
+	// by SetRegistryAttribution. Used to render the
+	// "registry:<id>" badge on each row + "Approved by" line in
+	// detail view. nil-safe — callers can read freely without
+	// guarding for an unset map.
+	registryByName map[string]string
 }
 
 // SetConnector updates the active connector for source labelling.
 // Called by the root Model whenever cfg or /health changes.
 func (p *SkillsPanel) SetConnector(name string) { p.connector = name }
+
+// SetRegistryAttribution replaces the in-memory name->registry-source-id
+// map used to render the "registry:<id>" badge. The caller (app.go's
+// propagateConnector / cfg-reload path) is responsible for building
+// the map from cfg.AssetPolicy.Skill.Registry; the panel does not
+// touch the config directly so test wiring stays cheap.
+//
+// Re-assigns the in-memory rows so a refresh isn't required to see
+// new attributions after a registry sync.
+func (p *SkillsPanel) SetRegistryAttribution(attr map[string]string) {
+	p.registryByName = attr
+	for i := range p.items {
+		p.items[i].RegistrySource = attr[p.items[i].Name]
+	}
+	for i := range p.filtered {
+		p.filtered[i].RegistrySource = attr[p.filtered[i].Name]
+	}
+}
 
 // SkillsLoadedMsg is sent when `defenseclaw skill list --json` completes.
 // Modeled on PluginsLoadedMsg so the dispatch pattern is identical —
@@ -230,6 +265,13 @@ func (p *SkillsPanel) ApplyLoaded(msg SkillsLoadedMsg) {
 		return
 	}
 	p.items = msg.Items
+	// Re-apply the latest attribution so registry badges survive
+	// a load triggered by `r` after a `registry sync`.
+	if p.registryByName != nil {
+		for i := range p.items {
+			p.items[i].RegistrySource = p.registryByName[p.items[i].Name]
+		}
+	}
 	p.loaded = true
 	p.message = ""
 	p.applyFilter()
@@ -589,6 +631,9 @@ func (p *SkillsPanel) View() string {
 		}
 
 		line := fmt.Sprintf("%s%s %-28s %-14s %s %-18s", pointer, badge, name, source, sev, actions)
+		if badge := registryBadge(item.RegistrySource); badge != "" {
+			line += " " + badge
+		}
 
 		if i == p.cursor {
 			line = lipgloss.NewStyle().Background(lipgloss.Color("236")).Width(p.width).Render(line)
@@ -650,6 +695,11 @@ func (p *SkillsPanel) renderDetail() string {
 		d.WriteString(labelStyle.Render("    Verdict: ") + valStyle.Render(info.Item.Verdict))
 	}
 	d.WriteString("\n")
+	if info.Item.RegistrySource != "" {
+		d.WriteString(labelStyle.Render("  Approved by: ") +
+			valStyle.Render("registry:"+info.Item.RegistrySource) +
+			labelStyle.Render("   (press R for registry view)") + "\n")
+	}
 
 	if info.Item.Description != "" {
 		desc := info.Item.Description

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "defenseclaw"
-version = "0.5.0"
+version = "0.4.0"
 description = "Enterprise governance layer for OpenClaw — secures agentic AI deployments"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/schemas/registry-manifest.schema.json
+++ b/schemas/registry-manifest.schema.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://defenseclaw.io/schemas/registry-manifest.json",
+  "title": "DefenseClaw Registry Manifest",
+  "description": "Vendor-neutral catalog manifest published by an external registry source (corporate HTTPS YAML/JSON, smithery.ai, a git repo containing defenseclaw-registry.yaml, etc.). The `defenseclaw registry sync` pipeline fetches this document, validates it against this schema, scans every entry with the existing skill / mcp scanners, and promotes clean entries into asset_policy.{skill,mcp}.registry. Untrusted-by-construction: all string fields are validated to length and character class to keep manifest poisoning from reaching scanner subprocesses.",
+  "type": "object",
+  "required": ["schema_version", "entries"],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema major version. Bumped only on breaking changes. v1 is the initial release."
+    },
+    "generated_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO-8601 UTC timestamp when the publisher built the manifest. Used for staleness reporting in `defenseclaw registry list` but not for verification."
+    },
+    "publisher": {
+      "type": ["string", "null"],
+      "maxLength": 256,
+      "description": "Human-readable publisher name (e.g. 'acme-corp'). Surfaced in the TUI but not used for trust decisions."
+    },
+    "default_connector": {
+      "type": ["string", "null"],
+      "enum": [null, "openclaw", "claudecode", "codex", "zeptoclaw"],
+      "description": "Optional default connector applied to entries that don't specify one. Per-entry `connector` overrides this."
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 0,
+      "maxItems": 10000,
+      "items": { "$ref": "#/$defs/entry" }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "entry": {
+      "oneOf": [
+        { "$ref": "#/$defs/skill_entry" },
+        { "$ref": "#/$defs/mcp_entry" }
+      ]
+    },
+    "skill_entry": {
+      "type": "object",
+      "required": ["name", "type", "source_url"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$",
+          "description": "Stable skill identifier. Must match the on-disk directory name and the skill-scanner output target."
+        },
+        "type": { "const": "skill" },
+        "source_url": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048,
+          "pattern": "^(clawhub://|https://|http://)",
+          "description": "Resolvable fetch URL. http:// is accepted but flagged by the SSRF guard; https:// is preferred. Local file:// URLs are intentionally NOT accepted in published manifests — operators that want to ingest local catalogs use kind=file on the source itself."
+        },
+        "sha256": {
+          "type": ["string", "null"],
+          "pattern": "^[a-fA-F0-9]{64}$",
+          "description": "Hex sha256 of the fetched archive. Required at sync time for https:// source_urls; clawhub:// entries inherit npm tarball integrity."
+        },
+        "version": { "type": ["string", "null"], "maxLength": 64 },
+        "license": { "type": ["string", "null"], "maxLength": 128 },
+        "publisher": { "type": ["string", "null"], "maxLength": 256 },
+        "description": { "type": ["string", "null"], "maxLength": 2048 },
+        "homepage": { "type": ["string", "null"], "maxLength": 2048, "pattern": "^https?://" },
+        "connector": {
+          "type": ["string", "null"],
+          "enum": [null, "openclaw", "claudecode", "codex", "zeptoclaw"]
+        },
+        "tags": {
+          "type": ["array", "null"],
+          "items": { "type": "string", "maxLength": 64 }
+        }
+      },
+      "additionalProperties": false
+    },
+    "mcp_entry": {
+      "type": "object",
+      "required": ["name", "type"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$"
+        },
+        "type": { "const": "mcp" },
+        "transport": {
+          "type": ["string", "null"],
+          "enum": [null, "stdio", "http", "sse", "streamable-http", "websocket"],
+          "description": "MCP transport. Empty / null defaults to stdio at sync time, matching how connector configs treat unset transports."
+        },
+        "command": {
+          "type": ["string", "null"],
+          "maxLength": 256,
+          "pattern": "^[A-Za-z0-9_./@-]*$",
+          "description": "Executable path or basename. Restricted to a conservative character class so a poisoned manifest can't smuggle shell metacharacters into the scanner subprocess. stdio entries require a non-empty command at sync time."
+        },
+        "args": {
+          "type": ["array", "null"],
+          "maxItems": 64,
+          "items": {
+            "type": "string",
+            "maxLength": 1024,
+            "description": "Argument values are NOT character-class restricted (they may legitimately contain paths, URLs, JSON snippets) but are length-capped. The sync command validates each entry before promotion."
+          }
+        },
+        "env_required": {
+          "type": ["array", "null"],
+          "maxItems": 32,
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Z0-9_]{0,127}$",
+            "description": "Names only — never values. Sync surfaces unset names so operators know which env vars they still need to provision."
+          }
+        },
+        "url": {
+          "type": ["string", "null"],
+          "maxLength": 2048,
+          "pattern": "^(https?|wss?|sse)://",
+          "description": "For non-stdio MCP servers."
+        },
+        "version": { "type": ["string", "null"], "maxLength": 64 },
+        "publisher": { "type": ["string", "null"], "maxLength": 256 },
+        "license": { "type": ["string", "null"], "maxLength": 128 },
+        "description": { "type": ["string", "null"], "maxLength": 2048 },
+        "homepage": { "type": ["string", "null"], "maxLength": 2048, "pattern": "^https?://" },
+        "connector": {
+          "type": ["string", "null"],
+          "enum": [null, "openclaw", "claudecode", "codex", "zeptoclaw"]
+        },
+        "tags": {
+          "type": ["array", "null"],
+          "items": { "type": "string", "maxLength": 64 }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/scripts/stamp-version.sh
+++ b/scripts/stamp-version.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Stamp a single semver across every in-repo version source.
+#
+# The git tag is the source of truth for releases; the release workflow
+# invokes this script before building so that the wheel
+# (`defenseclaw-X.Y.Z-py3-none-any.whl`) and plugin tarball
+# (`defenseclaw-plugin-X.Y.Z.tar.gz`) names match the tag, which in turn
+# matches what `install.sh` and `defenseclaw upgrade` look up.
+#
+# Sources kept in lock-step:
+#   1. Makefile                                 (VERSION := X.Y.Z)
+#   2. pyproject.toml                           (version = "X.Y.Z")
+#   3. cli/defenseclaw/__init__.py              (__version__ = "X.Y.Z")
+#   4. extensions/defenseclaw/package.json      ("version": "X.Y.Z")
+#
+# Usage:
+#   scripts/stamp-version.sh 0.4.0
+#   make set-version VERSION=0.4.0
+#
+# Idempotent: re-running with the same version is a no-op. The script
+# fails loudly if any of the four files cannot be located or already
+# contains a value that does not match the regex it expects, so a silent
+# drift never reaches a release artifact.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 <version>" >&2
+    exit 64
+fi
+
+VERSION="$1"
+
+# Strict semver only. Refuse pre-release / build-metadata suffixes for now —
+# the upgrade flow's URL builders assume bare X.Y.Z, so anything else would
+# silently 404 on `defenseclaw upgrade --version <pre-release>`. Reject here
+# rather than producing a release that the upgrade script cannot consume.
+if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: version must be X.Y.Z (got: ${VERSION})" >&2
+    exit 64
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Cross-platform sed -i wrapper: BSD sed (macOS) requires an explicit empty
+# string after -i, GNU sed (Linux) does not. Detect and dispatch so this
+# script works on both developer macs and the ubuntu-latest GH runner.
+sed_in_place() {
+    if sed --version >/dev/null 2>&1; then
+        sed -i "$@"
+    else
+        sed -i '' "$@"
+    fi
+}
+
+# Each stamp_*() is a separate function so a failure pinpoints which file
+# is malformed (the trap prints the failing function name).
+
+stamp_makefile() {
+    local f="Makefile"
+    [[ -f "${f}" ]] || { echo "error: ${f} not found" >&2; return 1; }
+    grep -qE '^VERSION[[:space:]]*:=[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*$' "${f}" \
+        || { echo "error: ${f} does not match expected 'VERSION := X.Y.Z' line" >&2; return 1; }
+    sed_in_place -E "s/^(VERSION[[:space:]]*:=[[:space:]]*)[0-9]+\.[0-9]+\.[0-9]+([[:space:]]*)\$/\1${VERSION}\2/" "${f}"
+}
+
+stamp_pyproject() {
+    local f="pyproject.toml"
+    [[ -f "${f}" ]] || { echo "error: ${f} not found" >&2; return 1; }
+    grep -qE '^version[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"[[:space:]]*$' "${f}" \
+        || { echo "error: ${f} does not match expected 'version = \"X.Y.Z\"' line" >&2; return 1; }
+    sed_in_place -E "s/^(version[[:space:]]*=[[:space:]]*\")[0-9]+\.[0-9]+\.[0-9]+(\"[[:space:]]*)\$/\1${VERSION}\2/" "${f}"
+}
+
+stamp_init_py() {
+    local f="cli/defenseclaw/__init__.py"
+    [[ -f "${f}" ]] || { echo "error: ${f} not found" >&2; return 1; }
+    grep -qE '^__version__[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"[[:space:]]*$' "${f}" \
+        || { echo "error: ${f} does not match expected '__version__ = \"X.Y.Z\"' line" >&2; return 1; }
+    sed_in_place -E "s/^(__version__[[:space:]]*=[[:space:]]*\")[0-9]+\.[0-9]+\.[0-9]+(\"[[:space:]]*)\$/\1${VERSION}\2/" "${f}"
+}
+
+stamp_package_json() {
+    local f="extensions/defenseclaw/package.json"
+    [[ -f "${f}" ]] || { echo "error: ${f} not found" >&2; return 1; }
+    # Anchor on the leading-two-space indentation that npm uses for package.json
+    # so we only touch the top-level "version" field, never a nested one inside
+    # dependency/devDependency blocks.
+    grep -qE '^  "version":[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+",?[[:space:]]*$' "${f}" \
+        || { echo "error: ${f} does not match expected '  \"version\": \"X.Y.Z\",' line" >&2; return 1; }
+    sed_in_place -E "s/^(  \"version\":[[:space:]]*\")[0-9]+\.[0-9]+\.[0-9]+(\",?[[:space:]]*)\$/\1${VERSION}\2/" "${f}"
+}
+
+stamp_makefile
+stamp_pyproject
+stamp_init_py
+stamp_package_json
+
+echo "stamped version ${VERSION} into:"
+echo "  Makefile"
+echo "  pyproject.toml"
+echo "  cli/defenseclaw/__init__.py"
+echo "  extensions/defenseclaw/package.json"

--- a/uv.lock
+++ b/uv.lock
@@ -714,7 +714,7 @@ wheels = [
 
 [[package]]
 name = "defenseclaw"
-version = "0.5.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cisco-ai-mcp-scanner", marker = "python_full_version >= '3.11'" },


### PR DESCRIPTION
## Summary

This PR ships two cross-cutting features and folds in a few incremental fixes that landed on the same branch:

1. **Registries** — first-class ingest of third-party skill / MCP catalogs (clawhub, smithery, skills.sh, plain HTTP manifests, git, file). Adds CLI, TUI, on-disk cache, asset-policy promotion, and provenance tracking.
2. **OS desktop notifications** — user-session notifications for `EventBlock` (enforced + would-block) and HITL approval-pending events, with category/source filters, dedup, and rate-limit roll-up.
3. **Bundled fixes** — release workflow fixes (previously PR #230, superseded), a flaky watchdog test, and small dead-code cleanup.

> **Why one PR:** Registries and Notifications were designed together — registry-required denials are one of the loudest signals we want surfaced as a desktop toast (`AssetPolicy` source on the dispatcher), and the asset-policy decision struct gained both `RegistrySource` and the notifier wire-up in the same commit. Splitting them would force a temporary state where one side ships without the other's data.

This PR **supersedes #230** (release workflow fixes). Those three commits (`139dfc8`, `2895e6c`, `18874bc`) are preserved here. #230 has been closed in favour of this one.

---

## Architecture at a glance

### Registries pipeline

```mermaid
flowchart LR
    A["External catalog<br/>(clawhub, smithery,<br/>skills.sh, http(s),<br/>git, file)"] -- HTTP / git --> B["CLI adapters<br/>+ SSRF guard<br/>+ size cap (8 MiB)<br/>+ redirect re-check"]
    B --> C["JSON Schema +<br/>invariant regex checks<br/>(manifest.py)"]
    C --> D["Optional scan callback<br/>(plugin scanner /<br/>mcp-scanner)"]
    D --> E["Cache<br/>~/.defenseclaw/registries/&lt;id&gt;/<br/>manifest.yaml + index.json<br/>(atomic writes)"]
    E -- "promote approved entries" --> F["asset_policy.{skill,mcp}.registry<br/>rules with Reason='registry:&lt;id&gt;'"]
    F --> G["Gateway runtime decisions<br/>stamp RegistrySource on<br/>audit + telemetry rows"]
    H["Operator overrides<br/>(approve / reject / require)"] -. "merged on every resync" .-> E
```

### Notification dispatcher

```mermaid
flowchart LR
    P1["proxy.recordTelemetry<br/>(block / would-block)"] --> D[Dispatcher]
    P2["hilt.Request<br/>(approval pending)"] --> D
    P3["asset_policy_runtime<br/>(skill / mcp violation)"] --> D
    D --> M1["Master switch"]
    M1 --> M2["Category gate<br/>BlockEnforced /<br/>BlockWouldBlock /<br/>HITLApproval"]
    M2 --> M3["Source gate<br/>Hook / Guardrail /<br/>AssetPolicy"]
    M3 --> M4["Dedup window +<br/>per-minute cap<br/>(roll-up notice)"]
    M4 --> M5["Body redaction"]
    M5 --> N1["macOS osascript"]
    M5 --> N2["Linux notify-send"]
    M5 --> N3["fallback writer"]
```

The dispatcher never blocks the request path; calls are best-effort and time-boxed. Bodies pass through the existing redaction pipeline so we never leak prompts or secrets to the OS notification daemon.

---

## What's changing

### Public surface (additive)

- **CLI:** `defenseclaw registry {add,edit,list,show,remove,sync,entries,approve,reject,require,wizard}` (interactive + `--non-interactive` / `--json` for automation).
- **CLI:** `defenseclaw setup notifications {on,off,status}`.
- **Onboarding:** `defenseclaw init` now asks once whether to enable desktop notifications, defaulting to platform-supported on macOS/Linux.
- **TUI:** new **Registries** panel with **Sources / Entries / Approved** tabs (`R` keybinding); Skills/MCPs panels expose a registry-provenance column and `R` jumps to a filtered Registries view.
- **TUI:** new **Notifications toggle modal** (`N` from Overview).
- **TUI:** Setup wizard gained a Registries step and a Notifications step.
- **Config:** new `registries:` and `notifications:` blocks in `config.yaml` (see `docs/CONFIG_FILES.md`).
- **Asset policy:** `AssetTypePolicy.RegistryEmptyAction` (`deny` | `allow`) and decision-side `RegistryConfigured` / `RegistrySource` fields.

### Files / packages added

| Area | Files |
| --- | --- |
| Docs | `docs/REGISTRIES.md`, `docs/CLI.md` & `docs/CONFIG_FILES.md` & `docs/TUI.md` updates, `README.md` |
| Schema | `schemas/registry-manifest.schema.json`, `bundles/registries/example-{skill,mcp}-catalog.yaml` |
| Python ingest | `cli/defenseclaw/registries/{__init__,manifest,cache,sync,ssrf}.py` |
| Python adapters | `cli/defenseclaw/registries/adapters/{_base,clawhub,smithery,skills_sh,http_manifest,git,file}.py` |
| Python CLI | `cli/defenseclaw/commands/cmd_registry.py`, edits to `cmd_init.py`, `cmd_setup.py`, `config.py`, `main.py` |
| Go config | `internal/config/{registries,notifications}.go`, edits to `config.go`, `asset_policy.go` |
| Go gateway | `internal/gateway/notifier/notifier.go`, wire-up in `api.go`, `hilt.go`, `proxy.go`, `sidecar.go`, `asset_policy_runtime.go`, `claude_code_hook.go`, `codex_hook.go` |
| Go TUI | `internal/tui/{registries,notifications_modal}.go`, edits to `app.go`, `overview.go`, `mcps.go`, `skills.go`, `setup.go`, `configedit.go`, `command.go` |
| Tests | 168 Python cases (registry adapters/manifest/ssrf/sync + cmd) and 11 new Go test files (notifier, notifier-wiring, registries-config, asset-policy-runtime, TUI registries/notifications/configedit) |

### Files removed / pruned

- `isClaudeCodeOtelKey` (unused), `hiltIDFromApprovalMessage` test helper (unused), `FirstRunPanel.setValue` (unused) — flagged by vet during the work.

### Bundled fixes from PR #230

- Tag-driven version stamping + `workflow_dispatch` trigger in `.github/workflows/release.yaml`.
- Dropped the homebrew-cask block that broke GoReleaser.
- Review-feedback follow-up: job ordering, shell-injection hardening, concurrency group, Makefile target.
- `uv.lock` realigned to `pyproject.toml` `0.4.0`.

---

## Why

### Registries

Today operators add skills/MCPs by editing YAML and rebuilding allow-lists by hand. As the ecosystem grows (skills.sh, ClawHub, vendor catalogs, internal git mirrors) we need a way to:

1. **Pull** entries from authoritative catalogs without copy-pasting manifests.
2. **Pin & verify** entries (sha256 digests, scanner verdicts, operator overrides) before they land in asset-policy.
3. **Attribute** every promoted rule back to its source so audit / telemetry / UI can answer "which catalog is responsible for this allow rule?"
4. **Stay safe**: the ingest path talks to arbitrary URLs the user types, so we need SSRF blocking, schema enforcement, size caps, and atomic on-disk writes.

### Notifications

Block events are the highest-signal moment in DefenseClaw, but they're invisible if the operator isn't watching the gateway logs. Asset-policy violations (especially registry-required misses) and HITL approvals deserve a desktop toast. Existing `internal/notify` could only send plain bodies — we needed structured `{Title, Subtitle, Body}`, category / source filtering, and dedup so we don't toast-storm the user when a misconfigured tool retries on every keystroke.

---

## How

### Ingest pipeline (Python)

- **`adapters/_base.py`** centralizes the HTTP code: SSRF check on every URL (including post-redirect), enforced same-origin redirects, response cap of 8 MiB, secure `Authorization` header handling that scrubs on cross-origin redirect.
- **`manifest.py`** parses YAML / JSON into `Manifest` / `ManifestEntry` dataclasses. Validation runs JSON Schema **and** hand-written invariants — regex allow-lists for names, commands, env vars, http(s) URLs, sha256 digests — so we stay safe even when `jsonschema` is not installed.
- **`ssrf.py`** is the single source of truth for what URLs we'll fetch: scheme allow-list, blocks loopback, link-local, multicast, RFC1918, ULA. `--allow-private` is the only operator escape hatch.
- **`cache.py`** writes `manifest.yaml` and `index.json` atomically (temp file + rename). Operator overrides (`approved`, `rejected`, `scan_failed`) are merged on top of fresh syncs so pinning survives.
- **`sync.py`** orchestrates: ingest → optional scan callback (plugin scanner or MCP scanner) → persist verdicts → promote allow-listed entries to `asset_policy.{skill,mcp}.registry`. Promoted rules carry `Reason="registry:<id>"`.

### Asset policy + decisions (Go)

- **`AssetTypePolicy.RegistryEmptyAction`** lets ops choose what happens when `RegistryRequired` is `true` but no rules are configured: `deny` (default, fail-closed) or `allow` (preview mode).
- **`AssetPolicyDecision`** gains `RegistryConfigured` and `RegistrySource`. Telemetry + audit rows now answer "was this allow due to a registry rule, and which registry?".
- **`ParseRegistrySourceID`** extracts the source ID from the `Reason` string so we don't have to thread the value through every call site.

### Notifier (Go)

- **`internal/gateway/notifier/notifier.go`** is the central dispatcher. `OnBlock`, `OnWouldBlock`, `OnApprovalPending` are the public surface. It owns the master switch, category gate (`BlockEnforced` / `BlockWouldBlock` / `HITLApproval`), source gate (`Hook` / `Guardrail` / `AssetPolicy`), dedup window, and per-minute cap with a single "(N) more notifications suppressed" roll-up.
- **`internal/notify`** now models a structured `Notification{Title, Subtitle, Body}`. macOS uses native `osascript` subtitle; Linux folds subtitle into body with em-dash because `notify-send` has no native subtitle.
- **Wire-up:** `Sidecar.NewSidecar` constructs the dispatcher once and `SetNotifier` injects it into `APIServer`, `HILTApprovalManager`, and `GuardrailProxy`. Hooks (`claude_code_hook.go`, `codex_hook.go`) call into asset-policy evaluation, which dispatches through the same path.
- **Bodies are redacted** before they leave the gateway. The dispatcher uses the existing redaction helpers; `notifier_wiring_test` asserts that prompts / keys never reach `recordingSender`.

### TUI

- **`registries.go`** owns the new panel: three tabs, async refresh from the Python CLI's `registry list / show / entries` JSON output, single-key actions for sync / approve / reject / remove / require.
- **`notifications_modal.go`** is a small confirmation modal — never toggles directly, always shells out to `defenseclaw setup notifications` so config changes follow the same write path as the CLI.
- **Cross-linking:** `SetRegistryAttribution` populates a name → source-id map on the Skills / MCPs panels so `R` jumps to the Registries panel pre-filtered to that entry.

---

## Security review checklist (CodeGuard rules)

- ✅ **SSRF (`codeguard-0-api-web-services`):** scheme allow-list + private / loopback / link-local block, redirects re-validated, same-origin redirect enforced, `--allow-private` opt-in only. Coverage in `test_registry_ssrf.py`.
- ✅ **Input validation / injection (`codeguard-0-input-validation-injection`):** schema + hand-written invariants on every manifest field; regex allow-lists for command paths, env-var names, URLs, sha256. `subprocess` callsites use list args (no shell). Coverage in `test_registry_manifest.py`.
- ✅ **Supply chain / file handling (`codeguard-0-file-handling-and-uploads`):** 8 MiB response cap, atomic writes (`tempfile + os.replace`), `config.yaml` permissions preserved, no extension-based trust.
- ✅ **No hardcoded credentials (`codeguard-1-hardcoded-credentials`):** auth tokens are read from the source config block, never logged, scrubbed on cross-origin redirect.
- ✅ **Logging (`codeguard-0-logging`):** notifier bodies are redacted; telemetry / audit rows include `registry_source` as a tag, not raw URLs.
- ✅ **MCP security (`codeguard-0-mcp-security`):** registries do not auto-approve; entries land as `pending` until scanner verdict + operator approval. `registry_required` paired with `registry_empty_action=deny` means an empty registry fails closed.

---

## Backwards compatibility

- All new config blocks are **optional** and default to empty / platform default. Existing `config.yaml` files load unchanged.
- `AssetPolicyDecision` field additions are append-only; serialized JSON tags preserved for older consumers.
- Notifications default-off on unsupported platforms; default-on for macOS / Linux is gated behind the per-source filter so existing operators with no notification sources configured see no toasts.
- No CLI flags were removed; the new `registry` group is additive.

---

## Test plan

### Automated (run locally — all green)

- `go test ./internal/config/... ./internal/notify/... ./internal/gateway/notifier/... ./internal/tui/... ./internal/gateway/...` — pass.
- `uv run --project cli pytest cli/tests/test_cmd_registry.py cli/tests/test_registry_*.py cli/tests/test_cmd_init.py cli/tests/test_cli_smoke.py cli/tests/test_cmd_uninstall.py` — 239 + 12 subtests pass.
- `go vet ./internal/gateway/... ./internal/config/... ./internal/tui/... ./internal/notify/...` — clean.

### Manual smoke (recommended for the reviewer)

1. `defenseclaw init` on a fresh `$HOME` — confirm the notifications onboarding prompt fires once and writes `notifications.enabled`.
2. `defenseclaw registry add --kind clawhub --url https://… --auth-env CLAW_TOKEN`, then `registry sync <id>` — confirm the cache lands at `~/.defenseclaw/registries/<id>/` and `registry entries <id> --json` matches the manifest.
3. Trigger a block via a banned tool prompt — confirm a desktop toast appears with redacted body and `source=Guardrail`.
4. Configure `registry_required: true` with no registry rules — confirm denial decision logs `registry_configured=false` and surfaces a notification (when `AssetPolicy` source is enabled).
5. TUI: open `Registries` panel, sync a source, approve an entry, verify it appears in the Skills / MCPs panels with the `R` shortcut wired to the source.

### Risk areas to look at first

- **`internal/gateway/asset_policy_runtime.go`** — registry-source attribution path; double-check `runtimeAssetDecision` always populates `RegistrySource` when a registry rule matched.
- **`cli/defenseclaw/registries/sync.py`** — operator-override merge logic. Resync should never demote a manual approve / reject.
- **`internal/gateway/notifier/notifier.go`** — dedup + per-minute cap math; the roll-up notice fires once per window.
- **`internal/gateway/proxy.go`** — placement of `enqueueWouldBlockNotification` calls; should not trigger for `action=allow`.

---

## Diagrams referenced inline

The Registries pipeline and Notifier dispatcher diagrams above are also reproduced in `docs/REGISTRIES.md` and the dispatcher description in `internal/gateway/notifier/notifier.go` package doc, respectively, so reviewers reading the source can find them in-tree.

---

## Closes / supersedes

- Supersedes #230 (release workflow fixes — three commits preserved here).
