### PR TITLE
Fix OpenClaw restart overwriting Discord allowance

### DIFF
--- a/docs-site/content/docs/connectors/openclaw.mdx
+++ b/docs-site/content/docs/connectors/openclaw.mdx
@@ -149,6 +149,10 @@ Not sure what to pick? Run `defenseclaw setup guardrail` (no flags) — the [int
 
 A hash-checked backup of `openclaw.json` is stored before edits; teardown restores or surgically removes only DefenseClaw-owned entries.
 
+<Callout>
+The `~/.openclaw/extensions/defenseclaw/` directory is a DefenseClaw-managed runtime bundle. Setup writes it from the gateway's embedded plugin and records a bundle hash; same-version restarts leave the directory alone, while upgrades may redeploy it. Put durable endpoint or policy changes in DefenseClaw config/source, not by hot-patching files under this generated extension directory.
+</Callout>
+
 ## What the plugin does
 
 <Sequence

--- a/extensions/defenseclaw/src/__tests__/provider-coverage.test.ts
+++ b/extensions/defenseclaw/src/__tests__/provider-coverage.test.ts
@@ -23,6 +23,7 @@ import providersConfig from "../providers.json" with { type: "json" };
 import {
   classifyBodyShape,
   hasLLMPathSuffix,
+  isKnownNonLLMEndpoint,
   isKnownSafeDomain,
   LLMBodyShape,
 } from "../fetch-interceptor.js";
@@ -84,6 +85,7 @@ function classifyRow(row: Row): "known" | "shape" | "passthrough" {
   if (isKnownProvider(row.url)) return "known";
   const m = (row.method || "GET").toUpperCase();
   if (m === "GET" || m === "HEAD" || m === "OPTIONS") return "passthrough";
+  if (isKnownNonLLMEndpoint(row.url)) return "passthrough";
   if (isKnownSafeDomain(row.url)) return "passthrough";
   if (hasLLMPathSuffix(row.url)) return "shape";
   const shape: LLMBodyShape = classifyBodyShape(row.body);

--- a/extensions/defenseclaw/src/__tests__/shape-detection.test.ts
+++ b/extensions/defenseclaw/src/__tests__/shape-detection.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect } from "vitest";
 import {
   classifyBodyShape,
   hasLLMPathSuffix,
+  isKnownNonLLMEndpoint,
   isKnownSafeDomain,
   isLLMShapedRequest,
   peekBodyForShape,
@@ -125,6 +126,23 @@ describe("isKnownSafeDomain", () => {
   });
 });
 
+describe("isKnownNonLLMEndpoint", () => {
+  it("matches Discord channel message endpoints only", () => {
+    expect(
+      isKnownNonLLMEndpoint(
+        "https://discord.com/api/channels/1496358523230093373/messages",
+      ),
+    ).toBe(true);
+    expect(
+      isKnownNonLLMEndpoint(
+        "https://discord.com/api/v10/channels/1496358523230093373/messages/1234567890",
+      ),
+    ).toBe(true);
+    expect(isKnownNonLLMEndpoint("https://api.anthropic.com/v1/messages")).toBe(false);
+    expect(isKnownNonLLMEndpoint("https://discord.com/api/webhooks/1/token")).toBe(false);
+  });
+});
+
 describe("isLLMShapedRequest", () => {
   const guardrailPort = 14010;
 
@@ -227,6 +245,33 @@ describe("isLLMShapedRequest", () => {
         guardrailPort,
       ),
     ).toBe(false);
+  });
+
+  it("does not treat Discord channel messages as Anthropic-style LLM calls", () => {
+    expect(
+      isLLMShapedRequest(
+        "https://discord.com/api/channels/1496358523230093373/messages",
+        "POST",
+        "none",
+        guardrailPort,
+      ),
+    ).toBe(false);
+    expect(
+      isLLMShapedRequest(
+        "https://discord.com/api/v10/channels/1496358523230093373/messages/1234567890",
+        "POST",
+        "none",
+        guardrailPort,
+      ),
+    ).toBe(false);
+    expect(
+      isLLMShapedRequest(
+        "https://api.anthropic.com/v1/messages",
+        "POST",
+        "none",
+        guardrailPort,
+      ),
+    ).toBe(true);
   });
 });
 

--- a/extensions/defenseclaw/src/fetch-interceptor.ts
+++ b/extensions/defenseclaw/src/fetch-interceptor.ts
@@ -410,6 +410,18 @@ export function isKnownSafeDomain(urlStr: string): boolean {
   return KNOWN_SAFE_DOMAINS.some(d => host === d || host.endsWith("." + d));
 }
 
