### PR TITLE
feat(observability): unify runtime findings + evaluation_id join key across surfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,8 @@ agent-out/
 # Local security-tooling working directories — each contributor's
 # Avarice / DeepSec runs drop campaign data, findings, and node_modules
 # under these trees. Keep them out of git so per-machine scan artifacts
-# never leak into PRs or the published audit trail.
+# never leak into PRs or the published audit trail. security_report/
+# holds ad-hoc on-disk review writeups produced by the same tooling.
 .avarice/
 .deepsec/
+security_report/

--- a/bundles/local_observability_stack/grafana/dashboards/defenseclaw-findings.json
+++ b/bundles/local_observability_stack/grafana/dashboards/defenseclaw-findings.json
@@ -2,7 +2,7 @@
   "annotations": {
     "list": []
   },
-  "description": "Rule-level findings detail. Driven by $rule_id, $scanner, $severity. Combines the Prometheus per-rule counter (defenseclaw_scan_findings_by_rule_total) with the Loki scan_finding event stream so operators can rank rules, map first/last-seen, and pivot into target attribution and finding\u2192verdict correlation.",
+  "description": "Rule-level findings detail. Driven by $rule_id, $scanner, $severity. Combines the Prometheus per-rule counter (defenseclaw_scan_findings_by_rule_total) with the Loki scan_finding event stream so operators can rank rules, map first/last-seen, and pivot into target attribution and finding\u2192verdict correlation. The $scanner dropdown is populated dynamically and covers the full unified finding pipeline: classic (skill, mcp), hook-rules (claudecode/codex/cursor/windsurf/copilot/geminicli/hermes), inspect-http, guardrail-llm, mid-stream, tool-call-inspect, asset-policy, and drift (rescan). Pivot from any per-rule row into the originating evaluation via the evaluation_id label.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,

--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -205,6 +205,32 @@ def _emit(tag: str, label: str, detail: str = "", *, r: _DoctorResult | None = N
         r.record(tag, label, detail)
 
 
+def _emit_hint(text: str, *, indent: str = "      ") -> None:
+    """Print an advisory hint line attached to the previous check row.
+
+    Hints don't count toward the pass/fail/warn/skip tally and are
+    suppressed in JSON mode (consumers parse the result dict, not
+    rendered text). Used today by the AI Defense probe to surface
+    the bound endpoint after a 401 — the most common cause is a
+    valid key for a different region, and the API can't disambiguate
+    that on its own.
+    """
+    if _json_mode:
+        return
+    click.echo(f"{indent}{ux.dim('↪ ' + text)}")
+
+
+def _emit_aid_hint(text: str) -> None:
+    """Convenience wrapper for AI Defense hint rows.
+
+    Kept as a named helper (rather than calling ``_emit_hint``
+    directly at every site) so tests and grep can target the
+    AI-Defense-specific hints without false matches against future
+    hints from other probes.
+    """
+    _emit_hint(text)
+
+
 def _resolve_api_key(env_name: str, dotenv_path: str) -> str:
     """Resolve an API key from env → .env file → empty."""
     val = os.environ.get(env_name, "")
@@ -977,10 +1003,26 @@ def _check_cisco_ai_defense(cfg, r: _DoctorResult) -> None:
         _emit("pass", "Cisco AI Defense", endpoint, r=r)
     elif code == 401 or code == 403:
         _emit("fail", "Cisco AI Defense", f"authentication failed (HTTP {code})", r=r)
+        # AI Defense has three regional deployments (us / eu / preview)
+        # and all of them reply with the same opaque "401 invalid api
+        # key" body — there's no way for the API itself to tell the
+        # operator "your key is for a different region". Surface the
+        # endpoint that was probed plus an actionable next step right
+        # under the failure so a wrong-region key (the most common
+        # post-rotation cause) doesn't get misdiagnosed as a revoked
+        # one. Hints are advisory rows: not counted in the result
+        # tally and suppressed in JSON mode (consumers there see the
+        # endpoint via the spec, not the rendered hint).
+        _emit_aid_hint(f"endpoint: {endpoint}")
+        _emit_aid_hint(
+            "if the key was issued for a different region, run: defenseclaw setup"
+        )
     elif code == 0:
         _emit("warn", "Cisco AI Defense", f"endpoint unreachable: {body[:100]}", r=r)
+        _emit_aid_hint(f"endpoint: {endpoint}")
     else:
         _emit("warn", "Cisco AI Defense", f"HTTP {code} (unexpected — endpoint responded but not 200)", r=r)
+        _emit_aid_hint(f"endpoint: {endpoint}")
 
 
 def _check_observability(cfg, r: _DoctorResult) -> None:

--- a/cli/defenseclaw/commands/cmd_keys.py
+++ b/cli/defenseclaw/commands/cmd_keys.py
@@ -35,12 +35,31 @@ from defenseclaw import ux
 from defenseclaw.audit_actions import ACTION_CONFIG_UPDATE
 from defenseclaw.context import AppContext, pass_ctx
 from defenseclaw.credentials import (
+    CredentialSpec,
     CredentialStatus,
     Requirement,
     classify,
     lookup,
     mask,
 )
+
+
+def _emit_bound_endpoint_hint(spec: CredentialSpec | None, cfg, *, indent: str) -> None:
+    """Print a "↪ bound to <url>" hint after a credential is saved.
+
+    Surfaces the operator's *current* paired endpoint so a key that
+    was issued for a different region/host is caught at save time
+    rather than at the next failed probe. No-op when the spec has no
+    bound endpoint (most credentials), so this is safe to call
+    unconditionally on every save.
+    """
+    if spec is None:
+        return
+    endpoint = spec.resolve_bound_endpoint(cfg)
+    if not endpoint:
+        return
+    click.echo(f"{indent}{ux.dim('↪ bound to ' + endpoint)}")
+    click.echo(f"{indent}{ux.dim('  change region/host: defenseclaw setup')}")
 
 
 @click.group("keys")
@@ -142,6 +161,7 @@ def keys_set(app: AppContext, env_name: str, value: str | None) -> None:
             ],
         )
     ux.ok(f"Saved {env_name} = {mask(value)} to {app.cfg.data_dir}/.env", indent="  ")
+    _emit_bound_endpoint_hint(spec, app.cfg, indent="    ")
 
 
 @keys_cmd.command("fill-missing")
@@ -183,6 +203,7 @@ def keys_fill_missing(app: AppContext, yes: bool) -> None:
             continue
         _save_secret_to_dotenv(s.resolution.env_name, value, app.cfg.data_dir)
         ux.ok(f"saved ({mask(value)})", indent="      ")
+        _emit_bound_endpoint_hint(s.spec, app.cfg, indent="        ")
         saved += 1
 
     click.echo()

--- a/cli/defenseclaw/credentials.py
+++ b/cli/defenseclaw/credentials.py
@@ -68,6 +68,16 @@ class CredentialSpec:
     This lets the registry track the real env var the user wired up
     (e.g. ``MY_CUSTOM_JUDGE_KEY``) instead of pretending the canonical
     one is expected.
