### PR TITLE
feat(gateway): configurable agent-to-upstream header forwarding (default on)

### DIFF
--- a/docs-site/content/docs/reference/configuration.mdx
+++ b/docs-site/content/docs/reference/configuration.mdx
@@ -86,6 +86,17 @@ llm:
   role: unified                # unified | agent | judge
   instance_name: ""            # binds to a ~/.defenseclaw/custom-providers.json entry; required with provider: custom
   region: ""                   # generic regional hint (Bedrock / Vertex); provider-specific sub-blocks below take precedence
+  # forward_custom_headers controls whether the guardrail gateway
+  # forwards inbound HTTP headers from the agent to the upstream LLM
+  # provider on both /v1/chat/completions and the passthrough path
+  # (/v1/responses, /v1/messages, Bedrock/Gemini native, ...). Default
+  # is on; set to false to suppress all inbound header copying so the
+  # upstream only sees the canonical Authorization the gateway re-mints
+  # from the secrets sidecar. A small blocklist (proxy-hop, auth, host,
+  # X-DC-*, X-DefenseClaw-*, W3C trace context) plus RFC 7230 /
+  # printable-ASCII validation and 64-header / 32 KiB caps apply
+  # regardless. See docs/GUARDRAIL.md → Custom Header Forwarding.
+  forward_custom_headers: true
 
   # Provider-specific sub-blocks. Only the one matching `provider`
   # is consulted; the others may exist as leftover state from a

--- a/docs/GUARDRAIL.md
+++ b/docs/GUARDRAIL.md
@@ -881,6 +881,73 @@ responses in-process:
 - In `action` mode, terminates the stream early if a high-severity threat is detected
 - After the stream completes, runs the full multi-scanner inspection pipeline on assembled content
 
+## Custom Header Forwarding (`llm.forward_custom_headers`)
+
+The guardrail proxy forwards inbound HTTP headers from the agent to
+the upstream LLM provider on both the chat/completions path (via
+Bifrost's per-request `schemas.BifrostContextKeyExtraHeaders` context
+value) and the passthrough path (`/v1/responses`, `/v1/messages`,
+Bedrock/Gemini native, etc.). Enabled by default; operators opt out
+with `llm.forward_custom_headers: false`.
+
+When enabled, every inbound header is forwarded to the upstream
+provider except a small blocklist that matches the pre-refactor
+`handlePassthrough` inline list exactly (no silent behavior change vs.
+earlier gateway versions):
+
+- Proxy-hop / framework-internal: `X-DC-Target-URL`, `X-AI-Auth`,
+  `X-DC-Auth`, and any `X-DC-*` / `X-DefenseClaw-*` header.
+- Wire framing: `Host`, `Content-Length` — `Content-Length` is stripped
+  because guardrail notification injection can mutate the body size;
+  the Go HTTP client writes the authoritative value from
+  `upstreamReq.ContentLength`.
+- Authentication: `Authorization`, `X-API-Key`, `Api-Key` — re-minted
+  canonically by the gateway from the secrets sidecar so the upstream
+  always sees the resolved provider key, never a stale agent header.
+- W3C trace context: `Traceparent`, `Tracestate`.
+
+`internal/gateway/forward_headers.go` carries an annotated, commented-out
+**blocklist expansion** with danger ratings (HIGH / MEDIUM / LOW / ZERO)
+for `Cookie`, `Set-Cookie`, `Proxy-Authorization`, `Transfer-Encoding`,
+`TE`, `Trailers`, `Connection`, `Keep-Alive`, `Upgrade`,
+`Proxy-Authenticate`, `Baggage`, and `Content-Type`. Operators with a
+stricter posture (or who don't need any of the listed headers reaching
+their custom upstream) are encouraged to uncomment the HIGH-rated
+entries — at minimum `Cookie`, `Set-Cookie`, `Proxy-Authorization`,
+`Transfer-Encoding`, and `TE` — and bump the matching test in
+`forward_headers_test.go`. `Content-Type` is ZERO-rated (actively
+wrong to block, because Go's `http.NewRequestWithContext` does not
+auto-set it for a raw `io.Reader` body).
+
+Every header that survives the blocklist is validated against RFC 7230
+tchar (name) and printable ASCII + HTAB (value); CR/LF/NUL in a value
+yields HTTP 400 to block header- and log-injection. Soft caps of 64
+headers and 32 KiB combined name+value bytes per request yield HTTP
+413 to bound a hostile caller; the limits comfortably cover real
+provider headers (`anthropic-version`, `anthropic-beta`,
+`openai-organization`, tenant tags, tracing IDs).
+
+On the chat/completions path the resulting headers are attached to the
+request `context.Context` under
+`schemas.BifrostContextKeyExtraHeaders` — Bifrost's per-request
+extra-headers hook, honored by every provider through
+`providers/utils/utils.go:SetExtraHeaders` — so the upstream HTTP
+request the SDK emits carries them onto the wire. On the passthrough
+path they are written directly to the upstream `*http.Request`.
+
+`ConnectorSignals.ExtraHeaders` (declared on the connector contract
+for future use by ZeptoClaw/Codex/etc.) is also merged in with
+connector-wins semantics; the same blocklist and validation apply.
+
+Telemetry: `defenseclaw.gateway.forwarded_headers{path,result}`
+(path = `chat-completions` | `passthrough`; result = `ok` |
+`rejected_invalid` | `rejected_overflow`). The OTel counter is the
+steady-state signal — a per-request `forwarded_header_count=<n>`
+stderr line is gated behind `DEFENSECLAW_DEBUG=1` for local triage.
+Rejection-path stderr lines (`header forwarding rejected: <reason>`)
+remain unconditional because they are operator-actionable. Header
+names and values are never logged.
+
 ## Hot Reload
 
 Mode and scanner_mode can be changed at runtime without restarting:

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -315,6 +315,7 @@ The gateway emits the following OTel metrics
 |--------|--------|
 | `defenseclaw.redaction.applied` | detector, field |
 | `defenseclaw.egress.events` | branch (known \| shape \| passthrough), decision (allow \| block), source (go \| ts) |
+| `defenseclaw.gateway.forwarded_headers` | path (chat-completions \| passthrough), result (ok \| rejected_invalid \| rejected_overflow) |
 
 **Sink delivery:**
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -317,6 +317,19 @@ type LLMConfig struct {
 	// LLMConfig.instance_name field.
 	InstanceName string `mapstructure:"instance_name" yaml:"instance_name,omitempty"`
 
+	// ForwardCustomHeaders controls whether the guardrail gateway
+	// forwards inbound HTTP headers (minus an always-denied blocklist of
+	// proxy-hop, auth, hop-by-hop, cookie, and framework-internal headers)
+	// from the agent on to the upstream LLM provider on both the
+	// /v1/chat/completions and passthrough paths (Responses API,
+	// /v1/messages, etc.).
+	//
+	// Pointer-typed so an absent YAML field round-trips as nil, which is
+	// interpreted as the safe default (enabled). Operators opt out
+	// explicitly with `forward_custom_headers: false`. Use
+	// ForwardCustomHeadersEnabled() to read the effective value.
+	ForwardCustomHeaders *bool `mapstructure:"forward_custom_headers" yaml:"forward_custom_headers,omitempty"`
+
 	// Region is a free-form region/location hint surfaced on the role
 	// (e.g. "us-east-1" for Bedrock, "us-central1" for Vertex). The
 	// per-provider sub-blocks (Bedrock.Region, Vertex.Region) take
@@ -484,6 +497,18 @@ func (l LLMConfig) IsLocalProvider() bool {
 		}
 	}
 	return false
+}
+
+// ForwardCustomHeadersEnabled reports whether the gateway forwards
+// inbound HTTP headers from the agent through to the upstream LLM
+// provider. The feature is enabled by default; nil (unset YAML) is
+// treated as true so existing configs keep working. Operators can
+// opt out with `llm.forward_custom_headers: false`.
+func (l LLMConfig) ForwardCustomHeadersEnabled() bool {
+	if l.ForwardCustomHeaders == nil {
+		return true
+	}
+	return *l.ForwardCustomHeaders
 }
 
 // recognizedLLMProviders lists the "provider/" prefixes the gateway and

