### PR TITLE
fix(status): detect openshell sandbox runtime

### DIFF
--- a/cli/defenseclaw/commands/cmd_status.py
+++ b/cli/defenseclaw/commands/cmd_status.py
@@ -71,6 +71,13 @@ def _status_row(key: str, value: str) -> None:
     click.echo(f"  {ux._style(label_padded, fg='bright_black', bold=True)}{rendered_value}")
 
 
+def _openshell_available(cfg) -> bool:
+    binary = getattr(getattr(cfg, "openshell", None), "binary", "")
+    if binary and shutil.which(str(binary)):
+        return True
+    return bool(shutil.which("openshell-sandbox"))
+
+
 @click.command()
 @click.option(
     "--json",
@@ -117,7 +124,7 @@ def status(app: AppContext, as_json: bool) -> None:
     click.echo()
 
     # Sandbox
-    if shutil.which(cfg.openshell.binary):
+    if _openshell_available(cfg):
         _status_row("Sandbox", ux._style("available", fg="green"))
     else:
         _status_row(
@@ -606,7 +613,7 @@ def _status_payload(app) -> dict:
         "config": f"{cfg.data_dir}/config.yaml",
         "audit_db": cfg.audit_db,
         "scope": _connector_scope_text(cfg),
-        "sandbox": {"available": bool(shutil.which(cfg.openshell.binary))},
+        "sandbox": {"available": _openshell_available(cfg)},
         "scanners": _scanner_status_map(cfg),
         "connectors": _connector_roster(cfg),
     }

--- a/cli/tests/test_cmd_misc.py
+++ b/cli/tests/test_cmd_misc.py
@@ -97,6 +97,31 @@ class TestStatusCommand(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("running", result.output)
 
+    @patch("defenseclaw.gateway.OrchestratorClient")
+    @patch("defenseclaw.commands.cmd_status.shutil.which")
+    def test_status_accepts_openshell_sandbox_binary(self, mock_which, mock_client_cls):
+        from defenseclaw.commands.cmd_status import status
+
+        def fake_which(binary):
+            if binary == "openshell-sandbox":
+                return "/usr/local/bin/openshell-sandbox"
+            return None
+
+        mock_which.side_effect = fake_which
+        mock_client = MagicMock()
+        mock_client.is_running.return_value = False
+        mock_client_cls.return_value = mock_client
+
+        result = self.runner.invoke(status, [], obj=self.app, catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Sandbox:", result.output)
+        self.assertIn("available", result.output)
+
+        result = self.runner.invoke(status, ["--json"], obj=self.app, catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertTrue(payload["sandbox"]["available"])
+
 
 # ---------------------------------------------------------------------------
 # Alerts command


### PR DESCRIPTION
## Summary
- treat openshell-sandbox as an available sandbox runtime in defenseclaw status
- keep the same availability result in the status JSON payload
- add a regression test for human and JSON output

## Validation
- uv run --python 3.12 pytest cli/tests/test_cmd_misc.py::TestStatusCommand -q
- uv run --python 3.12 ruff check cli/defenseclaw/commands/cmd_status.py cli/tests/test_cmd_misc.py
- make py-lint
- git diff --check HEAD~1..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox availability detection in the status command to recognize both a configured OpenShell binary and a fallback sandbox binary.
  * Kept the human-readable and JSON status outputs consistent, so both now report sandbox availability the same way.

* **Tests**
  * Added coverage for status output when the sandbox binary is available, including JSON reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->