### PR TITLE
feat(telemetry): add InsightClaw metrics adapter for dual-emission

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -718,16 +718,26 @@ func (c *Config) EffectiveInspectLLM() InspectLLMConfig {
 }
 
 type OTelConfig struct {
-	Enabled  bool               `mapstructure:"enabled"  yaml:"enabled"`
-	Protocol string             `mapstructure:"protocol" yaml:"protocol"`
-	Endpoint string             `mapstructure:"endpoint" yaml:"endpoint"`
-	Headers  map[string]string  `mapstructure:"headers"  yaml:"headers"`
-	TLS      OTelTLSConfig      `mapstructure:"tls"      yaml:"tls"`
-	Traces   OTelTracesConfig   `mapstructure:"traces"   yaml:"traces"`
-	Logs     OTelLogsConfig     `mapstructure:"logs"     yaml:"logs"`
-	Metrics  OTelMetricsConfig  `mapstructure:"metrics"  yaml:"metrics"`
-	Batch    OTelBatchConfig    `mapstructure:"batch"    yaml:"batch"`
-	Resource OTelResourceConfig `mapstructure:"resource" yaml:"resource"`
+	Enabled     bool                     `mapstructure:"enabled"       yaml:"enabled"`
+	Protocol    string                   `mapstructure:"protocol"      yaml:"protocol"`
+	Endpoint    string                   `mapstructure:"endpoint"      yaml:"endpoint"`
+	Headers     map[string]string        `mapstructure:"headers"       yaml:"headers"`
+	TLS         OTelTLSConfig            `mapstructure:"tls"           yaml:"tls"`
+	Traces      OTelTracesConfig         `mapstructure:"traces"        yaml:"traces"`
+	Logs        OTelLogsConfig           `mapstructure:"logs"          yaml:"logs"`
+	Metrics     OTelMetricsConfig        `mapstructure:"metrics"       yaml:"metrics"`
+	Batch       OTelBatchConfig          `mapstructure:"batch"         yaml:"batch"`
+	Resource    OTelResourceConfig       `mapstructure:"resource"      yaml:"resource"`
+	InsightClaw InsightClawAdapterConfig `mapstructure:"insight_claw"  yaml:"insight_claw"`
+}
+
+// InsightClawAdapterConfig controls the InsightClaw (openclaw.*) metrics adapter.
+// When enabled, DefenseClaw dual-emits InsightClaw-compatible metrics alongside
+// its native defenseclaw.* instruments via the same OTLP pipeline.
+type InsightClawAdapterConfig struct {
+	Enabled      bool   `mapstructure:"enabled"      yaml:"enabled"`
+	Prefix       string `mapstructure:"prefix"       yaml:"prefix"`
+	Experimental bool   `mapstructure:"experimental" yaml:"experimental"`
 }
 
 type OTelTLSConfig struct {

--- a/internal/telemetry/insightclaw/adapter.go
+++ b/internal/telemetry/insightclaw/adapter.go
@@ -1,0 +1,292 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package insightclaw provides a metrics adapter that emits InsightClaw-compatible
+// openclaw.* metrics alongside DefenseClaw's native defenseclaw.* instruments.
+// The adapter is toggled by otel.insight_claw.enabled config and uses the same
+// OTel Meter, so all metrics flow through the existing OTLP exporter pipeline.
+package insightclaw
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/otel/metric"
+)
+
+// Config holds adapter-level settings parsed from the defenseclaw config file.
+type Config struct {
+	Enabled      bool   `mapstructure:"enabled"      yaml:"enabled"`
+	Prefix       string `mapstructure:"prefix"       yaml:"prefix"`
+	Experimental bool   `mapstructure:"experimental" yaml:"experimental"`
+}
+
+// Adapter holds InsightClaw-compatible OTel instruments. When nil, all Emit*
+// methods are no-ops so callers can skip nil checks.
+type Adapter struct {
+	cfg Config
+
+	// --- Phase 1: Core workflow metrics ---
+	messagesReceived metric.Int64Counter
+	messagesSent     metric.Int64Counter
+	toolCalls        metric.Int64Counter
+	toolErrors       metric.Int64Counter
+	sessionResets    metric.Int64Counter
+	llmRequests      metric.Int64Counter
+	llmTokensPrompt  metric.Int64Counter
+	llmTokensCompl   metric.Int64Counter
+	llmTokensTotal   metric.Int64Counter
+	agentTurnDur     metric.Float64Histogram
+	llmDuration      metric.Float64Histogram
+	costUSD          metric.Float64Counter
+
+	// --- Phase 2: Diagnostics-driven gateway metrics ---
+	webhookReceived  metric.Int64Counter
+	webhookError     metric.Int64Counter
+	webhookDuration  metric.Float64Histogram
+	messageQueued    metric.Int64Counter
+	messageProcessed metric.Int64Counter
+	messageDuration  metric.Float64Histogram
+	queueDepth       metric.Float64Histogram
+	queueWaitMs      metric.Float64Histogram
+	queueLaneEnqueue metric.Int64Counter
+	queueLaneDequeue metric.Int64Counter
+	sessionState     metric.Int64Counter
+	sessionStuck     metric.Int64Counter
+	sessionStuckAge  metric.Float64Histogram
+	runAttempt       metric.Int64Counter
+	toolLoop         metric.Int64Counter
+}
+
+// NewAdapter registers openclaw.* instruments on the given meter. Returns nil
+// if cfg.Enabled is false (no-op path).
+func NewAdapter(m metric.Meter, cfg Config) (*Adapter, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+
+	prefix := cfg.Prefix
+	if prefix == "" {
+		prefix = "openclaw"
+	}
+
+	a := &Adapter{cfg: cfg}
+	var err error
+
+	// Helper to build metric name with prefix.
+	name := func(suffix string) string {
+		return fmt.Sprintf("%s.%s", prefix, suffix)
+	}
+
+	// --- Phase 1: Core workflow ---
+
+	a.messagesReceived, err = m.Int64Counter(name("messages.received"),
+		metric.WithUnit("{message}"),
+		metric.WithDescription("Messages received by the agent (prompt/tool_result hooks)."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.messagesSent, err = m.Int64Counter(name("messages.sent"),
+		metric.WithUnit("{message}"),
+		metric.WithDescription("Messages sent by the agent (completions/tool_call hooks)."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.toolCalls, err = m.Int64Counter(name("tool.calls"),
+		metric.WithUnit("{call}"),
+		metric.WithDescription("Tool calls observed via connector hooks."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.toolErrors, err = m.Int64Counter(name("tool.errors"),
+		metric.WithUnit("{error}"),
+		metric.WithDescription("Tool calls that resulted in an error."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.sessionResets, err = m.Int64Counter(name("session.resets"),
+		metric.WithUnit("{reset}"),
+		metric.WithDescription("Session resets (new/reset commands)."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.llmRequests, err = m.Int64Counter(name("llm.requests"),
+		metric.WithUnit("{request}"),
+		metric.WithDescription("LLM requests observed."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.llmTokensPrompt, err = m.Int64Counter(name("llm.tokens.prompt"),
+		metric.WithUnit("{token}"),
+		metric.WithDescription("Prompt (input) tokens consumed."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.llmTokensCompl, err = m.Int64Counter(name("llm.tokens.completion"),
+		metric.WithUnit("{token}"),
+		metric.WithDescription("Completion (output) tokens consumed."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.llmTokensTotal, err = m.Int64Counter(name("llm.tokens.total"),
+		metric.WithUnit("{token}"),
+		metric.WithDescription("Total tokens consumed."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.agentTurnDur, err = m.Float64Histogram(name("agent.turn_duration"),
+		metric.WithUnit("ms"),
+		metric.WithDescription("Agent turn duration."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.llmDuration, err = m.Float64Histogram(name("llm.duration"),
+		metric.WithUnit("ms"),
+		metric.WithDescription("LLM request duration."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.costUSD, err = m.Float64Counter(name("cost.usd"),
+		metric.WithUnit("USD"),
+		metric.WithDescription("Accumulated LLM cost in USD."))
+	if err != nil {
+		return nil, err
+	}
+
+	// --- Phase 2: Diagnostics-driven gateway metrics ---
+
+	a.webhookReceived, err = m.Int64Counter(name("webhook.received"),
+		metric.WithUnit("{webhook}"),
+		metric.WithDescription("Webhooks received."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.webhookError, err = m.Int64Counter(name("webhook.error"),
+		metric.WithUnit("{error}"),
+		metric.WithDescription("Webhook processing errors."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.webhookDuration, err = m.Float64Histogram(name("webhook.duration_ms"),
+		metric.WithUnit("ms"),
+		metric.WithDescription("Webhook ingress processing duration."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.messageQueued, err = m.Int64Counter(name("message.queued"),
+		metric.WithUnit("{message}"),
+		metric.WithDescription("Messages enqueued for processing."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.messageProcessed, err = m.Int64Counter(name("message.processed"),
+		metric.WithUnit("{message}"),
+		metric.WithDescription("Messages processed."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.messageDuration, err = m.Float64Histogram(name("message.duration_ms"),
+		metric.WithUnit("ms"),
+		metric.WithDescription("Message processing duration."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.queueDepth, err = m.Float64Histogram(name("queue.depth"),
+		metric.WithUnit("{item}"),
+		metric.WithDescription("Queue depth snapshot (backlog pressure)."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.queueWaitMs, err = m.Float64Histogram(name("queue.wait_ms"),
+		metric.WithUnit("ms"),
+		metric.WithDescription("Time spent waiting in the queue."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.queueLaneEnqueue, err = m.Int64Counter(name("queue.lane.enqueue"),
+		metric.WithUnit("{event}"),
+		metric.WithDescription("Queue lane enqueue events."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.queueLaneDequeue, err = m.Int64Counter(name("queue.lane.dequeue"),
+		metric.WithUnit("{event}"),
+		metric.WithDescription("Queue lane dequeue events."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.sessionState, err = m.Int64Counter(name("session.state"),
+		metric.WithUnit("{transition}"),
+		metric.WithDescription("Session state transitions."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.sessionStuck, err = m.Int64Counter(name("session.stuck"),
+		metric.WithUnit("{event}"),
+		metric.WithDescription("Sessions detected as stuck."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.sessionStuckAge, err = m.Float64Histogram(name("session.stuck_age_ms"),
+		metric.WithUnit("ms"),
+		metric.WithDescription("How long sessions have been stuck."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.runAttempt, err = m.Int64Counter(name("run.attempt"),
+		metric.WithUnit("{attempt}"),
+		metric.WithDescription("Run attempts (including retries)."))
+	if err != nil {
+		return nil, err
+	}
+
+	a.toolLoop, err = m.Int64Counter(name("tool.loop"),
+		metric.WithUnit("{loop}"),
+		metric.WithDescription("Tool loop detections."))
+	if err != nil {
+		return nil, err
+	}
+
+	return a, nil
+}
+
+// Enabled reports whether the adapter is active.
+func (a *Adapter) Enabled() bool {
+	return a != nil
+}

--- a/internal/telemetry/insightclaw/adapter_test.go
+++ b/internal/telemetry/insightclaw/adapter_test.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package insightclaw
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func setupTestAdapter(t *testing.T) (*Adapter, *sdkmetric.ManualReader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	meter := mp.Meter("test")
+
+	adapter, err := NewAdapter(meter, Config{Enabled: true})
+	if err != nil {
+		t.Fatalf("NewAdapter: %v", err)
+	}
+	return adapter, reader
+}
+
+func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	return rm
+}
+
+func findMetric(rm metricdata.ResourceMetrics, name string) *metricdata.Metrics {
+	for _, sm := range rm.ScopeMetrics {
+		for i := range sm.Metrics {
+			if sm.Metrics[i].Name == name {
+				return &sm.Metrics[i]
+			}
+		}
+	}
+	return nil
+}
+
+func TestNilAdapterIsNoop(t *testing.T) {
+	var a *Adapter
+	// These should not panic.
+	a.EmitMessageReceived(context.Background(), "test")
+	a.EmitMessageSent(context.Background(), "test")
+	a.EmitToolCall(context.Background(), "bash", "session-1")
+	a.EmitToolError(context.Background(), "bash")
+	a.EmitTokenUsage(context.Background(), "claudecode", "claude-4", 100, 50, 150)
+	a.EmitLLMDuration(context.Background(), "claude-4", 123.4)
+	a.EmitAgentTurnDuration(context.Background(), "claude-4", "agent-1", 500.0)
+	a.EmitWebhookReceived(context.Background(), "slack", "message")
+	a.EmitSessionState(context.Background(), "active", "")
+}
+
+func TestDisabledConfigReturnsNil(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	meter := mp.Meter("test")
+
+	adapter, err := NewAdapter(meter, Config{Enabled: false})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if adapter != nil {
+		t.Fatal("expected nil adapter when disabled")
+	}
+}
+
+func TestEmitMessageReceived(t *testing.T) {
+	adapter, reader := setupTestAdapter(t)
+	ctx := context.Background()
+
+	adapter.EmitMessageReceived(ctx, "claudecode")
+	adapter.EmitMessageReceived(ctx, "claudecode")
+	adapter.EmitMessageReceived(ctx, "codex")
+
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "openclaw.messages.received")
+	if m == nil {
+		t.Fatal("metric openclaw.messages.received not found")
+	}
+
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	if !ok {
+		t.Fatalf("expected Sum[int64], got %T", m.Data)
+	}
+
+	// Should have 2 data points (claudecode=2, codex=1).
+	if len(sum.DataPoints) != 2 {
+		t.Fatalf("expected 2 data points, got %d", len(sum.DataPoints))
+	}
+
+	total := int64(0)
+	for _, dp := range sum.DataPoints {
+		total += dp.Value
+	}
+	if total != 3 {
+		t.Fatalf("expected total=3, got %d", total)
+	}
+}
+
+func TestEmitTokenUsage(t *testing.T) {
+	adapter, reader := setupTestAdapter(t)
+	ctx := context.Background()
+
+	adapter.EmitTokenUsage(ctx, "claudecode", "claude-4", 100, 50, 150)
+
+	rm := collectMetrics(t, reader)
+
+	for _, name := range []string{
+		"openclaw.llm.tokens.prompt",
+		"openclaw.llm.tokens.completion",
+		"openclaw.llm.tokens.total",
+		"openclaw.llm.requests",
+	} {
+		m := findMetric(rm, name)
+		if m == nil {
+			t.Errorf("metric %s not found", name)
+		}
+	}
+
+	// Verify prompt tokens value.
+	m := findMetric(rm, "openclaw.llm.tokens.prompt")
+	sum := m.Data.(metricdata.Sum[int64])
+	if len(sum.DataPoints) != 1 {
+		t.Fatalf("expected 1 data point, got %d", len(sum.DataPoints))
+	}
+	if sum.DataPoints[0].Value != 100 {
+		t.Fatalf("expected prompt tokens=100, got %d", sum.DataPoints[0].Value)
+	}
+
+	// Verify model attribute.
+	found := false
+	for _, attr := range sum.DataPoints[0].Attributes.ToSlice() {
+		if attr.Key == attribute.Key("gen_ai.request.model") && attr.Value.AsString() == "claude-4" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("gen_ai.request.model attribute not found on token metric")
+	}
+}
+
+func TestEmitToolCall(t *testing.T) {
+	adapter, reader := setupTestAdapter(t)
+	ctx := context.Background()
+
+	adapter.EmitToolCall(ctx, "bash", "session-abc")
+
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "openclaw.tool.calls")
+	if m == nil {
+		t.Fatal("metric openclaw.tool.calls not found")
+	}
+
+	sum := m.Data.(metricdata.Sum[int64])
+	if len(sum.DataPoints) != 1 || sum.DataPoints[0].Value != 1 {
+		t.Fatalf("expected 1 tool call, got %v", sum.DataPoints)
+	}
+
+	// Verify session.key attribute is present.
+	found := false
+	for _, attr := range sum.DataPoints[0].Attributes.ToSlice() {
+		if attr.Key == attribute.Key("session.key") && attr.Value.AsString() == "session-abc" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("session.key attribute not found on tool.calls metric")
+	}
+}
+
+func TestCustomPrefix(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	meter := mp.Meter("test")
+
+	adapter, err := NewAdapter(meter, Config{Enabled: true, Prefix: "myprefix"})
+	if err != nil {
+		t.Fatalf("NewAdapter: %v", err)
+	}
+
+	adapter.EmitMessageReceived(context.Background(), "test")
+
+	rm := collectMetrics(t, reader)
+	m := findMetric(rm, "myprefix.messages.received")
+	if m == nil {
+		t.Fatal("metric myprefix.messages.received not found (custom prefix)")
+	}
+}

--- a/internal/telemetry/insightclaw/emit.go
+++ b/internal/telemetry/insightclaw/emit.go
@@ -1,0 +1,312 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package insightclaw
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// --- Phase 1: Core workflow Emit methods ---
+
+// EmitMessageReceived records a message received event (prompt or tool_result
+// arriving at the agent via connector hooks).
+func (a *Adapter) EmitMessageReceived(ctx context.Context, channel string) {
+	if a == nil {
+		return
+	}
+	a.messagesReceived.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("message.channel", channel),
+	))
+}
+
+// EmitMessageSent records a message sent event (completion or tool_call
+// emitted by the agent).
+func (a *Adapter) EmitMessageSent(ctx context.Context, channel string) {
+	if a == nil {
+		return
+	}
+	a.messagesSent.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("message.channel", channel),
+	))
+}
+
+// EmitToolCall records a tool call observation.
+func (a *Adapter) EmitToolCall(ctx context.Context, toolName, sessionKey string) {
+	if a == nil {
+		return
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String("gen_ai.tool.name", toolName),
+	}
+	if sessionKey != "" {
+		attrs = append(attrs, attribute.String("session.key", sessionKey))
+	}
+	a.toolCalls.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+// EmitToolError records a tool error.
+func (a *Adapter) EmitToolError(ctx context.Context, toolName string) {
+	if a == nil {
+		return
+	}
+	a.toolErrors.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("gen_ai.tool.name", toolName),
+	))
+}
+
+// EmitSessionReset records a session reset or new-session command.
+func (a *Adapter) EmitSessionReset(ctx context.Context, source string) {
+	if a == nil {
+		return
+	}
+	a.sessionResets.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("command.source", source),
+	))
+}
+
+// EmitLLMRequest records an LLM request. Called once per model invocation.
+func (a *Adapter) EmitLLMRequest(ctx context.Context, model, provider string) {
+	if a == nil {
+		return
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String("gen_ai.request.model", model),
+	}
+	if provider != "" {
+		attrs = append(attrs, attribute.String("gen_ai.provider.name", provider))
+	}
+	a.llmRequests.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+// EmitTokenUsage records prompt, completion, and total token counts.
+func (a *Adapter) EmitTokenUsage(ctx context.Context, connector, model string, prompt, completion, total int64) {
+	if a == nil {
+		return
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String("gen_ai.request.model", model),
+	}
+	if connector != "" {
+		attrs = append(attrs, attribute.String("connector", connector))
+	}
+
+	if prompt > 0 {
+		a.llmTokensPrompt.Add(ctx, prompt, metric.WithAttributes(attrs...))
+	}
+	if completion > 0 {
+		a.llmTokensCompl.Add(ctx, completion, metric.WithAttributes(attrs...))
+	}
+	if total > 0 {
+		a.llmTokensTotal.Add(ctx, total, metric.WithAttributes(attrs...))
+	}
+
+	// Also count as an LLM request (diagnostics-driven path).
+	a.llmRequests.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+// EmitAgentTurnDuration records the wall-clock duration of an agent turn.
+func (a *Adapter) EmitAgentTurnDuration(ctx context.Context, model, agentID string, durationMs float64) {
+	if a == nil {
+		return
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String("gen_ai.request.model", model),
+	}
+	if agentID != "" {
+		attrs = append(attrs, attribute.String("gen_ai.agent.id", agentID))
+	}
+	a.agentTurnDur.Record(ctx, durationMs, metric.WithAttributes(attrs...))
+}
+
+// EmitLLMDuration records model request latency.
+func (a *Adapter) EmitLLMDuration(ctx context.Context, model string, durationMs float64) {
+	if a == nil {
+		return
+	}
+	a.llmDuration.Record(ctx, durationMs, metric.WithAttributes(
+		attribute.String("gen_ai.request.model", model),
+	))
+}
+
+// EmitCostUSD records LLM cost in USD.
+func (a *Adapter) EmitCostUSD(ctx context.Context, model string, costUSD float64) {
+	if a == nil || costUSD <= 0 {
+		return
+	}
+	a.costUSD.Add(ctx, costUSD, metric.WithAttributes(
+		attribute.String("gen_ai.request.model", model),
+	))
+}
+
+// --- Phase 2: Diagnostics-driven gateway Emit methods ---
+
+// EmitWebhookReceived records a webhook reception event.
+func (a *Adapter) EmitWebhookReceived(ctx context.Context, channel, webhookType string) {
+	if a == nil {
+		return
+	}
+	a.webhookReceived.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("channel", channel),
+		attribute.String("webhook.type", webhookType),
+	))
+}
+
+// EmitWebhookError records a webhook processing error.
+func (a *Adapter) EmitWebhookError(ctx context.Context, channel, webhookType string) {
+	if a == nil {
+		return
+	}
+	a.webhookError.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("channel", channel),
+		attribute.String("webhook.type", webhookType),
+	))
+}
+
+// EmitWebhookDuration records webhook processing duration.
+func (a *Adapter) EmitWebhookDuration(ctx context.Context, channel string, durationMs float64) {
+	if a == nil {
+		return
+	}
+	a.webhookDuration.Record(ctx, durationMs, metric.WithAttributes(
+		attribute.String("channel", channel),
+	))
+}
+
+// EmitMessageQueued records a message being enqueued for processing.
+func (a *Adapter) EmitMessageQueued(ctx context.Context, channel, source string) {
+	if a == nil {
+		return
+	}
+	a.messageQueued.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("channel", channel),
+		attribute.String("source", source),
+	))
+}
+
+// EmitMessageProcessed records a message being processed.
+func (a *Adapter) EmitMessageProcessed(ctx context.Context, channel, outcome string) {
+	if a == nil {
+		return
+	}
+	a.messageProcessed.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("channel", channel),
+		attribute.String("outcome", outcome),
+	))
+}
+
+// EmitMessageDuration records message processing duration.
+func (a *Adapter) EmitMessageDuration(ctx context.Context, channel string, durationMs float64) {
+	if a == nil {
+		return
+	}
+	a.messageDuration.Record(ctx, durationMs, metric.WithAttributes(
+		attribute.String("channel", channel),
+	))
+}
+
+// EmitQueueDepth records a queue depth snapshot.
+func (a *Adapter) EmitQueueDepth(ctx context.Context, depth float64) {
+	if a == nil {
+		return
+	}
+	a.queueDepth.Record(ctx, depth)
+}
+
+// EmitQueueWait records queue wait time.
+func (a *Adapter) EmitQueueWait(ctx context.Context, lane string, waitMs float64) {
+	if a == nil {
+		return
+	}
+	a.queueWaitMs.Record(ctx, waitMs, metric.WithAttributes(
+		attribute.String("lane", lane),
+	))
+}
+
+// EmitQueueLaneEnqueue records a queue lane enqueue event.
+func (a *Adapter) EmitQueueLaneEnqueue(ctx context.Context, lane string) {
+	if a == nil {
+		return
+	}
+	a.queueLaneEnqueue.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("lane", lane),
+	))
+}
+
+// EmitQueueLaneDequeue records a queue lane dequeue event.
+func (a *Adapter) EmitQueueLaneDequeue(ctx context.Context, lane string) {
+	if a == nil {
+		return
+	}
+	a.queueLaneDequeue.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("lane", lane),
+	))
+}
+
+// EmitSessionState records a session state transition.
+func (a *Adapter) EmitSessionState(ctx context.Context, state, reason string) {
+	if a == nil {
+		return
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String("state", state),
+	}
+	if reason != "" {
+		attrs = append(attrs, attribute.String("reason", reason))
+	}
+	a.sessionState.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+// EmitSessionStuck records a stuck session detection.
+func (a *Adapter) EmitSessionStuck(ctx context.Context, state string, ageMs float64) {
+	if a == nil {
+		return
+	}
+	a.sessionStuck.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("state", state),
+	))
+	if ageMs > 0 {
+		a.sessionStuckAge.Record(ctx, ageMs, metric.WithAttributes(
+			attribute.String("state", state),
+		))
+	}
+}
+
+// EmitRunAttempt records a run attempt (including retries).
+func (a *Adapter) EmitRunAttempt(ctx context.Context, attempt int) {
+	if a == nil {
+		return
+	}
+	a.runAttempt.Add(ctx, 1, metric.WithAttributes(
+		attribute.Int("attempt", attempt),
+	))
+}
+
+// EmitToolLoop records a tool loop detection.
+func (a *Adapter) EmitToolLoop(ctx context.Context, toolName, detector, action, severity string) {
+	if a == nil {
+		return
+	}
+	a.toolLoop.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("gen_ai.tool.name", toolName),
+		attribute.String("detector", detector),
+		attribute.String("action", action),
+		attribute.String("severity", severity),
+	))
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -1223,6 +1223,11 @@ func (p *Provider) RecordToolCall(ctx context.Context, tool, provider string, da
 		attribute.String("tool.provider", provider),
 		attribute.Bool("dangerous", dangerous),
 	))
+
+	// Dual-emit InsightClaw tool call.
+	if p.insightClaw != nil {
+		p.insightClaw.EmitToolCall(ctx, tool, "")
+	}
 }
 
 // RecordToolDuration records a tool call duration metric.
@@ -1245,6 +1250,11 @@ func (p *Provider) RecordToolError(ctx context.Context, tool string, exitCode in
 		attribute.String("gen_ai.tool.name", tool),
 		attribute.Int("exit_code", exitCode),
 	))
+
+	// Dual-emit InsightClaw tool error.
+	if p.insightClaw != nil {
+		p.insightClaw.EmitToolError(ctx, tool)
+	}
 }
 
 // RecordApproval records an approval request metric.
@@ -1277,6 +1287,12 @@ func (p *Provider) RecordLLMTokens(ctx context.Context, operationName, providerN
 	}
 	if completion > 0 {
 		p.RecordLLMTokenUsage(ctx, operationName, providerName, model, agentName, agentID, sessionID, "output", completion)
+	}
+
+	// Dual-emit InsightClaw token usage (semconv path).
+	if p.insightClaw != nil {
+		modelLabel := NormalizeModelLabel(model)
+		p.insightClaw.EmitTokenUsage(ctx, providerName, modelLabel, prompt, completion, prompt+completion)
 	}
 }
 
@@ -1329,6 +1345,14 @@ func (p *Provider) RecordLLMDuration(ctx context.Context, operationName, provide
 		attrs = append(attrs, attribute.String("gen_ai.agent.id", agentID))
 	}
 	p.metrics.genAIOperationDuration.Record(ctx, durationSeconds, metric.WithAttributes(attrs...))
+
+	// Dual-emit InsightClaw LLM duration (convert seconds → ms) and agent turn duration.
+	if p.insightClaw != nil {
+		modelLabel := NormalizeModelLabel(model)
+		durationMs := durationSeconds * 1000
+		p.insightClaw.EmitLLMDuration(ctx, modelLabel, durationMs)
+		p.insightClaw.EmitAgentTurnDuration(ctx, modelLabel, agentID, durationMs)
+	}
 }
 
 // RecordAlert records a runtime alert metric.
@@ -1540,6 +1564,18 @@ func (p *Provider) RecordConnectorHookInvocation(ctx context.Context, connector,
 	}
 	p.metrics.hookInvocations.Add(ctx, 1, metric.WithAttributes(attrs...))
 	p.metrics.hookLatency.Record(ctx, durationMs, metric.WithAttributes(attrs...))
+
+	// Dual-emit InsightClaw message received/sent based on hook event type.
+	if p.insightClaw != nil {
+		switch eventType {
+		case "prompt", "tool_result":
+			p.insightClaw.EmitMessageReceived(ctx, connector)
+		case "tool_call":
+			p.insightClaw.EmitMessageSent(ctx, connector)
+		case "sessionstart":
+			p.insightClaw.EmitSessionReset(ctx, connector)
+		}
+	}
 }
 
 // RecordHookTokenUsage records token-usage counts attributable to a
@@ -1580,6 +1616,11 @@ func (p *Provider) RecordHookTokenUsage(ctx context.Context, connector, model st
 	record("prompt", promptTokens)
 	record("completion", completionTokens)
 	record("total", totalTokens)
+
+	// Dual-emit InsightClaw token usage.
+	if p.insightClaw != nil {
+		p.insightClaw.EmitTokenUsage(ctx, connector, modelLabel, promptTokens, completionTokens, totalTokens)
+	}
 }
 
 // modelLabelMaxLen caps the model attribute string length. Even with
@@ -2220,6 +2261,14 @@ func (p *Provider) RecordWebhookDispatch(ctx context.Context, webhookKind, outco
 		p.metrics.webhookFailures.Add(ctx, 1, attrs)
 	}
 	_ = latencyMs // latency recorded via RecordWebhookLatency for rich attributes
+
+	// Dual-emit InsightClaw webhook metrics.
+	if p.insightClaw != nil {
+		p.insightClaw.EmitWebhookReceived(ctx, webhookKind, outcome)
+		if outcome != "delivered" {
+			p.insightClaw.EmitWebhookError(ctx, webhookKind, outcome)
+		}
+	}
 }
 
 // RecordWebhookLatency records per-delivery latency on defenseclaw.webhook.latency
@@ -2233,6 +2282,11 @@ func (p *Provider) RecordWebhookLatency(ctx context.Context, webhookKind, target
 		attribute.String("webhook.target_hash", targetHash),
 		attribute.Int("http.status_code", httpStatus),
 	))
+
+	// Dual-emit InsightClaw webhook duration.
+	if p.insightClaw != nil {
+		p.insightClaw.EmitWebhookDuration(ctx, webhookKind, latencyMs)
+	}
 }
 
 // RecordWebhookCircuitBreaker records a circuit breaker state transition.
@@ -2266,6 +2320,11 @@ func (p *Provider) RecordLLMBridgeLatency(ctx context.Context, model, status str
 		attribute.String("gen_ai.request.model", model),
 		attribute.String("status", status),
 	))
+
+	// Dual-emit InsightClaw LLM duration.
+	if p.insightClaw != nil {
+		p.insightClaw.EmitLLMDuration(ctx, NormalizeModelLabel(model), durationMs)
+	}
 }
 
 // RecordOpenShellExit records an OpenShell subprocess exit (non-zero typically).
@@ -2432,6 +2491,11 @@ func (p *Provider) RecordQueueDepth(ctx context.Context, queueName string, depth
 		attribute.Int64("capacity", capacity),
 	)
 	p.metrics.queueDepthGauge.Record(ctx, depth, attrs)
+
+	// Dual-emit InsightClaw queue depth.
+	if p.insightClaw != nil {
+		p.insightClaw.EmitQueueDepth(ctx, float64(depth))
+	}
 }
 
 // RecordQueueDropped increments the drop counter (e.g. queue full).

--- a/internal/telemetry/provider.go
+++ b/internal/telemetry/provider.go
@@ -52,6 +52,7 @@ import (
 	tracehttp "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/telemetry/insightclaw"
 )
 
 // Provider holds the OTel SDK providers and exposes telemetry emission methods.
@@ -81,6 +82,11 @@ type Provider struct {
 	// guard it with an atomic load rather than a mutex; writes
 	// happen exactly once during NewSidecar.
 	agentInstanceID atomic.Value // string
+
+	// insightClaw is the InsightClaw metrics adapter. When non-nil,
+	// Record* methods also emit openclaw.* metrics for InsightClaw
+	// compatibility. Nil when otel.insight_claw.enabled is false.
+	insightClaw *insightclaw.Adapter
 }
 
 // NewProvider initializes the OTel SDK providers and exporters. When
@@ -146,6 +152,18 @@ func NewProvider(ctx context.Context, fullCfg *config.Config, version string) (*
 	}
 	p.metrics = ms
 
+	// Initialize InsightClaw adapter for dual-emit when configured.
+	icCfg := insightclaw.Config{
+		Enabled:      fullCfg.OTel.InsightClaw.Enabled,
+		Prefix:       fullCfg.OTel.InsightClaw.Prefix,
+		Experimental: fullCfg.OTel.InsightClaw.Experimental,
+	}
+	ic, err := insightclaw.NewAdapter(p.meter, icCfg)
+	if err != nil {
+		return nil, fmt.Errorf("telemetry: insightclaw adapter: %w", err)
+	}
+	p.insightClaw = ic
+
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
 		if err == nil || p.metrics == nil {
 			return
@@ -179,6 +197,15 @@ func NewProvider(ctx context.Context, fullCfg *config.Config, version string) (*
 // Enabled reports whether OTel export is active.
 func (p *Provider) Enabled() bool {
 	return p != nil && p.enabled
+}
+
+// InsightClaw returns the InsightClaw adapter for direct emission from
+// hook handlers. Returns nil when the adapter is disabled.
+func (p *Provider) InsightClaw() *insightclaw.Adapter {
+	if p == nil {
+		return nil
+	}
+	return p.insightClaw
 }
 
 // Tracer returns the defenseclaw tracer, or a no-op tracer when the

--- a/schemas/otel/insightclaw-metrics.schema.json
+++ b/schemas/otel/insightclaw-metrics.schema.json
@@ -1,0 +1,264 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://defenseclaw.dev/schemas/otel/insightclaw-metrics.schema.json",
+  "title": "InsightClaw Compatibility Metrics (openclaw.*)",
+  "description": "Metrics emitted by the DefenseClaw InsightClaw adapter for interoperability with InsightClaw dashboards and analytics. These are dual-emitted alongside native defenseclaw.* metrics when otel.insight_claw.enabled is true. Attribute names follow OTel semantic conventions (gen_ai.*, etc.) — no renaming.",
+  "x-emitted-metrics": [
+    {
+      "name": "openclaw.messages.received",
+      "type": "counter",
+      "unit": "{message}",
+      "description": "Messages received by the agent (prompt/tool_result hooks).",
+      "attributes": {
+        "message.channel": { "type": "string", "description": "Connector or channel that delivered the message." }
+      }
+    },
+    {
+      "name": "openclaw.messages.sent",
+      "type": "counter",
+      "unit": "{message}",
+      "description": "Messages sent by the agent (completions/tool_call hooks).",
+      "attributes": {
+        "message.channel": { "type": "string", "description": "Connector or channel the message was sent through." }
+      }
+    },
+    {
+      "name": "openclaw.tool.calls",
+      "type": "counter",
+      "unit": "{call}",
+      "description": "Tool calls observed via connector hooks.",
+      "attributes": {
+        "gen_ai.tool.name": { "type": "string", "description": "Tool name (OTel semconv)." },
+        "session.key": { "type": "string", "description": "Session key when available." }
+      }
+    },
+    {
+      "name": "openclaw.tool.errors",
+      "type": "counter",
+      "unit": "{error}",
+      "description": "Tool calls that resulted in an error.",
+      "attributes": {
+        "gen_ai.tool.name": { "type": "string", "description": "Tool name (OTel semconv)." }
+      }
+    },
+    {
+      "name": "openclaw.session.resets",
+      "type": "counter",
+      "unit": "{reset}",
+      "description": "Session resets (new/reset commands).",
+      "attributes": {
+        "command.source": { "type": "string", "description": "Source of the reset command." }
+      }
+    },
+    {
+      "name": "openclaw.llm.requests",
+      "type": "counter",
+      "unit": "{request}",
+      "description": "LLM requests observed.",
+      "attributes": {
+        "gen_ai.request.model": { "type": "string", "description": "Model identifier (OTel semconv)." },
+        "gen_ai.provider.name": { "type": "string", "description": "Provider name (OTel semconv)." },
+        "connector": { "type": "string", "description": "Connector that triggered the request." }
+      }
+    },
+    {
+      "name": "openclaw.llm.tokens.prompt",
+      "type": "counter",
+      "unit": "{token}",
+      "description": "Prompt (input) tokens consumed.",
+      "attributes": {
+        "gen_ai.request.model": { "type": "string" },
+        "connector": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.llm.tokens.completion",
+      "type": "counter",
+      "unit": "{token}",
+      "description": "Completion (output) tokens consumed.",
+      "attributes": {
+        "gen_ai.request.model": { "type": "string" },
+        "connector": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.llm.tokens.total",
+      "type": "counter",
+      "unit": "{token}",
+      "description": "Total tokens consumed.",
+      "attributes": {
+        "gen_ai.request.model": { "type": "string" },
+        "connector": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.agent.turn_duration",
+      "type": "histogram",
+      "unit": "ms",
+      "description": "Agent turn duration.",
+      "attributes": {
+        "gen_ai.request.model": { "type": "string" },
+        "gen_ai.agent.id": { "type": "string", "description": "Agent identifier." }
+      }
+    },
+    {
+      "name": "openclaw.llm.duration",
+      "type": "histogram",
+      "unit": "ms",
+      "description": "LLM request duration (model round-trip, not full turn).",
+      "attributes": {
+        "gen_ai.request.model": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.cost.usd",
+      "type": "counter",
+      "unit": "USD",
+      "description": "Accumulated LLM cost in USD.",
+      "attributes": {
+        "gen_ai.request.model": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.webhook.received",
+      "type": "counter",
+      "unit": "{webhook}",
+      "description": "Webhooks received.",
+      "attributes": {
+        "channel": { "type": "string" },
+        "webhook.type": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.webhook.error",
+      "type": "counter",
+      "unit": "{error}",
+      "description": "Webhook processing errors.",
+      "attributes": {
+        "channel": { "type": "string" },
+        "webhook.type": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.webhook.duration_ms",
+      "type": "histogram",
+      "unit": "ms",
+      "description": "Webhook ingress processing duration.",
+      "attributes": {
+        "channel": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.message.queued",
+      "type": "counter",
+      "unit": "{message}",
+      "description": "Messages enqueued for processing.",
+      "attributes": {
+        "channel": { "type": "string" },
+        "source": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.message.processed",
+      "type": "counter",
+      "unit": "{message}",
+      "description": "Messages processed.",
+      "attributes": {
+        "channel": { "type": "string" },
+        "outcome": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.message.duration_ms",
+      "type": "histogram",
+      "unit": "ms",
+      "description": "Message processing duration.",
+      "attributes": {
+        "channel": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.queue.depth",
+      "type": "histogram",
+      "unit": "{item}",
+      "description": "Queue depth snapshot (backlog pressure).",
+      "attributes": {}
+    },
+    {
+      "name": "openclaw.queue.wait_ms",
+      "type": "histogram",
+      "unit": "ms",
+      "description": "Time spent waiting in the queue.",
+      "attributes": {
+        "lane": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.queue.lane.enqueue",
+      "type": "counter",
+      "unit": "{event}",
+      "description": "Queue lane enqueue events.",
+      "attributes": {
+        "lane": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.queue.lane.dequeue",
+      "type": "counter",
+      "unit": "{event}",
+      "description": "Queue lane dequeue events.",
+      "attributes": {
+        "lane": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.session.state",
+      "type": "counter",
+      "unit": "{transition}",
+      "description": "Session state transitions.",
+      "attributes": {
+        "state": { "type": "string" },
+        "reason": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.session.stuck",
+      "type": "counter",
+      "unit": "{event}",
+      "description": "Sessions detected as stuck.",
+      "attributes": {
+        "state": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.session.stuck_age_ms",
+      "type": "histogram",
+      "unit": "ms",
+      "description": "How long sessions have been stuck.",
+      "attributes": {
+        "state": { "type": "string" }
+      }
+    },
+    {
+      "name": "openclaw.run.attempt",
+      "type": "counter",
+      "unit": "{attempt}",
+      "description": "Run attempts (including retries).",
+      "attributes": {
+        "attempt": { "type": "integer" }
+      }
+    },
+    {
+      "name": "openclaw.tool.loop",
+      "type": "counter",
+      "unit": "{loop}",
+      "description": "Tool loop detections.",
+      "attributes": {
+        "gen_ai.tool.name": { "type": "string" },
+        "detector": { "type": "string" },
+        "action": { "type": "string" },
+        "severity": { "type": "string" }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Introduced InsightClaw adapter to emit openclaw.* metrics alongside existing defenseclaw.* metrics.
- Updated Provider to initialize InsightClaw adapter based on configuration.
- Enhanced existing telemetry methods to include dual-emission for tool calls, errors, token usage, durations, and webhook metrics.
- Added comprehensive tests for the new InsightClaw adapter to ensure correct metric emission and behavior.
- Created JSON schema for InsightClaw metrics to facilitate interoperability with dashboards and analytics.