### PR TITLE
docs: fix gateway command examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Start local observability with:
 
 ```bash
 defenseclaw setup local-observability up
-defenseclaw gateway
+defenseclaw-gateway start
 defenseclaw setup local-observability status
 ```
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -620,7 +620,7 @@ writes the `otel:` block in `~/.defenseclaw/config.yaml` automatically):
 
 ```bash
 defenseclaw setup local-observability up
-defenseclaw gateway                            # start sidecar; it reads config.yaml
+defenseclaw-gateway start                      # start sidecar; it reads config.yaml
 defenseclaw setup local-observability status   # compose ps + reachability probes
 defenseclaw setup local-observability down     # stop (volumes preserved)
 defenseclaw setup local-observability reset    # stop + wipe data volumes
@@ -633,7 +633,7 @@ works for CI / scripted environments:
 cd bundles/local_observability_stack
 ./bin/openclaw-observability-bridge up         # or ./run.sh up (compat shim)
 eval "$(./bin/openclaw-observability-bridge env)"
-go run ./cmd/defenseclaw gateway
+go run ./cmd/defenseclaw
 ./bin/openclaw-observability-bridge down
 ```
 


### PR DESCRIPTION
## Summary
- Replace stale `defenseclaw gateway` examples with `defenseclaw-gateway start`.
- Fix the source-run observability example to use `go run ./cmd/defenseclaw` without an invalid subcommand.

## Verification
- `go run ./cmd/defenseclaw start --help`
- `git diff --check`
- stale command search returned no matches in the touched docs