### PR TITLE
docs: pin install examples across docs site

### DIFF
--- a/cli/tests/test_envvars.py
+++ b/cli/tests/test_envvars.py
@@ -9,6 +9,7 @@ truthy-value semantics).
 
 from __future__ import annotations
 
+import json
 import os
 import unittest
 from pathlib import Path

--- a/cli/tests/test_install_docs_static.py
+++ b/cli/tests/test_install_docs_static.py
@@ -13,11 +13,57 @@ from __future__ import annotations
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
+CURRENT_RELEASE = "0.8.2"
+STALE_RELEASES = ("0.8.0", "0.8.1")
+
+BASH_INSTALL_LINES = (
+    f"VERSION={CURRENT_RELEASE}",
+    'INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"',
+    'curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash',
+)
+
+DOC_INSTALL_COMMANDS = {
+    "README.md": BASH_INSTALL_LINES,
+    "docs/QUICKSTART.md": BASH_INSTALL_LINES,
+    "docs/INSTALL.md": BASH_INSTALL_LINES
+    + (
+        'curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash -s -- --connector codex',
+        'curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash -s -- --connector claudecode',
+        'curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash -s -- --connector zeptoclaw',
+        'curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash -s -- --connector none',
+        'curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash -s -- --no-openclaw',
+    ),
+    "docs-site/content/docs/get-started/install.mdx": BASH_INSTALL_LINES
+    + (
+        f'$Version = "{CURRENT_RELEASE}"',
+        '$InstallUrl = "https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/$Version/scripts/install.ps1"',
+        "& ([scriptblock]::Create((irm $InstallUrl))) -Version $Version",
+        "& ([scriptblock]::Create((irm $InstallUrl))) -Version $Version -Connector codex -Quickstart -Yes",
+    ),
+    "docs-site/content/docs/get-started/first-guardrail.mdx": (
+        f"VERSION={CURRENT_RELEASE}",
+        'INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"',
+        'curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash -s -- --connector claudecode',
+    ),
+    "docs-site/components/terminal-demo.tsx": (
+        f"const INSTALL_VERSION = '{CURRENT_RELEASE}';",
+        "text: `curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${INSTALL_VERSION}/scripts/install.sh | VERSION=${INSTALL_VERSION} bash`,",
+    ),
+}
 
 
 def test_quickstart_docs_do_not_pipe_main_installer() -> None:
-    for rel in ("README.md", "docs/QUICKSTART.md"):
+    for rel, expected_lines in DOC_INSTALL_COMMANDS.items():
         text = (ROOT / rel).read_text()
         assert "raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh" not in text
-        assert "VERSION=" in text
-        assert 'VERSION="$VERSION" bash' in text
+        assert "raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.ps1" not in text
+        for expected in expected_lines:
+            assert expected in text, f"{rel} is missing install snippet line: {expected}"
+
+
+def test_install_docs_track_current_release() -> None:
+    for rel, expected_lines in DOC_INSTALL_COMMANDS.items():
+        snippet = "\n".join(expected_lines)
+        assert CURRENT_RELEASE in snippet, f"{rel} must pin at least one installer version"
+        for stale in STALE_RELEASES:
+            assert stale not in snippet, f"{rel} still expects stale install snippet version {stale}"

--- a/docs-site/components/terminal-demo.tsx
+++ b/docs-site/components/terminal-demo.tsx
@@ -28,13 +28,15 @@ interface ScriptLine {
   text: string;
 }
 
+const INSTALL_VERSION = '0.8.2';
+
 // Static header — typed once on initial mount and never replayed.
 // `defenseclaw-gateway` is the canonical companion install line and
 // every connector setup runs after it.
 const HEADER: ScriptLine[] = [
   {
     kind: 'cmd',
-    text: 'curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash',
+    text: `curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${INSTALL_VERSION}/scripts/install.sh | VERSION=${INSTALL_VERSION} bash`,
   },
   { kind: 'ok', text: '✓ Installed defenseclaw + defenseclaw-gateway' },
 ];

--- a/docs-site/content/docs/get-started/first-guardrail.mdx
+++ b/docs-site/content/docs/get-started/first-guardrail.mdx
@@ -17,7 +17,9 @@ This walkthrough ends with DefenseClaw refusing to let Claude Code run `rm -rf ~
 ### Install
 
 ```bash
-curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash -s -- --connector claudecode
+VERSION=0.8.2
+INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
+curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash -s -- --connector claudecode
 ```
 
 </Step>

--- a/docs-site/content/docs/get-started/install.mdx
+++ b/docs-site/content/docs/get-started/install.mdx
@@ -44,7 +44,9 @@ The base install ships everything DefenseClaw needs to talk to the major LLM bac
 <Tab value="macOS/Linux curl">
 
 ```bash
-curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash
+VERSION=0.8.2
+INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
+curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash
 defenseclaw init
 ```
 
@@ -61,7 +63,9 @@ defenseclaw quickstart --connector codex
 <Tab value="Windows PowerShell">
 
 ```powershell
-irm https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.ps1 | iex
+$Version = "0.8.2"
+$InstallUrl = "https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/$Version/scripts/install.ps1"
+& ([scriptblock]::Create((irm $InstallUrl))) -Version $Version
 defenseclaw init
 ```
 
@@ -70,7 +74,9 @@ The PowerShell installer downloads the Windows release ZIP for your architecture
 For non-interactive demos or CI, download the script and pass flags directly:
 
 ```powershell
-.\install.ps1 -Connector codex -Quickstart -Yes
+$Version = "0.8.2"
+$InstallUrl = "https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/$Version/scripts/install.ps1"
+& ([scriptblock]::Create((irm $InstallUrl))) -Version $Version -Connector codex -Quickstart -Yes
 ```
 
 </Tab>

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -319,7 +319,7 @@ make clean        # Full clean (binaries, venv, node_modules, coverage)
 End users can install a released version without cloning the repo:
 
 ```bash
-VERSION=0.8.1
+VERSION=0.8.2
 INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
 curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash
 ```
@@ -332,7 +332,7 @@ confirmations.
 Pin a specific version:
 
 ```bash
-VERSION=0.8.0
+VERSION=0.8.2
 INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
 curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash
 ```
@@ -344,7 +344,7 @@ OpenClaw runtime and the DefenseClaw plugin). You can pick a different
 connector — or skip connector setup entirely — with `--connector`:
 
 ```bash
-VERSION=0.8.1
+VERSION=0.8.2
 INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
 
 # Codex (no OpenClaw, no plugin tarball; patches ~/.codex/config.toml + hooks)


### PR DESCRIPTION
## Summary
- pin the docs-site install examples to the current 0.8.2 release installers
- extend the static docs guard across README, install docs, docs-site pages, and the terminal demo snippet
- make the PowerShell quickstart example self-contained and restore the envvar registry test import needed by full CI

## Validation
- `make _bundle-data && uv run pytest cli/tests/test_envvars.py::RegistryStructureTests::test_bundled_registry_matches_source_registry cli/tests/test_install_docs_static.py -q`
- `uv run ruff check cli/tests/test_envvars.py cli/tests/test_install_docs_static.py`
- `npm run build` in `docs-site`
- `git diff --check`
