### PR TITLE
RFC: standard hook connector wire contract and declarative manifest schema

### DIFF
--- a/docs/HOOK-CONNECTOR-CONTRACT.md
+++ b/docs/HOOK-CONNECTOR-CONTRACT.md
@@ -21,8 +21,12 @@ sends and receives on the wire; Tier 2 is how DefenseClaw is configured to
 produce and interpret that wire traffic on behalf of a harness that cannot
 hand-roll it.
 
-> Status: design contract. This file and the JSON Schema define the target
-> behavior; the engine that consumes manifests is implemented separately.
+> Status: draft design contract. This file and the JSON Schema define the
+> target behavior; the engine that consumes manifests is implemented
+> separately. This contract should not be treated as frozen until a managed
+> built-in connector (the parity target is `cursor`) has been re-expressed as
+> an embedded manifest with byte-identical setup output, equivalent wire
+> verdicts, equivalent failure behavior, and equivalent hook exit codes.
 
 ---
 
@@ -30,7 +34,7 @@ hand-roll it.
 
 | You are… | Use | Why |
 | --- | --- | --- |
-| A harness author who can ship a hook/script that calls an HTTP endpoint | Tier 1 | Self-contained; you own the client; DefenseClaw needs nothing. |
+| A harness author who can ship a hook/script that calls an HTTP endpoint | Tier 1 | Self-contained; you own the client and enforcement semantics; DefenseClaw needs no harness-specific code. |
 | An operator who wants DefenseClaw to *manage* (install, verify, remove, decode, render) a harness's hooks for you | Tier 2 | DefenseClaw does the wiring; you ship a manifest, not code. |
 | DefenseClaw maintainers adding a first-party harness with no special behavior | Tier 2 (embedded) | New harness ships as embedded data, not a new connector package. |
 
@@ -44,32 +48,42 @@ it yet.
 
 ### 2.1 Endpoint
 
+Registered connectors (built-in or manifest-backed) post to their connector
+route:
+
 ```
 POST http://127.0.0.1:18970/api/v1/<connector>/hook
 ```
 
-- `<connector>` is the connector name (built-in name, or a manifest `name`).
+- `<connector>` is a registered connector name: a built-in connector, an
+  embedded manifest connector, or a validated drop-in manifest connector.
 - The gateway binds to loopback by default. The address is discoverable from
   the gateway-written hook environment / token files; do not hardcode a remote
   host.
-- A generic, connector-agnostic alias is also defined for harnesses that
-  self-wire without a manifest:
+- Unknown connector names are rejected. The gateway must not silently treat a
+  misspelled or attacker-chosen connector as a managed connector, because that
+  would bypass manifest provenance, capability, and route-registration checks.
+
+Harnesses that self-wire without a manifest use the deliberately generic route:
 
 ```
-POST http://127.0.0.1:18970/api/v1/hook        (connector via ?connector=<name> or X-DefenseClaw-Connector header)
+POST http://127.0.0.1:18970/api/v1/generic/hook
 ```
 
-When the connector cannot be resolved, the gateway falls back to a generic
-profile (flat decode, generic render) so the call still produces a valid
-verdict.
+Self-integrators may set `X-DefenseClaw-Harness: <name>` for telemetry labels,
+but that value is not a connector identity and cannot shadow a built-in or
+manifest connector. Generic Tier-1 calls use flat decode and generic rendering;
+the harness author owns the client-side stdout / exit-code interpretation. To
+get managed setup, teardown, capability gating, and connector-scoped telemetry,
+ship a Tier-2 manifest instead.
 
 ### 2.2 Request headers
 
 | Header | Required | Purpose |
 | --- | --- | --- |
 | `Content-Type: application/json` | yes | Body is a single JSON object. |
-| `Authorization: Bearer <token>` | yes when a token exists | Gateway hook token. Read from the gateway-provisioned hook token file / env. Loopback calls without a token are accepted with a logged warning to keep first-run UX working, but a token is the supported posture. |
-| `X-DefenseClaw-Client: <name>-hook/<v>` | yes | CSRF / origin marker. Mutating hook calls require a recognized client marker. |
+| `Authorization: Bearer <token>` | yes | Gateway hook token. Read from the gateway-provisioned hook token file / env. Legacy loopback no-token tolerance is not part of the public contract for new custom harnesses. |
+| `X-DefenseClaw-Client: <name>-hook/<v>` | yes | CSRF / origin marker. Managed connectors use the manifest/built-in name; Tier-1 generic clients use `generic-hook/<v>` and may add `X-DefenseClaw-Harness` for display. |
 | `traceparent` / `tracestate` | optional | W3C trace context. When present and the contract advertises `supports_traceparent`, the gateway continues the remote trace instead of minting a new root span. |
 | `X-DefenseClaw-Session-Id` | optional | Stable session correlation when the payload has no session id. |
 | `X-DefenseClaw-Run-Id`, `X-DefenseClaw-Agent-Id` | optional | Additional correlation dimensions surfaced on telemetry. |
@@ -91,6 +105,7 @@ maps your shape onto these canonical fields.
 | content | `prompt`, `user_prompt`, `message`, `text`, `content` | Prompt or message text for prompt-class events. |
 | cwd | `cwd`, `working_directory` | Working directory, if provided. |
 | model | `model`, `model_id` | Model identifier, if provided. |
+| surface | `surface`, `direction` | Optional explicit inspection surface: `prompt`, `tool_call`, `tool_result`, or `event_content`. |
 
 Events are classified into surfaces — **prompt** (user prompt submitted),
 **tool_call** (a tool/command is about to run), **tool_result** (a tool/command
@@ -128,9 +143,16 @@ fields and read only `<response_field>`, or vice versa.
 | `confirm` | Ask a human to approve. | Only when the connector advertises native ask **and** the event is ask-capable; otherwise downgraded to `alert`. |
 | `alert` | Surface a warning, proceed. | Always permitted. |
 
-The gateway never asks a harness to do something it cannot do: a manifest's
-`capabilities` (`can_block`, `can_ask_native`, `ask_events`, `block_events`)
-are the ceiling. `raw_action` preserves the pre-gating intent for audit.
+For registered managed connectors, the gateway never asks a harness to do
+something it cannot do: a manifest's `capabilities` (`can_block`,
+`can_ask_native`, `ask_events`, `block_events`) are the ceiling. `raw_action`
+preserves the pre-gating intent for audit.
+
+For the generic Tier-1 route, DefenseClaw returns the canonical policy verdict
+and generic output. The harness author owns whether and how that verdict maps to
+the harness's stdout and exit-code protocol. Operators who need DefenseClaw to
+own enforcement semantics should use a manifest connector rather than the
+generic route.
 
 ### 2.6 Exit-code styles
 
@@ -197,6 +219,8 @@ into one file:
 | `patchXHooks()` config writer | `wiring` |
 | `HookProfile.Decode` | `decode` |
 | `HookProfile.Respond` + `hookexec` style + `response_field` | `response` |
+| `hookexec` fail-closed / strict-availability tails | `response.failure` |
+| `ConnectorCapabilities` / component path discovery | `surfaces` |
 | Per-connector `X-hook.sh` | `wiring.entry_template` + generic hook template |
 
 ### 3.2 Loading model
@@ -239,13 +263,17 @@ for the authoritative field list. Summary:
   surface and drift-lock identity.
 - `capabilities` — `can_block`, `can_ask_native`, `ask_events`,
   `block_events`, `supports_fail_closed`, `scope`: the enforcement ceiling.
-- `wiring` — `targets`, `install_events`, `layout`, `container_key`, `matcher`,
-  `entry_template`, `ownership`, `extra_keys`: the config-patch recipe used by
-  Setup / verify / Teardown.
+- `wiring` — `targets`, `install_events`, `layout`, `command_invocation`,
+  `container_key`, `matcher`, `entry_template`, `ownership`, `extra_keys`: the
+  config-patch recipe used by Setup / verify / Teardown.
 - `response` — `response_field`, `exit_style`, `default_block_reason`,
-  `templates`: how a verdict renders into harness-native output and exit code.
+  `templates`, `failure`: how a verdict and response-layer failure render into
+  harness-native output and exit code.
 - `decode` — `field_map`, `event_aliases`: optional normalizer for non-flat
   payloads.
+- `surfaces` — optional connector-local MCP / skills / rules / plugins / agents
+  / CodeGuard / telemetry metadata consumed by setup, doctor, inventory, and
+  registry UX.
 - `provenance` — publisher/sha256/signature for drop-in trust.
 
 ### 3.4 Wiring layouts
