### PR TITLE
Reconcile connector-scoped fail-mode runtime

### DIFF
--- a/cli/defenseclaw/commands/cmd_guardrail.py
+++ b/cli/defenseclaw/commands/cmd_guardrail.py
@@ -53,6 +53,13 @@ from defenseclaw import ux
 from defenseclaw.config import _assert_config_write_allowed, config_path_for_data_dir
 from defenseclaw.connector_contracts import normalize_connector
 from defenseclaw.context import AppContext, pass_ctx
+from defenseclaw.fail_mode import (
+    fail_mode_transaction_lock,
+    reconcile_connector_registration,
+    resolve_connector_fail_mode,
+    restore_fail_mode_transaction,
+    snapshot_fail_mode_transaction,
+)
 
 # Note: ``defenseclaw.commands.cmd_setup._restart_services`` is
 # intentionally NOT imported at module load. Importing cmd_setup
@@ -80,6 +87,8 @@ _CONNECTOR_LABELS = {
     "opencode": "OpenCode",
     "omnigent": "OmniGent",
 }
+
+_RUNTIME_FAIL_MODE_CONNECTORS = frozenset({"claudecode", "codex"})
 
 
 def _preflight_config_write(app: AppContext) -> None:
@@ -582,13 +591,21 @@ def status_cmd(app: AppContext, connector_flag: str | None) -> None:
         actives = scoped
 
     rows: list[dict[str, tuple[str, str]]] = []
+    runtime_drift_rows: list[str] = []
     for name in actives:
         cmode = gc.effective_mode(name) if hasattr(gc, "effective_mode") else (gc.mode or "observe")
-        cfm = (
-            gc.effective_hook_fail_mode(name)
-            if hasattr(gc, "effective_hook_fail_mode")
-            else fail_mode
-        )
+        configured_cfm = gc.effective_hook_fail_mode(name) if hasattr(gc, "effective_hook_fail_mode") else fail_mode
+        cfm = configured_cfm
+        fail_drift = ""
+        if normalize_connector(name) in _RUNTIME_FAIL_MODE_CONNECTORS:
+            runtime_state = resolve_connector_fail_mode(app.cfg, name)
+            if runtime_state.runtime is not None:
+                cfm = runtime_state.runtime
+            else:
+                cfm = "unknown"
+            if runtime_state.drift:
+                fail_drift = f" (desired {runtime_state.desired}; drift: " + ", ".join(runtime_state.drift) + ")"
+                runtime_drift_rows.append(f"{_connector_label(name)} ({name}){fail_drift}")
         # Per-connector on/off: a connector turned off via
         # `guardrail disable --connector X` is reported as disabled so the
         # roster never implies it is enforcing when its hooks have been torn
@@ -612,6 +629,7 @@ def status_cmd(app: AppContext, connector_flag: str | None) -> None:
         else:
             state_raw = "disabled"
             state = ux._style(state_raw, fg="yellow")
+        fail_raw = cfm
         cfm_display = _style_fail_mode(cfm)
         # Each connector can scan against its OWN rule pack (per-connector
         # override, else the global pack); surface it so the roster shows which
@@ -642,7 +660,7 @@ def status_cmd(app: AppContext, connector_flag: str | None) -> None:
                 "key": (name, ux.dim(name)),
                 "state": (state_raw, state),
                 "mode": (cmode or "observe", _style_mode(cmode or "observe")),
-                "fail": (cfm, cfm_display),
+                "fail": (fail_raw, cfm_display),
                 "rule_pack": (rule_pack_raw, rule_pack),
                 "hilt": (hilt_raw, hilt_str),
                 "scan": (scan_raw, _style_scan_value(scan_raw)),
@@ -650,9 +668,9 @@ def status_cmd(app: AppContext, connector_flag: str | None) -> None:
             }
         )
     _render_connector_table(rows)
-    click.echo(
-        f"  • {ux.dim('fail = hook response-layer failures (4xx / bad JSON / missing action)')}"
-    )
+    for drift_row in runtime_drift_rows:
+        ux.warn("runtime fail-mode drift: " + drift_row, indent="  ")
+    click.echo(f"  • {ux.dim('fail = invalid, unauthorized, incomplete, or unreachable gateway responses')}")
 
     click.echo(f"  • {ux._style('port:', fg='bright_black', bold=True)}       {gc.port}")
     click.echo()
@@ -887,9 +905,82 @@ def enable_cmd(
         )
 
 
