### PR TITLE
Align launchd installer with Cisco layout

### DIFF
--- a/cli/tests/test_enterprise_packaging.py
+++ b/cli/tests/test_enterprise_packaging.py
@@ -191,16 +191,28 @@ def test_launchd_enterprise_installer_enforces_managed_config_trust_boundary():
         text=True,
     )
     assert "--config" in help_result.stdout
-    assert "root:defenseclaw" in help_result.stdout
+    assert "root:wheel" in help_result.stdout
     assert "0640" in help_result.stdout
-    assert "existing defenseclaw service user/group" in help_result.stdout
-    assert "not create it" in help_result.stdout
+    assert "No dedicated service user or group" in help_result.stdout
 
     text = installer.read_text(encoding="utf-8")
     required = {
         'CONFIG_DEST="/opt/cisco/secureclient/defenseclaw/etc/config.yaml"',
-        'install_file_atomic "$CONFIG_SOURCE" "$CONFIG_DEST" root "$SERVICE_GROUP" 0640',
-        'assert_path_metadata "$CONFIG_DEST" file 0 "$SERVICE_GID" 640',
+        'install_file_atomic "$CONFIG_SOURCE" "$CONFIG_DEST" root wheel 0640',
+        'install_file_atomic "$MANIFEST_SOURCE" "$MANIFEST_DEST" root wheel 0640',
+        '/usr/bin/install -d -o root -g wheel -m 0755 "$BINARY_ROOT" "$BIN_DIR" "$ETC_DIR"',
+        '/usr/bin/install -d -o root -g wheel -m 0750 "$RUNTIME_DIR" "$GUARDIAN_DIR" "$AUTH_DIR" "$LOG_DIR"',
+        'assert_path_metadata "$CONFIG_DEST" file 0 "$WHEEL_GID" 640',
+        'assert_path_metadata "$MANIFEST_DEST" file 0 "$WHEEL_GID" 640',
+        'assert_path_metadata "$ETC_DIR" dir 0 "$WHEEL_GID" 755',
+        'assert_path_metadata "$RUNTIME_DIR" dir 0 "$WHEEL_GID" 750',
+        'assert_path_metadata "$GUARDIAN_DIR" dir 0 "$WHEEL_GID" 750',
+        'assert_path_metadata "$AUTH_DIR" dir 0 "$WHEEL_GID" 750',
+        'assert_path_metadata "$LOG_DIR" dir 0 "$WHEEL_GID" 750',
+        'assert_existing_secure_dir_or_absent "$RUNTIME_DIR"',
+        'assert_existing_secure_dir_or_absent "$LOG_DIR"',
+        'assert_existing_secure_dir_or_absent "$LOG_VENDOR_DIR"',
+        'assert_existing_secure_dir_or_absent "$LOG_PRODUCT_DIR"',
         'refuse_symlink "$CONFIG_DEST"',
         "assert_no_write_acl()",
         'assert_no_write_acl "$path"',
@@ -210,6 +222,15 @@ def test_launchd_enterprise_installer_enforces_managed_config_trust_boundary():
     }
     missing = sorted(value for value in required if value not in text)
     assert not missing
+    stale_service_identity_contract = {
+        "SERVICE_USER",
+        "SERVICE_GROUP",
+        "SERVICE_UID",
+        "SERVICE_GID",
+        "assert_existing_acl_safe_dir_or_absent",
+    }
+    present = sorted(value for value in stale_service_identity_contract if value in text)
+    assert not present
 
     workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
     assert "macos-enterprise-packaging:" in workflow
@@ -221,6 +242,9 @@ def test_launchd_enterprise_installer_enforces_managed_config_trust_boundary():
     assert "managed_root=\"/opt/cisco/secureclient/defenseclaw\"" in smoke
     assert "config_dest=\"${managed_root}/etc/config.yaml\"" in smoke
     assert "log_dir=/Library/Logs/Cisco/SecureClient/DefenseClaw" in smoke
+    assert "assert_no_defenseclaw_identity()" in smoke
+    assert smoke.count("assert_no_defenseclaw_identity \"") == 3
+    assert "dscl . -create" not in smoke
     assert "/Library/Application Support/DefenseClaw" not in smoke
     assert "/Library/DefenseClaw" not in smoke
 
@@ -244,7 +268,6 @@ def test_launchd_enterprise_installer_matches_cisco_plist_layout():
     manifest = guardian["ProgramArguments"][-1]
 
     assert f"BINARY_ROOT={home}" in text
-    assert f'MANAGED_ROOT="{home}"' in text
     assert f'CONFIG_DEST="{config}"' in text
     assert f'MANIFEST_DEST="{manifest}"' in text
     assert f'AUTH_DIR="{auth_dir}"' in text
@@ -252,5 +275,32 @@ def test_launchd_enterprise_installer_matches_cisco_plist_layout():
     assert f'GUARDIAN_LABEL={guardian["Label"]}' in text
     assert '"system/${GATEWAY_LABEL}"' in text
     assert '"system/${GUARDIAN_LABEL}"' in text
-    assert '/bin/rm -f "$GATEWAY_PLIST_DEST" "$GUARDIAN_PLIST_DEST"' in text
+    assert "snapshot_file()" in text
+    assert "restore_snapshots()" in text
+    assert "rebootstrap_previously_loaded_job()" in text
+    assert "rollback_install()" in text
+    assert "GATEWAY_WAS_LOADED=true" in text
+    assert "GUARDIAN_WAS_LOADED=true" in text
+    assert 'snapshot_file "$destination"' in text
+    assert text.index("ROLLBACK_ARMED=true") < text.index('stop_job_if_loaded "$GUARDIAN_LABEL"')
+    assert 'stop_job_if_loaded "$GATEWAY_LABEL"' in text
+    assert 'stop_job_if_loaded "$GUARDIAN_LABEL"' in text
+    assert "ROLLBACK_ARMED=false" in text
     assert "system/com.defenseclaw." not in text
+
+    deployment_docs = (
+        ROOT / "docs-site" / "content" / "docs" / "setup" / "enterprise-deployment.mdx"
+    ).read_text(encoding="utf-8")
+    documented_contract = {
+        "There is no dedicated `defenseclaw` service user on macOS.",
+        "| `/opt/cisco/secureclient/defenseclaw/etc` | `root:wheel` | `0755` |",
+        "| `/opt/cisco/secureclient/defenseclaw/etc/config.yaml` | `root:wheel` | `0640` |",
+        "| `/opt/cisco/secureclient/defenseclaw/runtime` | `root:wheel` | `0750` |",
+        "| `/opt/cisco/secureclient/defenseclaw/hook-guardian` | `root:wheel` | `0750` |",
+        "| `/opt/cisco/secureclient/defenseclaw/hook-guardian/targets.yaml` | `root:wheel` | `0640` |",
+        "| `/opt/cisco/secureclient/defenseclaw/hook-guardian-state` | `root:wheel` | `0750` |",
+        "| `/Library/Logs/Cisco/SecureClient/DefenseClaw` | `root:wheel` | `0750` |",
+        "A failure after jobs are stopped restores the previous binary, config, manifest, and plists",
+    }
+    missing_contract = sorted(value for value in documented_contract if value not in deployment_docs)
+    assert not missing_contract

--- a/cli/tests/test_enterprise_packaging.py
+++ b/cli/tests/test_enterprise_packaging.py
@@ -216,6 +216,11 @@ def test_launchd_enterprise_installer_enforces_managed_config_trust_boundary():
     smoke = (ROOT / "scripts" / "test-macos-enterprise-packaging.sh").read_text(encoding="utf-8")
     assert "everyone allow add_file,add_subdirectory,delete_child" in smoke
     assert "installer accepted a write-capable managed-root ACL" in smoke
+    assert "managed_root=\"/opt/cisco/secureclient/defenseclaw\"" in smoke
+    assert "config_dest=\"${managed_root}/etc/config.yaml\"" in smoke
+    assert "log_dir=/Library/Logs/Cisco/SecureClient/DefenseClaw" in smoke
+    assert "/Library/Application Support/DefenseClaw" not in smoke
+    assert "/Library/DefenseClaw" not in smoke
 
 
 def test_launchd_enterprise_installer_matches_cisco_plist_layout():
@@ -245,4 +250,15 @@ def test_launchd_enterprise_installer_matches_cisco_plist_layout():
     assert f'GUARDIAN_LABEL={guardian["Label"]}' in text
     assert '"system/${GATEWAY_LABEL}"' in text
     assert '"system/${GUARDIAN_LABEL}"' in text
