### PR TITLE
[REM-95] add reveal toggle to masked secret fields

### DIFF
--- a/apps/appkit-app/DefenseClawAppKit/Views/Setup/SetupView.swift
+++ b/apps/appkit-app/DefenseClawAppKit/Views/Setup/SetupView.swift
@@ -523,11 +523,10 @@ private struct SetupFieldCard: View {
             .labelsHidden()
             .pickerStyle(.menu)
         case .password:
-            SecureField(field.placeholder, text: Binding(
+            RevealableSecureField(placeholder: field.placeholder, text: Binding(
                 get: { model.textBindingValue(for: field) },
                 set: { model.setText($0, for: field) }
             ))
-            .textFieldStyle(.roundedBorder)
         default:
             TextField(field.placeholder, text: Binding(
                 get: { model.textBindingValue(for: field) },
@@ -664,11 +663,10 @@ private struct SetupWorkflowCard: View {
                 .labelsHidden()
                 .pickerStyle(.menu)
             case .password:
-                SecureField("", text: Binding(
+                RevealableSecureField(placeholder: "", text: Binding(
                     get: { model.workflowTextValue(workflow, field: field) },
                     set: { model.setWorkflowText($0, workflow: workflow, field: field) }
                 ))
-                .textFieldStyle(.roundedBorder)
             default:
                 TextField("", text: Binding(
                     get: { model.workflowTextValue(workflow, field: field) },

--- a/apps/appkit-app/DefenseClawAppKit/Views/Shared/RevealableSecureField.swift
+++ b/apps/appkit-app/DefenseClawAppKit/Views/Shared/RevealableSecureField.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// A masked secret input with an explicit show/hide toggle.
+///
+/// Use for API keys, tokens, and other secret-like values so the user can
+/// verify what they typed without leaving the secret on screen by default.
+/// Mirrors the styling of the plain `SecureField` sites it replaces
+/// (`.roundedBorder`, privacy-sensitive redaction while masked).
+struct RevealableSecureField: View {
+    let placeholder: String
+    @Binding var text: String
+    var isEditable: Bool = true
+
+    @State private var isRevealed = false
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Group {
+                if isRevealed {
+                    TextField(placeholder, text: $text)
+                } else {
+                    SecureField(placeholder, text: $text)
+                }
+            }
+            .textFieldStyle(.roundedBorder)
+            .privacySensitive(!isRevealed)
+            .disabled(!isEditable)
+
+            Button {
+                isRevealed.toggle()
+            } label: {
+                Image(systemName: isRevealed ? "eye.slash" : "eye")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.borderless)
+            .help(isRevealed ? "Hide secret" : "Reveal secret")
+            .accessibilityLabel(isRevealed ? "Hide secret" : "Reveal secret")
+        }
+    }
+}

--- a/apps/appkit-app/DefenseClawAppKit/Views/Shared/StructuredDocumentEditorView.swift
+++ b/apps/appkit-app/DefenseClawAppKit/Views/Shared/StructuredDocumentEditorView.swift
@@ -254,10 +254,7 @@ private struct StructuredValueEditor: View {
         VStack(alignment: .leading, spacing: 6) {
             scalarHeader
             if isSecretLikeString {
-                SecureField("Secret value", text: textBinding)
-                    .textFieldStyle(.roundedBorder)
-                    .privacySensitive()
-                    .disabled(!isEditable)
+                RevealableSecureField(placeholder: "Secret value", text: textBinding, isEditable: isEditable)
                 Text("Masked because this field name looks secret-like. Prefer *_env fields or the Secrets setup flow for normal use.")
                     .font(.caption2)
                     .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary

Secret-like fields (API keys, tokens) are already masked on this branch — `SecureField` + secret-name detection in the Config editor, and `.password` kind in Setup — but there was no way to verify what was typed.

This adds a small reusable **`RevealableSecureField`** (show/hide eye toggle that stays `.privacySensitive()` while masked) and wires it into the three existing masked render sites:

- Setup `.password` control (`SetupView`)
- Setup workflow `.password` field (`SetupView`)
- Config editor secret-like scalar (`StructuredDocumentEditorView`)

The component encapsulates the styling the call sites previously applied inline, so the diff is net-negative in the edited files.

## Scope

Reveal affordance only. Secret **storage** routing (Keychain / managed `.env` instead of writing the raw value into `config.yaml`) is the bigger P0 and is tracked separately — it touches the secret model shared with the gateway, so worth aligning on approach first.

## Validation

- `swift build --package-path apps/shared`
- `swift build --package-path apps/appkit-app`
- `./script/build_and_run.sh --qa setup llm` — toggle works on the DefenseClaw LLM API Key field

Closes REM-95.

> Note: opened as a draft against `codex/reuse-pr62-macos-app` — happy to fold into PR #161 however you prefer, @vineethsai7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)