### PR TITLE
ci(connector-e2e): gate Layer A on PRs — always-on macOS cell + path-gated full matrix

### DIFF
--- a/.github/workflows/connector-live-e2e.yml
+++ b/.github/workflows/connector-live-e2e.yml
@@ -8,7 +8,10 @@
 #     Builds DefenseClaw, then feeds golden stdin payloads into the *installed*
 #     hook entrypoint for every registry connector and asserts the gateway
 #     received the event, the verdict was shaped correctly, and teardown is
-#     clean. Fork-safe; a candidate to promote to a required PR check later.
+#     clean. Fork-safe; runs on pull requests as well — one always-on macOS
+#     cell (codex / macOS, intended as a required check) plus the full
+#     Linux + macOS + Windows matrix when connector code changes (see the
+#     `changes` gate job).
 #
 #   live-matrix (Layer B) — installs the real upstream agent at its latest
 #     version, wires it with `defenseclaw setup`, and drives lifecycle + forced
@@ -42,6 +45,13 @@ on:
   # nightly suites do not contend for the same hosted-runner pool.
   schedule:
     - cron: "0 9 * * *"
+  # Layer A also gates pull requests. Every PR runs one always-on
+  # cross-platform smoke cell (codex / macOS) so there is a required
+  # connector signal on each change; when the PR touches connector, hook,
+  # registry, contract-script, or this workflow, the run expands to the full
+  # Linux + macOS + Windows x 9-connector matrix (see the `changes` job).
+  # Layer B (live) stays manual-only and never runs for pull requests.
+  pull_request:
   workflow_dispatch:
     inputs:
       connector:
@@ -99,24 +109,76 @@ permissions:
 
 jobs:
   # ---------------------------------------------------------------------------
+  # Gate — decide which contract cells to run for this event.
+  #
+  #   schedule / workflow_dispatch → full 3-OS x 9-connector matrix.
+  #   pull_request                 → just the always-on macOS smoke cell,
+  #                                  unless the PR touches connector / hook /
+  #                                  registry / contract-script / workflow
+  #                                  surfaces, in which case → full matrix.
+  # ---------------------------------------------------------------------------
+  changes:
+    name: Select contract cells
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.decide.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Need history back to the PR base so the path diff below is accurate.
+          fetch-depth: 0
+      - id: decide
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # Full 3-OS x 9-connector matrix for nightly + manual runs and for
+          # pull requests that touch connector-relevant code.
+          full='{"os":["ubuntu-latest","macos-latest","windows-latest"],"connector":["codex","claudecode","geminicli","cursor","copilot","openhands","hermes","windsurf","antigravity"]}'
+          # Always-on PR smoke: one connector on one cross-platform OS. macOS is
+          # chosen because ci.yml already guards the Windows hook path on every
+          # PR but has no macOS coverage at all — this adds the missing native
+          # macOS connector signal and is the cell to mark "required" in branch
+          # protection. Its check name is "Contract codex / macos-latest".
+          minimal='{"os":["macos-latest"],"connector":["codex"]}'
+
+          if [ "${EVENT}" != "pull_request" ]; then
+            echo "matrix=${full}" >> "$GITHUB_OUTPUT"
+            echo "event=${EVENT} -> full matrix"
+            exit 0
+          fi
+
+          changed="$(git diff --name-only "${BASE_SHA}"...HEAD)"
+          echo "Changed files in PR:"
+          printf '%s\n' "${changed}"
+
+          # connector / hook / registry / contract-script / workflow surfaces.
+          if printf '%s\n' "${changed}" | grep -qE \
+            -e '^internal/gateway/connector/' \
+            -e '^internal/cli/' \
+            -e '^cli/defenseclaw/inventory/' \
+            -e '^cli/defenseclaw/commands/cmd_setup\.py$' \
+            -e '^cli/defenseclaw/commands/cmd_init\.py$' \
+            -e '^test/e2e/' \
+            -e '^scripts/live-connector-e2e/' \
+            -e '^\.github/workflows/connector-live-e2e\.yml$'; then
+            echo "matrix=${full}" >> "$GITHUB_OUTPUT"
+            echo "connector-relevant change -> full Linux + macOS + Windows matrix"
+          else
+            echo "matrix=${minimal}" >> "$GITHUB_OUTPUT"
+            echo "no connector-relevant change -> macOS codex smoke only"
+          fi
+
+  # ---------------------------------------------------------------------------
   # Layer A — deterministic contract matrix (no secrets, every OS).
   # ---------------------------------------------------------------------------
   contract-matrix:
     name: Contract ${{ matrix.connector }} / ${{ matrix.os }}
