### PR TITLE
[codex] Fix envvars registry test import

### DIFF
--- a/cli/tests/test_envvars.py
+++ b/cli/tests/test_envvars.py
@@ -9,6 +9,7 @@ truthy-value semantics).
 
 from __future__ import annotations
 
+import json
 import os
 import unittest
 from pathlib import Path


### PR DESCRIPTION
## Problem

PR #397 added `RegistryStructureTests.test_bundled_registry_matches_source_registry`, but the test calls `json.loads(...)` without importing the standard-library `json` module. The merged default-branch head failed `Python Lint & Test` and `make test (unified)` because of that missing import.

Closes #407.

## Current Situation

The registry bundle behavior itself is intact, but the default branch cannot complete the env-var registry parity test after bundle data has been generated. The failing CI run was `28347239971` on merge commit `b6d854e47f6224e1ce101777f2251df83bb45b61`.

## Solution

Import `json` in `cli/tests/test_envvars.py` so the newly added parity assertion can parse the bundled and source registry files.

## Architecture Diagram

N/A

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `cli/tests/test_envvars.py` | Adds the missing `json` import used by `test_bundled_registry_matches_source_registry`. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

- `uv run --python 3.12 pytest cli/tests/test_envvars.py::RegistryStructureTests::test_bundled_registry_matches_source_registry -q`
  - Before fix: failed with `NameError: name 'json' is not defined`.
- `make _bundle-data && uv run --python 3.12 pytest cli/tests/test_envvars.py::RegistryStructureTests::test_bundled_registry_matches_source_registry -q`
  - After fix: `1 passed in 0.12s`.
- `uv run --python 3.12 ruff check cli/tests/test_envvars.py`
  - `All checks passed!`
- `uv run --python 3.12 pytest cli/tests/test_envvars.py -q`
  - `29 passed in 0.16s`.
- `git diff --check`
  - Passed with no output.
