### PR TITLE
fix: omit LLM content from pretty logs

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -637,6 +637,13 @@ only affects operator-facing stderr logs (for local incident triage); it
 has no effect on SQLite, webhooks, Splunk HEC, or OTLP logs — those
 always receive the scrubbed copy.
 
+The guardrail's pretty stderr stream never prints LLM request bodies,
+individual prompt/history/tool message bodies, or response bodies. It retains
+only operational metadata such as role, content length, model, timing, token
+usage, and verdict. Because the daemon persists stderr to `gateway.log` and
+deployments commonly forward that file, this omission also applies when
+`DEFENSECLAW_REVEAL_PII=1` or global redaction is disabled.
+
 > **Never set `DEFENSECLAW_REVEAL_PII=1` in production.** This flag is
 > intended for developer workstations and short-lived incident-triage
 > sessions only. When set, the gateway will print matched literals

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -2389,15 +2389,19 @@ func (p *GuardrailProxy) handleChatCompletion(w http.ResponseWriter, r *http.Req
 		redactAuthValue(r.Header.Get("Authorization")),
 		redactAuthValue(r.Header.Get("api-key")),
 		scrubURLSecrets(r.Header.Get("X-DC-Target-URL")))
-	// The raw LLM request body frequently contains user prompts
-	// (SSNs, emails, passwords, API keys). Stderr is operator-
-	// facing, so we honor DEFENSECLAW_REVEAL_PII via
-	// redaction.MessageContent: set DEFENSECLAW_REVEAL_PII=1 to
-	// get the raw body back for live debugging. Every persistent
-	// sink (audit store, webhooks, OTel) already redacts further
-	// downstream and never consults this flag.
-	fmt.Fprintf(os.Stderr, "[guardrail] raw body (%d bytes): %s\n",
-		len(body), truncateLog(redaction.MessageContent(string(body)), 2000))
+	// Request bodies contain prompts, conversation history, and tool
+	// results. Keep only their size in the pretty stderr stream because
+	// the daemon persists that stream to gateway.log and deployments may
+	// forward it to a centralized log service. This omission is
+	// unconditional: diagnostic reveal/redaction switches must not turn
+	// gateway.log into a transcript store.
+	//
+	// TODO(v8-logging-refactor): Re-evaluate an explicit, safe local-debug
+	// channel before restoring the former preview path below. Do not uncomment
+	// it while stderr is persisted or forwarded as an operational log.
+	// fmt.Fprintf(os.Stderr, "[guardrail] raw body (%d bytes): %s\n",
+	// 	len(body), truncateLog(redaction.MessageContent(string(body)), 2000))
+	logRequestBodyMetadata(body)
 
 	var req ChatRequest
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -4038,6 +4042,10 @@ func (p *GuardrailProxy) switchConnectorLocked(newName string) {
 // Logging
 // ---------------------------------------------------------------------------
 
+func logRequestBodyMetadata(body []byte) {
+	fmt.Fprintf(os.Stderr, "[guardrail] raw body: %d bytes (content omitted)\n", len(body))
+}
+
 func (p *GuardrailProxy) logPreCall(model string, messages []ChatMessage, verdict *ScanVerdict, elapsed time.Duration) {
 	ts := time.Now().UTC().Format("15:04:05")
 	severity := verdict.Severity
@@ -4048,13 +4056,15 @@ func (p *GuardrailProxy) logPreCall(model string, messages []ChatMessage, verdic
 		ts, model, len(messages), float64(elapsed.Milliseconds()))
 
 	for i, msg := range messages {
-		// Message bodies are verbatim user/assistant text. The
-		// original length is preserved in the log so operators
-		// can still see whether a payload was trimmed by the
-		// caller; only the preview itself is masked when
-		// Reveal is off.
-		preview := truncateLog(redaction.MessageContent(msg.Content), 500)
-		fmt.Fprintf(os.Stderr, "  \033[2m[%d]\033[0m %s (%d chars): %s\n", i, msg.Role, len(msg.Content), preview)
+		// Keep role and length for diagnostics without persisting a
+		// transcript in gateway.log (or any collector fed from stderr).
+		// Content remains omitted even when diagnostic reveal is enabled.
+		//
+		// TODO(v8-logging-refactor): Preserve the former bounded preview for
+		// consideration when v8 separates local debugging from shipped logs.
+		// preview := truncateLog(redaction.MessageContent(msg.Content), 500)
+		// fmt.Fprintf(os.Stderr, "  \033[2m[%d]\033[0m %s (%d chars): %s\n", i, msg.Role, len(msg.Content), preview)
+		fmt.Fprintf(os.Stderr, "  \033[2m[%d]\033[0m %s (%d chars; content omitted)\n", i, msg.Role, len(msg.Content))
 	}
 
 	logVerdict(severity, action, verdict, elapsed)
@@ -4074,13 +4084,15 @@ func (p *GuardrailProxy) logPostCall(model, content string, verdict *ScanVerdict
 	}
 	fmt.Fprintf(os.Stderr, "\033[92m[%s]\033[0m \033[1mPOST-CALL\033[0m  model=%s%s  \033[2m%.0fms\033[0m\n",
 		ts, model, tokStr, float64(elapsed.Milliseconds()))
-	// LLM responses can echo user PII (the model re-emits
-	// personal data verbatim in summaries, translations, etc.)
-	// or surface new secrets authored by the model itself. Both
-	// flows are operator-facing; the Reveal flag gates
-	// unredacted output for live debugging.
-	preview := truncateLog(redaction.MessageContent(content), 800)
-	fmt.Fprintf(os.Stderr, "  response (%d chars): %s\n", len(content), preview)
+	// Responses can echo prompts or author new sensitive content. Retain
+	// only the size so pretty logs remain useful without becoming a
+	// transcript store. Diagnostic reveal does not override this rule.
+	//
+	// TODO(v8-logging-refactor): Preserve the former bounded preview for
+	// consideration when v8 separates local debugging from shipped logs.
+	// preview := truncateLog(redaction.MessageContent(content), 800)
+	// fmt.Fprintf(os.Stderr, "  response (%d chars): %s\n", len(content), preview)
+	fmt.Fprintf(os.Stderr, "  response (%d chars; content omitted)\n", len(content))
 
 	logVerdict(severity, action, verdict, elapsed)
 	fmt.Fprintf(os.Stderr, "\033[92m%s\033[0m\n", strings.Repeat("─", 60))

--- a/internal/gateway/proxy_pii_log_test.go
+++ b/internal/gateway/proxy_pii_log_test.go
@@ -130,3 +130,55 @@ func TestLogVerdict_NoneSeverityEmitsNoReason(t *testing.T) {
 		t.Errorf("NONE branch leaked reason: %s", out)
 	}
 }
+
+func TestLogPreCall_OmitsMessageContentEvenWhenRevealEnabled(t *testing.T) {
+	t.Setenv("DEFENSECLAW_REVEAL_PII", "1")
+	const secretPrompt = "SENTINEL user prompt that must never reach gateway.log"
+	v := &ScanVerdict{Action: "allow", Severity: "NONE"}
+
+	out := captureStderr(t, func() {
+		(&GuardrailProxy{}).logPreCall("test-model", []ChatMessage{
+			{Role: "user", Content: secretPrompt},
+		}, v, 5*time.Millisecond)
+	})
+
+	if strings.Contains(out, secretPrompt) {
+		t.Fatalf("pre-call log leaked message content: %s", out)
+	}
+	if !strings.Contains(out, "user (54 chars; content omitted)") {
+		t.Fatalf("pre-call log dropped safe message metadata: %s", out)
+	}
+}
+
+func TestLogRequestBodyMetadata_OmitsBodyEvenWhenRevealEnabled(t *testing.T) {
+	t.Setenv("DEFENSECLAW_REVEAL_PII", "1")
+	body := []byte(`{"messages":[{"role":"user","content":"SENTINEL raw request prompt"}]}`)
+
+	out := captureStderr(t, func() {
+		logRequestBodyMetadata(body)
+	})
+
+	if strings.Contains(out, "SENTINEL raw request prompt") {
+		t.Fatalf("request log leaked body content: %s", out)
+	}
+	if !strings.Contains(out, "raw body: 70 bytes (content omitted)") {
+		t.Fatalf("request log dropped safe body metadata: %s", out)
+	}
+}
+
+func TestLogPostCall_OmitsResponseContentEvenWhenRevealEnabled(t *testing.T) {
+	t.Setenv("DEFENSECLAW_REVEAL_PII", "1")
+	const secretResponse = "SENTINEL assistant response that must never reach gateway.log"
+	v := &ScanVerdict{Action: "allow", Severity: "NONE"}
+
+	out := captureStderr(t, func() {
+		(&GuardrailProxy{}).logPostCall("test-model", secretResponse, v, 5*time.Millisecond, nil)
+	})
+
+	if strings.Contains(out, secretResponse) {
+		t.Fatalf("post-call log leaked response content: %s", out)
+	}
+	if !strings.Contains(out, "response (61 chars; content omitted)") {
+		t.Fatalf("post-call log dropped safe response metadata: %s", out)
+	}
+}

--- a/internal/gateway/router.go
+++ b/internal/gateway/router.go
@@ -641,15 +641,17 @@ func (r *EventRouter) handleSessionMessage(evt EventFrame) {
 				contentStr = string(msg.Content)
 			}
 		}