-def _set_connector_fail_mode(
-    app: AppContext, requested: str, mode: str | None, *, restart: bool, yes: bool
+def _apply_scoped_fail_mode_transaction(
+    app: AppContext,
+    *,
+    key: str,
+    mode: str,
+    restart: bool,
+    label: str,
+    entry: object | None,
+    stored_mode: str,
 ) -> None:
+    """Persist and refresh one connector under the transaction-wide lock."""
+
+    from defenseclaw.config import PerConnectorGuardrailConfig
+
+    gc = app.cfg.guardrail
+    conns = gc.connectors
+    with fail_mode_transaction_lock(app.cfg):
+        try:
+            snapshots = snapshot_fail_mode_transaction(app.cfg, [key])
+        except OSError as exc:
+            ux.err(f"Could not snapshot fail-mode transaction: {exc}", indent="  ")
+            raise click.Abort() from exc
+
+        old_entry = entry
+        old_mode = stored_mode
+        if entry is None:
+            entry = PerConnectorGuardrailConfig()
+            conns[key] = entry
+        entry.hook_fail_mode = mode
+        try:
+            app.cfg.save()
+            ux.ok(
+                f"Config saved (guardrail.connectors.{key}.hook_fail_mode = {mode})",
+                indent="  ",
+            )
+        except OSError as exc:
+            if old_entry is None:
+                conns.pop(key, None)
+            else:
+                old_entry.hook_fail_mode = old_mode
+            restore_fail_mode_transaction(snapshots)
+            ux.err(f"Failed to save config: {exc}", indent="  ")
+            raise click.Abort() from exc
+
+        if restart and gc.enabled:
+            try:
+                reconcile_connector_registration(app.cfg, key)
+            except (OSError, RuntimeError) as exc:
+                if old_entry is None:
+                    conns.pop(key, None)
+                else:
+                    old_entry.hook_fail_mode = old_mode
+                try:
+                    restore_fail_mode_transaction(snapshots)
+                except OSError as rollback_exc:
+                    ux.err(f"Fail-mode update failed and rollback was incomplete: {rollback_exc}", indent="  ")
+                    raise click.Abort() from rollback_exc
+                ux.err(f"Fail-mode update failed; previous config and registration restored: {exc}", indent="  ")
+                raise click.Abort() from exc
+            ux.ok(f"{label} runtime registration refreshed and verified with fail={mode}.", indent="  ")
+            click.echo()
+        elif not restart:
+            ux.warn(
+                "--no-restart saved the desired value, but runtime registration was not refreshed; "
+                "status will report drift until reconciliation succeeds.",
+                indent="  ",
+            )
+        elif not gc.enabled:
+            ux.warn(
+                "guardrail is currently disabled — value will take effect "
+                "the next time you run 'defenseclaw guardrail enable'.",
+                indent="  ",
+            )
+
+
+def _set_connector_fail_mode(app: AppContext, requested: str, mode: str | None, *, restart: bool, yes: bool) -> None:
     """Show or set the hook fail mode for a SINGLE connector.
 
     Per-connector analog of the global ``guardrail fail-mode``: writes
@@ -933,47 +1024,48 @@ def _set_connector_fail_mode(
     stored_mode = str(getattr(entry, "hook_fail_mode", "") or "").strip().lower()
     has_override = stored_mode in ("open", "closed")
     configured_mode = stored_mode if has_override else global_fm
+    runtime_state = resolve_connector_fail_mode(app.cfg, key)
 
     # No mode argument → just report this connector's effective value and
     # whether it is an override or inherited from the global default.
     if mode is None:
         click.echo()
-        click.echo(
-            f"  {ux.bold(f'{label} ({key}) hook_fail_mode:')} {ux.accent(current)}"
-        )
+        runtime_value = runtime_state.runtime or "unknown"
+        click.echo(f"  {ux.bold(f'{label} ({key}) hook_fail_mode:')} {ux.accent(runtime_value)}")
         if has_override:
-            ux.subhead(
-                f"per-connector override (global default: {global_fm}).", indent="  "
-            )
+            ux.subhead(f"per-connector override (global default: {global_fm}).", indent="  ")
         else:
-            ux.subhead(
-                f"inherited from global default ({global_fm}).", indent="  "
+            ux.subhead(f"inherited from global default ({global_fm}).", indent="  ")
+        if runtime_state.drift:
+            ux.warn(
+                f"Runtime drift (desired {runtime_state.desired}): " + ", ".join(runtime_state.drift),
+                indent="  ",
             )
         click.echo()
         return
 
-    if mode == configured_mode:
-        click.echo(
-            f"  {ux.dim(f'{label} hook fail mode is already')} {mode!r} "
-            f"{ux.dim('— nothing to do.')}"
-        )
+    if mode == configured_mode and runtime_state.desired == mode and runtime_state.current:
+        click.echo(f"  {ux.dim(f'{label} hook fail mode is already')} {mode!r} {ux.dim('— nothing to do.')}")
         return
 
     click.echo()
-    click.echo(
-        f"  {ux.bold(f'Changing {label} hook fail mode:')} {configured_mode} "
-        f"{ux.dim('→')} {ux.accent(mode)}"
-    )
+    if mode == configured_mode:
+        click.echo(f"  {ux.bold(f'Reconciling {label} hook runtime:')} {ux.accent(mode)}")
+        ux.warn("Persisted policy matches, but installed runtime state is stale or inconsistent.", indent="  ")
+    else:
+        click.echo(
+            f"  {ux.bold(f'Changing {label} hook fail mode:')} {configured_mode} {ux.dim('→')} {ux.accent(mode)}"
+        )
     if mode == "closed":
-        ux.warn(f"Response-layer failures will now BLOCK {label}.", indent="  ")
+        ux.warn(f"Invalid or unavailable gateway responses will now BLOCK {label}.", indent="  ")
         ux.subhead(
-            "A misconfigured gateway response (4xx, bad JSON) will exit 2 from this "
+            "A 4xx, malformed/incomplete response, timeout, or connection failure will exit 2 from this "
             "connector's hooks. Make sure your gateway is healthy first.",
             indent="    ",
         )
     else:
         ux.subhead(
-            f"Response-layer failures will now ALLOW {label} and log the failure to "
+            f"Invalid or unavailable gateway responses will now ALLOW {label} and log the failure to "
             "~/.defenseclaw/logs/hook-failures.jsonl.",
             indent="  ",
         )
@@ -983,42 +1075,15 @@ def _set_connector_fail_mode(
         click.echo(f"  {ux.dim('Cancelled.')}")
         raise click.Abort()
 
-    # Mutate the per-connector entry, preserving its other policy fields.
-    from defenseclaw.config import PerConnectorGuardrailConfig
-
-    if entry is None:
-        entry = PerConnectorGuardrailConfig()
-        conns[key] = entry
-    entry.hook_fail_mode = mode
-    try:
-        app.cfg.save()
-        ux.ok(
-            f"Config saved (guardrail.connectors.{key}.hook_fail_mode = {mode})",
-            indent="  ",
-        )
-    except OSError as exc:
-        ux.err(f"Failed to save config: {exc}", indent="  ")
-        raise click.Abort()
-
-    if restart and gc.enabled:
-        from defenseclaw.commands import cmd_setup
-
-        cmd_setup._restart_services(
-            app.cfg.data_dir,
-            app.cfg.gateway.host,
-            app.cfg.gateway.port,
-            connector=key,
-        )
-        ux.ok(
-            f"Gateway restarted, {label} hook regenerated with fail={mode}.", indent="  "
-        )
-        click.echo()
-    elif not gc.enabled:
-        ux.warn(
-            "guardrail is currently disabled — value will take effect "
-            "the next time you run 'defenseclaw guardrail enable'.",
-            indent="  ",
-        )
+    _apply_scoped_fail_mode_transaction(
+        app,
+        key=key,
+        mode=mode,
+        restart=restart,
+        label=label,
+        entry=entry,
+        stored_mode=stored_mode,
+    )
 
     if app.logger:
         app.logger.log_action(
@@ -1033,11 +1098,137 @@ def _multi_connector_fail_mode_targets(app: AppContext) -> list[str]:
     conns = getattr(app.cfg.guardrail, "connectors", {}) or {}
     if not conns:
         return []
-    return [
-        name
-        for name in _active_connector_set(app.cfg, _resolve_active_connector(app.cfg))
-        if name in conns
-    ]
+    return [name for name in _active_connector_set(app.cfg, _resolve_active_connector(app.cfg)) if name in conns]
+
+
+def _apply_global_fail_mode_transaction(
+    app: AppContext,
+    *,
+    mode: str,
+    restart: bool,
+    fail_mode_targets: list[str],
+    single_connector: str,
+    single_runtime: bool,
+) -> None:
+    """Persist global/fan-out fail mode and atomically refresh registrations."""
+
+    gc = app.cfg.guardrail
+    transaction_targets = fail_mode_targets or ([single_connector] if single_runtime else [])
+    with fail_mode_transaction_lock(app.cfg):
+        try:
+            snapshots = snapshot_fail_mode_transaction(app.cfg, transaction_targets)
+        except OSError as exc:
+            ux.err(f"Could not snapshot fail-mode transaction: {exc}", indent="  ")
+            raise click.Abort() from exc
+
+        old_global = gc.hook_fail_mode
+        old_entries: dict[str, tuple[object | None, str]] = {}
+        gc.hook_fail_mode = mode
+        if fail_mode_targets:
+            from defenseclaw.config import PerConnectorGuardrailConfig
+
+            for name in fail_mode_targets:
+                entry = gc.connectors.get(name)
+                old_entries[name] = (entry, str(getattr(entry, "hook_fail_mode", "") or ""))
+                if entry is None:
+                    entry = PerConnectorGuardrailConfig()
+                    gc.connectors[name] = entry
+                # Explicit fan-out makes the operation truthful in mixed
+                # observe/action installs and prevents old overrides from
+                # silently defeating the requested global posture.
+                entry.hook_fail_mode = mode
+        try:
+            app.cfg.save()
+            if fail_mode_targets:
+                ux.ok(
+                    f"Config saved (global default + {len(fail_mode_targets)} active connector overrides = {mode})",
+                    indent="  ",
+                )
+            else:
+                ux.ok(f"Config saved (guardrail.hook_fail_mode = {mode})", indent="  ")
+        except OSError as exc:
+            gc.hook_fail_mode = old_global
+            for name, (old_entry, old_mode) in old_entries.items():
+                if old_entry is None:
+                    gc.connectors.pop(name, None)
+                else:
+                    old_entry.hook_fail_mode = old_mode
+            restore_fail_mode_transaction(snapshots)
+            ux.err(f"Failed to save config: {exc}", indent="  ")
+            raise click.Abort() from exc
+
+        if restart and gc.enabled:
+            used_full_restart = False
+            try:
+                runtime_targets = [
+                    name for name in transaction_targets if normalize_connector(name) in _RUNTIME_FAIL_MODE_CONNECTORS
+                ]
+                if transaction_targets and len(runtime_targets) == len(transaction_targets):
+                    for name in runtime_targets:
+                        reconcile_connector_registration(app.cfg, name)
+                else:
+                    from defenseclaw.commands import cmd_setup
+
+                    used_full_restart = True
+                    cmd_setup._restart_services(
+                        app.cfg.data_dir,
+                        app.cfg.gateway.host,
+                        app.cfg.gateway.port,
+                        connector=single_connector,
+                        connectors=_active_connector_set(app.cfg, single_connector),
+                    )
+                    for name in runtime_targets:
+                        state = resolve_connector_fail_mode(app.cfg, name)
+                        if not state.current:
+                            raise OSError(
+                                f"connector runtime verification failed for {name}: " + ", ".join(state.drift)
+                            )
+            except (OSError, RuntimeError, click.ClickException) as exc:
+                gc.hook_fail_mode = old_global
+                for name, (old_entry, old_mode) in old_entries.items():
+                    if old_entry is None:
+                        gc.connectors.pop(name, None)
+                    else:
+                        old_entry.hook_fail_mode = old_mode
+                try:
+                    restore_fail_mode_transaction(snapshots)
+                except OSError as rollback_exc:
+                    ux.err(f"Fail-mode update failed and rollback was incomplete: {rollback_exc}", indent="  ")
+                    raise click.Abort() from rollback_exc
+                if used_full_restart:
+                    try:
+                        from defenseclaw.commands import cmd_setup
+
+                        cmd_setup._restart_services(
+                            app.cfg.data_dir,
+                            app.cfg.gateway.host,
+                            app.cfg.gateway.port,
+                            connector=single_connector,
+                            connectors=_active_connector_set(app.cfg, single_connector),
+                        )
+                    except (OSError, RuntimeError, click.ClickException) as rollback_exc:
+                        ux.err(
+                            "Fail-mode update failed and the previous files were restored, "
+                            f"but runtime rollback failed: {rollback_exc}",
+                            indent="  ",
+                        )
+                        raise click.Abort() from rollback_exc
+                ux.err(f"Fail-mode update failed; previous config and registration restored: {exc}", indent="  ")
+                raise click.Abort() from exc
+            ux.ok("Selected connector runtime registrations refreshed and verified.", indent="  ")
+            click.echo()
+        elif not restart:
+            ux.warn(
+                "--no-restart saved desired values, but runtime registrations were not refreshed; "
+                "status will report drift until reconciliation succeeds.",
+                indent="  ",
+            )
+        elif not gc.enabled:
+            ux.warn(
+                "guardrail is currently disabled — value will take effect "
+                "the next time you run 'defenseclaw guardrail enable'.",
+                indent="  ",
+            )
 
 
 @guardrail.command("fail-mode")
@@ -1078,11 +1269,10 @@ def fail_mode_cmd(
                Choose for regulated workflows where every prompt
                MUST be inspected.
 
-    Transport-layer failures (gateway unreachable / 5xx) are NOT
-    governed by this setting — they always allow unless the agent's
-    environment has ``DEFENSECLAW_STRICT_AVAILABILITY=1``. That is
-    the dedicated escape hatch for sites that prefer agent downtime
-    to a missed inspection during a real outage.
+    Transport-layer failures (gateway unreachable / timeout / 5xx)
+    follow the same connector-scoped setting. ``closed`` blocks them;
+    ``open`` allows them. ``DEFENSECLAW_STRICT_AVAILABILITY=1`` remains
+    an unconditional force-closed override for compatibility.
 
     Without an argument this prints the current value. With
     ``open`` or ``closed`` it persists the choice to ~/.defenseclaw/
@@ -1116,30 +1306,31 @@ def fail_mode_cmd(
         click.echo()
         click.echo(f"  {ux._style('per connector:', fg='bright_black', bold=True)}")
         for _name in _actives:
-            _eff = (
-                gc.effective_hook_fail_mode(_name)
-                if hasattr(gc, "effective_hook_fail_mode")
-                else current
-            )
+            _eff = gc.effective_hook_fail_mode(_name) if hasattr(gc, "effective_hook_fail_mode") else current
+            if normalize_connector(_name) in _RUNTIME_FAIL_MODE_CONNECTORS:
+                _state = resolve_connector_fail_mode(app.cfg, _name)
+                _eff = _state.runtime or "unknown"
+                if _state.drift:
+                    _eff += f" (desired {_state.desired}; drift: {', '.join(_state.drift)})"
             _eff_disp = ux._style(_eff, fg="yellow") if _eff == "closed" else _eff
             click.echo(f"      - {_connector_label(_name)} ({_name}): {_eff_disp}")
         click.echo()
         if current == "open":
             ux.subhead(
-                "Response-layer failures (4xx, malformed JSON) ALLOW the tool/prompt.",
+                "Invalid, unauthorized, incomplete, and unreachable responses ALLOW the tool/prompt.",
                 indent="  ",
             )
             click.echo(f"  {ux.dim('Switch to closed:')} defenseclaw guardrail fail-mode closed")
         else:
             ux.subhead(
-                "Response-layer failures (4xx, malformed JSON) BLOCK the tool/prompt.",
+                "Invalid, unauthorized, incomplete, and unreachable responses BLOCK the tool/prompt.",
                 indent="  ",
             )
             click.echo(f"  {ux.dim('Switch to open:')}   defenseclaw guardrail fail-mode open")
         click.echo()
         ux.subhead(
-            "Transport-layer failures (gateway unreachable) always allow unless "
-            "DEFENSECLAW_STRICT_AVAILABILITY=1 is set in the agent env.",
+            "Invalid, unauthorized, incomplete, and unreachable gateway responses "
+            "follow each connector's effective fail mode.",
             indent="  ",
         )
         click.echo()
@@ -1147,55 +1338,64 @@ def fail_mode_cmd(
 
     fail_mode_targets = _multi_connector_fail_mode_targets(app)
     target_modes: dict[str, str] = {}
+    runtime_states = {}
     if fail_mode_targets:
-        # Mutation comparisons use the stored posture, not the effective one.
-        # Observe mode intentionally forces the effective value open, but an
-        # operator must still be able to replace a dormant closed override
-        # before switching that connector into action mode.
+        # Mutation comparisons use the stored posture; runtime agreement is
+        # checked separately so a stale installation can never be a no-op.
         configured = getattr(gc, "connectors", {}) or {}
         for name in fail_mode_targets:
             entry = configured.get(name)
             stored = str(getattr(entry, "hook_fail_mode", "") or "").strip().lower()
             target_modes[name] = stored if stored in ("open", "closed") else current
+            runtime_states[name] = resolve_connector_fail_mode(app.cfg, name)
 
-    if fail_mode_targets and all(value == mode for value in target_modes.values()):
+    if (
+        fail_mode_targets
+        and all(value == mode for value in target_modes.values())
+        and all(state.desired == mode and state.current for state in runtime_states.values())
+    ):
         click.echo(
-            f"  {ux.dim('Hook fail mode is already')} {mode!r} "
-            f"{ux.dim('for all active connectors — nothing to do.')}"
+            f"  {ux.dim('Hook fail mode is already')} {mode!r} {ux.dim('for all active connectors — nothing to do.')}"
         )
         return
-    if not fail_mode_targets and mode == current:
+    single_connector = _resolve_active_connector(app.cfg)
+    single_state = (
+        resolve_connector_fail_mode(app.cfg, single_connector)
+        if not fail_mode_targets and normalize_connector(single_connector) in _RUNTIME_FAIL_MODE_CONNECTORS
+        else None
+    )
+    if (
+        not fail_mode_targets
+        and mode == current
+        and (single_state is None or (single_state.desired == mode and single_state.current))
+    ):
         click.echo(f"  {ux.dim('Hook fail mode is already')} {mode!r} {ux.dim('— nothing to do.')}")
         return
 
     click.echo()
     if fail_mode_targets:
-        click.echo(
-            f"  {ux.bold('Changing hook fail mode for active connectors:')} "
-            f"{ux.accent(mode)}"
-        )
+        click.echo(f"  {ux.bold('Changing hook fail mode for active connectors:')} {ux.accent(mode)}")
         for name in fail_mode_targets:
             old = target_modes.get(name, current)
             if old != mode:
-                click.echo(
-                    f"      - {_connector_label(name)} ({name}): "
-                    f"{old} {ux.dim('→')} {ux.accent(mode)}"
-                )
+                click.echo(f"      - {_connector_label(name)} ({name}): {old} {ux.dim('→')} {ux.accent(mode)}")
+            elif not runtime_states[name].current:
+                click.echo(f"      - {_connector_label(name)} ({name}): reconcile stale runtime")
     else:
         click.echo(f"  {ux.bold('Changing hook fail mode:')} {current} {ux.dim('→')} {ux.accent(mode)}")
     if mode == "closed":
         ux.warn(
-            "Response-layer failures will now BLOCK the agent.",
+            "Invalid or unavailable gateway responses will now BLOCK the agent.",
             indent="  ",
         )
         ux.subhead(
-            "A misconfigured gateway response (4xx, bad JSON) will exit 2 from "
+            "A 4xx, malformed/incomplete response, timeout, or connection failure will exit 2 from "
             "every hook. Make sure your gateway is healthy before flipping this.",
             indent="    ",
         )
     else:
         ux.subhead(
-            "Response-layer failures will now ALLOW the agent and log the failure to "
+            "Invalid or unavailable gateway responses will now ALLOW the agent and log the failure to "
             "~/.defenseclaw/logs/hook-failures.jsonl.",
             indent="  ",
         )
@@ -1210,50 +1410,14 @@ def fail_mode_cmd(
         # SystemExit bypasses that machinery.
         raise click.Abort()
 
-    if fail_mode_targets:
-        from defenseclaw.config import PerConnectorGuardrailConfig
-
-        for name in fail_mode_targets:
-            entry = gc.connectors.get(name)
-            if entry is None:
-                entry = PerConnectorGuardrailConfig()
-                gc.connectors[name] = entry
-            entry.hook_fail_mode = mode
-    else:
-        gc.hook_fail_mode = mode
-    try:
-        app.cfg.save()
-        if fail_mode_targets:
-            ux.ok(
-                f"Config saved ({len(fail_mode_targets)} connector hook_fail_mode overrides = {mode})",
-                indent="  ",
-            )
-        else:
-            ux.ok(f"Config saved (guardrail.hook_fail_mode = {mode})", indent="  ")
-    except OSError as exc:
-        ux.err(f"Failed to save config: {exc}", indent="  ")
-        raise click.Abort()
-
-    if restart and gc.enabled:
-        connector = _resolve_active_connector(app.cfg)
-        # Lazy import via module: see disable_cmd above for rationale.
-        from defenseclaw.commands import cmd_setup
-
-        cmd_setup._restart_services(
-            app.cfg.data_dir,
-            app.cfg.gateway.host,
-            app.cfg.gateway.port,
-            connector=connector,
-            connectors=_active_connector_set(app.cfg, connector),
-        )
-        ux.ok("Gateway restarted, hooks regenerated with the new fail mode.", indent="  ")
-        click.echo()
-    elif not gc.enabled:
-        ux.warn(
-            "guardrail is currently disabled — value will take effect "
-            "the next time you run 'defenseclaw guardrail enable'.",
-            indent="  ",
-        )
+    _apply_global_fail_mode_transaction(
+        app,
+        mode=mode,
+        restart=restart,
+        fail_mode_targets=fail_mode_targets,
+        single_connector=single_connector,
+        single_runtime=single_state is not None,
+    )
 
     if app.logger:
         app.logger.log_action(

--- a/cli/defenseclaw/config.py
+++ b/cli/defenseclaw/config.py
@@ -1828,11 +1828,9 @@ class GuardrailConfig:
     # by ``_migrate_0_4_0_seed_hook_fail_mode`` so the flip is a
     # NEW-INSTALL-ONLY behavior change.
     #
-    # Transport-layer failures (gateway unreachable / 5xx) are
-    # handled separately by each hook's ``fail_unreachable`` helper
-    # and ALWAYS allow unless the operator opts into strict
-    # availability via ``DEFENSECLAW_STRICT_AVAILABILITY=1`` —
-    # regardless of this field's value. Mirrors
+    # Transport-layer failures (gateway unreachable / timeout / 5xx)
+    # follow this same mode. ``DEFENSECLAW_STRICT_AVAILABILITY=1``
+    # remains an unconditional force-closed override. Mirrors
     # ``GuardrailConfig.HookFailMode`` in internal/config/config.go.
     hook_fail_mode: str = "closed"
     # ``llm_role`` is the operator's answer to "should DefenseClaw's
@@ -1917,13 +1915,19 @@ class GuardrailConfig:
         return self.hilt
 
     def effective_hook_fail_mode(self, connector: str = "") -> str:
-        """Observe always opens; action uses per-connector > global."""
-        if self.effective_mode(connector).strip().lower() != "action":
-            return "open"
+        """Explicit connector posture > observe compatibility > global.
+
+        Existing observe-only installs remain fail-open when they only carry
+        the legacy global value.  A connector-scoped value is an explicit
+        runtime response-integrity choice, however, and must not be collapsed
+        back to open merely because policy findings are being observed.
+        """
         pc = self._connector_override(connector)
         if pc is not None and pc.hook_fail_mode.strip():
             if pc.hook_fail_mode.strip().lower() == "closed":
                 return "closed"
+            return "open"
+        if self.effective_mode(connector).strip().lower() != "action":
             return "open"
         if self.hook_fail_mode.strip().lower() == "closed":
             return "closed"

--- a/cli/defenseclaw/fail_mode.py
+++ b/cli/defenseclaw/fail_mode.py
@@ -27,6 +27,16 @@ _EXPECTED_CONTRACT = {
     "claudecode": "claudecode-hooks-v1",
     "codex": "codex-hooks-v1",
 }
+_SHARED_HOOK_SCRIPTS = frozenset(
+    {
+        "inspect-tool.sh",
+        "inspect-request.sh",
+        "inspect-response.sh",
+        "inspect-tool-response.sh",
+        "_hardening.sh",
+    }
+)
+_LEGACY_SHARED_HOOK_SCRIPTS = _SHARED_HOOK_SCRIPTS - {"_hardening.sh"}
 
 
 def normalize_fail_mode(value: object, *, default: str = "closed") -> str:
@@ -225,24 +235,73 @@ def _registration_lock_state(cfg: Any, connector: str) -> tuple[str | None, str 
     }
     if expected_contract and not digests:
         return mode, "registration-digests-missing"
+
+    raw_lock_version = payload.get("version", 1)
+    if type(raw_lock_version) is not int or raw_lock_version < 1:
+        return mode, "registration-lock-malformed"
+    lock_version = raw_lock_version
+    if lock_version > 2:
+        return mode, "registration-lock-version-unsupported"
+    shared_digests: dict[str, object] = {}
+    if lock_version >= 2:
+        raw_shared = payload.get("shared_hook_script_digests")
+        if not isinstance(raw_shared, dict) or not _SHARED_HOOK_SCRIPTS.issubset(raw_shared):
+            return mode, "registration-shared-digests-missing"
+        shared_digests = raw_shared
+    else:
+        # A v1 lock duplicated shared-file expectations in every connector
+        # entry.  Divergent values cannot be reconciled by choosing whichever
+        # connector happens to match disk; require controlled setup to render
+        # canonical bytes and atomically migrate the whole lock to v2.
+        legacy_shared = False
+        if expected_contract and not _LEGACY_SHARED_HOOK_SCRIPTS.issubset(digests):
+            return mode, "registration-shared-digests-missing"
+        for filename in _SHARED_HOOK_SCRIPTS:
+            expected_values = {
+                str(candidate_digests.get(filename) or "")
+                for candidate in (connectors or {}).values()
+                if isinstance(candidate, dict)
+                for candidate_digests in [candidate.get("hook_script_digests")]
+                if isinstance(candidate_digests, dict) and filename in candidate_digests
+            }
+            legacy_shared = legacy_shared or bool(expected_values)
+            if len(expected_values) > 1:
+                return mode, "registration-shared-digest-divergent"
+        if legacy_shared and len(connectors or {}) > 1:
+            return mode, "registration-shared-lock-legacy"
     if os.name == "nt" and expected_contract:
         digest_names = {str(filename).casefold() for filename in digests}
         if "defenseclaw-hook.exe" not in digest_names:
             return mode, "registration-launcher-digest-missing"
-    for filename, expected in (digests or {}).items():
-        if expected_contract and Path(str(filename)).name != str(filename):
-            return mode, "registration-digest-path-stale"
-        if expected_contract:
-            path = (
-                Path.home() / ".local" / "bin" / "defenseclaw-hook.exe"
-                if str(filename).casefold() == "defenseclaw-hook.exe"
-                else Path(cfg.data_dir) / "hooks" / str(filename)
-            )
-        else:
-            path = path_by_name.get(str(filename), Path(cfg.data_dir) / "hooks" / str(filename))
-        actual = _sha256_regular_file(path)
-        if actual != str(expected or ""):
-            return mode, "registration-digest-stale"
+    digest_sets = [digests or {}]
+    if lock_version >= 2:
+        digest_sets.append(shared_digests)
+    for digest_set in digest_sets:
+        for filename, expected in digest_set.items():
+            if lock_version >= 2 and digest_set is digests and str(filename) in _SHARED_HOOK_SCRIPTS:
+                # Root shared evidence is authoritative in v2.  Ignore a
+                # lingering legacy duplicate until the next locked save strips
+                # it; never let the duplicate override the root digest.
+                continue
+            if expected_contract and Path(str(filename)).name != str(filename):
+                return mode, "registration-digest-path-stale"
+            if expected_contract:
+                # Prefer the exact setup-time location recorded by the lock.
+                # The Windows launcher can live outside the current process's
+                # notion of HOME (service accounts and isolated installs are
+                # common); hashing a guessed home path creates false drift.
+                path = path_by_name.get(str(filename))
+                if path is None:
+                    path = (
+                        Path.home() / ".local" / "bin" / "defenseclaw-hook.exe"
+                        if str(filename).casefold() == "defenseclaw-hook.exe"
+                        else Path(cfg.data_dir) / "hooks" / str(filename)
+                    )
+            else:
+                path = path_by_name.get(str(filename), Path(cfg.data_dir) / "hooks" / str(filename))
+            actual = _sha256_regular_file(path)
+            if actual != str(expected or ""):
+                return mode, "registration-digest-stale"
     return mode, None
 
 
@@ -309,7 +368,7 @@ def _read_small_bytes(path: Path) -> bytes | None:
         info = path.lstat()
         if not stat.S_ISREG(info.st_mode) or info.st_size > _MAX_RUNTIME_FILE:
             return None
-        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
         descriptor = os.open(path, flags)
         opened = os.fstat(descriptor)
         if not stat.S_ISREG(opened.st_mode) or opened.st_size > _MAX_RUNTIME_FILE:
@@ -333,7 +392,7 @@ def _sha256_regular_file(path: Path) -> str:
         before = path.lstat()
         if not stat.S_ISREG(before.st_mode) or before.st_size > _MAX_DIGEST_FILE:
             return ""
-        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
         descriptor = os.open(path, flags)
         opened = os.fstat(descriptor)
         if (
@@ -396,6 +455,7 @@ def snapshot_fail_mode_transaction(cfg: Any, connectors: list[str]) -> tuple[Fil
     paths.update(
         {
             hook_dir / ".hookcfg",
+            hook_dir / ".hookcfg.legacy",
             Path(cfg.data_dir) / "hook_contract_lock.json",
             hook_dir / "inspect-tool.sh",
             hook_dir / "inspect-request.sh",
@@ -411,6 +471,7 @@ def snapshot_fail_mode_transaction(cfg: Any, connectors: list[str]) -> tuple[Fil
     for raw_name in connectors:
         name = normalize(raw_name)
         paths.add(hook_dir / f".hook-{name}.token")
+        paths.add(hook_dir / f".hookcfg.{name}")
         for config_path in connector_config_files(name, workspace_dir=workspace):
             paths.add(Path(config_path))
         paths.add(hook_dir / f"{name}-hook.sh")
@@ -461,7 +522,7 @@ def _snapshot_regular_file(path: Path) -> tuple[bytes, int]:
     info = path.lstat()
     if not stat.S_ISREG(info.st_mode) or info.st_size > _MAX_RUNTIME_FILE:
         raise OSError(f"unsafe transaction path: {path}")
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     descriptor = os.open(path, flags)
     try:
         opened = os.fstat(descriptor)

--- a/cli/defenseclaw/fail_mode.py
+++ b/cli/defenseclaw/fail_mode.py
@@ -1,0 +1,542 @@
+"""Connector-scoped fail-mode resolution and transactional runtime refresh."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from defenseclaw import config as config_module
+from defenseclaw.connector_paths import connector_config_files, normalize
+
+_VALID_MODES = frozenset({"open", "closed"})
+_MAX_RUNTIME_FILE = 2 * 1024 * 1024
+_MAX_DIGEST_FILE = 128 * 1024 * 1024
+_FAIL_MODE_PATTERN = re.compile(r"FAIL_MODE=\"\$\{DEFENSECLAW_FAIL_MODE:-(open|closed)\}\"")
+_EXPECTED_CONTRACT = {
+    "claudecode": "claudecode-hooks-v1",
+    "codex": "codex-hooks-v1",
+}
+
+
+def normalize_fail_mode(value: object, *, default: str = "closed") -> str:
+    raw = str(value or "").strip().lower()
+    return raw if raw in _VALID_MODES else default
+
+
+@dataclass(frozen=True)
+class ConnectorFailModeState:
+    connector: str
+    desired: str
+    configured: str
+    runtime: str | None
+    sources: tuple[tuple[str, str | None], ...]
+    drift: tuple[str, ...]
+
+    @property
+    def current(self) -> bool:
+        return not self.drift and self.runtime == self.desired
+
+
+def resolve_connector_fail_mode(cfg: Any, connector: str) -> ConnectorFailModeState:
+    """Resolve desired, installed, and effective runtime fail mode for one connector."""
+
+    name = normalize(connector)
+    guardrail = cfg.guardrail
+    entry = guardrail._connector_override(name) if hasattr(guardrail, "_connector_override") else None
+    if entry is None:
+        configured_entries = getattr(guardrail, "connectors", {}) or {}
+        entry = configured_entries.get(name)
+    raw = getattr(entry, "hook_fail_mode", "") if entry is not None else ""
+    configured = normalize_fail_mode(raw or getattr(guardrail, "hook_fail_mode", ""))
+    resolver = getattr(guardrail, "effective_hook_fail_mode", None)
+    desired = normalize_fail_mode(resolver(name) if callable(resolver) else configured)
+    sources: list[tuple[str, str | None]] = [("config", configured)]
+    drift: list[str] = []
+
+    runtime_source = _platform_runtime_source(cfg, name)
+    sources.append(runtime_source)
+    runtime = runtime_source[1]
+    if runtime_source[0].endswith("-legacy"):
+        drift.append("windows-sidecar-legacy")
+    process_env = str(os.environ.get("DEFENSECLAW_FAIL_MODE", "")).strip().lower()
+    if process_env in _VALID_MODES:
+        sources.append(("process-env", process_env))
+        runtime = process_env
+
+    if name == "claudecode":
+        claude_env, registered = _claude_registration_state()
+        sources.append(("claude-env", claude_env))
+        if claude_env is not None:
+            runtime = claude_env
+        if not registered:
+            drift.append("registration-missing")
+    elif name == "codex" and not _codex_registration_current():
+        drift.append("registration-missing")
+
+    lock_mode, lock_drift = _registration_lock_state(cfg, name)
+    sources.append(("registration-lock", lock_mode))
+    if lock_mode != desired:
+        drift.append("registration-stale")
+    if lock_drift:
+        drift.append(lock_drift)
+    if os.name == "nt" and name in _EXPECTED_CONTRACT:
+        windows_registration = _windows_registration_freshness(cfg, name)
+        if windows_registration:
+            drift.append(windows_registration)
+    elif name in _EXPECTED_CONTRACT:
+        unix_registration = _unix_registration_freshness(cfg, name)
+        if unix_registration:
+            drift.append(unix_registration)
+
+    for source, mode in sources:
+        if source == "config":
+            continue
+        if mode is None:
+            if source not in {"claude-env"} or name == "claudecode":
+                drift.append(f"{source}-missing")
+        elif mode != desired:
+            drift.append(f"{source}-{mode}")
+
+    return ConnectorFailModeState(
+        connector=name,
+        desired=desired,
+        configured=configured,
+        runtime=runtime,
+        sources=tuple(sources),
+        drift=tuple(dict.fromkeys(drift)),
+    )
+
+
+def _platform_runtime_source(cfg: Any, connector: str) -> tuple[str, str | None]:
+    if os.name == "nt":
+        mode, legacy = _read_windows_hook_mode(Path(cfg.data_dir) / "hooks" / ".hookcfg", connector)
+        if legacy:
+            return "windows-sidecar-legacy", mode
+        return "windows-sidecar", mode
+    script_name = "claude-code-hook.sh" if connector == "claudecode" else f"{connector}-hook.sh"
+    return "hook-script", _read_baked_hook_mode(Path(cfg.data_dir) / "hooks" / script_name)
+
+
+def _read_windows_hook_mode(path: Path, connector: str) -> tuple[str | None, bool]:
+    data = _read_small_file(path)
+    if data is None:
+        return None, False
+    try:
+        payload = json.loads(data)
+    except (TypeError, ValueError):
+        payload = None
+    if isinstance(payload, dict) and int(payload.get("version", 0) or 0) >= 2:
+        modes = payload.get("fail_modes")
+        if isinstance(modes, dict):
+            value = modes.get(normalize(connector))
+            if str(value or "").strip() in _VALID_MODES:
+                return normalize_fail_mode(value), False
+        legacy_value = str(payload.get("legacy_fail_mode") or "").strip().lower()
+        if legacy_value in _VALID_MODES:
+            return legacy_value, True
+        return None, False
+    for line in data.splitlines():
+        key, separator, value = line.strip().partition("=")
+        if separator and key.removeprefix("export ").strip() == "DEFENSECLAW_FAIL_MODE":
+            value = value.strip().strip("\"'").lower()
+            return (value if value in _VALID_MODES else None), True
+    return None, True
+
+
+def _read_baked_hook_mode(path: Path) -> str | None:
+    data = _read_small_file(path)
+    if data is None:
+        return None
+    match = _FAIL_MODE_PATTERN.search(data)
+    return match.group(1) if match else None
+
+
+def _claude_registration_state() -> tuple[str | None, bool]:
+    data = _read_small_file(Path.home() / ".claude" / "settings.json")
+    if data is None:
+        return None, False
+    try:
+        settings = json.loads(data)
+    except (TypeError, ValueError):
+        return None, False
+    if not isinstance(settings, dict):
+        return None, False
+    env = settings.get("env")
+    value = env.get("DEFENSECLAW_FAIL_MODE") if isinstance(env, dict) else None
+    mode = str(value or "").strip().lower()
+    hooks = settings.get("hooks")
+    try:
+        hook_registration = json.dumps(hooks, separators=(",", ":")).lower()
+    except (TypeError, ValueError):
+        hook_registration = ""
+    registered = "defenseclaw" in hook_registration and (
+        "claudecode" in hook_registration or "claude-code-hook" in hook_registration
+    )
+    return (mode if mode in _VALID_MODES else None), registered
+
+
+def _codex_registration_current() -> bool:
+    data = _read_small_file(Path.home() / ".codex" / "config.toml")
+    if data is None:
+        return False
+    return "[hooks]" in data and "defenseclaw" in data.lower()
+
+
+def _registration_lock_state(cfg: Any, connector: str) -> tuple[str | None, str | None]:
+    data = _read_small_file(Path(cfg.data_dir) / "hook_contract_lock.json")
+    if data is None:
+        return None, "registration-lock-missing"
+    try:
+        payload = json.loads(data)
+    except (TypeError, ValueError):
+        return None, "registration-lock-malformed"
+    connectors = payload.get("connectors") if isinstance(payload, dict) else None
+    entry = connectors.get(connector) if isinstance(connectors, dict) else None
+    if not isinstance(entry, dict):
+        return None, "registration-lock-missing"
+    value = entry.get("hook_fail_mode") if isinstance(entry, dict) else None
+    raw = str(value or "").strip().lower()
+    mode = raw if raw in _VALID_MODES else None
+    expected_contract = _EXPECTED_CONTRACT.get(connector)
+    if expected_contract and str(entry.get("contract_id") or "") != expected_contract:
+        return mode, "registration-contract-stale"
+    if expected_contract and not str(entry.get("hook_script_version") or "").strip():
+        return mode, "registration-version-stale"
+    digests = entry.get("hook_script_digests")
+    if expected_contract and not isinstance(digests, dict):
+        return mode, "registration-digests-missing"
+    locations = entry.get("locations")
+    configured_paths = locations.get("hook_script_paths") if isinstance(locations, dict) else None
+    path_by_name = {
+        Path(str(item)).name: Path(str(item))
+        for item in (configured_paths if isinstance(configured_paths, list) else [])
+        if str(item or "").strip()
+    }
+    if expected_contract and not digests:
+        return mode, "registration-digests-missing"
+    if os.name == "nt" and expected_contract:
+        digest_names = {str(filename).casefold() for filename in digests}
+        if "defenseclaw-hook.exe" not in digest_names:
+            return mode, "registration-launcher-digest-missing"
+    for filename, expected in (digests or {}).items():
+        if expected_contract and Path(str(filename)).name != str(filename):
+            return mode, "registration-digest-path-stale"
+        if expected_contract:
+            path = (
+                Path.home() / ".local" / "bin" / "defenseclaw-hook.exe"
+                if str(filename).casefold() == "defenseclaw-hook.exe"
+                else Path(cfg.data_dir) / "hooks" / str(filename)
+            )
+        else:
+            path = path_by_name.get(str(filename), Path(cfg.data_dir) / "hooks" / str(filename))
+        actual = _sha256_regular_file(path)
+        if actual != str(expected or ""):
+            return mode, "registration-digest-stale"
+    return mode, None
+
+
+def _windows_registration_freshness(cfg: Any, connector: str) -> str | None:
+    """Return drift when the live Windows command/launcher is not current."""
+
+    from defenseclaw.doctor_hooks import validate_windows_hook_registration
+
+    workspace = ""
+    workspace_resolver = getattr(cfg, "connector_workspace_dir", None)
+    if callable(workspace_resolver):
+        workspace = str(workspace_resolver() or "")
+    paths = connector_config_files(connector, workspace_dir=workspace)
+    config_path = (
+        paths[0]
+        if paths
+        else str(Path.home() / (".codex/config.toml" if connector == "codex" else ".claude/settings.json"))
+    )
+    check = validate_windows_hook_registration(
+        connector=connector,
+        config_path=config_path,
+        data_dir=str(cfg.data_dir),
+        install_root=str(Path.home() / ".local" / "bin"),
+        search_path=os.environ.get("PATH", ""),
+        pathext=os.environ.get("PATHEXT", ""),
+    )
+    return None if check.healthy else f"registration-{check.state}"
+
+
+def _unix_registration_freshness(cfg: Any, connector: str) -> str | None:
+    """Verify the live Unix agent registration points at this data dir's hook."""
+
+    if connector == "claudecode":
+        registration_path = Path.home() / ".claude" / "settings.json"
+        script_name = "claude-code-hook.sh"
+    else:
+        registration_path = Path.home() / ".codex" / "config.toml"
+        script_name = "codex-hook.sh"
+    registration = _read_small_file(registration_path)
+    if registration is None:
+        return "registration-missing"
+    expected = str((Path(cfg.data_dir) / "hooks" / script_name).resolve())
+    # JSON/TOML string literals escape a backslash when this helper is unit
+    # tested from Windows; Unix paths use '/' and are unchanged.
+    expected_forms = {expected, expected.replace("\\", "\\\\")}
+    if not any(candidate in registration for candidate in expected_forms):
+        return "registration-command-stale"
+    return None
+
+
+def _read_small_file(path: Path) -> str | None:
+    body = _read_small_bytes(path)
+    if body is None:
+        return None
+    try:
+        return body.decode("utf-8")
+    except UnicodeError:
+        return None
+
+
+def _read_small_bytes(path: Path) -> bytes | None:
+    descriptor: int | None = None
+    try:
+        info = path.lstat()
+        if not stat.S_ISREG(info.st_mode) or info.st_size > _MAX_RUNTIME_FILE:
+            return None
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags)
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or opened.st_size > _MAX_RUNTIME_FILE:
+            return None
+        if not os.path.samestat(info, opened):
+            return None
+        with os.fdopen(descriptor, "rb") as handle:
+            descriptor = None
+            body = handle.read(_MAX_RUNTIME_FILE + 1)
+            return body if len(body) <= _MAX_RUNTIME_FILE else None
+    except OSError:
+        return None
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _sha256_regular_file(path: Path) -> str:
+    descriptor: int | None = None
+    try:
+        before = path.lstat()
+        if not stat.S_ISREG(before.st_mode) or before.st_size > _MAX_DIGEST_FILE:
+            return ""
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags)
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_size > _MAX_DIGEST_FILE
+            or not os.path.samestat(before, opened)
+        ):
+            return ""
+        digest = hashlib.sha256()
+        while chunk := os.read(descriptor, 1024 * 1024):
+            digest.update(chunk)
+        after = os.fstat(descriptor)
+        identity_before = (opened.st_dev, opened.st_ino, opened.st_size, opened.st_mtime_ns)
+        identity_after = (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
+        if identity_before != identity_after:
+            return ""
+        return "sha256:" + digest.hexdigest()
+    except OSError:
+        return ""
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+@dataclass(frozen=True)
+class FileSnapshot:
+    path: Path
+    existed: bool
+    data: bytes = b""
+    mode: int = 0o600
+
+
+@contextmanager
+def fail_mode_transaction_lock(cfg: Any) -> Iterator[None]:
+    """Serialize config + registration reconciliation across CLI/TUI callers."""
+
+    config_path = str(config_module.config_path_for_data_dir(cfg.data_dir))
+    lock_path = config_path + ".fail-mode-transaction.lock"
+    Path(lock_path).parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(lock_path, flags, 0o600)
+    try:
+        lock = os.fdopen(descriptor, "r+")
+    except BaseException:
+        os.close(descriptor)
+        raise
+    try:
+        config_module._lock_file_exclusive(lock)
+        try:
+            yield
+        finally:
+            config_module._unlock_file(lock)
+    finally:
+        lock.close()
+
+
+def snapshot_fail_mode_transaction(cfg: Any, connectors: list[str]) -> tuple[FileSnapshot, ...]:
+    paths = {config_module.config_path_for_data_dir(cfg.data_dir)}
+    hook_dir = Path(cfg.data_dir) / "hooks"
+    paths.update(
+        {
+            hook_dir / ".hookcfg",
+            Path(cfg.data_dir) / "hook_contract_lock.json",
+            hook_dir / "inspect-tool.sh",
+            hook_dir / "inspect-request.sh",
+            hook_dir / "inspect-response.sh",
+            hook_dir / "inspect-tool-response.sh",
+            hook_dir / "_hardening.sh",
+        }
+    )
+    workspace = ""
+    workspace_resolver = getattr(cfg, "connector_workspace_dir", None)
+    if callable(workspace_resolver):
+        workspace = str(workspace_resolver() or "")
+    for raw_name in connectors:
+        name = normalize(raw_name)
+        paths.add(hook_dir / f".hook-{name}.token")
+        for config_path in connector_config_files(name, workspace_dir=workspace):
+            paths.add(Path(config_path))
+        paths.add(hook_dir / f"{name}-hook.sh")
+        paths.add(Path(cfg.data_dir) / f"{name}_backup.json")
+        backup_dir = Path(cfg.data_dir) / "connector_backups" / name
+        for logical_name in ("config", "settings.json", "config.toml", "module", "pth", "openclaw.json"):
+            paths.add(backup_dir / f"{logical_name}.json")
+        if backup_dir.is_dir():
+            paths.update(path for path in backup_dir.rglob("*") if path.is_file())
+        if name == "claudecode":
+            paths.update(
+                {
+                    Path.home() / ".claude" / "settings.json",
+                    hook_dir / "claude-code-hook.sh",
+                    Path(cfg.data_dir) / "claudecode_backup.json",
+                    Path(cfg.data_dir) / "connector_backups" / "claudecode" / "settings.json.json",
+                }
+            )
+        elif name == "codex":
+            paths.update(
+                {
+                    Path.home() / ".codex" / "config.toml",
+                    hook_dir / "codex-hook.sh",
+                    Path(cfg.data_dir) / "codex_config_backup.json",
+                    Path(cfg.data_dir) / "codex_backup.json",
+                    Path(cfg.data_dir) / "connector_backups" / "codex" / "config.toml.json",
+                    Path(cfg.data_dir) / "notify-bridge.sh",
+                }
+            )
+    snapshots: list[FileSnapshot] = []
+    for path in sorted(paths, key=str):
+        try:
+            data, mode = _snapshot_regular_file(path)
+            snapshots.append(
+                FileSnapshot(
+                    path=path,
+                    existed=True,
+                    data=data,
+                    mode=mode,
+                )
+            )
+        except FileNotFoundError:
+            snapshots.append(FileSnapshot(path=path, existed=False))
+    return tuple(snapshots)
+
+
+def _snapshot_regular_file(path: Path) -> tuple[bytes, int]:
+    info = path.lstat()
+    if not stat.S_ISREG(info.st_mode) or info.st_size > _MAX_RUNTIME_FILE:
+        raise OSError(f"unsafe transaction path: {path}")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or opened.st_size > _MAX_RUNTIME_FILE:
+            raise OSError(f"unsafe opened transaction path: {path}")
+        if not os.path.samestat(info, opened):
+            raise OSError(f"transaction path changed while opening: {path}")
+        with os.fdopen(descriptor, "rb") as handle:
+            descriptor = -1
+            body = handle.read(_MAX_RUNTIME_FILE + 1)
+            if len(body) > _MAX_RUNTIME_FILE:
+                raise OSError(f"transaction path grew beyond size limit: {path}")
+            return body, stat.S_IMODE(opened.st_mode)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def restore_fail_mode_transaction(snapshots: tuple[FileSnapshot, ...]) -> None:
+    errors: list[str] = []
+    for snapshot in reversed(snapshots):
+        try:
+            if snapshot.existed:
+                snapshot.path.parent.mkdir(parents=True, exist_ok=True)
+                fd, temporary = tempfile.mkstemp(prefix=f".{snapshot.path.name}.", dir=snapshot.path.parent)
+                try:
+                    with os.fdopen(fd, "wb") as handle:
+                        handle.write(snapshot.data)
+                        handle.flush()
+                        os.fsync(handle.fileno())
+                    os.chmod(temporary, snapshot.mode)
+                    os.replace(temporary, snapshot.path)
+                finally:
+                    try:
+                        os.unlink(temporary)
+                    except FileNotFoundError:
+                        pass
+            else:
+                snapshot.path.unlink(missing_ok=True)
+        except OSError:
+            errors.append(str(snapshot.path))
+    if errors:
+        raise OSError("rollback failed for runtime files: " + ", ".join(errors))
+
+
+def reconcile_connector_registration(cfg: Any, connector: str) -> ConnectorFailModeState:
+    executable = shutil.which("defenseclaw-gateway")
+    if not executable or (os.name == "nt" and Path(executable).suffix.lower() != ".exe"):
+        raise OSError("native defenseclaw-gateway executable not found")
+    environment = os.environ.copy()
+    environment[config_module.CONFIG_PATH_ENV] = str(config_module.config_path_for_data_dir(cfg.data_dir))
+    try:
+        result = subprocess.run(
+            [
+                executable,
+                "connector",
+                "reconcile",
+                "--connector",
+                normalize(connector),
+                "--data-dir",
+                str(cfg.data_dir),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env=environment,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise OSError(f"connector reconcile failed: {exc}") from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "connector reconcile failed").splitlines()[0]
+        raise OSError(detail[:240])
+    state = resolve_connector_fail_mode(cfg, connector)
+    if not state.current:
+        raise OSError(f"connector runtime verification failed for {state.connector}: " + ", ".join(state.drift))
+    return state

--- a/cli/defenseclaw/tui/panels/setup.py
+++ b/cli/defenseclaw/tui/panels/setup.py
@@ -5597,6 +5597,14 @@ def _effective_guardrail_value(
     """
 
     guardrail = getattr(cfg, "guardrail", None)
+    if method_name == "effective_hook_fail_mode" and connector in {"claudecode", "codex"} and hasattr(cfg, "data_dir"):
+        try:
+            from defenseclaw.fail_mode import resolve_connector_fail_mode
+
+            state = resolve_connector_fail_mode(cfg, connector)
+            return state.runtime or state.desired
+        except Exception:  # noqa: BLE001 - config editor must remain available during drift.
+            pass
     resolver = getattr(guardrail, method_name, None) if guardrail is not None else None
     if callable(resolver):
         try:
@@ -5786,19 +5794,17 @@ def _per_connector_guardrail_fields(cfg: object | Mapping[str, Any] | None) -> l
                 _effective_guardrail_bool(cfg, connector, "effective_enabled", "", default=True),
             )
         )
-        # E4d: hook-response fail mode (open=allow on failure, closed=block).
-        fail_field = _field(
-            cfg,
-            "Hook Fail Mode",
-            f"guardrail.connectors.{connector}.hook_fail_mode",
-            "choice",
-            ("open", "closed"),
-            f"Per-connector hook fail mode for {connector} (inherits the global mode when unset).",
-        )
+        # Fail-mode writes must use the Guardrail action so config and the
+        # installed registration are updated transactionally. Keep the live
+        # effective value visible here, but do not expose a raw config edit.
+        fail_value = _effective_guardrail_value(cfg, connector, "effective_hook_fail_mode", "guardrail.hook_fail_mode")
         rows.append(
-            _field_with_original(
-                fail_field,
-                _effective_guardrail_value(cfg, connector, "effective_hook_fail_mode", "guardrail.hook_fail_mode"),
+            ConfigField(
+                label="Hook Fail Mode (use Guardrail action)",
+                key=f"guardrail.connectors.{connector}.hook_fail_mode",
+                kind="header",
+                value=fail_value,
+                original=fail_value,
             )
         )
         # E4d: human-in-the-loop approval. A per-connector hilt block fully
@@ -5871,13 +5877,10 @@ def _guardrail_section(cfg: object | Mapping[str, Any] | None) -> ConfigSection:
         _header(".. Core .."),
         _field(cfg, "Enabled", "guardrail.enabled", "bool", hint="Master guardrail switch."),
         _field(cfg, "Mode", "guardrail.mode", "choice", ("observe", "action"), "observe=log only; action=block."),
-        _field(
-            cfg,
-            "Hook Fail Mode",
+        _header(
+            "Hook Fail Mode (use Guardrail action)",
             "guardrail.hook_fail_mode",
-            "choice",
-            ("open", "closed"),
-            "open=allow hook response failures; closed=block.",
+            _value(cfg, "guardrail.hook_fail_mode"),
         ),
         _field(
             cfg,

--- a/cli/tests/test_cmd_guardrail.py
+++ b/cli/tests/test_cmd_guardrail.py
@@ -246,7 +246,9 @@ class FailModeCommandTests(unittest.TestCase):
     def test_set_open_to_closed_persists_and_restarts(self):
         runner = CliRunner()
         app = make_ctx(enabled=True, connector="codex", hook_fail_mode="open")
-        with patch("defenseclaw.commands.cmd_setup._restart_services") as restart_mock:
+        with patch(
+            "defenseclaw.commands.cmd_guardrail.reconcile_connector_registration"
+        ) as restart_mock:
             result = runner.invoke(
                 cmd_guardrail.fail_mode_cmd, ["closed", "--yes"], obj=app
             )
@@ -256,15 +258,21 @@ class FailModeCommandTests(unittest.TestCase):
         restart_mock.assert_called_once()
         # Active connector must propagate so hooks for the right
         # connector get rewritten.
-        kwargs = restart_mock.call_args.kwargs
-        self.assertEqual(kwargs.get("connector"), "codex")
+        self.assertEqual(restart_mock.call_args.args[1], "codex")
 
     def test_set_same_value_is_noop(self):
         runner = CliRunner()
         app = make_ctx(enabled=True, hook_fail_mode="closed")
-        result = runner.invoke(
-            cmd_guardrail.fail_mode_cmd, ["closed", "--yes"], obj=app
+        state = SimpleNamespace(
+            current=True, runtime="closed", desired="closed", drift=()
         )
+        with patch(
+            "defenseclaw.commands.cmd_guardrail.resolve_connector_fail_mode",
+            return_value=state,
+        ):
+            result = runner.invoke(
+                cmd_guardrail.fail_mode_cmd, ["closed", "--yes"], obj=app
+            )
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertIn("already 'closed'", result.output)
         app.cfg.save.assert_not_called()
@@ -309,6 +317,7 @@ class FailModeCommandTests(unittest.TestCase):
                 cmd_guardrail.fail_mode_cmd, ["closed", "--yes"], obj=app
             )
         self.assertNotEqual(result.exit_code, 0)
+        self.assertEqual(app.cfg.guardrail.hook_fail_mode, "open")
         # Config write failed → must NOT restart the gateway, or the
         # sidecar would re-render hooks from the on-disk old value
         # while we believe we just changed it.
@@ -718,7 +727,7 @@ class PerConnectorFailModeTests(unittest.TestCase):
         app = make_multi_ctx({"codex": None, "claudecode": None})
         app.cfg.guardrail.connectors["codex"].mode = "action"
         with patch(
-            "defenseclaw.commands.cmd_setup._restart_services"
+            "defenseclaw.commands.cmd_guardrail.reconcile_connector_registration"
         ) as restart_mock:
             result = runner.invoke(
                 cmd_guardrail.fail_mode_cmd,
@@ -733,7 +742,7 @@ class PerConnectorFailModeTests(unittest.TestCase):
         self.assertEqual(app.cfg.guardrail.hook_fail_mode, "open")
         app.cfg.save.assert_called_once()
         restart_mock.assert_called_once()
-        self.assertEqual(restart_mock.call_args.kwargs.get("connector"), "codex")
+        self.assertEqual(restart_mock.call_args.args[1], "codex")
 
     def test_show_per_connector_value_without_mode(self):
         runner = CliRunner()
@@ -743,7 +752,8 @@ class PerConnectorFailModeTests(unittest.TestCase):
             cmd_guardrail.fail_mode_cmd, ["--connector", "codex"], obj=app
         )
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        self.assertIn("open", result.output)
+        self.assertIn("unknown", result.output)
+        self.assertIn("desired closed", result.output)
         self.assertIn("override", result.output)
         app.cfg.save.assert_not_called()
 
@@ -785,12 +795,14 @@ class PerConnectorFailModeTests(unittest.TestCase):
         app = make_multi_ctx({"codex": None, "claudecode": None})
         app.cfg.guardrail.connectors["codex"].mode = "action"
         app.cfg.guardrail.connectors["claudecode"].mode = "action"
-        with patch("defenseclaw.commands.cmd_setup._restart_services"):
+        with patch(
+            "defenseclaw.commands.cmd_guardrail.reconcile_connector_registration"
+        ):
             result = runner.invoke(
                 cmd_guardrail.fail_mode_cmd, ["closed", "--yes"], obj=app
             )
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        self.assertEqual(app.cfg.guardrail.hook_fail_mode, "open")
+        self.assertEqual(app.cfg.guardrail.hook_fail_mode, "closed")
         self.assertEqual(app.cfg.guardrail.connectors["codex"].hook_fail_mode, "closed")
         self.assertEqual(app.cfg.guardrail.connectors["claudecode"].hook_fail_mode, "closed")
         self.assertEqual(app.cfg.guardrail.effective_hook_fail_mode("codex"), "closed")
@@ -801,7 +813,14 @@ class PerConnectorFailModeTests(unittest.TestCase):
         app = make_multi_ctx({"codex": None, "geminicli": None})
         app.cfg.guardrail.hook_fail_mode = "open"
         app.cfg.guardrail.connectors["geminicli"].hook_fail_mode = "closed"
-        with patch("defenseclaw.commands.cmd_setup._restart_services") as restart_mock:
+        state = SimpleNamespace(current=True, drift=())
+        with (
+            patch("defenseclaw.commands.cmd_setup._restart_services") as restart_mock,
+            patch(
+                "defenseclaw.commands.cmd_guardrail.resolve_connector_fail_mode",
+                return_value=state,
+            ),
+        ):
             result = runner.invoke(
                 cmd_guardrail.fail_mode_cmd, ["open", "--yes"], obj=app
             )
@@ -812,12 +831,36 @@ class PerConnectorFailModeTests(unittest.TestCase):
         self.assertEqual(app.cfg.guardrail.effective_hook_fail_mode("geminicli"), "open")
         app.cfg.save.assert_called_once()
         restart_mock.assert_called_once()
+        self.assertEqual(
+            set(restart_mock.call_args.kwargs["connectors"]),
+            {"codex", "geminicli"},
+        )
+
+    def test_bare_set_reload_failure_restores_config_and_runtime(self):
+        runner = CliRunner()
+        app = make_multi_ctx({"codex": None, "geminicli": None})
+        app.cfg.guardrail.hook_fail_mode = "open"
+        with patch(
+            "defenseclaw.commands.cmd_setup._restart_services",
+            side_effect=[OSError("reload failed"), None],
+        ) as restart_mock:
+            result = runner.invoke(
+                cmd_guardrail.fail_mode_cmd, ["closed", "--yes"], obj=app
+            )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertEqual(app.cfg.guardrail.hook_fail_mode, "open")
+        self.assertEqual(app.cfg.guardrail.connectors["codex"].hook_fail_mode, "")
+        self.assertEqual(app.cfg.guardrail.connectors["geminicli"].hook_fail_mode, "")
+        self.assertEqual(restart_mock.call_count, 2)
+        self.assertIn("restored", result.output)
 
     def test_connector_open_clears_dormant_closed_override_in_observe_mode(self):
         runner = CliRunner()
         app = make_multi_ctx({"codex": None, "claudecode": None})
         app.cfg.guardrail.connectors["codex"].hook_fail_mode = "closed"
-        with patch("defenseclaw.commands.cmd_setup._restart_services"):
+        with patch(
+            "defenseclaw.commands.cmd_guardrail.reconcile_connector_registration"
+        ):
             result = runner.invoke(
                 cmd_guardrail.fail_mode_cmd,
                 ["open", "--connector", "codex", "--yes"],

--- a/cli/tests/test_fail_mode_runtime.py
+++ b/cli/tests/test_fail_mode_runtime.py
@@ -14,6 +14,14 @@ from defenseclaw.commands import cmd_guardrail
 from defenseclaw.context import AppContext
 from defenseclaw.fail_mode import resolve_connector_fail_mode
 
+_SHARED_HOOK_SCRIPTS = (
+    "inspect-tool.sh",
+    "inspect-request.sh",
+    "inspect-response.sh",
+    "inspect-tool-response.sh",
+    "_hardening.sh",
+)
+
 
 @pytest.fixture(autouse=True)
 def _clear_global_fail_mode(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -67,6 +75,11 @@ def _write_current_runtime(cfg: SimpleNamespace, home: Path, modes: dict[str, st
     (home / ".codex" / "config.toml").write_text(
         '[hooks]\ndefenseclaw = "defenseclaw hook --connector codex"\n', encoding="utf-8"
     )
+    shared_digests = {}
+    for script_name in _SHARED_HOOK_SCRIPTS:
+        script_body = f"canonical shared hook: {script_name}\n".encode()
+        (hook_dir / script_name).write_bytes(script_body)
+        shared_digests[script_name] = "sha256:" + hashlib.sha256(script_body).hexdigest()
     entries = {}
     for name, mode in modes.items():
         script_name = "claude-code-hook.sh" if name == "claudecode" else f"{name}-hook.sh"
@@ -92,7 +105,8 @@ def _write_current_runtime(cfg: SimpleNamespace, home: Path, modes: dict[str, st
     (Path(cfg.data_dir) / "hook_contract_lock.json").write_text(
         json.dumps(
             {
-                "version": 1,
+                "version": 2,
+                "shared_hook_script_digests": shared_digests,
                 "connectors": entries,
             }
         ),
@@ -219,12 +233,20 @@ def test_scoped_reconcile_failure_rolls_back_config_and_registration(tmp_path: P
     cfg, home = _runtime_cfg(tmp_path, {"claudecode": "open", "codex": "open"})
     _write_current_runtime(cfg, home, {"claudecode": "open", "codex": "open"})
     original_settings = (home / ".claude" / "settings.json").read_bytes()
+    tracked_paths = [
+        Path(cfg.data_dir) / "hook_contract_lock.json",
+        Path(cfg.data_dir) / "hooks" / ".hookcfg",
+        *(Path(cfg.data_dir) / "hooks" / name for name in _SHARED_HOOK_SCRIPTS),
+    ]
+    original_runtime = {path: path.read_bytes() for path in tracked_paths}
     app = AppContext()
     app.cfg = cfg
     app.logger = MagicMock()
 
     def fail_after_partial_write(_cfg: object, _connector: str) -> None:
         (home / ".claude" / "settings.json").write_text('{"partial":true}', encoding="utf-8")
+        for path in tracked_paths:
+            path.write_text("partial reconciliation", encoding="utf-8")
         raise OSError("setup failed")
 
     with (
@@ -242,6 +264,7 @@ def test_scoped_reconcile_failure_rolls_back_config_and_registration(tmp_path: P
     assert result.exit_code != 0
     assert cfg.guardrail.connectors["claudecode"].hook_fail_mode == "open"
     assert (home / ".claude" / "settings.json").read_bytes() == original_settings
+    assert {path: path.read_bytes() for path in tracked_paths} == original_runtime
     assert "restored" in result.output
 
 
@@ -283,12 +306,88 @@ def test_stale_windows_launcher_digest_rejects_noop(tmp_path: Path) -> None:
     cfg, home = _runtime_cfg(tmp_path, {"claudecode": "closed", "codex": "open"})
     _write_current_runtime(cfg, home, {"claudecode": "closed", "codex": "open"})
     (home / ".local" / "bin" / "defenseclaw-hook.exe").write_bytes(b"MZstale-launcher")
-    with patch("defenseclaw.fail_mode.os.name", "nt"), patch(
-        "defenseclaw.fail_mode.Path.home", return_value=home
-    ):
+    with patch("defenseclaw.fail_mode.os.name", "nt"), patch("defenseclaw.fail_mode.Path.home", return_value=home):
         state = resolve_connector_fail_mode(cfg, "claudecode")
     assert not state.current
     assert "registration-digest-stale" in state.drift
+
+
+def test_runtime_digest_hashes_raw_windows_binary_bytes(tmp_path: Path) -> None:
+    artifact = tmp_path / "runtime.bin"
+    body = b"MZ\r\nraw-before\x1araw-after\r\n"
+    artifact.write_bytes(body)
+    assert fail_mode_runtime._sha256_regular_file(artifact) == "sha256:" + hashlib.sha256(body).hexdigest()
+
+
+def test_v2_shared_digest_is_authoritative_over_legacy_entry_duplicate(tmp_path: Path) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"claudecode": "closed", "codex": "open"})
+    _write_current_runtime(cfg, home, {"claudecode": "closed", "codex": "open"})
+    lock_path = Path(cfg.data_dir) / "hook_contract_lock.json"
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    lock["connectors"]["claudecode"]["hook_script_digests"]["inspect-tool.sh"] = "sha256:legacy-stale"
+    lock_path.write_text(json.dumps(lock), encoding="utf-8")
+    with patch("defenseclaw.fail_mode.os.name", "nt"), patch("defenseclaw.fail_mode.Path.home", return_value=home):
+        state = resolve_connector_fail_mode(cfg, "claudecode")
+    assert state.current
+
+
+def test_divergent_v1_shared_digests_require_controlled_migration(tmp_path: Path) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"claudecode": "open", "codex": "open"})
+    _write_current_runtime(cfg, home, {"claudecode": "open", "codex": "open"})
+    lock_path = Path(cfg.data_dir) / "hook_contract_lock.json"
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    shared = lock.pop("shared_hook_script_digests")
+    lock["version"] = 1
+    for name, entry in lock["connectors"].items():
+        for script_name, digest in shared.items():
+            entry["hook_script_digests"][script_name] = digest if name == "codex" else "sha256:divergent"
+    lock_path.write_text(json.dumps(lock), encoding="utf-8")
+    with patch("defenseclaw.fail_mode.os.name", "nt"), patch("defenseclaw.fail_mode.Path.home", return_value=home):
+        claude = resolve_connector_fail_mode(cfg, "claudecode")
+        codex = resolve_connector_fail_mode(cfg, "codex")
+    assert "registration-shared-digest-divergent" in claude.drift
+    assert "registration-shared-digest-divergent" in codex.drift
+
+
+def test_single_connector_v1_shared_digests_remain_compatible(tmp_path: Path) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"claudecode": "closed"})
+    _write_current_runtime(cfg, home, {"claudecode": "closed"})
+    lock_path = Path(cfg.data_dir) / "hook_contract_lock.json"
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    shared = lock.pop("shared_hook_script_digests")
+    lock["version"] = 1
+    lock["connectors"]["claudecode"]["hook_script_digests"].update(shared)
+    lock_path.write_text(json.dumps(lock), encoding="utf-8")
+    with patch("defenseclaw.fail_mode.os.name", "nt"), patch("defenseclaw.fail_mode.Path.home", return_value=home):
+        state = resolve_connector_fail_mode(cfg, "claudecode")
+    assert state.current
+
+
+def test_single_connector_v1_missing_shared_digests_is_stale(tmp_path: Path) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"claudecode": "closed"})
+    _write_current_runtime(cfg, home, {"claudecode": "closed"})
+    lock_path = Path(cfg.data_dir) / "hook_contract_lock.json"
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    lock.pop("shared_hook_script_digests")
+    lock["version"] = 1
+    lock_path.write_text(json.dumps(lock), encoding="utf-8")
+    with patch("defenseclaw.fail_mode.os.name", "nt"), patch("defenseclaw.fail_mode.Path.home", return_value=home):
+        state = resolve_connector_fail_mode(cfg, "claudecode")
+    assert "registration-shared-digests-missing" in state.drift
+
+
+@pytest.mark.parametrize("version", [True, 2.5, 3])
+def test_unsupported_contract_lock_version_is_stale(tmp_path: Path, version: object) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"claudecode": "closed"})
+    _write_current_runtime(cfg, home, {"claudecode": "closed"})
+    lock_path = Path(cfg.data_dir) / "hook_contract_lock.json"
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    lock["version"] = version
+    lock_path.write_text(json.dumps(lock), encoding="utf-8")
+    with patch("defenseclaw.fail_mode.os.name", "nt"), patch("defenseclaw.fail_mode.Path.home", return_value=home):
+        state = resolve_connector_fail_mode(cfg, "claudecode")
+    expected = "registration-lock-version-unsupported" if version == 3 else "registration-lock-malformed"
+    assert expected in state.drift
 
 
 def test_unix_registration_freshness_requires_current_script_path(tmp_path: Path) -> None:

--- a/cli/tests/test_fail_mode_runtime.py
+++ b/cli/tests/test_fail_mode_runtime.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+from defenseclaw import config as dcconfig
+from defenseclaw import fail_mode as fail_mode_runtime
+from defenseclaw.commands import cmd_guardrail
+from defenseclaw.context import AppContext
+from defenseclaw.fail_mode import resolve_connector_fail_mode
+
+
+@pytest.fixture(autouse=True)
+def _clear_global_fail_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DEFENSECLAW_FAIL_MODE", raising=False)
+    monkeypatch.setattr("defenseclaw.fail_mode._windows_registration_freshness", lambda *_args: None)
+
+
+def _runtime_cfg(tmp_path: Path, modes: dict[str, str]) -> tuple[SimpleNamespace, Path]:
+    data_dir = tmp_path / "data"
+    home = tmp_path / "home"
+    (data_dir / "hooks").mkdir(parents=True)
+    (home / ".claude").mkdir(parents=True)
+    (home / ".codex").mkdir(parents=True)
+
+    guardrail = dcconfig.GuardrailConfig()
+    guardrail.enabled = True
+    guardrail.hook_fail_mode = "open"
+    guardrail.connectors = {}
+    for name, mode in modes.items():
+        guardrail.connectors[name] = dcconfig.PerConnectorGuardrailConfig(hook_fail_mode=mode)
+    cfg = SimpleNamespace(
+        data_dir=str(data_dir),
+        guardrail=guardrail,
+        gateway=SimpleNamespace(host="127.0.0.1", port=18789),
+    )
+    cfg.active_connector = lambda: sorted(modes)[0]
+    cfg.active_connectors = lambda: sorted(modes)
+    cfg.save = MagicMock()
+    return cfg, home
+
+
+def _write_current_runtime(cfg: SimpleNamespace, home: Path, modes: dict[str, str]) -> None:
+    hook_dir = Path(cfg.data_dir) / "hooks"
+    launcher_path = home / ".local" / "bin" / "defenseclaw-hook.exe"
+    launcher_path.parent.mkdir(parents=True, exist_ok=True)
+    launcher_body = b"MZfixture-launcher"
+    launcher_path.write_bytes(launcher_body)
+    (hook_dir / ".hookcfg").write_text(
+        json.dumps({"version": 2, "gateway_addr": "127.0.0.1:18970", "fail_modes": modes}),
+        encoding="utf-8",
+    )
+    (home / ".claude" / "settings.json").write_text(
+        json.dumps(
+            {
+                "hooks": {"PreToolUse": [{"command": "defenseclaw hook --connector claudecode"}]},
+                "env": {"DEFENSECLAW_FAIL_MODE": modes.get("claudecode", "open")},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (home / ".codex" / "config.toml").write_text(
+        '[hooks]\ndefenseclaw = "defenseclaw hook --connector codex"\n', encoding="utf-8"
+    )
+    entries = {}
+    for name, mode in modes.items():
+        script_name = "claude-code-hook.sh" if name == "claudecode" else f"{name}-hook.sh"
+        script_path = hook_dir / script_name
+        script_body = f'FAIL_MODE="${{DEFENSECLAW_FAIL_MODE:-{mode}}}"\n'.encode()
+        script_path.write_bytes(script_body)
+        config_path = home / (".claude/settings.json" if name == "claudecode" else ".codex/config.toml")
+        entries[name] = {
+            "connector": name,
+            "contract_id": "claudecode-hooks-v1" if name == "claudecode" else "codex-hooks-v1",
+            "compatibility_status": "known",
+            "hook_script_version": "v6",
+            "hook_script_digests": {
+                script_name: "sha256:" + hashlib.sha256(script_body).hexdigest(),
+                launcher_path.name: "sha256:" + hashlib.sha256(launcher_body).hexdigest(),
+            },
+            "locations": {
+                "hook_config_paths": [str(config_path)],
+                "hook_script_paths": [str(script_path), str(launcher_path)],
+            },
+            "hook_fail_mode": mode,
+        }
+    (Path(cfg.data_dir) / "hook_contract_lock.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "connectors": entries,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_windows_resolver_reports_effective_mixed_modes(tmp_path: Path) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"claudecode": "closed", "codex": "open"})
+    _write_current_runtime(cfg, home, {"claudecode": "closed", "codex": "open"})
+    with patch("defenseclaw.fail_mode.os.name", "nt"), patch("defenseclaw.fail_mode.Path.home", return_value=home):
+        claude = resolve_connector_fail_mode(cfg, "claudecode")
+        codex = resolve_connector_fail_mode(cfg, "codex")
+    assert claude.current and claude.runtime == "closed"
+    assert codex.current and codex.runtime == "open"
+
+
+def test_windows_resolver_initial_open_open_and_reverse_mixed_mode(tmp_path: Path) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"claudecode": "open", "codex": "open"})
+    _write_current_runtime(cfg, home, {"claudecode": "open", "codex": "open"})
+    with patch("defenseclaw.fail_mode.os.name", "nt"), patch("defenseclaw.fail_mode.Path.home", return_value=home):
+        assert resolve_connector_fail_mode(cfg, "claudecode").current
+        assert resolve_connector_fail_mode(cfg, "codex").current
+
+        cfg.guardrail.connectors["codex"].hook_fail_mode = "closed"
+        _write_current_runtime(cfg, home, {"claudecode": "open", "codex": "closed"})
+        claude = resolve_connector_fail_mode(cfg, "claudecode")
+        codex = resolve_connector_fail_mode(cfg, "codex")
+    assert claude.current and claude.runtime == "open"
+    assert codex.current and codex.runtime == "closed"
+
+
+def test_cli_status_reports_effective_mixed_modes_without_drift(tmp_path: Path) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"claudecode": "closed", "codex": "open"})
+    _write_current_runtime(cfg, home, {"claudecode": "closed", "codex": "open"})
+    app = AppContext()
+    app.cfg = cfg
+    app.logger = MagicMock()
+    with patch("defenseclaw.fail_mode.os.name", "nt"), patch("defenseclaw.fail_mode.Path.home", return_value=home):
+        result = CliRunner().invoke(cmd_guardrail.status_cmd, [], obj=app)
+    assert result.exit_code == 0, result.output
+    assert "Claude Code" in result.output and "closed" in result.output
+    assert "Codex" in result.output and "open" in result.output
+    assert "runtime fail-mode drift" not in result.output
+
+
+def test_stale_persisted_closed_runtime_open_is_not_current(tmp_path: Path) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"claudecode": "closed", "codex": "open"})
+    _write_current_runtime(cfg, home, {"claudecode": "open", "codex": "open"})
+    with patch("defenseclaw.fail_mode.os.name", "nt"), patch("defenseclaw.fail_mode.Path.home", return_value=home):
+        state = resolve_connector_fail_mode(cfg, "claudecode")
+    assert not state.current
+    assert state.desired == "closed"
+    assert state.runtime == "open"
+    assert "claude-env-open" in state.drift
+
+
+def test_stale_closed_never_reports_already_closed(tmp_path: Path) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"claudecode": "closed", "codex": "open"})
+    _write_current_runtime(cfg, home, {"claudecode": "open", "codex": "open"})
+    app = AppContext()
+    app.cfg = cfg
+    app.logger = MagicMock()
+    with (
+        patch("defenseclaw.fail_mode.os.name", "nt"),
+        patch("defenseclaw.fail_mode.Path.home", return_value=home),
+        patch("defenseclaw.commands.cmd_guardrail.reconcile_connector_registration") as reconcile,
+    ):
+        result = CliRunner().invoke(
+            cmd_guardrail.fail_mode_cmd,
+            ["closed", "--connector", "claudecode", "--yes"],
+            obj=app,
+        )
+    assert result.exit_code == 0, result.output
+    assert "already" not in result.output
+    assert "Reconciling" in result.output
+    reconcile.assert_called_once()
+
+
+def test_raw_global_closed_observe_runtime_open_creates_scoped_override(tmp_path: Path) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"claudecode": "open", "codex": "open"})
+    cfg.guardrail.hook_fail_mode = "closed"
+    cfg.guardrail.connectors["claudecode"].hook_fail_mode = ""
+    _write_current_runtime(cfg, home, {"claudecode": "open", "codex": "open"})
+    app = AppContext()
+    app.cfg = cfg
+    app.logger = MagicMock()
+    with (
+        patch("defenseclaw.fail_mode.os.name", "nt"),
+        patch("defenseclaw.fail_mode.Path.home", return_value=home),
+        patch("defenseclaw.commands.cmd_guardrail.reconcile_connector_registration") as reconcile,
+    ):
+        before = resolve_connector_fail_mode(cfg, "claudecode")
+        result = CliRunner().invoke(
+            cmd_guardrail.fail_mode_cmd,
+            ["closed", "--connector", "claudecode", "--yes"],
+            obj=app,
+        )
+    assert before.desired == "open" and before.current
+    assert result.exit_code == 0, result.output
+    assert "already" not in result.output
+    assert cfg.guardrail.connectors["claudecode"].hook_fail_mode == "closed"
+    assert cfg.guardrail.connectors["codex"].hook_fail_mode == "open"
+    reconcile.assert_called_once_with(cfg, "claudecode")
+
+
+def test_legacy_hookcfg_is_runtime_fallback_but_requires_migration(tmp_path: Path) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"codex": "open"})
+    (Path(cfg.data_dir) / "hooks" / ".hookcfg").write_text(
+        "DEFENSECLAW_GATEWAY_ADDR=127.0.0.1:18970\nDEFENSECLAW_FAIL_MODE=open\n",
+        encoding="utf-8",
+    )
+    (home / ".codex" / "config.toml").write_text(
+        '[hooks]\ndefenseclaw = "defenseclaw hook --connector codex"\n', encoding="utf-8"
+    )
+    with patch("defenseclaw.fail_mode.os.name", "nt"), patch("defenseclaw.fail_mode.Path.home", return_value=home):
+        state = resolve_connector_fail_mode(cfg, "codex")
+    assert state.runtime == "open"
+    assert not state.current
+    assert any(reason.startswith("windows-sidecar-legacy") for reason in state.drift)
+
+
+def test_scoped_reconcile_failure_rolls_back_config_and_registration(tmp_path: Path) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"claudecode": "open", "codex": "open"})
+    _write_current_runtime(cfg, home, {"claudecode": "open", "codex": "open"})
+    original_settings = (home / ".claude" / "settings.json").read_bytes()
+    app = AppContext()
+    app.cfg = cfg
+    app.logger = MagicMock()
+
+    def fail_after_partial_write(_cfg: object, _connector: str) -> None:
+        (home / ".claude" / "settings.json").write_text('{"partial":true}', encoding="utf-8")
+        raise OSError("setup failed")
+
+    with (
+        patch("defenseclaw.fail_mode.Path.home", return_value=home),
+        patch(
+            "defenseclaw.commands.cmd_guardrail.reconcile_connector_registration",
+            side_effect=fail_after_partial_write,
+        ),
+    ):
+        result = CliRunner().invoke(
+            cmd_guardrail.fail_mode_cmd,
+            ["closed", "--connector", "claudecode", "--yes"],
+            obj=app,
+        )
+    assert result.exit_code != 0
+    assert cfg.guardrail.connectors["claudecode"].hook_fail_mode == "open"
+    assert (home / ".claude" / "settings.json").read_bytes() == original_settings
+    assert "restored" in result.output
+
+
+def test_truthful_noop_requires_current_runtime(tmp_path: Path) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"claudecode": "closed", "codex": "open"})
+    _write_current_runtime(cfg, home, {"claudecode": "closed", "codex": "open"})
+    app = AppContext()
+    app.cfg = cfg
+    app.logger = MagicMock()
+    with (
+        patch("defenseclaw.fail_mode.os.name", "nt"),
+        patch("defenseclaw.fail_mode.Path.home", return_value=home),
+        patch("defenseclaw.commands.cmd_guardrail.resolve_connector_fail_mode") as resolver,
+        patch("defenseclaw.commands.cmd_guardrail.reconcile_connector_registration") as reconcile,
+    ):
+        resolver.return_value = resolve_connector_fail_mode(cfg, "claudecode")
+        result = CliRunner().invoke(
+            cmd_guardrail.fail_mode_cmd,
+            ["closed", "--connector", "claudecode", "--yes"],
+            obj=app,
+        )
+    assert result.exit_code == 0
+    assert "nothing to do" in result.output
+    reconcile.assert_not_called()
+    cfg.save.assert_not_called()
+
+
+def test_stale_registered_script_digest_rejects_noop(tmp_path: Path) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"claudecode": "closed", "codex": "open"})
+    _write_current_runtime(cfg, home, {"claudecode": "closed", "codex": "open"})
+    (Path(cfg.data_dir) / "hooks" / "claude-code-hook.sh").write_text("stale launcher", encoding="utf-8")
+    with patch("defenseclaw.fail_mode.os.name", "nt"), patch("defenseclaw.fail_mode.Path.home", return_value=home):
+        state = resolve_connector_fail_mode(cfg, "claudecode")
+    assert not state.current
+    assert "registration-digest-stale" in state.drift
+
+
+def test_stale_windows_launcher_digest_rejects_noop(tmp_path: Path) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"claudecode": "closed", "codex": "open"})
+    _write_current_runtime(cfg, home, {"claudecode": "closed", "codex": "open"})
+    (home / ".local" / "bin" / "defenseclaw-hook.exe").write_bytes(b"MZstale-launcher")
+    with patch("defenseclaw.fail_mode.os.name", "nt"), patch(
+        "defenseclaw.fail_mode.Path.home", return_value=home
+    ):
+        state = resolve_connector_fail_mode(cfg, "claudecode")
+    assert not state.current
+    assert "registration-digest-stale" in state.drift
+
+
+def test_unix_registration_freshness_requires_current_script_path(tmp_path: Path) -> None:
+    cfg, home = _runtime_cfg(tmp_path, {"claudecode": "closed"})
+    settings_path = home / ".claude" / "settings.json"
+    settings_path.write_text(
+        json.dumps({"hooks": {"PreToolUse": [{"command": "/stale/claude-code-hook.sh"}]}}),
+        encoding="utf-8",
+    )
+    with patch("defenseclaw.fail_mode.Path.home", return_value=home):
+        assert fail_mode_runtime._unix_registration_freshness(cfg, "claudecode") == "registration-command-stale"
+        expected = str((Path(cfg.data_dir) / "hooks" / "claude-code-hook.sh").resolve())
+        settings_path.write_text(
+            json.dumps({"hooks": {"PreToolUse": [{"command": expected}]}}),
+            encoding="utf-8",
+        )
+        assert fail_mode_runtime._unix_registration_freshness(cfg, "claudecode") is None

--- a/cli/tests/test_multi_connector_config.py
+++ b/cli/tests/test_multi_connector_config.py
@@ -186,6 +186,18 @@ class TestEffectiveResolvers(unittest.TestCase):
         self.assertEqual(g.effective_block_message(""), "")
         self.assertEqual(g.effective_rule_pack_dir(""), "")
 
+    def test_explicit_connector_fail_mode_wins_in_observe(self):
+        g = GuardrailConfig(
+            mode="observe",
+            hook_fail_mode="closed",
+            connectors={
+                "codex": PerConnectorGuardrailConfig(hook_fail_mode="closed"),
+                "claudecode": PerConnectorGuardrailConfig(),
+            },
+        )
+        self.assertEqual(g.effective_hook_fail_mode("codex"), "closed")
+        self.assertEqual(g.effective_hook_fail_mode("claudecode"), "open")
+
     def test_empty_map_equals_absent(self):
         with_empty = GuardrailConfig(mode="action", connectors={})
         absent = GuardrailConfig(mode="action")

--- a/cli/tests/tui/test_setup_panel.py
+++ b/cli/tests/tui/test_setup_panel.py
@@ -2493,6 +2493,7 @@ def test_guardrail_section_renders_effective_per_connector_overrides() -> None:
     assert fields["guardrail.connectors.codex.enabled"].value == "false"
     assert fields["guardrail.connectors.codex.enabled"].kind == "bool"
     assert fields["guardrail.connectors.codex.hook_fail_mode"].value == "closed"
+    assert fields["guardrail.connectors.codex.hook_fail_mode"].kind == "header"
     assert fields["guardrail.connectors.codex.block_message"].value == "codex blocked"
     assert fields["guardrail.connectors.codex.hilt.enabled"].value == "true"
     assert fields["guardrail.connectors.codex.hilt.min_severity"].value == "LOW"
@@ -2503,6 +2504,7 @@ def test_guardrail_section_renders_effective_per_connector_overrides() -> None:
     # hermes has no override → inherits the global effective values.
     assert fields["guardrail.connectors.hermes.enabled"].value == "true"
     assert fields["guardrail.connectors.hermes.hook_fail_mode"].value == "open"
+    assert fields["guardrail.connectors.hermes.hook_fail_mode"].kind == "header"
     assert fields["guardrail.connectors.hermes.block_message"].value == "global blocked"
     assert fields["guardrail.connectors.hermes.hilt.enabled"].value == "false"
     assert fields["guardrail.connectors.hermes.hilt.min_severity"].value == "HIGH"
@@ -2552,10 +2554,20 @@ def test_per_connector_hook_fail_mode_normalizes() -> None:
     cfg = _multi_connector_cfg()
     apply_config_field(cfg, "guardrail.connectors.hermes.hook_fail_mode", "closed")
     assert cfg.guardrail.connectors["hermes"].hook_fail_mode == "closed"
-    assert cfg.guardrail.effective_hook_fail_mode("hermes") == "open"
+    assert cfg.guardrail.effective_hook_fail_mode("hermes") == "closed"
     # Anything that is not "closed" normalizes to "open".
     apply_config_field(cfg, "guardrail.connectors.hermes.hook_fail_mode", "open")
     assert cfg.guardrail.connectors["hermes"].hook_fail_mode == "open"
+
+
+def test_guardrail_editor_uses_runtime_fail_mode_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _multi_connector_cfg()
+    cfg.data_dir = "runtime-state"
+    state = SimpleNamespace(runtime="open", desired="closed")
+    monkeypatch.setattr("defenseclaw.fail_mode.resolve_connector_fail_mode", lambda *_args: state)
+
+    fields = {f.key: f for f in _section(build_setup_sections(cfg), "Guardrail").fields}
+    assert fields["guardrail.connectors.codex.hook_fail_mode"].value == "open"
 
 
 def test_per_connector_block_message_writes_string() -> None:

--- a/internal/cli/connector_cmd.go
+++ b/internal/cli/connector_cmd.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
+	"github.com/defenseclaw/defenseclaw/internal/managed"
 	"github.com/defenseclaw/defenseclaw/internal/version"
 )
 
@@ -274,6 +275,7 @@ func runConnectorReconcile(cmd *cobra.Command, _ []string) error {
 	if cfg != nil {
 		opts.HookFailMode = cfg.EffectiveHookFailModeForConnector(name)
 		opts.HILTEnabled = cfg.EffectiveHILTForConnector(name).Enabled
+		opts.ManagedEnterprise = managed.IsManagedEnterprise(cfg.DeploymentMode)
 	}
 	hookToken, err := connector.LoadHookAPIToken(dataDir, name)
 	if err != nil {

--- a/internal/cli/connector_cmd.go
+++ b/internal/cli/connector_cmd.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
+	"github.com/defenseclaw/defenseclaw/internal/version"
 )
 
 // connectorCmd is the parent for low-level connector lifecycle subcommands
@@ -108,6 +109,16 @@ Exit codes:
 	RunE: runConnectorVerify,
 }
 
+var connectorReconcileCmd = &cobra.Command{
+	Use:   "reconcile",
+	Short: "Refresh one connector's installed runtime registration",
+	Long: `Reconcile the named connector from the current DefenseClaw config.
+
+This is the selected-connector setup primitive used by transactional policy
+mutations. It does not restart the gateway and does not setup peer connectors.`,
+	RunE: runConnectorReconcile,
+}
+
 var connectorListBackupsCmd = &cobra.Command{
 	Use:   "list-backups",
 	Short: "List pristine connector backups stored under the data directory",
@@ -140,6 +151,7 @@ func init() {
 
 	connectorCmd.AddCommand(connectorTeardownCmd)
 	connectorCmd.AddCommand(connectorVerifyCmd)
+	connectorCmd.AddCommand(connectorReconcileCmd)
 	connectorCmd.AddCommand(connectorListBackupsCmd)
 
 	rootCmd.AddCommand(connectorCmd)
@@ -235,7 +247,95 @@ func resolveConnectorOpts(dataDir string) connector.SetupOpts {
 		opts.ProxyAddr = fmt.Sprintf("127.0.0.1:%d", cfg.Guardrail.Port)
 	}
 	opts.WorkspaceDir = cfg.ConnectorWorkspaceDir()
+	opts.APIToken = cfg.Gateway.ResolvedToken()
 	return opts
+}
+
+func runConnectorReconcile(cmd *cobra.Command, _ []string) error {
+	dataDir := resolveConnectorDataDir()
+	if dataDir == "" {
+		return fmt.Errorf("connector reconcile: no data directory configured")
+	}
+	name := resolveActiveConnectorName(dataDir)
+	reg := newConnectorRegistryWithPlugins()
+	conn, ok := reg.Get(name)
+	if !ok {
+		return fmt.Errorf("connector reconcile: unknown connector %q", name)
+	}
+	if name != "claudecode" && name != "codex" {
+		return fmt.Errorf("connector reconcile: selected refresh is supported only for claudecode and codex")
+	}
+	if warning, supportErr := connector.CheckPlatformSupportOnHost(name); supportErr != nil {
+		return fmt.Errorf("connector reconcile %s: %w", name, supportErr)
+	} else if warning != "" {
+		fmt.Fprintf(cmd.ErrOrStderr(), "connector reconcile %s: warning: %s\n", name, warning)
+	}
+	opts := resolveConnectorOpts(dataDir)
+	if cfg != nil {
+		opts.HookFailMode = cfg.EffectiveHookFailModeForConnector(name)
+		opts.HILTEnabled = cfg.EffectiveHILTForConnector(name).Enabled
+	}
+	hookToken, err := connector.LoadHookAPIToken(dataDir, name)
+	if err != nil {
+		return fmt.Errorf("connector reconcile: load scoped hook token: %w", err)
+	}
+	if hookToken == "" {
+		hookToken, err = connector.EnsureHookAPIToken(dataDir, name)
+		if err != nil {
+			return fmt.Errorf("connector reconcile: ensure scoped hook token: %w", err)
+		}
+	}
+	// Match the sidecar's least-privilege registration semantics: Claude and
+	// Codex use the connector-scoped token for both native telemetry and hook
+	// calls. Never write the gateway master token into agent-owned config.
+	opts.APIToken = hookToken
+	opts.HookAPIToken = hookToken
+	opts.HookAPITokenScoped = true
+	opts.AgentVersion = connector.LoadCachedAgentVersion(dataDir, name)
+	previous := connector.LoadHookContractLockEntry(dataDir, name)
+	if opts.AgentVersion == "" {
+		// A scoped policy refresh must not downgrade a previously verified
+		// registration merely because discovery cache cleanup ran between
+		// setups. Reuse the lock's exact observed version as audit evidence.
+		opts.AgentVersion = previous.RawAgentVersion
+	}
+	resolution := connector.ResolveHookContract(name, opts.AgentVersion)
+	opts.HookContractID = resolution.Contract.ContractID
+	actionMode := cfg != nil && strings.EqualFold(
+		strings.TrimSpace(cfg.EffectiveGuardrailModeForConnector(name)), "action",
+	)
+	if connector.HookContractNeedsActionOverride(resolution) && actionMode &&
+		os.Getenv("DEFENSECLAW_ALLOW_HOOK_CONTRACT_DRIFT") != "1" {
+		return fmt.Errorf(
+			"connector reconcile %s: agent version %q is not verified against a known hook contract: %s",
+			name, opts.AgentVersion, resolution.Reason,
+		)
+	}
+	if previous.Connector != "" {
+		current := connector.NewHookContractLockEntry(opts, conn, version.Current().BinaryVersion)
+		if connector.HookContractCompatibilityDrifted(previous, current) && actionMode &&
+			os.Getenv("DEFENSECLAW_ALLOW_HOOK_CONTRACT_DRIFT") != "1" {
+			return fmt.Errorf("connector reconcile %s: hook contract compatibility drift", name)
+		}
+	}
+
+	if err := conn.Setup(cmd.Context(), opts); err != nil {
+		return fmt.Errorf("connector reconcile %s: %w", name, err)
+	}
+	entry := connector.NewHookContractLockEntry(opts, conn, version.Current().BinaryVersion)
+	if err := connector.SaveHookContractLockEntry(dataDir, entry); err != nil {
+		return fmt.Errorf("connector reconcile %s lock: %w", name, err)
+	}
+	if connectorFlagJSON {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+			"connector": name,
+			"action":    "reconcile",
+			"ok":        true,
+			"fail_mode": opts.HookFailMode,
+		})
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "  %s %s runtime reconciled\n", Style("✓", "fg=green", "bold"), name)
+	return nil
 }
 
 func runConnectorTeardown(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/connector_cmd_test.go
+++ b/internal/cli/connector_cmd_test.go
@@ -7,10 +7,12 @@ package cli
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -20,6 +22,64 @@ import (
 	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
 	"github.com/defenseclaw/defenseclaw/internal/testenv"
 )
+
+type testHookContractLock struct {
+	Version                 int                                        `json:"version"`
+	SharedHookScriptDigests map[string]string                          `json:"shared_hook_script_digests"`
+	Connectors              map[string]connector.HookContractLockEntry `json:"connectors"`
+}
+
+func readTestHookContractLock(t *testing.T, dataDir string) testHookContractLock {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(dataDir, "hook_contract_lock.json"))
+	if err != nil {
+		t.Fatalf("read hook contract lock: %v", err)
+	}
+	var lock testHookContractLock
+	if err := json.Unmarshal(body, &lock); err != nil {
+		t.Fatalf("parse hook contract lock: %v", err)
+	}
+	return lock
+}
+
+func fileDigest(t *testing.T, path string) string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read digest target %s: %v", path, err)
+	}
+	sum := sha256.Sum256(body)
+	return fmt.Sprintf("sha256:%x", sum[:])
+}
+
+func assertMixedHookContractsCurrent(t *testing.T, dataDir, home string) testHookContractLock {
+	t.Helper()
+	lock := readTestHookContractLock(t, dataDir)
+	if lock.Version != 2 || len(lock.SharedHookScriptDigests) == 0 {
+		t.Fatalf("shared contract schema not current: %+v", lock)
+	}
+	for name, expected := range lock.SharedHookScriptDigests {
+		if actual := fileDigest(t, filepath.Join(dataDir, "hooks", name)); actual != expected {
+			t.Fatalf("shared digest %s=%s want %s", name, actual, expected)
+		}
+	}
+	for _, name := range []string{"claudecode", "codex"} {
+		entry, ok := lock.Connectors[name]
+		if !ok {
+			t.Fatalf("missing %s contract entry", name)
+		}
+		for artifact, expected := range entry.HookScriptDigests {
+			path := filepath.Join(dataDir, "hooks", artifact)
+			if runtime.GOOS == "windows" && strings.EqualFold(artifact, "defenseclaw-hook.exe") {
+				path = filepath.Join(home, ".local", "bin", "defenseclaw-hook.exe")
+			}
+			if actual := fileDigest(t, path); actual != expected {
+				t.Fatalf("%s artifact %s digest=%s want %s", name, artifact, actual, expected)
+			}
+		}
+	}
+	return lock
+}
 
 // withConnectorState swaps cfg/flags into a known state for one test and
 // restores the originals on teardown. The package-level globals are how
@@ -174,6 +234,149 @@ func TestConnectorReconcileRefreshesOnlySelectedRegistration(t *testing.T) {
 	lock := connector.LoadHookContractLockEntry(dataDir, "codex")
 	if lock.HookFailMode != "closed" {
 		t.Fatalf("lock fail mode = %q, want closed", lock.HookFailMode)
+	}
+}
+
+func TestConnectorReconcileMixedModesKeepsBothContractsCurrent(t *testing.T) {
+	dataDir := testenv.PrivateTempDir(t)
+	home := t.TempDir()
+	testenv.SetHome(t, home)
+	claudePath := filepath.Join(home, ".claude", "settings.json")
+	codexPath := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(claudePath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(codexPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	launcher := filepath.Join(home, ".local", "bin", "defenseclaw-hook.exe")
+	if runtime.GOOS == "windows" {
+		if err := os.MkdirAll(filepath.Dir(launcher), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(launcher, []byte("MZ-native-hook-fixture"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	previousClaudePath := connector.ClaudeCodeSettingsPathOverride
+	previousCodexPath := connector.CodexConfigPathOverride
+	connector.ClaudeCodeSettingsPathOverride = claudePath
+	connector.CodexConfigPathOverride = codexPath
+	t.Cleanup(func() {
+		connector.ClaudeCodeSettingsPathOverride = previousClaudePath
+		connector.CodexConfigPathOverride = previousCodexPath
+	})
+	defer withConnectorState(t, dataDir, "claudecode")()
+	cfg.Guardrail.Enabled = true
+	cfg.Guardrail.HookFailMode = "open"
+	cfg.Guardrail.Connectors = map[string]config.PerConnectorGuardrailConfig{
+		"claudecode": {HookFailMode: "open"},
+		"codex":      {HookFailMode: "open"},
+	}
+	for _, name := range []string{"claudecode", "codex"} {
+		if _, err := connector.EnsureHookAPIToken(dataDir, name); err != nil {
+			t.Fatalf("ensure %s token: %v", name, err)
+		}
+		_, stderr, _ := runConnectorCmd(t, "reconcile", "--connector", name, "--json")
+		if stderr != "" {
+			t.Fatalf("initial %s reconcile: %s", name, stderr)
+		}
+	}
+	initial := assertMixedHookContractsCurrent(t, dataDir, home)
+	codexBefore, err := os.ReadFile(codexPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	codexOwnedBefore := initial.Connectors["codex"].HookScriptDigests["codex-hook.sh"]
+
+	claudeMode := cfg.Guardrail.Connectors["claudecode"]
+	claudeMode.HookFailMode = "closed"
+	cfg.Guardrail.Connectors["claudecode"] = claudeMode
+	_, stderr, _ := runConnectorCmd(t, "reconcile", "--connector", "claudecode", "--json")
+	if stderr != "" {
+		t.Fatalf("Claude close reconcile: %s", stderr)
+	}
+	closed := assertMixedHookContractsCurrent(t, dataDir, home)
+	if closed.Connectors["claudecode"].HookFailMode != "closed" || closed.Connectors["codex"].HookFailMode != "open" {
+		t.Fatalf("mixed lock modes are wrong: Claude=%q Codex=%q", closed.Connectors["claudecode"].HookFailMode, closed.Connectors["codex"].HookFailMode)
+	}
+	codexAfter, err := os.ReadFile(codexPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(codexAfter, codexBefore) || closed.Connectors["codex"].HookScriptDigests["codex-hook.sh"] != codexOwnedBefore {
+		t.Fatal("Claude-only reconciliation changed Codex registration or owned contract")
+	}
+
+	// Seed the exact legacy failure: every connector claims a different hash
+	// for the same shared paths, while disk can match only one.  The normal
+	// selected reconcile must render canonical bytes and migrate atomically.
+	legacyPath := filepath.Join(dataDir, "hook_contract_lock.json")
+	legacyDoc := map[string]interface{}{}
+	legacyBody, err := os.ReadFile(legacyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(legacyBody, &legacyDoc); err != nil {
+		t.Fatal(err)
+	}
+	shared, _ := legacyDoc["shared_hook_script_digests"].(map[string]interface{})
+	delete(legacyDoc, "shared_hook_script_digests")
+	legacyDoc["version"] = float64(1)
+	entries, _ := legacyDoc["connectors"].(map[string]interface{})
+	for connectorName, rawEntry := range entries {
+		entry, _ := rawEntry.(map[string]interface{})
+		digests, _ := entry["hook_script_digests"].(map[string]interface{})
+		for artifact, digest := range shared {
+			if connectorName == "claudecode" {
+				digests[artifact] = "sha256:legacy-claude-divergent"
+			} else {
+				digests[artifact] = digest
+			}
+		}
+	}
+	legacyBody, err = json.MarshalIndent(legacyDoc, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, append(legacyBody, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, stderr, _ = runConnectorCmd(t, "reconcile", "--connector", "claudecode", "--json")
+	if stderr != "" {
+		t.Fatalf("legacy migration reconcile: %s", stderr)
+	}
+	assertMixedHookContractsCurrent(t, dataDir, home)
+
+	// Reverse the mixed state and repeatedly switch one connector.  Every
+	// intermediate lock must validate both registrations simultaneously.
+	claudeMode = cfg.Guardrail.Connectors["claudecode"]
+	claudeMode.HookFailMode = "open"
+	cfg.Guardrail.Connectors["claudecode"] = claudeMode
+	_, stderr, _ = runConnectorCmd(t, "reconcile", "--connector", "claudecode", "--json")
+	if stderr != "" {
+		t.Fatalf("Claude reopen reconcile: %s", stderr)
+	}
+	codexMode := cfg.Guardrail.Connectors["codex"]
+	codexMode.HookFailMode = "closed"
+	cfg.Guardrail.Connectors["codex"] = codexMode
+	_, stderr, _ = runConnectorCmd(t, "reconcile", "--connector", "codex", "--json")
+	if stderr != "" {
+		t.Fatalf("Codex close reconcile: %s", stderr)
+	}
+	reverse := assertMixedHookContractsCurrent(t, dataDir, home)
+	if reverse.Connectors["claudecode"].HookFailMode != "open" || reverse.Connectors["codex"].HookFailMode != "closed" {
+		t.Fatalf("reverse mixed modes are wrong: %+v", reverse.Connectors)
+	}
+	for _, mode := range []string{"closed", "open", "closed", "open"} {
+		claudeMode = cfg.Guardrail.Connectors["claudecode"]
+		claudeMode.HookFailMode = mode
+		cfg.Guardrail.Connectors["claudecode"] = claudeMode
+		_, stderr, _ = runConnectorCmd(t, "reconcile", "--connector", "claudecode", "--json")
+		if stderr != "" {
+			t.Fatalf("repeated Claude %s reconcile: %s", mode, stderr)
+		}
+		assertMixedHookContractsCurrent(t, dataDir, home)
 	}
 }
 

--- a/internal/cli/connector_cmd_test.go
+++ b/internal/cli/connector_cmd_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
 	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
+	"github.com/defenseclaw/defenseclaw/internal/testenv"
 )
 
 // withConnectorState swaps cfg/flags into a known state for one test and
@@ -101,6 +102,8 @@ func runConnectorCmd(t *testing.T, args ...string) (stdout, stderr string, exitC
 		err = runConnectorTeardown(cmd, nil)
 	case "verify":
 		err = runConnectorVerify(cmd, nil)
+	case "reconcile":
+		err = runConnectorReconcile(cmd, nil)
 	default:
 		t.Fatalf("unknown subcommand for harness: %s", sub)
 	}
@@ -108,6 +111,70 @@ func runConnectorCmd(t *testing.T, args ...string) (stdout, stderr string, exitC
 		fmt.Fprintln(&errb, err.Error())
 	}
 	return out.String(), errb.String(), exitCode
+}
+
+func TestConnectorReconcileRefreshesOnlySelectedRegistration(t *testing.T) {
+	dataDir := testenv.PrivateTempDir(t)
+	home := t.TempDir()
+	codexPath := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(codexPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	claudePath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(claudePath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	claudeBefore := []byte(`{"sentinel":"peer-registration"}`)
+	if err := os.WriteFile(claudePath, claudeBefore, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	originalCodexPath := connector.CodexConfigPathOverride
+	connector.CodexConfigPathOverride = codexPath
+	t.Cleanup(func() { connector.CodexConfigPathOverride = originalCodexPath })
+
+	defer withConnectorState(t, dataDir, "codex")()
+	scopedToken, err := connector.EnsureHookAPIToken(dataDir, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Gateway.Token = "master-token-must-not-be-registered"
+	cfg.Guardrail.Enabled = true
+	cfg.Guardrail.HookFailMode = "open"
+	cfg.Guardrail.Connectors = map[string]config.PerConnectorGuardrailConfig{
+		"codex":      {HookFailMode: "closed"},
+		"claudecode": {HookFailMode: "open"},
+	}
+	stdout, stderr, _ := runConnectorCmd(t, "reconcile", "--connector", "codex", "--json")
+	if stderr != "" {
+		t.Fatalf("reconcile stderr: %s", stderr)
+	}
+	if !strings.Contains(stdout, `"fail_mode":"closed"`) {
+		t.Fatalf("reconcile output = %s", stdout)
+	}
+	if _, err := os.Stat(codexPath); err != nil {
+		t.Fatalf("selected Codex registration missing: %v", err)
+	}
+	codexRegistration, err := os.ReadFile(codexPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(codexRegistration, []byte(cfg.Gateway.Token)) {
+		t.Fatal("selected registration contains the gateway master token")
+	}
+	if !bytes.Contains(codexRegistration, []byte(scopedToken)) {
+		t.Fatal("selected registration does not contain the connector-scoped token")
+	}
+	claudeAfter, err := os.ReadFile(claudePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(claudeAfter, claudeBefore) {
+		t.Fatalf("peer Claude registration changed: %s", claudeAfter)
+	}
+	lock := connector.LoadHookContractLockEntry(dataDir, "codex")
+	if lock.HookFailMode != "closed" {
+		t.Fatalf("lock fail mode = %q, want closed", lock.HookFailMode)
+	}
 }
 
 func TestResolveActiveConnectorName_FlagWins(t *testing.T) {

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -17,6 +17,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -192,7 +193,7 @@ func buildHookOptions(connector, event, apiAddr, failMode string) hookexec.Optio
 		failMode = v
 	}
 	if failMode == "" {
-		failMode = sidecar["DEFENSECLAW_FAIL_MODE"]
+		failMode = hookSidecarFailMode(sidecar, connector)
 	}
 
 	opts := hookexec.Options{
@@ -225,14 +226,30 @@ func buildHookOptions(connector, event, apiAddr, failMode string) hookexec.Optio
 	return opts
 }
 
-// readHookSidecar parses the hooks/.hookcfg file setup writes on Windows. It is
-// a small `KEY=value` file (DEFENSECLAW_GATEWAY_ADDR, DEFENSECLAW_FAIL_MODE); an
-// absent or unreadable file yields an empty map so callers fall back to flags,
-// environment, then defaults. Values may be optionally quoted.
+// readHookSidecar parses the hooks/.hookcfg file setup writes on Windows.
+// Version 2 is JSON with a connector-keyed fail_modes map. The legacy
+// KEY=value shape remains readable so the first connector refresh can migrate
+// an existing install without changing its runtime behavior beforehand.
 func readHookSidecar(path string) map[string]string {
 	out := map[string]string{}
 	data, err := os.ReadFile(path)
 	if err != nil {
+		return out
+	}
+	var current struct {
+		Version     int               `json:"version"`
+		GatewayAddr string            `json:"gateway_addr"`
+		FailModes   map[string]string `json:"fail_modes"`
+		LegacyMode  string            `json:"legacy_fail_mode"`
+	}
+	if json.Unmarshal(data, &current) == nil && current.Version >= 2 {
+		out["DEFENSECLAW_GATEWAY_ADDR"] = current.GatewayAddr
+		for connector, mode := range current.FailModes {
+			out[hookSidecarFailModeKey(connector)] = mode
+		}
+		if current.LegacyMode != "" {
+			out["DEFENSECLAW_FAIL_MODE"] = current.LegacyMode
+		}
 		return out
 	}
 	for _, line := range strings.Split(string(data), "\n") {
@@ -257,6 +274,19 @@ func readHookSidecar(path string) map[string]string {
 		}
 	}
 	return out
+}
+
+func hookSidecarFailMode(sidecar map[string]string, connector string) string {
+	if mode := sidecar[hookSidecarFailModeKey(connector)]; mode != "" {
+		return mode
+	}
+	return sidecar["DEFENSECLAW_FAIL_MODE"]
+}
+
+func hookSidecarFailModeKey(connector string) string {
+	name := strings.ToUpper(strings.TrimSpace(connector))
+	name = strings.NewReplacer("-", "", "_", "", " ", "").Replace(name)
+	return "DEFENSECLAW_FAIL_MODE_" + name
 }
 
 // hookIsLoopbackAddr reports whether addr ("host:port" or a bare host) targets

--- a/internal/cli/hook_test.go
+++ b/internal/cli/hook_test.go
@@ -160,6 +160,27 @@ func TestBuildHookOptionsSidecarFallback(t *testing.T) {
 	}
 }
 
+func TestBuildHookOptionsConnectorScopedSidecarMixedModes(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("DEFENSECLAW_HOME", home)
+	t.Setenv("DEFENSECLAW_GATEWAY_ADDR", "")
+	t.Setenv("DEFENSECLAW_FAIL_MODE", "")
+	writeHookSidecarForTest(t, home, `{
+  "version": 2,
+  "gateway_addr": "127.0.0.1:12345",
+  "fail_modes": {"claudecode": "closed", "codex": "open"}
+}`)
+
+	claude := buildHookOptions("claudecode", "", "", "")
+	codex := buildHookOptions("codex", "", "", "")
+	if claude.FailMode != "closed" || codex.FailMode != "open" {
+		t.Fatalf("mixed sidecar collapsed: Claude=%q Codex=%q", claude.FailMode, codex.FailMode)
+	}
+	if claude.APIAddr != "127.0.0.1:12345" || codex.APIAddr != claude.APIAddr {
+		t.Fatalf("shared gateway address not preserved: Claude=%q Codex=%q", claude.APIAddr, codex.APIAddr)
+	}
+}
+
 func TestBuildHookOptionsFlagAndEnvBeatSidecar(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("DEFENSECLAW_HOME", home)

--- a/internal/config/application_protection.go
+++ b/internal/config/application_protection.go
@@ -343,9 +343,6 @@ func (c *Config) EffectiveHookFailModeForConnector(connector string) string {
 	if c == nil {
 		return "closed"
 	}
-	if !strings.EqualFold(strings.TrimSpace(c.EffectiveGuardrailModeForConnector(connector)), "action") {
-		return "open"
-	}
 	if pc, ok := c.appProtectionGuardrailOverride(connector); ok {
 		if strings.TrimSpace(pc.HookFailMode) != "" {
 			if strings.EqualFold(strings.TrimSpace(pc.HookFailMode), "open") {

--- a/internal/config/application_protection_test.go
+++ b/internal/config/application_protection_test.go
@@ -157,8 +157,8 @@ func TestApplicationProtectionManualGuardrailPrecedence(t *testing.T) {
 	if got := cfg.EffectiveGuardrailModeForConnector("codex"); got != "observe" {
 		t.Errorf("manual mode should win, got %q", got)
 	}
-	if got := cfg.EffectiveHookFailModeForConnector("codex"); got != "open" {
-		t.Errorf("manual observe mode should force hook fail-open, got %q", got)
+	if got := cfg.EffectiveHookFailModeForConnector("codex"); got != "closed" {
+		t.Errorf("manual connector fail mode should remain independent of observe mode, got %q", got)
 	}
 	if got := cfg.EffectiveBlockMessageForConnector("codex"); got != "manual block" {
 		t.Errorf("manual block message should win, got %q", got)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1012,11 +1012,9 @@ func (c *WebhookConfig) ResolvedSecret() string {
 //     templates (codex-hook.sh, claude-code-hook.sh, inspect-*).
 //     It governs what those scripts do when the gateway returns a
 //     RESPONSE-LAYER failure (4xx, malformed JSON, missing
-//     `action` field). Its default is "open" because silently
-//     bricking the agent on a transient response error is worse
-//     than allowing one tool call. Transport-layer failures
-//     (gateway unreachable / 5xx) are handled separately and
-//     ALWAYS allow unless DEFENSECLAW_STRICT_AVAILABILITY=1.
+//     `action` field) or cannot be reached. Explicit "open" allows;
+//     "closed" blocks. DEFENSECLAW_STRICT_AVAILABILITY=1 remains an
+//     unconditional force-closed override.
 //
 //   - AgentHookConfig.FailMode (yaml: <connector>.fail_mode below)
 //     is a per-connector POLICY-LAYER hint that downstream
@@ -1394,30 +1392,20 @@ type GuardrailConfig struct {
 	// and emitted as an EventEgress with branch="shape".
 	AllowUnknownLLMDomains bool `mapstructure:"allow_unknown_llm_domains" yaml:"allow_unknown_llm_domains,omitempty"`
 
-	// HookFailMode is the operator-chosen response-layer fail mode
+	// HookFailMode is the operator-chosen hook failure mode
 	// for every generated hook script (codex-hook, claude-code-hook,
 	// inspect-*). Two values are supported:
 	//
-	//   - "open" (default, recommended): when the gateway answers
-	//     with a 4xx, malformed JSON, or a missing action field, the
-	//     hook ALLOWS the tool/prompt with a stderr warning and an
-	//     entry in $DEFENSECLAW_HOME/logs/hook-failures.jsonl. The
-	//     rationale: a misbehaving gateway that bricks every agent
-	//     interaction is strictly worse UX than a brief observability
-	//     gap, and the operator can detect the problem from the log.
+	//   - "closed" (secure default): malformed/incomplete responses,
+	//     authorization failures, and transport failures BLOCK the tool/
+	//     prompt (exit 2). Existing installs migrated from the legacy
+	//     behavior persist an explicit "open" value.
 	//
-	//   - "closed": the same response-layer failures BLOCK the tool/
-	//     prompt (exit 2). Choose when you'd rather take the agent
-	//     offline than miss a policy decision (e.g., regulated
-	//     workflows where every prompt MUST be inspected).
+	//   - "open": the same failure classes ALLOW the tool/prompt with a
+	//     stderr warning and a structured hook-failure audit record.
 	//
-	// This field governs ONLY response-layer failures. Transport-
-	// layer failures (gateway unreachable / 5xx) are handled
-	// separately by each hook's fail_unreachable helper and ALWAYS
-	// allow unless the operator opts into strict availability via
-	// DEFENSECLAW_STRICT_AVAILABILITY=1 — regardless of this field's
-	// value. See internal/gateway/connector/hooks/_hardening.sh for
-	// the rationale.
+	// DEFENSECLAW_STRICT_AVAILABILITY=1 remains an unconditional
+	// force-closed override.
 	//
 	// `defenseclaw setup guardrail` prompts for this when the install
 	// is fresh or when the operator changes guardrail.mode (observe
@@ -1758,17 +1746,14 @@ func (g *GuardrailConfig) EffectiveHookFailMode() string {
 }
 
 // EffectiveHookFailModeFor returns the hook fail mode for the named
-// connector. Observe mode is always fail-open: it may record findings but
-// cannot turn an internal hook failure into enforcement. In action mode a
-// per-connector override (when set) wins, otherwise the global fail mode is
-// used. Pass "" to resolve the global connector mode/value. Pure lookup —
-// never errors, never mutates.
+// connector. An explicit connector override wins even in observe mode: it is
+// an operator-selected response-integrity posture, not a policy verdict.
+// Observe-only connectors without an override retain the historical fail-open
+// behavior; action mode falls through to the global value. Pass "" to resolve
+// the global connector mode/value. Pure lookup — never errors, never mutates.
 func (g *GuardrailConfig) EffectiveHookFailModeFor(connector string) string {
 	if g == nil {
 		return "closed"
-	}
-	if !strings.EqualFold(strings.TrimSpace(g.EffectiveMode(connector)), "action") {
-		return "open"
 	}
 	if pc, ok := g.connectorOverride(connector); ok {
 		if strings.TrimSpace(pc.HookFailMode) != "" {
@@ -1782,6 +1767,9 @@ func (g *GuardrailConfig) EffectiveHookFailModeFor(connector string) string {
 			}
 			return "closed"
 		}
+	}
+	if !strings.EqualFold(strings.TrimSpace(g.EffectiveMode(connector)), "action") {
+		return "open"
 	}
 	return g.EffectiveHookFailMode()
 }
@@ -3256,9 +3244,10 @@ func setDefaults(dataDir string) {
 
 	viper.SetDefault("guardrail.enabled", false)
 	viper.SetDefault("guardrail.mode", "observe")
-	// "closed" is the safer default — response-layer failures (4xx,
-	// malformed JSON, missing action) BLOCK the tool/prompt rather
-	// than silently allowing it. Pre-existing operators are protected
+	// "closed" is the safer default — malformed/incomplete responses,
+	// authorization failures, and transport failures BLOCK rather than
+	// silently allowing an uninspected action. Pre-existing operators are
+	// protected
 	// by _migrate_0_4_0_seed_hook_fail_mode (migrations.py) which
 	// writes ``hook_fail_mode: open`` to existing config.yaml so prior
 	// behavior is preserved on upgrade. Operators who explicitly want

--- a/internal/config/multi_connector_test.go
+++ b/internal/config/multi_connector_test.go
@@ -197,8 +197,8 @@ func TestEffectiveResolvers_SafeFallbacks(t *testing.T) {
 	if got := g.EffectiveMode(""); got != "observe" {
 		t.Errorf("EffectiveMode empty = %q, want observe", got)
 	}
-	// Observe mode always resolves fail-open: findings remain visible but an
-	// internal hook error cannot become enforcement.
+	// An observe-only connector with no explicit override retains the
+	// historical fail-open behavior on every platform.
 	if got := g.EffectiveHookFailModeFor(""); got != "open" {
 		t.Errorf("EffectiveHookFailModeFor empty = %q, want open", got)
 	}
@@ -216,6 +216,23 @@ func TestEffectiveResolvers_SafeFallbacks(t *testing.T) {
 	}
 	if got := nilG.EffectiveHILT("x"); got != (HILTConfig{}) {
 		t.Errorf("nil EffectiveHILT = %+v, want zero", got)
+	}
+}
+
+func TestEffectiveHookFailMode_ExplicitOverrideWinsInObserve(t *testing.T) {
+	g := &GuardrailConfig{
+		Mode:         "observe",
+		HookFailMode: "closed",
+		Connectors: map[string]PerConnectorGuardrailConfig{
+			"codex":      {HookFailMode: "closed"},
+			"claudecode": {},
+		},
+	}
+	if got := g.EffectiveHookFailModeFor("codex"); got != "closed" {
+		t.Fatalf("explicit connector fail mode = %q, want closed", got)
+	}
+	if got := g.EffectiveHookFailModeFor("claudecode"); got != "open" {
+		t.Fatalf("unoverridden observe connector fail mode = %q, want open", got)
 	}
 }
 

--- a/internal/gateway/connector/connector.go
+++ b/internal/gateway/connector/connector.go
@@ -85,12 +85,11 @@ type SetupOpts struct {
 
 	// HookFailMode is the operator-chosen response-layer fail mode
 	// baked into every hook script we write. Values: "open" (default,
-	// allow on response-layer failures) or "closed" (block on
-	// response-layer failures). The sidecar populates this from
+	// allow on response or transport failures) or "closed" (block on
+	// either failure class). The sidecar populates this from
 	// cfg.Guardrail.EffectiveHookFailMode(); empty string is treated as
-	// the default ("open"). Transport-layer failures (gateway unreachable /
-	// 5xx) are governed separately by DEFENSECLAW_STRICT_AVAILABILITY in
-	// the hook scripts themselves and are NOT controlled by this field.
+	// the secure default ("closed"). DEFENSECLAW_STRICT_AVAILABILITY remains
+	// an unconditional force-closed override in generated hooks.
 	HookFailMode string
 
 	// HILTEnabled tells connectors with native approval surfaces to wire

--- a/internal/gateway/connector/connector_state.go
+++ b/internal/gateway/connector/connector_state.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -31,6 +32,13 @@ import (
 
 const activeConnectorFile = "active_connector.json"
 const hookContractLockFile = "hook_contract_lock.json"
+
+// hookContractLockVersion 2 separates artifacts that have one physical copy
+// per data directory from connector-owned registration artifacts.  Version 1
+// repeated the shared inspect-script hashes in every connector entry, which
+// could make a mixed installation impossible to validate when a selected
+// connector rendered different bytes into those shared paths.
+const hookContractLockVersion = 2
 
 // activeConnectorStateVersion is the schema version written by
 // SaveActiveConnectors. Version 2 introduced the multi-connector "names"
@@ -55,9 +63,10 @@ type connectorState struct {
 }
 
 type hookContractLock struct {
-	Version    int                              `json:"version"`
-	UpdatedAt  string                           `json:"updated_at"`
-	Connectors map[string]HookContractLockEntry `json:"connectors"`
+	Version                 int                              `json:"version"`
+	UpdatedAt               string                           `json:"updated_at"`
+	SharedHookScriptDigests map[string]string                `json:"shared_hook_script_digests,omitempty"`
+	Connectors              map[string]HookContractLockEntry `json:"connectors"`
 }
 
 // HookContractLockEntry is the persisted reproduction record for the hook
@@ -185,24 +194,81 @@ func SaveHookContractLockEntry(dataDir string, entry HookContractLockEntry) erro
 	path := filepath.Join(dataDir, hookContractLockFile)
 	return withFileLock(path, func() error {
 		entry.Connector = normalizeConnectorName(entry.Connector)
-		if entry.UpdatedAt == "" {
-			entry.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		entry.HookScriptDigests = cloneHookScriptDigests(entry.HookScriptDigests)
+		lock, err := loadHookContractLockForUpdate(dataDir)
+		if err != nil {
+			return fmt.Errorf("load hook contract lock for update: %w", err)
 		}
-		lock := loadHookContractLock(dataDir)
-		if lock.Version == 0 {
-			lock.Version = 1
+		if err := validateHookRuntimeStateForContract(dataDir, entry.Connector, entry.HookFailMode); err != nil {
+			return fmt.Errorf("validate hook runtime state for contract: %w", err)
 		}
 		if lock.Connectors == nil {
 			lock.Connectors = map[string]HookContractLockEntry{}
 		}
+
+		// Controlled setup has just rendered the canonical shared scripts.
+		// Extract their physical hashes once at the lock root and remove every
+		// legacy per-connector copy atomically.  We never choose between
+		// divergent v1 entries: the freshly rendered, on-disk artifacts are the
+		// sole migration input.
+		shared := takeSharedHookScriptDigests(entry.HookScriptDigests)
+		expectedShared := len(genericHookScripts) + len(hookHelperScripts)
+		if len(shared) > 0 && len(shared) != expectedShared {
+			return fmt.Errorf("incomplete shared hook digest set: got %d, want %d", len(shared), expectedShared)
+		}
+		lockChanged := false
+		if len(shared) > 0 {
+			if !reflect.DeepEqual(lock.SharedHookScriptDigests, shared) {
+				lock.SharedHookScriptDigests = shared
+				lockChanged = true
+			}
+			if lock.Version != hookContractLockVersion {
+				lock.Version = hookContractLockVersion
+				lockChanged = true
+			}
+		}
+		if len(lock.SharedHookScriptDigests) > 0 {
+			for name, peer := range lock.Connectors {
+				if removeSharedHookScriptDigests(peer.HookScriptDigests) {
+					lock.Connectors[name] = peer
+					lockChanged = true
+				}
+			}
+		}
+		// The Windows native launcher is also one physical artifact, but its
+		// per-connector location remains in the v1-compatible entry schema.
+		// Normalize every peer reference to the selected setup's current digest
+		// so legacy divergence cannot make registrations mutually exclusive.
+		if launcherDigest := entry.HookScriptDigests[windowsHookBinaryName]; launcherDigest != "" {
+			for name, peer := range lock.Connectors {
+				if peer.HookScriptDigests == nil {
+					peer.HookScriptDigests = map[string]string{}
+				}
+				if peer.HookScriptDigests[windowsHookBinaryName] != launcherDigest {
+					peer.HookScriptDigests[windowsHookBinaryName] = launcherDigest
+					lock.Connectors[name] = peer
+					lockChanged = true
+				}
+			}
+		}
+		removeSharedHookScriptDigests(entry.HookScriptDigests)
+
+		entryChanged := true
 		if previous, ok := lock.Connectors[entry.Connector]; ok {
 			previousComparison := previous
 			entryComparison := entry
 			previousComparison.UpdatedAt = ""
 			entryComparison.UpdatedAt = ""
 			if reflect.DeepEqual(previousComparison, entryComparison) {
-				return nil
+				entryChanged = false
+				entry.UpdatedAt = previous.UpdatedAt
 			}
+		}
+		if !entryChanged && !lockChanged {
+			return nil
+		}
+		if entry.UpdatedAt == "" {
+			entry.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 		}
 		lock.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 		lock.Connectors[entry.Connector] = entry
@@ -219,20 +285,55 @@ func ClearHookContractLockEntry(dataDir, connectorName string) error {
 	if strings.TrimSpace(dataDir) == "" {
 		return nil
 	}
+	connectorName = normalizeConnectorName(connectorName)
 	path := filepath.Join(dataDir, hookContractLockFile)
 	return withFileLock(path, func() error {
-		lock := loadHookContractLock(dataDir)
-		if len(lock.Connectors) == 0 {
-			return nil
-		}
-		delete(lock.Connectors, normalizeConnectorName(connectorName))
-		lock.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-		data, err := json.MarshalIndent(lock, "", "  ")
+		lock, err := loadHookContractLockForUpdate(dataDir)
 		if err != nil {
-			return err
+			return fmt.Errorf("load hook contract lock for clear: %w", err)
 		}
-		data = append(data, '\n')
-		return atomicWriteFile(path, data, 0o600)
+		_, contractExists := lock.Connectors[connectorName]
+		var contractBody []byte
+		if contractExists {
+			delete(lock.Connectors, connectorName)
+			if len(lock.Connectors) == 0 {
+				lock.SharedHookScriptDigests = nil
+			}
+			lock.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+			contractBody, err = json.MarshalIndent(lock, "", "  ")
+			if err != nil {
+				return err
+			}
+			contractBody = append(contractBody, '\n')
+		}
+
+		hookDir := filepath.Join(dataDir, "hooks")
+		if _, err := os.Stat(hookDir); os.IsNotExist(err) {
+			if contractExists {
+				return atomicWriteFile(path, contractBody, 0o600)
+			}
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("inspect hook runtime directory: %w", err)
+		}
+
+		runtimePath := filepath.Join(hookDir, hookConfigSidecarName)
+		return withFileLock(runtimePath, func() error {
+			snapshots, err := clearHookConfigSidecarEntryLocked(hookDir, connectorName)
+			if err != nil {
+				return fmt.Errorf("clear hook runtime state for %s: %w", connectorName, err)
+			}
+			if !contractExists {
+				return nil
+			}
+			if err := atomicWriteFile(path, contractBody, 0o600); err != nil {
+				if restoreErr := restoreHookRuntimeFiles(snapshots); restoreErr != nil {
+					return fmt.Errorf("write cleared hook contract lock: %v (%v)", err, restoreErr)
+				}
+				return fmt.Errorf("write cleared hook contract lock: %w", err)
+			}
+			return nil
+		})
 	})
 }
 
@@ -362,12 +463,67 @@ func HookScriptDigests(opts SetupOpts, conn Connector) map[string]string {
 	return out
 }
 
+func sharedHookScriptName(name string) bool {
+	for _, candidate := range genericHookScripts {
+		if name == candidate {
+			return true
+		}
+	}
+	for _, candidate := range hookHelperScripts {
+		if name == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneHookScriptDigests(digests map[string]string) map[string]string {
+	if digests == nil {
+		return nil
+	}
+	cloned := make(map[string]string, len(digests))
+	for name, digest := range digests {
+		cloned[name] = digest
+	}
+	return cloned
+}
+
+func takeSharedHookScriptDigests(digests map[string]string) map[string]string {
+	if len(digests) == 0 {
+		return nil
+	}
+	shared := map[string]string{}
+	for name, digest := range digests {
+		if sharedHookScriptName(name) {
+			shared[name] = digest
+		}
+	}
+	if len(shared) == 0 {
+		return nil
+	}
+	return shared
+}
+
+func removeSharedHookScriptDigests(digests map[string]string) bool {
+	changed := false
+	for name := range digests {
+		if sharedHookScriptName(name) {
+			delete(digests, name)
+			changed = true
+		}
+	}
+	return changed
+}
+
 func hookRuntimeArtifactPaths(opts SetupOpts, conn Connector) []string {
 	var paths []string
 	if provider, ok := conn.(HookRuntimeArtifactProvider); ok {
 		paths = append(paths, provider.HookRuntimeArtifacts(opts)...)
 	} else {
 		paths = append(paths, hookScriptPathsForConnector(opts, conn)...)
+		for _, name := range hookHelperScripts {
+			paths = append(paths, filepath.Join(opts.DataDir, "hooks", name))
+		}
 	}
 	if runtime.GOOS == "windows" && conn != nil {
 		name := normalizeConnectorName(conn.Name())
@@ -426,4 +582,32 @@ func loadHookContractLock(dataDir string) hookContractLock {
 		lock.Version = 1
 	}
 	return lock
+}
+
+func loadHookContractLockForUpdate(dataDir string) (hookContractLock, error) {
+	empty := hookContractLock{Version: 1, Connectors: map[string]HookContractLockEntry{}}
+	if strings.TrimSpace(dataDir) == "" {
+		return empty, nil
+	}
+	data, err := os.ReadFile(filepath.Join(dataDir, hookContractLockFile))
+	if os.IsNotExist(err) {
+		return empty, nil
+	}
+	if err != nil {
+		return hookContractLock{}, err
+	}
+	var lock hookContractLock
+	if err := json.Unmarshal(data, &lock); err != nil {
+		return hookContractLock{}, err
+	}
+	if lock.Version == 0 {
+		lock.Version = 1
+	}
+	if lock.Version < 1 || lock.Version > hookContractLockVersion {
+		return hookContractLock{}, fmt.Errorf("unsupported hook contract lock version %d", lock.Version)
+	}
+	if lock.Connectors == nil {
+		lock.Connectors = map[string]HookContractLockEntry{}
+	}
+	return lock, nil
 }

--- a/internal/gateway/connector/connector_state.go
+++ b/internal/gateway/connector/connector_state.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -75,6 +76,7 @@ type HookContractLockEntry struct {
 	HookScriptDigests      map[string]string  `json:"hook_script_digests,omitempty"`
 	Locations              ConnectorLocations `json:"locations,omitempty"`
 	DefenseClawVersion     string             `json:"defenseclaw_version,omitempty"`
+	HookFailMode           string             `json:"hook_fail_mode,omitempty"`
 	UpdatedAt              string             `json:"updated_at"`
 }
 
@@ -180,52 +182,58 @@ func SaveHookContractLockEntry(dataDir string, entry HookContractLockEntry) erro
 	if strings.TrimSpace(dataDir) == "" || strings.TrimSpace(entry.Connector) == "" {
 		return nil
 	}
-	entry.Connector = normalizeConnectorName(entry.Connector)
-	if entry.UpdatedAt == "" {
-		entry.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-	}
-	lock := loadHookContractLock(dataDir)
-	if lock.Version == 0 {
-		lock.Version = 1
-	}
-	if lock.Connectors == nil {
-		lock.Connectors = map[string]HookContractLockEntry{}
-	}
-	if previous, ok := lock.Connectors[entry.Connector]; ok {
-		previousComparison := previous
-		entryComparison := entry
-		previousComparison.UpdatedAt = ""
-		entryComparison.UpdatedAt = ""
-		if reflect.DeepEqual(previousComparison, entryComparison) {
-			return nil
+	path := filepath.Join(dataDir, hookContractLockFile)
+	return withFileLock(path, func() error {
+		entry.Connector = normalizeConnectorName(entry.Connector)
+		if entry.UpdatedAt == "" {
+			entry.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 		}
-	}
-	if entry.UpdatedAt == "" {
-		entry.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-	}
-	lock.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-	lock.Connectors[entry.Connector] = entry
-	data, err := json.MarshalIndent(lock, "", "  ")
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-	return atomicWriteFile(filepath.Join(dataDir, hookContractLockFile), data, 0o600)
+		lock := loadHookContractLock(dataDir)
+		if lock.Version == 0 {
+			lock.Version = 1
+		}
+		if lock.Connectors == nil {
+			lock.Connectors = map[string]HookContractLockEntry{}
+		}
+		if previous, ok := lock.Connectors[entry.Connector]; ok {
+			previousComparison := previous
+			entryComparison := entry
+			previousComparison.UpdatedAt = ""
+			entryComparison.UpdatedAt = ""
+			if reflect.DeepEqual(previousComparison, entryComparison) {
+				return nil
+			}
+		}
+		lock.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		lock.Connectors[entry.Connector] = entry
+		data, err := json.MarshalIndent(lock, "", "  ")
+		if err != nil {
+			return err
+		}
+		data = append(data, '\n')
+		return atomicWriteFile(path, data, 0o600)
+	})
 }
 
 func ClearHookContractLockEntry(dataDir, connectorName string) error {
-	lock := loadHookContractLock(dataDir)
-	if len(lock.Connectors) == 0 {
+	if strings.TrimSpace(dataDir) == "" {
 		return nil
 	}
-	delete(lock.Connectors, normalizeConnectorName(connectorName))
-	lock.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-	data, err := json.MarshalIndent(lock, "", "  ")
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-	return atomicWriteFile(filepath.Join(dataDir, hookContractLockFile), data, 0o600)
+	path := filepath.Join(dataDir, hookContractLockFile)
+	return withFileLock(path, func() error {
+		lock := loadHookContractLock(dataDir)
+		if len(lock.Connectors) == 0 {
+			return nil
+		}
+		delete(lock.Connectors, normalizeConnectorName(connectorName))
+		lock.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		data, err := json.MarshalIndent(lock, "", "  ")
+		if err != nil {
+			return err
+		}
+		data = append(data, '\n')
+		return atomicWriteFile(path, data, 0o600)
+	})
 }
 
 func NewHookContractLockEntry(opts SetupOpts, conn Connector, defenseClawVersion string) HookContractLockEntry {
@@ -251,6 +259,7 @@ func NewHookContractLockEntry(opts SetupOpts, conn Connector, defenseClawVersion
 		HookScriptDigests:      HookScriptDigests(opts, conn),
 		Locations:              ResolvedConnectorLocations(opts, conn),
 		DefenseClawVersion:     defenseClawVersion,
+		HookFailMode:           normalizeHookFailMode(opts.HookFailMode),
 		UpdatedAt:              time.Now().UTC().Format(time.RFC3339),
 	}
 	if opts.HookContractID != "" {
@@ -354,10 +363,22 @@ func HookScriptDigests(opts SetupOpts, conn Connector) map[string]string {
 }
 
 func hookRuntimeArtifactPaths(opts SetupOpts, conn Connector) []string {
+	var paths []string
 	if provider, ok := conn.(HookRuntimeArtifactProvider); ok {
-		return uniqueNonEmptyStrings(provider.HookRuntimeArtifacts(opts))
+		paths = append(paths, provider.HookRuntimeArtifacts(opts)...)
+	} else {
+		paths = append(paths, hookScriptPathsForConnector(opts, conn)...)
 	}
-	return hookScriptPathsForConnector(opts, conn)
+	if runtime.GOOS == "windows" && conn != nil {
+		name := normalizeConnectorName(conn.Name())
+		if name == "claudecode" || name == "codex" {
+			// The registered Windows command executes this PE directly. Record
+			// its digest and exact location so status/no-op checks detect an
+			// obsolete launcher even when the agent config path is unchanged.
+			paths = append(paths, defenseclawHookBinary())
+		}
+	}
+	return uniqueNonEmptyStrings(paths)
 }
 
 func LoadCachedAgentVersion(dataDir, connectorName string) string {

--- a/internal/gateway/connector/connector_test.go
+++ b/internal/gateway/connector/connector_test.go
@@ -3776,7 +3776,7 @@ func TestZeptoClaw_Setup_IsIdempotent(t *testing.T) {
 	}
 }
 
-func TestZeptoClaw_Setup_UsesHookFailMode(t *testing.T) {
+func TestZeptoClaw_Setup_UsesRuntimeFailModeForSharedHook(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell scripts not supported on windows")
 	}
@@ -3807,8 +3807,91 @@ func TestZeptoClaw_Setup_UsesHookFailMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read inspect-tool.sh: %v", err)
 	}
-	if !strings.Contains(string(body), `FAIL_MODE="${DEFENSECLAW_FAIL_MODE:-closed}"`) {
-		t.Fatalf("inspect-tool.sh did not render closed fail mode:\n%s", string(body))
+	if !strings.Contains(string(body), `defenseclaw_shared_runtime_fail_mode "$HOOK_DIR" "$RUNTIME_CONNECTOR"`) {
+		t.Fatalf("inspect-tool.sh does not resolve fail mode at runtime:\n%s", string(body))
+	}
+	opts.HookFailMode = "open"
+	if err := c.Setup(context.Background(), opts); err != nil {
+		t.Fatalf("open-mode Setup: %v", err)
+	}
+	after, err := os.ReadFile(filepath.Join(dir, "hooks", "inspect-tool.sh"))
+	if err != nil {
+		t.Fatalf("read open-mode inspect-tool.sh: %v", err)
+	}
+	if !bytes.Equal(after, body) {
+		t.Fatal("shared inspect hook changed when one connector changed fail mode")
+	}
+}
+
+func TestSharedInspectHookResolvesSingleConnectorRuntimeState(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell scripts not supported on windows")
+	}
+	for _, tc := range []struct {
+		mode     string
+		wantCode int
+	}{
+		{mode: "open", wantCode: 0},
+		{mode: "closed", wantCode: 2},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			var gotConnector, gotAuthorization string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotConnector = r.Header.Get("X-DefenseClaw-Connector")
+				gotAuthorization = r.Header.Get("Authorization")
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte("not-json"))
+			}))
+			defer srv.Close()
+			dir := t.TempDir()
+			hookDir := filepath.Join(dir, "hooks")
+			opts := SetupOpts{
+				DataDir:            dir,
+				APIAddr:            strings.TrimPrefix(srv.URL, "http://"),
+				HookFailMode:       tc.mode,
+				HookAPIToken:       "scoped-runtime-fixture",
+				HookAPITokenScoped: true,
+			}
+			if err := WriteHookScriptsForConnectorObjectWithOpts(hookDir, opts, NewZeptoClawConnector()); err != nil {
+				t.Fatalf("write shared hooks: %v", err)
+			}
+			// The parser-independent flat record must remain authoritative even
+			// when persistent/transient lock files and unrelated prefix matches
+			// are present. Those files must not become phantom connectors.
+			if err := os.WriteFile(filepath.Join(hookDir, ".hookcfg.lock"), nil, 0o600); err != nil {
+				t.Fatalf("write lock fixture: %v", err)
+			}
+			if err := os.WriteFile(
+				filepath.Join(hookDir, ".hookcfg.unrelated"),
+				[]byte("DEFENSECLAW_CONNECTOR=someone-else\nDEFENSECLAW_FAIL_MODE=closed\n"),
+				0o600,
+			); err != nil {
+				t.Fatalf("write unrelated sidecar fixture: %v", err)
+			}
+			cmd := exec.Command("bash", filepath.Join(hookDir, "inspect-request.sh"))
+			cmd.Stdin = strings.NewReader(`{"content":"hello"}`)
+			cmd.Env = []string{
+				"PATH=" + os.Getenv("PATH"),
+				"HOME=" + dir,
+				"DEFENSECLAW_HOME=" + dir,
+			}
+			err := cmd.Run()
+			code := 0
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				code = exitErr.ExitCode()
+			} else if err != nil {
+				t.Fatalf("run shared hook: %v", err)
+			}
+			if code != tc.wantCode {
+				t.Fatalf("shared hook exit=%d want %d", code, tc.wantCode)
+			}
+			if gotConnector != "zeptoclaw" {
+				t.Fatalf("connector header=%q", gotConnector)
+			}
+			if gotAuthorization != "Bearer scoped-runtime-fixture" {
+				t.Fatalf("authorization header did not use scoped runtime token")
+			}
+		})
 	}
 }
 
@@ -4021,11 +4104,11 @@ func TestOpenClawHookWriter_WritesGenericHooksOnly(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read generic hook %s: %v", name, err)
 		}
-		if !strings.Contains(string(body), ".hook-openclaw.token") {
-			t.Errorf("generic hook %s does not reference connector-scoped token sidecar", name)
+		if strings.Contains(string(body), ".hook-openclaw.token") || strings.Contains(string(body), "X-DefenseClaw-Connector: openclaw") {
+			t.Errorf("generic hook %s embeds OpenClaw-specific runtime state", name)
 		}
-		if !strings.Contains(string(body), "X-DefenseClaw-Connector: openclaw") {
-			t.Errorf("generic hook %s does not bind scoped token to OpenClaw", name)
+		if !strings.Contains(string(body), "defenseclaw_shared_hook_token_file") || !strings.Contains(string(body), "RUNTIME_CONNECTOR") {
+			t.Errorf("generic hook %s does not resolve connector state at runtime", name)
 		}
 	}
 	for _, name := range []string{"codex-hook.sh", "claude-code-hook.sh", "hermes-hook.sh"} {
@@ -5818,6 +5901,19 @@ func TestManagedEnterpriseHookIgnoresUserControlledHomeAndDisableSentinel(t *tes
 	}
 	if !strings.Contains(rendered, "DEFENSECLAW_MANAGED_HOOK=1") {
 		t.Fatal("managed hook does not force fail-closed transport and missing-token behavior")
+	}
+	sharedBody, err := os.ReadFile(filepath.Join(dir, "inspect-request.sh"))
+	if err != nil {
+		t.Fatalf("read managed shared hook: %v", err)
+	}
+	shared := string(sharedBody)
+	if strings.Contains(shared, `DEFENSECLAW_HOME="${DEFENSECLAW_HOME:-${HOME}/.defenseclaw}"`) ||
+		strings.Contains(shared, `[ -f "${DEFENSECLAW_HOME}/.disabled" ]`) {
+		t.Fatal("managed shared hook retained a user-controlled home or disable sentinel")
+	}
+	if !strings.Contains(shared, `DEFENSECLAW_HOME="$(cd "${HOOK_DIR}/.." && pwd -P)"`) ||
+		!strings.Contains(shared, "DEFENSECLAW_MANAGED_HOOK=1") {
+		t.Fatal("managed shared hook did not retain enterprise hardening")
 	}
 }
 

--- a/internal/gateway/connector/connector_test.go
+++ b/internal/gateway/connector/connector_test.go
@@ -5433,19 +5433,10 @@ func TestIsLoopback_IPv6Variants(t *testing.T) {
 	}
 }
 
-// TestHookScript_FailOpenOnUnreachable_Default asserts the post-PR
-// behavior: when the gateway is unreachable (transport failure), the
-// hook ALWAYS allows the agent to proceed by default — regardless of
-// FAIL_MODE. A DefenseClaw outage must not brick the user's agent.
-// Operators who want strict availability must opt in explicitly via
-// DEFENSECLAW_STRICT_AVAILABILITY=1 (see the next test).
-//
-// NOTE on fail_mode in the failure log: this is metadata recording
-// the configured response-layer fail mode at write time, not the
-// transport-layer behavior under test. Post-, the safer default
-// for response-layer failures is "closed", so the metadata reflects
-// that. The transport-layer fail-open behavior remains unchanged.
-func TestHookScript_FailOpenOnUnreachable_Default(t *testing.T) {
+// TestHookScript_FailClosedOnUnreachable_Default asserts that the secure
+// low-level default applies consistently to transport and response failures.
+// Existing observe-only installs explicitly resolve "open" before setup.
+func TestHookScript_FailClosedOnUnreachable_Default(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell scripts not supported on windows")
 	}
@@ -5468,8 +5459,10 @@ func TestHookScript_FailOpenOnUnreachable_Default(t *testing.T) {
 		"PATH="+os.Getenv("PATH"),
 		"DEFENSECLAW_HOME="+dcHome,
 	)
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("hook should fail-open (exit 0) on transport failure by default, got: %v", err)
+	err := cmd.Run()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok || exitErr.ExitCode() != 2 {
+		t.Fatalf("hook error = %v, want fail-closed exit 2", err)
 	}
 
 	// Even though the hook allowed, a structured failure record must
@@ -5486,10 +5479,6 @@ func TestHookScript_FailOpenOnUnreachable_Default(t *testing.T) {
 		`"connector":"claudecode"`,
 		`"hook":"claude-code-hook"`,
 		`"category":"transport"`,
-		// The response-layer default is "closed", so the failure log
-		// metadata reflects that. The functional invariant under test
-		// (hook exits 0 / allows agent on transport failure) is
-		// unchanged — that is the `category=transport` dimension above.
 		`"fail_mode":"closed"`,
 	} {
 		if !strings.Contains(logText, want) {
@@ -5542,10 +5531,8 @@ func TestHookScript_FailureLogEscapesFailMode(t *testing.T) {
 // TestHookScript_FailClosedOnUnreachable_StrictAvailability covers
 // the operator opt-in for strict availability: when
 // DEFENSECLAW_STRICT_AVAILABILITY=1 is set, the hook MUST exit 2 on
-// transport failures even though the response-layer FAIL_MODE
-// default is "open". This is the escape hatch for sites that prefer
-// to take the agent down rather than miss policy enforcement during
-// a gateway outage.
+// transport failures independently of the configured fail mode. This is the
+// force-closed escape hatch for sites that require strict availability.
 //
 // Also pins the operator-facing stderr contract: the verb the hook
 // prints MUST match what it actually does on exit. The pre-fix code
@@ -5669,12 +5656,8 @@ func TestHookScript_FailMode_RespectedOnResponseFailure(t *testing.T) {
 }
 
 // TestHookScript_FailOpen_Override covers the legacy operator
-// override: DEFENSECLAW_FAIL_MODE=open forces the response-layer
-// handler to allow even if the baked-in template default was
-// "closed". Transport failures are NOT routed through this — they
-// have their own DEFENSECLAW_STRICT_AVAILABILITY toggle — but
-// response-layer failures (which won't fire here against an
-// unreachable gateway) would respect this override.
+// override: DEFENSECLAW_FAIL_MODE=open allows both response and transport
+// failures even if the baked-in template default was "closed".
 func TestHookScript_FailOpen_Override(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell scripts not supported on windows")
@@ -5701,7 +5684,7 @@ func TestHookScript_FailOpen_Override(t *testing.T) {
 //
 // Contract:
 //   - Explicit "closed" stays closed when the connector supports it.
-//   - Empty / invalid HookFailMode normalizes to "open".
+//   - Empty / invalid HookFailMode normalizes to the secure "closed" default.
 func TestSetupOpts_HookFailMode_RespectsOperatorChoice(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell scripts not supported on windows")
@@ -5869,7 +5852,7 @@ func TestManagedEnterpriseHookFailsClosedWhenTokenIsMissing(t *testing.T) {
 	}
 }
 
-func TestCodexHookScript_FailOpen_DefaultForObservabilitySetup(t *testing.T) {
+func TestCodexHookScript_FailClosed_DefaultWithoutResolvedObserveMode(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell scripts not supported on windows")
 	}
@@ -5889,8 +5872,10 @@ func TestCodexHookScript_FailOpen_DefaultForObservabilitySetup(t *testing.T) {
 		"PATH="+os.Getenv("PATH"),
 		"DEFENSECLAW_HOME="+dcHome,
 	)
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("observability Codex hook should fail-open by default, got: %v", err)
+	err := cmd.Run()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok || exitErr.ExitCode() != 2 {
+		t.Fatalf("Codex hook error = %v, want fail-closed exit 2", err)
 	}
 	failureLog, err := os.ReadFile(filepath.Join(dcHome, "logs", "hook-failures.jsonl"))
 	if err != nil {
@@ -5906,10 +5891,6 @@ func TestCodexHookScript_FailOpen_DefaultForObservabilitySetup(t *testing.T) {
 		// down / network error) rather than a response failure
 		// (4xx / parse error). Operators triage these differently.
 		`"category":"transport"`,
-		// Response-layer default is "closed" — transport-layer
-		// fail-open behavior under test here is unchanged (the hook
-		// still exits 0 and the agent still proceeds when the gateway
-		// is unreachable).
 		`"fail_mode":"closed"`,
 	} {
 		if !strings.Contains(logText, want) {

--- a/internal/gateway/connector/hook_contract_test.go
+++ b/internal/gateway/connector/hook_contract_test.go
@@ -11,6 +11,7 @@
 package connector
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -20,6 +21,19 @@ import (
 
 	"github.com/defenseclaw/defenseclaw/internal/testenv"
 )
+
+func sharedHookBytes(t *testing.T, hookDir string) map[string][]byte {
+	t.Helper()
+	out := make(map[string][]byte, len(genericHookScripts)+len(hookHelperScripts))
+	for _, name := range append(append([]string{}, genericHookScripts...), hookHelperScripts...) {
+		body, err := os.ReadFile(filepath.Join(hookDir, name))
+		if err != nil {
+			t.Fatalf("read shared hook %s: %v", name, err)
+		}
+		out[name] = body
+	}
+	return out
+}
 
 func TestHookContractResolution(t *testing.T) {
 	cases := []struct {
@@ -391,6 +405,309 @@ func TestHookContractLockSaveLoadAndDrift(t *testing.T) {
 	changed.ContractID = "hermes-hooks-v0-other"
 	if !HookContractLockDrifted(loaded, changed) {
 		t.Fatalf("contract change should be drift")
+	}
+}
+
+func TestSharedInspectScriptsAreConnectorIndependent(t *testing.T) {
+	dir := testenv.PrivateTempDir(t)
+	hookDir := filepath.Join(dir, "hooks")
+	claudeOpts := SetupOpts{
+		DataDir:            dir,
+		APIAddr:            "127.0.0.1:18970",
+		HookFailMode:       "closed",
+		HookAPIToken:       "claude-scoped-fixture",
+		HookAPITokenScoped: true,
+		ManagedEnterprise:  true,
+	}
+	if err := WriteHookScriptsForConnectorObjectWithOpts(hookDir, claudeOpts, NewClaudeCodeConnector()); err != nil {
+		t.Fatalf("write Claude hooks: %v", err)
+	}
+	before := sharedHookBytes(t, hookDir)
+
+	codexOpts := claudeOpts
+	codexOpts.HookFailMode = "open"
+	codexOpts.HookAPIToken = "codex-scoped-fixture"
+	if err := WriteHookScriptsForConnectorObjectWithOpts(hookDir, codexOpts, NewCodexConnector()); err != nil {
+		t.Fatalf("write Codex hooks: %v", err)
+	}
+	after := sharedHookBytes(t, hookDir)
+	for name, want := range before {
+		if !bytes.Equal(after[name], want) {
+			t.Fatalf("shared hook %s changed across connector/mode/token render", name)
+		}
+		for _, forbidden := range [][]byte{
+			[]byte(".hook-claudecode.token"),
+			[]byte(".hook-codex.token"),
+			[]byte("X-DefenseClaw-Connector: claudecode"),
+			[]byte("X-DefenseClaw-Connector: codex"),
+		} {
+			if bytes.Contains(after[name], forbidden) {
+				t.Fatalf("shared hook %s contains connector-specific data %q", name, forbidden)
+			}
+		}
+	}
+}
+
+func TestHookContractLockStoresSharedScriptsOnce(t *testing.T) {
+	dir := testenv.PrivateTempDir(t)
+	hookDir := filepath.Join(dir, "hooks")
+	connectors := []struct {
+		conn Connector
+		mode string
+	}{
+		{NewClaudeCodeConnector(), "closed"},
+		{NewCodexConnector(), "open"},
+	}
+	for _, tc := range connectors {
+		opts := SetupOpts{DataDir: dir, APIAddr: "127.0.0.1:18970", HookFailMode: tc.mode}
+		if err := WriteHookScriptsForConnectorObjectWithOpts(hookDir, opts, tc.conn); err != nil {
+			t.Fatalf("write %s hooks: %v", tc.conn.Name(), err)
+		}
+		if err := SaveHookContractLockEntry(dir, NewHookContractLockEntry(opts, tc.conn, "test-build")); err != nil {
+			t.Fatalf("save %s lock: %v", tc.conn.Name(), err)
+		}
+	}
+	lock := loadHookContractLock(dir)
+	if lock.Version != hookContractLockVersion {
+		t.Fatalf("lock version=%d want %d", lock.Version, hookContractLockVersion)
+	}
+	if len(lock.SharedHookScriptDigests) != len(genericHookScripts)+len(hookHelperScripts) {
+		t.Fatalf("shared digests=%v", lock.SharedHookScriptDigests)
+	}
+	for _, tc := range connectors {
+		entry := lock.Connectors[tc.conn.Name()]
+		for name := range entry.HookScriptDigests {
+			if sharedHookScriptName(name) {
+				t.Fatalf("%s entry retained shared digest %s", tc.conn.Name(), name)
+			}
+		}
+		owned := "codex-hook.sh"
+		if tc.conn.Name() == "claudecode" {
+			owned = "claude-code-hook.sh"
+		}
+		if entry.HookScriptDigests[owned] == "" {
+			t.Fatalf("%s owned digest missing: %v", tc.conn.Name(), entry.HookScriptDigests)
+		}
+	}
+}
+
+func TestHookContractLockMigratesDivergentLegacySharedDigests(t *testing.T) {
+	dir := testenv.PrivateTempDir(t)
+	hookDir := filepath.Join(dir, "hooks")
+	opts := SetupOpts{DataDir: dir, APIAddr: "127.0.0.1:18970", HookFailMode: "closed"}
+	conn := NewClaudeCodeConnector()
+	if err := WriteHookScriptsForConnectorObjectWithOpts(hookDir, opts, conn); err != nil {
+		t.Fatalf("write canonical hooks: %v", err)
+	}
+	selected := NewHookContractLockEntry(opts, conn, "test-build")
+	peerOwned := "sha256:peer-owned"
+	legacy := hookContractLock{
+		Version: 1,
+		Connectors: map[string]HookContractLockEntry{
+			"claudecode": {
+				Connector:         "claudecode",
+				ContractID:        "claudecode-hooks-v1",
+				HookFailMode:      "open",
+				HookScriptDigests: map[string]string{"claude-code-hook.sh": "sha256:old-claude"},
+			},
+			"codex": {
+				Connector:         "codex",
+				ContractID:        "codex-hooks-v1",
+				HookFailMode:      "open",
+				HookScriptDigests: map[string]string{"codex-hook.sh": peerOwned},
+			},
+		},
+	}
+	for _, name := range append(append([]string{}, genericHookScripts...), hookHelperScripts...) {
+		legacy.Connectors["claudecode"].HookScriptDigests[name] = "sha256:legacy-claude"
+		legacy.Connectors["codex"].HookScriptDigests[name] = "sha256:legacy-codex"
+	}
+	body, err := json.MarshalIndent(legacy, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, hookContractLockFile), append(body, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SaveHookContractLockEntry(dir, selected); err != nil {
+		t.Fatalf("migrate lock: %v", err)
+	}
+	migratedPath := filepath.Join(dir, hookContractLockFile)
+	migrated, err := os.ReadFile(migratedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock := loadHookContractLock(dir)
+	if lock.Version != hookContractLockVersion {
+		t.Fatalf("migrated version=%d", lock.Version)
+	}
+	if lock.Connectors["codex"].HookFailMode != "open" || lock.Connectors["codex"].HookScriptDigests["codex-hook.sh"] != peerOwned {
+		t.Fatalf("peer metadata changed during migration: %+v", lock.Connectors["codex"])
+	}
+	for name, digest := range lock.SharedHookScriptDigests {
+		actual := HookScriptDigests(opts, conn)[name]
+		if digest != actual {
+			t.Fatalf("shared digest %s=%q want current %q", name, digest, actual)
+		}
+		for connectorName, entry := range lock.Connectors {
+			if _, exists := entry.HookScriptDigests[name]; exists {
+				t.Fatalf("legacy shared digest %s remains under %s", name, connectorName)
+			}
+		}
+	}
+	if err := SaveHookContractLockEntry(dir, NewHookContractLockEntry(opts, conn, "test-build")); err != nil {
+		t.Fatalf("repeat save: %v", err)
+	}
+	repeated, err := os.ReadFile(migratedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(repeated, migrated) {
+		t.Fatal("repeated reconciliation rewrote an already-current contract lock")
+	}
+}
+
+func TestHookContractLockRejectsMalformedOrFutureExistingLock(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{name: "malformed", body: `{not-json`},
+		{name: "future", body: `{"version":99,"future_field":"preserve","connectors":{"codex":{"connector":"codex"}}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := testenv.PrivateTempDir(t)
+			path := filepath.Join(dir, hookContractLockFile)
+			before := []byte(tc.body)
+			if err := os.WriteFile(path, before, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			err := SaveHookContractLockEntry(dir, HookContractLockEntry{Connector: "claudecode", ContractID: "claudecode-hooks-v1"})
+			if err == nil {
+				t.Fatal("save accepted an unreadable or unsupported existing lock")
+			}
+			after, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if !bytes.Equal(after, before) {
+				t.Fatal("failed save rewrote existing contract evidence")
+			}
+		})
+	}
+}
+
+func TestHookContractLockRejectsPartialSharedDigestSet(t *testing.T) {
+	dir := testenv.PrivateTempDir(t)
+	entry := HookContractLockEntry{
+		Connector:         "claudecode",
+		HookScriptDigests: map[string]string{"inspect-tool.sh": "sha256:partial", "claude-code-hook.sh": "sha256:owned"},
+	}
+	if err := SaveHookContractLockEntry(dir, entry); err == nil {
+		t.Fatal("partial shared digest set was accepted")
+	}
+	if _, err := os.Stat(filepath.Join(dir, hookContractLockFile)); !os.IsNotExist(err) {
+		t.Fatalf("partial save created a lock: %v", err)
+	}
+}
+
+func TestHookContractLockNormalizesSharedLauncherDigestAcrossPeers(t *testing.T) {
+	dir := testenv.PrivateTempDir(t)
+	legacy := hookContractLock{
+		Version: 1,
+		Connectors: map[string]HookContractLockEntry{
+			"claudecode": {Connector: "claudecode", HookScriptDigests: map[string]string{windowsHookBinaryName: "sha256:old-claude"}},
+			"codex":      {Connector: "codex", HookScriptDigests: map[string]string{windowsHookBinaryName: "sha256:old-codex"}},
+		},
+	}
+	body, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, hookContractLockFile), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	selected := legacy.Connectors["claudecode"]
+	selected.HookScriptDigests[windowsHookBinaryName] = "sha256:current-launcher"
+	if err := SaveHookContractLockEntry(dir, selected); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"claudecode", "codex"} {
+		entry := LoadHookContractLockEntry(dir, name)
+		if got := entry.HookScriptDigests[windowsHookBinaryName]; got != "sha256:current-launcher" {
+			t.Fatalf("%s launcher digest=%q", name, got)
+		}
+	}
+}
+
+func TestHookContractClearRollsBackWhenRuntimeStateCannotBeUpdated(t *testing.T) {
+	dir := testenv.PrivateTempDir(t)
+	hookDir := filepath.Join(dir, "hooks")
+	if err := os.MkdirAll(hookDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	lock := hookContractLock{
+		Version: hookContractLockVersion,
+		SharedHookScriptDigests: map[string]string{
+			"inspect-tool.sh": "sha256:shared",
+		},
+		Connectors: map[string]HookContractLockEntry{
+			"claudecode": {Connector: "claudecode"},
+			"codex":      {Connector: "codex"},
+		},
+	}
+	body, err := json.MarshalIndent(lock, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body = append(body, '\n')
+	lockPath := filepath.Join(dir, hookContractLockFile)
+	if err := os.WriteFile(lockPath, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hookDir, hookConfigSidecarName), []byte(`{"malformed":`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ClearHookContractLockEntry(dir, "claudecode"); err == nil {
+		t.Fatal("clear succeeded despite malformed runtime state")
+	}
+	after, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, body) {
+		t.Fatal("failed runtime clear did not restore the contract lock")
+	}
+}
+
+func TestHookContractClearCannotBeUndoneByStaleReconcileSave(t *testing.T) {
+	dir := testenv.PrivateTempDir(t)
+	hookDir := filepath.Join(dir, "hooks")
+	opts := SetupOpts{DataDir: dir, APIAddr: "127.0.0.1:18970", HookFailMode: "closed"}
+	conn := NewClaudeCodeConnector()
+	if err := WriteHookScriptsForConnectorObjectWithOpts(hookDir, opts, conn); err != nil {
+		t.Fatal(err)
+	}
+	entry := NewHookContractLockEntry(opts, conn, "test-build")
+	if err := SaveHookContractLockEntry(dir, entry); err != nil {
+		t.Fatal(err)
+	}
+	if err := ClearHookContractLockEntry(dir, conn.Name()); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveHookContractLockEntry(dir, entry); err == nil {
+		t.Fatal("stale reconcile save resurrected a contract after runtime teardown")
+	}
+	if got := LoadHookContractLockEntry(dir, conn.Name()); got.Connector != "" {
+		t.Fatalf("stale reconcile save restored cleared contract: %+v", got)
+	}
+	if err := WriteHookScriptsForConnectorObjectWithOpts(hookDir, opts, conn); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveHookContractLockEntry(dir, NewHookContractLockEntry(opts, conn, "test-build")); err != nil {
+		t.Fatalf("fresh reconcile could not restore runtime and contract together: %v", err)
 	}
 }
 

--- a/internal/gateway/connector/hook_contract_test.go
+++ b/internal/gateway/connector/hook_contract_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/defenseclaw/defenseclaw/internal/testenv"
@@ -390,6 +391,37 @@ func TestHookContractLockSaveLoadAndDrift(t *testing.T) {
 	changed.ContractID = "hermes-hooks-v0-other"
 	if !HookContractLockDrifted(loaded, changed) {
 		t.Fatalf("contract change should be drift")
+	}
+}
+
+func TestHookContractLockConcurrentUpdatesPreserveConnectorPeers(t *testing.T) {
+	dir := testenv.PrivateTempDir(t)
+	entries := []HookContractLockEntry{
+		{Connector: "claudecode", ContractID: "claudecode-hooks-v1", HookFailMode: "closed"},
+		{Connector: "codex", ContractID: "codex-hooks-v1", HookFailMode: "open"},
+	}
+	var wg sync.WaitGroup
+	errors := make(chan error, len(entries))
+	for _, entry := range entries {
+		entry := entry
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errors <- SaveHookContractLockEntry(dir, entry)
+		}()
+	}
+	wg.Wait()
+	close(errors)
+	for err := range errors {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, entry := range entries {
+		loaded := LoadHookContractLockEntry(dir, entry.Connector)
+		if loaded.ContractID != entry.ContractID || loaded.HookFailMode != entry.HookFailMode {
+			t.Fatalf("connector %s lock entry lost during concurrent update: %+v", entry.Connector, loaded)
+		}
 	}
 }
 

--- a/internal/gateway/connector/hookexec/hookexec.go
+++ b/internal/gateway/connector/hookexec/hookexec.go
@@ -63,8 +63,8 @@ type Options struct {
 	// APIAddr is the gateway "host:port" the hook posts to.
 	APIAddr string
 	// FailMode is "open" or "closed"; it governs response-layer failures
-	// (4xx / bad JSON). Transport failures always fail open unless
-	// StrictAvailability is set. Empty defaults to "open".
+	// (4xx / bad JSON) and transport failures. StrictAvailability forces
+	// closed independently. Empty defaults to "open".
 	FailMode string
 
 	// Home is DEFENSECLAW_HOME (default ~/.defenseclaw). If it does not exist
@@ -257,7 +257,13 @@ func (sp spec) decide(opts Options, body []byte) int {
 		return failResponse(opts, sp, normalizeFailMode(opts.FailMode), "invalid JSON response")
 	}
 
-	action := rawStringOr(fields, "action", "allow")
+	action, ok := rawString(fields, "action")
+	if !ok || (action != "allow" && action != "block" && action != "confirm") {
+		if sp.style == styleClaudeCode || sp.style == styleCodex || sp.style == styleActionStderr {
+			return failResponse(opts, sp, normalizeFailMode(opts.FailMode), "invalid or missing action in gateway response")
+		}
+		action = "allow"
+	}
 	reason := rawStringOr(fields, "reason", "")
 	output := compactField(fields, sp.outputField)
 
@@ -335,9 +341,9 @@ func (sp spec) decide(opts Options, body []byte) int {
 func handleMissingToken(opts Options, sp spec, failMode string) int {
 	const reason = "missing gateway token (connector-scoped and legacy token sidecars absent; DEFENSECLAW_GATEWAY_TOKEN unset)"
 	logHookFailure(opts, sp, reason, "transport", failMode)
-	if opts.StrictAvailability {
+	if opts.StrictAvailability || failMode == "closed" {
 		fmt.Fprintf(opts.Stderr,
-			"defenseclaw: %s, blocking %s (DEFENSECLAW_STRICT_AVAILABILITY=1)\n", reason, sp.subject)
+			"defenseclaw: %s, blocking %s (fail mode closed)\n", reason, sp.subject)
 		return emit(opts.Stdout, sp.unreachableStrict)
 	}
 	return emit(opts.Stdout, sp.openAllow)
@@ -353,17 +359,30 @@ func handleOversized(opts Options, sp spec, failMode string) int {
 	return emit(opts.Stdout, sp.openAllow)
 }
 
-// failUnreachable mirrors the transport-layer failure path: always allow
-// unless the operator opted into strict availability.
+// failUnreachable applies the connector's effective fail mode to native hook
+// transport failures. Strict availability remains an unconditional closed
+// override for compatibility with existing deployments.
 func failUnreachable(opts Options, sp spec, failMode, reason string) int {
 	logHookFailure(opts, sp, reason, "transport", failMode)
-	if opts.StrictAvailability {
+	if opts.StrictAvailability || failMode == "closed" {
 		fmt.Fprintf(opts.Stderr,
-			"defenseclaw: gateway unreachable, blocking %s (DEFENSECLAW_STRICT_AVAILABILITY=1): %s\n", sp.subject, reason)
+			"defenseclaw: gateway unreachable, blocking %s (fail mode closed): %s\n", sp.subject, reason)
 		return emit(opts.Stdout, sp.unreachableStrict)
 	}
 	fmt.Fprintf(opts.Stderr, "defenseclaw: gateway unreachable, allowing %s: %s\n", sp.subject, reason)
 	return emit(opts.Stdout, sp.openAllow)
+}
+
+func rawString(fields map[string]json.RawMessage, key string) (string, bool) {
+	raw, ok := fields[key]
+	if !ok {
+		return "", false
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false
+	}
+	return strings.ToLower(strings.TrimSpace(value)), true
 }
 
 // failResponse mirrors the response-layer failure path: honor FAIL_MODE.

--- a/internal/gateway/connector/hookexec/hookexec_test.go
+++ b/internal/gateway/connector/hookexec/hookexec_test.go
@@ -508,6 +508,39 @@ func TestResponseFailure(t *testing.T) {
 	})
 }
 
+func TestMixedConnectorEffectiveFailModeResponseMatrix(t *testing.T) {
+	failures := []struct {
+		name string
+		rt   func() *stubRT
+	}{
+		{name: "malformed json", rt: func() *stubRT { return ok("not-json") }},
+		{name: "incomplete response", rt: func() *stubRT { return ok(`{"reason":"missing action"}`) }},
+		{name: "invalid action", rt: func() *stubRT { return ok(`{"action":"unexpected"}`) }},
+		{name: "unauthorized", rt: func() *stubRT { return &stubRT{status: 401, body: "unauthorized"} }},
+		{name: "server failure", rt: func() *stubRT { return &stubRT{status: 503, body: "unavailable"} }},
+		{name: "connection failure", rt: func() *stubRT { return &stubRT{err: errors.New("connection refused")} }},
+		{name: "timeout", rt: func() *stubRT { return &stubRT{err: context.DeadlineExceeded} }},
+	}
+	connectors := []struct {
+		name string
+		mode string
+		code int
+	}{
+		{name: "claudecode", mode: "closed", code: 2},
+		{name: "codex", mode: "open", code: 0},
+	}
+	for _, failure := range failures {
+		for _, connector := range connectors {
+			t.Run(failure.name+"/"+connector.name, func(t *testing.T) {
+				r := run(t, connector.name, failure.rt(), func(o *Options) { o.FailMode = connector.mode })
+				if r.code != connector.code {
+					t.Fatalf("code = %d, want %d; stderr=%q", r.code, connector.code, r.stderr)
+				}
+			})
+		}
+	}
+}
+
 // --- Missing token ---
 
 func TestMissingToken(t *testing.T) {
@@ -550,6 +583,16 @@ func TestMissingToken(t *testing.T) {
 		}
 		if !strings.Contains(r.stderr, "missing gateway token") {
 			t.Errorf("stderr = %q", r.stderr)
+		}
+	})
+
+	t.Run("closed fail mode blocks", func(t *testing.T) {
+		r := run(t, "claudecode", ok(`{"action":"allow"}`), func(o *Options) {
+			noToken(o)
+			o.FailMode = "closed"
+		})
+		if r.code != 2 {
+			t.Fatalf("code = %d, want 2", r.code)
 		}
 	})
 }

--- a/internal/gateway/connector/hooks/_hardening.sh
+++ b/internal/gateway/connector/hooks/_hardening.sh
@@ -522,17 +522,15 @@ defenseclaw_response_failure_reason() {
   esac
 }
 
-# defenseclaw_should_fail_closed_on_unreachable returns 0 (true) for
-# guardian-installed managed hooks, or when an unmanaged operator explicitly
-# opts into strict availability via DEFENSECLAW_STRICT_AVAILABILITY=1. The
-# unmanaged default is to fail open on
-# transport failures (gateway down / network error / 5xx) regardless
-# of FAIL_MODE — a DefenseClaw outage must NEVER brick the user's
-# coding agent. FAIL_MODE still governs response-layer failures (4xx,
-# bad JSON, missing action) where the gateway answered but its answer
-# was wrong; those represent likely misconfiguration that the operator
-# should be told about loudly.
+# defenseclaw_should_fail_closed_on_unreachable returns 0 (true) when the
+# connector's effective fail mode is closed, for guardian-installed managed
+# hooks, or when strict availability is enabled. Fail mode therefore has one
+# consistent meaning across malformed responses, auth failures, and transport
+# failures instead of silently opening only the latter class.
 defenseclaw_should_fail_closed_on_unreachable() {
+  case "${FAIL_MODE:-open}" in
+    closed) return 0 ;;
+  esac
   case "${DEFENSECLAW_MANAGED_HOOK:-0}" in
     1|true|TRUE|yes|YES) return 0 ;;
   esac
@@ -562,7 +560,7 @@ defenseclaw_emit_unreachable_stderr() {
   local subject="${1:-tool}"
   local reason="${2:-unknown}"
   if defenseclaw_should_fail_closed_on_unreachable; then
-    echo "defenseclaw: gateway unreachable, blocking ${subject} (DEFENSECLAW_STRICT_AVAILABILITY=1): ${reason}" >&2
+    echo "defenseclaw: gateway unreachable, blocking ${subject} (fail mode closed): ${reason}" >&2
   else
     echo "defenseclaw: gateway unreachable, allowing ${subject}: ${reason}" >&2
   fi
@@ -575,19 +573,15 @@ defenseclaw_emit_unreachable_stderr() {
 # the historical behaviour was to exit 0 ("can't talk to gateway →
 # don't brick the agent"). That bypassed FAIL_MODE entirely.
 #
-# This helper preserves the historical default (allow-and-warn) but
-# routes the bypass through the same DEFENSECLAW_STRICT_AVAILABILITY
-# escape hatch as transport failures: an operator who explicitly opts
-# into strict availability gets fail-closed even on a missing-token
-# misconfiguration, AND every bypass — strict or not — is recorded in
-# hook-failures.jsonl so the audit log is honest about the missed
-# inspection.
+# This helper routes the bypass through the connector's FAIL_MODE and
+# the DEFENSECLAW_STRICT_AVAILABILITY force-closed override. Every bypass
+# is recorded in hook-failures.jsonl so the audit log is honest about the
+# missed inspection.
 #
 # Usage:
 #   defenseclaw_handle_missing_token CONNECTOR HOOK_NAME SUBJECT
 #
-# Exits 0 (allow) on the historical default path or 2 (block) when
-# strict availability is set. Never returns to the caller.
+# Exits 0 for fail-open or 2 for fail-closed. Never returns to the caller.
 defenseclaw_handle_missing_token() {
   local connector="${1:-unknown}"
   local hook_name="${2:-unknown}"
@@ -595,7 +589,7 @@ defenseclaw_handle_missing_token() {
   local reason="missing gateway token (.token absent and DEFENSECLAW_GATEWAY_TOKEN unset)"
   defenseclaw_log_hook_failure "$connector" "$hook_name" "$reason" transport "${FAIL_MODE:-open}"
   if defenseclaw_should_fail_closed_on_unreachable; then
-    echo "defenseclaw: ${reason}, blocking ${subject} (DEFENSECLAW_STRICT_AVAILABILITY=1)" >&2
+    echo "defenseclaw: ${reason}, blocking ${subject} (fail mode closed)" >&2
     exit 2
   fi
   exit 0

--- a/internal/gateway/connector/hooks/_hardening.sh
+++ b/internal/gateway/connector/hooks/_hardening.sh
@@ -167,6 +167,125 @@ defenseclaw_harden_env() {
   _defenseclaw_sweep_stale_hook_dirs
 }
 
+# Resolve optional connector identity for the shared inspect-* scripts.  The
+# selected connector is runtime state, never a render-time property of the one
+# physical shared script.  Reject anything outside the connector-name grammar
+# before it can participate in a token filename or HTTP header.
+defenseclaw_shared_runtime_connector() {
+  local connector="${DEFENSECLAW_CONNECTOR:-}"
+  # Non-managed shells may supply an ephemeral connector selection, matching
+  # the existing fail-mode/token override contract. Guardian-managed hooks do
+  # not trust process environment for connector identity and use only the
+  # installer-owned sidecars below.
+  if [ "${DEFENSECLAW_MANAGED_HOOK:-0}" = "1" ]; then
+    connector=""
+  fi
+  case "$connector" in
+    *[!a-z0-9_-]*) return 0 ;;
+    *) printf '%s' "$connector" ;;
+  esac
+  if [ -n "$connector" ]; then
+    return 0
+  fi
+  local hook_dir="${1:-}"
+  local candidate found="" suffix recorded
+  for candidate in "${hook_dir}"/.hookcfg.*; do
+    [ -f "$candidate" ] && [ ! -L "$candidate" ] || continue
+    suffix="${candidate##*.hookcfg.}"
+    [ "$suffix" != "legacy" ] && [ "$suffix" != "lock" ] || continue
+    case "$suffix" in
+      ""|*[!a-z0-9_-]*) continue ;;
+    esac
+    # Ignore lock files, interrupted atomic-write debris, and unrelated files
+    # that merely share the prefix. A valid record must identify itself with
+    # the exact connector encoded in its filename.
+    recorded="$(defenseclaw_flat_hookcfg_value "$candidate" DEFENSECLAW_CONNECTOR 2>/dev/null || true)"
+    [ "$recorded" = "$suffix" ] || continue
+    if [ -n "$found" ]; then
+      # Multiple connector records are intentionally ambiguous unless the
+      # caller supplies DEFENSECLAW_CONNECTOR.
+      return 0
+    fi
+    found="$suffix"
+  done
+  if [ -n "$found" ]; then
+    printf '%s' "$found"
+    return 0
+  fi
+  local config="${hook_dir}/.hookcfg"
+  if [ -f "$config" ]; then
+    if command -v jq >/dev/null 2>&1; then
+      connector="$(jq -r '.fail_modes | keys | if length == 1 then .[0] else empty end' "$config" 2>/dev/null || true)"
+    elif command -v python3 >/dev/null 2>&1; then
+      connector="$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1], encoding="utf-8")); k=list((d.get("fail_modes") or {}).keys()); print(k[0] if len(k)==1 else "")' "$config" 2>/dev/null || true)"
+    fi
+    case "$connector" in
+      ""|*[!a-z0-9_-]*) return 0 ;;
+      *) printf '%s' "$connector" ;;
+    esac
+  fi
+}
+
+defenseclaw_flat_hookcfg_value() {
+  local config="$1"
+  local wanted="$2"
+  local key value
+  [ -f "$config" ] && [ ! -L "$config" ] || return 1
+  while IFS='=' read -r key value; do
+    if [ "$key" = "$wanted" ]; then
+      printf '%s' "$value"
+      return 0
+    fi
+  done < "$config"
+  return 1
+}
+
+# Return the shared legacy token path or the connector-scoped token path named
+# by runtime state.  This does not search token files and never embeds one
+# connector's credential path into shared script bytes.
+defenseclaw_shared_hook_token_file() {
+  local hook_dir="$1"
+  local connector="${2:-}"
+  if [ -n "$connector" ] && [ -f "${hook_dir}/.hook-${connector}.token" ]; then
+    printf '%s/.hook-%s.token' "$hook_dir" "$connector"
+  else
+    printf '%s/.token' "$hook_dir"
+  fi
+}
+
+# Resolve the selected connector's fail mode from the connector-aware shared
+# runtime state.  An explicit process value still wins for ephemeral shells;
+# malformed, ambiguous, or missing state fails closed.
+defenseclaw_shared_runtime_fail_mode() {
+  local hook_dir="$1"
+  local connector="${2:-}"
+  local mode="${DEFENSECLAW_FAIL_MODE:-}"
+  local config="${hook_dir}/.hookcfg"
+  local flat_config="${hook_dir}/.hookcfg.legacy"
+  if [ -n "$connector" ]; then
+    flat_config="${hook_dir}/.hookcfg.${connector}"
+  fi
+  if [ "$mode" != "open" ] && [ "$mode" != "closed" ]; then
+    mode="$(defenseclaw_flat_hookcfg_value "$flat_config" DEFENSECLAW_FAIL_MODE 2>/dev/null || true)"
+  fi
+  if [ "$mode" != "open" ] && [ "$mode" != "closed" ] && [ -f "$config" ]; then
+    if command -v jq >/dev/null 2>&1; then
+      if [ -n "$connector" ]; then
+        mode="$(jq -r --arg connector "$connector" '.fail_modes[$connector] // empty' "$config" 2>/dev/null || true)"
+      else
+        mode="$(jq -r '.legacy_fail_mode // empty' "$config" 2>/dev/null || true)"
+      fi
+    elif command -v python3 >/dev/null 2>&1; then
+      mode="$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1], encoding="utf-8")); c=sys.argv[2]; print((d.get("fail_modes") or {}).get(c, "") if c else d.get("legacy_fail_mode", ""))' "$config" "$connector" 2>/dev/null || true)"
+    fi
+  fi
+  if [ "$mode" = "open" ]; then
+    printf open
+  else
+    printf closed
+  fi
+}
+
 # _defenseclaw_sweep_stale_hook_dirs removes orphaned hook-tmp.*
 # directories under DEFENSECLAW_HOME that haven't been touched in 60+
 # minutes. The 60-minute floor is the longest the hook itself can run

--- a/internal/gateway/connector/hooks/claude-code-hook.sh
+++ b/internal/gateway/connector/hooks/claude-code-hook.sh
@@ -63,7 +63,7 @@ defenseclaw_harden_env
 
 # Fail mode set BEFORE the missing-token check so the helper has a
 # stable FAIL_MODE to log against. See codex-hook.sh for the full
-# response-layer / transport-layer split rationale.
+# response-layer and transport-layer rationale.
 FAIL_MODE="${DEFENSECLAW_FAIL_MODE:-{{.FailMode}}}"
 
 # Bail early on missing token: see codex-hook.sh +
@@ -102,9 +102,8 @@ fi
 API_TOKEN="${DEFENSECLAW_GATEWAY_TOKEN:-}"
 
 # FAIL_MODE was already set above (before the missing-token branch).
-# Response-layer failures (4xx, bad JSON, missing action) respect
-# FAIL_MODE; transport-layer failures (gateway unreachable / 5xx)
-# always allow unless DEFENSECLAW_STRICT_AVAILABILITY=1.
+# Response-layer and transport-layer failures both respect FAIL_MODE;
+# DEFENSECLAW_STRICT_AVAILABILITY=1 remains a force-closed override.
 
 fail_unreachable() {
   defenseclaw_log_hook_failure claudecode claude-code-hook "$1" transport "$FAIL_MODE"
@@ -166,9 +165,13 @@ if [ -n "$OUTPUT" ] && [ "$OUTPUT" != "null" ]; then
   echo "$OUTPUT"
 fi
 
-ACTION=$(echo "$RESULT" | _dc_jq -r '.action // "allow"' 2>/dev/null) || {
+ACTION=$(echo "$RESULT" | _dc_jq -r '.action // empty' 2>/dev/null) || {
   fail_response "failed to parse action from response"
 }
+case "$ACTION" in
+  allow|block|confirm) ;;
+  *) fail_response "invalid or missing action in gateway response" ;;
+esac
 
 # Anthropic's Claude Code hook protocol — like Codex's — is strictly
 # EITHER structured JSON on stdout with exit 0 (Claude parses the

--- a/internal/gateway/connector/hooks/codex-hook.sh
+++ b/internal/gateway/connector/hooks/codex-hook.sh
@@ -64,10 +64,8 @@ defenseclaw_harden_resources
 defenseclaw_harden_env
 
 # Fail mode governs response-layer failures (4xx, bad JSON, missing
-# action). Transport failures (gateway unreachable / 5xx) are handled
-# separately by fail_unreachable below — they ALWAYS allow unless the
-# operator has set DEFENSECLAW_STRICT_AVAILABILITY=1, because a
-# DefenseClaw outage must not brick the user's agent. Set BEFORE the
+# action) and transport failures (gateway unreachable / timeout / 5xx).
+# DEFENSECLAW_STRICT_AVAILABILITY=1 remains a force-closed override. Set BEFORE the
 # missing-token check so defenseclaw_handle_missing_token below has a
 # stable FAIL_MODE to log against.
 FAIL_MODE="${DEFENSECLAW_FAIL_MODE:-{{.FailMode}}}"
@@ -114,7 +112,7 @@ API_TOKEN="${DEFENSECLAW_GATEWAY_TOKEN:-}"
 
 # Transport-layer failure: gateway is unreachable, the connection was
 # refused, the request timed out, or the gateway answered with 5xx.
-# Always allow unless the operator opted into strict availability.
+# Follow FAIL_MODE; strict availability is an additional force-closed override.
 fail_unreachable() {
   defenseclaw_log_hook_failure codex codex-hook "$1" transport "$FAIL_MODE"
   defenseclaw_emit_unreachable_stderr "codex tool" "$1"
@@ -187,9 +185,13 @@ if [ -n "$OUTPUT" ] && [ "$OUTPUT" != "null" ]; then
   echo "$OUTPUT"
 fi
 
-ACTION=$(echo "$RESULT" | _dc_jq -r '.action // "allow"' 2>/dev/null) || {
+ACTION=$(echo "$RESULT" | _dc_jq -r '.action // empty' 2>/dev/null) || {
   fail_response "failed to parse action from response"
 }
+case "$ACTION" in
+  allow|block|confirm) ;;
+  *) fail_response "invalid or missing action in gateway response" ;;
+esac
 
 # Codex's hook protocol is strictly EITHER structured JSON on stdout
 # with exit 0 (Codex parses the decision from the JSON) OR exit 2

--- a/internal/gateway/connector/hooks/hermes-hook.sh
+++ b/internal/gateway/connector/hooks/hermes-hook.sh
@@ -56,10 +56,9 @@ defenseclaw_harden_resources
 defenseclaw_harden_env
 
 # FAIL_MODE set BEFORE the missing-token check so the helper has a
-# stable FAIL_MODE to log against. Response-layer failures (4xx, bad
-# JSON, missing action) respect FAIL_MODE; transport-layer failures
-# (gateway unreachable / 5xx) always allow unless
-# DEFENSECLAW_STRICT_AVAILABILITY=1.
+# stable FAIL_MODE to log against. Response-layer and transport-layer
+# failures respect FAIL_MODE; DEFENSECLAW_STRICT_AVAILABILITY=1 remains
+# a force-closed override.
 FAIL_MODE="${DEFENSECLAW_FAIL_MODE:-{{.FailMode}}}"
 
 # Bail early on missing token via the shared helper so the bypass is

--- a/internal/gateway/connector/hooks/inspect-request.sh
+++ b/internal/gateway/connector/hooks/inspect-request.sh
@@ -52,24 +52,27 @@ defenseclaw_harden_env
 DEFENSECLAW_HOOK_CONNECTOR="inspect"
 DEFENSECLAW_HOOK_NAME="inspect-request"
 export DEFENSECLAW_HOOK_CONNECTOR DEFENSECLAW_HOOK_NAME
+RUNTIME_CONNECTOR="$(defenseclaw_shared_runtime_connector "$HOOK_DIR")"
+FAIL_MODE="$(defenseclaw_shared_runtime_fail_mode "$HOOK_DIR" "$RUNTIME_CONNECTOR")"
 
 # Avarice F-2025 / chain F-3397: include the gateway bearer token on
 # every inspection call. Pre-fix the hook never sent Authorization,
 # so a sidecar that required token auth would 401 every request and
 # (with FAIL_MODE=open) silently allow them. The token lives in
-# ${HOOK_DIR}/{{.TokenFile}} (mode 0600, written by the hook installer)
+# a runtime-selected token file (mode 0600, written by the hook installer)
 # and may be overridden by the env var for ephemeral CI shells.
-if [ ! -f "${HOOK_DIR}/{{.TokenFile}}" ] && [ -z "${DEFENSECLAW_GATEWAY_TOKEN:-}" ]; then
+TOKEN_FILE="$(defenseclaw_shared_hook_token_file "$HOOK_DIR" "$RUNTIME_CONNECTOR")"
+if [ ! -f "$TOKEN_FILE" ] && [ -z "${DEFENSECLAW_GATEWAY_TOKEN:-}" ]; then
   defenseclaw_handle_missing_token inspect inspect-request "request"
 fi
-if [ -z "${DEFENSECLAW_GATEWAY_TOKEN:-}" ] && [ -f "${HOOK_DIR}/{{.TokenFile}}" ]; then
-  {{if .ScopedToken}}
-  DEFENSECLAW_GATEWAY_TOKEN="$(tr -d '\r\n' < "${HOOK_DIR}/{{.TokenFile}}")"
+if [ -z "${DEFENSECLAW_GATEWAY_TOKEN:-}" ] && [ -f "$TOKEN_FILE" ]; then
+  if [ -n "$RUNTIME_CONNECTOR" ]; then
+    DEFENSECLAW_GATEWAY_TOKEN="$(tr -d '\r\n' < "$TOKEN_FILE")"
+  else
+    # shellcheck source=/dev/null
+    . "$TOKEN_FILE"
+  fi
   export DEFENSECLAW_GATEWAY_TOKEN
-  {{else}}
-  # shellcheck source=/dev/null
-  . "${HOOK_DIR}/{{.TokenFile}}"
-  {{end}}
 fi
 API_TOKEN="${DEFENSECLAW_GATEWAY_TOKEN:-}"
 
@@ -79,7 +82,6 @@ CONTENT="$(defenseclaw_read_stdin_capped)" || {
 }
 
 API_ADDR="{{.APIAddr}}"
-FAIL_MODE="${DEFENSECLAW_FAIL_MODE:-{{.FailMode}}}"
 
 # Transport and response failures respect FAIL_MODE;
 # DEFENSECLAW_STRICT_AVAILABILITY=1 remains a force-closed override.
@@ -118,9 +120,9 @@ if [ -n "${API_TOKEN}" ]; then
   AUTH_HEADER_ARGS=(-H "Authorization: Bearer ${API_TOKEN}")
 fi
 CONNECTOR_HEADER_ARGS=()
-{{if .ConnectorName}}
-CONNECTOR_HEADER_ARGS=(-H "X-DefenseClaw-Connector: {{.ConnectorName}}")
-{{end}}
+if [ -n "$RUNTIME_CONNECTOR" ]; then
+  CONNECTOR_HEADER_ARGS=(-H "X-DefenseClaw-Connector: ${RUNTIME_CONNECTOR}")
+fi
 
 RESPONSE=$(printf '%s' "$CONTENT" | curl -s -w "\n%{http_code}" -X POST "http://${API_ADDR}/api/v1/inspect/request" \
   -H "Content-Type: application/json" \

--- a/internal/gateway/connector/hooks/inspect-request.sh
+++ b/internal/gateway/connector/hooks/inspect-request.sh
@@ -81,9 +81,8 @@ CONTENT="$(defenseclaw_read_stdin_capped)" || {
 API_ADDR="{{.APIAddr}}"
 FAIL_MODE="${DEFENSECLAW_FAIL_MODE:-{{.FailMode}}}"
 
-# Transport failures (gateway down / 5xx) always allow unless
-# DEFENSECLAW_STRICT_AVAILABILITY=1. Response failures respect
-# FAIL_MODE.
+# Transport and response failures respect FAIL_MODE;
+# DEFENSECLAW_STRICT_AVAILABILITY=1 remains a force-closed override.
 fail_unreachable() {
   defenseclaw_log_hook_failure inspect inspect-request "$1" transport "$FAIL_MODE"
   defenseclaw_emit_unreachable_stderr "request" "$1"

--- a/internal/gateway/connector/hooks/inspect-response.sh
+++ b/internal/gateway/connector/hooks/inspect-response.sh
@@ -51,20 +51,23 @@ defenseclaw_harden_env
 DEFENSECLAW_HOOK_CONNECTOR="inspect"
 DEFENSECLAW_HOOK_NAME="inspect-response"
 export DEFENSECLAW_HOOK_CONNECTOR DEFENSECLAW_HOOK_NAME
+RUNTIME_CONNECTOR="$(defenseclaw_shared_runtime_connector "$HOOK_DIR")"
+FAIL_MODE="$(defenseclaw_shared_runtime_fail_mode "$HOOK_DIR" "$RUNTIME_CONNECTOR")"
 
 # Avarice F-2025 / chain F-3397: authenticate inspection calls. See
 # inspect-request.sh for the full rationale.
-if [ ! -f "${HOOK_DIR}/{{.TokenFile}}" ] && [ -z "${DEFENSECLAW_GATEWAY_TOKEN:-}" ]; then
+TOKEN_FILE="$(defenseclaw_shared_hook_token_file "$HOOK_DIR" "$RUNTIME_CONNECTOR")"
+if [ ! -f "$TOKEN_FILE" ] && [ -z "${DEFENSECLAW_GATEWAY_TOKEN:-}" ]; then
   defenseclaw_handle_missing_token inspect inspect-response "response"
 fi
-if [ -z "${DEFENSECLAW_GATEWAY_TOKEN:-}" ] && [ -f "${HOOK_DIR}/{{.TokenFile}}" ]; then
-  {{if .ScopedToken}}
-  DEFENSECLAW_GATEWAY_TOKEN="$(tr -d '\r\n' < "${HOOK_DIR}/{{.TokenFile}}")"
+if [ -z "${DEFENSECLAW_GATEWAY_TOKEN:-}" ] && [ -f "$TOKEN_FILE" ]; then
+  if [ -n "$RUNTIME_CONNECTOR" ]; then
+    DEFENSECLAW_GATEWAY_TOKEN="$(tr -d '\r\n' < "$TOKEN_FILE")"
+  else
+    # shellcheck source=/dev/null
+    . "$TOKEN_FILE"
+  fi
   export DEFENSECLAW_GATEWAY_TOKEN
-  {{else}}
-  # shellcheck source=/dev/null
-  . "${HOOK_DIR}/{{.TokenFile}}"
-  {{end}}
 fi
 API_TOKEN="${DEFENSECLAW_GATEWAY_TOKEN:-}"
 
@@ -74,7 +77,6 @@ CONTENT="$(defenseclaw_read_stdin_capped)" || {
 }
 
 API_ADDR="{{.APIAddr}}"
-FAIL_MODE="${DEFENSECLAW_FAIL_MODE:-{{.FailMode}}}"
 
 # Transport and response failures respect FAIL_MODE;
 # DEFENSECLAW_STRICT_AVAILABILITY=1 remains a force-closed override.
@@ -108,9 +110,9 @@ if [ -n "${API_TOKEN}" ]; then
   AUTH_HEADER_ARGS=(-H "Authorization: Bearer ${API_TOKEN}")
 fi
 CONNECTOR_HEADER_ARGS=()
-{{if .ConnectorName}}
-CONNECTOR_HEADER_ARGS=(-H "X-DefenseClaw-Connector: {{.ConnectorName}}")
-{{end}}
+if [ -n "$RUNTIME_CONNECTOR" ]; then
+  CONNECTOR_HEADER_ARGS=(-H "X-DefenseClaw-Connector: ${RUNTIME_CONNECTOR}")
+fi
 
 RESPONSE=$(printf '%s' "$CONTENT" | curl -s -w "\n%{http_code}" -X POST "http://${API_ADDR}/api/v1/inspect/response" \
   -H "Content-Type: application/json" \

--- a/internal/gateway/connector/hooks/inspect-response.sh
+++ b/internal/gateway/connector/hooks/inspect-response.sh
@@ -76,9 +76,8 @@ CONTENT="$(defenseclaw_read_stdin_capped)" || {
 API_ADDR="{{.APIAddr}}"
 FAIL_MODE="${DEFENSECLAW_FAIL_MODE:-{{.FailMode}}}"
 
-# Transport failures (gateway down / 5xx) always allow unless
-# DEFENSECLAW_STRICT_AVAILABILITY=1. Response failures respect
-# FAIL_MODE.
+# Transport and response failures respect FAIL_MODE;
+# DEFENSECLAW_STRICT_AVAILABILITY=1 remains a force-closed override.
 fail_unreachable() {
   defenseclaw_log_hook_failure inspect inspect-response "$1" transport "$FAIL_MODE"
   defenseclaw_emit_unreachable_stderr "response" "$1"

--- a/internal/gateway/connector/hooks/inspect-tool-response.sh
+++ b/internal/gateway/connector/hooks/inspect-tool-response.sh
@@ -51,20 +51,23 @@ defenseclaw_harden_env
 DEFENSECLAW_HOOK_CONNECTOR="inspect"
 DEFENSECLAW_HOOK_NAME="inspect-tool-response"
 export DEFENSECLAW_HOOK_CONNECTOR DEFENSECLAW_HOOK_NAME
+RUNTIME_CONNECTOR="$(defenseclaw_shared_runtime_connector "$HOOK_DIR")"
+FAIL_MODE="$(defenseclaw_shared_runtime_fail_mode "$HOOK_DIR" "$RUNTIME_CONNECTOR")"
 
 # Avarice F-2025 / chain F-3397: authenticate inspection calls. See
 # inspect-request.sh for the full rationale.
-if [ ! -f "${HOOK_DIR}/{{.TokenFile}}" ] && [ -z "${DEFENSECLAW_GATEWAY_TOKEN:-}" ]; then
+TOKEN_FILE="$(defenseclaw_shared_hook_token_file "$HOOK_DIR" "$RUNTIME_CONNECTOR")"
+if [ ! -f "$TOKEN_FILE" ] && [ -z "${DEFENSECLAW_GATEWAY_TOKEN:-}" ]; then
   defenseclaw_handle_missing_token inspect inspect-tool-response "tool-response"
 fi
-if [ -z "${DEFENSECLAW_GATEWAY_TOKEN:-}" ] && [ -f "${HOOK_DIR}/{{.TokenFile}}" ]; then
-  {{if .ScopedToken}}
-  DEFENSECLAW_GATEWAY_TOKEN="$(tr -d '\r\n' < "${HOOK_DIR}/{{.TokenFile}}")"
+if [ -z "${DEFENSECLAW_GATEWAY_TOKEN:-}" ] && [ -f "$TOKEN_FILE" ]; then
+  if [ -n "$RUNTIME_CONNECTOR" ]; then
+    DEFENSECLAW_GATEWAY_TOKEN="$(tr -d '\r\n' < "$TOKEN_FILE")"
+  else
+    # shellcheck source=/dev/null
+    . "$TOKEN_FILE"
+  fi
   export DEFENSECLAW_GATEWAY_TOKEN
-  {{else}}
-  # shellcheck source=/dev/null
-  . "${HOOK_DIR}/{{.TokenFile}}"
-  {{end}}
 fi
 API_TOKEN="${DEFENSECLAW_GATEWAY_TOKEN:-}"
 
@@ -75,7 +78,6 @@ TOOL_OUTPUT="$(defenseclaw_read_stdin_capped)" || {
 }
 
 API_ADDR="{{.APIAddr}}"
-FAIL_MODE="${DEFENSECLAW_FAIL_MODE:-{{.FailMode}}}"
 
 # Transport and response failures respect FAIL_MODE;
 # DEFENSECLAW_STRICT_AVAILABILITY=1 remains a force-closed override.
@@ -109,9 +111,9 @@ if [ -n "${API_TOKEN}" ]; then
   AUTH_HEADER_ARGS=(-H "Authorization: Bearer ${API_TOKEN}")
 fi
 CONNECTOR_HEADER_ARGS=()
-{{if .ConnectorName}}
-CONNECTOR_HEADER_ARGS=(-H "X-DefenseClaw-Connector: {{.ConnectorName}}")
-{{end}}
+if [ -n "$RUNTIME_CONNECTOR" ]; then
+  CONNECTOR_HEADER_ARGS=(-H "X-DefenseClaw-Connector: ${RUNTIME_CONNECTOR}")
+fi
 
 RESPONSE=$(jq -n --arg tool "$TOOL_NAME" --arg output "$TOOL_OUTPUT" \
   '{tool: $tool, output: $output}' | \

--- a/internal/gateway/connector/hooks/inspect-tool-response.sh
+++ b/internal/gateway/connector/hooks/inspect-tool-response.sh
@@ -77,9 +77,8 @@ TOOL_OUTPUT="$(defenseclaw_read_stdin_capped)" || {
 API_ADDR="{{.APIAddr}}"
 FAIL_MODE="${DEFENSECLAW_FAIL_MODE:-{{.FailMode}}}"
 
-# Transport failures (gateway down / 5xx) always allow unless
-# DEFENSECLAW_STRICT_AVAILABILITY=1. Response failures respect
-# FAIL_MODE.
+# Transport and response failures respect FAIL_MODE;
+# DEFENSECLAW_STRICT_AVAILABILITY=1 remains a force-closed override.
 fail_unreachable() {
   defenseclaw_log_hook_failure inspect inspect-tool-response "$1" transport "$FAIL_MODE"
   defenseclaw_emit_unreachable_stderr "tool-response" "$1"

--- a/internal/gateway/connector/hooks/inspect-tool.sh
+++ b/internal/gateway/connector/hooks/inspect-tool.sh
@@ -54,22 +54,25 @@ defenseclaw_harden_env
 DEFENSECLAW_HOOK_CONNECTOR="inspect"
 DEFENSECLAW_HOOK_NAME="inspect-tool"
 export DEFENSECLAW_HOOK_CONNECTOR DEFENSECLAW_HOOK_NAME
+RUNTIME_CONNECTOR="$(defenseclaw_shared_runtime_connector "$HOOK_DIR")"
+FAIL_MODE="$(defenseclaw_shared_runtime_fail_mode "$HOOK_DIR" "$RUNTIME_CONNECTOR")"
 
 # Avarice F-2025 / chain F-3397: load the gateway bearer token before
 # any agent-controlled input is touched. See inspect-request.sh for
 # the full rationale (hook now authenticates and treats 401/403 as a
 # fail-closed event regardless of FAIL_MODE).
-if [ ! -f "${HOOK_DIR}/{{.TokenFile}}" ] && [ -z "${DEFENSECLAW_GATEWAY_TOKEN:-}" ]; then
+TOKEN_FILE="$(defenseclaw_shared_hook_token_file "$HOOK_DIR" "$RUNTIME_CONNECTOR")"
+if [ ! -f "$TOKEN_FILE" ] && [ -z "${DEFENSECLAW_GATEWAY_TOKEN:-}" ]; then
   defenseclaw_handle_missing_token inspect inspect-tool "tool"
 fi
-if [ -z "${DEFENSECLAW_GATEWAY_TOKEN:-}" ] && [ -f "${HOOK_DIR}/{{.TokenFile}}" ]; then
-  {{if .ScopedToken}}
-  DEFENSECLAW_GATEWAY_TOKEN="$(tr -d '\r\n' < "${HOOK_DIR}/{{.TokenFile}}")"
+if [ -z "${DEFENSECLAW_GATEWAY_TOKEN:-}" ] && [ -f "$TOKEN_FILE" ]; then
+  if [ -n "$RUNTIME_CONNECTOR" ]; then
+    DEFENSECLAW_GATEWAY_TOKEN="$(tr -d '\r\n' < "$TOKEN_FILE")"
+  else
+    # shellcheck source=/dev/null
+    . "$TOKEN_FILE"
+  fi
   export DEFENSECLAW_GATEWAY_TOKEN
-  {{else}}
-  # shellcheck source=/dev/null
-  . "${HOOK_DIR}/{{.TokenFile}}"
-  {{end}}
 fi
 API_TOKEN="${DEFENSECLAW_GATEWAY_TOKEN:-}"
 
@@ -80,7 +83,6 @@ TOOL_INPUT="$(defenseclaw_read_stdin_capped)" || {
 }
 
 API_ADDR="{{.APIAddr}}"
-FAIL_MODE="${DEFENSECLAW_FAIL_MODE:-{{.FailMode}}}"
 
 # Transport and response failures respect FAIL_MODE;
 # DEFENSECLAW_STRICT_AVAILABILITY=1 remains a force-closed override.
@@ -116,9 +118,9 @@ if [ -n "${API_TOKEN}" ]; then
   AUTH_HEADER_ARGS=(-H "Authorization: Bearer ${API_TOKEN}")
 fi
 CONNECTOR_HEADER_ARGS=()
-{{if .ConnectorName}}
-CONNECTOR_HEADER_ARGS=(-H "X-DefenseClaw-Connector: {{.ConnectorName}}")
-{{end}}
+if [ -n "$RUNTIME_CONNECTOR" ]; then
+  CONNECTOR_HEADER_ARGS=(-H "X-DefenseClaw-Connector: ${RUNTIME_CONNECTOR}")
+fi
 
 RESPONSE=$(jq -n --arg tool "$TOOL_NAME" --arg args "$TOOL_INPUT" \
   '{tool: $tool, args: $args}' | \

--- a/internal/gateway/connector/hooks/inspect-tool.sh
+++ b/internal/gateway/connector/hooks/inspect-tool.sh
@@ -82,10 +82,8 @@ TOOL_INPUT="$(defenseclaw_read_stdin_capped)" || {
 API_ADDR="{{.APIAddr}}"
 FAIL_MODE="${DEFENSECLAW_FAIL_MODE:-{{.FailMode}}}"
 
-# Transport failures (gateway down / 5xx) always allow unless
-# DEFENSECLAW_STRICT_AVAILABILITY=1; a DefenseClaw outage must not
-# brick the user's tool calls. Response failures (4xx / parse error)
-# respect FAIL_MODE.
+# Transport and response failures respect FAIL_MODE;
+# DEFENSECLAW_STRICT_AVAILABILITY=1 remains a force-closed override.
 fail_unreachable() {
   defenseclaw_log_hook_failure inspect inspect-tool "$1" transport "$FAIL_MODE"
   defenseclaw_emit_unreachable_stderr "tool" "$1"

--- a/internal/gateway/connector/hookwiring_test.go
+++ b/internal/gateway/connector/hookwiring_test.go
@@ -34,6 +34,59 @@ func setHookBinaryOverride(t *testing.T, path string) {
 	t.Cleanup(func() { defenseclawHookBinaryOverride = prev })
 }
 
+func TestWindowsHookConfigSidecarPreservesMixedConnectorModes(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows connector-aware hook sidecar")
+	}
+	dir := t.TempDir()
+	if err := writeHookConfigSidecar(dir, "127.0.0.1:18970", "claudecode", "closed"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeHookConfigSidecar(dir, "127.0.0.1:18970", "codex", "open"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, hookConfigSidecarName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state hookConfigSidecar
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatal(err)
+	}
+	if state.FailModes["claudecode"] != "closed" || state.FailModes["codex"] != "open" {
+		t.Fatalf("mixed fail modes not preserved: %#v", state.FailModes)
+	}
+}
+
+func TestWindowsHookConfigSidecarMigratesLegacyScalar(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows legacy hook sidecar migration")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, hookConfigSidecarName)
+	legacy := []byte("DEFENSECLAW_GATEWAY_ADDR=127.0.0.1:18970\nDEFENSECLAW_FAIL_MODE=open\n")
+	if err := os.WriteFile(path, legacy, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeHookConfigSidecar(dir, "127.0.0.1:18970", "claudecode", "closed"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state hookConfigSidecar
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("legacy sidecar was not migrated to v2: %v", err)
+	}
+	if state.Version != 2 || state.FailModes["claudecode"] != "closed" {
+		t.Fatalf("migrated state = %#v", state)
+	}
+	if state.LegacyMode != "open" {
+		t.Fatalf("legacy fallback was not retained for unmigrated connector peers: %#v", state)
+	}
+}
+
 func TestWindowsHookBinaryUsesStableInstalledLocation(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows installed launcher path")
@@ -49,6 +102,26 @@ func TestWindowsHookBinaryUsesStableInstalledLocation(t *testing.T) {
 	notify := codexNativeNotifyCommand()
 	if len(notify) != 2 || !strings.EqualFold(filepath.Clean(notify[0]), filepath.Clean(want)) || notify[1] != "notify" {
 		t.Fatalf("codexNativeNotifyCommand() = %#v, want installed launcher + notify", notify)
+	}
+}
+
+func TestWindowsHookContractLockIncludesNativeLauncherDigest(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows native launcher contract")
+	}
+	root := t.TempDir()
+	launcher := filepath.Join(root, windowsHookBinaryName)
+	if err := os.WriteFile(launcher, []byte("MZfixture-launcher"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	setHookBinaryOverride(t, launcher)
+	opts := SetupOpts{DataDir: filepath.Join(root, "data"), HookFailMode: "closed"}
+	entry := NewHookContractLockEntry(opts, NewClaudeCodeConnector(), "test")
+	if entry.HookScriptDigests[windowsHookBinaryName] == "" {
+		t.Fatalf("native launcher digest missing: %v", entry.HookScriptDigests)
+	}
+	if !stringInSlice(entry.Locations.HookScriptPaths, launcher) {
+		t.Fatalf("native launcher path missing: %v", entry.Locations.HookScriptPaths)
 	}
 }
 
@@ -508,16 +581,20 @@ func TestWindowsNativeConfigMatrix(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read native hook config sidecar: %v", err)
 			}
-			if !strings.Contains(string(hookCfg), "DEFENSECLAW_GATEWAY_ADDR=127.0.0.1:18970") {
-				t.Errorf("hook config sidecar missing API address: %s", hookCfg)
+			var hookState hookConfigSidecar
+			if err := json.Unmarshal(hookCfg, &hookState); err != nil {
+				t.Fatalf("parse native hook config sidecar: %v", err)
+			}
+			if hookState.GatewayAddr != "127.0.0.1:18970" {
+				t.Errorf("hook config sidecar API address = %q", hookState.GatewayAddr)
 			}
 			wantFailMode := resolveHookFailMode(opts, tt.conn)
 			if hp, ok := tt.conn.(HookCapabilityProvider); ok &&
 				wantFailMode == "closed" && !hp.HookCapabilities(opts).SupportsFailClosed {
 				wantFailMode = "open"
 			}
-			if !strings.Contains(string(hookCfg), "DEFENSECLAW_FAIL_MODE="+wantFailMode) {
-				t.Errorf("hook config sidecar fail mode = %q, want %q", hookCfg, wantFailMode)
+			if got := hookState.FailModes[connectorName]; got != wantFailMode {
+				t.Errorf("hook config sidecar fail mode = %q, want %q", got, wantFailMode)
 			}
 
 			if err := tt.conn.Teardown(context.Background(), opts); err != nil {

--- a/internal/gateway/connector/hookwiring_test.go
+++ b/internal/gateway/connector/hookwiring_test.go
@@ -17,8 +17,10 @@
 package connector
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -39,10 +41,10 @@ func TestWindowsHookConfigSidecarPreservesMixedConnectorModes(t *testing.T) {
 		t.Skip("Windows connector-aware hook sidecar")
 	}
 	dir := t.TempDir()
-	if err := writeHookConfigSidecar(dir, "127.0.0.1:18970", "claudecode", "closed"); err != nil {
+	if err := writeHookConfigSidecar(dir, "127.0.0.1:18970", "claudecode", "closed", false); err != nil {
 		t.Fatal(err)
 	}
-	if err := writeHookConfigSidecar(dir, "127.0.0.1:18970", "codex", "open"); err != nil {
+	if err := writeHookConfigSidecar(dir, "127.0.0.1:18970", "codex", "open", false); err != nil {
 		t.Fatal(err)
 	}
 	data, err := os.ReadFile(filepath.Join(dir, hookConfigSidecarName))
@@ -68,7 +70,7 @@ func TestWindowsHookConfigSidecarMigratesLegacyScalar(t *testing.T) {
 	if err := os.WriteFile(path, legacy, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := writeHookConfigSidecar(dir, "127.0.0.1:18970", "claudecode", "closed"); err != nil {
+	if err := writeHookConfigSidecar(dir, "127.0.0.1:18970", "claudecode", "closed", false); err != nil {
 		t.Fatal(err)
 	}
 	data, err := os.ReadFile(path)
@@ -84,6 +86,105 @@ func TestWindowsHookConfigSidecarMigratesLegacyScalar(t *testing.T) {
 	}
 	if state.LegacyMode != "open" {
 		t.Fatalf("legacy fallback was not retained for unmigrated connector peers: %#v", state)
+	}
+}
+
+func TestHookConfigSidecarClearRemovesOnlySelectedConnector(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeHookConfigSidecar(dir, "127.0.0.1:18970", "claudecode", "closed", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeHookConfigSidecar(dir, "127.0.0.1:18970", "codex", "open", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := clearHookConfigSidecarEntry(dir, "claudecode"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, hookConfigSidecarName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state hookConfigSidecar
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := state.FailModes["claudecode"]; ok {
+		t.Fatalf("selected connector survived clear: %#v", state.FailModes)
+	}
+	if state.FailModes["codex"] != "open" {
+		t.Fatalf("peer connector changed during clear: %#v", state.FailModes)
+	}
+	if _, err := os.Stat(filepath.Join(dir, hookConfigSidecarName+".claudecode")); !os.IsNotExist(err) {
+		t.Fatalf("selected flat runtime record survived clear: %v", err)
+	}
+	peer, err := os.ReadFile(filepath.Join(dir, hookConfigSidecarName+".codex"))
+	if err != nil || !strings.Contains(string(peer), "DEFENSECLAW_FAIL_MODE=open") {
+		t.Fatalf("peer flat runtime record changed: err=%v body=%q", err, peer)
+	}
+}
+
+func TestHookConfigSidecarWriteRejectsMalformedPeerState(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, hookConfigSidecarName)
+	before := []byte(`{"version":2,"fail_modes":`)
+	if err := os.WriteFile(path, before, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeHookConfigSidecar(dir, "127.0.0.1:18970", "claudecode", "closed", false); err == nil {
+		t.Fatal("malformed peer runtime state was overwritten")
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatal("failed sidecar write changed malformed peer state")
+	}
+}
+
+func TestHookConfigSidecarSecondWriteFailureRollsBackBothFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeHookConfigSidecar(dir, "127.0.0.1:18970", "claudecode", "open", false); err != nil {
+		t.Fatal(err)
+	}
+	jsonPath := filepath.Join(dir, hookConfigSidecarName)
+	flatPath := filepath.Join(dir, hookConfigSidecarName+".claudecode")
+	jsonBefore, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	flatBefore, err := os.ReadFile(flatPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writes := 0
+	failSecond := func(path string, data []byte, mode os.FileMode) error {
+		writes++
+		if writes == 2 {
+			return errors.New("injected flat sidecar failure")
+		}
+		return atomicWriteFile(path, data, mode)
+	}
+	if err := writeHookConfigSidecarUsing(
+		dir,
+		"127.0.0.1:18970",
+		"claudecode",
+		"closed",
+		false,
+		failSecond,
+	); err == nil {
+		t.Fatal("injected second-file failure was ignored")
+	}
+	jsonAfter, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	flatAfter, err := os.ReadFile(flatPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(jsonAfter, jsonBefore) || !bytes.Equal(flatAfter, flatBefore) {
+		t.Fatal("second-file failure left JSON and flat runtime state changed")
 	}
 }
 

--- a/internal/gateway/connector/subprocess.go
+++ b/internal/gateway/connector/subprocess.go
@@ -413,7 +413,7 @@ func WriteHookScriptsWithToken(hookDir, apiAddr, token string) error {
 		}
 	}
 
-	if err := writeHookConfigSidecar(hookDir, apiAddr, "", defaultHookFailMode); err != nil {
+	if err := writeHookConfigSidecar(hookDir, apiAddr, "", defaultHookFailMode, false); err != nil {
 		return err
 	}
 
@@ -460,7 +460,7 @@ func writeHookScriptsCommonWithOptions(hookDir, apiAddr, token, failMode string,
 		return err
 	}
 
-	data := templateData{
+	connectorData := templateData{
 		APIAddr:       apiAddr,
 		APIToken:      "",
 		FailMode:      normalizeHookFailMode(failMode),
@@ -471,15 +471,17 @@ func writeHookScriptsCommonWithOptions(hookDir, apiAddr, token, failMode string,
 		HookBinaryPS:  strings.ReplaceAll(defenseclawHookBinary(), "'", "''"),
 		HookTimeoutMS: cursorAdapterTimeoutMS,
 	}
-
-	scripts := hookScriptNamesFromExtras(extras)
-
-	for _, name := range scripts {
+	// The inspect-* family has one physical copy per data directory.  Its
+	// bytes must therefore depend only on install-wide inputs; connector mode,
+	// identity and scoped credential selection happen at invocation time.  The
+	// connector-owned lifecycle scripts retain the selected connector data.
+	sharedData := templateData{APIAddr: apiAddr, Managed: managed}
+	renderAndWrite := func(name string, renderData templateData) error {
 		content, err := hookFS.ReadFile("hooks/" + name)
 		if err != nil {
 			return fmt.Errorf("read hook template %s: %w", name, err)
 		}
-		rendered, err := renderTemplate(string(content), data)
+		rendered, err := renderTemplate(string(content), renderData)
 		if err != nil {
 			return fmt.Errorf("render hook %s: %w", name, err)
 		}
@@ -487,8 +489,20 @@ func writeHookScriptsCommonWithOptions(hookDir, apiAddr, token, failMode string,
 		if err := atomicWriteFile(hookPath, []byte(rendered), 0o700); err != nil {
 			return fmt.Errorf("write hook %s: %w", name, err)
 		}
+		return nil
 	}
-	if err := writeHookConfigSidecar(hookDir, apiAddr, connectorName, normalizeHookFailMode(failMode)); err != nil {
+	for _, name := range genericHookScripts {
+		if err := renderAndWrite(name, sharedData); err != nil {
+			return err
+		}
+	}
+	scripts := hookScriptNamesFromExtras(extras)
+	for _, name := range scripts[len(genericHookScripts):] {
+		if err := renderAndWrite(name, connectorData); err != nil {
+			return err
+		}
+	}
+	if err := writeHookConfigSidecar(hookDir, apiAddr, connectorName, normalizeHookFailMode(failMode), managed); err != nil {
 		return err
 	}
 	return nil
@@ -524,18 +538,16 @@ func writeHookTokenFiles(hookDir, connectorName, token string) (string, error) {
 	return filepath.Base(scopedPath), nil
 }
 
-// hookConfigSidecarName is the file the native Go hook entrypoint reads on
-// Windows for the gateway address + connector-scoped fail modes. It lets the agent hook command
-// stay free of per-install flags (so its trust-hash / match string is stable),
-// while still conveying the operator's enforcement choice and a non-default
-// API port. The Bash hooks (Unix) bake these values into the script and ignore
-// this file.
+// hookConfigSidecarName is the shared connector-aware runtime state read by
+// the native Windows hook and the generic Unix inspect scripts. It lets hook
+// commands stay free of per-install flags while preserving mixed fail modes.
 const hookConfigSidecarName = ".hookcfg"
 
 type hookConfigSidecar struct {
 	Version     int               `json:"version"`
 	GatewayAddr string            `json:"gateway_addr"`
 	FailModes   map[string]string `json:"fail_modes,omitempty"`
+	Managed     bool              `json:"managed_enterprise,omitempty"`
 	// LegacyMode is migration-only fallback for connectors that do not yet
 	// have a map entry. Connector entries always win, so it cannot collapse a
 	// mixed-mode runtime and becomes inert after every peer is refreshed.
@@ -543,42 +555,240 @@ type hookConfigSidecar struct {
 }
 
 // writeHookConfigSidecar persists the gateway address and connector fail mode
-// the native Go hook entrypoint resolves at runtime. It is only written on Windows, where
-// connectors either invoke the native entrypoint directly or, for Cursor, via
-// the PowerShell input adapter. Unix keeps the .sh hooks unchanged and never
-// reads this file.
-func writeHookConfigSidecar(hookDir, apiAddr, connectorName, failMode string) error {
-	if runtime.GOOS != "windows" {
-		return nil
+// resolved at runtime. Connector entries always win; the legacy fallback is
+// written only for unscoped callers and cannot collapse mixed connector state.
+func writeHookConfigSidecar(hookDir, apiAddr, connectorName, failMode string, managed bool) error {
+	return writeHookConfigSidecarUsing(hookDir, apiAddr, connectorName, failMode, managed, atomicWriteFile)
+}
+
+type hookRuntimeFileSnapshot struct {
+	path    string
+	existed bool
+	data    []byte
+}
+
+func snapshotHookRuntimeFile(path string) (hookRuntimeFileSnapshot, error) {
+	snapshot := hookRuntimeFileSnapshot{path: path}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return snapshot, nil
 	}
+	if err != nil {
+		return snapshot, err
+	}
+	snapshot.existed = true
+	snapshot.data = data
+	return snapshot, nil
+}
+
+func restoreHookRuntimeFiles(snapshots []hookRuntimeFileSnapshot) error {
+	var failures []string
+	for i := len(snapshots) - 1; i >= 0; i-- {
+		snapshot := snapshots[i]
+		if snapshot.existed {
+			if err := atomicWriteFile(snapshot.path, snapshot.data, 0o600); err != nil {
+				failures = append(failures, fmt.Sprintf("%s: %v", snapshot.path, err))
+			}
+			continue
+		}
+		if err := os.Remove(snapshot.path); err != nil && !os.IsNotExist(err) {
+			failures = append(failures, fmt.Sprintf("%s: %v", snapshot.path, err))
+		}
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("restore hook runtime files: %s", strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+func writeHookConfigSidecarUsing(
+	hookDir, apiAddr, connectorName, failMode string,
+	managed bool,
+	writeFile func(string, []byte, os.FileMode) error,
+) error {
 	path := filepath.Join(hookDir, hookConfigSidecarName)
 	return withFileLock(path, func() error {
-		state := hookConfigSidecar{Version: 2, GatewayAddr: apiAddr, FailModes: map[string]string{}}
-		if existing, err := os.ReadFile(path); err == nil {
+		name := normalizeConnectorName(connectorName)
+		runtimeName := name
+		if runtimeName == "" {
+			runtimeName = "legacy"
+		}
+		flatPath := filepath.Join(hookDir, hookConfigSidecarName+"."+runtimeName)
+		jsonSnapshot, err := snapshotHookRuntimeFile(path)
+		if err != nil {
+			return fmt.Errorf("read hook config sidecar: %w", err)
+		}
+		flatSnapshot, err := snapshotHookRuntimeFile(flatPath)
+		if err != nil {
+			return fmt.Errorf("read shell hook runtime sidecar: %w", err)
+		}
+		snapshots := []hookRuntimeFileSnapshot{jsonSnapshot, flatSnapshot}
+
+		state := hookConfigSidecar{Version: 2, GatewayAddr: apiAddr, FailModes: map[string]string{}, Managed: managed}
+		if jsonSnapshot.existed {
 			var prior hookConfigSidecar
-			if json.Unmarshal(existing, &prior) == nil && prior.Version >= 2 {
+			if err := json.Unmarshal(jsonSnapshot.data, &prior); err == nil {
+				if prior.Version != 2 {
+					return fmt.Errorf("unsupported hook config sidecar version %d", prior.Version)
+				}
 				if prior.FailModes != nil {
 					state.FailModes = prior.FailModes
 				}
 				state.LegacyMode = prior.LegacyMode
 			} else {
-				state.LegacyMode = legacyHookConfigValue(existing, "DEFENSECLAW_FAIL_MODE")
+				legacyMode := legacyHookConfigValue(jsonSnapshot.data, "DEFENSECLAW_FAIL_MODE")
+				if legacyMode != "open" && legacyMode != "closed" {
+					return fmt.Errorf("parse hook config sidecar: %w", err)
+				}
+				state.LegacyMode = legacyMode
 			}
 		}
-		name := normalizeConnectorName(connectorName)
 		if name != "" {
 			state.FailModes[name] = normalizeHookFailMode(failMode)
+		} else {
+			state.LegacyMode = normalizeHookFailMode(failMode)
 		}
 		body, err := json.MarshalIndent(state, "", "  ")
 		if err != nil {
 			return fmt.Errorf("marshal hook config sidecar: %w", err)
 		}
 		body = append(body, '\n')
-		if err := atomicWriteFile(path, body, 0o600); err != nil {
+		if err := writeFile(path, body, 0o600); err != nil {
 			return fmt.Errorf("write hook config sidecar: %w", err)
+		}
+		// Shell hooks need a parser-independent connector record because jq and
+		// python3 are not guaranteed on the hardened macOS/Linux PATH.  One flat
+		// file per connector preserves mixed modes; an unscoped legacy record is
+		// a fallback only and never overrides a connector file.
+		runtimeBody := fmt.Sprintf(
+			"DEFENSECLAW_CONNECTOR=%s\nDEFENSECLAW_FAIL_MODE=%s\n",
+			name,
+			normalizeHookFailMode(failMode),
+		)
+		if err := writeFile(flatPath, []byte(runtimeBody), 0o600); err != nil {
+			if restoreErr := restoreHookRuntimeFiles(snapshots); restoreErr != nil {
+				return fmt.Errorf("write shell hook runtime sidecar: %v (%v)", err, restoreErr)
+			}
+			return fmt.Errorf("write shell hook runtime sidecar: %w", err)
 		}
 		return nil
 	})
+}
+
+// clearHookConfigSidecarEntry removes only one connector's runtime selection.
+// The shared JSON state and every peer's flat record remain intact. Runtime
+// state is cleared before its contract entry, so a teardown can never leave a
+// removed connector selectable by the shared Unix hooks.
+func clearHookConfigSidecarEntry(hookDir, connectorName string) error {
+	name := normalizeConnectorName(connectorName)
+	if strings.TrimSpace(hookDir) == "" || name == "" {
+		return nil
+	}
+	if _, err := os.Stat(hookDir); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("inspect hook runtime directory: %w", err)
+	}
+	path := filepath.Join(hookDir, hookConfigSidecarName)
+	return withFileLock(path, func() error {
+		_, err := clearHookConfigSidecarEntryLocked(hookDir, name)
+		return err
+	})
+}
+
+func clearHookConfigSidecarEntryLocked(hookDir, name string) ([]hookRuntimeFileSnapshot, error) {
+	path := filepath.Join(hookDir, hookConfigSidecarName)
+	flatPath := filepath.Join(hookDir, hookConfigSidecarName+"."+name)
+	jsonSnapshot, err := snapshotHookRuntimeFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read hook config sidecar: %w", err)
+	}
+	flatSnapshot, err := snapshotHookRuntimeFile(flatPath)
+	if err != nil {
+		return nil, fmt.Errorf("read shell hook runtime sidecar: %w", err)
+	}
+	snapshots := []hookRuntimeFileSnapshot{jsonSnapshot, flatSnapshot}
+	if jsonSnapshot.existed {
+		var state hookConfigSidecar
+		if err := json.Unmarshal(jsonSnapshot.data, &state); err != nil {
+			// A legacy scalar sidecar has no connector entry to remove and
+			// remains available for unmigrated callers. Unknown malformed JSON
+			// is not overwritten because that could destroy peer state.
+			legacyMode := legacyHookConfigValue(jsonSnapshot.data, "DEFENSECLAW_FAIL_MODE")
+			if legacyMode != "open" && legacyMode != "closed" {
+				return nil, fmt.Errorf("parse hook config sidecar: %w", err)
+			}
+		} else {
+			if state.Version != 2 {
+				return nil, fmt.Errorf("unsupported hook config sidecar version %d", state.Version)
+			}
+			if _, ok := state.FailModes[name]; ok {
+				delete(state.FailModes, name)
+				body, err := json.MarshalIndent(state, "", "  ")
+				if err != nil {
+					return nil, fmt.Errorf("marshal hook config sidecar: %w", err)
+				}
+				body = append(body, '\n')
+				if err := atomicWriteFile(path, body, 0o600); err != nil {
+					return nil, fmt.Errorf("write hook config sidecar: %w", err)
+				}
+			}
+		}
+	}
+	if err := os.Remove(flatPath); err != nil && !os.IsNotExist(err) {
+		if restoreErr := restoreHookRuntimeFiles(snapshots); restoreErr != nil {
+			return nil, fmt.Errorf("remove shell hook runtime sidecar: %v (%v)", err, restoreErr)
+		}
+		return nil, fmt.Errorf("remove shell hook runtime sidecar: %w", err)
+	}
+	return snapshots, nil
+}
+
+// validateHookRuntimeStateForContract closes the reconcile/teardown race: a
+// contract entry is committed only while its connector-aware JSON and flat
+// runtime records still agree. Absence of the shared sidecar is tolerated for
+// legacy/direct lock writers that do not install hooks; once the sidecar
+// exists, a missing or stale selected entry is an error.
+func validateHookRuntimeStateForContract(dataDir, connectorName, failMode string) error {
+	name := normalizeConnectorName(connectorName)
+	if strings.TrimSpace(dataDir) == "" || name == "" {
+		return nil
+	}
+	if name != "claudecode" && name != "codex" {
+		return nil
+	}
+	hookDir := filepath.Join(dataDir, "hooks")
+	path := filepath.Join(hookDir, hookConfigSidecarName)
+	body, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read hook config sidecar: %w", err)
+	}
+	var state hookConfigSidecar
+	if err := json.Unmarshal(body, &state); err != nil {
+		return fmt.Errorf("parse hook config sidecar: %w", err)
+	}
+	if state.Version != 2 {
+		return fmt.Errorf("unsupported hook config sidecar version %d", state.Version)
+	}
+	want := normalizeHookFailMode(failMode)
+	if got := state.FailModes[name]; got != want {
+		return fmt.Errorf("connector %s JSON fail mode %q, want %q", name, got, want)
+	}
+	flatPath := filepath.Join(hookDir, hookConfigSidecarName+"."+name)
+	flat, err := os.ReadFile(flatPath)
+	if err != nil {
+		return fmt.Errorf("read connector shell runtime sidecar: %w", err)
+	}
+	if got := legacyHookConfigValue(flat, "DEFENSECLAW_CONNECTOR"); got != name {
+		return fmt.Errorf("shell runtime connector %q, want %q", got, name)
+	}
+	if got := legacyHookConfigValue(flat, "DEFENSECLAW_FAIL_MODE"); got != want {
+		return fmt.Errorf("connector %s shell fail mode %q, want %q", name, got, want)
+	}
+	return nil
 }
 
 func legacyHookConfigValue(data []byte, wanted string) string {

--- a/internal/gateway/connector/subprocess.go
+++ b/internal/gateway/connector/subprocess.go
@@ -18,6 +18,7 @@ package connector
 
 import (
 	"embed"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -45,7 +46,7 @@ var shimBinaries = []string{"curl", "wget", "ssh", "nc", "pip", "npm"}
 type templateData struct {
 	APIAddr       string
 	APIToken      string // gateway bearer token; empty when unconfigured (loopback-allow)
-	FailMode      string // "closed" (default, response-layer fails block) or "open" (response-layer fails allow with a stderr warning); transport failures (gateway unreachable / 5xx) always fail open in the hooks unless DEFENSECLAW_STRICT_AVAILABILITY=1
+	FailMode      string // "closed" blocks response/transport failures; "open" allows with a warning; strict availability always blocks
 	Managed       bool
 	TokenFile     string
 	ScopedToken   bool
@@ -54,20 +55,13 @@ type templateData struct {
 	HookTimeoutMS int    // Cursor adapter child timeout; zero for templates that do not use it
 }
 
-// defaultHookFailMode is the fail mode injected into the response-
-// layer ({{.FailMode}}) of every hook when the caller doesn't supply
-// an explicit override. It governs ONLY response-layer failures —
-// 4xx, malformed JSON, missing action — where the gateway answered
-// but the answer was wrong (typically misconfiguration). Transport-
-// layer failures (curl exit non-zero, 5xx) are handled by each
-// hook's fail_unreachable helper in _hardening.sh and ALWAYS fail
-// open unless the operator opts into strict availability via
-// DEFENSECLAW_STRICT_AVAILABILITY=1.
+// defaultHookFailMode is injected into every hook when the caller does not
+// supply an explicit override. It governs malformed/incomplete responses,
+// authorization failures, and transport failures consistently. Strict
+// availability remains an unconditional force-closed override.
 //
-// "closed" is the safer default: a response-layer failure (4xx,
-// malformed JSON, missing action) means the gateway answered but the
-// verdict is untrustworthy, so the hook BLOCKS the tool/prompt rather
-// than forwarding an uninspected action. Operators who would rather
+// "closed" is the safer default: an absent or untrustworthy verdict BLOCKS
+// rather than forwarding an uninspected action. Operators who would rather
 // accept an observability gap than a hard block during a DefenseClaw
 // outage can flip this to "open" via DEFENSECLAW_FAIL_MODE=open at
 // runtime, or through the per-connector setup flow (which also
@@ -419,7 +413,7 @@ func WriteHookScriptsWithToken(hookDir, apiAddr, token string) error {
 		}
 	}
 
-	if err := writeHookConfigSidecar(hookDir, apiAddr, defaultHookFailMode); err != nil {
+	if err := writeHookConfigSidecar(hookDir, apiAddr, "", defaultHookFailMode); err != nil {
 		return err
 	}
 
@@ -494,7 +488,7 @@ func writeHookScriptsCommonWithOptions(hookDir, apiAddr, token, failMode string,
 			return fmt.Errorf("write hook %s: %w", name, err)
 		}
 	}
-	if err := writeHookConfigSidecar(hookDir, apiAddr, normalizeHookFailMode(failMode)); err != nil {
+	if err := writeHookConfigSidecar(hookDir, apiAddr, connectorName, normalizeHookFailMode(failMode)); err != nil {
 		return err
 	}
 	return nil
@@ -531,29 +525,70 @@ func writeHookTokenFiles(hookDir, connectorName, token string) (string, error) {
 }
 
 // hookConfigSidecarName is the file the native Go hook entrypoint reads on
-// Windows for the gateway address + fail mode. It lets the agent hook command
+// Windows for the gateway address + connector-scoped fail modes. It lets the agent hook command
 // stay free of per-install flags (so its trust-hash / match string is stable),
 // while still conveying the operator's enforcement choice and a non-default
 // API port. The Bash hooks (Unix) bake these values into the script and ignore
 // this file.
 const hookConfigSidecarName = ".hookcfg"
 
-// writeHookConfigSidecar persists the gateway address and fail mode the native
-// Go hook entrypoint resolves at runtime. It is only written on Windows, where
+type hookConfigSidecar struct {
+	Version     int               `json:"version"`
+	GatewayAddr string            `json:"gateway_addr"`
+	FailModes   map[string]string `json:"fail_modes,omitempty"`
+	// LegacyMode is migration-only fallback for connectors that do not yet
+	// have a map entry. Connector entries always win, so it cannot collapse a
+	// mixed-mode runtime and becomes inert after every peer is refreshed.
+	LegacyMode string `json:"legacy_fail_mode,omitempty"`
+}
+
+// writeHookConfigSidecar persists the gateway address and connector fail mode
+// the native Go hook entrypoint resolves at runtime. It is only written on Windows, where
 // connectors either invoke the native entrypoint directly or, for Cursor, via
 // the PowerShell input adapter. Unix keeps the .sh hooks unchanged and never
 // reads this file.
-func writeHookConfigSidecar(hookDir, apiAddr, failMode string) error {
+func writeHookConfigSidecar(hookDir, apiAddr, connectorName, failMode string) error {
 	if runtime.GOOS != "windows" {
 		return nil
 	}
-	body := fmt.Sprintf("DEFENSECLAW_GATEWAY_ADDR=%s\nDEFENSECLAW_FAIL_MODE=%s\n",
-		apiAddr, normalizeHookFailMode(failMode))
 	path := filepath.Join(hookDir, hookConfigSidecarName)
-	if err := atomicWriteFile(path, []byte(body), 0o600); err != nil {
-		return fmt.Errorf("write hook config sidecar: %w", err)
+	return withFileLock(path, func() error {
+		state := hookConfigSidecar{Version: 2, GatewayAddr: apiAddr, FailModes: map[string]string{}}
+		if existing, err := os.ReadFile(path); err == nil {
+			var prior hookConfigSidecar
+			if json.Unmarshal(existing, &prior) == nil && prior.Version >= 2 {
+				if prior.FailModes != nil {
+					state.FailModes = prior.FailModes
+				}
+				state.LegacyMode = prior.LegacyMode
+			} else {
+				state.LegacyMode = legacyHookConfigValue(existing, "DEFENSECLAW_FAIL_MODE")
+			}
+		}
+		name := normalizeConnectorName(connectorName)
+		if name != "" {
+			state.FailModes[name] = normalizeHookFailMode(failMode)
+		}
+		body, err := json.MarshalIndent(state, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal hook config sidecar: %w", err)
+		}
+		body = append(body, '\n')
+		if err := atomicWriteFile(path, body, 0o600); err != nil {
+			return fmt.Errorf("write hook config sidecar: %w", err)
+		}
+		return nil
+	})
+}
+
+func legacyHookConfigValue(data []byte, wanted string) string {
+	for _, line := range strings.Split(string(data), "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if ok && strings.TrimSpace(strings.TrimPrefix(key, "export ")) == wanted {
+			return strings.Trim(strings.TrimSpace(value), `"'`)
+		}
 	}
-	return nil
+	return ""
 }
 
 func hookScriptNamesForConnector(opts SetupOpts, c Connector) []string {
@@ -634,10 +669,9 @@ func WriteHookScriptsForConnectorObject(hookDir, apiAddr, token string, c Connec
 //     connectors stay fail-open and rely on their config writer to omit
 //     vendor fail-closed fields.
 //
-// Transport-layer failures (gateway unreachable / 5xx) are NOT
-// governed by FailMode — they always allow unless the operator opts
-// in via DEFENSECLAW_STRICT_AVAILABILITY=1, regardless of which
-// connector or HookFailMode value.
+// Transport-layer failures (gateway unreachable / timeout / 5xx) follow
+// FailMode too. DEFENSECLAW_STRICT_AVAILABILITY=1 remains an unconditional
+// force-closed override.
 func WriteHookScriptsForConnectorObjectWithOpts(hookDir string, opts SetupOpts, c Connector) error {
 	var extras []string
 	if owner, ok := c.(HookScriptOwner); ok {

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -2172,7 +2172,7 @@ func (s *Sidecar) runGuardrail(ctx context.Context) error {
 		// default "open" is applied uniformly when the field is unset
 		// — matches the user-friendly default in defaultsFor() and
 		// avoids a partial install accidentally going fail-closed.
-		HookFailMode:     s.currentConfig().Guardrail.EffectiveHookFailMode(),
+		HookFailMode:     s.currentConfig().EffectiveHookFailModeForConnector(conn.Name()),
 		HILTEnabled:      s.currentConfig().Guardrail.HILT.Enabled,
 		InstallCodeGuard: false,
 		AgentVersion:     agentVersion,

--- a/internal/gateway/sidecar_multi_boot_test.go
+++ b/internal/gateway/sidecar_multi_boot_test.go
@@ -425,8 +425,8 @@ func TestConnectorSetupOpts_PerConnectorHookFailMode(t *testing.T) {
 		t.Errorf("cursor HookFailMode=%q, want override %q", cursorOpts.HookFailMode, "closed")
 	}
 	windsurfOpts := mustConnectorSetupOpts(t, s, &bootStubConnector{stubConnector: stubConnector{name: "windsurf"}}, "tok", "a", "b")
-	if windsurfOpts.HookFailMode != "open" {
-		t.Errorf("windsurf HookFailMode=%q, want observe-mode open", windsurfOpts.HookFailMode)
+	if windsurfOpts.HookFailMode != "closed" {
+		t.Errorf("windsurf HookFailMode=%q, want connector override independent of observe mode", windsurfOpts.HookFailMode)
 	}
 }
 


### PR DESCRIPTION
## Stack

1. [#444 - Build the native Windows connector foundation](https://github.com/cisco-ai-defense/defenseclaw/pull/444)
2. [#418 - Complete native Windows support and CI hardening](https://github.com/cisco-ai-defense/defenseclaw/pull/418)
3. [#427 - Harden native Windows connectors and documentation](https://github.com/cisco-ai-defense/defenseclaw/pull/427)
4. [#441 - Fix native Windows regressions](https://github.com/cisco-ai-defense/defenseclaw/pull/441)
5. [#442 - Certify full test suites on native Windows](https://github.com/cisco-ai-defense/defenseclaw/pull/442)
6. [#443 - Complete native Windows release readiness](https://github.com/cisco-ai-defense/defenseclaw/pull/443)
7. [#445 - Add native Windows Local Splunk support](https://github.com/cisco-ai-defense/defenseclaw/pull/445)
8. [#446 - Repair native Windows MCP package launching](https://github.com/cisco-ai-defense/defenseclaw/pull/446)
9. [#447 - Reconcile connector-scoped fail-mode runtime](https://github.com/cisco-ai-defense/defenseclaw/pull/447)
10. [#448 - Apply registry requirements to active connectors](https://github.com/cisco-ai-defense/defenseclaw/pull/448)
11. [#449 - Preserve skill quarantine recovery provenance](https://github.com/cisco-ai-defense/defenseclaw/pull/449)

Merge bottom-up in this order. The top branch contains the complete manually testable result. Every incremental PR remains below CodeRabbit's 150-file limit.

---
## Goal

Make connector-scoped fail-mode changes reconcile the effective Windows runtime without invalidating another active connector.

This is layer **9 of 11**, based on #446, and changes **34 files**.

## What changed

- Reconcile configured, registered, and sidecar fail-mode state before reporting an operation as already complete.
- Refresh only the selected connector while preserving the rest of the active connector roster.
- Store shared hook-script digests once in contract schema v2 instead of recording contradictory connector-specific hashes for one physical file.
- Migrate prior contract state and keep configuration/runtime changes transactional with rollback on failed validation.
- Add Python and Go regression coverage for both connector directions, malformed gateway responses, shared contracts, and rollback.

## Root cause

The idempotency check trusted stale raw configuration, and the contract lock recorded different expected hashes for shared hook scripts under each connector. Because only one copy exists on disk, a mutually valid multi-connector state was impossible.

## User impact

An operator can change one connector to fail-closed while the other remains fail-open, and status plus runtime behavior now agree. Failed reconciliation restores the previous safe state.

## Verification summary

- Native Windows acceptance verified both directions: selected connector malformed JSON exits 2 while the other exits 0.
- Both connector registrations remained valid simultaneously.
- The combined upper-stack regression run passed.
- This incremental layer contains 34 changed files.

## Review status

This remains a **draft PR**. Merge only after #446, then retarget the next layer to `main`.