### PR TITLE
fix(init): clarify sandbox setup scope

### DIFF
--- a/cli/defenseclaw/bootstrap.py
+++ b/cli/defenseclaw/bootstrap.py
@@ -358,7 +358,7 @@ def run_first_run(options: FirstRunOptions) -> FirstRunReport:
             StepResult(
                 "Sandbox",
                 "warn",
-                "sandbox bootstrap remains Linux-only; run the dedicated sandbox setup",
+                "sandbox setup is experimental, Linux-only, and OpenClaw/OpenShell-only",
                 "defenseclaw sandbox setup",
             )
         )

--- a/cli/defenseclaw/commands/cmd_init.py
+++ b/cli/defenseclaw/commands/cmd_init.py
@@ -47,7 +47,11 @@ from defenseclaw.safety import DotenvValueError, sanitize_dotenv_value
 @click.command("init")
 @click.option("--skip-install", is_flag=True, help="Skip automatic scanner dependency installation")
 @click.option("--enable-guardrail", is_flag=True, help="Configure LLM guardrail during init")
-@click.option("--sandbox", is_flag=True, help="Set up sandbox mode (Linux only: creates sandbox user and directories)")
+@click.option(
+    "--sandbox",
+    is_flag=True,
+    help="Set up experimental OpenClaw/OpenShell sandbox mode (Linux only).",
+)
 @click.option("--non-interactive", is_flag=True, help="Run the guided first-run backend without prompts.")
 @click.option("--yes", "-y", is_flag=True, help="Assume defaults/yes for first-run prompts.")
 @click.option("--rescan-agents", is_flag=True, help="Refresh cached local agent discovery before choosing a connector.")
@@ -204,7 +208,8 @@ def init_cmd(  # noqa: PLR0913 - first-run CLI mirrors the setup surface.
     (the two compose). With neither flag (nor --connector), init keeps the
     legacy single-connector default.
 
-    Use --sandbox to set up openshell-sandbox standalone mode (Linux only).
+    Use --sandbox to set up OpenClaw/OpenShell standalone sandbox mode
+    (experimental, Linux only).
     Use --enable-guardrail to configure the LLM guardrail inline.
     """
     import platform

--- a/cli/tests/test_cmd_init.py
+++ b/cli/tests/test_cmd_init.py
@@ -159,6 +159,32 @@ class TestInitFirstRunBackend(unittest.TestCase):
         self.assertTrue(cfg["guardrail"]["enabled"])
         self.assertEqual(cfg["guardrail"]["detection_strategy"], "regex_judge")
 
+    def test_sandbox_flag_reports_explicit_scope(self):
+        result = self._invoke([
+            "--non-interactive",
+            "--yes",
+            "--connector",
+            "openclaw",
+            "--profile",
+            "observe",
+            "--scanner-mode",
+            "local",
+            "--skip-install",
+            "--sandbox",
+            "--no-start-gateway",
+            "--no-verify",
+            "--json-summary",
+        ])
+        self.assertEqual(result.exit_code, 0, result.output + (result.stderr or ""))
+
+        summary = json.loads(result.output)
+        sandbox_steps = [s for s in summary["setup"] if s["name"] == "Sandbox"]
+        self.assertEqual(len(sandbox_steps), 1, summary["setup"])
+        self.assertEqual(sandbox_steps[0]["status"], "warn")
+        self.assertIn("Linux-only", sandbox_steps[0]["detail"])
+        self.assertIn("OpenClaw/OpenShell-only", sandbox_steps[0]["detail"])
+        self.assertEqual(sandbox_steps[0]["next_command"], "defenseclaw sandbox setup")
+
     def test_with_judge_defaults_hook_coverage_to_all(self):
         result = self._invoke([
             "--non-interactive",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -666,6 +666,9 @@ print_success() {
             printf "    ${CYAN}defenseclaw init${NC}\n"
             ;;
     esac
+    if [[ "${INSTALL_SANDBOX}" == true && "${CONNECTOR}" != "openclaw" ]]; then
+        warn "Sandbox setup is experimental and currently applies to the OpenClaw/OpenShell path only."
+    fi
     echo ""
 }
 
@@ -718,11 +721,11 @@ while [[ $# -gt 0 ]]; do
             echo "  curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash"
             echo "  ./scripts/install.sh --local ./dist               # from local build"
             echo "  curl -LsSf <url>/install.sh | bash -s -- --yes    # non-interactive"
-            echo "  curl ... | bash -s -- --sandbox                   # also install openshell-sandbox"
+            echo "  curl ... | bash -s -- --sandbox                   # OpenClaw/OpenShell sandbox support"
             echo "  curl ... | bash -s -- --quickstart                # run quickstart after install"
             echo ""
             echo "Options:"
-            echo "  --sandbox             Also install openshell-sandbox (Linux only)"
+            echo "  --sandbox             Also install openshell-sandbox (experimental Linux/OpenClaw path)"
             echo "  --local <dir>         Install from a local dist directory"
             echo "  --yes, -y             Skip all confirmation prompts"
             echo "  --connector <name>    Pick agent connector (openclaw|codex|claudecode|zeptoclaw|none)"


### PR DESCRIPTION
## Summary
- clarify that sandbox setup is experimental, Linux-only, and OpenClaw/OpenShell-specific
- update guided init and installer messaging so other connector paths do not look sandbox-ready
- add a regression test for the structured init --sandbox warning

## Validation
- uv run pytest cli/tests/test_cmd_init.py
- bash -n scripts/install.sh
- bash scripts/install.sh --help
- uv run defenseclaw init --help
- git diff --check