-		// contentStr is a verbatim message body from an LLM
-		// session. The full length is preserved in the log
-		// metadata so operators can still tell at a glance
-		// whether the payload was truncated by the caller; only
-		// the preview is masked when Reveal is off.
-		contentPreview := truncate(redaction.MessageContent(contentStr), 120)
-
-		readLoopLogf("[bifrost] session.message: role=%s msgId=%s seq=%d session=%s content=(%d chars) %q",
-			msg.Role, envelope.MessageID, envelope.MessageSeq, envelope.SessionKey, len(contentStr), contentPreview)
+		// Session message bodies are prompts and responses. The daemon
+		// persists stderr to gateway.log, so log only routing metadata and
+		// length rather than creating a second conversation transcript.
+		//
+		// TODO(v8-logging-refactor): Preserve the former bounded preview for
+		// consideration when v8 separates local debugging from shipped logs.
+		// contentPreview := truncate(redaction.MessageContent(contentStr), 120)
+		// readLoopLogf("[bifrost] session.message: role=%s msgId=%s seq=%d session=%s content=(%d chars) %q",
+		// 	msg.Role, envelope.MessageID, envelope.MessageSeq, envelope.SessionKey, len(contentStr), contentPreview)
+		readLoopLogf("[bifrost] session.message: role=%s msgId=%s seq=%d session=%s content_len=%d content=omitted",
+			msg.Role, envelope.MessageID, envelope.MessageSeq, envelope.SessionKey, len(contentStr))
 
 		msgCtx := ContextWithSessionID(context.Background(), envelope.SessionKey)
 		msgMeta := streamLLMEventMeta(r, envelope.SessionKey, envelope.RunID, msg.Provider, msg.Model, "")


