### PR TITLE
docs: pin quickstart installer examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ make all
 ### Install with the release script
 
 ```bash
-curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash
+VERSION=0.8.2
+INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
+curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash
 defenseclaw init --enable-guardrail
 ```
 

--- a/cli/tests/test_install_docs_static.py
+++ b/cli/tests/test_install_docs_static.py
@@ -1,0 +1,23 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_quickstart_docs_do_not_pipe_main_installer() -> None:
+    for rel in ("README.md", "docs/QUICKSTART.md"):
+        text = (ROOT / rel).read_text()
+        assert "raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh" not in text
+        assert "VERSION=" in text
+        assert 'VERSION="$VERSION" bash' in text

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -23,7 +23,9 @@ for full details.
 ### Install DefenseClaw
 
 ```bash
-curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash
+VERSION=0.8.2
+INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
+curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash
 defenseclaw init --enable-guardrail
 ```
 


### PR DESCRIPTION
## Summary
- update README and Quickstart install examples to fetch installer code from a release tag
- pass the same version into the installer process
- add a static regression test for the copied quickstart examples

## Validation
- uv run --python 3.12 pytest cli/tests/test_install_docs_static.py -q
- uv run --python 3.12 ruff check cli/tests/test_install_docs_static.py
- git diff --check HEAD~1..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions in the README and Quick Start guide to use a version-pinned install script instead of the latest branch copy.
  * The commands now reference a specific release version and pass that version through during installation.

* **Tests**
  * Added coverage to ensure setup docs do not point to the latest branch installer.
  * Verified the docs include a version variable and the expected install command format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->