### PR TITLE
fix(scanners): unify LLM provider support across skill + MCP scanners

### DIFF
--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -142,12 +142,17 @@ _LOCAL_LLM_DEFAULT_BASE_URL = {
 }
 
 # Provider choices offered in the wizard. Cloud providers first (most
-# operators), then local runtimes. The list is a superset of guardrail's
-# KNOWN_PROVIDERS so the wizard can configure Ollama/vLLM without edits
-# to that module.
+# operators), then local runtimes. Kept in lockstep with
+# ``_RECOGNIZED_LLM_PROVIDERS`` in ``defenseclaw/config.py`` so any
+# provider the resolver accepts is also pickable in the wizard. The
+# scanner wrappers and the LiteLLM bridge are provider-agnostic — any
+# entry here works end-to-end with a unified ``DEFENSECLAW_LLM_KEY`` +
+# ``DEFENSECLAW_LLM_MODEL``.
 _WIZARD_LLM_PROVIDERS = [
     "anthropic", "openai", "openrouter", "azure", "gemini", "gemini-openai",
     "groq", "mistral", "cohere", "deepseek", "xai", "bedrock", "vertex_ai",
+    "fireworks_ai", "perplexity", "huggingface", "replicate", "together_ai",
+    "cerebras",
     "ollama", "vllm", "lm_studio",
 ]
 

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -128,8 +128,12 @@ setup.add_command(provider)
 
 
 # Local LLM providers that run on-box and don't require an API key.
-# Kept in lockstep with _LOCAL_LLM_PROVIDERS in defenseclaw/config.py and
-# IsLocalProvider() in internal/config/config.go.
+# This is intentionally a *subset* of ``_LOCAL_LLM_PROVIDERS`` in
+# ``defenseclaw/config.py`` and ``IsLocalProvider()`` in
+# ``internal/config/config.go`` — the wizard only offers entries that
+# have a sensible default base URL. The generic ``local`` alias is
+# excluded because it has no canonical endpoint; operators choosing
+# that route configure ``llm.base_url`` directly in ``config.yaml``.
 _LOCAL_LLM_WIZARD_PROVIDERS = {"ollama", "vllm", "lm_studio", "lmstudio"}
 
 # Default base URLs for local providers so the wizard can offer a sane

