### PR TITLE
[codex] Make macOS Claude version tests hermetic

### DIFF
--- a/packaging/macos/tests/test_discover_agent_version.sh
+++ b/packaging/macos/tests/test_discover_agent_version.sh
@@ -4,6 +4,16 @@
 # extension-fallback path without touching real installs.
 . "${PKG_DIR}/lib/installer_lib.sh"
 
+without_host_claude() {
+  local fakebin; fakebin="$(mktest_tmp)"
+  cat > "${fakebin}/claude" <<'SH'
+#!/usr/bin/env bash
+exit 127
+SH
+  chmod 0700 "${fakebin}/claude"
+  PATH="${fakebin}:${PATH}" "$@"
+}
+
 t_claudecode_via_cursor_extension() {
   local home; home="$(mktest_tmp)"
   local ext="${home}/.cursor/extensions/anthropic.claude-code-2.1.195-darwin-arm64"
@@ -13,7 +23,7 @@ t_claudecode_via_cursor_extension() {
 JSON
 
   local got
-  got="$(discover_agent_version claudecode "${home}")"
+  got="$(without_host_claude discover_agent_version claudecode "${home}")"
   assert_eq "${got}" "2.1.195" "claudecode version from Cursor extension"
 }
 
@@ -26,7 +36,7 @@ t_claudecode_via_vscode_extension() {
 JSON
 
   local got
-  got="$(discover_agent_version claudecode "${home}")"
+  got="$(without_host_claude discover_agent_version claudecode "${home}")"
   assert_eq "${got}" "2.0.99" "claudecode version from VS Code extension"
 }
 


### PR DESCRIPTION
## Summary
- shadow any host-installed `claude` executable during the extension-fallback test cases
- force the tests to exercise the staged Cursor and VS Code extension fixtures
- leave production version-discovery behavior unchanged

## Root cause
`discover_agent_version claudecode` checks `command -v claude` before inspecting HOME-relative extension package metadata. The tests expected extension fallback versions, but on machines with Claude Code installed they read the host CLI version instead.

## Impact
The new macOS packaging test target is deterministic on developer machines and CI runners that already have Claude Code installed.

## Validation
- `packaging/macos/tests/run_tests.sh packaging/macos/tests/test_discover_agent_version.sh` -> `5 passed, 0 failed`
- `packaging/macos/tests/run_tests.sh` -> `42 passed, 0 failed`

## Notes
- Linked finding: cisco-ai-defense/defenseclaw#410 review comment on host-dependent packaging tests.
