### PR TITLE
fix(macos): preserve guardian auth ownership

### DIFF
--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -812,10 +812,11 @@ if [[ "${SKIP_CONNECTOR}" != "true" ]]; then
   # inherit the running uid/gid (root:defenseclaw) with mode 0644 — so
   # the daemon (running as defenseclaw) can READ but not WRITE the audit
   # DB when it comes back up. Result: every hook evaluation runs, but
-  # the audit row silently drops. Fix by re-chowning after every CLI
-  # invocation completes.
+  # the audit row silently drops. Guardian auth state is written by the
+  # same root-owned CLI invocation, so repair it before the service user
+  # resumes too.
   log "  re-chowning runtime files created by CLI migrations"
-  chown -R "${SERVICE_UID}:${SERVICE_GID}" "${RUNTIME_DIR}"
+  chown -R "${SERVICE_UID}:${SERVICE_GID}" "${RUNTIME_DIR}" "${GUARDIAN_AUTH_DIR}"
 
   log "  resuming LaunchDaemon"
   launchctl bootstrap system "${PLIST_DST}"

--- a/packaging/macos/tests/test_packaging_assets.sh
+++ b/packaging/macos/tests/test_packaging_assets.sh
@@ -162,6 +162,35 @@ ${hints}"
   fi
 }
 
+t_install_rechowns_guardian_auth_dir_after_cli() {
+  local bad
+  bad="$(/usr/bin/python3 - "${PKG_DIR}/install.sh" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+joined = re.sub(r"\\\n\s*", " ", src)
+bad = []
+lines = joined.splitlines()
+for i, line in enumerate(lines, start=1):
+    if 're-chowning runtime files created by CLI migrations' not in line:
+        continue
+    for j, candidate in enumerate(lines[i:], start=i + 1):
+        if 'chown -R "${SERVICE_UID}:${SERVICE_GID}"' in candidate:
+            if '"${RUNTIME_DIR}"' not in candidate or '"${GUARDIAN_AUTH_DIR}"' not in candidate:
+                bad.append((j, candidate.strip()[:200]))
+            break
+    else:
+        bad.append((i, "missing chown after post-CLI repair log"))
+for i, l in bad:
+    print(f"{i}: {l}")
+PY
+)"
+  if [[ -n "${bad}" ]]; then
+    _fail "post-CLI runtime ownership repair must include GUARDIAN_AUTH_DIR:
+${bad}"
+    return 1
+  fi
+}
+
 t_scrub_py_syntax() {
   local rc=0
   /usr/bin/python3 -c "import ast; ast.parse(open('${PKG_DIR}/lib/scrub_agent_configs.py').read())" 2>&1 || rc=$?
@@ -355,6 +384,8 @@ run_case "scrub_agent_configs.py syntax"          t_scrub_py_syntax
 run_case "install.sh has ensure_service_user + calls it before launchd" t_install_has_service_user_helper
 run_case "install.sh passes DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR on every hooks-install call" \
   t_install_passes_guardian_auth_dir_to_cli
+run_case "install.sh re-chowns guardian auth state after hooks-install" \
+  t_install_rechowns_guardian_auth_dir_after_cli
 run_case "bundle layout: plist + binary resolve locally" t_bundle_layout_resolves_locally
 run_case "bundle without binary + no repo dies"          t_bundle_without_binary_and_no_repo_dies
 run_case "plist validator accepts bundle default owned by extracting user" \


### PR DESCRIPTION
## Problem

Fixes #453.

The macOS managed-enterprise installer runs `enterprise hooks install` as root and passes `DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR` to the CLI. Files created under that guardian auth directory can therefore inherit root ownership, but the LaunchDaemon resumes as the DefenseClaw service user.

## Current Situation

After the root-owned hook migration, `install.sh` repairs ownership for `RUNTIME_DIR` only. That covers audit DB files, but leaves guardian auth state out of the post-migration repair even though it is written by the same CLI invocation path.

## Solution

Include `GUARDIAN_AUTH_DIR` in the post-CLI `chown -R` repair so both runtime state directories are writable by the service user before launchd resumes the daemon.

## Architecture Diagram

N/A

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `packaging/macos/install.sh` | Re-chowns `GUARDIAN_AUTH_DIR` together with `RUNTIME_DIR` after per-user hook migration. |
| `packaging/macos/tests/test_packaging_assets.sh` | Adds a static regression test that requires the post-migration ownership repair to include guardian auth state. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

- [x] `packaging/macos/tests/run_tests.sh` — observed `84 passed, 0 failed in 3s`.
- [x] `git diff --check` — observed no output / exit 0.
