### PR TITLE
[codex] Speed up Textual TUI refreshes

### DIFF
--- a/cli/defenseclaw/tui/app.py
+++ b/cli/defenseclaw/tui/app.py
@@ -7504,7 +7504,7 @@ class DefenseClawTUI(App[None]):
         if self.active_panel == "setup" and self.setup_model.form_active:
             if self.focused is table:
                 self.set_focus(None)
-        elif self.focused is not table:
+        elif self.focused is None:
             table.focus()
 
     def _append_panel_table_row(self, table: DataTable[Any], row: tuple[str, ...]) -> None:

--- a/cli/defenseclaw/tui/app.py
+++ b/cli/defenseclaw/tui/app.py
@@ -759,9 +759,14 @@ class DefenseClawTUI(App[None]):
         # their scroll + cursor twice a second, so operators couldn't read or
         # scroll a row before it jumped back to the top (and the constant
         # ``table.focus()`` stole focus, which read as the UI "jumping"). We
-        # now skip the rebuild when the panel, columns, rows, and cursor are
-        # all unchanged. ``None`` forces a repaint.
+        # now skip the rebuild when the panel, columns, and rows are
+        # unchanged. Cursor-only changes are applied with ``move_cursor``;
+        # rebuilding thousands of unchanged log rows on every Up/Down press
+        # was one of the TUI's largest interactive latency sources. ``None``
+        # forces a repaint.
         self._last_table_signature: tuple[object, ...] | None = None
+        self._rendered_table_row_keys: list[Any] = []
+        self._next_table_row_key = 0
         # Overview renders ask for the same recent hook-event window several
         # times (header metrics, Enforcement, CONNECTORS rows). Cache it for a
         # single frame so keypresses don't wait behind repeated SQLite reads.
@@ -7396,15 +7401,15 @@ class DefenseClawTUI(App[None]):
         if not self._table_columns:
             table.add_class("hidden")
             table.clear(columns=True)
+            self._rendered_table_row_keys.clear()
             self._last_table_signature = None
             return
 
-        # Idempotence guard: only tear down and rebuild the DataTable when the
-        # panel, columns, rows, or target cursor actually changed. Without this
-        # the 2 s refresh ticker cleared every row, reset the cursor, and
-        # re-stole focus twice a second — so the Logs/Audit feeds were
-        # unreadable (scroll + cursor jumped to the top continuously) and the
-        # constant table.focus() read as the UI spontaneously jumping around.
+        # Idempotence guard: cursor-only changes and small streaming deltas
+        # stay on fast paths below; a full teardown is the fallback for a new
+        # panel/shape or a large content rewrite. Without this the 2 s refresh
+        # ticker cleared every row, reset the cursor, and re-stole focus — so
+        # the Logs/Audit feeds jumped while operators tried to read them.
         cursor_row = self._active_table_cursor() if self._table_rows else -1
         signature = (
             self.active_panel,
@@ -7416,38 +7421,156 @@ class DefenseClawTUI(App[None]):
         if signature == self._last_table_signature:
             return
 
+        # A cursor move does not change table content. Keep Textual's
+        # existing row/cell caches intact and move only the cursor instead of
+        # clearing and re-adding every row. This matters most for Logs (up to
+        # 5,000 rows), but also keeps Audit/Alerts navigation consistently
+        # responsive as their histories grow.
+        previous = self._last_table_signature
+        if previous is not None and (
+            signature[0],
+            signature[1],
+            signature[2],
+            signature[4],
+        ) == (
+            previous[0],
+            previous[1],
+            previous[2],
+            previous[4],
+        ):
+            self._position_panel_table_cursor(table, cursor_row)
+            self._last_table_signature = signature
+            return
+
+        # Streaming tails usually change by only a handful of rows. Reuse
+        # the retained middle of the DataTable and apply that small delta;
+        # clearing/re-adding the full 5,000-row tail caused a visible hitch
+        # on every two-second log refresh.
+        if previous is not None and (
+            signature[0],
+            signature[1],
+            signature[4],
+        ) == (
+            previous[0],
+            previous[1],
+            previous[4],
+        ) and self._update_panel_table_delta(table, previous[2], self._table_rows):
+            table.remove_class("hidden")
+            self._position_panel_table_cursor(table, cursor_row)
+            self._last_table_signature = signature
+            return
+
         table.remove_class("hidden")
         table.clear(columns=True)
+        self._rendered_table_row_keys.clear()
         table.add_columns(*self._table_columns)
-        for index, row in enumerate(self._table_rows):
-            cells = (
-                _styled_cell(column, value)
-                for column, value in zip(self._table_columns, row, strict=True)
-            )
-            table.add_row(*cells, key=str(index))
+        for row in self._table_rows:
+            self._append_panel_table_row(table, row)
 
         if self._table_rows:
-            # move_cursor fires RowHighlighted; suppress the handler's model
-            # write so restoring the cursor here can't pause the Logs stream.
-            self._restoring_table_cursor = True
-            try:
-                table.move_cursor(row=cursor_row, column=0, animate=False)
-            finally:
-                self._restoring_table_cursor = False
-            # Textual's DataTable binds left/right/enter to its own cursor
-            # actions, which silently swallows the keys the setup wizard
-            # form relies on (cycle choice, toggle bool, Ctrl+R submit).
-            # When the wizard form is open we keep the row cursor visible
-            # via the CSS rule on `.datatable--cursor` (no focus required)
-            # but defocus the table so the app-level key handler — and
-            # therefore `_handle_setup_form_key` — actually receives the
-            # arrow keys.
-            if self.active_panel == "setup" and self.setup_model.form_active:
-                if self.focused is table:
-                    self.set_focus(None)
-            else:
-                table.focus()
+            self._position_panel_table_cursor(table, cursor_row)
         self._last_table_signature = signature
+
+    def _position_panel_table_cursor(self, table: DataTable[Any], cursor_row: int) -> None:
+        """Move/focus the shared table without feeding the move back to models."""
+
+        if not self._table_rows:
+            return
+        # move_cursor fires RowHighlighted; suppress the handler's model
+        # write so restoring the cursor here can't pause the Logs stream.
+        self._restoring_table_cursor = True
+        try:
+            table.move_cursor(row=cursor_row, column=0, animate=False)
+        finally:
+            self._restoring_table_cursor = False
+        # Textual's DataTable binds left/right/enter to its own cursor
+        # actions, which silently swallows the keys the setup wizard form
+        # relies on. Keep its visual cursor but relinquish focus in that mode.
+        if self.active_panel == "setup" and self.setup_model.form_active:
+            if self.focused is table:
+                self.set_focus(None)
+        elif self.focused is not table:
+            table.focus()
+
+    def _append_panel_table_row(self, table: DataTable[Any], row: tuple[str, ...]) -> None:
+        cells = (
+            _styled_cell(column, value)
+            for column, value in zip(self._table_columns, row, strict=True)
+        )
+        key = f"panel-row-{self._next_table_row_key}"
+        self._next_table_row_key += 1
+        self._rendered_table_row_keys.append(table.add_row(*cells, key=key))
+
+    def _update_panel_table_delta(
+        self,
+        table: DataTable[Any],
+        previous_rows: object,
+        next_rows: tuple[tuple[str, ...], ...],
+    ) -> bool:
+        """Apply a small append/sliding-tail delta, or request a full rebuild."""
+
+        if not isinstance(previous_rows, tuple):
+            return False
+        old_rows = previous_rows
+        if len(self._rendered_table_row_keys) != len(old_rows) or table.row_count != len(old_rows):
+            return False
+        if not old_rows:
+            return False
+
+        max_delta = 256
+        remove_front = 0
+        keep = 0
+
+        # Growing file below the tail cap: retain everything and append.
+        if len(next_rows) >= len(old_rows) and next_rows[: len(old_rows)] == old_rows:
+            keep = len(old_rows)
+        elif next_rows:
+            # Sliding capped tail: find the old suffix that became the new
+            # prefix. Limit the search to a small batch; larger rewrites are
+            # cheaper and safer through DataTable.clear().
+            search_limit = min(len(old_rows), max_delta)
+            first = next_rows[0]
+            for candidate in range(1, search_limit + 1):
+                if candidate >= len(old_rows) or old_rows[candidate] != first:
+                    continue
+                candidate_keep = min(len(old_rows) - candidate, len(next_rows))
+                additions = len(next_rows) - candidate_keep
+                trailing_removals = len(old_rows) - candidate - candidate_keep
+                if candidate + trailing_removals + additions > max_delta:
+                    continue
+                if old_rows[candidate : candidate + candidate_keep] == next_rows[:candidate_keep]:
+                    remove_front = candidate
+                    keep = candidate_keep
+                    break
+
+        # A small changed suffix (for example a final partial log line that
+        # was completed) is also safe to patch without rebuilding columns.
+        if keep == 0:
+            prefix = 0
+            for old_row, new_row in zip(old_rows, next_rows):
+                if old_row != new_row:
+                    break
+                prefix += 1
+            if (len(old_rows) - prefix) + (len(next_rows) - prefix) <= max_delta:
+                keep = prefix
+            else:
+                return False
+
+        remove_back = len(old_rows) - remove_front - keep
+        additions = len(next_rows) - keep
+        if remove_front + remove_back + additions > max_delta:
+            return False
+
+        old_keys = self._rendered_table_row_keys
+        for key in old_keys[:remove_front]:
+            table.remove_row(key)
+        if remove_back:
+            for key in old_keys[len(old_keys) - remove_back :]:
+                table.remove_row(key)
+        self._rendered_table_row_keys = old_keys[remove_front : len(old_keys) - remove_back if remove_back else None]
+        for row in next_rows[keep:]:
+            self._append_panel_table_row(table, row)
+        return True
 
     def _render_detail_panel(self) -> None:
         panel = self.query_one("#detail-panel", VerticalScroll)

--- a/cli/defenseclaw/tui/app.py
+++ b/cli/defenseclaw/tui/app.py
@@ -9,7 +9,7 @@ import re
 import shutil
 import subprocess
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
@@ -7399,9 +7399,10 @@ class DefenseClawTUI(App[None]):
     def _render_panel_table(self) -> None:
         table = self.query_one("#panel-table", DataTable)
         if not self._table_columns:
-            table.add_class("hidden")
-            table.clear(columns=True)
-            self._rendered_table_row_keys.clear()
+            with self._programmatic_table_update():
+                table.add_class("hidden")
+                table.clear(columns=True)
+                self._rendered_table_row_keys.clear()
             self._last_table_signature = None
             return
 
@@ -7438,7 +7439,8 @@ class DefenseClawTUI(App[None]):
             previous[2],
             previous[4],
         ):