### PR DESCRIPTION
## Problem

DefenseClaw's pretty stderr logs include bounded previews of raw LLM request bodies, prompt/history/tool messages, and model responses. The daemon persists stderr to `gateway.log`, and deployments may forward that file to centralized logging, turning an operational log into a conversation transcript.

## Current Situation

The guardrail logs request, pre-call, post-call, and Bifrost session-message content through redacted preview helpers. Ordinary conversation text that does not match a redaction pattern remains visible. `DEFENSECLAW_REVEAL_PII=1` can additionally reveal matched sensitive values in operator-facing logs.

## Solution

Omit LLM message bodies unconditionally from the pretty stderr path while preserving operational metadata:

- Request body byte length
- Message role and character length
- Model, timing, token usage, and verdict details
- Session, sequence, and message identifiers

The previous bounded-preview statements remain commented beside the replacements with `TODO(v8-logging-refactor)` context so the v8 logging redesign can reconsider a dedicated local-debug channel without restoring transcript content to shipped operational logs.

Regression tests verify that request, prompt, and response bodies remain absent even when `DEFENSECLAW_REVEAL_PII=1` is enabled.

## Architecture Diagram

N/A

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `internal/gateway/proxy.go` | Replaces raw request, pre-call message, and post-call response previews with content-length metadata; preserves former preview code as v8 TODO comments. |
| `internal/gateway/router.go` | Replaces Bifrost session-message previews with role, routing identifiers, and content length; preserves the former preview code as a v8 TODO comment. |
| `internal/gateway/proxy_pii_log_test.go` | Adds regression tests proving content omission cannot be bypassed with the reveal flag. |
| `docs/OBSERVABILITY.md` | Documents the metadata-only stderr behavior and its interaction with redaction controls. |

## Breaking Changes

No API or configuration changes. Operator-facing `gateway.log` entries no longer contain LLM request, prompt/history/tool-message, or response body previews.

## Open Issues / Follow-ups

None.

## Test Plan

```bash
env GOCACHE=/private/tmp/defenseclaw-go-cache \
  go test ./internal/gateway \
  -run 'TestLog(PreCall|PostCall|RequestBodyMetadata|Verdict)' \
  -count=1
```

Observed result:

```text
ok  github.com/defenseclaw/defenseclaw/internal/gateway  0.498s
```
