### PR TITLE
fix(docs-site/policy-creator): rename Observe→Permissive posture; rebrand AID lane as "Optional · Enterprise" and link to product page

### DIFF
--- a/docs-site/components/policy-creator/playground.tsx
+++ b/docs-site/components/policy-creator/playground.tsx
@@ -236,7 +236,12 @@ const SECTION_DEFS: SectionDef[] = [
   },
   {
     id: 'cisco-ai-defense',
-    title: 'Cisco AI Defense (optional lane)',
+    // Wording: "Optional · Enterprise" makes it clear this lane is
+    // (a) not required for DefenseClaw to function and (b) backed by
+    // the enterprise Cisco AI Defense product. The body of the
+    // section links to https://www.cisco.com/site/us/en/products/security/ai-defense/
+    // so operators can learn more without leaving the wizard.
+    title: 'Cisco AI Defense (Optional · Enterprise)',
     subtitle: (p) => {
       const aid = p.cisco_ai_defense;
       if (!aid.enabled && !aid.api_key_env && !aid.endpoint) return 'off';

--- a/docs-site/components/policy-creator/playground/command-palette.tsx
+++ b/docs-site/components/policy-creator/playground/command-palette.tsx
@@ -95,7 +95,7 @@ export const INDEX: IndexEntry[] = [
   { sectionId: 'correlator', group: 'Correlator', label: 'Fingerprint chain', keywords: ['fingerprint', 'exfil', 'same value across turns'] },
 
   // cisco AI Defense
-  { sectionId: 'cisco-ai-defense', group: 'Cisco AI Defense', label: 'Cisco AI Defense lane', keywords: ['cisco', 'ai defense', 'aid', 'second opinion', 'remote scanner'] },
+  { sectionId: 'cisco-ai-defense', group: 'Cisco AI Defense', label: 'Cisco AI Defense (Optional · Enterprise)', keywords: ['cisco', 'ai defense', 'aid', 'second opinion', 'remote scanner', 'enterprise', 'optional'] },
   { sectionId: 'cisco-ai-defense', group: 'Cisco AI Defense', label: 'AID api key env var', keywords: ['api_key_env', 'CISCO_AI_DEFENSE_API_KEY', 'token'] },
   { sectionId: 'cisco-ai-defense', group: 'Cisco AI Defense', label: 'AID scan_hook_surface', keywords: ['hook surface', 'pretooluse', 'posttooluse', 'tool call coverage'] },
 

--- a/docs-site/components/policy-creator/quick-start/questions.ts
+++ b/docs-site/components/policy-creator/quick-start/questions.ts
@@ -16,9 +16,13 @@ import type { SeverityUpper } from '../types';
 export const POSTURES = [
   {
     id: 'permissive',
-    title: 'Observe',
+    // Renamed from "Observe" — the underlying `permissive` preset still
+    // blocks CRITICAL findings at install time and quarantines CRITICAL
+    // files, so "Observe" (which implies *never* block) was misleading.
+    // "Permissive" matches both the preset ID and the actual behaviour.
+    title: 'Permissive',
     description:
-      'Log everything, block almost nothing. Best for the first week of a pilot or a SOC team that wants visibility without operational risk.',
+      'Log everything; only CRITICAL findings block installs. Best for the first week of a pilot or a SOC team that wants visibility without operational risk.',
   },
   {
     id: 'default',

--- a/docs-site/components/policy-creator/sections/cisco-ai-defense.tsx
+++ b/docs-site/components/policy-creator/sections/cisco-ai-defense.tsx
@@ -41,9 +41,17 @@ export function CiscoAIDefenseSection({
     <div className="space-y-3">
       <div className="rounded-md border border-fd-border bg-fd-card p-3 text-[12px] leading-5 text-fd-muted-foreground">
         <p>
-          Optional second-opinion lane. When the gateway resolves a non-empty
+          Optional · Enterprise second-opinion lane. When the gateway resolves a non-empty
           <code className="mx-1">api_key_env</code>, it forwards prompts and (if{' '}
-          <strong>scan_hook_surface</strong> is on) hook-surface tool calls to Cisco AI Defense
+          <strong>scan_hook_surface</strong> is on) hook-surface tool calls to{' '}
+          <a
+            href="https://www.cisco.com/site/us/en/products/security/ai-defense/index.html"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-[var(--brand-cisco)] underline-offset-2 hover:underline"
+          >
+            Cisco AI Defense ↗
+          </a>{' '}
           and merges the verdict using strictest-wins semantics. The wizard never accepts a
           literal API key; only the env var name is written to YAML.
         </p>

--- a/docs-site/content/docs/connectors/copilot.mdx
+++ b/docs-site/content/docs/connectors/copilot.mdx
@@ -77,7 +77,7 @@ defenseclaw setup guardrail \
   --restart
 ```
 
-The alias keeps the connector pinned and writes the workspace hook; the follow-up `setup guardrail` swaps in the strict rule pack, runs both local + Cisco AI Defense scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
+The alias keeps the connector pinned and writes the workspace hook; the follow-up `setup guardrail` swaps in the strict rule pack, runs both local + [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
 
 </Tab>
 

--- a/docs-site/content/docs/connectors/cursor.mdx
+++ b/docs-site/content/docs/connectors/cursor.mdx
@@ -70,7 +70,7 @@ defenseclaw setup guardrail \
   --restart
 ```
 
-The alias keeps the connector pinned; the follow-up `setup guardrail` swaps in the strict rule pack, runs both local + Cisco AI Defense scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
+The alias keeps the connector pinned; the follow-up `setup guardrail` swaps in the strict rule pack, runs both local + [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
 
 </Tab>
 

--- a/docs-site/content/docs/connectors/geminicli.mdx
+++ b/docs-site/content/docs/connectors/geminicli.mdx
@@ -70,7 +70,7 @@ defenseclaw setup guardrail \
   --restart
 ```
 
-The alias keeps the connector pinned; the follow-up `setup guardrail` swaps in the strict rule pack, runs both local + Cisco AI Defense scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
+The alias keeps the connector pinned; the follow-up `setup guardrail` swaps in the strict rule pack, runs both local + [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
 
 </Tab>
 

--- a/docs-site/content/docs/connectors/hermes.mdx
+++ b/docs-site/content/docs/connectors/hermes.mdx
@@ -69,7 +69,7 @@ defenseclaw setup guardrail \
   --restart
 ```
 
-The alias keeps the connector pinned; the follow-up `setup guardrail` swaps in the strict rule pack, runs both local + Cisco AI Defense scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
+The alias keeps the connector pinned; the follow-up `setup guardrail` swaps in the strict rule pack, runs both local + [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
 
 </Tab>
 

--- a/docs-site/content/docs/connectors/windsurf.mdx
+++ b/docs-site/content/docs/connectors/windsurf.mdx
@@ -69,7 +69,7 @@ defenseclaw setup guardrail \
   --restart
 ```
 
-The alias keeps the connector pinned; the follow-up `setup guardrail` swaps in the strict rule pack, runs both local + Cisco AI Defense scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
+The alias keeps the connector pinned; the follow-up `setup guardrail` swaps in the strict rule pack, runs both local + [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
 
 </Tab>
 

--- a/docs-site/content/docs/defaults.mdx
+++ b/docs-site/content/docs/defaults.mdx
@@ -36,7 +36,7 @@ defenseclaw setup guardrail --rule-pack default                    # Guardrail l
 
 ## OPA admission policy — what each profile ships
 
-The OPA policy file (`policies/<name>.yaml`) drives admission decisions: what happens to a finding by severity, whether the allow-list lets first-party assets bypass scanning, and what threshold a Cisco AI Defense verdict has to clear before it blocks.
+The OPA policy file (`policies/<name>.yaml`) drives admission decisions: what happens to a finding by severity, whether the allow-list lets first-party assets bypass scanning, and what threshold a [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) verdict has to clear before it blocks.
 
 | Knob | `permissive` | `default` | `strict` |
 | --- | --- | --- | --- |

--- a/docs-site/content/docs/policies/creator.mdx
+++ b/docs-site/content/docs/policies/creator.mdx
@@ -68,9 +68,9 @@ without losing your in-flight Playground edits.
 
 <Step>
 
-**Step 1 — Posture.** Picks the base preset (Observe / Balanced / Strict). The Balanced default is
-the sensible production starting point; Observe is for shadow-mode evaluation; Strict is for
-regulated workloads where false-positive cost is acceptable.
+**Step 1 — Posture.** Picks the base preset (Permissive / Balanced / Strict). The Balanced default is
+the sensible production starting point; Permissive is for shadow-mode evaluation (only CRITICAL
+findings block installs); Strict is for regulated workloads where false-positive cost is acceptable.
 
 </Step>
 

--- a/docs-site/content/docs/policies/index.mdx
+++ b/docs-site/content/docs/policies/index.mdx
@@ -128,7 +128,7 @@ Every decision carries the matching `reasons[]` so the audit event can name the 
 The guardrail rule pack is the *content* the gateway evaluates against — the actual regex patterns, judge prompts, and category taxonomies. Three packs ship out of the box:
 
 <Cards>
-  <Card title="permissive" href="/docs/defaults#permissive" description="Observe-only baseline. Patterns log but don't block. Good for first-week pilots." />
+  <Card title="permissive" href="/docs/defaults#permissive" description="Permissive baseline. Patterns log; only CRITICAL findings block installs. Good for first-week pilots." />
   <Card title="default" href="/docs/defaults#default" description="Sensible production defaults. Blocks high-severity secrets, prompts for medium." />
   <Card title="strict" href="/docs/defaults#strict" description="Belt-and-suspenders. Blocks medium+ on most categories. Choose this for regulated workloads." />
 </Cards>

--- a/docs-site/content/docs/reference/env-vars.mdx
+++ b/docs-site/content/docs/reference/env-vars.mdx
@@ -25,7 +25,7 @@ Most operators want the persistent path: `defenseclaw keys set <ENV>` writes to 
 | --- | --- | --- | --- |
 | `DEFENSECLAW_LLM_KEY` | unset | The single canonical LLM key. Used by the gateway upstream, judge, and scanners. | `cli/defenseclaw/credentials.py` |
 | `OPENCLAW_GATEWAY_TOKEN` | auto-detected | Auth token the gateway uses to talk to OpenClaw. Auto-detected from `~/.openclaw/openclaw.json` when present. | `cli/defenseclaw/credentials.py` |
-| `CISCO_AI_DEFENSE_API_KEY` | unset | API key for the Cisco AI Defense remote scanner (`scanner_mode=remote\|both`). | `cli/defenseclaw/credentials.py` |
+| `CISCO_AI_DEFENSE_API_KEY` | unset | API key for the [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) remote scanner (`scanner_mode=remote\|both`). | `cli/defenseclaw/credentials.py` |
 | `JUDGE_API_KEY` | unset | Custom LLM judge key — only consulted when `guardrail.judge.llm.api_key_env` overrides the default. | `cli/defenseclaw/credentials.py` |
 | `VIRUSTOTAL_API_KEY` | unset | VirusTotal API key for the skill scanner (`use_virustotal=true`). | `cli/defenseclaw/credentials.py` |
 | `SPLUNK_ACCESS_TOKEN` | unset | Splunk HEC token for audit forwarding. | `cli/defenseclaw/credentials.py` |

--- a/docs-site/content/docs/reference/keys.mdx
+++ b/docs-site/content/docs/reference/keys.mdx
@@ -78,7 +78,7 @@ Every credential the gateway and CLI know about is registered in `cli/defensecla
 | `DEFENSECLAW_LLM_KEY` | `llm.default` | Any LLM-using component (guardrail upstream, judge, skill / MCP scanners) is enabled and falls back to the default key. | The single canonical key. Provider-specific keys (`OPENAI_API_KEY`, etc.) are derived from this + the model prefix at routing time. |
 | `OPENCLAW_GATEWAY_TOKEN` | `gateway` | Always (the gateway needs an auth token to talk to OpenClaw). | Auto-detected from `~/.openclaw/openclaw.json` when the file exists. Marked REQUIRED but auto-detected. |
 | `JUDGE_API_KEY` | `guardrail.judge` | The judge is enabled and `guardrail.judge.llm.api_key_env` overrides the default. | Only tracked when there's a custom override. Otherwise the judge falls through to `DEFENSECLAW_LLM_KEY`. |
-| `CISCO_AI_DEFENSE_API_KEY` | `guardrail.remote` | `guardrail.scanner_mode` is `remote` or `both`. | API key for the Cisco AI Defense remote scanner. |
+| `CISCO_AI_DEFENSE_API_KEY` | `guardrail.remote` | `guardrail.scanner_mode` is `remote` or `both`. | API key for the [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) remote scanner. |
 | `VIRUSTOTAL_API_KEY` | `skill-scanner.virustotal` | `scanners.skill_scanner.use_virustotal=true`. | Required when the skill scanner is wired up to ask VirusTotal. |
 | `SPLUNK_ACCESS_TOKEN` | `observability.splunk` | A Splunk audit sink is enabled. | The HEC token. |
 | `DEFENSECLAW_SKILL_SCANNER_LLM_KEY` | `skill-scanner.llm` | The skill scanner uses LLM and has a custom `llm.api_key_env` override. | Only tracked when there's a custom override; otherwise falls through to `DEFENSECLAW_LLM_KEY`. |

--- a/docs-site/content/docs/setup/mcp-scanner.mdx
+++ b/docs-site/content/docs/setup/mcp-scanner.mdx
@@ -172,7 +172,7 @@ Behavioural intent analysis depends on the LLM judge being able to reason about 
 defenseclaw keys set DEFENSECLAW_LLM_KEY
 ```
 
-DefenseClaw injects it into the scanner subprocess via `inject_llm_env`, alongside any Cisco AI Defense API key for content classification. See [Setup → Unified LLM key](/docs/setup/unified-llm-key) for the resolution order and Bifrost provider catalog.
+DefenseClaw injects it into the scanner subprocess via `inject_llm_env`, alongside any [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) API key for content classification. See [Setup → Unified LLM key](/docs/setup/unified-llm-key) for the resolution order and Bifrost provider catalog.
 
 <Callout type="info">
 The MCP scanner runs each stdio server inside a subprocess sandbox with a wall-clock timeout. Servers that hang are killed; servers that try to spawn networked side processes are flagged as findings, not just terminated silently.


### PR DESCRIPTION
## Problem

Two operator-reported wording issues on the live policy creator
(<https://cisco-ai-defense.github.io/defenseclaw/docs/policies/creator/>):

1. The Quick Start Step 1 card titled **"Observe"** says *"block
   almost nothing"*. Operators asked why "almost" — Observe normally
   implies *never* block. In reality the underlying \`permissive\`
   preset still blocks CRITICAL findings at install time, so the
   label and the description were both hedging.

2. The Playground section header says **"Cisco AI Defense (optional
   lane)"**. The word "lane" is internal jargon, and the section
   provides no link to learn more about the product the section is
   wiring up.

## Current Situation

\`policies/permissive.yaml\` ships with:

```yaml
skill_actions:
  critical:
    file: quarantine
    runtime: disable
    install: block
guardrail:
  block_threshold: 4   # = CRITICAL
```

…so even a fresh \`permissive\` policy blocks CRITICAL installs,
quarantines CRITICAL files, and disables CRITICAL skills at runtime.
The "Observe" label on the wizard card therefore overpromised, and
the description had to soften with "almost".

The \`Cisco AI Defense\` section header used internal product jargon
("optional lane") and the editor body referenced the product name
without linking out, leaving operators without a clear path to the
product page when they're trying to figure out whether to enable
the integration.

## Solution

**1. Rename "Observe" → "Permissive".** The underlying preset ID
is already \`permissive\`; the new card title matches both the preset
ID and the actual behaviour. The description is rewritten to be
specific instead of hedging:

> Log everything; only CRITICAL findings block installs. Best for
> the first week of a pilot or a SOC team that wants visibility
> without operational risk.

No behaviour change — the preset file, policy YAML schema, share
links, and policy-creator tests are unchanged.

**2. Rebrand AID lane wording + link to the product page.** The
playground section header reads
\`Cisco AI Defense (Optional · Enterprise)\`; the help blurb inside
the section editor now hyperlinks the product name to
<https://www.cisco.com/site/us/en/products/security/ai-defense/index.html>;
the command-palette entry is updated to match. User-facing MDX
docs (defaults, policies creator/index, reference keys/env-vars,
MCP scanner setup, and the 5 connector pages that mention AID)
link the first mention per page to the same URL so a reader can
reach the product page in one click from anywhere they encounter
AID in the docs.

Internal identifiers (\`cisco_ai_defense\` config keys,
\`CISCO_AI_DEFENSE_API_KEY\` env var, Go field names, audit-event
strings) are intentionally not renamed — that would churn the
policy YAML schema and the gateway config for what is otherwise a
purely cosmetic UI/docs change.

The gateway-mode card titled "Observe" in
\`docs/get-started/what-is-defenseclaw.mdx\` refers to the
Observe / Action / HITL operating-mode taxonomy
(\`cli/defenseclaw/commands/cmd_setup_mode.py\`), not the policy
preset, and that mode really does block nothing — left unchanged.

## Architecture Diagram

```
Wizard Quick Start (Step 1: Posture)
Before                                      After
┌────────────────────────────┐              ┌────────────────────────────┐
│  Observe                   │              │  Permissive                │
│  Log everything, block     │              │  Log everything; only      │
│  almost nothing. …         │              │  CRITICAL findings block   │
│                            │              │  installs. …               │
└────────────────────────────┘              └────────────────────────────┘
           │   ↓ preset ID                            │   ↓ preset ID
           │      "permissive"                        │      "permissive"   ← unchanged
           ▼                                          ▼
   policies/permissive.yaml                  policies/permissive.yaml      ← unchanged
```

```
Playground section header
Before                                      After
┌────────────────────────────┐              ┌────────────────────────────────┐
│  Cisco AI Defense          │              │  Cisco AI Defense              │
│  (optional lane)           │              │  (Optional · Enterprise)       │
└────────────────────────────┘              └────────────────────────────────┘
           ▼ body                                  ▼ body
   "…forwards prompts to                    "…forwards prompts to
    Cisco AI Defense …"                      [Cisco AI Defense ↗](cisco.com/…/ai-defense/)…"
```

## Flow Diagram

```
Operator             Quick Start Step 1          Playground (AID section)
   │ opens wizard          │                              │
   │──────────────────────▶│ renders 3 posture cards      │
   │                       │   • Permissive               │
   │                       │   • Balanced                 │
   │                       │   • Strict                   │
   │ picks Permissive      │                              │
   │──────────────────────▶│ basedOn = "permissive"       │
   │                       │ → same preset as before      │
   │ opens AID section     │                              │
   │─────────────────────────────────────────────────────▶│ header: "Cisco AI Defense
   │                       │                              │   (Optional · Enterprise)"
   │                       │                              │ body: link to cisco.com/…/ai-defense/
```

## What Changed (Where & How)

| File | Change Type | Summary |
|---|---|---|
| \`docs-site/components/policy-creator/quick-start/questions.ts\` | modified | Rename posture card "Observe" → "Permissive"; rewrite description to be specific ("only CRITICAL findings block installs"). Preset ID \`permissive\` unchanged. |
| \`docs-site/components/policy-creator/playground.tsx\` | modified | AID section title "Cisco AI Defense (optional lane)" → "Cisco AI Defense (Optional · Enterprise)". |
| \`docs-site/components/policy-creator/sections/cisco-ai-defense.tsx\` | modified | Rewrite the section's help blurb to drop "lane" jargon and hyperlink "Cisco AI Defense ↗" to cisco.com/site/us/en/products/security/ai-defense/index.html. |
| \`docs-site/components/policy-creator/playground/command-palette.tsx\` | modified | ⌘K palette label "Cisco AI Defense lane" → "Cisco AI Defense (Optional · Enterprise)" and add "enterprise" / "optional" keywords for fuzzy search. |
| \`docs-site/content/docs/policies/creator.mdx\` | docs | "Observe / Balanced / Strict" → "Permissive / Balanced / Strict" in the Step 1 explainer. |
| \`docs-site/content/docs/policies/index.mdx\` | docs | "Observe-only baseline" → "Permissive baseline. Patterns log; only CRITICAL findings block installs." |
| \`docs-site/content/docs/defaults.mdx\` | docs | Link first "Cisco AI Defense" mention to the product page. |
| \`docs-site/content/docs/setup/mcp-scanner.mdx\` | docs | Link first "Cisco AI Defense" mention to the product page. |
| \`docs-site/content/docs/reference/keys.mdx\` | docs | Link \`CISCO_AI_DEFENSE_API_KEY\` row to the product page. |
| \`docs-site/content/docs/reference/env-vars.mdx\` | docs | Link \`CISCO_AI_DEFENSE_API_KEY\` row to the product page. |
| \`docs-site/content/docs/connectors/{copilot,cursor,geminicli,hermes,windsurf}.mdx\` | docs | Link the shared "runs both local + Cisco AI Defense scanners" sentence to the product page. |

## Open Issues / Follow-ups

- \`docs-site/content/docs/setup/guardrail/index.mdx\` mentions
  Cisco AI Defense inside string literals of a typed-terminal
  animation and inside a \`PropTable\`-style description map; these
  render as plain strings, not markdown, so adding a markdown link
  inside them would render as literal \`[…](…)\`. Not changed.
- README's "Cisco AI Defense" mentions on lines 43 and 180 are not
  linked — the \`<a href>\` shield badge at line 27 already points
  to the same URL, so a reader of the README reaches the product
  page at the top of the file. Not changed.
- TypeScript types (\`CiscoAIDefenseConfig\`, \`policy.cisco_ai_defense\`)
  and the policy YAML key (\`cisco_ai_defense:\`) are not renamed.
  Renaming them would be a schema break for activated policies.

## Test Plan

- \`cd docs-site && npm run test:policy-creator\` → 53/53 pass
- \`cd docs-site && npx tsc --noEmit\` → 0 errors
- Manually walked the Quick Start tab: Step 1 now shows
  Permissive / Balanced / Strict cards with the updated blurb.
- Playground section header now reads
  "Cisco AI Defense (Optional · Enterprise)"; the help blurb
  inside the editor links the product name to the cisco.com page.