### PR TITLE
fix(release): build OpenClaw plugin + populate embed tree before GoReleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -159,6 +159,29 @@ jobs:
         with:
           node-version: "20"
 
+      # Build the OpenClaw plugin and sync its runtime files into
+      # internal/gateway/connector/openclaw_extension/ so the gateway's
+      # `//go:embed all:openclaw_extension` directive (openclaw.go:40)
+      # resolves at compile time.
+      #
+      # Without this step GoReleaser fails the cross-build with:
+      #   internal/gateway/connector/openclaw.go:40:12:
+      #     pattern all:openclaw_extension: no matching files found
+      # (release run #7 / 25533484548 hit this exactly).
+      #
+      # The embed dir is gitignored (.gitignore:75) and so is
+      # extensions/defenseclaw/{node_modules,dist,src/providers.json}, so
+      # this step does NOT dirty the working tree from git's perspective —
+      # GoReleaser's clean-tree check still passes.
+      #
+      # `make extensions` is `plugin + sync-openclaw-extension`. We use the
+      # full target rather than just `sync-openclaw-extension` (placeholder
+      # mode) so the released gateway binary actually contains the OpenClaw
+      # plugin runtime, not just a "not built" marker — operators get a
+      # working OpenClaw connector out of the curl-to-bash installer.
+      - name: Build OpenClaw plugin and populate embed tree
+        run: make extensions
+
       # ORDERING NOTE: GoReleaser MUST run before scripts/stamp-version.sh.
       # GoReleaser refuses to release from a dirty working tree
       # (https://goreleaser.com/errors/dirty/), and the stamp script edits


### PR DESCRIPTION
## Summary

Fixes release run #7 (https://github.com/cisco-ai-defense/defenseclaw/actions/runs/25533484548), which failed at the GoReleaser cross-build step:

```
internal/gateway/connector/openclaw.go:40:12:
  pattern all:openclaw_extension: no matching files found
```

## Root cause

`internal/gateway/connector/openclaw.go:40` declares `//go:embed all:openclaw_extension`. That directory is gitignored — every other build path in the project gets it through the `sync-openclaw-extension` Make dependency:

- `gateway`, `gateway-cross`, `gateway-test`, `go-test-cov`, `go-lint`, `connector-matrix-test`, `check-provider-coverage` — all `: sync-openclaw-extension`
- The e2e workflow explicitly runs `make sync-openclaw-extension` before `go test ./...` (`.github/workflows/e2e.yml:1311-1312`)

The release workflow invoked `goreleaser release --clean` directly, bypassing the Make dependency graph. The embed had nothing to resolve at compile time, and the cross-build aborted on every architecture.

## Fix

Insert one step between `actions/setup-node@v4` and the GoReleaser invocation:

```yaml
- name: Build OpenClaw plugin and populate embed tree
  run: make extensions
```

`make extensions` = `make plugin && make sync-openclaw-extension`:

1. npm-builds the TypeScript plugin under `extensions/defenseclaw/` (uses the node 20 toolchain set up by the previous step).
2. Copies the runtime files (`package.json`, `openclaw.plugin.json`, `dist/`, runtime `node_modules/{js-yaml,argparse}`) into `internal/gateway/connector/openclaw_extension/`.
3. `//go:embed all:openclaw_extension` resolves; cross-builds succeed.

### Why `make extensions` (full build) and not just `make sync-openclaw-extension` (placeholder)

The placeholder path drops a `.placeholder` file so the embed has at least one entry, but `openClawExtensionAvailable()` then returns `false` at runtime and OpenClaw setup fails with "extension not built". Shipping that to operators via the curl-to-bash installer would silently break OpenClaw even though we ship the plugin tarball as a separate asset. Full build → released gateway binary contains a working OpenClaw plugin.

### Why this doesn't dirty the working tree

GoReleaser still requires a clean working tree. Verified gitignored:

- `.gitignore:55` → `extensions/defenseclaw/node_modules/`
- `.gitignore:26` → `extensions/defenseclaw/dist/`
- `.gitignore:9`  → `extensions/defenseclaw/src/providers.json`
- `.gitignore:75` → `internal/gateway/connector/openclaw_extension/`

After `make extensions`, `git status --short` shows only this PR's workflow edit.

### Step ordering (after this PR)

```
 1. actions/checkout@v4
 2. Resolve and validate target tag
 3. Create local tag for GoReleaser (workflow_dispatch only)
 4. actions/setup-go@v5
 5. sigstore/cosign-installer@v3
 6. anchore/sbom-action/download-syft@v0
 7. astral-sh/setup-uv@v4
 8. actions/setup-node@v4
 9. Build OpenClaw plugin and populate embed tree   ← NEW
10. Build artifacts with GoReleaser
11. Stamp release version
12. Build CLI wheel and plugin tarball
13. Publish GitHub release with all assets
```

### Trade-off

`make dist-plugin` (step 12) re-runs `make plugin` as a Make dependency, which means `npm ci && npm run build` runs twice during a release (~40s extra). That keeps `make dist-plugin` independently usable from a developer machine. Optimizable later by making `dist-plugin` no-op the npm build when plugin artifacts already exist; not in scope here.

## Test plan

Verified locally in a clean worktree off `origin/main`:

```bash
$ rm -rf internal/gateway/connector/openclaw_extension
$ CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/defenseclaw
internal/gateway/connector/openclaw.go:40:12:
  pattern all:openclaw_extension: no matching files found    # reproduces the failure

$ make extensions
  • Synced OpenClaw extension → internal/gateway/connector/openclaw_extension/

$ git status --short
 M .github/workflows/release.yaml                             # only this PR's edit, no build artifacts

$ CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/defenseclaw
$ ls -la cmd/defenseclaw   # 67MB binary, success
```

After merge, re-run the Release workflow with `version=0.4.0` from the Actions UI.

## Refs

- Release run #7: https://github.com/cisco-ai-defense/defenseclaw/actions/runs/25533484548
- Embed directive: `internal/gateway/connector/openclaw.go:40`
- Same workaround in e2e: `.github/workflows/e2e.yml:1311-1312` (CI run 25037878418 was the original incident)