### PR TITLE
[codex] Fix Grafana dashboard data wiring

### DIFF
--- a/bundles/local_observability_stack/grafana/dashboards/defenseclaw-agent-identity.json
+++ b/bundles/local_observability_stack/grafana/dashboards/defenseclaw-agent-identity.json
@@ -204,6 +204,7 @@
     {
       "type": "stat",
       "title": "Discovery runs / hour",
+      "description": "On-demand connector discovery reports accepted during the selected range.",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"
@@ -216,7 +217,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(defenseclaw_ai_discovery_runs_total[$__range])) or vector(0)",
+          "expr": "sum(increase(defenseclaw_agent_discovery_runs_total[$__range])) or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -260,7 +261,7 @@
       },
       "targets": [
         {
-          "expr": "count(sum by (ai_product) (max_over_time(defenseclaw_ai_discovery_signals_total[$__range]))) or vector(0)",
+          "expr": "count(sum by (ecosystem, name) (max_over_time(defenseclaw_ai_components_installs[$__range]))) or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -307,7 +308,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (connector) (rate(defenseclaw_connector_hook_invocations_total{connector=~\"$connector\"}[$__rate_interval]))",
+          "expr": "sum by (source) (rate(defenseclaw_otel_ingest_records_total{source=~\"$connector\"}[$__rate_interval]))",
           "legendFormat": "{{source}}",
           "refId": "A"
         }
@@ -363,7 +364,7 @@
       },
       "targets": [
         {
-          "expr": "count by (gen_ai_agent_name) (sum by (gen_ai_agent_name, defenseclaw_agent_instance_id) (count_over_time({service_name=\"defenseclaw\"} | gen_ai_agent_name=~\"$connector\" | defenseclaw_agent_instance_id != \"\" [$__interval])))",
+          "expr": "count by (gen_ai_agent_name) (sum by (gen_ai_agent_name, gen_ai_agent_id) (count_over_time({service_name=\"defenseclaw\"} | gen_ai_agent_name=~\"$connector\" | gen_ai_agent_id != \"\" [$__interval])))",
           "legendFormat": "{{gen_ai_agent_name}}",
           "refId": "A",
           "datasource": {
@@ -394,7 +395,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (gen_ai_agent_name) (count_over_time({service_name=\"defenseclaw\"} | gen_ai_agent_name=~\"$connector\" | defenseclaw_agent_instance_id != \"\" [$__interval])) / sum by (gen_ai_agent_name) (count_over_time({service_name=\"defenseclaw\"} | gen_ai_agent_name=~\"$connector\" [$__interval]))",
+          "expr": "sum by (gen_ai_agent_name) (count_over_time({service_name=\"defenseclaw\"} | gen_ai_agent_name=~\"$connector\" | gen_ai_agent_id != \"\" [$__interval])) / sum by (gen_ai_agent_name) (count_over_time({service_name=\"defenseclaw\"} | gen_ai_agent_name=~\"$connector\" [$__interval]))",
           "legendFormat": "{{gen_ai_agent_name}}",
           "refId": "A",
           "datasource": {
@@ -498,12 +499,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(defenseclaw_ai_discovery_duration_milliseconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(defenseclaw_agent_discovery_duration_milliseconds_bucket[$__rate_interval])))",
           "legendFormat": "p50",
           "refId": "p50"
         },
         {
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(defenseclaw_ai_discovery_duration_milliseconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(defenseclaw_agent_discovery_duration_milliseconds_bucket[$__rate_interval])))",
           "legendFormat": "p95",
           "refId": "p95"
         }
@@ -531,7 +532,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (connector) (increase(defenseclaw_connector_hook_invocations_total{connector=~\"$connector\"}[$__range]))",
+          "expr": "max by (connector) (last_over_time(defenseclaw_agent_discovery_installed_ratio{connector=~\"$connector\"}[$__range]))",
           "instant": true,
           "format": "table",
           "refId": "A"
@@ -744,7 +745,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (le) (increase(defenseclaw_ai_discovery_duration_milliseconds_bucket[$__range]))",
+          "expr": "sum by (le) (increase(defenseclaw_ai_confidence_identity_score_bucket[$__range]))",
           "format": "heatmap",
           "refId": "A"
         }
@@ -766,7 +767,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (le) (increase(defenseclaw_ai_discovery_duration_milliseconds_bucket[$__range]))",
+          "expr": "sum by (le) (increase(defenseclaw_ai_confidence_presence_score_bucket[$__range]))",
           "format": "heatmap",
           "refId": "A"
         }
@@ -799,7 +800,7 @@
       "timeFrom": "1h",
       "targets": [
         {
-          "expr": "{service_name=\"defenseclaw\"} | defenseclaw_gateway_event_type=\"ai_discovery\"",
+          "expr": "{service_name=\"defenseclaw\"} | event_name=~\"defenseclaw[.](agent|ai)[.]discovery.*\"",
           "refId": "A",
           "datasource": {
             "type": "loki",

--- a/bundles/local_observability_stack/grafana/dashboards/defenseclaw-agent-identity.json
+++ b/bundles/local_observability_stack/grafana/dashboards/defenseclaw-agent-identity.json
@@ -203,7 +203,7 @@
     },
     {
       "type": "stat",
-      "title": "Discovery runs / hour",
+      "title": "Discovery runs (range)",
       "description": "On-demand connector discovery reports accepted during the selected range.",
       "datasource": {
         "type": "prometheus",

--- a/bundles/local_observability_stack/grafana/dashboards/defenseclaw-connector-detail.json
+++ b/bundles/local_observability_stack/grafana/dashboards/defenseclaw-connector-detail.json
@@ -194,8 +194,8 @@
     },
     {
       "type": "stat",
-      "title": "Silence (s)",
-      "description": "Seconds since the last accepted OTel batch (native-OTLP connectors) OR the last hook invocation seen for this connector. Hook-only connectors fall back to the hook-rate freshness so the panel is meaningful for cursor/hermes/copilot/geminicli/windsurf. >600s triggers DefenseClawConnectorTelemetrySilent.",
+      "title": "OTLP silence (s)",
+      "description": "Seconds since the last accepted OTel batch for a native-OTLP connector. Hook-only connectors intentionally show no series because a sampled counter cannot provide an honest last-event timestamp. >600s triggers DefenseClawConnectorTelemetrySilent for connectors that have emitted OTLP.",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"
@@ -208,7 +208,7 @@
       },
       "targets": [
         {
-          "expr": "time() - max(defenseclaw_otel_ingest_last_seen_ts_seconds{source=\"$connector\"}) or (time() - timestamp(sum(rate(defenseclaw_connector_hook_invocations_total{connector=\"$connector\"}[1m])) > bool 0)) or vector(0)",
+          "expr": "time() - max(defenseclaw_otel_ingest_last_seen_ts_seconds{source=\"$connector\"})",
           "refId": "A",
           "instant": true
         }
@@ -605,7 +605,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (severity) (rate(defenseclaw_connector_hook_outcome_total{connector=\"$connector\", severity!=\"NONE\"}[$__rate_interval])) or on() vector(0)",
+          "expr": "sum by (severity) (rate(defenseclaw_connector_hook_outcome_total{connector=\"$connector\", would_block=\"true\", severity!=\"NONE\"}[$__rate_interval])) * 60 or on() vector(0)",
           "legendFormat": "{{severity}}",
           "refId": "A"
         }
@@ -744,7 +744,7 @@
     {
       "type": "table",
       "title": "Top findings by rule (24h)",
-      "description": "Scanner findings aggregated by rule across all scanners.",
+      "description": "Scanner findings for the selected connector, aggregated by rule across all scanners.",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"
@@ -757,7 +757,7 @@
       },
       "targets": [
         {
-          "expr": "topk(20, sort_desc(sum by (scanner, rule_id, severity) (increase(defenseclaw_scan_findings_by_rule_total[24h]))))",
+          "expr": "topk(20, sort_desc(sum by (scanner, rule_id, severity) (increase(defenseclaw_scan_findings_by_rule_total{connector=\"$connector\"}[24h]))))",
           "instant": true,
           "format": "table",
           "refId": "A"

--- a/bundles/local_observability_stack/grafana/dashboards/defenseclaw-connectors.json
+++ b/bundles/local_observability_stack/grafana/dashboards/defenseclaw-connectors.json
@@ -288,7 +288,7 @@
       },
       "targets": [
         {
-          "expr": "count(group by (source) (rate(defenseclaw_otel_ingest_records_total{source=~\"$connector\"}[5m]) > 0)) or vector(0)",
+          "expr": "count((sum by (connector) (rate(defenseclaw_connector_hook_invocations_total{connector=~\"$connector\"}[5m])) > 0) or label_replace((sum by (source) (rate(defenseclaw_otel_ingest_records_total{source=~\"$connector\"}[5m])) > 0), \"connector\", \"$1\", \"source\", \"(.+)\")) or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -381,7 +381,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(defenseclaw_inspect_evaluations_total[5m])) * 60 or vector(0)",
+          "expr": "sum(rate(defenseclaw_inspect_evaluations_total{tool=~\"$connector:.*\"}[5m])) * 60 or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -412,7 +412,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(defenseclaw_inspect_evaluations_total{action=\"block\"}[5m])) * 60 or vector(0)",
+          "expr": "sum(rate(defenseclaw_inspect_evaluations_total{action=\"block\", tool=~\"$connector:.*\"}[5m])) * 60 or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -464,7 +464,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(gen_ai_client_token_usage_sum[5m])) * 60 or vector(0)",
+          "expr": "sum(rate(gen_ai_client_token_usage_sum{gen_ai_agent_name=~\"$connector\"}[5m])) * 60 or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -521,7 +521,7 @@
           "refId": "TOKENS",
           "instant": true,
           "format": "table",
-          "expr": "sum by (gen_ai_agent_name) (rate(gen_ai_client_token_usage_sum[5m])) * 60"
+          "expr": "sum by (gen_ai_agent_name) (rate(gen_ai_client_token_usage_sum{gen_ai_agent_name=~\"$connector\"}[5m])) * 60"
         }
       ],
       "transformations": [
@@ -645,7 +645,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (connector, event_type) (rate(defenseclaw_connector_hook_invocations_total{connector=~\"$connector\"}[$__rate_interval]))",
+          "expr": "sum by (source, signal) (rate(defenseclaw_otel_ingest_records_total{source=~\"$connector\"}[$__rate_interval]))",
           "legendFormat": "{{source}} / {{signal}}",
           "refId": "A"
         }
@@ -672,7 +672,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (connector) (rate(defenseclaw_connector_hook_invocations_total{connector=~\"$connector\"}[$__rate_interval]))",
+          "expr": "sum by (source, signal) (rate(defenseclaw_otel_ingest_bytes_total{source=~\"$connector\"}[$__rate_interval]))",
           "legendFormat": "{{source}} / {{signal}}",
           "refId": "A"
         }
@@ -775,7 +775,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (connector, event_type) (rate(defenseclaw_connector_hook_invocations_total{connector=~\"$connector\"}[$__rate_interval]))",
+          "expr": "sum by (gen_ai_agent_name, gen_ai_token_type) (rate(gen_ai_client_token_usage_sum{gen_ai_agent_name=~\"$connector\"}[$__rate_interval]))",
           "legendFormat": "{{gen_ai_agent_name}} / {{gen_ai_token_type}}",
           "refId": "A"
         }
@@ -802,7 +802,7 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le, connector) (rate(defenseclaw_connector_hook_latency_milliseconds_bucket{connector=~\"$connector\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, gen_ai_agent_name) (rate(gen_ai_client_operation_duration_seconds_bucket{gen_ai_agent_name=~\"$connector\"}[$__rate_interval])))",
           "legendFormat": "{{gen_ai_agent_name}}",
           "refId": "A"
         }
@@ -840,7 +840,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (action) (rate(defenseclaw_inspect_evaluations_total[$__rate_interval]))",
+          "expr": "sum by (action) (rate(defenseclaw_inspect_evaluations_total{tool=~\"$connector:.*\"}[$__rate_interval]))",
           "legendFormat": "{{action}}",
           "refId": "A"
         }
@@ -873,7 +873,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (severity) (rate(defenseclaw_inspect_evaluations_total{severity!=\"NONE\"}[$__rate_interval]))",
+          "expr": "sum by (severity) (rate(defenseclaw_inspect_evaluations_total{severity!=\"NONE\", tool=~\"$connector:.*\"}[$__rate_interval]))",
           "legendFormat": "{{severity}}",
           "refId": "A"
         }
@@ -906,7 +906,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (event_type) (rate(defenseclaw_connector_hook_outcome_total{connector=~\"$connector\", severity!=\"NONE\"}[$__rate_interval]))",
+          "expr": "sum by (tool) (rate(defenseclaw_inspect_evaluations_total{tool=~\"$connector:.*\"}[$__rate_interval]))",
           "legendFormat": "{{tool}}",
           "refId": "A"
         }
@@ -1027,7 +1027,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (event_type, result) (increase(defenseclaw_connector_hook_invocations_total{connector=\"codex\"}[$__range])) or on() vector(0)",
+          "expr": "sort_desc(sum by (type, status, result) (increase(defenseclaw_codex_notify_total[5m])))",
           "instant": true,
           "format": "table",
           "refId": "A"
@@ -1070,7 +1070,7 @@
       },
       "targets": [
         {
-          "expr": "sort_desc(time() - max by (connector) (timestamp(defenseclaw_connector_hook_invocations_total{connector=~\"$connector\"})))",
+          "expr": "sort_desc(time() - max by (source) (defenseclaw_otel_ingest_last_seen_ts_seconds{source=~\"$connector\"}))",
           "instant": true,
           "format": "table",
           "refId": "A"
@@ -1194,7 +1194,7 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le, connector) (rate(defenseclaw_connector_hook_latency_milliseconds_bucket{connector=~\"$connector\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, event_type) (rate(defenseclaw_connector_hook_latency_milliseconds_bucket{connector=~\"$connector\"}[$__rate_interval])))",
           "legendFormat": "{{event_type}}",
           "refId": "A"
         }

--- a/bundles/local_observability_stack/grafana/dashboards/defenseclaw-connectors.json
+++ b/bundles/local_observability_stack/grafana/dashboards/defenseclaw-connectors.json
@@ -275,7 +275,7 @@
     {
       "type": "stat",
       "title": "Active connectors (5m)",
-      "description": "Distinct sources that have emitted any OTLP record in the last 5 minutes.",
+      "description": "Distinct connectors that have emitted hook invocations or OTLP records in the last 5 minutes.",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"
@@ -288,7 +288,7 @@
       },
       "targets": [
         {
-          "expr": "count((sum by (connector) (rate(defenseclaw_connector_hook_invocations_total{connector=~\"$connector\"}[5m])) > 0) or label_replace((sum by (source) (rate(defenseclaw_otel_ingest_records_total{source=~\"$connector\"}[5m])) > 0), \"connector\", \"$1\", \"source\", \"(.+)\")) or vector(0)",
+          "expr": "count((sum by (connector) (rate(defenseclaw_connector_hook_invocations_total{connector=~\"$connector\"}[5m])) > 0) or sum by (connector) (label_replace((sum by (source) (rate(defenseclaw_otel_ingest_records_total{source=~\"$connector\"}[5m])) > 0), \"connector\", \"$1\", \"source\", \"(.+)\"))) or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -906,8 +906,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (tool) (rate(defenseclaw_inspect_evaluations_total{tool=~\"$connector:.*\"}[$__rate_interval]))",
-          "legendFormat": "{{tool}}",
+          "expr": "sum by (hook_event) (label_replace(rate(defenseclaw_inspect_evaluations_total{tool=~\"$connector:.*\"}[$__rate_interval]), \"hook_event\", \"$1\", \"tool\", \"^[^:]+:(.*)$\"))",
+          "legendFormat": "{{hook_event}}",
           "refId": "A"
         }
       ],

--- a/bundles/local_observability_stack/grafana/dashboards/defenseclaw-findings.json
+++ b/bundles/local_observability_stack/grafana/dashboards/defenseclaw-findings.json
@@ -806,7 +806,7 @@
               "service_namespace": true
             },
             "renameByName": {
-              "Value": "verdicts/1h"
+              "Value": "verdicts/range"
             }
           }
         }

--- a/bundles/local_observability_stack/grafana/dashboards/defenseclaw-findings.json
+++ b/bundles/local_observability_stack/grafana/dashboards/defenseclaw-findings.json
@@ -608,7 +608,7 @@
     {
       "type": "table",
       "title": "Last-seen per rule_id (24h)",
-      "description": "Approximation: scrape timestamp of the latest sample for each rule_id series. A rule that hasn't fired in 24h shows as no-data.",
+      "description": "Approximate latest firing time per rule, evaluated in five-minute windows across the last 24 hours. A rule that did not increase in the window shows no series.",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"
@@ -621,7 +621,7 @@
       },
       "targets": [
         {
-          "expr": "1000 * topk(20, max by (rule_id, scanner, severity) (timestamp(increase(defenseclaw_scan_findings_by_rule_total{scanner=~\"$scanner\", rule_id=~\"$rule_id\", severity=~\"$severity\", connector=~\"$connector\"}[24h]) > 0)))",
+          "expr": "1000 * topk(20, max by (rule_id, scanner, severity) (max_over_time((timestamp(increase(defenseclaw_scan_findings_by_rule_total{scanner=~\"$scanner\", rule_id=~\"$rule_id\", severity=~\"$severity\", connector=~\"$connector\"}[5m]) > 0))[24h:5m])))",
           "instant": true,
           "format": "table",
           "refId": "A"
@@ -664,7 +664,7 @@
     {
       "type": "table",
       "title": "First-seen per rule_id (24h)",
-      "description": "First-sample-with-increase timestamp per rule_id series in the window. Brand-new rules show their first appearance time.",
+      "description": "Approximate first firing time per rule, evaluated in five-minute windows across the last 24 hours. A rule that did not increase in the window shows no series.",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"
@@ -677,7 +677,7 @@
       },
       "targets": [
         {
-          "expr": "1000 * topk(20, min by (rule_id, scanner, severity) (timestamp(increase(defenseclaw_scan_findings_by_rule_total{scanner=~\"$scanner\", rule_id=~\"$rule_id\", severity=~\"$severity\", connector=~\"$connector\"}[24h]) > 0)))",
+          "expr": "1000 * topk(20, min by (rule_id, scanner, severity) (min_over_time((timestamp(increase(defenseclaw_scan_findings_by_rule_total{scanner=~\"$scanner\", rule_id=~\"$rule_id\", severity=~\"$severity\", connector=~\"$connector\"}[5m]) > 0))[24h:5m])))",
           "instant": true,
           "format": "table",
           "refId": "A"
@@ -774,8 +774,8 @@
     },
     {
       "type": "table",
-      "title": "Finding → verdict correlation (1h)",
-      "description": "When this $rule_id (or any rule with rule_id=All) fires, what verdict_action does the surrounding traffic see in the same 1h window? Coarse correlation — joins on time only, not on scan_id.",
+      "title": "Verdicts in selected connector/severity window",
+      "description": "Guardrail evaluation counts for the selected connector, severity, and dashboard range. This is supporting context rather than a direct rule_id or scan_id join.",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"

--- a/bundles/local_observability_stack/grafana/dashboards/defenseclaw-hitl.json
+++ b/bundles/local_observability_stack/grafana/dashboards/defenseclaw-hitl.json
@@ -154,7 +154,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(defenseclaw_inspect_evaluations_total{action=\"confirm\", tool=~\"$connector:.*\"}[$__range])) or vector(0)",
+          "expr": "sum(increase(defenseclaw_inspect_evaluations_total{action=\"confirm\", tool=~\"$connector:.*\"}[1h])) or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -185,7 +185,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(defenseclaw_connector_hook_outcome_total{connector=~\"$connector\", would_block=\"true\"}[$__range])) or vector(0)",
+          "expr": "sum(increase(defenseclaw_connector_hook_outcome_total{connector=~\"$connector\", would_block=\"true\"}[1h])) or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -214,7 +214,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(defenseclaw_inspect_evaluations_total{action=\"allow\", tool=~\"$connector:.*\"}[$__range])) or vector(0)",
+          "expr": "sum(increase(defenseclaw_inspect_evaluations_total{action=\"allow\", tool=~\"$connector:.*\"}[1h])) or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -252,7 +252,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(defenseclaw_inspect_evaluations_total{action=\"block\", tool=~\"$connector:.*\"}[$__range])) or vector(0)",
+          "expr": "sum(increase(defenseclaw_inspect_evaluations_total{action=\"block\", tool=~\"$connector:.*\"}[1h])) or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -291,7 +291,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(defenseclaw_gateway_errors_total[$__range])) or vector(0)",
+          "expr": "sum(increase(defenseclaw_gateway_errors_total[1h])) or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -329,7 +329,7 @@
     {
       "type": "stat",
       "title": "HILT unsupported (1h)",
-      "description": "hilt_unsupported — the connector accepted the prompt but the operator surface (chat client) cannot render an approval UI. Often indicates a misconfigured connector.\n\ncovered_by:\n  - defenseclaw_connector_hook_invocations → internal/gateway/hook_telemetry.go",
+      "description": "hilt_unsupported — the connector accepted the prompt but the operator surface (chat client) cannot render an approval UI. Often indicates a misconfigured connector.\n\ncovered_by:\n  - defenseclaw_guardrail_evaluations → internal/telemetry/metrics.go (RecordGuardrailEvaluation)",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"
@@ -342,7 +342,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(defenseclaw_connector_hook_invocations_total{connector=~\"$connector\", result=\"rejected\"}[$__range])) or vector(0)",
+          "expr": "sum(increase(defenseclaw_guardrail_evaluations_total{guardrail_connector=~\"$connector\", guardrail_scanner=\"openclaw:hilt\", guardrail_action_taken=\"hilt_unsupported\"}[1h])) or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -447,8 +447,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (severity) (rate(defenseclaw_connector_hook_outcome_total{connector=~\"$connector\", would_block=\"true\"}[$__rate_interval])) or on() vector(0)",
-          "legendFormat": "{{severity}}",
+          "expr": "sum by (guardrail_action_taken) (rate(defenseclaw_guardrail_evaluations_total{guardrail_connector=~\"$connector\", guardrail_scanner=\"openclaw:hilt\", guardrail_action_taken=~\"approval_requested|approval_approved|approval_denied|approval_timeout|hilt_unsupported\"}[$__rate_interval])) or on() vector(0)",
+          "legendFormat": "{{guardrail_action_taken}}",
           "refId": "A"
         }
       ],
@@ -480,7 +480,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (action) (rate(defenseclaw_inspect_evaluations_total{tool=~\"$connector:.*\", action=~\"allow|block|confirm\"}[$__rate_interval]))",
+          "expr": "(sum(rate(defenseclaw_guardrail_evaluations_total{guardrail_connector=~\"$connector\", guardrail_scanner=\"openclaw:hilt\", guardrail_action_taken=\"approval_approved\"}[1h])) or vector(0)) / clamp_min((sum(rate(defenseclaw_guardrail_evaluations_total{guardrail_connector=~\"$connector\", guardrail_scanner=\"openclaw:hilt\", guardrail_action_taken=~\"approval_approved|approval_denied|approval_timeout\"}[1h])) or vector(0)), 0.0001)",
           "legendFormat": "approval rate",
           "refId": "A"
         }
@@ -542,7 +542,7 @@
     },
     {
       "type": "row",
-      "title": "Exec approvals (RecordApproval / WebSocket)",
+      "title": "Exec approvals (global; RecordApproval / WebSocket)",
       "gridPos": {
         "x": 0,
         "y": 26,
@@ -566,7 +566,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(defenseclaw_inspect_evaluations_total{action=\"allow\", tool=~\"$connector:.*\"}[$__range])) or vector(0)",
+          "expr": "sum(increase(defenseclaw_approval_count_total{result=\"approved\"}[1h])) or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -579,7 +579,7 @@
           }
         }
       },
-      "description": "covered_by:\n  - defenseclaw_inspect_evaluations → internal/telemetry/metrics.go (RecordGuardrailEvaluation)"
+      "description": "Global exec approvals resolved as approved in the last hour. This metric has no connector label, so the dashboard connector filter does not apply.\n\ncovered_by:\n  - defenseclaw_approval_count → internal/telemetry/metrics.go (RecordApproval)"
     },
     {
       "type": "stat",
@@ -596,7 +596,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(defenseclaw_inspect_evaluations_total{action=\"block\", tool=~\"$connector:.*\"}[$__range])) or vector(0)",
+          "expr": "sum(increase(defenseclaw_approval_count_total{result=\"denied\"}[1h])) or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -609,12 +609,12 @@
           }
         }
       },
-      "description": "covered_by:\n  - defenseclaw_inspect_evaluations → internal/telemetry/metrics.go (RecordGuardrailEvaluation)"
+      "description": "Global exec approvals denied in the last hour. This metric has no connector label, so the dashboard connector filter does not apply.\n\ncovered_by:\n  - defenseclaw_approval_count → internal/telemetry/metrics.go (RecordApproval)"
     },
     {
       "type": "stat",
       "title": "Exec approvals pending (1h)",
-      "description": "result=pending — request sent to the operator but not yet decided.\n\ncovered_by:\n  - defenseclaw_inspect_evaluations → internal/telemetry/metrics.go (RecordGuardrailEvaluation)",
+      "description": "Global exec approval requests handed to the manual approval path in the last hour. This is an event count, not a live in-flight gauge.\n\ncovered_by:\n  - defenseclaw_approval_count → internal/telemetry/metrics.go (RecordApproval)",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"
@@ -627,7 +627,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(defenseclaw_inspect_evaluations_total{action=\"confirm\", tool=~\"$connector:.*\"}[1h])) or vector(0)",
+          "expr": "sum(increase(defenseclaw_approval_count_total{result=\"pending\"}[1h])) or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -649,7 +649,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(defenseclaw_connector_hook_outcome_total{connector=~\"$connector\", would_block=\"true\", result=\"ok\"}[1h])) / clamp_min(sum(increase(defenseclaw_connector_hook_outcome_total{connector=~\"$connector\"}[1h])), 0.0001) or vector(0)",
+          "expr": "(sum(increase(defenseclaw_approval_count_total{result=\"approved\", auto=\"true\"}[1h])) or vector(0)) / clamp_min((sum(increase(defenseclaw_approval_count_total{result=\"approved\"}[1h])) or vector(0)), 0.0001)",
           "refId": "A",
           "instant": true
         }
@@ -663,7 +663,7 @@
     {
       "type": "stat",
       "title": "Dangerous-command share (1h)",
-      "description": "dangerous=\"true\" share — fraction of approval requests flagged dangerous by the inspector.\n\ncovered_by:\n  - defenseclaw_inspect_evaluations → internal/telemetry/metrics.go (RecordGuardrailEvaluation)",
+      "description": "dangerous=\"true\" share across global exec approval events. This metric has no connector label, so the dashboard connector filter does not apply.\n\ncovered_by:\n  - defenseclaw_approval_count → internal/telemetry/metrics.go (RecordApproval)",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"
@@ -676,7 +676,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(defenseclaw_inspect_evaluations_total{tool=~\"$connector:.*\", severity=~\"HIGH|CRITICAL\"}[1h])) / clamp_min(sum(increase(defenseclaw_inspect_evaluations_total{tool=~\"$connector:.*\"}[1h])), 0.0001) or vector(0)",
+          "expr": "(sum(increase(defenseclaw_approval_count_total{dangerous=\"true\"}[1h])) or vector(0)) / clamp_min((sum(increase(defenseclaw_approval_count_total[1h])) or vector(0)), 0.0001)",
           "refId": "A",
           "instant": true
         }
@@ -706,8 +706,8 @@
     },
     {
       "type": "stat",
-      "title": "Block rate (HIGH+ severity, 1h)",
-      "description": "Among dangerous=\"true\" approvals, what fraction were denied. Should track upward — operators should reject most dangerous commands.\n\ncovered_by:\n  - defenseclaw_inspect_evaluations → internal/telemetry/metrics.go (RecordGuardrailEvaluation)",
+      "title": "Denial rate (dangerous exec, 1h)",
+      "description": "Among global dangerous=\"true\" exec approval events, the fraction denied. This metric has no connector label, so the dashboard connector filter does not apply.\n\ncovered_by:\n  - defenseclaw_approval_count → internal/telemetry/metrics.go (RecordApproval)",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"
@@ -720,7 +720,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(defenseclaw_inspect_evaluations_total{tool=~\"$connector:.*\", severity=~\"HIGH|CRITICAL\", action=\"block\"}[1h])) / clamp_min(sum(increase(defenseclaw_inspect_evaluations_total{tool=~\"$connector:.*\", severity=~\"HIGH|CRITICAL\"}[1h])), 0.0001) or vector(0)",
+          "expr": "(sum(increase(defenseclaw_approval_count_total{dangerous=\"true\", result=\"denied\"}[1h])) or vector(0)) / clamp_min((sum(increase(defenseclaw_approval_count_total{dangerous=\"true\"}[1h])) or vector(0)), 0.0001)",
           "refId": "A",
           "instant": true
         }
@@ -734,7 +734,7 @@
     {
       "type": "timeseries",
       "title": "Exec approval result mix over time",
-      "description": "Stacked counters for result ∈ {approved, denied, pending, timeout}. The pending bar should drain to zero quickly; sustained pending means operators are not responding.\n\ncovered_by:\n  - defenseclaw_inspect_evaluations → internal/telemetry/metrics.go (RecordGuardrailEvaluation)",
+      "description": "Global exec approval event rate by result ∈ {approved, denied, pending, timeout}. Pending is an emitted event, not a live in-flight gauge.\n\ncovered_by:\n  - defenseclaw_approval_count → internal/telemetry/metrics.go (RecordApproval)",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"
@@ -747,8 +747,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (action) (rate(defenseclaw_inspect_evaluations_total{tool=~\"$connector:.*\", action=~\"allow|block|confirm\"}[$__rate_interval])) or on() vector(0)",
-          "legendFormat": "{{action}}",
+          "expr": "sum by (result) (rate(defenseclaw_approval_count_total[$__rate_interval])) or on() vector(0)",
+          "legendFormat": "{{result}}",
           "refId": "A"
         }
       ],
@@ -766,8 +766,8 @@
     },
     {
       "type": "timeseries",
-      "title": "Shadow block vs allow outcomes",
-      "description": "auto=true (policy automatic) vs auto=false (operator). Big surges in auto without dangerous commands usually mean the policy is too permissive.\n\ncovered_by:\n  - defenseclaw_approval_count → internal/telemetry/metrics.go:1146 (RecordApproval) — code-emitted, will populate once exec approvals run",
+      "title": "Exec approvals by automatic vs manual",
+      "description": "Global exec approval event rate split by auto=true (policy automatic) and auto=false (manual or denied).\n\ncovered_by:\n  - defenseclaw_approval_count → internal/telemetry/metrics.go (RecordApproval)",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"
@@ -780,8 +780,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (would_block) (rate(defenseclaw_connector_hook_outcome_total{connector=~\"$connector\"}[$__rate_interval])) or on() vector(0)",
-          "legendFormat": "would_block={{would_block}}",
+          "expr": "sum by (auto) (rate(defenseclaw_approval_count_total[$__rate_interval])) or on() vector(0)",
+          "legendFormat": "auto={{auto}}",
           "refId": "A"
         }
       ],
@@ -795,79 +795,6 @@
             "fillOpacity": 25
           }
         }
-      }
-    },
-    {
-      "type": "row",
-      "title": "Recent HITL events (Loki)",
-      "gridPos": {
-        "x": 0,
-        "y": 39,
-        "w": 24,
-        "h": 1
-      },
-      "collapsed": false
-    },
-    {
-      "type": "logs",
-      "title": "Recent chat HILT lifecycle (approval_requested / _approved / _denied / _timeout / hilt_unsupported)",
-      "datasource": {
-        "type": "loki",
-        "uid": "defenseclaw-loki"
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 40,
-        "w": 24,
-        "h": 10
-      },
-      "timeFrom": "1h",
-      "targets": [
-        {
-          "expr": "{service_name=\"defenseclaw\"} | gen_ai_agent_name=~\"$connector\" | defenseclaw_gateway_event_type=\"tool_invocation\"",
-          "refId": "A",
-          "datasource": {
-            "type": "loki",
-            "uid": "defenseclaw-loki"
-          }
-        }
-      ],
-      "options": {
-        "showTime": true,
-        "wrapLogMessage": true,
-        "dedupStrategy": "none",
-        "enableLogDetails": true
-      }
-    },
-    {
-      "type": "logs",
-      "title": "Recent exec approval lifecycle (gateway-approval-*)",
-      "datasource": {
-        "type": "loki",
-        "uid": "defenseclaw-loki"
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 50,
-        "w": 24,
-        "h": 10
-      },
-      "timeFrom": "1h",
-      "targets": [
-        {
-          "expr": "{service_name=\"defenseclaw\"} | defenseclaw_gateway_event_type=\"tool_invocation\" | defenseclaw_tool_name=~\"Bash|.*[sS]hell.*|.*[eE]xec.*\"",
-          "refId": "A",
-          "datasource": {
-            "type": "loki",
-            "uid": "defenseclaw-loki"
-          }
-        }
-      ],
-      "options": {
-        "showTime": true,
-        "wrapLogMessage": true,
-        "dedupStrategy": "none",
-        "enableLogDetails": true
       }
     }
   ],

--- a/bundles/local_observability_stack/grafana/dashboards/defenseclaw-hitl.json
+++ b/bundles/local_observability_stack/grafana/dashboards/defenseclaw-hitl.json
@@ -467,7 +467,7 @@
     {
       "type": "timeseries",
       "title": "Chat HILT approval-vs-denial rate (1h rolling)",
-      "description": "approved / (approved + denied + timeout). Slow drift toward 0 means operators are denying more often — investigate via the verdict-categories panel on Security.\n\ncovered_by:\n  - defenseclaw_inspect_evaluations → internal/telemetry/metrics.go (RecordGuardrailEvaluation)",
+      "description": "approved / (approved + denied + timeout). Slow drift toward 0 means operators are denying more often — investigate via the verdict-categories panel on Security.\n\ncovered_by:\n  - defenseclaw_guardrail_evaluations → internal/telemetry/metrics.go (RecordGuardrailEvaluation)",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"

--- a/bundles/local_observability_stack/grafana/dashboards/defenseclaw-overview.json
+++ b/bundles/local_observability_stack/grafana/dashboards/defenseclaw-overview.json
@@ -716,7 +716,7 @@
       },
       "targets": [
         {
-          "expr": "count((sum by (connector) (rate(defenseclaw_connector_hook_invocations_total[5m])) > 0) or label_replace((sum by (source) (rate(defenseclaw_otel_ingest_records_total[5m])) > 0), \"connector\", \"$1\", \"source\", \"(.+)\")) or vector(0)",
+          "expr": "count((sum by (connector) (rate(defenseclaw_connector_hook_invocations_total[5m])) > 0) or sum by (connector) (label_replace((sum by (source) (rate(defenseclaw_otel_ingest_records_total[5m])) > 0), \"connector\", \"$1\", \"source\", \"(.+)\"))) or vector(0)",
           "refId": "A"
         }
       ],

--- a/bundles/local_observability_stack/grafana/dashboards/defenseclaw-overview.json
+++ b/bundles/local_observability_stack/grafana/dashboards/defenseclaw-overview.json
@@ -671,7 +671,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(defenseclaw_connector_hook_latency_milliseconds_bucket{le=\"2500.0\"}[5m])) / sum(rate(defenseclaw_connector_hook_latency_milliseconds_bucket{le=\"+Inf\"}[5m])) or vector(0)",
+          "expr": "sum(rate(defenseclaw_connector_hook_latency_milliseconds_bucket{le=\"2500\"}[5m])) / clamp_min(sum(rate(defenseclaw_connector_hook_latency_milliseconds_bucket{le=\"+Inf\"}[5m])), 0.0001) or vector(0)",
           "refId": "A"
         }
       ],
@@ -716,7 +716,7 @@
       },
       "targets": [
         {
-          "expr": "count(group by (connector) (rate(defenseclaw_connector_hook_invocations_total[5m]) > 0)) or count(group by (source) (rate(defenseclaw_otel_ingest_records_total[5m]) > 0)) or vector(0)",
+          "expr": "count((sum by (connector) (rate(defenseclaw_connector_hook_invocations_total[5m])) > 0) or label_replace((sum by (source) (rate(defenseclaw_otel_ingest_records_total[5m])) > 0), \"connector\", \"$1\", \"source\", \"(.+)\")) or vector(0)",
           "refId": "A"
         }
       ],
@@ -1032,7 +1032,7 @@
       },
       "targets": [
         {
-          "expr": "{service_name=\"defenseclaw\"} | defenseclaw_gateway_event_type=~\"tool_invocation|llm_prompt|scan_finding|error\"",
+          "expr": "{service_name=\"defenseclaw\"} | defenseclaw_gateway_event_type!=\"\"",
           "refId": "A",
           "datasource": {
             "type": "loki",
@@ -1132,7 +1132,7 @@
       },
       "targets": [
         {
-          "expr": "{service_name=\"defenseclaw\"} | defenseclaw_gateway_event_type=~\"tool_invocation|llm_prompt|scan_finding|error\"",
+          "expr": "{service_name=\"defenseclaw\"} | defenseclaw_gateway_event_type=~\"tool_invocation|llm_prompt|llm_response\"",
           "refId": "A",
           "datasource": {
             "type": "loki",

--- a/bundles/local_observability_stack/grafana/dashboards/defenseclaw-policy-decisions.json
+++ b/bundles/local_observability_stack/grafana/dashboards/defenseclaw-policy-decisions.json
@@ -712,8 +712,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (error_subsystem, error_code) (rate(defenseclaw_gateway_errors_total[$__rate_interval])) or on() vector(0)",
-          "legendFormat": "{{error_subsystem}} · {{error_code}}",
+          "expr": "sum by (event_type, code) (rate(defenseclaw_schema_violations_total[$__rate_interval])) or on() vector(0)",
+          "legendFormat": "{{event_type}} · {{code}}",
           "refId": "A"
         }
       ],

--- a/bundles/local_observability_stack/grafana/dashboards/defenseclaw-security.json
+++ b/bundles/local_observability_stack/grafana/dashboards/defenseclaw-security.json
@@ -382,7 +382,7 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(defenseclaw_connector_hook_latency_milliseconds_bucket{connector=~\"$connector\"}[5m])) by (le)) or vector(0)",
+          "expr": "histogram_quantile(0.95, sum(rate(defenseclaw_inspect_latency_milliseconds_bucket{connector=~\"$connector\"}[5m])) by (le)) or vector(0)",
           "refId": "A",
           "instant": true
         }
@@ -617,8 +617,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (event_type, severity) (rate(defenseclaw_connector_hook_outcome_total{connector=~\"$connector\", severity!=\"NONE\"}[$__rate_interval]))",
-          "legendFormat": "{{tool}} -> {{action}}",
+          "expr": "sum by (tool, action, severity) (rate(defenseclaw_inspect_evaluations_total{tool=~\"$connector:.*\", action!~\"allow|none\", severity=~\"$severity\"}[$__rate_interval])) or on() vector(0)",
+          "legendFormat": "{{tool}} -> {{action}} [{{severity}}]",
           "refId": "A"
         }
       ],
@@ -691,17 +691,17 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum by (le, tool) (rate(defenseclaw_connector_hook_latency_milliseconds_bucket{connector=~\"$connector\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (le, tool) (rate(defenseclaw_inspect_latency_milliseconds_bucket{connector=~\"$connector\"}[$__rate_interval])))",
           "legendFormat": "{{tool}} p50",
           "refId": "p50"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le, tool) (rate(defenseclaw_connector_hook_latency_milliseconds_bucket{connector=~\"$connector\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, tool) (rate(defenseclaw_inspect_latency_milliseconds_bucket{connector=~\"$connector\"}[$__rate_interval])))",
           "legendFormat": "{{tool}} p95",
           "refId": "p95"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le, tool) (rate(defenseclaw_connector_hook_latency_milliseconds_bucket{connector=~\"$connector\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le, tool) (rate(defenseclaw_inspect_latency_milliseconds_bucket{connector=~\"$connector\"}[$__rate_interval])))",
           "legendFormat": "{{tool}} p99",
           "refId": "p99"
         }
@@ -726,7 +726,7 @@
     {
       "type": "timeseries",
       "title": "Evaluations / sec by connector",
-      "description": "Guardrail evaluations split by connector. The inspect metric only carries the hook-event label `tool` (shaped `<connector>:<event>`, e.g. claudecode:PreToolUse), so the connector dimension is derived with label_replace to strip the `:<event>` suffix and re-aggregate. Filtered by $connector.",
+      "description": "Guardrail evaluations split by the canonical connector label and filtered by $connector.",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"
@@ -739,7 +739,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (connector) (rate(defenseclaw_connector_hook_outcome_total{connector=~\"$connector\"}[$__rate_interval]))",
+          "expr": "sum by (connector) (rate(defenseclaw_inspect_evaluations_total{connector=~\"$connector\"}[$__rate_interval]))",
           "legendFormat": "{{connector}}",
           "refId": "A"
         }
@@ -759,7 +759,7 @@
     {
       "type": "table",
       "title": "Per-connector verdict summary (1h)",
-      "description": "Snapshot: total verdicts, blocks, would-blocks, alerts, and confirm per connector in the last hour. The inspect metric only carries the hook-event label `tool` (shaped `<connector>:<event>`), so the connector is derived with label_replace and re-aggregated so each row is a real connector, not a hook event. would-block/1h counts observe-mode shadow blocks (would_block=true on defenseclaw_connector_hook_outcome_total) — the rules that would have blocked had the connector been enforcing. Filtered by $connector.",
+      "description": "Snapshot: total verdicts, blocks, would-blocks, alerts, and confirms per connector in the last hour. would-block/1h counts observe-mode shadow blocks (would_block=true on defenseclaw_connector_hook_outcome_total). Filtered by $connector.",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"
@@ -775,13 +775,13 @@
           "refId": "TOTAL",
           "instant": true,
           "format": "table",
-          "expr": "sum by (connector) (label_replace(increase(defenseclaw_inspect_evaluations_total{tool=~\"$connector:.*\"}[1h]), \"connector\", \"$1\", \"tool\", \"([^:]+):.*\"))"
+          "expr": "sum by (connector) (increase(defenseclaw_inspect_evaluations_total{connector=~\"$connector\"}[1h]))"
         },
         {
           "refId": "BLOCKS",
           "instant": true,
           "format": "table",
-          "expr": "sum by (connector) (label_replace(increase(defenseclaw_inspect_evaluations_total{action=\"block\", tool=~\"$connector:.*\"}[1h]), \"connector\", \"$1\", \"tool\", \"([^:]+):.*\"))"
+          "expr": "sum by (connector) (increase(defenseclaw_inspect_evaluations_total{action=\"block\", connector=~\"$connector\"}[1h]))"
         },
         {
           "refId": "WOULDBLOCK",
@@ -793,13 +793,13 @@
           "refId": "ALERTS",
           "instant": true,
           "format": "table",
-          "expr": "sum by (connector) (label_replace(increase(defenseclaw_inspect_evaluations_total{action=\"alert\", tool=~\"$connector:.*\"}[1h]), \"connector\", \"$1\", \"tool\", \"([^:]+):.*\"))"
+          "expr": "sum by (connector) (increase(defenseclaw_inspect_evaluations_total{action=\"alert\", connector=~\"$connector\"}[1h]))"
         },
         {
           "refId": "CONFIRM",
           "instant": true,
           "format": "table",
-          "expr": "sum by (connector) (label_replace(increase(defenseclaw_inspect_evaluations_total{action=\"confirm\", tool=~\"$connector:.*\"}[1h]), \"connector\", \"$1\", \"tool\", \"([^:]+):.*\"))"
+          "expr": "sum by (connector) (increase(defenseclaw_inspect_evaluations_total{action=\"confirm\", connector=~\"$connector\"}[1h]))"
         }
       ],
       "transformations": [

--- a/bundles/local_observability_stack/grafana/dashboards/defenseclaw-security.json
+++ b/bundles/local_observability_stack/grafana/dashboards/defenseclaw-security.json
@@ -604,7 +604,7 @@
     {
       "type": "timeseries",
       "title": "Non-allow evaluations by hook event",
-      "description": "Evaluations that resulted in alert/block/confirm, broken by which hook event triggered them.",
+      "description": "Evaluations that resulted in warn/alert/block/confirm, broken by which hook event triggered them.",
       "datasource": {
         "type": "prometheus",
         "uid": "defenseclaw-prometheus"

--- a/bundles/local_observability_stack/grafana/provisioning/datasources/datasources.yml
+++ b/bundles/local_observability_stack/grafana/provisioning/datasources/datasources.yml
@@ -9,7 +9,11 @@ datasources:
     isDefault: true
     jsonData:
       httpMethod: POST
-      timeInterval: 15s
+      # DefenseClaw's default OTel metric push interval is 60s. Grafana uses
+      # this value to calculate $__rate_interval; advertising Prometheus'
+      # internal 15s scrape interval produced 1m rate windows with only one
+      # application sample, so otherwise healthy panels rendered "No data".
+      timeInterval: 60s
       exemplarTraceIdDestinations:
         - name: trace_id
           datasourceUid: defenseclaw-tempo

--- a/cli/tests/test_grafana_dashboards.py
+++ b/cli/tests/test_grafana_dashboards.py
@@ -12,6 +12,7 @@ from types import ModuleType
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
+DASHBOARD_DIR = ROOT / "bundles/local_observability_stack/grafana/dashboards"
 
 
 def _load_audit_module() -> ModuleType:
@@ -21,6 +22,14 @@ def _load_audit_module() -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _dashboard(name: str) -> dict:
+    return json.loads((DASHBOARD_DIR / name).read_text(encoding="utf-8"))
+
+
+def _panel(dashboard: dict, title: str) -> dict:
+    return next(panel for panel in dashboard["panels"] if panel.get("title") == title)
 
 
 def test_grafana_dashboard_catalog_contract() -> None:
@@ -346,3 +355,248 @@ def test_tempo_target_query_rejects_invalid_raw_queries(query: object) -> None:
 
     with pytest.raises(audit.AuditError):
         audit.tempo_target_query({"query": query})
+
+
+def test_prometheus_rate_interval_matches_default_otel_push_cadence() -> None:
+    audit = _load_audit_module()
+
+    assert (
+        audit.prometheus_time_interval_seconds(audit.SOURCE_DATASOURCES)
+        >= audit.DEFAULT_METRIC_EXPORT_INTERVAL_SECONDS
+    )
+
+
+def test_static_audit_rejects_short_rate_windows_and_mislabelled_series(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    audit = _load_audit_module()
+    dashboard_dir = tmp_path / "dashboards"
+    dashboard_dir.mkdir()
+    dashboard = {
+        "uid": "rate-contract-fixture",
+        "title": "Rate contract fixture",
+        "description": "Exercises cadence, legend, and percentile validation.",
+        "panels": [
+            {
+                "type": "timeseries",
+                "title": "Wrong legend",
+                "datasource": {"type": "prometheus", "uid": "defenseclaw-prometheus"},
+                "targets": [
+                    {
+                        "expr": "sum by (action) (rate(example_total[5m]))",
+                        "legendFormat": "{{severity}}",
+                        "refId": "A",
+                    },
+                ],
+            },
+            {
+                "type": "timeseries",
+                "title": "Wrong percentile",
+                "datasource": {"type": "prometheus", "uid": "defenseclaw-prometheus"},
+                "targets": [
+                    {
+                        "expr": (
+                            "histogram_quantile(0.95, "
+                            "sum by (le) (rate(example_bucket[5m])))"
+                        ),
+                        "legendFormat": "p50",
+                        "refId": "p50",
+                    },
+                ],
+            },
+            {
+                "type": "timeseries",
+                "title": "Unknown metric label",
+                "datasource": {"type": "prometheus", "uid": "defenseclaw-prometheus"},
+                "targets": [
+                    {
+                        "expr": (
+                            "rate(defenseclaw_connector_hook_outcome_total"
+                            '{connector="codex", result="ok"}[5m])'
+                        ),
+                        "refId": "A",
+                    },
+                ],
+            },
+            {
+                "type": "timeseries",
+                "title": "Unknown histogram bucket",
+                "datasource": {"type": "prometheus", "uid": "defenseclaw-prometheus"},
+                "targets": [
+                    {
+                        "expr": (
+                            "rate(defenseclaw_connector_hook_latency_milliseconds_bucket"
+                            '{le="2500.0"}[5m])'
+                        ),
+                        "refId": "A",
+                    },
+                ],
+            },
+        ],
+    }
+    (dashboard_dir / "fixture.json").write_text(json.dumps(dashboard), encoding="utf-8")
+    datasource = tmp_path / "datasources.yml"
+    datasource.write_text("jsonData:\n  timeInterval: 15s\n", encoding="utf-8")
+
+    monkeypatch.setattr(audit, "SOURCE_DIR", dashboard_dir)
+    monkeypatch.setattr(audit, "PACKAGED_DIR", tmp_path / "missing-dashboards")
+    monkeypatch.setattr(audit, "SOURCE_DATASOURCES", datasource)
+    monkeypatch.setattr(audit, "PACKAGED_DATASOURCES", tmp_path / "missing-datasources.yml")
+
+    _dashboards, errors = audit.static_audit()
+
+    assert any("must be at least the default 60s" in error for error in errors)
+    assert any("legend references labels absent from the query: severity" in error for error in errors)
+    assert any("is labelled [50] but queries p95" in error for error in errors)
+    assert any("filters on unknown labels: result" in error for error in errors)
+    assert any("uses unknown exact le value '2500.0'" in error for error in errors)
+
+
+def test_connector_dashboard_queries_the_metric_named_by_each_panel() -> None:
+    dashboard = _dashboard("defenseclaw-connectors.json")
+    expected_fragments = {
+        "Records / sec by source x signal": (
+            "defenseclaw_otel_ingest_records_total",
+            "sum by (source, signal)",
+        ),
+        "Bytes / sec by source x signal": (
+            "defenseclaw_otel_ingest_bytes_total",
+            "sum by (source, signal)",
+        ),
+        "Tokens / sec by connector x direction": (
+            "gen_ai_client_token_usage_sum",
+            "sum by (gen_ai_agent_name, gen_ai_token_type)",
+        ),
+        "LLM operation duration p95 by connector": (
+            "gen_ai_client_operation_duration_seconds_bucket",
+            "sum by (le, gen_ai_agent_name)",
+        ),
+        "Evaluations / sec by hook event": (
+            "defenseclaw_inspect_evaluations_total",
+            "sum by (tool)",
+        ),
+        "Codex notify by type + status (5m)": ("defenseclaw_codex_notify_total",),
+        "Quietest connectors (silence sec)": (
+            "defenseclaw_otel_ingest_last_seen_ts_seconds",
+        ),
+        "Hook latency p95 by event type": (
+            "defenseclaw_connector_hook_latency_milliseconds_bucket",
+            "sum by (le, event_type)",
+        ),
+    }
+    for title, fragments in expected_fragments.items():
+        expression = _panel(dashboard, title)["targets"][0]["expr"]
+        assert all(fragment in expression for fragment in fragments), title
+
+
+def test_identity_dashboard_queries_identity_and_discovery_instruments() -> None:
+    dashboard = _dashboard("defenseclaw-agent-identity.json")
+    expected_metrics = {
+        "Discovery runs / hour": "defenseclaw_agent_discovery_runs_total",
+        "Components observed": "defenseclaw_ai_components_installs",
+        "OTLP records by connector (source)": "defenseclaw_otel_ingest_records_total",
+        "Per-connector install state (latest)": "defenseclaw_agent_discovery_installed_ratio",
+        "Identity confidence distribution": "defenseclaw_ai_confidence_identity_score_bucket",
+        "Presence confidence distribution": "defenseclaw_ai_confidence_presence_score_bucket",
+    }
+    for title, metric in expected_metrics.items():
+        expression = _panel(dashboard, title)["targets"][0]["expr"]
+        assert metric in expression, title
+
+    duration_targets = _panel(dashboard, "Discovery duration p50/p95")["targets"]
+    assert "histogram_quantile(0.50" in duration_targets[0]["expr"]
+    assert "histogram_quantile(0.95" in duration_targets[1]["expr"]
+    assert all(
+        "defenseclaw_agent_discovery_duration_milliseconds_bucket" in target["expr"]
+        for target in duration_targets
+    )
+
+    distinct_ids = _panel(dashboard, "Distinct agent.id observed (Loki, by gen_ai.agent.name)")
+    header_rate = _panel(
+        dashboard,
+        "Header-presence rate (Loki) — events with gen_ai.agent.id set",
+    )
+    assert "gen_ai_agent_id" in distinct_ids["targets"][0]["expr"]
+    assert "gen_ai_agent_id" in header_rate["targets"][0]["expr"]
+
+
+def test_security_dashboard_uses_inspection_metrics_for_inspection_panels() -> None:
+    dashboard = _dashboard("defenseclaw-security.json")
+    for title in (
+        "Inspect latency p95 (5m)",
+        "Inspect latency p50/p95/p99 by hook event",
+    ):
+        assert all(
+            "defenseclaw_inspect_latency_milliseconds_bucket" in target["expr"]
+            for target in _panel(dashboard, title)["targets"]
+        )
+
+    for title in (
+        "Non-allow evaluations by hook event",
+        "Evaluations / sec by connector",
+    ):
+        assert "defenseclaw_inspect_evaluations_total" in _panel(dashboard, title)["targets"][0][
+            "expr"
+        ]
+
+
+def test_hitl_dashboard_uses_dedicated_chat_and_exec_approval_metrics() -> None:
+    dashboard = _dashboard("defenseclaw-hitl.json")
+
+    chat_status = _panel(dashboard, "Chat HILT status mix over time")["targets"][0]["expr"]
+    chat_ratio = _panel(dashboard, "Chat HILT approval-vs-denial rate (1h rolling)")[
+        "targets"
+    ][0]["expr"]
+    assert "defenseclaw_guardrail_evaluations_total" in chat_status
+    assert "guardrail_scanner=\"openclaw:hilt\"" in chat_status
+    assert "guardrail_action_taken" in chat_status
+    assert "defenseclaw_guardrail_evaluations_total" in chat_ratio
+
+    for title in (
+        "Exec approvals approved (1h)",
+        "Exec approvals denied (1h)",
+        "Exec approvals pending (1h)",
+        "Auto-approval ratio (1h)",
+        "Dangerous-command share (1h)",
+        "Denial rate (dangerous exec, 1h)",
+        "Exec approval result mix over time",
+        "Exec approvals by automatic vs manual",
+    ):
+        expressions = [target["expr"] for target in _panel(dashboard, title)["targets"]]
+        assert all("defenseclaw_approval_count_total" in expression for expression in expressions)
+
+
+def test_cross_dashboard_semantic_regressions() -> None:
+    overview = _dashboard("defenseclaw-overview.json")
+    slo = _panel(overview, "Hook latency SLO < 2.5s (5m)")["targets"][0]["expr"]
+    assert 'le="2500"' in slo
+    assert 'le="2500.0"' not in slo
+    llm_stream = _panel(overview, "LLM prompt/response/tool event stream")["targets"][0]["expr"]
+    assert "llm_response" in llm_stream
+    assert "scan_finding" not in llm_stream
+
+    detail = _dashboard("defenseclaw-connector-detail.json")
+    would_block = _panel(detail, "Would-block / min (observe shadow blocks)")["targets"][0][
+        "expr"
+    ]
+    assert 'would_block="true"' in would_block
+    assert "* 60" in would_block
+    assert _panel(detail, "OTLP silence (s)")["targets"][0]["expr"] == (
+        'time() - max(defenseclaw_otel_ingest_last_seen_ts_seconds{source="$connector"})'
+    )
+
+    policy = _dashboard("defenseclaw-policy-decisions.json")
+    schema_violations = _panel(policy, "Schema violations by event_type × code")["targets"][0]
+    assert "defenseclaw_schema_violations_total" in schema_violations["expr"]
+    assert schema_violations["legendFormat"] == "{{event_type}} · {{code}}"
+
+    findings = _dashboard("defenseclaw-findings.json")
+    assert "max_over_time((timestamp(increase(" in _panel(
+        findings,
+        "Last-seen per rule_id (24h)",
+    )["targets"][0]["expr"]
+    assert "min_over_time((timestamp(increase(" in _panel(
+        findings,
+        "First-seen per rule_id (24h)",
+    )["targets"][0]["expr"]

--- a/cli/tests/test_grafana_dashboards.py
+++ b/cli/tests/test_grafana_dashboards.py
@@ -384,7 +384,7 @@ def test_static_audit_rejects_short_rate_windows_and_mislabelled_series(
                 "datasource": {"type": "prometheus", "uid": "defenseclaw-prometheus"},
                 "targets": [
                     {
-                        "expr": "sum by (action) (rate(example_total[5m]))",
+                        "expr": "sum by (action) (rate(example_total{severity=\"HIGH\"}[5m]))",
                         "legendFormat": "{{severity}}",
                         "refId": "A",
                     },
@@ -474,7 +474,8 @@ def test_connector_dashboard_queries_the_metric_named_by_each_panel() -> None:
         ),
         "Evaluations / sec by hook event": (
             "defenseclaw_inspect_evaluations_total",
-            "sum by (tool)",
+            "sum by (hook_event)",
+            "label_replace",
         ),
         "Codex notify by type + status (5m)": ("defenseclaw_codex_notify_total",),
         "Quietest connectors (silence sec)": (
@@ -493,7 +494,7 @@ def test_connector_dashboard_queries_the_metric_named_by_each_panel() -> None:
 def test_identity_dashboard_queries_identity_and_discovery_instruments() -> None:
     dashboard = _dashboard("defenseclaw-agent-identity.json")
     expected_metrics = {
-        "Discovery runs / hour": "defenseclaw_agent_discovery_runs_total",
+        "Discovery runs (range)": "defenseclaw_agent_discovery_runs_total",
         "Components observed": "defenseclaw_ai_components_installs",
         "OTLP records by connector (source)": "defenseclaw_otel_ingest_records_total",
         "Per-connector install state (latest)": "defenseclaw_agent_discovery_installed_ratio",
@@ -575,6 +576,12 @@ def test_cross_dashboard_semantic_regressions() -> None:
     llm_stream = _panel(overview, "LLM prompt/response/tool event stream")["targets"][0]["expr"]
     assert "llm_response" in llm_stream
     assert "scan_finding" not in llm_stream
+    overview_active = _panel(overview, "Active connectors (5m)")["targets"][0]["expr"]
+    assert "sum by (connector) (label_replace" in overview_active
+
+    connectors = _dashboard("defenseclaw-connectors.json")
+    connector_active = _panel(connectors, "Active connectors (5m)")["targets"][0]["expr"]
+    assert "sum by (connector) (label_replace" in connector_active
 
     detail = _dashboard("defenseclaw-connector-detail.json")
     would_block = _panel(detail, "Would-block / min (observe shadow blocks)")["targets"][0][
@@ -600,3 +607,7 @@ def test_cross_dashboard_semantic_regressions() -> None:
         findings,
         "First-seen per rule_id (24h)",
     )["targets"][0]["expr"]
+    verdict_panel = _panel(findings, "Verdicts in selected connector/severity window")
+    assert verdict_panel["transformations"][0]["options"]["renameByName"]["Value"] == (
+        "verdicts/range"
+    )

--- a/scripts/check_grafana_dashboards.py
+++ b/scripts/check_grafana_dashboards.py
@@ -25,6 +25,64 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE_DIR = ROOT / "bundles/local_observability_stack/grafana/dashboards"
 PACKAGED_DIR = ROOT / "cli/defenseclaw/_data/local_observability_stack/grafana/dashboards"
+SOURCE_DATASOURCES = (
+    ROOT / "bundles/local_observability_stack/grafana/provisioning/datasources/datasources.yml"
+)
+PACKAGED_DATASOURCES = (
+    ROOT
+    / "cli/defenseclaw/_data/local_observability_stack/grafana/provisioning/datasources/datasources.yml"
+)
+DEFAULT_METRIC_EXPORT_INTERVAL_SECONDS = 60
+
+# Prometheus label contracts for the security-sensitive metrics most likely to
+# produce plausible-looking zeroes when a dashboard filters on a nonexistent
+# label. Resource labels are shared across all application metrics and remain
+# legal selectors in addition to the instrument-specific labels below.
+COMMON_PROMETHEUS_RESOURCE_LABELS = {
+    "deployment_environment",
+    "host_arch",
+    "host_name",
+    "job",
+    "os_type",
+    "otel_scope_name",
+    "service_name",
+    "service_namespace",
+    "service_version",
+}
+PROMETHEUS_METRIC_LABELS = {
+    "defenseclaw_approval_count_total": {"result", "auto", "dangerous"},
+    "defenseclaw_connector_hook_outcome_total": {
+        "action",
+        "connector",
+        "event_type",
+        "severity",
+        "would_block",
+    },
+    "defenseclaw_guardrail_evaluations_total": {
+        "guardrail_action_taken",
+        "guardrail_connector",
+        "guardrail_scanner",
+    },
+    "defenseclaw_schema_violations_total": {"code", "event_type"},
+}
+PROMETHEUS_EXACT_LABEL_VALUES = {
+    ("defenseclaw_connector_hook_latency_milliseconds_bucket", "le"): {
+        "1",
+        "2",
+        "5",
+        "10",
+        "25",
+        "50",
+        "100",
+        "250",
+        "500",
+        "1000",
+        "2500",
+        "5000",
+        "10000",
+        "+Inf",
+    },
+}
 
 DATASOURCES = {
     "prometheus": "defenseclaw-prometheus",
@@ -79,6 +137,21 @@ def load_dashboards(path: Path) -> list[tuple[Path, dict[str, Any]]]:
     for dashboard_path in sorted(path.glob("*.json")):
         dashboards.append((dashboard_path, json.loads(dashboard_path.read_text(encoding="utf-8"))))
     return dashboards
+
+
+def prometheus_time_interval_seconds(path: Path) -> float:
+    """Read Grafana's advertised Prometheus sample interval without a YAML dependency."""
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise AuditError(f"cannot read Grafana datasource config {path}: {exc}") from exc
+    match = re.search(r"^\s*timeInterval:\s*([0-9]+(?:\.[0-9]+)?)(ms|s|m|h)\s*$", text, re.MULTILINE)
+    if match is None:
+        raise AuditError(f"{path}: Prometheus jsonData.timeInterval is required")
+    value = float(match.group(1))
+    multiplier = {"ms": 0.001, "s": 1.0, "m": 60.0, "h": 3600.0}[match.group(2)]
+    return value * multiplier
 
 
 def panels(dashboard: dict[str, Any]) -> Iterable[dict[str, Any]]:
@@ -174,6 +247,17 @@ def static_audit(
     if not dashboards:
         return dashboards, [f"no dashboards found under {SOURCE_DIR}"]
 
+    try:
+        datasource_interval = prometheus_time_interval_seconds(SOURCE_DATASOURCES)
+        if datasource_interval < DEFAULT_METRIC_EXPORT_INTERVAL_SECONDS:
+            errors.append(
+                "Grafana Prometheus timeInterval must be at least the default "
+                f"{DEFAULT_METRIC_EXPORT_INTERVAL_SECONDS}s OTel metric export interval; "
+                f"got {datasource_interval:g}s",
+            )
+    except AuditError as exc:
+        errors.append(str(exc))
+
     for path, dashboard in dashboards:
         if not dashboard.get("uid"):
             errors.append(f"{path.name}: dashboard UID is required")
@@ -247,6 +331,72 @@ def static_audit(
                     errors.append(f"{uid}/{title}: {datasource} must use {DATASOURCES[datasource]!r}")
 
                 expression = target.get("expr", "")
+                legend = target.get("legendFormat", "")
+                if datasource == "prometheus" and expression:
+                    for metric_name, selector in re.findall(
+                        r"\b([A-Za-z_:][A-Za-z0-9_:]*)\s*\{([^{}]*)\}",
+                        expression,
+                    ):
+                        selector_pairs = re.findall(
+                            r"([A-Za-z_][A-Za-z0-9_]*)\s*(=~|!~|=|!=)\s*\"([^\"]*)\"",
+                            selector,
+                        )
+                        if metric_name in PROMETHEUS_METRIC_LABELS:
+                            allowed_labels = (
+                                PROMETHEUS_METRIC_LABELS[metric_name]
+                                | COMMON_PROMETHEUS_RESOURCE_LABELS
+                            )
+                            unknown_labels = {
+                                label for label, _operator, _value in selector_pairs
+                            } - allowed_labels
+                            if unknown_labels:
+                                errors.append(
+                                    f"{uid}/{title}: {metric_name} filters on unknown labels: "
+                                    f"{', '.join(sorted(unknown_labels))}",
+                                )
+                        for label, operator, value in selector_pairs:
+                            allowed_values = PROMETHEUS_EXACT_LABEL_VALUES.get(
+                                (metric_name, label),
+                            )
+                            if allowed_values is None or operator != "=":
+                                continue
+                            if value not in allowed_values:
+                                errors.append(
+                                    f"{uid}/{title}: {metric_name} uses unknown exact "
+                                    f"{label} value {value!r}",
+                                )
+                if datasource == "prometheus" and expression and legend:
+                    legend_labels = set(
+                        re.findall(r"{{\s*([A-Za-z_][A-Za-z0-9_]*)\s*}}", legend),
+                    )
+                    grouped_labels: set[str] = set()
+                    for group in re.findall(r"\b(?:by|without)\s*\(([^)]*)\)", expression):
+                        grouped_labels.update(label.strip() for label in group.split(","))
+                    selector_labels = set(
+                        re.findall(r"([A-Za-z_][A-Za-z0-9_]*)\s*(?:=~|!~|=|!=)", expression),
+                    )
+                    missing_legend_labels = legend_labels - grouped_labels - selector_labels
+                    if missing_legend_labels:
+                        errors.append(
+                            f"{uid}/{title}: legend references labels absent from the query: "
+                            f"{', '.join(sorted(missing_legend_labels))}",
+                        )
+
+                quantile = re.search(r"histogram_quantile\(\s*(0(?:\.\d+)?|1(?:\.0+)?)", expression)
+                percentile_labels = {
+                    int(value)
+                    for value in re.findall(
+                        r"\bp(\d{1,3})\b",
+                        f"{target.get('refId', '')} {legend}".lower(),
+                    )
+                }
+                if quantile and percentile_labels:
+                    actual_percentile = round(float(quantile.group(1)) * 100)
+                    if percentile_labels != {actual_percentile}:
+                        errors.append(
+                            f"{uid}/{title}: target {target.get('refId', '?')} is labelled "
+                            f"{sorted(percentile_labels)} but queries p{actual_percentile}",
+                        )
                 if datasource == "tempo":
                     try:
                         tempo_target_query(target)
@@ -292,6 +442,12 @@ def static_audit(
         packaged_by_name = {path.name: dashboard for path, dashboard in packaged}
         if source_by_name != packaged_by_name:
             errors.append("CLI packaged Grafana dashboards do not match bundle sources")
+
+    if require_packaged and not PACKAGED_DATASOURCES.is_file():
+        errors.append(f"CLI packaged Grafana datasource config is missing: {PACKAGED_DATASOURCES}")
+    elif SOURCE_DATASOURCES.is_file() and PACKAGED_DATASOURCES.is_file():
+        if SOURCE_DATASOURCES.read_bytes() != PACKAGED_DATASOURCES.read_bytes():
+            errors.append("CLI packaged Grafana datasource config does not match bundle source")
 
     return dashboards, errors
 
@@ -342,8 +498,8 @@ def _inventory_variables(range_seconds: int) -> dict[str, str]:
     return variables
 
 
-def tempo_readiness_error(*, attempts: int = 6, retry_delay_seconds: float = 2) -> str | None:
-    """Wait up to ten seconds for transient Tempo startup/compaction readiness."""
+def tempo_readiness_error(*, attempts: int = 9, retry_delay_seconds: float = 2) -> str | None:
+    """Wait through Tempo's 15-second single-binary ingester startup delay."""
 
     tempo_error: OSError | None = None
     for attempt in range(attempts):
@@ -381,7 +537,11 @@ def live_inventory(
     now_ns = int(now_seconds * 1_000_000_000)
     start_ns = int(start_seconds * 1_000_000_000)
     variables = _inventory_variables(range_seconds)
-    step_seconds = max(60, min(900, range_seconds // 200))
+    # A long inventory range still needs a fine enough step to catch sparse
+    # counters that were exported for only a few minutes before an instance
+    # restarted. Fifteen-minute steps can skip those windows entirely and
+    # misclassify a working historical panel as empty.
+    step_seconds = max(60, min(300, range_seconds // 200))
     has_tempo_search = any(
         (query := tempo_target_query(target))
         and not any(variable in query for variable in ("$trace", "$agent", "$scope_label"))

--- a/scripts/check_grafana_dashboards.py
+++ b/scripts/check_grafana_dashboards.py
@@ -370,12 +370,26 @@ def static_audit(
                         re.findall(r"{{\s*([A-Za-z_][A-Za-z0-9_]*)\s*}}", legend),
                     )
                     grouped_labels: set[str] = set()
-                    for group in re.findall(r"\b(?:by|without)\s*\(([^)]*)\)", expression):
+                    for group in re.findall(r"\bby\s*\(([^)]*)\)", expression):
                         grouped_labels.update(label.strip() for label in group.split(","))
+                    removed_labels: set[str] = set()
+                    for group in re.findall(r"\bwithout\s*\(([^)]*)\)", expression):
+                        removed_labels.update(label.strip() for label in group.split(","))
                     selector_labels = set(
                         re.findall(r"([A-Za-z_][A-Za-z0-9_]*)\s*(?:=~|!~|=|!=)", expression),
                     )
-                    missing_legend_labels = legend_labels - grouped_labels - selector_labels
+                    if grouped_labels:
+                        # A `by(...)` aggregation drops every source label that is
+                        # not named in the grouping, even when that label appears
+                        # in a selector. Treat only grouped labels as available.
+                        missing_legend_labels = legend_labels - grouped_labels
+                    elif removed_labels:
+                        # `without(...)` preserves an open-ended set of source
+                        # labels, so the only labels we can prove absent are the
+                        # labels explicitly removed by the aggregation.
+                        missing_legend_labels = legend_labels & removed_labels
+                    else:
+                        missing_legend_labels = legend_labels - selector_labels
                     if missing_legend_labels:
                         errors.append(
                             f"{uid}/{title}: legend references labels absent from the query: "


### PR DESCRIPTION
Stack/base: standalone change targeting `main`.

## Problem

Several bundled Grafana panels rendered `No data` or a convincing zero even while DefenseClaw was actively emitting telemetry. The dashboards therefore hid live connector traffic, token usage, hook decisions, latency, approval activity, and identity data.

## Current Situation

Two classes of defects combined:

- Grafana advertised a 15-second Prometheus scrape interval while the default OTel metric export cadence is 60 seconds. Grafana's generated rate windows could contain only one remote-write sample, so valid `rate()` queries returned empty vectors.
- Multiple panels queried the wrong metric family, filtered on labels the instrument never emits, matched an exact histogram bucket value that does not exist, or described data that their query did not measure.

The failures were distributed across the connector, identity, overview, findings, HITL, policy, and security dashboards, so isolated panel fixes would not have been sufficient.

## Solution

### Align query cadence with telemetry export

Set the provisioned Prometheus `timeInterval` to 60 seconds, matching the default OTel metric export interval so Grafana generates usable rate windows.

### Rewire panels to emitted contracts

- Use OTLP ingest, GenAI token/duration, inspect evaluation, discovery, approval, and schema-violation metrics for the panels that describe those signals.
- Filter connector-scoped panels with labels actually emitted by each instrument.
- Rebuild chat HILT and exec approval panels around `defenseclaw_guardrail_evaluations_total` and `defenseclaw_approval_count_total`.
- Correct the 2.5-second hook-latency bucket selector, active-connector union, would-block rate, first/last finding timestamps, and LLM event stream.
- Remove two misleading HITL log panels whose queries were unrelated tool-event streams.

### Make the contract enforceable

Extend the dashboard checker to validate datasource cadence, packaged datasource parity, legend labels, percentile labels, selected metric-label contracts, exact hook-latency buckets, Tempo readiness, and live panel inventory classification.

```mermaid
flowchart LR
    Gateway["DefenseClaw gateway"] -->|"OTLP metrics every 60s"| Collector["OTel Collector"]
    Gateway -->|"OTLP logs"| Loki["Loki"]
    Gateway -->|"OTLP traces"| Tempo["Tempo"]
    Collector -->|"remote write"| Prometheus["Prometheus"]
    Prometheus -->|"60s datasource interval + validated PromQL"| Grafana["Grafana dashboards"]
    Loki -->|"validated LogQL"| Grafana
    Tempo -->|"validated TraceQL"| Grafana
    Checker["Dashboard contract checker"] -->|"static + live audit"| Grafana
    Checker --> Prometheus
    Checker --> Loki
    Checker --> Tempo
```

## What Changed (Where & How)

| Path | Change |
| --- | --- |
| `bundles/local_observability_stack/grafana/provisioning/datasources/datasources.yml` | Align Prometheus datasource interval with the 60-second OTel export cadence. |
| `bundles/local_observability_stack/grafana/dashboards/*.json` | Correct metric families, labels, filters, ratios, bucket values, event streams, and empty-state semantics across eight dashboards. |
| `scripts/check_grafana_dashboards.py` | Add cadence, semantic-query, packaged parity, Tempo readiness, and live inventory checks. |
| `cli/tests/test_grafana_dashboards.py` | Add regression coverage for the dashboard catalog and the corrected telemetry contracts. |

## Breaking Changes

- Grafana's configured minimum Prometheus interval changes from 15 seconds to 60 seconds. This changes the rate window Grafana derives for `$__rate_interval` and prevents under-sampled queries.
- The HITL dashboard now treats connector-scoped chat HILT telemetry separately from global exec-approval telemetry.
- The connector detail silence panel is explicitly OTLP-only; it no longer reports a false 0-second value for hook-only connectors.
- Two unrelated/misleading HITL log panels are removed.

No application API or gateway configuration format changes.

## Open Issues / Follow-ups

None.

## Test Plan

- `uv run pytest -q cli/tests/test_grafana_dashboards.py`
  - Observed: `19 passed in 0.34s`.
- `uv run ruff check scripts/check_grafana_dashboards.py cli/tests/test_grafana_dashboards.py`
  - Observed: `All checks passed!`.
- `python3 scripts/check_grafana_dashboards.py --live --require-packaged`
  - Observed: `Grafana audit passed: 14 dashboards, 313 panels, live queries compiled`.
- `python3 scripts/check_grafana_dashboards.py --inventory --inventory-hours 168 --require-packaged`
  - Observed: 14 dashboards and 313 panels inventoried with zero query errors; all 36 Agent Activity panels returned data.
- Rendered Grafana verification against the refreshed local stack.
  - Observed: live hook/token panels populated; the hook latency SLO rendered 53.3%; Grafana, Prometheus, Loki, Tempo, and the OTel Collector all returned HTTP 200.
