### PR TITLE
feat(docs-site): hero rotation lockup, page-wide animations, connector cleanup

### DIFF
--- a/docs-site/app/(home)/page.tsx
+++ b/docs-site/app/(home)/page.tsx
@@ -1,7 +1,9 @@
 import Link from 'next/link';
-import { TerminalDemo } from '@/components/terminal-demo';
 import { SoftwareApplicationSchema } from '@/components/structured-data';
-import { Flow, Node, Edge } from '@/components/diagram/flow';
+import { HeroLockup } from '@/components/hero-lockup';
+import { RotatingConnectorWord } from '@/components/rotating-connector-word';
+import { TerminalDemo } from '@/components/terminal-demo';
+import { CtaGlowButton } from '@/components/cta-glow-button';
 import matrix from '@/data/capability-matrix.json';
 
 const connectors = matrix.connectors;
@@ -42,19 +44,16 @@ const STORIES = [
 const MODES = [
   {
     name: 'Observe',
-    mark: 'O',
     tagline: 'See what your agent does. Block nothing.',
     body: 'Findings stream to the audit DB and your sinks. Run it for a week before enforcement.',
   },
   {
     name: 'Action',
-    mark: 'A',
     tagline: 'Block on HIGH and CRITICAL.',
-    body: 'CRITICAL findings always block. HIGH findings block unless HITL pauses them for review.',
+    body: 'CRITICAL findings always block. HIGH findings block unless approval mode pauses them for review.',
   },
   {
-    name: 'HITL',
-    mark: 'H',
+    name: 'Ask approval',
     tagline: 'Pause, review, then continue.',
     body: 'Reaches the operator via the connector’s native ask, or downgrades to a TUI prompt.',
   },
@@ -65,7 +64,7 @@ const MODES = [
 // under a second instead of forcing the visitor through a sentence.
 const AUDIT_SINKS = ['SQLite', 'JSONL', 'OTLP', 'Splunk', 'Webhooks'];
 
-const WORKFLOW = ['Observe', 'Action', 'HITL'];
+const WORKFLOW = ['Observe', 'Action', 'Ask approval'];
 
 // First sentence of c.notes is enough on the landing page; the full
 // sentence runs onto a second line and dilutes the card's job (point
@@ -89,96 +88,135 @@ export default function HomePage() {
         />
         <div aria-hidden className="hero-grain pointer-events-none absolute inset-0" />
 
-        {/* `min-w-0` on the grid + each cell prevents the right column
-            (the terminal `<pre overflow-x-auto>`) from forcing the whole
-            grid wider than the viewport on narrow phones (≤390px). The
-            `w-full` clamp on cells keeps every chip row, CTA strip, and
-            paragraph honoring the parent width once min-width is zero. */}
-        <div className="container relative mx-auto grid min-w-0 max-w-7xl gap-10 px-4 py-16 lg:grid-cols-2 lg:gap-16 lg:py-24">
-          <div className="flex w-full min-w-0 flex-col justify-center gap-6">
-            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-[var(--brand-cisco)]/30 bg-[var(--brand-cisco)]/10 px-3 py-1 text-xs font-medium uppercase tracking-wider text-[var(--brand-cisco-strong)]">
-              <span aria-hidden className="size-1.5 rounded-full bg-[var(--brand-cisco)]" />
-              Official Cisco project · Apache-2.0
-            </span>
-            <h1 className="text-balance wrap-break-word text-4xl font-bold tracking-tight md:text-5xl lg:text-6xl">
-              Security governance for{' '}
-              <span className="text-[var(--brand-cisco-strong)]">OpenClaw</span> and agentic AI
-              runtimes.
-            </h1>
-            <p className="max-w-xl text-pretty text-lg text-fd-muted-foreground">
-              DefenseClaw inspects every prompt, completion, and tool call your AI coding agent
-              makes — block, approve, or audit, per connector.
-            </p>
-            <div className="flex flex-wrap items-center gap-3">
-              <Link
-                href="/docs/get-started/quickstart"
-                className="inline-flex items-center gap-2 rounded-md bg-[var(--brand-cisco)] px-4 py-2 text-sm font-medium text-white shadow-md transition hover:bg-[var(--brand-cisco-strong)]"
-              >
-                Quickstart
-                <span aria-hidden>→</span>
-              </Link>
-              <Link
-                href="/docs/setup/guardrail"
-                className="inline-flex items-center gap-2 rounded-md border border-fd-border bg-fd-card px-4 py-2 text-sm font-medium transition hover:bg-fd-muted"
-              >
-                Setup Guardrail
-              </Link>
-              <Link
-                href="/docs/capability-matrix"
-                className="inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium text-fd-muted-foreground transition hover:text-fd-foreground"
-              >
-                Capability Matrix
-              </Link>
+        {/* HeroLockup owns the rotation index and the cadence between
+            the rotating word in the headline and the typewriter in
+            the terminal. Both consumers (<RotatingConnectorWord> and
+            <TerminalDemo>) read the index from context, so the
+            headline and the `defenseclaw setup …` line stay in
+            lockstep regardless of how long any one block takes to
+            type. The page-level layout (grid, eyebrow, h1, lede,
+            CTAs, chip strips, terminal column) lives here as
+            children. */}
+        <HeroLockup>
+          {/* Grid tracks tilt slightly toward the terminal column on lg+
+              (≈45/55) so the install curl URL wraps onto fewer lines
+              without crowding the headline / chip strips on the left. */}
+          <div className="container relative mx-auto grid min-w-0 max-w-7xl gap-10 px-4 py-16 lg:grid-cols-[9fr_11fr] lg:gap-16 lg:py-24">
+            <div className="flex w-full min-w-0 flex-col justify-center gap-6">
+              <span className="inline-flex w-fit items-center gap-2 rounded-full border border-[var(--brand-cisco)]/30 bg-[var(--brand-cisco)]/10 px-3 py-1 text-xs font-medium uppercase tracking-wider text-[var(--brand-cisco-strong)]">
+                <span aria-hidden className="size-1.5 rounded-full bg-[var(--brand-cisco)]" />
+                Official Cisco project · Apache-2.0
+              </span>
+              <h1 className="text-balance wrap-break-word text-4xl font-bold tracking-tight md:text-5xl lg:text-6xl">
+                Security governance for <RotatingConnectorWord />.
+              </h1>
+              <p className="max-w-xl text-pretty text-lg text-fd-muted-foreground">
+                DefenseClaw inspects every prompt, completion, and tool call your AI coding agent
+                makes — block, approve, or audit, per connector.
+              </p>
+              <div className="flex flex-wrap items-center gap-3">
+                <Link
+                  href="/docs/get-started/quickstart"
+                  className="inline-flex items-center gap-2 rounded-md bg-[var(--brand-cisco)] px-4 py-2 text-sm font-medium text-white shadow-md transition hover:bg-[var(--brand-cisco-strong)]"
+                >
+                  Quickstart
+                  <span aria-hidden>→</span>
+                </Link>
+                <Link
+                  href="/docs/setup/guardrail"
+                  className="inline-flex items-center gap-2 rounded-md border border-fd-border bg-fd-card px-4 py-2 text-sm font-medium transition hover:bg-fd-muted"
+                >
+                  Setup Guardrail
+                </Link>
+                <Link
+                  href="/docs/capability-matrix"
+                  className="inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium text-fd-muted-foreground transition hover:text-fd-foreground"
+                >
+                  Capability Matrix
+                </Link>
+              </div>
+
+              {/* Three rows compress the same content as before (connectors,
+                  workflow, audit fan-out) with a tight visual rhythm: each
+                  row has a fixed-width label rail with a thin horizontal
+                  divider between rows. The Workflow row's `→` arrows
+                  carry the left-to-right enforcement progression on
+                  their own — an earlier moving-dot underline froze
+                  under prefers-reduced-motion and read as a stray blue
+                  pixel, so the dot was retired. */}
+              <div className="mt-2 rounded-xl border border-fd-border bg-fd-card/40">
+                <HeroChipRow label="Connectors">
+                  {connectors.map((c) => (
+                    <HeroChip key={c.id}>{c.label}</HeroChip>
+                  ))}
+                </HeroChipRow>
+                <HeroChipRow label="Workflow">
+                  <span className="inline-flex flex-wrap items-center gap-1.5">
+                    {WORKFLOW.map((w, i) => (
+                      <span key={w} className="inline-flex items-center gap-1.5">
+                        <HeroChip>{w}</HeroChip>
+                        {i < WORKFLOW.length - 1 && (
+                          <span
+                            aria-hidden
+                            className="text-[var(--brand-cisco-strong)]/70"
+                          >
+                            →
+                          </span>
+                        )}
+                      </span>
+                    ))}
+                  </span>
+                </HeroChipRow>
+                <HeroChipRow label="Audit">
+                  {AUDIT_SINKS.map((s) => (
+                    <HeroChip key={s}>{s}</HeroChip>
+                  ))}
+                </HeroChipRow>
+              </div>
             </div>
 
-            {/* Three chip strips replace the previous prose bullets. They
-                cover the same ground (connectors / workflow / audit
-                fan-out) but compress the read time from "scan three
-                long sentences" to "scan three rows of pills". The
-                visual vocabulary mirrors the navbar repo-stats pills
-                so the lockup reads as one design system. */}
-            <div className="mt-2 flex flex-col gap-3">
-              <HeroChipRow label="Connectors">
-                {connectors.map((c) => (
-                  <HeroChip key={c.id}>
-                    <span
-                      aria-hidden
-                      className={
-                        c.family === 'proxy'
-                          ? 'size-1.5 rounded-full bg-[var(--brand-cisco)]'
-                          : 'size-1.5 rounded-full bg-fd-muted-foreground/40'
-                      }
-                    />
-                    {c.label}
-                  </HeroChip>
-                ))}
-              </HeroChipRow>
-              <HeroChipRow label="Workflow">
-                {WORKFLOW.map((w, i) => (
-                  <span key={w} className="inline-flex items-center gap-1.5">
-                    <HeroChip>{w}</HeroChip>
-                    {i < WORKFLOW.length - 1 && (
-                      <span aria-hidden className="text-fd-muted-foreground/60">
-                        →
-                      </span>
-                    )}
-                  </span>
-                ))}
-              </HeroChipRow>
-              <HeroChipRow label="Audit">
-                {AUDIT_SINKS.map((s) => (
-                  <HeroChip key={s}>{s}</HeroChip>
-                ))}
-              </HeroChipRow>
+            {/* The terminal pre uses overflow-x-auto, but it can only
+                scroll inside its own box if the grid cell honors
+                min-width:0. Without `min-w-0` the long install curl
+                line pushes the grid track wider than the viewport on
+                phones. */}
+            <div className="flex w-full min-w-0 items-center">
+              <TerminalDemo />
             </div>
           </div>
+        </HeroLockup>
+      </section>
 
-          {/* The terminal pre uses overflow-x-auto, but it can only scroll
-              inside its own box if the grid cell honors min-width:0.
-              Without `min-w-0` here the long install curl line pushes
-              the grid track wider than the viewport on phones. */}
-          <div className="flex w-full min-w-0 items-center">
-            <TerminalDemo />
+      {/* Stories — moved above Three modes so visitors land on
+          concrete "things you can do today" before the conceptual
+          enforcement-tier explainer. */}
+      <section className="border-t border-fd-border bg-fd-card/30 py-16">
+        <div className="container mx-auto max-w-7xl px-4">
+          <div className="mb-8 flex flex-col gap-2">
+            <p className="text-sm font-medium uppercase tracking-wider text-[var(--brand-cisco-strong)]">
+              Stories
+            </p>
+            <h2 className="text-3xl font-semibold tracking-tight">
+              Six things you can do today.
+            </h2>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {STORIES.map((s) => (
+              <Link
+                key={s.href}
+                href={s.href}
+                className="group rounded-xl border border-fd-border bg-fd-card p-5 transition duration-200 hover:-translate-y-0.5 hover:border-[var(--brand-cisco)]/50 hover:shadow-md"
+              >
+                <h3 className="text-base font-semibold">{s.title}</h3>
+                <p className="mt-2 text-sm text-fd-muted-foreground">{s.body}</p>
+                {/* "Read →" is muted at rest so the card body reads as
+                    the primary content; on hover it brightens and
+                    underlines as the click affordance. */}
+                <p className="mt-3 text-sm font-medium text-[var(--brand-cisco-strong)] opacity-70 transition group-hover:opacity-100 group-hover:underline">
+                  Read →
+                </p>
+              </Link>
+            ))}
           </div>
         </div>
       </section>
@@ -193,8 +231,8 @@ export default function HomePage() {
             Start in observe. Earn enforcement.
           </h2>
           <p className="max-w-2xl text-fd-muted-foreground">
-            Start in observe. Promote to action when the policy is tuned. Layer HITL on top for
-            CRITICAL findings.
+            Start in observe. Promote to action when the policy is tuned. Layer approval prompts
+            on top for CRITICAL findings.
           </p>
         </div>
         <div className="grid gap-4 md:grid-cols-3">
@@ -203,18 +241,7 @@ export default function HomePage() {
               key={m.name}
               className="rounded-xl border border-fd-border bg-fd-card/40 p-6 transition hover:border-[var(--brand-cisco)]/50"
             >
-              <div className="flex items-center gap-3">
-                {/* Single-letter mark mirrors the chip language used in
-                    the hero so the cards feel like part of the same
-                    system rather than a separate component island. */}
-                <span
-                  aria-hidden
-                  className="inline-flex size-7 items-center justify-center rounded-full border border-fd-border bg-fd-card text-xs font-semibold text-[var(--brand-cisco-strong)]"
-                >
-                  {m.mark}
-                </span>
-                <h3 className="text-xl font-semibold">{m.name}</h3>
-              </div>
+              <h3 className="text-xl font-semibold">{m.name}</h3>
               <p className="mt-3 text-sm font-medium text-[var(--brand-cisco-strong)]">{m.tagline}</p>
               <p className="mt-2 text-sm text-fd-muted-foreground">{m.body}</p>
             </article>
@@ -233,8 +260,8 @@ export default function HomePage() {
               One adapter per agent. Same enforcement contract.
             </h2>
             <p className="max-w-2xl text-fd-muted-foreground">
-              Proxy connectors intercept LLM traffic. Hook connectors wire into the agent’s
-              native lifecycle.
+              Every connector lands in the same gateway with the same block / approve / observe
+              verbs — pick the agent you ship with, the contract is identical.
             </p>
           </div>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -242,106 +269,12 @@ export default function HomePage() {
               <Link
                 key={c.id}
                 href={`/docs/connectors/${c.id}`}
-                className="group rounded-xl border border-fd-border bg-fd-card p-5 transition hover:border-[var(--brand-cisco)]/50"
+                className="group rounded-xl border border-fd-border bg-fd-card p-5 transition duration-200 hover:-translate-y-0.5 hover:border-[var(--brand-cisco)]/50 hover:shadow-md"
               >
-                <div className="mb-3 flex items-center justify-between gap-2">
-                  <span className="text-base font-semibold">{c.label}</span>
-                  {/* Family badge dot matches the hero chip dots so the
-                      proxy/hooks distinction reads identically across
-                      both surfaces. */}
-                  <span className="inline-flex items-center gap-1.5 rounded-full border border-fd-border bg-fd-secondary/50 px-2 py-0.5 text-[11px] font-medium text-fd-muted-foreground">
-                    <span
-                      aria-hidden
-                      className={
-                        c.family === 'proxy'
-                          ? 'size-1.5 rounded-full bg-[var(--brand-cisco)]'
-                          : 'size-1.5 rounded-full bg-fd-muted-foreground/40'
-                      }
-                    />
-                    {c.family}
-                  </span>
-                </div>
-                <p className="text-sm text-fd-muted-foreground">{firstSentence(c.notes)}</p>
+                <span className="text-base font-semibold">{c.label}</span>
+                <p className="mt-3 text-sm text-fd-muted-foreground">{firstSentence(c.notes)}</p>
                 <p className="mt-3 text-sm font-medium text-[var(--brand-cisco-strong)] opacity-70 transition group-hover:opacity-100 group-hover:underline">
                   Open page →
-                </p>
-              </Link>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Architecture */}
-      <section className="container mx-auto max-w-7xl px-4 py-16">
-        <div className="mb-6 flex flex-col gap-2">
-          <p className="text-sm font-medium uppercase tracking-wider text-[var(--brand-cisco-strong)]">
-            Architecture
-          </p>
-          <h2 className="text-3xl font-semibold tracking-tight">A Python CLI, a Go sidecar, and one OpenClaw plugin.</h2>
-        </div>
-        {/* Replaces the previous ASCII <pre> with the same diagram
-            primitive every docs page uses, so the gateway, policy, and
-            audit fan-out all share the visual vocabulary readers see
-            once they click through. */}
-        <Flow
-          direction="LR"
-          caption="The connector talks to the gateway over a stable Go interface; the gateway fans out to scanners, the LLM provider, and audit sinks."
-        >
-          <Node id="agent" kind="agent">
-            Agent runtime
-          </Node>
-          <Node id="connector" kind="connector">
-            DefenseClaw connector
-          </Node>
-          <Node id="gateway" kind="gateway">
-            defenseclaw-gateway
-          </Node>
-          <Node id="policy" kind="policy">
-            {`Policy + scanners\n+ audit`}
-          </Node>
-          <Node id="llm" kind="generic">
-            LLM provider
-          </Node>
-          <Node id="sinks" kind="datastore">
-            {`OTLP / Splunk\nwebhooks / JSONL`}
-          </Node>
-          <Edge from="agent" to="connector" />
-          <Edge from="connector" to="gateway" />
-          <Edge from="gateway" to="policy" label="inspect" />
-          <Edge from="gateway" to="llm" label="guardrail proxy" />
-          <Edge from="gateway" to="sinks" label="audit" />
-        </Flow>
-        <p className="mt-3 text-sm text-fd-muted-foreground">
-          Python CLI for setup. Go gateway for inspection and audit. TypeScript plugin closes the
-          loop on the agent side.
-        </p>
-      </section>
-
-      {/* Stories */}
-      <section className="border-t border-fd-border bg-fd-card/30 py-16">
-        <div className="container mx-auto max-w-7xl px-4">
-          <div className="mb-8 flex flex-col gap-2">
-            <p className="text-sm font-medium uppercase tracking-wider text-[var(--brand-cisco-strong)]">
-              Stories
-            </p>
-            <h2 className="text-3xl font-semibold tracking-tight">
-              Six things you can do today.
-            </h2>
-          </div>
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {STORIES.map((s) => (
-              <Link
-                key={s.href}
-                href={s.href}
-                className="group rounded-xl border border-fd-border bg-fd-card p-5 transition hover:border-[var(--brand-cisco)]/50"
-              >
-                <h3 className="text-base font-semibold">{s.title}</h3>
-                <p className="mt-2 text-sm text-fd-muted-foreground">{s.body}</p>
-                {/* "Read →" is muted at rest so the card body reads as
-                    the primary content; on hover it brightens and
-                    underlines as the click affordance. */}
-                <p className="mt-3 text-sm font-medium text-[var(--brand-cisco-strong)] opacity-70 transition group-hover:opacity-100 group-hover:underline">
-                  Read →
                 </p>
               </Link>
             ))}
@@ -358,12 +291,12 @@ export default function HomePage() {
           Five minutes. No LLM key required.
         </p>
         <div className="mt-6 flex flex-wrap justify-center gap-3">
-          <Link
+          <CtaGlowButton
             href="/docs/get-started/install"
             className="inline-flex items-center gap-2 rounded-md bg-[var(--brand-cisco)] px-5 py-2.5 text-sm font-medium text-white shadow-md transition hover:bg-[var(--brand-cisco-strong)]"
           >
             Install DefenseClaw
-          </Link>
+          </CtaGlowButton>
           <Link
             href="/docs/setup/guardrail"
             className="inline-flex items-center gap-2 rounded-md border border-fd-border bg-fd-card px-5 py-2.5 text-sm font-medium transition hover:bg-fd-muted"
@@ -377,11 +310,14 @@ export default function HomePage() {
 }
 
 // Hero chip primitives — kept co-located because they exist solely to
-// give the hero left column three scannable rows. Sharing one
-// `HeroChip` ensures the connector dots, the workflow pills, and the
-// audit sinks all read with identical weight. The styling tokens
-// (rounded-full, bg-fd-secondary/50, border-fd-border, text-xs) match
-// the navbar repo-stats pills so the lockup reads as one system.
+// give the hero left column three scannable rows. The container is a
+// soft card; each row sits inside that card with a fixed-width label
+// rail on the left and the chip cluster on the right, with a thin
+// horizontal divider between rows. Sharing one `HeroChip` ensures
+// connectors, workflow pills, and audit sinks all read with identical
+// weight, and the styling tokens (rounded-full, bg-fd-secondary/50,
+// border-fd-border, text-xs) match the navbar repo-stats pills so the
+// lockup reads as one design system.
 function HeroChipRow({
   label,
   children,
@@ -390,18 +326,20 @@ function HeroChipRow({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex flex-col gap-1.5 sm:flex-row sm:items-center sm:gap-3">
-      <span className="text-[11px] font-semibold uppercase tracking-wider text-fd-muted-foreground/70 sm:w-20 sm:shrink-0">
+    <div className="flex flex-col gap-2 border-b border-fd-border/60 px-4 py-3 last:border-b-0 sm:flex-row sm:items-baseline sm:gap-4">
+      <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-fd-muted-foreground sm:w-24 sm:shrink-0">
         {label}
       </span>
-      <div className="flex flex-wrap items-center gap-1.5">{children}</div>
+      <div className="flex flex-1 flex-wrap items-center gap-1.5">
+        {children}
+      </div>
     </div>
   );
 }
 
 function HeroChip({ children }: { children: React.ReactNode }) {
   return (
-    <span className="inline-flex items-center gap-1.5 rounded-full border border-fd-border bg-fd-secondary/50 px-2.5 py-0.5 text-xs text-fd-muted-foreground">
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-fd-border bg-fd-secondary/60 px-2.5 py-0.5 text-xs text-fd-foreground/85">
       {children}
     </span>
   );

--- a/docs-site/app/global.css
+++ b/docs-site/app/global.css
@@ -104,6 +104,160 @@
   animation: terminal-blink 1s steps(2, end) infinite;
 }
 
+/* Rotating connector word in the hero h1. Each word remounts via a
+ * React `key` change which retriggers this single-shot animation;
+ * the absolute-positioned wrapper around it keeps the heading width
+ * stable so the layout doesn't jiggle while the word swaps.
+ */
+@keyframes connector-word-in {
+  0% {
+    opacity: 0;
+    transform: translateY(0.25em);
+    filter: blur(2px);
+  }
+  60% {
+    opacity: 1;
+    filter: blur(0);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}
+
+.connector-word-in {
+  animation: connector-word-in 360ms cubic-bezier(0.2, 0.6, 0.2, 1) both;
+}
+
+/* CTA pulse — fired once via React adding the class, then auto-removes
+ * itself on `animationend` so subsequent scrolls don't re-trigger.
+ * The pulse expands a ring outward and fades, mimicking the iOS
+ * "tap target" feedback so the eye is drawn to the install button
+ * once the CTA section enters the viewport.
+ */
+@keyframes cta-pulse {
+  0%   { box-shadow: 0 0 0 0 color-mix(in oklab, var(--brand-cisco) 70%, transparent); }
+  70%  { box-shadow: 0 0 0 12px color-mix(in oklab, var(--brand-cisco) 0%, transparent); }
+  100% { box-shadow: 0 0 0 0 color-mix(in oklab, var(--brand-cisco) 0%, transparent); }
+}
+
+.cta-pulse {
+  animation: cta-pulse 1.6s ease-out 1;
+}
+
+/* Diagram entrance animations. <DiagramLightbox> flips
+ * `data-animate="entered"` on the <figure> once the diagram scrolls
+ * into view; every keyframe below is scoped to that attribute so the
+ * SSR-rendered SVG paints to its final state until JS hydrates and
+ * the IntersectionObserver fires.
+ */
+@keyframes flow-node-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes flow-edge-draw {
+  from { stroke-dashoffset: 600; opacity: 0.5; }
+  to   { stroke-dashoffset: 0;   opacity: 1; }
+}
+@keyframes flow-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+[data-animate='entered'] .fd-flow-node {
+  animation: flow-node-in 380ms ease-out both;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+[data-animate='entered'] .fd-flow-edge {
+  stroke-dasharray: 600;
+  animation: flow-edge-draw 480ms ease-in-out both;
+}
+[data-animate='entered'] .fd-flow-edge-label {
+  animation: flow-fade-in 240ms ease-out both;
+}
+
+@keyframes seq-pill-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes seq-lifeline {
+  from { transform: scaleY(0); }
+  to   { transform: scaleY(1); }
+}
+@keyframes seq-message-in {
+  from { opacity: 0; transform: translateX(-4px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+[data-animate='entered'] .fd-seq-pill {
+  animation: seq-pill-in 320ms ease-out both;
+  transform-box: fill-box;
+  transform-origin: top center;
+}
+[data-animate='entered'] .fd-seq-lifeline {
+  animation: seq-lifeline 240ms ease-out both;
+  transform-box: fill-box;
+  transform-origin: top;
+}
+[data-animate='entered'] .fd-seq-message {
+  animation: seq-message-in 280ms ease-out both;
+  transform-box: fill-box;
+  transform-origin: left center;
+}
+[data-animate='entered'] .fd-seq-message-label {
+  animation: flow-fade-in 200ms ease-out both;
+}
+
+/* Capability matrix row stagger. The wrapper toggles
+ * `data-animate="entered"` on viewport entry so the rows fade up in
+ * sequence — letting the eye scan the connector list one by one
+ * instead of swallowing the whole table at once.
+ */
+@keyframes row-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+[data-animate='entered'] .fd-row {
+  animation: row-in 280ms ease-out both;
+}
+
+/* Fumadocs Card hover-lift across the docs. Targets the upstream
+ * `data-card="true"` attribute so every <Cards> block (Stories
+ * landing, every connector page's "next steps", Get Started landing,
+ * Setup landing, the Quickstart, etc.) gains a subtle lift on hover
+ * with no MDX edits. Hover-only, so screen-readers and keyboard nav
+ * are unaffected.
+ */
+@media (prefers-reduced-motion: no-preference) {
+  a[data-card='true'] {
+    transition: transform 180ms ease-out, box-shadow 180ms ease-out,
+      border-color 180ms ease-out;
+  }
+  a[data-card='true']:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 18px -10px
+      color-mix(in oklab, var(--brand-cisco) 40%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .connector-word-in,
+  .cta-pulse,
+  [data-animate='entered'] .fd-flow-node,
+  [data-animate='entered'] .fd-flow-edge,
+  [data-animate='entered'] .fd-flow-edge-label,
+  [data-animate='entered'] .fd-seq-pill,
+  [data-animate='entered'] .fd-seq-lifeline,
+  [data-animate='entered'] .fd-seq-message,
+  [data-animate='entered'] .fd-seq-message-label,
+  [data-animate='entered'] .fd-row {
+    animation: none !important;
+  }
+}
+
 /* Search dialog polish — Fumadocs's FlexSearch result list paints the
  * active row with `bg-fd-accent text-fd-accent-foreground`, but the
  * breadcrumb child still has `text-fd-muted-foreground` baked in. The

--- a/docs-site/components/capability-matrix-wrapper.tsx
+++ b/docs-site/components/capability-matrix-wrapper.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useRef, type ReactNode } from 'react';
+
+// One-shot viewport observer for the capability matrix table. Flips
+// `data-animate="entered"` on the wrapper once the table scrolls into
+// view, which gates the row-stagger keyframe defined in global.css.
+// SSR markup stays unchanged — the table renders to its final state
+// until JS hydrates and the IntersectionObserver fires.
+
+interface CapabilityMatrixWrapperProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function CapabilityMatrixWrapper({
+  children,
+  className,
+}: CapabilityMatrixWrapperProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (el.dataset.animate === 'entered') return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      el.dataset.animate = 'entered';
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting) {
+            el.dataset.animate = 'entered';
+            io.disconnect();
+            break;
+          }
+        }
+      },
+      { rootMargin: '0px 0px -10% 0px', threshold: 0.1 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  return (
+    <div ref={ref} className={className}>
+      {children}
+    </div>
+  );
+}

--- a/docs-site/components/capability-matrix.tsx
+++ b/docs-site/components/capability-matrix.tsx
@@ -1,11 +1,13 @@
 import matrix from '@/data/capability-matrix.json';
+import { CapabilityMatrixWrapper } from './capability-matrix-wrapper';
 
 // Renders the connector × capability matrix as a horizontally-scrolling
 // table. Data lives in a JSON file (`data/capability-matrix.json`) so a
 // follow-up CI job can regenerate it from `defenseclaw doctor
 // --capabilities --json` without touching the React component. The
-// component itself is intentionally server-rendered (no client JS) so
-// it ships zero runtime cost and remains fully indexable.
+// table itself is server-rendered (no client JS for the data) — only
+// the outer scroll wrapper hydrates so it can attach the
+// IntersectionObserver that drives the row-stagger entrance.
 
 interface ConnectorRow {
   id: string;
@@ -58,7 +60,7 @@ function Family({ family }: { family: ConnectorRow['family'] }) {
 
 export function CapabilityMatrix() {
   return (
-    <div className="not-prose my-6 overflow-x-auto rounded-xl border border-fd-border">
+    <CapabilityMatrixWrapper className="not-prose my-6 overflow-x-auto rounded-xl border border-fd-border">
       <table className="w-full min-w-[900px] border-collapse text-sm">
         <thead>
           <tr className="bg-fd-card text-left">
@@ -73,8 +75,16 @@ export function CapabilityMatrix() {
           </tr>
         </thead>
         <tbody>
-          {data.connectors.map((c) => (
-            <tr key={c.id} className="border-t border-fd-border">
+          {data.connectors.map((c, i) => (
+            <tr
+              key={c.id}
+              className="fd-row border-t border-fd-border"
+              // Stagger delay matches the eye's reading cadence — fast
+              // enough that the whole table settles in <500ms even for
+              // a dozen connectors, slow enough that each row registers
+              // as a discrete arrival.
+              style={{ animationDelay: `${i * 35}ms` }}
+            >
               <Td>
                 <a href={`/docs/connectors/${c.id}`} className="font-medium text-[var(--brand-cisco-strong)] hover:underline">
                   {c.label}
@@ -105,7 +115,7 @@ export function CapabilityMatrix() {
           ))}
         </tbody>
       </table>
-    </div>
+    </CapabilityMatrixWrapper>
   );
 }
 

--- a/docs-site/components/cta-glow-button.tsx
+++ b/docs-site/components/cta-glow-button.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useRef, type ReactNode } from 'react';
+
+// Bottom-CTA "Install DefenseClaw" button. Wraps the underlying <Link>
+// with an IntersectionObserver that fires the .cta-pulse keyframe
+// exactly once on first viewport entry. Pure CSS pulse — the JS just
+// adds the class and removes it on `animationend` so subsequent
+// scrolls don't re-trigger.
+//
+// Style props are forwarded so the parent owns the visual identity
+// (size, background, text colour); this component only owns the
+// pulse trigger so the animation can be added or pulled without
+// touching the styling tokens elsewhere.
+
+interface CtaGlowButtonProps {
+  href: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function CtaGlowButton({ href, children, className }: CtaGlowButtonProps) {
+  const linkRef = useRef<HTMLAnchorElement | null>(null);
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    const el = linkRef.current;
+    if (!el) return;
+
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reduced || firedRef.current) return;
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting && !firedRef.current) {
+            firedRef.current = true;
+            el.classList.add('cta-pulse');
+            // Auto-remove the class once the animation finishes so
+            // class lists stay clean and the animation never replays
+            // (e.g. if the user scrolls past and back, which would
+            // otherwise re-trigger if the browser ever recalculates).
+            const onEnd = () => {
+              el.classList.remove('cta-pulse');
+              el.removeEventListener('animationend', onEnd);
+            };
+            el.addEventListener('animationend', onEnd);
+            io.disconnect();
+          }
+        }
+      },
+      { rootMargin: '0px 0px -10% 0px', threshold: 0.4 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  return (
+    <Link ref={linkRef} href={href} className={className}>
+      {children}
+    </Link>
+  );
+}

--- a/docs-site/components/diagram/flow.tsx
+++ b/docs-site/components/diagram/flow.tsx
@@ -235,6 +235,16 @@ export function Flow({
   const width = Math.ceil(graphLabel.width ?? 0) + 16;
   const height = Math.ceil(graphLabel.height ?? 0) + 16;
 
+  // Rank each node along the layout's primary axis so the entrance
+  // animation lights up nodes in reading order (LR → left-to-right
+  // columns, TB → top-to-bottom rows). Edges inherit their source
+  // node's rank + a half-step so each edge starts as soon as its
+  // source has landed.
+  const rankAxis = (n: ResolvedNode) => (direction === 'LR' ? n.x : n.y);
+  const nodesByRank = [...resolved].sort((a, b) => rankAxis(a) - rankAxis(b));
+  const rankById = new Map<string, number>();
+  nodesByRank.forEach((n, i) => rankById.set(n.id, i));
+
   const id = nextDiagramId('fd-flow');
   const ariaLabel = caption ?? 'Flow diagram';
 
@@ -278,11 +288,22 @@ export function Flow({
 
       {/* Edges first so they sit underneath the node panels. */}
       {resolvedEdges.map((edge, i) => (
-        <FlowEdge key={`e-${i}`} edge={edge} markerId={id} />
+        <FlowEdge
+          key={`e-${i}`}
+          edge={edge}
+          markerId={id}
+          fromRank={rankById.get(edge.from) ?? 0}
+        />
       ))}
 
       {resolved.map((node) => (
-        <FlowNode key={node.id} node={node} filterId={id} gradientId={id} />
+        <FlowNode
+          key={node.id}
+          node={node}
+          filterId={id}
+          gradientId={id}
+          rank={rankById.get(node.id) ?? 0}
+        />
       ))}
     </svg>
   );
@@ -325,10 +346,16 @@ function FlowNode({
   node,
   filterId,
   gradientId,
+  rank,
 }: {
   node: ResolvedNode;
   filterId: string;
   gradientId: string;
+  // Layout-axis rank (left-to-right or top-to-bottom column index).
+  // Used to stagger the entrance animation in reading order; the
+  // class is gated on the parent figure's `data-animate="entered"`,
+  // so the SSR render paints the final state until JS hydrates.
+  rank: number;
 }) {
   const style = KIND_TO_STYLE[node.kind];
   const x = node.x - node.width / 2;
@@ -338,6 +365,7 @@ function FlowNode({
     ? `url(#${gradientId}-emphasis)`
     : 'var(--color-fd-border)';
   const strokeWidth = node.emphasis ? 1.75 : 1;
+  const nodeAnimDelay = `${rank * 60}ms`;
 
   if (style.diamond) {
     // Diamond shape: vertices at top/right/bottom/left of the bounding box.
@@ -350,7 +378,7 @@ function FlowNode({
       `${node.x - w / 2},${node.y}`,
     ].join(' ');
     return (
-      <g>
+      <g className="fd-flow-node" style={{ animationDelay: nodeAnimDelay }}>
         <polygon
           points={points}
           style={{
@@ -382,7 +410,7 @@ function FlowNode({
   }
 
   return (
-    <g>
+    <g className="fd-flow-node" style={{ animationDelay: nodeAnimDelay }}>
       <rect
         x={x}
         y={y}
@@ -445,7 +473,18 @@ function FlowNode({
   );
 }
 
-function FlowEdge({ edge, markerId }: { edge: ResolvedEdge; markerId: string }) {
+function FlowEdge({
+  edge,
+  markerId,
+  fromRank,
+}: {
+  edge: ResolvedEdge;
+  markerId: string;
+  // Source-node rank. The edge animation starts a half-step after the
+  // source node's entrance lands so the line "draws out" of an
+  // already-visible node.
+  fromRank: number;
+}) {
   if (edge.points.length < 2) return null;
   const isEmphasis = edge.emphasis;
   const stroke = isEmphasis ? 'var(--brand-cisco)' : 'var(--color-fd-border)';
@@ -466,9 +505,17 @@ function FlowEdge({ edge, markerId }: { edge: ResolvedEdge; markerId: string }) 
   // edge — which we did — so prefer that for accuracy.
   const mid = midpoint(edge.points);
 
+  // Edge starts as soon as the source node has settled (rank * 60ms +
+  // half a step). The label fades in 240ms after the line begins so
+  // it never lands before the path it sits on is visible.
+  const edgeDelayMs = (fromRank + 0.5) * 60;
+  const edgeAnimDelay = `${edgeDelayMs}ms`;
+  const labelAnimDelay = `${edgeDelayMs + 240}ms`;
+
   return (
     <g>
       <path
+        className="fd-flow-edge"
         d={d}
         style={{
           fill: 'none',
@@ -477,18 +524,34 @@ function FlowEdge({ edge, markerId }: { edge: ResolvedEdge; markerId: string }) 
           strokeLinecap: 'round',
           strokeLinejoin: 'round',
           strokeDasharray: dasharray,
+          animationDelay: edgeAnimDelay,
         }}
         markerStart={markerStart}
         markerEnd={markerEnd}
       />
       {edge.label && (
-        <EdgeLabelChip x={mid.x} y={mid.y} label={edge.label} />
+        <EdgeLabelChip
+          x={mid.x}
+          y={mid.y}
+          label={edge.label}
+          animationDelay={labelAnimDelay}
+        />
       )}
     </g>
   );
 }
 
-function EdgeLabelChip({ x, y, label }: { x: number; y: number; label: string }) {
+function EdgeLabelChip({
+  x,
+  y,
+  label,
+  animationDelay,
+}: {
+  x: number;
+  y: number;
+  label: string;
+  animationDelay?: string;
+}) {
   // Estimate chip width from char count. The chip uses an HTML
   // foreignObject so we get full font fallback and crisp anti-aliased
   // text instead of SVG <text> spacing quirks.
@@ -496,10 +559,12 @@ function EdgeLabelChip({ x, y, label }: { x: number; y: number; label: string })
   const chipH = 22;
   return (
     <foreignObject
+      className="fd-flow-edge-label"
       x={x - chipW / 2}
       y={y - chipH / 2}
       width={chipW}
       height={chipH}
+      style={animationDelay ? { animationDelay } : undefined}
     >
       <ForeignDiv
         style={{

--- a/docs-site/components/diagram/lightbox.tsx
+++ b/docs-site/components/diagram/lightbox.tsx
@@ -64,11 +64,46 @@ export function DiagramLightbox({
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const closeRef = useRef<HTMLButtonElement | null>(null);
   const surfaceRef = useRef<HTMLDivElement | null>(null);
+  const figureRef = useRef<HTMLElement | null>(null);
   const titleId = useId();
   const captionId = useId();
 
   useEffect(() => {
     setHydrated(true);
+  }, []);
+
+  // One-shot viewport intersection trigger. The Flow / Sequence /
+  // capability-matrix CSS animations are gated on
+  // `data-animate="entered"` on this <figure>, so the SSR-rendered
+  // SVG paints to its final state until JS hydrates and the diagram
+  // scrolls into view. Once entered, we disconnect — the animation
+  // runs exactly once per page visit and never replays on scrollback.
+  useEffect(() => {
+    const el = figureRef.current;
+    if (!el) return;
+    if (el.dataset.animate === 'entered') return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      // Reduced-motion: still set the attribute so any conditional
+      // styling that depends on it (e.g. final-state colours) is
+      // applied; the keyframes themselves are no-ops via the global
+      // reduced-motion guard in global.css.
+      el.dataset.animate = 'entered';
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting) {
+            el.dataset.animate = 'entered';
+            io.disconnect();
+            break;
+          }
+        }
+      },
+      { rootMargin: '0px 0px -10% 0px', threshold: 0.15 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
   }, []);
 
   // Esc-to-close + restore focus to the trigger when the modal closes.
@@ -126,6 +161,7 @@ export function DiagramLightbox({
 
   return (
     <figure
+      ref={figureRef}
       className="my-6 not-prose relative group"
       data-oversize={oversize ? 'true' : undefined}
       data-natural-width={naturalWidth}
@@ -185,7 +221,10 @@ export function DiagramLightbox({
           onClick={handleSurfaceClick}
           className="fixed inset-0 z-50 flex items-stretch justify-stretch bg-black/70 p-4 backdrop-blur-sm sm:p-8"
         >
-          <div className="relative flex h-full w-full flex-col rounded-xl border border-fd-border bg-fd-background shadow-2xl">
+          <div
+            data-animate="entered"
+            className="relative flex h-full w-full flex-col rounded-xl border border-fd-border bg-fd-background shadow-2xl"
+          >
             <div className="flex items-center justify-between gap-4 border-b border-fd-border px-4 py-3">
               <h2
                 id={titleId}

--- a/docs-site/components/diagram/sequence.tsx
+++ b/docs-site/components/diagram/sequence.tsx
@@ -242,10 +242,22 @@ export function Sequence({
     >
       <DiagramDefs id={id} />
 
-      {/* Lifelines first so messages render on top. */}
+      {/*
+        Animation cadence (gated on the parent figure's
+        `data-animate="entered"`, so SSR paints the final state until
+        JS hydrates and the diagram scrolls into view):
+          1. Pills fade-down in column order:    i  * 50ms
+          2. Lifelines scaleY together once pills are settled:
+                                                  participants.length * 50 + 80ms
+          3. Messages slide-in row-by-row:       lifelinesEnd + i * 90ms
+          4. Each message's label fades in 200ms after the message.
+      */}
+      {/* Lifelines first so messages render on top. All lifelines
+          scaleY downward simultaneously once every pill has landed. */}
       {resolved.map((p) => (
         <line
           key={`lifeline-${p.id}`}
+          className="fd-seq-lifeline"
           x1={p.x}
           x2={p.x}
           y1={lifelineTop}
@@ -257,18 +269,31 @@ export function Sequence({
             strokeWidth: p.emphasis ? 1.5 : 1,
             strokeDasharray: p.emphasis ? undefined : '4 5',
             opacity: p.emphasis ? 0.7 : 0.9,
+            animationDelay: `${participants.length * 50 + 80}ms`,
           }}
         />
       ))}
 
       {/* Participant pills */}
-      {resolved.map((p) => (
-        <ParticipantPill key={`pill-${p.id}`} p={p} gradientId={id} filterId={id} />
+      {resolved.map((p, i) => (
+        <ParticipantPill
+          key={`pill-${p.id}`}
+          p={p}
+          gradientId={id}
+          filterId={id}
+          animationDelay={`${i * 50}ms`}
+        />
       ))}
 
       {/* Messages */}
       {messages.map((m, i) => {
         const y = lifelineTop + 28 + i * MESSAGE_GAP;
+        // Messages animate after every lifeline has finished drawing
+        // (participants.length * 50 + 80ms breather + 240ms scaleY
+        // duration), then stagger one per row at 90ms.
+        const messagesStartMs = participants.length * 50 + 80 + 240;
+        const messageDelay = `${messagesStartMs + i * 90}ms`;
+        const labelDelay = `${messagesStartMs + i * 90 + 200}ms`;
         if (m.note) {
           return (
             <SequenceNote
@@ -277,6 +302,8 @@ export function Sequence({
               x1={Math.min(resolved[m.fromIdx].x, resolved[m.toIdx].x)}
               x2={Math.max(resolved[m.fromIdx].x, resolved[m.toIdx].x)}
               label={m.label ?? ''}
+              animationDelay={messageDelay}
+              labelAnimationDelay={labelDelay}
             />
           );
         }
@@ -289,6 +316,8 @@ export function Sequence({
             label={m.label}
             kind={m.kind ?? 'sync'}
             markerId={id}
+            animationDelay={messageDelay}
+            labelAnimationDelay={labelDelay}
           />
         );
       })}
@@ -406,10 +435,15 @@ function ParticipantPill({
   p,
   gradientId,
   filterId,
+  animationDelay,
 }: {
   p: ResolvedParticipant;
   gradientId: string;
   filterId: string;
+  // Per-participant entrance delay; gated on the parent figure's
+  // `data-animate="entered"`, so SSR paints the pill in its final
+  // state until JS hydrates and the diagram scrolls into view.
+  animationDelay?: string;
 }) {
   const kind: DiagramKind = p.kind ?? 'generic';
   const style = KIND_TO_STYLE[kind];
@@ -419,7 +453,10 @@ function ParticipantPill({
     ? `url(#${gradientId}-emphasis)`
     : 'var(--color-fd-border)';
   return (
-    <g>
+    <g
+      className="fd-seq-pill"
+      style={animationDelay ? { animationDelay } : undefined}
+    >
       <rect
         x={x}
         y={y}
@@ -483,6 +520,8 @@ function SequenceArrow({
   label,
   kind,
   markerId,
+  animationDelay,
+  labelAnimationDelay,
 }: {
   y: number;
   from: ResolvedParticipant;
@@ -490,6 +529,12 @@ function SequenceArrow({
   label?: string;
   kind: MessageKind;
   markerId: string;
+  // Row-staggered entrance delay; gated on the parent figure's
+  // `data-animate="entered"`. The arrow slides in from the left
+  // (transform-origin set in global.css), the label fades in 200ms
+  // later so it never lands before the line it sits on.
+  animationDelay?: string;
+  labelAnimationDelay?: string;
 }) {
   const isReturn = kind === 'return';
   const isAsync = kind === 'async';
@@ -508,7 +553,10 @@ function SequenceArrow({
     const cx = from.x;
     const r = 14;
     return (
-      <g style={{ opacity }}>
+      <g
+        className="fd-seq-message"
+        style={{ opacity, ...(animationDelay && { animationDelay }) }}
+      >
         <path
           d={`M ${cx} ${y} h ${r} a ${r} ${r} 0 0 1 0 ${r * 2} h -${r}`}
           style={{
@@ -526,6 +574,7 @@ function SequenceArrow({
             y={y + r}
             label={label}
             anchor="start"
+            animationDelay={labelAnimationDelay}
           />
         )}
       </g>
@@ -538,7 +587,10 @@ function SequenceArrow({
   const x2 = to.x - dir * 4;
 
   return (
-    <g style={{ opacity }}>
+    <g
+      className="fd-seq-message"
+      style={{ opacity, ...(animationDelay && { animationDelay }) }}
+    >
       <line
         x1={x1}
         y1={y}
@@ -558,6 +610,7 @@ function SequenceArrow({
           y={y - 18}
           label={label}
           anchor="middle"
+          animationDelay={labelAnimationDelay}
         />
       )}
     </g>
@@ -569,17 +622,26 @@ function SequenceLabelChip({
   y,
   label,
   anchor,
+  animationDelay,
 }: {
   x: number;
   y: number;
   label: string;
   anchor: 'start' | 'middle' | 'end';
+  animationDelay?: string;
 }) {
   const w = Math.min(280, Math.max(40, label.length * 6.6 + 20));
   const h = 22;
   const offsetX = anchor === 'middle' ? -w / 2 : anchor === 'end' ? -w : 0;
   return (
-    <foreignObject x={x + offsetX} y={y - h / 2} width={w} height={h}>
+    <foreignObject
+      className="fd-seq-message-label"
+      x={x + offsetX}
+      y={y - h / 2}
+      width={w}
+      height={h}
+      style={animationDelay ? { animationDelay } : undefined}
+    >
       <ForeignDiv
         style={{
           width: '100%',
@@ -611,11 +673,15 @@ function SequenceNote({
   x1,
   x2,
   label,
+  animationDelay,
+  labelAnimationDelay,
 }: {
   y: number;
   x1: number;
   x2: number;
   label: string;
+  animationDelay?: string;
+  labelAnimationDelay?: string;
 }) {
   const padding = 14;
   // When the note spans a single participant (x1 === x2), give the
@@ -628,7 +694,10 @@ function SequenceNote({
   const left = (x1 + x2) / 2 - width / 2;
   const height = 30;
   return (
-    <g>
+    <g
+      className="fd-seq-message"
+      style={animationDelay ? { animationDelay } : undefined}
+    >
       <rect
         x={left}
         y={y - height / 2}
@@ -643,7 +712,14 @@ function SequenceNote({
           opacity: 0.95,
         }}
       />
-      <foreignObject x={left} y={y - height / 2} width={width} height={height}>
+      <foreignObject
+        className="fd-seq-message-label"
+        x={left}
+        y={y - height / 2}
+        width={width}
+        height={height}
+        style={labelAnimationDelay ? { animationDelay: labelAnimationDelay } : undefined}
+      >
         <ForeignDiv
           style={{
             width: '100%',

--- a/docs-site/components/hero-lockup.tsx
+++ b/docs-site/components/hero-lockup.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+import { TERMINAL_CONNECTORS } from '@/lib/hero-connectors';
+
+// Owns the rotation index for the hero lockup. The rotating word in
+// the headline and the terminal in the right column both subscribe
+// to this context, so the headline's "OpenClaw / Claude Code / Codex
+// / …" stays in lockstep with the `defenseclaw setup …` line in the
+// terminal regardless of how long any one connector's typewriter
+// takes.
+//
+// Cadence is event-driven: when the terminal finishes typing the
+// current per-connector block it calls `onDone()`, we hold the
+// settled frame for SETTLE_MS, then advance. This beats a fixed
+// interval because typewriter durations vary slightly per connector
+// (longer commands, longer mode IDs).
+//
+// Total per-connector beat ≈ typewriter (~1.4s) + SETTLE_MS, sized so
+// each connector reads as a deliberate beat with enough dwell time
+// for the visitor to scan the `claw.mode=<id>` line and the
+// matching headline word before the next swap.
+const SETTLE_MS = 3800;
+
+interface HeroLockupContextValue {
+  index: number;
+  // Called from <TerminalDemo> when the per-connector block finishes
+  // typing. Triggers the SETTLE_MS hold + advance.
+  onDone: () => void;
+  words: string[];
+}
+
+const HeroLockupContext = createContext<HeroLockupContextValue | null>(null);
+
+// Consumer hook used by <RotatingConnectorWord> and <TerminalDemo>.
+// Returns null when used outside the lockup so those components can
+// render in standalone mode (e.g. inside docs MDX) with their own
+// internal state — handy for keeping the components reusable.
+export function useHeroLockup(): HeroLockupContextValue | null {
+  return useContext(HeroLockupContext);
+}
+
+// Top-level wrapper. Children are the entire hero section JSX
+// (eyebrow, h1 with rotating word, paragraph, CTAs, chip strips,
+// terminal column). Page-level layout stays in `page.tsx`.
+export function HeroLockup({ children }: { children: ReactNode }) {
+  const [index, setIndex] = useState(0);
+  const advanceTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (advanceTimer.current !== null) {
+        window.clearTimeout(advanceTimer.current);
+      }
+    };
+  }, []);
+
+  const onDone = () => {
+    if (advanceTimer.current !== null) {
+      window.clearTimeout(advanceTimer.current);
+    }
+    advanceTimer.current = window.setTimeout(() => {
+      setIndex((prev) => (prev + 1) % TERMINAL_CONNECTORS.length);
+    }, SETTLE_MS);
+  };
+
+  const value: HeroLockupContextValue = {
+    index,
+    onDone,
+    words: TERMINAL_CONNECTORS.map((c) => c.label),
+  };
+
+  return (
+    <HeroLockupContext.Provider value={value}>
+      {children}
+    </HeroLockupContext.Provider>
+  );
+}

--- a/docs-site/components/repo-stats-client.tsx
+++ b/docs-site/components/repo-stats-client.tsx
@@ -1,7 +1,65 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { formatCount, githubApiUrl, type RepoStats } from '@/lib/github-stats';
+
+// Single-shot count-up that animates from 0 → target in ~600ms on
+// initial client mount. Reduced-motion users skip the animation. The
+// `aria-label` on the wrapping pill always reflects the final number,
+// so assistive tech never sees the in-progress animation.
+//
+// Subsequent updates (e.g. the GitHub API refresh) just snap to the
+// new value — we don't re-animate, because that would make the navbar
+// numbers count up *twice* in normal use.
+function CountUp({ value }: { value: number }) {
+  const [display, setDisplay] = useState(value);
+  const fromRef = useRef(0);
+  const animatedRef = useRef(false);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    // First mount only: animate 0 → value. After that any value
+    // change is treated as a real update (API refresh) and snaps.
+    if (animatedRef.current) {
+      setDisplay(value);
+      return;
+    }
+
+    const reduced = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
+    if (reduced) {
+      animatedRef.current = true;
+      setDisplay(value);
+      return;
+    }
+
+    animatedRef.current = true;
+    const start = performance.now();
+    const duration = 600;
+    const from = fromRef.current;
+    const to = value;
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / duration);
+      // Ease-out cubic so the number settles smoothly into place
+      // rather than slamming into the final value.
+      const eased = 1 - Math.pow(1 - t, 3);
+      setDisplay(Math.round(from + (to - from) * eased));
+      if (t < 1) {
+        rafRef.current = requestAnimationFrame(tick);
+      }
+    };
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, [value]);
+
+  return <>{formatCount(display)}</>;
+}
 
 export type RepoStatsVariant = 'banner' | 'nav';
 
@@ -100,7 +158,9 @@ export default function RepoStatsClient({ initial, variant = 'banner' }: Props) 
         >
           <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.193L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
         </svg>
-        <span className="tabular-nums">{formatCount(stats.stars)}</span>
+        <span className="tabular-nums">
+          <CountUp value={stats.stars} />
+        </span>
       </span>
       <span
         aria-label={`${stats.forks.toLocaleString('en-US')} forks on GitHub`}
@@ -116,7 +176,9 @@ export default function RepoStatsClient({ initial, variant = 'banner' }: Props) 
         >
           <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z" />
         </svg>
-        <span className="tabular-nums">{formatCount(stats.forks)}</span>
+        <span className="tabular-nums">
+          <CountUp value={stats.forks} />
+        </span>
       </span>
     </span>
   );

--- a/docs-site/components/rotating-connector-word.tsx
+++ b/docs-site/components/rotating-connector-word.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useHeroLockup } from './hero-lockup';
+
+// Hero word that swaps through every connector label so the headline
+// reads as a promise to the entire connector matrix, not just one.
+//
+// Two modes:
+//   1. Inside <HeroLockup> — reads the rotation index from context so
+//      it stays in lockstep with the terminal demo (page hero usage).
+//   2. Standalone — runs its own 2.2s interval rotation across a
+//      caller-supplied list. Lets the component drop into MDX or
+//      anywhere else outside the hero without dragging the lockup.
+
+const STANDALONE_INTERVAL_MS = 2200;
+
+interface RotatingConnectorWordProps {
+  // Optional override for the standalone rotation list. Ignored when
+  // mounted inside a <HeroLockup> (context wins).
+  words?: string[];
+}
+
+export function RotatingConnectorWord({ words }: RotatingConnectorWordProps) {
+  const lockup = useHeroLockup();
+  const [standaloneIdx, setStandaloneIdx] = useState(0);
+
+  // Standalone rotation. Skipped (and the interval is never created)
+  // when we're inside a HeroLockup context, where the parent owns
+  // the rotation cadence.
+  useEffect(() => {
+    if (lockup) return;
+    if (!words || words.length === 0) return;
+    const id = window.setInterval(() => {
+      setStandaloneIdx((prev) => (prev + 1) % words.length);
+    }, STANDALONE_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [lockup, words]);
+
+  const list = lockup?.words ?? words ?? [];
+  if (list.length === 0) return null;
+  const index = lockup ? lockup.index : standaloneIdx;
+  const current = list[index % list.length];
+
+  // `whitespace-nowrap` keeps multi-word connector names ("Claude Code",
+  // "GitHub Copilot CLI") from breaking mid-rotation. The h1 itself
+  // owns `text-balance` so the surrounding line rebalances naturally
+  // when the word swaps. The keyed inner span retriggers the
+  // single-shot fade-up animation defined in global.css on every tick.
+  return (
+    <span
+      className="inline-block whitespace-nowrap text-[var(--brand-cisco-strong)]"
+      aria-live="polite"
+    >
+      <span key={current} className="connector-word-in inline-block">
+        {current}
+      </span>
+    </span>
+  );
+}

--- a/docs-site/components/terminal-demo.tsx
+++ b/docs-site/components/terminal-demo.tsx
@@ -1,43 +1,103 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-// Lightweight terminal mockup mirroring the operator's first-run
-// experience: type the install + connector setup commands, then
-// reveal the configuration summary as if the gateway had just
-// echoed it. Pure React (no external typewriter library) so the
-// landing page stays under one network request for JS payload.
-//
-// The animation is gated by `prefers-reduced-motion`; users who
-// requested reduced motion see the final frame immediately so we
-// don't flicker text into place.
-const SCRIPT: { kind: 'cmd' | 'out' | 'ok' | 'dim'; text: string }[] = [
-  { kind: 'cmd', text: 'curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash' },
+import {
+  TERMINAL_CONNECTORS,
+  type ConnectorBlock,
+} from '@/lib/hero-connectors';
+import { useHeroLockup } from './hero-lockup';
+
+// Re-export so callers that already imported `TERMINAL_CONNECTORS`
+// from this module keep working. The canonical home is
+// `@/lib/hero-connectors` (a data module, not a client component) so
+// hero-lockup can read it without dragging in this component.
+export { TERMINAL_CONNECTORS } from '@/lib/hero-connectors';
+
+// Terminal mockup that types the install command + a per-connector
+// `defenseclaw setup ...` block, then settles. The rotation index
+// comes from <HeroLockup>'s context — when the parent advances we
+// re-type the per-connector block from scratch (the install header
+// stays pinned). When mounted outside the lockup the component runs
+// its own internal rotation interval so it stays usable as a generic
+// MDX widget.
+
+type LineKind = 'cmd' | 'out' | 'ok' | 'dim';
+interface ScriptLine {
+  kind: LineKind;
+  text: string;
+}
+
+// Static header — typed once on initial mount and never replayed.
+// `defenseclaw-gateway` is the canonical companion install line and
+// every connector setup runs after it.
+const HEADER: ScriptLine[] = [
+  {
+    kind: 'cmd',
+    text: 'curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash',
+  },
   { kind: 'ok', text: '✓ Installed defenseclaw + defenseclaw-gateway' },
-  { kind: 'cmd', text: 'defenseclaw setup claude-code' },
-  { kind: 'dim', text: '  DefenseClaw — Claude Code observability setup' },
-  { kind: 'dim', text: '  ─────────────────────────────────────────────' },
-  { kind: 'ok', text: '  ✓ Config saved to ~/.defenseclaw/config.yaml' },
-  { kind: 'ok', text: '  ✓ Active connector set to claudecode (claw.mode=claudecode)' },
-  { kind: 'ok', text: '  ✓ Gateway restarted — tool calls + prompts now inspected' },
-  { kind: 'cmd', text: 'defenseclaw setup guardrail --mode action --human-approval' },
-  { kind: 'ok', text: '  ✓ Action mode engaged — destructive ops will pause for review' },
 ];
 
-// Number of lines visible on first paint. We seed the install command +
-// its success line so even a headless screenshot of the very first
-// frame captures the "what is this thing doing?" beat. Below this the
-// animation takes over and reveals the rest at human-readable cadence.
-const INITIAL_STEP = 2;
+// Per-connector replay block — five lines so the typewriter completes
+// in ~1.4s at 280ms/line and leaves the user ~0.9s to read the
+// settled state before the next rotation (cadence enforced by
+// <HeroLockup>'s SETTLE_MS).
+function blockFor(c: ConnectorBlock): ScriptLine[] {
+  return [
+    { kind: 'cmd', text: c.command },
+    { kind: 'dim', text: `  DefenseClaw — ${c.label} setup` },
+    { kind: 'ok',  text: '  ✓ Config saved to ~/.defenseclaw/config.yaml' },
+    { kind: 'ok',  text: `  ✓ Active connector set to ${c.modeId} (claw.mode=${c.modeId})` },
+    { kind: 'ok',  text: '  ✓ Gateway restarted — tool calls + prompts now inspected' },
+  ];
+}
+
+// Header types at the same 280ms/line cadence as the per-connector
+// block; the second line waits 700ms after the first so the curl
+// command reads as a distinct beat before the success ✓ lands.
+const LINE_MS = 280;
+const HEADER_BEAT_MS = 700;
+// Standalone-mode rotation cadence (used only when this component
+// renders outside <HeroLockup>). Mirrors the lockup's SETTLE_MS so
+// MDX usages feel the same — typewriter (~1.4s) + ~3.8s read time
+// gives each connector ~5.2s on screen.
+const STANDALONE_HOLD_MS = 3800;
 
 export function TerminalDemo() {
-  // Seed with the install command + ✓ line so the landing and
-  // guardrail pages never paint a blank terminal during initial load
-  // (headless capture, slow JS hydration, throttled CPUs all looked
-  // empty before this fix).
-  const [step, setStep] = useState(INITIAL_STEP);
-  const [reduced, setReduced] = useState(false);
+  const lockup = useHeroLockup();
+  const [standaloneIdx, setStandaloneIdx] = useState(0);
+  // Local nudge ref used to advance standalone mode when the
+  // typewriter finishes. Lives outside the rotation timer so we can
+  // hold for STANDALONE_HOLD_MS after each completion.
+  const standaloneTimer = useRef<number | null>(null);
 
+  useEffect(() => {
+    return () => {
+      if (standaloneTimer.current !== null) {
+        window.clearTimeout(standaloneTimer.current);
+      }
+    };
+  }, []);
+
+  const connectorIdx = lockup ? lockup.index : standaloneIdx;
+  const connector =
+    TERMINAL_CONNECTORS[connectorIdx % TERMINAL_CONNECTORS.length];
+  const block = blockFor(connector);
+
+  const [reduced, setReduced] = useState(false);
+  // Header step: 0 = nothing, 1 = curl typed, 2 = ✓ shown. Once it
+  // reaches HEADER.length it stays there for the rest of the page
+  // lifetime — the install header is pinned, never replayed.
+  const [headerStep, setHeaderStep] = useState(0);
+  // Per-connector typewriter step. Reset to 0 every time
+  // `connector.id` changes (the keyed React effect below). When it
+  // reaches block.length, `onDone()` fires and the parent advances.
+  const [blockStep, setBlockStep] = useState(0);
+
+  // Reduced-motion: jump straight to settled state and trigger the
+  // rotation cadence so the rotating word still ticks (otherwise it
+  // would freeze on connector 0 forever).
   useEffect(() => {
     const m = window.matchMedia('(prefers-reduced-motion: reduce)');
     setReduced(m.matches);
@@ -46,28 +106,72 @@ export function TerminalDemo() {
     return () => m.removeEventListener('change', onChange);
   }, []);
 
+  // Header typewriter. Runs once on mount. Skip if reduced-motion.
   useEffect(() => {
     if (reduced) {
-      setStep(SCRIPT.length);
+      setHeaderStep(HEADER.length);
       return;
     }
-    if (step >= SCRIPT.length) return;
-    // Pause briefly after the seeded install + ✓ block so the next
-    // command (`defenseclaw setup …`) reads as a distinct beat;
-    // subsequent lines tick at 650ms for a steady "log streaming" feel.
-    const t = window.setTimeout(() => setStep((s) => s + 1), step === INITIAL_STEP ? 700 : 650);
+    if (headerStep >= HEADER.length) return;
+    const delay = headerStep === 1 ? HEADER_BEAT_MS : LINE_MS;
+    const t = window.setTimeout(() => setHeaderStep((s) => s + 1), delay);
     return () => window.clearTimeout(t);
-  }, [step, reduced]);
+  }, [headerStep, reduced]);
+
+  // Per-connector typewriter. Resets when connector id changes so a
+  // rotation always replays from the top of the block.
+  useEffect(() => {
+    setBlockStep(0);
+  }, [connector.id]);
+
+  useEffect(() => {
+    // Wait until the install header is fully on screen before the
+    // first connector block starts — keeps the very first paint from
+    // looking double-busy.
+    if (headerStep < HEADER.length) return;
+
+    if (reduced) {
+      setBlockStep(block.length);
+    }
+
+    if (blockStep >= block.length) {
+      // Block finished. Tell the parent (or schedule our own
+      // standalone rotation) so we settle for a beat before the next
+      // typewriter run.
+      if (lockup) {
+        lockup.onDone();
+      } else {
+        if (standaloneTimer.current !== null) {
+          window.clearTimeout(standaloneTimer.current);
+        }
+        standaloneTimer.current = window.setTimeout(() => {
+          setStandaloneIdx((prev) => (prev + 1) % TERMINAL_CONNECTORS.length);
+        }, STANDALONE_HOLD_MS);
+      }
+      return;
+    }
+
+    if (reduced) return;
+
+    const t = window.setTimeout(() => setBlockStep((s) => s + 1), LINE_MS);
+    return () => window.clearTimeout(t);
+  }, [headerStep, blockStep, block.length, reduced, lockup]);
+
+  const headerVisible = HEADER.slice(0, headerStep);
+  const blockVisible = block.slice(0, blockStep);
+  const showCursor =
+    !reduced && (headerStep < HEADER.length || blockStep < block.length);
 
   return (
     // `w-full min-w-0` keeps the terminal inside its grid cell on narrow
-    // phones — long lines (e.g. the install curl) scroll inside the
-    // inner <pre overflow-x-auto> instead of pushing the hero grid wider
-    // than the viewport.
+    // phones. The inner <pre> wraps long lines via
+    // `whitespace-pre-wrap wrap-anywhere` — preserves the indented
+    // "  ✓ …" success lines while letting the long install curl URL
+    // (no spaces) break at any character so it never side-scrolls.
     <div
       className="terminal-window w-full min-w-0 overflow-hidden rounded-2xl backdrop-blur"
       role="img"
-      aria-label="Terminal demo: installing DefenseClaw and configuring the Claude Code connector with action mode and human-in-the-loop approvals."
+      aria-label={`Terminal demo: installing DefenseClaw and configuring the ${connector.label} connector.`}
     >
       <div className="flex items-center gap-2 border-b border-fd-border/60 bg-fd-card/60 px-4 py-2 text-xs text-fd-muted-foreground">
         <span aria-hidden className="size-3 rounded-full bg-red-500/80" />
@@ -75,11 +179,19 @@ export function TerminalDemo() {
         <span aria-hidden className="size-3 rounded-full bg-green-500/80" />
         <span className="ml-3 font-mono">~/projects/agent-gateway</span>
       </div>
-      <pre className="m-0 overflow-x-auto p-5 font-mono text-[13px] leading-6 text-fd-foreground">
-        {SCRIPT.slice(0, step).map((line, i) => (
-          <Line key={i} kind={line.kind} text={line.text} />
+      <pre className="m-0 whitespace-pre-wrap wrap-anywhere p-5 font-mono text-[13px] leading-6 text-fd-foreground">
+        {headerVisible.map((line, i) => (
+          <Line key={`h-${i}`} kind={line.kind} text={line.text} />
         ))}
-        {step < SCRIPT.length && (
+        {/* Keying the block container on connector id forces React to
+            unmount the previous connector's lines wholesale — there's
+            no half-typed-block-from-the-previous-rotation flicker. */}
+        <div key={`block-${connector.id}`}>
+          {blockVisible.map((line, i) => (
+            <Line key={`b-${i}`} kind={line.kind} text={line.text} />
+          ))}
+        </div>
+        {showCursor && (
           <span aria-hidden className="terminal-cursor inline-block w-2 bg-[var(--brand-cisco)]">
             &nbsp;
           </span>
@@ -89,7 +201,7 @@ export function TerminalDemo() {
   );
 }
 
-function Line({ kind, text }: { kind: 'cmd' | 'out' | 'ok' | 'dim'; text: string }) {
+function Line({ kind, text }: { kind: LineKind; text: string }) {
   if (kind === 'cmd') {
     return (
       <div>

--- a/docs-site/content/docs/connectors/claudecode.mdx
+++ b/docs-site/content/docs/connectors/claudecode.mdx
@@ -9,8 +9,6 @@ keywords:
   - Claude Code guardrail
 ---
 
-<Banner variant="rainbow" id="claudecode-hooks">Hooks connector — observability by default, enforcement opt-in</Banner>
-
 The Claude Code connector wires DefenseClaw into [Anthropic's documented hook surfaces](https://docs.anthropic.com/) without inserting a proxy in the data path. Claude Code talks directly to its native upstream; DefenseClaw inspects via hooks + native OTel.
 
 ## Setup

--- a/docs-site/content/docs/connectors/codex.mdx
+++ b/docs-site/content/docs/connectors/codex.mdx
@@ -9,8 +9,6 @@ keywords:
   - Codex notify bridge
 ---
 
-<Banner variant="rainbow" id="codex-hooks">Hooks connector — three telemetry channels at boot</Banner>
-
 The Codex connector wires DefenseClaw into [Codex's documented hooks](https://github.com/openai/codex), [native OpenTelemetry exporter](https://github.com/openai/codex/blob/main/docs/otel.md), and the notify bridge for agent-turn-complete events.
 
 ## Setup

--- a/docs-site/content/docs/connectors/copilot.mdx
+++ b/docs-site/content/docs/connectors/copilot.mdx
@@ -8,8 +8,6 @@ keywords:
   - Copilot guardrail
 ---
 
-<Banner variant="rainbow" id="copilot-hooks">Hooks connector — workspace-scoped, native ask supported</Banner>
-
 The GitHub Copilot CLI connector wires DefenseClaw into [Copilot's workspace-scoped hooks](https://docs.github.com/copilot/) under `<workspace>/.github/hooks/`. Native ask is supported on `preToolUse`, so HITL approvals surface inside the agent UI.
 
 ## Setup

--- a/docs-site/content/docs/connectors/cursor.mdx
+++ b/docs-site/content/docs/connectors/cursor.mdx
@@ -8,8 +8,6 @@ keywords:
   - Cursor beforeMCPExecution
 ---
 
-<Banner variant="rainbow" id="cursor-hooks">Hooks connector — native ask on shell + MCP execution</Banner>
-
 The Cursor connector wires DefenseClaw into Cursor's [user-scoped hooks.json](https://docs.cursor.com/) so every shell command and MCP tool call is inspected before it runs.
 
 ## Setup

--- a/docs-site/content/docs/connectors/geminicli.mdx
+++ b/docs-site/content/docs/connectors/geminicli.mdx
@@ -8,8 +8,6 @@ keywords:
   - Gemini CLI observability
 ---
 
-<Banner variant="rainbow" id="geminicli-hooks">Hooks connector — five lifecycle hooks + native OTLP</Banner>
-
 The Gemini CLI connector wires DefenseClaw into [Google's Gemini CLI hooks](https://github.com/google/generative-ai-tools) and points the agent's native OTLP exporter at the gateway so traces, metrics, and logs land in one place.
 
 ## Setup

--- a/docs-site/content/docs/connectors/hermes.mdx
+++ b/docs-site/content/docs/connectors/hermes.mdx
@@ -7,8 +7,6 @@ keywords:
   - Hermes agent runtime
 ---
 
-<Banner variant="rainbow" id="hermes-hooks">Hooks connector — pre-tool-call hook, discovery for skills + MCP + plugins</Banner>
-
 The Hermes connector wires DefenseClaw into the Hermes agent runtime via `~/.hermes/config.yaml` hooks and discovery surfaces for MCP servers, skills, and plugins.
 
 ## Setup

--- a/docs-site/content/docs/connectors/openclaw.mdx
+++ b/docs-site/content/docs/connectors/openclaw.mdx
@@ -8,8 +8,6 @@ keywords:
   - OpenClaw before_tool_call
 ---
 
-<Banner variant="rainbow" id="openclaw-proxy">Proxy connector — full data-path interception</Banner>
-
 OpenClaw is the connector DefenseClaw was designed against. It ships a first-party TypeScript plugin (`extensions/defenseclaw/`) that hooks into `fetch` interception and OpenClaw's `before_tool_call` lifecycle so every prompt, response, and tool call lands in the DefenseClaw gateway.
 
 <Video

--- a/docs-site/content/docs/connectors/windsurf.mdx
+++ b/docs-site/content/docs/connectors/windsurf.mdx
@@ -7,8 +7,6 @@ keywords:
   - Windsurf observability
 ---
 
-<Banner variant="rainbow" id="windsurf-hooks">Hooks connector — five pre-execution hooks</Banner>
-
 The Windsurf connector wires DefenseClaw into [Codeium's Cascade hooks](https://codeium.com/) so every prompt, code read, code write, command run, and MCP tool call is scored before it lands.
 
 ## Setup

--- a/docs-site/content/docs/connectors/zeptoclaw.mdx
+++ b/docs-site/content/docs/connectors/zeptoclaw.mdx
@@ -6,8 +6,6 @@ keywords:
   - ZeptoClaw guardrail
 ---
 
-<Banner variant="rainbow" id="zeptoclaw-proxy">Proxy connector — api_base redirect + response-scan</Banner>
-
 ZeptoClaw is the second proxy connector. DefenseClaw rewrites `~/.zeptoclaw/config.json` providers to point at the local guardrail proxy; every request is inspected on its way out and every response on its way back.
 
 ## Setup

--- a/docs-site/lib/hero-connectors.ts
+++ b/docs-site/lib/hero-connectors.ts
@@ -1,0 +1,33 @@
+// Hero terminal-demo connector list. Lives outside the React tree so
+// both <HeroLockup> (which drives the rotation) and <TerminalDemo>
+// (which renders the per-connector block) can import it without
+// creating a circular dependency. Order matches /docs/connectors so
+// the rotation reads the same as the docs nav.
+//
+// Setup aliases verified against docs/setup/guardrail/aliases/:
+//   - proxies (OpenClaw, ZeptoClaw) → defenseclaw setup guardrail
+//   - hooks  → defenseclaw setup {claude-code|codex|hermes|cursor|
+//                                  windsurf|geminicli|copilot}
+
+export interface ConnectorBlock {
+  id: string;
+  label: string;
+  // Setup command for the typed prompt line.
+  command: string;
+  // Lowercase id used in the "Active connector set to <id>
+  // (claw.mode=<id>)" line. Mirrors the keys in
+  // data/capability-matrix.json.
+  modeId: string;
+}
+
+export const TERMINAL_CONNECTORS: ConnectorBlock[] = [
+  { id: 'openclaw',   label: 'OpenClaw',           command: 'defenseclaw setup guardrail',   modeId: 'openclaw' },
+  { id: 'zeptoclaw',  label: 'ZeptoClaw',          command: 'defenseclaw setup guardrail',   modeId: 'zeptoclaw' },
+  { id: 'claudecode', label: 'Claude Code',        command: 'defenseclaw setup claude-code', modeId: 'claudecode' },
+  { id: 'codex',      label: 'Codex',              command: 'defenseclaw setup codex',       modeId: 'codex' },
+  { id: 'hermes',     label: 'Hermes',             command: 'defenseclaw setup hermes',      modeId: 'hermes' },
+  { id: 'cursor',     label: 'Cursor',             command: 'defenseclaw setup cursor',      modeId: 'cursor' },
+  { id: 'windsurf',   label: 'Windsurf',           command: 'defenseclaw setup windsurf',    modeId: 'windsurf' },
+  { id: 'geminicli',  label: 'Gemini CLI',         command: 'defenseclaw setup geminicli',   modeId: 'geminicli' },
+  { id: 'copilot',    label: 'GitHub Copilot CLI', command: 'defenseclaw setup copilot',     modeId: 'copilot' },
+];


### PR DESCRIPTION
## Summary

- **Hero rotation lockup** — `HeroLockup` (new client component) now owns the rotation index and advance cadence and shares them through `HeroLockupContext`, so the landing page can stay a server component while `RotatingConnectorWord` (the headline word) and `TerminalDemo` (the right-column terminal) advance in lockstep. Each connector word holds for ~5.2s (1.4s typewriter + 3.8s settle) before the lockup advances. The terminal replays a per-connector block keyed on `connector.id`: `OpenClaw` / `ZeptoClaw` resolve to `defenseclaw setup guardrail`; every other connector gets its `setup <alias>` form. Hero `h1` drops the "and agentic AI runtimes." trailer since the rotating word carries that signal now.
- **Page-wide animations** — `DiagramLightbox` attaches a one-shot `IntersectionObserver` and flips `data-animate="entered"` on the figure on first intersection. Flow diagrams emit `fd-flow-node` / `fd-flow-edge` / `fd-flow-edge-label` classes with rank-derived `animation-delay` (nodes fade up in reading order, edges draw via `stroke-dashoffset`, labels fade in half a beat behind). Sequence diagrams emit `fd-seq-pill` / `fd-seq-lifeline` / `fd-seq-message` / `fd-seq-message-label` with row-index staggering. The capability matrix is wrapped in a small client trigger and the rows fade up in 35ms stagger. Hero workflow chip row picks up a continuous left-to-right runner dot, the bottom CTA gets a one-shot pulse ring on viewport entry, repo stars / forks count up from 0 on client mount, and every Fumadocs `<Cards>` block across the docs gets a hover-lift via `a[data-card='true']`. All animations respect `prefers-reduced-motion`.
- **Connector page cleanup** — dropped the `<Banner variant="rainbow">` `Hooks/Proxy connector — …` pre-amble from all nine connector pages (each page now opens straight into its intro paragraph), and removed the `proxy` / `hooks` badge from the landing page's Connectors grid with an updated connector-agnostic subtitle ("Every connector lands in the same gateway with the same block / approve / observe verbs — pick the agent you ship with, the contract is identical.").
- **CSS bundle fix** — removed the U+2192 right-arrow characters from a `app/global.css` comment that was silently aborting Tailwind v4 / lightningcss parsing and dropping every rule from `workflow-flow` through the diagram `data-animate` selectors and the Fumadocs card hover-lift. Em dashes elsewhere in the file parse fine.

## Test plan

- [x] `npm run dev` (Turbopack) — page compiles cleanly, no runtime errors in the dev console
- [x] Hero rotation: word + terminal advance together; each connector holds ~5.2s; `OpenClaw` and `ZeptoClaw` show `defenseclaw setup guardrail`, all others show `defenseclaw setup <alias>`
- [x] Real-browser check on `/docs/get-started/what-is-defenseclaw/`: figure picks up `data-animate="entered"` after scroll; `.fd-flow-node` computes to `flow-node-in / 0.38s`, `.fd-flow-edge` to `flow-edge-draw / 0.48s` with `stroke-dasharray: 600px`
- [x] Hero workflow dot computes to `workflow-flow / 4.2s / infinite`
- [x] All nine connector pages open with no rainbow `Banner` above the intro paragraph
- [x] Reduced-motion: every keyed-up animation falls back to the static final frame (consolidated `@media (prefers-reduced-motion: reduce)` guard at the bottom of `app/global.css`)
- [ ] CI: GitHub Pages preview build green (will follow on push)