### PR TITLE
test(gateway): exercise passthrough auth rejection

### DIFF
--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -1628,6 +1628,7 @@ func TestHandlePassthrough_AuthRejection(t *testing.T) {
 	insp := newMockInspector()
 	proxy := newTestProxy(t, prov, insp, "action")
 	proxy.gatewayToken = "secret-token"
+	proxy.skipAuthForTest = false
 
 	t.Run("missing_auth_rejected", func(t *testing.T) {
 		body := mustJSON(t, map[string]interface{}{


### PR DESCRIPTION
## Summary
- make the passthrough auth rejection test disable the test-only auth bypass
- keep the missing-auth case from reaching the real upstream URL
- cover the shared CI failure seen in the unified test job

## Validation
- make sync-openclaw-extension
- go test -race ./internal/gateway -run '^TestHandlePassthrough_AuthRejection$' -count=1 -v
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved authentication failure coverage to ensure missing credentials are handled through the normal rejection path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->