### PR TITLE
docs: pin legacy upgrade script examples

### DIFF
--- a/cli/tests/test_install_docs_static.py
+++ b/cli/tests/test_install_docs_static.py
@@ -21,6 +21,10 @@ BASH_INSTALL_LINES = (
     'INSTALL_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${VERSION}/scripts/install.sh"',
     'curl -LsSf "$INSTALL_URL" | VERSION="$VERSION" bash',
 )
+UPGRADE_SCRIPT_LINES = (
+    f"UPGRADE_SCRIPT_VERSION={CURRENT_RELEASE}",
+    'UPGRADE_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${UPGRADE_SCRIPT_VERSION}/scripts/upgrade.sh"',
+)
 
 DOC_INSTALL_COMMANDS = {
     "README.md": BASH_INSTALL_LINES,
@@ -64,6 +68,13 @@ def test_quickstart_docs_do_not_pipe_main_installer() -> None:
         assert "raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/install.ps1" not in text
         for expected in expected_lines:
             assert expected in text, f"{rel} is missing install snippet line: {expected}"
+
+
+def test_install_docs_do_not_pipe_main_upgrader() -> None:
+    text = (ROOT / "docs/INSTALL.md").read_text()
+    assert "raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/upgrade.sh" not in text
+    for expected in UPGRADE_SCRIPT_LINES:
+        assert expected in text
 
 
 def test_installer_help_does_not_pipe_main_installer() -> None:

--- a/cli/tests/test_install_docs_static.py
+++ b/cli/tests/test_install_docs_static.py
@@ -73,8 +73,18 @@ def test_quickstart_docs_do_not_pipe_main_installer() -> None:
 def test_install_docs_do_not_pipe_main_upgrader() -> None:
     text = (ROOT / "docs/INSTALL.md").read_text()
     assert "raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/upgrade.sh" not in text
+
+    upgrade_start = text.index("### Upgrading from 0.2.0 to an artifact-backed release")
+    rollback_start = text.index("### Rollback")
+    troubleshooting_start = text.index("## Troubleshooting")
+    upgrade_section = text[upgrade_start:rollback_start]
+    rollback_section = text[rollback_start:troubleshooting_start]
+
+    for section in (upgrade_section, rollback_section):
+        for expected in UPGRADE_SCRIPT_LINES:
+            assert expected in section
     for expected in UPGRADE_SCRIPT_LINES:
-        assert expected in text
+        assert text.count(expected) == 2
 
 
 def test_installer_help_does_not_pipe_main_installer() -> None:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -652,21 +652,27 @@ running `defenseclaw doctor` for the full report.
 
 ## Upgrading
 
-### Upgrading from 0.2.0 to 0.3.0
+### Upgrading from 0.2.0 to an artifact-backed release
 
 Release 0.2.0 does not include the `defenseclaw upgrade` CLI command. Use the
-standalone upgrade shell script instead:
+standalone upgrade shell script instead. Historical 0.3.x tags do not publish
+the wheel and gateway release assets required by the upgrader, so use 0.4.0 or
+newer as the target release.
 
 ```bash
-# Upgrade to 0.3.0 (downloads from GitHub Releases)
-curl -sSfL https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/upgrade.sh \
-  | bash -s -- --version 0.3.0
+# Upgrade to 0.4.0 (downloads from GitHub Releases)
+UPGRADE_SCRIPT_VERSION=0.8.3
+UPGRADE_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${UPGRADE_SCRIPT_VERSION}/scripts/upgrade.sh"
+curl -sSfL "$UPGRADE_URL" | bash -s -- --version 0.4.0
 ```
+
+`UPGRADE_SCRIPT_VERSION` pins the upgrade script itself; `--version` is the
+release you are installing.
 
 Or, if you have the repository cloned:
 
 ```bash
-./scripts/upgrade.sh --version 0.3.0
+./scripts/upgrade.sh --version 0.4.0
 ```
 
 Add `--yes` to skip the confirmation prompt.
@@ -683,6 +689,8 @@ After this upgrade completes, the `defenseclaw upgrade` CLI command becomes
 available for all future upgrades.
 
 #### 0.3.0 migration: legacy model provider cleanup
+
+This migration still runs when upgrading directly from 0.2.0 to 0.4.0 or newer.
 
 The 0.2.0 guardrail setup redirected LLM traffic by writing provider and model
 entries directly into `~/.openclaw/openclaw.json`:
@@ -751,8 +759,9 @@ cp ~/.defenseclaw/backups/upgrade-20260429T120000/openclaw.json ~/.openclaw/
 # Downgrade to the previous version
 defenseclaw upgrade --version 0.2.0
 # Or use the shell script if the CLI is broken:
-curl -sSfL https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/main/scripts/upgrade.sh \
-  | bash -s -- --version 0.2.0
+UPGRADE_SCRIPT_VERSION=0.8.3
+UPGRADE_URL="https://raw.githubusercontent.com/cisco-ai-defense/defenseclaw/${UPGRADE_SCRIPT_VERSION}/scripts/upgrade.sh"
+curl -sSfL "$UPGRADE_URL" | bash -s -- --version 0.2.0
 ```
 
 ---


### PR DESCRIPTION
## Summary
- replace mutable `main/scripts/upgrade.sh` examples with a pinned upgrade script version
- clarify that the script version and install target version are separate
- point the 0.2.x recovery path at 0.4.0 or newer because 0.3.x tags do not publish the release assets the upgrader requires
- add a static docs test so mutable upgrade script URLs do not come back

## Tests
- `uv run pytest cli/tests/test_install_docs_static.py -q`
- `uv run ruff check cli/tests/test_install_docs_static.py`
- `git diff --check`