### PR TITLE
feat(gateway): wire Bifrost ExtraHeaders from overlay and LLM config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -340,6 +340,11 @@ type LLMConfig struct {
 	// Azure holds optional per-role Azure OpenAI posture. Same merge
 	// semantics as Bedrock.
 	Azure *AzureKeyConfig `mapstructure:"azure"   yaml:"azure,omitempty"`
+
+	// ExtraHeaders are additional HTTP headers sent on every request to
+	// this provider (e.g. {"llm-model": "gpt-5-5"} for Circuit routing).
+	// Forwarded to Bifrost's NetworkConfig.ExtraHeaders.
+	ExtraHeaders map[string]string `mapstructure:"extra_headers" yaml:"extra_headers,omitempty"`
 }
 
 // TLSConfig captures per-instance TLS overrides on a role-level

--- a/internal/configs/embed.go
+++ b/internal/configs/embed.go
@@ -81,6 +81,11 @@ type Provider struct {
 	// Azure holds per-instance Azure OpenAI posture (endpoint / API
 	// version / auth / deployment aliases). Same omitempty semantics.
 	Azure *ProviderAzure `json:"azure,omitempty"`
+
+	// ExtraHeaders are additional HTTP headers sent on every request to
+	// this provider (e.g. {"llm-model": "gpt-5-5"} for Circuit routing).
+	// Forwarded to Bifrost's NetworkConfig.ExtraHeaders.
+	ExtraHeaders map[string]string `json:"extra_headers,omitempty"`
 }
 
 // ProviderTLS describes how the gateway should validate the provider's

--- a/internal/gateway/provider.go
+++ b/internal/gateway/provider.go
@@ -349,6 +349,7 @@ func buildProviderFromEffective(llm *config.LLMConfig, inst *configs.Provider) (
 		}
 	}
 
