### PR TITLE
macOS installer + tests for managed_enterprise hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ endif
 .PHONY: all path doctor uninstall quickstart llm-setup \
         build install cli-install dev-install pycli dev-pycli gateway gateway-cross gateway-run start gateway-install \
         plugin plugin-install maybe-openclaw-plugin-install extensions test cli-test cli-test-cov cli-test-snap tui-test gateway-test go-test-cov \
+        packaging-macos-test \
         security-suite-test security-suite-eval \
         connector-matrix-test go-connector-matrix-test py-connector-matrix-test \
         test-verbose test-file lint py-lint go-lint ts-test rego-test clean \
@@ -493,6 +494,12 @@ cli-test-snap:
 
 gateway-test: sync-openclaw-extension
 	go test -race ./internal/gateway/ ./test/... -v
+
+# packaging-macos-test runs the pure-bash unit tests for the macOS installer
+# scripts under packaging/macos/. They don't touch /Library, sudo, or
+# launchctl and are safe to run on any macOS or Linux dev host.
+packaging-macos-test:
+	packaging/macos/tests/run_tests.sh
 
 # security-suite-test runs the deterministic security + PII coverage suite
 # (regex layer + stubbed LLM-judge layer) plus the regex severity benchmark.

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 .PHONY: all path doctor uninstall quickstart llm-setup \
         build install cli-install dev-install pycli dev-pycli gateway gateway-cross gateway-run start gateway-install \
         plugin plugin-install maybe-openclaw-plugin-install extensions test cli-test cli-test-cov cli-test-snap tui-test gateway-test go-test-cov \
-        packaging-macos-test \
+        packaging-macos-test packaging-macos-bundle \
         security-suite-test security-suite-eval \
         connector-matrix-test go-connector-matrix-test py-connector-matrix-test \
         test-verbose test-file lint py-lint go-lint ts-test rego-test clean \
@@ -500,6 +500,64 @@ gateway-test: sync-openclaw-extension
 # launchctl and are safe to run on any macOS or Linux dev host.
 packaging-macos-test:
 	packaging/macos/tests/run_tests.sh
+
+# packaging-macos-bundle assembles a shippable folder + tarball containing
+# the prebuilt gateway binary alongside the install / uninstall scripts.
+# The bundle is fully self-contained — no repo tree required at install
+# time. Layout:
+#
+#   defenseclaw-macos-$(VERSION)-$(GOOS)-$(GOARCH)/
+#     defenseclaw-gateway              (binary)
+#     install.sh                       (calls the binary next to it)
+#     uninstall.sh
+#     com.defenseclaw.gateway.plist    (installed to /Library/LaunchDaemons)
+#     lib/installer_lib.sh
+#     lib/scrub_agent_configs.py
+#     README.md                        (short usage)
+#
+# Ships as dist/defenseclaw-macos-$(VERSION)-$(GOOS)-$(GOARCH).tar.gz.
+#
+# Overrides: GOOS/GOARCH cross-compile the gateway.
+BUNDLE_GOOS  ?= darwin
+BUNDLE_GOARCH ?= $(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+BUNDLE_NAME  := defenseclaw-macos-$(VERSION)-$(BUNDLE_GOOS)-$(BUNDLE_GOARCH)
+BUNDLE_DIR   := $(DIST_DIR)/$(BUNDLE_NAME)
+
+packaging-macos-bundle:
+	@[ "$(BUNDLE_GOOS)" = "darwin" ] || { \
+	  echo "packaging-macos-bundle: BUNDLE_GOOS must be 'darwin' (got '$(BUNDLE_GOOS)')" >&2; exit 1; }
+	@[ "$(BUNDLE_GOARCH)" = "amd64" ] || [ "$(BUNDLE_GOARCH)" = "arm64" ] || { \
+	  echo "packaging-macos-bundle: BUNDLE_GOARCH must be amd64 or arm64 (got '$(BUNDLE_GOARCH)')" >&2; exit 1; }
+	@echo "==> packaging macOS bundle: $(BUNDLE_NAME)"
+	@rm -rf "$(BUNDLE_DIR)"
+	@mkdir -p "$(BUNDLE_DIR)/lib"
+	@echo "==> building gateway ($(BUNDLE_GOOS)/$(BUNDLE_GOARCH))"
+	@GOOS=$(BUNDLE_GOOS) GOARCH=$(BUNDLE_GOARCH) CGO_ENABLED=1 \
+	    go build $(GOFLAGS) -o "$(BUNDLE_DIR)/defenseclaw-gateway" ./cmd/defenseclaw
+	@chmod 0755 "$(BUNDLE_DIR)/defenseclaw-gateway"
+	@echo "==> copying installer scripts"
+	@cp packaging/macos/install.sh    "$(BUNDLE_DIR)/install.sh"
+	@cp packaging/macos/uninstall.sh  "$(BUNDLE_DIR)/uninstall.sh"
+	@cp packaging/macos/lib/installer_lib.sh          "$(BUNDLE_DIR)/lib/installer_lib.sh"
+	@cp packaging/macos/lib/scrub_agent_configs.py    "$(BUNDLE_DIR)/lib/scrub_agent_configs.py"
+	@cp packaging/launchd/com.defenseclaw.gateway.plist "$(BUNDLE_DIR)/com.defenseclaw.gateway.plist"
+	@chmod 0755 "$(BUNDLE_DIR)/install.sh" "$(BUNDLE_DIR)/uninstall.sh"
+	@chmod 0755 "$(BUNDLE_DIR)/lib/installer_lib.sh" "$(BUNDLE_DIR)/lib/scrub_agent_configs.py"
+	@chmod 0644 "$(BUNDLE_DIR)/com.defenseclaw.gateway.plist"
+	@echo "==> writing README"
+	@scripts/write-macos-bundle-readme.sh \
+	    "$(BUNDLE_DIR)/README.md" \
+	    "$(VERSION)" \
+	    "$(BUNDLE_GOOS)" \
+	    "$(BUNDLE_GOARCH)"
+	@echo "==> creating tarball"
+	@( cd $(DIST_DIR) && tar -czf $(BUNDLE_NAME).tar.gz $(BUNDLE_NAME) )
+	@( cd $(DIST_DIR) && shasum -a 256 $(BUNDLE_NAME).tar.gz > $(BUNDLE_NAME).tar.gz.sha256 )
+	@echo ""
+	@echo "==> bundle ready:"
+	@echo "    $(BUNDLE_DIR)/"
+	@echo "    $(DIST_DIR)/$(BUNDLE_NAME).tar.gz"
+	@echo "    $(DIST_DIR)/$(BUNDLE_NAME).tar.gz.sha256"
 
 # security-suite-test runs the deterministic security + PII coverage suite
 # (regex layer + stubbed LLM-judge layer) plus the regex severity benchmark.

--- a/internal/gateway/connector/hook_only_profile.go
+++ b/internal/gateway/connector/hook_only_profile.go
@@ -85,6 +85,13 @@ func hookOnlyProfileRespond(in HookRespondInput) HookRespondOutput {
 			if in.AdditionalContext != "" {
 				output = map[string]interface{}{"continue": true, "permission": "allow", "agent_message": in.AdditionalContext}
 			}
+		default:
+			// Cursor's hook script is fail-closed: an empty stdout is
+			// treated as a hook failure and blocks the tool call. Every
+			// benign prompt hits this path when action=allow with no
+			// additional context, so we must always emit an explicit
+			// allow envelope for cursor.
+			output = map[string]interface{}{"continue": true, "permission": "allow"}
 		}
 	case "windsurf":
 		if in.Action == "block" {

--- a/internal/gateway/connector/hook_profile_dispatch_test.go
+++ b/internal/gateway/connector/hook_profile_dispatch_test.go
@@ -577,6 +577,108 @@ func TestHermesProfileRespond_Parity(t *testing.T) {
 	}
 }
 
+// TestCursorProfileRespond_AlwaysEmitsEnvelope pins the cursor branch
+// of hookOnlyProfileRespond. Cursor's hook script is fail-closed on
+// empty stdout — a hook that returns nothing gets treated as a hook
+// failure and blocks the tool call. That means every code path in the
+// cursor case must produce a non-nil Output map, including the plain
+// allow case where earlier versions left it nil and every benign
+// prompt in Cursor would fail-close.
+func TestCursorProfileRespond_AlwaysEmitsEnvelope(t *testing.T) {
+	cases := []struct {
+		name       string
+		action     string
+		rawAction  string
+		reason     string
+		additional string
+		expected   map[string]interface{}
+	}{
+		{
+			name:      "block_renders_deny_permission",
+			action:    "block",
+			rawAction: "block",
+			reason:    "matched SEC-AWS-KEY",
+			expected: map[string]interface{}{
+				"continue":      true,
+				"permission":    "deny",
+				"user_message":  "matched SEC-AWS-KEY",
+				"agent_message": "matched SEC-AWS-KEY",
+			},
+		},
+		{
+			name:      "confirm_renders_ask_permission",
+			action:    "confirm",
+			rawAction: "confirm",
+			reason:    "shell command needs approval",
+			expected: map[string]interface{}{
+				"continue":      true,
+				"permission":    "ask",
+				"user_message":  "shell command needs approval",
+				"agent_message": "shell command needs approval",
+			},
+		},
+		{
+			name:       "alert_with_context_renders_allow_with_agent_message",
+			action:     "alert",
+			rawAction:  "alert",
+			additional: "DefenseClaw observed a HIGH cursor finding",
+			expected: map[string]interface{}{
+				"continue":      true,
+				"permission":    "allow",
+				"agent_message": "DefenseClaw observed a HIGH cursor finding",
+			},
+		},
+		{
+			// Regression: plain allow used to leave Output nil, which
+			// produced an empty stdout in the hook script and tripped
+			// Cursor's failClosed=true guard. Must be a concrete allow.
+			name:      "allow_renders_explicit_allow_envelope",
+			action:    "allow",
+			rawAction: "allow",
+			expected: map[string]interface{}{
+				"continue":   true,
+				"permission": "allow",
+			},
+		},
+		{
+			name:      "empty_action_treated_as_allow",
+			action:    "",
+			rawAction: "",
+			expected: map[string]interface{}{
+				"continue":   true,
+				"permission": "allow",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := hookOnlyProfileRespond(HookRespondInput{
+				Req: HookProfileRequest{
+					ConnectorName: "cursor",
+					HookEventName: "beforeSubmitPrompt",
+				},
+				Action:            tc.action,
+				RawAction:         tc.rawAction,
+				Reason:            tc.reason,
+				AdditionalContext: tc.additional,
+				Caps: HookCapability{
+					CanBlock:     true,
+					CanAskNative: true,
+				},
+			})
+			if out.FieldName != "hook_output" {
+				t.Errorf("FieldName=%q want hook_output", out.FieldName)
+			}
+			if out.Output == nil {
+				t.Fatalf("cursor Respond must never return nil Output — Cursor fail-closes on empty stdout")
+			}
+			if !reflect.DeepEqual(out.Output, tc.expected) {
+				t.Errorf("Output mismatch\n got: %#v\nwant: %#v", out.Output, tc.expected)
+			}
+		})
+	}
+}
+
 // TestHermesProfileRespond_BlockDefaultReason asserts a hermes block
 // with an empty upstream reason still produces an actionable default
 // reason (rather than an empty string) on the wire.

--- a/packaging/launchd/com.defenseclaw.gateway.plist
+++ b/packaging/launchd/com.defenseclaw.gateway.plist
@@ -13,17 +13,17 @@
   <key>GroupName</key>
   <string>_defenseclaw</string>
   <key>WorkingDirectory</key>
-  <string>/Library/Application Support/DefenseClaw</string>
+  <string>/Library/Application Support/DefenseClaw/runtime</string>
   <key>EnvironmentVariables</key>
   <dict>
     <key>DEFENSECLAW_HOME</key>
-    <string>/Library/Application Support/DefenseClaw</string>
+    <string>/Library/Application Support/DefenseClaw/runtime</string>
     <key>DEFENSECLAW_CONFIG</key>
     <string>/Library/Application Support/DefenseClaw/config.yaml</string>
     <key>DEFENSECLAW_DEPLOYMENT_MODE</key>
     <string>managed_enterprise</string>
     <key>DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR</key>
-    <string>/Library/Application Support/DefenseClaw/hook-guardian-state</string>
+    <string>/Library/Application Support/DefenseClaw/runtime/hook-guardian-state</string>
   </dict>
   <key>RunAtLoad</key>
   <true/>

--- a/packaging/launchd/com.defenseclaw.gateway.plist
+++ b/packaging/launchd/com.defenseclaw.gateway.plist
@@ -9,9 +9,9 @@
     <string>/Library/DefenseClaw/bin/defenseclaw-gateway</string>
   </array>
   <key>UserName</key>
-  <string>_defenseclaw</string>
+  <string>defenseclaw</string>
   <key>GroupName</key>
-  <string>_defenseclaw</string>
+  <string>defenseclaw</string>
   <key>WorkingDirectory</key>
   <string>/Library/Application Support/DefenseClaw/runtime</string>
   <key>EnvironmentVariables</key>

--- a/packaging/launchd/com.defenseclaw.gateway.plist
+++ b/packaging/launchd/com.defenseclaw.gateway.plist
@@ -23,7 +23,7 @@
     <key>DEFENSECLAW_DEPLOYMENT_MODE</key>
     <string>managed_enterprise</string>
     <key>DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR</key>
-    <string>/Library/Application Support/DefenseClaw/runtime/hook-guardian-state</string>
+    <string>/Library/Application Support/DefenseClaw/runtime-hook-guardian</string>
   </dict>
   <key>RunAtLoad</key>
   <true/>

--- a/packaging/launchd/com.defenseclaw.gateway.plist
+++ b/packaging/launchd/com.defenseclaw.gateway.plist
@@ -9,9 +9,9 @@
     <string>/Library/DefenseClaw/bin/defenseclaw-gateway</string>
   </array>
   <key>UserName</key>
-  <string>defenseclaw</string>
+  <string>_defenseclaw</string>
   <key>GroupName</key>
-  <string>defenseclaw</string>
+  <string>_defenseclaw</string>
   <key>WorkingDirectory</key>
   <string>/Library/Application Support/DefenseClaw</string>
   <key>EnvironmentVariables</key>

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -80,13 +80,20 @@ die()  { printf '[install] ERROR: %s\n' "$*" >&2; exit 1; }
 # faster than issuing 100 -search calls. On a laptop with a network
 # directory attached, the per-candidate probe form could take 30s+.
 find_free_system_uid() {
-  local in_use
+  local in_use_uids in_use_gids in_use
   # Query /Local/Default explicitly — using `.` (the meta-node) makes
   # dscl walk every attached directory (AD/LDAP/OD), which can hang or
   # return ENETUNREACH on a Mac bound to an unreachable domain. Service
   # users only ever live in /Local/Default, so this is both faster and
   # safer.
-  in_use="$(dscl /Local/Default -list /Users UniqueID 2>/dev/null | awk '{print $2}')"
+  #
+  # Check BOTH /Users UIDs and /Groups GIDs — since our service user
+  # uses the same numeric ID for both, we can't pick a value that's
+  # taken by either. Missing this check produced a live install failure
+  # where UID 400 was free but GID 400 was taken by an unrelated group.
+  in_use_uids="$(dscl /Local/Default -list /Users  UniqueID       2>/dev/null | awk '{print $2}')"
+  in_use_gids="$(dscl /Local/Default -list /Groups PrimaryGroupID 2>/dev/null | awk '{print $2}')"
+  in_use="$(printf '%s\n%s\n' "${in_use_uids}" "${in_use_gids}" | sort -u)"
   local candidate
   for candidate in $(seq 400 499); do
     if ! printf '%s\n' "${in_use}" | grep -qxF "${candidate}"; then

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -109,6 +109,10 @@ case "${MODE}" in
   *) die "--mode must be 'observe' or 'action' (got: ${MODE})";;
 esac
 
+if [[ ! "${API_PORT}" =~ ^[0-9]+$ ]] || (( API_PORT < 1 || API_PORT > 65535 )); then
+  die "--port must be an integer between 1 and 65535 (got: ${API_PORT})"
+fi
+
 CONNECTOR_LINES="$(parse_connectors "${CONNECTOR}")" || \
   die "--connector has an empty entry (check the comma list)"
 CONNECTORS=()
@@ -199,14 +203,23 @@ log "loading LaunchDaemon"
 launchctl bootstrap system "${PLIST_DST}"
 launchctl enable "system/${LAUNCHD_LABEL}"
 
+wait_for_launchd_running() {
+  local deadline=$(( $(date +%s) + 15 ))
+  while (( $(date +%s) < deadline )); do
+    if launchctl print "system/${LAUNCHD_LABEL}" 2>/dev/null | grep -qE '^[[:space:]]+state = running'; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
 log "waiting for gateway to come up"
-SETTLE_DEADLINE=$(( $(date +%s) + 15 ))
-while (( $(date +%s) < SETTLE_DEADLINE )); do
-  if launchctl print "system/${LAUNCHD_LABEL}" 2>/dev/null | grep -qE '^[[:space:]]+state = running'; then
-    break
-  fi
-  sleep 1
-done
+if ! wait_for_launchd_running; then
+  warn "gateway did not reach running state within 15s; recent stderr:"
+  tail -20 "${LOGS_DIR}/gateway.err.log" 2>/dev/null | sed 's/^/    /' >&2 || true
+  die "${LAUNCHD_LABEL} failed to start; see ${LOGS_DIR}/gateway.err.log"
+fi
 
 # ---- per-user hook wiring ----------------------------------------------
 
@@ -261,7 +274,9 @@ if [[ "${SKIP_CONNECTOR}" != "true" ]]; then
       *)          DC_AGENT_DIR="";;
     esac
     if [[ -n "${DC_AGENT_DIR}" && -d "${DC_AGENT_DIR}" && ! -L "${DC_AGENT_DIR}" ]]; then
-      find "${DC_AGENT_DIR}" -exec chown -h "${TARGET_UID}:${TARGET_GID}" {} + 2>/dev/null || true
+      if ! find "${DC_AGENT_DIR}" -exec chown -h "${TARGET_UID}:${TARGET_GID}" {} +; then
+        die "[${c}] failed to set ownership on ${DC_AGENT_DIR}"
+      fi
     fi
 
     AGENT_VER="${AGENT_VERSION}"
@@ -290,13 +305,11 @@ if [[ "${SKIP_CONNECTOR}" != "true" ]]; then
   log "  resuming LaunchDaemon"
   launchctl bootstrap system "${PLIST_DST}"
   launchctl enable "system/${LAUNCHD_LABEL}"
-  SETTLE_DEADLINE=$(( $(date +%s) + 15 ))
-  while (( $(date +%s) < SETTLE_DEADLINE )); do
-    if launchctl print "system/${LAUNCHD_LABEL}" 2>/dev/null | grep -qE '^[[:space:]]+state = running'; then
-      break
-    fi
-    sleep 1
-  done
+  if ! wait_for_launchd_running; then
+    warn "gateway did not resume within 15s; recent stderr:"
+    tail -20 "${LOGS_DIR}/gateway.err.log" 2>/dev/null | sed 's/^/    /' >&2 || true
+    die "${LAUNCHD_LABEL} failed to resume after per-user wiring"
+  fi
 fi
 
 # ---- summary ------------------------------------------------------------

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -259,32 +259,31 @@ ensure_service_user() {
   fi
 
   if [[ "${needs_reset}" == "yes" ]]; then
-    # We're in the corrupt state DIAGNOSED on live install:
-    # /var/db/dslocal/nodes/Default/groups/_defenseclaw.plist exists
-    # on disk but its record is missing PrimaryGroupID. Every dscl
-    # write path (create/change/append) then fights that ghost record,
-    # and dscl -delete "succeeds" without actually removing the plist.
+    # Recovering the corrupt "record exists but attribute is missing"
+    # state. dscl can't fix what dscl (or a killed install) created,
+    # and /var/db/dslocal/nodes/Default is SIP-protected on modern
+    # macOS so `rm` returns "Operation not permitted" even as root.
     #
-    # The only reliable recovery is to rm the on-disk plist file
-    # directly and force opendirectoryd to reload. dscl is the wrong
-    # tool here — we're fixing the state that dscl itself created.
-    for plist in \
-      "/var/db/dslocal/nodes/Default/users/${name}.plist" \
-      "/var/db/dslocal/nodes/Default/groups/${name}.plist"; do
-      if [[ -f "${plist}" ]]; then
-        log "  removing on-disk ghost plist: ${plist}"
-        rm -f "${plist}" || die "failed to remove ${plist} (should be running as root)"
-      fi
-    done
+    # The tools that CAN modify SIP-protected local directory records
+    # are the ones that route through opendirectoryd's authenticated
+    # API: dseditgroup for groups, sysadminctl for users. Both were
+    # verified in a live diagnostic:
+    #
+    #   sudo dseditgroup -o delete _defenseclaw  → exit 0, record gone
+    #   sudo sysadminctl -deleteUser _defenseclaw → deletes if present
+    if [[ "${group_shell_present}" == "yes" ]]; then
+      log "  resetting group ${name} via dseditgroup"
+      /usr/sbin/dseditgroup -o delete "${name}" >/dev/null 2>&1 || \
+        warn "  dseditgroup -o delete ${name} failed"
+    fi
+    if [[ "${user_shell_present}" == "yes" ]]; then
+      log "  resetting user ${name} via sysadminctl"
+      /usr/sbin/sysadminctl -deleteUser "${name}" >/dev/null 2>&1 || \
+        warn "  sysadminctl -deleteUser ${name} failed"
+    fi
 
-    # Force opendirectoryd to reload from disk. Without this it will
-    # keep serving the cached ghost record.
-    /usr/bin/killall -HUP opendirectoryd 2>/dev/null || true
-    /usr/bin/dscacheutil -flushcache 2>/dev/null || true
-
-    # Wait for opendirectoryd to actually re-read. HUP is asynchronous;
-    # a subsequent dscl -read of the deleted record should return
-    # eDSRecordNotFound within a second.
+    # dseditgroup / sysadminctl already synchronize opendirectoryd, so
+    # no cache-flush dance needed. Just verify the reset actually took.
     local settle=0
     while (( settle < 5 )); do
       if ! dscl "${DS_NODE}" -read "/Users/${name}"  >/dev/null 2>&1 && \
@@ -299,12 +298,12 @@ ensure_service_user() {
     existing_gid=""
     existing_uid=""
 
-    # If the record STILL exists after the disk + cache reset, we're
-    # dealing with a network directory or something we can't fix
-    # from here. Bail with an actionable error.
+    # If the record STILL exists after that, it's coming from a
+    # network directory / MDM push that we can't manage locally.
+    # Bail with an actionable error.
     if dscl "${DS_NODE}" -read "/Users/${name}"  >/dev/null 2>&1 || \
        dscl "${DS_NODE}" -read "/Groups/${name}" >/dev/null 2>&1; then
-      die "cannot reset ${name} — record is not in /Local/Default and comes from a directory service we can't manage. Pass --service-user with a different name (e.g. --service-user _defenseclaw2)"
+      die "cannot reset ${name} — record survives dseditgroup/sysadminctl and is likely coming from a directory service (AD/LDAP/MDM). Pass --service-user with a different name (e.g. --service-user _defenseclaw2)"
     fi
   fi
 
@@ -327,14 +326,34 @@ ensure_service_user() {
   fi
 
   log "  ensuring group ${name} (gid=${uid})"
-  dscl_ensure_record "/Groups/${name}" \
-    || die "create group ${name} failed"
-  dscl_ensure_prop   "/Groups/${name}" PrimaryGroupID "${uid}" \
-    || die "set group ${name} gid failed"
-  dscl_ensure_prop   "/Groups/${name}" RealName "DefenseClaw Service Group" \
-    || warn "  set group ${name} RealName failed (non-fatal)"
+  # Use dseditgroup rather than dscl for group creation. On modern
+  # macOS (SIP enabled) dscl -create /Local/Default -create /Groups/X
+  # writes a plist under /var/db/dslocal — which is SIP-protected.
+  # dscl "succeeds" but the write can be partially dropped, leaving
+  # a phantom record with RecordName but no PrimaryGroupID. That's
+  # exactly the corruption pattern the reset block above cleans up.
+  #
+  # dseditgroup routes through opendirectoryd's authenticated API,
+  # which has entitlements to write SIP-protected records atomically
+  # and correctly.
+  if ! dscl "${DS_NODE}" -read "/Groups/${name}" >/dev/null 2>&1; then
+    /usr/sbin/dseditgroup -o create -i "${uid}" -r "DefenseClaw Service Group" "${name}" \
+      || die "dseditgroup -o create ${name} failed"
+  fi
+  # Verify the group ended up with the right GID (dseditgroup ignores
+  # -i if a group with the same name already exists in another node).
+  local actual_gid
+  actual_gid="$(dscl_read_prop "/Groups/${name}" PrimaryGroupID)"
+  if [[ "${actual_gid}" != "${uid}" ]]; then
+    die "group ${name} exists but PrimaryGroupID=${actual_gid:-<unset>} does not match target ${uid}"
+  fi
 
   log "  ensuring user ${name} (uid=${uid})"
+  # For users, sysadminctl is the SIP-safe primitive, but it requires
+  # a password argument and creates a full account. dscl still works
+  # for creating a hidden system user because Users/ plists in
+  # /var/db/dslocal are less restrictive than Groups/. We validate
+  # the write after each dscl call.
   dscl_ensure_record "/Users/${name}" \
     || die "create user ${name} failed"
   dscl_ensure_prop   "/Users/${name}" UserShell        /usr/bin/false

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -229,25 +229,70 @@ wait_for_id_resolves() {
 ensure_service_user() {
   local name="$1"
 
-  # Detect a corrupt half-state from a prior failed install: a record
-  # exists but its PrimaryGroupID / UniqueID is neither present nor
-  # settable (dscl -create says "already exists", -change says "not
-  # found", -append also says "already exists"). If we can even *read*
-  # the record shell but can't read the ID, delete the record and let
-  # us start clean.
+  # Detect a corrupt half-state from a prior failed install: dscl says
+  # the record exists (-create → eDSRecordAlreadyExists) but its
+  # PrimaryGroupID/UniqueID is neither readable (-read empty) nor
+  # settable (-change → eDSAttributeNotFound, -append → also
+  # eDSRecordAlreadyExists). This can happen when opendirectoryd's
+  # in-memory state got out of sync with the on-disk /var/db/dslocal
+  # plist during a prior interrupted install.
+  #
+  # Recovery: use sysadminctl -deleteUser / dscl -delete to hard-reset
+  # BOTH records, then flush opendirectoryd's cache so subsequent
+  # dscl -create calls see a clean slate.
   local existing_gid existing_uid
   existing_gid="$(dscl_read_prop "/Groups/${name}" PrimaryGroupID)"
   existing_uid="$(dscl_read_prop "/Users/${name}"  UniqueID)"
 
-  if [[ -z "${existing_gid}" ]] && dscl "${DS_NODE}" -read "/Groups/${name}" >/dev/null 2>&1; then
-    log "  group ${name} record present but PrimaryGroupID missing; hard-resetting"
-    dscl "${DS_NODE}" -delete "/Groups/${name}" 2>/dev/null || \
-      die "failed to reset corrupt group ${name}; run: sudo dscl /Local/Default -delete /Groups/${name}"
-  fi
-  if [[ -z "${existing_uid}" ]] && dscl "${DS_NODE}" -read "/Users/${name}" >/dev/null 2>&1; then
+  local user_shell_present group_shell_present
+  dscl "${DS_NODE}" -read "/Users/${name}"  >/dev/null 2>&1 && user_shell_present=yes  || user_shell_present=no
+  dscl "${DS_NODE}" -read "/Groups/${name}" >/dev/null 2>&1 && group_shell_present=yes || group_shell_present=no
+
+  local needs_reset=no
+  if [[ "${user_shell_present}" == "yes" && -z "${existing_uid}" ]]; then
     log "  user ${name} record present but UniqueID missing; hard-resetting"
-    dscl "${DS_NODE}" -delete "/Users/${name}" 2>/dev/null || \
-      die "failed to reset corrupt user ${name}; run: sudo dscl /Local/Default -delete /Users/${name}"
+    needs_reset=yes
+  fi
+  if [[ "${group_shell_present}" == "yes" && -z "${existing_gid}" ]]; then
+    log "  group ${name} record present but PrimaryGroupID missing; hard-resetting"
+    needs_reset=yes
+  fi
+
+  if [[ "${needs_reset}" == "yes" ]]; then
+    # sysadminctl is macOS's higher-level user API; it handles the
+    # cache/plist synchronization more reliably than raw dscl.
+    if [[ "${user_shell_present}" == "yes" ]]; then
+      /usr/sbin/sysadminctl -deleteUser "${name}" 2>/dev/null || \
+        dscl "${DS_NODE}" -delete "/Users/${name}" 2>/dev/null || true
+    fi
+    if [[ "${group_shell_present}" == "yes" ]]; then
+      # No sysadminctl equivalent for groups; use dscl directly.
+      dscl "${DS_NODE}" -delete "/Groups/${name}" 2>/dev/null || true
+    fi
+
+    # Flush opendirectoryd's cache so subsequent dscl calls don't see
+    # the phantom record we just deleted.
+    /usr/bin/dscacheutil -flushcache 2>/dev/null || true
+    /usr/bin/killall -HUP opendirectoryd 2>/dev/null || true
+    sleep 1
+
+    # Reset the state trackers so the fresh-provision path runs.
+    existing_gid=""
+    existing_uid=""
+
+    # If the record STILL exists after all that, the plist file
+    # itself is corrupt. Bail with an actionable message rather than
+    # loop forever.
+    if dscl "${DS_NODE}" -read "/Users/${name}"  >/dev/null 2>&1 || \
+       dscl "${DS_NODE}" -read "/Groups/${name}" >/dev/null 2>&1; then
+      die "cannot reset corrupt ${name} records — manually run:
+    sudo dscl /Local/Default -delete /Users/${name}
+    sudo dscl /Local/Default -delete /Groups/${name}
+    sudo rm -f /var/db/dslocal/nodes/Default/users/${name}.plist
+    sudo rm -f /var/db/dslocal/nodes/Default/groups/${name}.plist
+    sudo killall -HUP opendirectoryd
+    ...then re-run install.sh"
+    fi
   fi
 
   # Decide the id to use:

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -229,13 +229,26 @@ wait_for_id_resolves() {
 ensure_service_user() {
   local name="$1"
 
-  # Peek at the current state, but don't gate on it — OpenDirectory is
-  # eventually consistent so a read-then-create pattern can race. Every
-  # dscl call below uses dscl_ensure_* helpers that are safe under
-  # eDSRecordAlreadyExists.
+  # Detect a corrupt half-state from a prior failed install: a record
+  # exists but its PrimaryGroupID / UniqueID is neither present nor
+  # settable (dscl -create says "already exists", -change says "not
+  # found", -append also says "already exists"). If we can even *read*
+  # the record shell but can't read the ID, delete the record and let
+  # us start clean.
   local existing_gid existing_uid
   existing_gid="$(dscl_read_prop "/Groups/${name}" PrimaryGroupID)"
   existing_uid="$(dscl_read_prop "/Users/${name}"  UniqueID)"
+
+  if [[ -z "${existing_gid}" ]] && dscl "${DS_NODE}" -read "/Groups/${name}" >/dev/null 2>&1; then
+    log "  group ${name} record present but PrimaryGroupID missing; hard-resetting"
+    dscl "${DS_NODE}" -delete "/Groups/${name}" 2>/dev/null || \
+      die "failed to reset corrupt group ${name}; run: sudo dscl /Local/Default -delete /Groups/${name}"
+  fi
+  if [[ -z "${existing_uid}" ]] && dscl "${DS_NODE}" -read "/Users/${name}" >/dev/null 2>&1; then
+    log "  user ${name} record present but UniqueID missing; hard-resetting"
+    dscl "${DS_NODE}" -delete "/Users/${name}" 2>/dev/null || \
+      die "failed to reset corrupt user ${name}; run: sudo dscl /Local/Default -delete /Users/${name}"
+  fi
 
   # Decide the id to use:
   #   - reuse an existing UID/GID whenever we have one (avoids fighting

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -523,7 +523,15 @@ install -d -o root -g wheel -m 0755 "${INSTALL_PREFIX}/bin"
 install    -o root -g wheel -m 0755 "${BINARY_SRC}" "${GATEWAY_BIN}"
 
 log "creating support dirs"
+# SUPPORT_DIR is root:wheel 0750 — the config file at its root has to
+# be trust-checked, and the check walks every ancestor requiring
+# root ownership and no group/other write bits.
 install -d -o root -g wheel -m 0750 "${SUPPORT_DIR}"
+# RUNTIME_DIR lives INSIDE SUPPORT_DIR (matching what render_config
+# points data_dir at). It's chown'd to the service user after we
+# ensure the user exists — see below.
+RUNTIME_DIR="${SUPPORT_DIR}/runtime"
+install -d -o root -g wheel -m 0750 "${RUNTIME_DIR}"
 install -d -o root -g wheel -m 0750 "${LOGS_DIR}"
 
 CONFIG_PATH="${SUPPORT_DIR}/config.yaml"
@@ -542,18 +550,13 @@ log "ensuring service user ${SERVICE_USER}"
 ensure_service_user "${SERVICE_USER}"
 
 log "chowning runtime dirs to ${SERVICE_USER}:${SERVICE_GROUP} (uid=${SERVICE_UID} gid=${SERVICE_GID})"
-# Config stays root-owned (managed_enterprise trust check requires it),
-# but runtime state (audit DB, tokens, guardian state, logs) is owned
-# by the service user so the daemon can write to it. Use numeric IDs so
-# the chown doesn't depend on OpenDirectory cache warm-up — dscl -create
-# writes are async and getpwnam can be stale for several seconds.
+# Only RUNTIME_DIR + LOGS_DIR get service-user ownership. SUPPORT_DIR
+# itself and CONFIG_PATH stay root:wheel so the managed_enterprise
+# config trust check (which walks every ancestor of config.yaml)
+# accepts them.
 [[ -n "${SERVICE_UID}" && -n "${SERVICE_GID}" ]] \
   || die "service uid/gid unset after ensure_service_user (internal bug)"
-chown -R "${SERVICE_UID}:${SERVICE_GID}" "${SUPPORT_DIR}" "${LOGS_DIR}"
-# Re-tighten config ownership: the recursive chown above walked into
-# it, so put it back to root:wheel 0640.
-chown root:wheel "${CONFIG_PATH}"
-chmod 0640 "${CONFIG_PATH}"
+chown -R "${SERVICE_UID}:${SERVICE_GID}" "${RUNTIME_DIR}" "${LOGS_DIR}"
 
 log "installing LaunchDaemon plist -> ${PLIST_DST}"
 install -o root -g wheel -m 0644 "${PLIST_SRC}" "${PLIST_DST}"
@@ -638,20 +641,30 @@ if [[ "${SKIP_CONNECTOR}" != "true" ]]; then
       warn "  [${c}] refused to prepare userspace (symlinked or non-dir path); skipping"
       continue
     fi
-    # Match the ownership of any newly created files to the target user.
-    # -h so we chown the entry itself and never follow symlinks (defense
-    # in depth alongside ensure_safe_userspace_path in the lib helpers).
+    # Match ownership on JUST the files DefenseClaw just pre-created.
+    # A recursive chown over ~/.codex or ~/.cursor is wrong: those
+    # dirs may contain unrelated user state (Codex ships a signed
+    # `computer-use/*.app` bundle, Cursor stores signed extensions),
+    # and SIP-protected files in those trees will fail chown with
+    # "Operation not permitted" even as root.
+    #
+    # We only touch what prepare_userspace_for could have written:
+    # the connector's hook config file + its parent .<agent> dir.
     case "${c}" in
-      claudecode) DC_AGENT_DIR="${TARGET_HOME}/.claude";;
-      codex)      DC_AGENT_DIR="${TARGET_HOME}/.codex";;
-      cursor)     DC_AGENT_DIR="${TARGET_HOME}/.cursor";;
-      *)          DC_AGENT_DIR="";;
+      claudecode) DC_AGENT_TARGETS=( "${TARGET_HOME}/.claude" "${TARGET_HOME}/.claude/settings.json" );;
+      codex)      DC_AGENT_TARGETS=( "${TARGET_HOME}/.codex"  "${TARGET_HOME}/.codex/config.toml" );;
+      cursor)     DC_AGENT_TARGETS=( "${TARGET_HOME}/.cursor" "${TARGET_HOME}/.cursor/hooks.json" );;
+      *)          DC_AGENT_TARGETS=();;
     esac
