### PR TITLE
Support OpenClaw protocol v4 handshake

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -104,7 +104,7 @@ No production CLI command calls this directly.
 ```json
 {
   "health": { "..." },
-  "gateway_hello": { "protocol": "v3", "features": ["..."] }
+  "gateway_hello": { "protocol": 4, "features": { "methods": ["..."], "events": ["..."] } }
 }
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,7 +31,7 @@ enforcement, and auditing across existing tools without replacing any component.
 │  │  │ REST API  │ │ Audit /   │ │ Policy   │ │ OpenClaw WS     │       │    │
 │  │  │ Server    │ │ SIEM      │ │ Engine   │ │ Client          │       │    │
 │  │  │           │ │ Emitter   │ │          │ │                 │       │    │
-│  │  │ Accepts   │ │           │ │ Block /  │ │ WS protocol v3  │       │    │
+│  │  │ Accepts   │ │           │ │ Block /  │ │ WS protocol 3-4 │       │    │
 │  │  │ requests  │ │ Splunk    │ │ Allow /  │ │ Subscribes to   │       │    │
 │  │  │ from CLI  │ │ HEC, CSV  │ │ Scan     │ │ all events,     │       │    │
 │  │  │ & plugins │ │ export    │ │ gate     │ │ sends commands  │       │    │
@@ -154,7 +154,7 @@ only component with direct access to all subsystems.
 |----------------|--------|
 | REST API server (`:18970`) | Accepts requests from CLI and plugins; CSRF-protected, localhost-bound |
 | Guardrail proxy (`:4000`) | HTTP reverse proxy that inspects all LLM traffic; rate-limited (100/s, burst 200) |
-| OpenClaw WebSocket client | Connects via protocol v3, HMAC-SHA256 challenge-response auth, sequence tracking |
+| OpenClaw WebSocket client | Connects with a protocol v3-v4 range, Ed25519 device challenge-response auth, sequence tracking |
 | Event router | Dispatches WebSocket events (`tool_call`, `tool_result`, `exec.approval.requested`, `session.message`, `agent`) with judge semaphore (cap 16) |
 | Command dispatch | Sends RPC commands to OpenClaw: `exec.approval.resolve`, `skills.update`, `config.get`, `config.patch`, `tools.catalog`, `sessions.list` |
 | Enforcement engine | Manages block/allow lists in SQLite (`internal/enforce/`) — separate from OPA |
@@ -321,7 +321,7 @@ requires only a new case in `internal/config/claw.go`.
 ## Component Communication Summary
 
 ```
-┌─────────┐    REST     ┌──────────────┐    WS (v3)    ┌──────────────┐
+┌─────────┐    REST     ┌──────────────┐   WS (v3-v4)  ┌──────────────┐
 │   CLI   │───────────▶│  DefenseClaw │──────────────▶│   OpenClaw   │
 │ (Python)│            │   Gateway    │               │   Gateway    │
 └─────────┘            │   (Go)       │◀──────────────│              │

--- a/docs/SANDBOX_QUICKSTART.md
+++ b/docs/SANDBOX_QUICKSTART.md
@@ -175,7 +175,7 @@ DefenseClaw Sidecar Health
   Uptime:   25s
 
   Gateway:   RUNNING (since 2026-03-30T12:44:28-07:00)
-             protocol: 3
+             protocol: 4
 
   Watcher:   RUNNING (since 2026-03-30T12:44:28-07:00)
 

--- a/docs/reference/GATEWAY_SPEC.md
+++ b/docs/reference/GATEWAY_SPEC.md
@@ -53,7 +53,7 @@ cancellation.
 | File | Purpose |
 |------|---------|
 | `sidecar.go` | Top-level orchestrator. Creates client, router, watcher; runs all four subsystems; handles watcher verdicts. |
-| `client.go` | WebSocket client. Protocol v3 handshake, read loop, request/response multiplexing, reconnection with backoff. |
+| `client.go` | WebSocket client. OpenClaw protocol v3-v4 handshake range, read loop, request/response multiplexing, reconnection with backoff. |
 | `device.go` | Ed25519 device identity. Key generation, PEM persistence, challenge-response signing. |
 | `frames.go` | Wire format types. Request, response, event frames and all payload structs. |
 | `router.go` | Event dispatcher. Routes gateway events to handlers; dangerous command detection; exec approval gate. |
@@ -70,7 +70,7 @@ cancellation.
 | `provider.go` | `LLMProvider` interface and Bifrost SDK integration. Provider inference from model name/API key prefix. |
 | `dotenv.go` | `loadDotEnv` — loads `~/.defenseclaw/.env` for API key resolution when env vars are not set. |
 
