### PR TITLE
fix(docs-site/policy-creator): deploy OPA WASM, scroll long live-test pane, clarify rule-pack baseline

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -49,7 +49,26 @@ jobs:
           cache: 'npm'
           cache-dependency-path: docs-site/package-lock.json
 
+      - name: Setup OPA
+        # build-policy-assets.ts runs `opa build` to compile each Rego
+        # domain to WASM under docs-site/public/opa/. Without `opa` on
+        # PATH the script logs a warning and skips, which silently
+        # ships a Pages deploy where the Live Test pane shows
+        # "WASM modules aren't available" and the wizard cannot
+        # evaluate policies in-browser. Pin the action version so
+        # supply-chain drift on the third-party action is explicit.
+        uses: open-policy-agent/setup-opa@v2
+        with:
+          version: latest
+
       - name: Install dependencies
+        # CI_REQUIRE_OPA promotes the missing-opa warning in
+        # build-policy-assets.ts from a soft skip to a hard error, so
+        # a future change that drops the setup-opa step above (or that
+        # bumps OPA past a breaking CLI change) fails the build
+        # instead of silently shipping a broken Live Test pane.
+        env:
+          CI_REQUIRE_OPA: '1'
         run: npm ci --no-audit --no-fund
 
       - name: Unit tests (policy creator)
@@ -74,6 +93,21 @@ jobs:
             echo "::error::Built index.html does not reference /defenseclaw/_next/ — basePath may be misapplied."
             exit 1
           fi
+
+      - name: Verify OPA assets in output
+        # Pages ships everything under out/ verbatim. Missing WASM
+        # files manifest as a "WASM modules aren't available" warning
+        # in the wizard's Live Test pane — the symptom users actually
+        # report. Fail the deploy at build time instead.
+        run: |
+          missing=0
+          for f in manifest.json admission.wasm guardrail.wasm firewall.wasm audit.wasm skill_actions.wasm; do
+            if [ ! -f "out/opa/$f" ]; then
+              echo "::error::out/opa/$f is missing — policy creator Live Test pane will 404."
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ]
 
       - name: Add .nojekyll
         # GitHub Pages defaults to running Jekyll, which strips files