-    if [[ -n "${DC_AGENT_DIR}" && -d "${DC_AGENT_DIR}" && ! -L "${DC_AGENT_DIR}" ]]; then
-      if ! find "${DC_AGENT_DIR}" -exec chown -h "${TARGET_UID}:${TARGET_GID}" {} +; then
-        die "[${c}] failed to set ownership on ${DC_AGENT_DIR}"
+    for path in "${DC_AGENT_TARGETS[@]}"; do
+      # Skip symlinks (guarded upstream by ensure_safe_userspace_path)
+      # and missing paths. Any real chown failure aborts the connector.
+      if [[ -e "${path}" && ! -L "${path}" ]]; then
+        if ! chown -h "${TARGET_UID}:${TARGET_GID}" "${path}"; then
+          die "[${c}] failed to set ownership on ${path}"
+        fi
       fi
-    fi
+    done
 
     AGENT_VER="${AGENT_VERSION}"
     if [[ -z "${AGENT_VER}" ]]; then

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -259,39 +259,52 @@ ensure_service_user() {
   fi
 
   if [[ "${needs_reset}" == "yes" ]]; then
-    # sysadminctl is macOS's higher-level user API; it handles the
-    # cache/plist synchronization more reliably than raw dscl.
-    if [[ "${user_shell_present}" == "yes" ]]; then
-      /usr/sbin/sysadminctl -deleteUser "${name}" 2>/dev/null || \
-        dscl "${DS_NODE}" -delete "/Users/${name}" 2>/dev/null || true
-    fi
-    if [[ "${group_shell_present}" == "yes" ]]; then
-      # No sysadminctl equivalent for groups; use dscl directly.
-      dscl "${DS_NODE}" -delete "/Groups/${name}" 2>/dev/null || true
-    fi
+    # We're in the corrupt state DIAGNOSED on live install:
+    # /var/db/dslocal/nodes/Default/groups/_defenseclaw.plist exists
+    # on disk but its record is missing PrimaryGroupID. Every dscl
+    # write path (create/change/append) then fights that ghost record,
+    # and dscl -delete "succeeds" without actually removing the plist.
+    #
+    # The only reliable recovery is to rm the on-disk plist file
+    # directly and force opendirectoryd to reload. dscl is the wrong
+    # tool here — we're fixing the state that dscl itself created.
+    for plist in \
+      "/var/db/dslocal/nodes/Default/users/${name}.plist" \
+      "/var/db/dslocal/nodes/Default/groups/${name}.plist"; do
+      if [[ -f "${plist}" ]]; then
+        log "  removing on-disk ghost plist: ${plist}"
+        rm -f "${plist}" || die "failed to remove ${plist} (should be running as root)"
+      fi
+    done
 
-    # Flush opendirectoryd's cache so subsequent dscl calls don't see
-    # the phantom record we just deleted.
-    /usr/bin/dscacheutil -flushcache 2>/dev/null || true
+    # Force opendirectoryd to reload from disk. Without this it will
+    # keep serving the cached ghost record.
     /usr/bin/killall -HUP opendirectoryd 2>/dev/null || true
-    sleep 1
+    /usr/bin/dscacheutil -flushcache 2>/dev/null || true
+
+    # Wait for opendirectoryd to actually re-read. HUP is asynchronous;
+    # a subsequent dscl -read of the deleted record should return
+    # eDSRecordNotFound within a second.
+    local settle=0
+    while (( settle < 5 )); do
+      if ! dscl "${DS_NODE}" -read "/Users/${name}"  >/dev/null 2>&1 && \
+         ! dscl "${DS_NODE}" -read "/Groups/${name}" >/dev/null 2>&1; then
+        break
+      fi
+      sleep 1
+      settle=$((settle + 1))
+    done
 
     # Reset the state trackers so the fresh-provision path runs.
     existing_gid=""
     existing_uid=""
 
-    # If the record STILL exists after all that, the plist file
-    # itself is corrupt. Bail with an actionable message rather than
-    # loop forever.
+    # If the record STILL exists after the disk + cache reset, we're
+    # dealing with a network directory or something we can't fix
+    # from here. Bail with an actionable error.
     if dscl "${DS_NODE}" -read "/Users/${name}"  >/dev/null 2>&1 || \
        dscl "${DS_NODE}" -read "/Groups/${name}" >/dev/null 2>&1; then
-      die "cannot reset corrupt ${name} records — manually run:
-    sudo dscl /Local/Default -delete /Users/${name}
-    sudo dscl /Local/Default -delete /Groups/${name}
-    sudo rm -f /var/db/dslocal/nodes/Default/users/${name}.plist
-    sudo rm -f /var/db/dslocal/nodes/Default/groups/${name}.plist
-    sudo killall -HUP opendirectoryd
-    ...then re-run install.sh"
+      die "cannot reset ${name} — record is not in /Local/Default and comes from a directory service we can't manage. Pass --service-user with a different name (e.g. --service-user _defenseclaw2)"
     fi
   fi
 

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -109,11 +109,18 @@ DS_NODE="/Local/Default"
 # dscl_read_prop RECORD PROP — echoes the value of a single dscl property
 # or empty when the record/property doesn't exist. Handles the "AttrName:
 # value" one-liner shape dscl -read returns.
+#
+# NOTE: we swallow non-zero from `dscl -read` (record-not-found returns
+# rc=1) so this helper is safe to use inside command substitutions under
+# `set -o pipefail`. Callers check the returned value for emptiness.
 dscl_read_prop() {
   local record="$1"
   local prop="$2"
-  dscl "${DS_NODE}" -read "${record}" "${prop}" 2>/dev/null \
+  local raw
+  raw="$(dscl "${DS_NODE}" -read "${record}" "${prop}" 2>/dev/null || true)"
+  printf '%s\n' "${raw}" \
     | awk -v p="${prop}:" 'index($0, p) == 1 { $1=""; sub(/^ /, ""); print; exit }'
+  return 0
 }
 
 # dscl_ensure_record RECORD — creates a dscl record idempotently.

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -60,8 +60,8 @@ GATEWAY_BIN="${INSTALL_PREFIX}/bin/defenseclaw-gateway"
 # macOS convention is a hidden system user prefixed with an underscore.
 # We create this if it doesn't exist. Admins can override via
 # --service-user; the plist we ship gets rewritten to match.
-SERVICE_USER="_defenseclaw"
-SERVICE_GROUP="_defenseclaw"
+SERVICE_USER="defenseclaw"
+SERVICE_GROUP="defenseclaw"
 
 TARGET_USER=""
 AGENT_VERSION=""
@@ -399,7 +399,7 @@ Gateway options:
   --disable-redaction       Disable redaction in audit/sinks (default: on)
   --binary PATH             Use prebuilt binary (default: alongside install.sh)
   --plist PATH              Use this LaunchDaemon plist (default: alongside install.sh)
-  --service-user NAME       macOS service user for the daemon (default: _defenseclaw).
+  --service-user NAME       macOS service user for the daemon (default: defenseclaw).
                             Created via dscl if missing. Also used as the group.
   --skip-build              Reuse an existing gateway binary (no rebuild)
   --skip-launchd            Install files but don't bootstrap/enable launchd
@@ -685,7 +685,10 @@ if [[ "${SKIP_CONNECTOR}" != "true" ]]; then
 
     AGENT_VER="${AGENT_VERSION}"
     if [[ -z "${AGENT_VER}" ]]; then
-      AGENT_VER="$(discover_agent_version "${c}" "${TARGET_HOME}" || true)"
+      # Expose TARGET_USER to the lib so its Codex fallback can exec
+      # `codex --version` as the user (not as root).
+      AGENT_VER="$(DEFENSECLAW_TARGET_USER="${TARGET_USER}" \
+        discover_agent_version "${c}" "${TARGET_HOME}" || true)"
     fi
     if [[ -z "${AGENT_VER}" ]]; then
       warn "  [${c}] could not auto-detect agent version; skipping. Resume with:"

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -105,6 +105,29 @@ dscl_read_prop() {
 #
 # Uses Apple's convention for hidden system users: '_' prefix, /var/empty
 # home, /usr/bin/false shell, IsHidden=1.
+# SERVICE_UID / SERVICE_GID are populated by ensure_service_user for
+# downstream chown calls. macOS's userdb cache can lag several seconds
+# behind OpenDirectory after a `dscl -create`, so using numeric IDs is
+# more reliable than relying on getpwnam/getgrnam right after creation.
+SERVICE_UID=""
+SERVICE_GID=""
+
+# wait_for_id_resolves NAME [max_seconds] — polls until getpwnam sees the
+# user in the running process's cache, up to max_seconds. Returns 0 on
+# resolution, non-zero on timeout.
+wait_for_id_resolves() {
+  local name="$1"
+  local max="${2:-5}"
+  local deadline=$(( $(date +%s) + max ))
+  while (( $(date +%s) < deadline )); do
+    if id -u "${name}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
 ensure_service_user() {
   local name="$1"
 
@@ -112,9 +135,11 @@ ensure_service_user() {
   dscl . -read "/Users/${name}"  >/dev/null 2>&1 && user_exists="yes"
   dscl . -read "/Groups/${name}" >/dev/null 2>&1 && group_exists="yes"
 
-  # Fully provisioned already — nothing to do.
+  # Fully provisioned already — read the IDs and return.
   if [[ "${user_exists}" == "yes" && "${group_exists}" == "yes" ]]; then
     log "  service user ${name} already provisioned"
+    SERVICE_UID="$(dscl_read_prop "/Users/${name}"  UniqueID)"
+    SERVICE_GID="$(dscl_read_prop "/Groups/${name}" PrimaryGroupID)"
     return 0
   fi
 
@@ -156,6 +181,16 @@ ensure_service_user() {
     dscl . -create "/Users/${name}" PrimaryGroupID   "${uid}"
     dscl . -create "/Users/${name}" NFSHomeDirectory /var/empty
     dscl . -create "/Users/${name}" IsHidden         1
+  fi
+
+  SERVICE_UID="${uid}"
+  SERVICE_GID="${uid}"
+
+  # Wait for the OpenDirectory cache to see the new user. Downstream
+  # chown/find commands go through getpwnam and can otherwise fail with
+  # "illegal user name" for a few seconds after creation.
+  if ! wait_for_id_resolves "${name}" 5; then
+    warn "  ${name} still not resolvable via id(1) after 5s — chown will fall back to numeric UID"
   fi
 }
 
@@ -318,11 +353,15 @@ chmod 0640 "${CONFIG_PATH}"
 log "ensuring service user ${SERVICE_USER}"
 ensure_service_user "${SERVICE_USER}"
 
-log "chowning runtime dirs to ${SERVICE_USER}:${SERVICE_GROUP}"
+log "chowning runtime dirs to ${SERVICE_USER}:${SERVICE_GROUP} (uid=${SERVICE_UID} gid=${SERVICE_GID})"
 # Config stays root-owned (managed_enterprise trust check requires it),
 # but runtime state (audit DB, tokens, guardian state, logs) is owned
-# by the service user so the daemon can write to it.
-chown -R "${SERVICE_USER}:${SERVICE_GROUP}" "${SUPPORT_DIR}" "${LOGS_DIR}"
+# by the service user so the daemon can write to it. Use numeric IDs so
+# the chown doesn't depend on OpenDirectory cache warm-up — dscl -create
+# writes are async and getpwnam can be stale for several seconds.
+[[ -n "${SERVICE_UID}" && -n "${SERVICE_GID}" ]] \
+  || die "service uid/gid unset after ensure_service_user (internal bug)"
+chown -R "${SERVICE_UID}:${SERVICE_GID}" "${SUPPORT_DIR}" "${LOGS_DIR}"
 # Re-tighten config ownership: the recursive chown above walked into
 # it, so put it back to root:wheel 0640.
 chown root:wheel "${CONFIG_PATH}"

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -81,7 +81,12 @@ die()  { printf '[install] ERROR: %s\n' "$*" >&2; exit 1; }
 # directory attached, the per-candidate probe form could take 30s+.
 find_free_system_uid() {
   local in_use
-  in_use="$(dscl . -list /Users UniqueID 2>/dev/null | awk '{print $2}')"
+  # Query /Local/Default explicitly — using `.` (the meta-node) makes
+  # dscl walk every attached directory (AD/LDAP/OD), which can hang or
+  # return ENETUNREACH on a Mac bound to an unreachable domain. Service
+  # users only ever live in /Local/Default, so this is both faster and
+  # safer.
+  in_use="$(dscl /Local/Default -list /Users UniqueID 2>/dev/null | awk '{print $2}')"
   local candidate
   for candidate in $(seq 400 499); do
     if ! printf '%s\n' "${in_use}" | grep -qxF "${candidate}"; then
@@ -92,13 +97,22 @@ find_free_system_uid() {
   return 1
 }
 
+# DS_NODE is the dscl node the service-user helpers target.
+#
+# We deliberately pin to /Local/Default instead of the meta-node `.` so
+# that a Mac bound to an unreachable network directory (AD / LDAP /
+# managed OD) doesn't hang or ENETUNREACH us during install. Service
+# users always live in the local node — network directory users would
+# never be candidates for the DefenseClaw daemon principal.
+DS_NODE="/Local/Default"
+
 # dscl_read_prop RECORD PROP — echoes the value of a single dscl property
 # or empty when the record/property doesn't exist. Handles the "AttrName:
 # value" one-liner shape dscl -read returns.
 dscl_read_prop() {
   local record="$1"
   local prop="$2"
-  dscl . -read "${record}" "${prop}" 2>/dev/null \
+  dscl "${DS_NODE}" -read "${record}" "${prop}" 2>/dev/null \
     | awk -v p="${prop}:" 'index($0, p) == 1 { $1=""; sub(/^ /, ""); print; exit }'
 }
 
@@ -112,7 +126,7 @@ dscl_read_prop() {
 dscl_ensure_record() {
   local record="$1"
   local err
-  err="$(dscl . -create "${record}" 2>&1)"
+  err="$(dscl "${DS_NODE}" -create "${record}" 2>&1)"
   local rc=$?
   if (( rc == 0 )); then
     return 0
@@ -137,9 +151,9 @@ dscl_ensure_prop() {
     return 0
   fi
   if [[ -z "${current}" ]]; then
-    dscl . -create "${record}" "${prop}" "${value}"
+    dscl "${DS_NODE}" -create "${record}" "${prop}" "${value}"
   else
-    dscl . -change "${record}" "${prop}" "${current}" "${value}"
+    dscl "${DS_NODE}" -change "${record}" "${prop}" "${current}" "${value}"
   fi
 }
 

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -717,6 +717,17 @@ if [[ "${SKIP_CONNECTOR}" != "true" ]]; then
     fi
   done
 
+  # The CLI subcommands ran as root and created audit.db / judge_bodies.db
+  # + their -wal/-shm sidecars in RUNTIME_DIR. Even though RUNTIME_DIR's
+  # ownership is defenseclaw:defenseclaw, the newly-written files
+  # inherit the running uid/gid (root:defenseclaw) with mode 0644 — so
+  # the daemon (running as defenseclaw) can READ but not WRITE the audit
+  # DB when it comes back up. Result: every hook evaluation runs, but
+  # the audit row silently drops. Fix by re-chowning after every CLI
+  # invocation completes.
+  log "  re-chowning runtime files created by CLI migrations"
+  chown -R "${SERVICE_UID}:${SERVICE_GID}" "${RUNTIME_DIR}"
+
   log "  resuming LaunchDaemon"
   launchctl bootstrap system "${PLIST_DST}"
   launchctl enable "system/${LAUNCHD_LABEL}"

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 DEFAULT_MODE="observe"
 DEFAULT_CONNECTOR="codex"
 DEFAULT_API_PORT="18970"
-DISABLE_REDACTION="true"
+DISABLE_REDACTION="false"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -66,7 +66,7 @@ Gateway options:
                             Examples: --connector cursor
                                       --connector cursor,claudecode
   --port PORT               Loopback API port (default: ${DEFAULT_API_PORT})
-  --redact                  Enable redaction in audit/sinks (default: off)
+  --disable-redaction       Disable redaction in audit/sinks (default: on)
   --binary PATH             Use prebuilt binary instead of 'go build'
   --skip-build              Reuse ./defenseclaw-gateway in the repo (no rebuild)
   --skip-launchd            Install files but don't bootstrap/enable launchd
@@ -92,7 +92,7 @@ while [[ $# -gt 0 ]]; do
     --mode)             MODE="${2:?}"; shift 2;;
     --connector)        CONNECTOR="${2:?}"; shift 2;;
     --port)             API_PORT="${2:?}"; shift 2;;
-    --redact)           DISABLE_REDACTION="false"; shift;;
+    --disable-redaction|--no-redact) DISABLE_REDACTION="true"; shift;;
     --binary)           BINARY_SRC="${2:?}"; SKIP_BUILD="true"; shift 2;;
     --skip-build)       SKIP_BUILD="true"; shift;;
     --skip-launchd)     SKIP_LAUNCHD="true"; shift;;

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -86,31 +86,77 @@ find_free_system_uid() {
   return 1
 }
 
+# dscl_read_prop RECORD PROP — echoes the value of a single dscl property
+# or empty when the record/property doesn't exist. Handles the "AttrName:
+# value" one-liner shape dscl -read returns.
+dscl_read_prop() {
+  local record="$1"
+  local prop="$2"
+  dscl . -read "${record}" "${prop}" 2>/dev/null \
+    | awk -v p="${prop}:" 'index($0, p) == 1 { $1=""; sub(/^ /, ""); print; exit }'
+}
+
 # ensure_service_user NAME — idempotently creates a hidden macOS system
 # user + group so the LaunchDaemon has a real principal to drop into.
-# No-op when the user already exists. Uses the same convention as
-# Apple's own service users (_ prefix, hidden, /var/empty home,
-# /usr/bin/false shell).
+# Handles three states cleanly:
+#   1. Neither user nor group exist        → create both, sharing a fresh UID
+#   2. Group exists (orphan from a prior)  → adopt its existing GID for the user
+#   3. Both exist                          → no-op, just log
+#
+# Uses Apple's convention for hidden system users: '_' prefix, /var/empty
+# home, /usr/bin/false shell, IsHidden=1.
 ensure_service_user() {
   local name="$1"
-  if dscl . -read "/Users/${name}" >/dev/null 2>&1; then
-    log "  service user ${name} already exists"
+
+  local user_exists="no" group_exists="no"
+  dscl . -read "/Users/${name}"  >/dev/null 2>&1 && user_exists="yes"
+  dscl . -read "/Groups/${name}" >/dev/null 2>&1 && group_exists="yes"
+
+  # Fully provisioned already — nothing to do.
+  if [[ "${user_exists}" == "yes" && "${group_exists}" == "yes" ]]; then
+    log "  service user ${name} already provisioned"
     return 0
   fi
-  local uid
-  uid="$(find_free_system_uid)" || die "no free UID in 400..499 for service user ${name}"
-  log "  creating service user ${name} (uid=${uid})"
-  # Group first so the user's PrimaryGroupID resolves at create time.
-  dscl . -create "/Groups/${name}"           || die "create group ${name} failed"
-  dscl . -create "/Groups/${name}" PrimaryGroupID "${uid}" || die "set group ${name} gid failed"
-  dscl . -create "/Users/${name}"            || die "create user ${name} failed"
-  dscl . -create "/Users/${name}" UserShell /usr/bin/false
-  dscl . -create "/Users/${name}" RealName  "DefenseClaw Service"
-  dscl . -create "/Users/${name}" UniqueID  "${uid}"
-  dscl . -create "/Users/${name}" PrimaryGroupID "${uid}"
-  dscl . -create "/Users/${name}" NFSHomeDirectory /var/empty
-  # IsHidden keeps the user out of the login window and account list.
-  dscl . -create "/Users/${name}" IsHidden 1
+
+  # Resolve the UID/GID to use. Prefer the group's existing GID if the
+  # group is already there (Case 2), otherwise pick a free UID.
+  local gid=""
+  if [[ "${group_exists}" == "yes" ]]; then
+    gid="$(dscl_read_prop "/Groups/${name}" PrimaryGroupID)"
+  fi
+  local uid="${gid}"
+  if [[ -z "${uid}" ]]; then
+    uid="$(find_free_system_uid)" \
+      || die "no free UID in 400..499 for service user ${name}"
+  fi
+
+  # Create group first when missing, so the user's PrimaryGroupID resolves
+  # at create time. `dscl -create /Groups/X` on a non-existent record
+  # creates it; the same call on an existing record errors with
+  # eDSRecordAlreadyExists — the early-return above prevents that.
+  if [[ "${group_exists}" == "no" ]]; then
+    log "  creating group ${name} (gid=${uid})"
+    dscl . -create "/Groups/${name}" \
+      || die "create group ${name} failed"
+    dscl . -create "/Groups/${name}" PrimaryGroupID "${uid}" \
+      || die "set group ${name} gid failed"
+    dscl . -create "/Groups/${name}" RealName "DefenseClaw Service Group" \
+      || warn "  set group ${name} RealName failed (non-fatal)"
+  else
+    log "  group ${name} already exists (gid=${uid}); reusing"
+  fi
+
+  if [[ "${user_exists}" == "no" ]]; then
+    log "  creating user ${name} (uid=${uid})"
+    dscl . -create "/Users/${name}" \
+      || die "create user ${name} failed"
+    dscl . -create "/Users/${name}" UserShell        /usr/bin/false
+    dscl . -create "/Users/${name}" RealName         "DefenseClaw Service"
+    dscl . -create "/Users/${name}" UniqueID         "${uid}"
+    dscl . -create "/Users/${name}" PrimaryGroupID   "${uid}"
+    dscl . -create "/Users/${name}" NFSHomeDirectory /var/empty
+    dscl . -create "/Users/${name}" IsHidden         1
+  fi
 }
 
 # shellcheck source=lib/installer_lib.sh

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -551,12 +551,29 @@ ensure_service_user "${SERVICE_USER}"
 
 log "chowning runtime dirs to ${SERVICE_USER}:${SERVICE_GROUP} (uid=${SERVICE_UID} gid=${SERVICE_GID})"
 # Only RUNTIME_DIR + LOGS_DIR get service-user ownership. SUPPORT_DIR
-# itself and CONFIG_PATH stay root:wheel so the managed_enterprise
+# itself and CONFIG_PATH stay root-owned so the managed_enterprise
 # config trust check (which walks every ancestor of config.yaml)
 # accepts them.
 [[ -n "${SERVICE_UID}" && -n "${SERVICE_GID}" ]] \
   || die "service uid/gid unset after ensure_service_user (internal bug)"
 chown -R "${SERVICE_UID}:${SERVICE_GID}" "${RUNTIME_DIR}" "${LOGS_DIR}"
+
+# SUPPORT_DIR stays owned by root, but the service user needs group
+# traverse (x) access so launchd can chdir into
+# ${SUPPORT_DIR}/runtime as its WorkingDirectory. Without this the
+# daemon exits with EX_CONFIG before opening stdout/stderr — we can't
+# even see a log line explaining what happened.
+#
+# The trust check refuses (mode & 0o022) — group-WRITE or other-WRITE
+# bits — but group-execute (0o010) is fine. chgrp to the service group
+# and keep mode 0750: root has full access, service group has rx only,
+# world has nothing.
+chgrp "${SERVICE_GID}" "${SUPPORT_DIR}"
+chmod 0750 "${SUPPORT_DIR}"
+# Also make config.yaml readable by the service group (daemon needs
+# to read it). Owner stays root, mode 0640 (owner rw, group r, other 0).
+chgrp "${SERVICE_GID}" "${CONFIG_PATH}"
+chmod 0640 "${CONFIG_PATH}"
 
 log "installing LaunchDaemon plist -> ${PLIST_DST}"
 install -o root -g wheel -m 0644 "${PLIST_SRC}" "${PLIST_DST}"

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -174,10 +174,20 @@ dscl_ensure_prop() {
   fi
 
   if [[ "${err}" == *eDSRecordAlreadyExists* ]]; then
-    # Property exists — swap value in place. Passing an empty current
-    # value tells dscl to overwrite whatever is there.
-    dscl "${DS_NODE}" -change "${record}" "${prop}" "${current}" "${value}"
-    return $?
+    # Record already exists. The property may or may not be present.
+    # Try -change first (works when the attribute is already there); if
+    # dscl reports eDSAttributeNotFound, fall back to -append.
+    local err2 rc2=0
+    err2="$(dscl "${DS_NODE}" -change "${record}" "${prop}" "${current}" "${value}" 2>&1)" || rc2=$?
+    if (( rc2 == 0 )); then
+      return 0
+    fi
+    if [[ "${err2}" == *eDSAttributeNotFound* ]]; then
+      dscl "${DS_NODE}" -append "${record}" "${prop}" "${value}"
+      return $?
+    fi
+    printf '%s\n' "${err2}" >&2
+    return "${rc2}"
   fi
 
   printf '%s\n' "${err}" >&2

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -75,10 +75,16 @@ die()  { printf '[install] ERROR: %s\n' "$*" >&2; exit 1; }
 # find_free_system_uid — returns an unused UID in the System range so we
 # don't collide with an admin's existing service user. macOS reserves
 # < 500 for the OS; we scan 400..499 and pick the first free slot.
+#
+# Uses a single `dscl -list` to enumerate all in-use UIDs, which is much
+# faster than issuing 100 -search calls. On a laptop with a network
+# directory attached, the per-candidate probe form could take 30s+.
 find_free_system_uid() {
+  local in_use
+  in_use="$(dscl . -list /Users UniqueID 2>/dev/null | awk '{print $2}')"
   local candidate
   for candidate in $(seq 400 499); do
-    if ! dscl . -search /Users UniqueID "${candidate}" 2>/dev/null | grep -q .; then
+    if ! printf '%s\n' "${in_use}" | grep -qxF "${candidate}"; then
       printf '%s' "${candidate}"
       return 0
     fi
@@ -187,11 +193,15 @@ ensure_service_user() {
   local uid=""
   if [[ -n "${existing_gid}" ]]; then
     uid="${existing_gid}"
+    log "  reusing existing gid=${uid}"
   elif [[ -n "${existing_uid}" ]]; then
     uid="${existing_uid}"
+    log "  reusing existing uid=${uid}"
   else
+    log "  scanning UIDs 400..499 for a free slot"
     uid="$(find_free_system_uid)" \
       || die "no free UID in 400..499 for service user ${name}"
+    log "  picked free uid=${uid}"
   fi
 
   log "  ensuring group ${name} (gid=${uid})"

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+#
+# DefenseClaw macOS installer (managed_enterprise + LaunchDaemon + per-user
+# hook wiring via the enterprise hook guardian).
+#
+# System layout (root-owned):
+#   /Library/DefenseClaw/bin/defenseclaw-gateway          (root:wheel 0755)
+#   /Library/LaunchDaemons/com.defenseclaw.gateway.plist  (root:wheel 0644)
+#   /Library/Application Support/DefenseClaw/             (root:wheel 0750)
+#     config.yaml                                         (root:wheel 0640)
+#   /Library/Logs/DefenseClaw/                            (root:wheel 0750)
+#
+# Per-user (target-user-owned, written by the guardian dropping euid/egid):
+#   ~/.<agent>/<hook-config-file>                          (target-user 0600)
+#   ~/.defenseclaw/hooks/<connector>-hook.sh               (target-user 0700)
+#
+# This script orchestrates side-effecting steps (sudo, launchctl, install(8))
+# and delegates pure logic (arg parsing, config rendering, version probing,
+# userspace prep) to lib/installer_lib.sh so the test suite under tests/
+# can drive that logic without root.
+
+set -euo pipefail
+
+# ---- defaults -----------------------------------------------------------
+
+DEFAULT_MODE="observe"
+DEFAULT_CONNECTOR="codex"
+DEFAULT_API_PORT="18970"
+DISABLE_REDACTION="true"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BINARY_SRC=""
+PLIST_SRC="${REPO_ROOT}/packaging/launchd/com.defenseclaw.gateway.plist"
+SKIP_BUILD="false"
+SKIP_LAUNCHD="false"
+SKIP_CONNECTOR="false"
+
+INSTALL_PREFIX="/Library/DefenseClaw"
+SUPPORT_DIR="/Library/Application Support/DefenseClaw"
+LOGS_DIR="/Library/Logs/DefenseClaw"
+PLIST_DST="/Library/LaunchDaemons/com.defenseclaw.gateway.plist"
+LAUNCHD_LABEL="com.defenseclaw.gateway"
+GATEWAY_BIN="${INSTALL_PREFIX}/bin/defenseclaw-gateway"
+
+TARGET_USER=""
+AGENT_VERSION=""
+
+# ---- helpers ------------------------------------------------------------
+
+log()  { printf '[install] %s\n' "$*"; }
+warn() { printf '[install] WARN: %s\n' "$*" >&2; }
+die()  { printf '[install] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# shellcheck source=lib/installer_lib.sh
+. "${SCRIPT_DIR}/lib/installer_lib.sh"
+
+usage() {
+  cat <<EOF
+Usage: sudo $0 [options]
+
+Gateway options:
+  --mode {observe|action}   Guardrail + asset_policy mode (default: ${DEFAULT_MODE})
+  --connector LIST          Hook connector(s), comma-separated (default: ${DEFAULT_CONNECTOR})
+                            Supported: codex, claudecode, cursor
+                            Examples: --connector cursor
+                                      --connector cursor,claudecode
+  --port PORT               Loopback API port (default: ${DEFAULT_API_PORT})
+  --redact                  Enable redaction in audit/sinks (default: off)
+  --binary PATH             Use prebuilt binary instead of 'go build'
+  --skip-build              Reuse ./defenseclaw-gateway in the repo (no rebuild)
+  --skip-launchd            Install files but don't bootstrap/enable launchd
+
+Per-user hook wiring:
+  --user USER               Target macOS user (default: \$SUDO_USER)
+  --agent-version VERSION   Override agent version (auto-detected if omitted)
+  --skip-connector          Don't wire user-space hooks (gateway only)
+
+  -h, --help                Show this help
+
+EOF
+}
+
+# ---- arg parsing --------------------------------------------------------
+
+MODE="${DEFAULT_MODE}"
+CONNECTOR="${DEFAULT_CONNECTOR}"
+API_PORT="${DEFAULT_API_PORT}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)             MODE="${2:?}"; shift 2;;
+    --connector)        CONNECTOR="${2:?}"; shift 2;;
+    --port)             API_PORT="${2:?}"; shift 2;;
+    --redact)           DISABLE_REDACTION="false"; shift;;
+    --binary)           BINARY_SRC="${2:?}"; SKIP_BUILD="true"; shift 2;;
+    --skip-build)       SKIP_BUILD="true"; shift;;
+    --skip-launchd)     SKIP_LAUNCHD="true"; shift;;
+    --user)             TARGET_USER="${2:?}"; shift 2;;
+    --agent-version)    AGENT_VERSION="${2:?}"; shift 2;;
+    --skip-connector)   SKIP_CONNECTOR="true"; shift;;
+    -h|--help)          usage; exit 0;;
+    *) die "unknown flag: $1 (try --help)";;
+  esac
+done
+
+case "${MODE}" in
+  observe|action) ;;
+  *) die "--mode must be 'observe' or 'action' (got: ${MODE})";;
+esac
+
+CONNECTOR_LINES="$(parse_connectors "${CONNECTOR}")" || \
+  die "--connector has an empty entry (check the comma list)"
+CONNECTORS=()
+while IFS= read -r line; do
+  [[ -z "${line}" ]] && continue
+  CONNECTORS+=("${line}")
+done <<< "${CONNECTOR_LINES}"
+[[ ${#CONNECTORS[@]} -gt 0 ]] || die "--connector produced no entries"
+PRIMARY_CONNECTOR="${CONNECTORS[0]}"
+
+for c in "${CONNECTORS[@]}"; do
+  if ! is_supported_connector "${c}"; then
+    warn "connector '${c}' is not in the auto-wire list (codex|claudecode|cursor); will be written to config but per-user hooks won't be auto-wired"
+  fi
+done
+
+# ---- preflight ----------------------------------------------------------
+
+[[ "$(uname -s)" == "Darwin" ]] || die "macOS only (uname -s != Darwin)"
+[[ $EUID -eq 0 ]] || die "must run as root (try: sudo $0 $*)"
+[[ -f "${PLIST_SRC}" ]] || die "missing plist source: ${PLIST_SRC}"
+
+# Resolve target user (default: the user who invoked sudo)
+if [[ -z "${TARGET_USER}" ]]; then
+  TARGET_USER="${SUDO_USER:-}"
+fi
+if [[ -z "${TARGET_USER}" && "${SKIP_CONNECTOR}" != "true" ]]; then
+  warn "no target user (run with sudo from a user shell, or pass --user); skipping per-user hook wiring"
+  SKIP_CONNECTOR="true"
+fi
+if [[ -n "${TARGET_USER}" ]]; then
+  TARGET_HOME="$(dscl . -read "/Users/${TARGET_USER}" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
+  [[ -n "${TARGET_HOME}" && -d "${TARGET_HOME}" ]] || \
+    die "could not resolve home for --user ${TARGET_USER}"
+fi
+
+# Resolve the binary
+if [[ -z "${BINARY_SRC}" ]]; then
+  BINARY_SRC="${REPO_ROOT}/defenseclaw-gateway"
+fi
+if [[ "${SKIP_BUILD}" != "true" && ! -x "${BINARY_SRC}" ]]; then
+  command -v go >/dev/null 2>&1 || die "go not in PATH; install Go or pass --binary"
+  log "building gateway from ${REPO_ROOT}/cmd/defenseclaw"
+  ( cd "${REPO_ROOT}" && go build -o defenseclaw-gateway ./cmd/defenseclaw )
+fi
+[[ -x "${BINARY_SRC}" ]] || die "binary not found or not executable: ${BINARY_SRC}"
+
+# Refuse to clobber a running install silently
+if launchctl print "system/${LAUNCHD_LABEL}" >/dev/null 2>&1; then
+  warn "${LAUNCHD_LABEL} is currently loaded — bootouting before reinstall"
+  launchctl bootout "system/${LAUNCHD_LABEL}" 2>/dev/null || true
+  launchctl bootout system "${PLIST_DST}" 2>/dev/null || true
+fi
+
+# ---- gateway file install ----------------------------------------------
+
+log "installing binary -> ${GATEWAY_BIN}"
+install -d -o root -g wheel -m 0755 "${INSTALL_PREFIX}/bin"
+install    -o root -g wheel -m 0755 "${BINARY_SRC}" "${GATEWAY_BIN}"
+
+log "creating support dirs"
+install -d -o root -g wheel -m 0750 "${SUPPORT_DIR}"
+install -d -o root -g wheel -m 0750 "${LOGS_DIR}"
+
+CONFIG_PATH="${SUPPORT_DIR}/config.yaml"
+if [[ -f "${CONFIG_PATH}" ]]; then
+  BACKUP="${CONFIG_PATH}.$(date +%Y%m%d-%H%M%S).bak"
+  cp -p "${CONFIG_PATH}" "${BACKUP}"
+  log "backed up existing config to ${BACKUP}"
+fi
+
+log "writing config (mode=${MODE} connectors=${CONNECTORS[*]} port=${API_PORT} redaction_off=${DISABLE_REDACTION})"
+render_config "${MODE}" "${PRIMARY_CONNECTOR}" "${API_PORT}" "${DISABLE_REDACTION}" "${SUPPORT_DIR}" "${CONNECTORS[@]}" > "${CONFIG_PATH}"
+chown root:wheel "${CONFIG_PATH}"
+chmod 0640 "${CONFIG_PATH}"
+
+log "installing LaunchDaemon plist -> ${PLIST_DST}"
+install -o root -g wheel -m 0644 "${PLIST_SRC}" "${PLIST_DST}"
+
+if [[ "${SKIP_LAUNCHD}" == "true" ]]; then
+  log "skipping launchctl bootstrap (--skip-launchd)"
+  exit 0
+fi
+
+# ---- launchd ------------------------------------------------------------
+
+log "loading LaunchDaemon"
+launchctl bootstrap system "${PLIST_DST}"
+launchctl enable "system/${LAUNCHD_LABEL}"
+
+log "waiting for gateway to come up"
+SETTLE_DEADLINE=$(( $(date +%s) + 15 ))
+while (( $(date +%s) < SETTLE_DEADLINE )); do
+  if launchctl print "system/${LAUNCHD_LABEL}" 2>/dev/null | grep -qE '^[[:space:]]+state = running'; then
+    break
+  fi
+  sleep 1
+done
+
+# ---- per-user hook wiring ----------------------------------------------
+
+if [[ "${SKIP_CONNECTOR}" != "true" ]]; then
+  log "wiring user-space hooks for ${TARGET_USER} (${CONNECTORS[*]})"
+  TARGET_UID="$(id -u "${TARGET_USER}")"
+  TARGET_GID="$(id -g "${TARGET_USER}")"
+
+  if ! home_perms_ok "${TARGET_HOME}"; then
+    HOME_MODE="$(stat -f '%Lp' "${TARGET_HOME}" 2>/dev/null || echo '?')"
+    warn "home directory ${TARGET_HOME} is group/other writable (mode ${HOME_MODE})"
+    warn "  the enterprise hook guardian will refuse to write into a loose home;"
+    warn "  this is an administrator responsibility to fix. Suggested:"
+    warn "    sudo chmod 0755 ${TARGET_HOME}"
+    warn "  skipping user-space hook wiring. Gateway is still running."
+    warn "  after fixing perms, finish wiring per-connector with:"
+    for c in "${CONNECTORS[@]}"; do
+      warn "    sudo DEFENSECLAW_CONFIG=\"${CONFIG_PATH}\" ${GATEWAY_BIN} enterprise hooks install --connector ${c} --user ${TARGET_USER} --agent-version 'X.Y.Z' --json"
+    done
+    SKIP_CONNECTOR="true"
+  fi
+fi
+
+if [[ "${SKIP_CONNECTOR}" != "true" ]]; then
+  # The CLI subcommand opens the audit DB writer; pause the daemon once,
+  # run every per-connector install, then resume.
+  log "  pausing LaunchDaemon (CLI subcommands hold the audit DB lock)"
+  launchctl bootout "system/${LAUNCHD_LABEL}" 2>/dev/null || true
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    pgrep -fl "${GATEWAY_BIN}" >/dev/null 2>&1 || break
+    sleep 1
+  done
+
+  for c in "${CONNECTORS[@]}"; do
+    if ! is_supported_connector "${c}"; then
+      log "  skipping unsupported connector ${c} (no userspace wiring)"
+      continue
+    fi
+
+    log "  [${c}] preparing userspace"
+    prepare_userspace_for "${c}" "${TARGET_HOME}"
+    # Match the ownership of any newly created files to the target user.
+    chown -R "${TARGET_UID}:${TARGET_GID}" \
+      "${TARGET_HOME}/.${c%code}" 2>/dev/null || true
+    # Special-case naming (claudecode -> .claude, codex -> .codex, cursor -> .cursor).
+    case "${c}" in
+      claudecode) chown -R "${TARGET_UID}:${TARGET_GID}" "${TARGET_HOME}/.claude" 2>/dev/null || true;;
+      codex)      chown -R "${TARGET_UID}:${TARGET_GID}" "${TARGET_HOME}/.codex"  2>/dev/null || true;;
+      cursor)     chown -R "${TARGET_UID}:${TARGET_GID}" "${TARGET_HOME}/.cursor" 2>/dev/null || true;;
+    esac
+
+    AGENT_VER="${AGENT_VERSION}"
+    if [[ -z "${AGENT_VER}" ]]; then
+      AGENT_VER="$(discover_agent_version "${c}" "${TARGET_HOME}" || true)"
+    fi
+    if [[ -z "${AGENT_VER}" ]]; then
+      warn "  [${c}] could not auto-detect agent version; skipping. Resume with:"
+      warn "    sudo DEFENSECLAW_CONFIG=\"${CONFIG_PATH}\" ${GATEWAY_BIN} enterprise hooks install --connector ${c} --user ${TARGET_USER} --agent-version 'X.Y.Z' --json"
+      continue
+    fi
+
+    log "  [${c}] detected agent_version: ${AGENT_VER}"
+    log "  [${c}] running: enterprise hooks install --connector ${c} --user ${TARGET_USER}"
+    if DEFENSECLAW_CONFIG="${CONFIG_PATH}" "${GATEWAY_BIN}" enterprise hooks install \
+         --connector "${c}" \
+         --user "${TARGET_USER}" \
+         --agent-version "${AGENT_VER}" \
+         --json; then
+      log "  [${c}] hook wiring OK"
+    else
+      warn "  [${c}] hook wiring failed; see JSON output above"
+    fi
+  done
+
+  log "  resuming LaunchDaemon"
+  launchctl bootstrap system "${PLIST_DST}"
+  launchctl enable "system/${LAUNCHD_LABEL}"
+  SETTLE_DEADLINE=$(( $(date +%s) + 15 ))
+  while (( $(date +%s) < SETTLE_DEADLINE )); do
+    if launchctl print "system/${LAUNCHD_LABEL}" 2>/dev/null | grep -qE '^[[:space:]]+state = running'; then
+      break
+    fi
+    sleep 1
+  done
+fi
+
+# ---- summary ------------------------------------------------------------
+
+cat <<EOF
+
+[install] done.
+
+Next steps:
+  Gateway status:
+    sudo DEFENSECLAW_CONFIG="${CONFIG_PATH}" ${GATEWAY_BIN} status
+
+  Tail logs:
+    sudo tail -f ${LOGS_DIR}/gateway.log ${LOGS_DIR}/gateway.err.log
+
+  Query audit DB:
+    sudo sqlite3 -header -column "${SUPPORT_DIR}/audit.db" \\
+      "SELECT datetime(timestamp,'localtime'),action,severity,substr(details,1,80) \\
+       FROM audit_events ORDER BY timestamp DESC LIMIT 10;"
+
+  Master gateway token (for direct curl tests):
+    sudo grep DEFENSECLAW_GATEWAY_TOKEN "${SUPPORT_DIR}/.env"
+
+  Repair user-space hooks (per connector):
+$(for c in "${CONNECTORS[@]}"; do
+    printf '    sudo DEFENSECLAW_CONFIG="%s" %s enterprise hooks install --connector %s --user %s --agent-version "X.Y.Z" --json\n' \
+      "${CONFIG_PATH}" "${GATEWAY_BIN}" "${c}" "${TARGET_USER:-USER}"
+  done)
+
+  Uninstall:
+    sudo ${SCRIPT_DIR}/uninstall.sh
+EOF

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -147,7 +147,16 @@ dscl_ensure_record() {
 
 # dscl_ensure_prop RECORD PROP VALUE — sets a property on a dscl record
 # to a specific value, treating "already has this exact value" as success.
-# Uses -create when the property is unset, -change when it needs updating.
+#
+# We try `-create` first with fallback to `-change`: on some macOS
+# versions `dscl -create record prop value` returns eDSRecordAlreadyExists
+# when the record itself already exists (even though the property might
+# be unset), so we can't rely on read-then-create-or-change. Instead:
+#
+#   1. If the current value already matches, no-op.
+#   2. Otherwise try `-create`. Success → done.
+#   3. If -create failed with eDSRecordAlreadyExists, use `-change`.
+#      -change tolerates a missing old value by passing empty.
 dscl_ensure_prop() {
   local record="$1"
   local prop="$2"
@@ -157,11 +166,22 @@ dscl_ensure_prop() {
   if [[ "${current}" == "${value}" ]]; then
     return 0
   fi
-  if [[ -z "${current}" ]]; then
-    dscl "${DS_NODE}" -create "${record}" "${prop}" "${value}"
-  else
-    dscl "${DS_NODE}" -change "${record}" "${prop}" "${current}" "${value}"
+
+  local err rc=0
+  err="$(dscl "${DS_NODE}" -create "${record}" "${prop}" "${value}" 2>&1)" || rc=$?
+  if (( rc == 0 )); then
+    return 0
   fi
+
+  if [[ "${err}" == *eDSRecordAlreadyExists* ]]; then
+    # Property exists — swap value in place. Passing an empty current
+    # value tells dscl to overwrite whatever is there.
+    dscl "${DS_NODE}" -change "${record}" "${prop}" "${current}" "${value}"
+    return $?
+  fi
+
+  printf '%s\n' "${err}" >&2
+  return "${rc}"
 }
 
 # ensure_service_user NAME — idempotently creates a hidden macOS system

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -531,7 +531,15 @@ install -d -o root -g wheel -m 0750 "${SUPPORT_DIR}"
 # points data_dir at). It's chown'd to the service user after we
 # ensure the user exists — see below.
 RUNTIME_DIR="${SUPPORT_DIR}/runtime"
+# GUARDIAN_AUTH_DIR is the hook guardian's authorization state dir.
+# managed.HookGuardianAuthorizationDir() computes this as
+# `${data_dir}-hook-guardian` when DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR
+# isn't set — we mirror that default so the daemon (which does
+# have the env var set via the plist) and the CLI (invoked without
+# it) both resolve to the same path.
+GUARDIAN_AUTH_DIR="${SUPPORT_DIR}/runtime-hook-guardian"
 install -d -o root -g wheel -m 0750 "${RUNTIME_DIR}"
+install -d -o root -g wheel -m 0750 "${GUARDIAN_AUTH_DIR}"
 install -d -o root -g wheel -m 0750 "${LOGS_DIR}"
 
 CONFIG_PATH="${SUPPORT_DIR}/config.yaml"
@@ -556,7 +564,7 @@ log "chowning runtime dirs to ${SERVICE_USER}:${SERVICE_GROUP} (uid=${SERVICE_UI
 # accepts them.
 [[ -n "${SERVICE_UID}" && -n "${SERVICE_GID}" ]] \
   || die "service uid/gid unset after ensure_service_user (internal bug)"
-chown -R "${SERVICE_UID}:${SERVICE_GID}" "${RUNTIME_DIR}" "${LOGS_DIR}"
+chown -R "${SERVICE_UID}:${SERVICE_GID}" "${RUNTIME_DIR}" "${GUARDIAN_AUTH_DIR}" "${LOGS_DIR}"
 
 # SUPPORT_DIR stays owned by root, but the service user needs group
 # traverse (x) access so launchd can chdir into

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -96,6 +96,47 @@ dscl_read_prop() {
     | awk -v p="${prop}:" 'index($0, p) == 1 { $1=""; sub(/^ /, ""); print; exit }'
 }
 
+# dscl_ensure_record RECORD — creates a dscl record idempotently.
+# `dscl -create` will return eDSRecordAlreadyExists when the record is
+# already there; that's exactly the state we want, so we treat it as
+# success. Any other error is fatal. macOS's OpenDirectory can also be
+# temporarily inconsistent (a -read says "not there" while a subsequent
+# -create says "already there") for a few seconds after a prior create,
+# so this helper is more reliable than gating on -read.
+dscl_ensure_record() {
+  local record="$1"
+  local err
+  err="$(dscl . -create "${record}" 2>&1)"
+  local rc=$?
+  if (( rc == 0 )); then
+    return 0
+  fi
+  if [[ "${err}" == *eDSRecordAlreadyExists* ]]; then
+    return 0
+  fi
+  printf '%s\n' "${err}" >&2
+  return "${rc}"
+}
+
+# dscl_ensure_prop RECORD PROP VALUE — sets a property on a dscl record
+# to a specific value, treating "already has this exact value" as success.
+# Uses -create when the property is unset, -change when it needs updating.
+dscl_ensure_prop() {
+  local record="$1"
+  local prop="$2"
+  local value="$3"
+  local current
+  current="$(dscl_read_prop "${record}" "${prop}")"
+  if [[ "${current}" == "${value}" ]]; then
+    return 0
+  fi
+  if [[ -z "${current}" ]]; then
+    dscl . -create "${record}" "${prop}" "${value}"
+  else
+    dscl . -change "${record}" "${prop}" "${current}" "${value}"
+  fi
+}
+
 # ensure_service_user NAME — idempotently creates a hidden macOS system
 # user + group so the LaunchDaemon has a real principal to drop into.
 # Handles three states cleanly:
@@ -131,66 +172,55 @@ wait_for_id_resolves() {
 ensure_service_user() {
   local name="$1"
 
-  local user_exists="no" group_exists="no"
-  dscl . -read "/Users/${name}"  >/dev/null 2>&1 && user_exists="yes"
-  dscl . -read "/Groups/${name}" >/dev/null 2>&1 && group_exists="yes"
+  # Peek at the current state, but don't gate on it — OpenDirectory is
+  # eventually consistent so a read-then-create pattern can race. Every
+  # dscl call below uses dscl_ensure_* helpers that are safe under
+  # eDSRecordAlreadyExists.
+  local existing_gid existing_uid
+  existing_gid="$(dscl_read_prop "/Groups/${name}" PrimaryGroupID)"
+  existing_uid="$(dscl_read_prop "/Users/${name}"  UniqueID)"
 
-  # Fully provisioned already — read the IDs and return.
-  if [[ "${user_exists}" == "yes" && "${group_exists}" == "yes" ]]; then
-    log "  service user ${name} already provisioned"
-    SERVICE_UID="$(dscl_read_prop "/Users/${name}"  UniqueID)"
-    SERVICE_GID="$(dscl_read_prop "/Groups/${name}" PrimaryGroupID)"
-    return 0
-  fi
-
-  # Resolve the UID/GID to use. Prefer the group's existing GID if the
-  # group is already there (Case 2), otherwise pick a free UID.
-  local gid=""
-  if [[ "${group_exists}" == "yes" ]]; then
-    gid="$(dscl_read_prop "/Groups/${name}" PrimaryGroupID)"
-  fi
-  local uid="${gid}"
-  if [[ -z "${uid}" ]]; then
+  # Decide the id to use:
+  #   - reuse an existing UID/GID whenever we have one (avoids fighting
+  #     OD if either record is present)
+  #   - otherwise, allocate a free UID and use it for both
+  local uid=""
+  if [[ -n "${existing_gid}" ]]; then
+    uid="${existing_gid}"
+  elif [[ -n "${existing_uid}" ]]; then
+    uid="${existing_uid}"
+  else
     uid="$(find_free_system_uid)" \
       || die "no free UID in 400..499 for service user ${name}"
   fi
 
-  # Create group first when missing, so the user's PrimaryGroupID resolves
-  # at create time. `dscl -create /Groups/X` on a non-existent record
-  # creates it; the same call on an existing record errors with
-  # eDSRecordAlreadyExists — the early-return above prevents that.
-  if [[ "${group_exists}" == "no" ]]; then
-    log "  creating group ${name} (gid=${uid})"
-    dscl . -create "/Groups/${name}" \
-      || die "create group ${name} failed"
-    dscl . -create "/Groups/${name}" PrimaryGroupID "${uid}" \
-      || die "set group ${name} gid failed"
-    dscl . -create "/Groups/${name}" RealName "DefenseClaw Service Group" \
-      || warn "  set group ${name} RealName failed (non-fatal)"
-  else
-    log "  group ${name} already exists (gid=${uid}); reusing"
-  fi
+  log "  ensuring group ${name} (gid=${uid})"
+  dscl_ensure_record "/Groups/${name}" \
+    || die "create group ${name} failed"
+  dscl_ensure_prop   "/Groups/${name}" PrimaryGroupID "${uid}" \
+    || die "set group ${name} gid failed"
+  dscl_ensure_prop   "/Groups/${name}" RealName "DefenseClaw Service Group" \
+    || warn "  set group ${name} RealName failed (non-fatal)"
 
-  if [[ "${user_exists}" == "no" ]]; then
-    log "  creating user ${name} (uid=${uid})"
-    dscl . -create "/Users/${name}" \
-      || die "create user ${name} failed"
-    dscl . -create "/Users/${name}" UserShell        /usr/bin/false
-    dscl . -create "/Users/${name}" RealName         "DefenseClaw Service"
-    dscl . -create "/Users/${name}" UniqueID         "${uid}"
-    dscl . -create "/Users/${name}" PrimaryGroupID   "${uid}"
-    dscl . -create "/Users/${name}" NFSHomeDirectory /var/empty
-    dscl . -create "/Users/${name}" IsHidden         1
-  fi
+  log "  ensuring user ${name} (uid=${uid})"
+  dscl_ensure_record "/Users/${name}" \
+    || die "create user ${name} failed"
+  dscl_ensure_prop   "/Users/${name}" UserShell        /usr/bin/false
+  dscl_ensure_prop   "/Users/${name}" RealName         "DefenseClaw Service"
+  dscl_ensure_prop   "/Users/${name}" UniqueID         "${uid}"
+  dscl_ensure_prop   "/Users/${name}" PrimaryGroupID   "${uid}"
+  dscl_ensure_prop   "/Users/${name}" NFSHomeDirectory /var/empty
+  dscl_ensure_prop   "/Users/${name}" IsHidden         1
 
   SERVICE_UID="${uid}"
   SERVICE_GID="${uid}"
 
   # Wait for the OpenDirectory cache to see the new user. Downstream
   # chown/find commands go through getpwnam and can otherwise fail with
-  # "illegal user name" for a few seconds after creation.
+  # "illegal user name" for a few seconds after creation. Non-fatal —
+  # the chown site uses numeric IDs so it works regardless.
   if ! wait_for_id_resolves "${name}" 5; then
-    warn "  ${name} still not resolvable via id(1) after 5s — chown will fall back to numeric UID"
+    warn "  ${name} still not resolvable via id(1) after 5s — using numeric UID for chown"
   fi
 }
 

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -247,16 +247,22 @@ if [[ "${SKIP_CONNECTOR}" != "true" ]]; then
     fi
 
     log "  [${c}] preparing userspace"
-    prepare_userspace_for "${c}" "${TARGET_HOME}"
+    if ! prepare_userspace_for "${c}" "${TARGET_HOME}"; then
+      warn "  [${c}] refused to prepare userspace (symlinked or non-dir path); skipping"
+      continue
+    fi
     # Match the ownership of any newly created files to the target user.
-    chown -R "${TARGET_UID}:${TARGET_GID}" \
-      "${TARGET_HOME}/.${c%code}" 2>/dev/null || true
-    # Special-case naming (claudecode -> .claude, codex -> .codex, cursor -> .cursor).
+    # -h so we chown the entry itself and never follow symlinks (defense
+    # in depth alongside ensure_safe_userspace_path in the lib helpers).
     case "${c}" in
-      claudecode) chown -R "${TARGET_UID}:${TARGET_GID}" "${TARGET_HOME}/.claude" 2>/dev/null || true;;
-      codex)      chown -R "${TARGET_UID}:${TARGET_GID}" "${TARGET_HOME}/.codex"  2>/dev/null || true;;
-      cursor)     chown -R "${TARGET_UID}:${TARGET_GID}" "${TARGET_HOME}/.cursor" 2>/dev/null || true;;
+      claudecode) DC_AGENT_DIR="${TARGET_HOME}/.claude";;
+      codex)      DC_AGENT_DIR="${TARGET_HOME}/.codex";;
+      cursor)     DC_AGENT_DIR="${TARGET_HOME}/.cursor";;
+      *)          DC_AGENT_DIR="";;
     esac
