### PR TITLE
fix(gateway): respect env var in EnsureGatewayToken when local key re…

### DIFF
--- a/internal/gateway/firstboot.go
+++ b/internal/gateway/firstboot.go
@@ -49,12 +49,28 @@ func EnsureGatewayToken(dotenvPath string) (string, error) {
 	firstBootMu.Lock()
 	defer firstBootMu.Unlock()
 
-	if t := strings.TrimSpace(ResolveAPIKey("DEFENSECLAW_GATEWAY_TOKEN", dotenvPath)); t != "" {
+	// Check the process environment directly (not via ResolveAPIKey which
+	// is gated by localKeyResolutionDisabled). In enterprise/sidecar mode
+	// the gateway token is injected via ConfigMap envFrom and must be
+	// respected even when local key resolution is disabled for LLM keys.
+	if t := strings.TrimSpace(os.Getenv("DEFENSECLAW_GATEWAY_TOKEN")); t != "" {
 		return t, nil
 	}
-	// Compatibility shim: old installs may have the legacy var name.
-	if t := strings.TrimSpace(ResolveAPIKey("OPENCLAW_GATEWAY_TOKEN", dotenvPath)); t != "" {
+	if t := strings.TrimSpace(os.Getenv("OPENCLAW_GATEWAY_TOKEN")); t != "" {
 		return t, nil
+	}
+
+	// Fall back to dotenv file lookup (covers standalone CLI installs
+	// where the token lives in ~/.defenseclaw/.env).
+	if dotenvPath != "" {
+		if dotenv, err := loadDotEnv(dotenvPath); err == nil {
+			if t := strings.TrimSpace(dotenv["DEFENSECLAW_GATEWAY_TOKEN"]); t != "" {
+				return t, nil
+			}
+			if t := strings.TrimSpace(dotenv["OPENCLAW_GATEWAY_TOKEN"]); t != "" {
+				return t, nil
+			}
+		}
 	}
 
 	if dotenvPath == "" {

--- a/internal/gateway/firstboot_test.go
+++ b/internal/gateway/firstboot_test.go
@@ -130,6 +130,30 @@ func TestEnsureGatewayToken_PreservesOtherDotenvLines(t *testing.T) {
 	}
 }
 
+func TestEnsureGatewayToken_RespectsEnvWhenLocalKeyResolutionDisabled(t *testing.T) {
+	tmp := t.TempDir()
+	dotenv := filepath.Join(tmp, ".env")
+	t.Setenv("DEFENSECLAW_GATEWAY_TOKEN", "enterprise-configmap-token")
+	t.Setenv("OPENCLAW_GATEWAY_TOKEN", "")
+
+	// Simulate enterprise mode where DisableLocalKeyResolution() is called
+	// before the sidecar boots. The gateway token must still be read from
+	// the process env — localKeyResolutionDisabled only gates LLM API keys.
+	localKeyResolutionDisabled = true
+	t.Cleanup(func() { localKeyResolutionDisabled = false })
+
+	tok, err := EnsureGatewayToken(dotenv)
+	if err != nil {
+		t.Fatalf("EnsureGatewayToken: %v", err)
+	}
+	if tok != "enterprise-configmap-token" {
+		t.Errorf("expected env-supplied token, got %q (first-boot generation should not trigger when env is set)", tok)
+	}
+	if _, err := os.Stat(dotenv); err == nil {
+		t.Error("dotenv should not have been written when env var was already set")
+	}
+}
+
 // TestRunGuardrail_OpenClaw_CredentialsBeforeProbe pins the boot-path
 // invariant: the active connector must receive SetCredentials() BEFORE
 // the HasUsableProviders() probe runs in runGuardrail. The earlier


### PR DESCRIPTION
…solution is disabled

In enterprise mode, DisableLocalKeyResolution() prevents ResolveAPIKey() from reading environment variables (intended for LLM API keys). However, EnsureGatewayToken() was calling ResolveAPIKey() to check for the gateway token, causing it to always return "" and generate a new first-boot token — even when DEFENSECLAW_GATEWAY_TOKEN was correctly set via ConfigMap envFrom.

This broke intra-pod auth: the guardrail proxy generated a random token while openclaw held the ConfigMap-provisioned one, causing AUTH_INVALID_TOKEN on every LLM request through the proxy.

Fix: check os.Getenv() directly for the gateway token (same approach as config.GatewayConfig.ResolvedToken), then fall back to dotenv file lookup. The localKeyResolutionDisabled flag now only gates LLM API key resolution, not the gateway auth token.