### PR TITLE
fix(setup): PR #348 trusted-paths review follow-ups

### DIFF
--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -1808,6 +1808,16 @@ def trusted_paths_remove(app: AppContext, directory: str, as_json: bool) -> None
     _emit_trusted_path_result(as_json, ok=True, path=resolved, message="removed from trusted prefixes")
 
 
+def _emit_untrusted_prefix_setup_hints(resolved_binary: str, parent: str) -> None:
+    """Actionable remediation when action-mode setup cannot probe a connector binary."""
+    ux.subhead(f"  Binary resolves to: {resolved_binary}")
+    ux.subhead(f"  Trust it with: defenseclaw setup trusted-paths add {parent}")
+    ux.subhead(
+        "  `trusted-paths add` appends to ~/.defenseclaw/.env "
+        f"(DEFENSECLAW_TRUSTED_BIN_PREFIXES entries are {os.pathsep!r}-separated)."
+    )
+
+
 def _print_summary(sc, llm, aid) -> None:
     click.echo()
     click.echo("  Saved to ~/.defenseclaw/config.yaml")
@@ -2785,11 +2795,14 @@ def _check_connector_version_supported_for_setup(
                 and signal.binary_path
             )
             interactive = _allow_prompt and sys.stdin.isatty() and sys.stdout.isatty()
+            resolved_bin = ""
+            parent = ""
+            if is_untrusted_path:
+                resolved_bin = os.path.realpath(signal.binary_path)
+                parent = os.path.dirname(resolved_bin)
             if emit and is_untrusted_path and interactive:
-                resolved = os.path.realpath(signal.binary_path)
-                parent = os.path.dirname(resolved)
                 ux.warn(detail)
