### PR TITLE
fix(registry): accept OmniGent manifests

### DIFF
--- a/cli/defenseclaw/registries/manifest.py
+++ b/cli/defenseclaw/registries/manifest.py
@@ -83,6 +83,7 @@ KNOWN_CONNECTORS = {
     "openhands",
     "antigravity",
     "opencode",
+    "omnigent",
 }
 KNOWN_TYPES = {"skill", "mcp"}
 

--- a/cli/tests/test_registry_manifest.py
+++ b/cli/tests/test_registry_manifest.py
@@ -23,9 +23,11 @@ import json
 import os
 import sys
 import unittest
+from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from defenseclaw.connector_paths import KNOWN_CONNECTORS as RUNTIME_CONNECTORS
 from defenseclaw.registries.manifest import (
     KNOWN_CONNECTORS,
     KNOWN_TRANSPORTS,
@@ -34,6 +36,9 @@ from defenseclaw.registries.manifest import (
     ManifestError,
     parse_manifest,
 )
+
+ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_SCHEMA = ROOT / "schemas" / "registry-manifest.schema.json"
 
 
 def _wrap(*entries):
@@ -424,30 +429,22 @@ class TestKnownConstants(unittest.TestCase):
             {"stdio", "http", "sse", "streamable-http", "websocket"},
         )
 
-    def test_known_connectors_match_schema(self):
-        # Manifest-side allow-list must include every connector the
-        # registry/schema layer can route entries into. Hook-only
-        # connectors (cursor, windsurf, geminicli, copilot, hermes)
-        # are first-class targets in the v1 schema and have shipped
-        # ``connector:`` values in published manifests, so they must
-        # be part of this set.
-        self.assertEqual(
-            KNOWN_CONNECTORS,
-            {
-                "openclaw",
-                "claudecode",
-                "codex",
-                "zeptoclaw",
-                "hermes",
-                "cursor",
-                "windsurf",
-                "geminicli",
-                "copilot",
-                "openhands",
-                "antigravity",
-                "opencode",
-            },
-        )
+    def test_known_connectors_match_runtime(self):
+        # Published manifests can route entries into any connector the
+        # runtime recognizes, including hook-backed connectors.
+        self.assertEqual(KNOWN_CONNECTORS, set(RUNTIME_CONNECTORS))
+
+    def test_schema_connector_enums_match_runtime(self):
+        doc = json.loads(REGISTRY_SCHEMA.read_text(encoding="utf-8"))
+        expected = set(RUNTIME_CONNECTORS) | {None}
+        enums = {
+            "default_connector": doc["properties"]["default_connector"]["enum"],
+            "skill.connector": doc["$defs"]["skill_entry"]["properties"]["connector"]["enum"],
+            "mcp.connector": doc["$defs"]["mcp_entry"]["properties"]["connector"]["enum"],
+        }
+        for field, values in enums.items():
+            with self.subTest(field=field):
+                self.assertEqual(set(values), expected)
 
 
 if __name__ == "__main__":

--- a/schemas/registry-manifest.schema.json
+++ b/schemas/registry-manifest.schema.json
@@ -23,7 +23,7 @@
     },
     "default_connector": {
       "type": ["string", "null"],
-      "enum": [null, "openclaw", "claudecode", "codex", "zeptoclaw", "hermes", "cursor", "windsurf", "geminicli", "copilot", "openhands", "antigravity", "opencode"],
+      "enum": [null, "openclaw", "claudecode", "codex", "zeptoclaw", "hermes", "cursor", "windsurf", "geminicli", "copilot", "openhands", "antigravity", "opencode", "omnigent"],
       "description": "Optional default connector applied to entries that don't specify one. Per-entry `connector` overrides this."
     },
     "entries": {
@@ -70,7 +70,7 @@
         "homepage": { "type": ["string", "null"], "maxLength": 2048, "pattern": "^https?://" },
         "connector": {
           "type": ["string", "null"],
-          "enum": [null, "openclaw", "claudecode", "codex", "zeptoclaw", "hermes", "cursor", "windsurf", "geminicli", "copilot", "openhands", "antigravity", "opencode"]
+          "enum": [null, "openclaw", "claudecode", "codex", "zeptoclaw", "hermes", "cursor", "windsurf", "geminicli", "copilot", "openhands", "antigravity", "opencode", "omnigent"]
         },
         "tags": {
           "type": ["array", "null"],
@@ -130,7 +130,7 @@
         "homepage": { "type": ["string", "null"], "maxLength": 2048, "pattern": "^https?://" },
         "connector": {
           "type": ["string", "null"],
-          "enum": [null, "openclaw", "claudecode", "codex", "zeptoclaw", "hermes", "cursor", "windsurf", "geminicli", "copilot", "openhands", "antigravity", "opencode"]
+          "enum": [null, "openclaw", "claudecode", "codex", "zeptoclaw", "hermes", "cursor", "windsurf", "geminicli", "copilot", "openhands", "antigravity", "opencode", "omnigent"]
         },
         "tags": {
           "type": ["array", "null"],


### PR DESCRIPTION
## Summary
- allow OmniGent in registry manifest connector enums
- keep the Python fallback manifest validator aligned with runtime connectors
- add a regression test that compares checked-in schema connector enums to the runtime connector list

## Why
OmniGent is already a supported connector in runtime paths, installer choices, OTel schemas, and docs data, but registry manifests using it were rejected by the manifest schema and fallback validator.

## Tests
- `uv run pytest cli/tests/test_registry_manifest.py cli/tests/test_check_schemas.py -q`
- `make check-schemas`
- `uv run ruff check cli/defenseclaw/registries/manifest.py cli/tests/test_registry_manifest.py`