### PR TITLE
Guardrail setup and judge strategy fixes

### DIFF
--- a/cli/defenseclaw/commands/cmd_judge.py
+++ b/cli/defenseclaw/commands/cmd_judge.py
@@ -237,11 +237,11 @@ def _ensure_enabled_hook_judge_strategies(gc) -> bool:
     """Promote saved hook-lane strategies when judge coverage is enabled."""
     changed = False
     base = (getattr(gc, "detection_strategy", "") or "").strip().lower()
-    if base == "regex_only":
+    if not base or base == "regex_only":
         gc.detection_strategy = "regex_judge"
         changed = True
     completion = (getattr(gc, "detection_strategy_completion", "") or "").strip().lower()
-    if completion == "regex_only":
+    if not completion or completion == "regex_only":
         gc.detection_strategy_completion = "regex_judge"
         changed = True
     return changed

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -3761,6 +3761,17 @@ def setup_guardrail(
             gc.connectors[target_connector].block_message = block_message
         elif block_message is not None:
             gc.block_message = block_message
+            block_message_targets = (
+                _guardrail_setup_check_targets(app, gc, None)
+                if getattr(gc, "connectors", None)
+                else []
+            )
+            for connector in block_message_targets:
+                entry = gc.connectors.get(connector)
+                if entry is None:
+                    entry = PerConnectorGuardrailConfig()
+                    gc.connectors[connector] = entry
+                entry.block_message = block_message
         if detection_strategy is not None:
             gc.detection_strategy = detection_strategy
         _apply_guardrail_extra_options(

--- a/cli/tests/test_cmd_judge.py
+++ b/cli/tests/test_cmd_judge.py
@@ -278,6 +278,27 @@ class JudgeAddTests(unittest.TestCase):
         self.assertNotIn("no effect", result.output)
 
     @patch.object(cmd_setup, "_restart_services")
+    def test_add_enable_repairs_empty_completion_strategy_under_all_gate(self, restart):
+        # Legacy configs can have an empty completion strategy even when the
+        # hook gate is already broad. Re-running the explicit judge-enable
+        # command must still persist tool-output judge coverage.
+        app = make_ctx(
+            judge_enabled=True,
+            hook_connectors=["*"],
+            detection_strategy="regex_judge",
+            detection_strategy_completion="",
+        )
+        result = invoke(app, ["add", "hermes", "--enable", "--no-restart"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(app.cfg.guardrail.judge.hook_connectors, ["*"])
+        self.assertEqual(app.cfg.guardrail.detection_strategy, "regex_judge")
+        self.assertEqual(app.cfg.guardrail.detection_strategy_completion, "regex_judge")
+        app.cfg.save.assert_called_once()
+        restart.assert_not_called()
+        self.assertNotIn("nothing to do", result.output)
+        self.assertIn("detection_strategy", result.output)
+
+    @patch.object(cmd_setup, "_restart_services")
     def test_add_without_enable_leaves_judge_disabled(self, restart):
         # Default is preserved: add never flips judge.enabled, and the inert
         # warning still fires so the operator knows the gate is dormant.
@@ -290,8 +311,13 @@ class JudgeAddTests(unittest.TestCase):
     @patch.object(cmd_setup, "_restart_services")
     def test_add_enable_when_already_enabled_is_idempotent(self, restart):
         # --enable on an already-enabled judge is not itself a change: with
-        # the gate also a no-op there is nothing to save or restart.
-        app = make_ctx(judge_enabled=True, hook_connectors=["hermes"])
+        # the gate and strategies also no-op there is nothing to save or restart.
+        app = make_ctx(
+            judge_enabled=True,
+            hook_connectors=["hermes"],
+            detection_strategy="regex_judge",
+            detection_strategy_completion="regex_judge",
+        )
         result = invoke(app, ["add", "hermes", "--enable"])
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertTrue(app.cfg.guardrail.judge.enabled)

--- a/cli/tests/test_cmd_setup_fu_phase2.py
+++ b/cli/tests/test_cmd_setup_fu_phase2.py
@@ -208,6 +208,30 @@ class TestPerConnectorWriteSurface(_BaseSetup):
             self.assertEqual(gc.connectors[connector].mode, "observe")
             self.assertEqual(gc.effective_mode(connector), "observe")
 
+    def test_setup_guardrail_unscoped_block_message_updates_all_active_overrides(self):
+        self._seed_map("geminicli", "hermes")
+        gc = self.app.cfg.guardrail
+        gc.block_message = "Global block"
+        gc.connectors["geminicli"].block_message = "Gemini scoped block"
+
+        with _stub_side_effects():
+            res = _invoke(
+                [
+                    "guardrail",
+                    "--yes",
+                    "--no-restart",
+                    "--no-verify",
+                    "--block-message",
+                    "Global block 2",
+                ],
+                self.app,
+            )
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertEqual(gc.block_message, "Global block 2")
+        for connector in ("geminicli", "hermes"):
+            self.assertEqual(gc.connectors[connector].block_message, "Global block 2")
+            self.assertEqual(gc.effective_block_message(connector), "Global block 2")
+
     def test_setup_guardrail_unscoped_without_mode_preserves_active_overrides(self):
         self._seed_map("codex", "hermes")
         gc = self.app.cfg.guardrail


### PR DESCRIPTION
## Summary

- Fan out unscoped `setup guardrail --block-message ...` writes to active per-connector overrides in multi-connector installs, matching the operator expectation that no `--connector` applies to every active connector.
- Harden `guardrail judge add <connector> --enable` so empty/legacy hook-lane strategies are promoted to `regex_judge`, including `detection_strategy_completion`, when judge coverage is enabled.
- Add focused regressions for the Gemini scoped block-message override case and the legacy empty completion-strategy judge repair case.

## Root Cause

`setup guardrail --block-message` updated only `guardrail.block_message`, so existing `guardrail.connectors.<name>.block_message` overrides still won effective behavior. Separately, judge enablement only promoted saved strategies when they were exactly `regex_only`; empty/null legacy values were left unpersisted.

## Validation

- `uv run --frozen pytest cli/tests/test_cmd_setup_fu_phase2.py cli/tests/test_cmd_judge.py`
- `uv run --frozen pytest cli/tests/test_cmd_setup_fu_phase2.py cli/tests/test_cmd_judge.py cli/tests/test_cmd_guardrail.py`
- `uv run --frozen ruff check cli/defenseclaw/commands/cmd_setup.py cli/defenseclaw/commands/cmd_judge.py cli/tests/test_cmd_setup_fu_phase2.py cli/tests/test_cmd_judge.py`
- `git diff --check`
- Scratch CLI repro for `setup guardrail --block-message` fan-out
- Scratch CLI repro for legacy empty `detection_strategy_completion` repair