### PR TITLE
docs: update install snippets for 0.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ make all
 ### Install with the release script
 
 ```bash
-VERSION=0.8.2
+VERSION=0.8.3
 INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
 curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash
 defenseclaw init --enable-guardrail

--- a/cli/tests/test_install_docs_static.py
+++ b/cli/tests/test_install_docs_static.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 CURRENT_RELEASE = "0.8.3"
-STALE_RELEASES = ("0.8.0", "0.8.1")
+STALE_RELEASES = ("0.8.0", "0.8.1", "0.8.2")
 
 BASH_INSTALL_LINES = (
     f"VERSION={CURRENT_RELEASE}",

--- a/cli/tests/test_install_docs_static.py
+++ b/cli/tests/test_install_docs_static.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-CURRENT_RELEASE = "0.8.2"
+CURRENT_RELEASE = "0.8.3"
 STALE_RELEASES = ("0.8.0", "0.8.1")
 
 BASH_INSTALL_LINES = (

--- a/docs-site/components/terminal-demo.tsx
+++ b/docs-site/components/terminal-demo.tsx
@@ -28,7 +28,7 @@ interface ScriptLine {
   text: string;
 }
 
-const INSTALL_VERSION = '0.8.2';
+const INSTALL_VERSION = '0.8.3';
 
 // Static header — typed once on initial mount and never replayed.
 // `defenseclaw-gateway` is the canonical companion install line and

--- a/docs-site/content/docs/get-started/first-guardrail.mdx
+++ b/docs-site/content/docs/get-started/first-guardrail.mdx
@@ -17,7 +17,7 @@ This walkthrough ends with DefenseClaw refusing to let Claude Code run `rm -rf ~
 ### Install
 
 ```bash
-VERSION=0.8.2
+VERSION=0.8.3
 INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
 curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash -s -- --connector claudecode
 ```

--- a/docs-site/content/docs/get-started/install.mdx
+++ b/docs-site/content/docs/get-started/install.mdx
@@ -44,7 +44,7 @@ The base install ships everything DefenseClaw needs to talk to the major LLM bac
 <Tab value="macOS/Linux curl">
 
 ```bash
-VERSION=0.8.2
+VERSION=0.8.3
 INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
 curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash
 defenseclaw init
@@ -63,7 +63,7 @@ defenseclaw quickstart --connector codex
 <Tab value="Windows PowerShell">
 
 ```powershell
-$Version = "0.8.2"
+$Version = "0.8.3"
 $InstallUrl = "https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/$Version/scripts/install.ps1"
 & ([scriptblock]::Create((irm $InstallUrl))) -Version $Version
 defenseclaw init
@@ -74,7 +74,7 @@ The PowerShell installer downloads the Windows release ZIP for your architecture
 For non-interactive demos or CI, download the script and pass flags directly:
 
 ```powershell
-$Version = "0.8.2"
+$Version = "0.8.3"
 $InstallUrl = "https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/$Version/scripts/install.ps1"
 & ([scriptblock]::Create((irm $InstallUrl))) -Version $Version -Connector codex -Quickstart -Yes
 ```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -319,7 +319,7 @@ make clean        # Full clean (binaries, venv, node_modules, coverage)
 End users can install a released version without cloning the repo:
 
 ```bash
-VERSION=0.8.2
+VERSION=0.8.3
 INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
 curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash
 ```
@@ -332,7 +332,7 @@ confirmations.
 Pin a specific version:
 
 ```bash
-VERSION=0.8.2
+VERSION=0.8.3
 INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
 curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash
 ```
@@ -344,7 +344,7 @@ OpenClaw runtime and the DefenseClaw plugin). You can pick a different
 connector — or skip connector setup entirely — with `--connector`:
 
 ```bash
-VERSION=0.8.2
+VERSION=0.8.3
 INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
 
 # Codex (no OpenClaw, no plugin tarball; patches ~/.codex/config.toml + hooks)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -23,7 +23,7 @@ for full details.
 ### Install DefenseClaw
 
 ```bash
-VERSION=0.8.2
+VERSION=0.8.3
 INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
 curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash
 defenseclaw init --enable-guardrail


### PR DESCRIPTION
## Summary
- update install snippets from 0.8.2 to the current 0.8.3 release
- keep the static docs guard pointed at the same release

## Validation
- uv run pytest cli/tests/test_install_docs_static.py
- git diff --check