### PR TITLE
fix(installer): pin release URLs in help

### DIFF
--- a/cli/tests/test_install_docs_static.py
+++ b/cli/tests/test_install_docs_static.py
@@ -51,6 +51,11 @@ DOC_INSTALL_COMMANDS = {
     ),
 }
 
+INSTALLER_FILES = (
+    "scripts/install.sh",
+    "scripts/install.ps1",
+)
+
 
 def test_quickstart_docs_do_not_pipe_main_installer() -> None:
     for rel, expected_lines in DOC_INSTALL_COMMANDS.items():
@@ -59,6 +64,13 @@ def test_quickstart_docs_do_not_pipe_main_installer() -> None:
         assert "raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.ps1" not in text
         for expected in expected_lines:
             assert expected in text, f"{rel} is missing install snippet line: {expected}"
+
+
+def test_installer_help_does_not_pipe_main_installer() -> None:
+    for rel in INSTALLER_FILES:
+        text = (ROOT / rel).read_text()
+        assert "raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh" not in text
+        assert "raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.ps1" not in text
 
 
 def test_install_docs_track_current_release() -> None:

--- a/cli/tests/test_install_docs_static.py
+++ b/cli/tests/test_install_docs_static.py
@@ -71,6 +71,8 @@ def test_installer_help_does_not_pipe_main_installer() -> None:
         text = (ROOT / rel).read_text()
         assert "raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh" not in text
         assert "raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.ps1" not in text
+        assert "github.com/cisco-ai-defense/defenseclaw/main" not in text
+        assert "defenseclaw/main" not in text
 
 
 def test_install_docs_track_current_release() -> None:

--- a/cli/tests/test_install_docs_static.py
+++ b/cli/tests/test_install_docs_static.py
@@ -69,9 +69,6 @@ def test_quickstart_docs_do_not_pipe_main_installer() -> None:
 def test_installer_help_does_not_pipe_main_installer() -> None:
     for rel in INSTALLER_FILES:
         text = (ROOT / rel).read_text()
-        assert "raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh" not in text
-        assert "raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.ps1" not in text
-        assert "github.com/cisco-ai-defense/defenseclaw/main" not in text
         assert "defenseclaw/main" not in text
 
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -36,7 +36,9 @@
     %USERPROFILE%\.defenseclaw\.venv, so an installed setup upgrades in place.
 
 .EXAMPLE
-    irm https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.ps1 | iex
+    $Version = "0.8.3"
+    $InstallUrl = "https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/$Version/scripts/install.ps1"
+    & ([scriptblock]::Create((irm $InstallUrl))) -Version $Version
 
 .EXAMPLE
     # Pin a version and pick a connector, non-interactively:
@@ -102,7 +104,9 @@ function Show-Help {
 DefenseClaw Installer (Windows)
 
 Usage:
-  irm https://raw.githubusercontent.com/$Repo/main/scripts/install.ps1 | iex
+  `$Version = "0.8.3"
+  `$InstallUrl = "https://raw.githubusercontent.com/$Repo/`$Version/scripts/install.ps1"
+  & ([scriptblock]::Create((irm `$InstallUrl))) -Version `$Version
   .\install.ps1 -Local .\dist                 # from a local build
   .\install.ps1 -Yes                          # non-interactive
   .\install.ps1 -Connector codex -Quickstart  # pick connector + bootstrap

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,7 +22,9 @@
 # No Go, Node.js, or git required — only Python and uv.
 #
 #   # From GitHub release:
-#   curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash
+#   VERSION=0.8.3
+#   INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"
+#   curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash
 #
 #   # From local dist/ directory (for testing):
 #   ./scripts/install.sh --local ./dist
@@ -718,7 +720,9 @@ while [[ $# -gt 0 ]]; do
         --help|-h)
             echo ""
             echo "Usage:"
-            echo "  curl -LsSf https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.sh | bash"
+            echo '  VERSION=0.8.3'
+            echo '  INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"'
+            echo '  curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash'
             echo "  ./scripts/install.sh --local ./dist               # from local build"
             echo "  curl -LsSf <url>/install.sh | bash -s -- --yes    # non-interactive"
             echo "  curl ... | bash -s -- --sandbox                   # OpenClaw/OpenShell sandbox support"


### PR DESCRIPTION
## Summary
- replace mutable branch installer examples in shell and PowerShell help with tagged release examples
- add a static guard so installer help does not drift back to branch URLs

## Validation
- uv run pytest cli/tests/test_install_docs_static.py
- bash -n scripts/install.sh
- bash scripts/install.sh --help
- git diff --check

Note: pwsh is not installed on this machine, so the PowerShell help path was checked by static test and source inspection.