### PR TITLE
Add native Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
           uv --no-config venv "$tmp/venv" --python "${{ matrix.python-version }}"
           uv --no-config pip install --python "$tmp/venv/bin/python" "$whl"
           "$tmp/venv/bin/defenseclaw" --help >/dev/null
+          "$tmp/venv/bin/python" -c 'from defenseclaw.envvars import load_registry; assert load_registry().entries'
 
   upgrade-smoke:
     name: Upgrade Smoke

--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -201,6 +201,13 @@ _json_mode = False
 # attributable instead of reading as one primary connector.
 _label_suffix = ""
 
+# Probe bodies are bounded before decoding so an endpoint cannot make doctor
+# buffer an unbounded response. Most probe bodies are rendered only as short
+# diagnostics, but /health is structured input and can legitimately exceed
+# the display limit on multi-connector installs.
+_HTTP_PROBE_DISPLAY_BYTES = 2_000
+_HEALTH_DOCUMENT_MAX_BYTES = 1_048_576
+
 
 @contextlib.contextmanager
 def _capture_stdout_when_json():
@@ -458,6 +465,8 @@ def _http_probe(
     body: bytes | None = None,
     timeout: float = 10.0,
     verify_tls: bool = True,
+    response_limit: int = _HTTP_PROBE_DISPLAY_BYTES,
+    allow_truncation: bool = True,
 ) -> tuple[int, str]:
     """Fire an HTTP request; return (status_code, body_text). Returns (0, error) on failure.
 
@@ -469,7 +478,22 @@ def _http_probe(
     returning a redirect. We route through ``build_no_redirect_opener`` and
     surface a refused redirect as a non-following ``(0, message)`` result —
     the same shape callers already treat as "could not complete the probe".
+
+    ``response_limit`` is a byte bound, not just a post-read display slice.
+    The default retains the compact diagnostic-body behavior. Structured
+    callers such as the sidecar health check opt into a larger bounded document
+    and disable truncation so an oversized response is rejected rather than
+    parsed as if it were complete.
     """
+    if response_limit <= 0:
+        raise ValueError("response_limit must be positive")
+
+    def _read_response(stream) -> str:
+        raw = stream.read(response_limit + 1)
+        if len(raw) > response_limit and not allow_truncation:
+            return f"response exceeds {response_limit}-byte limit"
+        return raw[:response_limit].decode("utf-8", errors="replace")
+
     req = urllib.request.Request(url, method=method, headers=headers or {}, data=body)
     context = None
     if not verify_tls and url.lower().startswith("https://"):
@@ -479,11 +503,11 @@ def _http_probe(
     opener = build_no_redirect_opener(urllib.request.HTTPSHandler(context=context))
     try:
         with opener.open(req, timeout=timeout) as resp:
-            return resp.status, resp.read().decode("utf-8", errors="replace")[:2000]
+            return resp.status, _read_response(resp)
     except urllib.error.HTTPError as exc:
         body_text = ""
         try:
-            body_text = exc.read().decode("utf-8", errors="replace")[:2000]
+            body_text = _read_response(exc)
         except Exception:
             pass
         return exc.code, body_text
@@ -641,7 +665,12 @@ def _check_sidecar(cfg, r: _DoctorResult) -> None:
     if getattr(cfg, "openshell", None) and cfg.openshell.is_standalone():
         bind = getattr(cfg.guardrail, "host", None) or bind
     url = f"http://{bind}:{cfg.gateway.api_port}/health"
-    code, body = _http_probe(url, timeout=5.0)
+    code, body = _http_probe(
+        url,
+        timeout=5.0,
+        response_limit=_HEALTH_DOCUMENT_MAX_BYTES,
+        allow_truncation=False,
+    )
     if code == 200:
         _emit("pass", "Sidecar API", f"{bind}:{cfg.gateway.api_port}", r=r)
 

--- a/cli/defenseclaw/commands/cmd_doctor.py
+++ b/cli/defenseclaw/commands/cmd_doctor.py
@@ -43,6 +43,7 @@ from defenseclaw.connector_paths import omnigent_config_path
 from defenseclaw.context import AppContext, pass_ctx
 from defenseclaw.envvars import active_security_overrides
 from defenseclaw.safety import NoRedirectError, build_no_redirect_opener
+from defenseclaw.scanner_binary import resolve_scanner_binary
 from defenseclaw.webhooks import list_webhooks, validate_webhook_url
 
 # Doctor status markers, recomputed per emission so the per-call
@@ -595,11 +596,16 @@ def _check_scanners(cfg, r: _DoctorResult) -> None:
         ("mcp-scanner", cfg.scanners.mcp_scanner.binary),
     ]
     for name, binary in bins:
-        path = shutil.which(binary)
+        path = resolve_scanner_binary(binary)
         if path:
             _emit("pass", f"Scanner: {name}", path, r=r)
         else:
-            _emit("fail", f"Scanner: {name}", f"'{binary}' not on PATH", r=r)
+            _emit(
+                "fail",
+                f"Scanner: {name}",
+                f"'{binary}' not found in the managed environment or on PATH",
+                r=r,
+            )
 
 
 def _subsystem_expected_enabled(cfg, sub: str) -> bool | None:

--- a/cli/defenseclaw/commands/cmd_init.py
+++ b/cli/defenseclaw/commands/cmd_init.py
@@ -749,14 +749,55 @@ def _stdout_is_tty() -> bool:
         return False
 
 
+def _supports_terminal_redraw() -> bool:
+    """Return whether stdout can safely process ANSI cursor movement.
+
+    POSIX terminals expose this through ``isatty``.  On Windows a console can
+    be a TTY while still treating ANSI cursor controls as plain text (or while
+    Click/Colorama strips an unsupported control), which makes every refresh
+    append another copy of the menu.  Enable virtual-terminal processing when
+    the attached console supports it and otherwise use the line-based picker.
+    """
+
+    if not _stdout_is_tty():
+        return False
+    if os.name != "nt":
+        return True
+
+    try:
+        import ctypes
+        import msvcrt
+
+        stream = click.get_text_stream("stdout")
+        handle_value = msvcrt.get_osfhandle(stream.fileno())
+        if handle_value == -1:
+            return False
+        handle = ctypes.c_void_p(handle_value)
+        mode = ctypes.c_ulong()
+        kernel32 = ctypes.windll.kernel32
+        if not kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+            return False
+        enable_virtual_terminal_processing = 0x0004
+        if mode.value & enable_virtual_terminal_processing:
+            return True
+        return bool(
+            kernel32.SetConsoleMode(
+                handle,
+                mode.value | enable_virtual_terminal_processing,
+            )
+        )
+    except (AttributeError, OSError, TypeError, ValueError):
+        return False
+
+
 def _checkbox_key_name(ch: str) -> str:
     if ch in ("\r", "\n"):
         return "enter"
     if ch in (" ", "\t"):
         return "toggle"
-    if ch in ("\x1b[A", "k", "K"):
+    if ch in ("\x1b[A", "\x00H", "\xe0H", "k", "K"):
         return "up"
-    if ch in ("\x1b[B", "j", "J"):
+    if ch in ("\x1b[B", "\x00P", "\xe0P", "j", "J"):
         return "down"
     if ch == "a":
         return "all"
