### PR TITLE
fix(setup): prompt to trust binary prefix + add Caskroom to defaults

### DIFF
--- a/cli/defenseclaw/commands/cmd_agent.py
+++ b/cli/defenseclaw/commands/cmd_agent.py
@@ -40,6 +40,41 @@ def agent() -> None:
     """Inspect locally installed agent surfaces."""
 
 
+def _emit_untrusted_prefix_hint(disc: agent_discovery.AgentDiscovery) -> None:
+    """Point operators at the generic remediation when a connector binary
+    was skipped for living outside a trusted install prefix.
+
+    Without this, the only signal is the per-row "binary path is not in a
+    trusted install prefix" error — accurate but not actionable. The hint
+    is connector-agnostic and recommends the same ``trusted-paths`` command
+    the setup gate now points at, so discovery and setup stay consistent.
+    """
+    from defenseclaw import ux
+
+    dirs: list[str] = []
+    seen: set[str] = set()
+    for sig in disc.agents.values():
+        if sig.error == agent_discovery.UNTRUSTED_PREFIX_ERROR and sig.binary_path:
+            parent = os.path.dirname(os.path.realpath(sig.binary_path))
+            if parent and parent not in seen:
+                seen.add(parent)
+                dirs.append(parent)
+    if not dirs:
+        return
+    n = len(dirs)
+    click.echo()
+    ux.warn(
+        f"{n} director{'y' if n == 1 else 'ies'} hold connector binaries outside a "
+        "trusted install prefix; they were skipped during version discovery."
+    )
+    for d in dirs:
+        ux.subhead(f"  Trust it with: defenseclaw setup trusted-paths add {d}")
+    ux.subhead(
+        "  Only trust directories you control — a trusted directory lets "
+        "DefenseClaw execute any binary placed there during discovery."
+    )
+
+
 @agent.command("discover")
 @click.option("--refresh", is_flag=True, help="Refresh cached discovery before rendering.")
 @click.option("--no-cache", is_flag=True, help="Bypass the discovery cache for this run.")
@@ -75,6 +110,15 @@ def discover(
     gateway_token_env: str | None,
 ) -> None:
     """Run local agent discovery and optionally emit OTel telemetry."""
+    # `agent` is in main.SKIP_LOAD_COMMANDS, so the root group never loads
+    # config — and thus never hydrates ~/.defenseclaw/.env. Without this, a
+    # prefix persisted via `setup trusted-paths add` would be ignored here, so
+    # the untrusted-binary hint below would point at a fix this very command
+    # then disregards. Hydrate just the .env (cheap; no full config load or
+    # validation, keeping `agent` fast) so discovery honours persisted trust.
+    from defenseclaw.config import _load_dotenv_into_os, default_data_path  # noqa: PLC0415
+
+    _load_dotenv_into_os(str(default_data_path()))
     started = time.monotonic()
     disc = agent_discovery.discover_agents(use_cache=not no_cache, refresh=refresh)
     duration_ms = int((time.monotonic() - started) * 1000)
