### PR TITLE
Guardrail setup and judge strategy fixes

### DIFF
--- a/cli/defenseclaw/commands/cmd_init.py
+++ b/cli/defenseclaw/commands/cmd_init.py
@@ -1469,7 +1469,12 @@ def _prompt_first_run(
             hilt_min_severity=hilt_min_severity,
         )
 
-    judge_hook_connectors = _prompt_first_run_judge_connectors(connectors, default_all=with_judge)
+    judge_candidates = [c for c in connectors if c in action_set]
+    if judge_candidates:
+        judge_hook_connectors = _prompt_first_run_judge_connectors(judge_candidates, default_all=with_judge)
+    else:
+        judge_hook_connectors = []
+        ux.subhead("LLM judge: skipped because no selected connector is in action mode.")
     with_judge = bool(judge_hook_connectors)
 
     connector_settings: list[dict] = []
@@ -1498,16 +1503,16 @@ def _prompt_first_run(
 
 
 def _prompt_first_run_judge_connectors(connectors: list[str], *, default_all: bool) -> list[str]:
-    """Ask which first-run connectors should get the optional LLM judge."""
+    """Ask which first-run action connectors should get the optional LLM judge."""
     ux.section("Optional LLM judge")
     ux.subhead("Rule/regex scanning is already enabled for every active connector selected above.")
-    ux.subhead("Select active connectors that should add LLM judge review on top.")
+    ux.subhead("Only action-mode connectors can add LLM judge review in this setup flow.")
     ux.subhead("Leave every box clear for rules-only scanning with no LLM judge calls.")
     ux.subhead("Configure provider/model/key later with `defenseclaw setup guardrail` or `defenseclaw setup llm`.")
     return _prompt_checkbox_selection(
         connectors,
         default_selected=(connectors if default_all else []),
-        title="Select active connector(s) for LLM judge.",
+        title="Select action connector(s) for LLM judge.",
         empty_ok=True,
     )
 

--- a/cli/defenseclaw/commands/cmd_judge.py
+++ b/cli/defenseclaw/commands/cmd_judge.py
@@ -237,11 +237,11 @@ def _ensure_enabled_hook_judge_strategies(gc) -> bool:
     """Promote saved hook-lane strategies when judge coverage is enabled."""
     changed = False
     base = (getattr(gc, "detection_strategy", "") or "").strip().lower()
-    if base == "regex_only":
+    if not base or base == "regex_only":
         gc.detection_strategy = "regex_judge"
         changed = True
     completion = (getattr(gc, "detection_strategy_completion", "") or "").strip().lower()
-    if completion == "regex_only":
+    if not completion or completion == "regex_only":
         gc.detection_strategy_completion = "regex_judge"
         changed = True
     return changed

--- a/cli/defenseclaw/commands/cmd_plugin.py
+++ b/cli/defenseclaw/commands/cmd_plugin.py
@@ -1144,7 +1144,7 @@ def list_plugins(app: AppContext, as_json: bool, connector_flag: str) -> None:
                     "connector": c,
                     "plugins": _plugin_list_json_items(
                         _collect_plugins_for_connector(app, c, scan_map),
-                        scan_map,
+                        _build_plugin_scan_map_for_connector(app, c),
                         _build_plugin_actions_map(app.store, c),
                         connector=c,
                     ),
@@ -1156,7 +1156,7 @@ def list_plugins(app: AppContext, as_json: bool, connector_flag: str) -> None:
             plugins = _collect_plugins_for_connector(app, connectors[0], scan_map)
             _print_plugin_list_json(
                 plugins,
-                scan_map,
+                _build_plugin_scan_map_for_connector(app, connectors[0]),
                 _build_plugin_actions_map(app.store, connectors[0]),
                 connector=connectors[0],
             )
@@ -1172,7 +1172,8 @@ def list_plugins(app: AppContext, as_json: bool, connector_flag: str) -> None:
                 click.echo(f"Plugins (connector={connector}): no plugins found")
             continue
         actions_map = _build_plugin_actions_map(app.store, connector)
-        _print_plugin_list_table(plugins, scan_map, actions_map, connector)
+        connector_scan_map = _build_plugin_scan_map_for_connector(app, connector)
+        _print_plugin_list_table(plugins, connector_scan_map, actions_map, connector)
         shown_any = True
 
     if not shown_any:
@@ -3031,6 +3032,31 @@ def _build_plugin_scan_map(store) -> dict:
     for ls in latest:
         name = os.path.basename(ls["target"])
         scan_map[name] = _plugin_scan_payload_from_latest(ls)
+    return scan_map
+
+
+def _build_plugin_scan_map_for_connector(app: AppContext, connector: str) -> dict:
+    """Build plugin-name -> latest scan entry scoped to one connector's roots."""
+    scan_map: dict[str, dict[str, Any]] = {}
+    if app.store is None:
+        return scan_map
+    try:
+        latest = app.store.latest_scans_by_scanner("plugin-scanner")
+    except Exception as exc:
+        click.echo(f"warning: failed to load plugin scan data: {exc}", err=True)
+        return scan_map
+    matches: dict[str, tuple[Any, dict[str, Any]]] = {}
+    for ls in latest:
+        name = os.path.basename(ls["target"])
+        payload = _plugin_scan_payload_from_latest(ls)
+        if connector and not _scan_entry_matches_plugin_connector(app, payload, connector):
+            continue
+        timestamp = ls.get("timestamp")
+        current = matches.get(name)
+        if current is None or timestamp > current[0]:
+            matches[name] = (timestamp, payload)
+    for name, (_timestamp, payload) in matches.items():
+        scan_map[name] = payload
     return scan_map
 
 

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -23,10 +23,12 @@ from __future__ import annotations
 
 import json as _json
 import os
+import secrets
 import shutil
 import socket
 import subprocess
 import sys
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -69,7 +71,7 @@ from defenseclaw.connector_contracts import (
 )
 from defenseclaw.context import AppContext, pass_ctx
 from defenseclaw.inventory import agent_discovery
-from defenseclaw.paths import bundled_extensions_dir, splunk_bridge_bin
+from defenseclaw.paths import bundled_extensions_dir, bundled_splunk_bridge_dir, splunk_bridge_bin
 from defenseclaw.safety import reject_symlink, sanitize_dotenv_value
 
 # Key used to stash the pre-invocation config.yaml mtime in the Click
@@ -8393,6 +8395,8 @@ _SPLUNK_LOCAL_HEC_DEFAULTS = {
     "sourcetype": "defenseclaw:json",
 }
 
+_SPLUNK_BRIDGE_ENV_REL = os.path.join("splunk-bridge", "env", ".env")
+
 
 @click.group("splunk", invoke_without_command=True)
 @click.pass_context
@@ -9259,7 +9263,11 @@ def _resolve_bridge_bin(data_dir: str) -> str | None:
     return splunk_bridge_bin(data_dir)
 
 
-def _refresh_and_maybe_restart_splunk_bridge(data_dir: str) -> RefreshResult:
+def _refresh_and_maybe_restart_splunk_bridge(
+    data_dir: str,
+    *,
+    env_file: str | None = None,
+) -> RefreshResult:
     """Refresh the seeded Splunk bridge, stopping any running stack first.
 
     Sequence (all best-effort — refresh failures don't abort the parent
@@ -9287,8 +9295,11 @@ def _refresh_and_maybe_restart_splunk_bridge(data_dir: str) -> RefreshResult:
         bridge = _resolve_bridge_bin(data_dir)
         if bridge:
             try:
+                down_args = [bridge, "down"]
+                if env_file:
+                    down_args.extend(["--env-file", env_file])
                 subprocess.run(
-                    [bridge, "down"],
+                    down_args,
                     capture_output=True,
                     text=True,
                     timeout=120,
@@ -9345,8 +9356,9 @@ def _bootstrap_bridge(
     volumes survive ``down``, so user data is preserved) so the new
     bundle is what gets brought back up.
     """
+    env_file = _ensure_private_splunk_bridge_env(data_dir)
     if refresh_bundle:
-        _refresh_and_maybe_restart_splunk_bridge(data_dir)
+        _refresh_and_maybe_restart_splunk_bridge(data_dir, env_file=env_file)
 
     bridge = _resolve_bridge_bin(data_dir)
     if not bridge:
@@ -9376,7 +9388,7 @@ def _bootstrap_bridge(
         if env is not None:
             run_kwargs["env"] = env
         result = subprocess.run(
-            [bridge, "up", "--output", "json"],
+            [bridge, "up", "--env-file", env_file, "--output", "json"],
             **run_kwargs,
         )
         if result.returncode != 0:
@@ -9419,6 +9431,72 @@ def _bootstrap_bridge(
         if result is not None:
             _echo_bridge_output_tail(result)
         return None
+
+
+def _ensure_private_splunk_bridge_env(data_dir: str) -> str:
+    """Create the private bridge env file used by the local Splunk stack.
+
+    The bridge intentionally refuses to fall back to the checked-in
+    ``.env.example`` because it contains public placeholders. The CLI
+    setup path is responsible for creating an operator-owned copy with
+    fresh local credentials, then passing it explicitly to the bridge.
+    Existing files are preserved.
+    """
+    env_file = os.path.join(data_dir, _SPLUNK_BRIDGE_ENV_REL)
+    reject_symlink(env_file, what="Splunk bridge env file")
+    if os.path.isfile(env_file):
+        _chmod_private_best_effort(env_file)
+        return env_file
+
+    example = _load_splunk_bridge_example_env(data_dir)
+    if not example.get("SPLUNK_IMAGE"):
+        raise click.ClickException("Splunk bridge env template is missing SPLUNK_IMAGE")
+
+    env_dir = os.path.dirname(env_file)
+    os.makedirs(env_dir, mode=0o700, exist_ok=True)
+    try:
+        os.chmod(env_dir, 0o700)
+    except OSError:
+        pass
+
+    hec_token = str(uuid.uuid4())
+    entries = dict(example)
+    entries.update({
+        "SPLUNK_START_ARGS": "--accept-license",
+        "SPLUNK_LICENSE_URI": "Free",
+        "SPLUNK_GENERAL_TERMS": "--accept-sgt-current-at-splunk-com",
+        "SPLUNK_PASSWORD": f"DefenseClawLocal-{secrets.token_hex(16)}!",
+        "SPLUNK_HEC_TOKEN": hec_token,
+        "DEFENSECLAW_HEC_URL": entries.get(
+            "DEFENSECLAW_HEC_URL",
+            "https://127.0.0.1:8088/services/collector/event",
+        ),
+        "DEFENSECLAW_HEC_TOKEN": hec_token,
+        "DEFENSECLAW_INDEX": entries.get("DEFENSECLAW_INDEX", "defenseclaw_local"),
+        "DEFENSECLAW_SOURCETYPE": entries.get("DEFENSECLAW_SOURCETYPE", "defenseclaw:json"),
+        "DEFENSECLAW_SOURCE": entries.get("DEFENSECLAW_SOURCE", "defenseclaw"),
+        "DEFENSECLAW_INTEGRATION_ENABLED": "true",
+    })
+    _write_dotenv(env_file, entries)
+    return env_file
+
+
+def _load_splunk_bridge_example_env(data_dir: str) -> dict[str, str]:
+    candidates = (
+        os.path.join(data_dir, "splunk-bridge", "env", ".env.example"),
+        str(bundled_splunk_bridge_dir() / "env" / ".env.example"),
+    )
+    for path in candidates:
+        if os.path.isfile(path):
+            return _load_dotenv(path)
+    return {}
+
+
+def _chmod_private_best_effort(path: str) -> None:
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
 
 
 def _echo_bridge_output_tail(

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -3703,7 +3703,7 @@ def setup_guardrail(
         # B2: snapshot the judge gate state BEFORE the judge config below can
         # flip ``gc.judge.enabled`` on, so the hook-gate default only fires when
         # this run actually turns the judge on (not on every re-run).
-        was_judge_enabled = bool(gc.judge.enabled)
+        judge_enabled_by_this_run = False
         # Connector resolution order in non-interactive mode:
         #   1. explicit --connector / --agent flag (operator intent always wins)
         #   2. existing gc.connector if already set to a non-default value
@@ -3797,6 +3797,7 @@ def setup_guardrail(
             gc.judge.model = judge_model
             gc.judge.llm.model = judge_model
             gc.judge.enabled = True
+            judge_enabled_by_this_run = True
         if judge_api_base is not None:
             gc.judge.api_base = judge_api_base
             gc.judge.llm.base_url = judge_api_base
@@ -3875,6 +3876,7 @@ def setup_guardrail(
         if detection_strategy is not None:
             if _strategy_uses_judge(detection_strategy):
                 gc.judge.enabled = True
+                judge_enabled_by_this_run = True
             elif detection_strategy == "regex_only":
                 gc.judge.enabled = False
         if judge_hook_connectors is not None:
@@ -3885,6 +3887,7 @@ def setup_guardrail(
                 gc.detection_strategy_completion = "regex_only"
             else:
                 gc.judge.enabled = True
+                judge_enabled_by_this_run = True
                 if not gc.detection_strategy or gc.detection_strategy == "regex_only":
                     gc.detection_strategy = "regex_judge"
         gc.enabled = True
@@ -3914,7 +3917,8 @@ def setup_guardrail(
             judge_hook_connectors,
             judge_just_enabled=(
                 gc.judge.enabled
-                and (not was_judge_enabled or not list(gc.judge.hook_connectors or []))
+                and judge_enabled_by_this_run
+                and not list(gc.judge.hook_connectors or [])
             ),
             current=list(gc.judge.hook_connectors or []),
         )

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -5090,7 +5090,12 @@ def _setup_observability_alias(
     # didn't already decide via --enable-judge/--no-enable-judge. On yes,
     # _apply_hook_connector_setup flips the judge on for this connector and
     # bumps the strategy off regex_only.
-    if interactive and enable_judge is None and _prompt_enable_judge(connector, gc):
+    if (
+        interactive
+        and normalized_mode == "action"
+        and enable_judge is None
+        and _prompt_enable_judge(connector, gc)
+    ):
         enable_judge = True
 
     trusted_prompt_cache: dict[str, bool] | None = {} if interactive else None
@@ -5137,7 +5142,10 @@ def _setup_observability_alias(
     if not ok:
         raise click.ClickException(f"failed to configure {connector} (mode={normalized_mode}) — see errors above")
 
-    if interactive and enable_judge:
+    if interactive:
+        _prune_judge_gate_to_action_scope(app.cfg.guardrail, [connector])
+
+    if interactive and enable_judge and normalized_mode == "action":
         configure_model = click.confirm(
             "  Configure LLM judge provider/model/API settings now?",
             default=_judge_llm_needs_configuration(app),
@@ -5415,17 +5423,58 @@ def _merge_batch_judge_selection(
     return new_gate
 
 
+def _prune_judge_gate_to_action_scope(gc, connectors: list[str]) -> list[str]:
+    """Remove observe-mode connectors in this interactive setup scope from judge."""
+    targets = {
+        normalize_connector(c)
+        for c in connectors
+        if c and normalize_connector(c) in _HOOK_ENFORCED_CONNECTORS
+    }
+    if not targets:
+        return list(getattr(gc.judge, "hook_connectors", []) or [])
+
+    action_targets = {
+        c
+        for c in targets
+        if (gc.effective_mode(c) if hasattr(gc, "effective_mode") else getattr(gc, "mode", "observe")) == "action"
+    }
+    current_gate = [
+        normalize_connector(str(c))
+        for c in (getattr(gc.judge, "hook_connectors", []) or [])
+        if str(c).strip()
+    ]
+    if not current_gate:
+        return []
+
+    if current_gate == ["*"]:
+        configured_hook_connectors = {
+            normalize_connector(c)
+            for c in _configured_connector_set(gc)
+            if normalize_connector(c) in _HOOK_ENFORCED_CONNECTORS
+        }
+        new_gate = sorted((configured_hook_connectors - targets) | action_targets)
+    else:
+        new_gate = sorted(c for c in current_gate if c not in targets or c in action_targets)
+
+    gc.judge.hook_connectors = new_gate
+    if not new_gate:
+        gc.judge.enabled = False
+        gc.detection_strategy = "regex_only"
+        gc.detection_strategy_completion = "regex_only"
+    return new_gate
+
+
 def _prompt_batch_judge_connectors(connectors: list[str], gc) -> set[str]:
-    """Ask once which selected connectors should add LLM judge review."""
+    """Ask once which selected action connectors should add LLM judge review."""
     options, display_by_connector, connector_by_display = _connector_display_options(connectors)
     ux.section("Optional LLM judge")
     ux.subhead("Rule/regex scanning is enabled by default for every active connector selected above.")
-    ux.subhead("Checked active connectors add LLM judge review on top.")
+    ux.subhead("Only action-mode connectors can add LLM judge review in this setup flow.")
     ux.subhead("These LLM settings are shared by all connectors with judge enabled.")
     selected = _prompt_checkbox_selection(
         options,
         default_selected=_default_batch_judge_labels(connectors, gc, display_by_connector),
-        title="Select active connector(s) that should use the LLM judge.",
+        title="Select action connector(s) that should use the LLM judge.",
         empty_ok=True,
     )
     selected_connectors = {connector_by_display[label] for label in selected}
@@ -5443,12 +5492,12 @@ def _prompt_guardrail_judge_enablement(
     if judge_targets:
         options, display_by_connector, connector_by_display = _connector_display_options(judge_targets)
         ux.subhead("Rule/regex scanning is already enabled for every active connector.")
-        ux.subhead("Checked active connectors add LLM judge review on top.")
+        ux.subhead("Only action-mode connectors can add LLM judge review in this setup flow.")
         ux.subhead("These LLM settings are shared by all connectors with judge enabled.")
         selected = _prompt_checkbox_selection(
             options,
             default_selected=_default_batch_judge_labels(judge_targets, gc, display_by_connector),
-            title="Select active connector(s) for LLM judge.",
+            title="Select action connector(s) for LLM judge.",
             empty_ok=True,
         )
         selected_connectors = {connector_by_display[label] for label in selected}
@@ -5683,7 +5732,15 @@ def _dispatch_bare_setup(
         gc = app.cfg.guardrail
         connector_modes = _prompt_batch_connector_modes(targets, gc, default_mode=mode)
         trusted_prompt_cache = _prompt_batch_trusted_prefixes(app, connector_modes)
-        judge_connectors = _prompt_batch_judge_connectors(targets, gc)
+        judge_targets = [
+            c for c in targets
+            if (connector_modes.get(c, "observe") or "").strip().lower() == "action"
+        ]
+        if judge_targets:
+            judge_connectors = _prompt_batch_judge_connectors(judge_targets, gc)
+        else:
+            judge_connectors = set()
+            click.echo("  " + ux.dim("LLM judge: skipped because no selected connector is in action mode."))
         if judge_connectors:
             configure_model = click.confirm(
                 "  Configure LLM judge provider/model/API settings now?",
@@ -5704,6 +5761,8 @@ def _dispatch_bare_setup(
         allow_trusted_path_prompt=prompt_batch,
         trusted_prompt_cache=trusted_prompt_cache,
     )
+    if prompt_batch:
+        _prune_judge_gate_to_action_scope(app.cfg.guardrail, targets)
 
 
 def _hook_guardrail_options(fn):
@@ -7683,13 +7742,9 @@ def _interactive_guardrail_setup(
     # --- LLM Judge section ---
     #
     # The judge is a gateway-side verification layer that runs on
-    # any inspectable payload — proxy responses for the proxy data
-    # path, AND hook events (UserPromptSubmit, PreToolUse) for the
-    # hook-enforced connectors. So we offer it for every connector
-    # type. The hook surface stamps the verdict on the deny verdict
-    # exactly the same way the proxy surface stamps it on the
-    # response body, which is why the operator's judge config is
-    # connector-agnostic.
+    # inspectable payloads. Proxy connectors can still opt in here directly;
+    # hook connectors only see judge choices for connectors currently in action
+    # mode, so the wizard does not imply observe-mode judge enforcement.
     ux.section("Optional LLM judge")
     ux.subhead("Uses an LLM to verify detections and catch novel attacks.")
     ux.subhead("Works with any OpenAI-compatible API (Bifrost, OpenAI, Anthropic, etc.)")
@@ -7701,7 +7756,7 @@ def _interactive_guardrail_setup(
     click.echo("  " + ux.dim("Tool calls additionally run the tool_injection judge."))
     click.echo()
 
-    judge_targets = [
+    hook_judge_scope = [
         c for c in (
             mode_targets
             if is_multi
@@ -7709,9 +7764,17 @@ def _interactive_guardrail_setup(
         )
         if c in _HOOK_ENFORCED_CONNECTORS
     ]
+    judge_targets = [
+        c for c in hook_judge_scope
+        if (gc.effective_mode(c) if hasattr(gc, "effective_mode") else gc.mode) == "action"
+    ]
 
-    judge_kwargs = {"preserve_outside_targets": True} if agent_name and is_multi else {}
-    _prompt_guardrail_judge_enablement(gc, judge_targets, **judge_kwargs)
+    if hook_judge_scope and not judge_targets:
+        _prune_judge_gate_to_action_scope(gc, hook_judge_scope)
+        click.echo("  " + ux.dim("LLM judge: skipped because no selected connector is in action mode."))
+    else:
+        judge_kwargs = {"preserve_outside_targets": True} if agent_name and is_multi else {}
+        _prompt_guardrail_judge_enablement(gc, judge_targets, **judge_kwargs)
     if gc.judge.enabled:
         if not getattr(gc, "detection_strategy_completion", None):
             gc.detection_strategy_completion = "regex_only"

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -7775,6 +7775,10 @@ def _interactive_guardrail_setup(
     else:
         judge_kwargs = {"preserve_outside_targets": True} if agent_name and is_multi else {}
         _prompt_guardrail_judge_enablement(gc, judge_targets, **judge_kwargs)
+    if not getattr(gc, "detection_strategy", None):
+        gc.detection_strategy = "regex_only"
+    if not getattr(gc, "detection_strategy_completion", None):
+        gc.detection_strategy_completion = "regex_only"
     if gc.judge.enabled:
         if not getattr(gc, "detection_strategy_completion", None):
             gc.detection_strategy_completion = "regex_only"

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -3761,6 +3761,17 @@ def setup_guardrail(
             gc.connectors[target_connector].block_message = block_message
         elif block_message is not None:
             gc.block_message = block_message
+            block_message_targets = (
+                _guardrail_setup_check_targets(app, gc, None)
+                if getattr(gc, "connectors", None)
+                else []
+            )
+            for connector in block_message_targets:
+                entry = gc.connectors.get(connector)
+                if entry is None:
+                    entry = PerConnectorGuardrailConfig()
+                    gc.connectors[connector] = entry
+                entry.block_message = block_message
         if detection_strategy is not None:
             gc.detection_strategy = detection_strategy
         _apply_guardrail_extra_options(

--- a/cli/defenseclaw/commands/cmd_skill.py
+++ b/cli/defenseclaw/commands/cmd_skill.py
@@ -536,6 +536,11 @@ def _skill_info_card(
     suppress_global_action_only: bool = False,
 ) -> dict[str, Any] | None:
     """Build the rendered ``skill info`` payload for one connector scope."""
+    if (
+        isinstance(info_map, dict)
+        and "not found" in str(info_map.get("error") or "").lower()
+    ):
+        info_map = None
     scan_map = _build_scan_map(app.store)
     scan_entry: dict[str, Any] | None = None
     if (

--- a/cli/defenseclaw/commands/cmd_skill.py
+++ b/cli/defenseclaw/commands/cmd_skill.py
@@ -1171,6 +1171,46 @@ def scan(
     scan_dir = scan_path
     scan_connector = ""
     if not scan_dir:
+        if not connector_flag:
+            # Bare named scans must fan out over every configured connector copy
+            # before the active connector's info path can short-circuit.
+            matches = _skill_match_dir_scopes(app, target)
+            if len(matches) > 1:
+                json_rows: list[dict[str, Any]] = []
+                if remote:
+                    for match_connector, match_dir in matches:
+                        if not as_json:
+                            click.echo(ux._style(f"\n── connector: {match_connector} ──", fg="cyan"))
+                        _scan_via_sidecar(
+                            app,
+                            target=match_dir,
+                            name=os.path.basename(match_dir),
+                            as_json=as_json,
+                            connector=match_connector,
+                            json_sink=json_rows if as_json else None,
+                        )
+                    if as_json:
+                        click.echo(json.dumps(json_rows, indent=2, default=str))
+                    return
+                for match_connector, match_dir in matches:
+                    if not as_json:
+                        click.echo(ux._style(f"\n── connector: {match_connector} ──", fg="cyan"))
+                    _scan_one_local_skill(
+                        app,
+                        scanner,
+                        scan_dir=match_dir,
+                        as_json=as_json,
+                        action=action,
+                        connector=match_connector,
+                        json_sink=json_rows if as_json else None,
+                    )
+                if as_json:
+                    click.echo(json.dumps(json_rows, indent=2, default=str))
+                return
+            if matches:
+                scan_connector, scan_dir = matches[0]
+
+    if not scan_dir:
         info = _get_openclaw_skill_info(target, app, connector=connector_flag or None)
         if info and _skill_info_path(info):
             scan_dir = _skill_info_path(info) or ""

--- a/cli/defenseclaw/db.py
+++ b/cli/defenseclaw/db.py
@@ -111,8 +111,10 @@ CREATE TABLE IF NOT EXISTS target_snapshots (
 
 CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_events(timestamp);
 CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_events(action);
+CREATE INDEX IF NOT EXISTS idx_audit_action_timestamp ON audit_events(action, timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_audit_severity_timestamp ON audit_events(severity, timestamp);
 CREATE INDEX IF NOT EXISTS idx_scan_scanner ON scan_results(scanner);
+CREATE INDEX IF NOT EXISTS idx_scan_timestamp ON scan_results(timestamp);
 CREATE INDEX IF NOT EXISTS idx_finding_severity ON findings(severity);
 CREATE INDEX IF NOT EXISTS idx_finding_scan ON findings(scan_id);
 -- The actions uniqueness index is connector-aware (target_type, target_name,
@@ -257,6 +259,7 @@ class Store:
     def init(self) -> None:
         self.db.executescript(SCHEMA)
         self._ensure_run_id_columns()
+        self._ensure_audit_connector_columns()
         # Add the per-connector column + swap the actions uniqueness index to
         # (target_type, target_name, connector) BEFORE migrating the legacy
         # block/allow lists, so the INSERT OR REPLACE block-last-wins ordering
@@ -326,6 +329,28 @@ class Store:
             self.db.execute("ALTER TABLE audit_events ADD COLUMN structured_json TEXT")
         self.db.execute("CREATE INDEX IF NOT EXISTS idx_audit_run_id ON audit_events(run_id)")
         self.db.execute("CREATE INDEX IF NOT EXISTS idx_scan_run_id ON scan_results(run_id)")
+        self.db.commit()
+
+    def _ensure_audit_connector_columns(self) -> None:
+        """Mirror Go's additive audit_events connector columns and indexes."""
+
+        columns = {
+            row[1]
+            for row in self.db.execute("PRAGMA table_info(audit_events)").fetchall()
+        }
+        for column, ddl in (
+            ("connector", "ALTER TABLE audit_events ADD COLUMN connector TEXT"),
+            ("step_idx", "ALTER TABLE audit_events ADD COLUMN step_idx INTEGER"),
+            ("enforced", "ALTER TABLE audit_events ADD COLUMN enforced INTEGER"),
+            ("rule_pack_dir", "ALTER TABLE audit_events ADD COLUMN rule_pack_dir TEXT"),
+        ):
+            if column not in columns:
+                self.db.execute(ddl)
+        self.db.execute("CREATE INDEX IF NOT EXISTS idx_audit_connector ON audit_events(connector)")
+        self.db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_audit_action_connector_timestamp "
+            "ON audit_events(action, connector, timestamp DESC)"
+        )
         self.db.commit()
 
     def _ensure_connector_column(self) -> None:
@@ -447,20 +472,22 @@ class Store:
         if not event.run_id:
             event.run_id = _current_run_id()
         structured_json = json.dumps(event.structured, separators=(",", ":")) if event.structured else None
+        connector = _event_connector_value(event)
         self.db.execute(
             """INSERT INTO audit_events (
                 id, timestamp, action, target, actor, details,
-                structured_json, severity, run_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                structured_json, severity, run_id, connector
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (event.id, event.timestamp.isoformat(), event.action,
              event.target or None, event.actor, event.details or None,
-             structured_json, event.severity or None, event.run_id or None),
+             structured_json, event.severity or None, event.run_id or None,
+             connector or None),
         )
         self.db.commit()
 
     def list_events(self, limit: int = 100) -> list[Event]:
         cur = self.db.execute(
-            """SELECT id, timestamp, action, target, actor, details, severity, run_id, structured_json
+            """SELECT id, timestamp, action, target, actor, details, severity, run_id, structured_json, connector
                FROM audit_events ORDER BY timestamp DESC, rowid DESC LIMIT ?""",
             (max(limit, 1),),
         )
@@ -472,7 +499,7 @@ class Store:
         cur = self.db.execute(
             """SELECT id, timestamp, action, target, actor,
                       substr(COALESCE(details, ''), 1, ?) AS details,
-                      severity, run_id
+                      severity, run_id, NULL AS structured_json, connector
                FROM audit_events ORDER BY timestamp DESC, rowid DESC LIMIT ?""",
             (_SUMMARY_DETAILS_BYTES, max(limit, 1)),
         )
@@ -484,7 +511,7 @@ class Store:
         cur = self.db.execute(
             """SELECT id, timestamp, action, target, actor,
                       substr(COALESCE(details, ''), 1, ?) AS details,
-                      severity, run_id
+                      severity, run_id, NULL AS structured_json, connector
                FROM audit_events
                WHERE (
                    severity IN ('CRITICAL','HIGH','ERROR')
@@ -507,7 +534,7 @@ class Store:
         cur = self.db.execute(
             """SELECT id, timestamp, action, target, actor,
                       substr(COALESCE(details, ''), 1, ?) AS details,
-                      severity, run_id
+                      severity, run_id, NULL AS structured_json, connector
                FROM audit_events
                WHERE action = 'connector-hook'
                ORDER BY timestamp DESC, rowid DESC LIMIT ?""",
@@ -525,15 +552,9 @@ class Store:
         grouped aggregate instead of loading every hook row into the TUI.
         """
 
-        columns = {
-            row[1]
-            for row in self.db.execute("PRAGMA table_info(audit_events)").fetchall()
-        }
-        if "connector" not in columns:
-            return {}
         details_expr = "' ' || COALESCE(details, '') || ' '"
         cur = self.db.execute(
-            f"""SELECT LOWER(COALESCE(connector, '')) AS connector_name,
+            f"""SELECT connector AS connector_name,
                        COUNT(*) AS calls,
                        SUM(CASE
                              WHEN {details_expr} LIKE '% action=block %'
@@ -548,20 +569,20 @@ class Store:
                        MAX(timestamp) AS newest
                 FROM audit_events
                 WHERE action = 'connector-hook'
-                  AND COALESCE(connector, '') <> ''
-                GROUP BY LOWER(connector)"""
+                  AND connector <> ''
+                GROUP BY connector"""
         )
         stats: dict[str, dict[str, Any]] = {}
         for connector, calls, blocks, alerts, newest in cur.fetchall():
             key = str(connector or "").strip().lower()
             if not key:
                 continue
-            stats[key] = {
-                "calls": int(calls or 0),
-                "blocks": int(blocks or 0),
-                "alerts": int(alerts or 0),
-                "newest": newest or "",
-            }
+            entry = stats.setdefault(key, {"calls": 0, "blocks": 0, "alerts": 0, "newest": ""})
+            entry["calls"] = int(entry["calls"]) + int(calls or 0)
+            entry["blocks"] = int(entry["blocks"]) + int(blocks or 0)
+            entry["alerts"] = int(entry["alerts"]) + int(alerts or 0)
+            if newest and str(newest) > str(entry["newest"]):
+                entry["newest"] = newest
         return stats
 
     def count_scan_results_since(self, since: datetime | None) -> int:
@@ -581,7 +602,7 @@ class Store:
 
     def list_alerts(self, limit: int = 100) -> list[Event]:
         cur = self.db.execute(
-            """SELECT id, timestamp, action, target, actor, details, severity, run_id, structured_json
+            """SELECT id, timestamp, action, target, actor, details, severity, run_id, structured_json, connector
                FROM audit_events
                WHERE severity IN ('CRITICAL','HIGH','MEDIUM','LOW','ERROR','INFO')
                  AND action NOT LIKE 'dismiss%'
@@ -596,7 +617,7 @@ class Store:
         cur = self.db.execute(
             """SELECT id, timestamp, action, target, actor,
                       substr(COALESCE(details, ''), 1, ?) AS details,
-                      severity, run_id
+                      severity, run_id, NULL AS structured_json, connector
                FROM audit_events
                WHERE severity IN ('CRITICAL','HIGH','MEDIUM','LOW','ERROR','INFO')
                  AND action NOT LIKE 'dismiss%'
@@ -611,7 +632,7 @@ class Store:
         cur = self.db.execute(
             """SELECT id, timestamp, action, target, actor,
                       substr(COALESCE(details, ''), 1, ?) AS details,
-                      severity, run_id
+                      severity, run_id, NULL AS structured_json, connector
                FROM audit_events
                WHERE (
                    severity IN ('CRITICAL','HIGH','ERROR')
@@ -631,7 +652,7 @@ class Store:
 
     def get_event(self, event_id: str) -> Event | None:
         cur = self.db.execute(
-            """SELECT id, timestamp, action, target, actor, details, severity, run_id, structured_json
+            """SELECT id, timestamp, action, target, actor, details, severity, run_id, structured_json, connector
                FROM audit_events WHERE id = ?""",
             (event_id,),
         )
@@ -1006,6 +1027,7 @@ class Store:
             severity=row[6] or "",
             run_id=row[7] or "",
             structured=structured,
+            connector=(row[9] or "") if len(row) > 9 else "",
         )
 
     def get_target_snapshot(
@@ -1079,6 +1101,40 @@ class Store:
             updated_at=_parse_ts(row[6]),
             connector=(row[7] or "") if len(row) > 7 else "",
         )
+
+
+def _event_connector_value(event: Event) -> str:
+    connector = (event.connector or "").strip().lower()
+    if connector:
+        return connector
+    raw = event.structured.get("connector") if isinstance(event.structured, dict) else ""
+    connector = str(raw or "").strip().lower()
+    if connector:
+        return connector
+    return _details_connector(event.details)
+
+
+def _details_connector(details: str) -> str:
+    marker = "connector="
+    text = (details or "").strip()
+    if not text:
+        return ""
+    start = text.find(marker)
+    if start < 0:
+        return ""
+    value_start = start + len(marker)
+    if value_start >= len(text):
+        return ""
+    if text[value_start] == '"':
+        value_start += 1
+        value_end = text.find('"', value_start)
+        if value_end < 0:
+            value_end = len(text)
+    else:
+        value_end = text.find(" ", value_start)
+        if value_end < 0:
+            value_end = len(text)
+    return text[value_start:value_end].strip().lower()
 
 
 def _parse_ts(val: Any) -> datetime:

--- a/cli/defenseclaw/db.py
+++ b/cli/defenseclaw/db.py
@@ -486,11 +486,98 @@ class Store:
                       substr(COALESCE(details, ''), 1, ?) AS details,
                       severity, run_id
                FROM audit_events
-               WHERE severity IN ('CRITICAL','HIGH','ERROR')
+               WHERE (
+                   severity IN ('CRITICAL','HIGH','ERROR')
+                   OR (
+                       action = 'connector-hook'
+                       AND (
+                           details LIKE '%severity=CRITICAL%'
+                           OR details LIKE '%severity=HIGH%'
+                       )
+                   )
+               )
                ORDER BY timestamp DESC, rowid DESC LIMIT ?""",
             (_SUMMARY_DETAILS_BYTES, max(limit, 1)),
         )
         return [self._row_to_event(r) for r in cur.fetchall()]
+
+    def list_connector_hook_event_summaries(self, limit: int = 500) -> list[Event]:
+        """List recent connector-hook rows without the actionable filter."""
+
+        cur = self.db.execute(
+            """SELECT id, timestamp, action, target, actor,
+                      substr(COALESCE(details, ''), 1, ?) AS details,
+                      severity, run_id
+               FROM audit_events
+               WHERE action = 'connector-hook'
+               ORDER BY timestamp DESC, rowid DESC LIMIT ?""",
+            (_SUMMARY_DETAILS_BYTES, max(limit, 1)),
+        )
+        return [self._row_to_event(r) for r in cur.fetchall()]
+
+    def connector_hook_event_stats(self) -> dict[str, dict[str, Any]]:
+        """Return all-time connector-hook counters grouped by connector.
+
+        The Overview chart still uses a bounded event window for sparklines
+        and target breakdowns, but the CONNECTORS table's ``CALLS`` column
+        must not look frozen just because that window is full. Newer sidecar
+        schemas populate ``audit_events.connector`` and index it, so use a
+        grouped aggregate instead of loading every hook row into the TUI.
+        """
+
+        columns = {
+            row[1]
+            for row in self.db.execute("PRAGMA table_info(audit_events)").fetchall()
+        }
+        if "connector" not in columns:
+            return {}
+        details_expr = "' ' || COALESCE(details, '') || ' '"
+        cur = self.db.execute(
+            f"""SELECT LOWER(COALESCE(connector, '')) AS connector_name,
+                       COUNT(*) AS calls,
+                       SUM(CASE
+                             WHEN {details_expr} LIKE '% action=block %'
+                               OR {details_expr} LIKE '% action=deny %'
+                             THEN 1 ELSE 0
+                           END) AS blocks,
+                       SUM(CASE
+                             WHEN {details_expr} LIKE '% action=alert %'
+                               OR {details_expr} LIKE '% action=warn %'
+                             THEN 1 ELSE 0
+                           END) AS alerts,
+                       MAX(timestamp) AS newest
+                FROM audit_events
+                WHERE action = 'connector-hook'
+                  AND COALESCE(connector, '') <> ''
+                GROUP BY LOWER(connector)"""
+        )
+        stats: dict[str, dict[str, Any]] = {}
+        for connector, calls, blocks, alerts, newest in cur.fetchall():
+            key = str(connector or "").strip().lower()
+            if not key:
+                continue
+            stats[key] = {
+                "calls": int(calls or 0),
+                "blocks": int(blocks or 0),
+                "alerts": int(alerts or 0),
+                "newest": newest or "",
+            }
+        return stats
+
+    def count_scan_results_since(self, since: datetime | None) -> int:
+        """Count scan results in the active Overview session window."""
+
+        if since is None:
+            return int(
+                self.db.execute("SELECT COUNT(*) FROM scan_results").fetchone()[0] or 0
+            )
+        return int(
+            self.db.execute(
+                "SELECT COUNT(*) FROM scan_results WHERE datetime(timestamp) >= datetime(?)",
+                (since.isoformat(),),
+            ).fetchone()[0]
+            or 0
+        )
 
     def list_alerts(self, limit: int = 100) -> list[Event]:
         cur = self.db.execute(
@@ -526,7 +613,16 @@ class Store:
                       substr(COALESCE(details, ''), 1, ?) AS details,
                       severity, run_id
                FROM audit_events
-               WHERE severity IN ('CRITICAL','HIGH','ERROR')
+               WHERE (
+                   severity IN ('CRITICAL','HIGH','ERROR')
+                   OR (
+                       action = 'connector-hook'
+                       AND (
+                           details LIKE '%severity=CRITICAL%'
+                           OR details LIKE '%severity=HIGH%'
+                       )
+                   )
+               )
                  AND action NOT LIKE 'dismiss%'
                ORDER BY timestamp DESC, rowid DESC LIMIT ?""",
             (_SUMMARY_DETAILS_BYTES, max(limit, 1)),
@@ -989,9 +1085,16 @@ def _parse_ts(val: Any) -> datetime:
     if isinstance(val, datetime):
         return val
     if isinstance(val, str):
+        text = val.strip()
+        if text:
+            iso_text = text[:-1] + "+00:00" if text.endswith("Z") else text
+            try:
+                return datetime.fromisoformat(iso_text)
+            except ValueError:
+                pass
         for fmt in ("%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S"):
             try:
-                return datetime.strptime(val, fmt)
+                return datetime.strptime(text, fmt)
             except ValueError:
                 continue
     return datetime.now(timezone.utc)

--- a/cli/defenseclaw/inventory/agent_discovery.py
+++ b/cli/defenseclaw/inventory/agent_discovery.py
@@ -513,7 +513,7 @@ def _is_trusted_binary_path(binary_path: str) -> bool:
             # during passive discovery. Operator opt-in prefixes
             # (DEFENSECLAW_TRUSTED_BIN_PREFIXES) keep the looser checks.
             if prefix in default_prefixes and not _bin_chain_is_system_owned(resolved, prefix):
-                return False
+                continue
             return True
     return False
 

--- a/cli/defenseclaw/models.py
+++ b/cli/defenseclaw/models.py
@@ -169,6 +169,7 @@ class Event:
     structured: dict[str, Any] = field(default_factory=dict)
     severity: str = ""
     run_id: str = ""
+    connector: str = ""
 
 
 @dataclass

--- a/cli/defenseclaw/tui/app.py
+++ b/cli/defenseclaw/tui/app.py
@@ -6353,7 +6353,7 @@ class DefenseClawTUI(App[None]):
         """Fingerprint Overview content without volatile clock-only labels."""
 
         stable_text = re.sub(r"\buptime=\d+s\b", "uptime=<live>", self.body_text)
-        stable_text = re.sub(r"\b\d+[smhd] ago\b", "<live> ago", stable_text)
+        stable_text = re.sub(r"\b\d+(?:s|m|h|d) ago\b", "<live> ago", stable_text)
         return ("overview", self.help_open, stable_text)
 
     def _overview_connectors_panel(

--- a/cli/defenseclaw/tui/app.py
+++ b/cli/defenseclaw/tui/app.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import time
 from collections.abc import Iterable
+from contextlib import contextmanager
 from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -656,6 +657,11 @@ class DefenseClawTUI(App[None]):
         first_run: bool = False,
     ) -> None:
         super().__init__()
+        # Textual defaults to two rows per wheel notch, which makes the dense
+        # Overview dashboard feel like it is crawling. Keep this moderate so
+        # logs/tables are still controllable while trackpad/wheel scrolling
+        # moves a visible chunk of content.
+        self.scroll_sensitivity_y = 6.0
         self.first_run_model = first_run_model or FirstRunPanelModel(active=first_run)
         self.executor = CommandExecutor()
         self.config = config
@@ -743,9 +749,7 @@ class DefenseClawTUI(App[None]):
         # ``_periodic_refresh`` ticker tore the panel body down and
         # rebuilt it every tick — operators saw it as the panel
         # flickering and "switching between Activity and Logs". A
-        # ``None`` sentinel means "force a repaint next render"
-        # (used after the overview panel, whose renderable is a fresh
-        # Rich ``Group`` we cannot fingerprint reliably).
+        # ``None`` sentinel means "force a repaint next render".
         self._last_body_signature: tuple[object, ...] | None = None
         self._last_detail_signature: tuple[object, ...] | None = None
         # Same idempotence guard for the shared ``#panel-table`` DataTable.
@@ -758,6 +762,14 @@ class DefenseClawTUI(App[None]):
         # now skip the rebuild when the panel, columns, rows, and cursor are
         # all unchanged. ``None`` forces a repaint.
         self._last_table_signature: tuple[object, ...] | None = None
+        # Overview renders ask for the same recent hook-event window several
+        # times (header metrics, Enforcement, CONNECTORS rows). Cache it for a
+        # single frame so keypresses don't wait behind repeated SQLite reads.
+        self._connector_hook_event_cache_enabled = False
+        self._recent_connector_hook_events_cache: list[Any] | None = None
+        self._connector_hook_event_stats_cache: dict[str, dict[str, Any]] | None = None
+        self._overview_last_render_scroll_y: float | None = None
+        self._overview_last_scroll_activity_at: float = 0.0
         # Set while ``_render_panel_table`` programmatically restores the
         # DataTable cursor. Textual fires ``RowHighlighted`` for that move just
         # like a real keypress, and the handler would call the model's
@@ -1459,6 +1471,21 @@ class DefenseClawTUI(App[None]):
 
         self.action_switch_panel(panel)
         event.stop()
+
+    def on_mouse_scroll_down(self, event: events.MouseScrollDown) -> None:
+        self._mark_overview_scroll_activity()
+
+    def on_mouse_scroll_up(self, event: events.MouseScrollUp) -> None:
+        self._mark_overview_scroll_activity()
+
+    def _mark_overview_scroll_activity(self) -> None:
+        if self.active_panel == "overview" and not self.help_open and len(self.screen_stack) <= 1:
+            self._overview_last_scroll_activity_at = monotonic()
+
+    def _overview_scroll_activity_recent(self) -> bool:
+        if not self._overview_last_scroll_activity_at:
+            return False
+        return monotonic() - self._overview_last_scroll_activity_at < 0.45
 
     def _panel_hidden(self, panel: str) -> bool:
         """Return True if ``panel`` should be hidden from tabs + cycling.
@@ -2424,28 +2451,42 @@ class DefenseClawTUI(App[None]):
         # its wrapper scroll. DataTable panels keep #body as a short, auto-sized
         # header (the table does its own scrolling), so the class is overview-only.
         overview_active = self.active_panel == "overview" and not self.help_open
+        body_scroller: VerticalScroll | None = None
         try:
-            self.query_one("#body-scroll").set_class(overview_active, "overview-scroll")
+            body_scroller = self.query_one("#body-scroll", VerticalScroll)
+            body_scroller.set_class(overview_active, "overview-scroll")
         except Exception:  # noqa: BLE001 - the wrapper is always present; never break a render.
             pass
         if overview_active:
-            renderable = self._overview_renderable()
-            body_widget.update(renderable)
-            # The overview renderable is a freshly composed Rich
-            # ``Group`` every call (banner + notices + service cards),
-            # so equality comparisons aren't reliable. Bust the cache
-            # so the next text-body panel always paints, and accept
-            # that overview itself paints every tick (cheap; no
-            # DataTable underneath it).
-            self._last_body_signature = None
-            # Overview has no DataTable of its own and skips _body_text()
-            # (the only place these are reset), so clear the panel-table
-            # state here. Otherwise the columns/rows left over from the
-            # previously-viewed Audit/Logs panel survive and
-            # _render_panel_table() paints that stale feed at the bottom
-            # of the overview.
-            self._table_columns = ()
-            self._table_rows = ()
+            current_scroll_y = body_scroller.scroll_y if body_scroller is not None else None
+            scrolling_now = (
+                current_scroll_y is not None
+                and self._overview_last_render_scroll_y is not None
+                and current_scroll_y != self._overview_last_render_scroll_y
+                and self._last_body_signature is not None
+            )
+            wheel_active = self._overview_scroll_activity_recent() and self._last_body_signature is not None
+            if scrolling_now or wheel_active:
+                self._overview_last_render_scroll_y = current_scroll_y
+                self._table_columns = ()
+                self._table_rows = ()
+            else:
+                with self._connector_hook_event_render_cache():
+                    renderable = self._overview_renderable()
+                    body_signature = self._overview_body_signature()
+                    if body_signature != self._last_body_signature:
+                        body_widget.update(renderable)
+                        self._last_body_signature = body_signature
+                    self._overview_last_render_scroll_y = current_scroll_y
+                    # Overview has no DataTable of its own and skips _body_text()
+                    # (the only place these are reset), so clear the panel-table
+                    # state here. Otherwise the columns/rows left over from the
+                    # previously-viewed Audit/Logs panel survive and
+                    # _render_panel_table() paints that stale feed at the bottom
+                    # of the overview.
+                    self._table_columns = ()
+                    self._table_rows = ()
+                    self._render_native_widgets()
         else:
             text = self._body_text()
             # Skip the layout-triggering ``Static.update`` when the body
@@ -2461,7 +2502,7 @@ class DefenseClawTUI(App[None]):
             if body_signature != self._last_body_signature:
                 body_widget.update(self._safe_body_renderable(text))
                 self._last_body_signature = body_signature
-        self._render_native_widgets()
+            self._render_native_widgets()
         self._render_panel_controls()
         self._render_panel_table()
         self._render_detail_panel()
@@ -2786,8 +2827,10 @@ class DefenseClawTUI(App[None]):
 
     def _render_native_widgets(self) -> None:
         metrics = self.query_one("#overview-metrics", OverviewMetrics)
-        metrics.refresh_metrics(self._overview_metric_data())
-        metrics.set_class(self.active_panel != "overview" or self.help_open, "hidden")
+        overview_visible = self.active_panel == "overview" and not self.help_open
+        metrics.set_class(not overview_visible, "hidden")
+        if overview_visible:
+            metrics.refresh_metrics(self._overview_metric_data())
 
     def _render_panel_controls(self) -> None:
         overview = self.query_one("#overview-controls", Horizontal)
@@ -3904,7 +3947,7 @@ class DefenseClawTUI(App[None]):
         generic alert / scan / guardrail / agent set.
         """
 
-        counts = self.overview_model.enforcement
+        counts = self._overview_session_enforcement_counts()
         state_by_key = {
             card.key: card.state.strip().lower()
             for card in self.overview_model.service_cards()
@@ -3914,22 +3957,28 @@ class DefenseClawTUI(App[None]):
         ai_box = self.overview_model.ai_discovery_box()
         ai_count = len(ai_box.rows) + ai_box.overflow
 
-        connector = self.overview_model.active_connector_name()
-        connector_health = None
+        selected_connector = self._connector_filter()
+        multi_connectors = self._active_connector_names()
+        scope_connectors = (selected_connector,) if selected_connector else tuple(multi_connectors)
+        connector = selected_connector or self.overview_model.active_connector_name()
+        connector_health = (
+            None
+            if multi_connectors and not selected_connector
+            else self._connector_health_for_metric(connector, use_single=not multi_connectors or bool(selected_connector))
+        )
         health = self.overview_model.health
-        if health is not None:
-            connector_health = health.connector
         gateway_state = (health.gateway.state if health is not None else "").strip().lower()
         gateway_online = gateway_state in {"running", "ready", "healthy", "ok"}
 
-        sev = self.alerts_model.severity_counts() if self.alerts_model else {
-            "CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0,
-        }
+        sev = self._alert_severity_counts_for_connectors(scope_connectors)
+        fleet_sev = self._alert_severity_counts("")
         critical = sev.get("CRITICAL", 0)
         high = sev.get("HIGH", 0)
         medium = sev.get("MEDIUM", 0)
         low = sev.get("LOW", 0)
         total_findings = critical + high + medium + low
+        fleet_findings = sum(fleet_sev.values())
+        outside_roster_findings = max(fleet_findings - total_findings, 0) if scope_connectors and not selected_connector else 0
 
         cfg = self.overview_model.cfg
         guardrail_mode = (cfg.guardrail_mode if cfg else "") or "observe"
@@ -3977,27 +4026,62 @@ class DefenseClawTUI(App[None]):
             else:
                 requests = inspections = errors = tool_blocks = subprocess_blocks = 0
             blocks_total = tool_blocks + subprocess_blocks
-            allow_count, alert_count, block_decisions, top_hook = self._connector_hook_breakdown()
+            session_since = self._session_start_for_connectors(scope_connectors)
+            allow_count, alert_count, block_decisions, top_hook = self._connector_hook_breakdown_for_connectors(
+                scope_connectors, since=session_since
+            )
+            total_allow, total_alert, total_block, _total_newest = self._connector_hook_stats_for_connectors(scope_connectors)
+            fleet_total_allow, fleet_total_alert, fleet_total_block, _fleet_total_newest = self._connector_hook_stats_for_connectors()
+            live_hook_calls, live_blocks_value, has_live_hook_counts = self._connector_live_counts_for_connectors(scope_connectors)
+            fleet_live_hook_calls, fleet_live_blocks_value, has_fleet_live_hook_counts = self._connector_live_counts_for_connectors(())
 
-            # Hook connectors don't advance the gateway ``requests``
-            # counter, so fall back to the count of connector-hook audit
-            # events — the same events the operator sees streaming in the
-            # Logs panel — when the live counter is zero.
-            hook_timestamps = self._hook_event_timestamps()
-            hook_calls = requests or len(hook_timestamps)
-            block_timestamps = self._block_event_timestamps()
-            blocks_value = blocks_total or len(block_timestamps)
-            finding_timestamps = self._finding_event_timestamps()
+            # Prefer the gateway's live per-connector request counters when
+            # available. Older gateways did not expose the connector array, so
+            # fall back to grouped audit totals and finally the recent hook
+            # window used by the trend sparkline.
+            hook_timestamps = self._hook_event_timestamps_for_connectors(scope_connectors)
+            total_hook_calls = total_allow + total_alert + total_block
+            fleet_total_hook_calls = fleet_total_allow + fleet_total_alert + fleet_total_block
+            fleet_hook_calls = (
+                fleet_live_hook_calls
+                if has_fleet_live_hook_counts
+                else fleet_total_hook_calls
+            )
+            hook_calls = (
+                live_hook_calls
+                if has_live_hook_counts
+                else (requests or total_hook_calls or len(hook_timestamps))
+            )
+            outside_roster_hook_calls = max(fleet_hook_calls - hook_calls, 0) if scope_connectors and not selected_connector else 0
+            block_timestamps = self._block_event_timestamps_for_connectors(scope_connectors)
+            fleet_block_timestamps = self._block_event_timestamps()
+            blocks_value = (
+                live_blocks_value
+                if has_live_hook_counts
+                else (blocks_total or total_block or len(block_timestamps))
+            )
+            fleet_blocks_value = (
+                fleet_live_blocks_value
+                if has_fleet_live_hook_counts
+                else (fleet_total_block or len(fleet_block_timestamps))
+            )
+            outside_roster_blocks = max(fleet_blocks_value - blocks_value, 0) if scope_connectors and not selected_connector else 0
+            finding_timestamps = self._finding_event_timestamps_for_connectors(scope_connectors)
 
             call_detail_parts: list[str] = []
             if allow_count or alert_count or block_decisions:
                 call_detail_parts.append(
-                    f"[{TOKENS.accent_green}]a{allow_count}[/] "
+                    f"session [{TOKENS.accent_green}]a{allow_count}[/] "
                     f"[{TOKENS.accent_amber}]w{alert_count}[/] "
                     f"[{TOKENS.accent_red}]b{block_decisions}[/]"
                 )
                 if top_hook:
                     call_detail_parts.append(f"top: [{TOKENS.accent_cyan}]{top_hook}[/]")
+                if selected_connector:
+                    fleet_prefix = "live fleet" if has_fleet_live_hook_counts else "fleet"
+                    call_detail_parts.append(f"{fleet_prefix} {fleet_hook_calls}")
+                elif outside_roster_hook_calls:
+                    call_detail_parts.append(f"outside roster {outside_roster_hook_calls}")
             elif inspections or errors:
                 if inspections:
                     call_detail_parts.append(f"[{TOKENS.accent_blue}]{inspections}[/] inspected")
@@ -4009,9 +4093,11 @@ class DefenseClawTUI(App[None]):
                 call_detail_parts.append("waiting for tool calls")
             else:
                 call_detail_parts.append("agent active")
+                if selected_connector:
+                    call_detail_parts.append(f"fleet {fleet_hook_calls}")
             calls_detail = " · ".join(call_detail_parts)
 
-            top_blocked_target, top_blocked_count = self._top_block_target()
+            top_blocked_target, top_blocked_count = self._top_block_target_for_connectors(scope_connectors)
             block_detail_parts: list[str] = []
             if tool_blocks:
                 block_detail_parts.append(f"[{TOKENS.accent_red}]{tool_blocks}[/] tool")
@@ -4025,6 +4111,10 @@ class DefenseClawTUI(App[None]):
                     block_detail_parts.append(f"[{TOKENS.text_muted}]no data — gateway offline[/]")
                 else:
                     block_detail_parts.append("no blocks yet")
+            if selected_connector:
+                block_detail_parts.append(f"fleet {fleet_blocks_value}")
+            elif outside_roster_blocks:
+                block_detail_parts.append(f"outside roster {outside_roster_blocks}")
             blocks_detail = " · ".join(block_detail_parts)
 
             # D1=B: in multi-connector installs the aggregate counts above
@@ -4032,15 +4122,45 @@ class DefenseClawTUI(App[None]):
             # replace the detail sub-lines with a per-connector split and
             # relabel the Hook Calls tile to the connector count. No-op for
             # single-connector installs (helpers return empty).
-            multi_connectors = self._active_connector_names()
             hook_calls_label = f"Hook Calls ({connector})"
-            if multi_connectors:
+            blocks_label = "Blocks"
+            findings_label = "Findings"
+            if selected_connector:
+                hook_calls_label = f"Hook Calls ({selected_connector})"
+                blocks_label = f"Blocks ({selected_connector})"
+                findings_label = f"Findings ({selected_connector})"
+            elif multi_connectors:
                 multi_calls_detail, multi_blocks_detail = self._multi_connector_tile_details()
                 if multi_calls_detail:
                     calls_detail = multi_calls_detail
                 if multi_blocks_detail:
                     blocks_detail = multi_blocks_detail
+                if outside_roster_hook_calls and "outside roster" not in calls_detail:
+                    calls_detail = (
+                        f"{calls_detail} · outside roster {outside_roster_hook_calls}"
+                        if calls_detail
+                        else f"outside roster {outside_roster_hook_calls}"
+                    )
+                if outside_roster_blocks and "outside roster" not in blocks_detail:
+                    blocks_detail = (
+                        f"{blocks_detail} · outside roster {outside_roster_blocks}"
+                        if blocks_detail
+                        else f"outside roster {outside_roster_blocks}"
+                    )
                 hook_calls_label = f"Hook Calls ({len(multi_connectors)} connectors)"
+
+            findings_detail = self._findings_metric_detail(
+                critical,
+                high,
+                medium,
+                low,
+                connector=selected_connector,
+                connectors=scope_connectors,
+            )
+            if selected_connector:
+                findings_detail = f"{findings_detail} · fleet {fleet_findings}"
+            elif outside_roster_findings:
+                findings_detail = f"{findings_detail} · outside roster {outside_roster_findings}"
 
             return (
                 MetricDatum(
@@ -4055,7 +4175,7 @@ class DefenseClawTUI(App[None]):
                 ),
                 MetricDatum(
                     key="blocks",
-                    label="Blocks",
+                    label=blocks_label,
                     value=blocks_value,
                     progress=min(float(blocks_value) * 5, 100.0),
                     detail=blocks_detail,
@@ -4065,10 +4185,10 @@ class DefenseClawTUI(App[None]):
                 ),
                 MetricDatum(
                     key="findings",
-                    label="Findings",
+                    label=findings_label,
                     value=total_findings,
                     progress=min(float(total_findings) * 5, 100.0),
-                    detail=self._findings_metric_detail(critical, high, medium, low),
+                    detail=findings_detail,
                     trend=self._metric_history(finding_timestamps),
                     state="error" if critical or high else ("warn" if medium else "ok"),
                     target_panel="alerts",
@@ -4133,7 +4253,380 @@ class DefenseClawTUI(App[None]):
             ),
         )
 
-    def _findings_metric_detail(self, critical: int, high: int, medium: int, low: int) -> str:
+    @contextmanager
+    def _connector_hook_event_render_cache(self):
+        previous_enabled = self._connector_hook_event_cache_enabled
+        previous_cache = self._recent_connector_hook_events_cache
+        previous_stats_cache = self._connector_hook_event_stats_cache
+        self._connector_hook_event_cache_enabled = True
+        self._recent_connector_hook_events_cache = None
+        self._connector_hook_event_stats_cache = None
+        try:
+            yield
+        finally:
+            self._connector_hook_event_cache_enabled = previous_enabled
+            self._recent_connector_hook_events_cache = previous_cache
+            self._connector_hook_event_stats_cache = previous_stats_cache
+
+    def _connector_health_for_metric(self, connector: str, *, use_single: bool) -> Any | None:
+        """Live health row for a metric's connector scope."""
+
+        health = self.overview_model.health
+        if health is None:
+            return None
+        want = connector.strip().lower()
+        for conn in health.connectors:
+            if conn.name.strip().lower() == want:
+                return conn
+        if use_single and health.connector is not None:
+            if not want or health.connector.name.strip().lower() == want:
+                return health.connector
+        return None
+
+    @staticmethod
+    def _connector_health_has_live_window(connector_health: Any) -> bool:
+        """True when a health row represents a current gateway counter window."""
+
+        if not connector_health:
+            return False
+        if (getattr(connector_health, "since", "") or "").strip():
+            return True
+        return any(
+            _coerce_nonnegative_int(getattr(connector_health, field, 0))
+            for field in (
+                "requests",
+                "errors",
+                "tool_inspections",
+                "tool_blocks",
+                "subprocess_blocks",
+            )
+        )
+
+    def _connector_live_counts_for_connectors(
+        self, connectors: Iterable[str] = (),
+    ) -> tuple[int, int, bool]:
+        """Return live ``(requests, blocks, has_live_window)`` for a scope."""
+
+        health = self.overview_model.health
+        if health is None:
+            return 0, 0, False
+        scope = self._normalize_connector_scope(connectors)
+        rows: list[Any] = []
+        for conn in health.connectors:
+            name = conn.name.strip().lower()
+            if not scope or any(want in name for want in scope):
+                rows.append(conn)
+        if not rows and health.connector is not None:
+            name = health.connector.name.strip().lower()
+            if not scope or any(want in name for want in scope):
+                rows.append(health.connector)
+        live_rows = [row for row in rows if self._connector_health_has_live_window(row)]
+        if not live_rows:
+            return 0, 0, False
+        requests = sum(_coerce_nonnegative_int(getattr(row, "requests", 0)) for row in live_rows)
+        blocks = sum(
+            _coerce_nonnegative_int(getattr(row, "tool_blocks", 0))
+            + _coerce_nonnegative_int(getattr(row, "subprocess_blocks", 0))
+            for row in live_rows
+        )
+        return requests, blocks, True
+
+    def _session_start_for_connectors(
+        self, connectors: Iterable[str] = (),
+    ) -> datetime | None:
+        """Start of the active gateway/session window for a connector scope."""
+
+        health = self.overview_model.health
+        if health is None:
+            return None
+        scope = self._normalize_connector_scope(connectors)
+        starts: list[datetime] = []
+        for conn in health.connectors:
+            name = conn.name.strip().lower()
+            if scope and not any(want in name for want in scope):
+                continue
+            since = _parse_timestamp(conn.since)
+            if since is not None:
+                starts.append(since)
+        if not starts and health.connector is not None:
+            name = health.connector.name.strip().lower()
+            if not scope or any(want in name for want in scope):
+                since = _parse_timestamp(health.connector.since)
+                if since is not None:
+                    starts.append(since)
+        if not starts:
+            since = _parse_timestamp(health.guardrail.since)
+            if since is not None:
+                starts.append(since)
+        return min(starts) if starts else None
+
+    def _overview_session_enforcement_counts(self) -> EnforcementCounts:
+        """Overview counts using the active gateway/session where possible."""
+
+        current = self.overview_model.enforcement
+        scope = tuple(self._active_connector_names())
+        session_start = self._session_start_for_connectors(scope)
+        total_scans = current.total_scans
+        store = getattr(self.alerts_model, "store", None) or getattr(self.audit_model, "store", None)
+        loader = getattr(store, "count_scan_results_since", None)
+        if callable(loader):
+            try:
+                total_scans = int(loader(session_start))
+            except Exception:  # noqa: BLE001 - retain the last known count.
+                total_scans = current.total_scans
+        return EnforcementCounts(
+            blocked_skills=current.blocked_skills,
+            allowed_skills=current.allowed_skills,
+            blocked_mcps=current.blocked_mcps,
+            allowed_mcps=current.allowed_mcps,
+            total_scans=total_scans,
+            active_alerts=self._session_alert_count_for_connectors(scope),
+        )
+
+    def _session_alert_count_for_connectors(self, connectors: Iterable[str] = ()) -> int:
+        """Count current-session alert decisions for an Overview connector scope."""
+
+        scope = self._normalize_connector_scope(connectors)
+        since = self._session_start_for_connectors(scope)
+        seen: set[tuple[str, ...]] = set()
+
+        if self.alerts_model is not None:
+            for row in self.alerts_model.flat_rows():
+                if row.kind == "scan_finding":
+                    continue
+                event = row.event
+                if not self._event_in_session(event, since):
+                    continue
+                if not self._event_matches_connectors(event, scope):
+                    continue
+                bucket = self._event_metric_severity_bucket(event)
+                if bucket in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}:
+                    seen.add(self._event_count_key(event))
+
+        for event in self._recent_connector_hook_events():
+            if not self._event_in_session(event, since):
+                continue
+            if not self._event_matches_connectors(event, scope):
+                continue
+            if self._hook_decision(event) in {"alert", "warn"}:
+                seen.add(self._event_count_key(event))
+
+        return len(seen)
+
+    @staticmethod
+    def _event_count_key(event: Any) -> tuple[str, ...]:
+        event_id = str(getattr(event, "id", "") or "").strip()
+        if event_id:
+            return ("id", event_id)
+        timestamp = getattr(event, "timestamp", None)
+        timestamp_key = timestamp.isoformat() if isinstance(timestamp, datetime) else ""
+        return (
+            "event",
+            timestamp_key,
+            str(getattr(event, "action", "") or ""),
+            str(getattr(event, "target", "") or ""),
+            str(getattr(event, "details", "") or ""),
+        )
+
+    @staticmethod
+    def _event_in_session(event: Any, since: datetime | None) -> bool:
+        if since is None:
+            return True
+        ts = getattr(event, "timestamp", None)
+        if not isinstance(ts, datetime):
+            return False
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        return ts >= since
+
+    def _alert_severity_counts(self, connector: str = "") -> dict[str, int]:
+        """Severity counts for the active Overview metric scope."""
+
+        return self._alert_severity_counts_for_connectors((connector,) if connector else ())
+
+    def _alert_severity_counts_for_connectors(self, connectors: Iterable[str] = ()) -> dict[str, int]:
+        """Severity counts for a connector roster scope."""
+
+        counts = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0}
+        scope = self._normalize_connector_scope(connectors)
+        since = self._session_start_for_connectors(scope)
+        seen: set[tuple[str, ...]] = set()
+        if self.alerts_model is not None:
+            for row in self.alerts_model.flat_rows():
+                if row.kind == "scan_finding":
+                    continue
+                if not self._event_in_session(row.event, since):
+                    continue
+                if not self._event_matches_connectors(row.event, scope):
+                    continue
+                bucket = self._event_metric_severity_bucket(row.event)
+                if bucket in counts:
+                    seen.add(self._event_count_key(row.event))
+                    counts[bucket] += 1
+        for event in self._recent_connector_hook_events():
+            if not self._event_in_session(event, since):
+                continue
+            if not self._event_matches_connectors(event, scope):
+                continue
+            key = self._event_count_key(event)
+            if key in seen:
+                continue
+            if self._hook_decision(event) not in {"alert", "warn", "block"}:
+                continue
+            bucket = self._event_metric_severity_bucket(event)
+            if bucket in counts:
+                seen.add(key)
+                counts[bucket] += 1
+        return counts
+
+    @staticmethod
+    def _normalize_connector_scope(connectors: Iterable[str]) -> tuple[str, ...]:
+        return tuple(connector.strip().lower() for connector in connectors if connector.strip())
+
+    @staticmethod
+    def _event_connector(event: Any) -> str:
+        return _parse_kv_details(getattr(event, "details", "") or "").get("connector", "").strip().lower()
+
+    @staticmethod
+    def _event_metric_severity_bucket(event: Any) -> str:
+        bucket = _metric_severity_bucket(getattr(event, "severity", "") or "")
+        if bucket in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}:
+            return bucket
+        if str(getattr(event, "action", "") or "").strip().lower() == "connector-hook":
+            detail_bucket = _metric_severity_bucket(
+                _parse_kv_details(getattr(event, "details", "") or "").get("severity", "")
+            )
+            if detail_bucket in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}:
+                return detail_bucket
+        return bucket
+
+    @staticmethod
+    def _event_matches_connector(event: Any, connector: str) -> bool:
+        return DefenseClawTUI._event_matches_connectors(event, (connector,) if connector else ())
+
+    @staticmethod
+    def _event_matches_connectors(event: Any, connectors: Iterable[str]) -> bool:
+        scope = DefenseClawTUI._normalize_connector_scope(connectors)
+        if not scope:
+            return True
+        got = DefenseClawTUI._event_connector(event)
+        return bool(got) and any(want in got for want in scope)
+
+    @staticmethod
+    def _hook_decision(event: Any) -> str:
+        details = _parse_kv_details(getattr(event, "details", "") or "")
+        action = details.get("action", "").strip().lower()
+        raw_action = details.get("raw_action", "").strip().lower()
+        mode = details.get("mode", "").strip().lower()
+        would_block = details.get("would_block", "").strip().lower() == "true"
+
+        if action in {"block", "deny"}:
+            return "block"
+        if action in {"alert", "warn"}:
+            return "alert"
+        if action == "allow" and mode == "observe":
+            if raw_action in {"block", "deny"} or would_block:
+                return "alert"
+            if raw_action in {"alert", "warn"}:
+                return "alert"
+        return action
+
+    def _connector_hook_event_stats(self) -> dict[str, dict[str, Any]]:
+        """All-time connector-hook counts plus latest timestamps.
+
+        The recent event window is intentionally capped for render speed and
+        trend sparklines. These grouped totals power user-facing counters so a
+        busy connector does not appear stuck at ``498`` just because the latest
+        500 rows also include two old rows from another connector.
+        """
+
+        if self._connector_hook_event_cache_enabled and self._connector_hook_event_stats_cache is not None:
+            return self._connector_hook_event_stats_cache
+        stats: dict[str, dict[str, Any]] = {}
+        store = getattr(self.audit_model, "store", None) if self.audit_model is not None else None
+        loader = getattr(store, "connector_hook_event_stats", None)
+        if callable(loader):
+            try:
+                raw_stats = loader() or {}
+            except Exception:  # noqa: BLE001 - fall back to the recent in-memory window.
+                raw_stats = {}
+            for raw_connector, raw in raw_stats.items():
+                connector = str(raw_connector or "").strip().lower()
+                if not connector or not isinstance(raw, dict):
+                    continue
+                calls = _coerce_nonnegative_int(raw.get("calls"))
+                blocks = _coerce_nonnegative_int(raw.get("blocks"))
+                alerts = _coerce_nonnegative_int(raw.get("alerts"))
+                stats[connector] = {
+                    "calls": calls,
+                    "blocks": min(blocks, calls),
+                    "alerts": min(alerts, calls),
+                    "newest": _parse_timestamp(raw.get("newest")),
+                }
+        if not stats:
+            for event in self._recent_connector_hook_events():
+                connector = self._event_connector(event) or "__unattributed__"
+                entry = stats.setdefault(
+                    connector,
+                    {"calls": 0, "blocks": 0, "alerts": 0, "newest": None},
+                )
+                entry["calls"] = int(entry["calls"]) + 1
+                decision = self._hook_decision(event)
+                if decision in {"block", "deny"}:
+                    entry["blocks"] = int(entry["blocks"]) + 1
+                elif decision in {"alert", "warn"}:
+                    entry["alerts"] = int(entry["alerts"]) + 1
+                ts = getattr(event, "timestamp", None)
+                if isinstance(ts, datetime):
+                    newest = entry.get("newest")
+                    if newest is None or ts > newest:
+                        entry["newest"] = ts
+        if self._connector_hook_event_cache_enabled:
+            self._connector_hook_event_stats_cache = stats
+        return stats
+
+    def _connector_hook_stats_for_connectors(
+        self, connectors: Iterable[str] = (),
+    ) -> tuple[int, int, int, datetime | None]:
+        """Return ``(allow, alert, block, newest)`` for the connector scope."""
+
+        scope = self._normalize_connector_scope(connectors)
+        allow = alert = block = 0
+        newest: datetime | None = None
+        for connector, row in self._connector_hook_event_stats().items():
+            if scope and not any(want in connector for want in scope):
+                continue
+            calls = _coerce_nonnegative_int(row.get("calls"))
+            row_alerts = min(_coerce_nonnegative_int(row.get("alerts")), calls)
+            row_blocks = min(_coerce_nonnegative_int(row.get("blocks")), calls)
+            alert += row_alerts
+            block += row_blocks
+            allow += max(calls - row_alerts - row_blocks, 0)
+            ts = row.get("newest")
+            if isinstance(ts, datetime) and (newest is None or ts > newest):
+                newest = ts
+        return allow, alert, block, newest
+
+    @staticmethod
+    def _is_block_event(event: Any) -> bool:
+        action = (getattr(event, "action", "") or "").lower()
+        details = (getattr(event, "details", "") or "").lower()
+        return (
+            action in {"block", "guardrail-block", "deny", "quarantine"}
+            or "action=block" in details
+            or "action=deny" in details
+        )
+
+    def _findings_metric_detail(
+        self,
+        critical: int,
+        high: int,
+        medium: int,
+        low: int,
+        *,
+        connector: str = "",
+        connectors: Iterable[str] = (),
+    ) -> str:
         """Severity breakdown plus the top severity event target (if any).
 
         The breakdown is the primary signal; the top target gives one
@@ -4143,7 +4636,12 @@ class DefenseClawTUI(App[None]):
         """
 
         breakdown = _severity_breakdown_markup(critical, high, medium, low)
-        target, severity_letter_src = self._top_finding_target()
+        if connector:
+            target, severity_letter_src = self._top_finding_target(connector)
+        elif self._normalize_connector_scope(connectors):
+            target, severity_letter_src = self._top_finding_target_for_connectors(connectors)
+        else:
+            target, severity_letter_src = self._top_finding_target()
         if not target:
             return breakdown
         short_target = target if len(target) <= 18 else target[:17] + "…"
@@ -4190,22 +4688,34 @@ class DefenseClawTUI(App[None]):
         original aggregate behaviour for single-connector installs.
         """
 
+        return self._connector_hook_breakdown_for_connectors((connector,) if connector else ())
+
+    def _connector_hook_breakdown_for_connectors(
+        self,
+        connectors: Iterable[str] = (),
+        *,
+        since: datetime | None = None,
+    ) -> tuple[int, int, int, str]:
+        """Hook decision breakdown for a connector roster scope."""
+
         allow = alert = block = 0
         events_by_target: dict[str, int] = {}
-        if self.audit_model is None:
+        events = self._recent_connector_hook_events()
+        if not events:
             return 0, 0, 0, ""
-        want = connector.strip().lower()
-        for event in self.audit_model.items[-200:]:
-            if event.action != "connector-hook":
+        scope = self._normalize_connector_scope(connectors)
+        for event in events:
+            if since is not None:
+                ts = getattr(event, "timestamp", None)
+                if not isinstance(ts, datetime):
+                    continue
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if ts < since:
+                    continue
+            if not self._event_matches_connectors(event, scope):
                 continue
-            details = event.details or ""
-            if want and _parse_kv_details(details).get("connector", "").strip().lower() != want:
-                continue
-            decision = ""
-            for token in details.split():
-                if token.startswith("action="):
-                    decision = token[len("action="):].strip().lower()
-                    break
+            decision = self._hook_decision(event)
             if decision == "allow":
                 allow += 1
             elif decision == "alert" or decision == "warn":
@@ -4229,8 +4739,21 @@ class DefenseClawTUI(App[None]):
         (allow + alert + block) the connector's hooks produced.
         """
 
-        allow, alert, block, _top = self._connector_hook_breakdown(connector)
-        return allow + alert + block, alert, block
+        return self._enforcement_scope_breakdown((connector,))
+
+    def _enforcement_scope_breakdown(self, connectors: Iterable[str]) -> tuple[int, int, int]:
+        """``(calls, alerts, blocks)`` for an Overview connector scope."""
+
+        since = self._session_start_for_connectors(connectors)
+        allow, alert, block, _top = self._connector_hook_breakdown_for_connectors(
+            connectors, since=since
+        )
+        live_calls, live_blocks, has_live = self._connector_live_counts_for_connectors(connectors)
+        return (
+            live_calls if has_live else allow + alert + block,
+            alert,
+            live_blocks if has_live else block,
+        )
 
     _BLOCK_VERDICTS = frozenset({"block", "blocked", "deny", "denied", "quarantine", "quarantined"})
     _ALLOW_VERDICTS = frozenset({"allow", "allowed", "clean", "ok", "pass"})
@@ -4421,8 +4944,10 @@ class DefenseClawTUI(App[None]):
             self._set_status(f"Filtered to {friendly} ({connector}).")
         else:
             self._set_status("Showing all connectors.")
-        self._sync_signal_connector_filters()
-        self._sync_catalog_connector_filters()
+        # Keep connector-chip clicks responsive: the active panel syncs its
+        # model filters during render, and hidden panels sync when opened.
+        # Eagerly refiltering Logs/Audit/catalog data here made an Overview
+        # chip click pay for every table in the app.
         self._render_chrome()
 
     def _sync_catalog_connector_filters(self) -> None:
@@ -4521,7 +5046,7 @@ class DefenseClawTUI(App[None]):
         if y < 0 or y >= len(lines):
             return False
         plain = re.sub(r"\[/?[^\[\]]*\]", "", lines[y])
-        if not plain.startswith("Connector:"):
+        if not plain.startswith("Connector:") and not self._overview_chip_visual_line(y):
             return False
         for start, end, value in segments:
             if start <= x < end:
@@ -4533,6 +5058,22 @@ class DefenseClawTUI(App[None]):
             self.run_worker(self._open_mode_picker(), exclusive=False, thread=False)
             return True
         return False
+
+    def _overview_chip_visual_line(self, y: int) -> bool:
+        """True when ``y`` is the rendered Overview connector-chip line."""
+
+        if self.active_panel != "overview" or self.help_open:
+            return False
+        try:
+            if self.query_one("#body-scroll", VerticalScroll).scroll_y > 0:
+                return False
+        except NoMatches:
+            pass
+        # ``_overview_renderable`` paints the five-line logo, the tagline, and
+        # one spacer before the connector chip. The fallback ``body_text`` has
+        # a different line layout, so content validation alone misses clicks on
+        # the visible chip.
+        return y == len(_DEFENSECLAW_LOGO.splitlines()) + 2
 
     def _sync_signal_connector_filters(self) -> None:
         """Push the shared connector filter + column flag to the signal panes.
@@ -4555,9 +5096,9 @@ class DefenseClawTUI(App[None]):
         Returns ``(calls_detail, blocks_detail)``. Each active connector is
         scored independently via :meth:`_connector_hook_breakdown` so the
         single tile row stays intact (D1=B) while the detail sub-line
-        attributes activity to the right connector — e.g.
-        ``codex a12 w0 b3 · cursor a8 w1 b1``. ``blocks_detail`` lists only
-        connectors that actually blocked something. Returns ``("", "")``
+        attributes recent activity to the right connector — e.g.
+        ``recent codex a12 w0 b3 · cursor a8 w1 b1``. ``blocks_detail`` lists
+        only connectors that actually blocked something. Returns ``("", "")``
         when fewer than two connectors are active, leaving the
         single-connector detail lines unchanged.
         """
@@ -4568,9 +5109,12 @@ class DefenseClawTUI(App[None]):
         call_parts: list[str] = []
         block_parts: list[str] = []
         for connector in connectors:
-            allow, alert, block, _top = self._connector_hook_breakdown(connector)
+            since = self._session_start_for_connectors((connector,))
+            allow, alert, block, _top = self._connector_hook_breakdown_for_connectors(
+                (connector,), since=since
+            )
             call_parts.append(
-                f"[{TOKENS.accent_cyan}]{connector}[/] "
+                f"[{TOKENS.text_secondary}]session[/] [{TOKENS.accent_cyan}]{connector}[/] "
                 f"[{TOKENS.accent_green}]a{allow}[/] "
                 f"[{TOKENS.accent_amber}]w{alert}[/] "
                 f"[{TOKENS.accent_red}]b{block}[/]"
@@ -4601,11 +5145,12 @@ class DefenseClawTUI(App[None]):
     def _connector_last_activity(self, connector: str) -> datetime | None:
         """Most recent audit-event timestamp attributed to ``connector``."""
 
-        if self.audit_model is None:
-            return None
         want = connector.strip().lower()
+        stats_newest = self._connector_hook_event_stats().get(want, {}).get("newest")
+        if isinstance(stats_newest, datetime):
+            return stats_newest
         latest: datetime | None = None
-        for event in self.audit_model.items:
+        for event in self._recent_connector_hook_events():
             if event.timestamp is None:
                 continue
             attributed = _parse_kv_details(event.details or "").get("connector", "").strip().lower()
@@ -4639,7 +5184,22 @@ class DefenseClawTUI(App[None]):
         for connector, mode in cfg.connector_modes:
             if not connector:
                 continue
-            allow, alert, block, _top = self._connector_hook_breakdown(connector)
+            health_row = self._connector_health_for_metric(connector, use_single=False)
+            if health_row is not None and self._connector_health_has_live_window(health_row):
+                calls = _coerce_nonnegative_int(getattr(health_row, "requests", 0))
+                blocks = (
+                    _coerce_nonnegative_int(getattr(health_row, "tool_blocks", 0))
+                    + _coerce_nonnegative_int(getattr(health_row, "subprocess_blocks", 0))
+                )
+                since = _parse_timestamp(getattr(health_row, "since", ""))
+                _allow, alerts, audit_blocks, _top = self._connector_hook_breakdown_for_connectors(
+                    (connector,), since=since
+                )
+                if blocks == 0:
+                    blocks = audit_blocks
+            else:
+                allow, alerts, blocks, _newest = self._connector_hook_stats_for_connectors((connector,))
+                calls = allow + alerts + blocks
             last = self._connector_last_activity(connector)
             # A guardrail-disabled connector keeps its historical counts (so
             # the row still tells the story) but its STATUS is forced to
@@ -4656,15 +5216,15 @@ class DefenseClawTUI(App[None]):
                     mode=mode or "",
                     rule_pack=(packs.get(connector) or "").strip(),
                     last_activity=_relative_time_label(last, now),
-                    calls=allow + alert + block,
-                    blocks=block,
-                    alerts=alert,
+                    calls=calls,
+                    blocks=blocks,
+                    alerts=alerts,
                     status=status,
                 )
             )
         return rows
 
-    def _hook_event_timestamps(self) -> list[datetime]:
+    def _hook_event_timestamps(self, connector: str = "") -> list[datetime]:
         """Timestamps of recent connector-hook audit events.
 
         Each connector-hook event is one hook call (preToolUse,
@@ -4675,52 +5235,156 @@ class DefenseClawTUI(App[None]):
         moves for them.
         """
 
-        if self.audit_model is None:
-            return []
+        return self._hook_event_timestamps_for_connectors((connector,) if connector else ())
+
+    def _hook_event_timestamps_for_connectors(self, connectors: Iterable[str] = ()) -> list[datetime]:
+        """Timestamps of recent connector-hook audit events for a roster scope."""
+
+        scope = self._normalize_connector_scope(connectors)
         return [
             event.timestamp
-            for event in self.audit_model.items
-            if event.action == "connector-hook" and event.timestamp is not None
+            for event in self._recent_connector_hook_events()
+            if event.timestamp is not None and self._event_matches_connectors(event, scope)
         ]
 
-    def _block_event_timestamps(self) -> list[datetime]:
+    def _recent_connector_hook_events(self) -> list[Any]:
+        """Recent connector-hook events, bypassing the Audit panel's noise filter."""
+
+        if self._connector_hook_event_cache_enabled and self._recent_connector_hook_events_cache is not None:
+            return self._recent_connector_hook_events_cache
+        if self.audit_model is None:
+            if self._connector_hook_event_cache_enabled:
+                self._recent_connector_hook_events_cache = []
+            return []
+        events: list[Any]
+        store = getattr(self.audit_model, "store", None)
+        loader = getattr(store, "list_connector_hook_event_summaries", None)
+        if callable(loader):
+            try:
+                events = list(loader(500))
+            except Exception:  # noqa: BLE001 - metric tiles should degrade to cached panel rows.
+                events = []
+        else:
+            events = []
+        if not events:
+            events = [
+                event
+                for event in self.audit_model.items
+                if getattr(event, "action", "") == "connector-hook"
+            ]
+
+        def sort_key(event: Any) -> datetime:
+            ts = getattr(event, "timestamp", None)
+            if not isinstance(ts, datetime):
+                return datetime.min.replace(tzinfo=timezone.utc)
+            if ts.tzinfo is None:
+                return ts.replace(tzinfo=timezone.utc)
+            return ts
+
+        events = sorted(events, key=sort_key)
+        if self._connector_hook_event_cache_enabled:
+            self._recent_connector_hook_events_cache = events
+        return events
+
+    def _recent_block_events(self, connector: str = "") -> list[Any]:
+        """Recent block/deny events, including unfiltered connector-hook blocks."""
+
+        return self._recent_block_events_for_connectors((connector,) if connector else ())
+
+    def _recent_block_events_for_connectors(self, connectors: Iterable[str] = ()) -> list[Any]:
+        """Recent block/deny events for a connector roster scope."""
+
+        scope = self._normalize_connector_scope(connectors)
+        since = self._session_start_for_connectors(scope)
+        events: list[Any] = []
+        events.extend(self._recent_connector_hook_events())
+        if self.audit_model is not None:
+            events.extend(self.audit_model.items)
+        out: list[Any] = []
+        seen: set[str] = set()
+        for event in events:
+            key = str(getattr(event, "id", "") or id(event))
+            if key in seen:
+                continue
+            seen.add(key)
+            if not self._event_in_session(event, since):
+                continue
+            if not self._event_matches_connectors(event, scope):
+                continue
+            if self._is_block_event(event):
+                out.append(event)
+        return out[-200:]
+
+    def _block_event_timestamps(self, connector: str = "") -> list[datetime]:
         """Timestamps of recent block / deny / quarantine audit events."""
 
-        if self.audit_model is None:
-            return []
-        stamps: list[datetime] = []
-        for event in self.audit_model.items:
-            action = (event.action or "").lower()
-            details = (event.details or "").lower()
-            is_block = (
-                action in {"block", "guardrail-block", "deny", "quarantine"}
-                or "action=block" in details
-                or "action=deny" in details
-            )
-            if is_block and event.timestamp is not None:
-                stamps.append(event.timestamp)
-        return stamps
+        return self._block_event_timestamps_for_connectors((connector,) if connector else ())
 
-    def _finding_event_timestamps(self) -> list[datetime]:
-        """Timestamps of recent severity-bearing alert events."""
+    def _block_event_timestamps_for_connectors(self, connectors: Iterable[str] = ()) -> list[datetime]:
+        """Timestamps of recent block / deny / quarantine events for a roster scope."""
 
-        if self.alerts_model is None:
-            return []
         return [
             event.timestamp
-            for event in self.alerts_model.audit_events
+            for event in self._recent_block_events_for_connectors(connectors)
             if event.timestamp is not None
         ]
+
+    def _finding_event_timestamps(self, connector: str = "") -> list[datetime]:
+        """Timestamps of recent severity-bearing alert events."""
+
+        return self._finding_event_timestamps_for_connectors((connector,) if connector else ())
+
+    def _finding_event_timestamps_for_connectors(self, connectors: Iterable[str] = ()) -> list[datetime]:
+        """Timestamps of recent severity-bearing alert events for a roster scope."""
+
+        if self.alerts_model is None:
+            alert_events: list[Any] = []
+        else:
+            alert_events = list(self.alerts_model.audit_events)
+        scope = self._normalize_connector_scope(connectors)
+        since = self._session_start_for_connectors(scope)
+        stamps: list[datetime] = []
+        seen: set[tuple[str, ...]] = set()
+        for event in alert_events:
+            if (
+                event.timestamp is not None
+                and self._event_in_session(event, since)
+                and self._event_matches_connectors(event, scope)
+                and self._event_metric_severity_bucket(event) in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}
+            ):
+                stamps.append(event.timestamp)
+                seen.add(self._event_count_key(event))
+        for event in self._recent_connector_hook_events():
+            if not self._event_in_session(event, since):
+                continue
+            if not self._event_matches_connectors(event, scope):
+                continue
+            key = self._event_count_key(event)
+            if key in seen:
+                continue
+            if self._hook_decision(event) not in {"alert", "warn", "block"}:
+                continue
+            if self._event_metric_severity_bucket(event) not in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}:
+                continue
+            if event.timestamp is not None:
+                stamps.append(event.timestamp)
+                seen.add(key)
+        return stamps
 
     def _scan_event_timestamps(self) -> list[datetime]:
         """Timestamps of recent scan / finding audit events."""
 
         if self.audit_model is None:
             return []
+        since = self._session_start_for_connectors(tuple(self._active_connector_names()))
         stamps: list[datetime] = []
         for event in self.audit_model.items:
             action = (event.action or "").lower()
-            if ("scan" in action or "finding" in action) and event.timestamp is not None:
+            if (
+                ("scan" in action or "finding" in action)
+                and event.timestamp is not None
+                and self._event_in_session(event, since)
+            ):
                 stamps.append(event.timestamp)
         return stamps
 
@@ -4733,22 +5397,16 @@ class DefenseClawTUI(App[None]):
 
         return _event_histogram(timestamps, now=datetime.now(timezone.utc))
 
-    def _top_block_target(self) -> tuple[str, int]:
+    def _top_block_target(self, connector: str = "") -> tuple[str, int]:
         """Most-frequently blocked audit target across recent events."""
 
-        if self.audit_model is None:
-            return "", 0
+        return self._top_block_target_for_connectors((connector,) if connector else ())
+
+    def _top_block_target_for_connectors(self, connectors: Iterable[str] = ()) -> tuple[str, int]:
+        """Most-frequently blocked audit target for a connector roster scope."""
+
         blocked: dict[str, int] = {}
-        for event in self.audit_model.items[-200:]:
-            action = (event.action or "").lower()
-            details = (event.details or "").lower()
-            is_block = (
-                action in {"block", "guardrail-block", "deny", "quarantine"}
-                or "action=block" in details
-                or "action=deny" in details
-            )
-            if not is_block:
-                continue
+        for event in self._recent_block_events_for_connectors(connectors):
             target = (event.target or "").strip() or "(unknown)"
             blocked[target] = blocked.get(target, 0) + 1
         if not blocked:
@@ -4756,19 +5414,45 @@ class DefenseClawTUI(App[None]):
         top, count = max(blocked.items(), key=lambda kv: kv[1])
         return top, count
 
-    def _top_finding_target(self) -> tuple[str, str]:
+    def _top_finding_target(self, connector: str = "") -> tuple[str, str]:
         """Highest-severity recent alert's target + severity letter."""
 
-        if self.alerts_model is None:
-            return "", ""
+        return self._top_finding_target_for_connectors((connector,) if connector else ())
+
+    def _top_finding_target_for_connectors(self, connectors: Iterable[str] = ()) -> tuple[str, str]:
+        """Highest-severity recent alert target for a connector roster scope."""
+
+        alert_events: list[Any] = [] if self.alerts_model is None else list(self.alerts_model.audit_events[-200:])
+        scope = self._normalize_connector_scope(connectors)
+        since = self._session_start_for_connectors(scope)
         severity_rank = {"CRITICAL": 4, "HIGH": 3, "MEDIUM": 2, "LOW": 1}
         best: tuple[int, str, str] = (0, "", "")
-        for event in self.alerts_model.audit_events[-200:]:
-            rank = severity_rank.get((event.severity or "").upper(), 0)
+        seen: set[tuple[str, ...]] = set()
+
+        def consider(event: Any) -> None:
+            nonlocal best
+            if not self._event_in_session(event, since):
+                return
+            if not self._event_matches_connectors(event, scope):
+                return
+            severity = self._event_metric_severity_bucket(event)
+            rank = severity_rank.get(severity, 0)
             if rank <= best[0]:
-                continue
+                return
             target = (event.target or "").strip() or "(unknown)"
-            best = (rank, target, (event.severity or "").upper())
+            best = (rank, target, severity)
+
+        for event in alert_events:
+            seen.add(self._event_count_key(event))
+            consider(event)
+        for event in self._recent_connector_hook_events():
+            key = self._event_count_key(event)
+            if key in seen:
+                continue
+            if self._hook_decision(event) not in {"alert", "warn", "block"}:
+                continue
+            seen.add(key)
+            consider(event)
         return best[1], best[2]
 
     @staticmethod
@@ -5142,7 +5826,7 @@ class DefenseClawTUI(App[None]):
         doctor = self.overview_model.doctor_box()
         ai_box = self.overview_model.ai_discovery_box()
         cfg = self.overview_model.cfg
-        counts = self.overview_model.enforcement
+        counts = self._overview_session_enforcement_counts()
         health = self.overview_model.health
         state_by_key = {card.key: card.state or "unknown" for card in service_cards}
         detail_by_key = {card.key: card.detail or card.last_error for card in service_cards}
@@ -5155,6 +5839,10 @@ class DefenseClawTUI(App[None]):
             f"  Enterprise AI Governance  v{__version__}{uptime_suffix}",
             style=f"italic {TOKENS.text_secondary}",
         )
+        connector_chip = self._connector_chip_text()
+        connector_chip_block: list[RenderableType] = []
+        if connector_chip:
+            connector_chip_block = [Text.from_markup(connector_chip.rstrip()), Text("")]
 
         # Build the notice lines via ``Text.append`` rather than
         # ``Text.from_markup``: the icons (``[!]`` / ``[*]`` / ``[>]``)
@@ -5303,12 +5991,24 @@ class DefenseClawTUI(App[None]):
                 Text.from_markup(f"[{blocks_color} bold]{block_n}[/]"),
             )
         else:
+            calls_n, _hook_alert_n, block_n = self._enforcement_scope_breakdown(
+                self._active_connector_names()
+            )
             alerts_color = TOKENS.accent_red if counts.active_alerts else TOKENS.accent_green
             enf_table.add_row(
                 Text("Alerts", style=TOKENS.text_secondary),
                 Text.from_markup(
                     f"[{alerts_color} bold]{counts.active_alerts:<3}[/] {_mini_bar(counts.active_alerts, 20)}"
                 ),
+            )
+            enf_table.add_row(
+                Text("Hook calls", style=TOKENS.text_secondary),
+                Text.from_markup(f"[{TOKENS.accent_green}]{calls_n}[/]"),
+            )
+            blocks_color = TOKENS.accent_red if block_n else TOKENS.text_secondary
+            enf_table.add_row(
+                Text("Blocks", style=TOKENS.text_secondary),
+                Text.from_markup(f"[{blocks_color} bold]{block_n}[/]"),
             )
         if self.overview_model.silent_bypass > 0:
             enf_table.add_row(
@@ -5637,6 +6337,7 @@ class DefenseClawTUI(App[None]):
             banner,
             tagline,
             Text(""),
+            *connector_chip_block,
             *notice_block,
             Text(""),
             columns,
@@ -5647,6 +6348,13 @@ class DefenseClawTUI(App[None]):
             quick_text,
             footer_hint,
         )
+
+    def _overview_body_signature(self) -> tuple[object, ...]:
+        """Fingerprint Overview content without volatile clock-only labels."""
+
+        stable_text = re.sub(r"\buptime=\d+s\b", "uptime=<live>", self.body_text)
+        stable_text = re.sub(r"\b\d+[smhd] ago\b", "<live> ago", stable_text)
+        return ("overview", self.help_open, stable_text)
 
     def _overview_connectors_panel(
         self, rows: list[ConnectorOverviewRow]
@@ -5753,10 +6461,11 @@ class DefenseClawTUI(App[None]):
         doctor = self.overview_model.doctor_box()
         ai_box = self.overview_model.ai_discovery_box()
         cfg = self.overview_model.cfg
-        counts = self.overview_model.enforcement
+        counts = self._overview_session_enforcement_counts()
         state_by_key = {card.key: card.state or "unknown" for card in service_cards}
         detail_by_key = {card.key: card.detail or card.last_error for card in service_cards}
         health = self.overview_model.health
+        connector_chip = self._connector_chip_text()
 
         notice_lines = []
         for notice in notices[:3]:
@@ -5845,11 +6554,17 @@ class DefenseClawTUI(App[None]):
                 + scan_lines
             ).rstrip("\n")
         else:
+            calls_n, _hook_alert_n, block_n = self._enforcement_scope_breakdown(
+                self._active_connector_names()
+            )
             alert_color = TOKENS.accent_red if counts.active_alerts else TOKENS.accent_green
+            block_color = TOKENS.accent_red if block_n else TOKENS.text_secondary
             enforcement_text = (
                 f"  Active alerts    [{alert_color} bold]{counts.active_alerts}[/]   "
                 f"Total scans [{TOKENS.accent_green}]{counts.total_scans}[/]\n"
                 + silent_line
+                + f"  Hook calls       [{TOKENS.accent_green}]{calls_n}[/]   "
+                f"Blocks [{block_color} bold]{block_n}[/]\n"
                 + f"  Skills           [{TOKENS.accent_red}]{counts.blocked_skills}[/] blocked   "
                 f"[{TOKENS.accent_green}]{counts.allowed_skills}[/] allowed\n"
                 f"  MCPs             [{TOKENS.accent_red}]{counts.blocked_mcps}[/] blocked   "
@@ -5919,6 +6634,7 @@ class DefenseClawTUI(App[None]):
         return (
             "[bold #22D3EE]Overview[/]  [#9FB2CC]Command center for live risk, setup health, and next actions.[/]\n"
             f"[italic]DefenseClaw v{__version__}{uptime}[/]\n\n"
+            f"{connector_chip}"
             f"[bold {TOKENS.accent_green}]WHAT NEEDS ATTENTION[/]\n"
             + "\n".join(notice_lines)
             + "\n\n"
@@ -6374,8 +7090,17 @@ class DefenseClawTUI(App[None]):
     def _update_body_only(self) -> None:
         body_widget = self.query_one("#body", Static)
         if self.active_panel == "overview" and not self.help_open:
-            body_widget.update(self._overview_renderable())
-            self._last_body_signature = None
+            try:
+                current_scroll_y = self.query_one("#body-scroll", VerticalScroll).scroll_y
+            except NoMatches:
+                current_scroll_y = None
+            with self._connector_hook_event_render_cache():
+                renderable = self._overview_renderable()
+                body_signature = self._overview_body_signature()
+                if body_signature != self._last_body_signature:
+                    body_widget.update(renderable)
+                    self._last_body_signature = body_signature
+                self._overview_last_render_scroll_y = current_scroll_y
         else:
             # Same defense-in-depth as ``_render_chrome`` — any panel's
             # body string can contain malformed markup (the audit
@@ -6454,6 +7179,8 @@ class DefenseClawTUI(App[None]):
             if key == "m":
                 self.run_worker(self._open_mode_picker(), exclusive=False, thread=False)
                 return True
+            if self._scroll_overview_body(key):
+                return True
             # 8.13 drill-down: with a connector selected in the shared filter,
             # Enter jumps to that connector's Alerts (already pre-filtered).
             # With no selection in a multi-connector install, Enter opens the
@@ -6488,6 +7215,7 @@ class DefenseClawTUI(App[None]):
                 return True
             action = self._handle_inventory_key(key)
             return self._apply_inventory_action(action)
+
         if self.active_panel == "ai":
             action = self.ai_discovery_model.handle_key(_vim_key(key))
             return self._apply_ai_discovery_action(action)
@@ -6499,6 +7227,46 @@ class DefenseClawTUI(App[None]):
                 return self._apply_first_run_action(action)
             action = self._handle_setup_key(_vim_key(key))
             return self._apply_setup_action(action)
+        return False
+
+    def _scroll_overview_body(self, key: str) -> bool:
+        """Handle fast keyboard scrolling for the dense Overview dashboard."""
+
+        if self.active_panel != "overview" or self.help_open or len(self.screen_stack) > 1:
+            return False
+        key = key.lower()
+        scroll_line_keys = {"down", "j"}
+        scroll_up_keys = {"up", "k"}
+        page_down_keys = {"pagedown", "page_down", "ctrl+f"}
+        page_up_keys = {"pageup", "page_up", "ctrl+b"}
+        try:
+            scroller = self.query_one("#body-scroll", VerticalScroll)
+        except NoMatches:
+            return False
+        if key in scroll_line_keys:
+            self._mark_overview_scroll_activity()
+            scroller.scroll_relative(y=6, animate=False, immediate=True)
+            return True
+        if key in scroll_up_keys:
+            self._mark_overview_scroll_activity()
+            scroller.scroll_relative(y=-6, animate=False, immediate=True)
+            return True
+        if key in page_down_keys:
+            self._mark_overview_scroll_activity()
+            scroller.scroll_page_down(animate=False)
+            return True
+        if key in page_up_keys:
+            self._mark_overview_scroll_activity()
+            scroller.scroll_page_up(animate=False)
+            return True
+        if key == "home":
+            self._mark_overview_scroll_activity()
+            scroller.scroll_to(y=0, animate=False, immediate=True)
+            return True
+        if key == "end":
+            self._mark_overview_scroll_activity()
+            scroller.scroll_to(y=scroller.max_scroll_y, animate=False, immediate=True)
+            return True
         return False
 
     def _apply_alert_action(self, action: AlertPanelAction) -> bool:
@@ -9026,6 +9794,10 @@ def _coerce_int(value: Any) -> int:
         return 0
 
 
+def _coerce_nonnegative_int(value: Any) -> int:
+    return max(_coerce_int(value), 0)
+
+
 def _subsystem_from_mapping(raw: Any) -> SubsystemHealth:
     """Build a SubsystemHealth from a permissive dict payload.
 
@@ -9239,6 +10011,13 @@ def _severity_breakdown_markup(critical: int, high: int, medium: int, low: int) 
             cell("L", low, TOKENS.accent_blue),
         )
     )
+
+
+def _metric_severity_bucket(severity: str) -> str:
+    normalized = (severity or "").strip().upper()
+    if normalized == "WARNING":
+        return "MEDIUM"
+    return normalized
 
 
 def _metric_trend(value: int, *, invert: bool = False) -> tuple[float, ...]:

--- a/cli/defenseclaw/tui/app.py
+++ b/cli/defenseclaw/tui/app.py
@@ -767,9 +767,20 @@ class DefenseClawTUI(App[None]):
         # single frame so keypresses don't wait behind repeated SQLite reads.
         self._connector_hook_event_cache_enabled = False
         self._recent_connector_hook_events_cache: list[Any] | None = None
+        self._recent_connector_hook_scope_cache: dict[tuple[tuple[str, ...], str], dict[str, Any]] = {}
+        self._hook_event_connector_cache: dict[int, str] = {}
+        self._hook_event_decision_cache: dict[int, str] = {}
+        self._hook_event_severity_cache: dict[int, str] = {}
+        self._overview_metric_data_render_cache: tuple[MetricDatum, ...] | None = None
+        self._overview_connector_rows_render_cache: list[ConnectorOverviewRow] | None = None
+        self._overview_session_enforcement_counts_render_cache: EnforcementCounts | None = None
         self._connector_hook_event_stats_cache: dict[str, dict[str, Any]] | None = None
+        self._connector_hook_event_stats_loaded_at: float = 0.0
         self._overview_last_render_scroll_y: float | None = None
         self._overview_last_scroll_activity_at: float = 0.0
+        self._overview_deferred_render_token: int = 0
+        self._overview_sampled_refresh_scheduled = False
+        self._overview_connector_rows_signature_cache: tuple[object, ...] | None = None
         # Set while ``_render_panel_table`` programmatically restores the
         # DataTable cursor. Textual fires ``RowHighlighted`` for that move just
         # like a real keypress, and the handler would call the model's
@@ -834,6 +845,7 @@ class DefenseClawTUI(App[None]):
                 yield Button("?", id="help-button", compact=True, tooltip="Open help")
             with Vertical(id="body-panel"):
                 yield OverviewMetrics(self._overview_metric_data(), id="overview-metrics", classes="hidden")
+                yield Static("", id="overview-scope", classes="hidden")
                 with VerticalScroll(id="body-scroll"):
                     yield _BodyStatic("", id="body")
                 with Horizontal(id="overview-controls", classes="panel-controls hidden"):
@@ -1486,6 +1498,48 @@ class DefenseClawTUI(App[None]):
         if not self._overview_last_scroll_activity_at:
             return False
         return monotonic() - self._overview_last_scroll_activity_at < 0.45
+
+    def _overview_scroll_reading_active(self) -> bool:
+        """True while Overview scroll position should not be disturbed."""
+
+        if self.active_panel != "overview" or self.help_open or len(self.screen_stack) > 1:
+            return False
+        if self._overview_scroll_activity_recent():
+            return True
+        try:
+            scroller = self.query_one("#body-scroll", VerticalScroll)
+        except Exception:  # noqa: BLE001 - timer may fire while widgets settle.
+            return False
+        return float(scroller.scroll_y) > 0.0
+
+    def _overview_sampled_refresh_allowed(self, *, allow_scrolled: bool = False) -> bool:
+        """True when a passive sampled Overview repaint should run."""
+
+        if self.active_panel != "overview" or self.help_open or len(self.screen_stack) > 1:
+            return False
+        if self._overview_scroll_activity_recent():
+            return False
+        try:
+            scroller = self.query_one("#body-scroll", VerticalScroll)
+        except Exception:  # noqa: BLE001 - timer may fire while widgets settle.
+            return False
+        return allow_scrolled or float(scroller.scroll_y) <= 0.0
+
+    def _restore_overview_scroll(
+        self,
+        scroller: VerticalScroll | None,
+        scroll_y: float | None,
+    ) -> float | None:
+        """Keep Overview scroll stable across body relayouts."""
+
+        if scroller is None or scroll_y is None:
+            return scroll_y
+        target = max(0.0, min(float(scroll_y), float(scroller.max_scroll_y)))
+        try:
+            scroller.scroll_to(y=target, animate=False, immediate=True)
+        except Exception:  # noqa: BLE001 - scroll restoration is best-effort.
+            return scroll_y
+        return target
 
     def _panel_hidden(self, panel: str) -> bool:
         """Return True if ``panel`` should be hidden from tabs + cycling.
@@ -2446,6 +2500,7 @@ class DefenseClawTUI(App[None]):
         except NoMatches:
             return
         activity.set_class(self.active_panel != "activity", "hidden")
+        self._render_overview_scope_indicator()
         # The Overview body can exceed the viewport (metric tiles + notices +
         # SERVICES/CONFIG/ENFORCEMENT/SCANNERS + the CONNECTORS roster), so let
         # its wrapper scroll. DataTable panels keep #body as a short, auto-sized
@@ -2466,7 +2521,10 @@ class DefenseClawTUI(App[None]):
                 and self._last_body_signature is not None
             )
             wheel_active = self._overview_scroll_activity_recent() and self._last_body_signature is not None
-            if scrolling_now or wheel_active:
+            connector_rows_changed = (
+                False if wheel_active else self._overview_connector_rows_changed_since_render()
+            )
+            if (scrolling_now or wheel_active) and not connector_rows_changed:
                 self._overview_last_render_scroll_y = current_scroll_y
                 self._table_columns = ()
                 self._table_rows = ()
@@ -2474,9 +2532,17 @@ class DefenseClawTUI(App[None]):
                 with self._connector_hook_event_render_cache():
                     renderable = self._overview_renderable()
                     body_signature = self._overview_body_signature()
-                    if body_signature != self._last_body_signature:
+                    connector_rows_signature = self._overview_connector_rows_signature()
+                    if (
+                        body_signature != self._last_body_signature
+                        or connector_rows_signature != self._overview_connector_rows_signature_cache
+                    ):
                         body_widget.update(renderable)
                         self._last_body_signature = body_signature
+                        self._overview_connector_rows_signature_cache = connector_rows_signature
+                        current_scroll_y = self._restore_overview_scroll(
+                            body_scroller, current_scroll_y
+                        )
                     self._overview_last_render_scroll_y = current_scroll_y
                     # Overview has no DataTable of its own and skips _body_text()
                     # (the only place these are reset), so clear the panel-table
@@ -2826,11 +2892,35 @@ class DefenseClawTUI(App[None]):
         return f"backend=textual  panel={self.active_panel}  hints=: command | ? help | q local close | Ctrl+C quit"
 
     def _render_native_widgets(self) -> None:
-        metrics = self.query_one("#overview-metrics", OverviewMetrics)
+        self._render_overview_metrics()
+
+    def _render_overview_metrics(self) -> None:
+        """Refresh only the native Overview metric tiles."""
+
+        try:
+            metrics = self.query_one("#overview-metrics", OverviewMetrics)
+        except NoMatches:
+            return
         overview_visible = self.active_panel == "overview" and not self.help_open
         metrics.set_class(not overview_visible, "hidden")
         if overview_visible:
-            metrics.refresh_metrics(self._overview_metric_data())
+            if self._connector_hook_event_cache_enabled:
+                metric_data = self._overview_metric_data()
+            else:
+                with self._connector_hook_event_render_cache():
+                    metric_data = self._overview_metric_data()
+            metrics.refresh_metrics(metric_data)
+
+    def _render_overview_scope_indicator(self) -> None:
+        try:
+            scope = self.query_one("#overview-scope", Static)
+        except NoMatches:
+            return
+        overview_visible = self.active_panel == "overview" and not self.help_open
+        text = self._overview_connector_scope_text().strip() if overview_visible else ""
+        scope.set_class(not bool(text), "hidden")
+        if text:
+            scope.update(self._safe_body_renderable(text))
 
     def _render_panel_controls(self) -> None:
         overview = self.query_one("#overview-controls", Horizontal)
@@ -3947,6 +4037,12 @@ class DefenseClawTUI(App[None]):
         generic alert / scan / guardrail / agent set.
         """
 
+        if (
+            self._connector_hook_event_cache_enabled
+            and self._overview_metric_data_render_cache is not None
+        ):
+            return self._overview_metric_data_render_cache
+
         counts = self._overview_session_enforcement_counts()
         state_by_key = {
             card.key: card.state.strip().lower()
@@ -4030,15 +4126,23 @@ class DefenseClawTUI(App[None]):
             allow_count, alert_count, block_decisions, top_hook = self._connector_hook_breakdown_for_connectors(
                 scope_connectors, since=session_since
             )
-            total_allow, total_alert, total_block, _total_newest = self._connector_hook_stats_for_connectors(scope_connectors)
-            fleet_total_allow, fleet_total_alert, fleet_total_block, _fleet_total_newest = self._connector_hook_stats_for_connectors()
+            history_ready = health is not None
             live_hook_calls, live_blocks_value, has_live_hook_counts = self._connector_live_counts_for_connectors(scope_connectors)
             fleet_live_hook_calls, fleet_live_blocks_value, has_fleet_live_hook_counts = self._connector_live_counts_for_connectors(())
+            if history_ready and not has_live_hook_counts:
+                total_allow, total_alert, total_block, _total_newest = self._connector_hook_stats_for_connectors(scope_connectors)
+            else:
+                total_allow = total_alert = total_block = 0
+            if history_ready and not has_fleet_live_hook_counts:
+                fleet_total_allow, fleet_total_alert, fleet_total_block, _fleet_total_newest = self._connector_hook_stats_for_connectors()
+            else:
+                fleet_total_allow = fleet_total_alert = fleet_total_block = 0
 
             # Prefer the gateway's live per-connector request counters when
-            # available. Older gateways did not expose the connector array, so
-            # fall back to grouped audit totals and finally the recent hook
-            # window used by the trend sparkline.
+            # available. Older gateways did not expose the connector array,
+            # so after /health has loaded fall back to grouped audit totals.
+            # Before the first health poll, avoid flashing all-time history in
+            # the header; use the bounded recent window instead.
             hook_timestamps = self._hook_event_timestamps_for_connectors(scope_connectors)
             total_hook_calls = total_allow + total_alert + total_block
             fleet_total_hook_calls = fleet_total_allow + fleet_total_alert + fleet_total_block
@@ -4162,7 +4266,7 @@ class DefenseClawTUI(App[None]):
             elif outside_roster_findings:
                 findings_detail = f"{findings_detail} · outside roster {outside_roster_findings}"
 
-            return (
+            metrics = (
                 MetricDatum(
                     key="hook_calls",
                     label=hook_calls_label,
@@ -4205,8 +4309,11 @@ class DefenseClawTUI(App[None]):
                     value_text=guardrail_value_text,
                 ),
             )
+            if self._connector_hook_event_cache_enabled:
+                self._overview_metric_data_render_cache = metrics
+            return metrics
 
-        return (
+        metrics = (
             MetricDatum(
                 key="risk",
                 label="Alert Risk",
@@ -4252,21 +4359,42 @@ class DefenseClawTUI(App[None]):
                 target_panel="ai",
             ),
         )
+        if self._connector_hook_event_cache_enabled:
+            self._overview_metric_data_render_cache = metrics
+        return metrics
 
     @contextmanager
     def _connector_hook_event_render_cache(self):
         previous_enabled = self._connector_hook_event_cache_enabled
         previous_cache = self._recent_connector_hook_events_cache
-        previous_stats_cache = self._connector_hook_event_stats_cache
+        previous_scope_cache = self._recent_connector_hook_scope_cache
+        previous_connector_cache = self._hook_event_connector_cache
+        previous_decision_cache = self._hook_event_decision_cache
+        previous_severity_cache = self._hook_event_severity_cache
+        previous_metrics_cache = self._overview_metric_data_render_cache
+        previous_rows_cache = self._overview_connector_rows_render_cache
+        previous_counts_cache = self._overview_session_enforcement_counts_render_cache
         self._connector_hook_event_cache_enabled = True
         self._recent_connector_hook_events_cache = None
-        self._connector_hook_event_stats_cache = None
+        self._recent_connector_hook_scope_cache = {}
+        self._hook_event_connector_cache = {}
+        self._hook_event_decision_cache = {}
+        self._hook_event_severity_cache = {}
+        self._overview_metric_data_render_cache = None
+        self._overview_connector_rows_render_cache = None
+        self._overview_session_enforcement_counts_render_cache = None
         try:
             yield
         finally:
             self._connector_hook_event_cache_enabled = previous_enabled
             self._recent_connector_hook_events_cache = previous_cache
-            self._connector_hook_event_stats_cache = previous_stats_cache
+            self._recent_connector_hook_scope_cache = previous_scope_cache
+            self._hook_event_connector_cache = previous_connector_cache
+            self._hook_event_decision_cache = previous_decision_cache
+            self._hook_event_severity_cache = previous_severity_cache
+            self._overview_metric_data_render_cache = previous_metrics_cache
+            self._overview_connector_rows_render_cache = previous_rows_cache
+            self._overview_session_enforcement_counts_render_cache = previous_counts_cache
 
     def _connector_health_for_metric(self, connector: str, *, use_single: bool) -> Any | None:
         """Live health row for a metric's connector scope."""
@@ -4363,6 +4491,12 @@ class DefenseClawTUI(App[None]):
     def _overview_session_enforcement_counts(self) -> EnforcementCounts:
         """Overview counts using the active gateway/session where possible."""
 
+        if (
+            self._connector_hook_event_cache_enabled
+            and self._overview_session_enforcement_counts_render_cache is not None
+        ):
+            return self._overview_session_enforcement_counts_render_cache
+
         current = self.overview_model.enforcement
         scope = tuple(self._active_connector_names())
         session_start = self._session_start_for_connectors(scope)
@@ -4374,7 +4508,7 @@ class DefenseClawTUI(App[None]):
                 total_scans = int(loader(session_start))
             except Exception:  # noqa: BLE001 - retain the last known count.
                 total_scans = current.total_scans
-        return EnforcementCounts(
+        counts = EnforcementCounts(
             blocked_skills=current.blocked_skills,
             allowed_skills=current.allowed_skills,
             blocked_mcps=current.blocked_mcps,
@@ -4382,6 +4516,9 @@ class DefenseClawTUI(App[None]):
             total_scans=total_scans,
             active_alerts=self._session_alert_count_for_connectors(scope),
         )
+        if self._connector_hook_event_cache_enabled:
+            self._overview_session_enforcement_counts_render_cache = counts
+        return counts
 
     def _session_alert_count_for_connectors(self, connectors: Iterable[str] = ()) -> int:
         """Count current-session alert decisions for an Overview connector scope."""
@@ -4397,18 +4534,15 @@ class DefenseClawTUI(App[None]):
                 event = row.event
                 if not self._event_in_session(event, since):
                     continue
-                if not self._event_matches_connectors(event, scope):
+                if not self._cached_event_matches_scope(event, scope):
                     continue
-                bucket = self._event_metric_severity_bucket(event)
+                bucket = self._cached_event_metric_severity_bucket(event)
                 if bucket in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}:
                     seen.add(self._event_count_key(event))
 
-        for event in self._recent_connector_hook_events():
-            if not self._event_in_session(event, since):
-                continue
-            if not self._event_matches_connectors(event, scope):
-                continue
-            if self._hook_decision(event) in {"alert", "warn"}:
+        summary = self._recent_hook_scope_summary(scope, since=since)
+        if summary["alert"]:
+            for event in summary["alert_events"]:
                 seen.add(self._event_count_key(event))
 
         return len(seen)
@@ -4457,23 +4591,17 @@ class DefenseClawTUI(App[None]):
                     continue
                 if not self._event_in_session(row.event, since):
                     continue
-                if not self._event_matches_connectors(row.event, scope):
+                if not self._cached_event_matches_scope(row.event, scope):
                     continue
-                bucket = self._event_metric_severity_bucket(row.event)
+                bucket = self._cached_event_metric_severity_bucket(row.event)
                 if bucket in counts:
                     seen.add(self._event_count_key(row.event))
                     counts[bucket] += 1
-        for event in self._recent_connector_hook_events():
-            if not self._event_in_session(event, since):
-                continue
-            if not self._event_matches_connectors(event, scope):
-                continue
+        for event in self._recent_hook_scope_summary(scope, since=since)["finding_events"]:
             key = self._event_count_key(event)
             if key in seen:
                 continue
-            if self._hook_decision(event) not in {"alert", "warn", "block"}:
-                continue
-            bucket = self._event_metric_severity_bucket(event)
+            bucket = self._cached_event_metric_severity_bucket(event)
             if bucket in counts:
                 seen.add(key)
                 counts[bucket] += 1
@@ -4485,6 +4613,14 @@ class DefenseClawTUI(App[None]):
 
     @staticmethod
     def _event_connector(event: Any) -> str:
+        connector = str(getattr(event, "connector", "") or "").strip().lower()
+        if connector:
+            return connector
+        structured = getattr(event, "structured", None)
+        if isinstance(structured, dict):
+            connector = str(structured.get("connector") or "").strip().lower()
+            if connector:
+                return connector
         return _parse_kv_details(getattr(event, "details", "") or "").get("connector", "").strip().lower()
 
     @staticmethod
@@ -4493,6 +4629,11 @@ class DefenseClawTUI(App[None]):
         if bucket in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}:
             return bucket
         if str(getattr(event, "action", "") or "").strip().lower() == "connector-hook":
+            structured = getattr(event, "structured", None)
+            if isinstance(structured, dict):
+                structured_bucket = _metric_severity_bucket(str(structured.get("severity") or ""))
+                if structured_bucket in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}:
+                    return structured_bucket
             detail_bucket = _metric_severity_bucket(
                 _parse_kv_details(getattr(event, "details", "") or "").get("severity", "")
             )
@@ -4512,13 +4653,54 @@ class DefenseClawTUI(App[None]):
         got = DefenseClawTUI._event_connector(event)
         return bool(got) and any(want in got for want in scope)
 
+    def _cached_event_connector(self, event: Any) -> str:
+        if not self._connector_hook_event_cache_enabled:
+            return self._event_connector(event)
+        key = id(event)
+        if key not in self._hook_event_connector_cache:
+            self._hook_event_connector_cache[key] = self._event_connector(event)
+        return self._hook_event_connector_cache[key]
+
+    def _cached_event_metric_severity_bucket(self, event: Any) -> str:
+        if not self._connector_hook_event_cache_enabled:
+            return self._event_metric_severity_bucket(event)
+        key = id(event)
+        if key not in self._hook_event_severity_cache:
+            self._hook_event_severity_cache[key] = self._event_metric_severity_bucket(event)
+        return self._hook_event_severity_cache[key]
+
+    def _cached_hook_decision(self, event: Any) -> str:
+        if not self._connector_hook_event_cache_enabled:
+            return self._hook_decision(event)
+        key = id(event)
+        if key not in self._hook_event_decision_cache:
+            self._hook_event_decision_cache[key] = self._hook_decision(event)
+        return self._hook_event_decision_cache[key]
+
+    def _cached_event_matches_scope(self, event: Any, scope: Iterable[str]) -> bool:
+        normalized = self._normalize_connector_scope(scope)
+        if not normalized:
+            return True
+        got = self._cached_event_connector(event)
+        return bool(got) and any(want in got for want in normalized)
+
     @staticmethod
     def _hook_decision(event: Any) -> str:
         details = _parse_kv_details(getattr(event, "details", "") or "")
-        action = details.get("action", "").strip().lower()
-        raw_action = details.get("raw_action", "").strip().lower()
-        mode = details.get("mode", "").strip().lower()
-        would_block = details.get("would_block", "").strip().lower() == "true"
+        structured = getattr(event, "structured", None)
+        if isinstance(structured, dict):
+            action = str(structured.get("action") or details.get("action", "")).strip().lower()
+            raw_action = str(structured.get("raw_action") or details.get("raw_action", "")).strip().lower()
+            mode = str(structured.get("mode") or details.get("mode", "")).strip().lower()
+            if "would_block" in structured:
+                would_block = bool(structured.get("would_block"))
+            else:
+                would_block = details.get("would_block", "").strip().lower() == "true"
+        else:
+            action = details.get("action", "").strip().lower()
+            raw_action = details.get("raw_action", "").strip().lower()
+            mode = details.get("mode", "").strip().lower()
+            would_block = details.get("would_block", "").strip().lower() == "true"
 
         if action in {"block", "deny"}:
             return "block"
@@ -4540,7 +4722,11 @@ class DefenseClawTUI(App[None]):
         500 rows also include two old rows from another connector.
         """
 
-        if self._connector_hook_event_cache_enabled and self._connector_hook_event_stats_cache is not None:
+        stats_ttl_seconds = 1.5
+        if (
+            self._connector_hook_event_stats_cache is not None
+            and monotonic() - self._connector_hook_event_stats_loaded_at < stats_ttl_seconds
+        ):
             return self._connector_hook_event_stats_cache
         stats: dict[str, dict[str, Any]] = {}
         store = getattr(self.audit_model, "store", None) if self.audit_model is not None else None
@@ -4581,8 +4767,8 @@ class DefenseClawTUI(App[None]):
                     newest = entry.get("newest")
                     if newest is None or ts > newest:
                         entry["newest"] = ts
-        if self._connector_hook_event_cache_enabled:
-            self._connector_hook_event_stats_cache = stats
+        self._connector_hook_event_stats_cache = stats
+        self._connector_hook_event_stats_loaded_at = monotonic()
         return stats
 
     def _connector_hook_stats_for_connectors(
@@ -4606,6 +4792,70 @@ class DefenseClawTUI(App[None]):
             if isinstance(ts, datetime) and (newest is None or ts > newest):
                 newest = ts
         return allow, alert, block, newest
+
+    def _recent_hook_scope_summary(
+        self,
+        connectors: Iterable[str] = (),
+        *,
+        since: datetime | None = None,
+    ) -> dict[str, Any]:
+        """One-pass summary of recent connector-hook rows for an Overview scope."""
+
+        scope = self._normalize_connector_scope(connectors)
+        since_key = since.isoformat() if isinstance(since, datetime) else ""
+        cache_key = (scope, since_key)
+        if self._connector_hook_event_cache_enabled:
+            cached = self._recent_connector_hook_scope_cache.get(cache_key)
+            if cached is not None:
+                return cached
+
+        allow = alert = block = 0
+        events_by_target: dict[str, int] = {}
+        hook_timestamps: list[datetime] = []
+        alert_events: list[Any] = []
+        block_events: list[Any] = []
+        finding_events: list[Any] = []
+        for event in self._recent_connector_hook_events():
+            if not self._event_in_session(event, since):
+                continue
+            if not self._cached_event_matches_scope(event, scope):
+                continue
+            ts = getattr(event, "timestamp", None)
+            if isinstance(ts, datetime):
+                hook_timestamps.append(ts)
+            decision = self._cached_hook_decision(event)
+            if decision == "allow":
+                allow += 1
+            elif decision in {"alert", "warn"}:
+                alert += 1
+                alert_events.append(event)
+            elif decision in {"block", "deny"}:
+                block += 1
+                block_events.append(event)
+            target = (getattr(event, "target", "") or "").strip()
+            if target:
+                events_by_target[target] = events_by_target.get(target, 0) + 1
+            if decision in {"alert", "warn", "block"}:
+                bucket = self._cached_event_metric_severity_bucket(event)
+                if bucket in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}:
+                    finding_events.append(event)
+
+        top_event = ""
+        if events_by_target:
+            top_event, _count = max(events_by_target.items(), key=lambda kv: kv[1])
+        summary = {
+            "allow": allow,
+            "alert": alert,
+            "block": block,
+            "top_event": top_event,
+            "hook_timestamps": hook_timestamps,
+            "alert_events": alert_events,
+            "block_events": block_events,
+            "finding_events": finding_events,
+        }
+        if self._connector_hook_event_cache_enabled:
+            self._recent_connector_hook_scope_cache[cache_key] = summary
+        return summary
 
     @staticmethod
     def _is_block_event(event: Any) -> bool:
@@ -4698,37 +4948,13 @@ class DefenseClawTUI(App[None]):
     ) -> tuple[int, int, int, str]:
         """Hook decision breakdown for a connector roster scope."""
 
-        allow = alert = block = 0
-        events_by_target: dict[str, int] = {}
-        events = self._recent_connector_hook_events()
-        if not events:
-            return 0, 0, 0, ""
-        scope = self._normalize_connector_scope(connectors)
-        for event in events:
-            if since is not None:
-                ts = getattr(event, "timestamp", None)
-                if not isinstance(ts, datetime):
-                    continue
-                if ts.tzinfo is None:
-                    ts = ts.replace(tzinfo=timezone.utc)
-                if ts < since:
-                    continue
-            if not self._event_matches_connectors(event, scope):
-                continue
-            decision = self._hook_decision(event)
-            if decision == "allow":
-                allow += 1
-            elif decision == "alert" or decision == "warn":
-                alert += 1
-            elif decision in {"block", "deny"}:
-                block += 1
-            target = (event.target or "").strip()
-            if target:
-                events_by_target[target] = events_by_target.get(target, 0) + 1
-        top_event = ""
-        if events_by_target:
-            top_event, _ = max(events_by_target.items(), key=lambda kv: kv[1])
-        return allow, alert, block, top_event
+        summary = self._recent_hook_scope_summary(connectors, since=since)
+        return (
+            int(summary["allow"]),
+            int(summary["alert"]),
+            int(summary["block"]),
+            str(summary["top_event"]),
+        )
 
     def _enforcement_connector_breakdown(self, connector: str) -> tuple[int, int, int]:
         """``(calls, alerts, blocks)`` for ``connector`` from the hook stream.
@@ -4906,7 +5132,7 @@ class DefenseClawTUI(App[None]):
             self.connector_filter, self._active_connector_names()
         )
 
-    def _set_connector_filter(self, connector: str) -> None:
+    def _set_connector_filter(self, connector: str, *, defer_overview: bool = False) -> None:
         """Set the shared connector filter to ``connector`` (``""`` = All).
 
         8.13 pass 2: the catalog/inventory panels load *every* active connector
@@ -4948,6 +5174,11 @@ class DefenseClawTUI(App[None]):
         # model filters during render, and hidden panels sync when opened.
         # Eagerly refiltering Logs/Audit/catalog data here made an Overview
         # chip click pay for every table in the app.
+        if defer_overview and self.active_panel == "overview" and not self.help_open:
+            self._render_overview_scope_indicator()
+            self._render_overview_metrics()
+            self._schedule_overview_deferred_render()
+            return
         self._render_chrome()
 
     def _sync_catalog_connector_filters(self) -> None:
@@ -5026,6 +5257,66 @@ class DefenseClawTUI(App[None]):
             f"[{TOKENS.text_secondary}]Connector:[/] {chip}  "
             f"[{TOKENS.text_muted}](press [bold]m[/] to filter)[/]\n\n"
         )
+
+    def _overview_connector_scope_text(self) -> str:
+        """Compact Overview connector scope label.
+
+        Overview is the expensive dashboard path, so it avoids the full
+        clickable connector chip used by table panes. Operators can still
+        change scope with ``m``, which opens the connector picker.
+        """
+
+        self._chip_click_segments = []
+        if len(self._active_connector_names()) <= 1:
+            return ""
+        selected = self._connector_filter()
+        label = (
+            f"{friendly_connector_name(selected)} ({selected})"
+            if selected
+            else "All connectors"
+        )
+        return (
+            f"[{TOKENS.text_secondary}]Connector scope:[/] "
+            f"[{TOKENS.accent_cyan} bold]{rich_escape(label)}[/]  "
+            f"[{TOKENS.text_muted}](press [bold]m[/] to switch)[/]\n\n"
+        )
+
+    def _schedule_overview_deferred_render(self) -> None:
+        """Debounce expensive Overview repaints after connector-scope changes."""
+
+        self._overview_deferred_render_token += 1
+        token = self._overview_deferred_render_token
+
+        def render_if_current() -> None:
+            if token != self._overview_deferred_render_token:
+                return
+            if self.active_panel != "overview" or self.help_open or len(self.screen_stack) > 1:
+                return
+            self._render_chrome()
+
+        self.set_timer(0.2, render_if_current)
+
+    def _schedule_overview_sampled_refresh(
+        self,
+        *,
+        delay: float = 0.25,
+        allow_scrolled: bool = False,
+    ) -> None:
+        """Refresh Overview on an interval without colliding with interaction."""
+
+        if self._overview_sampled_refresh_scheduled:
+            return
+        if not self._overview_sampled_refresh_allowed(allow_scrolled=allow_scrolled):
+            return
+        self._overview_sampled_refresh_scheduled = True
+
+        def refresh_if_still_allowed() -> None:
+            self._overview_sampled_refresh_scheduled = False
+            if not self._overview_sampled_refresh_allowed(allow_scrolled=allow_scrolled):
+                return
+            self._render_chrome()
+
+        self.set_timer(delay, refresh_if_still_allowed)
 
     def _handle_body_chip_click(self, x: int, y: int) -> bool:
         """Resolve a click on the ``#body`` Static to a connector chip action.
@@ -5142,18 +5433,19 @@ class DefenseClawTUI(App[None]):
                     out[conn.name.strip().lower()] = (conn.state or "").strip()
         return out
 
-    def _connector_last_activity(self, connector: str) -> datetime | None:
+    def _connector_last_activity(self, connector: str, *, use_stats: bool = True) -> datetime | None:
         """Most recent audit-event timestamp attributed to ``connector``."""
 
         want = connector.strip().lower()
-        stats_newest = self._connector_hook_event_stats().get(want, {}).get("newest")
-        if isinstance(stats_newest, datetime):
-            return stats_newest
+        if use_stats and self.overview_model.health is not None:
+            stats_newest = self._connector_hook_event_stats().get(want, {}).get("newest")
+            if isinstance(stats_newest, datetime):
+                return stats_newest
         latest: datetime | None = None
         for event in self._recent_connector_hook_events():
             if event.timestamp is None:
                 continue
-            attributed = _parse_kv_details(event.details or "").get("connector", "").strip().lower()
+            attributed = self._cached_event_connector(event)
             if attributed != want:
                 continue
             if latest is None or event.timestamp > latest:
@@ -5169,9 +5461,18 @@ class DefenseClawTUI(App[None]):
         the audit store. Empty for single-connector installs.
         """
 
+        if (
+            self._connector_hook_event_cache_enabled
+            and self._overview_connector_rows_render_cache is not None
+        ):
+            return self._overview_connector_rows_render_cache
+
         cfg = self.overview_model.cfg
         if cfg is None or len(cfg.connector_modes) <= 1:
-            return []
+            rows: list[ConnectorOverviewRow] = []
+            if self._connector_hook_event_cache_enabled:
+                self._overview_connector_rows_render_cache = rows
+            return rows
         packs = dict(cfg.connector_packs)
         status_map = self._connector_status_map()
         # Fallback status when the gateway doesn't expose connectors[] yet:
@@ -5185,7 +5486,8 @@ class DefenseClawTUI(App[None]):
             if not connector:
                 continue
             health_row = self._connector_health_for_metric(connector, use_single=False)
-            if health_row is not None and self._connector_health_has_live_window(health_row):
+            health_has_live_window = health_row is not None and self._connector_health_has_live_window(health_row)
+            if health_has_live_window:
                 calls = _coerce_nonnegative_int(getattr(health_row, "requests", 0))
                 blocks = (
                     _coerce_nonnegative_int(getattr(health_row, "tool_blocks", 0))
@@ -5198,9 +5500,12 @@ class DefenseClawTUI(App[None]):
                 if blocks == 0:
                     blocks = audit_blocks
             else:
-                allow, alerts, blocks, _newest = self._connector_hook_stats_for_connectors((connector,))
+                if self.overview_model.health is None:
+                    allow, alerts, blocks, _top = self._connector_hook_breakdown_for_connectors((connector,))
+                else:
+                    allow, alerts, blocks, _newest = self._connector_hook_stats_for_connectors((connector,))
                 calls = allow + alerts + blocks
-            last = self._connector_last_activity(connector)
+            last = self._connector_last_activity(connector, use_stats=not health_has_live_window)
             # A guardrail-disabled connector keeps its historical counts (so
             # the row still tells the story) but its STATUS is forced to
             # "disabled" — the gateway drops it from connectors[], so without
@@ -5222,7 +5527,49 @@ class DefenseClawTUI(App[None]):
                     status=status,
                 )
             )
+        if self._connector_hook_event_cache_enabled:
+            self._overview_connector_rows_render_cache = rows
         return rows
+
+    def _overview_connector_rows_signature(self) -> tuple[object, ...]:
+        """Stable fingerprint for real CONNECTORS table data changes."""
+
+        def activity_bucket(label: str) -> str:
+            text = (label or "").strip()
+            if not text or text == "—":
+                return "none"
+            if re.fullmatch(r"\d+(?:s|m|h|d) ago", text):
+                return "active"
+            return text
+
+        rows = self._overview_connector_rows()
+        return tuple(
+            (
+                row.connector,
+                row.mode,
+                row.rule_pack,
+                activity_bucket(row.last_activity),
+                row.calls,
+                row.blocks,
+                row.alerts,
+                row.status,
+            )
+            for row in rows
+        )
+
+    def _overview_connector_rows_changed_since_render(self) -> bool:
+        """True when the lower CONNECTORS table has new non-clock data."""
+
+        if self._connector_hook_event_cache_enabled:
+            signature = self._overview_connector_rows_signature()
+        else:
+            with self._connector_hook_event_render_cache():
+                signature = self._overview_connector_rows_signature()
+        changed = signature != self._overview_connector_rows_signature_cache
+        if changed:
+            self._connector_hook_event_stats_cache = None
+            self._connector_hook_event_stats_loaded_at = 0.0
+        return changed
 
     def _hook_event_timestamps(self, connector: str = "") -> list[datetime]:
         """Timestamps of recent connector-hook audit events.
@@ -5240,12 +5587,7 @@ class DefenseClawTUI(App[None]):
     def _hook_event_timestamps_for_connectors(self, connectors: Iterable[str] = ()) -> list[datetime]:
         """Timestamps of recent connector-hook audit events for a roster scope."""
 
-        scope = self._normalize_connector_scope(connectors)
-        return [
-            event.timestamp
-            for event in self._recent_connector_hook_events()
-            if event.timestamp is not None and self._event_matches_connectors(event, scope)
-        ]
+        return list(self._recent_hook_scope_summary(connectors)["hook_timestamps"])
 
     def _recent_connector_hook_events(self) -> list[Any]:
         """Recent connector-hook events, bypassing the Audit panel's noise filter."""
@@ -5296,8 +5638,7 @@ class DefenseClawTUI(App[None]):
 
         scope = self._normalize_connector_scope(connectors)
         since = self._session_start_for_connectors(scope)
-        events: list[Any] = []
-        events.extend(self._recent_connector_hook_events())
+        events: list[Any] = list(self._recent_hook_scope_summary(scope, since=since)["block_events"])
         if self.audit_model is not None:
             events.extend(self.audit_model.items)
         out: list[Any] = []
@@ -5309,7 +5650,7 @@ class DefenseClawTUI(App[None]):
             seen.add(key)
             if not self._event_in_session(event, since):
                 continue
-            if not self._event_matches_connectors(event, scope):
+            if not self._cached_event_matches_scope(event, scope):
                 continue
             if self._is_block_event(event):
                 out.append(event)
@@ -5349,22 +5690,16 @@ class DefenseClawTUI(App[None]):
             if (
                 event.timestamp is not None
                 and self._event_in_session(event, since)
-                and self._event_matches_connectors(event, scope)
-                and self._event_metric_severity_bucket(event) in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}
+                and self._cached_event_matches_scope(event, scope)
+                and self._cached_event_metric_severity_bucket(event) in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}
             ):
                 stamps.append(event.timestamp)
                 seen.add(self._event_count_key(event))
-        for event in self._recent_connector_hook_events():
-            if not self._event_in_session(event, since):
-                continue
-            if not self._event_matches_connectors(event, scope):
-                continue
+        for event in self._recent_hook_scope_summary(scope, since=since)["finding_events"]:
             key = self._event_count_key(event)
             if key in seen:
                 continue
-            if self._hook_decision(event) not in {"alert", "warn", "block"}:
-                continue
-            if self._event_metric_severity_bucket(event) not in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}:
+            if self._cached_event_metric_severity_bucket(event) not in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}:
                 continue
             if event.timestamp is not None:
                 stamps.append(event.timestamp)
@@ -5433,9 +5768,9 @@ class DefenseClawTUI(App[None]):
             nonlocal best
             if not self._event_in_session(event, since):
                 return
-            if not self._event_matches_connectors(event, scope):
+            if not self._cached_event_matches_scope(event, scope):
                 return
-            severity = self._event_metric_severity_bucket(event)
+            severity = self._cached_event_metric_severity_bucket(event)
             rank = severity_rank.get(severity, 0)
             if rank <= best[0]:
                 return
@@ -5445,11 +5780,9 @@ class DefenseClawTUI(App[None]):
         for event in alert_events:
             seen.add(self._event_count_key(event))
             consider(event)
-        for event in self._recent_connector_hook_events():
+        for event in self._recent_hook_scope_summary(scope, since=since)["finding_events"]:
             key = self._event_count_key(event)
             if key in seen:
-                continue
-            if self._hook_decision(event) not in {"alert", "warn", "block"}:
                 continue
             seen.add(key)
             consider(event)
@@ -5839,10 +6172,6 @@ class DefenseClawTUI(App[None]):
             f"  Enterprise AI Governance  v{__version__}{uptime_suffix}",
             style=f"italic {TOKENS.text_secondary}",
         )
-        connector_chip = self._connector_chip_text()
-        connector_chip_block: list[RenderableType] = []
-        if connector_chip:
-            connector_chip_block = [Text.from_markup(connector_chip.rstrip()), Text("")]
 
         # Build the notice lines via ``Text.append`` rather than
         # ``Text.from_markup``: the icons (``[!]`` / ``[*]`` / ``[>]``)
@@ -6337,7 +6666,6 @@ class DefenseClawTUI(App[None]):
             banner,
             tagline,
             Text(""),
-            *connector_chip_block,
             *notice_block,
             Text(""),
             columns,
@@ -6465,7 +6793,7 @@ class DefenseClawTUI(App[None]):
         state_by_key = {card.key: card.state or "unknown" for card in service_cards}
         detail_by_key = {card.key: card.detail or card.last_error for card in service_cards}
         health = self.overview_model.health
-        connector_chip = self._connector_chip_text()
+        connector_scope = self._overview_connector_scope_text()
 
         notice_lines = []
         for notice in notices[:3]:
@@ -6634,7 +6962,7 @@ class DefenseClawTUI(App[None]):
         return (
             "[bold #22D3EE]Overview[/]  [#9FB2CC]Command center for live risk, setup health, and next actions.[/]\n"
             f"[italic]DefenseClaw v{__version__}{uptime}[/]\n\n"
-            f"{connector_chip}"
+            f"{connector_scope}"
             f"[bold {TOKENS.accent_green}]WHAT NEEDS ATTENTION[/]\n"
             + "\n".join(notice_lines)
             + "\n\n"
@@ -6770,9 +7098,11 @@ class DefenseClawTUI(App[None]):
         # crash). Build a Text object via the defensive wrapper so a
         # hostile filter degrades to plain text instead of tearing
         # down the status strip mid-frame.
-        self.query_one("#status", Static).update(
-            self._safe_body_renderable(f"{text}  [#444444]│[/]  {strip}")
-        )
+        try:
+            status = self.query_one("#status", Static)
+        except NoMatches:
+            return
+        status.update(self._safe_body_renderable(f"{text}  [#444444]│[/]  {strip}"))
 
     def _write_activity(self, text: str) -> None:
         self.activity_lines.append(text)
@@ -7100,6 +7430,11 @@ class DefenseClawTUI(App[None]):
                 if body_signature != self._last_body_signature:
                     body_widget.update(renderable)
                     self._last_body_signature = body_signature
+                    try:
+                        scroller = self.query_one("#body-scroll", VerticalScroll)
+                    except NoMatches:
+                        scroller = None
+                    current_scroll_y = self._restore_overview_scroll(scroller, current_scroll_y)
                 self._overview_last_render_scroll_y = current_scroll_y
         else:
             # Same defense-in-depth as ``_render_chrome`` — any panel's
@@ -8497,12 +8832,18 @@ class DefenseClawTUI(App[None]):
             return
         index = int(choice)
         if index == 0:
-            self._set_connector_filter("")
+            self._set_connector_filter(
+                "",
+                defer_overview=self.active_panel == "overview" and not self.help_open,
+            )
             return
         index -= 1
         if not (0 <= index < len(connectors)):
             return
-        self._set_connector_filter(connectors[index])
+        self._set_connector_filter(
+            connectors[index],
+            defer_overview=self.active_panel == "overview" and not self.help_open,
+        )
 
     async def _open_redaction_toggle(self) -> None:
         currently_disabled = _redaction_currently_disabled(self.config)
@@ -8777,6 +9118,11 @@ class DefenseClawTUI(App[None]):
             return
         if len(self.screen_stack) > 1:
             return
+        if self.active_panel == "overview" and not self.help_open:
+            connector_rows_changed = self._overview_connector_rows_changed_since_render()
+            self._render_overview_metrics()
+            self._schedule_overview_sampled_refresh(allow_scrolled=connector_rows_changed)
+            return
         self._periodic_refresh_running = True
         try:
             self._refresh_models_from_disk()
@@ -8937,23 +9283,29 @@ class DefenseClawTUI(App[None]):
         # Rebuild Setup readiness now that we have a fresh health
         # snapshot (the gateway/api/guardrail rows depend on it).
         self._sync_setup_readiness()
-        # Only repaint the chrome when the Overview panel is actually
-        # being shown; otherwise we'd churn the screen for nothing.
+        # Passive health polls update the model but do not force a full
+        # Overview repaint. The dashboard render is expensive enough that a
+        # 3s timer can block the first wheel/key event after idle.
         if self.active_panel == "overview" and not self.help_open:
-            self._render_chrome()
+            self._render_overview_scope_indicator()
+            self._schedule_overview_sampled_refresh()
 
     async def _poll_ai_usage(self, *, force_render: bool) -> None:
         snapshot = await asyncio.to_thread(_fetch_ai_usage, self.config)
         if snapshot is None:
             if self.ai_discovery_model.snapshot is None:
                 self.ai_discovery_model.message = "ai discovery offline or unauthorized"
-            if force_render or self.active_panel in {"overview", "ai"}:
+            if not force_render and self.active_panel == "overview":
+                self._schedule_overview_sampled_refresh()
+            if force_render or self.active_panel == "ai":
                 self._render_chrome()
             return
         self.overview_model.set_ai_usage(snapshot)
         self.ai_discovery_model.set_snapshot(snapshot)
         self.ai_discovery_model.message = ""
-        if force_render or self.active_panel in {"overview", "ai"}:
+        if not force_render and self.active_panel == "overview":
+            self._schedule_overview_sampled_refresh()
+        if force_render or self.active_panel == "ai":
             self._render_chrome()
 
     def _sync_setup_readiness(self) -> None:

--- a/cli/defenseclaw/tui/panels/alerts.py
+++ b/cli/defenseclaw/tui/panels/alerts.py
@@ -315,7 +315,8 @@ class AlertsPanelModel:
         filtered: list[AlertRow] = []
         for row in self.flat_rows():
             event = row.event
-            if self.severity_filter and _severity_bucket(event.severity) != self.severity_filter:
+            effective_severity = _event_severity_bucket(event)
+            if self.severity_filter and effective_severity != self.severity_filter:
                 continue
             if not self.severity_filter and not self.show_all_severities and _is_low_signal_alert(row):
                 continue
@@ -327,7 +328,7 @@ class AlertsPanelModel:
             if connector_value and connector_value not in ev_connector:
                 continue
             if remaining:
-                haystack = f"{event.severity} {event.action} {event.target} {event.details}".lower()
+                haystack = f"{effective_severity} {event.severity} {event.action} {event.target} {event.details}".lower()
                 if remaining not in haystack:
                     continue
             filtered.append(row)
@@ -425,7 +426,7 @@ class AlertsPanelModel:
         for row in self.flat_rows():
             if row.kind == "scan_finding":
                 continue
-            bucket = _severity_bucket(row.event.severity)
+            bucket = _event_severity_bucket(row.event)
             if bucket in counts:
                 counts[bucket] += 1
         return counts
@@ -605,6 +606,7 @@ class AlertsPanelModel:
         rows: list[AlertTableRow] = []
         for index, row in enumerate(self.filtered):
             event = row.event
+            severity_cell = _event_display_severity(event)
             marker = "*" if event.id in self.selected_ids else ""
             if row.kind == "scan":
                 marker = "+" if row.scan_id not in self.expanded else "-"
@@ -616,7 +618,7 @@ class AlertsPanelModel:
                 connector_cell = parse_kv_details(event.details).get("connector", "").strip() or "—"
                 cells = (
                     marker,
-                    event.severity,
+                    severity_cell,
                     event.timestamp.strftime("%b %d %H:%M"),
                     event.action,
                     connector_cell,
@@ -626,7 +628,7 @@ class AlertsPanelModel:
             else:
                 cells = (
                     marker,
-                    event.severity,
+                    severity_cell,
                     event.timestamp.strftime("%b %d %H:%M"),
                     event.action,
                     target_cell,
@@ -689,8 +691,9 @@ class AlertsPanelModel:
         if _is_hook_event(event):
             lines = _hook_detail_lines(event)
         else:
+            display_severity = _event_display_severity(event)
             lines = [
-                f"[bold #22D3EE]{event.severity} {event.action}[/]",
+                f"[bold #22D3EE]{display_severity} {event.action}[/]",
                 f"Target: {event.target}",
                 f"Time: {event.timestamp.strftime('%Y-%m-%d %H:%M:%S')}",
             ]
@@ -767,8 +770,9 @@ class AlertsPanelModel:
         if info is None:
             return ()
         event = info.event
+        display_severity = _event_display_severity(event)
         pairs: list[tuple[str, str]] = [
-            ("Severity", event.severity),
+            ("Severity", display_severity),
             ("Action", event.action),
             ("Target", event.target),
             ("Timestamp", event.timestamp.isoformat()),
@@ -821,8 +825,9 @@ class AlertsPanelModel:
         if info is None:
             return ""
         event = info.event
+        display_severity = _event_display_severity(event)
         lines = [
-            f"Severity: {event.severity}",
+            f"Severity: {display_severity}",
             f"Action: {event.action}",
             f"Target: {event.target}",
             f"Timestamp: {event.timestamp.isoformat()}",
@@ -923,9 +928,25 @@ def _severity_bucket(severity: str) -> str:
     return normalized
 
 
+def _event_severity_bucket(event: AlertEvent) -> str:
+    bucket = _severity_bucket(event.severity)
+    if bucket in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}:
+        return bucket
+    if _is_hook_event(event):
+        detail_bucket = _severity_bucket(parse_kv_details(event.details).get("severity", ""))
+        if detail_bucket in {"CRITICAL", "HIGH", "MEDIUM", "LOW"}:
+            return detail_bucket
+    return bucket
+
+
+def _event_display_severity(event: AlertEvent) -> str:
+    bucket = _event_severity_bucket(event)
+    return bucket or event.severity
+
+
 def _is_low_signal_alert(row: AlertRow) -> bool:
     event = row.event
-    severity = _severity_bucket(event.severity)
+    severity = _event_severity_bucket(event)
     if severity in ACTIONABLE_SEVERITIES:
         return False
     if severity not in LOW_SIGNAL_SEVERITIES:
@@ -1201,13 +1222,14 @@ def _hook_detail_lines(event: AlertEvent) -> list[str]:
     elif phase:
         title = f"[bold #22D3EE]{phase}[/]"
     else:
-        title = f"[bold #22D3EE]{event.severity} {event.action}[/]"
+        title = f"[bold #22D3EE]{_event_display_severity(event)} {event.action}[/]"
     lines = [
         title,
         f"Time: {event.timestamp.strftime('%Y-%m-%d %H:%M:%S')}",
     ]
-    if event.severity and event.severity.upper() not in {"", "NONE", "INFO"}:
-        lines.append(f"Severity: {event.severity}")
+    display_severity = _event_display_severity(event)
+    if display_severity and display_severity.upper() not in {"", "NONE", "INFO"}:
+        lines.append(f"Severity: {display_severity}")
     rows = structured_detail_rows(event.details)
     if rows:
         for label, value in rows:

--- a/cli/defenseclaw/tui/services/overview_state.py
+++ b/cli/defenseclaw/tui/services/overview_state.py
@@ -604,7 +604,9 @@ class OverviewPanelModel:
                 summary_parts=tuple(parts),
             )
 
-        rows = self.ai_usage_sorted or sort_ai_discovery_signals_for_overview(self.ai_usage.signals)
+        rows = unique_ai_discovery_signals_for_overview(
+            self.ai_usage_sorted or sort_ai_discovery_signals_for_overview(self.ai_usage.signals)
+        )
         overflow = max(len(rows) - MAX_AI_DISCOVERY_OVERVIEW_ROWS, 0)
         rendered = tuple(
             OverviewAIDiscoveryRow(
@@ -1155,6 +1157,34 @@ def sort_ai_discovery_signals_for_overview(signals: tuple[AIUsageSignal, ...]) -
         return (state_rank, -signal.confidence, -last_seen, display_ai_discovery_name(signal).lower())
 
     return tuple(sorted(signals, key=rank))
+
+
+def unique_ai_discovery_signals_for_overview(signals: tuple[AIUsageSignal, ...]) -> tuple[AIUsageSignal, ...]:
+    """Collapse multiple evidence signals into one Overview row per agent."""
+
+    seen: set[tuple[str, str]] = set()
+    rows: list[AIUsageSignal] = []
+    for signal in signals:
+        key = _ai_discovery_overview_key(signal)
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append(signal)
+    return tuple(rows)
+
+
+def _ai_discovery_overview_key(signal: AIUsageSignal) -> tuple[str, str]:
+    connector = signal.supported_connector.strip().lower()
+    if connector:
+        return ("connector", connector)
+    if signal.component is not None:
+        ecosystem = signal.component.ecosystem.strip().lower()
+        name = signal.component.name.strip().lower()
+        if ecosystem or name:
+            return ("component", f"{ecosystem}:{name}")
+    name = display_ai_discovery_name(signal).strip().lower()
+    vendor = display_ai_discovery_vendor(signal).strip().lower()
+    return ("display", f"{vendor}:{name}")
 
 
 def ai_discovery_state_badge(state: str) -> str:

--- a/cli/tests/test_agent_discovery.py
+++ b/cli/tests/test_agent_discovery.py
@@ -273,6 +273,41 @@ def test_trust_check_accepts_homebrew_symlink_targets(monkeypatch, tmp_path):
     assert ad._is_trusted_binary_path(str(link)) is True
 
 
+def test_operator_prefix_still_applies_after_default_prefix_ownership_failure(
+    monkeypatch,
+    tmp_path,
+):
+    """A default prefix match must not mask a later operator-added prefix."""
+    default_prefix = tmp_path / "homebrew"
+    operator_prefix = (
+        default_prefix
+        / "lib"
+        / "node_modules"
+        / "@openai"
+        / "codex"
+        / "bin"
+    )
+    binary = operator_prefix / "codex.js"
+    operator_prefix.mkdir(parents=True)
+    binary.write_text("#!/usr/bin/env node\n")
+    binary.chmod(0o755)
+    operator_prefix.chmod(0o755)
+
+    monkeypatch.setattr(
+        ad,
+        "_trusted_bin_prefixes",
+        lambda: (str(default_prefix), str(operator_prefix)),
+    )
+    monkeypatch.setattr(
+        ad,
+        "_default_trusted_bin_prefixes",
+        lambda: frozenset({str(default_prefix)}),
+    )
+    monkeypatch.setattr(ad, "_bin_chain_is_system_owned", lambda _resolved, _prefix: False)
+
+    assert ad._is_trusted_binary_path(str(binary)) is True
+
+
 def test_trust_check_accepts_claude_local_share_target(monkeypatch, tmp_path):
     real = tmp_path / ".local" / "share" / "claude" / "versions" / "2.1.139"
     real.parent.mkdir(parents=True, exist_ok=True)

--- a/cli/tests/test_cmd_init.py
+++ b/cli/tests/test_cmd_init.py
@@ -2112,6 +2112,12 @@ class TestMultiConnectorInit(unittest.TestCase):
         # scanner mode, fail mode, HITL severity
         prompts = iter(["local", "closed", "MEDIUM"])
         confirms = iter([True, False, True])  # action HITL, start_gateway, verify
+        checkbox_returns = iter([["codex", "claudecode"], ["claudecode"], []])
+        checkbox_calls: list[tuple[list[str], str]] = []
+
+        def checkbox(options, **kwargs):
+            checkbox_calls.append((list(options), kwargs.get("title", "")))
+            return next(checkbox_returns)
 
         with patch.object(cmd_init.agent_discovery, "discover_agents", return_value=disc), \
                 patch.object(cmd_init.agent_discovery, "render_discovery_table", return_value=""), \
@@ -2119,11 +2125,7 @@ class TestMultiConnectorInit(unittest.TestCase):
                     "defenseclaw.commands.cmd_setup._check_connector_version_supported_for_setup",
                     return_value=True,
                 ), \
-                patch.object(
-                    cmd_init,
-                    "_prompt_checkbox_selection",
-                    side_effect=[["codex", "claudecode"], ["claudecode"], []],
-                ), \
+                patch.object(cmd_init, "_prompt_checkbox_selection", side_effect=checkbox), \
                 patch.object(cmd_init.click, "prompt", side_effect=lambda *a, **k: next(prompts)), \
                 patch.object(cmd_init.click, "confirm", side_effect=lambda *a, **k: next(confirms)):
             settings, scanner_mode, with_judge, judge_connectors, start_gateway, verify = cmd_init._prompt_first_run(
@@ -2149,6 +2151,7 @@ class TestMultiConnectorInit(unittest.TestCase):
         self.assertEqual(judge_connectors, [])
         self.assertFalse(start_gateway)
         self.assertTrue(verify)
+        self.assertEqual(checkbox_calls[2], (["claudecode"], "Select action connector(s) for LLM judge."))
 
     def test_prompt_first_run_blank_action_keeps_all_observe(self):
         """Pressing Enter at the action prompt keeps every connector observe
@@ -2164,7 +2167,7 @@ class TestMultiConnectorInit(unittest.TestCase):
                 patch.object(
                     cmd_init,
                     "_prompt_checkbox_selection",
-                    side_effect=[["codex", "claudecode"], [], []],
+                    side_effect=[["codex", "claudecode"], []],
                 ), \
                 patch.object(cmd_init.click, "prompt", side_effect=lambda *a, **k: next(prompts)), \
                 patch.object(cmd_init.click, "confirm", side_effect=lambda *a, **k: next(confirms)):

--- a/cli/tests/test_cmd_judge.py
+++ b/cli/tests/test_cmd_judge.py
@@ -278,6 +278,27 @@ class JudgeAddTests(unittest.TestCase):
         self.assertNotIn("no effect", result.output)
 
     @patch.object(cmd_setup, "_restart_services")
+    def test_add_enable_repairs_empty_completion_strategy_under_all_gate(self, restart):
+        # Legacy configs can have an empty completion strategy even when the
+        # hook gate is already broad. Re-running the explicit judge-enable
+        # command must still persist tool-output judge coverage.
+        app = make_ctx(
+            judge_enabled=True,
+            hook_connectors=["*"],
+            detection_strategy="regex_judge",
+            detection_strategy_completion="",
+        )
+        result = invoke(app, ["add", "hermes", "--enable", "--no-restart"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(app.cfg.guardrail.judge.hook_connectors, ["*"])
+        self.assertEqual(app.cfg.guardrail.detection_strategy, "regex_judge")
+        self.assertEqual(app.cfg.guardrail.detection_strategy_completion, "regex_judge")
+        app.cfg.save.assert_called_once()
+        restart.assert_not_called()
+        self.assertNotIn("nothing to do", result.output)
+        self.assertIn("detection_strategy", result.output)
+
+    @patch.object(cmd_setup, "_restart_services")
     def test_add_without_enable_leaves_judge_disabled(self, restart):
         # Default is preserved: add never flips judge.enabled, and the inert
         # warning still fires so the operator knows the gate is dormant.
@@ -290,8 +311,13 @@ class JudgeAddTests(unittest.TestCase):
     @patch.object(cmd_setup, "_restart_services")
     def test_add_enable_when_already_enabled_is_idempotent(self, restart):
         # --enable on an already-enabled judge is not itself a change: with
-        # the gate also a no-op there is nothing to save or restart.
-        app = make_ctx(judge_enabled=True, hook_connectors=["hermes"])
+        # the gate and strategies also no-op there is nothing to save or restart.
+        app = make_ctx(
+            judge_enabled=True,
+            hook_connectors=["hermes"],
+            detection_strategy="regex_judge",
+            detection_strategy_completion="regex_judge",
+        )
         result = invoke(app, ["add", "hermes", "--enable"])
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertTrue(app.cfg.guardrail.judge.enabled)

--- a/cli/tests/test_cmd_misc.py
+++ b/cli/tests/test_cmd_misc.py
@@ -1332,9 +1332,10 @@ class TestSetupSplunkCommand(unittest.TestCase):
 
         self.assertEqual(contract["hec_token"], "bootstrap-token")
         mock_run.assert_called_once()
+        env_file = os.path.join(self.tmp_dir, "splunk-bridge", "env", ".env")
         self.assertEqual(
             mock_run.call_args.args[0],
-            ["/tmp/fake-splunk-claw-bridge", "up", "--output", "json"],
+            ["/tmp/fake-splunk-claw-bridge", "up", "--env-file", env_file, "--output", "json"],
         )
         kwargs = mock_run.call_args.kwargs
         self.assertEqual(kwargs["capture_output"], True)

--- a/cli/tests/test_cmd_plugin.py
+++ b/cli/tests/test_cmd_plugin.py
@@ -311,6 +311,51 @@ class TestPluginListMultiConnectorDefault(PluginCommandTestBase):
         self.assertEqual(payload[0]["connector"], "codex")
 
     @patch("defenseclaw.commands.cmd_plugin._list_openclaw_plugins", return_value=[])
+    def test_connector_json_uses_connector_scoped_scan_target(self, _mock_oc):
+        from datetime import datetime, timedelta, timezone
+
+        from defenseclaw.models import ScanResult
+
+        opencode_dir = os.path.join(self.tmp_dir, "opencode-plugins")
+        hermes_dir = os.path.join(self.tmp_dir, "hermes-plugins")
+        plugin_name = "dc-plugin-overview"
+        opencode_path = os.path.join(opencode_dir, plugin_name)
+        hermes_path = os.path.join(hermes_dir, plugin_name)
+        os.makedirs(opencode_path)
+        os.makedirs(hermes_path)
+        self.app.cfg.active_connectors = lambda: ["opencode", "hermes"]  # type: ignore[method-assign]
+        self.app.cfg.plugin_dirs = lambda connector=None: {  # type: ignore[method-assign]
+            "opencode": [opencode_dir],
+            "hermes": [hermes_dir],
+        }.get(connector or "opencode", [])
+        now = datetime.now(timezone.utc)
+        self.app.logger.log_scan(
+            ScanResult(
+                scanner="plugin-scanner", target=opencode_path,
+                timestamp=now, findings=[], duration=timedelta(seconds=0.1),
+            )
+        )
+        self.app.logger.log_scan(
+            ScanResult(
+                scanner="plugin-scanner", target=hermes_path,
+                timestamp=now + timedelta(seconds=1),
+                findings=[], duration=timedelta(seconds=0.1),
+            )
+        )
+
+        scoped = self.invoke(["list", "--connector", "hermes", "--json"])
+        self.assertEqual(scoped.exit_code, 0, scoped.output)
+        scoped_row = json.loads(scoped.output)[0]
+        self.assertEqual(scoped_row["connector"], "hermes")
+        self.assertEqual(scoped_row["scan"]["target"], hermes_path)
+
+        bare = self.invoke(["list", "--json"])
+        self.assertEqual(bare.exit_code, 0, bare.output)
+        groups = {group["connector"]: group["plugins"] for group in json.loads(bare.output)}
+        hermes_row = next(item for item in groups["hermes"] if item["id"] == plugin_name)
+        self.assertEqual(hermes_row["scan"]["target"], hermes_path)
+
+    @patch("defenseclaw.commands.cmd_plugin._list_openclaw_plugins", return_value=[])
     def test_table_title_counts_effectively_enabled_plugins(self, _mock_oc):
         codex_dir = os.path.join(self.tmp_dir, "codex-plugins")
         os.makedirs(os.path.join(codex_dir, "dc-plugin-alpha"))

--- a/cli/tests/test_cmd_setup_fu_phase2.py
+++ b/cli/tests/test_cmd_setup_fu_phase2.py
@@ -208,6 +208,30 @@ class TestPerConnectorWriteSurface(_BaseSetup):
             self.assertEqual(gc.connectors[connector].mode, "observe")
             self.assertEqual(gc.effective_mode(connector), "observe")
 
+    def test_setup_guardrail_unscoped_block_message_updates_all_active_overrides(self):
+        self._seed_map("geminicli", "hermes")
+        gc = self.app.cfg.guardrail
+        gc.block_message = "Global block"
+        gc.connectors["geminicli"].block_message = "Gemini scoped block"
+
+        with _stub_side_effects():
+            res = _invoke(
+                [
+                    "guardrail",
+                    "--yes",
+                    "--no-restart",
+                    "--no-verify",
+                    "--block-message",
+                    "Global block 2",
+                ],
+                self.app,
+            )
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertEqual(gc.block_message, "Global block 2")
+        for connector in ("geminicli", "hermes"):
+            self.assertEqual(gc.connectors[connector].block_message, "Global block 2")
+            self.assertEqual(gc.effective_block_message(connector), "Global block 2")
+
     def test_setup_guardrail_unscoped_without_mode_preserves_active_overrides(self):
         self._seed_map("codex", "hermes")
         gc = self.app.cfg.guardrail

--- a/cli/tests/test_cmd_setup_fu_phase2.py
+++ b/cli/tests/test_cmd_setup_fu_phase2.py
@@ -974,6 +974,39 @@ class TestJ3PerDirectionStrategy(_BaseSetup):
         self.assertEqual(self.app.cfg.guardrail.detection_strategy_completion, "regex_judge")
         self.assertEqual(self.app.cfg.guardrail.judge.hook_connectors, ["*"])
 
+    def test_scoped_mode_update_preserves_empty_judge_gate(self):
+        self._seed_map("antigravity", "hermes", "opencode")
+        gc = self.app.cfg.guardrail
+        gc.enabled = True
+        gc.mode = "observe"
+        gc.connectors["antigravity"].mode = "observe"
+        gc.connectors["hermes"].mode = "action"
+        gc.connectors["opencode"].mode = "action"
+        gc.judge.enabled = True
+        gc.judge.hook_connectors = []
+        gc.detection_strategy = "regex_judge"
+        gc.detection_strategy_completion = "regex_judge"
+
+        with _stub_side_effects(), \
+                patch("defenseclaw.commands.cmd_setup.execute_guardrail_setup", return_value=(True, [])):
+            res = _invoke(
+                [
+                    "guardrail", "--non-interactive", "--connector", "hermes",
+                    "--mode", "observe", "--no-restart", "--no-verify",
+                ],
+                self.app,
+            )
+
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertEqual(gc.effective_mode("antigravity"), "observe")
+        self.assertEqual(gc.effective_mode("hermes"), "observe")
+        self.assertEqual(gc.effective_mode("opencode"), "action")
+        self.assertEqual(sorted(gc.connectors), ["antigravity", "hermes", "opencode"])
+        self.assertTrue(gc.judge.enabled)
+        self.assertEqual(gc.judge.hook_connectors, [])
+        self.assertEqual(gc.detection_strategy, "regex_judge")
+        self.assertEqual(gc.detection_strategy_completion, "regex_judge")
+
     def test_explicit_completion_regex_only_preserved_when_judge_enabled(self):
         with _stub_side_effects(), \
                 patch("defenseclaw.commands.cmd_setup.execute_guardrail_setup", return_value=(True, [])):

--- a/cli/tests/test_cmd_setup_fu_phase2.py
+++ b/cli/tests/test_cmd_setup_fu_phase2.py
@@ -330,13 +330,40 @@ class TestInteractiveModeJudgePrompts(_BaseSetup):
         with _stub_side_effects(), \
                 patch("defenseclaw.commands.cmd_setup._is_interactive", return_value=True), \
                 patch("defenseclaw.commands.cmd_setup.click.confirm", side_effect=lambda *a, **k: next(confirms)), \
-                patch("defenseclaw.commands.cmd_setup.click.prompt", return_value="1"), \
+                patch("defenseclaw.commands.cmd_setup.click.prompt", return_value="2"), \
                 patch("defenseclaw.commands.cmd_setup._prompt_judge_model_config") as model_prompt:
             res = _invoke(["codex", "--no-restart"], self.app)
         self.assertEqual(res.exit_code, 0, msg=res.output)
         self.assertTrue(self.app.cfg.guardrail.judge.enabled)
         self.assertEqual(self.app.cfg.guardrail.judge.hook_connectors, ["codex"])
         model_prompt.assert_called_once()
+
+    def test_observe_mode_skips_judge_prompt_and_removes_connector_from_gate(self):
+        gc = self.app.cfg.guardrail
+        gc.judge.enabled = True
+        gc.judge.hook_connectors = ["codex"]
+        gc.detection_strategy = "regex_judge"
+        gc.detection_strategy_completion = "regex_judge"
+
+        confirms = iter([True])
+        with _stub_side_effects(), \
+                patch("defenseclaw.commands.cmd_setup._is_interactive", return_value=True), \
+                patch("defenseclaw.commands.cmd_setup.click.confirm", side_effect=lambda *a, **k: next(confirms)), \
+                patch("defenseclaw.commands.cmd_setup.click.prompt", return_value="1"), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_enable_judge",
+                    side_effect=AssertionError("observe mode should not ask for judge"),
+                ), \
+                patch(
+                    "defenseclaw.commands.cmd_setup._prompt_judge_model_config",
+                    side_effect=AssertionError("observe mode should not configure judge model"),
+                ):
+            res = _invoke(["codex", "--no-restart"], self.app)
+
+        self.assertEqual(res.exit_code, 0, msg=res.output)
+        self.assertFalse(gc.judge.enabled)
+        self.assertEqual(gc.judge.hook_connectors, [])
+        self.assertEqual(gc.detection_strategy, "regex_only")
 
     def test_scoped_guardrail_setup_preserves_unscoped_judge_gate(self):
         targets = ["antigravity", "claudecode", "hermes", "openhands"]
@@ -422,10 +449,9 @@ class TestInteractiveModeJudgePrompts(_BaseSetup):
         for connector in targets:
             self.assertEqual(gc.connectors[connector].mode, "observe")
             self.assertEqual(gc.effective_mode(connector), "observe")
-        self.assertEqual(
-            gc.judge.hook_connectors,
-            ["antigravity", "claudecode", "hermes", "openhands"],
-        )
+        self.assertFalse(gc.judge.enabled)
+        self.assertEqual(gc.judge.hook_connectors, [])
+        self.assertEqual(gc.detection_strategy, "regex_only")
 
     def test_non_interactive_does_not_prompt(self):
         # --yes path: no prompts fire (would error on EOF if they did).
@@ -691,9 +717,10 @@ class TestBareSetupBatch(_BaseSetup):
         gc.judge.enabled = True
         gc.judge.hook_connectors = ["*"]
 
-        def choose_hermes(targets, gc_arg):
-            cmd_setup._merge_batch_judge_selection(gc_arg, targets, {"hermes"})
-            return {"hermes"}
+        def choose_codex(targets, gc_arg):
+            self.assertEqual(targets, ["codex"])
+            cmd_setup._merge_batch_judge_selection(gc_arg, targets, {"codex"})
+            return {"codex"}
 
         with _stub_side_effects(), \
                 patch("defenseclaw.commands.cmd_setup._is_interactive", return_value=True), \
@@ -708,7 +735,7 @@ class TestBareSetupBatch(_BaseSetup):
                 patch("defenseclaw.commands.cmd_setup._prompt_batch_trusted_prefixes", return_value={}), \
                 patch(
                     "defenseclaw.commands.cmd_setup._prompt_batch_judge_connectors",
-                    side_effect=choose_hermes,
+                    side_effect=choose_codex,
                 ) as judge_picker, \
                 patch("defenseclaw.commands.cmd_setup.click.confirm", return_value=False) as confirm_mock, \
                 patch(
@@ -732,17 +759,13 @@ class TestBareSetupBatch(_BaseSetup):
         self.assertEqual(gc.connectors["codex"].mode, "action")
         self.assertEqual(gc.detection_strategy, "regex_judge")
         self.assertEqual(gc.detection_strategy_completion, "regex_judge")
-        self.assertEqual(gc.judge.hook_connectors, ["hermes"])
+        self.assertEqual(gc.judge.hook_connectors, ["codex"])
 
     def test_batch_judge_selection_drops_unselected_existing_connectors(self):
         self._seed_map("codex", "hermes")
         gc = self.app.cfg.guardrail
         gc.judge.enabled = True
         gc.judge.hook_connectors = ["*"]
-
-        def choose_hermes(targets, gc_arg):
-            cmd_setup._merge_batch_judge_selection(gc_arg, targets, {"hermes"})
-            return {"hermes"}
 
         with _stub_side_effects(), \
                 patch("defenseclaw.commands.cmd_setup._is_interactive", return_value=True), \
@@ -753,12 +776,13 @@ class TestBareSetupBatch(_BaseSetup):
                 patch("defenseclaw.commands.cmd_setup._prompt_batch_trusted_prefixes", return_value={}), \
                 patch(
                     "defenseclaw.commands.cmd_setup._prompt_batch_judge_connectors",
-                    side_effect=choose_hermes,
-                ), \
+                    side_effect=AssertionError("judge picker should be skipped without action connectors"),
+                ) as judge_picker, \
                 patch("defenseclaw.commands.cmd_setup.click.confirm", return_value=False):
             res = _invoke(["-c", "hermes", "--no-restart"], self.app)
         self.assertEqual(res.exit_code, 0, msg=res.output)
-        self.assertEqual(gc.judge.hook_connectors, ["hermes"])
+        judge_picker.assert_not_called()
+        self.assertEqual(gc.judge.hook_connectors, [])
         self.assertNotIn("codex", gc.judge.hook_connectors)
 
     def test_scoped_judge_selection_preserves_outside_existing_gate(self):
@@ -850,10 +874,6 @@ class TestBareSetupBatch(_BaseSetup):
         gc.judge.enabled = True
         gc.judge.hook_connectors = ["hermes"]
 
-        def choose_none(targets, gc_arg):
-            cmd_setup._merge_batch_judge_selection(gc_arg, targets, set())
-            return set()
-
         with _stub_side_effects(), \
                 patch("defenseclaw.commands.cmd_setup._is_interactive", return_value=True), \
                 patch(
@@ -867,8 +887,8 @@ class TestBareSetupBatch(_BaseSetup):
                 patch("defenseclaw.commands.cmd_setup._prompt_batch_trusted_prefixes", return_value={}), \
                 patch(
                     "defenseclaw.commands.cmd_setup._prompt_batch_judge_connectors",
-                    side_effect=choose_none,
-                ), \
+                    side_effect=AssertionError("judge picker should be skipped without action connectors"),
+                ) as judge_picker, \
                 patch(
                     "defenseclaw.commands.cmd_setup._prompt_judge_model_config",
                     side_effect=AssertionError("judge model prompt should not run with no judge connectors"),
@@ -879,6 +899,7 @@ class TestBareSetupBatch(_BaseSetup):
                 ):
             res = _invoke(["-c", "hermes", "-c", "codex", "--no-restart"], self.app)
         self.assertEqual(res.exit_code, 0, msg=res.output)
+        judge_picker.assert_not_called()
         self.assertFalse(gc.judge.enabled)
         self.assertEqual(gc.detection_strategy, "regex_only")
         self.assertEqual(gc.detection_strategy_completion, "regex_only")
@@ -893,7 +914,7 @@ class TestBareSetupBatch(_BaseSetup):
                 patch("defenseclaw.commands.cmd_setup._is_interactive", return_value=True), \
                 patch(
                     "defenseclaw.commands.cmd_setup._prompt_batch_connector_modes",
-                    return_value={"hermes": "observe"},
+                    return_value={"hermes": "action"},
                 ), \
                 patch(
                     "defenseclaw.commands.cmd_setup._prompt_batch_scan_strategy",

--- a/cli/tests/test_cmd_setup_observability.py
+++ b/cli/tests/test_cmd_setup_observability.py
@@ -215,8 +215,23 @@ class TestObservabilityWizard(unittest.TestCase):
     def test_judge_selection_enables_selected_hook_coverage_and_model(self):
         app, gc = _make_app("codex")
 
-        with patch("defenseclaw.commands.cmd_setup.click.confirm", side_effect=[True, False]), \
-             patch("defenseclaw.commands.cmd_setup.click.prompt", return_value="1"), \
+        confirm_answers = iter([True, False, False])
+
+        def _confirm(*args, **kwargs):
+            try:
+                return next(confirm_answers)
+            except StopIteration:
+                return kwargs.get("default", False)
+
+        def _prompt(label, *args, **kwargs):
+            if "Select mode" in str(label):
+                return "2"
+            return "1"
+
+        with patch("defenseclaw.commands.cmd_setup.click.confirm",
+                   side_effect=_confirm), \
+             patch("defenseclaw.commands.cmd_setup.click.prompt",
+                   side_effect=_prompt), \
              patch(
                  "defenseclaw.commands.cmd_setup._prompt_batch_scan_strategy",
                  side_effect=AssertionError("setup guardrail should not ask for scan strategy"),

--- a/cli/tests/test_cmd_skill.py
+++ b/cli/tests/test_cmd_skill.py
@@ -2278,8 +2278,8 @@ class TestSkillSearchUX(SkillCommandTestBase):
 
 
 class TestSkillBareNameResolution(SkillCommandTestBase):
-    """ND-1: a bare ``skill scan <name>`` resolves across every active
-    connector, and refuses (asking for --connector) when a name is ambiguous."""
+    """ND-1: a bare ``skill scan <name>`` resolves across every configured
+    connector and scans every matching copy."""
 
     def _fake_dirs(self, mapping: dict, active: str):
         def skill_dirs(connector=None):
@@ -2364,6 +2364,61 @@ class TestSkillBareNameResolution(SkillCommandTestBase):
         self.assertIn("── connector: hermes ──", result.output)
         self.assertIn("Scanning 1 skill on hermes", result.output)
         self.assertEqual(mock_scan.call_count, 2)
+
+    @patch("defenseclaw.commands.cmd_skill._get_openclaw_skill_info")
+    @patch("defenseclaw.scanner.skill.SkillScannerWrapper.scan")
+    def test_bare_name_duplicate_fans_out_before_active_info(
+        self, mock_scan, mock_info,
+    ):
+        a_root = os.path.join(self.tmp_dir, "antigravity", "skills")
+        h_root = os.path.join(self.tmp_dir, "hermes", "skills")
+        o_root = os.path.join(self.tmp_dir, "opencode", "skills")
+        a_skill = os.path.join(a_root, "dc-skill-final")
+        h_skill = os.path.join(h_root, "dc-skill-final")
+        o_skill = os.path.join(o_root, "dc-skill-final")
+        os.makedirs(a_skill)
+        os.makedirs(h_skill)
+        os.makedirs(o_skill)
+
+        self.app.cfg.active_connector = lambda: "antigravity"  # type: ignore[method-assign]
+        self.app.cfg.active_connectors = lambda: [  # type: ignore[method-assign]
+            "antigravity",
+            "hermes",
+            "opencode",
+        ]
+        self.app.cfg.skill_dirs = self._fake_dirs(  # type: ignore[method-assign]
+            {
+                "antigravity": [a_root],
+                "hermes": [h_root],
+                "opencode": [o_root],
+            },
+            "antigravity",
+        )
+        mock_info.return_value = {
+            "name": "dc-skill-final",
+            "baseDir": a_skill,
+            "eligible": True,
+        }
+        mock_scan.return_value = ScanResult(
+            scanner="skill-scanner", target="dc-skill-final",
+            timestamp=datetime.now(timezone.utc), findings=[],
+            duration=timedelta(seconds=0.1),
+        )
+
+        result = self.invoke(["scan", "dc-skill-final", "--no-use-llm"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("── connector: antigravity ──", result.output)
+        self.assertIn("Scanning 1 skill on antigravity", result.output)
+        self.assertIn("── connector: hermes ──", result.output)
+        self.assertIn("Scanning 1 skill on hermes", result.output)
+        self.assertIn("── connector: opencode ──", result.output)
+        self.assertIn("Scanning 1 skill on opencode", result.output)
+        self.assertEqual(
+            [call.args[0] for call in mock_scan.call_args_list],
+            [os.path.realpath(a_skill), os.path.realpath(h_skill), os.path.realpath(o_skill)],
+        )
+        mock_info.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/cli/tests/test_models_db.py
+++ b/cli/tests/test_models_db.py
@@ -238,6 +238,36 @@ class ModelsDbTests(unittest.TestCase):
         self.assertEqual(events[0].structured["schema"], "defenseclaw.hook.v1")
         self.assertEqual(events[0].structured["connector"], "codex")
 
+    def test_event_reader_parses_zulu_timestamps(self):
+        self.store.db.execute(
+            """INSERT INTO audit_events (
+                id, timestamp, action, target, actor, details, severity, run_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "evt-zulu",
+                "2026-06-24T16:46:56.1105Z",
+                "connector-hook",
+                "PostToolUse",
+                "defenseclaw",
+                "connector=codex action=block mode=action",
+                "INFO",
+                "",
+            ),
+        )
+        self.store.db.commit()
+
+        event = self.store.list_connector_hook_event_summaries(1)[0]
+
+        self.assertEqual(event.id, "evt-zulu")
+        self.assertEqual(event.timestamp.year, 2026)
+        self.assertEqual(event.timestamp.month, 6)
+        self.assertEqual(event.timestamp.day, 24)
+        self.assertEqual(event.timestamp.hour, 16)
+        self.assertEqual(event.timestamp.minute, 46)
+        self.assertEqual(event.timestamp.second, 56)
+        self.assertEqual(event.timestamp.microsecond, 110500)
+        self.assertEqual(event.timestamp.tzinfo, timezone.utc)
+
     def test_summary_readers_avoid_heavy_payloads_but_get_event_hydrates_full_row(self):
         details = "connector=codex " + ("x" * 6000)
         evt = Event(
@@ -263,6 +293,15 @@ class ModelsDbTests(unittest.TestCase):
 
     def test_actionable_summary_readers_skip_low_signal_rows(self):
         self.store.log_event(Event(id="info", action="connector-hook", target="preToolUse", severity="INFO"))
+        self.store.log_event(
+            Event(
+                id="hook-high",
+                action="connector-hook",
+                target="preToolUse",
+                severity="INFO",
+                details="connector=codex action=allow raw_action=alert severity=HIGH mode=observe",
+            )
+        )
         self.store.log_event(Event(id="medium", action="scan", target="skill://one", severity="MEDIUM"))
         self.store.log_event(Event(id="high", action="scan", target="skill://two", severity="HIGH"))
         self.store.log_event(Event(id="failure", action="sink-failure", target="splunk", severity="ERROR"))
@@ -270,8 +309,8 @@ class ModelsDbTests(unittest.TestCase):
         audit_ids = [event.id for event in self.store.list_actionable_event_summaries(10)]
         alert_ids = [event.id for event in self.store.list_actionable_alert_summaries(10)]
 
-        self.assertEqual(audit_ids, ["failure", "high"])
-        self.assertEqual(alert_ids, ["failure", "high"])
+        self.assertEqual(audit_ids, ["failure", "high", "hook-high"])
+        self.assertEqual(alert_ids, ["failure", "high", "hook-high"])
 
     def test_logger_uses_run_id_from_env(self):
         old = os.environ.get("DEFENSECLAW_RUN_ID")

--- a/cli/tests/test_models_db.py
+++ b/cli/tests/test_models_db.py
@@ -237,6 +237,33 @@ class ModelsDbTests(unittest.TestCase):
         events = self.store.list_events(1)
         self.assertEqual(events[0].structured["schema"], "defenseclaw.hook.v1")
         self.assertEqual(events[0].structured["connector"], "codex")
+        self.assertEqual(events[0].connector, "codex")
+
+    def test_connector_hook_stats_aggregate_normalized_connector_names(self):
+        self.store.log_event(
+            Event(
+                id="codex-structured",
+                action="connector-hook",
+                target="PreToolUse",
+                severity="INFO",
+                structured={"connector": "Codex"},
+                details="action=allow",
+            )
+        )
+        self.store.log_event(
+            Event(
+                id="codex-details",
+                action="connector-hook",
+                target="PreToolUse",
+                severity="HIGH",
+                details="connector=codex action=block",
+            )
+        )
+
+        stats = self.store.connector_hook_event_stats()
+
+        self.assertEqual(stats["codex"]["calls"], 2)
+        self.assertEqual(stats["codex"]["blocks"], 1)
 
     def test_event_reader_parses_zulu_timestamps(self):
         self.store.db.execute(

--- a/cli/tests/test_setup_refresh_bundle_wiring.py
+++ b/cli/tests/test_setup_refresh_bundle_wiring.py
@@ -68,6 +68,16 @@ def _read_dotenv(path: str) -> dict[str, str]:
     return entries
 
 
+def _bridge_up_args(mock_run: MagicMock) -> list[str]:
+    """Return the Splunk bridge `up` argv from mocked subprocess calls."""
+
+    for call in mock_run.call_args_list:
+        args = call.args[0]
+        if len(args) >= 2 and args[1] == "up":
+            return args
+    raise AssertionError("Splunk bridge up command was not invoked")
+
+
 class TestSetupSplunkRefreshWiring(unittest.TestCase):
     def setUp(self) -> None:
         self.runner = CliRunner()
@@ -129,9 +139,8 @@ class TestSetupSplunkRefreshWiring(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         env_file = _bridge_env_file(self.tmp_dir)
         mock_refresh.assert_called_once_with(self.tmp_dir, env_file=env_file)
-        mock_run.assert_called_once()
         self.assertEqual(
-            mock_run.call_args.args[0],
+            _bridge_up_args(mock_run),
             ["/tmp/fake-splunk-claw-bridge", "up", "--env-file", env_file, "--output", "json"],
         )
 
@@ -192,9 +201,8 @@ class TestSetupSplunkRefreshWiring(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         mock_refresh.assert_not_called()
         env_file = _bridge_env_file(self.tmp_dir)
-        mock_run.assert_called_once()
         self.assertEqual(
-            mock_run.call_args.args[0],
+            _bridge_up_args(mock_run),
             ["/tmp/fake-splunk-claw-bridge", "up", "--env-file", env_file, "--output", "json"],
         )
 

--- a/cli/tests/test_setup_refresh_bundle_wiring.py
+++ b/cli/tests/test_setup_refresh_bundle_wiring.py
@@ -31,8 +31,10 @@ from __future__ import annotations
 import io
 import json
 import os
+import stat
 import tempfile
 import unittest
+import uuid
 from contextlib import redirect_stdout
 from unittest.mock import MagicMock, patch
 
@@ -48,6 +50,22 @@ def _make_app() -> tuple[AppContext, str]:
     app = AppContext()
     app.cfg = cfg
     return app, tmp_dir
+
+
+def _bridge_env_file(data_dir: str) -> str:
+    return os.path.join(data_dir, "splunk-bridge", "env", ".env")
+
+
+def _read_dotenv(path: str) -> dict[str, str]:
+    entries: dict[str, str] = {}
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            entries[key] = value
+    return entries
 
 
 class TestSetupSplunkRefreshWiring(unittest.TestCase):
@@ -109,7 +127,21 @@ class TestSetupSplunkRefreshWiring(unittest.TestCase):
         )
 
         self.assertEqual(result.exit_code, 0, result.output)
-        mock_refresh.assert_called_once_with(self.tmp_dir)
+        env_file = _bridge_env_file(self.tmp_dir)
+        mock_refresh.assert_called_once_with(self.tmp_dir, env_file=env_file)
+        mock_run.assert_called_once()
+        self.assertEqual(
+            mock_run.call_args.args[0],
+            ["/tmp/fake-splunk-claw-bridge", "up", "--env-file", env_file, "--output", "json"],
+        )
+
+        self.assertEqual(stat.S_IMODE(os.stat(env_file).st_mode), 0o600)
+        entries = _read_dotenv(env_file)
+        self.assertEqual(entries["SPLUNK_HEC_TOKEN"], entries["DEFENSECLAW_HEC_TOKEN"])
+        uuid.UUID(entries["SPLUNK_HEC_TOKEN"])
+        self.assertEqual(entries["DEFENSECLAW_INTEGRATION_ENABLED"], "true")
+        self.assertTrue(entries["SPLUNK_PASSWORD"].startswith("DefenseClawLocal-"))
+        self.assertTrue(entries["SPLUNK_PASSWORD"].endswith("!"))
 
     @patch(
         "defenseclaw.commands.cmd_setup._refresh_and_maybe_restart_splunk_bridge",
@@ -159,6 +191,12 @@ class TestSetupSplunkRefreshWiring(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         mock_refresh.assert_not_called()
+        env_file = _bridge_env_file(self.tmp_dir)
+        mock_run.assert_called_once()
+        self.assertEqual(
+            mock_run.call_args.args[0],
+            ["/tmp/fake-splunk-claw-bridge", "up", "--env-file", env_file, "--output", "json"],
+        )
 
 
 class TestRefreshAndMaybeRestartSplunkBridge(unittest.TestCase):
@@ -197,14 +235,15 @@ class TestRefreshAndMaybeRestartSplunkBridge(unittest.TestCase):
         )
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
-        result = _refresh_and_maybe_restart_splunk_bridge("/data")
+        env_file = "/data/splunk-bridge/env/.env"
+        result = _refresh_and_maybe_restart_splunk_bridge("/data", env_file=env_file)
 
         self.assertTrue(result.was_running)
         self.assertTrue(result.stopped)
         # The down call must precede the refresh call. Pull the
         # subprocess args to confirm we asked the bridge for `down`.
         self.assertTrue(any(
-            call.args[0] == ["/fake/bin/splunk-claw-bridge", "down"]
+            call.args[0] == ["/fake/bin/splunk-claw-bridge", "down", "--env-file", env_file]
             for call in mock_run.call_args_list
         ))
         mock_refresh.assert_called_once_with("/data")

--- a/cli/tests/test_skill_severity_counts.py
+++ b/cli/tests/test_skill_severity_counts.py
@@ -21,6 +21,7 @@ import os
 import sys
 import unittest
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -87,6 +88,23 @@ class SeverityCountsInScanMapTests(unittest.TestCase):
         result = self.runner.invoke(
             skill, ["info", "myskill", "--json"], obj=self.app, catch_exceptions=False,
         )
+        self.assertEqual(result.exit_code, 0, result.output)
+        data = json.loads(result.output.strip())
+        self.assertIn("scan", data)
+        self.assertEqual(data["scan"]["severity_counts"]["critical"], 1)
+
+    def test_skill_info_json_falls_back_when_connector_reports_not_found(self):
+        with patch(
+            "defenseclaw.commands.cmd_skill._active_skill_connectors",
+            return_value=["openclaw"],
+        ), patch(
+            "defenseclaw.commands.cmd_skill._get_openclaw_skill_info",
+            return_value={"error": "not found", "skill": "myskill", "connector": "openclaw"},
+        ):
+            result = self.runner.invoke(
+                skill, ["info", "myskill", "--json"], obj=self.app, catch_exceptions=False,
+            )
+
         self.assertEqual(result.exit_code, 0, result.output)
         data = json.loads(result.output.strip())
         self.assertIn("scan", data)

--- a/cli/tests/tui/test_alerts_panel.py
+++ b/cli/tests/tui/test_alerts_panel.py
@@ -135,6 +135,40 @@ def test_alerts_connector_column_and_shared_filter() -> None:
     assert {row.event.id for row in model.filtered} == {"a1", "a2"}
 
 
+def test_alerts_connector_hook_uses_detail_severity_for_observe_findings() -> None:
+    """Observe-mode hook findings store INFO rows but carry policy severity in details."""
+
+    now = datetime(2026, 6, 24, 17, 46, tzinfo=timezone.utc)
+    model = AlertsPanelModel()
+    model.set_events(
+        [
+            AlertEvent(
+                id="plain",
+                timestamp=now,
+                severity="INFO",
+                action="connector-hook",
+                target="PostToolUse",
+                details="connector=codex action=allow raw_action=allow severity=NONE mode=observe",
+            ),
+            AlertEvent(
+                id="finding",
+                timestamp=now + timedelta(seconds=1),
+                severity="INFO",
+                action="connector-hook",
+                target="PostToolUse",
+                details="connector=codex action=allow raw_action=alert severity=HIGH mode=observe",
+            ),
+        ]
+    )
+
+    assert [row.event.id for row in model.filtered] == ["finding"]
+    assert model.severity_counts()["HIGH"] == 1
+    assert model.data_table_row_models()[0].cells[1] == "HIGH"
+
+    model.set_severity_filter_exact("HIGH")
+    assert [row.event.id for row in model.filtered] == ["finding"]
+
+
 def test_alerts_connector_token_filters_by_connector() -> None:
     # E5: the Alerts panel honors the same ``connector:<name>`` search token
     # as Audit, matching the kv connector in the event details. Free text in

--- a/cli/tests/tui/test_app_shell.py
+++ b/cli/tests/tui/test_app_shell.py
@@ -4509,6 +4509,7 @@ async def test_overview_connector_filter_does_not_refilter_hidden_panels(monkeyp
     async with app.run_test(size=(170, 44)) as pilot:
         await pilot.pause()
         app.active_panel = "overview"
+        hidden_filter_calls.clear()
         app._set_connector_filter("cursor")
 
     assert hidden_filter_calls == []

--- a/cli/tests/tui/test_app_shell.py
+++ b/cli/tests/tui/test_app_shell.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 import threading
 from datetime import datetime, timedelta, timezone
@@ -20,8 +21,10 @@ from types import SimpleNamespace
 
 import pytest
 from defenseclaw.config import RegistrySource
+from defenseclaw.db import Store
 from defenseclaw.models import Counts, Event
 from defenseclaw.tui.app import (
+    _DEFENSECLAW_LOGO,
     DefenseClawTUI,
     _catalog_panel_invalidated_by_command,
     _enforcement_label,
@@ -78,6 +81,65 @@ async def test_textual_shell_starts_on_overview() -> None:
         assert "SCANNERS" in app.body_text
         assert "backend=textual" in app.status_text
         assert app.hint_text
+
+
+@pytest.mark.asyncio
+async def test_overview_scroll_keys_move_body_scroll_container() -> None:
+    cfg = OverviewConfig(
+        data_dir="/tmp/dc",
+        claw_mode="codex",
+        guardrail_connector="codex",
+        connector_modes=(
+            ("antigravity", "action"),
+            ("claudecode", "observe"),
+            ("codex", "observe"),
+            ("hermes", "action"),
+            ("opencode", "action"),
+        ),
+    )
+    overview = OverviewPanelModel(cfg, version="test")
+    overview.set_health(HealthSnapshot(gateway=SubsystemHealth(state="running")))
+    app = DefenseClawTUI(overview_model=overview)
+
+    async with app.run_test(size=(120, 18)) as pilot:
+        await pilot.pause()
+        scroller = app.query_one("#body-scroll", VerticalScroll)
+        assert scroller.max_scroll_y > 0
+
+        await pilot.press("j")
+        await pilot.pause()
+        assert scroller.scroll_y >= 5
+
+        await pilot.press("end")
+        await pilot.pause()
+        assert scroller.scroll_y == scroller.max_scroll_y
+
+        assert app._last_body_signature is not None
+        render_calls = 0
+        original_renderable = app._overview_renderable
+
+        def counted_renderable():
+            nonlocal render_calls
+            render_calls += 1
+            return original_renderable()
+
+        app._overview_renderable = counted_renderable  # type: ignore[method-assign]
+        app._mark_overview_scroll_activity()
+        app._render_chrome()
+        assert render_calls == 0
+
+
+def test_overview_body_signature_ignores_clock_only_labels() -> None:
+    app = DefenseClawTUI()
+
+    app.body_text = "DefenseClaw v0.0.0 uptime=12s\nCodex 0s ago\nDoctor 1m ago\nCalls 6"
+    first = app._overview_body_signature()
+
+    app.body_text = "DefenseClaw v0.0.0 uptime=13s\nCodex 1s ago\nDoctor 2m ago\nCalls 6"
+    assert app._overview_body_signature() == first
+
+    app.body_text = "DefenseClaw v0.0.0 uptime=13s\nCodex 1s ago\nDoctor 2m ago\nCalls 7"
+    assert app._overview_body_signature() != first
 
 
 @pytest.mark.asyncio
@@ -3802,6 +3864,56 @@ async def test_hook_calls_tile_counts_audit_events_and_deeplinks_to_logs() -> No
 
 
 @pytest.mark.asyncio
+async def test_hook_calls_tile_uses_unfiltered_hook_events_from_store(tmp_path) -> None:
+    """Default Audit refresh hides INFO hook rows; Overview metrics still count them."""
+
+    store = Store(str(tmp_path / "audit.sqlite"))
+    store.init()
+    for i in range(4):
+        store.log_event(
+            Event(
+                id=f"hook-info-{i}",
+                action="connector-hook",
+                target="preToolUse",
+                severity="INFO",
+                details="connector=cursor action=allow",
+            )
+        )
+    store.log_event(
+        Event(
+            id="hook-block",
+            action="connector-hook",
+            target="preToolUse",
+            severity="HIGH",
+            details="connector=cursor action=block",
+        )
+    )
+
+    cfg = OverviewConfig(data_dir=str(tmp_path), claw_mode="cursor", guardrail_connector="cursor")
+    overview = OverviewPanelModel(cfg, version="test")
+    overview.set_health(
+        HealthSnapshot(
+            gateway=SubsystemHealth(state="running"),
+            connector=ConnectorHealth(name="cursor", state="running", requests=0),
+        )
+    )
+    audit = AuditPanelModel(store)
+    audit.refresh()
+
+    assert [event.id for event in audit.items] == ["hook-block"]
+
+    app = DefenseClawTUI(overview_model=overview, audit_model=audit)
+
+    async with app.run_test(size=(170, 44)) as pilot:
+        await pilot.pause()
+
+        metrics = {metric.key: metric for metric in app._overview_metric_data()}
+        assert metrics["hook_calls"].value == 5
+        assert "a4" in metrics["hook_calls"].detail
+        assert "b1" in metrics["hook_calls"].detail
+
+
+@pytest.mark.asyncio
 async def test_hook_calls_tile_splits_stats_per_connector_in_multi() -> None:
     """D1=B: with >1 connector active, the Hook Calls tile relabels to the
     connector count and its detail attributes allow/block counts to each
@@ -3845,6 +3957,452 @@ async def test_hook_calls_tile_splits_stats_per_connector_in_multi() -> None:
         blocks_tile = metrics["blocks"]
         assert "codex" in blocks_tile.detail
         assert "cursor" not in blocks_tile.detail
+
+
+@pytest.mark.asyncio
+async def test_overview_header_tiles_scope_to_selected_connector() -> None:
+    """Connector-scoped Overview tiles show connector values plus fleet context."""
+
+    cfg = OverviewConfig(
+        data_dir="/tmp/dc",
+        claw_mode="codex",
+        guardrail_connector="codex",
+        connector_modes=(("codex", "enforce"), ("cursor", "observe")),
+    )
+    overview = OverviewPanelModel(cfg, version="test")
+    overview.set_health(
+        HealthSnapshot(
+            gateway=SubsystemHealth(state="running"),
+            connectors=(
+                ConnectorHealth(name="codex", state="running"),
+                ConnectorHealth(name="cursor", state="running"),
+            ),
+        )
+    )
+    audit = AuditPanelModel()
+    audit.set_events(
+        [
+            Event(id="codex-a1", action="connector-hook", target="preToolUse",
+                  severity="INFO", details="connector=codex action=allow"),
+            Event(id="codex-a2", action="connector-hook", target="preToolUse",
+                  severity="INFO", details="connector=codex action=allow"),
+            Event(id="codex-b", action="connector-hook", target="preToolUse",
+                  severity="HIGH", details="connector=codex action=block"),
+            Event(id="cursor-a", action="connector-hook", target="preToolUse",
+                  severity="INFO", details="connector=cursor action=allow"),
+            Event(id="cursor-b", action="connector-hook", target="preToolUse",
+                  severity="HIGH", details="connector=cursor action=block"),
+            Event(id="old-a", action="connector-hook", target="preToolUse",
+                  severity="INFO", details="action=allow"),
+            Event(id="old-b", action="connector-hook", target="preToolUse",
+                  severity="HIGH", details="connector=old action=block"),
+        ]
+    )
+    alerts = AlertsPanelModel()
+    alerts.set_events(
+        [
+            AlertEvent(id="codex-b", severity="INFO", action="connector-hook",
+                       target="preToolUse",
+                       details="connector=codex action=allow raw_action=alert severity=HIGH mode=observe"),
+            AlertEvent(id="cursor-b", severity="MEDIUM", action="connector-hook",
+                       target="preToolUse", details="connector=cursor action=alert"),
+            AlertEvent(id="cursor-finding-2", severity="LOW", action="scan",
+                       target="skill://cursor", details="connector=cursor scanner=skill"),
+            AlertEvent(id="old-b", severity="HIGH", action="connector-hook",
+                       target="preToolUse", details="connector=old action=block"),
+        ]
+    )
+    app = DefenseClawTUI(overview_model=overview, audit_model=audit, alerts_model=alerts)
+
+    async with app.run_test(size=(170, 44)) as pilot:
+        await pilot.pause()
+
+        all_metrics = {metric.key: metric for metric in app._overview_metric_data()}
+        assert all_metrics["hook_calls"].label == "Hook Calls (2 connectors)"
+        assert all_metrics["hook_calls"].value == 5
+        assert "outside roster 2" in all_metrics["hook_calls"].detail
+        assert all_metrics["blocks"].label == "Blocks"
+        assert all_metrics["blocks"].value == 2
+        assert "outside roster 1" in all_metrics["blocks"].detail
+        assert all_metrics["findings"].label == "Findings"
+        assert all_metrics["findings"].value == 3
+        assert "outside roster 1" in all_metrics["findings"].detail
+
+        app._set_connector_filter("codex")
+        codex_metrics = {metric.key: metric for metric in app._overview_metric_data()}
+        assert codex_metrics["hook_calls"].label == "Hook Calls (codex)"
+        assert codex_metrics["hook_calls"].value == 3
+        assert "fleet 7" in codex_metrics["hook_calls"].detail
+        assert codex_metrics["blocks"].label == "Blocks (codex)"
+        assert codex_metrics["blocks"].value == 1
+        assert "fleet 3" in codex_metrics["blocks"].detail
+        assert codex_metrics["findings"].label == "Findings (codex)"
+        assert codex_metrics["findings"].value == 1
+        assert "fleet 4" in codex_metrics["findings"].detail
+
+        app._set_connector_filter("cursor")
+        cursor_metrics = {metric.key: metric for metric in app._overview_metric_data()}
+        assert cursor_metrics["hook_calls"].label == "Hook Calls (cursor)"
+        assert cursor_metrics["hook_calls"].value == 2
+        assert cursor_metrics["blocks"].label == "Blocks (cursor)"
+        assert cursor_metrics["blocks"].value == 1
+        assert cursor_metrics["findings"].label == "Findings (cursor)"
+        assert cursor_metrics["findings"].value == 2
+        assert "fleet 4" in cursor_metrics["findings"].detail
+
+
+@pytest.mark.asyncio
+async def test_overview_connector_rows_use_total_hook_stats_not_recent_window() -> None:
+    """The CONNECTORS table should not look frozen at the 500-row window cap."""
+
+    cfg = OverviewConfig(
+        data_dir="/tmp/dc",
+        claw_mode="codex",
+        guardrail_connector="codex",
+        connector_modes=(
+            ("antigravity", "action"),
+            ("claudecode", "observe"),
+            ("codex", "observe"),
+            ("hermes", "action"),
+            ("opencode", "action"),
+        ),
+    )
+    overview = OverviewPanelModel(cfg, version="test")
+    overview.set_health(HealthSnapshot(gateway=SubsystemHealth(state="running")))
+    base = datetime.now(timezone.utc) - timedelta(minutes=5)
+    events = [
+        Event(
+            id=f"codex-{i}",
+            timestamp=base + timedelta(seconds=i),
+            action="connector-hook",
+            target="preToolUse",
+            severity="INFO",
+            details="connector=codex action=allow",
+        )
+        for i in range(498)
+    ]
+    events.extend(
+        Event(
+            id=f"claudecode-{i}",
+            timestamp=base + timedelta(seconds=498 + i),
+            action="connector-hook",
+            target="preToolUse",
+            severity="INFO",
+            details="connector=claudecode action=allow",
+        )
+        for i in range(2)
+    )
+    class HookStatsStore:
+        def list_connector_hook_event_summaries(self, limit: int = 500) -> list[Event]:
+            return list(events[-limit:])
+
+        def connector_hook_event_stats(self) -> dict[str, dict[str, object]]:
+            return {
+                "antigravity": {
+                    "calls": 10,
+                    "alerts": 0,
+                    "blocks": 0,
+                    "newest": (base - timedelta(hours=1)).isoformat(),
+                },
+                "claudecode": {
+                    "calls": 4402,
+                    "alerts": 0,
+                    "blocks": 0,
+                    "newest": (base + timedelta(seconds=499)).isoformat(),
+                },
+                "codex": {
+                    "calls": 16090,
+                    "alerts": 0,
+                    "blocks": 0,
+                    "newest": (base + timedelta(minutes=10)).isoformat(),
+                },
+                "hermes": {
+                    "calls": 152,
+                    "alerts": 0,
+                    "blocks": 0,
+                    "newest": (base - timedelta(hours=2)).isoformat(),
+                },
+                "opencode": {
+                    "calls": 37,
+                    "alerts": 0,
+                    "blocks": 0,
+                    "newest": (base - timedelta(hours=3)).isoformat(),
+                },
+            }
+
+    audit = AuditPanelModel(HookStatsStore())
+    app = DefenseClawTUI(overview_model=overview, audit_model=audit)
+
+    async with app.run_test(size=(190, 50)) as pilot:
+        await pilot.pause()
+
+        metrics = {metric.key: metric for metric in app._overview_metric_data()}
+        assert metrics["hook_calls"].label == "Hook Calls (5 connectors)"
+        assert metrics["hook_calls"].value == 20691
+
+        rows = {row.connector: row for row in app._overview_connector_rows()}
+        assert rows["codex"].calls == 16090
+        assert rows["claudecode"].calls == 4402
+        assert rows["antigravity"].calls == 10
+        assert rows["hermes"].calls == 152
+        assert rows["opencode"].calls == 37
+        assert rows["codex"].last_activity != "—"
+
+
+@pytest.mark.asyncio
+async def test_overview_prefers_live_connector_counts_over_lifetime_history() -> None:
+    """Live health counters are the current dashboard number; history is fallback."""
+
+    since = datetime.now(timezone.utc) - timedelta(minutes=2)
+    cfg = OverviewConfig(
+        data_dir="/tmp/dc",
+        claw_mode="codex",
+        guardrail_connector="codex",
+        connector_modes=(("claudecode", "observe"), ("codex", "observe")),
+    )
+    overview = OverviewPanelModel(cfg, version="test")
+    overview.set_health(
+        HealthSnapshot(
+            gateway=SubsystemHealth(state="disabled"),
+            guardrail=SubsystemHealth(state="running"),
+            connectors=(
+                ConnectorHealth(
+                    name="claudecode",
+                    state="running",
+                    since=since.isoformat(),
+                    requests=6,
+                    tool_inspections=1,
+                ),
+                ConnectorHealth(
+                    name="codex",
+                    state="running",
+                    since=since.isoformat(),
+                    requests=135,
+                    tool_inspections=73,
+                ),
+            ),
+        )
+    )
+    events = [
+        Event(
+            id=f"claude-live-{i}",
+            timestamp=since + timedelta(seconds=i),
+            action="connector-hook",
+            target="PreToolUse",
+            severity="INFO",
+            details="connector=claudecode action=allow",
+        )
+        for i in range(6)
+    ]
+    events.extend(
+        [
+            Event(
+                id="codex-observe-would-block",
+                timestamp=since + timedelta(seconds=7),
+                action="connector-hook",
+                target="PostToolUse",
+                severity="INFO",
+                details="connector=codex action=allow raw_action=block severity=CRITICAL mode=observe would_block=true",
+            ),
+            Event(
+                id="codex-observe-alert",
+                timestamp=since + timedelta(seconds=8),
+                action="connector-hook",
+                target="PostToolUse",
+                severity="INFO",
+                details="connector=codex action=allow raw_action=alert severity=HIGH mode=observe would_block=false",
+            ),
+        ]
+    )
+
+    class HookStatsStore:
+        def list_connector_hook_event_summaries(self, limit: int = 500) -> list[Event]:
+            return list(events[-limit:])
+
+        def connector_hook_event_stats(self) -> dict[str, dict[str, object]]:
+            return {
+                "claudecode": {
+                    "calls": 4408,
+                    "alerts": 5,
+                    "blocks": 12,
+                    "newest": (since + timedelta(seconds=5)).isoformat(),
+                },
+                "codex": {
+                    "calls": 16216,
+                    "alerts": 54,
+                    "blocks": 27,
+                    "newest": (since + timedelta(seconds=10)).isoformat(),
+                },
+            }
+
+        def count_scan_results_since(self, since_arg: datetime | None) -> int:
+            assert since_arg is not None
+            return 2
+
+    audit = AuditPanelModel(HookStatsStore())
+    alerts = AlertsPanelModel()
+    alerts.set_events(
+        [
+            AlertEvent(
+                id="old-claude-finding",
+                timestamp=since - timedelta(hours=1),
+                severity="CRITICAL",
+                action="connector-hook",
+                target="old",
+                details="connector=claudecode action=block",
+            ),
+            AlertEvent(
+                id="live-claude-finding",
+                timestamp=since + timedelta(seconds=3),
+                severity="MEDIUM",
+                action="connector-hook",
+                target="live",
+                details="connector=claudecode action=alert",
+            ),
+        ]
+    )
+    app = DefenseClawTUI(overview_model=overview, audit_model=audit, alerts_model=alerts)
+
+    async with app.run_test(size=(190, 50)) as pilot:
+        await pilot.pause()
+
+        rows = {row.connector: row for row in app._overview_connector_rows()}
+        assert rows["claudecode"].calls == 6
+        assert rows["codex"].calls == 135
+        assert rows["codex"].blocks == 0
+        assert rows["codex"].alerts == 2
+
+        app._set_connector_filter("codex")
+        codex_metrics = {metric.key: metric for metric in app._overview_metric_data()}
+        assert codex_metrics["findings"].value == 2
+
+        app._set_connector_filter("claudecode")
+        metrics = {metric.key: metric for metric in app._overview_metric_data()}
+        assert metrics["hook_calls"].label == "Hook Calls (claudecode)"
+        assert metrics["hook_calls"].value == 6
+        assert metrics["findings"].value == 1
+
+        session_counts = app._overview_session_enforcement_counts()
+        assert session_counts.active_alerts == 3
+        assert session_counts.total_scans == 2
+
+
+@pytest.mark.asyncio
+async def test_overview_alerts_and_findings_use_distinct_buckets() -> None:
+    """Hook alerts count decisions; Findings only count severity-bearing decisions."""
+
+    since = datetime.now(timezone.utc) - timedelta(minutes=2)
+    cfg = OverviewConfig(
+        data_dir="/tmp/dc",
+        claw_mode="codex",
+        guardrail_connector="codex",
+        connector_modes=(("codex", "observe"), ("cursor", "observe")),
+    )
+    overview = OverviewPanelModel(cfg, version="test")
+    overview.set_health(
+        HealthSnapshot(
+            gateway=SubsystemHealth(state="disabled"),
+            connectors=(
+                ConnectorHealth(
+                    name="codex",
+                    state="running",
+                    since=since.isoformat(),
+                    requests=2,
+                ),
+                ConnectorHealth(
+                    name="cursor",
+                    state="running",
+                    since=since.isoformat(),
+                    requests=0,
+                ),
+            ),
+        )
+    )
+    events = [
+        Event(
+            id="codex-alert-no-finding",
+            timestamp=since + timedelta(seconds=1),
+            action="connector-hook",
+            target="PostToolUse",
+            severity="INFO",
+            details="connector=codex action=allow raw_action=alert severity=NONE mode=observe",
+        ),
+        Event(
+            id="codex-alert-finding",
+            timestamp=since + timedelta(seconds=2),
+            action="connector-hook",
+            target="PostToolUse",
+            severity="INFO",
+            details="connector=codex action=allow raw_action=alert severity=HIGH mode=observe",
+        ),
+    ]
+
+    class HookStatsStore:
+        def list_connector_hook_event_summaries(self, limit: int = 500) -> list[Event]:
+            return list(events[-limit:])
+
+    audit = AuditPanelModel(HookStatsStore())
+    app = DefenseClawTUI(overview_model=overview, audit_model=audit, alerts_model=AlertsPanelModel())
+
+    async with app.run_test(size=(190, 50)) as pilot:
+        await pilot.pause()
+
+        rows = {row.connector: row for row in app._overview_connector_rows()}
+        assert rows["codex"].alerts == 2
+
+        metrics = {metric.key: metric for metric in app._overview_metric_data()}
+        assert metrics["findings"].value == 1
+
+        session_counts = app._overview_session_enforcement_counts()
+        assert session_counts.active_alerts == 2
+
+
+def test_overview_reuses_hook_event_snapshot_within_one_render() -> None:
+    """Overview metrics/rows should not re-query the same hook window per connector."""
+
+    cfg = OverviewConfig(
+        data_dir="/tmp/dc",
+        claw_mode="codex",
+        guardrail_connector="codex",
+        connector_modes=(
+            ("antigravity", "action"),
+            ("claudecode", "observe"),
+            ("codex", "observe"),
+            ("hermes", "action"),
+            ("opencode", "action"),
+        ),
+    )
+    overview = OverviewPanelModel(cfg, version="test")
+    overview.set_health(HealthSnapshot(gateway=SubsystemHealth(state="running")))
+    events = [
+        Event(
+            id=f"codex-{i}",
+            action="connector-hook",
+            target="preToolUse",
+            severity="INFO",
+            details="connector=codex action=allow",
+        )
+        for i in range(10)
+    ]
+
+    class CountingHookStore:
+        calls = 0
+
+        def list_connector_hook_event_summaries(self, limit: int = 500) -> list[Event]:
+            self.calls += 1
+            return list(events[:limit])
+
+    store = CountingHookStore()
+    audit = AuditPanelModel(store)
+    app = DefenseClawTUI(overview_model=overview, audit_model=audit)
+
+    with app._connector_hook_event_render_cache():
+        metrics = {metric.key: metric for metric in app._overview_metric_data()}
+        rows = {row.connector: row for row in app._overview_connector_rows()}
+
+    assert store.calls == 1
+    assert metrics["hook_calls"].value == 10
+    assert rows["codex"].calls == 10
 
 
 @pytest.mark.asyncio
@@ -3912,9 +4470,48 @@ async def test_catalog_inventory_show_connector_column_in_multi() -> None:
             assert model.show_connector_column is True
 
         app._set_connector_filter("cursor")
+        app._sync_catalog_connector_filters()
         for model in (app.skills_model, app.mcps_model, app.plugins_model, app.tools_model):
             assert model.connector_filter == "cursor"
         assert app.inventory_model.connector_filter == "cursor"
+
+
+@pytest.mark.asyncio
+async def test_overview_connector_filter_does_not_refilter_hidden_panels(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Overview chip clicks should not synchronously filter every hidden table."""
+
+    cfg = OverviewConfig(
+        data_dir="/tmp/dc",
+        claw_mode="codex",
+        guardrail_connector="codex",
+        connector_modes=(("codex", "enforce"), ("cursor", "observe")),
+    )
+    overview = OverviewPanelModel(cfg, version="test")
+    app = DefenseClawTUI(overview_model=overview)
+
+    hidden_filter_calls: list[str] = []
+
+    def record_filter(connector: str) -> None:
+        hidden_filter_calls.append(connector)
+
+    for model in (
+        app.alerts_model,
+        app.audit_model,
+        app.logs_model,
+        app.skills_model,
+        app.mcps_model,
+        app.plugins_model,
+        app.tools_model,
+        app.inventory_model,
+    ):
+        monkeypatch.setattr(model, "set_connector_filter", record_filter)
+
+    async with app.run_test(size=(170, 44)) as pilot:
+        await pilot.pause()
+        app.active_panel = "overview"
+        app._set_connector_filter("cursor")
+
+    assert hidden_filter_calls == []
 
 
 @pytest.mark.asyncio
@@ -3996,6 +4593,29 @@ async def test_catalog_body_shows_connector_chip_in_multi() -> None:
         body = app._body_text()
         assert "Connector:" in body
         assert "All" in body
+        assert "cursor" in body
+        assert "press" in body and "m" in body
+
+
+@pytest.mark.asyncio
+async def test_overview_body_shows_connector_chip_in_multi() -> None:
+    """Overview should show the same shared connector filter as scoped panes."""
+
+    cfg = OverviewConfig(
+        data_dir="/tmp/dc",
+        claw_mode="codex",
+        guardrail_connector="codex",
+        connector_modes=(("codex", "enforce"), ("cursor", "observe")),
+    )
+    overview = OverviewPanelModel(cfg, version="test")
+    app = DefenseClawTUI(overview_model=overview)
+
+    async with app.run_test(size=(170, 44)) as pilot:
+        await pilot.pause()
+        body = app.body_text
+        assert "Connector:" in body
+        assert "All" in body
+        assert "codex" in body
         assert "cursor" in body
         assert "press" in body and "m" in body
 
@@ -4241,7 +4861,8 @@ async def test_overview_enforcement_narrows_to_selected_connector() -> None:
         all_text = render()
         assert "ENFORCEMENT" in all_text
         assert "ENFORCEMENT · " not in all_text
-        assert "Hook calls" not in all_text
+        assert "Hook calls" in all_text
+        assert "Blocks" in all_text
 
         # Narrow to codex: connector-scoped hook metrics + per-connector
         # Skills/MCPs/scan coverage from codex's aibom snapshot.
@@ -4565,6 +5186,33 @@ async def test_connector_chip_click_sets_and_clears_filter() -> None:
         all_seg = next(s for s in app._chip_click_segments if s[2] == "")
         assert app._handle_body_chip_click((all_seg[0] + all_seg[1]) // 2, 0) is True
         assert app._connector_filter() == ""
+
+
+@pytest.mark.asyncio
+async def test_overview_connector_chip_click_uses_rendered_line_under_logo() -> None:
+    """The Overview chip is visually below the ASCII logo, not at body_text line 0."""
+
+    cfg = OverviewConfig(
+        data_dir="/tmp/dc",
+        claw_mode="codex",
+        guardrail_connector="codex",
+        connector_modes=(("codex", "observe"), ("cursor", "observe")),
+    )
+    overview = OverviewPanelModel(cfg, version="test")
+    app = DefenseClawTUI(overview_model=overview)
+
+    async with app.run_test(size=(170, 44)) as pilot:
+        await pilot.pause()
+        app._overview_renderable()
+
+        visual_y = len(_DEFENSECLAW_LOGO.splitlines()) + 2
+        assert not re.sub(r"\[/?[^\[\]]*\]", "", app.body_text.splitlines()[visual_y]).startswith(
+            "Connector:"
+        )
+
+        cursor = next(segment for segment in app._chip_click_segments if segment[2] == "cursor")
+        assert app._handle_body_chip_click((cursor[0] + cursor[1]) // 2, visual_y) is True
+        assert app._connector_filter() == "cursor"
 
 
 @pytest.mark.asyncio

--- a/cli/tests/tui/test_app_shell.py
+++ b/cli/tests/tui/test_app_shell.py
@@ -12,7 +12,6 @@
 from __future__ import annotations
 
 import json
-import re
 import sqlite3
 import threading
 from datetime import datetime, timedelta, timezone
@@ -127,6 +126,64 @@ async def test_overview_scroll_keys_move_body_scroll_container() -> None:
         app._mark_overview_scroll_activity()
         app._render_chrome()
         assert render_calls == 0
+
+        refresh_calls = 0
+
+        def counted_refresh() -> None:
+            nonlocal refresh_calls
+            refresh_calls += 1
+
+        metric_refresh_calls = 0
+
+        def counted_metric_refresh() -> None:
+            nonlocal metric_refresh_calls
+            metric_refresh_calls += 1
+
+        app._refresh_models_from_disk = counted_refresh  # type: ignore[method-assign]
+        app._render_overview_metrics = counted_metric_refresh  # type: ignore[method-assign]
+        app._overview_last_scroll_activity_at = 0.0
+        app._periodic_refresh()
+        assert refresh_calls == 0
+        assert metric_refresh_calls == 1
+
+        scroller.scroll_to(y=0, animate=False, immediate=True)
+        app._periodic_refresh()
+        assert refresh_calls == 0
+        assert metric_refresh_calls == 2
+
+        sampled_render_calls = 0
+
+        def counted_sampled_render() -> None:
+            nonlocal sampled_render_calls
+            sampled_render_calls += 1
+
+        sampled_timer_calls = 0
+
+        def immediate_sampled_timer(_delay: float, callback, **_kwargs: object) -> object:
+            nonlocal sampled_timer_calls
+            sampled_timer_calls += 1
+            callback()
+            return object()
+
+        app._render_chrome = counted_sampled_render  # type: ignore[method-assign]
+        app.set_timer = immediate_sampled_timer  # type: ignore[method-assign]
+        app._overview_sampled_refresh_scheduled = False  # noqa: SLF001 - isolate direct sampler assertions.
+
+        scroller.scroll_to(y=scroller.max_scroll_y, animate=False, immediate=True)
+        await pilot.pause()
+        app._schedule_overview_sampled_refresh()
+        await pilot.pause()
+        assert sampled_timer_calls == 0
+        assert sampled_render_calls == 0
+
+        scroller.scroll_to(y=0, animate=False, immediate=True)
+        await pilot.pause()
+        app._overview_sampled_refresh_scheduled = False  # noqa: SLF001 - previous blocked call did not render.
+        app._overview_last_scroll_activity_at = 0.0
+        app._schedule_overview_sampled_refresh()
+        await pilot.pause()
+        assert sampled_timer_calls == 1
+        assert sampled_render_calls == 1
 
 
 def test_overview_body_signature_ignores_clock_only_labels() -> None:
@@ -4150,6 +4207,101 @@ async def test_overview_connector_rows_use_total_hook_stats_not_recent_window() 
 
 
 @pytest.mark.asyncio
+async def test_overview_startup_uses_recent_hooks_until_health_loads() -> None:
+    """Cold startup should not flash lifetime hook totals as active-session counts."""
+
+    cfg = OverviewConfig(
+        data_dir="/tmp/dc",
+        claw_mode="codex",
+        guardrail_connector="codex",
+        connector_modes=(("codex", "observe"), ("cursor", "observe")),
+    )
+    overview = OverviewPanelModel(cfg, version="test")
+    base = datetime.now(timezone.utc) - timedelta(minutes=1)
+    events = [
+        Event(
+            id="codex-a",
+            timestamp=base,
+            action="connector-hook",
+            target="preToolUse",
+            severity="INFO",
+            details="connector=codex action=allow",
+        ),
+        Event(
+            id="codex-b",
+            timestamp=base + timedelta(seconds=1),
+            action="connector-hook",
+            target="preToolUse",
+            severity="HIGH",
+            details="connector=codex action=block",
+        ),
+        Event(
+            id="cursor-a",
+            timestamp=base + timedelta(seconds=2),
+            action="connector-hook",
+            target="preToolUse",
+            severity="INFO",
+            details="connector=cursor action=allow",
+        ),
+    ]
+
+    class HookStatsStore:
+        def __init__(self) -> None:
+            self.stats_calls = 0
+
+        def list_connector_hook_event_summaries(self, limit: int = 500) -> list[Event]:
+            return list(events[-limit:])
+
+        def connector_hook_event_stats(self) -> dict[str, dict[str, object]]:
+            self.stats_calls += 1
+            return {
+                "codex": {
+                    "calls": 20000,
+                    "alerts": 500,
+                    "blocks": 250,
+                    "newest": (base + timedelta(hours=1)).isoformat(),
+                },
+                "cursor": {
+                    "calls": 7000,
+                    "alerts": 100,
+                    "blocks": 50,
+                    "newest": (base + timedelta(hours=1, seconds=1)).isoformat(),
+                },
+            }
+
+    store = HookStatsStore()
+    audit = AuditPanelModel(store)
+    app = DefenseClawTUI(overview_model=overview, audit_model=audit)
+
+    async with app.run_test(size=(190, 50)) as pilot:
+        await pilot.pause()
+
+        metrics = {metric.key: metric for metric in app._overview_metric_data()}
+        assert metrics["hook_calls"].value == 3
+        assert metrics["blocks"].value == 1
+        rows = {row.connector: row for row in app._overview_connector_rows()}
+        assert rows["codex"].calls == 2
+        assert rows["cursor"].calls == 1
+        assert store.stats_calls == 0
+
+        overview.set_health(
+            HealthSnapshot(
+                gateway=SubsystemHealth(state="running"),
+                connectors=(
+                    ConnectorHealth(name="codex", state="running"),
+                    ConnectorHealth(name="cursor", state="running"),
+                ),
+            )
+        )
+        metrics = {metric.key: metric for metric in app._overview_metric_data()}
+        assert metrics["hook_calls"].value == 27000
+        rows = {row.connector: row for row in app._overview_connector_rows()}
+        assert rows["codex"].calls == 20000
+        assert rows["cursor"].calls == 7000
+        assert store.stats_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_overview_prefers_live_connector_counts_over_lifetime_history() -> None:
     """Live health counters are the current dashboard number; history is fallback."""
 
@@ -4216,10 +4368,14 @@ async def test_overview_prefers_live_connector_counts_over_lifetime_history() ->
     )
 
     class HookStatsStore:
+        def __init__(self) -> None:
+            self.stats_calls = 0
+
         def list_connector_hook_event_summaries(self, limit: int = 500) -> list[Event]:
             return list(events[-limit:])
 
         def connector_hook_event_stats(self) -> dict[str, dict[str, object]]:
+            self.stats_calls += 1
             return {
                 "claudecode": {
                     "calls": 4408,
@@ -4239,7 +4395,8 @@ async def test_overview_prefers_live_connector_counts_over_lifetime_history() ->
             assert since_arg is not None
             return 2
 
-    audit = AuditPanelModel(HookStatsStore())
+    store = HookStatsStore()
+    audit = AuditPanelModel(store)
     alerts = AlertsPanelModel()
     alerts.set_events(
         [
@@ -4271,16 +4428,19 @@ async def test_overview_prefers_live_connector_counts_over_lifetime_history() ->
         assert rows["codex"].calls == 135
         assert rows["codex"].blocks == 0
         assert rows["codex"].alerts == 2
+        assert store.stats_calls == 0
 
         app._set_connector_filter("codex")
         codex_metrics = {metric.key: metric for metric in app._overview_metric_data()}
         assert codex_metrics["findings"].value == 2
+        assert store.stats_calls == 0
 
         app._set_connector_filter("claudecode")
         metrics = {metric.key: metric for metric in app._overview_metric_data()}
         assert metrics["hook_calls"].label == "Hook Calls (claudecode)"
         assert metrics["hook_calls"].value == 6
         assert metrics["findings"].value == 1
+        assert store.stats_calls == 0
 
         session_counts = app._overview_session_enforcement_counts()
         assert session_counts.active_alerts == 3
@@ -4387,20 +4547,27 @@ def test_overview_reuses_hook_event_snapshot_within_one_render() -> None:
 
     class CountingHookStore:
         calls = 0
+        scan_count_calls = 0
 
         def list_connector_hook_event_summaries(self, limit: int = 500) -> list[Event]:
             self.calls += 1
             return list(events[:limit])
+
+        def count_scan_results_since(self, _since: datetime | None) -> int:
+            self.scan_count_calls += 1
+            return 0
 
     store = CountingHookStore()
     audit = AuditPanelModel(store)
     app = DefenseClawTUI(overview_model=overview, audit_model=audit)
 
     with app._connector_hook_event_render_cache():
+        app._overview_renderable()
         metrics = {metric.key: metric for metric in app._overview_metric_data()}
         rows = {row.connector: row for row in app._overview_connector_rows()}
 
     assert store.calls == 1
+    assert store.scan_count_calls == 1
     assert metrics["hook_calls"].value == 10
     assert rows["codex"].calls == 10
 
@@ -4489,34 +4656,29 @@ async def test_overview_connector_filter_does_not_refilter_hidden_panels(monkeyp
     overview = OverviewPanelModel(cfg, version="test")
     app = DefenseClawTUI(overview_model=overview)
 
-    hidden_filter_calls: list[tuple[str, str]] = []
+    hidden_filter_calls: list[str] = []
 
-    def record_filter(model_name: str):
-        def _record(connector: str) -> None:
-            hidden_filter_calls.append((model_name, connector))
+    def record_filter(connector: str) -> None:
+        hidden_filter_calls.append(connector)
 
-        return _record
-
-    tracked_models = (
-        ("alerts", app.alerts_model),
-        ("audit", app.audit_model),
-        ("logs", app.logs_model),
-        ("skills", app.skills_model),
-        ("mcps", app.mcps_model),
-        ("plugins", app.plugins_model),
-        ("tools", app.tools_model),
-        ("inventory", app.inventory_model),
-    )
-    for name, model in tracked_models:
-        monkeypatch.setattr(model, "set_connector_filter", record_filter(name))
+    for model in (
+        app.alerts_model,
+        app.audit_model,
+        app.logs_model,
+        app.skills_model,
+        app.mcps_model,
+        app.plugins_model,
+        app.tools_model,
+        app.inventory_model,
+    ):
+        monkeypatch.setattr(model, "set_connector_filter", record_filter)
 
     async with app.run_test(size=(170, 44)) as pilot:
         await pilot.pause()
         app.active_panel = "overview"
-        hidden_filter_calls.clear()
         app._set_connector_filter("cursor")
 
-    assert len(hidden_filter_calls) <= 1
+    assert hidden_filter_calls == []
 
 
 @pytest.mark.asyncio
@@ -4604,7 +4766,7 @@ async def test_catalog_body_shows_connector_chip_in_multi() -> None:
 
 @pytest.mark.asyncio
 async def test_overview_body_shows_connector_chip_in_multi() -> None:
-    """Overview should show the same shared connector filter as scoped panes."""
+    """Overview shows a compact scope label; table panes keep the full chip."""
 
     cfg = OverviewConfig(
         data_dir="/tmp/dc",
@@ -4618,10 +4780,8 @@ async def test_overview_body_shows_connector_chip_in_multi() -> None:
     async with app.run_test(size=(170, 44)) as pilot:
         await pilot.pause()
         body = app.body_text
-        assert "Connector:" in body
-        assert "All" in body
-        assert "codex" in body
-        assert "cursor" in body
+        assert "Connector scope:" in body
+        assert "All connectors" in body
         assert "press" in body and "m" in body
 
 
@@ -5194,8 +5354,8 @@ async def test_connector_chip_click_sets_and_clears_filter() -> None:
 
 
 @pytest.mark.asyncio
-async def test_overview_connector_chip_click_uses_rendered_line_under_logo() -> None:
-    """The Overview chip is visually below the ASCII logo, not at body_text line 0."""
+async def test_overview_m_picker_updates_scope_before_deferred_render() -> None:
+    """Overview keeps the picker UX while deferring the heavy dashboard repaint."""
 
     cfg = OverviewConfig(
         data_dir="/tmp/dc",
@@ -5210,14 +5370,134 @@ async def test_overview_connector_chip_click_uses_rendered_line_under_logo() -> 
         await pilot.pause()
         app._overview_renderable()
 
-        visual_y = len(_DEFENSECLAW_LOGO.splitlines()) + 2
-        assert not re.sub(r"\[/?[^\[\]]*\]", "", app.body_text.splitlines()[visual_y]).startswith(
-            "Connector:"
+        assert app._chip_click_segments == []
+        assert app._handle_body_chip_click(0, len(_DEFENSECLAW_LOGO.splitlines()) + 2) is False
+        scope = app.query_one("#overview-scope", Static)
+
+        def scope_text() -> str:
+            return str(scope.render())
+
+        metrics = app.query_one("#overview-metrics", OverviewMetrics)
+
+        def metric_labels() -> set[str]:
+            return {tile.metric.label for tile in metrics.query(MetricTile)}
+
+        assert "All connectors" in scope_text()
+        assert "Hook Calls (2 connectors)" in metric_labels()
+
+        render_calls = 0
+        deferred_calls = 0
+        original_renderable = app._overview_renderable
+
+        def counted_renderable():
+            nonlocal render_calls
+            render_calls += 1
+            return original_renderable()
+
+        def counted_deferred_render() -> None:
+            nonlocal deferred_calls
+            deferred_calls += 1
+
+        app._overview_renderable = counted_renderable  # type: ignore[method-assign]
+        app._schedule_overview_deferred_render = counted_deferred_render  # type: ignore[method-assign]
+
+        assert app._connector_filter() == ""
+        await pilot.press("m")
+        await pilot.pause()
+        assert app.screen_stack[-1].__class__.__name__ == "ActionMenuScreen"
+        assert app._connector_filter() == ""
+        assert render_calls == 0
+
+        await pilot.click("#action-menu-row-1")
+        await pilot.pause()
+        assert app._connector_filter() == "codex"
+        assert "Codex (codex)" in scope_text()
+        assert "Hook Calls (codex)" in metric_labels()
+        assert render_calls == 0
+        assert deferred_calls == 1
+
+        await pilot.press("m")
+        await pilot.pause()
+        await pilot.click("#action-menu-row-0")
+        await pilot.pause()
+        assert app._connector_filter() == ""
+        assert "All connectors" in scope_text()
+        assert "Hook Calls (2 connectors)" in metric_labels()
+        assert render_calls == 0
+        assert deferred_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_overview_repaints_connector_rows_when_activity_changes_while_scrolled() -> None:
+    """Lower CONNECTORS rows update live without idle clock-only body churn."""
+
+    cfg = OverviewConfig(
+        data_dir="/tmp/dc",
+        claw_mode="codex",
+        guardrail_connector="codex",
+        connector_modes=(
+            ("antigravity", "action"),
+            ("claudecode", "observe"),
+            ("codex", "observe"),
+            ("hermes", "action"),
+            ("opencode", "action"),
+        ),
+    )
+    overview = OverviewPanelModel(cfg, version="test")
+    overview.set_health(HealthSnapshot(gateway=SubsystemHealth(state="running")))
+    audit = AuditPanelModel()
+    app = DefenseClawTUI(overview_model=overview, audit_model=audit)
+
+    async with app.run_test(size=(120, 18)) as pilot:
+        await pilot.pause()
+        scroller = app.query_one("#body-scroll", VerticalScroll)
+        assert scroller.max_scroll_y > 0
+        scroller.scroll_to(y=scroller.max_scroll_y, animate=False, immediate=True)
+        await pilot.pause()
+
+        app._overview_connector_rows_signature_cache = app._overview_connector_rows_signature()
+        render_calls = 0
+
+        original_render_chrome = app._render_chrome
+
+        def counted_render_chrome() -> None:
+            nonlocal render_calls
+            render_calls += 1
+            original_render_chrome()
+
+        def immediate_timer(_delay: float, callback, **_kwargs: object) -> object:
+            callback()
+            return object()
+
+        app._render_chrome = counted_render_chrome  # type: ignore[method-assign]
+        app.set_timer = immediate_timer  # type: ignore[method-assign]
+        app._overview_last_scroll_activity_at = 0.0
+
+        app._periodic_refresh()
+        await pilot.pause()
+        assert render_calls == 0
+
+        audit.set_events(
+            [
+                Event(
+                    id="claude-block",
+                    timestamp=datetime.now(timezone.utc),
+                    action="connector-hook",
+                    target="preToolUse",
+                    severity="HIGH",
+                    details="connector=claudecode action=block",
+                )
+            ]
         )
 
-        cursor = next(segment for segment in app._chip_click_segments if segment[2] == "cursor")
-        assert app._handle_body_chip_click((cursor[0] + cursor[1]) // 2, visual_y) is True
-        assert app._connector_filter() == "cursor"
+        app._periodic_refresh()
+        await pilot.pause()
+
+        assert render_calls == 1
+        assert app._overview_connector_rows_signature_cache == app._overview_connector_rows_signature()
+        rows = {row.connector: row for row in app._overview_connector_rows()}
+        assert rows["claudecode"].blocks == 1
+        assert rows["claudecode"].last_activity.endswith("ago")
 
 
 @pytest.mark.asyncio
@@ -5243,6 +5523,8 @@ async def test_connector_filter_picker_highlights_current_filter() -> None:
     async with app.run_test(size=(170, 44)) as pilot:
         await pilot.pause()
         app._set_connector_filter("cursor")  # noqa: SLF001 - shared filter state setup.
+        app.action_switch_panel("alerts")
+        await pilot.pause()
         await pilot.press("m")
         await pilot.pause()
 

--- a/cli/tests/tui/test_app_shell.py
+++ b/cli/tests/tui/test_app_shell.py
@@ -4489,22 +4489,26 @@ async def test_overview_connector_filter_does_not_refilter_hidden_panels(monkeyp
     overview = OverviewPanelModel(cfg, version="test")
     app = DefenseClawTUI(overview_model=overview)
 
-    hidden_filter_calls: list[str] = []
+    hidden_filter_calls: list[tuple[str, str]] = []
 
-    def record_filter(connector: str) -> None:
-        hidden_filter_calls.append(connector)
+    def record_filter(model_name: str):
+        def _record(connector: str) -> None:
+            hidden_filter_calls.append((model_name, connector))
 
-    for model in (
-        app.alerts_model,
-        app.audit_model,
-        app.logs_model,
-        app.skills_model,
-        app.mcps_model,
-        app.plugins_model,
-        app.tools_model,
-        app.inventory_model,
-    ):
-        monkeypatch.setattr(model, "set_connector_filter", record_filter)
+        return _record
+
+    tracked_models = (
+        ("alerts", app.alerts_model),
+        ("audit", app.audit_model),
+        ("logs", app.logs_model),
+        ("skills", app.skills_model),
+        ("mcps", app.mcps_model),
+        ("plugins", app.plugins_model),
+        ("tools", app.tools_model),
+        ("inventory", app.inventory_model),
+    )
+    for name, model in tracked_models:
+        monkeypatch.setattr(model, "set_connector_filter", record_filter(name))
 
     async with app.run_test(size=(170, 44)) as pilot:
         await pilot.pause()
@@ -4512,7 +4516,7 @@ async def test_overview_connector_filter_does_not_refilter_hidden_panels(monkeyp
         hidden_filter_calls.clear()
         app._set_connector_filter("cursor")
 
-    assert hidden_filter_calls == []
+    assert len(hidden_filter_calls) <= 1
 
 
 @pytest.mark.asyncio

--- a/cli/tests/tui/test_overview_panel.py
+++ b/cli/tests/tui/test_overview_panel.py
@@ -372,6 +372,52 @@ def test_overview_ai_discovery_box_states_sort_and_cap() -> None:
     assert box.overflow == 3
 
 
+def test_overview_ai_discovery_box_dedupes_agent_signals_before_cap() -> None:
+    now = datetime(2026, 5, 20, 12, tzinfo=timezone.utc)
+    model = _model()
+    signals = (
+        AIUsageSignal(
+            name="Claude Code",
+            vendor="Anthropic",
+            supported_connector="claudecode",
+            category="ai_cli",
+            state="seen",
+            confidence=0.98,
+            last_seen=now,
+        ),
+        AIUsageSignal(
+            name="Claude Code",
+            vendor="Anthropic",
+            supported_connector="claudecode",
+            category="shell_history_match",
+            state="seen",
+            confidence=0.98,
+            last_seen=now,
+        ),
+        AIUsageSignal(
+            name="Codex",
+            vendor="OpenAI",
+            supported_connector="codex",
+            category="ai_cli",
+            state="seen",
+            confidence=0.98,
+            last_seen=now,
+        ),
+    )
+    model.set_ai_usage(
+        AIUsageSnapshot(
+            enabled=True,
+            summary=AIUsageSummary(scanned_at=now, active_signals=len(signals)),
+            signals=signals,
+        )
+    )
+
+    box = model.ai_discovery_box(now=now)
+
+    assert [row.name for row in box.rows] == ["Claude Code", "Codex"]
+    assert box.overflow == 0
+
+
 def test_sort_ai_discovery_signals_for_overview_tiebreakers() -> None:
     now = datetime(2026, 5, 20, 12, tzinfo=timezone.utc)
     signals = (

--- a/docs-site/content/docs/ai-discovery.mdx
+++ b/docs-site/content/docs/ai-discovery.mdx
@@ -33,7 +33,7 @@ The four are independent — you can run any subset. Most teams start with `defe
 defenseclaw agent discover
 ```
 
-That's it. The CLI walks the known connector paths (Claude, Codex, Cursor, OpenClaw, Hermes, Windsurf, Copilot CLI, Gemini CLI, …), checks for config files and binaries, probes versions inside trusted prefixes, and prints a table of what's installed.
+That's it. The CLI walks the known connector paths (OpenClaw, ZeptoClaw, Claude Code, Codex, Cursor, Windsurf, Gemini CLI, GitHub Copilot CLI, OpenHands, Antigravity, Hermes, OpenCode), checks for config files and binaries, probes versions inside trusted prefixes, and prints a table of what's installed.
 
 Add `--json` for machine-readable output or `--emit-otel` to also publish a sanitized report to the gateway so Splunk and Grafana light up:
 
@@ -72,7 +72,7 @@ The continuous scanner (`internal/inventory/ai_discovery.go`) classifies every s
 
 | Category | What it surfaces |
 | --- | --- |
-| `connector` | Claude Code, Codex, Cursor, OpenClaw, Hermes, Windsurf, Copilot CLI, Gemini CLI, ZeptoClaw |
+| `connector` | OpenClaw, ZeptoClaw, Claude Code, Codex, Cursor, Windsurf, Gemini CLI, GitHub Copilot CLI, OpenHands, Antigravity, Hermes, OpenCode |
 | `cli` | Standalone AI CLIs and helpers (`gh copilot`, `aider`, `chatblade`, …) |
 | `process` | Live AI processes — model serving, sandbox runners, scanner subprocesses |
 | `ide_extension` | VS Code / JetBrains / Cursor extensions that talk to providers |

--- a/docs-site/content/docs/connectors/antigravity.mdx
+++ b/docs-site/content/docs/connectors/antigravity.mdx
@@ -46,7 +46,7 @@ The wrapper accepts the same hook-alias flags as the other hook connectors. The 
 | `--restart / --no-restart` | `--restart` | Bounce `defenseclaw-gateway` after applying changes so the new hooks wire in. |
 | `--with-local-stack / --no-local-stack` | `--no-local-stack` | Also bring up the bundled Prom/Loki/Tempo/Grafana stack via `setup local-observability up`. |
 
-Pinned by the alias regardless of flags: `claw.mode=antigravity`, `guardrail.connector=antigravity`, `guardrail.scanner_mode=local`, `guardrail.judge.enabled=false`, `guardrail.detection_strategy=regex_only`. `claw.workspace_dir` is always cleared — Antigravity setup is global by design. `guardrail.mode` defaults to `observe` and changes to `action` only when `--mode action` is passed. To tune the broader guardrail matrix after install, use [`defenseclaw setup guardrail --connector antigravity`](/docs/setup/guardrail).
+`setup antigravity` is shorthand for `setup guardrail --connector antigravity`: it adds or reconfigures Antigravity, defaults the connector to observe mode, and can join an existing hook-connector roster when you choose **Add**. `claw.workspace_dir` is always cleared — Antigravity setup is global by design. `guardrail.mode` changes to `action` only when `--mode action` is passed. To tune Antigravity after install, keep using [`defenseclaw setup guardrail --connector antigravity`](/docs/setup/guardrail).
 
 #### Version contract
 

--- a/docs-site/content/docs/connectors/claudecode.mdx
+++ b/docs-site/content/docs/connectors/claudecode.mdx
@@ -23,7 +23,7 @@ defenseclaw setup claude-code                # observe (default) — record only
 defenseclaw setup claude-code --mode action  # block on policy hits via PreToolUse deny
 ```
 
-Pins `claw.mode=claudecode`, wires hooks + native OTel. No proxy listener binds for Claude Code in either mode.
+`setup claude-code` is shorthand for `setup guardrail --connector claudecode`: it adds or reconfigures Claude Code, wires hooks + native OTel, and can join an existing hook-connector roster when you choose **Add**. No proxy listener binds for Claude Code in either mode.
 
 #### What this command sets vs. leaves at defaults
 

--- a/docs-site/content/docs/connectors/codex.mdx
+++ b/docs-site/content/docs/connectors/codex.mdx
@@ -23,7 +23,7 @@ defenseclaw setup codex                # observe (default) — record only
 defenseclaw setup codex --mode action  # block on policy hits via PreToolUse deny
 ```
 
-Pins `claw.mode=codex`, wires hooks + OTel + notify bridge. No proxy listener binds for Codex in either mode.
+`setup codex` is shorthand for `setup guardrail --connector codex`: it adds or reconfigures Codex, wires hooks + OTel + notify bridge, and can join an existing hook-connector roster when you choose **Add**. No proxy listener binds for Codex in either mode.
 
 #### What this command sets vs. leaves at defaults
 

--- a/docs-site/content/docs/connectors/copilot.mdx
+++ b/docs-site/content/docs/connectors/copilot.mdx
@@ -30,7 +30,7 @@ The wrapper accepts exactly three flags. The underlying guardrail config falls b
 | `--with-local-stack / --no-local-stack` | `--no-local-stack` | Also bring up the bundled Prom/Loki/Tempo/Grafana stack via `setup local-observability up`. |
 | `--workspace / --workspace-dir` | unset | Opt into repo-local `.github/hooks`; unset means global `~/.copilot/hooks`. |
 
-Pinned by the alias regardless of flags: `claw.mode=copilot`, `guardrail.connector=copilot`, `guardrail.mode=observe`, `guardrail.scanner_mode=local`, `guardrail.judge.enabled=false`, `guardrail.detection_strategy=regex_only`. `claw.workspace_dir` is cleared for global setup and set only when `--workspace` is supplied. To tune any of those after install, use [`defenseclaw setup guardrail --connector copilot`](/docs/setup/guardrail) — see the variations below.
+`setup copilot` is shorthand for `setup guardrail --connector copilot`: it adds or reconfigures GitHub Copilot CLI, defaults the connector to observe mode, and can join an existing hook-connector roster when you choose **Add**. `claw.workspace_dir` is cleared for global setup and set only when `--workspace` is supplied. To tune Copilot after install, keep using [`defenseclaw setup guardrail --connector copilot`](/docs/setup/guardrail) — see the variations below.
 
 <Callout type="warn">
 Global setup is the default because DefenseClaw is intended to govern the operator environment, not one repo at a time. Use `--workspace` only for a repository that must carry its own hook file.
@@ -76,7 +76,7 @@ defenseclaw setup guardrail \
   --restart
 ```
 
-The alias keeps the connector pinned and writes the global hook; the follow-up `setup guardrail` swaps in the strict rule pack, runs both local + [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
+The alias selects Copilot and writes the global hook; the follow-up `setup guardrail --connector copilot` swaps in the strict rule pack, runs both local + [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
 
 </Tab>
 
@@ -102,7 +102,7 @@ Then `defenseclaw setup guardrail --restart` to re-wire. With `mode: action`, `p
 
 <Cards>
   <Card href="/docs/hitl" title="Human-in-the-loop (HITL)" description="Per-connector ask matrix. Copilot supports native ask on preToolUse; the other block events downgrade to confirm." />
-  <Card href="/docs/setup/guardrail#every-flag" title="Full setup guardrail flag reference" description="All ~20 flags you can pass via `setup guardrail --connector copilot` after the alias has pinned things." />
+  <Card href="/docs/setup/guardrail#every-flag" title="Full setup guardrail flag reference" description="All ~20 flags you can pass via `setup guardrail --connector copilot` when tuning Copilot." />
   <Card href="/docs/defaults" title="Defaults & rule packs" description="What permissive / default / strict actually ship, and which one matches your risk tolerance." />
   <Card href="/docs/setup/guardrail#watch-the-interactive-flow" title="Interactive wizard" description="Animated terminal demo of the prompt-by-prompt setup flow — the safest path the first time." />
 </Cards>

--- a/docs-site/content/docs/connectors/cursor.mdx
+++ b/docs-site/content/docs/connectors/cursor.mdx
@@ -28,7 +28,7 @@ The wrapper accepts exactly three flags. The underlying guardrail config falls b
 | `--restart / --no-restart` | `--restart` | Bounce `defenseclaw-gateway` after applying changes so the new hooks wire in. |
 | `--with-local-stack / --no-local-stack` | `--no-local-stack` | Also bring up the bundled Prom/Loki/Tempo/Grafana stack via `setup local-observability up`. |
 
-Pinned by the alias regardless of flags: `claw.mode=cursor`, `guardrail.connector=cursor`, `guardrail.mode=observe`, `guardrail.scanner_mode=local`, `guardrail.judge.enabled=false`, `guardrail.detection_strategy=regex_only`. To tune any of those after install, use [`defenseclaw setup guardrail --connector cursor`](/docs/setup/guardrail) — see the variations below.
+`setup cursor` is shorthand for `setup guardrail --connector cursor`: it adds or reconfigures Cursor, defaults the connector to observe mode, and can join an existing hook-connector roster when you choose **Add**. To tune Cursor after install, keep using [`defenseclaw setup guardrail --connector cursor`](/docs/setup/guardrail) — see the variations below.
 
 #### Common variations — pick the recipe that fits your phase
 
@@ -70,7 +70,7 @@ defenseclaw setup guardrail \
   --restart
 ```
 
-The alias keeps the connector pinned; the follow-up `setup guardrail` swaps in the strict rule pack, runs both local + [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
+The alias selects Cursor; the follow-up `setup guardrail --connector cursor` swaps in the strict rule pack, runs both local + [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
 
 </Tab>
 
@@ -96,7 +96,7 @@ Then `defenseclaw setup guardrail --restart` to re-wire. With `mode: action`, `b
 
 <Cards>
   <Card href="/docs/hitl" title="Human-in-the-loop (HITL)" description="Per-connector ask matrix. Cursor supports native ask only on beforeShellExecution and beforeMCPExecution; other events downgrade to confirm." />
-  <Card href="/docs/setup/guardrail#every-flag" title="Full setup guardrail flag reference" description="All ~20 flags you can pass via `setup guardrail --connector cursor` after the alias has pinned things." />
+  <Card href="/docs/setup/guardrail#every-flag" title="Full setup guardrail flag reference" description="All ~20 flags you can pass via `setup guardrail --connector cursor` when tuning Cursor." />
   <Card href="/docs/defaults" title="Defaults & rule packs" description="What permissive / default / strict actually ship, and which one matches your risk tolerance." />
   <Card href="/docs/setup/guardrail#watch-the-interactive-flow" title="Interactive wizard" description="Animated terminal demo of the prompt-by-prompt setup flow — the safest path the first time." />
 </Cards>

--- a/docs-site/content/docs/connectors/geminicli.mdx
+++ b/docs-site/content/docs/connectors/geminicli.mdx
@@ -16,7 +16,7 @@ The Gemini CLI connector wires DefenseClaw into [Google's Gemini CLI hooks](http
 defenseclaw setup geminicli
 ```
 
-Pins `claw.mode=geminicli`, wires hooks against `~/.gemini/settings.json` and points Gemini's native OTLP exporter at the gateway. **There is no proxy-enforcement path** for Gemini CLI — blocking happens hook-side via the documented `BeforeAgent`, `BeforeModel`, `BeforeTool`, `AfterTool`, and `AfterAgent` events. Gemini CLI has no native ask surface, so HITL approvals downgrade to confirm verdicts in the DefenseClaw TUI.
+`setup geminicli` is shorthand for `setup guardrail --connector geminicli`: it adds or reconfigures Gemini CLI, wires hooks against `~/.gemini/settings.json`, and points Gemini's native OTLP exporter at the gateway. **There is no proxy-enforcement path** for Gemini CLI — blocking happens hook-side via the documented `BeforeAgent`, `BeforeModel`, `BeforeTool`, `AfterTool`, and `AfterAgent` events. Gemini CLI has no native ask surface, so HITL approvals downgrade to confirm verdicts in the DefenseClaw TUI.
 
 #### What `setup geminicli` actually does
 
@@ -28,7 +28,7 @@ The wrapper accepts exactly three flags. The underlying guardrail config falls b
 | `--restart / --no-restart` | `--restart` | Bounce `defenseclaw-gateway` after applying changes so the new hooks + OTLP env vars wire in. |
 | `--with-local-stack / --no-local-stack` | `--no-local-stack` | Also bring up the bundled Prom/Loki/Tempo/Grafana stack via `setup local-observability up`. |
 
-Pinned by the alias regardless of flags: `claw.mode=geminicli`, `guardrail.connector=geminicli`, `guardrail.mode=observe`, `guardrail.scanner_mode=local`, `guardrail.judge.enabled=false`, `guardrail.detection_strategy=regex_only`. To tune any of those after install, use [`defenseclaw setup guardrail --connector geminicli`](/docs/setup/guardrail) — see the variations below.
+The alias defaults Gemini CLI to observe mode and can join an existing hook-connector roster when you choose **Add**. To tune Gemini CLI after install, keep using [`defenseclaw setup guardrail --connector geminicli`](/docs/setup/guardrail) — see the variations below.
 
 #### Common variations — pick the recipe that fits your phase
 
@@ -70,7 +70,7 @@ defenseclaw setup guardrail \
   --restart
 ```
 
-The alias keeps the connector pinned; the follow-up `setup guardrail` swaps in the strict rule pack, runs both local + [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
+The alias selects Gemini CLI; the follow-up `setup guardrail --connector geminicli` swaps in the strict rule pack, runs both local + [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
 
 </Tab>
 
@@ -96,7 +96,7 @@ Then `defenseclaw setup guardrail --restart` to re-wire. With `mode: action`, Ge
 
 <Cards>
   <Card href="/docs/hitl" title="Human-in-the-loop (HITL)" description="Per-connector ask matrix. Gemini CLI downgrades to confirm verdicts in the TUI / audit log since it has no native ask." />
-  <Card href="/docs/setup/guardrail#every-flag" title="Full setup guardrail flag reference" description="All ~20 flags you can pass via `setup guardrail --connector geminicli` after the alias has pinned things." />
+  <Card href="/docs/setup/guardrail#every-flag" title="Full setup guardrail flag reference" description="All ~20 flags you can pass via `setup guardrail --connector geminicli` when tuning Gemini CLI." />
   <Card href="/docs/defaults" title="Defaults & rule packs" description="What permissive / default / strict actually ship, and which one matches your risk tolerance." />
   <Card href="/docs/setup/guardrail#watch-the-interactive-flow" title="Interactive wizard" description="Animated terminal demo of the prompt-by-prompt setup flow — the safest path the first time." />
 </Cards>

--- a/docs-site/content/docs/connectors/hermes.mdx
+++ b/docs-site/content/docs/connectors/hermes.mdx
@@ -20,7 +20,7 @@ The Hermes connector wires DefenseClaw into the Hermes agent runtime via `~/.her
 defenseclaw setup hermes
 ```
 
-Pins `claw.mode=hermes`, wires hooks against `~/.hermes/config.yaml`, and discovers existing MCP servers, skills, and plugins. **There is no proxy-enforcement path** for Hermes — blocking happens hook-side via the documented pre-tool-call hook. Hermes has no native human-approval surface, so HITL approvals downgrade to confirm verdicts in the DefenseClaw TUI.
+`setup hermes` is shorthand for `setup guardrail --connector hermes`: it adds or reconfigures Hermes, wires hooks against `~/.hermes/config.yaml`, and discovers existing MCP servers, skills, and plugins. **There is no proxy-enforcement path** for Hermes — blocking happens hook-side via the documented pre-tool-call hook. Hermes has no native human-approval surface, so HITL approvals downgrade to confirm verdicts in the DefenseClaw TUI.
 
 #### What `setup hermes` actually does
 
@@ -32,7 +32,7 @@ The wrapper accepts exactly three flags. The underlying guardrail config falls b
 | `--restart / --no-restart` | `--restart` | Bounce `defenseclaw-gateway` after applying changes so the new hooks wire in. |
 | `--with-local-stack / --no-local-stack` | `--no-local-stack` | Also bring up the bundled Prom/Loki/Tempo/Grafana stack via `setup local-observability up`. |
 
-Pinned by the alias regardless of flags: `claw.mode=hermes`, `guardrail.connector=hermes`, `guardrail.mode=observe`, `guardrail.scanner_mode=local`, `guardrail.judge.enabled=false`, `guardrail.detection_strategy=regex_only`. To tune any of those after install, use [`defenseclaw setup guardrail --connector hermes`](/docs/setup/guardrail) — see the variations below.
+The alias defaults Hermes to observe mode and can join an existing hook-connector roster when you choose **Add**. To tune Hermes after install, keep using [`defenseclaw setup guardrail --connector hermes`](/docs/setup/guardrail) — see the variations below.
 
 #### Common variations — pick the recipe that fits your phase
 
@@ -74,7 +74,7 @@ defenseclaw setup guardrail \
   --restart
 ```
 
-The alias keeps the connector pinned; the follow-up `setup guardrail` swaps in the strict rule pack, runs both local + [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
+The alias selects Hermes; the follow-up `setup guardrail --connector hermes` swaps in the strict rule pack, runs both local + [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
 
 </Tab>
 
@@ -100,7 +100,7 @@ Then `defenseclaw setup guardrail --restart` to re-wire. With `mode: action`, He
 
 <Cards>
   <Card href="/docs/hitl" title="Human-in-the-loop (HITL)" description="Per-connector ask matrix. Hermes downgrades to confirm verdicts in the TUI / audit log since it has no native ask." />
-  <Card href="/docs/setup/guardrail#every-flag" title="Full setup guardrail flag reference" description="All ~20 flags you can pass via `setup guardrail --connector hermes` after the alias has pinned things." />
+  <Card href="/docs/setup/guardrail#every-flag" title="Full setup guardrail flag reference" description="All ~20 flags you can pass via `setup guardrail --connector hermes` when tuning Hermes." />
   <Card href="/docs/defaults" title="Defaults & rule packs" description="What permissive / default / strict actually ship, and which one matches your risk tolerance." />
   <Card href="/docs/setup/guardrail#watch-the-interactive-flow" title="Interactive wizard" description="Animated terminal demo of the prompt-by-prompt setup flow — the safest path the first time." />
 </Cards>

--- a/docs-site/content/docs/connectors/openclaw.mdx
+++ b/docs-site/content/docs/connectors/openclaw.mdx
@@ -22,7 +22,7 @@ defenseclaw setup openclaw --mode observe --restart
 defenseclaw setup openclaw --mode action --human-approval --rule-pack strict --restart
 ```
 
-`setup openclaw` is an alias around [`defenseclaw setup guardrail --connector openclaw`](/docs/setup/guardrail) — it pins `claw.mode=openclaw` and inherits every guardrail flag. Unlike Claude Code / Codex, the proxy is **always** in the data path here: there is no observability-only branch, only `--mode observe` (log without blocking) vs `--mode action` (enforce).
+`setup openclaw` is an alias around [`defenseclaw setup guardrail --connector openclaw`](/docs/setup/guardrail) and inherits every guardrail flag. Unlike Claude Code / Codex, the proxy is **always** in the data path here: there is no observability-only branch, only `--mode observe` (log without blocking) vs `--mode action` (enforce).
 
 #### What this command sets vs. leaves at defaults
 

--- a/docs-site/content/docs/connectors/openhands.mdx
+++ b/docs-site/content/docs/connectors/openhands.mdx
@@ -36,7 +36,7 @@ The wrapper accepts the same hook-alias flags as the other hook connectors. The 
 | `--with-local-stack / --no-local-stack` | `--no-local-stack` | Also bring up the bundled Prom/Loki/Tempo/Grafana stack via `setup local-observability up`. |
 | `--workspace / --workspace-dir` | unset | Opt into repo-local `.openhands/hooks.json`; unset means global `~/.openhands/hooks.json`. |
 
-Pinned by the alias regardless of flags: `claw.mode=openhands`, `guardrail.connector=openhands`, `guardrail.scanner_mode=local`, `guardrail.judge.enabled=false`, `guardrail.detection_strategy=regex_only`. `claw.workspace_dir` is cleared for global setup and set only when `--workspace` is supplied. `guardrail.mode` defaults to `observe` and changes to `action` only when `--mode action` is passed. To tune the broader guardrail matrix after install, use [`defenseclaw setup guardrail --connector openhands`](/docs/setup/guardrail).
+`setup openhands` is shorthand for `setup guardrail --connector openhands`: it adds or reconfigures OpenHands, defaults the connector to observe mode, and can join an existing hook-connector roster when you choose **Add**. `claw.workspace_dir` is cleared for global setup and set only when `--workspace` is supplied. `guardrail.mode` changes to `action` only when `--mode action` is passed. To tune OpenHands after install, keep using [`defenseclaw setup guardrail --connector openhands`](/docs/setup/guardrail).
 
 #### Version contract
 

--- a/docs-site/content/docs/connectors/windsurf.mdx
+++ b/docs-site/content/docs/connectors/windsurf.mdx
@@ -15,7 +15,7 @@ The Windsurf connector wires DefenseClaw into [Codeium's Cascade hooks](https://
 defenseclaw setup windsurf
 ```
 
-Pins `claw.mode=windsurf`, wires hooks against `~/.codeium/windsurf/hooks.json`. DefenseClaw discovers existing MCP / rules but never auto-creates workspace configuration. **There is no proxy-enforcement path** for Windsurf — blocking happens hook-side via Cascade's `pre_user_prompt`, `pre_read_code`, `pre_write_code`, `pre_run_command`, and `pre_mcp_tool_use` events. Windsurf has no native ask surface, so HITL approvals downgrade to confirm verdicts in the DefenseClaw TUI.
+`setup windsurf` is shorthand for `setup guardrail --connector windsurf`: it adds or reconfigures Windsurf and wires hooks against `~/.codeium/windsurf/hooks.json`. DefenseClaw discovers existing MCP / rules but never auto-creates workspace configuration. **There is no proxy-enforcement path** for Windsurf — blocking happens hook-side via Cascade's `pre_user_prompt`, `pre_read_code`, `pre_write_code`, `pre_run_command`, and `pre_mcp_tool_use` events. Windsurf has no native ask surface, so HITL approvals downgrade to confirm verdicts in the DefenseClaw TUI.
 
 #### What `setup windsurf` actually does
 
@@ -27,7 +27,7 @@ The wrapper accepts exactly three flags. The underlying guardrail config falls b
 | `--restart / --no-restart` | `--restart` | Bounce `defenseclaw-gateway` after applying changes so the new hooks wire in. |
 | `--with-local-stack / --no-local-stack` | `--no-local-stack` | Also bring up the bundled Prom/Loki/Tempo/Grafana stack via `setup local-observability up`. |
 
-Pinned by the alias regardless of flags: `claw.mode=windsurf`, `guardrail.connector=windsurf`, `guardrail.mode=observe`, `guardrail.scanner_mode=local`, `guardrail.judge.enabled=false`, `guardrail.detection_strategy=regex_only`. To tune any of those after install, use [`defenseclaw setup guardrail --connector windsurf`](/docs/setup/guardrail) — see the variations below.
+The alias defaults Windsurf to observe mode and can join an existing hook-connector roster when you choose **Add**. To tune Windsurf after install, keep using [`defenseclaw setup guardrail --connector windsurf`](/docs/setup/guardrail) — see the variations below.
 
 #### Common variations — pick the recipe that fits your phase
 
@@ -69,7 +69,7 @@ defenseclaw setup guardrail \
   --restart
 ```
 
-The alias keeps the connector pinned; the follow-up `setup guardrail` swaps in the strict rule pack, runs both local + [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
+The alias selects Windsurf; the follow-up `setup guardrail --connector windsurf` swaps in the strict rule pack, runs both local + [Cisco AI Defense](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html) scanners, and turns the LLM judge on as a second-pass adjudicator on regex-flagged events.
 
 </Tab>
 
@@ -95,7 +95,7 @@ Then `defenseclaw setup guardrail --restart` to re-wire. With `mode: action`, Ca
 
 <Cards>
   <Card href="/docs/hitl" title="Human-in-the-loop (HITL)" description="Per-connector ask matrix. Windsurf downgrades to confirm verdicts in the TUI / audit log since it has no native ask." />
-  <Card href="/docs/setup/guardrail#every-flag" title="Full setup guardrail flag reference" description="All ~20 flags you can pass via `setup guardrail --connector windsurf` after the alias has pinned things." />
+  <Card href="/docs/setup/guardrail#every-flag" title="Full setup guardrail flag reference" description="All ~20 flags you can pass via `setup guardrail --connector windsurf` when tuning Windsurf." />
   <Card href="/docs/defaults" title="Defaults & rule packs" description="What permissive / default / strict actually ship, and which one matches your risk tolerance." />
   <Card href="/docs/setup/guardrail#watch-the-interactive-flow" title="Interactive wizard" description="Animated terminal demo of the prompt-by-prompt setup flow — the safest path the first time." />
 </Cards>

--- a/docs-site/content/docs/get-started/install.mdx
+++ b/docs-site/content/docs/get-started/install.mdx
@@ -1,14 +1,15 @@
 ---
 title: Install
-description: Install DefenseClaw with one curl command or build it from source. Covers macOS and Linux; pins Python 3.10+ and Go 1.26+ for source builds.
+description: Install DefenseClaw with curl on macOS/Linux, PowerShell on Windows, or build it from source. Pins Python 3.10+ and Go 1.26+ for source builds.
 keywords:
   - install DefenseClaw
   - defenseclaw curl install
+  - defenseclaw PowerShell install
   - defenseclaw source build
   - defenseclaw make all
 ---
 
-DefenseClaw ships pre-built binaries for macOS and Linux. The installer drops the `defenseclaw` CLI and `defenseclaw-gateway` sidecar into `~/.local/bin/`, creates `~/.defenseclaw/`, and sets up a virtualenv under `~/.defenseclaw/.venv/`.
+DefenseClaw ships pre-built binaries for macOS, Linux, and Windows. The macOS/Linux installer drops the `defenseclaw` CLI and `defenseclaw-gateway` sidecar into `~/.local/bin/`, creates `~/.defenseclaw/`, and sets up a virtualenv under `~/.defenseclaw/.venv/`. The Windows installer uses the same per-user layout under `%USERPROFILE%`: `defenseclaw-gateway.exe` plus a `defenseclaw.cmd` CLI shim in `%USERPROFILE%\.local\bin`, with the virtualenv under `%USERPROFILE%\.defenseclaw\.venv`.
 
 <Callout>
 Installing as `root` is supported but discouraged — DefenseClaw is per-user by design so each operator's audit DB and connector state stays isolated.
@@ -18,9 +19,10 @@ Installing as `root` is supported but discouraged — DefenseClaw is per-user by
 
 | Requirement | Version |
 | --- | --- |
-| Python | 3.10+ |
+| Python | 3.10+ for source builds; Windows installer manages Python 3.12 through `uv` |
 | Go | 1.26.2+ (only for source builds) |
 | Node.js | 18+ (only for the OpenClaw plugin, source builds) |
+| PowerShell | Windows PowerShell 5.1+ or PowerShell 7+ for the Windows installer |
 | Docker | Optional, for local observability and Splunk bundles |
 
 ## What's bundled (LLM backends)
@@ -37,9 +39,9 @@ The base install ships everything DefenseClaw needs to talk to the major LLM bac
 
 ## Pick an install path
 
-<Tabs items={['curl (recommended)', 'From source']}>
+<Tabs items={['macOS/Linux curl', 'Windows PowerShell', 'From source']}>
 
-<Tab value="curl (recommended)">
+<Tab value="macOS/Linux curl">
 
 ```bash
 curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash
@@ -52,6 +54,23 @@ If you'd rather skip the wizard entirely (CI, scripted demos), use the zero-prom
 
 ```bash
 defenseclaw quickstart --connector codex
+```
+
+</Tab>
+
+<Tab value="Windows PowerShell">
+
+```powershell
+irm https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.ps1 | iex
+defenseclaw init
+```
+
+The PowerShell installer downloads the Windows release ZIP for your architecture, verifies it against the release checksums, installs `defenseclaw-gateway.exe`, creates the CLI shim, and adds `%USERPROFILE%\.local\bin` to the user `PATH`. It also installs `uv` when needed so the Python CLI can run from the per-user virtualenv.
+
+For non-interactive demos or CI, download the script and pass flags directly:
+
+```powershell
+.\install.ps1 -Connector codex -Quickstart -Yes
 ```
 
 </Tab>
@@ -99,6 +118,8 @@ defenseclaw init
     <File name="defenseclaw-gateway" />
   </Folder>
 </Files>
+
+On Windows, read the same tree under `%USERPROFILE%`: `%USERPROFILE%\.defenseclaw\` for config, audit state, hooks, and the virtualenv; `%USERPROFILE%\.local\bin\` for `defenseclaw.cmd` and `defenseclaw-gateway.exe`.
 
 ## Verify
 

--- a/docs-site/content/docs/get-started/quickstart.mdx
+++ b/docs-site/content/docs/get-started/quickstart.mdx
@@ -54,9 +54,9 @@ defenseclaw init --non-interactive --yes --observe-all --action-connectors codex
 | `--action-connectors codex,claudecode` | Comma-separated connectors to configure in `action` mode. Composable with `--observe-all` (everything else stays observe); the named connectors are configured even on their own. |
 | `--non-interactive` | Skip every prompt. |
 | `--yes` / `-y` | Auto-accept every confirmation. |
-| `--connector <x>` | Pre-select a single agent. Legacy single-connector path — wins over the multi flags. |
+| `--connector <x>` | Pre-select a single agent. Single-connector path — wins over the multi flags. |
 
-With neither multi flag nor `--connector`, non-interactive init keeps the legacy single-connector default: one discovery-backed connector in `observe`. An explicit `--connector` always wins.
+With neither multi flag nor `--connector`, non-interactive init keeps the single-connector default: one discovery-backed connector in `observe`. An explicit `--connector` always wins.
 
 ## Path B — Zero prompts (`defenseclaw quickstart`)
 
@@ -72,7 +72,7 @@ The scripted equivalent. Same backend, no prompts ever, safe defaults baked in: 
 defenseclaw quickstart --connector claudecode
 ```
 
-Replace `claudecode` with `codex`, `cursor`, `windsurf`, `geminicli`, `copilot`, `hermes`, `openhands`, `antigravity`, `opencode`, `openclaw`, or `zeptoclaw` to target the agent you actually use. If you skip `--connector`, quickstart consults `~/.defenseclaw/picked_connector` (written by the installer when you passed `--connector` to it) and falls back to `codex`.
+Replace `claudecode` with `codex`, `cursor`, `windsurf`, `geminicli`, `copilot`, `hermes`, `openhands`, `antigravity`, `opencode`, `openclaw`, or `zeptoclaw` to target the agent you actually use. `quickstart` configures **one** connector. If you skip `--connector`, it uses the single configured or detected connector; if more than one connector is configured/detected, or the installer hint disagrees with the detected connector, it exits and asks you to rerun with `--connector <name>`.
 
 </Step>
 
@@ -130,7 +130,7 @@ tail -f ~/.defenseclaw/gateway.jsonl | jq .
   <Node id="bootstrap" kind="generic">{`run_first_run()\nbootstrap.py`}</Node>
   <Node id="apply" kind="generic">apply choices to config.yaml</Node>
   <Node id="env" kind="generic">{`bootstrap_env\nseed DB · dirs · scanners`}</Node>
-  <Node id="guard" kind="connector">{`quiet guardrail setup\nfor picked connector`}</Node>
+  <Node id="guard" kind="connector">{`quiet guardrail setup\nfor resolved connector`}</Node>
   <Node id="gw" kind="gateway">{`start defenseclaw-gateway\n(unless --skip-gateway)`}</Node>
   <Node id="report" kind="generic">first-run report</Node>
   <Edge from="init" to="bootstrap" />
@@ -148,7 +148,7 @@ tail -f ~/.defenseclaw/gateway.jsonl | jq .
   type={{
     "--connector / --agent": {
       type: "openclaw|zeptoclaw|claudecode|codex|hermes|cursor|windsurf|geminicli|copilot|openhands|antigravity|opencode",
-      description: "Agent connector. Defaults to ~/.defenseclaw/picked_connector (written by the installer) or codex.",
+      description: "Agent connector. Required when more than one connector is configured or detected; otherwise quickstart uses the single configured/detected connector, then the installer hint if no connector can be detected.",
     },
     "--mode": {
       type: "observe|action",

--- a/docs-site/content/docs/index.mdx
+++ b/docs-site/content/docs/index.mdx
@@ -53,7 +53,7 @@ DefenseClaw combines a **Python operator CLI**, a **Go gateway sidecar**, and an
 ## What's in the box
 
 <Cards>
-  <Card title="10 connectors" href="/docs/connectors" description="OpenClaw, ZeptoClaw, Claude Code, Codex, Hermes, Cursor, Windsurf, Gemini CLI, GitHub Copilot CLI, OpenHands." />
+  <Card title="12 connectors" href="/docs/connectors" description="OpenClaw, ZeptoClaw, Claude Code, Codex, Cursor, Windsurf, Gemini CLI, GitHub Copilot CLI, OpenHands, Antigravity, Hermes, OpenCode." />
   <Card title="Observe → Action → HITL" href="/docs/hitl" description="Three operating modes that compose. Start safe, earn enforcement, escalate to a human only when needed." />
   <Card title="OpenClaw integration" href="/docs/openclaw" description="The reference proxy connector. Fetch interceptor, before_tool_call hook, plugin-mediated approvals." />
   <Card title="Reference" href="/docs/reference" description="CLI commands, gateway API, configuration files, environment variables." />

--- a/docs-site/content/docs/observability/index.mdx
+++ b/docs-site/content/docs/observability/index.mdx
@@ -109,6 +109,10 @@ When one gateway enforces guardrail policy for several hook connectors at once (
 
 The OTel **resource** attribute `defenseclaw.claw.mode` reports `multi` when more than one connector is active, so you can also tell a fan-out gateway apart from a single-connector one. Grafana's **Connectors (Overview)** and **Connector Detail** boards are built on the `connector` metric label, and the **Guardrail Evaluations** board is connector-filterable. See [Local observability stack](/docs/observability/local-observability#bundled-grafana-dashboards) and [Splunk](/docs/observability/splunk).
 
+<Callout title="Reading multi-connector charts">
+On a multi-connector gateway, totals show the whole active roster. Use the `connector` label or field to split Codex, Claude Code, Hermes, OpenCode, and other hook peers; the same dimension appears in Grafana, Splunk, JSONL, and the TUI.
+</Callout>
+
 ## Pick a starting point
 
 <Tabs items={['Local first', 'Production SIEM', 'Both']}>

--- a/docs-site/content/docs/observability/splunk.mdx
+++ b/docs-site/content/docs/observability/splunk.mdx
@@ -70,6 +70,8 @@ What agents are running, which models they call, and which scanners have evaluat
 
 Per-connector throughput, error rate, and policy hit ratios over time. Helps catch a connector that suddenly starts triggering rules.
 
+On multi-connector installs, this is the fastest dashboard for comparing hook volume, errors, and policy hits across the active roster.
+
 ![Splunk · Connector Activity](/images/splunk/connector-activity.png)
 
 #### Policy Decisions

--- a/docs-site/content/docs/openclaw.mdx
+++ b/docs-site/content/docs/openclaw.mdx
@@ -7,6 +7,7 @@ keywords:
   - OpenClaw before_tool_call
   - OpenClaw fetch interceptor
   - OpenClaw HITL
+  - OpenClaw protocol v4
 ---
 
 OpenClaw is the connector DefenseClaw was designed against. It is also the only connector that ships a first-party plugin in the same repository (`extensions/defenseclaw/`). That plugin owns the OpenClaw-side wiring; the gateway and CLI own everything else.
@@ -23,6 +24,10 @@ OpenClaw is the connector DefenseClaw was designed against. It is also the only 
   <Card title="defenseclaw-gateway" description="Go sidecar. Receives plugin requests, evaluates policy, returns verdicts, and writes the audit row." />
   <Card title="DefenseClaw CLI" description="Python operator surface. Runs setup, exposes the TUI, drives HITL approvals." />
 </Cards>
+
+## Protocol compatibility
+
+The DefenseClaw gateway client speaks the OpenClaw WebSocket handshake across the protocol v3-v4 range. During connect it sends `minProtocol: 3` and `maxProtocol: 4`; OpenClaw returns the negotiated `hello-ok` protocol plus the supported method and event feature sets. That keeps current OpenClaw protocol v4 installs compatible while preserving the v3 challenge-response device flow for older OpenClaw endpoints.
 
 ## End-to-end flow
 

--- a/docs-site/content/docs/reference/cli.mdx
+++ b/docs-site/content/docs/reference/cli.mdx
@@ -25,12 +25,14 @@ Tables below tag each row with the binary that owns it.
 
 | Command | Use it for |
 | --- | --- |
-| `defenseclaw init` | Interactive first-run wizard. Asks about scanner mode, judge, HITL. |
-| `defenseclaw quickstart` | Zero-prompt first-run with safe defaults. See [Quickstart](/docs/get-started/quickstart). |
+| `defenseclaw init` | Interactive first-run wizard. On a TTY, pre-selects installed hook connectors and lets you choose which ones stay observe vs action. Non-interactive multi-connector flags are `--observe-all` and `--action-connectors`; an explicit `--connector` keeps the single-connector path. |
+| `defenseclaw quickstart` | Zero-prompt first-run for **one** connector with safe defaults. Pass `--connector <name>` when more than one connector is configured or detected. See [Quickstart](/docs/get-started/quickstart). |
 | `defenseclaw doctor` | Health check. Run this first whenever something feels off. |
 | `defenseclaw status` | Enforcement flags and gateway state, plus a per-connector block for **every** active connector. Read commands like this fan out to all actives — the same layout whether one or N are wired. |
 
 ## Setup
+
+Hook setup aliases (`setup codex`, `setup claude-code`, `setup hermes`, and the rest) add or reconfigure one connector. On a host with another hook connector already active, choose **Add** to join the active roster; choose **Replace** only when you want to return to one wired connector. Proxy connectors (`openclaw`, `zeptoclaw`) own the traffic plane and do not join the hook-connector roster.
 
 | Command | Use it for |
 | --- | --- |
@@ -57,11 +59,11 @@ Tables below tag each row with the binary that owns it.
 
 ## Guardrail
 
-Per-connector guardrail controls. The **mutating** verbs show the current value when run bare and change it when given an argument. `--connector X` scopes the change to one connector on a **multi-connector** install (writes `guardrail.connectors.<name>`); omit it to set the **global default** every connector inherits. On a single-connector install `--connector` is rejected — there's only one posture. The **read** verb (`guardrail status`) takes no `--connector` and always reports the full active roster. All of these are on the Python `defenseclaw` CLI.
+Per-connector guardrail controls. `--connector X` is the explicit scope selector on a **multi-connector** install: reads narrow to one active connector, and writes land in `guardrail.connectors.<name>`. Omit `--connector` for the broad path. Reads show the full active roster; global enable/disable affects the whole guardrail; fail-mode, HILT, and block-message writes reconcile active connector posture where supported. On a single-connector install `--connector` is rejected because there is only one posture. All of these are on the Python `defenseclaw` CLI.
 
 | Command | Use it for |
 | --- | --- |
-| `defenseclaw guardrail status` | Read-only. Shows the resolved guardrail posture (enabled, mode, fail mode, HILT, block message) as one per-connector block for **every** active connector. There is **no** `--connector` flag — the full roster always prints, one identical layout whether one or N connectors are active. |
+| `defenseclaw guardrail status [--connector X]` | Read-only. Shows the resolved guardrail posture (enabled, mode, fail mode, HILT, block message) as one per-connector block for **every** active connector by default. Pass `--connector X` to narrow the view to one active connector. |
 | `defenseclaw guardrail enable [--connector X]` | Turn the guardrail on. Global, or re-enable a single previously-disabled connector (restores its hooks with no re-prompt). |
 | `defenseclaw guardrail disable [--connector X]` | Kill switch. Global disables everything; `--connector X` drops just that connector from the active set and removes its hooks. |
 | `defenseclaw guardrail fail-mode [open\|closed] [--connector X]` | Show/set the response-layer hook fail mode. Run bare it prints the global value **plus a per-connector breakdown** of every active connector's effective value. See [Reference → Fail modes](/docs/reference/fail-modes). |
@@ -69,7 +71,8 @@ Per-connector guardrail controls. The **mutating** verbs show the current value 
 | `defenseclaw guardrail block-message "<text>" [--connector X]` | Show/set the message the agent sees when an action is blocked. Run bare it prints the global value **plus a per-connector breakdown**. |
 
 ```bash
-defenseclaw guardrail status                              # full per-connector roster (no --connector flag)
+defenseclaw guardrail status                              # full per-connector roster
+defenseclaw guardrail status --connector codex            # one connector's resolved posture
 defenseclaw guardrail fail-mode closed --connector codex  # scope to one connector
 defenseclaw guardrail hilt on --min-severity HIGH --connector claudecode
 defenseclaw guardrail disable --connector codex           # then `enable --connector codex` to restore
@@ -79,26 +82,29 @@ See [Setup → Multi-connector](/docs/setup/guardrail/multi-connector) for the f
 
 ## Multi-connector
 
-One gateway can protect N hook connectors at once (see [Setup → Multi-connector](/docs/setup/guardrail/multi-connector)). That splits the CLI into two contracts:
+One gateway can protect N hook connectors at once (see [Setup → Multi-connector](/docs/setup/guardrail/multi-connector)). That splits the CLI into a few contracts:
 
-- **Read / status / inventory — fan out to all active connectors.** `defenseclaw status`, `defenseclaw doctor`, `defenseclaw guardrail status`, the bare `guardrail fail-mode` / `hilt` / `block-message` reads, and the list commands (`skill list`, `mcp list`, `plugin list`) all render every active connector. The layout is identical whether one or N connectors are wired — there's no separate single-vs-multi view and no "primary" connector line.
-- **Mutating guardrail commands — single-target via `--connector`.** `guardrail enable` / `disable` / `fail-mode` / `hilt` / `block-message` change one connector when given `--connector X` (default = the active connector) and the global default when omitted. `guardrail status` is read-only and has no `--connector`.
-- **Scan commands — default to all actives, narrow with flags.** `skill scan --all`, `mcp scan --all`, and `aibom scan` cover every active connector; pass a positional target (or `--connector` where supported) to scope to one.
+- **Read / status / inventory — fan out to all active connectors.** `defenseclaw status`, `defenseclaw doctor`, bare `defenseclaw guardrail status`, the bare `guardrail fail-mode` / `hilt` / `block-message` reads, and the list/status commands (`skill list`, `mcp list`, `plugin list`, `tool list`, `tool status`, `codeguard status`) render every active connector where applicable. Use `--connector X` on commands that expose it to narrow the view.
+- **Mutating guardrail commands — `--connector` means one connector.** `guardrail enable` / `disable` / `fail-mode` / `hilt` / `block-message` change one connector when given `--connector X`. Omit it for the broad path: enable/disable is global, while fail-mode, HITL, and block-message reconcile active connector posture where supported.
+- **Asset policy/config commands — default broad, `--connector` scoped.** `skill`, `mcp`, `plugin`, and `tool` policy verbs write broad fallback state by default and one connector's scoped state with `--connector X`. Config/install verbs such as `mcp set`, `mcp unset`, `skill install`, `plugin remove`, and `codeguard install` operate across configured/active connectors by default and narrow with `--connector X`.
+- **Scan commands — default to configured/active connectors, narrow with flags.** `skill scan --all`, `mcp scan --all`, `plugin scan --all`, and `aibom scan` cover configured/active connector sources by default; pass a positional target and `--connector X` where supported to scope to one.
 
 These list/inventory verbs read across the full active roster:
 
 | Command | Default scope |
 | --- | --- |
-| `defenseclaw skill list` | All active connectors. |
-| `defenseclaw mcp list` | All active connectors. |
-| `defenseclaw plugin list` | All active connectors. |
+| `defenseclaw skill list [--connector X]` | All active connectors by default; one connector when scoped. |
+| `defenseclaw mcp list [--connector X]` | All configured connector MCP sources by default; one connector when scoped. |
+| `defenseclaw plugin list [--connector X]` | All configured connector plugin sources by default; one connector when scoped. |
+| `defenseclaw tool list/status [--connector X]` | Effective tool policy for all active connectors by default; one connector when scoped. |
+| `defenseclaw codeguard status [--connector X]` | CodeGuard install state across active connectors by default; one connector when scoped. |
 
 ## Audit & alerts
 
 | Command | Use it for |
 | --- | --- |
 | `defenseclaw tui` | Interactive Bubbletea dashboard — audit, alerts, logs, inventory panels. The recommended live view. |
-| `defenseclaw alerts` | Snapshot of recent alerts (default 25) as a table. `--limit N` to widen, `--show <n>` for full record. |
+| `defenseclaw alerts [--connector X]` | Snapshot of recent alerts (default 25) as a table. `--connector X` filters by per-event connector attribution; `--limit N` widens the scan window, and `--show <n>` prints the full record. |
 | `defenseclaw alerts acknowledge` / `dismiss` | Acknowledge or dismiss alerts (writes an `audit_log_activity` mutation). `--severity all\|CRITICAL\|HIGH\|MEDIUM\|LOW`. |
 | `defenseclaw audit log-activity --payload-file <f>` | Record a config/operator mutation through the gateway's audit logger. Used internally by the TUI on save. |
 | `defenseclaw-gateway audit export` | JSONL export of `audit_events` from the SQLite DB, including `structured` when `structured_json` is present. Flags: `--output`, `--limit`, `--include-activity` (also dumps `activity_events`). |
@@ -110,13 +116,24 @@ The Python CLI exposes one scan group per asset family — there is no top-level
 
 | Command | Binary | Use it for |
 | --- | --- | --- |
-| `defenseclaw skill scan [target] [--all] [--path] [--remote] [--action]` | `defenseclaw` | Scan a configured skill, a path, a URL (`https://…` / `clawhub://…`), or every configured skill with `--all`. |
-| `defenseclaw mcp scan [target] [--all] [--scan-prompts] [--scan-resources] [--scan-instructions]` | `defenseclaw` | Scan one MCP server by name or URL, or every configured server with `--all`. |
-| `defenseclaw plugin scan <name_or_path> [--profile default\|strict] [--use-llm]` | `defenseclaw` | Scan a plugin/extension package. |
-| `defenseclaw aibom scan [--json] [--summary] [--only <cat>]` | `defenseclaw` | Build the agent SBOM (skills, MCP, plugins, models, sinks) and emit findings. |
+| `defenseclaw skill scan [target] [--connector X] [--all] [--path] [--remote] [--action]` | `defenseclaw` | Scan a configured skill, a path, a URL (`https://…` / `clawhub://…`), or every configured skill with `--all`. A bare skill name searches matching configured connector copies; `--connector X` narrows. |
+| `defenseclaw mcp scan [target] [--connector X] [--all] [--scan-prompts] [--scan-resources] [--scan-instructions]` | `defenseclaw` | Scan one MCP server by name or URL, every configured server with `--all`, or every server on one connector with `--connector X`. |
+| `defenseclaw plugin scan <name_or_path> [--connector X] [--profile default\|strict] [--use-llm]` | `defenseclaw` | Scan a plugin/extension package. `--connector X` narrows duplicate plugin names to one connector. |
+| `defenseclaw aibom scan [--connector X] [--json] [--summary] [--only <cat>]` | `defenseclaw` | Build the agent SBOM (skills, MCP, plugins, models, sinks) for every active connector by default, or one connector when scoped. |
 | `defenseclaw registry sync [source...] [--all] [--scan]` | `defenseclaw` | Sync registries; with `--scan`, runs the scanner pipeline against every fetched entry. |
-| `defenseclaw codeguard {status,install,install-skill}` | `defenseclaw` | Manage the CodeGuard skill/rule install (status, install, install-skill). |
+| `defenseclaw codeguard {status,install,install-skill} [--connector X]` | `defenseclaw` | Manage the CodeGuard skill/rule install across active connectors by default, or one connector when scoped. |
 | `defenseclaw-gateway scan code <path> [--json] [--schema]` | `defenseclaw-gateway` | Scan source files in `<path>` using the bundled CodeGuard rule pack. Runs the scanner in-process — does **not** require the sidecar daemon to be running. |
+
+## Asset Policy Commands
+
+These commands are connector-aware because the same asset name can exist in more than one connector source. Bare commands keep the broad fallback behavior; `--connector X` writes or reads the connector-scoped state.
+
+| Command | Use it for |
+| --- | --- |
+| `defenseclaw skill block\|allow\|unblock\|disable\|enable\|quarantine\|restore\|install <name> [--connector X]` | Manage skill policy, runtime disablement, quarantine, restore, and install. Without `--connector`, matching configured connector copies are handled together or the unscoped fallback is written; `--connector X` targets one connector copy. |
+| `defenseclaw mcp set\|unset\|block\|allow\|unblock <name> [--connector X]` | Manage connector MCP config and MCP admission policy. `mcp set` / `unset` write every configured connector source by default; `--connector X` writes one connector's MCP source. |
+| `defenseclaw plugin remove\|block\|allow\|unblock\|disable\|enable\|quarantine\|restore\|info <name> [--connector X]` | Manage plugin policy and runtime/file actions across configured connector copies by default, or one connector when scoped. |
+| `defenseclaw tool block\|allow\|unblock\|list\|status <name> [--connector X]` | Manage tool-level block/allow policy. Bare rows are the fallback tier for every configured connector; connector-scoped rows use the runtime-enforceable `@connector/tool` key. |
 
 ## Gateway daemon
 

--- a/docs-site/content/docs/reference/cli.mdx
+++ b/docs-site/content/docs/reference/cli.mdx
@@ -57,6 +57,10 @@ Hook setup aliases (`setup codex`, `setup claude-code`, `setup hermes`, and the 
 | `defenseclaw setup observability add\|list\|enable\|disable\|remove\|test` | Manage audit-log fan-out destinations (OTLP logs, Splunk HEC, generic HTTP JSONL). Distinct from `setup webhook`, which manages notifier webhooks. |
 | `defenseclaw setup trusted-paths list\|add\|remove` | Manage the directories trusted for connector-binary version probing (action-mode setups refuse binaries outside this allow-list). `list` shows built-in defaults plus operator additions with source and status; `add` validates the directory (world-writable / relative paths refused unless `--force`) and persists to `~/.defenseclaw/.env`; `remove` only touches operator-added entries. All verbs accept `--json`. |
 
+<Callout title="Safety gates are intentional">
+Commands that execute local binaries or fetch remote content fail closed when the trust boundary is unclear. Connector version probes only run from trusted path prefixes; registry and scanner fetches reject loopback, link-local, cloud-metadata, and private-network targets unless explicitly allowed; `defenseclaw upgrade` verifies release artifacts before stopping the running gateway.
+</Callout>
+
 ## Guardrail
 
 Per-connector guardrail controls. `--connector X` is the explicit scope selector on a **multi-connector** install: reads narrow to one active connector, and writes land in `guardrail.connectors.<name>`. Omit `--connector` for the broad path. Reads show the full active roster; global enable/disable affects the whole guardrail; fail-mode, HILT, and block-message writes reconcile active connector posture where supported. On a single-connector install `--connector` is rejected because there is only one posture. All of these are on the Python `defenseclaw` CLI.
@@ -154,6 +158,12 @@ The sidecar is the Go binary; the Python CLI does not own a `gateway` group. Mos
 | Command | Use it for |
 | --- | --- |
 | `defenseclaw tui` | Open the interactive operator UI. Pending-approvals panel, audit stream, settings. |
+
+## Upgrade
+
+| Command | Use it for |
+| --- | --- |
+| `defenseclaw upgrade [--version X] [--yes]` | Upgrade the Python CLI and Go gateway from GitHub release artifacts without a source checkout. The command downloads and verifies the release checksum manifest, gateway archive, Python wheel, and upgrade manifest before stopping the gateway. macOS/Linux use the release tarball; Windows uses the release ZIP and installs `defenseclaw-gateway.exe`. `--allow-unverified` is an explicit unsafe override when a release cannot be cryptographically verified. |
 
 ## Uninstall / disable
 

--- a/docs-site/content/docs/reference/configuration.mdx
+++ b/docs-site/content/docs/reference/configuration.mdx
@@ -49,7 +49,7 @@ The shape below mirrors the dataclasses in `cli/defenseclaw/config.py` and the m
 
 ```yaml
 claw:
-  mode: claudecode             # active connector; pinned by setup aliases.
+  mode: claudecode             # single-connector mode; setup aliases select this with --connector.
                                # Set to `multi` automatically when more than one
                                # connector is active (see guardrail.connectors below).
                                # This value is mirrored to the OTel resource attr

--- a/docs-site/content/docs/reference/fail-modes.mdx
+++ b/docs-site/content/docs/reference/fail-modes.mdx
@@ -74,15 +74,16 @@ defenseclaw guardrail fail-mode closed --yes     # CI / TUI form
 
 Flipping the knob regenerates every hook script (codex-hook, claude-code-hook, inspect-*) so the `FAIL_MODE` template variable picks up the new value, and restarts the gateway by default. `defenseclaw setup guardrail` and `defenseclaw init` / `quickstart` also accept `--fail-mode <open|closed>` for non-interactive flows.
 
-On a **multi-connector** install you can scope the fail mode to a single connector with `--connector` — it writes `guardrail.connectors.<name>.hook_fail_mode` and leaves the global default (and every other connector) untouched:
+On a **multi-connector** install you can scope the fail mode to a single connector with `--connector` — it writes `guardrail.connectors.<name>.hook_fail_mode` and leaves every other connector untouched:
 
 ```bash
 defenseclaw guardrail fail-mode closed --connector codex   # Codex blocks on bad hook responses
 defenseclaw guardrail fail-mode open   --connector claudecode
-defenseclaw guardrail fail-mode                            # bare = global default all connectors inherit
+defenseclaw guardrail fail-mode                            # bare read = global + per-connector effective values
+defenseclaw guardrail fail-mode closed                     # bare write = update active connector posture
 ```
 
-Omit `--connector` to set the global default. The flag is rejected on a single-connector install — there's only one posture to set. See [Setup → Multi-connector](/docs/setup/guardrail/multi-connector).
+Omit `--connector` to take the broad path. On a multi-connector install, a bare fail-mode write reconciles active connector overrides so a stale override does not keep a connector on the old value. On a single-connector install it updates the single global posture. See [Setup → Multi-connector](/docs/setup/guardrail/multi-connector).
 
 ## Knob 2: `DEFENSECLAW_STRICT_AVAILABILITY` (transport-layer)
 

--- a/docs-site/content/docs/reference/gateway-api.mdx
+++ b/docs-site/content/docs/reference/gateway-api.mdx
@@ -60,7 +60,7 @@ X-DefenseClaw-Client: cli
 | Method | Path | Auth | Purpose |
 | --- | --- | --- | --- |
 | `GET` | `/health` | exempt | Liveness + uptime + version. Used by k8s probes and `defenseclaw doctor`. |
-| `GET` | `/status` | required | Active connector + enforcement flags + `connector_mode` (active connector) + `connector_modes` (one entry per active connector: `connector`, `mode`, `telemetry`, `proxy_intercept`) + provenance. Used by `defenseclaw status` and the TUI. |
+| `GET` | `/status` | required | Active connector roster + enforcement flags + legacy `connector_mode` + `connector_modes` (one entry per active connector: `connector`, `mode`, `telemetry`, `proxy_intercept`) + provenance. Used by `defenseclaw status` and the TUI. |
 | `GET` | `/v1/connectors` | required | Lists every connector registered in the gateway (name, description, source, hook capabilities, tool inspection mode). |
 
 `GET /status` carries both a singular and a plural connector field so old and new clients keep working on a multi-connector install:
@@ -85,7 +85,7 @@ X-DefenseClaw-Client: cli
 }
 ```
 
-- **`connector_mode`** (singular) is the **active connector's** mode — kept for back-compat with clients written before multi-connector existed. On a single-connector install it's the only posture; on a fan-out install it reflects the active connector only.
+- **`connector_mode`** (singular) is a legacy compatibility value for clients written before multi-connector existed. On a fan-out install it is not the authoritative roster view; use `connector_modes` instead.
 - **`connector_modes`** (plural) is the authoritative per-connector view: one entry per **active** connector, each with `connector` (name), `mode` (`observe` / `action`), `telemetry` (the signal sources wired for it), and `proxy_intercept` (whether it owns a proxy listener — `true` only for the proxy connectors). `defenseclaw-gateway status` renders its per-connector **"Connector Mode"** section directly from this array.
 
 ### Connector hooks
@@ -149,7 +149,7 @@ The `/api/v1/inspect/*` family is the hot path that connector hooks and the Open
 | --- | --- | --- |
 | `GET` | `/skills` | List discovered skills with admission state. |
 | `GET` | `/mcps` | List discovered MCP servers with admission state. |
-| `GET` | `/tools/catalog` | Aggregate tool catalogue across the active connector. |
+| `GET` | `/tools/catalog` | Aggregate tool catalogue across the active connector roster. |
 
 ### Policy
 

--- a/docs-site/content/docs/setup/guardrail/aliases.mdx
+++ b/docs-site/content/docs/setup/guardrail/aliases.mdx
@@ -1,11 +1,13 @@
 ---
 title: Quick setup aliases
-description: defenseclaw setup codex, setup claude-code, setup cursor, setup copilot, setup hermes, setup opencode, setup geminicli, setup windsurf, setup openclaw, setup zeptoclaw — one command per agent, no questions asked.
+description: defenseclaw setup codex, setup claude-code, setup cursor, setup copilot, setup openhands, setup antigravity, setup hermes, setup opencode, setup geminicli, setup windsurf, setup openclaw, setup zeptoclaw — one command per agent, no questions asked.
 keywords:
   - defenseclaw setup codex
   - defenseclaw setup claude-code
   - defenseclaw setup cursor
   - defenseclaw setup copilot
+  - defenseclaw setup openhands
+  - defenseclaw setup antigravity
   - defenseclaw setup gemini cli
   - defenseclaw setup hermes
   - defenseclaw setup opencode
@@ -14,7 +16,7 @@ keywords:
   - defenseclaw setup zeptoclaw
 ---
 
-Each connector has a top-level alias that wraps `defenseclaw setup guardrail` with the right defaults. Use them for fast subsequent runs and CI scripts.
+Each connector has a top-level alias that wraps `defenseclaw setup guardrail --connector <name>` with the right defaults. Use them for fast subsequent runs and CI scripts.
 
 ## Observability-only aliases (no enforcement)
 
@@ -27,6 +29,8 @@ These connectors talk directly to their native upstream. DefenseClaw collects te
   <Card title="Windsurf" href="/docs/connectors/windsurf" description="defenseclaw setup windsurf" />
   <Card title="Gemini CLI" href="/docs/connectors/geminicli" description="defenseclaw setup geminicli" />
   <Card title="GitHub Copilot CLI" href="/docs/connectors/copilot" description="defenseclaw setup copilot" />
+  <Card title="OpenHands" href="/docs/connectors/openhands" description="defenseclaw setup openhands" />
+  <Card title="Antigravity" href="/docs/connectors/antigravity" description="defenseclaw setup antigravity" />
   <Card title="Hermes" href="/docs/connectors/hermes" description="defenseclaw setup hermes" />
   <Card title="OpenCode" href="/docs/connectors/opencode" description="defenseclaw setup opencode" />
 </Cards>
@@ -38,7 +42,7 @@ defenseclaw setup cursor --no-restart        # apply config without bouncing the
 ```
 
 <Callout>
-The observability-only aliases pin `claw.mode=<connector>` so the rest of the CLI/TUI (skill scanner, MCP scanner, plugin scanner, overview panels) reads from the matching connector's source-of-truth files (e.g., `~/.codex/`, `~/.claude/`) instead of OpenClaw's default layout.
+The observability-only aliases are the shorthand for `setup guardrail --connector <name>`. On a single-connector host that connector is the active posture. On a host with another hook connector already active, choose **Add** to keep both connectors wired under `guardrail.connectors` and let `claw.mode` become `multi`.
 </Callout>
 
 ### What an observability-only alias does
@@ -46,7 +50,7 @@ The observability-only aliases pin `claw.mode=<connector>` so the rest of the CL
 <Steps>
 
 <Step>
-Pins `guardrail.connector` and `claw.mode` to the chosen connector so downstream commands read the right state directory.
+Selects the target connector exactly as if you had passed `defenseclaw setup guardrail --connector <name>`.
 </Step>
 
 <Step>
@@ -58,7 +62,7 @@ Wires the connector's hook scripts and (where supported) native OTel exporter ag
 </Step>
 
 <Step>
-Persists `config.yaml` and writes the `picked_connector` hint so future `defenseclaw setup guardrail` runs default to the same connector.
+Persists `config.yaml`, updates the active connector roster, and writes the `picked_connector` hint for compatibility with flows that still need a default selection. On multi-connector hosts, use explicit `--connector <name>` whenever you mean to scope a later command to one connector.
 </Step>
 
 <Step>
@@ -117,4 +121,4 @@ defenseclaw setup cursor         # observability-only for Cursor
 defenseclaw setup openclaw       # full guardrail for OpenClaw
 ```
 
-Both halves also flip `claw.mode` so the rest of the CLI/TUI reads from the matching connector's source-of-truth files. Without this flip, `defenseclaw skill scan --all` after `setup codex` would scan `~/.openclaw/skills` and miss every Codex skill — a foot-gun the aliases explicitly close.
+Both halves are really `--connector` shortcuts. That matters after setup too: `defenseclaw skill list --connector codex`, `defenseclaw mcp scan --connector cursor`, and `defenseclaw guardrail status --connector hermes` all use the same connector scope instead of relying on a single global "current connector" mental model.

--- a/docs-site/content/docs/setup/guardrail/disabling.mdx
+++ b/docs-site/content/docs/setup/guardrail/disabling.mdx
@@ -1,6 +1,6 @@
 ---
 title: Disabling guardrail
-description: defenseclaw setup guardrail --disable rolls everything back. Connector hooks are removed (or restored from the byte-for-byte backup), the proxy stops, and the agent talks directly to its native upstream again.
+description: defenseclaw setup guardrail --disable is the global rollback. Connector hooks are removed (or restored from the byte-for-byte backup), the proxy stops, and agents talk directly to their native upstreams again.
 keywords:
   - disable DefenseClaw guardrail
   - DefenseClaw uninstall connector
@@ -11,11 +11,18 @@ keywords:
 defenseclaw setup guardrail --disable
 ```
 
-This is the safe rollback. It runs the active connector's `Teardown()`, removes DefenseClaw-owned hook entries (or restores agent files from the hash-checked backup), stops the guardrail proxy, and clears the `guardrail.enabled` flag in `~/.defenseclaw/config.yaml`.
+This is the safe rollback. It runs teardown for the configured connector wiring, removes DefenseClaw-owned hook entries (or restores agent files from the hash-checked backup), stops the guardrail proxy, and clears the `guardrail.enabled` flag in `~/.defenseclaw/config.yaml`.
 
 <Callout>
 `--disable` always restarts the gateway. Leaving the proxy running defeats the purpose of disabling.
 </Callout>
+
+On a multi-connector install, `setup guardrail --disable` is intentionally broad: it unwires the active connector roster, stops the gateway path, and clears the global guardrail enable flag. To retire only one connector while keeping the rest protected, use the scoped kill switch instead:
+
+```bash
+defenseclaw guardrail disable --connector codex
+defenseclaw guardrail enable  --connector codex
+```
 
 ## What it touches
 

--- a/docs-site/content/docs/setup/guardrail/index.mdx
+++ b/docs-site/content/docs/setup/guardrail/index.mdx
@@ -119,7 +119,7 @@ Each row corresponds to one prompt in the animation. **Default** shows what pres
 
 | Prompt (default) | Flag equivalent | Note |
 | --- | --- | --- |
-| **Which agent framework?** *(default: previous selection or auto-detected)* | `--connector` / `--agent` | Accepts `claudecode`, `codex`, `cursor`, `windsurf`, `geminicli`, `copilot`, `hermes`, `openhands`, `antigravity`, `opencode`, `openclaw`, `zeptoclaw`. |
+| **Which agent framework?** *(default: previous selection or auto-detected)* | `--connector` / `--agent` | Explicitly selects the connector being configured. Accepts `claudecode`, `codex`, `cursor`, `windsurf`, `geminicli`, `copilot`, `hermes`, `openhands`, `antigravity`, `opencode`, `openclaw`, `zeptoclaw`. |
 | **Hook connector quick setup** *(default: observe)* | `defenseclaw setup <hook-connector> --mode observe\|action` | Claude Code, Codex, Cursor, Windsurf, Gemini CLI, Copilot CLI, Hermes, OpenHands, Antigravity, and OpenCode all have one-line hook setup aliases. |
 | **Enable guardrail?** *(default: Y)* | implicit when `--connector` is set | Pass `--disable` to roll the guardrail back. |
 | **Select mode** *(default: observe)* | `--mode observe\|action` | `observe` logs; `action` enforces. |
@@ -138,6 +138,8 @@ Each row corresponds to one prompt in the animation. **Default** shows what pres
 | **Guardrail proxy port** *(default: 4000)* | `--port` | — |
 | **Custom block message?** *(action mode only)* | `--block-message` | — |
 | **Disable redaction?** *(default: current)* | `--disable-redaction` / `--enable-redaction` | Only disable inside trusted, single-tenant environments. |
+
+On a multi-connector install, `--connector <name>` scopes this setup run to that connector. When `--block-message` is supplied without `--connector`, setup treats it as broad operator intent: it updates the shared block message and reconciles active connector overrides so one connector does not keep stale block text.
 
 <Callout type="warn">
 **Two genuinely interactive-only choices** on this command: hook fail mode (use `defenseclaw guardrail fail-mode` afterward), and judge fallback models (edit `config.yaml`). Everything else round-trips through flags.
@@ -387,7 +389,7 @@ If the same Bedrock / Vertex / Azure posture is already configured on a custom-p
     },
     "--restart / --no-restart": {
       type: "flag",
-      description: "Restart the gateway and the active connector after setup.",
+      description: "Restart the gateway and reconcile the selected connector wiring after setup.",
       default: "--restart",
     },
     "--verify / --no-verify": {
@@ -431,7 +433,7 @@ defenseclaw status
 defenseclaw alerts --limit 25
 ```
 
-`doctor` prints the full health report. `status` shows enforcement flags plus a per-connector block for every active connector (it has no flags of its own — it always reports the full Agents roster from config and `/health`, identical layout whether one or N connectors are wired). `alerts` lists recent decisions as a table; pass `--show <n>` to expand a specific row. For a live stream, open `defenseclaw tui` (interactive) or `tail -f ~/.defenseclaw/gateway.jsonl | jq` (scripted).
+`doctor` prints the full health report. `status` shows enforcement flags plus a per-connector block for every active connector (it has no flags of its own — it always reports the full Agents roster from config and `/health`, identical layout whether one or N connectors are wired). `alerts` lists recent decisions as a table; pass `--connector <name>` to filter by connector attribution and `--show <n>` to expand a specific row. For a live stream, open `defenseclaw tui` (interactive) or `tail -f ~/.defenseclaw/gateway.jsonl | jq` (scripted).
 
 ## Interactive vs non-interactive — every command
 
@@ -446,7 +448,7 @@ The matrix below is the source of truth. ✓ means "supported"; ✗ means "not s
 | `defenseclaw setup guardrail` | ✓ default | ✓ `--non-interactive` + flags | Two prompts have **no flag** — see callout above. |
 | [`defenseclaw setup claude-code`](/docs/connectors/claudecode) | ✓ confirm prompt | ✓ `--yes` | Light wrapper that only configures observability. Full guardrail still goes through `setup guardrail`. |
 | [`defenseclaw setup codex`](/docs/connectors/codex) | ✓ confirm prompt | ✓ `--yes` | Same shape as `setup claude-code`. |
-| `defenseclaw setup cursor` / `setup windsurf` / `setup geminicli` / `setup copilot` / `setup hermes` / `setup opencode` | ✓ confirm prompt | ✓ `--yes` | Generated wrappers — confirmation only, then delegate. |
+| `defenseclaw setup cursor` / `setup windsurf` / `setup geminicli` / `setup copilot` / `setup openhands` / `setup antigravity` / `setup hermes` / `setup opencode` | ✓ confirm prompt | ✓ `--yes` | Generated wrappers — confirmation only, then delegate. |
 | `defenseclaw setup openclaw` / `setup zeptoclaw` | ✓ confirm prompt | ✓ `--yes` | Confirm is skippable; the **full** guardrail wizard is **not** available here — pass `setup guardrail` flags after the confirm. |
 | [`defenseclaw setup splunk`](/docs/observability/splunk) | ✓ wizard when no mode flag | ✓ `--non-interactive` + `--logs` / `--enterprise` / `--o11y` | |
 | [`defenseclaw setup local-observability`](/docs/observability/local-observability) | ✗ no prompts | ✓ flags only | Compose-style up/down/logs subcommands; never asks. |

--- a/docs-site/content/docs/setup/guardrail/multi-connector.mdx
+++ b/docs-site/content/docs/setup/guardrail/multi-connector.mdx
@@ -105,25 +105,29 @@ defenseclaw guardrail disable --connector codex      # scoped kill switch
 defenseclaw guardrail enable  --connector codex      # restore it
 ```
 
-Omit `--connector` and the same verbs operate on the **global default** that every connector inherits. `--connector` is rejected on a single-connector install — there is only one posture to set.
+`--connector X` is the explicit scope selector: it writes only that connector's override. On a multi-connector install, unscoped writes are the broad operator-intent path. `guardrail fail-mode`, `guardrail hilt`, and `guardrail block-message` reconcile the active connector posture so an existing override does not silently keep the old value. `block-message` also updates the shared `guardrail.block_message` fallback. On a single-connector install, `--connector` is rejected because there is only one posture to set.
 
-To **read** the resolved posture, run bare `defenseclaw guardrail status` — it prints one per-connector block for **every** active connector (there is no `--connector` flag on `status`):
+To **read** the resolved posture, run bare `defenseclaw guardrail status` — it prints one per-connector block for **every** active connector. Pass `--connector X` to narrow the status view to one active connector:
 
 ```bash
 defenseclaw guardrail status     # per-connector blocks for ALL active connectors
+defenseclaw guardrail status --connector codex
 ```
 
 See [Reference → CLI](/docs/reference/cli#guardrail) for the full command group.
 
 ## CLI contract: read vs write
 
-Once a gateway protects more than one connector, the CLI splits cleanly into commands that **read across the whole roster** and commands that **write to one connector at a time**:
+Once a gateway protects more than one connector, the CLI splits cleanly into commands that **read across the whole roster**, commands that **write broad state by default**, and commands that **write to one connector when you pass `--connector`**:
 
 | Commands | Scope | How to narrow |
 | --- | --- | --- |
-| `defenseclaw status`, `defenseclaw doctor`, `defenseclaw guardrail status`, bare `guardrail fail-mode` / `hilt` / `block-message`, `skill list`, `mcp list`, `plugin list` | **Read — fans out to every active connector.** Identical layout whether one or N are wired. | n/a — these always show the full roster. |
-| `guardrail enable` / `disable` / `fail-mode` / `hilt` / `block-message` (with an argument) | **Write — one connector.** Defaults to the active connector. | `--connector X` to target a specific connector; omit to set the global default. |
-| `skill scan` / `mcp scan` / `aibom scan` | **Scan — all active connectors by default.** | Positional target (or `--connector` where supported) to scope to one. |
+| `defenseclaw status`, `defenseclaw doctor`, bare `defenseclaw guardrail status`, bare `guardrail fail-mode` / `hilt` / `block-message`, `skill list`, `mcp list`, `plugin list`, `tool list`, `tool status`, `codeguard status` | **Read — fans out to every active connector.** Identical layout whether one or N are wired. | `guardrail status --connector X`, `skill list --connector X`, `mcp list --connector X`, `plugin list --connector X`, `tool list --connector X`, and `tool status --connector X` narrow where supported. |
+| `alerts` | **Read — recent decisions across connectors by default.** | `alerts --connector X` filters to events attributed to one connector. |
+| `guardrail enable` / `disable` / `fail-mode` / `hilt` / `block-message` (with an argument) | **Guardrail write — scoped or broad.** `--connector X` writes one connector override. Omit `--connector` for the broad path: enable/disable is global; fail-mode, HITL, and block-message update active connector posture. | `--connector X` to target a specific connector. |
+| `skill`, `mcp`, `plugin`, and `tool` policy verbs (`block`, `allow`, `unblock`, plus runtime verbs such as `disable` / `enable` where supported) | **Asset-policy write — broad fallback by default, connector-scoped when requested.** Bare writes apply across matching configured connector copies or the unscoped fallback tier for that asset family. | `--connector X` writes or clears only that connector's scoped state. |
+| `mcp set` / `mcp unset`, `skill install`, `plugin remove`, `codeguard install` / `install-skill` | **Config/install write — all configured/active connectors by default.** | `--connector X` writes or removes only one connector's source. |
+| `skill scan` / `mcp scan` / `plugin scan` / `aibom scan` | **Scan — configured/active connectors by default.** | Positional target and `--connector X` narrow where supported. |
 
 <Callout type="info">
 `defenseclaw doctor` and `defenseclaw status` both render a **per-connector block** for each active connector when more than one is wired — the same fan-out the rest of the read commands use. There is no single "active connector" summary to misread.

--- a/docs-site/content/docs/setup/index.mdx
+++ b/docs-site/content/docs/setup/index.mdx
@@ -30,19 +30,21 @@ Run `defenseclaw setup guardrail` once. Reach for the auxiliary verbs only when 
 
 ## Connector aliases (thin wrappers around `setup guardrail`)
 
-Each alias pre-fills the connector flag and inherits every guardrail option. Pass `--mode observe` to run any of them in audit-only mode.
+Each alias pre-fills `setup guardrail --connector <name>` and inherits every guardrail option. Pass `--mode observe` to run any of them in audit-only mode. On a host with another hook connector already active, the setup flow can add the new connector to the roster instead of replacing the old one.
 
 <Cards>
-  <Card title="setup openclaw" href="/docs/setup/guardrail/aliases" description="Pins claw.mode=openclaw, installs the fetch interceptor + before_tool_call plugin." />
-  <Card title="setup zeptoclaw" href="/docs/setup/guardrail/aliases" description="Pins claw.mode=zeptoclaw, redirects api_base, runs scan + response-scan." />
-  <Card title="setup claude-code" href="/docs/setup/guardrail/aliases" description="Pins claw.mode=claudecode and installs the PreToolUse / Stop hooks into Claude Code's settings.json." />
-  <Card title="setup codex" href="/docs/setup/guardrail/aliases" description="Pins claw.mode=codex and installs the inspect-request / inspect-response hooks." />
-  <Card title="setup cursor" href="/docs/setup/guardrail/aliases" description="Pins claw.mode=cursor and writes hooks.json plus MCP/skills/rules surfaces." />
-  <Card title="setup windsurf" href="/docs/setup/guardrail/aliases" description="Pins claw.mode=windsurf — Cascade hooks plus local config discovery." />
-  <Card title="setup gemini-cli" href="/docs/setup/guardrail/aliases" description="Pins claw.mode=geminicli and configures settings.json hooks plus native OTLP export." />
-  <Card title="setup copilot" href="/docs/setup/guardrail/aliases" description="Pins claw.mode=copilot and writes global Copilot hook config." />
-  <Card title="setup hermes" href="/docs/setup/guardrail/aliases" description="Pins claw.mode=hermes and wires config.yaml hooks for MCP, skills, and plugins." />
-  <Card title="setup opencode" href="/docs/setup/guardrail/aliases" description="Pins claw.mode=opencode and writes the auto-loaded DefenseClaw bridge plugin." />
+  <Card title="setup openclaw" href="/docs/setup/guardrail/aliases" description="Selects OpenClaw with --connector openclaw and installs the fetch interceptor + before_tool_call plugin." />
+  <Card title="setup zeptoclaw" href="/docs/setup/guardrail/aliases" description="Selects ZeptoClaw with --connector zeptoclaw, redirects api_base, runs scan + response-scan." />
+  <Card title="setup claude-code" href="/docs/setup/guardrail/aliases" description="Adds or reconfigures Claude Code with --connector claudecode and installs its hooks." />
+  <Card title="setup codex" href="/docs/setup/guardrail/aliases" description="Adds or reconfigures Codex with --connector codex and installs hooks, OTel, and notify wiring." />
+  <Card title="setup cursor" href="/docs/setup/guardrail/aliases" description="Adds or reconfigures Cursor with --connector cursor and writes hooks.json plus MCP/skills/rules surfaces." />
+  <Card title="setup windsurf" href="/docs/setup/guardrail/aliases" description="Adds or reconfigures Windsurf with --connector windsurf for Cascade hooks plus local config discovery." />
+  <Card title="setup gemini-cli" href="/docs/setup/guardrail/aliases" description="Adds or reconfigures Gemini CLI with --connector geminicli and configures hooks plus native OTLP export." />
+  <Card title="setup copilot" href="/docs/setup/guardrail/aliases" description="Adds or reconfigures GitHub Copilot CLI with --connector copilot and writes hook config." />
+  <Card title="setup openhands" href="/docs/setup/guardrail/aliases" description="Adds or reconfigures OpenHands with --connector openhands and writes lifecycle hooks." />
+  <Card title="setup antigravity" href="/docs/setup/guardrail/aliases" description="Adds or reconfigures Antigravity with --connector antigravity and writes agy lifecycle hooks." />
+  <Card title="setup hermes" href="/docs/setup/guardrail/aliases" description="Adds or reconfigures Hermes with --connector hermes and wires config.yaml hooks." />
+  <Card title="setup opencode" href="/docs/setup/guardrail/aliases" description="Adds or reconfigures OpenCode with --connector opencode and writes the bridge plugin." />
 </Cards>
 
 ## Auxiliary setup verbs

--- a/docs-site/content/docs/setup/mcp-scanner.mdx
+++ b/docs-site/content/docs/setup/mcp-scanner.mdx
@@ -36,6 +36,7 @@ The CLI auto-discovers MCP server lists from the connectors you've set up, so yo
 
 ```bash
 defenseclaw mcp scan --all
+defenseclaw mcp scan --connector cursor
 ```
 
 The default sources include:
@@ -47,7 +48,7 @@ The default sources include:
 - `~/.gemini/config/mcp_config.json` and `<workspace>/.agents/mcp_config.json` → `mcpServers` (Antigravity)
 - Connector-specific paths registered by `defenseclaw setup guardrail`.
 
-Each server is scanned independently and findings are tagged with the connector that discovered them.
+Each server is scanned independently and findings are tagged with the connector that discovered them. Use `--connector <name>` on list, scan, set, unset, block, allow, and unblock commands when you want one connector's MCP source instead of the full configured roster. Without `--connector`, `mcp set` writes the server into every configured connector's MCP source, and `mcp unset` removes it from every configured connector that has it.
 
 ## One-shot scans
 
@@ -57,7 +58,7 @@ Each server is scanned independently and findings are tagged with the connector 
 defenseclaw mcp scan --all --json | jq -s '[.[].findings[]]'
 ```
 
-CI-friendly. Walks every server discovered across **all active connectors'** config files — not just `openclaw.json`, but every connector's MCP source (`claude_desktop_config.json`, `~/.cursor/mcp.json`, Codex, Copilot, …) — and emits **one JSON object per server** as a stream of top-level values (NDJSON-shaped, not wrapped in an array). `jq -s` slurps the stream into an array so a single pipeline can iterate findings across servers; for line-oriented tools use `--json | jq -c '.findings[]'` instead.
+CI-friendly. Walks every server discovered across **all configured connectors'** config files — not just `openclaw.json`, but every connector's MCP source (`claude_desktop_config.json`, `~/.cursor/mcp.json`, Codex, Copilot, …) — and emits **one JSON object per server** as a stream of top-level values (NDJSON-shaped, not wrapped in an array). `jq -s` slurps the stream into an array so a single pipeline can iterate findings across servers; for line-oriented tools use `--json | jq -c '.findings[]'` instead.
   </Tab>
   <Tab value="Specific server">
 ```bash
@@ -158,7 +159,11 @@ defenseclaw policy activate permissive
 The watcher's verdict is the default. Operators always have manual override (block / allow act on the **whole server**, not on individual tools — the CLI doesn't take a `--tool` flag):
 
 ```bash
-defenseclaw mcp list                                         # what is configured + state
+defenseclaw mcp list                                         # what is configured + state across configured connectors
+defenseclaw mcp list --connector opencode                    # one connector's MCP source
+defenseclaw mcp set context7 --command uvx --args context7-mcp
+defenseclaw mcp set context7 --command uvx --args context7-mcp --connector opencode
+defenseclaw mcp unset context7 --connector opencode
 defenseclaw mcp block untrusted-fs --reason "exfil tool found"
 defenseclaw mcp allow cisco-internal --reason "first-party"
 ```

--- a/docs-site/content/docs/setup/registries.mdx
+++ b/docs-site/content/docs/setup/registries.mdx
@@ -222,6 +222,8 @@ The Go gateway tags every admission decision with `Reason="registry:<id>"` (or `
 | `--non-interactive` | off | Required for CI; missing required flags exit non-zero with a clear `error: --foo is required`. |
 | SHA-256 on `source_url` | required for `http_yaml` / `http_json` / `git` / `file` | Per-entry integrity; the scanner refuses to download an entry whose computed digest does not match. |
 
+Registry fetches use the same hardened URL path in `test` and `sync`: loopback, link-local, cloud-metadata, and private-network destinations are refused by default, including DNS resolutions that rebind into a reserved range. Use `--allow-private` only for a registry mirror you intentionally run on an internal network. Local `file` registries must use absolute paths, and remote entry downloads must pass the per-entry SHA-256 check before scanner promotion can happen.
+
 ## Inspect what landed
 
 ```bash

--- a/docs-site/content/docs/setup/skill-scanner.mdx
+++ b/docs-site/content/docs/setup/skill-scanner.mdx
@@ -1,6 +1,6 @@
 ---
 title: Setup skill scanner
-description: Scan every Claude Code, Cursor, Codex, OpenClaw, or ZeptoClaw skill before an agent can execute it. DefenseClaw wraps cisco-ai-skill-scanner and writes its verdicts into the same skill_actions admission policy as the watcher.
+description: Scan configured connector skills before an agent can execute them. DefenseClaw wraps cisco-ai-skill-scanner and writes its verdicts into the same skill_actions admission policy as the watcher.
 keywords:
   - DefenseClaw skill scanner
   - cisco-ai-skill-scanner
@@ -24,7 +24,7 @@ DefenseClaw integrates Cisco's open-source [`cisco-ai-skill-scanner`](https://gi
 
 The wrapper at [`cli/defenseclaw/scanner/skill.py`](https://github.com/cisco-ai-defense/defenseclaw/blob/main/cli/defenseclaw/scanner/skill.py) accepts four target shapes — all **positional**. URL fetches in particular take the URL itself as the positional target (no `--remote` involved). The `--remote` flag does exist, but for a different scenario: it forwards the scan request to a sidecar API for a skill installed on a remote host (see the "Remote sidecar" tab below).
 
-- **Local skill name** (`my-skill`) — resolves through every connector's skill directory: `~/.claude/skills`, `~/.openclaw/skills`, `~/.cursor/skills`, `~/.codex/skills`, `~/.zeptoclaw/skills`.
+- **Local skill name** (`my-skill`) — resolves through configured connector skill directories. On a multi-connector install, a bare name checks matching connector copies; pass `--connector <name>` to force one connector's skill source.
 - **`--path <dir>`** — scan a directory you specify, useful inside a skill repo's pre-commit hook.
 - **`https://...`** — fetch a remote skill bundle into a temp dir, scan, then clean up. The downloaded bytes never touch your skill directory.
 - **`clawhub://author/skill@version`** — same fetch-to-temp flow, but resolves through the configured Clawhub registry source.
@@ -43,7 +43,7 @@ For each skill it runs:
 defenseclaw skill scan --all
 ```
 
-Walks every connector's skill directory, scans each bundle, prints a table of findings, and exits non-zero if anything is high severity. Add `--json` to pipe into CI.
+Walks every configured connector's skill directory, scans each bundle, prints connector-tagged findings, and exits non-zero if anything is high severity. Add `--json` to pipe into CI. Use `--connector <name>` to narrow the scan to one connector.
   </Tab>
   <Tab value="Specific path">
 ```bash
@@ -187,8 +187,11 @@ If the SDK is missing when you run a scan, DefenseClaw prints the install hint a
 The watcher's verdict is the default. Operators always have manual override:
 
 ```bash
-defenseclaw skill list                              # on-disk skills + state, across ALL active connectors (not just OpenClaw)
+defenseclaw skill list                              # on-disk skills + state, across ALL active connectors
+defenseclaw skill list --connector codex            # one connector
+defenseclaw skill scan my-skill --connector codex   # scan Codex's matching copy
 defenseclaw skill block <name> --reason "untrusted publisher"
+defenseclaw skill block <name> --connector codex --reason "Codex-only override"
 defenseclaw skill quarantine <name> --reason "review pending"
 defenseclaw skill restore <name>                    # un-quarantine
 defenseclaw skill allow <name> --reason "vetted"
@@ -196,6 +199,8 @@ defenseclaw skill disable <name>                    # runtime off, file untouche
 defenseclaw skill enable <name>
 defenseclaw skill info <name>                       # detailed view
 ```
+
+Without `--connector`, policy and runtime commands apply to matching configured connector copies where present or the unscoped fallback policy where that command uses one. Pass `--connector <name>` when the same skill exists under more than one connector and you want only that connector's copy.
 
 Every action is audited (`skill-block`, `skill-quarantine`, etc.) so the trail is intact even when the manual override contradicts the watcher.
 

--- a/docs-site/content/docs/stories/local-observability.mdx
+++ b/docs-site/content/docs/stories/local-observability.mdx
@@ -54,11 +54,11 @@ Brings up five containers via Docker Compose:
 
 ```bash
 defenseclaw setup guardrail \
-  --connector $(cat ~/.defenseclaw/picked_connector) \
+  --connector <name> \
   --restart
 ```
 
-Setup detects the local stack on `127.0.0.1:4317` and wires the top-level `otel.endpoint` (in `~/.defenseclaw/config.yaml`) to point at it.
+Replace `<name>` with a connector you have wired, such as `codex` or `claudecode`. Setup detects the local stack on `127.0.0.1:4317` and wires the top-level `otel.endpoint` (in `~/.defenseclaw/config.yaml`) to point at it. On a multi-connector host, the OTLP endpoint is shared; use `--connector <name>` only when you also want to reconcile that connector's hook wiring.
 
 </Step>
 


### PR DESCRIPTION
## Summary

This PR now contains 10 commits across guardrail setup/judge behavior, multi-connector CLI/docs polish, and the TUI dashboard fixes from manual testing.

- Fan out unscoped `setup guardrail --block-message ...` writes to active per-connector overrides in multi-connector installs.
- Repair guardrail judge enablement so empty/legacy hook-lane strategies are promoted to `regex_judge`, including completion strategy fields.
- Fix connector-scoped skill/plugin command behavior and Splunk/private bridge env wiring.
- Refresh docs for multi-connector commands, connector setup, guardrail behavior, fail modes, and local observability.
- Align the TUI Overview dashboard with live/current-session connector stats, correct Findings vs Alerts semantics, make connector filter clicks work consistently, reduce Overview scroll/filter lag, and dedupe AI Discovery rows by agent.

## Review Guide

1. **Guardrail setup + judge fixes**
   - `cli/defenseclaw/commands/cmd_setup.py`
   - `cli/defenseclaw/commands/cmd_judge.py`
   - tests in `cli/tests/test_cmd_setup_fu_phase2.py` and `cli/tests/test_cmd_judge.py`

2. **Multi-connector command/runtime polish**
   - `cmd_skill.py`, `cmd_plugin.py`, `cmd_init.py`, `agent_discovery.py`
   - related tests in `test_cmd_skill.py`, `test_cmd_plugin.py`, `test_cmd_init.py`, `test_agent_discovery.py`, and setup refresh bundle tests

3. **TUI Overview/dashboard fixes**
   - `cli/defenseclaw/tui/app.py`
   - `cli/defenseclaw/tui/panels/alerts.py`
   - `cli/defenseclaw/tui/services/overview_state.py`
   - related tests in `cli/tests/tui/test_app_shell.py`, `test_alerts_panel.py`, `test_overview_panel.py`, plus DB alert-reader coverage in `test_models_db.py`

4. **Docs**
   - `docs-site/content/docs/**`
   - Covers connector setup, guardrail setup, CLI reference, fail modes, Splunk/local observability, and release-facing docs gaps.

## Commit Map

Oldest to newest:

- `ae5861c6` **Fix guardrail setup block message fan-out**
  - Makes unscoped block-message writes apply across active per-connector overrides.

- `357b1beb` **Preserve scoped guardrail judge gate**
  - Keeps judge enablement scoped correctly and repairs legacy/empty strategy state.

- `e9772a9b` **Fix bare skill scan multi-connector fanout**
  - Corrects unscoped skill scan behavior across the active connector roster.

- `5cecaa8e` **Fix plugin list scan hydration by connector**
  - Hydrates plugin list scan metadata with connector-aware data.

- `183812cf` **Wire Splunk setup to private bridge env**
  - Carries Splunk setup through the private bridge environment path.

- `e21ced74` **docs: update multi-connector command docs**
  - Updates command docs for multi-connector setup and operations.

- `44ab87c0` **docs: cover general release docs gaps**
  - Fills remaining release-facing docs gaps across setup/reference/observability pages.

- `a8e7f735` **Honor operator trusted prefixes after default ownership failure**
  - Keeps operator-configured trusted prefixes effective after default ownership checks fail.

- `7d067c35` **Limit setup judge picker to action connectors**
  - Prevents the setup judge picker from presenting observe-only connectors as action targets.

- `311cc43d` **fix(tui): align connector overview metrics**
  - Scopes Overview tiles to active connector roster or selected connector.
  - Uses live/current-session hook calls, blocks, alerts, scans, skills, and MCP stats.
  - Distinguishes `ALERTS` hook decisions from severity-bearing `Findings`.
  - Loads INFO-column hook rows with `details severity=HIGH/CRITICAL` into actionable alert readers.
  - Fixes Overview connector chip click handling and avoids refiltering hidden panels on chip clicks.
  - Dedupes AI Discovery overview rows by agent before applying the display cap.

## Validation

Original guardrail/judge validation:

- `uv run --frozen pytest cli/tests/test_cmd_setup_fu_phase2.py cli/tests/test_cmd_judge.py`
- `uv run --frozen pytest cli/tests/test_cmd_setup_fu_phase2.py cli/tests/test_cmd_judge.py cli/tests/test_cmd_guardrail.py`
- `uv run --frozen ruff check cli/defenseclaw/commands/cmd_setup.py cli/defenseclaw/commands/cmd_judge.py cli/tests/test_cmd_setup_fu_phase2.py cli/tests/test_cmd_judge.py`
- Scratch CLI repro for `setup guardrail --block-message` fan-out
- Scratch CLI repro for legacy empty `detection_strategy_completion` repair

Latest TUI/manual-testing validation on the PR worktree:

- `uv run --frozen ruff check cli/defenseclaw/db.py cli/defenseclaw/tui/app.py cli/defenseclaw/tui/panels/alerts.py cli/defenseclaw/tui/services/overview_state.py cli/tests/test_models_db.py cli/tests/tui/test_alerts_panel.py cli/tests/tui/test_app_shell.py cli/tests/tui/test_overview_panel.py`
- `uv run --frozen pytest cli/tests/test_models_db.py::ModelsDbTests::test_event_reader_parses_zulu_timestamps cli/tests/test_models_db.py::ModelsDbTests::test_actionable_summary_readers_skip_low_signal_rows cli/tests/tui/test_alerts_panel.py`
- `uv run --frozen pytest cli/tests/tui/test_app_shell.py -k "overview_header_tiles_scope_to_selected_connector or overview_prefers_live_connector_counts or overview_alerts_and_findings_use_distinct_buckets or overview_connector_filter_does_not_refilter_hidden_panels or connector_chip_click or overview_body_shows_connector_chip or connector_filter_defaults or overview_enter_drills"`
- `uv run --frozen pytest cli/tests/tui/test_overview_panel.py -k "ai_discovery_box or sort_ai_discovery"`
- `git diff --check`

Note: the focused TUI app-shell tests still emit the existing asyncio subprocess cleanup warning on teardown, but the selected tests pass.