+    if [[ -n "${DC_AGENT_DIR}" && -d "${DC_AGENT_DIR}" && ! -L "${DC_AGENT_DIR}" ]]; then
+      find "${DC_AGENT_DIR}" -exec chown -h "${TARGET_UID}:${TARGET_GID}" {} + 2>/dev/null || true
+    fi
 
     AGENT_VER="${AGENT_VERSION}"
     if [[ -z "${AGENT_VER}" ]]; then

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -29,9 +29,23 @@ DEFAULT_API_PORT="18970"
 DISABLE_REDACTION="false"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd 2>/dev/null || echo "${SCRIPT_DIR}")"
 BINARY_SRC=""
-PLIST_SRC="${REPO_ROOT}/packaging/launchd/com.defenseclaw.gateway.plist"
+# Plist lookup order:
+#   1. --plist / DEFENSECLAW_PLIST_SRC  (explicit override)
+#   2. next to the script            (standalone-bundle layout)
+#   3. under the repo tree           (dev-tree layout)
+PLIST_SRC=""
+for _candidate in \
+  "${DEFENSECLAW_PLIST_SRC:-}" \
+  "${SCRIPT_DIR}/com.defenseclaw.gateway.plist" \
+  "${REPO_ROOT}/packaging/launchd/com.defenseclaw.gateway.plist"; do
+  if [[ -n "${_candidate}" && -f "${_candidate}" ]]; then
+    PLIST_SRC="${_candidate}"
+    break
+  fi
+done
+unset _candidate
 SKIP_BUILD="false"
 SKIP_LAUNCHD="false"
 SKIP_CONNECTOR="false"
@@ -67,8 +81,9 @@ Gateway options:
                                       --connector cursor,claudecode
   --port PORT               Loopback API port (default: ${DEFAULT_API_PORT})
   --disable-redaction       Disable redaction in audit/sinks (default: on)
-  --binary PATH             Use prebuilt binary instead of 'go build'
-  --skip-build              Reuse ./defenseclaw-gateway in the repo (no rebuild)
+  --binary PATH             Use prebuilt binary (default: alongside install.sh)
+  --plist PATH              Use this LaunchDaemon plist (default: alongside install.sh)
+  --skip-build              Reuse an existing gateway binary (no rebuild)
   --skip-launchd            Install files but don't bootstrap/enable launchd
 
 Per-user hook wiring:
@@ -94,6 +109,7 @@ while [[ $# -gt 0 ]]; do
     --port)             API_PORT="${2:?}"; shift 2;;
     --disable-redaction|--no-redact) DISABLE_REDACTION="true"; shift;;
     --binary)           BINARY_SRC="${2:?}"; SKIP_BUILD="true"; shift 2;;
+    --plist)            PLIST_SRC="${2:?}"; shift 2;;
     --skip-build)       SKIP_BUILD="true"; shift;;
     --skip-launchd)     SKIP_LAUNCHD="true"; shift;;
     --user)             TARGET_USER="${2:?}"; shift 2;;
@@ -149,11 +165,25 @@ if [[ -n "${TARGET_USER}" ]]; then
     die "could not resolve home for --user ${TARGET_USER}"
 fi
 
-# Resolve the binary
+# Resolve the binary. Lookup order matches PLIST_SRC:
+#   1. --binary                              (explicit override)
+#   2. ${SCRIPT_DIR}/defenseclaw-gateway     (standalone bundle)
+#   3. ${REPO_ROOT}/defenseclaw-gateway      (dev tree)
+#   4. `go build` from ${REPO_ROOT}/cmd/defenseclaw  (dev-tree fallback)
 if [[ -z "${BINARY_SRC}" ]]; then
-  BINARY_SRC="${REPO_ROOT}/defenseclaw-gateway"
+  if [[ -x "${SCRIPT_DIR}/defenseclaw-gateway" ]]; then
+    BINARY_SRC="${SCRIPT_DIR}/defenseclaw-gateway"
+    SKIP_BUILD="true"
+  elif [[ -x "${REPO_ROOT}/defenseclaw-gateway" ]]; then
+    BINARY_SRC="${REPO_ROOT}/defenseclaw-gateway"
+  else
+    BINARY_SRC="${REPO_ROOT}/defenseclaw-gateway"
+  fi
 fi
 if [[ "${SKIP_BUILD}" != "true" && ! -x "${BINARY_SRC}" ]]; then
+  if [[ ! -d "${REPO_ROOT}/cmd/defenseclaw" ]]; then
+    die "binary not found at ${BINARY_SRC} and no repo tree at ${REPO_ROOT}/cmd/defenseclaw to build from — ship the gateway binary next to install.sh, or pass --binary PATH"
+  fi
   command -v go >/dev/null 2>&1 || die "go not in PATH; install Go or pass --binary"
   log "building gateway from ${REPO_ROOT}/cmd/defenseclaw"
   ( cd "${REPO_ROOT}" && go build -o defenseclaw-gateway ./cmd/defenseclaw )

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -57,6 +57,12 @@ PLIST_DST="/Library/LaunchDaemons/com.defenseclaw.gateway.plist"
 LAUNCHD_LABEL="com.defenseclaw.gateway"
 GATEWAY_BIN="${INSTALL_PREFIX}/bin/defenseclaw-gateway"
 
+# macOS convention is a hidden system user prefixed with an underscore.
+# We create this if it doesn't exist. Admins can override via
+# --service-user; the plist we ship gets rewritten to match.
+SERVICE_USER="_defenseclaw"
+SERVICE_GROUP="_defenseclaw"
+
 TARGET_USER=""
 AGENT_VERSION=""
 
@@ -65,6 +71,47 @@ AGENT_VERSION=""
 log()  { printf '[install] %s\n' "$*"; }
 warn() { printf '[install] WARN: %s\n' "$*" >&2; }
 die()  { printf '[install] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# find_free_system_uid — returns an unused UID in the System range so we
+# don't collide with an admin's existing service user. macOS reserves
+# < 500 for the OS; we scan 400..499 and pick the first free slot.
+find_free_system_uid() {
+  local candidate
+  for candidate in $(seq 400 499); do
+    if ! dscl . -search /Users UniqueID "${candidate}" 2>/dev/null | grep -q .; then
+      printf '%s' "${candidate}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# ensure_service_user NAME — idempotently creates a hidden macOS system
+# user + group so the LaunchDaemon has a real principal to drop into.
+# No-op when the user already exists. Uses the same convention as
+# Apple's own service users (_ prefix, hidden, /var/empty home,
+# /usr/bin/false shell).
+ensure_service_user() {
+  local name="$1"
+  if dscl . -read "/Users/${name}" >/dev/null 2>&1; then
+    log "  service user ${name} already exists"
+    return 0
+  fi
+  local uid
+  uid="$(find_free_system_uid)" || die "no free UID in 400..499 for service user ${name}"
+  log "  creating service user ${name} (uid=${uid})"
+  # Group first so the user's PrimaryGroupID resolves at create time.
+  dscl . -create "/Groups/${name}"           || die "create group ${name} failed"
+  dscl . -create "/Groups/${name}" PrimaryGroupID "${uid}" || die "set group ${name} gid failed"
+  dscl . -create "/Users/${name}"            || die "create user ${name} failed"
+  dscl . -create "/Users/${name}" UserShell /usr/bin/false
+  dscl . -create "/Users/${name}" RealName  "DefenseClaw Service"
+  dscl . -create "/Users/${name}" UniqueID  "${uid}"
+  dscl . -create "/Users/${name}" PrimaryGroupID "${uid}"
+  dscl . -create "/Users/${name}" NFSHomeDirectory /var/empty
+  # IsHidden keeps the user out of the login window and account list.
+  dscl . -create "/Users/${name}" IsHidden 1
+}
 
 # shellcheck source=lib/installer_lib.sh
 . "${SCRIPT_DIR}/lib/installer_lib.sh"
@@ -83,6 +130,8 @@ Gateway options:
   --disable-redaction       Disable redaction in audit/sinks (default: on)
   --binary PATH             Use prebuilt binary (default: alongside install.sh)
   --plist PATH              Use this LaunchDaemon plist (default: alongside install.sh)
+  --service-user NAME       macOS service user for the daemon (default: _defenseclaw).
+                            Created via dscl if missing. Also used as the group.
   --skip-build              Reuse an existing gateway binary (no rebuild)
   --skip-launchd            Install files but don't bootstrap/enable launchd
 
@@ -110,6 +159,7 @@ while [[ $# -gt 0 ]]; do
     --disable-redaction|--no-redact) DISABLE_REDACTION="true"; shift;;
     --binary)           BINARY_SRC="${2:?}"; SKIP_BUILD="true"; shift 2;;
     --plist)            PLIST_SRC="${2:?}"; shift 2;;
+    --service-user)     SERVICE_USER="${2:?}"; SERVICE_GROUP="${2:?}"; shift 2;;
     --skip-build)       SKIP_BUILD="true"; shift;;
     --skip-launchd)     SKIP_LAUNCHD="true"; shift;;
     --user)             TARGET_USER="${2:?}"; shift 2;;
@@ -219,8 +269,29 @@ render_config "${MODE}" "${PRIMARY_CONNECTOR}" "${API_PORT}" "${DISABLE_REDACTIO
 chown root:wheel "${CONFIG_PATH}"
 chmod 0640 "${CONFIG_PATH}"
 
+log "ensuring service user ${SERVICE_USER}"
+ensure_service_user "${SERVICE_USER}"
+
+log "chowning runtime dirs to ${SERVICE_USER}:${SERVICE_GROUP}"
+# Config stays root-owned (managed_enterprise trust check requires it),
+# but runtime state (audit DB, tokens, guardian state, logs) is owned
+# by the service user so the daemon can write to it.
+chown -R "${SERVICE_USER}:${SERVICE_GROUP}" "${SUPPORT_DIR}" "${LOGS_DIR}"
+# Re-tighten config ownership: the recursive chown above walked into
+# it, so put it back to root:wheel 0640.
+chown root:wheel "${CONFIG_PATH}"
+chmod 0640 "${CONFIG_PATH}"
+
 log "installing LaunchDaemon plist -> ${PLIST_DST}"
 install -o root -g wheel -m 0644 "${PLIST_SRC}" "${PLIST_DST}"
+
+# Rewrite the plist's UserName / GroupName to match the actual service
+# user we ensured above. plutil is on every macOS install.
+log "wiring plist to service user ${SERVICE_USER}"
+/usr/bin/plutil -replace UserName  -string "${SERVICE_USER}"  "${PLIST_DST}" \
+  || die "failed to set UserName in ${PLIST_DST}"
+/usr/bin/plutil -replace GroupName -string "${SERVICE_GROUP}" "${PLIST_DST}" \
+  || die "failed to set GroupName in ${PLIST_DST}"
 
 if [[ "${SKIP_LAUNCHD}" == "true" ]]; then
   log "skipping launchctl bootstrap (--skip-launchd)"

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -25,6 +25,11 @@ parse_connectors() {
   if [[ -z "${raw}" ]]; then
     return 1
   fi
+  # Reject leading/trailing/consecutive commas explicitly; `read -ra`
+  # would silently drop a bare trailing empty field.
+  case "${raw}" in
+    ,*|*,|*,,*) return 1;;
+  esac
   local -a out=()
   local IFS=','
   read -ra out <<< "${raw}"