+    needs: changes
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        connector:
-          - codex
-          - claudecode
-          - geminicli
-          - cursor
-          - copilot
-          - openhands
-          - hermes
-          - windsurf
-          - antigravity
+      matrix: ${{ fromJSON(needs.changes.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     # Native Windows hook execution is not yet proven on hosted runners;
     # keep Windows cells advisory until they go consistently green.


### PR DESCRIPTION
## Problem

The connector contract matrix (Layer A in `connector-live-e2e.yml`) is the
deterministic, no-secret, all-OS check that proves every registry connector's
hook entrypoint fires and shapes a verdict correctly. It only ran on a nightly
`schedule` and manual `workflow_dispatch` — **never on pull requests**. So a
change that broke a connector hook on Linux/macOS/Windows merged green and was
only caught the next morning (or not at all, since the nightly opens an issue
rather than blocking). There was also **no macOS coverage of any kind on PRs**:
`ci.yml` guards the Windows hook path and Linux connector matrix on every PR,
but nothing exercised a connector on macOS pre-merge.

## Current Situation

- `connector-live-e2e.yml` triggers: `schedule` (09:00 UTC) + `workflow_dispatch`
  only. The `contract-matrix` job hard-codes a 3-OS × 9-connector matrix.
- `ci.yml` (runs on every PR) covers Linux (`connector-matrix` → `make
  connector-matrix-test`) and Windows (`Windows Hook Path`, `Windows Installer
  Smoke`), but **no macOS** job exists anywhere on the PR path.
- Net effect: connector/hook regressions are not gated pre-merge, and macOS
  native-hook behavior is unverified until the nightly run.

## Solution

Add a `pull_request` trigger with a **tiered scope** decided by a new lightweight
`changes` gate job, instead of either (a) leaving Layer A nightly-only or (b)
running the full 27-cell matrix on every push (which would burn the macOS/Windows
runner budget — macOS bills at 10×, Windows at 2× — for coverage that largely
overlaps `ci.yml`).

- **Every PR** runs exactly one always-on cross-platform cell: `codex /
  macos-latest`. macOS is chosen specifically because it is the platform with
  zero PR coverage today, so this adds the missing native-macOS connector signal.
  This is the cell intended to be a **required** status check.
- **When a PR touches connector surfaces** (connector / hook / registry /
  contract-script / this workflow), the run expands to the full Linux + macOS +
  Windows × 9-connector matrix.
- **Nightly + manual** keep running the full matrix, unchanged.

Trade-off: the always-on cell is macOS, not Windows, because Windows is already
guarded on every PR by `ci.yml` and hosted Windows cells here are advisory
(`continue-on-error`) due to historical flakiness — a flaky required check is
worse than none. Windows still runs in the expanded (path-gated) matrix.

Note: marking the check "required" is a branch-protection setting, not something
the workflow can do. The check name to require is `Contract codex / macos-latest`
(see Open Issues).

## Architecture Diagram

```
Before:
  ┌────────────┐  schedule(09:00) / dispatch  ┌───────────────────────────┐
  │  triggers  │─────────────────────────────▶│ contract-matrix 3 OS × 9  │
  └────────────┘                              └───────────────────────────┘
        (pull_request: not wired — no PR gate, no macOS PR coverage)

After:
  ┌────────────┐   schedule / dispatch        ┌───────────────────────────┐
  │  triggers  │─────────────────────────────▶│        full matrix        │
  │  + PR      │                              │     3 OS × 9 connectors   │
  └─────┬──────┘                              └────────────▲──────────────┘
        │ pull_request                                     │ fromJSON(matrix)
        ▼                                                  │
  ┌────────────┐  relevant paths changed? ────────────────┘
  │  changes   │  yes → full 3 OS × 9 matrix
  │  (gate)    │  no  → minimal {codex × macos-latest}  (always-on / required)
  └────────────┘
```

## Flow Diagram

```
PR event        changes job              contract-matrix
   │  open/sync     │                          │
   │───────────────▶│ checkout (full history)  │
   │                │ git diff base...HEAD      │
   │                │ match connector paths?    │
   │                │   no  → matrix=minimal ──▶│ codex / macos-latest (gate)
   │                │   yes → matrix=full ─────▶│ 27 cells (ubuntu/macos/win × 9)
   │                │                          │ Windows cells = continue-on-error
   │◀──────────────────────────────────────────│ required check: codex/macos
```

## What Changed (Where & How)

| File | Change Type | Summary |
|---|---|---|
| `.github/workflows/connector-live-e2e.yml` | config | Add `pull_request` trigger; add a `changes` gate job that emits the matrix JSON (full 3-OS×9 for schedule/dispatch/relevant-PRs, `{codex × macos-latest}` otherwise); make `contract-matrix` consume `fromJSON(needs.changes.outputs.matrix)`. Windows cells remain advisory; nightly/dispatch and Layer B unchanged. |

Path globs that expand a PR to the full matrix: `internal/gateway/connector/`,
`internal/cli/`, `cli/defenseclaw/inventory/`, `cli/defenseclaw/commands/cmd_setup.py`,
`cli/defenseclaw/commands/cmd_init.py`, `test/e2e/`, `scripts/live-connector-e2e/`,
and `.github/workflows/connector-live-e2e.yml`.

## Open Issues / Follow-ups

- The always-on cell `Contract codex / macos-latest` must be added to the
  branch-protection **required status checks** for `main` to actually block
  merges — the workflow cannot set that. Do **not** mark the other matrix cells
  required: on a non-relevant PR they don't run, so requiring them would wedge
  PRs in "Expected — Waiting for status". TODO(@vineeth): add the one check name
  to the ruleset (or ask me to do it via `gh api`).
- macOS hosted runners are billed at 10×; the always-on cell is a single
  ~3–5 min job per PR, deemed an acceptable cost for the missing macOS signal.
  If cost matters, the minimal cell could later be moved to Linux.
- Layer B (live, secret-gated) is intentionally untouched and still never runs
  for pull requests.

## Test Plan

- `ruby -ryaml` parse of `connector-live-e2e.yml` → valid; `on` = `[schedule,
  pull_request, workflow_dispatch]`; jobs = `[changes, contract-matrix,
  live-matrix, report]`; `contract-matrix.needs=changes`,
  `strategy.matrix = ${{ fromJSON(needs.changes.outputs.matrix) }}`.
- JSON validation of both matrix payloads → full = 27 cells, minimal = 1
  (`codex/macos-latest`).
- Path-filter dry run of the `changes` grep against sample paths:
  `connector-live-e2e.yml`, `internal/gateway/connector/registry.go`,
  `scripts/live-connector-e2e/run.sh`, `cli/.../inventory/validated_versions.json`
  → **RELEVANT** (full); `README.md`, `docs-site/*.mdx`, `cmd_upgrade.py` →
  **skip** (macOS smoke only).
- End-to-end: this PR modifies `connector-live-e2e.yml` (a relevant path), so its
  own CI run should expand to the **full 3-OS × 9 matrix** — verifying both the
  trigger and the gate. A docs-only PR would instead show just `Contract codex /
  macos-latest`.
- Not tested here: branch-protection enforcement (requires the manual ruleset
  change above).
