### PR TITLE
fix(macos): propagate userspace prep dispatch failures

### DIFF
--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -218,6 +218,7 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     prepare-userspace)
       shift
       prepare_userspace_for "$@"
+      exit $?
       ;;
     *)
       echo "usage: $0 prepare-userspace CONNECTOR HOME" >&2

--- a/packaging/macos/tests/test_prepare_userspace.sh
+++ b/packaging/macos/tests/test_prepare_userspace.sh
@@ -54,6 +54,19 @@ t_dispatch_via_lib_subcommand() {
   assert_file_mode "${home}/.cursor/hooks.json" "600"
 }
 
+t_dispatch_via_lib_subcommand_rejects_symlink() {
+  local home target status
+  home="$(mktest_tmp)"
+  target="$(mktest_tmp)"
+  ln -s "${target}" "${home}/.cursor"
+  /bin/bash "${PKG_DIR}/lib/installer_lib.sh" prepare-userspace cursor "${home}"
+  status=$?
+  assert_status "${status}" 1 "installer_lib prepare-userspace rejects symlinked .cursor"
+  if [[ -e "${target}/hooks.json" ]]; then
+    _fail "symlink target ${target}/hooks.json was written through"
+  fi
+}
+
 # Symlink-rejection matrix: for each connector, we exercise both
 # the directory-symlink and file-symlink attack surfaces, and after
 # rejection we verify the symlink target was never written to.
@@ -107,6 +120,7 @@ run_case "claudecode userspace pre-create"         t_claudecode_creates
 run_case "cursor userspace pre-create"             t_cursor_creates
 run_case "prepare_userspace_for dispatch"          t_dispatch_via_helper
 run_case "installer_lib prepare-userspace dispatch" t_dispatch_via_lib_subcommand
+run_case "installer_lib prepare-userspace rejects symlink" t_dispatch_via_lib_subcommand_rejects_symlink
 run_case "codex rejects symlinked .codex dir"      t_codex_rejects_symlink_dir
 run_case "codex rejects symlinked config.toml"     t_codex_rejects_symlink_file
 run_case "claudecode rejects symlinked .claude dir" t_claudecode_rejects_symlink_dir


### PR DESCRIPTION
* @cisco-ai-defense/defenseclaw-reviewers

## Problem

PR #435 moves macOS userspace prep into a target-user subprocess, but the new `installer_lib.sh prepare-userspace ...` executable entrypoint returns success even when `prepare_userspace_for` rejects an unsafe path.

## Current Situation

When a target user has a symlinked connector config directory, the direct helper returns failure, but invoking the library as a script masks that status because execution continues through later function declarations. The root installer depends on this subprocess status to skip unsafe userspace wiring.

## Solution

Exit immediately with the status from `prepare_userspace_for` in the `prepare-userspace` dispatch path, and add regression coverage for symlink rejection through the executable entrypoint.

## Architecture Diagram

N/A

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `packaging/macos/lib/installer_lib.sh` | Propagates the userspace prep status from the script entrypoint. |
| `packaging/macos/tests/test_prepare_userspace.sh` | Covers symlink rejection through `/bin/bash installer_lib.sh prepare-userspace ...`. |

## Breaking Changes

None

## Open Issues / Follow-ups

None

## Test Plan

- `packaging/macos/tests/run_tests.sh packaging/macos/tests/test_prepare_userspace.sh` -> `12 passed, 0 failed in 1s`
- `packaging/macos/tests/run_tests.sh` -> `69 passed, 1 failed in 11s`; failure is pre-existing host-dependent `test_discover_agent_version.sh :: codex without install`, which observes the local Codex metadata version `0.136.0` instead of an empty result.

Related security review finding: #435 executable userspace-prep dispatch masked rejection status.