+    assert '/bin/rm -f "$GATEWAY_PLIST_DEST" "$GUARDIAN_PLIST_DEST"' in text
     assert "system/com.defenseclaw." not in text
+
+    packaging = (ROOT / "packaging" / "macos" / "PACKAGING.md").read_text(encoding="utf-8")
+    documented_contract = {
+        "`/opt/cisco/secureclient/defenseclaw/etc/` — `root:defenseclaw 0750`",
+        "`/opt/cisco/secureclient/defenseclaw/hook-guardian/` — `root:defenseclaw 0750`",
+        "`/opt/cisco/secureclient/defenseclaw/hook-guardian-state/` — `root:defenseclaw 0750`",
+        "`/opt/cisco/secureclient/defenseclaw/etc/config.yaml` as `root:defenseclaw 0640`",
+    }
+    missing_contract = sorted(value for value in documented_contract if value not in packaging)
+    assert not missing_contract

--- a/cli/tests/test_enterprise_packaging.py
+++ b/cli/tests/test_enterprise_packaging.py
@@ -213,6 +213,9 @@ def test_launchd_enterprise_installer_enforces_managed_config_trust_boundary():
         'assert_existing_secure_dir_or_absent "$LOG_DIR"',
         'assert_existing_secure_dir_or_absent "$LOG_VENDOR_DIR"',
         'assert_existing_secure_dir_or_absent "$LOG_PRODUCT_DIR"',
+        "assert_trusted_system_dir /opt",
+        "assert_trusted_system_dir /opt/cisco",
+        "assert_trusted_system_dir /opt/cisco/secureclient",
         'refuse_symlink "$CONFIG_DEST"',
         "assert_no_write_acl()",
         'assert_no_write_acl "$path"',
@@ -222,6 +225,11 @@ def test_launchd_enterprise_installer_enforces_managed_config_trust_boundary():
     }
     missing = sorted(value for value in required if value not in text)
     assert not missing
