### PR TITLE
[codex] Allow signed upgrades without local cosign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OC_EXT_DIR  := $(HOME)/.openclaw/extensions/defenseclaw
 RUFF        := $(shell if [ -x "$(VENV)/bin/ruff" ]; then printf '%s' "$(VENV)/bin/ruff"; elif command -v ruff >/dev/null 2>&1; then command -v ruff; else printf '%s' "$(VENV)/bin/ruff"; fi)
 
 DIST_DIR    := dist
-UPGRADE_SMOKE_FROM ?= 0.7.2 0.7.1 0.6.6 0.6.5 0.6.4 0.6.3 0.6.2 0.6.1 0.6.0 0.5.0 0.4.0
+UPGRADE_SMOKE_FROM ?= 0.8.1 0.8.0 0.7.2 0.7.1 0.6.6 0.6.5 0.6.4 0.6.3 0.6.2 0.6.1 0.6.0 0.5.0 0.4.0
 
 # Cross-platform virtualenv / executable layout. Windows Python venvs expose
 # console entry points under Scripts/ (not bin/) and binaries carry a .exe

--- a/cli/defenseclaw/commands/cmd_upgrade.py
+++ b/cli/defenseclaw/commands/cmd_upgrade.py
@@ -64,7 +64,7 @@ _UPGRADE_MANIFEST_FILENAME = "upgrade-manifest.json"
     default=False,
     help=(
         "Proceed even when release artifacts cannot be cryptographically "
-        "verified (missing/unsigned checksums.txt, missing cosign, or "
+        "verified (missing/unsigned checksums.txt, invalid signature, or "
         "missing upgrade-manifest.json). UNSAFE: only use when you knowingly "
         "accept the supply-chain risk."
     ),
@@ -145,7 +145,8 @@ def upgrade(
         )
         if checksums is None:
             # F-0581 (BREAKING CHANGE): the only signed integrity manifest is
-            # the Sigstore-verified checksums.txt. GitHub's per-asset `digest`
+            # checksums.txt when it is either Sigstore-verified or accepted
+            # with an explicit missing-cosign warning. GitHub's per-asset `digest`
             # values come from the same (untrusted, remote) release service and
             # are UNSIGNED metadata — a compromised/spoofed release endpoint can
             # serve matching bytes + digest, so they are NOT a substitute for a
