### PR TITLE
[codex] Fix upgrade path and add smoke matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,23 @@ jobs:
           uv --no-config pip install --python "$tmp/venv/bin/python" "$whl"
           "$tmp/venv/bin/defenseclaw" --help >/dev/null
 
+  upgrade-smoke:
+    name: Upgrade Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      # Exercises real historical `defenseclaw upgrade` commands against a
+      # localhost-served candidate release before a tag exists. The seeded
+      # baselines keep the test stable even when an old release's dependency
+      # pins become unsatisfiable in today's resolver.
+      - run: make upgrade-smoke-matrix ARGS="--baseline-mode seed"
+
   connector-matrix:
     name: Connector Matrix
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,10 +1,6 @@
 name: E2E
 
 on:
-  push:
-    branches: [main, demo]
-  pull_request:
-  workflow_dispatch:
   schedule:
     - cron: "0 7 * * *"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -304,6 +304,9 @@ jobs:
             --output-signature=dist/checksums.txt.sig \
             dist/checksums.txt
 
+      - name: Pre-publish upgrade smoke
+        run: make upgrade-smoke-matrix ARGS="--release-dir dist --baseline-mode seed"
+
       # Atomic: tag + release + every asset are created in a single API
       # call. On workflow_dispatch, --target $GITHUB_SHA tells gh to create
       # the tag at this commit if it doesn't yet exist. On push:tags the

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ OC_EXT_DIR  := $(HOME)/.openclaw/extensions/defenseclaw
 RUFF        := $(shell if [ -x "$(VENV)/bin/ruff" ]; then printf '%s' "$(VENV)/bin/ruff"; elif command -v ruff >/dev/null 2>&1; then command -v ruff; else printf '%s' "$(VENV)/bin/ruff"; fi)
 
 DIST_DIR    := dist
+UPGRADE_SMOKE_FROM ?= 0.7.2 0.7.1 0.6.6 0.6.5 0.6.4 0.6.3 0.6.2 0.6.1 0.6.0 0.5.0 0.4.0
 
 # Cross-platform virtualenv / executable layout. Windows Python venvs expose
 # console entry points under Scripts/ (not bin/) and binaries carry a .exe
@@ -34,6 +35,7 @@ endif
         connector-matrix-test go-connector-matrix-test py-connector-matrix-test \
         test-verbose test-file lint py-lint go-lint ts-test rego-test clean \
         check check-audit-actions check-error-codes check-schemas check-v7 check-provider-coverage check-llm-catalog check-version-sync check-upgrade-manifest \
+        upgrade-smoke upgrade-smoke-matrix \
         set-version \
         _bundle-data \
         dist dist-cli dist-gateway dist-plugin dist-sandbox dist-test dist-upgrade-manifest dist-checksums dist-clean
@@ -600,6 +602,12 @@ check-llm-catalog:
 
 check-upgrade-manifest:
 	@python3 scripts/generate-upgrade-manifest.py --check
+
+upgrade-smoke:
+	@scripts/test-upgrade-release.sh $(ARGS)
+
+upgrade-smoke-matrix:
+	@scripts/test-upgrade-release.sh --from-versions "$(UPGRADE_SMOKE_FROM)" $(ARGS)
 
 # ---------------------------------------------------------------------------
 # Lint targets

--- a/cli/defenseclaw/commands/cmd_upgrade.py
+++ b/cli/defenseclaw/commands/cmd_upgrade.py
@@ -267,10 +267,22 @@ def upgrade(
             else os.path.expanduser("~/.defenseclaw")
         )
 
-        from defenseclaw.migrations import run_migrations
-        count = run_migrations(current_version, target_version, openclaw_home, data_dir)
+        migration_failed = False
+        try:
+            count = _run_installed_migrations(
+                current_version,
+                target_version,
+                openclaw_home,
+                data_dir,
+                os_name=os_name,
+            )
+        except subprocess.CalledProcessError:
+            migration_failed = True
+            count = 0
         click.echo()
-        if count == 0:
+        if migration_failed:
+            ux.warn("Migration runner failed; upgrade will continue. Run: defenseclaw doctor --fix")
+        elif count == 0:
             ux.ok("No migrations needed")
         else:
             ux.ok(f"Applied {count} migration(s)")
@@ -1352,6 +1364,68 @@ def _install_wheel(whl_path: str, os_name: str | None = None) -> None:
                 os.remove(symlink)
             os.symlink(venv_bin, symlink)
     ux.ok("Python CLI installed")
+
+
+def _run_installed_migrations(
+    from_version: str,
+    to_version: str,
+    openclaw_home: str,
+    data_dir: str,
+    *,
+    os_name: str | None = None,
+) -> int:
+    """Run migrations in the freshly installed managed venv.
+
+    ``defenseclaw upgrade`` replaces the wheel while this command is already
+    running. Importing ``defenseclaw.migrations`` in-process can therefore mix
+    old modules cached in ``sys.modules`` with new files on disk. A child
+    interpreter starts with a clean import graph from the just-installed wheel.
+    """
+    if os_name is None:
+        os_name = platform.system().lower()
+
+    venv = os.path.expanduser("~/.defenseclaw/.venv")
+    venv_python = _venv_python_path(venv, os_name)
+    if not os.path.isfile(venv_python):
+        raise subprocess.CalledProcessError(1, [venv_python, "-c", "<missing managed venv>"])
+
+    fd, result_path = tempfile.mkstemp(prefix="defenseclaw-migrations-", suffix=".json")
+    os.close(fd)
+    script = """
+import json
+import sys
+
+from defenseclaw.migrations import run_migrations
+
+count = run_migrations(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+with open(sys.argv[5], "w", encoding="utf-8") as fh:
+    json.dump({"count": count}, fh)
+"""
+    try:
+        subprocess.run(
+            [
+                venv_python,
+                "-c",
+                script,
+                from_version,
+                to_version,
+                openclaw_home,
+                data_dir,
+                result_path,
+            ],
+            check=True,
+        )
+        with open(result_path, encoding="utf-8") as f:
+            payload = json.load(f)
+        count = payload.get("count")
+        if not isinstance(count, int):
+            raise subprocess.CalledProcessError(1, [venv_python, "-c", "<invalid migration count>"])
+        return count
+    finally:
+        try:
+            os.remove(result_path)
+        except OSError:
+            pass
 
 
 def _venv_python_path(venv: str, os_name: str) -> str:

--- a/cli/defenseclaw/migrations.py
+++ b/cli/defenseclaw/migrations.py
@@ -36,11 +36,13 @@ Design contract for every migration:
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 import re
 import secrets
 import shutil
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
@@ -62,6 +64,50 @@ def _ver_tuple(v: str) -> tuple[int, ...]:
         m = re.match(r"\d+", part)
         out.append(int(m.group(0)) if m else 0)
     return tuple(out)