--- a/internal/gateway/forward_headers.go
+++ b/internal/gateway/forward_headers.go
@@ -1,0 +1,362 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"errors"
+	"net/http"
+	"net/textproto"
+	"strings"
+)
+
+// Header forwarding policy.
+//
+// The guardrail gateway forwards inbound agent headers to the upstream
+// LLM provider on both the chat/completions and passthrough code paths
+// when llm.forward_custom_headers is enabled (default on).
+//
+// The model is intentionally blocklist-only: every inbound header is
+// forwarded except a hardened set that would (a) leak DefenseClaw
+// internal routing metadata to third parties, (b) overwrite or
+// duplicate the canonical upstream Authorization header the gateway
+// re-mints from the secrets sidecar, (c) corrupt the upstream HTTP
+// framing (hop-by-hop headers, Content-Length when the body was
+// rewritten by guardrail notification injection), or (d) cross
+// trust boundaries via cookies / W3C trace context.
+//
+// Two further safeguards are applied to every header that survives
+// the blocklist:
+//   - RFC 7230 tchar validation on the name (rejects malformed names
+//     and prevents header smuggling via embedded control characters).
+//   - Printable-ASCII (+ HTAB) validation on the value (rejects CR,
+//     LF, and NUL — the primary HTTP-response/header injection and
+//     log-injection vectors).
+//
+// Soft caps bound the number of headers and the combined name+value
+// bytes forwarded per request to prevent a hostile client from
+// exhausting upstream provider header budgets.
+
+// Maximum number of headers forwarded per request, and maximum combined
+// bytes (sum of name + value lengths across forwarded headers). Caps
+// are deliberately generous so legitimate provider headers like
+// anthropic-version, anthropic-beta, openai-organization, tenant tags,
+// and tracing IDs all flow through; they exist to bound an abusive
+// caller rather than to constrain the common case.
+const (
+	maxForwardedHeaders = 64
+	maxForwardedBytes   = 32 * 1024
+)
+
+// alwaysDeniedHeaders is the never-forwarded set. Keys are lowercased
+// for case-insensitive comparison via http.CanonicalHeaderKey-folded
+// strings.ToLower. The X-DC-* and X-DefenseClaw-* families are handled
+// by prefix checks in shouldForwardHeader instead of by entries here.
+//
+// The set below is **identical to the pre-existing inline blocklist** in
+// handlePassthrough so this refactor does not silently change which
+// headers reach upstream providers. The expanded blocklist (cookies,
+// hop-by-hop per RFC 7230 §6.1, Baggage, Content-Type) is intentionally
+// commented out below — each entry carries a danger rating so operators
+// can re-enable selected names by uncommenting if they observe upstream
+// regressions or want stricter posture. See docs/GUARDRAIL.md for
+// guidance.
+var alwaysDeniedHeaders = map[string]struct{}{
+	// Proxy-hop / framework-internal headers (pre-existing).
+	"x-dc-target-url": {},
+	"x-ai-auth":       {},
+	"x-dc-auth":       {},
+	// Wire framing — Content-Length must not be copied because
+	// guardrail notification injection can change the body size;
+	// upstreamReq.ContentLength is the authoritative value. Host is
+	// rebuilt by http.NewRequestWithContext from the URL.
+	"host":           {},
+	"content-length": {},
+	// Authentication — re-minted canonically by the gateway from the
+	// secrets sidecar / token resolver (pre-existing).
+	"authorization": {},
+	"x-api-key":     {},
+	"api-key":       {},
+	// W3C trace context — internal correlation only; echoing into
+	// upstream provider logs leaks DefenseClaw routing metadata across
+	// tenants (pre-existing).
+	"traceparent": {},
+	"tracestate":  {},
+
+	// ── BEGIN: blocklist expansion — commented out to preserve the
+	// pre-refactor forwarding contract. Each entry below was added by
+	// the refactor and is *not* in the legacy inline loop. Uncomment
+	// selectively if your deployment's threat model requires it.
+	//
+	// DANGER RATING legend (per the security review):
+	//   HIGH:   genuinely exploitable if forwarded — strongly recommend
+	//           keeping commented-IN (i.e. enable the blocklist entry).
+	//   MEDIUM: protocol-incorrect to forward but rarely exploitable in
+	//           practice; Go's net/http client largely ignores them on
+	//           outbound requests.
+	//   LOW:    privacy / telemetry leak only; no exploit path.
+	//   ZERO:   actively wrong to block — upstream parsers depend on it.
+
+	// "cookie":              {}, // HIGH — agent session cookies (often
+	//                              // meant for the agent's frontend, not
+	//                              // the LLM provider). LLM-provider logs
+	//                              // could capture them. Cookie-stealing
+	//                              // via log search is the canonical
+	//                              // exploit pattern. ★ recommend
+	//                              // re-enabling.
+	// "set-cookie":          {}, // HIGH — only meaningful on responses
+	//                              // but cheap to block on requests as
+	//                              // defense-in-depth. ★ recommend
+	//                              // re-enabling.
+	// "proxy-authorization": {}, // HIGH — next-hop proxy credentials.
+	//                              // Forwarding leaks proxy-server auth
+	//                              // to the LLM provider. ★ recommend
+	//                              // re-enabling.
+	// "transfer-encoding":   {}, // HIGH — forwarding "chunked" alongside
+	//                              // a known Content-Length is a classic
+	//                              // HTTP request-smuggling vector. ★
+	//                              // recommend re-enabling.
+	// "te":                  {}, // HIGH — paired with Transfer-Encoding;
+	//                              // forwarding can enable smuggling
+	//                              // variants. ★ recommend re-enabling.
+	// "trailers":            {}, // MEDIUM — hop-by-hop announcement of
+	//                              // trailer fields; meaningless on the
+	//                              // outbound request but inconsistent
+	//                              // with RFC 7230 §6.1.
+	// "connection":          {}, // MEDIUM — hop-by-hop; "Connection:
+	//                              // close" forwarded to upstream forces
+	//                              // a per-request connection teardown,
+	//                              // wasting upstream's pool capacity.
+	// "keep-alive":          {}, // MEDIUM — hop-by-hop; rarely honored.
+	// "upgrade":              {}, // MEDIUM — could trigger an unintended
+	//                              // protocol upgrade (WebSocket/HTTP-2)
+	//                              // attempt at the upstream.
+	// "proxy-authenticate":  {}, // LOW — server→client header; forwarded
+	//                              // from a client direction it's
+	//                              // meaningless but harmless.
+	// "baggage":             {}, // LOW — OpenTelemetry context. Leaks
+	//                              // DefenseClaw session metadata to the
+	//                              // upstream provider; privacy concern
+	//                              // only, no exploit.
+	// "content-type":        {}, // ZERO — actively wrong to block. Go's
+	//                              // http.NewRequestWithContext does NOT
+	//                              // auto-set Content-Type for a raw
+	//                              // io.Reader body; if we strip the
+	//                              // inbound value, upstream parsers
+	//                              // expecting application/json will fail.
+	// ── END: blocklist expansion.
+}
+
+// ErrInvalidHeaderName is returned when a forwarded header name fails
+// RFC 7230 tchar validation. Callers should map this to HTTP 400.
+var ErrInvalidHeaderName = errors.New("invalid forwarded header name")
+
+// ErrInvalidHeaderValue is returned when a forwarded header value
+// contains CR, LF, NUL, or other non-printable bytes. Header-injection
+// defense. Callers should map this to HTTP 400.
+var ErrInvalidHeaderValue = errors.New("invalid forwarded header value")
+
+// ErrTooManyHeaders is returned when the forwarded header count would
+// exceed maxForwardedHeaders. Callers should map this to HTTP 413.
+var ErrTooManyHeaders = errors.New("too many forwarded headers")
+
+// ErrHeadersTooLarge is returned when the combined byte size of the
+// forwarded header names + values would exceed maxForwardedBytes.
+// Callers should map this to HTTP 413.
+var ErrHeadersTooLarge = errors.New("forwarded headers too large")
+
+// shouldForwardHeader returns true when the given header name (any
+// casing) is eligible for forwarding to the upstream provider. The
+// check enforces both the always-denied set and the X-DC-* /
+// X-DefenseClaw-* prefix blocklist.
+func shouldForwardHeader(name string) bool {
+	if name == "" {
+		return false
+	}
+	lk := strings.ToLower(name)
+	if _, denied := alwaysDeniedHeaders[lk]; denied {
+		return false
+	}
+	if strings.HasPrefix(lk, "x-dc-") || strings.HasPrefix(lk, "x-defenseclaw-") {
+		return false
+	}
+	return true
+}
+
+// isValidHeaderName reports whether name matches the RFC 7230 tchar
+// production. Empty input returns false. We do the check in-place to
+// avoid the per-call allocation a precompiled regexp would incur on
+// the request hot path.
+func isValidHeaderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '!' || c == '#' || c == '$' || c == '%' || c == '&' ||
+			c == '\'' || c == '*' || c == '+' || c == '-' || c == '.' ||
+			c == '^' || c == '_' || c == '`' || c == '|' || c == '~':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isValidHeaderValue rejects any byte that is not printable ASCII
+// (0x20-0x7E) or HTAB (0x09). In particular this blocks CR (0x0D),
+// LF (0x0A), and NUL (0x00) — the canonical header- and
+// log-injection vectors. Empty value is permitted (RFC 7230 allows
+// field-value to be empty after folding obs-fold).
+func isValidHeaderValue(value string) bool {
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+		if c == '\t' {
+			continue
+		}
+		if c < 0x20 || c > 0x7E {
+			return false
+		}
+	}
+	return true
+}
+
+// CopyForwardableHeaders copies every header from src to dst that is
+// safe to forward to an upstream LLM provider, applying the
+// always-denied blocklist, RFC 7230 name validation, value validation
+// (no CR/LF/NUL), and the count/size caps.
+//
+// Forwarded headers are written with Set semantics: any pre-existing
+// value on dst for the same canonical key is dropped first. This
+// prevents an upstream from seeing both an inbound value and a value
+// the gateway derived elsewhere (defense against header-spoofing via
+// duplicate names on different paths).
+//
+// Returns the number of headers written and an error keyed to one of
+// ErrInvalidHeaderName, ErrInvalidHeaderValue, ErrTooManyHeaders, or
+// ErrHeadersTooLarge so the caller can map to the correct HTTP
+// response code.
+func CopyForwardableHeaders(dst, src http.Header) (int, error) {
+	if dst == nil {
+		return 0, errors.New("forward_headers: nil destination")
+	}
+	count := 0
+	bytes := 0
+	for name, values := range src {
+		if !shouldForwardHeader(name) {
+			continue
+		}
+		if !isValidHeaderName(name) {
+			return count, ErrInvalidHeaderName
+		}
+		for _, v := range values {
+			if !isValidHeaderValue(v) {
+				return count, ErrInvalidHeaderValue
+			}
+		}
+		// Canonicalize so callers see deterministic header names on
+		// the upstream request regardless of inbound casing.
+		canonical := textproto.CanonicalMIMEHeaderKey(name)
+		dst.Del(canonical)
+		for _, v := range values {
+			dst.Add(canonical, v)
+			count++
+			bytes += len(canonical) + len(v)
+			if count > maxForwardedHeaders {
+				return count, ErrTooManyHeaders
+			}
+			if bytes > maxForwardedBytes {
+				return count, ErrHeadersTooLarge
+			}
+		}
+	}
+	return count, nil
+}
+
+// MergeConnectorExtraHeaders overlays headers contributed by an active
+// connector (via ConnectorSignals.ExtraHeaders) onto dst with
+// connector-wins semantics: connector values overwrite any prior dst
+// value for the same canonical key. The same blocklist and validation
+// applied to inbound headers also runs here so a misbehaving connector
+// cannot leak DefenseClaw correlation metadata or smuggle CR/LF
+// payloads into the upstream request.
+//
+// Returns the number of headers added/overwritten and an error keyed
+// to the same sentinel set as CopyForwardableHeaders.
+func MergeConnectorExtraHeaders(dst http.Header, extras map[string]string) (int, error) {
+	if dst == nil {
+		return 0, errors.New("forward_headers: nil destination")
+	}
+	if len(extras) == 0 {
+		return 0, nil
+	}
+	count := 0
+	bytes := 0
+	for name, value := range extras {
+		if !shouldForwardHeader(name) {
+			continue
+		}
+		if !isValidHeaderName(name) {
+			return count, ErrInvalidHeaderName
+		}
+		if !isValidHeaderValue(value) {
+			return count, ErrInvalidHeaderValue
+		}
+		canonical := textproto.CanonicalMIMEHeaderKey(name)
+		dst.Set(canonical, value)
+		count++
+		bytes += len(canonical) + len(value)
+		if count > maxForwardedHeaders {
+			return count, ErrTooManyHeaders
+		}
+		if bytes > maxForwardedBytes {
+			return count, ErrHeadersTooLarge
+		}
+	}
+	return count, nil
+}
+
+// httpStatusForHeaderError maps the forward-header sentinel errors to
+// the appropriate HTTP status code. Unknown errors return 400 so the
+// caller fails closed.
+func httpStatusForHeaderError(err error) int {
+	switch {
+	case errors.Is(err, ErrTooManyHeaders), errors.Is(err, ErrHeadersTooLarge):
+		return http.StatusRequestEntityTooLarge
+	case errors.Is(err, ErrInvalidHeaderName), errors.Is(err, ErrInvalidHeaderValue):
+		return http.StatusBadRequest
+	default:
+		return http.StatusBadRequest
+	}
+}
+
+// resultForHeaderError maps the forward-header sentinel errors to the
+// metric result label
+// (defenseclaw.gateway.forwarded_headers{result=...}).
+func resultForHeaderError(err error) string {
+	switch {
+	case errors.Is(err, ErrTooManyHeaders), errors.Is(err, ErrHeadersTooLarge):
+		return "rejected_overflow"
+	case errors.Is(err, ErrInvalidHeaderName), errors.Is(err, ErrInvalidHeaderValue):
+		return "rejected_invalid"
+	default:
+		return "rejected_invalid"
+	}
+}

