### PR TITLE
fix(installer): pin sandbox installer fallback

### DIFF
--- a/cli/tests/test_install_script_static.py
+++ b/cli/tests/test_install_script_static.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SH = ROOT / "scripts" / "install.sh"
+
+
+def test_sandbox_installer_fallback_uses_selected_release() -> None:
+    text = INSTALL_SH.read_text()
+    assert "raw.githubusercontent.com/${REPO}/main/scripts/install-openshell-sandbox.sh" not in text
+    assert (
+        "raw.githubusercontent.com/${REPO}/${RELEASE_VERSION}/scripts/install-openshell-sandbox.sh"
+        in text
+    )

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -808,7 +808,7 @@ if [[ "${INSTALL_SANDBOX}" == true ]]; then
             step "Installing openshell-sandbox"
             info "Downloading installer..."
             curl -fsSL \
-                "https://raw.githubusercontent.com/${REPO}/main/scripts/install-openshell-sandbox.sh" \
+                "https://raw.githubusercontent.com/${REPO}/${RELEASE_VERSION}/scripts/install-openshell-sandbox.sh" \
                 | bash
         fi
     fi


### PR DESCRIPTION
## Summary
- make the sandbox installer fallback use the selected DefenseClaw release
- avoid mixing a pinned installer with sandbox setup code from the moving branch
- add a static regression test for the fallback URL

## Validation
- bash -n scripts/install.sh
- uv run --python 3.12 pytest cli/tests/test_install_script_static.py -q
- uv run --python 3.12 ruff check cli/tests/test_install_script_static.py
- git diff --check HEAD~1..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The sandbox installer now fetches its fallback script from the matching release version instead of the latest main branch, improving consistency and reliability.
* **Tests**
  * Added coverage to verify the installer uses the release-pinned download path and no longer relies on the main-branch URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->