+
+
+def _ensure_legacy_openclaw_restart_shim(
+    from_version: str,
+    to_version: str,
+    data_dir: str,
+) -> None:
+    """Prevent pre-0.6.1 upgraders from crashing when ``openclaw`` is absent.
+
+    The 0.4.0-0.6.0 ``cmd_upgrade`` path installs the target wheel, imports
+    this module, runs migrations, and then calls ``subprocess.run(["openclaw",
+    "gateway", "restart"], check=False)``. If ``openclaw`` is not installed,
+    Python raises ``FileNotFoundError`` before ``check=False`` can matter,
+    aborting an otherwise successful upgrade. We cannot patch those already
+    released command modules, but we can provide a process-local PATH shim
+    before their ``finally`` block runs.
+    """
+    if os.name == "nt":
+        return
+    if _ver_tuple(to_version) < _ver_tuple("0.8.0"):
+        return
+    if _ver_tuple(from_version) >= _ver_tuple("0.6.1"):
+        return
+    if shutil.which("openclaw"):
+        return
+
+    shim_dir = os.path.join(data_dir, ".upgrade-shims")
+    shim_path = os.path.join(shim_dir, "openclaw")
+    try:
+        os.makedirs(shim_dir, mode=0o700, exist_ok=True)
+        with open(shim_path, "w", encoding="utf-8") as fh:
+            fh.write(
+                "#!/bin/sh\n"
+                "printf '%s\\n' 'openclaw CLI not found; skipping automatic gateway restart' >&2\n"
+                "exit 127\n"
+            )
+        os.chmod(shim_path, 0o700)
+    except OSError as exc:
+        ux.warn(f"could not create legacy openclaw restart shim: {exc}", indent="    ")
+        return
+
+    path_parts = [part for part in os.environ.get("PATH", "").split(os.pathsep) if part]
+    if shim_dir not in path_parts:
+        os.environ["PATH"] = os.pathsep.join([shim_dir, *path_parts])
 
 
 # ---------------------------------------------------------------------------