@@ -267,6 +295,12 @@ nested_named        root[<owner_key_prefix><event>] = { event: [ { matcher, hook
                     e.g. { "defenseclaw-opencode-PreToolUse": { "PreToolUse": [ {matcher:"*", hooks:[{…}]} ] } }
 ```
 
+`wiring.command_invocation` declares how the harness invokes the configured
+command. Most harnesses execute through a shell and need a shell-escaped hook
+path; some execute a configured command directly and need a bare path. This is a
+manifest-level behavior because changing quoting can turn a valid config into a
+silent no-fire.
+
 `ownership.match` (and `ownership.owner_key_prefix` for `nested_named`) lets
 Setup be idempotent and lets Teardown remove only DefenseClaw's entries from a
 file that may contain unrelated hooks.
@@ -279,13 +313,14 @@ language — just these literal substitutions:
 
 | Token | Expands to | Valid in |
 | --- | --- | --- |
-| `${hook_command}` | Platform-correct hook invocation (installed script on Unix; `defenseclaw hook --connector <name>` on Windows) | wiring entry/extra |
+| `${hook_command}` | Platform-correct hook invocation, rendered according to `wiring.command_invocation` (`shell` means shell-escaped script path on Unix; `direct_exec` means a bare executable path; Windows uses the native `defenseclaw hook --connector <name>` entrypoint) | wiring entry/extra |
 | `${api_addr}` | Gateway host:port | wiring entry/extra |
 | `${fail_closed}` | `true`/`false` per resolved fail mode | wiring entry/extra |
 | `${reason}` | Verdict reason text | response output |
 | `${additional_context}` | Extra context for the agent | response output |
 | `${tool}` | Tool/command name | response output |
 | `${event}` | Canonical event name | response output |
+| `${raw_event}` | Harness-native event name before aliasing / surface mapping | response output |
 | `${severity}` | Verdict severity | response output |
 
 Substitution is **type-preserving when a value is exactly one token**: a value
@@ -299,10 +334,36 @@ gated `action` (and optionally `event`) wins. Its `output` object is rendered
 (tokens substituted) and returned under `response_field`. If no template
 matches, or `templates` is omitted, the built-in generic renderer is used.
 
+`response.failure` describes the same connector-native failure tails that
+`hookexec/spec.go` currently hardcodes: oversized payload while fail-closed,
+gateway unavailable under strict availability, and response-layer failures while
+fail-closed. A manifest cannot claim parity with a native connector unless these
+failure bodies and exit codes match too.
+
 ### 3.7 Decode
 
 For flat payloads, omit `decode`. For nested payloads, `decode.field_map` maps
-each canonical field to a dotted path (`toolCall.args`).
+each canonical field to one or more dotted paths (`toolCall.args`). The simple
+form is a string path:
+
+```yaml
+decode:
+  field_map:
+    tool_name: toolCall.name
+```
+
+The expanded form supports alternate paths and constrained conversions:
+
+```yaml
+decode:
+  field_map:
+    turn_id:
+      paths: [stepIdx, step_idx]
+      type: string
+    content:
+      paths: [messages.content]
+      join: "\n\n"
+```
 
 `decode.event_aliases` is **classification-only**: it tells the surface
 classifier that a harness-native event behaves like a known one (for example
@@ -310,6 +371,63 @@ classifier that a harness-native event behaves like a known one (for example
 does **not** rename the event used for capability gating or wiring —
 `capabilities.block_events`, `capabilities.ask_events`, and
 `wiring.install_events` always use the harness-native event names.
+
+Prefer `decode.event_surfaces` for new manifests when the desired surface is
+known directly (`pre_prompt: prompt`, `pre_tool: tool_call`). Use
+`event_aliases` only when compatibility with an existing built-in event's
+classification is intentional.
+
+`decode.event_inference` is intentionally constrained: rules may infer an event
+only from field presence, not arbitrary expressions. If a harness needs
+branching based on arbitrary payload values, multi-field computation, or
+protocol-specific state, use Tier 1 self-integration or a thin native connector.
+
+### 3.8 Surface metadata
+
+The manifest's `surfaces` section describes connector-local assets beyond hook
+delivery: MCP servers, skills, rules, plugins, agents, optional CodeGuard asset
+installation, and telemetry. This keeps setup, doctor, TUI, inventory, and
+registry UX consistent with the gateway. Hook-only custom harnesses may omit
+`surfaces`; managed first-party manifests should populate it so Python and Go do
+not maintain parallel hardcoded connector matrices.
+
+### 3.9 Semantic validation beyond JSON Schema
+
+The JSON Schema validates shape. The manifest loader must also reject semantic
+drift that JSON Schema cannot express cleanly:
+
+- `name` must not collide with built-ins, aliases, `generic`, or another loaded
+  manifest.
+- `capabilities.ask_events` requires `can_ask_native: true`.
+- `ask_events` and `block_events` must be subsets of `contract.events` or
+  explicitly marked future-wired via `wiring.install_events`.
+- `nested_named` requires `ownership.owner_key_prefix`; other layouts require a
+  stable `ownership.match` or default to the resolved hook command.
+- `response.response_field` must not collide with canonical response fields
+  (`action`, `raw_action`, `reason`, `mode`, `would_block`, etc.).
+- Every substitution token must be known for the section where it appears.
+- Every `wiring.target.path_template` must resolve under `$HOME` or the selected
+  workspace, never inside the DefenseClaw data dir, and symlinks must be
+  resolved before the allowlist check.
+- Drop-in provenance is all-or-nothing for enforcement: `sha256`, `signature`,
+  `signature_alg`, and `public_key_id` must verify together before action mode
+  is allowed without an explicit operator override.
+
+### 3.10 Registration model
+
+A manifest loads into a real connector object that implements the same local
+interfaces as built-ins:
+
+- `Connector` for setup, teardown, auth, and clean verification.
+- `HookEndpoint` for `/api/v1/<name>/hook`.
+- `HookProfileProvider` for decode, verdict mapping, response rendering, and
+  compatibility metadata.
+- `ConnectorCapabilityProvider`, `AgentPathProvider`, and
+  `ComponentScanner` when `surfaces` are present.
+
+The gateway route registrar should be able to attach the existing unified hook
+handler to any registered connector with a `HookEndpoint` and a `HookProfile`;
+manifest connectors must not need a per-name `registerHookHandler()` init block.
 
 ---
 
@@ -351,6 +469,10 @@ binary) but still pass schema validation.
 | Drop-in, verified provenance | yes | yes | yes | action (operator-confirmed) |
 | Drop-in, unverified | yes | yes | n/a | observe |
 
+The generic Tier-1 route is not a trust tier for managed connectors. It is a
+wire compatibility endpoint for self-integrators and must not register, shadow,
+or impersonate connector identities.
+
 ---
 
 ## 5. Parity with native connectors
@@ -367,11 +489,14 @@ section):
 - `HookCapability` (block/ask events, scope, fail-closed) ↔ `capabilities`.
 - `HookContract` (version bounds, script version, events, AID surfaces) ↔
   `contract`.
-- `hookexec` decision style ↔ `response.exit_style`.
+- `hookexec` decision style and failure tails ↔ `response.exit_style` +
+  `response.failure`.
+- `ConnectorCapabilities` / component discovery ↔ `surfaces`.
 
 The acceptance bar: re-expressing a built-in (for example `cursor`) as a
-manifest yields byte-identical installed config, the same wire verdicts, and the
-same exit codes as the native connector.
+manifest yields byte-identical installed config, the same wire verdicts, the
+same failure responses, the same exit codes, and equivalent setup/doctor
+metadata as the native connector.
 
 ---
 

--- a/docs/HOOK-CONNECTOR-CONTRACT.md
+++ b/docs/HOOK-CONNECTOR-CONTRACT.md
@@ -1,0 +1,400 @@
+# DefenseClaw — Hook Connector Contract
+
+This document is the public, version-controlled contract for integrating any
+hook-capable agent harness with DefenseClaw **without writing a native (Go)
+connector**. It defines two layers that build on each other:
+
+- **Tier 1 — the hook wire contract.** A stable HTTP request/response and
+  exit-code contract. Any harness that can run a script (or an HTTP call) on a
+  lifecycle event can self-integrate against this contract with no DefenseClaw
+  code at all. This tier is *spec only*: you implement the small client side.
+- **Tier 2 — the declarative connector manifest.** A single data file
+  (`hook-connector-manifest.json`, validated by
+  [`schemas/hook-connector-manifest.json`](../schemas/hook-connector-manifest.json))
+  that teaches DefenseClaw how to discover, install, decode, evaluate, and
+  respond for a harness. Dropping a manifest auto-registers a full connector —
+  discovery, config patching, the `/api/v1/<name>/hook` route, verdict
+  rendering, and teardown — with **no new Go code per harness**.
+
+Both tiers describe the *same* runtime pipeline. Tier 1 is what the harness
+sends and receives on the wire; Tier 2 is how DefenseClaw is configured to
+produce and interpret that wire traffic on behalf of a harness that cannot
+hand-roll it.
+
+> Status: design contract. This file and the JSON Schema define the target
+> behavior; the engine that consumes manifests is implemented separately.
+
+---
+
+## 1. Which tier do I want?
+
+| You are… | Use | Why |
+| --- | --- | --- |
+| A harness author who can ship a hook/script that calls an HTTP endpoint | Tier 1 | Self-contained; you own the client; DefenseClaw needs nothing. |
+| An operator who wants DefenseClaw to *manage* (install, verify, remove, decode, render) a harness's hooks for you | Tier 2 | DefenseClaw does the wiring; you ship a manifest, not code. |
+| DefenseClaw maintainers adding a first-party harness with no special behavior | Tier 2 (embedded) | New harness ships as embedded data, not a new connector package. |
+
+Tier 2 is strictly more capable and is what powers managed connectors. Tier 1
+exists so a harness can integrate even when nobody has written a manifest for
+it yet.
+
+---
+
+## 2. Tier 1 — the hook wire contract
+
+### 2.1 Endpoint
+
+```
+POST http://127.0.0.1:18970/api/v1/<connector>/hook
+```
+
+- `<connector>` is the connector name (built-in name, or a manifest `name`).
+- The gateway binds to loopback by default. The address is discoverable from
+  the gateway-written hook environment / token files; do not hardcode a remote
+  host.
+- A generic, connector-agnostic alias is also defined for harnesses that
+  self-wire without a manifest:
+
+```
+POST http://127.0.0.1:18970/api/v1/hook        (connector via ?connector=<name> or X-DefenseClaw-Connector header)
+```
+
+When the connector cannot be resolved, the gateway falls back to a generic
+profile (flat decode, generic render) so the call still produces a valid
+verdict.
+
+### 2.2 Request headers
+
+| Header | Required | Purpose |
+| --- | --- | --- |
+| `Content-Type: application/json` | yes | Body is a single JSON object. |
+| `Authorization: Bearer <token>` | yes when a token exists | Gateway hook token. Read from the gateway-provisioned hook token file / env. Loopback calls without a token are accepted with a logged warning to keep first-run UX working, but a token is the supported posture. |
+| `X-DefenseClaw-Client: <name>-hook/<v>` | yes | CSRF / origin marker. Mutating hook calls require a recognized client marker. |
+| `traceparent` / `tracestate` | optional | W3C trace context. When present and the contract advertises `supports_traceparent`, the gateway continues the remote trace instead of minting a new root span. |
+| `X-DefenseClaw-Session-Id` | optional | Stable session correlation when the payload has no session id. |
+| `X-DefenseClaw-Run-Id`, `X-DefenseClaw-Agent-Id` | optional | Additional correlation dimensions surfaced on telemetry. |
+
+### 2.3 Request body — canonical fields
+
+The body is the harness's own event JSON. DefenseClaw normalizes it into a
+canonical request. For a **flat** payload, populate any of the accepted keys
+below (first non-empty wins); for a non-flat payload, a Tier-2 `decode.field_map`
+maps your shape onto these canonical fields.
+
+| Canonical field | Accepted source keys (flat payload) | Meaning |
+| --- | --- | --- |
+| event | `hook_event_name`, `hookEventName`, `event_type`, `event`, `type` | Lifecycle event name. |
+| session_id | `session_id`, `sessionId`, `conversation_id`, `task_id`, `thread_id` | Session/conversation correlation. |
+| turn_id | `turn_id`, `turnId`, `step_id` | Per-turn correlation. |
+| tool_name | `tool_name`, `toolName`, `command_name`, `name` | Tool/command about to run or just ran. |
+| tool_input | `tool_input`, `tool_args`, `arguments`, `args`, `input` | Tool arguments / command body. |
+| content | `prompt`, `user_prompt`, `message`, `text`, `content` | Prompt or message text for prompt-class events. |
+| cwd | `cwd`, `working_directory` | Working directory, if provided. |
+| model | `model`, `model_id` | Model identifier, if provided. |
+
+Events are classified into surfaces — **prompt** (user prompt submitted),
+**tool_call** (a tool/command is about to run), **tool_result** (a tool/command
+just completed), and **event_content** (generic) — which selects what the
+gateway inspects.
+
+### 2.4 Response body — canonical verdict
+
+`200 OK` with a JSON object:
+
+```jsonc
+{
+  "action": "allow",            // allow | block | alert | confirm (post-capability-gating)
+  "raw_action": "block",        // pre-downgrade action (e.g. before observe-mode allow)
+  "would_block": true,          // true when the verdict represents a block posture
+  "severity": "HIGH",           // CRITICAL|HIGH|MEDIUM|LOW|INFO|WARN|ERROR|NONE
+  "mode": "action",             // action | observe
+  "reason": "…redacted human-readable reason…",
+  "additional_context": "…optional extra context to surface to the agent…",
+  "evaluation_id": "…",         // correlation id for the decision
+  "<response_field>": { … }     // harness-native output map (see 2.6); key name is per-connector
+}
+```
+
+`<response_field>` (e.g. `hook_output`, `codex_output`) carries the object the
+harness actually understands. A Tier-1 self-integrator can ignore the canonical
+fields and read only `<response_field>`, or vice versa.
+
+### 2.5 Action semantics and capability gating
+
+| action | Meaning | Gating |
+| --- | --- | --- |
+| `allow` | Proceed. | Always permitted. |
+| `block` | Stop the pending action. | Only enforced on events the connector declares blockable; otherwise downgraded to `allow` with `would_block=true`. |
+| `confirm` | Ask a human to approve. | Only when the connector advertises native ask **and** the event is ask-capable; otherwise downgraded to `alert`. |
+| `alert` | Surface a warning, proceed. | Always permitted. |
+
+The gateway never asks a harness to do something it cannot do: a manifest's
+`capabilities` (`can_block`, `can_ask_native`, `ask_events`, `block_events`)
+are the ceiling. `raw_action` preserves the pre-gating intent for audit.
+
+### 2.6 Exit-code styles
+
+Hook scripts translate a `200 OK` into stdout + a process exit code that the
+harness understands. Five styles cover the known harness families:
+
+| Style | stdout | Exit code | Used when |
+| --- | --- | --- | --- |
+| `hook_echo` | echo `<response_field>` JSON verbatim | `0` | The decision is fully encoded inside the JSON (harness reads JSON, not exit code). |
+| `hook_echo_decision` | echo `<response_field>` JSON | `2` if its decision is deny/block, else `0` | Harness reads JSON *and* exit code. |
+| `action_stderr` | none | `2` on block (reason to stderr), else `0` | Harness keys purely off exit code + stderr. |
+| `claude_code` | vendor JSON | vendor codes | Claude Code's documented hook protocol. |
+| `codex` | vendor JSON | vendor codes | Codex's documented hook protocol. |
+
+On non-2xx or transport failure, the hook applies its **fail mode**:
+
+- Fail-open (default): exit `0` (allow) so a gateway outage never bricks the
+  agent.
+- Fail-closed: exit non-zero (deny) — only when the connector
+  `supports_fail_closed` and the operator opted in
+  (`DEFENSECLAW_FAIL_MODE=closed`).
+- Strict availability (`DEFENSECLAW_STRICT_AVAILABILITY=1`): treat an
+  unreachable gateway as fail-closed regardless of the per-event fail mode.
+
+### 2.7 Minimal Tier-1 flow
+
+```
+ harness            hook client                gateway
+   │ lifecycle event   │                          │
+   │──────────────────▶│ read event JSON (stdin)  │
+   │                   │ POST /api/v1/<name>/hook  │
+   │                   │  Authorization: Bearer …  │
+   │                   │  X-DefenseClaw-Client: …  │
+   │                   │──────────────────────────▶│ normalize → classify
+   │                   │                           │ evaluate policy/guardrail
+   │                   │                           │ gate by capabilities
+   │                   │◀──────────────────────────│ 200 {action, <response_field>}
+   │                   │ render per exit_style      │
+   │◀──────────────────│ stdout + exit code         │
+   │ enforce/proceed   │                            │
+```
+
+---
+
+## 3. Tier 2 — the declarative connector manifest
+
+A manifest is pure data; DefenseClaw interprets it with a constrained engine.
+There is **no executable code** in a manifest and no plugin `.so` to load — the
+engine only ever does data-shaped operations (read/patch known config files,
+map fields by dotted path, fill output templates). This is the key safety
+difference from native Go plugins.
+
+### 3.1 What a manifest replaces
+
+Adding a harness today touches many code sites. A manifest folds all of them
+into one file:
+
+| Native connector site | Manifest section |
+| --- | --- |
+| `NewXConnector()` + `registry.RegisterBuiltin` | `name`, `kind` (auto-registered) |
+| Agent discovery / version probe | `discovery` |
+| `HookContract` row in `hook_contracts.json` | `contract` |
+| `HookCapability` (block/ask events, scope) | `capabilities` |
+| `patchXHooks()` config writer | `wiring` |
+| `HookProfile.Decode` | `decode` |
+| `HookProfile.Respond` + `hookexec` style + `response_field` | `response` |
+| Per-connector `X-hook.sh` | `wiring.entry_template` + generic hook template |
+
+### 3.2 Loading model
+
+Two sources, one engine:
+
+```
+ ┌─────────────────────────────┐        ┌─────────────────────────────────┐
+ │ Embedded (first-party)      │        │ Drop-in (third-party / operator) │
+ │ shipped with the gateway    │        │ ~/.defenseclaw/connectors/*.json │
+ │ implicitly trusted          │        │ trust depends on provenance      │
+ └──────────────┬──────────────┘        └────────────────┬─────────────────┘
+                │           manifest loader (validate, gate, register)        │
+                └───────────────────────────┬────────────────────────────────┘
+                                             ▼
+                              one manifest connector per file
+                       (Connector + HookEndpoint + capability + paths)
+                                             ▼
+                          identical runtime path as native connectors
+                         (discovery → setup → /hook → verdict → teardown)
+```
+
+- **Embedded** manifests are baked into the gateway binary and are trusted the
+  same way built-in connectors are.
+- **Drop-in** manifests load from an operator-controlled directory (default
+  `~/.defenseclaw/connectors/`). They are subject to the full security gate in
+  §4 and default to observe mode unless verified.
+
+### 3.3 Manifest sections
+
+See [`schemas/hook-connector-manifest.json`](../schemas/hook-connector-manifest.json)
+for the authoritative field list. Summary:
+
+- `name`, `display_name`, `description`, `kind: "hook"` — identity. `name` is
+  the `/api/v1/<name>/hook` route and must not collide with a built-in.
+- `discovery` — `version_probe`, `binary_names`, `config_globs`,
+  `trusted_bin_prefixes`: how to detect the harness on a host.
+- `contract` — `contract_id`, `agent_version` bounds, `hook_script_version`,
+  `supports_traceparent`, `events`, `aid_surfaces`: the versioned compatibility
+  surface and drift-lock identity.
+- `capabilities` — `can_block`, `can_ask_native`, `ask_events`,
+  `block_events`, `supports_fail_closed`, `scope`: the enforcement ceiling.
+- `wiring` — `targets`, `install_events`, `layout`, `container_key`, `matcher`,
+  `entry_template`, `ownership`, `extra_keys`: the config-patch recipe used by
+  Setup / verify / Teardown.
+- `response` — `response_field`, `exit_style`, `default_block_reason`,
+  `templates`: how a verdict renders into harness-native output and exit code.
+- `decode` — `field_map`, `event_aliases`: optional normalizer for non-flat
+  payloads.
+- `provenance` — publisher/sha256/signature for drop-in trust.
+
+### 3.4 Wiring layouts
+
+Every known harness's hook config falls into one of four shapes. The
+`layout` enum selects the shape; `entry_template` is the leaf object inserted.
+
+```
+flat_map            container[event] = [ entry, … ]
+                    e.g. { "hooks": { "PreToolUse": [ {type:"command", command:"…"} ] } }
+
+grouped_matcher     container[event] = [ { matcher, hooks: [ entry, … ] } ]
+                    e.g. { "hooks": { "PreToolUse": [ {matcher:"*", hooks:[{…}]} ] } }
+
+top_level_grouped   root[event]      = [ { matcher, hooks: [ entry, … ] } ]
+                    (same as grouped_matcher but with no container key)
+
+nested_named        root[<owner_key_prefix><event>] = { event: [ { matcher, hooks:[entry] } ] }
+                    e.g. { "defenseclaw-opencode-PreToolUse": { "PreToolUse": [ {matcher:"*", hooks:[{…}]} ] } }
+```
+
+`ownership.match` (and `ownership.owner_key_prefix` for `nested_named`) lets
+Setup be idempotent and lets Teardown remove only DefenseClaw's entries from a
+file that may contain unrelated hooks.
+
+### 3.5 Substitution tokens
+
+String values in `wiring.entry_template`, `wiring.extra_keys`, and
+`response.templates[].output` support a fixed token set. No general expression
+language — just these literal substitutions:
+
+| Token | Expands to | Valid in |
+| --- | --- | --- |
+| `${hook_command}` | Platform-correct hook invocation (installed script on Unix; `defenseclaw hook --connector <name>` on Windows) | wiring entry/extra |
+| `${api_addr}` | Gateway host:port | wiring entry/extra |
+| `${fail_closed}` | `true`/`false` per resolved fail mode | wiring entry/extra |
+| `${reason}` | Verdict reason text | response output |
+| `${additional_context}` | Extra context for the agent | response output |
+| `${tool}` | Tool/command name | response output |
+| `${event}` | Canonical event name | response output |
+| `${severity}` | Verdict severity | response output |
+
+Substitution is **type-preserving when a value is exactly one token**: a value
+of `"${fail_closed}"` emits a JSON boolean (`true`/`false`), not the string
+`"true"`. Tokens embedded inside a larger string always render as text.
+
+### 3.6 Response templates
+
+`response.templates` is an ordered list; the first rule whose `when` matches the
+gated `action` (and optionally `event`) wins. Its `output` object is rendered
+(tokens substituted) and returned under `response_field`. If no template
+matches, or `templates` is omitted, the built-in generic renderer is used.
+
+### 3.7 Decode
+
+For flat payloads, omit `decode`. For nested payloads, `decode.field_map` maps
+each canonical field to a dotted path (`toolCall.args`).
+
+`decode.event_aliases` is **classification-only**: it tells the surface
+classifier that a harness-native event behaves like a known one (for example
+`pre_prompt` → `UserPromptSubmit`) so DefenseClaw inspects the right surface. It
+does **not** rename the event used for capability gating or wiring —
+`capabilities.block_events`, `capabilities.ask_events`, and
+`wiring.install_events` always use the harness-native event names.
+
+---
+
+## 4. Security and trust model
+
+Drop-in manifests can patch local config files and shape security decisions, so
+they are treated as untrusted input and run through a defense-in-depth gate.
+Embedded first-party manifests skip the trust checks (they ship in the signed
+binary) but still pass schema validation.
+
+### 4.1 Threat model
+
+- A malicious/compromised drop-in manifest tries to **shadow a built-in**
+  connector to intercept its hooks.
+- A manifest tries to **write outside** the user's home/workspace (path
+  traversal) or into the DefenseClaw data dir.
+- A manifest declares capabilities it should not have, or tries to silently run
+  in enforcing mode unverified.
+- A manifest file is tampered with after the operator placed it.
+
+### 4.2 Controls
+
+| Control | Enforcement |
+| --- | --- |
+| Schema validation | Every manifest must validate against `hook-connector-manifest.json` before registration; invalid manifests are rejected and audited. |
+| Name-collision guard | A drop-in `name` matching a built-in (or already-registered manifest) is refused — built-ins cannot be shadowed. |
+| Config-path allowlist | `wiring.targets` must resolve under `$HOME` or the selected workspace; targets resolving into the DefenseClaw data dir or absolute system paths are rejected. |
+| File ownership/permissions | The drop-in directory and manifest files must be owned by the user and not group/world-writable. |
+| Provenance verification | A drop-in may declare `provenance` (sha256 + detached signature). Signatures are verified against configured trusted keys. |
+| Observe-mode default | An **unverified** drop-in manifest is forced to observe mode (decisions logged, never enforced) unless the operator explicitly opts into enforcement. |
+| Capability ceiling | The gateway never blocks/asks beyond declared `capabilities`; `raw_action` records the intended action for audit. |
+| Audit emission | Manifest load, rejection, mode downgrade, and every hook decision emit audit events with the connector dimension. |
+
+### 4.3 Trust tiers
+
+| Source | Schema-validated | Path/permission gated | Signature required for enforce | Default mode |
+| --- | --- | --- | --- | --- |
+| Embedded (first-party) | yes | n/a | no | action |
+| Drop-in, verified provenance | yes | yes | yes | action (operator-confirmed) |
+| Drop-in, unverified | yes | yes | n/a | observe |
+
+---
+
+## 5. Parity with native connectors
+
+A manifest must be able to reproduce an existing native hook connector exactly.
+The mapping below is the parity checklist (each native structure ↔ manifest
+section):
+
+- `Connector` interface (`Name`/`Setup`/`Teardown`/`VerifyClean`) ↔ `name` +
+  `wiring`.
+- `HookEndpoint` route `/api/v1/<name>/hook` ↔ auto-registered from `name`.
+- `HookProfile` (`Decode`/`MapVerdict`/`Respond`, `ResponseFieldName`,
+  `SupportsTraceparent`) ↔ `decode` + `capabilities` + `response` + `contract`.
+- `HookCapability` (block/ask events, scope, fail-closed) ↔ `capabilities`.
+- `HookContract` (version bounds, script version, events, AID surfaces) ↔
+  `contract`.
+- `hookexec` decision style ↔ `response.exit_style`.
+
+The acceptance bar: re-expressing a built-in (for example `cursor`) as a
+manifest yields byte-identical installed config, the same wire verdicts, and the
+same exit codes as the native connector.
+
+---
+
+## 6. Worked examples
+
+- [`examples/cursor.manifest.yaml`](hook-connector-contract/examples/cursor.manifest.yaml)
+  — re-expresses the existing `cursor` connector as a manifest (parity target).
+- [`examples/opencode.manifest.yaml`](hook-connector-contract/examples/opencode.manifest.yaml)
+  — a net-new harness (OpenCode) integrated purely via manifest, exercising
+  `decode`, `nested_named` wiring, and `provenance`.
+
+> Examples are authored in YAML for readability; the on-disk and embedded form
+> is JSON validated by the schema. YAML and JSON are 1:1 here.
+
+---
+
+## 7. Non-goals (this contract version)
+
+- Manifests do not carry executable code, regexes-as-policy, or arbitrary
+  expressions — only the fixed token substitutions in §3.5.
+- Manifests do not configure proxy (LLM-interception) connectors; those remain
+  code-backed.
+- Native OTLP emission wiring stays code-backed; `contract.native_otlp` is
+  descriptive only in this version.
+- Per-harness bespoke approval UIs beyond the `confirm`/ask capability are out
+  of scope.

--- a/docs/hook-connector-contract/examples/cursor.manifest.yaml
+++ b/docs/hook-connector-contract/examples/cursor.manifest.yaml
@@ -91,6 +91,7 @@ wiring:
     - sessionEnd
     - preCompact
   layout: flat_map
+  command_invocation: shell
   container_key: hooks
   entry_template:
     type: command
@@ -123,7 +124,86 @@ response:
         continue: true
         permission: allow
         agent_message: "${additional_context}"
+  failure:
+    oversized_closed:
+      stdout:
+        continue: true
+        permission: deny
+        user_message: "DefenseClaw hook payload too large"
+        agent_message: "DefenseClaw hook payload too large"
+      exit_code: 2
+    unavailable_strict:
+      stdout:
+        continue: true
+        permission: deny
+        user_message: "DefenseClaw hook failed closed"
+        agent_message: "DefenseClaw hook failed closed"
+      exit_code: 2
+    response_closed:
+      stdout:
+        continue: true
+        permission: deny
+        user_message: "DefenseClaw hook failed closed"
+        agent_message: "DefenseClaw hook failed closed"
+      exit_code: 0
+
+surfaces:
+  mcp:
+    supported: true
+    scope: "workspace,user"
+    config_paths:
+      - "<workspace>/.cursor/mcp.json"
+      - "~/.cursor/mcp.json"
+    write_paths:
+      - "<workspace>/.cursor/mcp.json"
+    supports_backup: true
+    supports_restore: true
+  skills:
+    supported: true
+    scope: "workspace,user"
+    read_paths:
+      - "~/.cursor/skills"
+      - "~/.agents/skills"
+      - "<workspace>/.cursor/skills"
+      - "<workspace>/.agents/skills"
+    write_paths:
+      - "<workspace>/.cursor/skills"
+    install_targets: [skill]
+    requires_opt_in: true
+  rules:
+    supported: true
+    scope: workspace
+    read_paths:
+      - "<workspace>/.cursor/rules"
+      - "<workspace>/AGENTS.md"
+    write_paths:
+      - "<workspace>/.cursor/rules"
+    install_targets: [rule]
+    requires_opt_in: true
+  plugins:
+    supported: false
+    notes:
+      - "DefenseClaw plugins are an OpenClaw-only concept; this connector ships no plugin install surface."
+  agents:
+    supported: false
+    notes:
+      - "Cursor subagent installation is not a documented local surface for this connector."
+  codeguard:
+    supported: true
+    install_targets: [skill, rule]
+    opt_in_only: true
+    auto_install: false
+    idempotent: true
+    conflict_safe: true
+  telemetry:
+    native_otlp: false
+    hook_signals: [logs, metrics, traces]
+    auth_mode: header-token
+    source_modes: [hook]
+    notes:
+      - "Hook-generated telemetry is emitted by DefenseClaw for every hook invocation."
 
 notes:
   - "Cursor payloads are flat ({hook_event_name, tool_name, tool_input, prompt}), so no decode block is needed."
   - "exit_style hook_echo: the gateway encodes the decision inside hook_output; the hook echoes it and exits 0."
+  - "failure responses mirror hookexec/spec.go for cursor so manifest parity includes fail-closed and strict-availability behavior."

--- a/docs/hook-connector-contract/examples/cursor.manifest.yaml
+++ b/docs/hook-connector-contract/examples/cursor.manifest.yaml
@@ -1,0 +1,129 @@
+# Parity re-expression of the built-in `cursor` connector as a declarative
+# manifest. The acceptance bar for the manifest engine is that this file
+# produces byte-identical installed config, the same wire verdicts, and the
+# same exit codes as the native cursor connector.
+#
+# Native sources this mirrors:
+#   - wiring:   internal/gateway/connector/hook_only.go  (patchCursorHooks)
+#   - render:   internal/gateway/connector/hook_only_profile.go (case "cursor")
+#   - exit:     internal/gateway/connector/hookexec/spec.go (specs["cursor"])
+#   - contract: cli/defenseclaw/inventory/hook_contracts.json (connectors.cursor)
+#
+# Authored in YAML for readability; the on-disk/embedded form is JSON validated
+# by schemas/hook-connector-manifest.json.
+
+schema_version: 1
+name: cursor
+display_name: Cursor
+description: Cursor IDE agent-loop hooks (1.7+) forwarded to the DefenseClaw gateway.
+kind: hook
+homepage: https://cursor.com
+
+discovery:
+  version_probe: cursor --version
+  binary_names: [cursor]
+  config_globs:
+    - "~/.cursor/hooks.json"
+
+contract:
+  contract_id: cursor-hooks-v1
+  agent_version:
+    min_inclusive: "1.7.0"
+    max_exclusive: ""
+  default_for_unversioned: true
+  hook_script_version: v6
+  supports_traceparent: true
+  native_otlp: false
+  events:
+    - preToolUse
+    - beforeShellExecution
+    - beforeMCPExecution
+    - beforeReadFile
+    - beforeTabFileRead
+    - beforeSubmitPrompt
+    - stop
+  aid_surfaces: [prompt, tool_call, tool_result]
+  notes:
+    - "Cursor 1.7 introduced beta hooks for the agent loop."
+    - "Cursor native ask is limited to beforeShellExecution and beforeMCPExecution."
+
+capabilities:
+  can_block: true
+  can_ask_native: true
+  ask_events:
+    - beforeShellExecution
+    - beforeMCPExecution
+  block_events:
+    - preToolUse
+    - beforeShellExecution
+    - beforeMCPExecution
+    - beforeReadFile
+    - beforeTabFileRead
+    - beforeSubmitPrompt
+    - stop
+  supports_fail_closed: true
+  scope: user
+
+wiring:
+  targets:
+    - path_template: "~/.cursor/hooks.json"
+      format: json
+      scope: user
+  # Superset of contract.events: setup wires every event Cursor can emit so a
+  # future contract bump needs no re-install. Matches patchCursorHooks().
+  install_events:
+    - preToolUse
+    - postToolUse
+    - postToolUseFailure
+    - beforeShellExecution
+    - beforeMCPExecution
+    - afterShellExecution
+    - afterMCPExecution
+    - beforeReadFile
+    - beforeTabFileRead
+    - afterFileEdit
+    - afterTabFileEdit
+    - beforeSubmitPrompt
+    - afterAgentResponse
+    - afterAgentThought
+    - stop
+    - sessionStart
+    - sessionEnd
+    - preCompact
+  layout: flat_map
+  container_key: hooks
+  entry_template:
+    type: command
+    command: "${hook_command}"
+    timeout: 30000
+    failClosed: "${fail_closed}"   # single-token value -> emitted as JSON boolean
+  ownership:
+    match: "${hook_command}"
+  extra_keys:
+    version: 1
+
+response:
+  response_field: hook_output
+  exit_style: hook_echo
+  templates:
+    - when: { actions: [block] }
+      output:
+        continue: true
+        permission: deny
+        user_message: "${reason}"
+        agent_message: "${reason}"
+    - when: { actions: [confirm] }
+      output:
+        continue: true
+        permission: ask
+        user_message: "${reason}"
+        agent_message: "${reason}"
+    - when: { actions: [alert] }
+      output:
+        continue: true
+        permission: allow
+        agent_message: "${additional_context}"
+
+notes:
+  - "Cursor payloads are flat ({hook_event_name, tool_name, tool_input, prompt}), so no decode block is needed."
+  - "exit_style hook_echo: the gateway encodes the decision inside hook_output; the hook echoes it and exits 0."

--- a/docs/hook-connector-contract/examples/opencode.manifest.yaml
+++ b/docs/hook-connector-contract/examples/opencode.manifest.yaml
@@ -73,6 +73,7 @@ wiring:
   # removes only DefenseClaw's entries from a file that may hold others.
   #   { "defenseclaw-opencode-pre_tool": { "pre_tool": [ {matcher, hooks:[entry]} ] } }
   layout: nested_named
+  command_invocation: shell
   matcher: "*"
   entry_template:
     type: command
@@ -85,20 +86,49 @@ decode:
   # Map the harness's nested payload onto canonical fields via dotted paths.
   field_map:
     hook_event_name: event.type
-    session_id: session.id
-    turn_id: session.turn
-    tool_name: payload.tool.name
-    tool_input: payload.tool.arguments
-    content: payload.prompt.text
-    cwd: session.cwd
-    model: session.model
-  # Classification-only: tells the surface classifier how each native event
-  # behaves. Capability gating + wiring still use the native event names above.
+    session_id:
+      paths: [session.id, conversation.id]
+      type: string
+    turn_id:
+      paths: [session.turn, stepIdx, step_idx]
+      type: string
+    tool_name:
+      paths: [payload.tool.name, toolCall.name]
+      type: string
+    tool_input:
+      paths: [payload.tool.arguments, toolCall.args]
+      type: json
+    content:
+      paths: [payload.prompt.text, prompt.text, message.text]
+      type: string
+    cwd:
+      paths: [session.cwd, workspace.cwd]
+      type: string
+    model:
+      paths: [session.model, model.id]
+      type: string
+  # Preferred for new manifests: classify native events directly by surface.
+  # Capability gating + wiring still use the native event names above.
+  event_surfaces:
+    pre_prompt: prompt
+    pre_tool: tool_call
+    post_tool: tool_result
+    session_idle: event_content
+  # Optional compatibility aliases when downstream reports want to group these
+  # events with the nearest built-in hook family.
   event_aliases:
     pre_prompt: UserPromptSubmit
     pre_tool: PreToolUse
     post_tool: PostToolUse
     session_idle: Stop
+  # Fallback only when the payload omits event.type.
+  event_inference:
+    - event: pre_tool
+      surface: tool_call
+      when_path_exists: [payload.tool.name, toolCall.name]
+    - event: pre_prompt
+      surface: prompt
+      when_path_exists: [payload.prompt.text, prompt.text]
 
 response:
   response_field: hook_output
@@ -113,6 +143,47 @@ response:
       output:
         decision: allow
         additional_context: "${additional_context}"
+  failure:
+    oversized_closed:
+      stdout:
+        decision: deny
+        reason: "DefenseClaw hook payload too large"
+      exit_code: 2
+    unavailable_strict:
+      stdout:
+        decision: deny
+        reason: "DefenseClaw hook failed closed"
+      exit_code: 2
+    response_closed:
+      stdout:
+        decision: deny
+        reason: "DefenseClaw hook failed closed"
+      exit_code: 2
+
+surfaces:
+  mcp:
+    supported: false
+    notes:
+      - "Illustrative manifest manages hooks only; OpenCode MCP config paths must be verified before declaring this surface."
+  skills:
+    supported: false
+  rules:
+    supported: false
+  plugins:
+    supported: false
+  agents:
+    supported: false
+  codeguard:
+    supported: false
+    opt_in_only: true
+    auto_install: false
+    idempotent: true
+    conflict_safe: true
+  telemetry:
+    native_otlp: false
+    hook_signals: [logs, metrics, traces]
+    auth_mode: header-token
+    source_modes: [hook]
 
 provenance:
   publisher: "DefenseClaw community connectors"

--- a/docs/hook-connector-contract/examples/opencode.manifest.yaml
+++ b/docs/hook-connector-contract/examples/opencode.manifest.yaml
@@ -1,0 +1,127 @@
+# Net-new harness integrated purely via a drop-in manifest (no DefenseClaw Go
+# code). This exercises the parts of the schema the cursor parity example does
+# not: a nested payload `decode.field_map`, the `nested_named` wiring layout,
+# custom response templates, and signed `provenance` for action-mode trust.
+#
+# ILLUSTRATIVE: the OpenCode event names, payload shape, and config layout used
+# here are plausible placeholders chosen to stress the schema, not a verified
+# OpenCode hook contract. Treat this file as a schema demonstration and a
+# template for authoring a real drop-in manifest.
+#
+# Authored in YAML for readability; the on-disk/drop-in form is JSON validated
+# by schemas/hook-connector-manifest.json.
+
+schema_version: 1
+name: opencode
+display_name: OpenCode
+description: Drop-in manifest integrating the OpenCode terminal agent via lifecycle hooks.
+kind: hook
+homepage: https://opencode.ai
+docs_url: https://opencode.ai/docs
+
+discovery:
+  version_probe: opencode --version
+  binary_names: [opencode]
+  config_globs:
+    - "<workspace>/.opencode/hooks.json"
+    - "~/.config/opencode/hooks.json"
+
+contract:
+  contract_id: opencode-hooks-v1
+  agent_version:
+    min_inclusive: "0.4.0"
+    max_exclusive: ""
+  default_for_unversioned: true
+  hook_script_version: v1
+  supports_traceparent: true
+  native_otlp: false
+  events:
+    - pre_prompt
+    - pre_tool
+    - post_tool
+    - session_idle
+  aid_surfaces: [prompt, tool_call, tool_result]
+  notes:
+    - "OpenCode emits a nested event payload; decode.field_map flattens it onto DefenseClaw canonical fields."
+
+capabilities:
+  can_block: true
+  can_ask_native: false      # no documented native ask surface -> confirm downgrades to alert
+  ask_events: []
+  block_events:
+    - pre_prompt
+    - pre_tool
+  supports_fail_closed: true
+  scope: "user,workspace"
+
+wiring:
+  # First writable, in-scope target wins. A pinned workspace gets the repo-local
+  # file; otherwise the per-user config is patched.
+  targets:
+    - path_template: "<workspace>/.opencode/hooks.json"
+      format: json
+      scope: workspace
+    - path_template: "~/.config/opencode/hooks.json"
+      format: json
+      scope: user
+  install_events:
+    - pre_prompt
+    - pre_tool
+    - post_tool
+    - session_idle
+  # nested_named: each event lives under a stable per-event outer key so teardown
+  # removes only DefenseClaw's entries from a file that may hold others.
+  #   { "defenseclaw-opencode-pre_tool": { "pre_tool": [ {matcher, hooks:[entry]} ] } }
+  layout: nested_named
+  matcher: "*"
+  entry_template:
+    type: command
+    command: "${hook_command}"
+    fail_closed: "${fail_closed}"   # single-token value -> emitted as JSON boolean
+  ownership:
+    owner_key_prefix: "defenseclaw-opencode-"
+
+decode:
+  # Map the harness's nested payload onto canonical fields via dotted paths.
+  field_map:
+    hook_event_name: event.type
+    session_id: session.id
+    turn_id: session.turn
+    tool_name: payload.tool.name
+    tool_input: payload.tool.arguments
+    content: payload.prompt.text
+    cwd: session.cwd
+    model: session.model
+  # Classification-only: tells the surface classifier how each native event
+  # behaves. Capability gating + wiring still use the native event names above.
+  event_aliases:
+    pre_prompt: UserPromptSubmit
+    pre_tool: PreToolUse
+    post_tool: PostToolUse
+    session_idle: Stop
+
+response:
+  response_field: hook_output
+  exit_style: hook_echo_decision   # echo hook_output, exit 2 when decision is deny/block
+  default_block_reason: "Blocked by DefenseClaw OpenCode policy."
+  templates:
+    - when: { actions: [block] }
+      output:
+        decision: deny
+        reason: "${reason}"
+    - when: { actions: [alert] }
+      output:
+        decision: allow
+        additional_context: "${additional_context}"
+
+provenance:
+  publisher: "DefenseClaw community connectors"
+  # sha256 over the canonicalized manifest bytes (excluding provenance.signature).
+  sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+  signature: "BASE64_DETACHED_SIGNATURE_PLACEHOLDER"
+  signature_alg: ed25519
+  public_key_id: "defenseclaw-community-2026"
+
+notes:
+  - "Drop-in trust: with valid provenance verified against a configured trusted key, this connector may run in action (enforcing) mode. Unverified, it is forced to observe mode (decisions logged, never enforced)."
+  - "name 'opencode' must not collide with a built-in; the registry refuses shadowing registrations."

--- a/schemas/hook-connector-manifest.json
+++ b/schemas/hook-connector-manifest.json
@@ -1,0 +1,378 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://defenseclaw.io/schemas/hook-connector-manifest.json",
+  "title": "DefenseClaw Hook Connector Manifest",
+  "description": "Declarative description of a hook-based agent harness connector. A manifest lets DefenseClaw discover, install, decode, evaluate, and respond to a harness's lifecycle hooks without a bespoke native (Go) connector. Manifests load from a first-party embedded set shipped with the gateway and from an operator-managed drop-in directory (default ~/.defenseclaw/connectors/). Manifests are pure data interpreted by a constrained engine; they never carry executable code.",
+  "type": "object",
+  "required": ["schema_version", "name", "kind", "contract", "capabilities", "wiring", "response"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Manifest format version. Bump only for incompatible manifest-shape changes."
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_-]{0,63}$",
+      "description": "Connector identifier and hook route segment (/api/v1/<name>/hook). Must not collide with a built-in connector name; the registry refuses shadowing registrations."
+    },
+    "display_name": {
+      "type": "string",
+      "maxLength": 128,
+      "description": "Human-facing harness name shown in setup/doctor output."
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 512,
+      "description": "One-line summary of the harness and what DefenseClaw wires for it."
+    },
+    "kind": {
+      "type": "string",
+      "const": "hook",
+      "description": "Manifest connectors describe hook-based integrations only. Proxy connectors remain code-backed."
+    },
+    "homepage": { "type": "string", "format": "uri", "maxLength": 512 },
+    "docs_url": { "type": "string", "format": "uri", "maxLength": 512 },
+    "discovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "How DefenseClaw detects whether this harness is installed on the host (feeds agent discovery and setup gating).",
+      "properties": {
+        "version_probe": {
+          "type": "string",
+          "maxLength": 256,
+          "description": "Command run to read the harness version, for example 'opencode --version'. The first token must be the binary; arguments are passed verbatim. DefenseClaw resolves the binary on PATH under trusted prefixes only."
+        },
+        "binary_names": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 128 },
+          "maxItems": 16,
+          "uniqueItems": true,
+          "description": "Executable names looked up on PATH to detect installation."
+        },
+        "config_globs": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 512 },
+          "maxItems": 32,
+          "uniqueItems": true,
+          "description": "Path templates (~ and <workspace> expanded) whose existence implies the harness is installed."
+        },
+        "trusted_bin_prefixes": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 512 },
+          "maxItems": 32,
+          "uniqueItems": true,
+          "description": "Optional additional trusted install-prefix allowlist for the probed binary. The built-in default prefixes always apply; this only extends them."
+        }
+      }
+    },
+    "contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contract_id", "events"],
+      "description": "Versioned compatibility contract. DefenseClaw resolves the installed harness version to one contract before deciding what is blockable/askable/inspectable.",
+      "properties": {
+        "contract_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$",
+          "description": "Stable identifier for this hook surface, for example 'opencode-hooks-v1'. Recorded in the runtime hook-contract lock for drift detection."
+        },
+        "agent_version": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Inclusive lower / exclusive upper version bounds the contract applies to. Empty bounds mean open-ended.",
+          "properties": {
+            "min_inclusive": { "type": "string", "maxLength": 64 },
+            "max_exclusive": { "type": "string", "maxLength": 64 }
+          }
+        },
+        "default_for_unversioned": {
+          "type": "boolean",
+          "default": true,
+          "description": "When the harness version cannot be probed, use this contract. Exactly one contract per connector should set this."
+        },
+        "hook_script_version": {
+          "type": "string",
+          "maxLength": 32,
+          "description": "Version tag stamped into the installed hook script and audit envelope for provenance."
+        },
+        "supports_traceparent": {
+          "type": "boolean",
+          "default": true,
+          "description": "True when the installed hook forwards W3C traceparent/tracestate so the gateway continues the remote trace instead of minting a fresh root span."
+        },
+        "native_otlp": {
+          "type": "boolean",
+          "default": false,
+          "description": "Descriptive only in this schema version: declares the harness can emit native OTLP. Native OTLP wiring itself remains code-backed."
+        },
+        "events": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 128 },
+          "minItems": 1,
+          "maxItems": 128,
+          "uniqueItems": true,
+          "description": "Harness-native lifecycle event names this contract recognizes (for example PreToolUse, beforeShellExecution, pre_tool_call)."
+        },
+        "aid_surfaces": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["prompt", "tool_call", "tool_result", "event_content"] },
+          "maxItems": 8,
+          "uniqueItems": true,
+          "description": "Inspection target categories DefenseClaw exposes for this connector's AI discovery surface."
+        },
+        "notes": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 1024 },
+          "maxItems": 32
+        }
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["can_block"],
+      "description": "The lifecycle controls this harness can actually exercise. The gateway never escalates beyond what is declared here: a verdict cannot block on an event absent from block_events, and cannot ask natively unless can_ask_native and the event is in ask_events.",
+      "properties": {
+        "can_block": {
+          "type": "boolean",
+          "description": "True when the harness can stop a pending action from a hook decision."
+        },
+        "can_ask_native": {
+          "type": "boolean",
+          "default": false,
+          "description": "True when the harness can surface a native human-approval prompt from a hook decision."
+        },
+        "ask_events": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 128 },
+          "maxItems": 128,
+          "uniqueItems": true,
+          "description": "Subset of events on which a 'confirm' verdict renders as a native ask. Events outside this set downgrade confirm to alert."
+        },
+        "block_events": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 128 },
+          "maxItems": 128,
+          "uniqueItems": true,
+          "description": "Events on which a 'block' verdict is enforceable. Block verdicts on other events downgrade to allow with would_block=true."
+        },
+        "supports_fail_closed": {
+          "type": "boolean",
+          "default": false,
+          "description": "True when the harness honors a fail-closed (deny on hook error) posture; gates whether setup may install fail-closed wiring."
+        },
+        "scope": {
+          "type": "string",
+          "enum": ["user", "workspace", "user,workspace", "workspace,user"],
+          "default": "user",
+          "description": "Where the harness reads hook configuration."
+        }
+      }
+    },
+    "wiring": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["targets", "install_events", "layout", "entry_template"],
+      "description": "Declarative recipe DefenseClaw uses to install (Setup), verify, and remove (Teardown) the hook entries in the harness's own configuration file.",
+      "properties": {
+        "targets": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 8,
+          "description": "Candidate config files to patch. The first writable, in-scope target is used. Paths must resolve under $HOME or the selected workspace; targets resolving inside the DefenseClaw data dir or to absolute system paths are rejected.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path_template", "format"],
+            "properties": {
+              "path_template": {
+                "type": "string",
+                "maxLength": 512,
+                "description": "Config path with ~ (home) and <workspace> (selected workspace root) placeholders, for example '~/.cursor/hooks.json' or '<workspace>/.github/hooks/defenseclaw.json'."
+              },
+              "format": { "type": "string", "enum": ["json", "yaml", "toml"] },
+              "scope": { "type": "string", "enum": ["user", "workspace"], "default": "user" }
+            }
+          }
+        },
+        "install_events": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 128 },
+          "minItems": 1,
+          "maxItems": 128,
+          "uniqueItems": true,
+          "description": "Events to register in the harness config. May be a superset of contract.events so future events are wired ahead of upstream emitting them."
+        },
+        "layout": {
+          "type": "string",
+          "enum": ["flat_map", "grouped_matcher", "top_level_grouped", "nested_named"],
+          "description": "Shape of the inserted hook configuration. flat_map: container[event]=[entry...]. grouped_matcher: container[event]=[{matcher,hooks:[entry...]}]. top_level_grouped: root[event]=[{matcher,hooks:[entry...]}] (no container key). nested_named: root[<owner_key_prefix><event>]={event:[{matcher,hooks:[entry...]}]}."
+        },
+        "container_key": {
+          "type": "string",
+          "maxLength": 64,
+          "default": "hooks",
+          "description": "Parent object key under which events are written for flat_map and grouped_matcher layouts. Ignored by top_level_grouped and nested_named."
+        },
+        "matcher": {
+          "type": "string",
+          "maxLength": 128,
+          "default": "*",
+          "description": "Matcher value used by grouped_matcher / top_level_grouped / nested_named layouts."
+        },
+        "entry_template": {
+          "type": "object",
+          "description": "The per-event command entry object to insert. String values support the tokens ${hook_command}, ${api_addr}, and ${fail_closed}. ${hook_command} resolves to the platform-correct invocation (the installed shell script on Unix, the native 'defenseclaw hook --connector <name>' on Windows).",
+          "minProperties": 1
+        },
+        "ownership": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "How DefenseClaw recognizes its own entries for idempotent re-setup and clean teardown without disturbing third-party entries in the same file.",
+          "properties": {
+            "match": {
+              "type": "string",
+              "maxLength": 256,
+              "description": "Substring that identifies a DefenseClaw-owned entry. Defaults to the installed hook command/script path."
+            },
+            "owner_key_prefix": {
+              "type": "string",
+              "maxLength": 128,
+              "description": "Required for nested_named layout: the stable per-event outer key prefix, for example 'defenseclaw-opencode-'."
+            }
+          }
+        },
+        "extra_keys": {
+          "type": "object",
+          "description": "Optional fixed top-level keys to set on the config root, for example {\"version\": 1}. Applied additively and removed on teardown only if DefenseClaw set them.",
+          "additionalProperties": true
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exit_style"],
+      "description": "Declarative rendering of the gateway verdict into the harness-native hook response and process exit behavior.",
+      "properties": {
+        "response_field": {
+          "type": "string",
+          "maxLength": 64,
+          "default": "hook_output",
+          "description": "Top-level JSON key under which the harness-native output map is returned in the HTTP response and echoed by the hook to stdout."
+        },
+        "exit_style": {
+          "type": "string",
+          "enum": ["hook_echo", "hook_echo_decision", "action_stderr", "claude_code", "codex"],
+          "description": "How the hook turns a 2xx gateway response into stdout + exit code. hook_echo: echo response_field, exit 0 (decision already encoded in the JSON). hook_echo_decision: echo response_field, exit 2 when its decision is deny/block. action_stderr: no stdout echo, write reason to stderr + exit 2 on block. claude_code / codex: vendor-specific tails."
+        },
+        "default_block_reason": {
+          "type": "string",
+          "maxLength": 512,
+          "description": "Reason text used when a block verdict carries no upstream reason."
+        },
+        "templates": {
+          "type": "array",
+          "maxItems": 64,
+          "description": "Ordered rules mapping a (verdict action, event) to the harness-native output object. The first matching rule wins. Omit to fall back to the built-in generic renderer.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["when", "output"],
+            "properties": {
+              "when": {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Match predicate. An empty predicate matches everything. actions and events are matched after canonicalization.",
+                "properties": {
+                  "actions": {
+                    "type": "array",
+                    "items": { "type": "string", "enum": ["allow", "block", "alert", "confirm"] },
+                    "maxItems": 4,
+                    "uniqueItems": true
+                  },
+                  "events": {
+                    "type": "array",
+                    "items": { "type": "string", "maxLength": 128 },
+                    "maxItems": 128,
+                    "uniqueItems": true
+                  }
+                }
+              },
+              "output": {
+                "type": "object",
+                "minProperties": 1,
+                "description": "Harness-native output object emitted under response_field. String values support the tokens ${reason}, ${additional_context}, ${tool}, ${event}, and ${severity}."
+              }
+            }
+          }
+        }
+      }
+    },
+    "decode": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional payload normalizer for harnesses whose hook JSON is not the flat {hook_event_name, tool_name, tool_input} shape the built-in normalizer understands. Omit for flat payloads.",
+      "properties": {
+        "field_map": {
+          "type": "object",
+          "description": "Canonical field -> dotted path into the raw payload, for example {\"tool_name\": \"toolCall.name\", \"tool_input\": \"toolCall.args\", \"session_id\": \"conversationId\"}. Only the listed canonical keys are honored.",
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^[A-Za-z0-9_]+(\\.[A-Za-z0-9_]+)*$"
+          },
+          "propertyNames": {
+            "enum": [
+              "hook_event_name",
+              "session_id",
+              "turn_id",
+              "agent_id",
+              "agent_name",
+              "agent_type",
+              "cwd",
+              "tool_name",
+              "tool_input",
+              "content",
+              "direction",
+              "model"
+            ]
+          }
+        },
+        "event_aliases": {
+          "type": "object",
+          "description": "Map a raw harness event name to a canonical event name DefenseClaw classifies (prompt-like / tool-call / tool-result).",
+          "additionalProperties": { "type": "string", "maxLength": 128 },
+          "maxProperties": 128
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Trust metadata for third-party drop-in manifests. Required for a drop-in manifest to run in action (enforcing) mode; embedded first-party manifests are implicitly trusted. Unverified drop-ins are forced to observe mode unless the operator opts in.",
+      "properties": {
+        "publisher": { "type": "string", "maxLength": 256 },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$",
+          "description": "Lowercase hex SHA-256 of the canonicalized manifest bytes (excluding the provenance.signature field)."
+        },
+        "signature": {
+          "type": "string",
+          "maxLength": 4096,
+          "description": "Base64 detached signature over the canonicalized manifest bytes, verified against a configured trusted public key."
+        },
+        "signature_alg": { "type": "string", "enum": ["ed25519", "ecdsa-p256"] },
+        "public_key_id": { "type": "string", "maxLength": 256 }
+      }
+    },
+    "notes": {
+      "type": "array",
+      "items": { "type": "string", "maxLength": 1024 },
+      "maxItems": 32
+    }
+  }
+}

--- a/schemas/hook-connector-manifest.json
+++ b/schemas/hook-connector-manifest.json
@@ -210,6 +210,12 @@
           "enum": ["flat_map", "grouped_matcher", "top_level_grouped", "nested_named"],
           "description": "Shape of the inserted hook configuration. flat_map: container[event]=[entry...]. grouped_matcher: container[event]=[{matcher,hooks:[entry...]}]. top_level_grouped: root[event]=[{matcher,hooks:[entry...]}] (no container key). nested_named: root[<owner_key_prefix><event>]={event:[{matcher,hooks:[entry...]}]}."
         },
+        "command_invocation": {
+          "type": "string",
+          "enum": ["shell", "direct_exec"],
+          "default": "shell",
+          "description": "How the harness executes the configured command. shell renders ${hook_command} as a shell-safe invocation for agents that run hooks through sh/cmd. direct_exec renders a bare executable path or native hook entrypoint for agents that exec the configured value directly."
+        },
         "container_key": {
           "type": "string",
           "maxLength": 64,
@@ -308,6 +314,16 @@
               }
             }
           }
+        },
+        "failure": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Connector-native failure tails for the generated hook runner. These mirror hookexec/spec.go: oversized payload with fail-closed, unavailable gateway under strict availability, and response-layer failure with fail-closed.",
+          "properties": {
+            "oversized_closed": { "$ref": "#/$defs/failure_outcome" },
+            "unavailable_strict": { "$ref": "#/$defs/failure_outcome" },
+            "response_closed": { "$ref": "#/$defs/failure_outcome" }
+          }
         }
       }
     },
@@ -318,11 +334,12 @@
       "properties": {
         "field_map": {
           "type": "object",
-          "description": "Canonical field -> dotted path into the raw payload, for example {\"tool_name\": \"toolCall.name\", \"tool_input\": \"toolCall.args\", \"session_id\": \"conversationId\"}. Only the listed canonical keys are honored.",
+          "description": "Canonical field -> dotted path or constrained mapping into the raw payload, for example {\"tool_name\": \"toolCall.name\", \"tool_input\": \"toolCall.args\", \"session_id\": \"conversationId\"}. Only the listed canonical keys are honored.",
           "additionalProperties": {
-            "type": "string",
-            "maxLength": 256,
-            "pattern": "^[A-Za-z0-9_]+(\\.[A-Za-z0-9_]+)*$"
+            "oneOf": [
+              { "$ref": "#/$defs/dotted_path" },
+              { "$ref": "#/$defs/field_mapping" }
+            ]
           },
           "propertyNames": {
             "enum": [
@@ -336,23 +353,71 @@
               "tool_name",
               "tool_input",
               "content",
+              "surface",
               "direction",
               "model"
             ]
           }
+        },
+        "event_surfaces": {
+          "type": "object",
+          "description": "Map harness-native event names directly to DefenseClaw inspection surfaces. Preferred for new custom manifests over event_aliases when no built-in event compatibility is intended.",
+          "additionalProperties": { "type": "string", "enum": ["prompt", "tool_call", "tool_result", "event_content"] },
+          "maxProperties": 128
         },
         "event_aliases": {
           "type": "object",
           "description": "Map a raw harness event name to a canonical event name DefenseClaw classifies (prompt-like / tool-call / tool-result).",
           "additionalProperties": { "type": "string", "maxLength": 128 },
           "maxProperties": 128
+        },
+        "event_inference": {
+          "type": "array",
+          "maxItems": 32,
+          "description": "Constrained event inference rules used only when no event field is present. Rules may infer an event from field presence, not from arbitrary expressions.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["event", "when_path_exists"],
+            "properties": {
+              "event": { "type": "string", "maxLength": 128 },
+              "surface": { "type": "string", "enum": ["prompt", "tool_call", "tool_result", "event_content"] },
+              "when_path_exists": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 16,
+                "uniqueItems": true,
+                "items": { "$ref": "#/$defs/dotted_path" }
+              }
+            }
+          }
         }
+      }
+    },
+    "surfaces": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional connector-local surfaces beyond hook verdict delivery. These feed setup, doctor, inventory, TUI, and registry UX so custom connectors do not require a parallel hardcoded Python/Go connector matrix.",
+      "properties": {
+        "mcp": { "$ref": "#/$defs/surface_capability" },
+        "skills": { "$ref": "#/$defs/surface_capability" },
+        "rules": { "$ref": "#/$defs/surface_capability" },
+        "plugins": { "$ref": "#/$defs/surface_capability" },
+        "agents": { "$ref": "#/$defs/surface_capability" },
+        "codeguard": { "$ref": "#/$defs/codeguard_capability" },
+        "telemetry": { "$ref": "#/$defs/telemetry_capability" }
       }
     },
     "provenance": {
       "type": "object",
       "additionalProperties": false,
       "description": "Trust metadata for third-party drop-in manifests. Required for a drop-in manifest to run in action (enforcing) mode; embedded first-party manifests are implicitly trusted. Unverified drop-ins are forced to observe mode unless the operator opts in.",
+      "dependentRequired": {
+        "sha256": ["signature", "signature_alg", "public_key_id"],
+        "signature": ["sha256", "signature_alg", "public_key_id"],
+        "signature_alg": ["sha256", "signature", "public_key_id"],
+        "public_key_id": ["sha256", "signature", "signature_alg"]
+      },
       "properties": {
         "publisher": { "type": "string", "maxLength": 256 },
         "sha256": {
@@ -373,6 +438,119 @@
       "type": "array",
       "items": { "type": "string", "maxLength": 1024 },
       "maxItems": 32
+    }
+  },
+  "$defs": {
+    "dotted_path": {
+      "type": "string",
+      "maxLength": 256,
+      "pattern": "^[A-Za-z0-9_]+(\\.[A-Za-z0-9_]+)*$"
+    },
+    "field_mapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["paths"],
+      "properties": {
+        "paths": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 16,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/dotted_path" }
+        },
+        "type": {
+          "type": "string",
+          "enum": ["string", "json", "raw"],
+          "default": "string",
+          "description": "string stringifies the first non-empty value; json preserves object/array values for fields such as tool_input; raw preserves the value without conversion."
+        },
+        "join": {
+          "type": "string",
+          "maxLength": 16,
+          "description": "Optional separator used when a path resolves to multiple scalar values, for example joining messages[].content into prompt content."
+        }
+      }
+    },
+    "failure_outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exit_code"],
+      "properties": {
+        "stdout": {
+          "description": "Optional stdout body. Objects are serialized as JSON; strings are emitted as text after token substitution.",
+          "oneOf": [
+            { "type": "object", "additionalProperties": true },
+            { "type": "string", "maxLength": 4096 },
+            { "type": "null" }
+          ]
+        },
+        "stderr": { "type": "string", "maxLength": 2048 },
+        "exit_code": { "type": "integer", "minimum": 0, "maximum": 255 }
+      }
+    },
+    "string_array": {
+      "type": "array",
+      "maxItems": 64,
+      "uniqueItems": true,
+      "items": { "type": "string", "maxLength": 512 }
+    },
+    "surface_capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["supported"],
+      "properties": {
+        "supported": { "type": "boolean" },
+        "scope": { "type": "string", "enum": ["user", "workspace", "user,workspace", "workspace,user"] },
+        "config_paths": { "$ref": "#/$defs/string_array" },
+        "read_paths": { "$ref": "#/$defs/string_array" },
+        "write_paths": { "$ref": "#/$defs/string_array" },
+        "install_targets": { "$ref": "#/$defs/string_array" },
+        "discovery_only": { "type": "boolean", "default": false },
+        "requires_opt_in": { "type": "boolean", "default": false },
+        "supports_backup": { "type": "boolean", "default": false },
+        "supports_restore": { "type": "boolean", "default": false },
+        "notes": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 1024 },
+          "maxItems": 32
+        }
+      }
+    },
+    "codeguard_capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["supported"],
+      "properties": {
+        "supported": { "type": "boolean" },
+        "install_targets": { "$ref": "#/$defs/string_array" },
+        "opt_in_only": { "type": "boolean", "default": true },
+        "auto_install": { "type": "boolean", "default": false },
+        "idempotent": { "type": "boolean", "default": true },
+        "conflict_safe": { "type": "boolean", "default": true },
+        "notes": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 1024 },
+          "maxItems": 32
+        }
+      }
+    },
+    "telemetry_capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "native_otlp": { "type": "boolean", "default": false },
+        "native_signals": { "$ref": "#/$defs/string_array" },
+        "hook_signals": { "$ref": "#/$defs/string_array" },
+        "config_paths": { "$ref": "#/$defs/string_array" },
+        "auth_mode": { "type": "string", "maxLength": 128 },
+        "endpoint_template": { "type": "string", "maxLength": 512 },
+        "source_modes": { "$ref": "#/$defs/string_array" },
+        "notes": {
+          "type": "array",
+          "items": { "type": "string", "maxLength": 1024 },
+          "maxItems": 32
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem

Adding a new hook-based agent harness to DefenseClaw today requires a bespoke
native connector: a `NewXConnector()` registration, per-harness config patching,
a dedicated hook script, `HookProfile` decode/respond callbacks, `hookexec`
decision/failure entries, hook contract metadata, and CLI/doctor wiring.

That coupling means every structurally similar hook harness still becomes a
multi-file, multi-language release-train change. The wire contract is also
implicit today: endpoint shape, headers, canonical payload fields, verdict JSON,
exit codes, failure behavior, and compatibility metadata are spread across Go,
shell hooks, and Python inventory files.

## Current Situation

DefenseClaw already has the right runtime seam:

- hook connectors flow through the unified `handleAgentHook` path;
- `HookProfile` carries decode, verdict mapping, response rendering, and
  compatibility metadata;
- config installation remains hardcoded in `hook_only.go`;
- response-layer and failure semantics remain duplicated in hook scripts and
  `hookexec/spec.go`;
- Python setup/doctor/inventory still depend on hardcoded connector matrices.

This PR adds no runtime code. It publishes a draft target contract and schema so
implementation can be reviewed against an explicit acceptance bar.

## Solution

Introduce a two-tier integration model documented as an RFC and backed by a
Draft 2020-12 JSON Schema.

### Tier 1 - Hook Wire Contract

A stable contract for harness authors who own their hook client and enforcement
semantics.

- Registered connectors post to `POST /api/v1/<connector>/hook`.
- Unknown connector names are rejected; there is no silent fallback from a
  misspelled connector into managed enforcement.
- Self-integrators without a manifest use the deliberate generic route:
  `POST /api/v1/generic/hook`.
- New custom integrations require the gateway hook token and client marker.
- The canonical request/response shape includes action, raw action,
  would-block state, severity, mode, reason, evaluation id, and a
  harness-native response field.

### Tier 2 - Declarative Connector Manifest

A pure-data manifest that DefenseClaw can load as a real connector object. The
manifest target now covers:

| Manifest section | Replaces |
| --- | --- |
| `discovery` | Agent version probe + install detection |
| `contract` | hook contract metadata / drift lock |
| `capabilities` | hook block/ask/fail-closed enforcement ceiling |
| `wiring` | config patch recipes and hook command invocation style |
| `decode` | flat, nested, alternate-path, and constrained event inference mapping |
| `response` | verdict rendering, exit style, and failure tails |
| `surfaces` | MCP / skills / rules / plugins / agents / CodeGuard / telemetry metadata |
| `provenance` | drop-in trust and signature metadata |

A manifest connector should implement the same local interfaces as built-ins:
`Connector`, `HookEndpoint`, `HookProfileProvider`, and capability/path scanners
where surfaces are declared. Manifest connectors should attach to the existing
unified hook handler without a per-name gateway init registration.

## Key Design Changes In This Revision

- The RFC is explicitly draft, not frozen. The contract should not be frozen
  until a built-in connector, starting with `cursor`, is re-expressed as an
  embedded manifest with parity.
- The generic endpoint is now `/api/v1/generic/hook`, not
  `/api/v1/hook?connector=<name>`, and cannot shadow connector identities.
- The schema includes `command_invocation` so shell-run hooks and direct-exec
  hooks do not share unsafe quoting semantics.
- The schema includes `response.failure` so manifest parity covers oversized,
  strict-availability, and fail-closed response-layer behavior.
- The schema includes richer `decode` support: alternate paths, type-preserving
  values, explicit event surfaces, and constrained field-presence inference.
- The schema includes `surfaces` so Go and Python do not keep separate
  connector catalogs for setup, doctor, TUI, inventory, and registry UX.
- The RFC now documents semantic validation rules the loader must enforce beyond
  JSON Schema: reserved names, capability/event consistency, path allowlisting,
  response-field collisions, token allowlisting, and all-or-nothing provenance.

## What Changed

| File | Summary |
| --- | --- |
| `docs/HOOK-CONNECTOR-CONTRACT.md` | Draft RFC updated with route/auth semantics, manifest registration model, failure parity, richer decode, surfaces, semantic validation, and revised parity bar. |
| `schemas/hook-connector-manifest.json` | Schema extended for command invocation, failure outcomes, richer decode, surfaces, and provenance dependency rules. |
| `docs/hook-connector-contract/examples/cursor.manifest.yaml` | Cursor parity example now includes shell invocation, failure tails, and connector-local surfaces. |
| `docs/hook-connector-contract/examples/opencode.manifest.yaml` | Illustrative drop-in example now exercises expanded decode, event surfaces/inference, failure tails, and hook-only surface metadata. |

## Open Issues / Follow-ups

- Manifest engine: loader, trust gate, manifest-backed connector object, config
  patch engine, decode/render engines, and route registration.
- Generic Tier-1 endpoint: implement `/api/v1/generic/hook` deliberately rather
  than unknown-connector fallback.
- Generic hook runner/template: one parameterized hook script or native runner
  path for manifest connectors.
- CLI integration: setup, doctor, inventory, connector contracts, and TUI must
  consume the resolved connector catalog, including manifest connectors.
- Parity golden tests: re-express `cursor` as embedded manifest and assert
  installed config, verdict JSON, failure behavior, exit codes, and setup/doctor
  metadata against the native connector.
- Security tests: name collision, path escape/symlink rejection, unsafe token
  substitution, response-field collision, unsigned drop-in observe-mode gating,
  and owner/permission checks.
- OpenCode example remains illustrative; event names and config layout are not a
  verified upstream contract.

## Test Plan

- `/tmp/dcschema-venv/bin/python scripts/check_schemas.py` -> exit 0 with
  Draft 2020-12 meta-validation enabled.
- Strict example validation with `jsonschema` + `PyYAML`:
  - `cursor.manifest.yaml` validates against `hook-connector-manifest.json`.
  - `opencode.manifest.yaml` validates against `hook-connector-manifest.json`.
- `git diff --check` -> exit 0.

Not tested in this PR: gateway runtime, manifest loader, config patching, e2e
hook flows, CLI doctor/setup. This PR remains spec/schema only.