+/** Endpoint-specific non-LLM APIs whose path names overlap with LLM routes. */
+export function isKnownNonLLMEndpoint(urlStr: string): boolean {
+  try {
+    const u = new URL(urlStr);
+    const host = u.hostname.toLowerCase();
+    if (host !== "discord.com") return false;
+    return /^\/api(?:\/v\d+)?\/channels\/\d+\/messages(?:\/\d+)?$/.test(u.pathname);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Request-shape test: does this look like an LLM call even though the
  * hostname is not in providers.json? We require either an LLM-looking
@@ -430,6 +442,7 @@ export function isLLMShapedRequest(
   if (isAlreadyProxied(urlStr, guardrailPort)) return false;
   const m = (method || "GET").toUpperCase();
   if (m === "GET" || m === "HEAD" || m === "OPTIONS") return false;
+  if (isKnownNonLLMEndpoint(urlStr)) return false;
   if (isKnownSafeDomain(urlStr)) return false;
   if (hasLLMPathSuffix(urlStr)) return true;
   if (bodyShape !== "none") return true;
@@ -812,7 +825,9 @@ export function createFetchInterceptor(
           targetHost: hp.host,
           targetPath: hp.path,
           bodyShape,
-          looksLikeLLM: bodyShape !== "none" || hasLLMPathSuffix(urlStr),
+          looksLikeLLM:
+            !isKnownNonLLMEndpoint(urlStr) &&
+            (bodyShape !== "none" || hasLLMPathSuffix(urlStr)),
           branch: "passthrough",
           decision: "allow",
           reason: "no-match",
@@ -961,6 +976,7 @@ export function createFetchInterceptor(
       // Anthropic /messages, Gemini :generateContent, ollama /api/chat).
       const shapedForHTTPS = Boolean(
         urlStr &&
+          !isKnownNonLLMEndpoint(urlStr) &&
           !isKnownSafeDomain(urlStr) &&
           !isAlreadyProxied(urlStr, guardrailPort) &&
           hasLLMPathSuffix(urlStr),
@@ -1083,7 +1099,10 @@ export function createFetchInterceptor(
             reason: !knownForHTTPS && shapedForHTTPS ? "shape-match" : "known-provider",
           });
         }
-        return http.request(newOpts as unknown as Parameters<typeof http.request>[0], cb as Parameters<typeof http.request>[1]);
+        return http.request(
+          newOpts as unknown as Parameters<typeof http.request>[0],
+          cb as Parameters<typeof http.request>[1],
+        );
       }
 
       // Non-intercepted https.request — report silent passthrough so
@@ -1096,7 +1115,8 @@ export function createFetchInterceptor(
           targetHost: hp.host,
           targetPath: hp.path,
           bodyShape: "none",
-          looksLikeLLM: hasLLMPathSuffix(urlStr),
+          looksLikeLLM:
+            !isKnownNonLLMEndpoint(urlStr) && hasLLMPathSuffix(urlStr),
           branch: "passthrough",
           decision: "allow",
           reason: "no-match",

--- a/internal/gateway/connector/connector_test.go
+++ b/internal/gateway/connector/connector_test.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	"github.com/defenseclaw/defenseclaw/internal/redaction"
@@ -5847,6 +5848,62 @@ func TestInstallOpenClaw_SymlinkedExtDir(t *testing.T) {
 	data, err2 := os.ReadFile(filepath.Join(target, "precious.txt"))
 	if err2 != nil || string(data) != "don't delete me" {
 		t.Error("symlink attack: files in target directory were deleted")
+	}
+}
+
+func TestOpenClawExtensionCurrent_PreservesLocalEditsWhenBundleUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	extDir := filepath.Join(dir, "extensions", "defenseclaw")
+	if err := os.MkdirAll(filepath.Join(extDir, "dist"), 0o755); err != nil {
+		t.Fatalf("mkdir extension: %v", err)
+	}
+	files := map[string]string{
+		"package.json":              `{"name":"defenseclaw"}`,
+		"openclaw.plugin.json":      `{"id":"defenseclaw"}`,
+		"dist/index.js":             "export {};",
+		"dist/fetch-interceptor.js": "local Discord hotfix",
+	}
+	for rel, body := range files {
+		if err := os.WriteFile(filepath.Join(extDir, rel), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	hash, err := hashEmbeddedTree(fstest.MapFS{
+		"bundle/package.json":              {Data: []byte(`{"name":"defenseclaw"}`)},
+		"bundle/openclaw.plugin.json":      {Data: []byte(`{"id":"defenseclaw"}`)},
+		"bundle/dist/index.js":             {Data: []byte("export {};")},
+		"bundle/dist/fetch-interceptor.js": {Data: []byte("bundled source")},
+	}, "bundle")
+	if err != nil {
+		t.Fatalf("hashEmbeddedTree: %v", err)
+	}
+	if err := writeOpenClawManagedManifest(extDir, hash); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	if !installedOpenClawExtensionCurrent(extDir, hash) {
+		t.Fatal("expected matching managed marker to skip redeploy")
+	}
+}
+
+func TestOpenClawExtensionCurrent_MissingRequiredFileRedeploys(t *testing.T) {
+	dir := t.TempDir()
+	extDir := filepath.Join(dir, "extensions", "defenseclaw")
+	if err := os.MkdirAll(filepath.Join(extDir, "dist"), 0o755); err != nil {
+		t.Fatalf("mkdir extension: %v", err)
+	}
+	for _, rel := range []string{"package.json", "openclaw.plugin.json", filepath.Join("dist", "index.js")} {
+		if err := os.WriteFile(filepath.Join(extDir, rel), []byte("{}"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	if err := writeOpenClawManagedManifest(extDir, strings.Repeat("a", 64)); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	if installedOpenClawExtensionCurrent(extDir, strings.Repeat("a", 64)) {
+		t.Fatal("expected missing fetch-interceptor.js to force redeploy")
 	}
 }
 

--- a/internal/gateway/connector/openclaw.go
+++ b/internal/gateway/connector/openclaw.go
@@ -17,12 +17,16 @@
 package connector
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"embed"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -52,6 +56,14 @@ const openClawPluginRoot = "openclaw_extension"
 // Other connectors (zeptoclaw, codex, claudecode) don't touch this
 // embed at all and remain fully usable.
 const openClawPlaceholderName = ".placeholder"
+
+const openClawManagedManifestName = ".defenseclaw-managed.json"
+const openClawManagedManifestVersion = 1
+
+type openClawManagedManifest struct {
+	Version      int    `json:"version"`
+	BundleSHA256 string `json:"bundle_sha256"`
+}
 
 // openClawExtensionAvailable returns true when the embedded OpenClaw
 // extension contains the runtime files (package.json, dist/, etc.) and
@@ -200,11 +212,23 @@ func installOpenClawExtension(ocHome string, enablePluginApprovals bool) error {
 	extDir := filepath.Join(ocHome, "extensions", "defenseclaw")
 	parentDir := filepath.Join(ocHome, "extensions")
 
-	if err := safeRemoveAll(extDir, parentDir); err != nil {
-		return fmt.Errorf("remove prior extension: %w", err)
+	bundleHash, err := hashEmbeddedTree(openClawExtensionFS, openClawPluginRoot)
+	if err != nil {
+		return fmt.Errorf("hash bundled plugin files: %w", err)
 	}
-	if err := writeEmbeddedTree(openClawExtensionFS, openClawPluginRoot, extDir, 0o644, 0o755); err != nil {
-		return fmt.Errorf("write plugin files: %w", err)
+	if installedOpenClawExtensionCurrent(extDir, bundleHash) {
+		log.Printf("[connector] openclaw extension current target=%q changed=false bundle_sha256=%s", extDir, shortSHA256(bundleHash))
+	} else {
+		if err := safeRemoveAll(extDir, parentDir); err != nil {
+			return fmt.Errorf("remove prior extension: %w", err)
+		}
+		if err := writeEmbeddedTree(openClawExtensionFS, openClawPluginRoot, extDir, 0o644, 0o755); err != nil {
+			return fmt.Errorf("write plugin files: %w", err)
+		}
+		if err := writeOpenClawManagedManifest(extDir, bundleHash); err != nil {
+			return fmt.Errorf("write managed manifest: %w", err)
+		}
+		log.Printf("[connector] openclaw extension redeployed target=%q changed=true bundle_sha256=%s", extDir, shortSHA256(bundleHash))
 	}
 
 	configPath := filepath.Join(ocHome, "openclaw.json")
@@ -212,6 +236,90 @@ func installOpenClawExtension(ocHome string, enablePluginApprovals bool) error {
 		return fmt.Errorf("patch openclaw.json: %w", err)
 	}
 	return nil
+}
+
+func installedOpenClawExtensionCurrent(extDir, bundleHash string) bool {
+	info, err := os.Lstat(extDir)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return false
+	}
+	data, err := os.ReadFile(filepath.Join(extDir, openClawManagedManifestName))
+	if err != nil {
+		return false
+	}
+	var manifest openClawManagedManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return false
+	}
+	if manifest.Version != openClawManagedManifestVersion || manifest.BundleSHA256 != bundleHash {
+		return false
+	}
+	for _, rel := range []string{
+		"package.json",
+		"openclaw.plugin.json",
+		filepath.Join("dist", "index.js"),
+		filepath.Join("dist", "fetch-interceptor.js"),
+	} {
+		if _, err := os.Stat(filepath.Join(extDir, rel)); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func writeOpenClawManagedManifest(extDir, bundleHash string) error {
+	manifest := openClawManagedManifest{
+		Version:      openClawManagedManifestVersion,
+		BundleSHA256: bundleHash,
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(extDir, openClawManagedManifestName), append(data, '\n'), 0o644)
+}
+
+func hashEmbeddedTree(fsys fs.FS, srcRoot string) (string, error) {
+	h := sha256.New()
+	err := fs.WalkDir(fsys, srcRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(srcRoot, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		_, _ = h.Write([]byte(rel))
+		_, _ = h.Write([]byte{0})
+		if d.IsDir() {
+			_, _ = h.Write([]byte("dir"))
+			_, _ = h.Write([]byte{0})
+			return nil
+		}
+		data, err := fs.ReadFile(fsys, path)
+		if err != nil {
+			return err
+		}
+		_, _ = h.Write([]byte("file"))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write(data)
+		_, _ = h.Write([]byte{0})
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func shortSHA256(hash string) string {
+	if len(hash) <= 12 {
+		return hash
+	}
+	return hash[:12]
 }
 
 // safeRemoveAll removes target only if it resolves to a path under parent.
@@ -247,7 +355,7 @@ func safeRemoveAll(target, parent string) error {
 // Each target path is checked for path traversal to prevent zip-slip style
 // attacks from crafted embed paths. fileMode and dirMode control the
 // permissions of written files and directories respectively.
-func writeEmbeddedTree(fsys embed.FS, srcRoot, dstRoot string, fileMode, dirMode os.FileMode) error {
+func writeEmbeddedTree(fsys fs.FS, srcRoot, dstRoot string, fileMode, dirMode os.FileMode) error {
 	absDstRoot, err := filepath.Abs(dstRoot)
 	if err != nil {
 		return fmt.Errorf("resolve dstRoot: %w", err)
@@ -267,7 +375,7 @@ func writeEmbeddedTree(fsys embed.FS, srcRoot, dstRoot string, fileMode, dirMode
 		if d.IsDir() {
 			return os.MkdirAll(target, dirMode)
 		}
-		data, err := fsys.ReadFile(path)
+		data, err := fs.ReadFile(fsys, path)
 		if err != nil {
 			return err
 		}
@@ -335,7 +443,11 @@ func patchOpenClawConfig(configPath, extDir string, enablePluginApprovals bool) 
 		if err != nil {
 			return fmt.Errorf("marshal %s: %w", configPath, err)
 		}
-		return atomicWriteFile(configPath, append(out, '\n'), 0o644)
+		out = append(out, '\n')
+		if current, err := os.ReadFile(configPath); err == nil && bytes.Equal(current, out) {
+			return nil
+		}
+		return atomicWriteFile(configPath, out, 0o644)
 	})
 }
 

--- a/internal/gateway/provider_coverage_test.go
+++ b/internal/gateway/provider_coverage_test.go
@@ -80,6 +80,9 @@ func classifyURL(t *testing.T, urlStr, method string, body json.RawMessage) stri
 	if m == "GET" || m == "HEAD" || m == "OPTIONS" {
 		return "passthrough"
 	}
+	if isKnownNonLLMEndpoint(urlStr) {
+		return "passthrough"
+	}
 	// Known-safe allowlist beats both path and body shape.
 	if isKnownSafeDomain(urlStr) {
 		return "passthrough"

--- a/internal/gateway/shape.go
+++ b/internal/gateway/shape.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"net"
 	"net/url"
+	"regexp"
 	"strings"
 )
 
@@ -64,6 +65,8 @@ var KnownSafeDomains = []string{
 	"segment.io",
 	"segment.com",
 }
+
+var knownDiscordChannelMessagesPath = regexp.MustCompile(`^/api(?:/v[0-9]+)?/channels/[0-9]+/messages(?:/[0-9]+)?$`)
 
 // BodyShape enumerates the LLM body shapes Layer 1 can recognize.
 // Keep identical to the TS LLMBodyShape union.
@@ -174,6 +177,19 @@ func isLLMPathSuffix(rawURL string) bool {
 		}
 	}
 	return false
+}
+
+// isKnownNonLLMEndpoint reports endpoint-specific APIs whose path names
+// overlap with LLM routes but should not be treated as model traffic.
+func isKnownNonLLMEndpoint(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	if strings.ToLower(u.Hostname()) != "discord.com" {
+		return false
+	}
+	return knownDiscordChannelMessagesPath.MatchString(u.Path)
 }
 
 // isKnownSafeDomain returns true when the hostname is in KnownSafeDomains.

--- a/internal/gateway/shape_test.go
+++ b/internal/gateway/shape_test.go
@@ -81,6 +81,7 @@ func TestIsLLMPathSuffix(t *testing.T) {
 	cases := map[string]bool{
 		"https://api.openai.com/v1/chat/completions":                                     true,
 		"https://api.anthropic.com/v1/messages":                                          true,
+		"https://discord.com/api/channels/1496358523230093373/messages":                  true,
 		"https://generativelanguage.googleapis.com/v1beta/models/gemini:generateContent": true,
 		"https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse":             true,
 		"http://localhost:11434/api/chat":                                                true,
@@ -93,6 +94,24 @@ func TestIsLLMPathSuffix(t *testing.T) {
 	for u, want := range cases {
 		if got := isLLMPathSuffix(u); got != want {
 			t.Errorf("isLLMPathSuffix(%q) = %v, want %v", u, got, want)
+		}
+	}
+}
+
+func TestIsKnownNonLLMEndpoint(t *testing.T) {
+	cases := map[string]bool{
+		"https://discord.com/api/channels/1496358523230093373/messages":                true,
+		"https://discord.com/api/v10/channels/1496358523230093373/messages":            true,
+		"https://discord.com/api/v10/channels/1496358523230093373/messages/1234567890": true,
+		"https://discord.com/api/webhooks/123456789/abcdef":                            false,
+		"https://discord.com/api/v10/channels/not-a-channel/messages":                  false,
+		"https://api.anthropic.com/v1/messages":                                        false,
+		"https://canary.discord.com/api/channels/1496358523230093373/messages":         false,
+		"": false,
+	}
+	for u, want := range cases {
+		if got := isKnownNonLLMEndpoint(u); got != want {
+			t.Errorf("isKnownNonLLMEndpoint(%q) = %v, want %v", u, got, want)
 		}
 	}
 }

--- a/test/testdata/llm-endpoints.json
+++ b/test/testdata/llm-endpoints.json
@@ -136,6 +136,22 @@
       "expected_branch": "passthrough"
     },
     {
+      "name": "discord_channel_message",
+      "url": "https://discord.com/api/channels/1496358523230093373/messages",
+      "method": "POST",
+      "body": { "content": "hello from the bot" },
+      "expected_branch": "passthrough",
+      "notes": "Discord bot message sends overlap with Anthropic's /messages path but are not LLM calls."
+    },
+    {
+      "name": "discord_channel_message_versioned",
+      "url": "https://discord.com/api/v10/channels/1496358523230093373/messages/1234567890",
+      "method": "POST",
+      "body": null,
+      "expected_branch": "passthrough",
+      "notes": "Path-only detection must not catch versioned Discord channel message endpoints."
+    },
+    {
       "name": "safe_domain_with_llm_path",
       "url": "https://github.com/v1/messages",
       "method": "POST",


### PR DESCRIPTION
## Summary

This fixes a restart regression where the managed OpenClaw extension could be redeployed on gateway startup and overwrite a local Discord posting hotfix.

The Discord channel message endpoint looks like an LLM `/messages` API by path suffix, so it could be routed through DefenseClaw enforcement and blocked after the generated extension bundle reverted. The fix adds explicit known-non-LLM handling for Discord channel message endpoints in both the OpenClaw extension and gateway classifier, and adds corpus/test coverage for the overlap.

The connector installer is also now idempotent for unchanged managed bundles. It writes a managed bundle hash marker and skips redeploying the extension on same-version restarts, while still redeploying if required files are missing or the embedded bundle changes. `openclaw.json` writes are skipped when the content is already byte-identical.

## Validation

- `npm test -- --run src/__tests__/shape-detection.test.ts src/__tests__/provider-coverage.test.ts`
- `make sync-openclaw-extension && go test ./internal/gateway -run 'Test(IsLLMPathSuffix|IsKnownNonLLMEndpoint|ProviderCoverageCorpus)' -count=1`
- `make sync-openclaw-extension && go test ./internal/gateway/connector -run 'TestOpenClawExtensionCurrent|TestInstallOpenClaw_SymlinkedExtDir' -count=1`
- `npm run build`
- `go test ./internal/gateway ./internal/gateway/connector -count=1`
- `npm test`
- `git diff --check`