-## WebSocket Protocol (v3)
+## WebSocket Protocol (v4-compatible)
 
 ### Connection Handshake
 
@@ -82,8 +82,9 @@ Client                              Gateway
   │                                    │
   │◄─── event: connect.challenge ──────│  { nonce, ts }
   │                                    │
-  │──── req: connect ─────────────────►│  { protocol, client, role,
-  │     (signed device identity)       │    scopes, auth, device }
+  │──── req: connect ─────────────────►│  { minProtocol, maxProtocol,
+  │     (signed device identity)       │    client, role,
+  │                                    │    scopes, auth, device }
   │                                    │
   │◄─── res: hello-ok ────────────────│  { protocol, features,
   │                                    │    auth, policy }
@@ -95,8 +96,8 @@ Client                              Gateway
 2. Gateway sends a `connect.challenge` event containing a random `nonce`.
 3. Client starts the read loop and enables **handshake event buffering** —
    events received before `hello-ok` are queued in memory (not dropped).
-4. Client builds a connect request with protocol version, role, scopes,
-   auth token, and a device identity block containing the Ed25519 public
+4. Client builds a connect request with `minProtocol: 3`, `maxProtocol: 4`,
+   role, scopes, auth token, and a device identity block containing the Ed25519 public
    key and a signature over a deterministic v3 payload (see below).
 5. Gateway verifies the signature, returns `hello-ok` with negotiated
    features, auth confirmation, and policy (e.g. tick interval).
@@ -142,7 +143,7 @@ equal `lastSeq+1`, the client writes a warning to stderr:
 
 | Method | Params | Description |
 |--------|--------|-------------|
-| `connect` | protocol, client, role, scopes, auth, device | Initial handshake |
+| `connect` | minProtocol, maxProtocol, client, role, scopes, auth, device | Initial handshake |
 | `skills.update` | `{ skillKey, enabled }` | Enable or disable a skill at the gateway |
 | `config.get` | *(none)* | Fetch current gateway configuration |
 | `config.patch` | `{ path, value }` | Apply a partial config update |
@@ -455,7 +456,7 @@ Tests are split across two files:
   No external dependencies.
 - `gateway_ws_test.go` — integration tests using a mock WebSocket server
   (`httptest.Server` + gorilla/websocket upgrader) that simulates the full
-  v3 handshake. Covers the connect flow, all RPC methods, approval routing,
+  v4-compatible handshake. Covers the connect flow, all RPC methods, approval routing,
   API success paths, and sidecar admission result handling.
 
 Run with: `make gateway-test` or `go test -race ./internal/gateway/`

--- a/internal/gateway/client.go
+++ b/internal/gateway/client.go
@@ -64,7 +64,12 @@ type Client struct {
 	OnEvent func(EventFrame)
 }
 
-const connectRPCTimeout = 45 * time.Second
+const (
+	connectRPCTimeout = 45 * time.Second
+
+	openClawMinProtocol = 3
+	openClawMaxProtocol = 4
+)
 
 // NewClient creates a gateway client. The device identity is loaded or created
 // automatically from the configured key file path.
@@ -95,8 +100,8 @@ func (c *Client) wsURL() string {
 	return u.String()
 }
 
