### PR TITLE
Setup fixes

### DIFF
--- a/cli/defenseclaw/bootstrap.py
+++ b/cli/defenseclaw/bootstrap.py
@@ -41,7 +41,7 @@ from typing import TYPE_CHECKING
 from defenseclaw.inventory import agent_discovery
 
 if TYPE_CHECKING:
-    from defenseclaw.config import Config
+    from defenseclaw.config import Config, PerConnectorGuardrailConfig
     from defenseclaw.logger import Logger
 
 
@@ -673,6 +673,20 @@ def _apply_first_run_choices(
     if cfg.guardrail.hilt.enabled and not cfg.guardrail.hilt.min_severity:
         cfg.guardrail.hilt.min_severity = "HIGH"
 
+    selected_pc = _first_run_selected_connector_override(cfg, connector)
+    if options.human_approval is not None and selected_pc is not None:
+        from defenseclaw.config import HILTConfig
+
+        min_severity = cfg.guardrail.hilt.min_severity or "HIGH"
+        if not severity and selected_pc.hilt is not None and selected_pc.hilt.min_severity:
+            min_severity = selected_pc.hilt.min_severity
+        selected_pc.hilt = HILTConfig(
+            enabled=bool(options.human_approval),
+            min_severity=min_severity,
+        )
+    elif severity and selected_pc is not None and selected_pc.hilt is not None:
+        selected_pc.hilt.min_severity = cfg.guardrail.hilt.min_severity
+
     if options.llm_provider:
         cfg.llm.provider = options.llm_provider.strip()
     if options.llm_model:
@@ -714,6 +728,24 @@ def _apply_first_run_connector_override(cfg: Config, connector: str, mode: str) 
     if pc.enabled is False:
         pc.enabled = True
     gc.connectors[key] = pc
+
+
+def _first_run_selected_connector_override(
+    cfg: Config,
+    connector: str,
+) -> PerConnectorGuardrailConfig | None:
+    gc = cfg.guardrail
+    connectors = getattr(gc, "connectors", None)
+    if not connectors:
+        return None
+    pc = connectors.get(connector)
+    if pc is not None:
+        return pc
+    wanted = _normalize_connector(connector)
+    for existing_key, existing_pc in connectors.items():
+        if _normalize_connector(existing_key) == wanted:
+            return existing_pc
+    return None
 
 
 def _persist_first_run_secrets(cfg: Config, options: FirstRunOptions, steps: list[StepResult]) -> None:

--- a/cli/defenseclaw/bootstrap.py
+++ b/cli/defenseclaw/bootstrap.py
@@ -38,6 +38,8 @@ import subprocess
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from defenseclaw.inventory import agent_discovery
+
 if TYPE_CHECKING:
     from defenseclaw.config import Config
     from defenseclaw.logger import Logger
@@ -102,6 +104,7 @@ class FirstRunOptions:
     profile: str = "observe"  # observe | action
     scanner_mode: str = "local"  # local | remote | both
     with_judge: bool = False
+    judge_hook_connectors: list[str] | None = None
     skip_install: bool = False
     sandbox: bool = False
     start_gateway: bool = False
@@ -164,9 +167,10 @@ class FirstRunReport:
     setup: list[StepResult] = field(default_factory=list)
     readiness: list[StepResult] = field(default_factory=list)
     next_commands: list[str] = field(default_factory=list)
+    connector_mode_warnings: list[dict] = field(default_factory=list)
 
     def to_dict(self) -> dict:
-        return {
+        data = {
             "status": self.status,
             "config_file": self.config_file,
             "data_dir": self.data_dir,
@@ -176,6 +180,9 @@ class FirstRunReport:
             "readiness": [s.to_dict() for s in self.readiness],
             "next_commands": self.next_commands,
         }
+        if self.connector_mode_warnings:
+            data["connector_mode_warnings"] = self.connector_mode_warnings
+        return data
 
 
 def bootstrap_env(cfg: Config, logger: Logger | None = None) -> BootstrapReport:
@@ -284,6 +291,7 @@ def run_first_run(options: FirstRunOptions) -> FirstRunReport:
     connector = _normalize_connector(options.connector)
     profile = _normalize_profile(options.profile, connector)
     scanner_mode = _normalize_scanner_mode(options.scanner_mode)
+    connector_mode_warnings: list[dict] = []
 
     new_config = not os.path.exists(cfg_mod.config_path())
     try:
@@ -293,6 +301,12 @@ def run_first_run(options: FirstRunOptions) -> FirstRunReport:
         new_config = True
 
     cfg.environment = cfg_mod.detect_environment()
+    if profile == "action":
+        mode_warning = _first_run_action_mode_warning(connector, getattr(cfg, "data_dir", ""))
+        if mode_warning:
+            connector_mode_warnings.append(mode_warning)
+            profile = "observe"
+
     _apply_first_run_choices(cfg, options, connector, profile, scanner_mode)
 
     try:
@@ -337,6 +351,7 @@ def run_first_run(options: FirstRunOptions) -> FirstRunReport:
     app.logger = logger
 
     setup.append(_quiet_guardrail_setup(app, connector, verbose=options.verbose))
+    setup.extend(_connector_mode_warning_steps(connector_mode_warnings))
 
     if options.sandbox:
         setup.append(
@@ -380,6 +395,7 @@ def run_first_run(options: FirstRunOptions) -> FirstRunReport:
         setup=setup,
         readiness=readiness,
         next_commands=next_commands,
+        connector_mode_warnings=connector_mode_warnings,
     )
 
 
@@ -487,6 +503,87 @@ def _normalize_profile(raw: str, connector: str) -> str:
     return "observe"
 
 
+def _first_run_action_mode_warning(connector: str, data_dir: str) -> dict | None:
+    """Return structured action-to-observe remediation for first-run flows."""
+    from defenseclaw.commands.cmd_setup import _check_connector_version_supported_for_setup
+
+    if _check_connector_version_supported_for_setup(
+        connector,
+        mode="action",
+        emit=False,
+        data_dir=data_dir,
+        _allow_prompt=False,
+    ):
+        return None
+
+    discovery = None
+    try:
+        discovery = agent_discovery.discover_agents(
+            use_cache=False,
+            refresh=True,
+            data_dir=data_dir,
+        )
+    except Exception:
+        discovery = None
+    return _action_downgrade_record(connector, discovery)
+
+
+def _action_downgrade_record(connector: str, discovery=None) -> dict:
+    """Structured report for an action request that had to fall back to observe."""
+    key = _normalize_connector(connector)
+    record = {
+        "connector": key,
+        "requested_mode": "action",
+        "actual_mode": "observe",
+        "status": "needs_attention",
+        "reason": "connector version could not be verified against a known hook contract",
+        "next_command": f"defenseclaw setup {key} --mode action",
+    }
+    signal = getattr(discovery, "agents", {}).get(key) if discovery is not None else None
+    if (
+        signal is not None
+        and getattr(signal, "error", "") == agent_discovery.UNTRUSTED_PREFIX_ERROR
+        and getattr(signal, "binary_path", "")
+    ):
+        resolved_bin = os.path.realpath(signal.binary_path)
+        parent = os.path.dirname(resolved_bin)
+        record.update(
+            {
+                "reason": "binary path outside trusted prefixes; version was not probed",
+                "binary_path": resolved_bin,
+                "trusted_path": parent,
+                "next_command": f"defenseclaw setup trusted-paths add {parent}",
+            }
+        )
+    elif signal is not None and getattr(signal, "error", ""):
+        record["reason"] = f"connector version could not be verified: {signal.error}"
+    return record
+
+
+def _connector_mode_warning_steps(warnings: list[dict]) -> list[StepResult]:
+    if not warnings:
+        return []
+    from defenseclaw.commands.cmd_setup import _CONNECTOR_META
+
+    steps: list[StepResult] = []
+    for warning in warnings:
+        connector = warning.get("connector", "")
+        label = _CONNECTOR_META.get(connector, {}).get("label", connector or "Connector")
+        detail = (
+            f"requested action, configured observe: "
+            f"{warning.get('reason', 'connector version could not be verified')}"
+        )
+        steps.append(
+            StepResult(
+                f"{label} mode",
+                "fail",
+                detail,
+                warning.get("next_command", ""),
+            )
+        )
+    return steps
+
+
 def _normalize_scanner_mode(raw: str) -> str:
     value = (raw or "").strip().lower()
     return value if value in {"local", "remote", "both"} else "local"
@@ -502,11 +599,42 @@ def _apply_first_run_choices(
     cfg.claw.mode = connector
     cfg.claw.workspace_dir = ""
     cfg.guardrail.connector = connector
+    # A first-run walkthrough that asks for connector selection should not
+    # inherit stale peers from a previous multi-connector config. Preserve the
+    # selected connector's existing override when present, and let
+    # cmd_init._activate_additional_connectors rebuild any selected extras.
+    existing_connectors = getattr(cfg.guardrail, "connectors", None) or {}
+    if existing_connectors:
+        from defenseclaw.config import PerConnectorGuardrailConfig
+
+        selected_override = None
+        wanted = _normalize_connector(connector)
+        for key, pc in existing_connectors.items():
+            if _normalize_connector(str(key)) == wanted:
+                selected_override = pc
+                break
+        cfg.guardrail.connectors = {
+            connector: selected_override or PerConnectorGuardrailConfig()
+        }
+    else:
+        cfg.guardrail.connectors = {}
     cfg.guardrail.scanner_mode = scanner_mode
-    cfg.guardrail.mode = "action" if profile == "action" else "observe"
+    profile_mode = "action" if profile == "action" else "observe"
+    cfg.guardrail.mode = profile_mode
     cfg.guardrail.enabled = True
-    cfg.guardrail.judge.enabled = bool(options.with_judge)
+    if options.with_judge:
+        cfg.guardrail.judge.enabled = True
+        cfg.guardrail.judge.hook_connectors = (
+            list(options.judge_hook_connectors)
+            if options.judge_hook_connectors is not None
+            else ["*"]
+        )
+        if not cfg.guardrail.detection_strategy or cfg.guardrail.detection_strategy == "regex_only":
+            cfg.guardrail.detection_strategy = "regex_judge"
+    else:
+        cfg.guardrail.judge.enabled = False
     cfg.guardrail.detection_strategy = cfg.guardrail.detection_strategy or "regex_judge"
+    _apply_first_run_connector_override(cfg, connector, profile_mode)
 
     # Honor an explicit operator choice supplied via flag/prompt.
     # Empty string means "leave whatever was loaded alone" — usually
@@ -561,6 +689,31 @@ def _apply_first_run_choices(
         cfg.cisco_ai_defense.endpoint = options.cisco_endpoint.strip()
     if options.cisco_api_key_env:
         cfg.cisco_ai_defense.api_key_env = options.cisco_api_key_env.strip()
+
+
+def _apply_first_run_connector_override(cfg: Config, connector: str, mode: str) -> None:
+    """Keep an existing multi-connector map aligned with first-run choices."""
+    gc = cfg.guardrail
+    if not getattr(gc, "connectors", None):
+        return
+
+    from defenseclaw.config import PerConnectorGuardrailConfig
+
+    key = connector
+    pc = gc.connectors.get(key)
+    if pc is None:
+        wanted = _normalize_connector(connector)
+        for existing_key, existing_pc in gc.connectors.items():
+            if _normalize_connector(existing_key) == wanted:
+                key = existing_key
+                pc = existing_pc
+                break
+    if pc is None:
+        pc = PerConnectorGuardrailConfig()
+    pc.mode = "action" if mode == "action" else "observe"
+    if pc.enabled is False:
+        pc.enabled = True
+    gc.connectors[key] = pc
 
 
 def _persist_first_run_secrets(cfg: Config, options: FirstRunOptions, steps: list[StepResult]) -> None:
@@ -636,7 +789,12 @@ def _quiet_guardrail_setup(app, connector: str, *, verbose: bool) -> StepResult:
             detail += " | " + buf.getvalue().strip().splitlines()[-1]
         return StepResult("Guardrail", "fail", detail, "defenseclaw setup guardrail")
     if ok and not warnings:
-        return StepResult("Guardrail", "pass", f"{connector}, mode={app.cfg.guardrail.mode}")
+        mode = (
+            app.cfg.guardrail.effective_mode(connector)
+            if hasattr(app.cfg.guardrail, "effective_mode")
+            else app.cfg.guardrail.mode
+        )
+        return StepResult("Guardrail", "pass", f"{connector}, mode={mode}")
     if ok:
         return StepResult("Guardrail", "warn", "; ".join(warnings), "defenseclaw doctor")
     return StepResult("Guardrail", "fail", "setup returned false", "defenseclaw setup guardrail")

--- a/cli/defenseclaw/commands/cmd_guardrail.py
+++ b/cli/defenseclaw/commands/cmd_guardrail.py
@@ -45,6 +45,7 @@ Antigravity / ZeptoClaw configure themselves.
 from __future__ import annotations
 
 import os
+import shutil
 
 import click
 
@@ -291,21 +292,71 @@ def guardrail() -> None:
 #: as "every hook connector". Mirrored locally so the status readout never
 #: disagrees with what the gateway enforces.
 _JUDGE_ALL_SENTINEL = "*"
+_JUDGE_RUNNING_STRATEGIES = frozenset({"regex_judge", "judge_first"})
 
 
-def _effective_scan_strategy(gc) -> tuple[str, str, str]:
-    """Return ``(global, prompt, completion)`` effective detection strategies.
+def _configured_hook_scan_strategies(gc) -> dict[str, str]:
+    """Return configured hook-lane scan strategies by user-facing lane.
 
-    Detection strategy is a GLOBAL guardrail setting (with per-direction
-    overrides), not per-connector — mirrors Go ``EffectiveStrategy``. An
-    empty per-direction field inherits the global value. Tolerates older /
-    minimal configs that predate the fields via ``getattr`` so ``status``
-    never raises on a trimmed config.
+    Hook connectors expose prompt, tool-call, and tool-output surfaces. The
+    Go config still calls tool output ``completion`` because it shares the
+    proxy lane's output-shaped judge, but the status UI should speak in hook
+    terms. Empty per-lane fields inherit the global strategy.
     """
     base = (getattr(gc, "detection_strategy", "") or "regex_judge").strip() or "regex_judge"
     prompt = (getattr(gc, "detection_strategy_prompt", "") or "").strip() or base
     completion = (getattr(gc, "detection_strategy_completion", "") or "").strip() or base
-    return base, prompt, completion
+    tool_call = (getattr(gc, "detection_strategy_tool_call", "") or "").strip() or base
+    return {
+        "prompt": prompt,
+        "tool-call": tool_call,
+        "tool-output": completion,
+    }
+
+
+def _effective_hook_scan_strategies(gc, connector: str) -> dict[str, str]:
+    """Return the scan strategies that actually apply to one hook connector."""
+    judge_cfg = getattr(gc, "judge", None)
+    judge_enabled = bool(getattr(judge_cfg, "enabled", False))
+    judge_gate = list(getattr(judge_cfg, "hook_connectors", None) or [])
+    judge_selected = _judge_gated(judge_gate, connector)
+    effective: dict[str, str] = {}
+    for lane, strategy in _configured_hook_scan_strategies(gc).items():
+        normalized = (strategy or "").strip().lower() or "regex_judge"
+        if judge_enabled and judge_selected and normalized in _JUDGE_RUNNING_STRATEGIES:
+            effective[lane] = normalized
+        else:
+            effective[lane] = "regex_only"
+    return effective
+
+
+def _style_strategy(strategy: str) -> str:
+    if strategy == "judge_first":
+        return ux._style(strategy, fg="yellow", bold=True)
+    if strategy == "regex_judge":
+        return ux._style(strategy, fg="cyan", bold=True)
+    return ux.dim(strategy)
+
+
+def _scan_value(gc, connector: str) -> str:
+    strategies = _effective_hook_scan_strategies(gc, connector)
+    values = list(strategies.values())
+    if values and all(v == values[0] for v in values):
+        return values[0]
+    return ", ".join(f"{lane}:{strategy}" for lane, strategy in strategies.items())
+
+
+def _style_scan_value(value: str) -> str:
+    if "," not in value and ":" not in value:
+        return _style_strategy(value)
+    parts: list[str] = []
+    for part in value.split(", "):
+        if ":" not in part:
+            parts.append(part)
+            continue
+        lane, strategy = part.split(":", 1)
+        parts.append(f"{lane}:{_style_strategy(strategy)}")
+    return ", ".join(parts)
 
 
 def _judge_gated(gate, name: str) -> bool:
@@ -323,142 +374,104 @@ def _judge_gated(gate, name: str) -> bool:
     return False
 
 
-def _judge_gate_config_label(gate) -> str:
-    entries = list(gate or [])
-    if not entries:
-        return "none"
-    if any((e or "").strip() == _JUDGE_ALL_SENTINEL for e in entries):
-        return "all"
-    return ", ".join((e or "").strip() for e in entries if (e or "").strip()) or "none"
+def _connector_judge_value(gc, name: str) -> str:
+    strategies = _effective_hook_scan_strategies(gc, name)
+    if any(strategy in _JUDGE_RUNNING_STRATEGIES for strategy in strategies.values()):
+        return "on"
+    return "off"
 
 
-def _connector_status_label(name: str) -> str:
-    return f"{_connector_label(name)} ({name})"
+def _style_judge_value(value: str) -> str:
+    if value == "on":
+        return ux._style(value, fg="green", bold=True)
+    return ux.dim(value)
 
 
-def _judge_active_for_connector(
-    *,
-    gate,
-    judge_enabled: bool,
-    prompt_strategy: str,
-    connector: str,
-) -> bool:
-    return (
-        judge_enabled
-        and _judge_gated(gate, connector)
-        and (prompt_strategy or "").strip().lower() != "regex_only"
+def _style_mode(mode: str) -> str:
+    if mode == "action":
+        return ux._style(mode, fg="green", bold=True)
+    return ux._style(mode, fg="yellow") if mode == "observe" else mode
+
+
+def _style_fail_mode(mode: str) -> str:
+    if mode == "closed":
+        return ux._style(mode, fg="yellow", bold=True)
+    if mode == "open":
+        return ux._style(mode, fg="green")
+    return mode
+
+
+def _visible_pad(styled: str, raw: str, width: int) -> str:
+    return styled + (" " * max(width - len(raw), 0))
+
+
+def _terminal_width() -> int:
+    try:
+        return shutil.get_terminal_size((120, 20)).columns
+    except OSError:
+        return 120
+
+
+def _render_connector_table(rows: list[dict[str, tuple[str, str]]]) -> None:
+    columns = [
+        ("label", "Connector"),
+        ("key", "Key"),
+        ("state", "State"),
+        ("mode", "Mode"),
+        ("fail", "Fail"),
+        ("rule_pack", "Rule pack"),
+        ("hilt", "HILT"),
+        ("scan", "Scan"),
+        ("judge", "Judge"),
+    ]
+    widths = {
+        key: max(len(header), *(len(row[key][0]) for row in rows))
+        for key, header in columns
+    }
+    gap = "  "
+    table_width = 6 + sum(widths[key] for key, _ in columns) + len(gap) * (len(columns) - 1)
+    if table_width > _terminal_width():
+        _render_connector_blocks(rows)
+        return
+
+    header = gap.join(
+        _visible_pad(ux._style(header, fg="bright_black", bold=True), header, widths[key])
+        for key, header in columns
     )
-
-
-def _judge_status_label(
-    *,
-    gate,
-    judge_enabled: bool,
-    prompt_strategy: str,
-    connectors: list[str],
-    connector_flag: str | None,
-) -> str:
-    if connector_flag and connectors:
-        name = connectors[0]
-        label = _connector_status_label(name)
-        if _judge_active_for_connector(
-            gate=gate,
-            judge_enabled=judge_enabled,
-            prompt_strategy=prompt_strategy,
-            connector=name,
-        ):
-            return f"on for {label}"
-        if not judge_enabled:
-            return f"off for {label} (disabled globally)"
-        if (prompt_strategy or "").strip().lower() == "regex_only":
-            return f"off for {label} (prompt strategy is regex_only)"
-        if not _judge_gated(gate, name):
-            return f"off for {label} (not selected)"
-        return f"off for {label}"
-    if not judge_enabled:
-        return "off (disabled globally)"
-    if (prompt_strategy or "").strip().lower() == "regex_only":
-        return "off (prompt strategy is regex_only)"
-    active = [
-        name
-        for name in connectors
-        if _judge_active_for_connector(
-            gate=gate,
-            judge_enabled=judge_enabled,
-            prompt_strategy=prompt_strategy,
-            connector=name,
+    separator = gap.join(ux.dim("-" * widths[key]) for key, _ in columns)
+    click.echo(f"      {header}")
+    click.echo(f"      {separator}")
+    for row in rows:
+        click.echo(
+            "      "
+            + gap.join(
+                _visible_pad(row[key][1], row[key][0], widths[key])
+                for key, _ in columns
+            )
         )
+
+
+def _render_connector_blocks(rows: list[dict[str, tuple[str, str]]]) -> None:
+    fields = [
+        ("key", "key"),
+        ("state", "state"),
+        ("mode", "mode"),
+        ("fail", "fail"),
+        ("rule_pack", "rule-pack"),
+        ("hilt", "hilt"),
+        ("scan", "scan"),
+        ("judge", "judge"),
     ]
-    if not active:
-        return "off (no connectors selected)"
-    return "on"
-
-
-def _judge_coverage_label(
-    *,
-    gate,
-    judge_enabled: bool,
-    prompt_strategy: str,
-    connectors: list[str],
-    connector_flag: str | None,
-) -> str:
-    active = [
-        name
-        for name in connectors
-        if _judge_active_for_connector(
-            gate=gate,
-            judge_enabled=judge_enabled,
-            prompt_strategy=prompt_strategy,
-            connector=name,
-        )
-    ]
-    if connector_flag:
-        if not active:
-            if not judge_enabled or (prompt_strategy or "").strip().lower() == "regex_only":
-                return "none active"
-            return "not selected"
-        return "selected"
-    if not active:
-        return "none active"
-    if _judge_gate_config_label(gate) == "all" and len(active) == len(connectors) and connectors:
-        return "all active connectors"
-    return ", ".join(_connector_status_label(name) for name in active)
-
-
-def _saved_judge_gate_label(
-    *,
-    gate,
-    judge_enabled: bool,
-    prompt_strategy: str,
-) -> str:
-    configured = _judge_gate_config_label(gate)
-    if configured == "none":
-        return configured
-    if not judge_enabled:
-        return f"{configured} (inactive until judge is enabled)"
-    if (prompt_strategy or "").strip().lower() == "regex_only":
-        return f"{configured} (inactive while prompt strategy is regex_only)"
-    return configured
-
-
-def _connector_judge_token(gc, name: str, prompt_strategy: str) -> str:
-    """Per-connector hook-lane judge state for the status roster.
-
-    Honest about the J5 overstatement trap: a connector can be in the
-    judge gate AND the judge enabled, yet the judge never runs because the
-    (global) prompt scan strategy is ``regex_only``. We report ``on`` only
-    when the judge would actually execute, ``off (regex_only)`` for the
-    gated-but-strategy-suppressed case, else ``off``.
-    """
-    judge_cfg = getattr(gc, "judge", None)
-    if not getattr(judge_cfg, "enabled", False):
-        return "off"
-    gate = getattr(judge_cfg, "hook_connectors", None) or []
-    if not _judge_gated(gate, name):
-        return "off"
-    if (prompt_strategy or "").strip().lower() == "regex_only":
-        return "off (regex_only)"
-    return "on"
+    label_width = max(len(label) for _, label in fields)
+    for row in rows:
+        click.echo(f"      - {row['label'][1]}")
+        for key, label in fields:
+            label_raw = label + ":"
+            label_styled = ux._style(label_raw, fg="bright_black", bold=True)
+            click.echo(
+                f"          {_visible_pad(label_styled, label_raw, label_width + 1)} "
+                f"{row[key][1]}"
+            )
 
 
 @guardrail.command("status")
@@ -481,12 +494,12 @@ def status_cmd(app: AppContext, connector_flag: str | None) -> None:
     to reason about connector count. There is no separate single-vs-multi
     rendering and no "primary" connector line.
 
-    Also surfaces the global scan strategy and judge posture (with a
-    per-connector ``judge=`` token that never overstates coverage — it
-    reads ``off`` when a regex_only strategy means the judge can't run),
-    and renders an explicit "none configured" state rather than a phantom
-    ``openclaw`` when no connector is set up. ``--connector X`` narrows the
-    roster to one active peer.
+    The connector row is the source of truth for hook posture: enabled state,
+    mode, fail mode, rule pack, HILT, effective hook scan strategy, and judge
+    state are shown together so the scan strategy cannot contradict the judge
+    gate. ``--connector X`` narrows the roster to one active peer. When no
+    connector is set up, status renders an explicit "none configured" state
+    rather than a phantom ``openclaw``.
     """
     gc = app.cfg.guardrail
     connector = _resolve_active_connector(app.cfg)
@@ -496,17 +509,6 @@ def status_cmd(app: AppContext, connector_flag: str | None) -> None:
     enabled_val = ux._style(enabled_txt, fg="green") if gc.enabled else ux._style(enabled_txt, fg="yellow")
     click.echo(f"  • {ux._style('enabled:', fg='bright_black', bold=True)}    {enabled_val}")
 
-    # Scan strategy + judge posture (G3 / J5). detection_strategy is a GLOBAL
-    # guardrail setting (with per-direction overrides), not per-connector —
-    # surface it so an operator can see whether the LLM judge can run at all
-    # without grepping config.yaml. `guardrail judge list` gives the full
-    # per-lane breakdown; status keeps it to a one-line summary + a
-    # per-connector `judge=` token on each roster block below.
-    base_strategy, prompt_strategy, completion_strategy = _effective_scan_strategy(gc)
-    click.echo(
-        f"  • {ux._style('scan strategy:', fg='bright_black', bold=True)} {base_strategy} "
-        f"{ux.dim(f'(prompt: {prompt_strategy}, completion: {completion_strategy})')}"
-    )
     # Resolve the full active set and render exactly one coherent view: a
     # per-connector block for EACH active connector. active_connectors()
     # returns [connector] on a single-connector install and the full set on
@@ -564,44 +566,7 @@ def status_cmd(app: AppContext, connector_flag: str | None) -> None:
             raise SystemExit(1)
         actives = scoped
 
-    judge_cfg = getattr(gc, "judge", None)
-    judge_enabled = bool(getattr(judge_cfg, "enabled", False))
-    judge_gate = list(getattr(judge_cfg, "hook_connectors", None) or [])
-    judge_state_txt = _judge_status_label(
-        gate=judge_gate,
-        judge_enabled=judge_enabled,
-        prompt_strategy=prompt_strategy,
-        connectors=actives,
-        connector_flag=connector_flag,
-    )
-    judge_state_val = (
-        ux._style(judge_state_txt, fg="green")
-        if judge_state_txt.startswith("on")
-        else ux._style(judge_state_txt, fg="yellow")
-    )
-    coverage_lbl = _judge_coverage_label(
-        gate=judge_gate,
-        judge_enabled=judge_enabled,
-        prompt_strategy=prompt_strategy,
-        connectors=actives,
-        connector_flag=connector_flag,
-    )
-    saved_gate_lbl = _saved_judge_gate_label(
-        gate=judge_gate,
-        judge_enabled=judge_enabled,
-        prompt_strategy=prompt_strategy,
-    )
-    click.echo(f"  • {ux._style('judge:', fg='bright_black', bold=True)}      {judge_state_val}")
-    click.echo(
-        f"  • {ux._style('judge coverage:', fg='bright_black', bold=True)} "
-        f"{ux.dim(coverage_lbl)}"
-    )
-    click.echo(
-        f"  • {ux._style('saved judge gate:', fg='bright_black', bold=True)} "
-        f"{ux.dim(saved_gate_lbl)}"
-    )
-
-    click.echo(f"  • {ux._style('connectors:', fg='bright_black', bold=True)}")
+    rows: list[dict[str, tuple[str, str]]] = []
     for name in actives:
         cmode = gc.effective_mode(name) if hasattr(gc, "effective_mode") else (gc.mode or "observe")
         cfm = (
@@ -624,12 +589,15 @@ def status_cmd(app: AppContext, connector_flag: str | None) -> None:
         # while the top-level line (and the gateway, which tears every
         # connector down when guardrail.enabled is false) report it off.
         if not gc.enabled:
-            state = ux._style("disabled (guardrail off)", fg="yellow")
+            state_raw = "disabled (guardrail off)"
+            state = ux._style(state_raw, fg="yellow")
         elif c_enabled:
-            state = ux._style("enabled", fg="green")
+            state_raw = "enabled"
+            state = ux._style(state_raw, fg="green")
         else:
-            state = ux._style("disabled", fg="yellow")
-        cfm_display = ux._style(cfm, fg="yellow") if cfm == "closed" else cfm
+            state_raw = "disabled"
+            state = ux._style(state_raw, fg="yellow")
+        cfm_display = _style_fail_mode(cfm)
         # Each connector can scan against its OWN rule pack (per-connector
         # override, else the global pack); surface it so the roster shows which
         # policy each peer is enforcing. Empty dir = the built-in default pack.
@@ -638,38 +606,38 @@ def status_cmd(app: AppContext, connector_flag: str | None) -> None:
             if hasattr(gc, "effective_rule_pack_dir")
             else ""
         )
-        rule_pack = os.path.basename(rp_dir.rstrip("/")) if rp_dir.strip() else "default"
+        rule_pack_raw = os.path.basename(rp_dir.rstrip("/")) if rp_dir.strip() else "default"
+        rule_pack = ux.accent(rule_pack_raw) if rule_pack_raw != "default" else ux.dim(rule_pack_raw)
         # Per-connector HILT (human-in-the-loop): on@<min-severity> or off, so
         # the roster reflects `guardrail hilt --connector X` overrides.
         hilt_eff = gc.effective_hilt(name) if hasattr(gc, "effective_hilt") else None
         if hilt_eff is not None and getattr(hilt_eff, "enabled", False):
-            hilt_str = f"hilt=on@{(getattr(hilt_eff, 'min_severity', '') or 'HIGH').upper()}"
+            hilt_raw = f"on@{(getattr(hilt_eff, 'min_severity', '') or 'HIGH').upper()}"
+            hilt_str = (
+                ux._style(hilt_raw, fg="yellow", bold=True)
+            )
         else:
-            hilt_str = "hilt=off"
-        # Per-connector hook-lane judge state (G3 / J5). `on` only when the
-        # judge would actually run for this connector (enabled + gated +
-        # strategy not regex_only) — never overstates coverage.
-        judge_tok = _connector_judge_token(gc, name, prompt_strategy)
-        click.echo(
-            f"      - {_connector_label(name)} ({name}): "
-            f"{state} mode={cmode or 'observe'} fail={cfm_display} "
-            f"rule-pack={rule_pack} {hilt_str} judge={judge_tok}"
+            hilt_raw = "off"
+            hilt_str = ux.dim(hilt_raw)
+        scan_raw = _scan_value(gc, name)
+        judge_raw = _connector_judge_value(gc, name)
+        rows.append(
+            {
+                "label": (_connector_label(name), _connector_label(name)),
+                "key": (name, ux.dim(name)),
+                "state": (state_raw, state),
+                "mode": (cmode or "observe", _style_mode(cmode or "observe")),
+                "fail": (cfm, cfm_display),
+                "rule_pack": (rule_pack_raw, rule_pack),
+                "hilt": (hilt_raw, hilt_str),
+                "scan": (scan_raw, _style_scan_value(scan_raw)),
+                "judge": (judge_raw, _style_judge_value(judge_raw)),
+            }
         )
+    _render_connector_table(rows)
     click.echo(
         f"  • {ux.dim('fail = hook response-layer failures (4xx / bad JSON / missing action)')}"
     )
-
-    # J5 anti-overstatement: the judge can be enabled AND a connector gated,
-    # yet never run because the (global) prompt strategy is regex_only. Say so
-    # once, here, rather than letting `judge=` tokens imply coverage that the
-    # strategy silently suppresses.
-    if judge_enabled and prompt_strategy.strip().lower() == "regex_only":
-        ux.warn(
-            "judge is enabled but scan strategy is 'regex_only' — the judge "
-            "will not run on prompts. Set strategy to regex_judge or "
-            "judge_first to activate it.",
-            indent="  ",
-        )
 
     click.echo(f"  • {ux._style('port:', fg='bright_black', bold=True)}       {gc.port}")
     click.echo()

--- a/cli/defenseclaw/commands/cmd_init.py
+++ b/cli/defenseclaw/commands/cmd_init.py
@@ -93,8 +93,8 @@ from defenseclaw.safety import DotenvValueError, sanitize_dotenv_value
     "--action-connectors",
     default="",
     help=(
-        "Comma-separated connectors to configure in action (enforcing) mode. "
-        "The named connectors are configured even on their own; pair with "
+        "Comma-separated active connectors to configure in action (enforcing) mode. "
+        "The named connectors are activated even on their own; pair with "
         "--observe-all to bring up everything else in observe."
     ),
 )
@@ -536,6 +536,8 @@ def _run_first_run_cmd(  # noqa: PLR0913 - mirrors click options.
 
     data_dir = default_data_path()
     connector_settings: list[dict] | None = None
+    judge_hook_connectors: list[str] | None = None
+    interactive_wizard = False
     # --observe-all / --action-connectors express an explicit, scripted
     # connector selection. Honor them deterministically even on a TTY instead
     # of dropping into the wizard (which would silently ignore the flags).
@@ -547,10 +549,12 @@ def _run_first_run_cmd(  # noqa: PLR0913 - mirrors click options.
         and not json_summary
         and _stdin_is_tty()
     ):
+        interactive_wizard = True
         (
             connector_settings,
             scanner_mode,
             with_judge,
+            judge_hook_connectors,
             start_gateway,
             verify,
         ) = _prompt_first_run(
@@ -566,6 +570,21 @@ def _run_first_run_cmd(  # noqa: PLR0913 - mirrors click options.
             rescan_agents=rescan_agents,
             data_dir=data_dir,
         )
+        if with_judge:
+            (
+                llm_provider,
+                llm_model,
+                llm_api_key,
+                llm_api_key_env,
+                llm_base_url,
+            ) = _prompt_first_run_judge_llm_config(
+                data_dir=data_dir,
+                llm_provider=llm_provider,
+                llm_model=llm_model,
+                llm_api_key=llm_api_key,
+                llm_api_key_env=llm_api_key_env,
+                llm_base_url=llm_base_url,
+            )
 
     # Non-interactive / no-TTY path. With --observe-all / --action-connectors
     # this fans out to every detected hook connector (observe by default, the
@@ -583,6 +602,8 @@ def _run_first_run_cmd(  # noqa: PLR0913 - mirrors click options.
             human_approval=human_approval,
             hilt_min_severity=hilt_min_severity,
             rescan_agents=rescan_agents,
+            quiet=json_summary,
+            data_dir=data_dir,
         )
     if start_gateway is None:
         start_gateway = False
@@ -602,6 +623,7 @@ def _run_first_run_cmd(  # noqa: PLR0913 - mirrors click options.
         profile=primary["profile"] or "observe",
         scanner_mode=scanner_mode,
         with_judge=with_judge,
+        judge_hook_connectors=judge_hook_connectors,
         skip_install=skip_install,
         sandbox=sandbox,
         start_gateway=(False if defer_gateway else start_gateway),
@@ -636,6 +658,7 @@ def _run_first_run_cmd(  # noqa: PLR0913 - mirrors click options.
             extras,
             start_gateway=bool(start_gateway),
             quiet=json_summary,
+            allow_trusted_path_prompt=interactive_wizard,
         )
         # When the gateway start was deferred (multi-connector + start_gateway),
         # run_first_run recorded a stale "Sidecar not started (--no-start-gateway)"
@@ -663,10 +686,20 @@ def _run_first_run_cmd(  # noqa: PLR0913 - mirrors click options.
                 report.setup, report.readiness, report, report.profile
             )
 
+    mode_warnings = _connector_mode_warnings(connector_settings)
+    if mode_warnings:
+        _append_mode_warning_steps(report, mode_warnings)
+        report.status = _rollup_status(report.setup, report.readiness)
+        report.next_commands = _next_commands(
+            report.setup, report.readiness, report, report.profile
+        )
+
     if json_summary:
         payload = report.to_dict()
         if len(activated) > 1:
             payload["connectors"] = activated
+        if mode_warnings:
+            payload["connector_mode_warnings"] = mode_warnings
         click.echo(json.dumps(payload, indent=2))
         return
     _render_first_run_report(report, CLIRenderer())
@@ -796,11 +829,21 @@ def _installed_hook_connectors(disc) -> list[str]:
     return names
 
 
-def _untrusted_discovery_prefixes(disc) -> list[tuple[str, str, str]]:
+def _untrusted_discovery_prefixes(
+    disc,
+    connectors: list[str] | None = None,
+) -> list[tuple[str, str, str]]:
     rows: list[tuple[str, str, str]] = []
     seen: set[str] = set()
+    wanted = {
+        connector_paths.normalize(connector)
+        for connector in connectors or []
+        if connector.strip()
+    }
     order = getattr(agent_discovery, "DISCOVERY_PRECEDENCE", None) or sorted(disc.agents)
     for name in order:
+        if wanted and connector_paths.normalize(name) not in wanted:
+            continue
         signal = disc.agents.get(name)
         if (
             signal is None
@@ -822,8 +865,12 @@ def _prompt_trust_discovery_prefixes(
     *,
     data_dir: str | os.PathLike[str] | None,
     rescan_agents: bool,
+    connectors: list[str] | None = None,
+    trusted_prompt_cache: dict[str, bool] | None = None,
 ):
-    rows = _untrusted_discovery_prefixes(disc)
+    rows = _untrusted_discovery_prefixes(disc, connectors=connectors)
+    if trusted_prompt_cache is not None:
+        rows = [row for row in rows if row[2] not in trusted_prompt_cache]
     if not rows:
         return disc
 
@@ -839,6 +886,8 @@ def _prompt_trust_discovery_prefixes(
     )
     if not click.confirm("  Add these directories to trusted binary prefixes?", default=False):
         for _name, _resolved_bin, parent in rows:
+            if trusted_prompt_cache is not None:
+                trusted_prompt_cache[parent] = False
             ux.subhead(f"  Trust later with: defenseclaw setup trusted-paths add {parent}")
         return disc
 
@@ -851,9 +900,14 @@ def _prompt_trust_discovery_prefixes(
     for _name, _resolved_bin, parent in rows:
         resolved, err = agent_discovery.validate_trusted_prefix(parent)
         if err:
+            if trusted_prompt_cache is not None:
+                trusted_prompt_cache[parent] = False
             ux.warn(f"Not trusting {parent}: {err}", indent="  ")
             continue
         added = _add_trusted_bin_prefix(resolved, target_data_dir)
+        if trusted_prompt_cache is not None:
+            trusted_prompt_cache[parent] = True
+            trusted_prompt_cache[resolved] = True
         trusted_any = True
         verb = "trusted" if added else "already trusted"
         ux.subhead(f"  {verb}: {resolved}")
@@ -874,23 +928,34 @@ def _prompt_connector_selection(
     rescan_agents: bool,
     *,
     data_dir: str | os.PathLike[str] | None = None,
+    trusted_prompt_cache: dict[str, bool] | None = None,
 ) -> list[str]:
-    """Prompt for ONE OR MORE connectors to configure during first run.
+    """Prompt for ONE OR MORE active connectors to configure during first run.
 
     Returns an ordered, de-duplicated list (first = primary). A single name
     keeps the legacy single-connector setup; multiple names fan the
     wizard's per-connector questions out so several agents can be brought
-    up in one pass. Defaults to every installed hook connector so the
+    up in one pass. The selected names become the active connector set.
+    Defaults to every installed hook connector so the
     common "start everything I have" case is a single Enter."""
     if connector:
         names = _parse_connector_list(connector)
         if names:
+            disc = agent_discovery.discover_agents(refresh=rescan_agents, data_dir=data_dir)
+            _prompt_trust_discovery_prefixes(
+                disc,
+                data_dir=data_dir,
+                rescan_agents=rescan_agents,
+                connectors=names,
+                trusted_prompt_cache=trusted_prompt_cache,
+            )
             return names
     disc = agent_discovery.discover_agents(refresh=rescan_agents, data_dir=data_dir)
     disc = _prompt_trust_discovery_prefixes(
         disc,
         data_dir=data_dir,
         rescan_agents=rescan_agents,
+        trusted_prompt_cache=trusted_prompt_cache,
     )
     table = agent_discovery.render_discovery_table(disc).rstrip()
     if table:
@@ -902,12 +967,12 @@ def _prompt_connector_selection(
         return _prompt_checkbox_selection(
             installed,
             default_selected=installed,
-            title="Select connector(s) to configure. Detected connectors are pre-selected.",
+            title="Select active connector(s). Detected connectors are pre-selected.",
             empty_ok=False,
         )
 
     fallback = agent_discovery.first_installed(disc, "codex")
-    ux.subhead("No hook connectors were detected. Choose one connector to configure.")
+    ux.subhead("No hook connectors were detected. Choose one active connector to configure.")
     raw = click.prompt(
         "  Connector",
         type=click.Choice(sorted(connector_paths.KNOWN_CONNECTORS), case_sensitive=False),
@@ -941,22 +1006,22 @@ def _note_proxy_connectors(disc) -> None:
 
 
 def _prompt_action_connectors(connectors: list[str]) -> list[str]:
-    """Ask which of the configured connectors should run in ACTION mode.
+    """Ask which of the selected active connectors should run in ACTION mode.
 
-    Every connector defaults to observe (log-only). The operator names the
-    subset to enforce; a blank answer keeps everything in observe. The reply
-    is intersected with the configured list so a typo can't enable a connector
-    that isn't being set up."""
+    Every selected connector defaults to observe (log-only). The operator
+    names the subset to enforce; a blank answer keeps everything in observe.
+    The reply is intersected with the selected active list so a typo can't
+    enable a connector that isn't being set up."""
     ux.section("Enforcement mode")
     ux.subhead(
-        "All connectors start in observe (log-only). Select the ones that should "
+        "All selected active connectors start in observe (log-only). Select the ones that should "
         "ACTION (block/enforce); leave every box clear to keep everything in observe.",
     )
-    ux.subhead("Configured: " + ", ".join(connectors))
+    ux.subhead("Active connectors: " + ", ".join(connectors))
     requested = _prompt_checkbox_selection(
         connectors,
         default_selected=[],
-        title="Select connector(s) to run in action mode.",
+        title="Select active connector(s) to run in action mode.",
         empty_ok=True,
     )
     allowed = set(connectors)
@@ -1033,6 +1098,12 @@ def _supported_action_connectors(
     candidates: list[str],
     *,
     data_dir: str | os.PathLike[str] | None,
+    discovery=None,
+    downgrades: list[dict] | None = None,
+    quiet: bool = False,
+    allow_trusted_path_prompt: bool = False,
+    rescan_agents: bool = False,
+    trusted_prompt_cache: dict[str, bool] | None = None,
 ) -> list[str]:
     """Filter *candidates* to those whose installed version maps to a known
     hook contract in action mode.
@@ -1047,20 +1118,161 @@ def _supported_action_connectors(
     )
 
     out: list[str] = []
+    failed: list[str] = []
     for name in candidates:
         key = connector_paths.normalize(name)
         if _check_connector_version_supported_for_setup(
-            key, mode="action", emit=False, data_dir=data_dir
+            key,
+            mode="action",
+            emit=False,
+            data_dir=data_dir,
+            _allow_prompt=False,
         ):
             out.append(key)
         else:
+            failed.append(key)
+
+    if allow_trusted_path_prompt and failed:
+        try:
+            prompt_disc = agent_discovery.discover_agents(
+                use_cache=False,
+                refresh=True,
+                data_dir=data_dir,
+            )
+        except Exception:
+            prompt_disc = discovery
+        if prompt_disc is not None and _untrusted_discovery_prefixes(prompt_disc, connectors=failed):
+            _prompt_trust_discovery_prefixes(
+                prompt_disc,
+                data_dir=data_dir,
+                rescan_agents=rescan_agents,
+                connectors=failed,
+                trusted_prompt_cache=trusted_prompt_cache,
+            )
+            still_failed: list[str] = []
+            for key in failed:
+                if _check_connector_version_supported_for_setup(
+                    key,
+                    mode="action",
+                    emit=False,
+                    data_dir=data_dir,
+                    _allow_prompt=False,
+                ):
+                    out.append(key)
+                else:
+                    still_failed.append(key)
+            failed = still_failed
+
+    for key in failed:
+        warning = _fresh_action_downgrade_record(
+            key,
+            data_dir=data_dir,
+            fallback_discovery=discovery,
+        )
+        if downgrades is not None:
+            downgrades.append(warning)
+        if not quiet:
             click.echo(
-                f"  ⚠ {key}: installed version is not verified against a known hook "
-                "contract; configuring in observe mode. Set "
+                f"  ⚠ {key}: requested action but configuring in observe mode "
+                f"({warning['reason']}). Set "
                 "DEFENSECLAW_ALLOW_HOOK_CONTRACT_DRIFT=1 only for exploratory testing.",
                 err=True,
             )
     return out
+
+
+def _action_downgrade_record(connector: str, discovery=None) -> dict:
+    """Structured report for an action request that had to fall back to observe."""
+    key = connector_paths.normalize(connector)
+    record = {
+        "connector": key,
+        "requested_mode": "action",
+        "actual_mode": "observe",
+        "status": "needs_attention",
+        "reason": "connector version could not be verified against a known hook contract",
+        "next_command": f"defenseclaw setup {key} --mode action",
+    }
+    signal = getattr(discovery, "agents", {}).get(key) if discovery is not None else None
+    if (
+        signal is not None
+        and getattr(signal, "error", "") == agent_discovery.UNTRUSTED_PREFIX_ERROR
+        and getattr(signal, "binary_path", "")
+    ):
+        resolved_bin = os.path.realpath(signal.binary_path)
+        parent = os.path.dirname(resolved_bin)
+        record.update(
+            {
+                "reason": "binary path outside trusted prefixes; version was not probed",
+                "binary_path": resolved_bin,
+                "trusted_path": parent,
+                "next_command": f"defenseclaw setup trusted-paths add {parent}",
+            }
+        )
+    elif signal is not None and getattr(signal, "error", ""):
+        record["reason"] = f"connector version could not be verified: {signal.error}"
+    return record
+
+
+def _fresh_action_downgrade_record(
+    connector: str,
+    *,
+    data_dir: str | os.PathLike[str] | None,
+    fallback_discovery=None,
+) -> dict:
+    """Build an action downgrade warning from fresh probe context.
+
+    The action-mode gate uses a no-cache discovery refresh. If the JSON warning
+    is built from an older cached discovery result, it can lose the specific
+    untrusted-path probe error and fall back to the generic remediation. Refresh
+    here too so scripted init reports the same concrete reason the gate saw.
+    """
+    try:
+        discovery = agent_discovery.discover_agents(
+            use_cache=False,
+            refresh=True,
+            data_dir=data_dir,
+        )
+    except Exception:
+        discovery = fallback_discovery
+    return _action_downgrade_record(connector, discovery)
+
+
+def _connector_mode_warnings(settings: list[dict]) -> list[dict]:
+    warnings: list[dict] = []
+    seen: set[str] = set()
+    for setting in settings:
+        warning = setting.get("mode_warning")
+        if not warning:
+            continue
+        connector = warning.get("connector", "")
+        if connector in seen:
+            continue
+        seen.add(connector)
+        warnings.append(warning)
+    return warnings
+
+
+def _append_mode_warning_steps(report, warnings: list[dict]) -> None:
+    if not warnings:
+        return
+    from defenseclaw.bootstrap import StepResult
+    from defenseclaw.commands.cmd_setup import _CONNECTOR_META
+
+    for warning in warnings:
+        connector = warning.get("connector", "")
+        label = _CONNECTOR_META.get(connector, {}).get("label", connector or "Connector")
+        detail = (
+            f"requested action, configured observe: "
+            f"{warning.get('reason', 'connector version could not be verified')}"
+        )
+        report.setup.append(
+            StepResult(
+                f"{label} mode",
+                "fail",
+                detail,
+                warning.get("next_command", ""),
+            )
+        )
 
 
 def _build_noninteractive_connector_settings(
@@ -1073,6 +1285,8 @@ def _build_noninteractive_connector_settings(
     human_approval: bool | None,
     hilt_min_severity: str | None,
     rescan_agents: bool,
+    quiet: bool = False,
+    data_dir: str | os.PathLike[str] | None = None,
 ) -> list[dict]:
     """Build the ``connector_settings`` list for non-interactive / no-TTY init.
 
@@ -1121,7 +1335,7 @@ def _build_noninteractive_connector_settings(
             )
         return _single(connector, discover=False)
 
-    disc = agent_discovery.discover_agents(refresh=rescan_agents)
+    disc = agent_discovery.discover_agents(refresh=rescan_agents, data_dir=data_dir)
     detected = _installed_hook_connectors(disc)
 
     configured: list[str] = []
@@ -1148,12 +1362,19 @@ def _build_noninteractive_connector_settings(
     if not configured:
         return _single(None, discover=True)
 
+    action_downgrades: list[dict] = []
     action_set = set(
         _supported_action_connectors(
             [name for name in configured if name in action_list],
-            data_dir=None,
+            data_dir=data_dir,
+            discovery=disc,
+            downgrades=action_downgrades,
+            quiet=quiet,
         )
     )
+    downgrade_by_connector = {
+        warning["connector"]: warning for warning in action_downgrades
+    }
     settings: list[dict] = []
     for name in configured:
         is_action = name in action_set
@@ -1164,6 +1385,7 @@ def _build_noninteractive_connector_settings(
                 "fail_mode": (fail_mode if is_action else None),
                 "human_approval": (human_approval if is_action else None),
                 "hilt_min_severity": (hilt_min_severity if is_action else None),
+                "mode_warning": downgrade_by_connector.get(name),
             }
         )
     return settings
@@ -1182,24 +1404,34 @@ def _prompt_first_run(
     verify: bool | None,
     rescan_agents: bool,
     data_dir: str | os.PathLike[str] | None = None,
-) -> tuple[list[dict], str, bool, bool, bool]:
+) -> tuple[list[dict], str, bool, list[str] | None, bool, bool]:
     ux.section("DefenseClaw First-Run Setup")
     ux.subhead(
         "This wizard writes config.yaml, then runs targeted readiness checks.",
     )
     click.echo()
-    connectors = _prompt_connector_selection(connector, rescan_agents, data_dir=data_dir)
+    trusted_prompt_cache: dict[str, bool] = {}
+    connectors = _prompt_connector_selection(
+        connector,
+        rescan_agents,
+        data_dir=data_dir,
+        trusted_prompt_cache=trusted_prompt_cache,
+    )
 
-    # Scanner mode and the LLM judge are process-wide guardrail config
-    # fields (not per-connector), so they are asked once regardless of how
-    # many connectors are being configured.
+    # Scanner mode is process-wide guardrail config, so it is asked once
+    # regardless of how many connectors are being configured. Rule/regex
+    # scanning is the baseline; the judge prompt comes after per-connector
+    # observe/action selection so it reads as an optional layer on top.
     scanner_mode = click.prompt(
         "  " + ux.bold("Scanner mode"),
         type=click.Choice(["local", "remote", "both"], case_sensitive=False),
         default=scanner_mode or "local",
         show_choices=True,
     )
-    with_judge = click.confirm("  " + ux.bold("Enable LLM judge now?"), default=with_judge)
+
+    ux.section("Rule scanning baseline")
+    ux.subhead("Rule/regex scanning is enabled for every selected connector.")
+    ux.subhead("Observe records findings; action blocks matches for connectors selected below.")
 
     # Every connector defaults to observe. The operator names the subset to
     # enforce instead of choosing observe/action for each one. An explicit
@@ -1212,7 +1444,20 @@ def _prompt_first_run(
 
     # Gate action connectors on hook-contract support; unverified ones are
     # downgraded to observe (still guarded, just non-blocking).
-    action_set = set(_supported_action_connectors(requested_action, data_dir=None))
+    action_downgrades: list[dict] = []
+    action_set = set(
+        _supported_action_connectors(
+            requested_action,
+            data_dir=data_dir,
+            downgrades=action_downgrades,
+            allow_trusted_path_prompt=True,
+            rescan_agents=rescan_agents,
+            trusted_prompt_cache=trusted_prompt_cache,
+        )
+    )
+    downgrade_by_connector = {
+        warning["connector"]: warning for warning in action_downgrades
+    }
 
     # The action-only policy knobs (fail-mode + HITL) are asked once and
     # shared across every connector being enabled in action mode.
@@ -1224,6 +1469,9 @@ def _prompt_first_run(
             hilt_min_severity=hilt_min_severity,
         )
 
+    judge_hook_connectors = _prompt_first_run_judge_connectors(connectors, default_all=with_judge)
+    with_judge = bool(judge_hook_connectors)
+
     connector_settings: list[dict] = []
     for c in connectors:
         is_action = c in action_set
@@ -1234,6 +1482,7 @@ def _prompt_first_run(
                 "fail_mode": (shared_fail if is_action else None),
                 "human_approval": (shared_human if is_action else None),
                 "hilt_min_severity": (shared_sev if is_action else None),
+                "mode_warning": downgrade_by_connector.get(c),
             }
         )
 
@@ -1245,7 +1494,83 @@ def _prompt_first_run(
         "  " + ux.bold("Run targeted readiness checks?"),
         default=True if verify is None else bool(verify),
     )
-    return connector_settings, scanner_mode, with_judge, start_gateway, verify
+    return connector_settings, scanner_mode, with_judge, judge_hook_connectors, start_gateway, verify
+
+
+def _prompt_first_run_judge_connectors(connectors: list[str], *, default_all: bool) -> list[str]:
+    """Ask which first-run connectors should get the optional LLM judge."""
+    ux.section("Optional LLM judge")
+    ux.subhead("Rule/regex scanning is already enabled for every active connector selected above.")
+    ux.subhead("Select active connectors that should add LLM judge review on top.")
+    ux.subhead("Leave every box clear for rules-only scanning with no LLM judge calls.")
+    ux.subhead("Configure provider/model/key later with `defenseclaw setup guardrail` or `defenseclaw setup llm`.")
+    return _prompt_checkbox_selection(
+        connectors,
+        default_selected=(connectors if default_all else []),
+        title="Select active connector(s) for LLM judge.",
+        empty_ok=True,
+    )
+
+
+def _prompt_first_run_judge_llm_config(
+    *,
+    data_dir: str | os.PathLike[str],
+    llm_provider: str,
+    llm_model: str,
+    llm_api_key: str,
+    llm_api_key_env: str,
+    llm_base_url: str,
+) -> tuple[str, str, str, str, str]:
+    """Prompt for unified LLM settings when init enables the judge."""
+    ux.section("LLM judge configuration")
+    ux.subhead("These settings are saved to the unified llm block and used by the guardrail judge.")
+    if not click.confirm(
+        "  Configure LLM judge provider/model/API settings now?",
+        default=True,
+    ):
+        return llm_provider, llm_model, llm_api_key, llm_api_key_env, llm_base_url
+
+    from defenseclaw.commands._llm_picker import pick_key_env, pick_model, pick_provider
+    from defenseclaw.commands.cmd_setup import (
+        _LOCAL_LLM_DEFAULT_BASE_URL,
+        _LOCAL_LLM_WIZARD_PROVIDERS,
+        DEFENSECLAW_LLM_KEY_ENV,
+        _prompt_and_save_secret,
+    )
+
+    provider = pick_provider(
+        current=llm_provider or "",
+        flag_value=None,
+        non_interactive=False,
+    )
+    model = pick_model(
+        current=llm_model or "",
+        provider=provider,
+        instance=None,
+        flag_value=None,
+        non_interactive=False,
+    )
+    if provider in _LOCAL_LLM_WIZARD_PROVIDERS:
+        base_url = click.prompt(
+            f"  {provider} base URL",
+            default=llm_base_url or _LOCAL_LLM_DEFAULT_BASE_URL.get(provider, ""),
+            show_default=True,
+        )
+        return provider, model, "", "", base_url
+
+    key_env = pick_key_env(
+        provider=provider,
+        current=llm_api_key_env or DEFENSECLAW_LLM_KEY_ENV,
+        flag_value=None,
+        non_interactive=False,
+    )
+    _prompt_and_save_secret(key_env, llm_api_key, os.fspath(data_dir))
+    base_url = click.prompt(
+        "  LLM base URL (leave blank to use provider default)",
+        default=llm_base_url or "",
+        show_default=bool(llm_base_url),
+    )
+    return provider, model, "", key_env, base_url
 
 
 def _activate_additional_connectors(
@@ -1254,6 +1579,7 @@ def _activate_additional_connectors(
     *,
     start_gateway: bool,
     quiet: bool = False,
+    allow_trusted_path_prompt: bool = False,
 ) -> tuple[list[str], StepResult | None]:
     """Merge the extra first-run connectors into ``guardrail.connectors``.
 
@@ -1287,12 +1613,16 @@ def _activate_additional_connectors(
         return [primary_name], None
 
     gc = cfg.guardrail
-    if not getattr(gc, "connectors", None):
-        gc.connectors = {}
-    # Seed the primary so the multi map represents every active connector.
-    # An empty override means it inherits the global mode/fail/HITL that
-    # run_first_run already wrote for it.
-    gc.connectors.setdefault(primary_name, PerConnectorGuardrailConfig())
+    selected_keys = [primary_name]
+    for s in extras:
+        key = connector_paths.normalize(s["connector"])
+        if key not in selected_keys:
+            selected_keys.append(key)
+    # Rebuild the multi map from the connector selection made in this init
+    # run. Reusing the old map would keep unchecked/stale connectors active in
+    # `guardrail status`.
+    gc.connectors = {primary_name: PerConnectorGuardrailConfig()}
+    trusted_prompt_cache: dict[str, bool] | None = {} if allow_trusted_path_prompt else None
 
     for s in extras:
         key = connector_paths.normalize(s["connector"])
@@ -1305,15 +1635,27 @@ def _activate_additional_connectors(
         # applies the same gate at boot (skipping unverified action connectors),
         # so without this the CLI would silently write an action-mode connector
         # the gateway then refuses to enforce.
-        if mode == "action" and not _check_connector_version_supported_for_setup(
-            key, mode="action", emit=False, data_dir=getattr(cfg, "data_dir", None)
-        ):
-            click.echo(
-                f"  ⚠ {key}: installed version is not verified against a known "
-                "hook contract; configuring in observe mode. Set "
-                "DEFENSECLAW_ALLOW_HOOK_CONTRACT_DRIFT=1 only for exploratory testing.",
-                err=True,
+        version_check_kwargs = {
+            "mode": "action",
+            "emit": allow_trusted_path_prompt,
+            "data_dir": getattr(cfg, "data_dir", None),
+            "_allow_prompt": allow_trusted_path_prompt,
+        }
+        if trusted_prompt_cache is not None:
+            version_check_kwargs["_trusted_prompt_cache"] = trusted_prompt_cache
+        if mode == "action" and not _check_connector_version_supported_for_setup(key, **version_check_kwargs):
+            warning = _fresh_action_downgrade_record(
+                key,
+                data_dir=getattr(cfg, "data_dir", None),
             )
+            s["mode_warning"] = warning
+            if not quiet:
+                click.echo(
+                    f"  ⚠ {key}: requested action but configuring in observe mode "
+                    f"({warning['reason']}). Set "
+                    "DEFENSECLAW_ALLOW_HOOK_CONTRACT_DRIFT=1 only for exploratory testing.",
+                    err=True,
+                )
             mode = "observe"
         pc.mode = "action" if mode == "action" else "observe"
         if s["fail_mode"]:
@@ -1324,6 +1666,15 @@ def _activate_additional_connectors(
                 min_severity=(s["hilt_min_severity"] or "HIGH").upper(),
             )
         gc.connectors[key] = pc
+
+    gate = list(gc.judge.hook_connectors or [])
+    if gate != ["*"]:
+        selected_set = set(selected_keys)
+        gc.judge.hook_connectors = [
+            connector_paths.normalize(c)
+            for c in gate
+            if c and connector_paths.normalize(c) in selected_set
+        ]
 
     # Keep the singular mirror pointing at the sorted-first connector so
     # legacy single-connector readers (older Go binaries, single-connector

--- a/cli/defenseclaw/commands/cmd_quickstart.py
+++ b/cli/defenseclaw/commands/cmd_quickstart.py
@@ -26,6 +26,7 @@ users who want something different should use ``defenseclaw init`` or
 from __future__ import annotations
 
 import json
+import os
 import sys
 
 import click
@@ -124,9 +125,10 @@ import click
     ),
     default=None,
     help="Agent framework connector (alias: --agent). "
-    "Defaults to <data_dir>/picked_connector when set by the installer, "
-    "else the single auto-detected agent. Quickstart errors (no silent "
-    "default) when no agent is detected or several are present.",
+    "Quickstart configures one connector: an explicit value wins, otherwise "
+    "the single configured/detected connector is used. A picked_connector hint "
+    "is used only when no configured/detected connector exists. Bare quickstart "
+    "errors when the connector choice is ambiguous.",
 )
 @click.option(
     "--skip-gateway",
@@ -164,37 +166,50 @@ def quickstart_cmd(
     )
     from defenseclaw.ux import CLIRenderer
 
+    connector_source: dict[str, str] = {}
     if agent_name:
         connector = agent_name
     else:
         data_dir = str(cfg_mod.default_data_path())
-        # SU-12: never silently configure "codex". Resolve from the installer
-        # hint first, then auto-detect installed agents. Stop with an
-        # actionable error when nothing is detected or when several agents are
-        # present (ambiguous) instead of guessing — the operator disambiguates
-        # with --connector/--agent. Quickstart configures a single connector.
-        connector = _read_picked_connector(data_dir)
-        if not connector:
-            detected = _detect_installed_connectors()
-            if len(detected) == 1:
-                connector = detected[0]
-            elif not detected:
+        picked_path = os.path.join(data_dir, "picked_connector")
+        picked = _read_picked_connector(data_dir)
+        detected = _detect_installed_connectors()
+        configured = _configured_quickstart_connectors(cfg_mod)
+        candidates = sorted({name for name in [*configured, *detected] if name})
+        if len(candidates) > 1:
+            click.echo(
+                "  ✗ Multiple connectors detected/configured: "
+                f"{', '.join(candidates)}.\n"
+                "    Quickstart configures one connector.\n"
+                "    Re-run with --connector <name>.",
+                err=True,
+            )
+            sys.exit(2)
+        if len(candidates) == 1:
+            connector = candidates[0]
+            if picked and picked != connector:
                 click.echo(
-                    "  ✗ Could not detect an agent framework on this host.\n"
-                    "    Re-run with an explicit connector, e.g. "
-                    "`defenseclaw quickstart --connector hermes`.",
+                    "  ✗ Connector choice is ambiguous.\n"
+                    f"    picked_connector says {picked}, but the active/detected connector is {connector}.\n"
+                    "    Re-run with --connector <name>.",
                     err=True,
                 )
                 sys.exit(2)
-            else:
-                click.echo(
-                    "  ✗ Multiple agent frameworks detected "
-                    f"({', '.join(detected)}); quickstart configures one.\n"
-                    "    Pick one explicitly, e.g. "
-                    f"`defenseclaw quickstart --connector {detected[0]}`.",
-                    err=True,
-                )
-                sys.exit(2)
+        elif picked:
+            connector = picked
+            connector_source = {
+                "type": "picked_connector",
+                "connector": connector,
+                "path": picked_path,
+            }
+        else:
+            click.echo(
+                "  ✗ Could not detect an agent framework on this host.\n"
+                "    Re-run with an explicit connector, e.g. "
+                "`defenseclaw quickstart --connector hermes`.",
+                err=True,
+            )
+            sys.exit(2)
 
     profile = mode or "observe"
 
@@ -220,8 +235,34 @@ def quickstart_cmd(
         )
     )
     if json_summary:
-        click.echo(json.dumps(report.to_dict(), indent=2))
+        payload = report.to_dict()
+        if connector_source:
+            payload["connector_source"] = connector_source
+        click.echo(json.dumps(payload, indent=2))
     else:
+        if connector_source:
+            click.echo(
+                f"  Using picked connector hint: {connector} from {connector_source['path']}"
+            )
         _render_first_run_report(report, CLIRenderer())
     if report.status == "needs_attention":
         sys.exit(1)
+
+
+def _configured_quickstart_connectors(cfg_mod) -> list[str]:
+    """Return meaningful active connectors from an existing config, if any."""
+    try:
+        config_file = cfg_mod.config_path()
+        if not os.path.exists(config_file):
+            return []
+        cfg = cfg_mod.load()
+    except Exception:
+        return []
+
+    try:
+        if getattr(cfg.guardrail, "connectors", None):
+            return list(cfg.active_connectors())
+        active = cfg.active_connector()
+    except Exception:
+        return []
+    return [] if active == "openclaw" else [active]

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -5448,6 +5448,22 @@ def _apply_setup_batch(
             allow_trusted_path_prompt=allow_trusted_path_prompt,
             trusted_prompt_cache=trusted_prompt_cache,
         )
+        if not ok and (connector_mode or "").strip().lower() == "action":
+            label = _CONNECTOR_META.get(c, {}).get("label", c)
+            ux.warn(
+                f"{label}: requested action mode was refused; configuring observe mode instead."
+            )
+            ok = _apply_hook_connector_setup(
+                app,
+                connector=c,
+                mode="observe",
+                restart=False,
+                write_mode="add",
+                enable_judge=enable_judge,
+                judge_hook_connectors=None,
+                allow_trusted_path_prompt=allow_trusted_path_prompt,
+                trusted_prompt_cache=trusted_prompt_cache,
+            )
         if ok:
             applied.append(c)
 

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -157,7 +157,7 @@ def _safe_mtime(path: str | None) -> float | None:
     "-y",
     "batch_yes",
     is_flag=True,
-    help="(no subcommand) Skip the picker and per-connector prompts (use defaults).",
+    help="(no subcommand) Skip batch mode/judge prompts (use defaults).",
 )
 @click.pass_context
 def setup(
@@ -174,7 +174,7 @@ def setup(
     \b
     Multi-connector:
       One gateway enforces N hook connectors (codex, claudecode,
-      antigravity, openclaw) tracked under guardrail.connectors. Add one
+      hermes, antigravity) tracked under guardrail.connectors. Add one
       with 'defenseclaw setup <connector>' (choose Add when prompted),
       remove with 'defenseclaw setup remove <name>'. Scope policy per peer
       with 'defenseclaw guardrail ... --connector X', and inspect the
@@ -184,10 +184,10 @@ def setup(
     \b
     Batch (no subcommand):
       'defenseclaw setup' with no subcommand launches an interactive
-      multi-connector picker (detected connectors pre-checked) with
-      per-connector mode/judge prompts. For scripting, select connectors
-      with repeatable '-c/--connector', '--detected', and/or '--all'
-      (e.g. 'defenseclaw setup -c hermes -c codex --mode action').
+      active-connector picker (detected connectors pre-checked), then
+      batch mode / optional judge connector pickers. For scripting, select
+      connectors with repeatable '-c/--connector', '--detected', and/or
+      '--all' (e.g. 'defenseclaw setup -c hermes -c codex --mode action').
     """
     # Snapshot config.yaml's mtime before the subcommand runs. The
     # result callback below (``_auto_restart_sidecar_after_setup``)
@@ -2862,6 +2862,7 @@ def _check_connector_version_supported_for_setup(
     emit: bool = True,
     data_dir: str | os.PathLike[str] | None = None,
     _allow_prompt: bool = True,
+    _trusted_prompt_cache: dict[str, bool] | None = None,
 ) -> bool:
     """Verify the selected connector's installed version before setup.
 
@@ -2874,6 +2875,8 @@ def _check_connector_version_supported_for_setup(
     It defaults to ``True`` so direct CLI use is unchanged, but callers that
     must never block on stdin — the TUI, or this function's own re-entry after
     trusting a prefix — pass ``False`` to force the non-interactive path.
+    ``_trusted_prompt_cache`` is a flow-local map keyed by trusted directory so
+    batch setup can avoid asking the same yes/no question repeatedly.
     """
     connector = normalize_connector(connector)
     label = _CONNECTOR_META.get(connector, {}).get("label", connector or "connector")
@@ -2947,6 +2950,13 @@ def _check_connector_version_supported_for_setup(
         if is_untrusted_path:
             resolved_bin = os.path.realpath(signal.binary_path)
             parent = os.path.dirname(resolved_bin)
+        already_asked = bool(
+            is_untrusted_path
+            and _trusted_prompt_cache is not None
+            and parent in _trusted_prompt_cache
+        )
+        if already_asked:
+            interactive = False
         if emit and is_untrusted_path and interactive:
             ux.warn(detail)
             ux.subhead(f"  Binary resolves to: {resolved_bin}")
@@ -2957,6 +2967,8 @@ def _check_connector_version_supported_for_setup(
             )
             if click.confirm(f"  Add '{parent}' to trusted binary prefixes?", default=False):
                 _add_trusted_bin_prefix(parent, data_dir or os.path.expanduser("~/.defenseclaw"))
+                if _trusted_prompt_cache is not None:
+                    _trusted_prompt_cache[parent] = True
                 ux.subhead(f"  Trusted '{parent}' (persisted to ~/.defenseclaw/.env); re-checking…")
                 ux.subhead(
                     "  Note: if this path is version-specific it may need re-trusting "
@@ -2975,7 +2987,10 @@ def _check_connector_version_supported_for_setup(
                     emit=emit,
                     data_dir=data_dir,
                     _allow_prompt=False,
+                    _trusted_prompt_cache=_trusted_prompt_cache,
                 )
+            if _trusted_prompt_cache is not None:
+                _trusted_prompt_cache[parent] = False
             # Declined: fall through to the mode-specific handling below.
 
         if action_mode and not allow_drift:
@@ -3017,6 +3032,62 @@ def _check_connector_version_supported_for_setup(
     return True
 
 
+def _guardrail_setup_check_targets(app: AppContext, gc, explicit_connector: str | None) -> list[str]:
+    """Connectors whose binaries should be verified before guardrail setup."""
+    targets: list[str] = []
+
+    def _add(raw: str | None) -> None:
+        if not raw:
+            return
+        try:
+            connector = normalize_connector(raw)
+        except Exception:  # noqa: BLE001 - defensive against unmodeled test stubs.
+            connector = str(raw).strip().lower()
+        if connector and connector not in targets:
+            targets.append(connector)
+
+    if explicit_connector:
+        _add(explicit_connector)
+        return targets
+
+    try:
+        for connector in app.cfg.active_connectors():
+            _add(connector)
+    except Exception:  # noqa: BLE001 - SimpleNamespace tests may omit the method.
+        pass
+
+    if not targets:
+        _add(getattr(gc, "connector", "") or "openclaw")
+    return targets
+
+
+def _check_guardrail_setup_connector_versions(
+    app: AppContext,
+    gc,
+    *,
+    explicit_connector: str | None,
+    allow_prompt: bool,
+) -> bool:
+    """Verify every connector affected by a guardrail setup run."""
+    trusted_prompt_cache: dict[str, bool] | None = {} if allow_prompt else None
+    for connector in _guardrail_setup_check_targets(app, gc, explicit_connector):
+        mode = (
+            gc.effective_mode(connector)
+            if hasattr(gc, "effective_mode")
+            else (getattr(gc, "mode", "") or "observe")
+        )
+        version_check_kwargs = {
+            "mode": mode or "observe",
+            "data_dir": getattr(app.cfg, "data_dir", None),
+            "_allow_prompt": allow_prompt,
+        }
+        if trusted_prompt_cache is not None:
+            version_check_kwargs["_trusted_prompt_cache"] = trusted_prompt_cache
+        if not _check_connector_version_supported_for_setup(connector, **version_check_kwargs):
+            return False
+    return True
+
+
 def _hilt_support_note(connector: str) -> str:
     """Return the operator-facing HILT support note for a connector."""
     if connector == "openclaw":
@@ -3044,15 +3115,25 @@ def _hilt_support_note(connector: str) -> str:
     return "Support depends on the connector surface."
 
 
-def _configure_hilt_interactive(gc) -> None:
+def _configure_hilt_interactive(gc, *, action_connectors: list[str] | None = None) -> None:
     """Prompt for human approval settings from the guardrail advanced section."""
     ux.section("Human Approval (HILT)")
-    if (gc.mode or "observe").lower() != "action":
+    if action_connectors is not None:
+        if not action_connectors:
+            ux.subhead("Human approval is action-mode only.")
+            ux.subhead("No connector is currently in action mode, so approvals are inactive.")
+            return
+        ux.subhead(
+            "Applies to action-mode connector(s): "
+            + ", ".join(action_connectors)
+        )
+        connector = action_connectors[0] if len(action_connectors) == 1 else (gc.connector or "openclaw")
+    elif (gc.mode or "observe").lower() != "action":
         ux.subhead("Human approval is action-mode only.")
         ux.subhead("Current mode is observe, so approvals are inactive and no prompts will appear.")
         return
-
-    connector = gc.connector or "openclaw"
+    else:
+        connector = gc.connector or "openclaw"
     ux.subhead(_hilt_support_note(connector))
     ux.subhead("CRITICAL findings still block. HILT can confirm risky HIGH findings first.")
     enabled = click.confirm("  Human approval for risky actions?", default=gc.hilt.enabled)
@@ -3218,13 +3299,11 @@ def _resolve_judge_hook_gate(
 ) -> list[str] | None:
     """Resolve ``--judge-hook-connectors`` into a new ``judge.hook_connectors`` gate (B2).
 
-    The hook-lane judge is opt-in per connector via
-    ``guardrail.judge.hook_connectors``; the interactive wizard prompts for it
-    (``_prompt_judge_hook_connectors``) but the non-interactive path — which the
-    TUI guardrail wizard drives as a subprocess — had no surface, so a
-    "complete" judge setup left the gate empty and the judge inspected zero hook
-    connectors. This maps the CLI flag onto the same gate the interactive prompt
-    and ``guardrail judge add/list`` speak.
+    The hook-lane judge is tunable per connector via
+    ``guardrail.judge.hook_connectors``. Guardrail-level setup can still opt
+    every hook connector into judge review; direct connector setup defaults to
+    the connector being configured. This flag remains the explicit
+    non-interactive / advanced surface for widening or narrowing that gate.
 
     Accepted values:
       * ``all`` / ``*``  → ``["*"]`` (the all-hook-connectors sentinel)
@@ -3743,6 +3822,21 @@ def setup_guardrail(
                 if (target_connector or gc.connector or "openclaw") in _PROXY_BACKED_CONNECTORS
                 else "judge_only"
             )
+        if detection_strategy is not None:
+            if _strategy_uses_judge(detection_strategy):
+                gc.judge.enabled = True
+            elif detection_strategy == "regex_only":
+                gc.judge.enabled = False
+        if judge_hook_connectors is not None:
+            hook_gate_value = judge_hook_connectors.strip().lower()
+            if hook_gate_value in ("", "none"):
+                gc.judge.enabled = False
+                gc.detection_strategy = "regex_only"
+                gc.detection_strategy_completion = "regex_only"
+            else:
+                gc.judge.enabled = True
+                if not gc.detection_strategy or gc.detection_strategy == "regex_only":
+                    gc.detection_strategy = "regex_judge"
         gc.enabled = True
 
         # Apply sensible strategy defaults when judge is enabled
@@ -3769,7 +3863,10 @@ def setup_guardrail(
         # judge setup never leaves the hook lane silently un-judged.
         new_gate = _resolve_judge_hook_gate(
             judge_hook_connectors,
-            judge_just_enabled=(gc.judge.enabled and not was_judge_enabled),
+            judge_just_enabled=(
+                gc.judge.enabled
+                and (not was_judge_enabled or not list(gc.judge.hook_connectors or []))
+            ),
             current=list(gc.judge.hook_connectors or []),
         )
         if new_gate is not None:
@@ -3804,16 +3901,11 @@ def setup_guardrail(
         click.echo("  Guardrail not enabled. Run again without declining to configure.")
         return
 
-    setup_connector = target_connector if non_interactive else gc.connector
-    enforcement_mode = (
-        gc.effective_mode(setup_connector)
-        if setup_connector and hasattr(gc, "effective_mode")
-        else (gc.mode or "observe")
-    )
-    if not _check_connector_version_supported_for_setup(
-        setup_connector or gc.connector or "openclaw",
-        mode=enforcement_mode or "observe",
-        data_dir=getattr(app.cfg, "data_dir", None),
+    if not _check_guardrail_setup_connector_versions(
+        app,
+        gc,
+        explicit_connector=(target_connector if non_interactive else explicit_connector),
+        allow_prompt=not non_interactive,
     ):
         return
 
@@ -4259,10 +4351,10 @@ def _apply_judge_enablement(
     """Wire setup-time LLM-judge enablement for *connector* (SU-07/B3).
 
     ``enable_judge=True`` turns the judge on globally, bumps the strategy off
-    ``regex_only`` so it actually runs, and ensures *connector* is in the
-    hook-lane gate (``judge.hook_connectors``) — honoring an explicit
-    ``judge_hook_connectors`` spec, else defaulting to all hook connectors
-    (``["*"]``) the first time the judge is enabled (tui.md §10.2).
+    ``regex_only`` so it actually runs, and defaults the hook-lane gate
+    (``judge.hook_connectors``) to this connector. An explicit
+    ``judge_hook_connectors`` spec is still honored for scripted advanced
+    setup.
     ``enable_judge=False`` opts *connector* out of a concrete gate (leaving the
     global ``judge.enabled`` alone — peers may still use it). ``None`` is a
     no-op unless an explicit gate spec was passed.
@@ -4275,17 +4367,22 @@ def _apply_judge_enablement(
         gc.judge.enabled = True
         if not gc.detection_strategy or gc.detection_strategy == "regex_only":
             gc.detection_strategy = "regex_judge"
-        new_gate = _resolve_judge_hook_gate(
-            judge_hook_connectors,
-            judge_just_enabled=not was_enabled,
-            current=list(gc.judge.hook_connectors or []),
-        )
+        if judge_hook_connectors is None:
+            current = list(gc.judge.hook_connectors or []) if was_enabled else []
+            if current == ["*"]:
+                new_gate = current
+            else:
+                new_gate = list(current)
+                if connector not in new_gate:
+                    new_gate.append(connector)
+        else:
+            new_gate = _resolve_judge_hook_gate(
+                judge_hook_connectors,
+                judge_just_enabled=not was_enabled,
+                current=list(gc.judge.hook_connectors or []),
+            )
         if new_gate is not None:
             gc.judge.hook_connectors = new_gate
-        gate = list(gc.judge.hook_connectors or [])
-        if gate != ["*"] and connector not in gate:
-            gate.append(connector)
-            gc.judge.hook_connectors = gate
         return
 
     if judge_hook_connectors is not None:
@@ -4323,6 +4420,8 @@ def _apply_hook_connector_setup(
     hilt_min_severity: str | None = None,
     enable_judge: bool | None = None,
     judge_hook_connectors: str | None = None,
+    allow_trusted_path_prompt: bool = True,
+    trusted_prompt_cache: dict[str, bool] | None = None,
 ) -> bool:
     """Pin DefenseClaw to *connector* in hook-driven mode.
 
@@ -4373,11 +4472,14 @@ def _apply_hook_connector_setup(
     if desired_mode not in ("observe", "action"):
         desired_mode = "observe"
 
-    if not _check_connector_version_supported_for_setup(
-        connector,
-        mode=desired_mode,
-        data_dir=getattr(app.cfg, "data_dir", None),
-    ):
+    version_check_kwargs = {
+        "mode": desired_mode,
+        "data_dir": getattr(app.cfg, "data_dir", None),
+        "_allow_prompt": allow_trusted_path_prompt,
+    }
+    if trusted_prompt_cache is not None:
+        version_check_kwargs["_trusted_prompt_cache"] = trusted_prompt_cache
+    if not _check_connector_version_supported_for_setup(connector, **version_check_kwargs):
         return False
 
     cfg = app.cfg
@@ -4466,13 +4568,12 @@ def _apply_hook_connector_setup(
         hilt=hilt,
         hilt_min_severity=hilt_min_severity,
     )
-    # SU-07 / B3: setup-time LLM-judge enablement for this connector. Flips the
-    # global gc.judge.enabled, opts THIS connector into the hook-lane gate
-    # (judge.hook_connectors), and bumps the strategy off regex_only so the
-    # judge actually runs. Full judge LLM config (model/key) stays the job of
-    # `setup guardrail` / `setup llm`; this only wires setup-time enablement
-    # (SU-07 scope — the tool-output/tool-call Go lane wiring is Round-2
-    # fu/judge-go). Default (enable_judge is None) leaves judge state alone.
+    # SU-07 / B3: setup-time LLM-judge enablement. Flips the global
+    # gc.judge.enabled switch, opts this connector into hook-lane coverage,
+    # and bumps the strategy off regex_only so the judge actually runs. Full
+    # judge LLM config (model/key) stays the job of `setup guardrail` /
+    # `setup llm`; this only wires setup-time enablement. Default
+    # (enable_judge is None) leaves judge state alone.
     _apply_judge_enablement(
         gc,
         connector=connector,
@@ -4518,19 +4619,18 @@ def _apply_hook_connector_setup(
         )
     else:
         click.echo(
-            f"  ✓ Active connector set to {connector!r} "
+            f"  ✓ Connector {connector!r} configured "
             f"(claw.mode={getattr(cfg.claw, 'mode', '') or connector})"
         )
     if workspace:
         click.echo(f"  ✓ Workspace root pinned to {workspace}")
     else:
         click.echo("  ✓ Scope: global user config (no workspace pinned)")
-    # SU-01: echo where the mode actually landed — per-connector override vs the
-    # shared global field — so the summary matches what was written.
-    if write_mode == "add" and connector in gc.connectors:
-        click.echo(f"  ✓ {connector} mode={desired_mode} (per-connector)")
-    else:
-        click.echo(f"  ✓ guardrail.mode={desired_mode}")
+    # Hook connector setup should describe mode in connector terms. The first
+    # connector may still be represented through legacy global fields on disk,
+    # but presenting that as guardrail.mode nudges users toward unsafe global
+    # edits on multi-connector installs.
+    click.echo(f"  ✓ {connector} mode={desired_mode}")
 
     _write_guardrail_runtime(cfg.data_dir, gc)
 
@@ -4596,11 +4696,11 @@ def _print_connector_observability_banner(connector: str, *, mode: str = "observ
         click.echo("    • Notify     — agent-turn-complete events → /api/v1/codex/notify")
     click.echo()
     if mode == "observe":
-        click.echo("  To later turn enforcement on, set guardrail.mode=action")
-        click.echo("  in ~/.defenseclaw/config.yaml and restart the gateway.")
+        click.echo("  To later turn enforcement on:")
+        click.echo(f"    defenseclaw setup {connector} --mode action")
     else:
-        click.echo("  To revert to observe-only, set guardrail.mode=observe")
-        click.echo("  in ~/.defenseclaw/config.yaml and restart the gateway.")
+        click.echo("  To revert to observe-only:")
+        click.echo(f"    defenseclaw setup {connector} --mode observe")
     click.echo()
     _print_connector_mutation_notice(connector)
     click.echo()
@@ -4644,7 +4744,7 @@ def _print_observability_summary(connector: str, cfg=None, *, mode: str = "obser
             ),
         ),
         ("guardrail.enabled", "true"),
-        ("guardrail.mode", mode),
+        (f"{connector} mode", mode),
         ("enforcement", enforcement_label),
         ("ai_discovery", f"enabled ({cfg.ai_discovery.mode})" if cfg else "enabled"),
     ]
@@ -4789,7 +4889,7 @@ def _prompt_connector_mode(connector: str, *, default_mode: str) -> str:
 
 
 def _prompt_enable_judge(connector: str, gc) -> bool:
-    """SU-07: interactive 'enable the LLM judge for this connector?' prompt.
+    """SU-07: interactive setup-time LLM judge prompt.
 
     Returns True when the operator opts in. Default reflects whether the judge
     already covers this connector (so re-running setup with Enter preserves
@@ -4798,12 +4898,17 @@ def _prompt_enable_judge(connector: str, gc) -> bool:
     """
     gate = list(gc.judge.hook_connectors or [])
     already = bool(gc.judge.enabled) and (gate == ["*"] or connector in gate)
-    ux.section("LLM judge")
-    ux.subhead("Adds semantic injection/PII/exfil detection on top of regex.")
+    ux.section("Optional LLM judge")
+    ux.subhead(f"Rule/regex scanning is already enabled for {_CONNECTOR_META[connector]['label']}.")
+    ux.subhead("The judge adds semantic injection/PII/exfil detection on top of those rules.")
     ux.subhead("Judged hook calls add latency (up to the hook timeout) and LLM cost.")
-    ux.subhead("Configure the judge model later via `defenseclaw setup guardrail`.")
+    ux.subhead("These LLM settings are shared by all connectors with judge enabled.")
+    ux.subhead(
+        "This only enables judge scanning; configure provider/model/key with "
+        "`defenseclaw setup guardrail` or `defenseclaw setup llm`."
+    )
     return click.confirm(
-        f"  Enable the LLM judge for {_CONNECTOR_META[connector]['label']}?",
+        "  Add LLM judge on top of rule scanning?",
         default=already,
     )
 
@@ -4921,7 +5026,7 @@ def _setup_observability_alias(
     # SU-07: judge-enable prompt. Asked after the operator commits to
     # proceeding (write_mode resolved, not cancelled). Only when the operator
     # didn't already decide via --enable-judge/--no-enable-judge. On yes,
-    # _apply_hook_connector_setup flips the judge on, gates this connector, and
+    # _apply_hook_connector_setup flips the judge on for this connector and
     # bumps the strategy off regex_only.
     if interactive and enable_judge is None and _prompt_enable_judge(connector, gc):
         enable_judge = True
@@ -4941,9 +5046,24 @@ def _setup_observability_alias(
         hilt_min_severity=hilt_min_severity,
         enable_judge=enable_judge,
         judge_hook_connectors=judge_hook_connectors,
+        allow_trusted_path_prompt=interactive,
     )
     if not ok:
         raise click.ClickException(f"failed to configure {connector} (mode={normalized_mode}) — see errors above")
+
+    if interactive and enable_judge:
+        configure_model = click.confirm(
+            "  Configure LLM judge provider/model/API settings now?",
+            default=_judge_llm_needs_configuration(app),
+        )
+        if configure_model:
+            _prompt_judge_model_config(app, app.cfg.guardrail)
+            try:
+                app.cfg.save()
+                click.echo("  ✓ Judge LLM config saved to ~/.defenseclaw/config.yaml")
+            except OSError as exc:
+                raise click.ClickException(f"failed to save judge LLM config: {exc}") from exc
+
     if not restart:
         ctx = click.get_current_context(silent=True)
         if ctx is not None:
@@ -4957,9 +5077,9 @@ def _run_setup_picker(app: AppContext) -> list[str]:
     """SU-11: interactive multi-connector picker for bare ``setup``.
 
     Lists every supported hook connector with detected/configured tags,
-    pre-selects the detected + already-configured ones, and returns the
-    operator's chosen set (per-connector mode/judge prompts happen later in
-    ``_apply_setup_batch``). Returns an empty list when the operator selects
+    pre-selects the detected + already-configured ones, and returns the active
+    operator's chosen set (batch mode/judge pickers happen later in
+    ``_dispatch_bare_setup``). Returns an empty list when the operator selects
     nothing. Only called on an interactive TTY (the caller falls back to help
     on a non-interactive stream).
     """
@@ -4970,38 +5090,283 @@ def _run_setup_picker(app: AppContext) -> list[str]:
     }
     preselect = detected | configured
 
-    ux.section("Select connectors to configure")
-    ux.subhead("Detected and already-configured connectors are pre-selected.")
-    click.echo()
-    for i, c in enumerate(candidates, 1):
-        mark = "x" if c in preselect else " "
+    display_by_connector: dict[str, str] = {}
+    for c in candidates:
         tags = []
         if c in detected:
             tags.append("detected")
         if c in configured:
             tags.append("configured")
         suffix = f"  {ux.dim('(' + ', '.join(tags) + ')')}" if tags else ""
-        click.echo(f"    [{mark}] {i:>2}. {_CONNECTOR_META[c]['label']}{suffix}")
-    click.echo()
+        display_by_connector[c] = f"{_CONNECTOR_META[c]['label']}{suffix}"
+    connector_by_display = {label: c for c, label in display_by_connector.items()}
 
-    default_sel = ",".join(str(i) for i, c in enumerate(candidates, 1) if c in preselect)
-    raw = click.prompt(
-        "  Enter the numbers to configure (comma-separated)",
-        default=default_sel,
-        show_default=bool(default_sel),
+    ux.section("Select active connectors")
+    ux.subhead("Detected and already-configured connectors are pre-selected.")
+    ux.subhead("Unchecked connectors will not remain active after this setup run.")
+    selected = _prompt_checkbox_selection(
+        [display_by_connector[c] for c in candidates],
+        default_selected=[display_by_connector[c] for c in candidates if c in preselect],
+        title="Use Space to choose active connectors.",
+        empty_ok=True,
     )
-    chosen: list[str] = []
-    for token in str(raw).replace(" ", ",").split(","):
-        token = token.strip()
-        if not token:
+    return [connector_by_display[label] for label in selected]
+
+
+def _connector_display_options(connectors: list[str]) -> tuple[list[str], dict[str, str], dict[str, str]]:
+    """Return checkbox labels plus connector/display lookup maps."""
+    display_by_connector = {c: _CONNECTOR_META[c]["label"] for c in connectors}
+    connector_by_display = {label: c for c, label in display_by_connector.items()}
+    return [display_by_connector[c] for c in connectors], display_by_connector, connector_by_display
+
+
+def _prompt_batch_connector_modes(connectors: list[str], gc, *, default_mode: str) -> dict[str, str]:
+    """Ask once which selected connectors should use action mode."""
+    options, display_by_connector, connector_by_display = _connector_display_options(connectors)
+    default_action = [
+        display_by_connector[c]
+        for c in connectors
+        if (
+            (default_mode or "").strip().lower() == "action"
+            or (hasattr(gc, "effective_mode") and gc.effective_mode(c) == "action")
+        )
+    ]
+    ux.section("Enforcement mode")
+    ux.subhead("Rule/regex scanning applies to every active connector selected above.")
+    ux.subhead("Checked active connectors use action mode; unchecked ones use observe.")
+    ux.subhead("Action blocks matching tool calls. Observe logs and alerts only.")
+    selected = _prompt_checkbox_selection(
+        options,
+        default_selected=default_action,
+        title="Select active connector(s) for action mode.",
+        empty_ok=True,
+    )
+    action_connectors = {connector_by_display[label] for label in selected}
+    return {c: ("action" if c in action_connectors else "observe") for c in connectors}
+
+
+def _write_per_connector_modes(gc, connector_modes: dict[str, str]) -> bool:
+    """Persist per-connector observe/action choices and report whether any changed."""
+    if not connector_modes:
+        return False
+    if not getattr(gc, "connectors", None):
+        gc.connectors = {}
+
+    changed = False
+    for connector, mode in connector_modes.items():
+        current = (
+            gc.effective_mode(connector)
+            if hasattr(gc, "effective_mode")
+            else (getattr(gc, "mode", "") or "observe")
+        )
+        normalized = "action" if str(mode).strip().lower() == "action" else "observe"
+        if connector not in gc.connectors:
+            gc.connectors[connector] = PerConnectorGuardrailConfig()
+        gc.connectors[connector].mode = normalized
+        changed = changed or normalized != current
+    return changed
+
+
+def _existing_connector_override(gc, connector: str):
+    """Return an existing per-connector override matching *connector*, if any."""
+    wanted = normalize_connector(connector)
+    for key, pc in (getattr(gc, "connectors", None) or {}).items():
+        try:
+            normalized_key = normalize_connector(str(key))
+        except Exception:  # noqa: BLE001 - defensive for hand-written configs.
+            normalized_key = str(key).strip().lower()
+        if normalized_key == wanted:
+            return pc
+    return None
+
+
+def _reconcile_batch_active_connectors(cfg, connectors: list[str]) -> list[str]:
+    """Make bare setup's active connector map exactly match the selected set."""
+    selected: list[str] = []
+    for raw in connectors:
+        name = normalize_connector(raw)
+        if name not in selected:
+            selected.append(name)
+    if not selected:
+        return []
+
+    gc = cfg.guardrail
+    before = {
+        normalize_connector(str(c))
+        for c in (getattr(gc, "connectors", None) or {})
+        if str(c).strip()
+    }
+    if not before:
+        current = (getattr(gc, "connector", "") or getattr(cfg.claw, "mode", "") or "").strip()
+        if current:
+            before.add(normalize_connector(current))
+
+    gc.connectors = {
+        name: (_existing_connector_override(gc, name) or PerConnectorGuardrailConfig())
+        for name in selected
+    }
+    primary = sorted(selected)[0]
+    gc.connector = primary
+    cfg.claw.mode = primary
+
+    gate = list(gc.judge.hook_connectors or [])
+    if gate != ["*"]:
+        selected_set = set(selected)
+        gc.judge.hook_connectors = [
+            normalize_connector(c)
+            for c in gate
+            if c and normalize_connector(c) in selected_set
+        ]
+
+    removed = sorted(before - set(selected))
+    if removed:
+        click.echo("  " + ux.dim("Inactive connectors removed from this setup: " + ", ".join(removed)))
+    return removed
+
+
+def _strategy_uses_judge(strategy: str) -> bool:
+    return (strategy or "").strip().lower() in {"regex_judge", "judge_first"}
+
+
+def _prompt_batch_scan_strategy(gc) -> str:
+    """Ask once how hook calls should be scanned for a batch setup."""
+    ux.section("Scan strategy")
+    ux.subhead("Choose the detection strategy for all configured hook connectors.")
+    ux.subhead("Judge strategies use your configured LLM judge; this setup can ask for model settings next.")
+    ux.subhead(
+        "You can also configure provider/model/key later with "
+        "`defenseclaw setup guardrail` or `defenseclaw setup llm`."
+    )
+    click.echo("    " + ux.bold("[1] regex only") + "   — rules and regex scanning, no LLM judge calls")
+    click.echo("    " + ux.bold("[2] regex + judge") + " — rules first, then LLM judge review")
+    click.echo("    " + ux.bold("[3] judge first") + "  — LLM judge first, with regex fallback")
+    current = (getattr(gc, "detection_strategy", "") or "regex_only").strip().lower()
+    default = {"regex_only": "1", "regex_judge": "2", "judge_first": "3"}.get(current, "1")
+    choice = click.prompt(
+        "  Select scan strategy",
+        type=click.Choice(["1", "2", "3"]),
+        default=default,
+    )
+    return {"1": "regex_only", "2": "regex_judge", "3": "judge_first"}[choice]
+
+
+def _set_hook_judge_coverage_all(gc) -> None:
+    gc.judge.hook_connectors = ["*"]
+    click.echo("  " + ux.dim("Hook judge coverage: all configured hook connectors"))
+
+
+def _default_batch_judge_labels(
+    connectors: list[str],
+    gc,
+    display_by_connector: dict[str, str],
+) -> list[str]:
+    if not bool(getattr(gc.judge, "enabled", False)):
+        return []
+    gate = list(getattr(gc.judge, "hook_connectors", []) or [])
+    if gate == ["*"]:
+        selected = set(connectors)
+    else:
+        selected = {c for c in connectors if c in gate}
+    return [display_by_connector[c] for c in connectors if c in selected]
+
+
+def _merge_batch_judge_selection(gc, connectors: list[str], selected_connectors: set[str]) -> list[str]:
+    """Apply a bare-setup judge checkbox selection without a strategy prompt."""
+    targets = set(connectors)
+    # Bare setup is scoped to the connectors selected at the top of the flow.
+    # Do not carry previously configured, unselected connectors into the judge
+    # gate; otherwise the checkbox summary can name connectors the operator
+    # deliberately left out of this setup run.
+    new_gate = sorted(c for c in selected_connectors if c in targets)
+    gc.judge.hook_connectors = new_gate
+    if new_gate:
+        gc.judge.enabled = True
+        if not gc.detection_strategy or gc.detection_strategy == "regex_only":
+            gc.detection_strategy = "regex_judge"
+        _apply_judge_runtime_defaults(gc)
+        click.echo("  " + ux.dim(f"Hook judge connectors: {', '.join(new_gate)}"))
+    else:
+        gc.judge.enabled = False
+        gc.detection_strategy = "regex_only"
+        gc.detection_strategy_completion = "regex_only"
+        click.echo("  " + ux.dim("LLM judge: off (rule/regex scanning only)"))
+    return new_gate
+
+
+def _prompt_batch_judge_connectors(connectors: list[str], gc) -> set[str]:
+    """Ask once which selected connectors should add LLM judge review."""
+    options, display_by_connector, connector_by_display = _connector_display_options(connectors)
+    ux.section("Optional LLM judge")
+    ux.subhead("Rule/regex scanning is enabled by default for every active connector selected above.")
+    ux.subhead("Checked active connectors add LLM judge review on top.")
+    ux.subhead("These LLM settings are shared by all connectors with judge enabled.")
+    selected = _prompt_checkbox_selection(
+        options,
+        default_selected=_default_batch_judge_labels(connectors, gc, display_by_connector),
+        title="Select active connector(s) that should use the LLM judge.",
+        empty_ok=True,
+    )
+    selected_connectors = {connector_by_display[label] for label in selected}
+    _merge_batch_judge_selection(gc, connectors, selected_connectors)
+    return selected_connectors
+
+
+def _prompt_batch_trusted_prefixes(
+    app: AppContext,
+    connector_modes: dict[str, str],
+) -> dict[str, bool]:
+    """Prompt once per untrusted binary directory before batch judge prompts."""
+    cache: dict[str, bool] = {}
+    if not connector_modes:
+        return cache
+
+    try:
+        disc = agent_discovery.discover_agents(
+            use_cache=False,
+            refresh=True,
+            data_dir=getattr(app.cfg, "data_dir", None),
+        )
+    except Exception as exc:  # noqa: BLE001 - final per-connector validation reports details.
+        ux.warn(f"Could not refresh local connector discovery before setup ({exc}); continuing.")
+        return cache
+
+    for connector in connector_modes:
+        signal = disc.agents.get(connector)
+        if (
+            signal is None
+            or not bool(getattr(signal, "installed", False))
+            or getattr(signal, "error", "") != agent_discovery.UNTRUSTED_PREFIX_ERROR
+            or not getattr(signal, "binary_path", "")
+        ):
             continue
-        if not token.isdigit() or not (1 <= int(token) <= len(candidates)):
-            ux.warn(f"  Ignoring invalid selection {token!r}.")
+        resolved_bin = os.path.realpath(signal.binary_path)
+        parent = os.path.dirname(resolved_bin)
+        if parent in cache:
             continue
-        c = candidates[int(token) - 1]
-        if c not in chosen:
-            chosen.append(c)
-    return chosen
+
+        label = _CONNECTOR_META.get(connector, {}).get("label", connector)
+        ux.warn(f"{label}: binary path is outside DefenseClaw's trusted prefixes.")
+        ux.subhead(f"  Binary resolves to: {resolved_bin}")
+        ux.subhead(f"  Directory '{parent}' is not in the trusted prefix list.")
+        ux.subhead(
+            "  Trusting a directory lets DefenseClaw execute any binary placed "
+            "there during discovery — only trust locations you control."
+        )
+        if click.confirm(f"  Add '{parent}' to trusted binary prefixes?", default=False):
+            _add_trusted_bin_prefix(parent, getattr(app.cfg, "data_dir", None) or os.path.expanduser("~/.defenseclaw"))
+            cache[parent] = True
+            ux.subhead(f"  Trusted '{parent}' (persisted to ~/.defenseclaw/.env).")
+        else:
+            cache[parent] = False
+    return cache
+
+
+def _judge_llm_needs_configuration(app: AppContext) -> bool:
+    try:
+        resolved = app.cfg.resolve_llm("guardrail.judge")
+        return not (bool(resolved.model) and bool(resolved.resolved_api_key()))
+    except Exception:  # noqa: BLE001 — prompt conservatively if resolution fails.
+        return True
 
 
 def _apply_setup_batch(
@@ -5012,12 +5377,15 @@ def _apply_setup_batch(
     mode: str,
     restart: bool,
     prompt_per_connector: bool,
+    connector_modes: dict[str, str] | None = None,
+    allow_trusted_path_prompt: bool = True,
+    trusted_prompt_cache: dict[str, bool] | None = None,
 ) -> None:
     """Configure each connector in *connectors* as a multi-connector batch (SU-11).
 
     Each connector is written with the additive (``add``) shape so they all
-    land in ``guardrail.connectors`` as peers, with per-connector mode (and, if
-    prompted, judge) overrides. The gateway is bounced once at the end via the
+    land in ``guardrail.connectors`` as peers, with per-connector mode
+    overrides. The gateway is bounced once at the end via the
     group's auto-restart result callback (suppressed for ``--no-restart``)
     rather than per connector.
     """
@@ -5027,8 +5395,12 @@ def _apply_setup_batch(
     click.echo(f"  Configuring {len(connectors)} connector(s): {', '.join(connectors)}")
 
     applied: list[str] = []
+    if allow_trusted_path_prompt:
+        trusted_prompt_cache = trusted_prompt_cache if trusted_prompt_cache is not None else {}
+    else:
+        trusted_prompt_cache = None
     for c in connectors:
-        connector_mode = default_mode
+        connector_mode = (connector_modes or {}).get(c, default_mode)
         enable_judge: bool | None = None
         if prompt_per_connector:
             connector_mode = _prompt_connector_mode(c, default_mode=connector_mode)
@@ -5041,6 +5413,9 @@ def _apply_setup_batch(
             restart=False,
             write_mode="add",
             enable_judge=enable_judge,
+            judge_hook_connectors=None,
+            allow_trusted_path_prompt=allow_trusted_path_prompt,
+            trusted_prompt_cache=trusted_prompt_cache,
         )
         if ok:
             applied.append(c)
@@ -5119,14 +5494,34 @@ def _dispatch_bare_setup(
             click.echo("  Aborted — no connectors selected.")
             return
 
-    prompt_per_connector = (not yes) and _is_interactive()
+    prompt_batch = (not yes) and _is_interactive()
+    connector_modes: dict[str, str] | None = None
+    judge_connectors: set[str] | None = None
+    trusted_prompt_cache: dict[str, bool] | None = None
+    if prompt_batch:
+        gc = app.cfg.guardrail
+        connector_modes = _prompt_batch_connector_modes(targets, gc, default_mode=mode)
+        trusted_prompt_cache = _prompt_batch_trusted_prefixes(app, connector_modes)
+        judge_connectors = _prompt_batch_judge_connectors(targets, gc)
+        if judge_connectors:
+            configure_model = click.confirm(
+                "  Configure LLM judge provider/model/API settings now?",
+                default=_judge_llm_needs_configuration(app),
+            )
+            if configure_model:
+                _prompt_judge_model_config(app, gc)
+
+    _reconcile_batch_active_connectors(app.cfg, targets)
     _apply_setup_batch(
         ctx,
         app,
         targets,
         mode=mode,
         restart=restart,
-        prompt_per_connector=prompt_per_connector,
+        prompt_per_connector=False,
+        connector_modes=connector_modes,
+        allow_trusted_path_prompt=prompt_batch,
+        trusted_prompt_cache=trusted_prompt_cache,
     )
 
 
@@ -5152,10 +5547,11 @@ def _hook_guardrail_options(fn):
             "enable_judge",
             default=None,
             help=(
-                "Enable the LLM judge for THIS connector (opts it into the "
-                "hook-lane gate guardrail.judge.hook_connectors and bumps the "
-                "detection strategy off regex_only). OFF by default. Configure "
-                "the judge model via `setup guardrail` / `setup llm`."
+                "Enable LLM judge scanning for this connector and bump "
+                "the detection strategy off regex_only. --no-enable-judge "
+                "opts this connector out of a concrete hook-lane gate while "
+                "leaving the global judge switch alone. Configure the judge "
+                "model via `setup guardrail` / `setup llm`."
             ),
         ),
         click.option(
@@ -5164,8 +5560,7 @@ def _hook_guardrail_options(fn):
             help=(
                 "Hook-lane judge gate to write (guardrail.judge.hook_connectors): "
                 "'all'/'*', 'none', or a comma list of hook connectors. When "
-                "--enable-judge is given without this, defaults to all hook "
-                "connectors."
+                "--enable-judge is given without this, defaults to this connector."
             ),
         ),
         click.option(
@@ -5309,9 +5704,9 @@ def setup_codex(
     """Configure DefenseClaw for Codex via the hook bus.
 
     Alias for the hook-driven path of ``setup guardrail`` with
-    ``--connector codex``. Pins ``claw.mode=codex`` so the TUI, skill
-    scanner, MCP scanner, and plugin scanner read from ``~/.codex/``
-    instead of the OpenClaw default layout.
+    ``--connector codex``. Configures Codex in the hook connector set
+    so the TUI, skill scanner, MCP scanner, and plugin scanner read
+    from ``~/.codex/`` for Codex-scoped surfaces.
 
     Wires three telemetry channels at gateway boot:
 
@@ -5457,9 +5852,9 @@ def setup_claude_code(
     """Configure DefenseClaw for Claude Code via the hook bus.
 
     Alias for the hook-driven path of ``setup guardrail`` with
-    ``--connector claudecode``. Pins ``claw.mode=claudecode`` so the
-    TUI, skill scanner, MCP scanner, and plugin scanner read from
-    ``~/.claude/`` instead of the OpenClaw default layout.
+    ``--connector claudecode``. Configures Claude Code in the hook
+    connector set so the TUI, skill scanner, MCP scanner, and plugin
+    scanner read from ``~/.claude/`` for Claude-scoped surfaces.
 
     Wires two telemetry channels at gateway boot:
 
@@ -5707,8 +6102,9 @@ def _make_observability_setup_command(connector: str) -> click.Command:
         connector,
         help=(
             f"Configure DefenseClaw for {label} via the agent's hook bus.\n\n"
-            "Pins the active connector so CLI/TUI scanners read that agent's "
-            "documented local surfaces. Default mode is observe; pass "
+            "Configures this connector in the hook connector set so CLI/TUI "
+            "scanners read that agent's documented local surfaces. Default "
+            "mode is observe; pass "
             "--mode action to enable hook-driven blocking on policy hits "
             "(pre-tool hook deny verdict). No proxy is involved in either mode."
         ),
@@ -5837,8 +6233,9 @@ def _make_observability_setup_command(connector: str) -> click.Command:
     _cmd.__name__ = f"setup_{connector}"
     _cmd.__doc__ = (
         f"Configure DefenseClaw for {label} via the agent's hook bus.\n\n"
-        "Pins the active connector so CLI/TUI scanners read that agent's "
-        "documented local surfaces. Default mode is observe; pass "
+        "Configures this connector in the hook connector set so CLI/TUI "
+        "scanners read that agent's documented local surfaces. Default "
+        "mode is observe; pass "
         "--mode action to enable hook-driven blocking on policy hits."
     )
     return _cmd
@@ -6061,7 +6458,7 @@ def _make_guardrail_connector_setup_command(connector: str) -> click.Command:
         connector,
         help=(
             f"Configure DefenseClaw guardrail for {label}.\n\n"
-            "Pins claw.mode and guardrail.connector, then runs the "
+            "Configures the proxy-backed connector selection, then runs the "
             "same backend as `defenseclaw setup guardrail --connector ...`."
         ),
         short_help=f"Configure {label} guardrail setup.",
@@ -6738,51 +7135,110 @@ def _prompt_hook_fail_mode(gc) -> None:
     gc.hook_fail_mode = "open" if fail_choice == "1" else "closed"
 
 
-def _prompt_judge_hook_connectors(gc) -> None:
-    """Prompt for the hook-lane judge gate (``judge.hook_connectors``).
+def _apply_judge_runtime_defaults(gc) -> None:
+    gc.judge.injection = True
+    gc.judge.pii = True
+    gc.judge.pii_prompt = True
+    gc.judge.pii_completion = True
+    # Data-exfiltration judge runs alongside injection + PII on every prompt.
+    gc.judge.exfil = True
+    # Completion-side strategy defaults to regex_only (no judge latency).
+    if not getattr(gc, "detection_strategy_completion", None):
+        gc.detection_strategy_completion = "regex_only"
 
-    Only shown when at least one configured connector is hook-enforced —
-    on a proxy-only install the gate is irrelevant (that lane is always
-    judged when the judge is enabled). Fresh installs default to no selected
-    hook connectors; reruns preselect the saved hook gate.
-    """
-    hook_targets = [
-        c for c in _configured_connector_set(gc) if c in _HOOK_ENFORCED_CONNECTORS
-    ]
-    if not hook_targets:
-        return
 
-    current = list(gc.judge.hook_connectors or [])
-    if current == ["*"]:
-        default_selected = list(hook_targets)
-    else:
-        default_selected = [c for c in hook_targets if c in current]
+def _prompt_judge_model_config(app: AppContext, gc) -> None:
+    """Prompt for judge LLM details using the same model UX across setup flows."""
+    ux.subhead("These LLM settings are shared by all connectors with judge enabled.")
 
-    ux.section("Hook-lane judge")
-    ux.subhead("The judge always covers the proxy lane. Hook connectors are")
-    ux.subhead("opt-in per connector — judged calls add latency (up to the")
-    ux.subhead("hook timeout, default 5s) and LLM cost.")
-    click.echo()
-    if current:
-        gate_label = "all configured hook connectors" if current == ["*"] else ", ".join(current)
-        click.echo("  " + ux.dim(f"Current hook judge coverage: {gate_label}"))
-    else:
-        click.echo("  " + ux.dim("Current hook judge coverage: none"))
-    selected = _prompt_checkbox_selection(
-        hook_targets,
-        default_selected=default_selected,
-        title="Select hook connector(s) for judge coverage.",
-        empty_ok=True,
+    # V5 UX: when the operator has already configured the unified top-level
+    # ``llm:`` block, default the judge to INHERIT those values. Empty judge
+    # fields fall through ``Config.resolve_llm("guardrail.judge")`` to the
+    # top-level block and pick up ``DEFENSECLAW_LLM_KEY`` automatically.
+    top_llm = app.cfg.llm
+    has_unified_llm = bool(top_llm.model) and bool(top_llm.resolved_api_key())
+    judge_already_customised = bool(
+        gc.judge.model or gc.judge.api_base or gc.judge.api_key_env,
     )
-    if len(selected) == len(hook_targets):
-        gc.judge.hook_connectors = ["*"]
-        click.echo("  " + ux.dim("Hook judge coverage: all configured hook connectors"))
-    elif not selected:
-        gc.judge.hook_connectors = []
-        click.echo("  " + ux.dim("Hook judge coverage: none"))
+
+    inherit_unified = False
+    if has_unified_llm and not judge_already_customised:
+        click.echo("  Judge can reuse your unified LLM settings:")
+        click.echo(f"    model:       {top_llm.model}")
+        if top_llm.base_url:
+            click.echo(f"    base URL:    {top_llm.base_url}")
+        click.echo(f"    api key:     {top_llm.api_key_env or DEFENSECLAW_LLM_KEY_ENV} (inherited)")
+        click.echo()
+        inherit_unified = click.confirm(
+            "  Inherit the unified LLM for the judge?",
+            default=True,
+        )
+
+    if inherit_unified:
+        gc.judge.model = ""
+        gc.judge.api_base = ""
+        gc.judge.api_key_env = ""
+        click.echo(f"  ✓ Judge will use {top_llm.model} via {top_llm.api_key_env or DEFENSECLAW_LLM_KEY_ENV}.")
     else:
-        gc.judge.hook_connectors = selected
-        click.echo("  " + ux.dim(f"Hook judge coverage: {', '.join(selected)}"))
+        # Pre-fill each prompt from the top-level ``llm:`` block so operators
+        # who want to override only have to retype the fields they're changing.
+        default_api_base = gc.judge.api_base or top_llm.base_url or ""
+        gc.judge.api_base = click.prompt(
+            "  LLM API base URL (e.g. http://localhost:8080/v1 for Bifrost)",
+            default=default_api_base,
+            show_default=bool(default_api_base),
+        )
+        default_model = gc.judge.model or top_llm.model or ""
+        gc.judge.model = click.prompt(
+            "  Model (e.g. anthropic/claude-sonnet-4-20250514)",
+            default=default_model,
+            show_default=bool(default_model),
+        )
+
+        default_key_env = gc.judge.api_key_env or top_llm.api_key_env or DEFENSECLAW_LLM_KEY_ENV
+        gc.judge.api_key_env = click.prompt(
+            "  API key env var name",
+            default=default_key_env,
+        )
+        env_val = os.environ.get(gc.judge.api_key_env, "")
+        if env_val:
+            click.echo(f"    Current value: {_mask(env_val)} (set)")
+        else:
+            click.echo(f"    {gc.judge.api_key_env} is not set in environment")
+
+        # Only prompt for a secret value when the operator picked a custom env
+        # var that is not already satisfied by the unified key.
+        unified_env = top_llm.api_key_env or DEFENSECLAW_LLM_KEY_ENV
+        if gc.judge.api_key_env != unified_env or not env_val:
+            _prompt_and_save_secret(gc.judge.api_key_env, "", app.cfg.data_dir)
+
+    click.echo()
+    if click.confirm("  Configure fallback models?", default=bool(gc.judge.fallbacks)):
+        fallbacks: list[str] = []
+        for i in range(1, 6):
+            fb = click.prompt(f"    Fallback model {i} (blank to finish)", default="", show_default=False)
+            if not fb:
+                break
+            fallbacks.append(fb)
+        gc.judge.fallbacks = fallbacks
+    else:
+        gc.judge.fallbacks = []
+
+    _apply_judge_runtime_defaults(gc)
+
+    # Share a custom judge key into the v5 top-level LLM block only when that
+    # block is otherwise unset, matching the guardrail wizard's existing rule.
+    custom_judge_key = (
+        gc.judge.api_key_env
+        and gc.judge.api_key_env != DEFENSECLAW_LLM_KEY_ENV
+        and gc.judge.api_key_env != (top_llm.api_key_env or DEFENSECLAW_LLM_KEY_ENV)
+    )
+    if custom_judge_key and not app.cfg.llm.api_key_env:
+        if click.confirm(
+            f"  Use {gc.judge.api_key_env} as the shared LLM key for all scanners too?",
+            default=True,
+        ):
+            app.cfg.llm.api_key_env = gc.judge.api_key_env
 
 
 def _interactive_guardrail_setup(
@@ -6906,23 +7362,24 @@ def _interactive_guardrail_setup(
     gc.enabled = True
 
     if is_multi:
-        # Per-connector mode is the source of truth in multi-connector
-        # mode; a single observe/action answer cannot express
-        # "codex=action, antigravity=observe". Leave each connector's mode
-        # untouched — it is set via `setup <connector> --mode`. The legacy
-        # singular gc.mode is only a back-compat default here, so editing
-        # it would be misleading.
-        mode_changed = False
-        click.echo()
-        click.echo(
-            "  " + ux.dim(
-                "Enforcement mode is per-connector here — skipping the single "
-                "observe/action prompt. Use `defenseclaw setup <connector> "
-                "--mode observe|action` to change an individual connector."
-            )
+        # Per-connector mode is the source of truth in multi-connector mode;
+        # ask once across the active set instead of writing the legacy global
+        # gc.mode. When --connector scoped this guardrail run, only that peer is
+        # offered here; bare setup guardrail covers the full active set.
+        mode_targets = (
+            [agent_name]
+            if agent_name and agent_name in active_connectors
+            else list(active_connectors)
         )
+        connector_modes = _prompt_batch_connector_modes(
+            mode_targets,
+            gc,
+            default_mode=gc.mode or "observe",
+        )
+        mode_changed = _write_per_connector_modes(gc, connector_modes)
     else:
         ux.section("Enforcement mode")
+        ux.subhead("Rule/regex scanning applies in both modes.")
         click.echo(
             "    " + ux.bold("[1] observe") + " — log and alert only, never block " + ux.dim("(recommended to start)")
         )
@@ -6983,14 +7440,16 @@ def _interactive_guardrail_setup(
     # configured connector resolves to action mode; otherwise fall back
     # to the singular mode for the bootstrap/single-connector path.
     if is_multi:
-        hilt_applicable = any(
-            (gc.effective_mode(c) or "").strip() == "action"
-            for c in active_connectors
-        )
+        hilt_action_connectors = [
+            c for c in active_connectors
+            if (gc.effective_mode(c) or "").strip() == "action"
+        ]
+        hilt_applicable = bool(hilt_action_connectors)
     else:
+        hilt_action_connectors = None
         hilt_applicable = gc.mode == "action"
     if hilt_applicable:
-        _configure_hilt_interactive(gc)
+        _configure_hilt_interactive(gc, action_connectors=hilt_action_connectors)
 
     ux.section("Scanner engine")
     click.echo(
@@ -7060,216 +7519,67 @@ def _interactive_guardrail_setup(
     click.echo("  " + ux.dim("Tool calls additionally run the tool_injection judge."))
     click.echo()
 
-    # Connector-aware LLM role branching.
-    #
-    # Hook-based connectors (Codex, Claude Code, …) keep their own
-    # agent LLM — DefenseClaw only uses an LLM for the judge. Proxy-
-    # backed connectors (OpenClaw, ZeptoClaw) can either share one
-    # LLM for judge + agent or split them. We surface the decision
-    # here so saved configs declare intent rather than relying on
-    # implicit defaults.
-    default_role = gc.llm_role or connector_llm_role(gc.connector or "")
-    if connector_llm_role(gc.connector or "") == "judge_only":
-        click.echo(
-            "  " + ux.dim(
-                "This connector uses its own LLM — DefenseClaw will use the LLM "
-                "you configure here only for the judge."
-            )
+    judge_targets = [
+        c for c in (
+            mode_targets
+            if is_multi
+            else [gc.connector or "openclaw"]
         )
-        gc.llm_role = "judge_only"
+        if c in _HOOK_ENFORCED_CONNECTORS
+    ]
+
+    strategy = _prompt_batch_scan_strategy(gc)
+    gc.detection_strategy = strategy
+    if strategy == "regex_only":
+        gc.judge.enabled = False
+        gc.detection_strategy_completion = "regex_only"
     else:
-        click.echo("  " + ux.bold("How should DefenseClaw use the LLM?"))
-        click.echo(
-            "    " + ux.bold("[1] Judge only          ")
-            + ux.dim("— keep your existing agent LLM, use DefenseClaw only for the judge")
-        )
-        click.echo(
-            "    " + ux.bold("[2] Judge AND agent     ")
-            + ux.dim("— route the agent's LLM through DefenseClaw too (recommended)")
-        )
-        role_default = "2" if default_role == "judge_and_agent" else "1"
-        role_choice = click.prompt(
-            "  Select role", type=click.Choice(["1", "2"]), default=role_default,
-        )
-        gc.llm_role = "judge_only" if role_choice == "1" else "judge_and_agent"
-        click.echo()
-
-    enable_judge = click.confirm("  Enable LLM judge?", default=gc.judge.enabled)
-    gc.judge.enabled = enable_judge
-
-    if enable_judge:
-        # --- Hook-lane judge gate ---
-        #
-        # judge.enabled alone only covers the proxy lane. Hook-enforced
-        # connectors are gated per connector by
-        # ``guardrail.judge.hook_connectors`` (empty = off — deliberate,
-        # the judge adds latency + LLM cost per inspected hook call).
-        # Without this prompt an operator who answers "Enable LLM judge?
-        # y" on a hook-connector install reasonably believes the judge is
-        # running when the hook lane is in fact off. Defaults preserve
-        # the opt-in: "none" on fresh installs, the current gate on
-        # re-runs (so Enter never silently widens or clears it).
-        _prompt_judge_hook_connectors(gc)
-
-        ux.section("Detection strategy")
-        click.echo("    " + ux.bold("[1] regex_only ") + " — regex patterns only, no LLM calls " + ux.dim("(fastest)"))
-        click.echo(
-            "    "
-            + ux.bold("[2] regex_judge")
-            + " — regex triages, LLM verifies ambiguous matches "
-            + ux.dim("(recommended)")
-        )
-        click.echo(
-            "    "
-            + ux.bold("[3] judge_first")
-            + " — LLM runs primary detection, regex as safety net "
-            + ux.dim("(most accurate)")
-        )
-        strategy_map = {"1": "regex_only", "2": "regex_judge", "3": "judge_first"}
-        current_strat = gc.detection_strategy or "regex_judge"
-        strat_default = {"regex_only": "1", "regex_judge": "2", "judge_first": "3"}.get(current_strat, "2")
-        strat_choice = click.prompt(
-            "  Select strategy",
-            type=click.Choice(["1", "2", "3"]),
-            default=strat_default,
-        )
-        gc.detection_strategy = strategy_map[strat_choice]
-
-        click.echo()
-
-        # V5 UX: when the operator has already configured the unified
-        # top-level ``llm:`` block (common after ``make all`` runs
-        # ``scripts/setup-llm.sh``), default the judge to INHERIT those
-        # values — empty judge fields fall through ``Config.resolve_llm``
-        # to the top-level block and pick up ``DEFENSECLAW_LLM_KEY``
-        # automatically. This avoids the legacy UX where the judge
-        # prompted for a separate ``JUDGE_API_KEY`` that diverged from
-        # the unified key.
-        top_llm = app.cfg.llm
-        has_unified_llm = bool(top_llm.model) and bool(top_llm.resolved_api_key())
-        judge_already_customised = bool(
-            gc.judge.model or gc.judge.api_base or gc.judge.api_key_env,
-        )
-
-        inherit_unified = False
-        if has_unified_llm and not judge_already_customised:
-            click.echo("  Judge can reuse your unified LLM settings:")
-            click.echo(f"    model:       {top_llm.model}")
-            if top_llm.base_url:
-                click.echo(f"    base URL:    {top_llm.base_url}")
-            click.echo(f"    api key:     {top_llm.api_key_env or DEFENSECLAW_LLM_KEY_ENV} (inherited)")
-            click.echo()
-            inherit_unified = click.confirm(
-                "  Inherit the unified LLM for the judge?",
-                default=True,
-            )
-
-        if inherit_unified:
-            # Empty strings on the judge block mean "fall back to the
-            # top-level ``llm:`` block" — see resolve_llm("guardrail.judge").
-            gc.judge.model = ""
-            gc.judge.api_base = ""
-            gc.judge.api_key_env = ""
-            click.echo(f"  ✓ Judge will use {top_llm.model} via {top_llm.api_key_env or DEFENSECLAW_LLM_KEY_ENV}.")
-        else:
-            # Pre-fill each prompt from the top-level ``llm:`` block so
-            # operators who DO want to override only have to retype the
-            # fields they're actually changing.
-            default_api_base = gc.judge.api_base or top_llm.base_url or ""
-            gc.judge.api_base = click.prompt(
-                "  LLM API base URL (e.g. http://localhost:8080/v1 for Bifrost)",
-                default=default_api_base,
-                show_default=bool(default_api_base),
-            )
-            default_model = gc.judge.model or top_llm.model or ""
-            gc.judge.model = click.prompt(
-                "  Model (e.g. anthropic/claude-sonnet-4-20250514)",
-                default=default_model,
-                show_default=bool(default_model),
-            )
-
-            # Default to the unified ``DEFENSECLAW_LLM_KEY`` — NOT the
-            # legacy ``JUDGE_API_KEY``. The operator can still override
-            # it to a per-component env var; when they do, we'll prompt
-            # for the secret value below. When they accept the default
-            # unified key, the secret is already persisted to ``.env``
-            # via ``scripts/setup-llm.sh`` or ``defenseclaw setup llm``,
-            # so we skip the redundant secret prompt.
-            default_key_env = gc.judge.api_key_env or top_llm.api_key_env or DEFENSECLAW_LLM_KEY_ENV
-            gc.judge.api_key_env = click.prompt(
-                "  API key env var name",
-                default=default_key_env,
-            )
-            env_val = os.environ.get(gc.judge.api_key_env, "")
-            if env_val:
-                click.echo(f"    Current value: {_mask(env_val)} (set)")
-            else:
-                click.echo(f"    {gc.judge.api_key_env} is not set in environment")
-
-            # Only prompt for a secret value when the operator picked a
-            # custom env var that ISN'T already satisfied by the unified
-            # key. ``DEFENSECLAW_LLM_KEY`` is expected to be wired up by
-            # ``scripts/setup-llm.sh`` before this code runs; re-asking
-            # for it here confuses operators who just set it.
-            unified_env = top_llm.api_key_env or DEFENSECLAW_LLM_KEY_ENV
-            if gc.judge.api_key_env != unified_env or not env_val:
-                _prompt_and_save_secret(gc.judge.api_key_env, "", app.cfg.data_dir)
-
-        click.echo()
-        if click.confirm("  Configure fallback models?", default=bool(gc.judge.fallbacks)):
-            fallbacks: list[str] = []
-            for i in range(1, 6):
-                fb = click.prompt(f"    Fallback model {i} (blank to finish)", default="", show_default=False)
-                if not fb:
-                    break
-                fallbacks.append(fb)
-            gc.judge.fallbacks = fallbacks
-        else:
-            gc.judge.fallbacks = []
-
-        gc.judge.injection = True
-        gc.judge.pii = True
-        gc.judge.pii_prompt = True
-        gc.judge.pii_completion = True
-        # Data-exfiltration judge runs alongside injection + PII on
-        # every prompt. It exists because polite-tone /etc/passwd-shaped
-        # prompts slip through the injection judge ("not adversarial
-        # phrasing") and the PII judge ("no literal PII emitted yet").
-        # Audit rows for this judge appear with kind=exfil and follow
-        # the same retention / redaction rules as the other kinds.
-        gc.judge.exfil = True
-
-        # Completion-side strategy defaults to regex_only (no judge latency)
+        gc.judge.enabled = True
         if not getattr(gc, "detection_strategy_completion", None):
             gc.detection_strategy_completion = "regex_only"
+        if judge_targets:
+            _set_hook_judge_coverage_all(gc)
 
-        # Only prompt to "share" the judge key across scanners when the
-        # operator chose a CUSTOM env var AND the unified block isn't
-        # already pointing somewhere. If they inherited the unified
-        # ``DEFENSECLAW_LLM_KEY`` there's nothing to share (every
-        # scanner already resolves through it via
-        # ``Config.resolve_llm``); if ``llm.api_key_env`` is already
-        # set to a different value, silently overwriting it would
-        # disrupt the MCP/skill/plugin scanners — so we refuse to
-        # clobber and leave the operator to run ``defenseclaw setup
-        # llm`` explicitly. We write to ``llm.api_key_env`` (v5)
-        # rather than the deprecated ``default_llm_api_key_env`` (v4)
-        # so ``defenseclaw setup migrate-llm`` doesn't silently undo
-        # the change on the next run.
-        custom_judge_key = (
-            gc.judge.api_key_env
-            and gc.judge.api_key_env != DEFENSECLAW_LLM_KEY_ENV
-            and gc.judge.api_key_env != (top_llm.api_key_env or DEFENSECLAW_LLM_KEY_ENV)
-        )
-        if custom_judge_key and not app.cfg.llm.api_key_env:
-            if click.confirm(
-                f"  Use {gc.judge.api_key_env} as the shared LLM key for all scanners too?",
-                default=True,
-            ):
-                app.cfg.llm.api_key_env = gc.judge.api_key_env
-    else:
-        gc.detection_strategy = "regex_only"
-        gc.detection_strategy_completion = "regex_only"
+        # Connector-aware LLM role branching.
+        #
+        # Hook-based connectors (Codex, Claude Code, …) keep their own
+        # agent LLM — DefenseClaw only uses an LLM for the judge. Proxy-
+        # backed connectors (OpenClaw, ZeptoClaw) can either share one
+        # LLM for judge + agent or split them. We surface the decision
+        # here so saved configs declare intent rather than relying on
+        # implicit defaults.
+        default_role = gc.llm_role or connector_llm_role(gc.connector or "")
+        if connector_llm_role(gc.connector or "") == "judge_only":
+            click.echo(
+                "  " + ux.dim(
+                    "This connector uses its own LLM — DefenseClaw will use the LLM "
+                    "you configure here only for the judge."
+                )
+            )
+            gc.llm_role = "judge_only"
+        else:
+            click.echo("  " + ux.bold("How should DefenseClaw use the LLM?"))
+            click.echo(
+                "    " + ux.bold("[1] Judge only          ")
+                + ux.dim("— keep your existing agent LLM, use DefenseClaw only for the judge")
+            )
+            click.echo(
+                "    " + ux.bold("[2] Judge AND agent     ")
+                + ux.dim("— route the agent's LLM through DefenseClaw too (recommended)")
+            )
+            role_default = "2" if default_role == "judge_and_agent" else "1"
+            role_choice = click.prompt(
+                "  Select role", type=click.Choice(["1", "2"]), default=role_default,
+            )
+            gc.llm_role = "judge_only" if role_choice == "1" else "judge_and_agent"
+            click.echo()
+
+        _apply_judge_runtime_defaults(gc)
+        click.echo()
+        _prompt_judge_model_config(app, gc)
+
+    if bool(gc.judge.enabled):
+        click.echo()
 
     if click.confirm("  Configure advanced options?", default=False):
         gc.port = click.prompt("  Guardrail proxy port", default=gc.port, type=int)

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -4618,10 +4618,7 @@ def _apply_hook_connector_setup(
             f"{len(_actives)} connectors active: {', '.join(_actives)}"
         )
     else:
-        click.echo(
-            f"  ✓ Connector {connector!r} configured "
-            f"(claw.mode={getattr(cfg.claw, 'mode', '') or connector})"
-        )
+        click.echo(f"  ✓ Connector {connector!r} configured")
     if workspace:
         click.echo(f"  ✓ Workspace root pinned to {workspace}")
     else:
@@ -4711,12 +4708,13 @@ def _print_observability_summary(connector: str, cfg=None, *, mode: str = "obser
     label = _CONNECTOR_META[connector]["label"]
     enforcement_label = "enabled (hook-driven)" if mode == "action" else "disabled (observe-only)"
 
-    # Multi-connector awareness: a singular claw.mode row + a global
+    # Multi-connector awareness: a singular legacy mirror row + a global
     # "setup guardrail --disable" revert line both read as if this one
     # connector IS the whole install. When more than one connector is
     # configured, show the full roster (all connectors are peers) and point
     # revert / mode guidance at the per-connector commands. Single-connector
-    # output is unchanged.
+    # output still uses connector-specific wording rather than exposing
+    # claw.mode.
     actives: list[str] = []
     if cfg is not None and hasattr(cfg, "active_connectors"):
         try:
@@ -4731,7 +4729,7 @@ def _print_observability_summary(connector: str, cfg=None, *, mode: str = "obser
     if multi:
         mode_row = ("connectors", ", ".join(actives))
     else:
-        mode_row = ("claw.mode", connector)
+        mode_row = ("active connector", connector)
     rows = [
         ("connector", f"{label} ({connector})"),
         mode_row,

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -5311,6 +5311,39 @@ def _prompt_batch_judge_connectors(connectors: list[str], gc) -> set[str]:
     return selected_connectors
 
 
+def _prompt_guardrail_judge_enablement(gc, judge_targets: list[str]) -> set[str]:
+    """Interactive ``setup guardrail`` judge prompt without scan-strategy jargon."""
+    if judge_targets:
+        options, display_by_connector, connector_by_display = _connector_display_options(judge_targets)
+        ux.subhead("Rule/regex scanning is already enabled for every active connector.")
+        ux.subhead("Checked active connectors add LLM judge review on top.")
+        ux.subhead("These LLM settings are shared by all connectors with judge enabled.")
+        selected = _prompt_checkbox_selection(
+            options,
+            default_selected=_default_batch_judge_labels(judge_targets, gc, display_by_connector),
+            title="Select active connector(s) for LLM judge.",
+            empty_ok=True,
+        )
+        selected_connectors = {connector_by_display[label] for label in selected}
+        _merge_batch_judge_selection(gc, judge_targets, selected_connectors)
+        return selected_connectors
+
+    enabled = click.confirm(
+        "  Add LLM judge on top of rule scanning?",
+        default=bool(gc.judge.enabled),
+    )
+    if enabled:
+        gc.judge.enabled = True
+        if not gc.detection_strategy or gc.detection_strategy == "regex_only":
+            gc.detection_strategy = "regex_judge"
+        _apply_judge_runtime_defaults(gc)
+    else:
+        gc.judge.enabled = False
+        gc.detection_strategy = "regex_only"
+        gc.detection_strategy_completion = "regex_only"
+    return set()
+
+
 def _prompt_batch_trusted_prefixes(
     app: AppContext,
     connector_modes: dict[str, str],
@@ -7508,7 +7541,7 @@ def _interactive_guardrail_setup(
     # exactly the same way the proxy surface stamps it on the
     # response body, which is why the operator's judge config is
     # connector-agnostic.
-    ux.section("LLM Judge (reduces false positives)")
+    ux.section("Optional LLM judge")
     ux.subhead("Uses an LLM to verify detections and catch novel attacks.")
     ux.subhead("Works with any OpenAI-compatible API (Bifrost, OpenAI, Anthropic, etc.)")
     click.echo()
@@ -7528,17 +7561,10 @@ def _interactive_guardrail_setup(
         if c in _HOOK_ENFORCED_CONNECTORS
     ]
 
-    strategy = _prompt_batch_scan_strategy(gc)
-    gc.detection_strategy = strategy
-    if strategy == "regex_only":
-        gc.judge.enabled = False
-        gc.detection_strategy_completion = "regex_only"
-    else:
-        gc.judge.enabled = True
+    _prompt_guardrail_judge_enablement(gc, judge_targets)
+    if gc.judge.enabled:
         if not getattr(gc, "detection_strategy_completion", None):
             gc.detection_strategy_completion = "regex_only"
-        if judge_targets:
-            _set_hook_judge_coverage_all(gc)
 
         # Connector-aware LLM role branching.
         #

--- a/cli/defenseclaw/config.py
+++ b/cli/defenseclaw/config.py
@@ -67,6 +67,7 @@ from defenseclaw.connector_paths import (  # noqa: F401
 
 _log = logging.getLogger(__name__)
 _privacy_disable_redaction_warned = False
+_llm_migration_warned_keys: set[tuple[str, ...]] = set()
 
 DATA_DIR_NAME = ".defenseclaw"
 AUDIT_DB_NAME = "audit.db"
@@ -3139,8 +3140,8 @@ def _migrate_llm_fields(cfg: Config) -> None:
     module, which is wired up to stderr + audit pipeline in
     cli/defenseclaw/__init__.py) when legacy LLM fields are detected
     so operators notice the drift before v6 removes the fallbacks.
-    The warning is emitted at most once per Config instance via a
-    sentinel attribute so reloads don't spam.
+    The warning is emitted at most once per process for the same legacy
+    field set so command-level config reloads don't spam.
     """
     legacy_fields: list[str] = []
     if cfg.inspect_llm.model or cfg.inspect_llm.provider or cfg.inspect_llm.api_key_env:
@@ -3154,16 +3155,15 @@ def _migrate_llm_fields(cfg: Config) -> None:
     if cfg.guardrail.judge.model or cfg.guardrail.judge.api_key_env or cfg.guardrail.judge.api_base:
         legacy_fields.append("guardrail.judge.{model,api_key_env,api_base}")
 
-    if legacy_fields and not getattr(cfg, "_llm_migration_warned", False):
+    legacy_key = tuple(legacy_fields)
+    if legacy_key and legacy_key not in _llm_migration_warned_keys:
         _log.warning(
             "config: deprecated v4 LLM fields detected (%s); values are still honored "
             "but will be removed in a future release. Run `defenseclaw setup migrate-llm` "
             "to rewrite config.yaml to the unified llm: block.",
             ", ".join(legacy_fields),
         )
-        # Stamped once per Config instance so reload()/save() round-trips
-        # don't spam stderr in long-running processes (gateway, TUI).
-        cfg._llm_migration_warned = True  # type: ignore[attr-defined]
+        _llm_migration_warned_keys.add(legacy_key)
     # Top-level.
     if not cfg.llm.api_key_env:
         if cfg.default_llm_api_key_env:

--- a/cli/defenseclaw/tui/panels/setup.py
+++ b/cli/defenseclaw/tui/panels/setup.py
@@ -2118,8 +2118,8 @@ def _connector_setup_goals(cfg: object | Mapping[str, Any] | None) -> tuple[Wiza
         ),
         WizardGoal(
             "bulk",
-            "Set up multiple connectors",
-            summary="Run bare setup with repeatable connector flags, detected connectors, or all supported hooks.",
+            "Set active connectors",
+            summary="Run bare setup to choose the active hook connector set.",
             presets={"@Action": "batch"},
             fields=(
                 "Connectors (CSV)",
@@ -3727,7 +3727,7 @@ def connector_setup_wizard_fields(
         WizardFormField(
             "Connectors (CSV)",
             "string",
-            hint="Batch setup only: comma-separated connector names, e.g. codex,hermes,antigravity.",
+            hint="Batch setup only: comma-separated active connector names, e.g. codex,hermes,antigravity.",
         ),
         WizardFormField(
             "Action",
@@ -3735,7 +3735,7 @@ def connector_setup_wizard_fields(
             value="setup",
             default="setup",
             options=("setup", "batch", "remove"),
-            hint="Set up/add one connector, batch setup several connectors, or remove one.",
+            hint="Set up/add one connector, choose the active connector set, or remove one.",
         ),
         WizardFormField("Guardrail Mode", "choice", value=mode, default=mode, options=("observe", "action")),
         WizardFormField(
@@ -4226,6 +4226,7 @@ def _guardrail_wizard_fields_for(
     # ``llm.model`` is not emitted as ``--judge-model`` and must not promote.
     if judge and strategy in ("", "regex_only"):
         strategy = "regex_judge"
+    strategy = (overrides.get("--detection-strategy") or strategy).strip() or "regex_only"
     # A live provider change (driver) wins so the conditional Bedrock /
     # Vertex / Azure judge groups re-derive against the new selection.
     judge_provider = (overrides.get("@Provider") or judge_provider).strip().lower() or judge_provider
@@ -4247,11 +4248,25 @@ def _guardrail_wizard_fields_for(
     ).strip().lower() or "api_key"
     hilt = "yes" if bool(get_config_value(cfg, "guardrail.hilt.enabled", False)) else "no"
     redaction = "yes" if bool(get_config_value(cfg, "privacy.disable_redaction", False)) else "no"
-    j_bedrock = _provider_is("bedrock")
-    j_bedrock_iam = _bedrock_auth_mode_is("iam_credentials")
-    j_bedrock_profile = _bedrock_auth_mode_is("profile")
-    j_vertex = _provider_is("vertex_ai", "vertex")
-    j_azure = _provider_is("azure")
+    def j_strategy(dv: Mapping[str, str]) -> bool:
+        return (dv.get("strategy", "") or "").strip().lower() in {"regex_judge", "judge_first"}
+
+    def j_provider_is(*names: str) -> Callable[[Mapping[str, str]], bool]:
+        provider_visible = _provider_is(*names)
+        return lambda dv: j_strategy(dv) and provider_visible(dv)
+
+    def j_bedrock_auth_mode_is(*modes: str) -> Callable[[Mapping[str, str]], bool]:
+        auth_visible = _bedrock_auth_mode_is(*modes)
+        return lambda dv: j_strategy(dv) and auth_visible(dv)
+
+    def j_provider_regional_or_custom(dv: Mapping[str, str]) -> bool:
+        return j_strategy(dv) and _provider_regional_or_custom(dv)
+
+    j_bedrock = j_provider_is("bedrock")
+    j_bedrock_iam = j_bedrock_auth_mode_is("iam_credentials")
+    j_bedrock_profile = j_bedrock_auth_mode_is("profile")
+    j_vertex = j_provider_is("vertex_ai", "vertex")
+    j_azure = j_provider_is("azure")
     j_region_opts = _llm_catalog_regions(judge_provider)
     candidates: tuple[WizardFormField, ...] = (
         WizardFormField("Core", "section"),
@@ -4283,6 +4298,7 @@ def _guardrail_wizard_fields_for(
             value=strategy,
             default="regex_only",
             options=("regex_only", "regex_judge", "judge_first"),
+            hint="Rule/regex scanning is the baseline; judge strategies add LLM review on top.",
         ),
         WizardFormField(
             "Rule Pack",
@@ -4292,24 +4308,46 @@ def _guardrail_wizard_fields_for(
             default="default",
             options=("default", "strict", "permissive"),
         ),
-        WizardFormField("LLM Judge", "section"),
+        WizardFormField("LLM Judge", "section", visible_when=j_strategy),
         WizardFormField(
             "Provider",
             "choice",
             value=judge_provider,
             default=judge_provider_default,
             options=_llm_catalog_provider_choices(),
+            visible_when=j_strategy,
         ),
         WizardFormField(
-            "Model", "string", "--judge-model", value=judge_model, default=judge_model_default, picker="llm"
+            "Model",
+            "string",
+            "--judge-model",
+            value=judge_model,
+            default=judge_model_default,
+            picker="llm",
+            visible_when=j_strategy,
         ),
-        WizardFormField("API Key Env", "string", "--judge-api-key-env", value=judge_key_env, default=judge_key_default),
-        WizardFormField("API Base URL", "string", "--judge-api-base", value=judge_base, default=judge_base_default),
+        WizardFormField(
+            "API Key Env",
+            "string",
+            "--judge-api-key-env",
+            value=judge_key_env,
+            default=judge_key_default,
+            visible_when=j_strategy,
+        ),
+        WizardFormField(
+            "API Base URL",
+            "string",
+            "--judge-api-base",
+            value=judge_base,
+            default=judge_base_default,
+            visible_when=j_strategy,
+        ),
         WizardFormField(
             "Instance Name",
             "string",
             "--judge-instance-name",
             hint="Custom-provider instance for the judge (optional).",
+            visible_when=j_strategy,
         ),
         WizardFormField(
             "LLM Role",
@@ -4319,14 +4357,7 @@ def _guardrail_wizard_fields_for(
             default="judge_only",
             options=GUARDRAIL_JUDGE_LLM_ROLES,
             hint="judge_only=hook connectors; judge_and_agent=proxy connectors.",
-        ),
-        WizardFormField(
-            "Hook Connectors",
-            "string",
-            "--judge-hook-connectors",
-            value=_judge_hook_connectors_wizard_value(cfg),
-            default=_judge_hook_connectors_wizard_value(cfg),
-            hint="'all', 'none', or comma-separated hook connectors for hook-lane judge coverage.",
+            visible_when=j_strategy,
         ),
         WizardFormField(
             "Inherit From",
@@ -4336,6 +4367,7 @@ def _guardrail_wizard_fields_for(
             default="",
             options=GUARDRAIL_JUDGE_INHERIT_PATHS,
             hint="Copy a sibling LLM block onto the judge before flags (optional).",
+            visible_when=j_strategy,
         ),
         WizardFormField("Judge: Bedrock", "section", visible_when=j_bedrock),
         WizardFormField(
@@ -4392,13 +4424,13 @@ def _guardrail_wizard_fields_for(
             hint="model=deployment pairs, comma-separated (repeatable).",
             visible_when=j_azure,
         ),
-        WizardFormField("Judge: TLS", "section", visible_when=_provider_regional_or_custom),
+        WizardFormField("Judge: TLS", "section", visible_when=j_provider_regional_or_custom),
         WizardFormField(
             "TLS CA Cert File",
             "string",
             "--judge-tls-ca-cert-file",
             hint="PEM CA bundle for self-signed judge endpoints.",
-            visible_when=_provider_regional_or_custom,
+            visible_when=j_provider_regional_or_custom,
         ),
         WizardFormField(
             "Insecure Skip Verify",
@@ -4407,7 +4439,7 @@ def _guardrail_wizard_fields_for(
             value="no",
             default="no",
             hint="Disable TLS verification for the judge (lab use only).",
-            visible_when=_provider_regional_or_custom,
+            visible_when=j_provider_regional_or_custom,
         ),
         WizardFormField("Cisco AI Defense", "section"),
         WizardFormField(
@@ -4449,7 +4481,11 @@ def _guardrail_wizard_fields_for(
     return _apply_dynamic_fields(
         candidates,
         overrides,
-        {"provider": judge_provider, "bedrock_auth_mode": judge_bedrock_auth_mode},
+        {
+            "provider": judge_provider,
+            "bedrock_auth_mode": judge_bedrock_auth_mode,
+            "strategy": strategy,
+        },
     )
 
 

--- a/cli/tests/test_bootstrap.py
+++ b/cli/tests/test_bootstrap.py
@@ -30,6 +30,7 @@ from defenseclaw.config import (
     GatewayConfig,
     GuardrailConfig,
     OpenShellConfig,
+    PerConnectorGuardrailConfig,
 )
 
 
@@ -167,6 +168,52 @@ class ApplyFirstRunChoicesHookFailModeTests(unittest.TestCase):
         self._apply("klosed")
         self.assertEqual(self.cfg.guardrail.hook_fail_mode, "open",
                          "typo must NEVER silently put the agent in a stricter posture than the operator typed")
+
+
+# ---------------------------------------------------------------------------
+# _apply_first_run_choices: judge setup
+#
+# ``init`` and ``quickstart`` expose a single "enable judge" choice. When
+# selected, that choice must be effective for hook connectors without asking
+# for a second coverage list.
+# ---------------------------------------------------------------------------
+
+
+class ApplyFirstRunChoicesJudgeTests(unittest.TestCase):
+    def setUp(self):
+        from defenseclaw.config import default_config
+        self.cfg = default_config()
+
+    def _apply(self, *, with_judge: bool) -> None:
+        from defenseclaw.bootstrap import (
+            FirstRunOptions,
+            _apply_first_run_choices,
+        )
+
+        opts = FirstRunOptions(connector="codex", profile="observe", with_judge=with_judge)
+        _apply_first_run_choices(self.cfg, opts, "codex", "observe", "local")
+
+    def test_with_judge_enables_all_hook_coverage(self):
+        self._apply(with_judge=True)
+        self.assertTrue(self.cfg.guardrail.judge.enabled)
+        self.assertEqual(self.cfg.guardrail.detection_strategy, "regex_judge")
+        self.assertEqual(self.cfg.guardrail.judge.hook_connectors, ["*"])
+
+    def test_with_judge_bumps_regex_only_strategy(self):
+        self.cfg.guardrail.detection_strategy = "regex_only"
+        self._apply(with_judge=True)
+        self.assertEqual(self.cfg.guardrail.detection_strategy, "regex_judge")
+        self.assertEqual(self.cfg.guardrail.judge.hook_connectors, ["*"])
+
+    def test_first_run_choice_clears_stale_multi_connector_map(self):
+        self.cfg.guardrail.connectors = {
+            "codex": PerConnectorGuardrailConfig(),
+            "hermes": PerConnectorGuardrailConfig(),
+        }
+        self._apply(with_judge=False)
+        self.assertEqual(sorted(self.cfg.guardrail.connectors), ["codex"])
+        self.assertNotIn("hermes", self.cfg.guardrail.connectors)
+        self.assertEqual(self.cfg.active_connectors(), ["codex"])
 
 
 # ---------------------------------------------------------------------------

--- a/cli/tests/test_bootstrap.py
+++ b/cli/tests/test_bootstrap.py
@@ -29,6 +29,7 @@ from defenseclaw.config import (
     Config,
     GatewayConfig,
     GuardrailConfig,
+    HILTConfig,
     OpenShellConfig,
     PerConnectorGuardrailConfig,
 )
@@ -253,6 +254,7 @@ class ApplyFirstRunChoicesHITLTests(unittest.TestCase):
     def _apply(
         self,
         *,
+        connector: str = "codex",
         human_approval: bool | None = None,
         hilt_min_severity: str = "",
     ) -> None:
@@ -262,12 +264,12 @@ class ApplyFirstRunChoicesHITLTests(unittest.TestCase):
         )
 
         opts = FirstRunOptions(
-            connector="codex",
+            connector=connector,
             profile="action",
             human_approval=human_approval,
             hilt_min_severity=hilt_min_severity,
         )
-        _apply_first_run_choices(self.cfg, opts, "codex", "action", "local")
+        _apply_first_run_choices(self.cfg, opts, connector, "action", "local")
 
     def test_none_preserves_existing_enabled(self):
         self.cfg.guardrail.hilt.enabled = True
@@ -339,6 +341,40 @@ class ApplyFirstRunChoicesHITLTests(unittest.TestCase):
         self._apply(human_approval=False, hilt_min_severity="MEDIUM")
         self.assertFalse(self.cfg.guardrail.hilt.enabled)
         self.assertEqual(self.cfg.guardrail.hilt.min_severity, "MEDIUM")
+
+    def test_explicit_choice_updates_selected_connector_hilt_override(self):
+        self.cfg.guardrail.connectors = {
+            "codex": PerConnectorGuardrailConfig(
+                hilt=HILTConfig(enabled=True, min_severity="LOW")
+            ),
+            "hermes": PerConnectorGuardrailConfig(
+                hilt=HILTConfig(enabled=False, min_severity="HIGH")
+            ),
+        }
+        self.cfg.guardrail.hilt.enabled = False
+
+        self._apply(connector="hermes", human_approval=True)
+
+        self.assertEqual(sorted(self.cfg.guardrail.connectors), ["hermes"])
+        hermes_hilt = self.cfg.guardrail.connectors["hermes"].hilt
+        self.assertIsNotNone(hermes_hilt)
+        self.assertTrue(hermes_hilt.enabled)
+        self.assertEqual(hermes_hilt.min_severity, "HIGH")
+        self.assertTrue(self.cfg.guardrail.effective_hilt("hermes").enabled)
+
+    def test_explicit_false_updates_selected_connector_hilt_override(self):
+        self.cfg.guardrail.connectors = {
+            "hermes": PerConnectorGuardrailConfig(
+                hilt=HILTConfig(enabled=True, min_severity="MEDIUM")
+            ),
+        }
+
+        self._apply(connector="hermes", human_approval=False)
+
+        hermes_hilt = self.cfg.guardrail.connectors["hermes"].hilt
+        self.assertIsNotNone(hermes_hilt)
+        self.assertFalse(hermes_hilt.enabled)
+        self.assertEqual(hermes_hilt.min_severity, "MEDIUM")
 
 
 # ---------------------------------------------------------------------------

--- a/cli/tests/test_cmd_guardrail.py
+++ b/cli/tests/test_cmd_guardrail.py
@@ -113,7 +113,8 @@ class StatusCommandTests(unittest.TestCase):
         result = runner.invoke(cmd_guardrail.status_cmd, [], obj=app)
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertIn("enabled:    yes", result.output)
-        self.assertIn("OpenClaw (openclaw)", result.output)
+        self.assertIn("OpenClaw", result.output)
+        self.assertIn("openclaw", result.output)
         self.assertIn("disable", result.output)
 
     def test_status_disabled_codex(self):
@@ -122,7 +123,8 @@ class StatusCommandTests(unittest.TestCase):
         result = runner.invoke(cmd_guardrail.status_cmd, [], obj=app)
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertIn("enabled:    no", result.output)
-        self.assertIn("Codex (codex)", result.output)
+        self.assertIn("Codex", result.output)
+        self.assertIn("codex", result.output)
         self.assertIn("Enable with", result.output)
 
     def test_status_surfaces_hook_fail_mode(self):
@@ -133,29 +135,35 @@ class StatusCommandTests(unittest.TestCase):
         # The fail mode is a key posture knob: status MUST surface it so
         # operators can sanity-check their posture without grep-ing
         # config.yaml. It is folded into the (uniform) per-connector
-        # block as ``fail=...``.
-        self.assertIn("fail=closed", result.output)
+        # block as the Fail column.
+        self.assertIn("Fail", result.output)
+        self.assertIn("closed", result.output)
 
     def test_status_single_connector_uses_uniform_per_connector_block(self):
         # A single-connector install renders the SAME per-connector block
-        # layout as a fan-out install: one "connectors:" section with one
-        # tagged block. No singular "connector / mode / fail mode" lines.
+        # layout as a fan-out install: one connector roster table, no
+        # redundant "connectors:" label plus table header.
         runner = CliRunner()
         app = make_ctx(enabled=True, connector="openclaw")
         result = runner.invoke(cmd_guardrail.status_cmd, [], obj=app)
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        self.assertIn("connectors:", result.output)
-        # Uniform per-connector block: "<label> (<name>): <state> mode=... fail=...".
-        self.assertIn("OpenClaw (openclaw): ", result.output)
-        self.assertIn("mode=observe", result.output)
+        self.assertNotIn("connectors:", result.output)
+        # Uniform per-connector table: label + key + posture fields.
+        self.assertIn("Connector", result.output)
+        self.assertIn("Key", result.output)
+        self.assertIn("OpenClaw", result.output)
+        self.assertIn("openclaw", result.output)
+        self.assertIn("observe", result.output)
         # Default fail mode is the safer "closed" (response-layer
         # failures block); see _normalize_hook_fail_mode / default_config.
-        self.assertIn("fail=closed", result.output)
+        self.assertIn("closed", result.output)
         # The retired singular lines (and the "multi-connector"-only
         # footer hint) must NOT appear — there is exactly one rendering.
         self.assertNotIn("• connector:", result.output)
         self.assertNotIn("• mode:", result.output)
         self.assertNotIn("• fail mode:", result.output)
+        self.assertNotIn("scan strategy:", result.output)
+        self.assertNotIn("judge coverage:", result.output)
         self.assertNotIn("--connector", result.output)
 
     def test_status_multi_connector_uses_same_layout(self):
@@ -175,16 +183,34 @@ class StatusCommandTests(unittest.TestCase):
         result = runner.invoke(cmd_guardrail.status_cmd, [], obj=app)
         self.assertEqual(result.exit_code, 0, msg=result.output)
         # Both connectors' blocks are present, each tagged by name.
-        self.assertIn("Claude Code (claudecode): ", result.output)
-        self.assertIn("Codex (codex): ", result.output)
-        self.assertIn("mode=action", result.output)
-        self.assertIn("mode=observe", result.output)
+        self.assertIn("Claude Code", result.output)
+        self.assertIn("claudecode", result.output)
+        self.assertIn("Codex", result.output)
+        self.assertIn("codex", result.output)
+        self.assertIn("action", result.output)
+        self.assertIn("observe", result.output)
         # No count banner, no singular lines, no per-connector footer hint.
         self.assertNotIn("2 active", result.output)
         self.assertNotIn("• connector:", result.output)
         self.assertNotIn("• mode:", result.output)
         self.assertNotIn("• fail mode:", result.output)
+        self.assertNotIn("scan strategy:", result.output)
+        self.assertNotIn("judge coverage:", result.output)
         self.assertNotIn("--connector", result.output)
+
+    def test_status_uses_stacked_connector_blocks_when_narrow(self):
+        runner = CliRunner()
+        app = make_ctx(enabled=True, connector="codex")
+        app.cfg.active_connectors = lambda: ["codex"]  # type: ignore[method-assign]
+        with patch("defenseclaw.commands.cmd_guardrail._terminal_width", return_value=60):
+            result = runner.invoke(cmd_guardrail.status_cmd, [], obj=app)
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("- Codex", result.output)
+        self.assertIn("key:       codex", result.output)
+        self.assertNotIn("connector: codex", result.output)
+        self.assertIn("rule-pack:", result.output)
+        self.assertIn("scan:", result.output)
+        self.assertIn("judge:", result.output)
 
 
 class GroupHelpTests(unittest.TestCase):
@@ -589,8 +615,10 @@ class PerConnectorToggleTests(unittest.TestCase):
         # Both connectors get their own block in the uniform roster, each
         # tagged by name with its own effective enabled state: codex was
         # turned off (disabled), claudecode inherits the default (enabled).
-        self.assertIn("Codex (codex): ", result.output)
-        self.assertIn("Claude Code (claudecode): ", result.output)
+        self.assertIn("Codex", result.output)
+        self.assertIn("codex", result.output)
+        self.assertIn("Claude Code", result.output)
+        self.assertIn("claudecode", result.output)
         self.assertIn("disabled", result.output)
         self.assertIn("enabled", result.output)
 
@@ -607,9 +635,10 @@ class PerConnectorToggleTests(unittest.TestCase):
         )
         result = runner.invoke(cmd_guardrail.status_cmd, [], obj=app)
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        self.assertIn("rule-pack=strict", result.output)   # codex's own pack
-        self.assertIn("rule-pack=default", result.output)  # claudecode inherits
-        self.assertIn("hilt=on@LOW", result.output)        # codex's own HILT
+        self.assertIn("Rule pack", result.output)
+        self.assertIn("strict", result.output)    # codex's own pack
+        self.assertIn("default", result.output)   # claudecode inherits
+        self.assertIn("on@LOW", result.output)    # codex's own HILT
 
     def test_status_global_disable_overrides_per_connector_enabled(self):
         # Regression: when the GLOBAL guardrail kill switch is off, no
@@ -623,15 +652,17 @@ class PerConnectorToggleTests(unittest.TestCase):
         result = runner.invoke(cmd_guardrail.status_cmd, [], obj=app)
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertIn("enabled:    no", result.output)
-        self.assertIn("Codex (codex): ", result.output)
-        self.assertIn("Claude Code (claudecode): ", result.output)
+        self.assertIn("Codex", result.output)
+        self.assertIn("codex", result.output)
+        self.assertIn("Claude Code", result.output)
+        self.assertIn("claudecode", result.output)
         # The off-because-global reason is shown and NOT a bare green enabled.
         self.assertIn("disabled (guardrail off)", result.output)
         # Sanity: the roster must not render a standalone "enabled" state for
         # any connector while global is off (it would be misleading).
         for line in result.output.splitlines():
-            if "(codex):" in line or "(claudecode):" in line:
-                self.assertNotIn(": enabled ", line, msg=line)
+            if "codex" in line or "claudecode" in line:
+                self.assertNotIn(" enabled ", line, msg=line)
 
 
 class PerConnectorFailModeTests(unittest.TestCase):
@@ -1046,82 +1077,87 @@ class CommandRegistrationTests(unittest.TestCase):
 
 
 class StatusStrategyJudgeTests(unittest.TestCase):
-    """G3 / J5 — status surfaces scan strategy + per-connector judge state."""
+    """G3 / J5 — status surfaces effective scan strategy per connector."""
 
     def _rich(self, *, enabled=True, connector="hermes", judge_enabled=True,
-              gate=None, strategy="regex_judge", prompt="", completion=""):
+              gate=None, strategy="regex_judge", prompt="", completion="", tool_call=""):
         app = make_ctx(enabled=enabled, connector=connector)
         gc = app.cfg.guardrail
         gc.detection_strategy = strategy
         gc.detection_strategy_prompt = prompt
         gc.detection_strategy_completion = completion
+        gc.detection_strategy_tool_call = tool_call
         gc.judge = SimpleNamespace(enabled=judge_enabled, hook_connectors=list(gate or []))
         return app, gc
 
-    def test_status_shows_scan_strategy_line(self):
-        # The global strategy (with per-direction overrides) is surfaced so an
-        # operator can see whether the judge can run at all. completion is the
-        # force-pinned regex_only default in the wild.
-        app, _ = self._rich(strategy="regex_judge", completion="regex_only")
+    def test_status_puts_effective_scan_in_connector_row(self):
+        # Hook status is connector-first: the row shows the effective hook
+        # surfaces once, using hook vocabulary rather than proxy-lane
+        # "completion" wording.
+        app, _ = self._rich(strategy="regex_judge", completion="regex_only", gate=["hermes"])
         result = CliRunner().invoke(cmd_guardrail.status_cmd, [], obj=app)
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        self.assertIn("scan strategy: regex_judge", result.output)
-        self.assertIn("completion: regex_only", result.output)
+        self.assertNotIn("scan strategy:", result.output)
+        self.assertNotIn("judge coverage:", result.output)
+        self.assertIn("Hermes", result.output)
+        self.assertIn("hermes", result.output)
+        self.assertIn(
+            "prompt:regex_judge, tool-call:regex_judge, tool-output:regex_only",
+            result.output,
+        )
 
-    def test_status_judge_enabled_and_gate_label(self):
+    def test_status_judge_enabled_and_selected(self):
         app, _ = self._rich(judge_enabled=True, gate=["hermes"])
         result = CliRunner().invoke(cmd_guardrail.status_cmd, [], obj=app)
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        self.assertIn("judge:      on", result.output)
-        self.assertIn("judge coverage: Hermes (hermes)", result.output)
-        self.assertIn("saved judge gate: hermes", result.output)
-        # gated + enabled + strategy ok → this connector reports judge=on.
-        self.assertIn("judge=on", result.output)
+        self.assertIn("Hermes", result.output)
+        self.assertIn("hermes", result.output)
+        self.assertIn("regex_judge", result.output)
+        self.assertIn("Judge", result.output)
+        self.assertIn("on", result.output)
 
     def test_status_judge_off_when_disabled(self):
         app, _ = self._rich(judge_enabled=False, gate=["hermes"])
         result = CliRunner().invoke(cmd_guardrail.status_cmd, [], obj=app)
-        self.assertIn("judge:      off (disabled globally)", result.output)
-        self.assertIn("judge coverage: none active", result.output)
-        self.assertIn("saved judge gate: hermes (inactive until judge is enabled)", result.output)
-        self.assertIn("judge=off", result.output)
+        self.assertNotIn("judge coverage:", result.output)
+        self.assertIn("regex_only", result.output)
+        self.assertIn("Judge", result.output)
+        self.assertIn("off", result.output)
         self.assertNotIn("judge=on", result.output)
 
     def test_status_judge_off_when_not_gated(self):
-        # Judge enabled globally but this connector isn't in the gate.
+        # Judge enabled globally but this connector isn't selected: the
+        # effective hook strategy is regex_only, so there is no separate
+        # top-level explanation to reconcile.
         app, _ = self._rich(judge_enabled=True, gate=[])
         result = CliRunner().invoke(cmd_guardrail.status_cmd, [], obj=app)
-        self.assertIn("judge:      off (no connectors selected)", result.output)
-        self.assertIn("judge coverage: none active", result.output)
-        self.assertIn("saved judge gate: none", result.output)
-        self.assertIn("judge=off", result.output)
+        self.assertIn("Hermes", result.output)
+        self.assertIn("hermes", result.output)
+        self.assertIn("regex_only", result.output)
+        self.assertIn("off", result.output)
 
     def test_status_all_gate_judges_every_connector(self):
         app, _ = self._rich(judge_enabled=True, gate=["*"])
         app.cfg.active_connectors = lambda: ["codex", "hermes"]  # type: ignore[method-assign]
         result = CliRunner().invoke(cmd_guardrail.status_cmd, [], obj=app)
-        self.assertIn("judge:      on", result.output)
-        self.assertIn("judge coverage: all active connectors", result.output)
-        self.assertIn("saved judge gate: all", result.output)
-        # Both connectors judged — token appears once per roster block.
-        self.assertEqual(result.output.count("judge=on"), 2)
+        self.assertIn("Codex", result.output)
+        self.assertIn("codex", result.output)
+        self.assertIn("Hermes", result.output)
+        self.assertIn("hermes", result.output)
+        self.assertEqual(result.output.count("regex_judge"), 2)
+        self.assertIn("Judge", result.output)
 
-    def test_status_regex_only_does_not_overstate_and_warns(self):
+    def test_status_regex_only_does_not_overstate(self):
         # J5 anti-overstatement: judge enabled AND gated, but the global
-        # prompt strategy is regex_only → the judge never runs. The token must
-        # NOT say "on", and status warns explicitly.
+        # strategy is regex_only → the judge never runs. The row should simply
+        # show the effective strategy and judge state once.
         app, _ = self._rich(judge_enabled=True, gate=["*"], strategy="regex_only")
         result = CliRunner().invoke(cmd_guardrail.status_cmd, [], obj=app)
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        self.assertIn("judge:      off (prompt strategy is regex_only)", result.output)
-        self.assertIn("judge coverage: none active", result.output)
-        self.assertIn(
-            "saved judge gate: all (inactive while prompt strategy is regex_only)",
-            result.output,
-        )
-        self.assertIn("judge=off (regex_only)", result.output)
+        self.assertIn("regex_only", result.output)
+        self.assertIn("off", result.output)
         self.assertNotIn("judge=on", result.output)
-        self.assertIn("will not run", result.output)
+        self.assertNotIn("will not run", result.output)
 
 
 class StatusConnectorScopeTests(unittest.TestCase):
@@ -1140,8 +1176,10 @@ class StatusConnectorScopeTests(unittest.TestCase):
             cmd_guardrail.status_cmd, ["--connector", "hermes"], obj=app
         )
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        self.assertIn("Hermes (hermes):", result.output)
-        self.assertNotIn("Codex (codex):", result.output)
+        self.assertIn("Hermes", result.output)
+        self.assertIn("hermes", result.output)
+        self.assertNotIn("Codex", result.output)
+        self.assertNotIn("codex", result.output)
 
     def test_scopes_case_insensitively(self):
         app = self._multi()
@@ -1149,7 +1187,8 @@ class StatusConnectorScopeTests(unittest.TestCase):
             cmd_guardrail.status_cmd, ["--connector", "HERMES"], obj=app
         )
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        self.assertIn("Hermes (hermes):", result.output)
+        self.assertIn("Hermes", result.output)
+        self.assertIn("hermes", result.output)
 
     def test_scoped_status_does_not_show_other_connector_gate_as_active(self):
         app = self._multi()
@@ -1161,15 +1200,14 @@ class StatusConnectorScopeTests(unittest.TestCase):
             cmd_guardrail.status_cmd, ["--connector", "codex"], obj=app
         )
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        self.assertIn("judge:      off for Codex (codex) (disabled globally)", result.output)
-        self.assertIn("judge coverage: none active", result.output)
-        self.assertIn(
-            "saved judge gate: hermes (inactive until judge is enabled)",
-            result.output,
-        )
+        self.assertIn("regex_only", result.output)
+        self.assertIn("off", result.output)
+        self.assertNotIn("judge coverage:", result.output)
         self.assertNotIn("hook gate: hermes", result.output)
-        self.assertIn("Codex (codex):", result.output)
-        self.assertNotIn("Hermes (hermes):", result.output)
+        self.assertIn("Codex", result.output)
+        self.assertIn("codex", result.output)
+        self.assertNotIn("Hermes", result.output)
+        self.assertNotIn("hermes", result.output)
 
     def test_scoped_status_shows_selected_judge_connector(self):
         app = self._multi()
@@ -1181,11 +1219,12 @@ class StatusConnectorScopeTests(unittest.TestCase):
             cmd_guardrail.status_cmd, ["--connector", "hermes"], obj=app
         )
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        self.assertIn("judge:      on for Hermes (hermes)", result.output)
-        self.assertIn("judge coverage: selected", result.output)
-        self.assertIn("saved judge gate: hermes", result.output)
-        self.assertIn("Hermes (hermes):", result.output)
-        self.assertNotIn("Codex (codex):", result.output)
+        self.assertIn("regex_judge", result.output)
+        self.assertIn("on", result.output)
+        self.assertIn("Hermes", result.output)
+        self.assertIn("hermes", result.output)
+        self.assertNotIn("Codex", result.output)
+        self.assertNotIn("codex", result.output)
 
     def test_scoped_status_shows_unselected_judge_connector(self):
         app = self._multi()
@@ -1197,11 +1236,13 @@ class StatusConnectorScopeTests(unittest.TestCase):
             cmd_guardrail.status_cmd, ["--connector", "codex"], obj=app
         )
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        self.assertIn("judge:      off for Codex (codex) (not selected)", result.output)
-        self.assertIn("judge coverage: not selected", result.output)
-        self.assertIn("saved judge gate: hermes", result.output)
-        self.assertIn("Codex (codex):", result.output)
-        self.assertNotIn("Hermes (hermes):", result.output)
+        self.assertIn("regex_only", result.output)
+        self.assertIn("off", result.output)
+        self.assertNotIn("judge coverage:", result.output)
+        self.assertIn("Codex", result.output)
+        self.assertIn("codex", result.output)
+        self.assertNotIn("Hermes", result.output)
+        self.assertNotIn("hermes", result.output)
 
     def test_unknown_connector_errors(self):
         app = make_ctx(enabled=True, connector="codex")
@@ -1237,7 +1278,8 @@ class StatusPhantomTests(unittest.TestCase):
         app.cfg.has_connector_configured = lambda: True  # type: ignore[method-assign]
         result = CliRunner().invoke(cmd_guardrail.status_cmd, [], obj=app)
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        self.assertIn("OpenClaw (openclaw):", result.output)
+        self.assertIn("OpenClaw", result.output)
+        self.assertIn("openclaw", result.output)
         self.assertNotIn("none configured", result.output)
 
 

--- a/cli/tests/test_cmd_init.py
+++ b/cli/tests/test_cmd_init.py
@@ -29,8 +29,10 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from click.testing import CliRunner
 from defenseclaw.commands.cmd_init import init_cmd
+from defenseclaw.config import PerConnectorGuardrailConfig
 from defenseclaw.connector_paths import KNOWN_CONNECTORS
 from defenseclaw.context import AppContext
+from defenseclaw.inventory import agent_discovery
 from defenseclaw.inventory.agent_discovery import AgentDiscovery, AgentSignal
 
 
@@ -156,6 +158,141 @@ class TestInitFirstRunBackend(unittest.TestCase):
         self.assertEqual(cfg["guardrail"]["connector"], "codex")
         self.assertTrue(cfg["guardrail"]["enabled"])
         self.assertEqual(cfg["guardrail"]["detection_strategy"], "regex_judge")
+
+    def test_with_judge_defaults_hook_coverage_to_all(self):
+        result = self._invoke([
+            "--non-interactive",
+            "--yes",
+            "--connector",
+            "codex",
+            "--profile",
+            "observe",
+            "--scanner-mode",
+            "local",
+            "--skip-install",
+            "--with-judge",
+            "--no-start-gateway",
+            "--no-verify",
+            "--json-summary",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output + (result.stderr or ""))
+
+        import yaml
+        with open(os.path.join(self.tmp_dir, "config.yaml"), encoding="utf-8") as fh:
+            cfg = yaml.safe_load(fh)
+        self.assertTrue(cfg["guardrail"]["judge"]["enabled"])
+        self.assertEqual(cfg["guardrail"]["detection_strategy"], "regex_judge")
+        self.assertEqual(cfg["guardrail"]["judge"]["hook_connectors"], ["*"])
+
+    def test_interactive_judge_llm_config_collects_model_settings(self):
+        from defenseclaw.commands import cmd_init
+
+        with patch.object(cmd_init.click, "confirm", return_value=True), \
+                patch("defenseclaw.commands._llm_picker.pick_provider", return_value="openai") as provider, \
+                patch("defenseclaw.commands._llm_picker.pick_model", return_value="gpt-4o") as model, \
+                patch("defenseclaw.commands._llm_picker.pick_key_env", return_value="OPENAI_API_KEY") as key_env, \
+                patch("defenseclaw.commands.cmd_setup._prompt_and_save_secret") as save_secret, \
+                patch.object(cmd_init.click, "prompt", return_value="https://api.example/v1"):
+            got = cmd_init._prompt_first_run_judge_llm_config(
+                data_dir=self.tmp_dir,
+                llm_provider="",
+                llm_model="",
+                llm_api_key="sk-test",
+                llm_api_key_env="DEFENSECLAW_LLM_KEY",
+                llm_base_url="",
+            )
+
+        self.assertEqual(got, ("openai", "gpt-4o", "", "OPENAI_API_KEY", "https://api.example/v1"))
+        provider.assert_called_once()
+        model.assert_called_once()
+        key_env.assert_called_once()
+        save_secret.assert_called_once_with("OPENAI_API_KEY", "sk-test", self.tmp_dir)
+
+    @patch("defenseclaw.commands.cmd_setup._check_connector_version_supported_for_setup", return_value=True)
+    def test_explicit_action_updates_existing_per_connector_mode(self, _gate):
+        Path(self.tmp_dir, "config.yaml").write_text(
+            "claw:\n"
+            "  mode: codex\n"
+            "guardrail:\n"
+            "  enabled: true\n"
+            "  connector: codex\n"
+            "  mode: observe\n"
+            "  scanner_mode: local\n"
+            "  connectors:\n"
+            "    hermes:\n"
+            "      mode: observe\n",
+            encoding="utf-8",
+        )
+
+        result = self._invoke([
+            "--non-interactive",
+            "--yes",
+            "--connector",
+            "hermes",
+            "--profile",
+            "action",
+            "--scanner-mode",
+            "local",
+            "--skip-install",
+            "--no-start-gateway",
+            "--no-verify",
+            "--json-summary",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output + (result.stderr or ""))
+        summary = json.loads(result.output)
+        self.assertEqual(summary["profile"], "action")
+        setup = {step["name"]: step for step in summary["setup"]}
+        self.assertIn("hermes, mode=action", setup["Guardrail"]["detail"])
+
+        import yaml
+        with open(os.path.join(self.tmp_dir, "config.yaml"), encoding="utf-8") as fh:
+            cfg = yaml.safe_load(fh)
+        self.assertEqual(cfg["guardrail"]["connectors"]["hermes"]["mode"], "action")
+
+    @patch("defenseclaw.bootstrap.agent_discovery.discover_agents")
+    @patch("defenseclaw.commands.cmd_setup._check_connector_version_supported_for_setup", return_value=False)
+    def test_single_action_connector_trusted_path_downgrade_is_structured(self, _gate, mock_discover):
+        disc = self._discovery({"hermes"})
+        disc.agents["hermes"].binary_path = "/tmp/fake/hermes-bin"
+        disc.agents["hermes"].error = agent_discovery.UNTRUSTED_PREFIX_ERROR
+        mock_discover.return_value = disc
+
+        result = self._invoke([
+            "--non-interactive",
+            "--yes",
+            "--connector",
+            "hermes",
+            "--profile",
+            "action",
+            "--scanner-mode",
+            "local",
+            "--skip-install",
+            "--no-start-gateway",
+            "--no-verify",
+            "--json-summary",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output + (result.stderr or ""))
+        summary = json.loads(result.output)
+        self.assertEqual(summary["status"], "needs_attention")
+        self.assertEqual(summary["connector"], "hermes")
+        self.assertEqual(summary["profile"], "observe")
+        warning = summary["connector_mode_warnings"][0]
+        self.assertEqual(warning["connector"], "hermes")
+        self.assertEqual(warning["requested_mode"], "action")
+        self.assertEqual(warning["actual_mode"], "observe")
+        self.assertEqual(warning["reason"], "binary path outside trusted prefixes; version was not probed")
+        self.assertEqual(
+            warning["next_command"],
+            f"defenseclaw setup trusted-paths add {os.path.realpath('/tmp/fake')}",
+        )
+        setup = {step["name"]: step for step in summary["setup"]}
+        self.assertEqual(setup["Hermes mode"]["status"], "fail")
+
+        import yaml
+        with open(os.path.join(self.tmp_dir, "config.yaml"), encoding="utf-8") as fh:
+            cfg = yaml.safe_load(fh)
+        self.assertEqual(cfg["guardrail"]["connector"], "hermes")
+        self.assertEqual(cfg["guardrail"]["mode"], "observe")
 
     def test_first_run_persists_llm_secret_to_dotenv_not_config(self):
         result = self._invoke([
@@ -1865,6 +2002,11 @@ class TestMultiConnectorInit(unittest.TestCase):
             cfg.claw.mode = "codex"
             cfg.guardrail.mode = "observe"
             cfg.guardrail.enabled = True
+            cfg.guardrail.connectors = {
+                "codex": PerConnectorGuardrailConfig(),
+                "hermes": PerConnectorGuardrailConfig(),
+            }
+            cfg.guardrail.judge.hook_connectors = ["codex", "hermes"]
             cfg.save()
 
             active, sidecar_step = _activate_additional_connectors(
@@ -1881,6 +2023,8 @@ class TestMultiConnectorInit(unittest.TestCase):
             reloaded = cfg_mod.load()
             gc = reloaded.guardrail
             self.assertEqual(sorted(gc.connectors), ["claudecode", "codex"])
+            self.assertNotIn("hermes", gc.connectors)
+            self.assertEqual(gc.judge.hook_connectors, ["codex"])
             self.assertEqual(reloaded.active_connectors(), ["claudecode", "codex"])
             cc = gc.connectors["claudecode"]
             self.assertEqual(cc.mode, "action")
@@ -1966,7 +2110,7 @@ class TestMultiConnectorInit(unittest.TestCase):
         disc = self._disc({"codex", "claudecode"})
         # scanner mode, fail mode, HITL severity
         prompts = iter(["local", "closed", "MEDIUM"])
-        confirms = iter([False, True, False, True])  # judge, action HITL, start_gateway, verify
+        confirms = iter([True, False, True])  # action HITL, start_gateway, verify
 
         with patch.object(cmd_init.agent_discovery, "discover_agents", return_value=disc), \
                 patch.object(cmd_init.agent_discovery, "render_discovery_table", return_value=""), \
@@ -1977,11 +2121,11 @@ class TestMultiConnectorInit(unittest.TestCase):
                 patch.object(
                     cmd_init,
                     "_prompt_checkbox_selection",
-                    side_effect=[["codex", "claudecode"], ["claudecode"]],
+                    side_effect=[["codex", "claudecode"], ["claudecode"], []],
                 ), \
                 patch.object(cmd_init.click, "prompt", side_effect=lambda *a, **k: next(prompts)), \
                 patch.object(cmd_init.click, "confirm", side_effect=lambda *a, **k: next(confirms)):
-            settings, scanner_mode, with_judge, start_gateway, verify = cmd_init._prompt_first_run(
+            settings, scanner_mode, with_judge, judge_connectors, start_gateway, verify = cmd_init._prompt_first_run(
                 connector=None, profile=None, scanner_mode="local", with_judge=False,
                 fail_mode=None, human_approval=None, hilt_min_severity=None,
                 start_gateway=False, verify=None, rescan_agents=False,
@@ -2001,6 +2145,7 @@ class TestMultiConnectorInit(unittest.TestCase):
         self.assertEqual(by_name["claudecode"]["hilt_min_severity"], "MEDIUM")
         self.assertEqual(scanner_mode, "local")
         self.assertFalse(with_judge)
+        self.assertEqual(judge_connectors, [])
         self.assertFalse(start_gateway)
         self.assertTrue(verify)
 
@@ -2011,18 +2156,18 @@ class TestMultiConnectorInit(unittest.TestCase):
 
         disc = self._disc({"codex", "claudecode"})
         prompts = iter(["local"])  # scanner
-        confirms = iter([False, False, True])  # judge, start_gateway, verify
+        confirms = iter([False, True])  # start_gateway, verify
 
         with patch.object(cmd_init.agent_discovery, "discover_agents", return_value=disc), \
                 patch.object(cmd_init.agent_discovery, "render_discovery_table", return_value=""), \
                 patch.object(
                     cmd_init,
                     "_prompt_checkbox_selection",
-                    side_effect=[["codex", "claudecode"], []],
+                    side_effect=[["codex", "claudecode"], [], []],
                 ), \
                 patch.object(cmd_init.click, "prompt", side_effect=lambda *a, **k: next(prompts)), \
                 patch.object(cmd_init.click, "confirm", side_effect=lambda *a, **k: next(confirms)):
-            settings, _scanner, _judge, _start, _verify = cmd_init._prompt_first_run(
+            settings, _scanner, _judge, _judge_connectors, _start, _verify = cmd_init._prompt_first_run(
                 connector=None, profile=None, scanner_mode="local", with_judge=False,
                 fail_mode=None, human_approval=None, hilt_min_severity=None,
                 start_gateway=False, verify=None, rescan_agents=False,
@@ -2046,11 +2191,132 @@ class TestMultiConnectorInit(unittest.TestCase):
         with patch.object(cmd_init, "_prompt_checkbox_selection", return_value=[]):
             self.assertEqual(cmd_init._prompt_action_connectors(["codex"]), [])
 
-    def test_single_connector_selection_keeps_legacy_shape(self):
-        from defenseclaw.commands.cmd_init import _prompt_connector_selection
+    def test_single_connector_selection_prompts_trust_without_picker(self):
+        from defenseclaw.commands import cmd_init
+        from defenseclaw.inventory import agent_discovery as ad
 
-        # An explicit single connector short-circuits discovery entirely.
-        self.assertEqual(_prompt_connector_selection("codex", False), ["codex"])
+        hermes_dir = os.path.join(self.tmp_dir, "hermes-bin")
+        codex_dir = os.path.join(self.tmp_dir, "codex-bin")
+        os.makedirs(hermes_dir)
+        os.makedirs(codex_dir)
+        first = self._disc({"codex", "hermes"})
+        first.agents["hermes"].binary_path = os.path.join(hermes_dir, "hermes")
+        first.agents["hermes"].version = ""
+        first.agents["hermes"].error = ad.UNTRUSTED_PREFIX_ERROR
+        first.agents["codex"].binary_path = os.path.join(codex_dir, "codex")
+        first.agents["codex"].version = ""
+        first.agents["codex"].error = ad.UNTRUSTED_PREFIX_ERROR
+        second = self._disc({"codex", "hermes"})
+
+        with patch.object(cmd_init.agent_discovery, "discover_agents", side_effect=[first, second]) as discover, \
+                patch.object(cmd_init.click, "confirm", return_value=True), \
+                patch.object(cmd_init, "_prompt_checkbox_selection", side_effect=AssertionError("picker opened")):
+            got = cmd_init._prompt_connector_selection("hermes", False, data_dir=self.tmp_dir)
+
+        self.assertEqual(got, ["hermes"])
+        self.assertEqual(discover.call_count, 2)
+        dotenv = os.path.join(self.tmp_dir, ".env")
+        with open(dotenv, encoding="utf-8") as fh:
+            text = fh.read()
+        self.assertIn(os.path.realpath(hermes_dir), text)
+        self.assertNotIn(os.path.realpath(codex_dir), text)
+
+    def test_prompt_first_run_explicit_action_declined_trust_downgrades_with_remediation(self):
+        from defenseclaw.commands import cmd_init
+        from defenseclaw.inventory import agent_discovery as ad
+
+        bin_dir = os.path.join(self.tmp_dir, "hermes-bin")
+        os.makedirs(bin_dir)
+        bin_path = os.path.join(bin_dir, "hermes")
+        disc = self._disc({"hermes"})
+        disc.agents["hermes"].binary_path = bin_path
+        disc.agents["hermes"].version = ""
+        disc.agents["hermes"].error = ad.UNTRUSTED_PREFIX_ERROR
+        prompts = iter(["local"])
+        confirms = iter([False, False, True])  # early trust, start_gateway, verify
+
+        with patch.object(cmd_init.agent_discovery, "discover_agents", return_value=disc), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._check_connector_version_supported_for_setup",
+                    return_value=False,
+                ), \
+                patch.object(cmd_init, "_prompt_checkbox_selection", return_value=[]), \
+                patch.object(cmd_init.click, "prompt", side_effect=lambda *a, **k: next(prompts)), \
+                patch.object(cmd_init.click, "confirm", side_effect=lambda *a, **k: next(confirms)):
+            settings, scanner_mode, with_judge, judge_connectors, start_gateway, verify = cmd_init._prompt_first_run(
+                connector="hermes", profile="action", scanner_mode="local", with_judge=False,
+                fail_mode=None, human_approval=None, hilt_min_severity=None,
+                start_gateway=False, verify=None, rescan_agents=False, data_dir=self.tmp_dir,
+            )
+
+        self.assertEqual(scanner_mode, "local")
+        self.assertFalse(with_judge)
+        self.assertEqual(judge_connectors, [])
+        self.assertFalse(start_gateway)
+        self.assertTrue(verify)
+        self.assertEqual(settings[0]["connector"], "hermes")
+        self.assertEqual(settings[0]["profile"], "observe")
+        warning = settings[0]["mode_warning"]
+        self.assertEqual(warning["requested_mode"], "action")
+        self.assertEqual(warning["actual_mode"], "observe")
+        self.assertEqual(warning["trusted_path"], os.path.realpath(bin_dir))
+        self.assertEqual(
+            warning["next_command"],
+            f"defenseclaw setup trusted-paths add {os.path.realpath(bin_dir)}",
+        )
+
+    def test_prompt_first_run_action_trust_retry_keeps_action_mode(self):
+        from defenseclaw.commands import cmd_init
+        from defenseclaw.inventory import agent_discovery as ad
+
+        bin_dir = os.path.join(self.tmp_dir, "hermes-bin")
+        os.makedirs(bin_dir)
+        bin_path = os.path.join(bin_dir, "hermes")
+
+        cached = self._disc({"hermes"})
+        cached.agents["hermes"].binary_path = bin_path
+        cached.agents["hermes"].version = "hermes 1.0"
+        cached.agents["hermes"].error = ""
+
+        untrusted = self._disc({"hermes"})
+        untrusted.agents["hermes"].binary_path = bin_path
+        untrusted.agents["hermes"].version = ""
+        untrusted.agents["hermes"].error = ad.UNTRUSTED_PREFIX_ERROR
+
+        rescanned = self._disc({"hermes"})
+        rescanned.agents["hermes"].binary_path = bin_path
+        rescanned.agents["hermes"].version = "hermes 1.0"
+        rescanned.agents["hermes"].error = ""
+
+        prompts = iter(["local", "open"])
+        confirms = iter([True, False, False, True])  # trust, HITL, start_gateway, verify
+
+        with patch.object(cmd_init.agent_discovery, "discover_agents", side_effect=[cached, untrusted, rescanned]), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._check_connector_version_supported_for_setup",
+                    side_effect=[False, True],
+                ), \
+                patch.object(cmd_init, "_prompt_checkbox_selection", return_value=[]), \
+                patch.object(cmd_init.click, "prompt", side_effect=lambda *a, **k: next(prompts)), \
+                patch.object(cmd_init.click, "confirm", side_effect=lambda *a, **k: next(confirms)):
+            settings, scanner_mode, with_judge, judge_connectors, start_gateway, verify = cmd_init._prompt_first_run(
+                connector="hermes", profile="action", scanner_mode="local", with_judge=False,
+                fail_mode=None, human_approval=None, hilt_min_severity=None,
+                start_gateway=False, verify=None, rescan_agents=False, data_dir=self.tmp_dir,
+            )
+
+        self.assertEqual(scanner_mode, "local")
+        self.assertFalse(with_judge)
+        self.assertEqual(judge_connectors, [])
+        self.assertFalse(start_gateway)
+        self.assertTrue(verify)
+        self.assertEqual(settings[0]["connector"], "hermes")
+        self.assertEqual(settings[0]["profile"], "action")
+        self.assertIsNone(settings[0]["mode_warning"])
+
+        dotenv = os.path.join(self.tmp_dir, ".env")
+        with open(dotenv, encoding="utf-8") as fh:
+            self.assertIn(os.path.realpath(bin_dir), fh.read())
 
     def test_checkbox_selector_toggles_with_keys(self):
         from defenseclaw.commands import cmd_init
@@ -2237,10 +2503,102 @@ class TestInitObserveAllActionConnectors(unittest.TestCase):
             "--no-start-gateway", "--no-verify", "--json-summary",
         ])
         self.assertEqual(result.exit_code, 0, result.output + (result.stderr or ""))
-        self.assertIn("configuring in observe mode", result.output)
+
+        summary = json.loads(result.output)
+        self.assertEqual(summary["status"], "needs_attention")
+        warning = summary["connector_mode_warnings"][0]
+        self.assertEqual(warning["connector"], "codex")
+        self.assertEqual(warning["requested_mode"], "action")
+        self.assertEqual(warning["actual_mode"], "observe")
+        self.assertIn("version could not be verified", warning["reason"])
+        self.assertEqual(warning["next_command"], "defenseclaw setup codex --mode action")
+        self.assertTrue(
+            any(
+                step["name"] == "Codex mode"
+                and step["status"] == "fail"
+                and "requested action, configured observe" in step["detail"]
+                for step in summary["setup"]
+            ),
+            summary["setup"],
+        )
 
         cfg = self._load_cfg()
         self.assertEqual(cfg["guardrail"]["mode"], "observe")
+
+    @patch("defenseclaw.commands.cmd_setup._check_connector_version_supported_for_setup", return_value=False)
+    @patch("defenseclaw.commands.cmd_init.agent_discovery.discover_agents")
+    def test_action_connector_trusted_path_downgrade_is_structured(self, mock_discover, _gate):
+        from defenseclaw.inventory import agent_discovery as ad
+
+        disc = self._disc({"codex", "hermes"})
+        bin_dir = os.path.join(self.tmp_dir, "tool", "bin")
+        bin_path = os.path.join(bin_dir, "hermes")
+        disc.agents["hermes"].binary_path = bin_path
+        disc.agents["hermes"].version = ""
+        disc.agents["hermes"].error = ad.UNTRUSTED_PREFIX_ERROR
+        mock_discover.return_value = disc
+
+        result = self._invoke([
+            "--non-interactive", "--yes",
+            "--observe-all", "--action-connectors", "hermes",
+            "--scanner-mode", "local", "--skip-install",
+            "--no-start-gateway", "--no-verify", "--json-summary",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output + (result.stderr or ""))
+
+        summary = json.loads(result.output)
+        self.assertEqual(summary["status"], "needs_attention")
+        self.assertIn("hermes", summary["connectors"])
+        warning = summary["connector_mode_warnings"][0]
+        self.assertEqual(warning["connector"], "hermes")
+        self.assertEqual(warning["requested_mode"], "action")
+        self.assertEqual(warning["actual_mode"], "observe")
+        self.assertEqual(
+            warning["reason"],
+            "binary path outside trusted prefixes; version was not probed",
+        )
+        self.assertEqual(warning["binary_path"], os.path.realpath(bin_path))
+        self.assertEqual(warning["trusted_path"], os.path.realpath(bin_dir))
+        self.assertEqual(
+            warning["next_command"],
+            f"defenseclaw setup trusted-paths add {os.path.realpath(bin_dir)}",
+        )
+        self.assertIn(warning["next_command"], summary["next_commands"])
+
+        cfg = self._load_cfg()
+        self.assertEqual(cfg["guardrail"]["connectors"]["hermes"]["mode"], "observe")
+
+    @patch("defenseclaw.commands.cmd_setup._check_connector_version_supported_for_setup", return_value=False)
+    @patch("defenseclaw.commands.cmd_init.agent_discovery.discover_agents")
+    def test_action_connector_downgrade_refreshes_discovery_for_trusted_path_details(self, mock_discover, _gate):
+        from defenseclaw.inventory import agent_discovery as ad
+
+        stale = self._disc({"codex", "hermes"})
+        fresh = self._disc({"codex", "hermes"})
+        bin_dir = os.path.join(self.tmp_dir, "tool", "bin")
+        bin_path = os.path.join(bin_dir, "hermes")
+        fresh.agents["hermes"].binary_path = bin_path
+        fresh.agents["hermes"].version = ""
+        fresh.agents["hermes"].error = ad.UNTRUSTED_PREFIX_ERROR
+        mock_discover.side_effect = [stale, fresh]
+
+        result = self._invoke([
+            "--non-interactive", "--yes",
+            "--observe-all", "--action-connectors", "hermes",
+            "--scanner-mode", "local", "--skip-install",
+            "--no-start-gateway", "--no-verify", "--json-summary",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output + (result.stderr or ""))
+
+        summary = json.loads(result.output)
+        warning = summary["connector_mode_warnings"][0]
+        self.assertEqual(
+            warning["reason"],
+            "binary path outside trusted prefixes; version was not probed",
+        )
+        self.assertEqual(warning["binary_path"], os.path.realpath(bin_path))
+        self.assertEqual(warning["trusted_path"], os.path.realpath(bin_dir))
+        self.assertEqual(mock_discover.call_count, 2)
 
     @patch("defenseclaw.commands.cmd_init.agent_discovery.discover_agents")
     def test_no_multi_flags_keeps_single_connector_default(self, mock_discover):

--- a/cli/tests/test_cmd_judge.py
+++ b/cli/tests/test_cmd_judge.py
@@ -535,7 +535,7 @@ class JudgeListTests(unittest.TestCase):
 
 
 class WizardHookPromptTests(unittest.TestCase):
-    """``cmd_setup._prompt_judge_hook_connectors`` — the wizard touch."""
+    """Setup defaults hook judge coverage to all; tuning lives elsewhere."""
 
     def _gc(self, connectors=("hermes", "opencode"), gate=()):
         return SimpleNamespace(
@@ -544,71 +544,15 @@ class WizardHookPromptTests(unittest.TestCase):
             judge=SimpleNamespace(hook_connectors=list(gate)),
         )
 
-    def test_proxy_only_install_skips_prompt(self):
-        gc = self._gc(connectors=("openclaw",))
-        with patch.object(cmd_setup, "_prompt_checkbox_selection") as prompt:
-            cmd_setup._prompt_judge_hook_connectors(gc)
-        prompt.assert_not_called()
-        self.assertEqual(gc.judge.hook_connectors, [])
-
-    def test_fresh_install_defaults_to_none(self):
+    def test_setup_defaults_hook_judge_coverage_to_all(self):
         gc = self._gc()
-        with patch.object(cmd_setup, "_prompt_checkbox_selection", return_value=[]) as prompt:
-            cmd_setup._prompt_judge_hook_connectors(gc)
-        self.assertEqual(prompt.call_args.kwargs.get("default_selected"), [])
-        self.assertEqual(prompt.call_args.kwargs.get("empty_ok"), True)
-        self.assertEqual(gc.judge.hook_connectors, [])
-
-    def test_choice_all_writes_star(self):
-        gc = self._gc()
-        with patch.object(
-            cmd_setup,
-            "_prompt_checkbox_selection",
-            return_value=["hermes", "opencode"],
-        ):
-            cmd_setup._prompt_judge_hook_connectors(gc)
+        cmd_setup._set_hook_judge_coverage_all(gc)
         self.assertEqual(gc.judge.hook_connectors, ["*"])
 
-    def test_choice_single_connector(self):
-        gc = self._gc()
-        with patch.object(cmd_setup, "_prompt_checkbox_selection", return_value=["hermes"]):
-            cmd_setup._prompt_judge_hook_connectors(gc)
-        self.assertEqual(gc.judge.hook_connectors, ["hermes"])
-
-    def test_rerun_with_star_defaults_to_all(self):
-        gc = self._gc(gate=("*",))
-        with patch.object(
-            cmd_setup,
-            "_prompt_checkbox_selection",
-            return_value=["hermes", "opencode"],
-        ) as prompt:
-            cmd_setup._prompt_judge_hook_connectors(gc)
-        self.assertEqual(prompt.call_args.kwargs.get("default_selected"), ["hermes", "opencode"])
+    def test_setup_all_overwrites_existing_narrow_gate(self):
+        gc = self._gc(gate=("hermes",))
+        cmd_setup._set_hook_judge_coverage_all(gc)
         self.assertEqual(gc.judge.hook_connectors, ["*"])
-
-    def test_rerun_with_single_entry_defaults_to_it(self):
-        gc = self._gc(gate=("hermes",))
-        with patch.object(cmd_setup, "_prompt_checkbox_selection", return_value=["hermes"]) as prompt:
-            cmd_setup._prompt_judge_hook_connectors(gc)
-        self.assertEqual(prompt.call_args.kwargs.get("default_selected"), ["hermes"])
-        self.assertEqual(gc.judge.hook_connectors, ["hermes"])
-
-    def test_rerun_with_multi_entry_preselects_each_connector(self):
-        gc = self._gc(connectors=("hermes", "opencode", "codex"), gate=("hermes", "codex"))
-        with patch.object(
-            cmd_setup,
-            "_prompt_checkbox_selection",
-            return_value=["codex", "hermes"],
-        ) as prompt:
-            cmd_setup._prompt_judge_hook_connectors(gc)
-        self.assertEqual(prompt.call_args.kwargs.get("default_selected"), ["codex", "hermes"])
-        self.assertEqual(gc.judge.hook_connectors, ["codex", "hermes"])
-
-    def test_choice_none_clears_gate(self):
-        gc = self._gc(gate=("hermes",))
-        with patch.object(cmd_setup, "_prompt_checkbox_selection", return_value=[]):
-            cmd_setup._prompt_judge_hook_connectors(gc)
-        self.assertEqual(gc.judge.hook_connectors, [])
 
     def test_checkbox_selector_toggles_with_keys(self):
         keys = iter([" ", "j", " ", "\r"])

--- a/cli/tests/test_cmd_quickstart.py
+++ b/cli/tests/test_cmd_quickstart.py
@@ -18,11 +18,15 @@ import shutil
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from click.testing import CliRunner
 from defenseclaw.commands.cmd_quickstart import quickstart_cmd
+from defenseclaw.connector_paths import KNOWN_CONNECTORS
+from defenseclaw.inventory import agent_discovery
+from defenseclaw.inventory.agent_discovery import AgentDiscovery, AgentSignal
 
 
 class QuickstartProfileDefaultsTests(unittest.TestCase):
@@ -46,6 +50,23 @@ class QuickstartProfileDefaultsTests(unittest.TestCase):
                 "HOME": self.home_dir,
                 "PATH": self.empty_path,
             },
+        )
+
+    def _discovery(self, installed):
+        return AgentDiscovery(
+            scanned_at="2026-06-22T16:00:00Z",
+            agents={
+                name: AgentSignal(
+                    name=name,
+                    installed=name in installed,
+                    config_path=f"/tmp/{name}.config" if name in installed else "",
+                    binary_path="",
+                    version="",
+                    error="",
+                )
+                for name in KNOWN_CONNECTORS
+            },
+            cache_hit=False,
         )
 
     def test_codex_defaults_to_observe_profile(self):
@@ -84,6 +105,78 @@ class QuickstartProfileDefaultsTests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output + (result.stderr or ""))
         summary = json.loads(result.output)
         self.assertEqual(summary["profile"], "observe")
+
+    @patch("defenseclaw.commands.cmd_setup._check_connector_version_supported_for_setup", return_value=True)
+    def test_explicit_action_updates_existing_per_connector_mode(self, _gate):
+        with open(os.path.join(self.tmp_dir, "config.yaml"), "w", encoding="utf-8") as fh:
+            fh.write(
+                "claw:\n"
+                "  mode: codex\n"
+                "guardrail:\n"
+                "  enabled: true\n"
+                "  connector: codex\n"
+                "  mode: observe\n"
+                "  scanner_mode: local\n"
+                "  connectors:\n"
+                "    hermes:\n"
+                "      mode: observe\n"
+            )
+
+        result = self._invoke([
+            "--connector",
+            "hermes",
+            "--mode",
+            "action",
+            "--skip-gateway",
+            "--json-summary",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output + (result.stderr or ""))
+        summary = json.loads(result.output)
+        self.assertEqual(summary["profile"], "action")
+        setup = {step["name"]: step for step in summary["setup"]}
+        self.assertIn("hermes, mode=action", setup["Guardrail"]["detail"])
+
+        import yaml
+        with open(os.path.join(self.tmp_dir, "config.yaml"), encoding="utf-8") as fh:
+            cfg = yaml.safe_load(fh)
+        self.assertEqual(cfg["guardrail"]["connectors"]["hermes"]["mode"], "action")
+
+    @patch("defenseclaw.bootstrap.agent_discovery.discover_agents")
+    @patch("defenseclaw.commands.cmd_setup._check_connector_version_supported_for_setup", return_value=False)
+    def test_action_mode_trusted_path_downgrade_is_structured(self, _gate, mock_discover):
+        disc = self._discovery({"hermes"})
+        disc.agents["hermes"].binary_path = "/tmp/fake/hermes-bin"
+        disc.agents["hermes"].error = agent_discovery.UNTRUSTED_PREFIX_ERROR
+        mock_discover.return_value = disc
+
+        result = self._invoke([
+            "--connector",
+            "hermes",
+            "--mode",
+            "action",
+            "--skip-gateway",
+            "--json-summary",
+        ])
+        self.assertEqual(result.exit_code, 1, result.output + (result.stderr or ""))
+        summary = json.loads(result.output)
+        self.assertEqual(summary["status"], "needs_attention")
+        self.assertEqual(summary["connector"], "hermes")
+        self.assertEqual(summary["profile"], "observe")
+        warning = summary["connector_mode_warnings"][0]
+        self.assertEqual(warning["connector"], "hermes")
+        self.assertEqual(warning["requested_mode"], "action")
+        self.assertEqual(warning["actual_mode"], "observe")
+        self.assertEqual(warning["reason"], "binary path outside trusted prefixes; version was not probed")
+        self.assertEqual(
+            warning["next_command"],
+            f"defenseclaw setup trusted-paths add {os.path.realpath('/tmp/fake')}",
+        )
+
+        import yaml
+        with open(os.path.join(self.tmp_dir, "config.yaml"), encoding="utf-8") as fh:
+            cfg = yaml.safe_load(fh)
+        self.assertEqual(cfg["guardrail"]["connector"], "hermes")
+        self.assertEqual(cfg["guardrail"]["mode"], "observe")
 
     def test_help_lists_fail_mode_flag(self):
         # Quickstart is the headless path most likely to be wired
@@ -156,18 +249,64 @@ class QuickstartProfileDefaultsTests(unittest.TestCase):
         os.makedirs(os.path.join(self.home_dir, ".claude"), exist_ok=True)
         result = self._invoke(["--skip-gateway", "--json-summary"])
         self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("Multiple agent frameworks", result.output + (result.stderr or ""))
+        output = result.output + (result.stderr or "")
+        self.assertIn("Multiple connectors detected/configured", output)
+        self.assertIn("claudecode, codex", output)
+        self.assertIn("Re-run with --connector <name>", output)
 
-    def test_picked_hint_wins_over_detection(self):
-        # The installer's picked_connector hint resolves the connector even
-        # when another agent dir is present (no ambiguity error).
+    def test_picked_hint_does_not_mask_ambiguous_detection(self):
+        # The installer's picked_connector hint is advisory; it must not hide
+        # that a bare quickstart would be choosing among several connectors.
+        os.makedirs(os.path.join(self.home_dir, ".codex"), exist_ok=True)
         os.makedirs(os.path.join(self.home_dir, ".claude"), exist_ok=True)
+        with open(os.path.join(self.tmp_dir, "picked_connector"), "w", encoding="utf-8") as fh:
+            fh.write("codex")
+        result = self._invoke(["--skip-gateway", "--json-summary"])
+        self.assertNotEqual(result.exit_code, 0)
+        output = result.output + (result.stderr or "")
+        self.assertIn("Multiple connectors detected/configured", output)
+        self.assertIn("claudecode, codex", output)
+        self.assertNotIn('"connector": "codex"', result.output)
+
+    def test_picked_hint_without_detection_is_reported_in_json(self):
         with open(os.path.join(self.tmp_dir, "picked_connector"), "w", encoding="utf-8") as fh:
             fh.write("codex")
         result = self._invoke(["--skip-gateway", "--json-summary"])
         self.assertEqual(result.exit_code, 0, result.output + (result.stderr or ""))
         summary = json.loads(result.output)
         self.assertEqual(summary["connector"], "codex")
+        self.assertEqual(
+            summary["connector_source"],
+            {
+                "type": "picked_connector",
+                "connector": "codex",
+                "path": os.path.join(self.tmp_dir, "picked_connector"),
+            },
+        )
+
+    def test_multiple_configured_connectors_error_even_with_picked_hint(self):
+        with open(os.path.join(self.tmp_dir, "config.yaml"), "w", encoding="utf-8") as fh:
+            fh.write(
+                "claw:\n"
+                "  mode: codex\n"
+                "guardrail:\n"
+                "  enabled: true\n"
+                "  connector: codex\n"
+                "  mode: observe\n"
+                "  connectors:\n"
+                "    codex:\n"
+                "      mode: observe\n"
+                "    hermes:\n"
+                "      mode: observe\n"
+            )
+        with open(os.path.join(self.tmp_dir, "picked_connector"), "w", encoding="utf-8") as fh:
+            fh.write("codex")
+        result = self._invoke(["--skip-gateway", "--json-summary"])
+        self.assertNotEqual(result.exit_code, 0)
+        output = result.output + (result.stderr or "")
+        self.assertIn("Multiple connectors detected/configured", output)
+        self.assertIn("codex, hermes", output)
+        self.assertNotIn('"connector": "codex"', result.output)
 
 
 if __name__ == "__main__":

--- a/cli/tests/test_cmd_setup_codex_claudecode_alias.py
+++ b/cli/tests/test_cmd_setup_codex_claudecode_alias.py
@@ -12,10 +12,9 @@
 """Regression tests for the ``setup codex`` / ``setup claude-code`` aliases.
 
 These aliases configure DefenseClaw for hook-only operation against a
-single connector (Codex / Claude Code) and flip ``claw.mode`` so the
-rest of the CLI/TUI surfaces the matching connector's source-of-truth
-files (``~/.codex`` / ``~/.claude``) instead of the OpenClaw default
-layout.
+connector set (Codex / Claude Code) so the rest of the CLI/TUI surfaces
+the matching connector's source-of-truth files (``~/.codex`` /
+``~/.claude``).
 
 The tests pin two architectural invariants:
 
@@ -290,6 +289,13 @@ class TestSetupNewConnectorAliases(unittest.TestCase):
                 self.assertEqual(self.app.cfg.guardrail.mode, "observe")
                 self.assertEqual(self.app.cfg.guardrail.scanner_mode, "local")
                 self.assertFalse(self.app.cfg.guardrail.judge.enabled)
+                self.assertIn(f"Connector {connector!r} configured", result.output)
+                self.assertIn(f"{connector} mode=observe", result.output)
+                self.assertIn(f"defenseclaw setup {connector} --mode action", result.output)
+                self.assertNotIn("Active connector set", result.output)
+                self.assertNotIn("guardrail.mode=observe", result.output)
+                self.assertNotIn("guardrail.mode:", result.output)
+                self.assertNotIn("set guardrail.mode=action", result.output)
                 restart_mock.assert_not_called()
 
                 hint_path = os.path.join(self.app.cfg.data_dir, "picked_connector")
@@ -324,13 +330,50 @@ class TestSetupNewConnectorAliases(unittest.TestCase):
                 self.assertEqual(self.app.cfg.claw.workspace_dir, "")
                 self.assertTrue(self.app.cfg.guardrail.enabled)
                 self.assertEqual(self.app.cfg.guardrail.mode, "action")
-                self.assertIn("guardrail.mode=action", result.output)
+                self.assertIn(f"{connector} mode=action", result.output)
+                self.assertNotIn("guardrail.mode=action", result.output)
+                self.assertNotIn("guardrail.mode:", result.output)
+                self.assertIn(f"defenseclaw setup {connector} --mode observe", result.output)
+                self.assertNotIn("set guardrail.mode=observe", result.output)
                 version_mock.assert_called_with(
                     connector,
                     mode="action",
                     data_dir=self.app.cfg.data_dir,
+                    _allow_prompt=False,
                 )
                 restart_mock.assert_not_called()
+
+    def test_yes_no_restart_setup_does_not_reference_missing_interactive_flag(self):
+        for connector in ["hermes", "codex", "opencode"]:
+            with (
+                self.subTest(connector=connector),
+                patch(
+                    "defenseclaw.commands.cmd_setup._restart_services",
+                    return_value=None,
+                ),
+                patch(
+                    "defenseclaw.commands.cmd_setup._maybe_bring_up_local_stack",
+                    return_value=None,
+                ),
+                patch(
+                    "defenseclaw.commands.cmd_setup._check_connector_version_supported_for_setup",
+                    return_value=True,
+                ) as version_mock,
+            ):
+                self.app.cfg.claw.mode = "openclaw"
+                self.app.cfg.guardrail.connector = "openclaw"
+                self.app.cfg.guardrail.connectors = {}
+                result = _invoke([connector, "--yes", "--no-restart"], self.app)
+
+                self.assertEqual(result.exit_code, 0, msg=result.output)
+                self.assertEqual(self.app.cfg.guardrail.connector, connector)
+                self.assertNotIn("NameError", result.output)
+                version_mock.assert_called_with(
+                    connector,
+                    mode="observe",
+                    data_dir=self.app.cfg.data_dir,
+                    _allow_prompt=False,
+                )
 
     def test_alias_workspace_option_pins_workspace(self):
         workspace = os.path.join(self.tmp_dir, "repo")
@@ -376,6 +419,21 @@ class TestSetupNewConnectorAliases(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, msg=result.output)
         for connector in ["hermes", "cursor", "windsurf", "geminicli", "copilot", "openhands", "antigravity"]:
             self.assertIn(connector, result.output)
+        self.assertIn("codex, claudecode", result.output)
+        self.assertIn("hermes, antigravity", result.output)
+        self.assertIn("OpenClaw/ZeptoClaw use the proxy path", result.output)
+        self.assertNotIn("antigravity, openclaw", result.output)
+        self.assertNotIn("openclaw) tracked under guardrail.connectors", result.output)
+
+    def test_hook_help_uses_connector_set_wording(self):
+        for connector in ["codex", "claude-code", "hermes", "opencode"]:
+            with self.subTest(connector=connector):
+                result = _invoke([connector, "--help"], self.app)
+                self.assertEqual(result.exit_code, 0, msg=result.output)
+                self.assertIn("hook connector set", result.output)
+                self.assertNotIn("Pins the active connector", result.output)
+                self.assertNotIn("Pins claw.mode", result.output)
+                self.assertNotIn("OpenClaw default layout", result.output)
 
     def test_guardrail_help_mentions_new_connector_choices(self):
         result = _invoke(["guardrail", "--help"], self.app)

--- a/cli/tests/test_cmd_setup_codex_claudecode_alias.py
+++ b/cli/tests/test_cmd_setup_codex_claudecode_alias.py
@@ -290,6 +290,8 @@ class TestSetupNewConnectorAliases(unittest.TestCase):
                 self.assertEqual(self.app.cfg.guardrail.scanner_mode, "local")
                 self.assertFalse(self.app.cfg.guardrail.judge.enabled)
                 self.assertIn(f"Connector {connector!r} configured", result.output)
+                self.assertNotIn("claw.mode=", result.output)
+                self.assertNotIn("claw.mode:", result.output)
                 self.assertIn(f"{connector} mode=observe", result.output)
                 self.assertIn(f"defenseclaw setup {connector} --mode action", result.output)
                 self.assertNotIn("Active connector set", result.output)

--- a/cli/tests/test_cmd_setup_fu_phase2.py
+++ b/cli/tests/test_cmd_setup_fu_phase2.py
@@ -441,6 +441,48 @@ class TestBareSetupBatch(_BaseSetup):
         self.assertEqual(res.exit_code, 0, msg=res.output)
         add_mock.assert_called_once()
 
+    def test_batch_action_refusal_downgrades_saved_mode_to_observe(self):
+        def version_gate(connector, *, mode="observe", **_kwargs):
+            return (mode or "").strip().lower() != "action"
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(patch("defenseclaw.commands.cmd_setup._restart_services", return_value=None))
+            stack.enter_context(patch("defenseclaw.commands.cmd_setup._restart_defense_gateway", return_value=True))
+            stack.enter_context(patch("defenseclaw.commands.cmd_setup._maybe_bring_up_local_stack", return_value=None))
+            stack.enter_context(patch("defenseclaw.commands.cmd_setup._is_interactive", return_value=True))
+            stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_batch_connector_modes",
+                    return_value={"geminicli": "action", "windsurf": "action"},
+                )
+            )
+            stack.enter_context(patch("defenseclaw.commands.cmd_setup._prompt_batch_trusted_prefixes", return_value={}))
+            stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_batch_judge_connectors",
+                    return_value=set(),
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_setup._check_connector_version_supported_for_setup",
+                    side_effect=version_gate,
+                )
+            )
+            res = _invoke(
+                ["-c", "geminicli", "-c", "windsurf", "--no-restart"],
+                self.app,
+            )
+
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertIn("Gemini CLI: requested action mode was refused", res.output)
+        self.assertIn("Windsurf: requested action mode was refused", res.output)
+        gc = self.app.cfg.guardrail
+        self.assertEqual(gc.effective_mode("geminicli"), "observe")
+        self.assertEqual(gc.effective_mode("windsurf"), "observe")
+        self.assertEqual(gc.connectors["geminicli"].mode, "observe")
+        self.assertEqual(gc.connectors["windsurf"].mode, "observe")
+
     def test_interactive_batch_selects_judge_connectors_without_strategy_prompt(self):
         gc = self.app.cfg.guardrail
         gc.judge.enabled = True

--- a/cli/tests/test_cmd_setup_fu_phase2.py
+++ b/cli/tests/test_cmd_setup_fu_phase2.py
@@ -117,7 +117,7 @@ class TestPerConnectorWriteSurface(_BaseSetup):
         # Judge enablement is global + gated; strategy bumped off regex_only.
         self.assertTrue(gc.judge.enabled)
         self.assertNotEqual(gc.detection_strategy, "regex_only")
-        self.assertTrue(gc.judge.hook_connectors == ["*"] or "hermes" in gc.judge.hook_connectors)
+        self.assertEqual(gc.judge.hook_connectors, ["hermes"])
         # Peer left completely untouched (inherits global).
         codex = gc.connectors["codex"]
         self.assertEqual(codex.mode, "")
@@ -197,6 +197,18 @@ class TestPerConnectorWriteSurface(_BaseSetup):
         self.assertEqual(gc.detection_strategy, "regex_judge")
         self.assertEqual(gc.connectors["hermes"].block_message, "keep-me")
 
+    def test_enable_judge_adds_connector_to_existing_narrow_gate(self):
+        self._seed_map("codex", "hermes")
+        gc = self.app.cfg.guardrail
+        gc.judge.enabled = True
+        gc.judge.hook_connectors = ["codex"]
+        gc.detection_strategy = "regex_judge"
+        with _stub_side_effects():
+            res = _invoke(["hermes", "--yes", "--no-restart", "--enable-judge"], self.app)
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertTrue(gc.judge.enabled)
+        self.assertEqual(gc.judge.hook_connectors, ["codex", "hermes"])
+
     def test_no_enable_judge_opts_connector_out_of_concrete_gate(self):
         self._seed_map("codex", "hermes")
         gc = self.app.cfg.guardrail
@@ -226,13 +238,17 @@ class TestInteractiveModeJudgePrompts(_BaseSetup):
         self.assertEqual(self.app.cfg.guardrail.mode, "action")
 
     def test_judge_prompt_enables_judge(self):
+        confirms = iter([True, True, True])
         with _stub_side_effects(), \
                 patch("defenseclaw.commands.cmd_setup._is_interactive", return_value=True), \
-                patch("defenseclaw.commands.cmd_setup.click.confirm", return_value=True), \
-                patch("defenseclaw.commands.cmd_setup.click.prompt", return_value="1"):
+                patch("defenseclaw.commands.cmd_setup.click.confirm", side_effect=lambda *a, **k: next(confirms)), \
+                patch("defenseclaw.commands.cmd_setup.click.prompt", return_value="1"), \
+                patch("defenseclaw.commands.cmd_setup._prompt_judge_model_config") as model_prompt:
             res = _invoke(["codex", "--no-restart"], self.app)
         self.assertEqual(res.exit_code, 0, msg=res.output)
         self.assertTrue(self.app.cfg.guardrail.judge.enabled)
+        self.assertEqual(self.app.cfg.guardrail.judge.hook_connectors, ["codex"])
+        model_prompt.assert_called_once()
 
     def test_non_interactive_does_not_prompt(self):
         # --yes path: no prompts fire (would error on EOF if they did).
@@ -277,6 +293,32 @@ class TestTrustedPrefixObservePrompt(unittest.TestCase):
         _ok, add_mock, confirm_mock = self._run("action")
         self.assertTrue(confirm_mock.called)
         self.assertTrue(add_mock.called)
+
+    def test_noninteractive_observe_suppresses_prompt_but_emits_remediation(self):
+        signal = SimpleNamespace(
+            version="",
+            installed=True,
+            error=cmd_setup.agent_discovery.UNTRUSTED_PREFIX_ERROR,
+            binary_path="/tmp/fake/hermes-bin",
+        )
+        disc = SimpleNamespace(agents={"hermes": signal})
+        contract = SimpleNamespace(status=cmd_setup.STATUS_UNVERSIONED, contract=None, reason="unversioned")
+        hints = []
+        with patch.object(cmd_setup.agent_discovery, "discover_agents", return_value=disc), \
+                patch.object(cmd_setup, "resolve_connector_contract", return_value=contract), \
+                patch.object(cmd_setup.sys.stdin, "isatty", return_value=True), \
+                patch.object(cmd_setup.sys.stdout, "isatty", return_value=True), \
+                patch.object(cmd_setup, "_add_trusted_bin_prefix", return_value=True) as add_mock, \
+                patch.object(cmd_setup.click, "confirm", side_effect=AssertionError("prompted")), \
+                patch.object(cmd_setup.ux, "subhead", side_effect=lambda message: hints.append(message)):
+            ok = cmd_setup._check_connector_version_supported_for_setup(
+                "hermes",
+                mode="observe",
+                _allow_prompt=False,
+            )
+        self.assertTrue(ok)
+        add_mock.assert_not_called()
+        self.assertIn("trusted-paths add", " ".join(hints))
 
 
 # ---------------------------------------------------------------------------
@@ -364,14 +406,210 @@ class TestBareSetupBatch(_BaseSetup):
         with _stub_side_effects(), \
                 patch("defenseclaw.commands.cmd_setup._is_interactive", return_value=True), \
                 patch("defenseclaw.commands.cmd_setup._detect_installed_connectors", return_value=["hermes"]), \
-                patch("defenseclaw.commands.cmd_setup.click.prompt", return_value="2"), \
-                patch("defenseclaw.commands.cmd_setup.click.confirm", return_value=False):
+                patch("defenseclaw.commands.cmd_setup.click.getchar", return_value="\n"):
             res = _invoke(["--yes"], self.app)
-        # --yes => no per-connector prompts; picker prompt (click.prompt) picks
-        # candidate #2. The exact connector depends on sorted order; just assert
-        # exactly one connector was configured from the picker.
+        # --yes => no mode/judge prompts, but bare setup still needs the
+        # connector picker. Enter accepts the detected default selection.
         self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertNotIn("comma-separated", res.output)
         self.assertEqual(len(self.app.cfg.guardrail.connectors), 1)
+        self.assertIn("hermes", self.app.cfg.guardrail.connectors)
+
+    def test_batch_prompts_trusted_prefix_before_judge_picker(self):
+        signal = SimpleNamespace(
+            version="",
+            installed=True,
+            error=cmd_setup.agent_discovery.UNTRUSTED_PREFIX_ERROR,
+            binary_path="/tmp/fake/hermes-bin",
+        )
+        disc = SimpleNamespace(agents={"hermes": signal})
+
+        with _stub_side_effects(), \
+                patch("defenseclaw.commands.cmd_setup._is_interactive", return_value=True), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_batch_connector_modes",
+                    return_value={"hermes": "action"},
+                ), \
+                patch.object(cmd_setup.agent_discovery, "discover_agents", return_value=disc), \
+                patch("defenseclaw.commands.cmd_setup._add_trusted_bin_prefix") as add_mock, \
+                patch("defenseclaw.commands.cmd_setup.click.confirm", return_value=True), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_batch_judge_connectors",
+                    side_effect=lambda targets, gc: self.assertTrue(add_mock.called) or set(),
+                ):
+            res = _invoke(["-c", "hermes", "--no-restart"], self.app)
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        add_mock.assert_called_once()
+
+    def test_interactive_batch_selects_judge_connectors_without_strategy_prompt(self):
+        gc = self.app.cfg.guardrail
+        gc.judge.enabled = True
+        gc.judge.hook_connectors = ["*"]
+
+        def choose_hermes(targets, gc_arg):
+            cmd_setup._merge_batch_judge_selection(gc_arg, targets, {"hermes"})
+            return {"hermes"}
+
+        with _stub_side_effects(), \
+                patch("defenseclaw.commands.cmd_setup._is_interactive", return_value=True), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_batch_connector_modes",
+                    return_value={"hermes": "observe", "codex": "action"},
+                ) as mode_picker, \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_batch_scan_strategy",
+                    side_effect=AssertionError("bare setup should not ask for scan strategy"),
+                ), \
+                patch("defenseclaw.commands.cmd_setup._prompt_batch_trusted_prefixes", return_value={}), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_batch_judge_connectors",
+                    side_effect=choose_hermes,
+                ) as judge_picker, \
+                patch("defenseclaw.commands.cmd_setup.click.confirm", return_value=False) as confirm_mock, \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_judge_model_config",
+                    side_effect=AssertionError("model prompt should be skipped when declined"),
+                ), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_connector_mode",
+                    side_effect=AssertionError("per-connector mode prompt should not run"),
+                ), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_enable_judge",
+                    side_effect=AssertionError("per-connector judge prompt should not run"),
+                ):
+            res = _invoke(["-c", "hermes", "-c", "codex", "--no-restart"], self.app)
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        mode_picker.assert_called_once()
+        judge_picker.assert_called_once()
+        confirm_mock.assert_called_once()
+        self.assertEqual(gc.connectors["hermes"].mode, "observe")
+        self.assertEqual(gc.connectors["codex"].mode, "action")
+        self.assertEqual(gc.detection_strategy, "regex_judge")
+        self.assertEqual(gc.judge.hook_connectors, ["hermes"])
+
+    def test_batch_judge_selection_drops_unselected_existing_connectors(self):
+        self._seed_map("codex", "hermes")
+        gc = self.app.cfg.guardrail
+        gc.judge.enabled = True
+        gc.judge.hook_connectors = ["*"]
+
+        def choose_hermes(targets, gc_arg):
+            cmd_setup._merge_batch_judge_selection(gc_arg, targets, {"hermes"})
+            return {"hermes"}
+
+        with _stub_side_effects(), \
+                patch("defenseclaw.commands.cmd_setup._is_interactive", return_value=True), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_batch_connector_modes",
+                    return_value={"hermes": "observe"},
+                ), \
+                patch("defenseclaw.commands.cmd_setup._prompt_batch_trusted_prefixes", return_value={}), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_batch_judge_connectors",
+                    side_effect=choose_hermes,
+                ), \
+                patch("defenseclaw.commands.cmd_setup.click.confirm", return_value=False):
+            res = _invoke(["-c", "hermes", "--no-restart"], self.app)
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertEqual(gc.judge.hook_connectors, ["hermes"])
+        self.assertNotIn("codex", gc.judge.hook_connectors)
+
+    def test_batch_setup_reconciles_active_connectors_to_selected_set(self):
+        self._seed_map("codex", "hermes")
+        gc = self.app.cfg.guardrail
+        gc.judge.enabled = True
+        gc.judge.hook_connectors = ["codex", "hermes"]
+
+        with _stub_side_effects():
+            res = _invoke(["-c", "hermes", "--yes", "--no-restart"], self.app)
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertEqual(sorted(gc.connectors), ["hermes"])
+        self.assertEqual(gc.connector, "hermes")
+        self.assertEqual(self.app.cfg.claw.mode, "hermes")
+        self.assertEqual(gc.judge.hook_connectors, ["hermes"])
+
+    def test_batch_setup_does_not_seed_unselected_legacy_single_connector(self):
+        gc = self.app.cfg.guardrail
+        gc.connector = "codex"
+        self.app.cfg.claw.mode = "codex"
+        gc.connectors = {}
+
+        with _stub_side_effects():
+            res = _invoke(["-c", "hermes", "--yes", "--no-restart"], self.app)
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertEqual(sorted(gc.connectors), ["hermes"])
+        self.assertNotIn("codex", gc.connectors)
+        self.assertEqual(gc.connector, "hermes")
+
+    def test_empty_batch_judge_selection_skips_model_and_uses_regex_only(self):
+        gc = self.app.cfg.guardrail
+        gc.judge.enabled = True
+        gc.judge.hook_connectors = ["hermes"]
+
+        def choose_none(targets, gc_arg):
+            cmd_setup._merge_batch_judge_selection(gc_arg, targets, set())
+            return set()
+
+        with _stub_side_effects(), \
+                patch("defenseclaw.commands.cmd_setup._is_interactive", return_value=True), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_batch_connector_modes",
+                    return_value={"hermes": "observe", "codex": "observe"},
+                ), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_batch_scan_strategy",
+                    side_effect=AssertionError("bare setup should not ask for scan strategy"),
+                ), \
+                patch("defenseclaw.commands.cmd_setup._prompt_batch_trusted_prefixes", return_value={}), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_batch_judge_connectors",
+                    side_effect=choose_none,
+                ), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_judge_model_config",
+                    side_effect=AssertionError("judge model prompt should not run with no judge connectors"),
+                ), \
+                patch(
+                    "defenseclaw.commands.cmd_setup.click.confirm",
+                    side_effect=AssertionError("judge model confirm should not run with no judge connectors"),
+                ):
+            res = _invoke(["-c", "hermes", "-c", "codex", "--no-restart"], self.app)
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertFalse(gc.judge.enabled)
+        self.assertEqual(gc.detection_strategy, "regex_only")
+        self.assertEqual(gc.detection_strategy_completion, "regex_only")
+        self.assertEqual(gc.judge.hook_connectors, [])
+
+    def test_batch_judge_selection_can_configure_model(self):
+        def choose_hermes(targets, gc_arg):
+            cmd_setup._merge_batch_judge_selection(gc_arg, targets, {"hermes"})
+            return {"hermes"}
+
+        with _stub_side_effects(), \
+                patch("defenseclaw.commands.cmd_setup._is_interactive", return_value=True), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_batch_connector_modes",
+                    return_value={"hermes": "observe"},
+                ), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_batch_scan_strategy",
+                    side_effect=AssertionError("bare setup should not ask for scan strategy"),
+                ), \
+                patch("defenseclaw.commands.cmd_setup._prompt_batch_trusted_prefixes", return_value={}), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_batch_judge_connectors",
+                    side_effect=choose_hermes,
+                ), \
+                patch("defenseclaw.commands.cmd_setup.click.confirm", return_value=True) as confirm_mock, \
+                patch("defenseclaw.commands.cmd_setup._prompt_judge_model_config") as model_prompt:
+            res = _invoke(["-c", "hermes", "--no-restart"], self.app)
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        confirm_mock.assert_called_once()
+        model_prompt.assert_called_once()
+        self.assertTrue(self.app.cfg.guardrail.judge.enabled)
+        self.assertEqual(self.app.cfg.guardrail.detection_strategy, "regex_judge")
+        self.assertEqual(self.app.cfg.guardrail.judge.hook_connectors, ["hermes"])
 
     def test_flags_ignored_with_subcommand_warns(self):
         with _stub_side_effects():
@@ -415,6 +653,21 @@ class TestJ3PerDirectionStrategy(_BaseSetup):
             )
         self.assertEqual(res.exit_code, 0, msg=res.output)
         self.assertEqual(self.app.cfg.guardrail.detection_strategy_completion, "regex_judge")
+
+    def test_judge_strategy_flag_enables_judge_with_all_hook_coverage(self):
+        with _stub_side_effects(), \
+                patch("defenseclaw.commands.cmd_setup.execute_guardrail_setup", return_value=(True, [])):
+            res = _invoke(
+                [
+                    "guardrail", "--non-interactive", "--connector", "codex", "--no-restart", "--no-verify",
+                    "--detection-strategy", "regex_judge",
+                ],
+                self.app,
+            )
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertTrue(self.app.cfg.guardrail.judge.enabled)
+        self.assertEqual(self.app.cfg.guardrail.detection_strategy, "regex_judge")
+        self.assertEqual(self.app.cfg.guardrail.judge.hook_connectors, ["*"])
 
     def test_off_by_default_tool_call_unset(self):
         with _stub_side_effects(), \

--- a/cli/tests/test_cmd_setup_multi_connector.py
+++ b/cli/tests/test_cmd_setup_multi_connector.py
@@ -255,13 +255,17 @@ class TestObservabilitySummaryDisplay(unittest.TestCase):
         self.assertIn("claudecode", out)
         self.assertIn("codex", out)
         self.assertIn("connectors:", out)
+        self.assertIn("codex mode:", out)
+        self.assertNotIn("guardrail.mode:", out)
         # ...and no '(primary: ...)' callout leaks the back-compat pointer.
         self.assertNotIn("primary:", out)
 
-    def test_single_connector_summary_unchanged(self):
+    def test_single_connector_summary_uses_connector_mode_label(self):
         self._seed_map("cursor")  # single → claw.mode row, not a roster
         out = self._capture_summary("cursor")
         self.assertIn("claw.mode:", out)
+        self.assertIn("cursor mode:", out)
+        self.assertNotIn("guardrail.mode:", out)
         self.assertNotIn("connectors:", out)
         self.assertNotIn("primary:", out)
 

--- a/cli/tests/test_cmd_setup_multi_connector.py
+++ b/cli/tests/test_cmd_setup_multi_connector.py
@@ -261,10 +261,11 @@ class TestObservabilitySummaryDisplay(unittest.TestCase):
         self.assertNotIn("primary:", out)
 
     def test_single_connector_summary_uses_connector_mode_label(self):
-        self._seed_map("cursor")  # single → claw.mode row, not a roster
+        self._seed_map("cursor")
         out = self._capture_summary("cursor")
-        self.assertIn("claw.mode:", out)
+        self.assertIn("active connector:", out)
         self.assertIn("cursor mode:", out)
+        self.assertNotIn("claw.mode:", out)
         self.assertNotIn("guardrail.mode:", out)
         self.assertNotIn("connectors:", out)
         self.assertNotIn("primary:", out)

--- a/cli/tests/test_cmd_setup_observability.py
+++ b/cli/tests/test_cmd_setup_observability.py
@@ -38,6 +38,7 @@ from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from defenseclaw.commands import cmd_setup
 from defenseclaw.commands.cmd_setup import _interactive_guardrail_setup
 
 
@@ -146,8 +147,14 @@ class TestObservabilityWizard(unittest.TestCase):
                    return_value="1"), \
              patch("defenseclaw.commands.cmd_setup._select_connector_interactive",
                    return_value=connector), \
-             patch("defenseclaw.commands.cmd_setup._prompt_batch_scan_strategy",
-                   return_value="regex_only"), \
+             patch(
+                 "defenseclaw.commands.cmd_setup._prompt_batch_scan_strategy",
+                 side_effect=AssertionError("setup guardrail should not ask for scan strategy"),
+             ), \
+             patch(
+                 "defenseclaw.commands.cmd_setup._prompt_guardrail_judge_enablement",
+                 side_effect=lambda gc_arg, targets: cmd_setup._merge_batch_judge_selection(gc_arg, targets, set()),
+             ), \
              patch("defenseclaw.commands.cmd_setup._print_connector_info",
                    return_value=None), \
              patch("defenseclaw.commands.cmd_setup.click.echo",
@@ -181,15 +188,22 @@ class TestObservabilityWizard(unittest.TestCase):
         self.assertFalse(gc.judge.enabled)
         self.assertEqual(gc.hook_fail_mode, "open")
 
-    def test_regex_only_strategy_skips_judge_prompts(self):
+    def test_empty_judge_selection_skips_judge_model_prompt(self):
         app, gc = _make_app("codex")
 
         with patch("defenseclaw.commands.cmd_setup.click.confirm", side_effect=[True, False]), \
              patch("defenseclaw.commands.cmd_setup.click.prompt", return_value="1"), \
-             patch("defenseclaw.commands.cmd_setup._prompt_batch_scan_strategy", return_value="regex_only"), \
+             patch(
+                 "defenseclaw.commands.cmd_setup._prompt_batch_scan_strategy",
+                 side_effect=AssertionError("setup guardrail should not ask for scan strategy"),
+             ), \
+             patch(
+                 "defenseclaw.commands.cmd_setup._prompt_guardrail_judge_enablement",
+                 side_effect=lambda gc_arg, targets: cmd_setup._merge_batch_judge_selection(gc_arg, targets, set()),
+             ), \
              patch(
                  "defenseclaw.commands.cmd_setup._prompt_judge_model_config",
-                 side_effect=AssertionError("judge model prompt should not run for regex_only"),
+                 side_effect=AssertionError("judge model prompt should not run with no judge connectors"),
              ), \
              patch("defenseclaw.commands.cmd_setup._select_connector_interactive", return_value="codex"), \
              patch("defenseclaw.commands.cmd_setup._print_connector_info", return_value=None), \
@@ -198,12 +212,23 @@ class TestObservabilityWizard(unittest.TestCase):
         self.assertFalse(gc.judge.enabled)
         self.assertEqual(gc.detection_strategy, "regex_only")
 
-    def test_judge_strategy_enables_all_hook_coverage_and_model(self):
+    def test_judge_selection_enables_selected_hook_coverage_and_model(self):
         app, gc = _make_app("codex")
 
         with patch("defenseclaw.commands.cmd_setup.click.confirm", side_effect=[True, False]), \
              patch("defenseclaw.commands.cmd_setup.click.prompt", return_value="1"), \
-             patch("defenseclaw.commands.cmd_setup._prompt_batch_scan_strategy", return_value="regex_judge"), \
+             patch(
+                 "defenseclaw.commands.cmd_setup._prompt_batch_scan_strategy",
+                 side_effect=AssertionError("setup guardrail should not ask for scan strategy"),
+             ), \
+             patch(
+                 "defenseclaw.commands.cmd_setup._prompt_guardrail_judge_enablement",
+                 side_effect=lambda gc_arg, targets: cmd_setup._merge_batch_judge_selection(
+                     gc_arg,
+                     targets,
+                     {"codex"},
+                 ),
+             ), \
              patch("defenseclaw.commands.cmd_setup._prompt_judge_model_config") as model_prompt, \
              patch("defenseclaw.commands.cmd_setup._select_connector_interactive", return_value="codex"), \
              patch("defenseclaw.commands.cmd_setup._print_connector_info", return_value=None), \
@@ -211,7 +236,7 @@ class TestObservabilityWizard(unittest.TestCase):
             _interactive_guardrail_setup(app, gc, agent_name="codex")
         self.assertTrue(gc.judge.enabled)
         self.assertEqual(gc.detection_strategy, "regex_judge")
-        self.assertEqual(gc.judge.hook_connectors, ["*"])
+        self.assertEqual(gc.judge.hook_connectors, ["codex"])
         model_prompt.assert_called_once()
 
     def test_observability_decline_disables_connector(self):

--- a/cli/tests/test_cmd_setup_observability.py
+++ b/cli/tests/test_cmd_setup_observability.py
@@ -62,6 +62,7 @@ def _make_app(connector: str):
         api_base="",
         api_key_env="",
         fallbacks=[],
+        hook_connectors=[],
     )
     # Human-In-the-Loop (HILT) sub-namespace mirrors GuardrailConfig.hilt.
     # Required because the wizard now asks about HILT inline whenever
@@ -145,6 +146,8 @@ class TestObservabilityWizard(unittest.TestCase):
                    return_value="1"), \
              patch("defenseclaw.commands.cmd_setup._select_connector_interactive",
                    return_value=connector), \
+             patch("defenseclaw.commands.cmd_setup._prompt_batch_scan_strategy",
+                   return_value="regex_only"), \
              patch("defenseclaw.commands.cmd_setup._print_connector_info",
                    return_value=None), \
              patch("defenseclaw.commands.cmd_setup.click.echo",
@@ -162,8 +165,8 @@ class TestObservabilityWizard(unittest.TestCase):
         self.assertEqual(gc.scanner_mode, "local")
         self.assertEqual(gc.detection_strategy, "regex_only")
         self.assertFalse(gc.judge.enabled,
-                         "Default-accept path declines the judge prompt; "
-                         "operators who want it can opt in on rerun")
+                         "Default scan strategy is regex_only; "
+                         "operators who want judge can opt in on rerun")
         # The observability-only branch now also surfaces the hook
         # fail-mode prompt on initial setup. The mocked ``click.prompt``
         # returns "1" (open), so the persisted value must reflect that —
@@ -177,6 +180,39 @@ class TestObservabilityWizard(unittest.TestCase):
         self.assertEqual(gc.mode, "observe")
         self.assertFalse(gc.judge.enabled)
         self.assertEqual(gc.hook_fail_mode, "open")
+
+    def test_regex_only_strategy_skips_judge_prompts(self):
+        app, gc = _make_app("codex")
+
+        with patch("defenseclaw.commands.cmd_setup.click.confirm", side_effect=[True, False]), \
+             patch("defenseclaw.commands.cmd_setup.click.prompt", return_value="1"), \
+             patch("defenseclaw.commands.cmd_setup._prompt_batch_scan_strategy", return_value="regex_only"), \
+             patch(
+                 "defenseclaw.commands.cmd_setup._prompt_judge_model_config",
+                 side_effect=AssertionError("judge model prompt should not run for regex_only"),
+             ), \
+             patch("defenseclaw.commands.cmd_setup._select_connector_interactive", return_value="codex"), \
+             patch("defenseclaw.commands.cmd_setup._print_connector_info", return_value=None), \
+             patch("defenseclaw.commands.cmd_setup.click.echo", return_value=None):
+            _interactive_guardrail_setup(app, gc, agent_name="codex")
+        self.assertFalse(gc.judge.enabled)
+        self.assertEqual(gc.detection_strategy, "regex_only")
+
+    def test_judge_strategy_enables_all_hook_coverage_and_model(self):
+        app, gc = _make_app("codex")
+
+        with patch("defenseclaw.commands.cmd_setup.click.confirm", side_effect=[True, False]), \
+             patch("defenseclaw.commands.cmd_setup.click.prompt", return_value="1"), \
+             patch("defenseclaw.commands.cmd_setup._prompt_batch_scan_strategy", return_value="regex_judge"), \
+             patch("defenseclaw.commands.cmd_setup._prompt_judge_model_config") as model_prompt, \
+             patch("defenseclaw.commands.cmd_setup._select_connector_interactive", return_value="codex"), \
+             patch("defenseclaw.commands.cmd_setup._print_connector_info", return_value=None), \
+             patch("defenseclaw.commands.cmd_setup.click.echo", return_value=None):
+            _interactive_guardrail_setup(app, gc, agent_name="codex")
+        self.assertTrue(gc.judge.enabled)
+        self.assertEqual(gc.detection_strategy, "regex_judge")
+        self.assertEqual(gc.judge.hook_connectors, ["*"])
+        model_prompt.assert_called_once()
 
     def test_observability_decline_disables_connector(self):
         """When the operator declines the single confirm prompt, the

--- a/cli/tests/test_cmd_setup_trusted_paths.py
+++ b/cli/tests/test_cmd_setup_trusted_paths.py
@@ -271,6 +271,40 @@ class GatePromptContractGateTests(unittest.TestCase):
         self.assertIn(os.path.dirname(os.path.realpath(binpath)), joined)
         self.assertIn("appends to ~/.defenseclaw/.env", joined)
 
+    def test_prompt_cache_avoids_reasking_same_directory(self):
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(tmp, ignore_errors=True))
+        binpath = os.path.join(tmp, "bin", "codex")
+        disc = _disc(_signal("", ad.UNTRUSTED_PREFIX_ERROR, binpath))
+        cache: dict[str, bool] = {}
+
+        def contract(_c, v):
+            return _compat(v, STATUS_UNVERSIONED, "codex-hooks-v1")
+
+        with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": ""}, clear=False), \
+                patch.object(cmd_setup.agent_discovery, "discover_agents", return_value=disc), \
+                patch.object(cmd_setup, "resolve_connector_contract", side_effect=contract), \
+                patch.object(sys.stdin, "isatty", return_value=True), \
+                patch.object(sys.stdout, "isatty", return_value=True), \
+                patch.object(cmd_setup.click, "confirm", return_value=False) as confirm:
+            first = cmd_setup._check_connector_version_supported_for_setup(
+                "codex",
+                mode="action",
+                data_dir=tmp,
+                _trusted_prompt_cache=cache,
+            )
+            second = cmd_setup._check_connector_version_supported_for_setup(
+                "codex",
+                mode="action",
+                data_dir=tmp,
+                _trusted_prompt_cache=cache,
+            )
+
+        self.assertFalse(first)
+        self.assertFalse(second)
+        confirm.assert_called_once()
+        self.assertEqual(cache, {os.path.dirname(os.path.realpath(binpath)): False})
+
 
 class ValidateTrustedPrefixTests(unittest.TestCase):
     def test_rejects_non_absolute_path(self):

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -1171,6 +1171,36 @@ class TestConfigTopLevelSections(unittest.TestCase):
             self.assertEqual(output.count("privacy.disable_redaction=true"), 1)
             self.assertIn("UNREDACTED prompts", output)
 
+    def test_load_warns_once_for_same_legacy_llm_fields(self):
+        import yaml
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_data = {
+                "data_dir": tmpdir,
+                "guardrail": {
+                    "judge": {
+                        "model": "gpt-4o-mini",
+                        "api_key_env": "OPENAI_API_KEY",
+                        "api_base": "https://api.example.test/v1",
+                    }
+                },
+            }
+            with open(os.path.join(tmpdir, "config.yaml"), "w") as f:
+                yaml.dump(config_data, f)
+
+            with (
+                patch("defenseclaw.config.default_data_path") as mock_dp,
+                patch.object(config_mod, "_llm_migration_warned_keys", set()),
+                self.assertLogs("defenseclaw.config", level="WARNING") as logs,
+            ):
+                mock_dp.return_value = Path(tmpdir)
+                config_mod.load()
+                config_mod.load()
+
+            output = "\n".join(logs.output)
+            self.assertEqual(output.count("deprecated v4 LLM fields detected"), 1)
+            self.assertIn("guardrail.judge.{model,api_key_env,api_base}", output)
+
     def test_guardrail_config_has_no_cisco_ai_defense(self):
         """GuardrailConfig no longer nests CiscoAIDefenseConfig."""
         from defenseclaw.config import GuardrailConfig

--- a/cli/tests/test_guardrail.py
+++ b/cli/tests/test_guardrail.py
@@ -1518,7 +1518,7 @@ class TestSetupGuardrailCommand(unittest.TestCase):
         ), patch(
             "defenseclaw.commands.cmd_setup._check_connector_version_supported_for_setup",
             return_value=True,
-        ):
+        ) as version_check:
             result = self.runner.invoke(
                 setup,
                 ["guardrail", "--no-restart"],
@@ -1550,7 +1550,7 @@ class TestSetupGuardrailCommand(unittest.TestCase):
         ), patch(
             "defenseclaw.commands.cmd_setup._check_connector_version_supported_for_setup",
             return_value=True,
-        ):
+        ) as version_check:
             result = self.runner.invoke(
                 setup,
                 ["guardrail", "--no-restart"],
@@ -1571,10 +1571,10 @@ class TestSetupGuardrailCommand(unittest.TestCase):
             "Per-connector enforcement mode is managed via", result.output
         )
 
-    def test_interactive_multi_connector_skips_picker_and_mode(self):
-        """Two configured connectors: BOTH the picker and the singular
-        observe/action prompt are skipped — a single answer can't express
-        per-connector intent. The wizard still runs all GLOBAL steps."""
+    def test_interactive_multi_connector_uses_per_connector_mode_picker(self):
+        """Two configured connectors: the connector picker and singular
+        observe/action prompt are skipped, but the wizard offers a
+        per-connector action picker before the global policy steps."""
         from defenseclaw.commands.cmd_setup import setup
         from defenseclaw.config import PerConnectorGuardrailConfig
 
@@ -1593,7 +1593,7 @@ class TestSetupGuardrailCommand(unittest.TestCase):
         ), patch(
             "defenseclaw.commands.cmd_setup._check_connector_version_supported_for_setup",
             return_value=True,
-        ):
+        ) as version_check:
             result = self.runner.invoke(
                 setup,
                 ["guardrail", "--no-restart"],
@@ -1613,14 +1613,17 @@ class TestSetupGuardrailCommand(unittest.TestCase):
         self.assertIn(
             "Per-connector enforcement mode is managed via", result.output
         )
-        # The singular enforcement-mode prompt is skipped...
-        self.assertIn("Enforcement mode is per-connector here", result.output)
+        # The singular enforcement-mode prompt is skipped in favor of the
+        # per-connector action picker.
+        self.assertIn("Select connector(s) for action mode.", result.output)
         self.assertNotIn("Select mode", result.output)
-        # ...and per-connector modes are left untouched.
+        # Pressing Enter accepts the current per-connector defaults.
         self.assertEqual(self.app.cfg.guardrail.connectors["codex"].mode, "action")
         self.assertEqual(
             self.app.cfg.guardrail.connectors["claudecode"].mode, "observe"
         )
+        checked = {call.args[0] for call in version_check.call_args_list}
+        self.assertEqual(checked, {"codex", "claudecode"})
 
     def test_interactive_multi_connector_offers_hilt_when_any_action(self):
         """In multi-connector mode HILT is gated on whether ANY connector

--- a/cli/tests/tui/test_setup_panel.py
+++ b/cli/tests/tui/test_setup_panel.py
@@ -654,7 +654,7 @@ def test_guardrail_wizard_inherits_unified_llm_without_forcing_override() -> Non
         },
         "guardrail": {"mode": "observe", "scanner_mode": "local", "judge": {}, "hilt": {}},
     }
-    fields = guardrail_wizard_fields(cfg)
+    fields = _guardrail_wizard_fields_for({"--detection-strategy": "regex_judge"}, cfg)
 
     assert wizard_field_value(fields, "Provider") == "openai"
     assert wizard_field_value(fields, "Model") == "gpt-5"
@@ -667,9 +667,11 @@ def test_guardrail_wizard_inherits_unified_llm_without_forcing_override() -> Non
     assert "openai/gpt-5-mini" in build_wizard_args(SetupWizard.GUARDRAIL, fields)
 
 
-def test_guardrail_wizard_exposes_judge_hook_connectors_without_openclaw_default() -> None:
+def test_guardrail_wizard_omits_judge_hook_connectors_without_openclaw_default() -> None:
     empty_fields = guardrail_wizard_fields({})
     assert wizard_field_value(empty_fields, "Connector") == ""
+    assert wizard_field_value(empty_fields, "Provider") == ""
+    assert wizard_field_value(empty_fields, "Hook Connectors") == ""
     empty_argv = build_wizard_args(SetupWizard.GUARDRAIL, empty_fields)
     assert ("--connector", "openclaw") not in zip(empty_argv, empty_argv[1:])
 
@@ -681,13 +683,10 @@ def test_guardrail_wizard_exposes_judge_hook_connectors_without_openclaw_default
             "judge": {"hook_connectors": ["codex"]},
         },
     }
-    fields = guardrail_wizard_fields(cfg)
-    assert wizard_field_value(fields, "Hook Connectors") == "codex"
-
-    fields = _with_field(fields, "Hook Connectors", "codex,antigravity")
+    fields = _guardrail_wizard_fields_for({"--detection-strategy": "regex_judge"}, cfg)
     argv = build_wizard_args(SetupWizard.GUARDRAIL, fields)
-    assert "--judge-hook-connectors" in argv
-    assert _pair_after(argv, "--judge-hook-connectors") == "codex,antigravity"
+    assert wizard_field_value(fields, "Hook Connectors") == ""
+    assert "--judge-hook-connectors" not in argv
 
 
 def test_observability_and_webhook_wizards_pass_positionals_and_defaults() -> None:
@@ -1707,7 +1706,7 @@ def test_setup_panel_recompute_preserves_entered_values() -> None:
 
 
 def test_guardrail_wizard_regional_judge_families_and_llm_role() -> None:
-    fields = _guardrail_wizard_fields_for({"@Provider": "bedrock"}, None)
+    fields = _guardrail_wizard_fields_for({"--detection-strategy": "regex_judge", "@Provider": "bedrock"}, None)
     labels = {f.label for f in fields}
     assert "Judge: Bedrock" in labels
     assert "Judge: Vertex AI" not in labels
@@ -1725,7 +1724,7 @@ def test_guardrail_wizard_regional_judge_families_and_llm_role() -> None:
 
 
 def test_guardrail_wizard_omits_action_only_block_message_and_scopes_bedrock_auth_rows() -> None:
-    fields = _guardrail_wizard_fields_for({"@Provider": "bedrock"}, None)
+    fields = _guardrail_wizard_fields_for({"--detection-strategy": "regex_judge", "@Provider": "bedrock"}, None)
     labels = {f.label for f in fields}
     flags = {f.flag for f in fields}
 
@@ -1738,7 +1737,12 @@ def test_guardrail_wizard_omits_action_only_block_message_and_scopes_bedrock_aut
     iam_flags = {
         f.flag
         for f in _guardrail_wizard_fields_for(
-            {"@Provider": "bedrock", "--judge-bedrock-auth-mode": "iam_credentials"}, None
+            {
+                "--detection-strategy": "regex_judge",
+                "@Provider": "bedrock",
+                "--judge-bedrock-auth-mode": "iam_credentials",
+            },
+            None,
         )
     }
     assert "--judge-bedrock-access-key-env" in iam_flags
@@ -1748,7 +1752,14 @@ def test_guardrail_wizard_omits_action_only_block_message_and_scopes_bedrock_aut
 
     profile_flags = {
         f.flag
-        for f in _guardrail_wizard_fields_for({"@Provider": "bedrock", "--judge-bedrock-auth-mode": "profile"}, None)
+        for f in _guardrail_wizard_fields_for(
+            {
+                "--detection-strategy": "regex_judge",
+                "@Provider": "bedrock",
+                "--judge-bedrock-auth-mode": "profile",
+            },
+            None,
+        )
     }
     assert "--judge-bedrock-profile-name" in profile_flags
     assert "--judge-bedrock-secret-key-env" not in profile_flags


### PR DESCRIPTION
## Summary

This PR fixes the multi-connector setup/init guardrail issues found during manual DefenseClaw testing.

- cleans up guardrail status rendering so connector posture is shown in a readable table/block layout without contradictory judge wording
- updates setup/init/quickstart flows to avoid legacy single-connector wording and preserve connector-specific mode/judge/HILT state
- simplifies interactive judge setup so regex scanning is the default and judge is enabled per selected connector without a separate scan-strategy prompt
- adds interactive trusted-path remediation in setup/init paths and keeps scripted flows structured/non-interactive
- fixes init HILT persistence so `init --connector hermes` with approval enabled shows `hilt: on@HIGH` in scoped status
- downgrades refused batch action connectors to saved `observe` mode so status reflects effective enforcement

## Why

The manual test pass found several places where the CLI reported desired intent as if it were effective runtime posture, or used wording from the older primary-connector model. That was especially confusing in multi-connector setup where different connectors can have different modes, judge coverage, trusted-path states, and HILT settings.

## Validation

Ran targeted and related suites during the session, including:

- `uv run pytest cli/tests/test_bootstrap.py`
- `uv run pytest cli/tests/test_cmd_init.py cli/tests/test_cmd_guardrail.py`
- `uv run pytest cli/tests/test_cmd_setup_fu_phase2.py`
- `uv run pytest cli/tests/test_cmd_setup_multi_connector.py cli/tests/test_cmd_guardrail.py cli/tests/test_connector_contracts.py`
- `uv run ruff check cli/defenseclaw/bootstrap.py cli/tests/test_bootstrap.py`
- `uv run ruff check cli/defenseclaw/commands/cmd_setup.py cli/tests/test_cmd_setup_fu_phase2.py`

## Notes

The local worktree still has an unrelated unstaged deletion of `internal/gateway/connector/openclaw_extension/.placeholder`; it is intentionally not included in this PR.