@@ -37,6 +42,12 @@ parse_connectors() {
   for c in "${out[@]}"; do
     c="$(printf '%s' "${c}" | tr '[:upper:]' '[:lower:]' | awk '{$1=$1};1')"
     if [[ -z "${c}" ]]; then
+      return 1
+    fi
+    # Restrict to a YAML-safe key charset. Anything else would be
+    # rendered raw into config.yaml where it could break the parser
+    # or, worse, inject unrelated keys.
+    if [[ ! "${c}" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
       return 1
     fi
     printf '%s\n' "${c}"
@@ -66,38 +77,62 @@ home_perms_ok() {
 # ---- agent version discovery -------------------------------------------
 
 # discover_agent_version CONNECTOR HOME -> echoes the agent version or "".
-# Reads HOME-relative files; never executes installed agents under sudo.
-discover_agent_version() {
-  local connector="$1"
-  local home="$2"
-  case "${connector}" in
-    codex)
-      if command -v codex >/dev/null 2>&1; then
-        codex --version 2>/dev/null | head -1 || true
-      fi
-      ;;
-    claudecode)
-      if command -v claude >/dev/null 2>&1; then
-        local v
-        v="$(claude --version 2>/dev/null | head -1 || true)"
-        if [[ -n "${v}" ]]; then echo "${v}"; return; fi
-      fi
-      local ext_pkg
-      for ext_pkg in \
-        "${home}"/.cursor/extensions/anthropic.claude-code-*/package.json \
-        "${home}"/.vscode/extensions/anthropic.claude-code-*/package.json; do
-        [[ -f "${ext_pkg}" ]] || continue
-        /usr/bin/python3 -c '
+#
+# Metadata-only: reads files under HOME or under signed system app bundles
+# and never executes user-installed agent binaries. install.sh runs as root,
+# so invoking $PATH-resolved `codex` / `claude` / etc. would be a
+# privilege-escalation surface — the caller must pass --agent-version
+# explicitly for connectors that don't ship a stable metadata file.
+_read_json_version() {
+  local path="$1"
+  local py
+  py="$(command -v python3 || echo /usr/bin/python3)"
+  "${py}" -c '
 import json, sys
 try:
   with open(sys.argv[1]) as f:
     print(json.load(f).get("version",""))
 except Exception:
   pass
-' "${ext_pkg}" 2>/dev/null && return
+' "${path}" 2>/dev/null
+}
+
+discover_agent_version() {
+  local connector="$1"
+  local home="$2"
+  case "${connector}" in
+    codex)
+      # Codex-cli is distributed via npm. If a user-writable global
+      # install exposes a package.json, read it. We deliberately do NOT
+      # exec `codex --version` because install.sh calls this as root.
+      local pkg
+      for pkg in \
+        "${home}"/.npm-global/lib/node_modules/@openai/codex/package.json \
+        /usr/local/lib/node_modules/@openai/codex/package.json \
+        /opt/homebrew/lib/node_modules/@openai/codex/package.json; do
+        [[ -f "${pkg}" ]] || continue
+        local v; v="$(_read_json_version "${pkg}")"
+        if [[ -n "${v}" ]]; then echo "${v}"; return; fi
+      done
+      ;;
+    claudecode)
+      # Claude Code ships both as a standalone npm CLI (has a
+      # package.json we can read) and as a Cursor / VS Code extension.
+      local pkg
+      for pkg in \
+        "${home}"/.npm-global/lib/node_modules/@anthropic-ai/claude-code/package.json \
+        /usr/local/lib/node_modules/@anthropic-ai/claude-code/package.json \
+        /opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/package.json \
+        "${home}"/.cursor/extensions/anthropic.claude-code-*/package.json \
+        "${home}"/.vscode/extensions/anthropic.claude-code-*/package.json; do
+        [[ -f "${pkg}" ]] || continue
+        local v; v="$(_read_json_version "${pkg}")"
+        if [[ -n "${v}" ]]; then echo "${v}"; return; fi
       done
       ;;
     cursor)
+      # Cursor.app is a signed macOS bundle; read the Info.plist rather
+      # than exec'ing the binary. PlistBuddy is an Apple system tool.
       if [[ -f /Applications/Cursor.app/Contents/Info.plist ]]; then
         /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" \
           /Applications/Cursor.app/Contents/Info.plist 2>/dev/null || true

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -218,6 +218,13 @@ prepare_userspace_for() {
 # render_config MODE PRIMARY API_PORT DISABLE_REDACTION SUPPORT_DIR CONN... -> stdout
 # Renders the full config.yaml. Pure stdout, no file writes.
 # Extra args after SUPPORT_DIR are the full connector list (primary + others).
+#
+# SUPPORT_DIR holds config.yaml at its root (root:wheel 0640) — the
+# managed_enterprise trust check walks every ancestor and refuses group-
+# or other-writable dirs, so SUPPORT_DIR itself must be root-owned 0750.
+# Runtime state (audit DB, tokens, guardian state) lives in
+# ${SUPPORT_DIR}/runtime which is chown'd to the service user during
+# install. data_dir/audit_db point at that runtime subdir.
 render_config() {
   local mode="$1"
   local primary="$2"
@@ -226,14 +233,15 @@ render_config() {
   local support_dir="$5"
   shift 5
   local -a connectors=("$@")
+  local runtime_dir="${support_dir}/runtime"
 
   cat <<EOF
 config_version: 6
 deployment_mode: managed_enterprise
 
-data_dir: "${support_dir}"
-audit_db: "${support_dir}/audit.db"
-judge_bodies_db: "${support_dir}/judge_bodies.db"
+data_dir: "${runtime_dir}"
+audit_db: "${runtime_dir}/audit.db"
+judge_bodies_db: "${runtime_dir}/judge_bodies.db"
 
 gateway:
   api_bind: 127.0.0.1

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -102,9 +102,13 @@ discover_agent_version() {
   local home="$2"
   case "${connector}" in
     codex)
-      # Codex-cli is distributed via npm. If a user-writable global
-      # install exposes a package.json, read it. We deliberately do NOT
-      # exec `codex --version` because install.sh calls this as root.
+      # Codex-cli is a Rust binary, not npm. We probe metadata paths
+      # first (safe, no exec), then fall back to `codex --version`
+      # exec'd AS THE TARGET USER via `sudo -u`. Running the user's
+      # own codex binary as their identity is not a privilege
+      # escalation — install.sh's outer sudo drops privileges for this
+      # subprocess, matching the security posture of the hook
+      # guardian's connector.Setup call.
       local pkg
       for pkg in \
         "${home}"/.npm-global/lib/node_modules/@openai/codex/package.json \
@@ -114,6 +118,25 @@ discover_agent_version() {
         local v; v="$(_read_json_version "${pkg}")"
         if [[ -n "${v}" ]]; then echo "${v}"; return; fi
       done
+      # Homebrew cask keeps the binary under Caskroom with a version
+      # in the path itself: /opt/homebrew/Caskroom/codex/<version>/...
+      local caskroom
+      for caskroom in /opt/homebrew/Caskroom/codex /usr/local/Caskroom/codex; do
+        if [[ -d "${caskroom}" ]]; then
+          local ver
+          ver="$(ls -1 "${caskroom}" 2>/dev/null | grep -E '^[0-9]+\.[0-9]+' | sort -V | tail -1)"
+          if [[ -n "${ver}" ]]; then echo "${ver}"; return; fi
+        fi
+      done
+      # Last resort: exec codex --version as the target user (not as
+      # root). Requires TARGET_USER to be known to the caller.
+      if [[ -n "${DEFENSECLAW_TARGET_USER:-}" ]] && command -v codex >/dev/null 2>&1; then
+        local vraw
+        vraw="$(sudo -n -u "${DEFENSECLAW_TARGET_USER}" codex --version 2>/dev/null | head -1 || true)"
+        # Codex prints "codex-cli X.Y.Z"; take just the version token.
+        vraw="$(printf '%s' "${vraw}" | awk '{for(i=NF;i>=1;i--) if ($i ~ /^[0-9]+\.[0-9]+/) {print $i; exit}}')"
+        if [[ -n "${vraw}" ]]; then echo "${vraw}"; return; fi
+      fi
       ;;
     claudecode)
       # Claude Code ships both as a standalone npm CLI (has a

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -113,12 +113,28 @@ except Exception:
 # the target user (the test harness) or as root with a follow-up chown
 # (the real installer). They use install(8)/chmod for parents and writes.
 
+ensure_safe_userspace_path() {
+  local dir="$1"
+  local cfg="$2"
+  if [[ -L "${dir}" || -L "${cfg}" ]]; then
+    return 1
+  fi
+  if [[ -e "${dir}" && ! -d "${dir}" ]]; then
+    return 1
+  fi
+  mkdir -p "${dir}" || return 1
+  if [[ -L "${dir}" || -L "${cfg}" ]]; then
+    return 1
+  fi
+}
+
 prepare_codex_userspace() {
   local home="$1"
+  local dir="${home}/.codex"
   local cfg="${home}/.codex/config.toml"
+  ensure_safe_userspace_path "${dir}" "${cfg}" || return 1
   if [[ ! -f "${cfg}" ]]; then
-    mkdir -p "${home}/.codex"
-    chmod 0700 "${home}/.codex"
+    chmod 0700 "${dir}"
     cat > "${cfg}" <<'TOML'
 # Created by DefenseClaw installer so the enterprise hook guardian can
 # repair this file. Edit freely; DefenseClaw only owns [hooks], [otel],
@@ -130,10 +146,11 @@ TOML
 
 prepare_claudecode_userspace() {
   local home="$1"
+  local dir="${home}/.claude"
   local cfg="${home}/.claude/settings.json"
+  ensure_safe_userspace_path "${dir}" "${cfg}" || return 1
   if [[ ! -f "${cfg}" ]]; then
-    mkdir -p "${home}/.claude"
-    chmod 0700 "${home}/.claude"
+    chmod 0700 "${dir}"
     printf '{}\n' > "${cfg}"
     chmod 0600 "${cfg}"
   fi
@@ -141,10 +158,11 @@ prepare_claudecode_userspace() {
 
 prepare_cursor_userspace() {
   local home="$1"
+  local dir="${home}/.cursor"
   local cfg="${home}/.cursor/hooks.json"
+  ensure_safe_userspace_path "${dir}" "${cfg}" || return 1
   if [[ ! -f "${cfg}" ]]; then
-    mkdir -p "${home}/.cursor"
-    chmod 0700 "${home}/.cursor"
+    chmod 0700 "${dir}"
     printf '{"version":1,"hooks":{}}\n' > "${cfg}"
     chmod 0600 "${cfg}"
   fi

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+#
+# DefenseClaw macOS installer — pure-function helpers.
+#
+# This library contains the side-effect-free pieces of install.sh so they
+# can be unit-tested without touching /Library, sudo, or the LaunchDaemon.
+# install.sh sources this file. tests/ also sources it.
+#
+# Functions in this file MUST NOT:
+#   - call sudo, chown, chmod, install(8), launchctl
+#   - write outside paths the caller passed in
+#   - depend on globals other than what the caller exports
+#
+# They DO:
+#   - parse strings, render YAML, run pure file I/O against caller-owned
+#     paths (e.g. a tmpdir under /tmp/dctest-XXXX).
+
+# ---- connector list parsing --------------------------------------------
+
+# parse_connectors LIST -> echoes one normalized connector per line.
+# Splits on comma, trims whitespace, lowercases. Empty entries are an
+# error (caller's job to die() on non-zero return).
+parse_connectors() {
+  local raw="$1"
+  if [[ -z "${raw}" ]]; then
+    return 1
+  fi
+  local -a out=()
+  local IFS=','
+  read -ra out <<< "${raw}"
+  local c
+  # Guard for bash 3.2: ${array[@]} on an empty array under `set -u`
+  # would trip an "unbound variable" error.
+  if [[ ${#out[@]} -eq 0 ]]; then
+    return 1
+  fi
+  for c in "${out[@]}"; do
+    c="$(printf '%s' "${c}" | tr '[:upper:]' '[:lower:]' | awk '{$1=$1};1')"
+    if [[ -z "${c}" ]]; then
+      return 1
+    fi
+    printf '%s\n' "${c}"
+  done
+}
+
+# is_supported_connector NAME -> exit 0 if name is auto-wireable.
+is_supported_connector() {
+  case "$1" in
+    codex|claudecode|cursor) return 0;;
+    *) return 1;;
+  esac
+}
+
+# ---- home perms ---------------------------------------------------------
+
+# home_perms_ok PATH -> exit 0 iff path has no group/other write bits.
+# Mirrors validateUserHome() in internal/enterprisehooks/installer.go.
+home_perms_ok() {
+  local home="$1"
+  local mode
+  mode="$(stat -f '%Lp' "${home}" 2>/dev/null || stat -c '%a' "${home}" 2>/dev/null || echo "")"
+  [[ -z "${mode}" ]] && return 0
+  (( (8#${mode} & 8#022) == 0 ))
+}
+
+# ---- agent version discovery -------------------------------------------
+
+# discover_agent_version CONNECTOR HOME -> echoes the agent version or "".
+# Reads HOME-relative files; never executes installed agents under sudo.
+discover_agent_version() {
+  local connector="$1"
+  local home="$2"
+  case "${connector}" in
+    codex)
+      if command -v codex >/dev/null 2>&1; then
+        codex --version 2>/dev/null | head -1 || true
+      fi
+      ;;
+    claudecode)
+      if command -v claude >/dev/null 2>&1; then
+        local v
+        v="$(claude --version 2>/dev/null | head -1 || true)"
+        if [[ -n "${v}" ]]; then echo "${v}"; return; fi
+      fi
+      local ext_pkg
+      for ext_pkg in \
+        "${home}"/.cursor/extensions/anthropic.claude-code-*/package.json \
+        "${home}"/.vscode/extensions/anthropic.claude-code-*/package.json; do
+        [[ -f "${ext_pkg}" ]] || continue
+        /usr/bin/python3 -c '
+import json, sys
+try:
+  with open(sys.argv[1]) as f:
+    print(json.load(f).get("version",""))
+except Exception:
+  pass
+' "${ext_pkg}" 2>/dev/null && return
+      done
+      ;;
+    cursor)
+      if [[ -f /Applications/Cursor.app/Contents/Info.plist ]]; then
+        /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" \
+          /Applications/Cursor.app/Contents/Info.plist 2>/dev/null || true
+      fi
+      ;;
+  esac
+}
+
+# ---- per-connector userspace prep --------------------------------------
+#
+# Each prepare_* writes the connector's native hook config file under HOME
+# if missing. They do NOT chown — the caller is expected to be running as
+# the target user (the test harness) or as root with a follow-up chown
+# (the real installer). They use install(8)/chmod for parents and writes.
+
+prepare_codex_userspace() {
+  local home="$1"
+  local cfg="${home}/.codex/config.toml"
+  if [[ ! -f "${cfg}" ]]; then
+    mkdir -p "${home}/.codex"
+    chmod 0700 "${home}/.codex"
+    cat > "${cfg}" <<'TOML'
+# Created by DefenseClaw installer so the enterprise hook guardian can
+# repair this file. Edit freely; DefenseClaw only owns [hooks], [otel],
+# and the top-level notify entries.
+TOML
+    chmod 0600 "${cfg}"
+  fi
+}
+
+prepare_claudecode_userspace() {
+  local home="$1"
+  local cfg="${home}/.claude/settings.json"
+  if [[ ! -f "${cfg}" ]]; then
+    mkdir -p "${home}/.claude"
+    chmod 0700 "${home}/.claude"
+    printf '{}\n' > "${cfg}"
+    chmod 0600 "${cfg}"
+  fi
+}
+
+prepare_cursor_userspace() {
+  local home="$1"
+  local cfg="${home}/.cursor/hooks.json"
+  if [[ ! -f "${cfg}" ]]; then
+    mkdir -p "${home}/.cursor"
+    chmod 0700 "${home}/.cursor"
+    printf '{"version":1,"hooks":{}}\n' > "${cfg}"
+    chmod 0600 "${cfg}"
+  fi
+}
+
+prepare_userspace_for() {
+  local connector="$1"
+  local home="$2"
+  case "${connector}" in
+    codex)      prepare_codex_userspace      "${home}";;
+    claudecode) prepare_claudecode_userspace "${home}";;
+    cursor)     prepare_cursor_userspace     "${home}";;
+  esac
+}
+
+# ---- config rendering --------------------------------------------------
+
+# render_config MODE PRIMARY API_PORT DISABLE_REDACTION SUPPORT_DIR CONN... -> stdout
+# Renders the full config.yaml. Pure stdout, no file writes.
+# Extra args after SUPPORT_DIR are the full connector list (primary + others).
+render_config() {
+  local mode="$1"
+  local primary="$2"
+  local api_port="$3"
+  local disable_redaction="$4"
+  local support_dir="$5"
+  shift 5
+  local -a connectors=("$@")
+
+  cat <<EOF
+config_version: 6
+deployment_mode: managed_enterprise
+
+data_dir: "${support_dir}"
+audit_db: "${support_dir}/audit.db"
+judge_bodies_db: "${support_dir}/judge_bodies.db"
+
+gateway:
+  api_bind: 127.0.0.1
+  api_port: ${api_port}
+
+privacy:
+  disable_redaction: ${disable_redaction}
+
+guardrail:
+  enabled: true
+  mode: ${mode}
+  scanner_mode: both
+  connector: ${primary}
+EOF
+
+  if (( ${#connectors[@]} > 1 )); then
+    echo "  connectors:"
+    local c
+    for c in "${connectors[@]}"; do
+      cat <<EOF
+    ${c}:
+      enabled: true
+      mode: ${mode}
+EOF
+    done
+  fi
+
+  cat <<EOF
+
+asset_policy:
+  enabled: true
+  mode: ${mode}
+  mcp:
+    default: deny
+    registry_required: false
+  skill:
+    default: allow
+  plugin:
+    default: allow
+
+application_protection:
+  enabled: false
+EOF
+}

--- a/packaging/macos/lib/scrub_agent_configs.py
+++ b/packaging/macos/lib/scrub_agent_configs.py
@@ -81,12 +81,32 @@ def scrub_cursor(path: str, markers: tuple[str, ...]) -> tuple[bool, str | None]
     return True, None
 
 
+# DefenseClaw-owned keys in Claude Code's settings.json env block.
+# Kept in sync with claudeCodeOtelEnvKeys in
+# internal/gateway/connector/claudecode.go.
+CLAUDE_MANAGED_ENV_KEYS = frozenset({
+    "CLAUDE_CODE_ENABLE_TELEMETRY",
+    "DEFENSECLAW_FAIL_MODE",
+    "OTEL_METRICS_EXPORTER",
+    "OTEL_LOGS_EXPORTER",
+    "OTEL_EXPORTER_OTLP_PROTOCOL",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_HEADERS",
+    "OTEL_LOG_USER_PROMPTS",
+    "OTEL_RESOURCE_ATTRIBUTES",
+    "OTEL_SERVICE_NAME",
+})
+
+
 def scrub_claudecode(path: str, markers: tuple[str, ...]) -> tuple[bool, str | None]:
     """Drop DefenseClaw entries from ~/.claude/settings.json.
 
     Shape: { "hooks": { "<event>": [ {"hooks":[{entry}, ...]}, ... ] } }
     Nested one level deeper than Cursor's; otherwise the same idea.
-    Also strips a top-level "env" block that's DefenseClaw-only.
+    Also strips DefenseClaw-owned keys from the top-level "env" block
+    (kept in sync with claudeCodeOtelEnvKeys in the Go connector), and
+    strips any additional env value that references our data-dir markers.
+    Non-DefenseClaw env entries are preserved.
     """
     with open(path, "r", encoding="utf-8") as f:
         cfg = json.load(f)
@@ -115,6 +135,16 @@ def scrub_claudecode(path: str, markers: tuple[str, ...]) -> tuple[bool, str | N
                 hooks[event] = kept_groups
             else:
                 del hooks[event]
+    env = cfg.get("env")
+    if isinstance(env, dict):
+        for key in list(env.keys()):
+            if key in CLAUDE_MANAGED_ENV_KEYS:
+                del env[key]
+                continue
+            if looks_owned(env[key], markers):
+                del env[key]
+        if not env:
+            del cfg["env"]
     with open(path, "w", encoding="utf-8") as f:
         json.dump(cfg, f, indent=2, sort_keys=True)
         f.write("\n")
@@ -141,6 +171,11 @@ def scrub_claudecode(path: str, markers: tuple[str, ...]) -> tuple[bool, str | N
 
 
 TOML_TOP_LEVEL_RE = re.compile(r"^\[([^\[\].\s]+)\]\s*$")
+# Any TOML table header: simple `[name]`, dotted `[projects.foo]`, or
+# array-of-tables `[[array.of.tables]]`. Used to bound the "section
+# references DefenseClaw" scan so a matched marker inside `[hooks]`
+# can't accidentally swallow the next unrelated section.
+TOML_TABLE_HEADER_RE = re.compile(r"^\s*\[\[?[^\[\]]+\]\]?\s*$")
 
 
 def scrub_codex(path: str, markers: tuple[str, ...]) -> tuple[bool, str | None]:
@@ -172,7 +207,12 @@ def scrub_codex(path: str, markers: tuple[str, ...]) -> tuple[bool, str | None]:
         while j < n:
             line = lines[j]
             stripped = line.strip()
-            if stripped.startswith("[") and TOML_TOP_LEVEL_RE.match(stripped):
+            # Stop at ANY table header — simple, dotted, or array-of-tables.
+            # A simple `[name]` regex would let a dotted `[projects.foo]`
+            # slip through and be considered part of the [hooks] body,
+            # which would then be deleted if [hooks] happened to reference
+            # DefenseClaw. That would delete unrelated user state.
+            if TOML_TABLE_HEADER_RE.match(stripped):
                 break
             if any(m in line for m in markers):
                 matched = True

--- a/packaging/macos/lib/scrub_agent_configs.py
+++ b/packaging/macos/lib/scrub_agent_configs.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+Remove DefenseClaw-owned entries from a user's native agent hook config
+file. Intended to be invoked by the macOS uninstaller's --purge path so
+the agent doesn't keep calling a deleted hook script and fail-close every
+subsequent tool call.
+
+Stdlib-only by design (macOS system Python 3.9 has no tomllib). Targets
+the file shapes DefenseClaw's connectors write:
+
+  ~/.cursor/hooks.json     — JSON flat-hooks shape
+  ~/.claude/settings.json  — JSON nested {hooks: {event: [{hooks:[...]}]}}
+  ~/.codex/config.toml     — TOML; DefenseClaw owns [hooks], [otel],
+                             and the top-level notify array
+
+Exit codes:
+  0   — file successfully scrubbed (or no changes were needed)
+  2   — file missing (nothing to do)
+  3   — unsupported connector
+  4   — file unreadable / parse failure (left untouched)
+
+Usage:
+  scrub_agent_configs.py CONNECTOR FILE [DATADIR_PATTERN]
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+
+DEFAULT_MARKERS = (
+    "/.defenseclaw/hooks/",
+    "/defenseclaw/hooks/",
+    "defenseclaw-managed-hook",
+    "notify-bridge.sh",
+)
+
+
+def looks_owned(value: object, markers: tuple[str, ...]) -> bool:
+    """Best-effort recursive check: does any string in the structure
+    contain one of our markers? Used for JSON shapes."""
+    if isinstance(value, str):
+        return any(m in value for m in markers)
+    if isinstance(value, list):
+        return any(looks_owned(v, markers) for v in value)
+    if isinstance(value, dict):
+        return any(looks_owned(v, markers) for v in value.values())
+    return False
+
+
+# ---------- JSON: Cursor + Claude Code -----------------------------------
+
+
+def scrub_cursor(path: str, markers: tuple[str, ...]) -> tuple[bool, str | None]:
+    """Drop DefenseClaw entries from ~/.cursor/hooks.json.
+
+    Shape: { "version": 1, "hooks": { "<event>": [ {entry}, ... ] } }
+    Each entry has "command" pointing at the hook script. We drop any
+    entry whose command matches a marker. Events with no entries left
+    are removed too, so we don't leave empty arrays floating around.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        cfg = json.load(f)
+    if not isinstance(cfg, dict):
+        return False, "not a JSON object"
+    hooks = cfg.get("hooks")
+    if isinstance(hooks, dict):
+        for event, entries in list(hooks.items()):
+            if not isinstance(entries, list):
+                continue
+            kept = [e for e in entries if not looks_owned(e, markers)]
+            if not kept:
+                del hooks[event]
+            else:
+                hooks[event] = kept
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2, sort_keys=True)
+        f.write("\n")
+    return True, None
+
+
+def scrub_claudecode(path: str, markers: tuple[str, ...]) -> tuple[bool, str | None]:
+    """Drop DefenseClaw entries from ~/.claude/settings.json.
+
+    Shape: { "hooks": { "<event>": [ {"hooks":[{entry}, ...]}, ... ] } }
+    Nested one level deeper than Cursor's; otherwise the same idea.
+    Also strips a top-level "env" block that's DefenseClaw-only.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        cfg = json.load(f)
+    if not isinstance(cfg, dict):
+        return False, "not a JSON object"
+    hooks = cfg.get("hooks")
+    if isinstance(hooks, dict):
+        for event, groups in list(hooks.items()):
+            if not isinstance(groups, list):
+                continue
+            kept_groups: list = []
+            for grp in groups:
+                if not isinstance(grp, dict):
+                    kept_groups.append(grp)
+                    continue
+                inner = grp.get("hooks")
+                if not isinstance(inner, list):
+                    if not looks_owned(grp, markers):
+                        kept_groups.append(grp)
+                    continue
+                kept_inner = [h for h in inner if not looks_owned(h, markers)]
+                if kept_inner:
+                    grp["hooks"] = kept_inner
+                    kept_groups.append(grp)
+            if kept_groups:
+                hooks[event] = kept_groups
+            else:
+                del hooks[event]
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2, sort_keys=True)
+        f.write("\n")
+    return True, None
+
+
+# ---------- TOML: Codex --------------------------------------------------
+#
+# Codex's writer marshals a Go map[string]interface{} so it produces a
+# canonical TOML shape. DefenseClaw owns three top-level entries
+# wholesale (see internal/gateway/connector/codex.go):
+#   - [hooks] table        — every value references our script path
+#   - [otel] table         — endpoint points at the loopback gateway
+#   - notify = [...] array — invokes our notify-bridge.sh
+#
+# We deliberately scrub these wholesale rather than parsing TOML, because:
+#   1. stdlib doesn't have tomllib on Python < 3.11 and we cannot rely
+#      on tomli being installed on the admin's machine.
+#   2. Codex's writer overwrites these three top-level keys on every
+#      install, so deleting them entirely matches the install contract.
+#
+# Anything outside those three keys is left alone (model preferences,
+# project trust list, personality, etc.).
+
+
+TOML_TOP_LEVEL_RE = re.compile(r"^\[([^\[\].\s]+)\]\s*$")
+
+
+def scrub_codex(path: str, markers: tuple[str, ...]) -> tuple[bool, str | None]:
+    """Remove [hooks], [otel] tables and the `notify` array from a
+    Codex config.toml when their contents reference DefenseClaw.
+
+    Operates on lines; preserves everything else verbatim. Multi-line
+    table arrays ([[hooks.event]] style) aren't used by Codex's writer,
+    so we don't need to handle them — but if someone introduces them
+    we just won't touch their content (safe failure mode)."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+    except OSError as e:
+        return False, str(e)
+
+    out: list[str] = []
+    i = 0
+    n = len(lines)
+    changed = False
+
+    def section_references_dc(start: int) -> tuple[bool, int]:
+        """Look ahead from `start` (line right after a [section] header)
+        until the next top-level section or EOF. Returns (matched, end_idx)
+        where end_idx is the line index where the next section starts
+        (or n)."""
+        j = start
+        matched = False
+        while j < n:
+            line = lines[j]
+            stripped = line.strip()
+            if stripped.startswith("[") and TOML_TOP_LEVEL_RE.match(stripped):
+                break
+            if any(m in line for m in markers):
+                matched = True
+            j += 1
+        return matched, j
+
+    while i < n:
+        line = lines[i]
+        stripped = line.strip()
+
+        # Top-level [hooks] or [otel] table?
+        m = TOML_TOP_LEVEL_RE.match(stripped)
+        if m and m.group(1) in ("hooks", "otel"):
+            matched, end = section_references_dc(i + 1)
+            if matched:
+                # Drop the header AND every line up to the next section.
+                changed = True
+                i = end
+                # Also eat one trailing blank line if present, to keep
+                # the file tidy.
+                while i < n and lines[i].strip() == "":
+                    i += 1
+                    break
+                continue
+            else:
+                out.append(line)
+                i += 1
+                continue
+
+        # Top-level `notify = [...]` (single line or multi-line array)?
+        if re.match(r"^\s*notify\s*=", line):
+            # Single-line: notify = [...]
+            if "]" in line:
+                if any(m in line for m in markers):
+                    changed = True
+                    i += 1
+                    continue
+                out.append(line)
+                i += 1
+                continue
+            # Multi-line: collect until the closing bracket.
+            buf = [line]
+            j = i + 1
+            while j < n:
+                buf.append(lines[j])
+                if "]" in lines[j]:
+                    break
+                j += 1
+            joined = "".join(buf)
+            if any(m in joined for m in markers):
+                changed = True
+                i = j + 1
+                continue
+            out.extend(buf)
+            i = j + 1
+            continue
+
+        out.append(line)
+        i += 1
+
+    if not changed:
+        return True, None
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.writelines(out)
+    return True, None
+
+
+# ---------- dispatch -----------------------------------------------------
+
+
+HANDLERS = {
+    "cursor":     scrub_cursor,
+    "claudecode": scrub_claudecode,
+    "codex":      scrub_codex,
+}
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print(__doc__.strip(), file=sys.stderr)
+        return 64
+    connector = argv[1]
+    path = argv[2]
+    markers = list(DEFAULT_MARKERS)
+    if len(argv) >= 4 and argv[3]:
+        markers.insert(0, argv[3])
+    markers_t = tuple(markers)
+
+    handler = HANDLERS.get(connector)
+    if handler is None:
+        print(f"unsupported connector: {connector}", file=sys.stderr)
+        return 3
+    if not os.path.exists(path):
+        return 2
+    try:
+        ok, err = handler(path, markers_t)
+    except (OSError, ValueError) as e:
+        print(f"scrub failed for {path}: {e}", file=sys.stderr)
+        return 4
+    if not ok:
+        print(f"scrub skipped: {err}", file=sys.stderr)
+        return 4
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/packaging/macos/tests/run_tests.sh
+++ b/packaging/macos/tests/run_tests.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# Pure-bash unit test runner for the macOS installer scripts.
+#
+# Usage:
+#   packaging/macos/tests/run_tests.sh           # run all tests
+#   packaging/macos/tests/run_tests.sh -v        # verbose (show every assert)
+#   packaging/macos/tests/run_tests.sh test_*.sh # run a subset
+#
+# Each test file is sourced inside its own subshell with helpers from
+# this script available. Failures print file:line + the failing assert.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${PKG_DIR}/../.." && pwd)"
+
+VERBOSE="false"
+declare -a FILES=()
+for arg in "$@"; do
+  case "${arg}" in
+    -v|--verbose) VERBOSE="true";;
+    *)            FILES+=("${arg}");;
+  esac
+done
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  while IFS= read -r f; do
+    FILES+=("${f}")
+  done < <(find "${SCRIPT_DIR}" -maxdepth 1 -name 'test_*.sh' | sort)
+fi
+
+# ---- export paths for tests --------------------------------------------
+
+export PKG_DIR REPO_ROOT
+
+# ---- per-test working dir ----------------------------------------------
+
+TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/dctest.XXXXXX")"
+trap 'rm -rf "${TMPROOT}"' EXIT
+
+# ---- assertion helpers (sourced into each test) ------------------------
+
+TEST_FAIL_COUNT=0
+TEST_OK_COUNT=0
+CUR_TEST_FILE=""
+CUR_TEST_NAME=""
+
+_fail() {
+  local msg="$1"
+  printf 'FAIL  %s :: %s\n  at: %s\n  %s\n' \
+    "${CUR_TEST_FILE}" "${CUR_TEST_NAME}" "${BASH_SOURCE[2]}:${BASH_LINENO[1]}" "${msg}" >&2
+  TEST_FAIL_COUNT=$((TEST_FAIL_COUNT + 1))
+  return 1
+}
+
+assert_eq() {
+  local got="$1" want="$2" what="${3:-values}"
+  if [[ "${got}" != "${want}" ]]; then
+    _fail "${what} mismatch — got=$(printf %q "${got}") want=$(printf %q "${want}")"
+    return 1
+  fi
+  if [[ "${VERBOSE}" == "true" ]]; then
+    printf '  ok  %s == %q\n' "${what}" "${want}"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" what="${3:-output}"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    _fail "${what} missing substring $(printf %q "${needle}")\n  haystack head: $(printf %s "${haystack}" | head -5)"
+    return 1
+  fi
+  if [[ "${VERBOSE}" == "true" ]]; then
+    printf '  ok  %s contains %q\n' "${what}" "${needle}"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" what="${3:-output}"
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    _fail "${what} should not contain $(printf %q "${needle}")"
+    return 1
+  fi
+}
+
+assert_status() {
+  local got="$1" want="$2" what="${3:-exit status}"
+  if [[ "${got}" -ne "${want}" ]]; then
+    _fail "${what} got=${got} want=${want}"
+    return 1
+  fi
+}
+
+assert_file_exists() {
+  local path="$1"
+  if [[ ! -f "${path}" ]]; then
+    _fail "expected file to exist: ${path}"
+    return 1
+  fi
+}
+
+assert_file_mode() {
+  local path="$1" want="$2"
+  local got
+  got="$(stat -f '%Lp' "${path}" 2>/dev/null || stat -c '%a' "${path}" 2>/dev/null || echo "")"
+  if [[ "${got}" != "${want}" ]]; then
+    _fail "mode mismatch on ${path}: got=${got} want=${want}"
+    return 1
+  fi
+}
+
+# 'it NAME body...' marks a test case; the body is the next callable
+# function. We use a simpler convention here: each test file calls
+# `run_case NAME func` to invoke a named case.
+run_case() {
+  local name="$1"; shift
+  CUR_TEST_NAME="${name}"
+  if [[ "${VERBOSE}" == "true" ]]; then
+    printf 'CASE  %s :: %s\n' "${CUR_TEST_FILE}" "${name}"
+  fi
+  local before_fail=${TEST_FAIL_COUNT}
+  if "$@"; then : ; fi
+  if [[ ${TEST_FAIL_COUNT} -eq ${before_fail} ]]; then
+    TEST_OK_COUNT=$((TEST_OK_COUNT + 1))
+    if [[ "${VERBOSE}" == "true" ]]; then
+      printf '  PASS\n'
+    fi
+  fi
+}
+
+mktest_tmp() {
+  local d
+  d="$(mktemp -d "${TMPROOT}/case.XXXXXX")"
+  printf '%s' "${d}"
+}
+
+# ---- runner ------------------------------------------------------------
+
+START_TIME=$(date +%s)
+for f in "${FILES[@]}"; do
+  CUR_TEST_FILE="$(basename "${f}")"
+  if [[ "${VERBOSE}" == "true" ]]; then
+    printf '==== %s ====\n' "${CUR_TEST_FILE}"
+  fi
+  # shellcheck disable=SC1090
+  . "${f}"
+done
+
+ELAPSED=$(($(date +%s) - START_TIME))
+printf '\n----- %d passed, %d failed in %ds -----\n' \
+  "${TEST_OK_COUNT}" "${TEST_FAIL_COUNT}" "${ELAPSED}"
+
+if [[ ${TEST_FAIL_COUNT} -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/packaging/macos/tests/run_tests.sh
+++ b/packaging/macos/tests/run_tests.sh
@@ -121,7 +121,16 @@ run_case() {
     printf 'CASE  %s :: %s\n' "${CUR_TEST_FILE}" "${name}"
   fi
   local before_fail=${TEST_FAIL_COUNT}
-  if "$@"; then : ; fi
+  # Capture the case's exit status. If the function returns non-zero but
+  # never recorded a failure via _fail (typo'd name, mkdir/cd blew up,
+  # bare `if` with no `else` under `set -u`, etc.), treat that as a
+  # failure — the earlier "silently pass on non-zero" behavior masked
+  # broken tests that never actually asserted anything.
+  local rc=0
+  "$@" || rc=$?
+  if (( rc != 0 )) && (( TEST_FAIL_COUNT == before_fail )); then
+    _fail "case '${name}' exited with status ${rc} but recorded no assertion"
+  fi
   if [[ ${TEST_FAIL_COUNT} -eq ${before_fail} ]]; then
     TEST_OK_COUNT=$((TEST_OK_COUNT + 1))
     if [[ "${VERBOSE}" == "true" ]]; then

--- a/packaging/macos/tests/test_arg_parsing.sh
+++ b/packaging/macos/tests/test_arg_parsing.sh
@@ -62,8 +62,10 @@ t_install_requires_root() {
 t_uninstall_help() {
   local out
   out="$("${UNINSTALL_SH}" --help 2>&1)" || _fail "uninstall --help should exit 0"
-  assert_contains "${out}" "--purge"   "purge flag documented"
-  assert_contains "${out}" "audit DB"  "preservation note"
+  assert_contains "${out}" "--purge"                 "purge flag documented"
+  assert_contains "${out}" "audit DB"                "preservation note"
+  assert_contains "${out}" "--keep-agent-configs"    "scrub opt-out documented"
+  assert_contains "${out}" "scrub DefenseClaw"        "scrub behavior documented"
 }
 
 t_uninstall_unknown_flag() {

--- a/packaging/macos/tests/test_arg_parsing.sh
+++ b/packaging/macos/tests/test_arg_parsing.sh
@@ -64,7 +64,7 @@ t_install_help_documents_service_user() {
   local out
   out="$("${INSTALL_SH}" --help 2>&1)" || _fail "--help should exit 0"
   assert_contains "${out}" "--service-user NAME"    "service-user flag documented"
-  assert_contains "${out}" "_defenseclaw"            "default service user shown"
+  assert_contains "${out}" "default: defenseclaw"    "default service user shown"
 }
 
 t_uninstall_help_documents_service_user() {

--- a/packaging/macos/tests/test_arg_parsing.sh
+++ b/packaging/macos/tests/test_arg_parsing.sh
@@ -60,6 +60,19 @@ t_install_requires_root() {
   assert_contains "${out}" "must run as root" "explains root requirement"
 }
 
+t_install_help_documents_service_user() {
+  local out
+  out="$("${INSTALL_SH}" --help 2>&1)" || _fail "--help should exit 0"
+  assert_contains "${out}" "--service-user NAME"    "service-user flag documented"
+  assert_contains "${out}" "_defenseclaw"            "default service user shown"
+}
+
+t_uninstall_help_documents_service_user() {
+  local out
+  out="$("${UNINSTALL_SH}" --help 2>&1)" || _fail "uninstall --help should exit 0"
+  assert_contains "${out}" "--service-user NAME"    "uninstall service-user flag documented"
+}
+
 t_install_default_redaction_is_on() {
   # Parse install.sh's own defaults section directly so we're asserting
   # the actual install-time contract, not just what render_config emits
@@ -120,6 +133,8 @@ t_uninstall_requires_root() {
 }
 
 run_case "install --help"                 t_install_help
+run_case "install service-user documented" t_install_help_documents_service_user
+run_case "uninstall service-user documented" t_uninstall_help_documents_service_user
 run_case "install --mode garbage"         t_install_bad_mode_exits_nonzero
 run_case "install --bogus"                t_install_unknown_flag_exits_nonzero
 run_case "install --connector cursor,,X"  t_install_empty_connector_entry_exits_nonzero

--- a/packaging/macos/tests/test_arg_parsing.sh
+++ b/packaging/macos/tests/test_arg_parsing.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Drive install.sh's arg-parsing & preflight surface without going past
+# the root check. We invoke install.sh as a non-root user with --help
+# (exits 0 before root check) and with bad flags (exits non-zero with
+# a clear message). We do not exercise the side-effecting branches.
+INSTALL_SH="${PKG_DIR}/install.sh"
+UNINSTALL_SH="${PKG_DIR}/uninstall.sh"
+
+t_install_help() {
+  local out
+  out="$("${INSTALL_SH}" --help 2>&1)" || _fail "--help should exit 0"
+  assert_contains "${out}" "--mode {observe|action}" "mode flag in help"
+  assert_contains "${out}" "--connector LIST"        "connector flag in help"
+  assert_contains "${out}" "comma-separated"         "comma-separated note in help"
+  assert_contains "${out}" "Per-user hook wiring"    "per-user section header"
+}
+
+t_install_bad_mode_exits_nonzero() {
+  local out rc=0
+  out="$("${INSTALL_SH}" --mode garbage 2>&1)" || rc=$?
+  assert_status "${rc}" 1 "bad --mode should exit non-zero"
+  assert_contains "${out}" "must be 'observe' or 'action'" "explains valid modes"
+}
+
+t_install_unknown_flag_exits_nonzero() {
+  local out rc=0
+  out="$("${INSTALL_SH}" --bogus 2>&1)" || rc=$?
+  assert_status "${rc}" 1 "unknown flag should exit non-zero"
+  assert_contains "${out}" "unknown flag" "messages unknown flag"
+}
+
+t_install_empty_connector_entry_exits_nonzero() {
+  # `--connector cursor,,codex` should die() with the explicit message,
+  # not crash silently or proceed.
+  local out rc=0
+  out="$("${INSTALL_SH}" --connector "cursor,,codex" 2>&1)" || rc=$?
+  assert_status "${rc}" 1 "empty list entry should exit non-zero"
+  assert_contains "${out}" "empty entry" "messages empty entry"
+}
+
+t_install_warns_unsupported_connector() {
+  # Unsupported connector should NOT die, just warn. But we can't get
+  # past the root-check on a clean install. We rely on the fact that
+  # the warning is emitted BEFORE the root check.
+  local out rc=0
+  out="$("${INSTALL_SH}" --connector "geminicli" 2>&1)" || rc=$?
+  assert_contains "${out}" "is not in the auto-wire list" "warns about unsupported"
+}
+
+t_install_requires_root() {
+  # As non-root, after arg parsing the script must die on the root check.
+  if [[ $EUID -eq 0 ]]; then
+    if [[ "${VERBOSE:-false}" == "true" ]]; then printf '  skip (running as root)\n'; fi
+    return 0
+  fi
+  local out rc=0
+  out="$("${INSTALL_SH}" --connector codex 2>&1)" || rc=$?
+  assert_status "${rc}" 1 "non-root should exit non-zero"
+  assert_contains "${out}" "must run as root" "explains root requirement"
+}
+
+t_uninstall_help() {
+  local out
+  out="$("${UNINSTALL_SH}" --help 2>&1)" || _fail "uninstall --help should exit 0"
+  assert_contains "${out}" "--purge"   "purge flag documented"
+  assert_contains "${out}" "audit DB"  "preservation note"
+}
+
+t_uninstall_unknown_flag() {
+  local out rc=0
+  out="$("${UNINSTALL_SH}" --bogus 2>&1)" || rc=$?
+  assert_status "${rc}" 1 "uninstall unknown flag exits non-zero"
+}
+
+t_uninstall_requires_root() {
+  if [[ $EUID -eq 0 ]]; then
+    if [[ "${VERBOSE:-false}" == "true" ]]; then printf '  skip (running as root)\n'; fi
+    return 0
+  fi
+  local out rc=0
+  out="$("${UNINSTALL_SH}" 2>&1)" || rc=$?
+  assert_status "${rc}" 1 "uninstall non-root exits non-zero"
+  assert_contains "${out}" "must run as root" "explains root requirement"
+}
+
+run_case "install --help"                 t_install_help
+run_case "install --mode garbage"         t_install_bad_mode_exits_nonzero
+run_case "install --bogus"                t_install_unknown_flag_exits_nonzero
+run_case "install --connector cursor,,X"  t_install_empty_connector_entry_exits_nonzero
+run_case "install unsupported connector"  t_install_warns_unsupported_connector
+run_case "install non-root rejected"      t_install_requires_root
+run_case "uninstall --help"               t_uninstall_help
+run_case "uninstall --bogus"              t_uninstall_unknown_flag
+run_case "uninstall non-root rejected"    t_uninstall_requires_root

--- a/packaging/macos/tests/test_arg_parsing.sh
+++ b/packaging/macos/tests/test_arg_parsing.sh
@@ -51,13 +51,46 @@ t_install_warns_unsupported_connector() {
 t_install_requires_root() {
   # As non-root, after arg parsing the script must die on the root check.
   if [[ $EUID -eq 0 ]]; then
-    if [[ "${VERBOSE:-false}" == "true" ]]; then printf '  skip (running as root)\n'; fi
+    [[ "${VERBOSE:-false}" == "true" ]] && printf '  skip (running as root)\n'
     return 0
   fi
   local out rc=0
   out="$("${INSTALL_SH}" --connector codex 2>&1)" || rc=$?
   assert_status "${rc}" 1 "non-root should exit non-zero"
   assert_contains "${out}" "must run as root" "explains root requirement"
+}
+
+t_install_default_redaction_is_on() {
+  # Parse install.sh's own defaults section directly so we're asserting
+  # the actual install-time contract, not just what render_config emits
+  # when handed a value. If a future edit flips this back to
+  # "true" (redaction off by default), this test catches it before
+  # anything ships.
+  local default
+  default="$(awk '
+    /^DISABLE_REDACTION=/ {
+      # DISABLE_REDACTION="false"
+      match($0, /"([^"]+)"/, m)
+      print m[1]
+      exit
+    }' "${INSTALL_SH}" 2>/dev/null)"
+  # awk on macOS has no `match` capture — fall back to a portable parse.
+  if [[ -z "${default}" ]]; then
+    default="$(grep -E '^DISABLE_REDACTION=' "${INSTALL_SH}" | head -1 \
+      | sed -E 's/^DISABLE_REDACTION="?([^"]+)"?.*/\1/')"
+  fi
+  assert_eq "${default}" "false" "install.sh DISABLE_REDACTION default is false (redaction ON)"
+}
+
+t_install_bad_port_exits_nonzero() {
+  local out rc=0
+  out="$("${INSTALL_SH}" --port 99999 2>&1)" || rc=$?
+  assert_status "${rc}" 1 "out-of-range --port should exit non-zero"
+  assert_contains "${out}" "--port must be" "explains port range"
+  rc=0
+  out="$("${INSTALL_SH}" --port foo 2>&1)" || rc=$?
+  assert_status "${rc}" 1 "non-numeric --port should exit non-zero"
+  assert_contains "${out}" "--port must be" "explains port must be numeric"
 }
 
 t_uninstall_help() {
@@ -77,7 +110,7 @@ t_uninstall_unknown_flag() {
 
 t_uninstall_requires_root() {
   if [[ $EUID -eq 0 ]]; then
-    if [[ "${VERBOSE:-false}" == "true" ]]; then printf '  skip (running as root)\n'; fi
+    [[ "${VERBOSE:-false}" == "true" ]] && printf '  skip (running as root)\n'
     return 0
   fi
   local out rc=0
@@ -90,8 +123,10 @@ run_case "install --help"                 t_install_help
 run_case "install --mode garbage"         t_install_bad_mode_exits_nonzero
 run_case "install --bogus"                t_install_unknown_flag_exits_nonzero
 run_case "install --connector cursor,,X"  t_install_empty_connector_entry_exits_nonzero
+run_case "install --port out-of-range"    t_install_bad_port_exits_nonzero
 run_case "install unsupported connector"  t_install_warns_unsupported_connector
 run_case "install non-root rejected"      t_install_requires_root
+run_case "install default redaction on"   t_install_default_redaction_is_on
 run_case "uninstall --help"               t_uninstall_help
 run_case "uninstall --bogus"              t_uninstall_unknown_flag
 run_case "uninstall non-root rejected"    t_uninstall_requires_root

--- a/packaging/macos/tests/test_arg_parsing.sh
+++ b/packaging/macos/tests/test_arg_parsing.sh
@@ -11,6 +11,7 @@ t_install_help() {
   out="$("${INSTALL_SH}" --help 2>&1)" || _fail "--help should exit 0"
   assert_contains "${out}" "--mode {observe|action}" "mode flag in help"
   assert_contains "${out}" "--connector LIST"        "connector flag in help"
+  assert_contains "${out}" "--disable-redaction"     "disable redaction flag in help"
   assert_contains "${out}" "comma-separated"         "comma-separated note in help"
   assert_contains "${out}" "Per-user hook wiring"    "per-user section header"
 }

--- a/packaging/macos/tests/test_discover_agent_version.sh
+++ b/packaging/macos/tests/test_discover_agent_version.sh
@@ -58,13 +58,21 @@ t_claudecode_no_install_returns_empty() {
   assert_eq "${got}" "" "claudecode with no CLI/extensions returns empty"
 }
 
-t_codex_no_install_returns_empty() {
-  # Codex probe no longer exec's the CLI. With no metadata file present
-  # under the tmp HOME's npm dirs, the function must return empty.
+t_codex_no_home_metadata_uses_system_or_empty() {
+  # With no metadata under the tmp HOME, the probe falls through to
+  # /opt/homebrew/Caskroom/codex etc. On a CI/dev box without codex
+  # installed anywhere, that returns empty. On a dev box with codex
+  # installed, we get a real version (that's fine — the point of
+  # discover_agent_version is to find one when it exists). Both are
+  # valid; assert the shape rather than the specific value.
   local home; home="$(mktest_tmp)"
   local got
   got="$(without_host_agent_bins discover_agent_version codex "${home}" 2>/dev/null || true)"
-  assert_eq "${got}" "" "codex with no metadata returns empty"
+  # Either empty, or a plausible version string (semver-ish).
+  if [[ -n "${got}" && ! "${got}" =~ ^[0-9]+\.[0-9]+ ]]; then
+    _fail "codex probe returned unexpected non-empty non-version: ${got}"
+    return 1
+  fi
 }
 
 t_codex_from_user_npm_metadata() {
@@ -88,6 +96,6 @@ t_unknown_connector() {
 run_case "claudecode via Cursor extension"   t_claudecode_via_cursor_extension
 run_case "claudecode via VS Code extension"  t_claudecode_via_vscode_extension
 run_case "claudecode without install"        t_claudecode_no_install_returns_empty
-run_case "codex without install"             t_codex_no_install_returns_empty
+run_case "codex without home metadata"       t_codex_no_home_metadata_uses_system_or_empty
 run_case "codex from user npm metadata"      t_codex_from_user_npm_metadata
 run_case "unknown connector returns empty"   t_unknown_connector

--- a/packaging/macos/tests/test_discover_agent_version.sh
+++ b/packaging/macos/tests/test_discover_agent_version.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# discover_agent_version: per-connector probing.
+# We stage a fake Cursor extension under a tmp HOME to drive the claudecode
+# extension-fallback path without touching real installs.
+. "${PKG_DIR}/lib/installer_lib.sh"
+
+t_claudecode_via_cursor_extension() {
+  local home; home="$(mktest_tmp)"
+  local ext="${home}/.cursor/extensions/anthropic.claude-code-2.1.195-darwin-arm64"
+  mkdir -p "${ext}"
+  cat > "${ext}/package.json" <<'JSON'
+{ "name": "claude-code", "version": "2.1.195" }
+JSON
+
+  local got
+  got="$(discover_agent_version claudecode "${home}")"
+  assert_eq "${got}" "2.1.195" "claudecode version from Cursor extension"
+}
+
+t_claudecode_via_vscode_extension() {
+  local home; home="$(mktest_tmp)"
+  local ext="${home}/.vscode/extensions/anthropic.claude-code-2.0.99-darwin-arm64"
+  mkdir -p "${ext}"
+  cat > "${ext}/package.json" <<'JSON'
+{ "name": "claude-code", "version": "2.0.99" }
+JSON
+
+  local got
+  got="$(discover_agent_version claudecode "${home}")"
+  assert_eq "${got}" "2.0.99" "claudecode version from VS Code extension"
+}
+
+t_claudecode_no_install_returns_empty() {
+  # Use a tmp HOME with no extensions and override PATH so 'claude' CLI
+  # is not findable. We can't reliably hide a real /usr/local/bin/claude
+  # so we just assert the function doesn't error or echo a stale value.
+  local home; home="$(mktest_tmp)"
+  local got
+  # When claude CLI is on PATH this returns a real version; that's fine.
+  # The assertion is: the function returns cleanly (no syntax error / crash).
+  got="$(discover_agent_version claudecode "${home}" 2>/dev/null || true)"
+  # Nothing to assert; presence of CLI on host makes this nondeterministic.
+  if [[ "${VERBOSE:-false}" == "true" ]]; then
+    printf '  info  claudecode-on-empty-host got=%q\n' "${got}"
+  fi
+}
+
+t_codex_unknown_returns_empty() {
+  # If codex CLI isn't installed, function returns empty. If it IS installed,
+  # we just observe it returns something non-empty. Either is fine.
+  local got
+  got="$(discover_agent_version codex "$(mktest_tmp)" 2>/dev/null || true)"
+  if [[ "${VERBOSE:-false}" == "true" ]]; then
+    printf '  info  codex got=%q\n' "${got}"
+  fi
+}
+
+t_unknown_connector() {
+  local got
+  got="$(discover_agent_version geminicli "$(mktest_tmp)" 2>/dev/null || true)"
+  assert_eq "${got}" "" "unknown connector returns empty string"
+}
+
+run_case "claudecode via Cursor extension"   t_claudecode_via_cursor_extension
+run_case "claudecode via VS Code extension"  t_claudecode_via_vscode_extension
+run_case "claudecode without install"        t_claudecode_no_install_returns_empty
+run_case "codex graceful when missing"       t_codex_unknown_returns_empty
+run_case "unknown connector returns empty"   t_unknown_connector

--- a/packaging/macos/tests/test_discover_agent_version.sh
+++ b/packaging/macos/tests/test_discover_agent_version.sh
@@ -4,6 +4,16 @@
 # extension-fallback path without touching real installs.
 . "${PKG_DIR}/lib/installer_lib.sh"
 
+without_host_claude() {
+  local fakebin; fakebin="$(mktest_tmp)"
+  cat > "${fakebin}/claude" <<'SH'
+#!/usr/bin/env bash
+exit 127
+SH
+  chmod 0700 "${fakebin}/claude"
+  PATH="${fakebin}:${PATH}" "$@"
+}
+
 t_claudecode_via_cursor_extension() {
   local home; home="$(mktest_tmp)"
   local ext="${home}/.cursor/extensions/anthropic.claude-code-2.1.195-darwin-arm64"
@@ -13,7 +23,7 @@ t_claudecode_via_cursor_extension() {
 JSON
 
   local got
-  got="$(discover_agent_version claudecode "${home}")"
+  got="$(without_host_claude discover_agent_version claudecode "${home}")"
   assert_eq "${got}" "2.1.195" "claudecode version from Cursor extension"
 }
 
@@ -26,7 +36,7 @@ t_claudecode_via_vscode_extension() {
 JSON
 
   local got
-  got="$(discover_agent_version claudecode "${home}")"
+  got="$(without_host_claude discover_agent_version claudecode "${home}")"
   assert_eq "${got}" "2.0.99" "claudecode version from VS Code extension"
 }
 

--- a/packaging/macos/tests/test_discover_agent_version.sh
+++ b/packaging/macos/tests/test_discover_agent_version.sh
@@ -1,16 +1,26 @@
 #!/usr/bin/env bash
-# discover_agent_version: per-connector probing.
-# We stage a fake Cursor extension under a tmp HOME to drive the claudecode
-# extension-fallback path without touching real installs.
+# discover_agent_version: per-connector metadata probing.
+#
+# The lib never execs agent binaries (see the security note in
+# installer_lib.sh:discover_agent_version), so all cases are driven from
+# staged tmpdirs / bundle files — no host-agent leakage possible.
 . "${PKG_DIR}/lib/installer_lib.sh"
 
-without_host_claude() {
-  local fakebin; fakebin="$(mktest_tmp)"
-  cat > "${fakebin}/claude" <<'SH'
+# Wrapper that masks any host `claude` / `codex` CLI on PATH. We used
+# to need this because the lib exec'd those binaries; keeping it around
+# guards against a regression where a future CLI probe reintroduces the
+# code-exec surface.
+without_host_agent_bins() {
+  local fakebin
+  fakebin="$(mktest_tmp)"
+  local bin
+  for bin in claude codex; do
+    cat > "${fakebin}/${bin}" <<'SH'
 #!/usr/bin/env bash
 exit 127
 SH
-  chmod 0700 "${fakebin}/claude"
+    chmod 0700 "${fakebin}/${bin}"
+  done
   PATH="${fakebin}:${PATH}" "$@"
 }
 
@@ -23,7 +33,7 @@ t_claudecode_via_cursor_extension() {
 JSON
 
   local got
-  got="$(without_host_claude discover_agent_version claudecode "${home}")"
+  got="$(without_host_agent_bins discover_agent_version claudecode "${home}")"
   assert_eq "${got}" "2.1.195" "claudecode version from Cursor extension"
 }
 
@@ -36,33 +46,37 @@ t_claudecode_via_vscode_extension() {
 JSON
 
   local got
-  got="$(without_host_claude discover_agent_version claudecode "${home}")"
+  got="$(without_host_agent_bins discover_agent_version claudecode "${home}")"
   assert_eq "${got}" "2.0.99" "claudecode version from VS Code extension"
 }
 
 t_claudecode_no_install_returns_empty() {
-  # Use a tmp HOME with no extensions and override PATH so 'claude' CLI
-  # is not findable. We can't reliably hide a real /usr/local/bin/claude
-  # so we just assert the function doesn't error or echo a stale value.
+  # Empty tmp HOME + no CLI on PATH → empty version, cleanly.
   local home; home="$(mktest_tmp)"
   local got
-  # When claude CLI is on PATH this returns a real version; that's fine.
-  # The assertion is: the function returns cleanly (no syntax error / crash).
-  got="$(discover_agent_version claudecode "${home}" 2>/dev/null || true)"
-  # Nothing to assert; presence of CLI on host makes this nondeterministic.
-  if [[ "${VERBOSE:-false}" == "true" ]]; then
-    printf '  info  claudecode-on-empty-host got=%q\n' "${got}"
-  fi
+  got="$(without_host_agent_bins discover_agent_version claudecode "${home}" 2>/dev/null || true)"
+  assert_eq "${got}" "" "claudecode with no CLI/extensions returns empty"
 }
 
-t_codex_unknown_returns_empty() {
-  # If codex CLI isn't installed, function returns empty. If it IS installed,
-  # we just observe it returns something non-empty. Either is fine.
+t_codex_no_install_returns_empty() {
+  # Codex probe no longer exec's the CLI. With no metadata file present
+  # under the tmp HOME's npm dirs, the function must return empty.
+  local home; home="$(mktest_tmp)"
   local got
-  got="$(discover_agent_version codex "$(mktest_tmp)" 2>/dev/null || true)"
-  if [[ "${VERBOSE:-false}" == "true" ]]; then
-    printf '  info  codex got=%q\n' "${got}"
-  fi
+  got="$(without_host_agent_bins discover_agent_version codex "${home}" 2>/dev/null || true)"
+  assert_eq "${got}" "" "codex with no metadata returns empty"
+}
+
+t_codex_from_user_npm_metadata() {
+  local home; home="$(mktest_tmp)"
+  local pkg_dir="${home}/.npm-global/lib/node_modules/@openai/codex"
+  mkdir -p "${pkg_dir}"
+  cat > "${pkg_dir}/package.json" <<'JSON'
+{ "name": "@openai/codex", "version": "0.142.0" }
+JSON
+  local got
+  got="$(without_host_agent_bins discover_agent_version codex "${home}")"
+  assert_eq "${got}" "0.142.0" "codex version from user-npm metadata"
 }
 
 t_unknown_connector() {
@@ -74,5 +88,6 @@ t_unknown_connector() {
 run_case "claudecode via Cursor extension"   t_claudecode_via_cursor_extension
 run_case "claudecode via VS Code extension"  t_claudecode_via_vscode_extension
 run_case "claudecode without install"        t_claudecode_no_install_returns_empty
-run_case "codex graceful when missing"       t_codex_unknown_returns_empty
+run_case "codex without install"             t_codex_no_install_returns_empty
+run_case "codex from user npm metadata"      t_codex_from_user_npm_metadata
 run_case "unknown connector returns empty"   t_unknown_connector

--- a/packaging/macos/tests/test_home_perms.sh
+++ b/packaging/macos/tests/test_home_perms.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# home_perms_ok mirrors the guardian's check: reject group/other-write.
+. "${PKG_DIR}/lib/installer_lib.sh"
+
+t_0755_passes() {
+  local d; d="$(mktest_tmp)"
+  chmod 0755 "${d}"
+  local rc; home_perms_ok "${d}"; rc=$?
+  assert_status "${rc}" 0 "0755 should pass"
+}
+
+t_0700_passes() {
+  local d; d="$(mktest_tmp)"
+  chmod 0700 "${d}"
+  local rc; home_perms_ok "${d}"; rc=$?
+  assert_status "${rc}" 0 "0700 should pass"
+}
+
+t_0770_rejected() {
+  local d; d="$(mktest_tmp)"
+  chmod 0770 "${d}"
+  local rc; home_perms_ok "${d}"; rc=$?
+  assert_status "${rc}" 1 "0770 (group-write) should fail"
+}
+
+t_0775_rejected() {
+  local d; d="$(mktest_tmp)"
+  chmod 0775 "${d}"
+  local rc; home_perms_ok "${d}"; rc=$?
+  assert_status "${rc}" 1 "0775 (group-write) should fail"
+}
+
+t_0707_rejected() {
+  local d; d="$(mktest_tmp)"
+  chmod 0707 "${d}"
+  local rc; home_perms_ok "${d}"; rc=$?
+  assert_status "${rc}" 1 "0707 (other-write) should fail"
+}
+
+t_missing_path_is_ok() {
+  # When stat fails, we deliberately return ok so the install can proceed
+  # (the guardian will catch the real check). This is documented.
+  local rc; home_perms_ok "/nonexistent/$(date +%s)"; rc=$?
+  assert_status "${rc}" 0 "nonexistent path returns ok (guardian re-checks)"
+}
+
+run_case "0755 passes"  t_0755_passes
+run_case "0700 passes"  t_0700_passes
+run_case "0770 rejected" t_0770_rejected
+run_case "0775 rejected" t_0775_rejected
+run_case "0707 rejected" t_0707_rejected
+run_case "missing path returns ok" t_missing_path_is_ok

--- a/packaging/macos/tests/test_packaging_assets.sh
+++ b/packaging/macos/tests/test_packaging_assets.sh
@@ -23,6 +23,22 @@ t_plist_contains_managed_paths() {
   assert_contains "${body}" "<key>RunAtLoad</key>"                         "RunAtLoad set"
 }
 
+t_plist_service_user_is_hidden_convention() {
+  # The shipped plist must reference a service user prefixed with an
+  # underscore, matching Apple's convention for hidden system users
+  # (Rooms for reject-and-fix by admins who set --service-user, but
+  # never a raw "defenseclaw" that macOS won't know how to resolve).
+  local plist="${REPO_ROOT}/packaging/launchd/com.defenseclaw.gateway.plist"
+  local uname gname
+  if ! command -v plutil >/dev/null 2>&1; then
+    return 0
+  fi
+  uname="$(plutil -extract UserName  raw "${plist}" 2>/dev/null || true)"
+  gname="$(plutil -extract GroupName raw "${plist}" 2>/dev/null || true)"
+  assert_eq "${uname:0:1}" "_" "shipped plist UserName starts with _ (got: ${uname})"
+  assert_eq "${gname:0:1}" "_" "shipped plist GroupName starts with _ (got: ${gname})"
+}
+
 t_install_lib_syntax() {
   local rc=0
   bash -n "${PKG_DIR}/lib/installer_lib.sh" 2>&1 || rc=$?
@@ -59,6 +75,30 @@ t_scrub_py_exists_and_executable() {
   assert_file_exists "${PKG_DIR}/lib/scrub_agent_configs.py"
   if [[ ! -x "${PKG_DIR}/lib/scrub_agent_configs.py" ]]; then
     _fail "scrub_agent_configs.py missing +x"
+    return 1
+  fi
+}
+
+t_install_has_service_user_helper() {
+  # We can't invoke dscl in tests (needs root, mutates system state), so
+  # instead we lock in the contract: install.sh must define an
+  # ensure_service_user function and its execution path must actually
+  # call ensure_service_user before touching the LaunchDaemon plist.
+  local body
+  body="$(cat "${PKG_DIR}/install.sh")"
+  assert_contains "${body}" "ensure_service_user()"       "ensure_service_user function defined"
+  assert_contains "${body}" "ensure_service_user \""      "ensure_service_user is invoked"
+  # ensure_service_user must run before we bootstrap launchd, otherwise
+  # launchd will spawn a service whose UserName references a missing user.
+  local user_line boot_line
+  user_line=$(grep -n 'ensure_service_user "'  "${PKG_DIR}/install.sh" | head -1 | cut -d: -f1)
+  boot_line=$(grep -n 'launchctl bootstrap system "\${PLIST_DST}"' "${PKG_DIR}/install.sh" | head -1 | cut -d: -f1)
+  if [[ -z "${user_line}" || -z "${boot_line}" ]]; then
+    _fail "could not locate ensure_service_user or launchctl bootstrap line"
+    return 1
+  fi
+  if (( user_line >= boot_line )); then
+    _fail "ensure_service_user (line ${user_line}) must run before launchctl bootstrap (line ${boot_line})"
     return 1
   fi
 }
@@ -127,6 +167,7 @@ t_bundle_without_binary_and_no_repo_dies() {
 
 run_case "plist exists and lints"     t_plist_exists_and_parses
 run_case "plist references managed paths" t_plist_contains_managed_paths
+run_case "plist service user is _-prefixed" t_plist_service_user_is_hidden_convention
 run_case "installer_lib.sh syntax"    t_install_lib_syntax
 run_case "install.sh syntax"          t_install_sh_syntax
 run_case "uninstall.sh syntax"        t_uninstall_sh_syntax
@@ -134,5 +175,6 @@ run_case "install.sh executable"      t_install_sh_is_executable
 run_case "uninstall.sh executable"    t_uninstall_sh_is_executable
 run_case "scrub_agent_configs.py present and +x" t_scrub_py_exists_and_executable
 run_case "scrub_agent_configs.py syntax"          t_scrub_py_syntax
+run_case "install.sh has ensure_service_user + calls it before launchd" t_install_has_service_user_helper
 run_case "bundle layout: plist + binary resolve locally" t_bundle_layout_resolves_locally
 run_case "bundle without binary + no repo dies"          t_bundle_without_binary_and_no_repo_dies

--- a/packaging/macos/tests/test_packaging_assets.sh
+++ b/packaging/macos/tests/test_packaging_assets.sh
@@ -69,6 +69,62 @@ t_scrub_py_syntax() {
   assert_status "${rc}" 0 "scrub_agent_configs.py parses"
 }
 
+# Regression guard for the "shippable bundle" contract: install.sh must
+# discover the plist and binary next to itself (SCRIPT_DIR-relative)
+# before falling back to the repo tree, and it must NOT try to `go build`
+# when no repo tree is available. Simulate a bundle in a tmpdir and
+# confirm the script picks the bundle-local assets.
+t_bundle_layout_resolves_locally() {
+  local bundle; bundle="$(mktest_tmp)"
+  # mktest_tmp may return a path with a trailing slash from $TMPDIR;
+  # normalize so grep and the trace lines compare cleanly.
+  bundle="${bundle%/}"
+  # $bundle may still contain a mid-path `//` from the $TMPDIR concat
+  # (e.g. `/var/.../T//dctest...`). Bash's set -x prints it verbatim,
+  # so canonicalize via cd -P to match what install.sh's SCRIPT_DIR
+  # resolves to.
+  bundle="$(cd "${bundle}" && pwd -P)"
+  mkdir -p "${bundle}/lib"
+  cp "${PKG_DIR}/install.sh"                              "${bundle}/install.sh"
+  cp "${PKG_DIR}/lib/installer_lib.sh"                    "${bundle}/lib/installer_lib.sh"
+  # Fake bundle-local plist + binary so the resolution has something to
+  # find. Contents don't matter, only existence.
+  printf '<?xml version="1.0"?><plist/>' > "${bundle}/com.defenseclaw.gateway.plist"
+  printf '#!/bin/sh\nexit 0\n' > "${bundle}/defenseclaw-gateway"
+  chmod 0755 "${bundle}/defenseclaw-gateway" "${bundle}/install.sh"
+
+  # Bypass the root check so we can reach the resolution block.
+  sed -i.bak 's/\[\[ \$EUID -eq 0 \]\] || die/[[ 1 -eq 0 ]] || : /' "${bundle}/install.sh"
+  rm -f "${bundle}/install.sh.bak"
+
+  # Non-strict trace: filter for the PLIST/BINARY resolution lines.
+  local trace
+  trace="$(bash -x "${bundle}/install.sh" --connector codex --skip-launchd --skip-connector 2>&1 | \
+    grep -E "PLIST_SRC=|BINARY_SRC=/" || true)"
+
+  assert_contains "${trace}" "PLIST_SRC=${bundle}/com.defenseclaw.gateway.plist" "plist resolved from bundle"
+  assert_contains "${trace}" "BINARY_SRC=${bundle}/defenseclaw-gateway"          "binary resolved from bundle"
+}
+
+# Complementary: with NO bundle-local binary AND no repo tree, install.sh
+# must die with a clear message rather than trying to `go build`.
+t_bundle_without_binary_and_no_repo_dies() {
+  local bundle; bundle="$(mktest_tmp)"
+  bundle="$(cd "${bundle}" && pwd -P)"
+  mkdir -p "${bundle}/lib"
+  cp "${PKG_DIR}/install.sh"                              "${bundle}/install.sh"
+  cp "${PKG_DIR}/lib/installer_lib.sh"                    "${bundle}/lib/installer_lib.sh"
+  printf '<?xml version="1.0"?><plist/>' > "${bundle}/com.defenseclaw.gateway.plist"
+  chmod 0755 "${bundle}/install.sh"
+  sed -i.bak 's/\[\[ \$EUID -eq 0 \]\] || die/[[ 1 -eq 0 ]] || : /' "${bundle}/install.sh"
+  rm -f "${bundle}/install.sh.bak"
+
+  local out rc=0
+  out="$("${bundle}/install.sh" --connector codex --skip-launchd --skip-connector 2>&1)" || rc=$?
+  assert_status "${rc}" 1 "missing binary + no repo should die"
+  assert_contains "${out}" "no repo tree" "explains missing repo tree"
+}
+
 run_case "plist exists and lints"     t_plist_exists_and_parses
 run_case "plist references managed paths" t_plist_contains_managed_paths
 run_case "installer_lib.sh syntax"    t_install_lib_syntax
@@ -78,3 +134,5 @@ run_case "install.sh executable"      t_install_sh_is_executable
 run_case "uninstall.sh executable"    t_uninstall_sh_is_executable
 run_case "scrub_agent_configs.py present and +x" t_scrub_py_exists_and_executable
 run_case "scrub_agent_configs.py syntax"          t_scrub_py_syntax
+run_case "bundle layout: plist + binary resolve locally" t_bundle_layout_resolves_locally
+run_case "bundle without binary + no repo dies"          t_bundle_without_binary_and_no_repo_dies

--- a/packaging/macos/tests/test_packaging_assets.sh
+++ b/packaging/macos/tests/test_packaging_assets.sh
@@ -23,11 +23,11 @@ t_plist_contains_managed_paths() {
   assert_contains "${body}" "<key>RunAtLoad</key>"                         "RunAtLoad set"
 }
 
-t_plist_service_user_is_hidden_convention() {
-  # The shipped plist must reference a service user prefixed with an
-  # underscore, matching Apple's convention for hidden system users
-  # (Rooms for reject-and-fix by admins who set --service-user, but
-  # never a raw "defenseclaw" that macOS won't know how to resolve).
+t_plist_service_user_matches_gateway_expectation() {
+  # The gateway binary hardcodes trustedRuntimeOwner to look up a user
+  # literally named "defenseclaw" (see internal/managed/trust_unix.go).
+  # The shipped plist MUST reference that exact name or the daemon will
+  # reject the managed_enterprise data_dir trust check on boot.
   local plist="${REPO_ROOT}/packaging/launchd/com.defenseclaw.gateway.plist"
   local uname gname
   if ! command -v plutil >/dev/null 2>&1; then
@@ -35,8 +35,8 @@ t_plist_service_user_is_hidden_convention() {
   fi
   uname="$(plutil -extract UserName  raw "${plist}" 2>/dev/null || true)"
   gname="$(plutil -extract GroupName raw "${plist}" 2>/dev/null || true)"
-  assert_eq "${uname:0:1}" "_" "shipped plist UserName starts with _ (got: ${uname})"
-  assert_eq "${gname:0:1}" "_" "shipped plist GroupName starts with _ (got: ${gname})"
+  assert_eq "${uname}" "defenseclaw" "shipped plist UserName is 'defenseclaw' (got: ${uname})"
+  assert_eq "${gname}" "defenseclaw" "shipped plist GroupName is 'defenseclaw' (got: ${gname})"
 }
 
 t_install_lib_syntax() {
@@ -167,7 +167,7 @@ t_bundle_without_binary_and_no_repo_dies() {
 
 run_case "plist exists and lints"     t_plist_exists_and_parses
 run_case "plist references managed paths" t_plist_contains_managed_paths
-run_case "plist service user is _-prefixed" t_plist_service_user_is_hidden_convention
+run_case "plist service user matches gateway expectation" t_plist_service_user_matches_gateway_expectation
 run_case "installer_lib.sh syntax"    t_install_lib_syntax
 run_case "install.sh syntax"          t_install_sh_syntax
 run_case "uninstall.sh syntax"        t_uninstall_sh_syntax

--- a/packaging/macos/tests/test_packaging_assets.sh
+++ b/packaging/macos/tests/test_packaging_assets.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Sanity-check the packaging assets that install.sh expects to ship.
+
+t_plist_exists_and_parses() {
+  local plist="${REPO_ROOT}/packaging/launchd/com.defenseclaw.gateway.plist"
+  assert_file_exists "${plist}"
+  if command -v plutil >/dev/null 2>&1; then
+    local out rc=0
+    out="$(plutil -lint "${plist}" 2>&1)" || rc=$?
+    assert_status "${rc}" 0 "plutil -lint should succeed"
+    assert_contains "${out}" "OK" "plutil OK"
+  fi
+}
+
+t_plist_contains_managed_paths() {
+  local plist="${REPO_ROOT}/packaging/launchd/com.defenseclaw.gateway.plist"
+  local body; body="$(cat "${plist}")"
+  assert_contains "${body}" "/Library/DefenseClaw/bin/defenseclaw-gateway" "binary path"
+  assert_contains "${body}" "DEFENSECLAW_CONFIG"                          "config env var"
+  assert_contains "${body}" "/Library/Application Support/DefenseClaw"    "support dir path"
+  assert_contains "${body}" "com.defenseclaw.gateway"                     "launchd label"
+  assert_contains "${body}" "<key>KeepAlive</key>"                         "KeepAlive set"
+  assert_contains "${body}" "<key>RunAtLoad</key>"                         "RunAtLoad set"
+}
+
+t_install_lib_syntax() {
+  local rc=0
+  bash -n "${PKG_DIR}/lib/installer_lib.sh" 2>&1 || rc=$?
+  assert_status "${rc}" 0 "installer_lib.sh parses cleanly"
+}
+
+t_install_sh_syntax() {
+  local rc=0
+  bash -n "${PKG_DIR}/install.sh" 2>&1 || rc=$?
+  assert_status "${rc}" 0 "install.sh parses cleanly"
+}
+
+t_uninstall_sh_syntax() {
+  local rc=0
+  bash -n "${PKG_DIR}/uninstall.sh" 2>&1 || rc=$?
+  assert_status "${rc}" 0 "uninstall.sh parses cleanly"
+}
+
+t_install_sh_is_executable() {
+  if [[ ! -x "${PKG_DIR}/install.sh" ]]; then
+    _fail "install.sh missing +x"
+    return 1
+  fi
+}
+
+t_uninstall_sh_is_executable() {
+  if [[ ! -x "${PKG_DIR}/uninstall.sh" ]]; then
+    _fail "uninstall.sh missing +x"
+    return 1
+  fi
+}
+
+run_case "plist exists and lints"     t_plist_exists_and_parses
+run_case "plist references managed paths" t_plist_contains_managed_paths
+run_case "installer_lib.sh syntax"    t_install_lib_syntax
+run_case "install.sh syntax"          t_install_sh_syntax
+run_case "uninstall.sh syntax"        t_uninstall_sh_syntax
+run_case "install.sh executable"      t_install_sh_is_executable
+run_case "uninstall.sh executable"    t_uninstall_sh_is_executable

--- a/packaging/macos/tests/test_packaging_assets.sh
+++ b/packaging/macos/tests/test_packaging_assets.sh
@@ -55,6 +55,20 @@ t_uninstall_sh_is_executable() {
   fi
 }
 
+t_scrub_py_exists_and_executable() {
+  assert_file_exists "${PKG_DIR}/lib/scrub_agent_configs.py"
+  if [[ ! -x "${PKG_DIR}/lib/scrub_agent_configs.py" ]]; then
+    _fail "scrub_agent_configs.py missing +x"
+    return 1
+  fi
+}
+
+t_scrub_py_syntax() {
+  local rc=0
+  /usr/bin/python3 -c "import ast; ast.parse(open('${PKG_DIR}/lib/scrub_agent_configs.py').read())" 2>&1 || rc=$?
+  assert_status "${rc}" 0 "scrub_agent_configs.py parses"
+}
+
 run_case "plist exists and lints"     t_plist_exists_and_parses
 run_case "plist references managed paths" t_plist_contains_managed_paths
 run_case "installer_lib.sh syntax"    t_install_lib_syntax
@@ -62,3 +76,5 @@ run_case "install.sh syntax"          t_install_sh_syntax
 run_case "uninstall.sh syntax"        t_uninstall_sh_syntax
 run_case "install.sh executable"      t_install_sh_is_executable
 run_case "uninstall.sh executable"    t_uninstall_sh_is_executable
+run_case "scrub_agent_configs.py present and +x" t_scrub_py_exists_and_executable
+run_case "scrub_agent_configs.py syntax"          t_scrub_py_syntax

--- a/packaging/macos/tests/test_parse_connectors.sh
+++ b/packaging/macos/tests/test_parse_connectors.sh
@@ -26,6 +26,32 @@ t_empty_entry_rejected() {
   assert_status "${rc}" 1 "empty entry should exit non-zero"
 }
 
+t_trailing_comma_rejected() {
+  local rc=0
+  parse_connectors "cursor," >/dev/null 2>&1 || rc=$?
+  assert_status "${rc}" 1 "trailing comma should exit non-zero"
+}
+
+t_leading_comma_rejected() {
+  local rc=0
+  parse_connectors ",cursor" >/dev/null 2>&1 || rc=$?
+  assert_status "${rc}" 1 "leading comma should exit non-zero"
+}
+
+t_unsafe_token_rejected() {
+  # Anything outside [a-z0-9_-]+ must be rejected: it would either
+  # break the YAML parser or, worse, get rendered as an unrelated key.
+  local rc
+  rc=0; parse_connectors "cursor injected: value" >/dev/null 2>&1 || rc=$?
+  assert_status "${rc}" 1 "space + colon rejected"
+  rc=0; parse_connectors 'cursor\nfoo:bar' >/dev/null 2>&1 || rc=$?
+  assert_status "${rc}" 1 "backslash-n literal rejected"
+  rc=0; parse_connectors 'a"b' >/dev/null 2>&1 || rc=$?
+  assert_status "${rc}" 1 "quote rejected"
+  rc=0; parse_connectors 'a/b' >/dev/null 2>&1 || rc=$?
+  assert_status "${rc}" 1 "slash rejected"
+}
+
 t_empty_string_rejected() {
   local rc=0
   parse_connectors "" >/dev/null 2>&1 || rc=$?
@@ -48,5 +74,8 @@ run_case "single connector" t_single
 run_case "multi-connector preserves order" t_multi
 run_case "whitespace + case normalization" t_whitespace_and_case
 run_case "empty entry rejected" t_empty_entry_rejected
+run_case "trailing comma rejected" t_trailing_comma_rejected
+run_case "leading comma rejected" t_leading_comma_rejected
+run_case "unsafe connector token rejected" t_unsafe_token_rejected
 run_case "empty arg rejected" t_empty_string_rejected
 run_case "is_supported_connector allow-list" t_is_supported

--- a/packaging/macos/tests/test_parse_connectors.sh
+++ b/packaging/macos/tests/test_parse_connectors.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# parse_connectors: comma-split, trim, lowercase, reject empties.
+. "${PKG_DIR}/lib/installer_lib.sh"
+
+t_single() {
+  local got
+  got="$(parse_connectors "codex")"
+  assert_eq "${got}" "codex" "single connector"
+}
+
+t_multi() {
+  local got
+  got="$(parse_connectors "cursor,claudecode,codex" | tr '\n' '|')"
+  assert_eq "${got}" "cursor|claudecode|codex|" "multi connector ordering"
+}
+
+t_whitespace_and_case() {
+  local got
+  got="$(parse_connectors "  Cursor , CLAUDECODE  ,  codex" | tr '\n' '|')"
+  assert_eq "${got}" "cursor|claudecode|codex|" "whitespace + case"
+}
+
+t_empty_entry_rejected() {
+  local rc=0
+  parse_connectors "cursor,,codex" >/dev/null 2>&1 || rc=$?
+  assert_status "${rc}" 1 "empty entry should exit non-zero"
+}
+
+t_empty_string_rejected() {
+  local rc=0
+  parse_connectors "" >/dev/null 2>&1 || rc=$?
+  assert_status "${rc}" 1 "empty arg should exit non-zero"
+}
+
+t_is_supported() {
+  local rc
+  is_supported_connector "codex"; rc=$?
+  assert_status "${rc}" 0 "codex supported"
+  is_supported_connector "claudecode"; rc=$?
+  assert_status "${rc}" 0 "claudecode supported"
+  is_supported_connector "cursor"; rc=$?
+  assert_status "${rc}" 0 "cursor supported"
+  is_supported_connector "geminicli"; rc=$?
+  assert_status "${rc}" 1 "geminicli not auto-wired"
+}
+
+run_case "single connector" t_single
+run_case "multi-connector preserves order" t_multi
+run_case "whitespace + case normalization" t_whitespace_and_case
+run_case "empty entry rejected" t_empty_entry_rejected
+run_case "empty arg rejected" t_empty_string_rejected
+run_case "is_supported_connector allow-list" t_is_supported

--- a/packaging/macos/tests/test_prepare_userspace.sh
+++ b/packaging/macos/tests/test_prepare_userspace.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# prepare_*_userspace: pre-create connector hook config files in a tmp HOME.
+. "${PKG_DIR}/lib/installer_lib.sh"
+
+t_codex_creates() {
+  local home; home="$(mktest_tmp)"
+  prepare_codex_userspace "${home}"
+  assert_file_exists "${home}/.codex/config.toml"
+  assert_file_mode "${home}/.codex/config.toml" "600"
+  assert_file_mode "${home}/.codex" "700"
+
+  # Idempotent: second call must not clobber.
+  printf 'MY_USER_EDIT\n' >> "${home}/.codex/config.toml"
+  prepare_codex_userspace "${home}"
+  local body; body="$(cat "${home}/.codex/config.toml")"
+  assert_contains "${body}" "MY_USER_EDIT" "idempotent: existing content preserved"
+}
+
+t_claudecode_creates() {
+  local home; home="$(mktest_tmp)"
+  prepare_claudecode_userspace "${home}"
+  assert_file_exists "${home}/.claude/settings.json"
+  assert_file_mode "${home}/.claude/settings.json" "600"
+  assert_file_mode "${home}/.claude" "700"
+  local body; body="$(cat "${home}/.claude/settings.json")"
+  assert_eq "${body}" "{}" "settings.json initial body"
+}
+
+t_cursor_creates() {
+  local home; home="$(mktest_tmp)"
+  prepare_cursor_userspace "${home}"
+  assert_file_exists "${home}/.cursor/hooks.json"
+  assert_file_mode "${home}/.cursor/hooks.json" "600"
+  assert_file_mode "${home}/.cursor" "700"
+  local body; body="$(cat "${home}/.cursor/hooks.json")"
+  assert_contains "${body}" '"version":1' "hooks.json carries schema version"
+  assert_contains "${body}" '"hooks":{}'  "hooks.json has empty hooks map"
+}
+
+t_dispatch_via_helper() {
+  local home; home="$(mktest_tmp)"
+  prepare_userspace_for cursor     "${home}"
+  prepare_userspace_for codex      "${home}"
+  prepare_userspace_for claudecode "${home}"
+  assert_file_exists "${home}/.cursor/hooks.json"
+  assert_file_exists "${home}/.codex/config.toml"
+  assert_file_exists "${home}/.claude/settings.json"
+}
+
+run_case "codex userspace pre-create + idempotent" t_codex_creates
+run_case "claudecode userspace pre-create"         t_claudecode_creates
+run_case "cursor userspace pre-create"             t_cursor_creates
+run_case "prepare_userspace_for dispatch"          t_dispatch_via_helper

--- a/packaging/macos/tests/test_prepare_userspace.sh
+++ b/packaging/macos/tests/test_prepare_userspace.sh
@@ -47,7 +47,34 @@ t_dispatch_via_helper() {
   assert_file_exists "${home}/.claude/settings.json"
 }
 
+t_rejects_symlinked_agent_dir() {
+  local home target status
+  home="$(mktest_tmp)"
+  target="$(mktest_tmp)"
+  ln -s "${target}" "${home}/.codex"
+  prepare_codex_userspace "${home}"
+  status=$?
+  assert_status "${status}" 1 "symlinked .codex rejected"
+  if [[ -e "${target}/config.toml" ]]; then
+    _fail "symlink target was written through"
+  fi
+}
+
+t_rejects_symlinked_config_file() {
+  local home target status
+  home="$(mktest_tmp)"
+  target="$(mktest_tmp)/settings.json"
+  mkdir -p "${home}/.claude"
+  printf '{}\n' > "${target}"
+  ln -s "${target}" "${home}/.claude/settings.json"
+  prepare_claudecode_userspace "${home}"
+  status=$?
+  assert_status "${status}" 1 "symlinked settings.json rejected"
+}
+
 run_case "codex userspace pre-create + idempotent" t_codex_creates
 run_case "claudecode userspace pre-create"         t_claudecode_creates
 run_case "cursor userspace pre-create"             t_cursor_creates
 run_case "prepare_userspace_for dispatch"          t_dispatch_via_helper
+run_case "symlinked agent dir rejected"            t_rejects_symlinked_agent_dir
+run_case "symlinked config file rejected"          t_rejects_symlinked_config_file

--- a/packaging/macos/tests/test_prepare_userspace.sh
+++ b/packaging/macos/tests/test_prepare_userspace.sh
@@ -47,34 +47,61 @@ t_dispatch_via_helper() {
   assert_file_exists "${home}/.claude/settings.json"
 }
 
-t_rejects_symlinked_agent_dir() {
+# Symlink-rejection matrix: for each connector, we exercise both
+# the directory-symlink and file-symlink attack surfaces, and after
+# rejection we verify the symlink target was never written to.
+
+# Helper: run prep(<dir>), assert exit=1, verify target untouched.
+_assert_symlink_dir_rejected() {
+  local prep="$1"     # function name
+  local subdir="$2"   # e.g. .codex
+  local leaf="$3"     # e.g. config.toml
   local home target status
   home="$(mktest_tmp)"
   target="$(mktest_tmp)"
-  ln -s "${target}" "${home}/.codex"
-  prepare_codex_userspace "${home}"
+  ln -s "${target}" "${home}/${subdir}"
+  "${prep}" "${home}"
   status=$?
-  assert_status "${status}" 1 "symlinked .codex rejected"
-  if [[ -e "${target}/config.toml" ]]; then
-    _fail "symlink target was written through"
+  assert_status "${status}" 1 "symlinked ${subdir} rejected"
+  if [[ -e "${target}/${leaf}" ]]; then
+    _fail "symlink target ${target}/${leaf} was written through"
   fi
 }
 
-t_rejects_symlinked_config_file() {
+# Helper: for a file-symlink, stage a canary in the target; prep must
+# refuse and the canary must remain unchanged.
+_assert_symlink_file_rejected() {
+  local prep="$1"     # function name
+  local subdir="$2"
+  local leaf="$3"
+  local canary="$4"   # sentinel content
   local home target status
   home="$(mktest_tmp)"
-  target="$(mktest_tmp)/settings.json"
-  mkdir -p "${home}/.claude"
-  printf '{}\n' > "${target}"
-  ln -s "${target}" "${home}/.claude/settings.json"
-  prepare_claudecode_userspace "${home}"
+  target="$(mktest_tmp)/${leaf}"
+  mkdir -p "${home}/${subdir}" "$(dirname "${target}")"
+  printf '%s\n' "${canary}" > "${target}"
+  ln -s "${target}" "${home}/${subdir}/${leaf}"
+  "${prep}" "${home}"
   status=$?
-  assert_status "${status}" 1 "symlinked settings.json rejected"
+  assert_status "${status}" 1 "symlinked ${subdir}/${leaf} rejected"
+  local now; now="$(cat "${target}")"
+  assert_eq "${now}" "${canary}" "symlink target ${target} untouched"
 }
+
+t_codex_rejects_symlink_dir()      { _assert_symlink_dir_rejected  prepare_codex_userspace      .codex   config.toml; }
+t_codex_rejects_symlink_file()     { _assert_symlink_file_rejected prepare_codex_userspace      .codex   config.toml   "USER_CANARY_CODEX"; }
+t_claudecode_rejects_symlink_dir() { _assert_symlink_dir_rejected  prepare_claudecode_userspace .claude  settings.json; }
+t_claudecode_rejects_symlink_file(){ _assert_symlink_file_rejected prepare_claudecode_userspace .claude  settings.json '{"user":"canary"}'; }
+t_cursor_rejects_symlink_dir()     { _assert_symlink_dir_rejected  prepare_cursor_userspace     .cursor  hooks.json; }
+t_cursor_rejects_symlink_file()    { _assert_symlink_file_rejected prepare_cursor_userspace     .cursor  hooks.json    '{"user":"canary"}'; }
 
 run_case "codex userspace pre-create + idempotent" t_codex_creates
 run_case "claudecode userspace pre-create"         t_claudecode_creates
 run_case "cursor userspace pre-create"             t_cursor_creates
 run_case "prepare_userspace_for dispatch"          t_dispatch_via_helper
-run_case "symlinked agent dir rejected"            t_rejects_symlinked_agent_dir
-run_case "symlinked config file rejected"          t_rejects_symlinked_config_file
+run_case "codex rejects symlinked .codex dir"      t_codex_rejects_symlink_dir
+run_case "codex rejects symlinked config.toml"     t_codex_rejects_symlink_file
+run_case "claudecode rejects symlinked .claude dir" t_claudecode_rejects_symlink_dir
+run_case "claudecode rejects symlinked settings.json" t_claudecode_rejects_symlink_file
+run_case "cursor rejects symlinked .cursor dir"    t_cursor_rejects_symlink_dir
+run_case "cursor rejects symlinked hooks.json"     t_cursor_rejects_symlink_file

--- a/packaging/macos/tests/test_render_config.sh
+++ b/packaging/macos/tests/test_render_config.sh
@@ -34,16 +34,21 @@ t_multi_connector() {
   assert_contains "${out}" "mode: observe"            "observe mode"
 }
 
-t_redaction_default_on() {
+t_redaction_pass_through_on() {
+  # Pure rendering check: given "false", the block emits redaction on.
+  # This proves the rendering layer respects the caller's choice; the
+  # install.sh default-arg-parsing contract is asserted in
+  # test_arg_parsing.sh::t_install_default_redaction_is_on so we don't
+  # duplicate the "what's the default" check at two layers.
   local out
   out="$(render_config observe codex 18970 false "/var/lib/dc" codex)"
-  assert_contains "${out}" "disable_redaction: false" "redaction enabled by default"
+  assert_contains "${out}" "disable_redaction: false" "renderer emits redaction ON when false is passed"
 }
 
-t_redaction_disabled_opt_out() {
+t_redaction_pass_through_off() {
   local out
   out="$(render_config action codex 18970 true "/var/lib/dc" codex)"
-  assert_contains "${out}" "disable_redaction: true" "redaction disabled opt-out"
+  assert_contains "${out}" "disable_redaction: true" "renderer emits redaction OFF when true is passed"
 }
 
 t_yaml_parses() {
@@ -70,6 +75,6 @@ t_yaml_parses() {
 
 run_case "single-connector config"  t_single_connector
 run_case "multi-connector config"   t_multi_connector
-run_case "redaction default (on)"   t_redaction_default_on
-run_case "redaction opt-out flag"   t_redaction_disabled_opt_out
+run_case "renderer pass-through: redaction on"  t_redaction_pass_through_on
+run_case "renderer pass-through: redaction off" t_redaction_pass_through_off
 run_case "rendered YAML parses"     t_yaml_parses

--- a/packaging/macos/tests/test_render_config.sh
+++ b/packaging/macos/tests/test_render_config.sh
@@ -8,7 +8,9 @@ t_single_connector() {
 
   assert_contains "${out}" "config_version: 6"                  "config_version present"
   assert_contains "${out}" "deployment_mode: managed_enterprise" "managed_enterprise mode"
-  assert_contains "${out}" "data_dir: \"/Library/Application Support/DefenseClaw\"" "data_dir quoted"
+  assert_contains "${out}" "data_dir: \"/Library/Application Support/DefenseClaw/runtime\"" "data_dir points at runtime subdir (config-adjacent path stays root-only)"
+  assert_contains "${out}" "audit_db: \"/Library/Application Support/DefenseClaw/runtime/audit.db\"" "audit_db under runtime"
+  assert_contains "${out}" "judge_bodies_db: \"/Library/Application Support/DefenseClaw/runtime/judge_bodies.db\"" "judge_bodies_db under runtime"
   assert_contains "${out}" "api_port: 18970"                    "api_port"
   assert_contains "${out}" "disable_redaction: false"           "redaction disabled flag"
   assert_contains "${out}" "mode: action"                       "guardrail mode"
@@ -32,6 +34,22 @@ t_multi_connector() {
   assert_contains "${out}" "    codex:"               "codex entry under connectors"
   assert_contains "${out}" "disable_redaction: true"  "redaction explicit opt-out"
   assert_contains "${out}" "mode: observe"            "observe mode"
+}
+
+t_runtime_paths_disjoint_from_config_parent() {
+  # Regression guard: the managed_enterprise trust check walks every
+  # ancestor of config.yaml and requires each to be root-owned with
+  # no group/other write bits. That means data_dir CANNOT be the same
+  # directory that holds config.yaml (installer needs to chown it to
+  # the service user). Assert the renderer places data_dir strictly
+  # BELOW the support dir.
+  local out support runtime
+  support="/Library/Application Support/DefenseClaw"
+  runtime="${support}/runtime"
+  out="$(render_config observe cursor 18970 false "${support}" cursor)"
+  assert_contains "${out}" "data_dir: \"${runtime}\"" "data_dir under support"
+  # If data_dir was ever set back to support itself, trust check fails.
+  assert_not_contains "${out}" "data_dir: \"${support}\"" "data_dir MUST NOT equal support dir"
 }
 
 t_redaction_pass_through_on() {
@@ -75,6 +93,7 @@ t_yaml_parses() {
 
 run_case "single-connector config"  t_single_connector
 run_case "multi-connector config"   t_multi_connector
+run_case "runtime paths under support (trust-check invariant)" t_runtime_paths_disjoint_from_config_parent
 run_case "renderer pass-through: redaction on"  t_redaction_pass_through_on
 run_case "renderer pass-through: redaction off" t_redaction_pass_through_off
 run_case "rendered YAML parses"     t_yaml_parses

--- a/packaging/macos/tests/test_render_config.sh
+++ b/packaging/macos/tests/test_render_config.sh
@@ -30,20 +30,20 @@ t_multi_connector() {
   assert_contains "${out}" "    cursor:"              "cursor entry under connectors"
   assert_contains "${out}" "    claudecode:"          "claudecode entry under connectors"
   assert_contains "${out}" "    codex:"               "codex entry under connectors"
-  assert_contains "${out}" "disable_redaction: true"  "redaction-on (default)"
+  assert_contains "${out}" "disable_redaction: true"  "redaction explicit opt-out"
   assert_contains "${out}" "mode: observe"            "observe mode"
 }
 
-t_redaction_default_off() {
+t_redaction_default_on() {
   local out
-  out="$(render_config observe codex 18970 true "/var/lib/dc" codex)"
-  assert_contains "${out}" "disable_redaction: true" "redaction kill-switch flag"
+  out="$(render_config observe codex 18970 false "/var/lib/dc" codex)"
+  assert_contains "${out}" "disable_redaction: false" "redaction enabled by default"
 }
 
-t_redaction_enabled() {
+t_redaction_disabled_opt_out() {
   local out
-  out="$(render_config action codex 18970 false "/var/lib/dc" codex)"
-  assert_contains "${out}" "disable_redaction: false" "redaction enabled"
+  out="$(render_config action codex 18970 true "/var/lib/dc" codex)"
+  assert_contains "${out}" "disable_redaction: true" "redaction disabled opt-out"
 }
 
 t_yaml_parses() {
@@ -70,6 +70,6 @@ t_yaml_parses() {
 
 run_case "single-connector config"  t_single_connector
 run_case "multi-connector config"   t_multi_connector
-run_case "redaction default (off)"  t_redaction_default_off
-run_case "redaction enabled flag"   t_redaction_enabled
+run_case "redaction default (on)"   t_redaction_default_on
+run_case "redaction opt-out flag"   t_redaction_disabled_opt_out
 run_case "rendered YAML parses"     t_yaml_parses

--- a/packaging/macos/tests/test_render_config.sh
+++ b/packaging/macos/tests/test_render_config.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# render_config: single vs multi-connector YAML output.
+. "${PKG_DIR}/lib/installer_lib.sh"
+
+t_single_connector() {
+  local out
+  out="$(render_config action cursor 18970 false "/Library/Application Support/DefenseClaw" cursor)"
+
+  assert_contains "${out}" "config_version: 6"                  "config_version present"
+  assert_contains "${out}" "deployment_mode: managed_enterprise" "managed_enterprise mode"
+  assert_contains "${out}" "data_dir: \"/Library/Application Support/DefenseClaw\"" "data_dir quoted"
+  assert_contains "${out}" "api_port: 18970"                    "api_port"
+  assert_contains "${out}" "disable_redaction: false"           "redaction disabled flag"
+  assert_contains "${out}" "mode: action"                       "guardrail mode"
+  assert_contains "${out}" "scanner_mode: both"                 "scanner_mode"
+  assert_contains "${out}" "connector: cursor"                  "primary connector"
+  assert_not_contains "${out}" "  connectors:"                  "no multi-connector map when single"
+  assert_contains "${out}" "mcp:"                               "asset_policy mcp block"
+  assert_contains "${out}" "default: deny"                      "mcp default deny"
+  assert_contains "${out}" "application_protection:"            "application_protection block"
+  assert_contains "${out}" "enabled: false"                     "application_protection disabled"
+}
+
+t_multi_connector() {
+  local out
+  out="$(render_config observe cursor 18970 true "/Library/Application Support/DefenseClaw" cursor claudecode codex)"
+
+  assert_contains "${out}" "connector: cursor"        "primary is first arg"
+  assert_contains "${out}" "  connectors:"            "multi-connector map present"
+  assert_contains "${out}" "    cursor:"              "cursor entry under connectors"
+  assert_contains "${out}" "    claudecode:"          "claudecode entry under connectors"
+  assert_contains "${out}" "    codex:"               "codex entry under connectors"
+  assert_contains "${out}" "disable_redaction: true"  "redaction-on (default)"
+  assert_contains "${out}" "mode: observe"            "observe mode"
+}
+
+t_redaction_default_off() {
+  local out
+  out="$(render_config observe codex 18970 true "/var/lib/dc" codex)"
+  assert_contains "${out}" "disable_redaction: true" "redaction kill-switch flag"
+}
+
+t_redaction_enabled() {
+  local out
+  out="$(render_config action codex 18970 false "/var/lib/dc" codex)"
+  assert_contains "${out}" "disable_redaction: false" "redaction enabled"
+}
+
+t_yaml_parses() {
+  # Best-effort: if python3 + a yaml module exist, parse the output to
+  # catch indentation regressions.
+  if ! command -v /usr/bin/python3 >/dev/null 2>&1; then
+    if [[ "${VERBOSE:-false}" == "true" ]]; then printf '  skip (no python3)\n'; fi
+    return 0
+  fi
+  if ! /usr/bin/python3 -c "import yaml" 2>/dev/null; then
+    if [[ "${VERBOSE:-false}" == "true" ]]; then printf '  skip (PyYAML not installed)\n'; fi
+    return 0
+  fi
+  local out parsed
+  out="$(render_config action cursor 18970 false "/Library/Application Support/DefenseClaw" cursor claudecode)"
+  parsed="$(printf '%s\n' "${out}" | /usr/bin/python3 -c 'import sys,yaml,json; print(json.dumps(yaml.safe_load(sys.stdin)))' 2>&1)" || {
+    _fail "rendered YAML did not parse: ${parsed}"
+    return 1
+  }
+  assert_contains "${parsed}" '"deployment_mode": "managed_enterprise"' "parsed yaml has managed_enterprise"
+  assert_contains "${parsed}" '"connector": "cursor"' "parsed yaml has primary connector"
+  assert_contains "${parsed}" '"connectors":' "parsed yaml has connectors map"
+}
+
+run_case "single-connector config"  t_single_connector
+run_case "multi-connector config"   t_multi_connector
+run_case "redaction default (off)"  t_redaction_default_off
+run_case "redaction enabled flag"   t_redaction_enabled
+run_case "rendered YAML parses"     t_yaml_parses

--- a/packaging/macos/tests/test_scrub_agent_configs.sh
+++ b/packaging/macos/tests/test_scrub_agent_configs.sh
@@ -2,7 +2,10 @@
 # Scrub helper: remove DefenseClaw entries from user agent configs while
 # preserving the user's own state. Driven by lib/scrub_agent_configs.py.
 SCRUB="${PKG_DIR}/lib/scrub_agent_configs.py"
-PY=/usr/bin/python3
+# Prefer a PATH-resolved python3 for portability across Linux distros
+# where /usr/bin/python3 may not exist; fall back to the macOS system
+# python if PATH lookup fails.
+PY="$(command -v python3 || printf '/usr/bin/python3')"
 
 t_cursor_drops_dc_keeps_user_entry() {
   local d; d="$(mktest_tmp)"
@@ -42,6 +45,52 @@ JSON
   local rc=$?; assert_status "${rc}" 0 "scrub exit 0"
   local out; out="$(cat "${d}/hooks.json")"
   assert_contains "${out}" "my-hook.sh" "user hook preserved"
+}
+
+t_claudecode_strips_managed_env_keys() {
+  # DefenseClaw's Claude connector writes a specific set of env keys
+  # (see claudeCodeOtelEnvKeys in the Go connector). Scrub must drop
+  # them and preserve unrelated user env entries.
+  local d; d="$(mktest_tmp)"
+  cat > "${d}/settings.json" <<'JSON'
+{
+  "hooks": {},
+  "env": {
+    "MY_USER_VAR": "keep-me",
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:18970",
+    "OTEL_EXPORTER_OTLP_HEADERS": "x-defenseclaw-token=abc",
+    "DEFENSECLAW_FAIL_MODE": "open"
+  }
+}
+JSON
+  ${PY} "${SCRUB}" claudecode "${d}/settings.json"
+  local rc=$?; assert_status "${rc}" 0
+  local out; out="$(cat "${d}/settings.json")"
+  assert_contains     "${out}" "MY_USER_VAR"                 "user env preserved"
+  assert_contains     "${out}" "keep-me"                     "user env value preserved"
+  assert_not_contains "${out}" "CLAUDE_CODE_ENABLE_TELEMETRY" "managed env key removed"
+  assert_not_contains "${out}" "OTEL_EXPORTER_OTLP_ENDPOINT"  "managed env key removed"
+  assert_not_contains "${out}" "OTEL_EXPORTER_OTLP_HEADERS"   "managed env key removed"
+  assert_not_contains "${out}" "DEFENSECLAW_FAIL_MODE"        "managed env key removed"
+}
+
+t_claudecode_drops_all_managed_env() {
+  # When every env entry is DefenseClaw-owned, the whole env block
+  # should be removed (leaving the file tidy).
+  local d; d="$(mktest_tmp)"
+  cat > "${d}/settings.json" <<'JSON'
+{
+  "hooks": {},
+  "env": {
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:18970"
+  }
+}
+JSON
+  ${PY} "${SCRUB}" claudecode "${d}/settings.json"
+  local out; out="$(cat "${d}/settings.json")"
+  assert_not_contains "${out}" "\"env\"" "empty env block removed"
 }
 
 t_claudecode_preserves_non_hook_state() {
@@ -103,6 +152,34 @@ TOML
   assert_not_contains "${out}" "defenseclaw"                "no DC refs"
 }
 
+t_codex_stops_at_dotted_table_header() {
+  # Regression: the previous scrub's "next section" regex only matched
+  # simple [name] headers, so if [projects.foo] appeared after
+  # a DefenseClaw-owned [hooks] with no intervening blank line, the
+  # scrub could eat unrelated user state under [projects.foo].
+  local d; d="$(mktest_tmp)"
+  cat > "${d}/config.toml" <<'TOML'
+model = "gpt-5"
+
+[hooks]
+PreToolUse = "/Users/u/.defenseclaw/hooks/codex-hook.sh"
+[projects."/Users/u/dev"]
+trust_level = "trusted"
+model = "override"
+
+[[some.array.of.tables]]
+name = "user-owned-array-entry"
+TOML
+  ${PY} "${SCRUB}" codex "${d}/config.toml"
+  local out; out="$(cat "${d}/config.toml")"
+  assert_not_contains "${out}" "[hooks]"                        "[hooks] removed"
+  assert_not_contains "${out}" "defenseclaw"                    "no DC refs"
+  assert_contains     "${out}" "[projects.\"/Users/u/dev\"]"    "dotted table preserved"
+  assert_contains     "${out}" "trust_level = \"trusted\""      "dotted table content preserved"
+  assert_contains     "${out}" "[[some.array.of.tables]]"       "array-of-tables preserved"
+  assert_contains     "${out}" "user-owned-array-entry"         "array-of-tables content preserved"
+}
+
 t_codex_skips_unrelated_otel_or_hooks_blocks() {
   # If the user has their own [otel] block that does NOT reference
   # DefenseClaw, we must leave it alone. (DefenseClaw owns these blocks
@@ -155,8 +232,11 @@ t_empty_object_safe() {
 
 run_case "cursor: drops DC, keeps user entry (idempotent)" t_cursor_drops_dc_keeps_user_entry
 run_case "cursor: no-op without DC entries"                 t_cursor_no_op_when_no_dc_entries
+run_case "claudecode: strips managed env keys"              t_claudecode_strips_managed_env_keys
+run_case "claudecode: drops env block if only DC keys"      t_claudecode_drops_all_managed_env
 run_case "claudecode: preserves theme/env"                  t_claudecode_preserves_non_hook_state
 run_case "codex: strips managed sections"                   t_codex_strips_managed_sections
+run_case "codex: stops at dotted/array table headers"       t_codex_stops_at_dotted_table_header
 run_case "codex: leaves unrelated [otel]/[hooks] alone"     t_codex_skips_unrelated_otel_or_hooks_blocks
 run_case "missing file returns 2"                           t_missing_file_returns_2
 run_case "unsupported connector returns 3"                  t_unsupported_connector_returns_3

--- a/packaging/macos/tests/test_scrub_agent_configs.sh
+++ b/packaging/macos/tests/test_scrub_agent_configs.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Scrub helper: remove DefenseClaw entries from user agent configs while
+# preserving the user's own state. Driven by lib/scrub_agent_configs.py.
+SCRUB="${PKG_DIR}/lib/scrub_agent_configs.py"
+PY=/usr/bin/python3
+
+t_cursor_drops_dc_keeps_user_entry() {
+  local d; d="$(mktest_tmp)"
+  cat > "${d}/hooks.json" <<'JSON'
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {"type":"command","command":"/Users/u/.defenseclaw/hooks/cursor-hook.sh","timeout":30000,"failClosed":true},
+      {"type":"command","command":"/Users/u/.local/bin/my-other-hook.sh","timeout":5000}
+    ],
+    "sessionStart": [
+      {"type":"command","command":"/Users/u/.defenseclaw/hooks/cursor-hook.sh"}
+    ]
+  }
+}
+JSON
+  ${PY} "${SCRUB}" cursor "${d}/hooks.json"
+  local rc=$?; assert_status "${rc}" 0 "scrub exit 0"
+  local out; out="$(cat "${d}/hooks.json")"
+  assert_not_contains "${out}" "defenseclaw" "DefenseClaw refs removed"
+  assert_contains     "${out}" "my-other-hook.sh" "user hook preserved"
+  assert_not_contains "${out}" "sessionStart"     "DC-only event key removed"
+  # Idempotent: second run is a no-op.
+  ${PY} "${SCRUB}" cursor "${d}/hooks.json"
+  local rc2=$?; assert_status "${rc2}" 0 "second run also exit 0"
+  local out2; out2="$(cat "${d}/hooks.json")"
+  assert_eq "${out}" "${out2}" "idempotent (no further changes)"
+}
+
+t_cursor_no_op_when_no_dc_entries() {
+  local d; d="$(mktest_tmp)"
+  cat > "${d}/hooks.json" <<'JSON'
+{"version":1,"hooks":{"preToolUse":[{"type":"command","command":"/Users/u/my-hook.sh"}]}}
+JSON
+  ${PY} "${SCRUB}" cursor "${d}/hooks.json"
+  local rc=$?; assert_status "${rc}" 0 "scrub exit 0"
+  local out; out="$(cat "${d}/hooks.json")"
+  assert_contains "${out}" "my-hook.sh" "user hook preserved"
+}
+
+t_claudecode_preserves_non_hook_state() {
+  local d; d="$(mktest_tmp)"
+  cat > "${d}/settings.json" <<'JSON'
+{
+  "theme": "dark",
+  "env": {"FOO":"bar"},
+  "hooks": {
+    "PreToolUse": [
+      {"matcher":"Bash","hooks":[{"type":"command","command":"/Users/u/.defenseclaw/hooks/claudecode-hook.sh"}]}
+    ],
+    "UserPromptSubmit": [
+      {"hooks":[{"type":"command","command":"/Users/u/.defenseclaw/hooks/claudecode-hook.sh"}]},
+      {"hooks":[{"type":"command","command":"/Users/u/my-prompt-hook.sh"}]}
+    ]
+  }
+}
+JSON
+  ${PY} "${SCRUB}" claudecode "${d}/settings.json"
+  local rc=$?; assert_status "${rc}" 0
+  local out; out="$(cat "${d}/settings.json")"
+  assert_contains     "${out}" "\"theme\""           "non-hook state preserved (theme)"
+  assert_contains     "${out}" "\"env\""             "non-hook state preserved (env)"
+  assert_contains     "${out}" "\"FOO\": \"bar\""    "env values preserved"
+  assert_not_contains "${out}" "defenseclaw"         "DC refs removed"
+  assert_contains     "${out}" "my-prompt-hook.sh"   "user prompt hook preserved"
+  assert_not_contains "${out}" "PreToolUse"          "DC-only event key removed"
+}
+
+t_codex_strips_managed_sections() {
+  local d; d="$(mktest_tmp)"
+  cat > "${d}/config.toml" <<'TOML'
+model = "gpt-5"
+personality = "pragmatic"
+
+[projects."/Users/u/dev"]
+trust_level = "trusted"
+
+[hooks]
+PreToolUse = "/Users/u/.defenseclaw/hooks/codex-hook.sh"
+SessionStart = "/Users/u/.defenseclaw/hooks/codex-hook.sh"
+
+[otel]
+otlp_endpoint = "http://127.0.0.1:18970/v1/logs"
+
+notify = ["bash", "/Users/u/.defenseclaw/notify-bridge.sh"]
+TOML
+  ${PY} "${SCRUB}" codex "${d}/config.toml"
+  local rc=$?; assert_status "${rc}" 0
+  local out; out="$(cat "${d}/config.toml")"
+  assert_contains     "${out}" "model = \"gpt-5\""        "model preserved"
+  assert_contains     "${out}" "personality = \"pragmatic\"" "personality preserved"
+  assert_contains     "${out}" "[projects.\"/Users/u/dev\"]" "projects preserved"
+  assert_contains     "${out}" "trust_level = \"trusted\""  "project trust preserved"
+  assert_not_contains "${out}" "[hooks]"                    "[hooks] section removed"
+  assert_not_contains "${out}" "[otel]"                     "[otel] section removed"
+  assert_not_contains "${out}" "notify ="                   "notify array removed"
+  assert_not_contains "${out}" "defenseclaw"                "no DC refs"
+}
+
+t_codex_skips_unrelated_otel_or_hooks_blocks() {
+  # If the user has their own [otel] block that does NOT reference
+  # DefenseClaw, we must leave it alone. (DefenseClaw owns these blocks
+  # in managed installs, so in practice they always do reference DC,
+  # but we should not assume.)
+  local d; d="$(mktest_tmp)"
+  cat > "${d}/config.toml" <<'TOML'
+model = "gpt-5"
+
+[otel]
+otlp_endpoint = "https://my-vendor.example/v1"
+
+[hooks]
+PreToolUse = "/Users/u/my-own-hook.sh"
+TOML
+  ${PY} "${SCRUB}" codex "${d}/config.toml"
+  local rc=$?; assert_status "${rc}" 0
+  local out; out="$(cat "${d}/config.toml")"
+  assert_contains "${out}" "[otel]"     "user [otel] preserved"
+  assert_contains "${out}" "my-vendor"  "user otel endpoint preserved"
+  assert_contains "${out}" "[hooks]"    "user [hooks] preserved"
+  assert_contains "${out}" "my-own-hook.sh" "user hook script preserved"
+}
+
+t_missing_file_returns_2() {
+  ${PY} "${SCRUB}" cursor "/nonexistent/$(date +%s).json" 2>/dev/null
+  local rc=$?; assert_status "${rc}" 2 "missing file returns 2"
+}
+
+t_unsupported_connector_returns_3() {
+  local d; d="$(mktest_tmp)"
+  printf '{}\n' > "${d}/x.json"
+  ${PY} "${SCRUB}" geminicli "${d}/x.json" 2>/dev/null
+  local rc=$?; assert_status "${rc}" 3 "unsupported connector returns 3"
+}
+
+t_garbage_json_returns_4() {
+  local d; d="$(mktest_tmp)"
+  printf 'this is not json\n' > "${d}/broken.json"
+  ${PY} "${SCRUB}" cursor "${d}/broken.json" 2>/dev/null
+  local rc=$?; assert_status "${rc}" 4 "garbage JSON returns 4"
+}
+
+t_empty_object_safe() {
+  local d; d="$(mktest_tmp)"
+  printf '{}\n' > "${d}/empty.json"
+  ${PY} "${SCRUB}" cursor "${d}/empty.json"
+  local rc=$?; assert_status "${rc}" 0 "empty JSON is a no-op"
+}
+
+run_case "cursor: drops DC, keeps user entry (idempotent)" t_cursor_drops_dc_keeps_user_entry
+run_case "cursor: no-op without DC entries"                 t_cursor_no_op_when_no_dc_entries
+run_case "claudecode: preserves theme/env"                  t_claudecode_preserves_non_hook_state
+run_case "codex: strips managed sections"                   t_codex_strips_managed_sections
+run_case "codex: leaves unrelated [otel]/[hooks] alone"     t_codex_skips_unrelated_otel_or_hooks_blocks
+run_case "missing file returns 2"                           t_missing_file_returns_2
+run_case "unsupported connector returns 3"                  t_unsupported_connector_returns_3
+run_case "garbage JSON returns 4"                           t_garbage_json_returns_4
+run_case "empty object is no-op"                            t_empty_object_safe

--- a/packaging/macos/uninstall.sh
+++ b/packaging/macos/uninstall.sh
@@ -34,6 +34,7 @@ PURGE="false"
 ASSUME_YES="false"
 TARGET_USER=""
 KEEP_AGENT_CONFIGS="false"
+SCRUB_FAILED="false"
 
 # ---- helpers ------------------------------------------------------------
 
@@ -91,8 +92,9 @@ if [[ "${PURGE}" == "true" ]]; then
   fi
   if [[ -n "${TARGET_USER}" ]]; then
     TARGET_HOME="$(dscl . -read "/Users/${TARGET_USER}" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
-    TARGET_UID="$(id -u "${TARGET_USER}" 2>/dev/null || echo "")"
-    TARGET_GID="$(id -g "${TARGET_USER}" 2>/dev/null || echo "")"
+    if [[ -z "${TARGET_HOME}" || ! -d "${TARGET_HOME}" ]]; then
+      die "could not resolve home for --user ${TARGET_USER} (dscl returned '${TARGET_HOME}'); refusing to purge without a valid target"
+    fi
   fi
   if [[ "${ASSUME_YES}" != "true" ]]; then
     printf '[uninstall] --purge will DELETE:\n'
@@ -133,6 +135,8 @@ fi
 # we delete ~/.defenseclaw/hooks/*-hook.sh. The scrub runs as the target
 # user (drop privileges via sudo -u) so file ownership is preserved.
 
+PY="$(command -v python3 || printf '/usr/bin/python3')"
+
 scrub_agent_config() {
   local connector="$1"
   local cfg="$2"
@@ -141,19 +145,23 @@ scrub_agent_config() {
   fi
   if [[ ! -f "${SCRUB_PY}" ]]; then
     warn "scrub helper missing: ${SCRUB_PY}; skipping ${cfg}"
+    SCRUB_FAILED="true"
     return 0
   fi
   log "  scrubbing ${connector} entries from ${cfg}"
   local rc=0
   if [[ -n "${TARGET_USER:-}" && $(id -u "${TARGET_USER}" 2>/dev/null) != "0" ]]; then
-    sudo -u "${TARGET_USER}" /usr/bin/python3 "${SCRUB_PY}" "${connector}" "${cfg}" || rc=$?
+    sudo -u "${TARGET_USER}" "${PY}" "${SCRUB_PY}" "${connector}" "${cfg}" || rc=$?
   else
-    /usr/bin/python3 "${SCRUB_PY}" "${connector}" "${cfg}" || rc=$?
+    "${PY}" "${SCRUB_PY}" "${connector}" "${cfg}" || rc=$?
   fi
   case "${rc}" in
     0) ;;
     2) ;;  # file missing — fine
-    *) warn "  scrub exited ${rc} for ${cfg} (left unmodified)";;
+    *)
+      warn "  scrub exited ${rc} for ${cfg} (left unmodified)"
+      SCRUB_FAILED="true"
+      ;;
   esac
 }
 
@@ -188,6 +196,13 @@ if [[ "${PURGE}" == "true" ]]; then
   done
 
   if [[ -n "${TARGET_USER:-}" && -n "${TARGET_HOME:-}" && -d "${TARGET_HOME}/.defenseclaw" ]]; then
+    if [[ "${SCRUB_FAILED}" == "true" && "${KEEP_AGENT_CONFIGS}" != "true" ]]; then
+      # We're about to delete the hook scripts, but at least one agent
+      # config still references them. Deleting now would leave every
+      # future agent tool call fail-closed (exit 127 → block). Refuse
+      # rather than paint the operator into that corner.
+      die "one or more agent-config scrubs failed; refusing to delete ${TARGET_HOME}/.defenseclaw (rerun with --keep-agent-configs to force the delete, then repair or reinstall)"
+    fi
     log "purging ${TARGET_HOME}/.defenseclaw"
     rm -rf "${TARGET_HOME}/.defenseclaw"
     if [[ "${KEEP_AGENT_CONFIGS}" == "true" ]]; then

--- a/packaging/macos/uninstall.sh
+++ b/packaging/macos/uninstall.sh
@@ -12,14 +12,17 @@
 #
 # Per-user cleanup (with --purge):
 #   - ~/.defenseclaw/                (DefenseClaw-owned hook scripts/tokens)
-# Note: the user's native agent config files (~/.codex/config.toml,
-# ~/.claude/settings.json, ~/.cursor/hooks.json) are NOT touched even on
-# --purge because they may contain non-DefenseClaw entries the user owns.
-# Those files will still contain DefenseClaw hook entries pointing at
-# missing scripts — the user can re-run install, or remove those entries
-# by hand.
+#   - DefenseClaw entries scrubbed from each native agent hook config:
+#       ~/.codex/config.toml         (strip [hooks], [otel], notify=)
+#       ~/.claude/settings.json      (strip DC entries from hooks map)
+#       ~/.cursor/hooks.json         (strip DC entries from hooks map)
+#     Non-DefenseClaw user entries in those files are preserved verbatim.
+#     Pass --keep-agent-configs to skip the scrub.
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRUB_PY="${SCRIPT_DIR}/lib/scrub_agent_configs.py"
 
 INSTALL_PREFIX="/Library/DefenseClaw"
 SUPPORT_DIR="/Library/Application Support/DefenseClaw"
@@ -30,6 +33,7 @@ LAUNCHD_LABEL="com.defenseclaw.gateway"
 PURGE="false"
 ASSUME_YES="false"
 TARGET_USER=""
+KEEP_AGENT_CONFIGS="false"
 
 # ---- helpers ------------------------------------------------------------
 
@@ -42,13 +46,22 @@ usage() {
 Usage: sudo $0 [options]
 
 Options:
-  --purge      Also delete:
-                 ${SUPPORT_DIR}  (config + audit DB)
-                 ${LOGS_DIR}                       (gateway logs)
-                 ~/.defenseclaw/ for the invoking user (hook scripts)
-  --user USER  Per-user cleanup target for --purge (default: \$SUDO_USER)
-  -y, --yes    Don't prompt for --purge confirmation
-  -h, --help   Show this help
+  --purge               Also delete:
+                          ${SUPPORT_DIR}  (config + audit DB)
+                          ${LOGS_DIR}                       (gateway logs)
+                          ~/.defenseclaw/ for the target user (hook scripts)
+                        AND scrub DefenseClaw entries from:
+                          ~/.codex/config.toml
+                          ~/.claude/settings.json
+                          ~/.cursor/hooks.json
+                        Non-DefenseClaw entries in those files are preserved.
+  --keep-agent-configs  With --purge, skip the agent-config scrub. Hook
+                        scripts will be deleted, leaving dangling references
+                        that fail-close every agent tool call. Use only if
+                        you intend to immediately reinstall.
+  --user USER           Per-user cleanup target for --purge (default: \$SUDO_USER)
+  -y, --yes             Don't prompt for --purge confirmation
+  -h, --help            Show this help
 
 Default behavior preserves runtime state so reinstall keeps audit history.
 EOF
@@ -58,10 +71,11 @@ EOF
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --purge)  PURGE="true"; shift;;
-    --user)   TARGET_USER="${2:?}"; shift 2;;
-    -y|--yes) ASSUME_YES="true"; shift;;
-    -h|--help) usage; exit 0;;
+    --purge)               PURGE="true"; shift;;
+    --keep-agent-configs)  KEEP_AGENT_CONFIGS="true"; shift;;
+    --user)                TARGET_USER="${2:?}"; shift 2;;
+    -y|--yes)              ASSUME_YES="true"; shift;;
+    -h|--help)             usage; exit 0;;
     *) die "unknown flag: $1 (try --help)";;
   esac
 done
@@ -77,12 +91,24 @@ if [[ "${PURGE}" == "true" ]]; then
   fi
   if [[ -n "${TARGET_USER}" ]]; then
     TARGET_HOME="$(dscl . -read "/Users/${TARGET_USER}" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
+    TARGET_UID="$(id -u "${TARGET_USER}" 2>/dev/null || echo "")"
+    TARGET_GID="$(id -g "${TARGET_USER}" 2>/dev/null || echo "")"
   fi
   if [[ "${ASSUME_YES}" != "true" ]]; then
     printf '[uninstall] --purge will DELETE:\n'
     printf '  %s\n' "${SUPPORT_DIR}" "${LOGS_DIR}"
-    [[ -n "${TARGET_USER:-}" && -n "${TARGET_HOME:-}" ]] && \
+    if [[ -n "${TARGET_USER:-}" && -n "${TARGET_HOME:-}" ]]; then
       printf '  %s/.defenseclaw/\n' "${TARGET_HOME}"
+      if [[ "${KEEP_AGENT_CONFIGS}" != "true" ]]; then
+        printf '[uninstall] and will SCRUB DefenseClaw entries from:\n'
+        for f in "${TARGET_HOME}/.codex/config.toml" \
+                 "${TARGET_HOME}/.claude/settings.json" \
+                 "${TARGET_HOME}/.cursor/hooks.json"; do
+          [[ -f "${f}" ]] && printf '  %s\n' "${f}"
+        done
+        printf '  (non-DefenseClaw entries preserved)\n'
+      fi
+    fi
     printf '[uninstall] type yes to continue: '
     read -r REPLY
     [[ "${REPLY}" == "yes" ]] || die "purge declined"
@@ -98,6 +124,45 @@ if launchctl print "system/${LAUNCHD_LABEL}" >/dev/null 2>&1; then
     warn "bootout failed; the daemon may already be stopped"
 else
   log "daemon not loaded; skipping bootout"
+fi
+
+# ---- agent-config scrub (BEFORE we delete ~/.defenseclaw) --------------
+#
+# We scrub the user's native agent hook configs first so the agent doesn't
+# start hitting "command not found" + fail-close every tool call the moment
+# we delete ~/.defenseclaw/hooks/*-hook.sh. The scrub runs as the target
+# user (drop privileges via sudo -u) so file ownership is preserved.
+
+scrub_agent_config() {
+  local connector="$1"
+  local cfg="$2"
+  if [[ ! -f "${cfg}" ]]; then
+    return 0
+  fi
+  if [[ ! -f "${SCRUB_PY}" ]]; then
+    warn "scrub helper missing: ${SCRUB_PY}; skipping ${cfg}"
+    return 0
+  fi
+  log "  scrubbing ${connector} entries from ${cfg}"
+  local rc=0
+  if [[ -n "${TARGET_USER:-}" && $(id -u "${TARGET_USER}" 2>/dev/null) != "0" ]]; then
+    sudo -u "${TARGET_USER}" /usr/bin/python3 "${SCRUB_PY}" "${connector}" "${cfg}" || rc=$?
+  else
+    /usr/bin/python3 "${SCRUB_PY}" "${connector}" "${cfg}" || rc=$?
+  fi
+  case "${rc}" in
+    0) ;;
+    2) ;;  # file missing — fine
+    *) warn "  scrub exited ${rc} for ${cfg} (left unmodified)";;
+  esac
+}
+
+if [[ "${PURGE}" == "true" \
+   && "${KEEP_AGENT_CONFIGS}" != "true" \
+   && -n "${TARGET_HOME:-}" ]]; then
+  scrub_agent_config codex      "${TARGET_HOME}/.codex/config.toml"
+  scrub_agent_config claudecode "${TARGET_HOME}/.claude/settings.json"
+  scrub_agent_config cursor     "${TARGET_HOME}/.cursor/hooks.json"
 fi
 
 # ---- remove files we own unconditionally --------------------------------
@@ -125,17 +190,20 @@ if [[ "${PURGE}" == "true" ]]; then
   if [[ -n "${TARGET_USER:-}" && -n "${TARGET_HOME:-}" && -d "${TARGET_HOME}/.defenseclaw" ]]; then
     log "purging ${TARGET_HOME}/.defenseclaw"
     rm -rf "${TARGET_HOME}/.defenseclaw"
-    warn "your native agent configs still contain DefenseClaw hook entries:"
-    for cfg in "${TARGET_HOME}/.codex/config.toml" "${TARGET_HOME}/.claude/settings.json" "${TARGET_HOME}/.cursor/hooks.json"; do
-      [[ -f "${cfg}" ]] && warn "  ${cfg}"
-    done
-    warn "  (the hook scripts they reference are now gone; remove the entries"
-    warn "   by hand or just re-run install.sh to overwrite them with valid wiring)"
+    if [[ "${KEEP_AGENT_CONFIGS}" == "true" ]]; then
+      warn "--keep-agent-configs: agent configs still reference deleted hook scripts."
+      warn "  agents will fail-close every tool call until reinstall or manual edit."
+      for cfg in "${TARGET_HOME}/.codex/config.toml" \
+                 "${TARGET_HOME}/.claude/settings.json" \
+                 "${TARGET_HOME}/.cursor/hooks.json"; do
+        [[ -f "${cfg}" ]] && warn "    ${cfg}"
+      done
+    fi
   fi
 else
   log "preserving ${SUPPORT_DIR} (config + audit DB)"
   log "preserving ${LOGS_DIR}"
-  log "  (re-run with --purge to delete these and per-user ~/.defenseclaw)"
+  log "  (re-run with --purge to delete these and clean up per-user state)"
 fi
 
 # ---- sanity check -------------------------------------------------------

--- a/packaging/macos/uninstall.sh
+++ b/packaging/macos/uninstall.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# DefenseClaw macOS uninstaller.
+#
+# Removes:
+#   - LaunchDaemon (com.defenseclaw.gateway)
+#   - /Library/DefenseClaw/  (binary)
+#   - /Library/LaunchDaemons/com.defenseclaw.gateway.plist
+#
+# By default, system runtime state is PRESERVED so reinstall keeps audit
+# history. Pass --purge to wipe everything (system + per-user hook footprint).
+#
+# Per-user cleanup (with --purge):
+#   - ~/.defenseclaw/                (DefenseClaw-owned hook scripts/tokens)
+# Note: the user's native agent config files (~/.codex/config.toml,
+# ~/.claude/settings.json, ~/.cursor/hooks.json) are NOT touched even on
+# --purge because they may contain non-DefenseClaw entries the user owns.
+# Those files will still contain DefenseClaw hook entries pointing at
+# missing scripts — the user can re-run install, or remove those entries
+# by hand.
+
+set -euo pipefail
+
+INSTALL_PREFIX="/Library/DefenseClaw"
+SUPPORT_DIR="/Library/Application Support/DefenseClaw"
+LOGS_DIR="/Library/Logs/DefenseClaw"
+PLIST_DST="/Library/LaunchDaemons/com.defenseclaw.gateway.plist"
+LAUNCHD_LABEL="com.defenseclaw.gateway"
+
+PURGE="false"
+ASSUME_YES="false"
+TARGET_USER=""
+
+# ---- helpers ------------------------------------------------------------
+
+log()  { printf '[uninstall] %s\n' "$*"; }
+warn() { printf '[uninstall] WARN: %s\n' "$*" >&2; }
+die()  { printf '[uninstall] ERROR: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+  cat <<EOF
+Usage: sudo $0 [options]
+
+Options:
+  --purge      Also delete:
+                 ${SUPPORT_DIR}  (config + audit DB)
+                 ${LOGS_DIR}                       (gateway logs)
+                 ~/.defenseclaw/ for the invoking user (hook scripts)
+  --user USER  Per-user cleanup target for --purge (default: \$SUDO_USER)
+  -y, --yes    Don't prompt for --purge confirmation
+  -h, --help   Show this help
+
+Default behavior preserves runtime state so reinstall keeps audit history.
+EOF
+}
+
+# ---- arg parsing --------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --purge)  PURGE="true"; shift;;
+    --user)   TARGET_USER="${2:?}"; shift 2;;
+    -y|--yes) ASSUME_YES="true"; shift;;
+    -h|--help) usage; exit 0;;
+    *) die "unknown flag: $1 (try --help)";;
+  esac
+done
+
+# ---- preflight ----------------------------------------------------------
+
+[[ "$(uname -s)" == "Darwin" ]] || die "macOS only"
+[[ $EUID -eq 0 ]] || die "must run as root (try: sudo $0 $*)"
+
+if [[ "${PURGE}" == "true" ]]; then
+  if [[ -z "${TARGET_USER}" ]]; then
+    TARGET_USER="${SUDO_USER:-}"
+  fi
+  if [[ -n "${TARGET_USER}" ]]; then
+    TARGET_HOME="$(dscl . -read "/Users/${TARGET_USER}" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
+  fi
+  if [[ "${ASSUME_YES}" != "true" ]]; then
+    printf '[uninstall] --purge will DELETE:\n'
+    printf '  %s\n' "${SUPPORT_DIR}" "${LOGS_DIR}"
+    [[ -n "${TARGET_USER:-}" && -n "${TARGET_HOME:-}" ]] && \
+      printf '  %s/.defenseclaw/\n' "${TARGET_HOME}"
+    printf '[uninstall] type yes to continue: '
+    read -r REPLY
+    [[ "${REPLY}" == "yes" ]] || die "purge declined"
+  fi
+fi
+
+# ---- stop the daemon ----------------------------------------------------
+
+if launchctl print "system/${LAUNCHD_LABEL}" >/dev/null 2>&1; then
+  log "stopping LaunchDaemon (${LAUNCHD_LABEL})"
+  launchctl bootout "system/${LAUNCHD_LABEL}" 2>/dev/null || \
+    launchctl bootout system "${PLIST_DST}" 2>/dev/null || \
+    warn "bootout failed; the daemon may already be stopped"
+else
+  log "daemon not loaded; skipping bootout"
+fi
+
+# ---- remove files we own unconditionally --------------------------------
+
+if [[ -f "${PLIST_DST}" ]]; then
+  log "removing ${PLIST_DST}"
+  rm -f "${PLIST_DST}"
+fi
+
+if [[ -d "${INSTALL_PREFIX}" ]]; then
+  log "removing ${INSTALL_PREFIX}"
+  rm -rf "${INSTALL_PREFIX}"
+fi
+
+# ---- runtime state ------------------------------------------------------
+
+if [[ "${PURGE}" == "true" ]]; then
+  for d in "${SUPPORT_DIR}" "${LOGS_DIR}"; do
+    if [[ -d "${d}" ]]; then
+      log "purging ${d}"
+      rm -rf "${d}"
+    fi
+  done
+
+  if [[ -n "${TARGET_USER:-}" && -n "${TARGET_HOME:-}" && -d "${TARGET_HOME}/.defenseclaw" ]]; then
+    log "purging ${TARGET_HOME}/.defenseclaw"
+    rm -rf "${TARGET_HOME}/.defenseclaw"
+    warn "your native agent configs still contain DefenseClaw hook entries:"
+    for cfg in "${TARGET_HOME}/.codex/config.toml" "${TARGET_HOME}/.claude/settings.json" "${TARGET_HOME}/.cursor/hooks.json"; do
+      [[ -f "${cfg}" ]] && warn "  ${cfg}"
+    done
+    warn "  (the hook scripts they reference are now gone; remove the entries"
+    warn "   by hand or just re-run install.sh to overwrite them with valid wiring)"
+  fi
+else
+  log "preserving ${SUPPORT_DIR} (config + audit DB)"
+  log "preserving ${LOGS_DIR}"
+  log "  (re-run with --purge to delete these and per-user ~/.defenseclaw)"
+fi
+
+# ---- sanity check -------------------------------------------------------
+
+REMAINING=()
+[[ -e "${PLIST_DST}" ]]      && REMAINING+=("${PLIST_DST}")
+[[ -e "${INSTALL_PREFIX}" ]] && REMAINING+=("${INSTALL_PREFIX}")
+if [[ "${PURGE}" == "true" ]]; then
+  [[ -e "${SUPPORT_DIR}" ]] && REMAINING+=("${SUPPORT_DIR}")
+  [[ -e "${LOGS_DIR}" ]]    && REMAINING+=("${LOGS_DIR}")
+  [[ -n "${TARGET_HOME:-}" && -e "${TARGET_HOME}/.defenseclaw" ]] && REMAINING+=("${TARGET_HOME}/.defenseclaw")
+fi
+if (( ${#REMAINING[@]} > 0 )); then
+  warn "the following paths still exist (manual cleanup needed):"
+  printf '  - %s\n' "${REMAINING[@]}" >&2
+  exit 1
+fi
+
+log "done."

--- a/packaging/macos/uninstall.sh
+++ b/packaging/macos/uninstall.sh
@@ -53,6 +53,9 @@ Options:
                           ${SUPPORT_DIR}  (config + audit DB)
                           ${LOGS_DIR}                       (gateway logs)
                           ~/.defenseclaw/ for the target user (hook scripts)
+                          /Users/_defenseclaw + /Groups/_defenseclaw dscl
+                              records (service principal — deleted even if
+                              only half-provisioned by a prior failed run)
                         AND scrub DefenseClaw entries from:
                           ~/.codex/config.toml
                           ~/.claude/settings.json
@@ -137,9 +140,20 @@ fi
 
 if launchctl print "system/${LAUNCHD_LABEL}" >/dev/null 2>&1; then
   log "stopping LaunchDaemon (${LAUNCHD_LABEL})"
+  # Try both bootout forms (target vs plist path); either works and
+  # both are safe when the target is already gone.
   launchctl bootout "system/${LAUNCHD_LABEL}" 2>/dev/null || \
     launchctl bootout system "${PLIST_DST}" 2>/dev/null || \
     warn "bootout failed; the daemon may already be stopped"
+
+  # Wait briefly for launchd to fully release the service so a
+  # subsequent install can bootstrap without seeing "already loaded".
+  settle=0
+  while (( settle < 5 )); do
+    launchctl print "system/${LAUNCHD_LABEL}" >/dev/null 2>&1 || break
+    sleep 1
+    settle=$((settle + 1))
+  done
 else
   log "daemon not loaded; skipping bootout"
 fi
@@ -215,22 +229,66 @@ if [[ "${PURGE}" == "true" ]]; then
   # one (prefixed with an underscore per the install.sh convention). We
   # refuse to delete an unprefixed name — an admin who used a custom
   # unprefixed user probably shares it with another service.
+  #
+  # Delete both /Users and /Groups records regardless of which reads
+  # succeed. Prior failed installs can leave a half-provisioned record
+  # (e.g. record exists with no PrimaryGroupID) where dscl -read fails
+  # but the record still needs cleanup — so we delete unconditionally
+  # when the name is underscore-prefixed.
+  #
   # Pin to /Local/Default like install.sh does. Otherwise a Mac bound to
   # an unreachable network directory (AD/LDAP/managed OD) can hang or
   # ENETUNREACH us on the read/delete calls.
   if [[ -n "${SERVICE_USER}" && "${SERVICE_USER}" == _* ]]; then
-    if dscl /Local/Default -read "/Users/${SERVICE_USER}" >/dev/null 2>&1; then
-      log "removing service user ${SERVICE_USER}"
-      dscl /Local/Default -delete "/Users/${SERVICE_USER}"  2>/dev/null || \
-        warn "failed to delete /Users/${SERVICE_USER}"
-      dscl /Local/Default -delete "/Groups/${SERVICE_USER}" 2>/dev/null || \
-        warn "failed to delete /Groups/${SERVICE_USER} (may already be gone)"
-    else
-      log "service user ${SERVICE_USER} not present; skipping"
+    # 1. Try sysadminctl for the user (higher-level API, handles cache
+    #    sync). Falls through to dscl -delete for the group and for any
+    #    residue sysadminctl doesn't clear.
+    /usr/sbin/sysadminctl -deleteUser "${SERVICE_USER}" 2>/dev/null || true
+
+    dscl_removed_count=0
+    for record in "/Users/${SERVICE_USER}" "/Groups/${SERVICE_USER}"; do
+      # -delete returns 0 for both "removed" and (some versions) "not
+      # present". Capture stderr to distinguish.
+      dscl_err=""
+      dscl_rc=0
+      dscl_err="$(dscl /Local/Default -delete "${record}" 2>&1)" || dscl_rc=$?
+      if (( dscl_rc == 0 )); then
+        log "removed dscl record ${record}"
+        dscl_removed_count=$((dscl_removed_count + 1))
+      elif [[ "${dscl_err}" == *eDSRecordNotFound* ]]; then
+        log "dscl record ${record} not present; skipping"
+      else
+        warn "failed to delete ${record}: ${dscl_err}"
+      fi
+    done
+
+    # 2. Nuke on-disk plists directly, in case opendirectoryd's state is
+    #    out of sync with disk (this is what caused ghost records
+    #    surviving repeated dscl -delete on the live install).
+    for plist in \
+      "/var/db/dslocal/nodes/Default/users/${SERVICE_USER}.plist" \
+      "/var/db/dslocal/nodes/Default/groups/${SERVICE_USER}.plist"; do
+      if [[ -f "${plist}" ]]; then
+        log "removing on-disk plist ${plist}"
+        rm -f "${plist}"
+        dscl_removed_count=$((dscl_removed_count + 1))
+      fi
+    done
+
+    # 3. Flush caches so a subsequent install sees a truly clean slate.
+    if (( dscl_removed_count > 0 )); then
+      /usr/bin/dscacheutil -flushcache 2>/dev/null || true
+      /usr/bin/killall -HUP opendirectoryd 2>/dev/null || true
+    fi
+
+    if (( dscl_removed_count == 0 )); then
+      log "no ${SERVICE_USER} records to remove"
     fi
   elif [[ -n "${SERVICE_USER}" ]]; then
     warn "service user '${SERVICE_USER}' does not start with '_'; refusing to auto-delete"
-    warn "  delete it manually if it was created for DefenseClaw: sudo dscl /Local/Default -delete /Users/${SERVICE_USER}"
+    warn "  delete it manually if it was created for DefenseClaw:"
+    warn "    sudo dscl /Local/Default -delete /Users/${SERVICE_USER}"
+    warn "    sudo dscl /Local/Default -delete /Groups/${SERVICE_USER}"
   fi
 
   if [[ -n "${TARGET_USER:-}" && -n "${TARGET_HOME:-}" && -d "${TARGET_HOME}/.defenseclaw" ]]; then

--- a/packaging/macos/uninstall.sh
+++ b/packaging/macos/uninstall.sh
@@ -215,19 +215,22 @@ if [[ "${PURGE}" == "true" ]]; then
   # one (prefixed with an underscore per the install.sh convention). We
   # refuse to delete an unprefixed name — an admin who used a custom
   # unprefixed user probably shares it with another service.
+  # Pin to /Local/Default like install.sh does. Otherwise a Mac bound to
+  # an unreachable network directory (AD/LDAP/managed OD) can hang or
+  # ENETUNREACH us on the read/delete calls.
   if [[ -n "${SERVICE_USER}" && "${SERVICE_USER}" == _* ]]; then
-    if dscl . -read "/Users/${SERVICE_USER}" >/dev/null 2>&1; then
+    if dscl /Local/Default -read "/Users/${SERVICE_USER}" >/dev/null 2>&1; then
       log "removing service user ${SERVICE_USER}"
-      dscl . -delete "/Users/${SERVICE_USER}"  2>/dev/null || \
+      dscl /Local/Default -delete "/Users/${SERVICE_USER}"  2>/dev/null || \
         warn "failed to delete /Users/${SERVICE_USER}"
-      dscl . -delete "/Groups/${SERVICE_USER}" 2>/dev/null || \
+      dscl /Local/Default -delete "/Groups/${SERVICE_USER}" 2>/dev/null || \
         warn "failed to delete /Groups/${SERVICE_USER} (may already be gone)"
     else
       log "service user ${SERVICE_USER} not present; skipping"
     fi
   elif [[ -n "${SERVICE_USER}" ]]; then
     warn "service user '${SERVICE_USER}' does not start with '_'; refusing to auto-delete"
-    warn "  delete it manually if it was created for DefenseClaw: sudo dscl . -delete /Users/${SERVICE_USER}"
+    warn "  delete it manually if it was created for DefenseClaw: sudo dscl /Local/Default -delete /Users/${SERVICE_USER}"
   fi
 
   if [[ -n "${TARGET_USER:-}" && -n "${TARGET_HOME:-}" && -d "${TARGET_HOME}/.defenseclaw" ]]; then

--- a/packaging/macos/uninstall.sh
+++ b/packaging/macos/uninstall.sh
@@ -240,31 +240,17 @@ if [[ "${PURGE}" == "true" ]]; then
   # an unreachable network directory (AD/LDAP/managed OD) can hang or
   # ENETUNREACH us on the read/delete calls.
   if [[ -n "${SERVICE_USER}" && "${SERVICE_USER}" == _* ]]; then
-    # 1. Try sysadminctl for the user (higher-level API, handles cache
-    #    sync). Falls through to dscl -delete for the group and for any
-    #    residue sysadminctl doesn't clear.
-    /usr/sbin/sysadminctl -deleteUser "${SERVICE_USER}" 2>/dev/null || true
-
+    # Two-tier delete:
+    #   1. rm the on-disk plists FIRST — this is the authoritative
+    #      state. On a corrupt install (record has RecordName but no
+    #      PrimaryGroupID), dscl -delete "succeeds" without removing
+    #      the plist, which is exactly what stranded the ghost record
+    #      that broke the earlier reinstall on the live box.
+    #   2. dscl -delete afterward to clear whatever's still in
+    #      opendirectoryd's cache.
+    #   3. killall -HUP opendirectoryd so it re-reads from disk.
     dscl_removed_count=0
-    for record in "/Users/${SERVICE_USER}" "/Groups/${SERVICE_USER}"; do
-      # -delete returns 0 for both "removed" and (some versions) "not
-      # present". Capture stderr to distinguish.
-      dscl_err=""
-      dscl_rc=0
-      dscl_err="$(dscl /Local/Default -delete "${record}" 2>&1)" || dscl_rc=$?
-      if (( dscl_rc == 0 )); then
-        log "removed dscl record ${record}"
-        dscl_removed_count=$((dscl_removed_count + 1))
-      elif [[ "${dscl_err}" == *eDSRecordNotFound* ]]; then
-        log "dscl record ${record} not present; skipping"
-      else
-        warn "failed to delete ${record}: ${dscl_err}"
-      fi
-    done
 
-    # 2. Nuke on-disk plists directly, in case opendirectoryd's state is
-    #    out of sync with disk (this is what caused ghost records
-    #    surviving repeated dscl -delete on the live install).
     for plist in \
       "/var/db/dslocal/nodes/Default/users/${SERVICE_USER}.plist" \
       "/var/db/dslocal/nodes/Default/groups/${SERVICE_USER}.plist"; do
@@ -275,14 +261,23 @@ if [[ "${PURGE}" == "true" ]]; then
       fi
     done
 
-    # 3. Flush caches so a subsequent install sees a truly clean slate.
-    if (( dscl_removed_count > 0 )); then
-      /usr/bin/dscacheutil -flushcache 2>/dev/null || true
-      /usr/bin/killall -HUP opendirectoryd 2>/dev/null || true
-    fi
+    # sysadminctl for good measure (it can also remove a user's
+    # home dir if one somehow got created; ours never does).
+    /usr/sbin/sysadminctl -deleteUser "${SERVICE_USER}" 2>/dev/null || true
 
-    if (( dscl_removed_count == 0 )); then
-      log "no ${SERVICE_USER} records to remove"
+    # Now try dscl -delete on whatever remained in the cache. These
+    # are advisory: the disk truth is already gone above.
+    for record in "/Users/${SERVICE_USER}" "/Groups/${SERVICE_USER}"; do
+      dscl /Local/Default -delete "${record}" 2>/dev/null || true
+    done
+
+    # Force opendirectoryd to reload from the new on-disk state.
+    if (( dscl_removed_count > 0 )); then
+      /usr/bin/killall -HUP opendirectoryd 2>/dev/null || true
+      /usr/bin/dscacheutil -flushcache 2>/dev/null || true
+      log "removed ${SERVICE_USER} service principal (${dscl_removed_count} plist(s))"
+    else
+      log "no ${SERVICE_USER} plist(s) to remove"
     fi
   elif [[ -n "${SERVICE_USER}" ]]; then
     warn "service user '${SERVICE_USER}' does not start with '_'; refusing to auto-delete"

--- a/packaging/macos/uninstall.sh
+++ b/packaging/macos/uninstall.sh
@@ -29,7 +29,11 @@ SUPPORT_DIR="/Library/Application Support/DefenseClaw"
 LOGS_DIR="/Library/Logs/DefenseClaw"
 PLIST_DST="/Library/LaunchDaemons/com.defenseclaw.gateway.plist"
 LAUNCHD_LABEL="com.defenseclaw.gateway"
-SERVICE_USER_DEFAULT="_defenseclaw"
+SERVICE_USER_DEFAULT="defenseclaw"
+# Names we recognize as DefenseClaw-owned and safe to auto-delete on
+# --purge. Matches the hostname the gateway binary hardcodes in
+# trustedRuntimeOwner (see internal/managed/trust_unix.go).
+SERVICE_USER_KNOWN=(defenseclaw)
 
 PURGE="false"
 ASSUME_YES="false"
@@ -53,7 +57,7 @@ Options:
                           ${SUPPORT_DIR}  (config + audit DB)
                           ${LOGS_DIR}                       (gateway logs)
                           ~/.defenseclaw/ for the target user (hook scripts)
-                          /Users/_defenseclaw + /Groups/_defenseclaw dscl
+                          /Users/defenseclaw + /Groups/defenseclaw dscl
                               records (service principal — deleted even if
                               only half-provisioned by a prior failed run)
                         AND scrub DefenseClaw entries from:
@@ -67,7 +71,7 @@ Options:
                         you intend to immediately reinstall.
   --user USER           Per-user cleanup target for --purge (default: \$SUDO_USER)
   --service-user NAME   macOS service user to delete on --purge
-                        (default: read from the installed plist, else _defenseclaw)
+                        (default: read from the installed plist, else defenseclaw)
   -y, --yes             Don't prompt for --purge confirmation
   -h, --help            Show this help
 
@@ -239,7 +243,16 @@ if [[ "${PURGE}" == "true" ]]; then
   # Pin to /Local/Default like install.sh does. Otherwise a Mac bound to
   # an unreachable network directory (AD/LDAP/managed OD) can hang or
   # ENETUNREACH us on the read/delete calls.
-  if [[ -n "${SERVICE_USER}" && "${SERVICE_USER}" == _* ]]; then
+  # Auto-delete only if the service user matches one of our known
+  # installer names — never delete a random admin-configured user
+  # sharing the SERVICE_USER slot.
+  is_known="no"
+  for known in "${SERVICE_USER_KNOWN[@]}"; do
+    if [[ "${SERVICE_USER}" == "${known}" ]]; then
+      is_known="yes"; break
+    fi
+  done
+  if [[ -n "${SERVICE_USER}" && "${is_known}" == "yes" ]]; then
     # SIP protects /var/db/dslocal, so `rm plist` returns "Operation
     # not permitted" even for root. Use the SIP-safe official tools:
     # dseditgroup for groups, sysadminctl for users. Both route through
@@ -264,7 +277,7 @@ if [[ "${PURGE}" == "true" ]]; then
       log "no ${SERVICE_USER} records to remove"
     fi
   elif [[ -n "${SERVICE_USER}" ]]; then
-    warn "service user '${SERVICE_USER}' does not start with '_'; refusing to auto-delete"
+    warn "service user '${SERVICE_USER}' is not one of the known DefenseClaw installer names (${SERVICE_USER_KNOWN[*]}); refusing to auto-delete"
     warn "  delete it manually if it was created for DefenseClaw:"
     warn "    sudo dscl /Local/Default -delete /Users/${SERVICE_USER}"
     warn "    sudo dscl /Local/Default -delete /Groups/${SERVICE_USER}"

--- a/packaging/macos/uninstall.sh
+++ b/packaging/macos/uninstall.sh
@@ -29,12 +29,14 @@ SUPPORT_DIR="/Library/Application Support/DefenseClaw"
 LOGS_DIR="/Library/Logs/DefenseClaw"
 PLIST_DST="/Library/LaunchDaemons/com.defenseclaw.gateway.plist"
 LAUNCHD_LABEL="com.defenseclaw.gateway"
+SERVICE_USER_DEFAULT="_defenseclaw"
 
 PURGE="false"
 ASSUME_YES="false"
 TARGET_USER=""
 KEEP_AGENT_CONFIGS="false"
 SCRUB_FAILED="false"
+SERVICE_USER=""
 
 # ---- helpers ------------------------------------------------------------
 
@@ -61,6 +63,8 @@ Options:
                         that fail-close every agent tool call. Use only if
                         you intend to immediately reinstall.
   --user USER           Per-user cleanup target for --purge (default: \$SUDO_USER)
+  --service-user NAME   macOS service user to delete on --purge
+                        (default: read from the installed plist, else _defenseclaw)
   -y, --yes             Don't prompt for --purge confirmation
   -h, --help            Show this help
 
@@ -75,11 +79,23 @@ while [[ $# -gt 0 ]]; do
     --purge)               PURGE="true"; shift;;
     --keep-agent-configs)  KEEP_AGENT_CONFIGS="true"; shift;;
     --user)                TARGET_USER="${2:?}"; shift 2;;
+    --service-user)        SERVICE_USER="${2:?}"; shift 2;;
     -y|--yes)              ASSUME_YES="true"; shift;;
     -h|--help)             usage; exit 0;;
     *) die "unknown flag: $1 (try --help)";;
   esac
 done
+
+# Resolve which service user to delete on --purge. Precedence:
+#   1. --service-user flag
+#   2. UserName in the installed plist (matches whatever install.sh set)
+#   3. _defenseclaw default
+if [[ -z "${SERVICE_USER}" ]]; then
+  if [[ -f "${PLIST_DST}" ]]; then
+    SERVICE_USER="$(/usr/bin/plutil -extract UserName raw "${PLIST_DST}" 2>/dev/null || true)"
+  fi
+  SERVICE_USER="${SERVICE_USER:-${SERVICE_USER_DEFAULT}}"
+fi
 
 # ---- preflight ----------------------------------------------------------
 
@@ -194,6 +210,25 @@ if [[ "${PURGE}" == "true" ]]; then
       rm -rf "${d}"
     fi
   done
+
+  # Remove the service user + group if it looks like a DefenseClaw-created
+  # one (prefixed with an underscore per the install.sh convention). We
+  # refuse to delete an unprefixed name — an admin who used a custom
+  # unprefixed user probably shares it with another service.
+  if [[ -n "${SERVICE_USER}" && "${SERVICE_USER}" == _* ]]; then
+    if dscl . -read "/Users/${SERVICE_USER}" >/dev/null 2>&1; then
+      log "removing service user ${SERVICE_USER}"
+      dscl . -delete "/Users/${SERVICE_USER}"  2>/dev/null || \
+        warn "failed to delete /Users/${SERVICE_USER}"
+      dscl . -delete "/Groups/${SERVICE_USER}" 2>/dev/null || \
+        warn "failed to delete /Groups/${SERVICE_USER} (may already be gone)"
+    else
+      log "service user ${SERVICE_USER} not present; skipping"
+    fi
+  elif [[ -n "${SERVICE_USER}" ]]; then
+    warn "service user '${SERVICE_USER}' does not start with '_'; refusing to auto-delete"
+    warn "  delete it manually if it was created for DefenseClaw: sudo dscl . -delete /Users/${SERVICE_USER}"
+  fi
 
   if [[ -n "${TARGET_USER:-}" && -n "${TARGET_HOME:-}" && -d "${TARGET_HOME}/.defenseclaw" ]]; then
     if [[ "${SCRUB_FAILED}" == "true" && "${KEEP_AGENT_CONFIGS}" != "true" ]]; then

--- a/packaging/macos/uninstall.sh
+++ b/packaging/macos/uninstall.sh
@@ -240,44 +240,28 @@ if [[ "${PURGE}" == "true" ]]; then
   # an unreachable network directory (AD/LDAP/managed OD) can hang or
   # ENETUNREACH us on the read/delete calls.
   if [[ -n "${SERVICE_USER}" && "${SERVICE_USER}" == _* ]]; then
-    # Two-tier delete:
-    #   1. rm the on-disk plists FIRST — this is the authoritative
-    #      state. On a corrupt install (record has RecordName but no
-    #      PrimaryGroupID), dscl -delete "succeeds" without removing
-    #      the plist, which is exactly what stranded the ghost record
-    #      that broke the earlier reinstall on the live box.
-    #   2. dscl -delete afterward to clear whatever's still in
-    #      opendirectoryd's cache.
-    #   3. killall -HUP opendirectoryd so it re-reads from disk.
-    dscl_removed_count=0
+    # SIP protects /var/db/dslocal, so `rm plist` returns "Operation
+    # not permitted" even for root. Use the SIP-safe official tools:
+    # dseditgroup for groups, sysadminctl for users. Both route through
+    # opendirectoryd's authenticated API and atomically clean up the
+    # on-disk plists.
+    removed_any=no
 
-    for plist in \
-      "/var/db/dslocal/nodes/Default/users/${SERVICE_USER}.plist" \
-      "/var/db/dslocal/nodes/Default/groups/${SERVICE_USER}.plist"; do
-      if [[ -f "${plist}" ]]; then
-        log "removing on-disk plist ${plist}"
-        rm -f "${plist}"
-        dscl_removed_count=$((dscl_removed_count + 1))
-      fi
-    done
+    if dscl /Local/Default -read "/Groups/${SERVICE_USER}" >/dev/null 2>&1; then
+      log "removing group ${SERVICE_USER} via dseditgroup"
+      /usr/sbin/dseditgroup -o delete "${SERVICE_USER}" >/dev/null 2>&1 && \
+        removed_any=yes || warn "dseditgroup delete ${SERVICE_USER} failed"
+    fi
+    if dscl /Local/Default -read "/Users/${SERVICE_USER}" >/dev/null 2>&1; then
+      log "removing user ${SERVICE_USER} via sysadminctl"
+      /usr/sbin/sysadminctl -deleteUser "${SERVICE_USER}" >/dev/null 2>&1 && \
+        removed_any=yes || warn "sysadminctl deleteUser ${SERVICE_USER} failed"
+    fi
 
-    # sysadminctl for good measure (it can also remove a user's
-    # home dir if one somehow got created; ours never does).
-    /usr/sbin/sysadminctl -deleteUser "${SERVICE_USER}" 2>/dev/null || true
-
-    # Now try dscl -delete on whatever remained in the cache. These
-    # are advisory: the disk truth is already gone above.
-    for record in "/Users/${SERVICE_USER}" "/Groups/${SERVICE_USER}"; do
-      dscl /Local/Default -delete "${record}" 2>/dev/null || true
-    done
-
-    # Force opendirectoryd to reload from the new on-disk state.
-    if (( dscl_removed_count > 0 )); then
-      /usr/bin/killall -HUP opendirectoryd 2>/dev/null || true
-      /usr/bin/dscacheutil -flushcache 2>/dev/null || true
-      log "removed ${SERVICE_USER} service principal (${dscl_removed_count} plist(s))"
+    if [[ "${removed_any}" == "yes" ]]; then
+      log "removed ${SERVICE_USER} service principal"
     else
-      log "no ${SERVICE_USER} plist(s) to remove"
+      log "no ${SERVICE_USER} records to remove"
     fi
   elif [[ -n "${SERVICE_USER}" ]]; then
     warn "service user '${SERVICE_USER}' does not start with '_'; refusing to auto-delete"

--- a/scripts/write-macos-bundle-readme.sh
+++ b/scripts/write-macos-bundle-readme.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Emit the README that ships inside the macOS installer bundle.
+# Args: OUT_PATH VERSION GOOS GOARCH
+set -euo pipefail
+
+OUT="${1:?missing OUT_PATH}"
+VERSION="${2:?missing VERSION}"
+GOOS="${3:?missing GOOS}"
+GOARCH="${4:?missing GOARCH}"
+
+cat > "${OUT}" <<EOF
+# DefenseClaw macOS bundle ${VERSION} (${GOOS}/${GOARCH})
+
+Self-contained installer for a managed_enterprise DefenseClaw
+deployment on macOS. No repository checkout, Go toolchain, or Homebrew
+formula is required at install time — everything the installer needs
+ships in this folder.
+
+## Contents
+
+| Path                            | Purpose                                             |
+| ------------------------------- | --------------------------------------------------- |
+| \`defenseclaw-gateway\`           | Prebuilt gateway binary (installed root:wheel 0755) |
+| \`install.sh\`                    | Orchestrator: config, LaunchDaemon, per-user hooks  |
+| \`uninstall.sh\`                  | Bootout daemon + scrub agent hook configs           |
+| \`com.defenseclaw.gateway.plist\` | LaunchDaemon plist                                  |
+| \`lib/installer_lib.sh\`          | Pure helpers (sourced by install.sh)                |
+| \`lib/scrub_agent_configs.py\`    | Agent hook config scrubber (stdlib Python)          |
+
+## Install
+
+\`\`\`
+sudo ./install.sh --mode action --connector cursor,claudecode
+\`\`\`
+
+Full flag reference: \`./install.sh --help\`.
+
+The installer resolves the gateway binary and plist by looking next to
+\`install.sh\` first, so the bundle works verbatim from wherever you
+place it.
+
+## Uninstall
+
+Preserve config + audit DB (reversible reinstall):
+
+\`\`\`
+sudo ./uninstall.sh
+\`\`\`
+
+Full wipe (system files, runtime state, and DefenseClaw entries in the
+user's native agent configs — non-DefenseClaw entries preserved):
+
+\`\`\`
+sudo ./uninstall.sh --purge -y
+\`\`\`
+
+## Requirements
+
+- macOS with \`launchctl\` and \`/usr/bin/python3\` (stdlib only).
+- Root privileges (\`sudo\`).
+- Target user's home directory must not be group/other-writable
+  (installer will refuse with an exact \`chmod\` fix).
+
+Everything else — Codex / Claude Code / Cursor version detection, hook
+config pre-creation, guardian invocation, tamper repair — is handled by
+the scripts.
+EOF


### PR DESCRIPTION
## Problem

PR #379 shipped the managed-enterprise deployment mode for Linux (systemd units, hook guardian, scoped tokens) but left macOS admins on a manual install path. The `packaging/launchd/com.defenseclaw.gateway.plist` file existed, but there was no scripted way to:

1. Build and install the gateway binary + config + LaunchDaemon into the root-owned locations that the plist expects.
2. Pre-create each agent's native hook config file so the enterprise hook guardian's "refuse first-time creation" defense actually leaves the admin with a working install.
3. Auto-detect agent versions (Codex CLI on PATH, Claude Code as a Cursor/VS Code extension bundle, Cursor.app bundle) to feed the guardian's hook-contract check.
4. Cleanly uninstall — without leaving fail-closed dangling references in the user's `~/.cursor/hooks.json` / `~/.codex/config.toml` / `~/.claude/settings.json` that block every agent tool call after uninstall.

## Current Situation

After #379:

- `deployment_mode: managed_enterprise` is a stable config schema.
- The gateway binary supports `enterprise hooks install/reconcile/watch` and a hardened `internal/enterprisehooks/` installer that drops euid/egid, Lstat-refuses symlinks, and repairs on tamper.
- The macOS LaunchDaemon plist is checked in.
- `docs-site/content/docs/setup/enterprise-deployment.mdx` documents the file ownership and install steps, but the actual commands live in the doc — there is no reproducible script an admin can run.

Gaps that this PR fills:

- No `install.sh` / `uninstall.sh` for macOS.
- Nothing pre-creates `~/.cursor/hooks.json` etc., so the guardian's first-time refusal leaves the admin unable to complete a fresh install.
- `claude --version` isn't always on PATH — Claude Code is often only installed as a Cursor / VS Code extension, and the guardian's contract check refuses without a version. No auto-detect for that path.
- The default uninstaller design in #379 deletes `~/.defenseclaw/hooks/*-hook.sh` on --purge but leaves the references in `~/.cursor/hooks.json` etc., which fail-closes every subsequent Cursor/Codex/Claude Code tool call with exit 127.

## Solution

Adds `packaging/macos/` with three components, all no-op on Linux:

### `install.sh` — orchestrates the full managed-enterprise install

- Builds (or accepts `--binary`) the gateway; installs it root:wheel 0755 under `/Library/DefenseClaw/bin/`.
- Creates `/Library/Application Support/DefenseClaw/` (0750) and `/Library/Logs/DefenseClaw/` (0750).
- Writes a root:wheel 0640 `config.yaml` with:
  - `deployment_mode: managed_enterprise`
  - `guardrail.connector: <primary>` plus a `guardrail.connectors:` map when multiple are specified (multi-connector install)
  - `asset_policy.enabled: true`, `mcp.default: deny`
  - `privacy.disable_redaction: false` (**redaction on by default** — matches OBSERVABILITY.md; opt out with `--disable-redaction` / `--no-redact` for lab testing)
  - `application_protection.enabled: false` (managed mode delegates lifecycle to the guardian)
- Installs the LaunchDaemon plist and bootstraps it.
- Per-user wiring loop for `codex`, `claudecode`, `cursor`:
  - Pre-creates the connector's native hook config file (target-user-owned 0600).
  - Auto-detects agent version (CLI on PATH, then extension bundle package.json, then Info.plist for Cursor.app).
  - Pauses the LaunchDaemon around the CLI call (audit DB writer lock).
  - Runs `defenseclaw-gateway enterprise hooks install --connector <c> --user <u> --agent-version <v> --json`.

Preflights that fail loud (not silently continue):

- macOS-only guard (`uname -s == Darwin`).
- Root guard (must run under `sudo`).
- Home-perms guard mirroring the guardian's `mode & 0o022` rejection (0755 / 0700 pass; anything group/other-writable is refused with the exact `chmod` fix).
- Symlink refusal in `prepare_*_userspace` helpers: reject `~/.<agent>/` if it's a symlink, reject the config path if it's a symlink, re-check after `mkdir -p` in case one raced in.
- Skip `chown -h` when the prep helper rejected the target, and use `find -exec chown -h + } +` (no `-R`) so we never resolve symlinks at chown time.

### `uninstall.sh` — reversible + safe

- Default: bootout LaunchDaemon, remove `/Library/DefenseClaw/` and the plist. Preserves `/Library/Application Support/DefenseClaw/` (config + audit DB + scoped tokens) and `/Library/Logs/DefenseClaw/` for reinstall.
- `--purge`: additionally deletes the support dir, logs dir, and `~/.defenseclaw/`. **Before deleting the hook scripts**, invokes `lib/scrub_agent_configs.py` as the target user (`sudo -u`) to strip only the DefenseClaw-owned entries from each agent's native hook config, preserving unrelated user state (Cursor's other hooks, Claude Code's theme/env, Codex's project trust list). Without this scrub, agents fail-close every tool call because they call a script that no longer exists.
- `--keep-agent-configs`: legacy behavior — skip the scrub (useful for "reinstall immediately" flows).

### `lib/scrub_agent_configs.py` — stdlib-only agent config editor

- JSON scrub for Cursor and Claude Code: drops entries whose command references `~/.defenseclaw/hooks/` or the `# defenseclaw-managed-hook` marker; preserves unrelated events and non-hook state.
- TOML scrub for Codex: DefenseClaw's Codex writer owns `[hooks]`, `[otel]`, and the top-level `notify` array wholesale, so we drop those three when they reference DefenseClaw. Everything else in the file (model, personality, project trust list, user's own sections) is preserved verbatim.
- Stdlib-only — no `tomllib` (Python 3.11+) or `tomli` dependency, so it runs on macOS system Python 3.9.

### Test suite — pure bash 3.2, no root, no /Library writes

`packaging/macos/tests/` with a bespoke test runner + 8 suites, 55 cases:

- Argument parsing (both scripts): help output, bad mode, unknown flag, empty connector list, unsupported connector warn, non-root rejection.
- Connector list parsing: split, trim, lowercase, reject empties.
- Home permission gate: 0755 / 0700 pass; 0770 / 0775 / 0707 rejected (mirrors guardian check).
- Config rendering: single vs multi-connector YAML, redaction default, optional PyYAML round-trip.
- Userspace prep: idempotency + **symlink rejection** for agent dir and config file.
- Agent version discovery: **hermetic** — shims a fake `claude` binary onto PATH before the extension-fallback tests so results don't depend on whether the host has Claude Code installed. Uses a staged tmpdir tree for `~/.cursor/extensions/anthropic.claude-code-*/package.json`.
- Scrub helper: per-connector fixtures, idempotency, error codes (missing file → 2, unsupported connector → 3, parse failure → 4).
- Packaging assets: `plutil -lint` on the plist, `bash -n` on every shell file, +x bits, valid Python for the scrub helper.

Wired to `make packaging-macos-test`.

## Architecture Diagram

```mermaid
sequenceDiagram
  participant Admin
  participant Install as install.sh
  participant Lib as installer_lib.sh
  participant Gateway as defenseclaw-gateway
  participant Launchd
  participant User as target user
  participant Agent as Cursor / Codex / Claude Code

  Admin->>Install: sudo install.sh --mode action --connector cursor,claudecode
  Install->>Lib: parse_connectors, home_perms_ok
  Install->>Install: build + install binary (root:wheel 0755)
  Install->>Lib: render_config (managed_enterprise, connectors map)
  Install->>Launchd: bootstrap + enable
  Launchd-->>Install: state = running
  loop for each connector
    Install->>Lib: ensure_safe_userspace_path (reject symlink dir / config)
    Install->>User: create ~/.<agent>/<hook-config> (0700 / 0600)
    Install->>Lib: discover_agent_version (CLI / extension pkg / Info.plist)
    Install->>Launchd: bootout (audit DB lock)
    Install->>Gateway: enterprise hooks install --connector --user --agent-version
    Gateway->>User: hardened hook write (Lstat-refuse, drop euid, 0700)
    Install->>Launchd: bootstrap
  end
  Note over Agent,Gateway: Later, at runtime
  Agent->>Gateway: hook event over loopback with scoped token
  Gateway-->>Agent: allow / block verdict
```

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `Makefile` | Adds `packaging-macos-test` phony target. |
| `packaging/macos/install.sh` | Full install orchestrator: preflight (uname/root/plist), binary install, config generation (single + multi connector), plist bootstrap, per-connector userspace prep + guardian invocation with daemon pause/resume around it. |
| `packaging/macos/uninstall.sh` | Bootout, remove plist + `/Library/DefenseClaw/`. `--purge` invokes the scrub helper as the target user before deleting `~/.defenseclaw`. `--keep-agent-configs` opts out. |
| `packaging/macos/lib/installer_lib.sh` | Pure helpers sourced by install.sh and tests: `parse_connectors`, `is_supported_connector`, `home_perms_ok`, `discover_agent_version`, `prepare_*_userspace`, `ensure_safe_userspace_path`, `render_config`. Zero I/O outside caller-passed paths. |
| `packaging/macos/lib/scrub_agent_configs.py` | Stdlib-only Python: JSON scrub for Cursor + Claude Code, line-based TOML scrub for Codex `[hooks]`/`[otel]`/`notify=`. Preserves non-DefenseClaw state. |
| `packaging/macos/tests/run_tests.sh` | Bespoke pure-bash test runner (bash 3.2 compatible). Verbose mode, per-case reporting, `-v` and per-file invocation. |
| `packaging/macos/tests/test_*.sh` | 8 suites × 55 cases: parsing, home perms, version discovery (hermetic), config rendering, userspace prep + symlink rejection, scrub fixtures, packaging asset sanity. |

## Breaking Changes

Additive only for the repo — no existing macOS install path is being changed because there wasn't a scripted one. The `--redact` flag from an earlier revision of this branch was **removed** during review and replaced with `--disable-redaction` / `--no-redact`; the default is now redaction ON (matches OBSERVABILITY.md).

## Open Issues / Follow-ups

None.

## Test Plan

Local (no root):

```bash
make packaging-macos-test
# ----- 55 passed, 0 failed in ~2s -----
```

End-to-end live install, macOS 26.5.1 (Tahoe), Apple Silicon, Cursor 3.8.22, Claude Code extension 2.1.195:

```bash
sudo packaging/macos/install.sh --mode action --connector cursor,claudecode
# Expect:
#   [install] loading LaunchDaemon
#   [install]   [cursor] detected agent_version: 3.8.22
#   [install]   [cursor] hook wiring OK
#   [install]   [claudecode] detected agent_version: 2.1.195
#   [install]   [claudecode] hook wiring OK

sudo DEFENSECLAW_CONFIG="/Library/Application Support/DefenseClaw/config.yaml" \
  /Library/DefenseClaw/bin/defenseclaw-gateway status | head -30
# Expect: Connector: Cursor / Claude Code (multi), lifecycle_manager: enterprise_hook_guardian
```

Live guardrail: quit + relaunch Cursor, then paste a prompt with synthetic PII/secrets. Verify a `connector-hook` row appears in `audit.db`:

```bash
sudo sqlite3 -header -column "/Library/Application Support/DefenseClaw/audit.db" \
  "SELECT datetime(timestamp,'localtime'), connector, target,
          json_extract(structured_json,'\$.verdict.action') AS verdict,
          json_extract(structured_json,'\$.verdict.severity') AS sev
   FROM audit_events WHERE action='connector-hook'
   ORDER BY timestamp DESC LIMIT 5;"
```

Live tamper repair (Cursor still open):

```bash
echo "echo TAMPERED" > ~/.defenseclaw/hooks/cursor-hook.sh
sudo DEFENSECLAW_CONFIG="/Library/Application Support/DefenseClaw/config.yaml" \
  /Library/DefenseClaw/bin/defenseclaw-gateway enterprise hooks install \
    --connector cursor --user "$USER" --agent-version "3.8.22" --json
head -3 ~/.defenseclaw/hooks/cursor-hook.sh
# Expect: real hook script, not "echo TAMPERED"
```

Uninstall + scrub:

```bash
sudo packaging/macos/uninstall.sh --purge -y
grep -c defenseclaw ~/.cursor/hooks.json ~/.codex/config.toml ~/.claude/settings.json 2>/dev/null
# Expect: 0 for all files that exist
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
