### PR TITLE
fix(installer): offer current connector choices

### DIFF
--- a/cli/tests/test_install_script_static.py
+++ b/cli/tests/test_install_script_static.py
@@ -40,8 +40,20 @@ def test_release_installers_track_known_connector_choices() -> None:
     ps_match = re.search(r"\$ConnectorChoices = @\((.*?)\)", ps_text, re.DOTALL)
     assert ps_match is not None
     ps_choices = tuple(re.findall(r'"([^"]+)"', ps_match.group(1)))
+    hook_match = re.search(
+        r"\$HookConnectors = \$ConnectorChoices \| Where-Object "
+        r'\{ \$_ -notin @\((.*?)\) \}',
+        ps_text,
+        re.DOTALL,
+    )
+    assert hook_match is not None
+    hook_exclusions = tuple(re.findall(r'"([^"]+)"', hook_match.group(1)))
 
     assert shell_choices == (*CONNECTOR_CHOICES, "none")
 
     windows_choices = tuple(supported_connectors(CONNECTOR_CHOICES, "windows"))
     assert ps_choices == (*windows_choices, "none")
+    assert hook_exclusions == ("codex", "claudecode", "none")
+    assert tuple(c for c in ps_choices if c not in hook_exclusions) == tuple(
+        c for c in windows_choices if c not in hook_exclusions
+    )

--- a/cli/tests/test_install_script_static.py
+++ b/cli/tests/test_install_script_static.py
@@ -10,10 +10,15 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
+
+from defenseclaw.platform_support import supported_connectors
+from defenseclaw.tui.panels.first_run import CONNECTOR_CHOICES
 
 ROOT = Path(__file__).resolve().parents[2]
 INSTALL_SH = ROOT / "scripts" / "install.sh"
+INSTALL_PS1 = ROOT / "scripts" / "install.ps1"
 
 
 def test_sandbox_installer_fallback_uses_selected_release() -> None:
@@ -23,3 +28,20 @@ def test_sandbox_installer_fallback_uses_selected_release() -> None:
         "raw.githubusercontent.com/${REPO}/${RELEASE_VERSION}/scripts/install-openshell-sandbox.sh"
         in text
     )
+
+
+def test_release_installers_track_known_connector_choices() -> None:
+    sh_text = INSTALL_SH.read_text()
+    sh_match = re.search(r"readonly CONNECTOR_CHOICES=\(([^)]*)\)", sh_text)
+    assert sh_match is not None
+    shell_choices = tuple(sh_match.group(1).split())
+
+    ps_text = INSTALL_PS1.read_text()
+    ps_match = re.search(r"\$ConnectorChoices = @\((.*?)\)", ps_text, re.DOTALL)
+    assert ps_match is not None
+    ps_choices = tuple(re.findall(r'"([^"]+)"', ps_match.group(1)))
+
+    assert shell_choices == (*CONNECTOR_CHOICES, "none")
+
+    windows_choices = tuple(supported_connectors(CONNECTOR_CHOICES, "windows"))
+    assert ps_choices == (*windows_choices, "none")

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -81,7 +81,6 @@ $Venv = Join-Path $DefenseClawHome ".venv"
 # `defenseclaw upgrade` (which replaces the gateway there). The venv stays under
 # DEFENSECLAW_HOME so a custom home still relocates the heavy CLI environment.
 $InstallDir = Join-Path $env:USERPROFILE ".local\bin"
-$OpenClawVersion = "2026.3.24"
 
 # Keep in sync with cli/defenseclaw/connector_paths.py KNOWN_CONNECTORS.
 # PowerShell runs on Windows, where OpenClaw/ZeptoClaw proxy connectors are
@@ -114,7 +113,7 @@ Usage:
 
 Options:
   -Connector <name>    Pick agent connector ($($ConnectorChoices -join '|'))
-  -NoOpenclaw          Skip OpenClaw (alias for -Connector none when alone)
+  -NoOpenclaw          Install gateway/CLI only when no connector is selected
   -Version <x.y.z>     Install a specific release version
   -Local <dir>         Install from a local dist directory instead of downloading
   -Quickstart          Run 'defenseclaw quickstart --non-interactive' post-install
