### PR TITLE
[codex] Secure macOS installer redaction default

### DIFF
--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 DEFAULT_MODE="observe"
 DEFAULT_CONNECTOR="codex"
 DEFAULT_API_PORT="18970"
-DISABLE_REDACTION="true"
+DISABLE_REDACTION="false"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -66,7 +66,7 @@ Gateway options:
                             Examples: --connector cursor
                                       --connector cursor,claudecode
   --port PORT               Loopback API port (default: ${DEFAULT_API_PORT})
-  --redact                  Enable redaction in audit/sinks (default: off)
+  --disable-redaction       Disable redaction in audit/sinks (default: on)
   --binary PATH             Use prebuilt binary instead of 'go build'
   --skip-build              Reuse ./defenseclaw-gateway in the repo (no rebuild)
   --skip-launchd            Install files but don't bootstrap/enable launchd
@@ -92,7 +92,7 @@ while [[ $# -gt 0 ]]; do
     --mode)             MODE="${2:?}"; shift 2;;
     --connector)        CONNECTOR="${2:?}"; shift 2;;
     --port)             API_PORT="${2:?}"; shift 2;;
-    --redact)           DISABLE_REDACTION="false"; shift;;
+    --disable-redaction|--no-redact) DISABLE_REDACTION="true"; shift;;
     --binary)           BINARY_SRC="${2:?}"; SKIP_BUILD="true"; shift 2;;
     --skip-build)       SKIP_BUILD="true"; shift;;
     --skip-launchd)     SKIP_LAUNCHD="true"; shift;;

--- a/packaging/macos/tests/test_arg_parsing.sh
+++ b/packaging/macos/tests/test_arg_parsing.sh
@@ -11,6 +11,7 @@ t_install_help() {
   out="$("${INSTALL_SH}" --help 2>&1)" || _fail "--help should exit 0"
   assert_contains "${out}" "--mode {observe|action}" "mode flag in help"
   assert_contains "${out}" "--connector LIST"        "connector flag in help"
+  assert_contains "${out}" "--disable-redaction"     "disable redaction flag in help"
   assert_contains "${out}" "comma-separated"         "comma-separated note in help"
   assert_contains "${out}" "Per-user hook wiring"    "per-user section header"
 }

--- a/packaging/macos/tests/test_render_config.sh
+++ b/packaging/macos/tests/test_render_config.sh
@@ -30,20 +30,20 @@ t_multi_connector() {
   assert_contains "${out}" "    cursor:"              "cursor entry under connectors"
   assert_contains "${out}" "    claudecode:"          "claudecode entry under connectors"
   assert_contains "${out}" "    codex:"               "codex entry under connectors"
-  assert_contains "${out}" "disable_redaction: true"  "redaction-on (default)"
+  assert_contains "${out}" "disable_redaction: true"  "redaction explicit opt-out"
   assert_contains "${out}" "mode: observe"            "observe mode"
 }
 
-t_redaction_default_off() {
+t_redaction_default_on() {
   local out
-  out="$(render_config observe codex 18970 true "/var/lib/dc" codex)"
-  assert_contains "${out}" "disable_redaction: true" "redaction kill-switch flag"
+  out="$(render_config observe codex 18970 false "/var/lib/dc" codex)"
+  assert_contains "${out}" "disable_redaction: false" "redaction enabled by default"
 }
 
-t_redaction_enabled() {
+t_redaction_disabled_opt_out() {
   local out
-  out="$(render_config action codex 18970 false "/var/lib/dc" codex)"
-  assert_contains "${out}" "disable_redaction: false" "redaction enabled"
+  out="$(render_config action codex 18970 true "/var/lib/dc" codex)"
+  assert_contains "${out}" "disable_redaction: true" "redaction disabled opt-out"
 }
 
 t_yaml_parses() {
@@ -70,6 +70,6 @@ t_yaml_parses() {
 
 run_case "single-connector config"  t_single_connector
 run_case "multi-connector config"   t_multi_connector
-run_case "redaction default (off)"  t_redaction_default_off
-run_case "redaction enabled flag"   t_redaction_enabled
+run_case "redaction default (on)"   t_redaction_default_on
+run_case "redaction opt-out flag"   t_redaction_disabled_opt_out
 run_case "rendered YAML parses"     t_yaml_parses


### PR DESCRIPTION
## Summary
- enable redaction by default in the managed macOS installer
- replace the opt-in `--redact` flag with an explicit `--disable-redaction` / `--no-redact` opt-out
- update installer tests so the secure default is enforced

## Root cause
PR #410 initialized `DISABLE_REDACTION="true"`, so generated managed-enterprise configs wrote `privacy.disable_redaction: true` unless admins opted into redaction.

## Impact
Managed macOS installs now default to redacting sensitive prompt, credential, token, and audit content. Admins who intentionally need raw audit data still have an explicit opt-out.

## Validation
- `packaging/macos/tests/run_tests.sh packaging/macos/tests/test_arg_parsing.sh packaging/macos/tests/test_render_config.sh` -> `14 passed, 0 failed`

## Notes
- Linked finding: cisco-ai-defense/defenseclaw#410 review comment on insecure redaction default.
- Full `packaging-macos-test` is still blocked on the separate host-dependent Claude version test issue in PR #410; this branch keeps that fix separate.