@@ -159,7 +160,7 @@ def upgrade(
             # verification (we do not pretend unsigned digests are trusted).
             if not allow_unverified:
                 ux.err(
-                    "No Sigstore-verified checksums.txt is available for this "
+                    "No trusted checksums.txt is available for this "
                     "release — refusing to install release artifacts that "
                     "cannot be cryptographically integrity-verified. GitHub "
                     "per-asset digests are unsigned metadata and are NOT "
@@ -181,7 +182,7 @@ def upgrade(
                 indent="  ",
             )
         else:
-            ux.ok("Checksum manifest verified (checksums.txt)")
+            ux.ok("Checksum manifest accepted (checksums.txt)")
             # F-0582 (BREAKING CHANGE): do NOT silently fill missing artifact
             # entries from unsigned GitHub asset digests. Doing so would
             # downgrade those artifacts from signed to unsigned authentication
@@ -531,10 +532,13 @@ def _download_checksums(
     parse, not just download, because a 200 with garbage body would
     otherwise look "verified" to the caller.
 
-    F-0202: a downloaded ``checksums.txt`` is only trusted once its
-    Sigstore signature verifies. ``_verify_checksums_sigstore`` fails
-    closed when the manifest is unsigned/unverifiable unless the operator
-    passed ``allow_unverified``.
+    F-0202: a downloaded ``checksums.txt`` is trusted when either its
+    Sigstore signature verifies or the release shipped signature assets but
+    the local host cannot run cosign. The latter is a deliberate operator-UX
+    compromise: checksum validation still protects against a corrupt or
+    swapped payload, and the command prints a warning naming the missing
+    verifier. Other unsigned/unverifiable states still fail closed unless the
+    operator passed ``allow_unverified``.
     """
     dest = _download_optional_release_asset(version, _CHECKSUMS_FILENAME, staging_dir)
     if not dest:
@@ -597,14 +601,17 @@ def _verify_checksums_sigstore(
 ) -> None:
     """Verify checksums.txt with its Sigstore cert/signature.
 
-    Fails closed (``SystemExit``) when the manifest cannot be
-    cryptographically authenticated, unless ``allow_unverified`` is set:
+    Fails closed (``SystemExit``) when the manifest cannot be trusted, unless
+    ``allow_unverified`` is set:
 
     * F-0202: an unsigned manifest (no ``.sig``/``.pem`` assets, or only
       one of them) is untrusted — a checksum match against an unsigned
       manifest proves nothing about provenance.
-    * F-0704: a manifest that ships Sigstore assets but cannot be verified
-      because ``cosign`` is missing must not be downgraded to "unsigned".
+    * Bad Sigstore signatures are untrusted.
+    * Missing local ``cosign`` is a warning, not a hard stop, when both
+      Sigstore assets are present. The operator still gets SHA-256 checksum
+      validation and an explicit reminder to install cosign for provenance
+      verification.
     """
     sig_path = _download_optional_release_asset(version, f"{_CHECKSUMS_FILENAME}.sig", staging_dir)
     cert_path = _download_optional_release_asset(version, f"{_CHECKSUMS_FILENAME}.pem", staging_dir)
@@ -627,11 +634,11 @@ def _verify_checksums_sigstore(
 
     cosign = shutil.which("cosign")
     if not cosign:
-        _fail_unsigned_checksums(
+        ux.warn(
             "checksums.txt Sigstore signature is present, but cosign was "
-            "not found on PATH — refusing to downgrade signed verification "
-            "to unsigned.",
-            allow_unverified,
+            "not found on PATH; continuing with checksum verification only. "
+            "Install cosign to verify release provenance.",
+            indent="  ",
         )
         return
 

--- a/cli/tests/test_cmd_upgrade.py
+++ b/cli/tests/test_cmd_upgrade.py
@@ -532,10 +532,9 @@ class TestChecksumVerification(unittest.TestCase):
 
         self.assertEqual(ctx.exception.code, 1)
 
-    def test_checksums_sigstore_fails_closed_without_cosign(self):
-        """F-0704: a release that ships Sigstore assets must NOT be downgraded
-        to unsigned verification just because cosign is missing. The default
-        (no --allow-unverified) now fails closed."""
+    def test_checksums_sigstore_warns_without_cosign(self):
+        """A release that ships Sigstore assets should still be upgradeable on
+        hosts without cosign; checksum validation continues after a warning."""
         with TemporaryDirectory() as tmp:
             checksums = os.path.join(tmp, "checksums.txt")
             sig = os.path.join(tmp, "checksums.txt.sig")
@@ -552,15 +551,48 @@ class TestChecksumVerification(unittest.TestCase):
                 return_value=None,
             ), patch(
                 "defenseclaw.commands.cmd_upgrade.subprocess.run"
-            ) as run_mock, self.assertRaises(SystemExit) as ctx:
+            ) as run_mock, patch(
+                "defenseclaw.commands.cmd_upgrade.ux.warn"
+            ) as warn_mock:
                 _verify_checksums_sigstore("9.9.9", tmp, checksums)
 
-        self.assertEqual(ctx.exception.code, 1)
         run_mock.assert_not_called()
+        warn_mock.assert_called_once()
+        self.assertIn("continuing with checksum verification only", warn_mock.call_args.args[0])
+
+    def test_download_checksums_accepts_signed_manifest_without_cosign(self):
+        """Regression for 0.8.0 -> 0.8.1: signed release assets must not
+        require cosign to be installed before checksum validation can proceed."""
+        with TemporaryDirectory() as tmp:
+            checksums = os.path.join(tmp, "checksums.txt")
+            sig = os.path.join(tmp, "checksums.txt.sig")
+            cert = os.path.join(tmp, "checksums.txt.pem")
+            sha = "a" * 64
+            with open(checksums, "w", encoding="utf-8") as f:
+                f.write(f"{sha}  defenseclaw-9.9.9-py3-none-any.whl\n")
+            for path in (sig, cert):
+                with open(path, "wb") as f:
+                    f.write(b"release asset")
+
+            with patch(
+                "defenseclaw.commands.cmd_upgrade._download_optional_release_asset",
+                side_effect=[checksums, sig, cert],
+            ), patch(
+                "defenseclaw.commands.cmd_upgrade.shutil.which",
+                return_value=None,
+            ), patch(
+                "defenseclaw.commands.cmd_upgrade.subprocess.run"
+            ) as run_mock, patch(
+                "defenseclaw.commands.cmd_upgrade.ux.warn"
+            ) as warn_mock:
+                result = _download_checksums("9.9.9", tmp)
+
+        self.assertEqual(result, {"defenseclaw-9.9.9-py3-none-any.whl": sha})
+        run_mock.assert_not_called()
+        warn_mock.assert_called_once()
 
     def test_checksums_sigstore_allow_unverified_skips_cosign(self):
-        """With the explicit operator opt-in, a missing cosign degrades to a
-        warning instead of aborting (F-0704 escape hatch)."""
+        """The explicit operator opt-in still permits the missing-cosign path."""
         with TemporaryDirectory() as tmp:
             checksums = os.path.join(tmp, "checksums.txt")
             sig = os.path.join(tmp, "checksums.txt.sig")

--- a/cli/tests/test_remediation_upgrade.py
+++ b/cli/tests/test_remediation_upgrade.py
@@ -8,8 +8,8 @@ Findings covered:
 
 * F-0201 / F-0703 — abort the upgrade when no integrity metadata is available.
 * F-0202        — refuse an unsigned/unverifiable checksum manifest.
-* F-0704        — refuse to downgrade signed checksums to unsigned when cosign
-                  is missing.
+* F-0704        — warn and continue with checksum validation when cosign is
+                  missing but signed checksum assets are present.
 * F-0203        — fail closed when the release upgrade manifest cannot be
                   fetched.
 * F-0701        — never send the gateway bearer token to a non-loopback probe
@@ -336,11 +336,10 @@ class TestUnsignedChecksumManifestRejected(unittest.TestCase):
             self.assertEqual(ctx.exception.code, 1)
 
 
-class TestSigstoreCosignMissingFailsClosed(unittest.TestCase):
-    """F-0704: signed checksums must not be downgraded to unsigned just
-    because cosign is unavailable on the host."""
+class TestSigstoreCosignMissingWarns(unittest.TestCase):
+    """Signed checksums remain usable when cosign is unavailable locally."""
 
-    def test_missing_cosign_with_signature_fails_closed(self):
+    def test_missing_cosign_with_signature_warns_and_continues(self):
         with TemporaryDirectory() as tmp:
             checksums = os.path.join(tmp, "checksums.txt")
             sig = os.path.join(tmp, "checksums.txt.sig")
@@ -357,11 +356,14 @@ class TestSigstoreCosignMissingFailsClosed(unittest.TestCase):
                 return_value=None,
             ), patch(
                 "defenseclaw.commands.cmd_upgrade.subprocess.run"
-            ) as run_mock, self.assertRaises(SystemExit) as ctx:
+            ) as run_mock, patch(
+                "defenseclaw.commands.cmd_upgrade.ux.warn"
+            ) as warn_mock:
                 _verify_checksums_sigstore("9.9.9", tmp, checksums)
 
-        self.assertEqual(ctx.exception.code, 1)
         run_mock.assert_not_called()
+        warn_mock.assert_called_once()
+        self.assertIn("continuing with checksum verification only", warn_mock.call_args.args[0])
 
 
 class TestUpgradeManifestFailsClosed(unittest.TestCase):

--- a/docs-site/content/docs/reference/cli.mdx
+++ b/docs-site/content/docs/reference/cli.mdx
@@ -165,6 +165,8 @@ The sidecar is the Go binary; the Python CLI does not own a `gateway` group. Mos
 | --- | --- |
 | `defenseclaw upgrade [--version X] [--yes]` | Upgrade the Python CLI and Go gateway from GitHub release artifacts without a source checkout. The command downloads the release checksum manifest, verifies Sigstore provenance when local `cosign` is available, validates gateway/wheel checksums, and loads the upgrade manifest before stopping the gateway. macOS/Linux use the release tarball; Windows uses the release ZIP and installs `defenseclaw-gateway.exe`. Signed releases still upgrade without `cosign` by warning and continuing with checksum validation only; `--allow-unverified` is an explicit unsafe override when a release manifest is missing, unsigned, incomplete, or otherwise unverifiable. |
 
+`0.7.x` clients do not support `--allow-unverified`; upgrade them directly to the latest fixed release with plain `defenseclaw upgrade --yes` or `defenseclaw upgrade --version VERSION --yes`.
+
 ## Uninstall / disable
 
 | Command | Use it for |

--- a/docs-site/content/docs/reference/cli.mdx
+++ b/docs-site/content/docs/reference/cli.mdx
@@ -163,7 +163,7 @@ The sidecar is the Go binary; the Python CLI does not own a `gateway` group. Mos
 
 | Command | Use it for |
 | --- | --- |
-| `defenseclaw upgrade [--version X] [--yes]` | Upgrade the Python CLI and Go gateway from GitHub release artifacts without a source checkout. The command downloads and verifies the release checksum manifest, gateway archive, Python wheel, and upgrade manifest before stopping the gateway. macOS/Linux use the release tarball; Windows uses the release ZIP and installs `defenseclaw-gateway.exe`. `--allow-unverified` is an explicit unsafe override when a release cannot be cryptographically verified. |
+| `defenseclaw upgrade [--version X] [--yes]` | Upgrade the Python CLI and Go gateway from GitHub release artifacts without a source checkout. The command downloads the release checksum manifest, verifies Sigstore provenance when local `cosign` is available, validates gateway/wheel checksums, and loads the upgrade manifest before stopping the gateway. macOS/Linux use the release tarball; Windows uses the release ZIP and installs `defenseclaw-gateway.exe`. Signed releases still upgrade without `cosign` by warning and continuing with checksum validation only; `--allow-unverified` is an explicit unsafe override when a release manifest is missing, unsigned, incomplete, or otherwise unverifiable. |
 
 ## Uninstall / disable
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -464,6 +464,15 @@ Signed releases can be upgraded on hosts without `cosign`; the command warns
 and continues with SHA-256 checksum validation only. Install `cosign` to verify
 Sigstore provenance in addition to checksums.
 
+**Known recovery paths:**
+
+| Installed version | Recommendation |
+| --- | --- |
+| `0.8.0` or `0.8.1` | These versions can require local `cosign` before the fixed wheel is installed. Install `cosign` first (`brew install cosign` on macOS) and then run plain `defenseclaw upgrade`, or use `defenseclaw upgrade --allow-unverified` only if you accept the reduced provenance check for that one bridge upgrade. |
+| `0.7.x` | Upgrade directly to the latest release. Do not target `0.8.0`; that release had a broken migration-cache path. |
+| `0.7.0` release tag | No downloadable release assets were published for this tag, so release-asset smoke cannot cover it. Upgrade from a locally installed `0.7.0` directly to the latest release. |
+| `0.2.0` | This predates the `defenseclaw upgrade` command. Use the installer documented in `docs/INSTALL.md` to bridge to a modern release. |
+
 **Examples:**
 
 ```bash

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -457,6 +457,12 @@ by 0.2.0's guardrail setup) while preserving plugin registration.
 **Flags:**
 - `--yes`, `-y` — skip confirmation prompts
 - `--version VERSION` — upgrade to a specific release (default: latest)
+- `--allow-unverified` — unsafe override for releases whose checksum manifest
+  is missing, unsigned, incomplete, or otherwise unverifiable
+
+Signed releases can be upgraded on hosts without `cosign`; the command warns
+and continues with SHA-256 checksum validation only. Install `cosign` to verify
+Sigstore provenance in addition to checksums.
 
 **Examples:**
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -469,8 +469,8 @@ Sigstore provenance in addition to checksums.
 | Installed version | Recommendation |
 | --- | --- |
 | `0.8.0` or `0.8.1` | These versions can require local `cosign` before the fixed wheel is installed. Install `cosign` first (`brew install cosign` on macOS) and then run plain `defenseclaw upgrade`, or use `defenseclaw upgrade --allow-unverified` only if you accept the reduced provenance check for that one bridge upgrade. |
-| `0.7.x` | Upgrade directly to the latest release. Do not target `0.8.0`; that release had a broken migration-cache path. |
-| `0.7.0` release tag | No downloadable release assets were published for this tag, so release-asset smoke cannot cover it. Upgrade from a locally installed `0.7.0` directly to the latest release. |
+| `0.7.x` | Upgrade directly to the latest release with plain `defenseclaw upgrade --yes` or `defenseclaw upgrade --version VERSION --yes`. Do not pass `--allow-unverified`; `0.7.x` clients do not know that option. Do not target `0.8.0`; that release had a broken migration-cache path. |
+| `0.7.0` release tag | No downloadable release assets were published for this tag, so release-asset smoke cannot cover it. Upgrade from a locally installed `0.7.0` directly to the latest release without `--allow-unverified`. |
 | `0.2.0` | This predates the `defenseclaw upgrade` command. Use the installer documented in `docs/INSTALL.md` to bridge to a modern release. |
 
 **Examples:**

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -73,10 +73,10 @@ For a Linux host without the repo's Go toolchain, prepare candidate artifacts on
 ```bash
 scripts/test-upgrade-release.sh --prepare-only --platform linux/arm64 --keep-workdir
 scp -r /tmp/defenseclaw-upgrade-smoke.xxxxxx/candidate-release openclaw-vineeth:/tmp/
-ssh openclaw-vineeth 'scripts/test-upgrade-release.sh --release-root /tmp/candidate-release --from-versions "0.7.2,0.7.1,0.6.6,0.6.5,0.6.4,0.6.3,0.6.2,0.6.1,0.6.0,0.5.0,0.4.0" --baseline-mode seed'
+ssh openclaw-vineeth 'scripts/test-upgrade-release.sh --release-root /tmp/candidate-release --from-versions "0.8.1,0.8.0,0.7.2,0.7.1,0.6.6,0.6.5,0.6.4,0.6.3,0.6.2,0.6.1,0.6.0,0.5.0,0.4.0" --baseline-mode seed'
 ```
 
-The default matrix covers every published 0.4.0+ baseline that has both a Python wheel, platform gateway archives, and an upgrade command: `0.7.2`, `0.7.1`, `0.6.6`, `0.6.5`, `0.6.4`, `0.6.3`, `0.6.2`, `0.6.1`, `0.6.0`, `0.5.0`, and `0.4.0`. Release `0.7.0` has no downloadable release assets, and `0.2.0` predates the upgrade command, so they are not live-upgradeable by this harness.
+The default matrix covers every published 0.4.0+ baseline that has both a Python wheel, platform gateway archives, and an upgrade command: `0.8.1`, `0.8.0`, `0.7.2`, `0.7.1`, `0.6.6`, `0.6.5`, `0.6.4`, `0.6.3`, `0.6.2`, `0.6.1`, `0.6.0`, `0.5.0`, and `0.4.0`. Baselines newer than the candidate target are skipped automatically so local CI does not accidentally test downgrades before a release workflow stamps the next version. Release `0.7.0` has no downloadable release assets, and `0.2.0` predates the upgrade command, so they are not live-upgradeable by this harness.
 
 The release workflow also runs `make upgrade-smoke-matrix ARGS="--release-dir dist --baseline-mode seed"` after artifacts/checksums are finalized and before `gh release create`, so a broken upgrade path aborts before assets are published.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -52,6 +52,7 @@ Before cutting a release, run the upgrade smoke on at least macOS and Linux. It 
 - CLI and gateway versions match the candidate version
 - known regression markers such as `Traceback`, `AttributeError`, missing required migrations, and component drift are absent
 - the Textual metric tile refresh path works in the installed environment
+- signed candidates run the default upgrade path; `--allow-unverified` is only added automatically for unsigned local smoke artifacts
 
 ```bash
 # Current platform, building candidate artifacts from the working tree.

--- a/scripts/test-upgrade-release.sh
+++ b/scripts/test-upgrade-release.sh
@@ -62,7 +62,7 @@ Options:
 Examples:
   make upgrade-smoke
   scripts/test-upgrade-release.sh --from-version 0.7.2
-  scripts/test-upgrade-release.sh --from-versions "0.7.2,0.7.1,0.6.6,0.6.0,0.5.0,0.4.0"
+  scripts/test-upgrade-release.sh --from-versions "0.8.1,0.8.0,0.7.2,0.7.1,0.6.6,0.6.0,0.5.0,0.4.0"
   scripts/test-upgrade-release.sh --release-dir dist --baseline-mode seed
 
 For a Linux host without the repo's Go toolchain, build/copy artifacts first:
@@ -202,10 +202,27 @@ normalize_baseline_versions() {
         [[ -n "${version}" ]] || continue
         [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
             || die "invalid baseline version: ${version}"
+        if ! version_lte "${version}" "${TARGET_VERSION}"; then
+            warn "Skipping baseline ${version}; target ${TARGET_VERSION} is older"
+            continue
+        fi
         FROM_VERSION_LIST+=("${version}")
     done
     [[ "${#FROM_VERSION_LIST[@]}" -gt 0 ]] || die "no baseline versions provided"
     FROM_VERSION="${FROM_VERSION_LIST[0]}"
+}
+
+version_lte() {
+    python3 - "$1" "$2" <<'PY'
+import sys
+
+
+def parse(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
+raise SystemExit(0 if parse(sys.argv[1]) <= parse(sys.argv[2]) else 1)
+PY
 }
 
 validate_inputs() {

--- a/scripts/test-upgrade-release.sh
+++ b/scripts/test-upgrade-release.sh
@@ -399,10 +399,15 @@ upgrade_supports_allow_unverified() {
         defenseclaw upgrade --help 2>/dev/null | grep -q -- "--allow-unverified"
 }
 
+candidate_has_checksum_signature() {
+    local dir="${RELEASE_ROOT}/${TARGET_VERSION}"
+    [[ -f "${dir}/checksums.txt.sig" && -f "${dir}/checksums.txt.pem" ]]
+}
+
 run_upgrade() {
     log "Running upgrade ${FROM_VERSION} -> ${TARGET_VERSION}"
     local -a args=(upgrade --version "${TARGET_VERSION}" --yes --health-timeout "${HEALTH_TIMEOUT}")
-    if upgrade_supports_allow_unverified; then
+    if upgrade_supports_allow_unverified && ! candidate_has_checksum_signature; then
         args+=(--allow-unverified)
     fi
 


### PR DESCRIPTION
Stack/base note: targets `main` from `codex/fix-cosignless-upgrade`. This follows PR #385, which was merged as `0.8.1`; the local untracked `artifacts/` directory remains excluded.

## Problem

Users on `0.8.0` or `0.8.1` can be blocked by the default upgrade path before the fixed wheel is installed when the target release has `checksums.txt.sig`/`.pem` but the host does not have `cosign` on `PATH`.

The observed failure is:

```text
checksums.txt Sigstore signature is present, but cosign was not found on PATH — refusing to downgrade signed verification to unsigned.
Re-run with --allow-unverified to override (UNSAFE).
```

## Current Situation

`0.8.1` release assets are signed, which is good. The sharp edge is that `0.8.0`/`0.8.1` made local `cosign` availability mandatory for signed manifests. Many operator laptops do not have `cosign`, and a future fixed wheel cannot change the already-running old upgrader before that old upgrader downloads and installs the new wheel.

Why our testing missed it:

- The upgrade smoke harness automatically appended `--allow-unverified` whenever the installed upgrader supported that flag.
- That proved the upgrade could proceed with an escape hatch, but it masked the default operator path.
- The default smoke matrix did not include the `0.8.x` baselines, so the regression-prone bridge releases were not part of the release gate.

## Solution

### Make Missing Local Cosign A Warning

When both Sigstore sidecar assets are present, but local `cosign` is missing, `defenseclaw upgrade` now warns and continues with SHA-256 checksum validation. Bad signatures still fail closed when `cosign` is available. Missing, unsigned, or incomplete checksum manifests still require `--allow-unverified`.

```mermaid
flowchart TD
  A[Download checksums.txt] --> B{sig and pem present?}
  B -- no --> C[Fail unless --allow-unverified]
  B -- yes --> D{cosign on PATH?}
  D -- yes --> E{Sigstore verifies?}
  E -- no --> F[Fail closed]
  E -- yes --> G[Validate artifact SHA-256]
  D -- no --> H[Warn: provenance not verified]
  H --> G
```

### Stop Masking The Default Path In Smoke

`scripts/test-upgrade-release.sh` now only auto-adds `--allow-unverified` when the candidate release root is unsigned. Signed release-style candidates exercise the default upgrader path.

### Expand The Live Upgrade Matrix

The Makefile smoke matrix now includes `0.8.1` and `0.8.0` before the older live-upgradeable baselines. The harness skips baselines newer than the candidate target so local branches stamped `0.8.0` do not accidentally test downgrades; the release workflow will include `0.8.1` once the next version is stamped.

### Document The Recovery Path

CLI docs now distinguish checksum validation from Sigstore provenance verification and call out the recovery paths for broken published versions.

## What Changed (Where & How)

| Path | Change |
| --- | --- |
| `cli/defenseclaw/commands/cmd_upgrade.py` | Missing local `cosign` now warns and proceeds with checksum validation when signed checksum assets exist; bad signatures and unsigned/incomplete manifests still fail closed. |
| `cli/tests/test_cmd_upgrade.py` | Added regression coverage for `_download_checksums` with signed assets and missing `cosign`; updated missing-cosign unit expectations. |
| `cli/tests/test_remediation_upgrade.py` | Updated remediation coverage to assert warning-and-continue behavior for signed manifests without local `cosign`. |
| `scripts/test-upgrade-release.sh` | Only adds `--allow-unverified` automatically for unsigned local smoke candidates; skips baselines newer than the target version. |
| `Makefile` | Adds `0.8.1` and `0.8.0` to the default `upgrade-smoke-matrix` baseline list. |
| `docs/CLI.md` | Documents missing-cosign behavior and known recovery paths for broken versions. |
| `docs-site/content/docs/reference/cli.mdx` | Updates CLI reference for checksum vs provenance verification. |
| `docs/TESTING.md` | Notes that signed smoke candidates run the default upgrade path and documents the expanded matrix. |

## Breaking Changes

Behavior change: missing local `cosign` is no longer a hard stop when the release publishes both Sigstore assets. This is intentionally less disruptive for operators, while still preserving checksum validation and hard-failing invalid signatures when `cosign` is present.

Operational note: already-installed `0.8.0`/`0.8.1` clients still need a one-time bridge step because those published clients run before this fix can be installed. Operators should install `cosign` and run plain `defenseclaw upgrade`, or use `defenseclaw upgrade --allow-unverified` once if they accept reduced provenance verification for that bridge. `0.7.x` clients do not support `--allow-unverified`; those users should run plain `defenseclaw upgrade --version VERSION --yes` and avoid targeting broken `0.8.0`.

## Open Issues / Follow-ups

None.

## Test Plan

- `.venv/bin/ruff check cli/defenseclaw/commands/cmd_upgrade.py cli/tests/test_cmd_upgrade.py cli/tests/test_remediation_upgrade.py`
  - Result: `All checks passed!`
- `uv run pytest cli/tests/test_cmd_upgrade.py cli/tests/test_remediation_upgrade.py -q`
  - Result: `74 passed`.
- `bash -n scripts/test-upgrade-release.sh && git diff --check`
  - Result: passed.
- `make lint`
  - Result: passed; local `golangci-lint` was too old for Go `1.26.4`, so the Makefile fell back to `go vet ./...` and exited cleanly.
- `make test`
  - Result: `4486 passed, 3 skipped, 12 warnings, 303 subtests passed` for Python, followed by passing Go race tests.
- `make upgrade-smoke-matrix ARGS="--target-version 0.8.0 --baseline-mode seed"` on macOS arm64
  - Result: passed for `0.8.0`, `0.7.2`, `0.7.1`, `0.6.6`, `0.6.5`, `0.6.4`, `0.6.3`, `0.6.2`, `0.6.1`, `0.6.0`, `0.5.0`, and `0.4.0`; skipped `0.8.1` because target `0.8.0` is older.
- Linux arm64 remote smoke on `openclaw-vineeth`
  - Result: passed for the same 12 baselines against prepared Linux arm64 artifacts; skipped `0.8.1` because target `0.8.0` is older.

