### PR TITLE
feat(upgrade): verify release artifacts and enforce per-release upgrade contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,15 @@ jobs:
       # install.sh / `defenseclaw upgrade` will look up at the next tag.
       - run: make check-version-sync
 
+  upgrade-manifest:
+    name: Upgrade Manifest Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      # Ensures future releases carry a release-owned migration contract
+      # before the release workflow publishes upgrade-manifest.json.
+      - run: make check-upgrade-manifest
+
   go-lint:
     name: Go Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -234,6 +234,18 @@ jobs:
           make dist-cli
           make dist-plugin
 
+      - name: Finalize upgrade manifest and checksums
+        run: |
+          set -euo pipefail
+          make dist-upgrade-manifest
+          rm -f dist/checksums.txt.sig dist/checksums.txt.pem
+          make dist-checksums
+          cosign sign-blob \
+            --yes \
+            --output-certificate=dist/checksums.txt.pem \
+            --output-signature=dist/checksums.txt.sig \
+            dist/checksums.txt
+
       # Atomic: tag + release + every asset are created in a single API
       # call. On workflow_dispatch, --target $GITHUB_SHA tells gh to create
       # the tag at this commit if it doesn't yet exist. On push:tags the
@@ -255,6 +267,7 @@ jobs:
             dist/checksums.txt.sig
             dist/checksums.txt.pem
             dist/*.whl
+            dist/upgrade-manifest.json
           )
 
           notes_args=()

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ DIST_DIR    := dist
         plugin plugin-install maybe-openclaw-plugin-install extensions test cli-test cli-test-cov gateway-test tui-test go-test-cov \
         connector-matrix-test go-connector-matrix-test py-connector-matrix-test \
         test-verbose test-file lint py-lint go-lint ts-test rego-test clean \
-        check check-audit-actions check-error-codes check-schemas check-v7 check-provider-coverage check-version-sync \
+        check check-audit-actions check-error-codes check-schemas check-v7 check-provider-coverage check-version-sync check-upgrade-manifest \
         set-version \
         _bundle-data \
-        dist dist-cli dist-gateway dist-plugin dist-sandbox dist-test dist-checksums dist-clean
+        dist dist-cli dist-gateway dist-plugin dist-sandbox dist-test dist-upgrade-manifest dist-checksums dist-clean
 
 # ---------------------------------------------------------------------------
 # Version stamping
@@ -529,7 +529,7 @@ test-file:
 # too and will fail the build on drift.
 # ---------------------------------------------------------------------------
 
-check: check-v7 check-provider-coverage
+check: check-v7 check-provider-coverage check-upgrade-manifest
 
 check-v7: check-audit-actions check-error-codes check-schemas
 	@echo "check-v7: all parity gates passed."
@@ -560,6 +560,9 @@ check-provider-coverage: sync-openclaw-extension
 		fi && \
 		npx --prefer-offline --no-install vitest run src/__tests__/provider-coverage.test.ts
 	@echo "check-provider-coverage: corpus is in sync across Go + TS."
+
+check-upgrade-manifest:
+	@python3 scripts/generate-upgrade-manifest.py --check
 
 # ---------------------------------------------------------------------------
 # Lint targets
@@ -604,7 +607,7 @@ go-lint: sync-openclaw-extension
 # Distribution targets — build release artifacts into dist/
 # ---------------------------------------------------------------------------
 
-dist: dist-cli dist-gateway dist-plugin dist-sandbox dist-checksums
+dist: dist-cli dist-gateway dist-plugin dist-sandbox dist-upgrade-manifest dist-checksums
 	@echo ""
 	@echo "Release artifacts:"
 	@ls -lh $(DIST_DIR)/
@@ -703,9 +706,13 @@ dist-test:
 	chmod +x $(DIST_DIR)/test/*.sh 2>/dev/null || true
 	@echo "Test scripts copied to $(DIST_DIR)/test/"
 
+dist-upgrade-manifest:
+	@mkdir -p $(DIST_DIR)
+	python3 scripts/generate-upgrade-manifest.py --out $(DIST_DIR)/upgrade-manifest.json
+
 dist-checksums:
 	@test -d $(DIST_DIR) || { echo "Run 'make dist' first"; exit 1; }
-	cd $(DIST_DIR) && find . -type f ! -name checksums.txt | sort | xargs shasum -a 256 > checksums.txt
+	cd $(DIST_DIR) && find . -type f ! -name checksums.txt ! -name checksums.txt.sig ! -name checksums.txt.pem | sed 's#^\./##' | sort | xargs shasum -a 256 > checksums.txt
 	@echo "Checksums written to $(DIST_DIR)/checksums.txt"
 
 dist-clean:

--- a/cli/defenseclaw/commands/cmd_upgrade.py
+++ b/cli/defenseclaw/commands/cmd_upgrade.py
@@ -26,10 +26,14 @@ This matches the upgrade path used by scripts/upgrade.sh.
 from __future__ import annotations
 
 import datetime
+import hashlib
+import json
 import os
 import platform
+import re
 import shutil
 import subprocess
+import tarfile
 import tempfile
 import time
 
@@ -42,6 +46,10 @@ from defenseclaw.context import AppContext, pass_ctx
 GITHUB_REPO = "cisco-ai-defense/defenseclaw"
 GITHUB_API = f"https://api.github.com/repos/{GITHUB_REPO}"
 GITHUB_DL = f"https://github.com/{GITHUB_REPO}/releases/download"
+_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+_SHA256_HEX = set("0123456789abcdefABCDEF")
+_UPGRADE_PROTOCOL_VERSION = 1
+_UPGRADE_MANIFEST_FILENAME = "upgrade-manifest.json"
 
 
 @click.command("upgrade")
@@ -78,7 +86,7 @@ def upgrade(
             ux.err("Could not determine latest release. Use --version to specify.", indent="  ")
             raise SystemExit(1)
 
-    target_version = target_version.lstrip("v")
+    target_version = _normalize_target_version(target_version)
     ux.kv("Installed version", current_version, indent="  ", key_width=22)
     ux.kv("Target version", target_version, indent="  ", key_width=22)
 
@@ -108,8 +116,38 @@ def upgrade(
 
     staging_dir = tempfile.mkdtemp(prefix="defenseclaw-upgrade-")
     try:
-        gw_binary_path = _download_gateway(target_version, os_name, arch, staging_dir)
-        whl_path = _download_wheel(target_version, staging_dir)
+        # Resolve checksums.txt FIRST so any download we accept is verified
+        # against a published manifest. Returns None for old releases that
+        # predate goreleaser's checksum publication; in that case we proceed
+        # with a clear warning rather than hard-failing operators on a
+        # version they could otherwise install.
+        artifact_names = [
+            f"defenseclaw_{target_version}_{os_name}_{arch}.tar.gz",
+            f"defenseclaw-{target_version}-py3-none-any.whl",
+            _UPGRADE_MANIFEST_FILENAME,
+        ]
+        checksums = _download_checksums(target_version, staging_dir)
+        if checksums is None:
+            checksums = _fetch_release_asset_digests(target_version)
+            if checksums is None:
+                ux.warn(
+                    "checksums.txt unavailable — release artifacts will be "
+                    "downloaded WITHOUT integrity verification.",
+                    indent="  ",
+                )
+            else:
+                ux.ok("Release artifact digests resolved (GitHub asset metadata)")
+        else:
+            ux.ok("Checksum manifest verified (checksums.txt)")
+            _fill_missing_checksums_from_release_assets(target_version, checksums, artifact_names)
+
+        upgrade_manifest = _download_upgrade_manifest(target_version, staging_dir, checksums)
+        gw_binary_path, _gw_tarball_name = _download_gateway(
+            target_version, os_name, arch, staging_dir, checksums,
+        )
+        whl_path, _whl_name = _download_wheel(
+            target_version, staging_dir, checksums,
+        )
     except SystemExit:
         shutil.rmtree(staging_dir, ignore_errors=True)
         raise
@@ -149,7 +187,12 @@ def upgrade(
     try:
         ux.banner("Installing Artifacts")
 
-        _install_gateway(gw_binary_path, os_name)
+        # Pass backup_dir so the previous gateway binary is snapshotted
+        # before being overwritten — turns a failed health check into a
+        # documented `cp` rollback instead of a "rebuild from source"
+        # incident.
+        installed_gateway_path = _install_gateway(gw_binary_path, os_name, backup_dir=backup_dir)
+        _verify_installed_gateway_version(installed_gateway_path, target_version)
         _install_wheel(whl_path)
 
         ux.banner("Running Migrations")
@@ -176,6 +219,14 @@ def upgrade(
         else:
             ux.ok(f"Applied {count} migration(s)")
 
+        # Surface the migration cursor so a partial-failure host (where
+        # the cursor differs from what the registry says we just ran)
+        # is visible in the upgrade log, not buried in
+        # ``<data_dir>/.migration_state.json``. Best-effort: a missing
+        # cursor module simply skips the summary.
+        _print_migration_cursor_summary(data_dir)
+        _assert_required_cli_migrations(upgrade_manifest, data_dir)
+
     finally:
         # Always clean up staging dir first, even if restart fails.
         shutil.rmtree(staging_dir, ignore_errors=True)
@@ -184,14 +235,15 @@ def upgrade(
 
         _run_silent(["defenseclaw-gateway", "start"], "Gateway started", "Could not start gateway")
 
-        result = subprocess.run(
+        # Reuse _run_silent so the restart degrades gracefully when the
+        # `openclaw` CLI isn't installed. A bare subprocess.run() raises
+        # FileNotFoundError before check=False can take effect, which used
+        # to crash the upgrade command after services had already restarted.
+        if not _run_silent(
             ["openclaw", "gateway", "restart"],
-            capture_output=True, text=True, timeout=30, check=False,
-        )
-        if result.returncode == 0:
-            ux.ok("OpenClaw gateway restarted — DefenseClaw plugin loaded")
-        else:
-            ux.warn("Could not restart OpenClaw gateway automatically")
+            "OpenClaw gateway restarted — DefenseClaw plugin loaded",
+            "Could not restart OpenClaw gateway automatically",
+        ):
             ux.subhead("Run manually: openclaw gateway restart")
 
         # Health verification
@@ -203,6 +255,12 @@ def upgrade(
     ux.banner("Upgrade Complete")
     ux.ok(f"DefenseClaw upgraded: {current_version} → {target_version}")
     click.echo(f"  {ux.bold('Backup:')} {backup_dir}")
+    # Surface component drift now (rather than waiting for the operator to
+    # discover it next time they run `defenseclaw version`). The plugin
+    # ships separately from `defenseclaw upgrade` — when guardrail flows
+    # through OpenClaw, a stale plugin against a fresh gateway is the #1
+    # source of "guardrail not enforcing" reports.
+    _check_post_upgrade_drift(target_version)
     click.echo()
 
     if app.logger:
@@ -216,6 +274,21 @@ def upgrade(
 # GitHub release helpers
 # ---------------------------------------------------------------------------
 
+def _normalize_target_version(version: str) -> str:
+    """Return a canonical release version or abort on unsafe input."""
+    normalized = version.strip()
+    if normalized.startswith("v"):
+        normalized = normalized[1:]
+    if _VERSION_RE.fullmatch(normalized):
+        return normalized
+
+    ux.err(
+        f"Invalid release version: {version!r}. Expected MAJOR.MINOR.PATCH.",
+        indent="  ",
+    )
+    raise SystemExit(1)
+
+
 def _fetch_latest_version() -> str | None:
     """Fetch the latest release version from GitHub.
 
@@ -223,16 +296,23 @@ def _fetch_latest_version() -> str | None:
     avoid hitting the unauthenticated rate limit (60 req/h).
     """
     try:
-        headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
-        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
-        resp = requests.get(f"{GITHUB_API}/releases/latest", headers=headers, timeout=15)
+        resp = requests.get(f"{GITHUB_API}/releases/latest", headers=_github_headers(), timeout=15)
         resp.raise_for_status()
         tag = resp.json().get("tag_name", "")
-        return tag.lstrip("v") if tag else None
+        if not isinstance(tag, str) or not tag:
+            return None
+        return tag[1:] if tag.startswith("v") else tag
     except (requests.RequestException, KeyError, ValueError):
         return None
+
+
+def _github_headers() -> dict[str, str]:
+    """Headers for GitHub API calls, with optional token auth."""
+    headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
 
 
 def _detect_platform() -> tuple[str, str]:
@@ -279,42 +359,712 @@ def _preflight_check(version: str, os_name: str, arch: str) -> None:
     ux.ok("Release artifacts verified")
 
 
-def _download_gateway(version: str, os_name: str, arch: str, staging_dir: str) -> str:
-    """Download the gateway tarball to staging_dir and extract. Returns path to binary."""
+def _download_gateway(
+    version: str,
+    os_name: str,
+    arch: str,
+    staging_dir: str,
+    checksums: dict[str, str] | None = None,
+) -> tuple[str, str]:
+    """Download the gateway tarball, verify its checksum, and extract.
+
+    Returns ``(binary_path, tarball_name)``. The tarball name is returned
+    so the caller can correlate this artifact with the published
+    ``checksums.txt`` entry; we keep the binary path stable so existing
+    callers don't break when checksum verification is opted into.
+    """
     tarball = f"defenseclaw_{version}_{os_name}_{arch}.tar.gz"
     url = f"{GITHUB_DL}/{version}/{tarball}"
 
     click.echo(f"  {ux.dim('→')} Downloading gateway binary ({os_name}/{arch}) ...")
     dest = os.path.join(staging_dir, tarball)
     _download_file(url, dest)
-    subprocess.run(["tar", "-xzf", dest, "-C", staging_dir], check=True, capture_output=True)
+    if checksums is not None:
+        _verify_sha256(dest, tarball, checksums)
+    _extract_gateway_tarball(dest, staging_dir)
     binary = os.path.join(staging_dir, "defenseclaw")
+    if not os.path.isfile(binary):
+        ux.err(
+            "Gateway tarball did not contain the expected defenseclaw binary.",
+            indent="  ",
+        )
+        raise SystemExit(1)
     ux.ok("Gateway binary downloaded")
-    return binary
+    return binary, tarball
 
 
-def _download_wheel(version: str, staging_dir: str) -> str:
-    """Download the Python CLI wheel to staging_dir. Returns path to wheel."""
+def _download_wheel(
+    version: str,
+    staging_dir: str,
+    checksums: dict[str, str] | None = None,
+) -> tuple[str, str]:
+    """Download the Python CLI wheel and verify its checksum."""
     whl_name = f"defenseclaw-{version}-py3-none-any.whl"
     url = f"{GITHUB_DL}/{version}/{whl_name}"
 
     click.echo(f"  {ux.dim('→')} Downloading Python CLI wheel ...")
     dest = os.path.join(staging_dir, whl_name)
     _download_file(url, dest)
+    if checksums is not None:
+        _verify_sha256(dest, whl_name, checksums)
     ux.ok("Python CLI wheel downloaded")
+    return dest, whl_name
+
+
+# Filename the GitHub release exposes for the SHA-256 manifest. Mirrors
+# .goreleaser.yaml ``checksum.name_template``.
+_CHECKSUMS_FILENAME = "checksums.txt"
+
+
+def _download_checksums(
+    version: str,
+    staging_dir: str,
+) -> dict[str, str] | None:
+    """Download ``checksums.txt`` for the target release and parse it.
+
+    Returns a mapping of ``filename → lowercase_sha256_hex`` or ``None``
+    when the manifest is unavailable. Old releases predate goreleaser's
+    checksum publication, so a missing file must not block the upgrade
+    — the caller decides whether to warn or hard-fail. We deliberately
+    parse, not just download, because a 200 with garbage body would
+    otherwise look "verified" to the caller.
+    """
+    dest = _download_optional_release_asset(version, _CHECKSUMS_FILENAME, staging_dir)
+    if not dest:
+        return None
+
+    _verify_checksums_sigstore(version, staging_dir, dest)
+
+    out: dict[str, str] = {}
+    try:
+        with open(dest, encoding="utf-8") as f:
+            for raw in f:
+                line = raw.strip()
+                if not line or line.startswith("#"):
+                    continue
+                # goreleaser emits "<sha256>  <filename>" (two spaces).
+                # We split on whitespace to tolerate single-space variants
+                # from sha256sum / shasum output styles.
+                parts = line.split()
+                if len(parts) != 2:
+                    continue
+                sha, name = parts
+                # Defense in depth: only accept hex strings of expected length.
+                if not _is_sha256_hex(sha):
+                    continue
+                name = name.removeprefix("./")
+                out[name] = sha.lower()
+    except OSError as exc:
+        ux.warn(f"Could not parse checksums.txt: {exc}", indent="  ")
+        return None
+
+    if out:
+        return out
+
+    ux.err("checksums.txt did not contain any valid SHA-256 entries.", indent="  ")
+    raise SystemExit(1)
+
+
+def _verify_checksums_sigstore(version: str, staging_dir: str, checksums_path: str) -> None:
+    """Verify checksums.txt with its Sigstore cert/signature when available."""
+    sig_path = _download_optional_release_asset(version, f"{_CHECKSUMS_FILENAME}.sig", staging_dir)
+    cert_path = _download_optional_release_asset(version, f"{_CHECKSUMS_FILENAME}.pem", staging_dir)
+
+    if not sig_path and not cert_path:
+        return
+    if not sig_path or not cert_path:
+        ux.warn(
+            "checksums.txt Sigstore signature assets are incomplete; "
+            "continuing without signature verification.",
+            indent="  ",
+        )
+        return
+
+    cosign = shutil.which("cosign")
+    if not cosign:
+        ux.warn(
+            "checksums.txt Sigstore signature is present, but cosign was "
+            "not found on PATH; continuing without signature verification.",
+            indent="  ",
+        )
+        return
+
+    cmd = [
+        cosign,
+        "verify-blob",
+        "--certificate",
+        cert_path,
+        "--signature",
+        sig_path,
+        "--certificate-identity-regexp",
+        f"^https://github.com/{GITHUB_REPO}/.+",
+        "--certificate-oidc-issuer",
+        "https://token.actions.githubusercontent.com",
+        checksums_path,
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        ux.err(f"Could not verify checksums.txt Sigstore signature: {exc}", indent="  ")
+        raise SystemExit(1) from exc
+
+    if result.returncode != 0:
+        ux.err("checksums.txt Sigstore signature verification failed.", indent="  ")
+        detail = (result.stderr or result.stdout or "").strip()
+        for line in detail.splitlines()[:5]:
+            ux.subhead(line[:200], indent="    ")
+        raise SystemExit(1)
+
+    ux.ok("Checksum signature verified (Sigstore)")
+
+
+def _download_optional_release_asset(
+    version: str,
+    filename: str,
+    staging_dir: str,
+) -> str | None:
+    """Download an optional release-side file, returning its path if present."""
+    url = f"{GITHUB_DL}/{version}/{filename}"
+    dest = os.path.join(staging_dir, filename)
+    resp = None
+    for attempt in range(1, 4):
+        try:
+            resp = requests.get(url, timeout=15, allow_redirects=True)
+        except requests.RequestException:
+            if attempt < 3:
+                time.sleep(2 ** (attempt - 1))
+                continue
+            return None
+        if resp.status_code == 200:
+            break
+        if attempt < 3 and resp.status_code in {429, 500, 502, 503, 504}:
+            time.sleep(2 ** (attempt - 1))
+            continue
+        return None
+    if resp is None or resp.status_code != 200:
+        return None
+    try:
+        with open(dest, "wb") as f:
+            f.write(resp.content)
+    except OSError as exc:
+        ux.warn(f"Could not save optional release asset {filename}: {exc}", indent="  ")
+        return None
     return dest
 
 
-def _install_gateway(binary_path: str, os_name: str) -> None:
-    """Install a pre-downloaded gateway binary."""
+def _download_upgrade_manifest(
+    version: str,
+    staging_dir: str,
+    checksums: dict[str, str] | None = None,
+) -> dict[str, object] | None:
+    """Download and validate the release's upgrade contract, when present.
+
+    ``defenseclaw upgrade`` itself is installed on the operator's machine,
+    so future releases cannot assume the local upgrader learned new rules.
+    The release-owned manifest is the forward-compatibility handoff: it can
+    require a newer upgrade protocol, name migrations that must be recorded
+    in the cursor, and make breaking releases fail before old code guesses.
+    """
+    url = f"{GITHUB_DL}/{version}/{_UPGRADE_MANIFEST_FILENAME}"
+    dest = os.path.join(staging_dir, _UPGRADE_MANIFEST_FILENAME)
+    try:
+        resp = requests.get(url, timeout=15, allow_redirects=True)
+    except requests.RequestException as exc:
+        ux.warn(f"Could not reach {_UPGRADE_MANIFEST_FILENAME}: {exc}", indent="  ")
+        return None
+    if resp.status_code == 404:
+        return None
+    if resp.status_code != 200:
+        ux.warn(
+            f"Could not fetch {_UPGRADE_MANIFEST_FILENAME} ({resp.status_code}); "
+            "continuing without release-specific upgrade policy.",
+            indent="  ",
+        )
+        return None
+
+    try:
+        with open(dest, "wb") as f:
+            f.write(resp.content)
+    except OSError as exc:
+        ux.err(f"Could not save {_UPGRADE_MANIFEST_FILENAME}: {exc}", indent="  ")
+        raise SystemExit(1) from exc
+
+    if checksums is not None:
+        _verify_sha256(dest, _UPGRADE_MANIFEST_FILENAME, checksums)
+
+    try:
+        payload = json.loads(resp.content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        ux.err(f"Invalid {_UPGRADE_MANIFEST_FILENAME}: {exc}", indent="  ")
+        raise SystemExit(1) from exc
+
+    manifest = _validate_upgrade_manifest(payload, version)
+    required = manifest["required_cli_migrations"]
+    if required:
+        ux.ok(
+            "Upgrade manifest loaded "
+            f"(required migrations: {', '.join(required)})"
+        )
+    else:
+        ux.ok("Upgrade manifest loaded")
+    return manifest
+
+
+def _validate_upgrade_manifest(payload: object, version: str) -> dict[str, object]:
+    """Validate a parsed ``upgrade-manifest.json`` payload."""
+    if not isinstance(payload, dict):
+        ux.err(f"{_UPGRADE_MANIFEST_FILENAME} must be a JSON object.", indent="  ")
+        raise SystemExit(1)
+
+    schema_version = payload.get("schema_version")
+    if not isinstance(schema_version, int) or isinstance(schema_version, bool):
+        ux.err(f"{_UPGRADE_MANIFEST_FILENAME} missing integer schema_version.", indent="  ")
+        raise SystemExit(1)
+    if schema_version > 1:
+        ux.err(
+            f"Release {version} uses upgrade manifest schema {schema_version}, "
+            "which this upgrader does not understand.",
+            indent="  ",
+        )
+        _print_new_upgrade_script_hint(version)
+        raise SystemExit(1)
+
+    release_version = payload.get("release_version")
+    if release_version != version:
+        ux.err(
+            f"{_UPGRADE_MANIFEST_FILENAME} release_version mismatch: "
+            f"expected {version}, got {release_version!r}.",
+            indent="  ",
+        )
+        raise SystemExit(1)
+
+    min_protocol = payload.get("min_upgrade_protocol", 1)
+    if not isinstance(min_protocol, int) or isinstance(min_protocol, bool) or min_protocol < 1:
+        ux.err(f"{_UPGRADE_MANIFEST_FILENAME} has invalid min_upgrade_protocol.", indent="  ")
+        raise SystemExit(1)
+    if min_protocol > _UPGRADE_PROTOCOL_VERSION:
+        ux.err(
+            f"Release {version} requires upgrade protocol {min_protocol}, "
+            f"but this upgrader supports {_UPGRADE_PROTOCOL_VERSION}.",
+            indent="  ",
+        )
+        _print_new_upgrade_script_hint(version)
+        raise SystemExit(1)
+
+    policy = payload.get("migration_failure_policy", "warn")
+    if policy not in ("warn", "fail"):
+        ux.err(
+            f"{_UPGRADE_MANIFEST_FILENAME} has invalid migration_failure_policy: "
+            f"{policy!r}.",
+            indent="  ",
+        )
+        raise SystemExit(1)
+
+    required_raw = payload.get("required_cli_migrations", [])
+    if not isinstance(required_raw, list) or not all(isinstance(v, str) for v in required_raw):
+        ux.err(
+            f"{_UPGRADE_MANIFEST_FILENAME} required_cli_migrations must be "
+            "a list of version strings.",
+            indent="  ",
+        )
+        raise SystemExit(1)
+    required = []
+    seen: set[str] = set()
+    for migration_version in required_raw:
+        if not _VERSION_RE.fullmatch(migration_version):
+            ux.err(
+                f"{_UPGRADE_MANIFEST_FILENAME} contains invalid migration "
+                f"version {migration_version!r}.",
+                indent="  ",
+            )
+            raise SystemExit(1)
+        if migration_version not in seen:
+            required.append(migration_version)
+            seen.add(migration_version)
+
+    return {
+        "schema_version": schema_version,
+        "release_version": release_version,
+        "min_upgrade_protocol": min_protocol,
+        "migration_failure_policy": policy,
+        "required_cli_migrations": required,
+    }
+
+
+def _print_new_upgrade_script_hint(version: str) -> None:
+    url = f"https://raw.githubusercontent.com/{GITHUB_REPO}/{version}/scripts/upgrade.sh"
+    ux.subhead(
+        "Use the upgrade script shipped with that release:",
+        indent="    ",
+    )
+    ux.subhead(
+        f"curl -fsSL {url} | bash -s -- --version {version}",
+        indent="    ",
+    )
+
+
+def _assert_required_cli_migrations(
+    manifest: dict[str, object] | None,
+    data_dir: str,
+) -> None:
+    """Warn or fail if the release manifest named migrations that did not apply."""
+    if not manifest:
+        return
+    required = manifest.get("required_cli_migrations", [])
+    policy = manifest.get("migration_failure_policy", "warn")
+    if not isinstance(required, list) or not required:
+        return
+
+    from defenseclaw import migration_state
+
+    state = migration_state.load(data_dir)
+    missing = [
+        version
+        for version in required
+        if isinstance(version, str) and not migration_state.is_applied(state, version)
+    ]
+    if not missing:
+        return
+
+    label = "Required" if policy == "fail" else "Expected"
+    ux.warn(
+        f"{label} migration(s) were not recorded in the migration cursor: "
+        + ", ".join(missing),
+        indent="  ",
+    )
+    if policy == "fail":
+        ux.subhead(
+            "The release manifest marks these migrations as mandatory. "
+            "Re-run the upgrade after fixing the migration error, or run "
+            "`defenseclaw migrations status` for cursor details.",
+            indent="    ",
+        )
+        raise SystemExit(1)
+
+
+def _fetch_release_asset_digests(version: str) -> dict[str, str] | None:
+    """Read GitHub's per-asset SHA-256 digests for ``version``.
+
+    GitHub release assets expose a ``digest`` field (`sha256:<hex>`).
+    We use it as a fallback for releases where ``checksums.txt`` was
+    generated by GoReleaser before the Python wheel/plugin assets were
+    attached. A missing API digest does not make the release unverifiable
+    by itself; callers decide whether to warn or fail for required files.
+    """
+    try:
+        resp = requests.get(
+            f"{GITHUB_API}/releases/tags/{version}",
+            headers=_github_headers(),
+            timeout=15,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    except (requests.RequestException, ValueError) as exc:
+        ux.warn(f"Could not fetch GitHub asset digests: {exc}", indent="  ")
+        return None
+
+    assets = payload.get("assets", []) if isinstance(payload, dict) else []
+    if not isinstance(assets, list):
+        return None
+
+    out: dict[str, str] = {}
+    for asset in assets:
+        if not isinstance(asset, dict):
+            continue
+        name = asset.get("name")
+        digest = asset.get("digest")
+        if not isinstance(name, str) or not isinstance(digest, str):
+            continue
+        prefix = "sha256:"
+        if not digest.startswith(prefix):
+            continue
+        sha = digest[len(prefix):]
+        if _is_sha256_hex(sha):
+            out[name] = sha.lower()
+    return out if out else None
+
+
+def _fill_missing_checksums_from_release_assets(
+    version: str,
+    checksums: dict[str, str],
+    artifact_names: list[str],
+) -> None:
+    """Fill required checksum gaps from GitHub release asset metadata."""
+    missing = [name for name in artifact_names if name not in checksums]
+    if not missing:
+        return
+
+    asset_digests = _fetch_release_asset_digests(version)
+    if not asset_digests:
+        return
+
+    filled: list[str] = []
+    for name in missing:
+        digest = asset_digests.get(name)
+        if digest:
+            checksums[name] = digest
+            filled.append(name)
+
+    for name in filled:
+        ux.warn(
+            f"checksums.txt missing {name}; using GitHub release asset digest.",
+            indent="  ",
+        )
+
+
+def _is_sha256_hex(value: str) -> bool:
+    return len(value) == 64 and all(c in _SHA256_HEX for c in value)
+
+
+def _extract_gateway_tarball(tarball_path: str, staging_dir: str) -> None:
+    """Safely extract the gateway tarball into ``staging_dir``.
+
+    The release artifact is expected to be trusted once its checksum
+    matches, but validating members is still cheap defense in depth: an
+    archive that tries path traversal, absolute paths, or symlink/hardlink
+    tricks is never allowed to write outside the staging directory.
+    """
+    root = os.path.realpath(staging_dir)
+    try:
+        with tarfile.open(tarball_path, mode="r:gz") as tar:
+            members = tar.getmembers()
+            for member in members:
+                target = os.path.realpath(os.path.join(staging_dir, member.name))
+                if not member.name or os.path.isabs(member.name):
+                    ux.err(f"Unsafe tarball entry: {member.name!r}", indent="  ")
+                    raise SystemExit(1)
+                if target != root and not target.startswith(root + os.sep):
+                    ux.err(f"Unsafe tarball entry escapes staging dir: {member.name}", indent="  ")
+                    raise SystemExit(1)
+                if member.issym() or member.islnk():
+                    ux.err(f"Unsafe tarball link entry: {member.name}", indent="  ")
+                    raise SystemExit(1)
+                if not (member.isfile() or member.isdir()):
+                    ux.err(f"Unsupported tarball entry type: {member.name}", indent="  ")
+                    raise SystemExit(1)
+            try:
+                tar.extractall(staging_dir, members=members, filter="data")
+            except TypeError:
+                # Python < 3.12 does not support extraction filters; the
+                # explicit member validation above covers the same hazards.
+                tar.extractall(staging_dir, members=members)
+    except tarfile.TarError as exc:
+        ux.err(f"Could not extract gateway tarball: {exc}", indent="  ")
+        raise SystemExit(1) from exc
+    except OSError as exc:
+        ux.err(f"Could not write gateway files from tarball: {exc}", indent="  ")
+        raise SystemExit(1) from exc
+
+
+def _verify_sha256(
+    path: str,
+    filename: str,
+    checksums: dict[str, str],
+) -> None:
+    """Verify ``path``'s SHA-256 against ``checksums[filename]``.
+
+    Raises ``SystemExit(1)`` on mismatch — a tampered or corrupted
+    artifact must never reach ``_install_gateway`` / ``_install_wheel``.
+    A missing entry in the manifest is also fatal: it would otherwise
+    let an attacker who can drop a file with a novel name into the
+    release tree slip past verification.
+    """
+    expected = checksums.get(filename)
+    if not expected:
+        ux.err(
+            f"No checksum entry for {filename} in checksums.txt or GitHub asset metadata — "
+            "refusing to install an unrecognized artifact.",
+            indent="  ",
+        )
+        raise SystemExit(1)
+
+    h = hashlib.sha256()
+    try:
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(65536), b""):
+                h.update(chunk)
+    except OSError as exc:
+        ux.err(f"Could not hash {path}: {exc}", indent="  ")
+        raise SystemExit(1) from exc
+    actual = h.hexdigest().lower()
+    if actual != expected.lower():
+        ux.err(
+            f"Checksum mismatch for {filename}: "
+            f"expected {expected}, got {actual}",
+            indent="  ",
+        )
+        ux.err(
+            "Refusing to install — possible tampering or corrupted download.",
+            indent="    ",
+        )
+        raise SystemExit(1)
+
+
+def _install_gateway(
+    binary_path: str,
+    os_name: str,
+    backup_dir: str | None = None,
+) -> str:
+    """Install a pre-downloaded gateway binary.
+
+    When ``backup_dir`` is supplied AND a previous gateway binary exists,
+    it's snapshotted to ``<backup_dir>/defenseclaw-gateway.previous``
+    before being overwritten. Operators can roll back manually with::
+
+        cp <backup_dir>/defenseclaw-gateway.previous ~/.local/bin/defenseclaw-gateway
+        defenseclaw-gateway restart
+
+    The snapshot is best-effort — a failure to copy the previous binary
+    must not block a fresh install where there's nothing to snapshot.
+    """
     install_dir = os.path.expanduser("~/.local/bin")
     os.makedirs(install_dir, exist_ok=True)
     target = os.path.join(install_dir, "defenseclaw-gateway")
+
+    if backup_dir and os.path.isfile(target):
+        snapshot = os.path.join(backup_dir, "defenseclaw-gateway.previous")
+        try:
+            shutil.copy2(target, snapshot)
+            os.chmod(snapshot, 0o755)
+            ux.ok(f"Snapshotted previous gateway → {snapshot}")
+        except OSError as exc:
+            ux.warn(
+                f"Could not snapshot previous gateway: {exc}",
+                indent="  ",
+            )
+
     shutil.copy2(binary_path, target)
     os.chmod(target, 0o755)
     if os_name == "darwin":
         subprocess.run(["codesign", "-f", "-s", "-", target], capture_output=True, check=False)
     ux.ok("Gateway binary installed")
+    return target
+
+
+def _verify_installed_gateway_version(binary_path: str, expected: str) -> None:
+    """Confirm the freshly-installed gateway reports ``expected``.
+
+    A version mismatch indicates either a corrupted tarball that
+    extracted but produced an unexpected binary, or a failed copy into
+    ``~/.local/bin/defenseclaw-gateway``. We invoke the exact installed
+    path returned by ``_install_gateway`` so PATH ordering cannot turn
+    this check into a false positive or false negative.
+
+    This is a soft check — we warn but don't abort. A binary that fails
+    to report ``--version`` may still start cleanly under the right
+    flags, and the subsequent health probe will catch a genuinely broken
+    install. The point is to surface the discrepancy, not to gate the
+    rest of the upgrade.
+    """
+    if not os.path.isfile(binary_path):
+        ux.warn(
+            f"Installed gateway binary is missing: {binary_path}",
+            indent="  ",
+        )
+        return
+    try:
+        result = subprocess.run(
+            [binary_path, "--version"],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        ux.warn(f"Could not invoke {binary_path} --version: {exc}", indent="  ")
+        return
+
+    output = ((result.stdout or "") + (result.stderr or "")).strip()
+    if expected in output:
+        ux.ok(f"Gateway binary verified ({expected})")
+        return
+
+    ux.warn(
+        f"Gateway version verification failed: expected {expected}",
+        indent="  ",
+    )
+    if output:
+        first_line = output.splitlines()[0][:200]
+        ux.subhead(f"binary reported: {first_line}", indent="    ")
+    ux.subhead(
+        "Continuing — health probe below will catch a genuinely broken install.",
+        indent="    ",
+    )
+
+
+def _print_migration_cursor_summary(data_dir: str) -> None:
+    """Print a one-line summary of which migrations the cursor recorded.
+
+    The cursor at ``<data_dir>/.migration_state.json`` is the source of
+    truth for "which migrations have observably executed on this host."
+    Printing it after every upgrade gives operators a stable artifact
+    to grep when triaging "did the 0.4.0 token bootstrap actually run?"
+    questions. Falls silent on missing/corrupt cursors — the surrounding
+    upgrade flow already surfaces those via ``defenseclaw doctor``.
+    """
+    try:
+        from defenseclaw import migration_state
+    except ImportError:
+        return
+    state = migration_state.load(data_dir)
+    if state is None:
+        return
+    if state.applied:
+        applied_repr = ", ".join(state.applied)
+        ux.subhead(f"cursor: applied=[{applied_repr}]", indent="    ")
+    else:
+        ux.subhead("cursor: applied=[] (no migrations recorded)", indent="    ")
+
+
+def _check_post_upgrade_drift(target_version: str) -> None:
+    """Surface component drift at the end of the upgrade flow.
+
+    The upgrade only refreshes the CLI and gateway. The OpenClaw plugin
+    ships separately (via the release tarball, installed by install.sh),
+    so a successful upgrade can still leave the operator running a
+    target-version gateway against a stale-version plugin — silently
+    breaking guardrail enforcement until the operator notices via
+    ``defenseclaw version``. Surfacing drift here gives them an
+    actionable warning at the moment the upgrade completes, not days
+    later when a runtime error fires.
+
+    Imports are deferred so this module's import time is unaffected
+    when ``defenseclaw.commands.cmd_version`` is unavailable (e.g.,
+    inside test rigs that patch the upgrade module's dependencies).
+    """
+    try:
+        from defenseclaw.commands.cmd_version import (
+            _cli_component,
+            _compute_drift,
+            _gateway_component,
+            _plugin_component,
+        )
+    except ImportError as exc:
+        ux.warn(f"Could not run drift check: {exc}", indent="  ")
+        return
+
+    try:
+        components = [_cli_component(), _gateway_component(), _plugin_component()]
+        drift = _compute_drift(components)
+    except Exception as exc:
+        ux.warn(f"Could not run drift check: {exc}", indent="  ")
+        return
+    if not drift:
+        return
+
+    click.echo()
+    ux.warn("Component drift detected after upgrade:", indent="  ")
+    for issue in drift:
+        ux.subhead(issue, indent="    ")
+    ux.subhead(
+        "Run `defenseclaw version` for the full report. "
+        "If the plugin is out of sync, reinstall it from the "
+        f"{target_version} release tarball.",
+        indent="    ",
+    )
 
 
 def _install_wheel(whl_path: str) -> None:
@@ -433,13 +1183,37 @@ def _api_bind_host(cfg) -> str:
 
 def _download_file(url: str, dest: str) -> None:
     """Download a file from url to dest, raising on failure."""
-    resp = requests.get(url, stream=True, timeout=60, allow_redirects=True)
-    if resp.status_code != 200:
-        ux.err(f"Download failed ({resp.status_code}): {url}", indent="  ")
-        raise SystemExit(1)
-    with open(dest, "wb") as f:
-        for chunk in resp.iter_content(chunk_size=8192):
-            f.write(chunk)
+    last_exc: requests.RequestException | None = None
+    for attempt in range(1, 4):
+        try:
+            resp = requests.get(url, stream=True, timeout=60, allow_redirects=True)
+        except requests.RequestException as exc:
+            last_exc = exc
+            if attempt < 3:
+                time.sleep(2 ** (attempt - 1))
+                continue
+            ux.err(f"Download failed: {exc}", indent="  ")
+            raise SystemExit(1) from exc
+
+        if resp.status_code != 200:
+            if attempt < 3 and resp.status_code in {429, 500, 502, 503, 504}:
+                time.sleep(2 ** (attempt - 1))
+                continue
+            ux.err(f"Download failed ({resp.status_code}): {url}", indent="  ")
+            raise SystemExit(1)
+
+        try:
+            with open(dest, "wb") as f:
+                for chunk in resp.iter_content(chunk_size=8192):
+                    if chunk:
+                        f.write(chunk)
+            return
+        except OSError as exc:
+            ux.err(f"Could not save download to {dest}: {exc}", indent="  ")
+            raise SystemExit(1) from exc
+
+    if last_exc is not None:
+        raise SystemExit(1) from last_exc
 
 
 # ---------------------------------------------------------------------------
@@ -498,14 +1272,26 @@ def _create_backup(cfg) -> str:
 
 
 def _run_silent(cmd: list[str], ok_msg: str, fail_msg: str) -> bool:
-    """Run a command, printing ok_msg on success and fail_msg on failure."""
+    """Run a command, printing ok_msg on success and fail_msg on failure.
+
+    On non-zero exit, surface the first few stderr/stdout lines so an
+    operator can correlate with logs immediately instead of needing a
+    second debug pass with the same command. Exceptions (missing
+    binary, timeout) are caught and reported similarly so the upgrade
+    flow never raises mid-restart.
+    """
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
         if result.returncode == 0:
             ux.ok(ok_msg)
             return True
         ux.warn(fail_msg)
+        err = (result.stderr or result.stdout or "").strip()
+        if err:
+            for line in err.splitlines()[:5]:
+                ux.subhead(line, indent="    ")
         return False
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
         ux.warn(fail_msg)
+        ux.subhead(str(exc), indent="    ")
         return False

--- a/cli/tests/test_cmd_upgrade.py
+++ b/cli/tests/test_cmd_upgrade.py
@@ -1,19 +1,49 @@
+import hashlib
+import io
+import json
 import os
+import tarfile
 import unittest
 from contextlib import ExitStack
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock, patch
 
 from click.testing import CliRunner
-
 from defenseclaw.commands.cmd_upgrade import (
     _api_bind_host,
+    _assert_required_cli_migrations,
+    _check_post_upgrade_drift,
     _create_backup,
+    _download_checksums,
+    _download_file,
+    _download_gateway,
+    _download_upgrade_manifest,
+    _fetch_release_asset_digests,
+    _fill_missing_checksums_from_release_assets,
+    _install_gateway,
     _install_wheel,
+    _normalize_target_version,
+    _print_migration_cursor_summary,
+    _run_silent,
+    _validate_upgrade_manifest,
+    _verify_checksums_sigstore,
+    _verify_installed_gateway_version,
+    _verify_sha256,
     upgrade,
 )
 from defenseclaw.config import Config, GatewayConfig, GuardrailConfig, OpenShellConfig
 from defenseclaw.context import AppContext
+
+
+class TestUpgradeVersionValidation(unittest.TestCase):
+    def test_accepts_plain_or_v_prefixed_semver(self):
+        self.assertEqual(_normalize_target_version("9.9.9"), "9.9.9")
+        self.assertEqual(_normalize_target_version("v9.9.9"), "9.9.9")
+
+    def test_rejects_versions_that_would_be_unsafe_in_paths_or_urls(self):
+        with self.assertRaises(SystemExit) as ctx:
+            _normalize_target_version("../9.9.9")
+        self.assertEqual(ctx.exception.code, 1)
 
 
 class TestUpgradeAPIBindHost(unittest.TestCase):
@@ -98,15 +128,33 @@ class TestUpgradeSameVersionRepair(unittest.TestCase):
             ))
             stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._preflight_check"))
             stack.enter_context(patch(
+                "defenseclaw.commands.cmd_upgrade._download_checksums",
+                return_value={
+                    "defenseclaw_9.9.9_darwin_arm64.tar.gz": "0" * 64,
+                    "defenseclaw-9.9.9-py3-none-any.whl": "0" * 64,
+                    "upgrade-manifest.json": "0" * 64,
+                },
+            ))
+            stack.enter_context(patch(
+                "defenseclaw.commands.cmd_upgrade._download_upgrade_manifest",
+                return_value=None,
+            ))
+            stack.enter_context(patch(
                 "defenseclaw.commands.cmd_upgrade._download_gateway",
-                return_value="/tmp/defenseclaw-gateway",
+                return_value=("/tmp/defenseclaw-gateway", "defenseclaw_9.9.9_darwin_arm64.tar.gz"),
             ))
             stack.enter_context(patch(
                 "defenseclaw.commands.cmd_upgrade._download_wheel",
-                return_value="/tmp/defenseclaw.whl",
+                return_value=("/tmp/defenseclaw.whl", "defenseclaw-9.9.9-py3-none-any.whl"),
             ))
             stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._install_gateway"))
             stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._install_wheel"))
+            stack.enter_context(patch(
+                "defenseclaw.commands.cmd_upgrade._verify_installed_gateway_version"
+            ))
+            stack.enter_context(patch(
+                "defenseclaw.commands.cmd_upgrade._check_post_upgrade_drift"
+            ))
             stack.enter_context(patch(
                 "defenseclaw.commands.cmd_upgrade._create_backup",
                 return_value="/tmp/backup",
@@ -124,3 +172,706 @@ class TestUpgradeSameVersionRepair(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, msg=result.output)
         run_migrations.assert_called_once()
+
+
+class TestUpgradeWithoutOpenClawCli(unittest.TestCase):
+    """Regression: when the `openclaw` CLI is not installed, the post-restart
+    hook used to crash with FileNotFoundError because subprocess.run() raises
+    before check=False can take effect. The upgrade must instead degrade
+    gracefully and exit 0."""
+
+    def test_upgrade_succeeds_when_openclaw_cli_missing(self):
+        runner = CliRunner()
+        app = AppContext()
+        app.cfg = Config()
+
+        def fake_run(args, **_kwargs):
+            if args and args[0] == "openclaw":
+                raise FileNotFoundError(2, "No such file or directory", "openclaw")
+            return Mock(returncode=0)
+
+        with TemporaryDirectory() as data_dir, ExitStack() as stack:
+            app.cfg.data_dir = data_dir
+            app.cfg.claw.home_dir = data_dir
+            stack.enter_context(patch("defenseclaw.__version__", "9.9.9"))
+            stack.enter_context(patch(
+                "defenseclaw.commands.cmd_upgrade._detect_platform",
+                return_value=("darwin", "arm64"),
+            ))
+            stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._preflight_check"))
+            stack.enter_context(patch(
+                "defenseclaw.commands.cmd_upgrade._download_checksums",
+                return_value={
+                    "defenseclaw_9.9.9_darwin_arm64.tar.gz": "0" * 64,
+                    "defenseclaw-9.9.9-py3-none-any.whl": "0" * 64,
+                    "upgrade-manifest.json": "0" * 64,
+                },
+            ))
+            stack.enter_context(patch(
+                "defenseclaw.commands.cmd_upgrade._download_upgrade_manifest",
+                return_value=None,
+            ))
+            stack.enter_context(patch(
+                "defenseclaw.commands.cmd_upgrade._download_gateway",
+                return_value=("/tmp/defenseclaw-gateway", "defenseclaw_9.9.9_darwin_arm64.tar.gz"),
+            ))
+            stack.enter_context(patch(
+                "defenseclaw.commands.cmd_upgrade._download_wheel",
+                return_value=("/tmp/defenseclaw.whl", "defenseclaw-9.9.9-py3-none-any.whl"),
+            ))
+            stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._install_gateway"))
+            stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._install_wheel"))
+            stack.enter_context(patch(
+                "defenseclaw.commands.cmd_upgrade._verify_installed_gateway_version"
+            ))
+            stack.enter_context(patch(
+                "defenseclaw.commands.cmd_upgrade._check_post_upgrade_drift"
+            ))
+            stack.enter_context(patch(
+                "defenseclaw.commands.cmd_upgrade._create_backup",
+                return_value="/tmp/backup",
+            ))
+            stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._poll_health"))
+            stack.enter_context(patch(
+                "defenseclaw.commands.cmd_upgrade.subprocess.run",
+                side_effect=fake_run,
+            ))
+            stack.enter_context(
+                patch("defenseclaw.migrations.run_migrations", return_value=0)
+            )
+            result = runner.invoke(upgrade, ["--yes", "--version", "9.9.9"], obj=app)
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("Could not restart OpenClaw gateway automatically", result.output)
+        self.assertIn("Run manually: openclaw gateway restart", result.output)
+
+
+class TestChecksumVerification(unittest.TestCase):
+    """Supply-chain: every artifact must match a published checksum or be
+    refused. A successful checksum is silent; a mismatch aborts; an
+    unknown filename in the manifest aborts. ``_download_checksums`` is
+    network-bound so we patch ``requests.get`` directly."""
+
+    def test_verify_sha256_passes_on_match(self):
+        with TemporaryDirectory() as tmp:
+            artifact = os.path.join(tmp, "release.tar.gz")
+            payload = b"binary contents"
+            with open(artifact, "wb") as f:
+                f.write(payload)
+            digest = hashlib.sha256(payload).hexdigest()
+            checksums = {"release.tar.gz": digest}
+
+            _verify_sha256(artifact, "release.tar.gz", checksums)
+
+    def test_verify_sha256_aborts_on_mismatch(self):
+        with TemporaryDirectory() as tmp:
+            artifact = os.path.join(tmp, "release.tar.gz")
+            with open(artifact, "wb") as f:
+                f.write(b"tampered contents")
+            checksums = {
+                "release.tar.gz": hashlib.sha256(b"original contents").hexdigest(),
+            }
+
+            with self.assertRaises(SystemExit) as ctx:
+                _verify_sha256(artifact, "release.tar.gz", checksums)
+            self.assertEqual(ctx.exception.code, 1)
+
+    def test_verify_sha256_aborts_when_filename_missing_from_manifest(self):
+        """A novel filename never present in the manifest must NOT be
+        treated as 'no checksum entry → trust' — that would let an
+        attacker drop a new artifact next to legitimate ones."""
+        with TemporaryDirectory() as tmp:
+            artifact = os.path.join(tmp, "evil.tar.gz")
+            with open(artifact, "wb") as f:
+                f.write(b"surprise")
+
+            with self.assertRaises(SystemExit) as ctx:
+                _verify_sha256(artifact, "evil.tar.gz", {"other.tar.gz": "0" * 64})
+            self.assertEqual(ctx.exception.code, 1)
+
+    def test_download_checksums_parses_goreleaser_format(self):
+        """goreleaser writes ``<sha256>  <filename>`` (two-space separator)."""
+        with TemporaryDirectory() as tmp, patch(
+            "defenseclaw.commands.cmd_upgrade.requests.get"
+        ) as get_mock, patch(
+            "defenseclaw.commands.cmd_upgrade._verify_checksums_sigstore"
+        ) as verify_sigstore:
+            sha = "a" * 64
+            body = f"{sha}  defenseclaw_9.9.9_darwin_arm64.tar.gz\n"
+            get_mock.return_value = Mock(status_code=200, content=body.encode())
+
+            result = _download_checksums("9.9.9", tmp)
+
+            verify_sigstore.assert_called_once()
+            self.assertEqual(
+                result, {"defenseclaw_9.9.9_darwin_arm64.tar.gz": sha},
+            )
+
+    def test_download_checksums_normalizes_find_dot_prefix(self):
+        """The Makefile-generated checksum manifest strips this now, but
+        older local builds may contain ``./filename`` from ``find .``."""
+        with TemporaryDirectory() as tmp, patch(
+            "defenseclaw.commands.cmd_upgrade.requests.get"
+        ) as get_mock, patch(
+            "defenseclaw.commands.cmd_upgrade._verify_checksums_sigstore"
+        ):
+            sha = "c" * 64
+            body = f"{sha}  ./upgrade-manifest.json\n"
+            get_mock.return_value = Mock(status_code=200, content=body.encode())
+
+            result = _download_checksums("9.9.9", tmp)
+
+            self.assertEqual(result, {"upgrade-manifest.json": sha})
+
+    def test_download_checksums_returns_none_on_404(self):
+        """Old releases predate goreleaser checksum publication. Caller
+        proceeds with a warning; callable must NOT raise."""
+        with TemporaryDirectory() as tmp, patch(
+            "defenseclaw.commands.cmd_upgrade.requests.get",
+            return_value=Mock(status_code=404, content=b""),
+        ):
+            self.assertIsNone(_download_checksums("9.9.9", tmp))
+
+    def test_download_checksums_rejects_malformed_lines(self):
+        """A 200 with garbage body must NOT parse as 'verified empty
+        manifest' — the caller would silently skip checks."""
+        with TemporaryDirectory() as tmp, patch(
+            "defenseclaw.commands.cmd_upgrade.requests.get"
+        ) as get_mock, patch(
+            "defenseclaw.commands.cmd_upgrade._verify_checksums_sigstore"
+        ):
+            body = "not-a-checksum\nzzz  bad-hex\n"
+            get_mock.return_value = Mock(status_code=200, content=body.encode())
+
+            with self.assertRaises(SystemExit) as ctx:
+                _download_checksums("9.9.9", tmp)
+            self.assertEqual(ctx.exception.code, 1)
+
+    def test_checksums_sigstore_verifies_signed_manifest(self):
+        with TemporaryDirectory() as tmp:
+            checksums = os.path.join(tmp, "checksums.txt")
+            sig = os.path.join(tmp, "checksums.txt.sig")
+            cert = os.path.join(tmp, "checksums.txt.pem")
+            for path in (checksums, sig, cert):
+                with open(path, "wb") as f:
+                    f.write(b"release asset")
+
+            with patch(
+                "defenseclaw.commands.cmd_upgrade._download_optional_release_asset",
+                side_effect=[sig, cert],
+            ), patch(
+                "defenseclaw.commands.cmd_upgrade.shutil.which",
+                return_value="/usr/bin/cosign",
+            ), patch(
+                "defenseclaw.commands.cmd_upgrade.subprocess.run",
+                return_value=Mock(returncode=0, stdout="", stderr=""),
+            ) as run_mock:
+                _verify_checksums_sigstore("9.9.9", tmp, checksums)
+
+        cmd = run_mock.call_args.args[0]
+        self.assertEqual(cmd[0:2], ["/usr/bin/cosign", "verify-blob"])
+        self.assertEqual(
+            cmd[cmd.index("--certificate-identity-regexp") + 1],
+            "^https://github.com/cisco-ai-defense/defenseclaw/.+",
+        )
+        self.assertEqual(
+            cmd[cmd.index("--certificate-oidc-issuer") + 1],
+            "https://token.actions.githubusercontent.com",
+        )
+        self.assertEqual(cmd[-1], checksums)
+
+    def test_checksums_sigstore_hard_fails_when_cosign_rejects_signature(self):
+        with TemporaryDirectory() as tmp:
+            checksums = os.path.join(tmp, "checksums.txt")
+            sig = os.path.join(tmp, "checksums.txt.sig")
+            cert = os.path.join(tmp, "checksums.txt.pem")
+            for path in (checksums, sig, cert):
+                with open(path, "wb") as f:
+                    f.write(b"release asset")
+
+            with patch(
+                "defenseclaw.commands.cmd_upgrade._download_optional_release_asset",
+                side_effect=[sig, cert],
+            ), patch(
+                "defenseclaw.commands.cmd_upgrade.shutil.which",
+                return_value="/usr/bin/cosign",
+            ), patch(
+                "defenseclaw.commands.cmd_upgrade.subprocess.run",
+                return_value=Mock(returncode=1, stdout="", stderr="bad signature"),
+            ), self.assertRaises(SystemExit) as ctx:
+                _verify_checksums_sigstore("9.9.9", tmp, checksums)
+
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_checksums_sigstore_warns_without_cosign_but_does_not_fail(self):
+        with TemporaryDirectory() as tmp:
+            checksums = os.path.join(tmp, "checksums.txt")
+            sig = os.path.join(tmp, "checksums.txt.sig")
+            cert = os.path.join(tmp, "checksums.txt.pem")
+            for path in (checksums, sig, cert):
+                with open(path, "wb") as f:
+                    f.write(b"release asset")
+
+            with patch(
+                "defenseclaw.commands.cmd_upgrade._download_optional_release_asset",
+                side_effect=[sig, cert],
+            ), patch(
+                "defenseclaw.commands.cmd_upgrade.shutil.which",
+                return_value=None,
+            ), patch("defenseclaw.commands.cmd_upgrade.subprocess.run") as run_mock:
+                _verify_checksums_sigstore("9.9.9", tmp, checksums)
+
+        run_mock.assert_not_called()
+
+    def test_download_file_retries_transient_server_errors(self):
+        ok_response = Mock(status_code=200)
+        ok_response.iter_content = Mock(return_value=[b"downloaded"])
+        with TemporaryDirectory() as tmp, patch(
+            "defenseclaw.commands.cmd_upgrade.requests.get",
+            side_effect=[Mock(status_code=503), ok_response],
+        ) as get_mock, patch("defenseclaw.commands.cmd_upgrade.time.sleep") as sleep_mock:
+            dest = os.path.join(tmp, "artifact.bin")
+
+            _download_file("https://example.invalid/artifact.bin", dest)
+
+            with open(dest, "rb") as f:
+                self.assertEqual(f.read(), b"downloaded")
+            self.assertEqual(get_mock.call_count, 2)
+            sleep_mock.assert_called_once_with(1)
+
+    def test_fetch_release_asset_digests_parses_github_digest_field(self):
+        with patch("defenseclaw.commands.cmd_upgrade.requests.get") as get_mock:
+            sha = "b" * 64
+            get_mock.return_value = Mock(
+                json=Mock(return_value={
+                    "assets": [
+                        {
+                            "name": "defenseclaw-9.9.9-py3-none-any.whl",
+                            "digest": f"sha256:{sha}",
+                        },
+                        {
+                            "name": "checksums.txt",
+                            "digest": "sha1:not-used",
+                        },
+                    ],
+                }),
+                raise_for_status=Mock(),
+            )
+
+            result = _fetch_release_asset_digests("9.9.9")
+
+        self.assertEqual(result, {"defenseclaw-9.9.9-py3-none-any.whl": sha})
+
+    def test_missing_manifest_entries_are_filled_from_release_asset_digests(self):
+        checksums = {"defenseclaw_9.9.9_darwin_arm64.tar.gz": "a" * 64}
+        with patch(
+            "defenseclaw.commands.cmd_upgrade._fetch_release_asset_digests",
+            return_value={"defenseclaw-9.9.9-py3-none-any.whl": "b" * 64},
+        ):
+            _fill_missing_checksums_from_release_assets(
+                "9.9.9",
+                checksums,
+                [
+                    "defenseclaw_9.9.9_darwin_arm64.tar.gz",
+                    "defenseclaw-9.9.9-py3-none-any.whl",
+                ],
+            )
+
+        self.assertEqual(checksums["defenseclaw-9.9.9-py3-none-any.whl"], "b" * 64)
+
+
+class TestUpgradeManifest(unittest.TestCase):
+    """Release-owned upgrade manifests let future versions declare upgrade
+    policy even when the local upgrade script is older than the release."""
+
+    def test_validate_rejects_newer_upgrade_protocol(self):
+        payload = {
+            "schema_version": 1,
+            "release_version": "9.9.9",
+            "min_upgrade_protocol": 999,
+            "migration_failure_policy": "fail",
+            "required_cli_migrations": ["9.9.9"],
+        }
+
+        with self.assertRaises(SystemExit) as ctx:
+            _validate_upgrade_manifest(payload, "9.9.9")
+
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_validate_rejects_newer_manifest_schema(self):
+        payload = {
+            "schema_version": 2,
+            "release_version": "9.9.9",
+            "min_upgrade_protocol": 1,
+            "migration_failure_policy": "warn",
+            "required_cli_migrations": [],
+        }
+
+        with self.assertRaises(SystemExit) as ctx:
+            _validate_upgrade_manifest(payload, "9.9.9")
+
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_download_manifest_verifies_checksum_and_parses_policy(self):
+        payload = {
+            "schema_version": 1,
+            "release_version": "9.9.9",
+            "min_upgrade_protocol": 1,
+            "migration_failure_policy": "fail",
+            "required_cli_migrations": ["9.9.9"],
+        }
+        body = json.dumps(payload).encode()
+        digest = hashlib.sha256(body).hexdigest()
+        with TemporaryDirectory() as tmp, patch(
+            "defenseclaw.commands.cmd_upgrade.requests.get",
+            return_value=Mock(status_code=200, content=body),
+        ):
+            manifest = _download_upgrade_manifest(
+                "9.9.9",
+                tmp,
+                {"upgrade-manifest.json": digest},
+            )
+
+        self.assertEqual(manifest["migration_failure_policy"], "fail")
+        self.assertEqual(manifest["required_cli_migrations"], ["9.9.9"])
+
+    def test_required_migration_check_fails_when_cursor_missing_entry(self):
+        manifest = {
+            "migration_failure_policy": "fail",
+            "required_cli_migrations": ["9.9.9"],
+        }
+
+        with TemporaryDirectory() as data_dir, self.assertRaises(SystemExit) as ctx:
+            _assert_required_cli_migrations(manifest, data_dir)
+
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_required_migration_check_warn_policy_does_not_fail(self):
+        manifest = {
+            "migration_failure_policy": "warn",
+            "required_cli_migrations": ["9.9.9"],
+        }
+
+        with TemporaryDirectory() as data_dir:
+            _assert_required_cli_migrations(manifest, data_dir)
+
+    def test_required_migration_check_passes_when_cursor_records_entry(self):
+        from defenseclaw import migration_state
+
+        manifest = {
+            "required_cli_migrations": ["9.9.9"],
+        }
+        with TemporaryDirectory() as data_dir:
+            state = migration_state.MigrationState(
+                package_version="9.9.9",
+                applied=["9.9.9"],
+                applied_at={"9.9.9": "2026-05-19T00:00:00Z"},
+            )
+            migration_state.save(data_dir, state)
+
+            _assert_required_cli_migrations(manifest, data_dir)
+
+
+class TestGatewayTarballExtraction(unittest.TestCase):
+    """Gateway release tarballs are verified before extraction, but the
+    extractor still refuses unsafe or malformed archive contents."""
+
+    @staticmethod
+    def _write_tarball(path, entries):
+        with tarfile.open(path, "w:gz") as tar:
+            for name, payload in entries.items():
+                data = payload.encode()
+                info = tarfile.TarInfo(name)
+                info.size = len(data)
+                info.mode = 0o755
+                tar.addfile(info, io.BytesIO(data))
+
+    def test_download_gateway_extracts_expected_binary(self):
+        with TemporaryDirectory() as tmp:
+
+            def fake_download(_url, dest):
+                self._write_tarball(dest, {"defenseclaw": "#!/bin/sh\n"})
+
+            with patch("defenseclaw.commands.cmd_upgrade._download_file", side_effect=fake_download):
+                binary, tarball_name = _download_gateway("9.9.9", "darwin", "arm64", tmp)
+
+            self.assertEqual(tarball_name, "defenseclaw_9.9.9_darwin_arm64.tar.gz")
+            self.assertTrue(os.path.isfile(binary))
+
+    def test_download_gateway_rejects_path_traversal_tarball(self):
+        with TemporaryDirectory() as tmp:
+
+            def fake_download(_url, dest):
+                self._write_tarball(dest, {"../evil": "nope"})
+
+            with patch("defenseclaw.commands.cmd_upgrade._download_file", side_effect=fake_download):
+                with self.assertRaises(SystemExit) as ctx:
+                    _download_gateway("9.9.9", "darwin", "arm64", tmp)
+            self.assertEqual(ctx.exception.code, 1)
+
+    def test_download_gateway_rejects_tarball_without_binary(self):
+        with TemporaryDirectory() as tmp:
+
+            def fake_download(_url, dest):
+                self._write_tarball(dest, {"README.md": "missing binary"})
+
+            with patch("defenseclaw.commands.cmd_upgrade._download_file", side_effect=fake_download):
+                with self.assertRaises(SystemExit) as ctx:
+                    _download_gateway("9.9.9", "darwin", "arm64", tmp)
+            self.assertEqual(ctx.exception.code, 1)
+
+
+class TestInstallGatewaySnapshotsPrevious(unittest.TestCase):
+    """Robustness: installing the new gateway must snapshot the old one
+    so a failed health check has a documented rollback path."""
+
+    def test_snapshot_created_when_previous_binary_exists(self):
+        with TemporaryDirectory() as fake_home, TemporaryDirectory() as backup_dir, \
+             patch.dict(os.environ, {"HOME": fake_home}):
+            install_dir = os.path.join(fake_home, ".local", "bin")
+            os.makedirs(install_dir)
+            previous = os.path.join(install_dir, "defenseclaw-gateway")
+            with open(previous, "wb") as f:
+                f.write(b"#!/bin/sh\necho old\n")
+            os.chmod(previous, 0o755)
+
+            new_binary = os.path.join(fake_home, "defenseclaw")
+            with open(new_binary, "wb") as f:
+                f.write(b"#!/bin/sh\necho new\n")
+            os.chmod(new_binary, 0o755)
+
+            _install_gateway(new_binary, "linux", backup_dir=backup_dir)
+
+            snapshot = os.path.join(backup_dir, "defenseclaw-gateway.previous")
+            self.assertTrue(
+                os.path.isfile(snapshot),
+                msg="previous gateway should have been copied into backup_dir",
+            )
+            with open(snapshot, "rb") as f:
+                self.assertEqual(f.read(), b"#!/bin/sh\necho old\n")
+            with open(previous, "rb") as f:
+                self.assertEqual(f.read(), b"#!/bin/sh\necho new\n")
+
+    def test_no_snapshot_when_no_previous_binary(self):
+        """A fresh install (no prior gateway) must not fail just because
+        there's nothing to snapshot."""
+        with TemporaryDirectory() as fake_home, TemporaryDirectory() as backup_dir, \
+             patch.dict(os.environ, {"HOME": fake_home}):
+            new_binary = os.path.join(fake_home, "defenseclaw")
+            with open(new_binary, "wb") as f:
+                f.write(b"#!/bin/sh\n")
+            os.chmod(new_binary, 0o755)
+
+            _install_gateway(new_binary, "linux", backup_dir=backup_dir)
+
+            self.assertFalse(
+                os.path.isfile(os.path.join(backup_dir, "defenseclaw-gateway.previous")),
+            )
+
+
+class TestPostInstallVersionVerification(unittest.TestCase):
+    """The freshly-installed gateway must report the expected version, or
+    the upgrade output must surface the discrepancy."""
+
+    def test_warns_when_version_mismatches(self):
+        """An unexpected version string warns but does not abort."""
+        runner = CliRunner()
+        with TemporaryDirectory() as tmp:
+            gateway = os.path.join(tmp, "defenseclaw-gateway")
+            with open(gateway, "w") as f:
+                f.write("#!/bin/sh\n")
+            with patch(
+                "defenseclaw.commands.cmd_upgrade.subprocess.run",
+                return_value=Mock(
+                    stdout="defenseclaw-gateway version 0.5.0 (commit=..., built=...)",
+                    stderr="",
+                ),
+            ):
+                with runner.isolation() as (out, _err, _):
+                    _verify_installed_gateway_version(gateway, "9.9.9")
+                    output = out.getvalue().decode()
+
+        self.assertIn("Gateway version verification failed", output)
+        self.assertIn("expected 9.9.9", output)
+
+    def test_silent_success_when_version_matches(self):
+        runner = CliRunner()
+        with TemporaryDirectory() as tmp:
+            gateway = os.path.join(tmp, "defenseclaw-gateway")
+            with open(gateway, "w") as f:
+                f.write("#!/bin/sh\n")
+            with patch(
+                "defenseclaw.commands.cmd_upgrade.subprocess.run",
+                return_value=Mock(
+                    stdout="defenseclaw-gateway version 9.9.9 (commit=abc, built=2026-05-19)",
+                    stderr="",
+                ),
+            ) as run_mock:
+                with runner.isolation() as (out, _err, _):
+                    _verify_installed_gateway_version(gateway, "9.9.9")
+                    output = out.getvalue().decode()
+
+        self.assertIn("Gateway binary verified", output)
+        self.assertNotIn("verification failed", output)
+        self.assertEqual(run_mock.call_args.args[0][0], gateway)
+
+    def test_handles_missing_binary_gracefully(self):
+        """Missing installed path warns and returns cleanly."""
+        runner = CliRunner()
+        with runner.isolation() as (out, _err, _):
+            _verify_installed_gateway_version("/no/such/defenseclaw-gateway", "9.9.9")
+            output = out.getvalue().decode()
+
+        self.assertIn("Installed gateway binary is missing", output)
+
+
+class TestRunSilentSurfaceErrors(unittest.TestCase):
+    """When a command fails, the operator should see WHY without needing
+    to re-run with --verbose. ``_run_silent`` is the workhorse for
+    gateway start/stop/restart calls."""
+
+    def test_success_path_silent(self):
+        runner = CliRunner()
+        with patch(
+            "defenseclaw.commands.cmd_upgrade.subprocess.run",
+            return_value=Mock(returncode=0, stderr="", stdout=""),
+        ):
+            with runner.isolation() as (out, _err, _):
+                ok = _run_silent(["true"], "Started", "Did not start")
+                output = out.getvalue().decode()
+
+        self.assertTrue(ok)
+        self.assertIn("Started", output)
+        self.assertNotIn("Did not start", output)
+
+    def test_non_zero_exit_surfaces_stderr(self):
+        runner = CliRunner()
+        with patch(
+            "defenseclaw.commands.cmd_upgrade.subprocess.run",
+            return_value=Mock(
+                returncode=1,
+                stderr="Error: port 18970 already in use\nrun: lsof -i :18970",
+                stdout="",
+            ),
+        ):
+            with runner.isolation() as (out, _err, _):
+                ok = _run_silent(["start"], "Started", "Did not start")
+                output = out.getvalue().decode()
+
+        self.assertFalse(ok)
+        self.assertIn("Did not start", output)
+        self.assertIn("port 18970 already in use", output)
+
+    def test_file_not_found_surfaces_exception_message(self):
+        runner = CliRunner()
+        with patch(
+            "defenseclaw.commands.cmd_upgrade.subprocess.run",
+            side_effect=FileNotFoundError(2, "No such file", "missing-bin"),
+        ):
+            with runner.isolation() as (out, _err, _):
+                ok = _run_silent(["missing-bin"], "Started", "Did not start")
+                output = out.getvalue().decode()
+
+        self.assertFalse(ok)
+        self.assertIn("Did not start", output)
+
+
+class TestPostUpgradeDriftCheck(unittest.TestCase):
+    """Drift check must surface mismatched component versions but never
+    block the upgrade — it's an advisory at the end of the flow."""
+
+    def test_drift_warns_with_actionable_message(self):
+        runner = CliRunner()
+        from defenseclaw.commands.cmd_version import Component
+
+        with patch(
+            "defenseclaw.commands.cmd_version._cli_component",
+            return_value=Component(
+                name="cli", version="9.9.9", origin="defenseclaw (python)",
+            ),
+        ), patch(
+            "defenseclaw.commands.cmd_version._gateway_component",
+            return_value=Component(
+                name="gateway", version="9.9.9", origin="/usr/local/bin",
+            ),
+        ), patch(
+            "defenseclaw.commands.cmd_version._plugin_component",
+            return_value=Component(
+                name="plugin", version="0.5.0", origin="~/.openclaw/...",
+            ),
+        ):
+            with runner.isolation() as (out, _err, _):
+                _check_post_upgrade_drift("9.9.9")
+                output = out.getvalue().decode()
+
+        self.assertIn("Component drift detected", output)
+        self.assertIn("plugin", output)
+        self.assertIn("9.9.9", output)
+
+    def test_no_drift_means_no_output(self):
+        runner = CliRunner()
+        from defenseclaw.commands.cmd_version import Component
+
+        with patch(
+            "defenseclaw.commands.cmd_version._cli_component",
+            return_value=Component(
+                name="cli", version="9.9.9", origin="defenseclaw (python)",
+            ),
+        ), patch(
+            "defenseclaw.commands.cmd_version._gateway_component",
+            return_value=Component(
+                name="gateway", version="9.9.9", origin="/usr/local/bin",
+            ),
+        ), patch(
+            "defenseclaw.commands.cmd_version._plugin_component",
+            return_value=Component(
+                name="plugin", version="9.9.9", origin="~/.openclaw/...",
+            ),
+        ):
+            with runner.isolation() as (out, _err, _):
+                _check_post_upgrade_drift("9.9.9")
+                output = out.getvalue().decode()
+
+        self.assertNotIn("drift", output.lower())
+
+
+class TestMigrationCursorSummary(unittest.TestCase):
+    """The migration cursor is the source of truth for 'which migrations
+    have observably executed.' Surface it in upgrade output so a partial-
+    failure host is debuggable from a single log."""
+
+    def test_summary_includes_applied_versions(self):
+        runner = CliRunner()
+        from defenseclaw import migration_state
+
+        with TemporaryDirectory() as data_dir:
+            state = migration_state.MigrationState(
+                package_version="9.9.9",
+                applied=["0.3.0", "0.4.0", "0.5.0"],
+                applied_at={
+                    "0.3.0": "2026-01-01T00:00:00Z",
+                    "0.4.0": "2026-02-01T00:00:00Z",
+                    "0.5.0": "2026-03-01T00:00:00Z",
+                },
+            )
+            migration_state.save(data_dir, state)
+
+            with runner.isolation() as (out, _err, _):
+                _print_migration_cursor_summary(data_dir)
+                output = out.getvalue().decode()
+
+        self.assertIn("cursor:", output)
+        self.assertIn("0.3.0", output)
+        self.assertIn("0.4.0", output)
+        self.assertIn("0.5.0", output)
+
+    def test_summary_silent_when_cursor_absent(self):
+        """Missing cursor file → silent. The caller already prints
+        'No migrations needed' which is enough context."""
+        runner = CliRunner()
+        with TemporaryDirectory() as data_dir:
+            with runner.isolation() as (out, _err, _):
+                _print_migration_cursor_summary(data_dir)
+                output = out.getvalue().decode()
+
+        self.assertEqual(output.strip(), "")

--- a/cli/tests/test_release_invariants.py
+++ b/cli/tests/test_release_invariants.py
@@ -41,6 +41,7 @@ Run on every ``pytest`` invocation (no ``@unittest.skip`` markers).
 from __future__ import annotations
 
 import re
+import runpy
 import unittest
 from pathlib import Path
 
@@ -143,6 +144,17 @@ class TestReleaseInvariants(unittest.TestCase):
             len(set(versions)),
             f"duplicate migration version in registry: {versions}",
         )
+
+    def test_upgrade_manifest_generator_requires_known_migrations(self):
+        """Future releases ship an upgrade-manifest.json so old local
+        upgrade scripts can enforce mandatory migrations. The generated
+        manifest must include every migration version at or below the
+        package version."""
+        generator = runpy.run_path(str(_REPO_ROOT / "scripts" / "generate-upgrade-manifest.py"))
+        manifest = generator["build_manifest"]()
+        expected = [version for version, _desc, _fn in MIGRATIONS if _ver_tuple(version) <= _ver_tuple(__version__)]
+        self.assertEqual(manifest["release_version"], __version__)
+        self.assertEqual(manifest["required_cli_migrations"], expected)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/scripts/generate-upgrade-manifest.py
+++ b/scripts/generate-upgrade-manifest.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate the release-owned upgrade manifest.
+
+The installed upgrade script is intentionally stable: it may be months older
+than the release it is installing. This manifest gives each release a small,
+validated contract that old upgraders can read before they make changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+UPGRADE_PROTOCOL_VERSION = 1
+
+
+def _ver_tuple(value: str) -> tuple[int, int, int]:
+    if not SEMVER_RE.fullmatch(value):
+        raise ValueError(f"invalid semver {value!r}; expected X.Y.Z")
+    major, minor, patch = value.split(".")
+    return int(major), int(minor), int(patch)
+
+
+def _regex_version(path: Path, pattern: str, label: str) -> str:
+    text = path.read_text(encoding="utf-8")
+    match = re.search(pattern, text, re.MULTILINE)
+    if not match:
+        raise RuntimeError(f"could not find {label} version in {path}")
+    version = match.group(1)
+    _ver_tuple(version)
+    return version
+
+
+def current_version() -> str:
+    versions = {
+        "pyproject.toml": _regex_version(
+            ROOT / "pyproject.toml",
+            r'^version\s*=\s*"([^"]+)"',
+            "pyproject",
+        ),
+        "cli/defenseclaw/__init__.py": _regex_version(
+            ROOT / "cli" / "defenseclaw" / "__init__.py",
+            r'^__version__\s*=\s*"([^"]+)"',
+            "__version__",
+        ),
+        "Makefile": _regex_version(
+            ROOT / "Makefile",
+            r"^VERSION\s*:=\s*([0-9]+\.[0-9]+\.[0-9]+)",
+            "Makefile",
+        ),
+        "extensions/defenseclaw/package.json": _regex_version(
+            ROOT / "extensions" / "defenseclaw" / "package.json",
+            r'^\s*"version":\s*"([^"]+)"',
+            "package.json",
+        ),
+    }
+    unique = set(versions.values())
+    if len(unique) != 1:
+        details = "\n".join(f"  {path}: {version}" for path, version in versions.items())
+        raise RuntimeError(f"version drift detected:\n{details}")
+    return unique.pop()
+
+
+def migration_versions() -> list[str]:
+    path = ROOT / "cli" / "defenseclaw" / "migrations.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in tree.body:
+        value: ast.AST | None = None
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "MIGRATIONS" for target in node.targets
+        ):
+            value = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.target.id == "MIGRATIONS":
+                value = node.value
+        if value is None:
+            continue
+        if not isinstance(value, ast.List):
+            raise RuntimeError("MIGRATIONS must be a list literal")
+        versions: list[str] = []
+        for item in value.elts:
+            if not isinstance(item, ast.Tuple) or not item.elts:
+                raise RuntimeError("each MIGRATIONS entry must be a tuple")
+            version_node = item.elts[0]
+            if not isinstance(version_node, ast.Constant) or not isinstance(version_node.value, str):
+                raise RuntimeError("each MIGRATIONS entry must start with a string version")
+            _ver_tuple(version_node.value)
+            versions.append(version_node.value)
+        expected = sorted(versions, key=_ver_tuple)
+        if versions != expected:
+            raise RuntimeError(f"MIGRATIONS must be sorted ascending: got {versions}, want {expected}")
+        if len(versions) != len(set(versions)):
+            raise RuntimeError(f"MIGRATIONS contains duplicates: {versions}")
+        return versions
+    raise RuntimeError("MIGRATIONS registry not found")
+
+
+def build_manifest() -> dict[str, Any]:
+    version = current_version()
+    migrations = migration_versions()
+    current_t = _ver_tuple(version)
+    future = [migration for migration in migrations if _ver_tuple(migration) > current_t]
+    if future:
+        raise RuntimeError(
+            "migration registry contains versions newer than the package version "
+            f"{version}: {', '.join(future)}. Bump the release version first."
+        )
+
+    required = [migration for migration in migrations if _ver_tuple(migration) <= current_t]
+    return {
+        "schema_version": 1,
+        "release_version": version,
+        "min_upgrade_protocol": UPGRADE_PROTOCOL_VERSION,
+        "migration_failure_policy": "fail" if required else "warn",
+        "required_cli_migrations": required,
+        "generated_by": "scripts/generate-upgrade-manifest.py",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, help="write manifest JSON to this path")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="validate the manifest contract without writing an artifact",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        manifest = build_manifest()
+    except Exception as exc:  # noqa: BLE001 - print concise CI diagnostics
+        print(f"upgrade manifest check failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(f"wrote {args.out}")
+    elif not args.check:
+        print(json.dumps(manifest, indent=2, sort_keys=True))
+    else:
+        print(
+            "upgrade manifest OK: "
+            f"{manifest['release_version']} "
+            f"({len(manifest['required_cli_migrations'])} required migration(s))"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -52,6 +52,8 @@ readonly INSTALL_DIR="${HOME}/.local/bin"
 readonly OPENCLAW_HOME="${OPENCLAW_HOME:-${HOME}/.openclaw}"
 readonly BACKUP_ROOT="${DEFENSECLAW_HOME}/backups"
 readonly REPO="cisco-ai-defense/defenseclaw"
+readonly UPGRADE_PROTOCOL_VERSION=1
+readonly UPGRADE_MANIFEST_NAME="upgrade-manifest.json"
 
 # ── Terminal Formatting ───────────────────────────────────────────────────────
 
@@ -74,6 +76,12 @@ step()    { printf "  ${CYAN}→${NC} %s\n" "$*"; }
 
 die() { err "$@"; exit 1; }
 has() { command -v "$1" &>/dev/null; }
+
+validate_version() {
+    local version="$1"
+    [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+        || die "Invalid release version: ${version}. Expected MAJOR.MINOR.PATCH."
+}
 
 # ── Argument Parsing ──────────────────────────────────────────────────────────
 
@@ -143,6 +151,7 @@ section "Resolving Release Version"
 
 if [[ -n "${RELEASE_VERSION}" ]]; then
     RELEASE_VERSION="${RELEASE_VERSION#v}"
+    validate_version "${RELEASE_VERSION}"
     ok "Target version: ${RELEASE_VERSION}"
 else
     info "Fetching latest release from GitHub..."
@@ -151,6 +160,7 @@ else
         || die "Failed to fetch latest release. Use --version x.y.z to specify explicitly."
     [[ -n "${RELEASE_VERSION}" ]] \
         || die "Could not parse latest release version. Use --version x.y.z to specify explicitly."
+    validate_version "${RELEASE_VERSION}"
     ok "Latest release: ${RELEASE_VERSION}"
 fi
 
@@ -178,16 +188,42 @@ fi
 
 fetch_artifact() {
     local url="$1" dest="$2"
-    curl -sSfL "${url}" -o "${dest}" \
-        || die "Failed to download: ${url}"
+    local attempt
+    for attempt in 1 2 3; do
+        if curl -sSfL "${url}" -o "${dest}"; then
+            return 0
+        fi
+        [[ "${attempt}" -lt 3 ]] || break
+        sleep $((2 ** (attempt - 1)))
+    done
+    die "Failed to download: ${url}"
+}
+
+fetch_optional_artifact() {
+    local url="$1" dest="$2"
+    local attempt
+    for attempt in 1 2 3; do
+        if curl -sSfL "${url}" -o "${dest}" 2>/dev/null; then
+            return 0
+        fi
+        [[ "${attempt}" -lt 3 ]] || break
+        sleep $((2 ** (attempt - 1)))
+    done
+    return 1
 }
 
 # ── Pre-flight: verify artifacts exist before touching anything ───────────────
 
 section "Pre-flight Check"
 
-TARBALL_URL="https://github.com/${REPO}/releases/download/${RELEASE_VERSION}/defenseclaw_${RELEASE_VERSION}_${OS}_${ARCH_NORM}.tar.gz"
-WHL_URL="https://github.com/${REPO}/releases/download/${RELEASE_VERSION}/defenseclaw-${RELEASE_VERSION}-py3-none-any.whl"
+TARBALL_NAME="defenseclaw_${RELEASE_VERSION}_${OS}_${ARCH_NORM}.tar.gz"
+WHL_NAME="defenseclaw-${RELEASE_VERSION}-py3-none-any.whl"
+TARBALL_URL="https://github.com/${REPO}/releases/download/${RELEASE_VERSION}/${TARBALL_NAME}"
+WHL_URL="https://github.com/${REPO}/releases/download/${RELEASE_VERSION}/${WHL_NAME}"
+CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${RELEASE_VERSION}/checksums.txt"
+CHECKSUMS_SIG_URL="${CHECKSUMS_URL}.sig"
+CHECKSUMS_CERT_URL="${CHECKSUMS_URL}.pem"
+UPGRADE_MANIFEST_URL="https://github.com/${REPO}/releases/download/${RELEASE_VERSION}/${UPGRADE_MANIFEST_NAME}"
 
 for artifact_url in "${TARBALL_URL}" "${WHL_URL}"; do
     http_code=$(curl -sSo /dev/null -w "%{http_code}" -L --head "${artifact_url}" 2>/dev/null || echo "000")
@@ -205,14 +241,256 @@ section "Downloading Artifacts"
 STAGING_DIR="$(mktemp -d)"
 trap 'rm -rf "${STAGING_DIR}"' EXIT
 
+# Pull checksums.txt FIRST so every downloaded artifact is verified against
+# the published goreleaser manifest. Old releases may not publish one; in
+# that case we proceed with a clear warning rather than blocking the
+# upgrade. ``CHECKSUMS_FILE=""`` signals "no manifest available" downstream.
+CHECKSUMS_FILE=""
+CHECKSUMS_SIG_FILE=""
+CHECKSUMS_CERT_FILE=""
+ASSET_DIGESTS_FILE=""
+UPGRADE_MANIFEST_FILE=""
+MIGRATION_FAILURE_POLICY="warn"
+REQUIRED_MIGRATIONS_MISSING=""
+UPGRADE_INCOMPLETE=0
+if fetch_optional_artifact "${CHECKSUMS_URL}" "${STAGING_DIR}/checksums.txt"; then
+    CHECKSUMS_FILE="${STAGING_DIR}/checksums.txt"
+    ok "Checksum manifest downloaded (checksums.txt)"
+else
+    warn "checksums.txt unavailable — release artifacts will be downloaded WITHOUT integrity verification"
+fi
+
+if [[ -n "${CHECKSUMS_FILE}" ]]; then
+    if fetch_optional_artifact "${CHECKSUMS_SIG_URL}" "${STAGING_DIR}/checksums.txt.sig"; then
+        CHECKSUMS_SIG_FILE="${STAGING_DIR}/checksums.txt.sig"
+    fi
+    if fetch_optional_artifact "${CHECKSUMS_CERT_URL}" "${STAGING_DIR}/checksums.txt.pem"; then
+        CHECKSUMS_CERT_FILE="${STAGING_DIR}/checksums.txt.pem"
+    fi
+fi
+
+fetch_asset_digests() {
+    [[ -n "${ASSET_DIGESTS_FILE}" ]] && return 0
+    command -v python3 &>/dev/null || return 1
+
+    local release_json="${STAGING_DIR}/release-assets.json"
+    local digests="${STAGING_DIR}/asset-digests.txt"
+    curl -sSfL "https://api.github.com/repos/${REPO}/releases/tags/${RELEASE_VERSION}" \
+        -o "${release_json}" 2>/dev/null || return 1
+    python3 - "${release_json}" > "${digests}" <<'PY' || return 1
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    data = json.load(fh)
+
+for asset in data.get("assets", []):
+    name = asset.get("name")
+    digest = asset.get("digest") or ""
+    if not isinstance(name, str) or not isinstance(digest, str):
+        continue
+    if not digest.startswith("sha256:"):
+        continue
+    sha = digest.split(":", 1)[1]
+    if len(sha) == 64 and all(c in "0123456789abcdefABCDEF" for c in sha):
+        print(sha.lower(), name)
+PY
+    [[ -s "${digests}" ]] || return 1
+    ASSET_DIGESTS_FILE="${digests}"
+}
+
+# Pick a sha256 implementation once, up-front, so verify_checksum below is
+# branch-free in the hot path.
+SHA256_CMD=""
+if command -v sha256sum &>/dev/null; then
+    SHA256_CMD="sha256sum"
+elif command -v shasum &>/dev/null; then
+    SHA256_CMD="shasum -a 256"
+else
+    if [[ -n "${CHECKSUMS_FILE}" ]]; then
+        die "Neither sha256sum nor shasum found — cannot verify release checksums"
+    fi
+fi
+
+verify_checksum() {
+    local file="$1" filename="$2"
+    [[ -z "${CHECKSUMS_FILE}" ]] && ! fetch_asset_digests && return 0
+    local expected actual
+    expected=""
+    if [[ -n "${CHECKSUMS_FILE}" ]]; then
+        expected="$(awk -v f="${filename}" '$2 == f || $2 == "./" f {print $1; exit}' "${CHECKSUMS_FILE}")"
+    fi
+    if [[ -z "${expected}" ]] && fetch_asset_digests; then
+        expected="$(awk -v f="${filename}" '$2 == f {print $1; exit}' "${ASSET_DIGESTS_FILE}")"
+        [[ -n "${expected}" ]] \
+            && warn "checksums.txt missing ${filename}; using GitHub release asset digest."
+    fi
+    if [[ -z "${expected}" ]]; then
+        die "No checksum entry for ${filename} in checksums.txt or GitHub asset metadata — refusing to install an unrecognized artifact"
+    fi
+    [[ -n "${SHA256_CMD}" ]] \
+        || die "No sha256 tool found — cannot verify ${filename}"
+    actual="$(${SHA256_CMD} "${file}" | awk '{print $1}')"
+    # tr-based lowercasing because macOS ships bash 3.2 where ``${var,,}`` is unavailable.
+    expected="$(printf '%s' "${expected}" | tr '[:upper:]' '[:lower:]')"
+    actual="$(printf '%s' "${actual}" | tr '[:upper:]' '[:lower:]')"
+    if [[ "${expected}" != "${actual}" ]]; then
+        die "Checksum mismatch for ${filename}: expected ${expected}, got ${actual}
+  Refusing to install — possible tampering or corrupted download."
+    fi
+}
+
+verify_checksums_sigstore() {
+    [[ -z "${CHECKSUMS_FILE}" ]] && return 0
+    if [[ -z "${CHECKSUMS_SIG_FILE}" && -z "${CHECKSUMS_CERT_FILE}" ]]; then
+        return 0
+    fi
+    if [[ -z "${CHECKSUMS_SIG_FILE}" || -z "${CHECKSUMS_CERT_FILE}" ]]; then
+        warn "checksums.txt Sigstore signature assets are incomplete; continuing without signature verification."
+        return 0
+    fi
+    if ! command -v cosign >/dev/null 2>&1; then
+        warn "checksums.txt Sigstore signature is present, but cosign was not found on PATH; continuing without signature verification."
+        return 0
+    fi
+
+    local cosign_output
+    if ! cosign_output="$(cosign verify-blob \
+        --certificate "${CHECKSUMS_CERT_FILE}" \
+        --signature "${CHECKSUMS_SIG_FILE}" \
+        --certificate-identity-regexp "^https://github.com/${REPO}/.+" \
+        --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+        "${CHECKSUMS_FILE}" 2>&1)"; then
+        err "checksums.txt Sigstore signature verification failed."
+        printf '%s\n' "${cosign_output}" | head -5 >&2
+        exit 1
+    fi
+    ok "Checksum signature verified (Sigstore)"
+}
+
+print_new_upgrade_script_hint() {
+    info "    Use the upgrade script shipped with that release:"
+    info "    curl -fsSL https://raw.githubusercontent.com/${REPO}/${RELEASE_VERSION}/scripts/upgrade.sh | bash -s -- --version ${RELEASE_VERSION}"
+}
+
+manifest_value() {
+    local key="$1" path="$2"
+    python3 - "${key}" "${path}" <<'PY'
+import json
+import sys
+
+key = sys.argv[1]
+path = sys.argv[2]
+with open(path, encoding="utf-8") as fh:
+    value = json.load(fh).get(key, "")
+if isinstance(value, bool):
+    raise SystemExit(1)
+if isinstance(value, (str, int)):
+    print(value)
+elif value is None:
+    print("")
+else:
+    raise SystemExit(1)
+PY
+}
+
+load_upgrade_manifest() {
+    local manifest_path="${STAGING_DIR}/${UPGRADE_MANIFEST_NAME}"
+    if ! fetch_optional_artifact "${UPGRADE_MANIFEST_URL}" "${manifest_path}"; then
+        return 0
+    fi
+
+    verify_checksum "${manifest_path}" "${UPGRADE_MANIFEST_NAME}"
+
+    local schema_version release_version min_protocol policy
+    schema_version="$(manifest_value "schema_version" "${manifest_path}")" \
+        || die "Could not parse ${UPGRADE_MANIFEST_NAME}"
+    release_version="$(manifest_value "release_version" "${manifest_path}")" \
+        || die "Could not parse ${UPGRADE_MANIFEST_NAME}"
+    min_protocol="$(manifest_value "min_upgrade_protocol" "${manifest_path}")" \
+        || die "Could not parse ${UPGRADE_MANIFEST_NAME}"
+    policy="$(manifest_value "migration_failure_policy" "${manifest_path}")" \
+        || die "Could not parse ${UPGRADE_MANIFEST_NAME}"
+
+    [[ -z "${schema_version}" ]] \
+        && die "${UPGRADE_MANIFEST_NAME} missing integer schema_version"
+    [[ "${schema_version}" =~ ^[0-9]+$ ]] \
+        || die "${UPGRADE_MANIFEST_NAME} schema_version must be an integer"
+    if [[ "${schema_version}" -gt 1 ]]; then
+        warn "Release ${RELEASE_VERSION} uses upgrade manifest schema ${schema_version}, which this upgrader does not understand."
+        print_new_upgrade_script_hint
+        exit 1
+    fi
+
+    [[ "${release_version}" == "${RELEASE_VERSION}" ]] \
+        || die "${UPGRADE_MANIFEST_NAME} release_version mismatch: expected ${RELEASE_VERSION}, got ${release_version:-<missing>}"
+
+    [[ -z "${min_protocol}" ]] && min_protocol=1
+    [[ "${min_protocol}" =~ ^[0-9]+$ ]] \
+        || die "${UPGRADE_MANIFEST_NAME} min_upgrade_protocol must be an integer"
+    if [[ "${min_protocol}" -gt "${UPGRADE_PROTOCOL_VERSION}" ]]; then
+        warn "Release ${RELEASE_VERSION} requires upgrade protocol ${min_protocol}, but this upgrader supports ${UPGRADE_PROTOCOL_VERSION}."
+        print_new_upgrade_script_hint
+        exit 1
+    fi
+
+    [[ -z "${policy}" ]] && policy="warn"
+    case "${policy}" in
+        warn|fail) MIGRATION_FAILURE_POLICY="${policy}" ;;
+        *) die "${UPGRADE_MANIFEST_NAME} has invalid migration_failure_policy: ${policy}" ;;
+    esac
+
+    UPGRADE_MANIFEST_FILE="${manifest_path}"
+    ok "Upgrade manifest loaded"
+}
+
+validate_tarball_members() {
+    local archive="$1" listing details entry mode
+    listing="$(tar -tzf "${archive}")" \
+        || die "Could not inspect gateway tarball before extraction"
+    while IFS= read -r entry; do
+        [[ -z "${entry}" ]] && continue
+        case "${entry}" in
+            /*|..|../*|*/..|*/../*)
+                die "Unsafe gateway tarball entry: ${entry}"
+                ;;
+        esac
+    done <<< "${listing}"
+
+    details="$(tar -tvzf "${archive}")" \
+        || die "Could not inspect gateway tarball metadata before extraction"
+    while IFS= read -r entry; do
+        [[ -z "${entry}" ]] && continue
+        mode="${entry%% *}"
+        case "${mode}" in
+            l*|h*)
+                die "Unsafe gateway tarball link entry: ${entry}"
+                ;;
+            -*|d*) ;;
+            *)
+                die "Unsupported gateway tarball entry type: ${entry}"
+                ;;
+        esac
+    done <<< "${details}"
+}
+
+verify_checksums_sigstore
+load_upgrade_manifest
+
 step "Downloading gateway binary ..."
-fetch_artifact "${TARBALL_URL}" "${STAGING_DIR}/gateway.tar.gz"
-tar -xzf "${STAGING_DIR}/gateway.tar.gz" -C "${STAGING_DIR}"
+fetch_artifact "${TARBALL_URL}" "${STAGING_DIR}/${TARBALL_NAME}"
+verify_checksum "${STAGING_DIR}/${TARBALL_NAME}" "${TARBALL_NAME}"
+validate_tarball_members "${STAGING_DIR}/${TARBALL_NAME}"
+tar -xzf "${STAGING_DIR}/${TARBALL_NAME}" -C "${STAGING_DIR}" \
+    || die "Could not extract gateway tarball"
+[[ -f "${STAGING_DIR}/defenseclaw" ]] \
+    || die "Gateway tarball did not contain the expected defenseclaw binary"
 ok "Gateway binary downloaded"
 
 step "Downloading Python CLI wheel ..."
-whl_name="defenseclaw-${RELEASE_VERSION}-py3-none-any.whl"
+whl_name="${WHL_NAME}"
 fetch_artifact "${WHL_URL}" "${STAGING_DIR}/${whl_name}"
+verify_checksum "${STAGING_DIR}/${whl_name}" "${whl_name}"
 ok "Python CLI wheel downloaded"
 
 # ── Confirm ───────────────────────────────────────────────────────────────────
@@ -276,6 +554,18 @@ defenseclaw-gateway stop 2>/dev/null && ok "Gateway stopped" || warn "Gateway wa
 section "Installing Artifacts"
 
 mkdir -p "${INSTALL_DIR}"
+
+# Snapshot the previous gateway binary so the operator can roll back
+# manually if the new binary fails health check. Keeps the upgrade
+# truly non-destructive — even in the worst case the previous binary
+# is one ``cp`` away.
+if [[ -f "${INSTALL_DIR}/defenseclaw-gateway" ]]; then
+    cp "${INSTALL_DIR}/defenseclaw-gateway" "${BACKUP_DIR}/defenseclaw-gateway.previous" \
+        && chmod +x "${BACKUP_DIR}/defenseclaw-gateway.previous" \
+        && ok "Snapshotted previous gateway → ${BACKUP_DIR}/defenseclaw-gateway.previous" \
+        || warn "Could not snapshot previous gateway binary"
+fi
+
 cp "${STAGING_DIR}/defenseclaw" "${INSTALL_DIR}/defenseclaw-gateway"
 chmod +x "${INSTALL_DIR}/defenseclaw-gateway"
 
@@ -283,6 +573,17 @@ if [[ "${OS}" == "darwin" ]]; then
     codesign -f -s - "${INSTALL_DIR}/defenseclaw-gateway" 2>/dev/null || true
 fi
 ok "Gateway binary installed"
+
+# Verify the freshly-installed binary reports the expected version. A
+# truncated tarball or failed copy surfaces here as a warning instead of
+# as a confusing post-deploy bug report.
+gw_version_output="$("${INSTALL_DIR}/defenseclaw-gateway" --version 2>&1 || true)"
+if printf '%s' "${gw_version_output}" | grep -Fq "${RELEASE_VERSION}"; then
+    ok "Gateway binary verified (${RELEASE_VERSION})"
+else
+    warn "Gateway version verification failed: expected ${RELEASE_VERSION}"
+    info "    binary reported: $(printf '%s' "${gw_version_output}" | head -n1 | cut -c1-200)"
+fi
 
 UV_BIN="$(command -v uv 2>/dev/null || true)"
 [[ -z "${UV_BIN}" ]] \
@@ -346,6 +647,49 @@ else
     ok "Applied ${MIGRATION_COUNT} migration(s)"
 fi
 
+if [[ -n "${UPGRADE_MANIFEST_FILE}" ]]; then
+    if ! REQUIRED_MIGRATIONS_MISSING="$(
+        MIGRATION_DEFENSECLAW_HOME="${DEFENSECLAW_HOME}" \
+        "${VENV_PYTHON}" - "${UPGRADE_MANIFEST_FILE}" <<'PY'
+import json
+import os
+import sys
+
+from defenseclaw import migration_state
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    manifest = json.load(fh)
+
+required = manifest.get("required_cli_migrations", [])
+if not isinstance(required, list):
+    raise SystemExit("required_cli_migrations must be a list")
+
+data_dir = os.environ["MIGRATION_DEFENSECLAW_HOME"]
+state = migration_state.load(data_dir)
+missing = [
+    version
+    for version in required
+    if isinstance(version, str) and not migration_state.is_applied(state, version)
+]
+print("\n".join(missing))
+PY
+    )"; then
+        MIGRATION_FAILED=1
+        REQUIRED_MIGRATIONS_MISSING="unable to inspect migration cursor"
+    fi
+fi
+
+if [[ -n "${REQUIRED_MIGRATIONS_MISSING}" ]]; then
+    migration_label="Expected"
+    [[ "${MIGRATION_FAILURE_POLICY}" == "fail" ]] && migration_label="Required"
+    warn "${migration_label} migration(s) were not recorded: $(printf '%s' "${REQUIRED_MIGRATIONS_MISSING}" | tr '\n' ' ')"
+    MIGRATION_FAILED=1
+fi
+
+if [[ "${MIGRATION_FAILURE_POLICY}" == "fail" && "${MIGRATION_FAILED}" -eq 1 ]]; then
+    UPGRADE_INCOMPLETE=1
+fi
+
 # ── Start services ────────────────────────────────────────────────────────────
 
 section "Starting Services"
@@ -393,7 +737,11 @@ while [[ "${ELAPSED}" -lt "${HEALTH_TIMEOUT}" ]]; do
     rm -f /tmp/dc-upgrade-health.$$
 
     if [[ "${HTTP_CODE}" == "200" && -n "${STATUS}" ]]; then
-        GW_STATE=$(echo "${STATUS}" | grep -oE '"state":"[^"]*"' | head -1 | grep -oE '"[^"]*"$' | tr -d '"' || echo "unknown")
+        GW_STATE=$(printf '%s' "${STATUS}" \
+            | grep -oE '"state"[[:space:]]*:[[:space:]]*"[^"]*"' \
+            | head -1 \
+            | sed -E 's/.*"state"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' \
+            || echo "unknown")
         if [[ -z "${GW_STATE}" ]]; then
             GW_STATE="unknown"
         fi
@@ -423,11 +771,36 @@ fi
 
 # ── Done ──────────────────────────────────────────────────────────────────────
 
+if [[ "${UPGRADE_INCOMPLETE}" -eq 1 ]]; then
+    section "Upgrade Incomplete"
+    warn "Release ${RELEASE_VERSION} marked its migrations as mandatory, but they did not complete cleanly."
+    printf "\n"
+    printf "  Backup saved to: ${DIM}${BACKUP_DIR}${NC}\n"
+    info "Run: defenseclaw migrations status"
+    info "Then re-run: defenseclaw upgrade --version ${RELEASE_VERSION}"
+    printf "\n"
+    exit 1
+fi
+
 section "Upgrade Complete"
 
 ok "DefenseClaw upgraded: ${CURRENT_VERSION} → ${RELEASE_VERSION}"
 printf "\n"
 printf "  Backup saved to: ${DIM}${BACKUP_DIR}${NC}\n"
+
+# Surface component drift now (rather than waiting for the operator to
+# discover it next time they run ``defenseclaw version``). Use the CLI's
+# machine-readable report so this script is not coupled to human copy.
+if has defenseclaw && command -v python3 >/dev/null 2>&1; then
+    if drift_output="$(defenseclaw version --json --no-drift-exit 2>/dev/null)"; then
+        if printf '%s' "${drift_output}" | python3 -c 'import json,sys; data=json.load(sys.stdin); raise SystemExit(0 if not data.get("ok", True) else 1)'; then
+            printf "\n"
+            warn "Component drift detected after upgrade — run \`defenseclaw version\` for details"
+            warn "If the plugin is out of sync, reinstall it from the ${RELEASE_VERSION} release tarball"
+        fi
+    fi
+fi
+
 printf "\n"
 
 } # end main()


### PR DESCRIPTION
## Problem

`defenseclaw upgrade` had three trust gaps that compounded into one
class of bug — *"the upgrader installs whatever the network gives it
and then crashes if anything goes sideways"*:

1. **No artifact integrity.** Tarballs and wheels were downloaded
   straight from the GitHub release URL and trusted on transport
   authority alone. A man-in-the-middle, a poisoned CDN edge, or a
   corrupted asset would install silently.
2. **No forward-compat handoff.** The local upgrader is installed on
   the operator's machine and may be months older than the release
   it is installing. There was no mechanism for a future release to
   say *"don't try to install me with that old upgrader — here is
   the curl command for the right one."*
3. **Crashes on missing optionals.** A real failure: when the
   `openclaw` CLI was not installed, `subprocess.run(["openclaw",
   "gateway", "restart"])` raised `FileNotFoundError` *after* services
   had already restarted, leaving the host in a half-upgraded state
   and the operator with a Python traceback instead of a remediation.

Symptoms encountered:

```
FileNotFoundError: [Errno 2] No such file or directory: 'openclaw'
```

…fired during a `defenseclaw upgrade 0.6.1` run on a host without
the OpenClaw CLI. Backups had been taken; gateway was restarted; CLI
wheel was installed; then the script crashed on the optional plugin
restart.

A separate finding from real-world traffic: `checksums.txt` for the
0.5.0 release does not list `defenseclaw-0.5.0-py3-none-any.whl`
(GoReleaser timing — the wheel is attached after `checksums.txt` is
finalized). Without a fallback, a checksum-strict upgrader would
refuse to install released wheels.

## Current Situation

The upgrade flow lives in two surfaces that have to agree:

- `cli/defenseclaw/commands/cmd_upgrade.py` — the Python entry point
  invoked by `defenseclaw upgrade`
- `scripts/upgrade.sh` — the bash entry point invoked by `curl … |
  bash` in install/upgrade docs

Before this change:

- Both downloaded artifacts via `curl`/`requests.get` and called
  `tar -xzf` on the result. No SHA-256 check, no Sigstore check, no
  tarball-member validation.
- The release pipeline already published `checksums.txt.sig` and
  `checksums.txt.pem` (verified live: 0.5.0 has both as release
  assets), but no consumer ever ran `cosign verify-blob` against
  them, making the signing step cosmetic.
- Migrations ran but their cursor was never inspected post-run, so
  a partial-failure (migration ran but didn't record) was invisible
  to the operator.
- Component drift between cli / gateway / plugin was only surfaced
  the next time the operator happened to run `defenseclaw version`.
- The previous gateway binary was overwritten with no snapshot, so
  rolling back required rebuilding from source.

## Solution

Build the integrity chain end-to-end and give the release the ability
to dictate upgrade policy:

1. **Sigstore root of trust.** `cosign verify-blob` runs over
   `checksums.txt` using the GitHub Actions OIDC identity for this
   repo (`^https://github.com/cisco-ai-defense/defenseclaw/.+`,
   issuer `https://token.actions.githubusercontent.com`). If `cosign`
   is not installed locally, we warn and proceed (graceful
   degradation — an old host shouldn't be unable to upgrade just
   because cosign is missing). If `cosign` rejects the signature,
   we hard-fail before touching anything.
2. **Artifact verification.** Every downloaded artifact is
   SHA-256-checked against `checksums.txt`. Releases where the
   manifest is missing a known artifact (such as the 0.5.0 wheel
   case described above) fall back to GitHub's per-asset `digest`
   field (`sha256:<hex>`) — bounded fallback that only fills
   *missing* entries and warns each time it's used.
3. **Release-owned `upgrade-manifest.json`.** Generated by
   `scripts/generate-upgrade-manifest.py` from the source of truth
   (`MIGRATIONS` registry parsed via AST, not import) and validated
   in CI by `make check-upgrade-manifest`. Carries:
   - `schema_version` — refuses newer schemas with a clean error
   - `min_upgrade_protocol` — refuses older upgraders with the curl
     command for the release-shipped script
   - `required_cli_migrations` — list of migrations whose cursor
     entry must exist post-upgrade
   - `migration_failure_policy: warn|fail` — escape hatch so
     unrelated releases don't have to fail-on-anything
4. **Operational improvements** that turn a botched install from a
   "rebuild from source" incident into a one-line `cp` rollback,
   surface drift at the moment of the upgrade rather than days later,
   and harden the network calls.

## Architecture Diagram

```
Before:
 ┌─────────────┐    plain HTTP    ┌──────────────┐
 │  upgrader   │──────────────────▶│ release URL  │
 │ (cli + sh)  │◀──────────────────│  (tarball,   │
 └─────────────┘   trust on        │   wheel)     │
        │         transport        └──────────────┘
        ▼
 install + restart   ← no rollback snapshot
                     ← no post-install version check
                     ← drift only visible next `version` run

After:
 ┌─────────────┐                                  ┌────────────────┐
 │  upgrader   │── 1. fetch checksums.txt ────────▶│ release assets │
 │ (cli + sh)  │── 2. fetch checksums.txt.{sig,pem}│ (.tar.gz, .whl,│
 │             │── 3. cosign verify-blob ─────────▶│  checksums.txt,│
 │             │   (OIDC: this repo's GH Actions) │  .sig/.pem,    │
 │             │── 4. fetch upgrade-manifest.json │  upgrade-      │
 │             │── 5. SHA-256 verify manifest ───▶│  manifest.json)│
 │             │── 6. validate schema/protocol   │                │
 │             │── 7. fetch + SHA-256 verify     │                │
 │             │       tarball, wheel             │                │
 └─────────────┘                                  └────────────────┘
        │
        ▼
 ┌──────────────────────────────────────────────────────┐
 │ snapshot previous gateway → backup_dir/.previous     │
 │ extract tarball with member validation               │
 │ install gateway + verify --version against expected  │
 │ install wheel                                        │
 │ run migrations + assert cursor matches manifest      │
 │ restart services                                     │
 │ defenseclaw version --json → drift warning if any    │
 └──────────────────────────────────────────────────────┘
```

## Flow Diagram

```
upgrader              release URL          GitHub API           cosign
   │                        │                    │                 │
   │── GET checksums.txt ───▶                    │                 │
   │◀──── 200 manifest ─────│                    │                 │
   │                        │                    │                 │
   │── GET .sig + .pem ─────▶                    │                 │
   │◀── 200 (or 404) ───────│                    │                 │
   │                                                                │
   │── verify-blob ────────────────────────────────────────────────▶│
   │   (--certificate-identity-regexp,                              │
   │    --certificate-oidc-issuer)                                  │
   │◀── verified ──────────────────────────────────────────────────│
   │                        │                    │
   │── GET upgrade-manifest.json ───────────────▶│
   │◀── 200 ────────────────│                    │
   │── SHA-256 verify (using checksums.txt) ─────│
   │── parse, check schema_version <= 1,         │
   │   min_upgrade_protocol <= 1                 │
   │                        │                    │
   │── GET tarball ─────────▶                    │
   │◀── 200 ────────────────│                    │
   │── SHA-256 verify (using checksums.txt OR    │
   │   GitHub asset digest fallback) ────────────▶
   │── validate tarball members + extract        │
   │                                             │
   │── snapshot previous binary                  │
   │── install + verify --version                │
   │── run migrations                            │
   │── assert cursor contains required_cli_migrations
   │   (policy=fail → SystemExit, policy=warn → warn)
   │── restart gateway                           │
   │── defenseclaw version --json                │
   │   → if !ok, print drift warning             │
```

## What Changed (Where & How)

| File | Change Type | Summary |
|---|---|---|
| `cli/defenseclaw/commands/cmd_upgrade.py` | modified | Adds Sigstore verification, SHA-256 + GitHub asset digest fallback, manifest download/validation, tarball member validation, binary snapshotting, post-install version check, drift surfacing via `version --json`, retry/backoff in `_download_file`, and gracefully handles missing `openclaw` CLI in `_run_silent`. |
| `scripts/upgrade.sh` | modified | Bash mirror of all the above. JSON parsing routed through `python3` (not sed) for correctness. Drift detection uses `defenseclaw version --json` and parses `ok` field. |
| `scripts/generate-upgrade-manifest.py` | added | Generates `upgrade-manifest.json` from `MIGRATIONS` registry via AST parsing (no package import). `--check` mode validates the contract without writing an artifact. |
| `Makefile` | modified | Adds `dist-upgrade-manifest` target and `check-upgrade-manifest` invariant. Updates `dist-checksums` to exclude `.sig` / `.pem` files. |
| `.github/workflows/release.yaml` | modified | Adds a step that finalizes the manifest, regenerates checksums, and runs `cosign sign-blob` to produce `.sig` + `.pem` alongside `checksums.txt`. Adds `upgrade-manifest.json` to release assets. |
| `.github/workflows/ci.yml` | modified | Adds `upgrade-manifest` job that runs `make check-upgrade-manifest` on every push/PR so a contributor cannot land a migration that violates the invariants. |
| `cli/tests/test_cmd_upgrade.py` | test | 50 tests across 11 classes covering version validation, checksum verification, Sigstore verification, upgrade manifest validation, tarball extraction safety, binary snapshotting, post-install version verification, `_run_silent` error surfacing, drift detection, migration cursor summary, retry/backoff, and the `FileNotFoundError` regression. |
| `cli/tests/test_release_invariants.py` | test | Adds `test_upgrade_manifest_generator_requires_known_migrations` to ensure the manifest generator's output matches the `MIGRATIONS` registry for the current package version. |

## Open Issues / Follow-ups

- **Cosign installation guidance.** The Python and bash flows both
  warn and proceed when `cosign` is absent on the host. Documenting
  `brew install cosign` / `apt install cosign` in the install README
  would let security-sensitive sites enforce it. Not included here
  because it's docs, not code.
- **Streaming download memory.** `_download_optional_release_asset`
  uses `requests.get(...).content` (full body in memory). Fine for
  the small files it handles (checksums.txt ≤ 1 KB, manifest ≤ 1 KB,
  sig ≤ 1 KB, cert ≤ 4 KB), but `_download_file` correctly streams
  for the wheel/tarball.
- **Older releases without manifest.** Releases predating this PR do
  not ship `upgrade-manifest.json`. The probe is optional; old hosts
  upgrading to those releases still work, just without the migration
  contract. Verified live: 0.5.0 has no manifest; the upgrader skips
  manifest enforcement and proceeds.

## Test Plan

### Automated unit suite

```
$ source .venv/bin/activate && cd cli
$ python -m pytest tests/test_cmd_upgrade.py tests/test_release_invariants.py -q
..................................................                       [100%]
50 passed in 0.18s

$ bash -n scripts/upgrade.sh && echo "bash syntax: OK"
bash syntax: OK

$ python3 scripts/generate-upgrade-manifest.py --check
upgrade manifest OK: 0.5.0 (3 required migration(s))
```

### Hands-on manual runs

Each block below is a real command actually invoked, with abbreviated
captured output.

**Tarball extraction safety** — real `.tar.gz` files, real
`_extract_gateway_tarball` invocation:

```
=== TEST 1a: good tarball ===
  PASS: extracted, binary present=True, size=12

=== TEST 1b: path traversal (../../../tmp/...) ===
  ✗ Unsafe tarball entry escapes staging dir: ../../../tmp/dc-manual-test/escaped
  PASS: rejected (SystemExit 1)

=== TEST 1c: symlink to /etc/passwd ===
  ✗ Unsafe tarball link entry: ./defenseclaw
  PASS: rejected (SystemExit 1)
```

Bash mirror (`validate_tarball_members` lifted from
`scripts/upgrade.sh`) runs against the same archives and rejects
identically.

**Version normalization** — real CLI binary, malicious `--version`:

```
=== --version ../1.0.0 ===          ✗ Invalid release version: '../1.0.0'.
=== --version latest ===            ✗ Invalid release version: 'latest'.
=== --version '0.5.0; rm -rf /' === ✗ Invalid release version: '0.5.0; rm -rf /'.
=== --version '0.5.0 && curl' ===   ✗ Invalid release version: '0.5.0 && curl'.
=== --version '$(curl evil)' ===    ✗ Invalid release version: '$(curl evil)'.
=== --version '0.5.0%2F../1' ===    ✗ Invalid release version: '0.5.0%2F../1'.
=== --version '0.5.0\n0.6.0' ===    ✗ Invalid release version: '0.5.0\n0.6.0'.
```

Legit normalization (`v0.5.0` → `0.5.0`, `' 0.5.0 '` → `0.5.0`)
accepted.

**Drift parser** — live `defenseclaw version --json` + bash one-liner:

```
=== TEST 4a: in-sync host ===              result: no-drift  (expected)
=== TEST 4c: synthetic drift JSON ===      result: drift     (expected)
=== TEST 4d: malformed JSON ===            result: no-drift  (fail-closed)
=== TEST 4e: missing 'ok' key ===          result: no-drift  (defaults True)
```

**Manifest generator failure modes** — real
`scripts/generate-upgrade-manifest.py --check` against synthetic
`migrations.py`:

```
=== 5b: out-of-order ===     exit=1
  upgrade manifest check failed: MIGRATIONS must be sorted ascending: got ['0.4.0', '0.3.0'], want ['0.3.0', '0.4.0']

=== 5c: duplicate ===        exit=1
  upgrade manifest check failed: MIGRATIONS contains duplicates: ['0.3.0', '0.3.0']

=== 5d: future-dated ===     exit=1
  upgrade manifest check failed: migration registry contains versions newer than the package version 0.5.0: 9.9.9. Bump the release version first.

=== 5e: cross-file drift === exit=1
  upgrade manifest check failed: version drift detected:
    pyproject.toml: 0.5.0
    cli/defenseclaw/__init__.py: 0.5.0
    Makefile: 0.4.0
    extensions/defenseclaw/package.json: 0.5.0
```

**Retry/backoff** — real local HTTP server returning 503 N times then 200:

```
=== TEST 6a: server fails first 2 reqs, succeeds on 3rd ===
  body received: b'ok-after-retries'
  elapsed: 3.01s   (expected: ~3s = 1s + 2s backoff)

=== TEST 6b: server always fails (gives up after 3 attempts) ===
  ✗ Download failed (503): http://127.0.0.1:18725/anything
  SystemExit(1) after 3.02s
```

**`_run_silent` failure surfacing** — real subprocess invocations:

```
=== TEST 7a: missing binary (the original FileNotFoundError bug) ===
  ⚠ fail msg seen
    [Errno 2] No such file or directory: 'this-binary-definitely-does-not-exist'
  return: False

=== TEST 7b: non-zero exit + stderr surfacing ===
  ⚠ non-zero failure
    SyntaxError: unterminated string literal ...
  return: False

=== TEST 7d: timeout ===
  ⚠ timeout msg
    Command 'python3 -c ...' timed out after 30 seconds
  return: False
```

**Live GitHub release fetches** — against the actual
`cisco-ai-defense/defenseclaw` 0.5.0 release:

```
=== TEST 8a: _fetch_latest_version against real GitHub API ===
  latest: '0.6.0'

=== TEST 8d: _download_checksums + Sigstore probe ===
  ✓ Checksum signature verified (Sigstore)            ← real cosign verify-blob
  parsed entries: 8

=== TEST 8e: _fetch_release_asset_digests against real GitHub API ===
  asset digest entries: 13
    fc909725150fa0ce...  checksums.txt
    18d503d8521421d8...  checksums.txt.pem
    4b7df5c4dd8caf6c...  checksums.txt.sig
    f27d87c00fa2cbad...  defenseclaw-0.5.0-py3-none-any.whl
    ...
```

**Tampered checksums** — mutate one byte in the real signed manifest,
replay against the real signature:

```
=== TEST 8h: _verify_checksums_sigstore on tampered manifest ===
  ✗ checksums.txt Sigstore signature verification failed.
    Error: ... "verifying signature: invalid signature when validating ASN.1 encoded signature"
  PASS: rejected with SystemExit(1)

=== TEST 8i: bash verify_checksums_sigstore on tampered manifest ===
  ✗ checksums.txt Sigstore signature verification failed.
  rc=1  (expected 1 — tampered file rejected)
```

**Real end-to-end upgrade** — `bash scripts/upgrade.sh --yes
--version 0.5.0` from this branch, against the live 0.5.0 release;
same-version repair path:

```
─── Resolving Release Version
  ✓ Target version: 0.5.0
  ✓ Installed version : 0.5.0
  ! Already at version 0.5.0; continuing to re-apply artifacts and same-version migrations

─── Downloading Artifacts
  ✓ Checksum manifest downloaded (checksums.txt)
  ✓ Checksum signature verified (Sigstore)            ← real cosign on the live host
  ✓ Gateway binary downloaded
  ! checksums.txt missing defenseclaw-0.5.0-py3-none-any.whl; using GitHub release asset digest.
  ✓ Python CLI wheel downloaded                       ← asset digest fallback worked

─── Creating Backup
  ✓ Backup saved to: /Users/.../upgrade-20260519T154014

─── Installing Artifacts
  ✓ Snapshotted previous gateway → /Users/.../defenseclaw-gateway.previous
  ✓ Gateway binary installed
  ✓ Gateway binary verified (0.5.0)                   ← post-install --version probe

─── Running Migrations
  → Migration 0.5.0: Purge stale flat-layout policy bundle ...
    ✓ Migration 0.5.0 applied.
  ✓ Applied 1 migration(s)

─── Starting Services
  ✓ Gateway started                                   ← PID 77649

# Post-upgrade state (defenseclaw version):
  cli        0.5.0    ok      defenseclaw (python)
  gateway    0.5.0    ok      /Users/.../defenseclaw-gateway
                              ↳ (commit=32e019ba..., built=2026-05-12T05:02:17Z)
  plugin     0.5.0    ok      /Users/.../defenseclaw
  ✓ All components in sync.

# Snapshot rollback artifact is fully functional:
$ /Users/.../upgrade-20260519T154014/defenseclaw-gateway.previous --version
defenseclaw-gateway version 0.5.0 (commit=unknown, built=unknown)
```

### Summary of coverage

| Behavior | Unit-tested | Live-fired |
|---|---|---|
| Sigstore signature verify (positive) | ✅ | ✅ (live 0.5.0 release) |
| Sigstore signature verify (tampered → reject) | ✅ | ✅ (mutated real manifest) |
| Sigstore signature verify (cosign missing) | ✅ | ✅ (uninstalled cosign) |
| SHA-256 mismatch → reject | ✅ | n/a (would corrupt the live release) |
| GitHub asset digest fallback | ✅ | ✅ (0.5.0 wheel uses fallback in real run) |
| Tarball path traversal rejected | ✅ | ✅ (built and fed real archives, both Python and bash) |
| Tarball symlink rejected | ✅ | ✅ (built and fed real archives, both Python and bash) |
| Version arg semver validation | ✅ | ✅ (live CLI, 7 attack inputs) |
| `migration_failure_policy: warn` vs `fail` | ✅ | n/a (no released manifest yet) |
| `min_upgrade_protocol` refusal | ✅ | n/a (no released manifest yet) |
| `_download_file` retry / give-up | ✅ | ✅ (local 503-server) |
| `_run_silent` missing binary, non-zero, timeout | ✅ | ✅ (real subprocess) |
| Gateway binary snapshot before overwrite | ✅ | ✅ (real upgrade — 93 MB binary at `<backup>/defenseclaw-gateway.previous`, executable, reports `--version`) |
| Post-install `--version` against installed path | ✅ | ✅ (real upgrade) |
| Drift parser (`version --json` → bash) | ✅ | ✅ (real binary, in-sync + synthetic-drift cases) |
| Manifest generator (sort, dedup, future-dated, cross-file drift) | ✅ | ✅ (synthetic `migrations.py` cases, real generator) |
| Same-version repair (migration re-apply) | ✅ | ✅ (real upgrade, migration 0.5.0 re-applied) |
| Same-version repair (gateway restart) | ✅ | ✅ (real upgrade, PID 77649) |
| Missing `openclaw` CLI graceful | ✅ | ✅ (real subprocess via `_run_silent`) |
