### PR TITLE
fix(tui): defer overview connector filter render

### DIFF
--- a/cli/defenseclaw/tui/app.py
+++ b/cli/defenseclaw/tui/app.py
@@ -5132,7 +5132,7 @@ class DefenseClawTUI(App[None]):
             self.connector_filter, self._active_connector_names()
         )
 
-    def _set_connector_filter(self, connector: str, *, defer_overview: bool = False) -> None:
+    def _set_connector_filter(self, connector: str) -> None:
         """Set the shared connector filter to ``connector`` (``""`` = All).
 
         8.13 pass 2: the catalog/inventory panels load *every* active connector
@@ -5174,7 +5174,8 @@ class DefenseClawTUI(App[None]):
         # model filters during render, and hidden panels sync when opened.
         # Eagerly refiltering Logs/Audit/catalog data here made an Overview
         # chip click pay for every table in the app.
-        if defer_overview and self.active_panel == "overview" and not self.help_open:
+        overview_active = self.active_panel == "overview" and not self.help_open
+        if overview_active:
             self._render_overview_scope_indicator()
             self._render_overview_metrics()
             self._schedule_overview_deferred_render()
@@ -8832,18 +8833,12 @@ class DefenseClawTUI(App[None]):
             return
         index = int(choice)
         if index == 0:
-            self._set_connector_filter(
-                "",
-                defer_overview=self.active_panel == "overview" and not self.help_open,
-            )
+            self._set_connector_filter("")
             return
         index -= 1
         if not (0 <= index < len(connectors)):
             return
-        self._set_connector_filter(
-            connectors[index],
-            defer_overview=self.active_panel == "overview" and not self.help_open,
-        )
+        self._set_connector_filter(connectors[index])
 
     async def _open_redaction_toggle(self) -> None:
         currently_disabled = _redaction_currently_disabled(self.config)

--- a/cli/tests/tui/test_app_shell.py
+++ b/cli/tests/tui/test_app_shell.py
@@ -167,6 +167,8 @@ async def test_overview_scroll_keys_move_body_scroll_container() -> None:
 
         app._render_chrome = counted_sampled_render  # type: ignore[method-assign]
         app.set_timer = immediate_sampled_timer  # type: ignore[method-assign]
+        # Keep the mount-time interval from racing this direct sampler assertion on slow CI.
+        app._periodic_refresh_running = True  # noqa: SLF001
         app._overview_sampled_refresh_scheduled = False  # noqa: SLF001 - isolate direct sampler assertions.
 
         scroller.scroll_to(y=scroller.max_scroll_y, animate=False, immediate=True)
@@ -4679,6 +4681,34 @@ async def test_overview_connector_filter_does_not_refilter_hidden_panels(monkeyp
         app._set_connector_filter("cursor")
 
     assert hidden_filter_calls == []
+
+
+@pytest.mark.asyncio
+async def test_overview_connector_filter_defers_full_render(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Overview filter changes should avoid a full chrome render in the hot path."""
+
+    cfg = OverviewConfig(
+        data_dir="/tmp/dc",
+        claw_mode="codex",
+        guardrail_connector="codex",
+        connector_modes=(("codex", "enforce"), ("cursor", "observe")),
+    )
+    overview = OverviewPanelModel(cfg, version="test")
+    app = DefenseClawTUI(overview_model=overview)
+
+    async with app.run_test(size=(170, 44)) as pilot:
+        await pilot.pause()
+        app.active_panel = "overview"
+        render_calls: list[str] = []
+
+        def record_render() -> None:
+            render_calls.append("full")
+
+        monkeypatch.setattr(app, "_render_chrome", record_render)
+        app._set_connector_filter("cursor")
+
+        assert app._connector_filter() == "cursor"
+        assert render_calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- defer Overview connector-filter changes through the cheap Overview refresh path by default
- remove the now-redundant explicit defer flag from the private helper
- add a regression test proving Overview filter changes do not call the full chrome render hot path

## Verification
- uv run --python 3.12 pytest cli/tests/tui/test_app_shell.py::test_overview_connector_filter_does_not_refilter_hidden_panels cli/tests/tui/test_app_shell.py::test_overview_connector_filter_defers_full_render cli/tests/tui/test_app_shell.py::test_overview_m_picker_updates_scope_before_deferred_render -q
- uv run --python 3.12 ruff check cli/defenseclaw/tui/app.py cli/tests/tui/test_app_shell.py
- uv run --python 3.12 pytest cli/tests/tui/test_app_shell.py -q
- make py-lint
- make cli-test-cov