### PR TITLE
docs: full command-generator flag coverage + macOS sensitive-path parity + CRLF-safe token migration

### DIFF
--- a/cli/defenseclaw/migrations.py
+++ b/cli/defenseclaw/migrations.py
@@ -1369,7 +1369,13 @@ def _align_gateway_token_env_in_config(ctx: MigrationContext) -> None:
         return
 
     try:
-        with open(cfg_path) as f:
+        # newline="" preserves the file's existing line endings (CRLF on a
+        # Windows operator's hand-edited or cross-platform-copied config)
+        # so substituting the token_env value does not silently rewrite the
+        # whole file from CRLF to LF. Matches the CRLF-safe contract that
+        # ``_migrate_0_4_0_seed_hook_fail_mode`` already honours; Windows is
+        # a supported platform as of this release.
+        with open(cfg_path, newline="") as f:
             text = f.read()
     except OSError as exc:
         ux.warn(f"could not read {cfg_path}: {exc}", indent="    ")
@@ -1379,9 +1385,12 @@ def _align_gateway_token_env_in_config(ctx: MigrationContext) -> None:
     # ``_migrate_0_5_0_strip_codex_enforcement_keys`` — matches the
     # block header plus indented body, stopping at the next top-level
     # key. ``[ \t]*`` after the colon tolerates trailing whitespace
-    # that some YAML formatters add.
+    # that some YAML formatters add. ``\r?\n`` on the header (and the
+    # blank-line body branch) so a CRLF config matches too — ``[ \t]*``
+    # never consumes ``\r``, so a bare ``\n`` anchor would skip the
+    # whole block on a CRLF file and silently no-op the migration.
     block_match = re.search(
-        r"^gateway:[ \t]*\n(?P<body>(?:[ \t]+[^\n]*\n|\n)*)",
+        r"^gateway:[ \t]*\r?\n(?P<body>(?:[ \t]+[^\n]*\n|\r?\n)*)",
         text,
         flags=re.MULTILINE,
     )
@@ -1397,13 +1406,16 @@ def _align_gateway_token_env_in_config(ctx: MigrationContext) -> None:
     # we accept all three so we never miss a legitimately-formatted
     # legacy entry. An inline comment after the value is preserved
     # because the substitution only touches the captured value group.
+    # ``\r?\n`` in the suffix keeps a CRLF terminator intact in the
+    # rewritten line rather than dropping the ``\r`` (which would leave
+    # one LF line in an otherwise-CRLF file — mixed terminators).
     pattern = re.compile(
         r"""
         (?P<prefix>^[ \t]+token_env\s*:\s*)   # indent + key + colon + space
         (?P<quote>["']?)                       # optional opening quote
         OPENCLAW_GATEWAY_TOKEN                 # the literal legacy value
         (?P=quote)                             # matching closing quote
-        (?P<suffix>[ \t]*(?:\#[^\n]*)?\n)      # trailing space + optional comment + newline
+        (?P<suffix>[ \t]*(?:\#[^\n]*)?\r?\n)   # trailing space + optional comment + newline (CRLF-aware)
         """,
         flags=re.MULTILINE | re.VERBOSE,
     )

--- a/cli/defenseclaw/migrations.py
+++ b/cli/defenseclaw/migrations.py
@@ -979,26 +979,46 @@ def _read_active_connector_from_yaml(cfg_path: str) -> str:
     except OSError:
         return ""
 
-    # guardrail.connector wins if explicitly set (matches Config
-    # .activeConnector precedence in claw.go). The trailing
-    # ``[\t ]*(?:#[^\n]*)?$`` group accepts both bare values and
-    # values followed by a YAML inline comment so a hand-edited
-    # ``connector: codex  # gpt only`` still resolves cleanly.
-    m = re.search(
-        r"^guardrail:[ \t]*\n(?:[ \t]+[^\n]*\n)*?[ \t]+connector:[ \t]*[\"']?([A-Za-z0-9_-]+)[\"']?[ \t]*(?:#[^\n]*)?$",
-        text,
-        flags=re.MULTILINE,
-    )
-    if m and m.group(1).strip():
-        return _normalize_legacy_connector(m.group(1))
+    # Scope the value search to the block body captured by
+    # ``_find_top_level_block`` instead of one monolithic regex over
+    # the whole file. The previous pattern wrapped the block body in a
+    # lazy ``(?:[ \t]+[^\n]*\n)*?`` and required a trailing
+    # ``connector:``/``mode:`` line; when that key was ABSENT from a
+    # large block (e.g. a 30-line ``guardrail:`` with no
+    # ``connector:``), the ambiguous ``[ \t]+`` / ``[^\n]*`` overlap
+    # forced catastrophic backtracking (seconds of 100% CPU on a real
+    # config) — a ReDoS that hung ``defenseclaw upgrade`` at the v3
+    # active-connector seed. ``_find_top_level_block`` captures the
+    # body in linear time, and the per-line ``^[ \t]+<field>:`` search
+    # below is anchored with no nested unbounded quantifier, so it
+    # cannot backtrack pathologically.
+    def _value_in_block(key: str, field: str) -> str:
+        block = _find_top_level_block(text, key)
+        if not block:
+            return ""
+        # ``(?:#[^\n]*)?`` accepts a trailing YAML inline comment so a
+        # hand-edited ``connector: codex  # gpt only`` still resolves;
+        # ``(?:\r?\n|$)`` keeps the match CRLF- and EOF-safe.
+        field_match = re.search(
+            r"^[ \t]+" + re.escape(field) + r":[ \t]*[\"']?"
+            r"([A-Za-z0-9_-]+)[\"']?[ \t]*(?:#[^\n]*)?(?:\r?\n|$)",
+            block.group("body"),
+            flags=re.MULTILINE,
+        )
+        if field_match and field_match.group(1).strip():
+            return field_match.group(1)
+        return ""
 
-    m = re.search(
-        r"^claw:[ \t]*\n(?:[ \t]+[^\n]*\n)*?[ \t]+mode:[ \t]*[\"']?([A-Za-z0-9_-]+)[\"']?[ \t]*(?:#[^\n]*)?$",
-        text,
-        flags=re.MULTILINE,
-    )
-    if m and m.group(1).strip():
-        return _normalize_legacy_connector(m.group(1))
+    # guardrail.connector wins if explicitly set (matches Config
+    # .activeConnector precedence in claw.go); else fall back to
+    # claw.mode.
+    connector = _value_in_block("guardrail", "connector")
+    if connector:
+        return _normalize_legacy_connector(connector)
+
+    mode = _value_in_block("claw", "mode")
+    if mode:
+        return _normalize_legacy_connector(mode)
     return ""
 
 

--- a/cli/defenseclaw/migrations.py
+++ b/cli/defenseclaw/migrations.py
@@ -941,7 +941,7 @@ def _read_config_text(cfg_path: str) -> str | None:
 _TOP_LEVEL_BLOCK_BODY = r"(?P<body>(?:[ \t]+[^\n]*\n|\r?\n)*(?:[ \t]+[^\n]*)?)"
 
 
-def _find_top_level_block(text: str, key: str) -> "re.Match[str] | None":
+def _find_top_level_block(text: str, key: str) -> re.Match[str] | None:
     """Locate a column-0 ``<key>:`` block and capture its indented body.
 
     Returns the match (with a named ``body`` group spanning the block

--- a/cli/defenseclaw/migrations.py
+++ b/cli/defenseclaw/migrations.py
@@ -438,49 +438,66 @@ def _migrate_0_4_0_normalize_claw_mode(ctx: MigrationContext) -> None:
     YAML loader because the loader pulls in the entire dataclass tree
     (which has its own back-compat handling for the very fields we are
     trying to migrate) — a surgical sed-style edit is safer here. The
-    rewrite is anchored to the ``claw:`` block so a stray ``mode:
-    nemoclaw`` somewhere else in config.yaml is not touched.
+    rewrite is anchored to the ``claw:`` block (via
+    ``_find_top_level_block``) so a stray ``mode: nemoclaw`` somewhere
+    else in config.yaml is not touched. Reading through
+    ``_read_config_text`` + writing through ``_atomic_write_text``
+    preserves the file's line endings, so a CRLF config is rewritten in
+    place rather than flattened to LF.
+
+    The flow-style mapping ``claw: {mode: nemoclaw}`` is intentionally
+    NOT matched — those round-trip correctly through ``config.save()``
+    so the operator either edited them manually or the upgrade is
+    harmless.
     """
     cfg_path = os.path.join(ctx.data_dir, "config.yaml")
     if not os.path.isfile(cfg_path):
         return
 
-    try:
-        with open(cfg_path) as f:
-            text = f.read()
-    except OSError as exc:
-        ux.warn(f"could not read {cfg_path}: {exc}", indent="    ")
+    text = _read_config_text(cfg_path)
+    if text is None:
         return
 
-    new_text = text
+    block = _find_top_level_block(text, "claw")
+    if not block:
+        return
+
+    body = block.group("body")
+    new_body = body
     for legacy, replacement in _LEGACY_CLAW_MODE_REMAP.items():
-        # Match `mode: <legacy>` only inside the claw block. Since
-        # YAML allows arbitrary indentation we look for the literal
-        # `claw:` line followed (at any distance) by an indented
-        # `mode: <legacy>`. The trailing-context group preserves any
-        # closing quote, surrounding whitespace, and an optional
-        # YAML inline comment (``mode: nemoclaw  # legacy``) so a
-        # commented hand-edited line still normalizes cleanly. The
-        # pattern still rejects flow-style mappings (``claw: { mode:
-        # nemoclaw }``) — those round-trip correctly through
-        # ``config.save()`` so the operator either edited them
-        # manually or the upgrade is harmless.
+        # Match an indented ``mode: <legacy>`` line inside the claw
+        # body. The value may be bare or quoted; an inline comment
+        # (``mode: nemoclaw  # legacy``) is preserved because only the
+        # value group is substituted. ``(?:\r?\n|$)`` keeps a CRLF
+        # terminator intact and still matches a final line with no
+        # trailing newline.
         pattern = re.compile(
-            r"(^claw:[ \t]*\n(?:[ \t]+[^\n]*\n)*?[ \t]+mode:[ \t]*[\"']?)"
+            r"(?P<prefix>^[ \t]+mode:[ \t]*)(?P<quote>[\"']?)"
             + re.escape(legacy)
-            + r"([\"']?[ \t]*(?:#[^\n]*)?$)",
+            + r"(?P=quote)(?P<suffix>[ \t]*(?:#[^\n]*)?(?:\r?\n|$))",
             flags=re.MULTILINE,
         )
-        new_text, count = pattern.subn(rf"\g<1>{replacement}\g<2>", new_text)
+        new_body, count = pattern.subn(
+            lambda m, repl=replacement: (
+                f"{m.group('prefix')}{m.group('quote')}{repl}"
+                f"{m.group('quote')}{m.group('suffix')}"
+            ),
+            new_body,
+        )
         if count:
             ctx.changes.append(
                 f"normalized claw.mode: {legacy} → {replacement} "
                 "(S3.1: legacy enum dropped from OTel schema)"
             )
 
-    if new_text != text:
-        if not _atomic_write_text(cfg_path, new_text):
-            ux.warn(f"could not write {cfg_path}", indent="    ")
+    if new_body == body:
+        return
+
+    new_text = text[: block.start("body")] + new_body + text[block.end("body") :]
+    if new_text == text:
+        return
+    if not _atomic_write_text(cfg_path, new_text):
+        ux.warn(f"could not write {cfg_path}", indent="    ")
 
 
 def _migrate_0_4_0_seed_active_connector(ctx: MigrationContext) -> None:
