### PR TITLE
docs: pin released installer examples

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -319,7 +319,9 @@ make clean        # Full clean (binaries, venv, node_modules, coverage)
 End users can install a released version without cloning the repo:
 
 ```bash
-curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash
+VERSION=0.8.1
+INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
+curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash
 ```
 
 The installer detects the platform, downloads the correct gateway
@@ -330,7 +332,9 @@ confirmations.
 Pin a specific version:
 
 ```bash
-VERSION=0.8.0 curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash
+VERSION=0.8.0
+INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
+curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash
 ```
 
 #### Picking an agent connector at install time
@@ -340,22 +344,23 @@ OpenClaw runtime and the DefenseClaw plugin). You can pick a different
 connector — or skip connector setup entirely — with `--connector`:
 
 ```bash
-INSTALL_URL=https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh
+VERSION=0.8.1
+INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
 
 # Codex (no OpenClaw, no plugin tarball; patches ~/.codex/config.toml + hooks)
-curl -LsSf "$INSTALL_URL" | bash -s -- --connector codex
+curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash -s -- --connector codex
 
 # Claude Code (no OpenClaw; patches ~/.claude/settings.json hooks)
-curl -LsSf "$INSTALL_URL" | bash -s -- --connector claudecode
+curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash -s -- --connector claudecode
 
 # ZeptoClaw (no OpenClaw; patches ~/.zeptoclaw/config.json)
-curl -LsSf "$INSTALL_URL" | bash -s -- --connector zeptoclaw
+curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash -s -- --connector zeptoclaw
 
 # Lay binaries only — pick a connector later
-curl -LsSf "$INSTALL_URL" | bash -s -- --connector none
+curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash -s -- --connector none
 
 # Shortcut for "skip OpenClaw" without naming another connector
-curl -LsSf "$INSTALL_URL" | bash -s -- --no-openclaw
+curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash -s -- --no-openclaw
 ```
 
 Run interactively (without `--yes` and without `--connector`) and the


### PR DESCRIPTION
## Problem

Released install instructions fetched `scripts/install.sh` from the mutable `main` branch, even when installing a pinned release.

## Current Situation

Issue #387 tracks the risk: a user intending to install one release can execute a newer installer from `main`, mixing installer behavior with older release assets.

## Solution

Derive `INSTALL_URL` from the selected bare release tag and pass the same `VERSION` into the installer process in the released-install examples.

## Architecture Diagram

N/A

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `docs/INSTALL.md` | Updates released installer examples to fetch `scripts/install.sh` from the selected release tag instead of `main`. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

- `git diff --check` - passed.

Closes #387.