@@ -133,15 +132,6 @@ Environment variables:
 function Test-HasCommand {
     param([string]$Name)
     return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
-}
-
-function Confirm-YesNo {
-    param([string]$Prompt, [string]$Default = "y")
-    if ($Yes) { return $true }
-    $suffix = if ($Default -eq "y") { "[Y/n]" } else { "[y/N]" }
-    $answer = Read-Host "  $Prompt $suffix"
-    if ([string]::IsNullOrWhiteSpace($answer)) { $answer = $Default }
-    return $answer -match '^[Yy]'
 }
 
 # ── Platform detection ────────────────────────────────────────────────────────
@@ -400,26 +390,6 @@ function Save-PickedConnector {
     Set-Content -Path (Join-Path $DefenseClawHome "picked_connector") -Value $script:PickedConnector
 }
 
-# ── Optional: OpenClaw runtime (npm) ──────────────────────────────────────────
-
-function Install-OpenClaw {
-    if ($script:PickedConnector -ne "openclaw") { return }
-    Write-Step "Checking OpenClaw"
-    if (Test-HasCommand "openclaw") {
-        Write-Ok "OpenClaw found"
-        return
-    }
-    Write-Warn2 "OpenClaw is not installed (required $OpenClawVersion)."
-    if (-not (Test-HasCommand "npm")) {
-        Write-Info "Install Node.js + npm, then: npm install -g openclaw@$OpenClawVersion"
-        return
-    }
-    if (Confirm-YesNo "Install OpenClaw $OpenClawVersion via npm?") {
-        & npm install -g "openclaw@$OpenClawVersion" --loglevel=error
-        if ($LASTEXITCODE -eq 0) { Write-Ok "OpenClaw installed" } else { Write-Warn2 "OpenClaw install failed" }
-    }
-}
-
 # ── Optional: quickstart ──────────────────────────────────────────────────────
 
 function Invoke-Quickstart {
@@ -466,7 +436,6 @@ function Write-Success {
     Write-Host "  ============================================================" -ForegroundColor Green
     Write-Host ""
     switch ($script:PickedConnector) {
-        "openclaw"   { Write-Host "  Get started:`n`n    defenseclaw init --connector openclaw --profile observe`n" -ForegroundColor Cyan }
         "codex"      { Write-Host "  Get started (Codex):`n`n    defenseclaw init --connector codex`n" -ForegroundColor Cyan }
         "claudecode" { Write-Host "  Get started (Claude Code):`n`n    defenseclaw init --connector claudecode`n" -ForegroundColor Cyan }
         { $_ -in @("hermes", "cursor", "windsurf", "geminicli", "copilot", "openhands", "antigravity", "opencode", "omnigent") } {
@@ -489,7 +458,7 @@ function Main {
     $script:ChecksumsFile = $null
     $script:ReleaseVersion = $null
 
-    # Validate -Connector and reconcile with -NoOpenclaw, mirroring install.sh.
+    # Validate -Connector and reconcile with -NoOpenclaw.
     if ($Connector) {
         if ($ConnectorChoices -notcontains $Connector) {
             Die "Invalid -Connector '$Connector'. Choices: $($ConnectorChoices -join ', ')"
@@ -499,8 +468,6 @@ function Main {
     if ($NoOpenclaw) {
         if (-not $script:PickedConnector) {
             $script:PickedConnector = "none"
-        } elseif ($script:PickedConnector -eq "openclaw") {
-            Die "-NoOpenclaw is incompatible with -Connector openclaw"
         }
     }
 
@@ -518,7 +485,6 @@ function Main {
     Install-Cli
 
     switch ($script:PickedConnector) {
-        "openclaw"   { Install-OpenClaw }
         { $_ -in @("codex", "claudecode", "hermes", "cursor", "windsurf", "geminicli", "copilot", "openhands", "antigravity", "opencode", "omnigent") } {
             Write-Info "Connector '$script:PickedConnector' wires up via the CLI (no OpenClaw runtime needed)."
         }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -90,6 +90,10 @@ $ConnectorChoices = @(
     "windsurf", "geminicli", "copilot", "openhands",
     "antigravity", "opencode", "omnigent", "none"
 )
+$HookConnectors = @(
+    "hermes", "cursor", "windsurf", "geminicli", "copilot",
+    "openhands", "antigravity", "opencode", "omnigent"
+)
 
 # ── Logging ───────────────────────────────────────────────────────────────────
 
@@ -438,7 +442,7 @@ function Write-Success {
     switch ($script:PickedConnector) {
         "codex"      { Write-Host "  Get started (Codex):`n`n    defenseclaw init --connector codex`n" -ForegroundColor Cyan }
         "claudecode" { Write-Host "  Get started (Claude Code):`n`n    defenseclaw init --connector claudecode`n" -ForegroundColor Cyan }
-        { $_ -in @("hermes", "cursor", "windsurf", "geminicli", "copilot", "openhands", "antigravity", "opencode", "omnigent") } {
+        { $_ -in $HookConnectors } {
             Write-Host "  Get started ($script:PickedConnector):`n`n    defenseclaw init --connector $script:PickedConnector`n" -ForegroundColor Cyan
         }
         default      { Write-Host "  Get started (pick a connector later):`n`n    defenseclaw init`n" -ForegroundColor Cyan }
@@ -484,8 +488,9 @@ function Main {
     Install-Gateway -Arch $arch
     Install-Cli
 
+    $cliWiredConnectors = @("codex", "claudecode") + $HookConnectors
     switch ($script:PickedConnector) {
-        { $_ -in @("codex", "claudecode", "hermes", "cursor", "windsurf", "geminicli", "copilot", "openhands", "antigravity", "opencode", "omnigent") } {
+        { $_ -in $cliWiredConnectors } {
             Write-Info "Connector '$script:PickedConnector' wires up via the CLI (no OpenClaw runtime needed)."
         }
         default      { Write-Info "Skipping connector setup - run 'defenseclaw init' when ready" }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -90,10 +90,7 @@ $ConnectorChoices = @(
     "windsurf", "geminicli", "copilot", "openhands",
     "antigravity", "opencode", "omnigent", "none"
 )
-$HookConnectors = @(
-    "hermes", "cursor", "windsurf", "geminicli", "copilot",
-    "openhands", "antigravity", "opencode", "omnigent"
-)
+$HookConnectors = $ConnectorChoices | Where-Object { $_ -notin @("codex", "claudecode", "none") }
 
 # ── Logging ───────────────────────────────────────────────────────────────────
 
@@ -372,6 +369,7 @@ function Select-Connector {
             "opencode"   { Write-Host "    $i) opencode   - configure OpenCode hooks" }
             "omnigent"   { Write-Host "    $i) omnigent   - configure OmniGent hooks" }
             "none"       { Write-Host "    $i) none       - install gateway/CLI only; pick later" }
+            default      { Write-Host "    $i) $v" }
         }
         $i++
     }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -83,9 +83,14 @@ $Venv = Join-Path $DefenseClawHome ".venv"
 $InstallDir = Join-Path $env:USERPROFILE ".local\bin"
 $OpenClawVersion = "2026.3.24"
 
-# Keep in sync with scripts/install.sh CONNECTOR_CHOICES and
-# internal/gateway/connector/registry.go DefaultRegistry.
-$ConnectorChoices = @("codex", "claudecode", "zeptoclaw", "openclaw", "none")
+# Keep in sync with cli/defenseclaw/connector_paths.py KNOWN_CONNECTORS.
+# PowerShell runs on Windows, where OpenClaw/ZeptoClaw proxy connectors are
+# intentionally hidden because the native Windows path is hook-only.
+$ConnectorChoices = @(
+    "codex", "claudecode", "hermes", "cursor",
+    "windsurf", "geminicli", "copilot", "openhands",
+    "antigravity", "opencode", "omnigent", "none"
+)
 
 # ── Logging ───────────────────────────────────────────────────────────────────
 
@@ -363,8 +368,15 @@ function Select-Connector {
         switch ($v) {
             "codex"      { Write-Host "    $i) codex      - patch %USERPROFILE%\.codex\config.toml + hooks" }
             "claudecode" { Write-Host "    $i) claudecode - patch %USERPROFILE%\.claude\settings.json hooks" }
-            "zeptoclaw"  { Write-Host "    $i) zeptoclaw  - patch %USERPROFILE%\.zeptoclaw\config.json" }
-            "openclaw"   { Write-Host "    $i) openclaw   - install OpenClaw runtime + DefenseClaw plugin" }
+            "hermes"     { Write-Host "    $i) hermes     - configure Hermes Agent hooks" }
+            "cursor"     { Write-Host "    $i) cursor     - configure Cursor hooks" }
+            "windsurf"   { Write-Host "    $i) windsurf   - configure Windsurf hooks" }
+            "geminicli"  { Write-Host "    $i) geminicli  - configure Gemini CLI hooks" }
+            "copilot"    { Write-Host "    $i) copilot    - configure GitHub Copilot CLI hooks" }
+            "openhands"  { Write-Host "    $i) openhands  - configure OpenHands hooks" }
+            "antigravity" { Write-Host "    $i) antigravity - configure Antigravity hooks" }
+            "opencode"   { Write-Host "    $i) opencode   - configure OpenCode hooks" }
+            "omnigent"   { Write-Host "    $i) omnigent   - configure OmniGent hooks" }
             "none"       { Write-Host "    $i) none       - install gateway/CLI only; pick later" }
         }
         $i++
@@ -457,7 +469,9 @@ function Write-Success {
         "openclaw"   { Write-Host "  Get started:`n`n    defenseclaw init --connector openclaw --profile observe`n" -ForegroundColor Cyan }
         "codex"      { Write-Host "  Get started (Codex):`n`n    defenseclaw init --connector codex`n" -ForegroundColor Cyan }
         "claudecode" { Write-Host "  Get started (Claude Code):`n`n    defenseclaw init --connector claudecode`n" -ForegroundColor Cyan }
-        "zeptoclaw"  { Write-Host "  Get started (ZeptoClaw):`n`n    defenseclaw init --connector zeptoclaw`n" -ForegroundColor Cyan }
+        { $_ -in @("hermes", "cursor", "windsurf", "geminicli", "copilot", "openhands", "antigravity", "opencode", "omnigent") } {
+            Write-Host "  Get started ($script:PickedConnector):`n`n    defenseclaw init --connector $script:PickedConnector`n" -ForegroundColor Cyan
+        }
         default      { Write-Host "  Get started (pick a connector later):`n`n    defenseclaw init`n" -ForegroundColor Cyan }
     }
 }
@@ -505,7 +519,9 @@ function Main {
 
     switch ($script:PickedConnector) {
         "openclaw"   { Install-OpenClaw }
-        { $_ -in @("codex", "claudecode", "zeptoclaw") } { Write-Info "Connector '$script:PickedConnector' wires up via the CLI (no OpenClaw runtime needed)." }
+        { $_ -in @("codex", "claudecode", "hermes", "cursor", "windsurf", "geminicli", "copilot", "openhands", "antigravity", "opencode", "omnigent") } {
+            Write-Info "Connector '$script:PickedConnector' wires up via the CLI (no OpenClaw runtime needed)."
+        }
         default      { Write-Info "Skipping connector setup - run 'defenseclaw init' when ready" }
     }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -149,6 +149,8 @@ connector_display_name() {
         zeptoclaw) echo "ZeptoClaw" ;;
         openclaw) echo "OpenClaw" ;;
         hermes) echo "Hermes Agent" ;;
+        cursor) echo "Cursor" ;;
+        windsurf) echo "Windsurf" ;;
         geminicli) echo "Gemini CLI" ;;
         copilot) echo "GitHub Copilot CLI" ;;
         openhands) echo "OpenHands" ;;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,7 +33,7 @@
 #   curl ... | bash -s -- --no-openclaw              # Skip OpenClaw entirely
 #
 # Options:
-#   --connector <name>  Pick agent connector (openclaw|codex|claudecode|zeptoclaw|none)
+#   --connector <name>  Pick agent connector (see --help for choices)
 #   --no-openclaw       Skip OpenClaw install (alias for --connector none when used alone)
 #   --local <dir>       Install from a local dist directory instead of downloading
 #   --yes, -y           Skip confirmation prompts (for CI/automation)
@@ -53,10 +53,10 @@ readonly INSTALL_DIR="${HOME}/.local/bin"
 readonly REPO="cisco-ai-defense/defenseclaw"
 readonly OPENCLAW_VERSION="2026.3.24"
 
-# Supported connectors. Keep in sync with internal/gateway/connector/registry.go
-# DefaultRegistry. The "none" pseudo-value means "lay binaries only — pick a
-# connector later with `defenseclaw init --connector ...`".
-readonly CONNECTOR_CHOICES=(codex claudecode zeptoclaw openclaw none)
+# Supported connectors. Keep in sync with cli/defenseclaw/connector_paths.py
+# KNOWN_CONNECTORS. The "none" pseudo-value means "lay binaries only — pick
+# a connector later with `defenseclaw init --connector ...`".
+readonly CONNECTOR_CHOICES=(codex claudecode zeptoclaw openclaw hermes cursor windsurf geminicli copilot openhands antigravity opencode omnigent none)
 
 # ── Terminal Formatting ───────────────────────────────────────────────────────
 
@@ -161,6 +161,15 @@ pick_connector_interactive() {
             claudecode) printf "    ${BOLD}%d)${NC} claudecode — patch ~/.claude/settings.json hooks (no OpenClaw)\n" "$i" ;;
             zeptoclaw)  printf "    ${BOLD}%d)${NC} zeptoclaw  — patch ~/.zeptoclaw/config.json (no OpenClaw)\n" "$i" ;;
             openclaw)   printf "    ${BOLD}%d)${NC} openclaw   — install OpenClaw runtime + DefenseClaw plugin\n" "$i" ;;
+            hermes)     printf "    ${BOLD}%d)${NC} hermes     — configure Hermes Agent hooks\n" "$i" ;;
+            cursor)     printf "    ${BOLD}%d)${NC} cursor     — configure Cursor hooks\n" "$i" ;;
+            windsurf)   printf "    ${BOLD}%d)${NC} windsurf   — configure Windsurf hooks\n" "$i" ;;
+            geminicli)  printf "    ${BOLD}%d)${NC} geminicli  — configure Gemini CLI hooks\n" "$i" ;;
+            copilot)    printf "    ${BOLD}%d)${NC} copilot    — configure GitHub Copilot CLI hooks\n" "$i" ;;
+            openhands)  printf "    ${BOLD}%d)${NC} openhands  — configure OpenHands hooks\n" "$i" ;;
+            antigravity) printf "    ${BOLD}%d)${NC} antigravity — configure Antigravity hooks\n" "$i" ;;
+            opencode)   printf "    ${BOLD}%d)${NC} opencode   — configure OpenCode hooks\n" "$i" ;;
+            omnigent)   printf "    ${BOLD}%d)${NC} omnigent   — configure OmniGent hooks\n" "$i" ;;
             none)       printf "    ${BOLD}%d)${NC} none       — install gateway/CLI only; pick later\n" "$i" ;;
         esac
         i=$((i + 1))
