### PR TITLE
feat(observability): add Splunk O11y dashboards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -636,6 +636,7 @@ _bundle-data:
 	@rm -rf cli/defenseclaw/_data/policies/guardrail/default
 	@rm -rf cli/defenseclaw/_data/policies/guardrail/strict
 	@rm -rf cli/defenseclaw/_data/policies/guardrail/permissive
+	@rm -rf cli/defenseclaw/_data/splunk_o11y_dashboards
 	cp policies/rego/*.rego cli/defenseclaw/_data/policies/rego/
 	rm -f cli/defenseclaw/_data/policies/rego/*_test.rego
 	cp policies/rego/data.json cli/defenseclaw/_data/policies/rego/
@@ -657,6 +658,7 @@ _bundle-data:
 	@# so dashboard / dashcfg edits propagate without restarting the obs stack.
 	rsync -a --delete --inplace bundles/splunk_local_bridge/        cli/defenseclaw/_data/splunk_local_bridge/
 	rsync -a --delete --inplace bundles/local_observability_stack/  cli/defenseclaw/_data/local_observability_stack/
+	cp -r bundles/splunk_o11y_dashboards cli/defenseclaw/_data/
 	cp -r policies/openshell cli/defenseclaw/_data/policies/openshell
 
 dist-gateway:

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ For Splunk Observability Cloud, use the dashboard bundle at
 ```bash
 defenseclaw setup splunk dashboards apply \
   --api-url <api-endpoint> \
-  --auth-token <api-access-token> \
+  --o11y-api-token <api-access-token> \
   --with-detectors \
   --enable-detectors \
   --yes

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ For Splunk Observability Cloud, use the dashboard bundle at
 [bundles/splunk_o11y_dashboards/README.md](bundles/splunk_o11y_dashboards/README.md):
 
 ```bash
-defenseclaw setup splunk-o11y-dashboards apply \
+defenseclaw setup splunk dashboards apply \
   --api-url <api-endpoint> \
   --auth-token <api-access-token> \
   --with-detectors \

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ DefenseClaw combines a Python operator CLI, a Go gateway sidecar, and an OpenCla
 - **CodeGuard** - built-in static checks for secrets, dangerous execution, unsafe deserialization, weak crypto, injection patterns, and risky file access.
 - **OpenShell sandbox support** - Linux sandbox setup with network, filesystem, syscall, and policy controls.
 - **Registries** - ingest external skill / MCP catalogs (corporate HTTPS YAML, [smithery.ai](https://smithery.ai/), [skills.sh](https://skills.sh/), git, ClawHub) with SSRF guards, scanner-driven verdicts, and auto-promotion into asset policy. See [docs/REGISTRIES.md](docs/REGISTRIES.md).
-- **Audit and observability** - SQLite audit store, JSONL gateway logs, OTLP export, Splunk HEC, webhooks, and local Grafana/Splunk bundles.
+- **Audit and observability** - SQLite audit store, JSONL gateway logs, OTLP export, Splunk HEC, webhooks, Splunk Observability and local Grafana/Splunk bundles.
 - **Operator UX** - a CLI and TUI for setup, health checks, alerts, block/allow lists, scanner results, and policy workflows.
 
 ---
@@ -71,6 +71,7 @@ High-risk deployments should pair DefenseClaw with human review, least-privilege
 | [Sandbox](docs/SANDBOX.md) | OpenShell sandbox setup, architecture, monitoring, and debugging |
 | [Observability](docs/OBSERVABILITY.md) | Audit sinks, OTLP, Splunk, Grafana, and webhook notifications |
 | [Splunk App](docs/SPLUNK_APP.md) | Local Splunk app dashboards and investigation flow |
+| [Splunk O11y Dashboards](bundles/splunk_o11y_dashboards/README.md) | Splunk Observability Cloud dashboards and detectors for native OTel metrics |
 | [TUI](docs/TUI.md) | Terminal dashboard panels and navigation |
 | [Config Files](docs/CONFIG_FILES.md) | Config locations, environment variables, and policy files |
 | [Registries](docs/REGISTRIES.md) | External skill / MCP catalog ingestion (clawhub, smithery, skills.sh, http, git, file) |
@@ -201,6 +202,7 @@ DefenseClaw records enforcement and runtime evidence across several channels:
 | Gateway JSONL | Correlated structured runtime events |
 | OTLP | Metrics, logs, and traces to compatible collectors |
 | Splunk HEC | SIEM forwarding and local Splunk app workflows |
+| Splunk O11y dashboards | Native Splunk Observability Cloud dashboards and detectors for DefenseClaw metrics |
 | Webhooks | Slack, PagerDuty, Webex, and generic event notifications |
 | TUI | Operator-facing alerts, health, scans, tools, policy, and setup |
 
@@ -213,6 +215,18 @@ defenseclaw setup local-observability status
 ```
 
 See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) and [docs/SPLUNK_APP.md](docs/SPLUNK_APP.md).
+
+For Splunk Observability Cloud, use the dashboard bundle at
+[bundles/splunk_o11y_dashboards/README.md](bundles/splunk_o11y_dashboards/README.md):
+
+```bash
+defenseclaw setup splunk-o11y-dashboards apply \
+  --api-url <api-endpoint> \
+  --auth-token <api-access-token> \
+  --with-detectors \
+  --enable-detectors \
+  --yes
+```
 
 ---
 

--- a/bundles/splunk_o11y_dashboards/README.md
+++ b/bundles/splunk_o11y_dashboards/README.md
@@ -51,7 +51,7 @@ Preferred DefenseClaw CLI flow:
 The CLI automatically imports matching existing dashboards and detectors when they are already present in O11y, and creates fresh resources when they are not.
 
 ```bash
-defenseclaw setup splunk-o11y-dashboards apply \
+defenseclaw setup splunk dashboards apply \
   --api-url <api-url-endpoint> \
   --auth-token <api-access-token> \
   --yes
@@ -71,7 +71,7 @@ defenseclaw setup splunk-o11y-dashboards apply \
 | `--detector-notification <target>` | Repeatable detector notification target such as `Email,secops@example.com`. |
 
 ```bash
-defenseclaw setup splunk-o11y-dashboards apply \
+defenseclaw setup splunk dashboards apply \
   --api-url <api-url-endpoint> \
   --auth-token <api-access-token> \
   --dashboards-only \
@@ -81,7 +81,7 @@ defenseclaw setup splunk-o11y-dashboards apply \
 Create detectors, left disabled:
 
 ```bash
-defenseclaw setup splunk-o11y-dashboards apply \
+defenseclaw setup splunk dashboards apply \
   --api-url <api-url-endpoint> \
   --auth-token <api-access-token> \
   --with-detectors \
@@ -91,7 +91,7 @@ defenseclaw setup splunk-o11y-dashboards apply \
 Create detectors enabled:
 
 ```bash
-defenseclaw setup splunk-o11y-dashboards apply \
+defenseclaw setup splunk dashboards apply \
   --api-url <api-url-endpoint> \
   --auth-token <api-access-token> \
   --with-detectors \

--- a/bundles/splunk_o11y_dashboards/README.md
+++ b/bundles/splunk_o11y_dashboards/README.md
@@ -53,7 +53,7 @@ The CLI automatically imports matching existing dashboards and detectors when th
 ```bash
 defenseclaw setup splunk dashboards apply \
   --api-url <api-url-endpoint> \
-  --auth-token <api-access-token> \
+  --o11y-api-token <api-access-token> \
   --yes
 ```
 
@@ -63,7 +63,7 @@ defenseclaw setup splunk dashboards apply \
 | Flag | Purpose |
 |---|---|
 | `--api-url <url>` | Splunk Observability Cloud API URL|
-| `--auth-token <token>` | Splunk O11y API access token. |
+| `--o11y-api-token <token>` | Splunk O11y API access token. |
 | `--with-detectors` | Create detectors along with dashboards. Omit this flag for dashboards only. |
 | `--enable-detectors` | Create detectors enabled instead of disabled. This only matters when `--with-detectors` is set. |
 | `--dashboards-only` | Explicitly skip detectors. This is the default when `--with-detectors` is not provided. |
@@ -73,7 +73,7 @@ defenseclaw setup splunk dashboards apply \
 ```bash
 defenseclaw setup splunk dashboards apply \
   --api-url <api-url-endpoint> \
-  --auth-token <api-access-token> \
+  --o11y-api-token <api-access-token> \
   --dashboards-only \
   --yes
 ```
@@ -83,7 +83,7 @@ Create detectors, left disabled:
 ```bash
 defenseclaw setup splunk dashboards apply \
   --api-url <api-url-endpoint> \
-  --auth-token <api-access-token> \
+  --o11y-api-token <api-access-token> \
   --with-detectors \
   --yes
 ```
@@ -93,7 +93,7 @@ Create detectors enabled:
 ```bash
 defenseclaw setup splunk dashboards apply \
   --api-url <api-url-endpoint> \
-  --auth-token <api-access-token> \
+  --o11y-api-token <api-access-token> \
   --with-detectors \
   --enable-detectors \
   --yes

--- a/bundles/splunk_o11y_dashboards/README.md
+++ b/bundles/splunk_o11y_dashboards/README.md
@@ -1,0 +1,99 @@
+# DefenseClaw Splunk Observability Dashboards
+
+This bundle creates Splunk Observability Cloud dashboards for the native OTel
+metrics emitted by DefenseClaw.
+
+## Dashboards
+
+The Terraform bundle creates one dashboard group (`DefenseClaw O11y`) and seven
+dashboards:
+
+| Dashboard | Purpose |
+|---|---|
+| `Executive Agent Watch` | Landing view for verdicts, blocks, guardrails, inspections, connector ingress, GenAI usage, and error signals. |
+| `Guardrail and Inspection` | O11y-native equivalent of the exported guardrail dashboard: guardrail evaluations, inspection actions, tool/severity breakdowns, audit events, and latency. |
+| `Connector and OTel Ingest` | OTLP ingest health, connector hook telemetry, Codex notify, normalized LLM events, GenAI tokens, and LLM operation duration. |
+| `DefenseClaw AI Agents Token Economics` | GenAI token usage, estimated model cost, per-agent token breakdowns, and agent token inventory. |
+| `Security and Policy` | Gateway verdicts, policy decisions, findings, egress decisions, alerts, judge latency/errors, cache behavior, and external security integration latency. |
+| `Runtime and Reliability` | Gateway errors, schema violations, HTTP traffic, streams, audit sinks, webhooks, runtime gauges, SLO latency, SQLite health, exporter health, and queues. |
+| `Scanners and Findings` | Scanner throughput, scanner latency, scan errors, findings by severity/rule/scanner, quarantine actions, and scanner queue depth. |
+
+## Detectors
+
+The Terraform bundle also creates Splunk Observability detectors based on the
+local Prometheus alert rules in
+`bundles/local_observability_stack/prometheus/rules/alerts.yml`.
+
+Examples:
+
+| Prometheus source | Splunk O11y detector equivalent |
+|---|---|
+| `service:defenseclaw_gateway_block_ratio:5m` | SignalFlow ratio of `defenseclaw.gateway.verdicts{verdict.action=block}` to all verdicts. |
+| `service:defenseclaw_http_requests_5xx_ratio:5m` | SignalFlow ratio of `defenseclaw.http.request.count{http.status_code=5*}` to all HTTP requests. |
+| `slo:defenseclaw_block_latency:ratio_5m` | Detector on `defenseclaw.slo.block.latency` p95 crossing the 2s SLO threshold. |
+| `connector:defenseclaw_otel_ingest_malformed:ratio_5m` | SignalFlow ratio of malformed OTLP requests to total OTLP requests by source/signal. |
+| `connector:defenseclaw_otel_ingest_silence:seconds` | Splunk detector that fires when `defenseclaw.otel.ingest.last_seen_ts` stops reporting. |
+
+The detector set covers:
+
+- correctness: schema violations, gateway error spikes, recovered panics
+- SLOs: block latency and TUI refresh latency
+- telemetry pipeline: exporter silence/errors, audit sink failures, sink circuit state, sink drop ratio
+- security: block-rate spike, judge error rate, webhook failure rate
+- traffic: HTTP 5xx ratio, auth failures, rate-limit breaches
+- runtime: goroutine leak, SQLite busy retries, config load errors
+- connectors: silent connector telemetry and malformed OTLP payload ratio
+
+## Apply
+
+Preferred DefenseClaw CLI flow:
+
+```bash
+defenseclaw setup splunk-o11y-dashboards apply \
+  --api-url <api-url-endpoint> \
+  --auth-token <api-access-token> \
+  --yes
+```
+
+
+### CLI flags
+
+| Flag | Purpose |
+|---|---|
+| `--api-url <url>` | Splunk Observability Cloud API URL|
+| `--auth-token <token>` | Splunk O11y API access token. |
+| `--with-detectors` | Create detectors along with dashboards. Omit this flag for dashboards only. |
+| `--enable-detectors` | Create detectors enabled instead of disabled. This only matters when `--with-detectors` is set. |
+| `--dashboards-only` | Explicitly skip detectors. This is the default when `--with-detectors` is not provided. |
+| `--name-prefix <label>` | Prefix dashboard and detector names for smoke tests or disposable orgs. |
+| `--detector-notification <target>` | Repeatable detector notification target such as `Email,secops@example.com`. |
+
+```bash
+defenseclaw setup splunk-o11y-dashboards apply \
+  --api-url <api-url-endpoint> \
+  --auth-token <api-access-token> \
+  --name-prefix "Test" \
+  --dashboards-only \
+  --yes
+```
+
+Create detectors, left disabled:
+
+```bash
+defenseclaw setup splunk-o11y-dashboards apply \
+  --api-url <api-url-endpoint> \
+  --auth-token <api-access-token> \
+  --with-detectors \
+  --yes
+```
+
+Create detectors enabled:
+
+```bash
+defenseclaw setup splunk-o11y-dashboards apply \
+  --api-url <api-url-endpoint> \
+  --auth-token <api-access-token> \
+  --with-detectors \
+  --enable-detectors \
+  --yes
+```

--- a/bundles/splunk_o11y_dashboards/README.md
+++ b/bundles/splunk_o11y_dashboards/README.md
@@ -48,7 +48,7 @@ The detector set covers:
 
 Preferred DefenseClaw CLI flow:
 
-The CLI automatically imports matching existing dashboards, charts, and detectors when they are already present in O11y, and creates fresh resources when they are not.
+The CLI automatically imports matching existing dashboards and detectors when they are already present in O11y, and creates fresh resources when they are not.
 
 ```bash
 defenseclaw setup splunk-o11y-dashboards apply \

--- a/bundles/splunk_o11y_dashboards/README.md
+++ b/bundles/splunk_o11y_dashboards/README.md
@@ -48,6 +48,8 @@ The detector set covers:
 
 Preferred DefenseClaw CLI flow:
 
+The CLI automatically imports matching existing dashboards, charts, and detectors when they are already present in O11y, and creates fresh resources when they are not.
+
 ```bash
 defenseclaw setup splunk-o11y-dashboards apply \
   --api-url <api-url-endpoint> \
@@ -72,7 +74,6 @@ defenseclaw setup splunk-o11y-dashboards apply \
 defenseclaw setup splunk-o11y-dashboards apply \
   --api-url <api-url-endpoint> \
   --auth-token <api-access-token> \
-  --name-prefix "Test" \
   --dashboards-only \
   --yes
 ```

--- a/bundles/splunk_o11y_dashboards/terraform/detectors.tf
+++ b/bundles/splunk_o11y_dashboards/terraform/detectors.tf
@@ -1,0 +1,310 @@
+variable "create_detectors" {
+  description = "Whether to create Splunk Observability detectors alongside the dashboards."
+  type        = bool
+  default     = true
+}
+
+variable "detectors_disabled" {
+  description = "Create detector rules in a disabled state. Useful for dry-run rollout into an existing org."
+  type        = bool
+  default     = false
+}
+
+variable "detector_notifications" {
+  description = "Notification targets for every detector rule, for example [\"Email,secops@example.com\"] or [\"Team,teamId\"]. Empty means detectors create O11y alerts/events without external notifications."
+  type        = list(string)
+  default     = []
+}
+
+locals {
+  detectors = {
+    schema_violations = {
+      name             = "DefenseClaw - Schema violations"
+      severity         = "Critical"
+      detect_label     = "DefenseClawSchemaViolations"
+      description      = "gateway.jsonl events are being dropped for schema violations."
+      rule_description = "Runtime JSON schema validation is rejecting gateway events. Open Runtime and Reliability -> Schema violations by event type and code."
+      tags             = ["correctness", "gateway"]
+      program          = <<-EOT
+        A = data('defenseclaw.schema.violations', rollup='rate').sum().scale(60).publish(label='Schema violations / min')
+        detect(when(A > 0, '2m')).publish('DefenseClawSchemaViolations')
+      EOT
+    }
+    gateway_errors_spike = {
+      name             = "DefenseClaw - Gateway errors spike"
+      severity         = "Warning"
+      detect_label     = "DefenseClawGatewayErrorsSpike"
+      description      = "Gateway error rate is above 30/min for 5 minutes."
+      rule_description = "Structured gateway errors are sustained. Open Runtime and Reliability -> Gateway errors by subsystem and code."
+      tags             = ["correctness", "gateway"]
+      program          = <<-EOT
+        A = data('defenseclaw.gateway.errors', rollup='rate').sum().scale(60).publish(label='Gateway errors / min')
+        detect(when(A > 30, '5m')).publish('DefenseClawGatewayErrorsSpike')
+      EOT
+    }
+    panic = {
+      name             = "DefenseClaw - Panic recovered"
+      severity         = "Critical"
+      detect_label     = "DefenseClawPanic"
+      description      = "A DefenseClaw subsystem panic was recovered."
+      rule_description = "RecordPanic fired. Inspect Runtime and Reliability plus logs for the panic source."
+      tags             = ["correctness", "runtime"]
+      program          = <<-EOT
+        A = data('defenseclaw.panics.total', rollup='rate').sum().scale(60).publish(label='Panics / min')
+        detect(when(A > 0)).publish('DefenseClawPanic')
+      EOT
+    }
+    block_slo_breach = {
+      name             = "DefenseClaw - Block SLO p95 breach"
+      severity         = "Critical"
+      detect_label     = "DefenseClawBlockSLOBreach"
+      description      = "Admission/block p95 latency is above 2s for 10 minutes."
+      rule_description = "Admission-block decisions are exceeding the 2s latency target. Open Runtime and Reliability -> Block SLO latency p95."
+      tags             = ["slo", "runtime"]
+      program          = <<-EOT
+        A = histogram('defenseclaw.slo.block.latency').percentile(pct=95).publish(label='p95 block SLO ms')
+        detect(when(A > 2000, '10m')).publish('DefenseClawBlockSLOBreach')
+      EOT
+    }
+    tui_refresh_slo_breach = {
+      name             = "DefenseClaw - TUI refresh SLO p95 breach"
+      severity         = "Warning"
+      detect_label     = "DefenseClawTUIRefreshSLOBreach"
+      description      = "TUI refresh p95 latency is above 5s for 15 minutes."
+      rule_description = "TUI dashboards are refreshing slower than the 5s target. Open Runtime and Reliability -> TUI refresh latency p95."
+      tags             = ["slo", "runtime"]
+      program          = <<-EOT
+        A = histogram('defenseclaw.slo.tui.refresh').percentile(pct=95).publish(label='p95 TUI refresh ms')
+        detect(when(A > 5000, '15m')).publish('DefenseClawTUIRefreshSLOBreach')
+      EOT
+    }
+    otlp_exporter_silent = {
+      name             = "DefenseClaw - OTLP exporter silent"
+      severity         = "Critical"
+      detect_label     = "DefenseClawOTLPExporterStalled"
+      description      = "OTLP exporter health stopped reporting for 5 minutes."
+      rule_description = "Observability may be blind because exporter health is no longer reporting. Check OTel Collector and network reachability."
+      tags             = ["pipeline", "telemetry"]
+      program          = <<-EOT
+        A = data('defenseclaw.telemetry.exporter.last_export_ts', rollup='latest').max(by=['exporter']).publish(label='Last export timestamp')
+        detect(when(A is None, '5m')).publish('DefenseClawOTLPExporterStalled')
+      EOT
+    }
+    otlp_exporter_errors = {
+      name             = "DefenseClaw - OTLP exporter errors"
+      severity         = "Warning"
+      detect_label     = "DefenseClawOTLPExporterErrors"
+      description      = "OTLP exporter errors are above 6/min for 10 minutes."
+      rule_description = "Exporter errors are sustained; spans, metrics, or logs may be dropped. Open Runtime and Reliability -> Exporter errors by signal."
+      tags             = ["pipeline", "telemetry"]
+      program          = <<-EOT
+        A = data('defenseclaw.telemetry.exporter.errors', rollup='rate').sum().scale(60).publish(label='Exporter errors / min')
+        detect(when(A > 6, '10m')).publish('DefenseClawOTLPExporterErrors')
+      EOT
+    }
+    audit_sink_failures = {
+      name             = "DefenseClaw - Audit sink failures"
+      severity         = "Critical"
+      detect_label     = "DefenseClawAuditSinkFailures"
+      description      = "A configured audit sink is failing above 6/min for 10 minutes."
+      rule_description = "Compliance downstreams may be missing events. Open Runtime and Reliability -> Sink batches delivered vs dropped."
+      tags             = ["pipeline", "audit"]
+      program          = <<-EOT
+        A = data('defenseclaw.audit.sink.failures', rollup='rate').sum(by=['sink.kind', 'sink.name']).scale(60).publish(label='Sink failures / min')
+        detect(when(A > 6, '10m')).publish('DefenseClawAuditSinkFailures')
+      EOT
+    }
+    audit_sink_circuit_open = {
+      name             = "DefenseClaw - Audit sink circuit open"
+      severity         = "Warning"
+      detect_label     = "DefenseClawAuditSinkCircuitOpen"
+      description      = "An audit sink circuit breaker is non-closed for 5 minutes."
+      rule_description = "A sink circuit is open or half-open. Open Runtime and Reliability -> Sink queue and circuit state."
+      tags             = ["pipeline", "audit"]
+      program          = <<-EOT
+        A = data('defenseclaw.audit.sink.circuit.state', rollup='latest').max(by=['sink.kind', 'sink.name']).publish(label='Circuit state')
+        detect(when(A > 0.5, '5m')).publish('DefenseClawAuditSinkCircuitOpen')
+      EOT
+    }
+    audit_sink_drop_ratio = {
+      name             = "DefenseClaw - Audit sink drop ratio"
+      severity         = "Warning"
+      detect_label     = "DefenseClawAuditSinkDropRatio"
+      description      = "Audit sink dropped-batch ratio is above 10% for 10 minutes."
+      rule_description = "Dropped audit sink batches are high relative to total sink traffic. Open Runtime and Reliability -> Sink batches delivered vs dropped."
+      tags             = ["pipeline", "audit"]
+      program          = <<-EOT
+        D = data('defenseclaw.audit.sink.batches.dropped', rollup='rate').sum(by=['sink']).publish(label='Dropped batches / sec')
+        T = (data('defenseclaw.audit.sink.batches.delivered', rollup='rate').sum(by=['sink']) + data('defenseclaw.audit.sink.batches.dropped', rollup='rate').sum(by=['sink'])).publish(label='Total batches / sec')
+        R = (D / T).publish(label='Drop ratio')
+        detect(when(R > 0.10, '10m')).publish('DefenseClawAuditSinkDropRatio')
+      EOT
+    }
+    block_rate_spike = {
+      name             = "DefenseClaw - Block rate spike"
+      severity         = "Warning"
+      detect_label     = "DefenseClawBlockRateSpike"
+      description      = "More than 25% of gateway verdicts are blocks for 10 minutes."
+      rule_description = "Either a real attack is in progress or a recent policy/scanner change is producing false positives. Open Security and Policy -> Verdict breakdown."
+      tags             = ["security", "guardrail"]
+      program          = <<-EOT
+        B = data('defenseclaw.gateway.verdicts', filter=filter('verdict.action', 'block'), rollup='rate').sum().publish(label='Blocks / sec')
+        T = data('defenseclaw.gateway.verdicts', rollup='rate').sum().publish(label='Verdicts / sec')
+        R = (B / T).publish(label='Block ratio')
+        detect(when(R > 0.25, '10m')).publish('DefenseClawBlockRateSpike')
+      EOT
+    }
+    judge_error_rate = {
+      name             = "DefenseClaw - Judge error rate"
+      severity         = "Warning"
+      detect_label     = "DefenseClawJudgeErrorRate"
+      description      = "LLM judge error rate is above 10% for 10 minutes."
+      rule_description = "Guardrail judge quality is degraded and may fall back to heuristics. Open Security and Policy -> Judge errors by reason."
+      tags             = ["security", "guardrail"]
+      program          = <<-EOT
+        E = data('defenseclaw.gateway.judge.errors', rollup='rate').sum().publish(label='Judge errors / sec')
+        T = data('defenseclaw.gateway.judge.invocations', rollup='rate').sum().publish(label='Judge invocations / sec')
+        R = (E / T).publish(label='Judge error ratio')
+        detect(when(R > 0.10, '10m')).publish('DefenseClawJudgeErrorRate')
+      EOT
+    }
+    webhook_failures = {
+      name             = "DefenseClaw - Webhook failures sustained"
+      severity         = "Warning"
+      detect_label     = "DefenseClawWebhookFailuresSustained"
+      description      = "Webhook failures are above 3/min for 15 minutes."
+      rule_description = "Security or incident notification webhooks may be missing events. Open Runtime and Reliability -> Webhook outcomes."
+      tags             = ["security", "webhooks"]
+      program          = <<-EOT
+        A = data('defenseclaw.webhook.dispatches', filter=filter('outcome', 'failed'), rollup='rate').sum(by=['webhook.kind']).scale(60).publish(label='Webhook failures / min')
+        detect(when(A > 3, '15m')).publish('DefenseClawWebhookFailuresSustained')
+      EOT
+    }
+    http_5xx_spike = {
+      name             = "DefenseClaw - HTTP 5xx spike"
+      severity         = "Warning"
+      detect_label     = "DefenseClawHTTP5xxSpike"
+      description      = "Gateway 5xx ratio is above 2% for 10 minutes."
+      rule_description = "The gateway is returning 5xx on more than 2% of requests. Open Runtime and Reliability -> HTTP requests by route and status."
+      tags             = ["traffic", "gateway"]
+      program          = <<-EOT
+        E = data('defenseclaw.http.request.count', filter=filter('http.status_code', '5*'), rollup='rate').sum().publish(label='5xx / sec')
+        T = data('defenseclaw.http.request.count', rollup='rate').sum().publish(label='Requests / sec')
+        R = (E / T).publish(label='5xx ratio')
+        detect(when(R > 0.02, '10m')).publish('DefenseClawHTTP5xxSpike')
+      EOT
+    }
+    http_auth_failures = {
+      name             = "DefenseClaw - HTTP auth failures surge"
+      severity         = "Warning"
+      detect_label     = "DefenseClawHTTPAuthFailuresSurge"
+      description      = "Authentication failures are above 60/min for 10 minutes."
+      rule_description = "This could be bad-credential probing or a deployment regression. Open Runtime and Reliability -> Auth failures by route and reason."
+      tags             = ["traffic", "security"]
+      program          = <<-EOT
+        A = data('defenseclaw.http.auth.failures', rollup='rate').sum().scale(60).publish(label='Auth failures / min')
+        detect(when(A > 60, '10m')).publish('DefenseClawHTTPAuthFailuresSurge')
+      EOT
+    }
+    rate_limit_surge = {
+      name             = "DefenseClaw - Rate-limit surge"
+      severity         = "Warning"
+      detect_label     = "DefenseClawRateLimitSurge"
+      description      = "Rate-limit breaches are above 120/min for 10 minutes."
+      rule_description = "A client is being throttled aggressively. Open Runtime and Reliability -> HTTP surface and queue panels."
+      tags             = ["traffic", "gateway"]
+      program          = <<-EOT
+        A = data('defenseclaw.http.rate_limit.breaches', rollup='rate').sum().scale(60).publish(label='Rate-limit breaches / min')
+        detect(when(A > 120, '10m')).publish('DefenseClawRateLimitSurge')
+      EOT
+    }
+    goroutine_leak = {
+      name             = "DefenseClaw - Goroutine leak"
+      severity         = "Warning"
+      detect_label     = "DefenseClawGoroutineLeak"
+      description      = "Goroutine count is above 10k for 15 minutes."
+      rule_description = "Possible goroutine leak. Open Runtime and Reliability -> Runtime goroutines."
+      tags             = ["runtime"]
+      program          = <<-EOT
+        A = data('defenseclaw.runtime.goroutines', rollup='latest').max().publish(label='Goroutines')
+        detect(when(A > 10000, '15m')).publish('DefenseClawGoroutineLeak')
+      EOT
+    }
+    sqlite_busy_retries = {
+      name             = "DefenseClaw - SQLite busy retries"
+      severity         = "Warning"
+      detect_label     = "DefenseClawSQLiteBusyRetries"
+      description      = "SQLite busy retries are above 60/min for 10 minutes."
+      rule_description = "The audit store is contended and may hurt latency. Open Runtime and Reliability -> SQLite busy retries."
+      tags             = ["runtime", "audit-db"]
+      program          = <<-EOT
+        A = data('defenseclaw.sqlite.busy_retries', rollup='rate').sum().scale(60).publish(label='SQLite busy retries / min')
+        detect(when(A > 60, '10m')).publish('DefenseClawSQLiteBusyRetries')
+      EOT
+    }
+    config_load_errors = {
+      name             = "DefenseClaw - Config load errors"
+      severity         = "Warning"
+      detect_label     = "DefenseClawConfigLoadErrors"
+      description      = "Config reload failures were detected."
+      rule_description = "A recent config reload failed. The previous config is still active, but the operator-facing change did not take effect."
+      tags             = ["runtime", "config"]
+      program          = <<-EOT
+        A = data('defenseclaw.config.load.errors', rollup='rate').sum().scale(60).publish(label='Config load errors / min')
+        detect(when(A > 0)).publish('DefenseClawConfigLoadErrors')
+      EOT
+    }
+    connector_telemetry_silent = {
+      name             = "DefenseClaw - Connector telemetry silent"
+      severity         = "Warning"
+      detect_label     = "DefenseClawConnectorTelemetrySilent"
+      description      = "A previously reporting connector signal stopped reporting for 10 minutes."
+      rule_description = "A connector that was emitting OTLP telemetry is now silent. Open Connector and OTel Ingest and inspect source/signal mix."
+      tags             = ["connectors", "otel"]
+      program          = <<-EOT
+        A = data('defenseclaw.otel.ingest.last_seen_ts', rollup='latest').max(by=['source', 'signal']).publish(label='Connector last seen')
+        detect(when(A is None, '10m')).publish('DefenseClawConnectorTelemetrySilent')
+      EOT
+    }
+    connector_telemetry_malformed = {
+      name             = "DefenseClaw - Connector telemetry malformed"
+      severity         = "Warning"
+      detect_label     = "DefenseClawConnectorTelemetryMalformed"
+      description      = "Malformed connector telemetry ratio is above 10% for 10 minutes."
+      rule_description = "More than 10% of connector OTLP requests are malformed. Open Connector and OTel Ingest -> Malformed OTLP by source and signal."
+      tags             = ["connectors", "otel"]
+      program          = <<-EOT
+        M = data('defenseclaw.otel.ingest.malformed', rollup='rate').sum(by=['source', 'signal']).publish(label='Malformed / sec')
+        T = data('defenseclaw.otel.ingest.requests', rollup='rate').sum(by=['source', 'signal']).publish(label='Requests / sec')
+        R = (M / T).publish(label='Malformed ratio')
+        detect(when(R > 0.10, '10m')).publish('DefenseClawConnectorTelemetryMalformed')
+      EOT
+    }
+  }
+}
+
+resource "signalfx_detector" "detector" {
+  for_each = { for name, detector in local.detectors : name => detector if var.create_detectors }
+
+  name             = "${each.value.name}${local.display_name_suffix}"
+  description      = each.value.description
+  program_text     = trimspace(each.value.program)
+  tags             = concat(["defenseclaw", "otel"], each.value.tags)
+  show_event_lines = true
+  time_range       = 3600
+
+  rule {
+    detect_label          = each.value.detect_label
+    description           = each.value.rule_description
+    severity              = each.value.severity
+    disabled              = var.detectors_disabled
+    notifications         = var.detector_notifications
+    parameterized_body    = each.value.rule_description
+    parameterized_subject = "${each.value.name}${local.display_name_suffix}"
+  }
+}
+
+output "detector_urls" {
+  description = "Created Splunk Observability detector URLs."
+  value       = { for name, detector in signalfx_detector.detector : name => detector.url }
+}

--- a/bundles/splunk_o11y_dashboards/terraform/main.tf
+++ b/bundles/splunk_o11y_dashboards/terraform/main.tf
@@ -1,0 +1,2024 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    signalfx = {
+      source  = "splunk-terraform/signalfx"
+      version = ">= 9.6.0, < 10.0.0"
+    }
+  }
+}
+
+variable "signalfx_auth_token" {
+  description = "Splunk Observability Cloud user API access token. Leave null to use SFX_AUTH_TOKEN."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "signalfx_api_url" {
+  description = "Splunk Observability Cloud API URL. Leave null to use SFX_API_URL."
+  type        = string
+  default     = null
+}
+
+variable "name_prefix" {
+  description = "Optional label used to distinguish dashboard groups, dashboards, and detectors for disposable smoke tests."
+  type        = string
+  default     = ""
+}
+
+provider "signalfx" {
+  auth_token = var.signalfx_auth_token
+  api_url    = var.signalfx_api_url
+}
+
+locals {
+  display_name_prefix = trimspace(var.name_prefix) == "" ? "" : "${trimspace(var.name_prefix)} "
+  display_name_suffix = trimspace(var.name_prefix) == "" ? "" : " (${trimspace(var.name_prefix)})"
+
+  common_dashboard_variables = [
+    { property = "tenant_id", alias = "tenant" },
+    { property = "workspace_id", alias = "workspace" },
+    { property = "host.name", alias = "host" },
+  ]
+
+  dashboard_variables = {
+    executive = concat(local.common_dashboard_variables, [
+      { property = "gen_ai.agent.name", alias = "agent" },
+    ])
+    guardrail_inspection = concat(local.common_dashboard_variables, [
+      { property = "sf_service", alias = "service" },
+      { property = "gen_ai.agent.name", alias = "agent" },
+    ])
+    connector_ingest = concat(local.common_dashboard_variables, [
+      { property = "source", alias = "connector source" },
+      { property = "signal", alias = "otel signal" },
+      { property = "connector", alias = "hook connector" },
+      { property = "gen_ai.agent.name", alias = "agent" },
+    ])
+    security_policy = concat(local.common_dashboard_variables, [
+      { property = "policy.domain", alias = "policy domain" },
+      { property = "verdict.stage", alias = "verdict stage" },
+    ])
+    token_economics = [
+      { property = "deployment.environment", alias = "environment" },
+      { property = "service.name", alias = "service" },
+      { property = "gen_ai.agent.name", alias = "agent" },
+      { property = "gen_ai.request.model", alias = "model" },
+    ]
+    runtime_reliability = concat(local.common_dashboard_variables, [
+      { property = "http.route", alias = "route" },
+      { property = "sink", alias = "batch sink" },
+      { property = "sink.name", alias = "sink name" },
+      { property = "webhook.kind", alias = "webhook kind" },
+    ])
+    scanners_findings = concat(local.common_dashboard_variables, [
+      { property = "scanner", alias = "scanner" },
+      { property = "target_type", alias = "target type" },
+      { property = "severity", alias = "severity" },
+    ])
+  }
+
+  single_value_charts = {
+    executive_verdicts_31d = {
+      name        = "Verdicts"
+      description = "All DefenseClaw gateway verdicts in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.verdicts', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.gateway.verdicts', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Verdicts')
+      EOT
+    }
+    executive_blocks_31d = {
+      name        = "Blocks"
+      description = "Gateway verdicts where verdict.action is block in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.verdicts', filter=filter('verdict.action', 'block'), extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.gateway.verdicts', filter=filter('verdict.action', 'block'), extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Blocks')
+      EOT
+    }
+    executive_guardrail_evaluations_31d = {
+      name        = "Guardrail evals"
+      description = "Guardrail evaluations in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.guardrail.evaluations', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.guardrail.evaluations', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Guardrail evals')
+      EOT
+    }
+    executive_inspect_evaluations_31d = {
+      name        = "Inspections"
+      description = "Tool and message inspection evaluations in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.inspect.evaluations', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.inspect.evaluations', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Inspections')
+      EOT
+    }
+    executive_otel_records_31d = {
+      name        = "OTel records"
+      description = "Leaf records extracted from inbound OTLP logs, metrics, and traces in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.otel.ingest.records', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.otel.ingest.records', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='OTel records')
+      EOT
+    }
+    executive_gateway_errors_31d = {
+      name        = "Gateway errors"
+      description = "Structured gateway errors in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.errors', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.gateway.errors', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Gateway errors')
+      EOT
+    }
+    guardrail_total_evaluations = {
+      name        = "Guardrail evals"
+      description = "Guardrail evaluations in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.guardrail.evaluations', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.guardrail.evaluations', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Guardrail evals')
+      EOT
+    }
+    guardrail_total_inspections = {
+      name        = "Inspections"
+      description = "Tool and message inspection evaluations in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.inspect.evaluations', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.inspect.evaluations', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Inspections')
+      EOT
+    }
+    guardrail_total_blocked_inspections = {
+      name        = "Blocked inspections"
+      description = "Inspection evaluations where action is block in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.inspect.evaluations', filter=filter('action', 'block'), extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.inspect.evaluations', filter=filter('action', 'block'), extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Blocked inspections')
+      EOT
+    }
+    guardrail_total_alert_inspections = {
+      name        = "Alert inspections"
+      description = "Inspection evaluations where action is alert in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.inspect.evaluations', filter=filter('action', 'alert'), extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.inspect.evaluations', filter=filter('action', 'alert'), extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Alert inspections')
+      EOT
+    }
+    guardrail_total_audit_events = {
+      name        = "Audit events"
+      description = "Audit events in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.audit.events.total', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.audit.events.total', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Audit events')
+      EOT
+    }
+    guardrail_total_runtime_alerts = {
+      name        = "Runtime alerts"
+      description = "Runtime alerts in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.alert.count', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.alert.count', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Runtime alerts')
+      EOT
+    }
+    scanner_total_scans = {
+      name        = "Scans"
+      description = "Completed scans in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.scan.count', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.scan.count', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Scans')
+      EOT
+    }
+    scanner_total_findings = {
+      name        = "New findings"
+      description = "New scan findings in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.scan.findings', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.scan.findings', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='New findings')
+      EOT
+    }
+    scanner_total_scan_errors = {
+      name        = "Scan errors"
+      description = "Scanner invocation failures in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.scan.errors', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.scan.errors', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Scan errors')
+      EOT
+    }
+    scanner_open_findings = {
+      name        = "Open finding backlog"
+      description = "Latest open finding count in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.scan.findings.gauge', rollup='latest').sum().publish(label='Open finding backlog')
+      EOT
+    }
+    connector_total_otel_requests = {
+      name        = "OTLP requests"
+      description = "Inbound OTLP-HTTP requests in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.otel.ingest.requests', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.otel.ingest.requests', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='OTLP requests')
+      EOT
+    }
+    connector_total_otel_records = {
+      name        = "OTel records"
+      description = "Leaf records extracted from inbound OTLP batches in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.otel.ingest.records', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.otel.ingest.records', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='OTel records')
+      EOT
+    }
+    connector_total_otel_bytes = {
+      name        = "OTLP bytes"
+      description = "Inbound OTLP payload bytes in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.otel.ingest.bytes', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.otel.ingest.bytes', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='OTLP bytes')
+      EOT
+    }
+    connector_total_codex_notify = {
+      name        = "Codex notify"
+      description = "Codex notify-bridge webhook events in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.codex.notify', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.codex.notify', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Codex notify')
+      EOT
+    }
+    connector_total_hook_invocations = {
+      name        = "Hook invocations"
+      description = "Connector hook invocations in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.connector.hook.invocations', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.connector.hook.invocations', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Hook invocations')
+      EOT
+    }
+    connector_total_llm_events = {
+      name        = "LLM events"
+      description = "Gateway-normalized prompt, response, and tool events in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.events.emitted', filter=filter('event_type', 'llm_prompt', 'llm_response', 'tool_invocation'), extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.gateway.events.emitted', filter=filter('event_type', 'llm_prompt', 'llm_response', 'tool_invocation'), extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='LLM events')
+      EOT
+    }
+    security_total_policy_denies = {
+      name        = "Policy denies"
+      description = "Policy evaluations returning deny, block, blocked, or rejected in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.policy.evaluations', filter=filter('policy.verdict', 'deny', 'block', 'blocked', 'rejected'), extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.policy.evaluations', filter=filter('policy.verdict', 'deny', 'block', 'blocked', 'rejected'), extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Policy denies')
+      EOT
+    }
+    security_total_findings = {
+      name        = "New findings"
+      description = "New scan findings in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.scan.findings', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.scan.findings', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='New findings')
+      EOT
+    }
+    security_total_egress_blocks = {
+      name        = "Egress blocks"
+      description = "Egress events where decision is block in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.egress.events', filter=filter('decision', 'block'), extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.egress.events', filter=filter('decision', 'block'), extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Egress blocks')
+      EOT
+    }
+    security_total_runtime_alerts = {
+      name        = "Runtime alerts"
+      description = "Runtime alerts in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.alert.count', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.alert.count', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Runtime alerts')
+      EOT
+    }
+    security_total_judge_invocations = {
+      name        = "Judge invocations"
+      description = "Gateway judge invocations in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.judge.invocations', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.gateway.judge.invocations', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Judge invocations')
+      EOT
+    }
+    security_total_judge_errors = {
+      name        = "Judge errors"
+      description = "Gateway judge provider, parse, or empty-response errors in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.judge.errors', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.gateway.judge.errors', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Judge errors')
+      EOT
+    }
+    token_records = {
+      name        = "Token records"
+      description = "GenAI token usage observations in the selected time range."
+      program     = <<-EOT
+        A = histogram('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat')).count().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Token records')
+      EOT
+    }
+    token_errors = {
+      name        = "Errors"
+      description = "DefenseClaw gateway errors in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.errors', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.gateway.errors', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Errors')
+      EOT
+    }
+    token_active_agents = {
+      name        = "Active agents"
+      description = "Approximate active agent count from GenAI token metrics in the selected time range."
+      program     = <<-EOT
+        A = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat'), rollup='sum').sum(by=['gen_ai.agent.name']).sum(over=Args.get('ui.dashboard_window', '31d'))
+        B = A.count().publish(label='Agents')
+      EOT
+    }
+    token_total_tokens = {
+      name        = "Tokens"
+      description = "Total GenAI tokens from DefenseClaw GenAI OTel metrics in the selected time range."
+      program     = <<-EOT
+        A = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Tokens')
+      EOT
+    }
+    token_input_tokens = {
+      name        = "Input tokens"
+      description = "Input tokens from gen_ai.client.token.usage in the selected time range."
+      program     = <<-EOT
+        A = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'input'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Input tokens')
+      EOT
+    }
+    token_output_tokens = {
+      name        = "Output tokens"
+      description = "Output tokens from gen_ai.client.token.usage in the selected time range."
+      program     = <<-EOT
+        A = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'output'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Output tokens')
+      EOT
+    }
+    token_estimated_cost = {
+      name        = "Estimated cost"
+      description = "Estimated USD using dashboard-side standard model rates. Cached-input discounts are not applied because token usage is currently split only into input and output."
+      program     = <<-EOT
+        I4O = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'input') and filter('gen_ai.request.model', 'gpt-4o-mini'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00000015).fill(0)
+        O4O = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'output') and filter('gen_ai.request.model', 'gpt-4o-mini'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00000060).fill(0)
+        I41 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'input') and filter('gen_ai.request.model', 'gpt-4.1-mini'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00000040).fill(0)
+        O41 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'output') and filter('gen_ai.request.model', 'gpt-4.1-mini'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00000160).fill(0)
+        I54M = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'input') and filter('gen_ai.request.model', 'gpt-5.4-mini'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00000075).fill(0)
+        O54M = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'output') and filter('gen_ai.request.model', 'gpt-5.4-mini'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00000450).fill(0)
+        I54 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'input') and filter('gen_ai.request.model', 'gpt-5.4'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00000250).fill(0)
+        O54 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'output') and filter('gen_ai.request.model', 'gpt-5.4'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00001500).fill(0)
+        I55 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'input') and filter('gen_ai.request.model', 'gpt-5.5'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00000500).fill(0)
+        O55 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'output') and filter('gen_ai.request.model', 'gpt-5.5'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00003000).fill(0)
+        C = (I4O + O4O + I41 + O41 + I54M + O54M + I54 + O54 + I55 + O55).publish(label='Estimated USD')
+      EOT
+    }
+    token_estimated_input_cost = {
+      name        = "Estimated input cost"
+      description = "Estimated input USD using dashboard-side standard model rates. Cached-input discounts are not applied."
+      program     = <<-EOT
+        I4O = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'input') and filter('gen_ai.request.model', 'gpt-4o-mini'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00000015).fill(0)
+        I41 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'input') and filter('gen_ai.request.model', 'gpt-4.1-mini'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00000040).fill(0)
+        I54M = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'input') and filter('gen_ai.request.model', 'gpt-5.4-mini'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00000075).fill(0)
+        I54 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'input') and filter('gen_ai.request.model', 'gpt-5.4'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00000250).fill(0)
+        I55 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'input') and filter('gen_ai.request.model', 'gpt-5.5'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00000500).fill(0)
+        C = (I4O + I41 + I54M + I54 + I55).publish(label='Input USD')
+      EOT
+    }
+    token_estimated_output_cost = {
+      name        = "Estimated output cost"
+      description = "Estimated output USD using dashboard-side standard model rates."
+      program     = <<-EOT
+        O4O = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'output') and filter('gen_ai.request.model', 'gpt-4o-mini'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00000060).fill(0)
+        O41 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'output') and filter('gen_ai.request.model', 'gpt-4.1-mini'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00000160).fill(0)
+        O54M = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'output') and filter('gen_ai.request.model', 'gpt-5.4-mini'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00000450).fill(0)
+        O54 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'output') and filter('gen_ai.request.model', 'gpt-5.4'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00001500).fill(0)
+        O55 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'output') and filter('gen_ai.request.model', 'gpt-5.5'), rollup='sum').sum().sum(over=Args.get('ui.dashboard_window', '31d')).scale(0.00003000).fill(0)
+        C = (O4O + O41 + O54M + O54 + O55).publish(label='Output USD')
+      EOT
+    }
+    runtime_total_gateway_errors = {
+      name        = "Gateway errors"
+      description = "Structured gateway errors in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.errors', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.gateway.errors', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Gateway errors')
+      EOT
+    }
+    runtime_total_schema_violations = {
+      name        = "Schema violations"
+      description = "Runtime schema validation drops in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.schema.violations', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.schema.violations', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Schema violations')
+      EOT
+    }
+    runtime_total_http_requests = {
+      name        = "HTTP requests"
+      description = "Sidecar API requests in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.http.request.count', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.http.request.count', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='HTTP requests')
+      EOT
+    }
+    runtime_total_auth_failures = {
+      name        = "Auth failures"
+      description = "HTTP auth failures in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.http.auth.failures', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.http.auth.failures', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Auth failures')
+      EOT
+    }
+    runtime_total_exporter_errors = {
+      name        = "Exporter errors"
+      description = "OTLP telemetry exporter errors in the selected time range."
+      program     = <<-EOT
+        A = data('defenseclaw.telemetry.exporter.errors', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.telemetry.exporter.errors', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum().sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Exporter errors')
+      EOT
+    }
+    verdicts_per_min = {
+      name        = "Verdicts / min"
+      description = "All DefenseClaw gateway verdicts per minute."
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.verdicts', rollup='rate').sum().scale(60).publish(label='Verdicts / min')
+      EOT
+    }
+    blocks_per_min = {
+      name        = "Blocks / min"
+      description = "Gateway verdicts where verdict.action is block."
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.verdicts', filter=filter('verdict.action', 'block'), rollup='rate').sum().scale(60).publish(label='Blocks / min')
+      EOT
+    }
+    guardrail_evaluations_per_min = {
+      name        = "Guardrail evals / min"
+      description = "Guardrail evaluations emitted by scanner and action."
+      program     = <<-EOT
+        A = data('defenseclaw.guardrail.evaluations', rollup='rate').sum().scale(60).publish(label='Guardrail evals / min')
+      EOT
+    }
+    inspect_evaluations_per_min = {
+      name        = "Inspections / min"
+      description = "Tool and message inspection evaluations per minute."
+      program     = <<-EOT
+        A = data('defenseclaw.inspect.evaluations', rollup='rate').sum().scale(60).publish(label='Inspections / min')
+      EOT
+    }
+    blocked_inspections_per_min = {
+      name        = "Blocked inspections / min"
+      description = "Inspection evaluations where action is block."
+      program     = <<-EOT
+        A = data('defenseclaw.inspect.evaluations', filter=filter('action', 'block'), rollup='rate').sum().scale(60).publish(label='Blocked inspections / min')
+      EOT
+    }
+    alert_inspections_per_min = {
+      name        = "Alert inspections / min"
+      description = "Inspection evaluations where action is alert."
+      program     = <<-EOT
+        A = data('defenseclaw.inspect.evaluations', filter=filter('action', 'alert'), rollup='rate').sum().scale(60).publish(label='Alert inspections / min')
+      EOT
+    }
+    audit_events_per_min = {
+      name        = "Audit events / min"
+      description = "Audit events persisted per minute."
+      program     = <<-EOT
+        A = data('defenseclaw.audit.events.total', rollup='rate').sum().scale(60).publish(label='Audit events / min')
+      EOT
+    }
+    otel_requests_per_min = {
+      name        = "OTLP requests / min"
+      description = "Inbound OTLP-HTTP requests received by the connector ingest receiver."
+      program     = <<-EOT
+        A = data('defenseclaw.otel.ingest.requests', rollup='rate').sum().scale(60).publish(label='OTLP requests / min')
+      EOT
+    }
+    otel_records_per_min = {
+      name        = "OTel records / min"
+      description = "Leaf records extracted from inbound OTLP logs, metrics, and traces."
+      program     = <<-EOT
+        A = data('defenseclaw.otel.ingest.records', rollup='rate').sum().scale(60).publish(label='OTel records / min')
+      EOT
+    }
+    otel_malformed_per_min = {
+      name        = "Malformed OTLP / min"
+      description = "OTLP-JSON bodies that failed parsing."
+      program     = <<-EOT
+        A = data('defenseclaw.otel.ingest.malformed', rollup='rate').sum().scale(60).publish(label='Malformed OTLP / min')
+      EOT
+    }
+    codex_notify_per_min = {
+      name        = "Codex notify / min"
+      description = "Codex notify-bridge webhook events per minute."
+      program     = <<-EOT
+        A = data('defenseclaw.codex.notify', rollup='rate').sum().scale(60).publish(label='Codex notify / min')
+      EOT
+    }
+    hook_invocations_per_min = {
+      name        = "Hook invocations / min"
+      description = "Connector hook invocations observed by the gateway."
+      program     = <<-EOT
+        A = data('defenseclaw.connector.hook.invocations', rollup='rate').sum().scale(60).publish(label='Hook invocations / min')
+      EOT
+    }
+    llm_events_per_min = {
+      name        = "LLM events / min"
+      description = "Gateway-normalized prompt, response, and tool events."
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.events.emitted', filter=filter('event_type', 'llm_prompt', 'llm_response', 'tool_invocation'), rollup='rate').sum().scale(60).publish(label='LLM events / min')
+      EOT
+    }
+    policy_denies_per_min = {
+      name        = "Policy denies / min"
+      description = "Policy evaluations returning deny, block, blocked, or rejected."
+      program     = <<-EOT
+        A = data('defenseclaw.policy.evaluations', filter=filter('policy.verdict', 'deny', 'block', 'blocked', 'rejected'), rollup='rate').sum().scale(60).publish(label='Policy denies / min')
+      EOT
+    }
+    findings_per_min = {
+      name        = "Findings / min"
+      description = "Scan findings per minute."
+      program     = <<-EOT
+        A = data('defenseclaw.scan.findings', rollup='rate').sum().scale(60).publish(label='Findings / min')
+      EOT
+    }
+    scan_errors_per_min = {
+      name        = "Scan errors / min"
+      description = "Scanner invocation failures per minute."
+      program     = <<-EOT
+        A = data('defenseclaw.scan.errors', rollup='rate').sum().scale(60).publish(label='Scan errors / min')
+      EOT
+    }
+    open_findings = {
+      name        = "Open findings"
+      description = "Current open findings gauge across target types and severities."
+      program     = <<-EOT
+        A = data('defenseclaw.scan.findings.gauge', rollup='latest').sum().publish(label='Open findings')
+      EOT
+    }
+    quarantine_actions_per_min = {
+      name        = "Quarantine actions / min"
+      description = "Quarantine or restore operations per minute."
+      program     = <<-EOT
+        A = data('defenseclaw.quarantine.actions', rollup='rate').sum().scale(60).publish(label='Quarantine actions / min')
+      EOT
+    }
+    egress_blocks_per_min = {
+      name        = "Egress blocks / min"
+      description = "Egress events where decision is block."
+      program     = <<-EOT
+        A = data('defenseclaw.egress.events', filter=filter('decision', 'block'), rollup='rate').sum().scale(60).publish(label='Egress blocks / min')
+      EOT
+    }
+    alerts_per_min = {
+      name        = "Alerts / min"
+      description = "Runtime alert count per minute."
+      program     = <<-EOT
+        A = data('defenseclaw.alert.count', rollup='rate').sum().scale(60).publish(label='Alerts / min')
+      EOT
+    }
+    judge_invocations_per_min = {
+      name        = "Judge invocations / min"
+      description = "Gateway judge invocations per minute."
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.judge.invocations', rollup='rate').sum().scale(60).publish(label='Judge invocations / min')
+      EOT
+    }
+    judge_errors_per_min = {
+      name        = "Judge errors / min"
+      description = "Gateway judge provider, parse, or empty-response errors."
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.judge.errors', rollup='rate').sum().scale(60).publish(label='Judge errors / min')
+      EOT
+    }
+    gateway_errors_per_min = {
+      name        = "Gateway errors / min"
+      description = "Structured gateway errors per minute."
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.errors', rollup='rate').sum().scale(60).publish(label='Gateway errors / min')
+      EOT
+    }
+    schema_violations_per_min = {
+      name        = "Schema violations / min"
+      description = "Gateway events dropped by runtime schema validation."
+      program     = <<-EOT
+        A = data('defenseclaw.schema.violations', rollup='rate').sum().scale(60).publish(label='Schema violations / min')
+      EOT
+    }
+    sink_drops_per_min = {
+      name        = "Sink drops / min"
+      description = "Audit sink batches dropped due to queue or circuit breaker."
+      program     = <<-EOT
+        A = data('defenseclaw.audit.sink.batches.dropped', rollup='rate').sum().scale(60).publish(label='Sink drops / min')
+      EOT
+    }
+    exporter_errors_per_min = {
+      name        = "Exporter errors / min"
+      description = "OTLP telemetry exporter errors per minute."
+      program     = <<-EOT
+        A = data('defenseclaw.telemetry.exporter.errors', rollup='rate').sum().scale(60).publish(label='Exporter errors / min')
+      EOT
+    }
+    panics_1h = {
+      name        = "Panics / hour"
+      description = "Recovered DefenseClaw panics over the current rollup window."
+      program     = <<-EOT
+        A = data('defenseclaw.panics.total', rollup='rate').sum().scale(3600).publish(label='Panics / hour')
+      EOT
+    }
+    auth_failures_per_min = {
+      name        = "Auth failures / min"
+      description = "Sidecar 401/403 responses per minute."
+      program     = <<-EOT
+        A = data('defenseclaw.http.auth.failures', rollup='rate').sum().scale(60).publish(label='Auth failures / min')
+      EOT
+    }
+    rate_limit_breaches_per_min = {
+      name        = "Rate limits / min"
+      description = "Rate-limited HTTP requests per minute."
+      program     = <<-EOT
+        A = data('defenseclaw.http.rate_limit.breaches', rollup='rate').sum().scale(60).publish(label='Rate limits / min')
+      EOT
+    }
+    uptime_seconds = {
+      name        = "Process uptime"
+      description = "DefenseClaw process uptime in seconds."
+      program     = <<-EOT
+        A = data('defenseclaw.process.uptime_seconds', rollup='latest').max().publish(label='Uptime seconds')
+      EOT
+    }
+  }
+
+  time_charts = {
+    verdicts_by_action = {
+      name        = "Verdicts by action"
+      description = "Gateway verdict counts grouped by action."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "verdicts"
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.verdicts').sum(by=['verdict.action']).publish(label='Verdicts')
+      EOT
+    }
+    verdicts_by_stage = {
+      name        = "Verdicts by stage"
+      description = "Gateway verdict rate grouped by enforcement stage."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "events / min"
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.verdicts', rollup='rate').sum(by=['verdict.stage']).scale(60).publish(label='Verdicts / min')
+      EOT
+    }
+    verdicts_by_severity = {
+      name        = "Verdicts by severity"
+      description = "Gateway verdict rate grouped by severity."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "events / min"
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.verdicts', rollup='rate').sum(by=['verdict.severity']).scale(60).publish(label='Verdicts / min')
+      EOT
+    }
+    guardrail_evaluations_by_action = {
+      name        = "Guardrail Evaluations by Action"
+      description = "All guardrail evaluations grouped by action (block/alert/allow) - auto-discovers new action types."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "evaluations"
+      program     = <<-EOT
+        A = data('defenseclaw.guardrail.evaluations').sum(by=['guardrail.action_taken']).publish()
+      EOT
+    }
+    guardrail_latency_p95 = {
+      name        = "Guardrail latency p95"
+      description = "P95 guardrail evaluation latency."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ms"
+      program     = <<-EOT
+        A = histogram('defenseclaw.guardrail.latency').percentile(pct=95).publish(label='p95 guardrail ms')
+      EOT
+    }
+    inspections_by_tool = {
+      name        = "Inspections by Tool"
+      description = "All tool inspections grouped by tool name - automatically includes any new tools without chart changes."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "inspections"
+      program     = <<-EOT
+        A = data('defenseclaw.inspect.evaluations').sum(by=['tool']).publish()
+      EOT
+    }
+    inspections_by_severity = {
+      name        = "Inspections by Severity"
+      description = "All inspections grouped by severity level - auto-discovers severity values from the data."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "inspections"
+      program     = <<-EOT
+        A = data('defenseclaw.inspect.evaluations').sum(by=['severity']).publish()
+      EOT
+    }
+    blocked_inspections_by_tool = {
+      name        = "Block Rate by Tool"
+      description = "Blocked inspections over time grouped by tool - auto-discovers new tools."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "blocks"
+      program     = <<-EOT
+        A = data('defenseclaw.inspect.evaluations', filter=filter('action', 'block')).sum(by=['tool']).publish()
+      EOT
+    }
+    alert_inspections_by_tool = {
+      name        = "Alert Rate by Tool"
+      description = "Flagged (alert) inspections over time grouped by tool - auto-discovers new tools."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "alerts"
+      program     = <<-EOT
+        A = data('defenseclaw.inspect.evaluations', filter=filter('action', 'alert')).sum(by=['tool']).publish()
+      EOT
+    }
+    inspect_latency_p95 = {
+      name        = "Inspection latency p95"
+      description = "P95 tool/message inspection latency grouped by tool."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ms"
+      program     = <<-EOT
+        A = histogram('defenseclaw.inspect.latency').percentile(pct=95).publish(label='p95 inspect ms')
+      EOT
+    }
+    audit_events_by_action = {
+      name        = "Audit Events by Action"
+      description = "All audit events grouped by action type - auto-discovers new event types as they appear."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "events"
+      program     = <<-EOT
+        A = data('defenseclaw.audit.events.total').sum(by=['action']).publish()
+      EOT
+    }
+    otel_requests_by_source_signal = {
+      name        = "OTLP requests by source and signal"
+      description = "Inbound OTLP-HTTP request rate grouped by connector source and signal."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "requests / sec"
+      program     = <<-EOT
+        A = data('defenseclaw.otel.ingest.requests', rollup='rate').sum(by=['source', 'signal']).publish(label='OTLP requests / sec')
+      EOT
+    }
+    otel_records_by_source_signal = {
+      name        = "OTLP records by source and signal"
+      description = "Leaf records extracted from inbound OTLP batches."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "records / sec"
+      program     = <<-EOT
+        A = data('defenseclaw.otel.ingest.records', rollup='rate').sum(by=['source', 'signal']).publish(label='OTLP records / sec')
+      EOT
+    }
+    otel_bytes_by_source_signal = {
+      name        = "OTLP bytes by source and signal"
+      description = "Inbound OTLP body byte rate grouped by connector source and signal."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "bytes / sec"
+      program     = <<-EOT
+        A = data('defenseclaw.otel.ingest.bytes', rollup='rate').sum(by=['source', 'signal']).publish(label='OTLP bytes / sec')
+      EOT
+    }
+    malformed_by_source_signal = {
+      name        = "OTLP requests by result"
+      description = "Inbound OTLP request counts grouped by source, signal, and result."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "requests"
+      program     = <<-EOT
+        A = data('defenseclaw.otel.ingest.requests').sum(by=['source', 'signal', 'result']).publish(label='OTLP requests')
+      EOT
+    }
+    codex_notify_by_type_result = {
+      name        = "Codex notify by type and result"
+      description = "Codex notify-bridge events grouped by type and result."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "events / min"
+      program     = <<-EOT
+        A = data('defenseclaw.codex.notify', rollup='rate').sum(by=['type', 'result']).scale(60).publish(label='Codex notify / min')
+      EOT
+    }
+    hook_invocations_by_connector = {
+      name        = "Hook invocations by connector"
+      description = "Gateway connector hook invocations grouped by connector, event type, and result."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "hooks / min"
+      program     = <<-EOT
+        A = data('defenseclaw.connector.hook.invocations', rollup='rate').sum(by=['connector', 'event_type', 'result']).scale(60).publish(label='Hook invocations / min')
+      EOT
+    }
+    hook_latency_p95 = {
+      name        = "Connector hook latency p95"
+      description = "P95 connector hook handling latency."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ms"
+      program     = <<-EOT
+        A = histogram('defenseclaw.connector.hook.latency').percentile(pct=95).publish(label='p95 hook ms')
+      EOT
+    }
+    genai_tokens_by_agent_type = {
+      name        = "GenAI tokens by agent"
+      description = "Token usage from promoted GenAI OTel metrics grouped by agent."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "tokens"
+      program     = <<-EOT
+        A = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat'), rollup='sum').sum(by=['gen_ai.agent.name']).publish(label='Tokens')
+      EOT
+    }
+    genai_operation_duration_p95 = {
+      name        = "LLM operation duration p95"
+      description = "P95 duration for promoted GenAI client operations."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "seconds"
+      program     = <<-EOT
+        A = histogram('gen_ai.client.operation.duration').percentile(pct=95).publish(label='p95 operation seconds')
+      EOT
+    }
+    llm_events_by_type = {
+      name        = "LLM events by type"
+      description = "Gateway-normalized prompt, response, and tool event emission rate."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "events / min"
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.events.emitted', filter=filter('event_type', 'llm_prompt', 'llm_response', 'tool_invocation'), rollup='rate', extrapolation='zero').sum(by=['event_type']).scale(60).publish(label='LLM events / min')
+      EOT
+    }
+    token_tokens_by_agent = {
+      name        = "Tokens by agent"
+      description = "Token usage grouped by GenAI agent name."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "tokens"
+      program     = <<-EOT
+        A = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat'), rollup='sum').sum(by=['gen_ai.agent.name']).publish(label='Tokens')
+      EOT
+    }
+    token_tokens_by_model = {
+      name        = "Tokens by model"
+      description = "Token usage grouped by requested model."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "tokens"
+      program     = <<-EOT
+        A = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat'), rollup='sum').sum(by=['gen_ai.request.model']).publish(label='Tokens')
+      EOT
+    }
+    token_input_vs_output = {
+      name        = "Input vs output tokens"
+      description = "Token mix by token type."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "tokens"
+      program     = <<-EOT
+        A = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat'), rollup='sum').sum(by=['gen_ai.token.type']).publish(label='Tokens')
+      EOT
+    }
+    token_estimated_cost_by_agent = {
+      name        = "Estimated cost by agent"
+      description = "Estimated USD by agent using dashboard-side standard model rates. Cached-input discounts are not applied."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "USD"
+      program     = <<-EOT
+        I4O = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'input') and filter('gen_ai.request.model', 'gpt-4o-mini'), rollup='sum').sum(by=['gen_ai.agent.name']).scale(0.00000015).fill(0)
+        O4O = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'output') and filter('gen_ai.request.model', 'gpt-4o-mini'), rollup='sum').sum(by=['gen_ai.agent.name']).scale(0.00000060).fill(0)
+        C4O = (I4O + O4O).publish(label='gpt-4o-mini USD')
+
+        I41 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'input') and filter('gen_ai.request.model', 'gpt-4.1-mini'), rollup='sum').sum(by=['gen_ai.agent.name']).scale(0.00000040).fill(0)
+        O41 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'output') and filter('gen_ai.request.model', 'gpt-4.1-mini'), rollup='sum').sum(by=['gen_ai.agent.name']).scale(0.00000160).fill(0)
+        C41 = (I41 + O41).publish(label='gpt-4.1-mini USD')
+
+        I54M = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'input') and filter('gen_ai.request.model', 'gpt-5.4-mini'), rollup='sum').sum(by=['gen_ai.agent.name']).scale(0.00000075).fill(0)
+        O54M = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'output') and filter('gen_ai.request.model', 'gpt-5.4-mini'), rollup='sum').sum(by=['gen_ai.agent.name']).scale(0.00000450).fill(0)
+        C54M = (I54M + O54M).publish(label='gpt-5.4-mini USD')
+
+        I54 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'input') and filter('gen_ai.request.model', 'gpt-5.4'), rollup='sum').sum(by=['gen_ai.agent.name']).scale(0.00000250).fill(0)
+        O54 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'output') and filter('gen_ai.request.model', 'gpt-5.4'), rollup='sum').sum(by=['gen_ai.agent.name']).scale(0.00001500).fill(0)
+        C54 = (I54 + O54).publish(label='gpt-5.4 USD')
+
+        I55 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'input') and filter('gen_ai.request.model', 'gpt-5.5'), rollup='sum').sum(by=['gen_ai.agent.name']).scale(0.00000500).fill(0)
+        O55 = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat') and filter('gen_ai.token.type', 'output') and filter('gen_ai.request.model', 'gpt-5.5'), rollup='sum').sum(by=['gen_ai.agent.name']).scale(0.00003000).fill(0)
+        C55 = (I55 + O55).publish(label='gpt-5.5 USD')
+
+        C = (C4O + C41 + C54M + C54 + C55).publish(label='Estimated USD')
+      EOT
+    }
+    policy_evaluations_by_domain = {
+      name        = "Policy evaluations by verdict"
+      description = "Policy evaluations grouped by verdict."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "evaluations / min"
+      program     = <<-EOT
+        A = data('defenseclaw.policy.evaluations', rollup='rate').sum(by=['policy.verdict']).scale(60).publish(label='Policy evaluations / min')
+      EOT
+    }
+    policy_latency_p95 = {
+      name        = "Policy latency p95"
+      description = "P95 policy evaluation latency grouped by domain."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ms"
+      program     = <<-EOT
+        A = histogram('defenseclaw.policy.latency').percentile(pct=95).publish(label='p95 policy ms')
+      EOT
+    }
+    findings_by_severity = {
+      name        = "Findings by severity"
+      description = "Scan findings grouped by severity."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "findings / min"
+      program     = <<-EOT
+        A = data('defenseclaw.scan.findings', rollup='rate').sum(by=['severity']).scale(60).publish(label='Findings / min')
+      EOT
+    }
+    findings_by_scanner = {
+      name        = "Findings by scanner"
+      description = "Scan finding counts grouped by scanner."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "findings"
+      program     = <<-EOT
+        A = data('defenseclaw.scan.findings').sum(by=['scanner']).publish(label='Findings')
+      EOT
+    }
+    egress_by_decision = {
+      name        = "Egress decisions"
+      description = "Egress event rate grouped by decision."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "events / min"
+      program     = <<-EOT
+        A = data('defenseclaw.egress.events', rollup='rate').sum(by=['decision']).scale(60).publish(label='Egress events / min')
+      EOT
+    }
+    alerts_by_type_severity = {
+      name        = "Alerts by severity"
+      description = "Runtime alerts grouped by severity."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "alerts / min"
+      program     = <<-EOT
+        A = data('defenseclaw.alert.count', rollup='rate').sum(by=['alert.severity']).scale(60).publish(label='Alerts / min')
+      EOT
+    }
+    judge_latency_p95 = {
+      name        = "Judge latency p95"
+      description = "P95 gateway judge invocation latency."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ms"
+      program     = <<-EOT
+        A = histogram('defenseclaw.gateway.judge.latency').percentile(pct=95).publish(label='p95 judge ms')
+      EOT
+    }
+    judge_errors_by_reason = {
+      name        = "Judge errors by reason"
+      description = "Gateway judge errors grouped by reason."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "errors / min"
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.judge.errors', rollup='rate').sum(by=['judge.reason']).scale(60).publish(label='Judge errors / min')
+      EOT
+    }
+    guardrail_cache = {
+      name        = "Guardrail cache hits and misses"
+      description = "Verdict cache hit/miss rate by scanner and verdict."
+      plot_type   = "AreaChart"
+      stacked     = true
+      axis_label  = "events / min"
+      program     = <<-EOT
+        A = data('defenseclaw.guardrail.cache.hits', rollup='rate').sum(by=['scanner', 'verdict']).scale(60).publish(label='Cache hits / min')
+        B = data('defenseclaw.guardrail.cache.misses', rollup='rate').sum(by=['scanner', 'verdict']).scale(60).publish(label='Cache misses / min')
+      EOT
+    }
+    llm_bridge_latency_p95 = {
+      name        = "LLM bridge latency p95"
+      description = "P95 LiteLLM bridge latency grouped by model and status."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ms"
+      program     = <<-EOT
+        A = histogram('defenseclaw.llm_bridge.latency').percentile(pct=95).publish(label='p95 bridge ms')
+      EOT
+    }
+    cisco_inspect_latency_p95 = {
+      name        = "Cisco Inspect latency p95"
+      description = "P95 Cisco Inspect latency grouped by outcome."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ms"
+      program     = <<-EOT
+        A = histogram('defenseclaw.cisco_inspect.latency').percentile(pct=95).publish(label='p95 Cisco Inspect ms')
+      EOT
+    }
+    gateway_errors_by_code = {
+      name        = "Gateway errors by code"
+      description = "Structured gateway errors grouped by error code."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "errors"
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.errors').sum(by=['error.code']).publish(label='Gateway errors')
+      EOT
+    }
+    schema_violations_by_code = {
+      name        = "Schema violations by code"
+      description = "Runtime schema violations grouped by validation code."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "violations"
+      program     = <<-EOT
+        A = data('defenseclaw.schema.violations').sum(by=['code']).publish(label='Schema violations')
+      EOT
+    }
+    http_requests_by_route_status = {
+      name        = "HTTP requests by status"
+      description = "Sidecar API request counts grouped by HTTP status code."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "requests"
+      program     = <<-EOT
+        A = data('defenseclaw.http.request.count').sum(by=['http.status_code']).publish(label='HTTP requests')
+      EOT
+    }
+    http_duration_p95 = {
+      name        = "HTTP duration p95"
+      description = "P95 sidecar request duration."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ms"
+      program     = <<-EOT
+        A = histogram('defenseclaw.http.request.duration').percentile(pct=95).publish(label='p95 HTTP ms')
+      EOT
+    }
+    auth_failures_by_reason = {
+      name        = "Auth failures by reason"
+      description = "HTTP auth failures grouped by reason."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "failures"
+      program     = <<-EOT
+        A = data('defenseclaw.http.auth.failures').sum(by=['reason']).publish(label='Auth failures')
+      EOT
+    }
+    stream_lifecycle = {
+      name        = "Stream lifecycle"
+      description = "SSE stream open and close events grouped by outcome."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "events"
+      program     = <<-EOT
+        A = data('defenseclaw.stream.lifecycle').sum(by=['outcome']).publish(label='Stream events')
+      EOT
+    }
+    stream_duration_p95 = {
+      name        = "Stream duration p95"
+      description = "P95 SSE stream duration."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ms"
+      program     = <<-EOT
+        A = histogram('defenseclaw.stream.duration_ms').percentile(pct=95).publish(label='p95 stream ms')
+      EOT
+    }
+    tool_calls_by_tool = {
+      name        = "Tool calls by tool and provider"
+      description = "Runtime tool calls grouped by tool and provider."
+      plot_type   = "AreaChart"
+      stacked     = true
+      axis_label  = "calls / min"
+      program     = <<-EOT
+        A = data('defenseclaw.tool.calls', rollup='rate').sum(by=['gen_ai.tool.name', 'tool.provider']).scale(60).publish(label='Tool calls / min')
+      EOT
+    }
+    tool_duration_p95 = {
+      name        = "Tool duration p95"
+      description = "P95 runtime tool call duration."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ms"
+      program     = <<-EOT
+        A = histogram('defenseclaw.tool.duration').percentile(pct=95).publish(label='p95 tool ms')
+      EOT
+    }
+    admission_decisions = {
+      name        = "Admission decisions"
+      description = "Admission gate decisions grouped by decision."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "decisions"
+      program     = <<-EOT
+        A = data('defenseclaw.admission.decisions').sum(by=['decision']).publish(label='Admission decisions')
+      EOT
+    }
+    sink_batches = {
+      name        = "Sink batches delivered vs dropped"
+      description = "Audit sink delivery and drop counts."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "batches"
+      program     = <<-EOT
+        A = data('defenseclaw.audit.sink.batches.delivered').sum().publish(label='Delivered')
+        B = data('defenseclaw.audit.sink.batches.dropped').sum().publish(label='Dropped')
+      EOT
+    }
+    sink_delivery_latency_p95 = {
+      name        = "Sink delivery latency p95"
+      description = "P95 audit sink delivery latency."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ms"
+      program     = <<-EOT
+        A = histogram('defenseclaw.audit.sink.delivery.latency').percentile(pct=95).publish(label='p95 sink delivery ms')
+      EOT
+    }
+    sink_queue_depth = {
+      name        = "Sink queue depth"
+      description = "Audit sink queue depth by sink kind and sink name."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "items"
+      program     = <<-EOT
+        A = data('defenseclaw.audit.sink.queue.depth', rollup='latest').max(by=['sink.kind', 'sink.name']).publish(label='Sink queue depth')
+      EOT
+    }
+    webhook_outcomes = {
+      name        = "Webhook outcomes"
+      description = "Webhook dispatch outcomes grouped by outcome."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "dispatches"
+      program     = <<-EOT
+        A = data('defenseclaw.webhook.dispatches').sum(by=['outcome']).publish(label='Webhook dispatches')
+      EOT
+    }
+    webhook_latency_p95 = {
+      name        = "Webhook latency p95"
+      description = "P95 webhook delivery latency."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ms"
+      program     = <<-EOT
+        A = histogram('defenseclaw.webhook.latency').percentile(pct=95).publish(label='p95 webhook ms')
+      EOT
+    }
+    runtime_goroutines = {
+      name        = "Runtime goroutines"
+      description = "Go runtime goroutine gauge."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "goroutines"
+      program     = <<-EOT
+        A = data('defenseclaw.runtime.goroutines', rollup='latest').max().publish(label='Goroutines')
+      EOT
+    }
+    runtime_heap = {
+      name        = "Runtime heap"
+      description = "Go heap allocation and object count gauges."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "bytes / objects"
+      program     = <<-EOT
+        A = data('defenseclaw.runtime.heap.alloc', rollup='latest').max().publish(label='Heap alloc bytes')
+        B = data('defenseclaw.runtime.heap.objects', rollup='latest').max().publish(label='Heap objects')
+      EOT
+    }
+    runtime_gc_pause_p99 = {
+      name        = "Runtime GC pause p99"
+      description = "P99 Go runtime GC pause duration."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ns"
+      program     = <<-EOT
+        A = histogram('defenseclaw.runtime.gc.pause').percentile(pct=99).publish(label='p99 GC pause ns')
+      EOT
+    }
+    runtime_fd_in_use = {
+      name        = "Runtime file descriptors"
+      description = "Open file descriptor gauge."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "fds"
+      program     = <<-EOT
+        A = data('defenseclaw.runtime.fd.in_use', rollup='latest').max().publish(label='FDs in use')
+      EOT
+    }
+    block_slo_latency_p95 = {
+      name        = "Block SLO latency p95"
+      description = "P95 admission/block SLO latency."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ms"
+      program     = <<-EOT
+        A = histogram('defenseclaw.slo.block.latency').percentile(pct=95).publish(label='p95 block SLO ms')
+      EOT
+    }
+    tui_refresh_latency_p95 = {
+      name        = "TUI refresh latency p95"
+      description = "P95 TUI refresh latency."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ms"
+      program     = <<-EOT
+        A = histogram('defenseclaw.slo.tui.refresh').percentile(pct=95).publish(label='p95 TUI refresh ms')
+      EOT
+    }
+    sqlite_size = {
+      name        = "SQLite DB and WAL size"
+      description = "SQLite DB and WAL file size gauges."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "bytes"
+      program     = <<-EOT
+        A = data('defenseclaw.sqlite.db.bytes', rollup='latest').max().publish(label='DB bytes')
+        B = data('defenseclaw.sqlite.wal.bytes', rollup='latest').max().publish(label='WAL bytes')
+      EOT
+    }
+    sqlite_checkpoint_p95 = {
+      name        = "SQLite checkpoint duration p95"
+      description = "P95 SQLite checkpoint duration."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ms"
+      program     = <<-EOT
+        A = histogram('defenseclaw.sqlite.checkpoint.duration').percentile(pct=95).publish(label='p95 checkpoint ms')
+      EOT
+    }
+    sqlite_busy_retries = {
+      name        = "SQLite busy retries"
+      description = "SQLite busy retries grouped by operation."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "retries"
+      program     = <<-EOT
+        A = data('defenseclaw.sqlite.busy_retries').sum(by=['operation']).publish(label='Busy retries')
+      EOT
+    }
+    exporter_errors = {
+      name        = "Exporter errors by signal"
+      description = "Telemetry exporter errors grouped by signal."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "errors"
+      program     = <<-EOT
+        A = data('defenseclaw.telemetry.exporter.errors').sum(by=['signal']).publish(label='Exporter errors')
+      EOT
+    }
+    queue_depth = {
+      name        = "Queue depth"
+      description = "Generic buffered queue depth by queue."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "items"
+      program     = <<-EOT
+        A = data('defenseclaw.queue.depth', rollup='latest').max(by=['queue']).publish(label='Queue depth')
+      EOT
+    }
+    queue_drops = {
+      name        = "Queue drops"
+      description = "Generic buffered queue drops grouped by queue and reason."
+      plot_type   = "AreaChart"
+      stacked     = true
+      axis_label  = "drops / min"
+      program     = <<-EOT
+        A = data('defenseclaw.queue.drops', rollup='rate').sum(by=['queue', 'reason']).scale(60).publish(label='Queue drops / min')
+      EOT
+    }
+    scans_by_scanner = {
+      name        = "Scans by verdict"
+      description = "Scan counts grouped by verdict."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "scans"
+      program     = <<-EOT
+        A = data('defenseclaw.scan.count').sum(by=['verdict']).publish(label='Scans')
+      EOT
+    }
+    scan_counts_by_scanner = {
+      name        = "Scans by scanner"
+      description = "Scan counts grouped by scanner."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "scans"
+      program     = <<-EOT
+        A = data('defenseclaw.scan.count').sum(by=['scanner']).publish(label='Scans')
+      EOT
+    }
+    scan_duration_p95 = {
+      name        = "Scan duration p95"
+      description = "P95 scanner duration."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "ms"
+      program     = <<-EOT
+        A = histogram('defenseclaw.scan.duration').percentile(pct=95).publish(label='p95 scan ms')
+      EOT
+    }
+    scan_errors_by_type = {
+      name        = "Scan errors by type"
+      description = "Scanner error counts grouped by error type."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "errors"
+      program     = <<-EOT
+        A = data('defenseclaw.scan.errors').sum(by=['error_type']).publish(label='Scan errors')
+      EOT
+    }
+    scanner_findings_by_severity = {
+      name        = "Findings by severity"
+      description = "Scan finding counts grouped by severity."
+      plot_type   = "ColumnChart"
+      stacked     = true
+      axis_label  = "findings"
+      program     = <<-EOT
+        A = data('defenseclaw.scan.findings').sum(by=['severity']).publish(label='Findings')
+      EOT
+    }
+    quarantine_actions = {
+      name        = "Quarantine actions"
+      description = "Quarantine and restore operations by operation and result."
+      plot_type   = "AreaChart"
+      stacked     = true
+      axis_label  = "actions / min"
+      program     = <<-EOT
+        A = data('defenseclaw.quarantine.actions', rollup='rate').sum(by=['quarantine.op', 'quarantine.result']).scale(60).publish(label='Quarantine actions / min')
+      EOT
+    }
+    scanner_queue_depth = {
+      name        = "Scanner queue depth"
+      description = "Scanner queue depth grouped by scanner."
+      plot_type   = "LineChart"
+      stacked     = false
+      axis_label  = "items"
+      program     = <<-EOT
+        A = data('defenseclaw.scanner.queue.depth', rollup='latest').max(by=['scanner']).publish(label='Scanner queue depth')
+      EOT
+    }
+  }
+
+  time_chart_legend_dimensions = {
+    verdicts_by_action              = "verdict.action"
+    verdicts_by_stage               = "verdict.stage"
+    verdicts_by_severity            = "verdict.severity"
+    guardrail_evaluations_by_action = "guardrail.action_taken"
+    inspections_by_tool             = "tool"
+    inspections_by_severity         = "severity"
+    blocked_inspections_by_tool     = "tool"
+    alert_inspections_by_tool       = "tool"
+    audit_events_by_action          = "action"
+    otel_requests_by_source_signal  = "signal"
+    otel_records_by_source_signal   = "signal"
+    otel_bytes_by_source_signal     = "signal"
+    malformed_by_source_signal      = "result"
+    codex_notify_by_type_result     = "type"
+    hook_invocations_by_connector   = "event_type"
+    genai_tokens_by_agent_type      = "gen_ai.agent.name"
+    llm_events_by_type              = "event_type"
+    token_tokens_by_agent           = "gen_ai.agent.name"
+    token_tokens_by_model           = "gen_ai.request.model"
+    token_input_vs_output           = "gen_ai.token.type"
+    token_estimated_cost_by_agent   = "gen_ai.agent.name"
+    policy_evaluations_by_domain    = "policy.verdict"
+    findings_by_severity            = "severity"
+    findings_by_scanner             = "scanner"
+    egress_by_decision              = "decision"
+    alerts_by_type_severity         = "alert.severity"
+    judge_errors_by_reason          = "judge.reason"
+    guardrail_cache                 = "plot_label"
+    gateway_errors_by_code          = "error.code"
+    schema_violations_by_code       = "code"
+    http_requests_by_route_status   = "http.status_code"
+    auth_failures_by_reason         = "reason"
+    stream_lifecycle                = "outcome"
+    tool_calls_by_tool              = "gen_ai.tool.name"
+    admission_decisions             = "decision"
+    sink_batches                    = "plot_label"
+    sink_queue_depth                = "sink.name"
+    webhook_outcomes                = "outcome"
+    runtime_heap                    = "plot_label"
+    sqlite_size                     = "plot_label"
+    sqlite_busy_retries             = "operation"
+    exporter_errors                 = "signal"
+    queue_depth                     = "queue"
+    queue_drops                     = "queue"
+    scans_by_scanner                = "verdict"
+    scan_counts_by_scanner          = "scanner"
+    scan_errors_by_type             = "error_type"
+    scanner_findings_by_severity    = "severity"
+    quarantine_actions              = "quarantine.op"
+    scanner_queue_depth             = "scanner"
+  }
+
+  table_charts = {
+    verdict_breakdown = {
+      name        = "Verdict breakdown"
+      description = "Gateway verdict totals by action in the selected time range."
+      group_by    = ["verdict.action"]
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.verdicts', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.gateway.verdicts', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum(by=['verdict.action']).sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Verdicts')
+      EOT
+    }
+    policy_actions = {
+      name        = "Policy verdict table"
+      description = "Policy evaluation totals by domain and verdict in the selected time range."
+      group_by    = ["policy.domain", "policy.verdict"]
+      program     = <<-EOT
+        A = data('defenseclaw.policy.evaluations', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.policy.evaluations', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum(by=['policy.domain', 'policy.verdict']).sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Policy evaluations')
+      EOT
+    }
+    findings_by_rule = {
+      name        = "Findings by rule"
+      description = "Per-rule finding totals in the selected time range."
+      group_by    = ["scanner", "rule_id", "severity"]
+      program     = <<-EOT
+        A = data('defenseclaw.scan.findings.by_rule', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.scan.findings.by_rule', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum(by=['scanner', 'rule_id', 'severity']).sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Findings')
+      EOT
+    }
+    otel_ingest_mix = {
+      name        = "OTLP ingest mix"
+      description = "OTLP request totals by source, signal, and result in the selected time range."
+      group_by    = ["source", "signal", "result"]
+      program     = <<-EOT
+        A = data('defenseclaw.otel.ingest.requests', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.otel.ingest.requests', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum(by=['source', 'signal', 'result']).sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='OTLP requests')
+      EOT
+    }
+    codex_notify_mix = {
+      name        = "Codex notify mix"
+      description = "Codex notify event totals by type, status, and result in the selected time range."
+      group_by    = ["type", "status", "result"]
+      program     = <<-EOT
+        A = data('defenseclaw.codex.notify', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.codex.notify', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum(by=['type', 'status', 'result']).sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Codex notify')
+      EOT
+    }
+    token_agent_table = {
+      name        = "Agent token table"
+      description = "Current token rows grouped by agent, service, environment, provider, and model."
+      group_by    = ["gen_ai.agent.name", "service.name", "deployment.environment", "gen_ai.provider.name", "gen_ai.request.model"]
+      program     = <<-EOT
+        A = data('gen_ai.client.token.usage', filter=filter('gen_ai.operation.name', 'chat'), rollup='sum').sum(by=['gen_ai.agent.name', 'service.name', 'deployment.environment', 'gen_ai.provider.name', 'gen_ai.request.model']).sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Tokens')
+      EOT
+    }
+    sink_queue_by_sink = {
+      name        = "Sink queue and circuit state"
+      description = "Audit sink queue depth and circuit state by sink."
+      group_by    = ["sink.kind", "sink.name"]
+      program     = <<-EOT
+        A = data('defenseclaw.audit.sink.queue.depth', rollup='latest').max(by=['sink.kind', 'sink.name']).publish(label='Queue depth')
+        B = data('defenseclaw.audit.sink.circuit.state', rollup='latest').max(by=['sink.kind', 'sink.name']).publish(label='Circuit state')
+      EOT
+    }
+    gateway_error_codes = {
+      name        = "Gateway error codes"
+      description = "Structured gateway error totals by subsystem and code in the selected time range."
+      group_by    = ["error.subsystem", "error.code"]
+      program     = <<-EOT
+        A = data('defenseclaw.gateway.errors', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.gateway.errors', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum(by=['error.subsystem', 'error.code']).sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Gateway errors')
+      EOT
+    }
+    scan_errors = {
+      name        = "Scan error totals"
+      description = "Scanner error totals in the selected time range by scanner and error type."
+      group_by    = ["scanner", "error_type"]
+      program     = <<-EOT
+        A = data('defenseclaw.scan.errors', extrapolation='zero', rollup='delta')
+        B = data('defenseclaw.scan.errors', extrapolation='zero', rollup='latest')
+        C = A.delta()
+        D = (A if C is not None else B).sum(by=['scanner', 'error_type']).sum(over=Args.get('ui.dashboard_window', '31d')).publish(label='Scan errors')
+      EOT
+    }
+  }
+
+  dashboard_layouts = {
+    executive = [
+      { type = "single", key = "executive_verdicts_31d", row = 0, column = 0, width = 2, height = 1 },
+      { type = "single", key = "executive_blocks_31d", row = 0, column = 2, width = 2, height = 1 },
+      { type = "single", key = "executive_guardrail_evaluations_31d", row = 0, column = 4, width = 2, height = 1 },
+      { type = "single", key = "executive_inspect_evaluations_31d", row = 0, column = 6, width = 2, height = 1 },
+      { type = "single", key = "executive_otel_records_31d", row = 0, column = 8, width = 2, height = 1 },
+      { type = "single", key = "executive_gateway_errors_31d", row = 0, column = 10, width = 2, height = 1 },
+      { type = "time", key = "verdicts_by_action", row = 1, column = 0, width = 4, height = 2 },
+      { type = "time", key = "inspections_by_tool", row = 1, column = 4, width = 4, height = 2 },
+      { type = "time", key = "guardrail_latency_p95", row = 1, column = 8, width = 4, height = 2 },
+      { type = "time", key = "genai_tokens_by_agent_type", row = 3, column = 0, width = 4, height = 2 },
+      { type = "time", key = "llm_events_by_type", row = 3, column = 4, width = 4, height = 2 },
+      { type = "table", key = "verdict_breakdown", row = 3, column = 8, width = 4, height = 2 },
+    ]
+    guardrail_inspection = [
+      { type = "single", key = "guardrail_total_evaluations", row = 0, column = 0, width = 2, height = 1 },
+      { type = "single", key = "guardrail_total_inspections", row = 0, column = 2, width = 2, height = 1 },
+      { type = "single", key = "guardrail_total_blocked_inspections", row = 0, column = 4, width = 2, height = 1 },
+      { type = "single", key = "guardrail_total_alert_inspections", row = 0, column = 6, width = 2, height = 1 },
+      { type = "single", key = "guardrail_total_audit_events", row = 0, column = 8, width = 2, height = 1 },
+      { type = "single", key = "guardrail_total_runtime_alerts", row = 0, column = 10, width = 2, height = 1 },
+      { type = "time", key = "guardrail_evaluations_by_action", row = 1, column = 0, width = 4, height = 2 },
+      { type = "time", key = "blocked_inspections_by_tool", row = 1, column = 4, width = 4, height = 2 },
+      { type = "time", key = "alert_inspections_by_tool", row = 1, column = 8, width = 4, height = 2 },
+      { type = "time", key = "inspections_by_tool", row = 3, column = 0, width = 4, height = 2 },
+      { type = "time", key = "inspections_by_severity", row = 3, column = 4, width = 4, height = 2 },
+      { type = "time", key = "audit_events_by_action", row = 3, column = 8, width = 4, height = 2 },
+      { type = "time", key = "guardrail_latency_p95", row = 5, column = 0, width = 6, height = 2 },
+      { type = "time", key = "inspect_latency_p95", row = 5, column = 6, width = 6, height = 2 },
+    ]
+    connector_ingest = [
+      { type = "single", key = "connector_total_otel_requests", row = 0, column = 0, width = 3, height = 1 },
+      { type = "single", key = "connector_total_otel_records", row = 0, column = 3, width = 3, height = 1 },
+      { type = "single", key = "connector_total_otel_bytes", row = 0, column = 6, width = 3, height = 1 },
+      { type = "single", key = "connector_total_hook_invocations", row = 0, column = 9, width = 3, height = 1 },
+      { type = "time", key = "otel_requests_by_source_signal", row = 1, column = 0, width = 4, height = 2 },
+      { type = "time", key = "otel_records_by_source_signal", row = 1, column = 4, width = 4, height = 2 },
+      { type = "time", key = "otel_bytes_by_source_signal", row = 1, column = 8, width = 4, height = 2 },
+      { type = "time", key = "malformed_by_source_signal", row = 3, column = 0, width = 4, height = 2 },
+      { type = "table", key = "otel_ingest_mix", row = 3, column = 4, width = 4, height = 2 },
+      { type = "time", key = "hook_invocations_by_connector", row = 3, column = 8, width = 4, height = 2 },
+      { type = "time", key = "hook_latency_p95", row = 5, column = 0, width = 4, height = 2 },
+      { type = "time", key = "genai_tokens_by_agent_type", row = 5, column = 4, width = 4, height = 2 },
+      { type = "time", key = "genai_operation_duration_p95", row = 5, column = 8, width = 4, height = 2 },
+      { type = "time", key = "llm_events_by_type", row = 7, column = 0, width = 4, height = 2 },
+    ]
+    security_policy = [
+      { type = "single", key = "security_total_policy_denies", row = 0, column = 0, width = 2, height = 1 },
+      { type = "single", key = "security_total_findings", row = 0, column = 2, width = 2, height = 1 },
+      { type = "single", key = "security_total_egress_blocks", row = 0, column = 4, width = 2, height = 1 },
+      { type = "single", key = "security_total_runtime_alerts", row = 0, column = 6, width = 2, height = 1 },
+      { type = "single", key = "security_total_judge_invocations", row = 0, column = 8, width = 2, height = 1 },
+      { type = "single", key = "security_total_judge_errors", row = 0, column = 10, width = 2, height = 1 },
+      { type = "time", key = "verdicts_by_stage", row = 1, column = 0, width = 4, height = 2 },
+      { type = "time", key = "verdicts_by_severity", row = 1, column = 4, width = 4, height = 2 },
+      { type = "table", key = "verdict_breakdown", row = 1, column = 8, width = 4, height = 2 },
+      { type = "time", key = "policy_evaluations_by_domain", row = 3, column = 0, width = 4, height = 2 },
+      { type = "time", key = "policy_latency_p95", row = 3, column = 4, width = 4, height = 2 },
+      { type = "table", key = "policy_actions", row = 3, column = 8, width = 4, height = 2 },
+      { type = "time", key = "judge_latency_p95", row = 5, column = 0, width = 4, height = 2 },
+      { type = "time", key = "judge_errors_by_reason", row = 5, column = 4, width = 4, height = 2 },
+      { type = "time", key = "findings_by_severity", row = 7, column = 0, width = 4, height = 2 },
+      { type = "table", key = "findings_by_rule", row = 7, column = 4, width = 4, height = 2 },
+      { type = "time", key = "egress_by_decision", row = 7, column = 8, width = 4, height = 2 },
+      { type = "time", key = "alerts_by_type_severity", row = 9, column = 0, width = 4, height = 2 },
+    ]
+    token_economics = [
+      { type = "single", key = "token_records", row = 0, column = 0, width = 2, height = 1 },
+      { type = "single", key = "token_errors", row = 0, column = 2, width = 2, height = 1 },
+      { type = "single", key = "token_active_agents", row = 0, column = 4, width = 2, height = 1 },
+      { type = "single", key = "token_total_tokens", row = 0, column = 6, width = 2, height = 1 },
+      { type = "single", key = "token_input_tokens", row = 0, column = 8, width = 2, height = 1 },
+      { type = "single", key = "token_output_tokens", row = 0, column = 10, width = 2, height = 1 },
+      { type = "single", key = "token_estimated_cost", row = 1, column = 0, width = 4, height = 1 },
+      { type = "single", key = "token_estimated_input_cost", row = 1, column = 4, width = 4, height = 1 },
+      { type = "single", key = "token_estimated_output_cost", row = 1, column = 8, width = 4, height = 1 },
+      { type = "time", key = "token_tokens_by_agent", row = 2, column = 0, width = 4, height = 2 },
+      { type = "time", key = "token_tokens_by_model", row = 2, column = 4, width = 4, height = 2 },
+      { type = "time", key = "token_input_vs_output", row = 2, column = 8, width = 4, height = 2 },
+      { type = "time", key = "token_estimated_cost_by_agent", row = 4, column = 0, width = 6, height = 2 },
+      { type = "table", key = "token_agent_table", row = 4, column = 6, width = 6, height = 2 },
+    ]
+    runtime_reliability = [
+      { type = "single", key = "runtime_total_gateway_errors", row = 0, column = 0, width = 2, height = 1 },
+      { type = "single", key = "runtime_total_schema_violations", row = 0, column = 2, width = 2, height = 1 },
+      { type = "single", key = "runtime_total_http_requests", row = 0, column = 4, width = 2, height = 1 },
+      { type = "single", key = "runtime_total_auth_failures", row = 0, column = 6, width = 2, height = 1 },
+      { type = "single", key = "runtime_total_exporter_errors", row = 0, column = 8, width = 2, height = 1 },
+      { type = "single", key = "uptime_seconds", row = 0, column = 10, width = 2, height = 1 },
+      { type = "time", key = "gateway_errors_by_code", row = 1, column = 0, width = 4, height = 2 },
+      { type = "time", key = "schema_violations_by_code", row = 1, column = 4, width = 4, height = 2 },
+      { type = "table", key = "gateway_error_codes", row = 1, column = 8, width = 4, height = 2 },
+      { type = "time", key = "http_requests_by_route_status", row = 3, column = 0, width = 4, height = 2 },
+      { type = "time", key = "http_duration_p95", row = 3, column = 4, width = 4, height = 2 },
+      { type = "time", key = "auth_failures_by_reason", row = 3, column = 8, width = 4, height = 2 },
+      { type = "time", key = "stream_lifecycle", row = 5, column = 0, width = 4, height = 2 },
+      { type = "time", key = "stream_duration_p95", row = 5, column = 4, width = 4, height = 2 },
+      { type = "time", key = "admission_decisions", row = 5, column = 8, width = 4, height = 2 },
+      { type = "time", key = "sink_batches", row = 7, column = 0, width = 6, height = 2 },
+      { type = "time", key = "webhook_outcomes", row = 7, column = 6, width = 6, height = 2 },
+      { type = "time", key = "webhook_latency_p95", row = 9, column = 0, width = 4, height = 2 },
+      { type = "time", key = "exporter_errors", row = 9, column = 4, width = 4, height = 2 },
+      { type = "time", key = "sqlite_size", row = 9, column = 8, width = 4, height = 2 },
+      { type = "time", key = "runtime_goroutines", row = 11, column = 0, width = 3, height = 2 },
+      { type = "time", key = "runtime_heap", row = 11, column = 3, width = 3, height = 2 },
+      { type = "time", key = "runtime_gc_pause_p99", row = 11, column = 6, width = 3, height = 2 },
+      { type = "time", key = "runtime_fd_in_use", row = 11, column = 9, width = 3, height = 2 },
+      { type = "time", key = "sqlite_busy_retries", row = 13, column = 0, width = 6, height = 2 },
+      { type = "time", key = "sqlite_checkpoint_p95", row = 13, column = 6, width = 6, height = 2 },
+    ]
+    scanners_findings = [
+      { type = "single", key = "scanner_total_scans", row = 0, column = 0, width = 3, height = 1 },
+      { type = "single", key = "scanner_total_findings", row = 0, column = 3, width = 3, height = 1 },
+      { type = "single", key = "scanner_total_scan_errors", row = 0, column = 6, width = 3, height = 1 },
+      { type = "single", key = "scanner_open_findings", row = 0, column = 9, width = 3, height = 1 },
+      { type = "time", key = "scans_by_scanner", row = 1, column = 0, width = 4, height = 2 },
+      { type = "time", key = "scan_counts_by_scanner", row = 1, column = 4, width = 4, height = 2 },
+      { type = "time", key = "scan_duration_p95", row = 1, column = 8, width = 4, height = 2 },
+      { type = "time", key = "scanner_findings_by_severity", row = 3, column = 0, width = 4, height = 2 },
+      { type = "time", key = "findings_by_scanner", row = 3, column = 4, width = 4, height = 2 },
+      { type = "time", key = "scan_errors_by_type", row = 3, column = 8, width = 4, height = 2 },
+      { type = "table", key = "scan_errors", row = 5, column = 0, width = 12, height = 2 },
+    ]
+  }
+}
+
+resource "signalfx_dashboard_group" "defenseclaw_o11y" {
+  name        = "${local.display_name_prefix}DefenseClaw O11y"
+  description = "Splunk Observability Cloud dashboards for DefenseClaw native OTel metrics."
+}
+
+resource "signalfx_single_value_chart" "single" {
+  for_each = local.single_value_charts
+
+  name                    = each.value.name
+  description             = each.value.description
+  program_text            = trimspace(each.value.program)
+  color_by                = "Metric"
+  max_precision           = 2
+  is_timestamp_hidden     = true
+  secondary_visualization = "None"
+  show_spark_line         = false
+  timezone                = "UTC"
+  unit_prefix             = "Metric"
+}
+
+resource "signalfx_time_chart" "time" {
+  for_each = local.time_charts
+
+  name              = each.value.name
+  description       = each.value.description
+  program_text      = trimspace(each.value.program)
+  plot_type         = each.value.plot_type
+  stacked           = each.value.stacked
+  time_range        = 3600
+  axes_include_zero = true
+  # Shows the color key directly on the chart for grouped series.
+  on_chart_legend_dimension = lookup(local.time_chart_legend_dimensions, each.key, null)
+
+  axis_left {
+    label = each.value.axis_label
+  }
+}
+
+resource "signalfx_table_chart" "table" {
+  for_each = local.table_charts
+
+  name         = each.value.name
+  description  = each.value.description
+  program_text = trimspace(each.value.program)
+  group_by     = each.value.group_by
+}
+
+resource "signalfx_dashboard" "executive" {
+  name            = "Executive Agent Watch${local.display_name_suffix}"
+  description     = "Landing view for DefenseClaw verdicts, guardrails, inspections, connector ingress, GenAI usage, and error signals."
+  dashboard_group = signalfx_dashboard_group.defenseclaw_o11y.id
+  time_range      = "-31d"
+  tags            = ["defenseclaw", "executive", "agentwatch", "otel"]
+
+  dynamic "variable" {
+    for_each = local.dashboard_variables.executive
+    iterator = dashboard_var
+
+    content {
+      property       = dashboard_var.value.property
+      alias          = dashboard_var.value.alias
+      apply_if_exist = true
+    }
+  }
+
+  dynamic "chart" {
+    for_each = local.dashboard_layouts.executive
+    iterator = dashboard_chart
+
+    content {
+      chart_id = (
+        dashboard_chart.value.type == "single" ? signalfx_single_value_chart.single[dashboard_chart.value.key].id :
+        dashboard_chart.value.type == "time" ? signalfx_time_chart.time[dashboard_chart.value.key].id :
+        signalfx_table_chart.table[dashboard_chart.value.key].id
+      )
+      width  = dashboard_chart.value.width
+      height = dashboard_chart.value.height
+      row    = dashboard_chart.value.row
+      column = dashboard_chart.value.column
+    }
+  }
+}
+
+resource "signalfx_dashboard" "guardrail_inspection" {
+  name            = "Guardrail and Inspection${local.display_name_suffix}"
+  description     = "Guardrail evaluations, tool inspections, block/alert outcomes, audit events, and guardrail/inspection latency."
+  dashboard_group = signalfx_dashboard_group.defenseclaw_o11y.id
+  time_range      = "-31d"
+  tags            = ["defenseclaw", "guardrail", "inspection", "otel"]
+
+  dynamic "variable" {
+    for_each = local.dashboard_variables.guardrail_inspection
+    iterator = dashboard_var
+
+    content {
+      property       = dashboard_var.value.property
+      alias          = dashboard_var.value.alias
+      apply_if_exist = true
+    }
+  }
+
+  dynamic "chart" {
+    for_each = local.dashboard_layouts.guardrail_inspection
+    iterator = dashboard_chart
+
+    content {
+      chart_id = (
+        dashboard_chart.value.type == "single" ? signalfx_single_value_chart.single[dashboard_chart.value.key].id :
+        dashboard_chart.value.type == "time" ? signalfx_time_chart.time[dashboard_chart.value.key].id :
+        signalfx_table_chart.table[dashboard_chart.value.key].id
+      )
+      width  = dashboard_chart.value.width
+      height = dashboard_chart.value.height
+      row    = dashboard_chart.value.row
+      column = dashboard_chart.value.column
+    }
+  }
+}
+
+resource "signalfx_dashboard" "connector_ingest" {
+  name            = "Connector and OTel Ingest${local.display_name_suffix}"
+  description     = "OTLP ingest health, connector hooks, Codex notify, normalized LLM events, and GenAI token/duration telemetry."
+  dashboard_group = signalfx_dashboard_group.defenseclaw_o11y.id
+  time_range      = "-1h"
+  tags            = ["defenseclaw", "connectors", "otel", "codex", "claudecode"]
+
+  dynamic "variable" {
+    for_each = local.dashboard_variables.connector_ingest
+    iterator = dashboard_var
+
+    content {
+      property       = dashboard_var.value.property
+      alias          = dashboard_var.value.alias
+      apply_if_exist = true
+    }
+  }
+
+  dynamic "chart" {
+    for_each = local.dashboard_layouts.connector_ingest
+    iterator = dashboard_chart
+
+    content {
+      chart_id = (
+        dashboard_chart.value.type == "single" ? signalfx_single_value_chart.single[dashboard_chart.value.key].id :
+        dashboard_chart.value.type == "time" ? signalfx_time_chart.time[dashboard_chart.value.key].id :
+        signalfx_table_chart.table[dashboard_chart.value.key].id
+      )
+      width  = dashboard_chart.value.width
+      height = dashboard_chart.value.height
+      row    = dashboard_chart.value.row
+      column = dashboard_chart.value.column
+    }
+  }
+}
+
+resource "signalfx_dashboard" "security_policy" {
+  name            = "Security and Policy${local.display_name_suffix}"
+  description     = "Gateway verdicts, policy decisions, findings, egress decisions, alerts, judge latency/errors, and external security integrations."
+  dashboard_group = signalfx_dashboard_group.defenseclaw_o11y.id
+  time_range      = "-1h"
+  tags            = ["defenseclaw", "security", "policy", "otel"]
+
+  dynamic "variable" {
+    for_each = local.dashboard_variables.security_policy
+    iterator = dashboard_var
+
+    content {
+      property       = dashboard_var.value.property
+      alias          = dashboard_var.value.alias
+      apply_if_exist = true
+    }
+  }
+
+  dynamic "chart" {
+    for_each = local.dashboard_layouts.security_policy
+    iterator = dashboard_chart
+
+    content {
+      chart_id = (
+        dashboard_chart.value.type == "single" ? signalfx_single_value_chart.single[dashboard_chart.value.key].id :
+        dashboard_chart.value.type == "time" ? signalfx_time_chart.time[dashboard_chart.value.key].id :
+        signalfx_table_chart.table[dashboard_chart.value.key].id
+      )
+      width  = dashboard_chart.value.width
+      height = dashboard_chart.value.height
+      row    = dashboard_chart.value.row
+      column = dashboard_chart.value.column
+    }
+  }
+}
+
+resource "signalfx_dashboard" "token_economics" {
+  name            = "DefenseClaw AI Agents Token Economics${local.display_name_suffix}"
+  description     = "AI agent token usage and dashboard-side cost estimates from DefenseClaw GenAI OTel metrics. Cost cards use hardcoded pricebook rates and should be updated when supported model pricing changes."
+  dashboard_group = signalfx_dashboard_group.defenseclaw_o11y.id
+  time_range      = "-31d"
+  tags            = ["defenseclaw", "genai", "tokenomics", "otel"]
+
+  dynamic "variable" {
+    for_each = local.dashboard_variables.token_economics
+    iterator = dashboard_var
+
+    content {
+      property       = dashboard_var.value.property
+      alias          = dashboard_var.value.alias
+      apply_if_exist = true
+    }
+  }
+
+  dynamic "chart" {
+    for_each = local.dashboard_layouts.token_economics
+    iterator = dashboard_chart
+
+    content {
+      chart_id = (
+        dashboard_chart.value.type == "single" ? signalfx_single_value_chart.single[dashboard_chart.value.key].id :
+        dashboard_chart.value.type == "time" ? signalfx_time_chart.time[dashboard_chart.value.key].id :
+        signalfx_table_chart.table[dashboard_chart.value.key].id
+      )
+      width  = dashboard_chart.value.width
+      height = dashboard_chart.value.height
+      row    = dashboard_chart.value.row
+      column = dashboard_chart.value.column
+    }
+  }
+}
+
+resource "signalfx_dashboard" "runtime_reliability" {
+  name            = "Runtime and Reliability${local.display_name_suffix}"
+  description     = "Gateway reliability, HTTP traffic, auth failures, streams, audit sinks, webhooks, runtime gauges, exporter errors, and SQLite health."
+  dashboard_group = signalfx_dashboard_group.defenseclaw_o11y.id
+  time_range      = "-1h"
+  tags            = ["defenseclaw", "runtime", "reliability", "slo", "otel"]
+
+  dynamic "variable" {
+    for_each = local.dashboard_variables.runtime_reliability
+    iterator = dashboard_var
+
+    content {
+      property       = dashboard_var.value.property
+      alias          = dashboard_var.value.alias
+      apply_if_exist = true
+    }
+  }
+
+  dynamic "chart" {
+    for_each = local.dashboard_layouts.runtime_reliability
+    iterator = dashboard_chart
+
+    content {
+      chart_id = (
+        dashboard_chart.value.type == "single" ? signalfx_single_value_chart.single[dashboard_chart.value.key].id :
+        dashboard_chart.value.type == "time" ? signalfx_time_chart.time[dashboard_chart.value.key].id :
+        signalfx_table_chart.table[dashboard_chart.value.key].id
+      )
+      width  = dashboard_chart.value.width
+      height = dashboard_chart.value.height
+      row    = dashboard_chart.value.row
+      column = dashboard_chart.value.column
+    }
+  }
+}
+
+resource "signalfx_dashboard" "scanners_findings" {
+  name            = "Scanners and Findings${local.display_name_suffix}"
+  description     = "Scanner throughput, scanner latency, scan errors, and findings by severity and scanner."
+  dashboard_group = signalfx_dashboard_group.defenseclaw_o11y.id
+  time_range      = "-1h"
+  tags            = ["defenseclaw", "scanners", "findings", "otel"]
+
+  dynamic "variable" {
+    for_each = local.dashboard_variables.scanners_findings
+    iterator = dashboard_var
+
+    content {
+      property       = dashboard_var.value.property
+      alias          = dashboard_var.value.alias
+      apply_if_exist = true
+    }
+  }
+
+  dynamic "chart" {
+    for_each = local.dashboard_layouts.scanners_findings
+    iterator = dashboard_chart
+
+    content {
+      chart_id = (
+        dashboard_chart.value.type == "single" ? signalfx_single_value_chart.single[dashboard_chart.value.key].id :
+        dashboard_chart.value.type == "time" ? signalfx_time_chart.time[dashboard_chart.value.key].id :
+        signalfx_table_chart.table[dashboard_chart.value.key].id
+      )
+      width  = dashboard_chart.value.width
+      height = dashboard_chart.value.height
+      row    = dashboard_chart.value.row
+      column = dashboard_chart.value.column
+    }
+  }
+}
+
+output "dashboard_urls" {
+  description = "Created Splunk Observability dashboard URLs."
+  value = {
+    executive            = signalfx_dashboard.executive.url
+    guardrail_inspection = signalfx_dashboard.guardrail_inspection.url
+    connector_ingest     = signalfx_dashboard.connector_ingest.url
+    security_policy      = signalfx_dashboard.security_policy.url
+    token_economics      = signalfx_dashboard.token_economics.url
+    runtime_reliability  = signalfx_dashboard.runtime_reliability.url
+    scanners_findings    = signalfx_dashboard.scanners_findings.url
+  }
+}

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -116,13 +116,12 @@ from defenseclaw.commands.cmd_setup_local_observability import (  # noqa: E402
 
 setup.add_command(local_observability)
 
-# Register `defenseclaw setup splunk-o11y-dashboards` (Terraform-backed
-# dashboard and detector provisioning for Splunk Observability Cloud).
+# Import the Splunk O11y dashboard bundle command so it can be registered
+# under `defenseclaw setup splunk dashboards` after the Splunk group is
+# defined below.
 from defenseclaw.commands.cmd_setup_splunk_o11y_dashboards import (  # noqa: E402
     splunk_o11y_dashboards,
 )
-
-setup.add_command(splunk_o11y_dashboards)
 
 # Register `defenseclaw setup webhook` (Slack/PagerDuty/Webex/generic
 # notifiers). Distinct from `setup observability add webhook` (generic
@@ -4704,7 +4703,8 @@ _SPLUNK_LOCAL_HEC_DEFAULTS = {
 }
 
 
-@setup.command("splunk")
+@click.group("splunk", invoke_without_command=True)
+@click.pass_context
 @click.option("--o11y", "enable_o11y", is_flag=True, default=False,
               help="Enable Splunk Observability Cloud (OTLP traces + metrics)")
 @click.option("--logs", "enable_logs", is_flag=True, default=False,
@@ -4761,9 +4761,8 @@ _SPLUNK_LOCAL_HEC_DEFAULTS = {
     ),
 )
 @click.option("--non-interactive", is_flag=True, help="Use flags instead of prompts")
-@pass_ctx
 def setup_splunk(
-    app: AppContext,
+    ctx: click.Context,
     enable_o11y: bool,
     enable_logs: bool,
     s3_export: bool,
@@ -4808,6 +4807,13 @@ def setup_splunk(
 
     Both can run simultaneously. Without flags, runs an interactive wizard.
     """
+    if ctx.invoked_subcommand is not None:
+        return
+
+    app = ctx.find_object(AppContext)
+    if app is None:
+        raise click.ClickException("App context unavailable")
+
     if show_credentials:
         _show_splunk_credentials(app.cfg.data_dir)
         return
@@ -4895,6 +4901,12 @@ def setup_splunk(
         if did_enterprise:
             parts.append("enterprise=enabled")
         app.logger.log_action("setup-splunk", "config", " ".join(parts))
+
+
+# Register `defenseclaw setup splunk dashboards` (Terraform-backed dashboard
+# and detector provisioning for Splunk Observability Cloud).
+setup.add_command(setup_splunk)
+setup_splunk.add_command(splunk_o11y_dashboards)
 
 
 # ---------------------------------------------------------------------------

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -116,10 +116,11 @@ from defenseclaw.commands.cmd_setup_local_observability import (  # noqa: E402
 
 setup.add_command(local_observability)
 
-# Import the Splunk O11y dashboard bundle command so it can be registered
-# under `defenseclaw setup splunk dashboards` after the Splunk group is
-# defined below.
+# Import the Terraform-backed Splunk O11y dashboard installer so the
+# interactive Splunk wizard can reuse the same idempotent apply path and
+# the command group can be registered below.
 from defenseclaw.commands.cmd_setup_splunk_o11y_dashboards import (  # noqa: E402
+    apply_dashboards,
     splunk_o11y_dashboards,
 )
 
@@ -128,12 +129,6 @@ from defenseclaw.commands.cmd_setup_splunk_o11y_dashboards import (  # noqa: E40
 # HTTP JSONL audit-log forwarder) — see docs/OBSERVABILITY.md for the
 # disambiguation.
 from defenseclaw.commands.cmd_setup_webhook import webhook  # noqa: E402
-
-# Import the Terraform-backed Splunk O11y dashboard installer so the
-# interactive Splunk wizard can reuse the same idempotent apply path.
-from defenseclaw.commands.cmd_setup_splunk_o11y_dashboards import (  # noqa: E402
-    apply_dashboards,
-)
 
 setup.add_command(webhook)
 

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -129,6 +129,12 @@ from defenseclaw.commands.cmd_setup_splunk_o11y_dashboards import (  # noqa: E40
 # disambiguation.
 from defenseclaw.commands.cmd_setup_webhook import webhook  # noqa: E402
 
+# Import the Terraform-backed Splunk O11y dashboard installer so the
+# interactive Splunk wizard can reuse the same idempotent apply path.
+from defenseclaw.commands.cmd_setup_splunk_o11y_dashboards import (  # noqa: E402
+    apply_dashboards,
+)
+
 setup.add_command(webhook)
 
 # Register `defenseclaw setup provider` (custom-providers.json overlay).
@@ -4949,6 +4955,8 @@ def _interactive_splunk_setup(
         _interactive_o11y(app, realm, access_token, app_name)
         did_o11y = True
         click.echo()
+        _interactive_o11y_dashboards(app)
+        click.echo()
 
     if click.confirm("  Enable local Splunk (Docker, HEC logs, Free mode)?", default=False):
         did_logs = _interactive_logs(app)
@@ -5013,6 +5021,44 @@ def _interactive_o11y(
     )
 
 
+def _interactive_o11y_dashboards(app: AppContext) -> bool:
+    click.echo()
+    click.echo("  Splunk O11y Dashboards")
+    click.echo("  ──────────────────────")
+    click.echo()
+    if not click.confirm("  Install Splunk Observability Cloud dashboards now?", default=False):
+        return False
+
+    o11y_api_token = click.prompt(
+        "  O11y API token (not the ingest token)",
+        default="",
+        show_default=False,
+        hide_input=True,
+    )
+    if not o11y_api_token:
+        click.echo("  error: O11y API token is required to install dashboards", err=True)
+        raise SystemExit(1)
+
+    apply_dashboards(
+        app,
+        api_url=None,
+        o11y_api_token=o11y_api_token,
+        name_prefix="",
+        with_detectors=False,
+        enable_detectors=False,
+        detector_notifications=(),
+        work_dir=None,
+        state_path=None,
+        terraform_bin="terraform",
+        plugin_dir=None,
+        skip_init=False,
+        skip_validate=False,
+        timeout=900,
+        yes=True,
+    )
+    return True
+
+
 def _prompt_splunk_token(current: str | None) -> str:
     env_val = os.environ.get("SPLUNK_ACCESS_TOKEN", "")
     if current:
@@ -5022,7 +5068,12 @@ def _prompt_splunk_token(current: str | None) -> str:
     else:
         hint = "(not set)"
 
-    val = click.prompt(f"  Access token [{hint}]", default="", show_default=False, hide_input=True)
+    val = click.prompt(
+        f"  O11y ingest access token [{hint}]",
+        default="",
+        show_default=False,
+        hide_input=True,
+    )
     if val:
         return val
     return current or env_val

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -116,6 +116,14 @@ from defenseclaw.commands.cmd_setup_local_observability import (  # noqa: E402
 
 setup.add_command(local_observability)
 
+# Register `defenseclaw setup splunk-o11y-dashboards` (Terraform-backed
+# dashboard and detector provisioning for Splunk Observability Cloud).
+from defenseclaw.commands.cmd_setup_splunk_o11y_dashboards import (  # noqa: E402
+    splunk_o11y_dashboards,
+)
+
+setup.add_command(splunk_o11y_dashboards)
+
 # Register `defenseclaw setup webhook` (Slack/PagerDuty/Webex/generic
 # notifiers). Distinct from `setup observability add webhook` (generic
 # HTTP JSONL audit-log forwarder) — see docs/OBSERVABILITY.md for the

--- a/cli/defenseclaw/commands/cmd_setup_splunk_o11y_dashboards.py
+++ b/cli/defenseclaw/commands/cmd_setup_splunk_o11y_dashboards.py
@@ -1,0 +1,552 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""defenseclaw setup splunk-o11y-dashboards — manage O11y dashboards.
+
+This command is intentionally a thin Terraform driver. It copies the bundled
+Terraform module into the user's DefenseClaw data directory, resolves the
+Splunk Observability Cloud API URL/token from config or environment, and runs
+Terraform with the token supplied through ``TF_VAR_*`` rather than command-line
+arguments.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import click
+
+from defenseclaw import ux
+from defenseclaw.context import AppContext
+from defenseclaw.paths import bundled_splunk_o11y_dashboards_terraform_dir
+
+_DEFAULT_WORK_SUBDIR = "splunk-o11y-dashboards"
+
+
+@click.group(
+    "splunk-o11y-dashboards",
+    short_help="Create/update Splunk Observability Cloud dashboards.",
+)
+def splunk_o11y_dashboards() -> None:
+    """Create or update DefenseClaw Splunk Observability Cloud dashboards.
+
+    The command uses the Terraform bundle shipped with DefenseClaw and stores
+    Terraform working files under ``~/.defenseclaw/splunk-o11y-dashboards`` by
+    default. Re-running from the same state path updates the same O11y objects.
+    """
+
+
+def _dashboard_options(func):
+    func = click.option(
+        "--timeout",
+        type=int,
+        default=900,
+        show_default=True,
+        help="Timeout in seconds for each Terraform subprocess.",
+    )(func)
+    func = click.option(
+        "--skip-validate",
+        is_flag=True,
+        help="Skip `terraform validate` after init.",
+    )(func)
+    func = click.option(
+        "--skip-init",
+        is_flag=True,
+        help="Skip `terraform init` in the working directory.",
+    )(func)
+    func = click.option(
+        "--plugin-dir",
+        type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+        default=None,
+        envvar="DEFENSECLAW_TERRAFORM_PLUGIN_DIR",
+        help="Optional Terraform provider plugin directory for offline/cached provider installs.",
+    )(func)
+    func = click.option(
+        "--terraform-bin",
+        default="terraform",
+        show_default=True,
+        envvar="TERRAFORM_BIN",
+        help="Terraform executable to run.",
+    )(func)
+    func = click.option(
+        "--state",
+        "state_path",
+        type=click.Path(file_okay=True, dir_okay=False, path_type=Path),
+        default=None,
+        help="Terraform state file path. Defaults under the DefenseClaw data directory.",
+    )(func)
+    func = click.option(
+        "--work-dir",
+        type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+        default=None,
+        envvar="DEFENSECLAW_SPLUNK_O11Y_DASHBOARDS_WORK_DIR",
+        help="Terraform working directory. Defaults under the DefenseClaw data directory.",
+    )(func)
+    func = click.option(
+        "--detector-notification",
+        "detector_notifications",
+        multiple=True,
+        help='Detector notification target, e.g. "Email,secops@example.com". Repeatable.',
+    )(func)
+    func = click.option(
+        "--enable-detectors",
+        is_flag=True,
+        help="Create detector rules enabled. By default created detectors are disabled.",
+    )(func)
+    func = click.option(
+        "--with-detectors/--dashboards-only",
+        "with_detectors",
+        default=False,
+        show_default=True,
+        help="Create Splunk detectors in addition to dashboards.",
+    )(func)
+    func = click.option(
+        "--name-prefix",
+        default="",
+        envvar="DEFENSECLAW_O11Y_DASHBOARD_NAME_PREFIX",
+        help="Label dashboard groups, dashboards, and detectors. Useful for smoke tests.",
+    )(func)
+    func = click.option(
+        "--auth-token",
+        default=None,
+        help="Splunk O11y API access token. Required unless provided explicitly.",
+    )(func)
+    func = click.option(
+        "--api-url",
+        default=None,
+        envvar="SFX_API_URL",
+        help="Splunk O11y API URL. Defaults from SFX_API_URL or the configured OTLP ingest realm.",
+    )(func)
+    return func
+
+
+@splunk_o11y_dashboards.command("plan")
+@_dashboard_options
+@click.pass_context
+def plan_cmd(
+    ctx: click.Context,
+    api_url: str | None,
+    auth_token: str | None,
+    name_prefix: str,
+    with_detectors: bool,
+    enable_detectors: bool,
+    detector_notifications: tuple[str, ...],
+    work_dir: Path | None,
+    state_path: Path | None,
+    terraform_bin: str,
+    plugin_dir: Path | None,
+    skip_init: bool,
+    skip_validate: bool,
+    timeout: int,
+) -> None:
+    """Show Terraform changes for the O11y dashboard bundle."""
+    prepared = _prepare_run(
+        ctx,
+        api_url=api_url,
+        auth_token=auth_token,
+        name_prefix=name_prefix,
+        with_detectors=with_detectors,
+        enable_detectors=enable_detectors,
+        detector_notifications=detector_notifications,
+        work_dir=work_dir,
+        state_path=state_path,
+    )
+    _run_init_validate(
+        prepared,
+        terraform_bin=terraform_bin,
+        plugin_dir=plugin_dir,
+        skip_init=skip_init,
+        skip_validate=skip_validate,
+        timeout=timeout,
+    )
+    _run_terraform(
+        terraform_bin,
+        ["plan", "-input=false", f"-state={prepared.state_path}"],
+        cwd=prepared.work_dir,
+        env=prepared.env,
+        timeout=timeout,
+    )
+
+
+@splunk_o11y_dashboards.command("apply")
+@_dashboard_options
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Apply without an additional confirmation prompt.",
+)
+@click.pass_context
+def apply_cmd(
+    ctx: click.Context,
+    yes: bool,
+    api_url: str | None,
+    auth_token: str | None,
+    name_prefix: str,
+    with_detectors: bool,
+    enable_detectors: bool,
+    detector_notifications: tuple[str, ...],
+    work_dir: Path | None,
+    state_path: Path | None,
+    terraform_bin: str,
+    plugin_dir: Path | None,
+    skip_init: bool,
+    skip_validate: bool,
+    timeout: int,
+) -> None:
+    """Create or update the O11y dashboards."""
+    prepared = _prepare_run(
+        ctx,
+        api_url=api_url,
+        auth_token=auth_token,
+        name_prefix=name_prefix,
+        with_detectors=with_detectors,
+        enable_detectors=enable_detectors,
+        detector_notifications=detector_notifications,
+        work_dir=work_dir,
+        state_path=state_path,
+    )
+    _run_init_validate(
+        prepared,
+        terraform_bin=terraform_bin,
+        plugin_dir=plugin_dir,
+        skip_init=skip_init,
+        skip_validate=skip_validate,
+        timeout=timeout,
+    )
+    _run_terraform(
+        terraform_bin,
+        ["plan", "-input=false", f"-state={prepared.state_path}"],
+        cwd=prepared.work_dir,
+        env=prepared.env,
+        timeout=timeout,
+    )
+    if not yes:
+        click.confirm("Apply these Splunk Observability Cloud changes?", abort=True)
+    _run_terraform(
+        terraform_bin,
+        ["apply", "-input=false", "-auto-approve", f"-state={prepared.state_path}"],
+        cwd=prepared.work_dir,
+        env=prepared.env,
+        timeout=timeout,
+    )
+    _print_dashboard_outputs(prepared, terraform_bin=terraform_bin, timeout=timeout)
+
+
+@splunk_o11y_dashboards.command("destroy")
+@_dashboard_options
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Destroy without an additional confirmation prompt.",
+)
+@click.pass_context
+def destroy_cmd(
+    ctx: click.Context,
+    yes: bool,
+    api_url: str | None,
+    auth_token: str | None,
+    name_prefix: str,
+    with_detectors: bool,
+    enable_detectors: bool,
+    detector_notifications: tuple[str, ...],
+    work_dir: Path | None,
+    state_path: Path | None,
+    terraform_bin: str,
+    plugin_dir: Path | None,
+    skip_init: bool,
+    skip_validate: bool,
+    timeout: int,
+) -> None:
+    """Destroy O11y objects managed by the selected Terraform state."""
+    prepared = _prepare_run(
+        ctx,
+        api_url=api_url,
+        auth_token=auth_token,
+        name_prefix=name_prefix,
+        with_detectors=with_detectors,
+        enable_detectors=enable_detectors,
+        detector_notifications=detector_notifications,
+        work_dir=work_dir,
+        state_path=state_path,
+    )
+    _run_init_validate(
+        prepared,
+        terraform_bin=terraform_bin,
+        plugin_dir=plugin_dir,
+        skip_init=skip_init,
+        skip_validate=skip_validate,
+        timeout=timeout,
+    )
+    _run_terraform(
+        terraform_bin,
+        ["plan", "-destroy", "-input=false", f"-state={prepared.state_path}"],
+        cwd=prepared.work_dir,
+        env=prepared.env,
+        timeout=timeout,
+    )
+    if not yes:
+        click.confirm("Destroy these Splunk Observability Cloud objects?", abort=True)
+    _run_terraform(
+        terraform_bin,
+        ["destroy", "-input=false", "-auto-approve", f"-state={prepared.state_path}"],
+        cwd=prepared.work_dir,
+        env=prepared.env,
+        timeout=timeout,
+    )
+
+
+class _PreparedRun:
+    def __init__(self, work_dir: Path, state_path: Path, env: dict[str, str]) -> None:
+        self.work_dir = work_dir
+        self.state_path = state_path
+        self.env = env
+
+
+def _prepare_run(
+    ctx: click.Context,
+    *,
+    api_url: str | None,
+    auth_token: str | None,
+    name_prefix: str,
+    with_detectors: bool,
+    enable_detectors: bool,
+    detector_notifications: tuple[str, ...],
+    work_dir: Path | None,
+    state_path: Path | None,
+) -> _PreparedRun:
+    app = ctx.find_object(AppContext)
+    data_dir = _resolve_data_dir(app)
+    resolved_work_dir = (work_dir or data_dir / _DEFAULT_WORK_SUBDIR / "terraform").expanduser()
+    resolved_state_path = (state_path or data_dir / _DEFAULT_WORK_SUBDIR / "terraform.tfstate").expanduser()
+    resolved_api_url = _resolve_api_url(api_url, app)
+    resolved_auth_token = _resolve_auth_token(auth_token)
+
+    _sync_terraform_bundle(resolved_work_dir)
+    resolved_state_path.parent.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "TF_VAR_signalfx_auth_token": resolved_auth_token,
+            "TF_VAR_signalfx_api_url": resolved_api_url,
+            "TF_VAR_name_prefix": name_prefix,
+            "TF_VAR_create_detectors": _tf_bool(with_detectors),
+            "TF_VAR_detectors_disabled": _tf_bool(not enable_detectors),
+            "TF_VAR_detector_notifications": json.dumps(list(detector_notifications)),
+        }
+    )
+
+    ux.section("Splunk O11y dashboards")
+    click.echo(f"    Terraform dir: {resolved_work_dir}")
+    click.echo(f"    State:         {resolved_state_path}")
+    click.echo(f"    API URL:       {resolved_api_url}")
+    click.echo(f"    Test label:    {name_prefix or '(none)'}")
+    click.echo(f"    Detectors:     {_detector_summary(with_detectors, enable_detectors)}")
+    if not with_detectors:
+        click.echo(f"    {ux.dim('Use --with-detectors to create Splunk detectors from bundled rules.')}")
+    click.echo()
+
+    return _PreparedRun(
+        work_dir=resolved_work_dir,
+        state_path=resolved_state_path,
+        env=env,
+    )
+
+
+def _run_init_validate(
+    prepared: _PreparedRun,
+    *,
+    terraform_bin: str,
+    plugin_dir: Path | None,
+    skip_init: bool,
+    skip_validate: bool,
+    timeout: int,
+) -> None:
+    if not skip_init:
+        init_args = ["init", "-input=false"]
+        if plugin_dir is not None:
+            init_args.append(f"-plugin-dir={plugin_dir.expanduser()}")
+        _run_terraform(terraform_bin, init_args, cwd=prepared.work_dir, env=prepared.env, timeout=timeout)
+    if not skip_validate:
+        _run_terraform(terraform_bin, ["validate"], cwd=prepared.work_dir, env=prepared.env, timeout=timeout)
+
+
+def _run_terraform(
+    terraform_bin: str,
+    args: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    timeout: int,
+    capture_output: bool = False,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    display = " ".join([terraform_bin, *args])
+    click.echo(f"  {ux.dim('$')} {display}")
+    try:
+        result = subprocess.run(
+            [terraform_bin, *args],
+            cwd=str(cwd),
+            env=env,
+            text=True,
+            capture_output=capture_output,
+            timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        raise click.ClickException(
+            f"Terraform executable not found: {terraform_bin}. Install Terraform or pass --terraform-bin."
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise click.ClickException(f"Terraform command timed out after {timeout}s: {display}") from exc
+    except OSError as exc:
+        raise click.ClickException(f"Could not execute Terraform: {exc}") from exc
+
+    if check and result.returncode != 0:
+        if capture_output:
+            _echo_captured_failure(result)
+        raise click.ClickException(f"Terraform command failed with exit code {result.returncode}: {display}")
+    return result
+
+
+def _print_dashboard_outputs(prepared: _PreparedRun, *, terraform_bin: str, timeout: int) -> None:
+    result = _run_terraform(
+        terraform_bin,
+        ["output", "-json", f"-state={prepared.state_path}", "dashboard_urls"],
+        cwd=prepared.work_dir,
+        env=prepared.env,
+        timeout=timeout,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        ux.warn("apply completed, but dashboard_urls output was not available")
+        return
+    try:
+        urls = json.loads(result.stdout or "{}")
+    except ValueError:
+        ux.warn("apply completed, but dashboard_urls output was not valid JSON")
+        return
+    if not isinstance(urls, dict) or not urls:
+        return
+
+    ux.ok("Dashboard URLs")
+    for name, url in sorted(urls.items()):
+        click.echo(f"    {name}: {url}")
+
+
+def _echo_captured_failure(result: subprocess.CompletedProcess[str]) -> None:
+    output = (result.stderr or result.stdout or "").strip()
+    for line in output.splitlines()[:20]:
+        click.echo(f"    {line}", err=True)
+
+
+def _sync_terraform_bundle(work_dir: Path) -> None:
+    source_dir = bundled_splunk_o11y_dashboards_terraform_dir()
+    if not source_dir.is_dir():
+        raise click.ClickException(f"Bundled Splunk O11y Terraform directory not found: {source_dir}")
+    work_dir.mkdir(parents=True, exist_ok=True)
+    if source_dir.resolve() == work_dir.resolve():
+        return
+    for source_file in source_dir.glob("*.tf"):
+        shutil.copy2(source_file, work_dir / source_file.name)
+
+
+def _resolve_data_dir(app: AppContext | None) -> Path:
+    if app is not None and app.cfg is not None and getattr(app.cfg, "data_dir", None):
+        return Path(str(app.cfg.data_dir)).expanduser()
+    return Path.home() / ".defenseclaw"
+
+
+def _resolve_auth_token(auth_token: str | None) -> str:
+    if auth_token:
+        return auth_token
+    raise click.ClickException(
+        "Splunk O11y token not found. Pass --auth-token."
+    )
+
+
+def _resolve_api_url(api_url: str | None, app: AppContext | None) -> str:
+    if api_url:
+        return api_url
+    for endpoint in _configured_otel_endpoints(app):
+        derived = _api_url_from_ingest_endpoint(endpoint)
+        if derived:
+            return derived
+    raise click.ClickException(
+        "Splunk O11y API URL not found. Set SFX_API_URL, pass --api-url, or configure Splunk O11y ingest first."
+    )
+
+
+def _configured_otel_endpoints(app: AppContext | None) -> list[str]:
+    if app is None or app.cfg is None:
+        return []
+    otel = getattr(app.cfg, "otel", None)
+    if otel is None:
+        return []
+    endpoints: list[str] = []
+    for attr in ("endpoint",):
+        value = getattr(otel, attr, "")
+        if value:
+            endpoints.append(str(value))
+    for signal in ("metrics", "traces", "logs"):
+        cfg = getattr(otel, signal, None)
+        value = getattr(cfg, "endpoint", "") if cfg is not None else ""
+        if value:
+            endpoints.append(str(value))
+    return endpoints
+
+
+def _api_url_from_ingest_endpoint(endpoint: str) -> str | None:
+    host = _hostname_from_endpoint(endpoint)
+    if not host:
+        return None
+    if re.fullmatch(r"api\.[a-z0-9-]+\.(signalfx\.com|observability\.splunkcloud\.com)", host):
+        return f"https://{host}"
+    match = re.fullmatch(
+        r"ingest\.([a-z0-9-]+)\.(signalfx\.com|observability\.splunkcloud\.com)",
+        host,
+    )
+    if not match:
+        return None
+    realm = match.group(1)
+    return f"https://api.{realm}.signalfx.com"
+
+
+def _hostname_from_endpoint(endpoint: str) -> str:
+    raw = endpoint.strip()
+    if not raw:
+        return ""
+    parsed = urlsplit(raw if "://" in raw else f"//{raw}")
+    host = parsed.hostname or raw.split("/", 1)[0].split(":", 1)[0]
+    return host.lower().strip()
+
+
+def _tf_bool(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _detector_summary(with_detectors: bool, enable_detectors: bool) -> str:
+    if not with_detectors:
+        return "not created"
+    if enable_detectors:
+        return "created enabled"
+    return "created disabled"

--- a/cli/defenseclaw/commands/cmd_setup_splunk_o11y_dashboards.py
+++ b/cli/defenseclaw/commands/cmd_setup_splunk_o11y_dashboards.py
@@ -18,9 +18,9 @@
 
 This command is intentionally a thin Terraform driver. It copies the bundled
 Terraform module into the user's DefenseClaw data directory, resolves the
-Splunk Observability Cloud API URL/token from config or environment, and runs
-Terraform with the token supplied through ``TF_VAR_*`` rather than command-line
-arguments.
+Splunk Observability Cloud API URL from config or environment, and requires an
+explicit Splunk O11y API token for Terraform via ``TF_VAR_*`` rather than
+command-line arguments.
 """
 
 from __future__ import annotations
@@ -138,7 +138,7 @@ def _dashboard_options(func):
         help="Label dashboard groups, dashboards, and detectors. Useful for smoke tests.",
     )(func)
     func = click.option(
-        "--auth-token",
+        "--o11y-api-token",
         default=None,
         help="Splunk O11y API access token. Required unless provided explicitly.",
     )(func)
@@ -157,7 +157,7 @@ def _dashboard_options(func):
 def plan_cmd(
     ctx: click.Context,
     api_url: str | None,
-    auth_token: str | None,
+    o11y_api_token: str | None,
     name_prefix: str,
     with_detectors: bool,
     enable_detectors: bool,
@@ -172,9 +172,9 @@ def plan_cmd(
 ) -> None:
     """Show Terraform changes for the O11y dashboard bundle."""
     prepared = _prepare_run(
-        ctx,
+        ctx.find_object(AppContext),
         api_url=api_url,
-        auth_token=auth_token,
+        o11y_api_token=o11y_api_token,
         name_prefix=name_prefix,
         with_detectors=with_detectors,
         enable_detectors=enable_detectors,
@@ -212,7 +212,7 @@ def apply_cmd(
     ctx: click.Context,
     yes: bool,
     api_url: str | None,
-    auth_token: str | None,
+    o11y_api_token: str | None,
     name_prefix: str,
     with_detectors: bool,
     enable_detectors: bool,
@@ -226,43 +226,23 @@ def apply_cmd(
     timeout: int,
 ) -> None:
     """Create or update the O11y dashboards."""
-    prepared = _prepare_run(
-        ctx,
+    apply_dashboards(
+        ctx.find_object(AppContext),
         api_url=api_url,
-        auth_token=auth_token,
+        o11y_api_token=o11y_api_token,
         name_prefix=name_prefix,
         with_detectors=with_detectors,
         enable_detectors=enable_detectors,
         detector_notifications=detector_notifications,
         work_dir=work_dir,
         state_path=state_path,
-    )
-    _run_init_validate(
-        prepared,
         terraform_bin=terraform_bin,
         plugin_dir=plugin_dir,
         skip_init=skip_init,
         skip_validate=skip_validate,
         timeout=timeout,
+        yes=yes,
     )
-    _adopt_existing_resources(prepared, terraform_bin=terraform_bin, timeout=timeout)
-    _run_terraform(
-        terraform_bin,
-        ["plan", "-input=false", f"-state={prepared.state_path}"],
-        cwd=prepared.work_dir,
-        env=prepared.env,
-        timeout=timeout,
-    )
-    if not yes:
-        click.confirm("Apply these Splunk Observability Cloud changes?", abort=True)
-    _run_terraform(
-        terraform_bin,
-        ["apply", "-input=false", "-auto-approve", f"-state={prepared.state_path}"],
-        cwd=prepared.work_dir,
-        env=prepared.env,
-        timeout=timeout,
-    )
-    _print_dashboard_outputs(prepared, terraform_bin=terraform_bin, timeout=timeout)
 
 
 @splunk_o11y_dashboards.command("destroy")
@@ -277,7 +257,7 @@ def destroy_cmd(
     ctx: click.Context,
     yes: bool,
     api_url: str | None,
-    auth_token: str | None,
+    o11y_api_token: str | None,
     name_prefix: str,
     with_detectors: bool,
     enable_detectors: bool,
@@ -292,9 +272,9 @@ def destroy_cmd(
 ) -> None:
     """Destroy O11y objects managed by the selected Terraform state."""
     prepared = _prepare_run(
-        ctx,
+        ctx.find_object(AppContext),
         api_url=api_url,
-        auth_token=auth_token,
+        o11y_api_token=o11y_api_token,
         name_prefix=name_prefix,
         with_detectors=with_detectors,
         enable_detectors=enable_detectors,
@@ -346,10 +326,10 @@ class _PreparedRun:
 
 
 def _prepare_run(
-    ctx: click.Context,
+    app: AppContext | None,
     *,
     api_url: str | None,
-    auth_token: str | None,
+    o11y_api_token: str | None,
     name_prefix: str,
     with_detectors: bool,
     enable_detectors: bool,
@@ -357,12 +337,11 @@ def _prepare_run(
     work_dir: Path | None,
     state_path: Path | None,
 ) -> _PreparedRun:
-    app = ctx.find_object(AppContext)
     data_dir = _resolve_data_dir(app)
     resolved_work_dir = (work_dir or data_dir / _DEFAULT_WORK_SUBDIR / "terraform").expanduser()
     resolved_state_path = (state_path or data_dir / _DEFAULT_WORK_SUBDIR / "terraform.tfstate").expanduser()
     resolved_api_url = _resolve_api_url(api_url, app)
-    resolved_auth_token = _resolve_auth_token(auth_token)
+    resolved_o11y_api_token = _resolve_o11y_api_token(o11y_api_token)
 
     _sync_terraform_bundle(resolved_work_dir)
     resolved_state_path.parent.mkdir(parents=True, exist_ok=True)
@@ -370,7 +349,7 @@ def _prepare_run(
     env = os.environ.copy()
     env.update(
         {
-            "TF_VAR_signalfx_auth_token": resolved_auth_token,
+            "TF_VAR_signalfx_auth_token": resolved_o11y_api_token,
             "TF_VAR_signalfx_api_url": resolved_api_url,
             "TF_VAR_name_prefix": name_prefix,
             "TF_VAR_create_detectors": _tf_bool(with_detectors),
@@ -397,6 +376,63 @@ def _prepare_run(
         name_prefix=name_prefix,
         with_detectors=with_detectors,
     )
+
+
+def apply_dashboards(
+    app: AppContext | None,
+    *,
+    api_url: str | None,
+    o11y_api_token: str | None,
+    name_prefix: str,
+    with_detectors: bool,
+    enable_detectors: bool,
+    detector_notifications: tuple[str, ...],
+    work_dir: Path | None,
+    state_path: Path | None,
+    terraform_bin: str,
+    plugin_dir: Path | None,
+    skip_init: bool,
+    skip_validate: bool,
+    timeout: int,
+    yes: bool,
+) -> None:
+    prepared = _prepare_run(
+        app,
+        api_url=api_url,
+        o11y_api_token=o11y_api_token,
+        name_prefix=name_prefix,
+        with_detectors=with_detectors,
+        enable_detectors=enable_detectors,
+        detector_notifications=detector_notifications,
+        work_dir=work_dir,
+        state_path=state_path,
+    )
+    _run_init_validate(
+        prepared,
+        terraform_bin=terraform_bin,
+        plugin_dir=plugin_dir,
+        skip_init=skip_init,
+        skip_validate=skip_validate,
+        timeout=timeout,
+    )
+    _adopt_existing_resources(prepared, terraform_bin=terraform_bin, timeout=timeout)
+    _run_terraform(
+        terraform_bin,
+        ["plan", "-input=false", f"-state={prepared.state_path}"],
+        cwd=prepared.work_dir,
+        env=prepared.env,
+        timeout=timeout,
+    )
+    if not yes:
+        click.confirm("Apply these Splunk Observability Cloud changes?", abort=True)
+    _run_terraform(
+        terraform_bin,
+        ["apply", "-input=false", "-auto-approve", f"-state={prepared.state_path}"],
+        cwd=prepared.work_dir,
+        env=prepared.env,
+        timeout=timeout,
+    )
+    _print_dashboard_outputs(prepared, terraform_bin=terraform_bin, timeout=timeout)
 
 
 def _run_init_validate(
@@ -491,12 +527,17 @@ def _terraform_console_json(terraform_bin: str, *, prepared: _PreparedRun, expr:
     return decoded
 
 
-def _o11y_api_get_json(api_url: str, auth_token: str, path: str, params: dict[str, object] | None = None) -> object:
+def _o11y_api_get_json(
+    api_url: str,
+    o11y_api_token: str,
+    path: str,
+    params: dict[str, object] | None = None,
+) -> object:
     url = f"{api_url.rstrip('/')}/{path.lstrip('/')}"
     response = requests.get(
         url,
         headers={
-            "X-SF-TOKEN": auth_token,
+            "X-SF-TOKEN": o11y_api_token,
             "Accept": "application/json",
         },
         params=params or {},
@@ -666,7 +707,7 @@ def _adopt_existing_resources(
         raise click.ClickException("Unexpected Terraform console output for dashboard or detector metadata.")
 
     state_addresses = _terraform_state_list(terraform_bin, prepared=prepared, timeout=timeout)
-    api_token = str(prepared.env["TF_VAR_signalfx_auth_token"])
+    o11y_api_token = str(prepared.env["TF_VAR_signalfx_auth_token"])
     api_url = str(prepared.env["TF_VAR_signalfx_api_url"])
 
     imported = 0
@@ -701,11 +742,11 @@ def _adopt_existing_resources(
 
     group_name = _expected_group_name(prepared.name_prefix)
     dashboard_groups_payload = _extract_list_payload(
-        _o11y_api_get_json(api_url, api_token, "/v2/dashboardgroup", params={"limit": 200, "offset": 0})
+        _o11y_api_get_json(api_url, o11y_api_token, "/v2/dashboardgroup", params={"limit": 200, "offset": 0})
     )
     candidate_groups = _find_all_named(dashboard_groups_payload, group_name)
     dashboards_payload = _extract_list_payload(
-        _o11y_api_get_json(api_url, api_token, "/v2/dashboard", params={"limit": 500, "offset": 0})
+        _o11y_api_get_json(api_url, o11y_api_token, "/v2/dashboard", params={"limit": 500, "offset": 0})
     )
     expected_dashboard_names = {
         dashboard_key: _expected_dashboard_name(base_name, prepared.name_prefix)
@@ -775,7 +816,7 @@ def _adopt_existing_resources(
 
     if prepared.with_detectors:
         detector_items = _extract_list_payload(
-            _o11y_api_get_json(api_url, api_token, "/v2/detector", params={"limit": 500, "offset": 0})
+            _o11y_api_get_json(api_url, o11y_api_token, "/v2/detector", params={"limit": 500, "offset": 0})
         )
         for detector_key, detector_def in detector_defs.items():
             if not isinstance(detector_def, dict):
@@ -896,11 +937,11 @@ def _resolve_data_dir(app: AppContext | None) -> Path:
     return Path.home() / ".defenseclaw"
 
 
-def _resolve_auth_token(auth_token: str | None) -> str:
-    if auth_token:
-        return auth_token
+def _resolve_o11y_api_token(o11y_api_token: str | None) -> str:
+    if o11y_api_token:
+        return o11y_api_token
     raise click.ClickException(
-        "Splunk O11y token not found. Pass --auth-token."
+        "Splunk O11y token not found. Pass --o11y-api-token."
     )
 
 

--- a/cli/defenseclaw/commands/cmd_setup_splunk_o11y_dashboards.py
+++ b/cli/defenseclaw/commands/cmd_setup_splunk_o11y_dashboards.py
@@ -594,7 +594,14 @@ def _dashboard_group_id(item: dict) -> str:
     return ""
 
 
-def _terraform_import(terraform_bin: str, *, prepared: _PreparedRun, address: str, remote_id: str, timeout: int) -> None:
+def _terraform_import(
+    terraform_bin: str,
+    *,
+    prepared: _PreparedRun,
+    address: str,
+    remote_id: str,
+    timeout: int,
+) -> None:
     _run_terraform(
         terraform_bin,
         ["import", "-input=false", f"-state={prepared.state_path}", address, remote_id],
@@ -651,7 +658,9 @@ def _adopt_existing_resources(
     dashboard_layouts = console_data.get("layouts") or {}
     detector_defs = console_data.get("detectors") or {}
 
-    if not isinstance(chart_maps["single"], dict) or not isinstance(chart_maps["time"], dict) or not isinstance(chart_maps["table"], dict):
+    if not isinstance(chart_maps["single"], dict) or not isinstance(chart_maps["time"], dict) or not isinstance(
+        chart_maps["table"], dict
+    ):
         raise click.ClickException("Unexpected Terraform console output for chart metadata.")
     if not isinstance(dashboard_layouts, dict) or not isinstance(detector_defs, dict):
         raise click.ClickException("Unexpected Terraform console output for dashboard or detector metadata.")
@@ -686,7 +695,9 @@ def _adopt_existing_resources(
         },
     }
     if prepared.with_detectors:
-        bundle_addresses.update({f'signalfx_detector.detector["{detector_key}"]' for detector_key in detector_defs.keys()})
+        bundle_addresses.update(
+            {f'signalfx_detector.detector["{detector_key}"]' for detector_key in detector_defs.keys()}
+        )
 
     group_name = _expected_group_name(prepared.name_prefix)
     dashboard_groups_payload = _extract_list_payload(
@@ -750,7 +761,8 @@ def _adopt_existing_resources(
             for address in bundle_state_addresses:
                 state_addresses.discard(address)
         click.echo(
-            f"  Found {len(candidate_groups)} dashboard groups named {group_name!r}, but none contained matching dashboards."
+            f"  Found {len(candidate_groups)} dashboard groups named {group_name!r}, "
+            "but none contained matching dashboards."
         )
     else:
         bundle_state_addresses = sorted(address for address in bundle_addresses if address in state_addresses)
@@ -782,7 +794,13 @@ def _adopt_existing_resources(
     for resource in resources:
         if resource.address in state_addresses:
             continue
-        _terraform_import(terraform_bin, prepared=prepared, address=resource.address, remote_id=resource.remote_id, timeout=timeout)
+        _terraform_import(
+            terraform_bin,
+            prepared=prepared,
+            address=resource.address,
+            remote_id=resource.remote_id,
+            timeout=timeout,
+        )
         state_addresses.add(resource.address)
         imported += 1
 

--- a/cli/defenseclaw/commands/cmd_setup_splunk_o11y_dashboards.py
+++ b/cli/defenseclaw/commands/cmd_setup_splunk_o11y_dashboards.py
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""defenseclaw setup splunk-o11y-dashboards — manage O11y dashboards.
+"""defenseclaw setup splunk dashboards — manage O11y dashboards.
 
 This command is intentionally a thin Terraform driver. It copies the bundled
 Terraform module into the user's DefenseClaw data directory, resolves the
@@ -55,7 +55,7 @@ _DASHBOARD_SPECS = (
 
 
 @click.group(
-    "splunk-o11y-dashboards",
+    "dashboards",
     short_help="Create/update Splunk Observability Cloud dashboards.",
 )
 def splunk_o11y_dashboards() -> None:

--- a/cli/defenseclaw/commands/cmd_setup_splunk_o11y_dashboards.py
+++ b/cli/defenseclaw/commands/cmd_setup_splunk_o11y_dashboards.py
@@ -30,16 +30,28 @@ import os
 import re
 import shutil
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlsplit
 
 import click
+import requests
 
 from defenseclaw import ux
 from defenseclaw.context import AppContext
 from defenseclaw.paths import bundled_splunk_o11y_dashboards_terraform_dir
 
 _DEFAULT_WORK_SUBDIR = "splunk-o11y-dashboards"
+
+_DASHBOARD_SPECS = (
+    ("executive", "Executive Agent Watch"),
+    ("guardrail_inspection", "Guardrail and Inspection"),
+    ("connector_ingest", "Connector and OTel Ingest"),
+    ("security_policy", "Security and Policy"),
+    ("token_economics", "DefenseClaw AI Agents Token Economics"),
+    ("runtime_reliability", "Runtime and Reliability"),
+    ("scanners_findings", "Scanners and Findings"),
+)
 
 
 @click.group(
@@ -178,6 +190,7 @@ def plan_cmd(
         skip_validate=skip_validate,
         timeout=timeout,
     )
+    _adopt_existing_resources(prepared, terraform_bin=terraform_bin, timeout=timeout)
     _run_terraform(
         terraform_bin,
         ["plan", "-input=false", f"-state={prepared.state_path}"],
@@ -232,6 +245,7 @@ def apply_cmd(
         skip_validate=skip_validate,
         timeout=timeout,
     )
+    _adopt_existing_resources(prepared, terraform_bin=terraform_bin, timeout=timeout)
     _run_terraform(
         terraform_bin,
         ["plan", "-input=false", f"-state={prepared.state_path}"],
@@ -315,10 +329,20 @@ def destroy_cmd(
 
 
 class _PreparedRun:
-    def __init__(self, work_dir: Path, state_path: Path, env: dict[str, str]) -> None:
+    def __init__(
+        self,
+        work_dir: Path,
+        state_path: Path,
+        env: dict[str, str],
+        *,
+        name_prefix: str,
+        with_detectors: bool,
+    ) -> None:
         self.work_dir = work_dir
         self.state_path = state_path
         self.env = env
+        self.name_prefix = name_prefix
+        self.with_detectors = with_detectors
 
 
 def _prepare_run(
@@ -361,6 +385,7 @@ def _prepare_run(
     click.echo(f"    API URL:       {resolved_api_url}")
     click.echo(f"    Test label:    {name_prefix or '(none)'}")
     click.echo(f"    Detectors:     {_detector_summary(with_detectors, enable_detectors)}")
+    click.echo("    Adoption:      automatic import of matching existing resources before apply")
     if not with_detectors:
         click.echo(f"    {ux.dim('Use --with-detectors to create Splunk detectors from bundled rules.')}")
     click.echo()
@@ -369,6 +394,8 @@ def _prepare_run(
         work_dir=resolved_work_dir,
         state_path=resolved_state_path,
         env=env,
+        name_prefix=name_prefix,
+        with_detectors=with_detectors,
     )
 
 
@@ -388,6 +415,387 @@ def _run_init_validate(
         _run_terraform(terraform_bin, init_args, cwd=prepared.work_dir, env=prepared.env, timeout=timeout)
     if not skip_validate:
         _run_terraform(terraform_bin, ["validate"], cwd=prepared.work_dir, env=prepared.env, timeout=timeout)
+
+
+@dataclass(frozen=True)
+class _ImportTarget:
+    address: str
+    remote_id: str
+
+
+def _terraform_state_list(terraform_bin: str, *, prepared: _PreparedRun, timeout: int) -> set[str]:
+    result = _run_terraform(
+        terraform_bin,
+        ["state", "list", f"-state={prepared.state_path}"],
+        cwd=prepared.work_dir,
+        env=prepared.env,
+        timeout=timeout,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return set()
+    return {line.strip() for line in (result.stdout or "").splitlines() if line.strip()}
+
+
+def _terraform_console_json(terraform_bin: str, *, prepared: _PreparedRun, expr: str, timeout: int):
+    display = f"{terraform_bin} console"
+    click.echo(f"  {ux.dim('$')} {display}")
+    try:
+        result = subprocess.run(
+            [terraform_bin, "console", "-no-color"],
+            cwd=str(prepared.work_dir),
+            env=prepared.env,
+            text=True,
+            input=expr + "\n",
+            capture_output=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        raise click.ClickException(
+            f"Terraform executable not found: {terraform_bin}. Install Terraform or pass --terraform-bin."
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise click.ClickException(f"Terraform console timed out after {timeout}s: {display}") from exc
+    except OSError as exc:
+        raise click.ClickException(f"Could not execute Terraform console: {exc}") from exc
+
+    if result.returncode != 0:
+        _echo_captured_failure(result)
+        raise click.ClickException(f"Terraform console failed with exit code {result.returncode}: {display}")
+
+    raw = (result.stdout or "").strip()
+    if not raw:
+        return None
+    try:
+        decoded = json.loads(raw)
+    except ValueError as exc:
+        raise click.ClickException(f"Terraform console did not return JSON: {raw[:120]}") from exc
+    if isinstance(decoded, str):
+        try:
+            return json.loads(decoded)
+        except ValueError:
+            return decoded
+    return decoded
+
+
+def _o11y_api_get_json(api_url: str, auth_token: str, path: str, params: dict[str, object] | None = None) -> object:
+    url = f"{api_url.rstrip('/')}/{path.lstrip('/')}"
+    response = requests.get(
+        url,
+        headers={
+            "X-SF-TOKEN": auth_token,
+            "Accept": "application/json",
+        },
+        params=params or {},
+        timeout=30,
+    )
+    try:
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise click.ClickException(f"Splunk O11y API request failed for {url}: {exc}") from exc
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise click.ClickException(f"Splunk O11y API returned invalid JSON for {url}") from exc
+
+
+def _extract_list_payload(payload: object) -> list[object]:
+    if isinstance(payload, list):
+        return payload
+    if not isinstance(payload, dict):
+        return []
+    for key in ("results", "dashboardGroups", "dashboards", "detectors", "charts", "items", "data"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            return value
+    for value in payload.values():
+        if isinstance(value, list):
+            return value
+    return []
+
+
+def _find_exact_named(items: list[object], expected_name: str, *, group_id: str | None = None) -> dict | None:
+    matches: list[dict] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or item.get("dashboardName") or item.get("title") or "").strip()
+        if name != expected_name:
+            continue
+        if group_id:
+            item_group = str(
+                item.get("dashboardGroupId")
+                or item.get("dashboardGroupID")
+                or item.get("groupId")
+                or item.get("dashboard_group_id")
+                or ""
+            ).strip()
+            if item_group and item_group != group_id:
+                continue
+        matches.append(item)
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        raise click.ClickException(f"Found multiple O11y resources named {expected_name!r}; cannot adopt safely.")
+    return None
+
+
+def _find_all_named(items: list[object], expected_name: str) -> list[dict]:
+    matches: list[dict] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or item.get("dashboardName") or item.get("title") or "").strip()
+        if name == expected_name:
+            matches.append(item)
+    return matches
+
+
+def _resource_id(item: object) -> str:
+    if isinstance(item, str):
+        return item
+    if not isinstance(item, dict):
+        raise click.ClickException(f"Could not determine resource id from O11y object: {item!r}")
+    for key in ("id", "dashboardId", "dashboard_id", "detectorId", "detector_id", "chartId", "chart_id", "groupId"):
+        value = item.get(key)
+        if value:
+            return str(value)
+    raise click.ClickException(f"Could not determine resource id from O11y object: {item!r}")
+
+
+def _expected_dashboard_name(base: str, name_prefix: str) -> str:
+    prefix = name_prefix.strip()
+    return f"{base} ({prefix})" if prefix else base
+
+
+def _expected_group_name(name_prefix: str) -> str:
+    prefix = name_prefix.strip()
+    return f"{prefix} DefenseClaw O11y".strip() if prefix else "DefenseClaw O11y"
+
+
+def _dashboard_group_id(item: dict) -> str:
+    for key in ("dashboardGroupId", "dashboardGroupID", "groupId", "dashboard_group_id"):
+        value = item.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def _terraform_import(terraform_bin: str, *, prepared: _PreparedRun, address: str, remote_id: str, timeout: int) -> None:
+    _run_terraform(
+        terraform_bin,
+        ["import", "-input=false", f"-state={prepared.state_path}", address, remote_id],
+        cwd=prepared.work_dir,
+        env=prepared.env,
+        timeout=timeout,
+    )
+
+
+def _dashboard_charts(detail: object) -> list[dict]:
+    if not isinstance(detail, dict):
+        return []
+    for container in (detail, detail.get("dashboard"), detail.get("data")):
+        if not isinstance(container, dict):
+            continue
+        for key in ("charts", "dashboardCharts", "elements", "items"):
+            value = container.get(key)
+            if isinstance(value, list):
+                charts = [item if isinstance(item, dict) else {"id": str(item)} for item in value if item is not None]
+                if charts:
+                    return charts
+    return []
+
+
+def _adopt_existing_resources(
+    prepared: _PreparedRun,
+    *,
+    terraform_bin: str,
+    timeout: int,
+) -> None:
+    ux.section("Adopting existing Splunk O11y resources")
+    console_data = _terraform_console_json(
+        terraform_bin,
+        prepared=prepared,
+        expr=(
+            "jsonencode({"
+            "single = local.single_value_charts,"
+            "time = local.time_charts,"
+            "table = local.table_charts,"
+            "layouts = local.dashboard_layouts,"
+            "detectors = local.detectors"
+            "})"
+        ),
+        timeout=timeout,
+    )
+    if not isinstance(console_data, dict):
+        raise click.ClickException("Unexpected Terraform console output while loading the dashboard bundle metadata.")
+
+    chart_maps = {
+        "single": console_data.get("single") or {},
+        "time": console_data.get("time") or {},
+        "table": console_data.get("table") or {},
+    }
+    dashboard_layouts = console_data.get("layouts") or {}
+    detector_defs = console_data.get("detectors") or {}
+
+    if not isinstance(chart_maps["single"], dict) or not isinstance(chart_maps["time"], dict) or not isinstance(chart_maps["table"], dict):
+        raise click.ClickException("Unexpected Terraform console output for chart metadata.")
+    if not isinstance(dashboard_layouts, dict) or not isinstance(detector_defs, dict):
+        raise click.ClickException("Unexpected Terraform console output for dashboard or detector metadata.")
+
+    state_addresses = _terraform_state_list(terraform_bin, prepared=prepared, timeout=timeout)
+    api_token = str(prepared.env["TF_VAR_signalfx_auth_token"])
+    api_url = str(prepared.env["TF_VAR_signalfx_api_url"])
+
+    imported = 0
+    resources: list[_ImportTarget] = []
+
+    group_name = _expected_group_name(prepared.name_prefix)
+    dashboard_groups_payload = _extract_list_payload(
+        _o11y_api_get_json(api_url, api_token, "/v2/dashboardgroup", params={"limit": 200, "offset": 0})
+    )
+    candidate_groups = _find_all_named(dashboard_groups_payload, group_name)
+    dashboards_payload = _extract_list_payload(
+        _o11y_api_get_json(api_url, api_token, "/v2/dashboard", params={"limit": 500, "offset": 0})
+    )
+    expected_dashboard_names = {
+        dashboard_key: _expected_dashboard_name(base_name, prepared.name_prefix)
+        for dashboard_key, base_name in _DASHBOARD_SPECS
+    }
+    dashboards_by_group: dict[str, dict[str, dict]] = {}
+    for group_item in candidate_groups:
+        group_id = _resource_id(group_item)
+        group_dashboards: dict[str, dict] = {}
+        for dashboard_key, dashboard_name in expected_dashboard_names.items():
+            dashboard_item = _find_exact_named(dashboards_payload, dashboard_name, group_id=group_id)
+            if dashboard_item is not None:
+                group_dashboards[dashboard_key] = dashboard_item
+        dashboards_by_group[group_id] = group_dashboards
+
+    chosen_group: dict | None = None
+    chosen_group_dashboards: dict[str, dict] = {}
+    if candidate_groups:
+        chosen_group = max(
+            enumerate(candidate_groups),
+            key=lambda pair: (len(dashboards_by_group.get(_resource_id(pair[1]), {})), pair[0]),
+        )[1]
+        chosen_group_dashboards = dashboards_by_group.get(_resource_id(chosen_group), {})
+        top_score = len(chosen_group_dashboards)
+        tied = [
+            item
+            for item in candidate_groups
+            if len(dashboards_by_group.get(_resource_id(item), {})) == top_score
+        ]
+        if len(tied) > 1:
+            tie_ids = ", ".join(f"{_resource_id(item)}" for item in tied)
+            click.echo(
+                f"  warning: multiple dashboard groups named {group_name!r} matched equally ({top_score} dashboards); "
+                f"using the first candidate. IDs: {tie_ids}"
+            )
+
+    if chosen_group is not None and chosen_group_dashboards:
+        group_id = _resource_id(chosen_group)
+        click.echo(f"  Selected dashboard group {group_name!r} (id: {group_id}) for adoption.")
+        resources.append(_ImportTarget("signalfx_dashboard_group.defenseclaw_o11y", group_id))
+        for dashboard_key, dashboard_item in chosen_group_dashboards.items():
+            resources.append(_ImportTarget(f"signalfx_dashboard.{dashboard_key}", _resource_id(dashboard_item)))
+
+        for dashboard_key, dashboard_item in chosen_group_dashboards.items():
+            expected_layout = dashboard_layouts.get(dashboard_key) or []
+            if not isinstance(expected_layout, list):
+                continue
+            dashboard_id = _resource_id(dashboard_item)
+            chart_items = _dashboard_charts(_o11y_api_get_json(api_url, api_token, f"/v2/dashboard/{dashboard_id}"))
+            if len(chart_items) < len(expected_layout):
+                raise click.ClickException(
+                    f"Dashboard {dashboard_item.get('name')!r} has fewer remote charts than the Terraform bundle expects."
+                )
+            for position, chart_layout in enumerate(expected_layout):
+                if not isinstance(chart_layout, dict):
+                    continue
+                chart_key = str(chart_layout.get("key") or "").strip()
+                chart_type = str(chart_layout.get("type") or "").strip()
+                chart_defs = chart_maps.get(chart_type)
+                expected_chart = chart_defs.get(chart_key) if isinstance(chart_defs, dict) else None
+                resource_prefix = {
+                    "single": "signalfx_single_value_chart.single",
+                    "time": "signalfx_time_chart.time",
+                    "table": "signalfx_table_chart.table",
+                }.get(chart_type)
+                if resource_prefix is None:
+                    continue
+                chart_address = f'{resource_prefix}["{chart_key}"]'
+                if chart_address in state_addresses:
+                    continue
+                chart_item = chart_items[position]
+                if isinstance(expected_chart, dict) and isinstance(chart_item, dict):
+                    expected_name = str(expected_chart.get("name") or "").strip()
+                    expected_desc = str(expected_chart.get("description") or "").strip()
+                    remote_name = str(chart_item.get("name") or chart_item.get("title") or "").strip()
+                    remote_desc = str(chart_item.get("description") or "").strip()
+                    if expected_name and remote_name and expected_name != remote_name:
+                        match = None
+                        for candidate in chart_items:
+                            if not isinstance(candidate, dict):
+                                continue
+                            candidate_name = str(candidate.get("name") or candidate.get("title") or "").strip()
+                            candidate_desc = str(candidate.get("description") or "").strip()
+                            if candidate_name == expected_name and (not expected_desc or candidate_desc == expected_desc):
+                                match = candidate
+                                break
+                        if match is not None:
+                            chart_item = match
+                    elif expected_desc and remote_desc and expected_desc != remote_desc:
+                        match = None
+                        for candidate in chart_items:
+                            if not isinstance(candidate, dict):
+                                continue
+                            candidate_name = str(candidate.get("name") or candidate.get("title") or "").strip()
+                            candidate_desc = str(candidate.get("description") or "").strip()
+                            if candidate_name == expected_name and candidate_desc == expected_desc:
+                                match = candidate
+                                break
+                        if match is not None:
+                            chart_item = match
+                resources.append(_ImportTarget(chart_address, _resource_id(chart_item)))
+
+    elif candidate_groups:
+        click.echo(
+            f"  Found {len(candidate_groups)} dashboard groups named {group_name!r}, but none contained matching dashboards."
+        )
+    else:
+        click.echo(f"  No existing dashboard group named {group_name!r} was found; nothing to adopt.")
+
+    if prepared.with_detectors:
+        detector_items = _extract_list_payload(
+            _o11y_api_get_json(api_url, api_token, "/v2/detector", params={"limit": 500, "offset": 0})
+        )
+        for detector_key, detector_def in detector_defs.items():
+            if not isinstance(detector_def, dict):
+                continue
+            detector_name = str(detector_def.get("name") or "").strip()
+            if not detector_name:
+                continue
+            detector_item = _find_exact_named(detector_items, detector_name)
+            if detector_item is None:
+                continue
+            detector_address = f'signalfx_detector.detector["{detector_key}"]'
+            if detector_address in state_addresses:
+                continue
+            resources.append(_ImportTarget(detector_address, _resource_id(detector_item)))
+
+    for resource in resources:
+        if resource.address in state_addresses:
+            continue
+        _terraform_import(terraform_bin, prepared=prepared, address=resource.address, remote_id=resource.remote_id, timeout=timeout)
+        state_addresses.add(resource.address)
+        imported += 1
+
+    if imported:
+        click.echo(f"  Imported {imported} existing resources into the selected Terraform state.")
+    else:
+        click.echo("  No matching existing resources needed import.")
 
 
 def _run_terraform(

--- a/cli/defenseclaw/commands/cmd_setup_splunk_o11y_dashboards.py
+++ b/cli/defenseclaw/commands/cmd_setup_splunk_o11y_dashboards.py
@@ -385,7 +385,7 @@ def _prepare_run(
     click.echo(f"    API URL:       {resolved_api_url}")
     click.echo(f"    Test label:    {name_prefix or '(none)'}")
     click.echo(f"    Detectors:     {_detector_summary(with_detectors, enable_detectors)}")
-    click.echo("    Adoption:      automatic import of matching existing resources before apply")
+    click.echo("    Adoption:      automatic import of matching existing dashboards before apply")
     if not with_detectors:
         click.echo(f"    {ux.dim('Use --with-detectors to create Splunk detectors from bundled rules.')}")
     click.echo()
@@ -436,6 +436,18 @@ def _terraform_state_list(terraform_bin: str, *, prepared: _PreparedRun, timeout
     if result.returncode != 0:
         return set()
     return {line.strip() for line in (result.stdout or "").splitlines() if line.strip()}
+
+
+def _terraform_state_rm(terraform_bin: str, *, prepared: _PreparedRun, addresses: list[str], timeout: int) -> None:
+    if not addresses:
+        return
+    _run_terraform(
+        terraform_bin,
+        ["state", "rm", f"-state={prepared.state_path}", *addresses],
+        cwd=prepared.work_dir,
+        env=prepared.env,
+        timeout=timeout,
+    )
 
 
 def _terraform_console_json(terraform_bin: str, *, prepared: _PreparedRun, expr: str, timeout: int):
@@ -650,6 +662,31 @@ def _adopt_existing_resources(
 
     imported = 0
     resources: list[_ImportTarget] = []
+    chart_addresses = [
+        f'{resource_prefix}["{chart_key}"]'
+        for chart_type, resource_prefix in (
+            ("single", "signalfx_single_value_chart.single"),
+            ("time", "signalfx_time_chart.time"),
+            ("table", "signalfx_table_chart.table"),
+        )
+        for chart_key in (chart_maps.get(chart_type) or {}).keys()
+        if f'{resource_prefix}["{chart_key}"]' in state_addresses
+    ]
+    bundle_addresses = {
+        "signalfx_dashboard_group.defenseclaw_o11y",
+        *{f"signalfx_dashboard.{dashboard_key}" for dashboard_key in dashboard_layouts.keys()},
+        *{
+            f'{resource_prefix}["{chart_key}"]'
+            for chart_type, resource_prefix in (
+                ("single", "signalfx_single_value_chart.single"),
+                ("time", "signalfx_time_chart.time"),
+                ("table", "signalfx_table_chart.table"),
+            )
+            for chart_key in (chart_maps.get(chart_type) or {}).keys()
+        },
+    }
+    if prepared.with_detectors:
+        bundle_addresses.update({f'signalfx_detector.detector["{detector_key}"]' for detector_key in detector_defs.keys()})
 
     group_name = _expected_group_name(prepared.name_prefix)
     dashboard_groups_payload = _extract_list_payload(
@@ -700,71 +737,28 @@ def _adopt_existing_resources(
         resources.append(_ImportTarget("signalfx_dashboard_group.defenseclaw_o11y", group_id))
         for dashboard_key, dashboard_item in chosen_group_dashboards.items():
             resources.append(_ImportTarget(f"signalfx_dashboard.{dashboard_key}", _resource_id(dashboard_item)))
-
-        for dashboard_key, dashboard_item in chosen_group_dashboards.items():
-            expected_layout = dashboard_layouts.get(dashboard_key) or []
-            if not isinstance(expected_layout, list):
-                continue
-            dashboard_id = _resource_id(dashboard_item)
-            chart_items = _dashboard_charts(_o11y_api_get_json(api_url, api_token, f"/v2/dashboard/{dashboard_id}"))
-            if len(chart_items) < len(expected_layout):
-                raise click.ClickException(
-                    f"Dashboard {dashboard_item.get('name')!r} has fewer remote charts than the Terraform bundle expects."
-                )
-            for position, chart_layout in enumerate(expected_layout):
-                if not isinstance(chart_layout, dict):
-                    continue
-                chart_key = str(chart_layout.get("key") or "").strip()
-                chart_type = str(chart_layout.get("type") or "").strip()
-                chart_defs = chart_maps.get(chart_type)
-                expected_chart = chart_defs.get(chart_key) if isinstance(chart_defs, dict) else None
-                resource_prefix = {
-                    "single": "signalfx_single_value_chart.single",
-                    "time": "signalfx_time_chart.time",
-                    "table": "signalfx_table_chart.table",
-                }.get(chart_type)
-                if resource_prefix is None:
-                    continue
-                chart_address = f'{resource_prefix}["{chart_key}"]'
-                if chart_address in state_addresses:
-                    continue
-                chart_item = chart_items[position]
-                if isinstance(expected_chart, dict) and isinstance(chart_item, dict):
-                    expected_name = str(expected_chart.get("name") or "").strip()
-                    expected_desc = str(expected_chart.get("description") or "").strip()
-                    remote_name = str(chart_item.get("name") or chart_item.get("title") or "").strip()
-                    remote_desc = str(chart_item.get("description") or "").strip()
-                    if expected_name and remote_name and expected_name != remote_name:
-                        match = None
-                        for candidate in chart_items:
-                            if not isinstance(candidate, dict):
-                                continue
-                            candidate_name = str(candidate.get("name") or candidate.get("title") or "").strip()
-                            candidate_desc = str(candidate.get("description") or "").strip()
-                            if candidate_name == expected_name and (not expected_desc or candidate_desc == expected_desc):
-                                match = candidate
-                                break
-                        if match is not None:
-                            chart_item = match
-                    elif expected_desc and remote_desc and expected_desc != remote_desc:
-                        match = None
-                        for candidate in chart_items:
-                            if not isinstance(candidate, dict):
-                                continue
-                            candidate_name = str(candidate.get("name") or candidate.get("title") or "").strip()
-                            candidate_desc = str(candidate.get("description") or "").strip()
-                            if candidate_name == expected_name and candidate_desc == expected_desc:
-                                match = candidate
-                                break
-                        if match is not None:
-                            chart_item = match
-                resources.append(_ImportTarget(chart_address, _resource_id(chart_item)))
+        if chart_addresses:
+            _terraform_state_rm(terraform_bin, prepared=prepared, addresses=chart_addresses, timeout=timeout)
+            for address in chart_addresses:
+                state_addresses.discard(address)
 
     elif candidate_groups:
+        bundle_state_addresses = sorted(address for address in bundle_addresses if address in state_addresses)
+        if bundle_state_addresses:
+            click.echo("  No matching dashboards were found in O11y; clearing stale bundle state before apply.")
+            _terraform_state_rm(terraform_bin, prepared=prepared, addresses=bundle_state_addresses, timeout=timeout)
+            for address in bundle_state_addresses:
+                state_addresses.discard(address)
         click.echo(
             f"  Found {len(candidate_groups)} dashboard groups named {group_name!r}, but none contained matching dashboards."
         )
     else:
+        bundle_state_addresses = sorted(address for address in bundle_addresses if address in state_addresses)
+        if bundle_state_addresses:
+            click.echo("  No existing dashboard group was found; clearing stale bundle state before apply.")
+            _terraform_state_rm(terraform_bin, prepared=prepared, addresses=bundle_state_addresses, timeout=timeout)
+            for address in bundle_state_addresses:
+                state_addresses.discard(address)
         click.echo(f"  No existing dashboard group named {group_name!r} was found; nothing to adopt.")
 
     if prepared.with_detectors:

--- a/cli/defenseclaw/paths.py
+++ b/cli/defenseclaw/paths.py
@@ -21,12 +21,14 @@ Wheel install (production):
     <site-packages>/defenseclaw/_data/skills/codeguard/
     <site-packages>/defenseclaw/_data/splunk_local_bridge/
     <site-packages>/defenseclaw/_data/local_observability_stack/
+    <site-packages>/defenseclaw/_data/splunk_o11y_dashboards/
 
 Editable install (dev):
     <repo>/policies/
     <repo>/skills/codeguard/
     <repo>/bundles/splunk_local_bridge/
     <repo>/bundles/local_observability_stack/
+    <repo>/bundles/splunk_o11y_dashboards/
     <repo>/extensions/defenseclaw/
 
 Every resolver tries _data/ first (wheel), then repo-relative (dev).
@@ -94,6 +96,19 @@ def bundled_local_observability_dir() -> Path:
         _DATA_DIR / "local_observability_stack",
         _REPO_ROOT / "bundles" / "local_observability_stack",
     )
+
+
+def bundled_splunk_o11y_dashboards_dir() -> Path:
+    """Terraform dashboard bundle for Splunk Observability Cloud."""
+    return _first_existing(
+        _DATA_DIR / "splunk_o11y_dashboards",
+        _REPO_ROOT / "bundles" / "splunk_o11y_dashboards",
+    )
+
+
+def bundled_splunk_o11y_dashboards_terraform_dir() -> Path:
+    """Terraform module path for the Splunk Observability Cloud dashboard bundle."""
+    return bundled_splunk_o11y_dashboards_dir() / "terraform"
 
 
 def bundled_extensions_dir() -> Path:

--- a/cli/tests/test_cmd_misc.py
+++ b/cli/tests/test_cmd_misc.py
@@ -18,19 +18,17 @@
 
 import json
 import os
-import tempfile
+import sys
 import unittest
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
-import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from click.testing import CliRunner
-
 from defenseclaw.models import Event
-from tests.helpers import make_app_context, cleanup_app
 
+from tests.helpers import cleanup_app, make_app_context
 
 # ---------------------------------------------------------------------------
 # Status command
@@ -263,7 +261,6 @@ class TestAlertsCommand(unittest.TestCase):
     def _insert_scan_with_findings(self, target, scanner, findings):
         """Helper: insert a scan_result and its findings into the store."""
         import uuid
-        from datetime import timedelta
         scan_id = str(uuid.uuid4())
         max_sev = findings[0]["severity"] if findings else "INFO"
         self.app.store.insert_scan_result(
@@ -716,12 +713,22 @@ class TestSetupSplunkCommand(unittest.TestCase):
 
         result = self.runner.invoke(setup, ["splunk", "--help"], obj=self.app)
         self.assertEqual(result.exit_code, 0)
+        self.assertIn("dashboards", result.output)
         self.assertIn("--o11y", result.output)
         self.assertIn("--logs", result.output)
         self.assertIn("--enterprise", result.output)
         self.assertIn("--hec-endpoint", result.output)
         self.assertIn("--skip-test", result.output)
         self.assertIn("--accept-splunk-license", result.output)
+
+    def test_setup_splunk_dashboards_help(self):
+        from defenseclaw.commands.cmd_setup import setup
+
+        result = self.runner.invoke(setup, ["splunk", "dashboards", "apply", "--help"], obj=self.app)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("--api-url", result.output)
+        self.assertIn("--auth-token", result.output)
+        self.assertIn("--with-detectors", result.output)
 
     def test_setup_splunk_o11y_non_interactive(self):
         from defenseclaw.commands.cmd_setup import setup

--- a/cli/tests/test_cmd_misc.py
+++ b/cli/tests/test_cmd_misc.py
@@ -727,7 +727,7 @@ class TestSetupSplunkCommand(unittest.TestCase):
         result = self.runner.invoke(setup, ["splunk", "dashboards", "apply", "--help"], obj=self.app)
         self.assertEqual(result.exit_code, 0)
         self.assertIn("--api-url", result.output)
-        self.assertIn("--auth-token", result.output)
+        self.assertIn("--o11y-api-token", result.output)
         self.assertIn("--with-detectors", result.output)
 
     def test_setup_splunk_o11y_non_interactive(self):
@@ -1246,7 +1246,8 @@ class TestSetupSplunkCommand(unittest.TestCase):
         self.assertFalse(self.app.cfg.otel.enabled)
         self.assertFalse(self.app.cfg.splunk.enabled)
 
-    def test_setup_splunk_interactive_o11y(self):
+    @patch("defenseclaw.commands.cmd_setup.apply_dashboards")
+    def test_setup_splunk_interactive_o11y(self, mock_apply_dashboards):
         from defenseclaw.commands.cmd_setup import setup
 
         user_input = "\n".join([
@@ -1257,6 +1258,7 @@ class TestSetupSplunkCommand(unittest.TestCase):
             "y",           # Traces?
             "y",           # Metrics?
             "n",           # Logs?
+            "n",           # Install dashboards?
             "n",           # Enable local?
             "n",           # Enable Enterprise?
         ]) + "\n"
@@ -1269,6 +1271,37 @@ class TestSetupSplunkCommand(unittest.TestCase):
         self.assertTrue(self.app.cfg.otel.enabled)
         self.assertEqual(self.app.cfg.otel.traces.endpoint, "ingest.us1.observability.splunkcloud.com")
         self.assertFalse(self.app.cfg.otel.logs.enabled)
+        mock_apply_dashboards.assert_not_called()
+
+    @patch("defenseclaw.commands.cmd_setup.apply_dashboards")
+    def test_setup_splunk_interactive_o11y_installs_dashboards(self, mock_apply_dashboards):
+        from defenseclaw.commands.cmd_setup import setup
+
+        user_input = "\n".join([
+            "y",           # Enable O11y?
+            "us1",         # Realm
+            "my-secret",   # Access token
+            "test-svc",    # Service name
+            "y",           # Traces?
+            "y",           # Metrics?
+            "n",           # Logs?
+            "y",           # Install dashboards?
+            "o11y-api-token",  # O11y API token
+            "n",           # Enable local?
+            "n",           # Enable Enterprise?
+        ]) + "\n"
+
+        result = self.runner.invoke(
+            setup, ["splunk"], obj=self.app,
+            input=user_input, catch_exceptions=False,
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_apply_dashboards.assert_called_once()
+        call_args = mock_apply_dashboards.call_args.args
+        call_kwargs = mock_apply_dashboards.call_args.kwargs
+        self.assertIs(call_args[0], self.app)
+        self.assertEqual(call_kwargs["o11y_api_token"], "o11y-api-token")
+        self.assertTrue(call_kwargs["yes"])
 
     def test_setup_splunk_show_credentials_no_env_file(self):
         from defenseclaw.commands.cmd_setup import setup

--- a/cli/tests/test_cmd_setup_splunk_o11y_dashboards.py
+++ b/cli/tests/test_cmd_setup_splunk_o11y_dashboards.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -37,8 +38,23 @@ from defenseclaw.commands.cmd_setup_splunk_o11y_dashboards import (
 class SplunkO11yDashboardCommandTests(unittest.TestCase):
     def test_apply_runs_terraform_with_secret_in_env_not_args(self) -> None:
         calls = []
+        console_payload = {"single": {}, "time": {}, "table": {}, "layouts": {}, "detectors": {}}
 
-        def fake_run(cmd, cwd, env, text, capture_output, timeout):
+        class FakeResponse:
+            def __init__(self, payload):
+                self._payload = payload
+                self.status_code = 200
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return self._payload
+
+        def fake_get(url, headers=None, params=None, timeout=None):
+            return FakeResponse({"results": []})
+
+        def fake_run(cmd, cwd, env, text, capture_output, timeout, input=None):
             calls.append(
                 {
                     "cmd": cmd,
@@ -49,6 +65,10 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
                     "timeout": timeout,
                 }
             )
+            if cmd[1] == "console":
+                return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(json.dumps(console_payload)))
+            if cmd[1] == "state":
+                return subprocess.CompletedProcess(cmd, 0, stdout="")
             if cmd[1] == "output":
                 return subprocess.CompletedProcess(
                     cmd,
@@ -60,6 +80,9 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td, patch(
             "defenseclaw.commands.cmd_setup_splunk_o11y_dashboards.subprocess.run",
             side_effect=fake_run,
+        ), patch(
+            "defenseclaw.commands.cmd_setup_splunk_o11y_dashboards.requests.get",
+            side_effect=fake_get,
         ):
             tmp_path = Path(td)
             work_dir = tmp_path / "tf-work"
@@ -88,27 +111,278 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
             self.assertEqual(result.exit_code, 0, result.output)
             self.assertTrue((work_dir / "main.tf").is_file())
 
-        self.assertEqual([call["cmd"][1] for call in calls], ["plan", "apply", "output"])
+        self.assertEqual([call["cmd"][1] for call in calls], ["console", "state", "plan", "apply", "output"])
         self.assertTrue(all("secret-token" not in " ".join(call["cmd"]) for call in calls))
-        self.assertEqual(calls[0]["env"]["TF_VAR_signalfx_auth_token"], "secret-token")
-        self.assertEqual(calls[0]["env"]["TF_VAR_signalfx_api_url"], "https://api.realm.signalfx.com")
-        self.assertEqual(calls[0]["env"]["TF_VAR_name_prefix"], "Smoke")
-        self.assertEqual(calls[0]["env"]["TF_VAR_create_detectors"], "false")
-        self.assertEqual(calls[0]["env"]["TF_VAR_detectors_disabled"], "true")
-        self.assertIn(f"-state={state_path}", calls[0]["cmd"])
+        self.assertEqual(calls[2]["env"]["TF_VAR_signalfx_auth_token"], "secret-token")
+        self.assertEqual(calls[2]["env"]["TF_VAR_signalfx_api_url"], "https://api.realm.signalfx.com")
+        self.assertEqual(calls[2]["env"]["TF_VAR_name_prefix"], "Smoke")
+        self.assertEqual(calls[2]["env"]["TF_VAR_create_detectors"], "false")
+        self.assertEqual(calls[2]["env"]["TF_VAR_detectors_disabled"], "true")
+        self.assertIn(f"-state={state_path}", calls[1]["cmd"])
         self.assertIn(f"-state={state_path}", calls[2]["cmd"])
         self.assertIn("executive: https://app.signalfx.com/#/dashboard/abc", result.output)
 
-    def test_plan_initializes_with_optional_plugin_dir(self) -> None:
+    def test_apply_adopts_existing_dashboards_before_apply(self) -> None:
         calls = []
 
-        def fake_run(cmd, cwd, env, text, capture_output, timeout):
+        console_payload = {
+            "single": {
+                "executive_verdicts_31d": {
+                    "name": "Verdicts",
+                    "description": "All DefenseClaw gateway verdicts in the selected time range.",
+                }
+            },
+            "time": {},
+            "table": {},
+            "layouts": {
+                "executive": [
+                    {"type": "single", "key": "executive_verdicts_31d", "row": 0, "column": 0, "width": 2, "height": 1}
+                ],
+                "guardrail_inspection": [],
+                "connector_ingest": [],
+                "security_policy": [],
+                "token_economics": [],
+                "runtime_reliability": [],
+                "scanners_findings": [],
+            },
+            "detectors": {},
+        }
+
+        class FakeResponse:
+            def __init__(self, payload):
+                self._payload = payload
+                self.status_code = 200
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return self._payload
+
+        def fake_get(url, headers=None, params=None, timeout=None):
+            if url.endswith("/v2/dashboardgroup"):
+                return FakeResponse({"results": [{"id": "dg-1", "name": "Smoke DefenseClaw O11y"}]})
+            if url.endswith("/v2/dashboard"):
+                return FakeResponse(
+                    {
+                        "results": [
+                            {
+                                "id": "db-1",
+                                "name": "Executive Agent Watch (Smoke)",
+                                "dashboardGroupId": "dg-1",
+                            }
+                        ]
+                    }
+                )
+            if url.endswith("/v2/dashboard/db-1"):
+                return FakeResponse(
+                    {
+                        "charts": [
+                            {"id": "chart-1", "name": "Verdicts", "description": "All DefenseClaw gateway verdicts in the selected time range."}
+                        ]
+                    }
+                )
+            raise AssertionError(f"unexpected API url: {url}")
+
+        def fake_run(*args, **kwargs):
+            cmd = args[0]
+            calls.append({"cmd": cmd, "kwargs": kwargs})
+            if cmd[1] == "console":
+                return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(json.dumps(console_payload)))
+            if cmd[1] == "state":
+                return subprocess.CompletedProcess(cmd, 0, stdout="")
+            if cmd[1] == "import":
+                return subprocess.CompletedProcess(cmd, 0, stdout="")
+            if cmd[1] in {"plan", "apply", "output", "validate", "init"}:
+                if cmd[1] == "output":
+                    return subprocess.CompletedProcess(cmd, 0, stdout='{"executive":"https://app.signalfx.com/#/dashboard/abc"}')
+                return subprocess.CompletedProcess(cmd, 0, stdout="")
+            raise AssertionError(f"unexpected terraform cmd: {cmd}")
+
+        with tempfile.TemporaryDirectory() as td, patch(
+            "defenseclaw.commands.cmd_setup_splunk_o11y_dashboards.subprocess.run",
+            side_effect=fake_run,
+        ), patch(
+            "defenseclaw.commands.cmd_setup_splunk_o11y_dashboards.requests.get",
+            side_effect=fake_get,
+        ):
+            tmp_path = Path(td)
+            result = CliRunner().invoke(
+                splunk_o11y_dashboards,
+                [
+                    "apply",
+                    "--api-url",
+                    "https://api.realm.signalfx.com",
+                    "--auth-token",
+                    "secret-token",
+                    "--name-prefix",
+                    "Smoke",
+                    "--work-dir",
+                    str(tmp_path / "tf-work"),
+                    "--state",
+                    str(tmp_path / "state" / "terraform.tfstate"),
+                    "--skip-init",
+                    "--skip-validate",
+                    "--yes",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        import_cmds = [call["cmd"] for call in calls if call["cmd"][1] == "import"]
+        self.assertEqual(
+            import_cmds,
+            [
+                ["terraform", "import", "-input=false", f"-state={tmp_path / 'state' / 'terraform.tfstate'}", "signalfx_dashboard_group.defenseclaw_o11y", "dg-1"],
+                ["terraform", "import", "-input=false", f"-state={tmp_path / 'state' / 'terraform.tfstate'}", "signalfx_dashboard.executive", "db-1"],
+                ["terraform", "import", "-input=false", f"-state={tmp_path / 'state' / 'terraform.tfstate'}", 'signalfx_single_value_chart.single["executive_verdicts_31d"]', "chart-1"],
+            ],
+        )
+
+    def test_apply_adopts_best_matching_dashboard_group(self) -> None:
+        calls = []
+
+        console_payload = {
+            "single": {},
+            "time": {},
+            "table": {},
+            "layouts": {
+                "executive": [],
+                "guardrail_inspection": [],
+                "connector_ingest": [],
+                "security_policy": [],
+                "token_economics": [],
+                "runtime_reliability": [],
+                "scanners_findings": [],
+            },
+            "detectors": {},
+        }
+
+        class FakeResponse:
+            def __init__(self, payload):
+                self._payload = payload
+                self.status_code = 200
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return self._payload
+
+        def fake_get(url, headers=None, params=None, timeout=None):
+            if url.endswith("/v2/dashboardgroup"):
+                return FakeResponse(
+                    {
+                        "results": [
+                            {"id": "dg-stale", "name": "Smoke DefenseClaw O11y"},
+                            {"id": "dg-best", "name": "Smoke DefenseClaw O11y"},
+                        ]
+                    }
+                )
+            if url.endswith("/v2/dashboard"):
+                return FakeResponse(
+                    {
+                        "results": [
+                            {
+                                "id": "db-stale",
+                                "name": "Executive Agent Watch (Smoke)",
+                                "dashboardGroupId": "dg-stale",
+                            },
+                            {
+                                "id": "db-best",
+                                "name": "Executive Agent Watch (Smoke)",
+                                "dashboardGroupId": "dg-best",
+                            },
+                        ]
+                    }
+                )
+            if url.endswith("/v2/dashboard/db-stale"):
+                return FakeResponse({"charts": []})
+            if url.endswith("/v2/dashboard/db-best"):
+                return FakeResponse({"charts": []})
+            raise AssertionError(f"unexpected API url: {url}")
+
+        def fake_run(*args, **kwargs):
+            cmd = args[0]
+            calls.append({"cmd": cmd, "kwargs": kwargs})
+            if cmd[1] == "console":
+                return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(json.dumps(console_payload)))
+            if cmd[1] == "state":
+                return subprocess.CompletedProcess(cmd, 0, stdout="")
+            if cmd[1] == "import":
+                return subprocess.CompletedProcess(cmd, 0, stdout="")
+            if cmd[1] in {"plan", "apply", "output", "validate", "init"}:
+                if cmd[1] == "output":
+                    return subprocess.CompletedProcess(cmd, 0, stdout='{"executive":"https://app.signalfx.com/#/dashboard/abc"}')
+                return subprocess.CompletedProcess(cmd, 0, stdout="")
+            raise AssertionError(f"unexpected terraform cmd: {cmd}")
+
+        with tempfile.TemporaryDirectory() as td, patch(
+            "defenseclaw.commands.cmd_setup_splunk_o11y_dashboards.subprocess.run",
+            side_effect=fake_run,
+        ), patch(
+            "defenseclaw.commands.cmd_setup_splunk_o11y_dashboards.requests.get",
+            side_effect=fake_get,
+        ):
+            tmp_path = Path(td)
+            result = CliRunner().invoke(
+                splunk_o11y_dashboards,
+                [
+                    "apply",
+                    "--api-url",
+                    "https://api.realm.signalfx.com",
+                    "--auth-token",
+                    "secret-token",
+                    "--name-prefix",
+                    "Smoke",
+                    "--work-dir",
+                    str(tmp_path / "tf-work"),
+                    "--state",
+                    str(tmp_path / "state" / "terraform.tfstate"),
+                    "--skip-init",
+                    "--skip-validate",
+                    "--yes",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        import_cmds = [call["cmd"] for call in calls if call["cmd"][1] == "import"]
+        self.assertIn(
+            ["terraform", "import", "-input=false", f"-state={tmp_path / 'state' / 'terraform.tfstate'}", "signalfx_dashboard_group.defenseclaw_o11y", "dg-best"],
+            import_cmds,
+        )
+
+    def test_plan_initializes_with_optional_plugin_dir(self) -> None:
+        calls = []
+        console_payload = {"single": {}, "time": {}, "table": {}, "layouts": {}, "detectors": {}}
+
+        class FakeResponse:
+            def __init__(self, payload):
+                self._payload = payload
+                self.status_code = 200
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return self._payload
+
+        def fake_get(url, headers=None, params=None, timeout=None):
+            return FakeResponse({"results": []})
+
+        def fake_run(cmd, cwd, env, text, capture_output, timeout, input=None):
             calls.append(cmd)
+            if cmd[1] == "console":
+                return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(json.dumps(console_payload)))
+            if cmd[1] == "state":
+                return subprocess.CompletedProcess(cmd, 0, stdout="")
             return subprocess.CompletedProcess(cmd, 0, stdout="")
 
         with tempfile.TemporaryDirectory() as td, patch(
             "defenseclaw.commands.cmd_setup_splunk_o11y_dashboards.subprocess.run",
             side_effect=fake_run,
+        ), patch(
+            "defenseclaw.commands.cmd_setup_splunk_o11y_dashboards.requests.get",
+            side_effect=fake_get,
         ):
             tmp_path = Path(td)
             plugin_dir = tmp_path / "plugins"
@@ -134,7 +408,9 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertEqual(calls[0][1:], ["init", "-input=false", f"-plugin-dir={plugin_dir}"])
         self.assertEqual(calls[1][1:], ["validate"])
-        self.assertEqual(calls[2][1], "plan")
+        self.assertEqual(calls[2][1], "console")
+        self.assertEqual(calls[3][1], "state")
+        self.assertEqual(calls[4][1], "plan")
 
     def test_missing_token_reports_actionable_error(self) -> None:
         with tempfile.TemporaryDirectory() as td, patch.dict(os.environ, {}, clear=True):

--- a/cli/tests/test_cmd_setup_splunk_o11y_dashboards.py
+++ b/cli/tests/test_cmd_setup_splunk_o11y_dashboards.py
@@ -1,0 +1,171 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from click.testing import CliRunner
+
+from defenseclaw.commands.cmd_setup_splunk_o11y_dashboards import (
+    _api_url_from_ingest_endpoint,
+    splunk_o11y_dashboards,
+)
+
+
+class SplunkO11yDashboardCommandTests(unittest.TestCase):
+    def test_apply_runs_terraform_with_secret_in_env_not_args(self) -> None:
+        calls = []
+
+        def fake_run(cmd, cwd, env, text, capture_output, timeout):
+            calls.append(
+                {
+                    "cmd": cmd,
+                    "cwd": cwd,
+                    "env": env,
+                    "text": text,
+                    "capture_output": capture_output,
+                    "timeout": timeout,
+                }
+            )
+            if cmd[1] == "output":
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout='{"executive":"https://app.signalfx.com/#/dashboard/abc"}',
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="")
+
+        with tempfile.TemporaryDirectory() as td, patch(
+            "defenseclaw.commands.cmd_setup_splunk_o11y_dashboards.subprocess.run",
+            side_effect=fake_run,
+        ):
+            tmp_path = Path(td)
+            work_dir = tmp_path / "tf-work"
+            state_path = tmp_path / "state" / "terraform.tfstate"
+
+            result = CliRunner().invoke(
+                splunk_o11y_dashboards,
+                [
+                    "apply",
+                    "--api-url",
+                    "https://api.us1.signalfx.com",
+                    "--auth-token",
+                    "secret-token",
+                    "--name-prefix",
+                    "Smoke",
+                    "--work-dir",
+                    str(work_dir),
+                    "--state",
+                    str(state_path),
+                    "--skip-init",
+                    "--skip-validate",
+                    "--yes",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertTrue((work_dir / "main.tf").is_file())
+
+        self.assertEqual([call["cmd"][1] for call in calls], ["plan", "apply", "output"])
+        self.assertTrue(all("secret-token" not in " ".join(call["cmd"]) for call in calls))
+        self.assertEqual(calls[0]["env"]["TF_VAR_signalfx_auth_token"], "secret-token")
+        self.assertEqual(calls[0]["env"]["TF_VAR_signalfx_api_url"], "https://api.us1.signalfx.com")
+        self.assertEqual(calls[0]["env"]["TF_VAR_name_prefix"], "Smoke")
+        self.assertEqual(calls[0]["env"]["TF_VAR_create_detectors"], "false")
+        self.assertEqual(calls[0]["env"]["TF_VAR_detectors_disabled"], "true")
+        self.assertIn(f"-state={state_path}", calls[0]["cmd"])
+        self.assertIn(f"-state={state_path}", calls[2]["cmd"])
+        self.assertIn("executive: https://app.signalfx.com/#/dashboard/abc", result.output)
+
+    def test_plan_initializes_with_optional_plugin_dir(self) -> None:
+        calls = []
+
+        def fake_run(cmd, cwd, env, text, capture_output, timeout):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="")
+
+        with tempfile.TemporaryDirectory() as td, patch(
+            "defenseclaw.commands.cmd_setup_splunk_o11y_dashboards.subprocess.run",
+            side_effect=fake_run,
+        ):
+            tmp_path = Path(td)
+            plugin_dir = tmp_path / "plugins"
+            plugin_dir.mkdir()
+
+            result = CliRunner().invoke(
+                splunk_o11y_dashboards,
+                [
+                    "plan",
+                    "--api-url",
+                    "https://api.us1.signalfx.com",
+                    "--auth-token",
+                    "secret-token",
+                    "--work-dir",
+                    str(tmp_path / "tf-work"),
+                    "--state",
+                    str(tmp_path / "terraform.tfstate"),
+                    "--plugin-dir",
+                    str(plugin_dir),
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(calls[0][1:], ["init", "-input=false", f"-plugin-dir={plugin_dir}"])
+        self.assertEqual(calls[1][1:], ["validate"])
+        self.assertEqual(calls[2][1], "plan")
+
+    def test_missing_token_reports_actionable_error(self) -> None:
+        with tempfile.TemporaryDirectory() as td, patch.dict(os.environ, {}, clear=True):
+            result = CliRunner().invoke(
+                splunk_o11y_dashboards,
+                [
+                    "plan",
+                    "--api-url",
+                    "https://api.us1.signalfx.com",
+                    "--work-dir",
+                    str(Path(td) / "tf-work"),
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Splunk O11y token not found. Pass --auth-token.", result.output)
+
+    def test_api_url_derives_from_ingest_realm(self) -> None:
+        self.assertEqual(
+            _api_url_from_ingest_endpoint("https://ingest.us1.observability.splunkcloud.com/v1/metrics"),
+            "https://api.us1.signalfx.com",
+        )
+        self.assertEqual(
+            _api_url_from_ingest_endpoint("ingest.eu0.signalfx.com:443"),
+            "https://api.eu0.signalfx.com",
+        )
+        self.assertEqual(
+            _api_url_from_ingest_endpoint("https://api.us1.signalfx.com"),
+            "https://api.us1.signalfx.com",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/tests/test_cmd_setup_splunk_o11y_dashboards.py
+++ b/cli/tests/test_cmd_setup_splunk_o11y_dashboards.py
@@ -94,7 +94,7 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
                     "apply",
                     "--api-url",
                     "https://api.realm.signalfx.com",
-                    "--auth-token",
+                    "--o11y-api-token",
                     "secret-token",
                     "--name-prefix",
                     "Smoke",
@@ -213,7 +213,7 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
                     "apply",
                     "--api-url",
                     "https://api.realm.signalfx.com",
-                    "--auth-token",
+                    "--o11y-api-token",
                     "secret-token",
                     "--name-prefix",
                     "Smoke",
@@ -329,7 +329,7 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
                     "apply",
                     "--api-url",
                     "https://api.realm.signalfx.com",
-                    "--auth-token",
+                    "--o11y-api-token",
                     "secret-token",
                     "--name-prefix",
                     "Smoke",
@@ -393,7 +393,7 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
                     "plan",
                     "--api-url",
                     "https://api.realm.signalfx.com",
-                    "--auth-token",
+                    "--o11y-api-token",
                     "secret-token",
                     "--work-dir",
                     str(tmp_path / "tf-work"),
@@ -425,7 +425,7 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
             )
 
         self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("Splunk O11y token not found. Pass --auth-token.", result.output)
+        self.assertIn("Splunk O11y token not found. Pass --o11y-api-token.", result.output)
 
     def test_api_url_derives_from_ingest_realm(self) -> None:
         self.assertEqual(

--- a/cli/tests/test_cmd_setup_splunk_o11y_dashboards.py
+++ b/cli/tests/test_cmd_setup_splunk_o11y_dashboards.py
@@ -234,7 +234,6 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
             [
                 ["terraform", "import", "-input=false", f"-state={tmp_path / 'state' / 'terraform.tfstate'}", "signalfx_dashboard_group.defenseclaw_o11y", "dg-1"],
                 ["terraform", "import", "-input=false", f"-state={tmp_path / 'state' / 'terraform.tfstate'}", "signalfx_dashboard.executive", "db-1"],
-                ["terraform", "import", "-input=false", f"-state={tmp_path / 'state' / 'terraform.tfstate'}", 'signalfx_single_value_chart.single["executive_verdicts_31d"]', "chart-1"],
             ],
         )
 

--- a/cli/tests/test_cmd_setup_splunk_o11y_dashboards.py
+++ b/cli/tests/test_cmd_setup_splunk_o11y_dashboards.py
@@ -28,7 +28,6 @@ from unittest.mock import patch
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from click.testing import CliRunner
-
 from defenseclaw.commands.cmd_setup_splunk_o11y_dashboards import (
     _api_url_from_ingest_endpoint,
     splunk_o11y_dashboards,
@@ -178,7 +177,11 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
                 return FakeResponse(
                     {
                         "charts": [
-                            {"id": "chart-1", "name": "Verdicts", "description": "All DefenseClaw gateway verdicts in the selected time range."}
+                            {
+                                "id": "chart-1",
+                                "name": "Verdicts",
+                                "description": "All DefenseClaw gateway verdicts in the selected time range.",
+                            }
                         ]
                     }
                 )
@@ -232,8 +235,22 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
         self.assertEqual(
             import_cmds,
             [
-                ["terraform", "import", "-input=false", f"-state={tmp_path / 'state' / 'terraform.tfstate'}", "signalfx_dashboard_group.defenseclaw_o11y", "dg-1"],
-                ["terraform", "import", "-input=false", f"-state={tmp_path / 'state' / 'terraform.tfstate'}", "signalfx_dashboard.executive", "db-1"],
+                [
+                    "terraform",
+                    "import",
+                    "-input=false",
+                    f"-state={tmp_path / 'state' / 'terraform.tfstate'}",
+                    "signalfx_dashboard_group.defenseclaw_o11y",
+                    "dg-1",
+                ],
+                [
+                    "terraform",
+                    "import",
+                    "-input=false",
+                    f"-state={tmp_path / 'state' / 'terraform.tfstate'}",
+                    "signalfx_dashboard.executive",
+                    "db-1",
+                ],
             ],
         )
 
@@ -346,7 +363,14 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         import_cmds = [call["cmd"] for call in calls if call["cmd"][1] == "import"]
         self.assertIn(
-            ["terraform", "import", "-input=false", f"-state={tmp_path / 'state' / 'terraform.tfstate'}", "signalfx_dashboard_group.defenseclaw_o11y", "dg-best"],
+            [
+                "terraform",
+                "import",
+                "-input=false",
+                f"-state={tmp_path / 'state' / 'terraform.tfstate'}",
+                "signalfx_dashboard_group.defenseclaw_o11y",
+                "dg-best",
+            ],
             import_cmds,
         )
 

--- a/cli/tests/test_cmd_setup_splunk_o11y_dashboards.py
+++ b/cli/tests/test_cmd_setup_splunk_o11y_dashboards.py
@@ -70,7 +70,7 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
                 [
                     "apply",
                     "--api-url",
-                    "https://api.us1.signalfx.com",
+                    "https://api.realm.signalfx.com",
                     "--auth-token",
                     "secret-token",
                     "--name-prefix",
@@ -91,7 +91,7 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
         self.assertEqual([call["cmd"][1] for call in calls], ["plan", "apply", "output"])
         self.assertTrue(all("secret-token" not in " ".join(call["cmd"]) for call in calls))
         self.assertEqual(calls[0]["env"]["TF_VAR_signalfx_auth_token"], "secret-token")
-        self.assertEqual(calls[0]["env"]["TF_VAR_signalfx_api_url"], "https://api.us1.signalfx.com")
+        self.assertEqual(calls[0]["env"]["TF_VAR_signalfx_api_url"], "https://api.realm.signalfx.com")
         self.assertEqual(calls[0]["env"]["TF_VAR_name_prefix"], "Smoke")
         self.assertEqual(calls[0]["env"]["TF_VAR_create_detectors"], "false")
         self.assertEqual(calls[0]["env"]["TF_VAR_detectors_disabled"], "true")
@@ -119,7 +119,7 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
                 [
                     "plan",
                     "--api-url",
-                    "https://api.us1.signalfx.com",
+                    "https://api.realm.signalfx.com",
                     "--auth-token",
                     "secret-token",
                     "--work-dir",
@@ -143,7 +143,7 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
                 [
                     "plan",
                     "--api-url",
-                    "https://api.us1.signalfx.com",
+                    "https://api.realm.signalfx.com",
                     "--work-dir",
                     str(Path(td) / "tf-work"),
                 ],
@@ -154,16 +154,16 @@ class SplunkO11yDashboardCommandTests(unittest.TestCase):
 
     def test_api_url_derives_from_ingest_realm(self) -> None:
         self.assertEqual(
-            _api_url_from_ingest_endpoint("https://ingest.us1.observability.splunkcloud.com/v1/metrics"),
-            "https://api.us1.signalfx.com",
+            _api_url_from_ingest_endpoint("https://ingest.realm.observability.splunkcloud.com/v1/metrics"),
+            "https://api.realm.signalfx.com",
         )
         self.assertEqual(
-            _api_url_from_ingest_endpoint("ingest.eu0.signalfx.com:443"),
-            "https://api.eu0.signalfx.com",
+            _api_url_from_ingest_endpoint("ingest.realm2.signalfx.com:443"),
+            "https://api.realm2.signalfx.com",
         )
         self.assertEqual(
-            _api_url_from_ingest_endpoint("https://api.us1.signalfx.com"),
-            "https://api.us1.signalfx.com",
+            _api_url_from_ingest_endpoint("https://api.realm.signalfx.com"),
+            "https://api.realm.signalfx.com",
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,8 @@ defenseclaw = [
     "_data/local_observability_stack/grafana/dashboards/*.json",
     "_data/local_observability_stack/grafana/provisioning/dashboards/*.yml",
     "_data/local_observability_stack/grafana/provisioning/datasources/*.yml",
+    "_data/splunk_o11y_dashboards/*.md",
+    "_data/splunk_o11y_dashboards/terraform/*.tf",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary

Adds first-class Splunk Observability Cloud support for DefenseClaw via a new CLI setup flow and a bundled dashboard/detector package.

### What changed
- Added `defenseclaw setup splunk-o11y-dashboards apply`
- The wizard now:
  - prompts for whether to install dashboards
  - prompts for the O11y API token only if dashboards are selected
  - uses a clearly labeled prompt to distinguish the dashboard API token from the O11y ingest token
- Provisioning through the CLI with:
  - `--api-url`
  - `--o11y-api-token`
  - `--with-detectors`
  - `--enable-detectors`
  - `--dashboards-only`
  - `--name-prefix`
  - `--detector-notification`
  - the existing Terraform/runtime controls
- Added a new O11y dashboard bundle for the core DefenseClaw views:
  - Executive Agent Watch
  - Guardrail and Inspection
  - Scanners and Findings
  - Connector and OTEL Ingest
  - Security and Policy
  - Runtime and Reliability
  - DefenseClaw AI Agents Token Economics
- Added detector provisioning for the relevant Prometheus/alerting signals
- Added automatic adoption of matching existing O11y dashboards and detectors so reruns update existing resources instead of creating duplicates
- Updated the top-level README and bundle README to document the new setup flow

## Notes
- The dashboards are built from DefenseClaw metrics already emitted through OTel / gateway telemetry.
- Detectors are optional and can be enabled explicitly during setup.
- The setup flow is designed to be safe to rerun against an org that already has matching dashboards.
- O11y ingest setup still uses the existing ingest token path.
- Dashboard installation uses a separate O11y API token and is intentionally opt-in in the interactive wizard.

## Validation
- Focused unit tests for the O11y setup command passed
- Ruff lint passed for `cli/defenseclaw/`