-            self._position_panel_table_cursor(table, cursor_row)
+            with self._programmatic_table_update():
+                self._position_panel_table_cursor(table, cursor_row)
             self._last_table_signature = signature
             return
 
@@ -7446,7 +7448,7 @@ class DefenseClawTUI(App[None]):
         # the retained middle of the DataTable and apply that small delta;
         # clearing/re-adding the full 5,000-row tail caused a visible hitch
         # on every two-second log refresh.
-        if previous is not None and (
+        same_table_shape = previous is not None and (
             signature[0],
             signature[1],
             signature[4],
@@ -7454,22 +7456,39 @@ class DefenseClawTUI(App[None]):
             previous[0],
             previous[1],
             previous[4],
-        ) and self._update_panel_table_delta(table, previous[2], self._table_rows):
-            table.remove_class("hidden")
-            self._position_panel_table_cursor(table, cursor_row)
+        )
+        delta_applied = False
+        if same_table_shape:
+            with self._programmatic_table_update():
+                delta_applied = self._update_panel_table_delta(table, previous[2], self._table_rows)
+                if delta_applied:
+                    table.remove_class("hidden")
+                    self._position_panel_table_cursor(table, cursor_row)
+        if delta_applied:
             self._last_table_signature = signature
             return
 
-        table.remove_class("hidden")
-        table.clear(columns=True)
-        self._rendered_table_row_keys.clear()
-        table.add_columns(*self._table_columns)
-        for row in self._table_rows:
-            self._append_panel_table_row(table, row)
-
-        if self._table_rows:
-            self._position_panel_table_cursor(table, cursor_row)
+        with self._programmatic_table_update():
+            table.remove_class("hidden")
+            table.clear(columns=True)
+            self._rendered_table_row_keys.clear()
+            table.add_columns(*self._table_columns)
+            for row in self._table_rows:
+                self._append_panel_table_row(table, row)
+            if self._table_rows:
+                self._position_panel_table_cursor(table, cursor_row)
         self._last_table_signature = signature
+
+    @contextmanager
+    def _programmatic_table_update(self) -> Iterator[None]:
+        """Suppress model cursor writes during passive table mutations."""
+
+        was_restoring = self._restoring_table_cursor
+        self._restoring_table_cursor = True
+        try:
+            yield
+        finally:
+            self._restoring_table_cursor = was_restoring
 
     def _position_panel_table_cursor(self, table: DataTable[Any], cursor_row: int) -> None:
         """Move/focus the shared table without feeding the move back to models."""
@@ -7478,11 +7497,7 @@ class DefenseClawTUI(App[None]):
             return
         # move_cursor fires RowHighlighted; suppress the handler's model
         # write so restoring the cursor here can't pause the Logs stream.
-        self._restoring_table_cursor = True
-        try:
-            table.move_cursor(row=cursor_row, column=0, animate=False)
-        finally:
-            self._restoring_table_cursor = False
+        table.move_cursor(row=cursor_row, column=0, animate=False)
         # Textual's DataTable binds left/right/enter to its own cursor
         # actions, which silently swallows the keys the setup wizard form
         # relies on. Keep its visual cursor but relinquish focus in that mode.

--- a/cli/defenseclaw/tui/panels/alerts.py
+++ b/cli/defenseclaw/tui/panels/alerts.py
@@ -258,7 +258,7 @@ class AlertsPanelModel:
         self.store = store
 
     def set_events(self, events: list[AlertEvent]) -> None:
-        self.audit_events = events
+        self.audit_events = list(events)
         self._invalidate_row_caches()
         self.apply_filter()
         self.selected_ids.intersection_update(event.id for event in events)

--- a/cli/defenseclaw/tui/panels/alerts.py
+++ b/cli/defenseclaw/tui/panels/alerts.py
@@ -291,6 +291,10 @@ class AlertsPanelModel:
                 self.audit_events = audit_events
                 self._invalidate_row_caches()
         if self.data_dir is None:
+            if self.scan_blocks or self.egress_events:
+                self.scan_blocks = []
+                self.egress_events = []
+                self._invalidate_row_caches()
             self.apply_filter()
         else:
             self.refresh_gateway_scans()

--- a/cli/defenseclaw/tui/panels/alerts.py
+++ b/cli/defenseclaw/tui/panels/alerts.py
@@ -267,8 +267,12 @@ class AlertsPanelModel:
         if self.data_dir is None:
             return
         gateway_path = self.data_dir / "gateway.jsonl"
-        scan_blocks = load_gateway_scan_blocks(gateway_path)
-        egress_events = load_gateway_egress(gateway_path)
+        try:
+            scan_blocks = load_gateway_scan_blocks(gateway_path, raise_errors=True)
+            egress_events = load_gateway_egress(gateway_path, raise_errors=True)
+        except OSError:
+            self.apply_filter()
+            return
         if tuple(self.scan_blocks) != scan_blocks or tuple(self.egress_events) != egress_events:
             self.scan_blocks = list(scan_blocks)
             self.egress_events = list(egress_events)

--- a/cli/defenseclaw/tui/panels/alerts.py
+++ b/cli/defenseclaw/tui/panels/alerts.py
@@ -233,6 +233,13 @@ class AlertsPanelModel:
         # count; single-connector installs keep defaults (no filter/column).
         self.connector_filter = ""
         self.show_connector_column = False
+        # ``flat_rows`` sorts and expands all three alert sources. The app
+        # asks for that same projection repeatedly in one render (tab badge,
+        # status strip, hint bar, Overview counts), so retain it until a
+        # source or expansion state actually changes.
+        self._flat_rows_cache: tuple[AlertRow, ...] | None = None
+        self._flat_rows_expanded: frozenset[str] = frozenset()
+        self._severity_counts_cache: dict[str, int] | None = None
 
     def set_data_dir(self, data_dir: Path | str | None) -> None:
         """Late-bind the gateway.jsonl source after a config reload."""
@@ -252,6 +259,7 @@ class AlertsPanelModel:
 
     def set_events(self, events: list[AlertEvent]) -> None:
         self.audit_events = events
