### PR TITLE
refactor(docs-site): reorder connectors by adoption popularity

### DIFF
--- a/docs-site/content/docs/connectors/meta.json
+++ b/docs-site/content/docs/connectors/meta.json
@@ -2,14 +2,14 @@
   "title": "Connectors",
   "pages": [
     "index",
-    "openclaw",
-    "zeptoclaw",
     "claudecode",
     "codex",
+    "openclaw",
     "cursor",
-    "windsurf",
+    "hermes",
     "geminicli",
     "copilot",
-    "hermes"
+    "windsurf",
+    "zeptoclaw"
   ]
 }

--- a/docs-site/data/capability-matrix.json
+++ b/docs-site/data/capability-matrix.json
@@ -1,41 +1,8 @@
 {
   "_source": "Hand-curated from internal/gateway/connector/{hook_only,claudecode,codex,openclaw,zeptoclaw}.go and cli/defenseclaw/commands/cmd_setup.py (_CONNECTOR_META, _hilt_support_note). Re-extract on every connector change.",
   "_lastVerified": "2026-05-08",
+  "_order": "By adoption / popularity — mirrors the hero rotation (lib/hero-connectors.ts) and the docs nav (content/docs/connectors/meta.json).",
   "connectors": [
-    {
-      "id": "openclaw",
-      "label": "OpenClaw",
-      "family": "proxy",
-      "toolInspection": "pre-execution + response-scan",
-      "subprocessPolicy": "sandbox",
-      "hooks": {
-        "canBlock": true,
-        "canAskNative": true,
-        "askEvents": ["before_tool_call"],
-        "blockEvents": ["before_tool_call", "fetch_request", "fetch_response"],
-        "supportsFailClosed": true,
-        "scope": "user"
-      },
-      "hilt": "OpenClaw supports DefenseClaw approval prompts for tool actions. Approvals reach chat-origin sessions via the bundled plugin.",
-      "notes": "Reference proxy connector — full data-path interception, sandbox enforcement, plugin-mediated HITL."
-    },
-    {
-      "id": "zeptoclaw",
-      "label": "ZeptoClaw",
-      "family": "proxy",
-      "toolInspection": "pre-execution + response-scan",
-      "subprocessPolicy": "sandbox",
-      "hooks": {
-        "canBlock": true,
-        "canAskNative": false,
-        "askEvents": [],
-        "blockEvents": ["fetch_request", "fetch_response", "tool_call"],
-        "supportsFailClosed": true,
-        "scope": "user"
-      },
-      "hilt": "ZeptoClaw has no native ask surface; confirm verdicts are downgraded with raw_action preserved so operators can review in TUI/audit.",
-      "notes": "api_base redirect into the DefenseClaw proxy plus response-scan."
-    },
     {
       "id": "claudecode",
       "label": "Claude Code",
@@ -71,21 +38,21 @@
       "notes": "Three telemetry channels at boot: hooks, native OTel, and the notify bridge for agent-turn-complete events. Enforcement gated behind guardrail.codex_enforcement_enabled."
     },
     {
-      "id": "hermes",
-      "label": "Hermes",
-      "family": "hooks",
+      "id": "openclaw",
+      "label": "OpenClaw",
+      "family": "proxy",
       "toolInspection": "pre-execution + response-scan",
-      "subprocessPolicy": "none",
+      "subprocessPolicy": "sandbox",
       "hooks": {
         "canBlock": true,
-        "canAskNative": false,
-        "askEvents": [],
-        "blockEvents": ["pre_tool_call"],
-        "supportsFailClosed": false,
+        "canAskNative": true,
+        "askEvents": ["before_tool_call"],
+        "blockEvents": ["before_tool_call", "fetch_request", "fetch_response"],
+        "supportsFailClosed": true,
         "scope": "user"
       },
-      "hilt": "Can block supported hook events but has no native human-approval surface; confirm verdicts fall back explicitly.",
-      "notes": "Hooks live in ~/.hermes/config.yaml. Discovery surfaces for MCP, skills, plugins."
+      "hilt": "OpenClaw supports DefenseClaw approval prompts for tool actions. Approvals reach chat-origin sessions via the bundled plugin.",
+      "notes": "Reference proxy connector — full data-path interception, sandbox enforcement, plugin-mediated HITL."
     },
     {
       "id": "cursor",
@@ -113,8 +80,8 @@
       "notes": "hooks.json under ~/.cursor; MCP / skills / rules surfaces are workspace-scoped."
     },
     {
-      "id": "windsurf",
-      "label": "Windsurf",
+      "id": "hermes",
+      "label": "Hermes",
       "family": "hooks",
       "toolInspection": "pre-execution + response-scan",
       "subprocessPolicy": "none",
@@ -122,18 +89,12 @@
         "canBlock": true,
         "canAskNative": false,
         "askEvents": [],
-        "blockEvents": [
-          "pre_user_prompt",
-          "pre_read_code",
-          "pre_write_code",
-          "pre_run_command",
-          "pre_mcp_tool_use"
-        ],
+        "blockEvents": ["pre_tool_call"],
         "supportsFailClosed": false,
         "scope": "user"
       },
       "hilt": "Can block supported hook events but has no native human-approval surface; confirm verdicts fall back explicitly.",
-      "notes": "Cascade hooks under ~/.codeium/windsurf/hooks.json. Existing MCP/rules discovered, never auto-created."
+      "notes": "Hooks live in ~/.hermes/config.yaml. Discovery surfaces for MCP, skills, plugins."
     },
     {
       "id": "geminicli",
@@ -179,6 +140,46 @@
       },
       "hilt": "Copilot CLI supports native ask on documented preToolUse hooks.",
       "notes": "Workspace-scoped hooks under <workspace>/.github/hooks/."
+    },
+    {
+      "id": "windsurf",
+      "label": "Windsurf",
+      "family": "hooks",
+      "toolInspection": "pre-execution + response-scan",
+      "subprocessPolicy": "none",
+      "hooks": {
+        "canBlock": true,
+        "canAskNative": false,
+        "askEvents": [],
+        "blockEvents": [
+          "pre_user_prompt",
+          "pre_read_code",
+          "pre_write_code",
+          "pre_run_command",
+          "pre_mcp_tool_use"
+        ],
+        "supportsFailClosed": false,
+        "scope": "user"
+      },
+      "hilt": "Can block supported hook events but has no native human-approval surface; confirm verdicts fall back explicitly.",
+      "notes": "Cascade hooks under ~/.codeium/windsurf/hooks.json. Existing MCP/rules discovered, never auto-created."
+    },
+    {
+      "id": "zeptoclaw",
+      "label": "ZeptoClaw",
+      "family": "proxy",
+      "toolInspection": "pre-execution + response-scan",
+      "subprocessPolicy": "sandbox",
+      "hooks": {
+        "canBlock": true,
+        "canAskNative": false,
+        "askEvents": [],
+        "blockEvents": ["fetch_request", "fetch_response", "tool_call"],
+        "supportsFailClosed": true,
+        "scope": "user"
+      },
+      "hilt": "ZeptoClaw has no native ask surface; confirm verdicts are downgraded with raw_action preserved so operators can review in TUI/audit.",
+      "notes": "api_base redirect into the DefenseClaw proxy plus response-scan."
     }
   ]
 }