@@ -1980,8 +2026,23 @@ def run_migrations(
     """
     from defenseclaw import migration_state
 
+    if not all(
+        hasattr(migration_state, attr)
+        for attr in ("detect_schema", "is_future_schema", "FutureSchemaError")
+    ):
+        migration_state = importlib.reload(migration_state)
+    import defenseclaw as defenseclaw_pkg
+
+    if getattr(defenseclaw_pkg, "__version__", "") != to_version:
+        importlib.reload(defenseclaw_pkg)
+    cmd_version = sys.modules.get("defenseclaw.commands.cmd_version")
+    if cmd_version is not None:
+        importlib.reload(cmd_version)
+
     if data_dir is None:
         data_dir = os.environ.get("DEFENSECLAW_HOME") or os.path.expanduser("~/.defenseclaw")
+
+    _ensure_legacy_openclaw_restart_shim(from_version, to_version, data_dir)
 
     from_t = _ver_tuple(from_version)
     to_t = _ver_tuple(to_version)

--- a/cli/defenseclaw/tui/app.py
+++ b/cli/defenseclaw/tui/app.py
@@ -5174,7 +5174,8 @@ class DefenseClawTUI(App[None]):
         # model filters during render, and hidden panels sync when opened.
         # Eagerly refiltering Logs/Audit/catalog data here made an Overview
         # chip click pay for every table in the app.
-        if defer_overview and self.active_panel == "overview" and not self.help_open:
+        overview_active = self.active_panel == "overview" and not self.help_open
+        if (defer_overview or overview_active) and overview_active:
             self._render_overview_scope_indicator()
             self._render_overview_metrics()
             self._schedule_overview_deferred_render()

--- a/cli/defenseclaw/tui/widgets/native_metrics.py
+++ b/cli/defenseclaw/tui/widgets/native_metrics.py
@@ -155,12 +155,7 @@ class MetricTile(Vertical):
         self._progress.update(total=100, progress=_clamp(metric.progress))
         self._sparkline.data = metric.trend or (0,)
         self._detail.update(metric.detail)
-        # Textual >=8.2.4 ``DOM.update_classes`` swaps a whole class
-        # mapping in a single style-recomputation pass. The previous
-        # four ``set_class`` calls each triggered an independent
-        # restyle of the tile + its descendants; the tile is rendered
-        # on every metric refresh, so the cost was real.
-        self.update_classes(
+        self._apply_class_map(
             {
                 "metric-ok": metric.state == "ok",
                 "metric-warn": metric.state == "warn",
@@ -172,6 +167,16 @@ class MetricTile(Vertical):
             self.tooltip = f"Open {metric.target_panel.title()}"
         else:
             self.tooltip = None
+
+    def _apply_class_map(self, classes: dict[str, bool]) -> None:
+        """Apply a class map across Textual 7.x and 8.x."""
+
+        update_classes = getattr(self, "update_classes", None)
+        if callable(update_classes):
+            update_classes(classes)
+            return
+        for class_name, enabled in classes.items():
+            self.set_class(enabled, class_name)
 
     def on_click(self, event: events.Click) -> None:
         if not self.metric.target_panel:

--- a/cli/tests/test_cmd_upgrade.py
+++ b/cli/tests/test_cmd_upgrade.py
@@ -28,6 +28,7 @@ from defenseclaw.commands.cmd_upgrade import (
     _normalize_target_version,
     _preflight_wheel_install,
     _print_migration_cursor_summary,
+    _run_installed_migrations,
     _run_silent,
     _validate_upgrade_manifest,
     _verify_checksums_sigstore,
@@ -139,6 +140,36 @@ class TestUpgradeWheelInstall(unittest.TestCase):
         self.assertIn("--dry-run", calls[1])
         self.assertEqual(calls[1][-1], "/tmp/defenseclaw.whl")
 
+    def test_run_installed_migrations_uses_managed_venv_python(self):
+        with TemporaryDirectory() as home, patch.dict(os.environ, {"HOME": home}), \
+             patch("subprocess.run") as run_mock:
+            venv_python = os.path.join(home, ".defenseclaw", ".venv", "bin", "python")
+            os.makedirs(os.path.dirname(venv_python), exist_ok=True)
+            with open(venv_python, "w") as f:
+                f.write("# python")
+
+            def side_effect(args, **_kwargs):
+                result_path = args[-1]
+                with open(result_path, "w", encoding="utf-8") as f:
+                    json.dump({"count": 1}, f)
+                return Mock(returncode=0)
+
+            run_mock.side_effect = side_effect
+
+            count = _run_installed_migrations(
+                "0.7.0",
+                "0.8.0",
+                "/tmp/openclaw",
+                "/tmp/defenseclaw",
+                os_name="darwin",
+            )
+
+        self.assertEqual(count, 1)
+        call = run_mock.call_args.args[0]
+        self.assertEqual(call[0], venv_python)
+        self.assertEqual(call[1], "-c")
+        self.assertEqual(call[3:7], ["0.7.0", "0.8.0", "/tmp/openclaw", "/tmp/defenseclaw"])
+
 
 class TestUpgradeSameVersionRepair(unittest.TestCase):
     def test_same_version_reapplies_migrations(self):
@@ -195,7 +226,7 @@ class TestUpgradeSameVersionRepair(unittest.TestCase):
                 return_value=Mock(returncode=0),
             ))
             run_migrations = stack.enter_context(
-                patch("defenseclaw.migrations.run_migrations", return_value=1)
+                patch("defenseclaw.commands.cmd_upgrade._run_installed_migrations", return_value=1)
             )
             result = runner.invoke(upgrade, ["--yes", "--version", "9.9.9"], obj=app)
 
@@ -262,7 +293,7 @@ class TestUpgradeSameVersionRepair(unittest.TestCase):
             stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._run_silent"))
             stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._poll_health"))
             stack.enter_context(
-                patch("defenseclaw.migrations.run_migrations", return_value=0)
+                patch("defenseclaw.commands.cmd_upgrade._run_installed_migrations", return_value=0)
             )
             result = runner.invoke(upgrade, ["--yes", "--version", "9.9.9"], obj=app)
 
@@ -335,7 +366,7 @@ class TestUpgradeWithoutOpenClawCli(unittest.TestCase):
                 side_effect=fake_run,
             ))
             stack.enter_context(
-                patch("defenseclaw.migrations.run_migrations", return_value=0)
+                patch("defenseclaw.commands.cmd_upgrade._run_installed_migrations", return_value=0)
             )
             result = runner.invoke(upgrade, ["--yes", "--version", "9.9.9"], obj=app)
 

--- a/cli/tests/test_migrations.py
+++ b/cli/tests/test_migrations.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 import shutil
@@ -440,6 +441,65 @@ class TestRunMigrations(unittest.TestCase):
                 "run_migrations should persist the cursor under $DEFENSECLAW_HOME",
             )
         self.assertEqual(count, 1)
+
+    def test_run_migrations_reloads_stale_migration_state_module(self):
+        """0.7.x upgraders cache migration_state before installing 0.8.0.
+
+        The newly imported migrations module must refresh that stale module
+        before it reaches APIs introduced after 0.7.x.
+        """
+        import defenseclaw
+        import defenseclaw.commands.cmd_version as cmd_version
+        from defenseclaw import migration_state
+
+        defenseclaw.__version__ = "0.7.0"
+        cmd_version.__version__ = "0.7.0"
+        for attr in ("detect_schema", "is_future_schema", "FutureSchemaError"):
+            delattr(migration_state, attr)
+
+        calls: list[str] = []
+
+        def record(_ctx: MigrationContext) -> None:
+            calls.append("0.8.0")
+
+        try:
+            with patch("defenseclaw.migrations.MIGRATIONS", [("0.8.0", "compat", record)]):
+                with tempfile.TemporaryDirectory() as data_dir:
+                    count = run_migrations("0.7.0", "0.8.0", tempfile.mkdtemp(), data_dir)
+                    refreshed_version = defenseclaw.__version__
+                    refreshed_cmd_version = cmd_version.__version__
+        finally:
+            importlib.reload(defenseclaw)
+            importlib.reload(cmd_version)
+            importlib.reload(migration_state)
+
+        self.assertEqual(count, 1)
+        self.assertEqual(calls, ["0.8.0"])
+        self.assertEqual(refreshed_version, "0.8.0")
+        self.assertEqual(refreshed_cmd_version, "0.8.0")
+
+    def test_legacy_openclaw_restart_shim_for_pre_061_upgrade(self):
+        with tempfile.TemporaryDirectory() as data_dir, \
+             patch("defenseclaw.migrations.MIGRATIONS", []), \
+             patch("defenseclaw.migrations.shutil.which", return_value=None), \
+             patch.dict(os.environ, {"PATH": "/usr/bin"}):
+            run_migrations("0.6.0", "0.8.0", tempfile.mkdtemp(), data_dir)
+
+            shim_dir = os.path.join(data_dir, ".upgrade-shims")
+            shim_path = os.path.join(shim_dir, "openclaw")
+            self.assertTrue(os.path.isfile(shim_path))
+            self.assertTrue(os.access(shim_path, os.X_OK))
+            self.assertEqual(os.environ["PATH"].split(os.pathsep)[0], shim_dir)
+
+    def test_legacy_openclaw_restart_shim_skips_fixed_upgraders(self):
+        with tempfile.TemporaryDirectory() as data_dir, \
+             patch("defenseclaw.migrations.MIGRATIONS", []), \
+             patch("defenseclaw.migrations.shutil.which", return_value=None), \
+             patch.dict(os.environ, {"PATH": "/usr/bin"}):
+            run_migrations("0.6.1", "0.8.0", tempfile.mkdtemp(), data_dir)
+
+            self.assertFalse(os.path.exists(os.path.join(data_dir, ".upgrade-shims")))
+            self.assertEqual(os.environ["PATH"], "/usr/bin")
 
 
 # ---------------------------------------------------------------------------

--- a/cli/tests/test_remediation_upgrade.py
+++ b/cli/tests/test_remediation_upgrade.py
@@ -141,7 +141,7 @@ class TestUpgradeFailsClosedWithoutChecksums(unittest.TestCase):
                 return_value=Mock(returncode=0),
             ))
             stack.enter_context(
-                patch("defenseclaw.migrations.run_migrations", return_value=0)
+                patch("defenseclaw.commands.cmd_upgrade._run_installed_migrations", return_value=0)
             )
 
             result = runner.invoke(
@@ -264,7 +264,7 @@ class TestUpgradeRefusesUnsignedAssetDigests(unittest.TestCase):
                 return_value=Mock(returncode=0),
             ))
             stack.enter_context(
-                patch("defenseclaw.migrations.run_migrations", return_value=0)
+                patch("defenseclaw.commands.cmd_upgrade._run_installed_migrations", return_value=0)
             )
 
             result = runner.invoke(

--- a/cli/tests/tui/test_app_shell.py
+++ b/cli/tests/tui/test_app_shell.py
@@ -142,6 +142,7 @@ async def test_overview_scroll_keys_move_body_scroll_container() -> None:
         app._refresh_models_from_disk = counted_refresh  # type: ignore[method-assign]
         app._render_overview_metrics = counted_metric_refresh  # type: ignore[method-assign]
         app._overview_last_scroll_activity_at = 0.0
+        app._overview_sampled_refresh_scheduled = True
         app._periodic_refresh()
         assert refresh_calls == 0
         assert metric_refresh_calls == 1

--- a/cli/tests/tui/test_native_metrics.py
+++ b/cli/tests/tui/test_native_metrics.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from defenseclaw.tui.widgets.native_metrics import MetricDatum, MetricTile
+
+
+class _Textual7MetricTile(MetricTile):
+    update_classes = None
+
+
+def test_metric_tile_class_map_falls_back_to_set_class(monkeypatch) -> None:
+    tile = _Textual7MetricTile(
+        MetricDatum(
+            key="hook_calls",
+            label="Hook Calls",
+            value=0,
+            progress=0.0,
+            detail="gateway offline",
+            state="error",
+            target_panel="logs",
+        )
+    )
+    calls: list[tuple[bool, str]] = []
+
+    monkeypatch.setattr(
+        tile,
+        "set_class",
+        lambda enabled, class_name: calls.append((enabled, class_name)),
+    )
+
+    tile._apply_class_map(
+        {
+            "metric-ok": False,
+            "metric-warn": False,
+            "metric-error": True,
+            "tile-clickable": True,
+        }
+    )
+
+    assert calls == [
+        (False, "metric-ok"),
+        (False, "metric-warn"),
+        (True, "metric-error"),
+        (True, "tile-clickable"),
+    ]

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -17,6 +17,8 @@ DefenseClaw has Python, Go, TypeScript, Rego, docs, and end-to-end test surfaces
 | `make rego-test` | OPA tests for `policies/rego/` |
 | `make check` | Audit action, error code, schema, and provider coverage parity gates |
 | `make lint` | Ruff, Go formatting/linting, and Python compile check |
+| `make upgrade-smoke` | Build/serve candidate artifacts and run a real old-version upgrade in a throwaway HOME |
+| `make upgrade-smoke-matrix` | Run the release upgrade smoke against all supported historical baselines |
 
 ## Focused Tests
 
@@ -41,11 +43,47 @@ E2E scripts live under `scripts/` and are documented in [E2E.md](E2E.md). They c
 
 Run E2E tests only when the required local services, credentials, and platform assumptions are available.
 
+## Release Upgrade Smoke
+
+Before cutting a release, run the upgrade smoke on at least macOS and Linux. It builds or consumes candidate release artifacts, installs an older DefenseClaw in a temporary `HOME`, redirects that old `defenseclaw upgrade` command to a localhost release server, and verifies:
+
+- the upgrade exits successfully
+- every `required_cli_migrations` entry from `upgrade-manifest.json` is recorded in `.migration_state.json`
+- CLI and gateway versions match the candidate version
+- known regression markers such as `Traceback`, `AttributeError`, missing required migrations, and component drift are absent
+- the Textual metric tile refresh path works in the installed environment
+
+```bash
+# Current platform, building candidate artifacts from the working tree.
+make upgrade-smoke ARGS="--from-version 0.7.2"
+
+# Full supported historical matrix.
+make upgrade-smoke-matrix
+
+# Reuse an existing release-style dist directory, such as in release CI.
+make upgrade-smoke-matrix ARGS="--release-dir dist --baseline-mode seed"
+
+# Custom subset, useful while debugging one old branch of the upgrade path.
+scripts/test-upgrade-release.sh --from-versions "0.7.2,0.6.6,0.5.0,0.4.0"
+```
+
+For a Linux host without the repo's Go toolchain, prepare candidate artifacts on a machine that can cross-build, copy the printed release root to Linux, then run the same smoke there:
+
+```bash
+scripts/test-upgrade-release.sh --prepare-only --platform linux/arm64 --keep-workdir
+scp -r /tmp/defenseclaw-upgrade-smoke.xxxxxx/candidate-release openclaw-vineeth:/tmp/
+ssh openclaw-vineeth 'scripts/test-upgrade-release.sh --release-root /tmp/candidate-release --from-versions "0.7.2,0.7.1,0.6.6,0.6.5,0.6.4,0.6.3,0.6.2,0.6.1,0.6.0,0.5.0,0.4.0" --baseline-mode seed'
+```
+
+The default matrix covers every published 0.4.0+ baseline that has both a Python wheel, platform gateway archives, and an upgrade command: `0.7.2`, `0.7.1`, `0.6.6`, `0.6.5`, `0.6.4`, `0.6.3`, `0.6.2`, `0.6.1`, `0.6.0`, `0.5.0`, and `0.4.0`. Release `0.7.0` has no downloadable release assets, and `0.2.0` predates the upgrade command, so they are not live-upgradeable by this harness.
+
+The release workflow also runs `make upgrade-smoke-matrix ARGS="--release-dir dist --baseline-mode seed"` after artifacts/checksums are finalized and before `gh release create`, so a broken upgrade path aborts before assets are published.
+
 ## CI Workflows
 
 | Workflow | Purpose |
 |----------|---------|
-| `.github/workflows/ci.yml` | Go lint/test, Python test, TypeScript test, Rego test, and parity checks |
+| `.github/workflows/ci.yml` | Go lint/test, Python test, TypeScript test, Rego test, upgrade smoke, and parity checks |
 | `.github/workflows/e2e.yml` | Self-hosted end-to-end suites and scheduled validation |
 | `.github/workflows/release.yaml` | Tagged release artifacts |
 
@@ -57,4 +95,5 @@ make test
 make ts-test
 make rego-test
 make check
+make upgrade-smoke-matrix
 ```

--- a/scripts/test-upgrade-release.sh
+++ b/scripts/test-upgrade-release.sh
@@ -1,0 +1,530 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO="cisco-ai-defense/defenseclaw"
+FROM_VERSION="${FROM_VERSION:-0.7.2}"
+FROM_VERSIONS="${FROM_VERSIONS:-}"
+TARGET_VERSION="${TARGET_VERSION:-}"
+RELEASE_ROOT="${RELEASE_ROOT:-}"
+RELEASE_DIR="${RELEASE_DIR:-}"
+BASELINE_MODE="${BASELINE_MODE:-auto}" # auto | install | seed
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-1}"
+PORT="${PORT:-}"
+KEEP_WORKDIR="${KEEP_WORKDIR:-0}"
+PREPARE_ONLY=0
+BUILD_PLATFORM=""
+
+WORKDIR=""
+SERVER_PID=""
+SMOKE_HOME=""
+RELEASE_URL=""
+FROM_VERSION_LIST=()
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/test-upgrade-release.sh [options]
+
+Build or consume candidate release artifacts, install an older DefenseClaw in a
+throwaway HOME, redirect its upgrade command to the local candidate artifacts,
+then run and verify a real upgrade.
+
+Options:
+  --from-version VERSION     Installed baseline version to upgrade from (default: 0.7.2)
+  --from-versions LIST       Space/comma-separated baseline versions to test
+  --target-version VERSION   Candidate version (default: pyproject.toml version)
+  --release-dir DIR          Existing artifact dir, e.g. dist/ from the release workflow
+  --release-root DIR         Existing local release root containing VERSION/<assets>
+  --baseline-mode MODE       auto, install, or seed (default: auto)
+  --health-timeout SECONDS   Gateway health wait passed to upgrade (default: 1)
+  --port PORT                Local release server port (default: random high port)
+  --platform OS/ARCH         Build platform for --prepare-only (default: current host)
+  --prepare-only             Build/validate candidate release root, print it, and exit
+  --keep-workdir             Keep temp HOME/logs for debugging
+  --help                     Show this help
+
+Examples:
+  make upgrade-smoke
+  scripts/test-upgrade-release.sh --from-version 0.7.2
+  scripts/test-upgrade-release.sh --from-versions "0.7.2,0.7.1,0.6.6,0.6.0,0.5.0,0.4.0"
+  scripts/test-upgrade-release.sh --release-dir dist --baseline-mode seed
+
+For a Linux host without the repo's Go toolchain, build/copy artifacts first:
+  scripts/test-upgrade-release.sh --prepare-only --platform linux/arm64 --keep-workdir
+  scp -r /tmp/candidate-root user@linux:/tmp/
+  ssh user@linux 'scripts/test-upgrade-release.sh --release-root /tmp/candidate-root'
+EOF
+}
+
+log() { printf '==> %s\n' "$*"; }
+ok() { printf 'OK: %s\n' "$*"; }
+warn() { printf 'WARN: %s\n' "$*" >&2; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+cleanup() {
+    local status=$?
+    stop_smoke_gateway
+    if [[ -n "${SERVER_PID:-}" ]]; then
+        kill "${SERVER_PID}" >/dev/null 2>&1 || true
+        wait "${SERVER_PID}" >/dev/null 2>&1 || true
+    fi
+    if [[ "${KEEP_WORKDIR}" != "1" && -n "${WORKDIR:-}" && -d "${WORKDIR}" ]]; then
+        rm -rf "${WORKDIR}"
+    elif [[ -n "${WORKDIR:-}" ]]; then
+        warn "Kept smoke workdir: ${WORKDIR}"
+    fi
+    return "${status}"
+}
+trap cleanup EXIT
+
+stop_smoke_gateway() {
+    if [[ -n "${SMOKE_HOME:-}" && -x "${SMOKE_HOME}/.local/bin/defenseclaw-gateway" ]]; then
+        HOME="${SMOKE_HOME}" \
+        DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \
+        PATH="${SMOKE_HOME}/.local/bin:${PATH}" \
+            "${SMOKE_HOME}/.local/bin/defenseclaw-gateway" stop \
+            >"${SMOKE_HOME}/gateway-stop.log" 2>&1 || true
+    fi
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --from-version)
+                [[ $# -ge 2 ]] || die "--from-version requires a value"
+                FROM_VERSION="$2"; shift 2 ;;
+            --from-versions)
+                [[ $# -ge 2 ]] || die "--from-versions requires a value"
+                FROM_VERSIONS="$2"; shift 2 ;;
+            --target-version)
+                [[ $# -ge 2 ]] || die "--target-version requires a value"
+                TARGET_VERSION="$2"; shift 2 ;;
+            --release-dir)
+                [[ $# -ge 2 ]] || die "--release-dir requires a value"
+                RELEASE_DIR="$2"; shift 2 ;;
+            --release-root)
+                [[ $# -ge 2 ]] || die "--release-root requires a value"
+                RELEASE_ROOT="$2"; shift 2 ;;
+            --baseline-mode)
+                [[ $# -ge 2 ]] || die "--baseline-mode requires a value"
+                BASELINE_MODE="$2"; shift 2 ;;
+            --health-timeout)
+                [[ $# -ge 2 ]] || die "--health-timeout requires a value"
+                HEALTH_TIMEOUT="$2"; shift 2 ;;
+            --port)
+                [[ $# -ge 2 ]] || die "--port requires a value"
+                PORT="$2"; shift 2 ;;
+            --platform)
+                [[ $# -ge 2 ]] || die "--platform requires a value"
+                BUILD_PLATFORM="$2"; shift 2 ;;
+            --prepare-only)
+                PREPARE_ONLY=1; KEEP_WORKDIR=1; shift ;;
+            --keep-workdir)
+                KEEP_WORKDIR=1; shift ;;
+            --help|-h)
+                usage; exit 0 ;;
+            *)
+                die "unknown argument: $1" ;;
+        esac
+    done
+}
+
+current_version() {
+    python3 - <<'PY'
+from pathlib import Path
+import re
+
+text = Path("pyproject.toml").read_text(encoding="utf-8")
+match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+if not match:
+    raise SystemExit("could not read pyproject.toml version")
+print(match.group(1))
+PY
+}
+
+abs_path() {
+    python3 - "$1" <<'PY'
+from pathlib import Path
+import sys
+
+print(Path(sys.argv[1]).expanduser().resolve())
+PY
+}
+
+detect_platform() {
+    if [[ -n "${BUILD_PLATFORM}" ]]; then
+        case "${BUILD_PLATFORM}" in
+            linux/amd64|linux/arm64|darwin/amd64|darwin/arm64)
+                OS_NAME="${BUILD_PLATFORM%%/*}"
+                ARCH_NAME="${BUILD_PLATFORM##*/}"
+                return ;;
+            *)
+                die "--platform must be one of linux/amd64, linux/arm64, darwin/amd64, darwin/arm64" ;;
+        esac
+    fi
+    case "$(uname -s)" in
+        Darwin) OS_NAME="darwin" ;;
+        Linux) OS_NAME="linux" ;;
+        *) die "unsupported OS for upgrade smoke: $(uname -s)" ;;
+    esac
+    case "$(uname -m)" in
+        arm64|aarch64) ARCH_NAME="arm64" ;;
+        x86_64|amd64) ARCH_NAME="amd64" ;;
+        *) die "unsupported architecture for upgrade smoke: $(uname -m)" ;;
+    esac
+}
+
+normalize_baseline_versions() {
+    local raw="${FROM_VERSION}"
+    if [[ -n "${FROM_VERSIONS}" ]]; then
+        raw="${FROM_VERSIONS//,/ }"
+    fi
+
+    FROM_VERSION_LIST=()
+    local version
+    for version in ${raw}; do
+        [[ -n "${version}" ]] || continue
+        [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+            || die "invalid baseline version: ${version}"
+        FROM_VERSION_LIST+=("${version}")
+    done
+    [[ "${#FROM_VERSION_LIST[@]}" -gt 0 ]] || die "no baseline versions provided"
+    FROM_VERSION="${FROM_VERSION_LIST[0]}"
+}
+
+validate_inputs() {
+    normalize_baseline_versions
+    [[ "${TARGET_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "invalid --target-version: ${TARGET_VERSION}"
+    case "${BASELINE_MODE}" in
+        auto|install|seed) ;;
+        *) die "--baseline-mode must be auto, install, or seed" ;;
+    esac
+    if [[ -n "${RELEASE_DIR}" && -n "${RELEASE_ROOT}" ]]; then
+        die "use only one of --release-dir or --release-root"
+    fi
+    if [[ "${PREPARE_ONLY}" != "1" && -n "${BUILD_PLATFORM}" ]]; then
+        die "--platform is only valid with --prepare-only"
+    fi
+}
+
+build_candidate_release() {
+    RELEASE_ROOT="${WORKDIR}/candidate-release"
+    local out="${RELEASE_ROOT}/${TARGET_VERSION}"
+    mkdir -p "${out}"
+
+    log "Building candidate CLI wheel"
+    make -C "${ROOT}" dist-cli DIST_DIR="${out}"
+
+    log "Building candidate gateway (${OS_NAME}/${ARCH_NAME})"
+    make -C "${ROOT}" sync-openclaw-extension
+    local stage="${WORKDIR}/gateway-${OS_NAME}-${ARCH_NAME}"
+    mkdir -p "${stage}"
+    CGO_ENABLED=0 GOOS="${OS_NAME}" GOARCH="${ARCH_NAME}" \
+        go build -ldflags "-s -w -X main.version=${TARGET_VERSION}" \
+        -o "${stage}/defenseclaw" "${ROOT}/cmd/defenseclaw"
+    tar -czf "${out}/defenseclaw_${TARGET_VERSION}_${OS_NAME}_${ARCH_NAME}.tar.gz" \
+        -C "${stage}" defenseclaw
+
+    log "Generating candidate upgrade manifest/checksums"
+    python3 "${ROOT}/scripts/generate-upgrade-manifest.py" \
+        --out "${out}/upgrade-manifest.json"
+    (cd "${out}" && find . -type f ! -name checksums.txt ! -name checksums.txt.sig ! -name checksums.txt.pem \
+        | sed 's#^\./##' | sort | xargs shasum -a 256 > checksums.txt)
+}
+
+prepare_release_root() {
+    if [[ -n "${RELEASE_ROOT}" ]]; then
+        RELEASE_ROOT="$(abs_path "${RELEASE_ROOT}")"
+        return
+    fi
+
+    if [[ -n "${RELEASE_DIR}" ]]; then
+        local dir
+        dir="$(abs_path "${RELEASE_DIR}")"
+        [[ -d "${dir}" ]] || die "--release-dir not found: ${dir}"
+        RELEASE_ROOT="${WORKDIR}/candidate-release-root"
+        mkdir -p "${RELEASE_ROOT}"
+        ln -s "${dir}" "${RELEASE_ROOT}/${TARGET_VERSION}"
+        return
+    fi
+
+    build_candidate_release
+}
+
+assert_candidate_assets() {
+    local dir="${RELEASE_ROOT}/${TARGET_VERSION}"
+    [[ -d "${dir}" ]] || die "release root must contain ${TARGET_VERSION}/: ${RELEASE_ROOT}"
+    [[ -f "${dir}/defenseclaw-${TARGET_VERSION}-py3-none-any.whl" ]] \
+        || die "candidate wheel missing from ${dir}"
+    [[ -f "${dir}/defenseclaw_${TARGET_VERSION}_${OS_NAME}_${ARCH_NAME}.tar.gz" ]] \
+        || die "candidate gateway archive missing for ${OS_NAME}/${ARCH_NAME} in ${dir}"
+    [[ -f "${dir}/upgrade-manifest.json" ]] || die "upgrade-manifest.json missing from ${dir}"
+    [[ -f "${dir}/checksums.txt" ]] || die "checksums.txt missing from ${dir}"
+}
+
+start_release_server() {
+    local attempt
+    for attempt in 1 2 3 4 5; do
+        if [[ -z "${PORT}" ]]; then
+            PORT=$((18000 + RANDOM % 20000))
+        fi
+        log "Starting local release server on 127.0.0.1:${PORT}"
+        python3 -m http.server "${PORT}" --bind 127.0.0.1 --directory "${RELEASE_ROOT}" \
+            >"${WORKDIR}/release-server.log" 2>&1 &
+        SERVER_PID=$!
+        sleep 1
+        if curl -fsSI "http://127.0.0.1:${PORT}/${TARGET_VERSION}/checksums.txt" >/dev/null 2>&1; then
+            RELEASE_URL="http://127.0.0.1:${PORT}"
+            return
+        fi
+        kill "${SERVER_PID}" >/dev/null 2>&1 || true
+        wait "${SERVER_PID}" >/dev/null 2>&1 || true
+        SERVER_PID=""
+        PORT=""
+    done
+    die "could not start local release server; see ${WORKDIR}/release-server.log"
+}
+
+tail_log() {
+    local file="$1"
+    if [[ -f "${file}" ]]; then
+        printf '\n--- %s tail ---\n' "${file}" >&2
+        tail -80 "${file}" >&2 || true
+    fi
+}
+
+download_old_asset() {
+    local name="$1"
+    local dest="$2"
+    local url="https://github.com/${REPO}/releases/download/${FROM_VERSION}/${name}"
+    curl -fsSL "${url}" -o "${dest}"
+}
+
+seed_baseline_install() {
+    log "Seeding baseline ${FROM_VERSION} install"
+    mkdir -p "${SMOKE_HOME}/.local/bin" "${SMOKE_HOME}/.defenseclaw"
+
+    local old_dir="${WORKDIR}/old-release/${FROM_VERSION}"
+    mkdir -p "${old_dir}"
+    local old_wheel="${old_dir}/defenseclaw-${FROM_VERSION}-py3-none-any.whl"
+    local old_gateway="${old_dir}/defenseclaw_${FROM_VERSION}_${OS_NAME}_${ARCH_NAME}.tar.gz"
+    download_old_asset "defenseclaw-${FROM_VERSION}-py3-none-any.whl" "${old_wheel}" \
+        || die "could not download old wheel for ${FROM_VERSION}; choose a release with assets"
+    download_old_asset "defenseclaw_${FROM_VERSION}_${OS_NAME}_${ARCH_NAME}.tar.gz" "${old_gateway}" \
+        || die "could not download old gateway for ${FROM_VERSION}/${OS_NAME}/${ARCH_NAME}"
+
+    uv --no-config venv "${SMOKE_HOME}/.defenseclaw/.venv" --python 3.12 --quiet
+    local venv_python="${SMOKE_HOME}/.defenseclaw/.venv/bin/python"
+    uv --no-config pip install --python "${venv_python}" --quiet \
+        "${RELEASE_URL}/${TARGET_VERSION}/defenseclaw-${TARGET_VERSION}-py3-none-any.whl" \
+        >"${SMOKE_HOME}/seed-target-deps.log" 2>&1 \
+        || { tail_log "${SMOKE_HOME}/seed-target-deps.log"; die "could not seed target dependency set"; }
+    uv --no-config pip install --python "${venv_python}" --quiet --no-deps "${old_wheel}" \
+        >"${SMOKE_HOME}/seed-old-wheel.log" 2>&1 \
+        || { tail_log "${SMOKE_HOME}/seed-old-wheel.log"; die "could not install old wheel"; }
+
+    ln -sf "${SMOKE_HOME}/.defenseclaw/.venv/bin/defenseclaw" "${SMOKE_HOME}/.local/bin/defenseclaw"
+
+    local gateway_stage="${WORKDIR}/old-gateway/${FROM_VERSION}"
+    mkdir -p "${gateway_stage}"
+    tar -xzf "${old_gateway}" -C "${gateway_stage}"
+    cp "${gateway_stage}/defenseclaw" "${SMOKE_HOME}/.local/bin/defenseclaw-gateway"
+    chmod +x "${SMOKE_HOME}/.local/bin/defenseclaw-gateway"
+}
+
+install_baseline() {
+    if [[ "${BASELINE_MODE}" == "seed" ]]; then
+        seed_baseline_install
+        return
+    fi
+
+    log "Installing baseline ${FROM_VERSION} with scripts/install.sh"
+    if HOME="${SMOKE_HOME}" DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \
+        PATH="${SMOKE_HOME}/.local/bin:${PATH}" VERSION="${FROM_VERSION}" \
+        "${ROOT}/scripts/install.sh" --yes --connector none \
+        >"${SMOKE_HOME}/install-baseline.log" 2>&1; then
+        return
+    fi
+
+    if [[ "${BASELINE_MODE}" == "install" ]]; then
+        tail_log "${SMOKE_HOME}/install-baseline.log"
+        die "baseline install failed"
+    fi
+
+    warn "baseline installer failed; falling back to seeded old wheel"
+    tail_log "${SMOKE_HOME}/install-baseline.log"
+    seed_baseline_install
+}
+
+patch_installed_upgrade_endpoint() {
+    local upgrade_py
+    upgrade_py="$(find "${SMOKE_HOME}/.defenseclaw/.venv" \
+        -path '*/site-packages/defenseclaw/commands/cmd_upgrade.py' -print -quit)"
+    [[ -n "${upgrade_py}" ]] || die "installed cmd_upgrade.py not found"
+
+    python3 - "${upgrade_py}" "${RELEASE_URL}" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+release_url = sys.argv[2]
+text = path.read_text(encoding="utf-8")
+old = 'GITHUB_DL = f"https://github.com/{GITHUB_REPO}/releases/download"'
+new = f'GITHUB_DL = "{release_url}"'
+if old not in text:
+    raise SystemExit(f"release URL constant not found in {path}")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
+}
+
+upgrade_supports_allow_unverified() {
+    HOME="${SMOKE_HOME}" DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \
+    PATH="${SMOKE_HOME}/.local/bin:${PATH}" \
+        defenseclaw upgrade --help 2>/dev/null | grep -q -- "--allow-unverified"
+}
+
+run_upgrade() {
+    log "Running upgrade ${FROM_VERSION} -> ${TARGET_VERSION}"
+    local -a args=(upgrade --version "${TARGET_VERSION}" --yes --health-timeout "${HEALTH_TIMEOUT}")
+    if upgrade_supports_allow_unverified; then
+        args+=(--allow-unverified)
+    fi
+
+    if ! HOME="${SMOKE_HOME}" DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \
+        PATH="${SMOKE_HOME}/.local/bin:${PATH}" defenseclaw "${args[@]}" \
+        >"${SMOKE_HOME}/upgrade.log" 2>&1; then
+        tail_log "${SMOKE_HOME}/upgrade.log"
+        die "upgrade command failed"
+    fi
+
+    if grep -E "Traceback|AttributeError|Required migration\\(s\\).*not recorded|Component drift detected" \
+        "${SMOKE_HOME}/upgrade.log" >/dev/null; then
+        tail_log "${SMOKE_HOME}/upgrade.log"
+        die "upgrade log contains a known regression marker"
+    fi
+}
+
+verify_upgrade() {
+    log "Verifying upgraded install"
+    local venv_python="${SMOKE_HOME}/.defenseclaw/.venv/bin/python"
+    local release_dir="${RELEASE_ROOT}/${TARGET_VERSION}"
+
+    HOME="${SMOKE_HOME}" DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \
+    PATH="${SMOKE_HOME}/.local/bin:${PATH}" \
+        defenseclaw --version | grep -F "${TARGET_VERSION}" >/dev/null \
+        || die "defenseclaw --version does not report ${TARGET_VERSION}"
+
+    HOME="${SMOKE_HOME}" DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \
+    PATH="${SMOKE_HOME}/.local/bin:${PATH}" \
+        defenseclaw-gateway --version | grep -F "${TARGET_VERSION}" >/dev/null \
+        || die "defenseclaw-gateway --version does not report ${TARGET_VERSION}"
+
+    "${venv_python}" - "${SMOKE_HOME}/.defenseclaw" "${release_dir}/upgrade-manifest.json" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+data_dir = Path(sys.argv[1])
+manifest_path = Path(sys.argv[2])
+cursor_path = data_dir / ".migration_state.json"
+cursor = json.loads(cursor_path.read_text(encoding="utf-8"))
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+applied = set(cursor.get("applied", []))
+missing = [
+    version
+    for version in manifest.get("required_cli_migrations", [])
+    if isinstance(version, str) and version not in applied
+]
+if missing:
+    raise SystemExit(f"missing required migrations in cursor: {', '.join(missing)}")
+print("cursor_applied=" + ",".join(cursor.get("applied", [])))
+PY
+
+    "${venv_python}" - <<'PY'
+import textual
+from defenseclaw.tui.widgets.native_metrics import MetricDatum, MetricTile
+
+metric = MetricDatum(
+    key="hook_calls",
+    label="Hook Calls",
+    value=0,
+    progress=0.0,
+    detail="gateway offline",
+    state="error",
+    target_panel="logs",
+)
+tile = MetricTile(metric)
+tile.refresh_metric(metric)
+print("textual_version=" + getattr(textual, "__version__", "unknown"))
+print("metric_tile_refresh=ok")
+PY
+}
+
+run_one_upgrade_smoke() {
+    FROM_VERSION="$1"
+    local home_name="${FROM_VERSION//[^A-Za-z0-9._-]/_}"
+    SMOKE_HOME="${WORKDIR}/home-${home_name}"
+    rm -rf "${SMOKE_HOME}"
+    mkdir -p "${SMOKE_HOME}"
+
+    install_baseline
+    patch_installed_upgrade_endpoint
+    run_upgrade
+    verify_upgrade
+    stop_smoke_gateway
+
+    ok "Upgrade smoke passed: ${FROM_VERSION} -> ${TARGET_VERSION} (${OS_NAME}/${ARCH_NAME})"
+    if [[ "${KEEP_WORKDIR}" == "1" ]]; then
+        ok "Upgrade log: ${SMOKE_HOME}/upgrade.log"
+    fi
+}
+
+main() {
+    parse_args "$@"
+    cd "${ROOT}"
+    if [[ -z "${TARGET_VERSION}" ]]; then
+        TARGET_VERSION="$(current_version)"
+    fi
+    validate_inputs
+    detect_platform
+
+    WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/defenseclaw-upgrade-smoke.XXXXXX")"
+
+    prepare_release_root
+    assert_candidate_assets
+    if [[ "${PREPARE_ONLY}" == "1" ]]; then
+        ok "Prepared candidate release root: ${RELEASE_ROOT}"
+        ok "Contains ${TARGET_VERSION} artifacts for ${OS_NAME}/${ARCH_NAME}"
+        return
+    fi
+    start_release_server
+    local version
+    for version in "${FROM_VERSION_LIST[@]}"; do
+        run_one_upgrade_smoke "${version}"
+    done
+
+    ok "Upgrade smoke matrix passed for ${#FROM_VERSION_LIST[@]} baseline(s): ${FROM_VERSION_LIST[*]} -> ${TARGET_VERSION} (${OS_NAME}/${ARCH_NAME})"
+    if [[ "${KEEP_WORKDIR}" == "1" ]]; then
+        ok "Upgrade logs retained under: ${WORKDIR}"
+    else
+        ok "Temp HOME/logs cleaned automatically; re-run with --keep-workdir to retain them"
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
Stack/base note: targets `main` from `codex/fix-upgrade-path-ci`. The local untracked `artifacts/` directory is intentionally excluded from this branch.

## Problem

`defenseclaw upgrade` could fail during 0.7.x -> 0.8.0 and older-version upgrade paths even after artifacts installed successfully. Two concrete failures were observed:

- old upgraders mixed cached in-process modules with the newly installed wheel, so `defenseclaw.migration_state.is_future_schema` could be missing while 0.8.0 migration code expected it
- Textual 7.x installs crashed in the TUI because `MetricTile` called `update_classes`, which only exists in newer Textual

CI also still had a custom/manual E2E path that was making main noisy, and there was no release-blocking live upgrade smoke before publishing artifacts.

## Current Situation

Release asset inspection found that `0.4.0`, `0.5.0`, `0.6.0` through `0.6.6`, `0.7.1`, and `0.7.2` have the wheel, gateway archives, and old `upgrade` command needed for live upgrade tests. `0.7.0` has no downloadable release assets, and `0.2.0` predates the upgrade command.

Older baseline wheels also expose two compatibility edges:

- `0.4.0` through `0.6.0` call `openclaw gateway restart` directly and crash when the `openclaw` binary is absent
- `0.7.x` can cache old migration/version modules before the new wheel is installed

## Solution

### Run migrations from the installed wheel

`cmd_upgrade.py` now runs migrations in a child interpreter from `~/.defenseclaw/.venv` after the new wheel is installed. That avoids mixing old `sys.modules` entries with the new migration implementation.

### Preserve legacy upgrade compatibility

`migrations.py` reloads stale migration/version modules when needed and installs a process-local `openclaw` restart shim for pre-0.6.1 upgraders when no real `openclaw` is on `PATH`. The shim returns non-zero so old upgrade code emits its existing warning instead of crashing.

### Support Textual 7.x and 8.x

`MetricTile` now uses `update_classes` when available and falls back to `set_class` loops on Textual 7.x.

### Add release upgrade smoke matrix

Added `scripts/test-upgrade-release.sh`, `make upgrade-smoke`, and `make upgrade-smoke-matrix`. The smoke harness builds or consumes candidate artifacts, serves them locally, installs an old baseline in a throwaway `HOME`, redirects the old upgrade command to the local release server, and verifies versions, migrations, known regression markers, and TUI metric refresh.

```mermaid
flowchart LR
  A[Candidate artifacts] --> B[Local release server]
  C[Historical baseline install] --> D[Patch old upgrade download URL]
  B --> D
  D --> E[defenseclaw upgrade]
  E --> F[Fresh installed venv migration runner]
  F --> G[Verify CLI, gateway, cursor, TUI refresh]
```

## What Changed (Where & How)

| Path | Change |
| --- | --- |
| `.github/workflows/e2e.yml` | Removed push, PR, and manual triggers; left scheduled E2E only. |
| `.github/workflows/ci.yml` | Added upgrade smoke matrix job. |
| `.github/workflows/release.yaml` | Added pre-publish upgrade smoke matrix before release creation. |
| `Makefile` | Added `upgrade-smoke` and `upgrade-smoke-matrix` targets plus default historical baseline list. |
| `scripts/test-upgrade-release.sh` | New reusable live upgrade harness with single-baseline and matrix modes. |
| `cli/defenseclaw/commands/cmd_upgrade.py` | Runs migrations through the freshly installed managed venv. |
| `cli/defenseclaw/migrations.py` | Reloads stale modules and adds legacy `openclaw` restart shim for pre-0.6.1 upgrade paths. |
| `cli/defenseclaw/tui/widgets/native_metrics.py` | Adds Textual 7.x class-map fallback. |
| `cli/defenseclaw/tui/app.py` | Keeps overview connector filtering deferred while overview is active. |
| `cli/tests/**` | Adds regression coverage for migration reloads, legacy shim behavior, upgrade runner, and Textual fallback. |
| `docs/TESTING.md` | Documents upgrade smoke usage, mac/Linux flow, and supported historical baselines. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

- `bash -n scripts/test-upgrade-release.sh`
  - Result: passed.
- `uv run python - <<'PY' ... yaml.safe_load(...) ... PY`
  - Result: `.github/workflows/ci.yml` and `.github/workflows/release.yaml` parsed successfully.
- `uv run pytest cli/tests/test_migrations.py::TestRunMigrations cli/tests/test_cmd_upgrade.py cli/tests/test_remediation_upgrade.py cli/tests/tui/test_native_metrics.py cli/tests/tui/test_app_shell.py -q`
  - Result: `253 passed`.
- `make lint && make check-upgrade-manifest`
  - Result: passed; `golangci-lint` fell back to `go vet` because the installed linter was built with Go 1.25 while the repo targets Go 1.26.4.
- `make test`
  - Result: Python `4483 passed, 3 skipped, 11 warnings, 303 subtests passed`; Go race tests completed with `PASS`.
- `make upgrade-smoke-matrix ARGS="--baseline-mode seed"` on macOS darwin/arm64
  - Result: passed for `0.7.2`, `0.7.1`, `0.6.6`, `0.6.5`, `0.6.4`, `0.6.3`, `0.6.2`, `0.6.1`, `0.6.0`, `0.5.0`, and `0.4.0` -> `0.8.0`.
- Linux live test on `openclaw-vineeth` linux/arm64 using prepared candidate artifacts:
  - Command: `/tmp/test-upgrade-release.sh --release-root /tmp/defenseclaw-candidate-release-matrix-1782346164 --target-version 0.8.0 --from-versions "0.7.2,0.7.1,0.6.6,0.6.5,0.6.4,0.6.3,0.6.2,0.6.1,0.6.0,0.5.0,0.4.0" --baseline-mode seed`
  - Result: passed for all 11 baselines on linux/arm64; installed Textual version was `7.5.0` and `metric_tile_refresh=ok`.
