### PR TITLE
fix(connector): honor host-agent hook protocols and stop deleting in-use hook scripts

### DIFF
--- a/internal/gateway/connector/claudecode.go
+++ b/internal/gateway/connector/claudecode.go
@@ -161,6 +161,13 @@ func (c *ClaudeCodeConnector) Teardown(ctx context.Context, opts SetupOpts) erro
 		errs = append(errs, fmt.Sprintf("subprocess enforcement: %v", err))
 	}
 
+	// Scoped per-connector hook removal: only delete claude-code-hook.sh
+	// (the script we own). The previous behavior — deleting every
+	// connector's hook script via the global hookScripts list — caused
+	// the exit-127 bug during connector switches. See
+	// TeardownSubprocessEnforcement for the full rationale.
+	removeOwnedHookScripts(opts, c)
+
 	if len(errs) > 0 {
 		return fmt.Errorf("claudecode teardown errors: %s", strings.Join(errs, "; "))
 	}

--- a/internal/gateway/connector/codex.go
+++ b/internal/gateway/connector/codex.go
@@ -192,6 +192,13 @@ func (c *CodexConnector) Teardown(ctx context.Context, opts SetupOpts) error {
 	if err := TeardownSubprocessEnforcement(opts); err != nil {
 		return fmt.Errorf("codex teardown: subprocess enforcement: %w", err)
 	}
+	// Note: writeDisabledCodexHook below intentionally writes the
+	// codex-hook.sh stub AFTER the scoped removeOwnedHookScripts so
+	// any stale codex-hook.sh from a previous install is replaced
+	// rather than left in place. The disabled stub exits 0 so
+	// long-lived Codex sessions that cached the absolute hook path
+	// don't 127 after Teardown.
+	removeOwnedHookScripts(opts, c)
 	if err := writeDisabledCodexHook(opts); err != nil {
 		return fmt.Errorf("codex teardown: disabled hook: %w", err)
 	}

--- a/internal/gateway/connector/connector_test.go
+++ b/internal/gateway/connector/connector_test.go
@@ -3949,6 +3949,81 @@ func TestTeardownSubprocessEnforcement(t *testing.T) {
 	}
 }
 