--- a/internal/gateway/forward_headers_test.go
+++ b/internal/gateway/forward_headers_test.go
@@ -25,13 +25,13 @@ import (
 
 func TestCopyForwardableHeaders_PassesThroughCommonProviderHeaders(t *testing.T) {
 	src := http.Header{
-		"Anthropic-Version": []string{"2023-06-01"},
-		"Anthropic-Beta":    []string{"messages-2024-09-04"},
+		"Anthropic-Version":   []string{"2023-06-01"},
+		"Anthropic-Beta":      []string{"messages-2024-09-04"},
 		"Openai-Organization": []string{"org-abc123"},
-		"User-Agent":         []string{"litellm/1.0"},
-		"Accept":             []string{"application/json"},
-		"Tenant-Id":          []string{"tenant-42"},
-		"X-Region":           []string{"us-east-1"},
+		"User-Agent":          []string{"litellm/1.0"},
+		"Accept":              []string{"application/json"},
+		"Tenant-Id":           []string{"tenant-42"},
+		"X-Region":            []string{"us-east-1"},
 	}
 	dst := http.Header{}
 	n, err := CopyForwardableHeaders(dst, src)
@@ -252,7 +252,7 @@ func TestCopyForwardableHeaders_OverwritesPreExistingValue(t *testing.T) {
 
 func TestCopyForwardableHeaders_NameCanonicalization(t *testing.T) {
 	src := http.Header{
-		"x-tenant-id": []string{"t1"},
+		"x-tenant-id":  []string{"t1"},
 		"X-MIXED-cAsE": []string{"v"},
 	}
 	dst := http.Header{}

--- a/internal/gateway/forward_headers_test.go
+++ b/internal/gateway/forward_headers_test.go
@@ -1,0 +1,368 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestCopyForwardableHeaders_PassesThroughCommonProviderHeaders(t *testing.T) {
+	src := http.Header{
+		"Anthropic-Version": []string{"2023-06-01"},
+		"Anthropic-Beta":    []string{"messages-2024-09-04"},
+		"Openai-Organization": []string{"org-abc123"},
+		"User-Agent":         []string{"litellm/1.0"},
+		"Accept":             []string{"application/json"},
+		"Tenant-Id":          []string{"tenant-42"},
+		"X-Region":           []string{"us-east-1"},
+	}
+	dst := http.Header{}
+	n, err := CopyForwardableHeaders(dst, src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(src) {
+		t.Errorf("forwarded count = %d, want %d", n, len(src))
+	}
+	for name, vals := range src {
+		got := dst.Values(name)
+		if len(got) != len(vals) {
+			t.Errorf("header %q: got %d values, want %d", name, len(got), len(vals))
+			continue
+		}
+		for i, v := range vals {
+			if got[i] != v {
+				t.Errorf("header %q[%d] = %q, want %q", name, i, got[i], v)
+			}
+		}
+	}
+}
+
+func TestCopyForwardableHeaders_BlocklistedHeadersDropped(t *testing.T) {
+	// This is the pre-existing blocklist preserved across the refactor:
+	// proxy-hop, framework-internal, wire-framing (Host/Content-Length),
+	// auth, and W3C trace context. The expanded set (cookies,
+	// hop-by-hop per RFC 7230 §6.1, Baggage, Content-Type) is
+	// intentionally commented out in forward_headers.go and therefore
+	// NOT asserted here. See the "blocklist expansion" annotated block
+	// in forward_headers.go for the danger ratings and re-enable
+	// guidance.
+	cases := []string{
+		// Proxy-hop / framework-internal.
+		"X-DC-Target-URL", "X-AI-Auth", "X-DC-Auth",
+		// Wire framing.
+		"Host", "Content-Length",
+		// Auth — re-minted by the gateway.
+		"Authorization", "X-API-Key", "Api-Key",
+		// W3C trace context (Baggage is NOT in the active blocklist).
+		"Traceparent", "Tracestate",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			src := http.Header{name: []string{"value"}}
+			dst := http.Header{}
+			n, err := CopyForwardableHeaders(dst, src)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if n != 0 {
+				t.Errorf("expected blocklisted header %q to be dropped; got n=%d", name, n)
+			}
+			if dst.Get(name) != "" {
+				t.Errorf("expected blocklisted header %q to be dropped; dst has %q", name, dst.Get(name))
+			}
+		})
+	}
+}
+
+// TestCopyForwardableHeaders_CommentedOutBlocklistEntriesForward pins
+// the explicit decision to commented-out the expanded blocklist (per the
+// security review's recommendation to avoid silent behavior change).
+// Each header here is documented in forward_headers.go with a danger
+// rating; uncommenting any of them in production requires updating this
+// test in lockstep so a future refactor cannot silently re-block them.
+func TestCopyForwardableHeaders_CommentedOutBlocklistEntriesForward(t *testing.T) {
+	commentedOut := map[string]string{
+		"Cookie":              "session=abc",
+		"Set-Cookie":          "x=y",
+		"Proxy-Authorization": "Basic deadbeef",
+		"Transfer-Encoding":   "chunked",
+		"TE":                  "trailers",
+		"Trailers":            "X-Trailer",
+		"Connection":          "close",
+		"Keep-Alive":          "timeout=5",
+		"Upgrade":             "websocket",
+		"Proxy-Authenticate":  "Basic realm=\"x\"",
+		"Baggage":             "user-id=42",
+		"Content-Type":        "application/json",
+	}
+	for name, value := range commentedOut {
+		t.Run(name, func(t *testing.T) {
+			src := http.Header{name: []string{value}}
+			dst := http.Header{}
+			_, err := CopyForwardableHeaders(dst, src)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := dst.Get(name); got != value {
+				t.Errorf("expected %q to forward (commented out of blocklist); dst got %q", name, got)
+			}
+		})
+	}
+}
+
+func TestCopyForwardableHeaders_BlocklistIsCaseInsensitive(t *testing.T) {
+	src := http.Header{
+		"AUTHORIZATION":            []string{"Bearer leaked"},
+		"x-api-key":                []string{"leaked"},
+		"hOsT":                     []string{"evil.example"},
+		"X-Defenseclaw-Session-Id": []string{"abc"},
+		"x-dc-auth":                []string{"Bearer dc"},
+	}
+	dst := http.Header{}
+	n, _ := CopyForwardableHeaders(dst, src)
+	if n != 0 {
+		t.Errorf("expected all blocklisted headers to be dropped; got n=%d, dst=%v", n, dst)
+	}
+}
+
+func TestCopyForwardableHeaders_DCAndDefenseClawPrefixDropped(t *testing.T) {
+	src := http.Header{
+		"X-DC-Anything":           []string{"leak"},
+		"X-DefenseClaw-Whatever":  []string{"leak"},
+		"X-Dc-Mixed-Case":         []string{"leak"},
+		"x-defenseclaw-lowercase": []string{"leak"},
+		// Negative control: not a DC prefix.
+		"X-Something-Else": []string{"keep"},
+	}
+	dst := http.Header{}
+	n, err := CopyForwardableHeaders(dst, src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected only X-Something-Else to forward; got n=%d, dst=%v", n, dst)
+	}
+	if dst.Get("X-Something-Else") != "keep" {
+		t.Errorf("expected X-Something-Else=keep; dst=%v", dst)
+	}
+}
+
+func TestCopyForwardableHeaders_InvalidHeaderNameRejected(t *testing.T) {
+	// Space is not a valid tchar; RFC 7230 forbids it in field-name.
+	src := http.Header{
+		"Tenant Id": []string{"oops"},
+	}
+	dst := http.Header{}
+	_, err := CopyForwardableHeaders(dst, src)
+	if !errors.Is(err, ErrInvalidHeaderName) {
+		t.Errorf("expected ErrInvalidHeaderName; got %v", err)
+	}
+}
+
+func TestCopyForwardableHeaders_HeaderInjectionRejected(t *testing.T) {
+	cases := map[string]string{
+		"CR injection": "value\rEvil-Header: leaked",
+		"LF injection": "value\nEvil-Header: leaked",
+		"CRLF":         "value\r\nEvil-Header: leaked",
+		"NUL byte":     "value\x00",
+		"high byte":    "value\xff",
+	}
+	for name, payload := range cases {
+		t.Run(name, func(t *testing.T) {
+			src := http.Header{"X-User-Tag": []string{payload}}
+			dst := http.Header{}
+			_, err := CopyForwardableHeaders(dst, src)
+			if !errors.Is(err, ErrInvalidHeaderValue) {
+				t.Errorf("expected ErrInvalidHeaderValue for %s payload; got %v", name, err)
+			}
+		})
+	}
+}
+
+func TestCopyForwardableHeaders_HeaderValueAllowsTabAndPrintableASCII(t *testing.T) {
+	src := http.Header{
+		"X-Mixed-Case-Value": []string{"hello\tworld"},
+		"X-Punctuation":      []string{"!@#$%^&*()_+-={}[];':,./<>?"},
+	}
+	dst := http.Header{}
+	if _, err := CopyForwardableHeaders(dst, src); err != nil {
+		t.Errorf("unexpected error on valid printable values: %v", err)
+	}
+}
+
+func TestCopyForwardableHeaders_TooManyHeaders(t *testing.T) {
+	src := http.Header{}
+	for i := 0; i < maxForwardedHeaders+5; i++ {
+		src[http.CanonicalHeaderKey("x-tag-"+itoa(i))] = []string{"v"}
+	}
+	dst := http.Header{}
+	_, err := CopyForwardableHeaders(dst, src)
+	if !errors.Is(err, ErrTooManyHeaders) {
+		t.Errorf("expected ErrTooManyHeaders; got %v", err)
+	}
+}
+
+func TestCopyForwardableHeaders_HeadersTooLarge(t *testing.T) {
+	src := http.Header{
+		"X-Big-Value": []string{strings.Repeat("a", maxForwardedBytes+1)},
+	}
+	dst := http.Header{}
+	_, err := CopyForwardableHeaders(dst, src)
+	if !errors.Is(err, ErrHeadersTooLarge) {
+		t.Errorf("expected ErrHeadersTooLarge; got %v", err)
+	}
+}
+
+func TestCopyForwardableHeaders_OverwritesPreExistingValue(t *testing.T) {
+	// Set semantics: any pre-existing value on dst for a forwarded
+	// header is overwritten, never duplicated. Prevents spoofing
+	// where another code path already wrote the same canonical key.
+	dst := http.Header{
+		"X-Tenant-Id": []string{"stale-from-elsewhere"},
+	}
+	src := http.Header{
+		"X-Tenant-Id": []string{"actual-from-agent"},
+	}
+	if _, err := CopyForwardableHeaders(dst, src); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := dst.Values("X-Tenant-Id")
+	if len(got) != 1 || got[0] != "actual-from-agent" {
+		t.Errorf("got %v, want exactly [actual-from-agent]", got)
+	}
+}
+
+func TestCopyForwardableHeaders_NameCanonicalization(t *testing.T) {
+	src := http.Header{
+		"x-tenant-id": []string{"t1"},
+		"X-MIXED-cAsE": []string{"v"},
+	}
+	dst := http.Header{}
+	if _, err := CopyForwardableHeaders(dst, src); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// dst.Get is case-insensitive but iterating verifies canonical key.
+	if dst.Get("X-Tenant-Id") != "t1" {
+		t.Errorf("X-Tenant-Id missing in dst: %v", dst)
+	}
+	if dst.Get("X-Mixed-Case") != "v" {
+		t.Errorf("X-Mixed-Case missing in dst: %v", dst)
+	}
+}
+
+func TestCopyForwardableHeaders_NilDestination(t *testing.T) {
+	src := http.Header{"X": []string{"v"}}
+	if _, err := CopyForwardableHeaders(nil, src); err == nil {
+		t.Error("expected error on nil destination")
+	}
+}
+
+func TestMergeConnectorExtraHeaders_BasicAndBlocklist(t *testing.T) {
+	dst := http.Header{}
+	extras := map[string]string{
+		"X-Tenant":      "t1",
+		"Authorization": "Bearer stolen", // blocked
+		"X-DC-Auth":     "leak",          // blocked
+	}
+	n, err := MergeConnectorExtraHeaders(dst, extras)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("forwarded count = %d, want 1", n)
+	}
+	if dst.Get("X-Tenant") != "t1" {
+		t.Errorf("X-Tenant missing: %v", dst)
+	}
+	if dst.Get("Authorization") != "" {
+		t.Errorf("Authorization should have been blocklisted: %v", dst)
+	}
+}
+
+func TestMergeConnectorExtraHeaders_ConnectorWinsOverDst(t *testing.T) {
+	dst := http.Header{
+		"X-Tenant": []string{"old-from-inbound"},
+	}
+	extras := map[string]string{
+		"X-Tenant": "new-from-connector",
+	}
+	if _, err := MergeConnectorExtraHeaders(dst, extras); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := dst.Values("X-Tenant")
+	if len(got) != 1 || got[0] != "new-from-connector" {
+		t.Errorf("got %v, want [new-from-connector]", got)
+	}
+}
+
+func TestMergeConnectorExtraHeaders_ValidatesPayload(t *testing.T) {
+	dst := http.Header{}
+	bad := map[string]string{"X-Evil": "x\r\nInjected: yes"}
+	if _, err := MergeConnectorExtraHeaders(dst, bad); !errors.Is(err, ErrInvalidHeaderValue) {
+		t.Errorf("expected ErrInvalidHeaderValue; got %v", err)
+	}
+}
+
+func TestHTTPStatusForHeaderError(t *testing.T) {
+	cases := map[error]int{
+		ErrInvalidHeaderName:  http.StatusBadRequest,
+		ErrInvalidHeaderValue: http.StatusBadRequest,
+		ErrTooManyHeaders:     http.StatusRequestEntityTooLarge,
+		ErrHeadersTooLarge:    http.StatusRequestEntityTooLarge,
+		errors.New("other"):   http.StatusBadRequest,
+	}
+	for err, want := range cases {
+		if got := httpStatusForHeaderError(err); got != want {
+			t.Errorf("status for %v = %d, want %d", err, got, want)
+		}
+	}
+}
+
+func TestResultForHeaderError(t *testing.T) {
+	cases := map[error]string{
+		ErrInvalidHeaderName:  "rejected_invalid",
+		ErrInvalidHeaderValue: "rejected_invalid",
+		ErrTooManyHeaders:     "rejected_overflow",
+		ErrHeadersTooLarge:    "rejected_overflow",
+		errors.New("other"):   "rejected_invalid",
+	}
+	for err, want := range cases {
+		if got := resultForHeaderError(err); got != want {
+			t.Errorf("result for %v = %q, want %q", err, got, want)
+		}
+	}
+}
+
+// itoa is a tiny strconv shim so the test file doesn't need a strconv
+// import for one call site.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [16]byte
+	pos := len(b)
+	for i > 0 {
+		pos--
+		b[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[pos:])
+}

--- a/internal/gateway/header_forwarding_e2e_test.go
+++ b/internal/gateway/header_forwarding_e2e_test.go
@@ -1,0 +1,364 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// ---------------------------------------------------------------------------
+// Slice-2 test fixtures. Independent of the Responses-API hydration
+// fallback (PR fix/passthrough-direct-provider-hydration) — every test
+// here sets X-DC-Target-URL on the inbound request and uses an httptest
+// upstream so the feature is exercised without depending on the
+// hydration code path.
+// ---------------------------------------------------------------------------
+
+func boolPtr(b bool) *bool { return &b }
+
+// newForwardingProxy constructs a GuardrailProxy used by the
+// passthrough-path tests. The proxy is wired to an httptest upstream
+// via providerDomains registration so the three-branch passthrough
+// policy classifies the request as "known" and forwards it.
+func newForwardingProxy(t *testing.T, upstreamURL string) *GuardrailProxy {
+	t.Helper()
+	cfg := &config.GuardrailConfig{
+		Enabled:   true,
+		Model:     "openai/gpt-4",
+		ModelName: "gpt-4",
+		Port:      0,
+		Mode:      "observe",
+		LLM:       config.LLMConfig{Model: "openai/gpt-4"},
+	}
+	store, logger := testStoreAndLogger(t)
+	p := &GuardrailProxy{
+		cfg:             cfg,
+		logger:          logger,
+		health:          NewSidecarHealth(),
+		store:           store,
+		dataDir:         t.TempDir(),
+		inspector:       newMockInspector(),
+		mode:            "observe",
+		skipAuthForTest: true,
+	}
+	p.resolveProviderFn = func(_ *ChatRequest) LLMProvider { return &mockProvider{} }
+	u, err := url.Parse(upstreamURL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+	registerForwardingProviderDomain(t, u.Hostname(), "openai")
+	return p
+}
+
+// registerForwardingProviderDomain appends a (domain, provider) entry
+// to providerDomains for the duration of the test.
+func registerForwardingProviderDomain(t *testing.T, domain, provider string) {
+	t.Helper()
+	orig := providerDomains
+	providerDomains = append(append([]providerDomainEntry{}, orig...),
+		providerDomainEntry{domain: domain, name: provider})
+	t.Cleanup(func() { providerDomains = orig })
+}
+
+// postPassthrough fires an X-DC-Target-URL-attached passthrough
+// request at the proxy.
+func postPassthrough(t *testing.T, proxy *GuardrailProxy, targetURL, path string, headers map[string]string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-DC-Target-URL", targetURL)
+	req.Header.Set("X-AI-Auth", "Bearer sk-upstream")
+	for k, v := range headers {
+		req.Header[k] = []string{v}
+	}
+	req.RemoteAddr = "127.0.0.1:12345"
+	rec := httptest.NewRecorder()
+	proxy.handlePassthrough(rec, req)
+	return rec
+}
+
+// ---------------------------------------------------------------------------
+// Passthrough tests
+// ---------------------------------------------------------------------------
+
+// TestPassthrough_ForwardsAllowedHeaders verifies that an inbound
+// custom header (not on the blocklist) reaches the upstream provider
+// and that the canonical Authorization is re-minted from X-AI-Auth.
+func TestPassthrough_ForwardsAllowedHeaders(t *testing.T) {
+	var (
+		gotTenant      string
+		gotAnthropic   string
+		gotAuth        string
+		gotXDC         string
+		gotXDefclaw    string
+		gotHits        int32
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&gotHits, 1)
+		gotTenant = r.Header.Get("Tenant-Id")
+		gotAnthropic = r.Header.Get("Anthropic-Version")
+		gotAuth = r.Header.Get("Authorization")
+		gotXDC = r.Header.Get("X-DC-Target-URL")
+		gotXDefclaw = r.Header.Get("X-DefenseClaw-Policy")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_y","object":"response"}`))
+	}))
+	defer upstream.Close()
+
+	proxy := newForwardingProxy(t, upstream.URL)
+	body := mustJSON(t, map[string]interface{}{"model": "gpt-4.1", "input": "hi"})
+	rec := postPassthrough(t, proxy, upstream.URL, "/v1/responses", map[string]string{
+		"Tenant-Id":            "tenant-42",
+		"Anthropic-Version":    "2023-06-01",
+		"X-DC-Session-Id":      "internal-should-not-leak",
+		"X-DefenseClaw-Policy": "should-not-leak",
+	}, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if atomic.LoadInt32(&gotHits) != 1 {
+		t.Fatalf("expected 1 upstream call, got %d", atomic.LoadInt32(&gotHits))
+	}
+	if gotTenant != "tenant-42" {
+		t.Errorf("Tenant-Id = %q; want tenant-42", gotTenant)
+	}
+	if gotAnthropic != "2023-06-01" {
+		t.Errorf("Anthropic-Version = %q; want 2023-06-01", gotAnthropic)
+	}
+	if !strings.Contains(gotAuth, "sk-upstream") {
+		t.Errorf("Authorization should carry upstream key sk-upstream; got %q", gotAuth)
+	}
+	if gotXDC != "" {
+		t.Errorf("X-DC-Target-URL leaked to upstream: %q", gotXDC)
+	}
+	if gotXDefclaw != "" {
+		t.Errorf("X-DefenseClaw-Policy leaked to upstream: %q", gotXDefclaw)
+	}
+}
+
+// TestPassthrough_ForwardCustomHeaders_Disabled verifies that
+// llm.forward_custom_headers: false suppresses all inbound header
+// copying.
+func TestPassthrough_ForwardCustomHeaders_Disabled(t *testing.T) {
+	var gotTenant, gotAnthropic, gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTenant = r.Header.Get("Tenant-Id")
+		gotAnthropic = r.Header.Get("Anthropic-Version")
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer upstream.Close()
+
+	proxy := newForwardingProxy(t, upstream.URL)
+	proxy.cfg.LLM.ForwardCustomHeaders = boolPtr(false)
+
+	body := mustJSON(t, map[string]interface{}{"model": "gpt-4.1", "input": "hi"})
+	rec := postPassthrough(t, proxy, upstream.URL, "/v1/responses", map[string]string{
+		"Tenant-Id":         "should-not-forward",
+		"Anthropic-Version": "2023-06-01",
+	}, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if gotTenant != "" {
+		t.Errorf("Tenant-Id forwarded with toggle off: %q", gotTenant)
+	}
+	if gotAnthropic != "" {
+		t.Errorf("Anthropic-Version forwarded with toggle off: %q", gotAnthropic)
+	}
+	if !strings.Contains(gotAuth, "sk-upstream") {
+		t.Errorf("Authorization should still be re-minted; got %q", gotAuth)
+	}
+}
+
+// TestPassthrough_HeaderInjection400 verifies CR/LF in a forwarded
+// header value triggers HTTP 400 and the request does not reach the
+// upstream.
+func TestPassthrough_HeaderInjection400(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("upstream should not be reached on header injection")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	proxy := newForwardingProxy(t, upstream.URL)
+	body := mustJSON(t, map[string]interface{}{"model": "gpt-4.1", "input": "hi"})
+	rec := postPassthrough(t, proxy, upstream.URL, "/v1/responses", map[string]string{
+		"X-Evil": "value\r\nInjected-Header: leaked",
+	}, body)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 on header injection; got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Chat-completions tests
+// ---------------------------------------------------------------------------
+
+// ctxRecordingProvider captures the ctx of each provider call so tests
+// can assert what the gateway put on it (specifically the Bifrost
+// extra-headers map).
+type ctxRecordingProvider struct {
+	mu      sync.Mutex
+	lastCtx context.Context
+}
+
+func (p *ctxRecordingProvider) ChatCompletion(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	p.mu.Lock()
+	p.lastCtx = ctx
+	p.mu.Unlock()
+	return &ChatResponse{
+		ID:     "chatcmpl-ctx",
+		Object: "chat.completion",
+		Model:  req.Model,
+		Choices: []ChatChoice{{
+			Index:        0,
+			Message:      &ChatMessage{Role: "assistant", Content: "ok"},
+			FinishReason: strPtr("stop"),
+		}},
+	}, nil
+}
+
+func (p *ctxRecordingProvider) ChatCompletionStream(ctx context.Context, _ *ChatRequest, _ func(StreamChunk)) (*ChatUsage, error) {
+	p.mu.Lock()
+	p.lastCtx = ctx
+	p.mu.Unlock()
+	return &ChatUsage{}, nil
+}
+
+// TestChatCompletions_ForwardsHeadersOnBifrostContext verifies that
+// inbound headers (minus the blocklist) end up on the request context
+// under schemas.BifrostContextKeyExtraHeaders so every Bifrost
+// provider injects them onto the upstream HTTP request via
+// providers/utils/utils.go:SetExtraHeaders.
+func TestChatCompletions_ForwardsHeadersOnBifrostContext(t *testing.T) {
+	prov := &ctxRecordingProvider{}
+	insp := newMockInspector()
+	proxy := newTestProxy(t, prov, insp, "action")
+
+	body := mustJSON(t, map[string]interface{}{
+		"model":    "gpt-4",
+		"messages": []map[string]interface{}{{"role": "user", "content": "hi"}},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Anthropic-Version", "2023-06-01")
+	req.Header.Set("Tenant-Id", "t-77")
+	req.Header.Set("Authorization", "Bearer should-not-leak")
+	req.Header.Set("X-DC-Session-Id", "should-not-leak")
+	req.RemoteAddr = "127.0.0.1:12345"
+	rec := httptest.NewRecorder()
+
+	proxy.handleChatCompletion(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	prov.mu.Lock()
+	ctx := prov.lastCtx
+	prov.mu.Unlock()
+	if ctx == nil {
+		t.Fatal("provider was not called")
+	}
+	raw := ctx.Value(schemas.BifrostContextKeyExtraHeaders)
+	got, ok := raw.(map[string][]string)
+	if !ok {
+		t.Fatalf("BifrostContextKeyExtraHeaders missing or wrong type: %T %v", raw, raw)
+	}
+	if v := got["Anthropic-Version"]; len(v) != 1 || v[0] != "2023-06-01" {
+		t.Errorf("Anthropic-Version on Bifrost ctx = %v; want [2023-06-01]", v)
+	}
+	if v := got["Tenant-Id"]; len(v) != 1 || v[0] != "t-77" {
+		t.Errorf("Tenant-Id on Bifrost ctx = %v; want [t-77]", v)
+	}
+	for _, banned := range []string{"Authorization", "X-Dc-Session-Id"} {
+		if v, present := got[banned]; present {
+			t.Errorf("blocklisted header %q leaked onto Bifrost ctx: %v", banned, v)
+		}
+	}
+}
+
+// TestChatCompletions_ForwardCustomHeaders_Disabled verifies that
+// llm.forward_custom_headers: false suppresses the Bifrost context
+// key entirely (so the SDK has no headers to inject).
+func TestChatCompletions_ForwardCustomHeaders_Disabled(t *testing.T) {
+	prov := &ctxRecordingProvider{}
+	insp := newMockInspector()
+	proxy := newTestProxy(t, prov, insp, "action")
+	proxy.cfg.LLM.ForwardCustomHeaders = boolPtr(false)
+
+	body := mustJSON(t, map[string]interface{}{
+		"model":    "gpt-4",
+		"messages": []map[string]interface{}{{"role": "user", "content": "hi"}},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Tenant-Id", "should-not-forward")
+	req.RemoteAddr = "127.0.0.1:12345"
+	rec := httptest.NewRecorder()
+
+	proxy.handleChatCompletion(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	prov.mu.Lock()
+	ctx := prov.lastCtx
+	prov.mu.Unlock()
+	if ctx == nil {
+		t.Fatal("provider was not called")
+	}
+	if raw := ctx.Value(schemas.BifrostContextKeyExtraHeaders); raw != nil {
+		t.Errorf("toggle disabled: BifrostContextKeyExtraHeaders should be nil; got %v", raw)
+	}
+}
+
+// TestForwardCustomHeadersEnabled_Defaults exercises the *bool helper
+// directly to guarantee "nil = true" semantics survive any refactor.
+func TestForwardCustomHeadersEnabled_Defaults(t *testing.T) {
+	cases := []struct {
+		name string
+		val  *bool
+		want bool
+	}{
+		{"nil_defaults_true", nil, true},
+		{"explicit_true", boolPtr(true), true},
+		{"explicit_false", boolPtr(false), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := config.LLMConfig{ForwardCustomHeaders: tc.val}
+			if got := c.ForwardCustomHeadersEnabled(); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/gateway/header_forwarding_e2e_test.go
+++ b/internal/gateway/header_forwarding_e2e_test.go
@@ -111,12 +111,12 @@ func postPassthrough(t *testing.T, proxy *GuardrailProxy, targetURL, path string
 // and that the canonical Authorization is re-minted from X-AI-Auth.
 func TestPassthrough_ForwardsAllowedHeaders(t *testing.T) {
 	var (
-		gotTenant      string
-		gotAnthropic   string
-		gotAuth        string
-		gotXDC         string
-		gotXDefclaw    string
-		gotHits        int32
+		gotTenant    string
+		gotAnthropic string
+		gotAuth      string
+		gotXDC       string
+		gotXDefclaw  string
+		gotHits      int32
 	)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&gotHits, 1)

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -34,6 +34,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/maximhq/bifrost/core/schemas"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/crypto/pbkdf2"
 	"golang.org/x/time/rate"
@@ -684,10 +685,16 @@ func (p *GuardrailProxy) handlePassthrough(w http.ResponseWriter, r *http.Reques
 	// X-DC-Target-URL. Ask the active connector to resolve the
 	// upstream from its provider snapshot before bailing.
 	connForwardKey := ""
+	connExtraHeaders := map[string]string{}
 	if targetOrigin == "" {
-		if connUpstream, connKey := hydrateConnectorSignals(p.connector, r, body); connUpstream != "" {
-			targetOrigin = connUpstream
-			connForwardKey = connKey
+		if cs := hydrateConnectorSignalsFull(p.connector, r, body); cs != nil {
+			if cs.RawUpstream != "" {
+				targetOrigin = cs.RawUpstream
+				connForwardKey = cs.RawAPIKey
+			}
+			if cs.ExtraHeaders != nil {
+				connExtraHeaders = cs.ExtraHeaders
+			}
 		}
 	}
 	if targetOrigin == "" {
@@ -1031,38 +1038,51 @@ func (p *GuardrailProxy) handlePassthrough(w http.ResponseWriter, r *http.Reques
 	// (notably Anthropic) reject the request with 400 "unexpected EOF".
 	upstreamReq.ContentLength = int64(len(body))
 
-	// Copy all original headers except proxy-hop, auth, and internal
-	// DefenseClaw correlation headers.
+	// Forward inbound headers to the upstream provider, minus a
+	// hardened blocklist (proxy-hop, auth, framework-internal,
+	// hop-by-hop, cookies, W3C trace context). See
+	// internal/gateway/forward_headers.go for the policy.
 	//
-	//   - Auth headers (Authorization, x-api-key, api-key) are stripped to
-	//     avoid duplicates — the resolved upstreamAuth is set as the single
-	//     canonical Authorization header below.
-	//   - Content-Length is stripped because notification injection can
-	//     change the body size; upstreamReq.ContentLength is the
-	//     authoritative value (set above) and the Go http client writes
-	//     the correct header automatically.
-	//   - Internal DefenseClaw correlation headers (x-dc-*, x-defenseclaw-*)
-	//     MUST NOT leak to third-party LLM providers — they carry session,
-	//     agent, policy, and destination identifiers that are internal
-	//     metadata, and echoing them in provider logs creates a privacy
-	//     and operational-security regression.
-	//   - W3C trace context (traceparent/tracestate) is also internal and
-	//     not meaningful to upstream providers; strip to avoid cross-tenant
-	//     trace correlation leakage.
-	for k, vs := range r.Header {
-		lk := strings.ToLower(k)
-		switch lk {
-		case "x-dc-target-url", "x-ai-auth", "x-dc-auth", "host",
-			"authorization", "x-api-key", "api-key", "content-length",
-			"traceparent", "tracestate":
-			continue
+	// Toggled by llm.forward_custom_headers (default on). When
+	// disabled, the upstream request gets only the canonical
+	// Authorization re-set below — useful for operators who want zero
+	// header leakage from the agent to the provider.
+	forwardedHeaderCount := 0
+	if p.cfg != nil && p.cfg.LLM.ForwardCustomHeadersEnabled() {
+		n, herr := CopyForwardableHeaders(upstreamReq.Header, r.Header)
+		if herr != nil {
+			fmt.Fprintf(os.Stderr, "[guardrail] passthrough: header forwarding rejected: %v\n", herr)
+			p.otel.RecordForwardedHeaders(r.Context(), "passthrough", resultForHeaderError(herr), 1)
+			writeOpenAIError(w, httpStatusForHeaderError(herr), "invalid forwarded headers: "+herr.Error())
+			return
 		}
-		if strings.HasPrefix(lk, "x-dc-") || strings.HasPrefix(lk, "x-defenseclaw-") {
-			continue
+		forwardedHeaderCount += n
+		// Merge connector-supplied headers (currently unused by built-in
+		// connectors, but ZeptoClaw/Codex/etc. may declare per-provider
+		// headers via ConnectorSignals.ExtraHeaders). Connector-supplied
+		// values overwrite same-named inbound values; same blocklist
+		// applies. Failure here is a misconfigured connector — return
+		// the same error so the operator notices.
+		if len(connExtraHeaders) > 0 {
+			m, merr := MergeConnectorExtraHeaders(upstreamReq.Header, connExtraHeaders)
+			if merr != nil {
+				fmt.Fprintf(os.Stderr, "[guardrail] passthrough: connector-extra header rejected: %v\n", merr)
+				p.otel.RecordForwardedHeaders(r.Context(), "passthrough", resultForHeaderError(merr), 1)
+				writeOpenAIError(w, httpStatusForHeaderError(merr), "invalid connector-extra headers: "+merr.Error())
+				return
+			}
+			forwardedHeaderCount += m
 		}
-		for _, v := range vs {
-			upstreamReq.Header.Add(k, v)
+	}
+	if forwardedHeaderCount > 0 {
+		// Per-request count is debug-only by default. The OTel counter
+		// (defenseclaw.gateway.forwarded_headers) carries the steady-state
+		// signal; this stderr line is opt-in for local triage via
+		// DEFENSECLAW_DEBUG=1. Header names and values are never logged.
+		if os.Getenv("DEFENSECLAW_DEBUG") == "1" {
+			fmt.Fprintf(os.Stderr, "[guardrail] passthrough: forwarded_header_count=%d\n", forwardedHeaderCount)
 		}
+		p.otel.RecordForwardedHeaders(r.Context(), "passthrough", "ok", int64(forwardedHeaderCount))
 	}
 	// Set the single resolved auth header for the upstream provider.
 	if upstreamAuth != "" {
@@ -1673,14 +1693,26 @@ func (p *GuardrailProxy) resolveConfiguredProvider(req *ChatRequest) LLMProvider
 // Returning ("", "") means "no opinion" — the caller must leave req.TargetURL
 // / req.TargetAPIKey alone so fetch-interceptor paths still work.
 func hydrateConnectorSignals(conn connector.Connector, r *http.Request, body []byte) (string, string) {
-	if conn == nil {
-		return "", ""
-	}
-	cs, err := conn.Route(r, body)
-	if err != nil || cs == nil {
+	cs := hydrateConnectorSignalsFull(conn, r, body)
+	if cs == nil {
 		return "", ""
 	}
 	return cs.RawUpstream, cs.RawAPIKey
+}
+
+// hydrateConnectorSignalsFull is the variant used by call sites that
+// also need ExtraHeaders (e.g. the header-forwarding path on both
+// chat/completions and passthrough). Returns nil when there is no
+// active connector or it returned an error.
+func hydrateConnectorSignalsFull(conn connector.Connector, r *http.Request, body []byte) *connector.ConnectorSignals {
+	if conn == nil {
+		return nil
+	}
+	cs, err := conn.Route(r, body)
+	if err != nil {
+		return nil
+	}
+	return cs
 }
 
 // resolveProviderFromHeaders selects the upstream LLMProvider for the given
@@ -1842,14 +1874,58 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 	// request arrives without X-DC-Target-URL / X-AI-Auth. Ask the active
 	// connector to resolve them from its captured config snapshot. Existing
 	// header values win — fetch-interceptor paths are unchanged.
+	chatConnExtraHeaders := map[string]string{}
 	if !localKeyResolutionDisabled {
-		if connUpstream, connKey := hydrateConnectorSignals(p.connector, r, body); connUpstream != "" {
-			if req.TargetURL == "" {
-				req.TargetURL = connUpstream
+		if cs := hydrateConnectorSignalsFull(p.connector, r, body); cs != nil {
+			if cs.RawUpstream != "" {
+				if req.TargetURL == "" {
+					req.TargetURL = cs.RawUpstream
+				}
+				if req.TargetAPIKey == "" {
+					req.TargetAPIKey = cs.RawAPIKey
+				}
 			}
-			if req.TargetAPIKey == "" {
-				req.TargetAPIKey = connKey
+			if cs.ExtraHeaders != nil {
+				chatConnExtraHeaders = cs.ExtraHeaders
 			}
+		}
+	}
+
+	// Forward inbound HTTP headers to the upstream provider via
+	// Bifrost's per-request schemas.BifrostContextKeyExtraHeaders
+	// context value (honored by every Bifrost provider through
+	// providers/utils/utils.go:SetExtraHeaders). Same blocklist /
+	// validation / caps as the passthrough path. Toggled by
+	// llm.forward_custom_headers (default on).
+	if p.cfg != nil && p.cfg.LLM.ForwardCustomHeadersEnabled() {
+		fwd := http.Header{}
+		n, herr := CopyForwardableHeaders(fwd, r.Header)
+		if herr != nil {
+			fmt.Fprintf(os.Stderr, "[guardrail] chat: header forwarding rejected: %v\n", herr)
+			p.otel.RecordForwardedHeaders(r.Context(), "chat-completions", resultForHeaderError(herr), 1)
+			writeOpenAIError(w, httpStatusForHeaderError(herr), "invalid forwarded headers: "+herr.Error())
+			return
+		}
+		if len(chatConnExtraHeaders) > 0 {
+			m, merr := MergeConnectorExtraHeaders(fwd, chatConnExtraHeaders)
+			if merr != nil {
+				fmt.Fprintf(os.Stderr, "[guardrail] chat: connector-extra header rejected: %v\n", merr)
+				p.otel.RecordForwardedHeaders(r.Context(), "chat-completions", resultForHeaderError(merr), 1)
+				writeOpenAIError(w, httpStatusForHeaderError(merr), "invalid connector-extra headers: "+merr.Error())
+				return
+			}
+			n += m
+		}
+		if len(fwd) > 0 {
+			r = r.WithContext(context.WithValue(r.Context(),
+				schemas.BifrostContextKeyExtraHeaders,
+				map[string][]string(fwd)))
+			// Debug-only per-request count; opt in with DEFENSECLAW_DEBUG=1.
+			// OTel counter carries the steady-state signal.
+			if os.Getenv("DEFENSECLAW_DEBUG") == "1" {
+				fmt.Fprintf(os.Stderr, "[guardrail] chat: forwarded_header_count=%d\n", n)
+			}
+			p.otel.RecordForwardedHeaders(r.Context(), "chat-completions", "ok", int64(n))
 		}
 	}
 

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -117,6 +117,14 @@ type metricsSet struct {
 	// source (go|ts). Kept low-cardinality so Prometheus recording
 	// rules can roll this up per-branch without blowing up TSDB.
 	egressEvents metric.Int64Counter
+
+	// Guardrail per-request agent-to-upstream header forwarding
+	// (llm.forward_custom_headers). Labels: path
+	// (chat-completions|passthrough), result (ok|rejected_invalid|
+	// rejected_overflow). The counter is incremented once per
+	// request: ok records the number of forwarded headers; rejected_*
+	// records 1 so operators can alert on validation-failure rates.
+	forwardedHeaders metric.Int64Counter
 	// Track 7 (external integrations — sink health)
 	sinkBatchesDelivered metric.Int64Counter
 	sinkBatchesDropped   metric.Int64Counter
@@ -539,6 +547,17 @@ func newMetricsSet(m metric.Meter) (*metricsSet, error) {
 	ms.egressEvents, err = m.Int64Counter("defenseclaw.egress.events",
 		metric.WithUnit("{event}"),
 		metric.WithDescription("Egress requests classified by Layer 1 shape detection (branch=known|shape|passthrough)"))
+	if err != nil {
+		return nil, err
+	}
+
+	// Per-request header forwarding from agent to upstream LLM
+	// provider. Counts forwarded headers on the ok path; counts 1 per
+	// failed request on rejected_* so operators can alert on
+	// validation-failure rates without inflating ok totals.
+	ms.forwardedHeaders, err = m.Int64Counter("defenseclaw.gateway.forwarded_headers",
+		metric.WithUnit("{header}"),
+		metric.WithDescription("Inbound HTTP headers forwarded from the agent to the upstream LLM provider (path=chat-completions|passthrough, result=ok|rejected_invalid|rejected_overflow)"))
 	if err != nil {
 		return nil, err
 	}
@@ -1572,6 +1591,28 @@ func (p *Provider) RecordEgress(ctx context.Context, branch, decision, source st
 		attribute.String("branch", branch),
 		attribute.String("decision", decision),
 		attribute.String("source", source),
+	))
+}
+
+// RecordForwardedHeaders records agent-to-upstream header forwarding.
+// Call once per request:
+//   - On success: result="ok", count=number of headers forwarded.
+//   - On validation failure: result="rejected_invalid" or
+//     "rejected_overflow", count=1 (request count, not header count).
+//
+// path is "chat-completions" or "passthrough"; values outside that set
+// are still accepted so the schema validator catches the regression
+// in test rather than the gateway silently dropping the sample.
+func (p *Provider) RecordForwardedHeaders(ctx context.Context, path, result string, count int64) {
+	if !p.Enabled() || p.metrics == nil {
+		return
+	}
+	if count <= 0 {
+		return
+	}
+	p.metrics.forwardedHeaders.Add(ctx, count, metric.WithAttributes(
+		attribute.String("path", path),
+		attribute.String("result", result),
 	))
 }
 


### PR DESCRIPTION
## Summary

Forward inbound HTTP headers from the agent through to the upstream LLM provider on both the chat/completions path (via Bifrost's per-request `schemas.BifrostContextKeyExtraHeaders` context value) and the passthrough path (`/v1/responses`, `/v1/messages`, Bedrock/Gemini native, etc.). Replaces the inline header-copy loop in `handlePassthrough` with a shared `CopyForwardableHeaders` helper so both code paths apply the same policy.

Configurable via new `llm.forward_custom_headers *bool` (default on; `nil` treated as `true` so existing configs keep working; operators opt out with `llm.forward_custom_headers: false`).

**Pre-existing passthrough blocklist preserved exactly** (no silent behavior change): `X-DC-Target-URL`, `X-AI-Auth`, `X-DC-Auth`, `Host`, `Content-Length`, `Authorization`, `X-API-Key`, `Api-Key`, `Traceparent`, `Tracestate`, plus `X-DC-*` / `X-DefenseClaw-*` prefixes. The "blocklist expansion" set (`Cookie`, `Set-Cookie`, `Proxy-Authorization`, `Transfer-Encoding`, `TE`, `Trailers`, `Connection`, `Keep-Alive`, `Upgrade`, `Proxy-Authenticate`, `Baggage`, `Content-Type`) is documented in `forward_headers.go` as commented-out entries with per-name danger ratings:

| Header | Danger | Recommendation |
|---|---|---|
| `Cookie` / `Set-Cookie` | HIGH | Recommend re-enabling; cookie-stealing via upstream-log search |
| `Proxy-Authorization` | HIGH | Recommend re-enabling; next-hop proxy credentials |
| `Transfer-Encoding` / `TE` | HIGH | Recommend re-enabling; HTTP request-smuggling vector |
| `Trailers` / `Connection` / `Keep-Alive` / `Upgrade` | MEDIUM | Hop-by-hop per RFC 7230 §6.1; rarely exploitable |
| `Proxy-Authenticate` / `Baggage` | LOW | Privacy/telemetry only |
| `Content-Type` | **ZERO** | Actively wrong to block — Go's `http.NewRequestWithContext` does NOT auto-set for raw `io.Reader` body |

Operators with a stricter posture should uncomment the HIGH entries and bump the matching test in `forward_headers_test.go`. A pinning test (`TestCopyForwardableHeaders_CommentedOutBlocklistEntriesForward`) asserts the current behavior so a future refactor cannot silently re-block them.

## Security defenses

Per codeguard rules (`codeguard-0-input-validation-injection`, `codeguard-0-logging`, `codeguard-0-privacy-data-protection`):

- **RFC 7230 tchar** validation on header names (rejects malformed names and header smuggling).
- **Printable-ASCII + HTAB** validation on values (rejects CR, LF, NUL → HTTP 400; header- and log-injection defense).
- **Soft caps**: 64 headers, 32 KiB combined name+value bytes per request → HTTP 413. Limits comfortably cover real provider headers (`anthropic-version`, `anthropic-beta`, `openai-organization`, tenant tags, tracing IDs).
- **Authorization re-minted** canonically by the gateway from the secrets sidecar / token resolver — upstream never sees a stale agent header.
- **Header names and values are never logged.**

## Telemetry

New OTel counter `defenseclaw.gateway.forwarded_headers{path, result}`:
- `path` = `chat-completions` | `passthrough`
- `result` = `ok` | `rejected_invalid` | `rejected_overflow`

Per-request `forwarded_header_count=N` stderr line is **gated behind `DEFENSECLAW_DEBUG=1`** so steady-state log volume is unaffected. Rejection-path stderr lines remain unconditional (operator-actionable).

## Connector hook

`ConnectorSignals.ExtraHeaders` (previously declared but never consumed) is now read on both paths via a new `hydrateConnectorSignalsFull` helper, with connector-wins merge semantics. Same blocklist + validation apply. Legacy `hydrateConnectorSignals` returning `(RawUpstream, RawAPIKey)` is preserved as a thin back-compat wrapper so existing callers don't churn.

## Files changed

- New: `internal/gateway/forward_headers.go` — `CopyForwardableHeaders`, `MergeConnectorExtraHeaders`, blocklist, validation, caps.
- New: `internal/gateway/forward_headers_test.go` — extractor unit tests.
- New: `internal/gateway/header_forwarding_e2e_test.go` — end-to-end tests for both paths using `newTestProxy` + httptest upstream + explicit `X-DC-Target-URL` (independent of any hydration fallback).
- `internal/config/config.go` — `LLMConfig.ForwardCustomHeaders *bool` + `ForwardCustomHeadersEnabled()` helper.
- `internal/gateway/proxy.go` — `hydrateConnectorSignalsFull` introduction, replace inline header-copy loop, chat-completions Bifrost-context plumbing, `DEFENSECLAW_DEBUG=1` gates.
- `internal/telemetry/metrics.go` — `forwardedHeaders` counter + `RecordForwardedHeaders` method.
- `docs/GUARDRAIL.md` — new "Custom Header Forwarding" section.
- `docs/OBSERVABILITY.md` — metric table row.
- `docs-site/content/docs/reference/configuration.mdx` — config field documentation.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/gateway/` full suite passes (17.6s) including all new forwarding + extractor tests
- [x] `go test ./internal/telemetry/` passes
- [ ] Verify the OTel counter shows up in operator dashboards
- [ ] Decide whether to uncomment the HIGH-rated blocklist entries in a follow-up PR

## Companion PR

The Responses-API hydration bug fix (uncovered while testing this feature against the ZeptoClaw + custom-provider topology) is in a separate PR: `fix/passthrough-direct-provider-hydration`. The two PRs are independent (both off `main`); landing either alone is safe.

Made with [Cursor](https://cursor.com)