### PR TITLE
feat(gateway): auto-restore connector hook config when removed at runtime

### DIFF
--- a/cli/defenseclaw/audit_actions.py
+++ b/cli/defenseclaw/audit_actions.py
@@ -102,6 +102,13 @@ ACTION_CONNECTOR_HOOK: Final[str]              = "connector-hook"
 ACTION_CONNECTOR_HOOK_SYNTHETIC: Final[str]    = "connector-hook-synthetic"
 ACTION_ASSET_POLICY: Final[str]                = "asset-policy"
 
+# Connector hook self-heal. Mirrors
+# internal/audit/actions.go::ActionConnectorHook{Tampered,Repaired}.
+# The hook config guard re-installs a connector's hook block after a
+# user manually removes it while the gateway is running.
+ACTION_CONNECTOR_HOOK_TAMPERED: Final[str]     = "connector-hook-tampered"
+ACTION_CONNECTOR_HOOK_REPAIRED: Final[str]     = "connector-hook-repaired"
+
 # Codex notify webhook (agent-turn-complete et al.). The notify
 # bridge POSTs codex's JSON arg to /api/v1/codex/notify; the
 # gateway derives the action key from the payload's `type` field.
@@ -306,6 +313,8 @@ ALL_ACTIONS: Final[tuple[str, ...]] = (
     ACTION_CONNECTOR_HOOK,
     ACTION_CONNECTOR_HOOK_SYNTHETIC,
     ACTION_ASSET_POLICY,
+    ACTION_CONNECTOR_HOOK_TAMPERED,
+    ACTION_CONNECTOR_HOOK_REPAIRED,
     ACTION_CODEX_NOTIFY,
     ACTION_CODEX_NOTIFY_AGENT_TURN_COMPLETE,
     ACTION_CODEX_NOTIFY_MALFORMED,

--- a/internal/audit/actions.go
+++ b/internal/audit/actions.go
@@ -112,6 +112,16 @@ const (
 	ActionConnectorHookSynthetic Action = "connector-hook-synthetic"
 	ActionAssetPolicy            Action = "asset-policy"
 
+	// Connector hook self-heal. The hook config guard
+	// (internal/gateway/hook_config_guard.go) watches each active
+	// connector's agent config file (e.g. ~/.cursor/hooks.json,
+	// ~/.claude/settings.json, ~/.codex/config.toml) and re-installs
+	// the DefenseClaw hook block when a user removes it while the
+	// gateway is running. Tampered records the detection; Repaired
+	// records the successful re-install.
+	ActionConnectorHookTampered Action = "connector-hook-tampered"
+	ActionConnectorHookRepaired Action = "connector-hook-repaired"
+
 	// Codex notify webhook (agent-turn-complete et al.). The
 	// notify-bridge.sh shim installed by the codex connector POSTs
 	// codex's raw JSON arg to /api/v1/codex/notify after every
@@ -341,6 +351,8 @@ func AllActions() []Action {
 		ActionConnectorHook,
 		ActionConnectorHookSynthetic,
 		ActionAssetPolicy,
+		ActionConnectorHookTampered,
+		ActionConnectorHookRepaired,
 		ActionCodexNotify,
 		ActionCodexNotifyAgentTurnComplete,
 		ActionCodexNotifyMalformed,

--- a/internal/cli/embed/audit-event.json
+++ b/internal/cli/embed/audit-event.json
@@ -58,6 +58,8 @@
             "connector-hook",
             "connector-hook-synthetic",
             "asset-policy",
+            "connector-hook-tampered",
+            "connector-hook-repaired",
             "codex.notify",
             "codex.notify.agent-turn-complete",
             "codex.notify.malformed",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1248,6 +1248,22 @@ type GuardrailConfig struct {
 	// per-connector one. See AgentHookConfig docs for the full
 	// rationale.
 	HookFailMode string `mapstructure:"hook_fail_mode" yaml:"hook_fail_mode,omitempty"`
+
+	// HookSelfHeal enables the connector hook self-heal guard
+	// (internal/gateway/hook_config_guard.go). When true (the default),
+	// the sidecar watches the active connector's agent config file
+	// (e.g. ~/.cursor/hooks.json, ~/.claude/settings.json,
+	// ~/.codex/config.toml) and immediately re-installs the DefenseClaw
+	// hook block if a user deletes or strips it while the gateway is
+	// running. Set to false to allow operators to remove hooks by hand
+	// without the gateway restoring them; enforcement then lapses until
+	// the next setup/restart, which is the pre-self-heal behavior.
+	HookSelfHeal bool `mapstructure:"hook_self_heal" yaml:"hook_self_heal,omitempty"`
+
+	// HookSelfHealDebounceMs coalesces a burst of filesystem events into
+	// a single presence check before deciding whether to re-install.
+	// <= 0 falls back to the built-in default (500ms).
+	HookSelfHealDebounceMs int `mapstructure:"hook_self_heal_debounce_ms" yaml:"hook_self_heal_debounce_ms,omitempty"`
 }
 
 // EffectiveHookFailMode returns the operator-chosen hook fail mode,
@@ -2340,6 +2356,12 @@ func setDefaults(dataDir string) {
 	// guardrail` (which prompts) or `defenseclaw guardrail fail-mode
 	// closed`.
 	viper.SetDefault("guardrail.hook_fail_mode", "open")
+	// Self-heal connector hook configs by default: if a user deletes
+	// the DefenseClaw hook block while the gateway is running, the
+	// hook config guard re-installs it. Operators can opt out with
+	// `guardrail.hook_self_heal: false`.
+	viper.SetDefault("guardrail.hook_self_heal", true)
+	viper.SetDefault("guardrail.hook_self_heal_debounce_ms", 500)
 	viper.SetDefault("guardrail.scanner_mode", "both")
 	viper.SetDefault("guardrail.connector", "")
 	viper.SetDefault("guardrail.host", "")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -255,6 +255,12 @@ func TestDefaultConfigGuardrail(t *testing.T) {
 	if cfg.Guardrail.ScannerMode != "both" {
 		t.Errorf("expected guardrail scanner_mode %q, got %q", "both", cfg.Guardrail.ScannerMode)
 	}
+	if !cfg.Guardrail.HookSelfHeal {
+		t.Error("expected guardrail.hook_self_heal enabled by default")
+	}
+	if cfg.Guardrail.HookSelfHealDebounceMs != 500 {
+		t.Errorf("expected guardrail.hook_self_heal_debounce_ms 500, got %d", cfg.Guardrail.HookSelfHealDebounceMs)
+	}
 	if cfg.Guardrail.BlockMessage != "" {
 		t.Errorf("expected empty block_message by default, got %q", cfg.Guardrail.BlockMessage)
 	}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -186,6 +186,8 @@ func DefaultConfig() *Config {
 			ScannerMode:                 "both",
 			Host:                        "",
 			Port:                        4000,
+			HookSelfHeal:                true,
+			HookSelfHealDebounceMs:      500,
 			DetectionStrategy:           "regex_judge",
 			DetectionStrategyCompletion: "regex_only",
 			Judge: JudgeConfig{

--- a/internal/gateway/connector/hook_config_paths.go
+++ b/internal/gateway/connector/hook_config_paths.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+)
+
+// HookConfigPathsForConnector returns the absolute agent config file path(s)
+// that the given connector patches with DefenseClaw hook entries (e.g.
+// ~/.cursor/hooks.json, ~/.claude/settings.json, ~/.codex/config.toml).
+//
+// It returns nil for proxy/plugin connectors that do not register lifecycle
+// hooks in an agent hook file (openclaw, zeptoclaw). Those connectors do not
+// implement HookScriptOwner, so the self-heal guard treats them as inert.
+//
+// The resolved paths come from ResolvedConnectorLocations, the same path
+// contract captured into hook_contract_lock.json, so the guard watches
+// exactly the files Setup writes.
+func HookConfigPathsForConnector(conn Connector, opts SetupOpts) []string {
+	if conn == nil {
+		return nil
+	}
+	// Only connectors that own a vendor hook script register lifecycle
+	// hooks in an agent config file. Proxy/plugin connectors (openclaw,
+	// zeptoclaw) do not implement HookScriptOwner and must stay inert.
+	if _, ok := conn.(HookScriptOwner); !ok {
+		return nil
+	}
+	return uniqueNonEmptyStrings(ResolvedConnectorLocations(opts, conn).HookConfigPaths)
+}
+
+// ownedHookCommandNeedles returns the exact hook command string(s) the
+// connector writes into its agent config. On Unix this is the absolute hook
+// script path under <DataDir>/hooks/; on Windows it is the native
+// `defenseclaw-gateway hook --connector <name>` invocation. These are the
+// strings the JSON/TOML/YAML patchers insert, so a substring match against
+// the live config file reliably reports whether our hook entry survives.
+//
+// Returns nil for connectors that own no vendor hook script (openclaw,
+// zeptoclaw), keeping the self-heal guard inert for them.
+func ownedHookCommandNeedles(opts SetupOpts, conn Connector) []string {
+	owner, ok := conn.(HookScriptOwner)
+	if !ok {
+		return nil
+	}
+	hookDir := filepath.Join(opts.DataDir, "hooks")
+	var needles []string
+	for _, name := range owner.HookScriptNames(opts) {
+		cmd := hookInvocationCommand(conn.Name(), filepath.Join(hookDir, name))
+		if cmd != "" {
+			needles = append(needles, cmd)
+		}
+	}
+	return needles
+}
+
+// OwnedHooksPresent reports whether the connector's DefenseClaw hook entries
+// are still present in every agent config file it patches. It returns false
+// (heal needed) when any watched config file is missing entirely or no longer
+// references our hook command.
+//
+// Connectors with no hook config paths or no owned hook command (proxy/plugin
+// connectors) are reported as present so the guard never tries to heal them.
+func OwnedHooksPresent(conn Connector, opts SetupOpts) (bool, error) {
+	paths := HookConfigPathsForConnector(conn, opts)
+	if len(paths) == 0 {
+		return true, nil
+	}
+	needles := ownedHookCommandNeedles(opts, conn)
+	if len(needles) == 0 {
+		return true, nil
+	}
+	for _, path := range paths {
+		present, err := configFileReferencesHook(path, needles)
+		if err != nil {
+			return false, err
+		}
+		if !present {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// configFileReferencesHook reports whether the file at path contains any of
+// the owned hook command needles. A missing file reports false (not present)
+// rather than an error: a deleted connector config is exactly the tamper case
+// the guard re-installs. Any other read error is surfaced so the guard can log
+// and skip rather than heal on incomplete information.
+func configFileReferencesHook(path string, needles []string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, needle := range needles {
+		if needle != "" && bytes.Contains(data, []byte(needle)) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/gateway/connector/hook_config_paths.go
+++ b/internal/gateway/connector/hook_config_paths.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 // HookConfigPathsForConnector returns the absolute agent config file path(s)
@@ -34,26 +35,49 @@ func HookConfigPathsForConnector(conn Connector, opts SetupOpts) []string {
 	return uniqueNonEmptyStrings(ResolvedConnectorLocations(opts, conn).HookConfigPaths)
 }
 
-// ownedHookCommandNeedles returns the exact hook command string(s) the
-// connector writes into its agent config. On Unix this is the absolute hook
-// script path under <DataDir>/hooks/; on Windows it is the native
-// `defenseclaw-gateway hook --connector <name>` invocation. These are the
-// strings the JSON/TOML/YAML patchers insert, so a substring match against
-// the live config file reliably reports whether our hook entry survives.
+// ownedHookCommandNeedles returns escaping-invariant marker string(s) that the
+// connector writes into its agent config, used for a raw-bytes substring match
+// against the live config file. See ownedHookCommandNeedlesFor for the
+// platform rationale.
 //
 // Returns nil for connectors that own no vendor hook script (openclaw,
 // zeptoclaw), keeping the self-heal guard inert for them.
 func ownedHookCommandNeedles(opts SetupOpts, conn Connector) []string {
+	return ownedHookCommandNeedlesFor(runtime.GOOS, opts, conn)
+}
+
+// ownedHookCommandNeedlesFor is the OS-parameterized core of
+// ownedHookCommandNeedles, split out so the Windows marker can be exercised by
+// tests on any host.
+//
+// The needle must survive serialization into the agent config file, because
+// OwnedHooksPresent matches it against the raw file bytes (not a decoded
+// value). That constraint differs by platform:
+//
+//   - Unix: the agent runs the bundled .sh hook, so the config stores the
+//     absolute script path under <DataDir>/hooks/. Forward-slash paths contain
+//     no characters JSON/TOML/YAML escape, so the path appears verbatim.
+//
+//   - Windows: the config stores the native invocation
+//     (`"C:\...\defenseclaw-gateway.exe" hook --connector <name>`). The
+//     absolute exe path's backslashes and the surrounding quotes ARE escaped on
+//     serialization (`\"C:\\...\\..exe\"`), so the full command would never
+//     match the raw bytes. We therefore key on `hook --connector <name>` — the
+//     same distinctive marker isNativeHookCommand recognizes — which contains
+//     no escaped characters and survives verbatim across JSON/TOML/YAML.
+func ownedHookCommandNeedlesFor(goos string, opts SetupOpts, conn Connector) []string {
 	owner, ok := conn.(HookScriptOwner)
 	if !ok {
 		return nil
 	}
+	if goos == "windows" {
+		return []string{nativeHookFlag + conn.Name()}
+	}
 	hookDir := filepath.Join(opts.DataDir, "hooks")
 	var needles []string
 	for _, name := range owner.HookScriptNames(opts) {
-		cmd := hookInvocationCommand(conn.Name(), filepath.Join(hookDir, name))
-		if cmd != "" {
-			needles = append(needles, cmd)
+		if path := filepath.Join(hookDir, name); path != "" {
+			needles = append(needles, path)
 		}
 	}
 	return needles

--- a/internal/gateway/connector/hook_config_paths_test.go
+++ b/internal/gateway/connector/hook_config_paths_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// cursorTestSetup wires the cursor connector to a temp config path and returns
+// a connector + opts ready for Setup. The path override is reset on cleanup so
+// it never leaks across tests in this package.
+func cursorTestSetup(t *testing.T) (Connector, SetupOpts, string) {
+	t.Helper()
+	cfgPath := filepath.Join(t.TempDir(), "hooks.json")
+	prev := CursorHooksPathOverride
+	CursorHooksPathOverride = cfgPath
+	t.Cleanup(func() { CursorHooksPathOverride = prev })
+	opts := SetupOpts{
+		DataDir:      t.TempDir(),
+		APIAddr:      "127.0.0.1:18970",
+		APIToken:     "tok-test",
+		WorkspaceDir: t.TempDir(),
+	}
+	return NewCursorConnector(), opts, cfgPath
+}
+
+func TestHookConfigPathsForConnector_ResolvesOverride(t *testing.T) {
+	conn, opts, cfgPath := cursorTestSetup(t)
+
+	paths := HookConfigPathsForConnector(conn, opts)
+	if len(paths) != 1 {
+		t.Fatalf("HookConfigPathsForConnector = %v, want exactly the cursor hooks path", paths)
+	}
+	if paths[0] != cfgPath {
+		t.Fatalf("HookConfigPathsForConnector[0] = %q, want %q", paths[0], cfgPath)
+	}
+}
+
+func TestHookConfigPathsForConnector_ProxyConnectorsAreInert(t *testing.T) {
+	opts := SetupOpts{DataDir: t.TempDir(), ProxyAddr: "127.0.0.1:4000", APIAddr: "127.0.0.1:18970"}
+	for _, conn := range []Connector{NewOpenClawConnector(), NewZeptoClawConnector()} {
+		if paths := HookConfigPathsForConnector(conn, opts); paths != nil {
+			t.Errorf("%s: HookConfigPathsForConnector = %v, want nil (proxy/plugin connector must be inert)", conn.Name(), paths)
+		}
+	}
+}
+
+func TestHookConfigPathsForConnector_NilConnector(t *testing.T) {
+	if paths := HookConfigPathsForConnector(nil, SetupOpts{}); paths != nil {
+		t.Fatalf("HookConfigPathsForConnector(nil) = %v, want nil", paths)
+	}
+}
+
+func TestOwnedHooksPresent_TrueAfterSetup_FalseAfterRemoval(t *testing.T) {
+	conn, opts, cfgPath := cursorTestSetup(t)
+
+	if err := conn.Setup(context.Background(), opts); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+
+	present, err := OwnedHooksPresent(conn, opts)
+	if err != nil {
+		t.Fatalf("OwnedHooksPresent after Setup: %v", err)
+	}
+	if !present {
+		data, _ := os.ReadFile(cfgPath)
+		t.Fatalf("OwnedHooksPresent=false after Setup; config:\n%s", data)
+	}
+
+	// Strip the hook block: an empty JSON object no longer references our
+	// hook command.
+	if err := os.WriteFile(cfgPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("strip config: %v", err)
+	}
+	present, err = OwnedHooksPresent(conn, opts)
+	if err != nil {
+		t.Fatalf("OwnedHooksPresent after strip: %v", err)
+	}
+	if present {
+		t.Fatal("OwnedHooksPresent=true after stripping the hook block; want false")
+	}
+}
+
+func TestOwnedHooksPresent_FalseWhenFileMissing(t *testing.T) {
+	conn, opts, cfgPath := cursorTestSetup(t)
+
+	if err := conn.Setup(context.Background(), opts); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	if err := os.Remove(cfgPath); err != nil {
+		t.Fatalf("remove config: %v", err)
+	}
+
+	present, err := OwnedHooksPresent(conn, opts)
+	if err != nil {
+		t.Fatalf("OwnedHooksPresent with missing file returned error: %v", err)
+	}
+	if present {
+		t.Fatal("OwnedHooksPresent=true for a deleted config file; want false")
+	}
+}
+
+func TestOwnedHooksPresent_ProxyConnectorReportsPresent(t *testing.T) {
+	// Proxy/plugin connectors have no guarded hook config paths, so they
+	// are reported present (never heal-eligible).
+	opts := SetupOpts{DataDir: t.TempDir(), ProxyAddr: "127.0.0.1:4000", APIAddr: "127.0.0.1:18970"}
+	present, err := OwnedHooksPresent(NewOpenClawConnector(), opts)
+	if err != nil {
+		t.Fatalf("OwnedHooksPresent: %v", err)
+	}
+	if !present {
+		t.Fatal("OwnedHooksPresent=false for proxy connector; want true (inert)")
+	}
+}

--- a/internal/gateway/connector/hook_config_paths_test.go
+++ b/internal/gateway/connector/hook_config_paths_test.go
@@ -5,7 +5,9 @@
 package connector
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -115,5 +117,43 @@ func TestOwnedHooksPresent_ProxyConnectorReportsPresent(t *testing.T) {
 	}
 	if !present {
 		t.Fatal("OwnedHooksPresent=false for proxy connector; want true (inert)")
+	}
+}
+
+// TestOwnedHookNeedles_WindowsSurvivesConfigEscaping guards the Windows
+// presence-detection path. On Windows the agent config stores the native
+// invocation (`"C:\...\defenseclaw-gateway.exe" hook --connector <name>`),
+// whose backslashes and quotes are escaped when serialized into JSON/TOML.
+// The needle must therefore key on an escaping-invariant marker, not the full
+// command, or OwnedHooksPresent would false-negative on every check and the
+// guard would spuriously re-install hooks. This test runs on any host because
+// the OS is parameterized.
+func TestOwnedHookNeedles_WindowsSurvivesConfigEscaping(t *testing.T) {
+	opts := SetupOpts{DataDir: `C:\Users\me\AppData\Local\defenseclaw`}
+	conn := NewCursorConnector()
+
+	needles := ownedHookCommandNeedlesFor("windows", opts, conn)
+	if len(needles) != 1 || needles[0] != nativeHookFlag+conn.Name() {
+		t.Fatalf("windows needles = %v, want [%q]", needles, nativeHookFlag+conn.Name())
+	}
+
+	// What Setup actually writes on Windows: the native command embedded in a
+	// JSON config, where the exe path's backslashes/quotes get escaped.
+	winCmd := `"C:\Users\me\AppData\Local\defenseclaw\defenseclaw-gateway.exe" ` + nativeHookFlag + conn.Name()
+	encoded, err := json.Marshal(map[string]string{"command": winCmd})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// The full raw command must NOT appear in the escaped bytes (this is the
+	// failure mode the marker avoids) ...
+	if bytes.Contains(encoded, []byte(winCmd)) {
+		t.Fatalf("precondition: expected JSON to escape the windows command, but it appeared verbatim:\n%s", encoded)
+	}
+	// ... while the escaping-invariant marker IS present.
+	for _, n := range needles {
+		if !bytes.Contains(encoded, []byte(n)) {
+			t.Fatalf("windows needle %q not found in escaped config:\n%s", n, encoded)
+		}
 	}
 }

--- a/internal/gateway/hook_config_guard.go
+++ b/internal/gateway/hook_config_guard.go
@@ -1,0 +1,391 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	"github.com/defenseclaw/defenseclaw/internal/audit"
+	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
+	"github.com/defenseclaw/defenseclaw/internal/telemetry"
+)
+
+const (
+	// defaultHookGuardDebounce coalesces a burst of filesystem events
+	// (editors often emit several writes/renames per save) into a single
+	// presence check.
+	defaultHookGuardDebounce = 500 * time.Millisecond
+
+	// hookGuardHealSuppressWindow is how long the guard ignores events
+	// after it re-runs Setup. Setup rewrites the connector config file,
+	// which would otherwise re-trigger the guard; the presence check
+	// already prevents a sustained loop, but suppressing the immediate
+	// self-write keeps the audit trail clean.
+	hookGuardHealSuppressWindow = 3 * time.Second
+
+	// hookGuardSetupTimeout bounds a single re-install so a wedged
+	// connector Setup cannot block the guard goroutine forever.
+	hookGuardSetupTimeout = 15 * time.Second
+
+	// hookGuardSwitchSuppressWindow pauses self-heal across a runtime
+	// connector hot-swap. Tearing down the outgoing connector removes its
+	// hook entries; without this pause the guard (still pointed at the old
+	// connector until Repoint) could re-install them mid-swap, leaving
+	// stale enforcement for a connector that was deliberately deactivated.
+	// Sized to comfortably cover a teardown+Setup cycle plus a debounce
+	// tick; Repoint at the end of the swap re-targets the guard.
+	hookGuardSwitchSuppressWindow = 5 * time.Second
+)
+
+// HookConfigGuard watches the active connector's agent config file(s) and
+// auto-heals (re-installs) the DefenseClaw hook block when a user deletes or
+// strips it while the gateway is running. Without it, enforcement silently
+// lapses until the next sidecar restart or connector switch.
+//
+// The guard watches the parent directory of each resolved config path (so
+// editor atomic rename/replace saves are caught) and filters events down to
+// the exact target files. On a debounced event it checks whether the owned
+// hook command still appears in the config; only when it is gone does it
+// re-run conn.Setup, which idempotently re-patches the hook entries.
+//
+// The GuardrailProxy owns one guard and calls Repoint when it hot-swaps
+// connectors so the watcher follows the active connector.
+type HookConfigGuard struct {
+	logger   *audit.Logger
+	otel     *telemetry.Provider
+	debounce time.Duration
+
+	// onHealed is an optional fan-out hook (webhook / desktop
+	// notification) invoked after a successful re-install. nil is safe.
+	onHealed func(connectorName string, paths []string)
+
+	mu            sync.Mutex
+	started       bool
+	ctx           context.Context
+	cancel        context.CancelFunc
+	fsw           *fsnotify.Watcher
+	conn          connector.Connector
+	opts          connector.SetupOpts
+	targets       map[string]struct{} // cleaned absolute config file paths
+	watchedDirs   map[string]struct{} // cleaned absolute parent dirs added to fsw
+	pending       map[string]time.Time
+	suppressUntil time.Time
+	done          chan struct{}
+}
+
+// NewHookConfigGuard constructs a guard. debounce <= 0 falls back to the
+// default. logger and otel may be nil (observability becomes a no-op).
+func NewHookConfigGuard(logger *audit.Logger, otel *telemetry.Provider, debounce time.Duration) *HookConfigGuard {
+	if debounce <= 0 {
+		debounce = defaultHookGuardDebounce
+	}
+	return &HookConfigGuard{
+		logger:      logger,
+		otel:        otel,
+		debounce:    debounce,
+		targets:     map[string]struct{}{},
+		watchedDirs: map[string]struct{}{},
+		pending:     map[string]time.Time{},
+	}
+}
+
+// SetHealNotifier wires an optional callback fired after a successful
+// re-install, used to fan out to webhooks / desktop notifications. Safe to
+// leave unset.
+func (g *HookConfigGuard) SetHealNotifier(fn func(connectorName string, paths []string)) {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	g.onHealed = fn
+	g.mu.Unlock()
+}
+
+// Start begins watching the given connector's config files. It launches a
+// background goroutine bound to ctx and returns immediately. Starting a guard
+// for a connector with no hook config paths (proxy/plugin connectors) is
+// allowed: the goroutine runs idle until a later Repoint adds targets.
+func (g *HookConfigGuard) Start(ctx context.Context, conn connector.Connector, opts connector.SetupOpts) {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	if g.started {
+		g.mu.Unlock()
+		g.Repoint(conn, opts)
+		return
+	}
+
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		g.mu.Unlock()
+		fmt.Fprintf(os.Stderr, "[hook-guard] create fsnotify watcher: %v (self-heal disabled)\n", err)
+		return
+	}
+
+	gctx, cancel := context.WithCancel(ctx)
+	g.ctx = gctx
+	g.cancel = cancel
+	g.fsw = fsw
+	g.done = make(chan struct{})
+	g.started = true
+	g.applyTargetsLocked(conn, opts)
+	g.mu.Unlock()
+
+	go g.run()
+}
+
+// Repoint switches the guard to a new connector (e.g. after a runtime
+// connector hot-swap). It re-resolves config paths and adjusts the watched
+// directories. No-op until Start has been called.
+func (g *HookConfigGuard) Repoint(conn connector.Connector, opts connector.SetupOpts) {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if !g.started || g.fsw == nil {
+		// Remember the latest target so a future Start picks it up.
+		g.conn = conn
+		g.opts = opts
+		return
+	}
+	g.applyTargetsLocked(conn, opts)
+	// A connector switch invalidates any pending events for the old
+	// connector's files; drop them so we never heal the wrong connector.
+	g.pending = map[string]time.Time{}
+}
+
+// SuppressHealing pauses heal evaluation for at least d and drops any events
+// already queued for processing. Used during a runtime connector hot-swap so
+// the guard does not re-install the connector being torn down: the proxy calls
+// this before teardown and Repoint afterward. Nil-safe and a no-op for d <= 0.
+func (g *HookConfigGuard) SuppressHealing(d time.Duration) {
+	if g == nil || d <= 0 {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if until := time.Now().Add(d); until.After(g.suppressUntil) {
+		g.suppressUntil = until
+	}
+	// Drop in-flight events for the connector being swapped out so a
+	// pending teardown write cannot mature into a heal once the window
+	// elapses.
+	g.pending = map[string]time.Time{}
+}
+
+// Stop cancels the guard goroutine and releases the fsnotify watcher. Safe to
+// call multiple times.
+func (g *HookConfigGuard) Stop() {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	if !g.started {
+		g.mu.Unlock()
+		return
+	}
+	cancel := g.cancel
+	done := g.done
+	g.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
+}
+
+// applyTargetsLocked recomputes the watched config paths + parent dirs for the
+// given connector and syncs the fsnotify watch set. Caller must hold g.mu.
+func (g *HookConfigGuard) applyTargetsLocked(conn connector.Connector, opts connector.SetupOpts) {
+	g.conn = conn
+	g.opts = opts
+
+	newTargets := map[string]struct{}{}
+	newDirs := map[string]struct{}{}
+	for _, p := range connector.HookConfigPathsForConnector(conn, opts) {
+		clean := filepath.Clean(p)
+		newTargets[clean] = struct{}{}
+		newDirs[filepath.Dir(clean)] = struct{}{}
+	}
+	g.targets = newTargets
+
+	if g.fsw == nil {
+		g.watchedDirs = newDirs
+		return
+	}
+	// Add newly required directories.
+	for dir := range newDirs {
+		if _, ok := g.watchedDirs[dir]; ok {
+			continue
+		}
+		if err := g.fsw.Add(dir); err != nil {
+			fmt.Fprintf(os.Stderr, "[hook-guard] watch %s: %v (skipping)\n", dir, err)
+			continue
+		}
+		g.watchedDirs[dir] = struct{}{}
+	}
+	// Drop directories we no longer need.
+	for dir := range g.watchedDirs {
+		if _, ok := newDirs[dir]; ok {
+			continue
+		}
+		_ = g.fsw.Remove(dir)
+		delete(g.watchedDirs, dir)
+	}
+}
+
+func (g *HookConfigGuard) run() {
+	defer close(g.done)
+	defer func() {
+		g.mu.Lock()
+		if g.fsw != nil {
+			_ = g.fsw.Close()
+		}
+		g.started = false
+		g.mu.Unlock()
+	}()
+
+	ticker := time.NewTicker(g.debounce)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-g.ctx.Done():
+			return
+
+		case event, ok := <-g.fsw.Events:
+			if !ok {
+				return
+			}
+			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename|fsnotify.Remove) == 0 {
+				continue
+			}
+			name := filepath.Clean(event.Name)
+			g.mu.Lock()
+			_, isTarget := g.targets[name]
+			if isTarget {
+				if _, exists := g.pending[name]; !exists {
+					g.pending[name] = time.Now()
+				}
+			}
+			g.mu.Unlock()
+
+		case err, ok := <-g.fsw.Errors:
+			if !ok {
+				return
+			}
+			if g.otel != nil {
+				g.otel.RecordWatcherError(g.ctx)
+			}
+			fmt.Fprintf(os.Stderr, "[hook-guard] fsnotify error: %v\n", err)
+
+		case <-ticker.C:
+			g.processPending()
+		}
+	}
+}
+
+// processPending evaluates debounced events: if any guarded config file no
+// longer references the owned hook, re-install via Setup.
+func (g *HookConfigGuard) processPending() {
+	g.mu.Lock()
+	now := time.Now()
+	suppressed := now.Before(g.suppressUntil)
+	var ready []string
+	for path, firstSeen := range g.pending {
+		if now.Sub(firstSeen) >= g.debounce {
+			ready = append(ready, path)
+		}
+	}
+	for _, p := range ready {
+		delete(g.pending, p)
+	}
+	conn := g.conn
+	opts := g.opts
+	g.mu.Unlock()
+
+	if suppressed || len(ready) == 0 || conn == nil {
+		return
+	}
+
+	present, err := connector.OwnedHooksPresent(conn, opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[hook-guard] presence check for %s: %v\n", conn.Name(), err)
+		return
+	}
+	if present {
+		// The owned hook still exists — the operator edited unrelated
+		// keys, or a previous heal already restored it. Do not fight
+		// legitimate edits.
+		return
+	}
+
+	g.heal(conn, opts, ready)
+}
+
+// heal re-runs the connector Setup to re-install the hook block, emits audit
+// + telemetry, and suppresses the resulting self-write.
+func (g *HookConfigGuard) heal(conn connector.Connector, opts connector.SetupOpts, changed []string) {
+	connName := conn.Name()
+	detail := strings.Join(changed, ", ")
+	if g.logger != nil {
+		_ = g.logger.LogAction(string(audit.ActionConnectorHookTampered), connName,
+			fmt.Sprintf("hook config missing owned entries: %s", detail))
+	}
+
+	g.mu.Lock()
+	g.suppressUntil = time.Now().Add(hookGuardHealSuppressWindow)
+	baseCtx := g.ctx
+	g.mu.Unlock()
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+
+	hctx, cancel := context.WithTimeout(context.WithoutCancel(baseCtx), hookGuardSetupTimeout)
+	defer cancel()
+
+	if err := conn.Setup(hctx, opts); err != nil {
+		fmt.Fprintf(os.Stderr, "[hook-guard] re-install %s hooks failed: %v\n", connName, err)
+		if g.logger != nil {
+			_ = g.logger.LogAction(string(audit.ActionGuardrailDegraded), connName,
+				fmt.Sprintf("hook self-heal Setup failed: %v", err))
+		}
+		return
+	}
+
+	// A whole-directory deletion would have dropped our fsnotify watch;
+	// Setup recreates the parent dirs, so re-sync the watch set.
+	g.mu.Lock()
+	g.applyTargetsLocked(conn, opts)
+	g.mu.Unlock()
+
+	fmt.Fprintf(os.Stderr, "[hook-guard] re-installed %s hook config after manual removal (%s)\n", connName, detail)
+	if g.otel != nil {
+		g.otel.RecordWatcherEvent(g.ctx, "hook-heal", connName)
+	}
+	if g.logger != nil {
+		_ = g.logger.LogAction(string(audit.ActionConnectorHookRepaired), connName,
+			fmt.Sprintf("re-installed hook entries removed from: %s", detail))
+	}
+
+	g.mu.Lock()
+	notify := g.onHealed
+	g.mu.Unlock()
+	if notify != nil {
+		notify(connName, changed)
+	}
+}

--- a/internal/gateway/hook_config_guard_test.go
+++ b/internal/gateway/hook_config_guard_test.go
@@ -1,0 +1,304 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
+)
+
+const guardTestDebounce = 40 * time.Millisecond
+
+// installedCursorConnector wires the cursor connector to a temp config path,
+// runs its initial Setup, and returns the connector, opts, and resolved config
+// path. The path override is reset on cleanup.
+func installedCursorConnector(t *testing.T) (connector.Connector, connector.SetupOpts, string) {
+	t.Helper()
+	cfgPath := filepath.Join(t.TempDir(), "hooks.json")
+	prev := connector.CursorHooksPathOverride
+	connector.CursorHooksPathOverride = cfgPath
+	t.Cleanup(func() { connector.CursorHooksPathOverride = prev })
+
+	opts := connector.SetupOpts{
+		DataDir:      t.TempDir(),
+		APIAddr:      "127.0.0.1:18970",
+		APIToken:     "tok-test",
+		WorkspaceDir: t.TempDir(),
+	}
+	conn := connector.NewCursorConnector()
+	if err := conn.Setup(context.Background(), opts); err != nil {
+		t.Fatalf("cursor Setup: %v", err)
+	}
+	return conn, opts, cfgPath
+}
+
+func installedWindsurfConnector(t *testing.T) (connector.Connector, connector.SetupOpts, string) {
+	t.Helper()
+	cfgPath := filepath.Join(t.TempDir(), "hooks.json")
+	prev := connector.WindsurfHooksPathOverride
+	connector.WindsurfHooksPathOverride = cfgPath
+	t.Cleanup(func() { connector.WindsurfHooksPathOverride = prev })
+
+	opts := connector.SetupOpts{
+		DataDir:      t.TempDir(),
+		APIAddr:      "127.0.0.1:18970",
+		APIToken:     "tok-test",
+		WorkspaceDir: t.TempDir(),
+	}
+	conn := connector.NewWindsurfConnector()
+	if err := conn.Setup(context.Background(), opts); err != nil {
+		t.Fatalf("windsurf Setup: %v", err)
+	}
+	return conn, opts, cfgPath
+}
+
+func waitForPresence(t *testing.T, conn connector.Connector, opts connector.SetupOpts, want bool, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		present, err := connector.OwnedHooksPresent(conn, opts)
+		if err == nil && present == want {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	present, err := connector.OwnedHooksPresent(conn, opts)
+	t.Fatalf("timed out waiting for OwnedHooksPresent==%v (last present=%v err=%v)", want, present, err)
+}
+
+func TestHookConfigGuard_RestoresDeletedHookBlock(t *testing.T) {
+	conn, opts, cfgPath := installedCursorConnector(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	guard := NewHookConfigGuard(nil, nil, guardTestDebounce)
+	guard.Start(ctx, conn, opts)
+	defer guard.Stop()
+
+	waitForPresence(t, conn, opts, true, time.Second)
+
+	// Simulate a user deleting the DefenseClaw hook block.
+	if err := os.WriteFile(cfgPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("strip hook block: %v", err)
+	}
+
+	// The guard should re-install it within a few debounce cycles.
+	waitForPresence(t, conn, opts, true, 3*time.Second)
+}
+
+func TestHookConfigGuard_RecreatesDeletedFile(t *testing.T) {
+	conn, opts, cfgPath := installedCursorConnector(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	guard := NewHookConfigGuard(nil, nil, guardTestDebounce)
+	guard.Start(ctx, conn, opts)
+	defer guard.Stop()
+
+	waitForPresence(t, conn, opts, true, time.Second)
+
+	if err := os.Remove(cfgPath); err != nil {
+		t.Fatalf("remove config file: %v", err)
+	}
+
+	waitForPresence(t, conn, opts, true, 3*time.Second)
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Fatalf("config file not recreated: %v", err)
+	}
+}
+
+func TestHookConfigGuard_IgnoresUnrelatedEdits(t *testing.T) {
+	conn, opts, cfgPath := installedCursorConnector(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	guard := NewHookConfigGuard(nil, nil, guardTestDebounce)
+	guard.Start(ctx, conn, opts)
+	defer guard.Stop()
+
+	waitForPresence(t, conn, opts, true, time.Second)
+
+	// Edit an unrelated top-level key while keeping the hook block intact.
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	cfg["_dc_test_unrelated"] = "keepme"
+	edited, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if err := os.WriteFile(cfgPath, edited, 0o600); err != nil {
+		t.Fatalf("write edited config: %v", err)
+	}
+
+	// Give the guard several debounce cycles to (incorrectly) react.
+	time.Sleep(20 * guardTestDebounce)
+
+	// Hooks must still be present, the unrelated key must survive, and the
+	// guard must not have rewritten the file (no churn on legitimate edits).
+	present, err := connector.OwnedHooksPresent(conn, opts)
+	if err != nil {
+		t.Fatalf("OwnedHooksPresent: %v", err)
+	}
+	if !present {
+		t.Fatal("hooks no longer present after unrelated edit")
+	}
+	after, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("re-read config: %v", err)
+	}
+	if string(after) != string(edited) {
+		t.Fatalf("guard rewrote config on an unrelated edit:\nwant:\n%s\ngot:\n%s", edited, after)
+	}
+	var afterCfg map[string]interface{}
+	if err := json.Unmarshal(after, &afterCfg); err != nil {
+		t.Fatalf("unmarshal after: %v", err)
+	}
+	if afterCfg["_dc_test_unrelated"] != "keepme" {
+		t.Fatal("unrelated key was clobbered by the guard")
+	}
+}
+
+func TestHookConfigGuard_DisabledDoesNotHeal(t *testing.T) {
+	// Mirrors guardrail.hook_self_heal=false: the guard is never started,
+	// so a manual deletion is NOT restored.
+	conn, opts, cfgPath := installedCursorConnector(t)
+
+	if err := os.WriteFile(cfgPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("strip hook block: %v", err)
+	}
+	time.Sleep(20 * guardTestDebounce)
+
+	present, err := connector.OwnedHooksPresent(conn, opts)
+	if err != nil {
+		t.Fatalf("OwnedHooksPresent: %v", err)
+	}
+	if present {
+		t.Fatal("hook block restored even though no guard was started")
+	}
+}
+
+func TestHookConfigGuard_NotifierFiresOnHeal(t *testing.T) {
+	conn, opts, cfgPath := installedCursorConnector(t)
+
+	type healCall struct {
+		name  string
+		paths []string
+	}
+	calls := make(chan healCall, 4)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	guard := NewHookConfigGuard(nil, nil, guardTestDebounce)
+	guard.SetHealNotifier(func(name string, paths []string) {
+		calls <- healCall{name: name, paths: paths}
+	})
+	guard.Start(ctx, conn, opts)
+	defer guard.Stop()
+
+	waitForPresence(t, conn, opts, true, time.Second)
+
+	if err := os.WriteFile(cfgPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("strip hook block: %v", err)
+	}
+	waitForPresence(t, conn, opts, true, 3*time.Second)
+
+	select {
+	case got := <-calls:
+		if got.name != conn.Name() {
+			t.Errorf("notifier connector name = %q, want %q", got.name, conn.Name())
+		}
+		if len(got.paths) == 0 {
+			t.Error("notifier received no changed paths")
+		} else if got.paths[0] != cfgPath {
+			t.Errorf("notifier path = %q, want %q", got.paths[0], cfgPath)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("heal notifier did not fire after a successful re-install")
+	}
+}
+
+func TestHookConfigGuard_SuppressHealingPausesThenResumes(t *testing.T) {
+	conn, opts, cfgPath := installedCursorConnector(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	guard := NewHookConfigGuard(nil, nil, guardTestDebounce)
+	guard.Start(ctx, conn, opts)
+	defer guard.Stop()
+	waitForPresence(t, conn, opts, true, time.Second)
+
+	// Suppress healing, then strip the hook block. The deletion lands
+	// inside the suppression window and must NOT be auto-restored.
+	const window = 600 * time.Millisecond
+	guard.SuppressHealing(window)
+	if err := os.WriteFile(cfgPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("strip hook block: %v", err)
+	}
+
+	// Mid-window: the guard must still be holding off.
+	time.Sleep(window / 2)
+	present, err := connector.OwnedHooksPresent(conn, opts)
+	if err != nil {
+		t.Fatalf("OwnedHooksPresent: %v", err)
+	}
+	if present {
+		t.Fatal("hook restored during the suppression window; SuppressHealing did not pause healing")
+	}
+
+	// After the window elapses a fresh edit must be healed again, proving
+	// suppression is temporary and not a permanent disable.
+	time.Sleep(window)
+	if err := os.WriteFile(cfgPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("re-strip hook block after window: %v", err)
+	}
+	waitForPresence(t, conn, opts, true, 3*time.Second)
+}
+
+func TestHookConfigGuard_RepointFollowsConnectorSwitch(t *testing.T) {
+	cursorConn, cursorOpts, cursorPath := installedCursorConnector(t)
+	windsurfConn, windsurfOpts, windsurfPath := installedWindsurfConnector(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	guard := NewHookConfigGuard(nil, nil, guardTestDebounce)
+	guard.Start(ctx, cursorConn, cursorOpts)
+	defer guard.Stop()
+	waitForPresence(t, cursorConn, cursorOpts, true, time.Second)
+
+	// Switch the guard to the windsurf connector.
+	guard.Repoint(windsurfConn, windsurfOpts)
+
+	// Deleting windsurf's hook block is now healed.
+	if err := os.WriteFile(windsurfPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("strip windsurf hook block: %v", err)
+	}
+	waitForPresence(t, windsurfConn, windsurfOpts, true, 3*time.Second)
+
+	// Deleting the previous connector's hook block is NOT healed: the guard
+	// repointed away from it.
+	if err := os.WriteFile(cursorPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("strip cursor hook block: %v", err)
+	}
+	time.Sleep(20 * guardTestDebounce)
+	present, err := connector.OwnedHooksPresent(cursorConn, cursorOpts)
+	if err != nil {
+		t.Fatalf("OwnedHooksPresent cursor: %v", err)
+	}
+	if present {
+		t.Fatal("cursor hook block restored after the guard repointed to windsurf")
+	}
+}

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -127,6 +127,13 @@ type GuardrailProxy struct {
 	registry  *connector.Registry
 	setupOpts connector.SetupOpts
 
+	// hookGuard auto-heals the active connector's agent config file when
+	// a user manually deletes the DefenseClaw hook block while the
+	// gateway is running. nil when guardrail.hook_self_heal is disabled.
+	// Repointed on runtime connector switch so it follows the active
+	// connector.
+	hookGuard *HookConfigGuard
+
 	// Observability defaults set at bootstrap. defaultAgentName
 	// falls back to cfg.Claw.Mode ("openclaw") when the request
 	// does not carry an agent identifier; defaultPolicyID is the
@@ -433,6 +440,45 @@ func NewGuardrailProxy(
 func (p *GuardrailProxy) SetConnectorSwitchState(reg *connector.Registry, opts connector.SetupOpts) {
 	p.registry = reg
 	p.setupOpts = opts
+}
+
+// StartHookConfigGuard launches the connector hook self-heal guard bound to
+// ctx. It must be called after the connector's initial Setup so the watched
+// config files already exist. The guard is owned by the proxy and repointed on
+// runtime connector switch. The guard goroutine stops when ctx is cancelled.
+//
+// Started for both proxy-bound and observability-only connectors: hook-native
+// connectors (codex, claudecode, cursor, ...) never reach proxy.Run, so the
+// caller (runGuardrail) is responsible for invoking this before the
+// observability short-circuit.
+func (p *GuardrailProxy) StartHookConfigGuard(ctx context.Context, conn connector.Connector, opts connector.SetupOpts) {
+	if p == nil {
+		return
+	}
+	debounce := time.Duration(p.cfg.HookSelfHealDebounceMs) * time.Millisecond
+	guard := NewHookConfigGuard(p.logger, p.otel, debounce)
+	guard.SetHealNotifier(p.notifyHookHealed)
+	p.hookGuard = guard
+	guard.Start(ctx, conn, opts)
+}
+
+// notifyHookHealed fans a successful hook re-install out to the configured
+// webhook endpoints, mirroring the watchdog health-event path. The durable
+// audit row and OTel metric are emitted by the guard itself; this adds the
+// outbound notifier channel so operators learn that a connector hook was
+// tampered with and restored.
+func (p *GuardrailProxy) notifyHookHealed(connectorName string, paths []string) {
+	if p == nil || p.webhooks == nil {
+		return
+	}
+	p.webhooks.Dispatch(audit.Event{
+		Timestamp: time.Now().UTC(),
+		Action:    string(audit.ActionConnectorHookRepaired),
+		Target:    connectorName,
+		Actor:     "defenseclaw-hook-guard",
+		Details:   fmt.Sprintf("re-installed connector hook config after manual removal: %s", strings.Join(paths, ", ")),
+		Severity:  "HIGH",
+	})
 }
 
 // SetWebhookDispatcher attaches a webhook dispatcher for guardrail block notifications.
@@ -3416,6 +3462,13 @@ func (p *GuardrailProxy) switchConnectorLocked(newName string) {
 
 	newConn.SetCredentials(p.gatewayToken, p.masterKey)
 
+	// Pause self-heal across the swap. Teardown below strips the outgoing
+	// connector's hook entries, which must NOT be auto-restored; without
+	// this the guard (still pointed at oldConn until Repoint) could race the
+	// teardown and re-install hooks for a connector we just deactivated.
+	// Repoint at the end re-targets the guard at newConn.
+	p.hookGuard.SuppressHealing(hookGuardSwitchSuppressWindow)
+
 	if oldConn != nil {
 		fmt.Fprintf(os.Stderr, "[guardrail] runtime connector switch: tearing down %s\n", oldConn.Name())
 		if err := oldConn.Teardown(ctx, p.setupOpts); err != nil {
@@ -3441,6 +3494,10 @@ func (p *GuardrailProxy) switchConnectorLocked(newName string) {
 	if err := connector.SaveActiveConnector(p.setupOpts.DataDir, newName); err != nil {
 		fmt.Fprintf(os.Stderr, "[guardrail] save active connector state: %v\n", err)
 	}
+
+	// Follow the active connector so self-heal watches the new
+	// connector's config file rather than the torn-down one's.
+	p.hookGuard.Repoint(newConn, p.setupOpts)
 
 	if p.health != nil {
 		p.health.SetConnector(newConn.Name(), newConn.ToolInspectionMode(), newConn.SubprocessPolicy())

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -1483,6 +1483,14 @@ func (s *Sidecar) runGuardrail(ctx context.Context) error {
 		proxy.SetConnectorSwitchState(registry, setupOpts)
 		proxy.SetHILTApprovalManager(s.hilt)
 		proxy.SetNotifier(s.osNotifier)
+		// Start connector hook self-heal before the observability-only
+		// short-circuit below. Hook-native connectors (codex, claudecode,
+		// cursor, ...) never reach proxy.Run, so the guard MUST be started
+		// here to cover both the observability and proxy-bound paths. The
+		// guard goroutine stops when ctx is cancelled.
+		if s.cfg.Guardrail.Enabled && s.cfg.Guardrail.HookSelfHeal {
+			proxy.StartHookConfigGuard(ctx, conn, setupOpts)
+		}
 	}
 	if err != nil {
 		s.health.SetGuardrail(StateError, err.Error(), nil)

--- a/schemas/audit-event.json
+++ b/schemas/audit-event.json
@@ -58,6 +58,8 @@
             "connector-hook",
             "connector-hook-synthetic",
             "asset-policy",
+            "connector-hook-tampered",
+            "connector-hook-repaired",
             "codex.notify",
             "codex.notify.agent-turn-complete",
             "codex.notify.malformed",


### PR DESCRIPTION
> Stacked on top of #284 (`feat/hook-collector-unification`). Review/merge that PR first; this PR's base is the stack parent, not `main`.

## Problem

DefenseClaw enforcement for hook-native agents depends entirely on a hook
block living inside each agent's own config file (e.g. `~/.cursor/hooks.json`,
`~/.claude/settings.json`, `~/.codex/config.toml`). If a user edits that file
and deletes or strips the DefenseClaw hook entries **while the gateway is
running**, enforcement silently lapses: the agent keeps running with no
pre/post-tool inspection, and nothing restores the hook until the next
`setup`/restart or a connector switch. There is no detection and no recovery
of this tamper case at runtime.

## Current Situation

- Connectors install their hook block during `Connector.Setup()` and remove it
  during `Teardown()`. Once Setup has run, nothing watches the file.
- `defenseclaw doctor` can detect drift on demand, but it is not running
  continuously and does not auto-repair connector config files.
- Hook-native connectors (codex, claudecode, cursor, windsurf, ...) run in
  observability-only mode and never reach `proxy.Run`, so any recovery must be
  wired on a path both proxy-bound and observability-only connectors hit.
- Net effect: a single manual edit disables enforcement indefinitely with no
  audit signal.

## Solution

Add an event-driven self-heal guard that watches the active connector's config
file(s) and re-installs the hook block the moment it goes missing.

- `HookConfigGuard` (`internal/gateway/hook_config_guard.go`) watches the
  **parent directory** of each resolved config path via `fsnotify` (so atomic
  editor rename/replace saves are caught), debounces bursts, and on a debounced
  event runs a **presence check**. It only re-runs `conn.Setup()` when the
  owned hook command is actually gone, so legitimate unrelated edits cause no
  churn. It suppresses its own re-install writes to avoid loops.
- Presence detection (`internal/gateway/connector/hook_config_paths.go`) reuses
  the existing `ResolvedConnectorLocations` path contract and the
  `HookScriptOwner` interface, then does a format-agnostic substring match for
  the exact hook command the patchers write (works for JSON, TOML, YAML).
  Proxy/plugin connectors (openclaw, zeptoclaw) implement no `HookScriptOwner`
  and are treated as inert.
- `GuardrailProxy` owns one guard, starts it in `runGuardrail` **before** the
  observability short-circuit (covering both connector classes), `Repoint`s it
  on runtime connector hot-swap, and `SuppressHealing` across the swap so the
  connector being torn down is not re-installed.

**Why this approach over alternatives:** polling would add latency and wasted
work; inverting `VerifyClean` would over-trigger on benign edits. Event-driven
+ presence-gated re-Setup is precise, low-overhead, and reuses the connectors'
existing idempotent Setup so there is no second code path to keep in sync.

Gated by `guardrail.hook_self_heal` (default **true**); set false to restore
the prior behavior (hooks stay removed until next setup/restart).

## Architecture Diagram

```
Before:
  ┌──────────┐  Setup() writes hook  ┌────────────────────┐
  │Connector │──────────────────────▶│ agent config file  │
  └──────────┘                       │ (~/.cursor/...json) │
                                     └────────────────────┘
        (user deletes hook block) ─────────▶  enforcement lapses, no recovery

After:
  ┌──────────────┐ owns ┌───────────────┐ fsnotify ┌────────────────────┐
  │GuardrailProxy│─────▶│HookConfigGuard │◀─────────│ parent dir of cfg  │
  └──────┬───────┘      └───────┬───────┘  events    └─────────┬──────────┘
         │ Repoint/Suppress     │ presence-gated re-Setup       │
         │ on connector switch  ▼                               ▼
         │              ┌──────────────┐ rewrites    ┌────────────────────┐
         └─────────────▶│ Connector    │────────────▶│ agent config file  │
                        │ .Setup()     │             └────────────────────┘
                        └──────────────┘
                               │ audit + OTel + webhook on heal
                               ▼
                     connector-hook-tampered / connector-hook-repaired
```

## Flow Diagram

```
User           fsnotify        HookConfigGuard          Connector        Audit/OTel/Webhook
 │ delete hook  │                │                        │                  │
 │─────────────▶│ write/remove   │                        │                  │
 │              │───────────────▶│ record pending         │                  │
 │              │                │ (debounce tick)        │                  │
 │              │                │ OwnedHooksPresent? no  │                  │
 │              │                │ log tampered ──────────┼─────────────────▶│
 │              │                │ Setup(ctx) ───────────▶│ re-patch hook    │
 │              │                │ suppress self-write    │                  │
 │              │                │ re-sync watch set      │                  │
 │              │                │ log repaired + metric ─┼─────────────────▶│
 │              │                │ onHealed ──────────────┼──▶ webhook       │
```

## What Changed (Where & How)

| File | Change Type | Summary |
|---|---|---|
| `internal/gateway/connector/hook_config_paths.go` | added | `HookConfigPathsForConnector` + `OwnedHooksPresent`: resolve watched config files and detect the owned hook command (format-agnostic); inert for proxy/plugin connectors |
| `internal/gateway/hook_config_guard.go` | added | `HookConfigGuard`: fsnotify watch on parent dirs, debounce, self-write suppression, presence-gated re-Setup; `Start`/`Repoint`/`SuppressHealing`/`Stop` |
| `internal/gateway/proxy.go` | modified | Proxy owns the guard; `StartHookConfigGuard`, `notifyHookHealed` webhook fan-out, `Repoint` + `SuppressHealing` on runtime connector switch |
| `internal/gateway/sidecar.go` | modified | Start the guard in `runGuardrail` before the observability short-circuit, gated by `Enabled && HookSelfHeal` |
| `internal/config/config.go` | modified | Add `HookSelfHeal` (default true) + `HookSelfHealDebounceMs` to `GuardrailConfig`; viper defaults |
| `internal/config/defaults.go` | modified | Set defaults in `DefaultConfig()` |
| `internal/config/config_test.go` | test | Assert the new defaults |
| `internal/audit/actions.go` | modified | Add `ActionConnectorHookTampered` / `ActionConnectorHookRepaired` (+ `AllActions`) |
| `cli/defenseclaw/audit_actions.py` | modified | Mirror the two new action constants for Go/Python parity |
| `schemas/audit-event.json` | config | Add the two actions to the audit-event enum |
| `internal/cli/embed/audit-event.json` | config | Embedded schema parity for the two new actions |
| `internal/gateway/connector/hook_config_paths_test.go` | test | Unit tests for path resolution + presence detection (incl. inert proxy connectors, missing file) |
| `internal/gateway/hook_config_guard_test.go` | test | Integration tests: delete→restore, full-file recreate, unrelated-edit no-op, disabled no-op, repoint follows switch, notifier fires, suppress-then-resume |

## Open Issues / Follow-ups

- Transient `Setup` failure during a heal is logged as `guardrail-degraded`
  but not retried on a timer; recovery waits for the next filesystem event or a
  restart. Deferred — connector Setup is idempotent and failures are rare; a
  backoff-retry can be added if telemetry shows real occurrences.
- `SuppressHealing` uses a fixed 5s window across a connector hot-swap. A
  connector `Setup` that exceeds 5s would re-open a narrow race; abnormal and
  acceptable for now. TODO(@vineeth): revisit if slow-Setup connectors appear.
- Webhook fan-out reuses the existing dispatcher, which (correctly) rejects
  loopback endpoints via its SSRF allow-list; verified the callback path
  directly in tests rather than through a loopback receiver.

## Test Plan

- `gofmt -l` on changed files → clean
- `go build ./...` → OK
- `go vet ./internal/gateway/...` → OK
- `go test -race -run 'HookConfigGuard|OwnedHooksPresent|HookConfigPathsForConnector' ./internal/gateway/...` → PASS (delete→restore, recreate, unrelated-edit no-op, disabled no-op, repoint, notifier-fires, suppress-then-resume)
- `go test ./internal/config/...` → PASS (default-config assertions)
- `go test ./internal/audit/...` → PASS (audit action / schema parity)
- Manual end-to-end driver against the real `GuardrailProxy.StartHookConfigGuard` wiring + real audit SQLite store + real `WebhookDispatcher`: verified delete→restore, full-file recreate, unrelated-edit no-op, TOML (codex) restore, real `connector-hook-tampered`/`connector-hook-repaired` rows written, and the heal notifier firing with the correct connector name + path.
- Not tested: live multi-day soak; Windows path (native `defenseclaw-gateway hook` invocation) exercised via unit logic only, not on a Windows host.