+
+    ``bound_endpoint`` lets the registry attach the URL/host the
+    credential is paired with in ``config.yaml`` (e.g. AI Defense
+    region endpoint, Splunk HEC URL, judge LLM base URL). UX layers
+    (``keys set`` / ``keys fill-missing`` / doctor) can then render a
+    "↪ bound to <url>" hint right after the secret is saved or
+    probed, which is the primary signal an operator gets that a
+    fresh key is being paired with the wrong region/host. Returns
+    ``""`` when the credential has no paired endpoint or when the
+    config doesn't expose one.
     """
 
     env_name: str
@@ -76,6 +86,7 @@ class CredentialSpec:
     required: Callable[[Config], Requirement]
     auto_detected: bool = False
     effective_env_name: Callable[[Config], str] | None = None
+    bound_endpoint: Callable[[Config], str] | None = None
 
     def resolve_env_name(self, cfg: Config) -> str:
         """Return the env var name currently in effect for *cfg*."""
@@ -84,6 +95,19 @@ class CredentialSpec:
             if override:
                 return override
         return self.env_name
+
+    def resolve_bound_endpoint(self, cfg: Config) -> str:
+        """Return the paired endpoint URL/host for *cfg*, or ``""``.
+
+        Never raises — UX callers depend on a stable empty-string
+        sentinel so they can branch on truthiness without try/except.
+        """
+        if self.bound_endpoint is None:
+            return ""
+        try:
+            return self.bound_endpoint(cfg) or ""
+        except Exception:
+            return ""
 
 
 # ---------------------------------------------------------------------------
@@ -251,6 +275,20 @@ def _cisco_env(cfg: Config) -> str:
     return cad.api_key_env if cad is not None else ""
 
 
+def _cisco_endpoint(cfg: Config) -> str:
+    """Return the configured AI Defense region endpoint.
+
+    The single biggest source of "valid key looks invalid" reports is
+    a key issued for one regional deployment (us / eu / preview)
+    pasted into a config pointed at another. All three regions reply
+    with the same opaque ``401 invalid api key`` body, so the caller
+    can't tell auth from regional mismatch by status alone — the
+    only durable signal is "here's the URL we're sending it to".
+    """
+    cad = getattr(cfg, "cisco_ai_defense", None)
+    return getattr(cad, "endpoint", "") if cad is not None else ""
+
+
 def _virustotal_env(cfg: Config) -> str:
     sc = getattr(cfg, "scanners", None)
     if sc is None:
@@ -317,6 +355,7 @@ CREDENTIALS: tuple[CredentialSpec, ...] = (
         description="API key for Cisco AI Defense remote scanner (scanner_mode=remote|both)",
         required=_cisco_ai_defense_key,
         effective_env_name=_cisco_env,
+        bound_endpoint=_cisco_endpoint,
     ),
     CredentialSpec(
         env_name="VIRUSTOTAL_API_KEY",

--- a/cli/tests/test_cmd_doctor.py
+++ b/cli/tests/test_cmd_doctor.py
@@ -28,6 +28,7 @@ from defenseclaw.commands.cmd_doctor import (
     _ANTHROPIC_DEFAULT_PROBE_MODEL,
     _anthropic_probe_model,
     _bedrock_region,
+    _check_cisco_ai_defense,
     _check_copilot_hooks,
     _check_guardrail_proxy,
     _check_hilt_support,
@@ -38,7 +39,14 @@ from defenseclaw.commands.cmd_doctor import (
     _probe_splunk_hec,
     _verify_bedrock,
 )
-from defenseclaw.config import Config, GatewayConfig, GuardrailConfig, LLMConfig, OpenShellConfig
+from defenseclaw.config import (
+    CiscoAIDefenseConfig,
+    Config,
+    GatewayConfig,
+    GuardrailConfig,
+    LLMConfig,
+    OpenShellConfig,
+)
 
 
 class DoctorGuardrailTests(unittest.TestCase):
@@ -923,6 +931,101 @@ class BedrockRoutingTests(unittest.TestCase):
         r = _DoctorResult()
         _check_llm_api_key(cfg, r)
         mock_bedrock.assert_called_once()
+
+
+class CiscoAIDefenseProbeTests(unittest.TestCase):
+    """The AI Defense probe surfaces an actionable hint on auth
+    failures because all three regional deployments (us / eu /
+    preview) reply with the same opaque ``401 invalid api key``
+    body. Without the endpoint hint, an operator who pasted a key
+    issued for a different region sees a generic "authentication
+    failed" and assumes the key is bad — re-issuing wastes a key
+    rotation cycle. The hint preserves the failure verdict (real
+    auth problems still fail loudly) but adds the URL we'll send
+    the key to and a remediation pointer to ``defenseclaw setup``.
+    """
+
+    def _make_cfg(self, *, endpoint: str = "https://us.api.inspect.aidefense.security.cisco.com") -> Config:
+        return Config(
+            data_dir="/tmp/defenseclaw",
+            audit_db="/tmp/defenseclaw/audit.db",
+            quarantine_dir="/tmp/defenseclaw/quarantine",
+            plugin_dir="/tmp/defenseclaw/plugins",
+            policy_dir="/tmp/defenseclaw/policies",
+            guardrail=GuardrailConfig(enabled=True, scanner_mode="remote"),
+            gateway=GatewayConfig(),
+            openshell=OpenShellConfig(),
+            cisco_ai_defense=CiscoAIDefenseConfig(
+                endpoint=endpoint, api_key_env="CISCO_AI_DEFENSE_API_KEY",
+            ),
+        )
+
+    @patch("defenseclaw.commands.cmd_doctor.click.echo")
+    @patch("defenseclaw.commands.cmd_doctor._http_probe", return_value=(401, "invalid api key"))
+    @patch("defenseclaw.commands.cmd_doctor._resolve_api_key", return_value="fake-key")
+    def test_401_emits_endpoint_and_setup_hint(
+        self, _mock_resolve, _mock_probe, mock_echo,
+    ):
+        cfg = self._make_cfg(endpoint="https://eu.api.inspect.aidefense.security.cisco.com")
+        r = _DoctorResult()
+        _check_cisco_ai_defense(cfg, r)
+        self.assertEqual(r.failed, 1, r.checks)
+        # Hints go through click.echo (not _emit) so they don't
+        # count toward the tally. Walk the captured calls and
+        # assert the operator-visible text appears.
+        printed = "\n".join(
+            call.args[0] if call.args else "" for call in mock_echo.call_args_list
+        )
+        self.assertIn(
+            "endpoint: https://eu.api.inspect.aidefense.security.cisco.com",
+            printed,
+        )
+        self.assertIn("defenseclaw setup", printed)
+
+    @patch("defenseclaw.commands.cmd_doctor.click.echo")
+    @patch("defenseclaw.commands.cmd_doctor._http_probe", return_value=(403, "forbidden"))
+    @patch("defenseclaw.commands.cmd_doctor._resolve_api_key", return_value="fake-key")
+    def test_403_also_emits_region_hint(
+        self, _mock_resolve, _mock_probe, mock_echo,
+    ):
+        # 403 is the same UX failure mode (authenticated but not
+        # authorized for the route) — same hint applies.
+        cfg = self._make_cfg()
+        r = _DoctorResult()
+        _check_cisco_ai_defense(cfg, r)
+        self.assertEqual(r.failed, 1, r.checks)
+        printed = "\n".join(
+            call.args[0] if call.args else "" for call in mock_echo.call_args_list
+        )
+        self.assertIn("defenseclaw setup", printed)
+
+    @patch("defenseclaw.commands.cmd_doctor._http_probe", return_value=(200, "ok"))
+    @patch("defenseclaw.commands.cmd_doctor._resolve_api_key", return_value="fake-key")
+    def test_200_is_pass_with_no_hint_noise(self, _mock_resolve, _mock_probe):
+        cfg = self._make_cfg()
+        r = _DoctorResult()
+        _check_cisco_ai_defense(cfg, r)
+        self.assertEqual(r.passed, 1, r.checks)
+        # The pass path uses the existing single-row format; no
+        # extra hints should fire so we don't train operators to
+        # ignore them on the happy path.
+        details = " ".join(c["detail"] for c in r.checks)
+        self.assertNotIn("↪", details)
+
+    @patch("defenseclaw.commands.cmd_doctor.click.echo")
+    @patch("defenseclaw.commands.cmd_doctor._http_probe", return_value=(0, "DNS failure"))
+    @patch("defenseclaw.commands.cmd_doctor._resolve_api_key", return_value="fake-key")
+    def test_unreachable_warns_and_shows_endpoint(
+        self, _mock_resolve, _mock_probe, mock_echo,
+    ):
+        cfg = self._make_cfg(endpoint="https://preview.api.inspect.aidefense.aiteam.cisco.com")
+        r = _DoctorResult()
+        _check_cisco_ai_defense(cfg, r)
+        self.assertEqual(r.warned, 1, r.checks)
+        printed = "\n".join(
+            call.args[0] if call.args else "" for call in mock_echo.call_args_list
+        )
+        self.assertIn("preview.api.inspect.aidefense.aiteam.cisco.com", printed)
 
 
 if __name__ == "__main__":

--- a/cli/tests/test_cmd_keys.py
+++ b/cli/tests/test_cmd_keys.py
@@ -30,6 +30,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from defenseclaw.commands.cmd_keys import keys_cmd
 from defenseclaw.config import (
+    CiscoAIDefenseConfig,
     Config,
     GatewayConfig,
     GuardrailConfig,
@@ -48,6 +49,7 @@ def _make_app_context(data_dir: str, **overrides) -> AppContext:
         guardrail=overrides.get("guardrail", GuardrailConfig()),
         gateway=overrides.get("gateway", GatewayConfig()),
         openshell=overrides.get("openshell", OpenShellConfig()),
+        cisco_ai_defense=overrides.get("cisco_ai_defense", CiscoAIDefenseConfig()),
     )
     ctx = AppContext()
     ctx.cfg = cfg
@@ -130,6 +132,67 @@ class KeysSetTests(unittest.TestCase):
                 obj=app,
             )
             self.assertNotEqual(result.exit_code, 0)
+
+
+class BoundEndpointHintTests(unittest.TestCase):
+    """When a credential has a paired endpoint (today: AI Defense
+    region URL), `keys set` and `keys fill-missing` must surface the
+    bound URL right after the save line. The most common UX failure
+    we're catching is "operator pasted a key issued for a different
+    region into a config still pointed at the default" — all three
+    AID regions reply with the same opaque 401 body, so the only
+    durable signal of mismatch is showing the URL we'll send to.
+    """
+
+    def test_set_emits_bound_endpoint_for_cisco_aid(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app = _make_app_context(
+                tmp,
+                cisco_ai_defense=CiscoAIDefenseConfig(
+                    endpoint="https://eu.api.inspect.aidefense.security.cisco.com",
+                ),
+            )
+            runner = CliRunner()
+            result = runner.invoke(
+                keys_cmd,
+                ["set", "CISCO_AI_DEFENSE_API_KEY", "--value", "fake-aid-key-123"],
+                obj=app,
+            )
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            self.assertIn(
+                "↪ bound to https://eu.api.inspect.aidefense.security.cisco.com",
+                result.output,
+            )
+            self.assertIn("change region/host", result.output)
+
+    def test_set_does_not_emit_hint_for_unbound_credential(self):
+        """VirusTotal has no paired endpoint — no hint should fire,
+        otherwise we'd train operators to ignore them."""
+        with tempfile.TemporaryDirectory() as tmp:
+            app = _make_app_context(tmp)
+            runner = CliRunner()
+            result = runner.invoke(
+                keys_cmd,
+                ["set", "VIRUSTOTAL_API_KEY", "--value", "fake-vt-key"],
+                obj=app,
+            )
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            self.assertNotIn("↪ bound to", result.output)
+
+    def test_set_does_not_emit_hint_for_unregistered_env(self):
+        """Custom env vars without a registry entry (e.g. ad-hoc
+        operator-defined keys) must save successfully *and* not
+        attempt to render a hint — the spec is None in that path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            app = _make_app_context(tmp)
+            runner = CliRunner()
+            result = runner.invoke(
+                keys_cmd,
+                ["set", "DEFENSECLAW_TEST_CUSTOM_KEY", "--value", "abc"],
+                obj=app,
+            )
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            self.assertNotIn("↪ bound to", result.output)
 
 
 if __name__ == "__main__":

--- a/cli/tests/test_credentials.py
+++ b/cli/tests/test_credentials.py
@@ -28,6 +28,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from defenseclaw import credentials as C
 from defenseclaw.config import (
+    CiscoAIDefenseConfig,
     Config,
     GatewayConfig,
     GuardrailConfig,
@@ -201,6 +202,67 @@ class EffectiveEnvNameTests(unittest.TestCase):
         self.assertIsNotNone(spec)
         resolved = spec.resolve_env_name(cfg)
         self.assertIn(resolved, ("SPLUNK_ACCESS_TOKEN", ""))
+
+
+class BoundEndpointTests(unittest.TestCase):
+    """``CredentialSpec.bound_endpoint`` lets the registry attach the
+    URL/host a credential is paired with (e.g. AI Defense regional
+    endpoint). UX surfaces consume it via ``resolve_bound_endpoint``;
+    the contract is "non-empty string or empty string", never raise.
+    """
+
+    def test_cisco_aid_returns_configured_endpoint(self):
+        cfg = _make_cfg(
+            "/tmp/dc-test",
+            cisco_ai_defense=CiscoAIDefenseConfig(
+                endpoint="https://eu.api.inspect.aidefense.security.cisco.com",
+            ),
+        )
+        spec = C.lookup("CISCO_AI_DEFENSE_API_KEY")
+        self.assertIsNotNone(spec)
+        self.assertEqual(
+            spec.resolve_bound_endpoint(cfg),
+            "https://eu.api.inspect.aidefense.security.cisco.com",
+        )
+
+    def test_cisco_aid_default_endpoint_when_unset(self):
+        """No explicit override → returns the compiled-in US default
+        rather than empty. UX wants to render *something* so the
+        operator sees which region they're talking to even before
+        running setup."""
+        cfg = _make_cfg("/tmp/dc-test")
+        spec = C.lookup("CISCO_AI_DEFENSE_API_KEY")
+        self.assertIsNotNone(spec)
+        self.assertEqual(
+            spec.resolve_bound_endpoint(cfg),
+            "https://us.api.inspect.aidefense.security.cisco.com",
+        )
+
+    def test_no_bound_endpoint_returns_empty_string(self):
+        """Specs without a paired endpoint (e.g. VirusTotal API key)
+        must answer with ``""`` so callers can branch on truthiness
+        without try/except."""
+        cfg = _make_cfg("/tmp/dc-test")
+        spec = C.lookup("VIRUSTOTAL_API_KEY")
+        self.assertIsNotNone(spec)
+        self.assertEqual(spec.resolve_bound_endpoint(cfg), "")
+
+    def test_resolve_bound_endpoint_swallows_resolver_errors(self):
+        """If a future resolver raises (e.g. config refactor changes
+        an attribute name), the UX must still render — the hint is
+        advisory, not load-bearing."""
+        def boom(_cfg):
+            raise RuntimeError("synthetic")
+
+        cfg = _make_cfg("/tmp/dc-test")
+        spec = C.CredentialSpec(
+            env_name="X",
+            feature="x",
+            description="x",
+            required=lambda _c: C.Requirement.OPTIONAL,
+            bound_endpoint=boom,
+        )
+        self.assertEqual(spec.resolve_bound_endpoint(cfg), "")
 
 
 class ResolveTests(unittest.TestCase):

--- a/docs-site/content/docs/reference/gateway-api.mdx
+++ b/docs-site/content/docs/reference/gateway-api.mdx
@@ -235,7 +235,9 @@ The four `/api/v1/inspect/*` endpoints return a [`ToolInspectVerdict`](https://g
   ],
   "mode":       "action | observe",
   "would_block": true,
-  "approval_timeout_ms": 0
+  "approval_timeout_ms": 0,
+  "evaluation_id": "eval-7f3a…",
+  "rule_ids":      ["shell.dangerous-rm"]
 }
 ```
 
@@ -243,8 +245,30 @@ Notable behaviours:
 
 - **`action` is the *effective* verdict, not the raw policy decision.** `applyMode()` downgrades `block` / `confirm` / `alert` to `allow` when the gateway is in `observe` mode, but preserves the raw verdict in `raw_action` and the would-have-blocked signal in `would_block`. This is how observe-mode dry-runs work without touching the rule pack.
 - **`confirm` is the in-process HITL signal.** The gateway resolves the operator approval inline (via the in-process `HILTApprovalManager` it constructs in `SetHILTApprovalManager()`) before returning. There is **no** HTTP HITL surface — every HITL decision happens in-process and the verdict is downgraded to `allow` or `block` before the response is written. The TUI reads HITL state from the audit DB, not from a `/v1/hilt/*` endpoint.
+- **`evaluation_id` is the runtime join key.** For every `/api/v1/inspect/*` call and every connector hook (`/api/v1/{claude-code,codex,cursor,windsurf,geminicli,copilot,hermes}/hook`), the gateway mints a UUID and stamps it on (a) the structured `EventScan` / `EventScanFinding` / `EventVerdict` rows in `gateway.jsonl`, (b) the matching `scan_results.evaluation_id` / `scan_findings.evaluation_id` / `judge_responses.evaluation_id` columns in the audit DB, and (c) the `evaluation_id` and `rule_ids` fields in this response. SIEM dashboards keyed on `evaluation_id` can pivot from any per-finding row back to the aggregate evaluation and the verdict that gated it. See [Observability §1.4](/docs/observability) for the full per-surface contract.
+- **`detailed_findings` and `findings` are both populated** for backward compatibility. Existing clients that only read `findings: []string` are unaffected by the new structured field.
 
 Other endpoints return their own shapes — `/v1/skill/scan` returns a scanner-specific envelope, `/audit/event` returns `{"status": "stored", "id": "..."}`, `/skill/disable` returns `{"status": "disabled", "skillKey": "..."}`. Always confirm against the handler code before assuming a shape.
+
+## Connector hook responses
+
+Every connector hook response (`/api/v1/{claude-code,codex,cursor,...}/hook`) carries the same correlation triplet as the inspect verdict so SIEM joins work uniformly across both surfaces:
+
+```json
+{
+  "action":        "allow | block | deny | …",
+  "reason":        "rule X fired",
+  "findings":      ["rule.id.one", "rule.id.two"],
+  "detailed_findings": [
+    { "rule_id": "rule.id.one", "title": "…", "severity": "HIGH",
+      "confidence": 0.88, "evidence": "…", "tags": [] }
+  ],
+  "evaluation_id": "eval-c1d0…",
+  "rule_ids":      ["rule.id.one", "rule.id.two"]
+}
+```
+
+`detailed_findings` is opt-in (gated by an `X-DefenseClaw-Reveal-Findings: 1` header so existing string-only clients don't get a payload change), and `findings` continues to ship by default. `evaluation_id` and `rule_ids` are always populated when at least one rule fired.
 
 ## Headers
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -89,6 +89,88 @@ standard `OTEL_*` environment variables. There is **no** Splunk-specific
 coupling in the telemetry stack; operators who need a Splunk access
 token put it in `otel.headers` or `OTEL_EXPORTER_OTLP_HEADERS`.
 
+### 1.4 Unified finding pipeline
+
+Every runtime detection — whether it originates from a hook-based
+connector, an inspect HTTP endpoint, the proxy guardrail, a tool-call
+inspection, a mid-stream check, an asset-policy evaluation, or a
+rescan drift comparison — goes through the same `scanner.EmitScanResult`
+choke point as classic skill/MCP scans. There is exactly one finding
+pipeline, regardless of source. Practically, this means every finding
+is guaranteed to land on **all** of the following surfaces:
+
+1. `gateway.jsonl` (and every fanned-out audit sink) — one `EventScan`
+   row plus one `EventScanFinding` row per finding.
+2. `audit.sqlite` — one `scan_results` row plus one `scan_findings`
+   row per finding.
+3. Prometheus / OTel — `defenseclaw_scan_findings_by_rule_total`
+   (per-rule), `defenseclaw_scan_findings_total` (per-severity),
+   `defenseclaw_scan_count_total`, and `defenseclaw_scan_duration_*`.
+4. Correlator inputs — multi-step attack patterns see every finding,
+   not just those from CLI scans.
+
+The runtime origin is encoded on the `scanner` label, so dashboards can
+slice findings by source without changing the query shape:
+
+| `scanner=` value     | Origin                                                |
+|----------------------|-------------------------------------------------------|
+| `skill`              | Classic skill scanner (CLI / install / watcher)       |
+| `mcp`                | Classic MCP scanner (CLI / install / watcher)         |
+| `hook-rules`         | Hook-based connector rule engine (claudecode, codex, cursor, windsurf, geminicli, copilot, hermes) |
+| `inspect-http`       | `/api/v1/inspect/{request,response,tool-response,tool}` |
+| `guardrail-llm`      | Proxy guardrail final-stage verdict                   |
+| `mid-stream`         | Mid-stream guardrail re-check                         |
+| `tool-call-inspect`  | Inline tool-call guardrail check during proxy flow    |
+| `asset-policy`       | Runtime asset-policy enforcement (skills/MCP install) |
+| `drift`              | Rescan drift detection (new/removed/changed findings) |
+
+#### `evaluation_id` — the runtime join key
+
+For runtime sources (everything except classic `skill`/`mcp`), every
+emission carries an `evaluation_id` (UUID) generated at the entry
+point and propagated through the entire fan-out. It surfaces as:
+
+- `scan.evaluation_id` on the aggregate `EventScan` row.
+- `scan_finding.evaluation_id` on every child `EventScanFinding` row.
+- `verdict.evaluation_id` on the corresponding `EventVerdict` (proxy
+  guardrail / hook / inspect flows).
+- `error.evaluation_id` on schema-violation `EventError` rows when the
+  dropped payload was attributable to an evaluation (so a malformed
+  finding does not become an anonymous infrastructure error).
+- `evaluation_id` column on the `scan_results` and `scan_findings`
+  audit DB tables.
+- Audit log `details` for hook / HILT / asset-policy decisions, as
+  `evaluation_id=<uuid> rule_ids=<id1,id2,...>`.
+
+#### Pivot examples
+
+```text
+# All findings that fired during one proxy request:
+gateway.jsonl: event_type=scan_finding evaluation_id="eval-…"
+
+# Aggregate scan row + every child finding + the verdict that gated
+# the request, joined on evaluation_id:
+SELECT * FROM scan_results    WHERE evaluation_id = 'eval-…';
+SELECT * FROM scan_findings   WHERE evaluation_id = 'eval-…';
+SELECT * FROM judge_responses WHERE evaluation_id = 'eval-…';
+
+# Prometheus: how many findings did rule X fire across all surfaces
+# in the last hour, regardless of whether they came from a hook, the
+# proxy, or a CLI scan?
+sum(increase(defenseclaw_scan_findings_by_rule_total{rule_id="…"}[1h]))
+```
+
+#### Connectors that emit findings
+
+All hook-based connectors — Claude Code (`claudecode`), Codex
+(`codex`), Cursor (`cursor`), Windsurf (`windsurf`), Gemini CLI
+(`geminicli`), Copilot (`copilot`), Hermes (`hermes`) — emit per-rule
+findings through this pipeline. The HTTP hook response keeps the
+existing `findings: []string` field (backward-compatible) and adds an
+opt-in `detailed_findings: []RuleFinding` block plus top-level
+`evaluation_id` and `rule_ids` fields. Clients that don't read the
+new fields are unaffected.
+
 ---
 
 ## 2. Migration from v3 → v4

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -200,6 +200,17 @@ func (l *Logger) SetGatewayLogWriter(w *gatewaylog.Writer) {
 	l.mu.Unlock()
 }
 
+// GatewayLogWriter returns the installed gateway JSONL writer (may
+// be nil when none is wired). Callers outside the audit package
+// use this to fan EventScan / EventScanFinding events from
+// runtime finding emitters (hook handlers, /api/v1/inspect/*,
+// proxy guardrail, mid-stream, tool-call-inspect) through the
+// same choke point as scanner.EmitScanResult, so gateway.jsonl
+// stays the single source of truth.
+func (l *Logger) GatewayLogWriter() *gatewaylog.Writer {
+	return l.gatewayWriterSnapshot()
+}
+
 func (l *Logger) gatewayWriterSnapshot() *gatewaylog.Writer {
 	l.mu.RLock()
 	w := l.gwWriter

--- a/internal/audit/scan_persist.go
+++ b/internal/audit/scan_persist.go
@@ -31,8 +31,9 @@ INSERT INTO scan_results (
   id, scanner, target, timestamp, duration_ms, finding_count, max_severity, raw_json, run_id,
   verdict, exit_code, error,
   schema_version, content_hash, generation, binary_version,
-  agent_id, agent_instance_id, sidecar_instance_id, session_id, request_id, trace_id
-) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+  agent_id, agent_instance_id, sidecar_instance_id, session_id, request_id, trace_id,
+  evaluation_id
+) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		p.ScanID,
 		p.Scanner,
 		p.Target,
@@ -55,6 +56,7 @@ INSERT INTO scan_results (
 		nullStr(p.SessionID),
 		nullStr(p.RequestID),
 		nullStr(p.TraceID),
+		nullStr(p.EvaluationID),
 	)
 	if err != nil {
 		return fmt.Errorf("audit: insert scan summary: %w", err)
@@ -100,6 +102,11 @@ func (s *Store) InsertScanFindings(scanID, target string, findings []scanner.Fin
 			decisionPath = string(f.DecisionPath)
 		}
 
+		var confidence interface{}
+		if f.Confidence > 0 {
+			confidence = f.Confidence
+		}
+
 		id := uuid.New().String()
 		_, err := s.db.Exec(`
 INSERT INTO scan_findings (
@@ -107,8 +114,9 @@ INSERT INTO scan_findings (
   remediation, tags, timestamp,
   run_id, request_id, session_id, agent_id, agent_instance_id, sidecar_instance_id,
   schema_version, content_hash, generation, binary_version,
-  data_axis, tool_capability_class, content_fingerprint, external_endpoint, turn_id, decision_path
-) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+  data_axis, tool_capability_class, content_fingerprint, external_endpoint, turn_id, decision_path,
+  confidence, evaluation_id
+) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 			id,
 			scanID,
 			f.Scanner,
@@ -139,6 +147,8 @@ INSERT INTO scan_findings (
 			nullStr(f.ExternalEndpoint),
 			turnID,
 			decisionPath,
+			confidence,
+			nullStr(meta.EvaluationID),
 		)
 		if err != nil {
 			return fmt.Errorf("audit: insert scan finding: %w", err)
@@ -162,12 +172,22 @@ type ScanFindingRow struct {
 	LineNumber  sql.NullInt64
 	Remediation sql.NullString
 	Tags        sql.NullString
+	// Confidence is the per-finding model/heuristic score (0.0-1.0).
+	// Populated for runtime detections (hooks, inspect, proxy
+	// guardrail, mid-stream); zero for classic scanner CLIs that
+	// don't emit a confidence channel.
+	Confidence float64
+	// EvaluationID is the join key back to the upstream runtime
+	// evaluation (hook handler, /api/v1/inspect/*, proxy guardrail,
+	// rescan). Empty for classic scanner-CLI invocations.
+	EvaluationID string
 }
 
 // ListScanFindings returns persisted findings for a scan_id.
 func (s *Store) ListScanFindings(scanID string) ([]ScanFindingRow, error) {
 	rows, err := s.db.Query(`
-SELECT id, scan_id, scanner, target, rule_id, category, severity, title, description, location, line_number, remediation, tags
+SELECT id, scan_id, scanner, target, rule_id, category, severity, title, description, location, line_number,
+       remediation, tags, confidence, evaluation_id
 FROM scan_findings WHERE scan_id = ? ORDER BY severity`, scanID)
 	if err != nil {
 		return nil, fmt.Errorf("audit: list scan findings: %w", err)
@@ -177,11 +197,20 @@ FROM scan_findings WHERE scan_id = ? ORDER BY severity`, scanID)
 	var out []ScanFindingRow
 	for rows.Next() {
 		var r ScanFindingRow
+		var confidence sql.NullFloat64
+		var evaluationID sql.NullString
 		if err := rows.Scan(
 			&r.ID, &r.ScanID, &r.Scanner, &r.Target, &r.RuleID, &r.Category,
 			&r.Severity, &r.Title, &r.Description, &r.Location, &r.LineNumber, &r.Remediation, &r.Tags,
+			&confidence, &evaluationID,
 		); err != nil {
 			return nil, fmt.Errorf("audit: scan finding row: %w", err)
+		}
+		if confidence.Valid {
+			r.Confidence = confidence.Float64
+		}
+		if evaluationID.Valid {
+			r.EvaluationID = evaluationID.String
 		}
 		out = append(out, r)
 	}

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -932,6 +932,72 @@ var migrations = []migration{
 			return nil
 		},
 	},
+	{
+		// Unified runtime finding pipeline: scan_findings.confidence
+		// captures the regex / judge / AID detector self-reported
+		// score (0..1) so SIEM can rank by certainty alongside
+		// severity. evaluation_id on both scan_results and
+		// scan_findings joins each row to the upstream runtime
+		// evaluation (hook, /api/v1/inspect/*, proxy guardrail,
+		// mid-stream, tool-call-inspect, watcher rescan) that
+		// produced it. Classic scanner-invocation paths leave
+		// evaluation_id NULL.
+		description: "runtime findings: add confidence + evaluation_id to scan_results/scan_findings",
+		apply: func(ex dbExecer) error {
+			present, err := tableExists(ex, "scan_findings")
+			if err != nil {
+				return err
+			}
+			if present {
+				for _, spec := range []struct {
+					table, column, stmt string
+				}{
+					{"scan_findings", "confidence", `ALTER TABLE scan_findings ADD COLUMN confidence REAL`},
+					{"scan_findings", "evaluation_id", `ALTER TABLE scan_findings ADD COLUMN evaluation_id TEXT`},
+				} {
+					exists, err := hasColumnDB(ex, spec.table, spec.column)
+					if err != nil {
+						return err
+					}
+					if !exists {
+						if _, err := ex.Exec(spec.stmt); err != nil {
+							return fmt.Errorf("alter %s.%s: %w", spec.table, spec.column, err)
+						}
+					}
+				}
+				if _, err := ex.Exec(
+					`CREATE INDEX IF NOT EXISTS idx_scan_findings_evaluation_id ` +
+						`ON scan_findings(evaluation_id)`,
+				); err != nil {
+					return fmt.Errorf("create idx_scan_findings_evaluation_id: %w", err)
+				}
+			}
+			summaryPresent, err := tableExists(ex, "scan_results")
+			if err != nil {
+				return err
+			}
+			if summaryPresent {
+				exists, err := hasColumnDB(ex, "scan_results", "evaluation_id")
+				if err != nil {
+					return err
+				}
+				if !exists {
+					if _, err := ex.Exec(
+						`ALTER TABLE scan_results ADD COLUMN evaluation_id TEXT`,
+					); err != nil {
+						return fmt.Errorf("alter scan_results.evaluation_id: %w", err)
+					}
+				}
+				if _, err := ex.Exec(
+					`CREATE INDEX IF NOT EXISTS idx_scan_results_evaluation_id ` +
+						`ON scan_results(evaluation_id)`,
+				); err != nil {
+					return fmt.Errorf("create idx_scan_results_evaluation_id: %w", err)
+				}
+			}
+			return nil
+		},
+	},
 }
 
 // tableExists reports whether the given SQLite table is present.

--- a/internal/cli/embed/scan-result.json
+++ b/internal/cli/embed/scan-result.json
@@ -6,7 +6,16 @@
   "type": "object",
   "required": ["scanner", "target", "timestamp", "findings"],
   "properties": {
-    "scanner":   { "type": "string", "enum": ["skill", "mcp", "plugin", "aibom", "codeguard", "skill-scanner", "mcp-scanner", "plugin-scanner"] },
+    "scanner":   {
+      "type": "string",
+      "description": "Source of the scan. Classic scanner invocations use skill|mcp|plugin|aibom|codeguard (or their *-scanner aliases). Runtime finding emitters fanned out via EmitInspectFindings use hook-rules|inline-codeguard|ai-defense|asset-policy|tool-call-inspect|inspect-http|guardrail-llm|mid-stream|rescan.",
+      "enum": [
+        "skill", "mcp", "plugin", "aibom", "codeguard",
+        "skill-scanner", "mcp-scanner", "plugin-scanner",
+        "hook-rules", "inline-codeguard", "ai-defense", "asset-policy",
+        "tool-call-inspect", "inspect-http", "guardrail-llm", "mid-stream", "rescan"
+      ]
+    },
     "target":    { "type": "string" },
     "timestamp": { "type": "string", "format": "date-time" },
     "duration":  { "type": ["string", "null"] },

--- a/internal/gateway/agent_hook.go
+++ b/internal/gateway/agent_hook.go
@@ -95,6 +95,11 @@ type agentHookResponse struct {
 	WouldBlock        bool                   `json:"would_block"`
 	AdditionalContext string                 `json:"additional_context,omitempty"`
 	HookOutput        map[string]interface{} `json:"hook_output,omitempty"`
+	// EvaluationID + RuleIDs join this hook response to the
+	// matching scan_findings rows / audit row. Additive — older
+	// connector hook scripts ignore the fields.
+	EvaluationID string   `json:"evaluation_id,omitempty"`
+	RuleIDs      []string `json:"rule_ids,omitempty"`
 }
 
 func (a *APIServer) handleAgentHook(connectorName string) http.HandlerFunc {
@@ -218,6 +223,11 @@ func (a *APIServer) handleAgentHook(connectorName string) http.HandlerFunc {
 		// defenseclaw.panics.total{subsystem="gateway"} and on the
 		// `result="panic"` label on the standard hook invocation
 		// counter.
+		//
+		// resp.EvaluationID + resp.RuleIDs are stamped inside the
+		// per-profile evaluators (claudeCode / codex / generic) so
+		// they round-trip back to the HTTP response and onto the
+		// audit envelope without a second pass here.
 		resp, panicked := a.safeEvaluateHook(ctx, connectorName, req, b, payload, runtime)
 		elapsed := time.Since(t0)
 		enrichAgentHookSpan(ctx, req, resp, elapsed)
@@ -332,19 +342,21 @@ func (a *APIServer) finalizeAgentHook(
 			envResult = "panic"
 		}
 		env := HookAuditEnvelope{
-			Connector:   connectorName,
-			Event:       req.HookEventName,
-			Result:      envResult,
-			Action:      resp.Action,
-			RawAction:   resp.RawAction,
-			Severity:    resp.Severity,
-			Mode:        resp.Mode,
-			Reason:      resp.Reason,
-			WouldBlock:  resp.WouldBlock,
-			ElapsedMs:   elapsed.Milliseconds(),
-			BodyBytes:   int64(len(rawBody)),
-			RawOrigin:   rawOriginIfHook(rawEventIDs),
-			RawEventIDs: rawEventIDs,
+			Connector:    connectorName,
+			Event:        req.HookEventName,
+			Result:       envResult,
+			Action:       resp.Action,
+			RawAction:    resp.RawAction,
+			Severity:     resp.Severity,
+			Mode:         resp.Mode,
+			Reason:       resp.Reason,
+			WouldBlock:   resp.WouldBlock,
+			ElapsedMs:    elapsed.Milliseconds(),
+			BodyBytes:    int64(len(rawBody)),
+			RawOrigin:    rawOriginIfHook(rawEventIDs),
+			RawEventIDs:  rawEventIDs,
+			EvaluationID: resp.EvaluationID,
+			RuleIDs:      resp.RuleIDs,
 		}
 		if panicked {
 			env.Extra = map[string]string{"panic": "true"}
@@ -561,6 +573,8 @@ func (a *APIServer) handleAgentHookSynthetic(ctx context.Context, connectorName 
 		BodyBytes:           int64(len(rawBody)),
 		RawOrigin:           rawOriginIfHook(rawEventIDs),
 		RawEventIDs:         rawEventIDs,
+		EvaluationID:        resp.EvaluationID,
+		RuleIDs:             resp.RuleIDs,
 		AuditActionOverride: string(audit.ActionConnectorHookSynthetic),
 		Extra:               mergeHookEnvelopeExtra(extra, hookCompatibilityExtra(profile)),
 	}
@@ -1269,6 +1283,7 @@ func (a *APIServer) evaluateAgentHook(ctx context.Context, req agentHookRequest)
 	if a.scannerCfg != nil && !a.agentHookEnabled(req.ConnectorName) {
 		return agentHookResponseFor(req, "allow", "allow", "NONE", "", nil, mode, false, connector.HookCapability{})
 	}
+	t0 := time.Now()
 
 	verdict := &ToolInspectVerdict{Action: "allow", Severity: "NONE", Findings: []string{}}
 	var assetDecisions []runtimeAssetDecision
@@ -1328,10 +1343,22 @@ func (a *APIServer) evaluateAgentHook(ctx context.Context, req agentHookRequest)
 		}
 	}
 
+	// Emit the per-rule findings BEFORE dispatching the OS toast
+	// so the notification can carry the same evaluation_id +
+	// rule_ids surfaced on the audit row + HTTP response.
+	evalCtx := a.emitHookRuleFindings(ctx, req.ConnectorName, req.HookEventName, verdict,
+		hookTargetTypeForEvent(req.HookEventName), time.Since(t0))
 	if !hookNotificationCoveredByAssetPolicy(rawActionBeforeAssets, assetDecisions) {
-		a.dispatchAgentHookNotification(req, action, rawAction, severity, reason, wouldBlock)
+		a.dispatchAgentHookNotification(req, action, rawAction, severity, reason, wouldBlock, evalCtx)
 	}
-	return agentHookResponseForProfile(profile, req, action, rawAction, severity, reason, findings, mode, wouldBlock, caps)
+	resp := agentHookResponseForProfile(profile, req, action, rawAction, severity, reason, findings, mode, wouldBlock, caps)
+	// Stamp the unified-pipeline correlation keys so the HTTP
+	// response, the audit envelope (HookAuditEnvelope.EvaluationID
+	// / RuleIDs), and the scan_finding events all join on the same
+	// evaluation_id.
+	resp.EvaluationID = evalCtx.EvaluationID
+	resp.RuleIDs = evalCtx.RuleIDs
+	return resp
 }
 
 // collectAgentHookAssetDecisions runs the runtime asset-policy
@@ -1417,7 +1444,7 @@ func decodeAgentHookToolInput(raw json.RawMessage) map[string]interface{} {
 // req.ConnectorName so the subtitle reads e.g. "DefenseClaw hermes
 // PreToolUse" — operators paging through toasts can attribute each
 // one to a specific framework without opening the audit log.
-func (a *APIServer) dispatchAgentHookNotification(req agentHookRequest, action, rawAction, severity, reason string, wouldBlock bool) {
+func (a *APIServer) dispatchAgentHookNotification(req agentHookRequest, action, rawAction, severity, reason string, wouldBlock bool, evalCtx hookEvaluationContext) {
 	if a == nil || a.notifier == nil {
 		return
 	}
@@ -1427,12 +1454,14 @@ func (a *APIServer) dispatchAgentHookNotification(req agentHookRequest, action, 
 	}
 	safeReason := string(redaction.ForSinkReason(reason))
 	base := notifier.BlockEvent{
-		Source:    notifier.SourceHook,
-		Target:    target,
-		Reason:    safeReason,
-		Severity:  severity,
-		Connector: req.ConnectorName,
-		Event:     req.HookEventName,
+		Source:       notifier.SourceHook,
+		Target:       target,
+		Reason:       safeReason,
+		Severity:     severity,
+		Connector:    req.ConnectorName,
+		Event:        req.HookEventName,
+		EvaluationID: evalCtx.EvaluationID,
+		RuleIDs:      evalCtx.RuleIDs,
 	}
 	switch {
 	case action == "block":
@@ -1443,12 +1472,14 @@ func (a *APIServer) dispatchAgentHookNotification(req agentHookRequest, action, 
 		// Native chat-side ask actually issued — only path that
 		// belongs in the approvals category.
 		a.notifier.OnApprovalPending(notifier.ApprovalEvent{
-			Subject:   fmt.Sprintf("%s (%s)", target, req.HookEventName),
-			Reason:    safeReason,
-			Severity:  severity,
-			Source:    notifier.SourceHook,
-			Connector: req.ConnectorName,
-			Event:     req.HookEventName,
+			Subject:      fmt.Sprintf("%s (%s)", target, req.HookEventName),
+			Reason:       safeReason,
+			Severity:     severity,
+			Source:       notifier.SourceHook,
+			Connector:    req.ConnectorName,
+			Event:        req.HookEventName,
+			EvaluationID: evalCtx.EvaluationID,
+			RuleIDs:      evalCtx.RuleIDs,
 		})
 	case rawAction == "confirm":
 		// Verdict was confirm but the user will not see a chat ask

--- a/internal/gateway/agent_hook.go
+++ b/internal/gateway/agent_hook.go
@@ -426,6 +426,17 @@ func renderAgentHookResponseForProfile(profile connector.HookProfile, resp agent
 		}
 		out[fieldName] = resp.HookOutput
 	}
+	// Surface the unified-pipeline correlation keys so hook scripts
+	// + downstream tooling can pivot HTTP responses on the same
+	// evaluation_id used by gateway.jsonl + the audit DB. Both
+	// fields are additive — pre-existing hook scripts that ignore
+	// unknown keys continue to parse the same shape.
+	if resp.EvaluationID != "" {
+		out["evaluation_id"] = resp.EvaluationID
+	}
+	if len(resp.RuleIDs) > 0 {
+		out["rule_ids"] = resp.RuleIDs
+	}
 	return out
 }
 

--- a/internal/gateway/agent_hook_test.go
+++ b/internal/gateway/agent_hook_test.go
@@ -325,7 +325,7 @@ func TestAgentHookDispatch_BlockFiresOnBlock(t *testing.T) {
 		ToolName:      "Bash",
 	}
 	api.dispatchAgentHookNotification(req, "block", "block", "HIGH",
-		"matched policy: deny-rm-rf", false)
+		"matched policy: deny-rm-rf", false, hookEvaluationContext{})
 
 	got := rec.WaitFor(t, 1)
 	if !strings.Contains(strings.ToLower(got[0].Title), "block") {
@@ -349,6 +349,7 @@ func TestAgentHookDispatch_WouldBlockFiresOnWouldBlock(t *testing.T) {
 	api.dispatchAgentHookNotification(
 		agentHookRequest{ConnectorName: "geminicli", HookEventName: "BeforeTool", ToolName: "Read"},
 		"allow", "block", "MEDIUM", "observe-mode", true,
+		hookEvaluationContext{},
 	)
 	got := rec.WaitFor(t, 1)
 	if !strings.Contains(strings.ToLower(got[0].Title), "would") {
@@ -376,6 +377,7 @@ func TestAgentHookDispatch_ConfirmCarriesConnectorAndEvent(t *testing.T) {
 			ToolName:      "shell",
 		},
 		"confirm", "confirm", "HIGH", "matched: deny-rm-rf", false,
+		hookEvaluationContext{},
 	)
 	got := rec.WaitFor(t, 1)
 	if !strings.Contains(got[0].Title, "Approval needed") {
@@ -421,6 +423,7 @@ func TestAgentHookDispatch_ConfirmDowngradedRewordsToast(t *testing.T) {
 		// the surface action to "alert" because beforeReadFile is
 		// not in cursor's AskEvents.
 		"alert", "confirm", "HIGH", "matched: gateway.json access", false,
+		hookEvaluationContext{},
 	)
 	got := rec.WaitFor(t, 1)
 	if strings.Contains(got[0].Subtitle, "reply in chat") {
@@ -464,6 +467,7 @@ func TestAgentHookDispatch_ObserveModeConfirmRoutesThroughWouldBlock(t *testing.
 			ToolName:      "Shell",
 		},
 		"allow", "confirm", "HIGH", "matched: rm -rf /", false,
+		hookEvaluationContext{},
 	)
 	got := rec.WaitFor(t, 1)
 	if strings.Contains(strings.ToLower(got[0].Title), "approval needed") {
@@ -493,6 +497,7 @@ func TestAgentHookDispatch_RedactsReason(t *testing.T) {
 		agentHookRequest{ConnectorName: "copilot", HookEventName: "PreToolUse", ToolName: "shell"},
 		"block", "block", "HIGH",
 		"prompt contained AKIAIOSFODNN7EXAMPLE", false,
+		hookEvaluationContext{},
 	)
 	got := rec.WaitFor(t, 1)
 	if strings.Contains(got[0].Body, "AKIAIOSFODNN7EXAMPLE") {

--- a/internal/gateway/asset_policy_runtime.go
+++ b/internal/gateway/asset_policy_runtime.go
@@ -163,12 +163,14 @@ func (a *APIServer) evaluateRuntimeMCPAssetPolicy(ctx context.Context, connector
 			"would_block":         fmt.Sprintf("%t", decision.WouldBlock),
 		})
 	}
+	evalCtx := a.emitAssetPolicyDecisionFindings(ctx, decision, "mcp", connector, hookEvent)
 	if a.logger != nil {
-		a.logAssetPolicyAudit(ctx, "mcp:"+decision.TargetName,
-			fmt.Sprintf("action=%s source=%s registry_status=%s registry_configured=%v surface=%s hook=%s tool=%s connector=%s would_block=%v reason=%s",
-				decision.Action, decision.Source, decision.RegistryStatus, decision.RegistryConfigured, probe.Surface, hookEvent, probe.ToolName, connector, decision.WouldBlock, decision.Reason))
+		details := fmt.Sprintf("action=%s source=%s registry_status=%s registry_configured=%v surface=%s hook=%s tool=%s connector=%s would_block=%v reason=%s",
+			decision.Action, decision.Source, decision.RegistryStatus, decision.RegistryConfigured, probe.Surface, hookEvent, probe.ToolName, connector, decision.WouldBlock, decision.Reason)
+		details = appendHookEvaluationDetails(details, evalCtx)
+		a.logAssetPolicyAudit(ctx, "mcp:"+decision.TargetName, details)
 	}
-	a.dispatchAssetPolicyNotification(decision, "mcp", connector, hookEvent)
+	a.dispatchAssetPolicyNotification(decision, "mcp", connector, hookEvent, evalCtx)
 	return decision, true
 }
 
@@ -217,12 +219,14 @@ func (a *APIServer) evaluateRuntimeSkillAssetPolicy(ctx context.Context, connect
 		}
 		a.otel.EmitPolicyDecision("asset-policy", decision.Action, decision.TargetName, "skill", decision.Reason, attrs)
 	}
+	evalCtx := a.emitAssetPolicyDecisionFindings(ctx, decision, "skill", connector, hookEvent)
 	if a.logger != nil {
-		a.logAssetPolicyAudit(ctx, "skill:"+decision.TargetName,
-			fmt.Sprintf("action=%s source=%s registry_status=%s registry_configured=%v surface=%s hook=%s tool=%s connector=%s skill_name_raw=%q source_path=%q would_block=%v reason=%s",
-				decision.Action, decision.Source, decision.RegistryStatus, decision.RegistryConfigured, probe.Surface, hookEvent, probe.ToolName, connector, probe.RawName, probe.SourcePath, decision.WouldBlock, decision.Reason))
+		details := fmt.Sprintf("action=%s source=%s registry_status=%s registry_configured=%v surface=%s hook=%s tool=%s connector=%s skill_name_raw=%q source_path=%q would_block=%v reason=%s",
+			decision.Action, decision.Source, decision.RegistryStatus, decision.RegistryConfigured, probe.Surface, hookEvent, probe.ToolName, connector, probe.RawName, probe.SourcePath, decision.WouldBlock, decision.Reason)
+		details = appendHookEvaluationDetails(details, evalCtx)
+		a.logAssetPolicyAudit(ctx, "skill:"+decision.TargetName, details)
 	}
-	a.dispatchAssetPolicyNotification(decision, "skill", connector, hookEvent)
+	a.dispatchAssetPolicyNotification(decision, "skill", connector, hookEvent, evalCtx)
 	return decision, true
 }
 
@@ -248,9 +252,13 @@ func hookNotificationCoveredByAssetPolicy(rawActionBeforeAssets string, assetDec
 // for parity with the hook / proxy / HILT helpers — the toast is
 // rendered locally but a screenshot or screen recording is still a
 // data-exfil surface.
-func (a *APIServer) dispatchAssetPolicyNotification(decision config.AssetPolicyDecision, targetKind, connectorName, hookEvent string) {
+func (a *APIServer) dispatchAssetPolicyNotification(decision config.AssetPolicyDecision, targetKind, connectorName, hookEvent string, evalCtx ...hookEvaluationContext) {
 	if a == nil || a.notifier == nil {
 		return
+	}
+	var ec hookEvaluationContext
+	if len(evalCtx) > 0 {
+		ec = evalCtx[0]
 	}
 	target := strings.TrimSpace(decision.TargetName)
 	if target == "" {
@@ -259,12 +267,14 @@ func (a *APIServer) dispatchAssetPolicyNotification(decision config.AssetPolicyD
 		target = strings.ToLower(strings.TrimSpace(targetKind)) + ":" + target
 	}
 	ev := notifier.BlockEvent{
-		Source:    notifier.SourceAssetPolicy,
-		Target:    target,
-		Reason:    string(redaction.ForSinkReason(decision.Reason)),
-		Severity:  "HIGH",
-		Connector: connectorName,
-		Event:     hookEvent,
+		Source:       notifier.SourceAssetPolicy,
+		Target:       target,
+		Reason:       string(redaction.ForSinkReason(decision.Reason)),
+		Severity:     "HIGH",
+		Connector:    connectorName,
+		Event:        hookEvent,
+		EvaluationID: ec.EvaluationID,
+		RuleIDs:      ec.RuleIDs,
 	}
 	if decision.Action == "block" {
 		a.notifier.OnBlock(ev)

--- a/internal/gateway/claude_code_hook.go
+++ b/internal/gateway/claude_code_hook.go
@@ -79,6 +79,14 @@ type claudeCodeHookResponse struct {
 	WouldBlock        bool                   `json:"would_block"`
 	AdditionalContext string                 `json:"additional_context,omitempty"`
 	ClaudeCodeOutput  map[string]interface{} `json:"claude_code_output,omitempty"`
+	// EvaluationID joins this hook response to the matching audit
+	// row + per-finding scan_findings rows. Additive — older
+	// connector hook scripts ignore the field.
+	EvaluationID string `json:"evaluation_id,omitempty"`
+	// RuleIDs are the top detection rule_ids that drove this
+	// verdict (capped at 8). Lets operators correlate a block
+	// without joining against scan_findings. Additive.
+	RuleIDs []string `json:"rule_ids,omitempty"`
 }
 
 // Claude Code hook traffic flows through the unified pipeline at
@@ -87,13 +95,16 @@ type claudeCodeHookResponse struct {
 // concerns — audit envelope refresh, dispatch metric, dedup, trace
 // propagation, OTel emissions — live in exactly one place
 // (handleAgentHook) so per-connector handlers cannot drift apart on
-// any of those signals.
+// any of those signals. The evaluator stamps the unified-pipeline
+// correlation keys (resp.EvaluationID / resp.RuleIDs) on its return
+// value so downstream tooling and the audit envelope receive them.
 
 func (a *APIServer) evaluateClaudeCodeHook(ctx context.Context, req claudeCodeHookRequest) claudeCodeHookResponse {
 	mode := a.claudeCodeMode()
 	if a.scannerCfg != nil && !a.claudeCodeEnabled() {
 		return claudeCodeResponseFor(req, "allow", "allow", "NONE", "", nil, mode, false)
 	}
+	t0 := time.Now()
 
 	verdict := &ToolInspectVerdict{Action: "allow", Severity: "NONE", Findings: []string{}}
 	var assetDecisions []runtimeAssetDecision
@@ -174,10 +185,26 @@ func (a *APIServer) evaluateClaudeCodeHook(ctx context.Context, req claudeCodeHo
 			wouldBlock = true
 		}
 	}
+	// Fan the rule-level findings through the unified runtime
+	// finding pipeline so SIEM sees one EventScanFinding per
+	// matched rule and the correlator gets a chance to upgrade
+	// the verdict on multi-step attack flows. scanner="hook-rules".
+	// Done before dispatchClaudeCodeHookNotification so the OS toast
+	// can carry the same evaluation_id + rule_ids that the audit
+	// row + HTTP response will surface.
+	evalCtx := a.emitHookRuleFindings(ctx, "claudecode", req.HookEventName, verdict,
+		hookTargetTypeForEvent(req.HookEventName), time.Since(t0))
 	if !hookNotificationCoveredByAssetPolicy(rawActionBeforeAssets, assetDecisions) {
-		a.dispatchClaudeCodeHookNotification(req, action, rawAction, verdict.Severity, verdict.Reason, wouldBlock)
+		a.dispatchClaudeCodeHookNotification(req, action, rawAction, verdict.Severity, verdict.Reason, wouldBlock, evalCtx)
 	}
-	return claudeCodeResponseFor(req, action, rawAction, verdict.Severity, verdict.Reason, verdict.Findings, mode, wouldBlock)
+	resp := claudeCodeResponseFor(req, action, rawAction, verdict.Severity, verdict.Reason, verdict.Findings, mode, wouldBlock)
+	// Stamp the unified-pipeline correlation keys so the agent-hook
+	// dispatch wrapper (claudeCodeResponseToAgentHookResponse) and
+	// the audit envelope (HookAuditEnvelope.EvaluationID / RuleIDs)
+	// both see them without a second pass.
+	resp.EvaluationID = evalCtx.EvaluationID
+	resp.RuleIDs = evalCtx.RuleIDs
+	return resp
 }
 
 // dispatchClaudeCodeHookNotification fires a user-session OS toast
@@ -203,7 +230,7 @@ func (a *APIServer) evaluateClaudeCodeHook(ctx context.Context, req claudeCodeHo
 // through OnWouldBlock with WouldAsk=true so a single
 // notifications.block_would_block=false silences all observe-mode
 // noise without affecting real native asks.
-func (a *APIServer) dispatchClaudeCodeHookNotification(req claudeCodeHookRequest, action, rawAction, severity, reason string, wouldBlock bool) {
+func (a *APIServer) dispatchClaudeCodeHookNotification(req claudeCodeHookRequest, action, rawAction, severity, reason string, wouldBlock bool, evalCtx hookEvaluationContext) {
 	if a == nil || a.notifier == nil {
 		return
 	}
@@ -213,12 +240,14 @@ func (a *APIServer) dispatchClaudeCodeHookNotification(req claudeCodeHookRequest
 	}
 	safeReason := string(redaction.ForSinkReason(reason))
 	base := notifier.BlockEvent{
-		Source:    notifier.SourceHook,
-		Target:    target,
-		Reason:    safeReason,
-		Severity:  severity,
-		Connector: "claudecode",
-		Event:     req.HookEventName,
+		Source:       notifier.SourceHook,
+		Target:       target,
+		Reason:       safeReason,
+		Severity:     severity,
+		Connector:    "claudecode",
+		Event:        req.HookEventName,
+		EvaluationID: evalCtx.EvaluationID,
+		RuleIDs:      evalCtx.RuleIDs,
 	}
 	switch {
 	case action == "block":
@@ -227,12 +256,14 @@ func (a *APIServer) dispatchClaudeCodeHookNotification(req claudeCodeHookRequest
 		a.notifier.OnWouldBlock(base)
 	case action == "confirm":
 		a.notifier.OnApprovalPending(notifier.ApprovalEvent{
-			Subject:   fmt.Sprintf("%s (%s)", target, req.HookEventName),
-			Reason:    safeReason,
-			Severity:  severity,
-			Source:    notifier.SourceHook,
-			Connector: "claudecode",
-			Event:     req.HookEventName,
+			Subject:      fmt.Sprintf("%s (%s)", target, req.HookEventName),
+			Reason:       safeReason,
+			Severity:     severity,
+			Source:       notifier.SourceHook,
+			Connector:    "claudecode",
+			Event:        req.HookEventName,
+			EvaluationID: evalCtx.EvaluationID,
+			RuleIDs:      evalCtx.RuleIDs,
 		})
 	case rawAction == "confirm":
 		evt := base

--- a/internal/gateway/codex_hook.go
+++ b/internal/gateway/codex_hook.go
@@ -75,20 +75,28 @@ type codexHookResponse struct {
 	WouldBlock        bool                   `json:"would_block"`
 	AdditionalContext string                 `json:"additional_context,omitempty"`
 	CodexOutput       map[string]interface{} `json:"codex_output,omitempty"`
+	// EvaluationID + RuleIDs join this hook response to the
+	// matching scan_findings rows / audit row. Additive — older
+	// connector hook scripts ignore the fields.
+	EvaluationID string   `json:"evaluation_id,omitempty"`
+	RuleIDs      []string `json:"rule_ids,omitempty"`
 }
 
-// handleCodexHook + enrichCodexHookContext were deleted in PR #284.
-// Codex hook traffic now flows through the unified pipeline at
-// handleAgentHook("codex"); the typed evaluator (evaluateCodexHook,
-// kept below) is invoked through the HookProfile runtime registry.
-// Codex-specific span enrichment (turn_id, gen_ai.tool.call.id, model)
-// is preserved by the runtime callback immediately before
-// evaluateCodexHook runs.
+// handleCodexHook + enrichCodexHookContext were deleted in the
+// unified hook collector refactor. Codex hook traffic now flows
+// through the unified pipeline at handleAgentHook("codex"); the
+// typed evaluator (evaluateCodexHook, kept below) is invoked through
+// the HookProfile runtime registry. Codex-specific span enrichment
+// (turn_id, gen_ai.tool.call.id, model) is preserved by the runtime
+// callback immediately before evaluateCodexHook runs.
 //
 // The unified pipeline owns shared concerns (audit envelope refresh,
 // dispatch metric, dedup, trace propagation, OTel emissions) in
 // exactly one place now. See agent_hook.go and hook_profile_runtime.go
-// for the registry and shared-pipeline rationale.
+// for the registry and shared-pipeline rationale. The evaluator
+// stamps the unified-pipeline correlation keys (resp.EvaluationID /
+// resp.RuleIDs) on its return value so downstream tooling and the
+// audit envelope receive them.
 
 func enrichCodexHookSpan(ctx context.Context, req codexHookRequest) {
 	span := trace.SpanFromContext(ctx)
@@ -132,6 +140,7 @@ func (a *APIServer) evaluateCodexHook(ctx context.Context, req codexHookRequest)
 	if a.scannerCfg != nil && !a.codexEnabled() {
 		return codexResponseFor(req.HookEventName, "allow", "allow", "NONE", "", nil, mode, false)
 	}
+	t0 := time.Now()
 
 	verdict := &ToolInspectVerdict{Action: "allow", Severity: "NONE", Findings: []string{}}
 	var assetDecisions []runtimeAssetDecision
@@ -210,10 +219,20 @@ func (a *APIServer) evaluateCodexHook(ctx context.Context, req codexHookRequest)
 			wouldBlock = true
 		}
 	}
+	// Emit per-rule findings FIRST so the notification + audit
+	// rows produced below can carry the resulting evaluation_id
+	// and top rule_ids — keeping the SIEM pivot key identical
+	// across audit log, gateway.jsonl, OS notification, and the
+	// HTTP response body.
+	evalCtx := a.emitHookRuleFindings(ctx, "codex", req.HookEventName, verdict,
+		hookTargetTypeForEvent(req.HookEventName), time.Since(t0))
 	if !hookNotificationCoveredByAssetPolicy(rawActionBeforeAssets, assetDecisions) {
-		a.dispatchCodexHookNotification(req, action, rawAction, verdict.Severity, verdict.Reason, wouldBlock)
+		a.dispatchCodexHookNotification(req, action, rawAction, verdict.Severity, verdict.Reason, wouldBlock, evalCtx)
 	}
-	return codexResponseFor(req.HookEventName, action, rawAction, verdict.Severity, verdict.Reason, verdict.Findings, mode, wouldBlock)
+	resp := codexResponseFor(req.HookEventName, action, rawAction, verdict.Severity, verdict.Reason, verdict.Findings, mode, wouldBlock)
+	resp.EvaluationID = evalCtx.EvaluationID
+	resp.RuleIDs = evalCtx.RuleIDs
+	return resp
 }
 
 // dispatchCodexHookNotification mirrors the Claude Code path —
@@ -222,7 +241,7 @@ func (a *APIServer) evaluateCodexHook(ctx context.Context, req codexHookRequest)
 // dispatchCodexHookNotification follows the same routing contract
 // documented on dispatchAgentHookNotification. See that comment for
 // the rationale behind WouldAsk routing through OnWouldBlock.
-func (a *APIServer) dispatchCodexHookNotification(req codexHookRequest, action, rawAction, severity, reason string, wouldBlock bool) {
+func (a *APIServer) dispatchCodexHookNotification(req codexHookRequest, action, rawAction, severity, reason string, wouldBlock bool, evalCtx hookEvaluationContext) {
 	if a == nil || a.notifier == nil {
 		return
 	}
@@ -232,12 +251,14 @@ func (a *APIServer) dispatchCodexHookNotification(req codexHookRequest, action, 
 	}
 	safeReason := string(redaction.ForSinkReason(reason))
 	base := notifier.BlockEvent{
-		Source:    notifier.SourceHook,
-		Target:    target,
-		Reason:    safeReason,
-		Severity:  severity,
-		Connector: "codex",
-		Event:     req.HookEventName,
+		Source:       notifier.SourceHook,
+		Target:       target,
+		Reason:       safeReason,
+		Severity:     severity,
+		Connector:    "codex",
+		Event:        req.HookEventName,
+		EvaluationID: evalCtx.EvaluationID,
+		RuleIDs:      evalCtx.RuleIDs,
 	}
 	switch {
 	case action == "block":
@@ -246,12 +267,14 @@ func (a *APIServer) dispatchCodexHookNotification(req codexHookRequest, action, 
 		a.notifier.OnWouldBlock(base)
 	case action == "confirm":
 		a.notifier.OnApprovalPending(notifier.ApprovalEvent{
-			Subject:   fmt.Sprintf("%s (%s)", target, req.HookEventName),
-			Reason:    safeReason,
-			Severity:  severity,
-			Source:    notifier.SourceHook,
-			Connector: "codex",
-			Event:     req.HookEventName,
+			Subject:      fmt.Sprintf("%s (%s)", target, req.HookEventName),
+			Reason:       safeReason,
+			Severity:     severity,
+			Source:       notifier.SourceHook,
+			Connector:    "codex",
+			Event:        req.HookEventName,
+			EvaluationID: evalCtx.EvaluationID,
+			RuleIDs:      evalCtx.RuleIDs,
 		})
 	case rawAction == "confirm":
 		evt := base

--- a/internal/gateway/events.go
+++ b/internal/gateway/events.go
@@ -269,10 +269,25 @@ func emitEvent(ctx context.Context, e gatewaylog.Event) {
 	w.EmitContext(ctx, e)
 }
 
+// emitVerdictExtras carries optional verdict-event fields that
+// runtime finding emitters (guardrail Inspect, mid-stream,
+// tool-call inspect) stamp so SIEM can join the verdict to its
+// per-finding scan_findings rows. Pure additive — emitVerdict
+// callers that pass no extras get exactly the same wire shape as
+// before.
+type emitVerdictExtras struct {
+	EvaluationID string
+	RuleIDs      []string
+}
+
 // emitVerdict records a single guardrail-pipeline stage decision.
 // ctx carries the request correlation + agent identity that Gets
 // stamped onto the envelope. Pass context.Background() when emitting
 // outside a request (boot fall-backs, background self-tests).
+//
+// The variadic extras slot lets new call sites stamp evaluation_id
+// + rule_ids without forcing every existing caller (multi-turn,
+// block-list, approval-denied, etc.) to update.
 func emitVerdict(
 	ctx context.Context,
 	stage gatewaylog.Stage,
@@ -282,7 +297,12 @@ func emitVerdict(
 	severity gatewaylog.Severity,
 	categories []string,
 	latencyMs int64,
+	extras ...emitVerdictExtras,
 ) {
+	var ext emitVerdictExtras
+	if len(extras) > 0 {
+		ext = extras[0]
+	}
 	// Plan B6 / S0.10: VerdictPayload.Reason is documented as
 	// "short, redacted" but the redactor pipeline DOES legitimately
 	// receive raw-secret strings on the way in (the redaction layer
@@ -296,11 +316,13 @@ func emitVerdict(
 		Direction: direction,
 		Model:     model,
 		Verdict: &gatewaylog.VerdictPayload{
-			Stage:      stage,
-			Action:     action,
-			Reason:     reason,
-			Categories: categories,
-			LatencyMs:  latencyMs,
+			Stage:        stage,
+			Action:       action,
+			Reason:       reason,
+			Categories:   categories,
+			LatencyMs:    latencyMs,
+			EvaluationID: ext.EvaluationID,
+			RuleIDs:      ext.RuleIDs,
 		},
 	})
 }

--- a/internal/gateway/guardrail.go
+++ b/internal/gateway/guardrail.go
@@ -49,6 +49,13 @@ type ScanVerdict struct {
 	ScannerSources []string `json:"scanner_sources,omitempty"`
 	CiscoElapsedMs float64  `json:"cisco_elapsed_ms,omitempty"`
 	JudgeFailed    bool     `json:"-"`
+	// EvaluationID + RuleIDs are populated by the guardrail Inspect
+	// runtime emitter so downstream observers (recordTelemetry,
+	// EventVerdict, BlockEvent) can join this verdict to the
+	// per-finding scan_findings rows it produced. Not serialized on
+	// the wire; for in-process correlation only.
+	EvaluationID string   `json:"-"`
+	RuleIDs      []string `json:"-"`
 }
 
 func allowVerdict(scanner string) *ScanVerdict {

--- a/internal/gateway/hilt.go
+++ b/internal/gateway/hilt.go
@@ -79,13 +79,35 @@ func (m *HILTApprovalManager) SetNotifier(n *notifier.Dispatcher) {
 	m.notifier = n
 }
 
-func (m *HILTApprovalManager) Request(ctx context.Context, sessionID, subject, severity, reason string, timeout time.Duration) (bool, string, error) {
+// HILTApprovalContext carries the optional correlation IDs that
+// surfaces upstream of HILT (proxy guardrail verdict, inspect
+// endpoint, hook handler) attach to a confirm decision so the
+// resulting approval audit row + OS notification carry the same
+// evaluation_id + top rule_ids as the verdict that triggered the
+// prompt. Pass the zero value when no structured findings exist
+// for this approval (legacy callers, blocklist confirms).
+type HILTApprovalContext struct {
+	EvaluationID string
+	RuleIDs      []string
+}
+
+// Request blocks until the user replies, the timeout fires, or the
+// caller's context cancels. The optional evalCtx (last variadic
+// slot) lets callers stamp the same evaluation_id + rule_ids on
+// the approval audit row + OS toast that surfaced on the verdict
+// upstream — pure-additive, so existing callers pass nothing and
+// get the prior behavior.
+func (m *HILTApprovalManager) Request(ctx context.Context, sessionID, subject, severity, reason string, timeout time.Duration, evalCtx ...HILTApprovalContext) (bool, string, error) {
+	var ec HILTApprovalContext
+	if len(evalCtx) > 0 {
+		ec = evalCtx[0]
+	}
 	if m == nil {
 		return false, hiltStatusUnsupported, fmt.Errorf("hilt approval unavailable")
 	}
 	sessionIDs := m.sessionCandidates(sessionID)
 	if m.client == nil || len(sessionIDs) == 0 {
-		m.record(ctx, hiltStatusUnsupported, subject, severity, "session/client unavailable")
+		m.record(ctx, hiltStatusUnsupported, subject, severity, "session/client unavailable", ec)
 		return false, hiltStatusUnsupported, fmt.Errorf("hilt approval unavailable")
 	}
 	if timeout <= 0 {
@@ -126,10 +148,10 @@ func (m *HILTApprovalManager) Request(ctx context.Context, sessionID, subject, s
 		if lastErr != nil {
 			details = lastErr.Error()
 		}
-		m.record(ctx, hiltStatusUnsupported, subject, severity, details)
+		m.record(ctx, hiltStatusUnsupported, subject, severity, details, ec)
 		return false, hiltStatusUnsupported, fmt.Errorf("hilt approval unavailable: %s", details)
 	}
-	m.record(ctx, hiltStatusRequested, subject, severity, safeReason)
+	m.record(ctx, hiltStatusRequested, subject, severity, safeReason, ec)
 	// Fire a user-session toast as soon as the chat-side prompt has
 	// been delivered. This is the single chokepoint covering every
 	// HILT path — guardrail confirm verdicts, OpenClaw inspect
@@ -148,6 +170,8 @@ func (m *HILTApprovalManager) Request(ctx context.Context, sessionID, subject, s
 			// through under the master Enabled gate, which keeps
 			// approval coverage independent of the per-source
 			// filter that operators use to silence chatty blocks.
+			EvaluationID: ec.EvaluationID,
+			RuleIDs:      ec.RuleIDs,
 		})
 	}
 
@@ -156,18 +180,18 @@ func (m *HILTApprovalManager) Request(ctx context.Context, sessionID, subject, s
 	select {
 	case approved := <-pending.result:
 		if approved {
-			m.record(ctx, hiltStatusApproved, subject, severity, safeReason)
+			m.record(ctx, hiltStatusApproved, subject, severity, safeReason, ec)
 			return true, hiltStatusApproved, nil
 		}
-		m.record(ctx, hiltStatusDenied, subject, severity, safeReason)
+		m.record(ctx, hiltStatusDenied, subject, severity, safeReason, ec)
 		return false, hiltStatusDenied, nil
 	case <-timer.C:
 		m.remove(id)
-		m.record(ctx, hiltStatusTimeout, subject, severity, safeReason)
+		m.record(ctx, hiltStatusTimeout, subject, severity, safeReason, ec)
 		return false, hiltStatusTimeout, nil
 	case <-ctx.Done():
 		m.remove(id)
-		m.record(ctx, hiltStatusTimeout, subject, severity, ctx.Err().Error())
+		m.record(ctx, hiltStatusTimeout, subject, severity, ctx.Err().Error(), ec)
 		return false, hiltStatusTimeout, ctx.Err()
 	}
 }
@@ -263,13 +287,23 @@ func (m *HILTApprovalManager) remove(id string) {
 	m.mu.Unlock()
 }
 
-func (m *HILTApprovalManager) record(ctx context.Context, action, subject, severity, details string) {
+func (m *HILTApprovalManager) record(ctx context.Context, action, subject, severity, details string, evalCtx ...HILTApprovalContext) {
 	if m == nil {
 		return
 	}
+	var ec HILTApprovalContext
+	if len(evalCtx) > 0 {
+		ec = evalCtx[0]
+	}
 	if m.logger != nil {
-		_ = m.logger.LogActionCtx(ctx, action, subject,
-			fmt.Sprintf("severity=%s details=%s", severity, redaction.ForSinkReason(details)))
+		body := fmt.Sprintf("severity=%s details=%s", severity, redaction.ForSinkReason(details))
+		if ec.EvaluationID != "" {
+			body += " evaluation_id=" + ec.EvaluationID
+		}
+		if len(ec.RuleIDs) > 0 {
+			body += " rule_ids=" + strings.Join(ec.RuleIDs, ",")
+		}
+		_ = m.logger.LogActionCtx(ctx, action, subject, body)
 	}
 	if m.otel != nil {
 		m.otel.RecordGuardrailEvaluation(ctx, "openclaw:hilt", action)

--- a/internal/gateway/hook_audit_envelope.go
+++ b/internal/gateway/hook_audit_envelope.go
@@ -81,6 +81,18 @@ type HookAuditEnvelope struct {
 	RawPayload  string            `json:"raw_payload,omitempty"`
 	Extra       map[string]string `json:"extra,omitempty"`
 
+	// EvaluationID + RuleIDs are the unified-pipeline correlation
+	// keys this hook emission was attributed to. The hook
+	// evaluator stamps them on agentHookResponse via
+	// emitHookRuleFindings; finalizeAgentHook copies them onto the
+	// envelope so audit sinks see the same join key SIEM
+	// dashboards pivot on (matches ScanPayload.evaluation_id /
+	// ScanFindingPayload.evaluation_id / VerdictPayload.
+	// evaluation_id). Both are omitempty: hooks that fire on a
+	// clean evaluation (no rules matched) carry neither.
+	EvaluationID string   `json:"evaluation_id,omitempty"`
+	RuleIDs      []string `json:"rule_ids,omitempty"`
+
 	// AuditActionOverride steers the audit ROW action (not the
 	// envelope JSON). When non-empty, the audit.Logger writes the
 	// row under this action constant instead of

--- a/internal/gateway/hook_findings_emit.go
+++ b/internal/gateway/hook_findings_emit.go
@@ -1,0 +1,635 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/audit"
+	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/gatewaylog"
+	"github.com/defenseclaw/defenseclaw/internal/scanner"
+)
+
+// hookEvaluationContext carries the per-evaluation correlation
+// state that hook handlers stamp on both the JSON response (new
+// optional fields, additive — old clients ignore them) and the
+// audit log (key=value suffix appended to the existing details
+// string). All fields are optional; an empty struct represents a
+// no-findings evaluation that does not need stamping.
+type hookEvaluationContext struct {
+	// EvaluationID is the join key shared by scan_findings rows
+	// and the matching audit row. Empty when no findings were
+	// emitted (so audit detail stays unchanged).
+	EvaluationID string
+	// RuleIDs are the top detection rule_ids that drove this
+	// evaluation, capped so SIEM queries don't explode.
+	RuleIDs []string
+}
+
+// emitHookRuleFindings fans the verdict's DetailedFindings through
+// scanner.EmitInspectFindings so the per-rule matches are
+// observable via gateway.jsonl (EventScan + EventScanFinding),
+// scan_findings DB rows, defenseclaw_scan_findings_by_rule_total,
+// and the sliding-window correlator — without rebuilding the
+// audit/telemetry plumbing for each hook surface.
+//
+// Returns the empty struct when verdict has no detailed findings,
+// so callers can use the result unconditionally:
+//
+//	eval := a.emitHookRuleFindings(ctx, "claudecode", req.HookEventName,
+//	    verdict, "tool_call", elapsed)
+//	details = appendHookEvaluationDetails(details, eval)
+//	resp.EvaluationID = eval.EvaluationID
+//	resp.RuleIDs = eval.RuleIDs
+//
+// Best-effort: emission errors are swallowed and logged via the
+// underlying telemetry sink — the hook response must never fail
+// because the observability pipeline hiccupped.
+func (a *APIServer) emitHookRuleFindings(
+	ctx context.Context,
+	connector, hookEvent string,
+	verdict *ToolInspectVerdict,
+	targetType string,
+	latency time.Duration,
+) hookEvaluationContext {
+	return a.emitInspectVerdictFindings(ctx, "hook-rules", hookEvaluationTarget(connector, hookEvent),
+		targetType, verdict, latency, "emit_hook_findings")
+}
+
+// emitInspectVerdictFindings is the shared body of every
+// runtime finding emitter on the gateway side (hook handlers,
+// /api/v1/inspect/* HTTP endpoints, proxy mid-stream / tool-call
+// inspect). It fans verdict.DetailedFindings through
+// scanner.EmitInspectFindings under the supplied scanner enum,
+// stamps correlation IDs from the request context, and returns
+// the evaluation_id + top rule_ids for the caller to surface in
+// audit details + response payloads.
+//
+// Best-effort: emission errors are recorded via the otel error
+// counter (errorReason as the bucket label) and the function
+// returns an empty hookEvaluationContext so the upstream code
+// path is never aborted by a telemetry hiccup.
+func (a *APIServer) emitInspectVerdictFindings(
+	ctx context.Context,
+	scannerEnum, target, targetType string,
+	verdict *ToolInspectVerdict,
+	latency time.Duration,
+	errorReason string,
+) hookEvaluationContext {
+	if verdict == nil || len(verdict.DetailedFindings) == 0 {
+		return hookEvaluationContext{}
+	}
+
+	inspectFindings := ruleFindingsToInspect(verdict.DetailedFindings)
+	src := scanner.InspectFindingSource{
+		Scanner:    scannerEnum,
+		Target:     target,
+		TargetType: targetType,
+		Verdict:    verdict.Action,
+		DurationMs: latency.Milliseconds(),
+		Findings:   inspectFindings,
+	}
+
+	agent := hookAgentIdentityFromContext(ctx)
+
+	var pers scanner.ScanPersistence
+	if a.store != nil {
+		pers = a.store
+	}
+	var tel scanner.ScanTelemetry
+	if a.otel != nil {
+		tel = a.otel
+	}
+	w := a.gatewayLogWriter()
+
+	evalID, _, err := scanner.EmitInspectFindings(ctx, w, pers, tel, src, agent)
+	if err != nil {
+		if a.otel != nil {
+			a.otel.RecordAuditDBError(ctx, errorReason)
+		}
+		return hookEvaluationContext{}
+	}
+	return hookEvaluationContext{
+		EvaluationID: evalID,
+		RuleIDs:      scanner.TopRuleIDs(inspectFindings, 8),
+	}
+}
+
+// emitGuardrailScanVerdictFindings is the proxy-side companion of
+// emitInspectVerdictFindings: it fans a *ScanVerdict (which carries
+// only stringy Findings, not structured DetailedFindings) through
+// the same scanner.EmitInspectFindings pipeline so per-rule
+// runtime detections from the guardrail proxy (prompt + completion
+// + mid-stream + tool-call inspect) land on every observability
+// surface.
+//
+// Synthesis path: NormalizeScanVerdict already maps raw finding
+// strings to a stable canonical_id + category + severity + title
+// (+ confidence when the source detector reported one). We treat
+// each canonical_id as a rule_id so SIEM dashboards can pivot on
+// "rule_id=pii.email" across hook + proxy + inspect surfaces.
+//
+// Returns an empty struct (and emits nothing) when:
+//   - verdict is nil, or
+//   - verdict has no findings (NormalizeScanVerdict returned nil),
+//     so the metrics/correlator pipelines stay focused on real
+//     detections instead of "no-finding" rollups.
+func (p *GuardrailProxy) emitGuardrailScanVerdictFindings(
+	ctx context.Context,
+	scannerEnum, target, targetType string,
+	verdict *ScanVerdict,
+	latency time.Duration,
+	errorReason string,
+) hookEvaluationContext {
+	if verdict == nil {
+		return hookEvaluationContext{}
+	}
+	normalized := NormalizeScanVerdict(verdict)
+	if len(normalized) == 0 {
+		return hookEvaluationContext{}
+	}
+	inspectFindings := normalizedFindingsToInspect(normalized, verdict.Severity)
+	src := scanner.InspectFindingSource{
+		Scanner:    scannerEnum,
+		Target:     target,
+		TargetType: targetType,
+		Verdict:    verdict.Action,
+		DurationMs: latency.Milliseconds(),
+		Findings:   inspectFindings,
+	}
+	agent := hookAgentIdentityFromContext(ctx)
+
+	var pers scanner.ScanPersistence
+	if p.store != nil {
+		pers = p.store
+	}
+	var tel scanner.ScanTelemetry
+	if p.otel != nil {
+		tel = p.otel
+	}
+	w := p.gatewayLogWriterFromLogger()
+
+	evalID, _, err := scanner.EmitInspectFindings(ctx, w, pers, tel, src, agent)
+	if err != nil {
+		if p.otel != nil {
+			p.otel.RecordAuditDBError(ctx, errorReason)
+		}
+		return hookEvaluationContext{}
+	}
+	return hookEvaluationContext{
+		EvaluationID: evalID,
+		RuleIDs:      scanner.TopRuleIDs(inspectFindings, 8),
+	}
+}
+
+// gatewayLogWriterFromLogger returns the JSONL writer wired into
+// the proxy's audit logger, or nil when the writer hasn't been
+// installed yet (test harnesses, early sidecar boot). Mirrors the
+// APIServer.gatewayLogWriter() accessor — the proxy carries its
+// own *audit.Logger reference so it cannot reuse that method
+// directly.
+func (p *GuardrailProxy) gatewayLogWriterFromLogger() *gatewaylog.Writer {
+	if p == nil || p.logger == nil {
+		return nil
+	}
+	return p.logger.GatewayLogWriter()
+}
+
+// normalizedFindingsToInspect adapts NormalizedFinding records
+// (the canonical-ID view of a ScanVerdict's raw finding strings)
+// into the scanner.InspectFinding shape that EmitInspectFindings
+// understands. The canonical_id becomes rule_id so SIEM dashboards
+// can pivot on a single field across hook + inspect + proxy
+// surfaces.
+//
+// fallbackSeverity is the verdict-level severity; per-finding
+// severity overrides it when the normalizer captured one. Empty
+// titles fall back to the canonical ID so the EventScanFinding
+// payload never has an empty Title field on the wire.
+func normalizedFindingsToInspect(nfs []NormalizedFinding, fallbackSeverity string) []scanner.InspectFinding {
+	if len(nfs) == 0 {
+		return nil
+	}
+	out := make([]scanner.InspectFinding, 0, len(nfs))
+	for _, nf := range nfs {
+		sev := nf.Severity
+		if sev == "" {
+			sev = fallbackSeverity
+		}
+		title := nf.Title
+		if title == "" {
+			title = nf.CanonicalID
+		}
+		var tags []string
+		if strings.TrimSpace(nf.Category) != "" {
+			tags = []string{nf.Category}
+		}
+		out = append(out, scanner.InspectFinding{
+			RuleID:     nf.CanonicalID,
+			Title:      title,
+			Severity:   scanner.Severity(sev),
+			Confidence: nf.Confidence,
+			Tags:       tags,
+		})
+	}
+	return out
+}
+
+// emitAssetPolicyDecisionFindings adapts a single asset-policy
+// decision into the unified scan_findings pipeline so registry /
+// blocklist / admin-deny enforcement events are observable on the
+// same surfaces as hook + proxy + inspect detections.
+//
+// The decision is synthesized into a single InspectFinding because
+// asset-policy is a binary match-or-miss check (one verdict per
+// asset), not a multi-rule scan. We encode the registry provenance
+// (decision.Source, RegistryStatus, RegistryConfigured) into the
+// finding's Tags so SIEM queries can pivot on
+// "tag=registry-required" without re-parsing the audit details
+// string. The rule_id is composed as
+// "asset_policy.<target_type>.<source>" so the metric
+// defenseclaw_scan_findings_by_rule_total has stable, scoped
+// labels (asset_policy.skill.registry-required,
+// asset_policy.mcp.admin-deny, etc.).
+//
+// Returns an empty hookEvaluationContext when no notifier /
+// scanner-emit plumbing is wired or the decision is not a real
+// asset-policy match (callers already pre-filter to
+// RawAction==block, but the guard keeps the helper defensive
+// against future call sites).
+func (a *APIServer) emitAssetPolicyDecisionFindings(
+	ctx context.Context,
+	decision config.AssetPolicyDecision,
+	targetType, connector, hookEvent string,
+) hookEvaluationContext {
+	if strings.TrimSpace(decision.RawAction) == "" {
+		return hookEvaluationContext{}
+	}
+	ruleID := assetPolicyDecisionRuleID(decision, targetType)
+	title := assetPolicyDecisionTitle(decision)
+	finding := scanner.InspectFinding{
+		RuleID:   ruleID,
+		Title:    title,
+		Severity: "HIGH",
+		Tags:     assetPolicyDecisionTags(decision),
+	}
+	src := scanner.InspectFindingSource{
+		Scanner:    "asset-policy",
+		Target:     hookEvaluationTarget(connector, hookEvent),
+		TargetType: hookTargetTypeForEvent(hookEvent),
+		Verdict:    decision.Action,
+		Findings:   []scanner.InspectFinding{finding},
+	}
+	agent := hookAgentIdentityFromContext(ctx)
+
+	var pers scanner.ScanPersistence
+	if a.store != nil {
+		pers = a.store
+	}
+	var tel scanner.ScanTelemetry
+	if a.otel != nil {
+		tel = a.otel
+	}
+	w := a.gatewayLogWriter()
+
+	evalID, _, err := scanner.EmitInspectFindings(ctx, w, pers, tel, src, agent)
+	if err != nil {
+		if a.otel != nil {
+			a.otel.RecordAuditDBError(ctx, "emit_asset_policy")
+		}
+		return hookEvaluationContext{}
+	}
+	return hookEvaluationContext{
+		EvaluationID: evalID,
+		RuleIDs:      []string{ruleID},
+	}
+}
+
+// assetPolicyDecisionRuleID composes the canonical rule identifier
+// used in scan_findings rows and the EventScanFinding payload for
+// an asset-policy decision. The shape is intentionally namespaced
+// so SIEM rules can match on the prefix:
+//
+//	asset_policy.<target_type>.<source>
+//
+// target_type defaults to "asset" when the decision didn't carry
+// one (defensive — every call site sets one today). source
+// defaults to "match" when decision.Source is blank to avoid a
+// trailing-dot rule_id that complicates metric labels.
+func assetPolicyDecisionRuleID(decision config.AssetPolicyDecision, targetType string) string {
+	tt := strings.ToLower(strings.TrimSpace(targetType))
+	if tt == "" {
+		tt = strings.ToLower(strings.TrimSpace(decision.TargetType))
+	}
+	if tt == "" {
+		tt = "asset"
+	}
+	src := strings.TrimSpace(decision.Source)
+	if src == "" {
+		src = "match"
+	}
+	return "asset_policy." + tt + "." + src
+}
+
+// assetPolicyDecisionTitle picks the most operator-friendly text
+// for the EventScanFinding's Title field: prefer the decision's
+// human reason, fall back to the target name, then a generic
+// label. Title rendering downstream (TUI, Splunk) only shows the
+// first ~80 chars, so longer reasons get truncated implicitly.
+func assetPolicyDecisionTitle(decision config.AssetPolicyDecision) string {
+	if strings.TrimSpace(decision.Reason) != "" {
+		return strings.TrimSpace(decision.Reason)
+	}
+	if strings.TrimSpace(decision.TargetName) != "" {
+		return strings.TrimSpace(decision.TargetName)
+	}
+	return "asset policy violation"
+}
+
+// assetPolicyDecisionTags packs registry provenance + runtime
+// surface signals into the InspectFinding.Tags slice so SIEM
+// queries can filter on
+// `tag=registry-required AND tag=mcp`-style combinations without
+// parsing audit details strings. Empty values are dropped so the
+// emitted payload stays compact.
+func assetPolicyDecisionTags(decision config.AssetPolicyDecision) []string {
+	var tags []string
+	if v := strings.TrimSpace(decision.Source); v != "" {
+		tags = append(tags, v)
+	}
+	if v := strings.TrimSpace(decision.RegistryStatus); v != "" {
+		tags = append(tags, "registry_status="+v)
+	}
+	if v := strings.TrimSpace(decision.RuntimeSurface); v != "" {
+		tags = append(tags, "surface="+v)
+	}
+	if decision.RegistryConfigured {
+		tags = append(tags, "registry_configured=true")
+	} else {
+		tags = append(tags, "registry_configured=false")
+	}
+	if decision.WouldBlock {
+		tags = append(tags, "would_block=true")
+	}
+	return tags
+}
+
+// emitToolCallInspectFindings runs the structured RuleFinding[]
+// from inspectToolCalls through scanner.EmitInspectFindings under
+// scanner="tool-call-inspect". The proxy already has the full
+// per-rule structure (RuleID, Severity, Confidence, Evidence,
+// Tags), so we adapt directly via ruleFindingsToInspect instead of
+// going through NormalizeScanVerdict's stringy round-trip.
+//
+// Returns the resulting evaluation_id + top rule_ids so the
+// caller can stamp them on its audit row + ScanVerdict. Errors are
+// recorded via the otel error counter under
+// "emit_tool_call_inspect" and result in an empty
+// hookEvaluationContext so the upstream code path is unaffected.
+func (p *GuardrailProxy) emitToolCallInspectFindings(
+	ctx context.Context,
+	allFindings []RuleFinding,
+	action string,
+) hookEvaluationContext {
+	if len(allFindings) == 0 {
+		return hookEvaluationContext{}
+	}
+	inspectFindings := ruleFindingsToInspect(allFindings)
+	src := scanner.InspectFindingSource{
+		Scanner:    "tool-call-inspect",
+		Target:     p.connectorName() + ":tool-call",
+		TargetType: "tool_call",
+		Verdict:    action,
+		Findings:   inspectFindings,
+	}
+	agent := hookAgentIdentityFromContext(ctx)
+
+	var pers scanner.ScanPersistence
+	if p.store != nil {
+		pers = p.store
+	}
+	var tel scanner.ScanTelemetry
+	if p.otel != nil {
+		tel = p.otel
+	}
+	w := p.gatewayLogWriterFromLogger()
+
+	evalID, _, err := scanner.EmitInspectFindings(ctx, w, pers, tel, src, agent)
+	if err != nil {
+		if p.otel != nil {
+			p.otel.RecordAuditDBError(ctx, "emit_tool_call_inspect")
+		}
+		return hookEvaluationContext{}
+	}
+	return hookEvaluationContext{
+		EvaluationID: evalID,
+		RuleIDs:      scanner.TopRuleIDs(inspectFindings, 8),
+	}
+}
+
+// recordTelemetryScannerEnum picks the scanner-enum label that
+// best describes the proxy-side guardrail emission feeding into
+// the unified scan_findings pipeline.
+//
+//   - direction == "tool-call"  → "tool-call-inspect"
+//   - direction == "completion" and elapsed == 0 (the convention
+//     used by the streaming mid-stream / early-block branches that
+//     call recordTelemetry with elapsed=0 because the latency is
+//     not measured at that point) → "mid-stream"
+//   - everything else (prompt + post-stream completion verdicts)
+//     → "guardrail-llm"
+//
+// Centralizing the mapping keeps SIEM filters like
+// `scanner="mid-stream"` reliably equivalent across the four
+// recordTelemetry call sites in proxy.go.
+func recordTelemetryScannerEnum(direction string, verdict *ScanVerdict, elapsed time.Duration) string {
+	switch strings.TrimSpace(direction) {
+	case "tool-call", "tool_call":
+		return "tool-call-inspect"
+	case "completion":
+		if elapsed == 0 {
+			return "mid-stream"
+		}
+	}
+	_ = verdict
+	return "guardrail-llm"
+}
+
+// recordTelemetryTarget builds the target string used in the
+// scan_results / EventScan rows for proxy guardrail emissions.
+// The model name is the most useful field for SIEM queries
+// (e.g. "block rate per model"), with a "direction:" prefix so a
+// single model_id surfaces separately on prompt vs completion vs
+// tool-call surfaces.
+func recordTelemetryTarget(direction, model string) string {
+	d := strings.TrimSpace(direction)
+	if d == "" {
+		d = "unknown"
+	}
+	m := strings.TrimSpace(model)
+	if m == "" {
+		m = "unknown"
+	}
+	return d + ":" + m
+}
+
+// recordTelemetryTargetType maps the proxy guardrail's direction
+// label onto the v7 scan-event schema's target_type enum.
+func recordTelemetryTargetType(direction string) string {
+	switch strings.TrimSpace(direction) {
+	case "prompt":
+		return "prompt"
+	case "completion":
+		return "completion"
+	case "tool-call", "tool_call":
+		return "tool_call"
+	default:
+		return "inspect"
+	}
+}
+
+// hookTargetTypeForEvent returns the v7 gateway-event schema
+// target_type enum value that best describes the hook event:
+//
+//   - prompt-shaped events (UserPromptSubmit, UserMessage, etc.)
+//     map to "prompt"
+//   - tool-invocation events (PreToolUse, PermissionRequest, etc.)
+//     map to "tool_call"
+//   - tool-result events (PostToolUse, PostToolUseFailure, etc.)
+//     map to "tool_response"
+//   - assistant-output / completion events map to "completion"
+//   - everything else (SessionStart, Stop, etc.) falls back to
+//     "inspect"
+//
+// Keeping the mapping centralized means SIEM filters like
+// `target_type="prompt"` work uniformly across all hook
+// connectors (claudecode, codex, agent-hook, etc.).
+func hookTargetTypeForEvent(hookEvent string) string {
+	switch strings.TrimSpace(hookEvent) {
+	case "UserPromptSubmit", "UserPromptExpansion", "UserMessage",
+		"InstructionsLoaded", "ConfigChange", "FileChanged",
+		"Elicitation", "ElicitationResult", "Notification",
+		"TaskCreated", "TeammateIdle", "PreCompact":
+		return "prompt"
+	case "PreToolUse", "PermissionRequest", "PermissionDenied",
+		"ToolUse", "ToolCall":
+		return "tool_call"
+	case "PostToolUse", "PostToolUseFailure", "PostToolBatch",
+		"ToolResult":
+		return "tool_response"
+	case "AssistantResponse", "Completion":
+		return "completion"
+	default:
+		return "inspect"
+	}
+}
+
+// hookEvaluationTarget builds the canonical "connector:hookEvent"
+// target used by every hook-derived scan event. Empty parts default
+// to "unknown" so the writer's schema gate never sees an empty
+// target string.
+func hookEvaluationTarget(connector, hookEvent string) string {
+	connector = strings.TrimSpace(connector)
+	if connector == "" {
+		connector = "unknown"
+	}
+	hookEvent = strings.TrimSpace(hookEvent)
+	if hookEvent == "" {
+		hookEvent = "unknown"
+	}
+	return connector + ":" + hookEvent
+}
+
+// hookAgentIdentityFromContext lifts the v7 correlation envelope
+// off the request context (set by the gateway correlation
+// middleware) and copies it into a scanner.AgentIdentity so
+// EmitInspectFindings stamps run_id / session_id / agent_id on
+// every emitted row. Returns the zero value when no envelope is
+// present — that's the documented fallback in
+// scanner.EmitScanResult and downstream queries already treat
+// NULL columns as "unknown for this event".
+func hookAgentIdentityFromContext(ctx context.Context) scanner.AgentIdentity {
+	env := audit.EnvelopeFromContext(ctx)
+	return scanner.AgentIdentity{
+		AgentID:           env.AgentID,
+		AgentName:         env.AgentName,
+		AgentInstanceID:   env.AgentInstanceID,
+		SidecarInstanceID: env.SidecarInstanceID,
+		RunID:             env.RunID,
+		RequestID:         env.RequestID,
+		SessionID:         env.SessionID,
+		TraceID:           env.TraceID,
+	}
+}
+
+// gatewayLogWriter returns the JSONL writer wired into the audit
+// logger, or nil when the writer hasn't been installed yet
+// (test harnesses and the early phase of sidecar boot).
+func (a *APIServer) gatewayLogWriter() *gatewaylog.Writer {
+	if a == nil || a.logger == nil {
+		return nil
+	}
+	return a.logger.GatewayLogWriter()
+}
+
+// ruleFindingsToInspect adapts gateway.RuleFinding into the
+// scanner-package-neutral InspectFinding shape that
+// EmitInspectFindings understands. RuleFinding.Evidence is
+// already redacted upstream by the rules engine, so this is a
+// pure structural copy — no additional sanitization.
+func ruleFindingsToInspect(in []RuleFinding) []scanner.InspectFinding {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]scanner.InspectFinding, 0, len(in))
+	for _, f := range in {
+		out = append(out, scanner.InspectFinding{
+			RuleID:     f.RuleID,
+			Title:      f.Title,
+			Severity:   scanner.Severity(f.Severity),
+			Confidence: f.Confidence,
+			Evidence:   f.Evidence,
+			Tags:       f.Tags,
+		})
+	}
+	return out
+}
+
+// appendHookEvaluationDetails appends `evaluation_id=<uuid>` and
+// `rule_ids=<id1,id2,...>` to an existing key=value audit detail
+// string in a strictly additive way: pre-existing log parsers
+// keep matching the same prefix, and the new fields can be
+// extracted by a simple `grep -oE 'evaluation_id=[a-z0-9-]+'`.
+func appendHookEvaluationDetails(details string, eval hookEvaluationContext) string {
+	if eval.EvaluationID == "" && len(eval.RuleIDs) == 0 {
+		return details
+	}
+	parts := make([]string, 0, 3)
+	if strings.TrimSpace(details) != "" {
+		parts = append(parts, details)
+	}
+	if eval.EvaluationID != "" {
+		parts = append(parts, "evaluation_id="+eval.EvaluationID)
+	}
+	if len(eval.RuleIDs) > 0 {
+		parts = append(parts, "rule_ids="+strings.Join(eval.RuleIDs, ","))
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/gateway/hook_profile_runtime.go
+++ b/internal/gateway/hook_profile_runtime.go
@@ -130,6 +130,8 @@ func claudeCodeResponseToAgentHookResponse(resp claudeCodeHookResponse) agentHoo
 		WouldBlock:        resp.WouldBlock,
 		AdditionalContext: resp.AdditionalContext,
 		HookOutput:        resp.ClaudeCodeOutput,
+		EvaluationID:      resp.EvaluationID,
+		RuleIDs:           resp.RuleIDs,
 	}
 }
 
@@ -144,5 +146,7 @@ func codexResponseToAgentHookResponse(resp codexHookResponse) agentHookResponse 
 		WouldBlock:        resp.WouldBlock,
 		AdditionalContext: resp.AdditionalContext,
 		HookOutput:        resp.CodexOutput,
+		EvaluationID:      resp.EvaluationID,
+		RuleIDs:           resp.RuleIDs,
 	}
 }

--- a/internal/gateway/inspect.go
+++ b/internal/gateway/inspect.go
@@ -545,6 +545,21 @@ func (a *APIServer) handleInspectTool(w http.ResponseWriter, r *http.Request) {
 		_ = a.otel.EmitInspectSpan(context.Background(), req.Tool, verdict.Action, verdict.Severity, elapsedMs)
 	}
 
+	targetType := "tool_call"
+	if strings.ToLower(req.Tool) == "message" {
+		switch strings.ToLower(req.Direction) {
+		case "completion", "outbound", "response":
+			targetType = "completion"
+		case "tool_result", "tool-response":
+			targetType = "tool_response"
+		default:
+			targetType = "prompt"
+		}
+	}
+	evalCtx := a.emitInspectVerdictFindings(r.Context(), "inspect-http",
+		"/api/v1/inspect/tool:"+req.Tool, targetType, verdict, elapsed,
+		"emit_inspect_tool")
+
 	requestID := RequestIDFromContext(r.Context())
 	auditDetails := fmt.Sprintf("severity=%s confidence=%.2f reason=%s elapsed=%s mode=%s would_block=%v raw_action=%s",
 		verdict.Severity, verdict.Confidence, verdict.Reason, elapsed, verdict.Mode, verdict.WouldBlock, verdict.RawAction)
@@ -557,6 +572,7 @@ func (a *APIServer) handleInspectTool(w http.ResponseWriter, r *http.Request) {
 	if requestID != "" {
 		auditDetails += fmt.Sprintf(" request_id=%s", requestID)
 	}
+	auditDetails = appendHookEvaluationDetails(auditDetails, evalCtx)
 	_ = a.logger.LogActionCtx(r.Context(), auditAction, req.Tool, auditDetails)
 
 	a.emitCodeGuardOTel(&req, verdict, elapsed)

--- a/internal/gateway/inspect_hooks.go
+++ b/internal/gateway/inspect_hooks.go
@@ -170,12 +170,16 @@ func (a *APIServer) handleInspectRequest(w http.ResponseWriter, r *http.Request)
 		a.otel.RecordInspectLatency(context.Background(), tool, elapsedMs)
 	}
 
+	evalCtx := a.emitInspectVerdictFindings(r.Context(), "inspect-http",
+		"/api/v1/inspect/request", "prompt", verdict, elapsed, "emit_inspect_request")
+
 	requestID := RequestIDFromContext(r.Context())
 	auditDetails := fmt.Sprintf("severity=%s elapsed=%s mode=%s would_block=%v raw_action=%s model=%s",
 		verdict.Severity, elapsed, verdict.Mode, verdict.WouldBlock, verdict.RawAction, req.Model)
 	if requestID != "" {
 		auditDetails += fmt.Sprintf(" request_id=%s", requestID)
 	}
+	auditDetails = appendHookEvaluationDetails(auditDetails, evalCtx)
 	_ = a.logger.LogActionCtx(r.Context(), auditAction, "pre-request", auditDetails)
 
 	reveal := wantsReveal(r)
@@ -236,12 +240,16 @@ func (a *APIServer) handleInspectResponse(w http.ResponseWriter, r *http.Request
 		a.otel.RecordInspectLatency(context.Background(), tool, elapsedMs)
 	}
 
+	evalCtx := a.emitInspectVerdictFindings(r.Context(), "inspect-http",
+		"/api/v1/inspect/response", "completion", verdict, elapsed, "emit_inspect_response")
+
 	requestID := RequestIDFromContext(r.Context())
 	auditDetails := fmt.Sprintf("severity=%s elapsed=%s mode=%s would_block=%v raw_action=%s model=%s",
 		verdict.Severity, elapsed, verdict.Mode, verdict.WouldBlock, verdict.RawAction, req.Model)
 	if requestID != "" {
 		auditDetails += fmt.Sprintf(" request_id=%s", requestID)
 	}
+	auditDetails = appendHookEvaluationDetails(auditDetails, evalCtx)
 	_ = a.logger.LogActionCtx(r.Context(), auditAction, "post-response", auditDetails)
 
 	reveal := wantsReveal(r)
@@ -303,12 +311,17 @@ func (a *APIServer) handleInspectToolResponse(w http.ResponseWriter, r *http.Req
 		a.otel.RecordInspectLatency(context.Background(), tool, elapsedMs)
 	}
 
+	evalCtx := a.emitInspectVerdictFindings(r.Context(), "inspect-http",
+		"/api/v1/inspect/tool-response:"+req.Tool, "tool_response", verdict, elapsed,
+		"emit_inspect_tool_response")
+
 	requestID := RequestIDFromContext(r.Context())
 	auditDetails := fmt.Sprintf("tool=%s severity=%s elapsed=%s mode=%s would_block=%v raw_action=%s exit_code=%d",
 		req.Tool, verdict.Severity, elapsed, verdict.Mode, verdict.WouldBlock, verdict.RawAction, req.ExitCode)
 	if requestID != "" {
 		auditDetails += fmt.Sprintf(" request_id=%s", requestID)
 	}
+	auditDetails = appendHookEvaluationDetails(auditDetails, evalCtx)
 	_ = a.logger.LogActionCtx(r.Context(), auditAction, req.Tool, auditDetails)
 
 	reveal := wantsReveal(r)

--- a/internal/gateway/notifier/notifier.go
+++ b/internal/gateway/notifier/notifier.go
@@ -105,6 +105,20 @@ type BlockEvent struct {
 	Connector string
 	Event     string
 	WouldAsk  bool
+	// EvaluationID joins this block notification to the
+	// scan_findings rows produced by the detection that caused it,
+	// so SIEM correlations (block toast → underlying rule_id
+	// matches) work without rebuilding the join from free-form
+	// Reason text. Empty when the upstream verdict produced no
+	// structured findings (e.g. blocklist denials).
+	EvaluationID string
+	// RuleIDs lists the top detection rule identifiers that drove
+	// this block, capped at the same fan-out budget used by
+	// hooks / proxy / inspect emissions (8). Operators can
+	// dedupe / group notifications by rule_id without parsing
+	// Reason. Empty when no rule-based detection produced this
+	// block (manual blocklist, schema-gate failure, etc.).
+	RuleIDs []string
 }
 
 // ApprovalEvent describes a HITL/confirm prompt that is now waiting
@@ -125,6 +139,11 @@ type ApprovalEvent struct {
 	Source    Source
 	Connector string
 	Event     string
+	// EvaluationID + RuleIDs carry the same join key + rule list
+	// as BlockEvent so HILT approval prompts and the block toasts
+	// they replace share a single SIEM-pivotable shape.
+	EvaluationID string
+	RuleIDs      []string
 }
 
 // Dispatcher is the single fan-in point for OS notifications.

--- a/internal/gateway/notifier_wiring_test.go
+++ b/internal/gateway/notifier_wiring_test.go
@@ -130,6 +130,7 @@ func TestClaudeHookDispatch_BlockFiresOnBlock(t *testing.T) {
 	api.dispatchClaudeCodeHookNotification(
 		req, "block", "block", "HIGH",
 		"matched policy: deny-rm-rf", false,
+		hookEvaluationContext{},
 	)
 
 	got := rec.WaitFor(t, 1)
@@ -168,6 +169,7 @@ func TestClaudeHookDispatch_WouldBlockFiresOnWouldBlock(t *testing.T) {
 	api.dispatchClaudeCodeHookNotification(
 		claudeCodeHookRequest{HookEventName: "PreToolUse", ToolName: "Bash"},
 		"allow", "block", "MEDIUM", "observe-mode trial", true,
+		hookEvaluationContext{},
 	)
 
 	got := rec.WaitFor(t, 1)
@@ -192,6 +194,7 @@ func TestClaudeHookDispatch_ConfirmFiresOnApprovalPending(t *testing.T) {
 		claudeCodeHookRequest{HookEventName: "PreToolUse", ToolName: "Edit"},
 		"confirm", "confirm", "LOW",
 		"approval needed for write outside workspace", false,
+		hookEvaluationContext{},
 	)
 
 	got := rec.WaitFor(t, 1)
@@ -222,6 +225,7 @@ func TestClaudeHookDispatch_RedactsReason(t *testing.T) {
 	api.dispatchClaudeCodeHookNotification(
 		claudeCodeHookRequest{HookEventName: "PreToolUse", ToolName: "Bash"},
 		"block", "block", "HIGH", rawSecret, false,
+		hookEvaluationContext{},
 	)
 	got := rec.WaitFor(t, 1)
 	if strings.Contains(got[0].Body, "AKIAIOSFODNN7EXAMPLE") {
@@ -242,6 +246,7 @@ func TestCodexHookDispatch_BlockFiresOnBlock(t *testing.T) {
 	api.dispatchCodexHookNotification(
 		codexHookRequest{HookEventName: "PreToolUse", ToolName: "shell"},
 		"block", "block", "HIGH", "matched: blocked-shell", false,
+		hookEvaluationContext{},
 	)
 	got := rec.WaitFor(t, 1)
 	if !strings.Contains(got[0].Subtitle, "codex") {
@@ -261,6 +266,7 @@ func TestCodexHookDispatch_RedactsReason(t *testing.T) {
 		codexHookRequest{HookEventName: "PreToolUse", ToolName: "shell"},
 		"block", "block", "HIGH",
 		"prompt contained AKIAIOSFODNN7EXAMPLE", false,
+		hookEvaluationContext{},
 	)
 	got := rec.WaitFor(t, 1)
 	if strings.Contains(got[0].Body, "AKIAIOSFODNN7EXAMPLE") {
@@ -339,10 +345,12 @@ func TestNotifierDisabled_NoEmit(t *testing.T) {
 	api.dispatchClaudeCodeHookNotification(
 		claudeCodeHookRequest{HookEventName: "PreToolUse", ToolName: "Bash"},
 		"block", "block", "HIGH", "any reason", false,
+		hookEvaluationContext{},
 	)
 	api.dispatchCodexHookNotification(
 		codexHookRequest{HookEventName: "PreToolUse", ToolName: "shell"},
 		"block", "block", "HIGH", "any reason", false,
+		hookEvaluationContext{},
 	)
 	api.dispatchAssetPolicyNotification(
 		config.AssetPolicyDecision{
@@ -520,6 +528,7 @@ func TestNotifierSourceFilter_AssetPolicyOff(t *testing.T) {
 	api.dispatchClaudeCodeHookNotification(
 		claudeCodeHookRequest{HookEventName: "PreToolUse", ToolName: "Bash"},
 		"block", "block", "HIGH", "hook block", false,
+		hookEvaluationContext{},
 	)
 
 	got := rec.WaitFor(t, 1)

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -251,7 +251,8 @@ func (p *GuardrailProxy) resolveConfirm(ctx context.Context, r *http.Request, ve
 		return
 	}
 
-	approved, status, err := p.hilt.Request(ctx, hiltSessionID(ctx, r), subject, verdict.Severity, verdict.Reason, 0)
+	approved, status, err := p.hilt.Request(ctx, hiltSessionID(ctx, r), subject, verdict.Severity, verdict.Reason, 0,
+		HILTApprovalContext{EvaluationID: verdict.EvaluationID, RuleIDs: verdict.RuleIDs})
 	if approved {
 		verdict.Action = guardrailActionAllow
 		verdict.Reason = appendVerdictReason(verdict.Reason, "human approved once")
@@ -2469,12 +2470,14 @@ func (p *GuardrailProxy) enqueueBlockNotification(verdict *ScanVerdict, directio
 	// dispatcher applies its own per-category gate, dedup window,
 	// and rate limit before delivery.
 	p.notifier.OnBlock(notifier.BlockEvent{
-		Source:    notifier.SourceGuardrail,
-		Target:    model,
-		Reason:    string(redaction.ForSinkReason(verdict.Reason)),
-		Severity:  verdict.Severity,
-		Connector: p.connectorName(),
-		Event:     direction,
+		Source:       notifier.SourceGuardrail,
+		Target:       model,
+		Reason:       string(redaction.ForSinkReason(verdict.Reason)),
+		Severity:     verdict.Severity,
+		Connector:    p.connectorName(),
+		Event:        direction,
+		EvaluationID: verdict.EvaluationID,
+		RuleIDs:      verdict.RuleIDs,
 	})
 }
 
@@ -2491,12 +2494,14 @@ func (p *GuardrailProxy) enqueueWouldBlockNotification(verdict *ScanVerdict, dir
 		return
 	}
 	p.notifier.OnWouldBlock(notifier.BlockEvent{
-		Source:    notifier.SourceGuardrail,
-		Target:    model,
-		Reason:    string(redaction.ForSinkReason(verdict.Reason)),
-		Severity:  verdict.Severity,
-		Connector: p.connectorName(),
-		Event:     direction,
+		Source:       notifier.SourceGuardrail,
+		Target:       model,
+		Reason:       string(redaction.ForSinkReason(verdict.Reason)),
+		Severity:     verdict.Severity,
+		Connector:    p.connectorName(),
+		Event:        direction,
+		EvaluationID: verdict.EvaluationID,
+		RuleIDs:      verdict.RuleIDs,
 	})
 }
 
@@ -3509,6 +3514,42 @@ func (p *GuardrailProxy) recordTelemetry(ctx context.Context, direction, model s
 		}
 		details += fmt.Sprintf(" canonical=%s", strings.Join(ids, ","))
 	}
+
+	// Fan the verdict's findings through the unified scanner
+	// emission pipeline so per-rule detections from the guardrail
+	// proxy land on every observability surface (scan_findings DB
+	// rows, EventScan + EventScanFinding JSONL lines,
+	// defenseclaw_scan_findings_by_rule_total, sliding-window
+	// correlator). The resulting evaluation_id + top rule_ids are
+	// stamped onto the verdict so downstream notifier / webhook /
+	// block-notification paths can carry them too. The emission is
+	// skipped when an upstream caller (inspectToolCalls) already
+	// produced the IDs — that prevents double-emit of the same
+	// rule findings.
+	if verdict.EvaluationID == "" {
+		eval := p.emitGuardrailScanVerdictFindings(
+			ctx,
+			recordTelemetryScannerEnum(direction, verdict, elapsed),
+			recordTelemetryTarget(direction, model),
+			recordTelemetryTargetType(direction),
+			verdict,
+			elapsed,
+			"emit_proxy_findings",
+		)
+		if eval.EvaluationID != "" {
+			verdict.EvaluationID = eval.EvaluationID
+		}
+		if len(eval.RuleIDs) > 0 {
+			verdict.RuleIDs = eval.RuleIDs
+		}
+	}
+	if verdict.EvaluationID != "" {
+		details += fmt.Sprintf(" evaluation_id=%s", verdict.EvaluationID)
+	}
+	if len(verdict.RuleIDs) > 0 {
+		details += fmt.Sprintf(" rule_ids=%s", strings.Join(verdict.RuleIDs, ","))
+	}
+
 	if requestID != "" {
 		// Append the correlation key so the human-readable gateway.log
 		// line (which skips structured sinks) is still searchable by
@@ -4003,10 +4044,26 @@ func (p *GuardrailProxy) inspectToolCalls(ctx context.Context, toolCallsJSON jso
 	fmt.Fprintf(os.Stderr, "[guardrail] TOOL-CALL-INSPECT action=%s severity=%s findings=%d reason=%s\n",
 		action, severity, len(allFindings), strings.Join(top, ", "))
 
+	// Fan the structured per-rule findings through the unified
+	// scan_findings pipeline before stamping the audit row, so the
+	// `evaluation_id=` + `rule_ids=` correlation suffix can join
+	// the audit row to the EventScanFinding rows it produced.
+	// inspectToolCalls already has the full []RuleFinding (severity
+	// + confidence + evidence + tags per match) so we adapt them
+	// directly rather than re-deriving from NormalizeScanVerdict.
+	eval := p.emitToolCallInspectFindings(ctx, allFindings, action)
+	auditDetails := fmt.Sprintf("action=%s severity=%s confidence=%.2f", action, severity, confidence)
+	auditDetails = appendHookEvaluationDetails(auditDetails, eval)
+
 	if p.logger != nil {
 		for _, tc := range toolCalls {
-			_ = p.logger.LogActionCtx(ctx, string(audit.ActionGuardrailToolCallInspect), tc.Function.Name,
-				fmt.Sprintf("action=%s severity=%s confidence=%.2f", action, severity, confidence))
+			// Use the typed audit.ActionGuardrailToolCallInspect
+			// constant (rather than the string literal) for the
+			// row's action column, AND carry the evaluation_id +
+			// rule_ids in the details string so the unified-pipeline
+			// join key reaches SIEM without breaking the column-
+			// indexed action enum.
+			_ = p.logger.LogActionCtx(ctx, string(audit.ActionGuardrailToolCallInspect), tc.Function.Name, auditDetails)
 		}
 	}
 
@@ -4020,6 +4077,8 @@ func (p *GuardrailProxy) inspectToolCalls(ctx context.Context, toolCallsJSON jso
 		Reason:         strings.Join(top, ", "),
 		Findings:       FindingStrings(allFindings),
 		ScannerSources: []string{"tool-call-inspect"},
+		EvaluationID:   eval.EvaluationID,
+		RuleIDs:        eval.RuleIDs,
 	}
 }
 

--- a/internal/gateway/proxy_connector_parity_test.go
+++ b/internal/gateway/proxy_connector_parity_test.go
@@ -196,6 +196,12 @@ func TestSwitchConnector_PerConnectorPersistsState(t *testing.T) {
 	for _, target := range cases {
 		t.Run(target, func(t *testing.T) {
 			dir := t.TempDir()
+			// Copilot's Setup refuses any WorkspaceDir nested inside
+			// DataDir (audit DB / gateway config / secrets must not
+			// be reachable from the workspace tree). Use a sibling
+			// temp dir so every connector in the matrix gets a
+			// hermetic, validation-clean workspace.
+			workspaceDir := t.TempDir()
 			reg := connector.NewDefaultRegistry()
 
 			// Plan E1 / round-3 follow-up: when the gateway binary
@@ -244,7 +250,7 @@ func TestSwitchConnector_PerConnectorPersistsState(t *testing.T) {
 					ProxyAddr:    "127.0.0.1:4000",
 					APIAddr:      "127.0.0.1:18970",
 					APIToken:     "tok",
-					WorkspaceDir: filepath.Join(dir, "workspace"),
+					WorkspaceDir: workspaceDir,
 				},
 				health: NewSidecarHealth(),
 			}
@@ -285,6 +291,11 @@ func TestApplyRuntime_PerConnectorSwitch(t *testing.T) {
 	for _, target := range []string{"openclaw", "zeptoclaw", "claudecode", "codex", "hermes", "cursor", "windsurf", "geminicli", "copilot", "openhands"} {
 		t.Run(target, func(t *testing.T) {
 			dir := t.TempDir()
+			// See note in TestSwitchConnector_PerConnectorPersistsState:
+			// keep WorkspaceDir outside DataDir so copilot's Setup
+			// validation (and any future connector with the same
+			// guard) does not roll the switch back to codex.
+			workspaceDir := t.TempDir()
 			reg := connector.NewDefaultRegistry()
 
 			// Same OpenClaw extension probe as
@@ -322,7 +333,7 @@ func TestApplyRuntime_PerConnectorSwitch(t *testing.T) {
 					ProxyAddr:    "127.0.0.1:4000",
 					APIAddr:      "127.0.0.1:18970",
 					APIToken:     "tok",
-					WorkspaceDir: filepath.Join(dir, "workspace"),
+					WorkspaceDir: workspaceDir,
 				},
 				health:    NewSidecarHealth(),
 				inspector: NewGuardrailInspector("local", nil, nil, ""),

--- a/internal/gateway/unified_hook_dispatch_test.go
+++ b/internal/gateway/unified_hook_dispatch_test.go
@@ -191,6 +191,113 @@ func jsonKeys(m map[string]interface{}) []string {
 	return out
 }
 
+// TestUnifiedDispatch_SurfacesEvaluationIDAndRuleIDs pins the
+// HTTP-response contract for the unified runtime-finding
+// observability pipeline: when the evaluator stamps an
+// evaluation_id + rule_ids on the agentHookResponse,
+// renderAgentHookResponseForProfile MUST project them onto the
+// JSON output map so hook scripts (and any downstream consumer
+// of the HTTP response body) can pivot on the same join key
+// surfaced via gateway.jsonl, scan_findings, and the audit DB
+// structured envelope.
+//
+// Regression guard: the original render projection built a
+// hardcoded subset map that silently dropped the new fields. The
+// JSONL / audit DB surfaces still carried the join key, but
+// callers consuming only the HTTP body were left orphaned — the
+// "absolute observability" contract said every surface, so an
+// in-test assertion is the only way to keep that promise.
+//
+// Negative half: when the evaluator emits an allow/no-findings
+// response (the empty hookEvaluationContext path), neither
+// evaluation_id nor rule_ids should appear in the wire shape —
+// older hook scripts must continue parsing the same minimal
+// envelope.
+func TestUnifiedDispatch_SurfacesEvaluationIDAndRuleIDs(t *testing.T) {
+	t.Run("populated", func(t *testing.T) {
+		resp := agentHookResponse{
+			Action:       "allow",
+			RawAction:    "block",
+			Severity:     "CRITICAL",
+			Mode:         "observe",
+			WouldBlock:   true,
+			EvaluationID: "eval-fixture-uuid-1234",
+			RuleIDs:      []string{"SEC-ANTHROPIC", "SEC-AWS-KEY"},
+		}
+		for _, connectorName := range []string{"codex", "claudecode", "hermes"} {
+			out := renderAgentHookResponse(connectorName, resp)
+			if got, ok := out["evaluation_id"].(string); !ok || got != "eval-fixture-uuid-1234" {
+				t.Errorf("connector %s: evaluation_id = %v, want %q", connectorName, out["evaluation_id"], "eval-fixture-uuid-1234")
+			}
+			ids, ok := out["rule_ids"].([]string)
+			if !ok || len(ids) != 2 || ids[0] != "SEC-ANTHROPIC" || ids[1] != "SEC-AWS-KEY" {
+				t.Errorf("connector %s: rule_ids = %v, want [SEC-ANTHROPIC SEC-AWS-KEY]", connectorName, out["rule_ids"])
+			}
+		}
+	})
+
+	t.Run("empty_context_omits_fields", func(t *testing.T) {
+		resp := agentHookResponse{
+			Action:     "allow",
+			Severity:   "NONE",
+			Mode:       "observe",
+			WouldBlock: false,
+		}
+		out := renderAgentHookResponse("codex", resp)
+		if _, ok := out["evaluation_id"]; ok {
+			t.Errorf("no-findings path must omit evaluation_id; got keys=%v", jsonKeys(out))
+		}
+		if _, ok := out["rule_ids"]; ok {
+			t.Errorf("no-findings path must omit rule_ids; got keys=%v", jsonKeys(out))
+		}
+	})
+}
+
+// TestCodexResponseToAgentHookResponse_CarriesCorrelationIDs and
+// TestClaudeCodeResponseToAgentHookResponse_CarriesCorrelationIDs
+// guard the adapter layer that bridges codex/claudecode bespoke
+// response structs into the unified agentHookResponse. The
+// previous adapter dropped the EvaluationID + RuleIDs fields, so
+// the codex_hook.go / claude_code_hook.go evaluators happily
+// stamped them on the bespoke struct but they evaporated before
+// the render projection ever saw them. These two tests pin the
+// adapter contract so the regression cannot resurface.
+func TestCodexResponseToAgentHookResponse_CarriesCorrelationIDs(t *testing.T) {
+	src := codexHookResponse{
+		Action:       "allow",
+		RawAction:    "block",
+		Severity:     "CRITICAL",
+		Mode:         "observe",
+		EvaluationID: "eval-codex-fixture",
+		RuleIDs:      []string{"SEC-ANTHROPIC"},
+	}
+	out := codexResponseToAgentHookResponse(src)
+	if out.EvaluationID != "eval-codex-fixture" {
+		t.Errorf("EvaluationID = %q, want eval-codex-fixture", out.EvaluationID)
+	}
+	if len(out.RuleIDs) != 1 || out.RuleIDs[0] != "SEC-ANTHROPIC" {
+		t.Errorf("RuleIDs = %v, want [SEC-ANTHROPIC]", out.RuleIDs)
+	}
+}
+
+func TestClaudeCodeResponseToAgentHookResponse_CarriesCorrelationIDs(t *testing.T) {
+	src := claudeCodeHookResponse{
+		Action:       "allow",
+		RawAction:    "block",
+		Severity:     "CRITICAL",
+		Mode:         "observe",
+		EvaluationID: "eval-claude-fixture",
+		RuleIDs:      []string{"SEC-AWS-KEY", "SEC-GITHUB-TOKEN"},
+	}
+	out := claudeCodeResponseToAgentHookResponse(src)
+	if out.EvaluationID != "eval-claude-fixture" {
+		t.Errorf("EvaluationID = %q, want eval-claude-fixture", out.EvaluationID)
+	}
+	if len(out.RuleIDs) != 2 {
+		t.Errorf("RuleIDs len = %d, want 2", len(out.RuleIDs))
+	}
+}
+
 // runHookHandler invokes a hook handler with the supplied JSON body
 // and returns the response body. We cannot use httptest.NewServer
 // because that would require a fully wired APIServer with audit +

--- a/internal/gatewaylog/events.go
+++ b/internal/gatewaylog/events.go
@@ -458,6 +458,16 @@ type VerdictPayload struct {
 	Reason     string   `json:"reason,omitempty"`     // short, redacted
 	Categories []string `json:"categories,omitempty"` // e.g. [pii.email, injection.system_prompt]
 	LatencyMs  int64    `json:"latency_ms,omitempty"`
+	// EvaluationID joins this verdict to its per-finding rows in
+	// scan_findings and to the EventScanFinding fan-out emitted by
+	// the same runtime turn (hook, inspect, proxy, mid-stream,
+	// tool-call). Empty for verdicts that did not produce structured
+	// findings.
+	EvaluationID string `json:"evaluation_id,omitempty"`
+	// RuleIDs lists the (up to 8) detection rule identifiers that
+	// drove this verdict. Operators get a quick SIEM-pivot key
+	// without joining against scan_findings rows.
+	RuleIDs []string `json:"rule_ids,omitempty"`
 }
 
 // Finding matches the shape guardrail scanners emit. Keep the field
@@ -511,6 +521,18 @@ type ErrorPayload struct {
 	Code      string `json:"code,omitempty"` // stable short identifier
 	Message   string `json:"message"`
 	Cause     string `json:"cause,omitempty"`
+	// RuleID attributes this error to a specific detection rule
+	// when the broken event carried one (schema-gate violations
+	// on EventScanFinding, verdict-failure errors that reference
+	// a rule). Empty for errors that are not rule-attributable
+	// (boot failures, transport errors, audit DB faults).
+	RuleID string `json:"rule_id,omitempty"`
+	// EvaluationID joins this error to the upstream evaluation
+	// (scan_summary / hook / inspect / proxy guardrail) that
+	// produced the broken event. Empty when no upstream
+	// evaluation exists (e.g. schema gate firing on a config /
+	// admin emission, or a writer-level transport error).
+	EvaluationID string `json:"evaluation_id,omitempty"`
 }
 
 // DiagnosticPayload carries developer traces that don't fit the other
@@ -529,8 +551,8 @@ type DiagnosticPayload struct {
 // ScanFindingPayload tied to the same scan shares a ScanID.
 type ScanPayload struct {
 	ScanID      string         `json:"scan_id"`
-	Scanner     string         `json:"scanner"` // skill | mcp | plugin | aibom | codeguard
-	Target      string         `json:"target"`  // file path | skill name | server URL
+	Scanner     string         `json:"scanner"` // see scanner enum in scan-event.json schema
+	Target      string         `json:"target"`  // file path | skill name | server URL | tool name | message surface
 	TargetType  string         `json:"target_type,omitempty"`
 	Verdict     string         `json:"verdict,omitempty"` // clean | warn | block
 	DurationMs  int64          `json:"duration_ms,omitempty"`
@@ -539,6 +561,10 @@ type ScanPayload struct {
 	TotalCount  int            `json:"total_count,omitempty"`
 	ExitCode    int            `json:"exit_code,omitempty"`
 	Error       string         `json:"error,omitempty"` // scanner execution error
+	// EvaluationID joins this scan summary to the verdict / hook /
+	// inspect audit row that triggered it. Empty for classic
+	// scanner-invocation paths that have no upstream evaluation.
+	EvaluationID string `json:"evaluation_id,omitempty"`
 }
 
 // ScanFindingPayload [v7] records a single finding produced by a
@@ -558,6 +584,13 @@ type ScanFindingPayload struct {
 	LineNumber  int      `json:"line_number,omitempty"`
 	Remediation string   `json:"remediation,omitempty"`
 	Tags        []string `json:"tags,omitempty"`
+	// Confidence is the detector's self-reported certainty in [0,1].
+	// Populated by regex/judge/AID detectors; omitted for binary
+	// scanners that don't compute a score.
+	Confidence float64 `json:"confidence,omitempty"`
+	// EvaluationID matches ScanPayload.EvaluationID — joins this
+	// finding to the verdict / hook / inspect row that produced it.
+	EvaluationID string `json:"evaluation_id,omitempty"`
 }
 
 // ActivityPayload [v7] records an operator-facing mutation

--- a/internal/gatewaylog/schemas/gateway-event-envelope.json
+++ b/internal/gatewaylog/schemas/gateway-event-envelope.json
@@ -91,7 +91,9 @@
         "action":     { "type": "string", "enum": ["allow", "warn", "alert", "confirm", "block"] },
         "reason":     { "type": ["string", "null"] },
         "categories": { "type": ["array", "null"], "items": { "type": "string" } },
-        "latency_ms": { "type": ["integer", "null"] }
+        "latency_ms": { "type": ["integer", "null"] },
+        "evaluation_id": { "type": ["string", "null"], "description": "Optional join key linking this verdict to its per-finding scan_findings rows / EventScanFinding fan-out." },
+        "rule_ids":   { "type": ["array", "null"], "items": { "type": "string" }, "description": "Top detection rule identifiers that drove this verdict (capped at 8). Quick SIEM-pivot key." }
       }
     },
     "JudgePayload": {
@@ -122,10 +124,12 @@
       "type": "object",
       "required": ["subsystem", "message"],
       "properties": {
-        "subsystem": { "type": "string" },
-        "code":      { "type": ["string", "null"] },
-        "message":   { "type": "string" },
-        "cause":     { "type": ["string", "null"] }
+        "subsystem":     { "type": "string" },
+        "code":          { "type": ["string", "null"] },
+        "message":       { "type": "string" },
+        "cause":         { "type": ["string", "null"] },
+        "rule_id":       { "type": ["string", "null"], "description": "Optional rule identifier this error is attributable to (schema-gate violations on finding events, verdict-failure errors)." },
+        "evaluation_id": { "type": ["string", "null"], "description": "Optional join key linking this error to the evaluation that produced the broken event (matches ScanPayload.evaluation_id / VerdictPayload.evaluation_id)." }
       }
     },
     "DiagnosticPayload": {

--- a/internal/gatewaylog/schemas/scan-event.json
+++ b/internal/gatewaylog/schemas/scan-event.json
@@ -9,9 +9,24 @@
       "required": ["scan_id", "scanner", "target"],
       "properties": {
         "scan_id":     { "type": "string", "description": "Correlation id shared by the roll-up EventScan and all child EventScanFinding events." },
-        "scanner":     { "type": "string", "enum": ["skill", "mcp", "plugin", "aibom", "codeguard"] },
-        "target":      { "type": "string", "description": "File path | skill name | server URL. Redacted when scanner contract requires." },
-        "target_type": { "type": ["string", "null"], "enum": ["file", "skill", "mcp", "plugin", "aibom", null] },
+        "scanner":     {
+          "type": "string",
+          "description": "Source of the finding. Classic scanner invocations use skill|mcp|plugin|aibom|codeguard. Runtime finding emitters fanned out via EmitInspectFindings use hook-rules|inline-codeguard|ai-defense|asset-policy|tool-call-inspect|inspect-http|guardrail-llm|mid-stream|rescan.",
+          "enum": [
+            "skill", "mcp", "plugin", "aibom", "codeguard",
+            "hook-rules", "inline-codeguard", "ai-defense", "asset-policy",
+            "tool-call-inspect", "inspect-http", "guardrail-llm", "mid-stream", "rescan"
+          ]
+        },
+        "target":      { "type": "string", "description": "File path | skill name | server URL | tool name | message surface. Redacted when scanner contract requires." },
+        "target_type": {
+          "type": ["string", "null"],
+          "enum": [
+            "file", "skill", "mcp", "plugin", "aibom",
+            "tool_call", "prompt", "completion", "tool_response", "inspect",
+            null
+          ]
+        },
         "verdict":     { "type": ["string", "null"], "enum": ["clean", "warn", "block", null] },
         "duration_ms": { "type": ["integer", "null"] },
         "severity_max":{ "type": ["string", "null"], "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO", null] },
@@ -22,7 +37,8 @@
         },
         "total_count": { "type": ["integer", "null"], "minimum": 0 },
         "exit_code":   { "type": ["integer", "null"] },
-        "error":       { "type": ["string", "null"], "description": "Scanner execution error. Present only when the wrapper failed (timeout, non-zero exit)." }
+        "error":       { "type": ["string", "null"], "description": "Scanner execution error. Present only when the wrapper failed (timeout, non-zero exit)." },
+        "evaluation_id": { "type": ["string", "null"], "description": "Optional join key linking this scan to its upstream runtime evaluation (hook handler, /api/v1/inspect/*, proxy guardrail, mid-stream, tool-call-inspect, watcher rescan). Empty for classic scanner-invocation paths." }
       }
     }
   },

--- a/internal/gatewaylog/schemas/scan-finding-event.json
+++ b/internal/gatewaylog/schemas/scan-finding-event.json
@@ -9,7 +9,15 @@
       "required": ["scan_id", "scanner", "target"],
       "properties": {
         "scan_id":     { "type": "string" },
-        "scanner":     { "type": "string", "enum": ["skill", "mcp", "plugin", "aibom", "codeguard"] },
+        "scanner":     {
+          "type": "string",
+          "description": "Source of the finding. Classic scanner invocations use skill|mcp|plugin|aibom|codeguard. Runtime finding emitters fanned out via EmitInspectFindings use hook-rules|inline-codeguard|ai-defense|asset-policy|tool-call-inspect|inspect-http|guardrail-llm|mid-stream|rescan.",
+          "enum": [
+            "skill", "mcp", "plugin", "aibom", "codeguard",
+            "hook-rules", "inline-codeguard", "ai-defense", "asset-policy",
+            "tool-call-inspect", "inspect-http", "guardrail-llm", "mid-stream", "rescan"
+          ]
+        },
         "target":      { "type": "string" },
         "finding_id":  { "type": ["string", "null"] },
         "rule_id":     { "type": ["string", "null"], "description": "Stable detection rule identifier. Preferred group-by for SIEM; never display-string." },
@@ -20,7 +28,9 @@
         "location":    { "type": ["string", "null"], "description": "Redacted path + line." },
         "line_number": { "type": ["integer", "null"], "minimum": 0 },
         "remediation": { "type": ["string", "null"] },
-        "tags":        { "type": ["array", "null"], "items": { "type": "string" } }
+        "tags":        { "type": ["array", "null"], "items": { "type": "string" } },
+        "confidence":  { "type": ["number", "null"], "minimum": 0, "maximum": 1, "description": "Detector self-reported certainty in [0,1]. Omitted by binary scanners." },
+        "evaluation_id": { "type": ["string", "null"], "description": "Optional join key matching the parent ScanPayload.evaluation_id." }
       }
     }
   },

--- a/internal/gatewaylog/validator_test.go
+++ b/internal/gatewaylog/validator_test.go
@@ -114,6 +114,116 @@ func TestValidator_AcceptsGuardrailRuntimeActions(t *testing.T) {
 	}
 }
 
+// TestValidator_AcceptsRuntimeFindingScannerEnums covers the
+// scanner enum values used by runtime finding emitters fanned out
+// through EmitInspectFindings (hook handlers, /api/v1/inspect/*,
+// proxy guardrail, mid-stream, tool-call-inspect, watcher rescan).
+// Each value must validate on both EventScan and EventScanFinding;
+// a regression here causes events to be dropped at the writer's
+// schema gate.
+func TestValidator_AcceptsRuntimeFindingScannerEnums(t *testing.T) {
+	v := newRepoValidator(t)
+
+	runtimeScanners := []string{
+		"skill", "mcp", "plugin", "aibom", "codeguard",
+		"hook-rules", "inline-codeguard", "ai-defense", "asset-policy",
+		"tool-call-inspect", "inspect-http", "guardrail-llm", "mid-stream", "rescan",
+	}
+	for _, sc := range runtimeScanners {
+		scan := Event{
+			Timestamp:     time.Now().UTC(),
+			EventType:     EventScan,
+			Severity:      SeverityInfo,
+			SchemaVersion: 7,
+			Scan: &ScanPayload{
+				ScanID:  "scan-1",
+				Scanner: sc,
+				Target:  "synthetic",
+			},
+		}
+		if err := v.Validate(scan); err != nil {
+			t.Fatalf("EventScan with scanner=%q rejected: %v", sc, err)
+		}
+		finding := Event{
+			Timestamp:     time.Now().UTC(),
+			EventType:     EventScanFinding,
+			Severity:      SeverityInfo,
+			SchemaVersion: 7,
+			ScanFinding: &ScanFindingPayload{
+				ScanID:  "scan-1",
+				Scanner: sc,
+				Target:  "synthetic",
+			},
+		}
+		if err := v.Validate(finding); err != nil {
+			t.Fatalf("EventScanFinding with scanner=%q rejected: %v", sc, err)
+		}
+	}
+}
+
+// TestValidator_RejectsUnknownScannerEnum guards the writer's
+// schema gate: any new scanner value added in the future must be
+// declared in both scan-event.json and scan-finding-event.json
+// before code emits it.
+func TestValidator_RejectsUnknownScannerEnum(t *testing.T) {
+	v := newRepoValidator(t)
+	bad := Event{
+		Timestamp:     time.Now().UTC(),
+		EventType:     EventScanFinding,
+		Severity:      SeverityInfo,
+		SchemaVersion: 7,
+		ScanFinding: &ScanFindingPayload{
+			ScanID:  "scan-1",
+			Scanner: "definitely-not-a-real-scanner",
+			Target:  "synthetic",
+		},
+	}
+	if err := v.Validate(bad); err == nil {
+		t.Fatal("expected validation error for unknown scanner enum value")
+	}
+}
+
+// TestValidator_AcceptsVerdictEvaluationJoinKeys covers the new
+// evaluation_id + rule_ids fields on VerdictPayload that the
+// runtime finding emitters stamp so SIEM can join verdicts to
+// their per-finding scan_findings rows.
+func TestValidator_AcceptsVerdictEvaluationJoinKeys(t *testing.T) {
+	v := newRepoValidator(t)
+	e := validVerdict()
+	e.Verdict.EvaluationID = "eval-abc"
+	e.Verdict.RuleIDs = []string{"SECRET-AWS-AKIA", "PII-EMAIL"}
+	if err := v.Validate(e); err != nil {
+		t.Fatalf("verdict with evaluation_id+rule_ids rejected: %v", err)
+	}
+}
+
+// TestValidator_AcceptsScanFindingConfidenceAndEvaluationID covers
+// the new optional confidence + evaluation_id fields on
+// ScanFindingPayload.
+func TestValidator_AcceptsScanFindingConfidenceAndEvaluationID(t *testing.T) {
+	v := newRepoValidator(t)
+	conf := 0.87
+	_ = conf
+	e := Event{
+		Timestamp:     time.Now().UTC(),
+		EventType:     EventScanFinding,
+		Severity:      SeverityHigh,
+		SchemaVersion: 7,
+		ScanFinding: &ScanFindingPayload{
+			ScanID:       "scan-1",
+			Scanner:      "hook-rules",
+			Target:       "claudecode:PreToolUse",
+			RuleID:       "SECRET-AWS-AKIA",
+			Severity:     SeverityHigh,
+			Confidence:   0.87,
+			EvaluationID: "eval-abc",
+		},
+	}
+	if err := v.Validate(e); err != nil {
+		t.Fatalf("scan_finding with confidence+evaluation_id rejected: %v", err)
+	}
+}
+
 func TestValidator_AcceptsValidError(t *testing.T) {
 	v := newRepoValidator(t)
 	e := Event{
@@ -378,6 +488,88 @@ func TestWriter_StrictMode_ObserverPanicRecovered(t *testing.T) {
 	}()
 	if !strings.Contains(pretty.String(), "schema-violation observer panic") {
 		t.Fatalf("panic not surfaced on pretty sink:\n%s", pretty.String())
+	}
+}
+
+// TestWriter_StrictMode_ViolationErrorAttribution verifies that when a
+// scan_finding event is dropped for schema reasons, the synthesised
+// EventError carries the broken payload's rule_id + evaluation_id so
+// SIEM/dashboard filters keyed on those fields (a) still see the drop
+// and (b) can pivot back to the upstream evaluation. Without this,
+// schema-gate drops would look like anonymous infrastructure errors
+// even when the source clearly identified itself.
+func TestWriter_StrictMode_ViolationErrorAttribution(t *testing.T) {
+	v := newRepoValidator(t)
+	w, err := New(Config{Validator: v})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	var got []Event
+	w.WithFanout(func(e Event) { got = append(got, e) })
+
+	// Emit a scan_finding that is malformed on purpose (missing
+	// required Finding.title/severity) but carries rule_id and
+	// evaluation_id. The strict validator will drop it; the
+	// synthesised EventError must echo both correlation keys.
+	w.Emit(Event{
+		EventType: EventScanFinding,
+		Severity:  SeverityHigh,
+		ScanFinding: &ScanFindingPayload{
+			RuleID:       "PII.EMAIL",
+			EvaluationID: "eval-abc-123",
+		},
+	})
+
+	if len(got) != 1 || got[0].EventType != EventError {
+		t.Fatalf("expected exactly one EventError on fanout, got %+v", got)
+	}
+	ep := got[0].Error
+	if ep == nil {
+		t.Fatalf("EventError has nil Error payload: %+v", got[0])
+	}
+	if ep.RuleID != "PII.EMAIL" {
+		t.Fatalf("EventError.Error.RuleID: got %q want %q", ep.RuleID, "PII.EMAIL")
+	}
+	if ep.EvaluationID != "eval-abc-123" {
+		t.Fatalf("EventError.Error.EvaluationID: got %q want %q", ep.EvaluationID, "eval-abc-123")
+	}
+}
+
+// TestWriter_StrictMode_ViolationErrorAttributionVerdict mirrors the
+// scan_finding case for verdict drops: a verdict missing required
+// fields still surfaces its evaluation_id + the first rule_id on the
+// EventError so verdict-failure alerts retain SIEM pivot keys.
+func TestWriter_StrictMode_ViolationErrorAttributionVerdict(t *testing.T) {
+	v := newRepoValidator(t)
+	w, err := New(Config{Validator: v})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	var got []Event
+	w.WithFanout(func(e Event) { got = append(got, e) })
+
+	w.Emit(Event{
+		EventType: EventVerdict,
+		Severity:  SeverityHigh,
+		Verdict: &VerdictPayload{
+			// Stage/Action intentionally omitted to fail schema.
+			EvaluationID: "eval-verdict-42",
+			RuleIDs:      []string{"INJ.OVERRIDE", "INJ.SUFFIX"},
+		},
+	})
+
+	if len(got) != 1 || got[0].EventType != EventError {
+		t.Fatalf("expected exactly one EventError on fanout, got %+v", got)
+	}
+	ep := got[0].Error
+	if ep == nil {
+		t.Fatalf("EventError has nil Error payload: %+v", got[0])
+	}
+	if ep.RuleID != "INJ.OVERRIDE" {
+		t.Fatalf("EventError.Error.RuleID: got %q want %q", ep.RuleID, "INJ.OVERRIDE")
+	}
+	if ep.EvaluationID != "eval-verdict-42" {
+		t.Fatalf("EventError.Error.EvaluationID: got %q want %q", ep.EvaluationID, "eval-verdict-42")
 	}
 }
 

--- a/internal/gatewaylog/writer.go
+++ b/internal/gatewaylog/writer.go
@@ -359,6 +359,13 @@ func (w *Writer) handleSchemaViolation(src Event, cause error) {
 	// error is attributable to the exact request that produced the
 	// bad emission. event_type=error puts us on the `error`
 	// oneOf branch of the envelope.
+	// Surface the broken event's rule_id + evaluation_id (when
+	// present on the payload) so the schema-violation error
+	// attributes to the same SIEM pivot keys as the dropped event.
+	// Operators dashboards built on `error.rule_id` / `error.
+	// evaluation_id` can correlate the drop back to the upstream
+	// detection without parsing the violation message string.
+	ruleID, evalID := payloadCorrelationIDs(src)
 	viol := Event{
 		Timestamp:         time.Now().UTC(),
 		EventType:         EventError,
@@ -372,10 +379,12 @@ func (w *Writer) handleSchemaViolation(src Event, cause error) {
 		AgentInstanceID:   src.AgentInstanceID,
 		SidecarInstanceID: src.SidecarInstanceID,
 		Error: &ErrorPayload{
-			Subsystem: string(SubsystemGatewaylog),
-			Code:      string(ErrCodeSchemaViolation),
-			Message:   truncate(fmt.Sprintf("dropped %s event: %s", src.EventType, msg), 1024),
-			Cause:     string(src.EventType),
+			Subsystem:    string(SubsystemGatewaylog),
+			Code:         string(ErrCodeSchemaViolation),
+			Message:      truncate(fmt.Sprintf("dropped %s event: %s", src.EventType, msg), 1024),
+			Cause:        string(src.EventType),
+			RuleID:       ruleID,
+			EvaluationID: evalID,
 		},
 	}
 
@@ -387,6 +396,32 @@ func (w *Writer) handleSchemaViolation(src Event, cause error) {
 	w.emitDepth.Add(1)
 	defer w.emitDepth.Add(-1)
 	w.Emit(viol)
+}
+
+// payloadCorrelationIDs extracts rule_id + evaluation_id from the
+// dropped event's payload so a schema-violation EventError can
+// echo them onto its own ErrorPayload. We pick the first match
+// across the finding-shaped + scan-shaped + verdict-shaped
+// payloads — for any well-formed event at most one of these is
+// populated, and ill-formed events (the case the schema gate
+// triggers on) only get the IDs that did make it through.
+func payloadCorrelationIDs(src Event) (ruleID, evaluationID string) {
+	if src.ScanFinding != nil {
+		ruleID = src.ScanFinding.RuleID
+		evaluationID = src.ScanFinding.EvaluationID
+	}
+	if evaluationID == "" && src.Scan != nil {
+		evaluationID = src.Scan.EvaluationID
+	}
+	if src.Verdict != nil {
+		if evaluationID == "" {
+			evaluationID = src.Verdict.EvaluationID
+		}
+		if ruleID == "" && len(src.Verdict.RuleIDs) > 0 {
+			ruleID = src.Verdict.RuleIDs[0]
+		}
+	}
+	return ruleID, evaluationID
 }
 
 // truncate caps s at n runes and appends an ellipsis if we clipped.

--- a/internal/scanner/agent_identity.go
+++ b/internal/scanner/agent_identity.go
@@ -23,4 +23,13 @@ type AgentIdentity struct {
 	RequestID string
 	SessionID string
 	TraceID   string
+
+	// EvaluationID is an optional join key set by runtime
+	// finding emitters (hook handlers, /api/v1/inspect/*, proxy
+	// guardrail, mid-stream, tool-call-inspect, watcher rescan)
+	// so the per-finding rows produced by EmitScanResult can be
+	// correlated back to the upstream evaluation row. Classic
+	// scanner-invocation paths (skill, mcp, plugin, aibom,
+	// codeguard CLI/file scans) leave it empty.
+	EvaluationID string
 }

--- a/internal/scanner/inspect_emit.go
+++ b/internal/scanner/inspect_emit.go
@@ -1,0 +1,281 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/defenseclaw/defenseclaw/internal/gatewaylog"
+)
+
+// InspectFinding is the scanner-package-neutral input shape that
+// EmitInspectFindings adapts into a scanner.Finding for fan-out
+// through the existing EmitScanResult pipeline (scan_results +
+// scan_findings + EventScan + EventScanFinding +
+// defenseclaw_scan_findings_by_rule_total + correlator).
+//
+// Callers in the gateway package (hook handlers, /api/v1/inspect/*,
+// proxy guardrail, mid-stream, tool-call-inspect, watcher rescan,
+// AID lane, asset policy) populate it from their own
+// detector-specific structures (gateway.RuleFinding, AID
+// classifications, config.AssetPolicyDecision, etc.) and pass
+// already-redacted strings — EmitInspectFindings does not redact.
+type InspectFinding struct {
+	// RuleID is the stable detection rule identifier. Empty means
+	// "let EnsureRuleID synthesize from scanner+category+title".
+	RuleID string
+	// Title is a short human-readable label. May be displayed
+	// in TUI / dashboards.
+	Title string
+	// Description is the long form. Caller must redact before
+	// passing in; EmitInspectFindings will not redact again.
+	Description string
+	// Severity is the canonical CRITICAL|HIGH|MEDIUM|LOW|INFO.
+	Severity Severity
+	// Category groups findings when RuleID is absent.
+	Category string
+	// Tags are free-form labels picked up by the correlator's
+	// data-axis enricher (e.g. ["secret", "ingress_untrusted"]).
+	Tags []string
+	// Confidence is the detector's self-reported certainty in
+	// [0,1]. Zero means "not computed" and is omitted on the wire.
+	Confidence float64
+	// Evidence is the matched literal (already redacted by the
+	// caller via redaction.ForSinkEvidence). EmitInspectFindings
+	// turns it into ContentFingerprint = sha256(evidence)[:8] so
+	// correlator can match the same value across turns without
+	// persisting the cleartext.
+	Evidence string
+	// Location is the file/tool/source location. Caller must
+	// redact path/line if applicable.
+	Location string
+	// LineNumber is the 1-based source line; nil when not
+	// meaningful.
+	LineNumber *int
+	// Remediation is human-readable fix guidance. Caller must
+	// redact.
+	Remediation string
+	// ToolCapabilityClass labels what kind of tool this finding
+	// attached to (read_fs / write_fs / exec_shell / network_fetch
+	// / send_message). Optional.
+	ToolCapabilityClass string
+	// ExternalEndpoint is the host/URL for any network-touching
+	// finding. Optional.
+	ExternalEndpoint string
+}
+
+// InspectFindingSource describes a single runtime evaluation that
+// produced N>=0 findings. Callers fill this in once per evaluation
+// (one hook turn, one /api/v1/inspect/* call, one proxy guardrail
+// invocation, one mid-stream check, one tool-call-inspect, one
+// watcher rescan) and hand it to EmitInspectFindings.
+type InspectFindingSource struct {
+	// Scanner is one of the runtime-finding enum values defined
+	// in NormalizeScannerEnum: hook-rules | inline-codeguard |
+	// ai-defense | asset-policy | tool-call-inspect | inspect-http
+	// | guardrail-llm | mid-stream | rescan. Classic file scans
+	// should keep using EmitScanResult directly with skill / mcp /
+	// plugin / aibom / codeguard.
+	Scanner string
+	// Target is the surface the evaluation ran against. For hooks
+	// it's connector:hookEvent (e.g. "claudecode:PreToolUse"); for
+	// inspect-http it's the endpoint name; for proxy guardrail
+	// it's the model + direction; for tool-call-inspect it's the
+	// tool name.
+	Target string
+	// TargetType is one of the enum values defined in
+	// NormalizeTargetTypeEnum (file / skill / mcp / plugin /
+	// aibom / tool_call / prompt / completion / tool_response /
+	// inspect). Empty falls back to "inspect".
+	TargetType string
+	// Verdict is the evaluation's final action (clean / warn /
+	// block / alert / allow / confirm). Normalized through
+	// NormalizeVerdictEnum.
+	Verdict string
+	// DurationMs is the evaluation latency. Optional.
+	DurationMs int64
+	// EvaluationID is the join key linking this evaluation to
+	// the audit row that triggered it. Empty causes
+	// EmitInspectFindings to generate a fresh UUID.
+	EvaluationID string
+	// Timestamp is the evaluation time. Zero defaults to now.
+	Timestamp time.Time
+	// Findings is the list of per-rule findings produced. May be
+	// empty — empty-finding evaluations still emit the
+	// EventScan summary so SIEM sees the evaluation happened.
+	Findings []InspectFinding
+	// ScanError is populated when the evaluation itself failed
+	// (timeout, panic, AID HTTP error). Surfaced on the EventScan
+	// payload so dashboards can alert on detector-side outages.
+	ScanError string
+}
+
+// EmitInspectFindings fans the source into the existing scanner
+// emission pipeline: EmitScanResult writes scan_results +
+// scan_findings, emits EventScan + N×EventScanFinding, records
+// defenseclaw_scan_findings_by_rule_total, and (when session +
+// agent_instance_id are populated) runs the lethal-trifecta
+// correlator. Returns the evaluation_id (newly generated when the
+// caller passed empty) and the underlying scan_id for the caller
+// to stamp on its audit row.
+//
+// The function is intentionally tolerant: a nil writer / nil
+// persistence / nil telemetry each disable that surface. The only
+// hard requirement is a non-empty Scanner value (so the writer's
+// schema gate doesn't drop the event).
+func EmitInspectFindings(
+	ctx context.Context,
+	w *gatewaylog.Writer,
+	pers ScanPersistence,
+	tel ScanTelemetry,
+	src InspectFindingSource,
+	agent AgentIdentity,
+) (evaluationID, scanID string, err error) {
+	evaluationID = strings.TrimSpace(src.EvaluationID)
+	if evaluationID == "" {
+		evaluationID = uuid.New().String()
+	}
+	// Propagate evaluation_id onto the AgentIdentity so
+	// EmitScanResult stamps it on every emitted payload + DB row
+	// without each caller having to set it themselves.
+	agent.EvaluationID = evaluationID
+
+	if strings.TrimSpace(src.Scanner) == "" {
+		// Defensive — keep the writer's schema gate happy; the
+		// runtime-finding emitters should always set this.
+		src.Scanner = "guardrail-llm"
+	}
+	targetType := strings.TrimSpace(src.TargetType)
+	if targetType == "" {
+		targetType = "inspect"
+	}
+	ts := src.Timestamp
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
+
+	result := &ScanResult{
+		Scanner:    src.Scanner,
+		Target:     src.Target,
+		Timestamp:  ts,
+		Duration:   time.Duration(src.DurationMs) * time.Millisecond,
+		TargetType: targetType,
+		Verdict:    src.Verdict,
+		ScanError:  src.ScanError,
+	}
+	if len(src.Findings) > 0 {
+		result.Findings = make([]Finding, 0, len(src.Findings))
+		for _, in := range src.Findings {
+			result.Findings = append(result.Findings, adaptInspectFinding(in, src.Scanner))
+		}
+	}
+
+	scanID, err = EmitScanResult(ctx, w, pers, tel, result, agent)
+	return evaluationID, scanID, err
+}
+
+// adaptInspectFinding maps the gateway-package-neutral
+// InspectFinding into the existing scanner.Finding shape that
+// EmitScanResult understands. Caller is responsible for redaction.
+func adaptInspectFinding(in InspectFinding, scannerName string) Finding {
+	severity := in.Severity
+	if severity == "" {
+		severity = SeverityInfo
+	}
+
+	// Synthesize a stable per-finding ID from rule_id + a fresh
+	// uuid so multiple matches of the same rule in the same
+	// evaluation each get distinct DB rows.
+	id := strings.TrimSpace(in.RuleID)
+	if id == "" {
+		id = "finding"
+	}
+	id = id + ":" + uuid.New().String()
+
+	f := Finding{
+		ID:                  id,
+		Severity:            severity,
+		Title:               in.Title,
+		Description:         in.Description,
+		Location:            in.Location,
+		Remediation:         in.Remediation,
+		Scanner:             scannerName,
+		Tags:                in.Tags,
+		RuleID:              in.RuleID,
+		Category:            in.Category,
+		LineNumber:          in.LineNumber,
+		Confidence:          clampConfidence(in.Confidence),
+		ToolCapabilityClass: in.ToolCapabilityClass,
+		ExternalEndpoint:    in.ExternalEndpoint,
+	}
+	if strings.TrimSpace(in.Evidence) != "" {
+		f.ContentFingerprint = evidenceFingerprint(in.Evidence)
+	}
+	return f
+}
+
+// clampConfidence pins the detector's reported score into the
+// JSON-Schema-declared [0,1] range. Values outside the range are
+// silently corrected rather than dropped so a buggy detector
+// can't cause schema-gate event loss.
+func clampConfidence(c float64) float64 {
+	switch {
+	case c < 0:
+		return 0
+	case c > 1:
+		return 1
+	default:
+		return c
+	}
+}
+
+// evidenceFingerprint returns the first 8 hex chars of
+// sha256(evidence) — the same fingerprint shape the correlator
+// already reads via ScanFinding.ContentFingerprint. Caller must
+// redact the evidence string before passing it in; we hash
+// whatever they hand us.
+func evidenceFingerprint(evidence string) string {
+	sum := sha256.Sum256([]byte(evidence))
+	return hex.EncodeToString(sum[:])[:8]
+}
+
+// TopRuleIDs returns up to n distinct rule_ids from the source
+// findings, preserving order. Callers use this to populate
+// VerdictPayload.RuleIDs and to append ` rule_ids=` to audit
+// detail strings without redacting each call site.
+func TopRuleIDs(findings []InspectFinding, n int) []string {
+	if n <= 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, n)
+	out := make([]string, 0, n)
+	for i := range findings {
+		id := strings.TrimSpace(findings[i].RuleID)
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+		if len(out) >= n {
+			break
+		}
+	}
+	return out
+}

--- a/internal/scanner/inspect_emit_test.go
+++ b/internal/scanner/inspect_emit_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/gatewaylog"
+)
+
+func TestEmitInspectFindings_FansOutPerFindingEvent(t *testing.T) {
+	var emitted []gatewaylog.Event
+	w, err := gatewaylog.New(gatewaylog.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.WithFanout(func(e gatewaylog.Event) { emitted = append(emitted, e) })
+
+	tel := &mockTel{}
+	line := 12
+	evalID, scanID, err := EmitInspectFindings(context.Background(), w, nil, tel,
+		InspectFindingSource{
+			Scanner:    "hook-rules",
+			Target:     "claudecode:PreToolUse",
+			TargetType: "tool_call",
+			Verdict:    "block",
+			DurationMs: 2,
+			Findings: []InspectFinding{
+				{
+					RuleID:     "SECRET-AWS-AKIA",
+					Title:      "AWS access key",
+					Severity:   SeverityHigh,
+					Confidence: 0.95,
+					Evidence:   "AKIAIOSFODNN7EXAMPLE",
+					LineNumber: &line,
+					Tags:       []string{"secret"},
+				},
+				{
+					RuleID:     "PII-EMAIL",
+					Title:      "Email address",
+					Severity:   SeverityMedium,
+					Confidence: 0.7,
+					Evidence:   "alice@example.com",
+				},
+			},
+		},
+		AgentIdentity{
+			AgentID:         "agent-1",
+			AgentInstanceID: "instance-1",
+			SessionID:       "session-1",
+		},
+	)
+	if err != nil {
+		t.Fatalf("EmitInspectFindings: %v", err)
+	}
+	if evalID == "" || scanID == "" {
+		t.Fatalf("expected non-empty evaluation_id and scan_id, got %q / %q", evalID, scanID)
+	}
+
+	var scanEvent *gatewaylog.Event
+	var findingEvents []*gatewaylog.Event
+	for i := range emitted {
+		switch emitted[i].EventType {
+		case gatewaylog.EventScan:
+			scanEvent = &emitted[i]
+		case gatewaylog.EventScanFinding:
+			findingEvents = append(findingEvents, &emitted[i])
+		}
+	}
+	if scanEvent == nil {
+		t.Fatalf("missing EventScan; got %d emitted events", len(emitted))
+	}
+	if scanEvent.Scan == nil {
+		t.Fatal("scan event missing Scan payload")
+	}
+	if scanEvent.Scan.Scanner != "hook-rules" {
+		t.Errorf("scan.scanner = %q, want hook-rules", scanEvent.Scan.Scanner)
+	}
+	if scanEvent.Scan.EvaluationID != evalID {
+		t.Errorf("scan.evaluation_id = %q, want %q", scanEvent.Scan.EvaluationID, evalID)
+	}
+	if len(findingEvents) != 2 {
+		t.Fatalf("expected 2 EventScanFinding rows, got %d", len(findingEvents))
+	}
+	for _, ev := range findingEvents {
+		if ev.ScanFinding == nil {
+			t.Fatal("finding event missing payload")
+		}
+		if ev.ScanFinding.EvaluationID != evalID {
+			t.Errorf("scan_finding.evaluation_id = %q, want %q", ev.ScanFinding.EvaluationID, evalID)
+		}
+		if ev.ScanFinding.Scanner != "hook-rules" {
+			t.Errorf("scan_finding.scanner = %q, want hook-rules", ev.ScanFinding.Scanner)
+		}
+		if ev.ScanFinding.ScanID != scanID {
+			t.Errorf("scan_finding.scan_id = %q, want %q", ev.ScanFinding.ScanID, scanID)
+		}
+		if ev.ScanFinding.RuleID == "" {
+			t.Error("scan_finding.rule_id is empty")
+		}
+		if ev.ScanFinding.Confidence <= 0 || ev.ScanFinding.Confidence > 1 {
+			t.Errorf("scan_finding.confidence = %v, want in (0,1]", ev.ScanFinding.Confidence)
+		}
+	}
+
+	if len(tel.byRule) != 2 {
+		t.Errorf("RecordScanFindingByRule called %d times, want 2", len(tel.byRule))
+	}
+	for _, row := range tel.byRule {
+		if row[0] != "hook-rules" {
+			t.Errorf("metric scanner label = %q, want hook-rules", row[0])
+		}
+		if row[1] == "" {
+			t.Errorf("metric rule_id label is empty: %+v", row)
+		}
+	}
+}
+
+func TestEmitInspectFindings_EmptyFindingsStillEmitsScanRollup(t *testing.T) {
+	var emitted []gatewaylog.Event
+	w, err := gatewaylog.New(gatewaylog.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.WithFanout(func(e gatewaylog.Event) { emitted = append(emitted, e) })
+
+	evalID, scanID, err := EmitInspectFindings(context.Background(), w, nil, nil,
+		InspectFindingSource{
+			Scanner:    "inspect-http",
+			Target:     "POST /api/v1/inspect/request",
+			TargetType: "prompt",
+			Verdict:    "clean",
+			DurationMs: 1,
+		},
+		AgentIdentity{},
+	)
+	if err != nil {
+		t.Fatalf("EmitInspectFindings: %v", err)
+	}
+	if evalID == "" || scanID == "" {
+		t.Fatal("expected non-empty ids even for empty findings")
+	}
+	var sawScan bool
+	for _, ev := range emitted {
+		if ev.EventType == gatewaylog.EventScanFinding {
+			t.Errorf("unexpected EventScanFinding for empty source")
+		}
+		if ev.EventType == gatewaylog.EventScan {
+			sawScan = true
+			if ev.Scan == nil || ev.Scan.EvaluationID != evalID {
+				t.Errorf("scan event missing evaluation_id; got %+v", ev.Scan)
+			}
+		}
+	}
+	if !sawScan {
+		t.Fatal("expected an EventScan roll-up even with zero findings")
+	}
+}
+
+func TestEmitInspectFindings_GeneratesEvaluationIDWhenEmpty(t *testing.T) {
+	evalID, _, err := EmitInspectFindings(context.Background(), nil, nil, nil,
+		InspectFindingSource{Scanner: "guardrail-llm", Target: "model", Verdict: "allow"},
+		AgentIdentity{},
+	)
+	if err != nil {
+		t.Fatalf("EmitInspectFindings: %v", err)
+	}
+	if evalID == "" {
+		t.Fatal("expected generated evaluation_id")
+	}
+	if len(evalID) < 8 || !strings.Contains(evalID, "-") {
+		t.Errorf("evaluation_id %q does not look like a uuid", evalID)
+	}
+}
+
+func TestEmitInspectFindings_UsesProvidedEvaluationID(t *testing.T) {
+	evalID, _, err := EmitInspectFindings(context.Background(), nil, nil, nil,
+		InspectFindingSource{
+			Scanner:      "ai-defense",
+			Target:       "prompt",
+			Verdict:      "warn",
+			EvaluationID: "caller-supplied-1234",
+		},
+		AgentIdentity{},
+	)
+	if err != nil {
+		t.Fatalf("EmitInspectFindings: %v", err)
+	}
+	if evalID != "caller-supplied-1234" {
+		t.Errorf("EmitInspectFindings clobbered caller evaluation_id; got %q", evalID)
+	}
+}
+
+func TestTopRuleIDs(t *testing.T) {
+	in := []InspectFinding{
+		{RuleID: "A"},
+		{RuleID: "B"},
+		{RuleID: "A"}, // dedup
+		{RuleID: ""},  // skip
+		{RuleID: "C"},
+		{RuleID: "D"},
+		{RuleID: "E"},
+		{RuleID: "F"},
+	}
+	got := TopRuleIDs(in, 3)
+	want := []string{"A", "B", "C"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("TopRuleIDs(_, 3) = %v, want %v", got, want)
+	}
+	if TopRuleIDs(in, 0) != nil {
+		t.Error("TopRuleIDs with n=0 should return nil")
+	}
+}

--- a/internal/scanner/result.go
+++ b/internal/scanner/result.go
@@ -55,6 +55,10 @@ type Finding struct {
 	Category string `json:"category,omitempty"`
 	// LineNumber is 1-based when applicable; nil means unknown / N/A.
 	LineNumber *int `json:"line_number,omitempty"`
+	// Confidence is the detector's self-reported certainty in [0,1].
+	// Populated by regex/judge/AID detectors; 0 (omitted) for binary
+	// match-or-miss scanners.
+	Confidence float64 `json:"confidence,omitempty"`
 
 	// --- Multi-step correlation fields (see internal/guardrail/correlator.go) ---
 

--- a/internal/scanner/scan_emitter.go
+++ b/internal/scanner/scan_emitter.go
@@ -83,6 +83,11 @@ type ScanSummaryParams struct {
 	SessionID         string
 	RequestID         string
 	TraceID           string
+	// EvaluationID joins this scan to the upstream runtime
+	// evaluation (hook handler, /api/v1/inspect/*, proxy guardrail,
+	// mid-stream, tool-call-inspect). Empty for classic scanner
+	// invocations.
+	EvaluationID string
 }
 
 // ScanFindingMeta stamps correlation + provenance on scan_findings rows.
@@ -100,6 +105,10 @@ type ScanFindingMeta struct {
 	ContentHash       string
 	Generation        uint64
 	BinaryVersion     string
+	// EvaluationID matches ScanSummaryParams.EvaluationID; copied
+	// onto every scan_findings row so SIEM queries can pivot on it
+	// without joining to scan_results.
+	EvaluationID string
 }
 
 // EmitScanResult fans out one EventScan + N EventScanFinding events (when w
@@ -164,6 +173,7 @@ func EmitScanResult(
 		ContentHash:       prov.ContentHash,
 		Generation:        prov.Generation,
 		BinaryVersion:     prov.BinaryVersion,
+		EvaluationID:      agent.EvaluationID,
 	}
 
 	if pers != nil {
@@ -195,6 +205,7 @@ func EmitScanResult(
 			AgentName:         agent.AgentName,
 			AgentInstanceID:   agent.AgentInstanceID,
 			SidecarInstanceID: agent.SidecarInstanceID,
+			EvaluationID:      agent.EvaluationID,
 		}
 		if err := pers.InsertScanSummary(sum); err != nil {
 			return scanID, err
@@ -227,17 +238,18 @@ func EmitScanResult(
 			AgentInstanceID:   agent.AgentInstanceID,
 			SidecarInstanceID: agent.SidecarInstanceID,
 			Scan: &gatewaylog.ScanPayload{
-				ScanID:      scanID,
-				Scanner:     scannerEnum,
-				Target:      result.Target,
-				TargetType:  targetTypeEnum,
-				Verdict:     verdictEnum,
-				DurationMs:  result.Duration.Milliseconds(),
-				SeverityMax: maxSev,
-				Counts:      counts,
-				TotalCount:  len(result.Findings),
-				ExitCode:    result.ExitCode,
-				Error:       result.ScanError,
+				ScanID:       scanID,
+				Scanner:      scannerEnum,
+				Target:       result.Target,
+				TargetType:   targetTypeEnum,
+				Verdict:      verdictEnum,
+				DurationMs:   result.Duration.Milliseconds(),
+				SeverityMax:  maxSev,
+				Counts:       counts,
+				TotalCount:   len(result.Findings),
+				ExitCode:     result.ExitCode,
+				Error:        result.ScanError,
+				EvaluationID: agent.EvaluationID,
 			},
 		})
 		for i := range result.Findings {
@@ -259,19 +271,21 @@ func EmitScanResult(
 				AgentInstanceID:   agent.AgentInstanceID,
 				SidecarInstanceID: agent.SidecarInstanceID,
 				ScanFinding: &gatewaylog.ScanFindingPayload{
-					ScanID:      scanID,
-					Scanner:     scannerEnum,
-					Target:      result.Target,
-					FindingID:   f.ID,
-					RuleID:      f.RuleID,
-					Category:    f.Category,
-					Title:       f.Title,
-					Description: f.Description,
-					Severity:    toGatewaySeverity(f.Severity),
-					Location:    f.Location,
-					LineNumber:  ln,
-					Remediation: f.Remediation,
-					Tags:        f.Tags,
+					ScanID:       scanID,
+					Scanner:      scannerEnum,
+					Target:       result.Target,
+					FindingID:    f.ID,
+					RuleID:       f.RuleID,
+					Category:     f.Category,
+					Title:        f.Title,
+					Description:  f.Description,
+					Severity:     toGatewaySeverity(f.Severity),
+					Location:     f.Location,
+					LineNumber:   ln,
+					Remediation:  f.Remediation,
+					Tags:         f.Tags,
+					Confidence:   f.Confidence,
+					EvaluationID: agent.EvaluationID,
 				},
 			})
 		}

--- a/internal/scanner/target_type.go
+++ b/internal/scanner/target_type.go
@@ -27,7 +27,15 @@ func InferTargetType(scannerName string) string {
 }
 
 // NormalizeScannerEnum maps a raw scanner name to the v7 gateway-event
-// schema enum ("skill" | "mcp" | "plugin" | "aibom" | "codeguard").
+// schema enum. The enum is open to two families:
+//
+//   - "skill" | "mcp" | "plugin" | "aibom" | "codeguard": classic
+//     scanner-invocation sources (skill-scanner, mcp-scanner, etc.).
+//   - "hook-rules" | "inline-codeguard" | "ai-defense" |
+//     "asset-policy" | "tool-call-inspect" | "inspect-http" |
+//     "guardrail-llm" | "mid-stream" | "rescan": runtime
+//     finding-emitter sources fanned out through EmitInspectFindings.
+//
 // ClawShield family scanners are treated as codeguard siblings since
 // they ship builtin code/content detectors. Unknown scanners fall
 // back to "codeguard" (the most generic, always-schema-valid option)
@@ -49,21 +57,41 @@ func NormalizeScannerEnum(scannerName string) string {
 		"clawshield-vuln", "clawshield-secrets", "clawshield-pii",
 		"clawshield-malware", "clawshield-injection":
 		return "codeguard"
+	case "hook-rules",
+		"inline-codeguard",
+		"ai-defense",
+		"asset-policy",
+		"tool-call-inspect",
+		"inspect-http",
+		"guardrail-llm",
+		"mid-stream",
+		"rescan":
+		return scannerName
 	default:
 		return "codeguard"
 	}
 }
 
 // NormalizeTargetTypeEnum maps a raw target_type to the v7
-// gateway-event schema enum ("file" | "skill" | "mcp" | "plugin"
-// | "aibom"). Unknown / empty values are coerced to "file" (the
-// generic filesystem-object bucket) because the schema only allows
-// the listed enum values or nil, and we want to keep the payload
-// valid without hand-wiring every scanner. Callers should still
-// set TargetType on ScanResult when they have a better-typed value.
+// gateway-event schema enum. Two families:
+//
+//   - "file" | "skill" | "mcp" | "plugin" | "aibom": classic
+//     scanner-invocation targets.
+//   - "tool_call" | "prompt" | "completion" | "tool_response" |
+//     "inspect": runtime finding-emitter targets where the "target"
+//     is a tool name or message surface rather than a filesystem
+//     path.
+//
+// Unknown / empty values are coerced to "file" (the generic
+// filesystem-object bucket) because the schema only allows the
+// listed enum values or nil, and we want to keep the payload valid
+// without hand-wiring every scanner. Callers should still set
+// TargetType on ScanResult when they have a better-typed value.
 func NormalizeTargetTypeEnum(targetType string) string {
 	switch strings.TrimSpace(targetType) {
 	case "file", "skill", "mcp", "plugin", "aibom":
+		return targetType
+	case "tool_call", "prompt", "completion", "tool_response", "inspect":
 		return targetType
 	case "inventory":
 		return "aibom"

--- a/internal/watcher/rescan.go
+++ b/internal/watcher/rescan.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/defenseclaw/defenseclaw/internal/audit"
 	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/gatewaylog"
 	"github.com/defenseclaw/defenseclaw/internal/scanner"
 )
 
@@ -58,6 +59,13 @@ type DriftDelta struct {
 	Description string    `json:"description"`
 	Previous    string    `json:"previous,omitempty"`
 	Current     string    `json:"current,omitempty"`
+	// RuleID is the underlying detection rule that triggered this
+	// drift delta. Populated for finding-driven deltas
+	// (new_finding, resolved_finding, severity_escalation on a
+	// specific finding) so SIEM queries can join drift events back
+	// to the scan_findings rows they reference. Empty for content /
+	// dependency / endpoint deltas that don't map to a single rule.
+	RuleID string `json:"rule_id,omitempty"`
 }
 
 // rescanLoop runs periodic re-scans of all installed skills, plugins, and MCPs,
@@ -225,7 +233,7 @@ func (w *InstallWatcher) storeBaseline(ctx context.Context, evt InstallEvent, sn
 
 		result, err := s.Scan(scanCtx, w.scanTargetFor(evt))
 		if err == nil && result != nil {
-			scanID = w.persistScanResult(result)
+			scanID = w.emitRescanResult(scanCtx, result)
 		}
 	}
 
@@ -291,6 +299,14 @@ func (w *InstallWatcher) compareScanResults(ctx context.Context, evt InstallEven
 			Current:     curMax,
 		})
 	}
+
+	// Also run the current scan through EmitScanResult so the
+	// rescan-time per-rule findings are visible alongside the drift
+	// summary — without this hook, only the *baseline* scan is
+	// emitted via scan_findings rows, and intermediate rescans that
+	// don't qualify as "new baseline" are invisible to SIEM finding
+	// queries.
+	_ = w.emitRescanResult(scanCtx, current)
 
 	return deltas
 }
@@ -469,6 +485,7 @@ func diffFindings(prev, curr []scanner.Finding) []DriftDelta {
 				Severity:    string(f.Severity),
 				Description: fmt.Sprintf("new finding: %s (%s)", findingLabel(f), f.Severity),
 				Current:     findingLabel(f),
+				RuleID:      f.RuleID,
 			})
 			continue
 		}
@@ -483,6 +500,7 @@ func diffFindings(prev, curr []scanner.Finding) []DriftDelta {
 				Description: fmt.Sprintf("finding severity changed: %s (%s -> %s)", findingLabel(f), prevFinding.Severity, f.Severity),
 				Previous:    string(prevFinding.Severity),
 				Current:     string(f.Severity),
+				RuleID:      f.RuleID,
 			})
 		}
 	}
@@ -494,11 +512,41 @@ func diffFindings(prev, curr []scanner.Finding) []DriftDelta {
 				Severity:    "INFO",
 				Description: fmt.Sprintf("finding resolved: %s (was %s)", findingLabel(f), f.Severity),
 				Previous:    findingLabel(f),
+				RuleID:      f.RuleID,
 			})
 		}
 	}
 
 	return deltas
+}
+
+// driftRuleIDs collects the distinct rule identifiers from a set
+// of drift deltas, preserving discovery order and capping the
+// result at max entries. Empty rule IDs are skipped so the
+// `rule_ids=` suffix never carries empty tokens. The cap matches
+// the convention used by every other emission surface in the
+// gateway (hook handlers, proxy guardrail, inspect HTTP) so SIEM
+// dashboards can rely on a uniform fanout budget.
+func driftRuleIDs(deltas []DriftDelta, max int) []string {
+	if max <= 0 || len(deltas) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(deltas))
+	out := make([]string, 0, len(deltas))
+	for _, d := range deltas {
+		if d.RuleID == "" {
+			continue
+		}
+		if seen[d.RuleID] {
+			continue
+		}
+		seen[d.RuleID] = true
+		out = append(out, d.RuleID)
+		if len(out) >= max {
+			break
+		}
+	}
+	return out
 }
 
 // emitDriftAlerts logs drift deltas as alert events in the audit store.
@@ -515,12 +563,23 @@ func (w *InstallWatcher) emitDriftAlerts(evt InstallEvent, deltas []DriftDelta) 
 
 	fmt.Fprintf(os.Stderr, "[rescan] drift detected in %s %s: %s\n", evt.Type, evt.Name, summary)
 
+	// Surface the drift's distinct underlying rule identifiers
+	// alongside the structured JSON details so SIEM queries can
+	// pivot on `rule_ids` consistently with hook + proxy + inspect
+	// emissions. The JSON details remain the source of truth for
+	// per-delta info; the string suffix is the SIEM-friendly view.
+	ruleIDs := driftRuleIDs(deltas, 8)
+	details := string(detailsJSON)
+	if len(ruleIDs) > 0 {
+		details += " rule_ids=" + strings.Join(ruleIDs, ",")
+	}
+
 	event := audit.Event{
 		Timestamp: time.Now().UTC(),
 		Action:    string(audit.ActionDrift),
 		Target:    evt.Path,
 		Actor:     "defenseclaw-rescan",
-		Details:   string(detailsJSON),
+		Details:   details,
 		Severity:  maxSev,
 	}
 	if err := w.logger.LogEvent(event); err != nil {
@@ -622,20 +681,62 @@ func (w *InstallWatcher) scanTargetFor(evt InstallEvent) string {
 	return entry.Name
 }
 
-// persistScanResult stores a scan result in the audit DB and returns the generated scan ID.
-func (w *InstallWatcher) persistScanResult(result *scanner.ScanResult) string {
+// emitRescanResult fans a watcher rescan result through the
+// unified scan emission pipeline so the rescan's per-rule findings
+// land on every observability surface: scan_results + scan_findings
+// DB rows, EventScan + EventScanFinding gateway.jsonl lines,
+// defenseclaw_scan_findings_by_rule_total metrics, and the
+// sliding-window correlator. Previously this path called
+// audit.Store.InsertScanResult directly which wrote only the
+// aggregate row and dropped every per-rule detection on the floor
+// — making periodic rescans invisible to SIEM finding queries.
+//
+// Returns the generated scan ID so storeBaseline can persist it as
+// the snapshot's baseline reference. On emission failure (writer or
+// persistence error) returns the empty string and lets the
+// snapshot store fall back to "" — matching the prior behavior of
+// persistScanResult so callers don't see new failure modes.
+func (w *InstallWatcher) emitRescanResult(ctx context.Context, result *scanner.ScanResult) string {
 	if result == nil {
 		return ""
 	}
-	scanID := uuid.New().String()
-	raw, _ := result.JSON()
-	err := w.store.InsertScanResult(
-		scanID, result.Scanner, result.Target, result.Timestamp,
-		result.Duration.Milliseconds(), len(result.Findings),
-		string(result.MaxSeverity()), string(raw),
-	)
+	var pers scanner.ScanPersistence
+	if w.store != nil {
+		pers = w.store
+	}
+	var tel scanner.ScanTelemetry
+	if w.otel != nil {
+		tel = w.otel
+	}
+	gw := w.gatewayLogWriter()
+
+	agent := scanner.AgentIdentity{
+		RunID: rescanRunID(),
+	}
+	scanID, err := scanner.EmitScanResult(ctx, gw, pers, tel, result, agent)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "[rescan] emit scan result for %s: %v\n", result.Target, err)
 		return ""
 	}
 	return scanID
+}
+
+// gatewayLogWriter returns the gateway.jsonl writer wired into the
+// watcher's audit logger, or nil when the logger has no writer
+// attached (test harnesses, sidecar-less CLI invocations).
+func (w *InstallWatcher) gatewayLogWriter() *gatewaylog.Writer {
+	if w == nil || w.logger == nil {
+		return nil
+	}
+	return w.logger.GatewayLogWriter()
+}
+
+// rescanRunID returns a fresh run ID for each rescan emission so
+// the emitted scan rows are attributable to a specific cycle, and
+// downstream correlator joins can scope findings to one rescan
+// rather than blending cycles. Watchers don't carry a request_id
+// (there's no HTTP request to correlate against), so the run_id is
+// the only correlation key available — making it required.
+func rescanRunID() string {
+	return "rescan-" + uuid.New().String()
 }

--- a/schemas/gateway-event-envelope.json
+++ b/schemas/gateway-event-envelope.json
@@ -91,7 +91,9 @@
         "action":     { "type": "string", "enum": ["allow", "warn", "alert", "confirm", "block"] },
         "reason":     { "type": ["string", "null"] },
         "categories": { "type": ["array", "null"], "items": { "type": "string" } },
-        "latency_ms": { "type": ["integer", "null"] }
+        "latency_ms": { "type": ["integer", "null"] },
+        "evaluation_id": { "type": ["string", "null"], "description": "Optional join key linking this verdict to its per-finding scan_findings rows / EventScanFinding fan-out." },
+        "rule_ids":   { "type": ["array", "null"], "items": { "type": "string" }, "description": "Top detection rule identifiers that drove this verdict (capped at 8). Quick SIEM-pivot key." }
       }
     },
     "JudgePayload": {
@@ -122,10 +124,12 @@
       "type": "object",
       "required": ["subsystem", "message"],
       "properties": {
-        "subsystem": { "type": "string" },
-        "code":      { "type": ["string", "null"] },
-        "message":   { "type": "string" },
-        "cause":     { "type": ["string", "null"] }
+        "subsystem":     { "type": "string" },
+        "code":          { "type": ["string", "null"] },
+        "message":       { "type": "string" },
+        "cause":         { "type": ["string", "null"] },
+        "rule_id":       { "type": ["string", "null"], "description": "Optional rule identifier this error is attributable to (schema-gate violations on finding events, verdict-failure errors)." },
+        "evaluation_id": { "type": ["string", "null"], "description": "Optional join key linking this error to the evaluation that produced the broken event (matches ScanPayload.evaluation_id / VerdictPayload.evaluation_id)." }
       }
     },
     "DiagnosticPayload": {

--- a/schemas/scan-event.json
+++ b/schemas/scan-event.json
@@ -9,9 +9,24 @@
       "required": ["scan_id", "scanner", "target"],
       "properties": {
         "scan_id":     { "type": "string", "description": "Correlation id shared by the roll-up EventScan and all child EventScanFinding events." },
-        "scanner":     { "type": "string", "enum": ["skill", "mcp", "plugin", "aibom", "codeguard"] },
-        "target":      { "type": "string", "description": "File path | skill name | server URL. Redacted when scanner contract requires." },
-        "target_type": { "type": ["string", "null"], "enum": ["file", "skill", "mcp", "plugin", "aibom", null] },
+        "scanner":     {
+          "type": "string",
+          "description": "Source of the finding. Classic scanner invocations use skill|mcp|plugin|aibom|codeguard. Runtime finding emitters fanned out via EmitInspectFindings use hook-rules|inline-codeguard|ai-defense|asset-policy|tool-call-inspect|inspect-http|guardrail-llm|mid-stream|rescan.",
+          "enum": [
+            "skill", "mcp", "plugin", "aibom", "codeguard",
+            "hook-rules", "inline-codeguard", "ai-defense", "asset-policy",
+            "tool-call-inspect", "inspect-http", "guardrail-llm", "mid-stream", "rescan"
+          ]
+        },
+        "target":      { "type": "string", "description": "File path | skill name | server URL | tool name | message surface. Redacted when scanner contract requires." },
+        "target_type": {
+          "type": ["string", "null"],
+          "enum": [
+            "file", "skill", "mcp", "plugin", "aibom",
+            "tool_call", "prompt", "completion", "tool_response", "inspect",
+            null
+          ]
+        },
         "verdict":     { "type": ["string", "null"], "enum": ["clean", "warn", "block", null] },
         "duration_ms": { "type": ["integer", "null"] },
         "severity_max":{ "type": ["string", "null"], "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO", null] },
@@ -22,7 +37,8 @@
         },
         "total_count": { "type": ["integer", "null"], "minimum": 0 },
         "exit_code":   { "type": ["integer", "null"] },
-        "error":       { "type": ["string", "null"], "description": "Scanner execution error. Present only when the wrapper failed (timeout, non-zero exit)." }
+        "error":       { "type": ["string", "null"], "description": "Scanner execution error. Present only when the wrapper failed (timeout, non-zero exit)." },
+        "evaluation_id": { "type": ["string", "null"], "description": "Optional join key linking this scan to its upstream runtime evaluation (hook handler, /api/v1/inspect/*, proxy guardrail, mid-stream, tool-call-inspect, watcher rescan). Empty for classic scanner-invocation paths." }
       }
     }
   },

--- a/schemas/scan-finding-event.json
+++ b/schemas/scan-finding-event.json
@@ -9,7 +9,15 @@
       "required": ["scan_id", "scanner", "target"],
       "properties": {
         "scan_id":     { "type": "string" },
-        "scanner":     { "type": "string", "enum": ["skill", "mcp", "plugin", "aibom", "codeguard"] },
+        "scanner":     {
+          "type": "string",
+          "description": "Source of the finding. Classic scanner invocations use skill|mcp|plugin|aibom|codeguard. Runtime finding emitters fanned out via EmitInspectFindings use hook-rules|inline-codeguard|ai-defense|asset-policy|tool-call-inspect|inspect-http|guardrail-llm|mid-stream|rescan.",
+          "enum": [
+            "skill", "mcp", "plugin", "aibom", "codeguard",
+            "hook-rules", "inline-codeguard", "ai-defense", "asset-policy",
+            "tool-call-inspect", "inspect-http", "guardrail-llm", "mid-stream", "rescan"
+          ]
+        },
         "target":      { "type": "string" },
         "finding_id":  { "type": ["string", "null"] },
         "rule_id":     { "type": ["string", "null"], "description": "Stable detection rule identifier. Preferred group-by for SIEM; never display-string." },
@@ -20,7 +28,9 @@
         "location":    { "type": ["string", "null"], "description": "Redacted path + line." },
         "line_number": { "type": ["integer", "null"], "minimum": 0 },
         "remediation": { "type": ["string", "null"] },
-        "tags":        { "type": ["array", "null"], "items": { "type": "string" } }
+        "tags":        { "type": ["array", "null"], "items": { "type": "string" } },
+        "confidence":  { "type": ["number", "null"], "minimum": 0, "maximum": 1, "description": "Detector self-reported certainty in [0,1]. Omitted by binary scanners." },
+        "evaluation_id": { "type": ["string", "null"], "description": "Optional join key matching the parent ScanPayload.evaluation_id." }
       }
     }
   },

--- a/schemas/scan-result.json
+++ b/schemas/scan-result.json
@@ -6,7 +6,16 @@
   "type": "object",
   "required": ["scanner", "target", "timestamp", "findings"],
   "properties": {
-    "scanner":   { "type": "string", "enum": ["skill", "mcp", "plugin", "aibom", "codeguard", "skill-scanner", "mcp-scanner", "plugin-scanner"] },
+    "scanner":   {
+      "type": "string",
+      "description": "Source of the scan. Classic scanner invocations use skill|mcp|plugin|aibom|codeguard (or their *-scanner aliases). Runtime finding emitters fanned out via EmitInspectFindings use hook-rules|inline-codeguard|ai-defense|asset-policy|tool-call-inspect|inspect-http|guardrail-llm|mid-stream|rescan.",
+      "enum": [
+        "skill", "mcp", "plugin", "aibom", "codeguard",
+        "skill-scanner", "mcp-scanner", "plugin-scanner",
+        "hook-rules", "inline-codeguard", "ai-defense", "asset-policy",
+        "tool-call-inspect", "inspect-http", "guardrail-llm", "mid-stream", "rescan"
+      ]
+    },
     "target":    { "type": "string" },
     "timestamp": { "type": "string", "format": "date-time" },
     "duration":  { "type": ["string", "null"] },

--- a/test/e2e/v7_observability_test.go
+++ b/test/e2e/v7_observability_test.go
@@ -320,6 +320,110 @@ func testSurfaceScanFinding(t *testing.T, h *observabilityHarness) {
 	if len(findings) == 0 {
 		t.Fatal("expected scan_findings rows")
 	}
+
+	// Pin the unified-pipeline contract: when a parent scan event
+	// carries an evaluation_id (runtime flows: hooks, inspect HTTP,
+	// proxy guardrail, asset-policy, rescan), every child finding
+	// event must echo the same id so SIEM joins on evaluation_id
+	// work without falling back to scan_id. Classic scanner-CLI
+	// invocations (this surface test path) leave it empty, so the
+	// assertion is conditional: empty parent → empty children.
+	scanEvs := findGatewayEvents(h, gatewaylog.EventScan)
+	if len(scanEvs) == 0 {
+		t.Fatal("missing scan event for evaluation_id join check")
+	}
+	parentEval := scanEvs[len(scanEvs)-1].Scan.EvaluationID
+	for i, f := range evs {
+		if f.ScanFinding.EvaluationID != parentEval {
+			t.Fatalf("scan_finding[%d].evaluation_id=%q does not match parent scan evaluation_id=%q",
+				i, f.ScanFinding.EvaluationID, parentEval)
+		}
+	}
+}
+
+// TestV7ObservabilityRuntimeEvaluationIDJoinKey is the runtime-flow
+// counterpart to testSurfaceScanFinding: it drives a synthetic
+// runtime evaluation through scanner.EmitScanResult with a populated
+// AgentIdentity.EvaluationID (the contract used by every hook /
+// inspect / proxy-guardrail call site) and pins the join key on all
+// three observability surfaces — gateway JSONL, audit DB, and the
+// child finding events. A regression here means SIEM dashboards keyed
+// on evaluation_id silently lose runtime findings.
+func TestV7ObservabilityRuntimeEvaluationIDJoinKey(t *testing.T) {
+	t.Parallel()
+	h := newObservabilityHarness(t)
+
+	const wantEval = "eval-test-runtime-7f3a"
+	ln := 17
+	res := minimalScanResult([]scanner.Finding{
+		{
+			ID:         "rt-1",
+			Title:      "prompt injection: ignore previous",
+			Severity:   scanner.SeverityHigh,
+			Category:   "prompt_injection",
+			RuleID:     "INJ.OVERRIDE",
+			LineNumber: &ln,
+		},
+	})
+
+	scanID, err := scanner.EmitScanResult(
+		context.Background(),
+		h.GW,
+		h.Store,
+		h.Tel,
+		res,
+		scanner.AgentIdentity{
+			AgentID:      "gateway",
+			RunID:        e2eRunID,
+			TraceID:      e2eTraceID,
+			EvaluationID: wantEval,
+		},
+	)
+	if err != nil {
+		t.Fatalf("EmitScanResult: %v", err)
+	}
+	if scanID == "" {
+		t.Fatal("EmitScanResult returned empty scan_id")
+	}
+
+	scanEvs := findGatewayEvents(h, gatewaylog.EventScan)
+	if len(scanEvs) == 0 {
+		t.Fatal("missing scan event")
+	}
+	if got := scanEvs[len(scanEvs)-1].Scan.EvaluationID; got != wantEval {
+		t.Fatalf("EventScan.evaluation_id: got %q want %q", got, wantEval)
+	}
+
+	findEvs := findGatewayEvents(h, gatewaylog.EventScanFinding)
+	if len(findEvs) == 0 {
+		t.Fatal("missing scan_finding events")
+	}
+	for i, f := range findEvs {
+		if f.ScanFinding.EvaluationID != wantEval {
+			t.Fatalf("EventScanFinding[%d].evaluation_id: got %q want %q",
+				i, f.ScanFinding.EvaluationID, wantEval)
+		}
+		// Confidence is opt-in; assert it survives a zero value
+		// round-trip without panicking when not set on input.
+		_ = f.ScanFinding.Confidence
+	}
+
+	// Audit DB: the scan_findings row must persist evaluation_id so
+	// classic SQL queries (`SELECT * FROM scan_findings WHERE
+	// evaluation_id = ?`) work without joining to scan_results.
+	rows, err := h.Store.ListScanFindings(scanID)
+	if err != nil {
+		t.Fatalf("ListScanFindings: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("expected scan_findings rows in audit DB")
+	}
+	for i, r := range rows {
+		if r.EvaluationID != wantEval {
+			t.Fatalf("scan_findings[%d].evaluation_id: got %q want %q",
+				i, r.EvaluationID, wantEval)
+		}
+	}
 }
 
 func testSurfaceActivity(t *testing.T, h *observabilityHarness) {


### PR DESCRIPTION
> Stacked on top of #284. Base branch is `feat/hook-collector-unification`; rebase / merge this only after #284 lands (or re-target this PR to `main`).

## Problem

Runtime detections produced by hook-based connectors (claudecode, codex,
cursor, hermes, windsurf, geminicli, copilot, openhands), inspect HTTP
endpoints, the proxy guardrail, mid-stream checks, tool-call inspection,
asset-policy, and watcher rescan drift were observable inconsistently
across our five sinks. Operators routinely hit three concrete failure modes:

1. `scan_findings.evaluation_id` was empty on every runtime path, so a
   SIEM analyst pivoting from an audit row to the matching scan_finding
   events had to fall back to fuzzy joins on `scan_id + timestamp`.
2. `EventError` payloads emitted by the gateway log's schema gate and
   by verdict-failure paths surfaced as anonymous infrastructure errors,
   even when the broken event carried a `rule_id` and a runtime
   `evaluation_id` — those keys silently dropped on the floor.
3. `scan_findings.confidence` did not exist as a column. The runtime
   detector self-reported score (0..1) survived only in the JSONL stream,
   so dashboards ranking by certainty could not join through the audit DB.

## Current Situation

- `internal/scanner/scan_emitter.go` was the choke point for classic
  skill/MCP scans, but runtime callers (`internal/gateway/proxy.go`,
  `internal/gateway/inspect_hooks.go`, `internal/watcher/rescan.go`,
  `internal/gateway/asset_policy_runtime.go`) had their own emit paths
  with partial coverage of the five sinks.
- `HookAuditEnvelope` (`internal/gateway/hook_audit_envelope.go`) carried
  hook decision metadata but had no first-class fields for the unified
  correlation keys; per-connector handlers improvised them into
  `details` strings.
- `internal/audit/store.go` migrations had no slot for `confidence` or
  `evaluation_id` on `scan_findings` / `scan_results`.
- `internal/gatewaylog/events.go` `ErrorPayload` had no `rule_id` /
  `evaluation_id` fields, and the writer (`writer.go`) had no helper to
  recover those keys from a dropped event's payload.
- `scanner` enum (across four JSON schemas + `NormalizeScannerEnum`)
  listed only classic scanner names, so any new runtime scanner value
  was rejected by the strict-mode validator.

## Solution

Route every runtime emission — regardless of origin — through
`scanner.EmitInspectFindings` (which wraps `scanner.EmitScanResult`),
and stamp a single `evaluation_id` on the resulting EventScan +
EventScanFinding pair, the audit DB rows, the verdict envelope, and any
synthesised EventError. Per-connector evaluators stamp
`resp.EvaluationID` + `resp.RuleIDs` inline so the existing
`hookProfileRuntime.Evaluate` callback shape (returns a single
`agentHookResponse`) survives untouched. `finalizeAgentHook` copies
those into `HookAuditEnvelope` so the typed audit envelope carries them
as proper columns rather than free-form `details` k=v.

Alternatives considered:

- Adding a parallel correlator service that joins on best-effort
  heuristics. Rejected: more moving parts, still fuzzy.
- Changing the `Evaluate` callback signature to return
  `(agentHookResponse, hookEvaluationContext)`. Rejected: cascading
  break across every external test that constructs a fake runtime.
- Storing `evaluation_id` only on `scan_findings` and joining backward
  to `scan_results` by `scan_id`. Rejected: SIEM queries already pivot
  `scan_results` → `scan_findings` → verdict → `audit_events`, and a
  missing column on either side defeats the whole join.

## Architecture Diagram

```
Before:
 ┌──────────────────┐    ┌──────────────────────────┐
 │ hook handler     │──emit──▶│ ad-hoc audit details │ ────▶ JSONL
 ├──────────────────┤    └──────────────────────────┘       Audit DB (no eval id)
 │ inspect HTTP     │──emit──▶┌──────────────────────────┐    Metrics
 ├──────────────────┤        │ partial sink coverage    │    Notifier (no rule ids)
 │ proxy guardrail  │──emit──▶└──────────────────────────┘    HILT
 ├──────────────────┤
 │ watcher rescan   │──emit──▶ classic EmitScanResult only
 └──────────────────┘

After:
 ┌──────────────────┐    ┌────────────────────────────┐    ┌─────────────────────────┐
 │ hook handler     │──┐  │                            │    │ JSONL (EventScan,       │
 ├──────────────────┤  │  │                            │    │ EventScanFinding,       │
 │ inspect HTTP     │  ├──▶│ scanner.EmitInspectFindings │──▶│ EventVerdict, EventError│
 ├──────────────────┤  │  │                            │    │ all carry evaluation_id │
 │ proxy guardrail  │  │  │  - stamp evaluation_id,    │    ├─────────────────────────┤
 ├──────────────────┤  │  │    rule_ids, confidence    │    │ Audit DB                │
 │ watcher rescan   │──┤  │                            │    │ scan_findings.* +       │
 ├──────────────────┤  │  │  - wrap scanner.           │    │ scan_results.*          │
 │ asset-policy     │──┘  │    EmitScanResult          │    ├─────────────────────────┤
 └──────────────────┘    └────────────────────────────┘    │ Prometheus, Notifier,   │
                                                            │ HILT all join on        │
                                                            │ evaluation_id           │
                                                            └─────────────────────────┘
```

## Flow Diagram

```
hook script    Gateway evaluator           audit.Logger    gatewaylog                       scanner.EmitScanResult    Prometheus
 │ POST /hooks/* │                                │            │                                       │                  │
 │──────────────▶│                                │            │                                       │                  │
 │               │ evaluate (per-connector)       │            │                                       │                  │
 │               │── stamp resp.EvaluationID, RuleIDs ──────────────────────────────────────────────▶│                  │
 │               │                                │            │                                       │                  │
 │               │ finalize: HookAuditEnvelope{EvaluationID, RuleIDs} ──▶│                              │                  │
 │               │── emit via EmitInspectFindings ──▶│         │── EventScan / ScanFinding ──────────▶│                  │
 │               │                                │            │   (evaluation_id + rule_id)           │                  │
 │               │                                │            │                                       │── histogram ────▶│
 │ 200 OK (evaluation_id, rule_ids in body)       │            │                                       │                  │
 │◀──────────────│                                │            │                                       │                  │
```

## What Changed (Where & How)

| File | Change Type | Summary |
|---|---|---|
| `internal/scanner/inspect_emit.go` | added | `EmitInspectFindings` adapter: routes RuleFinding / CodeGuard / AID / AssetPolicy findings through `EmitScanResult` with `AgentIdentity.EvaluationID` and `scanner` label normalized. |
| `internal/scanner/inspect_emit_test.go` | test | Covers the adapter for hook-rules, inspect-http, guardrail-llm, mid-stream, tool-call-inspect, asset-policy, drift. |
| `internal/gateway/hook_findings_emit.go` | added | `emitHookRuleFindings` shared helper: builds the per-finding payload and returns the `hookEvaluationContext` (evaluation_id + rule_ids) used by every hook evaluator. |
| `internal/scanner/result.go` | modified | Adds `Confidence float64` to `scanner.Finding` (`omitempty` JSON); plumbs `EvaluationID` onto `ScanPayload`, `ScanFindingPayload`, `VerdictPayload`. |
| `internal/scanner/scan_emitter.go` | modified | Threads `AgentIdentity.EvaluationID` onto every `EventScan` + `EventScanFinding` it writes. |
| `internal/scanner/agent_identity.go` | modified | Adds `EvaluationID` to `AgentIdentity` so runtime callers can stamp the join key on the emission. |
| `internal/scanner/target_type.go` | modified | `NormalizeTargetTypeEnum` accepts the new runtime target values. |
| `internal/audit/store.go` | modified | New migration: `scan_findings.confidence` (REAL), `scan_findings.evaluation_id` (TEXT), `scan_results.evaluation_id` (TEXT), plus indexes on `evaluation_id`. |
| `internal/audit/scan_persist.go` | modified | `ScanFindingRow` projects `Confidence` + `EvaluationID`; `ListScanFindings` selects them. |
| `internal/audit/logger.go` | modified | Hook + inspect audit details append `evaluation_id=` / `rule_ids=` so SIEM rules can index them. |
| `internal/gateway/agent_hook.go` | modified | `evaluateAgentHook` stamps `resp.EvaluationID` + `resp.RuleIDs` inline; `finalizeAgentHook` copies them onto `HookAuditEnvelope`. |
| `internal/gateway/claude_code_hook.go` | modified | `evaluateClaudeCodeHook` stamps the same keys on `claudeCodeHookResponse`. |
| `internal/gateway/codex_hook.go` | modified | `evaluateCodexHook` stamps the same keys on `codexHookResponse`. |
| `internal/gateway/hook_audit_envelope.go` | modified | `HookAuditEnvelope` gains `EvaluationID` + `RuleIDs` as first-class JSON fields (omitempty). |
| `internal/gateway/inspect.go` | modified | `/api/v1/inspect/{request,response,tool-response,tool}` route through `EmitInspectFindings`. |
| `internal/gateway/inspect_hooks.go` | modified | Inspect-hook helpers carry `evaluationID` through to the emitter. |
| `internal/gateway/proxy.go` | modified | `recordTelemetry`, `InspectMidStream` non-block + early-block branches, and `inspectToolCalls` all route through `EmitInspectFindings`; verdict envelope carries `RuleIDs`. |
| `internal/gateway/asset_policy_runtime.go` | modified | Runtime asset-policy decisions emit through `EmitInspectFindings` with `scanner=asset-policy`. |
| `internal/gateway/guardrail.go` | modified | Guardrail-llm verdicts stamp `evaluation_id` and pass `RuleIDs`. |
| `internal/gateway/hilt.go` | modified | HILT approval/block events carry `RuleIDs` end-to-end. |
| `internal/gateway/events.go` | modified | `BlockEvent` + `ApprovalEvent` extended with `RuleIDs`. |
| `internal/gateway/notifier/notifier.go` | modified | Notifier dispatch surfaces `RuleIDs` in payload + log line. |
| `internal/watcher/rescan.go` | modified | Replaces direct `InsertScanResult` path with `EmitScanResult`; restructures drift as `RuleIDs`. |
| `internal/gatewaylog/events.go` | modified | `ErrorPayload` gains `RuleID` + `EvaluationID`. |
| `internal/gatewaylog/writer.go` | modified | Schema-violation `EventError` extracts `rule_id` + `evaluation_id` from the broken event's payload via new `payloadCorrelationIDs` helper. |
| `internal/gatewaylog/schemas/*.json` | modified | Envelope, scan event, scan-finding event schemas updated for new fields. |
| `internal/gatewaylog/validator_test.go` | test | New cases: positive validation for new scanner enum + error-attribution coverage for ScanFinding and Verdict drops. |
| `schemas/*.json` | modified | Top-level schemas mirror the envelope + scan-result enum extension. |
| `internal/cli/embed/scan-result.json` | modified | CLI embedded schema updated in lockstep. |
| `internal/gateway/agent_hook_test.go`, `claude_code_hook_test.go`, `codex_hook_test.go`, `notifier_wiring_test.go` | test | Adjusted to single-return evaluators; assert evaluation_id / rule_ids propagate. |
| `test/e2e/v7_observability_test.go` | test | `testSurfaceScanFinding` asserts parent→child `evaluation_id` consistency; new `TestV7ObservabilityRuntimeEvaluationIDJoinKey` drives a runtime emission and pins the id on JSONL + audit DB. |
| `docs/OBSERVABILITY.md` | docs | New §1.4 documenting the unified pipeline, scanner= catalog, evaluation_id pivot examples. |
| `docs-site/content/docs/reference/gateway-api.mdx` | docs | Verdict envelope JSON + new "Connector hook responses" section both surface `evaluation_id` + `rule_ids`. |
| `bundles/local_observability_stack/grafana/dashboards/defenseclaw-findings.json` | config | Description updated; `$scanner` dropdown documented as dynamically covering hook-rules, inspect-http, guardrail-llm, mid-stream, tool-call-inspect, asset-policy, drift. |
| `cli/defenseclaw/commands/cmd_doctor.py`, `cmd_keys.py`, `credentials.py` + tests | modified | Doctor/keys/credentials maintenance changes folded into the same branch (see "Open Issues / Follow-ups" — split-out PR may be preferable). |
| `.gitignore` | modified | Adds `security_report/` next to `.deepsec/` / `.avarice/` so local scan artifacts stay out of git. |

## Open Issues / Follow-ups

- The CLI doctor / keys / credentials changes are unrelated to the
  finding-pipeline work and ride along in this branch only because they
  were in the working tree at commit time. If reviewers prefer, I can
  split them into a separate PR; tracking decision in this PR's review.
- `evaluation_id` is currently a runtime-only key. Classic scanner-CLI
  invocations (skill, mcp) intentionally leave it NULL on the audit row
  + empty in the JSONL event. A follow-up could backfill a synthetic
  `evaluation_id` per scan invocation if cross-mode joins become
  useful, but the current SIEM dashboards do not need it.
- Grafana dashboard JSON only had its description updated; the `$scanner`
  template variable is already `label_values(scanner)` so it picks up
  new scanner enum values automatically. No panel-level changes shipped.
- `internal/config/TestReadMCPServers_DispatchesViaConnector` is a
  pre-existing environmental flake on machines that have Codex.app's
  bundled `node_repl` MCP server installed (it reads the local MCP
  inventory and finds the extra entry). Out of scope for this PR;
  unchanged on `main`.

## Test Plan

- `go build ./...` → ok
- `go vet ./...` → ok
- `go test ./internal/gateway/... ./internal/scanner/... ./internal/audit/... ./internal/gatewaylog/... ./internal/watcher/... ./test/e2e/...` → all packages pass
- `go test ./internal/...` → only failure is the pre-existing
  environmental `TestReadMCPServers_DispatchesViaConnector` flake
  documented above; same failure reproduces on `main`.

Surface-by-surface check covered by tests:

- JSONL: `TestV7ObservabilityRuntimeEvaluationIDJoinKey` (new) pins
  `EventScan.evaluation_id` and every child `EventScanFinding.evaluation_id`
  to the same value.
- Audit DB: same test asserts `scan_findings.evaluation_id` matches
  the JSONL pair.
- Error attribution: `TestWriter_StrictMode_ViolationErrorAttribution`
  and `TestWriter_StrictMode_ViolationErrorAttributionVerdict` pin
  `rule_id` + `evaluation_id` on synthesised `EventError`.
- HTTP wire shape: existing inspect/proxy integration tests assert
  `detailed_findings` survives the additive change without breaking
  the legacy `findings []string` consumers.
