### PR TITLE
[codex] Fix release upgrade smoke drift gate

### DIFF
--- a/scripts/test-upgrade-release.sh
+++ b/scripts/test-upgrade-release.sh
@@ -435,7 +435,12 @@ run_upgrade() {
         die "upgrade command failed"
     fi
 
-    if grep -E "Traceback|AttributeError|Required migration\\(s\\).*not recorded|Component drift detected" \
+    # The upgrade command runs inside the already-installed baseline process.
+    # Baselines that perform an in-process post-upgrade drift check can still
+    # have the old CLI version cached in sys.modules after replacing the wheel
+    # on disk. Do not fail on that warning here; verify_upgrade launches the
+    # freshly installed CLI/gateway as new processes and catches real drift.
+    if grep -E "Traceback|AttributeError|Required migration\\(s\\).*not recorded" \
         "${SMOKE_HOME}/upgrade.log" >/dev/null; then
         tail_log "${SMOKE_HOME}/upgrade.log"
         die "upgrade log contains a known regression marker"


### PR DESCRIPTION
Stack/base note: targets `main` from `codex/fix-release-smoke-drift`. This is a release-unblock follow-up after release workflow run `28184148444` failed before publishing `0.8.2` assets.

## Problem

The `0.8.2` release workflow failed in `Pre-publish upgrade smoke` while testing the first baseline, `0.8.1 -> 0.8.2`.

The upgrade itself completed, but the smoke harness failed because it treated any `Component drift detected` line in the upgrade log as a hard regression marker.

## Current Situation

The failing log showed:

```text
✓ DefenseClaw upgraded: 0.8.1 -> 0.8.2
⚠ Component drift detected after upgrade:
  gateway 0.8.2 differs from cli 0.8.1
ERROR: upgrade log contains a known regression marker
```

That warning comes from the already-running `0.8.1` Python process. After it replaces the wheel on disk, its in-memory `defenseclaw.__version__` is still `0.8.1`, so the old process can report false CLI/gateway drift. The smoke harness already launches fresh `defenseclaw --version` and `defenseclaw-gateway --version` processes immediately afterward, which is the reliable installed-state check.

## Solution

### Let Fresh Process Verification Own Drift Detection

Keep failing immediately on true known regression markers:

- Python tracebacks
- `AttributeError`
- required migration cursor gaps

Stop failing immediately on `Component drift detected` inside the old process log. The existing `verify_upgrade` step now gets to run and fails if the installed CLI or gateway really did not move to the target version.

## What Changed (Where & How)

| Path | Change |
| --- | --- |
| `scripts/test-upgrade-release.sh` | Removes `Component drift detected` from the pre-verify fatal grep and documents why fresh-process version checks are authoritative. |

## Breaking Changes

None. This only changes release smoke gating behavior; it does not change runtime upgrade behavior or release artifacts.

## Open Issues / Follow-ups

None.

## Test Plan

- `gh run view 28184148444 --repo cisco-ai-defense/defenseclaw --job 83481423984 --log`
  - Result: confirmed failure in `Pre-publish upgrade smoke` on `0.8.1 -> 0.8.2` due to `Component drift detected` marker after an otherwise completed upgrade.
- `bash -n scripts/test-upgrade-release.sh && git diff --check`
  - Result: passed.
- Detached temporary worktree from this branch, then:
  - `scripts/stamp-version.sh 0.8.2`
  - `scripts/test-upgrade-release.sh --from-versions "0.8.1" --target-version 0.8.2 --baseline-mode seed`
  - Result: `OK: Upgrade smoke passed: 0.8.1 -> 0.8.2 (darwin/arm64)`.