@@ -840,10 +857,18 @@ def _dotenv_update_keys(
 
 
 def _atomic_write_text(path: str, body: str, *, mode: int = 0o644) -> bool:
-    """Atomically write ``body`` to ``path`` with the given file mode.
+    """Atomically write ``body`` to ``path``.
 
     Creates parent directories as needed (mode 0o700 for the directory
     when it carries the secret-bearing files this migration touches).
+
+    File mode: when ``path`` already exists its current permissions are
+    preserved across the rewrite; ``mode`` is only the fallback for a
+    newly-created file. Without this, rewriting a single line in a
+    ``config.yaml`` an operator had locked down to 0o600 would silently
+    widen it to the 0o644 default — a migration that promises to be a
+    no-touch edit must not change a file's permission posture.
+
     Returns True on success.
     """
     parent = os.path.dirname(path)
@@ -853,6 +878,13 @@ def _atomic_write_text(path: str, body: str, *, mode: int = 0o644) -> bool:
         except OSError as exc:
             ux.warn(f"could not create {parent}: {exc}", indent="    ")
             return False
+    # Preserve the existing file's perms; fall back to ``mode`` so a
+    # caller creating a fresh secret-bearing file (e.g. the
+    # active-connector marker at 0o600) can still pin its perms.
+    try:
+        effective_mode = os.stat(path).st_mode & 0o777
+    except OSError:
+        effective_mode = mode
     tmp = path + ".tmp"
     try:
         # newline="" writes ``body`` byte-for-byte (no \n -> os.linesep
@@ -860,7 +892,7 @@ def _atomic_write_text(path: str, body: str, *, mode: int = 0o644) -> bool:
         # does not get them doubled to \r\r\n on Windows.
         with open(tmp, "w", encoding="utf-8", newline="") as f:
             f.write(body)
-        os.chmod(tmp, mode)
+        os.chmod(tmp, effective_mode)
         os.replace(tmp, path)
         return True
     except OSError as exc:
@@ -870,6 +902,63 @@ def _atomic_write_text(path: str, body: str, *, mode: int = 0o644) -> bool:
         except OSError:
             pass
         return False
+
+
+def _read_config_text(cfg_path: str) -> str | None:
+    """Read a ``config.yaml`` for in-place rewriting, preserving newlines.
+
+    ``newline=""`` disables Python's universal-newline translation so a
+    CRLF file (a Windows operator's config, or one copied from a Windows
+    host) keeps its ``\\r\\n`` bytes verbatim. Paired with
+    ``_atomic_write_text`` (which also writes byte-for-byte), a migration
+    that edits a single line does not silently reflow the whole file from
+    CRLF to LF. Returns ``None`` (after warning) when the file cannot be
+    read so callers can bail without special-casing the error themselves.
+
+    Every surgical ``config.yaml`` rewriter reads through here so the
+    newline contract lives in one place instead of being re-derived
+    (and occasionally forgotten) per migration.
+    """
+    try:
+        with open(cfg_path, newline="") as f:
+            return f.read()
+    except OSError as exc:
+        ux.warn(f"could not read {cfg_path}: {exc}", indent="    ")
+        return None
+
+
+# Body of a top-level YAML block: every indented or blank line beneath
+# the header, stopping at the next column-0 key or end-of-file.
+#
+#   * ``[ \t]+[^\n]*\n``  — an indented line. ``[^\n]*`` swallows a
+#     trailing ``\r`` so CRLF lines match without a dedicated branch.
+#   * ``\r?\n``           — a blank line, CRLF-aware so a blank ``\r\n``
+#     inside the block is not mistaken for the block's end (a bare
+#     ``\n`` branch would stop at the ``\r`` and truncate the body).
+#   * trailing ``(?:[ \t]+[^\n]*)?`` — an optional final indented line
+#     with NO trailing newline, so a config whose last line lacks an EOL
+#     terminator is still captured (and therefore still rewritable).
+_TOP_LEVEL_BLOCK_BODY = r"(?P<body>(?:[ \t]+[^\n]*\n|\r?\n)*(?:[ \t]+[^\n]*)?)"
+
+
+def _find_top_level_block(text: str, key: str) -> "re.Match[str] | None":
+    """Locate a column-0 ``<key>:`` block and capture its indented body.
+
+    Returns the match (with a named ``body`` group spanning the block
+    body) or ``None`` when no such block exists. Header and body are both
+    CRLF-aware and tolerate a final line without a trailing newline.
+
+    The surgical config rewriters (``claw.mode`` normalize, legacy
+    enforcement-key strip, gateway ``token_env`` realign) all locate
+    their block through here so "what counts as a top-level YAML block"
+    has exactly one definition. Previously each hand-rolled its own
+    regex, which is how the CRLF handling drifted apart between them.
+    """
+    return re.search(
+        r"^" + re.escape(key) + r":[ \t]*\r?\n" + _TOP_LEVEL_BLOCK_BODY,
+        text,
+        flags=re.MULTILINE,
+    )
 
 
 def _read_active_connector_from_yaml(cfg_path: str) -> str:
@@ -1231,18 +1320,11 @@ def _migrate_0_5_0_strip_codex_enforcement_keys(ctx: MigrationContext) -> None:
     if not os.path.isfile(cfg_path):
         return
 
-    try:
-        with open(cfg_path) as f:
-            text = f.read()
-    except OSError as exc:
-        ux.warn(f"could not read {cfg_path}: {exc}", indent="    ")
+    text = _read_config_text(cfg_path)
+    if text is None:
         return
 
-    block_match = re.search(
-        r"^guardrail:[ \t]*\n(?P<body>(?:[ \t]+[^\n]*\n|\n)*)",
-        text,
-        flags=re.MULTILINE,
-    )
+    block_match = _find_top_level_block(text, "guardrail")
     if not block_match:
         return
 
@@ -1253,12 +1335,14 @@ def _migrate_0_5_0_strip_codex_enforcement_keys(ctx: MigrationContext) -> None:
     removed: list[str] = []
     new_body = body
     for key in _LEGACY_GUARDRAIL_ENFORCEMENT_KEYS:
-        # Match the full line carrying the legacy key (with its
-        # trailing newline). The pattern accepts any value form
-        # (quoted/unquoted bool, optional inline comment) and any
-        # leading indentation the operator chose.
+        # Delete the whole line carrying the legacy key (with its
+        # terminator). The pattern accepts any value form (quoted /
+        # unquoted bool, optional inline comment) and any leading
+        # indentation the operator chose. ``(?:\r?\n|$)`` removes the
+        # CRLF terminator with the line (no orphaned ``\r`` left behind)
+        # and also matches a final key line with no trailing newline.
         pattern = re.compile(
-            r"^[ \t]+" + re.escape(key) + r"\s*:[^\n]*\n",
+            r"^[ \t]+" + re.escape(key) + r"\s*:[^\n]*(?:\r?\n|$)",
             flags=re.MULTILINE,
         )
         new_body, count = pattern.subn("", new_body)
@@ -1368,32 +1452,14 @@ def _align_gateway_token_env_in_config(ctx: MigrationContext) -> None:
     if not existing_env.get("DEFENSECLAW_GATEWAY_TOKEN", "").strip():
         return
 
-    try:
-        # newline="" preserves the file's existing line endings (CRLF on a
-        # Windows operator's hand-edited or cross-platform-copied config)
-        # so substituting the token_env value does not silently rewrite the
-        # whole file from CRLF to LF. Matches the CRLF-safe contract that
-        # ``_migrate_0_4_0_seed_hook_fail_mode`` already honours; Windows is
-        # a supported platform as of this release.
-        with open(cfg_path, newline="") as f:
-            text = f.read()
-    except OSError as exc:
-        ux.warn(f"could not read {cfg_path}: {exc}", indent="    ")
+    text = _read_config_text(cfg_path)
+    if text is None:
         return
 
-    # Find the ``gateway:`` block. Same pattern shape as
-    # ``_migrate_0_5_0_strip_codex_enforcement_keys`` — matches the
-    # block header plus indented body, stopping at the next top-level
-    # key. ``[ \t]*`` after the colon tolerates trailing whitespace
-    # that some YAML formatters add. ``\r?\n`` on the header (and the
-    # blank-line body branch) so a CRLF config matches too — ``[ \t]*``
-    # never consumes ``\r``, so a bare ``\n`` anchor would skip the
-    # whole block on a CRLF file and silently no-op the migration.
-    block_match = re.search(
-        r"^gateway:[ \t]*\r?\n(?P<body>(?:[ \t]+[^\n]*\n|\r?\n)*)",
-        text,
-        flags=re.MULTILINE,
-    )
+    # Scope the rewrite to the ``gateway:`` block (via the shared
+    # CRLF/EOF-aware block matcher) so a stray ``token_env:`` under
+    # another section is never touched.
+    block_match = _find_top_level_block(text, "gateway")
     if not block_match:
         return
 
@@ -1406,16 +1472,17 @@ def _align_gateway_token_env_in_config(ctx: MigrationContext) -> None:
     # we accept all three so we never miss a legitimately-formatted
     # legacy entry. An inline comment after the value is preserved
     # because the substitution only touches the captured value group.
-    # ``\r?\n`` in the suffix keeps a CRLF terminator intact in the
-    # rewritten line rather than dropping the ``\r`` (which would leave
-    # one LF line in an otherwise-CRLF file — mixed terminators).
+    # ``(?:\r?\n|$)`` in the suffix keeps a CRLF terminator intact in
+    # the rewritten line (rather than dropping the ``\r`` and leaving
+    # mixed terminators) and still matches a final line with no
+    # trailing newline.
     pattern = re.compile(
         r"""
         (?P<prefix>^[ \t]+token_env\s*:\s*)   # indent + key + colon + space
         (?P<quote>["']?)                       # optional opening quote
         OPENCLAW_GATEWAY_TOKEN                 # the literal legacy value
         (?P=quote)                             # matching closing quote
-        (?P<suffix>[ \t]*(?:\#[^\n]*)?\r?\n)   # trailing space + optional comment + newline (CRLF-aware)
+        (?P<suffix>[ \t]*(?:\#[^\n]*)?(?:\r?\n|$))  # trailing space + optional comment + EOL/EOF
         """,
         flags=re.MULTILINE | re.VERBOSE,
     )

--- a/cli/tests/test_migrations.py
+++ b/cli/tests/test_migrations.py
@@ -36,6 +36,7 @@ from defenseclaw.migrations import (
     _migrate_0_5_0,
     _migrate_0_5_0_strip_codex_enforcement_keys,
     _parse_dotenv,
+    _read_active_connector_from_yaml,
     run_migrations,
 )
 
@@ -799,6 +800,73 @@ class TestMigrate040SeedActiveConnector(unittest.TestCase):
         with open(state_path) as f:
             state = json.load(f)
         self.assertEqual(state["name"], "claudecode")
+
+    def test_large_guardrail_block_without_connector_is_not_redos(self):
+        """A real-world ``guardrail:`` block carries many nested keys and
+        no ``connector:``. The connector probe must stay linear: the old
+        ``^guardrail:...(?:[ \\t]+[^\\n]*\\n)*?connector:`` pattern
+        backtracked catastrophically (multi-second 100% CPU) on such a
+        block, hanging the v3 active-connector seed during upgrade.
+
+        We assert (a) the value still falls back to ``claw.mode`` and
+        (b) the lookup completes well inside a generous budget so a
+        future ReDoS regression trips this test instead of a stuck CLI.
+        """
+        import time
+
+        body_lines = "".join(
+            f"  key_{i}: value-{i}-with-some-trailing-text\n" for i in range(40)
+        )
+        cfg_path = os.path.join(self.data_dir, "config.yaml")
+        with open(cfg_path, "w") as f:
+            f.write(
+                "claw:\n  mode: openclaw\n"
+                "guardrail:\n  enabled: true\n  mode: action\n" + body_lines
+            )
+
+        start = time.perf_counter()
+        name = _read_active_connector_from_yaml(cfg_path)
+        elapsed = time.perf_counter() - start
+
+        self.assertEqual(name, "openclaw")
+        self.assertLess(
+            elapsed,
+            1.0,
+            msg=f"connector probe took {elapsed:.2f}s — possible ReDoS regression",
+        )
+
+    def test_seeds_active_connector_for_real_world_shaped_config(self):
+        """End-to-end: the 0.4.0 seed must complete (not hang) on a
+        config whose guardrail block has many keys but no connector."""
+        body_lines = "".join(f"  k{i}: v{i}\n" for i in range(40))
+        cfg_path = os.path.join(self.data_dir, "config.yaml")
+        with open(cfg_path, "w") as f:
+            f.write(
+                "claw:\n  mode: openclaw\n"
+                "guardrail:\n  enabled: true\n" + body_lines
+            )
+
+        ctx = _ctx(self.tmp, self.data_dir)
+        _migrate_0_4_0(ctx)
+
+        state_path = os.path.join(self.data_dir, "active_connector.json")
+        with open(state_path) as f:
+            state = json.load(f)
+        self.assertEqual(state["name"], "openclaw")
+
+    def test_explicit_connector_after_blank_line_in_block(self):
+        """``_find_top_level_block`` captures blank lines inside a block,
+        so a ``connector:`` separated from the header by a blank line is
+        still resolved (the old indented-line-only scan stopped at the
+        blank line)."""
+        cfg_path = os.path.join(self.data_dir, "config.yaml")
+        with open(cfg_path, "w") as f:
+            f.write(
+                "claw:\n  mode: openclaw\n"
+                "guardrail:\n  enabled: true\n\n  connector: codex\n"
+            )
+
+        self.assertEqual(_read_active_connector_from_yaml(cfg_path), "codex")
 
 
 class TestMigrate040NoTouchOnEmptyDataDir(unittest.TestCase):

--- a/cli/tests/test_migrations.py
+++ b/cli/tests/test_migrations.py
@@ -27,11 +27,14 @@ from unittest.mock import patch
 from defenseclaw.migrations import (
     _LEGACY_FLAT_REGO_FILENAMES,
     MigrationContext,
+    _atomic_write_text,
     _migrate_0_3_0,
     _migrate_0_3_0_from_pristine,
     _migrate_0_3_0_surgical,
     _migrate_0_4_0,
+    _migrate_0_4_0_normalize_claw_mode,
     _migrate_0_5_0,
+    _migrate_0_5_0_strip_codex_enforcement_keys,
     _parse_dotenv,
     run_migrations,
 )
@@ -707,6 +710,47 @@ class TestMigrate040ClawModeNormalize(unittest.TestCase):
         self.assertIn("mode: openclaw  # legacy enum, retired in 0.4.0", text)
         self.assertNotIn("nemoclaw", text)
 
+    def test_rewrites_crlf_config_preserving_line_endings(self):
+        """A CRLF config (Windows operator, or one copied from a Windows
+        host) must be normalized in place — not silently flattened to
+        LF, which would churn the operator's VCS diff and diverge from
+        the other surgical rewriters that already preserve CRLF."""
+        cfg_path = os.path.join(self.data_dir, "config.yaml")
+        with open(cfg_path, "w", newline="") as f:
+            f.write(
+                "claw:\r\n"
+                "  mode: nemoclaw  # legacy enum\r\n"
+                "  home_dir: ~/.openclaw\r\n"
+            )
+
+        ctx = _ctx(self.tmp, self.data_dir)
+        _migrate_0_4_0_normalize_claw_mode(ctx)
+
+        with open(cfg_path, newline="") as f:
+            text = f.read()
+        # Value flipped, inline comment + CRLF terminator preserved.
+        self.assertIn("  mode: openclaw  # legacy enum\r\n", text)
+        self.assertNotIn("nemoclaw", text)
+        # No mixed endings: every LF is part of a CRLF pair.
+        self.assertEqual(text.count("\n"), text.count("\r\n"))
+        self.assertIn("  home_dir: ~/.openclaw\r\n", text)
+
+    def test_rewrites_when_final_line_lacks_trailing_newline(self):
+        """A hand-edited config whose final line is the legacy mode
+        value with no trailing newline must still be rewritten — the
+        block matcher captures a terminator-less last line."""
+        cfg_path = os.path.join(self.data_dir, "config.yaml")
+        with open(cfg_path, "w", newline="") as f:
+            f.write("claw:\n  mode: nemoclaw")  # deliberately no EOL
+
+        ctx = _ctx(self.tmp, self.data_dir)
+        _migrate_0_4_0_normalize_claw_mode(ctx)
+
+        with open(cfg_path, newline="") as f:
+            text = f.read()
+        self.assertEqual(text, "claw:\n  mode: openclaw")
+        self.assertNotIn("nemoclaw", text)
+
 
 class TestMigrate040SeedActiveConnector(unittest.TestCase):
     def setUp(self):
@@ -1277,6 +1321,168 @@ class TestRunMigrations050(unittest.TestCase):
 
             # Stale file remains because 0.5.0 wasn't in range.
             self.assertTrue(os.path.isfile(stale))
+
+
+class TestMigrate050StripCodexEnforcementKeys(unittest.TestCase):
+    """0.5.0 deletes the retired ``guardrail.*_enforcement_enabled``
+    keys from config.yaml. This step had no dedicated unit coverage
+    before the surgical config rewriters were unified onto the shared
+    CRLF/EOF-aware block matcher — these tests lock in the contract
+    (sibling preservation, comment handling, CRLF, terminator-less
+    last line, idempotency)."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="dclaw-mig-050-strip-")
+        self.data_dir = os.path.join(self.tmp, "data")
+        os.makedirs(self.data_dir, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp)
+
+    def _ctx(self) -> MigrationContext:
+        return MigrationContext(openclaw_home=self.tmp, data_dir=self.data_dir)
+
+    def _write(self, body: str) -> None:
+        # newline="" keeps explicit \r\n bytes verbatim on write.
+        with open(os.path.join(self.data_dir, "config.yaml"), "w", newline="") as f:
+            f.write(body)
+
+    def _read(self) -> str:
+        with open(os.path.join(self.data_dir, "config.yaml"), newline="") as f:
+            return f.read()
+
+    def test_strips_both_keys_preserving_siblings(self):
+        self._write(
+            "guardrail:\n"
+            "  enabled: true\n"
+            "  codex_enforcement_enabled: true\n"
+            "  mode: action\n"
+            "  claudecode_enforcement_enabled: false\n"
+            "  block_message: hi\n"
+        )
+
+        ctx = self._ctx()
+        _migrate_0_5_0_strip_codex_enforcement_keys(ctx)
+
+        after = self._read()
+        self.assertNotIn("codex_enforcement_enabled", after)
+        self.assertNotIn("claudecode_enforcement_enabled", after)
+        # Unrelated keys survive, ordering intact.
+        self.assertIn("  enabled: true\n", after)
+        self.assertIn("  mode: action\n", after)
+        self.assertIn("  block_message: hi\n", after)
+        self.assertLess(after.index("mode: action"), after.index("block_message"))
+        joined = "\n".join(ctx.changes)
+        self.assertIn("codex_enforcement_enabled", joined)
+        self.assertIn("claudecode_enforcement_enabled", joined)
+
+    def test_idempotent_when_keys_absent(self):
+        original = "guardrail:\n  enabled: true\n  mode: action\n"
+        self._write(original)
+
+        ctx = self._ctx()
+        _migrate_0_5_0_strip_codex_enforcement_keys(ctx)
+
+        self.assertEqual(self._read(), original)
+        self.assertEqual(ctx.changes, [])
+
+    def test_strips_key_with_inline_comment(self):
+        self._write(
+            "guardrail:\n"
+            "  codex_enforcement_enabled: true  # legacy knob, retired 0.5.0\n"
+            "  mode: action\n"
+        )
+
+        ctx = self._ctx()
+        _migrate_0_5_0_strip_codex_enforcement_keys(ctx)
+
+        after = self._read()
+        self.assertNotIn("codex_enforcement_enabled", after)
+        self.assertNotIn("legacy knob", after)
+        self.assertIn("  mode: action\n", after)
+
+    def test_preserves_crlf_line_endings(self):
+        """The deleted line must take its CRLF terminator with it — no
+        orphaned ``\\r`` and no flatten of the surviving lines."""
+        self._write(
+            "guardrail:\r\n"
+            "  enabled: true\r\n"
+            "  codex_enforcement_enabled: true\r\n"
+            "  mode: action\r\n"
+        )
+
+        ctx = self._ctx()
+        _migrate_0_5_0_strip_codex_enforcement_keys(ctx)
+
+        after = self._read()
+        self.assertNotIn("codex_enforcement_enabled", after)
+        # No orphaned \r left where the line was deleted.
+        self.assertNotIn("\r\r", after)
+        # No mixed endings: every LF is part of a CRLF pair.
+        self.assertEqual(after.count("\n"), after.count("\r\n"))
+        self.assertIn("  enabled: true\r\n", after)
+        self.assertIn("  mode: action\r\n", after)
+
+    def test_strips_key_on_final_line_without_trailing_newline(self):
+        self._write(
+            "guardrail:\n"
+            "  mode: action\n"
+            "  codex_enforcement_enabled: true"  # deliberately no EOL
+        )
+
+        ctx = self._ctx()
+        _migrate_0_5_0_strip_codex_enforcement_keys(ctx)
+
+        after = self._read()
+        self.assertEqual(after, "guardrail:\n  mode: action\n")
+        self.assertNotIn("codex_enforcement_enabled", after)
+
+    def test_no_op_when_no_guardrail_block(self):
+        original = "claw:\n  mode: openclaw\n"
+        self._write(original)
+
+        ctx = self._ctx()
+        _migrate_0_5_0_strip_codex_enforcement_keys(ctx)
+
+        self.assertEqual(self._read(), original)
+        self.assertEqual(ctx.changes, [])
+
+    def test_no_op_when_config_missing(self):
+        ctx = self._ctx()
+        _migrate_0_5_0_strip_codex_enforcement_keys(ctx)  # no config.yaml
+        self.assertEqual(ctx.changes, [])
+
+
+class TestAtomicWriteTextModePreservation(unittest.TestCase):
+    """``_atomic_write_text`` must preserve an existing file's perms
+    across a rewrite — a surgical one-line config edit must never
+    silently widen a file an operator hardened to 0o600 — while still
+    honouring the explicit ``mode`` for a freshly-created file."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="dclaw-mig-atomic-")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp)
+
+    def test_preserves_existing_file_mode_on_rewrite(self):
+        path = os.path.join(self.tmp, "config.yaml")
+        with open(path, "w") as f:
+            f.write("old\n")
+        os.chmod(path, 0o600)
+
+        # Default mode is 0o644, but the existing 0o600 must win.
+        self.assertTrue(_atomic_write_text(path, "new\n"))
+
+        self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), 0o600)
+        with open(path) as f:
+            self.assertEqual(f.read(), "new\n")
+
+    def test_uses_mode_param_for_new_file(self):
+        path = os.path.join(self.tmp, "fresh.json")
+        # File does not exist yet → the explicit mode pins the perms.
+        self.assertTrue(_atomic_write_text(path, "{}", mode=0o600))
+        self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), 0o600)
 
 
 if __name__ == "__main__":

--- a/cli/tests/test_migrations_gateway_token_env_realign.py
+++ b/cli/tests/test_migrations_gateway_token_env_realign.py
@@ -245,6 +245,45 @@ class TestAlignGatewayTokenEnv(unittest.TestCase):
         after = _read_config(self.tmp)
         self.assertIn('token_env: "DEFENSECLAW_GATEWAY_TOKEN"', after)
 
+    def test_preserves_crlf_line_endings(self):
+        """A CRLF-terminated config.yaml (Windows operator, or a config
+        copied from a Windows host) must still get rewritten, and the
+        edited line must keep its CRLF terminator so the file does not
+        end up with mixed line endings. Windows is a supported platform
+        as of this release; without newline="" + a CRLF-aware regex the
+        migration either silently no-ops (header never matches) or
+        flattens the whole file to LF.
+        """
+        _seed_dotenv(self.tmp, DEFENSECLAW_GATEWAY_TOKEN="abc123")
+        cfg_path = os.path.join(self.tmp, "config.yaml")
+        # newline="" keeps our explicit \r\n bytes verbatim on write.
+        with open(cfg_path, "w", newline="") as f:
+            f.write(
+                "gateway:\r\n"
+                "  host: 127.0.0.1\r\n"
+                "  token_env: OPENCLAW_GATEWAY_TOKEN  # legacy\r\n"
+                "  api_port: 18970\r\n"
+                "guardrail:\r\n"
+                "  enabled: true\r\n"
+            )
+
+        ctx = self._ctx()
+        _align_gateway_token_env_in_config(ctx)
+
+        with open(cfg_path, newline="") as f:
+            after = f.read()
+        # Value rewritten, inline comment preserved, CRLF terminator intact.
+        self.assertIn(
+            "  token_env: DEFENSECLAW_GATEWAY_TOKEN  # legacy\r\n", after
+        )
+        self.assertNotIn("OPENCLAW_GATEWAY_TOKEN", after)
+        # No mixed endings: every LF in the file is part of a CRLF pair.
+        self.assertEqual(after.count("\n"), after.count("\r\n"))
+        # Unrelated lines kept their CRLF too.
+        self.assertIn("  host: 127.0.0.1\r\n", after)
+        self.assertIn("  api_port: 18970\r\n", after)
+        self.assertTrue(any("repointed gateway.token_env" in c for c in ctx.changes))
+
     def test_no_op_when_config_yaml_missing(self):
         """Fresh install or partial-setup host → no config.yaml. The
         migration must not crash; just return silently.

--- a/docs-site/components/command-generator.tsx
+++ b/docs-site/components/command-generator.tsx
@@ -41,6 +41,14 @@ type ScannerMode = 'local' | 'remote' | 'both';
 type DetectionStrategy = 'regex_only' | 'regex_judge' | 'judge_first';
 type RulePack = 'default' | 'strict' | 'permissive';
 type HitlSeverity = 'high' | 'medium' | 'low' | 'critical';
+// Advanced judge-provider knobs. Empty string = "omit the flag" for the
+// select-backed fields; the tri-state covers --inherit-llm/--no-inherit-llm.
+type LlmRole = '' | 'judge_only' | 'judge_and_agent';
+type InheritFrom = '' | 'guardrail' | 'scanners.skill' | 'scanners.mcp' | 'scanners.plugin';
+type InheritLlm = 'unset' | 'yes' | 'no';
+type BedrockAuthMode = '' | 'api_key' | 'iam_credentials' | 'profile' | 'instance_role';
+type VertexAuthMode = '' | 'service_account' | 'adc' | 'workload_identity';
+type AzureAuthMode = '' | 'api_key' | 'managed_identity';
 
 interface GeneratorState {
   connector: string;
@@ -54,14 +62,42 @@ interface GeneratorState {
   judgeModel: string;
   judgeApiBase: string;
   judgeApiKeyEnv: string;
+  // Advanced judge LLM provider + auth (only meaningful when a judge runs).
+  judgeProvider: string;
+  judgeRegion: string;
+  judgeInstanceName: string;
+  llmRole: LlmRole;
+  inheritFrom: InheritFrom;
+  inheritLlm: InheritLlm;
+  judgeBedrockRegion: string;
+  judgeBedrockAuthMode: BedrockAuthMode;
+  judgeBedrockAccessKeyEnv: string;
+  judgeBedrockSecretKeyEnv: string;
+  judgeBedrockSessionTokenEnv: string;
+  judgeBedrockProfileName: string;
+  judgeBedrockInferenceProfile: string;
+  judgeBedrockDeployments: string; // one `alias=model-id` per line
+  judgeVertexProjectId: string;
+  judgeVertexRegion: string;
+  judgeVertexAuthMode: VertexAuthMode;
+  judgeVertexServiceAccountJsonEnv: string;
+  judgeAzureEndpoint: string;
+  judgeAzureApiVersion: string;
+  judgeAzureAuthMode: AzureAuthMode;
+  judgeAzureDeployments: string; // one `model=deployment` per line
+  judgeTlsCaCertFile: string;
+  judgeInsecureSkipVerify: boolean;
   humanApproval: boolean;
   hiltMinSeverity: HitlSeverity;
   port: string;
   blockMessage: string;
   disableRedaction: boolean;
+  workspaceDir: string;
+  disableGuardrail: boolean;
   restart: boolean;
   verify: boolean;
   showAdvanced: boolean;
+  showJudgeProvider: boolean;
 }
 
 const DEFAULT_STATE: GeneratorState = {
@@ -76,15 +112,68 @@ const DEFAULT_STATE: GeneratorState = {
   judgeModel: 'anthropic/claude-sonnet-4-20250514',
   judgeApiBase: '',
   judgeApiKeyEnv: 'DEFENSECLAW_LLM_KEY',
+  judgeProvider: '',
+  judgeRegion: '',
+  judgeInstanceName: '',
+  llmRole: '',
+  inheritFrom: '',
+  inheritLlm: 'unset',
+  judgeBedrockRegion: '',
+  judgeBedrockAuthMode: '',
+  judgeBedrockAccessKeyEnv: '',
+  judgeBedrockSecretKeyEnv: '',
+  judgeBedrockSessionTokenEnv: '',
+  judgeBedrockProfileName: '',
+  judgeBedrockInferenceProfile: '',
+  judgeBedrockDeployments: '',
+  judgeVertexProjectId: '',
+  judgeVertexRegion: '',
+  judgeVertexAuthMode: '',
+  judgeVertexServiceAccountJsonEnv: '',
+  judgeAzureEndpoint: '',
+  judgeAzureApiVersion: '',
+  judgeAzureAuthMode: '',
+  judgeAzureDeployments: '',
+  judgeTlsCaCertFile: '',
+  judgeInsecureSkipVerify: false,
   humanApproval: false,
   hiltMinSeverity: 'high',
   port: '',
   blockMessage: '',
   disableRedaction: false,
+  workspaceDir: '',
+  disableGuardrail: false,
   restart: true,
   verify: true,
   showAdvanced: false,
+  showJudgeProvider: false,
 };
+
+// Provider classification helpers. The CLI accepts free-text providers but
+// only Bedrock / Vertex / Azure have typed-auth flag families; we normalise
+// here so the UI and the command builder agree on which auth block applies.
+function normProvider(p: string): string {
+  return p.trim().toLowerCase();
+}
+function isBedrockProvider(p: string): boolean {
+  return normProvider(p) === 'bedrock';
+}
+function isVertexProvider(p: string): boolean {
+  const n = normProvider(p);
+  return n === 'vertex_ai' || n === 'vertex' || n === 'gemini';
+}
+function isAzureProvider(p: string): boolean {
+  const n = normProvider(p);
+  return n === 'azure' || n === 'azure_openai';
+}
+
+// Split a textarea value (repeatable flag) into trimmed, non-empty lines.
+function splitLines(value: string): string[] {
+  return value
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
 
 // Quote a value for safe inclusion as a single shell argument. Single
 // quotes are bulletproof in POSIX shells; the only character that
@@ -104,12 +193,144 @@ function shellQuote(value: string): string {
   return "'" + value.replace(/'/g, "'\\''") + "'";
 }
 
+// Emit the advanced judge-provider + provider-typed auth flags. Only the
+// auth block matching the selected provider is emitted so the generated
+// command never mixes Bedrock + Vertex + Azure families. Called only when a
+// judge actually runs (detection strategy != regex_only). We expose the
+// canonical provider-typed auth-mode flags (--judge-bedrock-auth-mode etc.)
+// rather than the generic --judge-auth-mode alias, which the CLI just maps
+// onto these; emitting both would let an operator build a self-conflicting
+// command.
+function appendJudgeProviderFlags(
+  s: GeneratorState,
+  lines: string[],
+  preExports: string[],
+  warnings: string[],
+): void {
+  if (s.judgeProvider.trim()) {
+    lines.push(`--judge-provider ${shellQuote(s.judgeProvider.trim())}`);
+  }
+  if (s.judgeRegion.trim()) {
+    lines.push(`--judge-region ${shellQuote(s.judgeRegion.trim())}`);
+  }
+  if (s.judgeInstanceName.trim()) {
+    lines.push(`--judge-instance-name ${shellQuote(s.judgeInstanceName.trim())}`);
+  }
+  if (s.llmRole) {
+    lines.push(`--llm-role ${s.llmRole}`);
+  }
+  if (s.inheritFrom) {
+    lines.push(`--inherit-from ${shellQuote(s.inheritFrom)}`);
+  }
+  if (s.inheritLlm === 'yes') {
+    lines.push('--inherit-llm');
+  } else if (s.inheritLlm === 'no') {
+    lines.push('--no-inherit-llm');
+  }
+
+  const bedrock = isBedrockProvider(s.judgeProvider);
+  const vertex = isVertexProvider(s.judgeProvider);
+  const azure = isAzureProvider(s.judgeProvider);
+
+  if (bedrock) {
+    if (s.judgeBedrockRegion.trim()) {
+      lines.push(`--judge-bedrock-region ${shellQuote(s.judgeBedrockRegion.trim())}`);
+    }
+    if (s.judgeBedrockAuthMode) {
+      lines.push(`--judge-bedrock-auth-mode ${s.judgeBedrockAuthMode}`);
+    }
+    if (s.judgeBedrockAccessKeyEnv.trim()) {
+      lines.push(`--judge-bedrock-access-key-env ${shellQuote(s.judgeBedrockAccessKeyEnv.trim())}`);
+      preExports.push(`export ${s.judgeBedrockAccessKeyEnv.trim()}=<aws-access-key-id>`);
+    }
+    if (s.judgeBedrockSecretKeyEnv.trim()) {
+      lines.push(`--judge-bedrock-secret-key-env ${shellQuote(s.judgeBedrockSecretKeyEnv.trim())}`);
+      preExports.push(`export ${s.judgeBedrockSecretKeyEnv.trim()}=<aws-secret-access-key>`);
+    }
+    if (s.judgeBedrockSessionTokenEnv.trim()) {
+      lines.push(`--judge-bedrock-session-token-env ${shellQuote(s.judgeBedrockSessionTokenEnv.trim())}`);
+      preExports.push(`export ${s.judgeBedrockSessionTokenEnv.trim()}=<aws-session-token>`);
+    }
+    if (s.judgeBedrockProfileName.trim()) {
+      lines.push(`--judge-bedrock-profile-name ${shellQuote(s.judgeBedrockProfileName.trim())}`);
+    }
+    if (s.judgeBedrockInferenceProfile.trim()) {
+      lines.push(`--judge-bedrock-inference-profile ${shellQuote(s.judgeBedrockInferenceProfile.trim())}`);
+    }
+    for (const alias of splitLines(s.judgeBedrockDeployments)) {
+      lines.push(`--judge-bedrock-deployment ${shellQuote(alias)}`);
+    }
+  } else if (vertex) {
+    if (s.judgeVertexProjectId.trim()) {
+      lines.push(`--judge-vertex-project-id ${shellQuote(s.judgeVertexProjectId.trim())}`);
+    }
+    if (s.judgeVertexRegion.trim()) {
+      lines.push(`--judge-vertex-region ${shellQuote(s.judgeVertexRegion.trim())}`);
+    }
+    if (s.judgeVertexAuthMode) {
+      lines.push(`--judge-vertex-auth-mode ${s.judgeVertexAuthMode}`);
+    }
+    if (s.judgeVertexServiceAccountJsonEnv.trim()) {
+      lines.push(
+        `--judge-vertex-service-account-json-env ${shellQuote(s.judgeVertexServiceAccountJsonEnv.trim())}`,
+      );
+      preExports.push(
+        `export ${s.judgeVertexServiceAccountJsonEnv.trim()}=<path-to-service-account-json>`,
+      );
+    }
+  } else if (azure) {
+    if (s.judgeAzureEndpoint.trim()) {
+      lines.push(`--judge-azure-endpoint ${shellQuote(s.judgeAzureEndpoint.trim())}`);
+    }
+    if (s.judgeAzureApiVersion.trim()) {
+      lines.push(`--judge-azure-api-version ${shellQuote(s.judgeAzureApiVersion.trim())}`);
+    }
+    if (s.judgeAzureAuthMode) {
+      lines.push(`--judge-azure-auth-mode ${s.judgeAzureAuthMode}`);
+    }
+    for (const alias of splitLines(s.judgeAzureDeployments)) {
+      lines.push(`--judge-azure-deployment-alias ${shellQuote(alias)}`);
+    }
+  }
+
+  // Provider-agnostic judge TLS knobs.
+  if (s.judgeTlsCaCertFile.trim()) {
+    lines.push(`--judge-tls-ca-cert-file ${shellQuote(s.judgeTlsCaCertFile.trim())}`);
+  }
+  if (s.judgeInsecureSkipVerify) {
+    lines.push('--judge-insecure-skip-verify');
+    warnings.push(
+      'TLS verification is disabled for the judge endpoint (--judge-insecure-skip-verify). Lab use only — never point this at a production judge reached over an untrusted network.',
+    );
+  }
+}
+
 function buildCommand(s: GeneratorState): { lines: string[]; preExports: string[]; warnings: string[] } {
+  const connectorRow = CONNECTORS.find((c) => c.id === s.connector);
+
+  // Teardown short-circuit. `--disable` calls _disable_guardrail and
+  // returns *before* the CLI applies --connector or any other flag, so the
+  // generated command collapses to the bare disable verb. We deliberately
+  // do NOT emit --connector here: it parses fine but is ignored in this
+  // path, and printing it would falsely imply a connector-scoped teardown.
+  // The warning points operators at the genuinely scoped command instead.
+  if (s.disableGuardrail) {
+    const scoped = connectorRow
+      ? ` For a connector-scoped teardown, use 'defenseclaw guardrail disable --connector ${connectorRow.id}' instead.`
+      : '';
+    return {
+      lines: ['defenseclaw setup guardrail', '--disable'],
+      preExports: [],
+      warnings: [
+        `Teardown mode: --disable turns the guardrail off globally and restores direct LLM access. The CLI returns before reading any other flag, so every other knob on this page — including --connector — is ignored.${scoped}`,
+      ],
+    };
+  }
+
   const lines: string[] = ['defenseclaw setup guardrail', '--non-interactive'];
   const preExports: string[] = [];
   const warnings: string[] = [];
 
-  const connectorRow = CONNECTORS.find((c) => c.id === s.connector);
   if (connectorRow) {
     lines.push(`--connector ${shellQuote(connectorRow.id)}`);
   }
@@ -184,6 +405,9 @@ function buildCommand(s: GeneratorState): { lines: string[]; preExports: string[
     }
     const apiKeyEnv = s.judgeApiKeyEnv.trim() || 'DEFENSECLAW_LLM_KEY';
     preExports.push(`export ${apiKeyEnv}=<your-llm-api-key>`);
+
+    // Advanced judge provider + provider-typed auth.
+    appendJudgeProviderFlags(s, lines, preExports, warnings);
   }
 
   // Advanced knobs.
@@ -201,6 +425,10 @@ function buildCommand(s: GeneratorState): { lines: string[]; preExports: string[
     warnings.push(
       'Redaction is disabled. Sinks will receive UNREDACTED prompts. Only do this inside trusted, single-tenant environments.',
     );
+  }
+
+  if (s.workspaceDir.trim()) {
+    lines.push(`--workspace ${shellQuote(s.workspaceDir.trim())}`);
   }
 
   if (!s.restart) lines.push('--no-restart');
@@ -385,6 +613,229 @@ export function CommandGenerator() {
           )}
         </Section>
 
+        {state.detectionStrategy !== 'regex_only' && (
+          <Section
+            title="Judge LLM provider & auth"
+            subtitle="Point the judge at a managed provider (Bedrock / Vertex / Azure) or reuse a sibling LLM block. Leave blank to use a plain API-key provider via the env var above."
+          >
+            <button
+              type="button"
+              onClick={() => update('showJudgeProvider', !state.showJudgeProvider)}
+              className="text-sm font-medium text-[var(--brand-cisco-strong)] hover:underline"
+              aria-expanded={state.showJudgeProvider}
+            >
+              {state.showJudgeProvider ? 'Hide' : 'Show'} provider & auth options
+            </button>
+            {state.showJudgeProvider && (
+              <div className="mt-3 grid gap-3">
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <Field
+                    label="Judge provider"
+                    placeholder="anthropic / bedrock / vertex_ai / azure"
+                    value={state.judgeProvider}
+                    onChange={(v) => update('judgeProvider', v)}
+                  />
+                  <Field
+                    label="Region"
+                    placeholder="us-east-1"
+                    value={state.judgeRegion}
+                    onChange={(v) => update('judgeRegion', v)}
+                  />
+                  <Field
+                    label="Instance name (custom provider)"
+                    placeholder="my-bifrost-instance"
+                    value={state.judgeInstanceName}
+                    onChange={(v) => update('judgeInstanceName', v)}
+                  />
+                  <Select<LlmRole>
+                    label="LLM role (--llm-role)"
+                    value={state.llmRole}
+                    onChange={(v) => update('llmRole', v)}
+                    options={[
+                      { value: '', label: '(connector default)' },
+                      { value: 'judge_only', label: 'judge_only' },
+                      { value: 'judge_and_agent', label: 'judge_and_agent' },
+                    ]}
+                  />
+                  <Select<InheritFrom>
+                    label="Inherit LLM from (--inherit-from)"
+                    value={state.inheritFrom}
+                    onChange={(v) => update('inheritFrom', v)}
+                    options={[
+                      { value: '', label: '(none)' },
+                      { value: 'guardrail', label: 'guardrail' },
+                      { value: 'scanners.skill', label: 'scanners.skill' },
+                      { value: 'scanners.mcp', label: 'scanners.mcp' },
+                      { value: 'scanners.plugin', label: 'scanners.plugin' },
+                    ]}
+                  />
+                  <Select<InheritLlm>
+                    label="Inherit agent LLM (shortcut)"
+                    value={state.inheritLlm}
+                    onChange={(v) => update('inheritLlm', v)}
+                    options={[
+                      { value: 'unset', label: '(leave unset)' },
+                      { value: 'yes', label: '--inherit-llm' },
+                      { value: 'no', label: '--no-inherit-llm' },
+                    ]}
+                  />
+                </div>
+
+                {isBedrockProvider(state.judgeProvider) && (
+                  <div className="grid gap-3 rounded-lg border border-fd-border bg-fd-background/60 p-3 sm:grid-cols-2">
+                    <p className="text-xs font-semibold text-fd-foreground sm:col-span-2">
+                      AWS Bedrock judge auth
+                    </p>
+                    <Field
+                      label="Bedrock region"
+                      placeholder="us-east-1"
+                      value={state.judgeBedrockRegion}
+                      onChange={(v) => update('judgeBedrockRegion', v)}
+                    />
+                    <Select<BedrockAuthMode>
+                      label="Auth mode"
+                      value={state.judgeBedrockAuthMode}
+                      onChange={(v) => update('judgeBedrockAuthMode', v)}
+                      options={[
+                        { value: '', label: '(default)' },
+                        { value: 'api_key', label: 'api_key' },
+                        { value: 'iam_credentials', label: 'iam_credentials' },
+                        { value: 'profile', label: 'profile' },
+                        { value: 'instance_role', label: 'instance_role' },
+                      ]}
+                    />
+                    <Field
+                      label="Access key env"
+                      placeholder="AWS_ACCESS_KEY_ID"
+                      value={state.judgeBedrockAccessKeyEnv}
+                      onChange={(v) => update('judgeBedrockAccessKeyEnv', v)}
+                    />
+                    <Field
+                      label="Secret key env"
+                      placeholder="AWS_SECRET_ACCESS_KEY"
+                      value={state.judgeBedrockSecretKeyEnv}
+                      onChange={(v) => update('judgeBedrockSecretKeyEnv', v)}
+                    />
+                    <Field
+                      label="Session token env"
+                      placeholder="AWS_SESSION_TOKEN"
+                      value={state.judgeBedrockSessionTokenEnv}
+                      onChange={(v) => update('judgeBedrockSessionTokenEnv', v)}
+                    />
+                    <Field
+                      label="Profile name"
+                      placeholder="(when auth mode = profile)"
+                      value={state.judgeBedrockProfileName}
+                      onChange={(v) => update('judgeBedrockProfileName', v)}
+                    />
+                    <Field
+                      label="Inference profile"
+                      placeholder="us."
+                      value={state.judgeBedrockInferenceProfile}
+                      onChange={(v) => update('judgeBedrockInferenceProfile', v)}
+                    />
+                    <TextArea
+                      label="Deployments — one alias=model-id per line"
+                      placeholder={'sonnet=anthropic.claude-3-5-sonnet-20241022-v2:0'}
+                      value={state.judgeBedrockDeployments}
+                      onChange={(v) => update('judgeBedrockDeployments', v)}
+                      className="sm:col-span-2"
+                    />
+                  </div>
+                )}
+
+                {isVertexProvider(state.judgeProvider) && (
+                  <div className="grid gap-3 rounded-lg border border-fd-border bg-fd-background/60 p-3 sm:grid-cols-2">
+                    <p className="text-xs font-semibold text-fd-foreground sm:col-span-2">
+                      GCP Vertex AI judge auth
+                    </p>
+                    <Field
+                      label="Project ID"
+                      placeholder="my-gcp-project"
+                      value={state.judgeVertexProjectId}
+                      onChange={(v) => update('judgeVertexProjectId', v)}
+                    />
+                    <Field
+                      label="Region"
+                      placeholder="us-central1"
+                      value={state.judgeVertexRegion}
+                      onChange={(v) => update('judgeVertexRegion', v)}
+                    />
+                    <Select<VertexAuthMode>
+                      label="Auth mode"
+                      value={state.judgeVertexAuthMode}
+                      onChange={(v) => update('judgeVertexAuthMode', v)}
+                      options={[
+                        { value: '', label: '(default)' },
+                        { value: 'service_account', label: 'service_account' },
+                        { value: 'adc', label: 'adc' },
+                        { value: 'workload_identity', label: 'workload_identity' },
+                      ]}
+                    />
+                    <Field
+                      label="Service-account JSON env"
+                      placeholder="GOOGLE_APPLICATION_CREDENTIALS"
+                      value={state.judgeVertexServiceAccountJsonEnv}
+                      onChange={(v) => update('judgeVertexServiceAccountJsonEnv', v)}
+                    />
+                  </div>
+                )}
+
+                {isAzureProvider(state.judgeProvider) && (
+                  <div className="grid gap-3 rounded-lg border border-fd-border bg-fd-background/60 p-3 sm:grid-cols-2">
+                    <p className="text-xs font-semibold text-fd-foreground sm:col-span-2">
+                      Azure OpenAI judge auth
+                    </p>
+                    <Field
+                      label="Endpoint"
+                      placeholder="https://name.openai.azure.com"
+                      value={state.judgeAzureEndpoint}
+                      onChange={(v) => update('judgeAzureEndpoint', v)}
+                    />
+                    <Field
+                      label="API version"
+                      placeholder="2024-10-21"
+                      value={state.judgeAzureApiVersion}
+                      onChange={(v) => update('judgeAzureApiVersion', v)}
+                    />
+                    <Select<AzureAuthMode>
+                      label="Auth mode"
+                      value={state.judgeAzureAuthMode}
+                      onChange={(v) => update('judgeAzureAuthMode', v)}
+                      options={[
+                        { value: '', label: '(default)' },
+                        { value: 'api_key', label: 'api_key' },
+                        { value: 'managed_identity', label: 'managed_identity' },
+                      ]}
+                    />
+                    <TextArea
+                      label="Deployments — one model=deployment per line"
+                      placeholder={'gpt-4o=my-gpt4o-deployment'}
+                      value={state.judgeAzureDeployments}
+                      onChange={(v) => update('judgeAzureDeployments', v)}
+                      className="sm:col-span-2"
+                    />
+                  </div>
+                )}
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <Field
+                    label="Judge TLS CA cert file"
+                    placeholder="/path/to/ca-bundle.pem"
+                    value={state.judgeTlsCaCertFile}
+                    onChange={(v) => update('judgeTlsCaCertFile', v)}
+                  />
+                  <Toggle
+                    label="Skip judge TLS verify (lab only)"
+                    checked={state.judgeInsecureSkipVerify}
+                    onChange={(v) => update('judgeInsecureSkipVerify', v)}
+                  />
+                </div>
+              </div>
+            )}
+          </Section>
+        )}
+
         <Section
           title="Rule pack"
           subtitle={
@@ -467,6 +918,12 @@ export function CommandGenerator() {
                 onChange={(v) => update('blockMessage', v)}
                 disabled={state.mode !== 'action'}
               />
+              <Field
+                label="Workspace dir (--workspace)"
+                placeholder="(global user config)"
+                value={state.workspaceDir}
+                onChange={(v) => update('workspaceDir', v)}
+              />
               <Toggle
                 label="Disable redaction (dangerous)"
                 checked={state.disableRedaction}
@@ -481,6 +938,11 @@ export function CommandGenerator() {
                 label="Run connectivity verify"
                 checked={state.verify}
                 onChange={(v) => update('verify', v)}
+              />
+              <Toggle
+                label="Disable guardrail (teardown)"
+                checked={state.disableGuardrail}
+                onChange={(v) => update('disableGuardrail', v)}
               />
             </div>
           )}
@@ -795,6 +1257,73 @@ function Field({
           'rounded-md border border-fd-border bg-fd-background px-2 py-1.5 text-xs text-fd-foreground placeholder:text-fd-muted-foreground/60',
           'focus:border-[var(--brand-cisco)] focus:outline-none focus:ring-1 focus:ring-[var(--brand-cisco)]',
           disabled ? 'cursor-not-allowed opacity-60' : '',
+        ].join(' ')}
+      />
+    </label>
+  );
+}
+
+function Select<T extends string>({
+  label,
+  value,
+  onChange,
+  options,
+  disabled,
+}: {
+  label: string;
+  value: T;
+  onChange: (v: T) => void;
+  options: Array<{ value: T; label: string }>;
+  disabled?: boolean;
+}) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-xs font-medium text-fd-muted-foreground">{label}</span>
+      <select
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value as T)}
+        className={[
+          'rounded-md border border-fd-border bg-fd-background px-2 py-1.5 text-xs text-fd-foreground',
+          'focus:border-[var(--brand-cisco)] focus:outline-none focus:ring-1 focus:ring-[var(--brand-cisco)]',
+          disabled ? 'cursor-not-allowed opacity-60' : '',
+        ].join(' ')}
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function TextArea({
+  label,
+  value,
+  onChange,
+  placeholder,
+  className,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  className?: string;
+}) {
+  return (
+    <label className={['flex flex-col gap-1', className ?? ''].join(' ')}>
+      <span className="text-xs font-medium text-fd-muted-foreground">{label}</span>
+      <textarea
+        value={value}
+        placeholder={placeholder}
+        spellCheck={false}
+        rows={3}
+        onChange={(e) => onChange(e.target.value)}
+        className={[
+          'rounded-md border border-fd-border bg-fd-background px-2 py-1.5 font-mono text-xs text-fd-foreground placeholder:text-fd-muted-foreground/60',
+          'focus:border-[var(--brand-cisco)] focus:outline-none focus:ring-1 focus:ring-[var(--brand-cisco)]',
         ].join(' ')}
       />
     </label>

--- a/docs-site/content/docs/command-generator.mdx
+++ b/docs-site/content/docs/command-generator.mdx
@@ -21,20 +21,23 @@ Generated commands are display-only. Nothing on this page runs against your mach
 ## What the generator covers
 
 <Cards>
-  <Card title="Connector picker" description="All nine first-class connectors — proxy (OpenClaw, ZeptoClaw) and hooks (Claude Code, Codex, Cursor, Windsurf, Gemini CLI, GitHub Copilot CLI, Hermes). Each card surfaces whether the connector supports native ask and fail-closed enforcement so HITL decisions are informed." />
+  <Card title="Connector picker" description="All eleven first-class connectors — proxy (OpenClaw, ZeptoClaw) and hooks (Claude Code, Codex, Cursor, Windsurf, Gemini CLI, GitHub Copilot CLI, Hermes, OpenHands, Antigravity). Each card surfaces whether the connector supports native ask and fail-closed enforcement so HITL decisions are informed." />
   <Card title="Mode + scanner backend" description="--mode (observe / action) and --scanner-mode (local / remote / both). Picking remote or both surfaces the Cisco endpoint, API key env var, and timeout fields, and emits a placeholder export so you remember to set the key." />
-  <Card title="Detection strategy + judge" description="--detection-strategy (regex_only / regex_judge / judge_first). Switching off regex_only opens the judge model, judge API base, and judge API key env var inputs and adds the matching export line to the generated script." />
+  <Card title="Detection strategy + judge" description="--detection-strategy (regex_only / regex_judge / judge_first). Switching off regex_only opens the judge model, judge API base, and judge API key env var inputs, unlocks the provider & auth section below, and adds the matching export line to the generated script." />
+  <Card title="Judge provider & auth" description="When a judge runs: --judge-provider / --judge-region / --judge-instance-name, --llm-role, --inherit-from / --inherit-llm, and the full Bedrock / Vertex / Azure judge-auth families (region, auth-mode, credential env vars, profile, inference profile, repeatable deployment aliases), plus --judge-tls-ca-cert-file / --judge-insecure-skip-verify. Only the auth block for the selected provider is emitted, and credential env vars get placeholder export lines." />
   <Card title="Rule pack" description="--rule-pack (default / strict / permissive). Locked to action mode so the disabled state matches the CLI semantics." />
   <Card title="HITL" description="--human-approval + --hilt-min-severity (critical / high / medium / low). Disabled in observe mode. The connector card explains whether the prompt fires natively inside the agent UI or downgrades to a defenseclaw tui confirm." />
-  <Card title="Advanced knobs" description="--port, --block-message, --disable-redaction, --restart / --no-restart, --verify / --no-verify. The disable-redaction toggle emits a prominent warning so you don't ship un-redacted prompts to external sinks by accident." />
+  <Card title="Advanced knobs" description="--port, --block-message, --workspace, --disable-redaction, --restart / --no-restart, --verify / --no-verify, plus --disable (teardown). The disable-redaction toggle emits a prominent warning so you don't ship un-redacted prompts to external sinks by accident; --disable collapses the command to the guardrail-off verb." />
 </Cards>
 
 ## Conventions the generator follows
 
 1. **`--non-interactive` is always emitted** — the whole point of this page is producing a flag-driven command. Drop the flag if you want the wizard to prompt for anything the generator left blank.
-2. **`defenseclaw setup guardrail` is always the verb.** The hook-only aliases (`defenseclaw setup claude-code`, etc.) only configure observability and accept a much smaller flag surface; the guardrail verb works for all nine connectors and is the path documented for CI.
+2. **`defenseclaw setup guardrail` is always the verb.** The hook-only aliases (`defenseclaw setup claude-code`, etc.) only configure observability and accept a much smaller flag surface; the guardrail verb works for all eleven connectors and is the path documented for CI.
 3. **Values containing whitespace or shell metacharacters are POSIX-quoted.** Single quotes wrap any token outside the safe alphanumeric + `_./:@-` allow-list, with the standard `'\''` escape for embedded apostrophes. Copy-paste into `bash`, `zsh`, `dash`, or `fish` (interactive mode) without surprises.
 4. **Conflicting choices surface as warnings, not errors.** The generator never refuses to build a command — if you ask for `--human-approval` in observe mode, the flag is omitted (matching CLI behaviour) and a note explains why. Mistakes you should think about live in the **Notes & validation** panel.
+5. **Only the selected judge provider's auth block is emitted.** Bedrock, Vertex AI, and Azure OpenAI each have their own `--judge-bedrock-*` / `--judge-vertex-*` / `--judge-azure-*` flag family. Picking a provider hides the other two families so you never ship a command mixing Vertex credentials into a Bedrock judge. Repeatable flags (Bedrock/Azure deployment aliases) accept one entry per line and expand to one flag occurrence each.
+6. **`--disable` is a teardown verb, so it collapses the command.** Toggling *Disable guardrail* drops every configuration flag and emits exactly `defenseclaw setup guardrail --disable`. The CLI returns before reading any other flag — including `--connector` — so this teardown is global; the panel points you at `defenseclaw guardrail disable --connector <id>` when you need a connector-scoped teardown instead.
 
 ## Related
 

--- a/docs-site/content/docs/policies/creator.mdx
+++ b/docs-site/content/docs/policies/creator.mdx
@@ -53,7 +53,7 @@ yellow banner explaining which check failed instead of clobbering your draft.
   <Card
     title="Playground"
     href="#"
-    description="14 collapsible sections covering every knob the engine reads. Use this for fine-tuning the Quick Start output, hand-authoring rule packs, or writing custom Rego snippets."
+    description="18 collapsible sections covering every knob the engine reads. Use this for fine-tuning the Quick Start output, hand-authoring rule packs, or writing custom Rego snippets."
   />
 </Cards>
 
@@ -136,9 +136,14 @@ defenseclaw policy activate <name>
 | Suppressions     | The three layers: `pre_judge_strips`, `finding_suppressions`, `tool_suppressions`.                                                     |
 | Sensitive tools  | `sensitive_tools` array — per-tool result inspection and judge-result toggles.                                                         |
 | LLM judges       | `judges.<name>` (pii / injection / tool-injection / exfil) — system prompts and category mappings.                                     |
+| Session correlator (Layer 5) | `correlator` array — sliding-window attack patterns (lethal trifecta, escalation chain, destructive flow). Mirrors `internal/guardrail/correlator.go`. |
 | Firewall         | `firewall.default_action`, `blocked_destinations`, `allowed_domains`, `allowed_ports`.                                                 |
 | Webhooks         | `webhooks` array — Slack / Webex / PagerDuty / generic, signed via env-var secrets.                                                    |
-| Watch / Audit    | `watch.rescan_*`, `audit.log_*`, `audit.retention_days`.                                                                               |
+| Watch (rescan)   | `watch.rescan_enabled`, `watch.rescan_interval_min`.                                                                                    |
+| Enforcement      | `enforcement.max_enforcement_delay_seconds`.                                                                                            |
+| Audit            | `audit.log_all_actions`, `audit.log_scan_results`, `audit.retention_days`.                                                             |
+| Scanner profiles | `scanners.<scanner>` profile selection (codeguard / plugin-scanner / skill-scanner).                                                   |
+| Cisco AI Defense (optional · enterprise) | `cisco_ai_defense.enabled` / `endpoint` / `api_key_env` / `scan_hook_surface` — the optional remote lane read by `internal/config`. |
 | Custom Rego      | Per-snippet `package defenseclaw.custom.<name>` modules emitted into `policies/rego/custom-<name>.rego`.                               |
 | Review & export  | Renders every YAML file the engine needs + `policies/rego/data.json` + a copy-pasteable bash install script.                           |
 

--- a/docs-site/data/policy-presets.json
+++ b/docs-site/data/policy-presets.json
@@ -1262,7 +1262,7 @@
               "rules": [
                 {
                   "id": "PATH-SSH-DIR",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.ssh/",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.ssh/",
                   "title": "SSH directory access",
                   "severity": "HIGH",
                   "confidence": 0.95,
@@ -1284,7 +1284,7 @@
                 },
                 {
                   "id": "PATH-AWS-CREDS",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.aws/credentials",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.aws/credentials",
                   "title": "AWS credentials file",
                   "severity": "CRITICAL",
                   "confidence": 0.98,
@@ -1295,7 +1295,7 @@
                 },
                 {
                   "id": "PATH-AWS-CONFIG",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.aws/config",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.aws/config",
                   "title": "AWS config file",
                   "severity": "HIGH",
                   "confidence": 0.85,
@@ -1306,7 +1306,7 @@
                 },
                 {
                   "id": "PATH-KUBE",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.kube/config",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.kube/config",
                   "title": "Kubernetes config",
                   "severity": "HIGH",
                   "confidence": 0.9,
@@ -1317,7 +1317,7 @@
                 },
                 {
                   "id": "PATH-DOCKER",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.docker/config\\.json",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.docker/config\\.json",
                   "title": "Docker config",
                   "severity": "HIGH",
                   "confidence": 0.9,
@@ -1328,7 +1328,7 @@
                 },
                 {
                   "id": "PATH-GNUPG",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.gnupg/",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.gnupg/",
                   "title": "GPG keyring access",
                   "severity": "HIGH",
                   "confidence": 0.95,
@@ -1339,7 +1339,7 @@
                 },
                 {
                   "id": "PATH-NPMRC",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.npmrc",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.npmrc",
                   "title": "npm config (may contain tokens)",
                   "severity": "MEDIUM",
                   "confidence": 0.8,
@@ -1350,7 +1350,7 @@
                 },
                 {
                   "id": "PATH-PYPIRC",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.pypirc",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.pypirc",
                   "title": "PyPI config (may contain tokens)",
                   "severity": "MEDIUM",
                   "confidence": 0.8,
@@ -1361,7 +1361,7 @@
                 },
                 {
                   "id": "PATH-GIT-CREDS",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.git-credentials",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.git-credentials",
                   "title": "Git credentials file",
                   "severity": "CRITICAL",
                   "confidence": 0.95,
@@ -1372,7 +1372,7 @@
                 },
                 {
                   "id": "PATH-NETRC",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.netrc",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.netrc",
                   "title": "netrc credentials file",
                   "severity": "CRITICAL",
                   "confidence": 0.9,
@@ -1436,7 +1436,7 @@
                 },
                 {
                   "id": "PATH-HISTORY",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.(?:bash_history|zsh_history|python_history)",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.(?:bash_history|zsh_history|python_history)",
                   "title": "Shell history file",
                   "severity": "MEDIUM",
                   "confidence": 0.8,
@@ -3392,7 +3392,7 @@
               "rules": [
                 {
                   "id": "PATH-SSH-DIR",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.ssh/",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.ssh/",
                   "title": "SSH directory access",
                   "severity": "HIGH",
                   "confidence": 0.95,
@@ -3414,7 +3414,7 @@
                 },
                 {
                   "id": "PATH-AWS-CREDS",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.aws/credentials",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.aws/credentials",
                   "title": "AWS credentials file",
                   "severity": "CRITICAL",
                   "confidence": 0.98,
@@ -3425,7 +3425,7 @@
                 },
                 {
                   "id": "PATH-AWS-CONFIG",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.aws/config",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.aws/config",
                   "title": "AWS config file",
                   "severity": "HIGH",
                   "confidence": 0.85,
@@ -3436,7 +3436,7 @@
                 },
                 {
                   "id": "PATH-KUBE",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.kube/config",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.kube/config",
                   "title": "Kubernetes config",
                   "severity": "HIGH",
                   "confidence": 0.9,
@@ -3447,7 +3447,7 @@
                 },
                 {
                   "id": "PATH-DOCKER",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.docker/config\\.json",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.docker/config\\.json",
                   "title": "Docker config",
                   "severity": "HIGH",
                   "confidence": 0.9,
@@ -3458,7 +3458,7 @@
                 },
                 {
                   "id": "PATH-GNUPG",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.gnupg/",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.gnupg/",
                   "title": "GPG keyring access",
                   "severity": "HIGH",
                   "confidence": 0.95,
@@ -3469,7 +3469,7 @@
                 },
                 {
                   "id": "PATH-NPMRC",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.npmrc",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.npmrc",
                   "title": "npm config (may contain tokens)",
                   "severity": "MEDIUM",
                   "confidence": 0.8,
@@ -3480,7 +3480,7 @@
                 },
                 {
                   "id": "PATH-PYPIRC",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.pypirc",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.pypirc",
                   "title": "PyPI config (may contain tokens)",
                   "severity": "MEDIUM",
                   "confidence": 0.8,
@@ -3491,7 +3491,7 @@
                 },
                 {
                   "id": "PATH-GIT-CREDS",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.git-credentials",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.git-credentials",
                   "title": "Git credentials file",
                   "severity": "CRITICAL",
                   "confidence": 0.95,
@@ -3502,7 +3502,7 @@
                 },
                 {
                   "id": "PATH-NETRC",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.netrc",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.netrc",
                   "title": "netrc credentials file",
                   "severity": "CRITICAL",
                   "confidence": 0.9,
@@ -3566,7 +3566,7 @@
                 },
                 {
                   "id": "PATH-HISTORY",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.(?:bash_history|zsh_history|python_history)",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.(?:bash_history|zsh_history|python_history)",
                   "title": "Shell history file",
                   "severity": "MEDIUM",
                   "confidence": 0.8,
@@ -5434,7 +5434,7 @@
               "rules": [
                 {
                   "id": "PATH-SSH-DIR",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.ssh/",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.ssh/",
                   "title": "SSH directory access",
                   "severity": "HIGH",
                   "confidence": 0.95,
@@ -5456,7 +5456,7 @@
                 },
                 {
                   "id": "PATH-AWS-CREDS",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.aws/credentials",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.aws/credentials",
                   "title": "AWS credentials file",
                   "severity": "CRITICAL",
                   "confidence": 0.98,
@@ -5467,7 +5467,7 @@
                 },
                 {
                   "id": "PATH-AWS-CONFIG",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.aws/config",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.aws/config",
                   "title": "AWS config file",
                   "severity": "HIGH",
                   "confidence": 0.85,
@@ -5478,7 +5478,7 @@
                 },
                 {
                   "id": "PATH-KUBE",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.kube/config",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.kube/config",
                   "title": "Kubernetes config",
                   "severity": "HIGH",
                   "confidence": 0.9,
@@ -5489,7 +5489,7 @@
                 },
                 {
                   "id": "PATH-DOCKER",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.docker/config\\.json",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.docker/config\\.json",
                   "title": "Docker config",
                   "severity": "HIGH",
                   "confidence": 0.9,
@@ -5500,7 +5500,7 @@
                 },
                 {
                   "id": "PATH-GNUPG",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.gnupg/",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.gnupg/",
                   "title": "GPG keyring access",
                   "severity": "HIGH",
                   "confidence": 0.95,
@@ -5511,7 +5511,7 @@
                 },
                 {
                   "id": "PATH-NPMRC",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.npmrc",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.npmrc",
                   "title": "npm config (may contain tokens)",
                   "severity": "MEDIUM",
                   "confidence": 0.8,
@@ -5522,7 +5522,7 @@
                 },
                 {
                   "id": "PATH-PYPIRC",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.pypirc",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.pypirc",
                   "title": "PyPI config (may contain tokens)",
                   "severity": "MEDIUM",
                   "confidence": 0.8,
@@ -5533,7 +5533,7 @@
                 },
                 {
                   "id": "PATH-GIT-CREDS",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.git-credentials",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.git-credentials",
                   "title": "Git credentials file",
                   "severity": "CRITICAL",
                   "confidence": 0.95,
@@ -5544,7 +5544,7 @@
                 },
                 {
                   "id": "PATH-NETRC",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.netrc",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.netrc",
                   "title": "netrc credentials file",
                   "severity": "CRITICAL",
                   "confidence": 0.9,
@@ -5608,7 +5608,7 @@
                 },
                 {
                   "id": "PATH-HISTORY",
-                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.(?:bash_history|zsh_history|python_history)",
+                  "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.(?:bash_history|zsh_history|python_history)",
                   "title": "Shell history file",
                   "severity": "MEDIUM",
                   "confidence": 0.8,

--- a/docs-site/data/policy-recipes.json
+++ b/docs-site/data/policy-recipes.json
@@ -2276,7 +2276,7 @@
       "kind": "rule:sensitive-path",
       "body": {
         "id": "PATH-SSH-DIR",
-        "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.ssh/",
+        "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.ssh/",
         "title": "SSH directory access",
         "severity": "HIGH",
         "confidence": 0.95,
@@ -2330,7 +2330,7 @@
       "kind": "rule:sensitive-path",
       "body": {
         "id": "PATH-AWS-CREDS",
-        "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.aws/credentials",
+        "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.aws/credentials",
         "title": "AWS credentials file",
         "severity": "CRITICAL",
         "confidence": 0.98,
@@ -2357,7 +2357,7 @@
       "kind": "rule:sensitive-path",
       "body": {
         "id": "PATH-AWS-CONFIG",
-        "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.aws/config",
+        "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.aws/config",
         "title": "AWS config file",
         "severity": "HIGH",
         "confidence": 0.85,
@@ -2384,7 +2384,7 @@
       "kind": "rule:sensitive-path",
       "body": {
         "id": "PATH-KUBE",
-        "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.kube/config",
+        "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.kube/config",
         "title": "Kubernetes config",
         "severity": "HIGH",
         "confidence": 0.9,
@@ -2411,7 +2411,7 @@
       "kind": "rule:sensitive-path",
       "body": {
         "id": "PATH-DOCKER",
-        "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.docker/config\\.json",
+        "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.docker/config\\.json",
         "title": "Docker config",
         "severity": "HIGH",
         "confidence": 0.9,
@@ -2438,7 +2438,7 @@
       "kind": "rule:sensitive-path",
       "body": {
         "id": "PATH-GNUPG",
-        "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.gnupg/",
+        "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.gnupg/",
         "title": "GPG keyring access",
         "severity": "HIGH",
         "confidence": 0.95,
@@ -2465,7 +2465,7 @@
       "kind": "rule:sensitive-path",
       "body": {
         "id": "PATH-NPMRC",
-        "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.npmrc",
+        "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.npmrc",
         "title": "npm config (may contain tokens)",
         "severity": "MEDIUM",
         "confidence": 0.8,
@@ -2492,7 +2492,7 @@
       "kind": "rule:sensitive-path",
       "body": {
         "id": "PATH-PYPIRC",
-        "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.pypirc",
+        "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.pypirc",
         "title": "PyPI config (may contain tokens)",
         "severity": "MEDIUM",
         "confidence": 0.8,
@@ -2519,7 +2519,7 @@
       "kind": "rule:sensitive-path",
       "body": {
         "id": "PATH-GIT-CREDS",
-        "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.git-credentials",
+        "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.git-credentials",
         "title": "Git credentials file",
         "severity": "CRITICAL",
         "confidence": 0.95,
@@ -2546,7 +2546,7 @@
       "kind": "rule:sensitive-path",
       "body": {
         "id": "PATH-NETRC",
-        "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.netrc",
+        "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.netrc",
         "title": "netrc credentials file",
         "severity": "CRITICAL",
         "confidence": 0.9,
@@ -2704,7 +2704,7 @@
       "kind": "rule:sensitive-path",
       "body": {
         "id": "PATH-HISTORY",
-        "pattern": "(?:~|\\$HOME|/home/\\w+|/root)/\\.(?:bash_history|zsh_history|python_history)",
+        "pattern": "(?:~|\\$HOME|/home/\\w+|/root|/Users/\\w+)/\\.(?:bash_history|zsh_history|python_history)",
         "title": "Shell history file",
         "severity": "MEDIUM",
         "confidence": 0.8,

--- a/docs-site/lib/layout-options.tsx
+++ b/docs-site/lib/layout-options.tsx
@@ -57,6 +57,23 @@ export const baseOptions: BaseLayoutProps = {
       url: '/docs/stories',
       active: 'nested-url',
     },
+    // Interactive builders — surfaced as top-level nav after the
+    // content sections (Connectors, Stories) so operators can jump
+    // straight to the two "do something" pages: assemble a
+    // non-interactive `setup guardrail` command, or author a policy
+    // with live OPA-WASM evaluation.
+    {
+      type: 'main',
+      text: 'Command generator',
+      url: '/docs/command-generator',
+      active: 'nested-url',
+    },
+    {
+      type: 'main',
+      text: 'Policy creator',
+      url: '/docs/policies/creator',
+      active: 'nested-url',
+    },
     // Secondary nav anchors the project to its sibling community
     // surfaces. Order is intentional: parent-org → Discord → repo
     // stats → repo. Keeping the GitHub identity (stats pills + icon)

--- a/internal/gateway/rules.go
+++ b/internal/gateway/rules.go
@@ -133,18 +133,25 @@ var commandRules = []PatternRule{
 // matching ".env").
 // ---------------------------------------------------------------------------
 
+// The home-directory alternation `(?:~|$HOME|/home/\w+|/root|/Users/\w+)`
+// intentionally includes the macOS `/Users/<user>/` branch: agy's run_command
+// tool expands ~ via the shell BEFORE the regex sees it, so on macOS the
+// command line lands as /Users/<user>/.ssh/... rather than the literal
+// ~/.ssh/... These compiled-in defaults must stay in lockstep with the
+// externalized packs under policies/guardrail/<pack>/rules/sensitive-paths.yaml,
+// which are what replace this category once a rule pack is installed.
 var sensitivePathRules = []PatternRule{
-	{ID: "PATH-SSH-DIR", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root)/\.ssh/`), Title: "SSH directory access", Severity: "HIGH", Confidence: 0.95, Tags: []string{"credential", "file-sensitive"}},
+	{ID: "PATH-SSH-DIR", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.ssh/`), Title: "SSH directory access", Severity: "HIGH", Confidence: 0.95, Tags: []string{"credential", "file-sensitive"}},
 	{ID: "PATH-SSH-KEY", Pattern: regexp.MustCompile(`(?i)(?:^|[\\/])id_(?:rsa|ed25519|ecdsa|dsa)(?:$|[^A-Za-z0-9_.-])`), Title: "SSH private key file path", Severity: "CRITICAL", Confidence: 0.90, Tags: []string{"credential", "file-sensitive"}},
-	{ID: "PATH-AWS-CREDS", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root)/\.aws/credentials`), Title: "AWS credentials file", Severity: "CRITICAL", Confidence: 0.98, Tags: []string{"credential", "file-sensitive"}},
-	{ID: "PATH-AWS-CONFIG", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root)/\.aws/config`), Title: "AWS config file", Severity: "HIGH", Confidence: 0.85, Tags: []string{"credential", "file-sensitive"}},
-	{ID: "PATH-KUBE", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root)/\.kube/config`), Title: "Kubernetes config", Severity: "HIGH", Confidence: 0.90, Tags: []string{"credential", "file-sensitive"}},
-	{ID: "PATH-DOCKER", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root)/\.docker/config\.json`), Title: "Docker config", Severity: "HIGH", Confidence: 0.90, Tags: []string{"credential", "file-sensitive"}},
-	{ID: "PATH-GNUPG", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root)/\.gnupg/`), Title: "GPG keyring access", Severity: "HIGH", Confidence: 0.95, Tags: []string{"credential", "file-sensitive"}},
-	{ID: "PATH-NPMRC", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root)/\.npmrc`), Title: "npm config (may contain tokens)", Severity: "MEDIUM", Confidence: 0.80, Tags: []string{"credential", "file-sensitive"}},
-	{ID: "PATH-PYPIRC", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root)/\.pypirc`), Title: "PyPI config (may contain tokens)", Severity: "MEDIUM", Confidence: 0.80, Tags: []string{"credential", "file-sensitive"}},
-	{ID: "PATH-GIT-CREDS", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root)/\.git-credentials`), Title: "Git credentials file", Severity: "CRITICAL", Confidence: 0.95, Tags: []string{"credential", "file-sensitive"}},
-	{ID: "PATH-NETRC", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root)/\.netrc`), Title: "netrc credentials file", Severity: "CRITICAL", Confidence: 0.90, Tags: []string{"credential", "file-sensitive"}},
+	{ID: "PATH-AWS-CREDS", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.aws/credentials`), Title: "AWS credentials file", Severity: "CRITICAL", Confidence: 0.98, Tags: []string{"credential", "file-sensitive"}},
+	{ID: "PATH-AWS-CONFIG", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.aws/config`), Title: "AWS config file", Severity: "HIGH", Confidence: 0.85, Tags: []string{"credential", "file-sensitive"}},
+	{ID: "PATH-KUBE", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.kube/config`), Title: "Kubernetes config", Severity: "HIGH", Confidence: 0.90, Tags: []string{"credential", "file-sensitive"}},
+	{ID: "PATH-DOCKER", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.docker/config\.json`), Title: "Docker config", Severity: "HIGH", Confidence: 0.90, Tags: []string{"credential", "file-sensitive"}},
+	{ID: "PATH-GNUPG", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.gnupg/`), Title: "GPG keyring access", Severity: "HIGH", Confidence: 0.95, Tags: []string{"credential", "file-sensitive"}},
+	{ID: "PATH-NPMRC", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.npmrc`), Title: "npm config (may contain tokens)", Severity: "MEDIUM", Confidence: 0.80, Tags: []string{"credential", "file-sensitive"}},
+	{ID: "PATH-PYPIRC", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.pypirc`), Title: "PyPI config (may contain tokens)", Severity: "MEDIUM", Confidence: 0.80, Tags: []string{"credential", "file-sensitive"}},
+	{ID: "PATH-GIT-CREDS", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.git-credentials`), Title: "Git credentials file", Severity: "CRITICAL", Confidence: 0.95, Tags: []string{"credential", "file-sensitive"}},
+	{ID: "PATH-NETRC", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.netrc`), Title: "netrc credentials file", Severity: "CRITICAL", Confidence: 0.90, Tags: []string{"credential", "file-sensitive"}},
 	{ID: "PATH-ENV-FILE", Pattern: regexp.MustCompile(`(?:^|[\s/])\.env(?:\.(?:local|production|staging|development))?\s*["'\s,\]})]*$|(?:^|[\s/])\.env(?:\.(?:local|production|staging|development))?["'\s,\]})]`), Title: "Environment file", Severity: "HIGH", Confidence: 0.85, Tags: []string{"credential", "file-sensitive"}},
 	// The /etc/{passwd,shadow,sudoers} rules tolerate common obfuscations:
 	// canonical "/etc/passwd", space-separated "etc passwd", backslash
@@ -159,7 +166,7 @@ var sensitivePathRules = []PatternRule{
 	{ID: "PATH-ETC-SHADOW", Pattern: regexp.MustCompile(`(?i)(?:\betc[\s/\\]+(?:slash[\s]+)?shadow\b|\betc%2Fshadow\b)`), Title: "/etc/shadow access", Severity: "CRITICAL", Confidence: 0.90, Tags: []string{"system-file", "credential"}},
 	{ID: "PATH-ETC-SUDOERS", Pattern: regexp.MustCompile(`(?i)(?:\betc[\s/\\]+(?:slash[\s]+)?sudoers\b|\betc%2Fsudoers\b)`), Title: "/etc/sudoers access", Severity: "HIGH", Confidence: 0.85, Tags: []string{"system-file", "privilege"}},
 	{ID: "PATH-PROC-ENVIRON", Pattern: regexp.MustCompile(`/proc/(?:\d+|self)/environ`), Title: "/proc environ access", Severity: "CRITICAL", Confidence: 0.90, Tags: []string{"credential"}},
-	{ID: "PATH-HISTORY", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root)/\.(?:bash_history|zsh_history|python_history)`), Title: "Shell history file", Severity: "MEDIUM", Confidence: 0.80, Tags: []string{"credential", "file-sensitive"}},
+	{ID: "PATH-HISTORY", Pattern: regexp.MustCompile(`(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.(?:bash_history|zsh_history|python_history)`), Title: "Shell history file", Severity: "MEDIUM", Confidence: 0.80, Tags: []string{"credential", "file-sensitive"}},
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/gateway/rules_test.go
+++ b/internal/gateway/rules_test.go
@@ -368,6 +368,12 @@ func TestSensitivePathRules(t *testing.T) {
 		{"etc sudoers (space-obfuscated)", `append line to etc sudoers`, "PATH-ETC-SUDOERS"},
 		{"/proc environ", `/proc/1/environ`, "PATH-PROC-ENVIRON"},
 		{"bash history", `~/.bash_history`, "PATH-HISTORY"},
+		// macOS: agy's run_command expands ~ via the shell BEFORE the regex
+		// sees it, so the home dir lands as /Users/<user>/... rather than the
+		// literal ~/... These must still match the same rules.
+		{"macOS SSH directory", `{"path": "/Users/alice/.ssh/id_rsa"}`, "PATH-SSH-DIR"},
+		{"macOS AWS credentials", `cat /Users/alice/.aws/credentials`, "PATH-AWS-CREDS"},
+		{"macOS bash history", `/Users/alice/.bash_history`, "PATH-HISTORY"},
 	}
 
 	for _, tc := range cases {

--- a/policies/guardrail/permissive/rules/sensitive-paths.yaml
+++ b/policies/guardrail/permissive/rules/sensitive-paths.yaml
@@ -2,7 +2,11 @@ version: 1
 category: sensitive-path
 rules:
   - id: PATH-SSH-DIR
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.ssh/'
+    # Covers ~, $HOME, /home/<user>/ (Linux), /root, and /Users/<user>/ (macOS).
+    # The macOS branch matters because agy's run_command tool expands ~ via the
+    # shell BEFORE the regex sees it, so on macOS the command line lands as
+    # /Users/<user>/.ssh/... rather than the literal ~/.ssh/...
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.ssh/'
     title: "SSH directory access"
     severity: HIGH
     confidence: 0.95
@@ -14,55 +18,55 @@ rules:
     confidence: 0.90
     tags: [credential, file-sensitive]
   - id: PATH-AWS-CREDS
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.aws/credentials'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.aws/credentials'
     title: "AWS credentials file"
     severity: CRITICAL
     confidence: 0.98
     tags: [credential, file-sensitive]
   - id: PATH-AWS-CONFIG
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.aws/config'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.aws/config'
     title: "AWS config file"
     severity: HIGH
     confidence: 0.85
     tags: [credential, file-sensitive]
   - id: PATH-KUBE
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.kube/config'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.kube/config'
     title: "Kubernetes config"
     severity: HIGH
     confidence: 0.90
     tags: [credential, file-sensitive]
   - id: PATH-DOCKER
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.docker/config\.json'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.docker/config\.json'
     title: "Docker config"
     severity: HIGH
     confidence: 0.90
     tags: [credential, file-sensitive]
   - id: PATH-GNUPG
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.gnupg/'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.gnupg/'
     title: "GPG keyring access"
     severity: HIGH
     confidence: 0.95
     tags: [credential, file-sensitive]
   - id: PATH-NPMRC
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.npmrc'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.npmrc'
     title: "npm config (may contain tokens)"
     severity: MEDIUM
     confidence: 0.80
     tags: [credential, file-sensitive]
   - id: PATH-PYPIRC
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.pypirc'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.pypirc'
     title: "PyPI config (may contain tokens)"
     severity: MEDIUM
     confidence: 0.80
     tags: [credential, file-sensitive]
   - id: PATH-GIT-CREDS
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.git-credentials'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.git-credentials'
     title: "Git credentials file"
     severity: CRITICAL
     confidence: 0.95
     tags: [credential, file-sensitive]
   - id: PATH-NETRC
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.netrc'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.netrc'
     title: "netrc credentials file"
     severity: CRITICAL
     confidence: 0.90
@@ -98,7 +102,7 @@ rules:
     confidence: 0.90
     tags: [credential]
   - id: PATH-HISTORY
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.(?:bash_history|zsh_history|python_history)'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.(?:bash_history|zsh_history|python_history)'
     title: "Shell history file"
     severity: MEDIUM
     confidence: 0.80

--- a/policies/guardrail/strict/rules/sensitive-paths.yaml
+++ b/policies/guardrail/strict/rules/sensitive-paths.yaml
@@ -2,7 +2,11 @@ version: 1
 category: sensitive-path
 rules:
   - id: PATH-SSH-DIR
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.ssh/'
+    # Covers ~, $HOME, /home/<user>/ (Linux), /root, and /Users/<user>/ (macOS).
+    # The macOS branch matters because agy's run_command tool expands ~ via the
+    # shell BEFORE the regex sees it, so on macOS the command line lands as
+    # /Users/<user>/.ssh/... rather than the literal ~/.ssh/...
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.ssh/'
     title: "SSH directory access"
     severity: HIGH
     confidence: 0.95
@@ -14,55 +18,55 @@ rules:
     confidence: 0.90
     tags: [credential, file-sensitive]
   - id: PATH-AWS-CREDS
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.aws/credentials'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.aws/credentials'
     title: "AWS credentials file"
     severity: CRITICAL
     confidence: 0.98
     tags: [credential, file-sensitive]
   - id: PATH-AWS-CONFIG
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.aws/config'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.aws/config'
     title: "AWS config file"
     severity: HIGH
     confidence: 0.85
     tags: [credential, file-sensitive]
   - id: PATH-KUBE
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.kube/config'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.kube/config'
     title: "Kubernetes config"
     severity: HIGH
     confidence: 0.90
     tags: [credential, file-sensitive]
   - id: PATH-DOCKER
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.docker/config\.json'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.docker/config\.json'
     title: "Docker config"
     severity: HIGH
     confidence: 0.90
     tags: [credential, file-sensitive]
   - id: PATH-GNUPG
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.gnupg/'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.gnupg/'
     title: "GPG keyring access"
     severity: HIGH
     confidence: 0.95
     tags: [credential, file-sensitive]
   - id: PATH-NPMRC
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.npmrc'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.npmrc'
     title: "npm config (may contain tokens)"
     severity: MEDIUM
     confidence: 0.80
     tags: [credential, file-sensitive]
   - id: PATH-PYPIRC
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.pypirc'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.pypirc'
     title: "PyPI config (may contain tokens)"
     severity: MEDIUM
     confidence: 0.80
     tags: [credential, file-sensitive]
   - id: PATH-GIT-CREDS
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.git-credentials'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.git-credentials'
     title: "Git credentials file"
     severity: CRITICAL
     confidence: 0.95
     tags: [credential, file-sensitive]
   - id: PATH-NETRC
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.netrc'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.netrc'
     title: "netrc credentials file"
     severity: CRITICAL
     confidence: 0.90
@@ -98,7 +102,7 @@ rules:
     confidence: 0.90
     tags: [credential]
   - id: PATH-HISTORY
-    pattern: '(?:~|\$HOME|/home/\w+|/root)/\.(?:bash_history|zsh_history|python_history)'
+    pattern: '(?:~|\$HOME|/home/\w+|/root|/Users/\w+)/\.(?:bash_history|zsh_history|python_history)'
     title: "Shell history file"
     severity: MEDIUM
     confidence: 0.80


### PR DESCRIPTION
## Problem

Three independent accuracy/coverage gaps, surfaced while auditing the
docs-site interactive builders:

1. **Command generator was missing ~25 `defenseclaw setup guardrail`
   flags.** The advanced judge LLM provider/auth families (Bedrock,
   Vertex AI, Azure OpenAI), `--llm-role`, `--inherit-from` /
   `--inherit-llm`, `--workspace`, and the `--disable` teardown verb had
   no UI, so operators copying a generated command could not reproduce a
   managed-provider judge or a teardown. The page also overstated nothing
   but understated reality: it claimed "nine connectors" (actually
   eleven) and the policy creator doc claimed "14" playground sections
   (actually 18).

2. **macOS credential paths silently bypassed 11 sensitive-path rules.**
   The `strict` and `permissive` rule packs and the compiled-in gateway
   fallback only matched `~`, `$HOME`, `/home/<user>`, and `/root`. On
   macOS the shell expands `~` before the scanner sees the argument, so a
   read of `~/.ssh/id_rsa` lands as `/Users/<user>/.ssh/id_rsa` and
   matched nothing. The `default` pack already carried the `/Users`
   branch (added in #295); `strict`, `permissive`, and
   `internal/gateway/rules.go` were missed by that same change — so on
   macOS the "strict" pack caught *less* than "default".

3. **The gateway token_env migration corrupted or skipped CRLF configs.**
   `_align_gateway_token_env_in_config` read `config.yaml` with default
   newline handling and used LF-only (`\n`) regex anchors. On a Windows
   operator's config (or one copied from a Windows host) the gateway
   block never matched — silently no-opping the
   `OPENCLAW_GATEWAY_TOKEN` -> `DEFENSECLAW_GATEWAY_TOKEN` realignment —
   or the rewrite flattened the whole file from CRLF to LF. Windows is a
   supported platform as of the 0.7.0 release.

## Current Situation

- `docs-site/components/command-generator.tsx` exposed only mode, scanner
  backend, detection strategy, rule pack, HITL, and a handful of advanced
  knobs — a subset of the surface defined in
  `cli/defenseclaw/commands/cmd_setup.py`.
- `policies/guardrail/{strict,permissive}/rules/sensitive-paths.yaml` and
  `internal/gateway/rules.go` used the home-dir alternation
  `(?:~|$HOME|/home/\w+|/root)`; `policies/guardrail/default/...` used
  `(?:~|$HOME|/home/\w+|/root|/Users/\w+)`.
- `cli/defenseclaw/migrations.py` opened the config without `newline=""`
  and anchored on `\n`.

## Solution

1. **Command generator** — added a "Judge LLM provider & auth" section
   (rendered only when a judge runs) plus `--workspace` and a `--disable`
   toggle, with `Select`/`TextArea` helpers. Every flag name and
   `click.Choice` value was verified line-by-line against
   `cmd_setup.py`. Two behaviors are enforced to match the CLI exactly:
   only the selected provider's auth block is emitted (never a
   Bedrock+Vertex+Azure mix), and `--disable` collapses to the bare
   teardown verb because the CLI returns before reading `--connector` or
   any other flag (`cmd_setup.py` `if disable:` branch). Docs counts
   corrected (eleven connectors, 18 playground sections) and both
   builders added to the top nav after Stories.

2. **Sensitive paths** — added the `/Users/\w+` branch to the 11
   home-anchored rules in `strict`, `permissive`, and the compiled-in
   `rules.go`, reaching parity with `default`. Chose to fix all three
   surfaces (rather than just the packs) because the compiled-in set is
   the fallback used when no pack override is active (e.g. observe mode /
   zero-config local scanning). Intentional `strict` confidence bumps on
   the `/etc/*` rules were left untouched. Regenerated the docs policy
   assets from the packs.

3. **Migration** — open with `newline=""` and made the gateway-block and
   `token_env` regexes CRLF-aware (`\r?\n`), preserving the file's
   existing terminators. Matches the CRLF-safe contract
   `_migrate_0_4_0_seed_hook_fail_mode` already honours.

## Architecture Diagram

```
Command generator (source of truth = cmd_setup.py)
  Before:                              After:
  ┌───────────────────┐                ┌───────────────────────────────┐
  │ mode / scanner /   │                │ mode / scanner / strategy /    │
  │ strategy / pack /  │   ~25 flags    │ pack / HITL / advanced         │
  │ HITL / advanced    │   not exposed  │  + Judge provider & auth       │
  │  (subset of CLI)   │ ─────────────▶ │    (Bedrock/Vertex/Azure)      │
  └───────────────────┘                │  + --workspace + --disable     │
                                        └───────────────────────────────┘

Sensitive-path coverage (3 surfaces, one regex family)
  Before:  default = (~|$HOME|/home|/root|/Users)   ← has macOS
           strict | permissive | rules.go = (~|$HOME|/home|/root)  ← NO macOS
  After:   default | strict | permissive | rules.go = (...|/Users/\w+)
                                  │
                                  ▼ build:policy-assets (reads YAML packs)
                       docs-site/data/{policy-presets,policy-recipes}.json
```

## Flow Diagram

```
macOS credential read, action mode, no custom pack (compiled-in fallback)

  agent          shell            gateway scanner          verdict
   │  cat ~/.ssh/id_rsa            │                         │
   │──────────────▶ expands ~      │                         │
   │     /Users/alice/.ssh/id_rsa  │                         │
   │───────────────────────────────▶ ScanAllRules           │
   │                               │                         │
  Before: pattern (~|$HOME|/home|/root)/\.ssh/  → NO MATCH → allow (leak)
  After : pattern (...|/Users/\w+)/\.ssh/       → PATH-SSH-DIR HIGH → flag/block
```

## What Changed (Where & How)

| File | Change Type | Summary |
|---|---|---|
| `docs-site/components/command-generator.tsx` | modified | Add judge provider/auth state, types, `appendJudgeProviderFlags`, `--workspace`, `--disable` short-circuit, `Select`/`TextArea` helpers, and the provider & auth UI section |
| `docs-site/content/docs/command-generator.mdx` | docs | Coverage cards + conventions for the new flags; connector count nine→eleven |
| `docs-site/content/docs/policies/creator.mdx` | docs | Playground section count 14→18 with the missing sections documented |
| `docs-site/lib/layout-options.tsx` | modified | Add Command generator + Policy creator top-nav links after Stories |
| `policies/guardrail/strict/rules/sensitive-paths.yaml` | modified | Add `/Users/\w+` macOS branch to 11 home-anchored rules |
| `policies/guardrail/permissive/rules/sensitive-paths.yaml` | modified | Add `/Users/\w+` macOS branch to 11 home-anchored rules |
| `internal/gateway/rules.go` | modified | Add `/Users/\w+` to compiled-in `sensitivePathRules` (fallback parity) |
| `internal/gateway/rules_test.go` | test | macOS `/Users/...` cases in `TestSensitivePathRules` |
| `docs-site/data/policy-presets.json` | modified | Regenerated from packs (macOS branch) |
| `docs-site/data/policy-recipes.json` | modified | Regenerated from packs (macOS branch) |
| `cli/defenseclaw/migrations.py` | modified | CRLF-safe read (`newline=""`) + CRLF-aware regexes in gateway token_env realign |
| `cli/tests/test_migrations_gateway_token_env_realign.py` | test | CRLF round-trip test asserting terminator preserved, no mixed endings |

## Open Issues / Follow-ups

- The command generator's `--inherit-from` select omits the empty-string
  choice the CLI accepts; emitting `--inherit-from ''` is equivalent to
  omitting it, so this is intentional and not a gap.
- No automated UI/E2E test asserts the generated command string for the
  new provider permutations; coverage is via the CLI flag-parity audit
  (manual) plus the existing `test:policy-creator` unit suite. A
  golden-string test for `buildCommand` would harden this — not included
  to keep the PR focused. TODO(@vineeth).

## Test Plan

- `cd docs-site && npx tsc --noEmit` -> exit 0
- `cd docs-site && npm run validate-links` -> 0 errored files, 0 errors
- `cd docs-site && npm run test:policy-creator` -> 53/53 pass
- `cd docs-site && npm run build` -> 129 static pages, postbuild clean
- `cli/.venv/bin/python -m pytest cli/tests/test_playground_schema_parity.py` -> 1 passed
- `cli/.venv/bin/python -m pytest cli/tests/test_migrations_gateway_token_env_realign.py` -> 14 passed (includes the new CRLF round-trip test)
- `go test ./internal/gateway/...` -> ok (includes new macOS cases)
- `go vet ./internal/gateway/` -> clean
- Not tested: live `defenseclaw setup guardrail` execution against a real
  managed provider; the generator output is display-only.
