### PR TITLE
Validate macOS update archives before extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -626,6 +626,7 @@ macos-app-test:
 	macos/DefenseClawMac/script/test_output_safety.sh
 	macos/DefenseClawMac/script/test_secret_file_safety.sh
 	macos/DefenseClawMac/script/test_app_state_signal_safety.sh
+	macos/DefenseClawMac/script/test_update_checker_safety.sh
 	$(MAKE) macos-app-build
 
 macos-app-release: macos-app-license-check extensions dist-cli

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/UpdateChecker.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/UpdateChecker.swift
@@ -124,6 +124,16 @@ actor UpdateChecker {
 
     // MARK: - Download + install + restart
 
+    struct ZipArchiveEntry: Equatable {
+        var path: String
+        var mode: String
+    }
+
+    enum ArchiveValidationResult: Equatable {
+        case success(appBundleName: String)
+        case failure(String)
+    }
+
     /// Downloads the release zip, swaps the current bundle, and relaunches.
     /// Returns an error message, or never returns (the app restarts) on success.
     func downloadAndInstall(_ release: ReleaseInfo, progress: @Sendable @escaping (UpgradeState) -> Void) async -> String? {
@@ -169,6 +179,16 @@ actor UpdateChecker {
         // Unpack with ditto (preserves bundle structure + signature).
         let unpackDir = stage.appendingPathComponent("unpacked")
         try? FileManager.default.createDirectory(at: unpackDir, withIntermediateDirectories: true)
+        let entries = await Self.listZipEntries(zipPath)
+        guard entries.exitCode == 0 else {
+            return "Could not inspect update archive: \(entries.output)"
+        }
+        switch Self.validateUpdateArchive(entries: Self.parseZipEntries(entries.output)) {
+        case .success:
+            break
+        case .failure(let message):
+            return "Refusing unsafe update archive: \(message)"
+        }
         let unzip = await Self.runProcess("/usr/bin/ditto", ["-xk", zipPath.path, unpackDir.path])
         guard unzip.exitCode == 0 else { return "Unpack failed: \(unzip.output)" }
         let appNames = (try? FileManager.default.contentsOfDirectory(atPath: unpackDir.path))?
@@ -259,6 +279,57 @@ actor UpdateChecker {
     }
 
     // MARK: - Process helper
+
+    nonisolated static func validateUpdateArchive(entries: [ZipArchiveEntry]) -> ArchiveValidationResult {
+        guard !entries.isEmpty else {
+            return .failure("archive is empty")
+        }
+        var topLevelNames = Set<String>()
+        var appBundleName: String?
+        for entry in entries {
+            let path = entry.path.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let first = path.split(separator: "/", omittingEmptySubsequences: true).first else {
+                return .failure("empty archive path")
+            }
+            guard !path.hasPrefix("/"), !path.hasPrefix("~") else {
+                return .failure("unsafe path \(path)")
+            }
+            let components = path.split(separator: "/", omittingEmptySubsequences: true)
+            guard !components.contains("..") else {
+                return .failure("unsafe path \(path)")
+            }
+            guard !entry.mode.hasPrefix("l") && !entry.mode.hasPrefix("h") else {
+                return .failure("link entry \(path) is not allowed")
+            }
+            let root = String(first)
+            topLevelNames.insert(root)
+            if root.hasSuffix(".app") {
+                if appBundleName == nil {
+                    appBundleName = root
+                } else if appBundleName != root {
+                    return .failure("archive must contain a single top-level .app bundle")
+                }
+            }
+        }
+        guard topLevelNames.count == 1, let appBundleName else {
+            return .failure("archive must contain a single top-level .app bundle")
+        }
+        return .success(appBundleName: appBundleName)
+    }
+
+    nonisolated static func parseZipEntries(_ output: String) -> [ZipArchiveEntry] {
+        output.split(whereSeparator: \.isNewline).compactMap { rawLine in
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard !line.isEmpty else { return nil }
+            let fields = line.split(separator: " ", maxSplits: 8, omittingEmptySubsequences: true)
+            guard fields.count >= 9 else { return nil }
+            return ZipArchiveEntry(path: String(fields[8]), mode: String(fields[0]))
+        }
+    }
+
+    nonisolated static func listZipEntries(_ zipPath: URL) async -> (exitCode: Int32, output: String) {
+        await runProcess("/usr/bin/zipinfo", ["-l", zipPath.path])
+    }
 
     nonisolated static func runProcess(
         _ launchPath: String,

--- a/macos/DefenseClawMac/README.md
+++ b/macos/DefenseClawMac/README.md
@@ -27,7 +27,7 @@ Native SwiftUI companion app for [Cisco DefenseClaw](https://github.com/cisco-ai
 Every DefenseClaw release builds two Apple Silicon artifacts:
 
 - `DefenseClawMac-<version>-macos-arm64[-unverified].dmg` — the recommended unified installer. Mount it, drag `DefenseClawMac.app` to `/Applications`, launch it, then select **Install DefenseClaw Runtime** on first run.
-- `DefenseClawMac-<version>-macos-arm64[-unverified].zip` — the smaller app-only artifact used by the in-app self-updater. It does not replace or reinstall the independently updating runtime.
+- `DefenseClawMac-<version>-macos-arm64[-unverified].zip` — the smaller app-only artifact. Only the verified form without `-unverified` is eligible for in-app self-update; it does not replace or reinstall the independently updating runtime.
 
 The app inside the DMG contains an embedded `Contents/Resources/RuntimePayload` with the matching release's:
 
@@ -38,9 +38,11 @@ The app inside the DMG contains an embedded `Contents/Resources/RuntimePayload` 
 
 On first run, the app installs that payload into the user's normal DefenseClaw locations. It can download Python dependencies from PyPI and install `uv` or Python if they are missing, so the installer is unified but not fully offline. Configuration, tokens, and the audit database are preserved during install or repair.
 
-The current release does not require Apple credentials. Both ad-hoc artifacts are deliberately labeled `unverified`; macOS may require users to right-click the app and choose **Open**. The same release script automatically signs and notarizes the app-only build, unified app, and DMG when the documented GitHub environment secrets are added.
+The production GitHub release workflow defaults to failing closed unless the macOS app is Developer ID signed and notarized. Local builds without Apple credentials may still produce clearly labeled `-unverified` artifacts for manual testing, but the in-app self-updater ignores them and always requires code-signature and Gatekeeper validation.
 
-### Enable Apple verification later
+Before extracting an accepted update ZIP, the app verifies its GitHub-provided SHA-256 digest and inspects the archive manifest. It rejects empty archives, absolute or traversal paths, link entries, multiple app bundles, and content outside one top-level `.app`. After extraction it validates the bundle identity, version, runtime boundary, code signature, and Gatekeeper assessment before replacing the running app.
+
+### Production Apple verification
 
 Add these secrets to the GitHub `release` environment:
 
@@ -77,7 +79,7 @@ make dist-cli
 make macos-app-release
 ```
 
-The last target writes the unified DMG and app-only update zip to `dist/`. By default both are ad-hoc signed and carry the `-unverified` suffix.
+The last target writes the unified DMG and app-only update zip to `dist/`. A local invocation without Apple credentials produces ad-hoc artifacts carrying the `-unverified` suffix; the production release workflow sets `MACOS_REQUIRE_NOTARIZATION=true` and refuses that fallback.
 
 ## Runtime connections
 

--- a/macos/DefenseClawMac/Tests/UpdateCheckerSafetyTests.swift
+++ b/macos/DefenseClawMac/Tests/UpdateCheckerSafetyTests.swift
@@ -35,6 +35,7 @@ struct UpdateCheckerSafetyTests {
         rejectsHardlinkEntries()
         rejectsMultipleAppBundles()
         rejectsArchiveWithNoAppBundle()
+        rejectsEmptyArchivePath()
         print("Update checker safety tests passed")
     }
 
@@ -111,6 +112,14 @@ struct UpdateCheckerSafetyTests {
             UpdateChecker.ZipArchiveEntry(path: "DefenseClawMac/Contents/Info.plist", mode: "-rw-r--r--"),
         ])
         expect(result.isFailure(containing: "single top-level .app"), "archives without .app bundle are rejected")
+    }
+
+    private static func rejectsEmptyArchivePath() {
+        let result = UpdateChecker.validateUpdateArchive(entries: [
+            UpdateChecker.ZipArchiveEntry(path: "DefenseClawMac.app/Contents/Info.plist", mode: "-rw-r--r--"),
+            UpdateChecker.ZipArchiveEntry(path: "", mode: "-rw-r--r--"),
+        ])
+        expect(result.isFailure(containing: "empty archive path"), "empty archive paths are rejected")
     }
 
     private static func expect(_ condition: @autoclosure () -> Bool, _ label: String) {

--- a/macos/DefenseClawMac/Tests/UpdateCheckerSafetyTests.swift
+++ b/macos/DefenseClawMac/Tests/UpdateCheckerSafetyTests.swift
@@ -30,6 +30,11 @@ struct UpdateCheckerSafetyTests {
         rejectsAbsolutePathsBeforeExtraction()
         rejectsSymlinkEntriesBeforeExtraction()
         rejectsUnexpectedTopLevelFiles()
+        rejectsEmptyArchive()
+        rejectsTildePrefixedPaths()
+        rejectsHardlinkEntries()
+        rejectsMultipleAppBundles()
+        rejectsArchiveWithNoAppBundle()
         print("Update checker safety tests passed")
     }
 
@@ -71,6 +76,41 @@ struct UpdateCheckerSafetyTests {
             UpdateChecker.ZipArchiveEntry(path: "README.txt", mode: "-rw-r--r--"),
         ])
         expect(result.isFailure(containing: "single top-level .app"), "top-level extras are rejected")
+    }
+
+    private static func rejectsEmptyArchive() {
+        let result = UpdateChecker.validateUpdateArchive(entries: [])
+        expect(result.isFailure(containing: "archive is empty"), "empty archive is rejected")
+    }
+
+    private static func rejectsTildePrefixedPaths() {
+        let result = UpdateChecker.validateUpdateArchive(entries: [
+            UpdateChecker.ZipArchiveEntry(path: "~/Library/LaunchAgents/persist.plist", mode: "-rw-r--r--"),
+        ])
+        expect(result.isFailure(containing: "unsafe path"), "tilde-prefixed paths are rejected")
+    }
+
+    private static func rejectsHardlinkEntries() {
+        let result = UpdateChecker.validateUpdateArchive(entries: [
+            UpdateChecker.ZipArchiveEntry(path: "DefenseClawMac.app/Contents/Info.plist", mode: "-rw-r--r--"),
+            UpdateChecker.ZipArchiveEntry(path: "DefenseClawMac.app/Contents/Resources/link", mode: "hrwxr-xr-x"),
+        ])
+        expect(result.isFailure(containing: "link"), "hardlink entries are rejected")
+    }
+
+    private static func rejectsMultipleAppBundles() {
+        let result = UpdateChecker.validateUpdateArchive(entries: [
+            UpdateChecker.ZipArchiveEntry(path: "DefenseClawMac.app/Contents/Info.plist", mode: "-rw-r--r--"),
+            UpdateChecker.ZipArchiveEntry(path: "OtherDefenseClawMac.app/Contents/Info.plist", mode: "-rw-r--r--"),
+        ])
+        expect(result.isFailure(containing: "single top-level .app"), "multiple .app bundles are rejected")
+    }
+
+    private static func rejectsArchiveWithNoAppBundle() {
+        let result = UpdateChecker.validateUpdateArchive(entries: [
+            UpdateChecker.ZipArchiveEntry(path: "DefenseClawMac/Contents/Info.plist", mode: "-rw-r--r--"),
+        ])
+        expect(result.isFailure(containing: "single top-level .app"), "archives without .app bundle are rejected")
     }
 
     private static func expect(_ condition: @autoclosure () -> Bool, _ label: String) {

--- a/macos/DefenseClawMac/Tests/UpdateCheckerSafetyTests.swift
+++ b/macos/DefenseClawMac/Tests/UpdateCheckerSafetyTests.swift
@@ -1,0 +1,91 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+enum RuntimePayload {
+    static func sha256(of _: URL) -> String? {
+        nil
+    }
+}
+
+@main
+struct UpdateCheckerSafetyTests {
+    static func main() {
+        acceptsSingleAppBundleArchive()
+        rejectsPathTraversalBeforeExtraction()
+        rejectsAbsolutePathsBeforeExtraction()
+        rejectsSymlinkEntriesBeforeExtraction()
+        rejectsUnexpectedTopLevelFiles()
+        print("Update checker safety tests passed")
+    }
+
+    private static func acceptsSingleAppBundleArchive() {
+        let result = UpdateChecker.validateUpdateArchive(entries: [
+            UpdateChecker.ZipArchiveEntry(path: "DefenseClawMac.app/", mode: "drwxr-xr-x"),
+            UpdateChecker.ZipArchiveEntry(path: "DefenseClawMac.app/Contents/Info.plist", mode: "-rw-r--r--"),
+            UpdateChecker.ZipArchiveEntry(path: "DefenseClawMac.app/Contents/MacOS/DefenseClawMac", mode: "-rwxr-xr-x"),
+        ])
+        expect(result == .success(appBundleName: "DefenseClawMac.app"), "legitimate app archive is accepted")
+    }
+
+    private static func rejectsPathTraversalBeforeExtraction() {
+        let result = UpdateChecker.validateUpdateArchive(entries: [
+            UpdateChecker.ZipArchiveEntry(path: "DefenseClawMac.app/Contents/Info.plist", mode: "-rw-r--r--"),
+            UpdateChecker.ZipArchiveEntry(path: "DefenseClawMac.app/../../Library/LaunchAgents/persist.plist", mode: "-rw-r--r--"),
+        ])
+        expect(result.isFailure(containing: "unsafe path"), "path traversal is rejected")
+    }
+
+    private static func rejectsAbsolutePathsBeforeExtraction() {
+        let result = UpdateChecker.validateUpdateArchive(entries: [
+            UpdateChecker.ZipArchiveEntry(path: "/tmp/DefenseClawMac.app/Contents/Info.plist", mode: "-rw-r--r--"),
+        ])
+        expect(result.isFailure(containing: "unsafe path"), "absolute paths are rejected")
+    }
+
+    private static func rejectsSymlinkEntriesBeforeExtraction() {
+        let result = UpdateChecker.validateUpdateArchive(entries: [
+            UpdateChecker.ZipArchiveEntry(path: "DefenseClawMac.app/Contents/Info.plist", mode: "-rw-r--r--"),
+            UpdateChecker.ZipArchiveEntry(path: "DefenseClawMac.app/Contents/Resources/link", mode: "lrwxr-xr-x"),
+        ])
+        expect(result.isFailure(containing: "link"), "symlink entries are rejected")
+    }
+
+    private static func rejectsUnexpectedTopLevelFiles() {
+        let result = UpdateChecker.validateUpdateArchive(entries: [
+            UpdateChecker.ZipArchiveEntry(path: "DefenseClawMac.app/Contents/Info.plist", mode: "-rw-r--r--"),
+            UpdateChecker.ZipArchiveEntry(path: "README.txt", mode: "-rw-r--r--"),
+        ])
+        expect(result.isFailure(containing: "single top-level .app"), "top-level extras are rejected")
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ label: String) {
+        guard condition() else {
+            fputs("FAILED: \(label)\n", stderr)
+            exit(1)
+        }
+    }
+}
+
+private extension UpdateChecker.ArchiveValidationResult {
+    func isFailure(containing needle: String) -> Bool {
+        if case .failure(let message) = self {
+            return message.contains(needle)
+        }
+        return false
+    }
+}

--- a/macos/DefenseClawMac/UPDATING.md
+++ b/macos/DefenseClawMac/UPDATING.md
@@ -67,7 +67,8 @@ After syncing, review and restore these intentional differences:
 - Bundle identifier: `com.cisco.defenseclaw.macos`.
 - No personal Apple development team or signing identity in the project file.
 - App `MARKETING_VERSION` matches the repository `VERSION`.
-- `UpdateChecker` reads releases from `cisco-ai-defense/defenseclaw` and only selects `DefenseClawMac-*-macos-arm64*.zip` assets.
+- `UpdateChecker` reads releases from `cisco-ai-defense/defenseclaw`, selects only verified `DefenseClawMac-*-macos-arm64.zip` assets, and never offers `-unverified` artifacts through in-app self-update.
+- Before extraction, `UpdateChecker` rejects empty or malformed ZIP manifests, absolute and traversal paths, link entries, multiple app bundles, and content outside one top-level `.app` bundle.
 - `RuntimeInstaller` continues to understand `Contents/Resources/RuntimePayload`.
 - Release packaging remains in `scripts/build-macos-app-release.sh` and `.github/workflows/release.yaml`, producing a runtime-bearing DMG and app-only self-update zip.
 
@@ -105,6 +106,8 @@ make macos-app-release-verify
 
 Mount the resulting DMG and confirm it contains `DefenseClawMac.app`, an `/Applications` symlink, the matching gateway and wheel under `Contents/Resources/RuntimePayload`, and `payload-manifest.json`. Confirm the zip contains the app without `RuntimePayload`, preserving the independent runtime update track. Local development builds may produce clearly named `-unverified` artifacts, but the in-app self-updater ignores those assets.
 
+Confirm the app-only ZIP contains exactly one top-level `.app` bundle and no absolute paths, `..` components, symlinks, hardlinks, or unrelated top-level files. The updater performs this validation before `ditto` extraction, then requires bundle identity/version checks, code-signature validation, and Gatekeeper assessment before installation.
+
 The first-run runtime installer pins its fallback `uv` download by version and SHA-256 in `RuntimeInstaller.swift`. When updating that pin, use an immutable `astral-sh/uv` release, copy the Apple Silicon archive digest from the release asset, and verify the archive locally before changing both constants together.
 
 Production releases must publish verified macOS app-update assets. Configure all five release-environment secrets together (`MACOS_DEVELOPER_ID_P12_BASE64`, `MACOS_DEVELOPER_ID_P12_PASSWORD`, `MACOS_NOTARY_KEY_BASE64`, `MACOS_NOTARY_KEY_ID`, and `MACOS_NOTARY_ISSUER_ID`). The release workflow defaults `MACOS_REQUIRE_NOTARIZATION=true`, so missing credentials fail the build instead of publishing self-update assets that bypass Developer ID and Gatekeeper verification. Partial credentials fail the build as well.
@@ -115,6 +118,7 @@ Production releases must publish verified macOS app-update assets. Configure all
 - Confirm no credentials, signing certificates, developer-team IDs, generated build products, or local user paths were imported.
 - Confirm every GitHub Action is pinned to an immutable commit SHA.
 - Confirm the release job downloads both the DMG and zip before regenerating `checksums.txt` and publishing the atomic GitHub release.
+- Confirm `test_update_checker_verification.sh` and `test_update_checker_safety.sh` pass, covering verified-only asset selection and pre-extraction archive rejection.
 - Confirm `python3 scripts/check-macos-upstream.py` succeeds online. The release preflight fails before signing if the pin is stale.
 - Confirm the scheduled `macOS Upstream Freshness` workflow is enabled. It opens one update issue when the latest stable standalone release advances.
 - Record exact commands and observed results in the pull request test plan.

--- a/macos/DefenseClawMac/script/test_update_checker_safety.sh
+++ b/macos/DefenseClawMac/script/test_update_checker_safety.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/defenseclaw-update-checker-tests.XXXXXX")"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+MODULE_CACHE="$BUILD_DIR/ModuleCache"
+mkdir -p "$MODULE_CACHE"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE" xcrun swiftc \
+  -module-cache-path "$MODULE_CACHE" \
+  "$ROOT/DefenseClawMac/DataLayer/UpdateChecker.swift" \
+  "$ROOT/Tests/UpdateCheckerSafetyTests.swift" \
+  -o "$BUILD_DIR/UpdateCheckerSafetyTests"
+
+"$BUILD_DIR/UpdateCheckerSafetyTests"


### PR DESCRIPTION
## Problem

Fixes #464. The macOS self-updater downloaded and hash-verified a release ZIP, then extracted it with `ditto -xk` before validating archive member paths or link types. A malformed release asset could write outside the update staging directory before later bundle validation rejected it.

## Current Situation

`UpdateChecker.downloadAndInstall` validates verified release selection, the final extracted `.app` bundle identity, version, runtime payload boundary, code signature, and Gatekeeper assessment. Archive structure was not validated before extraction, leaving path traversal, absolute-path, and unsafe-link writes possible before those later checks.

## Solution

Add a pre-extraction ZIP manifest validation step. The updater lists archive entries with `zipinfo -l`, parses path and mode metadata, and refuses archives that are empty, contain absolute or traversal paths, contain link entries, or contain anything outside one top-level `.app` bundle.

The macOS updater documentation now describes the combined trust contract from #467 and this PR: verified-only release assets, fail-closed production notarization, pre-extraction archive validation, and post-extraction signature/Gatekeeper checks.

## Architecture Diagram

```mermaid
flowchart LR
  A[Verified release ZIP] --> B[Verify SHA-256]
  B --> C[List ZIP entries]
  C --> D{Safe single app archive?}
  D -- no --> E[Refuse before extraction]
  D -- yes --> F[Extract with ditto]
  F --> G[Validate identity and version]
  G --> H[Verify signature and Gatekeeper]
```

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `macos/DefenseClawMac/DefenseClawMac/DataLayer/UpdateChecker.swift` | Adds ZIP entry parsing and pre-extraction archive validation before `ditto -xk`. |
| `macos/DefenseClawMac/Tests/UpdateCheckerSafetyTests.swift` | Covers valid archives and every rejection branch, including traversal, absolute paths, links, empty paths, extra files, missing apps, and multiple apps. |
| `macos/DefenseClawMac/script/test_update_checker_safety.sh` | Adds the standalone Swift archive-safety runner. |
| `Makefile` | Includes both updater verification and archive-safety runners in `macos-app-test`. |
| `macos/DefenseClawMac/README.md` | Documents verified-only in-app updates, production notarization defaults, and the complete install-time validation sequence. |
| `macos/DefenseClawMac/UPDATING.md` | Records archive validation as a Cisco integration invariant and adds release-review checks. |

## Breaking Changes

None for valid, verified self-update ZIPs. Invalid, unsafe, or `-unverified` app-update archives are refused before installation.

## Open Issues / Follow-ups

None.

## Test Plan

- `macos/DefenseClawMac/script/test_update_checker_safety.sh` -> passed (`Update checker safety tests passed`).
- `macos/DefenseClawMac/script/test_update_checker_verification.sh` -> passed (`Update checker verification tests passed`).
- `python3 scripts/macos_license_headers.py` -> passed (`macOS app license headers OK`).
- `git diff --cached --check` -> passed.
- Full repository and macOS app checks are rerunning in CI on the updated head.