@@ -782,6 +823,52 @@ def _render_checkbox_menu(
         click.echo(f"  {pointer} [{mark}] {name}")
 
 
+def _prompt_checkbox_selection_no_redraw(
+    options: list[str],
+    selected: set[str],
+    *,
+    empty_ok: bool,
+) -> list[str]:
+    """Line-oriented checkbox fallback for Windows consoles without VT."""
+
+    for idx, name in enumerate(options, start=1):
+        mark = "x" if name in selected else " "
+        click.echo(f"    {idx}. [{mark}] {name}")
+    ux.subhead("  Enter comma-separated numbers; use 'all' or 'none'.")
+
+    default = ",".join(
+        str(idx)
+        for idx, name in enumerate(options, start=1)
+        if name in selected
+    ) or "none"
+    while True:
+        raw = click.prompt("  Selection", default=default, show_default=True).strip()
+        normalized = raw.lower()
+        if normalized in {"a", "all"}:
+            chosen = set(options)
+        elif normalized in {"n", "none"}:
+            chosen = set()
+        else:
+            chosen: set[str] = set()
+            invalid: list[str] = []
+            for token in (part.strip() for part in raw.split(",")):
+                if token.isdecimal() and 1 <= int(token) <= len(options):
+                    chosen.add(options[int(token) - 1])
+                elif token in options:
+                    chosen.add(token)
+                else:
+                    invalid.append(token or "(empty)")
+            if invalid:
+                ux.warn(
+                    f"Unknown selection: {', '.join(invalid)}.",
+                    indent="  ",
+                )
+                continue
+        if chosen or empty_ok:
+            return [name for name in options if name in chosen]
+        ux.warn("Select at least one connector.", indent="  ")
+
+
 def _prompt_checkbox_selection(
     options: list[str],
     *,
@@ -800,9 +887,16 @@ def _prompt_checkbox_selection(
     selected = {name for name in default_selected if name in options}
     cursor = 0
     ux.subhead(title)
-    ux.subhead("  Space toggles, j/k moves, a selects all, n clears, Enter continues.")
 
-    redraw = _stdout_is_tty()
+    redraw = _supports_terminal_redraw()
+    if not redraw:
+        return _prompt_checkbox_selection_no_redraw(
+            options,
+            selected,
+            empty_ok=empty_ok,
+        )
+
+    ux.subhead("  Space toggles, j/k moves, a selects all, n clears, Enter continues.")
     rendered = False
     while True:
         _render_checkbox_menu(options, selected, cursor, redraw=redraw and rendered)

--- a/cli/defenseclaw/commands/cmd_init.py
+++ b/cli/defenseclaw/commands/cmd_init.py
@@ -215,6 +215,18 @@ def init_cmd(  # noqa: PLR0913 - first-run CLI mirrors the setup surface.
     """
     import platform
 
+    requested_connectors = []
+    if connector:
+        requested_connectors.append(_normalize_connector_arg(connector))
+    requested_connectors.extend(_parse_connector_list(action_connectors))
+    for requested in requested_connectors:
+        support = platform_support.connector_platform_support(requested)
+        if not support.available:
+            raise click.ClickException(
+                f"connector {requested!r} is {support.status} on "
+                f"{platform_support.host_os()}: {support.reason}"
+            )
+
     if _use_guided_first_run(
         non_interactive=non_interactive,
         yes=yes,
@@ -830,7 +842,13 @@ def _installed_hook_connectors(disc) -> list[str]:
     names: list[str] = []
     for name in order:
         sig = disc.agents.get(name)
-        if sig and sig.installed and name in _HOOK_ENFORCED_CONNECTORS and name not in names:
+        if (
+            sig
+            and sig.installed
+            and name in _HOOK_ENFORCED_CONNECTORS
+            and platform_support.connector_supported_on_os(name)
+            and name not in names
+        ):
             names.append(name)
     return names
 
@@ -979,9 +997,12 @@ def _prompt_connector_selection(
 
     fallback = agent_discovery.first_installed(disc, "codex")
     ux.subhead("No hook connectors were detected. Choose one active connector to configure.")
+    choices = platform_support.supported_connectors(sorted(connector_paths.KNOWN_CONNECTORS))
+    if fallback not in choices:
+        fallback = choices[0] if choices else "codex"
     raw = click.prompt(
         "  Connector",
-        type=click.Choice(sorted(connector_paths.KNOWN_CONNECTORS), case_sensitive=False),
+        type=click.Choice(choices, case_sensitive=False),
         default=fallback,
         show_default=True,
     )
@@ -996,12 +1017,23 @@ def _note_proxy_connectors(disc) -> None:
     their dedicated setup so a detected proxy agent isn't silently skipped."""
     order = getattr(agent_discovery, "DISCOVERY_PRECEDENCE", None) or sorted(disc.agents)
     detected: list[str] = []
+    unavailable: list[str] = []
     for name in order:
         if not platform_support.is_proxy_connector(name):
             continue
         signal = disc.agents.get(name)
         if signal is not None and signal.installed:
-            detected.append(name)
+            if platform_support.connector_supported_on_os(name):
+                detected.append(name)
+            else:
+                unavailable.append(name)
+    for name in unavailable:
+        support = platform_support.connector_platform_support(name)
+        ux.warn(
+            f"Detected {name}, but it is {support.status} on "
+            f"{platform_support.host_os()}: {support.reason}",
+            indent="  ",
+        )
     if not detected:
         return
     ux.subhead(
@@ -1728,7 +1760,12 @@ def _normalize_connector_arg(
     if connector is None and discover_default:
         try:
             disc = agent_discovery.discover_agents(refresh=refresh_agents)
-            connector = agent_discovery.first_installed(disc, "codex")
+            discovered = agent_discovery.first_installed(disc, "codex")
+            if platform_support.connector_supported_on_os(discovered):
+                connector = discovered
+            else:
+                installed = _installed_hook_connectors(disc)
+                connector = installed[0] if installed else "codex"
         except Exception:
             connector = "codex"
     value = (connector or "codex").strip().lower()

--- a/cli/defenseclaw/commands/cmd_plugin.py
+++ b/cli/defenseclaw/commands/cmd_plugin.py
@@ -32,6 +32,7 @@ import click
 
 from defenseclaw.commands import compute_verdict as _compute_verdict
 from defenseclaw.context import AppContext, pass_ctx
+from defenseclaw.inventory.plugin_directories import plugin_directory_entries
 
 
 def _api_bind_host(app: AppContext) -> str:
@@ -1639,12 +1640,7 @@ def _enable_plugin_via_gateway(app: AppContext, plugin_name: str) -> bool:
 
 def _list_defenseclaw_plugins(plugin_dir: str) -> list[str]:
     """Return sorted list of DefenseClaw plugin directory names."""
-    if not os.path.isdir(plugin_dir):
-        return []
-    return sorted(
-        e for e in os.listdir(plugin_dir)
-        if os.path.isdir(os.path.join(plugin_dir, e))
-    )
+    return [entry for entry, _path in plugin_directory_entries(plugin_dir)]
 
 
 # _HOST_PLUGIN_MANIFEST_FILES — plan C6 / matrix #3. Each host agent
@@ -1698,24 +1694,8 @@ def _scan_plugin_dir(host_dir: str, connector: str) -> list[dict[str, Any]]:
     picking up unrelated nested package.json files (e.g. a plugin's
     own node_modules tree).
     """
-    if not os.path.isdir(host_dir):
-        return []
     out: list[dict[str, Any]] = []
-    try:
-        entries = sorted(os.listdir(host_dir))
-    except OSError:
-        return []
-    for entry in entries:
-        # N6: host plugin dirs carry non-plugin siblings — a ``cache``
-        # working dir (codex/zeptoclaw register ``…/plugins/cache``) and
-        # dot-prefixed dirs (``.git`` and editor/OS cruft). Skip both so they
-        # never surface as phantom plugin rows. The manifest stays optional
-        # below, so genuinely manifest-less host plugins still list.
-        if entry == "cache" or entry.startswith("."):
-            continue
-        plugin_path = os.path.join(host_dir, entry)
-        if not os.path.isdir(plugin_path):
-            continue
+    for entry, plugin_path in plugin_directory_entries(host_dir):
         manifest = _read_host_plugin_manifest(plugin_path) or {}
         plugin_id = manifest.get("id") or entry
         plugin_name = manifest.get("name") or plugin_id

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -2511,6 +2511,30 @@ def _fetch_connector_names(cfg=None) -> list[str]:
 _CONNECTOR_NAMES = platform_support.supported_connectors(_CONNECTOR_NAMES_FALLBACK)
 _HILT_MIN_SEVERITIES = ["HIGH", "MEDIUM", "LOW", "CRITICAL"]
 
+
+class _PlatformConnectorChoice(click.Choice):
+    """Hide unsupported choices while returning their reason on explicit use."""
+
+    def convert(
+        self,
+        value: Any,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> Any:
+        if isinstance(value, str):
+            connector = normalize_connector(value)
+            if connector in _CONNECTOR_NAMES_FALLBACK:
+                support = platform_support.connector_platform_support(connector)
+                if not support.available:
+                    self.fail(
+                        f"connector {connector!r} is {support.status} on "
+                        f"{platform_support.host_os()}: {support.reason}",
+                        param,
+                        ctx,
+                    )
+        return super().convert(value, param, ctx)
+
+
 _CONNECTOR_META: dict[str, dict[str, str]] = {
     "openclaw": {
         "label": "OpenClaw",
@@ -2597,6 +2621,24 @@ _CONNECTOR_META: dict[str, dict[str, str]] = {
         "subprocess_policy": "none",
     },
 }
+
+
+def _connector_presentation_label(connector: str) -> str:
+    """Return the connector label with an explicit preview marker."""
+    label = _CONNECTOR_META.get(connector, {}).get("label", connector)
+    if platform_support.connector_preview_on_os(connector):
+        return f"{label} (preview)"
+    return label
+
+
+def _ensure_connector_available(connector: str) -> None:
+    """Reject an unsupported host/connector pair with its recorded reason."""
+    support = platform_support.connector_platform_support(connector)
+    if not support.available:
+        raise click.ClickException(
+            f"connector {connector!r} is {support.status} on "
+            f"{platform_support.host_os()}: {support.reason}"
+        )
 
 _CONNECTOR_CHANGE_SURFACES: dict[str, tuple[str, ...]] = {
     "openclaw": (
@@ -2781,7 +2823,7 @@ def _detect_installed_connectors() -> list[str]:
         or os.path.isfile(os.path.join(home, ".gemini", "antigravity-cli", "hooks.json"))
         or os.path.isdir(os.path.join(home, ".gemini", "antigravity-cli")),
     )
-    return found
+    return platform_support.supported_connectors(found)
 
 
 def _detect_connector(data_dir: str | None = None) -> str | None:
@@ -2825,7 +2867,8 @@ def _select_connector_interactive(current: str, data_dir: str | None = None) -> 
     for i, name in enumerate(_CONNECTOR_NAMES, 1):
         meta = _CONNECTOR_META[name]
         marker = " *" if name == default else ""
-        click.echo(f"    {i}. {meta['label']:<14s} — {meta['description']}{marker}")
+        label = _connector_presentation_label(name)
+        click.echo(f"    {i}. {label:<22s} — {meta['description']}{marker}")
     click.echo()
     default_idx = _CONNECTOR_NAMES.index(default) + 1 if default in _CONNECTOR_NAMES else None
     raw = click.prompt(
@@ -2846,7 +2889,11 @@ def _print_connector_info(name: str) -> None:
         tool_display = "pre-execution + response-scan"
     else:
         tool_display = tool_mode
-    click.echo(f"    Connector:         {meta['label']} ({name})")
+    support = platform_support.connector_platform_support(name)
+    click.echo(f"    Connector:         {_connector_presentation_label(name)} ({name})")
+    # Keep the status visible even for stable connectors when this detail view
+    # is explicitly requested; it makes preview classification auditable.
+    click.echo(f"    Platform support:  {support.status} — {support.reason}")
     click.echo(f"    Tool inspection:   {tool_display}")
     click.echo(f"    Subprocess policy: {meta['subprocess_policy']}")
     click.echo()
@@ -3422,7 +3469,7 @@ def _resolve_judge_hook_gate(
     "--connector",
     "--agent",
     "agent_name",
-    type=click.Choice(_CONNECTOR_NAMES, case_sensitive=False),
+    type=_PlatformConnectorChoice(_CONNECTOR_NAMES, case_sensitive=False),
     default=None,
     help=(
         "Agent framework connector. Alias: --agent. Defaults to "
@@ -3725,6 +3772,11 @@ def setup_guardrail(
         _disable_guardrail(app, gc, restart=True)
         return
 
+    # Validate explicit operator input before mutating the in-memory config.
+    # Stored/picked fallback values are checked after resolution below.
+    if explicit_connector:
+        _ensure_connector_available(explicit_connector)
+
     aid = app.cfg.cisco_ai_defense
 
     if non_interactive:
@@ -3754,8 +3806,11 @@ def setup_guardrail(
         elif not gc.connector or gc.connector == "openclaw":
             picked = _read_picked_connector(getattr(app.cfg, "data_dir", None))
             if picked:
+                _ensure_connector_available(normalize_connector(picked))
                 gc.connector = picked
         target_connector = target_connector or gc.connector
+        if target_connector:
+            _ensure_connector_available(normalize_connector(target_connector))
         per_connector_target = bool(
             explicit_connector
             and target_connector
@@ -5060,6 +5115,7 @@ def _setup_observability_alias(
     """
     if connector not in _HOOK_ENFORCED_CONNECTORS:
         raise click.ClickException(f"unsupported connector for hook alias: {connector!r}")
+    _ensure_connector_available(connector)
 
     # Antigravity is global-only by design. agy v1.0.x merges every
     # hooks file it discovers (~/.gemini/config/hooks.json,
@@ -5228,7 +5284,7 @@ def _run_setup_picker(app: AppContext) -> list[str]:
     nothing. Only called on an interactive TTY (the caller falls back to help
     on a non-interactive stream).
     """
-    candidates = sorted(_HOOK_ENFORCED_CONNECTORS)
+    candidates = platform_support.supported_connectors(sorted(_HOOK_ENFORCED_CONNECTORS))
     detected = {c for c in _detect_installed_connectors() if c in _HOOK_ENFORCED_CONNECTORS}
     configured = {
         c for c in _configured_connector_set(app.cfg.guardrail) if c in _HOOK_ENFORCED_CONNECTORS
@@ -5243,7 +5299,7 @@ def _run_setup_picker(app: AppContext) -> list[str]:
         if c in configured:
             tags.append("configured")
         suffix = f"  {ux.dim('(' + ', '.join(tags) + ')')}" if tags else ""
-        display_by_connector[c] = f"{_CONNECTOR_META[c]['label']}{suffix}"
+        display_by_connector[c] = f"{_connector_presentation_label(c)}{suffix}"
     connector_by_display = {label: c for c, label in display_by_connector.items()}
 
     ux.section("Select active connectors")
@@ -5260,7 +5316,7 @@ def _run_setup_picker(app: AppContext) -> list[str]:
 
 def _connector_display_options(connectors: list[str]) -> tuple[list[str], dict[str, str], dict[str, str]]:
     """Return checkbox labels plus connector/display lookup maps."""
-    display_by_connector = {c: _CONNECTOR_META[c]["label"] for c in connectors}
+    display_by_connector = {c: _connector_presentation_label(c) for c in connectors}
     connector_by_display = {label: c for c, label in display_by_connector.items()}
     return [display_by_connector[c] for c in connectors], display_by_connector, connector_by_display
 
@@ -5751,6 +5807,12 @@ def _dispatch_bare_setup(
                 f"{sorted(_HOOK_ENFORCED_CONNECTORS)}. (OpenClaw/ZeptoClaw use "
                 "`defenseclaw setup openclaw` — they cannot be batch peers.)"
             )
+        support = platform_support.connector_platform_support(c)
+        if not support.available:
+            raise click.UsageError(
+                f"connector {c!r} is {support.status} on {platform_support.host_os()}: "
+                f"{support.reason}"
+            )
         if c not in targets:
             targets.append(c)
 
@@ -5758,10 +5820,10 @@ def _dispatch_bare_setup(
         _add(raw)
     if detected:
         for c in _detect_installed_connectors():
-            if c in _HOOK_ENFORCED_CONNECTORS:
+            if c in _HOOK_ENFORCED_CONNECTORS and platform_support.connector_supported_on_os(c):
                 _add(c)
     if all_connectors:
-        for c in sorted(_HOOK_ENFORCED_CONNECTORS):
+        for c in platform_support.supported_connectors(sorted(_HOOK_ENFORCED_CONNECTORS)):
             _add(c)
 
     if not targets:
@@ -6389,6 +6451,18 @@ def _make_observability_setup_command(connector: str) -> click.Command:
     """Create a ``defenseclaw setup <connector>`` hook-driven alias."""
     label = _CONNECTOR_META[connector]["label"]
     surface_name = "custom policy API" if connector == "omnigent" else "agent lifecycle hooks"
+    platform = platform_support.connector_platform_support(connector)
+    platform_note = (
+        ""
+        if platform.status == platform_support.SUPPORTED
+        else (
+            f"\n\nPlatform status on {platform_support.host_os()}: "
+            f"{platform.status} — {platform.reason}"
+        )
+    )
+    short_help = f"Configure DefenseClaw for {label}."
+    if platform.status != platform_support.SUPPORTED:
+        short_help = f"{label}: {platform.status} on {platform_support.host_os()}."
 
     @click.command(
         connector,
@@ -6399,8 +6473,9 @@ def _make_observability_setup_command(connector: str) -> click.Command:
             "mode is observe; pass "
             "--mode action to enable agent-native blocking/approval verdicts "
             "on supported events. No proxy is involved in either mode."
+            f"{platform_note}"
         ),
-        short_help=f"Configure DefenseClaw for {label}.",
+        short_help=short_help,
         epilog=(
             "Hook and policy connectors enforce through agent-native lifecycle "
             "verdicts (no LLM proxy). The judge/HILT/block-message options here write "
@@ -6672,6 +6747,7 @@ def _setup_guardrail_connector_alias(
     """Run the full guardrail setup backend for a specific connector."""
     if connector not in _GUARDRAIL_SUPPORTING_CONNECTORS:
         raise click.ClickException(f"{connector!r} is not a guardrail-capable connector")
+    _ensure_connector_available(connector)
 
     label = _CONNECTOR_META.get(connector, {}).get("label", connector)
     click.echo()
@@ -6746,6 +6822,18 @@ def _setup_guardrail_connector_alias(
 def _make_guardrail_connector_setup_command(connector: str) -> click.Command:
     """Create ``defenseclaw setup openclaw|zeptoclaw`` aliases."""
     label = _CONNECTOR_META[connector]["label"]
+    platform = platform_support.connector_platform_support(connector)
+    platform_note = (
+        ""
+        if platform.status == platform_support.SUPPORTED
+        else (
+            f"\n\nPlatform status on {platform_support.host_os()}: "
+            f"{platform.status} — {platform.reason}"
+        )
+    )
+    short_help = f"Configure {label} guardrail setup."
+    if platform.status != platform_support.SUPPORTED:
+        short_help = f"{label}: {platform.status} on {platform_support.host_os()}."
 
     @click.command(
         connector,
@@ -6753,8 +6841,9 @@ def _make_guardrail_connector_setup_command(connector: str) -> click.Command:
             f"Configure DefenseClaw guardrail for {label}.\n\n"
             "Configures the proxy-backed connector selection, then runs the "
             "same backend as `defenseclaw setup guardrail --connector ...`."
+            f"{platform_note}"
         ),
-        short_help=f"Configure {label} guardrail setup.",
+        short_help=short_help,
     )
     @click.option("--yes", "-y", "yes", is_flag=True, help="Skip confirmation prompt.")
     @click.option("--non-interactive", "--accept-defaults", is_flag=True, help="Alias for --yes.")

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -1703,7 +1703,11 @@ def _add_trusted_bin_prefix(prefix: str, data_dir: str) -> bool:
         os.environ.get("DEFENSECLAW_TRUSTED_BIN_PREFIXES", ""),
     )
     parts = [p.strip() for p in current.split(os.pathsep) if p.strip()]
-    added = prefix not in parts
+    prefix_key = agent_discovery._path_key(os.path.realpath(os.path.abspath(prefix)))
+    added = not any(
+        agent_discovery._path_key(os.path.realpath(os.path.abspath(part))) == prefix_key
+        for part in parts
+    )
     if added:
         parts.append(prefix)
     new_val = os.pathsep.join(parts)
@@ -1725,15 +1729,15 @@ def _add_trusted_bin_prefix(prefix: str, data_dir: str) -> bool:
 
 
 def _trusted_prefix_status(resolved: str) -> str:
-    """Classify a resolved prefix: ok / missing / not-a-dir / world-writable."""
+    """Classify a resolved prefix for trusted-paths list output."""
     if not os.path.exists(resolved):
         return "missing"
     if not os.path.isdir(resolved):
         return "not-a-dir"
-    try:
-        if os.stat(resolved).st_mode & 0o002:
-            return "world-writable"
-    except OSError:  # pragma: no cover - rare stat failure
+    _path, error = agent_discovery.validate_trusted_prefix(resolved)
+    if error:
+        if "write access" in error or "writable" in error:
+            return "unsafe-permissions"
         return "error"
     return "ok"
 
@@ -1841,7 +1845,7 @@ def trusted_paths_list(app: AppContext, as_json: bool) -> None:
 
 @trusted_paths.command("add")
 @click.argument("directory")
-@click.option("--force", is_flag=True, help="Add even when the directory is world-writable or missing.")
+@click.option("--force", is_flag=True, help="Record the path even when it is missing or has unsafe permissions.")
 @click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON instead of text.")
 @pass_ctx
 def trusted_paths_add(app: AppContext, directory: str, force: bool, as_json: bool) -> None:

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -4305,9 +4305,9 @@ def _checkbox_key_name(ch: str) -> str:
         return "enter"
     if ch in (" ", "\t"):
         return "toggle"
-    if ch in ("\x1b[A", "k", "K"):
+    if ch in ("\x1b[A", "\x00H", "\xe0H", "k", "K"):
         return "up"
-    if ch in ("\x1b[B", "j", "J"):
+    if ch in ("\x1b[B", "\x00P", "\xe0P", "j", "J"):
         return "down"
     if ch == "a":
         return "all"
@@ -4320,6 +4320,40 @@ def _stdout_is_tty() -> bool:
     try:
         return click.get_text_stream("stdout").isatty()
     except Exception:
+        return False
+
+
+def _supports_terminal_redraw() -> bool:
+    """Return whether stdout can safely process ANSI cursor movement."""
+
+    if not _stdout_is_tty():
+        return False
+    if os.name != "nt":
+        return True
+
+    try:
+        import ctypes
+        import msvcrt
+
+        stream = click.get_text_stream("stdout")
+        handle_value = msvcrt.get_osfhandle(stream.fileno())
+        if handle_value == -1:
+            return False
+        handle = ctypes.c_void_p(handle_value)
+        mode = ctypes.c_ulong()
+        kernel32 = ctypes.windll.kernel32
+        if not kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+            return False
+        enable_virtual_terminal_processing = 0x0004
+        if mode.value & enable_virtual_terminal_processing:
+            return True
+        return bool(
+            kernel32.SetConsoleMode(
+                handle,
+                mode.value | enable_virtual_terminal_processing,
+            )
+        )
+    except (AttributeError, OSError, TypeError, ValueError):
         return False
 
 
@@ -4340,6 +4374,52 @@ def _render_checkbox_menu(
         click.echo(f"  {pointer} [{mark}] {name}")
 
 
+def _prompt_checkbox_selection_no_redraw(
+    options: list[str],
+    selected: set[str],
+    *,
+    empty_ok: bool,
+) -> list[str]:
+    """Line-oriented checkbox fallback for Windows consoles without VT."""
+
+    for idx, name in enumerate(options, start=1):
+        mark = "x" if name in selected else " "
+        click.echo(f"    {idx}. [{mark}] {name}")
+    ux.subhead("  Enter comma-separated numbers; use 'all' or 'none'.")
+
+    default = ",".join(
+        str(idx)
+        for idx, name in enumerate(options, start=1)
+        if name in selected
+    ) or "none"
+    while True:
+        raw = click.prompt("  Selection", default=default, show_default=True).strip()
+        normalized = raw.lower()
+        if normalized in {"a", "all"}:
+            chosen = set(options)
+        elif normalized in {"n", "none"}:
+            chosen = set()
+        else:
+            chosen: set[str] = set()
+            invalid: list[str] = []
+            for token in (part.strip() for part in raw.split(",")):
+                if token.isdecimal() and 1 <= int(token) <= len(options):
+                    chosen.add(options[int(token) - 1])
+                elif token in options:
+                    chosen.add(token)
+                else:
+                    invalid.append(token or "(empty)")
+            if invalid:
+                ux.warn(
+                    f"Unknown selection: {', '.join(invalid)}.",
+                    indent="  ",
+                )
+                continue
+        if chosen or empty_ok:
+            return [name for name in options if name in chosen]
+        ux.warn("Select at least one connector.", indent="  ")
+
+
 def _prompt_checkbox_selection(
     options: list[str],
     *,
@@ -4358,9 +4438,16 @@ def _prompt_checkbox_selection(
     selected = {name for name in default_selected if name in options}
     cursor = 0
     ux.subhead(title)
-    ux.subhead("  Space toggles, j/k moves, a selects all, n clears, Enter continues.")
 
-    redraw = _stdout_is_tty()
+    redraw = _supports_terminal_redraw()
+    if not redraw:
+        return _prompt_checkbox_selection_no_redraw(
+            options,
+            selected,
+            empty_ok=empty_ok,
+        )
+
+    ux.subhead("  Space toggles, j/k moves, a selects all, n clears, Enter continues.")
     rendered = False
     while True:
         _render_checkbox_menu(options, selected, cursor, redraw=redraw and rendered)

--- a/cli/defenseclaw/commands/cmd_setup.py
+++ b/cli/defenseclaw/commands/cmd_setup.py
@@ -71,6 +71,7 @@ from defenseclaw.connector_contracts import (
     resolve_connector_contract,
 )
 from defenseclaw.context import AppContext, pass_ctx
+from defenseclaw.file_permissions import set_file_mode
 from defenseclaw.inventory import agent_discovery
 from defenseclaw.paths import bundled_extensions_dir, bundled_splunk_bridge_dir, splunk_bridge_bin
 from defenseclaw.safety import reject_symlink, sanitize_dotenv_value
@@ -1663,13 +1664,11 @@ def _load_dotenv(path: str) -> dict[str, str]:
 
 
 def _write_dotenv(path: str, entries: dict[str, str]) -> None:
-    """Write entries to a .env file with mode 0600.
+    """Write entries to a .env file with owner-only access.
 
     Note: ``O_CREAT`` only applies the ``0o600`` mode on *initial*
-    creation. When the file already exists (common on repeat runs),
-    the previous permission bits survive. We chmod() after the write
-    so that repeated invocations keep converging on 0600, even if a
-    stray ``chmod 644`` happened out-of-band.
+    creation. Tighten the open descriptor before writing so repeat runs also
+    converge on POSIX 0600 or the equivalent protected Windows DACL.
     """
     lines = [
         f"{k}={sanitize_dotenv_value(v, key=k)}\n"
@@ -1677,15 +1676,20 @@ def _write_dotenv(path: str, entries: dict[str, str]) -> None:
     ]
     reject_symlink(path, what="dotenv file")
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
-    fd = os.open(path, flags, 0o600)
-    with os.fdopen(fd, "w") as f:
-        f.writelines(lines)
+    fd = -1
     try:
-        os.chmod(path, 0o600)
-    except OSError:
-        # Best-effort: on some filesystems chmod is a no-op. We've
-        # already written the data, so don't fail the caller here.
-        pass
+        fd = os.open(path, flags, 0o600)
+        set_file_mode(fd, path, 0o600)
+        stream = os.fdopen(fd, "w")
+        fd = -1  # ownership transferred; stream closes on every with-path
+        with stream as f:
+            f.writelines(lines)
+    finally:
+        if fd != -1:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
 
 
 def _add_trusted_bin_prefix(prefix: str, data_dir: str) -> bool:

--- a/cli/defenseclaw/commands/cmd_setup_observability.py
+++ b/cli/defenseclaw/commands/cmd_setup_observability.py
@@ -57,6 +57,7 @@ from defenseclaw.audit_actions import ACTION_SETUP_OBSERVABILITY
 from defenseclaw.commands.redaction_status import print_redaction_status_hint
 from defenseclaw.config import locked_config_yaml, write_config_yaml_secure
 from defenseclaw.context import AppContext, pass_ctx
+from defenseclaw.file_permissions import set_file_mode
 from defenseclaw.observability import (
     PRESETS,
     Destination,
@@ -1220,16 +1221,25 @@ def _write_atomically(cfg_path: str, raw: dict[str, Any]) -> None:
     # and this config can carry HEC/OTLP tokens (F-0186).
     directory = os.path.dirname(cfg_path) or "."
     os.makedirs(directory, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(prefix=".config.", suffix=".tmp", dir=directory)
+    fd = -1
+    tmp = ""
     try:
-        os.fchmod(fd, 0o600)
-        with os.fdopen(fd, "w") as f:
+        fd, tmp = tempfile.mkstemp(prefix=".config.", suffix=".tmp", dir=directory)
+        set_file_mode(fd, tmp, 0o600)
+        stream = os.fdopen(fd, "w")
+        fd = -1  # ownership transferred; stream closes on every with-path
+        with stream as f:
             yaml.safe_dump(raw, f, default_flow_style=False, sort_keys=False)
         os.replace(tmp, cfg_path)
-    except BaseException:
-        with contextlib.suppress(OSError):
-            os.unlink(tmp)
-        raise
+        tmp = ""
+    finally:
+        if fd != -1:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        if tmp:
+            # Close first: an open CRT descriptor prevents unlink on Windows.
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
 
 
 # ---------------------------------------------------------------------------

--- a/cli/defenseclaw/commands/cmd_status.py
+++ b/cli/defenseclaw/commands/cmd_status.py
@@ -27,6 +27,7 @@ import click
 
 from defenseclaw import ux
 from defenseclaw.context import AppContext, pass_ctx
+from defenseclaw.scanner_binary import resolve_scanner_binary
 
 # ---------------------------------------------------------------------------
 # Color conventions for `defenseclaw status`
@@ -148,7 +149,7 @@ def status(app: AppContext, as_json: bool) -> None:
     for name, binary in scanner_bins:
         if binary == "built-in":
             click.echo(f"    {ux.bold(f'{name:<16s}')}{ux.dim('built-in')}")
-        elif shutil.which(binary):
+        elif resolve_scanner_binary(binary):
             click.echo(f"    {ux.bold(f'{name:<16s}')}{ux._style('installed', fg='green')}")
         else:
             click.echo(f"    {ux.bold(f'{name:<16s}')}{ux._style('not found', fg='yellow')}")
@@ -558,7 +559,7 @@ def _scanner_status_map(cfg) -> dict[str, str]:
         if binary == "built-in":
             out[name] = "built-in"
         else:
-            out[name] = "installed" if shutil.which(binary) else "not_found"
+            out[name] = "installed" if resolve_scanner_binary(binary) else "not_found"
     return out
 
 

--- a/cli/defenseclaw/file_permissions.py
+++ b/cli/defenseclaw/file_permissions.py
@@ -1,0 +1,158 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-platform file-permission helpers for secret-bearing writes."""
+
+from __future__ import annotations
+
+import os
+
+
+def set_file_mode(fd: int, path: str, mode: int) -> None:
+    """Apply *mode* to the open file described by *fd* and *path*.
+
+    POSIX uses the descriptor so the permission change cannot be redirected
+    through a path race. Windows has no :func:`os.fchmod`, and its
+    :func:`os.chmod` only toggles the read-only attribute; for owner-only
+    modes, install a protected DACL before secret bytes are written instead.
+
+    The caller must keep *fd* open for the duration of this call. Windows CRT
+    descriptors deny delete sharing, which keeps *path* bound to that file
+    while ``SetFileSecurityW`` applies the DACL.
+    """
+    if os.name == "nt":
+        if mode & 0o077 == 0:
+            _set_windows_owner_only_acl(path)
+        else:
+            os.chmod(path, mode)
+        return
+
+    fchmod = getattr(os, "fchmod", None)
+    if fchmod is not None:
+        fchmod(fd, mode)
+    else:
+        os.chmod(path, mode)
+
+
+def copy_windows_dacl(source: str, destination: str) -> None:
+    """Copy the Windows DACL from *source* to *destination*.
+
+    Atomic replacement creates a new file, so Windows ACLs do not follow the
+    old path automatically. This preserves an operator-hardened DACL (and also
+    avoids tightening a deliberately shared non-secret file) across rewrite.
+    """
+    if os.name != "nt":
+        raise OSError("Windows DACL copying is only available on Windows")
+
+    import ctypes
+    from ctypes import wintypes
+
+    dacl_security_information = 0x00000004
+    error_insufficient_buffer = 122
+
+    advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+    get_file_security = advapi32.GetFileSecurityW
+    get_file_security.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+    ]
+    get_file_security.restype = wintypes.BOOL
+
+    set_file_security = advapi32.SetFileSecurityW
+    set_file_security.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+    ]
+    set_file_security.restype = wintypes.BOOL
+
+    needed = wintypes.DWORD()
+    ctypes.set_last_error(0)
+    found = get_file_security(
+        source,
+        dacl_security_information,
+        None,
+        0,
+        ctypes.byref(needed),
+    )
+    error = ctypes.get_last_error()
+    if not found and error != error_insufficient_buffer:
+        raise ctypes.WinError(error)
+
+    descriptor = ctypes.create_string_buffer(needed.value)
+    if not get_file_security(
+        source,
+        dacl_security_information,
+        descriptor,
+        needed,
+        ctypes.byref(needed),
+    ):
+        raise ctypes.WinError(ctypes.get_last_error())
+    if not set_file_security(destination, dacl_security_information, descriptor):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+
+def _set_windows_owner_only_acl(path: str) -> None:
+    """Replace inherited access with a protected owner-full-control DACL."""
+    import ctypes
+    from ctypes import wintypes
+
+    sddl_revision_1 = 1
+    dacl_security_information = 0x00000004
+    # D:P protects the DACL from inheritance. OW is the Windows Owner Rights
+    # SID, and FA grants that owner full file access. No other ACE is present.
+    owner_only_sddl = "D:P(A;;FA;;;OW)"
+
+    advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    convert = advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW
+    convert.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.LPVOID),
+        ctypes.POINTER(wintypes.DWORD),
+    ]
+    convert.restype = wintypes.BOOL
+
+    set_file_security = advapi32.SetFileSecurityW
+    set_file_security.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+    ]
+    set_file_security.restype = wintypes.BOOL
+
+    local_free = kernel32.LocalFree
+    local_free.argtypes = [wintypes.HLOCAL]
+    local_free.restype = wintypes.HLOCAL
+
+    descriptor = wintypes.LPVOID()
+    if not convert(
+        owner_only_sddl,
+        sddl_revision_1,
+        ctypes.byref(descriptor),
+        None,
+    ):
+        raise ctypes.WinError(ctypes.get_last_error())
+    try:
+        if not set_file_security(path, dacl_security_information, descriptor):
+            raise ctypes.WinError(ctypes.get_last_error())
+    finally:
+        local_free(descriptor)

--- a/cli/defenseclaw/inventory/agent_discovery.py
+++ b/cli/defenseclaw/inventory/agent_discovery.py
@@ -70,7 +70,7 @@ VERSION_TIMEOUT_SECONDS = 2.0
 # default-trusted prefix would let the passive scan exec it. Operators
 # with bespoke install layouts extend the allow-list at runtime via the
 # ``DEFENSECLAW_TRUSTED_BIN_PREFIXES`` env var (``os.pathsep``-separated).
-_TRUSTED_BIN_PREFIXES_DEFAULT: tuple[str, ...] = (
+_TRUSTED_BIN_PREFIXES_DEFAULT_POSIX: tuple[str, ...] = (
     "/usr/bin",
     "/usr/local/bin",
     "/usr/sbin",
@@ -98,6 +98,67 @@ _TRUSTED_BIN_PREFIXES_DEFAULT: tuple[str, ...] = (
     # (``os.pathsep``-separated); the per-file/parent permission checks in
     # _is_trusted_binary_path still apply on top of any extension.
 )
+
+
+def _windows_default_trusted_bin_prefixes() -> tuple[str, ...]:
+    """Return narrow, documented Windows CLI installation roots.
+
+    Do not trust ``%LOCALAPPDATA%`` or ``%APPDATA%`` wholesale: either root can
+    contain unrelated executables.  These candidates are limited to the
+    connector and package-manager bin directories used by supported Windows
+    installers.  Admission still requires the real ACL checks below.
+    """
+    local_app_data = os.environ.get("LOCALAPPDATA", "")
+    roaming_app_data = os.environ.get("APPDATA", "")
+    home = os.path.expanduser("~")
+    program_roots = tuple(
+        path
+        for path in (
+            os.environ.get("ProgramFiles", ""),
+            os.environ.get("ProgramFiles(x86)", ""),
+        )
+        if path
+    )
+
+    candidates: list[str] = []
+    if local_app_data:
+        candidates.extend(
+            (
+                os.path.join(local_app_data, "Programs", "OpenAI", "Codex", "bin"),
+                os.path.join(local_app_data, "Programs", "cursor", "resources", "app", "bin"),
+                os.path.join(local_app_data, "Programs", "Windsurf", "bin"),
+                os.path.join(local_app_data, "Microsoft", "WinGet", "Links"),
+                os.path.join(local_app_data, "pnpm"),
+            )
+        )
+    if roaming_app_data:
+        candidates.append(os.path.join(roaming_app_data, "npm"))
+    if home:
+        candidates.extend(
+            (
+                os.path.join(home, ".local", "bin"),
+                os.path.join(home, ".opencode", "bin"),
+                os.path.join(home, "scoop", "shims"),
+            )
+        )
+    for root in program_roots:
+        candidates.extend(
+            (
+                os.path.join(root, "OpenAI", "Codex", "bin"),
+                os.path.join(root, "cursor", "resources", "app", "bin"),
+                os.path.join(root, "Windsurf", "bin"),
+            )
+        )
+    return tuple(candidates)
+
+
+_TRUSTED_BIN_PREFIXES_DEFAULT: tuple[str, ...] = (
+    _windows_default_trusted_bin_prefixes()
+    if os.name == "nt"
+    else _TRUSTED_BIN_PREFIXES_DEFAULT_POSIX
+)
+
+_WINDOWS_EXECUTABLE_EXTENSIONS = frozenset({".com", ".exe", ".bat", ".cmd"})
 
 DISCOVERY_PRECEDENCE: tuple[str, ...] = (
     "codex",
@@ -321,8 +382,30 @@ def _trusted_bin_prefixes() -> tuple[str, ...]:
     return tuple(_expand_bin_prefixes((*_TRUSTED_BIN_PREFIXES_DEFAULT, *extras)))
 
 
+def _path_key(path: str) -> str:
+    """Return the platform comparison key for an already-absolute path."""
+    return os.path.normcase(os.path.normpath(path))
+
+
+def _is_filesystem_root(path: str) -> bool:
+    anchor = Path(path).anchor
+    return bool(anchor) and _path_key(path) == _path_key(anchor)
+
+
+def _path_is_within(path: str, prefix: str) -> bool:
+    """Compare canonical paths with component and Windows case semantics."""
+    path_key = _path_key(path)
+    prefix_key = _path_key(prefix)
+    try:
+        return os.path.commonpath((path_key, prefix_key)) == prefix_key
+    except ValueError:
+        # Different Windows drives (or a malformed path) have no common path.
+        return False
+
+
 def _expand_bin_prefixes(prefixes: tuple[str, ...]) -> list[str]:
     expanded: list[str] = []
+    seen: set[str] = set()
     for prefix in prefixes:
         try:
             # Binary admission compares against the binary's realpath, so
@@ -337,13 +420,12 @@ def _expand_bin_prefixes(prefixes: tuple[str, ...]) -> list[str]:
         # `/` matches every absolute path, and `""` would normalize to
         # the current working directory which an attacker can pivot via
         # `cd`. The allow-list must name a real installation root.
-        normalized = absolute.rstrip(os.sep)
-        if normalized in ("", os.sep.rstrip(os.sep)):
+        if _is_filesystem_root(absolute):
             continue
-        # Require at least one path component below the filesystem
-        # root — `/usr` is fine, `/` is not.
-        if absolute.count(os.sep) < 1 or normalized == "":
+        key = _path_key(absolute)
+        if not key or key in seen:
             continue
+        seen.add(key)
         expanded.append(absolute)
     return expanded
 
@@ -392,6 +474,214 @@ def _bin_chain_is_system_owned(resolved: str, prefix: str) -> bool:
             break
         current = parent
     return True
+
+
+def _windows_acl_snapshot(path: str) -> tuple[str, bool, list[tuple[int, int, int, str]]]:
+    """Return ``(owner_sid, null_dacl, access_entries)`` for *path*.
+
+    ``os.stat().st_mode`` on Windows is synthesized from DOS attributes and
+    cannot answer who may replace an executable.  Read the owner and DACL from
+    the Win32 security descriptor instead.  The ctypes declarations stay
+    local so importing this module remains safe on Unix.
+    """
+    if os.name != "nt":  # pragma: no cover - guarded by Windows callers
+        raise OSError("Windows ACLs are unavailable on this platform")
+
+    import ctypes  # noqa: PLC0415
+    from ctypes import wintypes  # noqa: PLC0415
+
+    class _TrusteeW(ctypes.Structure):
+        pass
+
+    _TrusteeW._fields_ = [
+        ("pMultipleTrustee", ctypes.POINTER(_TrusteeW)),
+        ("MultipleTrusteeOperation", wintypes.DWORD),
+        ("TrusteeForm", wintypes.DWORD),
+        ("TrusteeType", wintypes.DWORD),
+        # For TRUSTEE_IS_SID this is a PSID, not a string pointer.
+        ("ptstrName", ctypes.c_void_p),
+    ]
+
+    class _ExplicitAccessW(ctypes.Structure):
+        _fields_ = [
+            ("grfAccessPermissions", wintypes.DWORD),
+            ("grfAccessMode", wintypes.DWORD),
+            ("grfInheritance", wintypes.DWORD),
+            ("Trustee", _TrusteeW),
+        ]
+
+    advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    get_security = advapi32.GetNamedSecurityInfoW
+    get_security.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    get_security.restype = wintypes.DWORD
+
+    get_entries = advapi32.GetExplicitEntriesFromAclW
+    get_entries.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(wintypes.ULONG),
+        ctypes.POINTER(ctypes.POINTER(_ExplicitAccessW)),
+    ]
+    get_entries.restype = wintypes.DWORD
+
+    sid_to_string = advapi32.ConvertSidToStringSidW
+    sid_to_string.argtypes = [ctypes.c_void_p, ctypes.POINTER(wintypes.LPWSTR)]
+    sid_to_string.restype = wintypes.BOOL
+
+    local_free = kernel32.LocalFree
+    local_free.argtypes = [ctypes.c_void_p]
+    local_free.restype = ctypes.c_void_p
+
+    def _sid_string(sid: int | None) -> str:
+        if not sid:
+            return ""
+        value = wintypes.LPWSTR()
+        if not sid_to_string(ctypes.c_void_p(sid), ctypes.byref(value)):
+            raise ctypes.WinError(ctypes.get_last_error())
+        try:
+            return value.value or ""
+        finally:
+            local_free(ctypes.cast(value, ctypes.c_void_p))
+
+    owner = ctypes.c_void_p()
+    dacl = ctypes.c_void_p()
+    descriptor = ctypes.c_void_p()
+    # SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION
+    result = get_security(
+        path,
+        1,
+        0x00000001 | 0x00000004,
+        ctypes.byref(owner),
+        None,
+        ctypes.byref(dacl),
+        None,
+        ctypes.byref(descriptor),
+    )
+    if result:
+        raise OSError(result, ctypes.FormatError(result), path)
+
+    entries_ptr = ctypes.POINTER(_ExplicitAccessW)()
+    try:
+        owner_sid = _sid_string(owner.value)
+        if not dacl.value:
+            return owner_sid, True, []
+
+        count = wintypes.ULONG()
+        result = get_entries(dacl, ctypes.byref(count), ctypes.byref(entries_ptr))
+        if result:
+            raise OSError(result, ctypes.FormatError(result), path)
+
+        entries: list[tuple[int, int, int, str]] = []
+        for index in range(count.value):
+            entry = entries_ptr[index]
+            # GetExplicitEntriesFromAcl normally returns SID trustees.  An
+            # unknown form with write rights is retained as an empty identity
+            # and rejected conservatively by the caller.
+            sid = (
+                _sid_string(entry.Trustee.ptstrName)
+                if entry.Trustee.TrusteeForm == 0
+                else ""
+            )
+            entries.append(
+                (
+                    int(entry.grfAccessPermissions),
+                    int(entry.grfAccessMode),
+                    int(entry.grfInheritance),
+                    sid,
+                )
+            )
+        return owner_sid, False, entries
+    finally:
+        if entries_ptr:
+            local_free(ctypes.cast(entries_ptr, ctypes.c_void_p))
+        if descriptor.value:
+            local_free(descriptor)
+
+
+def _windows_acl_write_error(path: str) -> str | None:
+    """Return a refusal when an untrusted Windows principal may write *path*."""
+    try:
+        owner_sid, null_dacl, entries = _windows_acl_snapshot(path)
+    except OSError as exc:
+        return f"cannot read Windows ACL ({exc})"
+
+    if null_dacl:
+        return "ACL grants write access to untrusted principal Everyone (null DACL)"
+
+    # The object owner plus the two privileged Windows control principals may
+    # retain write/full-control.  Other principals may read and execute, but
+    # must not be able to replace the binary or change its DACL/owner.
+    trusted_controllers = {
+        "S-1-3-4",  # OWNER RIGHTS (the descriptor's owner only)
+        "S-1-5-18",  # LocalSystem
+        "S-1-5-32-544",  # BUILTIN\Administrators
+    }
+    if owner_sid:
+        trusted_controllers.add(owner_sid)
+    write_mask = (
+        0x00000002  # FILE_WRITE_DATA / FILE_ADD_FILE
+        | 0x00000004  # FILE_APPEND_DATA / FILE_ADD_SUBDIRECTORY
+        | 0x00000010  # FILE_WRITE_EA
+        | 0x00000040  # FILE_DELETE_CHILD
+        | 0x00000100  # FILE_WRITE_ATTRIBUTES
+        | 0x00010000  # DELETE
+        | 0x00040000  # WRITE_DAC
+        | 0x00080000  # WRITE_OWNER
+        | 0x10000000  # GENERIC_ALL
+        | 0x40000000  # GENERIC_WRITE
+    )
+    sid_labels = {
+        "": "unknown trustee",
+        "S-1-1-0": "Everyone",
+        "S-1-3-0": "CREATOR OWNER",
+        "S-1-5-11": "Authenticated Users",
+        "S-1-5-32-545": "BUILTIN\\Users",
+    }
+    for permissions, access_mode, inheritance, sid in entries:
+        # GRANT_ACCESS and SET_ACCESS are the allow modes emitted by
+        # GetExplicitEntriesFromAcl.  Deny/audit entries do not grant writes.
+        if access_mode not in (1, 2) or not (permissions & write_mask):
+            continue
+        if sid in trusted_controllers:
+            continue
+        # CREATOR OWNER on an inherit-only ACE becomes the already-trusted
+        # owner of a newly created child; it grants nothing on this directory.
+        if sid == "S-1-3-0" and inheritance & 0x08:  # INHERIT_ONLY_ACE
+            continue
+        principal = sid_labels.get(sid, sid)
+        return f"ACL grants write access to untrusted principal {principal}"
+    return None
+
+
+def _windows_acl_chain_is_safe(resolved: str, prefix: str) -> bool:
+    """Check the executable and every ancestor through its trusted prefix."""
+    current = resolved
+    prefix_key = _path_key(prefix)
+    seen: set[str] = set()
+    while current:
+        key = _path_key(current)
+        if key in seen:
+            return False
+        seen.add(key)
+        if _windows_acl_write_error(current) is not None:
+            return False
+        if key == prefix_key:
+            return True
+        parent = os.path.dirname(current)
+        if parent == current:
+            return False
+        current = parent
+    return False
 
 
 def _trusted_prefix_dir_mode_error(st: os.stat_result) -> str | None:
@@ -453,7 +743,11 @@ def validate_trusted_prefix(path: str) -> tuple[str, str | None]:
         return resolved, f"cannot stat path ({exc})"
     if not os.path.isdir(resolved):
         return resolved, "path is not a directory"
-    mode_err = _trusted_prefix_dir_mode_error(st)
+    mode_err = (
+        _windows_acl_write_error(resolved)
+        if os.name == "nt"
+        else _trusted_prefix_dir_mode_error(st)
+    )
     if mode_err:
         return resolved, mode_err
     return resolved, None
@@ -478,48 +772,56 @@ def _is_trusted_binary_path(binary_path: str) -> bool:
         return False
     if not os.path.isfile(resolved):
         return False
-    if not os.access(resolved, os.X_OK):
-        return False
-    parent = os.path.dirname(resolved)
-    try:
-        parent_st = os.stat(parent)
-    except OSError:
-        return False
-    # World-writable parent → an attacker who can write to that dir
-    # could swap the binary at any time. Treat as untrusted.
-    if parent_st.st_mode & 0o002:
-        return False
-    # also reject group-writable parents unless the
-    # group is the system root group. A non-root user that shares a
-    # group with the parent dir can swap the binary.
-    if parent_st.st_mode & 0o020:
-        grp_name = ""
-        if _grp is not None:
-            try:
-                grp_name = _grp.getgrgid(parent_st.st_gid).gr_name
-            except (KeyError, OSError):
-                grp_name = ""
-        if grp_name not in ("root", "wheel", "admin"):
+    if os.name == "nt":
+        if os.path.splitext(resolved)[1].lower() not in _WINDOWS_EXECUTABLE_EXTENSIONS:
             return False
-    # refuse a binary whose own file is writable by
-    # anyone other than the trusted system owner. The user-writable
-    # ~/.local/bin/* case is the canonical exploit path; even if an
-    # operator extends DEFENSECLAW_TRUSTED_BIN_PREFIXES to include it,
-    # we still refuse the individual file when its mode bits expose
-    # group/world write.
-    try:
-        bin_st = os.stat(resolved)
-    except OSError:
-        return False
-    if bin_st.st_mode & 0o022:
-        return False
+    else:
+        if not os.access(resolved, os.X_OK):
+            return False
+        parent = os.path.dirname(resolved)
+        try:
+            parent_st = os.stat(parent)
+        except OSError:
+            return False
+        # World-writable parent → an attacker who can write to that dir
+        # could swap the binary at any time. Treat as untrusted.
+        if parent_st.st_mode & 0o002:
+            return False
+        # also reject group-writable parents unless the
+        # group is the system root group. A non-root user that shares a
+        # group with the parent dir can swap the binary.
+        if parent_st.st_mode & 0o020:
+            grp_name = ""
+            if _grp is not None:
+                try:
+                    grp_name = _grp.getgrgid(parent_st.st_gid).gr_name
+                except (KeyError, OSError):
+                    grp_name = ""
+            if grp_name not in ("root", "wheel", "admin"):
+                return False
+        # refuse a binary whose own file is writable by
+        # anyone other than the trusted system owner. The user-writable
+        # ~/.local/bin/* case is the canonical exploit path; even if an
+        # operator extends DEFENSECLAW_TRUSTED_BIN_PREFIXES to include it,
+        # we still refuse the individual file when its mode bits expose
+        # group/world write.
+        try:
+            bin_st = os.stat(resolved)
+        except OSError:
+            return False
+        if bin_st.st_mode & 0o022:
+            return False
     prefixes = _trusted_bin_prefixes()
     default_prefixes = _default_trusted_bin_prefixes()
     for prefix in prefixes:
         # Both the resolved binary and the candidate need to share a
         # path-component boundary; suffix-string match would let
         # /usr/binEvil sneak past /usr/bin.
-        if resolved == prefix or resolved.startswith(prefix.rstrip(os.sep) + os.sep):
+        if _path_is_within(resolved, prefix):
+            if os.name == "nt":
+                if not _windows_acl_chain_is_safe(resolved, prefix):
+                    continue
+                return True
             # F-0421: built-in default prefixes additionally require the
             # resolved binary and its parent chain (up to the prefix) to be
             # root-owned. A user-owned, owner-writable binary under a
@@ -533,6 +835,13 @@ def _is_trusted_binary_path(binary_path: str) -> bool:
     return False
 
 
+def _binary_command_name(binary_path: str) -> str:
+    """Normalize a CLI basename, stripping Windows executable wrappers."""
+    name = os.path.basename(binary_path).lower()
+    stem, extension = os.path.splitext(name)
+    return stem if extension in _WINDOWS_EXECUTABLE_EXTENSIONS else name
+
+
 def _version_for_binary(binary_path: str, version_args: tuple[str, ...]) -> tuple[str, str]:
     # M-4: the value of ``binary_path`` is sourced from
     # ``shutil.which(binary_name)`` which honours $PATH — an attacker
@@ -541,10 +850,10 @@ def _version_for_binary(binary_path: str, version_args: tuple[str, ...]) -> tupl
     # anything outside the canonical install prefixes.
     if not _is_trusted_binary_path(binary_path):
         return "", UNTRUSTED_PREFIX_ERROR
-    binary_name = os.path.basename(binary_path).lower()
+    binary_name = _binary_command_name(binary_path)
     env = None
     timeout = VERSION_TIMEOUT_SECONDS
-    if binary_name in {"hermes", "openhands"}:
+    if binary_name in {"claude", "hermes", "openhands"}:
         timeout = 8.0
     if binary_name == "openhands":
         env = {**os.environ, "OPENHANDS_SUPPRESS_BANNER": "1"}
@@ -578,7 +887,7 @@ def _version_line_for_binary(binary_path: str, stdout: str) -> str:
     lines = [line.strip() for line in stdout.splitlines() if line.strip()]
     if not lines:
         return ""
-    binary_name = os.path.basename(binary_path).lower()
+    binary_name = _binary_command_name(binary_path)
     if binary_name == "openhands":
         for line in reversed(lines):
             if "openhands cli" in line.lower():

--- a/cli/defenseclaw/inventory/claw_inventory.py
+++ b/cli/defenseclaw/inventory/claw_inventory.py
@@ -33,6 +33,7 @@ from typing import Any, NamedTuple
 
 from defenseclaw import connector_paths
 from defenseclaw.config import Config, SkillActionsConfig, _expand
+from defenseclaw.inventory.plugin_directories import plugin_directory_entries
 from defenseclaw.models import ActionEntry, Finding, ScanResult
 
 INVENTORY_VERSION = 3
@@ -2204,20 +2205,7 @@ def _enumerate_plugins_filesystem(
     rows: list[dict[str, Any]] = []
     seen: set[str] = set()
     for plugin_dir in cfg.plugin_dirs(connector):
-        if not os.path.isdir(plugin_dir):
-            continue
-        try:
-            entries = os.listdir(plugin_dir)
-        except OSError:
-            continue
-        for entry in sorted(entries):
-            if entry == "cache":
-                # Codex / ZeptoClaw use a "cache" sibling for transient
-                # downloads; not a plugin in its own right.
-                continue
-            full = os.path.join(plugin_dir, entry)
-            if not os.path.isdir(full):
-                continue
+        for entry, full in plugin_directory_entries(plugin_dir):
             if entry in seen:
                 continue
             seen.add(entry)

--- a/cli/defenseclaw/inventory/plugin_directories.py
+++ b/cli/defenseclaw/inventory/plugin_directories.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared filtering for filesystem-backed plugin inventories."""
+
+from __future__ import annotations
+
+import os
+
+
+def plugin_directory_entries(root: str) -> list[tuple[str, str]]:
+    """Return eligible immediate plugin directories under *root*.
+
+    Connector plugin roots also contain transient download caches and hidden
+    activation/staging directories. Those entries are implementation details,
+    not enabled plugins, so every inventory surface must exclude them.
+    """
+    if not os.path.isdir(root):
+        return []
+    try:
+        entries = sorted(os.listdir(root))
+    except OSError:
+        return []
+
+    eligible: list[tuple[str, str]] = []
+    for entry in entries:
+        if entry == "cache" or entry.startswith("."):
+            continue
+        path = os.path.join(root, entry)
+        if os.path.isdir(path):
+            eligible.append((entry, path))
+    return eligible

--- a/cli/defenseclaw/migrations.py
+++ b/cli/defenseclaw/migrations.py
@@ -50,6 +50,7 @@ from dataclasses import dataclass, field
 import click
 
 from defenseclaw import ux
+from defenseclaw.file_permissions import copy_windows_dacl, set_file_mode
 
 
 def _ver_tuple(v: str) -> tuple[int, ...]:
@@ -1060,7 +1061,10 @@ def _atomic_write_text(path: str, body: str, *, mode: int = 0o644) -> bool:
             suffix=os.path.basename(path) or ".tmp",
             dir=parent,
         )
-        os.fchmod(fd, effective_mode)
+        if os.name == "nt" and mode > 0o600 and os.path.exists(path):
+            copy_windows_dacl(path, tmp_path)
+        else:
+            set_file_mode(fd, tmp_path, effective_mode)
         # newline="" writes ``body`` byte-for-byte (no \n -> os.linesep
         # translation), so a caller that preserved a file's CRLF endings
         # does not get them doubled to \r\r\n on Windows.

--- a/cli/defenseclaw/observability/writer.py
+++ b/cli/defenseclaw/observability/writer.py
@@ -46,6 +46,7 @@ from urllib.parse import urlparse
 import yaml
 
 from defenseclaw.config import locked_config_yaml, write_config_yaml_secure
+from defenseclaw.file_permissions import set_file_mode
 from defenseclaw.observability.presets import Preset, Signal, resolve_preset
 from defenseclaw.safety import sanitize_dotenv_value
 
@@ -1313,19 +1314,20 @@ def _write_dotenv(path: str, entries: dict[str, str]) -> None:
     # O_NOFOLLOW (where available) refuses to open through a symlink so a
     # pre-planted symlink cannot redirect the secret write elsewhere.
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
-    fd = os.open(path, flags, 0o600)
-    with os.fdopen(fd, "w") as f:
+    fd = -1
+    try:
+        fd = os.open(path, flags, 0o600)
         # The 0o600 mode argument to os.open only applies when the file is
-        # newly CREATED — POSIX preserves the existing mode on O_TRUNC. A
-        # pre-existing group/world-readable dotenv would otherwise keep
-        # its loose perms and expose the freshly written observability
-        # token (F-0442), so explicitly tighten the descriptor to 0o600.
-        try:
-            os.fchmod(f.fileno(), 0o600)
-        except (AttributeError, OSError):
-            # os.fchmod is POSIX-only; fall back to a path-based chmod.
+        # newly CREATED. Tighten existing files too, and on Windows replace
+        # inherited access with a real owner-only DACL before writing secrets.
+        set_file_mode(fd, path, 0o600)
+        stream = os.fdopen(fd, "w")
+        fd = -1  # ownership transferred; stream closes on every with-path
+        with stream as f:
+            f.writelines(lines)
+    finally:
+        if fd != -1:
             try:
-                os.chmod(path, 0o600)
+                os.close(fd)
             except OSError:
                 pass
-        f.writelines(lines)

--- a/cli/defenseclaw/platform_support.py
+++ b/cli/defenseclaw/platform_support.py
@@ -10,72 +10,188 @@
 
 """Per-OS connector support — the Python single source of truth.
 
-DefenseClaw runs hook-only on Windows: agents invoke the native Go hook
-entrypoint (``defenseclaw hook``) directly, and there is no Windows
-guardrail-proxy lifecycle. The proxy/chat connectors (``openclaw`` and
-``zeptoclaw``) therefore cannot run on Windows, so the TUI/CLI must not
-offer or accept them there.
+Windows support is not a boolean derived from connector topology.  A native
+agent/runtime and a DefenseClaw integration that can be wired without WSL are
+both required.  The resulting status is one of ``supported``, ``preview``, or
+``unsupported`` and always carries an operator-facing reason.
 
-This module mirrors the Go ``connector.proxyConnectors`` set in
-``internal/gateway/connector/platform_support.go``; a parity test pins the
-two together so the lists cannot drift.
-
-Filtering is a pure no-op on non-Windows hosts, so callers can apply it
-unconditionally at presentation/validation points without changing
-behavior on macOS or Linux.
+This module mirrors ``internal/gateway/connector/platform_support.go``.  Tests
+pin the two taxonomies and all Python presentation lists together.  macOS and
+Linux retain their historical behavior: every built-in and plugin connector is
+offered there.
 """
 
 from __future__ import annotations
 
 import sys
 from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
 
-# Proxy/chat connectors that require the local guardrail proxy. These are
-# the only connectors unsupported on Windows. Keep in sync with the Go
-# ``proxyConnectors`` map.
-WINDOWS_UNSUPPORTED_CONNECTORS: frozenset[str] = frozenset({"openclaw", "zeptoclaw"})
+SupportStatus = Literal["supported", "preview", "unsupported"]
+
+SUPPORTED: SupportStatus = "supported"
+PREVIEW: SupportStatus = "preview"
+UNSUPPORTED: SupportStatus = "unsupported"
+
+PROXY_CONNECTORS: frozenset[str] = frozenset({"openclaw", "zeptoclaw"})
+
+
+@dataclass(frozen=True)
+class ConnectorPlatformSupport:
+    """Support classification for one connector on one operating system."""
+
+    status: SupportStatus
+    reason: str
+
+    @property
+    def available(self) -> bool:
+        """Whether setup/presentation may offer this connector."""
+        return self.status != UNSUPPORTED
+
+
+# Keep in exact parity with the Go ``windowsConnectorSupport`` map.  Cursor is
+# intentionally supported because DefenseClaw configures Cursor IDE hooks; the
+# separate ``cursor-agent`` CLI remains WSL-only and is not installed or wired
+# by native Windows setup.
+WINDOWS_CONNECTOR_SUPPORT: dict[str, ConnectorPlatformSupport] = {
+    "codex": ConnectorPlatformSupport(
+        SUPPORTED,
+        "Codex CLI and the DefenseClaw hook entrypoint run natively on Windows.",
+    ),
+    "claudecode": ConnectorPlatformSupport(
+        SUPPORTED,
+        "Claude Code supports native Windows with Git for Windows and native hooks.",
+    ),
+    "cursor": ConnectorPlatformSupport(
+        SUPPORTED,
+        "Cursor IDE hooks run natively on Windows; Cursor CLI remains WSL-only.",
+    ),
+    "windsurf": ConnectorPlatformSupport(
+        SUPPORTED,
+        "Windsurf documents native Windows Cascade hooks.",
+    ),
+    "geminicli": ConnectorPlatformSupport(
+        SUPPORTED,
+        "Gemini CLI documents native Windows command hooks and PowerShell execution.",
+    ),
+    "copilot": ConnectorPlatformSupport(
+        SUPPORTED,
+        "GitHub Copilot CLI documents Windows hook execution through PowerShell.",
+    ),
+    "antigravity": ConnectorPlatformSupport(
+        SUPPORTED,
+        "Antigravity runs natively on Windows and exposes local JSON hooks.",
+    ),
+    "opencode": ConnectorPlatformSupport(
+        SUPPORTED,
+        "OpenCode runs directly on Windows and loads the JavaScript bridge plugin without shell shims.",
+    ),
+    "hermes": ConnectorPlatformSupport(
+        PREVIEW,
+        "Hermes labels native Windows support Early Beta; setup is available as a preview.",
+    ),
+    "openhands": ConnectorPlatformSupport(
+        UNSUPPORTED,
+        "OpenHands CLI requires WSL; DefenseClaw does not implement a WSL connector path.",
+    ),
+    "omnigent": ConnectorPlatformSupport(
+        UNSUPPORTED,
+        "OmniGent has no supported native Windows terminal/sandbox path for this connector.",
+    ),
+    "openclaw": ConnectorPlatformSupport(
+        UNSUPPORTED,
+        "DefenseClaw on Windows is hook-only; OpenClaw integration requires the guardrail proxy.",
+    ),
+    "zeptoclaw": ConnectorPlatformSupport(
+        UNSUPPORTED,
+        "ZeptoClaw publishes macOS/Linux builds and its DefenseClaw integration requires the guardrail proxy.",
+    ),
+}
+
+WINDOWS_SUPPORTED_CONNECTORS: frozenset[str] = frozenset(
+    name for name, support in WINDOWS_CONNECTOR_SUPPORT.items() if support.status == SUPPORTED
+)
+WINDOWS_PREVIEW_CONNECTORS: frozenset[str] = frozenset(
+    name for name, support in WINDOWS_CONNECTOR_SUPPORT.items() if support.status == PREVIEW
+)
+WINDOWS_UNSUPPORTED_CONNECTORS: frozenset[str] = frozenset(
+    name for name, support in WINDOWS_CONNECTOR_SUPPORT.items() if support.status == UNSUPPORTED
+)
 
 
 def host_os() -> str:
-    """Return a Go-``GOOS``-style token for the current host.
+    """Return a Go-``GOOS``-style token for the current host."""
+    return _normalize_os_name(sys.platform)
 
-    Normalizes ``sys.platform`` to ``"windows"`` / ``"darwin"`` / ``"linux"``
-    so the same string compares cleanly against the Go side and against the
-    ``os_name`` arguments below.
-    """
-    plat = sys.platform
-    if plat.startswith("win"):
+
+def _normalize_os_name(os_name: str) -> str:
+    value = (os_name or "").strip().lower()
+    if value.startswith("win"):
         return "windows"
-    if plat == "darwin":
+    if value == "darwin":
         return "darwin"
-    if plat.startswith("linux"):
+    if value.startswith("linux"):
         return "linux"
-    return plat
+    return value
 
 
 def is_proxy_connector(name: str) -> bool:
     """Report whether *name* is a proxy/chat connector."""
-    return name in WINDOWS_UNSUPPORTED_CONNECTORS
+    return name in PROXY_CONNECTORS
+
+
+def connector_platform_support(
+    name: str,
+    os_name: str | None = None,
+) -> ConnectorPlatformSupport:
+    """Return the status and reason for *name* on *os_name*.
+
+    Unknown/plugin connectors preserve the pre-Windows-gate behavior and are
+    treated as supported.  Plugin-specific validation remains the plugin's
+    responsibility.
+    """
+    resolved_os = host_os() if os_name is None else _normalize_os_name(os_name)
+    if resolved_os == "windows":
+        return WINDOWS_CONNECTOR_SUPPORT.get(
+            name,
+            ConnectorPlatformSupport(
+                SUPPORTED,
+                "No native Windows restriction is registered for this plugin connector.",
+            ),
+        )
+    return ConnectorPlatformSupport(
+        SUPPORTED,
+        f"Connector setup is supported on {resolved_os or 'this platform'}.",
+    )
+
+
+def connector_support_status(name: str, os_name: str | None = None) -> SupportStatus:
+    """Return only the support status for presentation/serialization."""
+    return connector_platform_support(name, os_name).status
+
+
+def connector_support_reason(name: str, os_name: str | None = None) -> str:
+    """Return the operator-facing reason for the connector's status."""
+    return connector_platform_support(name, os_name).reason
 
 
 def connector_supported_on_os(name: str, os_name: str | None = None) -> bool:
-    """Report whether connector *name* can be offered/used on *os_name*.
+    """Report whether *name* may be offered/used on *os_name*.
 
-    Every hook-based connector is supported on every OS; the proxy
-    connectors are unsupported on Windows. *os_name* defaults to the host
-    OS but is injectable so tests can assert behavior for any platform.
+    Preview connectors are deliberately available; unsupported connectors are
+    hidden from pickers and rejected by explicit setup commands.
     """
-    if os_name is None:
-        os_name = host_os()
-    if os_name == "windows" and name in WINDOWS_UNSUPPORTED_CONNECTORS:
-        return False
-    return True
+    return connector_platform_support(name, os_name).available
+
+
+def connector_preview_on_os(name: str, os_name: str | None = None) -> bool:
+    """Report whether *name* is available as a preview on *os_name*."""
+    return connector_support_status(name, os_name) == PREVIEW
 
 
 def supported_connectors(
     names: Iterable[str], os_name: str | None = None
 ) -> list[str]:
-    """Filter *names* down to those supported on *os_name*, preserving order."""
-    if os_name is None:
-        os_name = host_os()
+    """Filter *names* to supported/preview entries, preserving order."""
     return [n for n in names if connector_supported_on_os(n, os_name)]

--- a/cli/defenseclaw/scanner_binary.py
+++ b/cli/defenseclaw/scanner_binary.py
@@ -1,0 +1,44 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve scanner executables installed with the DefenseClaw CLI."""
+
+from __future__ import annotations
+
+import shutil
+import sysconfig
+
+
+def resolve_scanner_binary(binary: str) -> str | None:
+    """Return a scanner executable path, preferring this Python environment.
+
+    Release installs put DefenseClaw and its scanner dependencies in the same
+    virtual environment. Its scripts directory is not intentionally added to
+    ``PATH`` on Windows, so check that managed location first (``Scripts`` on
+    Windows, ``bin`` on Unix) and retain the normal ``PATH`` lookup as a
+    fallback for operator-supplied installations.
+    """
+    command = str(binary or "").strip()
+    if not command:
+        return None
+
+    scripts_dir = sysconfig.get_path("scripts")
+    if scripts_dir:
+        managed = shutil.which(command, path=scripts_dir)
+        if managed:
+            return managed
+
+    return shutil.which(command)

--- a/cli/defenseclaw/tui/app.py
+++ b/cli/defenseclaw/tui/app.py
@@ -40,7 +40,11 @@ from defenseclaw.tui.command_line import (
     parse_command_line,
     suggested_next_action,
 )
-from defenseclaw.tui.executor import CommandAlreadyRunningError, CommandExecutor
+from defenseclaw.tui.executor import (
+    CommandAlreadyRunningError,
+    CommandExecutor,
+    resolve_subprocess_argv,
+)
 from defenseclaw.tui.models import HintState, ServiceStatus, StatusModel
 from defenseclaw.tui.panels.activity import ActivityPanelModel
 from defenseclaw.tui.panels.ai_discovery import AIDiscoveryPanelModel, AIUsageSnapshot
@@ -3833,8 +3837,7 @@ class DefenseClawTUI(App[None]):
         try:
             try:
                 proc = await asyncio.create_subprocess_exec(
-                    "defenseclaw",
-                    "doctor",
+                    *resolve_subprocess_argv("defenseclaw", ("doctor",)),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.STDOUT,
                 )
@@ -8868,10 +8871,10 @@ class DefenseClawTUI(App[None]):
     async def _load_setup_credentials(self) -> None:
         try:
             process = await asyncio.create_subprocess_exec(
-                "defenseclaw",
-                "keys",
-                "list",
-                "--json",
+                *resolve_subprocess_argv(
+                    "defenseclaw",
+                    ("keys", "list", "--json"),
+                ),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -8909,8 +8912,7 @@ class DefenseClawTUI(App[None]):
         self._set_status(intent.hint or "Loading inventory...")
         try:
             process = await asyncio.create_subprocess_exec(
-                intent.binary,
-                *intent.args,
+                *resolve_subprocess_argv(intent.binary, intent.args),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -8947,8 +8949,7 @@ class DefenseClawTUI(App[None]):
             intent = self.inventory_model.load_intent_for(name)
             try:
                 process = await asyncio.create_subprocess_exec(
-                    intent.binary,
-                    *intent.args,
+                    *resolve_subprocess_argv(intent.binary, intent.args),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -9180,8 +9181,7 @@ class DefenseClawTUI(App[None]):
         self._set_status(intent.hint or f"Loading {panel}...")
         try:
             process = await asyncio.create_subprocess_exec(
-                intent.binary,
-                *intent.args,
+                *resolve_subprocess_argv(intent.binary, intent.args),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -9217,8 +9217,7 @@ class DefenseClawTUI(App[None]):
             intent = model.load_intent_for(name)
             try:
                 process = await asyncio.create_subprocess_exec(
-                    intent.binary,
-                    *intent.args,
+                    *resolve_subprocess_argv(intent.binary, intent.args),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )

--- a/cli/defenseclaw/tui/executor.py
+++ b/cli/defenseclaw/tui/executor.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import ntpath
 import os
 import signal
+import sys
 import time
 
 if os.name == "posix":
@@ -99,7 +101,7 @@ class CommandExecutor:
         if self._process is not None:
             raise CommandAlreadyRunningError("A command is already running.")
 
-        resolved = _resolve_binary(binary)
+        resolved_argv = resolve_subprocess_argv(binary, args)
         started = time.monotonic()
         self._cancelled = False
         child_env = os.environ.copy()
@@ -108,14 +110,13 @@ class CommandExecutor:
         yield CommandEvent("start", " ".join((binary, *args)))
 
         if self.use_pty and stdin_input is None:
-            async for event in self._run_pty(resolved, args, started, env=child_env):
+            async for event in self._run_pty(resolved_argv, started, env=child_env):
                 yield event
             return
 
         try:
             process = await asyncio.create_subprocess_exec(
-                resolved,
-                *args,
+                *resolved_argv,
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
@@ -149,8 +150,7 @@ class CommandExecutor:
 
     async def _run_pty(
         self,
-        resolved: str,
-        args: tuple[str, ...],
+        resolved_argv: tuple[str, ...],
         started: float,
         *,
         env: dict[str, str] | None = None,
@@ -160,8 +160,7 @@ class CommandExecutor:
         try:
             master_fd, slave_fd = pty.openpty()
             process = await asyncio.create_subprocess_exec(
-                resolved,
-                *args,
+                *resolved_argv,
                 stdin=slave_fd,
                 stdout=slave_fd,
                 stderr=slave_fd,
@@ -206,10 +205,24 @@ class CommandExecutor:
         yield CommandEvent("done", exit_code=exit_code, duration=duration)
 
 
-def _resolve_binary(binary: str) -> str:
+def resolve_subprocess_argv(binary: str, args: tuple[str, ...]) -> tuple[str, ...]:
+    """Resolve a TUI command to argv that Windows can launch directly.
+
+    Console-script shims on Windows are commonly ``.cmd`` files.  The low-level
+    process API used by ``asyncio.create_subprocess_exec`` does not invoke a
+    command interpreter, so it cannot execute those shims.  Self-invocations
+    always use the current Python interpreter and module entry point instead;
+    this also avoids relying on PATH on every platform.
+    """
+
+    binary_name = ntpath.basename(binary).lower()
+    if binary_name in {"defenseclaw", "defenseclaw.exe", "defenseclaw.cmd", "defenseclaw.bat"}:
+        if not sys.executable:
+            raise RuntimeError("Cannot resolve DefenseClaw CLI: Python executable is unknown")
+        return (os.path.abspath(sys.executable), "-m", "defenseclaw.main", *args)
     if binary == "defenseclaw-gateway":
-        return resolve_gateway_binary() or "defenseclaw-gateway"
-    return binary
+        return (resolve_gateway_binary() or "defenseclaw-gateway", *args)
+    return (binary, *args)
 
 
 def _split_terminal_chunk(text: str) -> tuple[str, ...]:

--- a/cli/defenseclaw/tui/panels/first_run.py
+++ b/cli/defenseclaw/tui/panels/first_run.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-from defenseclaw.platform_support import supported_connectors
+from defenseclaw.platform_support import connector_preview_on_os, supported_connectors
 from defenseclaw.tui.services.setup_state import SetupCommandIntent
 
 FirstRunKind = Literal["choice", "bool"]
@@ -41,8 +41,7 @@ CONNECTOR_CHOICES: tuple[str, ...] = (
 def visible_connector_choices(os_name: str | None = None) -> tuple[str, ...]:
     """``CONNECTOR_CHOICES`` supported on *os_name*.
 
-    Drops proxy connectors (openclaw/zeptoclaw) on Windows; a no-op on
-    macOS/Linux.
+    Drops unsupported connectors on Windows; a no-op on macOS/Linux.
     """
     return tuple(supported_connectors(CONNECTOR_CHOICES, os_name))
 
@@ -64,6 +63,8 @@ class FirstRunField:
     @property
     def display_value(self) -> str:
         if self.kind != "bool":
+            if self.label == "Connector" and connector_preview_on_os(self.value):
+                return f"{self.value} (preview)"
             return self.value
         return "on" if self.value == "true" else "off"
 

--- a/cli/defenseclaw/tui/screens/mode_picker.py
+++ b/cli/defenseclaw/tui/screens/mode_picker.py
@@ -12,7 +12,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from textual import events, on
 from textual.app import ComposeResult
@@ -21,7 +21,11 @@ from textual.containers import Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Static
 
-from defenseclaw.platform_support import supported_connectors
+from defenseclaw.platform_support import (
+    connector_platform_support,
+    connector_preview_on_os,
+    supported_connectors,
+)
 from defenseclaw.tui.theme import DEFAULT_TOKENS
 from defenseclaw.tui.widgets.action_menu import ActionMenu, MenuAction
 
@@ -55,11 +59,23 @@ MODE_PICKER_CHOICES: tuple[ModeChoice, ...] = (
 def visible_mode_picker_choices(os_name: str | None = None) -> tuple[ModeChoice, ...]:
     """Mode-picker rows supported on *os_name*.
 
-    On Windows the proxy connectors (openclaw/zeptoclaw) are dropped because
-    DefenseClaw is hook-only there; on macOS/Linux this is a no-op.
+    Unsupported Windows connectors are dropped. Preview connectors remain
+    selectable with an explicit label/reason; macOS/Linux are unchanged.
     """
     supported = set(supported_connectors([c.wire for c in MODE_PICKER_CHOICES], os_name))
-    return tuple(c for c in MODE_PICKER_CHOICES if c.wire in supported)
+    visible: list[ModeChoice] = []
+    for choice in MODE_PICKER_CHOICES:
+        if choice.wire not in supported:
+            continue
+        if connector_preview_on_os(choice.wire, os_name):
+            reason = connector_platform_support(choice.wire, os_name).reason
+            choice = replace(
+                choice,
+                label=f"{choice.label} (preview)",
+                tagline=f"{choice.tagline}; {reason}",
+            )
+        visible.append(choice)
+    return tuple(visible)
 
 
 class ModePickerScreen(ModalScreen[str | None]):
@@ -103,7 +119,7 @@ class ModePickerScreen(ModalScreen[str | None]):
 
     def __init__(self, current_wire: str = "", *, os_name: str | None = None) -> None:
         super().__init__()
-        # Hide proxy connectors on Windows; no-op on macOS/Linux. Resolve
+        # Hide unsupported connectors on Windows; no-op on macOS/Linux. Resolve
         # once so compose() and _sync_preview() share the same row order.
         self.choices = visible_mode_picker_choices(os_name)
         self.current_wire = self._resolve_current_wire(current_wire)

--- a/cli/defenseclaw/tui/services/cli_choices.py
+++ b/cli/defenseclaw/tui/services/cli_choices.py
@@ -58,9 +58,9 @@ GUARDRAIL_CONNECTORS: frozenset[str] = frozenset({"openclaw", "zeptoclaw"})
 def supported_connector_choices(os_name: str | None = None) -> tuple[str, ...]:
     """``CONNECTORS`` filtered to those supported on *os_name*.
 
-    DefenseClaw is hook-only on Windows, so the proxy connectors
-    (openclaw/zeptoclaw) are dropped there; a no-op on macOS/Linux. Use this
-    wherever the connector list is presented to or chosen by the operator.
+    Unsupported connectors are dropped on Windows while preview connectors
+    remain selectable; this is a no-op on macOS/Linux. Use this wherever the
+    connector list is presented to or chosen by the operator.
     """
     return tuple(supported_connectors(CONNECTORS, os_name))
 

--- a/cli/defenseclaw/webhooks/writer.py
+++ b/cli/defenseclaw/webhooks/writer.py
@@ -45,6 +45,8 @@ from urllib.parse import urlparse
 
 import yaml
 
+from defenseclaw.file_permissions import set_file_mode
+
 # ---------------------------------------------------------------------------
 # Constants mirrored with internal/gateway/webhook.go and internal/config
 # ---------------------------------------------------------------------------
@@ -569,16 +571,25 @@ def _write_yaml(path: str, data: dict[str, Any]) -> None:
     """
     directory = os.path.dirname(path) or "."
     os.makedirs(directory, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(prefix=".webhooks.", suffix=".tmp", dir=directory)
+    fd = -1
+    tmp = ""
     try:
-        os.fchmod(fd, 0o600)
-        with os.fdopen(fd, "w") as f:
+        fd, tmp = tempfile.mkstemp(prefix=".webhooks.", suffix=".tmp", dir=directory)
+        set_file_mode(fd, tmp, 0o600)
+        stream = os.fdopen(fd, "w")
+        fd = -1  # ownership transferred; stream closes on every with-path
+        with stream as f:
             yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
         os.replace(tmp, path)
-    except BaseException:
-        with contextlib.suppress(OSError):
-            os.unlink(tmp)
-        raise
+        tmp = ""
+    finally:
+        if fd != -1:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        if tmp:
+            # Close first: an open CRT descriptor prevents unlink on Windows.
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
 
 
 # ---------------------------------------------------------------------------

--- a/cli/tests/permissions.py
+++ b/cli/tests/permissions.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Permission assertions shared by cross-platform security regressions."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+
+
+def assert_owner_only_file(path: str | os.PathLike[str]) -> None:
+    """Assert POSIX 0600 or the equivalent protected Windows DACL."""
+    if os.name != "nt":
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+        return
+
+    with tempfile.TemporaryDirectory(prefix="defenseclaw-acl-test-") as tmp:
+        saved_acl = os.path.join(tmp, "acl.txt")
+        subprocess.run(
+            ["icacls", os.fspath(path), "/save", saved_acl],
+            check=True,
+            capture_output=True,
+        )
+        with open(saved_acl, encoding="utf-16-le") as f:
+            lines = f.read().splitlines()
+
+    # /save emits stable SDDL even when account names and status messages are
+    # localized. This is exactly one protected Owner Rights full-control ACE.
+    assert lines[-1] == "D:P(A;;FA;;;OW)", lines

--- a/cli/tests/test_agent_discovery.py
+++ b/cli/tests/test_agent_discovery.py
@@ -23,6 +23,7 @@ import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import pytest
 from defenseclaw.connector_paths import KNOWN_CONNECTORS
 from defenseclaw.inventory import agent_discovery as ad
 
@@ -49,6 +50,7 @@ def _discovery(*installed: str, cache_hit: bool = False) -> ad.AgentDiscovery:
 def _pin_home(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("DEFENSECLAW_HOME", str(tmp_path / ".defenseclaw"))
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
 
 def test_cache_miss_hit_and_ttl_expiry(monkeypatch, tmp_path):
@@ -70,7 +72,10 @@ def test_cache_miss_hit_and_ttl_expiry(monkeypatch, tmp_path):
 
     cache_file = Path(os.environ["DEFENSECLAW_HOME"]) / ad.CACHE_FILENAME
     assert cache_file.is_file()
-    assert stat.S_IMODE(cache_file.stat().st_mode) == 0o600
+    if os.name == "nt":
+        assert ad._windows_acl_write_error(str(cache_file)) is None
+    else:
+        assert stat.S_IMODE(cache_file.stat().st_mode) == 0o600
 
     calls.clear()
     monkeypatch.setattr(ad, "_scan_agent", lambda name: (_ for _ in ()).throw(AssertionError(name)))
@@ -125,7 +130,7 @@ def test_timeout_sets_error_and_does_not_mark_binary_only_install(monkeypatch, t
 
     signal = ad._scan_agent("codex")
 
-    assert signal.binary_path == "/usr/local/bin/codex"
+    assert signal.binary_path == os.path.abspath("/usr/local/bin/codex")
     assert signal.config_path == ""
     assert signal.installed is False
     assert "timed out" in signal.error
@@ -151,7 +156,7 @@ def test_version_probe_uses_no_shell_and_list_args(monkeypatch, tmp_path):
     assert signal.installed is True
     assert signal.version == "codex 1.2.3"
     args, kwargs = calls[0]
-    assert args == ["/opt/bin/codex", "--version"]
+    assert args == [os.path.abspath("/opt/bin/codex"), "--version"]
     assert kwargs["shell"] is False
     assert kwargs["timeout"] == 2.0
     assert kwargs["capture_output"] is True
@@ -182,7 +187,7 @@ OpenHands CLI 1.16.0
     assert signal.installed is True
     assert signal.version == "OpenHands CLI 1.16.0"
     args, kwargs = calls[0]
-    assert args == ["/opt/bin/openhands", "--version"]
+    assert args == [os.path.abspath("/opt/bin/openhands"), "--version"]
     assert kwargs["timeout"] == 8.0
     assert kwargs["env"]["OPENHANDS_SUPPRESS_BANNER"] == "1"
 
@@ -205,6 +210,56 @@ def test_hermes_version_probe_gets_longer_timeout(monkeypatch, tmp_path):
     assert signal.version == "Hermes Agent v0.13.0"
     _, kwargs = calls[0]
     assert kwargs["timeout"] == 8.0
+
+
+def test_windows_executable_suffixes_preserve_agent_specific_probe_rules(monkeypatch):
+    calls = []
+    monkeypatch.setattr(ad, "_is_trusted_binary_path", lambda _path: True)
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout="SDK banner\nOpenHands CLI 1.16.0\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(ad.subprocess, "run", fake_run)
+
+    version, error = ad._version_for_binary(r"C:\Tools\openhands.EXE", ("--version",))
+
+    assert error == ""
+    assert version == "OpenHands CLI 1.16.0"
+    assert calls[0][1]["timeout"] == 8.0
+    assert calls[0][1]["env"]["OPENHANDS_SUPPRESS_BANNER"] == "1"
+
+
+def test_claude_version_probe_gets_longer_timeout_with_exe_suffix(monkeypatch):
+    calls = []
+    monkeypatch.setattr(ad, "_is_trusted_binary_path", lambda _path: True)
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="2.1.196 (Claude Code)\n", stderr="")
+
+    monkeypatch.setattr(ad.subprocess, "run", fake_run)
+
+    version, error = ad._version_for_binary(r"C:\Tools\claude.EXE", ("--version",))
+
+    assert error == ""
+    assert version == "2.1.196 (Claude Code)"
+    assert calls[0][1]["timeout"] == 8.0
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows PATHEXT regression")
+def test_which_discovers_cmd_wrapper(monkeypatch, tmp_path):
+    wrapper = tmp_path / "cursor.CMD"
+    wrapper.write_text("@echo 3.9.16\r\n", encoding="utf-8")
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+
+    assert ad._path_key(ad._which("cursor")) == ad._path_key(str(wrapper))
 
 
 def test_omnigent_discovery_honors_config_home(monkeypatch, tmp_path):
@@ -267,7 +322,7 @@ def test_version_probe_refuses_binary_outside_trusted_prefix(monkeypatch, tmp_pa
 def test_trust_check_accepts_canonical_prefix(monkeypatch, tmp_path):
     # Add tmp_path as a trusted prefix and place a real, non-world-writable
     # binary inside it.
-    binary = tmp_path / "bin" / "codex"
+    binary = tmp_path / "bin" / ("codex.exe" if os.name == "nt" else "codex")
     binary.parent.mkdir(parents=True, exist_ok=True)
     binary.write_text("#!/bin/sh\nexit 0\n")
     binary.chmod(0o755)
@@ -276,6 +331,49 @@ def test_trust_check_accepts_canonical_prefix(monkeypatch, tmp_path):
     assert ad._is_trusted_binary_path(str(binary)) is True
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows ACL regression")
+def test_windows_acl_distinguishes_owner_control_from_everyone_write(tmp_path):
+    safe = tmp_path / "safe"
+    unsafe = tmp_path / "everyone-write"
+    safe.mkdir()
+    unsafe.mkdir()
+    subprocess.run(
+        ["icacls", str(unsafe), "/grant", "*S-1-1-0:(OI)(CI)F"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    _safe_path, safe_error = ad.validate_trusted_prefix(str(safe))
+    _unsafe_path, unsafe_error = ad.validate_trusted_prefix(str(unsafe))
+
+    assert safe_error is None
+    assert unsafe_error is not None
+    assert "Everyone" in unsafe_error
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows path comparison regression")
+def test_windows_trust_check_is_case_insensitive(monkeypatch, tmp_path):
+    binary = tmp_path / "bin" / "codex.EXE"
+    binary.parent.mkdir()
+    binary.write_bytes(b"MZ")
+    monkeypatch.setenv("DEFENSECLAW_TRUSTED_BIN_PREFIXES", str(tmp_path).swapcase())
+
+    assert ad._is_trusted_binary_path(str(binary)) is True
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows prefix policy")
+def test_windows_defaults_are_narrow_and_reject_drive_root():
+    local_app_data = os.environ["LOCALAPPDATA"]
+    expected = os.path.join(local_app_data, "Programs", "OpenAI", "Codex", "bin")
+    default_keys = {ad._path_key(path) for path in ad._TRUSTED_BIN_PREFIXES_DEFAULT}
+
+    assert ad._path_key(expected) in default_keys
+    assert ad._path_key(local_app_data) not in default_keys
+    assert ad._expand_bin_prefixes((Path(local_app_data).anchor,)) == []
+
+
+@pytest.mark.skipif(os.name == "nt", reason="requires unprivileged POSIX symlinks")
 def test_trust_check_canonicalises_operator_prefix_symlink(monkeypatch, tmp_path):
     real_root = tmp_path / "real-tools"
     binary = real_root / "bin" / "omnigent"
@@ -291,6 +389,7 @@ def test_trust_check_canonicalises_operator_prefix_symlink(monkeypatch, tmp_path
     assert ad._is_trusted_binary_path(str(alias / "bin" / "omnigent")) is True
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX Homebrew layout")
 def test_trust_check_accepts_homebrew_symlink_targets(monkeypatch, tmp_path):
     homebrew = tmp_path / "homebrew"
     real = homebrew / "lib" / "node_modules" / "@openai" / "codex" / "bin" / "codex.js"
@@ -317,6 +416,7 @@ def test_trust_check_accepts_homebrew_symlink_targets(monkeypatch, tmp_path):
     assert ad._is_trusted_binary_path(str(link)) is True
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX ownership semantics")
 def test_operator_prefix_still_applies_after_default_prefix_ownership_failure(
     monkeypatch,
     tmp_path,
@@ -352,6 +452,7 @@ def test_operator_prefix_still_applies_after_default_prefix_ownership_failure(
     assert ad._is_trusted_binary_path(str(binary)) is True
 
 
+@pytest.mark.skipif(os.name == "nt", reason="requires unprivileged POSIX symlinks")
 def test_trust_check_accepts_claude_local_share_target(monkeypatch, tmp_path):
     real = tmp_path / ".local" / "share" / "claude" / "versions" / "2.1.139"
     real.parent.mkdir(parents=True, exist_ok=True)
@@ -374,6 +475,7 @@ def test_trust_check_accepts_claude_local_share_target(monkeypatch, tmp_path):
     assert ad._is_trusted_binary_path(str(link)) is True
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode-bit policy")
 def test_trust_check_rejects_world_writable_parent(monkeypatch, tmp_path):
     binary = tmp_path / "bin" / "codex"
     binary.parent.mkdir(parents=True, exist_ok=True)
@@ -386,6 +488,7 @@ def test_trust_check_rejects_world_writable_parent(monkeypatch, tmp_path):
     assert ad._is_trusted_binary_path(str(binary)) is False
 
 
+@pytest.mark.skipif(os.name == "nt", reason="requires unprivileged POSIX symlinks")
 def test_trust_check_follows_symlinks(monkeypatch, tmp_path):
     real = tmp_path / "untrusted" / "real-bin"
     real.parent.mkdir(parents=True, exist_ok=True)
@@ -401,6 +504,7 @@ def test_trust_check_follows_symlinks(monkeypatch, tmp_path):
     assert ad._is_trusted_binary_path(str(link)) is False
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX default-prefix policy")
 def test_default_trusted_prefixes_excludes_user_writable_roots():
     # Regression guard for the secure default: user-writable tool roots
     # are intentionally NOT auto-trusted. A local agent running as the
@@ -423,6 +527,7 @@ def test_default_trusted_prefixes_excludes_user_writable_roots():
     assert "/usr/local/bin" in ad._TRUSTED_BIN_PREFIXES_DEFAULT
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX standalone symlink layout")
 def test_trust_check_codex_standalone_symlink_requires_opt_in(monkeypatch, tmp_path):
     # Reproduce the Codex standalone layout under a fake HOME and assert
     # the secure-default behavior plus the documented opt-in escape

--- a/cli/tests/test_claw_inventory.py
+++ b/cli/tests/test_claw_inventory.py
@@ -2364,6 +2364,24 @@ class TestBuildAibomFromFilesystem(unittest.TestCase):
         ids = [p["id"] for p in inv["plugins"]]
         self.assertEqual(ids, ["real"])
 
+    def test_hidden_and_staging_plugin_dirs_are_skipped(self):
+        """Hidden activation state must not surface as enabled plugins."""
+        cfg = _make_cfg_for_connector(self.tmp, "codex")
+        plugin_root = os.path.join(self.tmp, "plugins")
+        os.makedirs(plugin_root, exist_ok=True)
+        _seed_plugin(plugin_root, ".plugin-appserver", manifest="plugin.json")
+        _seed_plugin(
+            plugin_root,
+            "..plugin-appserver.staging-123",
+            manifest="plugin.json",
+        )
+        _seed_plugin(plugin_root, "real", manifest="plugin.json")
+        with self._patch_skill_dirs([]), \
+             self._patch_plugin_dirs([plugin_root]), \
+             self._patch_mcp([]):
+            inv = build_claw_aibom(cfg, live=True)
+        self.assertEqual([p["id"] for p in inv["plugins"]], ["real"])
+
     def test_mcp_servers_passed_through(self):
         from defenseclaw.connector_paths import MCPServerEntry
         cfg = _make_cfg_for_connector(self.tmp, "codex")

--- a/cli/tests/test_cmd_doctor.py
+++ b/cli/tests/test_cmd_doctor.py
@@ -1831,6 +1831,22 @@ class DoctorHttpProbeRedirectTests(unittest.TestCase):
         # prove the auth header was NOT replayed to the redirect target.
         self.requests: list[dict] = []
         recorder = self.requests
+        self.health_body = json.dumps(
+            {
+                "gateway": {
+                    "state": "running",
+                    "details": {"inventory": "x" * 2200},
+                },
+                "watcher": {"state": "running"},
+                "guardrail": {"state": "running"},
+                "api": {"state": "running"},
+                "connectors": [
+                    {"name": "codex", "state": "running"},
+                    {"name": "claudecode", "state": "running"},
+                ],
+            }
+        ).encode("utf-8")
+        health_body = self.health_body
 
         class _Handler(http.server.BaseHTTPRequestHandler):
             def log_message(self, *args):  # silence test output
@@ -1848,7 +1864,7 @@ class DoctorHttpProbeRedirectTests(unittest.TestCase):
                     self.send_header("Location", "/leaked")
                     self.end_headers()
                 else:
-                    body = b"reached"
+                    body = health_body if self.path == "/health" else b"reached"
                     self.send_response(200)
                     self.send_header("Content-Length", str(len(body)))
                     self.end_headers()
@@ -1921,6 +1937,43 @@ class DoctorHttpProbeRedirectTests(unittest.TestCase):
         status, body = _http_probe(self._url("/ok"), timeout=5.0)
         self.assertEqual(status, 200, (status, body))
         self.assertIn("reached", body)
+
+    def test_sidecar_health_parses_complete_large_multi_connector_document(self):
+        self.assertGreater(len(self.health_body), 2_000)
+        cfg = SimpleNamespace(
+            openshell=None,
+            gateway=SimpleNamespace(api_port=self.port),
+        )
+        result = _DoctorResult()
+
+        _check_sidecar(cfg, result)
+
+        self.assertFalse(
+            any(c["label"] == "Sidecar health JSON" for c in result.checks),
+            result.checks,
+        )
+        subsystem_rows = {
+            c["label"].strip().removeprefix("└─ "): c["status"]
+            for c in result.checks
+            if "└─" in c["label"]
+        }
+        self.assertEqual(subsystem_rows["gateway"], "pass")
+        self.assertEqual(subsystem_rows["watcher"], "pass")
+        self.assertEqual(subsystem_rows["guardrail"], "pass")
+        self.assertEqual(subsystem_rows["api"], "pass")
+
+    def test_structured_probe_rejects_response_over_its_byte_bound(self):
+        from defenseclaw.commands.cmd_doctor import _http_probe
+
+        status, body = _http_probe(
+            self._url("/health"),
+            timeout=5.0,
+            response_limit=128,
+            allow_truncation=False,
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(body, "response exceeds 128-byte limit")
 
 
 class GuardrailProxyMultiConnectorTests(unittest.TestCase):

--- a/cli/tests/test_cmd_init.py
+++ b/cli/tests/test_cmd_init.py
@@ -160,21 +160,22 @@ class TestInitFirstRunBackend(unittest.TestCase):
         self.assertEqual(cfg["guardrail"]["detection_strategy"], "regex_judge")
 
     def test_sandbox_flag_reports_explicit_scope(self):
-        result = self._invoke([
-            "--non-interactive",
-            "--yes",
-            "--connector",
-            "openclaw",
-            "--profile",
-            "observe",
-            "--scanner-mode",
-            "local",
-            "--skip-install",
-            "--sandbox",
-            "--no-start-gateway",
-            "--no-verify",
-            "--json-summary",
-        ])
+        with patch("defenseclaw.platform_support.host_os", return_value="linux"):
+            result = self._invoke([
+                "--non-interactive",
+                "--yes",
+                "--connector",
+                "openclaw",
+                "--profile",
+                "observe",
+                "--scanner-mode",
+                "local",
+                "--skip-install",
+                "--sandbox",
+                "--no-start-gateway",
+                "--no-verify",
+                "--json-summary",
+            ])
         self.assertEqual(result.exit_code, 0, result.output + (result.stderr or ""))
 
         summary = json.loads(result.output)
@@ -2786,11 +2787,24 @@ class TestInitObserveAllActionConnectors(unittest.TestCase):
         from defenseclaw.commands import cmd_init
 
         disc = self._disc({"codex", "openclaw"})
-        with patch.object(cmd_init.ux, "subhead") as subhead:
+        with patch.object(cmd_init.platform_support, "host_os", return_value="linux"), \
+                patch.object(cmd_init.ux, "subhead") as subhead:
             cmd_init._note_proxy_connectors(disc)
         emitted = " ".join(call.args[0] for call in subhead.call_args_list if call.args)
         self.assertIn("openclaw", emitted)
         self.assertIn("defenseclaw setup openclaw", emitted)
+
+    def test_note_proxy_connectors_warns_when_unsupported_on_windows(self):
+        from defenseclaw.commands import cmd_init
+
+        disc = self._disc({"codex", "openclaw"})
+        with patch.object(cmd_init.platform_support, "host_os", return_value="windows"), \
+                patch.object(cmd_init.ux, "warn") as warn:
+            cmd_init._note_proxy_connectors(disc)
+        emitted = " ".join(call.args[0] for call in warn.call_args_list if call.args)
+        self.assertIn("openclaw", emitted)
+        self.assertIn("unsupported on windows", emitted)
+        self.assertIn("guardrail proxy", emitted)
 
     def test_note_proxy_connectors_silent_without_proxy(self):
         from defenseclaw.commands import cmd_init

--- a/cli/tests/test_cmd_init.py
+++ b/cli/tests/test_cmd_init.py
@@ -1020,13 +1020,13 @@ class TestResolveSplunkBridgeBundle(unittest.TestCase):
         from defenseclaw.commands.cmd_init import _resolve_splunk_bridge_bundle
 
         def fake_is_dir(path):
-            path_str = str(path)
+            path_str = str(path).replace("\\", "/")
             return path_str.endswith("_data/splunk_local_bridge") or path_str.endswith("bundles/splunk_local_bridge")
 
         with patch("pathlib.Path.is_dir", autospec=True, side_effect=fake_is_dir):
             result = _resolve_splunk_bridge_bundle()
 
-        self.assertTrue(str(result).endswith("_data/splunk_local_bridge"))
+        self.assertTrue(str(result).replace("\\", "/").endswith("_data/splunk_local_bridge"))
 
 
 class TestInitSeedsSplunkBridge(unittest.TestCase):

--- a/cli/tests/test_cmd_init.py
+++ b/cli/tests/test_cmd_init.py
@@ -23,6 +23,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import ANY, MagicMock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -2355,7 +2356,7 @@ class TestMultiConnectorInit(unittest.TestCase):
 
         keys = iter([" ", "j", " ", "\r"])
         with patch.object(cmd_init.click, "getchar", side_effect=lambda: next(keys)), \
-                patch.object(cmd_init, "_stdout_is_tty", return_value=False):
+                patch.object(cmd_init, "_supports_terminal_redraw", return_value=True):
             got = cmd_init._prompt_checkbox_selection(
                 ["codex", "claudecode"],
                 default_selected=["codex"],
@@ -2363,6 +2364,102 @@ class TestMultiConnectorInit(unittest.TestCase):
                 empty_ok=False,
             )
         self.assertEqual(got, ["claudecode"])
+
+    def test_checkbox_key_names_cover_windows_ansi_and_vi_navigation(self):
+        from defenseclaw.commands import cmd_init
+
+        cases = {
+            "\x1b[A": "up",
+            "\x1b[B": "down",
+            "\x00H": "up",
+            "\xe0H": "up",
+            "\x00P": "down",
+            "\xe0P": "down",
+            "k": "up",
+            "j": "down",
+        }
+        for key, expected in cases.items():
+            with self.subTest(key=list(map(ord, key))):
+                self.assertEqual(cmd_init._checkbox_key_name(key), expected)
+
+    def test_checkbox_selector_accepts_windows_extended_arrow(self):
+        from defenseclaw.commands import cmd_init
+
+        keys = iter(["\xe0P", " ", "\r"])
+        with patch.object(cmd_init.click, "getchar", side_effect=lambda: next(keys)), \
+                patch.object(cmd_init, "_supports_terminal_redraw", return_value=True):
+            got = cmd_init._prompt_checkbox_selection(
+                ["codex", "claudecode"],
+                default_selected=["codex"],
+                title="Select connectors",
+                empty_ok=False,
+            )
+        self.assertEqual(got, ["codex", "claudecode"])
+
+    def test_checkbox_no_vt_fallback_renders_once_and_uses_numbered_input(self):
+        from defenseclaw.commands import cmd_init
+
+        emitted: list[str] = []
+        with patch.object(cmd_init, "_supports_terminal_redraw", return_value=False), \
+                patch.object(cmd_init.click, "prompt", return_value="2"), \
+                patch.object(cmd_init.click, "echo", side_effect=lambda text="", **_kwargs: emitted.append(text)):
+            got = cmd_init._prompt_checkbox_selection(
+                ["codex", "claudecode"],
+                default_selected=["codex"],
+                title="Select connectors",
+                empty_ok=False,
+            )
+
+        self.assertEqual(got, ["claudecode"])
+        self.assertEqual(sum("codex" in line and "claudecode" not in line for line in emitted), 1)
+        self.assertEqual(sum("claudecode" in line for line in emitted), 1)
+
+    def test_checkbox_windows_console_enables_vt_before_redraw(self):
+        import ctypes
+
+        from defenseclaw.commands import cmd_init
+
+        set_modes: list[int] = []
+
+        def get_console_mode(_handle, mode_ptr):
+            mode_ptr._obj.value = 0  # noqa: SLF001 - ctypes byref test double.
+            return 1
+
+        def set_console_mode(_handle, mode):
+            set_modes.append(mode)
+            return 1
+
+        fake_msvcrt = SimpleNamespace(get_osfhandle=lambda _fd: 42)
+        fake_windll = SimpleNamespace(
+            kernel32=SimpleNamespace(
+                GetConsoleMode=get_console_mode,
+                SetConsoleMode=set_console_mode,
+            )
+        )
+        fake_stream = SimpleNamespace(fileno=lambda: 1)
+        with patch.object(cmd_init, "_stdout_is_tty", return_value=True), \
+                patch.object(cmd_init.os, "name", "nt"), \
+                patch.object(cmd_init.click, "get_text_stream", return_value=fake_stream), \
+                patch.dict(sys.modules, {"msvcrt": fake_msvcrt}), \
+                patch.object(ctypes, "windll", fake_windll, create=True):
+            self.assertTrue(cmd_init._supports_terminal_redraw())
+
+        self.assertEqual(set_modes, [0x0004])
+
+    def test_checkbox_redraw_uses_ansi_cursor_and_line_controls(self):
+        from defenseclaw.commands import cmd_init
+
+        with patch.object(cmd_init.click, "echo") as echo:
+            cmd_init._render_checkbox_menu(
+                ["codex", "claudecode"],
+                {"codex"},
+                1,
+                redraw=True,
+            )
+
+        emitted = "".join(call.args[0] for call in echo.call_args_list)
+        self.assertIn("\x1b[2F", emitted)
+        self.assertEqual(emitted.count("\x1b[2K"), 2)
 
     def test_connector_selection_uses_checkbox_menu(self):
         from defenseclaw.commands import cmd_init

--- a/cli/tests/test_cmd_judge.py
+++ b/cli/tests/test_cmd_judge.py
@@ -597,7 +597,7 @@ class WizardHookPromptTests(unittest.TestCase):
     def test_checkbox_selector_toggles_with_keys(self):
         keys = iter([" ", "j", " ", "\r"])
         with patch.object(cmd_setup.click, "getchar", side_effect=lambda: next(keys)), \
-                patch.object(cmd_setup, "_stdout_is_tty", return_value=False):
+                patch.object(cmd_setup, "_supports_terminal_redraw", return_value=True):
             got = cmd_setup._prompt_checkbox_selection(
                 ["codex", "hermes"],
                 default_selected=["codex"],
@@ -605,6 +605,12 @@ class WizardHookPromptTests(unittest.TestCase):
                 empty_ok=True,
             )
         self.assertEqual(got, ["hermes"])
+
+    def test_setup_checkbox_recognizes_windows_extended_arrows(self):
+        self.assertEqual(cmd_setup._checkbox_key_name("\x00H"), "up")
+        self.assertEqual(cmd_setup._checkbox_key_name("\xe0H"), "up")
+        self.assertEqual(cmd_setup._checkbox_key_name("\x00P"), "down")
+        self.assertEqual(cmd_setup._checkbox_key_name("\xe0P"), "down")
 
 
 if __name__ == "__main__":

--- a/cli/tests/test_cmd_plugin.py
+++ b/cli/tests/test_cmd_plugin.py
@@ -2187,14 +2187,25 @@ class HostPluginEnumerationTests(unittest.TestCase):
         # codex/zeptoclaw seed a sibling ``cache`` dir next to real plugins;
         # version control / OS cruft seeds dot-prefixed dirs.
         os.makedirs(os.path.join(self.tmp_dir, "cache"))
-        os.makedirs(os.path.join(self.tmp_dir, ".git"))
+        os.makedirs(os.path.join(self.tmp_dir, ".plugin-appserver"))
+        os.makedirs(os.path.join(self.tmp_dir, "..plugin-appserver.staging-123"))
         self._seed("real-plugin", {"id": "real-plugin", "name": "Real"})
 
         out = _scan_plugin_dir(self.tmp_dir, "codex")
         ids = sorted(p["id"] for p in out)
         self.assertEqual(ids, ["real-plugin"])
         self.assertNotIn("cache", ids)
-        self.assertNotIn(".git", ids)
+        self.assertNotIn(".plugin-appserver", ids)
+        self.assertNotIn("..plugin-appserver.staging-123", ids)
+
+    def test_defenseclaw_plugin_list_uses_shared_hidden_filter(self):
+        from defenseclaw.commands.cmd_plugin import _list_defenseclaw_plugins
+
+        self._seed(".plugin-appserver", manifest=None)
+        self._seed("..plugin-appserver.staging-123", manifest=None)
+        self._seed("real-plugin", manifest=None)
+
+        self.assertEqual(_list_defenseclaw_plugins(self.tmp_dir), ["real-plugin"])
 
     def test_list_host_plugins_skips_openclaw(self):
         """OpenClaw enumeration goes through the openclaw binary, not us."""

--- a/cli/tests/test_cmd_setup_codex_claudecode_alias.py
+++ b/cli/tests/test_cmd_setup_codex_claudecode_alias.py
@@ -44,6 +44,7 @@ from unittest.mock import patch
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from click.testing import CliRunner
+from defenseclaw import platform_support
 from defenseclaw.commands.cmd_setup import setup as setup_group
 
 from tests.helpers import cleanup_app, make_app_context
@@ -272,7 +273,7 @@ class TestSetupNewConnectorAliases(unittest.TestCase):
         cleanup_app(self.app, self.db_path, self.tmp_dir)
 
     def test_new_aliases_pin_observability_connector(self):
-        for connector in HOOK_ALIAS_CONNECTORS:
+        for connector in platform_support.supported_connectors(HOOK_ALIAS_CONNECTORS):
             with (
                 self.subTest(connector=connector),
                 patch(
@@ -317,7 +318,7 @@ class TestSetupNewConnectorAliases(unittest.TestCase):
                     self.assertEqual(fh.read().strip(), connector)
 
     def test_new_aliases_support_hook_action_mode(self):
-        for connector in HOOK_ALIAS_CONNECTORS:
+        for connector in platform_support.supported_connectors(HOOK_ALIAS_CONNECTORS):
             with (
                 self.subTest(connector=connector),
                 patch(
@@ -393,6 +394,7 @@ class TestSetupNewConnectorAliases(unittest.TestCase):
         workspace = os.path.join(self.tmp_dir, "repo")
         os.makedirs(workspace)
         with (
+            patch("defenseclaw.platform_support.host_os", return_value="linux"),
             patch("defenseclaw.commands.cmd_setup._restart_services", return_value=None),
             patch("defenseclaw.commands.cmd_setup._maybe_bring_up_local_stack", return_value=None),
             patch("defenseclaw.commands.cmd_setup._check_connector_version_supported_for_setup", return_value=True),
@@ -460,8 +462,11 @@ class TestSetupNewConnectorAliases(unittest.TestCase):
     def test_guardrail_help_mentions_new_connector_choices(self):
         result = _invoke(["guardrail", "--help"], self.app)
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        for connector in HOOK_ALIAS_CONNECTORS:
+        for connector in platform_support.supported_connectors(HOOK_ALIAS_CONNECTORS):
             self.assertIn(connector, result.output)
+        choice_text = result.output.split("--connector, --agent [", 1)[1].split("]", 1)[0]
+        for connector in platform_support.WINDOWS_UNSUPPORTED_CONNECTORS:
+            self.assertNotIn(connector, choice_text)
         self.assertNotIn("openclaw, claudecode, codex, zeptoclaw", result.output)
 
     def test_rotate_token_help_is_connector_agnostic(self):

--- a/cli/tests/test_cmd_setup_fu_phase2.py
+++ b/cli/tests/test_cmd_setup_fu_phase2.py
@@ -638,6 +638,7 @@ class TestBareSetupBatch(_BaseSetup):
         with _stub_side_effects(), \
                 patch("defenseclaw.commands.cmd_setup._is_interactive", return_value=True), \
                 patch("defenseclaw.commands.cmd_setup._detect_installed_connectors", return_value=["hermes"]), \
+                patch("defenseclaw.commands.cmd_setup._supports_terminal_redraw", return_value=True), \
                 patch("defenseclaw.commands.cmd_setup.click.getchar", return_value="\n"):
             res = _invoke(["--yes"], self.app)
         # --yes => no mode/judge prompts, but bare setup still needs the

--- a/cli/tests/test_cmd_setup_fu_phase2.py
+++ b/cli/tests/test_cmd_setup_fu_phase2.py
@@ -617,7 +617,10 @@ class TestBareSetupBatch(_BaseSetup):
         with _stub_side_effects():
             res = _invoke(["--all", "--no-restart"], self.app)
         self.assertEqual(res.exit_code, 0, msg=res.output)
-        self.assertEqual(set(self.app.cfg.guardrail.connectors), set(cmd_setup._HOOK_ENFORCED_CONNECTORS))
+        expected = cmd_setup.platform_support.supported_connectors(
+            cmd_setup._HOOK_ENFORCED_CONNECTORS
+        )
+        self.assertEqual(set(self.app.cfg.guardrail.connectors), set(expected))
 
     def test_invalid_connector_flag_errors(self):
         with _stub_side_effects():

--- a/cli/tests/test_cmd_setup_trusted_paths.py
+++ b/cli/tests/test_cmd_setup_trusted_paths.py
@@ -114,7 +114,10 @@ class AddTrustedBinPrefixTests(unittest.TestCase):
                 self.assertIn("/opt/more", parts)
             dotenv = os.path.join(tmp, ".env")
             self.assertTrue(os.path.isfile(dotenv))
-            self.assertEqual(os.stat(dotenv).st_mode & 0o777, 0o600)
+            if os.name == "nt":
+                self.assertIsNone(ad._windows_acl_write_error(dotenv))
+            else:
+                self.assertEqual(os.stat(dotenv).st_mode & 0o777, 0o600)
             body = open(dotenv, encoding="utf-8").read()
             self.assertIn("/opt/tools", body)
             self.assertIn("/opt/more", body)
@@ -177,6 +180,7 @@ class AddTrustedBinPrefixTests(unittest.TestCase):
 
 
 class CaskroomDefaultTests(unittest.TestCase):
+    @unittest.skipIf(os.name == "nt", "POSIX Homebrew default")
     def test_caskroom_is_a_builtin_default(self):
         self.assertIn("/opt/homebrew/Caskroom", ad._TRUSTED_BIN_PREFIXES_DEFAULT)
 
@@ -312,6 +316,7 @@ class ValidateTrustedPrefixTests(unittest.TestCase):
         self.assertIsNotNone(err)
         self.assertIn("not absolute", err or "")
 
+    @unittest.skipIf(os.name == "nt", "requires unprivileged POSIX symlinks")
     def test_realpath_canonicalises_symlink_directory(self):
         with tempfile.TemporaryDirectory() as tmp:
             target = os.path.join(tmp, "target")
@@ -322,6 +327,7 @@ class ValidateTrustedPrefixTests(unittest.TestCase):
             self.assertIsNone(err)
             self.assertEqual(resolved, os.path.realpath(target))
 
+    @unittest.skipIf(os.name == "nt", "POSIX mode-bit policy")
     def test_group_writable_directory_refused(self):
         with tempfile.TemporaryDirectory() as tmp:
             gdir = os.path.join(tmp, "gtools")
@@ -336,7 +342,7 @@ class TrustedPathsCliTests(unittest.TestCase):
     def setUp(self):
         self.runner = CliRunner()
 
-    def test_list_json_includes_defaults_and_caskroom(self):
+    def test_list_json_includes_platform_defaults(self):
         with tempfile.TemporaryDirectory() as tmp:
             app = _make_app_context(tmp)
             with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": ""}, clear=False):
@@ -344,7 +350,8 @@ class TrustedPathsCliTests(unittest.TestCase):
             self.assertEqual(result.exit_code, 0, msg=result.output)
             rows = json.loads(result.output)
             resolved = {r["resolved"] for r in rows}
-            self.assertIn("/opt/homebrew/Caskroom", resolved)
+            expected = set(ad._expand_bin_prefixes(ad._TRUSTED_BIN_PREFIXES_DEFAULT))
+            self.assertTrue(expected <= resolved)
             self.assertTrue(all({"path", "resolved", "source", "status", "removable"} <= set(r) for r in rows))
 
     def test_add_persists_and_shows_removable(self):
@@ -365,6 +372,7 @@ class TrustedPathsCliTests(unittest.TestCase):
             self.assertTrue(rows[resolved]["removable"])
             self.assertEqual(rows[resolved]["source"], ".env")
 
+    @unittest.skipIf(os.name == "nt", "POSIX mode-bit policy")
     def test_add_world_writable_refused_without_force(self):
         with tempfile.TemporaryDirectory() as tmp:
             app = _make_app_context(tmp)
@@ -378,6 +386,7 @@ class TrustedPathsCliTests(unittest.TestCase):
             self.assertFalse(payload["ok"])
             self.assertIn("world-writable", payload["message"])
 
+    @unittest.skipIf(os.name == "nt", "POSIX mode-bit policy")
     def test_add_world_writable_allowed_with_force(self):
         with tempfile.TemporaryDirectory() as tmp:
             app = _make_app_context(tmp)
@@ -389,11 +398,34 @@ class TrustedPathsCliTests(unittest.TestCase):
             self.assertEqual(result.exit_code, 0, msg=result.output)
             self.assertTrue(json.loads(result.output)["ok"])
 
+    @unittest.skipUnless(os.name == "nt", "Windows ACL regression")
+    def test_add_everyone_writable_refused_without_force(self):
+        import subprocess
+
+        with tempfile.TemporaryDirectory() as tmp:
+            app = _make_app_context(tmp)
+            unsafe = os.path.join(tmp, "everyone-write")
+            os.makedirs(unsafe)
+            subprocess.run(
+                ["icacls", unsafe, "/grant", "*S-1-1-0:(OI)(CI)F"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": ""}, clear=False):
+                result = self.runner.invoke(cmd_setup.trusted_paths, ["add", unsafe, "--json"], obj=app)
+
+            self.assertNotEqual(result.exit_code, 0)
+            payload = json.loads(result.output)
+            self.assertFalse(payload["ok"])
+            self.assertIn("Everyone", payload["message"])
+
     def test_add_builtin_default_is_noop(self):
         with tempfile.TemporaryDirectory() as tmp:
             app = _make_app_context(tmp)
+            default = ad._TRUSTED_BIN_PREFIXES_DEFAULT[0]
             with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": ""}, clear=False):
-                result = self.runner.invoke(cmd_setup.trusted_paths, ["add", "/usr/bin", "--json"], obj=app)
+                result = self.runner.invoke(cmd_setup.trusted_paths, ["add", default, "--json"], obj=app)
             self.assertEqual(result.exit_code, 0, msg=result.output)
             self.assertIn("default", json.loads(result.output)["message"])
 
@@ -412,8 +444,9 @@ class TrustedPathsCliTests(unittest.TestCase):
     def test_remove_builtin_default_refused(self):
         with tempfile.TemporaryDirectory() as tmp:
             app = _make_app_context(tmp)
+            default = ad._TRUSTED_BIN_PREFIXES_DEFAULT[0]
             with patch.dict(os.environ, {"DEFENSECLAW_TRUSTED_BIN_PREFIXES": ""}, clear=False):
-                result = self.runner.invoke(cmd_setup.trusted_paths, ["remove", "/usr/bin", "--json"], obj=app)
+                result = self.runner.invoke(cmd_setup.trusted_paths, ["remove", default, "--json"], obj=app)
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("default", json.loads(result.output)["message"])
 
@@ -468,8 +501,10 @@ class AgentDiscoverHintTests(unittest.TestCase):
                 with patch.object(cmd_agent.agent_discovery, "discover_agents", return_value=disc):
                     result = CliRunner().invoke(cmd_agent.discover, ["--no-emit-otel"], obj=app)
                 hydrated = os.environ.get("DEFENSECLAW_TRUSTED_BIN_PREFIXES", "")
+                trusted_keys = {ad._path_key(path) for path in ad._trusted_bin_prefixes()}
             self.assertEqual(result.exit_code, 0, msg=result.output)
             self.assertIn("/opt/demo-trust", hydrated.split(os.pathsep))
+            self.assertIn(ad._path_key(os.path.realpath(os.path.abspath("/opt/demo-trust"))), trusted_keys)
 
 
 class TrustedPathsTuiSectionTests(unittest.TestCase):
@@ -486,7 +521,8 @@ class TrustedPathsTuiSectionTests(unittest.TestCase):
             values = " ".join(f.value for f in fields)
             self.assertIn("Built-in defaults", labels)
             self.assertIn("default prefixes", values)
-            self.assertIn("/opt/acme/bin", values)
+            expected, _error = ad.validate_trusted_prefix("/opt/acme/bin")
+            self.assertIn(expected, values)
             self.assertTrue(any("trusted-paths add" in f.value for f in fields))
 
     def test_section_registered_in_build_setup_sections(self):

--- a/cli/tests/test_cmd_setup_trusted_paths.py
+++ b/cli/tests/test_cmd_setup_trusted_paths.py
@@ -52,6 +52,8 @@ from defenseclaw.connector_contracts import (
 from defenseclaw.context import AppContext
 from defenseclaw.inventory import agent_discovery as ad
 
+from tests.permissions import assert_owner_only_file
+
 
 def _make_app_context(data_dir: str) -> AppContext:
     cfg = Config(
@@ -114,10 +116,7 @@ class AddTrustedBinPrefixTests(unittest.TestCase):
                 self.assertIn("/opt/more", parts)
             dotenv = os.path.join(tmp, ".env")
             self.assertTrue(os.path.isfile(dotenv))
-            if os.name == "nt":
-                self.assertIsNone(ad._windows_acl_write_error(dotenv))
-            else:
-                self.assertEqual(os.stat(dotenv).st_mode & 0o777, 0o600)
+            assert_owner_only_file(dotenv)
             body = open(dotenv, encoding="utf-8").read()
             self.assertIn("/opt/tools", body)
             self.assertIn("/opt/more", body)

--- a/cli/tests/test_install_ps1.py
+++ b/cli/tests/test_install_ps1.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Windows PowerShell regression tests for ``scripts/install.ps1``."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+INSTALL_PS1 = ROOT / "scripts" / "install.ps1"
+
+
+def test_all_uv_calls_use_explicit_exit_status_wrapper() -> None:
+    text = INSTALL_PS1.read_text()
+
+    assert "function Invoke-Uv" in text
+    assert "& uv python install" not in text
+    assert "& uv venv" not in text
+    assert "& uv pip install" not in text
+    assert 'Invoke-Uv -Arguments @("python", "install", "3.12")' in text
+    assert 'Invoke-Uv -Arguments @("venv", $Venv' in text
+    assert 'Invoke-Uv -Arguments @("pip", "install"' in text
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires Windows PowerShell native stderr semantics")
+@pytest.mark.parametrize(
+    ("native_exit", "expected"),
+    [(0, "RESULT=continued native_exit=0"), (7, "RESULT=failed native_exit=7")],
+)
+def test_powershell_51_uses_uv_exit_status(tmp_path: Path, native_exit: int, expected: str) -> None:
+    powershell = shutil.which("powershell.exe")
+    if not powershell:
+        pytest.skip("Windows PowerShell is not installed")
+
+    fake_uv = tmp_path / "uv.cmd"
+    fake_uv.write_text(
+        f"@echo uv diagnostic on stderr 1>&2\r\n@exit /b {native_exit}\r\n",
+        encoding="ascii",
+    )
+    command = rf"""
+$ErrorActionPreference = "Stop"
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    "{INSTALL_PS1}", [ref]$tokens, [ref]$errors
+)
+foreach ($name in @("Invoke-Uv", "Ensure-Python")) {{
+    $fn = $ast.Find({{
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name
+    }}, $true)
+    Invoke-Expression $fn.Extent.Text
+}}
+function Write-Step {{ param([string]$Message) }}
+function Write-Ok {{ param([string]$Message) }}
+function Die {{ param([string]$Message) throw $Message }}
+try {{
+    Ensure-Python
+    Write-Output "RESULT=continued native_exit=$LASTEXITCODE"
+}} catch {{
+    Write-Output "RESULT=failed native_exit=$LASTEXITCODE"
+}}
+"""
+    env = os.environ.copy()
+    env["PATH"] = f"{tmp_path}{os.pathsep}{env.get('PATH', '')}"
+
+    completed = subprocess.run(
+        [powershell, "-NoProfile", "-NonInteractive", "-Command", command],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        env=env,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert expected in completed.stdout

--- a/cli/tests/test_install_ps1.py
+++ b/cli/tests/test_install_ps1.py
@@ -13,11 +13,16 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
+from defenseclaw.platform_support import (
+    WINDOWS_PREVIEW_CONNECTORS,
+    WINDOWS_SUPPORTED_CONNECTORS,
+)
 
 ROOT = Path(__file__).resolve().parents[2]
 INSTALL_PS1 = ROOT / "scripts" / "install.ps1"
@@ -33,6 +38,18 @@ def test_all_uv_calls_use_explicit_exit_status_wrapper() -> None:
     assert 'Invoke-Uv -Arguments @("python", "install", "3.12")' in text
     assert 'Invoke-Uv -Arguments @("venv", $Venv' in text
     assert 'Invoke-Uv -Arguments @("pip", "install"' in text
+
+
+def test_windows_installer_offers_only_native_connector_surface() -> None:
+    text = INSTALL_PS1.read_text()
+
+    choices_block = text.split("$ConnectorChoices = @(", 1)[1].split(")", 1)[0]
+    choices = set(re.findall(r'"([a-z]+)"', choices_block))
+    assert choices == WINDOWS_SUPPORTED_CONNECTORS | WINDOWS_PREVIEW_CONNECTORS | {"none"}
+
+    assert "Hermes native hooks (preview)" in text
+    assert "Cursor IDE native hooks (CLI remains WSL-only)" in text
+    assert "function Install-OpenClaw" not in text
 
 
 @pytest.mark.skipif(os.name != "nt", reason="requires Windows PowerShell native stderr semantics")

--- a/cli/tests/test_migrations.py
+++ b/cli/tests/test_migrations.py
@@ -26,6 +26,7 @@ import unittest
 from unittest.mock import patch
 
 import yaml
+from defenseclaw.file_permissions import set_file_mode
 from defenseclaw.migrations import (
     _LEGACY_FLAT_REGO_FILENAMES,
     MigrationContext,
@@ -42,6 +43,8 @@ from defenseclaw.migrations import (
     _read_active_connector_from_yaml,
     run_migrations,
 )
+
+from tests.permissions import assert_owner_only_file
 
 
 def _write_json(path: str, data: dict) -> None:
@@ -1988,12 +1991,16 @@ class TestAtomicWriteTextModePreservation(unittest.TestCase):
         path = os.path.join(self.tmp, "config.yaml")
         with open(path, "w") as f:
             f.write("old\n")
-        os.chmod(path, 0o600)
+        if os.name == "nt":
+            with open(path, "r+") as f:
+                set_file_mode(f.fileno(), path, 0o600)
+        else:
+            os.chmod(path, 0o600)
 
         # Default mode is 0o644, but the existing 0o600 must win.
         self.assertTrue(_atomic_write_text(path, "new\n"))
 
-        self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), 0o600)
+        assert_owner_only_file(path)
         with open(path) as f:
             self.assertEqual(f.read(), "new\n")
 
@@ -2001,7 +2008,7 @@ class TestAtomicWriteTextModePreservation(unittest.TestCase):
         path = os.path.join(self.tmp, "fresh.json")
         # File does not exist yet → the explicit mode pins the perms.
         self.assertTrue(_atomic_write_text(path, "{}", mode=0o600))
-        self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), 0o600)
+        assert_owner_only_file(path)
 
 
 if __name__ == "__main__":

--- a/cli/tests/test_platform_support.py
+++ b/cli/tests/test_platform_support.py
@@ -8,25 +8,37 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Per-OS connector support: parity and Windows-excludes-proxy behavior.
-
-These tests pin the Python ``platform_support`` module against the Go
-``connector.proxyConnectors`` set and against every Python connector list,
-so the "hook-only on Windows" contract cannot silently drift on either
-side. They run on every OS (the filtering takes an explicit ``os_name`` so
-the assertions are host-independent).
-"""
+"""Windows connector status, presentation, and direct-setup parity."""
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+from defenseclaw.commands.cmd_init import _normalize_connector_arg, init_cmd
 from defenseclaw.commands.cmd_setup import (
     _CONNECTOR_NAMES_FALLBACK,
     _HOOK_ENFORCED_CONNECTORS,
     _PROXY_BACKED_CONNECTORS,
 )
+from defenseclaw.commands.cmd_setup import (
+    setup as setup_group,
+)
 from defenseclaw.connector_paths import KNOWN_CONNECTORS
+from defenseclaw.context import AppContext
 from defenseclaw.platform_support import (
+    PREVIEW,
+    PROXY_CONNECTORS,
+    SUPPORTED,
+    UNSUPPORTED,
+    WINDOWS_CONNECTOR_SUPPORT,
+    WINDOWS_PREVIEW_CONNECTORS,
+    WINDOWS_SUPPORTED_CONNECTORS,
     WINDOWS_UNSUPPORTED_CONNECTORS,
+    connector_platform_support,
+    connector_preview_on_os,
     connector_supported_on_os,
     host_os,
     is_proxy_connector,
@@ -43,66 +55,93 @@ from defenseclaw.tui.services.cli_choices import (
     supported_connector_choices,
 )
 
-# Mirror of the Go ``proxyConnectors`` map in
-# internal/gateway/connector/platform_support.go. Any change there must be
-# made here too; the assertions below fail loudly if the two drift.
-PROXY_CONNECTORS = {"openclaw", "zeptoclaw"}
+from tests.helpers import cleanup_app, make_app_context
 
-# The hook-based connectors supported on every OS, including Windows.
-HOOK_CONNECTORS = {
+WINDOWS_SUPPORTED = {
     "codex",
     "claudecode",
-    "hermes",
     "cursor",
     "windsurf",
     "geminicli",
     "copilot",
-    "openhands",
     "antigravity",
     "opencode",
-    "omnigent",
 }
+WINDOWS_PREVIEW = {"hermes"}
+WINDOWS_UNSUPPORTED = {"openhands", "omnigent", "openclaw", "zeptoclaw"}
+ALL_CONNECTORS = WINDOWS_SUPPORTED | WINDOWS_PREVIEW | WINDOWS_UNSUPPORTED
 
 
-def test_windows_unsupported_set_matches_go_proxy_connectors() -> None:
-    assert set(WINDOWS_UNSUPPORTED_CONNECTORS) == PROXY_CONNECTORS
+def test_windows_taxonomy_matches_go_mirror_and_has_reasons() -> None:
+    assert set(WINDOWS_CONNECTOR_SUPPORT) == ALL_CONNECTORS
+    assert set(WINDOWS_SUPPORTED_CONNECTORS) == WINDOWS_SUPPORTED
+    assert set(WINDOWS_PREVIEW_CONNECTORS) == WINDOWS_PREVIEW
+    assert set(WINDOWS_UNSUPPORTED_CONNECTORS) == WINDOWS_UNSUPPORTED
+    for name, support in WINDOWS_CONNECTOR_SUPPORT.items():
+        assert support.status in {SUPPORTED, PREVIEW, UNSUPPORTED}, name
+        assert support.reason.strip(), name
+
+    go_source = (
+        Path(__file__).resolve().parents[2]
+        / "internal"
+        / "gateway"
+        / "connector"
+        / "platform_support.go"
+    ).read_text(encoding="utf-8")
+    go_status = {
+        SUPPORTED: "PlatformSupported",
+        PREVIEW: "PlatformPreview",
+        UNSUPPORTED: "PlatformUnsupported",
+    }
+    for name, support in WINDOWS_CONNECTOR_SUPPORT.items():
+        pattern = (
+            rf'"{re.escape(name)}":\s*\{{\s*'
+            rf'Status:\s*{go_status[support.status]},\s*'
+            rf'Reason:\s*"{re.escape(support.reason)}",'
+        )
+        assert re.search(pattern, go_source), f"Go status/reason drift for {name}"
 
 
-def test_proxy_set_agrees_with_existing_python_sources() -> None:
-    # GUARDRAIL_CONNECTORS (cli_choices) and _PROXY_BACKED_CONNECTORS
-    # (cmd_setup) are the pre-existing names for the same proxy set; the
-    # new single source of truth must agree with both.
-    assert set(GUARDRAIL_CONNECTORS) == PROXY_CONNECTORS
-    assert set(_PROXY_BACKED_CONNECTORS) == PROXY_CONNECTORS
-
-
-def test_hook_enforced_set_is_the_hook_connectors() -> None:
-    assert set(_HOOK_ENFORCED_CONNECTORS) == HOOK_CONNECTORS
-
-
-def test_is_proxy_connector() -> None:
+def test_proxy_topology_is_distinct_from_windows_support() -> None:
+    assert set(PROXY_CONNECTORS) == {"openclaw", "zeptoclaw"}
+    assert set(GUARDRAIL_CONNECTORS) == set(PROXY_CONNECTORS)
+    assert set(_PROXY_BACKED_CONNECTORS) == set(PROXY_CONNECTORS)
     assert is_proxy_connector("openclaw")
     assert is_proxy_connector("zeptoclaw")
-    for name in HOOK_CONNECTORS:
-        assert not is_proxy_connector(name)
+    assert not is_proxy_connector("openhands")
+    assert not is_proxy_connector("omnigent")
 
 
-def test_connector_supported_on_os_windows_excludes_only_proxy() -> None:
-    for name in PROXY_CONNECTORS:
-        assert connector_supported_on_os(name, "windows") is False
-    for name in HOOK_CONNECTORS:
+def test_windows_statuses_and_availability() -> None:
+    for name in WINDOWS_SUPPORTED:
+        assert connector_platform_support(name, "windows").status == SUPPORTED
         assert connector_supported_on_os(name, "windows") is True
+    for name in WINDOWS_PREVIEW:
+        assert connector_platform_support(name, "windows").status == PREVIEW
+        assert connector_preview_on_os(name, "windows") is True
+        assert connector_supported_on_os(name, "windows") is True
+    for name in WINDOWS_UNSUPPORTED:
+        assert connector_platform_support(name, "windows").status == UNSUPPORTED
+        assert connector_supported_on_os(name, "windows") is False
 
 
-def test_connector_supported_on_os_unix_allows_everything() -> None:
+def test_cursor_reason_distinguishes_native_ide_from_wsl_only_cli() -> None:
+    reason = connector_platform_support("cursor", "windows").reason
+    assert "IDE hooks" in reason
+    assert "CLI remains WSL-only" in reason
+
+
+def test_non_windows_behavior_is_unchanged() -> None:
     for os_name in ("linux", "darwin"):
-        for name in PROXY_CONNECTORS | HOOK_CONNECTORS:
-            assert connector_supported_on_os(name, os_name) is True
+        for name in ALL_CONNECTORS:
+            support = connector_platform_support(name, os_name)
+            assert support.status == SUPPORTED
+            assert support.available
 
 
-def test_supported_connectors_preserves_order_and_filters_windows() -> None:
-    ordered = ["openclaw", "codex", "zeptoclaw", "claudecode"]
-    assert supported_connectors(ordered, "windows") == ["codex", "claudecode"]
+def test_supported_connectors_preserves_order_and_keeps_preview() -> None:
+    ordered = ["openclaw", "codex", "hermes", "openhands", "claudecode"]
+    assert supported_connectors(ordered, "windows") == ["codex", "hermes", "claudecode"]
     assert supported_connectors(ordered, "linux") == ordered
 
 
@@ -111,31 +150,129 @@ def test_host_os_returns_known_token() -> None:
 
 
 def test_all_connector_lists_share_one_taxonomy() -> None:
-    # Fixing the historical openhands drift: every Python enumeration of
-    # connectors must contain exactly the proxy + hook connectors.
-    expected = PROXY_CONNECTORS | HOOK_CONNECTORS
-    assert set(KNOWN_CONNECTORS) == expected
-    assert set(_CONNECTOR_NAMES_FALLBACK) == expected
-    assert set(CONNECTORS) == expected
-    assert {c.wire for c in MODE_PICKER_CHOICES} == expected
-    assert set(CONNECTOR_CHOICES) == expected
+    assert set(KNOWN_CONNECTORS) == ALL_CONNECTORS
+    assert set(_CONNECTOR_NAMES_FALLBACK) == ALL_CONNECTORS
+    assert set(CONNECTORS) == ALL_CONNECTORS
+    assert {choice.wire for choice in MODE_PICKER_CHOICES} == ALL_CONNECTORS
+    assert set(CONNECTOR_CHOICES) == ALL_CONNECTORS
+    assert set(_HOOK_ENFORCED_CONNECTORS) == ALL_CONNECTORS - set(PROXY_CONNECTORS)
 
 
-def test_windows_views_exclude_proxy_and_keep_all_hook_connectors() -> None:
-    # cli_choices accessor
-    win_choices = supported_connector_choices("windows")
-    assert set(win_choices) == HOOK_CONNECTORS
-    assert not (set(win_choices) & PROXY_CONNECTORS)
+def test_windows_views_hide_unsupported_and_mark_hermes_preview() -> None:
+    expected = WINDOWS_SUPPORTED | WINDOWS_PREVIEW
+    assert set(supported_connector_choices("windows")) == expected
+    assert set(visible_connector_choices("windows")) == expected
 
-    # mode picker rows
-    win_modes = {c.wire for c in visible_mode_picker_choices("windows")}
-    assert win_modes == HOOK_CONNECTORS
-
-    # first-run wizard field
-    assert set(visible_connector_choices("windows")) == HOOK_CONNECTORS
+    win_modes = visible_mode_picker_choices("windows")
+    assert {choice.wire for choice in win_modes} == expected
+    hermes = next(choice for choice in win_modes if choice.wire == "hermes")
+    assert hermes.label == "Hermes (preview)"
+    assert "Early Beta" in hermes.tagline
 
 
 def test_non_windows_views_are_unfiltered() -> None:
     assert supported_connector_choices("linux") == CONNECTORS
     assert visible_mode_picker_choices("darwin") == MODE_PICKER_CHOICES
     assert visible_connector_choices("linux") == CONNECTOR_CHOICES
+
+
+def test_discovery_default_preserves_non_windows_and_avoids_unsupported_windows() -> None:
+    discovery = object()
+    with patch(
+        "defenseclaw.commands.cmd_init.agent_discovery.discover_agents",
+        return_value=discovery,
+    ), patch(
+        "defenseclaw.commands.cmd_init.agent_discovery.first_installed",
+        return_value="openclaw",
+    ), patch("defenseclaw.platform_support.host_os", return_value="linux"):
+        assert _normalize_connector_arg(None, discover_default=True) == "openclaw"
+
+    with patch(
+        "defenseclaw.commands.cmd_init.agent_discovery.discover_agents",
+        return_value=discovery,
+    ), patch(
+        "defenseclaw.commands.cmd_init.agent_discovery.first_installed",
+        return_value="openclaw",
+    ), patch(
+        "defenseclaw.commands.cmd_init._installed_hook_connectors",
+        return_value=["codex"],
+    ), patch("defenseclaw.platform_support.host_os", return_value="windows"):
+        assert _normalize_connector_arg(None, discover_default=True) == "codex"
+
+
+def test_direct_windows_setup_rejects_unsupported_with_reason() -> None:
+    app, tmp_dir, db_path = make_app_context()
+    try:
+        runner = CliRunner()
+        with patch("defenseclaw.platform_support.host_os", return_value="windows"):
+            openhands = runner.invoke(
+                setup_group,
+                ["openhands", "--yes", "--no-restart"],
+                obj=app,
+            )
+            omnigent = runner.invoke(
+                setup_group,
+                ["omnigent", "--yes", "--no-restart"],
+                obj=app,
+            )
+        assert openhands.exit_code != 0
+        assert "unsupported on windows" in openhands.output
+        assert "requires WSL" in openhands.output
+        assert omnigent.exit_code != 0
+        assert "unsupported on windows" in omnigent.output
+        assert "no supported native Windows" in omnigent.output
+    finally:
+        cleanup_app(app, db_path, tmp_dir)
+
+
+def test_bare_windows_setup_rejects_explicit_unsupported_before_mutation() -> None:
+    app, tmp_dir, db_path = make_app_context()
+    try:
+        runner = CliRunner()
+        with patch("defenseclaw.platform_support.host_os", return_value="windows"):
+            result = runner.invoke(
+                setup_group,
+                ["--connector", "openhands", "--yes", "--no-restart"],
+                obj=app,
+            )
+        assert result.exit_code != 0
+        assert "requires WSL" in result.output
+        assert app.cfg.guardrail.connectors == {}
+    finally:
+        cleanup_app(app, db_path, tmp_dir)
+
+
+def test_guardrail_windows_setup_rejects_unsupported_before_mutation() -> None:
+    app, tmp_dir, db_path = make_app_context()
+    try:
+        original = app.cfg.guardrail.connector
+        with patch("defenseclaw.platform_support.host_os", return_value="windows"):
+            result = CliRunner().invoke(
+                setup_group,
+                [
+                    "guardrail",
+                    "--connector",
+                    "openhands",
+                    "--non-interactive",
+                    "--no-restart",
+                    "--no-verify",
+                ],
+                obj=app,
+            )
+        assert result.exit_code != 0
+        assert "requires WSL" in result.output
+        assert app.cfg.guardrail.connector == original
+    finally:
+        cleanup_app(app, db_path, tmp_dir)
+
+
+def test_noninteractive_windows_init_rejects_unsupported_before_bootstrap() -> None:
+    with patch("defenseclaw.platform_support.host_os", return_value="windows"):
+        result = CliRunner().invoke(
+            init_cmd,
+            ["--non-interactive", "--yes", "--connector", "openhands"],
+            obj=AppContext(),
+        )
+    assert result.exit_code != 0
+    assert "unsupported on windows" in result.output
+    assert "requires WSL" in result.output

--- a/cli/tests/test_remediation_config.py
+++ b/cli/tests/test_remediation_config.py
@@ -67,6 +67,8 @@ from defenseclaw.logger import Logger
 from defenseclaw.migrations import run_migrations
 from defenseclaw.observability.writer import apply_preset
 
+from tests.permissions import assert_owner_only_file
+
 # ---------------------------------------------------------------------------
 # F-0022 / F-0023 / F-0024 — robust TLS boolean coercion
 # ---------------------------------------------------------------------------
@@ -681,10 +683,9 @@ def test_f0442_existing_loose_dotenv_is_tightened(tmp_path):
     secret = "dd-secret-from-f0442"
     apply_preset("datadog", {"site": "us5"}, data_dir, secret_value=secret)
 
-    mode = stat.S_IMODE(os.stat(dotenv_path).st_mode)
     content = Path(dotenv_path).read_text(encoding="utf-8")
     # The pre-existing world/group-readable dotenv is tightened to 0600...
-    assert mode == 0o600, oct(mode)
+    assert_owner_only_file(dotenv_path)
     # ...and still carries the freshly written secret.
     assert f"DD_API_KEY={secret}" in content
 
@@ -698,6 +699,5 @@ def test_f0442_fresh_dotenv_is_owner_only(tmp_path):
     apply_preset("datadog", {"site": "us5"}, data_dir, secret_value=secret)
 
     dotenv_path = os.path.join(data_dir, ".env")
-    mode = stat.S_IMODE(os.stat(dotenv_path).st_mode)
-    assert mode == 0o600, oct(mode)
+    assert_owner_only_file(dotenv_path)
     assert f"DD_API_KEY={secret}" in Path(dotenv_path).read_text(encoding="utf-8")

--- a/cli/tests/test_remediation_connector_webhooks.py
+++ b/cli/tests/test_remediation_connector_webhooks.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import json
 import os
-import stat
 import urllib.error
 import urllib.request
 from email.message import Message
@@ -49,6 +48,8 @@ from defenseclaw.openclaw_guardrail import (
 from defenseclaw.webhooks import WebhookView
 from defenseclaw.webhooks.dispatch import _redact_payload_preview
 from defenseclaw.webhooks.writer import _write_yaml, redact_webhook_url
+
+from tests.permissions import assert_owner_only_file
 
 
 # ---------------------------------------------------------------------------
@@ -145,13 +146,23 @@ def test_f0441_write_yaml_is_0600_and_ignores_tmp_symlink(tmp_path):
     target = tmp_path / "webhooks.yaml"
     sentinel = tmp_path / "sentinel.txt"
     sentinel.write_text("SENTINEL", encoding="utf-8")
-    os.symlink(sentinel, str(target) + ".tmp")
+    predictable_tmp = str(target) + ".tmp"
+    if os.name == "nt":
+        # Creating symlinks requires an optional Windows privilege. A planted
+        # regular file still proves the writer does not use the predictable
+        # name; the symlink form remains covered on POSIX.
+        with open(predictable_tmp, "w", encoding="utf-8") as f:
+            f.write("SENTINEL")
+    else:
+        os.symlink(sentinel, predictable_tmp)
 
     _write_yaml(str(target), {"webhooks": [{"name": "x"}]})
 
-    mode = stat.S_IMODE(os.stat(target).st_mode)
-    assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+    assert_owner_only_file(target)
     assert sentinel.read_text(encoding="utf-8") == "SENTINEL"
+    if os.name == "nt":
+        with open(predictable_tmp, encoding="utf-8") as f:
+            assert f.read() == "SENTINEL"
     assert "name: x" in target.read_text(encoding="utf-8")
 
 
@@ -287,13 +298,20 @@ def test_f0186_write_atomically_is_0600_and_ignores_tmp_symlink(tmp_path):
     cfg_path = tmp_path / "config.yaml"
     sentinel = tmp_path / "sentinel.txt"
     sentinel.write_text("SENTINEL", encoding="utf-8")
-    os.symlink(sentinel, str(cfg_path) + ".tmp")
+    predictable_tmp = str(cfg_path) + ".tmp"
+    if os.name == "nt":
+        with open(predictable_tmp, "w", encoding="utf-8") as f:
+            f.write("SENTINEL")
+    else:
+        os.symlink(sentinel, predictable_tmp)
 
     _write_atomically(str(cfg_path), {"data_dir": str(tmp_path)})
 
-    mode = stat.S_IMODE(os.stat(cfg_path).st_mode)
-    assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+    assert_owner_only_file(cfg_path)
     assert sentinel.read_text(encoding="utf-8") == "SENTINEL"
+    if os.name == "nt":
+        with open(predictable_tmp, encoding="utf-8") as f:
+            assert f.read() == "SENTINEL"
     assert "data_dir:" in cfg_path.read_text(encoding="utf-8")
 
 

--- a/cli/tests/test_scanner_binary.py
+++ b/cli/tests/test_scanner_binary.py
@@ -1,0 +1,118 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Scanner executable resolution for installed CLI virtual environments."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import call, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from click.testing import CliRunner
+from defenseclaw.commands.cmd_doctor import _check_scanners, _DoctorResult
+from defenseclaw.commands.cmd_status import status as status_cmd
+from defenseclaw.scanner_binary import resolve_scanner_binary
+
+from tests.helpers import cleanup_app, make_app_context
+
+
+class ScannerBinaryResolverTests(unittest.TestCase):
+    @patch("defenseclaw.scanner_binary.shutil.which")
+    @patch("defenseclaw.scanner_binary.sysconfig.get_path", return_value=r"C:\managed\.venv\Scripts")
+    def test_managed_scripts_directory_precedes_path(self, _get_path, mock_which):
+        managed = r"C:\managed\.venv\Scripts\skill-scanner.EXE"
+        mock_which.return_value = managed
+
+        self.assertEqual(resolve_scanner_binary("skill-scanner"), managed)
+        self.assertEqual(
+            mock_which.call_args_list,
+            [call("skill-scanner", path=r"C:\managed\.venv\Scripts")],
+        )
+
+    @patch("defenseclaw.scanner_binary.shutil.which")
+    @patch("defenseclaw.scanner_binary.sysconfig.get_path", return_value="/managed/.venv/bin")
+    def test_path_fallback_is_preserved_on_unix(self, _get_path, mock_which):
+        mock_which.side_effect = [None, "/usr/local/bin/mcp-scanner"]
+
+        self.assertEqual(resolve_scanner_binary("mcp-scanner"), "/usr/local/bin/mcp-scanner")
+        self.assertEqual(
+            mock_which.call_args_list,
+            [call("mcp-scanner", path="/managed/.venv/bin"), call("mcp-scanner")],
+        )
+
+    @patch("defenseclaw.scanner_binary.shutil.which")
+    def test_blank_binary_is_not_searched(self, mock_which):
+        self.assertIsNone(resolve_scanner_binary("  "))
+        mock_which.assert_not_called()
+
+
+class ScannerCommandIntegrationTests(unittest.TestCase):
+    def setUp(self):
+        self.app, self.tmp_dir, self.db_path = make_app_context()
+
+    def tearDown(self):
+        cleanup_app(self.app, self.db_path, self.tmp_dir)
+
+    @staticmethod
+    def _resolve(binary: str) -> str | None:
+        if binary == "skill-scanner":
+            return r"C:\managed\.venv\Scripts\skill-scanner.exe"
+        return None
+
+    @patch("defenseclaw.gateway.OrchestratorClient.is_running", return_value=False)
+    @patch("defenseclaw.commands.cmd_status.resolve_scanner_binary", side_effect=_resolve)
+    def test_status_human_and_json_share_resolution(self, _resolve_binary, _is_running):
+        runner = CliRunner()
+
+        human = runner.invoke(status_cmd, [], obj=self.app, catch_exceptions=False)
+        machine = runner.invoke(status_cmd, ["--json"], obj=self.app, catch_exceptions=False)
+
+        self.assertEqual(human.exit_code, 0, msg=human.output)
+        self.assertEqual(machine.exit_code, 0, msg=machine.output)
+        self.assertIn("skill-scanner   installed", human.output)
+        self.assertIn("mcp-scanner     not found", human.output)
+        self.assertEqual(
+            json.loads(machine.output)["scanners"],
+            {
+                "skill-scanner": "installed",
+                "mcp-scanner": "not_found",
+                "codeguard": "built-in",
+            },
+        )
+
+    @patch("defenseclaw.commands.cmd_doctor.resolve_scanner_binary", side_effect=_resolve)
+    def test_doctor_reports_resolved_managed_path(self, _resolve_binary):
+        cfg = SimpleNamespace(
+            scanners=SimpleNamespace(
+                skill_scanner=SimpleNamespace(binary="skill-scanner"),
+                mcp_scanner=SimpleNamespace(binary="mcp-scanner"),
+            )
+        )
+        result = _DoctorResult()
+
+        _check_scanners(cfg, result)
+
+        self.assertEqual(result.checks[0]["status"], "pass")
+        self.assertEqual(
+            result.checks[0]["detail"],
+            r"C:\managed\.venv\Scripts\skill-scanner.exe",
+        )
+        self.assertEqual(result.checks[1]["status"], "fail")
+        self.assertIn("managed environment or on PATH", result.checks[1]["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/tests/test_secure_write_permissions.py
+++ b/cli/tests/test_secure_write_permissions.py
@@ -1,0 +1,225 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-platform regressions for secure atomic-write permissions."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from types import SimpleNamespace
+
+import pytest
+import yaml
+from defenseclaw import file_permissions, migrations
+from defenseclaw.commands import cmd_setup_observability as setup_writer
+from defenseclaw.observability import writer as observability_writer
+from defenseclaw.webhooks import writer as webhook_writer
+
+from tests.permissions import assert_owner_only_file
+
+_ATOMIC_WRITERS = [
+    (
+        "webhooks",
+        webhook_writer,
+        lambda path: webhook_writer._write_yaml(
+            os.fspath(path),
+            {"webhooks": [{"name": "secure-write"}]},
+        ),
+    ),
+    (
+        "setup-observability",
+        setup_writer,
+        lambda path: setup_writer._write_atomically(
+            os.fspath(path),
+            {"data_dir": os.fspath(path.parent)},
+        ),
+    ),
+]
+
+
+def _assert_staging_cleanup(record: dict[str, object]) -> None:
+    fd = record["fd"]
+    path = record["path"]
+    assert isinstance(fd, int)
+    assert isinstance(path, str)
+
+    try:
+        os.fstat(fd)
+    except OSError:
+        descriptor_open = False
+    else:
+        descriptor_open = True
+
+    staging_exists = os.path.exists(path)
+    if descriptor_open:
+        os.close(fd)
+    if staging_exists:
+        os.unlink(path)
+
+    assert descriptor_open is False
+    assert staging_exists is False
+
+
+@pytest.mark.parametrize(("_name", "module", "write"), _ATOMIC_WRITERS)
+@pytest.mark.parametrize("failure_stage", ["permission", "serialize", "replace"])
+def test_atomic_writers_close_and_remove_staging_file_on_failure(
+    monkeypatch,
+    tmp_path,
+    _name,
+    module,
+    write,
+    failure_stage,
+):
+    record: dict[str, object] = {}
+    real_mkstemp = tempfile.mkstemp
+
+    def recording_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        record.update(fd=fd, path=path)
+        return fd, path
+
+    monkeypatch.setattr(tempfile, "mkstemp", recording_mkstemp)
+
+    def fail(*_args, **_kwargs):
+        raise OSError(f"injected {failure_stage} failure")
+
+    if failure_stage == "permission":
+        monkeypatch.setattr(module, "set_file_mode", fail)
+    elif failure_stage == "serialize":
+        monkeypatch.setattr(yaml, "safe_dump", fail)
+    else:
+        monkeypatch.setattr(os, "replace", fail)
+
+    target = tmp_path / f"{_name}.yaml"
+    target.write_text("ORIGINAL\n", encoding="utf-8")
+    with pytest.raises(OSError, match=f"injected {failure_stage} failure"):
+        write(target)
+
+    _assert_staging_cleanup(record)
+    assert target.read_text(encoding="utf-8") == "ORIGINAL\n"
+
+
+def test_migration_writer_closes_and_removes_staging_file_when_permissions_fail(
+    monkeypatch,
+    tmp_path,
+):
+    record: dict[str, object] = {}
+    real_mkstemp = tempfile.mkstemp
+
+    def recording_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        record.update(fd=fd, path=path)
+        return fd, path
+
+    monkeypatch.setattr(tempfile, "mkstemp", recording_mkstemp)
+    monkeypatch.setattr(
+        migrations,
+        "set_file_mode",
+        lambda *_args: (_ for _ in ()).throw(OSError("injected permission failure")),
+    )
+
+    target = tmp_path / "migration-secret.yaml"
+    assert migrations._atomic_write_text(os.fspath(target), "secret\n", mode=0o600) is False
+    _assert_staging_cleanup(record)
+
+
+def test_dotenv_writer_closes_descriptor_when_permissions_fail(monkeypatch, tmp_path):
+    record: dict[str, int] = {}
+    real_open = os.open
+
+    def recording_open(*args, **kwargs):
+        fd = real_open(*args, **kwargs)
+        record["fd"] = fd
+        return fd
+
+    monkeypatch.setattr(os, "open", recording_open)
+    monkeypatch.setattr(
+        observability_writer,
+        "set_file_mode",
+        lambda *_args: (_ for _ in ()).throw(OSError("injected permission failure")),
+    )
+
+    with pytest.raises(OSError, match="injected permission failure"):
+        observability_writer._write_dotenv(os.fspath(tmp_path / ".env"), {"TOKEN": "secret"})
+
+    fd = record["fd"]
+    try:
+        os.fstat(fd)
+    except OSError:
+        descriptor_open = False
+    else:
+        descriptor_open = True
+        os.close(fd)
+    assert descriptor_open is False
+
+
+def test_posix_file_mode_still_uses_descriptor_api(monkeypatch):
+    calls: list[tuple[int, int]] = []
+    fake_os = SimpleNamespace(
+        name="posix",
+        fchmod=lambda fd, mode: calls.append((fd, mode)),
+        chmod=lambda *_args: pytest.fail("path chmod must not replace POSIX fchmod"),
+    )
+    monkeypatch.setattr(file_permissions, "os", fake_os)
+
+    file_permissions.set_file_mode(17, "/tmp/secret", 0o600)
+
+    assert calls == [(17, 0o600)]
+
+
+@pytest.mark.skipif(os.name != "nt", reason="validates native Windows DACLs")
+@pytest.mark.allow_subprocess
+@pytest.mark.parametrize(
+    ("name", "write"),
+    [
+        ("webhooks", _ATOMIC_WRITERS[0][2]),
+        ("setup-observability", _ATOMIC_WRITERS[1][2]),
+        (
+            "migrations",
+            lambda path: migrations._atomic_write_text(
+                os.fspath(path),
+                "secret\n",
+                mode=0o600,
+            ),
+        ),
+        (
+            "observability-dotenv",
+            lambda path: observability_writer._write_dotenv(
+                os.fspath(path),
+                {"TOKEN": "secret"},
+            ),
+        ),
+    ],
+)
+def test_secret_writers_replace_inherited_windows_access(tmp_path, name, write):
+    broad_dir = tmp_path / name
+    broad_dir.mkdir()
+    subprocess.run(
+        ["icacls", os.fspath(broad_dir), "/grant", "*S-1-1-0:(OI)(CI)(RX)"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    target = broad_dir / "secret.yaml"
+
+    result = write(target)
+
+    if name == "migrations":
+        assert result is True
+    assert target.is_file()
+    assert_owner_only_file(target)

--- a/cli/tests/tui/test_executor.py
+++ b/cli/tests/tui/test_executor.py
@@ -12,12 +12,18 @@
 
 from __future__ import annotations
 
+import ast
+import asyncio
+import inspect
+import os
 import sys
 
+import defenseclaw.tui.app as app_module
 import pytest
-from defenseclaw.tui.executor import CommandExecutor
+from defenseclaw.tui.executor import CommandExecutor, resolve_subprocess_argv
 
 
+@pytest.mark.skipif(os.name != "posix", reason="stdlib PTYs are POSIX-only")
 @pytest.mark.asyncio
 async def test_executor_pty_forwards_interactive_stdin() -> None:
     executor = CommandExecutor(use_pty=True)
@@ -52,3 +58,128 @@ async def test_executor_pty_forwards_interactive_stdin() -> None:
     assert "Name?" in output
     assert "hello Ada" in output
     assert exit_codes == [0]
+
+
+def test_executor_default_pty_mode_matches_platform() -> None:
+    assert CommandExecutor().use_pty is (os.name == "posix")
+
+
+@pytest.mark.skipif(os.name == "posix", reason="non-POSIX platform behavior")
+def test_executor_rejects_forced_pty_on_windows() -> None:
+    with pytest.raises(ValueError, match="only supported on POSIX"):
+        CommandExecutor(use_pty=True)
+
+
+def test_self_cli_resolves_via_current_python_not_path_shim() -> None:
+    argv = resolve_subprocess_argv("defenseclaw", ("keys", "list", "--json"))
+
+    assert argv == (
+        os.path.abspath(sys.executable),
+        "-m",
+        "defenseclaw.main",
+        "keys",
+        "list",
+        "--json",
+    )
+    assert not argv[0].lower().endswith((".cmd", ".bat"))
+
+    shim_argv = resolve_subprocess_argv(
+        r"C:\Users\test\.local\bin\defenseclaw.cmd",
+        ("doctor",),
+    )
+    assert shim_argv[:3] == argv[:3]
+    assert shim_argv[3:] == ("doctor",)
+
+
+@pytest.mark.asyncio
+async def test_executor_launches_self_cli_with_resolved_argv(monkeypatch) -> None:
+    seen: list[tuple[str, ...]] = []
+
+    class EmptyStdout:
+        @staticmethod
+        async def readline() -> bytes:
+            return b""
+
+    class Process:
+        stdin = None
+        stdout = EmptyStdout()
+        returncode = 0
+
+        @staticmethod
+        async def wait() -> int:
+            return 0
+
+    async def fake_exec(*argv: str, **_kwargs) -> Process:
+        seen.append(argv)
+        return Process()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    events = [
+        event
+        async for event in CommandExecutor(use_pty=False).run(
+            "defenseclaw",
+            ("doctor",),
+        )
+    ]
+
+    assert seen == [
+        (
+            os.path.abspath(sys.executable),
+            "-m",
+            "defenseclaw.main",
+            "doctor",
+        )
+    ]
+    assert events[-1].exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_credentials_loader_uses_resolved_self_cli(monkeypatch, tmp_path) -> None:
+    seen: list[tuple[str, ...]] = []
+
+    class Process:
+        returncode = 0
+
+        @staticmethod
+        async def communicate() -> tuple[bytes, bytes]:
+            return b"[]", b""
+
+    async def fake_exec(*argv: str, **_kwargs) -> Process:
+        seen.append(argv)
+        return Process()
+
+    app = app_module.DefenseClawTUI(data_dir=tmp_path)
+    monkeypatch.setattr(app_module.asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(app, "_render_chrome", lambda: None)
+
+    await app._load_setup_credentials()  # noqa: SLF001 - focused subprocess wiring.
+
+    assert seen == [
+        (
+            os.path.abspath(sys.executable),
+            "-m",
+            "defenseclaw.main",
+            "keys",
+            "list",
+            "--json",
+        )
+    ]
+
+
+def test_every_direct_app_subprocess_uses_central_argv_resolution() -> None:
+    tree = ast.parse(inspect.getsource(app_module))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "create_subprocess_exec"
+    ]
+
+    assert calls, "expected direct TUI subprocess call sites"
+    for call in calls:
+        assert call.args and isinstance(call.args[0], ast.Starred)
+        resolver_call = call.args[0].value
+        assert isinstance(resolver_call, ast.Call)
+        assert isinstance(resolver_call.func, ast.Name)
+        assert resolver_call.func.id == "resolve_subprocess_argv"

--- a/cli/tests/tui/test_mode_picker.py
+++ b/cli/tests/tui/test_mode_picker.py
@@ -19,6 +19,7 @@ from defenseclaw.tui.screens.mode_picker import (
     choice_for_hotkey,
     choice_for_wire,
     preview_for_switch,
+    visible_mode_picker_choices,
 )
 from textual.app import App, ComposeResult
 from textual.widgets import Static
@@ -79,9 +80,10 @@ async def test_mode_picker_hotkey_returns_connector() -> None:
 @pytest.mark.asyncio
 async def test_mode_picker_mouse_click_returns_connector() -> None:
     app = ModePickerHarness("openclaw")
+    codex_row = next(i for i, choice in enumerate(visible_mode_picker_choices()) if choice.wire == "codex")
 
     async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.click("#action-menu-row-3")
+        await pilot.click(f"#action-menu-row-{codex_row}")
         await pilot.pause()
 
         assert app.result == "codex"

--- a/cli/tests/tui/test_setup_panel.py
+++ b/cli/tests/tui/test_setup_panel.py
@@ -53,6 +53,7 @@ from defenseclaw.tui.panels.setup import (
     wizard_state_summary,
 )
 from defenseclaw.tui.screens.model_picker import filter_models, picker_rows
+from defenseclaw.tui.services.cli_choices import supported_connector_choices
 from defenseclaw.tui.services.setup_state import (
     ConfigDiffEntry,
     ConfigField,
@@ -880,7 +881,7 @@ def test_config_field_catalog_preserves_secret_kind_and_choice_options() -> None
 
     assert _field_by_key(sections, "llm.api_key").kind == "password"
     assert _field_by_key(sections, "openshell.auto_pair").options == ("", "true", "false")
-    assert _field_by_key(sections, "claw.mode").options == CONNECTORS
+    assert _field_by_key(sections, "claw.mode").options == supported_connector_choices()
 
 
 def test_setup_wizard_info_and_form_field_hints_are_complete() -> None:

--- a/docs/CONNECTOR-MATRIX.md
+++ b/docs/CONNECTOR-MATRIX.md
@@ -43,13 +43,10 @@ defenseclaw setup omnigent --mode action --yes
 omnigent server --config "${OMNIGENT_CONFIG_HOME:-$HOME/.omnigent}/config.yaml"
 ```
 
-On Windows PowerShell, run:
-
-```powershell
-defenseclaw setup omnigent --mode action --yes
-$configHome = if ($env:OMNIGENT_CONFIG_HOME) { $env:OMNIGENT_CONFIG_HOME } else { Join-Path $HOME ".omnigent" }
-omnigent server --config (Join-Path $configHome "config.yaml")
-```
+OmniGent connector setup is not supported on native Windows. Its terminal
+runner requires `tmux`, its documented OS-sandbox backends are Linux/macOS,
+and its Windows desktop application is not yet available. DefenseClaw does not
+add a WSL implementation; use this connector on macOS/Linux.
 
 `~/.omnigent/config.yaml` is the default. When `OMNIGENT_CONFIG_HOME` is set,
 both OmniGent and DefenseClaw use `OMNIGENT_CONFIG_HOME/config.yaml` instead
@@ -115,21 +112,49 @@ to a hook connector believing it changes the agent's model.
 
 ## Platform support
 
-| Connector | macOS | Linux | Windows |
-| --------- | ----- | ----- | ------- |
-| OpenClaw, ZeptoClaw (proxy) | OK | OK | not supported |
-| Claude Code, Codex, Hermes, Cursor, Windsurf, Gemini CLI, Copilot CLI, OpenHands, Antigravity, OpenCode, OmniGent (hook-based) | OK | OK | OK |
+Support status is about the complete DefenseClaw integration on the named host,
+not merely whether the upstream agent has some Windows build. `preview` remains
+selectable with an explicit warning; `unsupported` is hidden from pickers and
+rejected by scripted/direct setup with the reason below.
 
-Windows is **hook-only**: the shell-hook connectors run their hook
-decisions natively in the `defenseclaw` binary (the agent invokes
-`defenseclaw hook --connector <name> --event <event>`), so no Git Bash, `jq`,
-or shell shims are required. OpenCode is cross-platform without shims by a
-different route — its bridge plugin is JavaScript and calls the gateway over
-HTTP directly, so it never needs the native hook binary. The proxy connectors (OpenClaw, ZeptoClaw) need
-the local guardrail proxy, which DefenseClaw does not host on Windows; they are
-hidden from the connector pickers and rejected by setup there. The Go registry
-(`connectorSupportedOnOS`) and the Python `platform_support` module are the two
-sources of truth for this gating, kept in sync by a parity test.
+| Connector | macOS | Linux | Native Windows | Windows reason |
+| --------- | ----- | ----- | -------------- | -------------- |
+| Codex | supported | supported | supported | Current Codex releases provide a native PowerShell installer; DefenseClaw uses its native hook entrypoint. |
+| Claude Code | supported | supported | supported | Native Windows with Git for Windows is documented and supports command hooks. |
+| Cursor | supported | supported | supported (IDE hooks) | Cursor IDE hooks are native. **Cursor CLI remains WSL-only** and native DefenseClaw setup does not install or configure it. |
+| Windsurf | supported | supported | supported | Cascade documents Windows hook locations and PowerShell/command execution. |
+| Gemini CLI | supported | supported | supported | Hook reference and best practices document Windows/PowerShell execution. |
+| Copilot CLI | supported | supported | supported | GitHub documents Windows Copilot CLI hooks using PowerShell 7+. |
+| Antigravity | supported | supported | supported | Antigravity runs natively on Windows and exposes local JSON hooks. |
+| OpenCode | supported | supported | supported | OpenCode runs directly on Windows; the DefenseClaw bridge is an auto-loaded JavaScript plugin. |
+| Hermes | supported | supported | **preview** | Upstream calls native Windows support **Early Beta** and recommends WSL2 for the most battle-tested path. |
+| OpenHands | supported | supported | unsupported | OpenHands CLI explicitly requires WSL; DefenseClaw has no WSL connector implementation. |
+| OmniGent | supported | supported | unsupported | The terminal path requires `tmux`, the OS sandbox documents Linux/macOS backends, and the Windows desktop app is still pending. |
+| OpenClaw | supported | supported | unsupported | OpenClaw itself has a native path, but DefenseClaw's connector requires the local guardrail-proxy lifecycle, which DefenseClaw does not host on Windows. |
+| ZeptoClaw | supported | supported | unsupported | Upstream publishes macOS/Linux support, and the DefenseClaw connector also requires the unavailable Windows guardrail proxy. |
+
+Evidence checked 2026-06-30 against the current upstream documentation:
+[Codex install](https://github.com/openai/codex#quickstart),
+[Claude Code Windows setup](https://docs.anthropic.com/en/docs/claude-code/getting-started),
+[Cursor CLI installation](https://docs.cursor.com/en/cli/installation),
+[Cursor hooks](https://cursor.com/docs/hooks),
+[Windsurf Cascade hooks](https://docs.windsurf.com/windsurf/cascade/hooks),
+[Gemini CLI hooks](https://geminicli.com/docs/hooks/reference/),
+[Copilot CLI hooks](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks),
+[Antigravity hooks](https://antigravity.google/docs/hooks),
+[OpenCode Windows](https://opencode.ai/docs/windows-wsl/),
+[OpenCode plugins](https://opencode.ai/docs/plugins/),
+[Hermes native Windows beta](https://github.com/NousResearch/hermes-agent#quick-install),
+[OpenHands CLI quick start](https://docs.openhands.dev/openhands/usage/cli/quick-start),
+[OmniGent terminal](https://omnigent.ai/docs/interact/terminal),
+[OmniGent sandbox](https://omnigent.ai/docs/policies/os-sandbox), and
+[ZeptoClaw installation](https://zeptoclaw.com/docs/getting-started/installation/).
+
+Windows DefenseClaw is **hook-only**. Supported command-hook connectors invoke
+`defenseclaw hook --connector <name> --event <event>` natively, without Git
+Bash, `jq`, shell shims, or WSL. OpenCode uses its JavaScript bridge directly.
+The Go registry and Python `platform_support` module mirror the same
+supported/preview/unsupported taxonomy and reasons, pinned by parity tests.
 
 ## Versioned Hook Contracts
 
@@ -275,10 +300,10 @@ harmless (permission denied) if a regression ever lets it through.
 | Copilot CLI | live\* | live\* | live\* | `copilot -p` | user-level hooks only; entitled token |
 | OpenHands | live | — | — | `openhands --headless --json` | Docker runtime, Linux-only |
 | OpenCode | contract-only | contract-only | contract-only | — | JS bridge plugin (tool.execute.before blocks); live smoke pending |
-| Hermes | contract-only | contract-only | contract-only | — | full lifecycle mapped (`hermes-hooks-v1`): `pre_tool_call` blocks, `pre_llm_call` injects context, `post_tool_call`/`post_llm_call`/session/subagent observe; live smoke pending |
+| Hermes | contract-only | contract-only | contract-only (preview) | — | Native Windows is upstream Early Beta; full lifecycle mapped (`hermes-hooks-v1`): `pre_tool_call` blocks, `pre_llm_call` injects context, `post_tool_call`/`post_llm_call`/session/subagent observe; live smoke pending |
 | Windsurf | contract-only | contract-only | contract-only | — | no headless CLI/SDK |
 | Antigravity | contract-only | contract-only | contract-only | — | headless auth is OAuth, no API key |
-| OmniGent | contract-only | contract-only | contract-only | — | Python custom-policy bridge covered by local integration tests; live smoke pending |
+| OmniGent | contract-only | contract-only | — | — | Native Windows connector unsupported; Python custom-policy bridge covered by local integration tests on supported hosts; live smoke pending |
 
 `\*` = advisory cell (`continue-on-error`) until it goes consistently green.
 All Windows live cells and every Copilot cell start advisory; they are promoted

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -17,9 +17,7 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -30,9 +28,15 @@ import (
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
 	"github.com/defenseclaw/defenseclaw/internal/daemon"
+	"github.com/defenseclaw/defenseclaw/internal/gateway"
 )
 
-const defaultStopTimeout = 10 * time.Second
+const (
+	defaultStopTimeout           = 10 * time.Second
+	defaultStartReadinessTimeout = 10 * time.Second
+	defaultReadinessPollInterval = 100 * time.Millisecond
+	defaultReadinessHTTPTimeout  = time.Second
+)
 
 var startCmd = &cobra.Command{
 	Use:   "start",
@@ -99,7 +103,26 @@ func runStart(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("start daemon: %w", err)
 	}
 
-	fmt.Printf("%s (PID %d)\n", Style("OK", "fg=green", "bold"), pid)
+	cfg, cfgErr := config.Load()
+	if cfg == nil {
+		cfg = config.DefaultConfig()
+	}
+	snap, ready, err := waitForGatewayReadiness(
+		&http.Client{Timeout: defaultReadinessHTTPTimeout},
+		sidecarHealthURL(cfg),
+		defaultStartReadinessTimeout,
+		defaultReadinessPollInterval,
+		func() bool {
+			running, currentPID := d.IsRunning()
+			return running && currentPID == pid
+		},
+	)
+	if err != nil {
+		fmt.Println(Style("FAILED", "fg=red", "bold"))
+		return fmt.Errorf("start daemon readiness: %w (check %s for errors)", err, d.LogFile())
+	}
+
+	printDaemonStartResult(pid, snap, ready)
 	fmt.Println()
 	fmt.Printf("  Log file: %s\n", d.LogFile())
 	fmt.Printf("  PID file: %s\n", d.PIDFile())
@@ -109,7 +132,6 @@ func runStart(cmd *cobra.Command, _ []string) error {
 	printSplunkLocalHint()
 
 	// Auto-start watchdog if enabled in config.
-	cfg, cfgErr := config.Load()
 	if cfgErr == nil && cfg.Gateway.Watchdog.Enabled {
 		if err := runWatchdogStart(nil, nil); err != nil {
 			fmt.Printf("  Watchdog: auto-start failed: %v\n", err)
@@ -171,15 +193,32 @@ func runRestart(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("start daemon: %w", err)
 	}
 
-	fmt.Printf("%s (PID %d)\n", Style("OK", "fg=green", "bold"), pid)
+	cfg, cfgErr := config.Load()
+	if cfg == nil {
+		cfg = config.DefaultConfig()
+	}
+	snap, ready, err := waitForGatewayReadiness(
+		&http.Client{Timeout: defaultReadinessHTTPTimeout},
+		sidecarHealthURL(cfg),
+		defaultStartReadinessTimeout,
+		defaultReadinessPollInterval,
+		func() bool {
+			running, currentPID := d.IsRunning()
+			return running && currentPID == pid
+		},
+	)
+	if err != nil {
+		fmt.Println(Style("FAILED", "fg=red", "bold"))
+		return fmt.Errorf("restart daemon readiness: %w (check %s for errors)", err, d.LogFile())
+	}
+
+	printDaemonStartResult(pid, snap, ready)
 	fmt.Println()
 	fmt.Printf("  Log file: %s\n", d.LogFile())
 	fmt.Println()
-	printCompactHealthSummary(cfg)
 	printSplunkLocalHint()
 
 	// Re-start watchdog if enabled in config.
-	cfg, cfgErr := config.Load()
 	if cfgErr == nil && cfg.Gateway.Watchdog.Enabled {
 		if err := runWatchdogStart(nil, nil); err != nil {
 			fmt.Printf("  Warning: watchdog auto-start failed: %v\n", err)
@@ -245,64 +284,112 @@ func readDotEnv(path string) map[string]string {
 	return env
 }
 
-// printCompactHealthSummary polls /health and prints a one-line status.
-func printCompactHealthSummary(cfg *config.Config) {
-	if cfg == nil {
-		return
+// waitForGatewayReadiness waits for the health endpoint to publish a running
+// API state. The endpoint being reachable is not enough: it can briefly serve
+// the initial "starting" snapshot before APIServer marks itself running.
+// A live process that does not become ready by the deadline is returned as a
+// truthful STARTING state; a process exit or explicit API error fails fast.
+func waitForGatewayReadiness(
+	client *http.Client,
+	healthURL string,
+	timeout time.Duration,
+	pollInterval time.Duration,
+	processRunning func() bool,
+) (gateway.HealthSnapshot, bool, error) {
+	if pollInterval <= 0 {
+		pollInterval = defaultReadinessPollInterval
 	}
-	apiPort := cfg.Gateway.APIPort
-	if apiPort == 0 {
-		apiPort = 18790
-	}
-	url := fmt.Sprintf("http://127.0.0.1:%d/health", apiPort)
+	deadline := time.Now().Add(timeout)
+	var lastSnap gateway.HealthSnapshot
+	var lastProbeErr error
 
-	client := &http.Client{Timeout: 3 * time.Second}
-	for i := 0; i < 5; i++ {
-		time.Sleep(time.Second)
-		resp, err := client.Get(url)
-		if err != nil {
-			continue
+	for {
+		if processRunning != nil && !processRunning() {
+			if lastProbeErr != nil {
+				return lastSnap, false, fmt.Errorf(
+					"gateway process exited before readiness (last health probe: %v)",
+					lastProbeErr,
+				)
+			}
+			return lastSnap, false, fmt.Errorf("gateway process exited before readiness")
 		}
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
-		resp.Body.Close()
-		if resp.StatusCode == 200 {
-			fmt.Printf("  Health: %s\n", summarizeHealth(body))
-			return
+
+		snap, err := fetchSidecarHealth(client, healthURL)
+		if err == nil {
+			lastSnap = snap
+			lastProbeErr = nil
+			switch snap.API.State {
+			case gateway.StateRunning:
+				return snap, true, nil
+			case gateway.StateError:
+				detail := strings.TrimSpace(snap.API.LastError)
+				if detail == "" {
+					detail = "API reported an error state"
+				}
+				return snap, false, fmt.Errorf("gateway API failed during startup: %s", detail)
+			}
+		} else {
+			lastProbeErr = err
 		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return lastSnap, false, nil
+		}
+		delay := pollInterval
+		if remaining < delay {
+			delay = remaining
+		}
+		timer := time.NewTimer(delay)
+		<-timer.C
 	}
-	fmt.Println("  Health: not responding yet (use 'defenseclaw-gateway status')")
 }
 
-func summarizeHealth(body []byte) string {
-	var health map[string]json.RawMessage
-	if err := json.Unmarshal(body, &health); err != nil {
-		return "ok"
+func printDaemonStartResult(pid int, snap gateway.HealthSnapshot, ready bool) {
+	if ready {
+		fmt.Printf("%s (PID %d)\n", Style("OK", "fg=green", "bold"), pid)
+		fmt.Printf("  Health: %s\n", summarizeHealthSnapshot(snap))
+		return
 	}
-	subsystems := []string{"gateway", "watcher", "guardrail", "api", "telemetry", "splunk", "sandbox"}
+
+	fmt.Printf("%s (PID %d)\n", Style("STARTING", "fg=yellow", "bold"), pid)
+	fmt.Printf(
+		"  Health: still starting after %s (use 'defenseclaw-gateway status')\n",
+		defaultStartReadinessTimeout,
+	)
+}
+
+func summarizeHealthSnapshot(snap gateway.HealthSnapshot) string {
+	subsystems := []struct {
+		name   string
+		health gateway.SubsystemHealth
+	}{
+		{name: "gateway", health: snap.Gateway},
+		{name: "watcher", health: snap.Watcher},
+		{name: "guardrail", health: snap.Guardrail},
+		{name: "api", health: snap.API},
+		{name: "telemetry", health: snap.Telemetry},
+		{name: "sinks", health: snap.Sinks},
+	}
+	if snap.Sandbox != nil {
+		subsystems = append(subsystems, struct {
+			name   string
+			health gateway.SubsystemHealth
+		}{name: "sandbox", health: *snap.Sandbox})
+	}
+
 	var parts []string
 	for _, sub := range subsystems {
-		raw, ok := health[sub]
-		if !ok {
-			continue
-		}
-		var info struct {
-			State  string `json:"state"`
-			Status string `json:"status"`
-		}
-		if json.Unmarshal(raw, &info) != nil {
-			continue
-		}
-		state := info.State
-		if state == "" {
-			state = info.Status
-		}
+		state := string(sub.health.State)
 		switch strings.ToLower(state) {
 		case "running", "healthy":
-			parts = append(parts, sub+":ok")
+			parts = append(parts, sub.name+":ok")
 		case "disabled", "stopped":
-			parts = append(parts, sub+":off")
+			parts = append(parts, sub.name+":off")
+		case "":
+			continue
 		default:
-			parts = append(parts, sub+":"+state)
+			parts = append(parts, sub.name+":"+state)
 		}
 	}
 	if len(parts) == 0 {

--- a/internal/cli/daemon_readiness_test.go
+++ b/internal/cli/daemon_readiness_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/defenseclaw/defenseclaw/internal/gateway"
+)
+
+func TestWaitForGatewayReadinessWaitsForRunningAPI(t *testing.T) {
+	var probes atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		state := gateway.StateStarting
+		if probes.Add(1) >= 3 {
+			state = gateway.StateRunning
+		}
+		_ = json.NewEncoder(w).Encode(gateway.HealthSnapshot{
+			API: gateway.SubsystemHealth{State: state},
+		})
+	}))
+	defer srv.Close()
+
+	snap, ready, err := waitForGatewayReadiness(
+		srv.Client(),
+		srv.URL,
+		time.Second,
+		5*time.Millisecond,
+		func() bool { return true },
+	)
+	if err != nil {
+		t.Fatalf("waitForGatewayReadiness() error = %v", err)
+	}
+	if !ready {
+		t.Fatal("waitForGatewayReadiness() ready = false, want true")
+	}
+	if snap.API.State != gateway.StateRunning {
+		t.Fatalf("API state = %q, want %q", snap.API.State, gateway.StateRunning)
+	}
+	if got := probes.Load(); got != 3 {
+		t.Fatalf("health probes = %d, want 3", got)
+	}
+}
+
+func TestWaitForGatewayReadinessReturnsStableStartingOnTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gateway.HealthSnapshot{
+			API: gateway.SubsystemHealth{State: gateway.StateStarting},
+		})
+	}))
+	defer srv.Close()
+
+	snap, ready, err := waitForGatewayReadiness(
+		srv.Client(),
+		srv.URL,
+		50*time.Millisecond,
+		5*time.Millisecond,
+		func() bool { return true },
+	)
+	if err != nil {
+		t.Fatalf("waitForGatewayReadiness() error = %v", err)
+	}
+	if ready {
+		t.Fatal("waitForGatewayReadiness() ready = true, want false")
+	}
+	if snap.API.State != gateway.StateStarting {
+		t.Fatalf("API state = %q, want %q", snap.API.State, gateway.StateStarting)
+	}
+}
+
+func TestWaitForGatewayReadinessFailsFastWhenProcessExits(t *testing.T) {
+	var probes atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		probes.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	_, ready, err := waitForGatewayReadiness(
+		srv.Client(),
+		srv.URL,
+		time.Second,
+		5*time.Millisecond,
+		func() bool { return false },
+	)
+	if err == nil || !strings.Contains(err.Error(), "exited before readiness") {
+		t.Fatalf("error = %v, want process-exit diagnostic", err)
+	}
+	if ready {
+		t.Fatal("waitForGatewayReadiness() ready = true, want false")
+	}
+	if got := probes.Load(); got != 0 {
+		t.Fatalf("health probes = %d, want 0 after confirmed process exit", got)
+	}
+}
+
+func TestWaitForGatewayReadinessFailsFastOnAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(gateway.HealthSnapshot{
+			API: gateway.SubsystemHealth{
+				State:     gateway.StateError,
+				LastError: "bind failed",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	_, ready, err := waitForGatewayReadiness(
+		srv.Client(),
+		srv.URL,
+		time.Second,
+		5*time.Millisecond,
+		func() bool { return true },
+	)
+	if err == nil || !strings.Contains(err.Error(), "bind failed") {
+		t.Fatalf("error = %v, want API startup diagnostic", err)
+	}
+	if ready {
+		t.Fatal("waitForGatewayReadiness() ready = true, want false")
+	}
+}
+
+func TestFetchSidecarHealthParsesLargeMultiConnectorDocument(t *testing.T) {
+	want := gateway.HealthSnapshot{
+		Gateway: gateway.SubsystemHealth{
+			State: gateway.StateRunning,
+			Details: map[string]interface{}{
+				"inventory": strings.Repeat("x", 2200),
+			},
+		},
+		API: gateway.SubsystemHealth{State: gateway.StateRunning},
+		Connectors: []gateway.ConnectorHealth{
+			{Name: "codex", State: gateway.StateRunning},
+			{Name: "claudecode", State: gateway.StateRunning},
+		},
+	}
+	payload, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(payload) <= 2000 {
+		t.Fatalf("fixture length = %d, want > 2000", len(payload))
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	got, err := fetchSidecarHealth(srv.Client(), srv.URL)
+	if err != nil {
+		t.Fatalf("fetchSidecarHealth() error = %v", err)
+	}
+	if got.API.State != gateway.StateRunning {
+		t.Fatalf("API state = %q, want %q", got.API.State, gateway.StateRunning)
+	}
+	if len(got.Connectors) != 2 {
+		t.Fatalf("connectors = %d, want 2", len(got.Connectors))
+	}
+}
+
+func TestFetchSidecarHealthRejectsOversizedDocument(t *testing.T) {
+	payload := []byte(`{"padding":"` + strings.Repeat("x", gatewayHealthDocumentMaxBytes) + `"}`)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	_, err := fetchSidecarHealth(srv.Client(), srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("error = %v, want bounded-document diagnostic", err)
+	}
+}

--- a/internal/cli/hook_test.go
+++ b/internal/cli/hook_test.go
@@ -196,3 +196,22 @@ func TestHookCommandRegisteredAndHidden(t *testing.T) {
 		t.Error("hook command should be hidden")
 	}
 }
+
+func TestNotifyCommandRegisteredAndHidden(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"notify"})
+	if err != nil {
+		t.Fatalf("notify command not found: %v", err)
+	}
+	if cmd.Name() != "notify" {
+		t.Fatalf("found %q, want notify", cmd.Name())
+	}
+	if !cmd.Hidden {
+		t.Error("notify command should be hidden")
+	}
+	if err := cmd.Args(cmd, nil); err == nil {
+		t.Error("notify command accepted a missing Codex JSON payload")
+	}
+	if err := cmd.Args(cmd, []string{`{"type":"agent-turn-complete"}`}); err != nil {
+		t.Errorf("notify command rejected one JSON payload argument: %v", err)
+	}
+}

--- a/internal/cli/notify.go
+++ b/internal/cli/notify.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/defenseclaw/defenseclaw/internal/gateway/connector/hookexec"
+)
+
+func init() {
+	rootCmd.AddCommand(newNotifyCmd())
+}
+
+// newNotifyCmd builds the hidden native counterpart to Codex's historical
+// notify-bridge.sh. Codex appends exactly one JSON payload argument to the
+// configured argv array; forwarding is telemetry-only and always best-effort.
+func newNotifyCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:               "notify EVENT_JSON",
+		Short:             "Forward a Codex notification to the local gateway",
+		Hidden:            true,
+		Args:              cobra.ExactArgs(1),
+		PersistentPreRunE: func(*cobra.Command, []string) error { return nil },
+		PersistentPostRun: func(*cobra.Command, []string) {},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts := buildHookOptions("codex", "notify", "", "open")
+			hookexec.RunCodexNotify(cmd.Context(), opts, []byte(args[0]))
+			return nil
+		},
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -15,8 +15,11 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -24,10 +27,14 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/defenseclaw/defenseclaw/internal/config"
 	"github.com/defenseclaw/defenseclaw/internal/gateway"
 )
 
-const gatewayStatusLabelWidth = 14
+const (
+	gatewayStatusLabelWidth       = 14
+	gatewayHealthDocumentMaxBytes = 1 << 20
+)
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
@@ -85,29 +92,64 @@ func styledConnectorStateVerb(state string) string {
 	}
 }
 
-func runSidecarStatus(_ *cobra.Command, _ []string) error {
-	bind := "127.0.0.1"
-	if cfg.Gateway.APIBind != "" {
-		bind = cfg.Gateway.APIBind
-	} else if cfg.OpenShell.IsStandalone() && cfg.Guardrail.Host != "" && cfg.Guardrail.Host != "localhost" {
-		bind = cfg.Guardrail.Host
+func sidecarHealthURL(c *config.Config) string {
+	if c == nil {
+		c = config.DefaultConfig()
 	}
-	addr := fmt.Sprintf("http://%s:%d/health", bind, cfg.Gateway.APIPort)
+	bind := "127.0.0.1"
+	if c.Gateway.APIBind != "" {
+		bind = c.Gateway.APIBind
+	} else if c.OpenShell.IsStandalone() && c.Guardrail.Host != "" && c.Guardrail.Host != "localhost" {
+		bind = c.Guardrail.Host
+	}
+	return fmt.Sprintf("http://%s:%d/health", bind, c.Gateway.APIPort)
+}
 
-	client := &http.Client{Timeout: 5 * time.Second}
+// fetchSidecarHealth reads one complete, bounded health document. Keeping the
+// byte bound here protects both status and daemon-readiness callers from an
+// unbounded local response without truncating valid multi-connector JSON before
+// it is parsed.
+func fetchSidecarHealth(client *http.Client, addr string) (gateway.HealthSnapshot, error) {
+	var snap gateway.HealthSnapshot
 	resp, err := client.Get(addr)
 	if err != nil {
-		fmt.Println()
-		Warn("Sidecar Status: NOT RUNNING")
-		printGatewayKV("Endpoint", addr)
-		Subhead("Start the sidecar with: defenseclaw-gateway start")
-		return fmt.Errorf("sidecar unreachable")
+		return snap, err
 	}
 	defer resp.Body.Close()
 
-	var snap gateway.HealthSnapshot
-	if err := json.NewDecoder(resp.Body).Decode(&snap); err != nil {
-		return fmt.Errorf("sidecar status: parse response: %w", err)
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
+		return snap, fmt.Errorf("health endpoint returned %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, gatewayHealthDocumentMaxBytes+1))
+	if err != nil {
+		return snap, fmt.Errorf("read response: %w", err)
+	}
+	if len(body) > gatewayHealthDocumentMaxBytes {
+		return snap, fmt.Errorf("health response exceeds %d bytes", gatewayHealthDocumentMaxBytes)
+	}
+	if err := json.Unmarshal(body, &snap); err != nil {
+		return snap, fmt.Errorf("parse response: %w", err)
+	}
+	return snap, nil
+}
+
+func runSidecarStatus(_ *cobra.Command, _ []string) error {
+	addr := sidecarHealthURL(cfg)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	snap, err := fetchSidecarHealth(client, addr)
+	if err != nil {
+		var requestErr *url.Error
+		if errors.As(err, &requestErr) {
+			fmt.Println()
+			Warn("Sidecar Status: NOT RUNNING")
+			printGatewayKV("Endpoint", addr)
+			Subhead("Start the sidecar with: defenseclaw-gateway start")
+			return fmt.Errorf("sidecar unreachable")
+		}
+		return fmt.Errorf("sidecar status: %w", err)
 	}
 
 	uptime := time.Duration(snap.UptimeMs) * time.Millisecond
@@ -117,6 +159,12 @@ func runSidecarStatus(_ *cobra.Command, _ []string) error {
 	printGatewayKV("Uptime", formatDuration(uptime))
 	fmt.Println()
 
+	bind := "127.0.0.1"
+	if cfg.Gateway.APIBind != "" {
+		bind = cfg.Gateway.APIBind
+	} else if cfg.OpenShell.IsStandalone() && cfg.Guardrail.Host != "" && cfg.Guardrail.Host != "localhost" {
+		bind = cfg.Guardrail.Host
+	}
 	if modes := fetchConnectorModes(client, bind, cfg.Gateway.APIPort); len(modes) > 0 {
 		printConnectorModes(modes)
 	}

--- a/internal/gateway/api.go
+++ b/internal/gateway/api.go
@@ -867,6 +867,8 @@ func (a *APIServer) handleConnectors(w http.ResponseWriter, r *http.Request) {
 		Source             string `json:"source"`
 		ToolInspectionMode string `json:"tool_inspection_mode"`
 		SubprocessPolicy   string `json:"subprocess_policy"`
+		PlatformStatus     string `json:"platform_status"`
+		PlatformReason     string `json:"platform_reason"`
 		// LLMTrafficMode ("proxy" | "hooks-only") tells the CLI whether a
 		// custom provider bound to this connector is enforced on the
 		// agent's own model traffic or only configures DefenseClaw's
@@ -887,6 +889,8 @@ func (a *APIServer) handleConnectors(w http.ResponseWriter, r *http.Request) {
 			Source:             info.Source,
 			ToolInspectionMode: string(info.ToolInspectionMode),
 			SubprocessPolicy:   string(info.SubprocessPolicy),
+			PlatformStatus:     string(info.PlatformStatus),
+			PlatformReason:     info.PlatformReason,
 			LLMTrafficMode:     connector.LLMTrafficModeForConnector(info.Name),
 		}
 		if conn, ok := reg.Get(info.Name); ok {

--- a/internal/gateway/connector/codex.go
+++ b/internal/gateway/connector/codex.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -180,8 +181,7 @@ func (c *CodexConnector) VerifyClean(opts SetupOpts) error {
 			if codexOtelBlockLooksManaged(cfg["otel"], opts) {
 				residual = append(residual, "config.toml [otel] still points at defenseclaw")
 			}
-			managedNotify := []interface{}{"bash", filepath.Join(opts.DataDir, "notify-bridge.sh")}
-			if codexValueMatches(cfg["notify"], managedNotify) {
+			if codexNotifyLooksManaged(cfg["notify"], opts) {
 				residual = append(residual, "config.toml notify still points at defenseclaw bridge")
 			}
 		}
@@ -707,16 +707,22 @@ func (c *CodexConnector) patchCodexConfig(opts SetupOpts, hookScript string) err
 	// gateway.jsonl with source="codex_otel".
 	cfg["otel"] = buildCodexOtelBlock(opts)
 
-	// agent-turn-complete bridge: codex shells out to ``notify`` with
-	// a JSON payload describing each completed turn. We point it at a
-	// per-instance bash bridge that POSTs to /api/v1/codex/notify.
-	// Runs on every install — the bridge is harmless when the
-	// endpoint isn't yet wired (curl --fail-with-body silently drops
-	// the event rather than crashing codex).
-	if err := writeCodexNotifyBridge(opts); err != nil {
-		return fmt.Errorf("write codex notify bridge: %w", err)
+	// agent-turn-complete bridge: Codex appends one JSON payload argument to
+	// this argv array. Windows invokes the gateway's hidden native notifier
+	// directly; Unix keeps the existing Bash bridge. The native form is an
+	// argv array rather than a command string, so paths containing spaces need
+	// no shell quoting and no Bash/jq/curl dependency is introduced.
+	if runtime.GOOS == "windows" {
+		cfg["notify"] = codexNativeNotifyCommand()
+		// Heal a bridge left by an older Windows setup. It is no longer
+		// referenced and contains a baked gateway token.
+		_ = os.Remove(filepath.Join(opts.DataDir, "notify-bridge.sh"))
+	} else {
+		if err := writeCodexNotifyBridge(opts); err != nil {
+			return fmt.Errorf("write codex notify bridge: %w", err)
+		}
+		cfg["notify"] = codexShellNotifyCommand(opts)
 	}
-	cfg["notify"] = []string{"bash", filepath.Join(opts.DataDir, "notify-bridge.sh")}
 
 	if !backupExists {
 		if err := c.saveConfigBackup(opts.DataDir, backup); err != nil {
@@ -952,6 +958,40 @@ func buildCodexOtelBlock(opts SetupOpts) map[string]interface{} {
 	return block
 }
 
+func codexNativeNotifyCommand() []string {
+	return []string{defenseclawHookBinary(), "notify"}
+}
+
+func codexShellNotifyCommand(opts SetupOpts) []string {
+	return []string{"bash", filepath.Join(opts.DataDir, "notify-bridge.sh")}
+}
+
+// codexNotifyLooksManaged recognizes both the current platform command and the
+// legacy Bash bridge. Native matching is strict on argv shape and gateway
+// executable basename so teardown never removes an unrelated user notifier
+// that happens to contain the word "notify".
+func codexNotifyLooksManaged(v interface{}, opts SetupOpts) bool {
+	if codexValueMatches(v, codexShellNotifyCommand(opts)) {
+		return true
+	}
+	var argv []string
+	switch list := v.(type) {
+	case []string:
+		argv = append(argv, list...)
+	case []interface{}:
+		for _, raw := range list {
+			s, ok := raw.(string)
+			if !ok {
+				return false
+			}
+			argv = append(argv, s)
+		}
+	default:
+		return false
+	}
+	return len(argv) == 2 && argv[1] == "notify" && isDefenseClawGatewayExecutable(argv[0])
+}
+
 // writeCodexNotifyBridge writes ~/.defenseclaw/notify-bridge.sh, the
 // shell shim codex invokes on agent-turn-complete. The script POSTs
 // codex's JSON arg to /api/v1/codex/notify with the gateway token
@@ -1105,15 +1145,15 @@ func (c *CodexConnector) restoreCodexConfig(opts SetupOpts) {
 		delete(cfg, "otel")
 	}
 
-	managedNotify := []interface{}{"bash", filepath.Join(opts.DataDir, "notify-bridge.sh")}
-	if codexValueMatches(cfg["notify"], managedNotify) && backup.HadNotify && len(backup.OriginalNotify) > 0 {
+	managedNotify := codexNotifyLooksManaged(cfg["notify"], opts)
+	if managedNotify && backup.HadNotify && len(backup.OriginalNotify) > 0 {
 		var orig interface{}
 		if err := json.Unmarshal(backup.OriginalNotify, &orig); err == nil {
 			cfg["notify"] = orig
 		} else {
 			delete(cfg, "notify")
 		}
-	} else if codexValueMatches(cfg["notify"], managedNotify) {
+	} else if managedNotify {
 		delete(cfg, "notify")
 	}
 

--- a/internal/gateway/connector/connector_test.go
+++ b/internal/gateway/connector/connector_test.go
@@ -2010,7 +2010,7 @@ func TestCodex_Setup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("hook script not created: %v", err)
 	}
-	if info.Mode()&0o111 == 0 {
+	if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
 		t.Error("hook script not executable")
 	}
 	data, _ := os.ReadFile(hookPath)
@@ -2152,8 +2152,12 @@ func TestCodex_Setup_RegistersHooksInline(t *testing.T) {
 			}
 		}
 	}
-	if !strings.Contains(content, "codex-hook.sh") {
-		t.Errorf("config.toml [hooks] missing codex-hook.sh reference\nfile:\n%s", content)
+	wantHookNeedle := "codex-hook.sh"
+	if runtime.GOOS == "windows" {
+		wantHookNeedle = nativeHookFlag + "codex"
+	}
+	if !strings.Contains(content, wantHookNeedle) {
+		t.Errorf("config.toml [hooks] missing %q reference\nfile:\n%s", wantHookNeedle, content)
 	}
 
 	// Re-parse to ensure it's valid TOML and codex's expected shape
@@ -2174,6 +2178,7 @@ func TestCodex_Setup_RegistersHooksInline(t *testing.T) {
 		t.Fatalf("hooks.state missing — Codex would ask the user to review DefenseClaw hooks")
 	}
 	hookPath := filepath.Join(dir, "hooks", "codex-hook.sh")
+	hookCommand := hookInvocationCommand("codex", filepath.ToSlash(hookPath))
 	for _, tc := range []struct {
 		eventType string
 		eventKey  string
@@ -2193,7 +2198,7 @@ func TestCodex_Setup_RegistersHooksInline(t *testing.T) {
 			t.Fatalf("hooks.state missing trusted entry for %s (%s); state=%v", tc.eventType, key, state)
 		}
 		gotHash, _ := entry["trusted_hash"].(string)
-		wantHash := codexCommandHookHash(tc.eventKey, tc.matcher, hookPath, tc.timeout)
+		wantHash := codexCommandHookHash(tc.eventKey, tc.matcher, hookCommand, tc.timeout)
 		if gotHash != wantHash {
 			t.Errorf("trusted_hash for %s = %q, want %q", tc.eventType, gotHash, wantHash)
 		}
@@ -2623,24 +2628,19 @@ log_user_prompt = false
 	}
 }
 
-// TestCodex_Setup_WiresNotifyBridge pins the agent-turn-complete
-// telemetry path. Codex shells out to `notify` with a JSON arg
-// describing each completed turn (per https://developers.openai.com
-// /codex/config-advanced). Our Setup writes a per-instance bash
-// bridge that POSTs the JSON to /api/v1/codex/notify. Without
-// this wiring, the third independent observability channel (after
-// hooks + OTel) would be dark.
+// TestCodex_Setup_WiresNotifyBridge pins the agent-turn-complete telemetry
+// path. Codex appends a JSON arg to the configured notify argv array. Windows
+// invokes the gateway's native notify subcommand; Unix keeps the per-instance
+// Bash bridge that POSTs to /api/v1/codex/notify.
 //
-// Asserts:
-//   - notify-bridge.sh exists at DataDir, mode 0o700 (operator-only)
-//   - bridge body baked the operator-supplied APIToken AND the
-//     gateway notify endpoint (no env-var indirection — codex's
-//     subshell can scrub env)
-//   - config.toml emits notify = ["bash", "<DataDir>/notify-bridge.sh"]
-//     in the canonical TOML array form (codex parses this; a
-//     non-array would silently disable the bridge with no log).
+// Asserts the platform-specific artifact plus the canonical TOML argv array:
+// Windows writes ["<gateway.exe>", "notify"] with no shell bridge; Unix writes
+// ["bash", "<DataDir>/notify-bridge.sh"] and keeps the operator-only bridge.
 func TestCodex_Setup_WiresNotifyBridge(t *testing.T) {
 	dir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		setHookBinaryOverride(t, `C:\Program Files\DefenseClaw\defenseclaw-gateway.exe`)
+	}
 	configPath := filepath.Join(dir, "config.toml")
 	if err := os.WriteFile(configPath, []byte(`model = "gpt-5"
 `), 0o600); err != nil {
@@ -2661,22 +2661,28 @@ func TestCodex_Setup_WiresNotifyBridge(t *testing.T) {
 	}
 
 	bridgePath := filepath.Join(dir, "notify-bridge.sh")
-	info, err := os.Stat(bridgePath)
-	if err != nil {
-		t.Fatalf("notify-bridge.sh missing — agent-turn-complete telemetry won't fire: %v", err)
-	}
-	if info.Mode().Perm() != 0o700 {
-		t.Errorf("notify-bridge.sh mode = %v, want 0o700 (operator-only — token is baked in)", info.Mode().Perm())
-	}
-	bridge, err := os.ReadFile(bridgePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(bridge), "test-token-codex-notify") {
-		t.Error("bridge missing baked-in APIToken — receiver would reject every call as unauthenticated")
-	}
-	if !strings.Contains(string(bridge), "127.0.0.1:18970/api/v1/codex/notify") {
-		t.Errorf("bridge missing gateway notify endpoint URL; body:\n%s", bridge)
+	if runtime.GOOS == "windows" {
+		if _, err := os.Stat(bridgePath); !os.IsNotExist(err) {
+			t.Fatalf("Windows setup left Bash notify bridge behind: %v", err)
+		}
+	} else {
+		info, err := os.Stat(bridgePath)
+		if err != nil {
+			t.Fatalf("notify-bridge.sh missing — agent-turn-complete telemetry won't fire: %v", err)
+		}
+		if info.Mode().Perm() != 0o700 {
+			t.Errorf("notify-bridge.sh mode = %v, want 0o700 (operator-only — token is baked in)", info.Mode().Perm())
+		}
+		bridge, err := os.ReadFile(bridgePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(bridge), "test-token-codex-notify") {
+			t.Error("bridge missing baked-in APIToken — receiver would reject every call as unauthenticated")
+		}
+		if !strings.Contains(string(bridge), "127.0.0.1:18970/api/v1/codex/notify") {
+			t.Errorf("bridge missing gateway notify endpoint URL; body:\n%s", bridge)
+		}
 	}
 
 	// config.toml notify entry must be the array shape codex parses.
@@ -2690,13 +2696,27 @@ func TestCodex_Setup_WiresNotifyBridge(t *testing.T) {
 		t.Fatalf("notify entry not an array (got %T) — codex would silently disable the bridge", parsed["notify"])
 	}
 	if len(notify) != 2 {
-		t.Errorf("notify array has %d entries, want 2 ([bash, bridge.sh]); got %v", len(notify), notify)
+		t.Fatalf("notify array has %d entries, want 2; got %v", len(notify), notify)
 	}
-	if first, _ := notify[0].(string); first != "bash" {
-		t.Errorf("notify[0] = %q, want \"bash\"", first)
-	}
-	if second, _ := notify[1].(string); !strings.HasSuffix(second, "/notify-bridge.sh") {
-		t.Errorf("notify[1] = %q, want path ending in /notify-bridge.sh", second)
+	if runtime.GOOS == "windows" {
+		if first, _ := notify[0].(string); first != `C:\Program Files\DefenseClaw\defenseclaw-gateway.exe` {
+			t.Errorf("notify[0] = %q, want native gateway path", first)
+		}
+		if second, _ := notify[1].(string); second != "notify" {
+			t.Errorf("notify[1] = %q, want native notify subcommand", second)
+		}
+		if strings.Contains(strings.ToLower(string(raw)), "bash") ||
+			strings.Contains(strings.ToLower(string(raw)), "curl") ||
+			strings.Contains(strings.ToLower(string(raw)), "jq") {
+			t.Errorf("Windows config contains a Unix notify dependency:\n%s", raw)
+		}
+	} else {
+		if first, _ := notify[0].(string); first != "bash" {
+			t.Errorf("notify[0] = %q, want \"bash\"", first)
+		}
+		if second, _ := notify[1].(string); !strings.HasSuffix(second, "/notify-bridge.sh") {
+			t.Errorf("notify[1] = %q, want path ending in /notify-bridge.sh", second)
+		}
 	}
 }
 

--- a/internal/gateway/connector/helpers.go
+++ b/internal/gateway/connector/helpers.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -43,6 +44,13 @@ func userHomeDir() string {
 // --connector <name>`). It is used both when writing an agent's hook command on
 // Windows and when recognizing DefenseClaw-owned hooks during teardown.
 const nativeHookFlag = "hook --connector "
+
+const windowsGatewayBinaryName = "defenseclaw-gateway.exe"
+
+// defenseclawHookBinaryOverride is a test seam for exercising generated
+// Windows configs with an installed gateway path that contains spaces. It is
+// intentionally package-private and empty in production.
+var defenseclawHookBinaryOverride string
 
 // hookInvocationCommand returns the command string an agent runtime is
 // configured to run for a DefenseClaw hook.
@@ -69,6 +77,15 @@ func hookInvocationCommandFor(goos, connector, unixCommand string) string {
 	if goos != "windows" {
 		return unixCommand
 	}
+	// Antigravity (agy v1) tokenizes the command itself and passes quote
+	// characters through to direct exec. An absolute path containing spaces
+	// therefore cannot be quoted safely in its command field. The Windows
+	// installer adds the gateway directory to PATH, so use the stable binary
+	// name for this one direct-exec surface. Other agents accept a normal
+	// quoted Windows command line and keep the absolute path.
+	if connector == "antigravity" {
+		return windowsGatewayBinaryName + " " + nativeHookFlag + connector
+	}
 	return windowsQuoteExe(defenseclawHookBinary()) + " " + nativeHookFlag + connector
 }
 
@@ -76,8 +93,14 @@ func hookInvocationCommandFor(goos, connector, unixCommand string) string {
 // also hosts the hidden `hook` subcommand. Falls back to the bare binary name
 // (resolved via PATH by the agent) when the path cannot be determined.
 func defenseclawHookBinary() string {
+	if strings.TrimSpace(defenseclawHookBinaryOverride) != "" {
+		return defenseclawHookBinaryOverride
+	}
 	if exe, err := os.Executable(); err == nil && strings.TrimSpace(exe) != "" {
 		return exe
+	}
+	if runtime.GOOS == "windows" {
+		return windowsGatewayBinaryName
 	}
 	return "defenseclaw-gateway"
 }
@@ -94,7 +117,53 @@ func windowsQuoteExe(p string) string {
 // recognition, which otherwise keys on a hooks-dir path / script marker that a
 // native (non-file) command does not carry.
 func isNativeHookCommand(cmd string) bool {
-	return strings.Contains(cmd, nativeHookFlag)
+	cmd = strings.TrimSpace(cmd)
+	marker := " " + nativeHookFlag
+	idx := strings.LastIndex(cmd, marker)
+	if idx <= 0 {
+		return false
+	}
+	exe := strings.TrimSpace(cmd[:idx])
+	connector := strings.TrimSpace(cmd[idx+len(marker):])
+	if !validNativeHookConnector(connector) {
+		return false
+	}
+	if strings.HasPrefix(exe, `"`) || strings.HasSuffix(exe, `"`) {
+		if len(exe) < 2 || !strings.HasPrefix(exe, `"`) || !strings.HasSuffix(exe, `"`) {
+			return false
+		}
+		exe = exe[1 : len(exe)-1]
+	}
+	if exe == "" || strings.ContainsAny(exe, `"'`) {
+		return false
+	}
+	return isDefenseClawGatewayExecutable(exe)
+}
+
+func isDefenseClawGatewayExecutable(exe string) bool {
+	exe = strings.TrimSpace(exe)
+	if current := strings.TrimSpace(defenseclawHookBinary()); current != "" &&
+		strings.EqualFold(filepath.Clean(exe), filepath.Clean(current)) {
+		return true
+	}
+	// filepath.Base follows the host separator, while tests exercise Windows
+	// paths on every OS. Normalize backslashes before taking the basename.
+	base := filepath.Base(strings.ReplaceAll(exe, `\`, `/`))
+	return strings.EqualFold(base, windowsGatewayBinaryName) ||
+		strings.EqualFold(base, "defenseclaw-gateway")
+}
+
+func validNativeHookConnector(connector string) bool {
+	if connector == "" {
+		return false
+	}
+	for _, r := range connector {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // SecureTokenMatch compares two token strings in constant time to prevent

--- a/internal/gateway/connector/helpers.go
+++ b/internal/gateway/connector/helpers.go
@@ -146,11 +146,16 @@ func isDefenseClawGatewayExecutable(exe string) bool {
 		strings.EqualFold(filepath.Clean(exe), filepath.Clean(current)) {
 		return true
 	}
-	// filepath.Base follows the host separator, while tests exercise Windows
-	// paths on every OS. Normalize backslashes before taking the basename.
-	base := filepath.Base(strings.ReplaceAll(exe, `\`, `/`))
-	return strings.EqualFold(base, windowsGatewayBinaryName) ||
-		strings.EqualFold(base, "defenseclaw-gateway")
+	// Antigravity intentionally stores a bare PATH-resolved executable name.
+	// Accept that exact form, but never accept an arbitrary absolute path merely
+	// because its basename resembles ours: teardown must not remove a foreign
+	// installation's hook entry.
+	normalized := strings.ReplaceAll(exe, `\`, "/")
+	if strings.Contains(normalized, "/") {
+		return false
+	}
+	return strings.EqualFold(normalized, windowsGatewayBinaryName) ||
+		strings.EqualFold(normalized, "defenseclaw-gateway")
 }
 
 func validNativeHookConnector(connector string) bool {

--- a/internal/gateway/connector/hook_only.go
+++ b/internal/gateway/connector/hook_only.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -1542,8 +1543,16 @@ func patchCopilotHooks(path, hookScript string) error {
 	} {
 		entry := map[string]interface{}{
 			"type":       "command",
-			"bash":       shellWord(hookScript),
 			"timeoutSec": 30,
+		}
+		if runtime.GOOS == "windows" {
+			// Copilot selects the command field by host OS. A `bash`-only
+			// entry is ignored on Windows even when its value names a native
+			// executable. PowerShell requires the call operator before a quoted
+			// executable path, otherwise the path is parsed as a string literal.
+			entry["powershell"] = "& " + hookScript
+		} else {
+			entry["bash"] = shellWord(hookScript)
 		}
 		hooks[event] = appendUniqueFlatHook(hooks[event], hookScript, entry)
 	}
@@ -1671,21 +1680,14 @@ var antigravityLifecycleEvents = []string{
 // scope antigravityLifecycleEvents to the verified-emitting
 // subset.
 //
-// The "command" field is written as a bare path WITHOUT
-// shellWord() quoting. agy v1.0.x invokes the configured command
-// via direct exec(), not through a shell, so any surrounding
-// single quotes added by shellWord() would become literal
-// characters in the exec path and the hook would silently
-// no-fire (verified empirically via the v0.5.0 antigravity smoke
-// test: D1=bare-path-OK, D2=sh -c-OK, D3=direct-exec-FAILS-127).
-// This intentionally diverges from the other patch* helpers
-// (Claude Code, Gemini CLI, OpenHands, etc.), which all run
-// through a shell and where shellWord() correctly handles
-// homedirs containing whitespace. If a future agy release
-// switches to shell invocation we should revisit and add quoting
-// back for spaces/special characters; until then, agy users with
-// paths containing whitespace need DEFENSECLAW_HOME pointed at a
-// whitespace-free directory.
+// The "command" field is written WITHOUT shellWord() quoting. agy v1.0.x
+// tokenizes the command itself and passes quote characters through to direct
+// exec, so shell quoting becomes literal path bytes and the hook silently
+// no-fires (verified empirically via the v0.5.0 Antigravity smoke test). On
+// Unix hookScript is the bare absolute .sh path. On Windows it is the PATH-
+// resolved `defenseclaw-gateway.exe hook --connector antigravity` command;
+// using the stable executable name avoids an unquotable absolute install path
+// containing spaces while retaining the native Go hook path.
 func patchAntigravityHooks(path, hookScript string) error {
 	cfg, err := readJSONObject(path)
 	if err != nil {

--- a/internal/gateway/connector/hook_only_test.go
+++ b/internal/gateway/connector/hook_only_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -236,8 +237,12 @@ func TestHookOnlyConnector_SetupTeardown_BackupRestore(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read config after setup: %v", err)
 			}
-			if !strings.Contains(string(data), conn.scriptName) {
-				t.Fatalf("config after setup does not reference %s:\n%s", conn.scriptName, string(data))
+			wantConfigNeedle := conn.scriptName
+			if runtime.GOOS == "windows" {
+				wantConfigNeedle = nativeHookFlag + conn.Name()
+			}
+			if !strings.Contains(string(data), wantConfigNeedle) {
+				t.Fatalf("config after setup does not reference %s:\n%s", wantConfigNeedle, string(data))
 			}
 			if err := conn.Teardown(context.Background(), opts); err != nil {
 				t.Fatalf("Teardown: %v", err)
@@ -468,14 +473,24 @@ func TestAntigravitySetup_WritesClaudeCodeNestedSchema(t *testing.T) {
 			command,
 		)
 	}
-	// Secondary: the path resolves cleanly to a file ending in
-	// antigravity-hook.sh. Defends against accidentally writing a
-	// relative path or a different script name.
-	if !strings.HasSuffix(command, "antigravity-hook.sh") {
-		t.Fatalf("command=%q does not end with antigravity-hook.sh", command)
+	wantCommand := conn.hookCommand(opts)
+	if command != wantCommand {
+		t.Fatalf("command=%q want %q", command, wantCommand)
 	}
-	if !filepath.IsAbs(command) {
-		t.Fatalf("command=%q is not an absolute path", command)
+	// Unix runs the absolute shell hook. Windows uses the stable gateway
+	// basename through PATH because agy's direct-exec tokenizer cannot dequote
+	// an absolute executable path containing spaces.
+	if runtime.GOOS == "windows" {
+		if command != `defenseclaw-gateway.exe hook --connector antigravity` {
+			t.Fatalf("windows command=%q", command)
+		}
+	} else {
+		if !strings.HasSuffix(command, "antigravity-hook.sh") {
+			t.Fatalf("command=%q does not end with antigravity-hook.sh", command)
+		}
+		if !filepath.IsAbs(command) {
+			t.Fatalf("command=%q is not an absolute path", command)
+		}
 	}
 	// Tertiary: no surrounding whitespace either.
 	if command != strings.TrimSpace(command) {
@@ -529,8 +544,8 @@ func TestAntigravitySetup_WritesClaudeCodeNestedSchema(t *testing.T) {
 			t.Errorf("%s[%q][0].hooks[0].type=%#v want command", outerKey, event, hookEntry["type"])
 		}
 		eventCommand, ok := hookEntry["command"].(string)
-		if !ok || !strings.HasSuffix(eventCommand, "antigravity-hook.sh") {
-			t.Errorf("%s[%q][0].hooks[0].command=%#v want absolute path ending antigravity-hook.sh", outerKey, event, hookEntry["command"])
+		if !ok || eventCommand != wantCommand {
+			t.Errorf("%s[%q][0].hooks[0].command=%#v want %q", outerKey, event, hookEntry["command"], wantCommand)
 		}
 	}
 }

--- a/internal/gateway/connector/hookexec/hookexec.go
+++ b/internal/gateway/connector/hookexec/hookexec.go
@@ -153,6 +153,60 @@ func Run(ctx context.Context, opts Options) int {
 	return doRequest(ctx, opts, sp, failMode, payload, token)
 }
 
+// RunCodexNotify forwards the JSON payload Codex appends to its configured
+// `notify` argv array. Notifications are telemetry-only and deliberately
+// best-effort: every local/configuration/transport/response failure returns 0,
+// matching the legacy Bash bridge's `curl ... || true` contract.
+func RunCodexNotify(ctx context.Context, opts Options, payload []byte) int {
+	opts = withDefaults(opts)
+	if info, err := os.Stat(opts.Home); err != nil || !info.IsDir() {
+		return 0
+	}
+	if _, err := os.Stat(filepath.Join(opts.Home, ".disabled")); err == nil {
+		return 0
+	}
+	if len(payload) == 0 || int64(len(payload)) > opts.MaxBody {
+		return 0
+	}
+
+	tokenFile := filepath.Join(opts.HookDir, ".token")
+	if opts.Token == "" && !fileExists(tokenFile) {
+		return 0
+	}
+	token := opts.Token
+	if token == "" {
+		token = readTokenFile(tokenFile)
+	}
+
+	notifyCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(notifyCtx, http.MethodPost,
+		"http://"+opts.APIAddr+"/api/v1/codex/notify", bytes.NewReader(payload))
+	if err != nil {
+		return 0
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-DefenseClaw-Client", "codex-notify/1.0")
+	req.Header.Set("x-defenseclaw-source", "codex-notify")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if v := strings.TrimSpace(opts.TraceParent); v != "" && validTraceparent(v) {
+		req.Header.Set("traceparent", v)
+	}
+	if v := strings.TrimSpace(opts.TraceState); v != "" && validTracestate(v) {
+		req.Header.Set("tracestate", v)
+	}
+
+	resp, err := opts.HTTPClient.Do(req)
+	if err != nil {
+		return 0
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, defaultMaxBody))
+	return 0
+}
+
 // doRequest performs the gateway POST and dispatches the response through the
 // connector-specific decision logic, applying the transport vs response
 // failure split exactly like the .sh hooks.

--- a/internal/gateway/connector/hookexec/hookexec_test.go
+++ b/internal/gateway/connector/hookexec/hookexec_test.go
@@ -138,6 +138,12 @@ func TestDecisionGolden(t *testing.T) {
 			wantCode:   2,
 		},
 		{
+			name:      "codex allow",
+			connector: "codex",
+			respBody:  `{"action":"allow"}`,
+			wantCode:  0,
+		},
+		{
 			name:       "codex block with output exits 0",
 			connector:  "codex",
 			respBody:   `{"action":"block","codex_output":{"hookSpecificOutput":{"permissionDecision":"deny"}}}`,
@@ -159,6 +165,13 @@ func TestDecisionGolden(t *testing.T) {
 			wantCode:   0,
 		},
 		{
+			name:       "cursor allow echoes hook_output exit 0",
+			connector:  "cursor",
+			respBody:   `{"hook_output":{"continue":true,"permission":"allow"}}`,
+			wantStdout: `{"continue":true,"permission":"allow"}` + "\n",
+			wantCode:   0,
+		},
+		{
 			name:       "cursor echoes hook_output exit 0",
 			connector:  "cursor",
 			respBody:   `{"hook_output":{"continue":true,"permission":"deny","user_message":"no"}}`,
@@ -166,10 +179,30 @@ func TestDecisionGolden(t *testing.T) {
 			wantCode:   0,
 		},
 		{
+			name:       "copilot allow echoes hook_output exit 0",
+			connector:  "copilot",
+			respBody:   `{"hook_output":{"permissionDecision":"allow"}}`,
+			wantStdout: `{"permissionDecision":"allow"}` + "\n",
+			wantCode:   0,
+		},
+		{
 			name:       "copilot echoes hook_output exit 0",
 			connector:  "copilot",
 			respBody:   `{"hook_output":{"permissionDecision":"deny"}}`,
 			wantStdout: `{"permissionDecision":"deny"}` + "\n",
+			wantCode:   0,
+		},
+		{
+			name:      "geminicli allow with no hook_output exit 0",
+			connector: "geminicli",
+			respBody:  `{"action":"allow"}`,
+			wantCode:  0,
+		},
+		{
+			name:       "geminicli echoes hook_output deny exit 0",
+			connector:  "geminicli",
+			respBody:   `{"action":"block","hook_output":{"decision":"deny","reason":"no"}}`,
+			wantStdout: `{"decision":"deny","reason":"no"}` + "\n",
 			wantCode:   0,
 		},
 		{
@@ -204,6 +237,13 @@ func TestDecisionGolden(t *testing.T) {
 			connector: "hermes",
 			respBody:  `{"action":"allow"}`,
 			wantCode:  0,
+		},
+		{
+			name:       "hermes block echoes hook_output exit 0",
+			connector:  "hermes",
+			respBody:   `{"action":"block","hook_output":{"action":"block","message":"no"}}`,
+			wantStdout: `{"action":"block","message":"no"}` + "\n",
+			wantCode:   0,
 		},
 		{
 			name:      "antigravity allow with no hook_output exit 0",
@@ -462,6 +502,93 @@ func TestRequestWiring(t *testing.T) {
 	}
 	if string(rt.gotBody) != `{"event":"x"}` {
 		t.Errorf("body = %q", string(rt.gotBody))
+	}
+}
+
+func TestNativeConnectorEndpointMatrix(t *testing.T) {
+	tests := map[string]string{
+		"codex":       "/api/v1/codex/hook",
+		"claudecode":  "/api/v1/claude-code/hook",
+		"cursor":      "/api/v1/cursor/hook",
+		"windsurf":    "/api/v1/windsurf/hook",
+		"geminicli":   "/api/v1/geminicli/hook",
+		"copilot":     "/api/v1/copilot/hook",
+		"antigravity": "/api/v1/antigravity/hook",
+		"hermes":      "/api/v1/hermes/hook",
+	}
+	for connector, endpoint := range tests {
+		t.Run(connector, func(t *testing.T) {
+			rt := ok(`{"action":"allow"}`)
+			r := run(t, connector, rt, nil)
+			if r.code != 0 {
+				t.Fatalf("allow exit = %d, want 0", r.code)
+			}
+			if rt.gotReq == nil {
+				t.Fatal("no request captured")
+			}
+			if got := rt.gotReq.URL.Path; got != endpoint {
+				t.Errorf("endpoint = %q, want %q", got, endpoint)
+			}
+			if got := rt.gotReq.Header.Get("Authorization"); got != "Bearer tkn" {
+				t.Errorf("authorization = %q", got)
+			}
+			if got := string(rt.gotBody); got != `{"event":"x"}` {
+				t.Errorf("JSON stdin body = %q", got)
+			}
+		})
+	}
+}
+
+func TestCodexNotifyRequestWiring(t *testing.T) {
+	home := t.TempDir()
+	hookDir := filepath.Join(home, "hooks")
+	if err := os.MkdirAll(hookDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hookDir, ".token"),
+		[]byte("DEFENSECLAW_GATEWAY_TOKEN=\"notify-token\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rt := ok(`{"status":"ok"}`)
+	payload := []byte(`{"type":"agent-turn-complete","last-assistant-message":"done"}`)
+	code := RunCodexNotify(context.Background(), Options{
+		APIAddr:    "127.0.0.1:8787",
+		Home:       home,
+		HookDir:    hookDir,
+		HTTPClient: &http.Client{Transport: rt},
+		TraceParent: "00-0af7651916cd43dd8448eb211c80319c-" +
+			"b7ad6b7169203331-01",
+	}, payload)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want best-effort 0", code)
+	}
+	if rt.gotReq == nil {
+		t.Fatal("no request captured")
+	}
+	if got := rt.gotReq.URL.String(); got != "http://127.0.0.1:8787/api/v1/codex/notify" {
+		t.Errorf("url = %s", got)
+	}
+	if got := rt.gotReq.Header.Get("Authorization"); got != "Bearer notify-token" {
+		t.Errorf("authorization = %q", got)
+	}
+	if got := rt.gotReq.Header.Get("X-DefenseClaw-Client"); got != "codex-notify/1.0" {
+		t.Errorf("client header = %q", got)
+	}
+	if got := rt.gotReq.Header.Get("x-defenseclaw-source"); got != "codex-notify" {
+		t.Errorf("source header = %q", got)
+	}
+	if !bytes.Equal(rt.gotBody, payload) {
+		t.Errorf("body = %q, want %q", rt.gotBody, payload)
+	}
+
+	// Notify remains telemetry-only: a gateway failure must never fail the
+	// Codex process or turn a completed turn into an agent error.
+	failing := &stubRT{err: errors.New("offline")}
+	if got := RunCodexNotify(context.Background(), Options{
+		APIAddr: "127.0.0.1:8787", Home: home, HookDir: hookDir,
+		HTTPClient: &http.Client{Transport: failing},
+	}, payload); got != 0 {
+		t.Fatalf("transport failure exit = %d, want 0", got)
 	}
 }
 

--- a/internal/gateway/connector/hookwiring_test.go
+++ b/internal/gateway/connector/hookwiring_test.go
@@ -80,6 +80,7 @@ func TestHookInvocationCommand(t *testing.T) {
 // corrupt the native Windows command (which is already a complete command line)
 // while still quoting Unix script paths for the agent's shell.
 func TestShellWordPassesNativeCommandThrough(t *testing.T) {
+	setHookBinaryOverride(t, `C:\Program Files\DefenseClaw\defenseclaw-gateway.exe`)
 	native := `"C:\Program Files\DefenseClaw\defenseclaw-gateway.exe" hook --connector cursor`
 	if got := shellWord(native); got != native {
 		t.Errorf("shellWord(native) = %q, want unchanged", got)
@@ -138,6 +139,7 @@ func TestBuildCodexHooksTableHashesTheCommand(t *testing.T) {
 // hooks dir and carries no on-disk marker.
 func TestIsOwnedHookRecognizesNativeCommand(t *testing.T) {
 	const hooksDir = "/home/u/.defenseclaw/hooks"
+	setHookBinaryOverride(t, `C:\Program Files\DefenseClaw\defenseclaw-gateway.exe`)
 
 	owned := map[string]interface{}{
 		"hooks": []interface{}{
@@ -171,9 +173,22 @@ func TestIsOwnedHookRecognizesNativeCommand(t *testing.T) {
 	if isOwnedHook(spoofed, hooksDir) {
 		t.Error("foreign executable with native-hook arguments wrongly recognized as owned")
 	}
+
+	foreignSameBasename := map[string]interface{}{
+		"hooks": []interface{}{
+			map[string]interface{}{
+				"type":    "command",
+				"command": `"C:\Tools\defenseclaw-gateway.exe" hook --connector claudecode`,
+			},
+		},
+	}
+	if isOwnedHook(foreignSameBasename, hooksDir) {
+		t.Error("different absolute gateway path was incorrectly recognized as owned")
+	}
 }
 
 func TestCodexNativeNotifyOwnership(t *testing.T) {
+	setHookBinaryOverride(t, `C:\Program Files\DefenseClaw\defenseclaw-gateway.exe`)
 	opts := SetupOpts{DataDir: `C:\Users\me\.defenseclaw`}
 	owned := []interface{}{`C:\Program Files\DefenseClaw\defenseclaw-gateway.exe`, "notify"}
 	if !codexNotifyLooksManaged(owned, opts) {
@@ -182,6 +197,10 @@ func TestCodexNativeNotifyOwnership(t *testing.T) {
 	foreign := []interface{}{`C:\Tools\desktop-notifier.exe`, "notify"}
 	if codexNotifyLooksManaged(foreign, opts) {
 		t.Fatal("foreign notifier was incorrectly recognized as managed")
+	}
+	foreignSameBasename := []interface{}{`C:\Tools\defenseclaw-gateway.exe`, "notify"}
+	if codexNotifyLooksManaged(foreignSameBasename, opts) {
+		t.Fatal("different absolute gateway notifier was incorrectly recognized as managed")
 	}
 }
 

--- a/internal/gateway/connector/hookwiring_test.go
+++ b/internal/gateway/connector/hookwiring_test.go
@@ -17,15 +17,28 @@
 package connector
 
 import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+func setHookBinaryOverride(t *testing.T, path string) {
+	t.Helper()
+	prev := defenseclawHookBinaryOverride
+	defenseclawHookBinaryOverride = path
+	t.Cleanup(func() { defenseclawHookBinaryOverride = prev })
+}
 
 // TestHookInvocationCommand pins the platform split: Unix runs the bundled .sh
 // path; Windows invokes the native Go `hook` subcommand instead of any Bash/.cmd
 // wrapper.
 func TestHookInvocationCommand(t *testing.T) {
 	const unix = "/home/u/.defenseclaw/hooks/codex-hook.sh"
+	const windowsExe = `C:\Program Files\DefenseClaw\defenseclaw-gateway.exe`
+	setHookBinaryOverride(t, windowsExe)
 
 	for _, goos := range []string{"linux", "darwin"} {
 		if got := hookInvocationCommandFor(goos, "codex", unix); got != unix {
@@ -34,6 +47,10 @@ func TestHookInvocationCommand(t *testing.T) {
 	}
 
 	win := hookInvocationCommandFor("windows", "cursor", unix)
+	wantWin := `"C:\Program Files\DefenseClaw\defenseclaw-gateway.exe" hook --connector cursor`
+	if win != wantWin {
+		t.Errorf("windows command = %q, want %q", win, wantWin)
+	}
 	if !strings.Contains(win, nativeHookFlag+"cursor") {
 		t.Errorf("windows command = %q, missing %q", win, nativeHookFlag+"cursor")
 	}
@@ -46,13 +63,24 @@ func TestHookInvocationCommand(t *testing.T) {
 	if isNativeHookCommand(unix) {
 		t.Errorf("isNativeHookCommand(%q) = true, want false for a .sh path", unix)
 	}
+
+	// Antigravity's direct-exec parser does not dequote command paths. Use the
+	// installer-provided PATH entry so an install root containing spaces still
+	// works without quote characters becoming part of argv[0].
+	agy := hookInvocationCommandFor("windows", "antigravity", unix)
+	if agy != `defenseclaw-gateway.exe hook --connector antigravity` {
+		t.Errorf("antigravity command = %q", agy)
+	}
+	if strings.ContainsAny(agy, `"'`) {
+		t.Errorf("antigravity direct-exec command contains literal quotes: %q", agy)
+	}
 }
 
 // TestShellWordPassesNativeCommandThrough ensures the bash-style quoter does not
 // corrupt the native Windows command (which is already a complete command line)
 // while still quoting Unix script paths for the agent's shell.
 func TestShellWordPassesNativeCommandThrough(t *testing.T) {
-	native := `"C:\dc.exe" hook --connector cursor`
+	native := `"C:\Program Files\DefenseClaw\defenseclaw-gateway.exe" hook --connector cursor`
 	if got := shellWord(native); got != native {
 		t.Errorf("shellWord(native) = %q, want unchanged", got)
 	}
@@ -115,7 +143,7 @@ func TestIsOwnedHookRecognizesNativeCommand(t *testing.T) {
 		"hooks": []interface{}{
 			map[string]interface{}{
 				"type":    "command",
-				"command": `"C:\dc.exe" hook --connector claudecode`,
+				"command": `"C:\Program Files\DefenseClaw\defenseclaw-gateway.exe" hook --connector claudecode`,
 			},
 		},
 	}
@@ -130,5 +158,156 @@ func TestIsOwnedHookRecognizesNativeCommand(t *testing.T) {
 	}
 	if isOwnedHook(foreign, hooksDir) {
 		t.Error("foreign command wrongly recognized as DefenseClaw-owned")
+	}
+
+	spoofed := map[string]interface{}{
+		"hooks": []interface{}{
+			map[string]interface{}{
+				"type":    "command",
+				"command": `"C:\Tools\other.exe" hook --connector claudecode`,
+			},
+		},
+	}
+	if isOwnedHook(spoofed, hooksDir) {
+		t.Error("foreign executable with native-hook arguments wrongly recognized as owned")
+	}
+}
+
+func TestCodexNativeNotifyOwnership(t *testing.T) {
+	opts := SetupOpts{DataDir: `C:\Users\me\.defenseclaw`}
+	owned := []interface{}{`C:\Program Files\DefenseClaw\defenseclaw-gateway.exe`, "notify"}
+	if !codexNotifyLooksManaged(owned, opts) {
+		t.Fatal("native Codex notifier was not recognized as managed")
+	}
+	foreign := []interface{}{`C:\Tools\desktop-notifier.exe`, "notify"}
+	if codexNotifyLooksManaged(foreign, opts) {
+		t.Fatal("foreign notifier was incorrectly recognized as managed")
+	}
+}
+
+// TestWindowsNativeConfigMatrix exercises the generated on-disk configs for
+// every WIN-016 native target plus the Hermes preview. OpenCode is intentionally
+// absent: its bridge remains a JavaScript plugin and has separate tests.
+func TestWindowsNativeConfigMatrix(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-native config matrix")
+	}
+	setHookBinaryOverride(t, `C:\Program Files\DefenseClaw\defenseclaw-gateway.exe`)
+
+	tests := []struct {
+		name     string
+		conn     Connector
+		override *string
+		ext      string
+	}{
+		{"codex", NewCodexConnector(), &CodexConfigPathOverride, ".toml"},
+		{"claudecode", NewClaudeCodeConnector(), &ClaudeCodeSettingsPathOverride, ".json"},
+		{"cursor", NewCursorConnector(), &CursorHooksPathOverride, ".json"},
+		{"windsurf", NewWindsurfConnector(), &WindsurfHooksPathOverride, ".json"},
+		{"geminicli", NewGeminiCLIConnector(), &GeminiSettingsPathOverride, ".json"},
+		{"copilot", NewCopilotConnector(), &CopilotHooksPathOverride, ".json"},
+		{"antigravity", NewAntigravityConnector(), &AntigravityHooksPathOverride, ".json"},
+		{"hermes-preview", NewHermesConnector(), &HermesConfigPathOverride, ".yaml"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), "Defense Claw Matrix")
+			configPath := filepath.Join(root, tt.name+tt.ext)
+			previous := *tt.override
+			*tt.override = configPath
+			t.Cleanup(func() { *tt.override = previous })
+
+			dataDir := filepath.Join(root, "Data Dir")
+			opts := SetupOpts{
+				DataDir:      dataDir,
+				APIAddr:      "127.0.0.1:18970",
+				APIToken:     "matrix-token",
+				HookFailMode: "closed",
+				WorkspaceDir: filepath.Join(root, "Workspace"),
+			}
+			if err := tt.conn.Setup(context.Background(), opts); err != nil {
+				t.Fatalf("Setup: %v", err)
+			}
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatalf("read generated config: %v", err)
+			}
+			text := string(data)
+			connectorName := tt.conn.Name()
+			if !strings.Contains(text, windowsGatewayBinaryName) {
+				t.Errorf("config does not invoke %s:\n%s", windowsGatewayBinaryName, text)
+			}
+			if !strings.Contains(text, nativeHookFlag+connectorName) {
+				t.Errorf("config missing native connector command for %s:\n%s", connectorName, text)
+			}
+			lower := strings.ToLower(text)
+			for _, forbidden := range []string{".sh", `"bash"`, "curl", "jq"} {
+				if strings.Contains(lower, forbidden) {
+					t.Errorf("config contains forbidden Windows hook dependency %q:\n%s", forbidden, text)
+				}
+			}
+			if connectorName == "copilot" {
+				cfg, err := readJSONObject(configPath)
+				if err != nil {
+					t.Fatalf("parse Copilot config: %v", err)
+				}
+				hooks, _ := cfg["hooks"].(map[string]interface{})
+				want := "& " + hookInvocationCommand("copilot", "")
+				for event, raw := range hooks {
+					entries, _ := raw.([]interface{})
+					if len(entries) == 0 {
+						t.Fatalf("Copilot %s hook has no entries", event)
+					}
+					entry, _ := entries[0].(map[string]interface{})
+					if got, _ := entry["powershell"].(string); got != want {
+						t.Errorf("Copilot %s powershell command = %q, want %q", event, got, want)
+					}
+					if _, present := entry["bash"]; present {
+						t.Errorf("Copilot %s retained a bash command on Windows", event)
+					}
+				}
+			}
+
+			token, err := os.ReadFile(filepath.Join(dataDir, "hooks", ".token"))
+			if err != nil {
+				t.Fatalf("read hook token sidecar: %v", err)
+			}
+			if !strings.Contains(string(token), "matrix-token") {
+				t.Error("hook token sidecar does not contain the configured token")
+			}
+			hookCfg, err := os.ReadFile(filepath.Join(dataDir, "hooks", hookConfigSidecarName))
+			if err != nil {
+				t.Fatalf("read native hook config sidecar: %v", err)
+			}
+			if !strings.Contains(string(hookCfg), "DEFENSECLAW_GATEWAY_ADDR=127.0.0.1:18970") {
+				t.Errorf("hook config sidecar missing API address: %s", hookCfg)
+			}
+			wantFailMode := resolveHookFailMode(opts, tt.conn)
+			if hp, ok := tt.conn.(HookCapabilityProvider); ok &&
+				wantFailMode == "closed" && !hp.HookCapabilities(opts).SupportsFailClosed {
+				wantFailMode = "open"
+			}
+			if !strings.Contains(string(hookCfg), "DEFENSECLAW_FAIL_MODE="+wantFailMode) {
+				t.Errorf("hook config sidecar fail mode = %q, want %q", hookCfg, wantFailMode)
+			}
+
+			if err := tt.conn.Teardown(context.Background(), opts); err != nil {
+				t.Fatalf("Teardown: %v", err)
+			}
+			if err := tt.conn.VerifyClean(opts); err != nil {
+				t.Fatalf("VerifyClean after teardown: %v", err)
+			}
+			if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+				t.Errorf("generated config survived teardown: %v", err)
+			}
+			// These sidecars are shared by all active native connectors. A
+			// single connector teardown must not remove them and break peers.
+			for _, name := range []string{".token", hookConfigSidecarName} {
+				if _, err := os.Stat(filepath.Join(dataDir, "hooks", name)); err != nil {
+					t.Errorf("shared sidecar %s removed by connector teardown: %v", name, err)
+				}
+			}
+		})
 	}
 }

--- a/internal/gateway/connector/platform_support.go
+++ b/internal/gateway/connector/platform_support.go
@@ -21,18 +21,88 @@ import (
 	"runtime"
 )
 
+// PlatformSupportStatus is the operator-facing availability state for a
+// connector on an operating system.
+type PlatformSupportStatus string
+
+const (
+	PlatformSupported   PlatformSupportStatus = "supported"
+	PlatformPreview     PlatformSupportStatus = "preview"
+	PlatformUnsupported PlatformSupportStatus = "unsupported"
+)
+
+// PlatformSupport includes both the machine-readable state and the reason that
+// setup/presentation surfaces show to the operator.
+type PlatformSupport struct {
+	Status PlatformSupportStatus
+	Reason string
+}
+
 // proxyConnectors are the chat/LLM-proxy connectors that interpose on model
-// traffic through DefenseClaw's local guardrail proxy. They are unsupported on
-// Windows, where DefenseClaw runs hook-only: the native Go hook entrypoint
-// replaces the Bash hook chain, and there is no Windows guardrail-proxy
-// lifecycle to host these connectors.
-//
-// This is the Go single source of truth for OS support. Keep it in sync with
-// the Python cli/defenseclaw/platform_support.py WINDOWS_UNSUPPORTED_CONNECTORS
-// set — a parity test pins the two lists together.
+// traffic through DefenseClaw's local guardrail proxy. Topology and platform
+// support are deliberately separate facts: OpenClaw itself has a native
+// Windows path, but DefenseClaw does not host its proxy lifecycle on Windows.
 var proxyConnectors = map[string]struct{}{
 	"openclaw":  {},
 	"zeptoclaw": {},
+}
+
+// windowsConnectorSupport is the Go source of truth for native Windows
+// connector availability. Keep it in exact parity with the Python
+// cli/defenseclaw/platform_support.py WINDOWS_CONNECTOR_SUPPORT mapping.
+var windowsConnectorSupport = map[string]PlatformSupport{
+	"codex": {
+		Status: PlatformSupported,
+		Reason: "Codex CLI and the DefenseClaw hook entrypoint run natively on Windows.",
+	},
+	"claudecode": {
+		Status: PlatformSupported,
+		Reason: "Claude Code supports native Windows with Git for Windows and native hooks.",
+	},
+	"cursor": {
+		Status: PlatformSupported,
+		Reason: "Cursor IDE hooks run natively on Windows; Cursor CLI remains WSL-only.",
+	},
+	"windsurf": {
+		Status: PlatformSupported,
+		Reason: "Windsurf documents native Windows Cascade hooks.",
+	},
+	"geminicli": {
+		Status: PlatformSupported,
+		Reason: "Gemini CLI documents native Windows command hooks and PowerShell execution.",
+	},
+	"copilot": {
+		Status: PlatformSupported,
+		Reason: "GitHub Copilot CLI documents Windows hook execution through PowerShell.",
+	},
+	"antigravity": {
+		Status: PlatformSupported,
+		Reason: "Antigravity runs natively on Windows and exposes local JSON hooks.",
+	},
+	"opencode": {
+		Status: PlatformSupported,
+		Reason: "OpenCode runs directly on Windows and loads the JavaScript bridge plugin without shell shims.",
+	},
+	"hermes": {
+		Status: PlatformPreview,
+		Reason: "Hermes labels native Windows support Early Beta; setup is available as a preview.",
+	},
+	"openhands": {
+		Status: PlatformUnsupported,
+		Reason: "OpenHands CLI requires WSL; DefenseClaw does not implement a WSL connector path.",
+	},
+	"omnigent": {
+		Status: PlatformUnsupported,
+		Reason: "OmniGent has no supported native Windows terminal/sandbox path for this connector.",
+	},
+	"openclaw": {
+		Status: PlatformUnsupported,
+		Reason: "DefenseClaw on Windows is hook-only; OpenClaw integration requires the guardrail proxy.",
+	},
+	"zeptoclaw": {
+		Status: PlatformUnsupported,
+		Reason: "ZeptoClaw publishes macOS/Linux builds and its DefenseClaw integration requires the guardrail proxy.",
+	},
 }
 
 // IsProxyConnector reports whether name is a proxy/chat connector (as opposed
@@ -42,23 +112,51 @@ func IsProxyConnector(name string) bool {
 	return ok
 }
 
-// connectorSupportedOnOS reports whether a connector can be listed or set up on
-// the given GOOS. Every hook-based connector is supported on every OS; the
-// proxy connectors are unsupported on Windows.
-func connectorSupportedOnOS(name, goos string) bool {
-	if goos == "windows" && IsProxyConnector(name) {
-		return false
+// ConnectorSupportOnOS returns a supported/preview/unsupported classification
+// with a human-readable reason. Unknown plugin connectors preserve historical
+// behavior and remain available.
+func ConnectorSupportOnOS(name, goos string) PlatformSupport {
+	if goos == "windows" {
+		if support, ok := windowsConnectorSupport[name]; ok {
+			return support
+		}
+		return PlatformSupport{
+			Status: PlatformSupported,
+			Reason: "No native Windows restriction is registered for this plugin connector.",
+		}
 	}
-	return true
+	return PlatformSupport{
+		Status: PlatformSupported,
+		Reason: fmt.Sprintf("Connector setup is supported on %s.", goos),
+	}
 }
 
-// ConnectorSupportedOnHostOS reports support on the current host OS.
+// connectorSupportedOnOS reports whether setup/presentation may offer name on
+// goos. Preview connectors are deliberately available.
+func connectorSupportedOnOS(name, goos string) bool {
+	return ConnectorSupportOnOS(name, goos).Status != PlatformUnsupported
+}
+
+// ConnectorSupportOnHostOS returns the full classification for the host OS.
+func ConnectorSupportOnHostOS(name string) PlatformSupport {
+	return ConnectorSupportOnOS(name, runtime.GOOS)
+}
+
+// ConnectorSupportedOnHostOS reports availability on the current host OS.
 func ConnectorSupportedOnHostOS(name string) bool {
-	return connectorSupportedOnOS(name, runtime.GOOS)
+	return ConnectorSupportOnHostOS(name).Status != PlatformUnsupported
 }
 
-// errConnectorUnsupportedOnOS is the clear, behavior-first error proxy-connector
-// Setup returns when invoked on an OS that cannot host the guardrail proxy.
+// validateConnectorSupportedOnOS returns the clear setup error used by direct
+// connector lifecycle calls. It is injectable by OS for focused tests.
+func validateConnectorSupportedOnOS(name, goos string) error {
+	support := ConnectorSupportOnOS(name, goos)
+	if support.Status != PlatformUnsupported {
+		return nil
+	}
+	return fmt.Errorf("connector %q is not supported on %s: %s", name, goos, support.Reason)
+}
+
 func errConnectorUnsupportedOnOS(name, goos string) error {
-	return fmt.Errorf("connector %q is not supported on %s: DefenseClaw on %s is hook-only and proxy connectors require the guardrail proxy", name, goos, goos)
+	return validateConnectorSupportedOnOS(name, goos)
 }

--- a/internal/gateway/connector/platform_support_test.go
+++ b/internal/gateway/connector/platform_support_test.go
@@ -18,31 +18,70 @@ package connector
 
 import (
 	"sort"
+	"strings"
 	"testing"
 )
 
-// proxyConnectorNames mirrors the Python
-// platform_support.WINDOWS_UNSUPPORTED_CONNECTORS set. A change on either
-// side must be made on both; these tests fail loudly if they drift.
-var proxyConnectorNames = []string{"openclaw", "zeptoclaw"}
-
-// hookConnectorNames are the hook-based connectors supported on every
-// OS, including Windows.
-var hookConnectorNames = []string{
+var windowsSupportedConnectorNames = []string{
 	"antigravity",
 	"claudecode",
 	"codex",
 	"copilot",
 	"cursor",
 	"geminicli",
-	"hermes",
-	"omnigent",
 	"opencode",
-	"openhands",
 	"windsurf",
 }
 
-func TestProxyConnectorsSetMatchesMirror(t *testing.T) {
+var windowsPreviewConnectorNames = []string{"hermes"}
+
+var windowsUnsupportedConnectorNames = []string{
+	"openclaw",
+	"openhands",
+	"omnigent",
+	"zeptoclaw",
+}
+
+var proxyConnectorNames = []string{"openclaw", "zeptoclaw"}
+
+func allWindowsConnectorNames() []string {
+	out := append([]string(nil), windowsSupportedConnectorNames...)
+	out = append(out, windowsPreviewConnectorNames...)
+	out = append(out, windowsUnsupportedConnectorNames...)
+	return out
+}
+
+func TestWindowsConnectorSupportTaxonomy(t *testing.T) {
+	want := make(map[string]PlatformSupportStatus)
+	for _, name := range windowsSupportedConnectorNames {
+		want[name] = PlatformSupported
+	}
+	for _, name := range windowsPreviewConnectorNames {
+		want[name] = PlatformPreview
+	}
+	for _, name := range windowsUnsupportedConnectorNames {
+		want[name] = PlatformUnsupported
+	}
+
+	if len(windowsConnectorSupport) != len(want) {
+		t.Fatalf("windowsConnectorSupport has %d entries, want %d", len(windowsConnectorSupport), len(want))
+	}
+	for name, wantStatus := range want {
+		support, ok := windowsConnectorSupport[name]
+		if !ok {
+			t.Errorf("windowsConnectorSupport missing %q", name)
+			continue
+		}
+		if support.Status != wantStatus {
+			t.Errorf("%s status=%q, want %q", name, support.Status, wantStatus)
+		}
+		if strings.TrimSpace(support.Reason) == "" {
+			t.Errorf("%s has no support reason", name)
+		}
+	}
+}
+
+func TestProxyConnectorsRemainTopologyOnly(t *testing.T) {
 	got := make([]string, 0, len(proxyConnectors))
 	for name := range proxyConnectors {
 		got = append(got, name)
@@ -50,78 +89,75 @@ func TestProxyConnectorsSetMatchesMirror(t *testing.T) {
 	sort.Strings(got)
 	want := append([]string(nil), proxyConnectorNames...)
 	sort.Strings(want)
-	if len(got) != len(want) {
-		t.Fatalf("proxyConnectors = %v, want %v", got, want)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("proxyConnectors=%v, want %v", got, want)
 	}
-	for i := range got {
-		if got[i] != want[i] {
-			t.Fatalf("proxyConnectors = %v, want %v", got, want)
-		}
-	}
-}
-
-func TestIsProxyConnector(t *testing.T) {
-	for _, name := range proxyConnectorNames {
-		if !IsProxyConnector(name) {
-			t.Errorf("IsProxyConnector(%q) = false, want true", name)
-		}
-	}
-	for _, name := range hookConnectorNames {
+	for _, name := range []string{"openhands", "omnigent", "hermes"} {
 		if IsProxyConnector(name) {
-			t.Errorf("IsProxyConnector(%q) = true, want false", name)
+			t.Errorf("IsProxyConnector(%q)=true, want false", name)
 		}
 	}
 }
 
-func TestConnectorSupportedOnOS(t *testing.T) {
-	// Windows: proxy connectors unsupported, hook connectors supported.
-	for _, name := range proxyConnectorNames {
-		if connectorSupportedOnOS(name, "windows") {
-			t.Errorf("connectorSupportedOnOS(%q, windows) = true, want false", name)
+func TestConnectorSupportOnOS(t *testing.T) {
+	for _, name := range windowsSupportedConnectorNames {
+		if got := ConnectorSupportOnOS(name, "windows").Status; got != PlatformSupported {
+			t.Errorf("%s status=%q, want supported", name, got)
 		}
 	}
-	for _, name := range hookConnectorNames {
+	for _, name := range windowsPreviewConnectorNames {
+		if got := ConnectorSupportOnOS(name, "windows").Status; got != PlatformPreview {
+			t.Errorf("%s status=%q, want preview", name, got)
+		}
 		if !connectorSupportedOnOS(name, "windows") {
-			t.Errorf("connectorSupportedOnOS(%q, windows) = false, want true", name)
+			t.Errorf("preview connector %s should remain available", name)
 		}
 	}
-	// Unix: everything supported.
+	for _, name := range windowsUnsupportedConnectorNames {
+		if got := ConnectorSupportOnOS(name, "windows").Status; got != PlatformUnsupported {
+			t.Errorf("%s status=%q, want unsupported", name, got)
+		}
+		if connectorSupportedOnOS(name, "windows") {
+			t.Errorf("unsupported connector %s should be unavailable", name)
+		}
+	}
+
 	for _, goos := range []string{"linux", "darwin"} {
-		for _, name := range append(append([]string(nil), proxyConnectorNames...), hookConnectorNames...) {
-			if !connectorSupportedOnOS(name, goos) {
-				t.Errorf("connectorSupportedOnOS(%q, %s) = false, want true", name, goos)
+		for _, name := range allWindowsConnectorNames() {
+			if got := ConnectorSupportOnOS(name, goos).Status; got != PlatformSupported {
+				t.Errorf("%s on %s status=%q, want supported", name, goos, got)
 			}
 		}
 	}
+
+	if got := ConnectorSupportOnOS("plugin-example", "windows").Status; got != PlatformSupported {
+		t.Fatalf("unknown plugin status=%q, want supported", got)
+	}
 }
 
-// TestRegistryNamesFilterToHookConnectorsOnWindows takes the full built-in
-// registry (Available() returns all connectors on this non-Windows host) and
-// asserts that applying the Windows OS filter yields exactly the hook
-// connectors, with both proxy connectors removed.
-func TestRegistryNamesFilterToHookConnectorsOnWindows(t *testing.T) {
+func TestValidateConnectorSupportedOnOS(t *testing.T) {
+	if err := validateConnectorSupportedOnOS("hermes", "windows"); err != nil {
+		t.Fatalf("preview connector should validate: %v", err)
+	}
+	err := validateConnectorSupportedOnOS("openhands", "windows")
+	if err == nil || !strings.Contains(err.Error(), "requires WSL") {
+		t.Fatalf("expected clear OpenHands Windows rejection, got %v", err)
+	}
+}
+
+func TestRegistryWindowsFilterKeepsSupportedAndPreview(t *testing.T) {
 	reg := NewDefaultRegistry()
-	var all []string
-	for _, info := range reg.Available() {
-		all = append(all, info.Name)
-	}
-
-	var onWindows []string
-	for _, name := range all {
+	var got []string
+	for _, name := range reg.Names() {
 		if connectorSupportedOnOS(name, "windows") {
-			onWindows = append(onWindows, name)
+			got = append(got, name)
 		}
 	}
-	sort.Strings(onWindows)
-
-	want := append([]string(nil), hookConnectorNames...)
+	sort.Strings(got)
+	want := append([]string(nil), windowsSupportedConnectorNames...)
+	want = append(want, windowsPreviewConnectorNames...)
 	sort.Strings(want)
-	if len(onWindows) != len(want) {
-		t.Fatalf("windows-filtered connectors = %v, want %v", onWindows, want)
-	}
-	for i := range onWindows {
-		if onWindows[i] != want[i] {
-			t.Fatalf("windows-filtered connectors = %v, want %v", onWindows, want)
-		}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("windows-filtered connectors=%v, want %v", got, want)
 	}
 }

--- a/internal/gateway/connector/registry.go
+++ b/internal/gateway/connector/registry.go
@@ -31,6 +31,8 @@ type ConnectorInfo struct {
 	Source             string // "built-in" or "plugin"
 	ToolInspectionMode ToolInspectionMode
 	SubprocessPolicy   SubprocessPolicy
+	PlatformStatus     PlatformSupportStatus
+	PlatformReason     string
 }
 
 // Registry holds all available connectors (built-in + discovered plugins).
@@ -112,10 +114,11 @@ func (r *Registry) Available() []ConnectorInfo {
 
 	out := make([]ConnectorInfo, 0, len(r.builtins)+len(r.plugins))
 	for _, c := range r.builtins {
-		// Hide connectors unsupported on this OS (proxy connectors on Windows)
-		// so the TUI/CLI and /v1/connectors never surface a path that cannot
-		// run here.
-		if !ConnectorSupportedOnHostOS(c.Name()) {
+		// Hide connectors unsupported on this OS so the TUI/CLI and
+		// /v1/connectors never surface a path that cannot run here. Retain
+		// preview connectors with explicit metadata for presentation consumers.
+		support := ConnectorSupportOnHostOS(c.Name())
+		if support.Status == PlatformUnsupported {
 			continue
 		}
 		out = append(out, ConnectorInfo{
@@ -124,10 +127,13 @@ func (r *Registry) Available() []ConnectorInfo {
 			Source:             "built-in",
 			ToolInspectionMode: c.ToolInspectionMode(),
 			SubprocessPolicy:   c.SubprocessPolicy(),
+			PlatformStatus:     support.Status,
+			PlatformReason:     support.Reason,
 		})
 	}
 	for _, c := range r.plugins {
-		if !ConnectorSupportedOnHostOS(c.Name()) {
+		support := ConnectorSupportOnHostOS(c.Name())
+		if support.Status == PlatformUnsupported {
 			continue
 		}
 		out = append(out, ConnectorInfo{
@@ -136,6 +142,8 @@ func (r *Registry) Available() []ConnectorInfo {
 			Source:             "plugin",
 			ToolInspectionMode: c.ToolInspectionMode(),
 			SubprocessPolicy:   c.SubprocessPolicy(),
+			PlatformStatus:     support.Status,
+			PlatformReason:     support.Reason,
 		})
 	}
 

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -29,6 +29,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -3973,6 +3974,14 @@ func (p *GuardrailProxy) switchConnectorLocked(newName string) {
 	if !ok {
 		fmt.Fprintf(os.Stderr, "[guardrail] runtime connector switch: %q not in registry — ignoring\n", newName)
 		return
+	}
+	support := connector.ConnectorSupportOnHostOS(newName)
+	if support.Status == connector.PlatformUnsupported {
+		fmt.Fprintf(os.Stderr, "[guardrail] runtime connector switch: %q is not supported on %s: %s\n", newName, runtime.GOOS, support.Reason)
+		return
+	}
+	if support.Status == connector.PlatformPreview {
+		fmt.Fprintf(os.Stderr, "[guardrail] WARNING: connector %s is preview on %s: %s\n", newName, runtime.GOOS, support.Reason)
 	}
 
 	ctx := context.Background()

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -1479,6 +1480,15 @@ func (s *Sidecar) runGuardrail(ctx context.Context) error {
 		}
 		connector.ClearActiveConnector(s.cfg.DataDir)
 	} else {
+		support := connector.ConnectorSupportOnHostOS(conn.Name())
+		if support.Status == connector.PlatformUnsupported {
+			err := fmt.Errorf("connector %q is not supported on %s: %s", conn.Name(), runtime.GOOS, support.Reason)
+			s.health.SetGuardrail(StateError, err.Error(), nil)
+			return err
+		}
+		if support.Status == connector.PlatformPreview {
+			fmt.Fprintf(os.Stderr, "[guardrail] WARNING: connector %s is preview on %s: %s\n", conn.Name(), runtime.GOOS, support.Reason)
+		}
 		if err := teardownPreviousConnector(registry, conn.Name(), setupOpts, ctx); err != nil {
 			fmt.Fprintf(os.Stderr, "[guardrail] WARNING: proceeding with %s setup despite stale state from previous connector\n", conn.Name())
 		}
@@ -2078,6 +2088,13 @@ func (s *Sidecar) connectorSetupOpts(conn connector.Connector, apiToken, proxyAd
 // back just this connector's Setup before returning so a half-installed
 // connector never lingers.
 func (s *Sidecar) setupOneConnector(ctx context.Context, conn connector.Connector, opts connector.SetupOpts, masterKey string, cache *guardrail.RulePackCache) error {
+	support := connector.ConnectorSupportOnHostOS(conn.Name())
+	if support.Status == connector.PlatformUnsupported {
+		return fmt.Errorf("connector %q is not supported on %s: %s", conn.Name(), runtime.GOOS, support.Reason)
+	}
+	if support.Status == connector.PlatformPreview {
+		fmt.Fprintf(os.Stderr, "[guardrail] WARNING: connector %s is preview on %s: %s\n", conn.Name(), runtime.GOOS, support.Reason)
+	}
 	// Inject credentials before Setup so probes keyed off them succeed.
 	conn.SetCredentials(opts.APIToken, masterKey)
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -130,6 +130,38 @@ function Test-HasCommand {
     return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
 }
 
+function Invoke-Uv {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [switch]$ShowFailureOutput
+    )
+
+    # Windows PowerShell 5.1 turns any native stderr text into an ErrorRecord.
+    # With the installer's global ErrorActionPreference=Stop, harmless uv
+    # progress/status output would therefore abort even when uv exits zero.
+    # Capture both streams under Continue and make the native exit status the
+    # only success criterion. PowerShell 7 does not need the workaround, but
+    # follows the same explicit status contract here.
+    $previousErrorActionPreference = $ErrorActionPreference
+    $output = @()
+    $exitCode = 1
+    try {
+        $ErrorActionPreference = "Continue"
+        $output = & uv @Arguments 2>&1
+        $exitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+
+    if ($ShowFailureOutput -and $exitCode -ne 0) {
+        foreach ($line in $output) {
+            Write-Host "    $line" -ForegroundColor DarkGray
+        }
+    }
+    return [int]$exitCode
+}
+
 function Confirm-YesNo {
     param([string]$Prompt, [string]$Default = "y")
     if ($Yes) { return $true }
@@ -186,7 +218,8 @@ function Ensure-Python {
     Write-Step "Checking Python"
     # uv manages an interpreter for us; ask it for 3.12 and install on demand.
     # This avoids depending on a system Python being present or new enough.
-    & uv python install 3.12 *> $null
+    $exitCode = Invoke-Uv -Arguments @("python", "install", "3.12") -ShowFailureOutput
+    if ($exitCode -ne 0) { Die "Failed to install Python 3.12 via uv" }
     Write-Ok "Python 3.12 (managed by uv)"
 }
 
@@ -307,10 +340,10 @@ function Install-Gateway {
 function Install-Cli {
     Write-Step "Installing DefenseClaw CLI"
     Write-Info "Creating Python environment..."
-    & uv venv $Venv --python 3.12 --quiet 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        & uv venv $Venv --quiet
-        if ($LASTEXITCODE -ne 0) { Die "Failed to create Python virtual environment" }
+    $venvExit = Invoke-Uv -Arguments @("venv", $Venv, "--python", "3.12", "--quiet")
+    if ($venvExit -ne 0) {
+        $venvExit = Invoke-Uv -Arguments @("venv", $Venv, "--quiet") -ShowFailureOutput
+        if ($venvExit -ne 0) { Die "Failed to create Python virtual environment" }
     }
     $venvPython = Join-Path $Venv "Scripts\python.exe"
 
@@ -328,8 +361,8 @@ function Install-Cli {
             $resolved = Get-Artifact -Name $whlName -Dest $whlPath
             Test-Checksum -File $whlPath -FileName $resolved
         }
-        & uv pip install --python $venvPython --quiet $whlPath
-        if ($LASTEXITCODE -ne 0) { Die "Failed to install CLI from wheel" }
+        $pipExit = Invoke-Uv -Arguments @("pip", "install", "--python", $venvPython, "--quiet", $whlPath) -ShowFailureOutput
+        if ($pipExit -ne 0) { Die "Failed to install CLI from wheel" }
     } finally {
         Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
     }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -81,11 +81,22 @@ $Venv = Join-Path $DefenseClawHome ".venv"
 # `defenseclaw upgrade` (which replaces the gateway there). The venv stays under
 # DEFENSECLAW_HOME so a custom home still relocates the heavy CLI environment.
 $InstallDir = Join-Path $env:USERPROFILE ".local\bin"
-$OpenClawVersion = "2026.3.24"
-
-# Keep in sync with scripts/install.sh CONNECTOR_CHOICES and
-# internal/gateway/connector/registry.go DefaultRegistry.
-$ConnectorChoices = @("codex", "claudecode", "zeptoclaw", "openclaw", "none")
+# Native-Windows release surface. Keep this in sync with
+# cli/defenseclaw/platform_support.py WINDOWS_CONNECTOR_SUPPORT. Hermes is
+# intentionally selectable but labelled preview; proxy/WSL-only connectors are
+# rejected by this installer.
+$ConnectorChoices = @(
+    "codex",
+    "claudecode",
+    "cursor",
+    "windsurf",
+    "geminicli",
+    "copilot",
+    "antigravity",
+    "opencode",
+    "hermes",
+    "none"
+)
 
 # ── Logging ───────────────────────────────────────────────────────────────────
 
@@ -109,7 +120,7 @@ Usage:
 
 Options:
   -Connector <name>    Pick agent connector ($($ConnectorChoices -join '|'))
-  -NoOpenclaw          Skip OpenClaw (alias for -Connector none when alone)
+  -NoOpenclaw          Legacy alias for -Connector none when used alone
   -Version <x.y.z>     Install a specific release version
   -Local <dir>         Install from a local dist directory instead of downloading
   -Quickstart          Run 'defenseclaw quickstart --non-interactive' post-install
@@ -394,11 +405,16 @@ function Select-Connector {
     $i = 1
     foreach ($v in $ConnectorChoices) {
         switch ($v) {
-            "codex"      { Write-Host "    $i) codex      - patch %USERPROFILE%\.codex\config.toml + hooks" }
-            "claudecode" { Write-Host "    $i) claudecode - patch %USERPROFILE%\.claude\settings.json hooks" }
-            "zeptoclaw"  { Write-Host "    $i) zeptoclaw  - patch %USERPROFILE%\.zeptoclaw\config.json" }
-            "openclaw"   { Write-Host "    $i) openclaw   - install OpenClaw runtime + DefenseClaw plugin" }
-            "none"       { Write-Host "    $i) none       - install gateway/CLI only; pick later" }
+            "codex"       { Write-Host "    $i) codex       - Codex CLI native hooks" }
+            "claudecode"  { Write-Host "    $i) claudecode  - Claude Code native hooks" }
+            "cursor"      { Write-Host "    $i) cursor      - Cursor IDE native hooks (CLI remains WSL-only)" }
+            "windsurf"    { Write-Host "    $i) windsurf    - Windsurf native hooks" }
+            "geminicli"   { Write-Host "    $i) geminicli   - Gemini CLI native hooks" }
+            "copilot"     { Write-Host "    $i) copilot     - GitHub Copilot native hooks" }
+            "antigravity" { Write-Host "    $i) antigravity - Antigravity native hooks" }
+            "opencode"    { Write-Host "    $i) opencode    - OpenCode native JavaScript bridge" }
+            "hermes"      { Write-Host "    $i) hermes      - Hermes native hooks (preview)" }
+            "none"        { Write-Host "    $i) none        - install gateway/CLI only; pick later" }
         }
         $i++
     }
@@ -419,26 +435,6 @@ function Save-PickedConnector {
     if (-not $script:PickedConnector -or $script:PickedConnector -eq "none") { return }
     New-Item -ItemType Directory -Force -Path $DefenseClawHome | Out-Null
     Set-Content -Path (Join-Path $DefenseClawHome "picked_connector") -Value $script:PickedConnector
-}
-
-# ── Optional: OpenClaw runtime (npm) ──────────────────────────────────────────
-
-function Install-OpenClaw {
-    if ($script:PickedConnector -ne "openclaw") { return }
-    Write-Step "Checking OpenClaw"
-    if (Test-HasCommand "openclaw") {
-        Write-Ok "OpenClaw found"
-        return
-    }
-    Write-Warn2 "OpenClaw is not installed (required $OpenClawVersion)."
-    if (-not (Test-HasCommand "npm")) {
-        Write-Info "Install Node.js + npm, then: npm install -g openclaw@$OpenClawVersion"
-        return
-    }
-    if (Confirm-YesNo "Install OpenClaw $OpenClawVersion via npm?") {
-        & npm install -g "openclaw@$OpenClawVersion" --loglevel=error
-        if ($LASTEXITCODE -eq 0) { Write-Ok "OpenClaw installed" } else { Write-Warn2 "OpenClaw install failed" }
-    }
 }
 
 # ── Optional: quickstart ──────────────────────────────────────────────────────
@@ -486,12 +482,10 @@ function Write-Success {
     Write-Host "         DefenseClaw installed successfully!" -ForegroundColor Green
     Write-Host "  ============================================================" -ForegroundColor Green
     Write-Host ""
-    switch ($script:PickedConnector) {
-        "openclaw"   { Write-Host "  Get started:`n`n    defenseclaw init --connector openclaw --profile observe`n" -ForegroundColor Cyan }
-        "codex"      { Write-Host "  Get started (Codex):`n`n    defenseclaw init --connector codex`n" -ForegroundColor Cyan }
-        "claudecode" { Write-Host "  Get started (Claude Code):`n`n    defenseclaw init --connector claudecode`n" -ForegroundColor Cyan }
-        "zeptoclaw"  { Write-Host "  Get started (ZeptoClaw):`n`n    defenseclaw init --connector zeptoclaw`n" -ForegroundColor Cyan }
-        default      { Write-Host "  Get started (pick a connector later):`n`n    defenseclaw init`n" -ForegroundColor Cyan }
+    if ($script:PickedConnector -and $script:PickedConnector -ne "none") {
+        Write-Host "  Get started ($script:PickedConnector):`n`n    defenseclaw init --connector $script:PickedConnector`n" -ForegroundColor Cyan
+    } else {
+        Write-Host "  Get started (pick a connector later):`n`n    defenseclaw init`n" -ForegroundColor Cyan
     }
 }
 
@@ -508,7 +502,8 @@ function Main {
     $script:ChecksumsFile = $null
     $script:ReleaseVersion = $null
 
-    # Validate -Connector and reconcile with -NoOpenclaw, mirroring install.sh.
+    # Validate against the native-Windows connector surface. -NoOpenclaw is
+    # retained only as a backwards-compatible alias for selecting none.
     if ($Connector) {
         if ($ConnectorChoices -notcontains $Connector) {
             Die "Invalid -Connector '$Connector'. Choices: $($ConnectorChoices -join ', ')"
@@ -518,8 +513,6 @@ function Main {
     if ($NoOpenclaw) {
         if (-not $script:PickedConnector) {
             $script:PickedConnector = "none"
-        } elseif ($script:PickedConnector -eq "openclaw") {
-            Die "-NoOpenclaw is incompatible with -Connector openclaw"
         }
     }
 
@@ -536,10 +529,10 @@ function Main {
     Install-Gateway -Arch $arch
     Install-Cli
 
-    switch ($script:PickedConnector) {
-        "openclaw"   { Install-OpenClaw }
-        { $_ -in @("codex", "claudecode", "zeptoclaw") } { Write-Info "Connector '$script:PickedConnector' wires up via the CLI (no OpenClaw runtime needed)." }
-        default      { Write-Info "Skipping connector setup - run 'defenseclaw init' when ready" }
+    if ($script:PickedConnector -and $script:PickedConnector -ne "none") {
+        Write-Info "Connector '$script:PickedConnector' wires up through the native Windows CLI."
+    } else {
+        Write-Info "Skipping connector setup - run 'defenseclaw init' when ready"
     }
 
     Save-PickedConnector


### PR DESCRIPTION
> Replaces #416 after the fork branch was renamed to `windows-native-support`.

## Goal

Ship DefenseClaw with native Windows support while preserving the existing macOS and Linux behavior.

This PR is deliberately **Windows-native only**. It does not implement or depend on WSL.

## Connector scope

| Status | Connectors |
|---|---|
| Native supported | Codex CLI, Claude Code, Cursor IDE, Windsurf, Gemini CLI, GitHub Copilot CLI, Antigravity, OpenCode |
| Native preview | Hermes |
| Not supported on native Windows | OpenHands, OmniGent, OpenClaw, ZeptoClaw |

Cursor IDE hooks are supported natively. Cursor Agent CLI remains WSL-only and is outside this release.

## Commit-by-commit review

### 1. `7650c785` — Define and enforce Windows connector support

**Problem:** Windows setup exposed connectors that do not have a supported native DefenseClaw path.

**Changes:**

- Added matching Python and Go `supported`, `preview`, and `unsupported` connector classifications.
- Limited native Windows setup to eight supported connectors plus Hermes preview.
- Hid unsupported connectors from CLI/TUI pickers.
- Rejected explicit unsupported setup requests before configuration mutation.
- Added platform status and reason fields to registry/API output.
- Preserved the existing macOS/Linux connector behavior.
- Updated `CONNECTOR-MATRIX.md` with support reasons and upstream references.

### 2. `f15bbaea` — Make secret-bearing file writes safe on Windows

**Problem:** WIN-023 reproduced an `os.fchmod` crash, leaked staging descriptor, locked temporary file, and prevented webhook configuration.

**Changes:**

- Added a shared cross-platform file-permission helper.
- Kept descriptor-based `fchmod` on POSIX.
- Added protected owner-only Windows DACL handling for secret files.
- Closed descriptors before cleanup so Windows can remove staging files.
- Preserved atomic targets when permission, serialization, or replacement operations fail.
- Applied the fix to webhook, observability, migration, and dotenv writers.
- Preserved existing Windows DACLs during non-secret migration rewrites.

### 3. `4321b3c3` — Fix PowerShell installation and scanner discovery

**Problems:**

- WIN-009: PowerShell 5.1 treated harmless `uv` stderr as a terminating error.
- WIN-007: installed scanner executables were reported as missing because only `PATH` was searched.

**Changes:**

- Added `Invoke-Uv`, which captures PowerShell 5.1 error-stream records and decides success from the native exit code.
- Applied explicit exit handling to Python installation, venv creation, and wheel installation.
- Added a shared scanner resolver that checks the active environment's `Scripts`/`bin` directory before `PATH`.
- Made human status, JSON status, and doctor use the same scanner resolution.

### 4. `7147069d` — Parse complete health documents and wait for readiness

**Problems:**

- WIN-006: doctor truncated valid multi-connector `/health` JSON before parsing it.
- WIN-011: start/restart returned before the gateway reached a stable state.

**Changes:**

- Read structured health documents completely within a one-megabyte safety bound.
- Retained the 2,000-character limit only for ordinary diagnostic display text.
- Shared complete bounded parsing with the Go status command.
- Made gateway start/restart wait for `api.state=running` for up to ten seconds.
- Added fast failure for process exit and explicit API error states.
- Reported a truthful `STARTING` state when a live process remains in startup.

### 5. `06204b2b` — Add Windows CLI and TUI parity

**Problems:**

- WIN-002: Windows arrow-key sequences were ignored.
- WIN-003: consoles without VT redraw support stacked repeated menus.
- WIN-013: the TUI could not launch a `.cmd` CLI shim with `create_subprocess_exec`.

**Changes:**

- Added Windows extended Up/Down sequences while retaining ANSI and `j`/`k` navigation.
- Enabled Windows Virtual Terminal processing when available.
- Added a numbered, line-oriented fallback for consoles without safe redraw support.
- Centralized TUI subprocess resolution through `python.exe -m defenseclaw.main`.
- Updated credentials, doctor, inventory, skills, plugins, and MCP subprocess call sites.
- Kept POSIX PTY behavior and made Windows reject forced POSIX PTY mode clearly.

### 6. `0d5134f0` — Align packaging and plugin inventory

**Verification outcomes:**

- WIN-004 was already fixed in the supported `make dist-cli` release path. Added an installed-wheel smoke assertion proving `registry.json` loads.
- WIN-005 was not reproducible on a clean profile. No speculative init change was made.
- WIN-020 was confirmed: AIBOM counted hidden/staging plugin directories that `plugin list` excluded.

**Changes:**

- Added one shared plugin-directory enumerator.
- Excluded cache, hidden activation state, and `..plugin-appserver.staging-*` directories consistently.
- Made AIBOM and `plugin list` report the same real plugins.

### 7. `7212814c` — Enable safe Windows trust and action mode

**Problems:**

- WIN-001: synthesized POSIX permission bits marked normal Windows directories as world-writable.
- WIN-014/WIN-015: agent versions could not be trusted or probed, making action mode unreachable.

**Changes:**

- Added native Win32 owner/DACL inspection through `ctypes`.
- Rejected broad write access from principals such as Everyone, Authenticated Users, and ordinary Users.
- Allowed appropriate control by the owner, Administrators, and SYSTEM.
- Checked the executable and ancestor chain through the trusted prefix.
- Added case-insensitive canonical containment and drive-root rejection.
- Added narrow documented Windows install locations without trusting AppData wholesale.
- Added `.exe`, `.cmd`, `.bat`, and `.com` handling and extension-aware version parsing.
- Enabled verified Codex, Claude, and Cursor version probes so action-mode compatibility checks can pass.
- Preserved the already-correct persisted-trust reload flow and added regression coverage.

### 8. `b3b92634` — Enforce hooks through native Windows commands

**Problem:** Several generated configs still depended on Bash or used command forms that native Windows agents did not execute correctly.

**Changes:**

- Generated direct `defenseclaw-gateway.exe hook --connector ...` commands on Windows.
- Replaced Codex's Bash notify bridge with a hidden native `notify` command.
- Added Copilot PowerShell hook entries with the required call operator.
- Used a PATH-resolved gateway command for Antigravity's quote-sensitive direct-exec parser.
- Kept OpenCode on its separate JavaScript bridge path.
- Tightened teardown ownership so unrelated hook commands are not removed.
- Added JSON stdin/stdout, endpoint, token, sidecar, fail-mode, allow/block, ownership, and teardown matrices.
- Verified generated commands from gateway paths containing spaces.

### 9. `17c63621` — Integration review corrections

**Purpose:** Resolve gaps only visible after reviewing all eight workstreams together.

**Changes:**

- Aligned the PowerShell installer picker with the final native connector taxonomy.
- Removed the Windows OpenClaw runtime installation path.
- Tightened hook ownership so a foreign absolute path with the same `defenseclaw-gateway.exe` basename is not treated as owned.
- Applied owner-only Windows DACL handling to the main setup `.env` writer.
- Fixed cross-session test assumptions for terminal redraw and Windows path separators.

## Verification summary

- Setup/platform: **103 passed**, plus **28 subtests**.
- TUI/judge: **155 passed**, with **1 POSIX-only skip**.
- Windows ACL trust/action: **38 passed**, with **14 intentional POSIX-only skips**.
- PowerShell 5.1 installer and managed scanner regressions: passed.
- Secure-write DACL, descriptor cleanup, and atomic failure regressions: passed.
- Complete health-document and gateway-readiness regressions: passed.
- Plugin hidden/staging enumeration regressions: passed.
- Native hookexec, connector config, endpoint, allow/block, token, teardown, readiness, and notify Go tests: passed.
- Windows release-surface gateway build: passed.
- Go vet, Ruff, Python compilation, PowerShell syntax parsing, and diff hygiene: passed.

## Known limits

- WSL setup and protection are not part of this PR.
- Hermes remains preview because its upstream native Windows runtime is Early Beta.
- Legacy Windows suites still contain unrelated failures for excluded connectors and tests that assume Bash, POSIX symlinks, Unix mode bits, or Unix home-path behavior.
- Physical Windows Terminal testing and final live-vendor connector smoke testing are still recommended before release.

## Review status

This remains a **draft PR**. It should not be merged until CI and human review are complete.
