### PR TITLE
fix(macos): run userspace prep as target user

### DIFF
--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -55,6 +55,12 @@ die()  { printf '[install] ERROR: %s\n' "$*" >&2; exit 1; }
 # shellcheck source=lib/installer_lib.sh
 . "${SCRIPT_DIR}/lib/installer_lib.sh"
 
+prepare_userspace_for_target() {
+  local connector="$1"
+  sudo -H -u "${TARGET_USER}" env HOME="${TARGET_HOME}" \
+    /bin/bash "${SCRIPT_DIR}/lib/installer_lib.sh" prepare-userspace "${connector}" "${TARGET_HOME}"
+}
+
 usage() {
   cat <<EOF
 Usage: sudo $0 [options]
@@ -260,7 +266,7 @@ if [[ "${SKIP_CONNECTOR}" != "true" ]]; then
     fi
 
     log "  [${c}] preparing userspace"
-    if ! prepare_userspace_for "${c}" "${TARGET_HOME}"; then
+    if ! prepare_userspace_for_target "${c}"; then
       warn "  [${c}] refused to prepare userspace (symlinked or non-dir path); skipping"
       continue
     fi

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -213,6 +213,19 @@ prepare_userspace_for() {
   esac
 }
 
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  case "${1:-}" in
+    prepare-userspace)
+      shift
+      prepare_userspace_for "$@"
+      ;;
+    *)
+      echo "usage: $0 prepare-userspace CONNECTOR HOME" >&2
+      exit 64
+      ;;
+  esac
+fi
+
 # ---- config rendering --------------------------------------------------
 
 # render_config MODE PRIMARY API_PORT DISABLE_REDACTION SUPPORT_DIR CONN... -> stdout

--- a/packaging/macos/tests/test_prepare_userspace.sh
+++ b/packaging/macos/tests/test_prepare_userspace.sh
@@ -47,6 +47,13 @@ t_dispatch_via_helper() {
   assert_file_exists "${home}/.claude/settings.json"
 }
 
+t_dispatch_via_lib_subcommand() {
+  local home; home="$(mktest_tmp)"
+  /bin/bash "${PKG_DIR}/lib/installer_lib.sh" prepare-userspace cursor "${home}"
+  assert_file_exists "${home}/.cursor/hooks.json"
+  assert_file_mode "${home}/.cursor/hooks.json" "600"
+}
+
 # Symlink-rejection matrix: for each connector, we exercise both
 # the directory-symlink and file-symlink attack surfaces, and after
 # rejection we verify the symlink target was never written to.
@@ -99,6 +106,7 @@ run_case "codex userspace pre-create + idempotent" t_codex_creates
 run_case "claudecode userspace pre-create"         t_claudecode_creates
 run_case "cursor userspace pre-create"             t_cursor_creates
 run_case "prepare_userspace_for dispatch"          t_dispatch_via_helper
+run_case "installer_lib prepare-userspace dispatch" t_dispatch_via_lib_subcommand
 run_case "codex rejects symlinked .codex dir"      t_codex_rejects_symlink_dir
 run_case "codex rejects symlinked config.toml"     t_codex_rejects_symlink_file
 run_case "claudecode rejects symlinked .claude dir" t_claudecode_rejects_symlink_dir


### PR DESCRIPTION
## Problem

PR #410 hardened pre-existing symlinked macOS userspace hook config paths, but the real installer still called `prepare_userspace_for` from the root shell. The helper checks for symlinks before writing, then opens `~/.codex/config.toml`, `~/.claude/settings.json`, or `~/.cursor/hooks.json` with ordinary shell redirection. A target user could race the config path after the check and before the root-owned open, causing a root write through a user-controlled symlink.

Related finding/comment: https://github.com/cisco-ai-defense/defenseclaw/pull/410#issuecomment-4873658536

## Current Situation

`install.sh` runs as root under `sudo`, and the userspace prep files are intended to be target-user-owned placeholders only. The secure invariant is that root should not open target-user-controlled config paths for writing.

## Solution

Run the userspace prep helper through `sudo -u <target-user>` with `HOME` pinned to the target home. Add a small `installer_lib.sh prepare-userspace` subcommand so the installer does not need inline shell evaluation and the test suite can exercise the same dispatch path.

## What Changed (Where & How)

| Path | Change |
| --- | --- |
| `packaging/macos/install.sh` | Calls `prepare_userspace_for_target`, which invokes the library helper as the target user. |
| `packaging/macos/lib/installer_lib.sh` | Adds a minimal `prepare-userspace` subcommand for non-sourced execution. |
| `packaging/macos/tests/test_prepare_userspace.sh` | Adds coverage for the library subcommand dispatch used by the installer. |

## Breaking Changes

None intended. The placeholder files are still created with the same content and modes; they are now created directly by the target user instead of root followed by `chown`.

## Open Issues / Follow-ups

None.

## Test Plan

```bash
packaging/macos/tests/run_tests.sh packaging/macos/tests/test_prepare_userspace.sh
bash -n packaging/macos/install.sh packaging/macos/lib/installer_lib.sh packaging/macos/uninstall.sh
git diff --check
make packaging-macos-test
```

Observed results:

- `packaging/macos/tests/run_tests.sh packaging/macos/tests/test_prepare_userspace.sh`: 11 passed, 0 failed.
- `bash -n packaging/macos/install.sh packaging/macos/lib/installer_lib.sh packaging/macos/uninstall.sh`: passed.
- `git diff --check`: passed.
- `make packaging-macos-test`: failed in unrelated existing host-dependent case `test_discover_agent_version.sh :: codex without install` because this runner has Codex installed and discovery returned `0.136.0` where the test expects empty output.

## CI Status

Pending GitHub Actions for this PR.