@@ -661,6 +670,10 @@ print_success() {
             printf "  Get started (ZeptoClaw):\n\n"
             printf "    ${CYAN}defenseclaw init --connector zeptoclaw${NC}\n"
             ;;
+        hermes|cursor|windsurf|geminicli|copilot|openhands|antigravity|opencode|omnigent)
+            printf "  Get started (%s):\n\n" "${CONNECTOR}"
+            printf "    ${CYAN}defenseclaw init --connector %s${NC}\n" "${CONNECTOR}"
+            ;;
         none|"")
             printf "  Get started (pick a connector later):\n\n"
             printf "    ${CYAN}defenseclaw init${NC}\n"
@@ -696,7 +709,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         --yes|-y) YES_MODE=true; shift ;;
         --connector)
-            [[ $# -lt 2 ]] && die "--connector requires a value (openclaw|codex|claudecode|zeptoclaw|none)"
+            [[ $# -lt 2 ]] && die "--connector requires a value (${CONNECTOR_CHOICES[*]})"
             CONNECTOR="$2"
             is_valid_connector "${CONNECTOR}" \
                 || die "Invalid --connector '${CONNECTOR}'. Choices: ${CONNECTOR_CHOICES[*]}"
@@ -728,7 +741,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --sandbox             Also install openshell-sandbox (experimental Linux/OpenClaw path)"
             echo "  --local <dir>         Install from a local dist directory"
             echo "  --yes, -y             Skip all confirmation prompts"
-            echo "  --connector <name>    Pick agent connector (openclaw|codex|claudecode|zeptoclaw|none)"
+            echo "  --connector <name>    Pick agent connector (${CONNECTOR_CHOICES[*]})"
             echo "  --no-openclaw         Skip OpenClaw runtime+plugin install (alias for --connector none)"
             echo "  --quickstart          Run 'defenseclaw quickstart --non-interactive' post-install"
             echo "  --quickstart-mode M   Pass --mode M to quickstart (observe|action; implies --quickstart)"
@@ -774,16 +787,15 @@ install_gateway
 install_python_cli
 
 # Only install the OpenClaw plugin and the OpenClaw runtime when the user
-# actually picked OpenClaw. Other connectors (Codex / Claude Code /
-# ZeptoClaw) integrate via config-file patching and need neither npm nor
-# the plugin tarball. For "none" we skip everything connector-specific
-# and let the user run `defenseclaw init` later.
+# actually picked OpenClaw. Other connectors integrate via CLI setup and need
+# neither npm nor the plugin tarball. For "none" we skip connector-specific
+# work and let the user run `defenseclaw init` later.
 case "${CONNECTOR}" in
     openclaw)
         install_plugin
         handle_openclaw
         ;;
-    codex|claudecode|zeptoclaw)
+    codex|claudecode|zeptoclaw|hermes|cursor|windsurf|geminicli|copilot|openhands|antigravity|opencode|omnigent)
         info "Skipping OpenClaw plugin/runtime install (connector: ${CONNECTOR})"
         ;;
     none|"")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -136,6 +136,40 @@ is_valid_connector() {
     return 1
 }
 
