### PR TITLE
fix(gateway): add tokenResolver fallback on passthrough when X-DC-Tar…

### DIFF
--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -1097,6 +1097,24 @@ func (p *GuardrailProxy) handlePassthrough(w http.ResponseWriter, r *http.Reques
 			upstreamAuth = auth
 		}
 	}
+	// Fallback: when the caller supplied X-DC-Target-URL but no credential
+	// headers (the "third_party_injected" mode used by ZeptoClaw/PulseClaw),
+	// consult the enterprise token resolver (secrets-sidecar hydrated key)
+	// so the proxy injects the upstream LLM credential on behalf of the
+	// caller. This mirrors the resolveConfiguredProvider path that
+	// handleChatCompletion already uses for direct-provider hydration.
+	if upstreamAuth == "" && tokenResolver != nil {
+		providerPrefix := provider
+		if providerPrefix == "" {
+			providerPrefix = inferProvider(partial.Model, "")
+		}
+		resolvedKey, err := tokenResolver(r.Context(), providerPrefix)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[guardrail] passthrough: token resolver error: %v\n", err)
+		} else if resolvedKey != "" {
+			upstreamAuth = "Bearer " + resolvedKey
+		}
+	}
 
 	// Apply a timeout so the proxy doesn't hang indefinitely if the upstream
 	// provider stalls. Streaming responses may take longer, so use 5 minutes;


### PR DESCRIPTION
…get-URL is set

handlePassthrough resolves upstream auth from inbound headers (X-AI-Auth, api-key, x-api-key, Authorization) but never consults the enterprise tokenResolver when all headers are empty. This leaves the Responses API (/v1/responses) and other passthrough paths unable to use secrets-sidecar hydrated credentials in the "third_party_injected" egress mode where the caller (PulseClaw/ZeptoClaw) provides X-DC-Target-URL but delegates credential injection to DefenseClaw.

Add a tokenResolver fallback after the header-based auth checks: when upstreamAuth is still empty and a tokenResolver is registered, call it to hydrate the upstream credential. This mirrors the resolveConfiguredProvider path that handleChatCompletion already uses and closes the gap where chat/completions works with hydration but responses does not.

The fix is additive — when any inbound auth header is present, it takes precedence (no behavior change for existing flows). The tokenResolver is only consulted as a last resort.