### PR TITLE
feat(config): add in-memory key store for secret hydration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -329,12 +329,18 @@ type LLMConfig struct {
 // these stay in lock-step.
 func (l LLMConfig) ResolvedAPIKey() string {
 	if l.APIKeyEnv != "" {
+		if v, ok := GetKey(l.APIKeyEnv); ok && strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
 		if v := strings.TrimSpace(os.Getenv(l.APIKeyEnv)); v != "" {
 			return v
 		}
 	}
 	if l.APIKey != "" {
 		return l.APIKey
+	}
+	if v, ok := GetKey(DefenseClawLLMKeyEnv); ok && strings.TrimSpace(v) != "" {
+		return strings.TrimSpace(v)
 	}
 	return strings.TrimSpace(os.Getenv(DefenseClawLLMKeyEnv))
 }
@@ -949,9 +955,12 @@ func (c *CiscoAIDefenseConfig) HookSurfaceEnabled() bool {
 	return *c.ScanHookSurface
 }
 
-// ResolvedAPIKey returns the API key from the env var (if set) or the direct value.
+// ResolvedAPIKey returns the API key from the key store, env var, or inline value.
 func (c *CiscoAIDefenseConfig) ResolvedAPIKey() string {
 	if c.APIKeyEnv != "" {
+		if v, ok := GetKey(c.APIKeyEnv); ok && v != "" {
+			return v
+		}
 		if v := os.Getenv(c.APIKeyEnv); v != "" {
 			return v
 		}

--- a/internal/config/key_store.go
+++ b/internal/config/key_store.go
@@ -7,7 +7,7 @@ import "sync"
 // in ResolvedAPIKey() so that secrets fetched from OpenBao never touch
 // the process environment.
 var (
-	keyStoreMu sync.RWMutex
+	keyStoreMu  sync.RWMutex
 	keyStoreMap = make(map[string]string)
 )
 

--- a/internal/config/key_store.go
+++ b/internal/config/key_store.go
@@ -1,0 +1,31 @@
+package config
+
+import "sync"
+
+// keyStore holds in-memory API keys injected at startup by the enterprise
+// token hydration layer. Keys stored here take priority over os.Getenv
+// in ResolvedAPIKey() so that secrets fetched from OpenBao never touch
+// the process environment.
+var (
+	keyStoreMu sync.RWMutex
+	keyStoreMap = make(map[string]string)
+)
+
+// SetKey stores an API key in the in-memory key store under the given
+// env var name. Subsequent calls to ResolvedAPIKey() and
+// CiscoAIDefenseConfig.ResolvedAPIKey() will find it here before
+// consulting os.Getenv.
+func SetKey(envVarName, value string) {
+	keyStoreMu.Lock()
+	keyStoreMap[envVarName] = value
+	keyStoreMu.Unlock()
+}
+
+// GetKey returns the in-memory key for the given env var name, or
+// empty string if not set. The bool return indicates presence.
+func GetKey(envVarName string) (string, bool) {
+	keyStoreMu.RLock()
+	v, ok := keyStoreMap[envVarName]
+	keyStoreMu.RUnlock()
+	return v, ok
+}

--- a/internal/config/key_store.go
+++ b/internal/config/key_store.go
@@ -4,8 +4,8 @@ import "sync"
 
 // keyStore holds in-memory API keys injected at startup by the enterprise
 // token hydration layer. Keys stored here take priority over os.Getenv
-// in ResolvedAPIKey() so that secrets fetched from OpenBao never touch
-// the process environment.
+// in ResolvedAPIKey() so that secrets fetched from an external vault
+// never touch the process environment.
 var (
 	keyStoreMu  sync.RWMutex
 	keyStoreMap = make(map[string]string)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,10 +116,10 @@ override-dependencies = [
     # CVE-2026-34513..34520, CVE-2026-34525). litellm 1.83.10's
     # transitive pin floats aiohttp downward without this override.
     "aiohttp>=3.13.4",
-    # PYSEC-2026-161 fixed in starlette 1.0.1. Cap below 1.1 because
-    # starlette 1.1 removed Router(on_startup=...) which breaks the
-    # fastapi version pinned by mcpscanner.
+    # PYSEC-2026-161 fixed in starlette 1.0.1. fastapi must be bumped
+    # to >=0.133.0 (first release supporting starlette 1.x).
     "starlette>=1.0.1,<1.1",
+    "fastapi>=0.133.0",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ override-dependencies = [
     # CVE-2026-34513..34520, CVE-2026-34525). litellm 1.83.10's
     # transitive pin floats aiohttp downward without this override.
     "aiohttp>=3.13.4",
+    "starlette>=1.0.1",         # PYSEC-2026-161 fixed in 1.0.1
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,10 @@ override-dependencies = [
     # CVE-2026-34513..34520, CVE-2026-34525). litellm 1.83.10's
     # transitive pin floats aiohttp downward without this override.
     "aiohttp>=3.13.4",
+    # PYSEC-2026-161 fixed in starlette 1.0.1. Cap below 1.1 because
+    # starlette 1.1 removed Router(on_startup=...) which breaks the
+    # fastapi version pinned by mcpscanner.
+    "starlette>=1.0.1,<1.1",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,6 @@ override-dependencies = [
     # CVE-2026-34513..34520, CVE-2026-34525). litellm 1.83.10's
     # transitive pin floats aiohttp downward without this override.
     "aiohttp>=3.13.4",
-    "starlette>=1.0.1",         # PYSEC-2026-161 fixed in 1.0.1
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,7 @@ overrides = [
     { name = "python-dotenv", specifier = "==1.2.1" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "rich", specifier = ">=13.7.1,<14.0.0" },
+    { name = "starlette", specifier = ">=1.0.1,<1.1" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
@@ -2924,15 +2925,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.50.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,6 @@ overrides = [
     { name = "python-dotenv", specifier = "==1.2.1" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "rich", specifier = ">=13.7.1,<14.0.0" },
-    { name = "starlette", specifier = ">=1.0.1" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
@@ -2925,15 +2924,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.1.0"
+version = "0.50.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ overrides = [
     { name = "aiohttp", specifier = ">=3.13.4" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "cryptography", specifier = ">=46.0.7" },
+    { name = "fastapi", specifier = ">=0.133.0" },
     { name = "idna", specifier = ">=3.15" },
     { name = "importlib-metadata", specifier = ">=8.7.1" },
     { name = "jsonschema", specifier = ">=4.26.0" },
@@ -809,17 +810,18 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.128.0"
+version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a", size = 365682, upload-time = "2025-12-27T15:21:13.714Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d", size = 103094, upload-time = "2025-12-27T15:21:12.154Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,7 @@ overrides = [
     { name = "python-dotenv", specifier = "==1.2.1" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "rich", specifier = ">=13.7.1,<14.0.0" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
@@ -2924,15 +2925,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.50.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Secrets fetched from OpenBao at startup can now be stored in memory via SetKey/GetKey rather than injected into the process environment. ResolvedAPIKey() on both LLMConfig and CiscoAIDefenseConfig checks the key store before os.Getenv, keeping secrets out of /proc/environ.