+        self._invalidate_row_caches()
         self.apply_filter()
         self.selected_ids.intersection_update(event.id for event in events)
 
@@ -259,8 +267,12 @@ class AlertsPanelModel:
         if self.data_dir is None:
             return
         gateway_path = self.data_dir / "gateway.jsonl"
-        self.scan_blocks = list(load_gateway_scan_blocks(gateway_path))
-        self.egress_events = list(load_gateway_egress(gateway_path))
+        scan_blocks = load_gateway_scan_blocks(gateway_path)
+        egress_events = load_gateway_egress(gateway_path)
+        if tuple(self.scan_blocks) != scan_blocks or tuple(self.egress_events) != egress_events:
+            self.scan_blocks = list(scan_blocks)
+            self.egress_events = list(egress_events)
+            self._invalidate_row_caches()
         self.apply_filter()
 
     def refresh(self) -> None:
@@ -269,18 +281,24 @@ class AlertsPanelModel:
         if self.store is not None and hasattr(self.store, "list_alerts"):
             reader = self._store_alert_reader()
             try:
-                self.audit_events = [
+                audit_events = [
                     _coerce_alert_event(event)
                     for event in reader(500)  # type: ignore[misc]
                 ]
             except Exception:  # noqa: BLE001 - missing/partial audit DBs render empty alerts.
-                self.audit_events = []
+                audit_events = []
+            if self.audit_events != audit_events:
+                self.audit_events = audit_events
+                self._invalidate_row_caches()
         if self.data_dir is None:
             self.apply_filter()
         else:
             self.refresh_gateway_scans()
 
     def flat_rows(self) -> list[AlertRow]:
+        expanded = frozenset(self.expanded)
+        if self._flat_rows_cache is not None and self._flat_rows_expanded == expanded:
+            return list(self._flat_rows_cache)
         groups: list[tuple[datetime, list[AlertRow]]] = [
             (event.timestamp, [AlertRow("audit", event)]) for event in self.audit_events
         ]
@@ -302,7 +320,15 @@ class AlertsPanelModel:
             event = synthetic_egress_event(egress)
             groups.append((event.timestamp, [AlertRow("egress", event)]))
         groups.sort(key=lambda group: group[0], reverse=True)
-        return [row for _timestamp, rows in groups for row in rows]
+        self._flat_rows_cache = tuple(row for _timestamp, rows in groups for row in rows)
+        self._flat_rows_expanded = expanded
+        self._severity_counts_cache = None
+        return list(self._flat_rows_cache)
+
+    def _invalidate_row_caches(self) -> None:
+        self._flat_rows_cache = None
+        self._flat_rows_expanded = frozenset()
+        self._severity_counts_cache = None
 
     def apply_filter(self) -> None:
         query = self.filter_text.lower()
@@ -397,6 +423,7 @@ class AlertsPanelModel:
                 self.expanded.remove(row.scan_id)
             else:
                 self.expanded.add(row.scan_id)
+            self._invalidate_row_caches()
             self.apply_filter()
             return
         self.detail_open = not self.detail_open
@@ -422,6 +449,8 @@ class AlertsPanelModel:
         return [row.event.id for row in self.filtered if not row.event.id.startswith("gw:")]
 
     def severity_counts(self) -> dict[str, int]:
+        if self._severity_counts_cache is not None:
+            return dict(self._severity_counts_cache)
         counts = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0}
         for row in self.flat_rows():
             if row.kind == "scan_finding":
@@ -429,7 +458,8 @@ class AlertsPanelModel:
             bucket = _event_severity_bucket(row.event)
             if bucket in counts:
                 counts[bucket] += 1
-        return counts
+        self._severity_counts_cache = counts
+        return dict(counts)
 
     def alert_count(self) -> int:
         """Return the number of top-level rows represented in Alerts."""

--- a/cli/defenseclaw/tui/panels/logs.py
+++ b/cli/defenseclaw/tui/panels/logs.py
@@ -991,7 +991,7 @@ class LogsPanelModel:
         rendered = self.lines[source]
         if len(rendered) != len(rows):
             return []
-        if self.filter_mode == FILTER_NONE and not self.search_text:
+        if self.filter_mode == FILTER_NONE and not self.search_text and not self.connector_filter:
             return list(rows)
         return [row for row, line in zip(rows, rendered, strict=True) if self.line_matches_current_filter(line.lower())]
 