@@ -99,6 +143,7 @@ def discover(
         return
 
     click.echo(agent_discovery.render_discovery_table(disc).rstrip())
+    _emit_untrusted_prefix_hint(disc)
     if emit_otel:
         if otel_result["emitted"]:
             click.echo("  OTel: emitted agent discovery telemetry")

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -26,6 +26,7 @@ import os
 import shutil
 import socket
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -1583,6 +1584,20 @@ def _write_dotenv(path: str, entries: dict[str, str]) -> None:
         pass
 
 
+def _add_trusted_bin_prefix(prefix: str, data_dir: str) -> None:
+    """Add a directory to DEFENSECLAW_TRUSTED_BIN_PREFIXES in .env and os.environ."""
+    dotenv_path = os.path.join(data_dir, ".env")
+    existing = _load_dotenv(dotenv_path)
+    current = existing.get("DEFENSECLAW_TRUSTED_BIN_PREFIXES", os.environ.get("DEFENSECLAW_TRUSTED_BIN_PREFIXES", ""))
+    parts = [p.strip() for p in current.split(":") if p.strip()]
+    if prefix not in parts:
+        parts.append(prefix)
+    new_val = ":".join(parts)
+    existing["DEFENSECLAW_TRUSTED_BIN_PREFIXES"] = new_val
+    _write_dotenv(dotenv_path, existing)
+    os.environ["DEFENSECLAW_TRUSTED_BIN_PREFIXES"] = new_val
+
+
 def _print_summary(sc, llm, aid) -> None:
     click.echo()
     click.echo("  Saved to ~/.defenseclaw/config.yaml")
@@ -2548,11 +2563,34 @@ def _check_connector_version_supported_for_setup(
             detail += f" ({probe_error})"
         detail += f"; using default hook contract {contract}."
         if action_mode and not allow_drift:
-            if emit:
+            is_untrusted_path = probe_error == "binary path is not in a trusted install prefix" and signal and signal.binary_path
+            interactive = sys.stdin.isatty() and sys.stdout.isatty()
+            if emit and is_untrusted_path and interactive:
+                resolved = os.path.realpath(signal.binary_path)
+                parent = os.path.dirname(resolved)
+                ux.warn(detail)
+                ux.subhead(f"  Binary resolves to: {resolved}")
+                ux.subhead(f"  Directory '{parent}' is not in the trusted prefix list.")
+                if click.confirm(f"  Add '{parent}' to trusted binary prefixes?", default=True):
+                    _add_trusted_bin_prefix(parent, data_dir or os.path.expanduser("~/.defenseclaw"))
+                    disc2 = agent_discovery.discover_agents(use_cache=False, refresh=True, data_dir=data_dir)
+                    signal2 = disc2.agents.get(connector)
+                    if signal2 and signal2.version:
+                        ux.ok(f"{label}: version {signal2.version} verified after trusting {parent}.")
+                        return True
+                    ux.err("  Version still could not be verified after adding trusted prefix.")
+            elif emit:
                 ux.err(
                     detail + " Refusing action-mode hook setup because the installed "
                     "connector version could not be verified."
                 )
+                if is_untrusted_path:
+                    resolved = os.path.realpath(signal.binary_path)
+                    parent = os.path.dirname(resolved)
+                    ux.subhead(f"  Binary resolves to: {resolved}")
+                    ux.subhead(f"  To fix, run: defenseclaw setup {connector} --mode action")
+                    ux.subhead(f"  Or manually add to ~/.defenseclaw/.env: DEFENSECLAW_TRUSTED_BIN_PREFIXES={parent}")
+            if emit:
                 ux.subhead("Set DEFENSECLAW_ALLOW_HOOK_CONTRACT_DRIFT=1 only for exploratory testing.")
             return False
         if emit:

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -1584,18 +1584,228 @@ def _write_dotenv(path: str, entries: dict[str, str]) -> None:
         pass
 
 
-def _add_trusted_bin_prefix(prefix: str, data_dir: str) -> None:
-    """Add a directory to DEFENSECLAW_TRUSTED_BIN_PREFIXES in .env and os.environ."""
+def _add_trusted_bin_prefix(prefix: str, data_dir: str) -> bool:
+    """Add a directory to DEFENSECLAW_TRUSTED_BIN_PREFIXES in .env and os.environ.
+
+    Entries are separated by ``os.pathsep`` (``:`` on POSIX, ``;`` on
+    Windows) so a Windows drive-qualified path like ``C:\\Tools`` is not
+    mangled by a hard-coded colon split. Returns ``True`` when the prefix
+    was newly added, ``False`` when it was already present (idempotent).
+    """
     dotenv_path = os.path.join(data_dir, ".env")
     existing = _load_dotenv(dotenv_path)
-    current = existing.get("DEFENSECLAW_TRUSTED_BIN_PREFIXES", os.environ.get("DEFENSECLAW_TRUSTED_BIN_PREFIXES", ""))
-    parts = [p.strip() for p in current.split(":") if p.strip()]
-    if prefix not in parts:
+    current = existing.get(
+        "DEFENSECLAW_TRUSTED_BIN_PREFIXES",
+        os.environ.get("DEFENSECLAW_TRUSTED_BIN_PREFIXES", ""),
+    )
+    parts = [p.strip() for p in current.split(os.pathsep) if p.strip()]
+    added = prefix not in parts
+    if added:
         parts.append(prefix)
-    new_val = ":".join(parts)
+    new_val = os.pathsep.join(parts)
     existing["DEFENSECLAW_TRUSTED_BIN_PREFIXES"] = new_val
     _write_dotenv(dotenv_path, existing)
     os.environ["DEFENSECLAW_TRUSTED_BIN_PREFIXES"] = new_val
+    return added
+
+
+# ---------------------------------------------------------------------------
+# `defenseclaw setup trusted-paths` — manage the binary-discovery allow-list.
+#
+# Built-in defaults live in agent_discovery._TRUSTED_BIN_PREFIXES_DEFAULT and
+# are read-only here. Operator additions persist to ~/.defenseclaw/.env via
+# the same _add_trusted_bin_prefix() the interactive prompt uses, validated by
+# the same agent_discovery.validate_trusted_prefix() guard the discovery gate
+# trusts — so the CLI, the prompt, and the gate can never disagree.
+# ---------------------------------------------------------------------------
+
+
+def _trusted_prefix_status(resolved: str) -> str:
+    """Classify a resolved prefix: ok / missing / not-a-dir / world-writable."""
+    if not os.path.exists(resolved):
+        return "missing"
+    if not os.path.isdir(resolved):
+        return "not-a-dir"
+    try:
+        if os.stat(resolved).st_mode & 0o002:
+            return "world-writable"
+    except OSError:  # pragma: no cover - rare stat failure
+        return "error"
+    return "ok"
+
+
+def _default_resolved_prefixes() -> set[str]:
+    """Resolved absolute paths of the built-in (non-removable) defaults."""
+    out: set[str] = set()
+    for raw in agent_discovery._TRUSTED_BIN_PREFIXES_DEFAULT:
+        resolved, _ = agent_discovery.validate_trusted_prefix(raw)
+        if resolved:
+            out.add(resolved)
+    return out
+
+
+def _collect_trusted_prefixes(data_dir: str) -> list[dict[str, object]]:
+    """Unified trusted-prefix view: built-in defaults + .env + exported env.
+
+    Source attribution: ``default`` (built-in), ``.env`` (operator-added,
+    removable), ``env`` (exported in the process environment but not in
+    .env — we can't rewrite the parent shell, so it is shown read-only).
+    """
+    dotenv_path = os.path.join(data_dir, ".env")
+    env_file_raw = _load_dotenv(dotenv_path).get("DEFENSECLAW_TRUSTED_BIN_PREFIXES", "")
+    env_file = [p.strip() for p in env_file_raw.split(os.pathsep) if p.strip()]
+    proc_raw = os.environ.get("DEFENSECLAW_TRUSTED_BIN_PREFIXES", "")
+    proc = [p.strip() for p in proc_raw.split(os.pathsep) if p.strip()]
+    env_only = [p for p in proc if p not in env_file]
+
+    rows: list[dict[str, object]] = []
+    seen: set[str] = set()
+
+    def _push(raw: str, source: str, removable: bool) -> None:
+        resolved, _err = agent_discovery.validate_trusted_prefix(raw)
+        if not resolved or resolved in seen:
+            return
+        seen.add(resolved)
+        rows.append(
+            {
+                "path": raw,
+                "resolved": resolved,
+                "source": source,
+                "status": _trusted_prefix_status(resolved),
+                "removable": removable,
+            }
+        )
+
+    for raw in agent_discovery._TRUSTED_BIN_PREFIXES_DEFAULT:
+        _push(raw, "default", False)
+    for raw in env_file:
+        _push(raw, ".env", True)
+    for raw in env_only:
+        _push(raw, "env", False)
+    return rows
+
+
+def _emit_trusted_path_result(as_json: bool, *, ok: bool, path: str, message: str) -> None:
+    if as_json:
+        click.echo(_json.dumps({"ok": ok, "path": path, "message": message}, indent=2))
+    elif ok:
+        ux.ok(f"{message}: {path}" if path else message)
+    else:
+        ux.err(f"{message}: {path}" if path else message)
+
+
+@setup.group("trusted-paths")
+def trusted_paths() -> None:
+    """Manage directories DefenseClaw trusts for connector-binary discovery.
+
+    \b
+    Action-mode setup reads a connector's version by executing its binary, but
+    only when that binary lives under a trusted prefix — a guard against a
+    hostile binary planted on $PATH. Built-in defaults cover system and
+    Homebrew locations; trust additional roots here for bespoke installs.
+    Additions persist to ~/.defenseclaw/.env (DEFENSECLAW_TRUSTED_BIN_PREFIXES).
+    """
+
+
+@trusted_paths.command("list")
+@click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON instead of a table.")
+@pass_ctx
+def trusted_paths_list(app: AppContext, as_json: bool) -> None:
+    """List trusted binary prefixes (built-in defaults + operator-added)."""
+    rows = _collect_trusted_prefixes(app.cfg.data_dir)
+    if as_json:
+        click.echo(_json.dumps(rows, indent=2))
+        return
+    if not rows:
+        click.echo(f"  {ux.dim('No trusted prefixes configured.')}")
+        return
+    click.echo()
+    src_w = max(len(str(r["source"])) for r in rows)
+    st_w = max(len(str(r["status"])) for r in rows)
+    for r in rows:
+        mark = "✓" if r["status"] == "ok" else "✗"
+        source = str(r["source"]).ljust(src_w)
+        status = str(r["status"]).ljust(st_w)
+        line = f"  {mark}  {ux.dim(source)}  {status}  {r['resolved']}"
+        if r["removable"]:
+            line += f"  {ux.dim('(removable)')}"
+        click.echo(line)
+    click.echo()
+    click.echo(f"  {ux.dim('Add with: defenseclaw setup trusted-paths add <dir>')}")
+    click.echo()
+
+
+@trusted_paths.command("add")
+@click.argument("directory")
+@click.option("--force", is_flag=True, help="Add even when the directory is world-writable or missing.")
+@click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON instead of text.")
+@pass_ctx
+def trusted_paths_add(app: AppContext, directory: str, force: bool, as_json: bool) -> None:
+    """Trust DIRECTORY for connector-binary discovery (persisted to .env)."""
+    resolved, err = agent_discovery.validate_trusted_prefix(directory)
+    if not resolved:
+        _emit_trusted_path_result(as_json, ok=False, path=directory, message=f"invalid path ({err})")
+        click.get_current_context().exit(1)
+    if resolved in _default_resolved_prefixes():
+        _emit_trusted_path_result(
+            as_json, ok=True, path=resolved, message="already trusted by default; nothing to do"
+        )
+        return
+    if err and not force:
+        _emit_trusted_path_result(
+            as_json,
+            ok=False,
+            path=resolved,
+            message=f"refusing to trust ({err}); re-run with --force to override",
+        )
+        click.get_current_context().exit(1)
+    added = _add_trusted_bin_prefix(resolved, app.cfg.data_dir)
+    message = "added to trusted prefixes" if added else "already an operator-added trusted prefix"
+    if err and force:
+        message += f" (forced despite: {err})"
+    _emit_trusted_path_result(as_json, ok=True, path=resolved, message=message)
+
+
+@trusted_paths.command("remove")
+@click.argument("directory")
+@click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON instead of text.")
+@pass_ctx
+def trusted_paths_remove(app: AppContext, directory: str, as_json: bool) -> None:
+    """Remove an operator-added trusted prefix (never a built-in default)."""
+    resolved, _err = agent_discovery.validate_trusted_prefix(directory)
+    if resolved in _default_resolved_prefixes():
+        _emit_trusted_path_result(
+            as_json, ok=False, path=resolved, message="refusing to remove a built-in default prefix"
+        )
+        click.get_current_context().exit(1)
+    data_dir = app.cfg.data_dir
+    dotenv_path = os.path.join(data_dir, ".env")
+    existing = _load_dotenv(dotenv_path)
+    current = existing.get("DEFENSECLAW_TRUSTED_BIN_PREFIXES", "")
+    entries = [p.strip() for p in current.split(os.pathsep) if p.strip()]
+    target = (directory or "").strip()
+    kept = [
+        e
+        for e in entries
+        if e != target and agent_discovery.validate_trusted_prefix(e)[0] != resolved
+    ]
+    if len(kept) == len(entries):
+        _emit_trusted_path_result(
+            as_json,
+            ok=False,
+            path=resolved,
+            message="not an operator-added (.env) trusted prefix; nothing to remove",
+        )
+        click.get_current_context().exit(1)
+    new_val = os.pathsep.join(kept)
+    if new_val:
+        existing["DEFENSECLAW_TRUSTED_BIN_PREFIXES"] = new_val
+        os.environ["DEFENSECLAW_TRUSTED_BIN_PREFIXES"] = new_val
+    else:
+        existing.pop("DEFENSECLAW_TRUSTED_BIN_PREFIXES", None)
+        os.environ.pop("DEFENSECLAW_TRUSTED_BIN_PREFIXES", None)
+    _write_dotenv(dotenv_path, existing)
+    _emit_trusted_path_result(as_json, ok=True, path=resolved, message="removed from trusted prefixes")
 
 
 def _print_summary(sc, llm, aid) -> None:
@@ -2500,6 +2710,7 @@ def _check_connector_version_supported_for_setup(
     mode: str = "observe",
     emit: bool = True,
     data_dir: str | os.PathLike[str] | None = None,
+    _allow_prompt: bool = True,
 ) -> bool:
     """Verify the selected connector's installed version before setup.
 
@@ -2507,6 +2718,11 @@ def _check_connector_version_supported_for_setup(
     the operator before it writes config and restarts services. Unknown hook
     contracts are fatal in action mode unless the explicit exploratory
     override used by the gateway is set.
+
+    ``_allow_prompt`` gates the interactive "trust this directory" remediation.
+    It defaults to ``True`` so direct CLI use is unchanged, but callers that
+    must never block on stdin — the TUI, or this function's own re-entry after
+    trusting a prefix — pass ``False`` to force the non-interactive path.
     """
     connector = normalize_connector(connector)
     label = _CONNECTOR_META.get(connector, {}).get("label", connector or "connector")
@@ -2563,23 +2779,45 @@ def _check_connector_version_supported_for_setup(
             detail += f" ({probe_error})"
         detail += f"; using default hook contract {contract}."
         if action_mode and not allow_drift:
-            is_untrusted_path = probe_error == "binary path is not in a trusted install prefix" and signal and signal.binary_path
-            interactive = sys.stdin.isatty() and sys.stdout.isatty()
+            is_untrusted_path = bool(
+                probe_error == agent_discovery.UNTRUSTED_PREFIX_ERROR
+                and signal
+                and signal.binary_path
+            )
+            interactive = _allow_prompt and sys.stdin.isatty() and sys.stdout.isatty()
             if emit and is_untrusted_path and interactive:
                 resolved = os.path.realpath(signal.binary_path)
                 parent = os.path.dirname(resolved)
                 ux.warn(detail)
                 ux.subhead(f"  Binary resolves to: {resolved}")
                 ux.subhead(f"  Directory '{parent}' is not in the trusted prefix list.")
-                if click.confirm(f"  Add '{parent}' to trusted binary prefixes?", default=True):
+                ux.subhead(
+                    "  Trusting a directory lets DefenseClaw execute any binary placed "
+                    "there during discovery — only trust locations you control."
+                )
+                if click.confirm(f"  Add '{parent}' to trusted binary prefixes?", default=False):
                     _add_trusted_bin_prefix(parent, data_dir or os.path.expanduser("~/.defenseclaw"))
-                    disc2 = agent_discovery.discover_agents(use_cache=False, refresh=True, data_dir=data_dir)
-                    signal2 = disc2.agents.get(connector)
-                    if signal2 and signal2.version:
-                        ux.ok(f"{label}: version {signal2.version} verified after trusting {parent}.")
-                        return True
-                    ux.err("  Version still could not be verified after adding trusted prefix.")
-            elif emit:
+                    ux.subhead(f"  Trusted '{parent}' (persisted to ~/.defenseclaw/.env); re-checking…")
+                    ux.subhead(
+                        "  Note: if this path is version-specific it may need re-trusting "
+                        "after an upgrade — `defenseclaw setup trusted-paths add <dir>`."
+                    )
+                    # Re-run the FULL gate (now non-interactive) so the
+                    # version -> hook-contract check still applies. Trusting the
+                    # path only lets us READ the version; it must not be treated
+                    # as version approval. Suppressing the prompt on re-entry
+                    # also prevents an infinite loop when trusting the directory
+                    # cannot help (e.g. a world-writable parent the per-file
+                    # guard still rejects).
+                    return _check_connector_version_supported_for_setup(
+                        connector,
+                        mode=mode,
+                        emit=emit,
+                        data_dir=data_dir,
+                        _allow_prompt=False,
+                    )
+                # Declined: fall through to the refusal/hint below.
+            if emit and not (is_untrusted_path and interactive):
                 ux.err(
                     detail + " Refusing action-mode hook setup because the installed "
                     "connector version could not be verified."
@@ -2588,8 +2826,11 @@ def _check_connector_version_supported_for_setup(
                     resolved = os.path.realpath(signal.binary_path)
                     parent = os.path.dirname(resolved)
                     ux.subhead(f"  Binary resolves to: {resolved}")
-                    ux.subhead(f"  To fix, run: defenseclaw setup {connector} --mode action")
-                    ux.subhead(f"  Or manually add to ~/.defenseclaw/.env: DEFENSECLAW_TRUSTED_BIN_PREFIXES={parent}")
+                    ux.subhead(f"  Trust it with: defenseclaw setup trusted-paths add {parent}")
+                    ux.subhead(
+                        f"  (or add manually to ~/.defenseclaw/.env: "
+                        f"DEFENSECLAW_TRUSTED_BIN_PREFIXES={parent})"
+                    )
             if emit:
                 ux.subhead("Set DEFENSECLAW_ALLOW_HOOK_CONTRACT_DRIFT=1 only for exploratory testing.")
             return False

--- a/cli/defenseclaw/inventory/agent_discovery.py
+++ b/cli/defenseclaw/inventory/agent_discovery.py
@@ -41,6 +41,14 @@ except ImportError:  # pragma: no cover - non-POSIX
 from defenseclaw.config import default_data_path
 from defenseclaw.connector_paths import KNOWN_CONNECTORS, _expand
 
+# Sentinel error returned by ``_version_for_binary`` when a connector
+# binary resolves outside the trusted install prefixes. Callers (e.g.
+# ``cmd_setup``) key off this exact value to decide whether to offer the
+# "trust this directory" remediation, so it lives here as a shared
+# constant rather than being duplicated as a string literal on both
+# sides — if the wording ever changes, the consumer can't silently drift.
+UNTRUSTED_PREFIX_ERROR = "binary path is not in a trusted install prefix"
+
 CACHE_SCHEMA_VERSION = 1
 CACHE_TTL_SECONDS = 86_400
 CACHE_FILENAME = "agent_discovery.json"
@@ -279,7 +287,9 @@ def _trusted_bin_prefixes() -> tuple[str, ...]:
     """
     extras: list[str] = []
     raw = os.environ.get("DEFENSECLAW_TRUSTED_BIN_PREFIXES", "")
-    for piece in raw.split(":"):
+    # Split on os.pathsep (':' POSIX, ';' Windows) so a Windows
+    # drive-qualified path like 'C:\\Tools' survives unmangled.
+    for piece in raw.split(os.pathsep):
         piece = piece.strip()
         if piece:
             extras.append(piece)
@@ -302,6 +312,44 @@ def _trusted_bin_prefixes() -> tuple[str, ...]:
             continue
         expanded.append(absolute)
     return tuple(expanded)
+
+
+def validate_trusted_prefix(path: str) -> tuple[str, str | None]:
+    """Validate a candidate trusted-bin-prefix directory.
+
+    Returns ``(resolved_abspath, error)`` where ``error`` is ``None`` when the
+    directory is a safe place to trust, or a short human-readable reason
+    otherwise. Shared by the ``setup trusted-paths`` CLI (and any other
+    caller) so the security rules can never drift from the discovery gate.
+
+    Rules:
+      * a *non-absolute* input is rejected — the resolved location would
+        otherwise depend on the caller's working directory;
+      * a *world-writable* directory is rejected — anyone on the host could
+        drop a malicious binary into it, the exact threat the allow-list
+        defends against;
+      * a path that exists but is not a directory is rejected;
+      * a path that does not yet exist is allowed (the caller may warn) — it
+        is not itself unsafe to trust.
+    """
+    raw = (path or "").strip()
+    if not raw:
+        return "", "path is empty"
+    expanded = _expand(raw)
+    if not os.path.isabs(expanded):
+        return os.path.abspath(expanded), "path is not absolute"
+    resolved = os.path.abspath(expanded)
+    try:
+        st = os.stat(resolved)
+    except FileNotFoundError:
+        return resolved, None
+    except OSError as exc:  # pragma: no cover - rare stat failure
+        return resolved, f"cannot stat path ({exc})"
+    if not os.path.isdir(resolved):
+        return resolved, "path is not a directory"
+    if st.st_mode & 0o002:
+        return resolved, "directory is world-writable"
+    return resolved, None
 
 
 def _is_trusted_binary_path(binary_path: str) -> bool:
@@ -377,7 +425,7 @@ def _version_for_binary(binary_path: str, version_args: tuple[str, ...]) -> tupl
     # exec their binary as part of a passive discovery scan. Refuse
     # anything outside the canonical install prefixes.
     if not _is_trusted_binary_path(binary_path):
-        return "", "binary path is not in a trusted install prefix"
+        return "", UNTRUSTED_PREFIX_ERROR
     binary_name = os.path.basename(binary_path).lower()
     env = None
     timeout = VERSION_TIMEOUT_SECONDS

--- a/cli/defenseclaw/inventory/agent_discovery.py
+++ b/cli/defenseclaw/inventory/agent_discovery.py
@@ -72,6 +72,7 @@ _TRUSTED_BIN_PREFIXES_DEFAULT: tuple[str, ...] = (
     "/opt/homebrew/bin",
     "/opt/homebrew/sbin",
     "/opt/homebrew/Cellar",
+    "/opt/homebrew/Caskroom",
     "/opt/homebrew/lib/node_modules",
     "/usr/local/Cellar",
     "/usr/local/lib/node_modules",

--- a/cli/defenseclaw/tui/app.py
+++ b/cli/defenseclaw/tui/app.py
@@ -99,6 +99,11 @@ from defenseclaw.tui.screens.setup_resource_editor import (
     webhook_rows_from_config,
 )
 from defenseclaw.tui.screens.theme_picker import ThemePickerScreen
+from defenseclaw.tui.screens.trusted_paths_editor import (
+    TrustedPathsEditorScreen,
+    trusted_paths_rows_from_config,
+    untrusted_connector_dir,
+)
 from defenseclaw.tui.screens.uninstall import UninstallScreen
 from defenseclaw.tui.services import connector_filter as connector_filter_svc
 from defenseclaw.tui.services.catalog_state import (
@@ -6790,6 +6795,10 @@ class DefenseClawTUI(App[None]):
                 return SetupPanelAction(True, hint="Opening Audit Sinks editor.", open_resource_editor="audit_sinks")
             if section is not None and section.name == "Webhooks":
                 return SetupPanelAction(True, hint="Opening Webhooks editor.", open_resource_editor="webhooks")
+            if section is not None and section.name == "Trusted Paths":
+                return SetupPanelAction(
+                    True, hint="Opening Trusted Paths editor.", open_resource_editor="trusted_paths"
+                )
             return SetupPanelAction(True, hint="No list editor is available for this setup section.")
         if key in {"up", "k"}:
             self.setup_model.active_line = max(0, self.setup_model.active_line - 1)
@@ -6896,6 +6905,11 @@ class DefenseClawTUI(App[None]):
         elif resource_kind == "webhooks":
             rows = webhook_rows_from_config(self.config)
             screen = SetupResourceEditorScreen("webhooks", rows)
+        elif resource_kind == "trusted_paths":
+            screen = TrustedPathsEditorScreen(
+                trusted_paths_rows_from_config(self.config),
+                data_dir=getattr(self.config, "data_dir", None),
+            )
         else:
             self._set_status(f"Unknown setup editor: {resource_kind}")
             return
@@ -6931,6 +6945,32 @@ class DefenseClawTUI(App[None]):
             needs_preview=True,
         )
         self.run_worker(self._confirm_and_run_parsed(parsed), exclusive=False, thread=False)
+
+    async def _route_untrusted_binary_to_panel(self, connector: str) -> bool:
+        """Open the Trusted Paths editor when a connector binary is untrusted.
+
+        Returns ``True`` when setup may proceed (binary already trusted, or the
+        connector/discovery is unknown), or ``False`` when we routed the
+        operator into the editor instead. This is the TUI equivalent of the
+        CLI's "trust this directory?" prompt — it surfaces the same decision in
+        the panel rather than firing ``click.confirm`` under a full-screen TUI.
+        """
+        parent = untrusted_connector_dir(connector, getattr(self.config, "data_dir", None))
+        if not parent:
+            return True
+        rows = trusted_paths_rows_from_config(self.config)
+        context = (
+            f"{friendly_connector_name(connector)} binary is outside a trusted "
+            f"prefix ({parent}). Trust it below, then re-run setup."
+        )
+        result = await self.push_screen_wait(
+            TrustedPathsEditorScreen(rows, prefill=parent, context=context)
+        )
+        if result is None:
+            self._set_status(f"{connector} setup paused — '{parent}' was not trusted.")
+            return False
+        self._handle_setup_resource_result(result)
+        return False
 
     async def _cancel_running_command(self) -> None:
         # Snapshot the running command before cancellation so we can
@@ -7241,6 +7281,11 @@ class DefenseClawTUI(App[None]):
         args, display = connector_setup_command_for_mode(choice)
         if not args:
             self._set_status(f"No setup command available for connector {choice}.")
+            return
+        # When the connector binary is outside a trusted prefix, route the
+        # operator into the Trusted Paths editor instead of running a setup the
+        # trust gate would refuse (the TUI replacement for the CLI prompt).
+        if not await self._route_untrusted_binary_to_panel(choice):
             return
         intent = OverviewCommandIntent(
             label=display,

--- a/cli/defenseclaw/tui/panels/setup.py
+++ b/cli/defenseclaw/tui/panels/setup.py
@@ -1411,6 +1411,12 @@ def build_setup_sections(cfg: object | Mapping[str, Any] | None) -> tuple[Config
             "Cisco AI Defense", tuple(_cisco_ai_defense_fields(cfg)), "Cloud-hosted prompt/response moderation."
         ),
         ConfigSection("Firewall", tuple(_firewall_fields(cfg)), "Host firewall anchor paths. Read-only in the TUI."),
+        ConfigSection(
+            "Trusted Paths",
+            tuple(_trusted_paths_summary_fields(cfg)),
+            "Binary locations trusted for connector discovery. Read-only here; "
+            "manage via 'defenseclaw setup trusted-paths'.",
+        ),
     ]
     return tuple(sections)
 
@@ -4885,6 +4891,71 @@ def _webhook_summary_fields(cfg: object | Mapping[str, Any] | None) -> tuple[Con
         summary = f"\\[{'enabled' if enabled else 'disabled'}] {url}"
         out.append(ConfigField(name, f"webhooks.{index}", "header", summary, summary))
     out.append(hint)
+    return tuple(out)
+
+
+def _trusted_paths_summary_fields(cfg: object | Mapping[str, Any] | None) -> tuple[ConfigField, ...]:
+    """Read-only summary of the binary-discovery trusted-prefix allow-list.
+
+    Mutations go through the CLI (``defenseclaw setup trusted-paths ...``) so
+    the TUI, the inline setup prompt, and the discovery gate all share a single
+    persistence path and can't drift. We reuse ``_collect_trusted_prefixes`` —
+    the exact view the CLI renders — so the panel can never disagree with it.
+    """
+    from defenseclaw.commands.cmd_setup import _collect_trusted_prefixes  # noqa: PLC0415
+
+    data_dir = ""
+    for attr in ("data_dir", "config_dir", "home"):
+        val = getattr(cfg, attr, "")
+        if isinstance(val, str) and val:
+            data_dir = val
+            break
+    if not data_dir:
+        data_dir = os.environ.get("DEFENSECLAW_HOME") or os.path.expanduser("~/.defenseclaw")
+
+    try:
+        rows = _collect_trusted_prefixes(data_dir)
+    except Exception:
+        rows = []
+
+    defaults = [r for r in rows if r.get("source") == "default"]
+    operator = [r for r in rows if r.get("source") != "default"]
+    present = sum(1 for r in defaults if r.get("status") == "ok")
+
+    # NOTE: the *proactive* "which connectors are in an untrusted dir" highlight
+    # lives in the interactive editor (TrustedPathsEditorScreen), opened from
+    # this section. We deliberately do NOT run connector discovery here — this
+    # builder feeds the static Setup panel that re-renders on every refresh, so
+    # a subprocess discovery pass would be both slow and host-dependent.
+    out: list[ConfigField] = [
+        _header(
+            "Built-in defaults",
+            "trusted_paths.defaults",
+            f"{len(defaults)} default prefixes, {present} present on this host",
+        )
+    ]
+    if operator:
+        for index, row in enumerate(operator):
+            # Escape the opening bracket so Rich renders ``[src/status]`` as
+            # literal text rather than parsing it as a style tag (which would
+            # crash the panel — see the webhook summary note above).
+            summary = f"\\[{row.get('source')}/{row.get('status')}] {row.get('resolved')}"
+            out.append(_header(f"Operator path {index + 1}", f"trusted_paths.op.{index}", summary))
+    else:
+        out.append(
+            _header(
+                "Operator-added",
+                "trusted_paths.operator",
+                "none — all trust comes from built-in defaults",
+            )
+        )
+    out.append(
+        _header(
+            "How to edit",
+            "trusted_paths.hint",
+            "defenseclaw setup trusted-paths add|remove <dir>",
+        )
+    )
     return tuple(out)
 
 

--- a/cli/defenseclaw/tui/screens/trusted_paths_editor.py
+++ b/cli/defenseclaw/tui/screens/trusted_paths_editor.py
@@ -1,0 +1,395 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native Setup editor for trusted binary-discovery prefixes.
+
+Mutations dismiss with a ``SetupResourceResult`` carrying ``defenseclaw setup
+trusted-paths add|remove`` argv, which the app runs through the same
+command-preview + execute path as the Webhooks/Audit-Sinks editors. That keeps
+a single persistence path (the CLI) shared by the TUI, the inline setup prompt,
+and the discovery gate — they can't drift, and the preview screen surfaces the
+exact command (and therefore the security implication) before it runs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from textual import events, on
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, DataTable, Input, Static
+
+from defenseclaw.tui.screens.setup_resource_editor import SetupResourceResult
+from defenseclaw.tui.theme import DEFAULT_TOKENS
+
+TOKENS = DEFAULT_TOKENS
+
+
+@dataclass(frozen=True)
+class TrustedPathRow:
+    """One trusted-prefix row for the editor table."""
+
+    resolved: str
+    source: str
+    status: str
+    removable: bool
+
+
+class TrustedPathsEditorScreen(ModalScreen[SetupResourceResult | None]):
+    """Rounded native editor for the trusted binary-prefix allow-list."""
+
+    CSS = f"""
+    TrustedPathsEditorScreen {{
+        align: center middle;
+    }}
+
+    #trusted-editor-dialog {{
+        width: 116;
+        height: 32;
+        padding: 1 2;
+        border: round {TOKENS.border_active};
+        background: {TOKENS.surface_panel};
+        color: {TOKENS.text_primary};
+    }}
+
+    #trusted-editor-title {{
+        height: 1;
+        margin-bottom: 1;
+        color: {TOKENS.accent_cyan};
+        text-style: bold;
+    }}
+
+    #trusted-editor-table {{
+        height: 16;
+        margin-bottom: 1;
+    }}
+
+    #trusted-editor-add {{
+        height: 3;
+        margin-bottom: 1;
+    }}
+
+    #trusted-editor-status {{
+        height: 2;
+        color: {TOKENS.text_secondary};
+    }}
+
+    #trusted-editor-buttons {{
+        height: 3;
+        align-horizontal: right;
+    }}
+
+    #trusted-editor-buttons Button {{
+        margin-left: 1;
+    }}
+    """
+
+    BINDINGS = [
+        # Letter keys are reserved for the directory Input, so removal/close
+        # use non-text keys that can't collide with typing a path.
+        Binding("escape", "cancel", "Close", show=False),
+        Binding("delete", "remove", "Remove", show=False),
+    ]
+
+    def __init__(
+        self,
+        rows: tuple[TrustedPathRow, ...],
+        *,
+        prefill: str = "",
+        context: str = "",
+        data_dir: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.rows = tuple(rows)
+        self.cursor = 0
+        # When the editor is opened by routing an untrusted-binary setup into
+        # it, ``prefill`` seeds the add field with the offending directory and
+        # ``context`` explains why the operator landed here.
+        # NOTE: store as ``_context_text`` — ``_context`` is reserved by
+        # Textual's ``MessagePump`` (a callable used as ``with self._context():``
+        # in the message loop). Shadowing it with a str crashes the screen's
+        # message pump on startup and hangs the whole app.
+        self._prefill = prefill
+        self._context_text = context
+        # Used to scan connectors for the proactive untrusted-binary summary
+        # shown when the editor is browsed directly (no routing context).
+        self._data_dir = data_dir
+        # Last message pushed to the status line (mirrored for tests/debug).
+        self._status_message = ""
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="trusted-editor-dialog"):
+            yield Static("Trusted Binary Locations", id="trusted-editor-title")
+            yield DataTable(id="trusted-editor-table", cursor_type="row", zebra_stripes=True)
+            yield Input(
+                placeholder="Directory to trust (e.g. ~/.local/bin) — Enter to add",
+                id="trusted-editor-add",
+            )
+            yield Static(self._status_text(), id="trusted-editor-status")
+            with Horizontal(id="trusted-editor-buttons"):
+                yield Button("Add", id="trusted-add", variant="primary")
+                yield Button("Remove", id="trusted-remove", variant="error")
+                yield Button("Close", id="trusted-close", variant="default")
+
+    def on_mount(self) -> None:
+        table = self.query_one("#trusted-editor-table", DataTable)
+        table.add_columns("Source", "Status", "Owned", "Path")
+        for row in self.rows:
+            table.add_row(row.source, row.status, "yes" if row.removable else "—", row.resolved)
+        if self.rows:
+            table.move_cursor(row=0, column=0, animate=False)
+        add_input = self.query_one("#trusted-editor-add", Input)
+        if self._prefill:
+            add_input.value = self._prefill
+        if self._context_text:
+            # Routed here for one specific connector — that message wins.
+            self._set_status(self._context_text)
+        else:
+            # Browsed directly: proactively highlight any connector whose
+            # binary currently resolves into an untrusted directory.
+            summary = self._untrusted_summary()
+            if summary:
+                self._set_status(summary)
+        # Focus the input so the operator can immediately add (or edit) a path.
+        add_input.focus()
+
+    def _untrusted_summary(self) -> str:
+        """One-line summary of connectors whose binary is in an untrusted dir."""
+        try:
+            pairs = untrusted_connector_dirs(self._data_dir)
+        except Exception:
+            return ""
+        if not pairs:
+            return ""
+        names = ", ".join(f"{name} ({directory})" for name, directory in pairs[:3])
+        if len(pairs) > 3:
+            names += f", +{len(pairs) - 3} more"
+        noun = "connector" if len(pairs) == 1 else "connectors"
+        return f"⚠ {len(pairs)} {noun} in untrusted dirs: {names} — add the dir to trust it."
+
+    # ----- actions -------------------------------------------------------
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def action_add(self) -> None:
+        path = self.query_one("#trusted-editor-add", Input).value.strip()
+        if not path:
+            self._set_status("Enter a directory to trust, then press Add.")
+            return
+        args = ("setup", "trusted-paths", "add", path)
+        self.dismiss(
+            SetupResourceResult("add", args=args, display_name=" ".join(args), category="setup")
+        )
+
+    def action_remove(self) -> None:
+        row = self._selected_row()
+        if row is None:
+            self._set_status("Select a row to remove.")
+            return
+        if not row.removable:
+            self._set_status(
+                f"{row.source!r} entries can't be removed here — only operator-added "
+                "(.env) prefixes are removable; built-in defaults are protected."
+            )
+            return
+        args = ("setup", "trusted-paths", "remove", row.resolved)
+        self.dismiss(
+            SetupResourceResult("remove", args=args, display_name=" ".join(args), category="setup")
+        )
+
+    # ----- events --------------------------------------------------------
+
+    @on(Input.Submitted, "#trusted-editor-add")
+    def _on_add_submitted(self, event: Input.Submitted) -> None:
+        event.stop()
+        self.action_add()
+
+    @on(DataTable.RowHighlighted, "#trusted-editor-table")
+    def _on_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        self.cursor = event.cursor_row
+
+    @on(DataTable.RowSelected, "#trusted-editor-table")
+    def _on_row_selected(self, event: DataTable.RowSelected) -> None:
+        self.cursor = event.cursor_row
+
+    @on(Button.Pressed)
+    def _on_button_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        match event.button.id:
+            case "trusted-add":
+                self.action_add()
+            case "trusted-remove":
+                self.action_remove()
+            case "trusted-close":
+                self.action_cancel()
+
+    def on_click(self, event: events.Click) -> None:
+        if event.widget is self:
+            event.stop()
+            self.dismiss(None)
+
+    # ----- helpers -------------------------------------------------------
+
+    def _selected_row(self) -> TrustedPathRow | None:
+        if not self.rows:
+            return None
+        return self.rows[max(0, min(self.cursor, len(self.rows) - 1))]
+
+    def _set_status(self, message: str) -> None:
+        # Mirror the message onto an attribute so it can be asserted without
+        # reaching into Textual's widget-internal render state (which varies
+        # across versions). Also handy for debugging.
+        self._status_message = message
+        self.query_one("#trusted-editor-status", Static).update(message)
+
+    def _status_text(self) -> str:
+        return (
+            "type a dir + Enter to add · Add/Remove buttons · Del removes selected · Esc close — "
+            "only directories you control should be trusted"
+        )
+
+
+def _resolve_data_dir(config: object | Mapping[str, Any] | None) -> str:
+    import os  # noqa: PLC0415
+
+    for attr in ("data_dir", "config_dir", "home"):
+        val = getattr(config, attr, "")
+        if isinstance(val, str) and val:
+            return val
+    if isinstance(config, Mapping):
+        val = config.get("data_dir", "")
+        if isinstance(val, str) and val:
+            return val
+    return os.environ.get("DEFENSECLAW_HOME") or os.path.expanduser("~/.defenseclaw")
+
+
+def trusted_paths_rows_from_config(config: object | Mapping[str, Any] | None) -> tuple[TrustedPathRow, ...]:
+    """Build editor rows from the live trusted-prefix view (defaults + .env + env).
+
+    Reuses ``cmd_setup._collect_trusted_prefixes`` so the editor shows exactly
+    what ``defenseclaw setup trusted-paths list`` shows.
+    """
+    from defenseclaw.commands.cmd_setup import _collect_trusted_prefixes  # noqa: PLC0415
+
+    data_dir = _resolve_data_dir(config)
+    try:
+        raw = _collect_trusted_prefixes(data_dir)
+    except Exception:
+        raw = []
+    return tuple(
+        TrustedPathRow(
+            resolved=str(item.get("resolved", "")),
+            source=str(item.get("source", "")),
+            status=str(item.get("status", "")),
+            removable=bool(item.get("removable", False)),
+        )
+        for item in raw
+    )
+
+
+def _refresh_trusted_prefix_env(data_dir: str | None) -> None:
+    """Merge persisted-``.env`` trusted prefixes into the live environment.
+
+    The TUI reads ``DEFENSECLAW_TRUSTED_BIN_PREFIXES`` into ``os.environ`` once
+    at launch (``config.load()``). A prefix trusted *after* launch — via the CLI
+    or the editor's own Add button, which runs ``trusted-paths add`` in a
+    subprocess — never reaches the running process's environment, so a
+    same-session discovery scan would still treat it as untrusted. Re-read the
+    persisted value and union it into the live one (never dropping anything
+    already exported) so the scan reflects current trust without a TUI restart.
+    """
+    import os  # noqa: PLC0415
+
+    from defenseclaw.commands.cmd_setup import _load_dotenv  # noqa: PLC0415
+    from defenseclaw.config import default_data_path  # noqa: PLC0415
+
+    resolved_dir = data_dir or str(default_data_path())
+    try:
+        persisted = _load_dotenv(os.path.join(resolved_dir, ".env")).get(
+            "DEFENSECLAW_TRUSTED_BIN_PREFIXES", ""
+        )
+    except Exception:
+        return
+    if not persisted:
+        return
+    current = os.environ.get("DEFENSECLAW_TRUSTED_BIN_PREFIXES", "")
+    merged: list[str] = []
+    for piece in (*current.split(os.pathsep), *persisted.split(os.pathsep)):
+        piece = piece.strip()
+        if piece and piece not in merged:
+            merged.append(piece)
+    os.environ["DEFENSECLAW_TRUSTED_BIN_PREFIXES"] = os.pathsep.join(merged)
+
+
+def untrusted_connector_dir(connector: str, data_dir: str | None = None) -> str | None:
+    """Return the directory a connector binary lives in when it is *untrusted*.
+
+    Returns ``None`` when the connector is absent, its binary is trusted, or
+    discovery fails. Used by the TUI to route an untrusted-binary setup into
+    the Trusted Paths editor instead of running a setup that the trust gate
+    would refuse (where the CLI would otherwise fire ``click.confirm``).
+
+    Runs a *fresh* scan (and re-hydrates persisted trust) so the routing
+    reflects current state — a stale "trusted" cache must not let an
+    untrusted-binary setup slip past the panel.
+    """
+    import os  # noqa: PLC0415
+
+    from defenseclaw.inventory import agent_discovery  # noqa: PLC0415
+
+    _refresh_trusted_prefix_env(data_dir)
+    try:
+        disc = agent_discovery.discover_agents(use_cache=False, refresh=True, data_dir=data_dir)
+    except Exception:
+        return None
+    signal = disc.agents.get(connector)
+    if signal is None or not signal.binary_path:
+        return None
+    if signal.error != agent_discovery.UNTRUSTED_PREFIX_ERROR:
+        return None
+    return os.path.dirname(os.path.realpath(signal.binary_path))
+
+
+def untrusted_connector_dirs(data_dir: str | None = None) -> list[tuple[str, str]]:
+    """All connectors whose binary currently resolves into an untrusted dir.
+
+    Returns ``(connector, parent_dir)`` pairs (deduped, sorted by connector)
+    for the *proactive* panel highlight — so an operator browsing the Trusted
+    Paths panel can see which connectors are untrusted without first triggering
+    setup on each one. One discovery pass scans every connector at once. Returns
+    an empty list when discovery fails. Mirrors the ``agent discover`` hint in
+    ``cmd_agent`` so the TUI and CLI surface the same set.
+
+    Runs a *fresh* scan (and re-hydrates persisted trust) so the highlight drops
+    a directory the moment it is trusted, rather than lagging behind the cache.
+    """
+    import os  # noqa: PLC0415
+
+    from defenseclaw.inventory import agent_discovery  # noqa: PLC0415
+
+    _refresh_trusted_prefix_env(data_dir)
+    try:
+        disc = agent_discovery.discover_agents(use_cache=False, refresh=True, data_dir=data_dir)
+    except Exception:
+        return []
+    out: dict[str, str] = {}
+    for name, signal in disc.agents.items():
+        if signal is None or not signal.binary_path:
+            continue
+        if signal.error != agent_discovery.UNTRUSTED_PREFIX_ERROR:
+            continue
+        out.setdefault(name, os.path.dirname(os.path.realpath(signal.binary_path)))
+    return sorted(out.items())

--- a/cli/tests/test_cmd_setup_trusted_paths.py
+++ b/cli/tests/test_cmd_setup_trusted_paths.py
@@ -1,0 +1,363 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the PR #348 trusted-prefix work and its review follow-ups.
+
+Covers:
+  * ``_add_trusted_bin_prefix`` append/dedupe/0600/os.environ behaviour;
+  * the action-mode gate's "trust this directory" prompt re-running the FULL
+    compatibility check (review finding #1 — the prompt must not short-circuit
+    on version truthiness and admit an unsupported version);
+  * ``/opt/homebrew/Caskroom`` being a built-in default;
+  * the ``defenseclaw setup trusted-paths`` CLI (list / add / remove, JSON,
+    world-writable refusal, default protection).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from defenseclaw.commands import cmd_agent, cmd_setup
+from defenseclaw.config import (
+    CiscoAIDefenseConfig,
+    Config,
+    GatewayConfig,
+    GuardrailConfig,
+    OpenShellConfig,
+)
+from defenseclaw.connector_contracts import (
+    STATUS_KNOWN,
+    STATUS_UNKNOWN,
+    STATUS_UNVERSIONED,
+    ConnectorCompatibility,
+    ConnectorContract,
+)
+from defenseclaw.context import AppContext
+from defenseclaw.inventory import agent_discovery as ad
+
+
+def _make_app_context(data_dir: str) -> AppContext:
+    cfg = Config(
+        data_dir=data_dir,
+        audit_db=os.path.join(data_dir, "audit.db"),
+        quarantine_dir=os.path.join(data_dir, "quarantine"),
+        plugin_dir=os.path.join(data_dir, "plugins"),
+        policy_dir=os.path.join(data_dir, "policies"),
+        guardrail=GuardrailConfig(),
+        gateway=GatewayConfig(),
+        openshell=OpenShellConfig(),
+        cisco_ai_defense=CiscoAIDefenseConfig(),
+    )
+    ctx = AppContext()
+    ctx.cfg = cfg
+    return ctx
+
+
+def _signal(version: str, error: str, binary_path: str) -> ad.AgentSignal:
+    return ad.AgentSignal(
+        name="codex",
+        installed=True,
+        config_path="",
+        binary_path=binary_path,
+        version=version,
+        error=error,
+    )
+
+
+def _disc(signal: ad.AgentSignal) -> ad.AgentDiscovery:
+    return ad.AgentDiscovery(scanned_at="t", agents={"codex": signal}, cache_hit=False)
+
+
+def _compat(version: str, status: str, contract_id: str | None = None, reason: str = "") -> ConnectorCompatibility:
+    contract = ConnectorContract(connector="codex", contract_id=contract_id) if contract_id else None
+    return ConnectorCompatibility(
+        connector="codex",
+        raw_version=version,
+        normalized_version=version,
+        status=status,
+        reason=reason,
+        contract=contract,
+    )
+
+
+class AddTrustedBinPrefixTests(unittest.TestCase):
+    def test_append_dedupe_persist_0600_and_environ(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": ""}, clear=False):
+                added1 = cmd_setup._add_trusted_bin_prefix("/opt/tools", tmp)
+                added2 = cmd_setup._add_trusted_bin_prefix("/opt/tools", tmp)  # dedupe
+                added3 = cmd_setup._add_trusted_bin_prefix("/opt/more", tmp)
+                self.assertTrue(added1)
+                self.assertFalse(added2, "second add of same prefix should be a no-op")
+                self.assertTrue(added3)
+                # os.environ reflects both, separated by os.pathsep.
+                val = os.environ["DEFENSECLAW_TRUSTED_BIN_PREFIXES"]
+                parts = val.split(os.pathsep)
+                self.assertEqual(parts.count("/opt/tools"), 1)
+                self.assertIn("/opt/more", parts)
+            dotenv = os.path.join(tmp, ".env")
+            self.assertTrue(os.path.isfile(dotenv))
+            self.assertEqual(os.stat(dotenv).st_mode & 0o777, 0o600)
+            body = open(dotenv, encoding="utf-8").read()
+            self.assertIn("/opt/tools", body)
+            self.assertIn("/opt/more", body)
+
+
+class CaskroomDefaultTests(unittest.TestCase):
+    def test_caskroom_is_a_builtin_default(self):
+        self.assertIn("/opt/homebrew/Caskroom", ad._TRUSTED_BIN_PREFIXES_DEFAULT)
+
+
+class GatePromptContractGateTests(unittest.TestCase):
+    """Review #1: trusting the prefix must re-run the contract gate, not
+    short-circuit on a non-empty version string."""
+
+    def _run(self, second_signal, confirm, contract_side_effect):
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(tmp, ignore_errors=True))
+        binpath = os.path.join(tmp, "codex")
+        first = _disc(_signal("", ad.UNTRUSTED_PREFIX_ERROR, binpath))
+        discos = [first, _disc(second_signal)] if second_signal is not None else [first]
+        with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": ""}, clear=False), patch.object(
+            cmd_setup.agent_discovery, "discover_agents", side_effect=discos
+        ) as mock_disc, patch.object(
+            cmd_setup, "resolve_connector_contract", side_effect=contract_side_effect
+        ), patch.object(
+            sys.stdin, "isatty", return_value=True
+        ), patch.object(
+            sys.stdout, "isatty", return_value=True
+        ), patch.object(
+            cmd_setup.click, "confirm", return_value=confirm
+        ):
+            result = cmd_setup._check_connector_version_supported_for_setup(
+                "codex", mode="action", data_dir=tmp
+            )
+        return result, mock_disc, tmp, binpath
+
+    def test_trusted_but_unsupported_version_is_still_refused(self):
+        # After trusting, re-discovery yields a real version that maps to
+        # STATUS_UNKNOWN (unsupported). The OLD code returned True here; the
+        # fix re-runs the gate and returns False.
+        def contract(_c, v):
+            return _compat(v, STATUS_UNVERSIONED, "codex-hooks-v1") if v == "" else _compat(v, STATUS_UNKNOWN, reason="too new")
+
+        result, mock_disc, tmp, binpath = self._run(
+            _signal("99.0", "", os.path.join(tempfile.gettempdir(), "codex")),
+            confirm=True,
+            contract_side_effect=contract,
+        )
+        self.assertFalse(result, "unsupported version must be refused even after trusting the path")
+        self.assertEqual(mock_disc.call_count, 2, "should re-discover after trusting (full gate re-run)")
+        # The path WAS trusted (persisted) — proving we refused on the
+        # contract, not because trusting failed.
+        body = open(os.path.join(tmp, ".env"), encoding="utf-8").read()
+        self.assertIn(os.path.dirname(os.path.realpath(binpath)), body)
+
+    def test_trusted_and_supported_version_is_accepted(self):
+        def contract(_c, v):
+            return _compat(v, STATUS_UNVERSIONED, "codex-hooks-v1") if v == "" else _compat(v, STATUS_KNOWN, "codex-hooks-v1")
+
+        result, mock_disc, _tmp, _bin = self._run(
+            _signal("1.0", "", os.path.join(tempfile.gettempdir(), "codex")),
+            confirm=True,
+            contract_side_effect=contract,
+        )
+        self.assertTrue(result, "a supported version should pass after trusting")
+        self.assertEqual(mock_disc.call_count, 2)
+
+    def test_declined_prompt_refuses_and_does_not_trust(self):
+        def contract(_c, v):
+            return _compat(v, STATUS_UNVERSIONED, "codex-hooks-v1")
+
+        result, mock_disc, tmp, _bin = self._run(
+            None, confirm=False, contract_side_effect=contract
+        )
+        self.assertFalse(result)
+        self.assertEqual(mock_disc.call_count, 1, "declining must not trigger a re-discovery")
+        dotenv = os.path.join(tmp, ".env")
+        if os.path.isfile(dotenv):
+            self.assertNotIn("DEFENSECLAW_TRUSTED_BIN_PREFIXES", open(dotenv, encoding="utf-8").read())
+
+
+class TrustedPathsCliTests(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_list_json_includes_defaults_and_caskroom(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app = _make_app_context(tmp)
+            with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": ""}, clear=False):
+                result = self.runner.invoke(cmd_setup.trusted_paths, ["list", "--json"], obj=app)
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            rows = json.loads(result.output)
+            resolved = {r["resolved"] for r in rows}
+            self.assertIn("/opt/homebrew/Caskroom", resolved)
+            self.assertTrue(all({"path", "resolved", "source", "status", "removable"} <= set(r) for r in rows))
+
+    def test_add_persists_and_shows_removable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app = _make_app_context(tmp)
+            newdir = os.path.join(tmp, "tools")
+            os.makedirs(newdir)
+            with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": ""}, clear=False):
+                add = self.runner.invoke(cmd_setup.trusted_paths, ["add", newdir, "--json"], obj=app)
+                self.assertEqual(add.exit_code, 0, msg=add.output)
+                self.assertTrue(json.loads(add.output)["ok"])
+                listing = self.runner.invoke(cmd_setup.trusted_paths, ["list", "--json"], obj=app)
+                rows = {r["resolved"]: r for r in json.loads(listing.output)}
+            self.assertIn(newdir, open(os.path.join(tmp, ".env"), encoding="utf-8").read())
+            self.assertTrue(rows[newdir]["removable"])
+            self.assertEqual(rows[newdir]["source"], ".env")
+
+    def test_add_world_writable_refused_without_force(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app = _make_app_context(tmp)
+            wdir = os.path.join(tmp, "wtools")
+            os.makedirs(wdir)
+            os.chmod(wdir, 0o777)
+            with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": ""}, clear=False):
+                result = self.runner.invoke(cmd_setup.trusted_paths, ["add", wdir, "--json"], obj=app)
+            self.assertNotEqual(result.exit_code, 0)
+            payload = json.loads(result.output)
+            self.assertFalse(payload["ok"])
+            self.assertIn("world-writable", payload["message"])
+
+    def test_add_world_writable_allowed_with_force(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app = _make_app_context(tmp)
+            wdir = os.path.join(tmp, "wtools")
+            os.makedirs(wdir)
+            os.chmod(wdir, 0o777)
+            with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": ""}, clear=False):
+                result = self.runner.invoke(cmd_setup.trusted_paths, ["add", wdir, "--force", "--json"], obj=app)
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            self.assertTrue(json.loads(result.output)["ok"])
+
+    def test_add_builtin_default_is_noop(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app = _make_app_context(tmp)
+            with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": ""}, clear=False):
+                result = self.runner.invoke(cmd_setup.trusted_paths, ["add", "/usr/bin", "--json"], obj=app)
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            self.assertIn("default", json.loads(result.output)["message"])
+
+    def test_remove_operator_added(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app = _make_app_context(tmp)
+            newdir = os.path.join(tmp, "tools")
+            os.makedirs(newdir)
+            with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": ""}, clear=False):
+                self.runner.invoke(cmd_setup.trusted_paths, ["add", newdir], obj=app)
+                result = self.runner.invoke(cmd_setup.trusted_paths, ["remove", newdir, "--json"], obj=app)
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            self.assertTrue(json.loads(result.output)["ok"])
+            self.assertNotIn(newdir, open(os.path.join(tmp, ".env"), encoding="utf-8").read())
+
+    def test_remove_builtin_default_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app = _make_app_context(tmp)
+            with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": ""}, clear=False):
+                result = self.runner.invoke(cmd_setup.trusted_paths, ["remove", "/usr/bin", "--json"], obj=app)
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertIn("default", json.loads(result.output)["message"])
+
+    def test_remove_absent_errors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app = _make_app_context(tmp)
+            with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": ""}, clear=False):
+                result = self.runner.invoke(
+                    cmd_setup.trusted_paths, ["remove", os.path.join(tmp, "nope"), "--json"], obj=app
+                )
+            self.assertNotEqual(result.exit_code, 0)
+
+
+class AgentDiscoverHintTests(unittest.TestCase):
+    """`agent discover` should point at the generic trusted-paths remediation
+    when a connector binary is skipped for living outside a trusted prefix."""
+
+    def test_hint_points_at_trusted_paths_for_untrusted_binary(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app = _make_app_context(tmp)
+            binpath = os.path.join(tmp, "codex")
+            disc = _disc(_signal("", ad.UNTRUSTED_PREFIX_ERROR, binpath))
+            with patch.dict(os.environ, {"DEFENSECLAW_HOME": tmp}, clear=False):
+                with patch.object(cmd_agent.agent_discovery, "discover_agents", return_value=disc):
+                    result = CliRunner().invoke(cmd_agent.discover, ["--no-emit-otel"], obj=app)
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            self.assertIn("trusted-paths add", result.output)
+            self.assertIn(os.path.dirname(os.path.realpath(binpath)), result.output)
+
+    def test_no_hint_when_all_binaries_trusted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app = _make_app_context(tmp)
+            disc = _disc(_signal("1.0", "", "/usr/bin/codex"))
+            with patch.dict(os.environ, {"DEFENSECLAW_HOME": tmp}, clear=False):
+                with patch.object(cmd_agent.agent_discovery, "discover_agents", return_value=disc):
+                    result = CliRunner().invoke(cmd_agent.discover, ["--no-emit-otel"], obj=app)
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            self.assertNotIn("trusted-paths add", result.output)
+
+    def test_discover_hydrates_persisted_trusted_prefix_from_env(self):
+        """Fix (b): `agent` skips the root config load, so discover must itself
+        hydrate ~/.defenseclaw/.env — otherwise a prefix added via
+        `trusted-paths add` is ignored by `agent discover`."""
+        with tempfile.TemporaryDirectory() as tmp:
+            app = _make_app_context(tmp)
+            with open(os.path.join(tmp, ".env"), "w", encoding="utf-8") as fh:
+                fh.write("DEFENSECLAW_TRUSTED_BIN_PREFIXES=/opt/demo-trust\n")
+            disc = _disc(_signal("1.0", "", "/usr/bin/codex"))
+            env = {"DEFENSECLAW_HOME": tmp}
+            with patch.dict(os.environ, env, clear=False):
+                os.environ.pop("DEFENSECLAW_TRUSTED_BIN_PREFIXES", None)
+                with patch.object(cmd_agent.agent_discovery, "discover_agents", return_value=disc):
+                    result = CliRunner().invoke(cmd_agent.discover, ["--no-emit-otel"], obj=app)
+                hydrated = os.environ.get("DEFENSECLAW_TRUSTED_BIN_PREFIXES", "")
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            self.assertIn("/opt/demo-trust", hydrated.split(os.pathsep))
+
+
+class TrustedPathsTuiSectionTests(unittest.TestCase):
+    """The TUI setup panel exposes a read-only 'Trusted Paths' section that
+    reuses the CLI's _collect_trusted_prefixes view (so they can't drift)."""
+
+    def test_section_lists_operator_path_and_cli_hint(self):
+        from defenseclaw.tui.panels import setup as panel
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": "/opt/acme/bin"}, clear=False):
+                fields = panel._trusted_paths_summary_fields(SimpleNamespace(data_dir=tmp))
+            labels = [f.label for f in fields]
+            values = " ".join(f.value for f in fields)
+            self.assertIn("Built-in defaults", labels)
+            self.assertIn("default prefixes", values)
+            self.assertIn("/opt/acme/bin", values)
+            self.assertTrue(any("trusted-paths add" in f.value for f in fields))
+
+    def test_section_registered_in_build_setup_sections(self):
+        from defenseclaw.tui.panels import setup as panel
+
+        with tempfile.TemporaryDirectory() as tmp:
+            app = _make_app_context(tmp)
+            names = [s.name for s in panel.build_setup_sections(app.cfg)]
+            self.assertIn("Trusted Paths", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/tests/tui/test_app_shell.py
+++ b/cli/tests/tui/test_app_shell.py
@@ -449,7 +449,10 @@ async def test_activity_panel_uses_activity_model() -> None:
 
 
 @pytest.mark.asyncio
-async def test_overview_mode_key_opens_native_picker_and_preview() -> None:
+async def test_overview_mode_key_opens_native_picker_and_preview(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The untrusted-binary routing scans the live host; force "trusted" so the
+    # picker path under test stays hermetic regardless of local installs.
+    monkeypatch.setattr("defenseclaw.tui.app.untrusted_connector_dir", lambda *_a, **_k: None)
     app = DefenseClawTUI()
 
     async with app.run_test(size=(150, 44)) as pilot:
@@ -467,7 +470,8 @@ async def test_overview_mode_key_opens_native_picker_and_preview() -> None:
 
 
 @pytest.mark.asyncio
-async def test_overview_mode_picker_mouse_click_opens_preview() -> None:
+async def test_overview_mode_picker_mouse_click_opens_preview(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("defenseclaw.tui.app.untrusted_connector_dir", lambda *_a, **_k: None)
     app = DefenseClawTUI()
 
     async with app.run_test(size=(150, 44)) as pilot:
@@ -479,6 +483,29 @@ async def test_overview_mode_picker_mouse_click_opens_preview() -> None:
         screen = app.screen_stack[-1]
         assert screen.__class__.__name__ == "CommandPreviewScreen"
         assert "defenseclaw setup codex --yes" in screen.preview.masked_display
+
+
+@pytest.mark.asyncio
+async def test_overview_mode_picker_routes_untrusted_binary_to_trusted_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Inverse of the hermetic stubs above: when the connector binary IS in an
+    # untrusted directory, setup must route into the Trusted Paths editor
+    # instead of dispatching a setup the trust gate would refuse.
+    monkeypatch.setattr(
+        "defenseclaw.tui.app.untrusted_connector_dir", lambda *_a, **_k: "/opt/untrusted/bin"
+    )
+    app = DefenseClawTUI()
+
+    async with app.run_test(size=(150, 44)) as pilot:
+        await pilot.press("m")
+        await pilot.pause()
+        await pilot.press("c")
+        await pilot.pause()
+
+        screen = app.screen_stack[-1]
+        assert screen.__class__.__name__ == "TrustedPathsEditorScreen"
+        assert "/opt/untrusted/bin" in screen._context_text
 
 
 @pytest.mark.asyncio

--- a/cli/tests/tui/test_setup_panel.py
+++ b/cli/tests/tui/test_setup_panel.py
@@ -115,6 +115,7 @@ def test_setup_config_sections_match_go_catalog_order() -> None:
         "Inspect LLM (legacy - read-only)",
         "Cisco AI Defense",
         "Firewall",
+        "Trusted Paths",
     )
 
 

--- a/cli/tests/tui/test_trusted_paths_editor.py
+++ b/cli/tests/tui/test_trusted_paths_editor.py
@@ -1,0 +1,328 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the native Trusted Paths setup editor modal."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from defenseclaw.inventory import agent_discovery as ad
+from defenseclaw.tui.screens.setup_resource_editor import SetupResourceResult
+from defenseclaw.tui.screens.trusted_paths_editor import (
+    TrustedPathRow,
+    TrustedPathsEditorScreen,
+    _refresh_trusted_prefix_env,
+    trusted_paths_rows_from_config,
+    untrusted_connector_dir,
+    untrusted_connector_dirs,
+)
+from textual.app import App, ComposeResult
+from textual.widgets import Input, Static
+
+_DEFAULT_ROW = TrustedPathRow("/usr/bin", "default", "ok", False)
+_OPERATOR_ROW = TrustedPathRow("/opt/acme/bin", ".env", "missing", True)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_trusted_env(tmp_path, monkeypatch):
+    """Point DEFENSECLAW_HOME at an empty dir so the new ``_refresh`` helper
+    reads no persisted ``.env`` and never mutates the real process env across
+    tests. Individual tests that need a populated ``.env`` write into tmp_path."""
+    monkeypatch.setenv("DEFENSECLAW_HOME", str(tmp_path))
+    monkeypatch.delenv("DEFENSECLAW_TRUSTED_BIN_PREFIXES", raising=False)
+    return tmp_path
+
+
+class _Harness(App):
+    def __init__(self, rows: tuple[TrustedPathRow, ...], *, prefill: str = "", context: str = "") -> None:
+        super().__init__()
+        self._rows = rows
+        self._prefill = prefill
+        # NOTE: not ``_context`` — that name is reserved by Textual's
+        # MessagePump (called as ``with self._context():`` in the message
+        # loop); shadowing it with a str crashes the app's pump and hangs.
+        self._context_text = context
+        self.result: SetupResourceResult | None = None
+
+    def compose(self) -> ComposeResult:
+        yield Static("trusted-paths harness")
+
+    def on_mount(self) -> None:
+        self.push_screen(
+            TrustedPathsEditorScreen(self._rows, prefill=self._prefill, context=self._context_text),
+            self._set_result,
+        )
+
+    def _set_result(self, result: SetupResourceResult | None) -> None:
+        self.result = result
+
+
+def _disc(signal: ad.AgentSignal) -> ad.AgentDiscovery:
+    return ad.AgentDiscovery(scanned_at="t", agents={"codex": signal}, cache_hit=False)
+
+
+def _sig(binary_path: str, error: str, version: str = "") -> ad.AgentSignal:
+    return ad.AgentSignal(
+        name="codex",
+        installed=True,
+        config_path="",
+        binary_path=binary_path,
+        version=version,
+        error=error,
+    )
+
+
+def test_untrusted_connector_dir_detects_untrusted_binary() -> None:
+    disc = _disc(_sig("/home/u/.local/bin/codex", ad.UNTRUSTED_PREFIX_ERROR))
+    with patch.object(ad, "discover_agents", return_value=disc):
+        result = untrusted_connector_dir("codex")
+    assert result == os.path.dirname(os.path.realpath("/home/u/.local/bin/codex"))
+
+
+def test_untrusted_connector_dir_none_when_trusted() -> None:
+    disc = _disc(_sig("/usr/bin/codex", "", version="1.0"))
+    with patch.object(ad, "discover_agents", return_value=disc):
+        assert untrusted_connector_dir("codex") is None
+
+
+def test_untrusted_connector_dir_none_when_connector_absent() -> None:
+    disc = ad.AgentDiscovery(scanned_at="t", agents={}, cache_hit=False)
+    with patch.object(ad, "discover_agents", return_value=disc):
+        assert untrusted_connector_dir("codex") is None
+
+
+def test_rows_from_config_reflect_collect_view() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        with open(os.path.join(tmp, ".env"), "w", encoding="utf-8") as fh:
+            fh.write("DEFENSECLAW_TRUSTED_BIN_PREFIXES=/opt/acme/bin\n")
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("DEFENSECLAW_TRUSTED_BIN_PREFIXES", None)
+            rows = trusted_paths_rows_from_config(SimpleNamespace(data_dir=tmp))
+    resolved = {r.resolved: r for r in rows}
+    assert "/usr/bin" in resolved  # a built-in default
+    assert not resolved["/usr/bin"].removable
+    assert "/opt/acme/bin" in resolved  # operator-added via .env
+    assert resolved["/opt/acme/bin"].source == ".env"
+    assert resolved["/opt/acme/bin"].removable
+
+
+@pytest.mark.asyncio
+async def test_add_via_input_returns_cli_args() -> None:
+    app = _Harness((_DEFAULT_ROW,))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.screen.query_one("#trusted-editor-add", Input).value = "/opt/tools"
+        app.screen.action_add()
+        await pilot.pause()
+    assert isinstance(app.result, SetupResourceResult)
+    assert app.result.action == "add"
+    assert app.result.args == ("setup", "trusted-paths", "add", "/opt/tools")
+
+
+@pytest.mark.asyncio
+async def test_remove_removable_row_returns_cli_args() -> None:
+    app = _Harness((_OPERATOR_ROW,))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.screen.cursor = 0
+        app.screen.action_remove()
+        await pilot.pause()
+    assert isinstance(app.result, SetupResourceResult)
+    assert app.result.action == "remove"
+    assert app.result.args == ("setup", "trusted-paths", "remove", "/opt/acme/bin")
+
+
+@pytest.mark.asyncio
+async def test_remove_default_row_is_refused() -> None:
+    app = _Harness((_DEFAULT_ROW,))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.screen.cursor = 0
+        app.screen.action_remove()
+        await pilot.pause()
+        # No dismissal happened: a built-in default cannot be removed, so the
+        # editor is still the active modal.
+        assert isinstance(app.screen, TrustedPathsEditorScreen)
+    assert app.result is None
+
+
+@pytest.mark.asyncio
+async def test_empty_add_is_refused() -> None:
+    app = _Harness((_DEFAULT_ROW,))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.screen.action_add()  # input is empty
+        await pilot.pause()
+    assert app.result is None
+
+
+@pytest.mark.asyncio
+async def test_escape_dismisses_without_action() -> None:
+    app = _Harness((_OPERATOR_ROW,))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+    assert app.result is None
+
+
+@pytest.mark.asyncio
+async def test_prefill_seeds_the_add_field() -> None:
+    app = _Harness((_OPERATOR_ROW,), prefill="/opt/acme/bin", context="trust this dir")
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        value = app.screen.query_one("#trusted-editor-add", Input).value
+    assert value == "/opt/acme/bin"
+
+
+@pytest.mark.asyncio
+async def test_prefill_path_can_be_added_directly() -> None:
+    app = _Harness((_OPERATOR_ROW,), prefill="/opt/acme/bin")
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.screen.action_add()  # uses the pre-filled value, no typing needed
+        await pilot.pause()
+    assert isinstance(app.result, SetupResourceResult)
+    assert app.result.args == ("setup", "trusted-paths", "add", "/opt/acme/bin")
+
+
+# ---- proactive untrusted-connector highlight ------------------------------
+
+
+def _multi_disc(agents: dict[str, ad.AgentSignal]) -> ad.AgentDiscovery:
+    return ad.AgentDiscovery(scanned_at="t", agents=agents, cache_hit=False)
+
+
+def _agent(name: str, binary_path: str, error: str, version: str = "") -> ad.AgentSignal:
+    return ad.AgentSignal(
+        name=name,
+        installed=True,
+        config_path="",
+        binary_path=binary_path,
+        version=version,
+        error=error,
+    )
+
+
+def test_untrusted_connector_dirs_lists_every_untrusted_connector() -> None:
+    disc = _multi_disc(
+        {
+            "codex": _agent("codex", "/home/u/.local/bin/codex", ad.UNTRUSTED_PREFIX_ERROR),
+            "claudecode": _agent("claudecode", "/opt/foo/claude", ad.UNTRUSTED_PREFIX_ERROR),
+            "cursor": _agent("cursor", "/usr/bin/cursor", "", version="1.0"),  # trusted
+        }
+    )
+    with patch.object(ad, "discover_agents", return_value=disc):
+        pairs = untrusted_connector_dirs()
+    names = [name for name, _ in pairs]
+    assert names == ["claudecode", "codex"]  # sorted, trusted cursor excluded
+    assert dict(pairs)["codex"] == os.path.dirname(os.path.realpath("/home/u/.local/bin/codex"))
+
+
+def test_untrusted_connector_dirs_empty_when_all_trusted() -> None:
+    disc = _multi_disc({"cursor": _agent("cursor", "/usr/bin/cursor", "", version="1.0")})
+    with patch.object(ad, "discover_agents", return_value=disc):
+        assert untrusted_connector_dirs() == []
+
+
+@pytest.mark.asyncio
+async def test_editor_shows_untrusted_summary_when_browsed() -> None:
+    """Opened directly (no routing context) the editor surfaces a one-line
+    summary of connectors whose binary resolves into an untrusted dir."""
+    disc = _multi_disc(
+        {"codex": _agent("codex", "/home/u/.local/bin/codex", ad.UNTRUSTED_PREFIX_ERROR)}
+    )
+    app = _Harness((_DEFAULT_ROW,))  # no prefill, no context
+    with patch.object(ad, "discover_agents", return_value=disc):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            text = app.screen._status_message
+    assert "codex" in text
+    assert "untrusted" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_editor_routing_context_wins_over_summary() -> None:
+    """When routed for a specific connector, that context message is shown
+    instead of the generic untrusted-connectors summary."""
+    disc = _multi_disc(
+        {"codex": _agent("codex", "/home/u/.local/bin/codex", ad.UNTRUSTED_PREFIX_ERROR)}
+    )
+    app = _Harness((_DEFAULT_ROW,), context="Claude Code binary is outside a trusted prefix.")
+    with patch.object(ad, "discover_agents", return_value=disc):
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            text = app.screen._status_message
+    assert text == "Claude Code binary is outside a trusted prefix."
+
+
+# ---- fix (a): fresh scan reflects current trust without a restart ----------
+
+
+def test_refresh_merges_persisted_env(tmp_path, monkeypatch):
+    """A prefix persisted to .env after launch is unioned into the live env,
+    without dropping anything already exported."""
+    (tmp_path / ".env").write_text(
+        "DEFENSECLAW_TRUSTED_BIN_PREFIXES=/opt/foo\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("DEFENSECLAW_TRUSTED_BIN_PREFIXES", "/opt/bar")
+    _refresh_trusted_prefix_env(str(tmp_path))
+    parts = os.environ["DEFENSECLAW_TRUSTED_BIN_PREFIXES"].split(os.pathsep)
+    assert "/opt/bar" in parts  # exported value preserved
+    assert "/opt/foo" in parts  # persisted value merged in
+
+
+def test_refresh_noop_without_persisted_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEFENSECLAW_TRUSTED_BIN_PREFIXES", "/opt/bar")
+    _refresh_trusted_prefix_env(str(tmp_path))  # tmp_path has no .env
+    assert os.environ["DEFENSECLAW_TRUSTED_BIN_PREFIXES"] == "/opt/bar"
+
+
+def test_untrusted_dirs_forces_fresh_discovery() -> None:
+    """The highlight must re-scan (no stale cache) so it drops a dir the moment
+    it is trusted."""
+    captured = {}
+
+    def _fake(**kwargs):
+        captured.update(kwargs)
+        return _multi_disc({})
+
+    with patch.object(ad, "discover_agents", side_effect=_fake):
+        untrusted_connector_dirs()
+    assert captured.get("use_cache") is False
+    assert captured.get("refresh") is True
+
+
+def test_untrusted_dir_reflects_newly_trusted_prefix(tmp_path, monkeypatch) -> None:
+    """End-to-end for fix (a): once a dir is persisted to .env, a connector
+    whose binary lives there is no longer reported untrusted."""
+    bindir = tmp_path / "tools"
+    bindir.mkdir()
+    binpath = str(bindir / "codex")
+
+    def _disc_respecting_env(**kwargs):
+        prefixes = os.environ.get("DEFENSECLAW_TRUSTED_BIN_PREFIXES", "")
+        trusted = str(bindir) in prefixes.split(os.pathsep)
+        err = "" if trusted else ad.UNTRUSTED_PREFIX_ERROR
+        return _multi_disc({"codex": _agent("codex", binpath, err, version="1.0" if trusted else "")})
+
+    with patch.object(ad, "discover_agents", side_effect=_disc_respecting_env):
+        # Before trusting: codex is flagged.
+        assert untrusted_connector_dir("codex", str(tmp_path)) == str(bindir)
+        # Persist the trust to .env, then re-scan: codex drops off.
+        (tmp_path / ".env").write_text(
+            f"DEFENSECLAW_TRUSTED_BIN_PREFIXES={bindir}\n", encoding="utf-8"
+        )
+        assert untrusted_connector_dir("codex", str(tmp_path)) is None

--- a/docs-site/content/docs/ai-discovery.mdx
+++ b/docs-site/content/docs/ai-discovery.mdx
@@ -306,7 +306,7 @@ Discovery touches the most sensitive parts of the host filesystem. DefenseClaw i
     **No raw values.** Env var *names* are recorded, never values. File paths are hashed (`config_path_hash`, `binary_path_hash`) — only basenames are kept.
   </Step>
   <Step>
-    **Trusted-prefix binary probing.** Version probes (`<binary> --version`) only run inside an allow-listed set of prefixes (`/usr/bin`, `/opt/homebrew`, …) plus anything in `DEFENSECLAW_TRUSTED_BIN_PREFIXES`. Untrusted binaries are recorded as present but not executed.
+    **Trusted-prefix binary probing.** Version probes (`<binary> --version`) only run inside an allow-listed set of prefixes (`/usr/bin`, `/opt/homebrew`, …) plus anything in `DEFENSECLAW_TRUSTED_BIN_PREFIXES`. Untrusted binaries are recorded as present but not executed — `defenseclaw agent discover` prints the offending directory and the command to trust it. Manage the allow-list with `defenseclaw setup trusted-paths list|add|remove` (or the TUI's Trusted Paths panel): `add` validates the directory (refusing world-writable or relative paths unless `--force`) and persists it to `~/.defenseclaw/.env`; built-in defaults can never be removed.
   </Step>
   <Step>
     **HMAC-stamped events.** Continuous-discovery events are signed with a per-installation HMAC (`PayloadHMAC` on the gateway envelope). Tampering downstream of the gateway is detectable.

--- a/docs-site/content/docs/connectors/compatibility.mdx
+++ b/docs-site/content/docs/connectors/compatibility.mdx
@@ -35,6 +35,8 @@ The floors come from upstream release notes or current vendor docs: Codex `0.124
 
 Every `defenseclaw setup ...` path that chooses a connector refreshes local agent discovery, reads the installed connector version, and checks it against the manifest before writing config. Unsupported or unverified hook connector versions are allowed in observe mode with a warning, but action mode fails closed unless `DEFENSECLAW_ALLOW_HOOK_CONTRACT_DRIFT=1` is set for exploratory testing.
 
+The most common reason a version can't be read is the connector binary living outside a trusted install prefix (for example a bespoke install under `~/.local`). Interactive action-mode setup detects this and offers to trust the directory (defaulting to No, persisting to `~/.defenseclaw/.env`, then re-running the full contract check — trusting a path never bypasses the version gate). Non-interactive runs print the equivalent remediation: `defenseclaw setup trusted-paths add <dir>`. See the `trusted-paths` group on the [CLI reference](/docs/reference/cli) and the trust model in [AI Discovery](/docs/ai-discovery).
+
 Proxy connectors are recorded in the manifest too, but they are marked `not-gated` because their enforcement surface is the DefenseClaw proxy instead of an agent hook contract.
 
 ## Runtime lock

--- a/docs-site/content/docs/reference/cli.mdx
+++ b/docs-site/content/docs/reference/cli.mdx
@@ -53,6 +53,7 @@ Tables below tag each row with the binary that owns it.
 | `defenseclaw setup splunk` | Configure the Splunk audit sink. |
 | `defenseclaw setup webhook` | Configure Slack / PagerDuty / Webex / generic notifier webhooks (chat + incident routing). |
 | `defenseclaw setup observability add\|list\|enable\|disable\|remove\|test` | Manage audit-log fan-out destinations (OTLP logs, Splunk HEC, generic HTTP JSONL). Distinct from `setup webhook`, which manages notifier webhooks. |
+| `defenseclaw setup trusted-paths list\|add\|remove` | Manage the directories trusted for connector-binary version probing (action-mode setups refuse binaries outside this allow-list). `list` shows built-in defaults plus operator additions with source and status; `add` validates the directory (world-writable / relative paths refused unless `--force`) and persists to `~/.defenseclaw/.env`; `remove` only touches operator-added entries. All verbs accept `--json`. |
 
 ## Guardrail
 

--- a/docs-site/content/docs/reference/env-vars.mdx
+++ b/docs-site/content/docs/reference/env-vars.mdx
@@ -130,7 +130,7 @@ This is the canonical list of every environment variable DefenseClaw reads. The 
 | Env var | Impact | Default | Accepted values | Purpose | Security concern | Consumers |
 | --- | --- | --- | --- | --- | --- | --- |
 | `DEFENSECLAW_ANTHROPIC_PROBE_MODEL` | — | claude-3-5-haiku-latest | `any-anthropic-model-id` | Override the model used by 'defenseclaw doctor' to probe Anthropic API key validity. | — | `cli/defenseclaw/commands/cmd_doctor.py:659` — Doctor's Anthropic probe |
-| `DEFENSECLAW_TRUSTED_BIN_PREFIXES` | **medium** | `unset` (only /usr/bin and /usr/local/bin trusted) | `colon-separated absolute paths`, `unset` | Colon-separated list of extra trusted binary prefixes for AI Discovery's binary probing. | Tight binary-discovery trust list — prevents PATH-shadow elevation where a malicious binary in a user-writable dir gets probed and treated as a real agent runtime. | `cli/defenseclaw/inventory/agent_discovery.py:241` — Agent discovery binary probe |
+| `DEFENSECLAW_TRUSTED_BIN_PREFIXES` | **medium** | `unset` (built-in defaults only) | `os.pathsep-separated absolute paths (':' POSIX, ';' Windows)`, `unset` | Extra trusted binary prefixes for AI Discovery's binary probing, separated by os.pathsep (':' on POSIX, ';' on Windows). | Tight binary-discovery trust list — prevents PATH-shadow elevation where a malicious binary in a user-writable dir gets probed and treated as a real agent runtime. 'trusted-paths add' refuses world-writable and non-absolute directories unless --force. | `cli/defenseclaw/inventory/agent_discovery.py:289` — Agent discovery binary probe<br/>`cli/defenseclaw/commands/cmd_setup.py:1587` — setup trusted-paths CLI and inline trust prompt persistence |
 
 ## Hook-internal (do not override)
 

--- a/docs/ENV-VARS.md
+++ b/docs/ENV-VARS.md
@@ -129,7 +129,7 @@ Active overrides are also surfaced live by `defenseclaw doctor`
 | Env var | Impact | Default | Accepted values | Purpose | Security concern | Consumers |
 | --- | --- | --- | --- | --- | --- | --- |
 | `DEFENSECLAW_ANTHROPIC_PROBE_MODEL` | — | claude-3-5-haiku-latest | `any-anthropic-model-id` | Override the model used by 'defenseclaw doctor' to probe Anthropic API key validity. | — | `cli/defenseclaw/commands/cmd_doctor.py:659` — Doctor's Anthropic probe |
-| `DEFENSECLAW_TRUSTED_BIN_PREFIXES` | **medium** | `unset` (only /usr/bin and /usr/local/bin trusted) | `colon-separated absolute paths`, `unset` | Colon-separated list of extra trusted binary prefixes for AI Discovery's binary probing. | Tight binary-discovery trust list — prevents PATH-shadow elevation where a malicious binary in a user-writable dir gets probed and treated as a real agent runtime. | `cli/defenseclaw/inventory/agent_discovery.py:241` — Agent discovery binary probe |
+| `DEFENSECLAW_TRUSTED_BIN_PREFIXES` | **medium** | `unset` (built-in defaults only) | `os.pathsep-separated absolute paths (':' POSIX, ';' Windows)`, `unset` | Extra trusted binary prefixes for AI Discovery's binary probing, separated by os.pathsep (':' on POSIX, ';' on Windows). | Tight binary-discovery trust list — prevents PATH-shadow elevation where a malicious binary in a user-writable dir gets probed and treated as a real agent runtime. 'trusted-paths add' refuses world-writable and non-absolute directories unless --force. | `cli/defenseclaw/inventory/agent_discovery.py:289` — Agent discovery binary probe<br>`cli/defenseclaw/commands/cmd_setup.py:1587` — setup trusted-paths CLI and inline trust prompt persistence |
 
 ## Hook-internal (do not override)
 

--- a/internal/envvars/registry.json
+++ b/internal/envvars/registry.json
@@ -1071,14 +1071,14 @@
     {
       "name": "DEFENSECLAW_TRUSTED_BIN_PREFIXES",
       "category": "discovery",
-      "purpose": "Colon-separated list of extra trusted binary prefixes for AI Discovery's binary probing. The default trust list is intentionally narrow (system bin dirs only); operators with non-standard layouts (e.g. /opt/mycorp/bin) can re-enable specific paths.",
-      "default": "unset (only /usr/bin and /usr/local/bin trusted)",
-      "accepted_values": ["colon-separated absolute paths", "unset"],
+      "purpose": "Extra trusted binary prefixes for AI Discovery's binary probing, separated by os.pathsep (':' on POSIX, ';' on Windows). The default trust list covers system bin dirs, Homebrew (incl. Caskroom), MacPorts, and global node_modules trees; operators with non-standard layouts (e.g. /opt/mycorp/bin) can trust additional roots. Prefer managing via 'defenseclaw setup trusted-paths add|remove|list', which validates the directory and persists this variable to ~/.defenseclaw/.env; interactive action-mode setup offers the same remediation inline.",
+      "default": "unset (built-in defaults only)",
+      "accepted_values": ["os.pathsep-separated absolute paths (':' POSIX, ';' Windows)", "unset"],
       "security_impact": "medium",
       "surface_in_doctor": true,
-      "consumers": [{"location": "cli/defenseclaw/inventory/agent_discovery.py:241", "description": "Agent discovery binary probe"}],
+      "consumers": [{"location": "cli/defenseclaw/inventory/agent_discovery.py:289", "description": "Agent discovery binary probe"}, {"location": "cli/defenseclaw/commands/cmd_setup.py:1587", "description": "setup trusted-paths CLI and inline trust prompt persistence"}],
       "since": "0.5.0",
-      "security_note": "Tight binary-discovery trust list — prevents PATH-shadow elevation where a malicious binary in a user-writable dir gets probed and treated as a real agent runtime."
+      "security_note": "Tight binary-discovery trust list — prevents PATH-shadow elevation where a malicious binary in a user-writable dir gets probed and treated as a real agent runtime. 'trusted-paths add' refuses world-writable and non-absolute directories unless --force."
     },
     {
       "name": "DEFENSECLAW_ANTHROPIC_PROBE_MODEL",


### PR DESCRIPTION
## Summary

- When a connector binary resolves outside trusted prefixes (e.g. Homebrew Caskroom), interactive action-mode setup now **prompts the operator** to trust the directory instead of failing with a cryptic error — and after trusting, **re-runs the full version → hook-contract gate**, so an unsupported version is still refused
- Adds `/opt/homebrew/Caskroom` to the default trusted prefix list (same ownership/trust model as the already-trusted `/opt/homebrew/Cellar`)
- Adds first-class trusted-locations management: a `defenseclaw setup trusted-paths` CLI group and a native TUI panel/editor (review follow-up)

## Problem

Claude Code installed via `brew install --cask claude-code` resolves to `/opt/homebrew/Caskroom/claude-code/<version>/claude`. This path isn't in the default trusted prefix list, so `defenseclaw setup claude-code --mode action` fails with:

```
✗ Claude Code: version not available (binary path is not in a trusted install prefix)
  Refusing action-mode hook setup...
  Set DEFENSECLAW_ALLOW_HOOK_CONTRACT_DRIFT=1 only for exploratory testing.
```

The error gives no actionable remediation. (The Go gateway independently applies the same gate at boot and **skips** unverified action connectors — it does not crash; an earlier revision of this description overstated that.)

## Fix

**Interactive CLI:** prompts (default **No**, with a one-line warning of what trusting means) to add the resolved directory to `DEFENSECLAW_TRUSTED_BIN_PREFIXES`, persists to `~/.defenseclaw/.env` (0600), then re-enters the gate non-interactively so the contract check still applies and no re-prompt loop is possible.

**Non-interactive (CI):** prints the resolved path and points at `defenseclaw setup trusted-paths add <dir>`.

**TUI:** never prompts. A read-only "Trusted Paths" setup section plus a `TrustedPathsEditorScreen` list prefixes, highlight connectors resolving into untrusted directories, and dispatch add/remove through the standard command-preview pipeline. Untrusted-binary connector setups are routed into the editor instead of reaching `click.confirm`.

**CLI group:** `defenseclaw setup trusted-paths list|add|remove` with `--json` and `--force`; `add` refuses world-writable or non-absolute directories unless forced; `remove` never touches built-in defaults. The CLI, the inline prompt, and the discovery gate share the same helpers and a single `agent_discovery.validate_trusted_prefix` guard so they cannot drift.

**`agent discover`:** prints the same trusted-paths remediation hint for skipped untrusted binaries.

**Hardening from review:** shared `UNTRUSTED_PREFIX_ERROR` constant instead of a duplicated string literal; prefix lists join/split on `os.pathsep` so Windows drive-qualified paths survive; the prompt warns that version-pinned paths need re-trusting after upgrades.

## Test plan

- [x] `cli/tests/test_cmd_setup_trusted_paths.py` — gate re-run after trusting (incl. version-present-but-unsupported refusal), decline path, `_add_trusted_bin_prefix` append/dedupe/0600/environ, Caskroom default, trusted-paths CLI (list/add/remove, `--json`, world-writable refusal, default protection), `agent discover` hint
- [x] `cli/tests/tui/test_trusted_paths_editor.py` + `test_app_shell.py` — TUI editor add/remove/default-protection and untrusted-binary routing
- [x] Full TUI suite: 657 passed; `test_agent_discovery.py`: pass
- [x] Manual: `defenseclaw setup codex --mode action` on an untrusted install shows the default-No prompt, persists trust on `y`, re-runs the gate, and proceeds on a supported version; TUI panel/editor and routing verified interactively
- [ ] CI green