+	extraHeaders := llm.ExtraHeaders
 	if inst != nil {
 		if baseURL == "" {
 			baseURL = strings.TrimRight(inst.BaseURL, "/")
@@ -361,6 +362,9 @@ func buildProviderFromEffective(llm *config.LLMConfig, inst *configs.Provider) (
 				CACertPEM:          inst.TLS.CACertPEM,
 				InsecureSkipVerify: inst.TLS.InsecureSkipVerify,
 			}
+		}
+		if len(inst.ExtraHeaders) > 0 && len(extraHeaders) == 0 {
+			extraHeaders = inst.ExtraHeaders
 		}
 		if effBedrock == nil && inst.Bedrock != nil {
 			effBedrock = &config.BedrockKeyConfig{
@@ -418,14 +422,15 @@ func buildProviderFromEffective(llm *config.LLMConfig, inst *configs.Provider) (
 	}
 
 	return &bifrostProvider{
-		providerKey: providerKey,
-		model:       modelID,
-		apiKey:      apiKey,
-		baseURL:     baseURL,
-		tls:         tls,
-		bedrock:     effBedrock,
-		vertex:      effVertex,
-		azure:       effAzure,
+		providerKey:  providerKey,
+		model:        modelID,
+		apiKey:       apiKey,
+		baseURL:      baseURL,
+		tls:          tls,
+		extraHeaders: extraHeaders,
+		bedrock:      effBedrock,
+		vertex:       effVertex,
+		azure:        effAzure,
 	}, nil
 }
 

--- a/internal/gateway/provider_bifrost.go
+++ b/internal/gateway/provider_bifrost.go
@@ -39,11 +39,12 @@ import (
 // endpoints, regional posture, and TLS posture for one tenant are isolated
 // from other in-flight requests.
 type bifrostProvider struct {
-	providerKey schemas.ModelProvider
-	model       string
-	apiKey      string
-	baseURL     string
-	tls         tlsOverrides
+	providerKey  schemas.ModelProvider
+	model        string
+	apiKey       string
+	baseURL      string
+	tls          tlsOverrides
+	extraHeaders map[string]string
 	// Effective per-provider sub-blocks (role wins, overlay fills
 	// blanks; see NewProviderForLLMConfig). Pointer-typed so an
 	// absent block contributes nothing to the Bifrost Key.
@@ -188,6 +189,7 @@ func newTenantAccount(
 	bedrock *config.BedrockKeyConfig,
 	vertex *config.VertexKeyConfig,
 	azure *config.AzureKeyConfig,
+	extraHeaders map[string]string,
 ) *tenantAccount {
 	key := schemas.Key{
 		ID:     keyID,
@@ -279,6 +281,9 @@ func newTenantAccount(
 	if tls.CACertPEM != "" {
 		nc.CACertPEM = tls.CACertPEM
 	}
+	if len(extraHeaders) > 0 {
+		nc.ExtraHeaders = extraHeaders
+	}
 	return &tenantAccount{
 		provider: providerKey,
 		keys:     []schemas.Key{key},
@@ -342,6 +347,7 @@ func getBifrostClient(
 	bedrock *config.BedrockKeyConfig,
 	vertex *config.VertexKeyConfig,
 	azure *config.AzureKeyConfig,
+	extraHeaders map[string]string,
 ) (*bifrost.Bifrost, error) {
 	tk := tenantKey{
 		provider: providerKey,
@@ -364,7 +370,7 @@ func getBifrostClient(
 		return c, nil
 	}
 
-	acct := newTenantAccount(providerKey, apiKey, tk.keyID, baseURL, tls, bedrock, vertex, azure)
+	acct := newTenantAccount(providerKey, apiKey, tk.keyID, baseURL, tls, bedrock, vertex, azure, extraHeaders)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	client, err := bifrost.Init(ctx, schemas.BifrostConfig{Account: acct})
@@ -422,7 +428,7 @@ func mapProviderKey(provider string) (schemas.ModelProvider, error) {
 }
 
 func (bp *bifrostProvider) ChatCompletion(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
-	client, err := getBifrostClient(bp.providerKey, bp.apiKey, bp.baseURL, bp.tls, bp.bedrock, bp.vertex, bp.azure)
+	client, err := getBifrostClient(bp.providerKey, bp.apiKey, bp.baseURL, bp.tls, bp.bedrock, bp.vertex, bp.azure, bp.extraHeaders)
 	if err != nil {
 		return nil, err
 	}
@@ -438,7 +444,7 @@ func (bp *bifrostProvider) ChatCompletion(ctx context.Context, req *ChatRequest)
 }
 
 func (bp *bifrostProvider) ChatCompletionStream(ctx context.Context, req *ChatRequest, chunkCb func(StreamChunk)) (*ChatUsage, error) {
-	client, err := getBifrostClient(bp.providerKey, bp.apiKey, bp.baseURL, bp.tls, bp.bedrock, bp.vertex, bp.azure)
+	client, err := getBifrostClient(bp.providerKey, bp.apiKey, bp.baseURL, bp.tls, bp.bedrock, bp.vertex, bp.azure, bp.extraHeaders)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gateway/provider_bifrost_e2e_test.go
+++ b/internal/gateway/provider_bifrost_e2e_test.go
@@ -218,14 +218,14 @@ func TestBifrostE2E_TenantKeyUniqueness(t *testing.T) {
 
 	// Verify each tuple materializes to an account carrying exactly its
 	// own credentials — no mutation from sibling tuples.
-	a1 := newTenantAccount(provKey, "key-1", k1, "", tlsOverrides{}, nil, nil, nil)
-	a2 := newTenantAccount(provKey, "key-2", k2, "", tlsOverrides{}, nil, nil, nil)
+	a1 := newTenantAccount(provKey, "key-1", k1, "", tlsOverrides{}, nil, nil, nil, nil)
+	a2 := newTenantAccount(provKey, "key-2", k2, "", tlsOverrides{}, nil, nil, nil, nil)
 	if a1.keys[0].Value.Val != "key-1" || a2.keys[0].Value.Val != "key-2" {
 		t.Errorf("tenant accounts leaked keys: a1=%q a2=%q",
 			a1.keys[0].Value.Val, a2.keys[0].Value.Val)
 	}
 
-	withBase := newTenantAccount(provKey, "key-1", k1, "http://custom:8080", tlsOverrides{}, nil, nil, nil)
+	withBase := newTenantAccount(provKey, "key-1", k1, "http://custom:8080", tlsOverrides{}, nil, nil, nil, nil)
 	if withBase.config.NetworkConfig.BaseURL != "http://custom:8080" {
 		t.Errorf("baseURL not propagated: got %q", withBase.config.NetworkConfig.BaseURL)
 	}
@@ -242,7 +242,7 @@ func TestBifrostE2E_TenantKeyUniqueness(t *testing.T) {
 		k1,
 		"https://lab.internal",
 		tlsOverrides{CACertPEM: "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----\n", InsecureSkipVerify: true},
-		nil, nil, nil,
+		nil, nil, nil, nil,
 	)
 	if !withTLS.config.NetworkConfig.InsecureSkipVerify {
 		t.Error("insecure_skip_verify did not propagate to NetworkConfig")
@@ -663,7 +663,7 @@ func TestBifrostE2E_EmptyModelProviderInference(t *testing.T) {
 
 func TestBifrostE2E_BedrockABSKTenantAccount(t *testing.T) {
 	keyID := bifrostKeyID(schemas.Bedrock, "ABSKe2eTestKey123")
-	acc := newTenantAccount(schemas.Bedrock, "ABSKe2eTestKey123", keyID, "", tlsOverrides{}, nil, nil, nil)
+	acc := newTenantAccount(schemas.Bedrock, "ABSKe2eTestKey123", keyID, "", tlsOverrides{}, nil, nil, nil, nil)
 
 	if len(acc.keys) != 1 {
 		t.Fatalf("expected 1 key, got %d", len(acc.keys))

--- a/internal/gateway/provider_bifrost_test.go
+++ b/internal/gateway/provider_bifrost_test.go
@@ -117,7 +117,7 @@ func TestBifrostProvider_ABSKKeyDetection(t *testing.T) {
 func TestBifrostProvider_NewTenantAccount(t *testing.T) {
 	provKey := schemas.ModelProvider("test-provider")
 	keyID := bifrostKeyID(provKey, "test-key-123")
-	acc := newTenantAccount(provKey, "test-key-123", keyID, "", tlsOverrides{}, nil, nil, nil)
+	acc := newTenantAccount(provKey, "test-key-123", keyID, "", tlsOverrides{}, nil, nil, nil, nil)
 
 	if len(acc.keys) != 1 {
 		t.Fatalf("expected 1 key, got %d", len(acc.keys))
@@ -150,7 +150,7 @@ func TestBifrostProvider_NewTenantAccount(t *testing.T) {
 
 func TestBifrostProvider_NewTenantAccountBedrockABSK(t *testing.T) {
 	keyID := bifrostKeyID(schemas.Bedrock, "ABSKtest123")
-	acc := newTenantAccount(schemas.Bedrock, "ABSKtest123", keyID, "", tlsOverrides{}, nil, nil, nil)
+	acc := newTenantAccount(schemas.Bedrock, "ABSKtest123", keyID, "", tlsOverrides{}, nil, nil, nil, nil)
 
 	if len(acc.keys) != 1 {
 		t.Fatalf("expected 1 key, got %d", len(acc.keys))
@@ -519,8 +519,8 @@ func TestBifrostProvider_TenantIsolation(t *testing.T) {
 
 	// Each tuple builds an independent, immutable Account. Mutating one's
 	// input arguments can't affect another's cached state.
-	a1 := newTenantAccount(provKey, "key-1", k1, "", tlsOverrides{}, nil, nil, nil)
-	a2 := newTenantAccount(provKey, "key-2", k2, "", tlsOverrides{}, nil, nil, nil)
+	a1 := newTenantAccount(provKey, "key-1", k1, "", tlsOverrides{}, nil, nil, nil, nil)
+	a2 := newTenantAccount(provKey, "key-2", k2, "", tlsOverrides{}, nil, nil, nil, nil)
 	if a1 == a2 {
 		t.Fatal("newTenantAccount must return distinct instances for distinct tenants")
 	}
@@ -529,7 +529,7 @@ func TestBifrostProvider_TenantIsolation(t *testing.T) {
 	}
 
 	// BaseURL variation must flow into NetworkConfig.
-	aURL := newTenantAccount(provKey, "key-1", k1, "http://custom:8080", tlsOverrides{}, nil, nil, nil)
+	aURL := newTenantAccount(provKey, "key-1", k1, "http://custom:8080", tlsOverrides{}, nil, nil, nil, nil)
 	if aURL.config.NetworkConfig.BaseURL != "http://custom:8080" {
 		t.Errorf("baseURL = %q, want http://custom:8080", aURL.config.NetworkConfig.BaseURL)
 	}


### PR DESCRIPTION
Circuit (Cisco AI proxy) requires a `llm-model` header on every request for model routing. The Bifrost SDK already supports `NetworkConfig.ExtraHeaders` but DefenseClaw never exposed it.

This adds `extra_headers` to both the custom-providers.json overlay (`configs.Provider`) and the role-level `LLMConfig`, then threads it through to `newTenantAccount` → `NetworkConfig.ExtraHeaders`.

Precedence: role-level (config.yaml llm.extra_headers) wins; overlay fills blanks when the role has no headers set.

Usage in config.yaml:
  llm:
    extra_headers:
      llm-model: gpt-5-5

Or via custom-providers.json overlay:
  { "name": "circuit", "extra_headers": {"llm-model": "gpt-5-5"} }