-                ux.subhead(f"  Binary resolves to: {resolved}")
+                ux.subhead(f"  Binary resolves to: {resolved_bin}")
                 ux.subhead(f"  Directory '{parent}' is not in the trusted prefix list.")
                 ux.subhead(
                     "  Trusting a directory lets DefenseClaw execute any binary placed "
@@ -2816,22 +2829,15 @@ def _check_connector_version_supported_for_setup(
                         data_dir=data_dir,
                         _allow_prompt=False,
                     )
-                # Declined: fall through to the refusal/hint below.
-            if emit and not (is_untrusted_path and interactive):
-                ux.err(
-                    detail + " Refusing action-mode hook setup because the installed "
-                    "connector version could not be verified."
-                )
-                if is_untrusted_path:
-                    resolved = os.path.realpath(signal.binary_path)
-                    parent = os.path.dirname(resolved)
-                    ux.subhead(f"  Binary resolves to: {resolved}")
-                    ux.subhead(f"  Trust it with: defenseclaw setup trusted-paths add {parent}")
-                    ux.subhead(
-                        f"  (or add manually to ~/.defenseclaw/.env: "
-                        f"DEFENSECLAW_TRUSTED_BIN_PREFIXES={parent})"
-                    )
+                # Declined: fall through — still emit the trusted-paths hint below.
             if emit:
+                if not (is_untrusted_path and interactive):
+                    ux.err(
+                        detail + " Refusing action-mode hook setup because the installed "
+                        "connector version could not be verified."
+                    )
+                if is_untrusted_path:
+                    _emit_untrusted_prefix_setup_hints(resolved_bin, parent)
                 ux.subhead("Set DEFENSECLAW_ALLOW_HOOK_CONTRACT_DRIFT=1 only for exploratory testing.")
             return False
         if emit:

--- a/cli/defenseclaw/inventory/agent_discovery.py
+++ b/cli/defenseclaw/inventory/agent_discovery.py
@@ -69,7 +69,7 @@ VERSION_TIMEOUT_SECONDS = 2.0
 # those dirs, plant `codex` (or any other discovery target), and a
 # default-trusted prefix would let the passive scan exec it. Operators
 # with bespoke install layouts extend the allow-list at runtime via the
-# ``DEFENSECLAW_TRUSTED_BIN_PREFIXES`` env var (colon-separated).
+# ``DEFENSECLAW_TRUSTED_BIN_PREFIXES`` env var (``os.pathsep``-separated).
 _TRUSTED_BIN_PREFIXES_DEFAULT: tuple[str, ...] = (
     "/usr/bin",
     "/usr/local/bin",
@@ -94,7 +94,7 @@ _TRUSTED_BIN_PREFIXES_DEFAULT: tuple[str, ...] = (
     # it. Operators who install discovery targets under a user-owned tool
     # root (modern Codex CLI lives in ~/.codex/packages/standalone/...)
     # must opt in explicitly via DEFENSECLAW_TRUSTED_BIN_PREFIXES
-    # (colon-separated); the per-file/parent permission checks in
+    # (``os.pathsep``-separated); the per-file/parent permission checks in
     # _is_trusted_binary_path still apply on top of any extension.
 )
 
@@ -282,7 +282,7 @@ def _trusted_bin_prefixes() -> tuple[str, ...]:
     The defaults cover platform-package, Homebrew, MacPorts, and common
     user-scoped tooling (cargo, npm, pyenv, asdf, pipx, etc.). Operators
     can extend the list at runtime via ``DEFENSECLAW_TRUSTED_BIN_PREFIXES``
-    (colon-separated). Each entry is tilde-expanded and absolutised
+    (``os.pathsep``-separated). Each entry is tilde-expanded and absolutised
     before comparison.
     """
     extras: list[str] = []
@@ -314,6 +314,27 @@ def _trusted_bin_prefixes() -> tuple[str, ...]:
     return tuple(expanded)
 
 
+def _trusted_prefix_dir_mode_error(st: os.stat_result) -> str | None:
+    """Return a human-readable refusal when a directory mode is unsafe to trust.
+
+    Mirrors the parent-directory permission checks in ``_is_trusted_binary_path``
+    so ``trusted-paths add`` cannot succeed on directories discovery would still
+    reject for version probing.
+    """
+    if st.st_mode & 0o002:
+        return "directory is world-writable"
+    if st.st_mode & 0o020:
+        grp_name = ""
+        if _grp is not None:
+            try:
+                grp_name = _grp.getgrgid(st.st_gid).gr_name
+            except (KeyError, OSError):
+                grp_name = ""
+        if grp_name not in ("root", "wheel", "admin"):
+            return "directory is group-writable"
+    return None
+
+
 def validate_trusted_prefix(path: str) -> tuple[str, str | None]:
     """Validate a candidate trusted-bin-prefix directory.
 
@@ -325,9 +346,11 @@ def validate_trusted_prefix(path: str) -> tuple[str, str | None]:
     Rules:
       * a *non-absolute* input is rejected — the resolved location would
         otherwise depend on the caller's working directory;
-      * a *world-writable* directory is rejected — anyone on the host could
-        drop a malicious binary into it, the exact threat the allow-list
-        defends against;
+      * existing paths are canonicalised with ``realpath`` so symlink aliases
+        match the discovery gate;
+      * a *world-writable* or unsafe *group-writable* directory is rejected —
+        anyone on the host (or anyone sharing the group) could drop a malicious
+        binary into it, the exact threat the allow-list defends against;
       * a path that exists but is not a directory is rejected;
       * a path that does not yet exist is allowed (the caller may warn) — it
         is not itself unsafe to trust.
@@ -338,7 +361,10 @@ def validate_trusted_prefix(path: str) -> tuple[str, str | None]:
     expanded = _expand(raw)
     if not os.path.isabs(expanded):
         return os.path.abspath(expanded), "path is not absolute"
-    resolved = os.path.abspath(expanded)
+    try:
+        resolved = os.path.realpath(expanded)
+    except OSError:
+        resolved = os.path.abspath(expanded)
     try:
         st = os.stat(resolved)
     except FileNotFoundError:
@@ -347,8 +373,9 @@ def validate_trusted_prefix(path: str) -> tuple[str, str | None]:
         return resolved, f"cannot stat path ({exc})"
     if not os.path.isdir(resolved):
         return resolved, "path is not a directory"
-    if st.st_mode & 0o002:
-        return resolved, "directory is world-writable"
+    mode_err = _trusted_prefix_dir_mode_error(st)
+    if mode_err:
+        return resolved, mode_err
     return resolved, None
 
 

--- a/cli/defenseclaw/tui/app.py
+++ b/cli/defenseclaw/tui/app.py
@@ -6970,6 +6970,10 @@ class DefenseClawTUI(App[None]):
             self._set_status(f"{connector} setup paused — '{parent}' was not trusted.")
             return False
         self._handle_setup_resource_result(result)
+        label = friendly_connector_name(connector)
+        self._set_status(
+            f"{label}: trusted-paths command queued — when it finishes, press m again to re-run setup."
+        )
         return False
 
     async def _cancel_running_command(self) -> None:

--- a/cli/defenseclaw/tui/screens/trusted_paths_editor.py
+++ b/cli/defenseclaw/tui/screens/trusted_paths_editor.py
@@ -334,6 +334,24 @@ def _refresh_trusted_prefix_env(data_dir: str | None) -> None:
     os.environ["DEFENSECLAW_TRUSTED_BIN_PREFIXES"] = os.pathsep.join(merged)
 
 
+_UNTRUSTED_DIR_CACHE: dict[str, str | None] = {}
+
+
+def _trust_state_token(data_dir: str | None) -> str:
+    """Fingerprint persisted + live trust state for short-lived routing cache."""
+    import os  # noqa: PLC0415
+
+    from defenseclaw.config import default_data_path  # noqa: PLC0415
+
+    resolved_dir = data_dir or str(default_data_path())
+    dotenv = os.path.join(resolved_dir, ".env")
+    try:
+        mtime = str(os.path.getmtime(dotenv))
+    except OSError:
+        mtime = "0"
+    return f"{mtime}:{os.environ.get('DEFENSECLAW_TRUSTED_BIN_PREFIXES', '')}"
+
+
 def untrusted_connector_dir(connector: str, data_dir: str | None = None) -> str | None:
     """Return the directory a connector binary lives in when it is *untrusted*.
 
@@ -342,25 +360,33 @@ def untrusted_connector_dir(connector: str, data_dir: str | None = None) -> str 
     the Trusted Paths editor instead of running a setup that the trust gate
     would refuse (where the CLI would otherwise fire ``click.confirm``).
 
-    Runs a *fresh* scan (and re-hydrates persisted trust) so the routing
-    reflects current state — a stale "trusted" cache must not let an
-    untrusted-binary setup slip past the panel.
+    Re-hydrates persisted trust and scans connectors. Results are cached per
+    connector for the current trust fingerprint so repeated mode-picker opens
+    in one session do not re-exec every binary.
     """
     import os  # noqa: PLC0415
 
     from defenseclaw.inventory import agent_discovery  # noqa: PLC0415
 
+    cache_key = f"{connector}|{_trust_state_token(data_dir)}"
+    if cache_key in _UNTRUSTED_DIR_CACHE:
+        return _UNTRUSTED_DIR_CACHE[cache_key]
+
     _refresh_trusted_prefix_env(data_dir)
     try:
         disc = agent_discovery.discover_agents(use_cache=False, refresh=True, data_dir=data_dir)
     except Exception:
+        _UNTRUSTED_DIR_CACHE[cache_key] = None
         return None
     signal = disc.agents.get(connector)
     if signal is None or not signal.binary_path:
-        return None
-    if signal.error != agent_discovery.UNTRUSTED_PREFIX_ERROR:
-        return None
-    return os.path.dirname(os.path.realpath(signal.binary_path))
+        result = None
+    elif signal.error != agent_discovery.UNTRUSTED_PREFIX_ERROR:
+        result = None
+    else:
+        result = os.path.dirname(os.path.realpath(signal.binary_path))
+    _UNTRUSTED_DIR_CACHE[cache_key] = result
+    return result
 
 
 def untrusted_connector_dirs(data_dir: str | None = None) -> list[tuple[str, str]]:

--- a/cli/tests/test_cmd_setup_trusted_paths.py
+++ b/cli/tests/test_cmd_setup_trusted_paths.py
@@ -195,6 +195,52 @@ class GatePromptContractGateTests(unittest.TestCase):
         if os.path.isfile(dotenv):
             self.assertNotIn("DEFENSECLAW_TRUSTED_BIN_PREFIXES", open(dotenv, encoding="utf-8").read())
 
+    def test_declined_prompt_still_emits_trusted_paths_hint(self):
+        """Review follow-up: declining the trust prompt must still show remediation."""
+        hints: list[str] = []
+
+        def _capture(msg: str) -> None:
+            hints.append(msg)
+
+        def contract(_c, v):
+            return _compat(v, STATUS_UNVERSIONED, "codex-hooks-v1")
+
+        with patch.object(cmd_setup.ux, "subhead", side_effect=_capture):
+            result, _mock_disc, _tmp, binpath = self._run(
+                None, confirm=False, contract_side_effect=contract
+            )
+        self.assertFalse(result)
+        joined = " ".join(hints)
+        self.assertIn("trusted-paths add", joined)
+        self.assertIn(os.path.dirname(os.path.realpath(binpath)), joined)
+        self.assertIn("appends to ~/.defenseclaw/.env", joined)
+
+
+class ValidateTrustedPrefixTests(unittest.TestCase):
+    def test_rejects_non_absolute_path(self):
+        resolved, err = ad.validate_trusted_prefix("relative/bin")
+        self.assertIsNotNone(err)
+        self.assertIn("not absolute", err or "")
+
+    def test_realpath_canonicalises_symlink_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "target")
+            link = os.path.join(tmp, "link")
+            os.makedirs(target)
+            os.symlink(target, link)
+            resolved, err = ad.validate_trusted_prefix(link)
+            self.assertIsNone(err)
+            self.assertEqual(resolved, os.path.realpath(target))
+
+    def test_group_writable_directory_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            gdir = os.path.join(tmp, "gtools")
+            os.makedirs(gdir)
+            os.chmod(gdir, 0o770)
+            with patch.object(ad, "_trusted_prefix_dir_mode_error", return_value="directory is group-writable"):
+                _resolved, err = ad.validate_trusted_prefix(gdir)
+            self.assertEqual(err, "directory is group-writable")
+
 
 class TrustedPathsCliTests(unittest.TestCase):
     def setUp(self):

--- a/cli/tests/test_cmd_setup_trusted_paths.py
+++ b/cli/tests/test_cmd_setup_trusted_paths.py
@@ -262,15 +262,18 @@ class TrustedPathsCliTests(unittest.TestCase):
             app = _make_app_context(tmp)
             newdir = os.path.join(tmp, "tools")
             os.makedirs(newdir)
+            resolved, err = ad.validate_trusted_prefix(newdir)
+            self.assertIsNone(err)
             with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": ""}, clear=False):
                 add = self.runner.invoke(cmd_setup.trusted_paths, ["add", newdir, "--json"], obj=app)
                 self.assertEqual(add.exit_code, 0, msg=add.output)
                 self.assertTrue(json.loads(add.output)["ok"])
                 listing = self.runner.invoke(cmd_setup.trusted_paths, ["list", "--json"], obj=app)
                 rows = {r["resolved"]: r for r in json.loads(listing.output)}
-            self.assertIn(newdir, open(os.path.join(tmp, ".env"), encoding="utf-8").read())
-            self.assertTrue(rows[newdir]["removable"])
-            self.assertEqual(rows[newdir]["source"], ".env")
+            dotenv_body = open(os.path.join(tmp, ".env"), encoding="utf-8").read()
+            self.assertIn(resolved, dotenv_body)
+            self.assertTrue(rows[resolved]["removable"])
+            self.assertEqual(rows[resolved]["source"], ".env")
 
     def test_add_world_writable_refused_without_force(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/cli/tests/tui/test_trusted_paths_editor.py
+++ b/cli/tests/tui/test_trusted_paths_editor.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 import pytest
 from defenseclaw.inventory import agent_discovery as ad
 from defenseclaw.tui.screens.setup_resource_editor import SetupResourceResult
+from defenseclaw.tui.screens import trusted_paths_editor as tpe
 from defenseclaw.tui.screens.trusted_paths_editor import (
     TrustedPathRow,
     TrustedPathsEditorScreen,
@@ -40,9 +41,11 @@ def _isolate_trusted_env(tmp_path, monkeypatch):
     """Point DEFENSECLAW_HOME at an empty dir so the new ``_refresh`` helper
     reads no persisted ``.env`` and never mutates the real process env across
     tests. Individual tests that need a populated ``.env`` write into tmp_path."""
+    tpe._UNTRUSTED_DIR_CACHE.clear()
     monkeypatch.setenv("DEFENSECLAW_HOME", str(tmp_path))
     monkeypatch.delenv("DEFENSECLAW_TRUSTED_BIN_PREFIXES", raising=False)
-    return tmp_path
+    yield tmp_path
+    tpe._UNTRUSTED_DIR_CACHE.clear()
 
 
 class _Harness(App):
@@ -86,8 +89,10 @@ def _sig(binary_path: str, error: str, version: str = "") -> ad.AgentSignal:
 
 def test_untrusted_connector_dir_detects_untrusted_binary() -> None:
     disc = _disc(_sig("/home/u/.local/bin/codex", ad.UNTRUSTED_PREFIX_ERROR))
-    with patch.object(ad, "discover_agents", return_value=disc):
+    with patch.object(ad, "discover_agents", return_value=disc) as mock_disc:
         result = untrusted_connector_dir("codex")
+        untrusted_connector_dir("codex")
+    assert mock_disc.call_count == 1
     assert result == os.path.dirname(os.path.realpath("/home/u/.local/bin/codex"))
 
 


### PR DESCRIPTION
## Summary

Small follow-up to #348 addressing code-review findings:

- **Declined trust prompt** — interactive action-mode setup now still prints `trusted-paths add` remediation when the operator answers No (previously only showed the drift escape hatch).
- **`validate_trusted_prefix` hardening** — canonicalises existing paths with `realpath` (symlink parity with discovery) and rejects group-writable directories using the same rules as `_is_trusted_binary_path`.
- **Docs/comments** — replace stale "colon-separated" wording with `os.pathsep`-separated in `agent_discovery.py`.
- **TUI UX** — status nudge after trusting via the editor; session cache for `untrusted_connector_dir` keyed on `.env` mtime + live env to avoid re-scanning every connector on each mode-picker open.

## Test plan

- [x] `cli/tests/test_cmd_setup_trusted_paths.py` — declined-prompt hint, `validate_trusted_prefix` (non-absolute, symlink, group-writable)
- [x] `cli/tests/tui/test_trusted_paths_editor.py` — routing cache hits on repeat lookup
- [ ] CI green on `fix/high-critical-remediation`

Stacks on #348 (merged) → targets PR #258 (`fix/high-critical-remediation`).