### PR TITLE
fix(dev): sync OpenClaw embed before dev build

### DIFF
--- a/cli/tests/test_install_dev_static.py
+++ b/cli/tests/test_install_dev_static.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+INSTALL_DEV = ROOT / "scripts" / "install-dev.sh"
+
+
+def test_dev_install_syncs_openclaw_embed_before_go_build() -> None:
+    text = INSTALL_DEV.read_text()
+    sync = 'make -C "${REPO_ROOT}" sync-openclaw-extension'
+    build = 'GOOS="${OS}" GOARCH="${ARCH_NORMALIZED}" go build'
+    assert sync in text
+    assert build in text
+    assert text.index(sync) < text.index(build)

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -406,6 +406,9 @@ build_go_gateway() {
     log_step "Building Go Gateway Binary"
     
     cd "${REPO_ROOT}"
+
+    log_info "Preparing OpenClaw extension embed..."
+    make -C "${REPO_ROOT}" sync-openclaw-extension
     
     # Fetch dependencies
     log_info "Fetching Go dependencies..."


### PR DESCRIPTION
## Summary
- run the OpenClaw embed sync before the dev installer builds the gateway
- keep fresh clones from hitting a missing embedded extension directory
- add a static regression test for the build order

## Validation
- bash -n scripts/install-dev.sh
- uv run --python 3.12 pytest cli/tests/test_install_dev_static.py -q
- uv run --python 3.12 ruff check cli/tests/test_install_dev_static.py
- git diff --check HEAD~1..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the development install flow to sync the OpenClaw extension before building the Go gateway.
  * This helps ensure the gateway is built with the latest embedded extension content.

* **Tests**
  * Added coverage to verify the install script includes the sync step and runs it before the build command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->