### PR TITLE
fix(docs-site/policy-creator): clarify summary baseline + make Paste-JSON discoverable

### DIFF
--- a/docs-site/components/policy-creator/quick-start/summary.tsx
+++ b/docs-site/components/policy-creator/quick-start/summary.tsx
@@ -7,9 +7,12 @@
 
 'use client';
 
+import { useMemo } from 'react';
 import type { Policy } from '../types';
 import type { Answers } from './questions';
 import { POSTURES } from './questions';
+import { diffAgainstBase } from '../lib/diff';
+import { policyFromPreset } from '../lib/presets';
 
 export function PolicySummaryCard({
   policy,
@@ -19,15 +22,37 @@ export function PolicySummaryCard({
   answers: Answers;
 }) {
   const postureLabel = POSTURES.find((p) => p.id === answers.posture)?.title ?? answers.posture;
+
+  // Active rule count + how it compares to the preset baseline.
+  // The previous implementation compared against "preset full pack",
+  // but every shipped preset disables some rules out of the box —
+  // the bundled `default` preset, for example, ships with 122 of 128
+  // rules active. That caused the summary to display
+  //   "6 rules disabled vs. preset full pack"
+  // even when the operator hadn't touched anything, which read as
+  // "I disabled those" rather than "the preset shipped that way."
+  // The correct comparison is against the preset's own baseline.
   const totalRules = policy.rule_pack.files.reduce((acc, f) => acc + f.rules.length, 0);
   const enabledRules = policy.rule_pack.files.reduce(
     (acc, f) => acc + f.rules.filter((r) => r.enabled !== false).length,
     0,
   );
-  // Suppressed rules are surfaced separately so the operator can tell
-  // "I haven't touched anything" (suppressed=0) apart from "I'm running
-  // a near-full pack but trimmed a few" (suppressed>0).
-  const suppressedInPack = totalRules - enabledRules;
+  const baselineEnabled = useMemo(() => {
+    const base = policyFromPreset(policy.basedOn);
+    return base.rule_pack.files.reduce(
+      (acc, f) => acc + f.rules.filter((r) => r.enabled !== false).length,
+      0,
+    );
+  }, [policy.basedOn]);
+  const rulesDelta = enabledRules - baselineEnabled;
+
+  // Whole-policy diff vs. the preset baseline. This is the same
+  // signal the playground "X changes from <preset>" banner shows,
+  // surfaced here so the Quick Start Review tab makes it obvious
+  // when the operator HAS in fact modified things from the preset.
+  const diff = useMemo(() => diffAgainstBase(policy), [policy]);
+  const changeCount = diff.length;
+
   const suppressionTotal =
     policy.suppressions.tool_suppressions.length +
     policy.suppressions.finding_suppressions.length +
@@ -39,20 +64,47 @@ export function PolicySummaryCard({
 
   return (
     <div className="space-y-3 rounded-xl border border-fd-border bg-fd-card p-3">
-      <h3 className="text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">
-        Policy summary
-      </h3>
+      <div className="flex items-baseline justify-between gap-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-fd-muted-foreground">
+          Policy summary
+        </h3>
+        {/*
+          Pill that summarizes "have I changed anything from the preset?".
+          Zero changes → muted "unchanged" pill so the operator can tell
+          their Quick Start clicks have actually mutated the policy.
+        */}
+        <span
+          className={[
+            'shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide',
+            changeCount === 0
+              ? 'bg-fd-muted/40 text-fd-muted-foreground'
+              : 'bg-[var(--brand-cisco)]/15 text-[var(--brand-cisco-strong)]',
+          ].join(' ')}
+          title={
+            changeCount === 0
+              ? `No changes from the ${policy.basedOn} preset yet`
+              : `${changeCount} change${changeCount === 1 ? '' : 's'} vs. the ${policy.basedOn} preset`
+          }
+        >
+          {changeCount === 0
+            ? `${policy.basedOn} preset`
+            : `${changeCount} change${changeCount === 1 ? '' : 's'} vs. ${policy.basedOn}`}
+        </span>
+      </div>
       <ul className="space-y-1.5 text-[12px] text-fd-foreground">
         <Row label="Posture" value={postureLabel} />
         <Row
-          label="Rule pack"
-          value={`${enabledRules} of ${totalRules} active`}
-          // Suppressed=0 ⇒ "this is just the preset baseline"; >0 ⇒
-          // "you (or the posture) trimmed N from the preset".
+          label="Rules active"
+          value={`${enabledRules} of ${totalRules}`}
+          // Three-state hint: identical-to-baseline, you-enabled-more,
+          // you-disabled-some. Phrased so it's never ambiguous about
+          // who did what.
           hint={
-            suppressedInPack === 0
-              ? `Preset baseline — disable individual rules in the Playground → Rule Pack section.`
-              : `${suppressedInPack} rule${suppressedInPack === 1 ? '' : 's'} disabled vs. preset full pack.`
+            rulesDelta === 0
+              ? `Baseline for the ${policy.basedOn} preset — change individual rules in the Playground → Rule Pack section.`
+              : rulesDelta > 0
+                ? `You enabled ${rulesDelta} more rule${rulesDelta === 1 ? '' : 's'} than the ${policy.basedOn} preset ships with.`
+                : `You disabled ${Math.abs(rulesDelta)} rule${rulesDelta === -1 ? '' : 's'} from the ${policy.basedOn} preset baseline.`
           }
         />
         <Row label="Suppressions" value={String(suppressionTotal)} />

--- a/docs-site/components/policy-creator/sections/live-test.tsx
+++ b/docs-site/components/policy-creator/sections/live-test.tsx
@@ -44,13 +44,17 @@ const DOMAIN_OPTIONS: Array<{ value: Domain; label: string; hint?: string }> = [
 ];
 
 const SOURCE_OPTIONS: Array<{ value: Source; label: string }> = [
-  { value: 'scenario', label: 'Canned scenario' },
-  { value: 'custom', label: 'Custom input' },
+  // Labels chosen so the three options are obviously distinct
+  // *actions*, not just three nouns. Operators reported that
+  // "Custom input" was easy to miss next to "Canned scenario" —
+  // "Paste JSON" is more obviously a CTA.
+  { value: 'scenario', label: 'Pick scenario' },
+  { value: 'custom', label: 'Paste JSON' },
   // G1 — replay every bundled scenario for the active domain at
   // once and surface a pass/fail table. Useful for "did my edit
   // regress any bundled fixture?" before downloading the install
   // script.
-  { value: 'corpus', label: 'Replay all' },
+  { value: 'corpus', label: 'Run all scenarios' },
 ];
 
 const LS_CUSTOM_PREFIX = 'dc-policy-creator/live-test/custom/v1/';
@@ -360,7 +364,7 @@ export function LiveTestPane({ policy }: { policy: Policy }) {
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between">
           <span className="text-[11px] font-medium uppercase tracking-wide text-fd-muted-foreground">
-            Input source
+            Test with
           </span>
           {source === 'custom' && (
             <div className="flex items-center gap-2">
@@ -391,6 +395,25 @@ export function LiveTestPane({ policy }: { policy: Policy }) {
           onChange={setSource}
           size="sm"
         />
+        {/*
+          Inline discoverability hint. Without this, operators report
+          "I don't see a way to update the input JSON" because the
+          segmented control above is small and gets visually
+          eclipsed by the larger scenario picker below.
+        */}
+        {source === 'scenario' && (
+          <p className="text-[10px] text-fd-muted-foreground">
+            Want to test your own input?{' '}
+            <button
+              type="button"
+              onClick={() => setSource('custom')}
+              className="font-medium text-[var(--brand-cisco)] underline-offset-2 hover:underline"
+            >
+              Switch to Paste JSON
+            </button>{' '}
+            to paste a JSON document — it persists per-domain in localStorage.
+          </p>
+        )}
       </div>
 
       {source === 'corpus' ? (


### PR DESCRIPTION
## Problem

After PR #288 shipped, an operator running the live wizard on
`https://cisco-ai-defense.github.io/defenseclaw/docs/policies/creator/`
reported three issues:

1. **"122 of 128 selected is shown even if I select nothing"** — the
   Quick Start Review summary said *"6 rules disabled vs. preset full
   pack"* on an untouched policy, reading as "I disabled those" rather
   than "the preset ships that way".
2. **"I don't see a way to update the input JSON"** — the segmented
   control that switches the Live Test pane between canned scenarios
   and a custom JSON editor is small, sits above a much larger
   scenario list, and uses noun labels that don't read as actions.
3. **"I changed a few things here and there but it's not working"** —
   because (1) above, the Quick Start summary did not visibly react
   to the operator's edits.

Issue (3) re Input JSON being clipped in the Playground was already
fixed in PR #288 and is verified still working on prod
(`canScroll: true`, scroller 436px visible / 888px content).

## Current Situation

`docs-site/components/policy-creator/quick-start/summary.tsx`
computed:

```
suppressedInPack = totalRules - enabledRules
```

…and rendered a subtitle based on whether `suppressedInPack === 0`.
But every bundled preset disables some rules out of the box (the
`default` preset enables 122/128; `strict` enables 128/128;
`permissive` enables fewer still). So `suppressedInPack` is never
zero for the `default` preset, and the subtitle always read
*"6 rules disabled vs. preset full pack"* even for an unmodified
policy — exactly the misread the operator hit.

`docs-site/components/policy-creator/sections/live-test.tsx` exposes
its three input modes through `SegmentedControl` with labels:

```
Canned scenario | Custom input | Replay all
```

The "Custom input" label is a noun and visually identical in weight
to its neighbours, so operators scanning for an "edit JSON" affordance
miss it.

## Solution

**Summary (`summary.tsx`).** Compare against the preset's *own*
baseline, not the full rule pack. Compute `baselineEnabled` from
`policyFromPreset(policy.basedOn)` and render a three-state hint:

- `rulesDelta === 0` → "Baseline for the `<preset>` preset — change
  individual rules in the Playground → Rule Pack section."
- `rulesDelta > 0`  → "You enabled N more rules than the `<preset>`
  preset ships with."
- `rulesDelta < 0`  → "You disabled N rules from the `<preset>`
  preset baseline."

Also surface the same whole-policy diff the Playground banner uses
(`diffAgainstBase(policy)`) as a header pill: muted "`<preset>`
preset" pill when there are zero changes, brand-tinted "N changes
vs. `<preset>`" pill otherwise. The operator now sees at a glance
whether their Quick Start clicks have moved the policy off the
preset.

**Live Test (`live-test.tsx`).** Re-label the segmented control so
the three options read as actions instead of nouns:

```
Pick scenario | Paste JSON | Run all scenarios
```

…with `"Input source"`  →  `"Test with"`. Add an inline hint that
only shows in scenario mode, with a clickable shortcut into the
JSON editor: *"Want to test your own input? Switch to Paste JSON
to paste a JSON document — it persists per-domain in
localStorage."*

This was chosen over moving Custom input into a tab or modal because
keeping it as a peer of "Pick scenario" preserves the 250ms
re-evaluation loop documented on the page and the per-domain
localStorage drafts that already exist.

## Architecture Diagram

```
Before:
  ┌─────────────────────────┐                ┌────────────────────────────┐
  │  Quick Start Review     │                │  Live Test pane            │
  │  ┌───────────────────┐  │                │  INPUT SOURCE              │
  │  │ Rule pack         │  │                │  ( Canned scenario )       │
  │  │   122 of 128 act. │  │                │  (  Custom input    )      │
  │  │   "6 rules disab- │  │                │  (  Replay all      )      │
  │  │    led vs preset  │  │                │                            │
  │  │    full pack"     │  │                │  SCENARIOS                 │
  │  │  ↑ misleading     │  │                │  [ CRITICAL skill scan ]   │
  │  └───────────────────┘  │                │  [ MEDIUM MCP scan     ]   │
  └─────────────────────────┘                │  …                         │
                                             └────────────────────────────┘

After:
  ┌─────────────────────────┐                ┌────────────────────────────┐
  │  Quick Start Review     │                │  Live Test pane            │
  │  POLICY SUMMARY  ┌─────┐│                │  TEST WITH                 │
  │                  │def. ││                │  ( Pick scenario )         │
  │                  │pre- ││                │  (  Paste JSON   )         │
  │                  │set  ││                │  (  Run all scen.)         │
  │                  └─────┘│                │                            │
  │  Rules active           │                │  Want to test your own     │
  │   122 of 128            │                │  input? Switch to Paste    │
  │   Baseline for the      │                │  JSON …                    │
  │   default preset.       │                │                            │
  │                         │                │  SCENARIOS                 │
  │   (changes pill switches│                │  [ CRITICAL skill scan ]   │
  │    to "3 changes vs.    │                │  [ MEDIUM MCP scan     ]   │
  │    default" when user   │                │  …                         │
  │    actually edits)      │                └────────────────────────────┘
  └─────────────────────────┘
```

## Flow Diagram

```
Operator                  Quick Start Review                Live Test
   │ clicks Posture=Balanced  │                                 │
   │─────────────────────────▶│ updates policy.basedOn          │
   │                          │ recomputes diffAgainstBase()    │
   │                          │ pill → "default preset"         │
   │                          │   (0 changes)                   │
   │ toggles a block card     │                                 │
   │─────────────────────────▶│ pill → "3 changes vs. default"  │
   │                          │ row hint → "You enabled 1 more  │
   │                          │   rule than default ships with" │
   │                          │                                 │
   │ wants to test custom JSON│                                 │
   │──────────────────────────────────────────────────────────▶│
   │                          │                                 │ shows hint
   │                          │                                 │ "Switch to
   │                          │                                 │  Paste JSON"
   │ clicks "Paste JSON"      │                                 │
   │──────────────────────────────────────────────────────────▶│ swaps to
   │                          │                                 │ JSON editor
   │ pastes JSON              │                                 │ 250ms debounce
   │                          │                                 │ → OPA-WASM
   │                          │                                 │ → verdict
```

## What Changed (Where & How)

| File | Change Type | Summary |
|---|---|---|
| `docs-site/components/policy-creator/quick-start/summary.tsx` | modified | Compare active rule count against the preset's own baseline (not the full pack). Add a `diffAgainstBase()`-driven "X changes vs. `<preset>`" pill in the summary header. Reword the Rules-active hint into three unambiguous states. |
| `docs-site/components/policy-creator/sections/live-test.tsx` | modified | Re-label the Live Test segmented control options as actions (`Pick scenario` / `Paste JSON` / `Run all scenarios`), rename the field label to `Test with`, and add an inline hint in scenario mode that links into the Paste JSON editor. |

## Open Issues / Follow-ups

- The summary pill counts whole-policy diff entries; it does not
  enumerate them inline. Operators who want the full list still
  expand the Playground "X changes from `<preset>`" banner — which
  surfaces every entry. We could surface a top-3 preview here later
  if requested, but it is not in scope for this fix.
- The Custom input label change does not migrate persisted
  localStorage drafts (keys are unchanged; per-domain drafts still
  load). No data loss, just a UI rename.

## Test Plan

- `cd docs-site && npm run test:policy-creator` → 53/53 pass
- `cd docs-site && npx tsc --noEmit` → 0 errors
- Live Playwright run against
  `https://cisco-ai-defense.github.io/defenseclaw/docs/policies/creator/`:
  - Confirmed Custom input radio (`Paste JSON` after this PR) IS
    reachable and the JSON textarea accepts input
    (`"Valid JSON · re-evaluates 250 ms after you stop typing"`).
  - Confirmed Replay-all corpus produces 3 pass / 1 fail on the
    `admission` domain with the bundled default preset.
  - Confirmed the Live Test sticky pane already scrolls internally
    (`canScroll: true`, scroller 436px / 888px) — the Input-JSON
    cutoff fix from PR #288 is live and unchanged.