### PR TITLE
test(upgrade): include latest 0.8 baselines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OC_EXT_DIR  := $(HOME)/.openclaw/extensions/defenseclaw
 RUFF        := $(shell if [ -x "$(VENV)/bin/ruff" ]; then printf '%s' "$(VENV)/bin/ruff"; elif command -v ruff >/dev/null 2>&1; then command -v ruff; else printf '%s' "$(VENV)/bin/ruff"; fi)
 
 DIST_DIR    := dist
-UPGRADE_SMOKE_FROM ?= 0.8.1 0.8.0 0.7.2 0.7.1 0.6.6 0.6.5 0.6.4 0.6.3 0.6.2 0.6.1 0.6.0 0.5.0 0.4.0
+UPGRADE_SMOKE_FROM ?= 0.8.3 0.8.2 0.8.1 0.8.0 0.7.2 0.7.1 0.6.6 0.6.5 0.6.4 0.6.3 0.6.2 0.6.1 0.6.0 0.5.0 0.4.0
 
 # Cross-platform virtualenv / executable layout. Windows Python venvs expose
 # console entry points under Scripts/ (not bin/) and binaries carry a .exe

--- a/cli/tests/test_upgrade_smoke_static.py
+++ b/cli/tests/test_upgrade_smoke_static.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UPGRADE_SMOKE_BASELINES = (
+    "0.8.3",
+    "0.8.2",
+    "0.8.1",
+    "0.8.0",
+    "0.7.2",
+    "0.7.1",
+    "0.6.6",
+    "0.6.5",
+    "0.6.4",
+    "0.6.3",
+    "0.6.2",
+    "0.6.1",
+    "0.6.0",
+    "0.5.0",
+    "0.4.0",
+)
+
+
+def test_makefile_upgrade_smoke_matrix_tracks_supported_baselines() -> None:
+    text = (ROOT / "Makefile").read_text()
+    match = re.search(r"^UPGRADE_SMOKE_FROM \?= (.+)$", text, re.MULTILINE)
+    assert match is not None
+    assert tuple(match.group(1).split()) == UPGRADE_SMOKE_BASELINES
+
+
+def test_upgrade_smoke_docs_cover_default_matrix() -> None:
+    text = (ROOT / "docs" / "TESTING.md").read_text()
+    default_line = next(
+        line for line in text.splitlines() if line.startswith("The default matrix covers")
+    )
+    for version in UPGRADE_SMOKE_BASELINES:
+        assert f"`{version}`" in default_line
+
+
+def test_upgrade_smoke_help_example_includes_latest_0_8_releases() -> None:
+    text = (ROOT / "scripts" / "test-upgrade-release.sh").read_text()
+    assert "0.8.3,0.8.2,0.8.1,0.8.0" in text

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -73,10 +73,10 @@ For a Linux host without the repo's Go toolchain, prepare candidate artifacts on
 ```bash
 scripts/test-upgrade-release.sh --prepare-only --platform linux/arm64 --keep-workdir
 scp -r /tmp/defenseclaw-upgrade-smoke.xxxxxx/candidate-release openclaw-vineeth:/tmp/
-ssh openclaw-vineeth 'scripts/test-upgrade-release.sh --release-root /tmp/candidate-release --from-versions "0.8.1,0.8.0,0.7.2,0.7.1,0.6.6,0.6.5,0.6.4,0.6.3,0.6.2,0.6.1,0.6.0,0.5.0,0.4.0" --baseline-mode seed'
+ssh openclaw-vineeth 'scripts/test-upgrade-release.sh --release-root /tmp/candidate-release --from-versions "0.8.3,0.8.2,0.8.1,0.8.0,0.7.2,0.7.1,0.6.6,0.6.5,0.6.4,0.6.3,0.6.2,0.6.1,0.6.0,0.5.0,0.4.0" --baseline-mode seed'
 ```
 
-The default matrix covers every published 0.4.0+ baseline that has both a Python wheel, platform gateway archives, and an upgrade command: `0.8.1`, `0.8.0`, `0.7.2`, `0.7.1`, `0.6.6`, `0.6.5`, `0.6.4`, `0.6.3`, `0.6.2`, `0.6.1`, `0.6.0`, `0.5.0`, and `0.4.0`. Baselines newer than the candidate target are skipped automatically so local CI does not accidentally test downgrades before a release workflow stamps the next version. Release `0.7.0` has no downloadable release assets, and `0.2.0` predates the upgrade command, so they are not live-upgradeable by this harness.
+The default matrix covers every published 0.4.0+ baseline that has both a Python wheel, platform gateway archives, and an upgrade command: `0.8.3`, `0.8.2`, `0.8.1`, `0.8.0`, `0.7.2`, `0.7.1`, `0.6.6`, `0.6.5`, `0.6.4`, `0.6.3`, `0.6.2`, `0.6.1`, `0.6.0`, `0.5.0`, and `0.4.0`. Baselines newer than the candidate target are skipped automatically so local CI does not accidentally test downgrades before a release workflow stamps the next version. Release `0.7.0` has no downloadable release assets, and `0.2.0` predates the upgrade command, so they are not live-upgradeable by this harness.
 
 The release workflow also runs `make upgrade-smoke-matrix ARGS="--release-dir dist --baseline-mode seed"` after artifacts/checksums are finalized and before `gh release create`, so a broken upgrade path aborts before assets are published.
 

--- a/scripts/test-upgrade-release.sh
+++ b/scripts/test-upgrade-release.sh
@@ -62,7 +62,7 @@ Options:
 Examples:
   make upgrade-smoke
   scripts/test-upgrade-release.sh --from-version 0.7.2
-  scripts/test-upgrade-release.sh --from-versions "0.8.1,0.8.0,0.7.2,0.7.1,0.6.6,0.6.0,0.5.0,0.4.0"
+  scripts/test-upgrade-release.sh --from-versions "0.8.3,0.8.2,0.8.1,0.8.0,0.7.2,0.7.1,0.6.6,0.6.0,0.5.0,0.4.0"
   scripts/test-upgrade-release.sh --release-dir dist --baseline-mode seed
 
 For a Linux host without the repo's Go toolchain, build/copy artifacts first:


### PR DESCRIPTION
## Summary
- add 0.8.3 and 0.8.2 to the default upgrade smoke baseline matrix
- update the release testing docs and smoke script example to match
- add a static test that keeps the Makefile matrix, docs, and script help aligned

## Tests
- `uv run pytest cli/tests/test_upgrade_smoke_static.py -q`
- `uv run ruff check cli/tests/test_upgrade_smoke_static.py`
- `bash -n scripts/test-upgrade-release.sh`
- `git diff --check`
- `make check-version-sync`