### PR TITLE
fix(scanner): route gateway MCP scans through the defenseclaw mcp scan CLI

### DIFF
--- a/internal/scanner/mcp.go
+++ b/internal/scanner/mcp.go
@@ -22,18 +22,112 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
 )
 
-// MCPScanner shells out to the Python “cisco-ai-mcp-scanner“ CLI.
-// Mirrors “SkillScanner“: the LLM-facing surface is driven by the
-// unified “config.LLMConfig“ resolved at “scanners.mcp“, with the
-// legacy “InspectLLMConfig“ kept only to preserve the old
-// “NewMCPScanner“ signature for existing callers/tests.
+// mcpScanTargetLooksLikeURL returns true when “target“ parses as a
+// remote URL (http/https/ws/wss/sse). Local paths and stdio targets
+// fall through unchanged so the scanner still accepts them.
+func mcpScanTargetLooksLikeURL(target string) bool {
+	if target == "" {
+		return false
+	}
+	lower := strings.ToLower(target)
+	for _, scheme := range []string{"http://", "https://", "ws://", "wss://", "sse://"} {
+		if strings.HasPrefix(lower, scheme) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateMCPScanTargetURL refuses MCP scan URLs that point at
+// loopback / private / link-local / cloud metadata destinations, or
+// that embed inline credentials. The check is opt-out via
+// DEFENSECLAW_ALLOW_LOCAL_MCP_TARGETS=1 for local development only.
+func validateMCPScanTargetURL(target string) error {
+	if os.Getenv("DEFENSECLAW_ALLOW_LOCAL_MCP_TARGETS") == "1" {
+		return nil
+	}
+	u, err := url.Parse(target)
+	if err != nil {
+		return fmt.Errorf("invalid MCP scan target URL: %w", err)
+	}
+	if u.User != nil {
+		return errors.New("MCP scan target URL must not contain inline credentials")
+	}
+	host := u.Hostname()
+	if host == "" {
+		return errors.New("MCP scan target URL has empty host")
+	}
+	lowerHost := strings.ToLower(host)
+	if lowerHost == "localhost" ||
+		lowerHost == "ip6-localhost" ||
+		lowerHost == "ip6-loopback" ||
+		strings.HasSuffix(lowerHost, ".localhost") {
+		return fmt.Errorf("MCP scan target %q points at loopback host", host)
+	}
+	if lowerHost == "metadata.google.internal" {
+		return fmt.Errorf("MCP scan target %q points at cloud metadata host", host)
+	}
+	if literal := net.ParseIP(host); literal != nil {
+		if literal.IsLoopback() ||
+			literal.IsPrivate() ||
+			literal.IsLinkLocalUnicast() ||
+			literal.IsLinkLocalMulticast() ||
+			literal.IsUnspecified() ||
+			literal.IsMulticast() {
+			return fmt.Errorf("MCP scan target IP %s is loopback/private/link-local/multicast", literal)
+		}
+		// AWS / Oracle / DO IMDS literals.
+		if literal.String() == "169.254.169.254" || literal.String() == "fd00:ec2::254" {
+			return fmt.Errorf("MCP scan target %s is a cloud metadata endpoint", literal)
+		}
+		return nil
+	}
+	addrs, err := net.LookupIP(host)
+	if err != nil {
+		// DNS failure is treated as fatal here: an unresolvable host
+		// would be revalidated at dial time and we cannot rely on the
+		// downstream scanner to do that.
+		return fmt.Errorf("MCP scan target %q does not resolve: %w", host, err)
+	}
+	for _, ip := range addrs {
+		if ip.IsLoopback() ||
+			ip.IsPrivate() ||
+			ip.IsLinkLocalUnicast() ||
+			ip.IsLinkLocalMulticast() ||
+			ip.IsUnspecified() ||
+			ip.IsMulticast() ||
+			ip.String() == "169.254.169.254" ||
+			ip.String() == "fd00:ec2::254" {
+			return fmt.Errorf("MCP scan target %q resolves to private/loopback IP %s", host, ip)
+		}
+	}
+	return nil
+}
+
+// MCPScanner shells out to the SDK-backed Python CLI
+// (“defenseclaw mcp scan --json“) rather than the standalone
+// “mcp-scanner“ binary. The standalone binary never had a usable
+// “scan“ subcommand, and “defenseclaw mcp scan“ already resolves
+// URL-vs-name targets (including local stdio servers), honours the
+// “--analyzers/--scan-*“ knobs, and emits “ScanResult.to_json()“ —
+// the exact contract the plugin scanner already parses, so there is a
+// single SDK code path with no drift-prone second JSON schema.
+//
+// The legacy “InspectLLMConfig“/“CiscoAIDefenseConfig“ fields are kept
+// only to preserve the existing constructor signatures; LLM and Cisco
+// AI Defense credentials are resolved by the Python CLI from its own
+// config, so they are no longer injected into the subprocess env.
 type MCPScanner struct {
 	Config         config.MCPScannerConfig
 	LLM            config.LLMConfig
@@ -41,14 +135,28 @@ type MCPScanner struct {
 	CiscoAIDefense config.CiscoAIDefenseConfig
 }
 
+// mcpScannerBinary returns the executable to invoke, coercing the
+// empty default and the legacy “mcp-scanner“ value to “defenseclaw“.
+// A bare “mcp-scanner“ can never work here (it has no “mcp scan“
+// command), so any existing config still pointing at it is routed to
+// the Python CLI on upgrade.
+func mcpScannerBinary(binary string) string {
+	if binary == "" {
+		return "defenseclaw"
+	}
+	switch filepath.Base(binary) {
+	case "mcp-scanner", "mcp-scanner.exe":
+		return "defenseclaw"
+	}
+	return binary
+}
+
 // NewMCPScanner is the back-compat constructor. Translates the legacy
 // “InspectLLMConfig“ shape into the unified “LLMConfig“ internally
 // so everything downstream only deals with one structure. Prefer
 // “NewMCPScannerFromLLM“ in new code.
 func NewMCPScanner(cfg config.MCPScannerConfig, llm config.InspectLLMConfig, aid config.CiscoAIDefenseConfig) *MCPScanner {
-	if cfg.Binary == "" {
-		cfg.Binary = "mcp-scanner"
-	}
+	cfg.Binary = mcpScannerBinary(cfg.Binary)
 	return &MCPScanner{
 		Config:         cfg,
 		LLM:            inspectToLLM(llm),
@@ -61,9 +169,7 @@ func NewMCPScanner(cfg config.MCPScannerConfig, llm config.InspectLLMConfig, aid
 // LLM config. Call sites should resolve once via
 // “rootCfg.ResolveLLM("scanners.mcp")“ and pass the result here.
 func NewMCPScannerFromLLM(cfg config.MCPScannerConfig, llm config.LLMConfig, aid config.CiscoAIDefenseConfig) *MCPScanner {
-	if cfg.Binary == "" {
-		cfg.Binary = "mcp-scanner"
-	}
+	cfg.Binary = mcpScannerBinary(cfg.Binary)
 	return &MCPScanner{
 		Config:         cfg,
 		LLM:            llm,
@@ -75,60 +181,29 @@ func (s *MCPScanner) Name() string               { return "mcp-scanner" }
 func (s *MCPScanner) Version() string            { return "1.0.0" }
 func (s *MCPScanner) SupportedTargets() []string { return []string{"mcp"} }
 
+// buildArgs builds the argument vector for “defenseclaw mcp scan“.
+// The “--json/--analyzers/--scan-*“ flags are options on the “scan“
+// subcommand, so they follow “mcp scan“; the target is positional and
+// comes last. The Python CLI resolves a bare server name or a URL via
+// its own “_resolve_scan_target“, so the gateway can pass either.
 func (s *MCPScanner) buildArgs(target string) []string {
-	args := []string{"--output", "json"}
+	args := []string{"mcp", "scan", "--json"}
 
 	if s.Config.Analyzers != "" {
 		args = append(args, "--analyzers", s.Config.Analyzers)
 	}
+	if s.Config.ScanPrompts {
+		args = append(args, "--scan-prompts")
+	}
+	if s.Config.ScanResources {
+		args = append(args, "--scan-resources")
+	}
+	if s.Config.ScanInstructions {
+		args = append(args, "--scan-instructions")
+	}
 
-	args = append(args, "config", "--config-path", target)
+	args = append(args, target)
 	return args
-}
-
-func (s *MCPScanner) scanEnv() []string {
-	env := os.Environ()
-
-	inject := []struct {
-		envVar string
-		value  string
-	}{
-		{"MCP_SCANNER_API_KEY", s.CiscoAIDefense.ResolvedAPIKey()},
-		{"MCP_SCANNER_ENDPOINT", s.CiscoAIDefense.Endpoint},
-		// mcp-scanner-specific env vars. The Python scanner reads
-		// these directly; ``liteLLMModel`` yields the LiteLLM-shaped
-		// ``provider/model`` string when a bare model + separate
-		// provider were configured, matching what the unified
-		// ``Config.ResolveLLM`` produces.
-		{"MCP_SCANNER_LLM_API_KEY", s.LLM.ResolvedAPIKey()},
-		{"MCP_SCANNER_LLM_MODEL", liteLLMModel(s.LLM)},
-		{"MCP_SCANNER_LLM_BASE_URL", s.LLM.BaseURL},
-	}
-
-	existing := make(map[string]bool)
-	for _, e := range env {
-		for i := 0; i < len(e); i++ {
-			if e[i] == '=' {
-				existing[e[:i]] = true
-				break
-			}
-		}
-	}
-
-	for _, kv := range inject {
-		if kv.value != "" && !existing[kv.envVar] {
-			env = append(env, kv.envVar+"="+kv.value)
-		}
-	}
-
-	if !existing["NO_COLOR"] {
-		env = append(env, "NO_COLOR=1")
-	}
-	if !existing["TERM"] {
-		env = append(env, "TERM=dumb")
-	}
-
-	return env
 }
 
 func (s *MCPScanner) Scan(ctx context.Context, target string) (*ScanResult, error) {
@@ -141,9 +216,35 @@ func (s *MCPScanner) Scan(ctx context.Context, target string) (*ScanResult, erro
 		FinishScanSpan(sp, result, exitCode, scanErr)
 	}()
 
+	// ("MCP scan target is passed to a remote-
+	// capable scanner without URL guarding"): mcp-scanner accepts
+	// either a local path or a URL. When it's a URL, it dials the
+	// host from the sidecar's network context. Apply the same
+	// outbound-URL guard that webhook validation and the proxy use:
+	// reject loopback, private, link-local, metadata, and
+	// userinfo-bearing URLs unless the caller opts in via
+	// DEFENSECLAW_ALLOW_LOCAL_MCP_TARGETS=1 (only useful for local
+	// dev; never enable in production).
+	if mcpScanTargetLooksLikeURL(target) {
+		if err := validateMCPScanTargetURL(target); err != nil {
+			result = &ScanResult{
+				Scanner:   s.Name(),
+				Target:    target,
+				Timestamp: start,
+				ScanError: err.Error(),
+				ExitCode:  -1,
+			}
+			scanErr = err
+			exitCode = -1
+			return result, scanErr
+		}
+	}
+
 	args := s.buildArgs(target)
 	cmd := exec.CommandContext(ctx, s.Config.Binary, args...)
-	cmd.Env = s.scanEnv()
+	// Inherit the gateway's environment (like the plugin scanner):
+	// the Python CLI resolves LLM / Cisco AI Defense credentials from
+	// its own config, so no scanner-specific env injection is needed.
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -167,7 +268,7 @@ func (s *MCPScanner) Scan(ctx context.Context, target string) (*ScanResult, erro
 			exitCode = exitErr.ExitCode()
 		}
 		if errors.Is(err, exec.ErrNotFound) {
-			scanErr = fmt.Errorf("scanner: %s not found at %q — install with: uv tool install cisco-ai-mcp-scanner", s.Name(), s.Config.Binary)
+			scanErr = fmt.Errorf("scanner: %s not found at %q — install with: pip install defenseclaw (the mcpscanner SDK is provided by cisco-ai-mcp-scanner)", s.Name(), s.Config.Binary)
 			return nil, scanErr
 		}
 		if exitCode != 0 {
@@ -193,34 +294,60 @@ func (s *MCPScanner) Scan(ctx context.Context, target string) (*ScanResult, erro
 		result.Findings = findings
 	}
 
+	// hardening (S2.scanners): fail closed on any non-zero
+	// scanner exit, even when stdout was parseable. Previously a
+	// scanner that exited non-zero with `{"findings":[]}` was treated
+	// as a clean scan because admission callers branched only on the
+	// returned error. The returned result is preserved so callers can
+	// observe ExitCode/ScanError/partial findings for diagnostics,
+	// but the non-nil error guarantees fail-closed behaviour in the
+	// watcher and REST scan handlers. See finding "Non-zero MCP
+	// scanner exits can be treated as successful scans".
+	if exitCode != 0 {
+		scanErr = fmt.Errorf("scanner %s exited %d (stderr=%s)", s.Name(), exitCode, stderrStr)
+		return result, scanErr
+	}
+
 	return result, nil
 }
 
-type mcpOutput struct {
-	Findings []mcpFinding `json:"findings"`
+// mcpScanResult matches the JSON emitted by the Python CLI
+// (“defenseclaw mcp scan --json“ → “ScanResult.to_json()“). It is the
+// same top-level shape the plugin scanner parses, so the two paths
+// share a single contract.
+type mcpScanResult struct {
+	Scanner   string       `json:"scanner"`
+	Target    string       `json:"target"`
+	Timestamp string       `json:"timestamp"`
+	Findings  []mcpFinding `json:"findings"`
 }
 
 type mcpFinding struct {
-	ID          string `json:"id"`
-	Severity    string `json:"severity"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Location    string `json:"location"`
-	Remediation string `json:"remediation"`
-	RuleID      string `json:"rule_id"`
-	Category    string `json:"category"`
-	Line        int    `json:"line"`
+	ID          string   `json:"id"`
+	RuleID      string   `json:"rule_id"`
+	Category    string   `json:"category"`
+	Severity    string   `json:"severity"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Location    string   `json:"location"`
+	Line        int      `json:"line"`
+	Remediation string   `json:"remediation"`
+	Tags        []string `json:"tags"`
+	Suppressed  bool     `json:"suppressed"`
 }
 
 func parseMCPOutput(data []byte) ([]Finding, error) {
 	clean := extractJSON(ansiRe.ReplaceAll(data, nil))
-	var out mcpOutput
+	var out mcpScanResult
 	if err := json.Unmarshal(clean, &out); err != nil {
 		return nil, err
 	}
 
 	findings := make([]Finding, 0, len(out.Findings))
 	for _, f := range out.Findings {
+		if f.Suppressed {
+			continue
+		}
 		var ln *int
 		if f.Line > 0 {
 			v := f.Line
@@ -234,6 +361,7 @@ func parseMCPOutput(data []byte) ([]Finding, error) {
 			Location:    f.Location,
 			Remediation: f.Remediation,
 			Scanner:     "mcp-scanner",
+			Tags:        f.Tags,
 			RuleID:      f.RuleID,
 			Category:    f.Category,
 			LineNumber:  ln,

--- a/internal/scanner/mcp.go
+++ b/internal/scanner/mcp.go
@@ -76,22 +76,13 @@ func (s *MCPScanner) Version() string            { return "1.0.0" }
 func (s *MCPScanner) SupportedTargets() []string { return []string{"mcp"} }
 
 func (s *MCPScanner) buildArgs(target string) []string {
-	args := []string{"scan", "--format", "json"}
+	args := []string{"--output", "json"}
 
 	if s.Config.Analyzers != "" {
 		args = append(args, "--analyzers", s.Config.Analyzers)
 	}
-	if s.Config.ScanPrompts {
-		args = append(args, "--scan-prompts")
-	}
-	if s.Config.ScanResources {
-		args = append(args, "--scan-resources")
-	}
-	if s.Config.ScanInstructions {
-		args = append(args, "--scan-instructions")
-	}
 
-	args = append(args, target)
+	args = append(args, "config", "--config-path", target)
 	return args
 }
 

--- a/internal/scanner/mcp.go
+++ b/internal/scanner/mcp.go
@@ -228,11 +228,13 @@ func (s *MCPScanner) Scan(ctx context.Context, target string) (*ScanResult, erro
 	if mcpScanTargetLooksLikeURL(target) {
 		if err := validateMCPScanTargetURL(target); err != nil {
 			result = &ScanResult{
-				Scanner:   s.Name(),
-				Target:    target,
-				Timestamp: start,
-				ScanError: err.Error(),
-				ExitCode:  -1,
+				Scanner:    s.Name(),
+				Target:     target,
+				Timestamp:  start,
+				Duration:   time.Since(start),
+				TargetType: InferTargetType(s.Name()),
+				ScanError:  err.Error(),
+				ExitCode:   -1,
 			}
 			scanErr = err
 			exitCode = -1
@@ -323,14 +325,18 @@ type mcpScanResult struct {
 }
 
 type mcpFinding struct {
-	ID          string   `json:"id"`
-	RuleID      string   `json:"rule_id"`
-	Category    string   `json:"category"`
-	Severity    string   `json:"severity"`
-	Title       string   `json:"title"`
-	Description string   `json:"description"`
-	Location    string   `json:"location"`
-	Line        int      `json:"line"`
+	ID          string `json:"id"`
+	RuleID      string `json:"rule_id"`
+	Category    string `json:"category"`
+	Severity    string `json:"severity"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Location    string `json:"location"`
+	// LineNumber mirrors ScanResult.to_json()'s "line_number" field
+	// (Finding.to_dict in cli/defenseclaw/models.py). The Python CLI
+	// never emits a bare "line", so reading "line" here silently
+	// dropped every line number.
+	LineNumber  int      `json:"line_number"`
 	Remediation string   `json:"remediation"`
 	Tags        []string `json:"tags"`
 	Suppressed  bool     `json:"suppressed"`
@@ -349,8 +355,8 @@ func parseMCPOutput(data []byte) ([]Finding, error) {
 			continue
 		}
 		var ln *int
-		if f.Line > 0 {
-			v := f.Line
+		if f.LineNumber > 0 {
+			v := f.LineNumber
 			ln = &v
 		}
 		findings = append(findings, Finding{

--- a/internal/scanner/mcp_subprocess_test.go
+++ b/internal/scanner/mcp_subprocess_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+)
+
+// A non-zero scanner exit must fail closed even when stdout parsed
+// cleanly: callers branch on the returned error, so a scanner that
+// exits non-zero with a well-formed `{"findings":[]}` must not be
+// mistaken for a clean scan. The result is still returned so callers
+// can inspect ExitCode / findings for diagnostics.
+func TestMCPScanner_NonZeroExitFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "fake-mcp.sh")
+	script := "#!/bin/sh\n" +
+		`echo '{"scanner":"mcp-scanner","target":"my-server","findings":[{"id":"f1","severity":"HIGH","title":"t","line_number":4}]}'` + "\n" +
+		"exit 3\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ms := NewMCPScannerFromLLM(config.MCPScannerConfig{Binary: bin}, config.LLMConfig{}, config.CiscoAIDefenseConfig{})
+
+	// Bare server name (not a URL) so the SSRF guard is skipped and we
+	// exercise the subprocess-exit path specifically.
+	result, err := ms.Scan(context.Background(), "my-server")
+	if err == nil {
+		t.Fatal("expected non-nil error for non-zero scanner exit (fail closed)")
+	}
+	if result == nil {
+		t.Fatal("expected result to be preserved alongside the error")
+	}
+	if result.ExitCode != 3 {
+		t.Errorf("ExitCode = %d, want 3", result.ExitCode)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected 1 parsed finding preserved for diagnostics, got %d", len(result.Findings))
+	}
+	if result.Findings[0].LineNumber == nil || *result.Findings[0].LineNumber != 4 {
+		t.Errorf("LineNumber = %v, want 4 (line_number must deserialize)", result.Findings[0].LineNumber)
+	}
+}

--- a/internal/scanner/mcp_test.go
+++ b/internal/scanner/mcp_test.go
@@ -77,8 +77,9 @@ func TestMCPScanner_BinaryCoercion(t *testing.T) {
 
 // parseMCPOutput must accept the ScanResult.to_json() shape emitted by
 // "defenseclaw mcp scan --json": a top-level object with a "findings"
-// array. Suppressed findings are dropped; positive line numbers map to
-// LineNumber.
+// array. Suppressed findings are dropped; the line number arrives as
+// "line_number" (Finding.to_dict in cli/defenseclaw/models.py), so the
+// fixture uses the real field name rather than a bare "line".
 func TestParseMCPOutput_ScanResultShape(t *testing.T) {
 	payload := []byte(`{
 		"scanner": "mcp-scanner",
@@ -88,12 +89,11 @@ func TestParseMCPOutput_ScanResultShape(t *testing.T) {
 			{
 				"id": "f1",
 				"rule_id": "R-1",
-				"category": "prompt-injection",
 				"severity": "HIGH",
 				"title": "Suspicious tool description",
 				"description": "desc",
 				"location": "tools/echo",
-				"line": 12,
+				"line_number": 12,
 				"remediation": "fix it",
 				"tags": ["mcp", "yara"],
 				"suppressed": false

--- a/internal/scanner/mcp_test.go
+++ b/internal/scanner/mcp_test.go
@@ -1,0 +1,249 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/config"
+)
+
+// ---------------------------------------------------------------------------
+// buildArgs — the MCP scanner now shells out to the SDK-backed Python
+// CLI ("defenseclaw mcp scan --json <target>") instead of the
+// standalone mcp-scanner binary, which never had a usable "scan"
+// subcommand. Flags are options on the "scan" subcommand and the
+// target is positional, so the order is: mcp scan --json [flags...]
+// <target>.
+// ---------------------------------------------------------------------------
+
+func TestMCPScanner_BuildArgs_Default(t *testing.T) {
+	ms := NewMCPScannerFromLLM(config.MCPScannerConfig{}, config.LLMConfig{}, config.CiscoAIDefenseConfig{})
+	got := ms.buildArgs("my-server")
+	want := []string{"mcp", "scan", "--json", "my-server"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildArgs default = %v, want %v", got, want)
+	}
+}
+
+func TestMCPScanner_BuildArgs_AllKnobs(t *testing.T) {
+	cfg := config.MCPScannerConfig{
+		Analyzers:        "yara,llm",
+		ScanPrompts:      true,
+		ScanResources:    true,
+		ScanInstructions: true,
+	}
+	ms := NewMCPScannerFromLLM(cfg, config.LLMConfig{}, config.CiscoAIDefenseConfig{})
+	got := ms.buildArgs("https://example.com/mcp")
+	want := []string{
+		"mcp", "scan", "--json",
+		"--analyzers", "yara,llm",
+		"--scan-prompts", "--scan-resources", "--scan-instructions",
+		"https://example.com/mcp",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildArgs all knobs = %v, want %v", got, want)
+	}
+}
+
+func TestMCPScanner_BinaryCoercion(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", "defenseclaw"},
+		{"mcp-scanner", "defenseclaw"},
+		{"/usr/local/bin/mcp-scanner", "defenseclaw"},
+		{"defenseclaw", "defenseclaw"},
+		{"/opt/custom/defenseclaw", "/opt/custom/defenseclaw"},
+	}
+	for _, tc := range cases {
+		ms := NewMCPScannerFromLLM(config.MCPScannerConfig{Binary: tc.in}, config.LLMConfig{}, config.CiscoAIDefenseConfig{})
+		if ms.Config.Binary != tc.want {
+			t.Errorf("binary %q coerced to %q, want %q", tc.in, ms.Config.Binary, tc.want)
+		}
+	}
+}
+
+// parseMCPOutput must accept the ScanResult.to_json() shape emitted by
+// "defenseclaw mcp scan --json": a top-level object with a "findings"
+// array. Suppressed findings are dropped; positive line numbers map to
+// LineNumber.
+func TestParseMCPOutput_ScanResultShape(t *testing.T) {
+	payload := []byte(`{
+		"scanner": "mcp-scanner",
+		"target": "github",
+		"timestamp": "2026-06-09T00:00:00Z",
+		"findings": [
+			{
+				"id": "f1",
+				"rule_id": "R-1",
+				"category": "prompt-injection",
+				"severity": "HIGH",
+				"title": "Suspicious tool description",
+				"description": "desc",
+				"location": "tools/echo",
+				"line": 12,
+				"remediation": "fix it",
+				"tags": ["mcp", "yara"],
+				"suppressed": false
+			},
+			{
+				"id": "f2",
+				"severity": "LOW",
+				"title": "ignored",
+				"suppressed": true
+			}
+		]
+	}`)
+
+	findings, err := parseMCPOutput(payload)
+	if err != nil {
+		t.Fatalf("parseMCPOutput returned error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding (suppressed dropped), got %d", len(findings))
+	}
+	f := findings[0]
+	if f.ID != "f1" || f.Severity != Severity("HIGH") || f.RuleID != "R-1" {
+		t.Errorf("unexpected finding fields: %+v", f)
+	}
+	if f.Scanner != "mcp-scanner" {
+		t.Errorf("Scanner = %q, want 'mcp-scanner'", f.Scanner)
+	}
+	if f.LineNumber == nil || *f.LineNumber != 12 {
+		t.Errorf("LineNumber = %v, want 12", f.LineNumber)
+	}
+	if !reflect.DeepEqual(f.Tags, []string{"mcp", "yara"}) {
+		t.Errorf("Tags = %v, want [mcp yara]", f.Tags)
+	}
+}
+
+func TestParseMCPOutput_EmptyFindings(t *testing.T) {
+	findings, err := parseMCPOutput([]byte(`{"scanner":"mcp-scanner","target":"x","findings":[]}`))
+	if err != nil {
+		t.Fatalf("parseMCPOutput returned error: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings, got %d", len(findings))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// validateMCPScanTargetURL — SSRF guard for the MCP scanner's remote-URL
+// targets. The default rejects loopback / private / link-local / cloud-
+// metadata destinations and URLs that embed inline credentials.
+//
+// DEFENSECLAW_ALLOW_LOCAL_MCP_TARGETS=1 is the opt-out for local
+// development; it bypasses every other check, including inline
+// credentials, so it must NEVER be set in production.
+// ---------------------------------------------------------------------------
+
+func TestValidateMCPScanTargetURL_Default(t *testing.T) {
+	// Make sure no leftover env from a previous test flips the gate.
+	t.Setenv("DEFENSECLAW_ALLOW_LOCAL_MCP_TARGETS", "")
+
+	cases := []struct {
+		name    string
+		target  string
+		wantErr string
+	}{
+		{"loopback hostname", "http://localhost:8080/mcp", "loopback"},
+		{"loopback v4 literal", "http://127.0.0.1/mcp", "loopback"},
+		{"loopback v6 literal", "http://[::1]/mcp", "loopback"},
+		{"rfc1918", "http://10.0.0.1/mcp", "private"},
+		// 169.254/16 falls into the link-local class first, so the
+		// error reads "link-local" rather than "metadata" — the IMDS
+		// literal check is a belt-and-braces follow-up for the case
+		// where the link-local class wasn't enough. Either rejection
+		// is acceptable for this gate.
+		{"link-local", "http://169.254.1.1/mcp", "link-local"},
+		{"cloud IMDS v4", "http://169.254.169.254/mcp", "link-local"},
+		{"GCP metadata hostname", "http://metadata.google.internal/mcp", "metadata"},
+		{"inline credentials", "http://user:pass@public.example.com/mcp", "credentials"},
+		{"empty host", "http:///mcp", "host"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateMCPScanTargetURL(tc.target)
+			if err == nil {
+				t.Fatalf("validateMCPScanTargetURL(%q) = nil, want error containing %q", tc.target, tc.wantErr)
+			}
+			if !strings.Contains(strings.ToLower(err.Error()), tc.wantErr) {
+				t.Errorf("validateMCPScanTargetURL(%q) err = %q, want substring %q", tc.target, err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateMCPScanTargetURL_AllowLocalOptIn(t *testing.T) {
+	// With the opt-out engaged, even the worst cases must pass —
+	// inline credentials, loopback, and IMDS. This pins exactly how
+	// dangerous the env var is; the test passing means the gate is
+	// genuinely bypassed.
+	t.Setenv("DEFENSECLAW_ALLOW_LOCAL_MCP_TARGETS", "1")
+	cases := []string{
+		"http://localhost:8080/mcp",
+		"http://127.0.0.1/mcp",
+		"http://10.0.0.1/mcp",
+		"http://169.254.169.254/mcp",
+		"http://user:pass@public.example.com/mcp",
+	}
+	for _, target := range cases {
+		if err := validateMCPScanTargetURL(target); err != nil {
+			t.Errorf("DEFENSECLAW_ALLOW_LOCAL_MCP_TARGETS=1, validateMCPScanTargetURL(%q) = %v, want nil", target, err)
+		}
+	}
+}
+
+func TestValidateMCPScanTargetURL_OnlyExactOneOptsIn(t *testing.T) {
+	// Anything other than the exact string "1" must keep the gate
+	// closed. This prevents a typo like "true" / "yes" / " 1 " from
+	// silently disabling the SSRF guard.
+	for _, v := range []string{"", "0", "true", "yes", "TRUE", " 1 ", "1\n"} {
+		t.Setenv("DEFENSECLAW_ALLOW_LOCAL_MCP_TARGETS", v)
+		if err := validateMCPScanTargetURL("http://localhost:8080/mcp"); err == nil {
+			t.Errorf("env=%q must NOT opt in; localhost target unexpectedly accepted", v)
+		}
+	}
+}
+
+func TestMcpScanTargetLooksLikeURL(t *testing.T) {
+	urls := []string{
+		"http://example.com/mcp",
+		"https://example.com/mcp",
+		"ws://example.com/mcp",
+		"wss://example.com/mcp",
+		"sse://example.com/mcp",
+		// Case-insensitive scheme prefix.
+		"HTTPS://example.com/mcp",
+	}
+	notURLs := []string{
+		"",
+		"/local/path",
+		"./relative",
+		"stdio://something", // unknown scheme
+		"file:///etc/passwd",
+		"my-server-name",
+	}
+	for _, u := range urls {
+		if !mcpScanTargetLooksLikeURL(u) {
+			t.Errorf("mcpScanTargetLooksLikeURL(%q) = false, want true", u)
+		}
+	}
+	for _, n := range notURLs {
+		if mcpScanTargetLooksLikeURL(n) {
+			t.Errorf("mcpScanTargetLooksLikeURL(%q) = true, want false", n)
+		}
+	}
+}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -124,9 +124,17 @@ func TestSkillScanner_ScanEnv_InjectsCiscoKey(t *testing.T) {
 }
 
 func TestNewMCPScanner_DefaultBinary(t *testing.T) {
+	// The MCP scanner now routes through the SDK-backed Python CLI
+	// (defenseclaw mcp scan), so the empty default and the legacy
+	// "mcp-scanner" value both coerce to "defenseclaw".
 	ms := NewMCPScanner(config.MCPScannerConfig{}, config.InspectLLMConfig{}, config.CiscoAIDefenseConfig{})
-	if ms.Config.Binary != "mcp-scanner" {
-		t.Errorf("expected default binary 'mcp-scanner', got %q", ms.Config.Binary)
+	if ms.Config.Binary != "defenseclaw" {
+		t.Errorf("expected default binary 'defenseclaw', got %q", ms.Config.Binary)
+	}
+
+	legacy := NewMCPScanner(config.MCPScannerConfig{Binary: "mcp-scanner"}, config.InspectLLMConfig{}, config.CiscoAIDefenseConfig{})
+	if legacy.Config.Binary != "defenseclaw" {
+		t.Errorf("legacy 'mcp-scanner' must coerce to 'defenseclaw', got %q", legacy.Config.Binary)
 	}
 }
 
@@ -144,60 +152,7 @@ func TestNewMCPScanner_StoresCommonConfigs(t *testing.T) {
 	}
 }
 
-func TestMCPScanner_ScanEnv_InjectsCommonKeys(t *testing.T) {
-	os.Unsetenv("MCP_SCANNER_API_KEY")
-	os.Unsetenv("MCP_SCANNER_LLM_API_KEY")
-	os.Unsetenv("MCP_SCANNER_LLM_MODEL")
-	os.Unsetenv("MCP_SCANNER_LLM_BASE_URL")
-
-	llm := config.InspectLLMConfig{APIKey: "llm-key", Model: "gpt-4o", BaseURL: "https://custom.llm"}
-	aid := config.CiscoAIDefenseConfig{APIKey: "aid-key", APIKeyEnv: "", Endpoint: "https://ep.example.com"}
-
-	ms := NewMCPScanner(config.MCPScannerConfig{}, llm, aid)
-	env := ms.scanEnv()
-
-	found := map[string]string{}
-	for _, e := range env {
-		parts := strings.SplitN(e, "=", 2)
-		if len(parts) == 2 {
-			found[parts[0]] = parts[1]
-		}
-	}
-
-	if found["MCP_SCANNER_API_KEY"] != "aid-key" {
-		t.Errorf("expected MCP_SCANNER_API_KEY='aid-key', got %q", found["MCP_SCANNER_API_KEY"])
-	}
-	if found["MCP_SCANNER_ENDPOINT"] != "https://ep.example.com" {
-		t.Errorf("expected MCP_SCANNER_ENDPOINT endpoint, got %q", found["MCP_SCANNER_ENDPOINT"])
-	}
-	if found["MCP_SCANNER_LLM_API_KEY"] != "llm-key" {
-		t.Errorf("expected MCP_SCANNER_LLM_API_KEY='llm-key', got %q", found["MCP_SCANNER_LLM_API_KEY"])
-	}
-	if found["MCP_SCANNER_LLM_MODEL"] != "gpt-4o" {
-		t.Errorf("expected MCP_SCANNER_LLM_MODEL='gpt-4o', got %q", found["MCP_SCANNER_LLM_MODEL"])
-	}
-	if found["MCP_SCANNER_LLM_BASE_URL"] != "https://custom.llm" {
-		t.Errorf("expected MCP_SCANNER_LLM_BASE_URL='https://custom.llm', got %q", found["MCP_SCANNER_LLM_BASE_URL"])
-	}
-}
-
-func TestMCPScanner_ScanEnv_ResolvesKeyFromEnv(t *testing.T) {
-	t.Setenv("TEST_MCP_CISCO_ENV_KEY", "resolved-from-env")
-	os.Unsetenv("MCP_SCANNER_API_KEY")
-
-	aid := config.CiscoAIDefenseConfig{APIKey: "fallback", APIKeyEnv: "TEST_MCP_CISCO_ENV_KEY"}
-	ms := NewMCPScanner(config.MCPScannerConfig{}, config.InspectLLMConfig{}, aid)
-
-	env := ms.scanEnv()
-
-	for _, e := range env {
-		if strings.HasPrefix(e, "MCP_SCANNER_API_KEY=") {
-			val := strings.TrimPrefix(e, "MCP_SCANNER_API_KEY=")
-			if val != "resolved-from-env" {
-				t.Errorf("expected 'resolved-from-env', got %q", val)
-			}
-			return
-		}
-	}
-	t.Error("MCP_SCANNER_API_KEY not found in scanEnv()")
-}
+// The MCP scanner no longer injects MCP_SCANNER_* environment
+// variables: it shells out to "defenseclaw mcp scan", which resolves
+// LLM and Cisco AI Defense credentials from its own config. The
+// former TestMCPScanner_ScanEnv_* tests were removed with scanEnv.


### PR DESCRIPTION
## Summary

The Go gateway's MCP scanner subprocess has been broken since the initial commit — it invoked `mcp-scanner scan ...` but the `cisco-ai-mcp-scanner` CLI has never had a usable `scan` subcommand. Per @vineethsai's review, this PR **drops the standalone `mcp-scanner` binary entirely and routes through the SDK-backed Python CLI** (`defenseclaw mcp scan --json`) — the same pattern the plugin scanner already uses (`defenseclaw plugin scan --json`).

This replaces the earlier `config --config-path` attempt, which still couldn't work: `--output` is a file destination (not a JSON selector), the gateway passes a URL or server name (never a config file), and the SDK's per-item array never matched the Go parser.

## What changed

**Reroute to the Python CLI (`internal/scanner/mcp.go`)**
- `buildArgs` now emits `mcp scan --json [--analyzers <a>] [--scan-prompts] [--scan-resources] [--scan-instructions] <target>` — flags follow the `scan` subcommand, target is positional (matches click parsing).
- Coerce the empty default and the legacy `mcp-scanner` binary (incl. pathed variants) to `defenseclaw`, so existing configs self-heal on upgrade.
- Parse the `ScanResult.to_json()` shape (mirrors `parsePluginOutput`), dropping suppressed findings. The Python CLI resolves URL-vs-name targets (`_resolve_scan_target`, incl. local stdio servers) and LLM / Cisco AI Defense credentials from its own config, so the Go-side `MCP_SCANNER_*` env injection is removed (single SDK code path, no drift-prone second parser).

**Companion controls that must ship with a working dial path**

Before this PR, gateway-initiated MCP scans *silently failed* (no dial). The reroute is what finally makes them actually dial the target, so it carries:
- **SSRF guard** (`validateMCPScanTargetURL`): rejects loopback / private / link-local / cloud-metadata / credential-bearing URLs before dialing. Opt-out via `DEFENSECLAW_ALLOW_LOCAL_MCP_TARGETS=1` (local dev only). Required because neither the Python CLI nor the SDK validates the target, and `/v1/mcp/scan` accepts an arbitrary target from the request body.
- **Fail closed** on any non-zero scanner exit, even when stdout parsed cleanly.

**Tests**
- New unit tests: `buildArgs` (default + all knobs), binary coercion table, and `parseMCPOutput` against the `ScanResult.to_json()` schema (suppressed-drop / line / tags / empty).
- Updated the default-binary test (`defenseclaw` + legacy coercion) and removed the obsolete `scanEnv` tests.
- SSRF-guard tests included.

## Verification
- `go build ./...` clean; `go test ./internal/scanner/` passes; `go vet` clean; `gofmt` clean.
- Live: `defenseclaw mcp scan --json --analyzers yara <server>` → exit 0, clean `ScanResult.to_json()` on stdout, empty stderr; the Go parser deserializes it 1:1 (`{"scanner","target","timestamp","findings":[],"duration_ms"}`).

## Notes
- `cisco-ai-mcp-scanner` stays required — it provides the `mcpscanner` SDK that `defenseclaw mcp scan` imports — so `scripts/setup-scanners.sh` is unchanged; only the standalone `mcp-scanner` binary invocation is dropped.
- Operational: if a deployment sets `scanners.mcp.analyzers` to include `llm`, the LLM key must be present in `~/.defenseclaw/config.yaml` (or a standard provider env var) — same config source as before, now resolved by the Python CLI. The default `yara` analyzer needs no LLM.