+    directory_creation = (
+        '/usr/bin/install -d -o root -g wheel -m 0755 "$BINARY_ROOT" "$BIN_DIR" "$ETC_DIR"'
+    )
+    for ancestor in ("/opt", "/opt/cisco", "/opt/cisco/secureclient"):
+        assert text.index(directory_creation) < text.index(f"assert_trusted_system_dir {ancestor}")
     stale_service_identity_contract = {
         "SERVICE_USER",
         "SERVICE_GROUP",

--- a/cli/tests/test_enterprise_packaging.py
+++ b/cli/tests/test_enterprise_packaging.py
@@ -196,7 +196,7 @@ def test_launchd_enterprise_installer_enforces_managed_config_trust_boundary():
 
     text = installer.read_text(encoding="utf-8")
     required = {
-        'CONFIG_DEST="${MANAGED_ROOT}/config.yaml"',
+        'CONFIG_DEST="/opt/cisco/secureclient/defenseclaw/etc/config.yaml"',
         'install_file_atomic "$CONFIG_SOURCE" "$CONFIG_DEST" root "$SERVICE_GROUP" 0640',
         'assert_path_metadata "$CONFIG_DEST" file 0 "$SERVICE_GID" 640',
         'refuse_symlink "$CONFIG_DEST"',
@@ -216,3 +216,33 @@ def test_launchd_enterprise_installer_enforces_managed_config_trust_boundary():
     smoke = (ROOT / "scripts" / "test-macos-enterprise-packaging.sh").read_text(encoding="utf-8")
     assert "everyone allow add_file,add_subdirectory,delete_child" in smoke
     assert "installer accepted a write-capable managed-root ACL" in smoke
+
+
+def test_launchd_enterprise_installer_matches_cisco_plist_layout():
+    installer = ROOT / "packaging" / "launchd" / "install-enterprise.sh"
+    text = installer.read_text(encoding="utf-8")
+
+    gateway_plist = ROOT / "packaging" / "launchd" / "com.cisco.secureclient.defenseclaw.plist"
+    guardian_plist = (
+        ROOT / "packaging" / "launchd" / "com.cisco.secureclient.defenseclaw.hook-guardian.plist"
+    )
+    with gateway_plist.open("rb") as fh:
+        gateway = plistlib.load(fh)
+    with guardian_plist.open("rb") as fh:
+        guardian = plistlib.load(fh)
+
+    home = gateway["EnvironmentVariables"]["DEFENSECLAW_HOME"]
+    config = gateway["EnvironmentVariables"]["DEFENSECLAW_CONFIG"]
+    auth_dir = gateway["EnvironmentVariables"]["DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR"]
+    manifest = guardian["ProgramArguments"][-1]
+
+    assert f"BINARY_ROOT={home}" in text
+    assert f'MANAGED_ROOT="{home}"' in text
+    assert f'CONFIG_DEST="{config}"' in text
+    assert f'MANIFEST_DEST="{manifest}"' in text
+    assert f'AUTH_DIR="{auth_dir}"' in text
+    assert f'GATEWAY_LABEL={gateway["Label"]}' in text
+    assert f'GUARDIAN_LABEL={guardian["Label"]}' in text
+    assert '"system/${GATEWAY_LABEL}"' in text
+    assert '"system/${GUARDIAN_LABEL}"' in text
+    assert "system/com.defenseclaw." not in text

--- a/cli/tests/test_enterprise_packaging.py
+++ b/cli/tests/test_enterprise_packaging.py
@@ -193,6 +193,8 @@ def test_launchd_enterprise_installer_enforces_managed_config_trust_boundary():
     assert "--config" in help_result.stdout
     assert "root:defenseclaw" in help_result.stdout
     assert "0640" in help_result.stdout
+    assert "existing defenseclaw service user/group" in help_result.stdout
+    assert "not create it" in help_result.stdout
 
     text = installer.read_text(encoding="utf-8")
     required = {
@@ -252,13 +254,3 @@ def test_launchd_enterprise_installer_matches_cisco_plist_layout():
     assert '"system/${GUARDIAN_LABEL}"' in text
     assert '/bin/rm -f "$GATEWAY_PLIST_DEST" "$GUARDIAN_PLIST_DEST"' in text
     assert "system/com.defenseclaw." not in text
-
-    packaging = (ROOT / "packaging" / "macos" / "PACKAGING.md").read_text(encoding="utf-8")
-    documented_contract = {
-        "`/opt/cisco/secureclient/defenseclaw/etc/` — `root:defenseclaw 0750`",
-        "`/opt/cisco/secureclient/defenseclaw/hook-guardian/` — `root:defenseclaw 0750`",
-        "`/opt/cisco/secureclient/defenseclaw/hook-guardian-state/` — `root:defenseclaw 0750`",
-        "`/opt/cisco/secureclient/defenseclaw/etc/config.yaml` as `root:defenseclaw 0640`",
-    }
-    missing_contract = sorted(value for value in documented_contract if value not in packaging)
-    assert not missing_contract

--- a/docs-site/content/docs/setup/enterprise-deployment.mdx
+++ b/docs-site/content/docs/setup/enterprise-deployment.mdx
@@ -446,12 +446,18 @@ The installer refuses symlinked sources or managed destinations, verifies the ro
 
 | Path | Owner | Mode |
 | --- | --- | --- |
-| `/opt/cisco/secureclient/defenseclaw/bin/defenseclaw-gateway` | `root:wheel` | `0755` |
 | `/opt/cisco/secureclient/defenseclaw` | `root:wheel` | `0755` |
+| `/opt/cisco/secureclient/defenseclaw/bin/defenseclaw-gateway` | `root:wheel` | `0755` |
+| `/opt/cisco/secureclient/defenseclaw/etc` | `root:wheel` | `0755` |
 | `/opt/cisco/secureclient/defenseclaw/etc/config.yaml` | `root:wheel` | `0640` |
-| `/opt/cisco/secureclient/defenseclaw/hook-guardian/targets.yaml` | `root:wheel` | `0640` |
 | `/opt/cisco/secureclient/defenseclaw/runtime` | `root:wheel` | `0750` |
+| `/opt/cisco/secureclient/defenseclaw/hook-guardian` | `root:wheel` | `0750` |
+| `/opt/cisco/secureclient/defenseclaw/hook-guardian/targets.yaml` | `root:wheel` | `0640` |
+| `/opt/cisco/secureclient/defenseclaw/hook-guardian-state` | `root:wheel` | `0750` |
+| `/Library/Logs/Cisco/SecureClient/DefenseClaw` | `root:wheel` | `0750` |
 | `/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw*.plist` | `root:wheel` | `0644` |
+
+Before replacing files, the installer snapshots the existing deployment and records which LaunchDaemons are loaded. A failure after jobs are stopped restores the previous binary, config, manifest, and plists, then re-bootstrap only the jobs that were loaded before the attempt. A failed fresh install removes files created by that attempt instead of leaving persistent LaunchDaemon plists.
 
 Use `--no-start` when MDM or a package transaction must install and verify the files before a separate orchestration step loads the jobs. Even in that mode, an already loaded DefenseClaw job is unloaded before replacement and remains stopped until the administrator starts it.
 

--- a/docs-site/content/docs/setup/enterprise-deployment.mdx
+++ b/docs-site/content/docs/setup/enterprise-deployment.mdx
@@ -457,7 +457,7 @@ The installer refuses symlinked sources or managed destinations, verifies the ro
 | `/Library/Logs/Cisco/SecureClient/DefenseClaw` | `root:wheel` | `0750` |
 | `/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw*.plist` | `root:wheel` | `0644` |
 
-Before replacing files, the installer snapshots the existing deployment and records which LaunchDaemons are loaded. A failure after jobs are stopped restores the previous binary, config, manifest, and plists, then re-bootstrap only the jobs that were loaded before the attempt. A failed fresh install removes files created by that attempt instead of leaving persistent LaunchDaemon plists.
+Before replacing files, the installer snapshots the existing deployment and records which LaunchDaemons are loaded. A failure after jobs are stopped restores the previous binary, config, manifest, and plists, then re-bootstraps only the jobs that were loaded before the attempt. A failed fresh install removes files created by that attempt instead of leaving persistent LaunchDaemon plists.
 
 Use `--no-start` when MDM or a package transaction must install and verify the files before a separate orchestration step loads the jobs. Even in that mode, an already loaded DefenseClaw job is unloaded before replacement and remains stopped until the administrator starts it.
 

--- a/packaging/launchd/install-enterprise.sh
+++ b/packaging/launchd/install-enterprise.sh
@@ -40,6 +40,9 @@ Installs the macOS managed-enterprise gateway and guardian. The managed
 config is atomically installed as root:defenseclaw with mode 0640 and is
 verified before either LaunchDaemon can start.
 
+An existing defenseclaw service user/group is required; this installer does
+not create it.
+
 Options:
   --config PATH    Administrator-approved managed config (required)
   --manifest PATH  Administrator-approved guardian targets (required)

--- a/packaging/launchd/install-enterprise.sh
+++ b/packaging/launchd/install-enterprise.sh
@@ -300,6 +300,7 @@ if [ "$START_JOBS" = true ]; then
     /bin/launchctl bootstrap system "$GATEWAY_PLIST_DEST" || die "failed to bootstrap gateway LaunchDaemon"
     if ! /bin/launchctl bootstrap system "$GUARDIAN_PLIST_DEST"; then
         /bin/launchctl bootout "system/${GATEWAY_LABEL}" >/dev/null 2>&1 || true
+        /bin/rm -f "$GATEWAY_PLIST_DEST" "$GUARDIAN_PLIST_DEST"
         die "failed to bootstrap hook guardian LaunchDaemon"
     fi
     /bin/launchctl enable "system/${GATEWAY_LABEL}"

--- a/packaging/launchd/install-enterprise.sh
+++ b/packaging/launchd/install-enterprise.sh
@@ -8,15 +8,18 @@ export PATH
 
 SERVICE_USER=defenseclaw
 SERVICE_GROUP=defenseclaw
-BINARY_ROOT=/Library/DefenseClaw
+BINARY_ROOT=/opt/cisco/secureclient/defenseclaw
 BIN_DIR="${BINARY_ROOT}/bin"
-MANAGED_ROOT="/Library/Application Support/DefenseClaw"
-RUNTIME_DIR="${MANAGED_ROOT}/runtime"
-GUARDIAN_DIR="${MANAGED_ROOT}/hook-guardian"
-AUTH_DIR="${MANAGED_ROOT}/hook-guardian-state"
-LOG_DIR=/Library/Logs/DefenseClaw
-CONFIG_DEST="${MANAGED_ROOT}/config.yaml"
-MANIFEST_DEST="${GUARDIAN_DIR}/targets.yaml"
+MANAGED_ROOT="/opt/cisco/secureclient/defenseclaw"
+ETC_DIR="/opt/cisco/secureclient/defenseclaw/etc"
+RUNTIME_DIR="/opt/cisco/secureclient/defenseclaw/runtime"
+GUARDIAN_DIR="/opt/cisco/secureclient/defenseclaw/hook-guardian"
+AUTH_DIR="/opt/cisco/secureclient/defenseclaw/hook-guardian-state"
+LOG_DIR=/Library/Logs/Cisco/SecureClient/DefenseClaw
+CONFIG_DEST="/opt/cisco/secureclient/defenseclaw/etc/config.yaml"
+MANIFEST_DEST="/opt/cisco/secureclient/defenseclaw/hook-guardian/targets.yaml"
+GATEWAY_LABEL=com.cisco.secureclient.defenseclaw
+GUARDIAN_LABEL=com.cisco.secureclient.defenseclaw.hook-guardian
 GATEWAY_PLIST_DEST=/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.plist
 GUARDIAN_PLIST_DEST=/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.hook-guardian.plist
 
@@ -240,11 +243,14 @@ SERVICE_GID="$(/usr/bin/id -g "$SERVICE_USER" 2>/dev/null)" || die "service grou
 WHEEL_GID="$(/usr/bin/stat -f '%g' /Library)"
 
 assert_trusted_system_dir /Library
-assert_trusted_system_dir "/Library/Application Support"
 assert_trusted_system_dir /Library/LaunchDaemons
 assert_trusted_system_dir /Library/Logs
+assert_existing_secure_dir_or_absent /opt
+assert_existing_secure_dir_or_absent /opt/cisco
+assert_existing_secure_dir_or_absent /opt/cisco/secureclient
 assert_existing_secure_dir_or_absent "$BINARY_ROOT"
 assert_existing_secure_dir_or_absent "$BIN_DIR"
+assert_existing_secure_dir_or_absent "$ETC_DIR"
 assert_existing_secure_dir_or_absent "$MANAGED_ROOT"
 assert_existing_secure_dir_or_absent "$GUARDIAN_DIR"
 assert_existing_secure_dir_or_absent "$AUTH_DIR"
@@ -268,7 +274,7 @@ stop_job_if_loaded com.cisco.secureclient.defenseclaw.hook-guardian
 stop_job_if_loaded com.cisco.secureclient.defenseclaw
 
 /usr/bin/install -d -o root -g wheel -m 0755 "$BINARY_ROOT" "$BIN_DIR"
-/usr/bin/install -d -o root -g "$SERVICE_GROUP" -m 0750 "$MANAGED_ROOT" "$GUARDIAN_DIR" "$AUTH_DIR"
+/usr/bin/install -d -o root -g "$SERVICE_GROUP" -m 0750 "$ETC_DIR" "$GUARDIAN_DIR" "$AUTH_DIR"
 /usr/bin/install -d -o "$SERVICE_USER" -g "$SERVICE_GROUP" -m 0750 "$RUNTIME_DIR" "$LOG_DIR"
 
 install_file_atomic "$BINARY_SOURCE" "${BIN_DIR}/defenseclaw-gateway" root wheel 0755
@@ -279,7 +285,7 @@ install_file_atomic "${SCRIPT_DIR}/com.cisco.secureclient.defenseclaw.hook-guard
 
 assert_path_metadata "$BINARY_ROOT" dir 0 "$WHEEL_GID" 755
 assert_path_metadata "$BIN_DIR" dir 0 "$WHEEL_GID" 755
-assert_path_metadata "$MANAGED_ROOT" dir 0 "$SERVICE_GID" 750
+assert_path_metadata "$ETC_DIR" dir 0 "$SERVICE_GID" 750
 assert_path_metadata "$RUNTIME_DIR" dir "$SERVICE_UID" "$SERVICE_GID" 750
 assert_path_metadata "$GUARDIAN_DIR" dir 0 "$SERVICE_GID" 750
 assert_path_metadata "$AUTH_DIR" dir 0 "$SERVICE_GID" 750
@@ -293,13 +299,13 @@ assert_path_metadata "$GUARDIAN_PLIST_DEST" file 0 "$WHEEL_GID" 644
 if [ "$START_JOBS" = true ]; then
     /bin/launchctl bootstrap system "$GATEWAY_PLIST_DEST" || die "failed to bootstrap gateway LaunchDaemon"
     if ! /bin/launchctl bootstrap system "$GUARDIAN_PLIST_DEST"; then
-        /bin/launchctl bootout system/com.defenseclaw.gateway >/dev/null 2>&1 || true
+        /bin/launchctl bootout "system/${GATEWAY_LABEL}" >/dev/null 2>&1 || true
         die "failed to bootstrap hook guardian LaunchDaemon"
     fi
-    /bin/launchctl enable system/com.defenseclaw.gateway
-    /bin/launchctl enable system/com.defenseclaw.hook-guardian
-    /bin/launchctl kickstart -k system/com.defenseclaw.gateway
-    /bin/launchctl kickstart -k system/com.defenseclaw.hook-guardian
+    /bin/launchctl enable "system/${GATEWAY_LABEL}"
+    /bin/launchctl enable "system/${GUARDIAN_LABEL}"
+    /bin/launchctl kickstart -k "system/${GATEWAY_LABEL}"
+    /bin/launchctl kickstart -k "system/${GUARDIAN_LABEL}"
 fi
 
 printf 'DefenseClaw managed enterprise installation verified.\n'

--- a/packaging/launchd/install-enterprise.sh
+++ b/packaging/launchd/install-enterprise.sh
@@ -6,15 +6,14 @@ umask 077
 PATH=/usr/bin:/bin:/usr/sbin:/sbin
 export PATH
 
-SERVICE_USER=defenseclaw
-SERVICE_GROUP=defenseclaw
 BINARY_ROOT=/opt/cisco/secureclient/defenseclaw
 BIN_DIR="${BINARY_ROOT}/bin"
-MANAGED_ROOT="/opt/cisco/secureclient/defenseclaw"
 ETC_DIR="/opt/cisco/secureclient/defenseclaw/etc"
 RUNTIME_DIR="/opt/cisco/secureclient/defenseclaw/runtime"
 GUARDIAN_DIR="/opt/cisco/secureclient/defenseclaw/hook-guardian"
 AUTH_DIR="/opt/cisco/secureclient/defenseclaw/hook-guardian-state"
+LOG_VENDOR_DIR=/Library/Logs/Cisco
+LOG_PRODUCT_DIR=/Library/Logs/Cisco/SecureClient
 LOG_DIR=/Library/Logs/Cisco/SecureClient/DefenseClaw
 CONFIG_DEST="/opt/cisco/secureclient/defenseclaw/etc/config.yaml"
 MANIFEST_DEST="/opt/cisco/secureclient/defenseclaw/hook-guardian/targets.yaml"
@@ -28,6 +27,10 @@ die() {
     exit 1
 }
 
+warn() {
+    printf 'defenseclaw enterprise install: warning: %s\n' "$*" >&2
+}
+
 usage() {
     cat <<'EOF'
 Usage:
@@ -37,11 +40,11 @@ Usage:
     [--binary /path/to/defenseclaw] [--no-start]
 
 Installs the macOS managed-enterprise gateway and guardian. The managed
-config is atomically installed as root:defenseclaw with mode 0640 and is
+config is atomically installed as root:wheel with mode 0640 and is
 verified before either LaunchDaemon can start.
 
-An existing defenseclaw service user/group is required; this installer does
-not create it.
+Both LaunchDaemons run as root. No dedicated service user or group is created
+or required.
 
 Options:
   --config PATH    Administrator-approved managed config (required)
@@ -101,17 +104,6 @@ assert_trusted_system_dir() {
     [ $((8#$mode & 8#022)) -eq 0 ] || die "system directory is group/other writable: $path ($mode)"
 }
 
-assert_existing_acl_safe_dir_or_absent() {
-    local path="$1"
-    [ -e "$path" ] || {
-        refuse_symlink "$path"
-        return
-    }
-    refuse_symlink "$path"
-    [ -d "$path" ] || die "required directory path is not a directory: $path"
-    assert_no_write_acl "$path"
-}
-
 assert_existing_secure_dir_or_absent() {
     local path="$1"
     [ -e "$path" ] || {
@@ -144,13 +136,104 @@ assert_path_metadata() {
 }
 
 TEMP_FILES=()
+ROLLBACK_DESTINATIONS=()
+ROLLBACK_BACKUPS=()
+ROLLBACK_EXISTED=()
+ROLLBACK_DIR=
+ROLLBACK_ARMED=false
+GATEWAY_WAS_LOADED=false
+GUARDIAN_WAS_LOADED=false
+
+snapshot_file() {
+    local destination="$1"
+    local index="${#ROLLBACK_DESTINATIONS[@]}"
+    local backup="${ROLLBACK_DIR}/${index}"
+    ROLLBACK_DESTINATIONS+=("$destination")
+    if [ -e "$destination" ]; then
+        refuse_symlink "$destination"
+        [ -f "$destination" ] || die "existing destination is not a regular file: $destination"
+        ROLLBACK_BACKUPS+=("$backup")
+        ROLLBACK_EXISTED+=(true)
+        /bin/cp -p "$destination" "$backup"
+    else
+        ROLLBACK_BACKUPS+=("")
+        ROLLBACK_EXISTED+=(false)
+    fi
+}
+
+restore_snapshots() {
+    local index destination backup temporary
+    local failed=false
+    for ((index = ${#ROLLBACK_DESTINATIONS[@]} - 1; index >= 0; index--)); do
+        destination="${ROLLBACK_DESTINATIONS[$index]}"
+        if [ "${ROLLBACK_EXISTED[$index]}" = true ]; then
+            backup="${ROLLBACK_BACKUPS[$index]}"
+            temporary="${destination}.rollback.$$"
+            if [ -e "$temporary" ] || [ -L "$temporary" ]; then
+                warn "cannot restore $destination: rollback temporary path exists"
+                failed=true
+                continue
+            fi
+            if ! /bin/cp -p "$backup" "$temporary" || ! /bin/mv -f -- "$temporary" "$destination"; then
+                warn "failed to restore $destination"
+                /bin/rm -f -- "$temporary" || true
+                failed=true
+            fi
+        elif ! /bin/rm -f -- "$destination"; then
+            warn "failed to remove newly installed file: $destination"
+            failed=true
+        fi
+    done
+    [ "$failed" = false ]
+}
+
+rebootstrap_previously_loaded_job() {
+    local was_loaded="$1"
+    local label="$2"
+    local plist="$3"
+    [ "$was_loaded" = true ] || return 0
+    if [ ! -f "$plist" ]; then
+        warn "cannot restore loaded job ${label}: plist was not restored"
+        return 1
+    fi
+    if ! /bin/launchctl bootstrap system "$plist"; then
+        warn "failed to restore loaded job ${label}"
+        return 1
+    fi
+    if ! /bin/launchctl kickstart -k "system/${label}"; then
+        warn "restored but could not restart job ${label}"
+        return 1
+    fi
+}
+
+rollback_install() {
+    local failed=false
+    ROLLBACK_ARMED=false
+    /bin/launchctl bootout "system/${GUARDIAN_LABEL}" >/dev/null 2>&1 || true
+    /bin/launchctl bootout "system/${GATEWAY_LABEL}" >/dev/null 2>&1 || true
+    restore_snapshots || failed=true
+    rebootstrap_previously_loaded_job "$GATEWAY_WAS_LOADED" "$GATEWAY_LABEL" "$GATEWAY_PLIST_DEST" || failed=true
+    rebootstrap_previously_loaded_job "$GUARDIAN_WAS_LOADED" "$GUARDIAN_LABEL" "$GUARDIAN_PLIST_DEST" || failed=true
+    if [ "$failed" = true ]; then
+        warn "rollback was incomplete; inspect the installation before retrying"
+    fi
+}
 
 cleanup() {
+    local status=$?
     local path
-    for path in "${TEMP_FILES[@]-}"; do
+    trap - EXIT
+    if [ "$status" -ne 0 ] && [ "$ROLLBACK_ARMED" = true ]; then
+        rollback_install
+    fi
+    for path in "${TEMP_FILES[@]-}" "${ROLLBACK_BACKUPS[@]-}"; do
         [ -n "$path" ] || continue
-        /bin/rm -f -- "$path"
+        /bin/rm -f -- "$path" || true
     done
+    if [ -n "$ROLLBACK_DIR" ]; then
+        /bin/rmdir "$ROLLBACK_DIR" >/dev/null 2>&1 || true
+    fi
+    exit "$status"
 }
 trap cleanup EXIT
 trap 'exit 130' HUP INT TERM
@@ -240,76 +323,94 @@ require_regular_source "${SCRIPT_DIR}/com.cisco.secureclient.defenseclaw.hook-gu
 plist_pins_managed_mode "${SCRIPT_DIR}/com.cisco.secureclient.defenseclaw.plist" || die "gateway plist does not pin managed_enterprise"
 plist_pins_managed_mode "${SCRIPT_DIR}/com.cisco.secureclient.defenseclaw.hook-guardian.plist" || die "guardian plist does not pin managed_enterprise"
 
-SERVICE_UID="$(/usr/bin/id -u "$SERVICE_USER" 2>/dev/null)" || die "service user does not exist: $SERVICE_USER"
-SERVICE_GID="$(/usr/bin/id -g "$SERVICE_USER" 2>/dev/null)" || die "service group does not exist: $SERVICE_GROUP"
-[ "$(/usr/bin/id -gn "$SERVICE_USER")" = "$SERVICE_GROUP" ] || die "service user primary group must be $SERVICE_GROUP"
 WHEEL_GID="$(/usr/bin/stat -f '%g' /Library)"
 
 assert_trusted_system_dir /Library
 assert_trusted_system_dir /Library/LaunchDaemons
 assert_trusted_system_dir /Library/Logs
+assert_existing_secure_dir_or_absent "$LOG_VENDOR_DIR"
+assert_existing_secure_dir_or_absent "$LOG_PRODUCT_DIR"
 assert_existing_secure_dir_or_absent /opt
 assert_existing_secure_dir_or_absent /opt/cisco
 assert_existing_secure_dir_or_absent /opt/cisco/secureclient
 assert_existing_secure_dir_or_absent "$BINARY_ROOT"
 assert_existing_secure_dir_or_absent "$BIN_DIR"
 assert_existing_secure_dir_or_absent "$ETC_DIR"
-assert_existing_secure_dir_or_absent "$MANAGED_ROOT"
+assert_existing_secure_dir_or_absent "$RUNTIME_DIR"
 assert_existing_secure_dir_or_absent "$GUARDIAN_DIR"
 assert_existing_secure_dir_or_absent "$AUTH_DIR"
-assert_existing_acl_safe_dir_or_absent "$RUNTIME_DIR"
-assert_existing_acl_safe_dir_or_absent "$LOG_DIR"
+assert_existing_secure_dir_or_absent "$LOG_DIR"
 refuse_symlink "$CONFIG_DEST"
 
-for destination in \
-    "${BIN_DIR}/defenseclaw-gateway" \
-    "$CONFIG_DEST" \
-    "$MANIFEST_DEST" \
-    "$GATEWAY_PLIST_DEST" \
-    "$GUARDIAN_PLIST_DEST"; do
+INSTALL_DESTINATIONS=(
+    "${BIN_DIR}/defenseclaw-gateway"
+    "$CONFIG_DEST"
+    "$MANIFEST_DEST"
+    "$GATEWAY_PLIST_DEST"
+    "$GUARDIAN_PLIST_DEST"
+)
+for destination in "${INSTALL_DESTINATIONS[@]}"; do
     refuse_symlink "$destination"
     if [ -e "$destination" ]; then
         assert_no_write_acl "$destination"
     fi
 done
 
-stop_job_if_loaded com.cisco.secureclient.defenseclaw.hook-guardian
-stop_job_if_loaded com.cisco.secureclient.defenseclaw
+if /bin/launchctl print "system/${GATEWAY_LABEL}" >/dev/null 2>&1; then
+    GATEWAY_WAS_LOADED=true
+    [ -f "$GATEWAY_PLIST_DEST" ] || die "loaded gateway job has no restorable plist"
+fi
+if /bin/launchctl print "system/${GUARDIAN_LABEL}" >/dev/null 2>&1; then
+    GUARDIAN_WAS_LOADED=true
+    [ -f "$GUARDIAN_PLIST_DEST" ] || die "loaded hook guardian job has no restorable plist"
+fi
 
-/usr/bin/install -d -o root -g wheel -m 0755 "$BINARY_ROOT" "$BIN_DIR"
-/usr/bin/install -d -o root -g "$SERVICE_GROUP" -m 0750 "$ETC_DIR" "$GUARDIAN_DIR" "$AUTH_DIR"
-/usr/bin/install -d -o "$SERVICE_USER" -g "$SERVICE_GROUP" -m 0750 "$RUNTIME_DIR" "$LOG_DIR"
+ROLLBACK_DIR="$(/usr/bin/mktemp -d "/private/tmp/defenseclaw-enterprise-rollback.XXXXXX")"
+/bin/chmod 0700 "$ROLLBACK_DIR"
+for destination in "${INSTALL_DESTINATIONS[@]}"; do
+    snapshot_file "$destination"
+done
+ROLLBACK_ARMED=true
+
+stop_job_if_loaded "$GUARDIAN_LABEL"
+stop_job_if_loaded "$GATEWAY_LABEL"
+
+for parent in "$LOG_VENDOR_DIR" "$LOG_PRODUCT_DIR"; do
+    if [ ! -d "$parent" ]; then
+        /usr/bin/install -d -o root -g wheel -m 0755 "$parent"
+    fi
+    assert_trusted_system_dir "$parent"
+done
+/usr/bin/install -d -o root -g wheel -m 0755 "$BINARY_ROOT" "$BIN_DIR" "$ETC_DIR"
+/usr/bin/install -d -o root -g wheel -m 0750 "$RUNTIME_DIR" "$GUARDIAN_DIR" "$AUTH_DIR" "$LOG_DIR"
 
 install_file_atomic "$BINARY_SOURCE" "${BIN_DIR}/defenseclaw-gateway" root wheel 0755
-install_file_atomic "$CONFIG_SOURCE" "$CONFIG_DEST" root "$SERVICE_GROUP" 0640
-install_file_atomic "$MANIFEST_SOURCE" "$MANIFEST_DEST" root "$SERVICE_GROUP" 0640
+install_file_atomic "$CONFIG_SOURCE" "$CONFIG_DEST" root wheel 0640
+install_file_atomic "$MANIFEST_SOURCE" "$MANIFEST_DEST" root wheel 0640
 install_file_atomic "${SCRIPT_DIR}/com.cisco.secureclient.defenseclaw.plist" "$GATEWAY_PLIST_DEST" root wheel 0644
 install_file_atomic "${SCRIPT_DIR}/com.cisco.secureclient.defenseclaw.hook-guardian.plist" "$GUARDIAN_PLIST_DEST" root wheel 0644
 
 assert_path_metadata "$BINARY_ROOT" dir 0 "$WHEEL_GID" 755
 assert_path_metadata "$BIN_DIR" dir 0 "$WHEEL_GID" 755
-assert_path_metadata "$ETC_DIR" dir 0 "$SERVICE_GID" 750
-assert_path_metadata "$RUNTIME_DIR" dir "$SERVICE_UID" "$SERVICE_GID" 750
-assert_path_metadata "$GUARDIAN_DIR" dir 0 "$SERVICE_GID" 750
-assert_path_metadata "$AUTH_DIR" dir 0 "$SERVICE_GID" 750
-assert_path_metadata "$LOG_DIR" dir "$SERVICE_UID" "$SERVICE_GID" 750
+assert_path_metadata "$ETC_DIR" dir 0 "$WHEEL_GID" 755
+assert_path_metadata "$RUNTIME_DIR" dir 0 "$WHEEL_GID" 750
+assert_path_metadata "$GUARDIAN_DIR" dir 0 "$WHEEL_GID" 750
+assert_path_metadata "$AUTH_DIR" dir 0 "$WHEEL_GID" 750
+assert_path_metadata "$LOG_DIR" dir 0 "$WHEEL_GID" 750
 assert_path_metadata "${BIN_DIR}/defenseclaw-gateway" file 0 "$WHEEL_GID" 755
-assert_path_metadata "$CONFIG_DEST" file 0 "$SERVICE_GID" 640
-assert_path_metadata "$MANIFEST_DEST" file 0 "$SERVICE_GID" 640
+assert_path_metadata "$CONFIG_DEST" file 0 "$WHEEL_GID" 640
+assert_path_metadata "$MANIFEST_DEST" file 0 "$WHEEL_GID" 640
 assert_path_metadata "$GATEWAY_PLIST_DEST" file 0 "$WHEEL_GID" 644
 assert_path_metadata "$GUARDIAN_PLIST_DEST" file 0 "$WHEEL_GID" 644
 
 if [ "$START_JOBS" = true ]; then
     /bin/launchctl bootstrap system "$GATEWAY_PLIST_DEST" || die "failed to bootstrap gateway LaunchDaemon"
-    if ! /bin/launchctl bootstrap system "$GUARDIAN_PLIST_DEST"; then
-        /bin/launchctl bootout "system/${GATEWAY_LABEL}" >/dev/null 2>&1 || true
-        /bin/rm -f "$GATEWAY_PLIST_DEST" "$GUARDIAN_PLIST_DEST"
-        die "failed to bootstrap hook guardian LaunchDaemon"
-    fi
-    /bin/launchctl enable "system/${GATEWAY_LABEL}"
-    /bin/launchctl enable "system/${GUARDIAN_LABEL}"
-    /bin/launchctl kickstart -k "system/${GATEWAY_LABEL}"
-    /bin/launchctl kickstart -k "system/${GUARDIAN_LABEL}"
+    /bin/launchctl bootstrap system "$GUARDIAN_PLIST_DEST" || die "failed to bootstrap hook guardian LaunchDaemon"
+    /bin/launchctl enable "system/${GATEWAY_LABEL}" || die "failed to enable gateway LaunchDaemon"
+    /bin/launchctl enable "system/${GUARDIAN_LABEL}" || die "failed to enable hook guardian LaunchDaemon"
+    /bin/launchctl kickstart -k "system/${GATEWAY_LABEL}" || die "failed to start gateway LaunchDaemon"
+    /bin/launchctl kickstart -k "system/${GUARDIAN_LABEL}" || die "failed to start hook guardian LaunchDaemon"
 fi
 
+ROLLBACK_ARMED=false
 printf 'DefenseClaw managed enterprise installation verified.\n'

--- a/packaging/launchd/install-enterprise.sh
+++ b/packaging/launchd/install-enterprise.sh
@@ -383,6 +383,9 @@ for parent in "$LOG_VENDOR_DIR" "$LOG_PRODUCT_DIR"; do
 done
 /usr/bin/install -d -o root -g wheel -m 0755 "$BINARY_ROOT" "$BIN_DIR" "$ETC_DIR"
 /usr/bin/install -d -o root -g wheel -m 0750 "$RUNTIME_DIR" "$GUARDIAN_DIR" "$AUTH_DIR" "$LOG_DIR"
+assert_trusted_system_dir /opt
+assert_trusted_system_dir /opt/cisco
+assert_trusted_system_dir /opt/cisco/secureclient
 
 install_file_atomic "$BINARY_SOURCE" "${BIN_DIR}/defenseclaw-gateway" root wheel 0755
 install_file_atomic "$CONFIG_SOURCE" "$CONFIG_DEST" root wheel 0640

--- a/packaging/macos/PACKAGING.md
+++ b/packaging/macos/PACKAGING.md
@@ -119,20 +119,22 @@ curl -sS http://127.0.0.1:18970/healthz
 
 Requires `sudo`. The installer:
 
-- Creates directories under the managed install tree (all `root:wheel`):
-  - `/opt/cisco/secureclient/defenseclaw/bin/` — `0755` (gateway binary)
-  - `/opt/cisco/secureclient/defenseclaw/etc/` — `0755` (config.yaml)
-  - `/opt/cisco/secureclient/defenseclaw/runtime/` — `0750` (audit DB, tokens, device key)
-  - `/opt/cisco/secureclient/defenseclaw/hook-guardian-state/` — `0750` (authorization records)
-  - `/Library/Logs/Cisco/SecureClient/DefenseClaw/` — `0750`
+- Creates directories under the managed install tree:
+  - `/opt/cisco/secureclient/defenseclaw/` — `root:wheel 0755`
+  - `/opt/cisco/secureclient/defenseclaw/bin/` — `root:wheel 0755` (gateway binary)
+  - `/opt/cisco/secureclient/defenseclaw/etc/` — `root:defenseclaw 0750` (config.yaml)
+  - `/opt/cisco/secureclient/defenseclaw/runtime/` — `defenseclaw:defenseclaw 0750` (audit DB, tokens, device key)
+  - `/opt/cisco/secureclient/defenseclaw/hook-guardian/` — `root:defenseclaw 0750` (hook target manifest)
+  - `/opt/cisco/secureclient/defenseclaw/hook-guardian-state/` — `root:defenseclaw 0750` (authorization records)
+  - `/Library/Logs/Cisco/SecureClient/DefenseClaw/` — `defenseclaw:defenseclaw 0750`
 - Writes `/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.plist` (`root:wheel 0644`) and `launchctl bootstrap`s it.
-- Writes `/opt/cisco/secureclient/defenseclaw/etc/config.yaml` as `root:wheel 0640`.
-- Does NOT create a dedicated service user. The gateway daemon runs as root (uid 0) because the managed cloud auth provider requires root to read and re-perm its credential store on disk.
+- Writes `/opt/cisco/secureclient/defenseclaw/etc/config.yaml` as `root:defenseclaw 0640`.
+- Creates the `defenseclaw` service user/group for managed file ownership. The gateway daemon still runs as root (uid 0) because the managed cloud auth provider requires root to read and re-perm its credential store on disk.
 - Wires per-user hook configs in the target user's `~/.codex/config.toml`, `~/.claude/settings.json`, and/or `~/.cursor/hooks.json` depending on `--connector`.
 - Sweeps legacy pre-managed-layout install locations (`/Library/DefenseClaw/`, `/Library/Application Support/DefenseClaw/`, `/Library/Logs/DefenseClaw/`, `com.defenseclaw.gateway.plist`) if present — an upgrade from an older install produces a clean cutover.
 
 ### Runtime privileges
 
-The daemon runs as **root** (uid 0). The plist deliberately omits `UserName` / `GroupName` so launchd defaults to root; the managed cloud auth provider requires root to read and re-perm its on-disk credential store. No dedicated service user is created. Every install-time chown of a DefenseClaw-owned path uses `root:wheel`.
+The daemon runs as **root** (uid 0). The plist deliberately omits `UserName` / `GroupName` so launchd defaults to root; the managed cloud auth provider requires root to read and re-perm its on-disk credential store. The installer still creates the `defenseclaw` service identity so managed config, manifest, runtime, guardian-state, and log paths can be group-restricted to `defenseclaw` instead of world-readable.
 
 Upgrades from a pre-root install (which provisioned a `defenseclaw` service user via `dscl` / `sysadminctl`) are handled by `uninstall.sh --purge`, which sweeps the legacy uid/gid so a subsequent reinstall starts from a clean uid namespace.

--- a/packaging/macos/PACKAGING.md
+++ b/packaging/macos/PACKAGING.md
@@ -119,22 +119,20 @@ curl -sS http://127.0.0.1:18970/healthz
 
 Requires `sudo`. The installer:
 
-- Creates directories under the managed install tree:
-  - `/opt/cisco/secureclient/defenseclaw/` — `root:wheel 0755`
-  - `/opt/cisco/secureclient/defenseclaw/bin/` — `root:wheel 0755` (gateway binary)
-  - `/opt/cisco/secureclient/defenseclaw/etc/` — `root:defenseclaw 0750` (config.yaml)
-  - `/opt/cisco/secureclient/defenseclaw/runtime/` — `defenseclaw:defenseclaw 0750` (audit DB, tokens, device key)
-  - `/opt/cisco/secureclient/defenseclaw/hook-guardian/` — `root:defenseclaw 0750` (hook target manifest)
-  - `/opt/cisco/secureclient/defenseclaw/hook-guardian-state/` — `root:defenseclaw 0750` (authorization records)
-  - `/Library/Logs/Cisco/SecureClient/DefenseClaw/` — `defenseclaw:defenseclaw 0750`
-- Writes `/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.plist` and `/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.hook-guardian.plist` (`root:wheel 0644`) and `launchctl bootstrap`s both.
-- Writes `/opt/cisco/secureclient/defenseclaw/etc/config.yaml` as `root:defenseclaw 0640`.
-- Creates the `defenseclaw` service user/group for managed file ownership. The gateway daemon still runs as root (uid 0) because the managed cloud auth provider requires root to read and re-perm its credential store on disk.
+- Creates directories under the managed install tree (all `root:wheel`):
+  - `/opt/cisco/secureclient/defenseclaw/bin/` — `0755` (gateway binary)
+  - `/opt/cisco/secureclient/defenseclaw/etc/` — `0755` (config.yaml)
+  - `/opt/cisco/secureclient/defenseclaw/runtime/` — `0750` (audit DB, tokens, device key)
+  - `/opt/cisco/secureclient/defenseclaw/hook-guardian-state/` — `0750` (authorization records)
+  - `/Library/Logs/Cisco/SecureClient/DefenseClaw/` — `0750`
+- Writes `/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.plist` (`root:wheel 0644`) and `launchctl bootstrap`s it.
+- Writes `/opt/cisco/secureclient/defenseclaw/etc/config.yaml` as `root:wheel 0640`.
+- Does NOT create a dedicated service user. The gateway daemon runs as root (uid 0) because the managed cloud auth provider requires root to read and re-perm its credential store on disk.
 - Wires per-user hook configs in the target user's `~/.codex/config.toml`, `~/.claude/settings.json`, and/or `~/.cursor/hooks.json` depending on `--connector`.
 - Sweeps legacy pre-managed-layout install locations (`/Library/DefenseClaw/`, `/Library/Application Support/DefenseClaw/`, `/Library/Logs/DefenseClaw/`, `com.defenseclaw.gateway.plist`) if present — an upgrade from an older install produces a clean cutover.
 
 ### Runtime privileges
 
-The daemon runs as **root** (uid 0). The plist deliberately omits `UserName` / `GroupName` so launchd defaults to root; the managed cloud auth provider requires root to read and re-perm its on-disk credential store. The installer still creates the `defenseclaw` service identity so managed config, manifest, runtime, guardian-state, and log paths can be group-restricted to `defenseclaw` instead of world-readable.
+The daemon runs as **root** (uid 0). The plist deliberately omits `UserName` / `GroupName` so launchd defaults to root; the managed cloud auth provider requires root to read and re-perm its on-disk credential store. No dedicated service user is created. Every install-time chown of a DefenseClaw-owned path uses `root:wheel`.
 
 Upgrades from a pre-root install (which provisioned a `defenseclaw` service user via `dscl` / `sysadminctl`) are handled by `uninstall.sh --purge`, which sweeps the legacy uid/gid so a subsequent reinstall starts from a clean uid namespace.

--- a/packaging/macos/PACKAGING.md
+++ b/packaging/macos/PACKAGING.md
@@ -127,7 +127,7 @@ Requires `sudo`. The installer:
   - `/opt/cisco/secureclient/defenseclaw/hook-guardian/` — `root:defenseclaw 0750` (hook target manifest)
   - `/opt/cisco/secureclient/defenseclaw/hook-guardian-state/` — `root:defenseclaw 0750` (authorization records)
   - `/Library/Logs/Cisco/SecureClient/DefenseClaw/` — `defenseclaw:defenseclaw 0750`
-- Writes `/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.plist` (`root:wheel 0644`) and `launchctl bootstrap`s it.
+- Writes `/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.plist` and `/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.hook-guardian.plist` (`root:wheel 0644`) and `launchctl bootstrap`s both.
 - Writes `/opt/cisco/secureclient/defenseclaw/etc/config.yaml` as `root:defenseclaw 0640`.
 - Creates the `defenseclaw` service user/group for managed file ownership. The gateway daemon still runs as root (uid 0) because the managed cloud auth provider requires root to read and re-perm its credential store on disk.
 - Wires per-user hook configs in the target user's `~/.codex/config.toml`, `~/.claude/settings.json`, and/or `~/.cursor/hooks.json` depending on `--connector`.

--- a/scripts/test-macos-enterprise-packaging.sh
+++ b/scripts/test-macos-enterprise-packaging.sh
@@ -7,6 +7,13 @@ fail() {
     exit 1
 }
 
+assert_no_defenseclaw_identity() {
+    local message="$1"
+    if id defenseclaw >/dev/null 2>&1 || dscl . -read /Groups/defenseclaw >/dev/null 2>&1; then
+        fail "$message"
+    fi
+}
+
 [ "$(uname -s)" = Darwin ] || fail "this smoke test requires macOS"
 [ "$(id -u)" -ne 0 ] || fail "run as a non-root CI user"
 [ "${MACOS_ENTERPRISE_PACKAGING_SMOKE:-}" = 1 ] || fail "set MACOS_ENTERPRISE_PACKAGING_SMOKE=1 on a disposable host"
@@ -20,13 +27,10 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 installer="${root}/packaging/launchd/install-enterprise.sh"
 managed_root="/opt/cisco/secureclient/defenseclaw"
 config_dest="${managed_root}/etc/config.yaml"
-binary_root=/opt/cisco/secureclient/defenseclaw
 gateway_plist=/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.plist
 guardian_plist=/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.hook-guardian.plist
 log_dir=/Library/Logs/Cisco/SecureClient/DefenseClaw
 fixture="$(mktemp -d "${TMPDIR:-/tmp}/defenseclaw-packaging.XXXXXX")"
-user_created=false
-group_created=false
 installation_owned=false
 
 cleanup() {
@@ -35,23 +39,16 @@ cleanup() {
     if [ "$installation_owned" = true ]; then
         sudo -n launchctl bootout system/com.cisco.secureclient.defenseclaw.hook-guardian >/dev/null 2>&1 || true
         sudo -n launchctl bootout system/com.cisco.secureclient.defenseclaw >/dev/null 2>&1 || true
-        sudo -n rm -rf -- "$binary_root" "$managed_root" "$log_dir"
+        sudo -n rm -rf -- "$managed_root" "$log_dir"
         sudo -n rm -f -- "$gateway_plist" "$guardian_plist"
     fi
-    if [ "$user_created" = true ]; then
-        sudo -n dscl . -delete /Users/defenseclaw >/dev/null 2>&1 || true
-    fi
-    if [ "$group_created" = true ]; then
-        sudo -n dscl . -delete /Groups/defenseclaw >/dev/null 2>&1 || true
-    fi
-    sudo -n dscacheutil -flushcache >/dev/null 2>&1 || true
     rm -rf -- "$fixture"
     exit "$status"
 }
 trap cleanup EXIT
 trap 'exit 130' HUP INT TERM
 
-for path in "$binary_root" "$managed_root" "$log_dir" "$gateway_plist" "$guardian_plist"; do
+for path in "$managed_root" "$log_dir" "$gateway_plist" "$guardian_plist"; do
     [ ! -e "$path" ] && [ ! -L "$path" ] || fail "refusing to overwrite pre-existing path: $path"
 done
 for label in com.cisco.secureclient.defenseclaw com.cisco.secureclient.defenseclaw.hook-guardian; do
@@ -60,40 +57,7 @@ for label in com.cisco.secureclient.defenseclaw com.cisco.secureclient.defensecl
     fi
 done
 installation_owned=true
-if id defenseclaw >/dev/null 2>&1 || dscl . -read /Groups/defenseclaw >/dev/null 2>&1; then
-    fail "refusing to reuse a pre-existing defenseclaw identity"
-fi
-
-used_ids="$(
-    dscl . -list /Users UniqueID 2>/dev/null | awk '{print $NF}'
-    dscl . -list /Groups PrimaryGroupID 2>/dev/null | awk '{print $NF}'
-)"
-service_id=499
-while printf '%s\n' "$used_ids" | grep -qx "$service_id"; do
-    service_id=$((service_id - 1))
-    [ "$service_id" -ge 400 ] || fail "no free service uid/gid available"
-done
-
-sudo -n dscl . -create /Groups/defenseclaw
-group_created=true
-sudo -n dscl . -create /Groups/defenseclaw RealName "DefenseClaw Service"
-sudo -n dscl . -create /Groups/defenseclaw PrimaryGroupID "$service_id"
-sudo -n dscl . -create /Users/defenseclaw
-user_created=true
-sudo -n dscl . -create /Users/defenseclaw RealName "DefenseClaw Service"
-sudo -n dscl . -create /Users/defenseclaw UniqueID "$service_id"
-sudo -n dscl . -create /Users/defenseclaw PrimaryGroupID "$service_id"
-sudo -n dscl . -create /Users/defenseclaw NFSHomeDirectory /var/empty
-sudo -n dscl . -create /Users/defenseclaw UserShell /usr/bin/false
-sudo -n dscl . -create /Users/defenseclaw IsHidden 1
-sudo -n dscacheutil -flushcache
-
-attempt=0
-until id defenseclaw >/dev/null 2>&1 && [ "$(id -gn defenseclaw 2>/dev/null)" = defenseclaw ]; do
-    attempt=$((attempt + 1))
-    [ "$attempt" -lt 50 ] || fail "service identity did not become visible"
-    sleep 0.1
-done
+assert_no_defenseclaw_identity "cannot verify service-user-free install while a defenseclaw identity exists"
 
 config_source="${fixture}/config.yaml"
 manifest_source="${fixture}/targets.yaml"
@@ -123,11 +87,12 @@ sudo -n "$installer" \
     --manifest "$manifest_source" \
     --no-start
 
-service_gid="$(id -g defenseclaw)"
+wheel_gid="$(stat -f '%g' /Library)"
 [ "$(sudo -n stat -f '%u' "$config_dest")" = 0 ] || fail "managed config is not root-owned"
-[ "$(sudo -n stat -f '%g' "$config_dest")" = "$service_gid" ] || fail "managed config group is not defenseclaw"
+[ "$(sudo -n stat -f '%g' "$config_dest")" = "$wheel_gid" ] || fail "managed config group is not wheel"
 [ "$(sudo -n stat -f '%Lp' "$config_dest")" = 640 ] || fail "managed config mode is not 0640"
 [ ! -w "$config_dest" ] || fail "standard user can write managed config"
+assert_no_defenseclaw_identity "installer created a defenseclaw identity during fresh install"
 
 config_hash_before_acl="$(sudo -n shasum -a 256 "$config_dest" | awk '{print $1}')"
 sudo -n chmod +a "everyone allow add_file,add_subdirectory,delete_child,writeattr,writeextattr,writesecurity,chown" "$managed_root"
@@ -149,7 +114,8 @@ sudo -n "$installer" \
     --config "$config_source" \
     --manifest "$manifest_source" \
     --no-start
-[ "$(sudo -n stat -f '%u:%g:%Lp' "$config_dest")" = "0:${service_gid}:640" ] || fail "installer did not repair config metadata"
+[ "$(sudo -n stat -f '%u:%g:%Lp' "$config_dest")" = "0:${wheel_gid}:640" ] || fail "installer did not repair config metadata"
+assert_no_defenseclaw_identity "installer created a defenseclaw identity during repair"
 
 decoy="${fixture}/decoy.yaml"
 printf 'decoy must remain unchanged\n' >"$decoy"

--- a/scripts/test-macos-enterprise-packaging.sh
+++ b/scripts/test-macos-enterprise-packaging.sh
@@ -18,12 +18,12 @@ sudo -n true || fail "passwordless sudo is required"
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 installer="${root}/packaging/launchd/install-enterprise.sh"
-managed_root="/Library/Application Support/DefenseClaw"
-config_dest="${managed_root}/config.yaml"
-binary_root=/Library/DefenseClaw
+managed_root="/opt/cisco/secureclient/defenseclaw"
+config_dest="${managed_root}/etc/config.yaml"
+binary_root=/opt/cisco/secureclient/defenseclaw
 gateway_plist=/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.plist
 guardian_plist=/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.hook-guardian.plist
-log_dir=/Library/Logs/DefenseClaw
+log_dir=/Library/Logs/Cisco/SecureClient/DefenseClaw
 fixture="$(mktemp -d "${TMPDIR:-/tmp}/defenseclaw-packaging.XXXXXX")"
 user_created=false
 group_created=false
@@ -100,11 +100,11 @@ manifest_source="${fixture}/targets.yaml"
 cat >"$config_source" <<'EOF'
 config_version: 7
 deployment_mode: managed_enterprise
-data_dir: /Library/Application Support/DefenseClaw/runtime
-audit_db: /Library/Application Support/DefenseClaw/runtime/audit.db
-judge_bodies_db: /Library/Application Support/DefenseClaw/runtime/judge_bodies.db
-plugin_dir: /Library/Application Support/DefenseClaw/runtime/plugins
-policy_dir: /Library/Application Support/DefenseClaw/runtime/policies
+data_dir: /opt/cisco/secureclient/defenseclaw/runtime
+audit_db: /opt/cisco/secureclient/defenseclaw/runtime/audit.db
+judge_bodies_db: /opt/cisco/secureclient/defenseclaw/runtime/judge_bodies.db
+plugin_dir: /opt/cisco/secureclient/defenseclaw/runtime/plugins
+policy_dir: /opt/cisco/secureclient/defenseclaw/runtime/policies
 gateway:
   api_bind: 127.0.0.1
   api_port: 18970


### PR DESCRIPTION
## Problem

Fixes #469. The enterprise launchd installer copied files into legacy DefenseClaw paths while the Cisco launchd plists execute binaries and read config/manifest state from `/opt/cisco/secureclient/defenseclaw`. The installer also retained a stale dedicated-service-user ownership model even though both macOS LaunchDaemons run as root.

## Current Situation

The Cisco plists use:

- `/opt/cisco/secureclient/defenseclaw/bin/defenseclaw-gateway`
- `/opt/cisco/secureclient/defenseclaw/etc/config.yaml`
- `/opt/cisco/secureclient/defenseclaw/hook-guardian/targets.yaml`
- Cisco launchd labels under `com.cisco.secureclient.defenseclaw*`

`install-enterprise.sh` still installed to legacy `/Library` paths, kickstarted old `com.defenseclaw.*` labels, and required a `defenseclaw` user/group that the production macOS install path does not create.

## Solution

- Align every installer destination and launchd label with the packaged Cisco plists.
- Use the documented root-running macOS model throughout: `root:wheel` ownership, no dedicated service account, `0755` executable/config parents, `0750` sensitive state directories, and `0640` config/manifest files.
- Validate shared Cisco log ancestors without changing permissions owned by other Cisco products.
- Snapshot replaced files and loaded-job state before stopping services. Any failure restores the previous binary, config, manifest, and plists and re-bootstraps only jobs that were previously loaded.
- Keep the disposable-host smoke test aligned with the production identity and ownership model.

## Architecture Diagram

```mermaid
flowchart LR
  A[install-enterprise.sh] --> B[/opt/cisco/secureclient/defenseclaw]
  A --> C[/Library/Logs/Cisco/SecureClient/DefenseClaw]
  A --> D[Cisco LaunchDaemon plists]
  D --> E[root gateway]
  D --> F[root hook guardian]
  G[pre-install snapshot] --> H{install succeeds?}
  H -- yes --> I[commit new deployment]
  H -- no --> J[restore files and loaded jobs]
```

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `packaging/launchd/install-enterprise.sh` | Aligns Cisco paths and labels, removes the stale service-user dependency, enforces root-owned metadata, protects shared log ancestors, and adds transactional rollback. |
| `scripts/test-macos-enterprise-packaging.sh` | Uses Cisco paths, proves no service identity is created during fresh install or repair, and verifies `root:wheel` metadata. |
| `cli/tests/test_enterprise_packaging.py` | Adds plist/installer parity, root ownership, rollback, smoke-test, and documentation-contract assertions. |
| `docs-site/content/docs/setup/enterprise-deployment.mdx` | Documents the complete macOS ownership/mode table and failure rollback behavior. |

## Breaking Changes

The legacy launchd enterprise installer now installs to the Cisco Secure Client layout rather than `/Library/DefenseClaw` and `/Library/Application Support/DefenseClaw`. A dedicated `defenseclaw` macOS service identity is no longer required.

## Open Issues / Follow-ups

None.

## Test Plan

- `uv run pytest cli/tests/test_enterprise_packaging.py` -> passed (`8 passed`).
- `bash -n packaging/launchd/install-enterprise.sh && bash -n scripts/test-macos-enterprise-packaging.sh` -> passed.
- `cd docs-site && npm run validate-links` -> passed (`0 errored file, 0 errors`).
- `cd docs-site && npm run validate-snippets` -> passed (`Validated shell syntax in 507 documentation code fences`).
- `cd docs-site && npm run build` -> passed, including static generation and postbuild checks.
- `git diff --cached --check` -> passed.
- `scripts/test-macos-enterprise-packaging.sh` remains CI-only because it requires `MACOS_ENTERPRISE_PACKAGING_SMOKE=1`, passwordless sudo, and a disposable macOS host.