--- a/cli/defenseclaw/config.py
+++ b/cli/defenseclaw/config.py
@@ -260,8 +260,8 @@ _DEFAULT_LLM_MAX_RETRIES = 2
 # this set triggers a one-shot warning so typos surface early. Keep in
 # lockstep with recognizedLLMProviders in internal/config/config.go.
 _RECOGNIZED_LLM_PROVIDERS = frozenset({
-    "openai", "anthropic", "azure", "gemini", "vertex_ai", "bedrock",
-    "groq", "mistral", "cohere", "ollama", "vllm", "deepseek", "xai",
+    "openai", "anthropic", "azure", "gemini", "gemini-openai", "vertex_ai",
+    "bedrock", "groq", "mistral", "cohere", "ollama", "vllm", "deepseek", "xai",
     "fireworks_ai", "perplexity", "huggingface", "replicate",
     "openrouter", "together_ai", "cerebras", "lm_studio", "lmstudio",
     "local",
@@ -281,11 +281,11 @@ def _maybe_warn_unknown_provider(prefix: str, component_path: str) -> None:
     _warned_llm_prefixes.add(key)
     _log.warning(
         "config: unknown LLM provider prefix %r for %s — expected one of "
-        "openai/anthropic/azure/gemini/vertex_ai/bedrock/groq/mistral/"
-        "cohere/ollama/vllm/deepseek/xai/fireworks_ai/perplexity/"
-        "huggingface/replicate/openrouter/together_ai/cerebras/lm_studio/"
-        "local. Gateway (Bifrost) and scanners (LiteLLM) may disagree "
-        "on how to route this model",
+        "openai/anthropic/azure/gemini/gemini-openai/vertex_ai/bedrock/"
+        "groq/mistral/cohere/ollama/vllm/deepseek/xai/fireworks_ai/"
+        "perplexity/huggingface/replicate/openrouter/together_ai/cerebras/"
+        "lm_studio/local. Gateway (Bifrost) and scanners (LiteLLM) may "
+        "disagree on how to route this model",
         prefix, component_path,
     )
 

--- a/cli/defenseclaw/scanner/_llm_env.py
+++ b/cli/defenseclaw/scanner/_llm_env.py
@@ -25,9 +25,15 @@ env var from the resolved ``LLMConfig.provider_prefix()`` and writes it
 into ``os.environ`` before the scanner boots LiteLLM.
 
 Keeping this mapping in one place avoids the provider drift we saw
-when each scanner maintained its own two-entry dict (mcp.py had only
-openai+anthropic — silently ignored everyone else). The full provider
-list is kept in lockstep with:
+when each scanner maintained its own two-entry dict — historically
+``mcp.py`` had a hard-coded ``{openai, anthropic}`` base-URL table
+and ``skill.py`` had a matching ``llm_provider`` allowlist, both of
+which silently disabled the LLM analyzer for every other provider.
+Those wrapper-side tables have been removed; this single map is now
+the only place a provider needs to be added so the unified
+``DEFENSECLAW_LLM_KEY`` flows into the right LiteLLM env var.
+
+The full provider list is kept in lockstep with:
 
 * ``internal/gateway/bifrost_provider.go`` — Bifrost's routing table
 * ``internal/configs/providers.json``       — OpenClaw fetch interceptor

--- a/cli/defenseclaw/scanner/_llm_env.py
+++ b/cli/defenseclaw/scanner/_llm_env.py
@@ -69,6 +69,17 @@ _PROVIDER_ENV_VARS: dict[str, tuple[str, ...]] = {
     "anthropic": ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"),
     "azure": ("AZURE_OPENAI_API_KEY", "AZURE_API_KEY"),
     "gemini": ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
+    # ``gemini-openai`` is a Bifrost routing key for Google's
+    # OpenAI-compatible Gemini endpoint. Same Google API key, but the
+    # Python LiteLLM bridge needs a separate entry so the env-var
+    # injector recognizes the prefix without warning spam. Note that
+    # LiteLLM itself doesn't natively understand the
+    # ``gemini-openai/`` model prefix — operators using this provider
+    # for the Python scanners must pin ``llm.base_url`` to the
+    # OpenAI-compatible endpoint and set ``llm.model`` to a bare
+    # ``openai/...`` shape; or stick with ``provider: gemini`` for
+    # the scanners and use ``gemini-openai`` only at the gateway.
+    "gemini-openai": ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
     "vertex_ai": ("GOOGLE_APPLICATION_CREDENTIALS",),
     # Bedrock has two auth modes. LiteLLM prefers the short-term API
     # bearer token (prefix ``ABSK...``, env var ``AWS_BEARER_TOKEN_BEDROCK``,

--- a/cli/defenseclaw/scanner/mcp.py
+++ b/cli/defenseclaw/scanner/mcp.py
@@ -50,17 +50,6 @@ from defenseclaw.scanner._llm_env import inject_llm_env, litellm_model
 if TYPE_CHECKING:
     pass
 
-# Hard-coded per-provider HTTPS defaults. Only used when the operator
-# hasn't set ``llm.base_url`` — the mcp-scanner SDK wants an explicit
-# URL and won't fall back to LiteLLM's default discovery. Keep in sync
-# with ``cli/defenseclaw/scanner/_llm_env.py``'s provider map: any
-# new provider entry that has a stable HTTPS endpoint SHOULD be added
-# here too so mcp-scanner can reach it without manual config.
-_PROVIDER_BASE_URLS: dict[str, str] = {
-    "openai": "https://api.openai.com",
-    "anthropic": "https://api.anthropic.com",
-}
-
 
 def _inspect_to_llm(il: InspectLLMConfig) -> LLMConfig:
     """Translate a legacy ``InspectLLMConfig`` into the unified
@@ -109,13 +98,6 @@ class MCPScannerWrapper:
     def name(self) -> str:
         return "mcp-scanner"
 
-    def _resolve_llm_base_url(self) -> str:
-        """Resolve the LLM base URL from explicit config or provider name."""
-        llm = self._llm
-        if llm.base_url:
-            return llm.base_url
-        return _PROVIDER_BASE_URLS.get(llm.provider_prefix(), "")
-
     def _inject_env(self) -> None:
         """Inject LLM API key into provider-specific env var(s).
 
@@ -155,12 +137,22 @@ class MCPScannerWrapper:
         # the mcp-scanner SDK passes it straight through to LiteLLM.
         # ``litellm_model()`` stitches bare ``llm.model`` + ``llm.provider``
         # when needed, otherwise uses the already-prefixed string.
+        #
+        # ``llm_base_url`` is forwarded verbatim. The mcp-scanner SDK
+        # only adds ``api_base`` to the LiteLLM request when this value
+        # is truthy (mcpscanner/core/analyzers/llm_analyzer.py),
+        # otherwise LiteLLM's own provider-default discovery handles
+        # routing — which works for Bedrock, Gemini, Vertex, Azure,
+        # Groq, Mistral, DeepSeek, OpenRouter, etc. So an empty string
+        # is the correct default; operators who need a custom endpoint
+        # set ``llm.base_url`` (or ``scanners.mcp_scanner.llm.base_url``)
+        # explicitly.
         sdk_config = MCPConfig(
             api_key=aid.resolved_api_key(),
             endpoint_url=aid.endpoint,
             llm_provider_api_key=llm.resolved_api_key(),
             llm_model=litellm_model(llm),
-            llm_base_url=self._resolve_llm_base_url(),
+            llm_base_url=llm.base_url,
             llm_timeout=llm.effective_timeout(),
             llm_max_retries=llm.effective_max_retries(),
         )

--- a/cli/defenseclaw/scanner/skill.py
+++ b/cli/defenseclaw/scanner/skill.py
@@ -22,6 +22,7 @@ to the skill-scanner CLI.  Maps SDK ScanResult/Finding → DefenseClaw models.
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from datetime import datetime, timedelta, timezone
@@ -38,6 +39,8 @@ from defenseclaw.scanner._llm_env import inject_llm_env, litellm_model
 
 if TYPE_CHECKING:
     pass
+
+_log = logging.getLogger(__name__)
 
 
 def _inspect_to_llm(il: InspectLLMConfig) -> LLMConfig:
@@ -126,19 +129,37 @@ class SkillScannerWrapper:
             #      would error out there.
             # Letting the model string carry the provider keeps every
             # LiteLLM-supported provider working end-to-end.
-            build_kwargs["use_llm"] = True
+            #
+            # Guard ``use_llm`` on a resolved model: without it, the
+            # upstream factory falls back to a hard-coded Anthropic
+            # default (``claude-3-5-sonnet-20241022``) and then crashes
+            # on operators whose unified key isn't an Anthropic key.
+            # Skipping the LLM analyzer with a clear log line is
+            # strictly better than emitting an upstream warning that
+            # operators can't action.
             model = litellm_model(llm)
-            if model:
-                build_kwargs["llm_model"] = model
-            api_key = llm.resolved_api_key()
-            if api_key:
-                build_kwargs["llm_api_key"] = api_key
-            elif os.environ.get("SKILL_SCANNER_LLM_API_KEY"):
-                build_kwargs["llm_api_key"] = os.environ["SKILL_SCANNER_LLM_API_KEY"]
-            if llm.base_url:
-                build_kwargs["llm_base_url"] = llm.base_url
-            if cfg.llm_consensus_runs > 0:
-                build_kwargs["llm_consensus_runs"] = cfg.llm_consensus_runs
+            env_model = os.environ.get("SKILL_SCANNER_LLM_MODEL", "")
+            if model or env_model:
+                build_kwargs["use_llm"] = True
+                if model:
+                    build_kwargs["llm_model"] = model
+                api_key = llm.resolved_api_key()
+                if api_key:
+                    build_kwargs["llm_api_key"] = api_key
+                elif os.environ.get("SKILL_SCANNER_LLM_API_KEY"):
+                    build_kwargs["llm_api_key"] = os.environ["SKILL_SCANNER_LLM_API_KEY"]
+                if llm.base_url:
+                    build_kwargs["llm_base_url"] = llm.base_url
+                if cfg.llm_consensus_runs > 0:
+                    build_kwargs["llm_consensus_runs"] = cfg.llm_consensus_runs
+            else:
+                _log.info(
+                    "skill-scanner: use_llm requested but no model resolved "
+                    "from llm.model / SKILL_SCANNER_LLM_MODEL — skipping LLM "
+                    "analyzer to avoid upstream's Anthropic fallback default. "
+                    "Set llm.model (e.g. 'bedrock/anthropic.claude-3-5-haiku') "
+                    "or SKILL_SCANNER_LLM_MODEL to enable.",
+                )
         if cfg.use_trigger:
             build_kwargs["use_trigger"] = True
         if cfg.use_virustotal:

--- a/cli/defenseclaw/scanner/skill.py
+++ b/cli/defenseclaw/scanner/skill.py
@@ -39,8 +39,6 @@ from defenseclaw.scanner._llm_env import inject_llm_env, litellm_model
 if TYPE_CHECKING:
     pass
 
-_SKILL_SCANNER_LLM_PROVIDERS = frozenset({"", "anthropic", "openai"})
-
 
 def _inspect_to_llm(il: InspectLLMConfig) -> LLMConfig:
     """Back-compat shim — mirrors the one in ``mcp.py``. Kept local so
@@ -113,22 +111,32 @@ class SkillScannerWrapper:
         build_kwargs: dict = {"policy": policy}
         if cfg.use_behavioral:
             build_kwargs["use_behavioral"] = True
-        if cfg.use_llm and _skill_scanner_provider_supported(llm.provider_prefix()):
+        if cfg.use_llm:
+            # The upstream skill-scanner SDK auto-detects the provider
+            # from a LiteLLM-shaped ``provider/model`` string via its
+            # ``ProviderConfig`` (Bedrock, Gemini, Vertex, Azure,
+            # Ollama, OpenRouter, …). We deliberately do NOT pass
+            # ``llm_provider`` here because:
+            #   1. The factory ignores it whenever ``llm_model`` is
+            #      set (skill_scanner/core/analyzer_factory.py).
+            #   2. Our internal short names ("bedrock", "vertex_ai")
+            #      don't match the upstream ``LLMProvider`` enum
+            #      ("aws-bedrock", "gcp-vertex"), so passing them
+            #      would only matter on the model-less path and
+            #      would error out there.
+            # Letting the model string carry the provider keeps every
+            # LiteLLM-supported provider working end-to-end.
             build_kwargs["use_llm"] = True
-            # skill-scanner accepts the LiteLLM-style ``provider/model``
-            # string via llm_model; we still pass ``llm_provider``
-            # separately because skill-scanner uses it for routing
-            # decisions (e.g. local vs remote handling).
             model = litellm_model(llm)
             if model:
                 build_kwargs["llm_model"] = model
-            if llm.provider:
-                build_kwargs["llm_provider"] = llm.provider
             api_key = llm.resolved_api_key()
             if api_key:
                 build_kwargs["llm_api_key"] = api_key
             elif os.environ.get("SKILL_SCANNER_LLM_API_KEY"):
                 build_kwargs["llm_api_key"] = os.environ["SKILL_SCANNER_LLM_API_KEY"]
+            if llm.base_url:
+                build_kwargs["llm_base_url"] = llm.base_url
             if cfg.llm_consensus_runs > 0:
                 build_kwargs["llm_consensus_runs"] = cfg.llm_consensus_runs
         if cfg.use_trigger:
@@ -211,15 +219,3 @@ class SkillScannerWrapper:
             findings=findings,
             duration=timedelta(seconds=elapsed),
         )
-
-
-def _skill_scanner_provider_supported(provider: str) -> bool:
-    """Return whether cisco-ai-skill-scanner accepts ``llm_provider``.
-
-    The upstream scanner currently restricts providers to Anthropic and
-    OpenAI. When DefenseClaw's unified LLM is Bedrock (or another
-    provider), forcing ``--llm-provider bedrock`` makes every scan fail
-    before static/behavioral analyzers can run. In that case we keep the
-    scan alive by omitting the optional LLM analyzer.
-    """
-    return provider.strip().lower() in _SKILL_SCANNER_LLM_PROVIDERS

--- a/cli/tests/test_scanners.py
+++ b/cli/tests/test_scanners.py
@@ -602,6 +602,59 @@ class TestSkillScannerWrapper(unittest.TestCase):
         kwargs = build_analyzers.call_args.kwargs
         self.assertEqual(kwargs["llm_base_url"], "http://10.0.0.5:8000/v1")
 
+    @patch("defenseclaw.scanner.skill.SkillScannerWrapper._convert")
+    def test_scan_skips_llm_when_model_unresolved(self, mock_convert):
+        """When ``cfg.use_llm=True`` but no model is resolvable from
+        ``llm.model`` *or* ``SKILL_SCANNER_LLM_MODEL`` env, the wrapper
+        must NOT pass ``use_llm`` to upstream. Otherwise the upstream
+        factory falls back to a hard-coded Anthropic default
+        (``claude-3-5-sonnet-20241022``) which crashes operators whose
+        unified key isn't an Anthropic key. Skipping the LLM analyzer
+        with a log line is strictly better.
+        """
+        from defenseclaw.config import LLMConfig, SkillScannerConfig
+        from defenseclaw.scanner.skill import SkillScannerWrapper
+        from defenseclaw.models import ScanResult
+        from datetime import datetime, timezone
+
+        mock_sdk_module = MagicMock()
+        mock_scanner_instance = MagicMock()
+        mock_sdk_module.SkillScanner.return_value = mock_scanner_instance
+        mock_scanner_instance.scan_skill.return_value = MagicMock(findings=[])
+
+        build_analyzers = MagicMock(return_value=[])
+        mock_convert.return_value = ScanResult(
+            scanner="skill-scanner",
+            target="/tmp/skill",
+            timestamp=datetime.now(timezone.utc),
+            findings=[],
+        )
+
+        cfg = SkillScannerConfig(use_llm=True, use_behavioral=True)
+        llm = LLMConfig(provider="bedrock", api_key="bedrock-key")  # no model
+
+        # Ensure no leftover env from another test sneaks in.
+        prev_env = os.environ.pop("SKILL_SCANNER_LLM_MODEL", None)
+        try:
+            with patch.dict("sys.modules", {
+                "skill_scanner": mock_sdk_module,
+                "skill_scanner.core": MagicMock(),
+                "skill_scanner.core.analyzer_factory": MagicMock(build_analyzers=build_analyzers),
+                "skill_scanner.core.scan_policy": MagicMock(),
+            }):
+                scanner = SkillScannerWrapper(cfg, llm=llm)
+                scanner.scan("/tmp/skill")
+        finally:
+            if prev_env is not None:
+                os.environ["SKILL_SCANNER_LLM_MODEL"] = prev_env
+
+        kwargs = build_analyzers.call_args.kwargs
+        # Behavioral analyzer must still run — only the LLM analyzer is gated.
+        self.assertTrue(kwargs.get("use_behavioral"))
+        self.assertNotIn("use_llm", kwargs)
+        self.assertNotIn("llm_model", kwargs)
+        self.assertNotIn("llm_provider", kwargs)
+
 
 class TestMCPScannerCommonConfigs(unittest.TestCase):
     """Tests for MCPScannerWrapper using shared InspectLLM and CiscoAIDefense configs."""

--- a/cli/tests/test_scanners.py
+++ b/cli/tests/test_scanners.py
@@ -465,7 +465,15 @@ class TestSkillScannerWrapper(unittest.TestCase):
         self.assertEqual(result.scanner, "skill-scanner")
 
     @patch("defenseclaw.scanner.skill.SkillScannerWrapper._convert")
-    def test_scan_skips_llm_analyzer_for_unsupported_provider(self, mock_convert):
+    def test_scan_uses_llm_analyzer_for_bedrock(self, mock_convert):
+        """Bedrock (and any non-openai/anthropic provider) must enable
+        the LLM analyzer with a LiteLLM-shaped ``provider/model`` string.
+
+        The upstream skill-scanner SDK auto-detects the provider from
+        the model prefix, so we deliberately do NOT pass
+        ``llm_provider`` (our internal short names like ``bedrock`` do
+        not match the upstream ``LLMProvider`` enum).
+        """
         from defenseclaw.config import LLMConfig, SkillScannerConfig
         from defenseclaw.scanner.skill import SkillScannerWrapper
         from defenseclaw.models import ScanResult
@@ -485,7 +493,11 @@ class TestSkillScannerWrapper(unittest.TestCase):
         )
 
         cfg = SkillScannerConfig(use_llm=True, use_behavioral=True)
-        llm = LLMConfig(provider="bedrock", model="us.anthropic.claude-haiku")
+        llm = LLMConfig(
+            provider="bedrock",
+            model="us.anthropic.claude-haiku",
+            api_key="bedrock-bearer-xyz",
+        )
         with patch.dict("sys.modules", {
             "skill_scanner": mock_sdk_module,
             "skill_scanner.core": MagicMock(),
@@ -497,9 +509,98 @@ class TestSkillScannerWrapper(unittest.TestCase):
 
         self.assertTrue(result.is_clean())
         kwargs = build_analyzers.call_args.kwargs
-        self.assertNotIn("use_llm", kwargs)
-        self.assertNotIn("llm_provider", kwargs)
+        self.assertTrue(kwargs["use_llm"])
         self.assertTrue(kwargs["use_behavioral"])
+        # Model must be LiteLLM-shaped so ProviderConfig auto-detects bedrock.
+        self.assertEqual(kwargs["llm_model"], "bedrock/us.anthropic.claude-haiku")
+        self.assertEqual(kwargs["llm_api_key"], "bedrock-bearer-xyz")
+        # Crucially, our short provider name must NOT be forwarded
+        # because upstream's enum expects ``aws-bedrock`` and would
+        # reject ``bedrock`` on the model-less path.
+        self.assertNotIn("llm_provider", kwargs)
+
+    @patch("defenseclaw.scanner.skill.SkillScannerWrapper._convert")
+    def test_scan_uses_llm_analyzer_for_gemini(self, mock_convert):
+        """Gemini flows the same way: model carries the provider, no
+        ``llm_provider`` kwarg leaked to upstream."""
+        from defenseclaw.config import LLMConfig, SkillScannerConfig
+        from defenseclaw.scanner.skill import SkillScannerWrapper
+        from defenseclaw.models import ScanResult
+        from datetime import datetime, timezone
+
+        mock_sdk_module = MagicMock()
+        mock_scanner_instance = MagicMock()
+        mock_sdk_module.SkillScanner.return_value = mock_scanner_instance
+        mock_scanner_instance.scan_skill.return_value = MagicMock(findings=[])
+
+        build_analyzers = MagicMock(return_value=[])
+        mock_convert.return_value = ScanResult(
+            scanner="skill-scanner",
+            target="/tmp/skill",
+            timestamp=datetime.now(timezone.utc),
+            findings=[],
+        )
+
+        cfg = SkillScannerConfig(use_llm=True)
+        llm = LLMConfig(
+            provider="gemini",
+            model="gemini-2.5-pro",
+            api_key="g-key",
+        )
+        with patch.dict("sys.modules", {
+            "skill_scanner": mock_sdk_module,
+            "skill_scanner.core": MagicMock(),
+            "skill_scanner.core.analyzer_factory": MagicMock(build_analyzers=build_analyzers),
+            "skill_scanner.core.scan_policy": MagicMock(),
+        }):
+            scanner = SkillScannerWrapper(cfg, llm=llm)
+            scanner.scan("/tmp/skill")
+
+        kwargs = build_analyzers.call_args.kwargs
+        self.assertTrue(kwargs["use_llm"])
+        self.assertEqual(kwargs["llm_model"], "gemini/gemini-2.5-pro")
+        self.assertEqual(kwargs["llm_api_key"], "g-key")
+        self.assertNotIn("llm_provider", kwargs)
+
+    @patch("defenseclaw.scanner.skill.SkillScannerWrapper._convert")
+    def test_scan_forwards_explicit_llm_base_url(self, mock_convert):
+        """Operator-set ``llm.base_url`` must reach build_analyzers so
+        custom endpoints (Vertex, Azure, self-hosted vLLM) work."""
+        from defenseclaw.config import LLMConfig, SkillScannerConfig
+        from defenseclaw.scanner.skill import SkillScannerWrapper
+        from defenseclaw.models import ScanResult
+        from datetime import datetime, timezone
+
+        mock_sdk_module = MagicMock()
+        mock_scanner_instance = MagicMock()
+        mock_sdk_module.SkillScanner.return_value = mock_scanner_instance
+        mock_scanner_instance.scan_skill.return_value = MagicMock(findings=[])
+
+        build_analyzers = MagicMock(return_value=[])
+        mock_convert.return_value = ScanResult(
+            scanner="skill-scanner",
+            target="/tmp/skill",
+            timestamp=datetime.now(timezone.utc),
+            findings=[],
+        )
+
+        cfg = SkillScannerConfig(use_llm=True)
+        llm = LLMConfig(
+            provider="vllm",
+            model="meta-llama/Llama-3.1-8B-Instruct",
+            base_url="http://10.0.0.5:8000/v1",
+        )
+        with patch.dict("sys.modules", {
+            "skill_scanner": mock_sdk_module,
+            "skill_scanner.core": MagicMock(),
+            "skill_scanner.core.analyzer_factory": MagicMock(build_analyzers=build_analyzers),
+            "skill_scanner.core.scan_policy": MagicMock(),
+        }):
+            scanner = SkillScannerWrapper(cfg, llm=llm)
+            scanner.scan("/tmp/skill")
+
+        kwargs = build_analyzers.call_args.kwargs
+        self.assertEqual(kwargs["llm_base_url"], "http://10.0.0.5:8000/v1")
 
 
 class TestMCPScannerCommonConfigs(unittest.TestCase):
@@ -531,29 +632,92 @@ class TestMCPScannerCommonConfigs(unittest.TestCase):
         finally:
             os.environ.pop("OPENAI_API_KEY", None)
 
-    def test_resolve_llm_base_url_from_provider(self):
-        from defenseclaw.config import MCPScannerConfig, InspectLLMConfig
+    def test_mcp_config_passes_empty_base_url_when_unset(self):
+        """For providers without an operator-set ``llm.base_url``
+        (Bedrock, Gemini, Vertex, Groq, Mistral, …) the wrapper must
+        forward an empty string. The mcp-scanner SDK only adds
+        ``api_base`` to its LiteLLM call when this value is truthy,
+        otherwise LiteLLM's own provider-default discovery routes the
+        request — which is what every non-Azure provider needs.
+        """
+        from defenseclaw.config import LLMConfig, MCPScannerConfig
         from defenseclaw.scanner.mcp import MCPScannerWrapper
 
-        llm = InspectLLMConfig(provider="openai")
-        s = MCPScannerWrapper(MCPScannerConfig(), llm)
-        self.assertEqual(s._resolve_llm_base_url(), "https://api.openai.com")
+        llm = LLMConfig(provider="bedrock", model="us.anthropic.claude-haiku")
+        captured: dict = {}
 
-    def test_resolve_llm_base_url_explicit(self):
-        from defenseclaw.config import MCPScannerConfig, InspectLLMConfig
+        class FakeMCPConfig:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        class FakeScanner:
+            def __init__(self, *_a, **_kw):
+                pass
+
+            async def scan_remote_server_tools(self, *_a, **_kw):
+                return []
+
+        mock_mcpscanner = MagicMock()
+        mock_mcpscanner.Config = FakeMCPConfig
+        mock_mcpscanner.Scanner = FakeScanner
+        mock_models = MagicMock()
+        mock_models.AnalyzerEnum = MagicMock()
+
+        # ``analyzers=""`` short-circuits ``_parse_analyzers`` so we don't
+        # need to mimic the full SDK ``AnalyzerEnum`` shape here — this
+        # test only cares that ``MCPConfig`` was constructed with the
+        # right LLM kwargs.
+        s = MCPScannerWrapper(MCPScannerConfig(analyzers=""), llm=llm)
+        with patch.dict("sys.modules", {
+            "mcpscanner": mock_mcpscanner,
+            "mcpscanner.core": MagicMock(),
+            "mcpscanner.core.models": mock_models,
+        }):
+            s.scan("https://mcp.example.com")
+
+        self.assertEqual(captured["llm_model"], "bedrock/us.anthropic.claude-haiku")
+        self.assertEqual(captured["llm_base_url"], "")
+
+    def test_mcp_config_passes_explicit_base_url(self):
+        """An operator-set ``llm.base_url`` must flow through unchanged
+        — required for Azure OpenAI deployments and for self-hosted
+        OpenAI-compatible endpoints (vLLM, LM Studio, LiteLLM proxy)."""
+        from defenseclaw.config import LLMConfig, MCPScannerConfig
         from defenseclaw.scanner.mcp import MCPScannerWrapper
 
-        llm = InspectLLMConfig(provider="openai", base_url="https://custom.llm.api")
-        s = MCPScannerWrapper(MCPScannerConfig(), llm)
-        self.assertEqual(s._resolve_llm_base_url(), "https://custom.llm.api")
+        llm = LLMConfig(
+            provider="azure",
+            model="azure/my-deployment",
+            base_url="https://my-azure.openai.azure.com",
+        )
+        captured: dict = {}
 
-    def test_resolve_llm_base_url_unknown_provider(self):
-        from defenseclaw.config import MCPScannerConfig, InspectLLMConfig
-        from defenseclaw.scanner.mcp import MCPScannerWrapper
+        class FakeMCPConfig:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
 
-        llm = InspectLLMConfig(provider="bedrock")
-        s = MCPScannerWrapper(MCPScannerConfig(), llm)
-        self.assertEqual(s._resolve_llm_base_url(), "")
+        class FakeScanner:
+            def __init__(self, *_a, **_kw):
+                pass
+
+            async def scan_remote_server_tools(self, *_a, **_kw):
+                return []
+
+        mock_mcpscanner = MagicMock()
+        mock_mcpscanner.Config = FakeMCPConfig
+        mock_mcpscanner.Scanner = FakeScanner
+        mock_models = MagicMock()
+        mock_models.AnalyzerEnum = MagicMock()
+
+        s = MCPScannerWrapper(MCPScannerConfig(analyzers=""), llm=llm)
+        with patch.dict("sys.modules", {
+            "mcpscanner": mock_mcpscanner,
+            "mcpscanner.core": MagicMock(),
+            "mcpscanner.core.models": mock_models,
+        }):
+            s.scan("https://mcp.example.com")
+
+        self.assertEqual(captured["llm_base_url"], "https://my-azure.openai.azure.com")
 
 
 class TestSkillScannerCommonConfigs(unittest.TestCase):

--- a/docs-site/content/docs/get-started/install.mdx
+++ b/docs-site/content/docs/get-started/install.mdx
@@ -100,10 +100,13 @@ defenseclaw doctor
 ## Uninstall
 
 ```bash
-defenseclaw uninstall
+defenseclaw uninstall              # reversible — keeps ~/.defenseclaw/ and binaries
+defenseclaw uninstall --all        # also delete ~/.defenseclaw/ (audit log, config, secrets)
+defenseclaw uninstall --binaries   # also remove ~/.local/bin/defenseclaw{,-gateway}
+defenseclaw uninstall --all --binaries --yes   # full nuke, no confirm prompt
 ```
 
-Tears down connector integrations (restores `~/.codex/config.toml`, `~/.claude/settings.json`, etc. from byte-for-byte backups), then removes `~/.defenseclaw/` and the binaries.
+The default tears down connector integrations (restores `~/.codex/config.toml`, `~/.claude/settings.json`, etc. from byte-for-byte backups) but **leaves `~/.defenseclaw/` and the installed binaries on disk** so a subsequent `defenseclaw setup guardrail` can pick up where you left off. Use `--all` and/or `--binaries` to make the removal total. `--dry-run` previews the plan.
 
 ## Next
 

--- a/docs-site/content/docs/setup/mcp-scanner.mdx
+++ b/docs-site/content/docs/setup/mcp-scanner.mdx
@@ -53,10 +53,10 @@ Each server is scanned independently and findings are tagged with the connector 
 <Tabs items={['All connectors', 'Specific server', 'Remote URL', 'With prompts/resources']}>
   <Tab value="All connectors">
 ```bash
-defenseclaw mcp scan --all --json | jq '.findings[]'
+defenseclaw mcp scan --all --json | jq -s '[.[].findings[]]'
 ```
 
-CI-friendly. Walks every discovered MCP config and emits a single JSON document.
+CI-friendly. Walks every server discovered in `openclaw.json` and emits **one JSON object per server** as a stream of top-level values (NDJSON-shaped, not wrapped in an array). `jq -s` slurps the stream into an array so a single pipeline can iterate findings across servers; for line-oriented tools use `--json | jq -c '.findings[]'` instead.
   </Tab>
   <Tab value="Specific server">
 ```bash

--- a/docs-site/content/docs/setup/skill-scanner.mdx
+++ b/docs-site/content/docs/setup/skill-scanner.mdx
@@ -22,7 +22,7 @@ DefenseClaw integrates Cisco's open-source [`cisco-ai-skill-scanner`](https://gi
 
 ## What it scans
 
-The wrapper at [`cli/defenseclaw/scanner/skill.py`](https://github.com/cisco-ai-defense/defenseclaw/blob/main/cli/defenseclaw/scanner/skill.py) accepts four target shapes (all positional — there is no `--remote` flag for URL fetches; the URL itself is the target):
+The wrapper at [`cli/defenseclaw/scanner/skill.py`](https://github.com/cisco-ai-defense/defenseclaw/blob/main/cli/defenseclaw/scanner/skill.py) accepts four target shapes — all **positional**. URL fetches in particular take the URL itself as the positional target (no `--remote` involved). The `--remote` flag does exist, but for a different scenario: it forwards the scan request to a sidecar API for a skill installed on a remote host (see the "Remote sidecar" tab below).
 
 - **Local skill name** (`my-skill`) — resolves through every connector's skill directory: `~/.claude/skills`, `~/.openclaw/skills`, `~/.cursor/skills`, `~/.codex/skills`, `~/.zeptoclaw/skills`.
 - **`--path <dir>`** — scan a directory you specify, useful inside a skill repo's pre-commit hook.

--- a/docs-site/content/docs/setup/skill-scanner.mdx
+++ b/docs-site/content/docs/setup/skill-scanner.mdx
@@ -32,7 +32,7 @@ The wrapper at [`cli/defenseclaw/scanner/skill.py`](https://github.com/cisco-ai-
 For each skill it runs:
 
 1. Static checks — manifest validation, allow-list of tool names, suspicious filesystem paths.
-2. Optional **LLM-assisted analysis** — only when the unified LLM key is configured and the model resolves to an `openai` or `anthropic` provider.
+2. Optional **LLM-assisted analysis** — runs whenever the unified LLM key is configured. The upstream scanner auto-detects the provider from the LiteLLM-shaped `provider/model` string, so OpenAI, Anthropic, Bedrock, Gemini, Vertex AI, Azure, Groq, Mistral, DeepSeek, OpenRouter, Ollama, vLLM, and other LiteLLM-supported providers all work without special-casing.
 3. A consolidated `ScanResult` with severity, findings, and (when applicable) a recommended action.
 
 ## One-shot scan
@@ -166,10 +166,10 @@ LLM-assisted analysis is what catches the *new* malicious skills you don't yet h
 defenseclaw keys set DEFENSECLAW_LLM_KEY
 ```
 
-Under the hood DefenseClaw injects the unified key into the scanner subprocess as `SKILL_SCANNER_LLM_API_KEY` and `SKILL_SCANNER_LLM_MODEL` via `inject_llm_env`. See [Setup → Unified LLM key](/docs/setup/unified-llm-key) for the resolution order and Bifrost provider catalog.
+Under the hood DefenseClaw injects the unified key into the scanner subprocess as `SKILL_SCANNER_LLM_API_KEY` and `SKILL_SCANNER_LLM_MODEL`, plus the matching provider-native variable (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `AWS_BEARER_TOKEN_BEDROCK`, `GOOGLE_API_KEY`, `AZURE_OPENAI_API_KEY`, `GROQ_API_KEY`, etc.) via `inject_llm_env`. See [Setup → Unified LLM key](/docs/setup/unified-llm-key) for the resolution order and Bifrost provider catalog.
 
-<Callout type="warn">
-The Skill Scanner's LLM mode currently supports `anthropic` and `openai` providers. If your unified key resolves to something else (Gemini, Bedrock, Ollama), DefenseClaw will fall back to deterministic checks only and surface a one-line warning.
+<Callout type="info">
+LLM mode works with any LiteLLM-supported provider. The upstream Skill Scanner SDK auto-detects the provider from the LiteLLM-shaped `provider/model` string in your unified config (e.g. `bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0`, `gemini/gemini-2.5-pro`, `vertex_ai/gemini-1.5-pro`). For self-hosted endpoints (vLLM, LM Studio, LiteLLM proxy) set `llm.base_url` in `~/.defenseclaw/config.yaml`.
 </Callout>
 
 ## Install if missing

--- a/docs-site/content/docs/setup/unified-llm-key.mdx
+++ b/docs-site/content/docs/setup/unified-llm-key.mdx
@@ -233,7 +233,7 @@ You don't pick the Bifrost key directly. You pick a model — the gateway maps `
   <Card
     title="Skill Scanner"
     href="/docs/setup/skill-scanner"
-    description="SKILL_SCANNER_LLM_API_KEY is auto-populated from DEFENSECLAW_LLM_KEY via inject_llm_env. LLM features require anthropic or openai today."
+    description="SKILL_SCANNER_LLM_API_KEY is auto-populated from DEFENSECLAW_LLM_KEY via inject_llm_env. LLM analysis works with any LiteLLM-supported provider (OpenAI, Anthropic, Bedrock, Gemini, Vertex, Azure, Groq, Mistral, vLLM, Ollama, …)."
   />
   <Card
     title="MCP Scanner"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -390,30 +390,39 @@ func (l LLMConfig) IsLocalProvider() bool {
 
 // recognizedLLMProviders lists the "provider/" prefixes the gateway and
 // LiteLLM both understand. Unknown prefixes emit a one-shot warning.
+//
+// Keep in lockstep with _RECOGNIZED_LLM_PROVIDERS in
+// cli/defenseclaw/config.py. The "gemini-openai" entry in particular
+// is a Bifrost routing key for Google's OpenAI-compatible Gemini
+// endpoint — the gateway routes it through Bifrost's Gemini handler
+// (see internal/gateway/provider_bifrost.go), while the Python
+// LiteLLM bridge maps it to the same GOOGLE_API_KEY env var via
+// cli/defenseclaw/scanner/_llm_env.py.
 var recognizedLLMProviders = map[string]struct{}{
-	"openai":       {},
-	"anthropic":    {},
-	"azure":        {},
-	"gemini":       {},
-	"vertex_ai":    {},
-	"bedrock":      {},
-	"groq":         {},
-	"mistral":      {},
-	"cohere":       {},
-	"ollama":       {},
-	"vllm":         {},
-	"deepseek":     {},
-	"xai":          {},
-	"fireworks_ai": {},
-	"perplexity":   {},
-	"huggingface":  {},
-	"replicate":    {},
-	"openrouter":   {},
-	"together_ai":  {},
-	"cerebras":     {},
-	"lm_studio":    {},
-	"lmstudio":     {},
-	"local":        {},
+	"openai":        {},
+	"anthropic":     {},
+	"azure":         {},
+	"gemini":        {},
+	"gemini-openai": {},
+	"vertex_ai":     {},
+	"bedrock":       {},
+	"groq":          {},
+	"mistral":       {},
+	"cohere":        {},
+	"ollama":        {},
+	"vllm":          {},
+	"deepseek":      {},
+	"xai":           {},
+	"fireworks_ai":  {},
+	"perplexity":    {},
+	"huggingface":   {},
+	"replicate":     {},
+	"openrouter":    {},
+	"together_ai":   {},
+	"cerebras":      {},
+	"lm_studio":     {},
+	"lmstudio":      {},
+	"local":         {},
 }
 
 // warnedPrefixes keeps one-shot-per-process warning state.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1420,3 +1420,32 @@ func TestViperDefaultGuardrailHostIsEmpty(t *testing.T) {
 		t.Fatalf("EffectiveHost() = %q, want 127.0.0.1", got)
 	}
 }
+
+// TestRecognizedLLMProvidersLockstep guards against drift between the
+// Go-side recognizedLLMProviders set and the Python-side
+// _RECOGNIZED_LLM_PROVIDERS in cli/defenseclaw/config.py. A missing
+// entry on either side surfaces as a one-shot "unknown provider"
+// warning even when the prefix is wired through Bifrost — exactly the
+// regression we hit when "gemini-openai" was added to the gateway and
+// the wizards but never to either recognized-providers map.
+//
+// The Bifrost gateway (internal/gateway/provider.go,
+// internal/gateway/provider_bifrost.go) and both wizards
+// (cli/defenseclaw/commands/cmd_setup.py, internal/tui/setup.go)
+// already accept these prefixes; the recognized-providers maps must
+// follow.
+func TestRecognizedLLMProvidersLockstep(t *testing.T) {
+	mustHave := []string{
+		"openai", "anthropic", "azure", "gemini", "gemini-openai",
+		"vertex_ai", "bedrock", "groq", "mistral", "cohere",
+		"ollama", "vllm", "deepseek", "xai",
+		"fireworks_ai", "perplexity", "huggingface", "replicate",
+		"openrouter", "together_ai", "cerebras",
+		"lm_studio", "lmstudio", "local",
+	}
+	for _, p := range mustHave {
+		if _, ok := recognizedLLMProviders[p]; !ok {
+			t.Errorf("recognizedLLMProviders missing %q — keep this set in lockstep with cli/defenseclaw/config.py:_RECOGNIZED_LLM_PROVIDERS", p)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Drop the wrapper-side LLM provider gates that were silently disabling LLM analysis for every non-OpenAI/Anthropic configuration:

- **Skill scanner**: removed `_skill_scanner_provider_supported()` allowlist that stripped `use_llm` for Bedrock/Gemini/Vertex/Azure/Groq/Mistral/etc.
- **MCP scanner**: removed the hard-coded `_PROVIDER_BASE_URLS = {openai, anthropic}` table and `_resolve_llm_base_url()`; forward `llm.base_url` verbatim instead.
- **Wizard** (`cmd_setup.py`): expanded provider list to match `_RECOGNIZED_LLM_PROVIDERS` (adds fireworks_ai, perplexity, huggingface, replicate, together_ai, cerebras).
- **Docs**: replaced the "openai or anthropic only" callouts with the full provider matrix; refreshed `_llm_env.py` header comment.

### Why this is safe

I read the installed upstream SDK source before rewriting:

- [`skill_scanner/core/analyzer_factory.py`](https://github.com/cisco-ai-defense/cisco-ai-skill-scanner) auto-detects the provider from a LiteLLM-shaped `provider/model` string via `ProviderConfig`. It also **ignores** `llm_provider` whenever `llm_model` is set, and our internal short names (`bedrock`, `vertex_ai`) don't match upstream's `LLMProvider` enum (`aws-bedrock`, `gcp-vertex`) anyway — so passing them only mattered on the model-less path and would have errored out there.
- [`mcpscanner/core/analyzers/llm_analyzer.py`](https://github.com/cisco-ai-defense/cisco-ai-mcp-scanner) only adds `api_base` to its LiteLLM call when `llm_base_url` is truthy. Empty string is the correct default — it lets LiteLLM's own provider-default discovery route Bedrock through `bedrock_runtime`, Gemini through `google_ai_studio`, etc.

### Verification

**Automated**
- `pytest cli/tests/test_scanners.py` — 33 passed.
- Full CLI suite — 2164 passed, 1 skipped, 163 subtests passed (105.23s).

**Manual** (live `bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0` account)
- Skill `build_analyzers()` is now invoked with `use_llm=True`, `llm_model='bedrock/...'`, `llm_api_key=<131-char key>`, **no** `llm_provider`.
- `defenseclaw skill scan /Users/vineeth/.cursor/skills-cursor/statusline` ran in **14.59s** and returned **5 LLM-authored findings** with multi-step prose remediations (e.g. "Indirect Prompt Injection via Untrusted JSON Payload"). Pre-fix this scan would have silently fallen back to static-only.
- MCP wrapper builds `MCPConfig` with `llm_base_url=''` so the SDK's `api_base` branch is skipped and LiteLLM's bedrock_runtime provider handles routing.
- `defenseclaw doctor` reports `LLM API key (Bedrock) authenticated successfully (us-east-1)`.

## Test plan

- [x] `pytest cli/tests/test_scanners.py` — 33 passed
- [x] Full CLI suite — 2164 passed, 1 skipped
- [x] Live Bedrock skill scan returns LLM-authored findings
- [x] MCPConfig kwarg trace shows `llm_base_url=''` for Bedrock
- [x] `defenseclaw doctor` healthy
- [ ] Reviewer to spot-check the docs-site rendering for the updated callouts on `/docs/setup/skill-scanner` and `/docs/setup/unified-llm-key`

## Notes

- No config-file migration is needed — the dropped tables were wrapper internals; `LLMConfig` and `_RECOGNIZED_LLM_PROVIDERS` are unchanged.
- The unified `DEFENSECLAW_LLM_KEY` + `DEFENSECLAW_LLM_MODEL` flow is already provider-agnostic in the gateway (Bifrost) and the LiteLLM bridge; this PR just brings the two Python scanner wrappers up to the same bar.