### PR TITLE
fix(policy): add custom enterprise data detections

### DIFF
--- a/policies/guardrail/default/rules/enterprise-data.yaml
+++ b/policies/guardrail/default/rules/enterprise-data.yaml
@@ -118,3 +118,17 @@ rules:
     severity: HIGH
     confidence: 0.75
     tags: [pii, bulk-data]
+
+  - id: ENT-CUSTOM-NAMES
+    pattern: '(?i)\b(?:Ezra\s+Doyle|Liam\s+Hernandez|Josh\s+Greene)\b'
+    title: "Restricted individual name (organization-defined)"
+    severity: CRITICAL
+    confidence: 0.90
+    tags: [pii, custom]
+
+  - id: ENT-CUSTOM-COMPETITOR-EMAIL
+    pattern: '(?i)\b[a-z0-9._%+\-]+@competitor\.com\b'
+    title: "Email address on competitor.com (organization-defined)"
+    severity: CRITICAL
+    confidence: 0.95
+    tags: [pii, custom]

--- a/policies/guardrail/permissive/rules/enterprise-data.yaml
+++ b/policies/guardrail/permissive/rules/enterprise-data.yaml
@@ -122,3 +122,17 @@ rules:
     confidence: 0.75
     tags: [pii, bulk-data]
     enabled: false
+
+  - id: ENT-CUSTOM-NAMES
+    pattern: '(?i)\b(?:Ezra\s+Doyle|Liam\s+Hernandez|Josh\s+Greene)\b'
+    title: "Restricted individual name (organization-defined)"
+    severity: CRITICAL
+    confidence: 0.90
+    tags: [pii, custom]
+
+  - id: ENT-CUSTOM-COMPETITOR-EMAIL
+    pattern: '(?i)\b[a-z0-9._%+\-]+@competitor\.com\b'
+    title: "Email address on competitor.com (organization-defined)"
+    severity: CRITICAL
+    confidence: 0.95
+    tags: [pii, custom]

--- a/policies/guardrail/strict/rules/enterprise-data.yaml
+++ b/policies/guardrail/strict/rules/enterprise-data.yaml
@@ -112,3 +112,17 @@ rules:
     severity: HIGH
     confidence: 0.75
     tags: [pii, bulk-data]
+
+  - id: ENT-CUSTOM-NAMES
+    pattern: '(?i)\b(?:Ezra\s+Doyle|Liam\s+Hernandez|Josh\s+Greene)\b'
+    title: "Restricted individual name (organization-defined)"
+    severity: CRITICAL
+    confidence: 0.90
+    tags: [pii, custom]
+
+  - id: ENT-CUSTOM-COMPETITOR-EMAIL
+    pattern: '(?i)\b[a-z0-9._%+\-]+@competitor\.com\b'
+    title: "Email address on competitor.com (organization-defined)"
+    severity: CRITICAL
+    confidence: 0.95
+    tags: [pii, custom]


### PR DESCRIPTION
## Summary

Adds organization-defined enterprise data detections across all guardrail postures:

- Adds `ENT-CUSTOM-NAMES` to detect restricted individual names.
- Adds `ENT-CUSTOM-COMPETITOR-EMAIL` to detect `competitor.com` email addresses.
- Applies the rules consistently to default, permissive, and strict enterprise data rule packs.

## Why

The enterprise data rule packs did not include these custom organization-defined indicators, so matching names and competitor-domain email addresses could pass through without the expected critical-severity finding.

## Impact

Guardrail policy scans now flag these custom enterprise data patterns with critical severity and `pii/custom` tags in each supported posture.

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p) }; puts "All policy YAML OK: #{ARGV.length} files"' $(git ls-files 'policies/*.yaml' 'policies/**/*.yaml')`
- `pytest cli/tests/test_guardrail.py cli/tests/test_cmd_guardrail.py cli/tests/test_cmd_guardrail_matrix.py cli/tests/test_cmd_policy.py cli/tests/test_policy_scan_integration.py`