### PR TITLE
fix: skip sandbox install for non-openclaw connectors

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -794,7 +794,9 @@ esac
 record_picked_connector
 
 if [[ "${INSTALL_SANDBOX}" == true ]]; then
-    if [[ "${OS}" != "linux" ]]; then
+    if [[ "${CONNECTOR}" != "openclaw" ]]; then
+        warn "Sandbox setup is experimental and currently applies to the OpenClaw/OpenShell path only — skipping openshell-sandbox"
+    elif [[ "${OS}" != "linux" ]]; then
         warn "Sandbox mode requires Linux — skipping openshell-sandbox"
     else
         local script_dir


### PR DESCRIPTION
## Problem

`scripts/install.sh --connector <non-openclaw> --sandbox` still installed `openshell-sandbox`, even though sandbox setup is documented as the OpenClaw/OpenShell path only.

## Current Situation

Issue #386 tracks the mismatch. Non-OpenClaw connector installs can leave an unnecessary privileged sandbox binary installed despite the warning that sandbox setup does not apply.

## Solution

Gate the sandbox installer on `CONNECTOR=openclaw`. For other connectors, keep the warning and skip `openshell-sandbox` installation before reaching either local or downloaded installer paths.

## Architecture Diagram

N/A

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `scripts/install.sh` | Skips `openshell-sandbox` installation when `--sandbox` is used with a non-OpenClaw connector. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

- `bash -n scripts/install.sh` - passed.
- `git diff --check` - passed.

Closes #386.