--- a/docs-site/components/policy-creator/playground.tsx
+++ b/docs-site/components/policy-creator/playground.tsx
@@ -357,7 +357,16 @@ export function Playground({
           totalFindings={findings.length}
         />
       </div>
-      <aside className="lg:sticky lg:top-20 lg:h-[calc(100vh-6rem)]">
+      {/*
+        min-h-0 is required for the inner flex column inside
+        LiveTestPane to honour overflow-y-auto under a fixed-height
+        sticky container. Without it the inner pane grows past the
+        aside and the Input JSON / verdict reason / corpus table get
+        clipped at the bottom of the viewport (issue reported on the
+        merged Pages deploy: "Input JSON in full playground is
+        getting cut off").
+      */}
+      <aside className="flex min-h-0 flex-col lg:sticky lg:top-20 lg:h-[calc(100vh-6rem)]">
         <LiveTestPane policy={policy} />
       </aside>
     </div>

--- a/docs-site/components/policy-creator/quick-start/summary.tsx
+++ b/docs-site/components/policy-creator/quick-start/summary.tsx
@@ -24,6 +24,10 @@ export function PolicySummaryCard({
     (acc, f) => acc + f.rules.filter((r) => r.enabled !== false).length,
     0,
   );
+  // Suppressed rules are surfaced separately so the operator can tell
+  // "I haven't touched anything" (suppressed=0) apart from "I'm running
+  // a near-full pack but trimmed a few" (suppressed>0).
+  const suppressedInPack = totalRules - enabledRules;
   const suppressionTotal =
     policy.suppressions.tool_suppressions.length +
     policy.suppressions.finding_suppressions.length +
@@ -40,7 +44,17 @@ export function PolicySummaryCard({
       </h3>
       <ul className="space-y-1.5 text-[12px] text-fd-foreground">
         <Row label="Posture" value={postureLabel} />
-        <Row label="Rules enabled" value={`${enabledRules} of ${totalRules}`} />
+        <Row
+          label="Rule pack"
+          value={`${enabledRules} of ${totalRules} active`}
+          // Suppressed=0 ⇒ "this is just the preset baseline"; >0 ⇒
+          // "you (or the posture) trimmed N from the preset".
+          hint={
+            suppressedInPack === 0
+              ? `Preset baseline — disable individual rules in the Playground → Rule Pack section.`
+              : `${suppressedInPack} rule${suppressedInPack === 1 ? '' : 's'} disabled vs. preset full pack.`
+          }
+        />
         <Row label="Suppressions" value={String(suppressionTotal)} />
         <Row
           label="Firewall"
@@ -58,11 +72,16 @@ export function PolicySummaryCard({
   );
 }
 
-function Row({ label, value }: { label: string; value: string }) {
+function Row({ label, value, hint }: { label: string; value: string; hint?: string }) {
   return (
-    <li className="flex items-baseline justify-between gap-2">
-      <span className="text-fd-muted-foreground">{label}</span>
-      <span className="text-right font-medium tabular-nums">{value}</span>
+    <li className="flex flex-col gap-0.5">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-fd-muted-foreground">{label}</span>
+        <span className="text-right font-medium tabular-nums">{value}</span>
+      </div>
+      {hint && (
+        <span className="text-[10px] leading-tight text-fd-muted-foreground/80">{hint}</span>
+      )}
     </li>
   );
 }

--- a/docs-site/components/policy-creator/sections/live-test.tsx
+++ b/docs-site/components/policy-creator/sections/live-test.tsx
@@ -319,14 +319,20 @@ export function LiveTestPane({ policy }: { policy: Policy }) {
     source === 'scenario' && expected != null && verdict === expected;
 
   return (
-    <div className="flex h-full flex-col gap-4 rounded-lg border border-fd-border bg-fd-card p-4">
-      <header className="flex flex-col gap-1">
+    // Outer shell keeps the title pinned; body scrolls. min-h-0 is
+    // mandatory for the inner overflow-y-auto to honour the parent
+    // sticky container's fixed height — without it the body would
+    // grow past the viewport and clip the verdict / Input JSON pane.
+    <div className="flex h-full min-h-0 flex-col rounded-lg border border-fd-border bg-fd-card">
+      <header className="flex flex-col gap-1 border-b border-fd-border bg-fd-card/80 p-4 backdrop-blur-sm">
         <h3 className="text-sm font-semibold text-fd-foreground">Live Test</h3>
         <p className="text-[11px] text-fd-muted-foreground">
           Evaluates your policy in your browser via OPA-WASM. No data leaves the page —
           custom inputs stay in localStorage.
         </p>
       </header>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
 
       {available === false && (
         <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-700 dark:text-amber-300">
@@ -466,6 +472,7 @@ export function LiveTestPane({ policy }: { policy: Policy }) {
         )}
       </div>
       )}
+      </div>
     </div>
   );
 }

--- a/docs-site/components/policy-creator/ui/scenario-picker.tsx
+++ b/docs-site/components/policy-creator/ui/scenario-picker.tsx
@@ -58,7 +58,11 @@ export function ScenarioJsonPreview({ scenario, expanded }: { scenario: Scenario
         <span aria-hidden="true">{open ? '▼' : '▶'}</span>
       </button>
       {open && (
-        <pre className="overflow-x-auto border-t border-fd-border bg-fd-background px-2.5 py-2 text-[11px] leading-snug text-fd-foreground">
+        // Cap to ~18rem and scroll inside so a tall scenario can't
+        // push the verdict pane below the viewport. Both axes scroll
+        // because some scenarios have long string fields (skill paths,
+        // base64 payloads) that don't wrap.
+        <pre className="max-h-72 overflow-auto border-t border-fd-border bg-fd-background px-2.5 py-2 font-mono text-[11px] leading-snug text-fd-foreground">
           {JSON.stringify(scenario.input, null, 2)}
         </pre>
       )}

--- a/docs-site/scripts/build-policy-assets.ts
+++ b/docs-site/scripts/build-policy-assets.ts
@@ -812,7 +812,13 @@ function compileWasm(opts: { skipMissingOpa: boolean }): { compiled: string[]; s
 
 function main() {
   const args = process.argv.slice(2);
-  const skipMissingOpa = !args.includes('--require-opa');
+  // CI_REQUIRE_OPA is the env-driven equivalent of --require-opa.
+  // The docs-site GitHub Pages workflow sets it before `npm ci` so
+  // the postinstall pass fails loudly if `opa` was not installed on
+  // the runner. Local `npm install` keeps the soft-skip semantics so
+  // contributors without OPA can still build the rest of the site.
+  const skipMissingOpa =
+    !args.includes('--require-opa') && process.env.CI_REQUIRE_OPA !== '1';
 
   ensureDir(DATA_OUT);
 


### PR DESCRIPTION
## Problem
Three regressions reported on the GitHub Pages deploy of the policy creator after #262 merged:

1. **Live Test pane shows "WASM modules aren't available" on prod.** A live probe of `https://cisco-ai-defense.github.io/defenseclaw/opa/manifest.json` returns HTTP 404 — the WASM modules the in-browser OPA evaluator needs never made it to the deploy, so the wizard's Live Test, Quick Start verdict preview, corpus replay, and "Open install script" gating are all broken on prod.
2. **Quick Start summary card says "Rules enabled: 122 of 128"** before the operator clicks anything — reads like they enabled them.
3. **Playground sticky Live Test rail clips Input JSON / verdict reason / corpus rows** below the viewport when content gets tall.

## Current Situation
1. `docs-site/scripts/build-policy-assets.ts` shells out to `opa build` for each Rego domain and writes `docs-site/public/opa/*.wasm`. If `opa` isn't on PATH the script logs a warning and skips, so contributors without OPA installed can still build the rest of the site. The Pages workflow `.github/workflows/docs-site.yml` never installs OPA, so every deploy after #262 silently shipped without any WASM files. `opa-eval.ts`'s `fetch('/defenseclaw/opa/manifest.json')` 404s and the wizard falls back to the "WASM modules aren't available" banner.
2. `quick-start/summary.tsx` labels the active rule count as `Rules enabled: 122 of 128`. The \`default\` preset legitimately enables 122 of 128 rules out of the box; the number is correct but the wording reads like the operator opted in to all of them.
3. `playground.tsx` wraps `LiveTestPane` in `<aside className="lg:sticky lg:top-20 lg:h-[calc(100vh-6rem)]">`. The inner `LiveTestPane` uses `flex h-full flex-col` with no internal overflow, so tall content (domain selector + scenario picker + Input JSON `<pre>` + verdict + reason + corpus rows) grows past the aside's fixed height and the bottom of the pane is clipped. `ScenarioJsonPreview` has only `overflow-x-auto` on its `<pre>` so a single tall canned scenario can blow out the rail by itself.

## Solution
Three independent fixes, no schema or policy-emission changes:

1. **OPA WASM deploys.** Three-layer defence so a missing-WASM deploy can't slip past CI again:
   - `docs-site.yml`: add `open-policy-agent/setup-opa@v2` step before `npm ci`.
   - `docs-site.yml`: set `CI_REQUIRE_OPA=1` on the `npm ci` step so `build-policy-assets.ts` postinstall fails the job loudly instead of soft-skipping.
   - `docs-site.yml`: post-build verify step fails the deploy if `out/opa/manifest.json` or any of the 5 expected `*.wasm` files (`admission`, `guardrail`, `firewall`, `audit`, `skill_actions`) are missing.
   - `build-policy-assets.ts`: reads `CI_REQUIRE_OPA=1` as env equivalent of `--require-opa` so the workflow can opt into hard-fail without changing the npm script.
2. **Rule pack baseline.** Rename row to \`Rule pack: X of Y active\` and add an adaptive subtitle:
   - 0 disabled: "Preset baseline — disable individual rules in the Playground → Rule Pack section."
   - N>0 disabled: "N rule(s) disabled vs. preset full pack."
3. **Playground scroll polish.** \`flex min-h-0 flex-col\` on the right-rail \`aside\` so the inner pane can honour overflow-y under the fixed-height sticky container. Split \`LiveTestPane\` into a pinned header (\`border-b\`) and an internally-scrolling body (\`flex-1 min-h-0 overflow-y-auto\`). Cap \`ScenarioJsonPreview\`'s \`<pre>\` at \`max-h-72 overflow-auto\` so tall canned scenarios scroll inside their own card.

Alternatives considered:
- *Soft-skip with a CI warning instead of hard-fail*: rejected — this is exactly how the bug got into prod the first time. CI must fail loudly when the deploy is missing user-facing assets.
- *Generic \`ls out/opa/*.wasm | grep -q .\` check*: rejected — would rubber-stamp a deploy that's missing one domain. The explicit per-domain list catches partial regressions.
- *\`overflow-y-auto\` on the outer aside directly*: rejected — works but leaves the "Live Test" title scrolling out of view. Pinning the header inside the pane is the better UX.

## Architecture Diagram

```
Before (broken Pages deploy):
 ┌──────────────────┐                ┌─────────────────────┐
 │ docs-site.yml    │ npm ci         │ build-policy-assets │
 │ (Pages workflow) │───────────────▶│ postinstall         │
 └──────────────────┘                │ ┌─────────────────┐ │
                                     │ │ which opa?      │ │
                                     │ │   missing       │ │
                                     │ │   warn + skip   │ │   no out/opa/*.wasm
                                     │ └─────────────────┘ │──────────────────┐
                                     └─────────────────────┘                  ▼
                                                                  ┌─────────────────────┐
                                                                  │ Pages deploy        │
                                                                  │ /defenseclaw/opa/   │
                                                                  │   manifest.json 404 │
                                                                  └─────────────────────┘

After:
 ┌──────────────────┐ setup-opa@v2   ┌─────────────────────┐
 │ docs-site.yml    │───────────────▶│ opa on PATH         │
 │ (Pages workflow) │                └─────────┬───────────┘
 └──────────────────┘ npm ci                   │
        │      CI_REQUIRE_OPA=1                ▼
        │                              ┌─────────────────────┐
        │                              │ build-policy-assets │ opa missing? throw
        │                              │ postinstall         │──── exit 1 ──▶ CI fails
        │                              └─────────┬───────────┘
        │                                        │
        │                                        ▼
        │                              out/opa/{manifest.json,*.wasm × 5}
        │ "Verify OPA assets" step               │
        └────────────────────────────────────────┘ all 6 files present?
                                                    │
                                                    ▼
                                         ┌─────────────────────┐
                                         │ Pages deploy        │
                                         │ /defenseclaw/opa/*  │ 200 OK
                                         └─────────────────────┘
```

## Flow Diagram

```
Operator        Pages (out/)      opa-eval.ts        opa-wasm
   │ open creator    │                  │                 │
   │────────────────▶│                  │                 │
   │                 │  GET             │                 │
   │                 │  /defenseclaw/   │                 │
   │                 │  opa/manifest.json                 │
   │                 │ ◀────────────────│                 │
   │                 │ 200 + manifest   │                 │
   │                 │─────────────────▶│                 │
   │                 │                  │ loadPolicy(.wasm)
   │                 │                  │────────────────▶│
   │                 │                  │ ◀───────────────│
   │                 │                  │ verdict+reason  │
   │ Live Test panel │                  │                 │
   │ ◀───────────────────────────────────│                 │

After-fix Playground sticky pane (issue #3):
   ┌──────────────────────────────────────────┐
   │ aside (lg:h-[calc(100vh-6rem)])         │
   │   flex min-h-0 flex-col                  │
   │   ┌──────────────────────────────────┐   │
   │   │ LiveTestPane                     │   │
   │   │   header  ← pinned, border-b     │   │
   │   ├──────────────────────────────────┤   │
   │   │   body                           │   │
   │   │   flex-1 min-h-0 overflow-y-auto │ ▲ │
   │   │   ┌────────────────────────────┐ │ │ │
   │   │   │ ScenarioJsonPreview <pre>  │ │ │ │  scrolls
   │   │   │  max-h-72 overflow-auto    │ │ │ │  inside
   │   │   └────────────────────────────┘ │ │ │  the rail
   │   │   verdict / reason / corpus      │ ▼ │
   │   └──────────────────────────────────┘   │
   └──────────────────────────────────────────┘
```

## What Changed (Where & How)

| File | Change Type | Summary |
|---|----|---|
| \`.github/workflows/docs-site.yml\` | modified | Add Setup OPA step before \`npm ci\`; set \`CI_REQUIRE_OPA=1\`; add post-build verify step that fails the deploy if any expected \`out/opa/\` file is missing |
| \`docs-site/scripts/build-policy-assets.ts\` | modified | Honour \`CI_REQUIRE_OPA=1\` env var as the env-driven equivalent of \`--require-opa\` |
| \`docs-site/components/policy-creator/quick-start/summary.tsx\` | modified | Rename "Rules enabled" → "Rule pack"; add adaptive subtitle so 0-vs->0 customizations read differently; \`Row\` now supports an optional \`hint\` prop |
| \`docs-site/components/policy-creator/playground.tsx\` | modified | Add \`flex min-h-0 flex-col\` to right-rail \`aside\` so the inner pane can scroll inside the fixed-height sticky container |
| \`docs-site/components/policy-creator/sections/live-test.tsx\` | modified | Split into pinned header (\`border-b\`) + \`flex-1 min-h-0 overflow-y-auto\` body |
| \`docs-site/components/policy-creator/ui/scenario-picker.tsx\` | modified | Cap \`<pre>\` at \`max-h-72 overflow-auto\` so tall canned scenarios don't blow out the rail |

## Open Issues / Follow-ups
- Pages cache may serve the stale 404 \`manifest.json\` briefly after merge — first deploy after this lands re-populates \`out/opa/\` and Pages refreshes within ~1 cache TTL.
- The verify step hard-codes the 5 WASM filenames; if \`REGO_DOMAINS\` in \`build-policy-assets.ts\` grows we need to update the verify step too. Acceptable trade-off vs. a generic glob because we want the check to fail loudly on a missing domain rather than rubber-stamp \`[ -n $(ls out/opa/*.wasm) ]\`.

## Test Plan
- \`npx tsc --noEmit\` → clean.
- \`npm run test:policy-creator\` → 53/53 pass.
- \`npm run build:policy-assets\` → \`presets=3 recipes=133 scenarios=14 compiled=5 skipped=0\`; \`public/opa/\` populated with manifest.json + 5 wasm files.
- Manual: \`compileWasm({ skipMissingOpa: false })\` in \`build-policy-assets.ts\` throws on missing \`opa\` (line 741); \`CI_REQUIRE_OPA=1\` flips \`main()\` to that branch.
- Pre-merge live probe: \`curl -sI https://cisco-ai-defense.github.io/defenseclaw/opa/manifest.json\` → HTTP/2 404.
- Post-merge expectation: same probe returns HTTP/2 200 with \`application/json\` body matching \`{ domains: [...] }\`, and the wizard's Live Test pane evaluates verdicts in-browser without the "WASM modules aren't available" banner.