+is_hook_connector() {
+    local n="$1"
+    is_valid_connector "$n" || return 1
+    [[ "$n" != "openclaw" && "$n" != "none" ]]
+}
+
+connector_display_name() {
+    case "$1" in
+        codex) echo "Codex" ;;
+        claudecode) echo "Claude Code" ;;
+        zeptoclaw) echo "ZeptoClaw" ;;
+        openclaw) echo "OpenClaw" ;;
+        hermes) echo "Hermes Agent" ;;
+        geminicli) echo "Gemini CLI" ;;
+        copilot) echo "GitHub Copilot CLI" ;;
+        openhands) echo "OpenHands" ;;
+        antigravity) echo "Antigravity" ;;
+        opencode) echo "OpenCode" ;;
+        omnigent) echo "OmniGent" ;;
+        *) echo "$1" ;;
+    esac
+}
+
+connector_menu_hint() {
+    case "$1" in
+        codex) echo "patch ~/.codex/config.toml + hooks (no OpenClaw)" ;;
+        claudecode) echo "patch ~/.claude/settings.json hooks (no OpenClaw)" ;;
+        zeptoclaw) echo "patch ~/.zeptoclaw/config.json (no OpenClaw)" ;;
+        openclaw) echo "install OpenClaw runtime + DefenseClaw plugin" ;;
+        none) echo "install gateway/CLI only; pick later" ;;
+        *) printf "configure %s hooks\n" "$(connector_display_name "$1")" ;;
+    esac
+}
+
 # pick_connector_interactive — prompt the user to pick a connector when
 # none was passed on the command line and we are not in --yes mode.
 # Sets global CONNECTOR. Non-interactive installs intentionally choose
