### PR TITLE
fix(connector): heal stale codex proxy redirect on `setup codex` (PR #265 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,26 @@ Claude Code now talk directly to their native upstreams in both
 - Migration is idempotent and runs automatically on
   `defenseclaw upgrade`. Failures are logged via `defenseclaw
   doctor --fix` and never block the upgrade.
+- **`defenseclaw setup codex` now heals pre-PR-#265 installs in place.**
+  The legacy setup rewrote `~/.codex/config.toml`'s top-level
+  `openai_base_url` to `http://127.0.0.1:<port>/c/codex`. PR #265
+  deleted the matching proxy mount but left the operator's
+  `config.toml` carrying a now-broken value, so every Codex turn
+  failed with `stream disconnected before completion` against the
+  closed loopback port. `patchCodexConfig` now strips any
+  `openai_base_url` whose URL shape matches the loopback `/c/codex`
+  pattern DefenseClaw itself wrote (scheme `http(s)`, host
+  `127.0.0.1` / `localhost` / `::1`, path beginning `/c/codex`). An
+  operator's enterprise gateway URL is preserved unchanged —
+  `TestCodex_Setup_DefaultObservability_NoProxyRewrite` continues
+  to gate that contract, and `TestIsDefenseClawCodexProxyRedirect`
+  pins the strip detector's full accept/reject surface.
+- **Known follow-up:** `Teardown` does not yet apply the same heal,
+  so `defenseclaw teardown codex` against a pre-PR-#265 install can
+  restore the stale `openai_base_url` from the managed-file backup
+  snapshot captured at the original Setup. Operators uninstalling
+  DefenseClaw should re-run `setup codex` once before `teardown`,
+  or hand-strip the line. Tracked as the immediate next PR.
 
 ### Tests
 

--- a/internal/gateway/connector/codex.go
+++ b/internal/gateway/connector/codex.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -378,6 +379,36 @@ var codexHookGroups = []struct {
 	{"Stop", "", 90},
 }
 
+// isDefenseClawCodexProxyRedirect reports whether v is the loopback
+// LLM-proxy URL DefenseClaw itself wrote into ~/.codex/config.toml on
+// pre-PR-#265 installs. Matching is strict on three axes so an
+// operator's enterprise gateway URL is never mistaken for ours:
+//
+//   - scheme must be http or https (rejects file://, ws://, etc.)
+//   - host must be loopback (127.0.0.1, ::1, or the literal "localhost")
+//   - path must begin with /c/codex (the legacy proxy mount point)
+//
+// Any port is accepted because the historical default of :4000 was
+// configurable via `setup` and operators may have overridden it.
+func isDefenseClawCodexProxyRedirect(v string) bool {
+	u, err := url.Parse(strings.TrimSpace(v))
+	if err != nil {
+		return false
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	switch host {
+	case "127.0.0.1", "::1", "localhost":
+	default:
+		return false
+	}
+	path := strings.TrimSuffix(u.Path, "/")
+	return path == "/c/codex" || strings.HasPrefix(path, "/c/codex/")
+}
+
 func (c *CodexConnector) patchCodexConfig(opts SetupOpts, hookScript string) error {
 	configPath := codexConfigPath()
 	if err := captureManagedFileBackup(opts.DataDir, c.Name(), "config.toml", configPath); err != nil {
@@ -393,6 +424,22 @@ func (c *CodexConnector) patchCodexConfig(opts SetupOpts, hookScript string) err
 		if err := toml.Unmarshal(raw, &cfg); err != nil {
 			return fmt.Errorf("parse codex config: %w", err)
 		}
+	}
+
+	// Heal pre-PR-#265 installs that injected a DefenseClaw LLM-proxy
+	// redirect at the top-level `openai_base_url`. The proxy listener
+	// no longer binds (the value points at a closed loopback port), so
+	// leaving the key in place causes every Codex turn to fail with
+	// "stream disconnected before completion" against the dead
+	// 127.0.0.1:<port>/c/codex endpoint.
+	//
+	// The strip is intentionally narrow: it only deletes values whose
+	// URL shape matches the loopback /c/codex pattern DefenseClaw
+	// itself wrote. An operator's enterprise gateway URL (e.g.
+	// https://gateway.corp.example/openai) is preserved and continues
+	// to be covered by TestCodex_Setup_DefaultObservability_NoProxyRewrite.
+	if v, ok := cfg["openai_base_url"].(string); ok && isDefenseClawCodexProxyRedirect(v) {
+		delete(cfg, "openai_base_url")
 	}
 
 	backupPath := filepath.Join(opts.DataDir, "codex_config_backup.json")

--- a/internal/gateway/connector/connector_test.go
+++ b/internal/gateway/connector/connector_test.go
@@ -2087,6 +2087,132 @@ env_key = "OPENROUTER_API_KEY"
 	}
 }
 
+// TestCodex_Setup_HealsStaleProxyRedirect covers the migration path for
+// operators upgrading from a pre-PR-#265 install. The legacy setup
+// rewrote ~/.codex/config.toml's top-level openai_base_url to point at
+// the gateway's :4000/c/codex proxy mount; PR #265 deleted that mount
+// but left the operator's config.toml carrying a now-broken value, so
+// every Codex turn fails with "stream disconnected before completion"
+// against the closed loopback port.
+//
+// PR #265's "Open question #1" predicted this and the call was to let
+// the next `defenseclaw setup codex` overwrite — but the new Setup is
+// intentionally non-destructive toward openai_base_url (see
+// TestCodex_Setup_DefaultObservability_NoProxyRewrite), so without
+// this heal the stale value survives forever. This test pins the
+// narrow strip: only the loopback /c/codex shape DefenseClaw itself
+// wrote gets removed, and the heal is independent of port number
+// because the pre-#265 default of :4000 was operator-configurable.
+func TestCodex_Setup_HealsStaleProxyRedirect(t *testing.T) {
+	cases := []struct {
+		name      string
+		staleURL  string
+		wantStrip bool
+	}{
+		{name: "ipv4_default_port_4000", staleURL: "http://127.0.0.1:4000/c/codex", wantStrip: true},
+		{name: "ipv4_custom_port", staleURL: "http://127.0.0.1:18971/c/codex", wantStrip: true},
+		{name: "localhost_alias", staleURL: "http://localhost:4000/c/codex", wantStrip: true},
+		{name: "ipv6_loopback", staleURL: "http://[::1]:4000/c/codex", wantStrip: true},
+		{name: "https_loopback", staleURL: "https://127.0.0.1:4000/c/codex", wantStrip: true},
+		{name: "trailing_slash", staleURL: "http://127.0.0.1:4000/c/codex/", wantStrip: true},
+		{name: "deeper_path", staleURL: "http://127.0.0.1:4000/c/codex/responses", wantStrip: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			configPath := filepath.Join(dir, "config.toml")
+			original := `model = "gpt-5"
+openai_base_url = "` + tc.staleURL + `"
+`
+			if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			CodexConfigPathOverride = configPath
+			defer func() { CodexConfigPathOverride = "" }()
+
+			c := NewCodexConnector()
+			opts := SetupOpts{
+				DataDir:   dir,
+				ProxyAddr: "127.0.0.1:4000",
+				APIAddr:   "127.0.0.1:18970",
+			}
+			if err := c.Setup(context.Background(), opts); err != nil {
+				t.Fatalf("Setup: %v", err)
+			}
+
+			raw, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatalf("read patched config: %v", err)
+			}
+			var parsed map[string]interface{}
+			if err := toml.Unmarshal(raw, &parsed); err != nil {
+				t.Fatalf("invalid TOML after Setup: %v", err)
+			}
+			if _, present := parsed["openai_base_url"]; present {
+				t.Errorf("openai_base_url=%q survived Setup — heal did not strip stale proxy redirect\nfile:\n%s",
+					parsed["openai_base_url"], raw)
+			}
+			// The /c/codex prefix must be entirely gone — there is no
+			// legitimate Codex config value pointing there.
+			if strings.Contains(string(raw), "/c/codex") {
+				t.Errorf("config.toml still contains /c/codex after Setup:\n%s", raw)
+			}
+			// Hooks must still be installed — the heal only removes the
+			// proxy redirect, not the telemetry wiring this Setup adds.
+			if _, ok := parsed["hooks"].(map[string]interface{}); !ok {
+				t.Errorf("[hooks] table missing after heal (got=%T)", parsed["hooks"])
+			}
+		})
+	}
+}
+
+// TestIsDefenseClawCodexProxyRedirect locks the strip-detector's blast
+// radius. The heal in patchCodexConfig must never delete a value that
+// wasn't written by DefenseClaw itself, so this table-driven test
+// asserts the full reject set for shapes an operator might legitimately
+// hand-write (enterprise gateways, public LLM hosts, non-HTTP schemes,
+// non-loopback IPs, /c/codex paths on non-loopback hosts).
+func TestIsDefenseClawCodexProxyRedirect(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		// Healed: the exact loopback /c/codex shape DefenseClaw wrote.
+		{name: "ipv4_default", url: "http://127.0.0.1:4000/c/codex", want: true},
+		{name: "ipv4_alt_port", url: "http://127.0.0.1:18971/c/codex", want: true},
+		{name: "ipv4_no_port", url: "http://127.0.0.1/c/codex", want: true},
+		{name: "localhost", url: "http://localhost:4000/c/codex", want: true},
+		{name: "ipv6", url: "http://[::1]:4000/c/codex", want: true},
+		{name: "https", url: "https://127.0.0.1:4000/c/codex", want: true},
+		{name: "trailing_slash", url: "http://127.0.0.1:4000/c/codex/", want: true},
+		{name: "responses_subpath", url: "http://127.0.0.1:4000/c/codex/responses", want: true},
+		{name: "uppercase_scheme", url: "HTTP://127.0.0.1:4000/c/codex", want: true},
+		{name: "whitespace_padded", url: "  http://127.0.0.1:4000/c/codex  ", want: true},
+
+		// Preserved: shapes an operator may legitimately write.
+		{name: "enterprise_https", url: "https://gateway.corp.example/openai", want: false},
+		{name: "openai_public", url: "https://api.openai.com/v1", want: false},
+		{name: "azure_openai", url: "https://my-aoai.openai.azure.com/", want: false},
+		{name: "loopback_non_codex_path", url: "http://127.0.0.1:8080/v1", want: false},
+		{name: "loopback_root", url: "http://127.0.0.1:4000/", want: false},
+		{name: "non_loopback_codex_path", url: "https://example.com/c/codex", want: false},
+		{name: "rfc1918_codex_path", url: "http://10.0.0.1:4000/c/codex", want: false},
+		{name: "file_scheme", url: "file:///c/codex", want: false},
+		{name: "ws_scheme", url: "ws://127.0.0.1:4000/c/codex", want: false},
+		{name: "empty", url: "", want: false},
+		{name: "garbage", url: "not a url at all", want: false},
+		{name: "fragment_match_attempt", url: "http://attacker.example/#http://127.0.0.1:4000/c/codex", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isDefenseClawCodexProxyRedirect(tc.url); got != tc.want {
+				t.Errorf("isDefenseClawCodexProxyRedirect(%q) = %v, want %v", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestCodex_Setup_WritesOtelBlock pins the [otel] block contract: in
 // observability mode the codex connector must register codex's
 // native OTel exporter pointing at the gateway's OTLP-HTTP receiver.


### PR DESCRIPTION
> Follow-up to **#265** — answers its "Open question #1" with **yes, fix it**.

## TL;DR

PR #265 deleted the LLM-proxy data path for Codex but left every pre-#265 operator's `~/.codex/config.toml` carrying a now-broken `openai_base_url = 'http://127.0.0.1:<port>/c/codex'` value pointing at a port that no longer binds. The result: every Codex turn fails with `stream disconnected before completion`, and the next `defenseclaw setup codex` **does not** clean it up because the new Setup is intentionally non-destructive toward `openai_base_url` (gated by `TestCodex_Setup_DefaultObservability_NoProxyRewrite`).

This PR adds a narrow heal in `patchCodexConfig` so the next `setup codex` strips only the loopback `/c/codex` shape DefenseClaw itself wrote, leaving enterprise gateway URLs untouched.

## What the user sees today

```
Reconnecting... 1/5
Reconnecting... 2/5
...
stream disconnected before completion: error sending request for url (http://127.0.0.1:4000/c/codex/responses)
```

And the supposed fix (`defenseclaw setup codex`) runs to completion without resolving the issue, because Setup never touches `openai_base_url`.

## The fix

Narrow strip in `patchCodexConfig` (`internal/gateway/connector/codex.go`):

```go
if v, ok := cfg["openai_base_url"].(string); ok && isDefenseClawCodexProxyRedirect(v) {
    delete(cfg, "openai_base_url")
}
```

The detector is intentionally strict on three axes so an operator's enterprise gateway URL is never mistaken for ours:

| axis    | accept                                          | reject                                  |
| ------- | ----------------------------------------------- | --------------------------------------- |
| scheme  | `http`, `https` (case-insensitive)              | `file://`, `ws://`, anything else       |
| host    | `127.0.0.1`, `localhost`, `::1`                 | RFC1918, public hosts, enterprise FQDNs |
| path    | begins with `/c/codex`                          | anything else                           |
| port    | any (legacy default was operator-configurable)  | n/a                                     |

## Diff stats

```
 CHANGELOG.md                                 |  20 +++++
 internal/gateway/connector/codex.go          |  47 ++++++++++
 internal/gateway/connector/connector_test.go | 126 +++++++++++++++++++++++++++
 3 files changed, 193 insertions(+)
```

One file under `internal/`, all-additive (zero deletions). No interface changes, no breaking-change surface.

## Tests

Two new tests added, both table-driven:

- **`TestCodex_Setup_HealsStaleProxyRedirect`** — end-to-end through `Setup()`. Asserts that the following pre-#265 shapes are all stripped on the next setup run, while the rest of the new managed state (`[hooks]`, `[otel]`, `notify`) is still installed:
  - `http://127.0.0.1:4000/c/codex` (default)
  - `http://127.0.0.1:18971/c/codex` (custom port)
  - `http://localhost:4000/c/codex` (localhost alias)
  - `http://[::1]:4000/c/codex` (IPv6)
  - `https://127.0.0.1:4000/c/codex` (TLS variant)
  - `http://127.0.0.1:4000/c/codex/` (trailing slash)
  - `http://127.0.0.1:4000/c/codex/responses` (deeper path)

- **`TestIsDefenseClawCodexProxyRedirect`** — unit test pinning the detector's full accept/reject surface across 22 cases including 11 explicit reject shapes (enterprise HTTPS, public OpenAI/Azure, RFC1918, `file://`, `ws://`, empty, garbage, a URL-fragment match attempt, and a non-loopback host with the `/c/codex` path).

The existing **`TestCodex_Setup_DefaultObservability_NoProxyRewrite`** continues to gate the "operator's enterprise `openai_base_url` survives untouched" contract — passes unchanged on this branch.

### Full results

```
$ go test ./internal/gateway/connector/...
ok    github.com/defenseclaw/defenseclaw/internal/gateway/connector       3.119s

$ go test ./internal/gateway/...
ok    github.com/defenseclaw/defenseclaw/internal/gateway                22.235s
ok    github.com/defenseclaw/defenseclaw/internal/gateway/connector       4.350s
ok    github.com/defenseclaw/defenseclaw/internal/gateway/notifier        1.276s

$ go vet ./internal/gateway/connector/...    # clean
$ go build ./...                              # clean
```

## Known follow-up — Teardown-side heal

`restoreCodexConfig` (the Teardown path) does **not** yet apply the same heal. Two paths exist there:

1. **Hash-checked managed-file restore** (`restoreManagedFileBackupIfUnchanged`) — the snapshot captured at the original pre-#265 Setup contained the stale `openai_base_url`, so restoring verbatim would re-introduce it.
2. **Field-level fallback** — only touches `[hooks]`, `[features]`, `[otel]`, and `notify`; top-level `openai_base_url` is untouched there as well.

Result: an operator who runs `defenseclaw teardown codex` against a pre-#265 install can end up with a stale proxy redirect after teardown, breaking native Codex post-uninstall.

CHANGELOG documents the immediate workaround (re-run `setup codex` once before `teardown`, so the post-heal hash gets recorded into the managed-file backup). I'll send the Teardown-side heal as the immediate next PR — kept out of this one to keep the review surface tight and the user-facing bug fixed today.

## Manual verification (the broken-Codex reproduction)

```bash
# Repro the stale-config state
cat > /tmp/codex_config_stale.toml <<'CFG'
model = "gpt-5"
openai_base_url = "http://127.0.0.1:4000/c/codex"
CFG
cp /tmp/codex_config_stale.toml ~/.codex/config.toml

# Before this PR: openai_base_url survives, Codex still 500s
defenseclaw setup codex
grep -c openai_base_url ~/.codex/config.toml   # → 1 (broken)

# After this PR: openai_base_url is healed
defenseclaw setup codex
grep -c openai_base_url ~/.codex/config.toml   # → 0 (healed)

# Codex now talks directly to its native upstream — no reconnect loop.
```

## Risk

**Low.** The change is gated by a strict URL-shape match (`/c/codex` on loopback only), and `TestCodex_Setup_DefaultObservability_NoProxyRewrite` continues to gate the "enterprise URL survives" contract. No interface changes, no behavior change for operators who never had a DefenseClaw-injected `openai_base_url`. Zero deletions in this PR.

## Open questions for reviewers

1. **Should `defenseclaw doctor` also detect the stale value and offer `--fix`?** The Setup heal covers the most common path (next setup run) but `doctor` would catch the case where the operator never re-runs setup. Happy to add in this PR or as a sibling PR — preference?
2. **Teardown-side heal scope** — fold into this PR or split? My read is split (this PR is the user-facing bug fix; Teardown is uninstall hygiene), but I'm open to folding if reviewers prefer one atomic heal.
3. **Should the stale-config detection log a `[SECURITY]` or audit line when it strips?** It's not strictly a security event, but it would surface "we healed your config" in `defenseclaw alerts` so operators have an audit trail of the change. Currently silent — happy to add a log line if useful.