### PR TITLE
feat(setup): refresh seeded bundle and restart docker stack on `setup splunk` / `setup local-observability`

### DIFF
--- a/cli/defenseclaw/bundle_refresh.py
+++ b/cli/defenseclaw/bundle_refresh.py
@@ -1,0 +1,422 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Refresh user-seeded bundle copies from the wheel/repo source.
+
+Both the local Splunk bridge (``~/.defenseclaw/splunk-bridge/``) and the
+local observability stack (``~/.defenseclaw/observability-stack/``) are
+seeded by ``defenseclaw init`` and *never* refreshed by it on a re-run
+(``init`` preserves the seeded copy so operator edits survive). That
+historically meant new bundle code shipped in the wheel — the v0.130
+``s3_exporter/`` sidecar, a fix to ``compose/docker-compose.local.yml``,
+a new dashboard — sat unused on disk forever.
+
+This module is the explicit, opt-out path for picking those up:
+
+* :func:`refresh_splunk_bridge` does an rsync-style overwrite of the
+  whole bridge, preserving only operator-secret files (``env/.env``)
+  and regenerated artefacts (``splunk/build/``). The Splunk bundle is
+  overwhelmingly maintainer-owned (compose, bin, app source,
+  ``s3_exporter/``); the only operator-overrideable Splunk runtime
+  state lives inside the persistent ``splunk_etc`` Docker volume,
+  which we never touch.
+
+* :func:`refresh_local_observability_stack` refreshes maintainer-owned
+  files (``bin/``, ``run.sh``, ``docker-compose.yml``) by default and
+  preserves operator-editable surfaces (Grafana dashboards, Prometheus
+  rules, Loki/Tempo/OTel-Collector configs). Pass
+  ``refresh_config=True`` for a wholesale refresh — that's destructive
+  to operator dashboard edits and so is opt-in.
+
+* :func:`is_compose_project_running` uses ``docker ps`` labels to spot
+  a running stack so callers can stop → refresh → restart in one
+  motion.
+
+All refresh writes go through a tmp dir + ``os.replace`` so a crash
+midway through a copy can't leave the seeded copy half-overwritten.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from defenseclaw.paths import (
+    bundled_local_observability_dir,
+    bundled_splunk_bridge_dir,
+)
+
+# ---------------------------------------------------------------------------
+# Public dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RefreshResult:
+    """Outcome of a single refresh + (optional) restart cycle.
+
+    All paths are stored as the relative-to-bundle-root strings the
+    caller passed in (e.g. ``"compose/docker-compose.local.yml"``) so
+    they render cleanly in CLI status output.
+    """
+
+    bundle_kind: str
+    seeded_dest: str
+    bundle_source: str
+    refreshed: bool = False
+    refreshed_paths: list[str] = field(default_factory=list)
+    preserved_paths: list[str] = field(default_factory=list)
+    skipped_reason: str | None = None
+    was_running: bool = False
+    stopped: bool = False
+    restarted: bool = False
+    errors: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Splunk bridge refresh
+# ---------------------------------------------------------------------------
+
+
+# Files inside ``~/.defenseclaw/splunk-bridge/`` that the refresh must
+# never overwrite. ``env/.env`` carries the operator's SPLUNK_PASSWORD
+# (and any AWS creds for the s3_exporter sidecar), and ``splunk/build/``
+# is the generated tarball that ``package_local_mode_app.sh`` rebuilds
+# every ``up`` so there is no point in ferrying it across.
+_SPLUNK_BRIDGE_PRESERVE: tuple[str, ...] = (
+    "env/.env",
+    "splunk/build",
+)
+
+_SPLUNK_BRIDGE_DEST_REL: str = "splunk-bridge"
+
+
+def refresh_splunk_bridge(data_dir: str) -> RefreshResult:
+    """Refresh ``~/.defenseclaw/splunk-bridge/`` from the bundled source.
+
+    Returns a :class:`RefreshResult` describing what changed. Never
+    raises for missing source / missing dest — the result captures
+    those as a ``skipped_reason`` so the CLI can render a soft
+    warning instead of crashing the setup flow.
+    """
+    bundle = bundled_splunk_bridge_dir()
+    dest = os.path.join(data_dir, _SPLUNK_BRIDGE_DEST_REL)
+    result = RefreshResult(
+        bundle_kind="splunk-bridge",
+        seeded_dest=dest,
+        bundle_source=str(bundle),
+    )
+
+    if not bundle.is_dir():
+        result.skipped_reason = f"bundled source missing ({bundle})"
+        return result
+
+    if not os.path.isdir(dest):
+        # No prior seed — fall back to a plain copytree. Keeps the
+        # refresh path safe to call before ``init`` has run.
+        try:
+            shutil.copytree(str(bundle), dest)
+        except OSError as exc:
+            result.errors.append(f"initial seed: {exc}")
+            return result
+        bridge_bin = os.path.join(dest, "bin", "splunk-claw-bridge")
+        if os.path.isfile(bridge_bin):
+            try:
+                os.chmod(bridge_bin, 0o755)
+            except OSError as exc:
+                result.errors.append(f"chmod splunk-claw-bridge: {exc}")
+        result.refreshed = True
+        result.refreshed_paths.append("(initial seed)")
+        return result
+
+    refreshed, preserved, errors = _rsync_overwrite(
+        src=Path(bundle),
+        dest=Path(dest),
+        preserve=_SPLUNK_BRIDGE_PRESERVE,
+    )
+    result.refreshed_paths = refreshed
+    result.preserved_paths = preserved
+    result.errors = errors
+    result.refreshed = bool(refreshed)
+
+    bridge_bin = os.path.join(dest, "bin", "splunk-claw-bridge")
+    if os.path.isfile(bridge_bin):
+        try:
+            os.chmod(bridge_bin, 0o755)
+        except OSError as exc:
+            result.errors.append(f"chmod splunk-claw-bridge: {exc}")
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Local observability stack refresh
+# ---------------------------------------------------------------------------
+
+
+# Operator-editable surfaces — preserved unless the caller passes
+# ``refresh_config=True``. Each entry is a relative path inside
+# ``~/.defenseclaw/observability-stack/`` and may be a file or a
+# directory; ``_rsync_overwrite`` treats both correctly.
+_LOCAL_OBSERVABILITY_OPERATOR_PATHS: tuple[str, ...] = (
+    "grafana",
+    "prometheus",
+    "loki",
+    "tempo",
+    "otel-collector",
+)
+
+_LOCAL_OBSERVABILITY_DEST_REL: str = "observability-stack"
+
+
+def refresh_local_observability_stack(
+    data_dir: str,
+    *,
+    refresh_config: bool = False,
+) -> RefreshResult:
+    """Refresh ``~/.defenseclaw/observability-stack/`` from the bundle.
+
+    By default we refresh maintainer-owned files (``bin/``, ``run.sh``,
+    ``docker-compose.yml``) and preserve every operator-editable
+    surface listed in :data:`_LOCAL_OBSERVABILITY_OPERATOR_PATHS`. Set
+    ``refresh_config=True`` to also overwrite those — destructive to
+    Grafana dashboard / Prometheus rule edits, hence opt-in.
+    """
+    bundle = bundled_local_observability_dir()
+    dest = os.path.join(data_dir, _LOCAL_OBSERVABILITY_DEST_REL)
+    result = RefreshResult(
+        bundle_kind="observability-stack",
+        seeded_dest=dest,
+        bundle_source=str(bundle),
+    )
+
+    if not bundle.is_dir():
+        result.skipped_reason = f"bundled source missing ({bundle})"
+        return result
+
+    if not os.path.isdir(dest):
+        try:
+            shutil.copytree(str(bundle), dest)
+        except OSError as exc:
+            result.errors.append(f"initial seed: {exc}")
+            return result
+        _ensure_observability_executables(dest)
+        result.refreshed = True
+        result.refreshed_paths.append("(initial seed)")
+        return result
+
+    preserve: tuple[str, ...] = ()
+    if not refresh_config:
+        preserve = _LOCAL_OBSERVABILITY_OPERATOR_PATHS
+
+    refreshed, preserved, errors = _rsync_overwrite(
+        src=Path(bundle),
+        dest=Path(dest),
+        preserve=preserve,
+    )
+    result.refreshed_paths = refreshed
+    result.preserved_paths = preserved
+    result.errors = errors
+    result.refreshed = bool(refreshed)
+
+    _ensure_observability_executables(dest)
+    return result
+
+
+def _ensure_observability_executables(dest: str) -> None:
+    """Make the bridge entry points executable after a refresh.
+
+    Keeps parity with ``cmd_init._ensure_observability_stack_executables``
+    — re-implemented here so the refresh module has zero dependencies on
+    the (much larger) ``cmd_init`` import chain at import time.
+    """
+    for rel in (
+        os.path.join("bin", "openclaw-observability-bridge"),
+        "run.sh",
+    ):
+        path = os.path.join(dest, rel)
+        if os.path.isfile(path):
+            try:
+                os.chmod(path, 0o755)
+            except OSError:
+                # Non-fatal — the bridge will fail loudly on first
+                # invocation if it really lacks the +x bit, and we
+                # don't want refresh() to abort over a chmod hiccup.
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Compose-project running detection
+# ---------------------------------------------------------------------------
+
+
+# Compose project label values used by each bundle — kept in lockstep
+# with bundles/splunk_local_bridge/compose/docker-compose.local.yml
+# (``name:`` field) and bundles/local_observability_stack/docker-compose.yml.
+SPLUNK_COMPOSE_PROJECT: str = "defenseclaw-splunk-local"
+LOCAL_OBSERVABILITY_COMPOSE_PROJECT: str = "defenseclaw-observability"
+
+
+def is_compose_project_running(project_name: str, *, timeout: float = 5.0) -> bool:
+    """Return True if a docker-compose project has at least one running container.
+
+    Best-effort: returns False if Docker is missing/unreachable rather
+    than raising. Callers use this to decide whether to stop the stack
+    before refreshing the bundle on disk; a False here is correctly
+    interpreted as "nothing to stop".
+    """
+    if not shutil.which("docker"):
+        return False
+    try:
+        result = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "--filter",
+                f"label=com.docker.compose.project={project_name}",
+                "--filter",
+                "status=running",
+                "--format",
+                "{{.ID}}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if result.returncode != 0:
+        return False
+    return bool((result.stdout or "").strip())
+
+
+# ---------------------------------------------------------------------------
+# rsync-style overwrite primitive
+# ---------------------------------------------------------------------------
+
+
+def _rsync_overwrite(
+    *,
+    src: Path,
+    dest: Path,
+    preserve: tuple[str, ...],
+) -> tuple[list[str], list[str], list[str]]:
+    """Copy every file from ``src`` over ``dest``, except ``preserve`` paths.
+
+    Returns ``(refreshed_paths, preserved_paths, errors)`` where each
+    list contains the source-relative paths actually touched / kept /
+    failed. ``preserve`` entries may be either files or directories;
+    a directory in ``preserve`` shields its entire subtree.
+
+    The copy goes through ``shutil.copy2 → tmp → os.replace`` per file
+    so a crash during the loop leaves each file either fully old or
+    fully new (never half-written). We do NOT prune dest-only files —
+    the seeded copy can have generated artefacts (e.g.
+    ``splunk/build/defenseclaw_local_mode.tgz``) that should outlive
+    the refresh.
+    """
+    refreshed: list[str] = []
+    preserved: list[str] = []
+    errors: list[str] = []
+
+    preserve_norm = tuple(p.strip("/") for p in preserve if p)
+
+    for root, dirs, files in os.walk(src):
+        rel_root = os.path.relpath(root, src)
+        if rel_root == ".":
+            rel_root = ""
+
+        # Prune directories that match a preserve entry so we don't
+        # descend into them at all. Track each as preserved so the
+        # caller can show what survived.
+        kept_dirs: list[str] = []
+        for d in dirs:
+            rel_dir = os.path.join(rel_root, d) if rel_root else d
+            if _path_is_preserved(rel_dir, preserve_norm):
+                preserved.append(rel_dir)
+                continue
+            kept_dirs.append(d)
+        dirs[:] = kept_dirs
+
+        for fname in files:
+            rel_file = os.path.join(rel_root, fname) if rel_root else fname
+            if _path_is_preserved(rel_file, preserve_norm):
+                preserved.append(rel_file)
+                continue
+
+            src_path = os.path.join(root, fname)
+            dest_path = os.path.join(str(dest), rel_file)
+            try:
+                os.makedirs(os.path.dirname(dest_path) or ".", exist_ok=True)
+                _atomic_copy_file(src_path, dest_path)
+            except OSError as exc:
+                errors.append(f"{rel_file}: {exc}")
+                continue
+            refreshed.append(rel_file)
+
+    return refreshed, preserved, errors
+
+
+def _path_is_preserved(rel: str, preserve: tuple[str, ...]) -> bool:
+    """Return True if ``rel`` exactly matches or is nested under any preserve entry."""
+    rel_norm = rel.strip("/")
+    for p in preserve:
+        if rel_norm == p:
+            return True
+        if rel_norm.startswith(p + "/"):
+            return True
+    return False
+
+
+def _atomic_copy_file(src_path: str, dest_path: str) -> None:
+    """``shutil.copy2`` to a same-directory tmp file, then ``os.replace``.
+
+    Preserves mode bits via ``copy2``. Same-directory tmp file is
+    required because ``os.replace`` is only atomic on the same
+    filesystem — a tmp in ``/tmp`` could land on a different mount
+    on Linux when ``data_dir`` is on an external volume.
+    """
+    dest_dir = os.path.dirname(dest_path) or "."
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".refresh-", dir=dest_dir,
+    )
+    os.close(fd)
+    try:
+        shutil.copy2(src_path, tmp_path)
+        os.replace(tmp_path, dest_path)
+    except OSError:
+        # Best-effort cleanup of the orphan tmp; re-raise so the
+        # caller logs the original failure.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+__all__ = [
+    "LOCAL_OBSERVABILITY_COMPOSE_PROJECT",
+    "RefreshResult",
+    "SPLUNK_COMPOSE_PROJECT",
+    "is_compose_project_running",
+    "refresh_local_observability_stack",
+    "refresh_splunk_bridge",
+]

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -34,6 +34,12 @@ import click
 # ``ux.section("Hook fail mode")`` and the source of the color
 # convention is obvious to anybody auditing this file.
 from defenseclaw import ux