@@ -156,22 +190,7 @@ pick_connector_interactive() {
     echo ""
     local i=1
     for v in "${CONNECTOR_CHOICES[@]}"; do
-        case "$v" in
-            codex)      printf "    ${BOLD}%d)${NC} codex      — patch ~/.codex/config.toml + hooks (no OpenClaw)\n" "$i" ;;
-            claudecode) printf "    ${BOLD}%d)${NC} claudecode — patch ~/.claude/settings.json hooks (no OpenClaw)\n" "$i" ;;
-            zeptoclaw)  printf "    ${BOLD}%d)${NC} zeptoclaw  — patch ~/.zeptoclaw/config.json (no OpenClaw)\n" "$i" ;;
-            openclaw)   printf "    ${BOLD}%d)${NC} openclaw   — install OpenClaw runtime + DefenseClaw plugin\n" "$i" ;;
-            hermes)     printf "    ${BOLD}%d)${NC} hermes     — configure Hermes Agent hooks\n" "$i" ;;
-            cursor)     printf "    ${BOLD}%d)${NC} cursor     — configure Cursor hooks\n" "$i" ;;
-            windsurf)   printf "    ${BOLD}%d)${NC} windsurf   — configure Windsurf hooks\n" "$i" ;;
-            geminicli)  printf "    ${BOLD}%d)${NC} geminicli  — configure Gemini CLI hooks\n" "$i" ;;
-            copilot)    printf "    ${BOLD}%d)${NC} copilot    — configure GitHub Copilot CLI hooks\n" "$i" ;;
-            openhands)  printf "    ${BOLD}%d)${NC} openhands  — configure OpenHands hooks\n" "$i" ;;
-            antigravity) printf "    ${BOLD}%d)${NC} antigravity — configure Antigravity hooks\n" "$i" ;;
-            opencode)   printf "    ${BOLD}%d)${NC} opencode   — configure OpenCode hooks\n" "$i" ;;
-            omnigent)   printf "    ${BOLD}%d)${NC} omnigent   — configure OmniGent hooks\n" "$i" ;;
-            none)       printf "    ${BOLD}%d)${NC} none       — install gateway/CLI only; pick later\n" "$i" ;;
-        esac
+        printf "    ${BOLD}%d)${NC} %-11s — %s\n" "$i" "$v" "$(connector_menu_hint "$v")"
         i=$((i + 1))
     done
     echo ""
