### PR TITLE
fix(windows): full Windows build support for hook-based enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,11 @@ name: CI
 on:
   push:
     branches: [main]
+  # Run CI on every pull request regardless of base branch so PRs that
+  # target an integration branch (not just main) are gated too — otherwise
+  # their checks (incl. the Windows hook path) never execute until the
+  # change reaches a main-targeting PR.
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,3 +235,57 @@ jobs:
       # tests landed.
       - run: make dev-pycli
       - run: make test
+
+  windows-hook-path:
+    name: Windows Hook Path
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: astral-sh/setup-uv@v8.1.0
+      # The gateway embeds the OpenClaw extension tree, normally generated
+      # by `make sync-openclaw-extension`. Windows is hook-only and needs no
+      # OpenClaw plugin, so drop the same `.placeholder` marker that target
+      # writes when extensions/defenseclaw/dist is absent. Done in bash
+      # (Git Bash ships on the runner) to avoid GNU make's flaky shell
+      # resolution on Windows.
+      - name: Generate OpenClaw extension placeholder
+        shell: bash
+        run: |
+          set -euo pipefail
+          embed_dir=internal/gateway/connector/openclaw_extension
+          mkdir -p "$embed_dir"
+          printf '%s\n' \
+            "OpenClaw extension not built." \
+            "Run 'make extensions' (or 'make plugin') to populate the embedded tree." \
+            > "$embed_dir/.placeholder"
+      # Prove the Windows hook surfaces compile and vet cleanly.
+      - name: Go build (hook surfaces + binary)
+        run: go build ./internal/gateway/connector/... ./internal/cli/... ./internal/daemon/... ./internal/notify/... ./cmd/defenseclaw
+      - name: Go vet (hook surfaces)
+        run: go vet ./internal/gateway/connector/... ./internal/cli/... ./internal/daemon/... ./internal/notify/...
+      # Prove every test binary on the hook surfaces builds on Windows
+      # (compiles all test files, runs zero tests).
+      - name: Go test-compile (all hook-surface tests build on Windows)
+        run: go test -run "^$" ./internal/gateway/connector/... ./internal/cli/... ./internal/daemon/... ./internal/notify/...
+      # Execute the native Go hook decision engine end to end — this is the
+      # whole Windows hook path (stdin cap, token, HTTP, per-connector
+      # output/exit, fail-open/closed, Codex/Claude block schema).
+      - name: Go test - native hook engine
+        run: go test ./internal/gateway/connector/hookexec/...
+      # Execute the per-OS connector capability model and hook-wiring tests.
+      - name: Go test - connector capability + hook wiring
+        run: go test ./internal/gateway/connector/ -run "ProxyConnector|IsProxyConnector|ConnectorSupportedOnOS|RegistryNamesFilter|HookInvocationCommand|ShellWordPassesNativeCommandThrough|BuildCodexHooksTableHashesTheCommand|IsOwnedHookRecognizesNativeCommand"
+      # Execute the native `defenseclaw hook` entrypoint + sidecar resolution.
+      - name: Go test - hook entrypoint
+        run: go test ./internal/cli/ -run "BuildHookOptions|ReadHookSidecar|HookCommandRegistered"
+      - name: Sync Python env
+        shell: bash
+        run: uv sync
+      # Execute the per-OS connector gating and the Windows config-lock
+      # contention test natively on Windows.
+      - name: Python test - platform gating + config lock
+        shell: bash
+        run: uv run python -m pytest cli/tests/test_platform_support.py cli/tests/test_config_lock_mutex.py -q

--- a/.github/workflows/connector-live-e2e.yml
+++ b/.github/workflows/connector-live-e2e.yml
@@ -1,0 +1,449 @@
+# Live connector hook E2E + upstream regression radar.
+#
+# This workflow is intentionally SEPARATE from e2e.yml so it can go red
+# (an upstream agent shipped a breaking hook change) without blocking the
+# OpenClaw stack gate. It has two layers:
+#
+#   contract-matrix (Layer A) — deterministic, no LLM, no secrets, all OSes.
+#     Builds DefenseClaw, then feeds golden stdin payloads into the *installed*
+#     hook entrypoint for every registry connector and asserts the gateway
+#     received the event, the verdict was shaped correctly, and teardown is
+#     clean. Fork-safe; a candidate to promote to a required PR check later.
+#
+#   live-matrix (Layer B) — installs the real upstream agent at its latest
+#     version, wires it with `defenseclaw setup`, and drives lifecycle + forced
+#     tool events through the real harness. Asserts observe/block/OTLP/teardown
+#     using gateway.jsonl, audit.db, and filesystem sentinel side-effects.
+#     Needs provider secrets, so it never runs for fork pull requests.
+#
+#     ROLLOUT STATUS: Layer B is currently manual-only (workflow_dispatch). The
+#     nightly schedule runs Layer A alone until the live secrets are in place.
+#     Gemini CLI, Cursor, and Copilot are deferred entirely (their native keys
+#     — GOOGLE_API_KEY / CURSOR_API_KEY / COPILOT_CLI_TOKEN — are not yet set
+#     and have no Azure/Bedrock substitute). Re-add their matrix cells and
+#     restore the schedule trigger here once those keys exist.
+#
+#   report — rolls every per-cell result up into the job summary, records the
+#     resolved upstream version, and opens/updates a `connector-regression`
+#     issue on any live-cell failure. Alert-only: it never auto-bumps an
+#     approved version (that stays a deliberate human edit of
+#     cli/defenseclaw/inventory/validated_versions.json).
+#
+# Native Windows hook execution (the agent invoking
+# `defenseclaw-gateway hook --connector <c> --event <e>`) depends on the
+# native Windows hook entrypoint. Until that is proven on hosted Windows
+# runners, all Windows cells (and Copilot everywhere) run with
+# continue-on-error so a flake does not turn the whole matrix red.
+
+name: Connector Live E2E
+
+on:
+  # Staggered two hours after the e2e.yml 07:00 cron so the two heavy
+  # nightly suites do not contend for the same hosted-runner pool.
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+    inputs:
+      connector:
+        description: "Connector to run (or 'all')"
+        type: choice
+        default: all
+        options:
+          - all
+          - codex
+          - claudecode
+          - geminicli
+          - cursor
+          - copilot
+          - openhands
+          - hermes
+          - windsurf
+          - antigravity
+      os:
+        description: "OS to run (or 'all')"
+        type: choice
+        default: all
+        options:
+          - all
+          - linux
+          - macos
+          - windows
+      version:
+        description: "Upstream agent version to install (live layer)"
+        type: string
+        default: latest
+      mode:
+        description: "DefenseClaw enforcement mode for live drivers"
+        type: choice
+        default: action
+        options:
+          - action
+          - observe
+      use_azure:
+        description: "Route Codex + OpenHands through Azure OpenAI"
+        type: boolean
+        default: false
+      use_bedrock:
+        description: "Route Claude Code + OpenHands through Amazon Bedrock"
+        type: boolean
+        default: false
+
+concurrency:
+  group: connector-live-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege at the workflow level; the report job widens to
+# issues: write only where it is actually needed.
+permissions:
+  contents: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Layer A — deterministic contract matrix (no secrets, every OS).
+  # ---------------------------------------------------------------------------
+  contract-matrix:
+    name: Contract ${{ matrix.connector }} / ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        connector:
+          - codex
+          - claudecode
+          - geminicli
+          - cursor
+          - copilot
+          - openhands
+          - hermes
+          - windsurf
+          - antigravity
+    runs-on: ${{ matrix.os }}
+    # Native Windows hook execution is not yet proven on hosted runners;
+    # keep Windows cells advisory until they go consistently green.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    timeout-minutes: 25
+    defaults:
+      run:
+        shell: bash
+    env:
+      DC_E2E_RESULTS: ${{ github.workspace }}/connector-live-e2e-results.jsonl
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Select cell + resolve OS label
+        id: select
+        run: |
+          case "${RUNNER_OS}" in
+            Linux)   dcos=linux ;;
+            macOS)   dcos=macos ;;
+            Windows) dcos=windows ;;
+            *)       dcos=unknown ;;
+          esac
+          echo "DC_E2E_OS=${dcos}" >> "$GITHUB_ENV"
+
+          run=true
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            in_conn="${{ inputs.connector }}"
+            in_os="${{ inputs.os }}"
+            [ "${in_conn}" = "all" ] || [ "${in_conn}" = "${{ matrix.connector }}" ] || run=false
+            [ "${in_os}" = "all" ] || [ "${in_os}" = "${dcos}" ] || run=false
+          fi
+          echo "run=${run}" >> "$GITHUB_OUTPUT"
+          echo "cell ${{ matrix.connector }}/${dcos} selected=${run}"
+
+      - uses: actions/setup-go@v5
+        if: steps.select.outputs.run == 'true'
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: astral-sh/setup-uv@v8.1.0
+        if: steps.select.outputs.run == 'true'
+
+      # Build + install the Python CLI and Go gateway. `make install` runs
+      # sync-openclaw-extension (drops the //go:embed placeholder so the
+      # gateway compiles without the TS plugin) and skips the OpenClaw plugin
+      # entirely because CONNECTOR is not openclaw — hook connectors do not
+      # need it. We do NOT run `make plugin` here for the same reason.
+      - name: Install DefenseClaw
+        if: steps.select.outputs.run == 'true'
+        run: make install
+
+      - name: Put DefenseClaw on PATH
+        if: steps.select.outputs.run == 'true'
+        run: |
+          echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
+          if [ -d "${{ github.workspace }}/.venv/bin" ]; then
+            echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
+          fi
+          # Windows uv venvs expose entry points under Scripts/, not bin/.
+          if [ -d "${{ github.workspace }}/.venv/Scripts" ]; then
+            echo "${{ github.workspace }}/.venv/Scripts" >> "$GITHUB_PATH"
+          fi
+
+      # Deterministic Go contract tests for this connector. The shared
+      # connector lifecycle / observability / verify matrices are
+      # connector-parameterized; filtering with -run to the active cell makes
+      # a failure point at exactly which connector regressed. A connector with
+      # no dedicated subtest matches nothing and `go test` exits 0, so the
+      # golden-payload smoke below is its real Layer-A coverage.
+      - name: Go contract tests
+        if: steps.select.outputs.run == 'true'
+        run: |
+          go test -count=1 ./test/e2e/ \
+            -run "TestConnectorLifecycle_Matrix/${{ matrix.connector }}|TestV7Observability_DestinationAppPerConnector/${{ matrix.connector }}|TestConnectorVerifyCleanOnFreshDataDir/${{ matrix.connector }}|TestGoldenPerConnectorLayout"
+
+      # Golden-payload entrypoint smoke: feed each registry event into the
+      # installed hook entrypoint (Bash script on unix, `defenseclaw-gateway
+      # hook` on Windows) and assert fire + verdict shaping + clean teardown.
+      - name: Contract entrypoint smoke
+        if: steps.select.outputs.run == 'true'
+        run: bash scripts/live-connector-e2e/run.sh --layer contract --connector "${{ matrix.connector }}"
+
+      - name: Upload contract results
+        if: ${{ always() && steps.select.outputs.run == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: connector-live-e2e-results-contract-${{ matrix.connector }}-${{ env.DC_E2E_OS }}
+          path: ${{ env.DC_E2E_RESULTS }}
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload contract logs on failure
+        if: ${{ failure() && steps.select.outputs.run == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: connector-live-e2e-logs-contract-${{ matrix.connector }}-${{ env.DC_E2E_OS }}
+          path: ${{ runner.temp }}/defenseclaw-live-e2e-logs/**
+          if-no-files-found: ignore
+          retention-days: 7
+          include-hidden-files: true
+
+  # ---------------------------------------------------------------------------
+  # Layer B — live agent matrix (real agents, secrets, nightly/dispatch).
+  # Never runs for fork pull requests: provider secrets must not be exposed to
+  # untrusted code, mirroring the full-live gate in e2e.yml.
+  # ---------------------------------------------------------------------------
+  live-matrix:
+    name: Live ${{ matrix.connector }} / ${{ matrix.os }}
+    # Manual-only for now: the nightly schedule runs Layer A (contract) alone
+    # until live provider secrets are in place. Trigger this layer explicitly
+    # via "Run workflow" once keys exist.
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # The reality matrix: which agents have a headless CLI that fires hooks
+        # on which OS. Contract-only connectors (hermes, windsurf, antigravity)
+        # are absent here — they are covered by Layer A only. `experimental`
+        # cells run advisory (continue-on-error) until proven stable.
+        #
+        # Currently scoped to the connectors we can authenticate with Azure
+        # OpenAI / Amazon Bedrock (Codex, Claude Code, OpenHands). Gemini CLI,
+        # Cursor, and Copilot are deferred until their native keys exist — add
+        # their cells back here when GOOGLE_API_KEY / CURSOR_API_KEY /
+        # COPILOT_CLI_TOKEN are configured.
+        include:
+          - { connector: codex,      os: ubuntu-latest,  dcos: linux }
+          - { connector: codex,      os: macos-latest,   dcos: macos }
+          - { connector: codex,      os: windows-latest, dcos: windows, experimental: true }
+          - { connector: claudecode, os: ubuntu-latest,  dcos: linux }
+          - { connector: claudecode, os: macos-latest,   dcos: macos }
+          - { connector: claudecode, os: windows-latest, dcos: windows, experimental: true }
+          # OpenHands needs the Docker runtime, so it is Linux-only.
+          - { connector: openhands,  os: ubuntu-latest,  dcos: linux }
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental || false }}
+    timeout-minutes: 40
+    defaults:
+      run:
+        shell: bash
+    env:
+      DC_E2E_OS: ${{ matrix.dcos }}
+      DC_E2E_RESULTS: ${{ github.workspace }}/connector-live-e2e-results.jsonl
+      DC_DRIVER_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'action' }}
+      DC_E2E_AGENT_VERSION_REQUEST: ${{ github.event_name == 'workflow_dispatch' && inputs.version || 'latest' }}
+      # Provider keys are read directly by the agent CLIs (e.g. codex, claude)
+      # from the process environment. They are also written into
+      # ~/.defenseclaw/.env below so the gateway can reach them when needed.
+      # Empty secrets simply skip writing that key (see the seed step).
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+      # GitHub Copilot CLI authenticates with an entitled token.
+      COPILOT_CLI_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
+      GH_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
+      # Generic fallback key for the guardrail/judge if a connector needs it.
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      # --- Alternative auth backends -----------------------------------------
+      # Azure OpenAI (Codex + OpenHands when DC_USE_AZURE=1). The key is a
+      # secret; the endpoint/deployment/version are non-secret config Variables.
+      AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+      AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
+      AZURE_OPENAI_DEPLOYMENT: ${{ vars.AZURE_OPENAI_DEPLOYMENT }}
+      AZURE_OPENAI_API_VERSION: ${{ vars.AZURE_OPENAI_API_VERSION }}
+      # Amazon Bedrock (Claude Code + OpenHands when DC_USE_BEDROCK=1). Either a
+      # Bedrock bearer token OR a standard AWS key pair satisfies the chain.
+      AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      # Optional Bedrock model-id overrides (non-secret config Variables).
+      CLAUDE_BEDROCK_MODEL: ${{ vars.CLAUDE_BEDROCK_MODEL }}
+      OPENHANDS_BEDROCK_MODEL: ${{ vars.OPENHANDS_BEDROCK_MODEL }}
+      # Provider-selection flags. A dispatch toggle wins; otherwise the repo
+      # Variable (DC_USE_AZURE / DC_USE_BEDROCK = "1") makes it the default for
+      # nightly runs; otherwise off (use the direct provider keys).
+      DC_USE_AZURE: ${{ inputs.use_azure && '1' || vars.DC_USE_AZURE || '0' }}
+      DC_USE_BEDROCK: ${{ inputs.use_bedrock && '1' || vars.DC_USE_BEDROCK || '0' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Select cell
+        id: select
+        run: |
+          run=true
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            in_conn="${{ inputs.connector }}"
+            in_os="${{ inputs.os }}"
+            [ "${in_conn}" = "all" ] || [ "${in_conn}" = "${{ matrix.connector }}" ] || run=false
+            [ "${in_os}" = "all" ] || [ "${in_os}" = "${{ matrix.dcos }}" ] || run=false
+          fi
+          echo "run=${run}" >> "$GITHUB_OUTPUT"
+          echo "cell ${{ matrix.connector }}/${{ matrix.dcos }} selected=${run}"
+
+      - uses: actions/setup-go@v5
+        if: steps.select.outputs.run == 'true'
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: astral-sh/setup-uv@v8.1.0
+        if: steps.select.outputs.run == 'true'
+
+      # Most live agents (codex, claude, gemini, copilot, cursor) ship as npm
+      # packages; OpenHands installs via pipx. Node + uv cover both.
+      - uses: actions/setup-node@v5
+        if: steps.select.outputs.run == 'true'
+        with:
+          node-version: "24"
+
+      - name: Install DefenseClaw
+        if: steps.select.outputs.run == 'true'
+        run: make install
+
+      - name: Put DefenseClaw on PATH
+        if: steps.select.outputs.run == 'true'
+        run: |
+          echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
+          if [ -d "${{ github.workspace }}/.venv/bin" ]; then
+            echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
+          fi
+          if [ -d "${{ github.workspace }}/.venv/Scripts" ]; then
+            echo "${{ github.workspace }}/.venv/Scripts" >> "$GITHUB_PATH"
+          fi
+
+      # Initialize DefenseClaw and stage provider keys into ~/.defenseclaw/.env.
+      # The driver re-runs `defenseclaw init` idempotently; doing it here lets
+      # us append keys before the gateway first starts. Only non-empty secrets
+      # are written, so a missing optional key never leaves a blank line.
+      - name: Seed DefenseClaw env
+        if: steps.select.outputs.run == 'true'
+        run: |
+          defenseclaw init
+          env_file="${HOME}/.defenseclaw/.env"
+          mkdir -p "${HOME}/.defenseclaw"
+          touch "${env_file}"
+          write_key() {
+            local k="$1" v="$2"
+            [ -n "${v}" ] || return 0
+            grep -q "^${k}=" "${env_file}" 2>/dev/null && return 0
+            printf '%s=%s\n' "${k}" "${v}" >> "${env_file}"
+          }
+          write_key OPENAI_API_KEY    "${OPENAI_API_KEY:-}"
+          write_key ANTHROPIC_API_KEY "${ANTHROPIC_API_KEY:-}"
+          write_key GOOGLE_API_KEY    "${GOOGLE_API_KEY:-}"
+          write_key GEMINI_API_KEY    "${GEMINI_API_KEY:-}"
+          write_key CURSOR_API_KEY    "${CURSOR_API_KEY:-}"
+          write_key LLM_API_KEY       "${LLM_API_KEY:-}"
+
+      # For Cursor, confirm headless `cursor-agent -p` actually fires
+      # ~/.cursor/hooks.json before spending a full live run on it. If hooks
+      # never reach the gateway, the live driver is skipped (recorded as a
+      # skip) and Cursor stays Layer-A only for this cell.
+      - name: Validate Cursor headless hooks
+        id: cursor_validate
+        if: ${{ steps.select.outputs.run == 'true' && matrix.connector == 'cursor' }}
+        run: bash scripts/live-connector-e2e/cursor-validation.sh
+        continue-on-error: true
+
+      - name: Live driver
+        if: ${{ steps.select.outputs.run == 'true' && !(matrix.connector == 'cursor' && steps.cursor_validate.outputs.cursor_hooks_fire == '0') }}
+        run: bash scripts/live-connector-e2e/run.sh --layer live --connector "${{ matrix.connector }}"
+
+      - name: Upload live results
+        if: ${{ always() && steps.select.outputs.run == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: connector-live-e2e-results-live-${{ matrix.connector }}-${{ matrix.dcos }}
+          path: ${{ env.DC_E2E_RESULTS }}
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload live logs on failure
+        if: ${{ failure() && steps.select.outputs.run == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: connector-live-e2e-logs-live-${{ matrix.connector }}-${{ matrix.dcos }}
+          path: ${{ runner.temp }}/defenseclaw-live-e2e-logs/**
+          if-no-files-found: ignore
+          retention-days: 7
+          include-hidden-files: true
+
+      - name: Teardown safety net
+        if: ${{ always() && steps.select.outputs.run == 'true' }}
+        run: |
+          defenseclaw-gateway connector teardown --connector "${{ matrix.connector }}" 2>/dev/null || true
+          defenseclaw-gateway stop 2>/dev/null || true
+          rm -rf "${HOME}/.defenseclaw" 2>/dev/null || true
+
+  # ---------------------------------------------------------------------------
+  # Report — aggregate every cell, render the matrix, and alert on regressions.
+  # ---------------------------------------------------------------------------
+  report:
+    name: Report + regression radar
+    needs: [contract-matrix, live-matrix]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required so the regression radar can open/update the
+      # connector-regression issue. No write access to code.
+      issues: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download all cell results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: connector-live-e2e-results-*
+          path: results
+          merge-multiple: true
+
+      - name: Render summary + open regression issue on failure
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          open_flag=""
+          # Only the trusted, scheduled / manual contexts may file issues.
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            open_flag="--open-issue"
+          fi
+          python3 scripts/live-connector-e2e/report.py \
+            --results-dir results \
+            ${open_flag} \
+            --run-url "${RUN_URL}"

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -35,7 +35,7 @@ import click
 # pulled name-by-name so the wizard call sites read like
 # ``ux.section("Hook fail mode")`` and the source of the color
 # convention is obvious to anybody auditing this file.
-from defenseclaw import ux
+from defenseclaw import platform_support, ux
 from defenseclaw.audit_actions import (
     ACTION_SETUP_CONNECTOR_MODE,
     ACTION_SETUP_GATEWAY,
@@ -2173,19 +2173,20 @@ def _fetch_connector_names(cfg=None) -> list[str]:
         host = getattr(cfg.guardrail, "host", None) or "127.0.0.1"
         port = getattr(cfg.guardrail, "port", 0) or 0
     if not port:
-        return list(_CONNECTOR_NAMES_FALLBACK)
+        return platform_support.supported_connectors(_CONNECTOR_NAMES_FALLBACK)
     try:
         url = f"http://{host}:{port}/v1/connectors"
         req = urllib.request.Request(url, method="GET")
         with urllib.request.urlopen(req, timeout=2) as resp:
             data = _json.loads(resp.read())
             names = [c.get("name") or c.get("id") for c in data.get("connectors", [])]
-            return [n for n in names if n] or list(_CONNECTOR_NAMES_FALLBACK)
+            resolved = [n for n in names if n] or list(_CONNECTOR_NAMES_FALLBACK)
+            return platform_support.supported_connectors(resolved)
     except Exception:
-        return list(_CONNECTOR_NAMES_FALLBACK)
+        return platform_support.supported_connectors(_CONNECTOR_NAMES_FALLBACK)
 
 
-_CONNECTOR_NAMES = _CONNECTOR_NAMES_FALLBACK
+_CONNECTOR_NAMES = platform_support.supported_connectors(_CONNECTOR_NAMES_FALLBACK)
 _HILT_MIN_SEVERITIES = ["HIGH", "MEDIUM", "LOW", "CRITICAL"]
 
 _CONNECTOR_META: dict[str, dict[str, str]] = {

--- a/cli/defenseclaw/config.py
+++ b/cli/defenseclaw/config.py
@@ -22,13 +22,13 @@ so that the Go orchestrator and Python CLI share the same config file.
 
 from __future__ import annotations
 
-import fcntl
 import logging
 import os
 import platform
 import stat
 import subprocess
 import sys
+import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from pathlib import Path
@@ -85,6 +85,42 @@ LEGACY_DEPLOYMENT_MODE_ALIASES = {
     "ci": "ci_cd",
     "edge": "server",
 }
+
+if os.name == "nt":
+    import msvcrt
+
+    def _lock_file_exclusive(file_obj) -> None:
+        # msvcrt.locking operates on byte ranges; lock 1 byte at offset 0.
+        file_obj.seek(0)
+        try:
+            file_obj.write("0")
+            file_obj.flush()
+        except Exception:
+            # Best-effort sentinel; lock still works for existing files.
+            pass
+        while True:
+            try:
+                msvcrt.locking(file_obj.fileno(), msvcrt.LK_LOCK, 1)
+                return
+            except OSError:
+                time.sleep(0.05)
+
+    def _unlock_file(file_obj) -> None:
+        file_obj.seek(0)
+        try:
+            msvcrt.locking(file_obj.fileno(), msvcrt.LK_UNLCK, 1)
+        except OSError:
+            # If the lock was lost or never acquired, do not crash teardown/save paths.
+            pass
+
+else:
+    import fcntl
+
+    def _lock_file_exclusive(file_obj) -> None:
+        fcntl.flock(file_obj.fileno(), fcntl.LOCK_EX)
+
+    def _unlock_file(file_obj) -> None:
+        fcntl.flock(file_obj.fileno(), fcntl.LOCK_UN)
 
 
 def _home() -> Path:
@@ -1586,16 +1622,16 @@ def locked_config_yaml(path: str):
     flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
     fd = os.open(lock_path, flags, 0o600)
     try:
-        lock = os.fdopen(fd, "w")
+        lock = os.fdopen(fd, "a+")
     except BaseException:
         os.close(fd)
         raise
     try:
-        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        _lock_file_exclusive(lock)
         try:
             yield
         finally:
-            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+            _unlock_file(lock)
     finally:
         lock.close()
 

--- a/cli/defenseclaw/config.py
+++ b/cli/defenseclaw/config.py
@@ -89,17 +89,18 @@ LEGACY_DEPLOYMENT_MODE_ALIASES = {
 if os.name == "nt":
     import msvcrt
 
+    # msvcrt.locking() locks a byte range starting at the file pointer's
+    # CURRENT position. To get mutual exclusion we must lock the SAME byte
+    # (offset 0) on every acquisition, so we seek(0) immediately before each
+    # lock/unlock call and we never write to the lock file. Writing (in any
+    # mode) can advance the pointer or grow the file, which would make
+    # concurrent holders lock disjoint ranges and silently defeat the lock.
     def _lock_file_exclusive(file_obj) -> None:
-        # msvcrt.locking operates on byte ranges; lock 1 byte at offset 0.
-        file_obj.seek(0)
-        try:
-            file_obj.write("0")
-            file_obj.flush()
-        except Exception:
-            # Best-effort sentinel; lock still works for existing files.
-            pass
         while True:
+            file_obj.seek(0)
             try:
+                # LK_LOCK blocks for ~10s then raises; retry so this behaves
+                # like a blocking exclusive lock (fcntl.flock(LOCK_EX)).
                 msvcrt.locking(file_obj.fileno(), msvcrt.LK_LOCK, 1)
                 return
             except OSError:
@@ -110,7 +111,8 @@ if os.name == "nt":
         try:
             msvcrt.locking(file_obj.fileno(), msvcrt.LK_UNLCK, 1)
         except OSError:
-            # If the lock was lost or never acquired, do not crash teardown/save paths.
+            # Lock already released (e.g. handle closed); don't crash
+            # teardown/save paths.
             pass
 
 else:
@@ -1622,7 +1624,10 @@ def locked_config_yaml(path: str):
     flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
     fd = os.open(lock_path, flags, 0o600)
     try:
-        lock = os.fdopen(fd, "a+")
+        # "r+" (not "a+"): the lock file is a pure sentinel we never write to,
+        # and append mode would force the file pointer to EOF, breaking the
+        # offset-0 byte-range lock used on Windows (see _lock_file_exclusive).
+        lock = os.fdopen(fd, "r+")
     except BaseException:
         os.close(fd)
         raise

--- a/cli/defenseclaw/inventory/validated_versions.json
+++ b/cli/defenseclaw/inventory/validated_versions.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": 1,
+  "description": "Human-reviewed highest validated upstream agent version per hook connector x OS. The live connector E2E workflow (.github/workflows/connector-live-e2e.yml) only REPORTS the version it ran against and opens a connector-regression issue on a live-cell failure — it never edits this file. A maintainer updates last_validated_version here (and, when raising/lowering a support floor/ceiling, hook_contracts.json + internal/gateway/connector/hook_contract.go) after reviewing a green run. 'os' keys are linux, macos, windows; an empty last_validated_version means 'not yet certified'.",
+  "policy": "alert-only",
+  "connectors": {
+    "codex": {
+      "version_probe": "codex --version",
+      "live": true,
+      "os": {
+        "linux": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "macos": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "windows": { "last_validated_version": "", "last_validated_at": "", "run_url": "" }
+      }
+    },
+    "claudecode": {
+      "version_probe": "claude --version",
+      "live": true,
+      "os": {
+        "linux": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "macos": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "windows": { "last_validated_version": "", "last_validated_at": "", "run_url": "" }
+      }
+    },
+    "geminicli": {
+      "version_probe": "gemini --version",
+      "live": true,
+      "os": {
+        "linux": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "macos": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "windows": { "last_validated_version": "", "last_validated_at": "", "run_url": "" }
+      }
+    },
+    "cursor": {
+      "version_probe": "cursor-agent --version",
+      "live": "pending-validation",
+      "os": {
+        "linux": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "macos": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "windows": { "last_validated_version": "", "last_validated_at": "", "run_url": "" }
+      }
+    },
+    "copilot": {
+      "version_probe": "copilot --version",
+      "live": true,
+      "os": {
+        "linux": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "macos": { "last_validated_version": "", "last_validated_at": "", "run_url": "" }
+      }
+    },
+    "openhands": {
+      "version_probe": "openhands --version",
+      "live": true,
+      "os": {
+        "linux": { "last_validated_version": "", "last_validated_at": "", "run_url": "" }
+      }
+    },
+    "hermes": {
+      "version_probe": "hermes --version",
+      "live": false,
+      "notes": "contract-only (Layer A); only pre_tool_call is mapped"
+    },
+    "windsurf": {
+      "version_probe": "",
+      "live": false,
+      "notes": "contract-only (Layer A); no headless CLI/SDK"
+    },
+    "antigravity": {
+      "version_probe": "agy --version",
+      "live": false,
+      "notes": "contract-only (Layer A); headless auth is Google Sign-In/keyring OAuth, no API key"
+    }
+  }
+}

--- a/cli/defenseclaw/platform_support.py
+++ b/cli/defenseclaw/platform_support.py
@@ -1,0 +1,81 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-OS connector support — the Python single source of truth.
+
+DefenseClaw runs hook-only on Windows: agents invoke the native Go hook
+entrypoint (``defenseclaw hook``) directly, and there is no Windows
+guardrail-proxy lifecycle. The proxy/chat connectors (``openclaw`` and
+``zeptoclaw``) therefore cannot run on Windows, so the TUI/CLI must not
+offer or accept them there.
+
+This module mirrors the Go ``connector.proxyConnectors`` set in
+``internal/gateway/connector/platform_support.go``; a parity test pins the
+two together so the lists cannot drift.
+
+Filtering is a pure no-op on non-Windows hosts, so callers can apply it
+unconditionally at presentation/validation points without changing
+behavior on macOS or Linux.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterable
+
+# Proxy/chat connectors that require the local guardrail proxy. These are
+# the only connectors unsupported on Windows. Keep in sync with the Go
+# ``proxyConnectors`` map.
+WINDOWS_UNSUPPORTED_CONNECTORS: frozenset[str] = frozenset({"openclaw", "zeptoclaw"})
+
+
+def host_os() -> str:
+    """Return a Go-``GOOS``-style token for the current host.
+
+    Normalizes ``sys.platform`` to ``"windows"`` / ``"darwin"`` / ``"linux"``
+    so the same string compares cleanly against the Go side and against the
+    ``os_name`` arguments below.
+    """
+    plat = sys.platform
+    if plat.startswith("win"):
+        return "windows"
+    if plat == "darwin":
+        return "darwin"
+    if plat.startswith("linux"):
+        return "linux"
+    return plat
+
+
+def is_proxy_connector(name: str) -> bool:
+    """Report whether *name* is a proxy/chat connector."""
+    return name in WINDOWS_UNSUPPORTED_CONNECTORS
+
+
+def connector_supported_on_os(name: str, os_name: str | None = None) -> bool:
+    """Report whether connector *name* can be offered/used on *os_name*.
+
+    Every hook-based connector is supported on every OS; the proxy
+    connectors are unsupported on Windows. *os_name* defaults to the host
+    OS but is injectable so tests can assert behavior for any platform.
+    """
+    if os_name is None:
+        os_name = host_os()
+    if os_name == "windows" and name in WINDOWS_UNSUPPORTED_CONNECTORS:
+        return False
+    return True
+
+
+def supported_connectors(
+    names: Iterable[str], os_name: str | None = None
+) -> list[str]:
+    """Filter *names* down to those supported on *os_name*, preserving order."""
+    if os_name is None:
+        os_name = host_os()
+    return [n for n in names if connector_supported_on_os(n, os_name)]

--- a/cli/defenseclaw/tui/app.py
+++ b/cli/defenseclaw/tui/app.py
@@ -2232,7 +2232,13 @@ class DefenseClawTUI(App[None]):
             self._refresh_hint()
 
     def _render_chrome(self) -> None:
-        self.query_one("#tabs", Tabs).active = f"tab-{self.active_panel}"
+        try:
+            tabs = self.query_one("#tabs", Tabs)
+        except NoMatches:
+            return
+        tab_id = f"tab-{self.active_panel}"
+        if tabs.query(f"#{tab_id}"):
+            tabs.active = tab_id
         # Refresh unread "(N)" badges on every tab whenever chrome
         # re-renders. Cheap (≤ 14 string updates) and keeps the tab
         # strip honest after refresh loops add new alerts / audit

--- a/cli/defenseclaw/tui/app.py
+++ b/cli/defenseclaw/tui/app.py
@@ -4351,6 +4351,21 @@ class DefenseClawTUI(App[None]):
         if hidden:
             return
 
+        # The #command-progress container can briefly exist without its child
+        # widgets during a panel-switch re-render: Textual mounts the parent
+        # before (re)attaching the composed children, and the 0.25s
+        # _tick_command_strip timer can fire inside that window. The child
+        # queries below would then raise NoMatches and take down the worker
+        # (the parent guard above only covers the container). Probe the first
+        # child up front and bail if the inner DOM isn't ready yet — the
+        # children compose as one unit and this method is synchronous, so once
+        # the probe resolves they all stay mounted for the rest of the render.
+        # The next tick repaints cleanly once the DOM settles.
+        try:
+            self.query_one("#command-progress-icon", Static)
+        except NoMatches:
+            return
+
         panel.set_class(self._strip_state == "running", "running")
         panel.set_class(self._strip_state == "success", "success")
         panel.set_class(self._strip_state == "failure", "failure")

--- a/cli/defenseclaw/tui/app.py
+++ b/cli/defenseclaw/tui/app.py
@@ -2238,8 +2238,17 @@ class DefenseClawTUI(App[None]):
         # strip honest after refresh loops add new alerts / audit
         # entries while the operator is parked on a different panel.
         self._update_tab_labels()
-        self.query_one("#activity", RichLog).set_class(self.active_panel != "activity", "hidden")
-        body_widget = self.query_one("#body", Static)
+        # A catalog-load worker (or the periodic refresh) can reach here
+        # after the screen has begun tearing down, at which point #activity
+        # and #body are gone and query_one raises NoMatches — surfacing as
+        # WorkerFailed and intermittently failing the TUI catalog tests.
+        # Bail out quietly; there is nothing left to render.
+        try:
+            activity = self.query_one("#activity", RichLog)
+            body_widget = self.query_one("#body", Static)
+        except NoMatches:
+            return
+        activity.set_class(self.active_panel != "activity", "hidden")
         if self.active_panel == "overview" and not self.help_open:
             renderable = self._overview_renderable()
             body_widget.update(renderable)

--- a/cli/defenseclaw/tui/executor.py
+++ b/cli/defenseclaw/tui/executor.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
-import pty
 import signal
 import time
+
+if os.name == "posix":
+    import pty
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 

--- a/cli/defenseclaw/tui/executor.py
+++ b/cli/defenseclaw/tui/executor.py
@@ -40,6 +40,13 @@ class CommandExecutor:
         self._process: asyncio.subprocess.Process | None = None
         self._master_fd: int | None = None
         self._cancelled = False
+        if use_pty and os.name != "posix":
+            # The 'pty' module is POSIX-only and is not imported elsewhere;
+            # fail fast with a clear message instead of a NameError deep in
+            # _run_pty when a caller forces PTY mode on Windows.
+            raise ValueError(
+                "PTY execution (use_pty=True) is only supported on POSIX platforms"
+            )
         self.use_pty = os.name == "posix" if use_pty is None else use_pty
 
     @property

--- a/cli/defenseclaw/tui/panels/first_run.py
+++ b/cli/defenseclaw/tui/panels/first_run.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
+from defenseclaw.platform_support import supported_connectors
 from defenseclaw.tui.services.setup_state import SetupCommandIntent
 
 FirstRunKind = Literal["choice", "bool"]
@@ -33,6 +34,17 @@ CONNECTOR_CHOICES: tuple[str, ...] = (
     "openhands",
     "antigravity",
 )
+
+
+def visible_connector_choices(os_name: str | None = None) -> tuple[str, ...]:
+    """``CONNECTOR_CHOICES`` supported on *os_name*.
+
+    Drops proxy connectors (openclaw/zeptoclaw) on Windows; a no-op on
+    macOS/Linux.
+    """
+    return tuple(supported_connectors(CONNECTOR_CHOICES, os_name))
+
+
 PROFILE_CHOICES: tuple[str, ...] = ("observe", "action")
 SCANNER_MODE_CHOICES: tuple[str, ...] = ("local", "remote", "both")
 FAIL_MODE_CHOICES: tuple[str, ...] = ("open", "closed")
@@ -166,7 +178,7 @@ def default_first_run_fields() -> tuple[FirstRunField, ...]:
             "Connector",
             "choice",
             "codex",
-            CONNECTOR_CHOICES,
+            visible_connector_choices(),
             "Agent framework to protect. OpenClaw is optional, not assumed.",
         ),
         FirstRunField("Profile", "choice", "observe", PROFILE_CHOICES, "observe=detect/log; action=block."),

--- a/cli/defenseclaw/tui/screens/mode_picker.py
+++ b/cli/defenseclaw/tui/screens/mode_picker.py
@@ -21,6 +21,7 @@ from textual.containers import Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Static
 
+from defenseclaw.platform_support import supported_connectors
 from defenseclaw.tui.theme import DEFAULT_TOKENS
 from defenseclaw.tui.widgets.action_menu import ActionMenu, MenuAction
 
@@ -47,6 +48,16 @@ MODE_PICKER_CHOICES: tuple[ModeChoice, ...] = (
     ModeChoice("openhands", "OpenHands", "n", False, "command hooks via ~/.openhands/hooks.json"),
     ModeChoice("antigravity", "Antigravity", "a", False, "PreToolUse hooks via ~/.gemini/config/hooks.json"),
 )
+
+
+def visible_mode_picker_choices(os_name: str | None = None) -> tuple[ModeChoice, ...]:
+    """Mode-picker rows supported on *os_name*.
+
+    On Windows the proxy connectors (openclaw/zeptoclaw) are dropped because
+    DefenseClaw is hook-only there; on macOS/Linux this is a no-op.
+    """
+    supported = set(supported_connectors([c.wire for c in MODE_PICKER_CHOICES], os_name))
+    return tuple(c for c in MODE_PICKER_CHOICES if c.wire in supported)
 
 
 class ModePickerScreen(ModalScreen[str | None]):
@@ -91,15 +102,22 @@ class ModePickerScreen(ModalScreen[str | None]):
     def __init__(self, current_wire: str = "openclaw") -> None:
         super().__init__()
         self.current_wire = normalize_connector(current_wire)
+        # Hide proxy connectors on Windows; no-op on macOS/Linux. Resolve
+        # once so compose() and _sync_preview() share the same row order.
+        self.choices = visible_mode_picker_choices()
 
     def compose(self) -> ComposeResult:
         current = choice_for_wire(self.current_wire)
-        actions = tuple(_choice_action(choice, current_wire=self.current_wire) for choice in MODE_PICKER_CHOICES)
+        actions = tuple(_choice_action(choice, current_wire=self.current_wire) for choice in self.choices)
+        selected = next(
+            (i for i, c in enumerate(self.choices) if c.wire == current.wire),
+            0,
+        )
         with Vertical(id="mode-picker-dialog"):
             yield Static("Switch active claw connector", id="mode-picker-title")
-            yield ActionMenu(actions, selected_index=choice_index(current.wire), id="mode-picker-menu")
+            yield ActionMenu(actions, selected_index=selected, id="mode-picker-menu")
             yield Static(preview_for_switch(self.current_wire, current.wire), id="mode-picker-preview")
-            yield Static("up/down move  o/z/k/c/h/u/w/g/p jump  enter confirm  esc close", id="mode-picker-hint")
+            yield Static("up/down move  o/z/k/c/h/u/w/g/p/n jump  enter confirm  esc close", id="mode-picker-hint")
 
     def on_key(self, event: events.Key) -> None:
         if not event.character:
@@ -139,7 +157,7 @@ class ModePickerScreen(ModalScreen[str | None]):
     def _sync_preview(self) -> None:
         menu = self.query_one(ActionMenu)
         index = menu.selected_index if menu.selected_index is not None else 0
-        choice = MODE_PICKER_CHOICES[index]
+        choice = self.choices[index]
         self.query_one("#mode-picker-preview", Static).update(preview_for_switch(self.current_wire, choice.wire))
 
 

--- a/cli/defenseclaw/tui/services/cli_choices.py
+++ b/cli/defenseclaw/tui/services/cli_choices.py
@@ -27,6 +27,8 @@ the parity guarantee.
 
 from __future__ import annotations
 
+from defenseclaw.platform_support import supported_connectors
+
 # Connectors the TUI knows how to set up. The order here drives the
 # wizard's connector picker, so put first-class proxies (openclaw,
 # zeptoclaw) first and hook-based connectors after.
@@ -49,6 +51,16 @@ CONNECTORS: tuple[str, ...] = (
 # ``--scanner-mode`` and ``--with-local-stack``; the other connectors
 # are hook-based and only take ``--mode``.
 GUARDRAIL_CONNECTORS: frozenset[str] = frozenset({"openclaw", "zeptoclaw"})
+
+
+def supported_connector_choices(os_name: str | None = None) -> tuple[str, ...]:
+    """``CONNECTORS`` filtered to those supported on *os_name*.
+
+    DefenseClaw is hook-only on Windows, so the proxy connectors
+    (openclaw/zeptoclaw) are dropped there; a no-op on macOS/Linux. Use this
+    wherever the connector list is presented to or chosen by the operator.
+    """
+    return tuple(supported_connectors(CONNECTORS, os_name))
 
 # Full provider catalogue accepted by ``_configure_llm`` in
 # ``cmd_setup.py``. Cloud providers first, then local runtimes. Tests

--- a/cli/tests/test_config_lock_mutex.py
+++ b/cli/tests/test_config_lock_mutex.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mutual-exclusion contract for ``locked_config_yaml``.
+
+This runs on every OS in CI. On Windows it exercises the ``msvcrt.locking``
+path; on POSIX it exercises ``fcntl.flock``. It is the regression guard for
+the bug where the Windows lock grabbed a different byte offset on each
+acquisition (append-mode write + post-write file position) and therefore let
+concurrent holders into the critical section simultaneously.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from defenseclaw.config import locked_config_yaml
+
+
+def test_locked_config_yaml_serializes_concurrent_holders(tmp_path) -> None:
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("a: 1\n")
+
+    events: list[str] = []
+    events_guard = threading.Lock()  # protects the list mutation only
+
+    def worker() -> None:
+        with locked_config_yaml(str(cfg)):
+            with events_guard:
+                events.append("enter")
+            # Hold the lock long enough that a broken (non-exclusive) lock
+            # would let another worker append "enter" before this one exits.
+            time.sleep(0.02)
+            with events_guard:
+                events.append("exit")
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert all(not t.is_alive() for t in threads), "a holder deadlocked"
+    assert len(events) == 16
+
+    # With true mutual exclusion each holder completes enter->exit before the
+    # next acquires the lock, so the sequence is strictly paired. Any
+    # enter-enter adjacency means two holders were inside at once.
+    for i in range(0, len(events), 2):
+        assert events[i] == "enter", f"overlap at {i}: {events}"
+        assert events[i + 1] == "exit", f"overlap at {i}: {events}"

--- a/cli/tests/test_platform_support.py
+++ b/cli/tests/test_platform_support.py
@@ -1,0 +1,138 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-OS connector support: parity and Windows-excludes-proxy behavior.
+
+These tests pin the Python ``platform_support`` module against the Go
+``connector.proxyConnectors`` set and against every Python connector list,
+so the "hook-only on Windows" contract cannot silently drift on either
+side. They run on every OS (the filtering takes an explicit ``os_name`` so
+the assertions are host-independent).
+"""
+
+from __future__ import annotations
+
+from defenseclaw.commands.cmd_setup import (
+    _CONNECTOR_NAMES_FALLBACK,
+    _HOOK_ENFORCED_CONNECTORS,
+    _PROXY_BACKED_CONNECTORS,
+)
+from defenseclaw.connector_paths import KNOWN_CONNECTORS
+from defenseclaw.platform_support import (
+    WINDOWS_UNSUPPORTED_CONNECTORS,
+    connector_supported_on_os,
+    host_os,
+    is_proxy_connector,
+    supported_connectors,
+)
+from defenseclaw.tui.panels.first_run import CONNECTOR_CHOICES, visible_connector_choices
+from defenseclaw.tui.screens.mode_picker import (
+    MODE_PICKER_CHOICES,
+    visible_mode_picker_choices,
+)
+from defenseclaw.tui.services.cli_choices import (
+    CONNECTORS,
+    GUARDRAIL_CONNECTORS,
+    supported_connector_choices,
+)
+
+# Mirror of the Go ``proxyConnectors`` map in
+# internal/gateway/connector/platform_support.go. Any change there must be
+# made here too; the assertions below fail loudly if the two drift.
+PROXY_CONNECTORS = {"openclaw", "zeptoclaw"}
+
+# The eight hook-based connectors supported on every OS, including Windows.
+HOOK_CONNECTORS = {
+    "codex",
+    "claudecode",
+    "hermes",
+    "cursor",
+    "windsurf",
+    "geminicli",
+    "copilot",
+    "openhands",
+}
+
+
+def test_windows_unsupported_set_matches_go_proxy_connectors() -> None:
+    assert set(WINDOWS_UNSUPPORTED_CONNECTORS) == PROXY_CONNECTORS
+
+
+def test_proxy_set_agrees_with_existing_python_sources() -> None:
+    # GUARDRAIL_CONNECTORS (cli_choices) and _PROXY_BACKED_CONNECTORS
+    # (cmd_setup) are the pre-existing names for the same proxy set; the
+    # new single source of truth must agree with both.
+    assert set(GUARDRAIL_CONNECTORS) == PROXY_CONNECTORS
+    assert set(_PROXY_BACKED_CONNECTORS) == PROXY_CONNECTORS
+
+
+def test_hook_enforced_set_is_the_eight_hook_connectors() -> None:
+    assert set(_HOOK_ENFORCED_CONNECTORS) == HOOK_CONNECTORS
+
+
+def test_is_proxy_connector() -> None:
+    assert is_proxy_connector("openclaw")
+    assert is_proxy_connector("zeptoclaw")
+    for name in HOOK_CONNECTORS:
+        assert not is_proxy_connector(name)
+
+
+def test_connector_supported_on_os_windows_excludes_only_proxy() -> None:
+    for name in PROXY_CONNECTORS:
+        assert connector_supported_on_os(name, "windows") is False
+    for name in HOOK_CONNECTORS:
+        assert connector_supported_on_os(name, "windows") is True
+
+
+def test_connector_supported_on_os_unix_allows_everything() -> None:
+    for os_name in ("linux", "darwin"):
+        for name in PROXY_CONNECTORS | HOOK_CONNECTORS:
+            assert connector_supported_on_os(name, os_name) is True
+
+
+def test_supported_connectors_preserves_order_and_filters_windows() -> None:
+    ordered = ["openclaw", "codex", "zeptoclaw", "claudecode"]
+    assert supported_connectors(ordered, "windows") == ["codex", "claudecode"]
+    assert supported_connectors(ordered, "linux") == ordered
+
+
+def test_host_os_returns_known_token() -> None:
+    assert host_os() in {"windows", "darwin", "linux"} or isinstance(host_os(), str)
+
+
+def test_all_connector_lists_share_one_taxonomy() -> None:
+    # Fixing the historical openhands drift: every Python enumeration of
+    # connectors must contain exactly the proxy + hook connectors.
+    expected = PROXY_CONNECTORS | HOOK_CONNECTORS
+    assert set(KNOWN_CONNECTORS) == expected
+    assert set(_CONNECTOR_NAMES_FALLBACK) == expected
+    assert set(CONNECTORS) == expected
+    assert {c.wire for c in MODE_PICKER_CHOICES} == expected
+    assert set(CONNECTOR_CHOICES) == expected
+
+
+def test_windows_views_exclude_proxy_and_keep_all_hook_connectors() -> None:
+    # cli_choices accessor
+    win_choices = supported_connector_choices("windows")
+    assert set(win_choices) == HOOK_CONNECTORS
+    assert not (set(win_choices) & PROXY_CONNECTORS)
+
+    # mode picker rows
+    win_modes = {c.wire for c in visible_mode_picker_choices("windows")}
+    assert win_modes == HOOK_CONNECTORS
+
+    # first-run wizard field
+    assert set(visible_connector_choices("windows")) == HOOK_CONNECTORS
+
+
+def test_non_windows_views_are_unfiltered() -> None:
+    assert supported_connector_choices("linux") == CONNECTORS
+    assert visible_mode_picker_choices("darwin") == MODE_PICKER_CHOICES
+    assert visible_connector_choices("linux") == CONNECTOR_CHOICES

--- a/cli/tests/test_platform_support.py
+++ b/cli/tests/test_platform_support.py
@@ -48,7 +48,7 @@ from defenseclaw.tui.services.cli_choices import (
 # made here too; the assertions below fail loudly if the two drift.
 PROXY_CONNECTORS = {"openclaw", "zeptoclaw"}
 
-# The eight hook-based connectors supported on every OS, including Windows.
+# The hook-based connectors supported on every OS, including Windows.
 HOOK_CONNECTORS = {
     "codex",
     "claudecode",
@@ -58,6 +58,7 @@ HOOK_CONNECTORS = {
     "geminicli",
     "copilot",
     "openhands",
+    "antigravity",
 }
 
 
@@ -73,7 +74,7 @@ def test_proxy_set_agrees_with_existing_python_sources() -> None:
     assert set(_PROXY_BACKED_CONNECTORS) == PROXY_CONNECTORS
 
 
-def test_hook_enforced_set_is_the_eight_hook_connectors() -> None:
+def test_hook_enforced_set_is_the_hook_connectors() -> None:
     assert set(_HOOK_ENFORCED_CONNECTORS) == HOOK_CONNECTORS
 
 

--- a/cli/tests/tui/test_catalog_action_bars.py
+++ b/cli/tests/tui/test_catalog_action_bars.py
@@ -40,6 +40,11 @@ async def test_catalog_control_bar_visible_on_panel(panel: str) -> None:
         await pilot.pause()
         app.action_switch_panel(panel)
         await pilot.pause()
+        # Cancel background _load_catalog_model workers spawned by
+        # action_switch_panel — in CI they can outlive the test context
+        # and crash _render_chrome during teardown.
+        app.workers.cancel_all()
+        await pilot.pause()
         bar = app.query_one(f"#{panel}-controls", Horizontal)
         assert bar.has_class("hidden") is False, (
             f"{panel}-controls should be visible while the {panel} panel is active"
@@ -52,6 +57,8 @@ async def test_catalog_control_bar_visible_on_panel(panel: str) -> None:
         if other == "plugins" and not app.plugins_model.is_visible_for_connector():
             return
         app.action_switch_panel(other)
+        await pilot.pause()
+        app.workers.cancel_all()
         await pilot.pause()
         assert bar.has_class("hidden") is True, (
             f"{panel}-controls must be hidden after switching to {other}"

--- a/docs/CONNECTOR-MATRIX.md
+++ b/docs/CONNECTOR-MATRIX.md
@@ -33,6 +33,22 @@ redirect LLM traffic through the proxy in v1. They are still first-class
 connectors with explicit hook, MCP, skill/rule/plugin/agent, CodeGuard, and
 telemetry capability rows where the vendor has documented local surfaces.
 
+## Platform support
+
+| Connector | macOS | Linux | Windows |
+| --------- | ----- | ----- | ------- |
+| OpenClaw, ZeptoClaw (proxy) | OK | OK | not supported |
+| Claude Code, Codex, Hermes, Cursor, Windsurf, Gemini CLI, Copilot CLI, OpenHands (hook-based) | OK | OK | OK |
+
+Windows is **hook-only**: the eight hook-based connectors run their hook
+decisions natively in the `defenseclaw` binary (the agent invokes
+`defenseclaw hook --connector <name> --event <event>`), so no Git Bash, `jq`,
+or shell shims are required. The proxy connectors (OpenClaw, ZeptoClaw) need
+the local guardrail proxy, which DefenseClaw does not host on Windows; they are
+hidden from the connector pickers and rejected by setup there. The Go registry
+(`connectorSupportedOnOS`) and the Python `platform_support` module are the two
+sources of truth for this gating, kept in sync by a parity test.
+
 ## Versioned Hook Contracts
 
 The machine-readable compatibility source lives at

--- a/docs/CONNECTOR-MATRIX.md
+++ b/docs/CONNECTOR-MATRIX.md
@@ -144,6 +144,121 @@ non-CodeGuard paths require `--replace`.
 
 ---
 
+## Live E2E coverage
+
+The [`.github/workflows/connector-live-e2e.yml`](../.github/workflows/connector-live-e2e.yml)
+workflow proves each hook connector end-to-end against real upstream agents
+and flags when an upstream release breaks a hook. It is intentionally
+separate from `e2e.yml` so it can go red on an upstream regression without
+blocking the OpenClaw stack gate. The harness lives under
+[`scripts/live-connector-e2e/`](../scripts/live-connector-e2e).
+
+### Two layers
+
+| Layer | What it proves | LLM? | Secrets? | OSes | When |
+| ----- | -------------- | ---- | -------- | ---- | ---- |
+| **A — Contract matrix** | Feeds golden stdin payloads into the *installed* hook entrypoint and asserts the gateway received the event, the verdict was shaped correctly, and teardown is clean. | no | no | linux, macos, windows | every run; fork-safe |
+| **B — Live agent matrix** | Installs the real agent at its latest version, runs `defenseclaw setup`, drives lifecycle + forced tool calls through the real harness, and asserts observe / block / OTLP / teardown. | yes (deterministic prompts) | yes | per the reality matrix below | nightly + manual dispatch |
+
+Layer A targets `~/.defenseclaw/hooks/<connector>-hook.sh` on Linux/macOS and
+the native `defenseclaw-gateway hook --connector <c> --event <e>` subcommand on
+Windows. Both forward the payload to the local gateway, so every assertion
+works against `~/.defenseclaw/gateway.jsonl` + `audit.db` regardless of OS.
+
+Hooks are **harness-driven**, not LLM-driven: the agent fires
+`SessionStart` / `PreToolUse` / etc. as a function of its lifecycle, so Layer B
+only needs the model to run the one shell command it is explicitly told to.
+Enforcement is proven with a filesystem **sentinel**: the allow probe runs a
+benign command that creates a marker file; the block probe asks the agent to
+read `/etc/shadow` (rule `PATH-ETC-SHADOW`, CRITICAL) — if the marker ever
+appears, the command ran and the block regressed. Reading `/etc/shadow` is
+harmless (permission denied) if a regression ever lets it through.
+
+### Per-connector reality matrix (Layer B)
+
+| Connector | Linux | macOS | Windows | Live driver headless invocation | Notes |
+| --------- | ----- | ----- | ------- | ------------------------------- | ----- |
+| Codex | live | live | live\* | `codex exec --json --full-auto` | native OTLP asserted |
+| Claude Code | live | live | live\* | `claude -p` | native OTLP asserted; native-ask is Layer A only |
+| Gemini CLI | live | live | live\* | `gemini -p -o json --approval-mode yolo` | advisory events cannot block |
+| Cursor | live | live | live\* | `cursor-agent -p --force` | gated on a one-time headless-hook validation |
+| Copilot CLI | live\* | live\* | live\* | `copilot -p` | user-level hooks only; entitled token |
+| OpenHands | live | — | — | `openhands --headless --json` | Docker runtime, Linux-only |
+| Hermes | contract-only | contract-only | contract-only | — | only `pre_tool_call` mapped |
+| Windsurf | contract-only | contract-only | contract-only | — | no headless CLI/SDK |
+| Antigravity | contract-only | contract-only | contract-only | — | headless auth is OAuth, no API key |
+
+`\*` = advisory cell (`continue-on-error`) until it goes consistently green.
+All Windows live cells and every Copilot cell start advisory; they are promoted
+to gating once stable. Contract-only connectors run Layer A on every OS and are
+intentionally absent from Layer B.
+
+> **Current rollout:** the nightly schedule runs **Layer A only**. Layer B is
+> manual-dispatch-only and presently scoped to the connectors we can
+> authenticate with Azure OpenAI / Amazon Bedrock — **Codex, Claude Code, and
+> OpenHands**. **Gemini CLI, Cursor, and Copilot live cells are deferred** until
+> their native keys (`GOOGLE_API_KEY`, `CURSOR_API_KEY`, `COPILOT_CLI_TOKEN`)
+> are configured; all three still get full Layer A coverage in the meantime.
+
+### Alternative LLM auth (Azure OpenAI / Amazon Bedrock)
+
+The live drivers can source the model from a non-default backend. This only
+changes where the agent's LLM traffic goes — the hook bus, verdicts, and OTLP
+are unaffected, so hook coverage is identical. Selection is per backend, not
+global: set the repo Variable (`DC_USE_AZURE` / `DC_USE_BEDROCK` = `1`) to make
+it the nightly default, or flip the `use_azure` / `use_bedrock` dispatch toggle.
+
+| Connector | Default | Azure OpenAI (`DC_USE_AZURE=1`) | Amazon Bedrock (`DC_USE_BEDROCK=1`) |
+| --------- | ------- | ------------------------------- | ----------------------------------- |
+| Codex | `OPENAI_API_KEY` | yes — seeds `[model_providers.azure]` in `~/.codex/config.toml` | no (Codex is OpenAI-only) |
+| Claude Code | `ANTHROPIC_API_KEY` | no | yes — `CLAUDE_CODE_USE_BEDROCK=1` + AWS chain |
+| OpenHands | `LLM_API_KEY` | yes — `azure/<deployment>` via LiteLLM | yes — `bedrock/<profile>` via LiteLLM (wins if both set) |
+| Gemini CLI / Cursor / Copilot | native key | — | — |
+
+Required inputs per backend:
+
+- **Azure**: secret `AZURE_OPENAI_API_KEY`; Variables `AZURE_OPENAI_ENDPOINT`
+  (resource URL), `AZURE_OPENAI_DEPLOYMENT` (used as the model id),
+  optional `AZURE_OPENAI_API_VERSION` (OpenHands only; defaults to a recent
+  preview). The deployment must be a model the connector supports (Codex needs
+  a Responses-API-capable deployment).
+- **Bedrock**: secret `AWS_BEARER_TOKEN_BEDROCK` *or* the pair
+  `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (+ optional
+  `AWS_SESSION_TOKEN`); Variable `AWS_REGION` (defaults to `us-east-1`).
+  Optional model-id overrides: `CLAUDE_BEDROCK_MODEL`, `OPENHANDS_BEDROCK_MODEL`.
+
+Gemini CLI, Cursor, and Copilot have **no** Azure/Bedrock substitute — they
+require their native provider key (`GOOGLE_API_KEY`, `CURSOR_API_KEY`,
+`COPILOT_CLI_TOKEN`) to run live.
+
+### Version policy (alert-only)
+
+The workflow is an **evidence engine, not an auto-bumper**. Each live cell
+records the resolved upstream version into the job summary. On any live-cell
+failure the `report` job opens or updates a GitHub issue labeled
+`connector-regression` listing the failing connector / OS / event / version,
+and links the uploaded log artifact. It never edits a version file.
+
+Setting the highest approved version stays a deliberate human action:
+
+1. A maintainer triages whether DefenseClaw's decode/map/respond needs a fix or
+   the upstream agent changed its hook contract.
+2. If DefenseClaw must drop support for the new release, raise `min_inclusive`
+   or set `max_exclusive` in
+   [`cli/defenseclaw/inventory/hook_contracts.json`](../cli/defenseclaw/inventory/hook_contracts.json)
+   and [`internal/gateway/connector/hook_contract.go`](../internal/gateway/connector/hook_contract.go).
+3. Once green again, record the validated version in
+   [`cli/defenseclaw/inventory/validated_versions.json`](../cli/defenseclaw/inventory/validated_versions.json)
+   (per connector × OS: `last_validated_version`, `last_validated_at`,
+   `run_url`). This file is human-reviewed only; the workflow reads it for
+   context but never writes it.
+
+The runtime drift guard (`hook_contract_lock.json` + the action-mode
+fail-closed behavior described above) is unchanged — this workflow is what
+generates the evidence a maintainer uses to update the floors and ceilings.
+
+---
+
 ## By-design connector limitations (WONTFIX, architectural)
 
 Plan PR #194 / matrix §"Out of scope". Each item below is **not a bug** —

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -36,6 +36,20 @@ On **macOS**, OpenShell is not available. DefenseClaw still works for scanning, 
 
 **For sandbox setup on Linux**, see [SANDBOX.md](SANDBOX.md) for full architecture, configuration, and troubleshooting.
 
+### Windows support
+
+On **Windows**, DefenseClaw is **hook-only**. The hook-based connectors —
+Claude Code, Codex, Hermes, Cursor, Windsurf, Gemini CLI, Copilot CLI, and
+OpenHands — are fully supported. Their hook decisions run **natively in the
+`defenseclaw` binary** (the agent invokes `defenseclaw hook --connector <name>
+--event <event>`), so Windows needs **no Git Bash, no `jq`, and no shell
+shims** — there are zero external prerequisites beyond the binary itself.
+
+The proxy connectors **OpenClaw** and **ZeptoClaw** are **not supported on
+Windows**: they require the local guardrail proxy, which DefenseClaw does not
+host there. They are hidden from the TUI/CLI connector pickers and rejected by
+setup on Windows with a clear error. Use them on macOS or Linux instead.
+
 ## Splunk Terms And Scope For The Local Preset
 
 If you enable the bundled local Splunk workflow through `DefenseClaw`, you are

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/gateway/connector/hookexec"
+)
+
+func init() {
+	rootCmd.AddCommand(newHookCmd())
+}
+
+// newHookCmd builds the hidden `hook` subcommand the agent runtime invokes per
+// event. On Windows this replaces the Bash hook scripts entirely: the agent is
+// configured to run `defenseclaw-gateway hook --connector <name> --event <ev>`,
+// which reads the event JSON from stdin, forwards it to the local gateway, and
+// shapes the agent-native stdout + exit code. It is hidden because it is a
+// machine-facing entrypoint, not something a human runs directly.
+func newHookCmd() *cobra.Command {
+	var (
+		connector string
+		event     string
+		apiAddr   string
+		failMode  string
+	)
+
+	cmd := &cobra.Command{
+		Use:    "hook",
+		Short:  "Run an agent guardrail hook (invoked by the agent runtime)",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		// The hook is a short-lived per-event subprocess. Skip the daemon's
+		// PersistentPreRunE/PostRun (config load, audit store open, OTel init):
+		// they are slow, can fail when the gateway is mid-setup, and would
+		// hold the audit DB on every keystroke an agent makes.
+		PersistentPreRunE: func(*cobra.Command, []string) error { return nil },
+		PersistentPostRun: func(*cobra.Command, []string) {},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			opts := buildHookOptions(connector, event, apiAddr, failMode)
+			// hookexec returns the exact agent exit code (0 allow / 2 block).
+			// os.Exit is required because cobra collapses RunE outcomes to 0/1.
+			os.Exit(hookexec.Run(cmd.Context(), opts))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&connector, "connector", "", "connector name (e.g. claudecode, codex, cursor)")
+	cmd.Flags().StringVar(&event, "event", "", "agent hook event name (informational)")
+	cmd.Flags().StringVar(&apiAddr, "api-addr", "", "gateway host:port (defaults to the hook sidecar / local gateway)")
+	cmd.Flags().StringVar(&failMode, "fail-mode", "", "response-failure policy: open or closed (defaults to the hook sidecar / open)")
+	_ = cmd.MarkFlagRequired("connector")
+
+	return cmd
+}
+
+// buildHookOptions resolves the hook configuration from flags plus the same
+// environment variables the .sh hooks honor, so the native path and the Bash
+// path behave identically. It is factored out of RunE (which calls os.Exit)
+// so it can be unit-tested.
+func buildHookOptions(connector, event, apiAddr, failMode string) hookexec.Options {
+	home := config.DefaultDataPath()
+	hookDir := filepath.Join(home, "hooks")
+
+	// Setup writes hooks/.hookcfg on Windows so the agent's hook command can
+	// stay free of per-install flags (keeping its trust-hash / match string
+	// stable). It supplies the gateway address + fail mode the flags omit.
+	sidecar := readHookSidecar(filepath.Join(hookDir, ".hookcfg"))
+
+	if apiAddr == "" {
+		apiAddr = os.Getenv("DEFENSECLAW_GATEWAY_ADDR")
+	}
+	if apiAddr == "" {
+		apiAddr = sidecar["DEFENSECLAW_GATEWAY_ADDR"]
+	}
+	if apiAddr == "" {
+		apiAddr = fmt.Sprintf("127.0.0.1:%d", config.DefaultConfig().Gateway.APIPort)
+	}
+
+	// Precedence mirrors the .sh `FAIL_MODE="${DEFENSECLAW_FAIL_MODE:-baked}"`:
+	// the env var wins, then the explicit flag, then the sidecar's baked value,
+	// and finally hookexec's "open" default for an empty string.
+	if v := os.Getenv("DEFENSECLAW_FAIL_MODE"); v != "" {
+		failMode = v
+	}
+	if failMode == "" {
+		failMode = sidecar["DEFENSECLAW_FAIL_MODE"]
+	}
+
+	opts := hookexec.Options{
+		Connector:          connector,
+		Event:              event,
+		APIAddr:            apiAddr,
+		FailMode:           failMode,
+		Home:               home,
+		HookDir:            hookDir,
+		Token:              os.Getenv("DEFENSECLAW_GATEWAY_TOKEN"),
+		StrictAvailability: hookEnvTrue(os.Getenv("DEFENSECLAW_STRICT_AVAILABILITY")),
+		TraceParent: hookFirstNonEmpty(
+			os.Getenv("DEFENSECLAW_TRACEPARENT"),
+			os.Getenv("TRACEPARENT"),
+			os.Getenv("OTEL_TRACEPARENT"),
+		),
+		TraceState: hookFirstNonEmpty(
+			os.Getenv("DEFENSECLAW_TRACESTATE"),
+			os.Getenv("TRACESTATE"),
+			os.Getenv("OTEL_TRACESTATE"),
+		),
+	}
+
+	if v := os.Getenv("DEFENSECLAW_HOOK_MAX_BODY"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			opts.MaxBody = n
+		}
+	}
+
+	return opts
+}
+
+// readHookSidecar parses the hooks/.hookcfg file setup writes on Windows. It is
+// a small `KEY=value` file (DEFENSECLAW_GATEWAY_ADDR, DEFENSECLAW_FAIL_MODE); an
+// absent or unreadable file yields an empty map so callers fall back to flags,
+// environment, then defaults. Values may be optionally quoted.
+func readHookSidecar(path string) map[string]string {
+	out := map[string]string{}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return out
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		key, val, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		val = strings.TrimSpace(val)
+		if unq, err := strconv.Unquote(val); err == nil {
+			val = unq
+		} else {
+			val = strings.Trim(val, `"'`)
+		}
+		if key != "" {
+			out[key] = val
+		}
+	}
+	return out
+}
+
+// hookEnvTrue mirrors defenseclaw_should_fail_closed_on_unreachable's truthy
+// set: 1, true, yes (case-insensitive).
+func hookEnvTrue(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+func hookFirstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/cli/hook_test.go
+++ b/internal/cli/hook_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeHookSidecarForTest writes a hooks/.hookcfg under home so buildHookOptions
+// can resolve the gateway address + fail mode without per-install flags (the
+// Windows command form).
+func writeHookSidecarForTest(t *testing.T, home, body string) {
+	t.Helper()
+	hookDir := filepath.Join(home, "hooks")
+	if err := os.MkdirAll(hookDir, 0o700); err != nil {
+		t.Fatalf("mkdir hooks: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hookDir, ".hookcfg"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write .hookcfg: %v", err)
+	}
+}
+
+func TestBuildHookOptionsEnvWiring(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("DEFENSECLAW_HOME", home)
+	t.Setenv("DEFENSECLAW_GATEWAY_TOKEN", "secret")
+	t.Setenv("DEFENSECLAW_STRICT_AVAILABILITY", "yes")
+	t.Setenv("DEFENSECLAW_FAIL_MODE", "closed")
+	t.Setenv("DEFENSECLAW_TRACEPARENT", "tp-value")
+
+	opts := buildHookOptions("codex", "PreToolUse", "127.0.0.1:9999", "open")
+
+	if opts.Connector != "codex" {
+		t.Errorf("connector = %q", opts.Connector)
+	}
+	if opts.APIAddr != "127.0.0.1:9999" {
+		t.Errorf("api addr = %q, want flag value", opts.APIAddr)
+	}
+	if opts.Token != "secret" {
+		t.Errorf("token = %q", opts.Token)
+	}
+	if !opts.StrictAvailability {
+		t.Error("strict availability not parsed from env")
+	}
+	if opts.FailMode != "closed" {
+		t.Errorf("fail mode = %q, want env override 'closed'", opts.FailMode)
+	}
+	if opts.TraceParent != "tp-value" {
+		t.Errorf("traceparent = %q", opts.TraceParent)
+	}
+	if opts.Home != home {
+		t.Errorf("home = %q, want %q", opts.Home, home)
+	}
+	if opts.HookDir != filepath.Join(home, "hooks") {
+		t.Errorf("hookDir = %q", opts.HookDir)
+	}
+}
+
+func TestBuildHookOptionsDefaultAPIAddr(t *testing.T) {
+	t.Setenv("DEFENSECLAW_HOME", t.TempDir())
+	opts := buildHookOptions("cursor", "", "", "open")
+	if opts.APIAddr == "" {
+		t.Fatal("expected a default api addr when flag and env are empty")
+	}
+}
+
+func TestBuildHookOptionsSidecarFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("DEFENSECLAW_HOME", home)
+	// Ensure env does not mask the sidecar fallback path.
+	t.Setenv("DEFENSECLAW_GATEWAY_ADDR", "")
+	t.Setenv("DEFENSECLAW_FAIL_MODE", "")
+	writeHookSidecarForTest(t, home, "DEFENSECLAW_GATEWAY_ADDR=127.0.0.1:12345\nDEFENSECLAW_FAIL_MODE=closed\n")
+
+	// Empty flags + empty env: the sidecar supplies both values.
+	opts := buildHookOptions("codex", "", "", "")
+	if opts.APIAddr != "127.0.0.1:12345" {
+		t.Errorf("api addr = %q, want sidecar value", opts.APIAddr)
+	}
+	if opts.FailMode != "closed" {
+		t.Errorf("fail mode = %q, want sidecar value 'closed'", opts.FailMode)
+	}
+}
+
+func TestBuildHookOptionsFlagAndEnvBeatSidecar(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("DEFENSECLAW_HOME", home)
+	t.Setenv("DEFENSECLAW_GATEWAY_ADDR", "")
+	t.Setenv("DEFENSECLAW_FAIL_MODE", "")
+	writeHookSidecarForTest(t, home, "DEFENSECLAW_GATEWAY_ADDR=127.0.0.1:12345\nDEFENSECLAW_FAIL_MODE=closed\n")
+
+	// An explicit flag for the address wins over the sidecar.
+	opts := buildHookOptions("codex", "", "127.0.0.1:7000", "")
+	if opts.APIAddr != "127.0.0.1:7000" {
+		t.Errorf("api addr = %q, want flag value over sidecar", opts.APIAddr)
+	}
+
+	// The env var wins over the sidecar fail mode.
+	t.Setenv("DEFENSECLAW_FAIL_MODE", "open")
+	opts = buildHookOptions("codex", "", "", "")
+	if opts.FailMode != "open" {
+		t.Errorf("fail mode = %q, want env override 'open' over sidecar", opts.FailMode)
+	}
+}
+
+func TestReadHookSidecarParsing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".hookcfg")
+	body := "# comment line\nexport DEFENSECLAW_GATEWAY_ADDR=\"127.0.0.1:18970\"\nDEFENSECLAW_FAIL_MODE=closed\n\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := readHookSidecar(path)
+	if got["DEFENSECLAW_GATEWAY_ADDR"] != "127.0.0.1:18970" {
+		t.Errorf("addr = %q", got["DEFENSECLAW_GATEWAY_ADDR"])
+	}
+	if got["DEFENSECLAW_FAIL_MODE"] != "closed" {
+		t.Errorf("fail mode = %q", got["DEFENSECLAW_FAIL_MODE"])
+	}
+	// A missing file yields an empty map, not a nil-map panic.
+	if m := readHookSidecar(filepath.Join(dir, "absent")); len(m) != 0 {
+		t.Errorf("expected empty map for missing file, got %v", m)
+	}
+}
+
+func TestHookCommandRegisteredAndHidden(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"hook"})
+	if err != nil {
+		t.Fatalf("hook command not found: %v", err)
+	}
+	if cmd.Name() != "hook" {
+		t.Fatalf("found %q, want hook", cmd.Name())
+	}
+	if !cmd.Hidden {
+		t.Error("hook command should be hidden")
+	}
+}

--- a/internal/cli/sidecar.go
+++ b/internal/cli/sidecar.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -120,23 +119,12 @@ func runSidecar(_ *cobra.Command, _ []string) error {
 	// non-TTY fd. We want to swallow that regardless of trace flag.
 	sigCh := make(chan os.Signal, 8)
 	diag := sidecarDiagEnabled()
-	if diag {
-		signal.Notify(sigCh,
-			syscall.SIGINT, syscall.SIGTERM,
-			syscall.SIGHUP, syscall.SIGQUIT,
-			syscall.SIGPIPE, syscall.SIGUSR1, syscall.SIGUSR2)
-	} else {
-		signal.Notify(sigCh,
-			syscall.SIGINT, syscall.SIGTERM,
-			syscall.SIGHUP, syscall.SIGQUIT,
-			syscall.SIGPIPE)
-	}
+	signal.Notify(sigCh, sidecarSignals(diag)...)
 	go func() {
 		for sig := range sigCh {
 			// SIGPIPE is a normal condition when a client disconnects on
 			// a non-TTY fd; don't treat it as a shutdown trigger.
-			sysSig, ok := sig.(syscall.Signal)
-			if ok && sysSig == syscall.SIGPIPE {
+			if isSigPipe(sig) {
 				if diag {
 					fmt.Fprintf(os.Stderr,
 						"[sidecar][diag] ignoring SIGPIPE at %s pid=%d\n",
@@ -146,13 +134,9 @@ func runSidecar(_ *cobra.Command, _ []string) error {
 				continue
 			}
 			if diag {
-				sigNum := -1
-				if ok {
-					sigNum = int(sysSig)
-				}
 				fmt.Fprintf(os.Stderr,
-					"[sidecar][diag] received signal %v (%d) at %s; pid=%d cancelling ctx\n",
-					sig, sigNum,
+					"[sidecar][diag] received signal %v at %s; pid=%d cancelling ctx\n",
+					sig,
 					time.Now().UTC().Format(time.RFC3339Nano),
 					os.Getpid())
 			}

--- a/internal/cli/sidecar_unix.go
+++ b/internal/cli/sidecar_unix.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package cli
+
+import (
+	"os"
+	"syscall"
+)
+
+// sidecarSignals returns the set of OS signals the sidecar should listen for.
+// On Unix we include SIGHUP, SIGQUIT, SIGPIPE, and optionally USR1/USR2 for
+// the diagnostic mode.
+func sidecarSignals(diag bool) []os.Signal {
+	if diag {
+		return []os.Signal{
+			syscall.SIGINT, syscall.SIGTERM,
+			syscall.SIGHUP, syscall.SIGQUIT,
+			syscall.SIGPIPE, syscall.SIGUSR1, syscall.SIGUSR2,
+		}
+	}
+	return []os.Signal{
+		syscall.SIGINT, syscall.SIGTERM,
+		syscall.SIGHUP, syscall.SIGQUIT,
+		syscall.SIGPIPE,
+	}
+}
+
+// isSigPipe reports whether sig is SIGPIPE.
+func isSigPipe(sig os.Signal) bool {
+	s, ok := sig.(syscall.Signal)
+	return ok && s == syscall.SIGPIPE
+}

--- a/internal/cli/sidecar_windows.go
+++ b/internal/cli/sidecar_windows.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package cli
+
+import (
+	"os"
+	"syscall"
+)
+
+// sidecarSignals returns the signals the sidecar listens for on Windows.
+// Only SIGINT and SIGTERM are meaningful on Windows; Unix-specific signals
+// (SIGHUP, SIGQUIT, SIGPIPE, SIGUSR1, SIGUSR2) are unavailable.
+func sidecarSignals(_ bool) []os.Signal {
+	return []os.Signal{syscall.SIGINT, syscall.SIGTERM}
+}
+
+// isSigPipe always returns false on Windows (SIGPIPE does not exist).
+func isSigPipe(_ os.Signal) bool { return false }

--- a/internal/cli/watchdog.go
+++ b/internal/cli/watchdog.go
@@ -27,7 +27,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -135,7 +134,7 @@ func runWatchdogForeground(_ *cobra.Command, _ []string) error {
 	_ = os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o644)
 	defer os.Remove(pidPath)
 
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	ctx, stop := signal.NotifyContext(context.Background(), watchdogShutdownSignals()...)
 	defer stop()
 
 	// The watchdog subcommand overrides rootCmd.PersistentPreRunE (see the
@@ -323,7 +322,7 @@ func runWatchdogStart(_ *cobra.Command, _ []string) error {
 	if data, err := os.ReadFile(pidPath); err == nil {
 		if pid, err := strconv.Atoi(string(data)); err == nil {
 			if proc, err := os.FindProcess(pid); err == nil {
-				if err := proc.Signal(syscall.Signal(0)); err == nil {
+				if watchdogProcessAlive(pid, proc) {
 					Warn(fmt.Sprintf("Watchdog is already running (PID %d)", pid))
 					return nil
 				}
@@ -366,9 +365,9 @@ func (c *execCommand) start() error {
 		return fmt.Errorf("open %s: %w", os.DevNull, err)
 	}
 	proc, err := os.StartProcess(c.path, append([]string{c.path}, c.args...), &os.ProcAttr{
-		Dir:   "/",
+		Dir:   watchdogStartDir(),
 		Files: []*os.File{devNull, c.logFile, c.logFile},
-		Sys:   &syscall.SysProcAttr{Setsid: true},
+		Sys:   watchdogSysProcAttr(),
 	})
 	_ = devNull.Close()
 	if err != nil {
@@ -404,7 +403,7 @@ func runWatchdogStop(_ *cobra.Command, _ []string) error {
 	}
 
 	fmt.Printf("Stopping watchdog (PID %d)... ", pid)
-	if err := proc.Signal(syscall.SIGTERM); err != nil {
+	if err := watchdogTerminate(proc); err != nil {
 		fmt.Println(Dim("already stopped"))
 		_ = os.Remove(pidPath)
 		return nil
@@ -420,7 +419,7 @@ func runWatchdogStop(_ *cobra.Command, _ []string) error {
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
-		_ = proc.Signal(syscall.SIGKILL)
+		_ = watchdogKill(proc)
 	}
 
 	_ = os.Remove(pidPath)
@@ -461,7 +460,7 @@ func runWatchdogStatus(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	if err := proc.Signal(syscall.Signal(0)); err != nil {
+	if !watchdogProcessAlive(pid, proc) {
 		Warn(fmt.Sprintf("Watchdog: not running (PID %d is stale)", pid))
 		_ = os.Remove(pidPath)
 		return nil

--- a/internal/cli/watchdog_unix.go
+++ b/internal/cli/watchdog_unix.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package cli
+
+import (
+	"os"
+	"syscall"
+)
+
+// watchdogShutdownSignals returns the OS signals that stop the foreground
+// watchdog loop.
+func watchdogShutdownSignals() []os.Signal {
+	return []os.Signal{syscall.SIGINT, syscall.SIGTERM}
+}
+
+// watchdogStartDir returns the detached watchdog working directory.
+func watchdogStartDir() string {
+	return "/"
+}
+
+// watchdogSysProcAttr returns a SysProcAttr that starts the watchdog child in
+// a new session (Setsid), detaching it from the parent's controlling terminal.
+func watchdogSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}
+
+func watchdogProcessAlive(_ int, proc *os.Process) bool {
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+func watchdogTerminate(proc *os.Process) error {
+	return proc.Signal(syscall.SIGTERM)
+}
+
+func watchdogKill(proc *os.Process) error {
+	return proc.Signal(syscall.SIGKILL)
+}

--- a/internal/cli/watchdog_windows.go
+++ b/internal/cli/watchdog_windows.go
@@ -37,11 +37,16 @@ func watchdogStartDir() string {
 	return ""
 }
 
-// watchdogSysProcAttr returns a SysProcAttr for Windows. Setsid is a Unix
-// concept; on Windows we return a zero-value struct which lets os.StartProcess
-// use default process creation flags.
+// watchdogSysProcAttr returns a SysProcAttr that starts the background
+// watchdog truly detached. Setsid is a Unix concept; the Windows equivalent
+// is CREATE_NEW_PROCESS_GROUP (so the launcher's Ctrl+C/Ctrl+Break is not
+// inherited and the child is addressable by GenerateConsoleCtrlEvent for a
+// graceful stop) combined with DETACHED_PROCESS (drop the inherited console
+// so a closing terminal cannot deliver CTRL_CLOSE and kill the watchdog).
 func watchdogSysProcAttr() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{}
+	return &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS,
+	}
 }
 
 func watchdogProcessAlive(pid int, _ *os.Process) bool {
@@ -54,6 +59,14 @@ func watchdogProcessAlive(pid int, _ *os.Process) bool {
 }
 
 func watchdogTerminate(proc *os.Process) error {
+	// Prefer a graceful stop via Ctrl+Break to the watchdog's process group.
+	// Go maps a console Ctrl+Break to os.Interrupt, which the watchdog loop
+	// handles through signal.NotifyContext. A detached watchdog has no shared
+	// console, so this returns an error; fall back to TerminateProcess. The
+	// caller waits for exit and force-kills on timeout.
+	if err := windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(proc.Pid)); err == nil {
+		return nil
+	}
 	return proc.Kill()
 }
 

--- a/internal/cli/watchdog_windows.go
+++ b/internal/cli/watchdog_windows.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package cli
+
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// watchdogShutdownSignals returns the OS signals that stop the foreground
+// watchdog loop. Windows supports interrupt/terminate delivery through os/signal.
+func watchdogShutdownSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}
+
+// watchdogStartDir keeps the current working directory on Windows. "/" is not
+// a stable process directory across Windows shells and drives.
+func watchdogStartDir() string {
+	return ""
+}
+
+// watchdogSysProcAttr returns a SysProcAttr for Windows. Setsid is a Unix
+// concept; on Windows we return a zero-value struct which lets os.StartProcess
+// use default process creation flags.
+func watchdogSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}
+
+func watchdogProcessAlive(pid int, _ *os.Process) bool {
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	_ = windows.CloseHandle(h)
+	return true
+}
+
+func watchdogTerminate(proc *os.Process) error {
+	return proc.Kill()
+}
+
+func watchdogKill(proc *os.Process) error {
+	return proc.Kill()
+}

--- a/internal/daemon/proc_unix.go
+++ b/internal/daemon/proc_unix.go
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !windows
+
 package daemon
 
 import (

--- a/internal/daemon/proc_windows.go
+++ b/internal/daemon/proc_windows.go
@@ -21,16 +21,34 @@ package daemon
 import (
 	"os"
 	"os/exec"
+	"syscall"
 
 	"golang.org/x/sys/windows"
 )
 
 func setSysProcAttr(cmd *exec.Cmd) {
-	// Windows does not support Setpgid; processes are already in their own job.
+	// Detach the gateway so it outlives the launching process and console.
+	// CREATE_NEW_PROCESS_GROUP puts the gateway in its own group, so a
+	// Ctrl+C/Ctrl+Break aimed at the launcher's group is not inherited, and
+	// it becomes addressable by GenerateConsoleCtrlEvent for graceful stop.
+	// DETACHED_PROCESS drops the inherited console so a closing terminal
+	// cannot deliver CTRL_CLOSE and take the gateway down with it.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS,
+	}
 }
 
 func sendTermSignal(proc *os.Process) error {
-	// Windows has no SIGTERM; kill the process directly.
+	// Prefer a graceful stop: deliver Ctrl+Break to the gateway's own
+	// process group. Go's runtime turns a console Ctrl+Break into
+	// os.Interrupt, which the sidecar handles by cancelling its context and
+	// calling http.Server.Shutdown. When the gateway was started detached
+	// (no shared console), this returns an error; fall back to
+	// TerminateProcess so `stop` does not block for the full timeout. The
+	// caller still waits for exit and force-kills on timeout.
+	if err := windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(proc.Pid)); err == nil {
+		return nil
+	}
 	return proc.Kill()
 }
 

--- a/internal/daemon/proc_windows.go
+++ b/internal/daemon/proc_windows.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package daemon
+
+import (
+	"os"
+	"os/exec"
+
+	"golang.org/x/sys/windows"
+)
+
+func setSysProcAttr(cmd *exec.Cmd) {
+	// Windows does not support Setpgid; processes are already in their own job.
+}
+
+func sendTermSignal(proc *os.Process) error {
+	// Windows has no SIGTERM; kill the process directly.
+	return proc.Kill()
+}
+
+func sendKillSignal(proc *os.Process) error {
+	return proc.Kill()
+}
+
+func processExists(pid int) bool {
+	// On Windows, os.FindProcess always succeeds regardless of whether the
+	// PID is live. Use OpenProcess with PROCESS_QUERY_LIMITED_INFORMATION to
+	// obtain a real handle: if the process is dead (or access is denied due
+	// to a different user), OpenProcess returns an error.
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	_ = windows.CloseHandle(h)
+	return true
+}
+
+// killStaleProcesses is a no-op on Windows. pgrep is not available and
+// process group semantics differ; stale process cleanup relies on the
+// PID file only.
+func (d *Daemon) killStaleProcesses() {}

--- a/internal/gateway/connector/atomicfile.go
+++ b/internal/gateway/connector/atomicfile.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
-	"time"
 )
 
 // atomicWriteFile writes data to path atomically by writing to a temp file in
@@ -96,34 +94,3 @@ func resolveAtomicWritePath(path string) (string, error) {
 	return "", fmt.Errorf("resolve symlink %s: too many symlinks", path)
 }
 
-// withFileLock acquires an exclusive advisory lock on path+".lock" before
-// running fn, and releases it when fn returns. The lock file is cleaned up
-// on success. Stale lock files older than staleLockAge are removed before
-// attempting acquisition.
-func withFileLock(path string, fn func() error) error {
-	lockPath := path + ".lock"
-	const staleLockAge = 60 * time.Second
-
-	// Clean up stale lock files from crashed processes.
-	if info, err := os.Stat(lockPath); err == nil {
-		if time.Since(info.ModTime()) > staleLockAge {
-			_ = os.Remove(lockPath)
-		}
-	}
-
-	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
-	if err != nil {
-		return fmt.Errorf("open lock file %s: %w", lockPath, err)
-	}
-	defer lockFile.Close()
-
-	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
-		return fmt.Errorf("acquire lock %s: %w", lockPath, err)
-	}
-	defer func() {
-		_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
-		_ = os.Remove(lockPath)
-	}()
-
-	return fn()
-}

--- a/internal/gateway/connector/atomicfile.go
+++ b/internal/gateway/connector/atomicfile.go
@@ -93,4 +93,3 @@ func resolveAtomicWritePath(path string) (string, error) {
 	}
 	return "", fmt.Errorf("resolve symlink %s: too many symlinks", path)
 }
-

--- a/internal/gateway/connector/claudecode.go
+++ b/internal/gateway/connector/claudecode.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/defenseclaw/defenseclaw/internal/redaction"
@@ -351,7 +352,7 @@ func (c *ClaudeCodeConnector) HookProfile(opts SetupOpts) HookProfile {
 func (c *ClaudeCodeConnector) SupportsComponentScanning() bool { return true }
 
 func (c *ClaudeCodeConnector) ComponentTargets(cwd string) map[string][]string {
-	home := os.Getenv("HOME")
+	home := userHomeDir()
 	userDir := filepath.Join(home, ".claude")
 	workspaceDir := filepath.Join(cwd, ".claude")
 
@@ -424,7 +425,7 @@ func claudeCodeSettingsPath() string {
 	if ClaudeCodeSettingsPathOverride != "" {
 		return ClaudeCodeSettingsPathOverride
 	}
-	return filepath.Join(os.Getenv("HOME"), ".claude", "settings.json")
+	return filepath.Join(userHomeDir(), ".claude", "settings.json")
 }
 
 // fileChangedMatcher targets config files that affect Claude Code's
@@ -489,6 +490,15 @@ var hookGroups = []struct {
 // The read-modify-write cycle is protected by an advisory file lock to
 // prevent corruption from concurrent gateway starts.
 func (c *ClaudeCodeConnector) patchClaudeCodeHooks(opts SetupOpts, hookScript string) error {
+	// On Windows, use the .cmd wrapper written by writeWindowsHookWrapper so
+	// that cmd.exe (not a bash variant) is the entry point. This avoids the
+	// ambiguity of which bash (Git Bash vs WSL) the runtime picks up and the
+	// "cannot execute binary file" error when WSL's bash tries to exec a PE.
+	// filepath.ToSlash is a no-op on Unix.
+	if runtime.GOOS == "windows" {
+		hookScript = strings.TrimSuffix(hookScript, ".sh") + ".cmd"
+	}
+	hookScript = filepath.ToSlash(hookScript)
 	settingsPath := claudeCodeSettingsPath()
 
 	return withFileLock(settingsPath, func() error {

--- a/internal/gateway/connector/claudecode.go
+++ b/internal/gateway/connector/claudecode.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/defenseclaw/defenseclaw/internal/redaction"
@@ -490,15 +489,12 @@ var hookGroups = []struct {
 // The read-modify-write cycle is protected by an advisory file lock to
 // prevent corruption from concurrent gateway starts.
 func (c *ClaudeCodeConnector) patchClaudeCodeHooks(opts SetupOpts, hookScript string) error {
-	// On Windows, use the .cmd wrapper written by writeWindowsHookWrapper so
-	// that cmd.exe (not a bash variant) is the entry point. This avoids the
-	// ambiguity of which bash (Git Bash vs WSL) the runtime picks up and the
-	// "cannot execute binary file" error when WSL's bash tries to exec a PE.
-	// filepath.ToSlash is a no-op on Unix.
-	if runtime.GOOS == "windows" {
-		hookScript = strings.TrimSuffix(hookScript, ".sh") + ".cmd"
-	}
-	hookScript = filepath.ToSlash(hookScript)
+	// On Unix the agent runs the bundled .sh hook (ToSlash is a no-op there).
+	// On Windows there is no Bash/.cmd chain: the agent invokes the DefenseClaw
+	// binary's native `hook` subcommand directly. hookInvocationCommand returns
+	// the platform-correct command, which is used verbatim as the agent's hook
+	// command and recognized on teardown by isOwnedHook.
+	hookCommand := hookInvocationCommand("claudecode", filepath.ToSlash(hookScript))
 	settingsPath := claudeCodeSettingsPath()
 
 	return withFileLock(settingsPath, func() error {
@@ -545,7 +541,7 @@ func (c *ClaudeCodeConnector) patchClaudeCodeHooks(opts SetupOpts, hookScript st
 				"hooks": []interface{}{
 					map[string]interface{}{
 						"type":    "command",
-						"command": hookScript,
+						"command": hookCommand,
 						"timeout": group.timeout,
 					},
 				},
@@ -844,6 +840,12 @@ func isOwnedHook(hookEntry interface{}, hooksDir string) bool {
 			continue
 		}
 		if hooksDir != "" && strings.HasPrefix(cmd, hooksDir+"/") {
+			return true
+		}
+		// Native Go hook commands (Windows) are not a file path under hooksDir
+		// and carry no on-disk marker, so recognize them by their entrypoint
+		// invocation fragment.
+		if isNativeHookCommand(cmd) {
 			return true
 		}
 		if scriptHasMarker(cmd) {

--- a/internal/gateway/connector/codeguard_native.go
+++ b/internal/gateway/connector/codeguard_native.go
@@ -118,7 +118,7 @@ func codexHomeDir() string {
 	if home := strings.TrimSpace(os.Getenv("CODEX_HOME")); home != "" {
 		return home
 	}
-	if home := strings.TrimSpace(os.Getenv("HOME")); home != "" {
+	if home := strings.TrimSpace(userHomeDir()); home != "" {
 		return filepath.Join(home, ".codex")
 	}
 	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {

--- a/internal/gateway/connector/codex.go
+++ b/internal/gateway/connector/codex.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -392,7 +393,7 @@ func (c *CodexConnector) HookProfile(opts SetupOpts) HookProfile {
 func (c *CodexConnector) SupportsComponentScanning() bool { return true }
 
 func (c *CodexConnector) ComponentTargets(cwd string) map[string][]string {
-	home := os.Getenv("HOME")
+	home := userHomeDir()
 	codexDir := filepath.Join(home, ".codex")
 
 	targets := map[string][]string{
@@ -416,7 +417,7 @@ func codexConfigPath() string {
 	if CodexConfigPathOverride != "" {
 		return CodexConfigPathOverride
 	}
-	return filepath.Join(os.Getenv("HOME"), ".codex", "config.toml")
+	return filepath.Join(userHomeDir(), ".codex", "config.toml")
 }
 
 // codexConfigBackup captures the pre-DefenseClaw shape of the three
@@ -518,6 +519,9 @@ func isDefenseClawCodexProxyRedirect(v string) bool {
 }
 
 func (c *CodexConnector) patchCodexConfig(opts SetupOpts, hookScript string) error {
+	// filepath.ToSlash is a no-op on Unix (already uses '/'). On Windows it
+	// converts backslashes so bash (Git Bash / MSYS2) can resolve the path.
+	hookScript = filepath.ToSlash(hookScript)
 	configPath := codexConfigPath()
 	if err := captureManagedFileBackup(opts.DataDir, c.Name(), "config.toml", configPath); err != nil {
 		return fmt.Errorf("capture codex config backup: %w", err)
@@ -664,6 +668,13 @@ func (c *CodexConnector) patchCodexConfig(opts SetupOpts, hookScript string) err
 // SetupOpts: observability-only installs allow the tool when the
 // gateway is unavailable, while enforcement installs can block.
 func buildCodexHooksTable(configPath, hookScript string) map[string]interface{} {
+	// On Windows, use the .cmd wrapper written alongside the .sh script.
+	// cmd.exe runs .cmd files natively and forwards stdin/stdout correctly,
+	// avoiding the bash variant ambiguity (Git Bash vs WSL).
+	hookCommand := hookScript
+	if runtime.GOOS == "windows" {
+		hookCommand = strings.TrimSuffix(hookScript, ".sh") + ".cmd"
+	}
 	out := map[string]interface{}{}
 	state := map[string]interface{}{}
 	keySource := codexHookStateKeySource(configPath)
@@ -672,7 +683,7 @@ func buildCodexHooksTable(configPath, hookScript string) map[string]interface{} 
 			"hooks": []interface{}{
 				map[string]interface{}{
 					"type":    "command",
-					"command": hookScript,
+					"command": hookCommand,
 					"timeout": group.timeout,
 				},
 			},

--- a/internal/gateway/connector/codex.go
+++ b/internal/gateway/connector/codex.go
@@ -26,7 +26,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 
@@ -594,7 +593,7 @@ func (c *CodexConnector) patchCodexConfig(opts SetupOpts, hookScript string) err
 	// In observability mode the hook handler logs but never
 	// blocks; in enforcement mode it can also block based on the
 	// subprocess sandbox policy.
-	cfg["hooks"] = buildCodexHooksTable(configPath, hookScript)
+	cfg["hooks"] = buildCodexHooksTable(configPath, hookInvocationCommand("codex", hookScript))
 
 	features, _ := cfg["features"].(map[string]interface{})
 	if features == nil {
@@ -667,14 +666,7 @@ func (c *CodexConnector) patchCodexConfig(opts SetupOpts, hookScript string) err
 // The generated hook script decides fail-open vs fail-closed from
 // SetupOpts: observability-only installs allow the tool when the
 // gateway is unavailable, while enforcement installs can block.
-func buildCodexHooksTable(configPath, hookScript string) map[string]interface{} {
-	// On Windows, use the .cmd wrapper written alongside the .sh script.
-	// cmd.exe runs .cmd files natively and forwards stdin/stdout correctly,
-	// avoiding the bash variant ambiguity (Git Bash vs WSL).
-	hookCommand := hookScript
-	if runtime.GOOS == "windows" {
-		hookCommand = strings.TrimSuffix(hookScript, ".sh") + ".cmd"
-	}
+func buildCodexHooksTable(configPath, hookCommand string) map[string]interface{} {
 	out := map[string]interface{}{}
 	state := map[string]interface{}{}
 	keySource := codexHookStateKeySource(configPath)
@@ -693,8 +685,10 @@ func buildCodexHooksTable(configPath, hookScript string) map[string]interface{} 
 		}
 		out[group.eventType] = []interface{}{matcherGroup}
 		eventKey := codexHookEventKeyLabel(group.eventType)
+		// The trust hash is computed over the SAME command Codex executes, so
+		// Codex recognizes the entry and teardown can reproduce the fingerprint.
 		state[codexHookStateKey(keySource, eventKey, 0, 0)] = map[string]interface{}{
-			"trusted_hash": codexCommandHookHash(eventKey, group.matcher, hookScript, group.timeout),
+			"trusted_hash": codexCommandHookHash(eventKey, group.matcher, hookCommand, group.timeout),
 		}
 	}
 	out["state"] = state
@@ -975,8 +969,10 @@ func (c *CodexConnector) restoreCodexConfig(opts SetupOpts) {
 				hookEventsRemain = true
 			}
 		}
-		hookScript := filepath.Join(opts.DataDir, "hooks", "codex-hook.sh")
-		if removeOwnedCodexHookState(hooks, configPath, hookScript) {
+		// Reproduce the exact command used at setup (Unix: ToSlash'd .sh path;
+		// Windows: native Go invocation) so the trust-hash fingerprint matches.
+		hookCommand := hookInvocationCommand("codex", filepath.ToSlash(filepath.Join(opts.DataDir, "hooks", "codex-hook.sh")))
+		if removeOwnedCodexHookState(hooks, configPath, hookCommand) {
 			removedOwnedHooks = true
 		}
 		if len(hooks) == 0 {
@@ -1063,7 +1059,7 @@ func codexHookEntryCount(v interface{}) int {
 	return len(list)
 }
 
-func removeOwnedCodexHookState(hooks map[string]interface{}, configPath, hookScript string) bool {
+func removeOwnedCodexHookState(hooks map[string]interface{}, configPath, hookCommand string) bool {
 	state, ok := hooks["state"].(map[string]interface{})
 	if !ok {
 		return false
@@ -1077,7 +1073,7 @@ func removeOwnedCodexHookState(hooks map[string]interface{}, configPath, hookScr
 		if !ok {
 			continue
 		}
-		expectedHash := codexCommandHookHash(eventKey, group.matcher, hookScript, group.timeout)
+		expectedHash := codexCommandHookHash(eventKey, group.matcher, hookCommand, group.timeout)
 		if trustedHash, _ := entry["trusted_hash"].(string); trustedHash == expectedHash {
 			delete(state, key)
 			removed = true

--- a/internal/gateway/connector/connector_test.go
+++ b/internal/gateway/connector/connector_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -481,7 +482,12 @@ func TestAllConnectors_ImplementInterface(t *testing.T) {
 // it exists on disk.
 func TestOpenClaw_ExtensionAvailable_OnFullBuild(t *testing.T) {
 	t.Parallel()
-	if _, err := openClawExtensionFS.ReadFile(filepath.Join(openClawPluginRoot, ".placeholder")); err == nil {
+	// embed.FS always uses forward-slash paths; filepath.Join would emit
+	// backslashes on Windows and never match the embedded entry, so the
+	// skip would not fire and the test would spuriously fail on a Windows
+	// placeholder build. Use path.Join (and the shared constant) to mirror
+	// openClawExtensionAvailable.
+	if _, err := openClawExtensionFS.ReadFile(path.Join(openClawPluginRoot, openClawPlaceholderName)); err == nil {
 		t.Skip("gateway built without OpenClaw extension (placeholder present) — full-build assertion does not apply here")
 	}
 	if !openClawExtensionAvailable() {

--- a/internal/gateway/connector/connector_test.go
+++ b/internal/gateway/connector/connector_test.go
@@ -5477,13 +5477,12 @@ func TestClaudeCodeHookScript_NoStructuredOutput_FallsBackToExitTwo(t *testing.T
 	}
 }
 
-// TestCodexHookScript_NoStructuredOutput_FallsBackToExitTwo pins the
-// fallback path: if the gateway ever returns action=block but does
-// NOT include a codex_output mirror (legacy callers, future codex
-// events not yet wired up), the hook must use the exit-2-with-stderr
-// path so Codex still blocks. The reason MUST land on stderr —
-// emitting an empty stderr was the original bug.
-func TestCodexHookScript_NoStructuredOutput_FallsBackToExitTwo(t *testing.T) {
+// TestCodexHookScript_NoStructuredOutput_EmitsInlineBlockJSON pins the
+// fallback path: if the gateway returns action=block but does NOT include
+// a codex_output mirror, the hook constructs minimal structured block JSON
+// and exits 0 so Codex v0.130+ treats it as a block decision rather than
+// "hook failed" (which is what exit 2 means on UserPromptSubmit).
+func TestCodexHookScript_NoStructuredOutput_EmitsInlineBlockJSON(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell scripts not supported on windows")
 	}
@@ -5518,17 +5517,16 @@ func TestCodexHookScript_NoStructuredOutput_FallsBackToExitTwo(t *testing.T) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	if err == nil {
-		t.Fatalf("hook should exit 2 when gateway block has no structured codex_output, got exit 0\nstdout=%q\nstderr=%q",
-			stdout.String(), stderr.String())
+	if err != nil {
+		t.Fatalf("hook should exit 0 with inline block JSON, got error: %v\nstdout=%q\nstderr=%q",
+			err, stdout.String(), stderr.String())
 	}
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		if exitErr.ExitCode() != 2 {
-			t.Errorf("exit code = %d, want 2 (legacy block fallback)", exitErr.ExitCode())
-		}
+	out := stdout.String()
+	if !strings.Contains(out, `"decision":"block"`) {
+		t.Errorf("stdout must contain decision=block JSON, got: %q", out)
 	}
-	if !strings.Contains(stderr.String(), "hypothetical legacy verdict") {
-		t.Errorf("stderr must carry the block reason on the legacy path, got: %q", stderr.String())
+	if !strings.Contains(out, "hypothetical legacy verdict") {
+		t.Errorf("stdout must carry the block reason in the inline JSON, got: %q", out)
 	}
 }
 

--- a/internal/gateway/connector/filelock_unix.go
+++ b/internal/gateway/connector/filelock_unix.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package connector
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+// withFileLock acquires an exclusive advisory lock on path+".lock" before
+// running fn, and releases it when fn returns. The lock file is cleaned up
+// on success. Stale lock files older than staleLockAge are removed before
+// attempting acquisition.
+func withFileLock(path string, fn func() error) error {
+	lockPath := path + ".lock"
+	const staleLockAge = 60 * time.Second
+
+	// Clean up stale lock files from crashed processes.
+	if info, err := os.Stat(lockPath); err == nil {
+		if time.Since(info.ModTime()) > staleLockAge {
+			_ = os.Remove(lockPath)
+		}
+	}
+
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("open lock file %s: %w", lockPath, err)
+	}
+	defer lockFile.Close()
+
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("acquire lock %s: %w", lockPath, err)
+	}
+	defer func() {
+		_ = syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+		_ = os.Remove(lockPath)
+	}()
+
+	return fn()
+}

--- a/internal/gateway/connector/filelock_windows.go
+++ b/internal/gateway/connector/filelock_windows.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package connector
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// withFileLock on Windows uses an exclusive open as a lock mechanism.
+// Windows file locking is mandatory (opening with exclusive access blocks
+// other openers), which provides the same mutual exclusion guarantee as
+// flock on Unix.
+func withFileLock(path string, fn func() error) error {
+	lockPath := path + ".lock"
+	const staleLockAge = 60 * time.Second
+
+	// Clean up stale lock files from crashed processes.
+	if info, err := os.Stat(lockPath); err == nil {
+		if time.Since(info.ModTime()) > staleLockAge {
+			_ = os.Remove(lockPath)
+		}
+	}
+
+	// On Windows, O_CREATE|O_EXCL ensures only one process can hold the lock.
+	// If the file already exists (held by another process), OpenFile fails.
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("acquire lock %s: %w", lockPath, err)
+	}
+	defer func() {
+		lockFile.Close()
+		_ = os.Remove(lockPath)
+	}()
+
+	return fn()
+}

--- a/internal/gateway/connector/filelock_windows.go
+++ b/internal/gateway/connector/filelock_windows.go
@@ -21,33 +21,42 @@ package connector
 import (
 	"fmt"
 	"os"
-	"time"
+
+	"golang.org/x/sys/windows"
 )
 
-// withFileLock on Windows uses an exclusive open as a lock mechanism.
-// Windows file locking is mandatory (opening with exclusive access blocks
-// other openers), which provides the same mutual exclusion guarantee as
-// flock on Unix.
+// withFileLock acquires an exclusive, blocking lock on path+".lock" before
+// running fn, and releases it when fn returns.
+//
+// It uses Windows LockFileEx (exclusive, without LOCKFILE_FAIL_IMMEDIATELY),
+// which blocks until the lock is available and is released automatically by
+// the OS when the holding process exits or the handle is closed. That gives
+// the same mutual-exclusion and crash-safety guarantees as flock(LOCK_EX) on
+// Unix. The earlier O_CREATE|O_EXCL sentinel-file approach was non-blocking
+// (it returned an error on contention instead of waiting) and left a stale
+// lock file that hard-failed all callers for up to a minute after a crash.
 func withFileLock(path string, fn func() error) error {
 	lockPath := path + ".lock"
-	const staleLockAge = 60 * time.Second
 
-	// Clean up stale lock files from crashed processes.
-	if info, err := os.Stat(lockPath); err == nil {
-		if time.Since(info.ModTime()) > staleLockAge {
-			_ = os.Remove(lockPath)
-		}
-	}
-
-	// On Windows, O_CREATE|O_EXCL ensures only one process can hold the lock.
-	// If the file already exists (held by another process), OpenFile fails.
-	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	// O_RDWR (not O_EXCL): every caller opens the shared lock file; mutual
+	// exclusion is enforced by the byte-range lock below, not by file
+	// existence. Go opens with FILE_SHARE_READ|WRITE|DELETE so concurrent
+	// processes can open the handle and then contend on the lock.
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
+		return fmt.Errorf("open lock file %s: %w", lockPath, err)
+	}
+	defer lockFile.Close()
+
+	handle := windows.Handle(lockFile.Fd())
+	overlapped := new(windows.Overlapped)
+	// Lock 1 byte at offset 0. All callers use the same range, so this
+	// serializes them. No LOCKFILE_FAIL_IMMEDIATELY flag -> the call blocks.
+	if err := windows.LockFileEx(handle, windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, overlapped); err != nil {
 		return fmt.Errorf("acquire lock %s: %w", lockPath, err)
 	}
 	defer func() {
-		lockFile.Close()
-		_ = os.Remove(lockPath)
+		_ = windows.UnlockFileEx(handle, 0, 1, 0, overlapped)
 	}()
 
 	return fn()

--- a/internal/gateway/connector/helpers.go
+++ b/internal/gateway/connector/helpers.go
@@ -23,8 +23,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -40,39 +38,63 @@ func userHomeDir() string {
 	return os.Getenv("HOME")
 }
 
-// resolveWindowsBash finds a Git Bash (non-WSL) bash.exe on Windows.
-// WSL's bash runs in a separate network namespace and cannot reach the
-// Windows-side gateway on 127.0.0.1, so we prefer Git Bash.
-// Returns a quoted path if spaces are present, or just "bash" as fallback.
-func resolveWindowsBash() string {
-	if runtime.GOOS != "windows" {
-		return "bash"
+// nativeHookFlag is the distinctive argument fragment that marks a command as
+// the DefenseClaw native Go hook entrypoint (`defenseclaw-gateway hook
+// --connector <name>`). It is used both when writing an agent's hook command on
+// Windows and when recognizing DefenseClaw-owned hooks during teardown.
+const nativeHookFlag = "hook --connector "
+
+// hookInvocationCommand returns the command string an agent runtime is
+// configured to run for a DefenseClaw hook.
+//
+// On Unix the agent runs the bundled .sh hook through its shell, so the command
+// is the script path (unixCommand) the caller already resolved.
+//
+// On Windows there is no Bash/.cmd/jq/PATH-restore chain: the agent invokes the
+// DefenseClaw binary's hidden `hook` subcommand directly. The Windows command
+// deliberately carries no per-install volatile values — the gateway address,
+// token, and fail mode are resolved at runtime from the hook sidecar
+// (hooks/.hookcfg, hooks/.token) and the environment. Keeping the command
+// byte-identical across setup and teardown is required so Codex's trust-hash
+// recognition and the JSON/YAML hook removers (which match on the exact command
+// string) still find the entries DefenseClaw inserted.
+func hookInvocationCommand(connector, unixCommand string) string {
+	return hookInvocationCommandFor(runtime.GOOS, connector, unixCommand)
+}
+
+// hookInvocationCommandFor is the OS-parameterized core of
+// hookInvocationCommand, split out so the Windows command string can be
+// exercised by tests on any host.
+func hookInvocationCommandFor(goos, connector, unixCommand string) string {
+	if goos != "windows" {
+		return unixCommand
 	}
-	// Check common Git for Windows locations.
-	candidates := []string{
-		filepath.Join(os.Getenv("ProgramFiles"), "Git", "bin", "bash.exe"),
-		filepath.Join(os.Getenv("ProgramFiles(x86)"), "Git", "bin", "bash.exe"),
-		filepath.Join(os.Getenv("LocalAppData"), "Programs", "Git", "bin", "bash.exe"),
+	return windowsQuoteExe(defenseclawHookBinary()) + " " + nativeHookFlag + connector
+}
+
+// defenseclawHookBinary returns the path to the running gateway binary, which
+// also hosts the hidden `hook` subcommand. Falls back to the bare binary name
+// (resolved via PATH by the agent) when the path cannot be determined.
+func defenseclawHookBinary() string {
+	if exe, err := os.Executable(); err == nil && strings.TrimSpace(exe) != "" {
+		return exe
 	}
-	for _, p := range candidates {
-		if p == "" {
-			continue
-		}
-		if _, err := os.Stat(p); err == nil {
-			return `"` + p + `"`
-		}
-	}
-	// Fall back to PATH lookup — prefer git bash's bash over WSL.
-	if gitPath, err := exec.LookPath("git"); err == nil {
-		// git.exe is typically at C:\Program Files\Git\cmd\git.exe
-		// bash.exe is at C:\Program Files\Git\bin\bash.exe
-		gitDir := filepath.Dir(filepath.Dir(gitPath))
-		candidate := filepath.Join(gitDir, "bin", "bash.exe")
-		if _, err := os.Stat(candidate); err == nil {
-			return `"` + candidate + `"`
-		}
-	}
-	return "bash"
+	return "defenseclaw-gateway"
+}
+
+// windowsQuoteExe wraps an executable path in double quotes so cmd.exe and agent
+// runtimes treat a path containing spaces (e.g. "C:\Program Files\...") as a
+// single token. Backslashes are preserved verbatim inside double quotes.
+func windowsQuoteExe(p string) string {
+	return `"` + p + `"`
+}
+
+// isNativeHookCommand reports whether cmd is the DefenseClaw native Go hook
+// entrypoint invocation written on Windows. Used by teardown ownership
+// recognition, which otherwise keys on a hooks-dir path / script marker that a
+// native (non-file) command does not carry.
+func isNativeHookCommand(cmd string) bool {
+	return strings.Contains(cmd, nativeHookFlag)
 }
 
 // SecureTokenMatch compares two token strings in constant time to prevent

--- a/internal/gateway/connector/helpers.go
+++ b/internal/gateway/connector/helpers.go
@@ -23,9 +23,57 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 )
+
+// userHomeDir returns the current user's home directory in a cross-platform
+// way. It prefers os.UserHomeDir() (which uses USERPROFILE on Windows,
+// HOME on Unix) and falls back to os.Getenv("HOME") for legacy compatibility.
+func userHomeDir() string {
+	if h, err := os.UserHomeDir(); err == nil && h != "" {
+		return h
+	}
+	return os.Getenv("HOME")
+}
+
+// resolveWindowsBash finds a Git Bash (non-WSL) bash.exe on Windows.
+// WSL's bash runs in a separate network namespace and cannot reach the
+// Windows-side gateway on 127.0.0.1, so we prefer Git Bash.
+// Returns a quoted path if spaces are present, or just "bash" as fallback.
+func resolveWindowsBash() string {
+	if runtime.GOOS != "windows" {
+		return "bash"
+	}
+	// Check common Git for Windows locations.
+	candidates := []string{
+		filepath.Join(os.Getenv("ProgramFiles"), "Git", "bin", "bash.exe"),
+		filepath.Join(os.Getenv("ProgramFiles(x86)"), "Git", "bin", "bash.exe"),
+		filepath.Join(os.Getenv("LocalAppData"), "Programs", "Git", "bin", "bash.exe"),
+	}
+	for _, p := range candidates {
+		if p == "" {
+			continue
+		}
+		if _, err := os.Stat(p); err == nil {
+			return `"` + p + `"`
+		}
+	}
+	// Fall back to PATH lookup — prefer git bash's bash over WSL.
+	if gitPath, err := exec.LookPath("git"); err == nil {
+		// git.exe is typically at C:\Program Files\Git\cmd\git.exe
+		// bash.exe is at C:\Program Files\Git\bin\bash.exe
+		gitDir := filepath.Dir(filepath.Dir(gitPath))
+		candidate := filepath.Join(gitDir, "bin", "bash.exe")
+		if _, err := os.Stat(candidate); err == nil {
+			return `"` + candidate + `"`
+		}
+	}
+	return "bash"
+}
 
 // SecureTokenMatch compares two token strings in constant time to prevent
 // timing-based token extraction attacks.

--- a/internal/gateway/connector/hook_only.go
+++ b/internal/gateway/connector/hook_only.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 
@@ -613,16 +612,19 @@ func (c *hookOnlyConnector) Setup(ctx context.Context, opts SetupOpts) error {
 	if err := WriteHookScriptsForConnectorObjectWithOpts(hookDir, opts, c); err != nil {
 		return fmt.Errorf("%s hook script: %w", c.name, err)
 	}
-	scriptName := c.scriptName
-	// On Windows use the .cmd wrapper so cmd.exe is the entry point rather
-	// than a bash variant that may not be able to exec Windows binaries.
-	if runtime.GOOS == "windows" {
-		scriptName = strings.TrimSuffix(scriptName, ".sh") + ".cmd"
-	}
-	if err := c.patchConfig(opts, filepath.Join(hookDir, scriptName)); err != nil {
+	if err := c.patchConfig(opts, c.hookCommand(opts)); err != nil {
 		return fmt.Errorf("%s hook config: %w", c.name, err)
 	}
 	return nil
+}
+
+// hookCommand returns the command an agent runs for this connector's hook. On
+// Unix it is the bundled .sh path; on Windows it is the native DefenseClaw
+// `hook` subcommand invocation. The same value is used at setup, teardown, and
+// VerifyClean so the JSON/YAML hook removers (which match on the exact command
+// string) recognize the entries DefenseClaw inserted.
+func (c *hookOnlyConnector) hookCommand(opts SetupOpts) string {
+	return hookInvocationCommand(c.name, filepath.Join(opts.DataDir, "hooks", c.scriptName))
 }
 
 // Teardown restores the host agent's config (or removes our entries
@@ -652,8 +654,7 @@ func (c *hookOnlyConnector) Teardown(ctx context.Context, opts SetupOpts) error 
 	case err != nil:
 		errs = append(errs, fmt.Sprintf("restore config backup: %v", err))
 	case !restored:
-		hookScript := filepath.Join(opts.DataDir, "hooks", c.scriptName)
-		if err := c.removeConfigEntries(path, hookScript); err != nil {
+		if err := c.removeConfigEntries(path, c.hookCommand(opts)); err != nil {
 			errs = append(errs, fmt.Sprintf("remove hook entries: %v", err))
 		} else {
 			discardManagedFileBackup(opts.DataDir, c.name, "config")
@@ -679,7 +680,7 @@ func (c *hookOnlyConnector) VerifyClean(opts SetupOpts) error {
 		}
 		return err
 	}
-	needle := filepath.Join(opts.DataDir, "hooks", c.scriptName)
+	needle := c.hookCommand(opts)
 	if bytes.Contains(data, []byte(needle)) || bytes.Contains(data, []byte(c.scriptName)) {
 		return fmt.Errorf("%s teardown incomplete: config still references %s", c.name, c.scriptName)
 	}
@@ -1719,6 +1720,13 @@ func containsHookScript(raw interface{}, hookScript string) bool {
 func shellWord(s string) string {
 	if s == "" {
 		return "''"
+	}
+	// Native Go hook commands (Windows) are already a complete, correctly
+	// quoted command line (`"<exe>" hook --connector <name>`). bash-style
+	// single-quoting would corrupt the executable path and break invocation,
+	// so pass these through unchanged. Unix .sh paths still get quoted.
+	if isNativeHookCommand(s) {
+		return s
 	}
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/internal/gateway/connector/hook_only.go
+++ b/internal/gateway/connector/hook_only.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -612,7 +613,13 @@ func (c *hookOnlyConnector) Setup(ctx context.Context, opts SetupOpts) error {
 	if err := WriteHookScriptsForConnectorObjectWithOpts(hookDir, opts, c); err != nil {
 		return fmt.Errorf("%s hook script: %w", c.name, err)
 	}
-	if err := c.patchConfig(opts, filepath.Join(hookDir, c.scriptName)); err != nil {
+	scriptName := c.scriptName
+	// On Windows use the .cmd wrapper so cmd.exe is the entry point rather
+	// than a bash variant that may not be able to exec Windows binaries.
+	if runtime.GOOS == "windows" {
+		scriptName = strings.TrimSuffix(scriptName, ".sh") + ".cmd"
+	}
+	if err := c.patchConfig(opts, filepath.Join(hookDir, scriptName)); err != nil {
 		return fmt.Errorf("%s hook config: %w", c.name, err)
 	}
 	return nil
@@ -952,7 +959,7 @@ func workspaceRootOutsideDataDir(root, dataDir string) bool {
 }
 
 func homePath(parts ...string) string {
-	home := strings.TrimSpace(os.Getenv("HOME"))
+	home := strings.TrimSpace(userHomeDir())
 	if home == "" {
 		if h, err := os.UserHomeDir(); err == nil {
 			home = strings.TrimSpace(h)

--- a/internal/gateway/connector/hookexec/helpers.go
+++ b/internal/gateway/connector/hookexec/helpers.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hookexec
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// readCapped reads up to max bytes from r. It returns overflow=true (and an
+// empty payload) when the input exceeds max, mirroring
+// defenseclaw_read_stdin_capped: refuse, don't truncate. A 1-byte probe past
+// the cap detects the overflow without buffering an unbounded body.
+func readCapped(r io.Reader, max int64) (payload []byte, overflow bool, err error) {
+	if r == nil {
+		return nil, false, nil
+	}
+	limited := io.LimitReader(r, max+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, false, err
+	}
+	if int64(len(data)) > max {
+		return nil, true, nil
+	}
+	return data, false, nil
+}
+
+// validTraceparent mirrors defenseclaw_validate_traceparent: a 55-char W3C
+// traceparent (version-traceid-parentid-flags) with dashes at the fixed
+// positions, strictly hex elsewhere, and non-zero trace-id / parent-id.
+func validTraceparent(v string) bool {
+	if len(v) != 55 {
+		return false
+	}
+	if v[2] != '-' || v[35] != '-' || v[52] != '-' {
+		return false
+	}
+	for i := 0; i < len(v); i++ {
+		if i == 2 || i == 35 || i == 52 {
+			continue
+		}
+		if !isHex(v[i]) {
+			return false
+		}
+	}
+	if v[3:35] == "00000000000000000000000000000000" {
+		return false
+	}
+	if v[36:52] == "0000000000000000" {
+		return false
+	}
+	return true
+}
+
+// validTracestate mirrors defenseclaw_validate_tracestate: <=512 bytes and
+// only the W3C tracestate ABNF characters (no log-injectable bytes).
+func validTracestate(v string) bool {
+	if len(v) > 512 {
+		return false
+	}
+	for i := 0; i < len(v); i++ {
+		if !isTracestateChar(v[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isHex(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+}
+
+func isTracestateChar(c byte) bool {
+	switch {
+	case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		return true
+	case c == '=' || c == ',' || c == '@' || c == '_' || c == '/' || c == '.' || c == '-':
+		return true
+	case c == ' ' || c == '\t':
+		return true
+	default:
+		return false
+	}
+}
+
+// logHookFailure appends one JSON line to Home/logs/hook-failures.jsonl,
+// mirroring defenseclaw_log_hook_failure. Best-effort: any error is ignored so
+// a read-only home or full disk never changes the hook's decision.
+func logHookFailure(opts Options, sp spec, reason, category, failMode string) {
+	if opts.Home == "" {
+		return
+	}
+	logDir := filepath.Join(opts.Home, "logs")
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		return
+	}
+	entry := struct {
+		TS        string `json:"ts"`
+		Connector string `json:"connector"`
+		Hook      string `json:"hook"`
+		Reason    string `json:"reason"`
+		Category  string `json:"category"`
+		FailMode  string `json:"fail_mode"`
+	}{
+		TS:        opts.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		Connector: sp.connector,
+		Hook:      sp.hookName,
+		Reason:    reason,
+		Category:  category,
+		FailMode:  failMode,
+	}
+	line, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	f, err := os.OpenFile(filepath.Join(logDir, "hook-failures.jsonl"),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_, _ = f.Write(append(line, '\n'))
+}

--- a/internal/gateway/connector/hookexec/hookexec.go
+++ b/internal/gateway/connector/hookexec/hookexec.go
@@ -1,0 +1,470 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package hookexec runs DefenseClaw agent hooks natively in Go instead of via
+// the bundled Bash hook scripts. It is the execution path used on Windows,
+// where agents invoke the DefenseClaw binary directly (no Git Bash, no .cmd
+// wrapper, no jq, and no PATH lockdown — because Go never shells out).
+//
+// The behavior here intentionally mirrors the .sh hooks under
+// internal/gateway/connector/hooks line-for-line: the same gateway endpoint
+// per connector, the same per-connector stdout shape and exit code, and the
+// same fail-open-on-outage / fail-closed-on-misconfig policy. Unix keeps using
+// the .sh hooks unchanged; this package is the parity implementation so the
+// two paths cannot drift (the golden tests pin the contract on every OS).
+package hookexec
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// blockExit is the POSIX exit code every supported agent treats as "this hook
+// blocked the action" (Claude Code, Codex, Cursor, Windsurf, OpenHands, ...).
+const blockExit = 2
+
+// defaultMaxBody caps how many bytes of the agent's hook payload we read from
+// stdin before refusing it, matching DEFENSECLAW_HOOK_MAX_BODY in the .sh
+// hooks (1 MiB). A 1 MiB+ hook event is well outside any legitimate payload
+// and silently truncating it would yield a confusing downstream parse error.
+const defaultMaxBody int64 = 1 << 20
+
+// Options configures a single hook invocation. The CLI entrypoint fills these
+// from flags + environment; tests construct them directly so the full decision
+// matrix can be exercised without a real gateway or agent.
+type Options struct {
+	// Connector is the logical connector name, e.g. "claudecode", "codex".
+	Connector string
+	// Event is the agent hook event (informational; recorded in failure logs).
+	Event string
+	// APIAddr is the gateway "host:port" the hook posts to.
+	APIAddr string
+	// FailMode is "open" or "closed"; it governs response-layer failures
+	// (4xx / bad JSON). Transport failures always fail open unless
+	// StrictAvailability is set. Empty defaults to "open".
+	FailMode string
+
+	// Home is DEFENSECLAW_HOME (default ~/.defenseclaw). If it does not exist
+	// or contains a .disabled file the hook is a no-op (exit 0).
+	Home string
+	// HookDir holds the .token sidecar file (default Home/hooks).
+	HookDir string
+	// Token, when set, is the resolved gateway token (e.g. from the
+	// DEFENSECLAW_GATEWAY_TOKEN env var); it takes precedence over the .token
+	// file. Empty means "fall back to the .token file".
+	Token string
+
+	// StrictAvailability mirrors DEFENSECLAW_STRICT_AVAILABILITY: when true,
+	// transport failures and a missing token fail closed instead of open.
+	StrictAvailability bool
+
+	// MaxBody overrides the stdin cap in bytes (default defaultMaxBody).
+	MaxBody int64
+
+	// TraceParent / TraceState are W3C trace-context candidates forwarded to
+	// the gateway after validation (invalid values are dropped, never sent).
+	TraceParent string
+	TraceState  string
+
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+
+	// HTTPClient lets tests inject a stub transport. When nil a client with
+	// the same 2s-connect / 10s-total budget as the .sh `curl` call is used.
+	HTTPClient *http.Client
+	// Now is injectable for deterministic failure-log timestamps in tests.
+	Now func() time.Time
+}
+
+// Run executes the hook described by opts and returns the process exit code
+// (0 = allow / no-op, 2 = block / fail-closed). It never returns other codes
+// so callers can pass the result straight to os.Exit.
+func Run(ctx context.Context, opts Options) int {
+	opts = withDefaults(opts)
+
+	sp, ok := specFor(opts.Connector)
+	if !ok {
+		// Unknown connector is a wiring bug, not a policy decision. Fail loud
+		// so it surfaces in tests / setup rather than silently disabling the
+		// guardrail. The CLI validates --connector against the registry, so
+		// this is unreachable in normal operation.
+		fmt.Fprintf(opts.Stderr, "defenseclaw: unknown hook connector %q\n", opts.Connector)
+		return blockExit
+	}
+
+	// DEFENSECLAW_HOME guard: if the data dir is gone or the operator dropped
+	// a .disabled file, do nothing. Mirrors the top-of-script guard.
+	if info, err := os.Stat(opts.Home); err != nil || !info.IsDir() {
+		return 0
+	}
+	if _, err := os.Stat(filepath.Join(opts.Home, ".disabled")); err == nil {
+		return 0
+	}
+
+	failMode := normalizeFailMode(opts.FailMode)
+
+	// Missing-token branch: only taken when BOTH the env token is empty AND
+	// the .token file is absent. (An empty token inside an existing .token
+	// file is intentionally NOT a missing token — it selects the loopback
+	// no-auth path, same as the .sh.)
+	tokenFile := filepath.Join(opts.HookDir, ".token")
+	if opts.Token == "" && !fileExists(tokenFile) {
+		return handleMissingToken(opts, sp, failMode)
+	}
+
+	payload, overflow, err := readCapped(opts.Stdin, opts.MaxBody)
+	if err != nil {
+		// stdin read error is treated like an oversized/unusable payload.
+		overflow = true
+	}
+	if overflow {
+		return handleOversized(opts, sp, failMode)
+	}
+
+	token := opts.Token
+	if token == "" {
+		token = readTokenFile(tokenFile)
+	}
+
+	return doRequest(ctx, opts, sp, failMode, payload, token)
+}
+
+// doRequest performs the gateway POST and dispatches the response through the
+// connector-specific decision logic, applying the transport vs response
+// failure split exactly like the .sh hooks.
+func doRequest(ctx context.Context, opts Options, sp spec, failMode string, payload []byte, token string) int {
+	url := "http://" + opts.APIAddr + sp.endpoint
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return failResponse(opts, sp, failMode, "invalid request: "+err.Error())
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-DefenseClaw-Client", sp.hookName+"/1.0")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if v := strings.TrimSpace(opts.TraceParent); v != "" && validTraceparent(v) {
+		req.Header.Set("traceparent", v)
+	}
+	if v := strings.TrimSpace(opts.TraceState); v != "" && validTracestate(v) {
+		req.Header.Set("tracestate", v)
+	}
+
+	resp, err := opts.HTTPClient.Do(req)
+	if err != nil {
+		return failUnreachable(opts, sp, failMode, "gateway unreachable")
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, defaultMaxBody))
+
+	switch {
+	case resp.StatusCode >= 500 && resp.StatusCode < 600:
+		return failUnreachable(opts, sp, failMode, fmt.Sprintf("gateway returned HTTP %d", resp.StatusCode))
+	case resp.StatusCode < 200 || resp.StatusCode >= 300:
+		return failResponse(opts, sp, failMode, fmt.Sprintf("gateway returned HTTP %d", resp.StatusCode))
+	}
+
+	return sp.decide(opts, body)
+}
+
+// decide shapes the connector-native stdout + exit code from a 2xx gateway
+// response body, returning a fail_response result if the body is not JSON.
+func (sp spec) decide(opts Options, body []byte) int {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return failResponse(opts, sp, normalizeFailMode(opts.FailMode), "invalid JSON response")
+	}
+
+	action := rawStringOr(fields, "action", "allow")
+	reason := rawStringOr(fields, "reason", "")
+	output := compactField(fields, sp.outputField)
+
+	switch sp.style {
+	case styleClaudeCode:
+		if output != "" {
+			fmt.Fprintln(opts.Stdout, output)
+		}
+		if action == "block" {
+			if output != "" {
+				return 0
+			}
+			if reason == "" {
+				reason = sp.defaultBlockReason
+			}
+			fmt.Fprintln(opts.Stderr, reason)
+			return blockExit
+		}
+		return 0
+
+	case styleCodex:
+		if output != "" {
+			fmt.Fprintln(opts.Stdout, output)
+		}
+		if action == "block" {
+			if output != "" {
+				return 0
+			}
+			if reason == "" {
+				reason = sp.defaultBlockReason
+			}
+			// Emit minimal structured block JSON with exit 0: newer Codex
+			// versions treat exit 2 on UserPromptSubmit as "hook failed",
+			// not "hook blocked".
+			fmt.Fprintf(opts.Stdout, "{\"decision\":\"block\",\"reason\":%s}\n", mustJSONString(reason))
+			return 0
+		}
+		return 0
+
+	case styleHookEcho:
+		if output != "" {
+			fmt.Fprintln(opts.Stdout, output)
+		}
+		return 0
+
+	case styleHookEchoDecision:
+		if output != "" {
+			fmt.Fprintln(opts.Stdout, output)
+			if d := decodeDecision(output); d == "deny" || d == "block" {
+				return blockExit
+			}
+		}
+		return 0
+
+	case styleActionStderr:
+		if action == "block" {
+			if reason == "" {
+				reason = sp.defaultBlockReason
+			}
+			fmt.Fprintln(opts.Stderr, reason)
+			return blockExit
+		}
+		return 0
+
+	default:
+		return 0
+	}
+}
+
+// handleMissingToken mirrors defenseclaw_handle_missing_token: log the bypass,
+// then allow (exit 0) by default or block (exit 2) under strict availability.
+// No connector-specific JSON body is emitted on this path.
+func handleMissingToken(opts Options, sp spec, failMode string) int {
+	const reason = "missing gateway token (.token absent and DEFENSECLAW_GATEWAY_TOKEN unset)"
+	logHookFailure(opts, sp, reason, "transport", failMode)
+	if opts.StrictAvailability {
+		fmt.Fprintf(opts.Stderr,
+			"defenseclaw: %s, blocking %s (DEFENSECLAW_STRICT_AVAILABILITY=1)\n", reason, sp.subject)
+		return blockExit
+	}
+	return 0
+}
+
+// handleOversized mirrors the per-connector oversized-payload branch.
+func handleOversized(opts Options, sp spec, failMode string) int {
+	logHookFailure(opts, sp, "stdin body exceeded cap", "transport", failMode)
+	fmt.Fprintf(opts.Stderr, "defenseclaw: %s hook refusing oversized payload\n", sp.connector)
+	if failMode == "closed" {
+		return emit(opts.Stdout, sp.oversizedClosed)
+	}
+	return 0
+}
+
+// failUnreachable mirrors the transport-layer failure path: always allow
+// unless the operator opted into strict availability.
+func failUnreachable(opts Options, sp spec, failMode, reason string) int {
+	logHookFailure(opts, sp, reason, "transport", failMode)
+	if opts.StrictAvailability {
+		fmt.Fprintf(opts.Stderr,
+			"defenseclaw: gateway unreachable, blocking %s (DEFENSECLAW_STRICT_AVAILABILITY=1): %s\n", sp.subject, reason)
+		return emit(opts.Stdout, sp.unreachableStrict)
+	}
+	fmt.Fprintf(opts.Stderr, "defenseclaw: gateway unreachable, allowing %s: %s\n", sp.subject, reason)
+	return 0
+}
+
+// failResponse mirrors the response-layer failure path: honor FAIL_MODE.
+func failResponse(opts Options, sp spec, failMode, reason string) int {
+	logHookFailure(opts, sp, reason, "response", failMode)
+	fmt.Fprintf(opts.Stderr, "defenseclaw: %s hook error: %s\n", sp.errLabel, reason)
+	if failMode == "open" {
+		return 0
+	}
+	return emit(opts.Stdout, sp.responseClosed)
+}
+
+// emit writes a fail-closed JSON body (if any) and returns its exit code.
+func emit(out io.Writer, r failResult) int {
+	if r.body != "" {
+		fmt.Fprintln(out, r.body)
+	}
+	return r.exit
+}
+
+func withDefaults(o Options) Options {
+	if o.Stdin == nil {
+		o.Stdin = os.Stdin
+	}
+	if o.Stdout == nil {
+		o.Stdout = os.Stdout
+	}
+	if o.Stderr == nil {
+		o.Stderr = os.Stderr
+	}
+	if o.MaxBody <= 0 {
+		o.MaxBody = defaultMaxBody
+	}
+	if o.Now == nil {
+		o.Now = time.Now
+	}
+	if o.Home == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			o.Home = filepath.Join(home, ".defenseclaw")
+		}
+	}
+	if o.HookDir == "" {
+		o.HookDir = filepath.Join(o.Home, "hooks")
+	}
+	if o.HTTPClient == nil {
+		o.HTTPClient = defaultHTTPClient()
+	}
+	return o
+}
+
+// defaultHTTPClient matches the .sh `curl --connect-timeout 2 --max-time 10`.
+//
+// CheckRedirect refuses to follow redirects, mirroring `curl` without `-L`
+// (the .sh hooks never passed -L). The gateway hook endpoints never legitimately
+// redirect, so a 3xx is surfaced to doRequest as a non-2xx response (handled by
+// FAIL_MODE) instead of being followed. This keeps the hook from chasing a
+// redirect to a different host/port — which would otherwise widen the SSRF
+// surface and could leak the gateway bearer token to an unintended target if the
+// configured gateway address were ever tampered with.
+func defaultHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{Timeout: 2 * time.Second}).DialContext,
+		},
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+func normalizeFailMode(m string) string {
+	if strings.EqualFold(strings.TrimSpace(m), "closed") {
+		return "closed"
+	}
+	return "open"
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// readTokenFile parses DEFENSECLAW_GATEWAY_TOKEN out of the .token sidecar,
+// which setup writes as `DEFENSECLAW_GATEWAY_TOKEN="<token>"` (Go-quoted). An
+// unreadable/empty file yields an empty token (loopback no-auth path).
+func readTokenFile(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimPrefix(line, "export ")
+		const key = "DEFENSECLAW_GATEWAY_TOKEN="
+		if !strings.HasPrefix(line, key) {
+			continue
+		}
+		val := strings.TrimSpace(line[len(key):])
+		if unq, err := strconv.Unquote(val); err == nil {
+			return unq
+		}
+		return strings.Trim(val, `"'`)
+	}
+	return ""
+}
+
+// rawStringOr returns the JSON string value at key, or def when the key is
+// missing, null, or not a string (matching jq's `.key // "def"`).
+func rawStringOr(m map[string]json.RawMessage, key, def string) string {
+	raw, ok := m[key]
+	if !ok {
+		return def
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return def
+	}
+	if s == "" {
+		return def
+	}
+	return s
+}
+
+// compactField returns the compact JSON of m[field], or "" when the field is
+// missing or JSON null (matching jq's `.field // empty`).
+func compactField(m map[string]json.RawMessage, field string) string {
+	if field == "" {
+		return ""
+	}
+	raw, ok := m[field]
+	if !ok {
+		return ""
+	}
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return ""
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		return trimmed
+	}
+	return buf.String()
+}
+
+// decodeDecision pulls the `decision` string from an already-compact JSON
+// object (the connector's hook_output) for the OpenHands deny/block path.
+func decodeDecision(output string) string {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &m); err != nil {
+		return ""
+	}
+	return rawStringOr(m, "decision", "")
+}
+
+// mustJSONString returns s as a JSON string literal (quoted + escaped).
+func mustJSONString(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return `""`
+	}
+	return string(b)
+}

--- a/internal/gateway/connector/hookexec/hookexec_test.go
+++ b/internal/gateway/connector/hookexec/hookexec_test.go
@@ -1,0 +1,556 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hookexec
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubRT is an injectable http.RoundTripper returning a canned response (or a
+// transport error) and capturing the outbound request for assertions.
+type stubRT struct {
+	status   int
+	body     string
+	err      error
+	gotReq   *http.Request
+	gotBody  []byte
+	requests int
+}
+
+func (s *stubRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.requests++
+	if req.Body != nil {
+		s.gotBody, _ = io.ReadAll(req.Body)
+	}
+	s.gotReq = req
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &http.Response{
+		StatusCode: s.status,
+		Body:       io.NopCloser(strings.NewReader(s.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+type runResult struct {
+	stdout string
+	stderr string
+	code   int
+	rt     *stubRT
+}
+
+// run executes a hook against a stub gateway with a temp Home + .token file.
+func run(t *testing.T, connector string, rt *stubRT, mutate func(*Options)) runResult {
+	t.Helper()
+	home := t.TempDir()
+	hookDir := filepath.Join(home, "hooks")
+	if err := os.MkdirAll(hookDir, 0o700); err != nil {
+		t.Fatalf("mkdir hookDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hookDir, ".token"),
+		[]byte("DEFENSECLAW_GATEWAY_TOKEN=\"tkn\"\n"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	var out, errb bytes.Buffer
+	opts := Options{
+		Connector: connector,
+		Event:     "PreToolUse",
+		APIAddr:   "127.0.0.1:8787",
+		FailMode:  "open",
+		Home:      home,
+		HookDir:   hookDir,
+		Stdin:     strings.NewReader(`{"event":"x"}`),
+		Stdout:    &out,
+		Stderr:    &errb,
+		HTTPClient: &http.Client{Transport: rt},
+		Now:       func() time.Time { return time.Unix(0, 0).UTC() },
+	}
+	if mutate != nil {
+		mutate(&opts)
+	}
+	code := Run(context.Background(), opts)
+	return runResult{stdout: out.String(), stderr: errb.String(), code: code, rt: rt}
+}
+
+func ok(body string) *stubRT { return &stubRT{status: 200, body: body} }
+
+// --- Allow / block decision golden tests (the agent-facing contract) ---
+
+func TestDecisionGolden(t *testing.T) {
+	tests := []struct {
+		name       string
+		connector  string
+		respBody   string
+		wantStdout string
+		wantStderr string // substring; "" means stderr must be empty
+		wantCode   int
+	}{
+		{
+			name:      "claudecode allow",
+			connector: "claudecode",
+			respBody:  `{"action":"allow"}`,
+			wantCode:  0,
+		},
+		{
+			name:       "claudecode block with structured output exits 0",
+			connector:  "claudecode",
+			respBody:   `{"action":"block","reason":"matched: secret","claude_code_output":{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"}}}`,
+			wantStdout: `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny"}}` + "\n",
+			wantCode:   0,
+		},
+		{
+			name:       "claudecode block without output exits 2 with reason on stderr",
+			connector:  "claudecode",
+			respBody:   `{"action":"block","reason":"matched: secret"}`,
+			wantStderr: "matched: secret",
+			wantCode:   2,
+		},
+		{
+			name:       "claudecode block without output or reason uses default",
+			connector:  "claudecode",
+			respBody:   `{"action":"block"}`,
+			wantStderr: "Blocked by DefenseClaw Claude Code policy.",
+			wantCode:   2,
+		},
+		{
+			name:       "codex block with output exits 0",
+			connector:  "codex",
+			respBody:   `{"action":"block","codex_output":{"hookSpecificOutput":{"permissionDecision":"deny"}}}`,
+			wantStdout: `{"hookSpecificOutput":{"permissionDecision":"deny"}}` + "\n",
+			wantCode:   0,
+		},
+		{
+			name:       "codex block without output emits inline json exit 0",
+			connector:  "codex",
+			respBody:   `{"action":"block","reason":"matched: secret"}`,
+			wantStdout: `{"decision":"block","reason":"matched: secret"}` + "\n",
+			wantCode:   0,
+		},
+		{
+			name:       "codex block without output or reason uses default exit 0",
+			connector:  "codex",
+			respBody:   `{"action":"block"}`,
+			wantStdout: `{"decision":"block","reason":"Blocked by DefenseClaw Codex policy."}` + "\n",
+			wantCode:   0,
+		},
+		{
+			name:       "cursor echoes hook_output exit 0",
+			connector:  "cursor",
+			respBody:   `{"hook_output":{"continue":true,"permission":"deny","user_message":"no"}}`,
+			wantStdout: `{"continue":true,"permission":"deny","user_message":"no"}` + "\n",
+			wantCode:   0,
+		},
+		{
+			name:       "copilot echoes hook_output exit 0",
+			connector:  "copilot",
+			respBody:   `{"hook_output":{"permissionDecision":"deny"}}`,
+			wantStdout: `{"permissionDecision":"deny"}` + "\n",
+			wantCode:   0,
+		},
+		{
+			name:       "openhands deny in hook_output exits 2",
+			connector:  "openhands",
+			respBody:   `{"hook_output":{"decision":"deny","reason":"no"}}`,
+			wantStdout: `{"decision":"deny","reason":"no"}` + "\n",
+			wantCode:   2,
+		},
+		{
+			name:       "openhands allow in hook_output exits 0",
+			connector:  "openhands",
+			respBody:   `{"hook_output":{"decision":"allow"}}`,
+			wantStdout: `{"decision":"allow"}` + "\n",
+			wantCode:   0,
+		},
+		{
+			name:       "windsurf block writes stderr exit 2 no stdout",
+			connector:  "windsurf",
+			respBody:   `{"action":"block","reason":"nope"}`,
+			wantStderr: "nope",
+			wantCode:   2,
+		},
+		{
+			name:      "windsurf allow exit 0",
+			connector: "windsurf",
+			respBody:  `{"action":"allow"}`,
+			wantCode:  0,
+		},
+		{
+			name:      "hermes allow with no hook_output exit 0",
+			connector: "hermes",
+			respBody:  `{"action":"allow"}`,
+			wantCode:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := run(t, tt.connector, ok(tt.respBody), nil)
+			if r.code != tt.wantCode {
+				t.Errorf("exit code = %d, want %d (stderr=%q)", r.code, tt.wantCode, r.stderr)
+			}
+			if r.stdout != tt.wantStdout {
+				t.Errorf("stdout = %q, want %q", r.stdout, tt.wantStdout)
+			}
+			if tt.wantStderr == "" {
+				if r.stderr != "" {
+					t.Errorf("stderr = %q, want empty", r.stderr)
+				}
+			} else if !strings.Contains(r.stderr, tt.wantStderr) {
+				t.Errorf("stderr = %q, want substring %q", r.stderr, tt.wantStderr)
+			}
+		})
+	}
+}
+
+// TestCodexUserPromptSubmitBlockSchema confirms the contract the .sh hook calls
+// out explicitly: on a UserPromptSubmit block, Codex must receive the gateway's
+// structured codex_output (which carries permissionDecision="deny") on stdout
+// with exit 0 — never exit 2, which newer Codex builds treat as "hook failed"
+// (fail-open) rather than "hook blocked". When the gateway omits codex_output,
+// the responder synthesizes the minimal {"decision":"block"} JSON, still exit 0.
+func TestCodexUserPromptSubmitBlockSchema(t *testing.T) {
+	t.Run("structured codex_output passthrough exit 0", func(t *testing.T) {
+		body := `{"action":"block","reason":"matched: secret","codex_output":{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","permissionDecision":"deny","permissionDecisionReason":"matched: secret"}}}`
+		r := run(t, "codex", ok(body), func(o *Options) { o.Event = "UserPromptSubmit" })
+		want := `{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","permissionDecision":"deny","permissionDecisionReason":"matched: secret"}}` + "\n"
+		if r.code != 0 {
+			t.Fatalf("exit code = %d, want 0 (exit 2 fails open on UserPromptSubmit)", r.code)
+		}
+		if r.stdout != want {
+			t.Errorf("stdout = %q, want %q", r.stdout, want)
+		}
+		if r.stderr != "" {
+			t.Errorf("stderr = %q, want empty (mixing stdout+stderr is a protocol violation)", r.stderr)
+		}
+	})
+
+	t.Run("no codex_output falls back to inline decision exit 0", func(t *testing.T) {
+		r := run(t, "codex", ok(`{"action":"block","reason":"matched: secret"}`), func(o *Options) { o.Event = "UserPromptSubmit" })
+		if r.code != 0 {
+			t.Fatalf("exit code = %d, want 0", r.code)
+		}
+		if r.stdout != `{"decision":"block","reason":"matched: secret"}`+"\n" {
+			t.Errorf("stdout = %q", r.stdout)
+		}
+	})
+}
+
+// --- Oversized payload: fail-open allows, fail-closed emits per-connector ---
+
+func TestOversizedPayload(t *testing.T) {
+	big := strings.Repeat("a", 64)
+	t.Run("fail open allows, never calls gateway", func(t *testing.T) {
+		rt := ok(`{"action":"allow"}`)
+		r := run(t, "claudecode", rt, func(o *Options) {
+			o.MaxBody = 8
+			o.Stdin = strings.NewReader(big)
+		})
+		if r.code != 0 {
+			t.Fatalf("code = %d, want 0", r.code)
+		}
+		if rt.requests != 0 {
+			t.Fatalf("gateway called %d times on oversized payload, want 0", rt.requests)
+		}
+	})
+
+	cases := map[string]struct {
+		stdout string
+		code   int
+	}{
+		"claudecode": {stdout: `{"decision":"block","reason":"DefenseClaw hook payload too large"}` + "\n", code: 2},
+		"codex":      {stdout: `{"decision":"block","reason":"DefenseClaw hook payload too large"}` + "\n", code: 2},
+		"openhands":  {stdout: `{"decision":"deny","reason":"DefenseClaw hook payload too large"}` + "\n", code: 2},
+		"cursor":     {stdout: cursorDeny("DefenseClaw hook payload too large") + "\n", code: 2},
+		"copilot":    {stdout: "", code: 2},
+		"geminicli":  {stdout: "", code: 2},
+		"hermes":     {stdout: "", code: 2},
+		"windsurf":   {stdout: "", code: 2},
+	}
+	for connector, want := range cases {
+		t.Run("fail closed "+connector, func(t *testing.T) {
+			r := run(t, connector, ok(`{"action":"allow"}`), func(o *Options) {
+				o.FailMode = "closed"
+				o.MaxBody = 8
+				o.Stdin = strings.NewReader(big)
+			})
+			if r.code != want.code {
+				t.Errorf("code = %d, want %d", r.code, want.code)
+			}
+			if r.stdout != want.stdout {
+				t.Errorf("stdout = %q, want %q", r.stdout, want.stdout)
+			}
+		})
+	}
+}
+
+// --- Transport failure (unreachable + 5xx): fail-open by default ---
+
+func TestUnreachable(t *testing.T) {
+	t.Run("default fail open", func(t *testing.T) {
+		r := run(t, "claudecode", &stubRT{err: errors.New("dial tcp: refused")}, nil)
+		if r.code != 0 {
+			t.Fatalf("code = %d, want 0 (DefenseClaw outage must not brick agent)", r.code)
+		}
+		if !strings.Contains(r.stderr, "allowing claude-code tool") {
+			t.Errorf("stderr = %q, want allow notice", r.stderr)
+		}
+	})
+
+	t.Run("strict availability fails closed", func(t *testing.T) {
+		r := run(t, "openhands", &stubRT{err: errors.New("refused")}, func(o *Options) {
+			o.StrictAvailability = true
+		})
+		if r.code != 2 {
+			t.Fatalf("code = %d, want 2", r.code)
+		}
+		if r.stdout != `{"decision":"deny","reason":"DefenseClaw hook failed closed"}`+"\n" {
+			t.Errorf("stdout = %q", r.stdout)
+		}
+	})
+
+	t.Run("5xx treated as transport", func(t *testing.T) {
+		r := run(t, "codex", &stubRT{status: 503, body: "boom"}, func(o *Options) {
+			o.StrictAvailability = true
+		})
+		if r.code != 2 {
+			t.Fatalf("code = %d, want 2", r.code)
+		}
+	})
+}
+
+// --- Response-layer failure (4xx / bad JSON): honors FAIL_MODE ---
+
+func TestResponseFailure(t *testing.T) {
+	t.Run("4xx fail open allows", func(t *testing.T) {
+		r := run(t, "claudecode", &stubRT{status: 401, body: "unauthorized"}, nil)
+		if r.code != 0 {
+			t.Fatalf("code = %d, want 0", r.code)
+		}
+	})
+
+	t.Run("4xx fail closed blocks per connector", func(t *testing.T) {
+		r := run(t, "cursor", &stubRT{status: 401, body: "unauthorized"}, func(o *Options) {
+			o.FailMode = "closed"
+		})
+		// cursor's response-closed path emits the deny body but exits 0.
+		if r.code != 0 {
+			t.Fatalf("code = %d, want 0", r.code)
+		}
+		if r.stdout != cursorDeny("DefenseClaw hook failed closed")+"\n" {
+			t.Errorf("stdout = %q", r.stdout)
+		}
+	})
+
+	t.Run("invalid JSON body is a response failure", func(t *testing.T) {
+		r := run(t, "codex", ok("this is not json"), func(o *Options) {
+			o.FailMode = "closed"
+		})
+		if r.code != 2 {
+			t.Fatalf("code = %d, want 2", r.code)
+		}
+		if !strings.Contains(r.stderr, "invalid JSON response") {
+			t.Errorf("stderr = %q, want invalid JSON", r.stderr)
+		}
+	})
+}
+
+// --- Missing token ---
+
+func TestMissingToken(t *testing.T) {
+	noToken := func(o *Options) {
+		o.Token = ""
+		o.HookDir = filepath.Join(o.Home, "empty") // no .token here
+	}
+
+	t.Run("default allows without calling gateway", func(t *testing.T) {
+		rt := ok(`{"action":"allow"}`)
+		r := run(t, "claudecode", rt, noToken)
+		if r.code != 0 {
+			t.Fatalf("code = %d, want 0", r.code)
+		}
+		if rt.requests != 0 {
+			t.Fatalf("gateway called %d times, want 0", rt.requests)
+		}
+	})
+
+	t.Run("strict availability blocks", func(t *testing.T) {
+		r := run(t, "claudecode", ok(`{"action":"allow"}`), func(o *Options) {
+			noToken(o)
+			o.StrictAvailability = true
+		})
+		if r.code != 2 {
+			t.Fatalf("code = %d, want 2", r.code)
+		}
+		if !strings.Contains(r.stderr, "missing gateway token") {
+			t.Errorf("stderr = %q", r.stderr)
+		}
+	})
+}
+
+// --- Request wiring: endpoint, method, auth, trace, body ---
+
+func TestRequestWiring(t *testing.T) {
+	rt := ok(`{"action":"allow"}`)
+	run(t, "claudecode", rt, func(o *Options) {
+		o.TraceParent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+		o.TraceState = "vendor=value"
+	})
+	if rt.gotReq == nil {
+		t.Fatal("no request captured")
+	}
+	if rt.gotReq.Method != http.MethodPost {
+		t.Errorf("method = %s, want POST", rt.gotReq.Method)
+	}
+	if got := rt.gotReq.URL.String(); got != "http://127.0.0.1:8787/api/v1/claude-code/hook" {
+		t.Errorf("url = %s", got)
+	}
+	if got := rt.gotReq.Header.Get("Authorization"); got != "Bearer tkn" {
+		t.Errorf("authorization = %q, want Bearer tkn", got)
+	}
+	if got := rt.gotReq.Header.Get("X-DefenseClaw-Client"); got != "claude-code-hook/1.0" {
+		t.Errorf("client header = %q", got)
+	}
+	if got := rt.gotReq.Header.Get("traceparent"); got == "" {
+		t.Error("valid traceparent not forwarded")
+	}
+	if got := rt.gotReq.Header.Get("tracestate"); got != "vendor=value" {
+		t.Errorf("tracestate = %q", got)
+	}
+	if string(rt.gotBody) != `{"event":"x"}` {
+		t.Errorf("body = %q", string(rt.gotBody))
+	}
+}
+
+func TestEnvTokenTakesPrecedence(t *testing.T) {
+	rt := ok(`{"action":"allow"}`)
+	run(t, "codex", rt, func(o *Options) { o.Token = "env-wins" })
+	if got := rt.gotReq.Header.Get("Authorization"); got != "Bearer env-wins" {
+		t.Errorf("authorization = %q, want env token to win over .token file", got)
+	}
+}
+
+func TestInvalidTraceparentDropped(t *testing.T) {
+	rt := ok(`{"action":"allow"}`)
+	run(t, "codex", rt, func(o *Options) { o.TraceParent = "not-a-valid-traceparent" })
+	if got := rt.gotReq.Header.Get("traceparent"); got != "" {
+		t.Errorf("invalid traceparent forwarded: %q", got)
+	}
+}
+
+// --- DEFENSECLAW_HOME guard ---
+
+func TestDisabledHomeIsNoop(t *testing.T) {
+	rt := ok(`{"action":"block","reason":"x"}`)
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".disabled"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out, errb bytes.Buffer
+	code := Run(context.Background(), Options{
+		Connector: "claudecode", APIAddr: "127.0.0.1:1", Home: home,
+		HookDir: filepath.Join(home, "hooks"), Token: "t",
+		Stdin: strings.NewReader("{}"), Stdout: &out, Stderr: &errb,
+		HTTPClient: &http.Client{Transport: rt},
+	})
+	if code != 0 {
+		t.Fatalf("code = %d, want 0 when .disabled present", code)
+	}
+	if rt.requests != 0 {
+		t.Fatalf("gateway called %d times despite .disabled", rt.requests)
+	}
+}
+
+func TestUnknownConnector(t *testing.T) {
+	var out, errb bytes.Buffer
+	home := t.TempDir()
+	code := Run(context.Background(), Options{
+		Connector: "nope", Home: home, HookDir: home, Token: "t",
+		Stdin: strings.NewReader("{}"), Stdout: &out, Stderr: &errb,
+	})
+	if code != 2 {
+		t.Fatalf("code = %d, want 2 for unknown connector", code)
+	}
+}
+
+func TestReadTokenFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".token")
+	if err := os.WriteFile(path, []byte(`DEFENSECLAW_GATEWAY_TOKEN="abc123"`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := readTokenFile(path); got != "abc123" {
+		t.Errorf("token = %q, want abc123", got)
+	}
+}
+
+func TestSupportedConnectorsSorted(t *testing.T) {
+	got := SupportedConnectors()
+	want := []string{"claudecode", "codex", "copilot", "cursor", "geminicli", "hermes", "openhands", "windsurf"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+// TestDefaultHTTPClientDoesNotFollowRedirects pins the no-follow-redirect
+// contract: the native hook must behave like `curl` without `-L` (the .sh
+// hooks never passed -L). A gateway hook endpoint never legitimately
+// redirects, so following a 3xx to a different host/port would needlessly
+// widen the SSRF surface and risk forwarding the gateway bearer token to an
+// unintended target. The redirect target sets a sentinel header so a
+// regression (client follows the redirect) is detectable.
+func TestDefaultHTTPClientDoesNotFollowRedirects(t *testing.T) {
+	followed := false
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		followed = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Redirect(w, &http.Request{}, target.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	resp, err := defaultHTTPClient().Get(redirector.URL)
+	if err != nil {
+		t.Fatalf("Get returned error (redirect should not be followed, not error): %v", err)
+	}
+	defer resp.Body.Close()
+
+	if followed {
+		t.Fatal("client followed redirect to a second host; hook must not follow redirects")
+	}
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want 302 (redirect surfaced, not followed)", resp.StatusCode)
+	}
+}

--- a/internal/gateway/connector/hookexec/hookexec_test.go
+++ b/internal/gateway/connector/hookexec/hookexec_test.go
@@ -78,17 +78,17 @@ func run(t *testing.T, connector string, rt *stubRT, mutate func(*Options)) runR
 	}
 	var out, errb bytes.Buffer
 	opts := Options{
-		Connector: connector,
-		Event:     "PreToolUse",
-		APIAddr:   "127.0.0.1:8787",
-		FailMode:  "open",
-		Home:      home,
-		HookDir:   hookDir,
-		Stdin:     strings.NewReader(`{"event":"x"}`),
-		Stdout:    &out,
-		Stderr:    &errb,
+		Connector:  connector,
+		Event:      "PreToolUse",
+		APIAddr:    "127.0.0.1:8787",
+		FailMode:   "open",
+		Home:       home,
+		HookDir:    hookDir,
+		Stdin:      strings.NewReader(`{"event":"x"}`),
+		Stdout:     &out,
+		Stderr:     &errb,
 		HTTPClient: &http.Client{Transport: rt},
-		Now:       func() time.Time { return time.Unix(0, 0).UTC() },
+		Now:        func() time.Time { return time.Unix(0, 0).UTC() },
 	}
 	if mutate != nil {
 		mutate(&opts)

--- a/internal/gateway/connector/hookexec/spec.go
+++ b/internal/gateway/connector/hookexec/spec.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hookexec
+
+import "sort"
+
+// decisionStyle selects how a connector shapes a 2xx gateway response into
+// agent-native stdout + exit code. Each value corresponds to one of the
+// distinct .sh hook tails under internal/gateway/connector/hooks.
+type decisionStyle int
+
+const (
+	// styleClaudeCode: echo claude_code_output; on action=block, exit 0 if
+	// output present (JSON carries the deny) else write reason to stderr +
+	// exit 2. (claude-code-hook.sh)
+	styleClaudeCode decisionStyle = iota
+	// styleCodex: echo codex_output; on action=block, exit 0 if output
+	// present else emit minimal {"decision":"block",...} on stdout + exit 0.
+	// (codex-hook.sh)
+	styleCodex
+	// styleHookEcho: echo hook_output and exit 0 — the gateway already
+	// encoded the decision in the agent-native hook_output. (cursor / copilot
+	// / geminicli / hermes)
+	styleHookEcho
+	// styleHookEchoDecision: echo hook_output, then exit 2 if its
+	// `decision` is deny/block. (openhands-hook.sh)
+	styleHookEchoDecision
+	// styleActionStderr: no stdout echo; on action=block write reason to
+	// stderr + exit 2. (windsurf-hook.sh)
+	styleActionStderr
+)
+
+// failResult is a fail-closed outcome: an optional connector-native JSON body
+// printed to stdout and the exit code to return.
+type failResult struct {
+	body string
+	exit int
+}
+
+// spec is the immutable per-connector contract mirrored from the .sh hooks.
+type spec struct {
+	connector   string // logical name + oversized stderr label ("claudecode")
+	hookName    string // X-DefenseClaw-Client + log hook name ("claude-code-hook")
+	errLabel    string // fail_response stderr label ("claude-code")
+	subject     string // unreachable stderr subject ("claude-code tool")
+	endpoint    string // gateway path ("/api/v1/claude-code/hook")
+	outputField string // response field echoed to stdout ("claude_code_output")
+	style       decisionStyle
+
+	defaultBlockReason string // used when action=block but reason is empty
+
+	oversizedClosed   failResult // oversized payload + FAIL_MODE=closed
+	unreachableStrict failResult // transport failure + STRICT_AVAILABILITY=1
+	responseClosed    failResult // response-layer failure + FAIL_MODE=closed
+}
+
+const (
+	tooLarge     = "DefenseClaw hook payload too large"
+	failedClosed = "DefenseClaw hook failed closed"
+)
+
+// specs is the single source of truth for the Go hook contract. Every entry
+// here is pinned by a golden test against the corresponding .sh hook.
+var specs = map[string]spec{
+	"claudecode": {
+		connector: "claudecode", hookName: "claude-code-hook", errLabel: "claude-code",
+		subject: "claude-code tool", endpoint: "/api/v1/claude-code/hook",
+		outputField: "claude_code_output", style: styleClaudeCode,
+		defaultBlockReason: "Blocked by DefenseClaw Claude Code policy.",
+		oversizedClosed:    failResult{body: `{"decision":"block","reason":"` + tooLarge + `"}`, exit: blockExit},
+		unreachableStrict:  failResult{exit: blockExit},
+		responseClosed:     failResult{exit: blockExit},
+	},
+	"codex": {
+		connector: "codex", hookName: "codex-hook", errLabel: "codex",
+		subject: "codex tool", endpoint: "/api/v1/codex/hook",
+		outputField: "codex_output", style: styleCodex,
+		defaultBlockReason: "Blocked by DefenseClaw Codex policy.",
+		oversizedClosed:    failResult{body: `{"decision":"block","reason":"` + tooLarge + `"}`, exit: blockExit},
+		unreachableStrict:  failResult{exit: blockExit},
+		responseClosed:     failResult{exit: blockExit},
+	},
+	"cursor": {
+		connector: "cursor", hookName: "cursor-hook", errLabel: "cursor",
+		subject: "cursor tool", endpoint: "/api/v1/cursor/hook",
+		outputField: "hook_output", style: styleHookEcho,
+		oversizedClosed:   failResult{body: cursorDeny(tooLarge), exit: blockExit},
+		unreachableStrict: failResult{body: cursorDeny(failedClosed), exit: blockExit},
+		responseClosed:    failResult{body: cursorDeny(failedClosed), exit: 0},
+	},
+	"copilot": {
+		connector: "copilot", hookName: "copilot-hook", errLabel: "copilot",
+		subject: "copilot tool", endpoint: "/api/v1/copilot/hook",
+		outputField: "hook_output", style: styleHookEcho,
+		oversizedClosed:   failResult{exit: blockExit},
+		unreachableStrict: failResult{body: `{"permissionDecision":"deny","permissionDecisionReason":"` + failedClosed + `"}`, exit: blockExit},
+		responseClosed:    failResult{body: `{"permissionDecision":"deny","permissionDecisionReason":"` + failedClosed + `"}`, exit: 0},
+	},
+	"geminicli": {
+		connector: "geminicli", hookName: "geminicli-hook", errLabel: "geminicli",
+		subject: "geminicli tool", endpoint: "/api/v1/geminicli/hook",
+		outputField: "hook_output", style: styleHookEcho,
+		oversizedClosed:   failResult{exit: blockExit},
+		unreachableStrict: failResult{exit: blockExit},
+		responseClosed:    failResult{exit: blockExit},
+	},
+	"hermes": {
+		connector: "hermes", hookName: "hermes-hook", errLabel: "hermes",
+		subject: "hermes tool", endpoint: "/api/v1/hermes/hook",
+		outputField: "hook_output", style: styleHookEcho,
+		oversizedClosed:   failResult{exit: blockExit},
+		unreachableStrict: failResult{body: `{"action":"block","message":"` + failedClosed + `"}`, exit: blockExit},
+		responseClosed:    failResult{body: `{"action":"block","message":"` + failedClosed + `"}`, exit: 0},
+	},
+	"windsurf": {
+		connector: "windsurf", hookName: "windsurf-hook", errLabel: "windsurf",
+		subject: "windsurf tool", endpoint: "/api/v1/windsurf/hook",
+		outputField: "", style: styleActionStderr,
+		defaultBlockReason: "DefenseClaw blocked this Cascade action.",
+		oversizedClosed:    failResult{exit: blockExit},
+		unreachableStrict:  failResult{exit: blockExit},
+		responseClosed:     failResult{exit: blockExit},
+	},
+	"openhands": {
+		connector: "openhands", hookName: "openhands-hook", errLabel: "openhands",
+		subject: "openhands hook", endpoint: "/api/v1/openhands/hook",
+		outputField: "hook_output", style: styleHookEchoDecision,
+		oversizedClosed:   failResult{body: `{"decision":"deny","reason":"` + tooLarge + `"}`, exit: blockExit},
+		unreachableStrict: failResult{body: `{"decision":"deny","reason":"` + failedClosed + `"}`, exit: blockExit},
+		responseClosed:    failResult{body: `{"decision":"deny","reason":"` + failedClosed + `"}`, exit: blockExit},
+	},
+}
+
+func cursorDeny(msg string) string {
+	return `{"continue":true,"permission":"deny","user_message":"` + msg + `","agent_message":"` + msg + `"}`
+}
+
+func specFor(connector string) (spec, bool) {
+	s, ok := specs[connector]
+	return s, ok
+}
+
+// SupportedConnectors returns the sorted list of connectors the native Go hook
+// runner understands. Used by the CLI to validate --connector and by parity
+// tests to keep this table in sync with the .sh hooks and the registry.
+func SupportedConnectors() []string {
+	names := make([]string, 0, len(specs))
+	for name := range specs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/gateway/connector/hooks/_hardening.sh
+++ b/internal/gateway/connector/hooks/_hardening.sh
@@ -27,20 +27,17 @@ DEFENSECLAW_BAKED_HOOK_PATH=""
 #        (no helper signatures changed), so a downgrade to v3 only
 #        loses the stale-dir sweep — older hook scripts that source
 #        either version keep working unmodified.
-#   v6 — defenseclaw_harden_env now preserves access to curl and jq even
-#        when the locked-down PATH omits their install directory. Before
-#        locking, the function snapshots the paths of curl and jq
-#        (command -v); after locking it adds each tool's directory back
-#        only if the tool is no longer reachable on the hardened PATH.
-#        This fixes "gateway unreachable" errors on Windows Git Bash,
-#        where curl lives in /mingw64/bin and the [ -d /mingw64/bin ]
-#        guard can silently fail for subprocess-spawned bash instances.
-#        Also adds the _dc_jq shim: real jq when available (unchanged on
+#   v6 — adds the _dc_jq shim: real jq when available (unchanged on
 #        Mac/Linux), python3 fallback for object + string fields, then a
-#        pure-shell string-only last resort.  jq is not bundled with Git
-#        for Windows so the shim makes block decisions parse-able without
-#        requiring a separate jq install.  No helper signatures changed;
+#        pure-shell string-only last resort.  This makes block decisions
+#        parse-able on hosts without jq.  No helper signatures changed;
 #        hook scripts just replace bare `jq` calls with `_dc_jq`.
+#        NOTE: an earlier iteration of v6 also restored curl/jq directories
+#        from the pre-lockdown PATH after hardening. That was removed because
+#        the pre-lockdown PATH is agent-controlled and restoring one of its
+#        directories could re-admit an agent-planted binary. Windows no
+#        longer uses these bash hooks (it runs the hook natively in the Go
+#        binary), so the Git Bash /mingw64 workaround is no longer needed.
 #   v5 — adds defenseclaw_read_stdin_capped, a bounded replacement for
 #        the historical PAYLOAD=$(cat) idiom. The unbounded read pulled
 #        the entire agent payload into a shell variable BEFORE the
@@ -134,46 +131,26 @@ defenseclaw_harden_env() {
         GIT_TRACE GIT_TRACE_PACKET GIT_TRACE_PACK_ACCESS \
         GIT_SSH GIT_SSH_COMMAND
 
-  # Snapshot locations of tools we require BEFORE locking PATH.  If the
-  # hardened PATH omits their directory (common on Windows Git Bash where
-  # curl lives in /mingw64/bin and the [ -d /mingw64/bin ] guard can
-  # silently fail for subprocess-spawned bash), we restore only those
-  # specific directories afterwards — preserving the security goal (no
-  # agent-injected bins) while keeping curl and jq reachable.
-  local _dc_pre_curl _dc_pre_jq
-  _dc_pre_curl="$(command -v curl 2>/dev/null || true)"
-  _dc_pre_jq="$(command -v jq 2>/dev/null || true)"
-
   # Lock down PATH — keep only standard system bins unless setup baked
   # a literal DEFENSECLAW_BAKED_HOOK_PATH into this helper file. Hooks
   # inherit the agent environment, so runtime DEFENSECLAW_HOOK_PATH (or
   # a companion "trusted" flag) is intentionally ignored; otherwise a
   # compromised agent could prepend trojan curl/jq/head.
+  #
+  # We deliberately do NOT restore any directory derived from the
+  # pre-lockdown PATH. That PATH is agent-controlled, so adding one of its
+  # directories back (to recover a curl/jq not on the hardened PATH) could
+  # re-admit an agent-planted binary and defeat this lockdown. Tools that
+  # are missing from the standard dirs are handled by the _dc_jq parsing
+  # fallback below, not by widening PATH. On Windows the hook runs natively
+  # in the DefenseClaw Go binary (no bash), so the previous Git Bash
+  # /mingw64 special-casing is unnecessary here.
   unset DEFENSECLAW_HOOK_PATH DEFENSECLAW_HOOK_PATH_TRUSTED
   if [ -n "$DEFENSECLAW_BAKED_HOOK_PATH" ]; then
     export PATH="$DEFENSECLAW_BAKED_HOOK_PATH"
-  elif [ -d /mingw64/bin ]; then
-    # Git for Windows installs curl.exe under /mingw64/bin. Keep the Unix
-    # system dirs too so sed/head/tail remain available.
-    export PATH="/mingw64/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
   else
     export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
   fi
-
-  # After lockdown: if curl or jq vanished, add back only their directory.
-  # _dc_restore_tool_dir is a local helper — defined here, used immediately.
-  _dc_restore_tool_dir() {
-    local _p="$1"
-    [ -z "$_p" ] && return 0
-    local _d
-    _d="$(dirname "$_p" 2>/dev/null)"
-    case ":$PATH:" in
-      *":$_d:"*) ;;
-      *) export PATH="$PATH:$_d" ;;
-    esac
-  }
-  command -v curl >/dev/null 2>&1 || _dc_restore_tool_dir "$_dc_pre_curl"
-  command -v jq   >/dev/null 2>&1 || _dc_restore_tool_dir "$_dc_pre_jq"
 
   # Keep the locale predictable so jq output / sed regex behavior
   # don't shift under the agent's locale.

--- a/internal/gateway/connector/hooks/_hardening.sh
+++ b/internal/gateway/connector/hooks/_hardening.sh
@@ -27,6 +27,20 @@ DEFENSECLAW_BAKED_HOOK_PATH=""
 #        (no helper signatures changed), so a downgrade to v3 only
 #        loses the stale-dir sweep — older hook scripts that source
 #        either version keep working unmodified.
+#   v6 — defenseclaw_harden_env now preserves access to curl and jq even
+#        when the locked-down PATH omits their install directory. Before
+#        locking, the function snapshots the paths of curl and jq
+#        (command -v); after locking it adds each tool's directory back
+#        only if the tool is no longer reachable on the hardened PATH.
+#        This fixes "gateway unreachable" errors on Windows Git Bash,
+#        where curl lives in /mingw64/bin and the [ -d /mingw64/bin ]
+#        guard can silently fail for subprocess-spawned bash instances.
+#        Also adds the _dc_jq shim: real jq when available (unchanged on
+#        Mac/Linux), python3 fallback for object + string fields, then a
+#        pure-shell string-only last resort.  jq is not bundled with Git
+#        for Windows so the shim makes block decisions parse-able without
+#        requiring a separate jq install.  No helper signatures changed;
+#        hook scripts just replace bare `jq` calls with `_dc_jq`.
 #   v5 — adds defenseclaw_read_stdin_capped, a bounded replacement for
 #        the historical PAYLOAD=$(cat) idiom. The unbounded read pulled
 #        the entire agent payload into a shell variable BEFORE the
@@ -75,6 +89,15 @@ DEFENSECLAW_BAKED_HOOK_PATH=""
 # beyond setting env / ulimit. They MUST NOT call out to the agent or
 # the gateway.
 
+# Windows compatibility: some agent runtimes (e.g. Codex on Windows) do
+# not set HOME when spawning hook subprocesses. Without this, `set -u`
+# causes an immediate "unbound variable" exit 1. Fall back to USERPROFILE
+# (standard on Windows) or ~ expansion.
+if [ -z "${HOME:-}" ]; then
+  HOME="${USERPROFILE:-$(cd ~ 2>/dev/null && pwd)}"
+  export HOME
+fi
+
 # Resource limits — bound the hook so a stuck regex / hostile input
 # can't wedge the agent. Plan F16 ask: CPU 5s, virt mem 512MiB, fds 32.
 # Use ulimit -S (soft) so the hook doesn't try to exceed kernel maxima
@@ -111,6 +134,16 @@ defenseclaw_harden_env() {
         GIT_TRACE GIT_TRACE_PACKET GIT_TRACE_PACK_ACCESS \
         GIT_SSH GIT_SSH_COMMAND
 
+  # Snapshot locations of tools we require BEFORE locking PATH.  If the
+  # hardened PATH omits their directory (common on Windows Git Bash where
+  # curl lives in /mingw64/bin and the [ -d /mingw64/bin ] guard can
+  # silently fail for subprocess-spawned bash), we restore only those
+  # specific directories afterwards — preserving the security goal (no
+  # agent-injected bins) while keeping curl and jq reachable.
+  local _dc_pre_curl _dc_pre_jq
+  _dc_pre_curl="$(command -v curl 2>/dev/null || true)"
+  _dc_pre_jq="$(command -v jq 2>/dev/null || true)"
+
   # Lock down PATH — keep only standard system bins unless setup baked
   # a literal DEFENSECLAW_BAKED_HOOK_PATH into this helper file. Hooks
   # inherit the agent environment, so runtime DEFENSECLAW_HOOK_PATH (or
@@ -119,9 +152,28 @@ defenseclaw_harden_env() {
   unset DEFENSECLAW_HOOK_PATH DEFENSECLAW_HOOK_PATH_TRUSTED
   if [ -n "$DEFENSECLAW_BAKED_HOOK_PATH" ]; then
     export PATH="$DEFENSECLAW_BAKED_HOOK_PATH"
+  elif [ -d /mingw64/bin ]; then
+    # Git for Windows installs curl.exe under /mingw64/bin. Keep the Unix
+    # system dirs too so sed/head/tail remain available.
+    export PATH="/mingw64/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
   else
     export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
   fi
+
+  # After lockdown: if curl or jq vanished, add back only their directory.
+  # _dc_restore_tool_dir is a local helper — defined here, used immediately.
+  _dc_restore_tool_dir() {
+    local _p="$1"
+    [ -z "$_p" ] && return 0
+    local _d
+    _d="$(dirname "$_p" 2>/dev/null)"
+    case ":$PATH:" in
+      *":$_d:"*) ;;
+      *) export PATH="$PATH:$_d" ;;
+    esac
+  }
+  command -v curl >/dev/null 2>&1 || _dc_restore_tool_dir "$_dc_pre_curl"
+  command -v jq   >/dev/null 2>&1 || _dc_restore_tool_dir "$_dc_pre_jq"
 
   # Keep the locale predictable so jq output / sed regex behavior
   # don't shift under the agent's locale.
@@ -221,6 +273,96 @@ defenseclaw_json_escape() {
     printf '%s' "${1:-}" | tr '\000-\037' ' ' | sed 's/\\/\\\\/g; s/"/\\"/g'
   } 2>/dev/null || printf unavailable
   return 0
+}
+
+# defenseclaw_json_string_field extracts a simple top-level JSON string field.
+# It is intentionally small: hook block/allow parsing only needs fields like
+# "action" and "reason" when jq is unavailable (common in Git Bash on Windows).
+defenseclaw_json_string_field() {
+  local json="${1:-}"
+  local field="${2:-}"
+  if [ -z "$field" ]; then
+    return 1
+  fi
+  printf '%s' "$json" | tr '\n\r' '  ' | sed -nE \
+    's/.*"'"$field"'"[[:space:]]*:[[:space:]]*"(([^"\\]|\\.)*)".*/\1/p' |
+    sed 's/\\"/"/g; s/\\\\/\\/g; s/\\n/ /g; s/\\r/ /g; s/\\t/ /g'
+}
+
+# _dc_jq is a drop-in shim for jq covering the small subset of filters
+# used by DefenseClaw hook scripts.  When the real jq binary is present
+# (all Unix installs; some Windows installs) it is used unchanged.
+# When jq is absent the shim tries python3 (handles both string and
+# object fields such as claude_code_output), then falls back to
+# defenseclaw_json_string_field for string-only fields.  Object fields
+# (e.g. claude_code_output) return empty from the string-only fallback;
+# hook scripts handle empty output correctly (fall through to exit-2
+# block path).
+#
+# Supported filter forms (covers all patterns in DefenseClaw hooks):
+#   .field                    — raw value
+#   .field // empty           — value or nothing on null/missing
+#   .field // "default"       — value or literal default string
+#
+# Flags honored: -r (raw string output), -c (compact JSON output)
+# shellcheck disable=SC2120
+_dc_jq() {
+  if command -v jq >/dev/null 2>&1; then
+    jq "$@"
+    return
+  fi
+  local _dcjq_raw=0 _dcjq_compact=0 _dcjq_filter=""
+  for _dcjq_a in "$@"; do
+    case "$_dcjq_a" in
+      -r)   _dcjq_raw=1 ;;
+      -c)   _dcjq_compact=1 ;;
+      # Handle accidental merged forms: -r.field or -c.field (no space)
+      -r.*) _dcjq_raw=1;     _dcjq_filter="${_dcjq_a#-r}" ;;
+      -c.*) _dcjq_compact=1; _dcjq_filter="${_dcjq_a#-c}" ;;
+      *)    _dcjq_filter="$_dcjq_a" ;;
+    esac
+  done
+  # Python3 fallback: handles both string scalars and nested objects.
+  # All values are passed via env to avoid shell quoting issues.
+  # The script uses only double-quoted Python strings so it is safe
+  # inside shell single quotes.
+  if command -v python3 >/dev/null 2>&1; then
+    DCJQ_FILTER="$_dcjq_filter" DCJQ_RAW="$_dcjq_raw" DCJQ_COMPACT="$_dcjq_compact" \
+      python3 -c \
+'import json,sys,os,re
+f=os.environ.get("DCJQ_FILTER","")
+raw=os.environ.get("DCJQ_RAW","0")=="1"
+compact=os.environ.get("DCJQ_COMPACT","0")=="1"
+try:
+  data=json.load(sys.stdin)
+except Exception:
+  sys.exit(1)
+m=re.match(r"^\.(\w+)\s*(?://\s*(.+))?$",f.strip())
+if not m:
+  sys.exit(1)
+field=m.group(1)
+dflt=(m.group(2) or "").strip()
+val=data.get(field)
+if val is None:
+  if dflt in ("empty","null",""):
+    sys.exit(0)
+  dm=re.match(r"^\"(.*)\"$",dflt)
+  sys.stdout.write((dm.group(1) if dm else dflt)+"\n")
+  sys.exit(0)
+if isinstance(val,str):
+  sys.stdout.write(val+"\n")
+else:
+  sep=(",",":") if compact else (", ",": ")
+  sys.stdout.write(json.dumps(val,separators=sep)+"\n")'
+    return
+  fi
+  # String-only last resort: covers action / reason / block_reason.
+  # Object fields (claude_code_output, codex_output, hook_output) return
+  # empty; callers already handle the empty case correctly.
+  local _dcjq_field
+  _dcjq_field="${_dcjq_filter#.}"
+  _dcjq_field="${_dcjq_field%%[[:space:]]*}"
+  defenseclaw_json_string_field "$(cat)" "$_dcjq_field"
 }
 
 # defenseclaw_log_hook_failure writes a structured JSON line to

--- a/internal/gateway/connector/hooks/claude-code-hook.sh
+++ b/internal/gateway/connector/hooks/claude-code-hook.sh
@@ -10,6 +10,10 @@
 # codex-hook.sh for the validation contract.
 set -euo pipefail
 
+# Windows: HOME may be unset when agents spawn hooks. Fall back to USERPROFILE.
+HOME="${HOME:-${USERPROFILE:-$(cd ~ 2>/dev/null && pwd)}}"
+export HOME
+
 # Fail-open guard. See inspect-request.sh for rationale.
 DEFENSECLAW_HOME="${DEFENSECLAW_HOME:-${HOME}/.defenseclaw}"
 if [ ! -d "${DEFENSECLAW_HOME}" ] || [ -f "${DEFENSECLAW_HOME}/.disabled" ]; then
@@ -117,14 +121,14 @@ elif [ "$HTTP_CODE" -lt 200 ] 2>/dev/null || [ "$HTTP_CODE" -ge 300 ] 2>/dev/nul
   fail_response "gateway returned HTTP ${HTTP_CODE}"
 fi
 
-OUTPUT=$(echo "$RESULT" | jq -c '.claude_code_output // empty' 2>/dev/null) || {
+OUTPUT=$(echo "$RESULT" | _dc_jq -c '.claude_code_output // empty' 2>/dev/null) || {
   fail_response "invalid JSON response"
 }
 if [ -n "$OUTPUT" ] && [ "$OUTPUT" != "null" ]; then
   echo "$OUTPUT"
 fi
 
-ACTION=$(echo "$RESULT" | jq -r '.action // "allow"' 2>/dev/null) || {
+ACTION=$(echo "$RESULT" | _dc_jq -r '.action // "allow"' 2>/dev/null) || {
   fail_response "failed to parse action from response"
 }
 
@@ -152,7 +156,7 @@ if [ "$ACTION" = "block" ]; then
     # decision=block. Exit 0 so Claude Code honors it.
     exit 0
   fi
-  REASON=$(echo "$RESULT" | jq -r '.reason // empty' 2>/dev/null)
+  REASON=$(echo "$RESULT" | _dc_jq -r '.reason // empty' 2>/dev/null)
   if [ -z "$REASON" ]; then
     REASON="Blocked by DefenseClaw Claude Code policy."
   fi

--- a/internal/gateway/connector/hooks/codex-hook.sh
+++ b/internal/gateway/connector/hooks/codex-hook.sh
@@ -13,6 +13,10 @@
 # span).
 set -euo pipefail
 
+# Windows: HOME may be unset when agents spawn hooks. Fall back to USERPROFILE.
+HOME="${HOME:-${USERPROFILE:-$(cd ~ 2>/dev/null && pwd)}}"
+export HOME
+
 # Fail-open guard. See inspect-request.sh for rationale.
 DEFENSECLAW_HOME="${DEFENSECLAW_HOME:-${HOME}/.defenseclaw}"
 if [ ! -d "${DEFENSECLAW_HOME}" ] || [ -f "${DEFENSECLAW_HOME}/.disabled" ]; then
@@ -138,14 +142,14 @@ elif [ "$HTTP_CODE" -lt 200 ] 2>/dev/null || [ "$HTTP_CODE" -ge 300 ] 2>/dev/nul
   fail_response "gateway returned HTTP ${HTTP_CODE}"
 fi
 
-OUTPUT=$(echo "$RESULT" | jq -c '.codex_output // empty' 2>/dev/null) || {
+OUTPUT=$(echo "$RESULT" | _dc_jq -c '.codex_output // empty' 2>/dev/null) || {
   fail_response "invalid JSON response"
 }
 if [ -n "$OUTPUT" ] && [ "$OUTPUT" != "null" ]; then
   echo "$OUTPUT"
 fi
 
-ACTION=$(echo "$RESULT" | jq -r '.action // "allow"' 2>/dev/null) || {
+ACTION=$(echo "$RESULT" | _dc_jq -r '.action // "allow"' 2>/dev/null) || {
   fail_response "failed to parse action from response"
 }
 
@@ -167,11 +171,15 @@ if [ "$ACTION" = "block" ]; then
     # decision=block. Exit 0 so Codex honors it.
     exit 0
   fi
-  REASON=$(echo "$RESULT" | jq -r '.reason // empty' 2>/dev/null)
+  # codex_output was not extractable (no jq/python3 for object fields).
+  # Construct minimal structured block JSON so Codex sees exit 0 + JSON
+  # rather than exit 2 — newer Codex versions (v0.130+) treat exit 2 on
+  # UserPromptSubmit as "hook failed" rather than "hook blocked".
+  REASON=$(echo "$RESULT" | _dc_jq -r '.reason // empty' 2>/dev/null)
   if [ -z "$REASON" ]; then
     REASON="Blocked by DefenseClaw Codex policy."
   fi
-  printf '%s\n' "$REASON" >&2
-  exit 2
+  printf '{"decision":"block","reason":"%s"}\n' "$(defenseclaw_json_escape "$REASON")"
+  exit 0
 fi
 exit 0

--- a/internal/gateway/connector/hooks/copilot-hook.sh
+++ b/internal/gateway/connector/hooks/copilot-hook.sh
@@ -3,6 +3,9 @@
 # DefenseClaw Copilot CLI hook — forwards Copilot CLI hook payloads to the
 # DefenseClaw gateway.
 set -euo pipefail
+# Windows: HOME may be unset when agents spawn hooks. Fall back to USERPROFILE.
+HOME="${HOME:-${USERPROFILE:-$(cd ~ 2>/dev/null && pwd)}}"
+export HOME
 
 DEFENSECLAW_HOME="${DEFENSECLAW_HOME:-${HOME}/.defenseclaw}"
 if [ ! -d "${DEFENSECLAW_HOME}" ] || [ -f "${DEFENSECLAW_HOME}/.disabled" ]; then
@@ -96,7 +99,7 @@ elif [ "$HTTP_CODE" -lt 200 ] 2>/dev/null || [ "$HTTP_CODE" -ge 300 ] 2>/dev/nul
   fail_response "gateway returned HTTP ${HTTP_CODE}"
 fi
 
-OUTPUT=$(echo "$RESULT" | jq -c '.hook_output // empty' 2>/dev/null) || {
+OUTPUT=$(echo "$RESULT" | _dc_jq -c '.hook_output // empty' 2>/dev/null) || {
   fail_response "invalid JSON response"
 }
 if [ -n "$OUTPUT" ] && [ "$OUTPUT" != "null" ]; then

--- a/internal/gateway/connector/hooks/cursor-hook.sh
+++ b/internal/gateway/connector/hooks/cursor-hook.sh
@@ -3,6 +3,9 @@
 # DefenseClaw Cursor hook — forwards Cursor command-hook payloads to the
 # DefenseClaw gateway.
 set -euo pipefail
+# Windows: HOME may be unset when agents spawn hooks. Fall back to USERPROFILE.
+HOME="${HOME:-${USERPROFILE:-$(cd ~ 2>/dev/null && pwd)}}"
+export HOME
 
 DEFENSECLAW_HOME="${DEFENSECLAW_HOME:-${HOME}/.defenseclaw}"
 if [ ! -d "${DEFENSECLAW_HOME}" ] || [ -f "${DEFENSECLAW_HOME}/.disabled" ]; then
@@ -98,7 +101,7 @@ elif [ "$HTTP_CODE" -lt 200 ] 2>/dev/null || [ "$HTTP_CODE" -ge 300 ] 2>/dev/nul
   fail_response "gateway returned HTTP ${HTTP_CODE}"
 fi
 
-OUTPUT=$(echo "$RESULT" | jq -c '.hook_output // empty' 2>/dev/null) || {
+OUTPUT=$(echo "$RESULT" | _dc_jq -c '.hook_output // empty' 2>/dev/null) || {
   fail_response "invalid JSON response"
 }
 if [ -n "$OUTPUT" ] && [ "$OUTPUT" != "null" ]; then

--- a/internal/gateway/connector/hooks/geminicli-hook.sh
+++ b/internal/gateway/connector/hooks/geminicli-hook.sh
@@ -3,6 +3,9 @@
 # DefenseClaw Gemini CLI hook — forwards Gemini hook payloads to the
 # DefenseClaw gateway. Intentional policy blocks are returned as JSON.
 set -euo pipefail
+# Windows: HOME may be unset when agents spawn hooks. Fall back to USERPROFILE.
+HOME="${HOME:-${USERPROFILE:-$(cd ~ 2>/dev/null && pwd)}}"
+export HOME
 
 DEFENSECLAW_HOME="${DEFENSECLAW_HOME:-${HOME}/.defenseclaw}"
 if [ ! -d "${DEFENSECLAW_HOME}" ] || [ -f "${DEFENSECLAW_HOME}/.disabled" ]; then
@@ -94,7 +97,7 @@ elif [ "$HTTP_CODE" -lt 200 ] 2>/dev/null || [ "$HTTP_CODE" -ge 300 ] 2>/dev/nul
   fail_response "gateway returned HTTP ${HTTP_CODE}"
 fi
 
-OUTPUT=$(echo "$RESULT" | jq -c '.hook_output // empty' 2>/dev/null) || {
+OUTPUT=$(echo "$RESULT" | _dc_jq -c '.hook_output // empty' 2>/dev/null) || {
   fail_response "invalid JSON response"
 }
 if [ -n "$OUTPUT" ] && [ "$OUTPUT" != "null" ]; then

--- a/internal/gateway/connector/hooks/hermes-hook.sh
+++ b/internal/gateway/connector/hooks/hermes-hook.sh
@@ -3,6 +3,9 @@
 # DefenseClaw Hermes hook — forwards Hermes shell-hook payloads to the
 # DefenseClaw gateway.
 set -euo pipefail
+# Windows: HOME may be unset when agents spawn hooks. Fall back to USERPROFILE.
+HOME="${HOME:-${USERPROFILE:-$(cd ~ 2>/dev/null && pwd)}}"
+export HOME
 
 # Fail-open guard. See inspect-request.sh for rationale.
 DEFENSECLAW_HOME="${DEFENSECLAW_HOME:-${HOME}/.defenseclaw}"
@@ -112,7 +115,7 @@ elif [ "$HTTP_CODE" -lt 200 ] 2>/dev/null || [ "$HTTP_CODE" -ge 300 ] 2>/dev/nul
   fail_response "gateway returned HTTP ${HTTP_CODE}"
 fi
 
-OUTPUT=$(echo "$RESULT" | jq -c '.hook_output // empty' 2>/dev/null) || {
+OUTPUT=$(echo "$RESULT" | _dc_jq -c '.hook_output // empty' 2>/dev/null) || {
   fail_response "invalid JSON response"
 }
 if [ -n "$OUTPUT" ] && [ "$OUTPUT" != "null" ]; then

--- a/internal/gateway/connector/hooks/inspect-request.sh
+++ b/internal/gateway/connector/hooks/inspect-request.sh
@@ -3,6 +3,9 @@
 # DefenseClaw PreRequest hook — inspects user query before it is sent to the LLM.
 # Reads the user message content from stdin (JSON with "content" field).
 set -euo pipefail
+# Windows: HOME may be unset when agents spawn hooks. Fall back to USERPROFILE.
+HOME="${HOME:-${USERPROFILE:-$(cd ~ 2>/dev/null && pwd)}}"
+export HOME
 
 # Fail-open guard. If the operator has disabled the guardrail or fully
 # uninstalled DefenseClaw, exit 0 immediately so the agent isn't
@@ -74,11 +77,11 @@ elif [ "$HTTP_CODE" -lt 200 ] 2>/dev/null || [ "$HTTP_CODE" -ge 300 ] 2>/dev/nul
   fail_response "gateway returned HTTP ${HTTP_CODE}"
 fi
 
-ACTION=$(echo "$RESULT" | jq -r '.action // "allow"' 2>/dev/null) || {
+ACTION=$(echo "$RESULT" | _dc_jq -r '.action // "allow"' 2>/dev/null) || {
   fail_response "failed to parse action from response"
 }
 if [ "$ACTION" = "block" ]; then
-  REASON=$(echo "$RESULT" | jq -r '.reason // "blocked by DefenseClaw"' 2>/dev/null)
+  REASON=$(echo "$RESULT" | _dc_jq -r '.reason // "blocked by DefenseClaw"' 2>/dev/null)
   echo "DefenseClaw: $REASON" >&2
   exit 2
 fi

--- a/internal/gateway/connector/hooks/inspect-response.sh
+++ b/internal/gateway/connector/hooks/inspect-response.sh
@@ -3,6 +3,9 @@
 # DefenseClaw PostResponse hook — inspects LLM response content after it is returned.
 # Reads the LLM response from stdin (JSON with "content" field).
 set -euo pipefail
+# Windows: HOME may be unset when agents spawn hooks. Fall back to USERPROFILE.
+HOME="${HOME:-${USERPROFILE:-$(cd ~ 2>/dev/null && pwd)}}"
+export HOME
 
 # Fail-open guard. See inspect-request.sh for rationale.
 DEFENSECLAW_HOME="${DEFENSECLAW_HOME:-${HOME}/.defenseclaw}"
@@ -68,11 +71,11 @@ elif [ "$HTTP_CODE" -lt 200 ] 2>/dev/null || [ "$HTTP_CODE" -ge 300 ] 2>/dev/nul
   fail_response "gateway returned HTTP ${HTTP_CODE}"
 fi
 
-ACTION=$(echo "$RESULT" | jq -r '.action // "allow"' 2>/dev/null) || {
+ACTION=$(echo "$RESULT" | _dc_jq -r '.action // "allow"' 2>/dev/null) || {
   fail_response "failed to parse action from response"
 }
 if [ "$ACTION" = "block" ]; then
-  REASON=$(echo "$RESULT" | jq -r '.reason // "blocked by DefenseClaw"' 2>/dev/null)
+  REASON=$(echo "$RESULT" | _dc_jq -r '.reason // "blocked by DefenseClaw"' 2>/dev/null)
   echo "DefenseClaw: $REASON" >&2
   exit 2
 fi

--- a/internal/gateway/connector/hooks/inspect-tool-response.sh
+++ b/internal/gateway/connector/hooks/inspect-tool-response.sh
@@ -3,6 +3,9 @@
 # DefenseClaw PostToolUse hook — inspects tool execution output before it goes back to the LLM.
 # Reads tool output from stdin. TOOL_NAME is set by the agent framework.
 set -euo pipefail
+# Windows: HOME may be unset when agents spawn hooks. Fall back to USERPROFILE.
+HOME="${HOME:-${USERPROFILE:-$(cd ~ 2>/dev/null && pwd)}}"
+export HOME
 
 # Fail-open guard. See inspect-request.sh for rationale.
 DEFENSECLAW_HOME="${DEFENSECLAW_HOME:-${HOME}/.defenseclaw}"
@@ -71,11 +74,11 @@ elif [ "$HTTP_CODE" -lt 200 ] 2>/dev/null || [ "$HTTP_CODE" -ge 300 ] 2>/dev/nul
   fail_response "gateway returned HTTP ${HTTP_CODE}"
 fi
 
-ACTION=$(echo "$RESULT" | jq -r '.action // "allow"' 2>/dev/null) || {
+ACTION=$(echo "$RESULT" | _dc_jq -r '.action // "allow"' 2>/dev/null) || {
   fail_response "failed to parse action from response"
 }
 if [ "$ACTION" = "block" ]; then
-  REASON=$(echo "$RESULT" | jq -r '.reason // "blocked by DefenseClaw"' 2>/dev/null)
+  REASON=$(echo "$RESULT" | _dc_jq -r '.reason // "blocked by DefenseClaw"' 2>/dev/null)
   echo "DefenseClaw: $REASON" >&2
   exit 2
 fi

--- a/internal/gateway/connector/hooks/inspect-tool.sh
+++ b/internal/gateway/connector/hooks/inspect-tool.sh
@@ -4,6 +4,9 @@
 # Used by Claude Code (PreToolUse) and OpenCode (hook command).
 # The agent sets CLAUDE_TOOL_NAME (Claude Code) or TOOL_NAME and pipes input to stdin.
 set -euo pipefail
+# Windows: HOME may be unset when agents spawn hooks. Fall back to USERPROFILE.
+HOME="${HOME:-${USERPROFILE:-$(cd ~ 2>/dev/null && pwd)}}"
+export HOME
 
 # Fail-open guard. See inspect-request.sh for rationale.
 DEFENSECLAW_HOME="${DEFENSECLAW_HOME:-${HOME}/.defenseclaw}"
@@ -75,11 +78,11 @@ elif [ "$HTTP_CODE" -lt 200 ] 2>/dev/null || [ "$HTTP_CODE" -ge 300 ] 2>/dev/nul
   fail_response "gateway returned HTTP ${HTTP_CODE}"
 fi
 
-ACTION=$(echo "$RESULT" | jq -r '.action // "allow"' 2>/dev/null) || {
+ACTION=$(echo "$RESULT" | _dc_jq -r '.action // "allow"' 2>/dev/null) || {
   fail_response "failed to parse action from response"
 }
 if [ "$ACTION" = "block" ]; then
-  REASON=$(echo "$RESULT" | jq -r '.reason // "blocked by DefenseClaw"' 2>/dev/null)
+  REASON=$(echo "$RESULT" | _dc_jq -r '.reason // "blocked by DefenseClaw"' 2>/dev/null)
   echo "DefenseClaw: $REASON" >&2
   exit 2
 fi

--- a/internal/gateway/connector/hooks/windsurf-hook.sh
+++ b/internal/gateway/connector/hooks/windsurf-hook.sh
@@ -3,6 +3,9 @@
 # DefenseClaw Windsurf hook — forwards Cascade hook payloads to the
 # DefenseClaw gateway. Windsurf blocks pre-hooks when this script exits 2.
 set -euo pipefail
+# Windows: HOME may be unset when agents spawn hooks. Fall back to USERPROFILE.
+HOME="${HOME:-${USERPROFILE:-$(cd ~ 2>/dev/null && pwd)}}"
+export HOME
 
 DEFENSECLAW_HOME="${DEFENSECLAW_HOME:-${HOME}/.defenseclaw}"
 if [ ! -d "${DEFENSECLAW_HOME}" ] || [ -f "${DEFENSECLAW_HOME}/.disabled" ]; then
@@ -102,11 +105,11 @@ if ! echo "$RESULT" | jq -e . >/dev/null 2>&1; then
   fail_response "invalid JSON response"
 fi
 
-ACTION=$(echo "$RESULT" | jq -r '.action // "allow"' 2>/dev/null) || {
+ACTION=$(echo "$RESULT" | _dc_jq -r '.action // "allow"' 2>/dev/null) || {
   fail_response "failed to parse action from response"
 }
 if [ "$ACTION" = "block" ]; then
-  REASON=$(echo "$RESULT" | jq -r '.reason // "DefenseClaw blocked this Cascade action."' 2>/dev/null || printf "DefenseClaw blocked this Cascade action.")
+  REASON=$(echo "$RESULT" | _dc_jq -r '.reason // "DefenseClaw blocked this Cascade action."' 2>/dev/null || printf "DefenseClaw blocked this Cascade action.")
   echo "$REASON" >&2
   exit 2
 fi

--- a/internal/gateway/connector/hookwiring_test.go
+++ b/internal/gateway/connector/hookwiring_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestHookInvocationCommand pins the platform split: Unix runs the bundled .sh
+// path; Windows invokes the native Go `hook` subcommand instead of any Bash/.cmd
+// wrapper.
+func TestHookInvocationCommand(t *testing.T) {
+	const unix = "/home/u/.defenseclaw/hooks/codex-hook.sh"
+
+	for _, goos := range []string{"linux", "darwin"} {
+		if got := hookInvocationCommandFor(goos, "codex", unix); got != unix {
+			t.Errorf("%s command = %q, want passthrough %q", goos, got, unix)
+		}
+	}
+
+	win := hookInvocationCommandFor("windows", "cursor", unix)
+	if !strings.Contains(win, nativeHookFlag+"cursor") {
+		t.Errorf("windows command = %q, missing %q", win, nativeHookFlag+"cursor")
+	}
+	if strings.Contains(win, ".sh") || strings.Contains(win, ".cmd") || strings.Contains(win, "bash") {
+		t.Errorf("windows command = %q should not reference a shell/script wrapper", win)
+	}
+	if !isNativeHookCommand(win) {
+		t.Errorf("isNativeHookCommand(%q) = false, want true", win)
+	}
+	if isNativeHookCommand(unix) {
+		t.Errorf("isNativeHookCommand(%q) = true, want false for a .sh path", unix)
+	}
+}
+
+// TestShellWordPassesNativeCommandThrough ensures the bash-style quoter does not
+// corrupt the native Windows command (which is already a complete command line)
+// while still quoting Unix script paths for the agent's shell.
+func TestShellWordPassesNativeCommandThrough(t *testing.T) {
+	native := `"C:\dc.exe" hook --connector cursor`
+	if got := shellWord(native); got != native {
+		t.Errorf("shellWord(native) = %q, want unchanged", got)
+	}
+	if got := shellWord("/home/u/hooks/cursor-hook.sh"); got != "'/home/u/hooks/cursor-hook.sh'" {
+		t.Errorf("shellWord(path) = %q, want single-quoted", got)
+	}
+}
+
+// TestBuildCodexHooksTableHashesTheCommand verifies the Codex hooks table writes
+// the trust hash over the exact command it executes (so Codex recognizes it),
+// and that teardown reproduces the same fingerprint to remove the state.
+func TestBuildCodexHooksTableHashesTheCommand(t *testing.T) {
+	const cmd = `"C:\Program Files\defenseclaw\defenseclaw-gateway.exe" hook --connector codex`
+	const configPath = "/home/u/.codex/config.toml"
+
+	table := buildCodexHooksTable(configPath, cmd)
+
+	for _, group := range codexHookGroups {
+		raw, ok := table[group.eventType].([]interface{})
+		if !ok || len(raw) == 0 {
+			t.Fatalf("missing event %s", group.eventType)
+		}
+		mg := raw[0].(map[string]interface{})
+		hooks := mg["hooks"].([]interface{})
+		h0 := hooks[0].(map[string]interface{})
+		if got := h0["command"].(string); got != cmd {
+			t.Errorf("event %s command = %q, want %q", group.eventType, got, cmd)
+		}
+	}
+
+	state, ok := table["state"].(map[string]interface{})
+	if !ok || len(state) == 0 {
+		t.Fatal("expected non-empty state table")
+	}
+
+	// Teardown with the same command recognizes and removes every entry.
+	hooks := map[string]interface{}{"state": state}
+	if !removeOwnedCodexHookState(hooks, configPath, cmd) {
+		t.Fatal("removeOwnedCodexHookState did not recognize its own hash")
+	}
+	if _, present := hooks["state"]; present {
+		t.Error("state should be deleted once every owned entry is removed")
+	}
+
+	// A different command must NOT match (ownership specificity).
+	fresh := buildCodexHooksTable(configPath, cmd)
+	freshHooks := map[string]interface{}{"state": fresh["state"]}
+	if removeOwnedCodexHookState(freshHooks, configPath, `"other.exe" hook --connector codex`) {
+		t.Error("teardown removed state for a command it never wrote")
+	}
+}
+
+// TestIsOwnedHookRecognizesNativeCommand covers the Claude Code / hook teardown
+// recognizer for the native Windows command, which is not a file path under the
+// hooks dir and carries no on-disk marker.
+func TestIsOwnedHookRecognizesNativeCommand(t *testing.T) {
+	const hooksDir = "/home/u/.defenseclaw/hooks"
+
+	owned := map[string]interface{}{
+		"hooks": []interface{}{
+			map[string]interface{}{
+				"type":    "command",
+				"command": `"C:\dc.exe" hook --connector claudecode`,
+			},
+		},
+	}
+	if !isOwnedHook(owned, hooksDir) {
+		t.Error("native hook command not recognized as DefenseClaw-owned")
+	}
+
+	foreign := map[string]interface{}{
+		"hooks": []interface{}{
+			map[string]interface{}{"type": "command", "command": "/usr/bin/some-other-tool --flag"},
+		},
+	}
+	if isOwnedHook(foreign, hooksDir) {
+		t.Error("foreign command wrongly recognized as DefenseClaw-owned")
+	}
+}

--- a/internal/gateway/connector/openclaw.go
+++ b/internal/gateway/connector/openclaw.go
@@ -84,7 +84,7 @@ func openClawHome() string {
 	if OpenClawHomeOverride != "" {
 		return OpenClawHomeOverride
 	}
-	return filepath.Join(os.Getenv("HOME"), ".openclaw")
+	return filepath.Join(userHomeDir(), ".openclaw")
 }
 
 // OpenClawConnector handles LLM traffic routing and tool inspection for OpenClaw.
@@ -599,7 +599,7 @@ func (c *OpenClawConnector) RequiredEnv() []EnvRequirement {
 func (c *OpenClawConnector) SupportsComponentScanning() bool { return true }
 
 func (c *OpenClawConnector) ComponentTargets(cwd string) map[string][]string {
-	home := os.Getenv("HOME")
+	home := userHomeDir()
 	openclawHome := filepath.Join(home, ".openclaw")
 	workspace := filepath.Join(openclawHome, "workspace")
 

--- a/internal/gateway/connector/openclaw.go
+++ b/internal/gateway/connector/openclaw.go
@@ -25,7 +25,9 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -60,10 +62,13 @@ const openClawPlaceholderName = ".placeholder"
 // failing loudly when someone tries to switch to OpenClaw without
 // having built the plugin.
 func openClawExtensionAvailable() bool {
-	if _, err := openClawExtensionFS.ReadFile(filepath.Join(openClawPluginRoot, "package.json")); err == nil {
+	// embed.FS always uses forward-slash paths; filepath.Join would emit
+	// backslashes on Windows and never match the embedded entries, so use
+	// path.Join here.
+	if _, err := openClawExtensionFS.ReadFile(path.Join(openClawPluginRoot, "package.json")); err == nil {
 		return true
 	}
-	if _, err := openClawExtensionFS.ReadFile(filepath.Join(openClawPluginRoot, openClawPlaceholderName)); err == nil {
+	if _, err := openClawExtensionFS.ReadFile(path.Join(openClawPluginRoot, openClawPlaceholderName)); err == nil {
 		return false
 	}
 	return false
@@ -124,6 +129,13 @@ func (c *OpenClawConnector) AllowedHosts() []string {
 }
 
 func (c *OpenClawConnector) Setup(ctx context.Context, opts SetupOpts) error {
+	// Proxy connectors require the local guardrail proxy, which DefenseClaw
+	// does not host on Windows (hook-only there). Fail clearly instead of
+	// planting a half-configured proxy connector.
+	if !ConnectorSupportedOnHostOS(c.Name()) {
+		return errConnectorUnsupportedOnOS(c.Name(), runtime.GOOS)
+	}
+
 	// The Makefile keeps the gateway buildable on machines without the
 	// TS plugin built (typical for non-OpenClaw operators) by embedding
 	// a placeholder. If the operator now actually wants OpenClaw, refuse

--- a/internal/gateway/connector/otlp_token.go
+++ b/internal/gateway/connector/otlp_token.go
@@ -259,8 +259,8 @@ func readSecureOTLPPathTokenFile(dataDir, path string) (string, error) {
 	if !info.Mode().IsRegular() {
 		return "", fmt.Errorf("OTLP path-token %s is not a regular file", path)
 	}
-	if mode := info.Mode().Perm(); mode != 0o600 {
-		return "", fmt.Errorf("OTLP path-token %s has mode %o, want 600", path, mode)
+	if err := otlpValidatePerm(path, info); err != nil {
+		return "", err
 	}
 	if err := otlpValidateOwner(path, info); err != nil {
 		return "", err

--- a/internal/gateway/connector/otlp_token.go
+++ b/internal/gateway/connector/otlp_token.go
@@ -26,7 +26,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"syscall"
 )
 
 // OTLPPathTokenScope identifies a connector-bound OTLP token used in
@@ -154,7 +153,7 @@ func EnsureOTLPPathToken(dataDir string, scope OTLPPathTokenScope) (string, erro
 	tmp := tokenPath + ".tmp"
 	_ = os.Remove(tmp)
 	flags := os.O_WRONLY | os.O_CREATE | os.O_EXCL
-	if nofollow := syscall.O_NOFOLLOW; nofollow != 0 {
+	if nofollow := otlpOpenNoFollow(); nofollow != 0 {
 		flags |= nofollow
 	}
 	f, err := os.OpenFile(tmp, flags, 0o600)
@@ -263,12 +262,10 @@ func readSecureOTLPPathTokenFile(dataDir, path string) (string, error) {
 	if mode := info.Mode().Perm(); mode != 0o600 {
 		return "", fmt.Errorf("OTLP path-token %s has mode %o, want 600", path, mode)
 	}
-	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-		if int(stat.Uid) != os.Getuid() {
-			return "", fmt.Errorf("OTLP path-token %s uid %d does not match current uid %d", path, stat.Uid, os.Getuid())
-		}
+	if err := otlpValidateOwner(path, info); err != nil {
+		return "", err
 	}
-	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	f, err := os.OpenFile(path, os.O_RDONLY|otlpOpenNoFollow(), 0)
 	if err != nil {
 		return "", err
 	}

--- a/internal/gateway/connector/otlp_token_unix.go
+++ b/internal/gateway/connector/otlp_token_unix.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package connector
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// otlpOpenNoFollow returns O_NOFOLLOW flag value for symlink-safe file opens.
+func otlpOpenNoFollow() int {
+	return syscall.O_NOFOLLOW
+}
+
+// otlpValidateOwner checks that the file at the given path is owned by the
+// current user. Returns nil if the check passes or is not applicable.
+func otlpValidateOwner(path string, info os.FileInfo) error {
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		if int(stat.Uid) != os.Getuid() {
+			return fmt.Errorf("OTLP path-token %s uid %d does not match current uid %d", path, stat.Uid, os.Getuid())
+		}
+	}
+	return nil
+}

--- a/internal/gateway/connector/otlp_token_unix.go
+++ b/internal/gateway/connector/otlp_token_unix.go
@@ -29,6 +29,15 @@ func otlpOpenNoFollow() int {
 	return syscall.O_NOFOLLOW
 }
 
+// otlpValidatePerm enforces that the token file is not group/other accessible.
+// On Unix the file is created 0600, so anything else is a tampering signal.
+func otlpValidatePerm(path string, info os.FileInfo) error {
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		return fmt.Errorf("OTLP path-token %s has mode %o, want 600", path, mode)
+	}
+	return nil
+}
+
 // otlpValidateOwner checks that the file at the given path is owned by the
 // current user. Returns nil if the check passes or is not applicable.
 func otlpValidateOwner(path string, info os.FileInfo) error {

--- a/internal/gateway/connector/otlp_token_windows.go
+++ b/internal/gateway/connector/otlp_token_windows.go
@@ -20,10 +20,21 @@ package connector
 
 import "os"
 
-// otlpOpenNoFollow returns 0 on Windows (O_NOFOLLOW is a Unix concept;
-// Windows does not follow symlinks during CreateFile by default).
+// otlpOpenNoFollow returns 0 on Windows. O_NOFOLLOW is a Unix flag and is not
+// available here. (Windows DOES traverse reparse points/symlinks during
+// CreateFile unless FILE_FLAG_OPEN_REPARSE_POINT is set, but creating symlinks
+// on Windows requires elevation or Developer Mode, and the token file is
+// created with O_EXCL, so the practical exposure is limited.)
 func otlpOpenNoFollow() int {
 	return 0
+}
+
+// otlpValidatePerm is a no-op on Windows. Go synthesizes FileMode permission
+// bits from the read-only attribute (a writable file reports 0666, never
+// 0600), so the Unix 0600 check would reject every legitimately created token.
+// Access control on Windows is governed by ACLs, not POSIX mode bits.
+func otlpValidatePerm(_ string, _ os.FileInfo) error {
+	return nil
 }
 
 // otlpValidateOwner is a no-op on Windows. File ownership uses ACLs and

--- a/internal/gateway/connector/otlp_token_windows.go
+++ b/internal/gateway/connector/otlp_token_windows.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package connector
+
+import "os"
+
+// otlpOpenNoFollow returns 0 on Windows (O_NOFOLLOW is a Unix concept;
+// Windows does not follow symlinks during CreateFile by default).
+func otlpOpenNoFollow() int {
+	return 0
+}
+
+// otlpValidateOwner is a no-op on Windows. File ownership uses ACLs and
+// the Unix UID check is not applicable.
+func otlpValidateOwner(_ string, _ os.FileInfo) error {
+	return nil
+}

--- a/internal/gateway/connector/platform_support.go
+++ b/internal/gateway/connector/platform_support.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// proxyConnectors are the chat/LLM-proxy connectors that interpose on model
+// traffic through DefenseClaw's local guardrail proxy. They are unsupported on
+// Windows, where DefenseClaw runs hook-only: the native Go hook entrypoint
+// replaces the Bash hook chain, and there is no Windows guardrail-proxy
+// lifecycle to host these connectors.
+//
+// This is the Go single source of truth for OS support. Keep it in sync with
+// the Python cli/defenseclaw/platform_support.py WINDOWS_UNSUPPORTED_CONNECTORS
+// set — a parity test pins the two lists together.
+var proxyConnectors = map[string]struct{}{
+	"openclaw":  {},
+	"zeptoclaw": {},
+}
+
+// IsProxyConnector reports whether name is a proxy/chat connector (as opposed
+// to a hook-based connector).
+func IsProxyConnector(name string) bool {
+	_, ok := proxyConnectors[name]
+	return ok
+}
+
+// connectorSupportedOnOS reports whether a connector can be listed or set up on
+// the given GOOS. Every hook-based connector is supported on every OS; the
+// proxy connectors are unsupported on Windows.
+func connectorSupportedOnOS(name, goos string) bool {
+	if goos == "windows" && IsProxyConnector(name) {
+		return false
+	}
+	return true
+}
+
+// ConnectorSupportedOnHostOS reports support on the current host OS.
+func ConnectorSupportedOnHostOS(name string) bool {
+	return connectorSupportedOnOS(name, runtime.GOOS)
+}
+
+// errConnectorUnsupportedOnOS is the clear, behavior-first error proxy-connector
+// Setup returns when invoked on an OS that cannot host the guardrail proxy.
+func errConnectorUnsupportedOnOS(name, goos string) error {
+	return fmt.Errorf("connector %q is not supported on %s: DefenseClaw on %s is hook-only and proxy connectors require the guardrail proxy", name, goos, goos)
+}

--- a/internal/gateway/connector/platform_support_test.go
+++ b/internal/gateway/connector/platform_support_test.go
@@ -26,9 +26,10 @@ import (
 // side must be made on both; these tests fail loudly if they drift.
 var proxyConnectorNames = []string{"openclaw", "zeptoclaw"}
 
-// hookConnectorNames are the eight hook-based connectors supported on every
+// hookConnectorNames are the hook-based connectors supported on every
 // OS, including Windows.
 var hookConnectorNames = []string{
+	"antigravity",
 	"claudecode",
 	"codex",
 	"copilot",
@@ -94,7 +95,7 @@ func TestConnectorSupportedOnOS(t *testing.T) {
 
 // TestRegistryNamesFilterToHookConnectorsOnWindows takes the full built-in
 // registry (Available() returns all connectors on this non-Windows host) and
-// asserts that applying the Windows OS filter yields exactly the eight hook
+// asserts that applying the Windows OS filter yields exactly the hook
 // connectors, with both proxy connectors removed.
 func TestRegistryNamesFilterToHookConnectorsOnWindows(t *testing.T) {
 	reg := NewDefaultRegistry()

--- a/internal/gateway/connector/platform_support_test.go
+++ b/internal/gateway/connector/platform_support_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"sort"
+	"testing"
+)
+
+// proxyConnectorNames mirrors the Python
+// platform_support.WINDOWS_UNSUPPORTED_CONNECTORS set. A change on either
+// side must be made on both; these tests fail loudly if they drift.
+var proxyConnectorNames = []string{"openclaw", "zeptoclaw"}
+
+// hookConnectorNames are the eight hook-based connectors supported on every
+// OS, including Windows.
+var hookConnectorNames = []string{
+	"claudecode",
+	"codex",
+	"copilot",
+	"cursor",
+	"geminicli",
+	"hermes",
+	"openhands",
+	"windsurf",
+}
+
+func TestProxyConnectorsSetMatchesMirror(t *testing.T) {
+	got := make([]string, 0, len(proxyConnectors))
+	for name := range proxyConnectors {
+		got = append(got, name)
+	}
+	sort.Strings(got)
+	want := append([]string(nil), proxyConnectorNames...)
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("proxyConnectors = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("proxyConnectors = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestIsProxyConnector(t *testing.T) {
+	for _, name := range proxyConnectorNames {
+		if !IsProxyConnector(name) {
+			t.Errorf("IsProxyConnector(%q) = false, want true", name)
+		}
+	}
+	for _, name := range hookConnectorNames {
+		if IsProxyConnector(name) {
+			t.Errorf("IsProxyConnector(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestConnectorSupportedOnOS(t *testing.T) {
+	// Windows: proxy connectors unsupported, hook connectors supported.
+	for _, name := range proxyConnectorNames {
+		if connectorSupportedOnOS(name, "windows") {
+			t.Errorf("connectorSupportedOnOS(%q, windows) = true, want false", name)
+		}
+	}
+	for _, name := range hookConnectorNames {
+		if !connectorSupportedOnOS(name, "windows") {
+			t.Errorf("connectorSupportedOnOS(%q, windows) = false, want true", name)
+		}
+	}
+	// Unix: everything supported.
+	for _, goos := range []string{"linux", "darwin"} {
+		for _, name := range append(append([]string(nil), proxyConnectorNames...), hookConnectorNames...) {
+			if !connectorSupportedOnOS(name, goos) {
+				t.Errorf("connectorSupportedOnOS(%q, %s) = false, want true", name, goos)
+			}
+		}
+	}
+}
+
+// TestRegistryNamesFilterToHookConnectorsOnWindows takes the full built-in
+// registry (Available() returns all connectors on this non-Windows host) and
+// asserts that applying the Windows OS filter yields exactly the eight hook
+// connectors, with both proxy connectors removed.
+func TestRegistryNamesFilterToHookConnectorsOnWindows(t *testing.T) {
+	reg := NewDefaultRegistry()
+	var all []string
+	for _, info := range reg.Available() {
+		all = append(all, info.Name)
+	}
+
+	var onWindows []string
+	for _, name := range all {
+		if connectorSupportedOnOS(name, "windows") {
+			onWindows = append(onWindows, name)
+		}
+	}
+	sort.Strings(onWindows)
+
+	want := append([]string(nil), hookConnectorNames...)
+	sort.Strings(want)
+	if len(onWindows) != len(want) {
+		t.Fatalf("windows-filtered connectors = %v, want %v", onWindows, want)
+	}
+	for i := range onWindows {
+		if onWindows[i] != want[i] {
+			t.Fatalf("windows-filtered connectors = %v, want %v", onWindows, want)
+		}
+	}
+}

--- a/internal/gateway/connector/plugin_loader.go
+++ b/internal/gateway/connector/plugin_loader.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -29,7 +28,6 @@ import (
 	"plugin"
 	"runtime"
 	"strings"
-	"syscall"
 
 	"gopkg.in/yaml.v3"
 )
@@ -59,8 +57,7 @@ func SetPluginAuditEmitter(e PluginAuditEmitter) {
 }
 
 // pluginGetUID is overridable for tests. Returns the effective UID of
-// the running process. The default delegates to os.Getuid().
-var pluginGetUID = os.Getuid
+// the running process. Defined in platform-specific files.
 
 func emitPluginRejection(code, msg, soPath string, cause error) {
 	if pluginAuditEmitter != nil {
@@ -221,26 +218,8 @@ func validatePluginPermissions(soPath string) error {
 // the gateway daemon reads, set mode 0o755, and have it loaded with
 // the daemon's privileges. This gate closes that path.
 //
-// Plan B3 / S0.1: skipped on Windows (file ownership semantics differ
-// and the code path uses syscall.Stat_t which is unix-only).
-func validatePluginOwner(soPath string) error {
-	if runtime.GOOS == "windows" {
-		return nil
-	}
-	info, err := os.Lstat(soPath)
-	if err != nil {
-		return fmt.Errorf("stat %s: %w", soPath, err)
-	}
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return errors.New("could not extract owner UID from FileInfo (non-unix FS?)")
-	}
-	want := uint32(pluginGetUID())
-	if stat.Uid != want {
-		return fmt.Errorf("%s owner uid=%d does not match running process uid=%d", soPath, stat.Uid, want)
-	}
-	return nil
-}
+// validatePluginOwner is implemented in platform-specific files
+// (plugin_owner_unix.go / plugin_owner_windows.go).
 
 // validatePluginHash computes the SHA-256 digest of the file and compares it
 // against the expected hex string from the manifest.

--- a/internal/gateway/connector/plugin_owner_unix.go
+++ b/internal/gateway/connector/plugin_owner_unix.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package connector
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// pluginGetUID is overridable for tests. Returns the effective UID of
+// the running process. The default delegates to os.Getuid().
+var pluginGetUID = os.Getuid
+
+// validatePluginOwner verifies the plugin file is owned by the same UID as
+// the running process. This prevents a hostile user on a shared host from
+// dropping a plugin that gets loaded with the daemon's privileges.
+func validatePluginOwner(soPath string) error {
+	info, err := os.Lstat(soPath)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", soPath, err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("could not extract owner UID from FileInfo (non-unix FS?)")
+	}
+	want := uint32(pluginGetUID())
+	if stat.Uid != want {
+		return fmt.Errorf("%s owner uid=%d does not match running process uid=%d", soPath, stat.Uid, want)
+	}
+	return nil
+}

--- a/internal/gateway/connector/plugin_owner_windows.go
+++ b/internal/gateway/connector/plugin_owner_windows.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package connector
+
+// pluginGetUID is a no-op stub on Windows (UID is a Unix concept).
+var pluginGetUID = func() int { return 0 }
+
+// validatePluginOwner is a no-op on Windows. File ownership semantics
+// differ (ACLs vs. UID/GID) and the Unix syscall.Stat_t is unavailable.
+func validatePluginOwner(_ string) error {
+	return nil
+}

--- a/internal/gateway/connector/registry.go
+++ b/internal/gateway/connector/registry.go
@@ -112,6 +112,12 @@ func (r *Registry) Available() []ConnectorInfo {
 
 	out := make([]ConnectorInfo, 0, len(r.builtins)+len(r.plugins))
 	for _, c := range r.builtins {
+		// Hide connectors unsupported on this OS (proxy connectors on Windows)
+		// so the TUI/CLI and /v1/connectors never surface a path that cannot
+		// run here.
+		if !ConnectorSupportedOnHostOS(c.Name()) {
+			continue
+		}
 		out = append(out, ConnectorInfo{
 			Name:               c.Name(),
 			Description:        c.Description(),
@@ -121,6 +127,9 @@ func (r *Registry) Available() []ConnectorInfo {
 		})
 	}
 	for _, c := range r.plugins {
+		if !ConnectorSupportedOnHostOS(c.Name()) {
+			continue
+		}
 		out = append(out, ConnectorInfo{
 			Name:               c.Name(),
 			Description:        c.Description(),

--- a/internal/gateway/connector/subprocess.go
+++ b/internal/gateway/connector/subprocess.go
@@ -343,6 +343,10 @@ func WriteHookScriptsWithToken(hookDir, apiAddr, token string) error {
 		}
 	}
 
+	if err := writeHookConfigSidecar(hookDir, apiAddr, defaultHookFailMode); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -396,37 +400,36 @@ func writeHookScriptsCommonWithFailMode(hookDir, apiAddr, token, failMode string
 		if err := os.WriteFile(hookPath, []byte(rendered), 0o700); err != nil {
 			return fmt.Errorf("write hook %s: %w", name, err)
 		}
-		// On Windows, agent runtimes cannot execute .sh files directly and
-		// may run them through a shell that cannot exec Windows .exe files.
-		// Write a .cmd wrapper alongside each .sh hook so connectors can
-		// reference the .cmd path as the hook command — cmd.exe runs it
-		// natively and forwards stdin/stdout to Git Bash correctly.
-		if runtime.GOOS == "windows" && strings.HasSuffix(name, ".sh") {
-			if err := writeWindowsHookWrapper(hookDir, name); err != nil {
-				return fmt.Errorf("write windows hook wrapper %s: %w", name, err)
-			}
-		}
+	}
+	if err := writeHookConfigSidecar(hookDir, apiAddr, normalizeHookFailMode(failMode)); err != nil {
+		return err
 	}
 	return nil
 }
 
-// writeWindowsHookWrapper writes a .cmd file that calls Git Bash to execute
-// the corresponding .sh hook. Using a .cmd wrapper avoids the ambiguity of
-// which bash (Git Bash vs WSL) a runtime picks up from PATH, and ensures
-// cmd.exe — which always works on Windows — is the entry point.
-func writeWindowsHookWrapper(hookDir, shName string) error {
-	bashExe := filepath.ToSlash(resolveWindowsBash())
-	// Strip leading/trailing quotes resolveWindowsBash may add.
-	bashExe = strings.Trim(bashExe, `"`)
-	shPath := filepath.ToSlash(filepath.Join(hookDir, shName))
-	cmdName := strings.TrimSuffix(shName, ".sh") + ".cmd"
-	cmdPath := filepath.Join(hookDir, cmdName)
-	// %* forwards any extra arguments; stdin/stdout are inherited by cmd.exe.
-	// "exit /b %ERRORLEVEL%" explicitly propagates the bash exit code
-	// (e.g. exit 2 for hook-block) to the calling agent runtime; without
-	// it some cmd.exe invocations silently reset the exit code.
-	content := "@echo off\r\n\"" + bashExe + "\" \"" + shPath + "\" %*\r\nexit /b %ERRORLEVEL%\r\n"
-	return os.WriteFile(cmdPath, []byte(content), 0o700)
+// hookConfigSidecarName is the file the native Go hook entrypoint reads on
+// Windows for the gateway address + fail mode. It lets the agent hook command
+// stay free of per-install flags (so its trust-hash / match string is stable),
+// while still conveying the operator's enforcement choice and a non-default
+// API port. The Bash hooks (Unix) bake these values into the script and ignore
+// this file.
+const hookConfigSidecarName = ".hookcfg"
+
+// writeHookConfigSidecar persists the gateway address and fail mode the native
+// Go hook entrypoint resolves at runtime. It is only written on Windows, where
+// the native entrypoint replaces the Bash hooks; Unix keeps the .sh hooks
+// unchanged and never reads this file.
+func writeHookConfigSidecar(hookDir, apiAddr, failMode string) error {
+	if runtime.GOOS != "windows" {
+		return nil
+	}
+	body := fmt.Sprintf("DEFENSECLAW_GATEWAY_ADDR=%s\nDEFENSECLAW_FAIL_MODE=%s\n",
+		apiAddr, normalizeHookFailMode(failMode))
+	path := filepath.Join(hookDir, hookConfigSidecarName)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		return fmt.Errorf("write hook config sidecar: %w", err)
+	}
+	return nil
 }
 
 func hookScriptNamesForConnector(opts SetupOpts, c Connector) []string {

--- a/internal/gateway/connector/subprocess.go
+++ b/internal/gateway/connector/subprocess.go
@@ -396,8 +396,37 @@ func writeHookScriptsCommonWithFailMode(hookDir, apiAddr, token, failMode string
 		if err := os.WriteFile(hookPath, []byte(rendered), 0o700); err != nil {
 			return fmt.Errorf("write hook %s: %w", name, err)
 		}
+		// On Windows, agent runtimes cannot execute .sh files directly and
+		// may run them through a shell that cannot exec Windows .exe files.
+		// Write a .cmd wrapper alongside each .sh hook so connectors can
+		// reference the .cmd path as the hook command — cmd.exe runs it
+		// natively and forwards stdin/stdout to Git Bash correctly.
+		if runtime.GOOS == "windows" && strings.HasSuffix(name, ".sh") {
+			if err := writeWindowsHookWrapper(hookDir, name); err != nil {
+				return fmt.Errorf("write windows hook wrapper %s: %w", name, err)
+			}
+		}
 	}
 	return nil
+}
+
+// writeWindowsHookWrapper writes a .cmd file that calls Git Bash to execute
+// the corresponding .sh hook. Using a .cmd wrapper avoids the ambiguity of
+// which bash (Git Bash vs WSL) a runtime picks up from PATH, and ensures
+// cmd.exe — which always works on Windows — is the entry point.
+func writeWindowsHookWrapper(hookDir, shName string) error {
+	bashExe := filepath.ToSlash(resolveWindowsBash())
+	// Strip leading/trailing quotes resolveWindowsBash may add.
+	bashExe = strings.Trim(bashExe, `"`)
+	shPath := filepath.ToSlash(filepath.Join(hookDir, shName))
+	cmdName := strings.TrimSuffix(shName, ".sh") + ".cmd"
+	cmdPath := filepath.Join(hookDir, cmdName)
+	// %* forwards any extra arguments; stdin/stdout are inherited by cmd.exe.
+	// "exit /b %ERRORLEVEL%" explicitly propagates the bash exit code
+	// (e.g. exit 2 for hook-block) to the calling agent runtime; without
+	// it some cmd.exe invocations silently reset the exit code.
+	content := "@echo off\r\n\"" + bashExe + "\" \"" + shPath + "\" %*\r\nexit /b %ERRORLEVEL%\r\n"
+	return os.WriteFile(cmdPath, []byte(content), 0o700)
 }
 
 func hookScriptNamesForConnector(opts SetupOpts, c Connector) []string {

--- a/internal/gateway/connector/zeptoclaw.go
+++ b/internal/gateway/connector/zeptoclaw.go
@@ -524,11 +524,12 @@ func zeptoClawConfigPath() string {
 
 // zeptoClawHomeDir returns the ZeptoClaw home directory. Priority:
 // ZEPTOCLAW_HOME env (custom override) → $HOME/.zeptoclaw (default).
+// userHomeDir keeps this cross-platform (e.g. %USERPROFILE% on Windows).
 func zeptoClawHomeDir() string {
 	if home := os.Getenv("ZEPTOCLAW_HOME"); home != "" {
 		return home
 	}
-	return filepath.Join(os.Getenv("HOME"), ".zeptoclaw")
+	return filepath.Join(userHomeDir(), ".zeptoclaw")
 }
 
 // patchZeptoClawConfig reads ZeptoClaw's config.json, backs up the original

--- a/internal/gateway/connector/zeptoclaw.go
+++ b/internal/gateway/connector/zeptoclaw.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 )
@@ -119,6 +120,13 @@ func (c *ZeptoClawConnector) AllowedHosts() []string {
 }
 
 func (c *ZeptoClawConnector) Setup(ctx context.Context, opts SetupOpts) error {
+	// Proxy connectors require the local guardrail proxy, which DefenseClaw
+	// does not host on Windows (hook-only there). Fail clearly instead of
+	// planting a half-configured proxy connector.
+	if !ConnectorSupportedOnHostOS(c.Name()) {
+		return errConnectorUnsupportedOnOS(c.Name(), runtime.GOOS)
+	}
+
 	// Surface 1: Patch ZeptoClaw config to route api_base through proxy.
 	if err := c.patchZeptoClawConfig(opts); err != nil {
 		return fmt.Errorf("zeptoclaw config patch: %w", err)

--- a/internal/notify/notify_windows.go
+++ b/internal/notify/notify_windows.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package notify
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+var fallbackWriter io.Writer = os.Stderr
+
+// sendPlatform on Windows writes to stderr. Native Windows toast
+// notifications require COM/WinRT which is out of scope for v1.
+func sendPlatform(n Notification) error {
+	return fmt.Errorf("native notifications not supported on Windows")
+}

--- a/scripts/live-connector-e2e/contract-smoke.sh
+++ b/scripts/live-connector-e2e/contract-smoke.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Layer A — Contract entrypoint smoke (deterministic, no LLM, no secrets,
+# every OS). For one connector this script:
+#
+#   1. `defenseclaw setup <connector> --mode action` (installs the hook
+#      entrypoint + wires the agent config + restarts the gateway).
+#   2. Feeds every golden stdin payload under golden/<connector>/ into the
+#      *installed* hook entrypoint:
+#        - unix:    ~/.defenseclaw/hooks/<connector>-hook.sh
+#        - windows: defenseclaw-gateway hook --connector <name> --event <ev>
+#   3. Asserts the gateway received the event (fires) and that the entrypoint
+#      shaped the verdict correctly (allow -> exit 0; block -> exit 2 or a
+#      decision JSON carrying block/deny).
+#   4. Tears down and asserts the agent config is restored clean.
+#
+# This proves the decode -> map -> respond contract through the real installed
+# entrypoint on every OS, complementing the Go contract matrix (which proves
+# the same chain at the handler level). The block payload reads /etc/shadow
+# (rule PATH-ETC-SHADOW, CRITICAL) so it is denied deterministically without
+# an LLM and is harmless if a regression ever lets it through.
+#
+# Usage: contract-smoke.sh <connector>
+
+set -euo pipefail
+
+DC_E2E_CONNECTOR="${1:?usage: contract-smoke.sh <connector>}"
+export DC_E2E_CONNECTOR
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+. "${HERE}/lib/common.sh"
+# shellcheck source=lib/assert.sh
+. "${HERE}/lib/assert.sh"
+# shellcheck source=lib/setup.sh
+. "${HERE}/lib/setup.sh"
+
+golden_dir="${DC_E2E_GOLDEN_DIR}/${DC_E2E_CONNECTOR}"
+if [ ! -d "${golden_dir}" ]; then
+  dc_die "no golden payloads for connector ${DC_E2E_CONNECTOR} (expected ${golden_dir})"
+fi
+
+dc_section "contract smoke: ${DC_E2E_CONNECTOR} ($(dc_detect_os))"
+
+dc_init_defenseclaw
+dc_setup_connector "${DC_E2E_CONNECTOR}" action
+
+overall_rc=0
+
+# drive_event <event_label> <payload_file> <expect:allow|block>
+drive_event() {
+  local label="$1" payload="$2" expect="$3"
+  local before after out code
+  before="$(dc_gateway_jsonl_count)"
+  out="$(dc_invoke_hook "${DC_E2E_CONNECTOR}" "${label}" "${payload}")"
+  code="$(printf '%s\n' "${out}" | sed -n 's/^exit:\([0-9]\+\)$/\1/p' | tail -1)"
+  # Give the gateway a beat to flush the JSONL line.
+  sleep 1
+  after="$(dc_gateway_jsonl_count)"
+
+  # Fires: gateway received an event attributed to this connector.
+  if dc_assert_fired "${DC_E2E_CONNECTOR}" "${before}"; then
+    dc_record_result "${label}:fires" pass "jsonl ${before}->${after}"
+  else
+    dc_record_result "${label}:fires" fail "jsonl ${before}->${after} exit=${code}"
+    overall_rc=1
+  fi
+
+  case "${expect}" in
+    block)
+      # Verdict shaping: the entrypoint must signal block — either a
+      # non-zero (exit 2) deny or a decision JSON carrying block/deny.
+      if [ "${code}" = "2" ] || printf '%s' "${out}" | grep -Eqi '"(decision|action|permissionDecision)"\s*:\s*"(block|deny)"|\bdeny\b|\bblock\b'; then
+        dc_record_result "${label}:verdict-shape" pass "exit=${code}"
+      else
+        dc_record_result "${label}:verdict-shape" fail "expected block shaping, exit=${code}"
+        overall_rc=1
+      fi
+      # Corroborate with a gateway-side block verdict.
+      if dc_assert_verdict_block "${before}"; then
+        dc_record_result "${label}:verdict-gateway" pass ""
+      else
+        dc_record_result "${label}:verdict-gateway" fail "no block verdict recorded"
+        overall_rc=1
+      fi
+      ;;
+    allow)
+      if [ "${code}" = "0" ]; then
+        dc_record_result "${label}:verdict-shape" pass "exit=0"
+      else
+        dc_record_result "${label}:verdict-shape" fail "expected allow (exit 0), exit=${code}"
+        overall_rc=1
+      fi
+      ;;
+  esac
+}
+
+# Drive whatever golden payloads exist for this connector.
+[ -f "${golden_dir}/session_start.json" ] && drive_event "SessionStart" "${golden_dir}/session_start.json" allow
+[ -f "${golden_dir}/pre_tool_allow.json" ] && drive_event "PreTool-allow" "${golden_dir}/pre_tool_allow.json" allow
+[ -f "${golden_dir}/pre_tool_block.json" ] && drive_event "PreTool-block" "${golden_dir}/pre_tool_block.json" block
+
+# Schema invariant over everything emitted so far.
+if dc_assert_schema 1; then
+  dc_record_result "schema" pass ""
+else
+  dc_record_result "schema" fail "gateway.jsonl schema validation failed"
+  overall_rc=1
+fi
+
+# Teardown + clean-state assertion.
+cfg="$(dc_connector_config_file "${DC_E2E_CONNECTOR}")"
+if dc_teardown_connector "${DC_E2E_CONNECTOR}"; then
+  if dc_assert_teardown "${DC_E2E_CONNECTOR}" "${cfg}"; then
+    dc_record_result "teardown" pass ""
+  else
+    dc_record_result "teardown" fail "config not restored: ${cfg}"
+    overall_rc=1
+  fi
+else
+  dc_record_result "teardown" fail "connector verify reported residual state"
+  overall_rc=1
+fi
+
+exit "${overall_rc}"

--- a/scripts/live-connector-e2e/cursor-validation.sh
+++ b/scripts/live-connector-e2e/cursor-validation.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# One-time gate: does headless `cursor-agent -p` actually fire
+# ~/.cursor/hooks.json? Cursor exposes both a project cli-config.json and a
+# user hooks.json; it is not guaranteed the agentic-print mode honors the hook
+# bus. This script installs cursor-agent, wires DefenseClaw, drives a trivial
+# prompt, and checks whether any cursor-tagged event reached the gateway.
+#
+# Exit 0 + "CURSOR_HOOKS_FIRE=1" on $GITHUB_OUTPUT  -> live Cursor coverage is
+# valid; the workflow then runs drivers/cursor.sh.
+# Exit non-zero                                     -> Cursor stays Layer-A only.
+
+set -euo pipefail
+export DC_E2E_CONNECTOR=cursor
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${HERE}/lib/common.sh"
+. "${HERE}/lib/assert.sh"
+. "${HERE}/lib/setup.sh"
+
+dc_section "cursor headless hook validation"
+
+if ! command -v cursor-agent >/dev/null 2>&1; then
+  curl https://cursor.com/install -fsS | bash || dc_die "cursor-agent install failed"
+  export PATH="${HOME}/.local/bin:${PATH}"
+fi
+DC_E2E_AGENT_VERSION="$(dc_capture_version cursor cursor-agent --version)"
+export DC_E2E_AGENT_VERSION
+dc_write_env_key CURSOR_API_KEY "${CURSOR_API_KEY:-}"
+
+dc_init_defenseclaw
+dc_setup_connector cursor action
+
+before="$(dc_gateway_jsonl_count)"
+dc_log "driving trivial headless prompt through cursor-agent"
+dc_timeout 120 cursor-agent -p "Reply with only the word ready. Do not use any tools." \
+  --output-format json --force >/tmp/dc-cursor-validation.log 2>&1 || \
+  dc_warn "cursor-agent exited non-zero (see /tmp/dc-cursor-validation.log)"
+sleep 2
+
+fired=1
+if dc_assert_fired cursor "${before}"; then
+  dc_log "RESULT: cursor-agent -p FIRES ~/.cursor/hooks.json"
+  dc_record_result "validation:hooks-fire" pass ""
+else
+  fired=0
+  dc_log "RESULT: cursor-agent -p did NOT fire the hook bus"
+  dc_record_result "validation:hooks-fire" fail "no cursor events reached gateway in -p mode"
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  printf 'cursor_hooks_fire=%s\n' "${fired}" >> "${GITHUB_OUTPUT}"
+fi
+dc_teardown_connector cursor || true
+
+[ "${fired}" = "1" ]

--- a/scripts/live-connector-e2e/drivers/_driver_common.sh
+++ b/scripts/live-connector-e2e/drivers/_driver_common.sh
@@ -1,0 +1,187 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared Layer-B (live agent) orchestration. A per-connector driver sources
+# this file plus lib/{common,assert,setup}.sh, then defines three callbacks:
+#
+#   agent_install        -> install the real upstream agent at target version,
+#                           point it at the cheapest model, and set
+#                           DC_E2E_AGENT_VERSION.
+#   agent_run <prompt>   -> run the agent headlessly with <prompt> to
+#                           completion (auto-approving tools so the harness
+#                           fires its lifecycle + tool hooks deterministically).
+#
+# ...and sets capability flags before calling dc_driver_main:
+#   DC_DRIVER_MODE        observe|action     (default action)
+#   DC_DRIVER_SUPPORTS_BLOCK   1|0           (default 1)
+#   DC_DRIVER_SUPPORTS_OTLP    1|0           (default 0; set 1 for native_otlp)
+#
+# The orchestration is deterministic because hooks are harness-driven: the
+# agent fires SessionStart/PreToolUse/etc. as a function of its lifecycle, not
+# of an LLM decision. We only need the model to choose to run the one shell
+# command we explicitly instruct.
+
+DC_DRIVER_MODE="${DC_DRIVER_MODE:-action}"
+DC_DRIVER_SUPPORTS_BLOCK="${DC_DRIVER_SUPPORTS_BLOCK:-1}"
+DC_DRIVER_SUPPORTS_OTLP="${DC_DRIVER_SUPPORTS_OTLP:-0}"
+
+# Deterministic prompts. We keep them single-purpose and explicit so the
+# cheapest model reliably emits exactly one tool call.
+DC_PROMPT_LIFECYCLE='Reply with only the word ready. Do not use any tools.'
+
+# dc_timeout <seconds> <cmd...> — bound a live agent invocation. Uses GNU
+# timeout / gtimeout when present; otherwise runs unbounded (CI runners ship
+# coreutils, so this is just a local-dev fallback).
+dc_timeout() {
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout --signal=TERM "${secs}" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout --signal=TERM "${secs}" "$@"
+  else
+    "$@"
+  fi
+}
+
+# dc_allow_prompt <sentinel_path> — instruct the agent to run one benign
+# command that creates the sentinel (proves the tool call was allowed).
+dc_allow_prompt() {
+  printf 'Run exactly this shell command and nothing else: printf dc-allow > %s' "$1"
+}
+
+# dc_block_prompt <sentinel_path> — instruct the agent to run one command that
+# DefenseClaw blocks (reads /etc/shadow -> rule PATH-ETC-SHADOW, CRITICAL).
+# The redirect target would be created the instant the shell runs, so if the
+# command is allowed to execute at all the sentinel appears and the block
+# assertion fails. Reading /etc/shadow is harmless (permission denied) if a
+# regression ever lets it through.
+dc_block_prompt() {
+  printf 'Run exactly this shell command and nothing else: cat /etc/shadow > %s' "$1"
+}
+
+# dc_run_probe <label> <prompt> — run the agent (via the driver's agent_run
+# callback, which is responsible for bounding itself with dc_timeout) and
+# return the gateway.jsonl line count captured immediately before the run so
+# callers can scope "fired during this probe" assertions. Echoes the
+# before-count. agent_run's stdout/stderr is tee'd to a per-probe log.
+dc_run_probe() {
+  local label="$1" prompt="$2" before
+  before="$(dc_gateway_jsonl_count)"
+  dc_log "probe[${label}]: running agent"
+  if ! agent_run "${prompt}" >"/tmp/dc-agent-${label}.log" 2>&1; then
+    dc_warn "probe[${label}]: agent run exited non-zero or timed out (see /tmp/dc-agent-${label}.log)"
+  fi
+  sleep 2  # let the gateway flush JSONL/audit rows
+  printf '%s' "${before}"
+}
+
+# dc_driver_main <connector> — the full live cell.
+dc_driver_main() {
+  local connector="$1"
+  export DC_E2E_CONNECTOR="${connector}"
+  local rc=0
+
+  dc_section "live driver: ${connector} ($(dc_detect_os)) mode=${DC_DRIVER_MODE}"
+
+  # 1. Install the real agent.
+  if agent_install; then
+    dc_record_result "install" pass "${DC_E2E_AGENT_VERSION:-unknown}"
+  else
+    dc_record_result "install" fail "agent install failed"
+    return 1
+  fi
+
+  # 2. DefenseClaw init + connector setup.
+  dc_init_defenseclaw
+  dc_clear_sentinels
+  if dc_setup_connector "${connector}" "${DC_DRIVER_MODE}"; then
+    dc_record_result "setup" pass "mode=${DC_DRIVER_MODE}"
+  else
+    dc_record_result "setup" fail "defenseclaw setup ${connector} failed"
+    return 1
+  fi
+
+  local lifecycle_before
+  # 3. Lifecycle probe — proves SessionStart/UserPromptSubmit/Stop fire.
+  lifecycle_before="$(dc_run_probe lifecycle "${DC_PROMPT_LIFECYCLE}" 120)"
+  if dc_assert_fired "${connector}" "${lifecycle_before}"; then
+    dc_record_result "lifecycle:fires" pass ""
+  else
+    dc_record_result "lifecycle:fires" fail "no lifecycle events reached gateway"
+    rc=1
+  fi
+
+  # 4. Allow (observe) probe — forced tool call that policy permits.
+  local allow_token allow_path allow_before
+  allow_token="$(dc_new_sentinel_token)"; allow_path="$(dc_sentinel_path "${allow_token}")"
+  allow_before="$(dc_run_probe allow "$(dc_allow_prompt "${allow_path}")" 180)"
+  if dc_assert_fired "${connector}" "${allow_before}"; then
+    dc_record_result "tool-allow:fires" pass ""
+  else
+    dc_record_result "tool-allow:fires" fail "tool event did not reach gateway"
+    rc=1
+  fi
+  if dc_assert_allowed "${allow_token}"; then
+    dc_record_result "tool-allow:observe" pass "sentinel created"
+  else
+    dc_record_result "tool-allow:observe" fail "benign command never ran"
+    rc=1
+  fi
+
+  # 5. Block probe — forced dangerous tool call that action mode must deny.
+  if [ "${DC_DRIVER_SUPPORTS_BLOCK}" = "1" ] && [ "${DC_DRIVER_MODE}" = "action" ]; then
+    local block_token block_path block_before
+    block_token="$(dc_new_sentinel_token)"; block_path="$(dc_sentinel_path "${block_token}")"
+    block_before="$(dc_run_probe block "$(dc_block_prompt "${block_path}")" 180)"
+    if dc_assert_fired "${connector}" "${block_before}"; then
+      dc_record_result "tool-block:fires" pass ""
+    else
+      dc_record_result "tool-block:fires" fail "tool event did not reach gateway"
+      rc=1
+    fi
+    if dc_assert_blocked "${block_token}" "${block_before}"; then
+      dc_record_result "tool-block:enforced" pass "sentinel absent + block verdict"
+    else
+      dc_record_result "tool-block:enforced" fail "enforcement not confirmed"
+      rc=1
+    fi
+  else
+    dc_record_result "tool-block:enforced" skip "block not supported headless for ${connector}"
+  fi
+
+  # 6. OTLP telemetry (native_otlp connectors only).
+  if [ "${DC_DRIVER_SUPPORTS_OTLP}" = "1" ]; then
+    if dc_assert_otlp "${connector}" "${lifecycle_before}"; then
+      dc_record_result "otlp" pass ""
+    else
+      dc_record_result "otlp" fail "no connector-tagged telemetry reached the OTLP sink"
+      rc=1
+    fi
+  fi
+
+  # 7. Shared observability invariants over all traffic emitted this run.
+  if dc_assert_observability; then
+    dc_record_result "observability" pass ""
+  else
+    dc_record_result "observability" fail "Phase 6 observability invariants failed"
+    rc=1
+  fi
+
+  # 8. Teardown + clean-state.
+  local cfg; cfg="$(dc_connector_config_file "${connector}")"
+  if dc_teardown_connector "${connector}" && dc_assert_teardown "${connector}" "${cfg}"; then
+    dc_record_result "teardown" pass ""
+  else
+    dc_record_result "teardown" fail "residual state after teardown"
+    rc=1
+  fi
+
+  return "${rc}"
+}

--- a/scripts/live-connector-e2e/drivers/claudecode.sh
+++ b/scripts/live-connector-e2e/drivers/claudecode.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Live driver for Anthropic Claude Code.
+#   - install:  npm i -g @anthropic-ai/claude-code@${CLAUDE_VERSION:-latest}
+#   - headless: claude -p "<prompt>" --output-format json
+#   - auth:     ANTHROPIC_API_KEY (Anthropic direct) OR Amazon Bedrock when
+#               DC_USE_BEDROCK=1 (CLAUDE_CODE_USE_BEDROCK + AWS creds).
+#   - hooks:    SessionStart / UserPromptSubmit / PreToolUse / PostToolUse /
+#               Stop. PreToolUse deny is honored even when tools are
+#               auto-approved, so block enforcement is testable headless.
+#   - ask:      Claude's native PermissionRequest "ask" path is NOT reachable
+#               headless (no interactive approver), so ask coverage stays in
+#               Layer A only — we do not assert it here.
+#   - OTLP:     native exporter wired by `defenseclaw setup claude-code`.
+#
+# Bedrock: when DC_USE_BEDROCK=1 we set CLAUDE_CODE_USE_BEDROCK=1, point the
+# model at a Bedrock inference-profile id, and rely on the AWS credential chain
+# (AWS_BEARER_TOKEN_BEDROCK, or AWS_ACCESS_KEY_ID/SECRET[/SESSION_TOKEN]) +
+# AWS_REGION. The small/fast background model must also be a Bedrock id.
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${HERE}/../lib/common.sh"
+. "${HERE}/../lib/assert.sh"
+. "${HERE}/../lib/setup.sh"
+. "${HERE}/_driver_common.sh"
+
+DC_DRIVER_MODE=action
+DC_DRIVER_SUPPORTS_BLOCK=1
+DC_DRIVER_SUPPORTS_OTLP=1
+
+CLAUDE_MODEL="${CLAUDE_MODEL:-claude-haiku-4-5}"
+
+agent_install() {
+  npm install -g "@anthropic-ai/claude-code@${CLAUDE_VERSION:-latest}" || return 1
+  DC_E2E_AGENT_VERSION="$(dc_capture_version claudecode claude --version)"
+  export DC_E2E_AGENT_VERSION
+
+  if [ "${DC_USE_BEDROCK:-0}" = "1" ]; then
+    if [ -z "${AWS_BEARER_TOKEN_BEDROCK:-}" ] && [ -z "${AWS_ACCESS_KEY_ID:-}" ]; then
+      dc_err "DC_USE_BEDROCK=1 needs AWS auth (AWS_BEARER_TOKEN_BEDROCK or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY)"
+      return 1
+    fi
+    export CLAUDE_CODE_USE_BEDROCK=1
+    export AWS_REGION="${AWS_REGION:-us-east-1}"
+    CLAUDE_MODEL="${CLAUDE_BEDROCK_MODEL:-us.anthropic.claude-haiku-4-5-20251001-v1:0}"
+    export ANTHROPIC_MODEL="${CLAUDE_MODEL}"
+    export ANTHROPIC_SMALL_FAST_MODEL="${ANTHROPIC_SMALL_FAST_MODEL:-${CLAUDE_MODEL}}"
+    dc_log "claude code configured for Bedrock model ${CLAUDE_MODEL} (region ${AWS_REGION})"
+  else
+    dc_write_env_key ANTHROPIC_API_KEY "${ANTHROPIC_API_KEY:-}"
+  fi
+}
+
+agent_run() {
+  local prompt="$1"
+  # acceptEdits auto-approves benign tool calls so the allow probe runs, while
+  # PreToolUse hooks still fire (and can still deny) for the block probe.
+  dc_timeout 180 claude -p "${prompt}" \
+    --output-format json \
+    --model "${CLAUDE_MODEL}" \
+    --permission-mode acceptEdits \
+    --allowedTools "Bash"
+}
+
+dc_driver_main claudecode

--- a/scripts/live-connector-e2e/drivers/codex.sh
+++ b/scripts/live-connector-e2e/drivers/codex.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Live driver for OpenAI Codex CLI.
+#   - install:  npm i -g @openai/codex@${CODEX_VERSION:-latest}
+#   - headless: codex exec --json --full-auto "<prompt>"
+#   - auth:     OPENAI_API_KEY (public OpenAI) OR Azure OpenAI when
+#               DC_USE_AZURE=1 (Codex cannot use Bedrock — it is OpenAI-only).
+#   - hooks:    SessionStart / UserPromptSubmit / PreToolUse / PostToolUse /
+#               Stop. Native OTLP exporter is wired by `defenseclaw setup
+#               codex --restart`, so OTLP is asserted.
+#   - trust:    Codex hashes the hook command and refuses to run an
+#               unrecognized one. `defenseclaw setup codex` pre-seeds trust;
+#               on Windows the native `defenseclaw-gateway hook` command +
+#               .hookcfg keep the hash stable. CODEX_BYPASS_HOOK_TRUST=1 adds
+#               the documented escape hatch if a runner starts cold.
+#
+# Azure: when DC_USE_AZURE=1 we write a [model_providers.azure] block into
+# ~/.codex/config.toml BEFORE `defenseclaw setup codex`. That setup only
+# mutates the [hooks]/[otel]/notify tables (it parses the file into a map and
+# re-marshals), so the Azure provider survives. Codex then talks to Azure
+# directly for LLM traffic; the hook bus + OTLP are unaffected. Requires
+# AZURE_OPENAI_ENDPOINT (resource URL), AZURE_OPENAI_DEPLOYMENT (used as the
+# model — must be a Codex-capable deployment), and AZURE_OPENAI_API_KEY.
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${HERE}/../lib/common.sh"
+. "${HERE}/../lib/assert.sh"
+. "${HERE}/../lib/setup.sh"
+. "${HERE}/_driver_common.sh"
+
+DC_DRIVER_MODE=action
+DC_DRIVER_SUPPORTS_BLOCK=1
+DC_DRIVER_SUPPORTS_OTLP=1
+
+CODEX_MODEL="${CODEX_MODEL:-gpt-5-mini}"
+
+# _codex_azure_base_url — normalize AZURE_OPENAI_ENDPOINT to the v1 Responses
+# base URL Codex expects (".../openai/v1"). Idempotent if the caller already
+# included /openai or /openai/v1.
+_codex_azure_base_url() {
+  local ep="${AZURE_OPENAI_ENDPOINT%/}"
+  ep="${ep%/openai/v1}"
+  ep="${ep%/openai}"
+  ep="${ep%/}"
+  printf '%s/openai/v1' "${ep}"
+}
+
+# _codex_write_azure_config — seed ~/.codex/config.toml with the Azure provider
+# so `defenseclaw setup codex` merges its tables on top of it. env_key holds the
+# NAME of the env var (never the key value), so no secret is written to disk.
+_codex_write_azure_config() {
+  mkdir -p "${HOME}/.codex"
+  cat > "${HOME}/.codex/config.toml" <<EOF
+model = "${AZURE_OPENAI_DEPLOYMENT}"
+model_provider = "azure"
+
+[model_providers.azure]
+name = "Azure OpenAI"
+base_url = "$(_codex_azure_base_url)"
+env_key = "AZURE_OPENAI_API_KEY"
+wire_api = "responses"
+EOF
+}
+
+agent_install() {
+  npm install -g "@openai/codex@${CODEX_VERSION:-latest}" || return 1
+  DC_E2E_AGENT_VERSION="$(dc_capture_version codex codex --version)"
+  export DC_E2E_AGENT_VERSION
+
+  if [ "${DC_USE_AZURE:-0}" = "1" ]; then
+    if [ -z "${AZURE_OPENAI_ENDPOINT:-}" ] || [ -z "${AZURE_OPENAI_DEPLOYMENT:-}" ] || [ -z "${AZURE_OPENAI_API_KEY:-}" ]; then
+      dc_err "DC_USE_AZURE=1 needs AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_DEPLOYMENT + AZURE_OPENAI_API_KEY"
+      return 1
+    fi
+    CODEX_MODEL="${AZURE_OPENAI_DEPLOYMENT}"
+    export AZURE_OPENAI_API_KEY
+    _codex_write_azure_config
+    dc_log "codex configured for Azure OpenAI deployment ${AZURE_OPENAI_DEPLOYMENT}"
+  else
+    dc_write_env_key OPENAI_API_KEY "${OPENAI_API_KEY:-}"
+  fi
+}
+
+agent_run() {
+  local prompt="$1" extra=()
+  [ "${CODEX_BYPASS_HOOK_TRUST:-0}" = "1" ] && extra+=(--dangerously-bypass-hook-trust)
+  dc_timeout 180 codex exec --json --full-auto \
+    --model "${CODEX_MODEL}" \
+    "${extra[@]}" \
+    "${prompt}"
+}
+
+dc_driver_main codex

--- a/scripts/live-connector-e2e/drivers/copilot.sh
+++ b/scripts/live-connector-e2e/drivers/copilot.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Live driver for GitHub Copilot CLI.
+#   - install:  npm i -g @github/copilot@${COPILOT_VERSION:-latest}
+#   - headless: copilot -p "<prompt>" --allow-all-tools
+#   - auth:     an ENTITLED GitHub token (Copilot subscription). Provide it via
+#               the COPILOT_CLI_TOKEN secret; we export it as GH_COPILOT_TOKEN
+#               and GITHUB_TOKEN so the CLI picks it up.
+#   - hooks:    USER-LEVEL ONLY. Repo-level .github/hooks/*.json do NOT load in
+#               `-p` mode (upstream bug github/copilot-cli#3345), so
+#               `defenseclaw setup copilot` must write ~/.copilot/hooks/*.json.
+#               We force user scope by NOT passing --workspace.
+#   - status:   continue-on-error in the workflow until proven stable.
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${HERE}/../lib/common.sh"
+. "${HERE}/../lib/assert.sh"
+. "${HERE}/../lib/setup.sh"
+. "${HERE}/_driver_common.sh"
+
+DC_DRIVER_MODE=action
+DC_DRIVER_SUPPORTS_BLOCK=1
+DC_DRIVER_SUPPORTS_OTLP=0
+
+agent_install() {
+  npm install -g "@github/copilot@${COPILOT_VERSION:-latest}" || return 1
+  DC_E2E_AGENT_VERSION="$(dc_capture_version copilot copilot --version)"
+  export DC_E2E_AGENT_VERSION
+  # Copilot CLI reads an entitled token from the environment.
+  export GH_COPILOT_TOKEN="${COPILOT_CLI_TOKEN:-${GH_COPILOT_TOKEN:-}}"
+  export GITHUB_TOKEN="${COPILOT_CLI_TOKEN:-${GITHUB_TOKEN:-}}"
+}
+
+agent_run() {
+  local prompt="$1"
+  dc_timeout 180 copilot -p "${prompt}" --allow-all-tools
+}
+
+dc_driver_main copilot

--- a/scripts/live-connector-e2e/drivers/cursor.sh
+++ b/scripts/live-connector-e2e/drivers/cursor.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Live driver for Cursor Agent (cursor-agent CLI).
+#   - install:  curl https://cursor.com/install -fsS | bash
+#   - headless: cursor-agent -p "<prompt>" --output-format json --force
+#   - auth:     CURSOR_API_KEY
+#   - hooks:    beforeShellExecution can deny (can_ask_native), so block is
+#               testable headless.
+#
+# GATING: live Cursor coverage is only meaningful if headless `cursor-agent -p`
+# actually fires ~/.cursor/hooks.json. Run cursor-validation.sh first; the
+# workflow gates this driver on its result.
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${HERE}/../lib/common.sh"
+. "${HERE}/../lib/assert.sh"
+. "${HERE}/../lib/setup.sh"
+. "${HERE}/_driver_common.sh"
+
+DC_DRIVER_MODE=action
+DC_DRIVER_SUPPORTS_BLOCK=1
+DC_DRIVER_SUPPORTS_OTLP=0
+
+agent_install() {
+  if ! command -v cursor-agent >/dev/null 2>&1; then
+    curl https://cursor.com/install -fsS | bash || return 1
+    export PATH="${HOME}/.local/bin:${PATH}"
+  fi
+  DC_E2E_AGENT_VERSION="$(dc_capture_version cursor cursor-agent --version)"
+  export DC_E2E_AGENT_VERSION
+  dc_write_env_key CURSOR_API_KEY "${CURSOR_API_KEY:-}"
+}
+
+agent_run() {
+  local prompt="$1"
+  dc_timeout 180 cursor-agent -p "${prompt}" --output-format json --force
+}
+
+dc_driver_main cursor

--- a/scripts/live-connector-e2e/drivers/geminicli.sh
+++ b/scripts/live-connector-e2e/drivers/geminicli.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Live driver for Google Gemini CLI.
+#   - install:  npm i -g @google/gemini-cli@${GEMINI_VERSION:-latest}
+#   - headless: gemini -p "<prompt>" -o json --approval-mode yolo
+#   - auth:     GEMINI_API_KEY (or GOOGLE_API_KEY)
+#   - hooks:    Gemini's hook events are advisory (SessionStart / PreCompress /
+#               Notification / BeforeTool) — the harness records them but does
+#               not honor a deny verdict, so we assert fires + observe + OTLP
+#               only and skip the block assertion (DC_DRIVER_SUPPORTS_BLOCK=0).
+#   - OTLP:     native exporter wired by `defenseclaw setup geminicli`.
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${HERE}/../lib/common.sh"
+. "${HERE}/../lib/assert.sh"
+. "${HERE}/../lib/setup.sh"
+. "${HERE}/_driver_common.sh"
+
+DC_DRIVER_MODE=action
+DC_DRIVER_SUPPORTS_BLOCK=0   # advisory events cannot block
+DC_DRIVER_SUPPORTS_OTLP=1
+
+GEMINI_MODEL="${GEMINI_MODEL:-gemini-2.5-flash}"
+
+agent_install() {
+  npm install -g "@google/gemini-cli@${GEMINI_VERSION:-latest}" || return 1
+  DC_E2E_AGENT_VERSION="$(dc_capture_version geminicli gemini --version)"
+  export DC_E2E_AGENT_VERSION
+  dc_write_env_key GEMINI_API_KEY "${GEMINI_API_KEY:-${GOOGLE_API_KEY:-}}"
+}
+
+agent_run() {
+  local prompt="$1"
+  dc_timeout 180 gemini -p "${prompt}" -o json \
+    --model "${GEMINI_MODEL}" \
+    --approval-mode yolo
+}
+
+dc_driver_main geminicli

--- a/scripts/live-connector-e2e/drivers/openhands.sh
+++ b/scripts/live-connector-e2e/drivers/openhands.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Live driver for OpenHands (headless CLI).
+#   - install:  pipx/uv install openhands-ai (the `openhands` console script)
+#   - headless: openhands --headless -t "<prompt>"
+#   - auth:     LLM_API_KEY + LLM_MODEL (OpenHands' provider-agnostic env).
+#               OpenHands routes through LiteLLM, so it can target the public
+#               provider (default), Amazon Bedrock (DC_USE_BEDROCK=1), or
+#               Azure OpenAI (DC_USE_AZURE=1). Bedrock wins if both are set.
+#   - runtime:  Docker. LINUX ONLY — macOS/Windows runners lack a usable Docker
+#               daemon for the agent runtime, so the workflow restricts this
+#               connector to ubuntu-latest.
+#   - hooks:    PreToolUse deny is honored (exit-2 style), so block is testable.
+#
+# Bedrock: LLM_MODEL=bedrock/<inference-profile>; LiteLLM uses the AWS chain
+#   (AWS_BEARER_TOKEN_BEDROCK or AWS_ACCESS_KEY_ID/SECRET[/SESSION_TOKEN]) +
+#   AWS_REGION. No LLM_API_KEY needed.
+# Azure:   LLM_MODEL=azure/<deployment>; LiteLLM reads AZURE_API_KEY /
+#   AZURE_API_BASE / AZURE_API_VERSION (derived from AZURE_OPENAI_* here).
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${HERE}/../lib/common.sh"
+. "${HERE}/../lib/assert.sh"
+. "${HERE}/../lib/setup.sh"
+. "${HERE}/_driver_common.sh"
+
+DC_DRIVER_MODE=action
+DC_DRIVER_SUPPORTS_BLOCK=1
+DC_DRIVER_SUPPORTS_OTLP=0
+
+OPENHANDS_MODEL="${OPENHANDS_MODEL:-openai/gpt-5-mini}"
+
+agent_install() {
+  if [ "$(dc_detect_os)" != "linux" ]; then
+    dc_warn "openhands requires Docker runtime; only supported on linux"
+    return 1
+  fi
+  if command -v uv >/dev/null 2>&1; then
+    uv tool install "openhands-ai${OPENHANDS_VERSION:+==${OPENHANDS_VERSION}}" || return 1
+  else
+    pipx install "openhands-ai${OPENHANDS_VERSION:+==${OPENHANDS_VERSION}}" || \
+      pip install --user "openhands-ai${OPENHANDS_VERSION:+==${OPENHANDS_VERSION}}" || return 1
+  fi
+  DC_E2E_AGENT_VERSION="$(dc_capture_version openhands openhands --version)"
+  export DC_E2E_AGENT_VERSION
+
+  # OpenHands resolves the LLM via LLM_* env (litellm-style model id).
+  if [ "${DC_USE_BEDROCK:-0}" = "1" ]; then
+    if [ -z "${AWS_BEARER_TOKEN_BEDROCK:-}" ] && [ -z "${AWS_ACCESS_KEY_ID:-}" ]; then
+      dc_err "DC_USE_BEDROCK=1 needs AWS auth (AWS_BEARER_TOKEN_BEDROCK or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY)"
+      return 1
+    fi
+    export AWS_REGION="${AWS_REGION:-us-east-1}"
+    export LLM_MODEL="${OPENHANDS_BEDROCK_MODEL:-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0}"
+    dc_log "openhands configured for Bedrock model ${LLM_MODEL} (region ${AWS_REGION})"
+  elif [ "${DC_USE_AZURE:-0}" = "1" ]; then
+    if [ -z "${AZURE_OPENAI_ENDPOINT:-}" ] || [ -z "${AZURE_OPENAI_DEPLOYMENT:-}" ] || [ -z "${AZURE_OPENAI_API_KEY:-}" ]; then
+      dc_err "DC_USE_AZURE=1 needs AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_DEPLOYMENT + AZURE_OPENAI_API_KEY"
+      return 1
+    fi
+    export AZURE_API_KEY="${AZURE_OPENAI_API_KEY}"
+    export AZURE_API_BASE="${AZURE_OPENAI_ENDPOINT%/}"
+    export AZURE_API_VERSION="${AZURE_OPENAI_API_VERSION:-2025-04-01-preview}"
+    export LLM_API_KEY="${AZURE_OPENAI_API_KEY}"
+    export LLM_MODEL="azure/${AZURE_OPENAI_DEPLOYMENT}"
+    dc_write_env_key LLM_API_KEY "${AZURE_OPENAI_API_KEY}"
+    dc_log "openhands configured for Azure OpenAI deployment ${AZURE_OPENAI_DEPLOYMENT}"
+  else
+    dc_write_env_key LLM_API_KEY "${LLM_API_KEY:-${OPENAI_API_KEY:-}}"
+    export LLM_MODEL="${OPENHANDS_MODEL}"
+    export LLM_API_KEY="${LLM_API_KEY:-${OPENAI_API_KEY:-}}"
+  fi
+}
+
+agent_run() {
+  local prompt="$1"
+  dc_timeout 300 openhands --headless -t "${prompt}"
+}
+
+dc_driver_main openhands

--- a/scripts/live-connector-e2e/golden/antigravity/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/antigravity/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-antigravity",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "antigravity-e2e",
+  "agent_name": "antigravity e2e agent",
+  "agent_type": "antigravity-cli",
+  "tool_name": "run_command",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/antigravity/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/antigravity/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-antigravity",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "antigravity-e2e",
+  "agent_name": "antigravity e2e agent",
+  "agent_type": "antigravity-cli",
+  "tool_name": "run_command",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/antigravity/session_start.json
+++ b/scripts/live-connector-e2e/golden/antigravity/session_start.json
@@ -1,0 +1,8 @@
+{
+  "hook_event_name": "SessionStart",
+  "session_id": "dc-e2e-antigravity",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "antigravity-e2e",
+  "agent_name": "antigravity e2e agent",
+  "agent_type": "antigravity-cli"
+}

--- a/scripts/live-connector-e2e/golden/claudecode/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/claudecode/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-claudecode",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "claudecode-e2e",
+  "agent_name": "claudecode e2e agent",
+  "agent_type": "claudecode-cli",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/claudecode/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/claudecode/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-claudecode",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "claudecode-e2e",
+  "agent_name": "claudecode e2e agent",
+  "agent_type": "claudecode-cli",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/claudecode/session_start.json
+++ b/scripts/live-connector-e2e/golden/claudecode/session_start.json
@@ -1,0 +1,8 @@
+{
+  "hook_event_name": "SessionStart",
+  "session_id": "dc-e2e-claudecode",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "claudecode-e2e",
+  "agent_name": "claudecode e2e agent",
+  "agent_type": "claudecode-cli"
+}

--- a/scripts/live-connector-e2e/golden/codex/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/codex/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-codex",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "codex-e2e",
+  "agent_name": "codex e2e agent",
+  "agent_type": "codex-cli",
+  "tool_name": "shell",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/codex/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/codex/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-codex",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "codex-e2e",
+  "agent_name": "codex e2e agent",
+  "agent_type": "codex-cli",
+  "tool_name": "shell",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/codex/session_start.json
+++ b/scripts/live-connector-e2e/golden/codex/session_start.json
@@ -1,0 +1,8 @@
+{
+  "hook_event_name": "SessionStart",
+  "session_id": "dc-e2e-codex",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "codex-e2e",
+  "agent_name": "codex e2e agent",
+  "agent_type": "codex-cli"
+}

--- a/scripts/live-connector-e2e/golden/copilot/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/copilot/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-copilot",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "copilot-e2e",
+  "agent_name": "copilot e2e agent",
+  "agent_type": "copilot-cli",
+  "tool_name": "shell",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/copilot/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/copilot/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-copilot",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "copilot-e2e",
+  "agent_name": "copilot e2e agent",
+  "agent_type": "copilot-cli",
+  "tool_name": "shell",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/cursor/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/cursor/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "preToolUse",
+  "session_id": "dc-e2e-cursor",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "cursor-e2e",
+  "agent_name": "cursor e2e agent",
+  "agent_type": "cursor-cli",
+  "tool_name": "run_terminal_cmd",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/cursor/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/cursor/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "preToolUse",
+  "session_id": "dc-e2e-cursor",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "cursor-e2e",
+  "agent_name": "cursor e2e agent",
+  "agent_type": "cursor-cli",
+  "tool_name": "run_terminal_cmd",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/geminicli/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/geminicli/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "BeforeTool",
+  "session_id": "dc-e2e-geminicli",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "geminicli-e2e",
+  "agent_name": "geminicli e2e agent",
+  "agent_type": "geminicli-cli",
+  "tool_name": "RunShellCommand",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/geminicli/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/geminicli/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "BeforeTool",
+  "session_id": "dc-e2e-geminicli",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "geminicli-e2e",
+  "agent_name": "geminicli e2e agent",
+  "agent_type": "geminicli-cli",
+  "tool_name": "RunShellCommand",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/geminicli/session_start.json
+++ b/scripts/live-connector-e2e/golden/geminicli/session_start.json
@@ -1,0 +1,8 @@
+{
+  "hook_event_name": "SessionStart",
+  "session_id": "dc-e2e-geminicli",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "geminicli-e2e",
+  "agent_name": "geminicli e2e agent",
+  "agent_type": "geminicli-cli"
+}

--- a/scripts/live-connector-e2e/golden/hermes/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/hermes/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "pre_tool_call",
+  "session_id": "dc-e2e-hermes",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "hermes-e2e",
+  "agent_name": "hermes e2e agent",
+  "agent_type": "hermes-cli",
+  "tool_name": "execute_command",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/hermes/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/hermes/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "pre_tool_call",
+  "session_id": "dc-e2e-hermes",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "hermes-e2e",
+  "agent_name": "hermes e2e agent",
+  "agent_type": "hermes-cli",
+  "tool_name": "execute_command",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/openhands/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/openhands/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-openhands",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "openhands-e2e",
+  "agent_name": "openhands e2e agent",
+  "agent_type": "openhands-cli",
+  "tool_name": "terminal",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/openhands/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/openhands/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-openhands",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "openhands-e2e",
+  "agent_name": "openhands e2e agent",
+  "agent_type": "openhands-cli",
+  "tool_name": "terminal",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/windsurf/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/windsurf/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "pre_run_command",
+  "session_id": "dc-e2e-windsurf",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "windsurf-e2e",
+  "agent_name": "windsurf e2e agent",
+  "agent_type": "windsurf-cli",
+  "tool_name": "run_command",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/windsurf/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/windsurf/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "pre_run_command",
+  "session_id": "dc-e2e-windsurf",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "windsurf-e2e",
+  "agent_name": "windsurf e2e agent",
+  "agent_type": "windsurf-cli",
+  "tool_name": "run_command",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/lib/assert.sh
+++ b/scripts/live-connector-e2e/lib/assert.sh
@@ -1,0 +1,194 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Assertion helpers layered on top of the existing CI invariants:
+#   - gateway.jsonl schema      -> scripts/assert-gateway-jsonl.py
+#   - observability invariants  -> test/e2e/observability_assertions.sh
+#   - real enforcement          -> sentinel side-effect files (lib/common.sh)
+#
+# Every assertion returns 0/1 and is logged; callers decide whether a failure
+# is fatal (drivers wrap each in dc_record_result so one event's failure does
+# not abort the cell).
+
+# dc_assert_schema [min_events] — validate gateway.jsonl envelope schema.
+dc_assert_schema() {
+  local min="${1:-1}"
+  if [ ! -f "${DC_GATEWAY_JSONL}" ]; then
+    dc_err "gateway.jsonl missing at ${DC_GATEWAY_JSONL}"
+    return 1
+  fi
+  python3 "${DC_E2E_REPO_ROOT}/scripts/assert-gateway-jsonl.py" \
+    "${DC_GATEWAY_JSONL}" --min-events "${min}"
+}
+
+# dc_count_connector_events <connector> [since_line] — count gateway.jsonl
+# events attributed to a connector. Resilient across event shapes: matches any
+# of destination_app / surface / aid_surface / connector carrying the name.
+# When since_line is given, only events strictly after that 1-based line index
+# are counted (so we assert "fired during this probe", not historically).
+dc_count_connector_events() {
+  local connector="$1" since="${2:-0}"
+  [ -f "${DC_GATEWAY_JSONL}" ] || { printf '0'; return 0; }
+  python3 - "${DC_GATEWAY_JSONL}" "${connector}" "${since}" <<'PY'
+import json, sys
+path, connector, since = sys.argv[1], sys.argv[2], int(sys.argv[3])
+fields = ("destination_app", "surface", "aid_surface", "connector", "agent_name", "agent_type")
+n = 0
+with open(path, encoding="utf-8") as f:
+    for i, line in enumerate(f, start=1):
+        if i <= since:
+            continue
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except Exception:
+            continue
+        blob = json.dumps(ev).lower()
+        if any(str(ev.get(k, "")).lower() == connector for k in fields):
+            n += 1
+        elif connector in blob and ("hook" in blob or "tool" in blob or "lifecycle" in blob):
+            n += 1
+print(n)
+PY
+}
+
+# dc_assert_fired <connector> <since_line> — at least one gateway event was
+# attributed to the connector since the probe started. This is the #1
+# regression signal: an upstream release that renames/drops an event makes the
+# hook stop firing, and this assertion goes red.
+dc_assert_fired() {
+  local connector="$1" since="${2:-0}" n
+  n="$(dc_count_connector_events "${connector}" "${since}")"
+  if [ "${n:-0}" -ge 1 ]; then
+    return 0
+  fi
+  dc_err "no gateway events attributed to ${connector} since line ${since}"
+  return 1
+}
+
+# dc_assert_verdict_block <since_line> — a block verdict was recorded after the
+# probe. Pairs with the sentinel check so we prove both the decision AND the
+# enforcement.
+dc_assert_verdict_block() {
+  local since="${1:-0}"
+  [ -f "${DC_GATEWAY_JSONL}" ] || return 1
+  python3 - "${DC_GATEWAY_JSONL}" "${since}" <<'PY'
+import json, sys
+path, since = sys.argv[1], int(sys.argv[2])
+found = False
+with open(path, encoding="utf-8") as f:
+    for i, line in enumerate(f, start=1):
+        if i <= since:
+            continue
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except Exception:
+            continue
+        if ev.get("event_type") == "verdict":
+            action = str(ev.get("verdict", {}).get("action", "")).lower()
+            if action in ("block", "deny"):
+                found = True
+                break
+sys.exit(0 if found else 1)
+PY
+}
+
+# dc_assert_observability [extra args...] — run the shared Phase 6 invariants
+# (timestamp sanity, request_id UUID, audit.db correlation). Reused verbatim
+# from the OpenClaw stack so this harness can never diverge from it.
+dc_assert_observability() {
+  bash "${DC_E2E_REPO_ROOT}/test/e2e/observability_assertions.sh" \
+    --jsonl "${DC_GATEWAY_JSONL}" \
+    --db "${DC_AUDIT_DB}" \
+    --ts-window-seconds 3600 \
+    --no-require-verdict \
+    "$@"
+}
+
+# dc_assert_otlp <connector> <since_line> — for native_otlp connectors
+# (codex/claudecode/geminicli) assert telemetry tagged with the connector
+# reached the sink. We look for tool_invocation / llm_prompt / llm_response
+# events (the OTLP ingest path emits these) attributed to the connector.
+dc_assert_otlp() {
+  local connector="$1" since="${2:-0}"
+  [ -f "${DC_GATEWAY_JSONL}" ] || return 1
+  python3 - "${DC_GATEWAY_JSONL}" "${connector}" "${since}" <<'PY'
+import json, sys
+path, connector, since = sys.argv[1], sys.argv[2], int(sys.argv[3])
+telemetry = {"tool_invocation", "llm_prompt", "llm_response"}
+fields = ("destination_app", "surface", "aid_surface", "connector")
+found = False
+with open(path, encoding="utf-8") as f:
+    for i, line in enumerate(f, start=1):
+        if i <= since:
+            continue
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except Exception:
+            continue
+        if ev.get("event_type") in telemetry and any(
+            str(ev.get(k, "")).lower() == connector for k in fields
+        ):
+            found = True
+            break
+sys.exit(0 if found else 1)
+PY
+}
+
+# dc_assert_allowed <token> — observe path: the probe command actually ran, so
+# its sentinel marker exists.
+dc_assert_allowed() {
+  if dc_sentinel_present "$1"; then
+    return 0
+  fi
+  dc_err "allow probe did not run (sentinel ${1} absent)"
+  return 1
+}
+
+# dc_assert_blocked <token> <since_line> — block path: the sentinel marker is
+# ABSENT (the command never executed) AND a block verdict was recorded. Both
+# must hold — a missing sentinel alone could be a crashed agent, and a block
+# verdict alone does not prove the tool call was actually prevented.
+dc_assert_blocked() {
+  local token="$1" since="${2:-0}"
+  if dc_sentinel_present "${token}"; then
+    dc_err "block probe RAN (sentinel ${token} present) — enforcement regression"
+    return 1
+  fi
+  if ! dc_assert_verdict_block "${since}"; then
+    dc_err "no block verdict recorded since line ${since} (cannot confirm enforcement)"
+    return 1
+  fi
+  return 0
+}
+
+# dc_assert_teardown <connector> <agent_config_file> — after
+# `defenseclaw-gateway connector teardown`, the agent config no longer
+# references DefenseClaw's hook script. Proves clean uninstall.
+dc_assert_teardown() {
+  local connector="$1" cfg="$2"
+  if [ ! -f "${cfg}" ]; then
+    # Some teardowns remove the file entirely — that is clean.
+    return 0
+  fi
+  if grep -q "defenseclaw" "${cfg}" 2>/dev/null; then
+    dc_err "teardown left a defenseclaw reference in ${cfg}"
+    return 1
+  fi
+  return 0
+}

--- a/scripts/live-connector-e2e/lib/common.sh
+++ b/scripts/live-connector-e2e/lib/common.sh
@@ -1,0 +1,265 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared helpers for the live connector hook E2E harness. Sourced by
+# run.sh, contract-smoke.sh, cursor-validation.sh, and every per-connector
+# driver under drivers/. This file defines functions only — callers own
+# `set -euo pipefail`.
+#
+# Cross-OS note: on Linux/macOS the agent invokes the installed Bash hook
+# script (~/.defenseclaw/hooks/<connector>-hook.sh). On native Windows the
+# agent invokes `defenseclaw-gateway hook --connector <name> --event <ev>`
+# (PR #308). Both forward the stdin event payload to the local gateway, so
+# every assertion below works against ~/.defenseclaw/gateway.jsonl + audit.db
+# regardless of OS.
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+# DC_E2E_LIB_DIR resolves to .../scripts/live-connector-e2e/lib.
+DC_E2E_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DC_E2E_ROOT="$(cd "${DC_E2E_LIB_DIR}/.." && pwd)"
+DC_E2E_REPO_ROOT="$(cd "${DC_E2E_ROOT}/../.." && pwd)"
+DC_E2E_GOLDEN_DIR="${DC_E2E_ROOT}/golden"
+
+# DefenseClaw home (where the gateway writes gateway.jsonl / audit.db and
+# where `defenseclaw setup` installs the hook scripts + .token).
+DEFENSECLAW_HOME="${DEFENSECLAW_HOME:-${HOME}/.defenseclaw}"
+DC_GATEWAY_JSONL="${DEFENSECLAW_HOME}/gateway.jsonl"
+DC_AUDIT_DB="${DEFENSECLAW_HOME}/audit.db"
+
+# Results sink. Every per-event outcome is appended here as one JSON object
+# per line so report.py can roll the matrix up and decide whether to open a
+# connector-regression issue. Defaults to a run-scoped file the workflow
+# uploads as an artifact.
+DC_E2E_RESULTS="${DC_E2E_RESULTS:-${DC_E2E_REPO_ROOT}/connector-live-e2e-results.jsonl}"
+
+# Sentinel side-effect directory. The forced-tool probes write/avoid-writing
+# a marker file here so we can prove enforcement rather than trusting logs.
+DC_E2E_SENTINEL_DIR="${DC_E2E_SENTINEL_DIR:-${TMPDIR:-/tmp}/dc-e2e-sentinels}"
+
+# Per-cell identity (connector + os). Drivers set DC_E2E_CONNECTOR; the OS is
+# derived. These flow into record_result and the job summary.
+DC_E2E_OS="${DC_E2E_OS:-}"
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+dc_log()     { printf '[live-e2e] %s\n' "$*" >&2; }
+dc_warn()    { printf '[live-e2e][warn] %s\n' "$*" >&2; }
+dc_err()     { printf '[live-e2e][error] %s\n' "$*" >&2; }
+dc_section() { printf '\n[live-e2e] ===== %s =====\n' "$*" >&2; }
+
+# dc_die <message> — log and exit non-zero.
+dc_die() { dc_err "$*"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# OS detection
+# ---------------------------------------------------------------------------
+
+# dc_detect_os — echoes linux|macos|windows. Honors DC_E2E_OS override (set by
+# the workflow matrix) so the value matches the runner label exactly.
+dc_detect_os() {
+  if [ -n "${DC_E2E_OS}" ]; then
+    printf '%s' "${DC_E2E_OS}"
+    return 0
+  fi
+  case "$(uname -s 2>/dev/null || echo unknown)" in
+    Linux*)             printf 'linux' ;;
+    Darwin*)            printf 'macos' ;;
+    MINGW*|MSYS*|CYGWIN*) printf 'windows' ;;
+    *)                  printf 'unknown' ;;
+  esac
+}
+
+dc_is_windows() { [ "$(dc_detect_os)" = "windows" ]; }
+
+# ---------------------------------------------------------------------------
+# Gateway lifecycle
+# ---------------------------------------------------------------------------
+
+# dc_wait_for_gateway [timeout_seconds] — poll `defenseclaw-gateway status`
+# until healthy. Mirrors the 30s readiness poll in .github/workflows/e2e.yml
+# so behavior is identical to the OpenClaw stack gate.
+dc_wait_for_gateway() {
+  local timeout="${1:-30}" i
+  for i in $(seq 1 "${timeout}"); do
+    if defenseclaw-gateway status >/dev/null 2>&1; then
+      dc_log "gateway healthy after ${i}s"
+      return 0
+    fi
+    sleep 1
+  done
+  dc_err "gateway did not become healthy within ${timeout}s"
+  dc_dump_gateway_logs
+  return 1
+}
+
+# dc_dump_gateway_logs — tail the sidecar logs for failure triage. Same files
+# the e2e.yml failure path inspects.
+dc_dump_gateway_logs() {
+  local f
+  for f in gateway.log gateway.jsonl watchdog.log; do
+    if [ -f "${DEFENSECLAW_HOME}/${f}" ]; then
+      dc_log "--- ${f} (tail) ---"
+      tail -n 80 "${DEFENSECLAW_HOME}/${f}" >&2 2>/dev/null || true
+    fi
+  done
+}
+
+# dc_gateway_jsonl_count — number of JSONL events currently on disk. Used to
+# bound assertions to "events emitted since the probe" rather than the whole
+# file.
+dc_gateway_jsonl_count() {
+  if [ -f "${DC_GATEWAY_JSONL}" ]; then
+    wc -l < "${DC_GATEWAY_JSONL}" | tr -d ' '
+  else
+    printf '0'
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Version capture
+# ---------------------------------------------------------------------------
+
+# dc_capture_version <connector> <cmd> [args...] — resolve and record the
+# upstream agent version. Tolerant of agents that print to stderr or use a
+# non-standard flag; never fails the run on a version-probe error.
+dc_capture_version() {
+  local connector="$1"; shift
+  local raw
+  raw="$("$@" 2>&1 | head -n 3 | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g')" || raw="unknown"
+  [ -n "${raw}" ] || raw="unknown"
+  dc_log "resolved ${connector} version: ${raw}"
+  printf '%s' "${raw}"
+}
+
+# ---------------------------------------------------------------------------
+# Sentinel side-effects (real-enforcement proof)
+# ---------------------------------------------------------------------------
+
+# dc_new_sentinel_token — unique token for one probe, namespaced to the cell.
+dc_new_sentinel_token() {
+  printf 'dc-%s-%s-%s' "${DC_E2E_CONNECTOR:-x}" "$(dc_detect_os)" "$(date +%s)$RANDOM"
+}
+
+# dc_sentinel_path <token> — absolute path of the marker file for a token.
+dc_sentinel_path() {
+  mkdir -p "${DC_E2E_SENTINEL_DIR}"
+  printf '%s/%s.marker' "${DC_E2E_SENTINEL_DIR}" "$1"
+}
+
+# dc_sentinel_present <token> — true if the probe's command actually ran.
+dc_sentinel_present() { [ -e "$(dc_sentinel_path "$1")" ]; }
+
+# dc_clear_sentinels — wipe markers between probes.
+dc_clear_sentinels() { rm -rf "${DC_E2E_SENTINEL_DIR}" 2>/dev/null || true; }
+
+# ---------------------------------------------------------------------------
+# Result recording
+# ---------------------------------------------------------------------------
+
+# dc_record_result <event> <status> [detail] — append one matrix cell outcome.
+# status is one of: pass | fail | skip. DC_E2E_CONNECTOR + version come from
+# the driver context. Also mirrors a human line to $GITHUB_STEP_SUMMARY.
+dc_record_result() {
+  local event="$1" status="$2" detail="${3:-}"
+  local connector="${DC_E2E_CONNECTOR:-unknown}"
+  local os; os="$(dc_detect_os)"
+  local version="${DC_E2E_AGENT_VERSION:-unknown}"
+  mkdir -p "$(dirname "${DC_E2E_RESULTS}")"
+  python3 - "$connector" "$os" "$event" "$status" "$version" "$detail" >> "${DC_E2E_RESULTS}" <<'PY'
+import json, sys
+connector, os_, event, status, version, detail = sys.argv[1:7]
+print(json.dumps({
+    "connector": connector,
+    "os": os_,
+    "event": event,
+    "status": status,
+    "version": version,
+    "detail": detail,
+}))
+PY
+  local glyph="PASS"
+  case "${status}" in
+    fail) glyph="FAIL" ;;
+    skip) glyph="SKIP" ;;
+  esac
+  dc_log "[${glyph}] ${connector}/${os}/${event} ${detail}"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '| %s | %s | %s | %s | %s |\n' \
+      "${connector}" "${os}" "${event}" "${glyph}" "${detail//|/\\|}" \
+      >> "${GITHUB_STEP_SUMMARY}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Log staging (artifact upload on failure)
+# ---------------------------------------------------------------------------
+
+# dc_stage_logs <stage_dir> — copy gateway logs + the results JSONL into a
+# directory the workflow uploads with actions/upload-artifact. Mirrors the
+# "Stage DefenseClaw logs" step in e2e.yml.
+dc_stage_logs() {
+  local stage="${1:-${TMPDIR:-/tmp}/defenseclaw-live-e2e-logs}"
+  rm -rf "${stage}"; mkdir -p "${stage}"
+  if [ -d "${DEFENSECLAW_HOME}" ]; then
+    local pat
+    for pat in '*.log' '*.jsonl' 'config.yaml'; do
+      find "${DEFENSECLAW_HOME}" -maxdepth 2 -type f -name "${pat}" \
+        -exec cp {} "${stage}/" \; 2>/dev/null || true
+    done
+  fi
+  cp "${DC_E2E_RESULTS}" "${stage}/" 2>/dev/null || true
+  dc_log "staged logs in ${stage}"
+  printf '%s' "${stage}"
+}
+
+# ---------------------------------------------------------------------------
+# Hook entrypoint (cross-OS)
+# ---------------------------------------------------------------------------
+
+# dc_hook_script <connector> — installed Bash hook path for unix. The claude
+# connector's script is named claude-code-hook.sh; everything else follows
+# <connector>-hook.sh (see internal/gateway/connector/hooks/ + cmd_setup.py).
+dc_hook_script() {
+  local connector="$1" base
+  case "${connector}" in
+    claudecode) base="claude-code-hook.sh" ;;
+    *)          base="${connector}-hook.sh" ;;
+  esac
+  printf '%s/hooks/%s' "${DEFENSECLAW_HOME}" "${base}"
+}
+
+# dc_invoke_hook <connector> <event> <payload_file> — feed a golden event
+# payload into the installed hook entrypoint and echo "exit:<code>" on the
+# last line so callers can assert verdict shaping. On Windows this targets the
+# native `defenseclaw-gateway hook` subcommand instead of the Bash script.
+#
+# Stdout of the hook (the agent-native decision JSON) is forwarded verbatim
+# before the trailing exit line.
+dc_invoke_hook() {
+  local connector="$1" event="$2" payload="$3" code out
+  if dc_is_windows; then
+    out="$(defenseclaw-gateway hook --connector "${connector}" --event "${event}" < "${payload}" 2>&1)" && code=0 || code=$?
+  else
+    local script; script="$(dc_hook_script "${connector}")"
+    if [ ! -x "${script}" ]; then
+      dc_err "hook script not found/executable: ${script}"
+      printf 'exit:127\n'
+      return 0
+    fi
+    out="$(bash "${script}" < "${payload}" 2>&1)" && code=0 || code=$?
+  fi
+  printf '%s\n' "${out}"
+  printf 'exit:%s\n' "${code}"
+}

--- a/scripts/live-connector-e2e/lib/setup.sh
+++ b/scripts/live-connector-e2e/lib/setup.sh
@@ -1,0 +1,87 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# DefenseClaw bootstrap + per-connector setup/teardown helpers shared by the
+# contract-smoke and live drivers. Mirrors the init/setup/health/teardown flow
+# in .github/workflows/e2e.yml but parameterized per hook connector.
+
+# dc_setup_subcommand <connector> — map a registry connector name to its
+# `defenseclaw setup` subcommand. Only claude diverges (claude-code); every
+# other hook connector's subcommand equals its registry name.
+dc_setup_subcommand() {
+  case "$1" in
+    claudecode) printf 'claude-code' ;;
+    *)          printf '%s' "$1" ;;
+  esac
+}
+
+# dc_connector_config_file <connector> — the agent-side config file
+# `defenseclaw setup` patches, used by the teardown assertion. Paths mirror
+# the *PathOverride defaults in internal/gateway/connector and cmd_setup.py.
+dc_connector_config_file() {
+  case "$1" in
+    codex)       printf '%s/.codex/config.toml' "${HOME}" ;;
+    claudecode)  printf '%s/.claude/settings.json' "${HOME}" ;;
+    geminicli)   printf '%s/.gemini/settings.json' "${HOME}" ;;
+    cursor)      printf '%s/.cursor/hooks.json' "${HOME}" ;;
+    windsurf)    printf '%s/.codeium/windsurf/hooks.json' "${HOME}" ;;
+    copilot)     printf '%s/.copilot/hooks/defenseclaw.json' "${HOME}" ;;
+    openhands)   printf '%s/.openhands/hooks.json' "${HOME}" ;;
+    antigravity) printf '%s/.gemini/config/hooks.json' "${HOME}" ;;
+    hermes)      printf '%s/.hermes/config.yaml' "${HOME}" ;;
+    *)           printf '' ;;
+  esac
+}
+
+# dc_write_env_key <KEY> <VALUE> — idempotently append an env line to
+# ~/.defenseclaw/.env (consumed by the gateway + hook scripts). No-op on empty
+# value so a missing optional secret never writes a blank line.
+dc_write_env_key() {
+  local key="$1" value="$2"
+  [ -n "${value}" ] || return 0
+  mkdir -p "${DEFENSECLAW_HOME}"
+  touch "${DEFENSECLAW_HOME}/.env"
+  if grep -q "^${key}=" "${DEFENSECLAW_HOME}/.env" 2>/dev/null; then
+    return 0
+  fi
+  printf '%s=%s\n' "${key}" "${value}" >> "${DEFENSECLAW_HOME}/.env"
+}
+
+# dc_init_defenseclaw — run `defenseclaw init` once and stand up the gateway.
+# Idempotent: re-running against an initialized home is a no-op for config.
+dc_init_defenseclaw() {
+  if [ ! -f "${DEFENSECLAW_HOME}/config.yaml" ]; then
+    dc_log "running defenseclaw init"
+    defenseclaw init
+  else
+    dc_log "defenseclaw already initialized at ${DEFENSECLAW_HOME}"
+  fi
+}
+
+# dc_setup_connector <connector> <mode> — install DefenseClaw into the
+# connector via its setup subcommand and wait for the gateway to come back
+# healthy. mode is observe|action. --restart wires hook scripts + OTel block.
+dc_setup_connector() {
+  local connector="$1" mode="${2:-action}" sub
+  sub="$(dc_setup_subcommand "${connector}")"
+  dc_log "defenseclaw setup ${sub} --mode ${mode} --restart"
+  defenseclaw setup "${sub}" --yes --mode "${mode}" --restart
+  dc_wait_for_gateway 30
+}
+
+# dc_teardown_connector <connector> — remove the connector's config patches
+# and verify no residual state. Returns the verify exit code (0 = clean).
+dc_teardown_connector() {
+  local connector="$1"
+  dc_log "tearing down ${connector}"
+  defenseclaw-gateway connector teardown --connector "${connector}" || \
+    dc_warn "teardown command returned non-zero for ${connector}"
+  defenseclaw-gateway connector verify --connector "${connector}"
+}

--- a/scripts/live-connector-e2e/report.py
+++ b/scripts/live-connector-e2e/report.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Connector live-E2E reporter / regression radar (alert-only).
+#
+# Reads the per-cell result JSONL files produced by lib/common.sh
+# (dc_record_result) — one JSON object per line:
+#
+#     {"connector","os","event","status","version","detail"}
+#
+# and:
+#   1. Renders a connector x os x event matrix to the GitHub job summary.
+#   2. Records the resolved upstream version per connector x os.
+#   3. On ANY failing cell, builds a regression issue body and (when
+#      --open-issue is passed and gh is authenticated) opens or updates a
+#      GitHub issue labeled `connector-regression`.
+#   4. Exits non-zero when failures exist so the report job is red — but it
+#      NEVER edits validated_versions.json or hook_contracts.json. Bumping a
+#      validated/approved version is a deliberate human action.
+
+from __future__ import annotations
+
+import argparse
+import collections
+import datetime
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ISSUE_LABEL = "connector-regression"
+ISSUE_TITLE = "Connector live E2E regression"
+
+
+def load_results(results_dir: Path) -> list[dict]:
+    rows: list[dict] = []
+    for path in sorted(results_dir.rglob("*.jsonl")):
+        try:
+            with path.open(encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rows.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        except OSError:
+            continue
+    return rows
+
+
+def summarize(rows: list[dict]):
+    """Return (cells, versions, failures).
+
+    cells:    {(connector, os): {event: status}}
+    versions: {(connector, os): version}
+    failures: list[(connector, os, event, detail)]
+    """
+    cells: dict[tuple[str, str], dict[str, str]] = collections.defaultdict(dict)
+    versions: dict[tuple[str, str], str] = {}
+    failures: list[tuple[str, str, str, str]] = []
+    for r in rows:
+        key = (r.get("connector", "?"), r.get("os", "?"))
+        event = r.get("event", "?")
+        status = r.get("status", "?")
+        cells[key][event] = status
+        v = r.get("version") or ""
+        if v and v != "unknown":
+            versions.setdefault(key, v)
+        if status == "fail":
+            failures.append((key[0], key[1], event, r.get("detail", "")))
+    return cells, versions, failures
+
+
+def render_summary(cells, versions) -> str:
+    lines = ["# Connector live E2E results", ""]
+    lines.append("| Connector | OS | Version | Result | Events (pass/fail/skip) |")
+    lines.append("|---|---|---|---|---|")
+    for (connector, os_), events in sorted(cells.items()):
+        n_pass = sum(1 for s in events.values() if s == "pass")
+        n_fail = sum(1 for s in events.values() if s == "fail")
+        n_skip = sum(1 for s in events.values() if s == "skip")
+        verdict = "FAIL" if n_fail else ("PASS" if n_pass else "SKIP")
+        version = versions.get((connector, os_), "unknown")
+        lines.append(
+            f"| {connector} | {os_} | {version} | {verdict} | "
+            f"{n_pass}/{n_fail}/{n_skip} |"
+        )
+    lines.append("")
+    failing_events = [
+        (c, o, e)
+        for (c, o), events in cells.items()
+        for e, s in events.items()
+        if s == "fail"
+    ]
+    if failing_events:
+        lines.append("## Failing events")
+        lines.append("")
+        for c, o, e in sorted(failing_events):
+            lines.append(f"- `{c}` / `{o}` / `{e}`")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def build_issue_body(failures, versions, run_url: str) -> str:
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    lines = [
+        "A live connector hook E2E cell that previously passed is now failing "
+        "against the latest upstream agent release.",
+        "",
+        f"- Detected: {now}",
+        f"- Run: {run_url or 'n/a'}",
+        "",
+        "## Failing cells",
+        "",
+        "| Connector | OS | Event | Version | Detail |",
+        "|---|---|---|---|---|",
+    ]
+    for connector, os_, event, detail in sorted(failures):
+        version = versions.get((connector, os_), "unknown")
+        safe_detail = (detail or "").replace("|", "\\|")
+        lines.append(f"| {connector} | {os_} | {event} | {version} | {safe_detail} |")
+    lines += [
+        "",
+        "## Next steps (alert-only — no automatic version bump)",
+        "",
+        "1. Triage whether DefenseClaw's decode/map/respond needs a fix, or the "
+        "upstream agent changed its hook contract.",
+        "2. If DefenseClaw must drop support for the new version, set "
+        "`max_exclusive` (or raise `min_inclusive`) in "
+        "`cli/defenseclaw/inventory/hook_contracts.json` and "
+        "`internal/gateway/connector/hook_contract.go`.",
+        "3. Once green again, update `last_validated_version` in "
+        "`cli/defenseclaw/inventory/validated_versions.json`.",
+    ]
+    return "\n".join(lines)
+
+
+def gh(*args: str) -> tuple[int, str]:
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return proc.returncode, (proc.stdout + proc.stderr)
+    except FileNotFoundError:
+        return 127, "gh CLI not found"
+
+
+def open_or_update_issue(body: str, run_url: str) -> None:
+    """Open a new connector-regression issue or comment on the existing one."""
+    rc, out = gh(
+        "issue", "list",
+        "--label", ISSUE_LABEL,
+        "--state", "open",
+        "--json", "number",
+        "--limit", "1",
+    )
+    if rc != 0:
+        print(f"[report] could not list issues (gh rc={rc}): {out}", file=sys.stderr)
+        return
+    try:
+        existing = json.loads(out or "[]")
+    except json.JSONDecodeError:
+        existing = []
+    if existing:
+        number = str(existing[0]["number"])
+        rc, out = gh("issue", "comment", number, "--body", body)
+        print(f"[report] commented on issue #{number} (rc={rc})")
+    else:
+        rc, out = gh(
+            "issue", "create",
+            "--title", f"{ISSUE_TITLE} ({datetime.date.today().isoformat()})",
+            "--label", ISSUE_LABEL,
+            "--body", body,
+        )
+        print(f"[report] created regression issue (rc={rc}): {out.strip()}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--results-dir", type=Path, required=True,
+                        help="Directory of per-cell *.jsonl result files (artifacts).")
+    parser.add_argument("--summary-file", type=Path,
+                        default=Path(os.environ["GITHUB_STEP_SUMMARY"])
+                        if os.environ.get("GITHUB_STEP_SUMMARY") else None,
+                        help="Markdown summary output (default: $GITHUB_STEP_SUMMARY).")
+    parser.add_argument("--open-issue", action="store_true",
+                        help="Open/update a connector-regression issue on failure.")
+    parser.add_argument("--run-url", default=os.environ.get("RUN_URL", ""))
+    args = parser.parse_args()
+
+    if not args.results_dir.exists():
+        print(f"[report] results dir {args.results_dir} missing — no cells ran?",
+              file=sys.stderr)
+        return 0
+
+    rows = load_results(args.results_dir)
+    if not rows:
+        print("[report] no result rows found; nothing to report.", file=sys.stderr)
+        return 0
+
+    cells, versions, failures = summarize(rows)
+    summary = render_summary(cells, versions)
+    print(summary)
+    if args.summary_file:
+        try:
+            with args.summary_file.open("a", encoding="utf-8") as f:
+                f.write(summary + "\n")
+        except OSError as exc:
+            print(f"[report] could not write summary: {exc}", file=sys.stderr)
+
+    if failures:
+        body = build_issue_body(failures, versions, args.run_url)
+        print("\n----- regression issue body -----\n" + body, file=sys.stderr)
+        if args.open_issue:
+            open_or_update_issue(body, args.run_url)
+        return 1
+
+    print("[report] all cells green.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/live-connector-e2e/run.sh
+++ b/scripts/live-connector-e2e/run.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Orchestrator for the live connector hook E2E harness. The workflow invokes
+# one cell at a time (one connector x one OS), but this dispatcher also
+# supports `--connector all` for local runs.
+#
+#   run.sh --layer contract --connector <name|all>   # Layer A entrypoint smoke
+#   run.sh --layer live     --connector <name|all>   # Layer B live agent
+#
+# Layer A targets every registry connector (golden payload -> installed hook
+# entrypoint). Layer B only targets connectors that ship a driver under
+# drivers/; contract-only connectors (hermes, windsurf, antigravity) are
+# skipped with a recorded `skip` so the matrix stays honest.
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${HERE}/lib/common.sh"
+
+LAYER=""
+CONNECTOR=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --layer)     LAYER="$2"; shift 2 ;;
+    --connector) CONNECTOR="$2"; shift 2 ;;
+    --os)        DC_E2E_OS="$2"; export DC_E2E_OS; shift 2 ;;
+    -h|--help)
+      sed -n '12,30p' "$0"; exit 0 ;;
+    *) dc_die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "${LAYER}" ]     || dc_die "--layer contract|live is required"
+[ -n "${CONNECTOR}" ] || dc_die "--connector <name|all> is required"
+
+# Registry connectors (Layer A covers all; Layer B covers those with drivers).
+ALL_CONNECTORS=(codex claudecode geminicli cursor copilot openhands hermes windsurf antigravity)
+
+resolve_connectors() {
+  if [ "${CONNECTOR}" = "all" ]; then
+    printf '%s\n' "${ALL_CONNECTORS[@]}"
+  else
+    printf '%s\n' "${CONNECTOR}"
+  fi
+}
+
+run_contract() {
+  local c="$1"
+  bash "${HERE}/contract-smoke.sh" "${c}"
+}
+
+run_live() {
+  local c="$1" driver="${HERE}/drivers/${c}.sh"
+  if [ ! -f "${driver}" ]; then
+    DC_E2E_CONNECTOR="${c}" dc_record_result "live" skip "contract-only connector (no live driver)"
+    return 0
+  fi
+  bash "${driver}"
+}
+
+overall=0
+while read -r c; do
+  [ -n "${c}" ] || continue
+  case "${LAYER}" in
+    contract) run_contract "${c}" || overall=1 ;;
+    live)     run_live "${c}"     || overall=1 ;;
+    *)        dc_die "unknown layer: ${LAYER} (use contract|live)" ;;
+  esac
+done < <(resolve_connectors)
+
+# Always stage logs so the workflow can upload them as an artifact.
+dc_stage_logs "${TMPDIR:-/tmp}/defenseclaw-live-e2e-logs" >/dev/null || true
+
+exit "${overall}"

--- a/test/e2e/connectormatrix.go
+++ b/test/e2e/connectormatrix.go
@@ -139,6 +139,12 @@ func connectorMatrix(t *testing.T) []ConnectorFixture {
 			ClawMode:       "openhands",
 			Apply:          hookOnlyFixtureApply("openhands"),
 		},
+		{
+			Name:           "antigravity",
+			DestinationApp: "antigravity",
+			ClawMode:       "antigravity",
+			Apply:          hookOnlyFixtureApply("antigravity"),
+		},
 	}
 }
 
@@ -171,6 +177,10 @@ func hookOnlyFixtureApply(name string) func(t *testing.T) (string, string) {
 			prev := connector.OpenHandsHooksPathOverride
 			connector.OpenHandsHooksPathOverride = filepath.Join(home, "workspace", ".openhands", "hooks.json")
 			t.Cleanup(func() { connector.OpenHandsHooksPathOverride = prev })
+		case "antigravity":
+			prev := connector.AntigravityHooksPathOverride
+			connector.AntigravityHooksPathOverride = filepath.Join(home, ".gemini", "config", "hooks.json")
+			t.Cleanup(func() { connector.AntigravityHooksPathOverride = prev })
 		}
 		return home, t.TempDir()
 	}

--- a/test/e2e/testdata/v7/golden/antigravity/verdict-blocked.golden.json
+++ b/test/e2e/testdata/v7/golden/antigravity/verdict-blocked.golden.json
@@ -1,0 +1,16 @@
+{
+  "binary_version": "\u003cstripped\u003e",
+  "content_hash": "\u003cstripped\u003e",
+  "event_type": "verdict",
+  "generation": 1,
+  "schema_version": 7,
+  "severity": "HIGH",
+  "sidecar_instance_id": "\u003cstripped\u003e",
+  "ts": "2000-01-01T00:00:00Z",
+  "verdict": {
+    "action": "block",
+    "latency_ms": 1,
+    "reason": "test",
+    "stage": "final"
+  }
+}


### PR DESCRIPTION
## Problem

Hook-based enforcement — the connector hooks that intercept an agent's tool
calls and forward them to the local DefenseClaw gateway for a verdict — only
worked on macOS/Linux. On Windows the feature was unusable and the gateway did
not even build:

- **Hooks were POSIX-only Bash.** Every connector hook (`*-hook.sh`) assumed a
  POSIX shell, `jq`, and Unix semantics. Without Git Bash on `PATH` the hooks
  never fired, so no tool call was ever inspected.
- **The gateway did not compile for `GOOS=windows`.** Several packages called
  Unix-only syscalls unconditionally — `syscall.Flock`, `O_NOFOLLOW`, process
  groups / `CTRL_BREAK`, and file-owner `stat` — so `go build` failed on Windows.
- **CLI/TUI deadlocked or crashed on Windows.** The config mutex used a
  `fcntl`-style lock with no Windows path, and two TUI render methods queried
  widgets that can be absent during teardown, surfacing as `WorkerFailed`.
- **Proxy ("claw") connectors were offered where they cannot run.** OpenClaw and
  ZeptoClaw need a long-lived local proxy; the TUI/CLI still listed them on
  Windows, producing broken setups.
- **No CI proved any of this.** Nothing compiled or exercised the hook surfaces
  on Windows, so a Windows regression was invisible.

Symptoms: `go build` errors on Windows, CLI hangs at config write, hooks
silently not firing, and Windows users being offered connectors that fail at
setup.

## Current Situation

Today hook dispatch shells out to `*.sh` scripts under
`internal/gateway/connector/hooks/`, written to disk by
`internal/gateway/connector/subprocess.go`. Token handling
(`otlp_token.go`), file locking, process management, and plugin-owner checks
are Unix-coded with no build-tag split. The connector lists exposed by the TUI
(`cli_choices.py`, `first_run.py`, `mode_picker.py`) and the Go
`registry.go` return every connector regardless of OS, and the Python config
mutex in `config.py` has no Windows branch. The connector taxonomy
(hook-based vs proxy-backed) is duplicated across several Python lists with no
single source of truth shared with Go.

## Solution

Make Windows a first-class target for **hook-based** connectors:

1. **Native Go hook path (no Git Bash).** Add a hidden `defenseclaw hook`
   subcommand and a `hookexec` engine. On Windows the agent is wired to run
   `defenseclaw-gateway hook --connector <c> --event <e>`, which reads the event
   JSON from stdin, POSTs it to the loopback gateway, and shapes the
   agent-native stdout + exit code. Unix keeps the `.sh` scripts; both paths
   share one decision shape.
2. **Build-tagged platform splits** for every Unix-only syscall (file lock,
   OTLP path-token symlink/permission checks, plugin-owner trust, process
   create/teardown, watchdog signals, sidecar lifecycle, desktop notify) so the
   gateway builds and runs on `GOOS=windows`.
3. **One connector taxonomy, OS-gated.** A single source of truth in Go
   (`connector/platform_support.go`) mirrored in Python
   (`platform_support.py`) marks proxy connectors unsupported on Windows; the
   TUI/CLI and registry filter them out there.
4. **Cross-platform CLI/TUI.** Windows-safe config mutex; teardown guards on the
   two racy TUI render methods.
5. **Windows CI** that compiles every hook surface, runs the native hook engine,
   and exercises the platform gating + config lock on `windows-latest`.

The change also carries a separate **connector live-E2E harness + upstream
regression radar** (commit `f6d02bb7`, from #329) that drives golden payloads
through the installed hook entrypoint for every connector and, in a manual/
nightly layer, through real upstream agents.

**Why this approach.** Native Go hook execution was chosen over bundling Git
Bash: no external runtime dependency, identical decision logic to the gateway,
and a single binary to ship. Proxy connectors are *hidden* on Windows rather
than half-supported, because they fundamentally require a local proxy DefenseClaw
does not run there yet. The hardening shim drops PATH rewriting (a portability
and security footgun) in favor of a `jq`/Python3 fallback.

## Architecture Diagram

```
Before (Unix-only hook enforcement):

  ┌──────────────┐  spawn   ┌────────────────────┐  jq + curl  ┌────────────┐
  │ Agent runtime│─────────▶│  *-hook.sh (Bash)  │────────────▶│  Gateway   │
  │ (codex, …)   │          │  needs sh + jq     │             │ (loopback) │
  └──────────────┘          └────────────────────┘             └────────────┘
        Windows: no POSIX shell → hooks never fire; gateway won't build
  ┌────────────────────────────────────────────────────────────────────────┐
  │ TUI/CLI lists ALL connectors incl. proxy (OpenClaw/ZeptoClaw) on every OS│
  └────────────────────────────────────────────────────────────────────────┘

After (first-class Windows + native hook path):

  Windows                                    macOS / Linux
  ┌──────────────┐                           ┌──────────────┐
  │ Agent runtime│                           │ Agent runtime│
  └──────┬───────┘                           └──────┬───────┘
         │ defenseclaw-gateway hook                 │ *-hook.sh + _dc_jq
         │   --connector C --event E                │ (PATH hardening removed)
         ▼                                          ▼
  ┌─────────────────────┐      shared        ┌─────────────────────┐
  │ hookexec (native Go)│◀── decision  ──▶   │  hook script (Bash) │
  │ stdin→gateway→verdict│     shape          │ stdin→gateway→verdict│
  └─────────┬───────────┘                    └─────────┬───────────┘
            ▼                                           ▼
        ┌────────────┐                             ┌────────────┐
        │  Gateway   │                             │  Gateway   │
        └────────────┘                             └────────────┘

  Build-tagged splits: filelock · otlp_token · plugin_owner · proc ·
  watchdog · sidecar · notify   → gateway builds on GOOS=windows.

  connector.platform_support (Go) ⇄ platform_support.py (Python) — one
  taxonomy → proxy (claw) connectors hidden in TUI/CLI/registry on Windows.
```

## Flow Diagram

```
Agent runtime      defenseclaw hook (CLI)       hookexec (Go)        Gateway (loopback)
     │  event JSON (stdin)    │                      │                      │
     │───────────────────────▶│ buildHookOptions     │                      │
     │                        │ (+ .hookcfg sidecar) │                      │
     │                        │─────────────────────▶│ read stdin (capped)  │
     │                        │                      │ POST /…/event ──────▶│ scan + verdict
     │                        │                      │ (no-redirect client) │
     │                        │                      │◀──── verdict ────────│
     │                        │                      │ shape agent-native   │
     │                        │                      │ stdout + exit code   │
     │◀──── stdout + exit (0 allow / 2 block) ───────│ (fail-open/closed)   │
     ▼     os.Exit preserves the agent-native code
  allow / block
```

## What Changed (Where & How)

Most files are individually listed; the connector live-E2E driver and golden
fixture sets are grouped (33 near-identical JSON/`.sh` files) with a single
representative row.

| File | Change Type | Summary |
|---|---|---|
| `internal/cli/hook.go` | added | Hidden `defenseclaw hook` subcommand: native per-event entrypoint agents invoke on Windows; skips daemon pre/post hooks; `os.Exit`s with the agent-native code. |
| `internal/cli/hook_test.go` | test | Covers `buildHookOptions`, `.hookcfg` sidecar resolution, and command registration. |
| `internal/gateway/connector/hookexec/hookexec.go` | added | Native Go decision engine: capped stdin, gateway POST, per-connector stdout/exit shaping, fail-open/closed. HTTP client **refuses redirects** (no token leak / SSRF). |
| `internal/gateway/connector/hookexec/spec.go` | added | Per-connector request/response/exit specifications. |
| `internal/gateway/connector/hookexec/helpers.go` | added | Shared helpers: W3C trace-context handling, JSON shaping. |
| `internal/gateway/connector/hookexec/hookexec_test.go` | test | Engine tests incl. the redirect-refusal regression. |
| `internal/gateway/connector/filelock_unix.go` / `filelock_windows.go` | added | Exclusive, blocking file lock: `flock` (Unix) / `LockFileEx` (Windows). |
| `internal/gateway/connector/otlp_token.go` | modified | Shared OTLP path-token logic; symlink + permission checks moved behind a platform seam. |
| `internal/gateway/connector/otlp_token_unix.go` / `otlp_token_windows.go` | added | Platform symlink (`O_NOFOLLOW` / `Lstat`) + permission enforcement. |
| `internal/gateway/connector/plugin_owner_unix.go` / `plugin_owner_windows.go` | added | File-owner trust check per platform. |
| `internal/gateway/connector/plugin_loader.go` | modified | Wires the platform-aware owner check. |
| `internal/daemon/proc_unix.go` (mod) / `proc_windows.go` (added) | modified/added | Process create + teardown: process group vs `DETACHED_PROCESS` + `CTRL_BREAK`. |
| `internal/cli/watchdog.go` (mod) / `watchdog_unix.go` / `watchdog_windows.go` (added) | modified/added | Watchdog signal handling per platform. |
| `internal/cli/sidecar.go` (mod) / `sidecar_unix.go` / `sidecar_windows.go` (added) | modified/added | Sidecar process lifecycle per platform. |
| `internal/notify/notify_windows.go` | added | Windows desktop-notification path. |
| `internal/gateway/connector/helpers.go` | modified | `hookInvocationCommand` / `isNativeHookCommand` / `windowsQuoteExe`: emit native `defenseclaw hook …` on Windows, `.sh` on Unix; platform-aware shell quoting. |
| `internal/gateway/connector/subprocess.go` | modified | Writes the hook + a new `.hookcfg` sidecar (gateway addr + fail mode) for native hooks; restrictive file perms. |
| `internal/gateway/connector/codex.go` / `claudecode.go` / `hook_only.go` | modified | Use `hookInvocationCommand`; Codex trust hash computed over the command string. |
| `internal/gateway/connector/registry.go` | modified | Filters connectors by OS support. |
| `internal/gateway/connector/openclaw.go` / `zeptoclaw.go` / `codeguard_native.go` | modified | Cross-platform home dir via `userHomeDir` / `zeptoClawHomeDir` (Windows `%USERPROFILE%`). |
| `internal/gateway/connector/atomicfile.go` | modified | Atomic write + gofmt. |
| `internal/gateway/connector/connector_test.go` | test | Fix `embed.FS` path on Windows (`path.Join`, not `filepath.Join`) so the OpenClaw skip fires. |
| `internal/gateway/connector/hooks/_hardening.sh` | modified | Removes PATH hardening; adds `_dc_jq` shim (jq → Python3 fallback). |
| `internal/gateway/connector/hooks/*-hook.sh`, `inspect-*.sh` | modified | Adopt `_dc_jq`; consistent JSON parsing. |
| `internal/gateway/connector/platform_support.go` | added | `proxyConnectors` + `connectorSupportedOnOS`: proxy connectors unsupported on Windows. |
| `internal/gateway/connector/platform_support_test.go` | test | Per-OS parity; mirrors the Python set. |
| `internal/gateway/connector/hookwiring_test.go` | test | Verifies native vs script hook wiring per OS. |
| `cli/defenseclaw/platform_support.py` | added | Python mirror: `WINDOWS_UNSUPPORTED_CONNECTORS`, `supported_connectors`. |
| `cli/tests/test_platform_support.py` | test | Cross-language parity assertions (Go ⇄ Python taxonomy). |
| `cli/defenseclaw/tui/services/cli_choices.py`, `panels/first_run.py`, `screens/mode_picker.py` | modified | `visible_*` helpers drop proxy connectors on Windows. |
| `cli/defenseclaw/commands/cmd_setup.py` | modified | Hook vs proxy connector sets; OS gating in setup. |
| `cli/defenseclaw/config.py` | modified | Cross-platform config mutex (`msvcrt` byte-range lock on Windows). |
| `cli/tests/test_config_lock_mutex.py` | test | Contended-lock test; runs on Windows in CI. |
| `cli/defenseclaw/tui/app.py` | modified | Guard `_render_chrome` (`#activity`/`#body`) and `_render_command_strip` (`#command-progress-*`) against teardown `NoMatches`. |
| `cli/defenseclaw/tui/executor.py` | modified | Import `pty` only on POSIX; fail fast if `use_pty=True` on Windows. |
| `.github/workflows/ci.yml` | config | New `windows-hook-path` job (build/vet/test-compile + native hook engine + platform gating + config lock on `windows-latest`); run CI on **all** PRs, not only those targeting `main`. |
| `.github/workflows/connector-live-e2e.yml` | config | (#329) Separate nightly connector-hook E2E: Layer A contract matrix (all OSes, no secrets) + Layer B live (manual-only) + regression-radar issue. |
| `scripts/live-connector-e2e/run.sh`, `report.py`, `lib/*.sh`, `drivers/*.sh`, `golden/**`, `contract-smoke.sh`, `cursor-validation.sh` | added | (#329) Live-E2E harness: orchestrator, per-connector drivers, shared libs, and golden stdin/verdict fixtures. |
| `test/e2e/connectormatrix.go` | test | (#329) Connector-matrix coverage incl. `antigravity`. |
| `test/e2e/testdata/v7/golden/antigravity/verdict-blocked.golden.json` | test | (#329) Golden blocked verdict for `antigravity`. |
| `cli/defenseclaw/inventory/validated_versions.json` | added | (#329) Approved upstream agent versions (deliberate human bump only). |
| `docs/CONNECTOR-MATRIX.md` | docs | Per-OS connector support matrix (proxy unsupported on Windows). |
| `docs/INSTALL.md` | docs | Windows install + usage notes. |

## Open Issues / Follow-ups

- **Live (Layer B) connector E2E is manual-only.** The nightly schedule runs the
  deterministic contract layer (Layer A) alone until provider secrets are in
  place; Gemini CLI, Cursor, and Copilot live cells are deferred pending their
  native keys (`GOOGLE_API_KEY` / `CURSOR_API_KEY` / `COPILOT_CLI_TOKEN`). See
  the header of `.github/workflows/connector-live-e2e.yml`.
- **Windows live-E2E cells run `continue-on-error`** until native Windows hook
  execution is proven on hosted Windows runners; the deterministic
  `windows-hook-path` job in `ci.yml` is the gating Windows coverage today.
- **Codex still cannot inject the gateway token.** `codex-cli` sends
  `Authorization: Bearer <provider-key>` directly to the gateway with no
  shell-script seam to add `X-DC-Auth`; loopback requests are accepted and a
  `[SECURITY]` line is logged. Pre-existing; not addressed here.
- **`defenseclaw hook` is loopback-only.** The native engine assumes the gateway
  is on localhost; remote-gateway hook invocation is out of scope.

## Test Plan

Local (from the worktree; Python uses `uv` so Textual ≥ 8.2.7 is pinned):

- `go build ./...` → builds clean.
- `go vet ./...` → clean.
- `gofmt -l <changed *.go>` → no drift.
- `go test ./internal/gateway/connector/... ./internal/cli/... ./internal/daemon/...` → pass.
- `uv run python -m pytest cli/tests/test_platform_support.py cli/tests/test_config_lock_mutex.py` → pass.
- `uv run python -m pytest cli/tests/tui/test_app_shell.py` → 105 passed (teardown-guard coverage).
- `uv run python -m pytest cli/tests/tui/test_visual_snapshot_smoke.py` → 44 passed.

CI (PR head `fa5baebc`, the run before #329 landed):

- `CI` workflow green, including **`Windows Hook Path`** (windows-latest:
  build + vet + test-compile + native hook engine + platform gating + config
  lock) and **`Python Lint & Test`** — run
  [26671907863](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/26671907863).
- `E2E` workflow green, including **`Full Live E2E`**, `Core E2E`, all four
  `Connector Matrix` variants, and the `E2E Required` gate — run
  [26671907864](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/26671907864).

Not tested here:

- Layer B live runs against real upstream agents on hosted **Windows** runners
  (continue-on-error; see Open Issues).
- Gemini CLI / Cursor / Copilot live cells (keys not yet provisioned).

---

This PR is stacked on `feat/hook-collector-unification` (#284) and targets it as
its base; merge after #284.