+from defenseclaw.bundle_refresh import (
+    SPLUNK_COMPOSE_PROJECT,
+    RefreshResult,
+    is_compose_project_running,
+    refresh_splunk_bridge,
+)
 from defenseclaw.commands.redaction_status import print_redaction_status_hint
 from defenseclaw.config import DEFENSECLAW_LLM_KEY_ENV
 from defenseclaw.context import AppContext, pass_ctx
@@ -4674,6 +4680,19 @@ _SPLUNK_LOCAL_HEC_DEFAULTS = {
 @click.option("--skip-test", is_flag=True,
               help="Skip the live HEC probe after remote Splunk Enterprise setup")
 @click.option("--show-credentials", is_flag=True, help="Show Splunk Web login credentials")
+@click.option(
+    "--refresh-bundle/--no-refresh-bundle",
+    "refresh_bundle",
+    default=True,
+    show_default=True,
+    help=(
+        "Before starting local Splunk, refresh ~/.defenseclaw/splunk-bridge/ "
+        "from the wheel/repo bundle so newly-shipped compose, bin, app, and "
+        "s3_exporter changes take effect. Operator secrets (env/.env) are "
+        "preserved. If the stack is already running, it will be stopped, "
+        "refreshed, and restarted automatically."
+    ),
+)
 @click.option("--non-interactive", is_flag=True, help="Use flags instead of prompts")
 @pass_ctx
 def setup_splunk(
@@ -4700,6 +4719,7 @@ def setup_splunk(
     accept_splunk_license: bool,
     skip_test: bool,
     show_credentials: bool,
+    refresh_bundle: bool,
     non_interactive: bool,
 ) -> None:
     """Configure Splunk integration for DefenseClaw.
@@ -4766,6 +4786,7 @@ def setup_splunk(
             s3_bucket=s3_bucket,
             s3_prefix=s3_prefix,
             aws_region=aws_region,
+            refresh_bundle=refresh_bundle,
         )
 
     if enable_enterprise:
@@ -5042,6 +5063,7 @@ def _setup_logs(
     s3_bucket: str | None = None,
     s3_prefix: str | None = None,
     aws_region: str | None = None,
+    refresh_bundle: bool = True,
 ) -> bool:
     if not _ensure_splunk_license_acceptance(
         accept_splunk_license=accept_splunk_license,
@@ -5070,6 +5092,7 @@ def _setup_logs(
         s3_bucket=s3_bucket,
         s3_prefix=s3_prefix,
         aws_region=aws_region,
+        refresh_bundle=refresh_bundle,
     )
     click.echo("  Local Splunk configured (Free mode from day 1)")
     return True
@@ -5222,6 +5245,7 @@ def _apply_logs_config(
     s3_bucket: str | None = None,
     s3_prefix: str | None = None,
     aws_region: str | None = None,
+    refresh_bundle: bool = True,
 ) -> None:
     """Thin alias over ``observability.apply_preset("splunk-hec", ...)``.
 
@@ -5239,6 +5263,7 @@ def _apply_logs_config(
             s3_bucket=s3_bucket,
             s3_prefix=s3_prefix,
             aws_region=aws_region,
+            refresh_bundle=refresh_bundle,
         )
         if not contract:
             raise SystemExit(1)
@@ -5373,6 +5398,78 @@ def _resolve_bridge_bin(data_dir: str) -> str | None:
     return splunk_bridge_bin(data_dir)
 
 
+def _refresh_and_maybe_restart_splunk_bridge(data_dir: str) -> RefreshResult:
+    """Refresh the seeded Splunk bridge, stopping any running stack first.
+
+    Sequence (all best-effort — refresh failures don't abort the parent
+    setup flow because the operator can still run with a stale bundle):
+
+    1. Detect a running ``defenseclaw-splunk-local`` compose project.
+    2. If running and a bridge binary exists, invoke ``bridge down``
+       to release the compose project (named volumes survive, so user
+       data is preserved across the bounce).
+    3. Refresh ``~/.defenseclaw/splunk-bridge/`` from the bundle. The
+       refresh preserves operator secrets (``env/.env``) and the
+       generated app tarball (``splunk/build/``).
+    4. The caller then runs ``bridge up`` so the freshly refreshed
+       bundle (compose, bin, s3_exporter Dockerfile, app source) is
+       what materializes the next stack.
+
+    Surface every step inline so an operator sees exactly what
+    happened and never has to wonder why a previously-running stack
+    came back up on a different image.
+    """
+    was_running = is_compose_project_running(SPLUNK_COMPOSE_PROJECT)
+    stopped = False
+    if was_running:
+        click.echo(
+            f"  {ux.dim('→')} Stopping running local Splunk stack to refresh bundle..."
+        )
+        bridge = _resolve_bridge_bin(data_dir)
+        if bridge:
+            try:
+                subprocess.run(
+                    [bridge, "down"],
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                    check=False,
+                )
+                stopped = True
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+                click.echo(f"    warning: could not stop stack: {exc}")
+        else:
+            click.echo(
+                "    warning: bridge binary missing — cannot stop stack cleanly. "
+                "Run 'defenseclaw init' to seed."
+            )
+
+    result = refresh_splunk_bridge(data_dir)
+    result.was_running = was_running
+    result.stopped = stopped
+
+    if result.skipped_reason:
+        click.echo(f"  {ux.dim('→')} Bundle refresh skipped: {result.skipped_reason}")
+        return result
+    if result.errors:
+        for err in result.errors[:3]:
+            click.echo(f"  warning: refresh: {err}")
+    if result.refreshed:
+        count = len(result.refreshed_paths)
+        preserved_count = len(result.preserved_paths)
+        click.echo(
+            f"  {ux.bold('Bundle refreshed:')} ~/.defenseclaw/splunk-bridge/ "
+            f"({count} file{'s' if count != 1 else ''} updated, "
+            f"{preserved_count} preserved)"
+        )
+    else:
+        click.echo(
+            f"  {ux.dim('→')} Bundle refresh: no changes "
+            "(seeded copy already matches bundle)"
+        )
+    return result
+
+
 def _bootstrap_bridge(
     data_dir: str,
     *,
@@ -5380,8 +5477,22 @@ def _bootstrap_bridge(
     s3_bucket: str | None = None,
     s3_prefix: str | None = None,
     aws_region: str | None = None,
+    refresh_bundle: bool = True,
 ) -> dict[str, str] | None:
-    """Start the local Splunk bridge and return the connection contract."""
+    """Start the local Splunk bridge and return the connection contract.
+
+    When ``refresh_bundle=True`` (the default) we sync
+    ``~/.defenseclaw/splunk-bridge/`` from the wheel/repo bundle before
+    invoking ``up`` so newly-shipped compose, bin, app, and
+    ``s3_exporter/`` changes take effect without requiring the operator
+    to ``rm -rf`` the seeded copy. If a docker-compose project for the
+    Splunk stack is already running we stop it first (Docker named
+    volumes survive ``down``, so user data is preserved) so the new
+    bundle is what gets brought back up.
+    """
+    if refresh_bundle:
+        _refresh_and_maybe_restart_splunk_bridge(data_dir)
+
     bridge = _resolve_bridge_bin(data_dir)
     if not bridge:
         click.echo("  Splunk bridge runtime not found.")

--- a/cli/defenseclaw/commands/cmd_setup_local_observability.py
+++ b/cli/defenseclaw/commands/cmd_setup_local_observability.py
@@ -40,6 +40,12 @@ from typing import Any
 import click
 
 from defenseclaw import ux
+from defenseclaw.bundle_refresh import (
+    LOCAL_OBSERVABILITY_COMPOSE_PROJECT,
+    RefreshResult,
+    is_compose_project_running,
+    refresh_local_observability_stack,
+)
 from defenseclaw.commands.redaction_status import print_redaction_status_hint
 from defenseclaw.context import AppContext, pass_ctx
 from defenseclaw.paths import local_observability_bridge_bin
@@ -169,6 +175,31 @@ def local_observability(ctx: click.Context) -> None:
         "untouched (e.g. when a different SIEM owns the audit pipeline)."
     ),
 )
+@click.option(
+    "--refresh-bundle/--no-refresh-bundle",
+    "refresh_bundle",
+    default=True,
+    show_default=True,
+    help=(
+        "Before starting the stack, refresh ~/.defenseclaw/observability-stack/ "
+        "from the wheel/repo bundle so newly-shipped bridge / compose changes "
+        "take effect. Operator-editable surfaces (Grafana dashboards, Prometheus "
+        "rules, Loki/Tempo/OTel-Collector configs) are preserved unless "
+        "--refresh-config is also passed. If the stack is already running, it "
+        "will be stopped, refreshed, and restarted automatically."
+    ),
+)
+@click.option(
+    "--refresh-config",
+    "refresh_config",
+    is_flag=True,
+    default=False,
+    help=(
+        "When refreshing the bundle, also overwrite operator-editable surfaces "
+        "(grafana/, prometheus/, loki/, tempo/, otel-collector/). Destructive "
+        "to local dashboard / rule / config edits — opt-in only."
+    ),
+)
 @pass_ctx
 def up_cmd(
     app: AppContext,
@@ -179,10 +210,18 @@ def up_cmd(
     signals: str,
     service_name: str,
     with_audit_sink: bool,
+    refresh_bundle: bool,
+    refresh_config: bool,
 ) -> None:
     """Start the stack, wait for readiness, and wire the gateway config."""
     if not _preflight_docker():
         raise SystemExit(1)
+
+    if refresh_bundle:
+        _refresh_and_maybe_restart_local_observability(
+            app.cfg.data_dir,
+            refresh_config=refresh_config,
+        )
 
     bridge = _resolve_bridge(app.cfg.data_dir)
 
@@ -376,6 +415,86 @@ def _resolve_bridge(data_dir: str) -> str:
         )
         raise SystemExit(1)
     return bridge
+
+
+def _refresh_and_maybe_restart_local_observability(
+    data_dir: str,
+    *,
+    refresh_config: bool,
+) -> RefreshResult:
+    """Refresh the seeded observability stack, stopping any running stack first.
+
+    Sequence:
+
+    1. Detect a running ``defenseclaw-observability`` compose project.
+    2. If running and the bridge binary exists, invoke ``bridge down``
+       so the compose project releases its container names. Volumes
+       (Grafana / Prometheus / Loki / Tempo data) survive ``down`` so
+       the operator's history is preserved across the bounce.
+    3. Refresh ``~/.defenseclaw/observability-stack/`` from the bundle.
+       Operator-editable config surfaces (dashboards, rules, OTel
+       collector config) are preserved by default; pass
+       ``refresh_config=True`` to also overwrite them.
+    4. The caller then runs ``bridge up`` so the freshly refreshed
+       bundle is what materializes the next stack.
+
+    Best-effort throughout: refresh failures or a missing bundle are
+    surfaced as warnings, never raised — the operator can still bring
+    the stack up against the existing seeded copy.
+    """
+    was_running = is_compose_project_running(LOCAL_OBSERVABILITY_COMPOSE_PROJECT)
+    stopped = False
+    if was_running:
+        click.echo(
+            f"  {ux.dim('→')} Stopping running observability stack to refresh bundle..."
+        )
+        bridge = local_observability_bridge_bin(data_dir)
+        if bridge:
+            try:
+                subprocess.run(
+                    [bridge, "down"],
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                    check=False,
+                )
+                stopped = True
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+                click.echo(f"    warning: could not stop stack: {exc}")
+        else:
+            click.echo(
+                "    warning: bridge binary missing — cannot stop stack cleanly. "
+                "Run 'defenseclaw init' to seed."
+            )
+
+    result = refresh_local_observability_stack(
+        data_dir, refresh_config=refresh_config,
+    )
+    result.was_running = was_running
+    result.stopped = stopped
+
+    if result.skipped_reason:
+        click.echo(
+            f"  {ux.dim('→')} Bundle refresh skipped: {result.skipped_reason}"
+        )
+        return result
+    if result.errors:
+        for err in result.errors[:3]:
+            click.echo(f"  warning: refresh: {err}")
+    if result.refreshed:
+        count = len(result.refreshed_paths)
+        preserved_count = len(result.preserved_paths)
+        click.echo(
+            f"  {ux.bold('Bundle refreshed:')} ~/.defenseclaw/observability-stack/ "
+            f"({count} file{'s' if count != 1 else ''} updated, "
+            f"{preserved_count} preserved)"
+        )
+    else:
+        click.echo(
+            f"  {ux.dim('→')} Bundle refresh: no changes "
+            "(seeded copy already matches bundle)"
+        )
+    return result
 
 
 def _run_bridge_up(

--- a/cli/tests/test_bundle_refresh.py
+++ b/cli/tests/test_bundle_refresh.py
@@ -1,0 +1,476 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``defenseclaw.bundle_refresh``.
+
+Covers the rsync-style overwrite primitive, the Splunk + local
+observability refresh wrappers (preserve / refresh contracts), and
+the docker-ps-based running-stack detector. No real Docker calls are
+made — :func:`is_compose_project_running` is exercised against a
+mocked ``subprocess.run``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+class TestRsyncOverwrite(unittest.TestCase):
+    """Cover the low-level :func:`_rsync_overwrite` primitive."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="dclaw-rsync-")
+        self.src = os.path.join(self.tmp, "src")
+        self.dest = os.path.join(self.tmp, "dest")
+        os.makedirs(self.src)
+        os.makedirs(self.dest)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write(self, root: str, rel: str, contents: str) -> str:
+        path = os.path.join(root, rel)
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(contents)
+        return path
+
+    def test_overwrites_dest_files_from_src(self) -> None:
+        from defenseclaw.bundle_refresh import _rsync_overwrite
+
+        self._write(self.src, "bin/run.sh", "new\n")
+        self._write(self.dest, "bin/run.sh", "old\n")
+
+        refreshed, preserved, errors = _rsync_overwrite(
+            src=Path(self.src), dest=Path(self.dest), preserve=(),
+        )
+
+        self.assertEqual(errors, [])
+        self.assertIn("bin/run.sh", refreshed)
+        self.assertEqual(preserved, [])
+        with open(os.path.join(self.dest, "bin/run.sh"), encoding="utf-8") as handle:
+            self.assertEqual(handle.read(), "new\n")
+
+    def test_creates_missing_dest_subdirs(self) -> None:
+        from defenseclaw.bundle_refresh import _rsync_overwrite
+
+        self._write(self.src, "compose/docker-compose.local.yml", "new\n")
+
+        refreshed, _preserved, errors = _rsync_overwrite(
+            src=Path(self.src), dest=Path(self.dest), preserve=(),
+        )
+
+        self.assertEqual(errors, [])
+        self.assertIn("compose/docker-compose.local.yml", refreshed)
+        path = os.path.join(self.dest, "compose/docker-compose.local.yml")
+        self.assertTrue(os.path.isfile(path))
+
+    def test_preserves_files_listed_explicitly(self) -> None:
+        from defenseclaw.bundle_refresh import _rsync_overwrite
+
+        self._write(self.src, "env/.env", "new-secret\n")
+        self._write(self.dest, "env/.env", "operator-secret\n")
+
+        refreshed, preserved, errors = _rsync_overwrite(
+            src=Path(self.src),
+            dest=Path(self.dest),
+            preserve=("env/.env",),
+        )
+
+        self.assertEqual(errors, [])
+        self.assertNotIn("env/.env", refreshed)
+        self.assertIn("env/.env", preserved)
+        with open(os.path.join(self.dest, "env/.env"), encoding="utf-8") as handle:
+            self.assertEqual(handle.read(), "operator-secret\n")
+
+    def test_preserves_whole_directory_subtree(self) -> None:
+        from defenseclaw.bundle_refresh import _rsync_overwrite
+
+        self._write(self.src, "splunk/build/app.tgz", "new-tarball\n")
+        self._write(self.dest, "splunk/build/app.tgz", "old-tarball\n")
+        self._write(self.dest, "splunk/build/old-only.txt", "operator-only\n")
+
+        refreshed, preserved, errors = _rsync_overwrite(
+            src=Path(self.src),
+            dest=Path(self.dest),
+            preserve=("splunk/build",),
+        )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(refreshed, [])
+        self.assertIn("splunk/build", preserved)
+        with open(os.path.join(self.dest, "splunk/build/app.tgz"), encoding="utf-8") as handle:
+            self.assertEqual(handle.read(), "old-tarball\n")
+        self.assertTrue(os.path.isfile(os.path.join(self.dest, "splunk/build/old-only.txt")))
+
+    def test_does_not_prune_dest_only_files_outside_preserve(self) -> None:
+        """A file present only in dest survives a refresh.
+
+        The seeded copy can have generated artefacts (e.g.
+        ``splunk/build/defenseclaw_local_mode.tgz``) that should not
+        be deleted just because they don't appear in the source bundle.
+        """
+        from defenseclaw.bundle_refresh import _rsync_overwrite
+
+        self._write(self.src, "bin/run.sh", "new\n")
+        self._write(self.dest, "bin/run.sh", "old\n")
+        self._write(self.dest, "bin/dest-only.sh", "i-stay\n")
+
+        _refreshed, _preserved, errors = _rsync_overwrite(
+            src=Path(self.src), dest=Path(self.dest), preserve=(),
+        )
+
+        self.assertEqual(errors, [])
+        self.assertTrue(os.path.isfile(os.path.join(self.dest, "bin/dest-only.sh")))
+
+
+class TestRefreshSplunkBridge(unittest.TestCase):
+    """Cover the :func:`refresh_splunk_bridge` wrapper."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="dclaw-splunk-refresh-")
+        self.bundle = tempfile.mkdtemp(prefix="dclaw-splunk-bundle-")
+
+        os.makedirs(os.path.join(self.bundle, "bin"))
+        with open(
+            os.path.join(self.bundle, "bin", "splunk-claw-bridge"),
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            handle.write("#!/usr/bin/env bash\n# new bridge\n")
+        os.makedirs(os.path.join(self.bundle, "compose"))
+        with open(
+            os.path.join(self.bundle, "compose", "docker-compose.local.yml"),
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            handle.write("name: defenseclaw-splunk-local\n# new compose\n")
+        os.makedirs(os.path.join(self.bundle, "env"))
+        with open(
+            os.path.join(self.bundle, "env", ".env.example"),
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            handle.write("# example env (refreshed)\n")
+        os.makedirs(os.path.join(self.bundle, "s3_exporter"))
+        with open(
+            os.path.join(self.bundle, "s3_exporter", "Dockerfile"),
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            handle.write("# new s3 exporter\n")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+        shutil.rmtree(self.bundle, ignore_errors=True)
+
+    def _seeded_dest(self) -> str:
+        return os.path.join(self.tmp, "splunk-bridge")
+
+    @patch("defenseclaw.bundle_refresh.bundled_splunk_bridge_dir")
+    def test_initial_seed_when_dest_missing(self, mock_bundle: MagicMock) -> None:
+        from defenseclaw.bundle_refresh import refresh_splunk_bridge
+
+        mock_bundle.return_value = Path(self.bundle)
+        result = refresh_splunk_bridge(self.tmp)
+
+        self.assertTrue(result.refreshed)
+        self.assertEqual(result.refreshed_paths, ["(initial seed)"])
+        bridge_bin = os.path.join(self._seeded_dest(), "bin", "splunk-claw-bridge")
+        self.assertTrue(os.path.isfile(bridge_bin))
+        self.assertTrue(os.access(bridge_bin, os.X_OK))
+
+    @patch("defenseclaw.bundle_refresh.bundled_splunk_bridge_dir")
+    def test_refresh_overwrites_maintainer_files(self, mock_bundle: MagicMock) -> None:
+        """A re-run after the bundle changes copies the new files
+        across, ensuring operators who already ran ``init`` actually
+        get bundle changes shipped post-PR-227 (s3_exporter, compose).
+        """
+        from defenseclaw.bundle_refresh import refresh_splunk_bridge
+
+        mock_bundle.return_value = Path(self.bundle)
+        # First seed.
+        refresh_splunk_bridge(self.tmp)
+
+        # Now bump bundle versions.
+        with open(
+            os.path.join(self.bundle, "compose", "docker-compose.local.yml"),
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            handle.write("name: defenseclaw-splunk-local\n# v2 compose\n")
+        with open(
+            os.path.join(self.bundle, "s3_exporter", "Dockerfile"),
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            handle.write("# v2 s3 exporter\n")
+
+        result = refresh_splunk_bridge(self.tmp)
+        self.assertTrue(result.refreshed)
+        self.assertIn("compose/docker-compose.local.yml", result.refreshed_paths)
+        self.assertIn("s3_exporter/Dockerfile", result.refreshed_paths)
+
+        with open(
+            os.path.join(self._seeded_dest(), "compose", "docker-compose.local.yml"),
+            encoding="utf-8",
+        ) as handle:
+            self.assertIn("v2 compose", handle.read())
+        with open(
+            os.path.join(self._seeded_dest(), "s3_exporter", "Dockerfile"),
+            encoding="utf-8",
+        ) as handle:
+            self.assertIn("v2 s3 exporter", handle.read())
+
+    @patch("defenseclaw.bundle_refresh.bundled_splunk_bridge_dir")
+    def test_refresh_preserves_operator_env_dotenv(self, mock_bundle: MagicMock) -> None:
+        """``env/.env`` carries operator secrets (SPLUNK_PASSWORD, AWS
+        keys) and must never be overwritten by a refresh.
+        """
+        from defenseclaw.bundle_refresh import refresh_splunk_bridge
+
+        mock_bundle.return_value = Path(self.bundle)
+        refresh_splunk_bridge(self.tmp)
+
+        operator_env = os.path.join(self._seeded_dest(), "env", ".env")
+        with open(operator_env, "w", encoding="utf-8") as handle:
+            handle.write("SPLUNK_PASSWORD=do-not-overwrite\n")
+
+        # Now ship a new bundle that includes a stale env/.env we
+        # should NOT honour.
+        with open(
+            os.path.join(self.bundle, "env", ".env"),
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            handle.write("SPLUNK_PASSWORD=stale-from-bundle\n")
+
+        result = refresh_splunk_bridge(self.tmp)
+        self.assertIn("env/.env", result.preserved_paths)
+        self.assertNotIn("env/.env", result.refreshed_paths)
+        with open(operator_env, encoding="utf-8") as handle:
+            self.assertIn("do-not-overwrite", handle.read())
+
+    @patch("defenseclaw.bundle_refresh.bundled_splunk_bridge_dir")
+    def test_refresh_preserves_generated_app_tarball(self, mock_bundle: MagicMock) -> None:
+        from defenseclaw.bundle_refresh import refresh_splunk_bridge
+
+        mock_bundle.return_value = Path(self.bundle)
+        refresh_splunk_bridge(self.tmp)
+
+        build_dir = os.path.join(self._seeded_dest(), "splunk", "build")
+        os.makedirs(build_dir, exist_ok=True)
+        tarball = os.path.join(build_dir, "defenseclaw_local_mode.tgz")
+        with open(tarball, "wb") as handle:
+            handle.write(b"\x1f\x8b\x08\x00fake")  # gzip magic + junk
+
+        # A new bundle that ships a different tarball — we should not
+        # ferry it over because we always rebuild from app source via
+        # package_local_mode_app.sh on `up`.
+        os.makedirs(os.path.join(self.bundle, "splunk", "build"), exist_ok=True)
+        with open(
+            os.path.join(self.bundle, "splunk", "build", "defenseclaw_local_mode.tgz"),
+            "wb",
+        ) as handle:
+            handle.write(b"NEW")
+
+        refresh_splunk_bridge(self.tmp)
+        with open(tarball, "rb") as handle:
+            data = handle.read()
+        self.assertNotEqual(data, b"NEW")  # operator artefact survived
+
+    @patch("defenseclaw.bundle_refresh.bundled_splunk_bridge_dir")
+    def test_missing_bundle_returns_skipped(self, mock_bundle: MagicMock) -> None:
+        from defenseclaw.bundle_refresh import refresh_splunk_bridge
+
+        mock_bundle.return_value = Path(self.bundle) / "does-not-exist"
+        result = refresh_splunk_bridge(self.tmp)
+
+        self.assertFalse(result.refreshed)
+        self.assertIsNotNone(result.skipped_reason)
+        self.assertFalse(os.path.isdir(self._seeded_dest()))
+
+
+class TestRefreshLocalObservabilityStack(unittest.TestCase):
+    """Cover :func:`refresh_local_observability_stack`."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="dclaw-obs-refresh-")
+        self.bundle = tempfile.mkdtemp(prefix="dclaw-obs-bundle-")
+
+        os.makedirs(os.path.join(self.bundle, "bin"))
+        with open(
+            os.path.join(self.bundle, "bin", "openclaw-observability-bridge"),
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            handle.write("#!/usr/bin/env bash\n# v2 bridge\n")
+        with open(os.path.join(self.bundle, "run.sh"), "w", encoding="utf-8") as handle:
+            handle.write("#!/usr/bin/env bash\n# v2 shim\n")
+        with open(
+            os.path.join(self.bundle, "docker-compose.yml"),
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            handle.write("# v2 compose\n")
+        os.makedirs(os.path.join(self.bundle, "grafana", "dashboards"))
+        with open(
+            os.path.join(self.bundle, "grafana", "dashboards", "overview.json"),
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            handle.write('{"title": "bundled-v2"}\n')
+        os.makedirs(os.path.join(self.bundle, "prometheus"))
+        with open(
+            os.path.join(self.bundle, "prometheus", "prometheus.yml"),
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            handle.write("# v2 prometheus\n")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+        shutil.rmtree(self.bundle, ignore_errors=True)
+
+    def _dest(self) -> str:
+        return os.path.join(self.tmp, "observability-stack")
+
+    @patch("defenseclaw.bundle_refresh.bundled_local_observability_dir")
+    def test_default_refresh_preserves_operator_dashboards(
+        self, mock_bundle: MagicMock,
+    ) -> None:
+        """The default refresh must not stomp on operator-edited dashboards."""
+        from defenseclaw.bundle_refresh import refresh_local_observability_stack
+
+        mock_bundle.return_value = Path(self.bundle)
+        refresh_local_observability_stack(self.tmp)
+
+        dashboards = os.path.join(self._dest(), "grafana", "dashboards")
+        os.makedirs(dashboards, exist_ok=True)
+        operator = os.path.join(dashboards, "overview.json")
+        with open(operator, "w", encoding="utf-8") as handle:
+            handle.write('{"title": "operator-edited"}\n')
+        operator_prom = os.path.join(self._dest(), "prometheus", "prometheus.yml")
+        with open(operator_prom, "w", encoding="utf-8") as handle:
+            handle.write("# operator-edited prometheus\n")
+
+        # Bump bridge in the bundle to drive a maintainer-file refresh.
+        with open(
+            os.path.join(self.bundle, "bin", "openclaw-observability-bridge"),
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            handle.write("#!/usr/bin/env bash\n# v3 bridge\n")
+
+        result = refresh_local_observability_stack(self.tmp)
+        self.assertIn("bin/openclaw-observability-bridge", result.refreshed_paths)
+        self.assertIn("grafana", result.preserved_paths)
+        self.assertIn("prometheus", result.preserved_paths)
+
+        with open(operator, encoding="utf-8") as handle:
+            self.assertIn("operator-edited", handle.read())
+        with open(operator_prom, encoding="utf-8") as handle:
+            self.assertIn("operator-edited prometheus", handle.read())
+        bridge_bin = os.path.join(
+            self._dest(), "bin", "openclaw-observability-bridge",
+        )
+        with open(bridge_bin, encoding="utf-8") as handle:
+            self.assertIn("v3 bridge", handle.read())
+        self.assertTrue(os.access(bridge_bin, os.X_OK))
+
+    @patch("defenseclaw.bundle_refresh.bundled_local_observability_dir")
+    def test_refresh_config_overwrites_operator_surfaces(
+        self, mock_bundle: MagicMock,
+    ) -> None:
+        """``refresh_config=True`` is the destructive mode operators opt
+        into when they want a clean wipe of dashboards / rules /
+        configs to match the new bundle.
+        """
+        from defenseclaw.bundle_refresh import refresh_local_observability_stack
+
+        mock_bundle.return_value = Path(self.bundle)
+        refresh_local_observability_stack(self.tmp)
+
+        # Operator edit in place...
+        operator = os.path.join(self._dest(), "grafana", "dashboards", "overview.json")
+        with open(operator, "w", encoding="utf-8") as handle:
+            handle.write('{"title": "operator-edited"}\n')
+
+        # ...gets overwritten when explicit opt-in is passed.
+        result = refresh_local_observability_stack(self.tmp, refresh_config=True)
+        self.assertIn("grafana/dashboards/overview.json", result.refreshed_paths)
+        self.assertNotIn("grafana", result.preserved_paths)
+        with open(operator, encoding="utf-8") as handle:
+            self.assertIn("bundled-v2", handle.read())
+
+
+class TestIsComposeProjectRunning(unittest.TestCase):
+    """Cover :func:`is_compose_project_running`."""
+
+    @patch("defenseclaw.bundle_refresh.shutil.which", return_value=None)
+    def test_returns_false_without_docker_binary(self, _which: MagicMock) -> None:
+        from defenseclaw.bundle_refresh import is_compose_project_running
+
+        self.assertFalse(is_compose_project_running("any-project"))
+
+    @patch("defenseclaw.bundle_refresh.subprocess.run")
+    @patch("defenseclaw.bundle_refresh.shutil.which", return_value="/usr/bin/docker")
+    def test_returns_true_when_docker_lists_a_container_id(
+        self, _which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        from defenseclaw.bundle_refresh import is_compose_project_running
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="abc123\n", stderr="")
+        self.assertTrue(is_compose_project_running("defenseclaw-splunk-local"))
+        # Confirm we asked docker for the right project label.
+        called_args = mock_run.call_args.args[0]
+        self.assertIn(
+            "label=com.docker.compose.project=defenseclaw-splunk-local",
+            called_args,
+        )
+
+    @patch("defenseclaw.bundle_refresh.subprocess.run")
+    @patch("defenseclaw.bundle_refresh.shutil.which", return_value="/usr/bin/docker")
+    def test_returns_false_when_docker_lists_no_containers(
+        self, _which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        from defenseclaw.bundle_refresh import is_compose_project_running
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="\n", stderr="")
+        self.assertFalse(is_compose_project_running("any-project"))
+
+    @patch(
+        "defenseclaw.bundle_refresh.subprocess.run",
+        side_effect=OSError("broken pipe"),
+    )
+    @patch("defenseclaw.bundle_refresh.shutil.which", return_value="/usr/bin/docker")
+    def test_returns_false_on_docker_exec_error(
+        self, _which: MagicMock, _run: MagicMock,
+    ) -> None:
+        from defenseclaw.bundle_refresh import is_compose_project_running
+
+        # OSError must NOT propagate — callers treat False as
+        # "nothing to stop".
+        self.assertFalse(is_compose_project_running("any-project"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/tests/test_cmd_misc.py
+++ b/cli/tests/test_cmd_misc.py
@@ -1105,12 +1105,17 @@ class TestSetupSplunkCommand(unittest.TestCase):
             stderr="",
         )
 
+        # refresh_bundle=False so the test isolates the env-var
+        # passthrough on the `up` invocation. The refresh + restart
+        # cycle is exercised separately in
+        # ``test_setup_refresh_bundle_wiring.py``.
         contract = _bootstrap_bridge(
             self.tmp_dir,
             s3_export=True,
             s3_bucket="agentwatch-demo",
             s3_prefix="agentwatch/defenseclaw",
             aws_region="us-west-2",
+            refresh_bundle=False,
         )
 
         self.assertEqual(contract["hec_token"], "bootstrap-token")

--- a/cli/tests/test_setup_refresh_bundle_wiring.py
+++ b/cli/tests/test_setup_refresh_bundle_wiring.py
@@ -1,0 +1,416 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end wiring tests for ``--refresh-bundle``.
+
+Asserts that ``defenseclaw setup splunk --logs`` and
+``defenseclaw setup local-observability up`` both invoke the
+bundle-refresh helper before bringing the stack up, and that the
+running-stack detector is consulted so a stop → refresh → start cycle
+happens when Docker shows the project running.
+
+We mock at the boundary between the CLI and Docker / disk so these
+tests don't need a real Docker daemon or filesystem-resident bundle.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from defenseclaw import config
+from defenseclaw.context import AppContext
+
+
+def _make_app() -> tuple[AppContext, str]:
+    """Build a Click context backed by a throwaway data dir."""
+    tmp_dir = tempfile.mkdtemp(prefix="dclaw-refresh-wiring-")
+    cfg = config.Config(data_dir=tmp_dir)
+    app = AppContext()
+    app.cfg = cfg
+    return app, tmp_dir
+
+
+class TestSetupSplunkRefreshWiring(unittest.TestCase):
+    def setUp(self) -> None:
+        self.runner = CliRunner()
+        self.app, self.tmp_dir = _make_app()
+
+    def tearDown(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    @patch(
+        "defenseclaw.commands.cmd_setup._refresh_and_maybe_restart_splunk_bridge",
+    )
+    @patch("defenseclaw.commands.cmd_setup._preflight_docker", return_value=True)
+    @patch("defenseclaw.commands.cmd_setup.subprocess.run")
+    @patch(
+        "defenseclaw.commands.cmd_setup.splunk_bridge_bin",
+        return_value="/tmp/fake-splunk-claw-bridge",
+    )
+    def test_setup_splunk_logs_default_refreshes_bundle(
+        self,
+        _bridge_bin: MagicMock,
+        mock_run: MagicMock,
+        _preflight: MagicMock,
+        mock_refresh: MagicMock,
+    ) -> None:
+        from defenseclaw.bundle_refresh import RefreshResult
+        from defenseclaw.commands.cmd_setup import setup
+
+        mock_refresh.return_value = RefreshResult(
+            bundle_kind="splunk-bridge",
+            seeded_dest=os.path.join(self.tmp_dir, "splunk-bridge"),
+            bundle_source="/dummy/bundle",
+            refreshed=True,
+            refreshed_paths=["compose/docker-compose.local.yml"],
+        )
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({
+                "splunk_web_url": "http://127.0.0.1:8000",
+                "hec_url": "http://127.0.0.1:8088/services/collector/event",
+                "hec_token": "bootstrap-token",
+                "license_group": "Free",
+                "web_login_required": False,
+                "index": "defenseclaw_local",
+                "source": "defenseclaw",
+                "sourcetype": "defenseclaw:json",
+            }),
+            stderr="",
+        )
+
+        result = self.runner.invoke(
+            setup,
+            ["splunk", "--logs", "--non-interactive", "--accept-splunk-license"],
+            obj=self.app,
+            catch_exceptions=False,
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_refresh.assert_called_once_with(self.tmp_dir)
+
+    @patch(
+        "defenseclaw.commands.cmd_setup._refresh_and_maybe_restart_splunk_bridge",
+    )
+    @patch("defenseclaw.commands.cmd_setup._preflight_docker", return_value=True)
+    @patch("defenseclaw.commands.cmd_setup.subprocess.run")
+    @patch(
+        "defenseclaw.commands.cmd_setup.splunk_bridge_bin",
+        return_value="/tmp/fake-splunk-claw-bridge",
+    )
+    def test_setup_splunk_logs_no_refresh_bundle_skips_refresh(
+        self,
+        _bridge_bin: MagicMock,
+        mock_run: MagicMock,
+        _preflight: MagicMock,
+        mock_refresh: MagicMock,
+    ) -> None:
+        from defenseclaw.commands.cmd_setup import setup
+
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({
+                "splunk_web_url": "http://127.0.0.1:8000",
+                "hec_url": "http://127.0.0.1:8088/services/collector/event",
+                "hec_token": "bootstrap-token",
+                "license_group": "Free",
+                "web_login_required": False,
+                "index": "defenseclaw_local",
+                "source": "defenseclaw",
+                "sourcetype": "defenseclaw:json",
+            }),
+            stderr="",
+        )
+
+        result = self.runner.invoke(
+            setup,
+            [
+                "splunk",
+                "--logs",
+                "--non-interactive",
+                "--accept-splunk-license",
+                "--no-refresh-bundle",
+            ],
+            obj=self.app,
+            catch_exceptions=False,
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_refresh.assert_not_called()
+
+
+class TestRefreshAndMaybeRestartSplunkBridge(unittest.TestCase):
+    """Direct coverage of the stop → refresh decision logic."""
+
+    @patch(
+        "defenseclaw.commands.cmd_setup.refresh_splunk_bridge",
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup.is_compose_project_running",
+        return_value=True,
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup._resolve_bridge_bin",
+        return_value="/fake/bin/splunk-claw-bridge",
+    )
+    @patch("defenseclaw.commands.cmd_setup.subprocess.run")
+    def test_running_stack_is_stopped_before_refresh(
+        self,
+        mock_run: MagicMock,
+        _resolve: MagicMock,
+        _running: MagicMock,
+        mock_refresh: MagicMock,
+    ) -> None:
+        from defenseclaw.bundle_refresh import RefreshResult
+        from defenseclaw.commands.cmd_setup import (
+            _refresh_and_maybe_restart_splunk_bridge,
+        )
+
+        mock_refresh.return_value = RefreshResult(
+            bundle_kind="splunk-bridge",
+            seeded_dest="/dest",
+            bundle_source="/src",
+            refreshed=True,
+            refreshed_paths=["compose/docker-compose.local.yml"],
+        )
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        result = _refresh_and_maybe_restart_splunk_bridge("/data")
+
+        self.assertTrue(result.was_running)
+        self.assertTrue(result.stopped)
+        # The down call must precede the refresh call. Pull the
+        # subprocess args to confirm we asked the bridge for `down`.
+        self.assertTrue(any(
+            call.args[0] == ["/fake/bin/splunk-claw-bridge", "down"]
+            for call in mock_run.call_args_list
+        ))
+        mock_refresh.assert_called_once_with("/data")
+
+    @patch(
+        "defenseclaw.commands.cmd_setup.refresh_splunk_bridge",
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup.is_compose_project_running",
+        return_value=False,
+    )
+    @patch("defenseclaw.commands.cmd_setup.subprocess.run")
+    def test_no_running_stack_skips_stop_step(
+        self,
+        mock_run: MagicMock,
+        _running: MagicMock,
+        mock_refresh: MagicMock,
+    ) -> None:
+        from defenseclaw.bundle_refresh import RefreshResult
+        from defenseclaw.commands.cmd_setup import (
+            _refresh_and_maybe_restart_splunk_bridge,
+        )
+
+        mock_refresh.return_value = RefreshResult(
+            bundle_kind="splunk-bridge",
+            seeded_dest="/dest",
+            bundle_source="/src",
+            refreshed=False,
+        )
+
+        result = _refresh_and_maybe_restart_splunk_bridge("/data")
+
+        self.assertFalse(result.was_running)
+        self.assertFalse(result.stopped)
+        mock_run.assert_not_called()
+        mock_refresh.assert_called_once_with("/data")
+
+
+class TestSetupLocalObservabilityRefreshWiring(unittest.TestCase):
+    def setUp(self) -> None:
+        self.runner = CliRunner()
+        self.app, self.tmp_dir = _make_app()
+
+    def tearDown(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability"
+        "._refresh_and_maybe_restart_local_observability",
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability._preflight_docker",
+        return_value=True,
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability._run_bridge_up",
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability._resolve_bridge",
+        return_value="/fake/bin/openclaw-observability-bridge",
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability._apply_local_otlp_config",
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability"
+        "._apply_local_otlp_audit_sink",
+    )
+    def test_up_default_calls_refresh_helper(
+        self,
+        _audit: MagicMock,
+        _otlp: MagicMock,
+        _resolve: MagicMock,
+        mock_run_up: MagicMock,
+        _preflight: MagicMock,
+        mock_refresh: MagicMock,
+    ) -> None:
+        from defenseclaw.commands.cmd_setup_local_observability import (
+            local_observability,
+        )
+
+        mock_run_up.return_value = {
+            "otlp_endpoint": "127.0.0.1:4317",
+            "otlp_protocol": "grpc",
+            "grafana_url": "http://localhost:3000",
+            "prometheus_url": "http://localhost:9090",
+            "tempo_url": "http://localhost:3200",
+            "loki_url": "http://localhost:3100",
+            "otlp_http_endpoint": "127.0.0.1:4318",
+        }
+
+        result = self.runner.invoke(
+            local_observability,
+            ["up", "--no-wait"],
+            obj=self.app,
+            catch_exceptions=False,
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_refresh.assert_called_once()
+        # The wiring should pass refresh_config=False unless the user
+        # opts in.
+        self.assertFalse(mock_refresh.call_args.kwargs["refresh_config"])
+
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability"
+        "._refresh_and_maybe_restart_local_observability",
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability._preflight_docker",
+        return_value=True,
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability._run_bridge_up",
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability._resolve_bridge",
+        return_value="/fake/bin/openclaw-observability-bridge",
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability._apply_local_otlp_config",
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability"
+        "._apply_local_otlp_audit_sink",
+    )
+    def test_up_no_refresh_bundle_skips_refresh(
+        self,
+        _audit: MagicMock,
+        _otlp: MagicMock,
+        _resolve: MagicMock,
+        mock_run_up: MagicMock,
+        _preflight: MagicMock,
+        mock_refresh: MagicMock,
+    ) -> None:
+        from defenseclaw.commands.cmd_setup_local_observability import (
+            local_observability,
+        )
+
+        mock_run_up.return_value = {
+            "otlp_endpoint": "127.0.0.1:4317",
+            "otlp_protocol": "grpc",
+        }
+
+        result = self.runner.invoke(
+            local_observability,
+            ["up", "--no-wait", "--no-refresh-bundle"],
+            obj=self.app,
+            catch_exceptions=False,
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_refresh.assert_not_called()
+
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability"
+        "._refresh_and_maybe_restart_local_observability",
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability._preflight_docker",
+        return_value=True,
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability._run_bridge_up",
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability._resolve_bridge",
+        return_value="/fake/bin/openclaw-observability-bridge",
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability._apply_local_otlp_config",
+    )
+    @patch(
+        "defenseclaw.commands.cmd_setup_local_observability"
+        "._apply_local_otlp_audit_sink",
+    )
+    def test_up_refresh_config_propagates_flag(
+        self,
+        _audit: MagicMock,
+        _otlp: MagicMock,
+        _resolve: MagicMock,
+        mock_run_up: MagicMock,
+        _preflight: MagicMock,
+        mock_refresh: MagicMock,
+    ) -> None:
+        from defenseclaw.commands.cmd_setup_local_observability import (
+            local_observability,
+        )
+
+        mock_run_up.return_value = {
+            "otlp_endpoint": "127.0.0.1:4317",
+            "otlp_protocol": "grpc",
+        }
+
+        result = self.runner.invoke(
+            local_observability,
+            ["up", "--no-wait", "--refresh-config"],
+            obj=self.app,
+            catch_exceptions=False,
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_refresh.assert_called_once()
+        self.assertTrue(mock_refresh.call_args.kwargs["refresh_config"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`defenseclaw init` seeds `~/.defenseclaw/splunk-bridge/` and `~/.defenseclaw/observability-stack/` from `bundles/` and **never refreshes them** on a re-run — the seed contract has always been *"preserve operator edits across re-init"*. That means every bundle change shipped after the first init sat unused on disk until the operator manually `rm -rf`'d the seeded copy. Concrete recent examples that bit operators:

- The v0.130 `s3_exporter/` sidecar from #227 — invisible to anyone who'd run `defenseclaw init` previously.
- Compose / bin / app fixes in `bundles/splunk_local_bridge/`.
- New Grafana dashboards or `openclaw-observability-bridge` bash 3.2 fixes in `bundles/local_observability_stack/`.

## Solution

Wire an opt-out refresh into both setup commands so the default flow picks up the latest bundle automatically — and if the docker stack is already running, stop → refresh → restart in one motion.

### `defenseclaw setup splunk --logs` (and `--s3-export`)

1. Detect a running `defenseclaw-splunk-local` compose project via `docker ps`.
2. If running → `bridge down` (named volumes survive, so `splunk_etc` / `splunk_var` / `splunk_s3_exporter_state` operator data is preserved).
3. Refresh `~/.defenseclaw/splunk-bridge/` from the wheel/repo bundle.
   - **Preserved:** `env/.env` (operator secrets like `SPLUNK_PASSWORD`, AWS keys), `splunk/build/` (regenerated tarball).
   - **Refreshed:** everything else — `compose/`, `bin/`, `s3_exporter/`, `splunk/apps/`, `splunk/ansible/`, `splunk/default.yml`.
4. `bridge up` runs against the freshly refreshed bundle.
5. Pass `--no-refresh-bundle` to skip step 3 entirely.

### `defenseclaw setup local-observability up`

1. Same docker-ps detect → `bridge down` if `defenseclaw-observability` is up.
2. Refresh `~/.defenseclaw/observability-stack/` from the bundle.
   - **Refreshed by default:** maintainer-owned files (`bin/`, `run.sh`, `docker-compose.yml`).
   - **Preserved by default:** operator-editable surfaces (`grafana/`, `prometheus/`, `loki/`, `tempo/`, `otel-collector/`).
   - Pass `--refresh-config` to also overwrite the operator-editable surfaces (destructive to local dashboard / rule edits — opt-in).
3. `bridge up` runs against the refreshed bundle.
4. Pass `--no-refresh-bundle` to skip step 2 entirely.

## New shared module — `cli/defenseclaw/bundle_refresh.py`

- `refresh_splunk_bridge(data_dir)` and `refresh_local_observability_stack(data_dir, *, refresh_config)` — rsync-style wrappers with explicit preserve allow-lists.
- `_rsync_overwrite(src, dest, preserve)` — the underlying primitive. Each file copied via `shutil.copy2` → same-dir tmp → `os.replace` so a crash mid-loop leaves files either fully old or fully new (never half-written). Dest-only files (e.g. generated tarballs) are **not** pruned.
- `is_compose_project_running(project_name)` — `docker ps --filter label=com.docker.compose.project=...`. Returns `False` (never raises) if Docker is missing/unreachable so callers correctly read "nothing to stop".
- Compose project name constants (`SPLUNK_COMPOSE_PROJECT`, `LOCAL_OBSERVABILITY_COMPOSE_PROJECT`) kept in lockstep with the bundle compose YAMLs.

## Safety properties

- Docker named volumes (`splunk_etc`, `splunk_var`, `defenseclaw_grafana_data`, `defenseclaw_prometheus_data`, etc.) are never touched — operator history survives the bounce.
- Refresh failures are surfaced as warnings, never raised — the operator can still bring the stack up against the existing seeded copy.
- A missing bundle (e.g. running off a non-editable wheel where `_data/` is gone) yields `skipped_reason` and a soft warning instead of a crash.
- Per-file atomic write (`tmp` → `os.replace`) prevents a half-overwritten seed if the process is killed mid-loop.

## Files changed

```
cli/defenseclaw/bundle_refresh.py                       | 422 +++++++++++++++++  (new)
cli/defenseclaw/commands/cmd_setup.py                   | 113 +++-
cli/defenseclaw/commands/cmd_setup_local_observability.py | 119 ++++
cli/tests/test_bundle_refresh.py                        | 476 +++++++++++++++++  (new)
cli/tests/test_cmd_misc.py                              |   5 +-
cli/tests/test_setup_refresh_bundle_wiring.py           | 416 ++++++++++++++++  (new)
6 files changed, 1550 insertions(+), 1 deletion(-)
```

## Test plan

- [x] `make cli-test` — 2074 pass, 3 pre-existing pytest-import errors in untouched files (`test_ai_signatures.py`, `test_connector_mcp_writers.py`, `test_connector_paths.py`), 0 new failures.
- [x] 23 new tests added and pass:
  - `TestRsyncOverwrite` (5 cases) — overwrite, missing-subdir creation, file-level preserve, directory-level preserve, dest-only file survival.
  - `TestRefreshSplunkBridge` (5 cases) — initial seed, maintainer-file refresh, operator `env/.env` preserve, generated-tarball preserve, missing-bundle skip.
  - `TestRefreshLocalObservabilityStack` (2 cases) — default preserve operator dashboards, `--refresh-config` opt-in overwrite.
  - `TestIsComposeProjectRunning` (4 cases) — no Docker binary, container listed, no containers, exec error suppressed.
  - `TestSetupSplunkRefreshWiring` (2 cases) — default refreshes, `--no-refresh-bundle` skips.
  - `TestRefreshAndMaybeRestartSplunkBridge` (2 cases) — running-stack stopped before refresh, no-running skips stop step.
  - `TestSetupLocalObservabilityRefreshWiring` (3 cases) — default refresh, `--no-refresh-bundle` skips, `--refresh-config` propagates.
- [x] One existing test updated: `test_bootstrap_bridge_s3_export_uses_single_run_kwargs` now passes `refresh_bundle=False` so it can keep asserting `assert_called_once` on the env-var passthrough; the refresh + restart path is exercised by the new wiring tests instead.

## Backward compatibility

- New flags default to **on** for refresh, **off** for the destructive `--refresh-config`. CI / setup scripts that already pass other flags continue to work — they'll just start picking up bundle changes on the next invocation, which is the desired behavior.
- Operators who hand-edit dashboards keep them by default. Anyone who wants the old "never touch the seeded copy" behavior gets it via `--no-refresh-bundle`.
- The CLI surface is purely additive — no flags removed or renamed.

## Notes for reviewers

- The refresh helper lives in `cli/defenseclaw/bundle_refresh.py` rather than `cmd_init.py` on purpose — it has zero `cmd_init` import dependency, so importing it from setup commands doesn't drag in the larger init chain at module-load time.
- The `_resolve_bridge_bin` lookup chain is unchanged: seeded copy at `~/.defenseclaw/splunk-bridge/bin/splunk-claw-bridge` is still preferred over the bundle. Refresh updates the seeded copy in place so the lookup keeps working.
- The wiring intentionally calls `refresh_splunk_bridge` *before* resolving the bridge binary so a refresh can also fix a corrupt/missing seeded bridge (see `_bootstrap_bridge` ordering).