### PR TITLE
Apply registry requirements to active connectors

### DIFF
--- a/cli/defenseclaw/commands/cmd_registry.py
+++ b/cli/defenseclaw/commands/cmd_registry.py
@@ -40,7 +40,7 @@ from typing import Any
 
 import click
 
-from defenseclaw import connector_paths, ux
+from defenseclaw import ux
 from defenseclaw.config import (
     REGISTRY_CONTENT_TYPES,
     REGISTRY_KINDS,
@@ -65,6 +65,11 @@ from defenseclaw.registries.sync import (
     ScanCallback,
     manual_set_verdict,
     promote_from_cache,
+)
+from defenseclaw.registry_policy import (
+    RegistryRequiredResult,
+    RegistryRequiredUpdateError,
+    set_registry_required,
 )
 
 # ---------------------------------------------------------------------------
@@ -1414,45 +1419,28 @@ def _do_manual_verdict(
 # require — toggle asset_policy.{type}.registry_required
 # ---------------------------------------------------------------------------
 
-def _resolve_per_connector_asset_block(
-    cfg: Config, connector: str, asset_type: str,
-):
-    """Resolve (creating if absent) the per-connector per-type scalar block
-    ``asset_policy.connectors[connector].<asset_type>`` (OTHER-7).
 
-    Returns ``(storage_key, block)``. An existing alias-equivalent key (via
-    ``connector_paths.normalize``) is reused rather than minting a second
-    entry, so the save round-trip never trips
-    :meth:`AssetPolicyConfig.validate`'s alias-collision guard. Mirrors the
-    lookup in :meth:`AssetPolicyConfig._connector_override`. Connector identity
-    is deliberately NOT validated here — matching ``validate()`` and the
-    guardrail per-connector writers, an unknown connector is left to the
-    gateway boot loop. Only the ``registry_required`` scalar is touched; any
-    existing per-connector ``mode`` / ``default`` / ``registry_empty_action``
-    and the other per-type blocks are preserved untouched.
-    """
-    from defenseclaw.config import (
-        PerConnectorAssetPolicy,
-        PerConnectorAssetTypePolicy,
-    )
-
-    conns = cfg.asset_policy.connectors
-    key = connector
-    if connector not in conns:
-        want = connector_paths.normalize(connector)
-        for name in conns:
-            if connector_paths.normalize(name) == want:
-                key = name
-                break
-    pc = conns.get(key)
-    if pc is None:
-        pc = PerConnectorAssetPolicy()
-        conns[key] = pc
-    block = getattr(pc, asset_type)
-    if block is None:
-        block = PerConnectorAssetTypePolicy()
-        setattr(pc, asset_type, block)
-    return key, block
+def _registry_required_payload(result: RegistryRequiredResult) -> dict[str, Any]:
+    return {
+        "asset_type": result.asset_type,
+        "connector": result.connector,
+        "registry_required": result.requested,
+        "global_changed": result.global_before != result.global_after,
+        "active_connectors": list(result.active_connectors),
+        "affected_connectors": [
+            {
+                "connector": change.connector,
+                "status": change.status,
+                "before": change.before,
+                "after": change.after,
+            }
+            for change in result.connectors
+        ],
+        "changed_connectors": list(result.changed_connectors),
+        "already_compliant_connectors": list(result.already_compliant_connectors),
+        "failed_connectors": [],
+        "preserved_inactive_connectors": list(result.preserved_inactive_connectors),
+    }
 
 
 @registry.command("require")
@@ -1492,51 +1480,90 @@ def require_cmd(
     the gateway: an empty registry list with require=on means "no
     asset is approved".
 
-    With ``--connector C`` the toggle is written to the per-connector
-    override ``asset_policy.connectors[C].<type>.registry_required``
-    (OTHER-7) instead of the global scalar, so one connector can require
-    a registry match while others inherit the global value. The registry
-    rule list itself stays global (rules are filtered by ``rule.connector``
-    at match time); only the scalar is per-connector.
+    With ``--connector C`` only that connector's override is changed. Without
+    ``--connector``, the global default is changed and every active connector
+    is reconciled to inherit it, so a stale opposite override cannot defeat
+    broad operator intent. Inactive connector overrides are preserved for
+    future activation. Registry rule lists stay global and continue to be
+    filtered by ``rule.connector`` at match time.
     """
     cfg = _require_cfg(app)
     asset = asset_type.lower()
     connector = (connector or "").strip()
 
-    if connector:
-        key, block = _resolve_per_connector_asset_block(cfg, connector, asset)
-        block.registry_required = bool(enabled)
-        scope_label = f"asset_policy.connectors.{key}.{asset}"
-    else:
-        key = ""
-        target = getattr(cfg.asset_policy, asset)
-        target.registry_required = bool(enabled)
-        scope_label = f"asset_policy.{asset}"
-    cfg.save()
+    try:
+        result = set_registry_required(cfg, asset, enabled, connector=connector)
+    except RegistryRequiredUpdateError as exc:
+        failed = [change.connector for change in exc.result.connectors]
+        rollback_failed = "could not be restored" in str(exc.cause)
+        if emit_json:
+            payload = _registry_required_payload(exc.result)
+            payload.update({
+                "status": "failed",
+                "error": str(exc.cause),
+                "rollback": "failed" if rollback_failed else "restored",
+                "changed_connectors": [],
+                "already_compliant_connectors": [],
+                "failed_connectors": failed,
+                "affected_connectors": [
+                    {
+                        "connector": change.connector,
+                        "status": "failed",
+                        "before": change.before,
+                        "after": change.before,
+                    }
+                    for change in exc.result.connectors
+                ],
+            })
+            _emit_json(payload)
+            raise click.exceptions.Exit(1) from exc
+        targets = ", ".join(failed) if failed else "global default"
+        rollback = "rollback failed" if rollback_failed else "previous configuration restored"
+        raise click.ClickException(
+            f"registry policy update failed for {targets}; {rollback}: {exc.cause}"
+        ) from exc
+
+    scope_label = (
+        f"asset_policy.connectors.{result.storage_key}.{asset}"
+        if result.storage_key is not None
+        else f"asset_policy.{asset}"
+    )
 
     # Messaging reads the *effective* per-type policy for the scope: rule
     # lists stay global, so the empty-list check sees the global registry;
     # the empty-action is the per-connector-resolved value when --connector
     # is in play (falls back to the global one when unset).
-    if connector:
-        effective = cfg.asset_policy.effective_asset_type_policy(connector, asset)
+    if result.connector:
+        effective = cfg.asset_policy.effective_asset_type_policy(result.connector, asset)
     else:
         effective = getattr(cfg.asset_policy, asset)
     empty_registry = len(effective.registry) == 0
     empty_action = getattr(effective, "registry_empty_action", "deny") or "deny"
 
     if emit_json:
-        _emit_json({
-            "asset_type": asset,
-            "connector": key or None,
-            "registry_required": bool(enabled),
+        payload = _registry_required_payload(result)
+        payload.update({
+            "status": "ok",
             "registry_size": len(effective.registry),
             "registry_empty_action": empty_action,
         })
+        _emit_json(payload)
         return
 
     state = "required" if enabled else "optional"
     ux.ok(f"{scope_label}.registry is now {state}.")
+    if result.connectors:
+        connector_status = ", ".join(
+            f"{change.connector} ({change.status.replace('_', ' ')})"
+            for change in result.connectors
+        )
+        ux.subhead(f"Affected connectors: {connector_status}.")
+    if result.preserved_inactive_connectors:
+        ux.subhead(
+            "Inactive connector overrides preserved: "
+            + ", ".join(result.preserved_inactive_connectors)
+            + "."
+        )
     if not enabled:
         return
 

--- a/cli/defenseclaw/config.py
+++ b/cli/defenseclaw/config.py
@@ -30,6 +30,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Callable
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field, replace
 from pathlib import Path
@@ -2657,6 +2658,45 @@ class Config:
                 owned_base=self._loaded_owned_nested_values,
             )
             write_config_yaml_secure(path, merged)
+
+    def save_verified(self, verify: Callable[[str], None]) -> None:
+        """Persist atomically, verify the written file, and roll back on failure.
+
+        ``verify`` runs while the existing per-config lock is still held, so a
+        successful return proves the exact generation written by this call was
+        inspected.  If verification fails after the atomic replace, the prior
+        YAML document is atomically restored before the error is re-raised.
+        Callers should mutate a copy of the live :class:`Config` and publish
+        that copy back to their in-memory state only after this method returns.
+        """
+        path = str(config_path_for_data_dir(self.data_dir))
+        dataclass_data = _config_to_dict(self)
+        owned_keys = _owned_top_level_keys(self)
+        with locked_config_yaml(path):
+            existed = os.path.exists(path)
+            existing = _load_existing_config_yaml(path)
+            merged = _merge_preserving_unmodeled(
+                existing,
+                dataclass_data,
+                owned_keys,
+                authoritative_base=self._loaded_authoritative_dicts,
+                owned_base=self._loaded_owned_nested_values,
+            )
+            write_config_yaml_secure(path, merged)
+            try:
+                verify(path)
+            except Exception as verify_error:
+                try:
+                    if existed:
+                        write_config_yaml_secure(path, existing)
+                    else:
+                        os.unlink(path)
+                except Exception as rollback_error:
+                    raise RuntimeError(
+                        "config verification failed and the previous configuration "
+                        f"could not be restored: {rollback_error}"
+                    ) from verify_error
+                raise
 
 
 # ---------------------------------------------------------------------------

--- a/cli/defenseclaw/registry_policy.py
+++ b/cli/defenseclaw/registry_policy.py
@@ -1,0 +1,304 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared mutation service for ``asset_policy.*.registry_required``.
+
+The gateway resolves this scalar as ``connector override > global``.  A broad
+operator write therefore has to reconcile active connector overrides rather
+than changing only the global default.  This module is shared by the CLI and
+the TUI config editor so both surfaces apply the same precedence semantics.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+
+from defenseclaw import connector_paths
+from defenseclaw.config import (
+    Config,
+    PerConnectorAssetPolicy,
+    PerConnectorAssetTypePolicy,
+)
+
+_ASSET_TYPES = frozenset({"skill", "mcp", "plugin"})
+
+
+@dataclass(frozen=True)
+class ConnectorRegistryRequiredChange:
+    """One connector's effective state before and after reconciliation."""
+
+    connector: str
+    before: bool
+    after: bool
+
+    @property
+    def status(self) -> str:
+        return "already_compliant" if self.before == self.after else "changed"
+
+
+@dataclass(frozen=True)
+class RegistryRequiredResult:
+    """Mutation result used for verification and operator-facing reporting."""
+
+    asset_type: str
+    requested: bool
+    connector: str | None
+    storage_key: str | None
+    global_before: bool
+    global_after: bool
+    active_connectors: tuple[str, ...]
+    connectors: tuple[ConnectorRegistryRequiredChange, ...]
+    preserved_inactive_connectors: tuple[str, ...]
+
+    @property
+    def changed_connectors(self) -> tuple[str, ...]:
+        return tuple(change.connector for change in self.connectors if change.status == "changed")
+
+    @property
+    def already_compliant_connectors(self) -> tuple[str, ...]:
+        return tuple(change.connector for change in self.connectors if change.status == "already_compliant")
+
+
+class RegistryRequiredUpdateError(RuntimeError):
+    """A registry-required transaction failed and did not update live state."""
+
+    def __init__(self, result: RegistryRequiredResult, cause: BaseException) -> None:
+        self.result = result
+        self.cause = cause
+        super().__init__(str(cause))
+
+
+def _asset_type(asset_type: str) -> str:
+    value = str(asset_type or "").strip().lower()
+    if value not in _ASSET_TYPES:
+        raise ValueError(f"unsupported asset type {asset_type!r}")
+    return value
+
+
+def _active_connectors(cfg: Config) -> tuple[str, ...]:
+    """Return the canonical roster from Config's multi-connector resolver."""
+    names: set[str] = set()
+    for raw in cfg.active_connectors():
+        value = str(raw or "").strip()
+        if value:
+            names.add(connector_paths.normalize(value))
+    return tuple(sorted(names))
+
+
+def _connector_storage_key(connectors: dict[str, Any], connector: str) -> tuple[str, str]:
+    canonical = connector_paths.normalize(connector)
+    if connector in connectors:
+        return connector, canonical
+    for name in connectors:
+        if connector_paths.normalize(name) == canonical:
+            return name, canonical
+    return canonical, canonical
+
+
+def _ensure_connector_asset_block(
+    cfg: Config,
+    connector: str,
+    asset_type: str,
+) -> tuple[str, PerConnectorAssetTypePolicy]:
+    connectors = cfg.asset_policy.connectors
+    key, _canonical = _connector_storage_key(connectors, connector)
+    policy = connectors.get(key)
+    if policy is None:
+        policy = PerConnectorAssetPolicy()
+        connectors[key] = policy
+    block = getattr(policy, asset_type)
+    if block is None:
+        block = PerConnectorAssetTypePolicy()
+        setattr(policy, asset_type, block)
+    return key, block
+
+
+def reconcile_registry_required(
+    cfg: Config,
+    asset_type: str,
+    enabled: bool,
+    *,
+    connector: str = "",
+) -> RegistryRequiredResult:
+    """Apply scoped or broad registry-required intent to an in-memory config.
+
+    Scoped writes materialize only the selected connector override.  Broad
+    writes update the global default and clear only the targeted override field
+    for every active connector, making each inherit the requested value while
+    preserving the surrounding connector/type object and every sibling field.
+
+    Explicit overrides for known but inactive connectors are intentionally left
+    untouched.  This avoids silently changing their saved posture if they are
+    activated later; a future broad operation will reconcile them once they are
+    part of :meth:`Config.active_connectors`.
+    """
+    asset = _asset_type(asset_type)
+    requested = bool(enabled)
+    selected = str(connector or "").strip()
+    global_policy = getattr(cfg.asset_policy, asset)
+    global_before = bool(global_policy.registry_required)
+    active = _active_connectors(cfg)
+
+    if selected:
+        key, canonical = _connector_storage_key(cfg.asset_policy.connectors, selected)
+        effective_before = cfg.asset_policy.effective_asset_type_policy(canonical, asset)
+        before = bool(effective_before.registry_required) if effective_before is not None else global_before
+        key, block = _ensure_connector_asset_block(cfg, selected, asset)
+        block.registry_required = requested
+        effective_after = cfg.asset_policy.effective_asset_type_policy(canonical, asset)
+        after = bool(effective_after.registry_required) if effective_after is not None else requested
+        if after != requested:
+            raise RuntimeError(f"failed to reconcile registry_required for connector {canonical}")
+        inactive = tuple(
+            sorted({
+                connector_paths.normalize(name)
+                for name in cfg.asset_policy.connectors
+                if connector_paths.normalize(name) not in active and connector_paths.normalize(name) != canonical
+            })
+        )
+        return RegistryRequiredResult(
+            asset_type=asset,
+            requested=requested,
+            connector=canonical,
+            storage_key=key,
+            global_before=global_before,
+            global_after=global_before,
+            active_connectors=active,
+            connectors=(ConnectorRegistryRequiredChange(canonical, before, after),),
+            preserved_inactive_connectors=inactive,
+        )
+
+    before_by_connector: dict[str, bool] = {}
+    for name in active:
+        effective = cfg.asset_policy.effective_asset_type_policy(name, asset)
+        before_by_connector[name] = bool(effective.registry_required) if effective is not None else global_before
+
+    global_policy.registry_required = requested
+    for name in active:
+        key, _canonical = _connector_storage_key(cfg.asset_policy.connectors, name)
+        policy = cfg.asset_policy.connectors.get(key)
+        block = getattr(policy, asset, None) if policy is not None else None
+        if block is not None:
+            # None means inherit.  Leave the block itself in place so sibling
+            # scalar overrides and the surrounding connector policy survive.
+            block.registry_required = None
+
+    changes: list[ConnectorRegistryRequiredChange] = []
+    for name in active:
+        effective = cfg.asset_policy.effective_asset_type_policy(name, asset)
+        after = bool(effective.registry_required) if effective is not None else requested
+        if after != requested:
+            raise RuntimeError(f"failed to reconcile registry_required for active connector {name}")
+        changes.append(ConnectorRegistryRequiredChange(name, before_by_connector[name], after))
+
+    inactive = tuple(
+        sorted({
+            connector_paths.normalize(name)
+            for name in cfg.asset_policy.connectors
+            if connector_paths.normalize(name) not in active
+        })
+    )
+    return RegistryRequiredResult(
+        asset_type=asset,
+        requested=requested,
+        connector=None,
+        storage_key=None,
+        global_before=global_before,
+        global_after=requested,
+        active_connectors=active,
+        connectors=tuple(changes),
+        preserved_inactive_connectors=inactive,
+    )
+
+
+def _document_connector_override(raw: dict[str, Any], connector: str) -> dict[str, Any] | None:
+    asset_policy = raw.get("asset_policy")
+    if not isinstance(asset_policy, dict):
+        return None
+    connectors = asset_policy.get("connectors")
+    if not isinstance(connectors, dict):
+        return None
+    direct = connectors.get(connector)
+    if isinstance(direct, dict):
+        return direct
+    canonical = connector_paths.normalize(connector)
+    for name, value in connectors.items():
+        if connector_paths.normalize(str(name)) == canonical and isinstance(value, dict):
+            return value
+    return None
+
+
+def _document_effective_registry_required(raw: dict[str, Any], connector: str, asset_type: str) -> bool:
+    asset_policy = raw.get("asset_policy")
+    asset_policy = asset_policy if isinstance(asset_policy, dict) else {}
+    global_policy = asset_policy.get(asset_type)
+    global_policy = global_policy if isinstance(global_policy, dict) else {}
+    global_value = global_policy.get("registry_required")
+    effective = global_value if isinstance(global_value, bool) else False
+    connector_policy = _document_connector_override(raw, connector)
+    type_override = connector_policy.get(asset_type) if connector_policy is not None else None
+    if isinstance(type_override, dict) and isinstance(type_override.get("registry_required"), bool):
+        effective = type_override["registry_required"]
+    return bool(effective)
+
+
+def _verify_registry_required(path: str, result: RegistryRequiredResult) -> None:
+    with open(path, encoding="utf-8") as stream:
+        raw = yaml.safe_load(stream) or {}
+    if not isinstance(raw, dict):
+        raise ValueError("persisted config is not a YAML mapping")
+    asset_policy = raw.get("asset_policy")
+    asset_policy = asset_policy if isinstance(asset_policy, dict) else {}
+    global_policy = asset_policy.get(result.asset_type)
+    global_policy = global_policy if isinstance(global_policy, dict) else {}
+    global_value = global_policy.get("registry_required")
+    expected_global = result.global_after
+    if global_value is not None and not isinstance(global_value, bool):
+        raise ValueError(
+            f"persisted global {result.asset_type}.registry_required={global_value!r}; expected a boolean"
+        )
+    persisted_global = global_value if isinstance(global_value, bool) else False
+    if persisted_global != expected_global:
+        raise ValueError(
+            f"persisted global {result.asset_type}.registry_required={global_value!r}; "
+            f"expected {expected_global!r}"
+        )
+    targets = (result.connector,) if result.connector is not None else result.active_connectors
+    for connector in targets:
+        if connector is None:
+            continue
+        effective = _document_effective_registry_required(raw, connector, result.asset_type)
+        if effective != result.requested:
+            raise ValueError(
+                f"persisted effective {result.asset_type}.registry_required for {connector} "
+                f"is {effective!r}; expected {result.requested!r}"
+            )
+
+
+def set_registry_required(
+    cfg: Config,
+    asset_type: str,
+    enabled: bool,
+    *,
+    connector: str = "",
+) -> RegistryRequiredResult:
+    """Reconcile, atomically persist, verify, then publish to ``cfg``."""
+    working = copy.deepcopy(cfg)
+    result = reconcile_registry_required(working, asset_type, enabled, connector=connector)
+    try:
+        working.save_verified(lambda path: _verify_registry_required(path, result))
+    except Exception as exc:
+        raise RegistryRequiredUpdateError(result, exc) from exc
+    cfg.asset_policy = working.asset_policy
+    return result

--- a/cli/defenseclaw/tui/panels/registries.py
+++ b/cli/defenseclaw/tui/panels/registries.py
@@ -366,13 +366,28 @@ class RegistriesPanelModel:
         return tuple(rows)
 
     def _registry_required(self, asset_type: str) -> bool:
-        """Read ``asset_policy.<type>.registry_required`` from the cached config.
+        """Return whether every active connector effectively requires it.
 
         Tolerant of a missing/partial config (None → False) so the require
         toggle still produces a sensible ``--enabled`` intent on a fresh
-        install where the asset-policy block hasn't been materialized yet.
+        install where the asset-policy block hasn't been materialized yet. A
+        mixed roster returns False, so the next broad toggle enables and
+        reconciles every active connector instead of trusting only the global
+        default while an opposite override remains live.
         """
         asset_policy = _get_attr(self.config, "asset_policy", "AssetPolicy", default=None)
+        active_connectors = getattr(self.config, "active_connectors", None)
+        effective_policy = getattr(asset_policy, "effective_asset_type_policy", None)
+        if callable(active_connectors) and callable(effective_policy):
+            try:
+                connectors = tuple(active_connectors())
+                if connectors:
+                    return all(
+                        bool(effective_policy(connector, asset_type).registry_required)
+                        for connector in connectors
+                    )
+            except (AttributeError, TypeError, ValueError):
+                pass
         target = _get_attr(asset_policy, asset_type, asset_type.capitalize(), default=None)
         return bool(_get_attr(target, "registry_required", "RegistryRequired", default=False))
 

--- a/cli/defenseclaw/tui/services/setup_state.py
+++ b/cli/defenseclaw/tui/services/setup_state.py
@@ -645,6 +645,8 @@ def apply_config_field(cfg: object | dict[str, Any], key: str, value: str) -> No
     if key.startswith(("skill_actions.", "mcp_actions.", "plugin_actions.")):
         _apply_action_matrix_field(cfg, key, value)
         return
+    if _apply_global_registry_required_field(cfg, key, value):
+        return
     if key.startswith("asset_policy.connectors."):
         _apply_per_connector_asset_policy_field(cfg, key, value)
         return
@@ -661,6 +663,24 @@ def apply_config_field(cfg: object | dict[str, Any], key: str, value: str) -> No
         _apply_judge_hook_connector_toggle(cfg, key, value)
         return
     _apply_typed_field(cfg, key, value)
+
+
+def _apply_global_registry_required_field(cfg: object | dict[str, Any], key: str, value: str) -> bool:
+    """Route broad TUI registry-required edits through the shared resolver."""
+    parts = key.split(".")
+    if len(parts) != 3 or parts[0] != "asset_policy" or parts[2] != "registry_required":
+        return False
+    if parts[1] not in {"skill", "mcp", "plugin"}:
+        return False
+    try:
+        from defenseclaw.config import Config  # noqa: PLC0415
+        from defenseclaw.registry_policy import reconcile_registry_required  # noqa: PLC0415
+    except Exception:  # noqa: BLE001 - dict/test fixtures use the generic writer.
+        return False
+    if not isinstance(cfg, Config):
+        return False
+    reconcile_registry_required(cfg, parts[1], value.strip().lower() == "true")
+    return True
 
 
 # B4/E4c/E4d: the config editor exposes every per-connector guardrail override.
@@ -1065,6 +1085,18 @@ def _apply_per_connector_asset_policy_field(cfg: object | dict[str, Any], key: s
         set_config_value(cfg, key, _coerce_per_connector_asset_policy_value(field_name, value))
         return
 
+    coerced = _coerce_per_connector_asset_policy_value(field_name, value)
+    if field_name == "registry_required" and coerced is not None:
+        try:
+            from defenseclaw.config import Config  # noqa: PLC0415
+            from defenseclaw.registry_policy import reconcile_registry_required  # noqa: PLC0415
+        except Exception:  # noqa: BLE001 - continue through the typed fallback.
+            pass
+        else:
+            if isinstance(cfg, Config):
+                reconcile_registry_required(cfg, asset_type, coerced, connector=connector)
+                return
+
     try:
         from defenseclaw.config import PerConnectorAssetPolicy, PerConnectorAssetTypePolicy  # noqa: PLC0415
     except Exception:  # noqa: BLE001 - degrade to the dict fallback.
@@ -1093,7 +1125,7 @@ def _apply_per_connector_asset_policy_field(cfg: object | dict[str, Any], key: s
                     setattr(replacement_block, sib_key, sib_val)
         setattr(entry, asset_type, replacement_block)
         block = replacement_block
-    setattr(block, field_name, _coerce_per_connector_asset_policy_value(field_name, value))
+    setattr(block, field_name, coerced)
 
 
 _BOOL_FIELD_KEYS = frozenset(

--- a/cli/tests/test_cmd_registry.py
+++ b/cli/tests/test_cmd_registry.py
@@ -462,6 +462,14 @@ class TestRegistryRequire(RegistryCommandTestBase):
         with patch.dict(os.environ, {"DEFENSECLAW_HOME": self.tmp_dir}):
             return config_mod.load()
 
+    def _activate(self, *connectors):
+        from defenseclaw.config import PerConnectorGuardrailConfig
+
+        self.app.cfg.guardrail.connectors = {
+            connector: PerConnectorGuardrailConfig()
+            for connector in connectors
+        }
+
     def test_require_per_connector_write(self):
         # --connector writes the per-connector override, NOT the global scalar.
         result = self.invoke([
@@ -559,6 +567,275 @@ class TestRegistryRequire(RegistryCommandTestBase):
         self.assertFalse(
             self.app.cfg.asset_policy.connectors["codex"].mcp.registry_required
         )
+
+    def test_require_unscoped_reconciles_skill_and_mcp_both_directions(self):
+        from defenseclaw.config import (
+            AssetPolicyConfig,
+            PerConnectorAssetPolicy,
+            PerConnectorAssetTypePolicy,
+        )
+
+        cases = (
+            ("skill", False, True, "codex"),
+            ("skill", True, False, "codex"),
+            ("mcp", False, True, "claudecode"),
+            ("mcp", True, False, "claudecode"),
+        )
+        for asset_type, initial, requested, opposite_connector in cases:
+            with self.subTest(
+                asset_type=asset_type,
+                initial=initial,
+                requested=requested,
+                opposite_connector=opposite_connector,
+            ):
+                self.app.cfg.asset_policy = AssetPolicyConfig()
+                self._activate("codex", "claudecode")
+                global_policy = getattr(self.app.cfg.asset_policy, asset_type)
+                global_policy.registry_required = initial
+                peer = "claudecode" if opposite_connector == "codex" else "codex"
+                setattr(
+                    self.app.cfg.asset_policy.connectors.setdefault(
+                        opposite_connector, PerConnectorAssetPolicy(),
+                    ),
+                    asset_type,
+                    PerConnectorAssetTypePolicy(registry_required=initial),
+                )
+                setattr(
+                    self.app.cfg.asset_policy.connectors.setdefault(
+                        peer, PerConnectorAssetPolicy(),
+                    ),
+                    asset_type,
+                    PerConnectorAssetTypePolicy(registry_required=requested),
+                )
+                self.app.cfg.save()
+
+                flag = "--enabled" if requested else "--disabled"
+                result = self.invoke(["require", "--type", asset_type, flag, "--json"])
+
+                self.assertEqual(result.exit_code, 0, result.output)
+                payload = json.loads(result.output)
+                self.assertEqual(payload["changed_connectors"], [opposite_connector])
+                self.assertEqual(payload["already_compliant_connectors"], [peer])
+                self.assertEqual(payload["failed_connectors"], [])
+                self.assertEqual(payload["active_connectors"], ["claudecode", "codex"])
+                self.assertEqual(
+                    getattr(self.app.cfg.asset_policy, asset_type).registry_required,
+                    requested,
+                )
+                for connector in ("codex", "claudecode"):
+                    effective = self.app.cfg.asset_policy.effective_asset_type_policy(
+                        connector, asset_type,
+                    )
+                    self.assertEqual(effective.registry_required, requested)
+                    block = getattr(self.app.cfg.asset_policy.connectors[connector], asset_type)
+                    self.assertIsNone(block.registry_required)
+
+    def test_require_unscoped_preserves_unrelated_fields_rules_filters_and_inactive_override(self):
+        from defenseclaw.config import (
+            AssetPolicyRule,
+            PerConnectorAssetPolicy,
+            PerConnectorAssetTypePolicy,
+        )
+
+        self._activate("codex", "claudecode")
+        ap = self.app.cfg.asset_policy
+        ap.mode = "action"
+        ap.skill.registry_required = False
+        ap.skill.registry = [AssetPolicyRule(name="approved", connector="codex", reason="registry:corp")]
+        ap.skill.allowed = [AssetPolicyRule(name="manual", connector="claudecode")]
+        ap.skill.denied = [AssetPolicyRule(name="blocked", connector="codex")]
+        ap.connectors = {
+            "codex": PerConnectorAssetPolicy(
+                mode="observe",
+                skill=PerConnectorAssetTypePolicy(
+                    default="deny",
+                    registry_required=False,
+                    registry_empty_action="warn",
+                ),
+                mcp=PerConnectorAssetTypePolicy(
+                    default="allow",
+                    registry_required=True,
+                    registry_empty_action="allow",
+                ),
+            ),
+            "claudecode": PerConnectorAssetPolicy(
+                skill=PerConnectorAssetTypePolicy(registry_required=False),
+            ),
+            "cursor": PerConnectorAssetPolicy(
+                mode="action",
+                skill=PerConnectorAssetTypePolicy(
+                    default="deny",
+                    registry_required=False,
+                    registry_empty_action="deny",
+                ),
+            ),
+        }
+        self.app.cfg.save()
+
+        result = self.invoke(["require", "--type", "skill", "--enabled", "--json"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["preserved_inactive_connectors"], ["cursor"])
+        reloaded = self._reload_cfg().asset_policy
+        self.assertTrue(reloaded.skill.registry_required)
+        self.assertEqual(reloaded.skill.registry[0].connector, "codex")
+        self.assertEqual(reloaded.skill.registry[0].reason, "registry:corp")
+        self.assertEqual(reloaded.skill.allowed[0].connector, "claudecode")
+        self.assertEqual(reloaded.skill.denied[0].connector, "codex")
+        codex = reloaded.connectors["codex"]
+        self.assertEqual(codex.mode, "observe")
+        self.assertEqual(codex.skill.default, "deny")
+        self.assertEqual(codex.skill.registry_empty_action, "warn")
+        self.assertIsNone(codex.skill.registry_required)
+        self.assertTrue(codex.mcp.registry_required)
+        self.assertEqual(codex.mcp.registry_empty_action, "allow")
+        cursor = reloaded.connectors["cursor"]
+        self.assertEqual(cursor.mode, "action")
+        self.assertFalse(cursor.skill.registry_required)
+        self.assertEqual(cursor.skill.default, "deny")
+
+    def test_require_scoped_updates_only_selected_connector_for_codex_and_claude(self):
+        from defenseclaw.config import (
+            AssetPolicyConfig,
+            PerConnectorAssetPolicy,
+            PerConnectorAssetTypePolicy,
+        )
+
+        for selected, peer in (("codex", "claudecode"), ("claudecode", "codex")):
+            with self.subTest(selected=selected):
+                self.app.cfg.asset_policy = AssetPolicyConfig()
+                self._activate("codex", "claudecode")
+                self.app.cfg.asset_policy.skill.registry_required = False
+                self.app.cfg.asset_policy.connectors = {
+                    "codex": PerConnectorAssetPolicy(
+                        mode="action",
+                        skill=PerConnectorAssetTypePolicy(
+                            default="deny", registry_required=False, registry_empty_action="warn",
+                        ),
+                    ),
+                    "claudecode": PerConnectorAssetPolicy(
+                        mode="observe",
+                        skill=PerConnectorAssetTypePolicy(
+                            default="allow", registry_required=False, registry_empty_action="allow",
+                        ),
+                    ),
+                }
+                self.app.cfg.save()
+                peer_before = self.app.cfg.asset_policy.connectors[peer].skill
+
+                result = self.invoke([
+                    "require", "--type", "skill", "--enabled",
+                    "--connector", selected, "--json",
+                ])
+
+                self.assertEqual(result.exit_code, 0, result.output)
+                payload = json.loads(result.output)
+                self.assertEqual(payload["connector"], selected)
+                self.assertEqual(payload["changed_connectors"], [selected])
+                self.assertFalse(self.app.cfg.asset_policy.skill.registry_required)
+                selected_block = self.app.cfg.asset_policy.connectors[selected].skill
+                self.assertTrue(selected_block.registry_required)
+                self.assertEqual(selected_block.default, "deny" if selected == "codex" else "allow")
+                peer_after = self.app.cfg.asset_policy.connectors[peer].skill
+                self.assertEqual(peer_after, peer_before)
+
+    def test_require_unscoped_is_idempotent_and_reports_already_compliant(self):
+        self._activate("codex", "claudecode")
+
+        first = self.invoke(["require", "--type", "mcp", "--enabled", "--json"])
+        second = self.invoke(["require", "--type", "mcp", "--enabled", "--json"])
+
+        self.assertEqual(first.exit_code, 0, first.output)
+        self.assertEqual(second.exit_code, 0, second.output)
+        payload = json.loads(second.output)
+        self.assertEqual(payload["changed_connectors"], [])
+        self.assertEqual(payload["already_compliant_connectors"], ["claudecode", "codex"])
+        self.assertFalse(payload["global_changed"])
+
+    def test_require_uses_normalized_active_roster_and_existing_alias_key(self):
+        from defenseclaw.config import (
+            PerConnectorAssetPolicy,
+            PerConnectorAssetTypePolicy,
+        )
+
+        self._activate("Codex", "open-hands")
+        self.app.cfg.asset_policy.connectors = {
+            "codex": PerConnectorAssetPolicy(
+                mcp=PerConnectorAssetTypePolicy(registry_required=False),
+            ),
+            "open_hands": PerConnectorAssetPolicy(
+                mcp=PerConnectorAssetTypePolicy(registry_required=False),
+            ),
+        }
+        self.app.cfg.save()
+
+        result = self.invoke(["require", "--type", "mcp", "--enabled", "--json"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["active_connectors"], ["codex", "openhands"])
+        self.assertIsNone(self.app.cfg.asset_policy.connectors["codex"].mcp.registry_required)
+        self.assertIsNone(self.app.cfg.asset_policy.connectors["open_hands"].mcp.registry_required)
+        self.assertNotIn("openhands", self.app.cfg.asset_policy.connectors)
+
+    def test_require_verification_failure_rolls_back_and_reports_failed_connectors(self):
+        import yaml
+        from defenseclaw.config import (
+            PerConnectorAssetPolicy,
+            PerConnectorAssetTypePolicy,
+        )
+
+        self._activate("codex", "claudecode")
+        self.app.cfg.asset_policy.skill.registry_required = False
+        self.app.cfg.asset_policy.connectors["codex"] = PerConnectorAssetPolicy(
+            skill=PerConnectorAssetTypePolicy(registry_required=False),
+        )
+        self.app.cfg.save()
+        config_path = os.path.join(self.tmp_dir, "config.yaml")
+        with open(config_path, encoding="utf-8") as stream:
+            before = yaml.safe_load(stream)
+
+        with patch(
+            "defenseclaw.registry_policy._verify_registry_required",
+            side_effect=RuntimeError("verification fixture"),
+        ):
+            result = self.invoke(["require", "--type", "skill", "--enabled", "--json"])
+
+        self.assertEqual(result.exit_code, 1, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "failed")
+        self.assertEqual(payload["failed_connectors"], ["claudecode", "codex"])
+        self.assertEqual(payload["changed_connectors"], [])
+        with open(config_path, encoding="utf-8") as stream:
+            self.assertEqual(yaml.safe_load(stream), before)
+        self.assertFalse(self.app.cfg.asset_policy.skill.registry_required)
+        self.assertFalse(
+            self.app.cfg.asset_policy.effective_asset_type_policy("codex", "skill").registry_required
+        )
+
+    def test_require_write_failure_keeps_previous_configuration_and_exits_nonzero(self):
+        import yaml
+
+        self._activate("codex", "claudecode")
+        self.app.cfg.asset_policy.mcp.registry_required = False
+        self.app.cfg.save()
+        config_path = os.path.join(self.tmp_dir, "config.yaml")
+        with open(config_path, encoding="utf-8") as stream:
+            before = yaml.safe_load(stream)
+
+        with patch(
+            "defenseclaw.config.write_config_yaml_secure",
+            side_effect=OSError("write fixture"),
+        ):
+            result = self.invoke(["require", "--type", "mcp", "--enabled", "--json"])
+
+        self.assertEqual(result.exit_code, 1, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["failed_connectors"], ["claudecode", "codex"])
+        with open(config_path, encoding="utf-8") as stream:
+            self.assertEqual(yaml.safe_load(stream), before)
+        self.assertFalse(self.app.cfg.asset_policy.mcp.registry_required)
 
 
 class TestFileAdapterPathValidation(RegistryCommandTestBase):

--- a/cli/tests/tui/test_registries_panel.py
+++ b/cli/tests/tui/test_registries_panel.py
@@ -299,6 +299,41 @@ def test_registries_panel_remove_source_only_from_sources_tab(tmp_path: Path) ->
     assert panel.handle_key("d").handled is False
 
 
+def test_registries_panel_mixed_effective_state_toggles_broad_enforcement_on(tmp_path: Path) -> None:
+    from defenseclaw.config import (
+        GuardrailConfig,
+        PerConnectorAssetPolicy,
+        PerConnectorAssetTypePolicy,
+        PerConnectorGuardrailConfig,
+    )
+
+    write_index(
+        tmp_path,
+        "corp-skills",
+        {"verdicts": [{"name": "demo-skill", "type": "skill", "status": "clean"}]},
+    )
+    cfg = new_panel(tmp_path).config
+    cfg.guardrail = GuardrailConfig(
+        connectors={
+            "codex": PerConnectorGuardrailConfig(),
+            "claudecode": PerConnectorGuardrailConfig(),
+        },
+    )
+    cfg.asset_policy.skill.registry_required = True
+    cfg.asset_policy.connectors["codex"] = PerConnectorAssetPolicy(
+        skill=PerConnectorAssetTypePolicy(registry_required=False),
+    )
+    panel = RegistriesPanelModel(cfg)
+    panel.set_tab(RegistriesTab.ENTRIES)
+
+    action = panel.handle_key("R")
+
+    assert action.intent is not None
+    assert action.intent.args == (
+        "registry", "require", "--type", "skill", "--enabled", "--json",
+    )
+
+
 def test_registries_panel_approve_requires_selection(tmp_path: Path) -> None:
     panel = new_panel(tmp_path)
     panel.set_tab(RegistriesTab.ENTRIES)

--- a/cli/tests/tui/test_setup_panel.py
+++ b/cli/tests/tui/test_setup_panel.py
@@ -2696,3 +2696,55 @@ def test_per_connector_asset_policy_field_writes_typed_override() -> None:
 
     apply_config_field(cfg, "asset_policy.connectors.hermes.mcp.registry_required", "")
     assert entry.mcp.registry_required is None
+
+
+def test_global_registry_required_field_reconciles_every_active_connector() -> None:
+    from defenseclaw.config import PerConnectorAssetPolicy, PerConnectorAssetTypePolicy
+    from defenseclaw.tui.services.setup_state import apply_config_field
+
+    cfg = _multi_connector_cfg()
+    cfg.asset_policy.skill.registry_required = False
+    cfg.asset_policy.connectors = {
+        "codex": PerConnectorAssetPolicy(
+            mode="action",
+            skill=PerConnectorAssetTypePolicy(
+                default="deny", registry_required=False, registry_empty_action="warn",
+            ),
+        ),
+        "hermes": PerConnectorAssetPolicy(
+            skill=PerConnectorAssetTypePolicy(registry_required=True),
+        ),
+    }
+
+    apply_config_field(cfg, "asset_policy.skill.registry_required", "true")
+
+    assert cfg.asset_policy.skill.registry_required is True
+    for connector in ("codex", "hermes"):
+        assert cfg.asset_policy.effective_asset_type_policy(connector, "skill").registry_required is True
+        assert cfg.asset_policy.connectors[connector].skill.registry_required is None
+    assert cfg.asset_policy.connectors["codex"].mode == "action"
+    assert cfg.asset_policy.connectors["codex"].skill.default == "deny"
+    assert cfg.asset_policy.connectors["codex"].skill.registry_empty_action == "warn"
+
+
+def test_scoped_registry_required_field_uses_same_resolver_without_peer_changes() -> None:
+    from defenseclaw.config import PerConnectorAssetPolicy, PerConnectorAssetTypePolicy
+    from defenseclaw.tui.services.setup_state import apply_config_field
+
+    cfg = _multi_connector_cfg()
+    cfg.asset_policy.mcp.registry_required = True
+    cfg.asset_policy.connectors = {
+        "codex": PerConnectorAssetPolicy(mcp=PerConnectorAssetTypePolicy(registry_required=True)),
+        "hermes": PerConnectorAssetPolicy(
+            mode="observe",
+            mcp=PerConnectorAssetTypePolicy(default="deny", registry_required=True),
+        ),
+    }
+
+    apply_config_field(cfg, "asset_policy.connectors.codex.mcp.registry_required", "false")
+
+    assert cfg.asset_policy.mcp.registry_required is True
+    assert cfg.asset_policy.connectors["codex"].mcp.registry_required is False
+    assert cfg.asset_policy.connectors["hermes"].mcp.registry_required is True
+    assert cfg.asset_policy.connectors["hermes"].mcp.default == "deny"
+    assert cfg.asset_policy.connectors["hermes"].mode == "observe"

--- a/docs-site/content/docs/setup/registries.mdx
+++ b/docs-site/content/docs/setup/registries.mdx
@@ -157,9 +157,9 @@ Each entry is run through the MCP scanner (transport probe + behavioral introspe
       type: 'subcommand',
       description: 'Mark an entry rejected (always blocked, even if the scanner is clean). --type skill|mcp required.',
     },
-    'require --type skill|mcp|plugin --enabled|--disabled': {
+    'require --type skill|mcp --enabled|--disabled [--connector <name>]': {
       type: 'subcommand',
-      description: 'Toggle asset_policy.<type>.registry_required. When enabled, an asset must match a rule in the (type) registry list to bypass the default deny.',
+      description: 'Scope registry_required to one connector, or update the global default and reconcile every active connector. Inactive connector overrides are preserved.',
     },
     'wizard': {
       type: 'subcommand',
@@ -204,6 +204,15 @@ Once entries are flowing in, `asset_policy.<type>.registry_required` flips the c
 defenseclaw registry require --type skill --enabled
 defenseclaw registry require --type mcp   --enabled
 ```
+
+An unscoped operation is broad operator intent: it updates the global default
+and clears only the targeted `registry_required` override on every active
+connector, so stale opposite overrides cannot keep enforcement disabled. All
+other per-connector fields and the global registry rule/filter lists remain
+unchanged. `--connector <name>` changes only that connector's explicit
+override. Known but inactive connector overrides are preserved so future
+activation does not silently inherit a weaker or stronger posture than the one
+previously saved.
 
 When `registry_required=true`:
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -154,7 +154,7 @@ External skill / MCP catalog ingestion. See
 | `registry entries <id> [--approved\|--rejected]` | Show cached entries (after sync); operator-override filters |
 | `registry approve <id> <name> --type {skill\|mcp}` | Manually approve an entry |
 | `registry reject <id> <name> --type {skill\|mcp}` | Manually reject an entry (sets status to `blocked`) |
-| `registry require --type <t> --enabled/--disabled` | Toggle `asset_policy.<t>.registry_required` |
+| `registry require --type <t> --enabled/--disabled [--connector <name>]` | Scope to one connector, or update the global default and reconcile all active connectors |
 | `registry wizard` | Interactive add+sync convenience flow |
 | `setup registry` | Wrapper for `registry wizard` so it shows up in `setup --help` |
 

--- a/docs/REGISTRIES.md
+++ b/docs/REGISTRIES.md
@@ -164,7 +164,7 @@ and CI/CD pipelines call, with `--json` for machine-readable output.
 | `registry entries <id> [--approved/--rejected]` | Show cached entries (after sync) |
 | `registry approve <id> <name> --type {skill\|mcp}` | Mark approved |
 | `registry reject <id> <name> --type {skill\|mcp}` | Mark rejected (sets status to `blocked`) |
-| `registry require --type <t> --enabled/--disabled` | Toggle `asset_policy.<t>.registry_required` |
+| `registry require --type <t> --enabled/--disabled [--connector <name>]` | Toggle `asset_policy.<t>.registry_required` for one connector or reconcile every active connector |
 | `registry wizard` | Interactive add+sync convenience flow |
 | `setup registry` | Discoverable shortcut from `defenseclaw setup` that drops into the wizard |
 
@@ -243,6 +243,18 @@ Tighten admission so only registry-approved skills are allowed:
 ```bash
 defenseclaw registry require --type skill --enabled
 ```
+
+Without `--connector`, the command updates the global default and removes only
+the `registry_required` override for each active connector so every active
+connector inherits the requested value. Other connector policy fields and the
+global registry rule/filter lists are preserved. With `--connector`, only that
+connector's explicit override changes; the global default and peer connectors
+remain untouched.
+
+Overrides belonging to known but inactive connectors are deliberately
+preserved. This avoids silently changing their saved enforcement posture if
+they are activated later; a future unscoped operation reconciles them once
+they join the active roster.
 
 ---
 


### PR DESCRIPTION
## Stack

1. [#444 - Build the native Windows connector foundation](https://github.com/cisco-ai-defense/defenseclaw/pull/444)
2. [#418 - Complete native Windows support and CI hardening](https://github.com/cisco-ai-defense/defenseclaw/pull/418)
3. [#427 - Harden native Windows connectors and documentation](https://github.com/cisco-ai-defense/defenseclaw/pull/427)
4. [#441 - Fix native Windows regressions](https://github.com/cisco-ai-defense/defenseclaw/pull/441)
5. [#442 - Certify full test suites on native Windows](https://github.com/cisco-ai-defense/defenseclaw/pull/442)
6. [#443 - Complete native Windows release readiness](https://github.com/cisco-ai-defense/defenseclaw/pull/443)
7. [#445 - Add native Windows Local Splunk support](https://github.com/cisco-ai-defense/defenseclaw/pull/445)
8. [#446 - Repair native Windows MCP package launching](https://github.com/cisco-ai-defense/defenseclaw/pull/446)
9. [#447 - Reconcile connector-scoped fail-mode runtime](https://github.com/cisco-ai-defense/defenseclaw/pull/447)
10. [#448 - Apply registry requirements to active connectors](https://github.com/cisco-ai-defense/defenseclaw/pull/448)
11. [#449 - Preserve skill quarantine recovery provenance](https://github.com/cisco-ai-defense/defenseclaw/pull/449)

Merge bottom-up in this order. The top branch contains the complete manually testable result. Every incremental PR remains below CodeRabbit's 150-file limit.

---
## Goal

Make unscoped registry requirements apply to every active connector while preserving connector-scoped isolation.

This is layer **10 of 11**, based on #447, and changes **11 files**.

## What changed

- Apply unscoped skill and MCP registry enable/disable operations to the global value and every active connector.
- Remove only conflicting `registry_required` overrides while preserving unrelated connector policy fields and inactive connector state.
- Keep `--connector` operations isolated to the selected connector.
- Report the connectors actually affected in CLI and TUI flows.
- Add regressions for opposite explicit overrides in both directions for skill and MCP policy.

## Root cause

The unscoped command changed only the global default. Existing connector overrides retained higher precedence, so the command could report global enforcement enabled while an active connector remained disabled.

## User impact

Global registry commands now mean global enforcement for the active roster, while connector-specific commands remain narrow and predictable.

## Verification summary

- Focused CLI and TUI policy regressions passed.
- The combined upper-stack regression run passed.
- This incremental layer contains 11 changed files.

## Review status

This remains a **draft PR**. Merge only after #447, then retarget the next layer to `main`.