### PR TITLE
Require verified macOS self-update assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -204,7 +204,7 @@ jobs:
           MACOS_NOTARY_KEY_BASE64: ${{ secrets.MACOS_NOTARY_KEY_BASE64 }}
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
-          MACOS_REQUIRE_NOTARIZATION: ${{ vars.MACOS_REQUIRE_NOTARIZATION || 'false' }}
+          MACOS_REQUIRE_NOTARIZATION: ${{ vars.MACOS_REQUIRE_NOTARIZATION || 'true' }}
         run: scripts/build-macos-app-release.sh "$RELEASE_VERSION" dist
 
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/Makefile
+++ b/Makefile
@@ -626,6 +626,7 @@ macos-app-test:
 	macos/DefenseClawMac/script/test_output_safety.sh
 	macos/DefenseClawMac/script/test_secret_file_safety.sh
 	macos/DefenseClawMac/script/test_app_state_signal_safety.sh
+	macos/DefenseClawMac/script/test_update_checker_verification.sh
 	$(MAKE) macos-app-build
 
 macos-app-release: macos-app-license-check extensions dist-cli

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/UpdateChecker.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/UpdateChecker.swift
@@ -98,28 +98,29 @@ actor UpdateChecker {
               let tag = dict["tag_name"] as? String
         else { return nil }
         let assets = (dict["assets"] as? [[String: Any]]) ?? []
-        let appZips = assets.filter {
-            let name = ($0["name"] as? String) ?? ""
-            return name.hasPrefix("DefenseClawMac-")
-                && name.contains("-macos-arm64")
-                && name.hasSuffix(".zip")
+        guard let zip = Self.selectSelfUpdateAsset(from: assets) else {
+            return nil
         }
-        // Prefer a Developer ID signed + notarized artifact once release
-        // credentials are configured. Until then, releases intentionally use
-        // the explicit "unverified" suffix.
-        let zip = appZips.first {
-            !(($0["name"] as? String) ?? "").contains("-unverified")
-        } ?? appZips.first
         return ReleaseInfo(
             tag: tag,
             version: tag.hasPrefix("v") ? String(tag.dropFirst()) : tag,
-            assetName: (zip?["name"] as? String) ?? "",
-            assetURL: (zip?["browser_download_url"] as? String) ?? "",
-            assetSHA256: ((zip?["digest"] as? String) ?? "")
+            assetName: (zip["name"] as? String) ?? "",
+            assetURL: (zip["browser_download_url"] as? String) ?? "",
+            assetSHA256: ((zip["digest"] as? String) ?? "")
                 .replacingOccurrences(of: "sha256:", with: ""),
             htmlURL: (dict["html_url"] as? String) ?? "https://github.com/\(repo)/releases",
             notes: (dict["body"] as? String) ?? ""
         )
+    }
+
+    nonisolated static func selectSelfUpdateAsset(from assets: [[String: Any]]) -> [String: Any]? {
+        assets.first {
+            let name = ($0["name"] as? String) ?? ""
+            return name.hasPrefix("DefenseClawMac-")
+                && name.contains("-macos-arm64")
+                && name.hasSuffix(".zip")
+                && !name.contains("-unverified")
+        }
     }
 
     // MARK: - Download + install + restart
@@ -194,13 +195,11 @@ actor UpdateChecker {
         guard signature.exitCode == 0 else {
             return "The downloaded app failed code-signature verification: \(signature.output)"
         }
-        if !release.assetName.contains("-unverified") {
-            let assessment = await Self.runProcess(
-                "/usr/sbin/spctl", ["--assess", "--type", "execute", "--verbose=2", newApp.path]
-            )
-            guard assessment.exitCode == 0 else {
-                return "The downloaded app failed Gatekeeper assessment: \(assessment.output)"
-            }
+        let assessment = await Self.runProcess(
+            "/usr/sbin/spctl", ["--assess", "--type", "execute", "--verbose=2", newApp.path]
+        )
+        guard assessment.exitCode == 0 else {
+            return "The downloaded app failed Gatekeeper assessment: \(assessment.output)"
         }
 
         // Swap the running bundle: move the old aside (the running process keeps

--- a/macos/DefenseClawMac/Tests/UpdateCheckerVerificationTests.swift
+++ b/macos/DefenseClawMac/Tests/UpdateCheckerVerificationTests.swift
@@ -1,0 +1,79 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+enum RuntimePayload {
+    static func sha256(of _: URL) -> String? {
+        nil
+    }
+}
+
+@main
+struct UpdateCheckerVerificationTests {
+    static func main() {
+        rejectsUnverifiedSelfUpdateAssets()
+        selectsVerifiedSelfUpdateAsset()
+        rejectsNonAppZipAssets()
+        print("Update checker verification tests passed")
+    }
+
+    private static func rejectsUnverifiedSelfUpdateAssets() {
+        let assets: [[String: Any]] = [
+            [
+                "name": "DefenseClawMac-1.2.3-macos-arm64-unverified.zip",
+                "browser_download_url": "https://example.test/unverified.zip",
+                "digest": "sha256:abc",
+            ],
+        ]
+        expect(UpdateChecker.selectSelfUpdateAsset(from: assets) == nil, "unverified app zip is not eligible")
+    }
+
+    private static func selectsVerifiedSelfUpdateAsset() {
+        let assets: [[String: Any]] = [
+            [
+                "name": "DefenseClawMac-1.2.3-macos-arm64-unverified.zip",
+                "browser_download_url": "https://example.test/unverified.zip",
+                "digest": "sha256:abc",
+            ],
+            [
+                "name": "DefenseClawMac-1.2.3-macos-arm64.zip",
+                "browser_download_url": "https://example.test/verified.zip",
+                "digest": "sha256:def",
+            ],
+        ]
+        let selected = UpdateChecker.selectSelfUpdateAsset(from: assets)
+        expect(selected?["name"] as? String == "DefenseClawMac-1.2.3-macos-arm64.zip", "verified app zip is selected")
+    }
+
+    private static func rejectsNonAppZipAssets() {
+        let assets: [[String: Any]] = [
+            [
+                "name": "defenseclaw-1.2.3-py3-none-any.whl",
+                "browser_download_url": "https://example.test/runtime.whl",
+                "digest": "sha256:abc",
+            ],
+        ]
+        expect(UpdateChecker.selectSelfUpdateAsset(from: assets) == nil, "runtime assets are not self-update assets")
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ label: String) {
+        guard condition() else {
+            fputs("FAILED: \(label)\n", stderr)
+            exit(1)
+        }
+    }
+}

--- a/macos/DefenseClawMac/UPDATING.md
+++ b/macos/DefenseClawMac/UPDATING.md
@@ -103,11 +103,11 @@ make macos-app-release
 make macos-app-release-verify
 ```
 
-Mount the resulting DMG and confirm it contains `DefenseClawMac.app`, an `/Applications` symlink, the matching gateway and wheel under `Contents/Resources/RuntimePayload`, and `payload-manifest.json`. Confirm the zip contains the app without `RuntimePayload`, preserving the independent runtime update track. Verify both artifact names contain `-unverified` unless Developer ID signing and notarization were deliberately configured.
+Mount the resulting DMG and confirm it contains `DefenseClawMac.app`, an `/Applications` symlink, the matching gateway and wheel under `Contents/Resources/RuntimePayload`, and `payload-manifest.json`. Confirm the zip contains the app without `RuntimePayload`, preserving the independent runtime update track. Local development builds may produce clearly named `-unverified` artifacts, but the in-app self-updater ignores those assets.
 
 The first-run runtime installer pins its fallback `uv` download by version and SHA-256 in `RuntimeInstaller.swift`. When updating that pin, use an immutable `astral-sh/uv` release, copy the Apple Silicon archive digest from the release asset, and verify the archive locally before changing both constants together.
 
-Until Apple credentials are available, releases intentionally publish the clearly named `-unverified` artifacts. When enabling verified distribution, configure all five release-environment secrets together (`MACOS_DEVELOPER_ID_P12_BASE64`, `MACOS_DEVELOPER_ID_P12_PASSWORD`, `MACOS_NOTARY_KEY_BASE64`, `MACOS_NOTARY_KEY_ID`, and `MACOS_NOTARY_ISSUER_ID`), then set the release-environment variable `MACOS_REQUIRE_NOTARIZATION=true`. Partial credentials fail the build, and the variable prevents any future release from falling back to unverified artifacts.
+Production releases must publish verified macOS app-update assets. Configure all five release-environment secrets together (`MACOS_DEVELOPER_ID_P12_BASE64`, `MACOS_DEVELOPER_ID_P12_PASSWORD`, `MACOS_NOTARY_KEY_BASE64`, `MACOS_NOTARY_KEY_ID`, and `MACOS_NOTARY_ISSUER_ID`). The release workflow defaults `MACOS_REQUIRE_NOTARIZATION=true`, so missing credentials fail the build instead of publishing self-update assets that bypass Developer ID and Gatekeeper verification. Partial credentials fail the build as well.
 
 ## 5. Review before merging
 

--- a/macos/DefenseClawMac/script/test_update_checker_verification.sh
+++ b/macos/DefenseClawMac/script/test_update_checker_verification.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/defenseclaw-update-verification-tests.XXXXXX")"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+MODULE_CACHE="$BUILD_DIR/ModuleCache"
+mkdir -p "$MODULE_CACHE"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE" xcrun swiftc \
+  -module-cache-path "$MODULE_CACHE" \
+  "$ROOT/DefenseClawMac/DataLayer/UpdateChecker.swift" \
+  "$ROOT/Tests/UpdateCheckerVerificationTests.swift" \
+  -o "$BUILD_DIR/UpdateCheckerVerificationTests"
+
+"$BUILD_DIR/UpdateCheckerVerificationTests"


### PR DESCRIPTION
## Problem

Fixes #465. The macOS in-app updater could select `-unverified` app ZIP assets and intentionally skipped Gatekeeper assessment for those assets. The release workflow also defaulted notarization enforcement to false, so production releases could publish self-update assets without Developer ID/Gatekeeper verification.

## Current Situation

Self-update validates SHA-256 and code signatures, but the release selector falls back to unverified assets and the install path bypasses `spctl` when the asset name contains `-unverified`. That makes the explicit development fallback reachable through the in-app update path.

## Solution

Make verified distribution the only in-app self-update path:

- Ignore `-unverified` macOS app ZIPs when selecting release assets.
- Always run Gatekeeper assessment on downloaded app bundles.
- Default the release workflow to `MACOS_REQUIRE_NOTARIZATION=true`.
- Update macOS release docs so unverified artifacts are described as local/dev-only and ignored by self-update.

## Architecture Diagram

```mermaid
flowchart LR
  A[GitHub release assets] --> B{Verified macOS app ZIP?}
  B -- no --> C[No in-app update offered]
  B -- yes --> D[Download and SHA-256 verify]
  D --> E[Code-signature verify]
  E --> F[Gatekeeper assess]
  F --> G[Install]
```

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `macos/DefenseClawMac/DefenseClawMac/DataLayer/UpdateChecker.swift` | Adds verified self-update asset selection and removes the `-unverified` Gatekeeper bypass. |
| `.github/workflows/release.yaml` | Defaults macOS app release packaging to require notarization. |
| `macos/DefenseClawMac/UPDATING.md` | Documents production verified-release requirements and local-only unverified artifacts. |
| `macos/DefenseClawMac/Tests/UpdateCheckerVerificationTests.swift` | Adds focused release-asset selection policy coverage. |
| `macos/DefenseClawMac/script/test_update_checker_verification.sh` | Adds a standalone Swift runner for updater verification policy tests. |
| `Makefile` | Includes the new updater verification runner in `macos-app-test`. |

## Breaking Changes

In-app self-update no longer offers `-unverified` app ZIPs. Production macOS release packaging now fails closed unless notarization credentials are configured or the release environment explicitly overrides the requirement.

## Open Issues / Follow-ups

None.

## Test Plan

- `macos/DefenseClawMac/script/test_update_checker_verification.sh` -> passed (`Update checker verification tests passed`).
- `macos/DefenseClawMac/script/test_update_checker_verification.sh && macos/DefenseClawMac/script/test_output_safety.sh && macos/DefenseClawMac/script/test_secret_file_safety.sh && python3 scripts/macos_license_headers.py` -> passed (`Update checker verification tests passed`, `CLI output and inventory parser safety tests passed`, `SecretAndFileSafetyTests passed`, `macOS app license headers OK`).
- `git diff --cached --check` -> passed before commit.
- `make macos-app-build` was attempted in the sibling updater PR environment and is blocked here because `xcodebuild` requires full Xcode, while the active developer directory is `/Library/Developer/CommandLineTools`.