+// TestTeardown_DoesNotDeleteOtherConnectorsHookScripts is a regression
+// test for the exit-127 "command not found" bug observed during a
+// claudecode → codex switch. The old TeardownSubprocessEnforcement
+// iterated the GLOBAL hookScripts slice (every connector's *-hook.sh
+// + every generic inspect-*.sh) and removed them all from the shared
+// hooks dir. When called from one connector's Teardown that wiped
+// scripts owned by the incoming connector AND the shared inspect-*.sh
+// helpers, leaving the agent with an empty hooks/ dir if the
+// follow-up Setup hit any silent partial-install path.
+//
+// The fix scopes per-Teardown deletion to the calling connector's own
+// HookScriptOwner.HookScriptNames basenames. This test simulates the
+// failure: pre-populates hooks/ with codex-hook.sh + inspect-*.sh,
+// runs claudecode.Teardown, and asserts that codex-hook.sh and the
+// generic inspect-*.sh files SURVIVE (only claude-code-hook.sh is
+// removed).
+func TestTeardown_DoesNotDeleteOtherConnectorsHookScripts(t *testing.T) {
+	dir := t.TempDir()
+	opts := SetupOpts{DataDir: dir, APIAddr: "127.0.0.1:18970", ProxyAddr: "127.0.0.1:4000"}
+
+	hookDir := filepath.Join(dir, "hooks")
+	if err := os.MkdirAll(hookDir, 0o700); err != nil {
+		t.Fatalf("mkdir hooks: %v", err)
+	}
+
+	preExisting := []string{
+		"codex-hook.sh",
+		"claude-code-hook.sh",
+		"inspect-tool.sh",
+		"inspect-request.sh",
+		"inspect-response.sh",
+		"inspect-tool-response.sh",
+	}
+	for _, name := range preExisting {
+		if err := os.WriteFile(filepath.Join(hookDir, name), []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	reg := NewDefaultRegistry()
+	cc, ok := reg.Get("claudecode")
+	if !ok {
+		t.Fatal("claudecode connector missing from registry")
+	}
+
+	if err := cc.Teardown(context.Background(), opts); err != nil {
+		// Some teardown sub-steps (settings.json restore, etc.) may
+		// surface non-fatal errors in a tmp dir without a real
+		// ~/.claude/settings.json. We only care about the hook-dir
+		// invariant here.
+		t.Logf("claudecode.Teardown returned (non-fatal in tmp env): %v", err)
+	}
+
+	// Invariant 1: claude-code-hook.sh — the script claudecode owns —
+	// should be removed.
+	if _, err := os.Stat(filepath.Join(hookDir, "claude-code-hook.sh")); !os.IsNotExist(err) {
+		t.Errorf("claude-code-hook.sh should be removed by claudecode.Teardown, got stat err=%v", err)
+	}
+
+	// Invariant 2: every other connector's hook script and every
+	// generic inspect-*.sh script must survive — they're owned by
+	// other connectors or shared infrastructure.
+	for _, name := range []string{
+		"codex-hook.sh",
+		"inspect-tool.sh",
+		"inspect-request.sh",
+		"inspect-response.sh",
+		"inspect-tool-response.sh",
+	} {
+		if _, err := os.Stat(filepath.Join(hookDir, name)); err != nil {
+			t.Errorf("expected %s to survive claudecode.Teardown, got stat err=%v", name, err)
+		}
+	}
+}
+
 // --- Security Surface Coverage tests ---
 
 func TestSecuritySurfaceCoverage(t *testing.T) {
@@ -5472,6 +5547,281 @@ func TestCodexHookScript_FailOpen_DefaultForObservabilitySetup(t *testing.T) {
 		if !strings.Contains(logText, want) {
 			t.Fatalf("hook failure log missing %s:\n%s", want, logText)
 		}
+	}
+}
+
+// TestCodexHookScript_StructuredBlock_ExitsZeroNotTwo pins the
+// Codex hook protocol contract: when the gateway returns a block
+// verdict with a structured `codex_output` JSON body (which every
+// block path in codex_hook.go does), the hook MUST print that JSON
+// to stdout and exit 0. It MUST NOT exit 2.
+//
+// Codex's hook protocol is strictly either-or:
+//   - exit 0 + JSON on stdout  → Codex parses the JSON decision
+//   - exit 2 + reason on stderr → Codex blocks with stderr text
+//
+// Doing BOTH (exit 2 with stdout JSON and empty stderr) makes Codex
+// pick the exit code, ignore stdout, find an empty stderr, then log
+// "exited with code 2 but did not write a blocking reason to stderr"
+// and FAIL OPEN. We hit that bug live with a CRITICAL prompt-injection
+// pattern (RSA private key paste): the gateway correctly returned
+// permissionDecision=deny on stdout, the hook also exited 2, and the
+// model still got the prompt because Codex treated the hook as
+// malformed.
+func TestCodexHookScript_StructuredBlock_ExitsZeroNotTwo(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell scripts not supported on windows")
+	}
+	// Stand up a tiny gateway stub that returns a verdict shaped
+	// exactly like codex_hook.go:codexResponseFor for action=block on
+	// PreToolUse. The codex_output mirror is the critical bit — it's
+	// the JSON the hook script must echo to stdout.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"action":"block",
+			"raw_action":"block",
+			"severity":"CRITICAL",
+			"reason":"matched: PATH-ETC-SHADOW:/etc/shadow access",
+			"findings":["PATH-ETC-SHADOW:/etc/shadow access"],
+			"mode":"action",
+			"would_block":false,
+			"codex_output":{
+				"hookSpecificOutput":{
+					"hookEventName":"PreToolUse",
+					"permissionDecision":"deny",
+					"permissionDecisionReason":"matched: PATH-ETC-SHADOW:/etc/shadow access"
+				}
+			}
+		}`))
+	}))
+	defer srv.Close()
+	addr := strings.TrimPrefix(srv.URL, "http://")
+
+	dir := t.TempDir()
+	opts := SetupOpts{APIAddr: addr, APIToken: "tok-test", CodexEnforcement: true}
+	if err := WriteHookScriptsForConnectorObjectWithOpts(dir, opts, &CodexConnector{}); err != nil {
+		t.Fatalf("WriteHookScriptsForConnectorObjectWithOpts: %v", err)
+	}
+	dcHome := t.TempDir()
+
+	cmd := exec.Command("bash", filepath.Join(dir, "codex-hook.sh"))
+	cmd.Stdin = strings.NewReader(`{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":["bash","-lc","cat /etc/shadow"]}}`)
+	cmd.Env = append(os.Environ(),
+		"PATH="+os.Getenv("PATH"),
+		"DEFENSECLAW_HOME="+dcHome,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("hook should exit 0 when gateway returned structured codex_output (Codex protocol: JSON-on-stdout xor exit-2-on-stderr); got err=%v\nstdout=%q\nstderr=%q",
+			err, stdout.String(), stderr.String())
+	}
+
+	// stdout must carry the codex_output JSON Codex will parse.
+	stdoutText := stdout.String()
+	for _, want := range []string{
+		`"hookEventName":"PreToolUse"`,
+		`"permissionDecision":"deny"`,
+		`"permissionDecisionReason":"matched: PATH-ETC-SHADOW:/etc/shadow access"`,
+	} {
+		if !strings.Contains(stdoutText, want) {
+			t.Errorf("stdout missing %q\nfull stdout: %q", want, stdoutText)
+		}
+	}
+	// stderr must be empty (no "blocking" hint, no "fail" log) —
+	// otherwise Codex still logs "did not write a blocking reason to
+	// stderr" because we used the wrong protocol path.
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Errorf("stderr should be empty when block goes via structured stdout JSON, got: %q", stderr.String())
+	}
+}
+
+// TestClaudeCodeHookScript_StructuredBlock_ExitsZeroNotTwo pins the
+// same Anthropic-side hook protocol contract that
+// TestCodexHookScript_StructuredBlock_ExitsZeroNotTwo pins for Codex:
+// when the gateway returns a block verdict with a structured
+// claude_code_output JSON body, the hook MUST print that JSON to
+// stdout and exit 0 — NOT exit 2.
+//
+// The bug here was structurally identical to the codex one: the
+// pre-fix script wrote claude_code_output to stdout AND exited 2 on
+// action=block, which is a Claude Code hook protocol violation.
+// Depending on Claude Code version that either silently swaps our
+// rich "matched: SEC-FOO" reason for a generic "Hook exited with code
+// 2" surface, or ignores stdout entirely. Either way the operator
+// loses the actual policy reason, and on some versions the agent
+// fails open the same way Codex did.
+func TestClaudeCodeHookScript_StructuredBlock_ExitsZeroNotTwo(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell scripts not supported on windows")
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"action":"block",
+			"raw_action":"block",
+			"severity":"CRITICAL",
+			"reason":"matched: SEC-PRIVKEY:Private key",
+			"findings":["SEC-PRIVKEY:Private key"],
+			"mode":"action",
+			"would_block":false,
+			"claude_code_output":{
+				"hookSpecificOutput":{
+					"hookEventName":"PreToolUse",
+					"permissionDecision":"deny",
+					"permissionDecisionReason":"matched: SEC-PRIVKEY:Private key"
+				}
+			}
+		}`))
+	}))
+	defer srv.Close()
+	addr := strings.TrimPrefix(srv.URL, "http://")
+
+	dir := t.TempDir()
+	opts := SetupOpts{APIAddr: addr, APIToken: "tok-test", ClaudeCodeEnforcement: true}
+	if err := WriteHookScriptsForConnectorObjectWithOpts(dir, opts, &ClaudeCodeConnector{}); err != nil {
+		t.Fatalf("WriteHookScriptsForConnectorObjectWithOpts: %v", err)
+	}
+	dcHome := t.TempDir()
+
+	cmd := exec.Command("bash", filepath.Join(dir, "claude-code-hook.sh"))
+	cmd.Stdin = strings.NewReader(`{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"cat /etc/shadow"}}`)
+	cmd.Env = append(os.Environ(),
+		"PATH="+os.Getenv("PATH"),
+		"DEFENSECLAW_HOME="+dcHome,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("hook should exit 0 when gateway returned structured claude_code_output (Claude Code protocol: JSON-on-stdout xor exit-2-on-stderr); got err=%v\nstdout=%q\nstderr=%q",
+			err, stdout.String(), stderr.String())
+	}
+
+	stdoutText := stdout.String()
+	for _, want := range []string{
+		`"hookEventName":"PreToolUse"`,
+		`"permissionDecision":"deny"`,
+		`"permissionDecisionReason":"matched: SEC-PRIVKEY:Private key"`,
+	} {
+		if !strings.Contains(stdoutText, want) {
+			t.Errorf("stdout missing %q\nfull stdout: %q", want, stdoutText)
+		}
+	}
+	// stderr must be empty so Claude Code uses the rich JSON reason
+	// instead of the stderr fallback.
+	if strings.TrimSpace(stderr.String()) != "" {
+		t.Errorf("stderr should be empty when block goes via structured stdout JSON, got: %q", stderr.String())
+	}
+}
+
+// TestClaudeCodeHookScript_NoStructuredOutput_FallsBackToExitTwo
+// mirrors the codex fallback test for symmetry: legacy/edge code
+// paths that don't include a claude_code_output mirror still block
+// via exit 2 with the reason on stderr.
+func TestClaudeCodeHookScript_NoStructuredOutput_FallsBackToExitTwo(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell scripts not supported on windows")
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"action":"block",
+			"raw_action":"block",
+			"severity":"CRITICAL",
+			"reason":"hypothetical legacy claude verdict",
+			"mode":"action",
+			"would_block":false
+		}`))
+	}))
+	defer srv.Close()
+	addr := strings.TrimPrefix(srv.URL, "http://")
+
+	dir := t.TempDir()
+	opts := SetupOpts{APIAddr: addr, APIToken: "tok-test", ClaudeCodeEnforcement: true}
+	if err := WriteHookScriptsForConnectorObjectWithOpts(dir, opts, &ClaudeCodeConnector{}); err != nil {
+		t.Fatalf("WriteHookScriptsForConnectorObjectWithOpts: %v", err)
+	}
+	dcHome := t.TempDir()
+
+	cmd := exec.Command("bash", filepath.Join(dir, "claude-code-hook.sh"))
+	cmd.Stdin = strings.NewReader(`{"hook_event_name":"PreToolUse"}`)
+	cmd.Env = append(os.Environ(),
+		"PATH="+os.Getenv("PATH"),
+		"DEFENSECLAW_HOME="+dcHome,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("hook should exit 2 when gateway block has no structured claude_code_output, got exit 0\nstdout=%q\nstderr=%q",
+			stdout.String(), stderr.String())
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		if exitErr.ExitCode() != 2 {
+			t.Errorf("exit code = %d, want 2 (legacy block fallback)", exitErr.ExitCode())
+		}
+	}
+	if !strings.Contains(stderr.String(), "hypothetical legacy claude verdict") {
+		t.Errorf("stderr must carry the block reason on the legacy path, got: %q", stderr.String())
+	}
+}
+
+// TestCodexHookScript_NoStructuredOutput_FallsBackToExitTwo pins the
+// fallback path: if the gateway ever returns action=block but does
+// NOT include a codex_output mirror (legacy callers, future codex
+// events not yet wired up), the hook must use the exit-2-with-stderr
+// path so Codex still blocks. The reason MUST land on stderr —
+// emitting an empty stderr was the original bug.
+func TestCodexHookScript_NoStructuredOutput_FallsBackToExitTwo(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell scripts not supported on windows")
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"action":"block",
+			"raw_action":"block",
+			"severity":"CRITICAL",
+			"reason":"hypothetical legacy verdict",
+			"mode":"action",
+			"would_block":false
+		}`))
+	}))
+	defer srv.Close()
+	addr := strings.TrimPrefix(srv.URL, "http://")
+
+	dir := t.TempDir()
+	opts := SetupOpts{APIAddr: addr, APIToken: "tok-test", CodexEnforcement: true}
+	if err := WriteHookScriptsForConnectorObjectWithOpts(dir, opts, &CodexConnector{}); err != nil {
+		t.Fatalf("WriteHookScriptsForConnectorObjectWithOpts: %v", err)
+	}
+	dcHome := t.TempDir()
+
+	cmd := exec.Command("bash", filepath.Join(dir, "codex-hook.sh"))
+	cmd.Stdin = strings.NewReader(`{"hook_event_name":"PreToolUse"}`)
+	cmd.Env = append(os.Environ(),
+		"PATH="+os.Getenv("PATH"),
+		"DEFENSECLAW_HOME="+dcHome,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("hook should exit 2 when gateway block has no structured codex_output, got exit 0\nstdout=%q\nstderr=%q",
+			stdout.String(), stderr.String())
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		if exitErr.ExitCode() != 2 {
+			t.Errorf("exit code = %d, want 2 (legacy block fallback)", exitErr.ExitCode())
+		}
+	}
+	if !strings.Contains(stderr.String(), "hypothetical legacy verdict") {
+		t.Errorf("stderr must carry the block reason on the legacy path, got: %q", stderr.String())
 	}
 }
 

--- a/internal/gateway/connector/hooks/claude-code-hook.sh
+++ b/internal/gateway/connector/hooks/claude-code-hook.sh
@@ -111,7 +111,36 @@ fi
 ACTION=$(echo "$RESULT" | jq -r '.action // "allow"' 2>/dev/null) || {
   fail_response "failed to parse action from response"
 }
+
+# Anthropic's Claude Code hook protocol — like Codex's — is strictly
+# EITHER structured JSON on stdout with exit 0 (Claude parses the
+# permissionDecision/decision from the JSON) OR exit 2 with the reason
+# on stderr. Doing BOTH is a protocol violation: depending on Claude
+# version, either the exit code wins (and the rich JSON reason is
+# silently replaced with a generic "Hook exited with code 2" surface),
+# or stdout wins inconsistently. This is the same shape bug we hit on
+# codex-hook.sh where Codex explicitly logged
+# "exited with code 2 but did not write a blocking reason to stderr"
+# and then FAILED OPEN. Even where Claude Code currently still blocks
+# on the exit code, mixing the protocols means the operator-facing
+# reason ("matched: SEC-PRIVKEY:Private key") is at risk of being
+# dropped between Claude versions.
+#
+# Resolution: when the gateway gave us structured claude_code_output
+# (every block path in claude_code_hook.go does), trust it and exit 0.
+# Fall back to exit-2-plus-stderr only when no structured output is
+# present.
 if [ "$ACTION" = "block" ]; then
+  if [ -n "$OUTPUT" ] && [ "$OUTPUT" != "null" ]; then
+    # JSON on stdout already carries permissionDecision=deny /
+    # decision=block. Exit 0 so Claude Code honors it.
+    exit 0
+  fi
+  REASON=$(echo "$RESULT" | jq -r '.reason // empty' 2>/dev/null)
+  if [ -z "$REASON" ]; then
+    REASON="Blocked by DefenseClaw Claude Code policy."
+  fi
+  printf '%s\n' "$REASON" >&2
   exit 2
 fi
 exit 0

--- a/internal/gateway/connector/hooks/codex-hook.sh
+++ b/internal/gateway/connector/hooks/codex-hook.sh
@@ -124,7 +124,30 @@ fi
 ACTION=$(echo "$RESULT" | jq -r '.action // "allow"' 2>/dev/null) || {
   fail_response "failed to parse action from response"
 }
+
+# Codex's hook protocol is strictly EITHER structured JSON on stdout
+# with exit 0 (Codex parses the decision from the JSON) OR exit 2
+# with the reason on stderr (Codex blocks with stderr as the
+# message). Doing BOTH is a protocol violation: Codex sees exit 2,
+# ignores stdout, finds an empty stderr, then logs
+# "exited with code 2 but did not write a blocking reason to stderr"
+# and FAILS OPEN — which is exactly the bug we hit when our gateway
+# returned permissionDecision=deny on stdout AND we exited 2.
+#
+# Resolution: trust the structured JSON when the gateway gave us one
+# (every block path in codex_hook.go does), and only fall back to
+# the exit-2-plus-stderr path when no structured output exists.
 if [ "$ACTION" = "block" ]; then
+  if [ -n "$OUTPUT" ] && [ "$OUTPUT" != "null" ]; then
+    # JSON on stdout already carries permissionDecision=deny /
+    # decision=block. Exit 0 so Codex honors it.
+    exit 0
+  fi
+  REASON=$(echo "$RESULT" | jq -r '.reason // empty' 2>/dev/null)
+  if [ -z "$REASON" ]; then
+    REASON="Blocked by DefenseClaw Codex policy."
+  fi
+  printf '%s\n' "$REASON" >&2
   exit 2
 fi
 exit 0

--- a/internal/gateway/connector/openclaw.go
+++ b/internal/gateway/connector/openclaw.go
@@ -184,6 +184,7 @@ func (c *OpenClawConnector) Teardown(ctx context.Context, opts SetupOpts) error 
 	if err := TeardownSubprocessEnforcement(opts); err != nil {
 		errs = append(errs, fmt.Sprintf("subprocess enforcement: %v", err))
 	}
+	removeOwnedHookScripts(opts, c)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("openclaw teardown errors: %s", strings.Join(errs, "; "))

--- a/internal/gateway/connector/subprocess.go
+++ b/internal/gateway/connector/subprocess.go
@@ -613,22 +613,55 @@ func SetupSubprocessEnforcement(policy SubprocessPolicy, opts SetupOpts) error {
 	return nil
 }
 
-// TeardownSubprocessEnforcement removes shim scripts, individual hook scripts,
-// and sandbox policies. It removes files by name rather than nuking the shared
-// hooks/ directory, which may be used by other active connectors.
+// TeardownSubprocessEnforcement removes shim scripts and the sandbox
+// policy file. It deliberately does NOT touch the shared hooks/
+// directory anymore: the previous implementation iterated the GLOBAL
+// `hookScripts` slice (= every connector's *-hook.sh + every generic
+// inspect-*.sh) and deleted them all from the shared dir. When called
+// from one connector's Teardown — e.g. claudecode.Teardown during a
+// claudecode → codex switch — that wiped scripts owned by the
+// incoming connector AND the shared inspect-*.sh helpers. If the
+// follow-up codex.Setup() then failed to re-write codex-hook.sh
+// (silent partial install, mtime race, hostFS read miss, etc.), the
+// agent ended up with an empty hooks/ dir and every hook invocation
+// failed with exit 127 ("command not found").
+//
+// Per-connector hook removal is now the responsibility of each
+// Connector.Teardown via removeOwnedHookScripts, which scopes
+// deletion to the calling connector's own *-hook.sh basenames
+// (HookScriptOwner.HookScriptNames) and leaves the shared
+// inspect-*.sh helpers in place.
 func TeardownSubprocessEnforcement(opts SetupOpts) error {
 	shimDir := filepath.Join(opts.DataDir, "shims")
 	_ = os.RemoveAll(shimDir)
-
-	hookDir := filepath.Join(opts.DataDir, "hooks")
-	for _, name := range hookScripts {
-		_ = os.Remove(filepath.Join(hookDir, name))
-	}
 
 	policyPath := filepath.Join(opts.DataDir, "policies", "defenseclaw-policy.yaml")
 	_ = os.Remove(policyPath)
 
 	return nil
+}
+
+// removeOwnedHookScripts removes ONLY the hook scripts the calling
+// connector owns. Generic inspect-*.sh scripts and other connectors'
+// *-hook.sh files are intentionally left in place — they're either
+// shared infrastructure or owned by a different connector that may
+// still be active or about to become active. Removing them here is
+// what produced the exit-127 "command not found" bug during
+// connector switches.
+//
+// If c is nil or does not implement HookScriptOwner this is a no-op.
+func removeOwnedHookScripts(opts SetupOpts, c Connector) {
+	if c == nil {
+		return
+	}
+	owner, ok := c.(HookScriptOwner)
+	if !ok {
+		return
+	}
+	hookDir := filepath.Join(opts.DataDir, "hooks")
+	for _, name := range owner.HookScriptNames(opts) {
+		_ = os.Remove(filepath.Join(hookDir, name))
+	}
 }
 
 // ShimBinaries returns the list of binary names that are shimmed.

--- a/internal/gateway/connector/zeptoclaw.go
+++ b/internal/gateway/connector/zeptoclaw.go
@@ -155,6 +155,7 @@ func (c *ZeptoClawConnector) Teardown(ctx context.Context, opts SetupOpts) error
 	if err := TeardownSubprocessEnforcement(opts); err != nil {
 		errs = append(errs, fmt.Sprintf("subprocess enforcement: %v", err))
 	}
+	removeOwnedHookScripts(opts, c)
 
 	if len(errs) > 0 {
 		return fmt.Errorf("zeptoclaw teardown errors: %s", strings.Join(errs, "; "))

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -1283,6 +1283,29 @@ func (s *Sidecar) runGuardrail(ctx context.Context) error {
 			fmt.Fprintf(os.Stderr, "[guardrail] connector setup %s failed: %v — connector may not be fully initialized\n", conn.Name(), err)
 			recordAndRollbackFailedConnectorSetup(conn, setupOpts, ctx)
 		} else {
+			// Post-Setup verification: every owned hook script the
+			// connector said it would write MUST exist on disk before
+			// we mark the connector active. Without this check, a
+			// silent partial install (Setup returns nil but
+			// writeHookScriptsCommonWithFailMode never reached its
+			// for-loop, or another goroutine deleted the freshly
+			// written script) ships a connector whose every hook
+			// invocation will exit 127 ("command not found") — the
+			// exact symptom we hit during the claudecode → codex
+			// switch. Fail loud here and try one re-Setup so the
+			// operator either sees the error or gets a self-healing
+			// install.
+			if missing := verifyHookScriptsOnDisk(setupOpts.DataDir, conn); len(missing) > 0 {
+				fmt.Fprintf(os.Stderr, "[guardrail] WARNING: connector %s setup completed but hook scripts missing on disk: %v — retrying Setup\n", conn.Name(), missing)
+				if err := conn.Setup(ctx, setupOpts); err != nil {
+					fmt.Fprintf(os.Stderr, "[guardrail] connector %s re-Setup after missing-hook detection failed: %v\n", conn.Name(), err)
+					recordAndRollbackFailedConnectorSetup(conn, setupOpts, ctx)
+				} else if missing := verifyHookScriptsOnDisk(setupOpts.DataDir, conn); len(missing) > 0 {
+					fmt.Fprintf(os.Stderr, "[guardrail] connector %s STILL missing hook scripts after re-Setup: %v — connector marked active but hooks WILL fail with exit 127\n", conn.Name(), missing)
+				} else {
+					fmt.Fprintf(os.Stderr, "[guardrail] connector %s re-Setup restored missing hook scripts\n", conn.Name())
+				}
+			}
 			if err := connector.SaveActiveConnector(s.cfg.DataDir, conn.Name()); err != nil {
 				fmt.Fprintf(os.Stderr, "[guardrail] save active connector state: %v\n", err)
 			}
@@ -1560,6 +1583,31 @@ func isLoopbackGatewayHost(host string) bool {
 		return ip.IsLoopback()
 	}
 	return false
+}
+
+// verifyHookScriptsOnDisk checks that every hook script the connector
+// claims to own (HookScriptOwner.HookScriptNames) is present in
+// <dataDir>/hooks. Returns the list of missing basenames so callers
+// can decide whether to retry Setup, fall back, or fail loud. Connectors
+// that do not implement HookScriptOwner contribute no entries — there
+// is nothing connector-specific to verify and the generic inspect-*.sh
+// scripts are checked separately by the connector's own Setup path.
+func verifyHookScriptsOnDisk(dataDir string, conn connector.Connector) []string {
+	if conn == nil {
+		return nil
+	}
+	owner, ok := conn.(connector.HookScriptOwner)
+	if !ok {
+		return nil
+	}
+	hookDir := filepath.Join(dataDir, "hooks")
+	var missing []string
+	for _, name := range owner.HookScriptNames(connector.SetupOpts{DataDir: dataDir}) {
+		if _, err := os.Stat(filepath.Join(hookDir, name)); err != nil {
+			missing = append(missing, name)
+		}
+	}
+	return missing
 }
 
 // teardownPreviousConnector checks if a different connector was previously


### PR DESCRIPTION
## Summary

Two bugs were causing guardrail block decisions to be silently dropped on Codex and Claude Code, even when the gateway returned `action=block`. End-to-end smoke-tested against Codex (`v0.129.0`) and Claude Code with both CRITICAL and HIGH-only profiles.

### 1. Hook scripts violated the host-agent protocol on block

`codex-hook.sh` and `claude-code-hook.sh` both wrote structured JSON (`permissionDecision=deny` / `decision=block`) to **stdout** *and* exited **2**.

Both Codex and Claude Code treat `exit 2` as “use the stderr reason only” and **discard the structured stdout output**, which is why the UI surfaced:

> hook did not write a blocking reason to stderr

instead of blocking. The prompt would proceed.

**Fix:** when structured output is present, exit `0` so the JSON decision is honored; otherwise fall back to `exit 2` with a reason on stderr. New regression tests cover both branches for both connectors.

### 2. `TeardownSubprocessEnforcement` deleted every hook script on disk

Switching connectors (e.g. `claude-code → codex`) wiped the *new* connector's hook scripts immediately after `Setup` wrote them, producing `hook exited with code 127` on the next prompt — independent of bug #1.

**Fix:**
- `TeardownSubprocessEnforcement` now only removes generic shims and policy files.
- Per-connector hook scripts are removed via a new `HookScriptOwner`-based `removeOwnedHookScripts` helper that each connector's `Teardown` opts into (claudecode, codex, openclaw, zeptoclaw).
- New regression test `TestTeardown_DoesNotDeleteOtherConnectorsHookScripts` asserts one connector's teardown leaves another connector's scripts in place.

### 3. Defense-in-depth: post-Setup verification

`sidecar.go` now calls `verifyHookScriptsOnDisk` after `Setup` returns. It stats every script the connector claims to own and retries `Setup` once if any are missing, logging loudly if hooks are *still* absent. This turns a silent hook-loss into a visible warning instead of an opaque `exit 127` at runtime.

## Files changed

```
internal/gateway/connector/claudecode.go           |   7 +
internal/gateway/connector/codex.go                |   7 +
internal/gateway/connector/connector_test.go       | 350 +++
internal/gateway/connector/hooks/claude-code-hook.sh |  29 +
internal/gateway/connector/hooks/codex-hook.sh     |  23 +
internal/gateway/connector/openclaw.go             |   1 +
internal/gateway/connector/subprocess.go           |  49 +-
internal/gateway/connector/zeptoclaw.go            |   1 +
internal/gateway/sidecar.go                        |  48 +
9 files changed, 507 insertions(+), 8 deletions(-)
```

## Test plan

- [x] `go vet ./internal/gateway/...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./internal/gateway/connector/ -count=1` — all green
- [x] New regression tests added and pass:
  - [x] `TestCodexHookScript_StructuredBlock_ExitsZeroNotTwo`
  - [x] `TestCodexHookScript_NoStructuredOutput_FallsBackToExitTwo`
  - [x] `TestClaudeCodeHookScript_StructuredBlock_ExitsZeroNotTwo`
  - [x] `TestClaudeCodeHookScript_NoStructuredOutput_FallsBackToExitTwo`
  - [x] `TestTeardown_DoesNotDeleteOtherConnectorsHookScripts`
- [x] Manual end-to-end on Codex `v0.129.0`:
  - [x] CRITICAL rule (`/etc/shadow`) — hard-blocks with `permissionDecision=deny` JSON honored, no `exit 2` warning
  - [x] HIGH rule (`/etc/passwd`) — alerts as expected per default profile
  - [x] Connector switch claudecode→codex no longer produces `exit 127`
- [x] Manual end-to-end on Claude Code:
  - [x] CRITICAL block path delivers structured `decision=block` and the UI shows the block reason
  - [x] No regression on `UserPromptSubmit` confirm→alert degradation (unchanged behavior)

## Notes for reviewers

- Both bug-fixes are independent but interact: bug #2 alone would mask bug #1 (hooks would 127 before they could mis-encode the block), so they need to land together.
- `verifyHookScriptsOnDisk` is intentionally non-fatal — it warns and proceeds. We can promote to a hard failure later once we have telemetry on how often retry succeeds.
- No public API changes. New `HookScriptOwner` interface lives entirely inside `internal/gateway/connector/`.