### PR TITLE
fix: restart guardrail on connector change

### DIFF
--- a/internal/gateway/config_manager_test.go
+++ b/internal/gateway/config_manager_test.go
@@ -137,6 +137,17 @@ func TestReloadPredicatesRestartLLMConsumers(t *testing.T) {
 	}
 }
 
+func TestReloadPredicatesRestartGuardrailConnectorChange(t *testing.T) {
+	oldCfg := &config.Config{}
+	newCfg := &config.Config{}
+	oldCfg.Guardrail.Connector = "openclaw"
+	newCfg.Guardrail.Connector = "codex"
+
+	if !guardrailNeedsRestart(oldCfg, newCfg) {
+		t.Fatal("guardrailNeedsRestart returned false for guardrail.connector change")
+	}
+}
+
 func TestApplyConfigReloadRebuildsSharedJudge(t *testing.T) {
 	oldCfg := config.DefaultConfig()
 	oldCfg.DataDir = t.TempDir()

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -1205,6 +1205,7 @@ func guardrailNeedsRestart(oldCfg, newCfg *config.Config) bool {
 	oldG, newG := oldCfg.Guardrail, newCfg.Guardrail
 	if oldG.Host != newG.Host || oldG.Port != newG.Port || oldG.Enabled != newG.Enabled ||
 		!reflect.DeepEqual(oldCfg.LLM, newCfg.LLM) ||
+		oldG.Connector != newG.Connector ||
 		!reflect.DeepEqual(oldG.Connectors, newG.Connectors) ||
 		oldG.RulePackDir != newG.RulePackDir || oldG.HookSelfHeal != newG.HookSelfHeal ||
 		oldG.HookSelfHealDebounceMs != newG.HookSelfHealDebounceMs ||


### PR DESCRIPTION
## Problem

Changing the singular `guardrail.connector` selector through config reload can switch which connector should own the guardrail listener, but the reload predicate only compared the plural `guardrail.connectors` list.

## Current Situation

PR #372 adds hot config reload support. In that branch, edits to `guardrail.connector` can be classified as hot-applied even though the guardrail proxy must restart to bind/unbind the connector listener. Review finding: https://github.com/cisco-ai-defense/defenseclaw/pull/372#issuecomment-4796774679

## Solution

Treat `guardrail.connector` changes the same as `guardrail.connectors` changes in `guardrailNeedsRestart`.

## Architecture Diagram

N/A

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `internal/gateway/sidecar.go` | Includes `Guardrail.Connector` in the guardrail restart predicate. |
| `internal/gateway/config_manager_test.go` | Adds a regression test proving connector selector changes require guardrail restart. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

- `make sync-openclaw-extension && go test ./internal/gateway` - passed (`ok github.com/defenseclaw/defenseclaw/internal/gateway 32.019s`).
