### PR TITLE
feat(docs-site): add non-interactive command generator

### DIFF
--- a/docs-site/components/command-generator.tsx
+++ b/docs-site/components/command-generator.tsx
@@ -1,0 +1,811 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import matrix from '@/data/capability-matrix.json';
+
+// Interactive, non-interactive `defenseclaw setup guardrail` command
+// builder. Every knob the operator can pass on the CLI is exposed as
+// a form control here. The generated `defenseclaw setup guardrail
+// --non-interactive ...` is rendered live below the form with a copy
+// button and a notes panel that surfaces validation warnings (e.g.
+// remote scanner requires Cisco endpoint, HITL in observe mode is a
+// no-op, connectors without native ask downgrade to a TUI confirm).
+//
+// The component reads the capability matrix shipped at
+// `data/capability-matrix.json` for connector metadata so this stays
+// in lockstep with the rest of the docs site. Update the JSON; this
+// updates with it.
+
+type ConnectorRow = {
+  id: string;
+  label: string;
+  family: 'proxy' | 'hooks';
+  toolInspection: string;
+  subprocessPolicy: string;
+  hooks: {
+    canBlock: boolean;
+    canAskNative: boolean;
+    askEvents: string[];
+    blockEvents: string[];
+    supportsFailClosed: boolean;
+    scope: 'user' | 'workspace';
+  };
+  hilt: string;
+  notes?: string;
+};
+
+const CONNECTORS = (matrix as { connectors: ConnectorRow[] }).connectors;
+
+type Mode = 'observe' | 'action';
+type ScannerMode = 'local' | 'remote' | 'both';
+type DetectionStrategy = 'regex_only' | 'regex_judge' | 'judge_first';
+type RulePack = 'default' | 'strict' | 'permissive';
+type HitlSeverity = 'high' | 'medium' | 'low' | 'critical';
+
+interface GeneratorState {
+  connector: string;
+  mode: Mode;
+  scannerMode: ScannerMode;
+  ciscoEndpoint: string;
+  ciscoApiKeyEnv: string;
+  ciscoTimeoutMs: string;
+  rulePack: RulePack;
+  detectionStrategy: DetectionStrategy;
+  judgeModel: string;
+  judgeApiBase: string;
+  judgeApiKeyEnv: string;
+  humanApproval: boolean;
+  hiltMinSeverity: HitlSeverity;
+  port: string;
+  blockMessage: string;
+  disableRedaction: boolean;
+  restart: boolean;
+  verify: boolean;
+  showAdvanced: boolean;
+}
+
+const DEFAULT_STATE: GeneratorState = {
+  connector: 'claudecode',
+  mode: 'observe',
+  scannerMode: 'local',
+  ciscoEndpoint: '',
+  ciscoApiKeyEnv: 'CISCO_AI_DEFENSE_API_KEY',
+  ciscoTimeoutMs: '',
+  rulePack: 'default',
+  detectionStrategy: 'regex_only',
+  judgeModel: 'anthropic/claude-sonnet-4-20250514',
+  judgeApiBase: '',
+  judgeApiKeyEnv: 'DEFENSECLAW_LLM_KEY',
+  humanApproval: false,
+  hiltMinSeverity: 'high',
+  port: '',
+  blockMessage: '',
+  disableRedaction: false,
+  restart: true,
+  verify: true,
+  showAdvanced: false,
+};
+
+// Quote a value for safe inclusion as a single shell argument. Single
+// quotes are bulletproof in POSIX shells; the only character that
+// can't appear inside them is `'` itself, which we escape via the
+// `'\''` close-reopen idiom. We deliberately do NOT skip quoting when
+// the value "looks safe" — keeping every operator-supplied value
+// quoted means there is no path where injected metacharacters survive
+// the rendered command. The output is for display + copy-paste only;
+// the generator never executes any shell.
+function shellQuote(value: string): string {
+  if (value === '') return "''";
+  // Conservative allow-list: bare tokens only when the value is
+  // strictly alphanumeric plus a handful of always-safe punctuation
+  // (model slugs, env-var names, hostnames, integer ports). Everything
+  // else gets the single-quote treatment.
+  if (/^[A-Za-z0-9_./:@\-]+$/.test(value)) return value;
+  return "'" + value.replace(/'/g, "'\\''") + "'";
+}
+
+function buildCommand(s: GeneratorState): { lines: string[]; preExports: string[]; warnings: string[] } {
+  const lines: string[] = ['defenseclaw setup guardrail', '--non-interactive'];
+  const preExports: string[] = [];
+  const warnings: string[] = [];
+
+  const connectorRow = CONNECTORS.find((c) => c.id === s.connector);
+  if (connectorRow) {
+    lines.push(`--connector ${shellQuote(connectorRow.id)}`);
+  }
+
+  lines.push(`--mode ${s.mode}`);
+
+  // Scanner backend.
+  lines.push(`--scanner-mode ${s.scannerMode}`);
+  if (s.scannerMode === 'remote' || s.scannerMode === 'both') {
+    if (s.ciscoEndpoint.trim()) {
+      lines.push(`--cisco-endpoint ${shellQuote(s.ciscoEndpoint.trim())}`);
+    } else {
+      warnings.push(
+        'Remote scanner is enabled but no Cisco endpoint is set. The CLI will reject the run unless an endpoint is already in ~/.defenseclaw/config.yaml.',
+      );
+    }
+    if (s.ciscoApiKeyEnv.trim() && s.ciscoApiKeyEnv !== 'CISCO_AI_DEFENSE_API_KEY') {
+      lines.push(`--cisco-api-key-env ${shellQuote(s.ciscoApiKeyEnv.trim())}`);
+    }
+    if (s.ciscoTimeoutMs.trim()) {
+      const n = Number(s.ciscoTimeoutMs.trim());
+      if (Number.isFinite(n) && n > 0) {
+        lines.push(`--cisco-timeout-ms ${n}`);
+      }
+    }
+    const apiKeyEnv = s.ciscoApiKeyEnv.trim() || 'CISCO_AI_DEFENSE_API_KEY';
+    preExports.push(`export ${apiKeyEnv}=<your-cisco-ai-defense-api-key>`);
+  }
+
+  // Action-mode-only enforcement knobs.
+  if (s.mode === 'action') {
+    lines.push(`--rule-pack ${s.rulePack}`);
+    if (s.blockMessage.trim()) {
+      lines.push(`--block-message ${shellQuote(s.blockMessage)}`);
+    }
+    if (s.humanApproval) {
+      lines.push('--human-approval');
+      lines.push(`--hilt-min-severity ${s.hiltMinSeverity}`);
+    } else {
+      lines.push('--no-human-approval');
+    }
+  } else {
+    // Observe mode silently ignores HITL / rule-pack / block-message
+    // server-side. Warn here so the operator notices.
+    if (s.humanApproval) {
+      warnings.push(
+        'Human approval (HITL) only fires in action mode. Observe mode logs without blocking, so there is nothing to pause on. The --human-approval flag was omitted.',
+      );
+    }
+    if (s.blockMessage.trim()) {
+      warnings.push(
+        'Custom block message only applies in action mode. Observe never blocks. The --block-message flag was omitted.',
+      );
+    }
+  }
+
+  // Detection strategy + judge knobs.
+  lines.push(`--detection-strategy ${s.detectionStrategy}`);
+  if (s.detectionStrategy !== 'regex_only') {
+    if (s.judgeModel.trim()) {
+      lines.push(`--judge-model ${shellQuote(s.judgeModel.trim())}`);
+    } else {
+      warnings.push(
+        `Detection strategy ${s.detectionStrategy} requires --judge-model. Pick a judge model below or the CLI will fall back to regex_only.`,
+      );
+    }
+    if (s.judgeApiBase.trim()) {
+      lines.push(`--judge-api-base ${shellQuote(s.judgeApiBase.trim())}`);
+    }
+    if (s.judgeApiKeyEnv.trim()) {
+      lines.push(`--judge-api-key-env ${shellQuote(s.judgeApiKeyEnv.trim())}`);
+    }
+    const apiKeyEnv = s.judgeApiKeyEnv.trim() || 'DEFENSECLAW_LLM_KEY';
+    preExports.push(`export ${apiKeyEnv}=<your-llm-api-key>`);
+  }
+
+  // Advanced knobs.
+  if (s.port.trim()) {
+    const n = Number(s.port.trim());
+    if (Number.isFinite(n) && n > 0 && n <= 65535) {
+      lines.push(`--port ${n}`);
+    } else {
+      warnings.push(`Port ${s.port} is not a valid TCP port. Flag omitted.`);
+    }
+  }
+
+  if (s.disableRedaction) {
+    lines.push('--disable-redaction');
+    warnings.push(
+      'Redaction is disabled. Sinks will receive UNREDACTED prompts. Only do this inside trusted, single-tenant environments.',
+    );
+  }
+
+  if (!s.restart) lines.push('--no-restart');
+  if (!s.verify) lines.push('--no-verify');
+
+  // Connector-specific HITL notes.
+  if (s.mode === 'action' && s.humanApproval && connectorRow) {
+    if (!connectorRow.hooks.canAskNative) {
+      warnings.push(
+        `${connectorRow.label} has no native ask surface. HITL prompts downgrade to a confirm verdict that the operator approves in 'defenseclaw tui' (raw_action preserved in the audit log).`,
+      );
+    } else if (connectorRow.hooks.askEvents.length > 0) {
+      warnings.push(
+        `${connectorRow.label} surfaces HITL prompts natively on: ${connectorRow.hooks.askEvents.join(', ')}.`,
+      );
+    }
+  }
+
+  if (s.mode === 'action' && connectorRow && !connectorRow.hooks.supportsFailClosed) {
+    warnings.push(
+      `${connectorRow.label} does not support fail-closed enforcement. On guardrail failure the request will be allowed through; use 'defenseclaw guardrail fail-mode closed' only on connectors that support it.`,
+    );
+  }
+
+  return { lines, preExports, warnings };
+}
+
+function renderShellScript(preExports: string[], lines: string[]): string {
+  const out: string[] = [];
+  for (const e of preExports) {
+    out.push(e);
+  }
+  if (preExports.length > 0) out.push('');
+  // Join the verb + flags as one logical command with `\` line
+  // continuations so the rendered output is a copy-pasteable POSIX
+  // shell command, not a list.
+  for (let i = 0; i < lines.length; i += 1) {
+    const isLast = i === lines.length - 1;
+    const indent = i === 0 ? '' : '  ';
+    out.push(`${indent}${lines[i]}${isLast ? '' : ' \\'}`);
+  }
+  return out.join('\n');
+}
+
+export function CommandGenerator() {
+  const [state, setState] = useState<GeneratorState>(DEFAULT_STATE);
+  const [copied, setCopied] = useState(false);
+
+  const built = useMemo(() => buildCommand(state), [state]);
+  const script = useMemo(
+    () => renderShellScript(built.preExports, built.lines),
+    [built],
+  );
+
+  const update = <K extends keyof GeneratorState>(key: K, value: GeneratorState[K]) => {
+    setState((prev) => ({ ...prev, [key]: value }));
+    setCopied(false);
+  };
+
+  const onCopy = async () => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(script);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard can be blocked by the embedding context (e.g.
+      // sandboxed iframe). Fail silent — the user can still select +
+      // copy the rendered <pre> manually.
+    }
+  };
+
+  const onReset = () => {
+    setState(DEFAULT_STATE);
+    setCopied(false);
+  };
+
+  const selected = CONNECTORS.find((c) => c.id === state.connector);
+
+  return (
+    <div className="not-prose my-6 grid gap-6 rounded-2xl border border-fd-border bg-fd-card/60 p-5 lg:grid-cols-[1.1fr_1fr]">
+      <div className="grid gap-6">
+        <Section title="Connector" subtitle="Pick the agent framework.">
+          <div className="grid gap-2 sm:grid-cols-2">
+            {CONNECTORS.map((c) => (
+              <ConnectorOption
+                key={c.id}
+                row={c}
+                selected={state.connector === c.id}
+                onSelect={() => update('connector', c.id)}
+              />
+            ))}
+          </div>
+        </Section>
+
+        <Section
+          title="Mode"
+          subtitle="observe logs without blocking. action enforces on configured severities."
+        >
+          <SegmentedControl<Mode>
+            name="mode"
+            options={[
+              { value: 'observe', label: 'observe', hint: 'log only' },
+              { value: 'action', label: 'action', hint: 'block on findings' },
+            ]}
+            value={state.mode}
+            onChange={(v) => update('mode', v)}
+          />
+        </Section>
+
+        <Section title="Scanner backend" subtitle="local is zero-key bundled regex. remote calls Cisco AI Defense. both runs the union.">
+          <SegmentedControl<ScannerMode>
+            name="scanner-mode"
+            options={[
+              { value: 'local', label: 'local' },
+              { value: 'remote', label: 'remote' },
+              { value: 'both', label: 'both' },
+            ]}
+            value={state.scannerMode}
+            onChange={(v) => update('scannerMode', v)}
+          />
+          {(state.scannerMode === 'remote' || state.scannerMode === 'both') && (
+            <div className="mt-3 grid gap-3 sm:grid-cols-2">
+              <Field
+                label="Cisco endpoint"
+                placeholder="https://aidefense.example.com"
+                value={state.ciscoEndpoint}
+                onChange={(v) => update('ciscoEndpoint', v)}
+              />
+              <Field
+                label="API key env var"
+                placeholder="CISCO_AI_DEFENSE_API_KEY"
+                value={state.ciscoApiKeyEnv}
+                onChange={(v) => update('ciscoApiKeyEnv', v)}
+              />
+              <Field
+                label="Timeout (ms)"
+                placeholder="5000"
+                inputMode="numeric"
+                value={state.ciscoTimeoutMs}
+                onChange={(v) => update('ciscoTimeoutMs', v)}
+              />
+            </div>
+          )}
+        </Section>
+
+        <Section
+          title="Detection strategy"
+          subtitle="regex_only is the zero-key default. The judge variants need an LLM key."
+        >
+          <SegmentedControl<DetectionStrategy>
+            name="detection-strategy"
+            options={[
+              { value: 'regex_only', label: 'regex_only' },
+              { value: 'regex_judge', label: 'regex_judge' },
+              { value: 'judge_first', label: 'judge_first' },
+            ]}
+            value={state.detectionStrategy}
+            onChange={(v) => update('detectionStrategy', v)}
+          />
+          {state.detectionStrategy !== 'regex_only' && (
+            <div className="mt-3 grid gap-3 sm:grid-cols-2">
+              <Field
+                label="Judge model"
+                placeholder="anthropic/claude-sonnet-4-20250514"
+                value={state.judgeModel}
+                onChange={(v) => update('judgeModel', v)}
+              />
+              <Field
+                label="API key env var"
+                placeholder="DEFENSECLAW_LLM_KEY"
+                value={state.judgeApiKeyEnv}
+                onChange={(v) => update('judgeApiKeyEnv', v)}
+              />
+              <Field
+                label="API base (optional)"
+                placeholder="https://bifrost.example.com"
+                value={state.judgeApiBase}
+                onChange={(v) => update('judgeApiBase', v)}
+              />
+            </div>
+          )}
+        </Section>
+
+        <Section
+          title="Rule pack"
+          subtitle={
+            state.mode === 'action'
+              ? 'Bundled rule-pack profile. Picks the directory under ~/.defenseclaw/policies/guardrail/.'
+              : 'Rule packs only apply when --mode is action.'
+          }
+        >
+          <SegmentedControl<RulePack>
+            name="rule-pack"
+            options={[
+              { value: 'default', label: 'default' },
+              { value: 'strict', label: 'strict' },
+              { value: 'permissive', label: 'permissive' },
+            ]}
+            value={state.rulePack}
+            onChange={(v) => update('rulePack', v)}
+            disabled={state.mode !== 'action'}
+          />
+        </Section>
+
+        <Section
+          title="Human-in-the-Loop (HITL)"
+          subtitle={
+            state.mode === 'action'
+              ? selected?.hooks.canAskNative
+                ? `${selected.label} supports native ask. HIGH findings pause inside the agent UI.`
+                : selected
+                  ? `${selected.label} has no native ask surface — HITL downgrades to a confirm verdict in defenseclaw tui.`
+                  : 'Pause risky tool calls and ask for operator approval before they run.'
+              : 'HITL only fires in action mode. Switch above to enable.'
+          }
+        >
+          <div className="flex flex-wrap items-center gap-3">
+            <Toggle
+              label="Enable human approval"
+              checked={state.humanApproval}
+              onChange={(v) => update('humanApproval', v)}
+              disabled={state.mode !== 'action'}
+            />
+            <SeverityPicker
+              value={state.hiltMinSeverity}
+              onChange={(v) => update('hiltMinSeverity', v)}
+              disabled={state.mode !== 'action' || !state.humanApproval}
+            />
+          </div>
+          {selected && (
+            <p className="mt-3 text-xs text-fd-muted-foreground">
+              <span className="font-medium text-fd-foreground">{selected.label} HITL:</span>{' '}
+              {selected.hilt}
+            </p>
+          )}
+        </Section>
+
+        <Section
+          title="Advanced"
+          subtitle="Knobs most operators leave untouched."
+        >
+          <button
+            type="button"
+            onClick={() => update('showAdvanced', !state.showAdvanced)}
+            className="text-sm font-medium text-[var(--brand-cisco-strong)] hover:underline"
+            aria-expanded={state.showAdvanced}
+          >
+            {state.showAdvanced ? 'Hide' : 'Show'} advanced options
+          </button>
+          {state.showAdvanced && (
+            <div className="mt-3 grid gap-3 sm:grid-cols-2">
+              <Field
+                label="Gateway port"
+                placeholder="4000"
+                inputMode="numeric"
+                value={state.port}
+                onChange={(v) => update('port', v)}
+              />
+              <Field
+                label="Custom block message"
+                placeholder="(action mode only)"
+                value={state.blockMessage}
+                onChange={(v) => update('blockMessage', v)}
+                disabled={state.mode !== 'action'}
+              />
+              <Toggle
+                label="Disable redaction (dangerous)"
+                checked={state.disableRedaction}
+                onChange={(v) => update('disableRedaction', v)}
+              />
+              <Toggle
+                label="Restart gateway after setup"
+                checked={state.restart}
+                onChange={(v) => update('restart', v)}
+              />
+              <Toggle
+                label="Run connectivity verify"
+                checked={state.verify}
+                onChange={(v) => update('verify', v)}
+              />
+            </div>
+          )}
+        </Section>
+      </div>
+
+      <div className="grid gap-4">
+        <div className="rounded-xl border border-fd-border bg-fd-card">
+          <div className="flex items-center justify-between border-b border-fd-border px-4 py-2">
+            <div className="text-xs font-medium text-fd-muted-foreground">
+              defenseclaw setup guardrail —{' '}
+              <span className="text-fd-foreground">
+                {selected?.label ?? state.connector}
+              </span>{' '}
+              <span className="text-fd-muted-foreground/80">/ {state.mode}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={onReset}
+                className="rounded-md px-2 py-1 text-xs font-medium text-fd-muted-foreground hover:bg-fd-muted hover:text-fd-foreground"
+              >
+                Reset
+              </button>
+              <button
+                type="button"
+                onClick={onCopy}
+                className="rounded-md bg-[var(--brand-cisco)]/15 px-2 py-1 text-xs font-medium text-[var(--brand-cisco-strong)] hover:bg-[var(--brand-cisco)]/25"
+                aria-live="polite"
+              >
+                {copied ? 'Copied' : 'Copy'}
+              </button>
+            </div>
+          </div>
+          <pre className="m-0 overflow-x-auto whitespace-pre p-4 font-mono text-[12.5px] leading-6 text-fd-foreground">
+            {script}
+          </pre>
+        </div>
+
+        <div className="rounded-xl border border-fd-border bg-fd-card p-4">
+          <h4 className="mb-2 text-sm font-semibold text-fd-foreground">
+            Notes & validation
+          </h4>
+          {built.warnings.length === 0 ? (
+            <p className="text-sm text-fd-muted-foreground">
+              No warnings. The command above should run cleanly with the
+              connector and flags selected.
+            </p>
+          ) : (
+            <ul className="space-y-2 text-sm">
+              {built.warnings.map((w, i) => (
+                <li
+                  key={i}
+                  className="flex gap-2 rounded-md border border-[var(--brand-warn)]/40 bg-[var(--brand-warn)]/10 px-3 py-2 text-fd-foreground"
+                >
+                  <span aria-hidden className="text-[var(--brand-warn)]">
+                    ⚠
+                  </span>
+                  <span>{w}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {selected && (
+          <div className="rounded-xl border border-fd-border bg-fd-card p-4">
+            <h4 className="mb-2 text-sm font-semibold text-fd-foreground">
+              {selected.label} capabilities
+            </h4>
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+              <Capability label="Family">{selected.family}</Capability>
+              <Capability label="Scope">{selected.hooks.scope}</Capability>
+              <Capability label="Tool inspection">{selected.toolInspection}</Capability>
+              <Capability label="Subprocess policy">{selected.subprocessPolicy}</Capability>
+              <Capability label="Native ask">
+                {selected.hooks.canAskNative ? 'yes' : 'no — downgrades to confirm'}
+              </Capability>
+              <Capability label="Fail-closed">
+                {selected.hooks.supportsFailClosed ? 'supported' : 'not supported'}
+              </Capability>
+            </dl>
+            <p className="mt-3 text-xs text-fd-muted-foreground">
+              See{' '}
+              <a
+                href={`/docs/connectors/${selected.id}`}
+                className="text-[var(--brand-cisco-strong)] hover:underline"
+              >
+                /docs/connectors/{selected.id}
+              </a>{' '}
+              for the full per-connector guide.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-xl border border-fd-border bg-fd-card p-4">
+      <h3 className="text-sm font-semibold text-fd-foreground">{title}</h3>
+      {subtitle && (
+        <p className="mt-1 text-xs leading-relaxed text-fd-muted-foreground">
+          {subtitle}
+        </p>
+      )}
+      <div className="mt-3">{children}</div>
+    </section>
+  );
+}
+
+function ConnectorOption({
+  row,
+  selected,
+  onSelect,
+}: {
+  row: ConnectorRow;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      className={[
+        'flex flex-col items-start gap-1 rounded-lg border px-3 py-2 text-left transition-colors',
+        selected
+          ? 'border-[var(--brand-cisco)] bg-[var(--brand-cisco)]/10'
+          : 'border-fd-border bg-fd-card hover:border-[var(--brand-cisco)]/40 hover:bg-fd-muted/40',
+      ].join(' ')}
+    >
+      <div className="flex w-full items-center justify-between gap-2">
+        <span className="text-sm font-medium text-fd-foreground">{row.label}</span>
+        <span
+          className={
+            row.family === 'proxy'
+              ? 'rounded-full bg-[var(--brand-cisco)]/15 px-2 py-0.5 text-[10px] font-medium text-[var(--brand-cisco-strong)]'
+              : 'rounded-full bg-fd-muted px-2 py-0.5 text-[10px] font-medium text-fd-muted-foreground'
+          }
+        >
+          {row.family}
+        </span>
+      </div>
+      <span className="text-[11px] text-fd-muted-foreground">
+        {row.hooks.canAskNative ? 'native ask' : 'downgraded confirm'}
+        {' · '}
+        {row.hooks.supportsFailClosed ? 'fail-closed ok' : 'fail-open only'}
+      </span>
+    </button>
+  );
+}
+
+function SegmentedControl<T extends string>({
+  name,
+  options,
+  value,
+  onChange,
+  disabled,
+}: {
+  name: string;
+  options: Array<{ value: T; label: string; hint?: string }>;
+  value: T;
+  onChange: (v: T) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={name}
+      className={[
+        'inline-flex flex-wrap rounded-lg border border-fd-border bg-fd-background p-1',
+        disabled ? 'opacity-50' : '',
+      ].join(' ')}
+    >
+      {options.map((opt) => {
+        const isActive = opt.value === value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            disabled={disabled}
+            onClick={() => onChange(opt.value)}
+            className={[
+              'rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
+              isActive
+                ? 'bg-[var(--brand-cisco)]/15 text-[var(--brand-cisco-strong)]'
+                : 'text-fd-muted-foreground hover:text-fd-foreground',
+              disabled ? 'cursor-not-allowed' : '',
+            ].join(' ')}
+          >
+            {opt.label}
+            {opt.hint && (
+              <span className="ml-1 text-[10px] text-fd-muted-foreground">
+                {opt.hint}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function Toggle({
+  label,
+  checked,
+  onChange,
+  disabled,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <label
+      className={[
+        'inline-flex items-center gap-2 text-sm',
+        disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
+      ].join(' ')}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        className="size-4 rounded border-fd-border text-[var(--brand-cisco)] focus:ring-[var(--brand-cisco)]"
+      />
+      <span className="text-fd-foreground">{label}</span>
+    </label>
+  );
+}
+
+function SeverityPicker({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: HitlSeverity;
+  onChange: (v: HitlSeverity) => void;
+  disabled?: boolean;
+}) {
+  const opts: Array<{ value: HitlSeverity; label: string }> = [
+    { value: 'critical', label: 'critical' },
+    { value: 'high', label: 'high' },
+    { value: 'medium', label: 'medium' },
+    { value: 'low', label: 'low' },
+  ];
+  return (
+    <label
+      className={[
+        'inline-flex items-center gap-2 text-sm',
+        disabled ? 'opacity-60' : '',
+      ].join(' ')}
+    >
+      <span className="text-xs text-fd-muted-foreground">Min severity</span>
+      <select
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value as HitlSeverity)}
+        className="rounded-md border border-fd-border bg-fd-background px-2 py-1 text-xs text-fd-foreground"
+      >
+        {opts.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  placeholder,
+  inputMode,
+  disabled,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  inputMode?: 'text' | 'numeric' | 'email' | 'url';
+  disabled?: boolean;
+}) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-xs font-medium text-fd-muted-foreground">{label}</span>
+      <input
+        type="text"
+        value={value}
+        disabled={disabled}
+        placeholder={placeholder}
+        inputMode={inputMode}
+        onChange={(e) => onChange(e.target.value)}
+        className={[
+          'rounded-md border border-fd-border bg-fd-background px-2 py-1.5 text-xs text-fd-foreground placeholder:text-fd-muted-foreground/60',
+          'focus:border-[var(--brand-cisco)] focus:outline-none focus:ring-1 focus:ring-[var(--brand-cisco)]',
+          disabled ? 'cursor-not-allowed opacity-60' : '',
+        ].join(' ')}
+      />
+    </label>
+  );
+}
+
+function Capability({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <>
+      <dt className="text-fd-muted-foreground">{label}</dt>
+      <dd className="font-mono text-fd-foreground">{children}</dd>
+    </>
+  );
+}

--- a/docs-site/components/mdx-components.tsx
+++ b/docs-site/components/mdx-components.tsx
@@ -10,6 +10,7 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
 import type { MDXComponents } from 'mdx/types';
 import { Flow, Node, Edge, Sequence, Message } from '@/components/diagram';
 import { CapabilityMatrix, HookEventsList } from '@/components/capability-matrix';
+import { CommandGenerator } from '@/components/command-generator';
 import { Video } from '@/components/video';
 import { TerminalAnimation } from '@/components/terminal-animation';
 
@@ -41,6 +42,7 @@ export const mdxComponents: MDXComponents = {
   Message,
   CapabilityMatrix,
   HookEventsList,
+  CommandGenerator,
   Video,
   TerminalAnimation,
 };

--- a/docs-site/content/docs/command-generator.mdx
+++ b/docs-site/content/docs/command-generator.mdx
@@ -1,0 +1,46 @@
+---
+title: Command generator
+description: Build a non-interactive `defenseclaw setup guardrail` command for any connector. Pick mode, scanner backend, detection strategy, rule pack, HITL behaviour, and every advanced knob; copy the result straight into your terminal or CI pipeline.
+keywords:
+  - DefenseClaw command generator
+  - defenseclaw setup guardrail non-interactive
+  - DefenseClaw CI setup
+  - DefenseClaw HITL command
+  - DefenseClaw LLM judge command
+  - DefenseClaw connector setup generator
+---
+
+`defenseclaw setup guardrail` is fully scriptable — every prompt in the interactive wizard has a flag, with [three documented exceptions](/docs/setup/guardrail#prompt--flag-mapping). The generator below lets you build the exact `--non-interactive` invocation for any connector without leaving the docs. Pick the knobs; the command rewrites itself live; the **Notes & validation** panel flags combinations that won't behave the way you expect (e.g. HITL in observe mode, remote scanner with no Cisco endpoint, connectors that can't fail closed).
+
+<Callout>
+Generated commands are display-only. Nothing on this page runs against your machine — copy the result and paste it into the terminal of whichever host you operate.
+</Callout>
+
+<CommandGenerator />
+
+## What the generator covers
+
+<Cards>
+  <Card title="Connector picker" description="All nine first-class connectors — proxy (OpenClaw, ZeptoClaw) and hooks (Claude Code, Codex, Cursor, Windsurf, Gemini CLI, GitHub Copilot CLI, Hermes). Each card surfaces whether the connector supports native ask and fail-closed enforcement so HITL decisions are informed." />
+  <Card title="Mode + scanner backend" description="--mode (observe / action) and --scanner-mode (local / remote / both). Picking remote or both surfaces the Cisco endpoint, API key env var, and timeout fields, and emits a placeholder export so you remember to set the key." />
+  <Card title="Detection strategy + judge" description="--detection-strategy (regex_only / regex_judge / judge_first). Switching off regex_only opens the judge model, judge API base, and judge API key env var inputs and adds the matching export line to the generated script." />
+  <Card title="Rule pack" description="--rule-pack (default / strict / permissive). Locked to action mode so the disabled state matches the CLI semantics." />
+  <Card title="HITL" description="--human-approval + --hilt-min-severity (critical / high / medium / low). Disabled in observe mode. The connector card explains whether the prompt fires natively inside the agent UI or downgrades to a defenseclaw tui confirm." />
+  <Card title="Advanced knobs" description="--port, --block-message, --disable-redaction, --restart / --no-restart, --verify / --no-verify. The disable-redaction toggle emits a prominent warning so you don't ship un-redacted prompts to external sinks by accident." />
+</Cards>
+
+## Conventions the generator follows
+
+1. **`--non-interactive` is always emitted** — the whole point of this page is producing a flag-driven command. Drop the flag if you want the wizard to prompt for anything the generator left blank.
+2. **`defenseclaw setup guardrail` is always the verb.** The hook-only aliases (`defenseclaw setup claude-code`, etc.) only configure observability and accept a much smaller flag surface; the guardrail verb works for all nine connectors and is the path documented for CI.
+3. **Values containing whitespace or shell metacharacters are POSIX-quoted.** Single quotes wrap any token outside the safe alphanumeric + `_./:@-` allow-list, with the standard `'\''` escape for embedded apostrophes. Copy-paste into `bash`, `zsh`, `dash`, or `fish` (interactive mode) without surprises.
+4. **Conflicting choices surface as warnings, not errors.** The generator never refuses to build a command — if you ask for `--human-approval` in observe mode, the flag is omitted (matching CLI behaviour) and a note explains why. Mistakes you should think about live in the **Notes & validation** panel.
+
+## Related
+
+<Cards>
+  <Card title="defenseclaw setup guardrail" href="/docs/setup/guardrail" description="The narrative reference for every flag, including the three interactive-only prompts." />
+  <Card title="HITL" href="/docs/hitl" description="Per-connector native-ask vs downgraded-confirm matrix and the decision flow." />
+  <Card title="Capability matrix" href="/docs/capability-matrix" description="Connector × capability comparison the generator reads from at build time." />
+  <Card title="CLI commands" href="/docs/reference/cli" description="Full CLI surface — first run, setup, audit, scanning, gateway control, status." />
+</Cards>

--- a/docs-site/content/docs/meta.json
+++ b/docs-site/content/docs/meta.json
@@ -2,6 +2,7 @@
   "title": "Documentation",
   "pages": [
     "index",
+    "command-generator",
     "---Get Started---",
     "get-started",
     "---Setup---",

--- a/docs-site/content/docs/reference/index.mdx
+++ b/docs-site/content/docs/reference/index.mdx
@@ -12,6 +12,7 @@ The narrative docs live elsewhere — these pages are the lookup tables you reac
 
 <Cards>
   <Card title="CLI commands" href="/docs/reference/cli" description="Every defenseclaw verb, grouped by what you're trying to do." />
+  <Card title="Command generator" href="/docs/command-generator" description="Interactive builder for a non-interactive defenseclaw setup guardrail invocation. Pick connector, mode, scanner, judge, HITL — copy the command." />
   <Card title="Gateway API" href="/docs/reference/gateway-api" description="The HTTP surface defenseclaw-gateway exposes. Used by connectors, hooks, and the CLI." />
   <Card title="Configuration" href="/docs/reference/configuration" description="config.yaml schema, environment variables, and the on-disk layout." />
 </Cards>

--- a/docs-site/content/docs/setup/guardrail/index.mdx
+++ b/docs-site/content/docs/setup/guardrail/index.mdx
@@ -106,6 +106,10 @@ defenseclaw setup guardrail \
 
 Pass `--non-interactive` (or `--accept-defaults`) to skip every prompt; missing flags fall back to the same defaults the wizard would have offered. The judge stays off until you pass `--judge-model` (or pick a strategy that uses it); `--detection-strategy regex_only` here just makes that explicit.
 
+<Callout title="Don't hand-roll the flags">
+The [Command generator](/docs/command-generator) builds a non-interactive `defenseclaw setup guardrail` invocation for any connector with all the knobs below — mode, scanner, judge, HITL, advanced — and surfaces validation warnings inline.
+</Callout>
+
 ## Prompt → flag mapping
 
 Each row corresponds to one prompt in the animation. **Default** shows what pressing Enter selects; **Flag** is the CI-shaped equivalent. Rows tagged **interactive-only** have no direct flag — the Note explains the workaround.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,13 +92,13 @@ default-groups = ["dev"]
 override-dependencies = [
     "rich>=13.7.1,<14.0.0",
     "cryptography>=46.0.7",   # CVE-2026-39892 fixed in 46.0.7
-    "litellm==1.83.7",        # CVE-2026-35029, CVE-2026-35030, GHSA-xqmj-j6mv-4862
-    # litellm 1.83.7 ships exact pins for several transitive deps that
-    # conflict with what cisco-ai-skill-scanner 2.0.8 (and our own pins)
-    # expect. We override to a single compatible version per package —
-    # the newer of the two — and rely on litellm's runtime API surface
-    # being compatible with the bumped versions (verified via Python
-    # tests in CI). CVE-2026-28684 (python-dotenv 1.2.1) is tracked via
+    "litellm==1.83.10",       # CVE-2026-40217 fixed in 1.83.10 (also covers CVE-2026-35029, CVE-2026-35030, GHSA-xqmj-j6mv-4862 fixed in earlier 1.83.x)
+    # litellm pins exact transitive versions that conflict with what
+    # cisco-ai-skill-scanner 2.0.8 (and our own pins) expect. We
+    # override to a single compatible version per package — the newer
+    # of the two — and rely on litellm's runtime API surface being
+    # compatible with the bumped versions (verified via Python tests
+    # in CI). CVE-2026-28684 (python-dotenv 1.2.1) is tracked via
     # pip-audit's ignore list in ci.yml.
     "python-dotenv==1.2.1",
     "openai==2.30.0",
@@ -106,6 +106,11 @@ override-dependencies = [
     "importlib-metadata>=8.7.1",
     "jsonschema>=4.26.0",
     "python-multipart>=0.0.27", # CVE-2026-42561 fixed in 0.0.27
+    "urllib3>=2.7.0",           # CVE-2026-44431, CVE-2026-44432 fixed in 2.7.0
+    # aiohttp 3.13.4 fixes a batch of HTTP-parser CVEs (CVE-2026-22815,
+    # CVE-2026-34513..34520, CVE-2026-34525). litellm 1.83.10's
+    # transitive pin floats aiohttp downward without this override.
+    "aiohttp>=3.13.4",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -14,15 +14,17 @@ resolution-markers = [
 
 [manifest]
 overrides = [
+    { name = "aiohttp", specifier = ">=3.13.4" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "importlib-metadata", specifier = ">=8.7.1" },
     { name = "jsonschema", specifier = ">=4.26.0" },
-    { name = "litellm", specifier = "==1.83.7" },
+    { name = "litellm", specifier = "==1.83.10" },
     { name = "openai", specifier = "==2.30.0" },
     { name = "python-dotenv", specifier = "==1.2.1" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "rich", specifier = ">=13.7.1,<14.0.0" },
+    { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
 [[package]]
@@ -1361,7 +1363,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.7"
+version = "1.83.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1377,9 +1379,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/2b/b58bf6bbcbc3d0e55d0a84fdf9128e5b1436517f46fce89b1cd8948ebb81/litellm-1.83.7.tar.gz", hash = "sha256:e2f2cb99df2e2b2eab63f1354faa45c88dd7c8d40c18eb648afb1b349c689633", size = 17791694, upload-time = "2026-04-13T17:35:01.606Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/16/fc51935e406887079f0d7c20427b9a15b9fc1d558e68b4e7072331b70db4/litellm-1.83.10.tar.gz", hash = "sha256:d54eaa98f93a1eb02decf593dbb525fa1ddd4cf03686c1d5c7bb69c2a9ba2a41", size = 14726546, upload-time = "2026-04-19T02:36:28.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/80/caeb4cdcad96451ba83ad3ba2a9da08b1e1a915fa845c489f56ea044488b/litellm-1.83.7-py3-none-any.whl", hash = "sha256:5784a1d9a9a4a8acd6ca1e347003a5e2e1b3c749b4d41e7da4904577adade111", size = 16069807, upload-time = "2026-04-13T17:34:58.36Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/58/8dd69d5b1ab11f206a9c9f21b6fd191bcdd4fb3ed90b8efbf3a1291fd47c/litellm-1.83.10-py3-none-any.whl", hash = "sha256:55203a7b5551efec8f2fccde29ee045ba057e768591e0b6b9fe1d12f00685ff8", size = 16334780, upload-time = "2026-04-19T02:36:25.274Z" },
 ]
 
 [[package]]
@@ -3175,11 +3177,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- New `/docs/command-generator` page with an interactive widget that builds a `defenseclaw setup guardrail --non-interactive` invocation for any of the nine connectors. Live preview + copy button + reset.
- Every wizard prompt exposed as a control: connector, mode, scanner backend (local/remote/both with Cisco endpoint/key/timeout), detection strategy (regex_only/regex_judge/judge_first) with judge model/base/api-key-env, rule pack, HITL with min-severity, advanced port/block-message/disable-redaction/restart/verify.
- Connector metadata is read from `data/capability-matrix.json`, so the per-connector cards stay in lockstep with the rest of the docs (HITL native ask vs downgraded confirm, fail-closed support, hilt notes).
- A **Notes & validation** panel surfaces conflicts inline instead of failing silently — HITL in observe mode, remote scanner with no Cisco endpoint, connectors that lack fail-closed support, missing judge model when the judge strategy is on, redaction disabled.
- All operator-supplied strings are POSIX-quoted via a conservative alphanumeric + `_./:@-` allow-list with the standard `'\''` escape, so generated commands paste safely into `bash`, `zsh`, `dash`, or `fish`.
- Promoted to the **top of the docs sidebar** (right under the landing page index, above the Get Started section) so operators reach for it before hand-rolling flags. Cross-links added from `/docs/setup/guardrail` (Callout under "Same setup, no prompts") and `/docs/reference` (Card on the index).

### File map

- New: `docs-site/components/command-generator.tsx` (client component, ~570 lines, reads `data/capability-matrix.json`)
- New: `docs-site/content/docs/command-generator.mdx` (the page that mounts `<CommandGenerator />`)
- Edited: `docs-site/components/mdx-components.tsx` — register `CommandGenerator` for MDX
- Edited: `docs-site/content/docs/meta.json` — insert `command-generator` right after `index`
- Edited: `docs-site/content/docs/reference/index.mdx` — Card cross-link
- Edited: `docs-site/content/docs/setup/guardrail/index.mdx` — Callout under "Same setup, no prompts"

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx next build` — 109 static pages, page exported to `out/docs/command-generator/index.html`
- [x] `scripts/build-page-markdown.ts` — 50 llms.md files generated
- [x] `scripts/check-diagram-widths.ts` — 24 diagrams scanned
- [x] `scripts/validate-links.ts` — 0 errors across the site
- [x] `npm run dev` — `/docs/command-generator/` returns HTTP 200, old `/docs/reference/command-generator/` returns HTTP 404 (correctly gone)
- [ ] Manual smoke: pick Cursor → action mode → enable HITL → confirm notes panel says "native PreToolUse ask"
- [ ] Manual smoke: switch to Windsurf → confirm notes flip to "no native ask, downgrades to defenseclaw tui" and "does not support fail-closed"
- [ ] Manual smoke: detection strategy `regex_judge` → confirm judge fields appear + `export DEFENSECLAW_LLM_KEY=…` prepended
- [ ] Manual smoke: scanner `both` with empty Cisco endpoint → confirm warning fires
- [ ] Manual smoke: Advanced → Disable redaction → confirm prominent warning lights up