@@ -644,41 +663,22 @@ print_success() {
     printf "${BOLD}${GREEN}╚══════════════════════════════════════════════════════════╝${NC}\n"
     echo ""
 
-    # Connector-specific next-step guidance. The picked connector
-    # determines which `defenseclaw` command to run next; surfacing
-    # this here means the operator does not have to read docs after
-    # `curl | bash` to find the right verb.
-    case "${CONNECTOR}" in
-        openclaw)
-            if [[ "${INSTALL_SANDBOX}" == true ]] && [[ "${OS}" == "linux" ]]; then
-                printf "  Get started:\n\n"
-                printf "    ${CYAN}defenseclaw init --connector openclaw --sandbox${NC}\n"
-            else
-                printf "  Get started:\n\n"
-                printf "    ${CYAN}defenseclaw init --connector openclaw --profile observe${NC}\n"
-            fi
-            ;;
-        codex)
-            printf "  Get started (Codex):\n\n"
-            printf "    ${CYAN}defenseclaw init --connector codex${NC}\n"
-            ;;
-        claudecode)
-            printf "  Get started (Claude Code):\n\n"
-            printf "    ${CYAN}defenseclaw init --connector claudecode${NC}\n"
-            ;;
-        zeptoclaw)
-            printf "  Get started (ZeptoClaw):\n\n"
-            printf "    ${CYAN}defenseclaw init --connector zeptoclaw${NC}\n"
-            ;;
-        hermes|cursor|windsurf|geminicli|copilot|openhands|antigravity|opencode|omnigent)
-            printf "  Get started (%s):\n\n" "${CONNECTOR}"
-            printf "    ${CYAN}defenseclaw init --connector %s${NC}\n" "${CONNECTOR}"
-            ;;
-        none|"")
-            printf "  Get started (pick a connector later):\n\n"
-            printf "    ${CYAN}defenseclaw init${NC}\n"
-            ;;
-    esac
+    # Connector-specific next-step guidance. The picked connector determines
+    # which `defenseclaw` command to run next.
+    if [[ "${CONNECTOR}" == "openclaw" ]]; then
+        printf "  Get started:\n\n"
+        if [[ "${INSTALL_SANDBOX}" == true ]] && [[ "${OS}" == "linux" ]]; then
+            printf "    ${CYAN}defenseclaw init --connector openclaw --sandbox${NC}\n"
+        else
+            printf "    ${CYAN}defenseclaw init --connector openclaw --profile observe${NC}\n"
+        fi
+    elif is_hook_connector "${CONNECTOR}"; then
+        printf "  Get started (%s):\n\n" "$(connector_display_name "${CONNECTOR}")"
+        printf "    ${CYAN}defenseclaw init --connector %s${NC}\n" "${CONNECTOR}"
+    else
+        printf "  Get started (pick a connector later):\n\n"
+        printf "    ${CYAN}defenseclaw init${NC}\n"
+    fi
     if [[ "${INSTALL_SANDBOX}" == true && "${CONNECTOR}" != "openclaw" ]]; then
         warn "Sandbox setup is experimental and currently applies to the OpenClaw/OpenShell path only."
     fi
