### PR TITLE
fix(test): prevent flakiness in init test by clearing DEFENSECLAW_*/OPENCLAW_* env vars (#360)

### DIFF
--- a/cli/tests/test_cmd_init.py
+++ b/cli/tests/test_cmd_init.py
@@ -807,8 +807,9 @@ class TestInitShowsGatewayDefaults(unittest.TestCase):
     def test_init_no_token_shows_local(self, mock_path, _mock_env, _mock_scanners, _mock_guardrail, _mock_which, _mock_gw):
         from pathlib import Path
         mock_path.return_value = Path(self.tmp_dir)
-        os.environ.pop("DEFENSECLAW_GATEWAY_TOKEN", None)
-        os.environ.pop("OPENCLAW_GATEWAY_TOKEN", None)
+        for k in list(os.environ.keys()):
+            if k.startswith("DEFENSECLAW_") or k.startswith("OPENCLAW_"):
+                os.environ.pop(k, None)
 
         app = AppContext()
         result = self.runner.invoke(init_cmd, ["--skip-install"], obj=app)


### PR DESCRIPTION
Fixes #360

## Problem

The test test_init_no_token_shows_local assumes a clean environment but only clears two specific env vars DEFENSECLAW_GATEWAY_TOKEN & OPENCLAW_GATEWAY_TOKEN. This makes it sensitive to leftover DEFENSECLAW_* or OPENCLAW_* variables from other tests, leading to potential flakiness during full test suite runs.

## Current Situation

The test explicitly removes DEFENSECLAW_GATEWAY_TOKEN and OPENCLAW_GATEWAY_TOKEN, but the codebase relies on many other DEFENSECLAW_* environment variables. Leaked variables from other tests can affect behavior and break the assumption that no token is set.

## Solution

Clear all DEFENSECLAW_* and OPENCLAW_* environment variables at the start of the test to ensure full isolation and remove dependency on ambient state.

## Architecture Diagram

N/A

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| cli/tests/test_cmd_init.py | Replace selective env var cleanup with prefix-based removal of all DEFENSECLAW_* and OPENCLAW_* variables to ensure full test isolation |

## Breaking Changes

None

## Open Issues / Follow-ups

None

## Test Plan

Ran the test in isolation:
python -m unittest cli.tests.test_cmd_init.TestInitShowsGatewayDefaults.test_init_no_token_shows_local -v
-> Passed

Ran full CLI test suite:
python -m pytest cli/tests -v
-> No additional failures introduced (same failures as before change)
