### PR TITLE
ci: connector hook E2E (contract matrix + live agent drivers) with upstream regression radar

### DIFF
--- a/.github/workflows/connector-live-e2e.yml
+++ b/.github/workflows/connector-live-e2e.yml
@@ -1,0 +1,449 @@
+# Live connector hook E2E + upstream regression radar.
+#
+# This workflow is intentionally SEPARATE from e2e.yml so it can go red
+# (an upstream agent shipped a breaking hook change) without blocking the
+# OpenClaw stack gate. It has two layers:
+#
+#   contract-matrix (Layer A) — deterministic, no LLM, no secrets, all OSes.
+#     Builds DefenseClaw, then feeds golden stdin payloads into the *installed*
+#     hook entrypoint for every registry connector and asserts the gateway
+#     received the event, the verdict was shaped correctly, and teardown is
+#     clean. Fork-safe; a candidate to promote to a required PR check later.
+#
+#   live-matrix (Layer B) — installs the real upstream agent at its latest
+#     version, wires it with `defenseclaw setup`, and drives lifecycle + forced
+#     tool events through the real harness. Asserts observe/block/OTLP/teardown
+#     using gateway.jsonl, audit.db, and filesystem sentinel side-effects.
+#     Needs provider secrets, so it never runs for fork pull requests.
+#
+#     ROLLOUT STATUS: Layer B is currently manual-only (workflow_dispatch). The
+#     nightly schedule runs Layer A alone until the live secrets are in place.
+#     Gemini CLI, Cursor, and Copilot are deferred entirely (their native keys
+#     — GOOGLE_API_KEY / CURSOR_API_KEY / COPILOT_CLI_TOKEN — are not yet set
+#     and have no Azure/Bedrock substitute). Re-add their matrix cells and
+#     restore the schedule trigger here once those keys exist.
+#
+#   report — rolls every per-cell result up into the job summary, records the
+#     resolved upstream version, and opens/updates a `connector-regression`
+#     issue on any live-cell failure. Alert-only: it never auto-bumps an
+#     approved version (that stays a deliberate human edit of
+#     cli/defenseclaw/inventory/validated_versions.json).
+#
+# Native Windows hook execution (the agent invoking
+# `defenseclaw-gateway hook --connector <c> --event <e>`) depends on the
+# native Windows hook entrypoint. Until that is proven on hosted Windows
+# runners, all Windows cells (and Copilot everywhere) run with
+# continue-on-error so a flake does not turn the whole matrix red.
+
+name: Connector Live E2E
+
+on:
+  # Staggered two hours after the e2e.yml 07:00 cron so the two heavy
+  # nightly suites do not contend for the same hosted-runner pool.
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+    inputs:
+      connector:
+        description: "Connector to run (or 'all')"
+        type: choice
+        default: all
+        options:
+          - all
+          - codex
+          - claudecode
+          - geminicli
+          - cursor
+          - copilot
+          - openhands
+          - hermes
+          - windsurf
+          - antigravity
+      os:
+        description: "OS to run (or 'all')"
+        type: choice
+        default: all
+        options:
+          - all
+          - linux
+          - macos
+          - windows
+      version:
+        description: "Upstream agent version to install (live layer)"
+        type: string
+        default: latest
+      mode:
+        description: "DefenseClaw enforcement mode for live drivers"
+        type: choice
+        default: action
+        options:
+          - action
+          - observe
+      use_azure:
+        description: "Route Codex + OpenHands through Azure OpenAI"
+        type: boolean
+        default: false
+      use_bedrock:
+        description: "Route Claude Code + OpenHands through Amazon Bedrock"
+        type: boolean
+        default: false
+
+concurrency:
+  group: connector-live-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege at the workflow level; the report job widens to
+# issues: write only where it is actually needed.
+permissions:
+  contents: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Layer A — deterministic contract matrix (no secrets, every OS).
+  # ---------------------------------------------------------------------------
+  contract-matrix:
+    name: Contract ${{ matrix.connector }} / ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        connector:
+          - codex
+          - claudecode
+          - geminicli
+          - cursor
+          - copilot
+          - openhands
+          - hermes
+          - windsurf
+          - antigravity
+    runs-on: ${{ matrix.os }}
+    # Native Windows hook execution is not yet proven on hosted runners;
+    # keep Windows cells advisory until they go consistently green.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    timeout-minutes: 25
+    defaults:
+      run:
+        shell: bash
+    env:
+      DC_E2E_RESULTS: ${{ github.workspace }}/connector-live-e2e-results.jsonl
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Select cell + resolve OS label
+        id: select
+        run: |
+          case "${RUNNER_OS}" in
+            Linux)   dcos=linux ;;
+            macOS)   dcos=macos ;;
+            Windows) dcos=windows ;;
+            *)       dcos=unknown ;;
+          esac
+          echo "DC_E2E_OS=${dcos}" >> "$GITHUB_ENV"
+
+          run=true
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            in_conn="${{ inputs.connector }}"
+            in_os="${{ inputs.os }}"
+            [ "${in_conn}" = "all" ] || [ "${in_conn}" = "${{ matrix.connector }}" ] || run=false
+            [ "${in_os}" = "all" ] || [ "${in_os}" = "${dcos}" ] || run=false
+          fi
+          echo "run=${run}" >> "$GITHUB_OUTPUT"
+          echo "cell ${{ matrix.connector }}/${dcos} selected=${run}"
+
+      - uses: actions/setup-go@v5
+        if: steps.select.outputs.run == 'true'
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: astral-sh/setup-uv@v8.1.0
+        if: steps.select.outputs.run == 'true'
+
+      # Build + install the Python CLI and Go gateway. `make install` runs
+      # sync-openclaw-extension (drops the //go:embed placeholder so the
+      # gateway compiles without the TS plugin) and skips the OpenClaw plugin
+      # entirely because CONNECTOR is not openclaw — hook connectors do not
+      # need it. We do NOT run `make plugin` here for the same reason.
+      - name: Install DefenseClaw
+        if: steps.select.outputs.run == 'true'
+        run: make install
+
+      - name: Put DefenseClaw on PATH
+        if: steps.select.outputs.run == 'true'
+        run: |
+          echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
+          if [ -d "${{ github.workspace }}/.venv/bin" ]; then
+            echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
+          fi
+          # Windows uv venvs expose entry points under Scripts/, not bin/.
+          if [ -d "${{ github.workspace }}/.venv/Scripts" ]; then
+            echo "${{ github.workspace }}/.venv/Scripts" >> "$GITHUB_PATH"
+          fi
+
+      # Deterministic Go contract tests for this connector. The shared
+      # connector lifecycle / observability / verify matrices are
+      # connector-parameterized; filtering with -run to the active cell makes
+      # a failure point at exactly which connector regressed. A connector with
+      # no dedicated subtest matches nothing and `go test` exits 0, so the
+      # golden-payload smoke below is its real Layer-A coverage.
+      - name: Go contract tests
+        if: steps.select.outputs.run == 'true'
+        run: |
+          go test -count=1 ./test/e2e/ \
+            -run "TestConnectorLifecycle_Matrix/${{ matrix.connector }}|TestV7Observability_DestinationAppPerConnector/${{ matrix.connector }}|TestConnectorVerifyCleanOnFreshDataDir/${{ matrix.connector }}|TestGoldenPerConnectorLayout"
+
+      # Golden-payload entrypoint smoke: feed each registry event into the
+      # installed hook entrypoint (Bash script on unix, `defenseclaw-gateway
+      # hook` on Windows) and assert fire + verdict shaping + clean teardown.
+      - name: Contract entrypoint smoke
+        if: steps.select.outputs.run == 'true'
+        run: bash scripts/live-connector-e2e/run.sh --layer contract --connector "${{ matrix.connector }}"
+
+      - name: Upload contract results
+        if: ${{ always() && steps.select.outputs.run == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: connector-live-e2e-results-contract-${{ matrix.connector }}-${{ env.DC_E2E_OS }}
+          path: ${{ env.DC_E2E_RESULTS }}
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload contract logs on failure
+        if: ${{ failure() && steps.select.outputs.run == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: connector-live-e2e-logs-contract-${{ matrix.connector }}-${{ env.DC_E2E_OS }}
+          path: ${{ runner.temp }}/defenseclaw-live-e2e-logs/**
+          if-no-files-found: ignore
+          retention-days: 7
+          include-hidden-files: true
+
+  # ---------------------------------------------------------------------------
+  # Layer B — live agent matrix (real agents, secrets, nightly/dispatch).
+  # Never runs for fork pull requests: provider secrets must not be exposed to
+  # untrusted code, mirroring the full-live gate in e2e.yml.
+  # ---------------------------------------------------------------------------
+  live-matrix:
+    name: Live ${{ matrix.connector }} / ${{ matrix.os }}
+    # Manual-only for now: the nightly schedule runs Layer A (contract) alone
+    # until live provider secrets are in place. Trigger this layer explicitly
+    # via "Run workflow" once keys exist.
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # The reality matrix: which agents have a headless CLI that fires hooks
+        # on which OS. Contract-only connectors (hermes, windsurf, antigravity)
+        # are absent here — they are covered by Layer A only. `experimental`
+        # cells run advisory (continue-on-error) until proven stable.
+        #
+        # Currently scoped to the connectors we can authenticate with Azure
+        # OpenAI / Amazon Bedrock (Codex, Claude Code, OpenHands). Gemini CLI,
+        # Cursor, and Copilot are deferred until their native keys exist — add
+        # their cells back here when GOOGLE_API_KEY / CURSOR_API_KEY /
+        # COPILOT_CLI_TOKEN are configured.
+        include:
+          - { connector: codex,      os: ubuntu-latest,  dcos: linux }
+          - { connector: codex,      os: macos-latest,   dcos: macos }
+          - { connector: codex,      os: windows-latest, dcos: windows, experimental: true }
+          - { connector: claudecode, os: ubuntu-latest,  dcos: linux }
+          - { connector: claudecode, os: macos-latest,   dcos: macos }
+          - { connector: claudecode, os: windows-latest, dcos: windows, experimental: true }
+          # OpenHands needs the Docker runtime, so it is Linux-only.
+          - { connector: openhands,  os: ubuntu-latest,  dcos: linux }
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental || false }}
+    timeout-minutes: 40
+    defaults:
+      run:
+        shell: bash
+    env:
+      DC_E2E_OS: ${{ matrix.dcos }}
+      DC_E2E_RESULTS: ${{ github.workspace }}/connector-live-e2e-results.jsonl
+      DC_DRIVER_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'action' }}
+      DC_E2E_AGENT_VERSION_REQUEST: ${{ github.event_name == 'workflow_dispatch' && inputs.version || 'latest' }}
+      # Provider keys are read directly by the agent CLIs (e.g. codex, claude)
+      # from the process environment. They are also written into
+      # ~/.defenseclaw/.env below so the gateway can reach them when needed.
+      # Empty secrets simply skip writing that key (see the seed step).
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+      # GitHub Copilot CLI authenticates with an entitled token.
+      COPILOT_CLI_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
+      GH_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
+      # Generic fallback key for the guardrail/judge if a connector needs it.
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      # --- Alternative auth backends -----------------------------------------
+      # Azure OpenAI (Codex + OpenHands when DC_USE_AZURE=1). The key is a
+      # secret; the endpoint/deployment/version are non-secret config Variables.
+      AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+      AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
+      AZURE_OPENAI_DEPLOYMENT: ${{ vars.AZURE_OPENAI_DEPLOYMENT }}
+      AZURE_OPENAI_API_VERSION: ${{ vars.AZURE_OPENAI_API_VERSION }}
+      # Amazon Bedrock (Claude Code + OpenHands when DC_USE_BEDROCK=1). Either a
+      # Bedrock bearer token OR a standard AWS key pair satisfies the chain.
+      AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      # Optional Bedrock model-id overrides (non-secret config Variables).
+      CLAUDE_BEDROCK_MODEL: ${{ vars.CLAUDE_BEDROCK_MODEL }}
+      OPENHANDS_BEDROCK_MODEL: ${{ vars.OPENHANDS_BEDROCK_MODEL }}
+      # Provider-selection flags. A dispatch toggle wins; otherwise the repo
+      # Variable (DC_USE_AZURE / DC_USE_BEDROCK = "1") makes it the default for
+      # nightly runs; otherwise off (use the direct provider keys).
+      DC_USE_AZURE: ${{ inputs.use_azure && '1' || vars.DC_USE_AZURE || '0' }}
+      DC_USE_BEDROCK: ${{ inputs.use_bedrock && '1' || vars.DC_USE_BEDROCK || '0' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Select cell
+        id: select
+        run: |
+          run=true
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            in_conn="${{ inputs.connector }}"
+            in_os="${{ inputs.os }}"
+            [ "${in_conn}" = "all" ] || [ "${in_conn}" = "${{ matrix.connector }}" ] || run=false
+            [ "${in_os}" = "all" ] || [ "${in_os}" = "${{ matrix.dcos }}" ] || run=false
+          fi
+          echo "run=${run}" >> "$GITHUB_OUTPUT"
+          echo "cell ${{ matrix.connector }}/${{ matrix.dcos }} selected=${run}"
+
+      - uses: actions/setup-go@v5
+        if: steps.select.outputs.run == 'true'
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: astral-sh/setup-uv@v8.1.0
+        if: steps.select.outputs.run == 'true'
+
+      # Most live agents (codex, claude, gemini, copilot, cursor) ship as npm
+      # packages; OpenHands installs via pipx. Node + uv cover both.
+      - uses: actions/setup-node@v5
+        if: steps.select.outputs.run == 'true'
+        with:
+          node-version: "24"
+
+      - name: Install DefenseClaw
+        if: steps.select.outputs.run == 'true'
+        run: make install
+
+      - name: Put DefenseClaw on PATH
+        if: steps.select.outputs.run == 'true'
+        run: |
+          echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
+          if [ -d "${{ github.workspace }}/.venv/bin" ]; then
+            echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
+          fi
+          if [ -d "${{ github.workspace }}/.venv/Scripts" ]; then
+            echo "${{ github.workspace }}/.venv/Scripts" >> "$GITHUB_PATH"
+          fi
+
+      # Initialize DefenseClaw and stage provider keys into ~/.defenseclaw/.env.
+      # The driver re-runs `defenseclaw init` idempotently; doing it here lets
+      # us append keys before the gateway first starts. Only non-empty secrets
+      # are written, so a missing optional key never leaves a blank line.
+      - name: Seed DefenseClaw env
+        if: steps.select.outputs.run == 'true'
+        run: |
+          defenseclaw init
+          env_file="${HOME}/.defenseclaw/.env"
+          mkdir -p "${HOME}/.defenseclaw"
+          touch "${env_file}"
+          write_key() {
+            local k="$1" v="$2"
+            [ -n "${v}" ] || return 0
+            grep -q "^${k}=" "${env_file}" 2>/dev/null && return 0
+            printf '%s=%s\n' "${k}" "${v}" >> "${env_file}"
+          }
+          write_key OPENAI_API_KEY    "${OPENAI_API_KEY:-}"
+          write_key ANTHROPIC_API_KEY "${ANTHROPIC_API_KEY:-}"
+          write_key GOOGLE_API_KEY    "${GOOGLE_API_KEY:-}"
+          write_key GEMINI_API_KEY    "${GEMINI_API_KEY:-}"
+          write_key CURSOR_API_KEY    "${CURSOR_API_KEY:-}"
+          write_key LLM_API_KEY       "${LLM_API_KEY:-}"
+
+      # For Cursor, confirm headless `cursor-agent -p` actually fires
+      # ~/.cursor/hooks.json before spending a full live run on it. If hooks
+      # never reach the gateway, the live driver is skipped (recorded as a
+      # skip) and Cursor stays Layer-A only for this cell.
+      - name: Validate Cursor headless hooks
+        id: cursor_validate
+        if: ${{ steps.select.outputs.run == 'true' && matrix.connector == 'cursor' }}
+        run: bash scripts/live-connector-e2e/cursor-validation.sh
+        continue-on-error: true
+
+      - name: Live driver
+        if: ${{ steps.select.outputs.run == 'true' && !(matrix.connector == 'cursor' && steps.cursor_validate.outputs.cursor_hooks_fire == '0') }}
+        run: bash scripts/live-connector-e2e/run.sh --layer live --connector "${{ matrix.connector }}"
+
+      - name: Upload live results
+        if: ${{ always() && steps.select.outputs.run == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: connector-live-e2e-results-live-${{ matrix.connector }}-${{ matrix.dcos }}
+          path: ${{ env.DC_E2E_RESULTS }}
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload live logs on failure
+        if: ${{ failure() && steps.select.outputs.run == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: connector-live-e2e-logs-live-${{ matrix.connector }}-${{ matrix.dcos }}
+          path: ${{ runner.temp }}/defenseclaw-live-e2e-logs/**
+          if-no-files-found: ignore
+          retention-days: 7
+          include-hidden-files: true
+
+      - name: Teardown safety net
+        if: ${{ always() && steps.select.outputs.run == 'true' }}
+        run: |
+          defenseclaw-gateway connector teardown --connector "${{ matrix.connector }}" 2>/dev/null || true
+          defenseclaw-gateway stop 2>/dev/null || true
+          rm -rf "${HOME}/.defenseclaw" 2>/dev/null || true
+
+  # ---------------------------------------------------------------------------
+  # Report — aggregate every cell, render the matrix, and alert on regressions.
+  # ---------------------------------------------------------------------------
+  report:
+    name: Report + regression radar
+    needs: [contract-matrix, live-matrix]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required so the regression radar can open/update the
+      # connector-regression issue. No write access to code.
+      issues: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download all cell results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: connector-live-e2e-results-*
+          path: results
+          merge-multiple: true
+
+      - name: Render summary + open regression issue on failure
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          open_flag=""
+          # Only the trusted, scheduled / manual contexts may file issues.
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            open_flag="--open-issue"
+          fi
+          python3 scripts/live-connector-e2e/report.py \
+            --results-dir results \
+            ${open_flag} \
+            --run-url "${RUN_URL}"

--- a/cli/defenseclaw/inventory/validated_versions.json
+++ b/cli/defenseclaw/inventory/validated_versions.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": 1,
+  "description": "Human-reviewed highest validated upstream agent version per hook connector x OS. The live connector E2E workflow (.github/workflows/connector-live-e2e.yml) only REPORTS the version it ran against and opens a connector-regression issue on a live-cell failure — it never edits this file. A maintainer updates last_validated_version here (and, when raising/lowering a support floor/ceiling, hook_contracts.json + internal/gateway/connector/hook_contract.go) after reviewing a green run. 'os' keys are linux, macos, windows; an empty last_validated_version means 'not yet certified'.",
+  "policy": "alert-only",
+  "connectors": {
+    "codex": {
+      "version_probe": "codex --version",
+      "live": true,
+      "os": {
+        "linux": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "macos": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "windows": { "last_validated_version": "", "last_validated_at": "", "run_url": "" }
+      }
+    },
+    "claudecode": {
+      "version_probe": "claude --version",
+      "live": true,
+      "os": {
+        "linux": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "macos": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "windows": { "last_validated_version": "", "last_validated_at": "", "run_url": "" }
+      }
+    },
+    "geminicli": {
+      "version_probe": "gemini --version",
+      "live": true,
+      "os": {
+        "linux": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "macos": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "windows": { "last_validated_version": "", "last_validated_at": "", "run_url": "" }
+      }
+    },
+    "cursor": {
+      "version_probe": "cursor-agent --version",
+      "live": "pending-validation",
+      "os": {
+        "linux": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "macos": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "windows": { "last_validated_version": "", "last_validated_at": "", "run_url": "" }
+      }
+    },
+    "copilot": {
+      "version_probe": "copilot --version",
+      "live": true,
+      "os": {
+        "linux": { "last_validated_version": "", "last_validated_at": "", "run_url": "" },
+        "macos": { "last_validated_version": "", "last_validated_at": "", "run_url": "" }
+      }
+    },
+    "openhands": {
+      "version_probe": "openhands --version",
+      "live": true,
+      "os": {
+        "linux": { "last_validated_version": "", "last_validated_at": "", "run_url": "" }
+      }
+    },
+    "hermes": {
+      "version_probe": "hermes --version",
+      "live": false,
+      "notes": "contract-only (Layer A); only pre_tool_call is mapped"
+    },
+    "windsurf": {
+      "version_probe": "",
+      "live": false,
+      "notes": "contract-only (Layer A); no headless CLI/SDK"
+    },
+    "antigravity": {
+      "version_probe": "agy --version",
+      "live": false,
+      "notes": "contract-only (Layer A); headless auth is Google Sign-In/keyring OAuth, no API key"
+    }
+  }
+}

--- a/docs/CONNECTOR-MATRIX.md
+++ b/docs/CONNECTOR-MATRIX.md
@@ -144,6 +144,121 @@ non-CodeGuard paths require `--replace`.
 
 ---
 
+## Live E2E coverage
+
+The [`.github/workflows/connector-live-e2e.yml`](../.github/workflows/connector-live-e2e.yml)
+workflow proves each hook connector end-to-end against real upstream agents
+and flags when an upstream release breaks a hook. It is intentionally
+separate from `e2e.yml` so it can go red on an upstream regression without
+blocking the OpenClaw stack gate. The harness lives under
+[`scripts/live-connector-e2e/`](../scripts/live-connector-e2e).
+
+### Two layers
+
+| Layer | What it proves | LLM? | Secrets? | OSes | When |
+| ----- | -------------- | ---- | -------- | ---- | ---- |
+| **A — Contract matrix** | Feeds golden stdin payloads into the *installed* hook entrypoint and asserts the gateway received the event, the verdict was shaped correctly, and teardown is clean. | no | no | linux, macos, windows | every run; fork-safe |
+| **B — Live agent matrix** | Installs the real agent at its latest version, runs `defenseclaw setup`, drives lifecycle + forced tool calls through the real harness, and asserts observe / block / OTLP / teardown. | yes (deterministic prompts) | yes | per the reality matrix below | nightly + manual dispatch |
+
+Layer A targets `~/.defenseclaw/hooks/<connector>-hook.sh` on Linux/macOS and
+the native `defenseclaw-gateway hook --connector <c> --event <e>` subcommand on
+Windows. Both forward the payload to the local gateway, so every assertion
+works against `~/.defenseclaw/gateway.jsonl` + `audit.db` regardless of OS.
+
+Hooks are **harness-driven**, not LLM-driven: the agent fires
+`SessionStart` / `PreToolUse` / etc. as a function of its lifecycle, so Layer B
+only needs the model to run the one shell command it is explicitly told to.
+Enforcement is proven with a filesystem **sentinel**: the allow probe runs a
+benign command that creates a marker file; the block probe asks the agent to
+read `/etc/shadow` (rule `PATH-ETC-SHADOW`, CRITICAL) — if the marker ever
+appears, the command ran and the block regressed. Reading `/etc/shadow` is
+harmless (permission denied) if a regression ever lets it through.
+
+### Per-connector reality matrix (Layer B)
+
+| Connector | Linux | macOS | Windows | Live driver headless invocation | Notes |
+| --------- | ----- | ----- | ------- | ------------------------------- | ----- |
+| Codex | live | live | live\* | `codex exec --json --full-auto` | native OTLP asserted |
+| Claude Code | live | live | live\* | `claude -p` | native OTLP asserted; native-ask is Layer A only |
+| Gemini CLI | live | live | live\* | `gemini -p -o json --approval-mode yolo` | advisory events cannot block |
+| Cursor | live | live | live\* | `cursor-agent -p --force` | gated on a one-time headless-hook validation |
+| Copilot CLI | live\* | live\* | live\* | `copilot -p` | user-level hooks only; entitled token |
+| OpenHands | live | — | — | `openhands --headless --json` | Docker runtime, Linux-only |
+| Hermes | contract-only | contract-only | contract-only | — | only `pre_tool_call` mapped |
+| Windsurf | contract-only | contract-only | contract-only | — | no headless CLI/SDK |
+| Antigravity | contract-only | contract-only | contract-only | — | headless auth is OAuth, no API key |
+
+`\*` = advisory cell (`continue-on-error`) until it goes consistently green.
+All Windows live cells and every Copilot cell start advisory; they are promoted
+to gating once stable. Contract-only connectors run Layer A on every OS and are
+intentionally absent from Layer B.
+
+> **Current rollout:** the nightly schedule runs **Layer A only**. Layer B is
+> manual-dispatch-only and presently scoped to the connectors we can
+> authenticate with Azure OpenAI / Amazon Bedrock — **Codex, Claude Code, and
+> OpenHands**. **Gemini CLI, Cursor, and Copilot live cells are deferred** until
+> their native keys (`GOOGLE_API_KEY`, `CURSOR_API_KEY`, `COPILOT_CLI_TOKEN`)
+> are configured; all three still get full Layer A coverage in the meantime.
+
+### Alternative LLM auth (Azure OpenAI / Amazon Bedrock)
+
+The live drivers can source the model from a non-default backend. This only
+changes where the agent's LLM traffic goes — the hook bus, verdicts, and OTLP
+are unaffected, so hook coverage is identical. Selection is per backend, not
+global: set the repo Variable (`DC_USE_AZURE` / `DC_USE_BEDROCK` = `1`) to make
+it the nightly default, or flip the `use_azure` / `use_bedrock` dispatch toggle.
+
+| Connector | Default | Azure OpenAI (`DC_USE_AZURE=1`) | Amazon Bedrock (`DC_USE_BEDROCK=1`) |
+| --------- | ------- | ------------------------------- | ----------------------------------- |
+| Codex | `OPENAI_API_KEY` | yes — seeds `[model_providers.azure]` in `~/.codex/config.toml` | no (Codex is OpenAI-only) |
+| Claude Code | `ANTHROPIC_API_KEY` | no | yes — `CLAUDE_CODE_USE_BEDROCK=1` + AWS chain |
+| OpenHands | `LLM_API_KEY` | yes — `azure/<deployment>` via LiteLLM | yes — `bedrock/<profile>` via LiteLLM (wins if both set) |
+| Gemini CLI / Cursor / Copilot | native key | — | — |
+
+Required inputs per backend:
+
+- **Azure**: secret `AZURE_OPENAI_API_KEY`; Variables `AZURE_OPENAI_ENDPOINT`
+  (resource URL), `AZURE_OPENAI_DEPLOYMENT` (used as the model id),
+  optional `AZURE_OPENAI_API_VERSION` (OpenHands only; defaults to a recent
+  preview). The deployment must be a model the connector supports (Codex needs
+  a Responses-API-capable deployment).
+- **Bedrock**: secret `AWS_BEARER_TOKEN_BEDROCK` *or* the pair
+  `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (+ optional
+  `AWS_SESSION_TOKEN`); Variable `AWS_REGION` (defaults to `us-east-1`).
+  Optional model-id overrides: `CLAUDE_BEDROCK_MODEL`, `OPENHANDS_BEDROCK_MODEL`.
+
+Gemini CLI, Cursor, and Copilot have **no** Azure/Bedrock substitute — they
+require their native provider key (`GOOGLE_API_KEY`, `CURSOR_API_KEY`,
+`COPILOT_CLI_TOKEN`) to run live.
+
+### Version policy (alert-only)
+
+The workflow is an **evidence engine, not an auto-bumper**. Each live cell
+records the resolved upstream version into the job summary. On any live-cell
+failure the `report` job opens or updates a GitHub issue labeled
+`connector-regression` listing the failing connector / OS / event / version,
+and links the uploaded log artifact. It never edits a version file.
+
+Setting the highest approved version stays a deliberate human action:
+
+1. A maintainer triages whether DefenseClaw's decode/map/respond needs a fix or
+   the upstream agent changed its hook contract.
+2. If DefenseClaw must drop support for the new release, raise `min_inclusive`
+   or set `max_exclusive` in
+   [`cli/defenseclaw/inventory/hook_contracts.json`](../cli/defenseclaw/inventory/hook_contracts.json)
+   and [`internal/gateway/connector/hook_contract.go`](../internal/gateway/connector/hook_contract.go).
+3. Once green again, record the validated version in
+   [`cli/defenseclaw/inventory/validated_versions.json`](../cli/defenseclaw/inventory/validated_versions.json)
+   (per connector × OS: `last_validated_version`, `last_validated_at`,
+   `run_url`). This file is human-reviewed only; the workflow reads it for
+   context but never writes it.
+
+The runtime drift guard (`hook_contract_lock.json` + the action-mode
+fail-closed behavior described above) is unchanged — this workflow is what
+generates the evidence a maintainer uses to update the floors and ceilings.
+
+---
+
 ## By-design connector limitations (WONTFIX, architectural)
 
 Plan PR #194 / matrix §"Out of scope". Each item below is **not a bug** —

--- a/scripts/live-connector-e2e/contract-smoke.sh
+++ b/scripts/live-connector-e2e/contract-smoke.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Layer A — Contract entrypoint smoke (deterministic, no LLM, no secrets,
+# every OS). For one connector this script:
+#
+#   1. `defenseclaw setup <connector> --mode action` (installs the hook
+#      entrypoint + wires the agent config + restarts the gateway).
+#   2. Feeds every golden stdin payload under golden/<connector>/ into the
+#      *installed* hook entrypoint:
+#        - unix:    ~/.defenseclaw/hooks/<connector>-hook.sh
+#        - windows: defenseclaw-gateway hook --connector <name> --event <ev>
+#   3. Asserts the gateway received the event (fires) and that the entrypoint
+#      shaped the verdict correctly (allow -> exit 0; block -> exit 2 or a
+#      decision JSON carrying block/deny).
+#   4. Tears down and asserts the agent config is restored clean.
+#
+# This proves the decode -> map -> respond contract through the real installed
+# entrypoint on every OS, complementing the Go contract matrix (which proves
+# the same chain at the handler level). The block payload reads /etc/shadow
+# (rule PATH-ETC-SHADOW, CRITICAL) so it is denied deterministically without
+# an LLM and is harmless if a regression ever lets it through.
+#
+# Usage: contract-smoke.sh <connector>
+
+set -euo pipefail
+
+DC_E2E_CONNECTOR="${1:?usage: contract-smoke.sh <connector>}"
+export DC_E2E_CONNECTOR
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+. "${HERE}/lib/common.sh"
+# shellcheck source=lib/assert.sh
+. "${HERE}/lib/assert.sh"
+# shellcheck source=lib/setup.sh
+. "${HERE}/lib/setup.sh"
+
+golden_dir="${DC_E2E_GOLDEN_DIR}/${DC_E2E_CONNECTOR}"
+if [ ! -d "${golden_dir}" ]; then
+  dc_die "no golden payloads for connector ${DC_E2E_CONNECTOR} (expected ${golden_dir})"
+fi
+
+dc_section "contract smoke: ${DC_E2E_CONNECTOR} ($(dc_detect_os))"
+
+dc_init_defenseclaw
+dc_setup_connector "${DC_E2E_CONNECTOR}" action
+
+overall_rc=0
+
+# drive_event <event_label> <payload_file> <expect:allow|block>
+drive_event() {
+  local label="$1" payload="$2" expect="$3"
+  local before after out code
+  before="$(dc_gateway_jsonl_count)"
+  out="$(dc_invoke_hook "${DC_E2E_CONNECTOR}" "${label}" "${payload}")"
+  code="$(printf '%s\n' "${out}" | sed -n 's/^exit:\([0-9]\+\)$/\1/p' | tail -1)"
+  # Give the gateway a beat to flush the JSONL line.
+  sleep 1
+  after="$(dc_gateway_jsonl_count)"
+
+  # Fires: gateway received an event attributed to this connector.
+  if dc_assert_fired "${DC_E2E_CONNECTOR}" "${before}"; then
+    dc_record_result "${label}:fires" pass "jsonl ${before}->${after}"
+  else
+    dc_record_result "${label}:fires" fail "jsonl ${before}->${after} exit=${code}"
+    overall_rc=1
+  fi
+
+  case "${expect}" in
+    block)
+      # Verdict shaping: the entrypoint must signal block — either a
+      # non-zero (exit 2) deny or a decision JSON carrying block/deny.
+      if [ "${code}" = "2" ] || printf '%s' "${out}" | grep -Eqi '"(decision|action|permissionDecision)"\s*:\s*"(block|deny)"|\bdeny\b|\bblock\b'; then
+        dc_record_result "${label}:verdict-shape" pass "exit=${code}"
+      else
+        dc_record_result "${label}:verdict-shape" fail "expected block shaping, exit=${code}"
+        overall_rc=1
+      fi
+      # Corroborate with a gateway-side block verdict.
+      if dc_assert_verdict_block "${before}"; then
+        dc_record_result "${label}:verdict-gateway" pass ""
+      else
+        dc_record_result "${label}:verdict-gateway" fail "no block verdict recorded"
+        overall_rc=1
+      fi
+      ;;
+    allow)
+      if [ "${code}" = "0" ]; then
+        dc_record_result "${label}:verdict-shape" pass "exit=0"
+      else
+        dc_record_result "${label}:verdict-shape" fail "expected allow (exit 0), exit=${code}"
+        overall_rc=1
+      fi
+      ;;
+  esac
+}
+
+# Drive whatever golden payloads exist for this connector.
+[ -f "${golden_dir}/session_start.json" ] && drive_event "SessionStart" "${golden_dir}/session_start.json" allow
+[ -f "${golden_dir}/pre_tool_allow.json" ] && drive_event "PreTool-allow" "${golden_dir}/pre_tool_allow.json" allow
+[ -f "${golden_dir}/pre_tool_block.json" ] && drive_event "PreTool-block" "${golden_dir}/pre_tool_block.json" block
+
+# Schema invariant over everything emitted so far.
+if dc_assert_schema 1; then
+  dc_record_result "schema" pass ""
+else
+  dc_record_result "schema" fail "gateway.jsonl schema validation failed"
+  overall_rc=1
+fi
+
+# Teardown + clean-state assertion.
+cfg="$(dc_connector_config_file "${DC_E2E_CONNECTOR}")"
+if dc_teardown_connector "${DC_E2E_CONNECTOR}"; then
+  if dc_assert_teardown "${DC_E2E_CONNECTOR}" "${cfg}"; then
+    dc_record_result "teardown" pass ""
+  else
+    dc_record_result "teardown" fail "config not restored: ${cfg}"
+    overall_rc=1
+  fi
+else
+  dc_record_result "teardown" fail "connector verify reported residual state"
+  overall_rc=1
+fi
+
+exit "${overall_rc}"

--- a/scripts/live-connector-e2e/cursor-validation.sh
+++ b/scripts/live-connector-e2e/cursor-validation.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# One-time gate: does headless `cursor-agent -p` actually fire
+# ~/.cursor/hooks.json? Cursor exposes both a project cli-config.json and a
+# user hooks.json; it is not guaranteed the agentic-print mode honors the hook
+# bus. This script installs cursor-agent, wires DefenseClaw, drives a trivial
+# prompt, and checks whether any cursor-tagged event reached the gateway.
+#
+# Exit 0 + "CURSOR_HOOKS_FIRE=1" on $GITHUB_OUTPUT  -> live Cursor coverage is
+# valid; the workflow then runs drivers/cursor.sh.
+# Exit non-zero                                     -> Cursor stays Layer-A only.
+
+set -euo pipefail
+export DC_E2E_CONNECTOR=cursor
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${HERE}/lib/common.sh"
+. "${HERE}/lib/assert.sh"
+. "${HERE}/lib/setup.sh"
+
+dc_section "cursor headless hook validation"
+
+if ! command -v cursor-agent >/dev/null 2>&1; then
+  curl https://cursor.com/install -fsS | bash || dc_die "cursor-agent install failed"
+  export PATH="${HOME}/.local/bin:${PATH}"
+fi
+DC_E2E_AGENT_VERSION="$(dc_capture_version cursor cursor-agent --version)"
+export DC_E2E_AGENT_VERSION
+dc_write_env_key CURSOR_API_KEY "${CURSOR_API_KEY:-}"
+
+dc_init_defenseclaw
+dc_setup_connector cursor action
+
+before="$(dc_gateway_jsonl_count)"
+dc_log "driving trivial headless prompt through cursor-agent"
+dc_timeout 120 cursor-agent -p "Reply with only the word ready. Do not use any tools." \
+  --output-format json --force >/tmp/dc-cursor-validation.log 2>&1 || \
+  dc_warn "cursor-agent exited non-zero (see /tmp/dc-cursor-validation.log)"
+sleep 2
+
+fired=1
+if dc_assert_fired cursor "${before}"; then
+  dc_log "RESULT: cursor-agent -p FIRES ~/.cursor/hooks.json"
+  dc_record_result "validation:hooks-fire" pass ""
+else
+  fired=0
+  dc_log "RESULT: cursor-agent -p did NOT fire the hook bus"
+  dc_record_result "validation:hooks-fire" fail "no cursor events reached gateway in -p mode"
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  printf 'cursor_hooks_fire=%s\n' "${fired}" >> "${GITHUB_OUTPUT}"
+fi
+dc_teardown_connector cursor || true
+
+[ "${fired}" = "1" ]

--- a/scripts/live-connector-e2e/drivers/_driver_common.sh
+++ b/scripts/live-connector-e2e/drivers/_driver_common.sh
@@ -1,0 +1,187 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared Layer-B (live agent) orchestration. A per-connector driver sources
+# this file plus lib/{common,assert,setup}.sh, then defines three callbacks:
+#
+#   agent_install        -> install the real upstream agent at target version,
+#                           point it at the cheapest model, and set
+#                           DC_E2E_AGENT_VERSION.
+#   agent_run <prompt>   -> run the agent headlessly with <prompt> to
+#                           completion (auto-approving tools so the harness
+#                           fires its lifecycle + tool hooks deterministically).
+#
+# ...and sets capability flags before calling dc_driver_main:
+#   DC_DRIVER_MODE        observe|action     (default action)
+#   DC_DRIVER_SUPPORTS_BLOCK   1|0           (default 1)
+#   DC_DRIVER_SUPPORTS_OTLP    1|0           (default 0; set 1 for native_otlp)
+#
+# The orchestration is deterministic because hooks are harness-driven: the
+# agent fires SessionStart/PreToolUse/etc. as a function of its lifecycle, not
+# of an LLM decision. We only need the model to choose to run the one shell
+# command we explicitly instruct.
+
+DC_DRIVER_MODE="${DC_DRIVER_MODE:-action}"
+DC_DRIVER_SUPPORTS_BLOCK="${DC_DRIVER_SUPPORTS_BLOCK:-1}"
+DC_DRIVER_SUPPORTS_OTLP="${DC_DRIVER_SUPPORTS_OTLP:-0}"
+
+# Deterministic prompts. We keep them single-purpose and explicit so the
+# cheapest model reliably emits exactly one tool call.
+DC_PROMPT_LIFECYCLE='Reply with only the word ready. Do not use any tools.'
+
+# dc_timeout <seconds> <cmd...> — bound a live agent invocation. Uses GNU
+# timeout / gtimeout when present; otherwise runs unbounded (CI runners ship
+# coreutils, so this is just a local-dev fallback).
+dc_timeout() {
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout --signal=TERM "${secs}" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout --signal=TERM "${secs}" "$@"
+  else
+    "$@"
+  fi
+}
+
+# dc_allow_prompt <sentinel_path> — instruct the agent to run one benign
+# command that creates the sentinel (proves the tool call was allowed).
+dc_allow_prompt() {
+  printf 'Run exactly this shell command and nothing else: printf dc-allow > %s' "$1"
+}
+
+# dc_block_prompt <sentinel_path> — instruct the agent to run one command that
+# DefenseClaw blocks (reads /etc/shadow -> rule PATH-ETC-SHADOW, CRITICAL).
+# The redirect target would be created the instant the shell runs, so if the
+# command is allowed to execute at all the sentinel appears and the block
+# assertion fails. Reading /etc/shadow is harmless (permission denied) if a
+# regression ever lets it through.
+dc_block_prompt() {
+  printf 'Run exactly this shell command and nothing else: cat /etc/shadow > %s' "$1"
+}
+
+# dc_run_probe <label> <prompt> — run the agent (via the driver's agent_run
+# callback, which is responsible for bounding itself with dc_timeout) and
+# return the gateway.jsonl line count captured immediately before the run so
+# callers can scope "fired during this probe" assertions. Echoes the
+# before-count. agent_run's stdout/stderr is tee'd to a per-probe log.
+dc_run_probe() {
+  local label="$1" prompt="$2" before
+  before="$(dc_gateway_jsonl_count)"
+  dc_log "probe[${label}]: running agent"
+  if ! agent_run "${prompt}" >"/tmp/dc-agent-${label}.log" 2>&1; then
+    dc_warn "probe[${label}]: agent run exited non-zero or timed out (see /tmp/dc-agent-${label}.log)"
+  fi
+  sleep 2  # let the gateway flush JSONL/audit rows
+  printf '%s' "${before}"
+}
+
+# dc_driver_main <connector> — the full live cell.
+dc_driver_main() {
+  local connector="$1"
+  export DC_E2E_CONNECTOR="${connector}"
+  local rc=0
+
+  dc_section "live driver: ${connector} ($(dc_detect_os)) mode=${DC_DRIVER_MODE}"
+
+  # 1. Install the real agent.
+  if agent_install; then
+    dc_record_result "install" pass "${DC_E2E_AGENT_VERSION:-unknown}"
+  else
+    dc_record_result "install" fail "agent install failed"
+    return 1
+  fi
+
+  # 2. DefenseClaw init + connector setup.
+  dc_init_defenseclaw
+  dc_clear_sentinels
+  if dc_setup_connector "${connector}" "${DC_DRIVER_MODE}"; then
+    dc_record_result "setup" pass "mode=${DC_DRIVER_MODE}"
+  else
+    dc_record_result "setup" fail "defenseclaw setup ${connector} failed"
+    return 1
+  fi
+
+  local lifecycle_before
+  # 3. Lifecycle probe — proves SessionStart/UserPromptSubmit/Stop fire.
+  lifecycle_before="$(dc_run_probe lifecycle "${DC_PROMPT_LIFECYCLE}" 120)"
+  if dc_assert_fired "${connector}" "${lifecycle_before}"; then
+    dc_record_result "lifecycle:fires" pass ""
+  else
+    dc_record_result "lifecycle:fires" fail "no lifecycle events reached gateway"
+    rc=1
+  fi
+
+  # 4. Allow (observe) probe — forced tool call that policy permits.
+  local allow_token allow_path allow_before
+  allow_token="$(dc_new_sentinel_token)"; allow_path="$(dc_sentinel_path "${allow_token}")"
+  allow_before="$(dc_run_probe allow "$(dc_allow_prompt "${allow_path}")" 180)"
+  if dc_assert_fired "${connector}" "${allow_before}"; then
+    dc_record_result "tool-allow:fires" pass ""
+  else
+    dc_record_result "tool-allow:fires" fail "tool event did not reach gateway"
+    rc=1
+  fi
+  if dc_assert_allowed "${allow_token}"; then
+    dc_record_result "tool-allow:observe" pass "sentinel created"
+  else
+    dc_record_result "tool-allow:observe" fail "benign command never ran"
+    rc=1
+  fi
+
+  # 5. Block probe — forced dangerous tool call that action mode must deny.
+  if [ "${DC_DRIVER_SUPPORTS_BLOCK}" = "1" ] && [ "${DC_DRIVER_MODE}" = "action" ]; then
+    local block_token block_path block_before
+    block_token="$(dc_new_sentinel_token)"; block_path="$(dc_sentinel_path "${block_token}")"
+    block_before="$(dc_run_probe block "$(dc_block_prompt "${block_path}")" 180)"
+    if dc_assert_fired "${connector}" "${block_before}"; then
+      dc_record_result "tool-block:fires" pass ""
+    else
+      dc_record_result "tool-block:fires" fail "tool event did not reach gateway"
+      rc=1
+    fi
+    if dc_assert_blocked "${block_token}" "${block_before}"; then
+      dc_record_result "tool-block:enforced" pass "sentinel absent + block verdict"
+    else
+      dc_record_result "tool-block:enforced" fail "enforcement not confirmed"
+      rc=1
+    fi
+  else
+    dc_record_result "tool-block:enforced" skip "block not supported headless for ${connector}"
+  fi
+
+  # 6. OTLP telemetry (native_otlp connectors only).
+  if [ "${DC_DRIVER_SUPPORTS_OTLP}" = "1" ]; then
+    if dc_assert_otlp "${connector}" "${lifecycle_before}"; then
+      dc_record_result "otlp" pass ""
+    else
+      dc_record_result "otlp" fail "no connector-tagged telemetry reached the OTLP sink"
+      rc=1
+    fi
+  fi
+
+  # 7. Shared observability invariants over all traffic emitted this run.
+  if dc_assert_observability; then
+    dc_record_result "observability" pass ""
+  else
+    dc_record_result "observability" fail "Phase 6 observability invariants failed"
+    rc=1
+  fi
+
+  # 8. Teardown + clean-state.
+  local cfg; cfg="$(dc_connector_config_file "${connector}")"
+  if dc_teardown_connector "${connector}" && dc_assert_teardown "${connector}" "${cfg}"; then
+    dc_record_result "teardown" pass ""
+  else
+    dc_record_result "teardown" fail "residual state after teardown"
+    rc=1
+  fi
+
+  return "${rc}"
+}

--- a/scripts/live-connector-e2e/drivers/claudecode.sh
+++ b/scripts/live-connector-e2e/drivers/claudecode.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Live driver for Anthropic Claude Code.
+#   - install:  npm i -g @anthropic-ai/claude-code@${CLAUDE_VERSION:-latest}
+#   - headless: claude -p "<prompt>" --output-format json
+#   - auth:     ANTHROPIC_API_KEY (Anthropic direct) OR Amazon Bedrock when
+#               DC_USE_BEDROCK=1 (CLAUDE_CODE_USE_BEDROCK + AWS creds).
+#   - hooks:    SessionStart / UserPromptSubmit / PreToolUse / PostToolUse /
+#               Stop. PreToolUse deny is honored even when tools are
+#               auto-approved, so block enforcement is testable headless.
+#   - ask:      Claude's native PermissionRequest "ask" path is NOT reachable
+#               headless (no interactive approver), so ask coverage stays in
+#               Layer A only — we do not assert it here.
+#   - OTLP:     native exporter wired by `defenseclaw setup claude-code`.
+#
+# Bedrock: when DC_USE_BEDROCK=1 we set CLAUDE_CODE_USE_BEDROCK=1, point the
+# model at a Bedrock inference-profile id, and rely on the AWS credential chain
+# (AWS_BEARER_TOKEN_BEDROCK, or AWS_ACCESS_KEY_ID/SECRET[/SESSION_TOKEN]) +
+# AWS_REGION. The small/fast background model must also be a Bedrock id.
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${HERE}/../lib/common.sh"
+. "${HERE}/../lib/assert.sh"
+. "${HERE}/../lib/setup.sh"
+. "${HERE}/_driver_common.sh"
+
+DC_DRIVER_MODE=action
+DC_DRIVER_SUPPORTS_BLOCK=1
+DC_DRIVER_SUPPORTS_OTLP=1
+
+CLAUDE_MODEL="${CLAUDE_MODEL:-claude-haiku-4-5}"
+
+agent_install() {
+  npm install -g "@anthropic-ai/claude-code@${CLAUDE_VERSION:-latest}" || return 1
+  DC_E2E_AGENT_VERSION="$(dc_capture_version claudecode claude --version)"
+  export DC_E2E_AGENT_VERSION
+
+  if [ "${DC_USE_BEDROCK:-0}" = "1" ]; then
+    if [ -z "${AWS_BEARER_TOKEN_BEDROCK:-}" ] && [ -z "${AWS_ACCESS_KEY_ID:-}" ]; then
+      dc_err "DC_USE_BEDROCK=1 needs AWS auth (AWS_BEARER_TOKEN_BEDROCK or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY)"
+      return 1
+    fi
+    export CLAUDE_CODE_USE_BEDROCK=1
+    export AWS_REGION="${AWS_REGION:-us-east-1}"
+    CLAUDE_MODEL="${CLAUDE_BEDROCK_MODEL:-us.anthropic.claude-haiku-4-5-20251001-v1:0}"
+    export ANTHROPIC_MODEL="${CLAUDE_MODEL}"
+    export ANTHROPIC_SMALL_FAST_MODEL="${ANTHROPIC_SMALL_FAST_MODEL:-${CLAUDE_MODEL}}"
+    dc_log "claude code configured for Bedrock model ${CLAUDE_MODEL} (region ${AWS_REGION})"
+  else
+    dc_write_env_key ANTHROPIC_API_KEY "${ANTHROPIC_API_KEY:-}"
+  fi
+}
+
+agent_run() {
+  local prompt="$1"
+  # acceptEdits auto-approves benign tool calls so the allow probe runs, while
+  # PreToolUse hooks still fire (and can still deny) for the block probe.
+  dc_timeout 180 claude -p "${prompt}" \
+    --output-format json \
+    --model "${CLAUDE_MODEL}" \
+    --permission-mode acceptEdits \
+    --allowedTools "Bash"
+}
+
+dc_driver_main claudecode

--- a/scripts/live-connector-e2e/drivers/codex.sh
+++ b/scripts/live-connector-e2e/drivers/codex.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Live driver for OpenAI Codex CLI.
+#   - install:  npm i -g @openai/codex@${CODEX_VERSION:-latest}
+#   - headless: codex exec --json --full-auto "<prompt>"
+#   - auth:     OPENAI_API_KEY (public OpenAI) OR Azure OpenAI when
+#               DC_USE_AZURE=1 (Codex cannot use Bedrock — it is OpenAI-only).
+#   - hooks:    SessionStart / UserPromptSubmit / PreToolUse / PostToolUse /
+#               Stop. Native OTLP exporter is wired by `defenseclaw setup
+#               codex --restart`, so OTLP is asserted.
+#   - trust:    Codex hashes the hook command and refuses to run an
+#               unrecognized one. `defenseclaw setup codex` pre-seeds trust;
+#               on Windows the native `defenseclaw-gateway hook` command +
+#               .hookcfg keep the hash stable. CODEX_BYPASS_HOOK_TRUST=1 adds
+#               the documented escape hatch if a runner starts cold.
+#
+# Azure: when DC_USE_AZURE=1 we write a [model_providers.azure] block into
+# ~/.codex/config.toml BEFORE `defenseclaw setup codex`. That setup only
+# mutates the [hooks]/[otel]/notify tables (it parses the file into a map and
+# re-marshals), so the Azure provider survives. Codex then talks to Azure
+# directly for LLM traffic; the hook bus + OTLP are unaffected. Requires
+# AZURE_OPENAI_ENDPOINT (resource URL), AZURE_OPENAI_DEPLOYMENT (used as the
+# model — must be a Codex-capable deployment), and AZURE_OPENAI_API_KEY.
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${HERE}/../lib/common.sh"
+. "${HERE}/../lib/assert.sh"
+. "${HERE}/../lib/setup.sh"
+. "${HERE}/_driver_common.sh"
+
+DC_DRIVER_MODE=action
+DC_DRIVER_SUPPORTS_BLOCK=1
+DC_DRIVER_SUPPORTS_OTLP=1
+
+CODEX_MODEL="${CODEX_MODEL:-gpt-5-mini}"
+
+# _codex_azure_base_url — normalize AZURE_OPENAI_ENDPOINT to the v1 Responses
+# base URL Codex expects (".../openai/v1"). Idempotent if the caller already
+# included /openai or /openai/v1.
+_codex_azure_base_url() {
+  local ep="${AZURE_OPENAI_ENDPOINT%/}"
+  ep="${ep%/openai/v1}"
+  ep="${ep%/openai}"
+  ep="${ep%/}"
+  printf '%s/openai/v1' "${ep}"
+}
+
+# _codex_write_azure_config — seed ~/.codex/config.toml with the Azure provider
+# so `defenseclaw setup codex` merges its tables on top of it. env_key holds the
+# NAME of the env var (never the key value), so no secret is written to disk.
+_codex_write_azure_config() {
+  mkdir -p "${HOME}/.codex"
+  cat > "${HOME}/.codex/config.toml" <<EOF
+model = "${AZURE_OPENAI_DEPLOYMENT}"
+model_provider = "azure"
+
+[model_providers.azure]
+name = "Azure OpenAI"
+base_url = "$(_codex_azure_base_url)"
+env_key = "AZURE_OPENAI_API_KEY"
+wire_api = "responses"
+EOF
+}
+
+agent_install() {
+  npm install -g "@openai/codex@${CODEX_VERSION:-latest}" || return 1
+  DC_E2E_AGENT_VERSION="$(dc_capture_version codex codex --version)"
+  export DC_E2E_AGENT_VERSION
+
+  if [ "${DC_USE_AZURE:-0}" = "1" ]; then
+    if [ -z "${AZURE_OPENAI_ENDPOINT:-}" ] || [ -z "${AZURE_OPENAI_DEPLOYMENT:-}" ] || [ -z "${AZURE_OPENAI_API_KEY:-}" ]; then
+      dc_err "DC_USE_AZURE=1 needs AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_DEPLOYMENT + AZURE_OPENAI_API_KEY"
+      return 1
+    fi
+    CODEX_MODEL="${AZURE_OPENAI_DEPLOYMENT}"
+    export AZURE_OPENAI_API_KEY
+    _codex_write_azure_config
+    dc_log "codex configured for Azure OpenAI deployment ${AZURE_OPENAI_DEPLOYMENT}"
+  else
+    dc_write_env_key OPENAI_API_KEY "${OPENAI_API_KEY:-}"
+  fi
+}
+
+agent_run() {
+  local prompt="$1" extra=()
+  [ "${CODEX_BYPASS_HOOK_TRUST:-0}" = "1" ] && extra+=(--dangerously-bypass-hook-trust)
+  dc_timeout 180 codex exec --json --full-auto \
+    --model "${CODEX_MODEL}" \
+    "${extra[@]}" \
+    "${prompt}"
+}
+
+dc_driver_main codex

--- a/scripts/live-connector-e2e/drivers/copilot.sh
+++ b/scripts/live-connector-e2e/drivers/copilot.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Live driver for GitHub Copilot CLI.
+#   - install:  npm i -g @github/copilot@${COPILOT_VERSION:-latest}
+#   - headless: copilot -p "<prompt>" --allow-all-tools
+#   - auth:     an ENTITLED GitHub token (Copilot subscription). Provide it via
+#               the COPILOT_CLI_TOKEN secret; we export it as GH_COPILOT_TOKEN
+#               and GITHUB_TOKEN so the CLI picks it up.
+#   - hooks:    USER-LEVEL ONLY. Repo-level .github/hooks/*.json do NOT load in
+#               `-p` mode (upstream bug github/copilot-cli#3345), so
+#               `defenseclaw setup copilot` must write ~/.copilot/hooks/*.json.
+#               We force user scope by NOT passing --workspace.
+#   - status:   continue-on-error in the workflow until proven stable.
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${HERE}/../lib/common.sh"
+. "${HERE}/../lib/assert.sh"
+. "${HERE}/../lib/setup.sh"
+. "${HERE}/_driver_common.sh"
+
+DC_DRIVER_MODE=action
+DC_DRIVER_SUPPORTS_BLOCK=1
+DC_DRIVER_SUPPORTS_OTLP=0
+
+agent_install() {
+  npm install -g "@github/copilot@${COPILOT_VERSION:-latest}" || return 1
+  DC_E2E_AGENT_VERSION="$(dc_capture_version copilot copilot --version)"
+  export DC_E2E_AGENT_VERSION
+  # Copilot CLI reads an entitled token from the environment.
+  export GH_COPILOT_TOKEN="${COPILOT_CLI_TOKEN:-${GH_COPILOT_TOKEN:-}}"
+  export GITHUB_TOKEN="${COPILOT_CLI_TOKEN:-${GITHUB_TOKEN:-}}"
+}
+
+agent_run() {
+  local prompt="$1"
+  dc_timeout 180 copilot -p "${prompt}" --allow-all-tools
+}
+
+dc_driver_main copilot

--- a/scripts/live-connector-e2e/drivers/cursor.sh
+++ b/scripts/live-connector-e2e/drivers/cursor.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Live driver for Cursor Agent (cursor-agent CLI).
+#   - install:  curl https://cursor.com/install -fsS | bash
+#   - headless: cursor-agent -p "<prompt>" --output-format json --force
+#   - auth:     CURSOR_API_KEY
+#   - hooks:    beforeShellExecution can deny (can_ask_native), so block is
+#               testable headless.
+#
+# GATING: live Cursor coverage is only meaningful if headless `cursor-agent -p`
+# actually fires ~/.cursor/hooks.json. Run cursor-validation.sh first; the
+# workflow gates this driver on its result.
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${HERE}/../lib/common.sh"
+. "${HERE}/../lib/assert.sh"
+. "${HERE}/../lib/setup.sh"
+. "${HERE}/_driver_common.sh"
+
+DC_DRIVER_MODE=action
+DC_DRIVER_SUPPORTS_BLOCK=1
+DC_DRIVER_SUPPORTS_OTLP=0
+
+agent_install() {
+  if ! command -v cursor-agent >/dev/null 2>&1; then
+    curl https://cursor.com/install -fsS | bash || return 1
+    export PATH="${HOME}/.local/bin:${PATH}"
+  fi
+  DC_E2E_AGENT_VERSION="$(dc_capture_version cursor cursor-agent --version)"
+  export DC_E2E_AGENT_VERSION
+  dc_write_env_key CURSOR_API_KEY "${CURSOR_API_KEY:-}"
+}
+
+agent_run() {
+  local prompt="$1"
+  dc_timeout 180 cursor-agent -p "${prompt}" --output-format json --force
+}
+
+dc_driver_main cursor

--- a/scripts/live-connector-e2e/drivers/geminicli.sh
+++ b/scripts/live-connector-e2e/drivers/geminicli.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Live driver for Google Gemini CLI.
+#   - install:  npm i -g @google/gemini-cli@${GEMINI_VERSION:-latest}
+#   - headless: gemini -p "<prompt>" -o json --approval-mode yolo
+#   - auth:     GEMINI_API_KEY (or GOOGLE_API_KEY)
+#   - hooks:    Gemini's hook events are advisory (SessionStart / PreCompress /
+#               Notification / BeforeTool) — the harness records them but does
+#               not honor a deny verdict, so we assert fires + observe + OTLP
+#               only and skip the block assertion (DC_DRIVER_SUPPORTS_BLOCK=0).
+#   - OTLP:     native exporter wired by `defenseclaw setup geminicli`.
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${HERE}/../lib/common.sh"
+. "${HERE}/../lib/assert.sh"
+. "${HERE}/../lib/setup.sh"
+. "${HERE}/_driver_common.sh"
+
+DC_DRIVER_MODE=action
+DC_DRIVER_SUPPORTS_BLOCK=0   # advisory events cannot block
+DC_DRIVER_SUPPORTS_OTLP=1
+
+GEMINI_MODEL="${GEMINI_MODEL:-gemini-2.5-flash}"
+
+agent_install() {
+  npm install -g "@google/gemini-cli@${GEMINI_VERSION:-latest}" || return 1
+  DC_E2E_AGENT_VERSION="$(dc_capture_version geminicli gemini --version)"
+  export DC_E2E_AGENT_VERSION
+  dc_write_env_key GEMINI_API_KEY "${GEMINI_API_KEY:-${GOOGLE_API_KEY:-}}"
+}
+
+agent_run() {
+  local prompt="$1"
+  dc_timeout 180 gemini -p "${prompt}" -o json \
+    --model "${GEMINI_MODEL}" \
+    --approval-mode yolo
+}
+
+dc_driver_main geminicli

--- a/scripts/live-connector-e2e/drivers/openhands.sh
+++ b/scripts/live-connector-e2e/drivers/openhands.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Live driver for OpenHands (headless CLI).
+#   - install:  pipx/uv install openhands-ai (the `openhands` console script)
+#   - headless: openhands --headless -t "<prompt>"
+#   - auth:     LLM_API_KEY + LLM_MODEL (OpenHands' provider-agnostic env).
+#               OpenHands routes through LiteLLM, so it can target the public
+#               provider (default), Amazon Bedrock (DC_USE_BEDROCK=1), or
+#               Azure OpenAI (DC_USE_AZURE=1). Bedrock wins if both are set.
+#   - runtime:  Docker. LINUX ONLY — macOS/Windows runners lack a usable Docker
+#               daemon for the agent runtime, so the workflow restricts this
+#               connector to ubuntu-latest.
+#   - hooks:    PreToolUse deny is honored (exit-2 style), so block is testable.
+#
+# Bedrock: LLM_MODEL=bedrock/<inference-profile>; LiteLLM uses the AWS chain
+#   (AWS_BEARER_TOKEN_BEDROCK or AWS_ACCESS_KEY_ID/SECRET[/SESSION_TOKEN]) +
+#   AWS_REGION. No LLM_API_KEY needed.
+# Azure:   LLM_MODEL=azure/<deployment>; LiteLLM reads AZURE_API_KEY /
+#   AZURE_API_BASE / AZURE_API_VERSION (derived from AZURE_OPENAI_* here).
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${HERE}/../lib/common.sh"
+. "${HERE}/../lib/assert.sh"
+. "${HERE}/../lib/setup.sh"
+. "${HERE}/_driver_common.sh"
+
+DC_DRIVER_MODE=action
+DC_DRIVER_SUPPORTS_BLOCK=1
+DC_DRIVER_SUPPORTS_OTLP=0
+
+OPENHANDS_MODEL="${OPENHANDS_MODEL:-openai/gpt-5-mini}"
+
+agent_install() {
+  if [ "$(dc_detect_os)" != "linux" ]; then
+    dc_warn "openhands requires Docker runtime; only supported on linux"
+    return 1
+  fi
+  if command -v uv >/dev/null 2>&1; then
+    uv tool install "openhands-ai${OPENHANDS_VERSION:+==${OPENHANDS_VERSION}}" || return 1
+  else
+    pipx install "openhands-ai${OPENHANDS_VERSION:+==${OPENHANDS_VERSION}}" || \
+      pip install --user "openhands-ai${OPENHANDS_VERSION:+==${OPENHANDS_VERSION}}" || return 1
+  fi
+  DC_E2E_AGENT_VERSION="$(dc_capture_version openhands openhands --version)"
+  export DC_E2E_AGENT_VERSION
+
+  # OpenHands resolves the LLM via LLM_* env (litellm-style model id).
+  if [ "${DC_USE_BEDROCK:-0}" = "1" ]; then
+    if [ -z "${AWS_BEARER_TOKEN_BEDROCK:-}" ] && [ -z "${AWS_ACCESS_KEY_ID:-}" ]; then
+      dc_err "DC_USE_BEDROCK=1 needs AWS auth (AWS_BEARER_TOKEN_BEDROCK or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY)"
+      return 1
+    fi
+    export AWS_REGION="${AWS_REGION:-us-east-1}"
+    export LLM_MODEL="${OPENHANDS_BEDROCK_MODEL:-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0}"
+    dc_log "openhands configured for Bedrock model ${LLM_MODEL} (region ${AWS_REGION})"
+  elif [ "${DC_USE_AZURE:-0}" = "1" ]; then
+    if [ -z "${AZURE_OPENAI_ENDPOINT:-}" ] || [ -z "${AZURE_OPENAI_DEPLOYMENT:-}" ] || [ -z "${AZURE_OPENAI_API_KEY:-}" ]; then
+      dc_err "DC_USE_AZURE=1 needs AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_DEPLOYMENT + AZURE_OPENAI_API_KEY"
+      return 1
+    fi
+    export AZURE_API_KEY="${AZURE_OPENAI_API_KEY}"
+    export AZURE_API_BASE="${AZURE_OPENAI_ENDPOINT%/}"
+    export AZURE_API_VERSION="${AZURE_OPENAI_API_VERSION:-2025-04-01-preview}"
+    export LLM_API_KEY="${AZURE_OPENAI_API_KEY}"
+    export LLM_MODEL="azure/${AZURE_OPENAI_DEPLOYMENT}"
+    dc_write_env_key LLM_API_KEY "${AZURE_OPENAI_API_KEY}"
+    dc_log "openhands configured for Azure OpenAI deployment ${AZURE_OPENAI_DEPLOYMENT}"
+  else
+    dc_write_env_key LLM_API_KEY "${LLM_API_KEY:-${OPENAI_API_KEY:-}}"
+    export LLM_MODEL="${OPENHANDS_MODEL}"
+    export LLM_API_KEY="${LLM_API_KEY:-${OPENAI_API_KEY:-}}"
+  fi
+}
+
+agent_run() {
+  local prompt="$1"
+  dc_timeout 300 openhands --headless -t "${prompt}"
+}
+
+dc_driver_main openhands

--- a/scripts/live-connector-e2e/golden/antigravity/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/antigravity/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-antigravity",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "antigravity-e2e",
+  "agent_name": "antigravity e2e agent",
+  "agent_type": "antigravity-cli",
+  "tool_name": "run_command",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/antigravity/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/antigravity/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-antigravity",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "antigravity-e2e",
+  "agent_name": "antigravity e2e agent",
+  "agent_type": "antigravity-cli",
+  "tool_name": "run_command",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/antigravity/session_start.json
+++ b/scripts/live-connector-e2e/golden/antigravity/session_start.json
@@ -1,0 +1,8 @@
+{
+  "hook_event_name": "SessionStart",
+  "session_id": "dc-e2e-antigravity",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "antigravity-e2e",
+  "agent_name": "antigravity e2e agent",
+  "agent_type": "antigravity-cli"
+}

--- a/scripts/live-connector-e2e/golden/claudecode/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/claudecode/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-claudecode",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "claudecode-e2e",
+  "agent_name": "claudecode e2e agent",
+  "agent_type": "claudecode-cli",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/claudecode/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/claudecode/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-claudecode",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "claudecode-e2e",
+  "agent_name": "claudecode e2e agent",
+  "agent_type": "claudecode-cli",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/claudecode/session_start.json
+++ b/scripts/live-connector-e2e/golden/claudecode/session_start.json
@@ -1,0 +1,8 @@
+{
+  "hook_event_name": "SessionStart",
+  "session_id": "dc-e2e-claudecode",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "claudecode-e2e",
+  "agent_name": "claudecode e2e agent",
+  "agent_type": "claudecode-cli"
+}

--- a/scripts/live-connector-e2e/golden/codex/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/codex/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-codex",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "codex-e2e",
+  "agent_name": "codex e2e agent",
+  "agent_type": "codex-cli",
+  "tool_name": "shell",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/codex/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/codex/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-codex",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "codex-e2e",
+  "agent_name": "codex e2e agent",
+  "agent_type": "codex-cli",
+  "tool_name": "shell",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/codex/session_start.json
+++ b/scripts/live-connector-e2e/golden/codex/session_start.json
@@ -1,0 +1,8 @@
+{
+  "hook_event_name": "SessionStart",
+  "session_id": "dc-e2e-codex",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "codex-e2e",
+  "agent_name": "codex e2e agent",
+  "agent_type": "codex-cli"
+}

--- a/scripts/live-connector-e2e/golden/copilot/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/copilot/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-copilot",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "copilot-e2e",
+  "agent_name": "copilot e2e agent",
+  "agent_type": "copilot-cli",
+  "tool_name": "shell",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/copilot/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/copilot/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-copilot",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "copilot-e2e",
+  "agent_name": "copilot e2e agent",
+  "agent_type": "copilot-cli",
+  "tool_name": "shell",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/cursor/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/cursor/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "preToolUse",
+  "session_id": "dc-e2e-cursor",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "cursor-e2e",
+  "agent_name": "cursor e2e agent",
+  "agent_type": "cursor-cli",
+  "tool_name": "run_terminal_cmd",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/cursor/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/cursor/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "preToolUse",
+  "session_id": "dc-e2e-cursor",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "cursor-e2e",
+  "agent_name": "cursor e2e agent",
+  "agent_type": "cursor-cli",
+  "tool_name": "run_terminal_cmd",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/geminicli/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/geminicli/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "BeforeTool",
+  "session_id": "dc-e2e-geminicli",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "geminicli-e2e",
+  "agent_name": "geminicli e2e agent",
+  "agent_type": "geminicli-cli",
+  "tool_name": "RunShellCommand",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/geminicli/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/geminicli/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "BeforeTool",
+  "session_id": "dc-e2e-geminicli",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "geminicli-e2e",
+  "agent_name": "geminicli e2e agent",
+  "agent_type": "geminicli-cli",
+  "tool_name": "RunShellCommand",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/geminicli/session_start.json
+++ b/scripts/live-connector-e2e/golden/geminicli/session_start.json
@@ -1,0 +1,8 @@
+{
+  "hook_event_name": "SessionStart",
+  "session_id": "dc-e2e-geminicli",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "geminicli-e2e",
+  "agent_name": "geminicli e2e agent",
+  "agent_type": "geminicli-cli"
+}

--- a/scripts/live-connector-e2e/golden/hermes/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/hermes/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "pre_tool_call",
+  "session_id": "dc-e2e-hermes",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "hermes-e2e",
+  "agent_name": "hermes e2e agent",
+  "agent_type": "hermes-cli",
+  "tool_name": "execute_command",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/hermes/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/hermes/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "pre_tool_call",
+  "session_id": "dc-e2e-hermes",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "hermes-e2e",
+  "agent_name": "hermes e2e agent",
+  "agent_type": "hermes-cli",
+  "tool_name": "execute_command",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/openhands/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/openhands/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-openhands",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "openhands-e2e",
+  "agent_name": "openhands e2e agent",
+  "agent_type": "openhands-cli",
+  "tool_name": "terminal",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/openhands/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/openhands/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "dc-e2e-openhands",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "openhands-e2e",
+  "agent_name": "openhands e2e agent",
+  "agent_type": "openhands-cli",
+  "tool_name": "terminal",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/windsurf/pre_tool_allow.json
+++ b/scripts/live-connector-e2e/golden/windsurf/pre_tool_allow.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "pre_run_command",
+  "session_id": "dc-e2e-windsurf",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "windsurf-e2e",
+  "agent_name": "windsurf e2e agent",
+  "agent_type": "windsurf-cli",
+  "tool_name": "run_command",
+  "tool_input": {
+    "command": "echo dc-contract-allow"
+  }
+}

--- a/scripts/live-connector-e2e/golden/windsurf/pre_tool_block.json
+++ b/scripts/live-connector-e2e/golden/windsurf/pre_tool_block.json
@@ -1,0 +1,12 @@
+{
+  "hook_event_name": "pre_run_command",
+  "session_id": "dc-e2e-windsurf",
+  "turn_id": "dc-e2e-turn",
+  "agent_id": "windsurf-e2e",
+  "agent_name": "windsurf e2e agent",
+  "agent_type": "windsurf-cli",
+  "tool_name": "run_command",
+  "tool_input": {
+    "command": "cat /etc/shadow"
+  }
+}

--- a/scripts/live-connector-e2e/lib/assert.sh
+++ b/scripts/live-connector-e2e/lib/assert.sh
@@ -1,0 +1,194 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Assertion helpers layered on top of the existing CI invariants:
+#   - gateway.jsonl schema      -> scripts/assert-gateway-jsonl.py
+#   - observability invariants  -> test/e2e/observability_assertions.sh
+#   - real enforcement          -> sentinel side-effect files (lib/common.sh)
+#
+# Every assertion returns 0/1 and is logged; callers decide whether a failure
+# is fatal (drivers wrap each in dc_record_result so one event's failure does
+# not abort the cell).
+
+# dc_assert_schema [min_events] — validate gateway.jsonl envelope schema.
+dc_assert_schema() {
+  local min="${1:-1}"
+  if [ ! -f "${DC_GATEWAY_JSONL}" ]; then
+    dc_err "gateway.jsonl missing at ${DC_GATEWAY_JSONL}"
+    return 1
+  fi
+  python3 "${DC_E2E_REPO_ROOT}/scripts/assert-gateway-jsonl.py" \
+    "${DC_GATEWAY_JSONL}" --min-events "${min}"
+}
+
+# dc_count_connector_events <connector> [since_line] — count gateway.jsonl
+# events attributed to a connector. Resilient across event shapes: matches any
+# of destination_app / surface / aid_surface / connector carrying the name.
+# When since_line is given, only events strictly after that 1-based line index
+# are counted (so we assert "fired during this probe", not historically).
+dc_count_connector_events() {
+  local connector="$1" since="${2:-0}"
+  [ -f "${DC_GATEWAY_JSONL}" ] || { printf '0'; return 0; }
+  python3 - "${DC_GATEWAY_JSONL}" "${connector}" "${since}" <<'PY'
+import json, sys
+path, connector, since = sys.argv[1], sys.argv[2], int(sys.argv[3])
+fields = ("destination_app", "surface", "aid_surface", "connector", "agent_name", "agent_type")
+n = 0
+with open(path, encoding="utf-8") as f:
+    for i, line in enumerate(f, start=1):
+        if i <= since:
+            continue
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except Exception:
+            continue
+        blob = json.dumps(ev).lower()
+        if any(str(ev.get(k, "")).lower() == connector for k in fields):
+            n += 1
+        elif connector in blob and ("hook" in blob or "tool" in blob or "lifecycle" in blob):
+            n += 1
+print(n)
+PY
+}
+
+# dc_assert_fired <connector> <since_line> — at least one gateway event was
+# attributed to the connector since the probe started. This is the #1
+# regression signal: an upstream release that renames/drops an event makes the
+# hook stop firing, and this assertion goes red.
+dc_assert_fired() {
+  local connector="$1" since="${2:-0}" n
+  n="$(dc_count_connector_events "${connector}" "${since}")"
+  if [ "${n:-0}" -ge 1 ]; then
+    return 0
+  fi
+  dc_err "no gateway events attributed to ${connector} since line ${since}"
+  return 1
+}
+
+# dc_assert_verdict_block <since_line> — a block verdict was recorded after the
+# probe. Pairs with the sentinel check so we prove both the decision AND the
+# enforcement.
+dc_assert_verdict_block() {
+  local since="${1:-0}"
+  [ -f "${DC_GATEWAY_JSONL}" ] || return 1
+  python3 - "${DC_GATEWAY_JSONL}" "${since}" <<'PY'
+import json, sys
+path, since = sys.argv[1], int(sys.argv[2])
+found = False
+with open(path, encoding="utf-8") as f:
+    for i, line in enumerate(f, start=1):
+        if i <= since:
+            continue
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except Exception:
+            continue
+        if ev.get("event_type") == "verdict":
+            action = str(ev.get("verdict", {}).get("action", "")).lower()
+            if action in ("block", "deny"):
+                found = True
+                break
+sys.exit(0 if found else 1)
+PY
+}
+
+# dc_assert_observability [extra args...] — run the shared Phase 6 invariants
+# (timestamp sanity, request_id UUID, audit.db correlation). Reused verbatim
+# from the OpenClaw stack so this harness can never diverge from it.
+dc_assert_observability() {
+  bash "${DC_E2E_REPO_ROOT}/test/e2e/observability_assertions.sh" \
+    --jsonl "${DC_GATEWAY_JSONL}" \
+    --db "${DC_AUDIT_DB}" \
+    --ts-window-seconds 3600 \
+    --no-require-verdict \
+    "$@"
+}
+
+# dc_assert_otlp <connector> <since_line> — for native_otlp connectors
+# (codex/claudecode/geminicli) assert telemetry tagged with the connector
+# reached the sink. We look for tool_invocation / llm_prompt / llm_response
+# events (the OTLP ingest path emits these) attributed to the connector.
+dc_assert_otlp() {
+  local connector="$1" since="${2:-0}"
+  [ -f "${DC_GATEWAY_JSONL}" ] || return 1
+  python3 - "${DC_GATEWAY_JSONL}" "${connector}" "${since}" <<'PY'
+import json, sys
+path, connector, since = sys.argv[1], sys.argv[2], int(sys.argv[3])
+telemetry = {"tool_invocation", "llm_prompt", "llm_response"}
+fields = ("destination_app", "surface", "aid_surface", "connector")
+found = False
+with open(path, encoding="utf-8") as f:
+    for i, line in enumerate(f, start=1):
+        if i <= since:
+            continue
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except Exception:
+            continue
+        if ev.get("event_type") in telemetry and any(
+            str(ev.get(k, "")).lower() == connector for k in fields
+        ):
+            found = True
+            break
+sys.exit(0 if found else 1)
+PY
+}
+
+# dc_assert_allowed <token> — observe path: the probe command actually ran, so
+# its sentinel marker exists.
+dc_assert_allowed() {
+  if dc_sentinel_present "$1"; then
+    return 0
+  fi
+  dc_err "allow probe did not run (sentinel ${1} absent)"
+  return 1
+}
+
+# dc_assert_blocked <token> <since_line> — block path: the sentinel marker is
+# ABSENT (the command never executed) AND a block verdict was recorded. Both
+# must hold — a missing sentinel alone could be a crashed agent, and a block
+# verdict alone does not prove the tool call was actually prevented.
+dc_assert_blocked() {
+  local token="$1" since="${2:-0}"
+  if dc_sentinel_present "${token}"; then
+    dc_err "block probe RAN (sentinel ${token} present) — enforcement regression"
+    return 1
+  fi
+  if ! dc_assert_verdict_block "${since}"; then
+    dc_err "no block verdict recorded since line ${since} (cannot confirm enforcement)"
+    return 1
+  fi
+  return 0
+}
+
+# dc_assert_teardown <connector> <agent_config_file> — after
+# `defenseclaw-gateway connector teardown`, the agent config no longer
+# references DefenseClaw's hook script. Proves clean uninstall.
+dc_assert_teardown() {
+  local connector="$1" cfg="$2"
+  if [ ! -f "${cfg}" ]; then
+    # Some teardowns remove the file entirely — that is clean.
+    return 0
+  fi
+  if grep -q "defenseclaw" "${cfg}" 2>/dev/null; then
+    dc_err "teardown left a defenseclaw reference in ${cfg}"
+    return 1
+  fi
+  return 0
+}

--- a/scripts/live-connector-e2e/lib/common.sh
+++ b/scripts/live-connector-e2e/lib/common.sh
@@ -1,0 +1,265 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared helpers for the live connector hook E2E harness. Sourced by
+# run.sh, contract-smoke.sh, cursor-validation.sh, and every per-connector
+# driver under drivers/. This file defines functions only — callers own
+# `set -euo pipefail`.
+#
+# Cross-OS note: on Linux/macOS the agent invokes the installed Bash hook
+# script (~/.defenseclaw/hooks/<connector>-hook.sh). On native Windows the
+# agent invokes `defenseclaw-gateway hook --connector <name> --event <ev>`
+# (PR #308). Both forward the stdin event payload to the local gateway, so
+# every assertion below works against ~/.defenseclaw/gateway.jsonl + audit.db
+# regardless of OS.
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+# DC_E2E_LIB_DIR resolves to .../scripts/live-connector-e2e/lib.
+DC_E2E_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DC_E2E_ROOT="$(cd "${DC_E2E_LIB_DIR}/.." && pwd)"
+DC_E2E_REPO_ROOT="$(cd "${DC_E2E_ROOT}/../.." && pwd)"
+DC_E2E_GOLDEN_DIR="${DC_E2E_ROOT}/golden"
+
+# DefenseClaw home (where the gateway writes gateway.jsonl / audit.db and
+# where `defenseclaw setup` installs the hook scripts + .token).
+DEFENSECLAW_HOME="${DEFENSECLAW_HOME:-${HOME}/.defenseclaw}"
+DC_GATEWAY_JSONL="${DEFENSECLAW_HOME}/gateway.jsonl"
+DC_AUDIT_DB="${DEFENSECLAW_HOME}/audit.db"
+
+# Results sink. Every per-event outcome is appended here as one JSON object
+# per line so report.py can roll the matrix up and decide whether to open a
+# connector-regression issue. Defaults to a run-scoped file the workflow
+# uploads as an artifact.
+DC_E2E_RESULTS="${DC_E2E_RESULTS:-${DC_E2E_REPO_ROOT}/connector-live-e2e-results.jsonl}"
+
+# Sentinel side-effect directory. The forced-tool probes write/avoid-writing
+# a marker file here so we can prove enforcement rather than trusting logs.
+DC_E2E_SENTINEL_DIR="${DC_E2E_SENTINEL_DIR:-${TMPDIR:-/tmp}/dc-e2e-sentinels}"
+
+# Per-cell identity (connector + os). Drivers set DC_E2E_CONNECTOR; the OS is
+# derived. These flow into record_result and the job summary.
+DC_E2E_OS="${DC_E2E_OS:-}"
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+dc_log()     { printf '[live-e2e] %s\n' "$*" >&2; }
+dc_warn()    { printf '[live-e2e][warn] %s\n' "$*" >&2; }
+dc_err()     { printf '[live-e2e][error] %s\n' "$*" >&2; }
+dc_section() { printf '\n[live-e2e] ===== %s =====\n' "$*" >&2; }
+
+# dc_die <message> — log and exit non-zero.
+dc_die() { dc_err "$*"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# OS detection
+# ---------------------------------------------------------------------------
+
+# dc_detect_os — echoes linux|macos|windows. Honors DC_E2E_OS override (set by
+# the workflow matrix) so the value matches the runner label exactly.
+dc_detect_os() {
+  if [ -n "${DC_E2E_OS}" ]; then
+    printf '%s' "${DC_E2E_OS}"
+    return 0
+  fi
+  case "$(uname -s 2>/dev/null || echo unknown)" in
+    Linux*)             printf 'linux' ;;
+    Darwin*)            printf 'macos' ;;
+    MINGW*|MSYS*|CYGWIN*) printf 'windows' ;;
+    *)                  printf 'unknown' ;;
+  esac
+}
+
+dc_is_windows() { [ "$(dc_detect_os)" = "windows" ]; }
+
+# ---------------------------------------------------------------------------
+# Gateway lifecycle
+# ---------------------------------------------------------------------------
+
+# dc_wait_for_gateway [timeout_seconds] — poll `defenseclaw-gateway status`
+# until healthy. Mirrors the 30s readiness poll in .github/workflows/e2e.yml
+# so behavior is identical to the OpenClaw stack gate.
+dc_wait_for_gateway() {
+  local timeout="${1:-30}" i
+  for i in $(seq 1 "${timeout}"); do
+    if defenseclaw-gateway status >/dev/null 2>&1; then
+      dc_log "gateway healthy after ${i}s"
+      return 0
+    fi
+    sleep 1
+  done
+  dc_err "gateway did not become healthy within ${timeout}s"
+  dc_dump_gateway_logs
+  return 1
+}
+
+# dc_dump_gateway_logs — tail the sidecar logs for failure triage. Same files
+# the e2e.yml failure path inspects.
+dc_dump_gateway_logs() {
+  local f
+  for f in gateway.log gateway.jsonl watchdog.log; do
+    if [ -f "${DEFENSECLAW_HOME}/${f}" ]; then
+      dc_log "--- ${f} (tail) ---"
+      tail -n 80 "${DEFENSECLAW_HOME}/${f}" >&2 2>/dev/null || true
+    fi
+  done
+}
+
+# dc_gateway_jsonl_count — number of JSONL events currently on disk. Used to
+# bound assertions to "events emitted since the probe" rather than the whole
+# file.
+dc_gateway_jsonl_count() {
+  if [ -f "${DC_GATEWAY_JSONL}" ]; then
+    wc -l < "${DC_GATEWAY_JSONL}" | tr -d ' '
+  else
+    printf '0'
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Version capture
+# ---------------------------------------------------------------------------
+
+# dc_capture_version <connector> <cmd> [args...] — resolve and record the
+# upstream agent version. Tolerant of agents that print to stderr or use a
+# non-standard flag; never fails the run on a version-probe error.
+dc_capture_version() {
+  local connector="$1"; shift
+  local raw
+  raw="$("$@" 2>&1 | head -n 3 | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g')" || raw="unknown"
+  [ -n "${raw}" ] || raw="unknown"
+  dc_log "resolved ${connector} version: ${raw}"
+  printf '%s' "${raw}"
+}
+
+# ---------------------------------------------------------------------------
+# Sentinel side-effects (real-enforcement proof)
+# ---------------------------------------------------------------------------
+
+# dc_new_sentinel_token — unique token for one probe, namespaced to the cell.
+dc_new_sentinel_token() {
+  printf 'dc-%s-%s-%s' "${DC_E2E_CONNECTOR:-x}" "$(dc_detect_os)" "$(date +%s)$RANDOM"
+}
+
+# dc_sentinel_path <token> — absolute path of the marker file for a token.
+dc_sentinel_path() {
+  mkdir -p "${DC_E2E_SENTINEL_DIR}"
+  printf '%s/%s.marker' "${DC_E2E_SENTINEL_DIR}" "$1"
+}
+
+# dc_sentinel_present <token> — true if the probe's command actually ran.
+dc_sentinel_present() { [ -e "$(dc_sentinel_path "$1")" ]; }
+
+# dc_clear_sentinels — wipe markers between probes.
+dc_clear_sentinels() { rm -rf "${DC_E2E_SENTINEL_DIR}" 2>/dev/null || true; }
+
+# ---------------------------------------------------------------------------
+# Result recording
+# ---------------------------------------------------------------------------
+
+# dc_record_result <event> <status> [detail] — append one matrix cell outcome.
+# status is one of: pass | fail | skip. DC_E2E_CONNECTOR + version come from
+# the driver context. Also mirrors a human line to $GITHUB_STEP_SUMMARY.
+dc_record_result() {
+  local event="$1" status="$2" detail="${3:-}"
+  local connector="${DC_E2E_CONNECTOR:-unknown}"
+  local os; os="$(dc_detect_os)"
+  local version="${DC_E2E_AGENT_VERSION:-unknown}"
+  mkdir -p "$(dirname "${DC_E2E_RESULTS}")"
+  python3 - "$connector" "$os" "$event" "$status" "$version" "$detail" >> "${DC_E2E_RESULTS}" <<'PY'
+import json, sys
+connector, os_, event, status, version, detail = sys.argv[1:7]
+print(json.dumps({
+    "connector": connector,
+    "os": os_,
+    "event": event,
+    "status": status,
+    "version": version,
+    "detail": detail,
+}))
+PY
+  local glyph="PASS"
+  case "${status}" in
+    fail) glyph="FAIL" ;;
+    skip) glyph="SKIP" ;;
+  esac
+  dc_log "[${glyph}] ${connector}/${os}/${event} ${detail}"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '| %s | %s | %s | %s | %s |\n' \
+      "${connector}" "${os}" "${event}" "${glyph}" "${detail//|/\\|}" \
+      >> "${GITHUB_STEP_SUMMARY}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Log staging (artifact upload on failure)
+# ---------------------------------------------------------------------------
+
+# dc_stage_logs <stage_dir> — copy gateway logs + the results JSONL into a
+# directory the workflow uploads with actions/upload-artifact. Mirrors the
+# "Stage DefenseClaw logs" step in e2e.yml.
+dc_stage_logs() {
+  local stage="${1:-${TMPDIR:-/tmp}/defenseclaw-live-e2e-logs}"
+  rm -rf "${stage}"; mkdir -p "${stage}"
+  if [ -d "${DEFENSECLAW_HOME}" ]; then
+    local pat
+    for pat in '*.log' '*.jsonl' 'config.yaml'; do
+      find "${DEFENSECLAW_HOME}" -maxdepth 2 -type f -name "${pat}" \
+        -exec cp {} "${stage}/" \; 2>/dev/null || true
+    done
+  fi
+  cp "${DC_E2E_RESULTS}" "${stage}/" 2>/dev/null || true
+  dc_log "staged logs in ${stage}"
+  printf '%s' "${stage}"
+}
+
+# ---------------------------------------------------------------------------
+# Hook entrypoint (cross-OS)
+# ---------------------------------------------------------------------------
+
+# dc_hook_script <connector> — installed Bash hook path for unix. The claude
+# connector's script is named claude-code-hook.sh; everything else follows
+# <connector>-hook.sh (see internal/gateway/connector/hooks/ + cmd_setup.py).
+dc_hook_script() {
+  local connector="$1" base
+  case "${connector}" in
+    claudecode) base="claude-code-hook.sh" ;;
+    *)          base="${connector}-hook.sh" ;;
+  esac
+  printf '%s/hooks/%s' "${DEFENSECLAW_HOME}" "${base}"
+}
+
+# dc_invoke_hook <connector> <event> <payload_file> — feed a golden event
+# payload into the installed hook entrypoint and echo "exit:<code>" on the
+# last line so callers can assert verdict shaping. On Windows this targets the
+# native `defenseclaw-gateway hook` subcommand instead of the Bash script.
+#
+# Stdout of the hook (the agent-native decision JSON) is forwarded verbatim
+# before the trailing exit line.
+dc_invoke_hook() {
+  local connector="$1" event="$2" payload="$3" code out
+  if dc_is_windows; then
+    out="$(defenseclaw-gateway hook --connector "${connector}" --event "${event}" < "${payload}" 2>&1)" && code=0 || code=$?
+  else
+    local script; script="$(dc_hook_script "${connector}")"
+    if [ ! -x "${script}" ]; then
+      dc_err "hook script not found/executable: ${script}"
+      printf 'exit:127\n'
+      return 0
+    fi
+    out="$(bash "${script}" < "${payload}" 2>&1)" && code=0 || code=$?
+  fi
+  printf '%s\n' "${out}"
+  printf 'exit:%s\n' "${code}"
+}

--- a/scripts/live-connector-e2e/lib/setup.sh
+++ b/scripts/live-connector-e2e/lib/setup.sh
@@ -1,0 +1,87 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# DefenseClaw bootstrap + per-connector setup/teardown helpers shared by the
+# contract-smoke and live drivers. Mirrors the init/setup/health/teardown flow
+# in .github/workflows/e2e.yml but parameterized per hook connector.
+
+# dc_setup_subcommand <connector> — map a registry connector name to its
+# `defenseclaw setup` subcommand. Only claude diverges (claude-code); every
+# other hook connector's subcommand equals its registry name.
+dc_setup_subcommand() {
+  case "$1" in
+    claudecode) printf 'claude-code' ;;
+    *)          printf '%s' "$1" ;;
+  esac
+}
+
+# dc_connector_config_file <connector> — the agent-side config file
+# `defenseclaw setup` patches, used by the teardown assertion. Paths mirror
+# the *PathOverride defaults in internal/gateway/connector and cmd_setup.py.
+dc_connector_config_file() {
+  case "$1" in
+    codex)       printf '%s/.codex/config.toml' "${HOME}" ;;
+    claudecode)  printf '%s/.claude/settings.json' "${HOME}" ;;
+    geminicli)   printf '%s/.gemini/settings.json' "${HOME}" ;;
+    cursor)      printf '%s/.cursor/hooks.json' "${HOME}" ;;
+    windsurf)    printf '%s/.codeium/windsurf/hooks.json' "${HOME}" ;;
+    copilot)     printf '%s/.copilot/hooks/defenseclaw.json' "${HOME}" ;;
+    openhands)   printf '%s/.openhands/hooks.json' "${HOME}" ;;
+    antigravity) printf '%s/.gemini/config/hooks.json' "${HOME}" ;;
+    hermes)      printf '%s/.hermes/config.yaml' "${HOME}" ;;
+    *)           printf '' ;;
+  esac
+}
+
+# dc_write_env_key <KEY> <VALUE> — idempotently append an env line to
+# ~/.defenseclaw/.env (consumed by the gateway + hook scripts). No-op on empty
+# value so a missing optional secret never writes a blank line.
+dc_write_env_key() {
+  local key="$1" value="$2"
+  [ -n "${value}" ] || return 0
+  mkdir -p "${DEFENSECLAW_HOME}"
+  touch "${DEFENSECLAW_HOME}/.env"
+  if grep -q "^${key}=" "${DEFENSECLAW_HOME}/.env" 2>/dev/null; then
+    return 0
+  fi
+  printf '%s=%s\n' "${key}" "${value}" >> "${DEFENSECLAW_HOME}/.env"
+}
+
+# dc_init_defenseclaw — run `defenseclaw init` once and stand up the gateway.
+# Idempotent: re-running against an initialized home is a no-op for config.
+dc_init_defenseclaw() {
+  if [ ! -f "${DEFENSECLAW_HOME}/config.yaml" ]; then
+    dc_log "running defenseclaw init"
+    defenseclaw init
+  else
+    dc_log "defenseclaw already initialized at ${DEFENSECLAW_HOME}"
+  fi
+}
+
+# dc_setup_connector <connector> <mode> — install DefenseClaw into the
+# connector via its setup subcommand and wait for the gateway to come back
+# healthy. mode is observe|action. --restart wires hook scripts + OTel block.
+dc_setup_connector() {
+  local connector="$1" mode="${2:-action}" sub
+  sub="$(dc_setup_subcommand "${connector}")"
+  dc_log "defenseclaw setup ${sub} --mode ${mode} --restart"
+  defenseclaw setup "${sub}" --yes --mode "${mode}" --restart
+  dc_wait_for_gateway 30
+}
+
+# dc_teardown_connector <connector> — remove the connector's config patches
+# and verify no residual state. Returns the verify exit code (0 = clean).
+dc_teardown_connector() {
+  local connector="$1"
+  dc_log "tearing down ${connector}"
+  defenseclaw-gateway connector teardown --connector "${connector}" || \
+    dc_warn "teardown command returned non-zero for ${connector}"
+  defenseclaw-gateway connector verify --connector "${connector}"
+}

--- a/scripts/live-connector-e2e/report.py
+++ b/scripts/live-connector-e2e/report.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Connector live-E2E reporter / regression radar (alert-only).
+#
+# Reads the per-cell result JSONL files produced by lib/common.sh
+# (dc_record_result) — one JSON object per line:
+#
+#     {"connector","os","event","status","version","detail"}
+#
+# and:
+#   1. Renders a connector x os x event matrix to the GitHub job summary.
+#   2. Records the resolved upstream version per connector x os.
+#   3. On ANY failing cell, builds a regression issue body and (when
+#      --open-issue is passed and gh is authenticated) opens or updates a
+#      GitHub issue labeled `connector-regression`.
+#   4. Exits non-zero when failures exist so the report job is red — but it
+#      NEVER edits validated_versions.json or hook_contracts.json. Bumping a
+#      validated/approved version is a deliberate human action.
+
+from __future__ import annotations
+
+import argparse
+import collections
+import datetime
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ISSUE_LABEL = "connector-regression"
+ISSUE_TITLE = "Connector live E2E regression"
+
+
+def load_results(results_dir: Path) -> list[dict]:
+    rows: list[dict] = []
+    for path in sorted(results_dir.rglob("*.jsonl")):
+        try:
+            with path.open(encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rows.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        except OSError:
+            continue
+    return rows
+
+
+def summarize(rows: list[dict]):
+    """Return (cells, versions, failures).
+
+    cells:    {(connector, os): {event: status}}
+    versions: {(connector, os): version}
+    failures: list[(connector, os, event, detail)]
+    """
+    cells: dict[tuple[str, str], dict[str, str]] = collections.defaultdict(dict)
+    versions: dict[tuple[str, str], str] = {}
+    failures: list[tuple[str, str, str, str]] = []
+    for r in rows:
+        key = (r.get("connector", "?"), r.get("os", "?"))
+        event = r.get("event", "?")
+        status = r.get("status", "?")
+        cells[key][event] = status
+        v = r.get("version") or ""
+        if v and v != "unknown":
+            versions.setdefault(key, v)
+        if status == "fail":
+            failures.append((key[0], key[1], event, r.get("detail", "")))
+    return cells, versions, failures
+
+
+def render_summary(cells, versions) -> str:
+    lines = ["# Connector live E2E results", ""]
+    lines.append("| Connector | OS | Version | Result | Events (pass/fail/skip) |")
+    lines.append("|---|---|---|---|---|")
+    for (connector, os_), events in sorted(cells.items()):
+        n_pass = sum(1 for s in events.values() if s == "pass")
+        n_fail = sum(1 for s in events.values() if s == "fail")
+        n_skip = sum(1 for s in events.values() if s == "skip")
+        verdict = "FAIL" if n_fail else ("PASS" if n_pass else "SKIP")
+        version = versions.get((connector, os_), "unknown")
+        lines.append(
+            f"| {connector} | {os_} | {version} | {verdict} | "
+            f"{n_pass}/{n_fail}/{n_skip} |"
+        )
+    lines.append("")
+    failing_events = [
+        (c, o, e)
+        for (c, o), events in cells.items()
+        for e, s in events.items()
+        if s == "fail"
+    ]
+    if failing_events:
+        lines.append("## Failing events")
+        lines.append("")
+        for c, o, e in sorted(failing_events):
+            lines.append(f"- `{c}` / `{o}` / `{e}`")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def build_issue_body(failures, versions, run_url: str) -> str:
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    lines = [
+        "A live connector hook E2E cell that previously passed is now failing "
+        "against the latest upstream agent release.",
+        "",
+        f"- Detected: {now}",
+        f"- Run: {run_url or 'n/a'}",
+        "",
+        "## Failing cells",
+        "",
+        "| Connector | OS | Event | Version | Detail |",
+        "|---|---|---|---|---|",
+    ]
+    for connector, os_, event, detail in sorted(failures):
+        version = versions.get((connector, os_), "unknown")
+        safe_detail = (detail or "").replace("|", "\\|")
+        lines.append(f"| {connector} | {os_} | {event} | {version} | {safe_detail} |")
+    lines += [
+        "",
+        "## Next steps (alert-only — no automatic version bump)",
+        "",
+        "1. Triage whether DefenseClaw's decode/map/respond needs a fix, or the "
+        "upstream agent changed its hook contract.",
+        "2. If DefenseClaw must drop support for the new version, set "
+        "`max_exclusive` (or raise `min_inclusive`) in "
+        "`cli/defenseclaw/inventory/hook_contracts.json` and "
+        "`internal/gateway/connector/hook_contract.go`.",
+        "3. Once green again, update `last_validated_version` in "
+        "`cli/defenseclaw/inventory/validated_versions.json`.",
+    ]
+    return "\n".join(lines)
+
+
+def gh(*args: str) -> tuple[int, str]:
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return proc.returncode, (proc.stdout + proc.stderr)
+    except FileNotFoundError:
+        return 127, "gh CLI not found"
+
+
+def open_or_update_issue(body: str, run_url: str) -> None:
+    """Open a new connector-regression issue or comment on the existing one."""
+    rc, out = gh(
+        "issue", "list",
+        "--label", ISSUE_LABEL,
+        "--state", "open",
+        "--json", "number",
+        "--limit", "1",
+    )
+    if rc != 0:
+        print(f"[report] could not list issues (gh rc={rc}): {out}", file=sys.stderr)
+        return
+    try:
+        existing = json.loads(out or "[]")
+    except json.JSONDecodeError:
+        existing = []
+    if existing:
+        number = str(existing[0]["number"])
+        rc, out = gh("issue", "comment", number, "--body", body)
+        print(f"[report] commented on issue #{number} (rc={rc})")
+    else:
+        rc, out = gh(
+            "issue", "create",
+            "--title", f"{ISSUE_TITLE} ({datetime.date.today().isoformat()})",
+            "--label", ISSUE_LABEL,
+            "--body", body,
+        )
+        print(f"[report] created regression issue (rc={rc}): {out.strip()}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--results-dir", type=Path, required=True,
+                        help="Directory of per-cell *.jsonl result files (artifacts).")
+    parser.add_argument("--summary-file", type=Path,
+                        default=Path(os.environ["GITHUB_STEP_SUMMARY"])
+                        if os.environ.get("GITHUB_STEP_SUMMARY") else None,
+                        help="Markdown summary output (default: $GITHUB_STEP_SUMMARY).")
+    parser.add_argument("--open-issue", action="store_true",
+                        help="Open/update a connector-regression issue on failure.")
+    parser.add_argument("--run-url", default=os.environ.get("RUN_URL", ""))
+    args = parser.parse_args()
+
+    if not args.results_dir.exists():
+        print(f"[report] results dir {args.results_dir} missing — no cells ran?",
+              file=sys.stderr)
+        return 0
+
+    rows = load_results(args.results_dir)
+    if not rows:
+        print("[report] no result rows found; nothing to report.", file=sys.stderr)
+        return 0
+
+    cells, versions, failures = summarize(rows)
+    summary = render_summary(cells, versions)
+    print(summary)
+    if args.summary_file:
+        try:
+            with args.summary_file.open("a", encoding="utf-8") as f:
+                f.write(summary + "\n")
+        except OSError as exc:
+            print(f"[report] could not write summary: {exc}", file=sys.stderr)
+
+    if failures:
+        body = build_issue_body(failures, versions, args.run_url)
+        print("\n----- regression issue body -----\n" + body, file=sys.stderr)
+        if args.open_issue:
+            open_or_update_issue(body, args.run_url)
+        return 1
+
+    print("[report] all cells green.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/live-connector-e2e/run.sh
+++ b/scripts/live-connector-e2e/run.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Orchestrator for the live connector hook E2E harness. The workflow invokes
+# one cell at a time (one connector x one OS), but this dispatcher also
+# supports `--connector all` for local runs.
+#
+#   run.sh --layer contract --connector <name|all>   # Layer A entrypoint smoke
+#   run.sh --layer live     --connector <name|all>   # Layer B live agent
+#
+# Layer A targets every registry connector (golden payload -> installed hook
+# entrypoint). Layer B only targets connectors that ship a driver under
+# drivers/; contract-only connectors (hermes, windsurf, antigravity) are
+# skipped with a recorded `skip` so the matrix stays honest.
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${HERE}/lib/common.sh"
+
+LAYER=""
+CONNECTOR=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --layer)     LAYER="$2"; shift 2 ;;
+    --connector) CONNECTOR="$2"; shift 2 ;;
+    --os)        DC_E2E_OS="$2"; export DC_E2E_OS; shift 2 ;;
+    -h|--help)
+      sed -n '12,30p' "$0"; exit 0 ;;
+    *) dc_die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "${LAYER}" ]     || dc_die "--layer contract|live is required"
+[ -n "${CONNECTOR}" ] || dc_die "--connector <name|all> is required"
+
+# Registry connectors (Layer A covers all; Layer B covers those with drivers).
+ALL_CONNECTORS=(codex claudecode geminicli cursor copilot openhands hermes windsurf antigravity)
+
+resolve_connectors() {
+  if [ "${CONNECTOR}" = "all" ]; then
+    printf '%s\n' "${ALL_CONNECTORS[@]}"
+  else
+    printf '%s\n' "${CONNECTOR}"
+  fi
+}
+
+run_contract() {
+  local c="$1"
+  bash "${HERE}/contract-smoke.sh" "${c}"
+}
+
+run_live() {
+  local c="$1" driver="${HERE}/drivers/${c}.sh"
+  if [ ! -f "${driver}" ]; then
+    DC_E2E_CONNECTOR="${c}" dc_record_result "live" skip "contract-only connector (no live driver)"
+    return 0
+  fi
+  bash "${driver}"
+}
+
+overall=0
+while read -r c; do
+  [ -n "${c}" ] || continue
+  case "${LAYER}" in
+    contract) run_contract "${c}" || overall=1 ;;
+    live)     run_live "${c}"     || overall=1 ;;
+    *)        dc_die "unknown layer: ${LAYER} (use contract|live)" ;;
+  esac
+done < <(resolve_connectors)
+
+# Always stage logs so the workflow can upload them as an artifact.
+dc_stage_logs "${TMPDIR:-/tmp}/defenseclaw-live-e2e-logs" >/dev/null || true
+
+exit "${overall}"

--- a/test/e2e/connectormatrix.go
+++ b/test/e2e/connectormatrix.go
@@ -139,6 +139,12 @@ func connectorMatrix(t *testing.T) []ConnectorFixture {
 			ClawMode:       "openhands",
 			Apply:          hookOnlyFixtureApply("openhands"),
 		},
+		{
+			Name:           "antigravity",
+			DestinationApp: "antigravity",
+			ClawMode:       "antigravity",
+			Apply:          hookOnlyFixtureApply("antigravity"),
+		},
 	}
 }
 
@@ -171,6 +177,10 @@ func hookOnlyFixtureApply(name string) func(t *testing.T) (string, string) {
 			prev := connector.OpenHandsHooksPathOverride
 			connector.OpenHandsHooksPathOverride = filepath.Join(home, "workspace", ".openhands", "hooks.json")
 			t.Cleanup(func() { connector.OpenHandsHooksPathOverride = prev })
+		case "antigravity":
+			prev := connector.AntigravityHooksPathOverride
+			connector.AntigravityHooksPathOverride = filepath.Join(home, ".gemini", "config", "hooks.json")
+			t.Cleanup(func() { connector.AntigravityHooksPathOverride = prev })
 		}
 		return home, t.TempDir()
 	}

--- a/test/e2e/testdata/v7/golden/antigravity/verdict-blocked.golden.json
+++ b/test/e2e/testdata/v7/golden/antigravity/verdict-blocked.golden.json
@@ -1,0 +1,16 @@
+{
+  "binary_version": "\u003cstripped\u003e",
+  "content_hash": "\u003cstripped\u003e",
+  "event_type": "verdict",
+  "generation": 1,
+  "schema_version": 7,
+  "severity": "HIGH",
+  "sidecar_instance_id": "\u003cstripped\u003e",
+  "ts": "2000-01-01T00:00:00Z",
+  "verdict": {
+    "action": "block",
+    "latency_ms": 1,
+    "reason": "test",
+    "stage": "final"
+  }
+}


### PR DESCRIPTION
## Problem

When an upstream agent (Codex, Claude Code, Gemini CLI, …) ships a new
release, it can silently change the hook contract DefenseClaw relies on —
the event names, the stdin payload shape, the permission/deny semantics, or
the telemetry surface. Today there is no automated signal that a fresh
upstream version still fires the hooks we decode, still honors a `block`
verdict, and still tears down cleanly. A regression would only be noticed
when a user upgrades their agent and enforcement quietly stops working.

There is also no per-OS proof that the *installed* hook entrypoint behaves
identically on Linux, macOS, and native Windows.

## Current Situation

- `internal/gateway/agent_hook_e2e_test.go` and the `test/e2e` matrices
  exercise the gateway's hook handling with synthetic in-process payloads,
  but nothing installs a real upstream agent, runs `defenseclaw setup`, and
  drives the agent's own harness to confirm the hooks fire from the outside.
- `e2e.yml` is the stack gate; piggy-backing flaky, secret-dependent live
  agent runs onto it would let an upstream break block unrelated merges.
- The connector inventory has no record of the highest agent version each
  connector has actually been validated against.
- `antigravity` was absent from the cross-OS golden parity fixtures.

## Solution

Add a **separate** workflow (`connector-live-e2e.yml`) so it can go red on an
upstream break without blocking the stack gate. It has two independent
layers and an alert-only reporter:

1. **Contract matrix** — deterministic, no LLM, no secrets, every OS. Feeds
   golden stdin payloads into the *installed* hook entrypoint (the connector
   hook script on unix, `defenseclaw-gateway hook` on Windows) and asserts
   the gateway received the event, the verdict was shaped correctly, and
   teardown is clean. Cheap and fork-safe; a candidate to promote to a
   required check later.
2. **Live agent matrix** — installs the real upstream agent, runs
   `defenseclaw setup`, drives lifecycle + forced tool calls through the
   real harness, and asserts observe / block / OTLP / teardown via
   `gateway.jsonl`, `audit.db`, and filesystem **sentinel side-effects** (a
   blocked `cat /etc/shadow` must leave no marker). Needs provider secrets,
   so it never runs for fork PRs.
3. **Reporter / regression radar** — rolls every cell into the job summary,
   records the resolved upstream version, and opens/updates a
   `connector-regression` issue on any failure. **Alert-only**: it never
   auto-bumps a version. Setting the highest approved version stays a
   deliberate human edit of `validated_versions.json`.

**Why two layers instead of one:** the contract layer gives fast, secret-free,
all-OS coverage of the wiring; the live layer proves the real harness still
fires it. Keeping them separate means PR-time gating can adopt the cheap
deterministic layer while the expensive live layer stays nightly/manual.

**Scope choices (deliberate, see Open Issues):**
- The live layer is **manual-dispatch-only** right now; the nightly schedule
  runs the contract layer alone until live secrets are in place.
- The live layer is scoped to the connectors authenticatable today — Codex,
  Claude Code, OpenHands. Drivers support **Azure OpenAI** (Codex, OpenHands)
  and **Amazon Bedrock** (Claude Code, OpenHands) via `DC_USE_AZURE` /
  `DC_USE_BEDROCK`. Gemini CLI, Cursor, and Copilot are deferred until their
  native keys exist (no Azure/Bedrock substitute) but keep full contract
  coverage.
- Contract-only connectors (Hermes, Windsurf, Antigravity) have no headless
  CLI that fires hooks, so they are intentionally absent from the live layer.

## Architecture Diagram

```
Before:
 ┌─────────────────────┐  synthetic payload   ┌───────────────┐
 │ agent_hook_e2e_test │─────────────────────▶│ gateway hook  │
 │ test/e2e matrices   │   (in-process)        │ handler       │
 └─────────────────────┘                       └───────────────┘
   (no real agent, no per-OS installed entrypoint, no upstream version)

After (new, separate from e2e.yml stack gate):
 ┌───────────────────────── connector-live-e2e.yml ─────────────────────────┐
 │                                                                           │
 │  Contract matrix (no secrets, all OS)      Live matrix (secrets, manual)  │
 │  ┌──────────────────────────┐              ┌──────────────────────────┐   │
 │  │ golden stdin payloads     │              │ install upstream agent    │   │
 │  │   │                       │              │ defenseclaw setup         │   │
 │  │   ▼                       │              │   │                       │   │
 │  │ installed hook entrypoint │              │ real agent harness        │   │
 │  │  (hook.sh | gw hook)      │              │  (codex/claude/openhands) │   │
 │  └───────────┬──────────────┘              └───────────┬──────────────┘   │
 │              ▼                                          ▼                  │
 │        DefenseClaw gateway  ◀── gateway.jsonl / audit.db / OTLP ──▶        │
 │              │                                          │                  │
 │              └──────────────────┬───────────────────────┘                  │
 │                                 ▼                                          │
 │                   report.py → job summary + connector-regression issue     │
 │                   (alert-only; never edits validated_versions.json)        │
 └───────────────────────────────────────────────────────────────────────────┘
```

## Flow Diagram

```
Contract cell (per connector × OS):
  build DC ──▶ defenseclaw setup <c> ──▶ feed golden payload to entrypoint
                                          │
                                          ▼
                            assert event in gateway.jsonl
                            assert verdict shape (allow/block)
                            defenseclaw teardown ──▶ assert clean

Live cell (manual dispatch, secrets present):
  install agent ──▶ defenseclaw setup <c> --restart ──▶ run headless prompt
       │                                                     │
       │                                  ┌──────────────────┤
       ▼                                  ▼                  ▼
   capture version              allow probe           block probe
                                  │                     │ (cat /etc/shadow)
                                  ▼                     ▼
                         sentinel CREATED        sentinel ABSENT + block
                         + event fired           verdict in audit.db
                                  └─────────┬───────────┘
                                            ▼
                                  dc_record_result → results.jsonl
                                            ▼
                              report.py aggregates → issue on fail
```

## What Changed (Where & How)

| File | Change Type | Summary |
|---|---|---|
| `.github/workflows/connector-live-e2e.yml` | added | New workflow: contract-matrix (9×3), live-matrix (manual, Codex/Claude/OpenHands), report. Nightly schedule runs contract only; live is dispatch-only. Plumbs Azure/Bedrock creds + `DC_USE_AZURE`/`DC_USE_BEDROCK`. |
| `scripts/live-connector-e2e/run.sh` | added | Orchestrator: `--layer contract|live --connector <name|all>`. |
| `scripts/live-connector-e2e/contract-smoke.sh` | added | Layer-A driver: setup → feed each golden payload to the installed entrypoint → assert fire/verdict/teardown. |
| `scripts/live-connector-e2e/lib/common.sh` | added | Gateway-health poll, cross-OS hook invocation, sentinel helpers, version capture, result recording, log staging. |
| `scripts/live-connector-e2e/lib/assert.sh` | added | gateway.jsonl / audit.db / OTLP assertions and sentinel allow/block checks. |
| `scripts/live-connector-e2e/lib/setup.sh` | added | `defenseclaw init/setup/teardown` helpers + per-connector config paths. |
| `scripts/live-connector-e2e/drivers/_driver_common.sh` | added | Shared live orchestration: install → setup → standard allow/block probes. |
| `scripts/live-connector-e2e/drivers/codex.sh` | added | Codex live driver; OpenAI default + Azure OpenAI path (`[model_providers.azure]`). |
| `scripts/live-connector-e2e/drivers/claudecode.sh` | added | Claude Code live driver; Anthropic default + Bedrock path (`CLAUDE_CODE_USE_BEDROCK`). |
| `scripts/live-connector-e2e/drivers/openhands.sh` | added | OpenHands (Linux/Docker) live driver; OpenAI default + Azure + Bedrock via LiteLLM. |
| `scripts/live-connector-e2e/drivers/geminicli.sh` | added | Gemini CLI live driver (deferred from live matrix; retained for re-enable). |
| `scripts/live-connector-e2e/drivers/cursor.sh` | added | Cursor live driver (deferred; gated on a headless-hook validation). |
| `scripts/live-connector-e2e/drivers/copilot.sh` | added | Copilot CLI live driver (deferred). |
| `scripts/live-connector-e2e/cursor-validation.sh` | added | One-time check that headless `cursor-agent -p` actually fires `~/.cursor/hooks.json`. |
| `scripts/live-connector-e2e/golden/<connector>/*.json` | added | Golden stdin payloads (session_start / pre_tool_allow / pre_tool_block) for all 9 connectors. |
| `scripts/live-connector-e2e/report.py` | added | Aggregates results, renders summary, opens/updates `connector-regression` issue; never bumps versions. |
| `cli/defenseclaw/inventory/validated_versions.json` | added | Human-edited highest-validated version per connector × OS. |
| `test/e2e/connectormatrix.go` | modified | Register `antigravity` fixture + `~/.gemini/config/hooks.json` path override. |
| `test/e2e/testdata/v7/golden/antigravity/verdict-blocked.golden.json` | test | Golden fixture so `TestGoldenPerConnectorLayout` covers antigravity. |
| `docs/CONNECTOR-MATRIX.md` | docs | New "Live E2E coverage" section: two-layer model, per-connector reality matrix, Azure/Bedrock auth options, alert-only version policy, current rollout note. |

## Open Issues / Follow-ups

- **Native Windows live execution depends on #308** (this branch's base —
  the `defenseclaw-gateway hook` subcommand). All Windows live cells run
  advisory (`continue-on-error`) until that lands and they go green.
- **Live layer is manual-dispatch-only** and the nightly schedule runs the
  contract layer alone — intentional until live provider secrets are
  configured. Restore the `schedule`/PR trigger on `live-matrix` to enable
  nightly live runs.
- **Gemini CLI / Cursor / Copilot live cells are deferred** pending
  `GOOGLE_API_KEY` / `CURSOR_API_KEY` / `COPILOT_CLI_TOKEN` (no Azure/Bedrock
  substitute). Their drivers and golden payloads are committed; re-add their
  matrix cells when the keys exist. They retain full contract coverage now.
- **Cursor live coverage** is additionally gated on `cursor-validation.sh`
  confirming headless hooks fire; if they do not, Cursor stays contract-only.
- **Copilot** uses user-level hooks only and starts advisory everywhere.
- Azure deployments for Codex must be Responses-API-capable, or
  `wire_api = "responses"` calls 404.

## Test Plan

Static / local validation performed on this branch:

- `bash -n` on every script under `scripts/live-connector-e2e/` → clean.
- `python3 -m py_compile scripts/live-connector-e2e/report.py` → clean; verified
  it returns 0 with no/contract-only results and 1 with a failing cell.
- Workflow YAML parsed: 3 jobs; contract-matrix = 9 connectors × 3 OSes (27
  cells); live-matrix = 7 cells (Codex×3, Claude×3, OpenHands×1), `if`
  dispatch-only; 6 dispatch inputs incl. `use_azure`/`use_bedrock`.
- All golden payloads and `validated_versions.json` parsed as valid JSON.
- `go vet ./test/e2e/` → clean; Azure base-URL normalization checked
  idempotent across endpoint shapes.

Not yet exercised in CI (requires merge + secrets):

- A real contract-matrix run on hosted Linux/macOS/Windows runners.
- A real live-matrix dispatch for Codex/Claude/OpenHands with Azure/Bedrock
  credentials (and the Windows native entrypoint from #308).

Suggested first validation after merge: dispatch with
`connector=codex, os=linux, use_azure=true` (or `claudecode` + `use_bedrock`)
and confirm a `connector-regression` issue is *not* opened on green.