@@ -786,22 +786,17 @@ pick_connector_interactive
 install_gateway
 install_python_cli
 
-# Only install the OpenClaw plugin and the OpenClaw runtime when the user
-# actually picked OpenClaw. Other connectors integrate via CLI setup and need
-# neither npm nor the plugin tarball. For "none" we skip connector-specific
-# work and let the user run `defenseclaw init` later.
-case "${CONNECTOR}" in
-    openclaw)
-        install_plugin
-        handle_openclaw
-        ;;
-    codex|claudecode|zeptoclaw|hermes|cursor|windsurf|geminicli|copilot|openhands|antigravity|opencode|omnigent)
-        info "Skipping OpenClaw plugin/runtime install (connector: ${CONNECTOR})"
-        ;;
-    none|"")
-        info "Skipping connector setup — run 'defenseclaw init' when ready"
-        ;;
-esac
+# Only install the OpenClaw plugin and runtime when the user actually picked
+# OpenClaw. Other connectors integrate via CLI setup and need neither npm nor
+# the plugin tarball.
+if [[ "${CONNECTOR}" == "openclaw" ]]; then
+    install_plugin
+    handle_openclaw
+elif is_hook_connector "${CONNECTOR}"; then
+    info "Skipping OpenClaw plugin/runtime install (connector: ${CONNECTOR})"
+else
+    info "Skipping connector setup — run 'defenseclaw init' when ready"
+fi
 
 record_picked_connector
 


### PR DESCRIPTION
## Summary
- update the shell installer connector menu to include the current connector set
- keep the Windows installer on hook-supported choices only
- add a static test that keeps release installer choices aligned with the first-run connector list and Windows filtering

## Validation
- uv run pytest cli/tests/test_install_script_static.py cli/tests/test_platform_support.py cli/tests/tui/test_first_run_panel.py
- bash -n scripts/install.sh
- bash scripts/install.sh --help
- bash scripts/install.sh --connector omnigent --help
- git diff --check

Note: pwsh is not installed on this machine, so PowerShell behavior was covered by static parsing and source inspection.