--- a/docs-site/lib/hero-connectors.ts
+++ b/docs-site/lib/hero-connectors.ts
@@ -1,8 +1,11 @@
 // Hero terminal-demo connector list. Lives outside the React tree so
 // both <HeroLockup> (which drives the rotation) and <TerminalDemo>
 // (which renders the per-connector block) can import it without
-// creating a circular dependency. Order matches /docs/connectors so
-// the rotation reads the same as the docs nav.
+// creating a circular dependency. Order is by adoption / popularity so
+// the rotation leads with the connectors most visitors recognize
+// first; the docs nav (content/docs/connectors/meta.json) and the
+// capability matrix (data/capability-matrix.json) follow the same
+// ordering.
 //
 // Setup aliases verified against docs/setup/guardrail/aliases/:
 //   - proxies (OpenClaw, ZeptoClaw) → defenseclaw setup guardrail
@@ -21,13 +24,13 @@ export interface ConnectorBlock {
 }
 
 export const TERMINAL_CONNECTORS: ConnectorBlock[] = [
-  { id: 'openclaw',   label: 'OpenClaw',           command: 'defenseclaw setup guardrail',   modeId: 'openclaw' },
-  { id: 'zeptoclaw',  label: 'ZeptoClaw',          command: 'defenseclaw setup guardrail',   modeId: 'zeptoclaw' },
   { id: 'claudecode', label: 'Claude Code',        command: 'defenseclaw setup claude-code', modeId: 'claudecode' },
   { id: 'codex',      label: 'Codex',              command: 'defenseclaw setup codex',       modeId: 'codex' },
-  { id: 'hermes',     label: 'Hermes',             command: 'defenseclaw setup hermes',      modeId: 'hermes' },
+  { id: 'openclaw',   label: 'OpenClaw',           command: 'defenseclaw setup guardrail',   modeId: 'openclaw' },
   { id: 'cursor',     label: 'Cursor',             command: 'defenseclaw setup cursor',      modeId: 'cursor' },
-  { id: 'windsurf',   label: 'Windsurf',           command: 'defenseclaw setup windsurf',    modeId: 'windsurf' },
+  { id: 'hermes',     label: 'Hermes',             command: 'defenseclaw setup hermes',      modeId: 'hermes' },
   { id: 'geminicli',  label: 'Gemini CLI',         command: 'defenseclaw setup geminicli',   modeId: 'geminicli' },
   { id: 'copilot',    label: 'GitHub Copilot CLI', command: 'defenseclaw setup copilot',     modeId: 'copilot' },
+  { id: 'windsurf',   label: 'Windsurf',           command: 'defenseclaw setup windsurf',    modeId: 'windsurf' },
+  { id: 'zeptoclaw',  label: 'ZeptoClaw',          command: 'defenseclaw setup guardrail',   modeId: 'zeptoclaw' },
 ];