-// Connect establishes the WebSocket connection and completes the protocol v3
-// handshake including device challenge-response authentication.
+// Connect establishes the WebSocket connection and completes the OpenClaw
+// gateway handshake including device challenge-response authentication.
 func (c *Client) Connect(ctx context.Context) error {
 	target := c.wsURL()
 	fmt.Fprintf(os.Stderr, "[gateway] dialing %s ...\n", target)
@@ -135,8 +140,8 @@ func (c *Client) Connect(ctx context.Context) error {
 	c.startHandshakeEventBuffer()
 	go c.readLoop()
 
-	fmt.Fprintf(os.Stderr, "[gateway] sending connect (protocol=3, role=operator, device=%s) ...\n",
-		c.device.DeviceID)
+	fmt.Fprintf(os.Stderr, "[gateway] sending connect (protocol=%d..%d, role=operator, device=%s) ...\n",
+		openClawMinProtocol, openClawMaxProtocol, c.device.DeviceID)
 	hello, err := c.sendConnect(ctx, nonce)
 	buf := c.stopHandshakeEventBuffer()
 	if err != nil {
@@ -261,8 +266,8 @@ func (c *Client) sendConnect(ctx context.Context, nonce string) (*HelloOK, error
 	}
 
 	params := map[string]interface{}{
-		"minProtocol": 3,
-		"maxProtocol": 3,
+		"minProtocol": openClawMinProtocol,
+		"maxProtocol": openClawMaxProtocol,
 		"client": map[string]interface{}{
 			"id":       clientID,
 			"version":  "1.0.0",

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -92,13 +92,13 @@ func TestNewSidecarHealthInitialState(t *testing.T) {
 func TestSidecarHealthSetGateway(t *testing.T) {
 	h := NewSidecarHealth()
 
-	h.SetGateway(StateRunning, "", map[string]interface{}{"protocol": 3})
+	h.SetGateway(StateRunning, "", map[string]interface{}{"protocol": openClawMaxProtocol})
 	snap := h.Snapshot()
 	if snap.Gateway.State != StateRunning {
 		t.Errorf("Gateway.State = %q, want %q", snap.Gateway.State, StateRunning)
 	}
-	if snap.Gateway.Details["protocol"] != 3 {
-		t.Errorf("Gateway.Details[protocol] = %v, want 3", snap.Gateway.Details["protocol"])
+	if snap.Gateway.Details["protocol"] != openClawMaxProtocol {
+		t.Errorf("Gateway.Details[protocol] = %v, want %d", snap.Gateway.Details["protocol"], openClawMaxProtocol)
 	}
 
 	h.SetGateway(StateError, "connection lost", nil)
@@ -1243,7 +1243,7 @@ func TestEventFrameNoSeq(t *testing.T) {
 func TestHelloOKParsing(t *testing.T) {
 	raw := `{
 		"type": "hello-ok",
-		"protocol": 3,
+		"protocol": 4,
 		"features": {
 			"methods": ["skills.update", "config.patch"],
 			"events": ["tool_call", "tool_result"]
@@ -1260,8 +1260,8 @@ func TestHelloOKParsing(t *testing.T) {
 		t.Fatalf("Unmarshal: %v", err)
 	}
 
-	if hello.Protocol != 3 {
-		t.Errorf("Protocol = %d, want 3", hello.Protocol)
+	if hello.Protocol != openClawMaxProtocol {
+		t.Errorf("Protocol = %d, want %d", hello.Protocol, openClawMaxProtocol)
 	}
 	if hello.Features == nil {
 		t.Fatal("Features should not be nil")
@@ -1278,7 +1278,7 @@ func TestHelloOKParsing(t *testing.T) {
 }
 
 func TestHelloOKWithPolicy(t *testing.T) {
-	raw := `{"type":"hello-ok","protocol":3,"policy":{"tickIntervalMs":5000}}`
+	raw := `{"type":"hello-ok","protocol":4,"policy":{"tickIntervalMs":5000}}`
 	var hello HelloOK
 	if err := json.Unmarshal([]byte(raw), &hello); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
@@ -1292,7 +1292,7 @@ func TestHelloOKWithPolicy(t *testing.T) {
 }
 
 func TestHelloOKMinimalPayload(t *testing.T) {
-	raw := `{"type":"hello-ok","protocol":3}`
+	raw := `{"type":"hello-ok","protocol":4}`
 	var hello HelloOK
 	if err := json.Unmarshal([]byte(raw), &hello); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
@@ -2477,7 +2477,7 @@ func TestAPIStatusHandlerWithHello(t *testing.T) {
 	health := NewSidecarHealth()
 	client := &Client{
 		hello: &HelloOK{
-			Protocol: 3,
+			Protocol: openClawMaxProtocol,
 			Features: &HelloFeatures{Methods: []string{"skills.update"}},
 		},
 	}

--- a/internal/gateway/gateway_ws_test.go
+++ b/internal/gateway/gateway_ws_test.go
@@ -67,7 +67,7 @@ func newLocalTestServer(t *testing.T, handler http.Handler) *httptest.Server {
 }
 
 // startMockGW creates an httptest server that simulates the gateway WebSocket.
-// It performs the v3 challenge-response handshake, then calls afterHandshake.
+// It performs the challenge-response handshake, then calls afterHandshake.
 func startMockGW(t *testing.T, afterHandshake func(t *testing.T, conn *websocket.Conn)) *httptest.Server {
 	t.Helper()
 	upgrader := websocket.Upgrader{}
@@ -88,10 +88,11 @@ func startMockGW(t *testing.T, afterHandshake func(t *testing.T, conn *websocket
 		}
 		var req RequestFrame
 		json.Unmarshal(raw, &req)
+		assertConnectProtocolRange(t, req)
 
 		helloData, _ := json.Marshal(HelloOK{
 			Type:     "hello-ok",
-			Protocol: 3,
+			Protocol: openClawMaxProtocol,
 			Features: &HelloFeatures{
 				Methods: []string{"skills.update", "config.patch", "config.set", "config.get", "status", "tools.catalog", "exec.approval.resolve"},
 				Events:  []string{"tool_call", "tool_result", "exec.approval.requested", "tick"},
@@ -105,6 +106,29 @@ func startMockGW(t *testing.T, afterHandshake func(t *testing.T, conn *websocket
 		}
 	}))
 	return srv
+}
+
+func assertConnectProtocolRange(t *testing.T, req RequestFrame) {
+	t.Helper()
+	if req.Method != "connect" {
+		t.Fatalf("first request method = %q, want connect", req.Method)
+	}
+
+	var params struct {
+		MinProtocol int `json:"minProtocol"`
+		MaxProtocol int `json:"maxProtocol"`
+	}
+	rawParams, err := json.Marshal(req.Params)
+	if err != nil {
+		t.Fatalf("marshal connect params: %v", err)
+	}
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		t.Fatalf("parse connect params: %v", err)
+	}
+	if params.MinProtocol != openClawMinProtocol || params.MaxProtocol != openClawMaxProtocol {
+		t.Fatalf("connect protocol range = %d..%d, want %d..%d",
+			params.MinProtocol, params.MaxProtocol, openClawMinProtocol, openClawMaxProtocol)
+	}
 }
 
 func rpcEchoLoop(t *testing.T, conn *websocket.Conn) {
@@ -245,8 +269,8 @@ func TestClientConnectSuccess(t *testing.T) {
 		t.Fatal("Hello() should not be nil after connect")
 		return
 	}
-	if hello.Protocol != 3 {
-		t.Errorf("Protocol = %d, want 3", hello.Protocol)
+	if hello.Protocol != openClawMaxProtocol {
+		t.Errorf("Protocol = %d, want %d", hello.Protocol, openClawMaxProtocol)
 	}
 	if hello.Features == nil {
 		t.Fatal("Features should not be nil")
@@ -349,6 +373,7 @@ func TestConnectHandshakeApprovalEventBeforeOK(t *testing.T) {
 		}
 		var connectReq RequestFrame
 		json.Unmarshal(raw, &connectReq)
+		assertConnectProtocolRange(t, connectReq)
 
 		apPayload, _ := json.Marshal(ApprovalRequestPayload{
 			ID: "early-approval",
@@ -364,7 +389,7 @@ func TestConnectHandshakeApprovalEventBeforeOK(t *testing.T) {
 
 		helloData, _ := json.Marshal(HelloOK{
 			Type:     "hello-ok",
-			Protocol: 3,
+			Protocol: openClawMaxProtocol,
 			Features: &HelloFeatures{
 				Methods: []string{"exec.approval.resolve"},
 				Events:  []string{"exec.approval.requested"},
@@ -1087,7 +1112,7 @@ func TestSidecarAccessors(t *testing.T) {
 func TestSidecarLogHelloWithFeatures(t *testing.T) {
 	s := &Sidecar{}
 	s.logHello(&HelloOK{
-		Protocol: 3,
+		Protocol: openClawMaxProtocol,
 		Features: &HelloFeatures{
 			Methods: []string{"skills.update", "config.patch"},
 			Events:  []string{"tool_call", "tool_result"},
@@ -1097,7 +1122,7 @@ func TestSidecarLogHelloWithFeatures(t *testing.T) {
 
 func TestSidecarLogHelloWithoutFeatures(t *testing.T) {
 	s := &Sidecar{}
-	s.logHello(&HelloOK{Protocol: 3})
+	s.logHello(&HelloOK{Protocol: openClawMaxProtocol})
 }
 
 func TestHandleAdmissionResultBlocked(t *testing.T) {


### PR DESCRIPTION
## Summary
- Advertise an OpenClaw gateway protocol range of `3..4` during the connect handshake instead of `3..3`
- Update gateway tests to assert the outbound connect range and expect negotiated protocol v4
- Refresh gateway/API docs and examples for the v4-compatible handshake

## Verification
- Confirmed `cisco-ai-defense/defenseclaw` latest release is `0.6.1` at `01b21cf`, and `origin/main` still sends `minProtocol: 3`, `maxProtocol: 3`
- Confirmed `openclaw@latest` is `2026.5.22` and its packaged gateway docs require current protocol v4 with examples using `minProtocol: 3`, `maxProtocol: 4`
- `go test ./internal/gateway -run 'Test(ClientConnectSuccess|ConnectHandshakeApprovalEventBeforeOK|HelloOKParsing|HelloOKWithPolicy|HelloOKMinimalPayload|APIStatusHandlerWithHello|SidecarHealthSetGateway|SidecarLogHello)'`
- `go test ./internal/gateway`
- `git diff --check`