@@ -1175,7 +1175,7 @@ def _short_digest(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8", errors="replace")).hexdigest()[:12]
 
 
-def _file_signature(path: Path) -> tuple[int, int, int, int] | None:
+def _file_signature(path: Path) -> tuple[int, int, int, int, int] | None:
     """Return a rotation-safe, nanosecond file identity for polling.
 
     ``None`` deliberately represents missing/unreadable files. The caller
@@ -1187,7 +1187,7 @@ def _file_signature(path: Path) -> tuple[int, int, int, int] | None:
         stat = path.stat()
     except OSError:
         return None
-    return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
+    return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns)
 
 
 def _tail_text_file(path: Path, *, max_bytes: int = 512 * 1024, max_lines: int = 5000) -> tuple[str, ...]:

--- a/cli/defenseclaw/tui/panels/logs.py
+++ b/cli/defenseclaw/tui/panels/logs.py
@@ -620,9 +620,14 @@ class LogsPanelModel:
             signature = _file_signature(path)
             if self._refresh_signatures.get(source, _UNSET_SIGNATURE) == signature:
                 continue
-            self._refresh_signatures[source] = signature
-            self._load_file(source, path)
-            changed_sources.add(source)
+            if self._load_file(source, path):
+                self._refresh_signatures[source] = signature
+                changed_sources.add(source)
+            elif signature is None:
+                # A missing file is a stable snapshot; creation changes the
+                # signature and naturally retries. Existing-but-unreadable
+                # files keep the old signature so transient failures retry.
+                self._refresh_signatures[source] = signature
 
         gateway_events_path = self.data_dir / "gateway.jsonl"
         structured_signature = (
@@ -632,7 +637,6 @@ class LogsPanelModel:
             self.verdict_severity,
         )
         if self._refresh_signatures.get("structured", _UNSET_SIGNATURE) != structured_signature:
-            self._refresh_signatures["structured"] = structured_signature
             views = load_gateway_log_views(
                 gateway_events_path,
                 action_filter=self.verdict_action,
@@ -641,11 +645,15 @@ class LogsPanelModel:
             )
             self.error_messages["verdicts"] = views.error
             self.error_messages["otel"] = views.error
-            self.verdict_rows = list(views.verdict_rows)
-            self.otel_rows = list(views.otel_rows)
-            self.lines["verdicts"] = list(views.verdict_lines)
-            self.lines["otel"] = list(views.otel_lines)
-            changed_sources.update(("verdicts", "otel"))
+            if not views.error:
+                self._refresh_signatures["structured"] = structured_signature
+                self.verdict_rows = list(views.verdict_rows)
+                self.otel_rows = list(views.otel_rows)
+                self.lines["verdicts"] = list(views.verdict_lines)
+                self.lines["otel"] = list(views.otel_lines)
+                changed_sources.update(("verdicts", "otel"))
+            elif structured_signature[0] is None:
+                self._refresh_signatures["structured"] = structured_signature
 
         if self.source in changed_sources:
             self._clamp_cursor()
@@ -1037,13 +1045,15 @@ class LogsPanelModel:
         else:
             self._clamp_cursor()
 
-    def _load_file(self, source: LogSource, path: Path) -> None:
+    def _load_file(self, source: LogSource, path: Path) -> bool:
         try:
-            self.lines[source] = list(_tail_text_file(path))
-            self.error_messages[source] = ""
+            lines = list(_tail_text_file(path))
         except OSError as exc:
-            self.lines[source] = []
             self.error_messages[source] = f"Cannot open: {exc}"
+            return False
+        self.lines[source] = lines
+        self.error_messages[source] = ""
+        return True
 
     def _header_text(self) -> str:
         state = "PAUSED" if self.paused else "LIVE"

--- a/cli/defenseclaw/tui/panels/logs.py
+++ b/cli/defenseclaw/tui/panels/logs.py
@@ -142,6 +142,7 @@ LOW_SIGNAL_LOG_PATTERNS: tuple[str, ...] = (
 
 REDACTION_ENV_VAR = "DEFENSECLAW_DISABLE_REDACTION"
 TRUTHY_REDACTION_VALUES = {"1", "true", "yes", "on"}
+_UNSET_SIGNATURE = object()
 
 FILTER_TYPE_ACTION = "action"
 FILTER_TYPE_EVENT_TYPE = "event_type"
@@ -324,6 +325,19 @@ class LogsPanelModel:
         # operator knows whether anything interesting happened while
         # they were reading. ``None`` = not paused for this source.
         self._pause_baseline: dict[LogSource, int | None] = {source: None for source in LOG_SOURCES}
+        # File tails and structured gateway events are polled every two
+        # seconds. Most ticks observe identical files; remember their cheap
+        # stat signatures so those ticks don't reread/reparse up to 1.5 MiB
+        # of logs on Textual's UI thread.
+        self._refresh_signatures: dict[str, object] = {}
+        # A single render asks for the same filtered source several times
+        # (table rows, summary, source tabs, cursor clamping). Cache the pure
+        # filter result so a 5,000-line tail is scanned once per content or
+        # filter change instead of repeatedly in the same keypress/frame.
+        self._filtered_lines_cache: dict[
+            LogSource,
+            tuple[tuple[str, ...], tuple[str, str, str], tuple[str, ...]],
+        ] = {}
 
     def set_data_dir(self, data_dir: str | Path | None) -> None:
         """Late-bind the data dir so a setup-driven config reload can
@@ -336,7 +350,10 @@ class LogsPanelModel:
         preserved across the swap.
         """
 
-        self.data_dir = Path(data_dir) if data_dir else None
+        next_data_dir = Path(data_dir) if data_dir else None
+        if next_data_dir != self.data_dir:
+            self._refresh_signatures.clear()
+        self.data_dir = next_data_dir
 
     @property
     def paused(self) -> bool:
@@ -555,12 +572,17 @@ class LogsPanelModel:
     def data_table_rows(self) -> tuple[tuple[str, ...], ...]:
         """Return active filtered rows in the table shape consumed by Textual."""
 
+        # The shell only needs cell text here. Building ``LogTableRow``
+        # metadata for every line also hashes each row and classifies its
+        # style; doing that for a cursor-only repaint cost ~25-30 ms at the
+        # 5,000-line tail limit even though the table contents were unchanged.
+        lines = self.filtered_lines()
         if self.show_connector_column:
             return tuple(
-                (_line_connector(row.cells[0]) or "—", *row.cells)
-                for row in self.data_table_row_models()
+                (_line_connector(line) or "—", line)
+                for line in lines
             )
-        return tuple(row.cells for row in self.data_table_row_models())
+        return tuple((line,) for line in lines)
 
     def data_table_row_models(self) -> tuple[LogTableRow, ...]:
         """Return active rows with stable row keys and cursor indexes."""
@@ -592,21 +614,41 @@ class LogsPanelModel:
 
         if self.data_dir is None:
             return
-        self._load_file("gateway", self.data_dir / "gateway.log")
-        self._load_file("watchdog", self.data_dir / "watchdog.log")
-        views = load_gateway_log_views(
-            self.data_dir / "gateway.jsonl",
-            action_filter=self.verdict_action,
-            event_type_filter=self.verdict_event_type,
-            severity_filter=self.verdict_severity,
+        changed_sources: set[LogSource] = set()
+        for source, filename in (("gateway", "gateway.log"), ("watchdog", "watchdog.log")):
+            path = self.data_dir / filename
+            signature = _file_signature(path)
+            if self._refresh_signatures.get(source, _UNSET_SIGNATURE) == signature:
+                continue
+            self._refresh_signatures[source] = signature
+            self._load_file(source, path)
+            changed_sources.add(source)
+
+        gateway_events_path = self.data_dir / "gateway.jsonl"
+        structured_signature = (
+            _file_signature(gateway_events_path),
+            self.verdict_action,
+            self.verdict_event_type,
+            self.verdict_severity,
         )
-        self.error_messages["verdicts"] = views.error
-        self.error_messages["otel"] = views.error
-        self.verdict_rows = list(views.verdict_rows)
-        self.otel_rows = list(views.otel_rows)
-        self.lines["verdicts"] = list(views.verdict_lines)
-        self.lines["otel"] = list(views.otel_lines)
-        self._clamp_cursor()
+        if self._refresh_signatures.get("structured", _UNSET_SIGNATURE) != structured_signature:
+            self._refresh_signatures["structured"] = structured_signature
+            views = load_gateway_log_views(
+                gateway_events_path,
+                action_filter=self.verdict_action,
+                event_type_filter=self.verdict_event_type,
+                severity_filter=self.verdict_severity,
+            )
+            self.error_messages["verdicts"] = views.error
+            self.error_messages["otel"] = views.error
+            self.verdict_rows = list(views.verdict_rows)
+            self.otel_rows = list(views.otel_rows)
+            self.lines["verdicts"] = list(views.verdict_lines)
+            self.lines["otel"] = list(views.otel_lines)
+            changed_sources.update(("verdicts", "otel"))
+
+        if self.source in changed_sources:
+            self._clamp_cursor()
 
     def set_source(self, source: LogSource) -> None:
         self.source = source
@@ -666,9 +708,17 @@ class LogsPanelModel:
     def filtered_lines(self, source: LogSource | None = None) -> list[str]:
         active = source or self.source
         rows = self.lines[active]
+        rows_snapshot = tuple(rows)
+        filter_signature = (self.filter_mode, self.search_text, self.connector_filter)
+        cached = self._filtered_lines_cache.get(active)
+        if cached is not None and cached[0] == rows_snapshot and cached[1] == filter_signature:
+            return list(cached[2])
         if self.filter_mode == FILTER_NONE and not self.search_text and not self.connector_filter:
-            return list(rows)
-        return [line for line in rows if self.line_matches_current_filter(line.lower())]
+            filtered = rows_snapshot
+        else:
+            filtered = tuple(line for line in rows if self.line_matches_current_filter(line.lower()))
+        self._filtered_lines_cache[active] = (rows_snapshot, filter_signature, filtered)
+        return list(filtered)
 
     def filtered_verdicts(self) -> list[GatewayLogRow]:
         if self.source != "verdicts":
@@ -1123,6 +1173,21 @@ def _log_row_key(source: LogSource, index: int, row: GatewayLogRow | None, line:
 
 def _short_digest(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8", errors="replace")).hexdigest()[:12]
+
+
+def _file_signature(path: Path) -> tuple[int, int, int, int] | None:
+    """Return a rotation-safe, nanosecond file identity for polling.
+
+    ``None`` deliberately represents missing/unreadable files. The caller
+    keeps a separate unset sentinel, so the first miss still flows through
+    the normal loader and records its operator-facing error state.
+    """
+
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
 
 
 def _tail_text_file(path: Path, *, max_bytes: int = 512 * 1024, max_lines: int = 5000) -> tuple[str, ...]:

--- a/cli/defenseclaw/tui/panels/logs.py
+++ b/cli/defenseclaw/tui/panels/logs.py
@@ -353,6 +353,13 @@ class LogsPanelModel:
         next_data_dir = Path(data_dir) if data_dir else None
         if next_data_dir != self.data_dir:
             self._refresh_signatures.clear()
+            if next_data_dir is None:
+                self.lines = {source: [] for source in LOG_SOURCES}
+                self.error_messages = {source: "" for source in LOG_SOURCES}
+                self.verdict_rows = []
+                self.otel_rows = []
+                self._filtered_lines_cache.clear()
+                self._clamp_cursor()
         self.data_dir = next_data_dir
 
     @property
@@ -577,12 +584,14 @@ class LogsPanelModel:
         # style; doing that for a cursor-only repaint cost ~25-30 ms at the
         # 5,000-line tail limit even though the table contents were unchanged.
         lines = self.filtered_lines()
+        return tuple(self._table_cells(line) for line in lines)
+
+    def _table_cells(self, line: str) -> tuple[str, ...]:
+        """Return the shared row shape for shell and metadata consumers."""
+
         if self.show_connector_column:
-            return tuple(
-                (_line_connector(line) or "—", line)
-                for line in lines
-            )
-        return tuple((line,) for line in lines)
+            return (_line_connector(line) or "—", line)
+        return (line,)
 
     def data_table_row_models(self) -> tuple[LogTableRow, ...]:
         """Return active rows with stable row keys and cursor indexes."""
@@ -599,7 +608,7 @@ class LogsPanelModel:
                 key=_log_row_key(self.source, index, structured.get(index), line),
                 cursor_index=index,
                 source=self.source,
-                cells=(line,),
+                cells=self._table_cells(line),
                 selected=index == selected,
                 style_key=self.line_style_key(line),
                 detail_title=self._detail_title_for_row(structured.get(index)),

--- a/cli/defenseclaw/tui/services/gateway_events.py
+++ b/cli/defenseclaw/tui/services/gateway_events.py
@@ -131,7 +131,7 @@ def count_recent_silent_bypass(
     return n
 
 
-def load_gateway_egress(path: Path | str) -> tuple[EgressEvent, ...]:
+def load_gateway_egress(path: Path | str, *, raise_errors: bool = False) -> tuple[EgressEvent, ...]:
     """Read the tail of ``gateway.jsonl`` and return egress rows.
 
     Bounded to the last 512 KiB to match the Go reader's budget; on a
@@ -144,6 +144,8 @@ def load_gateway_egress(path: Path | str) -> tuple[EgressEvent, ...]:
         signature = _gateway_file_signature(p)
         return _load_gateway_egress_cached(str(p), signature)
     except OSError:
+        if raise_errors:
+            raise
         return ()
 
 
@@ -262,13 +264,15 @@ def render_verdict_line(event: GatewayEvent) -> str:
     return str(event.raw)
 
 
-def load_gateway_activity(path: Path) -> tuple[ActivityMutation, ...]:
+def load_gateway_activity(path: Path, *, raise_errors: bool = False) -> tuple[ActivityMutation, ...]:
     """Load activity events from a gateway JSONL file."""
 
     try:
         signature = _gateway_file_signature(path)
         return _load_gateway_activity_cached(str(path), signature)
     except OSError:
+        if raise_errors:
+            raise
         return ()
 
 
@@ -305,13 +309,15 @@ def _load_gateway_activity_cached(
     return tuple(rows)
 
 
-def load_gateway_scan_blocks(path: Path) -> tuple[ScanBlock, ...]:
+def load_gateway_scan_blocks(path: Path, *, raise_errors: bool = False) -> tuple[ScanBlock, ...]:
     """Load scan summary blocks and attached findings from gateway JSONL."""
 
     try:
         signature = _gateway_file_signature(path)
         return _load_gateway_scan_blocks_cached(str(path), signature)
     except OSError:
+        if raise_errors:
+            raise
         return ()
 
 
@@ -405,9 +411,12 @@ def _read_tail_event_lines(
     offset = size - read_size
     with path.open("rb") as fh:
         if offset > 0:
-            fh.seek(offset)
+            fh.seek(offset - 1)
+            starts_mid_line = fh.read(1) != b"\n"
+        else:
+            starts_mid_line = False
         data = fh.read(read_size)
-    if offset > 0:
+    if starts_mid_line:
         _, _, data = data.partition(b"\n")
     lines = data.decode("utf-8", errors="replace").splitlines()
     if max_lines is not None and len(lines) > max_lines:

--- a/cli/defenseclaw/tui/services/gateway_events.py
+++ b/cli/defenseclaw/tui/services/gateway_events.py
@@ -142,9 +142,9 @@ def load_gateway_egress(path: Path | str) -> tuple[EgressEvent, ...]:
     p = Path(path)
     try:
         signature = _gateway_file_signature(p)
+        return _load_gateway_egress_cached(str(p), signature)
     except OSError:
         return ()
-    return _load_gateway_egress_cached(str(p), signature)
 
 
 @lru_cache(maxsize=16)
@@ -154,30 +154,8 @@ def _load_gateway_egress_cached(
 ) -> tuple[EgressEvent, ...]:
     """Parse egress rows once per immutable file snapshot."""
 
-    p = Path(path)
-    try:
-        size = p.stat().st_size
-    except (OSError, FileNotFoundError):
-        return ()
-    max_bytes = 512 * 1024
-    read_size = min(size, max_bytes)
-    offset = size - read_size
-    try:
-        with p.open("rb") as fh:
-            if offset > 0:
-                fh.seek(offset)
-            chunk = fh.read(read_size)
-    except OSError:
-        return ()
-    text = chunk.decode("utf-8", errors="replace")
-    if offset > 0:
-        # The first line is almost certainly a half-record; drop it so
-        # ``json.loads`` doesn't reject it.
-        nl = text.find("\n")
-        if nl >= 0:
-            text = text[nl + 1 :]
     out: list[EgressEvent] = []
-    for raw in text.splitlines():
+    for raw in _read_tail_event_lines(Path(path), max_lines=None):
         line = raw.strip()
         if not line:
             continue
@@ -289,9 +267,9 @@ def load_gateway_activity(path: Path) -> tuple[ActivityMutation, ...]:
 
     try:
         signature = _gateway_file_signature(path)
+        return _load_gateway_activity_cached(str(path), signature)
     except OSError:
         return ()
-    return _load_gateway_activity_cached(str(path), signature)
 
 
 @lru_cache(maxsize=16)
@@ -302,7 +280,7 @@ def _load_gateway_activity_cached(
     """Parse activity mutations once per immutable file snapshot."""
 
     rows: list[ActivityMutation] = []
-    for line in _tail_event_lines(Path(path)):
+    for line in _read_tail_event_lines(Path(path)):
         if not line.strip():
             continue
         try:
@@ -332,9 +310,9 @@ def load_gateway_scan_blocks(path: Path) -> tuple[ScanBlock, ...]:
 
     try:
         signature = _gateway_file_signature(path)
+        return _load_gateway_scan_blocks_cached(str(path), signature)
     except OSError:
         return ()
-    return _load_gateway_scan_blocks_cached(str(path), signature)
 
 
 @lru_cache(maxsize=16)
@@ -345,7 +323,7 @@ def _load_gateway_scan_blocks_cached(
     """Parse scan blocks once per immutable file snapshot."""
 
     blocks: dict[str, dict[str, Any]] = {}
-    for line in _tail_event_lines(Path(path)):
+    for line in _read_tail_event_lines(Path(path)):
         if not line.strip():
             continue
         # A single malformed gateway row must never break the Alerts
@@ -414,31 +392,25 @@ def _load_gateway_scan_blocks_cached(
     )
 
 
-def _tail_event_lines(
+def _read_tail_event_lines(
     path: Path,
     *,
     max_bytes: int = 512 * 1024,
-    max_lines: int = 2000,
+    max_lines: int | None = 2000,
 ) -> tuple[str, ...]:
-    """Return a bounded tail of a JSONL event file."""
+    """Return a bounded tail, raising so transient failures are not cached."""
 
-    try:
-        size = path.stat().st_size
-    except (OSError, FileNotFoundError):
-        return ()
+    size = path.stat().st_size
     read_size = min(size, max_bytes)
     offset = size - read_size
-    try:
-        with path.open("rb") as fh:
-            if offset > 0:
-                fh.seek(offset)
-            data = fh.read(read_size)
-    except OSError:
-        return ()
+    with path.open("rb") as fh:
+        if offset > 0:
+            fh.seek(offset)
+        data = fh.read(read_size)
     if offset > 0:
         _, _, data = data.partition(b"\n")
     lines = data.decode("utf-8", errors="replace").splitlines()
-    if len(lines) > max_lines:
+    if max_lines is not None and len(lines) > max_lines:
         lines = lines[-max_lines:]
     return tuple(lines)
 

--- a/cli/defenseclaw/tui/services/gateway_events.py
+++ b/cli/defenseclaw/tui/services/gateway_events.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Literal
 
@@ -137,6 +138,21 @@ def load_gateway_egress(path: Path | str) -> tuple[EgressEvent, ...]:
     fresh install the file may not exist yet, in which case we return
     an empty tuple instead of raising.
     """
+
+    p = Path(path)
+    try:
+        signature = _gateway_file_signature(p)
+    except OSError:
+        return ()
+    return _load_gateway_egress_cached(str(p), signature)
+
+
+@lru_cache(maxsize=16)
+def _load_gateway_egress_cached(
+    path: str,
+    _signature: tuple[int, int, int, int],
+) -> tuple[EgressEvent, ...]:
+    """Parse egress rows once per immutable file snapshot."""
 
     p = Path(path)
     try:
@@ -271,8 +287,22 @@ def render_verdict_line(event: GatewayEvent) -> str:
 def load_gateway_activity(path: Path) -> tuple[ActivityMutation, ...]:
     """Load activity events from a gateway JSONL file."""
 
+    try:
+        signature = _gateway_file_signature(path)
+    except OSError:
+        return ()
+    return _load_gateway_activity_cached(str(path), signature)
+
+
+@lru_cache(maxsize=16)
+def _load_gateway_activity_cached(
+    path: str,
+    _signature: tuple[int, int, int, int],
+) -> tuple[ActivityMutation, ...]:
+    """Parse activity mutations once per immutable file snapshot."""
+
     rows: list[ActivityMutation] = []
-    for line in _tail_event_lines(path):
+    for line in _tail_event_lines(Path(path)):
         if not line.strip():
             continue
         try:
@@ -300,8 +330,22 @@ def load_gateway_activity(path: Path) -> tuple[ActivityMutation, ...]:
 def load_gateway_scan_blocks(path: Path) -> tuple[ScanBlock, ...]:
     """Load scan summary blocks and attached findings from gateway JSONL."""
 
+    try:
+        signature = _gateway_file_signature(path)
+    except OSError:
+        return ()
+    return _load_gateway_scan_blocks_cached(str(path), signature)
+
+
+@lru_cache(maxsize=16)
+def _load_gateway_scan_blocks_cached(
+    path: str,
+    _signature: tuple[int, int, int, int],
+) -> tuple[ScanBlock, ...]:
+    """Parse scan blocks once per immutable file snapshot."""
+
     blocks: dict[str, dict[str, Any]] = {}
-    for line in _tail_event_lines(path):
+    for line in _tail_event_lines(Path(path)):
         if not line.strip():
             continue
         # A single malformed gateway row must never break the Alerts
@@ -397,6 +441,13 @@ def _tail_event_lines(
     if len(lines) > max_lines:
         lines = lines[-max_lines:]
     return tuple(lines)
+
+
+def _gateway_file_signature(path: Path) -> tuple[int, int, int, int]:
+    """Return a file identity that changes on append, rewrite, or rotation."""
+
+    stat = path.stat()
+    return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
 
 
 def _mapping(raw: object) -> dict[str, Any]:

--- a/cli/tests/tui/test_activity_panel.py
+++ b/cli/tests/tui/test_activity_panel.py
@@ -112,6 +112,17 @@ def test_gateway_event_loaders_retry_after_transient_read_failure(tmp_path, monk
         assert loader(path)
 
 
+def test_gateway_event_tail_preserves_row_at_exact_window_boundary(tmp_path) -> None:
+    first = b'{"event_type":"activity","activity":{"action":"first"}}\n'
+    second = b'{"event_type":"activity","activity":{"action":"second"}}\n'
+    path = tmp_path / "gateway.jsonl"
+    path.write_bytes(first + second)
+
+    lines = gateway_events._read_tail_event_lines(path, max_bytes=len(second), max_lines=None)
+
+    assert lines == (second.decode().strip(),)
+
+
 def test_gateway_event_scan_rendering_matches_go_smoke() -> None:
     event = parse_gateway_event(
         '{"ts":"2026-04-20T12:00:00Z","event_type":"scan","severity":"HIGH",'

--- a/cli/tests/tui/test_activity_panel.py
+++ b/cli/tests/tui/test_activity_panel.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 from defenseclaw.tui.panels.activity import ActivityPanelModel
+from defenseclaw.tui.services import gateway_events
 from defenseclaw.tui.services.gateway_events import parse_gateway_event, render_verdict_line
 
 
@@ -75,6 +76,40 @@ def test_activity_panel_mutation_diff_toggle(tmp_path) -> None:
     assert "alice" in rendered
     assert "config-update" in rendered
     assert "replace /guardrail/enabled" in rendered
+
+
+def test_gateway_event_loaders_retry_after_transient_read_failure(tmp_path, monkeypatch) -> None:
+    path = tmp_path / "gateway.jsonl"
+    path.write_text(
+        (
+            '{"ts":"2026-04-20T12:00:00Z","event_type":"egress","egress":'
+            '{"branch":"shape","decision":"allow","looks_like_llm":true}}\n'
+            '{"ts":"2026-04-20T12:00:01Z","event_type":"activity","activity":'
+            '{"actor":"alice","action":"config-update","target_id":"cfg"}}\n'
+            '{"ts":"2026-04-20T12:00:02Z","event_type":"scan","severity":"HIGH","scan":'
+            '{"scan_id":"sid1","scanner":"skill-scanner","target":"t.py"}}\n'
+        ),
+        encoding="utf-8",
+    )
+    original = gateway_events._read_tail_event_lines
+    fail_next = False
+
+    def flaky_read(*args, **kwargs):
+        nonlocal fail_next
+        if fail_next:
+            fail_next = False
+            raise OSError("transient read failure")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(gateway_events, "_read_tail_event_lines", flaky_read)
+    for loader in (
+        gateway_events.load_gateway_egress,
+        gateway_events.load_gateway_activity,
+        gateway_events.load_gateway_scan_blocks,
+    ):
+        fail_next = True
+        assert loader(path) == ()
+        assert loader(path)
 
 
 def test_gateway_event_scan_rendering_matches_go_smoke() -> None:

--- a/cli/tests/tui/test_alerts_panel.py
+++ b/cli/tests/tui/test_alerts_panel.py
@@ -60,6 +60,17 @@ def test_alerts_filter_selection_and_counts() -> None:
     assert action.filter_change.new == "CRITICAL"
 
 
+def test_alerts_set_events_owns_the_input_list() -> None:
+    events = [AlertEvent(id="a1", severity="HIGH", action="scan", target="skill://one")]
+    model = AlertsPanelModel()
+
+    model.set_events(events)
+    events.clear()
+
+    assert [event.id for event in model.audit_events] == ["a1"]
+    assert [row.event.id for row in model.filtered] == ["a1"]
+
+
 def test_alerts_default_hides_low_signal_rows_until_all_opt_in() -> None:
     model = AlertsPanelModel()
     model.set_events(
@@ -236,6 +247,7 @@ def test_alerts_refresh_clears_gateway_rows_when_data_dir_is_removed(tmp_path) -
     )
     model = AlertsPanelModel(tmp_path)
     model.show_all_severities = True
+    model.set_events([AlertEvent(id="audit-1", severity="HIGH", action="proxy", target="gateway")])
     model.refresh()
     assert model.scan_blocks
 
@@ -244,6 +256,7 @@ def test_alerts_refresh_clears_gateway_rows_when_data_dir_is_removed(tmp_path) -
 
     assert model.scan_blocks == []
     assert model.egress_events == []
+    assert model.filtered
     assert all(row.kind == "audit" for row in model.filtered)
 
 

--- a/cli/tests/tui/test_alerts_panel.py
+++ b/cli/tests/tui/test_alerts_panel.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+from defenseclaw.tui.panels import alerts as alerts_module
 from defenseclaw.tui.panels.alerts import AlertEvent, AlertFinding, AlertsPanelModel, humanize_alert_details
 from defenseclaw.tui.services.gateway_events import count_recent_silent_bypass, load_gateway_egress
 
@@ -66,6 +67,7 @@ def test_alerts_set_events_owns_the_input_list() -> None:
 
     model.set_events(events)
     events.clear()
+    model.refresh()
 
     assert [event.id for event in model.audit_events] == ["a1"]
     assert [row.event.id for row in model.filtered] == ["a1"]
@@ -258,6 +260,29 @@ def test_alerts_refresh_clears_gateway_rows_when_data_dir_is_removed(tmp_path) -
     assert model.egress_events == []
     assert model.filtered
     assert all(row.kind == "audit" for row in model.filtered)
+
+
+def test_alerts_refresh_keeps_gateway_rows_after_transient_read_failure(tmp_path, monkeypatch) -> None:
+    (tmp_path / "gateway.jsonl").write_text(
+        (
+            '{"ts":"2026-04-20T12:00:00Z","event_type":"scan","severity":"HIGH",'
+            '"scan":{"scan_id":"sid1","scanner":"skill-scanner","target":"t.py"}}\n'
+        ),
+        encoding="utf-8",
+    )
+    model = AlertsPanelModel(tmp_path)
+    model.show_all_severities = True
+    model.refresh_gateway_scans()
+    previous = tuple(model.scan_blocks)
+
+    def fail_load(*_args, **_kwargs):
+        raise OSError("transient gateway read")
+
+    monkeypatch.setattr(alerts_module, "load_gateway_scan_blocks", fail_load)
+    model.refresh_gateway_scans()
+
+    assert tuple(model.scan_blocks) == previous
+    assert any(row.kind == "scan" for row in model.filtered)
 
 
 def test_alerts_refresh_ingests_gateway_egress_and_filters_warning_as_medium(tmp_path) -> None:

--- a/cli/tests/tui/test_alerts_panel.py
+++ b/cli/tests/tui/test_alerts_panel.py
@@ -225,6 +225,28 @@ def test_alerts_refresh_ingests_scan_finding_from_gateway_jsonl(tmp_path) -> Non
     assert "line=3" in finding.event.details
 
 
+def test_alerts_refresh_clears_gateway_rows_when_data_dir_is_removed(tmp_path) -> None:
+    (tmp_path / "gateway.jsonl").write_text(
+        (
+            '{"ts":"2026-04-20T12:00:00Z","event_type":"scan","severity":"HIGH",'
+            '"scan":{"scan_id":"sid1","scanner":"skill-scanner","target":"t.py",'
+            '"verdict":"warn","severity_max":"HIGH"}}\n'
+        ),
+        encoding="utf-8",
+    )
+    model = AlertsPanelModel(tmp_path)
+    model.show_all_severities = True
+    model.refresh()
+    assert model.scan_blocks
+
+    model.set_data_dir(None)
+    model.refresh()
+
+    assert model.scan_blocks == []
+    assert model.egress_events == []
+    assert all(row.kind == "audit" for row in model.filtered)
+
+
 def test_alerts_refresh_ingests_gateway_egress_and_filters_warning_as_medium(tmp_path) -> None:
     now = datetime.now(timezone.utc)
     old = now - timedelta(minutes=10)

--- a/cli/tests/tui/test_app_shell.py
+++ b/cli/tests/tui/test_app_shell.py
@@ -1387,6 +1387,9 @@ async def test_logs_stream_refresh_applies_sliding_tail_delta() -> None:
         await pilot.pause()
         table = app.query_one("#panel-table", DataTable)
         previous_second_row = list(table.rows.values())[1]
+        logs.set_cursor(50)
+        app._render_chrome()  # noqa: SLF001 - establish a non-default cursor.
+        assert table.cursor_row == 50
         restore_flags: list[bool] = []
         update_delta = app._update_panel_table_delta  # noqa: SLF001
 
@@ -1400,6 +1403,7 @@ async def test_logs_stream_refresh_applies_sliding_tail_delta() -> None:
         app._render_chrome()  # noqa: SLF001 - deterministic stream refresh.
 
         assert restore_flags == [True]
+        assert table.cursor_row == 50
         assert table.row_count == 200
         assert list(table.rows.values())[0] is previous_second_row
         assert str(table.get_cell_at((199, 0))) == "error row=new"

--- a/cli/tests/tui/test_app_shell.py
+++ b/cli/tests/tui/test_app_shell.py
@@ -1348,6 +1348,55 @@ async def test_logs_and_audit_panels_render_worker_models() -> None:
 
 
 @pytest.mark.asyncio
+async def test_logs_cursor_only_render_reuses_existing_table_rows() -> None:
+    """Cursor movement must not reconstruct a large unchanged log table."""
+
+    logs = LogsPanelModel()
+    logs.filter_mode = ""
+    logs.lines["gateway"] = [f"error row={index}" for index in range(200)]
+    app = DefenseClawTUI(logs_model=logs)
+
+    async with app.run_test(size=(150, 40)) as pilot:
+        await pilot.press("8")
+        await pilot.pause()
+        table = app.query_one("#panel-table", DataTable)
+        row_objects = tuple(table.rows.values())
+
+        logs.cursor["gateway"] = 1
+        app._render_chrome()  # noqa: SLF001 - exercise the render fast path directly.
+
+        assert tuple(table.rows.values()) == row_objects
+        assert all(
+            current is previous
+            for current, previous in zip(table.rows.values(), row_objects, strict=True)
+        )
+        assert table.cursor_row == 1
+
+
+@pytest.mark.asyncio
+async def test_logs_stream_refresh_applies_sliding_tail_delta() -> None:
+    """A new tail line should retain existing DataTable row objects."""
+
+    logs = LogsPanelModel()
+    logs.filter_mode = ""
+    logs.lines["gateway"] = [f"error row={index}" for index in range(200)]
+    app = DefenseClawTUI(logs_model=logs)
+
+    async with app.run_test(size=(150, 40)) as pilot:
+        await pilot.press("8")
+        await pilot.pause()
+        table = app.query_one("#panel-table", DataTable)
+        previous_second_row = list(table.rows.values())[1]
+
+        logs.lines["gateway"] = logs.lines["gateway"][1:] + ["error row=new"]
+        app._render_chrome()  # noqa: SLF001 - deterministic stream refresh.
+
+        assert table.row_count == 200
+        assert list(table.rows.values())[0] is previous_second_row
+        assert str(table.get_cell_at((199, 0))) == "error row=new"
+
+
+@pytest.mark.asyncio
 async def test_logs_notification_judge_history_and_enter_detail_modals(tmp_path) -> None:
     audit_db = tmp_path / "audit.db"
     with sqlite3.connect(audit_db) as db:

--- a/cli/tests/tui/test_app_shell.py
+++ b/cli/tests/tui/test_app_shell.py
@@ -1387,10 +1387,19 @@ async def test_logs_stream_refresh_applies_sliding_tail_delta() -> None:
         await pilot.pause()
         table = app.query_one("#panel-table", DataTable)
         previous_second_row = list(table.rows.values())[1]
+        restore_flags: list[bool] = []
+        update_delta = app._update_panel_table_delta  # noqa: SLF001
+
+        def tracked_update_delta(*args: object) -> bool:
+            restore_flags.append(app._restoring_table_cursor)  # noqa: SLF001
+            return update_delta(*args)  # type: ignore[arg-type]
+
+        app._update_panel_table_delta = tracked_update_delta  # type: ignore[method-assign]  # noqa: SLF001
 
         logs.lines["gateway"] = logs.lines["gateway"][1:] + ["error row=new"]
         app._render_chrome()  # noqa: SLF001 - deterministic stream refresh.
 
+        assert restore_flags == [True]
         assert table.row_count == 200
         assert list(table.rows.values())[0] is previous_second_row
         assert str(table.get_cell_at((199, 0))) == "error row=new"

--- a/cli/tests/tui/test_logs_panel.py
+++ b/cli/tests/tui/test_logs_panel.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+from defenseclaw.tui.panels import logs as logs_module
 from defenseclaw.tui.panels.logs import (
     FILTER_ERRORS,
     FILTER_HOOKS,
@@ -30,6 +31,7 @@ from defenseclaw.tui.panels.logs import (
 from defenseclaw.tui.services.gateway_log_views import (
     EVENT_TYPE_FILTERS,
     GatewayLogRow,
+    GatewayLogViews,
     detail_pairs,
     load_gateway_log_views,
     parse_gateway_log_row,
@@ -211,7 +213,6 @@ def test_logs_error_empty_and_cursor_scrolling_states(tmp_path) -> None:
     panel.lines["gateway"] = [f"line {index}" for index in range(30)]
 
     assert panel.selected_raw_line() == "line 29"
-
     panel.move_cursor(-5, height=10)
     assert panel.selected_raw_line() == "line 24"
     assert panel.paused is True
@@ -224,6 +225,48 @@ def test_logs_error_empty_and_cursor_scrolling_states(tmp_path) -> None:
     panel.lines["gateway"] = []
     panel.error_messages["gateway"] = ""
     assert "Log file is empty or not yet created" in panel.render_text()
+
+
+def test_logs_refresh_retries_transient_raw_and_structured_reads(tmp_path, monkeypatch) -> None:
+    (tmp_path / "gateway.log").write_text("gateway ready\n", encoding="utf-8")
+    (tmp_path / "gateway.jsonl").write_text("{}\n", encoding="utf-8")
+    panel = LogsPanelModel(tmp_path)
+
+    raw_reader = logs_module._tail_text_file
+    raw_calls = 0
+
+    def flaky_raw_reader(*args, **kwargs):
+        nonlocal raw_calls
+        if args[0].name == "gateway.log":
+            raw_calls += 1
+            if raw_calls == 1:
+                raise OSError("transient raw read")
+        return raw_reader(*args, **kwargs)
+
+    view_loader = logs_module.load_gateway_log_views
+    view_calls = 0
+
+    def flaky_view_loader(*args, **kwargs):
+        nonlocal view_calls
+        view_calls += 1
+        if view_calls == 1:
+            return GatewayLogViews(error="transient structured read")
+        return view_loader(*args, **kwargs)
+
+    monkeypatch.setattr(logs_module, "_tail_text_file", flaky_raw_reader)
+    monkeypatch.setattr(logs_module, "load_gateway_log_views", flaky_view_loader)
+
+    panel.refresh()
+    assert panel.lines["gateway"] == []
+    assert panel.error_messages["gateway"].startswith("Cannot open:")
+    assert panel.error_messages["verdicts"] == "transient structured read"
+
+    panel.refresh()
+    assert panel.lines["gateway"] == ["gateway ready"]
+    assert panel.error_messages["gateway"] == ""
+    assert panel.error_messages["verdicts"] == ""
+    assert raw_calls == 2
+    assert view_calls == 2
 
 
 def test_logs_no_noise_default_hides_low_signal_severities() -> None:

--- a/cli/tests/tui/test_logs_panel.py
+++ b/cli/tests/tui/test_logs_panel.py
@@ -183,6 +183,20 @@ def test_logs_selected_structured_row_respects_search_and_preset_filters() -> No
     panel.search_text = "no-such-token"
     assert panel.selected_verdict() is None
 
+    # The structured detail row must use the same connector-filtered index
+    # as the visible table, not the unfiltered structured list.
+    panel.search_text = ""
+    panel.filter_mode = FILTER_NONE
+    panel.lines["verdicts"] = [
+        "VERDICT ALLOW connector=codex clean",
+        "VERDICT ALERT connector=cursor suspicious",
+        "VERDICT BLOCK connector=codex error injection",
+    ]
+    panel.set_connector_filter("cursor")
+    selected = panel.selected_verdict()
+    assert selected is not None
+    assert selected.action == "alert"
+
 
 def test_logs_error_empty_and_cursor_scrolling_states(tmp_path) -> None:
     panel = LogsPanelModel(tmp_path)

--- a/cli/tests/tui/test_logs_panel.py
+++ b/cli/tests/tui/test_logs_panel.py
@@ -269,6 +269,23 @@ def test_logs_refresh_retries_transient_raw_and_structured_reads(tmp_path, monke
     assert view_calls == 2
 
 
+def test_logs_set_data_dir_none_clears_loaded_state(tmp_path) -> None:
+    panel = LogsPanelModel(tmp_path)
+    panel.lines["gateway"] = ["gateway ready"]
+    panel.lines["verdicts"] = ["VERDICT ALLOW"]
+    panel.verdict_rows = [GatewayLogRow(raw="{}", event_type="verdict", action="allow")]
+    panel.otel_rows = [GatewayLogRow(raw="{}", event_type="lifecycle")]
+    panel.filtered_lines()
+
+    panel.set_data_dir(None)
+
+    assert all(not lines for lines in panel.lines.values())
+    assert all(not error for error in panel.error_messages.values())
+    assert panel.verdict_rows == []
+    assert panel.otel_rows == []
+    assert panel.filtered_lines() == []
+
+
 def test_logs_no_noise_default_hides_low_signal_severities() -> None:
     panel = LogsPanelModel()
     panel.filter_mode = FILTER_NO_NOISE
@@ -517,6 +534,7 @@ def test_logs_connector_column_and_shared_filter() -> None:
     panel.show_connector_column = True
     assert panel.data_table_columns() == ("Connector", "Line")
     rows = panel.data_table_rows()
+    assert all(len(row.cells) == 2 for row in panel.data_table_row_models())
     # First cell is the parsed connector; untagged lines show the em dash.
     connectors = {row[0] for row in rows}
     assert "codex" in connectors and "cursor" in connectors and "—" in connectors


### PR DESCRIPTION
Base: `main` (standalone; no stacked dependencies).

## Problem

The Python/Textual TUI becomes visibly sluggish as log and alert histories grow. Cursor movement, passive two-second refreshes, and single-line streaming updates can all perform work proportional to the full retained history.

## Current Situation

Profiling found three compounding hot paths:

- The two-second refresh loop rereads and reparses unchanged gateway/log files on Textual's UI thread.
- A single render filters the same log tail several times for table rows, counts, tabs, and cursor clamping.
- Cursor-only changes and one-line tail updates clear and reconstruct the shared `DataTable`, up to the 5,000-row log limit.

A local synthetic benchmark using a 5,000-line log tail and a 1.7 MiB gateway event file measured:

| Scenario | Before | After | Reduction |
|---|---:|---:|---:|
| Cursor-only render | 25.2 ms | 1.10 ms | 95.6% |
| One-line sliding-tail render | 59.3 ms | 3.81 ms | 93.6% |
| Unchanged periodic model refresh | 129.1 ms | 0.83 ms | 99.4% |

These are local microbenchmarks intended to isolate the affected hot paths; end-to-end latency varies with terminal size and event volume.

## Solution

### Reuse the rendered table

Split table rendering into three paths:

1. Cursor-only changes call `move_cursor()` and retain all row/cell caches.
2. Small append or sliding-tail changes remove/add only the changed rows.
3. Panel changes, column changes, and large rewrites retain the existing full-rebuild fallback.

### Avoid unchanged polling work

Track rotation-safe file signatures `(device, inode, size, mtime_ns)`. Unchanged files reuse their existing bounded tails and parsed gateway projections. File creation, append, rewrite, deletion, and rotation still invalidate the cache.

### Cache pure projections

Cache filtered log lines, flattened alert rows, severity counts, and parsed scan/activity/egress snapshots until their source data or active filters change.

```mermaid
flowchart LR
    Timer["2-second refresh"] --> Stat["Check file signature"]
    Stat -->|unchanged| Cached["Reuse parsed model"]
    Stat -->|changed| Parse["Read bounded tail and parse"]
    Cached --> Signature["Compare table signature"]
    Parse --> Signature
    Input["Cursor or stream event"] --> Signature
    Signature -->|cursor only| Move["Move cursor"]
    Signature -->|small tail delta| Patch["Remove/add changed rows"]
    Signature -->|large or structural change| Rebuild["Full rebuild fallback"]
```

## What Changed (Where & How)

| Path | Change |
|---|---|
| `cli/defenseclaw/tui/app.py` | Adds cursor-only and incremental sliding-tail `DataTable` update paths while preserving the full-rebuild fallback. |
| `cli/defenseclaw/tui/panels/logs.py` | Adds file-signature polling, filtered-line caching, and a cell-only table-row projection. |
| `cli/defenseclaw/tui/panels/alerts.py` | Caches flattened alert rows and severity counts with explicit invalidation. |
| `cli/defenseclaw/tui/services/gateway_events.py` | Caches bounded scan, activity, and egress parsing by file snapshot. |
| `cli/tests/tui/test_app_shell.py`, `test_activity_panel.py`, `test_alerts_panel.py`, `test_logs_panel.py` | Adds regression coverage for incremental updates, connector filtering, detached sources, transient read retries, and JSONL tail boundaries. |

## Breaking Changes

None. No configuration, API, default, or operator workflow changes.

## Open Issues / Follow-ups

None.

## Test Plan

- `uv run --frozen --group dev ruff check cli/defenseclaw/tui/app.py cli/defenseclaw/tui/panels/logs.py cli/defenseclaw/tui/panels/alerts.py cli/defenseclaw/tui/services/gateway_events.py cli/tests/tui/test_app_shell.py cli/tests/tui/test_activity_panel.py cli/tests/tui/test_alerts_panel.py cli/tests/tui/test_logs_panel.py`\n  - Observed: `All checks passed!`
- `git diff --check`
  - Observed: passed with no whitespace errors.
- `uv run --frozen --group dev pytest -q cli/tests/tui/test_app_shell.py cli/tests/tui/test_activity_panel.py cli/tests/tui/test_alerts_panel.py cli/tests/tui/test_logs_panel.py`
  - Observed: `219 passed, 1 warning in 102.24s`.
  - The warning is a non-failing async subprocess cleanup/resource warning.