### PR DESCRIPTION
## Summary

Reorders the connector list in the three sources that drive the connector ordering on the docs site so visitors see the most-recognized connectors first:

**Claude Code → Codex → OpenClaw → Cursor → Hermes → Gemini CLI → GitHub Copilot → Windsurf → ZeptoClaw**

Touched files:

- `docs-site/lib/hero-connectors.ts` — drives both hero surfaces: the rotating word in the headline and the per-connector block in the terminal demo (both subscribe to the same `HeroLockup` index, so they advance in lockstep).
- `docs-site/data/capability-matrix.json` — drives the **Connectors** chip strip in the hero card and the **Connectors** grid section further down the home page; also the `/docs/capability-matrix` table which iterates the same array.
- `docs-site/content/docs/connectors/meta.json` — drives the docs sidebar nav under **Connectors** (`index` stays first).

No data, rendering logic, or copy was changed — array order only. Comments at the top of `hero-connectors.ts` and a new `_order` metadata key in `capability-matrix.json` document the rationale and the cross-references between the three sources.

## Test plan

- [ ] Run `npm run dev` in `docs-site/` and confirm the hero rotation cycles in the new order (Claude Code first).
- [ ] Confirm the **Connectors** chip strip and the **Connectors** grid section on the home page render in the new order.
- [ ] Confirm the docs sidebar under **Connectors** lists the agents in the new order.
- [ ] Confirm the table on `/docs/capability-matrix` rows are in the new order.
- [ ] Confirm no link breakage — every connector page (`/docs/connectors/{id}`) still resolves.