### PR TITLE
Add daily connector upgrade regression radar

### DIFF
--- a/.github/workflows/connector-version-radar.yml
+++ b/.github/workflows/connector-version-radar.yml
@@ -1,0 +1,378 @@
+# Daily upstream connector version radar and isolated macOS upgrade regression
+# harness. This workflow is intentionally separate from connector-live-e2e.yml:
+# the existing hosted Layer A contract matrix remains unchanged, while only
+# trusted default-branch code can reach the persistent connector-lab runner.
+
+name: Connector Version Radar
+
+on:
+  schedule:
+    # Stagger away from the existing 09:00 UTC connector contract matrix.
+    - cron: "17 10 * * *"
+  workflow_dispatch:
+    inputs:
+      connector:
+        description: "Connector to check (or all)"
+        type: choice
+        default: all
+        options:
+          - all
+          - codex
+          - claudecode
+          - antigravity
+      force:
+        description: "Run even when the candidate was already attempted"
+        type: boolean
+        default: false
+      baseline_version:
+        description: "Optional exact baseline (single connector only; e.g. 0.142.5)"
+        type: string
+        default: ""
+      candidate_version:
+        description: "Optional exact candidate (single connector only; e.g. 0.144.1)"
+        type: string
+        default: ""
+
+# The lab is persistent. Prevent overlap and never cancel a harness midway
+# through connector config restoration. GitHub retains at most one pending run.
+concurrency:
+  group: connector-version-radar-main
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    name: Detect new connector versions
+    # A manual dispatch may select another ref in the UI. Never send that ref's
+    # code to the persistent runner.
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: [self-hosted, macOS, ARM64, connector-lab, defenseclaw-macos]
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      any_new: ${{ steps.radar.outputs.any_new }}
+      matrix: ${{ steps.radar.outputs.matrix }}
+      status: ${{ steps.radar.outputs.status }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: main
+          persist-credentials: false
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: "24"
+
+      - name: Establish LaunchAgent PATH and private state path
+        shell: bash
+        run: |
+          set -euo pipefail
+          for path in \
+            "${HOME}/.local/bin" \
+            "${HOME}/.npm-global/bin" \
+            /opt/homebrew/bin \
+            /usr/local/bin; do
+            echo "${path}" >> "${GITHUB_PATH}"
+          done
+          state_dir="${HOME}/Library/Application Support/DefenseClawConnectorLab"
+          mkdir -p "${state_dir}" "${RUNNER_TEMP}/connector-version-radar-detection"
+          chmod 700 "${state_dir}"
+          echo "RADAR_STATE=${state_dir}/version-radar-state.json" >> "${GITHUB_ENV}"
+          echo "RADAR_OUTPUT=${RUNNER_TEMP}/connector-version-radar-detection/radar.json" >> "${GITHUB_ENV}"
+
+      - name: Validate manual overrides
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        env:
+          SELECTED_CONNECTOR: ${{ inputs.connector }}
+          BASELINE_VERSION: ${{ inputs.baseline_version }}
+          CANDIDATE_VERSION: ${{ inputs.candidate_version }}
+        run: |
+          set -euo pipefail
+          if { [ -n "${BASELINE_VERSION}" ] || [ -n "${CANDIDATE_VERSION}" ]; } && \
+             [ "${SELECTED_CONNECTOR}" = all ]; then
+            echo "::error::Version overrides require one connector, not 'all'."
+            exit 1
+          fi
+          for value in "${BASELINE_VERSION}" "${CANDIDATE_VERSION}"; do
+            [ -z "${value}" ] || [[ "${value}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]] || {
+              echo "::error::Version overrides must be exact semantic versions: ${value}"
+              exit 1
+            }
+          done
+
+      - name: Query installed and upstream stable versions
+        id: radar
+        shell: bash
+        env:
+          SELECTED_CONNECTOR: ${{ inputs.connector || 'all' }}
+          FORCE_REQUESTED: ${{ inputs.force || false }}
+          BASELINE_OVERRIDE: ${{ inputs.baseline_version || '' }}
+          CANDIDATE_OVERRIDE: ${{ inputs.candidate_version || '' }}
+        run: |
+          set -euo pipefail
+          args=(
+            check
+            --state "${RADAR_STATE}"
+            --output "${RADAR_OUTPUT}"
+            --github-output "${GITHUB_OUTPUT}"
+          )
+          if [ "${SELECTED_CONNECTOR}" != all ]; then
+            args+=(--connector "${SELECTED_CONNECTOR}")
+          fi
+          # Explicit versions describe a deliberate comparison, so they imply
+          # force even if the detected latest version was already attempted.
+          if [ "${FORCE_REQUESTED}" = true ] || \
+             [ -n "${BASELINE_OVERRIDE}" ] || [ -n "${CANDIDATE_OVERRIDE}" ]; then
+            args+=(--force)
+          fi
+          python3 scripts/connector-version-radar.py "${args[@]}"
+
+      - name: Snapshot radar state for audit
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          destination="${RUNNER_TEMP}/connector-version-radar-detection/state-after-check.json"
+          if [ -f "${RADAR_STATE:-}" ]; then
+            /bin/cp -p "${RADAR_STATE}" "${destination}"
+          fi
+
+      - name: Upload detection evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: connector-version-radar-detection
+          path: ${{ runner.temp }}/connector-version-radar-detection
+          if-no-files-found: warn
+          retention-days: 30
+          include-hidden-files: true
+
+  live:
+    name: Upgrade ${{ matrix.connector }} ${{ inputs.baseline_version || matrix.baseline_version }} to ${{ inputs.candidate_version || matrix.candidate_version }}
+    needs: detect
+    if: ${{ needs.detect.outputs.any_new == 'true' && github.ref == 'refs/heads/main' }}
+    runs-on: [self-hosted, macOS, ARM64, connector-lab, defenseclaw-macos]
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      # Preserve the machine-local state file and connector config transaction
+      # even if more connector-lab runners are added later.
+      max-parallel: 1
+      matrix: ${{ fromJSON(needs.detect.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: main
+          persist-credentials: false
+
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: "24"
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Establish connector and Homebrew PATH
+        shell: bash
+        run: |
+          set -euo pipefail
+          for path in \
+            "${HOME}/.local/bin" \
+            "${HOME}/.npm-global/bin" \
+            /opt/homebrew/bin \
+            /usr/local/bin; do
+            echo "${path}" >> "${GITHUB_PATH}"
+          done
+
+      - name: Build repository-local DefenseClaw
+        shell: bash
+        run: |
+          set -euo pipefail
+          make pycli gateway
+          echo "${GITHUB_WORKSPACE}/.venv/bin" >> "${GITHUB_PATH}"
+          echo "${GITHUB_WORKSPACE}" >> "${GITHUB_PATH}"
+          test -x "${GITHUB_WORKSPACE}/.venv/bin/defenseclaw"
+          test -x "${GITHUB_WORKSPACE}/defenseclaw-gateway"
+
+      - name: Resolve exact comparison versions
+        id: versions
+        shell: bash
+        env:
+          DISCOVERED_BASELINE: ${{ matrix.baseline_version }}
+          DISCOVERED_CANDIDATE: ${{ matrix.candidate_version }}
+          BASELINE_OVERRIDE: ${{ inputs.baseline_version || '' }}
+          CANDIDATE_OVERRIDE: ${{ inputs.candidate_version || '' }}
+        run: |
+          set -euo pipefail
+          baseline="${BASELINE_OVERRIDE:-${DISCOVERED_BASELINE}}"
+          candidate="${CANDIDATE_OVERRIDE:-${DISCOVERED_CANDIDATE}}"
+          for value in "${baseline}" "${candidate}"; do
+            [[ "${value}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]] || {
+              echo "::error::Refusing invalid comparison version: ${value}"
+              exit 1
+            }
+          done
+          echo "baseline=${baseline}" >> "${GITHUB_OUTPUT}"
+          echo "candidate=${candidate}" >> "${GITHUB_OUTPUT}"
+
+      - name: Run isolated upgrade regression harness
+        id: harness
+        shell: bash
+        env:
+          CONNECTOR: ${{ matrix.connector }}
+          BASELINE_VERSION: ${{ steps.versions.outputs.baseline }}
+          CANDIDATE_VERSION: ${{ steps.versions.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          result_root="${RUNNER_TEMP}/connector-version-radar/${CONNECTOR}-${CANDIDATE_VERSION}"
+          mkdir -p "${result_root}/harness"
+          echo "result_root=${result_root}" >> "${GITHUB_OUTPUT}"
+          set +e
+          bash scripts/live-connector-e2e/upgrade-regression.sh \
+            --connector "${CONNECTOR}" \
+            --baseline-version "${BASELINE_VERSION}" \
+            --candidate-version "${CANDIDATE_VERSION}" \
+            --results "${result_root}/results.jsonl" \
+            --classification-output "${result_root}/classification.json" \
+            --artifacts-dir "${result_root}/harness" \
+            --mode action
+          harness_rc=$?
+          set -e
+          echo "exit_code=${harness_rc}" >> "${GITHUB_OUTPUT}"
+          # Defer failure until state and artifacts have been handled.
+          exit 0
+
+      - name: Record meaningful radar outcome
+        if: ${{ always() }}
+        shell: bash
+        env:
+          CONNECTOR: ${{ matrix.connector }}
+          FALLBACK_CANDIDATE: ${{ steps.versions.outputs.candidate }}
+          RESOLVED_CANDIDATE: ${{ steps.harness.outputs.candidate_version }}
+          CLASSIFICATION: ${{ steps.harness.outputs.classification }}
+          RESULT_ROOT: ${{ steps.harness.outputs.result_root }}
+          BASELINE_VERSION: ${{ steps.versions.outputs.baseline }}
+          BASELINE_OVERRIDE: ${{ inputs.baseline_version || '' }}
+          CANDIDATE_OVERRIDE: ${{ inputs.candidate_version || '' }}
+        run: |
+          set -euo pipefail
+          state="${HOME}/Library/Application Support/DefenseClawConnectorLab/version-radar-state.json"
+          version="${RESOLVED_CANDIDATE:-${FALLBACK_CANDIDATE}}"
+          if [ -n "${BASELINE_OVERRIDE}" ] || [ -n "${CANDIDATE_OVERRIDE}" ]; then
+            echo "Not advancing daily radar state for an explicit historical/manual comparison."
+            if [ -n "${RESULT_ROOT}" ] && [ -f "${state}" ]; then
+              /bin/cp -p "${state}" "${RESULT_ROOT}/radar-state-after.json"
+            fi
+            exit 0
+          fi
+          case "${CLASSIFICATION}" in
+            pass)
+              python3 scripts/connector-version-radar.py mark \
+                --state "${state}" --connector "${CONNECTOR}" \
+                --version "${version}" --result passed
+              ;;
+            candidate_regression)
+              if [ "${BASELINE_VERSION}" != "${version}" ]; then
+                # The harness proved this exact baseline before the candidate
+                # failed. Preserve it as the next comparison's known-good
+                # release even if the globally installed CLI auto-updates.
+                python3 scripts/connector-version-radar.py mark \
+                  --state "${state}" --connector "${CONNECTOR}" \
+                  --version "${BASELINE_VERSION}" --result passed
+              fi
+              python3 scripts/connector-version-radar.py mark \
+                --state "${state}" --connector "${CONNECTOR}" \
+                --version "${version}" --result attempted
+              ;;
+            *)
+              echo "Not advancing radar state for classification=${CLASSIFICATION:-missing}; a later run will retry."
+              ;;
+          esac
+          if [ -n "${RESULT_ROOT}" ] && [ -f "${state}" ]; then
+            /bin/cp -p "${state}" "${RESULT_ROOT}/radar-state-after.json"
+          fi
+
+      - name: Upload live evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: connector-version-radar-${{ matrix.connector }}-${{ steps.versions.outputs.candidate }}
+          path: ${{ steps.harness.outputs.result_root }}
+          if-no-files-found: error
+          retention-days: 30
+          include-hidden-files: true
+
+      - name: Propagate harness classification
+        if: ${{ always() }}
+        shell: bash
+        env:
+          HARNESS_EXIT_CODE: ${{ steps.harness.outputs.exit_code }}
+        run: |
+          set -euo pipefail
+          case "${HARNESS_EXIT_CODE:-4}" in
+            0) exit 0 ;;
+            2|3|4|5) exit "${HARNESS_EXIT_CODE}" ;;
+            *) echo "::error::Unexpected harness exit code: ${HARNESS_EXIT_CODE:-missing}"; exit 4 ;;
+          esac
+
+  report:
+    name: Report connector regressions
+    needs: [detect, live]
+    if: ${{ always() && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Download radar evidence
+        if: ${{ needs.live.result != 'skipped' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: connector-version-radar-*
+          path: radar-results
+          # Keep one subdirectory per artifact. The reporter recursively reads
+          # JSONL files, and flattening can overwrite identical result names.
+          merge-multiple: false
+
+      - name: Ensure regression label exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create connector-regression \
+            --description "Upstream connector version compatibility regression" \
+            --color d73a4a \
+            --force
+
+      - name: Render summary and open or update the regression issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p radar-results
+          open_flag=()
+          while IFS= read -r -d '' classification; do
+            if jq -e '.classification == "candidate_regression"' "${classification}" >/dev/null; then
+              open_flag+=(--open-issue)
+              break
+            fi
+          done < <(find radar-results -name classification.json -type f -print0)
+          python3 scripts/live-connector-e2e/report.py \
+            --results-dir radar-results \
+            "${open_flag[@]}" \
+            --run-url "${RUN_URL}"

--- a/cli/tests/test_connector_version_radar.py
+++ b/cli/tests/test_connector_version_radar.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hermetic tests for the connector release radar."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "connector-version-radar.py"
+SPEC = importlib.util.spec_from_file_location("connector_version_radar", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+radar = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = radar
+SPEC.loader.exec_module(radar)
+
+
+class FakeCommandRunner:
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = []
+
+    def __call__(self, command, timeout):
+        key = tuple(command)
+        self.calls.append((key, timeout))
+        if key not in self.responses:
+            raise AssertionError(f"unexpected command: {key}")
+        return self.responses[key]
+
+
+class ConnectorVersionRadarTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.root = Path(self.tempdir.name)
+        self.state = self.root / "machine-state.json"
+
+    @staticmethod
+    def _success(value):
+        return radar.ExternalResult(True, stdout=value)
+
+    def _runner(self, *, codex_installed="codex-cli 0.142.5", codex_latest='"0.144.1"'):
+        return FakeCommandRunner(
+            {
+                ("codex", "--version"): self._success(codex_installed),
+                ("npm", "view", "@openai/codex", "dist-tags.latest", "--json"): self._success(
+                    codex_latest
+                ),
+                ("claude", "--version"): self._success("2.1.207 (Claude Code)"),
+                (
+                    "npm",
+                    "view",
+                    "@anthropic-ai/claude-code",
+                    "dist-tags.latest",
+                    "--json",
+                ): self._success('"2.1.207"'),
+                ("agy", "--version"): self._success("Antigravity CLI v1.1.1"),
+            }
+        )
+
+    @staticmethod
+    def _manifest_fetcher(url, timeout):
+        if not url.endswith("/darwin_arm64.json"):
+            raise AssertionError(f"unexpected release URL: {url}")
+        if timeout <= 0:
+            raise AssertionError("timeout must be positive")
+        return radar.ExternalResult(True, stdout='{"version":"1.1.1","url":"ignored"}')
+
+    def test_version_normalization_and_semver_ordering(self):
+        self.assertEqual(radar.parse_version("codex-cli 0.144.1").normalized, "0.144.1")
+        self.assertEqual(radar.parse_version("Claude Code v2.1.207+build.9").normalized, "2.1.207")
+        prerelease = radar.parse_version("agy 1.2.0-rc.2")
+        self.assertEqual(prerelease.normalized, "1.2.0-rc.2")
+        self.assertLess(prerelease.compare(radar.parse_version("1.2.0")), 0)
+        self.assertLess(
+            radar.parse_version("1.2.0-rc.2").compare(radar.parse_version("1.2.0-rc.10")),
+            0,
+        )
+        with self.assertRaisesRegex(ValueError, "stable channel returned prerelease"):
+            radar.parse_version("1.2.0-beta.1", require_stable=True)
+
+    def test_empty_state_seeds_installed_versions_but_requires_initial_tests(self):
+        runner = self._runner()
+        payload = radar.check_radar(
+            state_path=self.state,
+            command_runner=runner,
+            url_fetcher=self._manifest_fetcher,
+            antigravity_platform_name="darwin_arm64",
+            now="2026-07-11T12:00:00Z",
+        )
+
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(
+            [(item["connector"], item["candidate_version"]) for item in payload["candidates"]],
+            [("codex", "0.144.1"), ("claudecode", "2.1.207"), ("antigravity", "1.1.1")],
+        )
+        self.assertTrue(payload["any_new"])
+        self.assertEqual(payload["connectors"]["codex"]["status"], "update_available")
+        self.assertEqual(payload["candidates"][0]["baseline_version"], "0.142.5")
+        self.assertEqual(payload["connectors"]["claudecode"]["status"], "initial_test_required")
+        self.assertEqual(payload["connectors"]["antigravity"]["status"], "initial_test_required")
+
+        persisted = json.loads(self.state.read_text(encoding="utf-8"))
+        self.assertEqual(persisted["connectors"]["codex"]["installed_seed_version"], "0.142.5")
+        self.assertNotIn("last_attempted_version", persisted["connectors"]["codex"])
+        self.assertNotIn("last_passed_version", persisted["connectors"]["codex"])
+        self.assertEqual(self.state.stat().st_mode & 0o777, 0o600)
+
+        commands = [call[0] for call in runner.calls]
+        self.assertIn(("codex", "--version"), commands)
+        self.assertIn(("npm", "view", "@openai/codex", "dist-tags.latest", "--json"), commands)
+        self.assertFalse(any("install" in command for call in commands for command in call))
+
+    def test_attempted_and_passed_releases_are_persisted_and_not_retested(self):
+        runner = self._runner()
+        radar.check_radar(
+            state_path=self.state,
+            connector_names=("codex",),
+            command_runner=runner,
+            antigravity_platform_name="darwin_arm64",
+            now="2026-07-11T12:00:00Z",
+        )
+        radar.mark_state(
+            state_path=self.state,
+            connector="codex",
+            version="v0.144.1",
+            result="attempted",
+            now="2026-07-11T12:05:00Z",
+        )
+        attempted = radar.check_radar(
+            state_path=self.state,
+            connector_names=("codex",),
+            command_runner=runner,
+            now="2026-07-12T12:00:00Z",
+        )
+        self.assertFalse(attempted["has_candidates"])
+        self.assertEqual(attempted["connectors"]["codex"]["status"], "already_attempted")
+        self.assertIsNone(attempted["connectors"]["codex"]["state"]["last_passed_version"])
+
+        radar.mark_state(
+            state_path=self.state,
+            connector="codex",
+            version="0.144.1",
+            result="passed",
+            now="2026-07-12T12:05:00Z",
+        )
+        passed = radar.check_radar(
+            state_path=self.state,
+            connector_names=("codex",),
+            command_runner=runner,
+            now="2026-07-13T12:00:00Z",
+        )
+        self.assertFalse(passed["has_candidates"])
+        self.assertEqual(passed["connectors"]["codex"]["status"], "tested_passed")
+        self.assertEqual(passed["connectors"]["codex"]["state"]["last_passed_version"], "0.144.1")
+
+        forced = radar.check_radar(
+            state_path=self.state,
+            connector_names=("codex",),
+            command_runner=runner,
+            force=True,
+            now="2026-07-14T12:00:00Z",
+        )
+        self.assertTrue(forced["any_new"])
+        self.assertEqual(forced["connectors"]["codex"]["status"], "forced_test_required")
+        self.assertEqual(
+            forced["candidates"],
+            [
+                {
+                    "connector": "codex",
+                    "baseline_version": "0.144.1",
+                    "installed_version": "0.142.5",
+                    "candidate_version": "0.144.1",
+                }
+            ],
+        )
+
+    def test_last_passed_release_remains_baseline_after_global_cli_updates(self):
+        initial_runner = self._runner()
+        radar.check_radar(
+            state_path=self.state,
+            connector_names=("codex",),
+            command_runner=initial_runner,
+            now="2026-07-11T12:00:00Z",
+        )
+        radar.mark_state(
+            state_path=self.state,
+            connector="codex",
+            version="0.142.5",
+            result="passed",
+            now="2026-07-11T12:05:00Z",
+        )
+        radar.mark_state(
+            state_path=self.state,
+            connector="codex",
+            version="0.144.1",
+            result="attempted",
+            now="2026-07-11T12:06:00Z",
+        )
+
+        upgraded_runner = self._runner(
+            codex_installed="codex-cli 0.144.1",
+            codex_latest='"0.145.0"',
+        )
+        payload = radar.check_radar(
+            state_path=self.state,
+            connector_names=("codex",),
+            command_runner=upgraded_runner,
+            now="2026-07-12T12:00:00Z",
+        )
+
+        self.assertEqual(
+            payload["candidates"],
+            [
+                {
+                    "connector": "codex",
+                    "baseline_version": "0.142.5",
+                    "installed_version": "0.144.1",
+                    "candidate_version": "0.145.0",
+                }
+            ],
+        )
+
+    def test_query_failures_are_infrastructure_errors_not_candidates(self):
+        runner = FakeCommandRunner(
+            {
+                ("codex", "--version"): self._success("codex 0.144.0"),
+                ("npm", "view", "@openai/codex", "dist-tags.latest", "--json"): self._success(
+                    '"0.145.0-beta.1"'
+                ),
+                ("claude", "--version"): radar.ExternalResult(False, error="executable not found: claude"),
+                (
+                    "npm",
+                    "view",
+                    "@anthropic-ai/claude-code",
+                    "dist-tags.latest",
+                    "--json",
+                ): self._success('"2.1.208"'),
+                ("agy", "--version"): self._success("1.1.1"),
+            }
+        )
+
+        payload = radar.check_radar(
+            state_path=self.state,
+            command_runner=runner,
+            url_fetcher=lambda _url, _timeout: radar.ExternalResult(False, error="simulated timeout"),
+            antigravity_platform_name="darwin_arm64",
+            now="2026-07-11T12:00:00Z",
+        )
+
+        self.assertEqual(payload["status"], "infrastructure_error")
+        self.assertFalse(payload["has_candidates"])
+        self.assertEqual(
+            {(item["connector"], item["stage"]) for item in payload["infrastructure_errors"]},
+            {
+                ("codex", "latest_query"),
+                ("claudecode", "installed_probe"),
+                ("antigravity", "latest_query"),
+            },
+        )
+        self.assertTrue(all(item["status"] == "infrastructure_error" for item in payload["connectors"].values()))
+
+    def test_structured_npm_output_cannot_select_an_unrelated_version(self):
+        payload = radar.check_radar(
+            state_path=self.state,
+            connector_names=("codex",),
+            command_runner=self._runner(codex_latest='{"npm":"10.9.2"}'),
+            now="2026-07-11T12:00:00Z",
+        )
+        self.assertEqual(payload["status"], "infrastructure_error")
+        self.assertFalse(payload["any_new"])
+        self.assertIn(
+            "dist-tags.latest did not return a JSON string",
+            payload["infrastructure_errors"][0]["error"],
+        )
+
+    def test_fixture_mode_never_falls_through_to_commands_or_network(self):
+        def unexpected_command(_command, _timeout):
+            raise AssertionError("fixture mode executed a command")
+
+        def unexpected_fetch(_url, _timeout):
+            raise AssertionError("fixture mode used the network")
+
+        payload = radar.check_radar(
+            state_path=self.state,
+            connector_names=("codex",),
+            command_runner=unexpected_command,
+            url_fetcher=unexpected_fetch,
+            fixtures={"codex": {"installed": "0.143.0"}},
+            now="2026-07-11T12:00:00Z",
+        )
+
+        self.assertEqual(payload["status"], "infrastructure_error")
+        self.assertFalse(payload["has_candidates"])
+        self.assertIn("fixture missing codex.latest", payload["infrastructure_errors"][0]["error"])
+
+    def test_installed_version_ahead_of_stable_channel_is_not_downgraded(self):
+        payload = radar.check_radar(
+            state_path=self.state,
+            connector_names=("codex",),
+            command_runner=self._runner(codex_installed="0.145.0", codex_latest='"0.144.1"'),
+            now="2026-07-11T12:00:00Z",
+        )
+        self.assertFalse(payload["has_candidates"])
+        self.assertEqual(payload["connectors"]["codex"]["status"], "installed_ahead")
+
+    def test_cli_fixture_emits_json_file_and_github_outputs(self):
+        fixture = self.root / "fixture.json"
+        output = self.root / "radar.json"
+        github_output = self.root / "github-output.txt"
+        fixture.write_text(
+            json.dumps(
+                {
+                    "codex": {"installed": "codex-cli 0.142.5", "latest": '"0.144.1"'},
+                    "claudecode": {"installed": "2.1.207", "latest": '"2.1.208"'},
+                    "antigravity": {"installed": "1.1.1", "latest": '{"version":"1.1.2"}'},
+                }
+            ),
+            encoding="utf-8",
+        )
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = radar.main(
+                [
+                    "check",
+                    "--state",
+                    str(self.state),
+                    "--fixture",
+                    str(fixture),
+                    "--output",
+                    str(output),
+                    "--github-output",
+                    str(github_output),
+                    "--antigravity-platform",
+                    "darwin_arm64",
+                ]
+            )
+
+        self.assertEqual(exit_code, radar.EXIT_OK)
+        stdout_payload = json.loads(stdout.getvalue())
+        self.assertEqual(stdout_payload, json.loads(output.read_text(encoding="utf-8")))
+        github_values = dict(
+            line.split("=", 1)
+            for line in github_output.read_text(encoding="utf-8").splitlines()
+        )
+        self.assertEqual(github_values["status"], "ok")
+        self.assertEqual(github_values["any_new"], "true")
+        self.assertEqual(github_values["has_candidates"], "true")
+        self.assertEqual(
+            json.loads(github_values["candidate_connectors"]),
+            ["codex", "claudecode", "antigravity"],
+        )
+        self.assertEqual(len(json.loads(github_values["candidate_matrix"])["include"]), 3)
+        self.assertEqual(json.loads(github_values["matrix"]), json.loads(github_values["candidate_matrix"]))
+        self.assertEqual(
+            set(json.loads(github_values["matrix"])["include"][0]),
+            {"connector", "baseline_version", "installed_version", "candidate_version"},
+        )
+        self.assertEqual(json.loads(github_values["radar_json"]), stdout_payload)
+
+    def test_corrupt_state_returns_distinct_infrastructure_exit(self):
+        self.state.write_text("not-json", encoding="utf-8")
+        fixture = self.root / "fixture.json"
+        fixture.write_text(json.dumps({"codex": {"installed": "0.1.0", "latest": "0.1.1"}}), encoding="utf-8")
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = radar.main(
+                [
+                    "check",
+                    "--state",
+                    str(self.state),
+                    "--fixture",
+                    str(fixture),
+                    "--connector",
+                    "codex",
+                ]
+            )
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, radar.EXIT_INFRASTRUCTURE_ERROR)
+        self.assertEqual(payload["status"], "infrastructure_error")
+        self.assertFalse(payload["has_candidates"])
+        self.assertIn("not valid JSON", payload["infrastructure_errors"][0]["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cli/tests/test_live_connector_upgrade_harness.py
+++ b/cli/tests/test_live_connector_upgrade_harness.py
@@ -1,0 +1,183 @@
+"""Safety contracts for the persistent-macOS connector upgrade harness."""
+
+from __future__ import annotations
+
+import os
+import runpy
+import stat
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+HARNESS = REPO / "scripts" / "live-connector-e2e" / "upgrade-regression.sh"
+PERSIST = REPO / "scripts" / "live-connector-e2e" / "lib" / "persistent-macos.sh"
+REPORT = REPO / "scripts" / "live-connector-e2e" / "report.py"
+
+
+def _bash(script: str, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    merged = os.environ.copy()
+    if env:
+        merged.update(env)
+    return subprocess.run(
+        ["bash", "-c", script],
+        cwd=REPO,
+        env=merged,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_harness_cli_exposes_workflow_contract() -> None:
+    proc = subprocess.run(
+        ["bash", str(HARNESS), "--help"],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    for flag in (
+        "--connector",
+        "--baseline-version",
+        "--candidate-version",
+        "--results",
+        "--classification-output",
+    ):
+        assert flag in proc.stdout
+
+
+def test_harness_never_globally_installs_or_removes_auth_homes() -> None:
+    text = HARNESS.read_text(encoding="utf-8")
+    persist_text = PERSIST.read_text(encoding="utf-8")
+    assert "npm install -g" not in text
+    assert "npm i -g" not in text
+    assert "rm -rf" not in text
+    assert 'export DEFENSECLAW_HOME="${SCRATCH}/defenseclaw"' in text
+    assert 'export DC_E2E_AGENT_WORKSPACE="${SCRATCH}/workspace"' in text
+    assert 'cd "${DC_E2E_AGENT_WORKSPACE}"' in text
+    assert "--no-restart" in text
+    assert "--skip-git-repo-check" in text
+    assert "switching to isolated candidate without re-running" in text
+    assert "defenseclaw-gateway stop" in text
+    assert 'if [ "${LOCK_ACQUIRED}" = "1" ]' in text
+    assert "antigravity.google/cli/install.sh" not in text
+    assert "read -r DC_PERSIST_WS_PORT DC_PERSIST_API_PORT DC_PERSIST_SCANNER_PORT" in persist_text
+
+
+def test_snapshot_restore_preserves_exact_bytes_and_mode(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    config = home / ".codex" / "config.toml"
+    snapshot = tmp_path / "snapshot"
+    config.parent.mkdir(parents=True)
+    original = b'model = "original"\n# keep whitespace  \n'
+    config.write_bytes(original)
+    config.chmod(0o640)
+
+    proc = _bash(
+        f"""
+        set -euo pipefail
+        dc_err() {{ printf '%s\n' "$*" >&2; }}
+        . {PERSIST!s}
+        dc_persist_snapshot_init {snapshot!s}
+        dc_persist_snapshot_file {config!s}
+        printf '%s\n' changed > {config!s}
+        chmod 600 {config!s}
+        dc_persist_restore_files
+        """,
+        env={"HOME": str(home)},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert config.read_bytes() == original
+    assert stat.S_IMODE(config.stat().st_mode) == 0o640
+
+
+def test_snapshot_restore_removes_only_created_file_not_parent(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    parent = home / ".gemini" / "config"
+    config = parent / "hooks.json"
+    snapshot = tmp_path / "snapshot"
+    parent.mkdir(parents=True)
+
+    proc = _bash(
+        f"""
+        set -euo pipefail
+        dc_err() {{ printf '%s\n' "$*" >&2; }}
+        . {PERSIST!s}
+        dc_persist_snapshot_init {snapshot!s}
+        dc_persist_snapshot_file {config!s}
+        printf '{{}}\n' > {config!s}
+        dc_persist_restore_files
+        """,
+        env={"HOME": str(home)},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert not config.exists()
+    assert parent.is_dir()
+
+
+def test_snapshot_rejects_symlinked_connector_config(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    target = tmp_path / "target"
+    target.write_text("secret", encoding="utf-8")
+    config = home / "config.toml"
+    config.symlink_to(target)
+    snapshot = tmp_path / "snapshot"
+
+    proc = _bash(
+        f"""
+        set -euo pipefail
+        dc_err() {{ printf '%s\n' "$*" >&2; }}
+        . {PERSIST!s}
+        dc_persist_snapshot_init {snapshot!s}
+        dc_persist_snapshot_file {config!s}
+        """,
+        env={"HOME": str(home)},
+    )
+    assert proc.returncode != 0
+    assert "symlinked config" in proc.stderr
+    assert target.read_text(encoding="utf-8") == "secret"
+
+
+def test_lock_release_refuses_another_process_owner(tmp_path: Path) -> None:
+    lock = tmp_path / "active.lock"
+    lock.mkdir()
+    (lock / "pid").write_text("999999\n", encoding="utf-8")
+    proc = _bash(
+        f"""
+        set -euo pipefail
+        dc_err() {{ printf '%s\n' "$*" >&2; }}
+        . {PERSIST!s}
+        dc_persist_release_lock {lock!s}
+        """
+    )
+    assert proc.returncode != 0
+    assert "refusing to release" in proc.stderr
+    assert lock.is_dir()
+    assert (lock / "pid").read_text(encoding="utf-8") == "999999\n"
+
+
+def test_report_prefers_candidate_version_over_known_good_baseline() -> None:
+    summarize = runpy.run_path(str(REPORT))["summarize"]
+    _cells, versions, failures = summarize(
+        [
+            {
+                "connector": "codex",
+                "os": "macos",
+                "event": "baseline:lifecycle:fires",
+                "status": "pass",
+                "version": "0.142.5",
+            },
+            {
+                "connector": "codex",
+                "os": "macos",
+                "event": "candidate-upgrade:lifecycle:fires",
+                "status": "fail",
+                "version": "0.144.1",
+                "detail": "hook missing",
+            },
+        ]
+    )
+    assert versions[("codex", "macos")] == "0.144.1"
+    assert failures == [("codex", "macos", "candidate-upgrade:lifecycle:fires", "hook missing")]

--- a/scripts/connector-version-radar.py
+++ b/scripts/connector-version-radar.py
@@ -1,0 +1,769 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Discover untested stable connector releases without modifying installations.
+
+The radar intentionally has a small scope: the three CLI connectors exercised by
+the dedicated macOS connector lab.  It probes installed binaries, queries the
+upstream stable release channels, and keeps attempted/passed history in a
+caller-supplied machine-local state file.  It never changes an installed tool and
+never edits ``validated_versions.json``.
+
+``check`` writes one JSON document to stdout.  An optional fixture file makes the
+whole discovery path hermetic for tests and local workflow development::
+
+    {
+      "codex": {
+        "installed": "codex-cli 0.142.5",
+        "latest": "0.144.1"
+      },
+      "claudecode": {
+        "installed": {"stdout": "2.1.207 (Claude Code)", "returncode": 0},
+        "latest": {"stdout": "\"2.1.208\"", "returncode": 0}
+      },
+      "antigravity": {
+        "installed": "1.1.1",
+        "latest": "{\"version\": \"1.1.2\"}"
+      }
+    }
+
+When ``--fixture`` is present, a missing fixture is an infrastructure error; the
+radar never falls through to a real command or network request.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import os
+import platform
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+EXIT_OK = 0
+EXIT_INFRASTRUCTURE_ERROR = 2
+DEFAULT_TIMEOUT_SECONDS = 20.0
+ANTIGRAVITY_MANIFEST_BASE = (
+    "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests"
+)
+CONNECTOR_ORDER = ("codex", "claudecode", "antigravity")
+_VERSION_RE = re.compile(
+    r"(?<![0-9A-Za-z])v?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?"
+    r"(?:\+(?P<build>[0-9A-Za-z.-]+))?(?![0-9A-Za-z])"
+)
+_PLATFORM_RE = re.compile(r"^[a-z0-9_]+$")
+
+
+class RadarError(RuntimeError):
+    """An infrastructure/configuration error that is not a connector regression."""
+
+
+@dataclasses.dataclass(frozen=True)
+class ConnectorSpec:
+    name: str
+    executable: str
+    installed_command: tuple[str, ...]
+    npm_package: str | None = None
+
+
+SPECS: dict[str, ConnectorSpec] = {
+    "codex": ConnectorSpec(
+        name="codex",
+        executable="codex",
+        installed_command=("codex", "--version"),
+        npm_package="@openai/codex",
+    ),
+    "claudecode": ConnectorSpec(
+        name="claudecode",
+        executable="claude",
+        installed_command=("claude", "--version"),
+        npm_package="@anthropic-ai/claude-code",
+    ),
+    "antigravity": ConnectorSpec(
+        name="antigravity",
+        executable="agy",
+        installed_command=("agy", "--version"),
+    ),
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class SemVersion:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[str, ...] = ()
+
+    @property
+    def stable(self) -> bool:
+        return not self.prerelease
+
+    @property
+    def normalized(self) -> str:
+        base = f"{self.major}.{self.minor}.{self.patch}"
+        if self.prerelease:
+            return f"{base}-{'.'.join(self.prerelease)}"
+        return base
+
+    def compare(self, other: SemVersion) -> int:
+        own_core = (self.major, self.minor, self.patch)
+        other_core = (other.major, other.minor, other.patch)
+        if own_core != other_core:
+            return 1 if own_core > other_core else -1
+        if not self.prerelease and not other.prerelease:
+            return 0
+        if not self.prerelease:
+            return 1
+        if not other.prerelease:
+            return -1
+        for own, theirs in zip(self.prerelease, other.prerelease, strict=False):
+            if own == theirs:
+                continue
+            own_numeric = own.isdigit()
+            theirs_numeric = theirs.isdigit()
+            if own_numeric and theirs_numeric:
+                return 1 if int(own) > int(theirs) else -1
+            if own_numeric != theirs_numeric:
+                return -1 if own_numeric else 1
+            return 1 if own > theirs else -1
+        if len(self.prerelease) == len(other.prerelease):
+            return 0
+        return 1 if len(self.prerelease) > len(other.prerelease) else -1
+
+
+@dataclasses.dataclass(frozen=True)
+class ExternalResult:
+    ok: bool
+    stdout: str = ""
+    error: str = ""
+
+
+CommandRunner = Callable[[Sequence[str], float], ExternalResult]
+URLFetcher = Callable[[str, float], ExternalResult]
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_version(value: str, *, require_stable: bool = False) -> SemVersion:
+    """Extract and normalize the first semantic version in command/JSON output."""
+
+    match = _VERSION_RE.search(value.strip())
+    if not match:
+        raise ValueError("no semantic x.y.z version found")
+    prerelease = tuple(filter(None, (match.group("prerelease") or "").split(".")))
+    parsed = SemVersion(
+        major=int(match.group("major")),
+        minor=int(match.group("minor")),
+        patch=int(match.group("patch")),
+        prerelease=prerelease,
+    )
+    if require_stable and not parsed.stable:
+        raise ValueError(f"stable channel returned prerelease {parsed.normalized}")
+    return parsed
+
+
+def run_command(command: Sequence[str], timeout: float) -> ExternalResult:
+    """Run a read-only version query and convert execution failures to data."""
+
+    try:
+        proc = subprocess.run(
+            list(command),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return ExternalResult(False, error=f"executable not found: {command[0]}")
+    except subprocess.TimeoutExpired:
+        return ExternalResult(False, error=f"command timed out after {timeout:g}s: {command[0]}")
+    except OSError as exc:
+        return ExternalResult(False, error=f"could not execute {command[0]}: {exc}")
+
+    if proc.returncode != 0:
+        detail = _short_error(proc.stderr or proc.stdout or "no diagnostic output")
+        return ExternalResult(False, error=f"{command[0]} exited {proc.returncode}: {detail}")
+    return ExternalResult(True, stdout=proc.stdout.strip())
+
+
+def fetch_url(url: str, timeout: float) -> ExternalResult:
+    """Fetch release metadata only; downloaded agent payloads are never requested."""
+
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json", "User-Agent": "DefenseClaw-Connector-Radar/1"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310 - fixed HTTPS origin
+            return ExternalResult(True, stdout=response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, UnicodeError, OSError) as exc:
+        return ExternalResult(False, error=f"release metadata request failed: {_short_error(str(exc))}")
+
+
+def _short_error(value: str, limit: int = 400) -> str:
+    flattened = " ".join(value.split())
+    return flattened[:limit] + ("..." if len(flattened) > limit else "")
+
+
+def antigravity_platform() -> str:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    arch_aliases = {
+        "arm64": "arm64",
+        "aarch64": "arm64",
+        "x86_64": "amd64",
+        "amd64": "amd64",
+    }
+    arch = arch_aliases.get(machine)
+    if not arch:
+        raise RadarError(f"unsupported Antigravity architecture: {machine or 'unknown'}")
+    if system == "darwin":
+        return f"darwin_{arch}"
+    if system == "linux":
+        libc_name = platform.libc_ver()[0].lower()
+        musl = libc_name == "musl" or any(
+            Path(path).exists()
+            for path in ("/lib/libc.musl-x86_64.so.1", "/lib/libc.musl-aarch64.so.1")
+        )
+        return f"linux_{arch}{'_musl' if musl else ''}"
+    if system == "windows":
+        return f"windows_{arch}"
+    raise RadarError(f"unsupported Antigravity operating system: {system or 'unknown'}")
+
+
+def load_fixture(path: Path | None) -> dict[str, Any] | None:
+    if path is None:
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RadarError(f"could not read fixture {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise RadarError(f"fixture {path} is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RadarError("fixture root must be a JSON object")
+    connectors = payload.get("connectors", payload)
+    if not isinstance(connectors, dict):
+        raise RadarError("fixture connectors must be a JSON object")
+    return connectors
+
+
+def fixture_result(fixtures: Mapping[str, Any], connector: str, stage: str) -> ExternalResult:
+    connector_fixture = fixtures.get(connector)
+    if not isinstance(connector_fixture, Mapping) or stage not in connector_fixture:
+        return ExternalResult(False, error=f"fixture missing {connector}.{stage}")
+    value = connector_fixture[stage]
+    if isinstance(value, str):
+        return ExternalResult(True, stdout=value)
+    if not isinstance(value, Mapping):
+        return ExternalResult(False, error=f"fixture {connector}.{stage} must be a string or object")
+    if value.get("error"):
+        return ExternalResult(False, error=_short_error(str(value["error"])))
+    try:
+        returncode = int(value.get("returncode", 0))
+    except (TypeError, ValueError):
+        return ExternalResult(False, error=f"fixture {connector}.{stage}.returncode must be an integer")
+    stdout = str(value.get("stdout", ""))
+    if returncode:
+        detail = _short_error(str(value.get("stderr", stdout or "fixture failure")))
+        return ExternalResult(False, error=f"fixture returned {returncode}: {detail}")
+    return ExternalResult(True, stdout=stdout)
+
+
+def query_installed(
+    spec: ConnectorSpec,
+    *,
+    timeout: float,
+    command_runner: CommandRunner,
+    fixtures: Mapping[str, Any] | None,
+) -> ExternalResult:
+    if fixtures is not None:
+        return fixture_result(fixtures, spec.name, "installed")
+    return command_runner(spec.installed_command, timeout)
+
+
+def query_latest(
+    spec: ConnectorSpec,
+    *,
+    timeout: float,
+    command_runner: CommandRunner,
+    url_fetcher: URLFetcher,
+    fixtures: Mapping[str, Any] | None,
+    antigravity_platform_name: str,
+) -> tuple[ExternalResult, str]:
+    if fixtures is not None:
+        result = fixture_result(fixtures, spec.name, "latest")
+        return result, "fixture"
+    if spec.npm_package:
+        command = ("npm", "view", spec.npm_package, "dist-tags.latest", "--json")
+        return command_runner(command, timeout), f"npm:{spec.npm_package}:dist-tags.latest"
+    manifest_url = f"{ANTIGRAVITY_MANIFEST_BASE}/{antigravity_platform_name}.json"
+    return url_fetcher(manifest_url, timeout), manifest_url
+
+
+def _latest_version_from_output(spec: ConnectorSpec, output: str) -> SemVersion:
+    value: Any = output
+    try:
+        parsed_json = json.loads(output)
+    except json.JSONDecodeError:
+        parsed_json = None
+    if spec.name == "antigravity":
+        if isinstance(parsed_json, dict):
+            value = parsed_json.get("version", "")
+        elif isinstance(parsed_json, str):
+            value = parsed_json
+        elif parsed_json is not None:
+            raise ValueError("Antigravity release metadata did not contain an object or string")
+    elif isinstance(parsed_json, str):
+        value = parsed_json
+    elif parsed_json is not None:
+        raise ValueError("npm dist-tags.latest did not return a JSON string")
+    if not isinstance(value, str):
+        raise ValueError("release metadata did not contain a string version")
+    return parse_version(value, require_stable=True)
+
+
+def empty_state() -> dict[str, Any]:
+    return {"schema_version": SCHEMA_VERSION, "connectors": {}}
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return empty_state()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RadarError(f"could not read state {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise RadarError(f"state {path} is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RadarError("state root must be a JSON object")
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise RadarError(
+            f"unsupported state schema_version {payload.get('schema_version')!r}; expected {SCHEMA_VERSION}"
+        )
+    if not isinstance(payload.get("connectors"), dict):
+        raise RadarError("state connectors must be a JSON object")
+    version_fields = (
+        "installed_seed_version",
+        "last_seen_installed_version",
+        "last_attempted_version",
+        "last_passed_version",
+    )
+    for connector, entry in payload["connectors"].items():
+        if not isinstance(connector, str) or not isinstance(entry, dict):
+            raise RadarError("each state connector must map a string name to a JSON object")
+        for field in version_fields:
+            if field not in entry:
+                continue
+            value = entry[field]
+            if not isinstance(value, str):
+                raise RadarError(f"state {connector}.{field} must be a semantic-version string")
+            try:
+                parse_version(value)
+            except ValueError as exc:
+                raise RadarError(f"state {connector}.{field} is invalid: {exc}") from exc
+    return payload
+
+
+def atomic_write_json(path: Path, payload: Any, *, mode: int = 0o600) -> None:
+    """Atomically replace a JSON file and keep machine-local state private."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def _state_version(entry: Mapping[str, Any], key: str) -> str:
+    value = entry.get(key, "")
+    if not value:
+        return ""
+    if not isinstance(value, str):
+        raise RadarError(f"state field {key} must be a semantic-version string")
+    try:
+        return parse_version(value).normalized
+    except ValueError as exc:
+        raise RadarError(f"state field {key} is invalid: {exc}") from exc
+
+
+def check_radar(
+    *,
+    state_path: Path,
+    connector_names: Sequence[str] = CONNECTOR_ORDER,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    command_runner: CommandRunner = run_command,
+    url_fetcher: URLFetcher = fetch_url,
+    fixtures: Mapping[str, Any] | None = None,
+    antigravity_platform_name: str | None = None,
+    force: bool = False,
+    now: str | None = None,
+) -> dict[str, Any]:
+    """Collect version data, persist last-seen state, and return the radar document."""
+
+    state = load_state(state_path)
+    state_connectors = state["connectors"]
+    generated_at = now or utc_now()
+    platform_name = antigravity_platform_name
+    if "antigravity" in connector_names and platform_name is None:
+        try:
+            platform_name = antigravity_platform()
+        except RadarError as exc:
+            platform_name = ""
+            platform_error = str(exc)
+        else:
+            platform_error = ""
+    else:
+        platform_error = ""
+    if platform_name and not _PLATFORM_RE.fullmatch(platform_name):
+        raise RadarError("Antigravity platform may contain only lowercase letters, digits, and underscores")
+
+    connector_results: dict[str, Any] = {}
+    candidates: list[dict[str, str]] = []
+    infrastructure_errors: list[dict[str, str]] = []
+
+    for connector in connector_names:
+        spec = SPECS[connector]
+        entry = state_connectors.setdefault(connector, {})
+        if not isinstance(entry, dict):
+            entry = {}
+            state_connectors[connector] = entry
+
+        installed_result = query_installed(
+            spec,
+            timeout=timeout,
+            command_runner=command_runner,
+            fixtures=fixtures,
+        )
+        installed_version = ""
+        installed_error = installed_result.error
+        if installed_result.ok:
+            try:
+                installed_version = parse_version(installed_result.stdout).normalized
+            except ValueError as exc:
+                installed_error = f"could not parse `{spec.executable} --version`: {exc}"
+
+        if installed_version:
+            if not entry.get("installed_seed_version"):
+                entry["installed_seed_version"] = installed_version
+                entry["installed_seeded_at"] = generated_at
+            entry["last_seen_installed_version"] = installed_version
+            entry["last_seen_installed_at"] = generated_at
+
+        if connector == "antigravity" and platform_error:
+            latest_result = ExternalResult(False, error=platform_error)
+            latest_source = "official Antigravity release manifest"
+        else:
+            latest_result, latest_source = query_latest(
+                spec,
+                timeout=timeout,
+                command_runner=command_runner,
+                url_fetcher=url_fetcher,
+                fixtures=fixtures,
+                antigravity_platform_name=platform_name or "",
+            )
+        latest_version = ""
+        latest_error = latest_result.error
+        if latest_result.ok:
+            try:
+                latest_version = _latest_version_from_output(spec, latest_result.stdout).normalized
+            except ValueError as exc:
+                latest_error = f"could not parse latest stable version: {exc}"
+
+        previous_attempted = _state_version(entry, "last_attempted_version")
+        previous_passed = _state_version(entry, "last_passed_version")
+        baseline_version = previous_passed or installed_version
+        needs_test = False
+        status = "current"
+
+        if installed_error:
+            status = "infrastructure_error"
+            infrastructure_errors.append(
+                {"connector": connector, "stage": "installed_probe", "error": installed_error}
+            )
+        if latest_error:
+            status = "infrastructure_error"
+            infrastructure_errors.append(
+                {"connector": connector, "stage": "latest_query", "error": latest_error}
+            )
+
+        if not installed_error and not latest_error:
+            installed_semver = parse_version(installed_version)
+            latest_semver = parse_version(latest_version)
+            if force:
+                needs_test = True
+                status = "forced_test_required"
+                candidates.append(
+                    {
+                        "connector": connector,
+                        "baseline_version": baseline_version,
+                        "installed_version": installed_version,
+                        "candidate_version": latest_version,
+                    }
+                )
+            elif latest_semver.compare(installed_semver) < 0:
+                status = "installed_ahead"
+            elif previous_attempted == latest_version:
+                status = "tested_passed" if previous_passed == latest_version else "already_attempted"
+            else:
+                attempted_semver = parse_version(previous_attempted) if previous_attempted else None
+                if attempted_semver is not None and latest_semver.compare(attempted_semver) < 0:
+                    status = "latest_older_than_attempted"
+                else:
+                    needs_test = True
+                    status = (
+                        "update_available"
+                        if latest_semver.compare(installed_semver) > 0
+                        else "initial_test_required"
+                    )
+                    candidates.append(
+                        {
+                            "connector": connector,
+                            "baseline_version": baseline_version,
+                            "installed_version": installed_version,
+                            "candidate_version": latest_version,
+                        }
+                    )
+
+        connector_results[connector] = {
+            "status": status,
+            "needs_test": needs_test,
+            "baseline_version": baseline_version or None,
+            "installed": {
+                "status": "ok" if installed_version else "error",
+                "version": installed_version or None,
+                "source": " ".join(spec.installed_command),
+                "error": installed_error or None,
+            },
+            "latest": {
+                "status": "ok" if latest_version else "error",
+                "version": latest_version or None,
+                "stable": bool(latest_version),
+                "source": latest_source,
+                "error": latest_error or None,
+            },
+            "state": {
+                "installed_seed_version": entry.get("installed_seed_version"),
+                "last_attempted_version": previous_attempted or None,
+                "last_passed_version": previous_passed or None,
+            },
+        }
+
+    state["updated_at"] = generated_at
+    try:
+        atomic_write_json(state_path, state)
+    except OSError as exc:
+        raise RadarError(f"could not persist state {state_path}: {exc}") from exc
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "status": "infrastructure_error" if infrastructure_errors else "ok",
+        "forced": force,
+        "any_new": bool(candidates),
+        "has_candidates": bool(candidates),
+        "candidates": candidates,
+        "infrastructure_errors": infrastructure_errors,
+        "connectors": connector_results,
+    }
+
+
+def mark_state(
+    *,
+    state_path: Path,
+    connector: str,
+    version: str,
+    result: str,
+    now: str | None = None,
+) -> dict[str, Any]:
+    """Persist a candidate attempt or a successful live certification run."""
+
+    normalized = parse_version(version).normalized
+    timestamp = now or utc_now()
+    state = load_state(state_path)
+    entry = state["connectors"].setdefault(connector, {})
+    if not isinstance(entry, dict):
+        entry = {}
+        state["connectors"][connector] = entry
+    entry["last_attempted_version"] = normalized
+    entry["last_attempted_at"] = timestamp
+    if result == "passed":
+        entry["last_passed_version"] = normalized
+        entry["last_passed_at"] = timestamp
+    state["updated_at"] = timestamp
+    try:
+        atomic_write_json(state_path, state)
+    except OSError as exc:
+        raise RadarError(f"could not persist state {state_path}: {exc}") from exc
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "ok",
+        "connector": connector,
+        "version": normalized,
+        "result": result,
+        "recorded_at": timestamp,
+    }
+
+
+def write_github_outputs(path: Path, payload: Mapping[str, Any]) -> None:
+    candidates = payload.get("candidates", [])
+    errors = payload.get("infrastructure_errors", [])
+    matrix = {"include": candidates}
+    outputs = {
+        "status": payload.get("status", "infrastructure_error"),
+        "any_new": str(bool(candidates)).lower(),
+        "has_candidates": str(bool(candidates)).lower(),
+        "candidate_connectors": json.dumps(
+            [item["connector"] for item in candidates], separators=(",", ":")
+        ),
+        "candidate_matrix": json.dumps(matrix, separators=(",", ":")),
+        "matrix": json.dumps(matrix, separators=(",", ":")),
+        "has_infrastructure_errors": str(bool(errors)).lower(),
+        "infrastructure_error_connectors": json.dumps(
+            sorted({item.get("connector", "radar") for item in errors}), separators=(",", ":")
+        ),
+        "radar_json": json.dumps(payload, sort_keys=True, separators=(",", ":")),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={value}\n")
+
+
+def infrastructure_payload(message: str, *, now: str | None = None) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": now or utc_now(),
+        "status": "infrastructure_error",
+        "forced": False,
+        "any_new": False,
+        "has_candidates": False,
+        "candidates": [],
+        "infrastructure_errors": [{"connector": "radar", "stage": "configuration", "error": message}],
+        "connectors": {},
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check = subparsers.add_parser("check", help="Query installed and latest stable connector versions.")
+    check.add_argument("--state", required=True, type=Path, help="Machine-local attempted/passed state JSON path.")
+    check.add_argument("--output", type=Path, help="Also atomically write the full radar JSON to this path.")
+    check.add_argument(
+        "--github-output",
+        type=Path,
+        default=Path(os.environ["GITHUB_OUTPUT"]) if os.environ.get("GITHUB_OUTPUT") else None,
+        help="Append compact outputs to this GitHub Actions output file (default: $GITHUB_OUTPUT).",
+    )
+    check.add_argument("--fixture", type=Path, help="Hermetic installed/latest responses; disables real queries.")
+    check.add_argument(
+        "--connector",
+        action="append",
+        choices=CONNECTOR_ORDER,
+        dest="connectors",
+        help="Limit discovery to a connector (repeatable; default: all three).",
+    )
+    check.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    check.add_argument(
+        "--force",
+        action="store_true",
+        help="Schedule all successfully queried selected connectors, even if already attempted.",
+    )
+    check.add_argument(
+        "--antigravity-platform",
+        help="Override the official manifest platform name (for example darwin_arm64).",
+    )
+
+    mark = subparsers.add_parser("mark", help="Record that a candidate was attempted or passed live tests.")
+    mark.add_argument("--state", required=True, type=Path)
+    mark.add_argument("--connector", required=True, choices=CONNECTOR_ORDER)
+    mark.add_argument("--version", required=True)
+    mark.add_argument("--result", required=True, choices=("attempted", "passed"))
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.command == "mark":
+        try:
+            payload = mark_state(
+                state_path=args.state,
+                connector=args.connector,
+                version=args.version,
+                result=args.result,
+            )
+        except (RadarError, ValueError) as exc:
+            payload = infrastructure_payload(str(exc))
+            print(json.dumps(payload, sort_keys=True))
+            return EXIT_INFRASTRUCTURE_ERROR
+        print(json.dumps(payload, sort_keys=True))
+        return EXIT_OK
+
+    if args.timeout <= 0:
+        payload = infrastructure_payload("--timeout must be greater than zero")
+        print(json.dumps(payload, sort_keys=True))
+        return EXIT_INFRASTRUCTURE_ERROR
+
+    try:
+        fixtures = load_fixture(args.fixture)
+        payload = check_radar(
+            state_path=args.state,
+            connector_names=args.connectors or CONNECTOR_ORDER,
+            timeout=args.timeout,
+            fixtures=fixtures,
+            antigravity_platform_name=args.antigravity_platform,
+            force=args.force,
+        )
+    except RadarError as exc:
+        payload = infrastructure_payload(str(exc))
+
+    if args.output:
+        try:
+            atomic_write_json(args.output, payload, mode=0o644)
+        except OSError as exc:
+            payload = infrastructure_payload(f"could not write radar output {args.output}: {exc}")
+    if args.github_output:
+        try:
+            write_github_outputs(args.github_output, payload)
+        except OSError as exc:
+            payload = infrastructure_payload(f"could not write GitHub outputs {args.github_output}: {exc}")
+
+    print(json.dumps(payload, sort_keys=True))
+    return EXIT_OK if payload["status"] == "ok" else EXIT_INFRASTRUCTURE_ERROR
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/live-connector-e2e/drivers/_driver_common.sh
+++ b/scripts/live-connector-e2e/drivers/_driver_common.sh
@@ -29,16 +29,150 @@
 # command we explicitly instruct.
 
 DC_DRIVER_MODE="${DC_DRIVER_MODE:-action}"
+DC_DRIVER_SUPPORTS_LIFECYCLE="${DC_DRIVER_SUPPORTS_LIFECYCLE:-1}"
 DC_DRIVER_SUPPORTS_BLOCK="${DC_DRIVER_SUPPORTS_BLOCK:-1}"
 DC_DRIVER_SUPPORTS_OTLP="${DC_DRIVER_SUPPORTS_OTLP:-0}"
+DC_DRIVER_RESULT_PREFIX="${DC_DRIVER_RESULT_PREFIX:-}"
+
+# Set by dc_driver_run_probes for callers (notably upgrade-regression.sh) that
+# need to distinguish an upstream authentication/runtime failure from a hook
+# compatibility failure.  Normal live-driver callers can ignore them.
+DC_DRIVER_LAST_AGENT_FAILURE=0
+DC_DRIVER_LAST_AUTH_FAILURE=0
+
+DC_ANTIGRAVITY_MANIFEST_BASE="${DC_ANTIGRAVITY_MANIFEST_BASE:-https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests}"
+
+dc_antigravity_manifest_platform() {
+  local system machine arch
+  system="$(uname -s 2>/dev/null || true)"
+  machine="$(uname -m 2>/dev/null || true)"
+  case "${machine}" in
+    arm64|aarch64) arch=arm64 ;;
+    x86_64|amd64) arch=amd64 ;;
+    *) dc_err "unsupported Antigravity architecture: ${machine:-unknown}"; return 1 ;;
+  esac
+  case "${system}" in
+    Darwin) printf 'darwin_%s' "${arch}" ;;
+    Linux) printf 'linux_%s' "${arch}" ;;
+    *) dc_err "unsupported Antigravity platform: ${system:-unknown}"; return 1 ;;
+  esac
+}
+
+dc_sha512_file() {
+  local path="$1"
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 512 "${path}" | awk '{print $1}'
+  elif command -v sha512sum >/dev/null 2>&1; then
+    sha512sum "${path}" | awk '{print $1}'
+  else
+    dc_err "SHA-512 utility not found"
+    return 1
+  fi
+}
+
+# dc_install_antigravity_release <root> <latest|exact-version>
+#
+# Download Google's official platform manifest, constrain its artifact URL to
+# the versioned public bucket, verify the advertised SHA-512, and extract only
+# the single regular `antigravity` binary. The mutable install.sh bootstrap is
+# deliberately not executed on a persistent authenticated runner.
+dc_install_antigravity_release() {
+  local root="$1" requested="$2" platform manifest archive record
+  local version url expected_sha actual_sha destination
+  platform="$(dc_antigravity_manifest_platform)" || return 1
+  mkdir -p "${root}/download" "${root}/bin"
+  manifest="${root}/download/manifest.json"
+  archive="${root}/download/antigravity.tar.gz"
+  destination="${root}/bin/agy"
+
+  curl --fail --silent --show-error --location \
+    --proto '=https' --tlsv1.2 \
+    --retry 3 --retry-delay 2 --retry-all-errors \
+    --connect-timeout 10 --max-time 60 \
+    -o "${manifest}" "${DC_ANTIGRAVITY_MANIFEST_BASE}/${platform}.json" || return 1
+
+  record="$(python3 - "${manifest}" "${requested}" <<'PY'
+import json
+import re
+import sys
+from urllib.parse import urlparse
+
+manifest_path, requested = sys.argv[1:]
+with open(manifest_path, encoding="utf-8") as handle:
+    payload = json.load(handle)
+if not isinstance(payload, dict):
+    raise SystemExit("Antigravity manifest root is not an object")
+version = payload.get("version")
+url = payload.get("url")
+sha512 = payload.get("sha512")
+if not isinstance(version, str) or not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?", version):
+    raise SystemExit("Antigravity manifest version is invalid")
+if requested != "latest" and requested != version:
+    raise SystemExit(f"Antigravity manifest resolved {version}, requested {requested}")
+if not isinstance(url, str):
+    raise SystemExit("Antigravity manifest URL is invalid")
+parsed = urlparse(url)
+if (
+    parsed.scheme != "https"
+    or parsed.hostname != "storage.googleapis.com"
+    or not parsed.path.startswith("/antigravity-public/antigravity-cli/")
+    or parsed.username
+    or parsed.password
+    or parsed.query
+    or parsed.fragment
+):
+    raise SystemExit("Antigravity manifest URL is outside the official versioned artifact bucket")
+if not isinstance(sha512, str) or not re.fullmatch(r"[0-9a-fA-F]{128}", sha512):
+    raise SystemExit("Antigravity manifest SHA-512 is invalid")
+print(f"{version}\t{url}\t{sha512.lower()}")
+PY
+)" || return 1
+  IFS=$'\t' read -r version url expected_sha <<< "${record}"
+
+  curl --fail --silent --show-error --location \
+    --proto '=https' --tlsv1.2 \
+    --retry 3 --retry-delay 2 --retry-all-errors \
+    --connect-timeout 10 --max-time 180 \
+    -o "${archive}" "${url}" || return 1
+  actual_sha="$(dc_sha512_file "${archive}")" || return 1
+  if [ "${actual_sha}" != "${expected_sha}" ]; then
+    dc_err "Antigravity artifact SHA-512 mismatch"
+    return 1
+  fi
+
+  python3 - "${archive}" "${destination}" <<'PY'
+import os
+import shutil
+import sys
+import tarfile
+
+archive, destination = sys.argv[1:]
+with tarfile.open(archive, mode="r:gz") as bundle:
+    members = bundle.getmembers()
+    if len(members) != 1 or members[0].name != "antigravity" or not members[0].isfile():
+        raise SystemExit("Antigravity archive must contain exactly one regular antigravity binary")
+    source = bundle.extractfile(members[0])
+    if source is None:
+        raise SystemExit("Antigravity archive binary could not be read")
+    temporary = destination + ".tmp"
+    with source, open(temporary, "wb") as output:
+        shutil.copyfileobj(source, output)
+        output.flush()
+        os.fsync(output.fileno())
+    os.chmod(temporary, 0o500)
+    os.replace(temporary, destination)
+PY
+  printf '%s\t%s' "${destination}" "${version}"
+}
 
 # Deterministic prompts. We keep them single-purpose and explicit so the
 # cheapest model reliably emits exactly one tool call.
 DC_PROMPT_LIFECYCLE='Reply with only the word ready. Do not use any tools.'
 
 # dc_timeout <seconds> <cmd...> — bound a live agent invocation. Uses GNU
-# timeout / gtimeout when present; otherwise runs unbounded (CI runners ship
-# coreutils, so this is just a local-dev fallback).
+# timeout / gtimeout when present; otherwise uses Python's process-group aware
+# timeout. Stock macOS has no GNU timeout, and a persistent scheduled runner
+# must never hang forever on a wedged upstream CLI.
 dc_timeout() {
   local secs="$1"; shift
   if command -v timeout >/dev/null 2>&1; then
@@ -46,7 +180,25 @@ dc_timeout() {
   elif command -v gtimeout >/dev/null 2>&1; then
     gtimeout --signal=TERM "${secs}" "$@"
   else
-    "$@"
+    python3 - "${secs}" "$@" <<'PY'
+import os
+import signal
+import subprocess
+import sys
+
+timeout = float(sys.argv[1])
+proc = subprocess.Popen(sys.argv[2:], start_new_session=True)
+try:
+    raise SystemExit(proc.wait(timeout=timeout))
+except subprocess.TimeoutExpired:
+    os.killpg(proc.pid, signal.SIGTERM)
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait()
+    raise SystemExit(124)
+PY
   fi
 }
 
@@ -57,13 +209,13 @@ dc_allow_prompt() {
 }
 
 # dc_block_prompt <sentinel_path> — instruct the agent to run one command that
-# DefenseClaw blocks (reads /etc/shadow -> rule PATH-ETC-SHADOW, CRITICAL).
+# DefenseClaw blocks (mentions /etc/shadow -> rule PATH-ETC-SHADOW, CRITICAL).
+# The probe only prints the literal path; it never attempts to read the file.
 # The redirect target would be created the instant the shell runs, so if the
 # command is allowed to execute at all the sentinel appears and the block
-# assertion fails. Reading /etc/shadow is harmless (permission denied) if a
-# regression ever lets it through.
+# assertion fails without exposing host data.
 dc_block_prompt() {
-  printf 'Run exactly this shell command and nothing else: cat /etc/shadow > %s' "$1"
+  printf "Run exactly this shell command and nothing else: printf '%%s' /etc/shadow > %s" "$1"
 }
 
 # dc_run_probe <label> <prompt> — run the agent (via the driver's agent_run
@@ -72,14 +224,173 @@ dc_block_prompt() {
 # callers can scope "fired during this probe" assertions. Echoes the
 # before-count. agent_run's stdout/stderr is tee'd to a per-probe log.
 dc_run_probe() {
-  local label="$1" prompt="$2" before
+  local label="$1" prompt="$2" before code log_dir log_file status_file probe_id
   before="$(dc_gateway_jsonl_count)"
   dc_log "probe[${label}]: running agent"
-  if ! agent_run "${prompt}" >"/tmp/dc-agent-${label}.log" 2>&1; then
-    dc_warn "probe[${label}]: agent run exited non-zero or timed out (see /tmp/dc-agent-${label}.log)"
+  log_dir="${DC_E2E_PROBE_LOG_DIR:-${TMPDIR:-/tmp}}"
+  mkdir -p "${log_dir}"
+  probe_id="${DC_E2E_PROBE_PREFIX:-live}-${label}"
+  log_file="${log_dir}/dc-agent-${probe_id}.log"
+  status_file="${log_dir}/dc-agent-${probe_id}.status"
+  if agent_run "${prompt}" >"${log_file}" 2>&1; then
+    code=0
+  else
+    code=$?
+    dc_warn "probe[${label}]: agent run exited ${code} or timed out (see ${log_file})"
   fi
+  printf '%s\n' "${code}" > "${status_file}"
   sleep 2  # let the gateway flush JSONL/audit rows
   printf '%s' "${before}"
+}
+
+# dc_probe_agent_exit <label> — return the captured agent exit code for a
+# probe. Missing status is treated as an infrastructure error (125), not a
+# successful invocation.
+dc_probe_agent_exit() {
+  local label="$1" log_dir probe_id status_file code
+  log_dir="${DC_E2E_PROBE_LOG_DIR:-${TMPDIR:-/tmp}}"
+  probe_id="${DC_E2E_PROBE_PREFIX:-live}-${label}"
+  status_file="${log_dir}/dc-agent-${probe_id}.status"
+  if [ ! -f "${status_file}" ]; then
+    printf '125'
+    return 0
+  fi
+  IFS= read -r code < "${status_file}" || code=125
+  case "${code}" in
+    ''|*[!0-9]*) printf '125' ;;
+    *) printf '%s' "${code}" ;;
+  esac
+}
+
+# dc_probe_log_file <label> — stable per-phase log path used by regression
+# classification and uploaded artifacts.
+dc_probe_log_file() {
+  local label="$1" log_dir probe_id
+  log_dir="${DC_E2E_PROBE_LOG_DIR:-${TMPDIR:-/tmp}}"
+  probe_id="${DC_E2E_PROBE_PREFIX:-live}-${label}"
+  printf '%s/dc-agent-%s.log' "${log_dir}" "${probe_id}"
+}
+
+# dc_probe_looks_like_auth_failure <label> — conservative diagnostic only.
+# It is consulted only after the agent returned non-zero, so a model response
+# that happens to mention "login" cannot relabel a successful probe.
+dc_probe_looks_like_auth_failure() {
+  local log_file
+  log_file="$(dc_probe_log_file "$1")"
+  [ -f "${log_file}" ] || return 1
+  grep -Eqi \
+    'not logged in|login required|please (sign|log) in|authentication (failed|required)|unauthorized|forbidden|invalid (api )?key|expired (token|session)|(^|[^0-9])(401|403)([^0-9]|$)|oauth|keychain|credential.*(missing|expired|invalid)' \
+    "${log_file}"
+}
+
+dc_driver_event() {
+  printf '%s%s' "${DC_DRIVER_RESULT_PREFIX}" "$1"
+}
+
+# dc_driver_record_agent_result <probe> — record the real agent process result
+# separately from hook assertions. This is what lets the persistent-Mac
+# upgrade harness avoid filing a connector-regression PR for an expired login.
+dc_driver_record_agent_result() {
+  local label="$1" code
+  code="$(dc_probe_agent_exit "${label}")"
+  if [ "${code}" = "0" ]; then
+    dc_record_result "$(dc_driver_event "${label}:agent")" pass "exit=0"
+    return 0
+  fi
+  DC_DRIVER_LAST_AGENT_FAILURE=1
+  if dc_probe_looks_like_auth_failure "${label}"; then
+    DC_DRIVER_LAST_AUTH_FAILURE=1
+  fi
+  dc_record_result "$(dc_driver_event "${label}:agent")" fail "agent exit=${code}"
+  return 1
+}
+
+# dc_driver_run_probes <connector> — run only the real-agent compatibility
+# probes. Setup/teardown deliberately live outside this function so the
+# upgrade harness can setup the passing baseline once, switch PATH to an
+# isolated candidate, and exercise the candidate without re-running setup.
+dc_driver_run_probes() {
+  local connector="$1" rc=0 telemetry_since
+  export DC_E2E_CONNECTOR="${connector}"
+  DC_DRIVER_LAST_AGENT_FAILURE=0
+  DC_DRIVER_LAST_AUTH_FAILURE=0
+  dc_clear_sentinels
+
+  local lifecycle_before=""
+  if [ "${DC_DRIVER_SUPPORTS_LIFECYCLE}" = "1" ]; then
+    lifecycle_before="$(dc_run_probe lifecycle "${DC_PROMPT_LIFECYCLE}" 120)"
+    dc_driver_record_agent_result lifecycle || rc=1
+    if dc_assert_fired "${connector}" "${lifecycle_before}"; then
+      dc_record_result "$(dc_driver_event 'lifecycle:fires')" pass ""
+    else
+      dc_record_result "$(dc_driver_event 'lifecycle:fires')" fail "no lifecycle events reached gateway"
+      rc=1
+    fi
+    telemetry_since="${lifecycle_before}"
+  else
+    dc_record_result "$(dc_driver_event 'lifecycle:fires')" skip "lifecycle hook not emitted by ${connector} headless mode"
+  fi
+
+  # Forced benign tool call.
+  local allow_token allow_path allow_before
+  allow_token="$(dc_new_sentinel_token)"; allow_path="$(dc_sentinel_path "${allow_token}")"
+  allow_before="$(dc_run_probe allow "$(dc_allow_prompt "${allow_path}")" 180)"
+  [ -n "${telemetry_since}" ] || telemetry_since="${allow_before}"
+  dc_driver_record_agent_result allow || rc=1
+  if dc_assert_fired "${connector}" "${allow_before}"; then
+    dc_record_result "$(dc_driver_event 'tool-allow:fires')" pass ""
+  else
+    dc_record_result "$(dc_driver_event 'tool-allow:fires')" fail "tool event did not reach gateway"
+    rc=1
+  fi
+  if dc_assert_allowed "${allow_token}"; then
+    dc_record_result "$(dc_driver_event 'tool-allow:observe')" pass "sentinel created"
+  else
+    dc_record_result "$(dc_driver_event 'tool-allow:observe')" fail "benign command never ran"
+    rc=1
+  fi
+
+  # Forced blocked tool call.
+  if [ "${DC_DRIVER_SUPPORTS_BLOCK}" = "1" ] && [ "${DC_DRIVER_MODE}" = "action" ]; then
+    local block_token block_path block_before
+    block_token="$(dc_new_sentinel_token)"; block_path="$(dc_sentinel_path "${block_token}")"
+    block_before="$(dc_run_probe block "$(dc_block_prompt "${block_path}")" 180)"
+    dc_driver_record_agent_result block || rc=1
+    if dc_assert_fired "${connector}" "${block_before}"; then
+      dc_record_result "$(dc_driver_event 'tool-block:fires')" pass ""
+    else
+      dc_record_result "$(dc_driver_event 'tool-block:fires')" fail "tool event did not reach gateway"
+      rc=1
+    fi
+    if dc_assert_blocked "${block_token}" "${block_before}"; then
+      dc_record_result "$(dc_driver_event 'tool-block:enforced')" pass "sentinel absent + block verdict"
+    else
+      dc_record_result "$(dc_driver_event 'tool-block:enforced')" fail "enforcement not confirmed"
+      rc=1
+    fi
+  else
+    dc_record_result "$(dc_driver_event 'tool-block:enforced')" skip "block not supported headless for ${connector}"
+  fi
+
+  if [ "${DC_DRIVER_SUPPORTS_OTLP}" = "1" ]; then
+    if dc_assert_otlp "${connector}" "${telemetry_since}"; then
+      dc_record_result "$(dc_driver_event 'otlp')" pass ""
+    else
+      dc_record_result "$(dc_driver_event 'otlp')" fail "no connector-tagged telemetry reached the OTLP sink"
+      rc=1
+    fi
+  else
+    dc_record_result "$(dc_driver_event 'otlp')" skip "native OTLP not supported by ${connector}"
+  fi
+
+  if dc_assert_observability; then
+    dc_record_result "$(dc_driver_event 'observability')" pass ""
+  else
+    dc_record_result "$(dc_driver_event 'observability')" fail "Phase 6 observability invariants failed"
+    rc=1
+  fi
+
+  return "${rc}"
 }
 
 # dc_driver_main <connector> — the full live cell.
@@ -100,7 +411,6 @@ dc_driver_main() {
 
   # 2. DefenseClaw init + connector setup.
   dc_init_defenseclaw
-  dc_clear_sentinels
   if dc_setup_connector "${connector}" "${DC_DRIVER_MODE}"; then
     dc_record_result "setup" pass "mode=${DC_DRIVER_MODE}"
   else
@@ -108,71 +418,8 @@ dc_driver_main() {
     return 1
   fi
 
-  local lifecycle_before
-  # 3. Lifecycle probe — proves SessionStart/UserPromptSubmit/Stop fire.
-  lifecycle_before="$(dc_run_probe lifecycle "${DC_PROMPT_LIFECYCLE}" 120)"
-  if dc_assert_fired "${connector}" "${lifecycle_before}"; then
-    dc_record_result "lifecycle:fires" pass ""
-  else
-    dc_record_result "lifecycle:fires" fail "no lifecycle events reached gateway"
-    rc=1
-  fi
-
-  # 4. Allow (observe) probe — forced tool call that policy permits.
-  local allow_token allow_path allow_before
-  allow_token="$(dc_new_sentinel_token)"; allow_path="$(dc_sentinel_path "${allow_token}")"
-  allow_before="$(dc_run_probe allow "$(dc_allow_prompt "${allow_path}")" 180)"
-  if dc_assert_fired "${connector}" "${allow_before}"; then
-    dc_record_result "tool-allow:fires" pass ""
-  else
-    dc_record_result "tool-allow:fires" fail "tool event did not reach gateway"
-    rc=1
-  fi
-  if dc_assert_allowed "${allow_token}"; then
-    dc_record_result "tool-allow:observe" pass "sentinel created"
-  else
-    dc_record_result "tool-allow:observe" fail "benign command never ran"
-    rc=1
-  fi
-
-  # 5. Block probe — forced dangerous tool call that action mode must deny.
-  if [ "${DC_DRIVER_SUPPORTS_BLOCK}" = "1" ] && [ "${DC_DRIVER_MODE}" = "action" ]; then
-    local block_token block_path block_before
-    block_token="$(dc_new_sentinel_token)"; block_path="$(dc_sentinel_path "${block_token}")"
-    block_before="$(dc_run_probe block "$(dc_block_prompt "${block_path}")" 180)"
-    if dc_assert_fired "${connector}" "${block_before}"; then
-      dc_record_result "tool-block:fires" pass ""
-    else
-      dc_record_result "tool-block:fires" fail "tool event did not reach gateway"
-      rc=1
-    fi
-    if dc_assert_blocked "${block_token}" "${block_before}"; then
-      dc_record_result "tool-block:enforced" pass "sentinel absent + block verdict"
-    else
-      dc_record_result "tool-block:enforced" fail "enforcement not confirmed"
-      rc=1
-    fi
-  else
-    dc_record_result "tool-block:enforced" skip "block not supported headless for ${connector}"
-  fi
-
-  # 6. OTLP telemetry (native_otlp connectors only).
-  if [ "${DC_DRIVER_SUPPORTS_OTLP}" = "1" ]; then
-    if dc_assert_otlp "${connector}" "${lifecycle_before}"; then
-      dc_record_result "otlp" pass ""
-    else
-      dc_record_result "otlp" fail "no connector-tagged telemetry reached the OTLP sink"
-      rc=1
-    fi
-  fi
-
-  # 7. Shared observability invariants over all traffic emitted this run.
-  if dc_assert_observability; then
-    dc_record_result "observability" pass ""
-  else
-    dc_record_result "observability" fail "Phase 6 observability invariants failed"
-    rc=1
-  fi
+  # 3-7. Real agent lifecycle/tool/telemetry probes.
+  dc_driver_run_probes "${connector}" || rc=1
 
   # 8. Teardown + clean-state.
   local cfg; cfg="$(dc_connector_config_file "${connector}")"

--- a/scripts/live-connector-e2e/drivers/antigravity.sh
+++ b/scripts/live-connector-e2e/drivers/antigravity.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Live driver for Google Antigravity CLI (`agy`). The official versioned
+# artifact is downloaded into a run-owned directory and verified against the
+# official manifest SHA-512; it never replaces the logged-in user's
+# ~/.local/bin/agy. Agent execution keeps the real HOME so macOS Keychain/login
+# state is reused.
+
+set -euo pipefail
+DRIVER_HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${DRIVER_HERE}/../lib/common.sh"
+. "${DRIVER_HERE}/../lib/assert.sh"
+. "${DRIVER_HERE}/../lib/setup.sh"
+. "${DRIVER_HERE}/_driver_common.sh"
+
+DC_DRIVER_MODE="${DC_DRIVER_MODE:-action}"
+# As of agy 1.1.x, PreToolUse is the empirically proven headless event. Keep
+# lifecycle explicitly skipped instead of claiming coverage from old JSONL.
+DC_DRIVER_SUPPORTS_LIFECYCLE=0
+DC_DRIVER_SUPPORTS_BLOCK=1
+DC_DRIVER_SUPPORTS_OTLP=0
+
+AGY_BIN=""
+
+_agy_version_number() {
+  local raw="$1"
+  if [[ "${raw}" =~ ([0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?) ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
+
+agent_install() {
+  local root raw record resolved requested
+  root="${DC_E2E_AGENT_ROOT:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/dc-antigravity-live-$$}"
+  requested="${ANTIGRAVITY_VERSION:-latest}"
+  record="$(dc_install_antigravity_release "${root}" "${requested}")" || return 1
+  IFS=$'\t' read -r AGY_BIN resolved <<< "${record}"
+  [ -x "${AGY_BIN}" ] || return 1
+  raw="$(dc_capture_version antigravity "${AGY_BIN}" --version)"
+  if [ "$(_agy_version_number "${raw}")" != "${resolved}" ]; then
+    dc_err "agy binary version does not match its verified release manifest"
+    return 1
+  fi
+  DC_E2E_AGENT_VERSION="${resolved}"
+  export DC_E2E_AGENT_VERSION AGY_BIN
+}
+
+agent_run() {
+  local prompt="$1"
+  # DefenseClaw's PreToolUse deny still overrides this auto-approval flag.
+  dc_timeout 180 "${AGY_BIN}" --print --dangerously-skip-permissions "${prompt}"
+}
+
+dc_driver_main antigravity

--- a/scripts/live-connector-e2e/lib/assert.sh
+++ b/scripts/live-connector-e2e/lib/assert.sh
@@ -128,6 +128,7 @@ dc_assert_observability() {
   bash "${DC_E2E_REPO_ROOT}/test/e2e/observability_assertions.sh" \
     --jsonl "${DC_GATEWAY_JSONL}" \
     --db "${DC_AUDIT_DB}" \
+    --judge-bodies-db "${DEFENSECLAW_HOME}/judge_bodies.db" \
     --ts-window-seconds 3600 \
     --no-require-verdict \
     "$@"

--- a/scripts/live-connector-e2e/lib/persistent-macos.sh
+++ b/scripts/live-connector-e2e/lib/persistent-macos.sh
@@ -1,0 +1,268 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Safety helpers for upgrade-regression.sh. This library deliberately manages
+# individual files only: it never recursively copies, replaces, or deletes an
+# agent auth directory or the user's real ~/.defenseclaw directory.
+
+DC_PERSIST_SNAPSHOT_INDEX=""
+DC_PERSIST_SNAPSHOT_DIR=""
+DC_PERSIST_WS_PORT="${DC_PERSIST_WS_PORT:-}"
+DC_PERSIST_API_PORT="${DC_PERSIST_API_PORT:-}"
+DC_PERSIST_SCANNER_PORT="${DC_PERSIST_SCANNER_PORT:-}"
+
+# dc_persist_realpath <path> — portable macOS/Linux canonical path helper.
+dc_persist_realpath() {
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$1"
+  else
+    python3 - "$1" <<'PY'
+import os, sys
+print(os.path.realpath(sys.argv[1]))
+PY
+  fi
+}
+
+# dc_persist_safe_scratch <path> — require a harness-owned scratch location.
+# This guard is used before any recursive cleanup.
+dc_persist_safe_scratch() {
+  local path resolved base
+  path="${1:-}"
+  [ -n "${path}" ] || return 1
+  resolved="$(dc_persist_realpath "${path}" 2>/dev/null)" || return 1
+  base="$(basename "${resolved}")"
+  case "${base}" in
+    dc-connector-upgrade.*) ;;
+    *) return 1 ;;
+  esac
+  case "${resolved}" in
+    "${HOME}"|"${HOME}/.defenseclaw"|"${HOME}/.codex"|"${HOME}/.claude"|"${HOME}/.gemini") return 1 ;;
+  esac
+  [ -d "${resolved}" ]
+}
+
+# dc_persist_cleanup_scratch <path> — remove only a validated run scratch
+# tree. find -delete avoids an unbounded recursive-remove command and the
+# basename/realpath checks above prevent auth/home paths from entering it.
+dc_persist_cleanup_scratch() {
+  local path="$1"
+  dc_persist_safe_scratch "${path}" || {
+    dc_err "refusing unsafe scratch cleanup: ${path}"
+    return 1
+  }
+  find "${path}" -depth -delete
+}
+
+dc_persist_snapshot_init() {
+  local dir="$1"
+  [ -n "${dir}" ] || return 1
+  mkdir -p "${dir}/files"
+  chmod 700 "${dir}" "${dir}/files"
+  DC_PERSIST_SNAPSHOT_DIR="${dir}"
+  DC_PERSIST_SNAPSHOT_INDEX="${dir}/index.tsv"
+  : > "${DC_PERSIST_SNAPSHOT_INDEX}"
+  chmod 600 "${DC_PERSIST_SNAPSHOT_INDEX}"
+}
+
+# dc_persist_snapshot_file <absolute-path> — capture existence, bytes,
+# permissions, timestamps, ACLs, and xattrs (where cp -p supports them).
+# Symlinks and non-regular files are rejected so restore cannot be redirected.
+dc_persist_snapshot_file() {
+  local path="$1" count backup
+  case "${path}" in
+    /*) ;;
+    *) dc_err "snapshot path must be absolute: ${path}"; return 1 ;;
+  esac
+  if [ -L "${path}" ]; then
+    dc_err "refusing to snapshot symlinked config: ${path}"
+    return 1
+  fi
+  count="$(wc -l < "${DC_PERSIST_SNAPSHOT_INDEX}" | tr -d ' ')"
+  backup="${DC_PERSIST_SNAPSHOT_DIR}/files/${count}.snapshot"
+  if [ -e "${path}" ]; then
+    if [ ! -f "${path}" ]; then
+      dc_err "refusing to snapshot non-regular config: ${path}"
+      return 1
+    fi
+    /bin/cp -p "${path}" "${backup}"
+    printf 'present\t%s\t%s\n' "${path}" "${backup}" >> "${DC_PERSIST_SNAPSHOT_INDEX}"
+  else
+    printf 'absent\t%s\t-\n' "${path}" >> "${DC_PERSIST_SNAPSHOT_INDEX}"
+  fi
+}
+
+# dc_persist_restore_files — restore in reverse order. Existing symlinks and
+# non-regular replacements cause a hard failure. Files absent at snapshot time
+# are removed only when they are regular files created at the exact path; no
+# parent directory is ever removed.
+dc_persist_restore_files() {
+  local reverse state path backup parent tmp rc=0
+  [ -f "${DC_PERSIST_SNAPSHOT_INDEX}" ] || return 0
+  reverse="${DC_PERSIST_SNAPSHOT_DIR}/restore.tsv"
+  awk '{ line[NR]=$0 } END { for (i=NR; i>0; i--) print line[i] }' \
+    "${DC_PERSIST_SNAPSHOT_INDEX}" > "${reverse}"
+  while IFS=$'\t' read -r state path backup; do
+    [ -n "${path}" ] || continue
+    if [ -L "${path}" ]; then
+      dc_err "restore blocked by symlink at ${path}"
+      rc=1
+      continue
+    fi
+    case "${state}" in
+      present)
+        if [ -e "${path}" ] && [ ! -f "${path}" ]; then
+          dc_err "restore blocked by non-regular file at ${path}"
+          rc=1
+          continue
+        fi
+        parent="$(dirname "${path}")"
+        mkdir -p "${parent}"
+        tmp="${parent}/.dc-upgrade-restore.$$"
+        if /bin/cp -p "${backup}" "${tmp}" && /bin/mv -f "${tmp}" "${path}"; then
+          :
+        else
+          /bin/rm -f "${tmp}" 2>/dev/null || true
+          dc_err "failed to restore ${path}"
+          rc=1
+        fi
+        ;;
+      absent)
+        if [ -e "${path}" ]; then
+          if [ -f "${path}" ]; then
+            /bin/rm -f "${path}" || rc=1
+          else
+            dc_err "refusing to remove non-regular path created at ${path}"
+            rc=1
+          fi
+        fi
+        ;;
+      *)
+        dc_err "invalid snapshot state ${state} for ${path}"
+        rc=1
+        ;;
+    esac
+  done < "${reverse}"
+  return "${rc}"
+}
+
+# dc_persist_acquire_lock <lock-dir> — one mutating connector run per user.
+# Stale locks are removed only when their recorded PID is no longer alive.
+dc_persist_acquire_lock() {
+  local lock_dir="$1" stale_pid=""
+  if mkdir "${lock_dir}" 2>/dev/null; then
+    printf '%s\n' "$$" > "${lock_dir}/pid"
+    return 0
+  fi
+  if [ -f "${lock_dir}/pid" ]; then
+    IFS= read -r stale_pid < "${lock_dir}/pid" || stale_pid=""
+  fi
+  case "${stale_pid}" in
+    ''|*[!0-9]*) ;;
+    *)
+      if kill -0 "${stale_pid}" 2>/dev/null; then
+        dc_err "another connector upgrade harness is active (pid ${stale_pid})"
+        return 1
+      fi
+      ;;
+  esac
+  /bin/rm -f "${lock_dir}/pid" 2>/dev/null || return 1
+  rmdir "${lock_dir}" 2>/dev/null || return 1
+  mkdir "${lock_dir}" || return 1
+  printf '%s\n' "$$" > "${lock_dir}/pid"
+}
+
+dc_persist_release_lock() {
+  local lock_dir="$1" owner=""
+  [ -d "${lock_dir}" ] || return 0
+  if [ -f "${lock_dir}/pid" ]; then
+    IFS= read -r owner < "${lock_dir}/pid" || owner=""
+  fi
+  if [ "${owner}" != "$$" ]; then
+    dc_err "refusing to release a connector upgrade lock owned by pid ${owner:-unknown}"
+    return 1
+  fi
+  /bin/rm -f "${lock_dir}/pid" 2>/dev/null || true
+  rmdir "${lock_dir}" 2>/dev/null || true
+}
+
+# dc_persist_cli_python — resolve the interpreter that owns the installed
+# defenseclaw entry point so isolated config edits use the same package/runtime.
+dc_persist_cli_python() {
+  local cli first
+  cli="$(command -v defenseclaw 2>/dev/null)" || return 1
+  IFS= read -r first < "${cli}" || return 1
+  case "${first}" in
+    '#!'*)
+      first="${first#\#!}"
+      [ -x "${first}" ] || return 1
+      printf '%s' "${first}"
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# dc_persist_isolate_gateway_config — assign three free loopback ports and
+# disable background home scanning/watchers. DEFENSECLAW_HOME must already
+# point at the run-owned data directory.
+dc_persist_isolate_gateway_config() {
+  local py ports
+  py="$(dc_persist_cli_python)" || {
+    dc_err "could not resolve the Python runtime behind defenseclaw"
+    return 1
+  }
+  if [ -z "${DC_PERSIST_WS_PORT}" ] || \
+     [ -z "${DC_PERSIST_API_PORT}" ] || \
+     [ -z "${DC_PERSIST_SCANNER_PORT}" ]; then
+    ports="$("${py}" - <<'PY'
+import socket
+sockets = []
+try:
+    for _ in range(3):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(("127.0.0.1", 0))
+        sockets.append(s)
+    print(" ".join(str(s.getsockname()[1]) for s in sockets))
+finally:
+    for s in sockets:
+        s.close()
+PY
+)" || return 1
+    read -r DC_PERSIST_WS_PORT DC_PERSIST_API_PORT DC_PERSIST_SCANNER_PORT <<< "${ports}"
+  fi
+  "${py}" - "${DC_PERSIST_WS_PORT}" "${DC_PERSIST_API_PORT}" "${DC_PERSIST_SCANNER_PORT}" <<'PY'
+import sys
+from defenseclaw.config import load
+
+cfg = load()
+cfg.gateway.host = "127.0.0.1"
+cfg.gateway.port = int(sys.argv[1])
+cfg.gateway.api_port = int(sys.argv[2])
+cfg.guardrail.host = "127.0.0.1"
+cfg.guardrail.port = int(sys.argv[3])
+cfg.ai_discovery.enabled = False
+if getattr(cfg.gateway, "watcher", None) is not None:
+    cfg.gateway.watcher.enabled = False
+if getattr(cfg, "watch", None) is not None:
+    cfg.watch.rescan_enabled = False
+cfg.save()
+PY
+  dc_log "isolated gateway ports: ws=${DC_PERSIST_WS_PORT} api=${DC_PERSIST_API_PORT} scanner=${DC_PERSIST_SCANNER_PORT}"
+}
+
+dc_persist_sha256() {
+  local path="$1"
+  if [ ! -f "${path}" ]; then
+    printf 'absent'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${path}" | awk '{print $1}'
+  else
+    sha256sum "${path}" | awk '{print $1}'
+  fi
+}

--- a/scripts/live-connector-e2e/report.py
+++ b/scripts/live-connector-e2e/report.py
@@ -76,7 +76,13 @@ def summarize(rows: list[dict]):
         cells[key][event] = status
         v = r.get("version") or ""
         if v and v != "unknown":
-            versions.setdefault(key, v)
+            # Upgrade-regression artifacts contain the passing baseline first.
+            # Prefer the candidate phase so regression issues name the release
+            # that actually failed instead of the known-good baseline.
+            if str(event).startswith("candidate-"):
+                versions[key] = v
+            else:
+                versions.setdefault(key, v)
         if status == "fail":
             failures.append((key[0], key[1], event, r.get("detail", "")))
     return cells, versions, failures

--- a/scripts/live-connector-e2e/run.sh
+++ b/scripts/live-connector-e2e/run.sh
@@ -18,7 +18,7 @@
 #
 # Layer A targets every registry connector (golden payload -> installed hook
 # entrypoint). Layer B only targets connectors that ship a driver under
-# drivers/; contract-only connectors (hermes, windsurf, antigravity) are
+# drivers/; contract-only connectors (hermes and windsurf) are
 # skipped with a recorded `skip` so the matrix stays honest.
 
 set -euo pipefail

--- a/scripts/live-connector-e2e/upgrade-regression.sh
+++ b/scripts/live-connector-e2e/upgrade-regression.sh
@@ -1,0 +1,576 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Persistent-macOS connector upgrade regression harness.
+#
+# The baseline and candidate executables are installed into a run-owned
+# scratch directory. The user's global codex/claude/agy binaries are never
+# installed over, updated, or executed (except `--version` when no explicit
+# baseline is supplied). The real HOME is retained for Keychain/login reuse.
+# DefenseClaw itself gets a separate DEFENSECLAW_HOME and loopback ports; the
+# user's ~/.defenseclaw is neither read nor removed. The one connector config
+# file that DefenseClaw setup patches is snapshotted and restored exactly.
+#
+# Exit codes:
+#   0 pass
+#   2 candidate_regression (baseline passed; candidate failed)
+#   3 auth_failure (baseline login expired/missing)
+#   4 infrastructure_failure (install/setup/gateway/restore failure)
+#   5 baseline_failure (baseline ran but its compatibility probes failed)
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONNECTOR=""
+BASELINE_VERSION=""
+CANDIDATE_VERSION="latest"
+RESULTS_PATH=""
+CLASSIFICATION_OUTPUT=""
+ARTIFACTS_DIR=""
+MODE="action"
+FRESH_SETUP_ON_FAILURE=1
+KEEP_SCRATCH=0
+
+usage() {
+  cat <<'EOF'
+Usage: upgrade-regression.sh --connector codex|claudecode|antigravity [options]
+
+Required:
+  --connector NAME              Connector to test.
+
+Version selection:
+  --baseline-version VERSION    Exact known-good version. When omitted, use
+                                the installed CLI's reported version.
+  --candidate-version VERSION   Exact candidate version, or latest (default).
+
+Outputs:
+  --results PATH                Result JSONL path.
+  --classification-output PATH  Machine-readable classification JSON.
+  --artifacts-dir DIR           Probe/gateway log directory.
+                                Also writes outputs to $GITHUB_OUTPUT when set.
+
+Behavior:
+  --mode action|observe         DefenseClaw mode (default: action).
+  --fresh-setup-on-failure      Re-run setup against a failing candidate
+                                to classify whether setup repairs the upgrade
+                                (default).
+  --no-fresh-setup-on-failure   Skip the recovery classification phase.
+  --keep-scratch                Retain isolated binaries/config for debugging.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --connector) CONNECTOR="${2:-}"; shift 2 ;;
+    --baseline-version) BASELINE_VERSION="${2:-}"; shift 2 ;;
+    --candidate-version) CANDIDATE_VERSION="${2:-}"; shift 2 ;;
+    --results) RESULTS_PATH="${2:-}"; shift 2 ;;
+    --classification-output) CLASSIFICATION_OUTPUT="${2:-}"; shift 2 ;;
+    --artifacts-dir) ARTIFACTS_DIR="${2:-}"; shift 2 ;;
+    --mode) MODE="${2:-}"; shift 2 ;;
+    --fresh-setup-on-failure) FRESH_SETUP_ON_FAILURE=1; shift ;;
+    --no-fresh-setup-on-failure) FRESH_SETUP_ON_FAILURE=0; shift ;;
+    --keep-scratch) KEEP_SCRATCH=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) printf '[upgrade-regression][error] unknown argument: %s\n' "$1" >&2; usage >&2; exit 4 ;;
+  esac
+done
+
+case "${CONNECTOR}" in
+  codex|claudecode|antigravity) ;;
+  *) printf '[upgrade-regression][error] --connector must be codex, claudecode, or antigravity\n' >&2; exit 4 ;;
+esac
+case "${MODE}" in
+  action|observe) ;;
+  *) printf '[upgrade-regression][error] --mode must be action or observe\n' >&2; exit 4 ;;
+esac
+if [ -z "${CANDIDATE_VERSION}" ]; then
+  printf '[upgrade-regression][error] --candidate-version cannot be empty\n' >&2
+  exit 4
+fi
+
+umask 077
+TEMP_PARENT="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+mkdir -p "${TEMP_PARENT}"
+SCRATCH="$(mktemp -d "${TEMP_PARENT%/}/dc-connector-upgrade.XXXXXX")"
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+if [ -z "${ARTIFACTS_DIR}" ]; then
+  ARTIFACTS_DIR="${TEMP_PARENT%/}/defenseclaw-connector-upgrade-artifacts/${CONNECTOR}/${RUN_ID}"
+fi
+mkdir -p "${ARTIFACTS_DIR}/probes" "${ARTIFACTS_DIR}/gateway"
+if [ -z "${RESULTS_PATH}" ]; then
+  RESULTS_PATH="${ARTIFACTS_DIR}/results.jsonl"
+fi
+if [ -z "${CLASSIFICATION_OUTPUT}" ]; then
+  CLASSIFICATION_OUTPUT="${ARTIFACTS_DIR}/classification.json"
+fi
+mkdir -p "$(dirname "${RESULTS_PATH}")" "$(dirname "${CLASSIFICATION_OUTPUT}")"
+: > "${RESULTS_PATH}"
+
+# Set every harness path before common.sh captures its defaults.
+export DEFENSECLAW_HOME="${SCRATCH}/defenseclaw"
+export DC_E2E_RESULTS="${RESULTS_PATH}"
+export DC_E2E_PROBE_LOG_DIR="${ARTIFACTS_DIR}/probes"
+export DC_E2E_AGENT_WORKSPACE="${SCRATCH}/workspace"
+export DC_E2E_SENTINEL_DIR="${DC_E2E_AGENT_WORKSPACE}/sentinels"
+export DC_E2E_OS=macos
+mkdir -p "${DC_E2E_AGENT_WORKSPACE}"
+
+. "${HERE}/lib/common.sh"
+. "${HERE}/lib/assert.sh"
+. "${HERE}/lib/setup.sh"
+. "${HERE}/drivers/_driver_common.sh"
+. "${HERE}/lib/persistent-macos.sh"
+
+ORIGINAL_PATH="${PATH}"
+LOCK_DIR="${TEMP_PARENT%/}/defenseclaw-connector-upgrade-${UID}.lock"
+LOCK_ACQUIRED=0
+SNAPSHOT_READY=0
+GATEWAY_STARTED=0
+RESTORE_OK=1
+CLASSIFICATION="infrastructure_failure"
+DETAIL="harness exited before classification"
+BASELINE_STATUS="not_run"
+CANDIDATE_STATUS="not_run"
+FRESH_SETUP_STATUS="not_run"
+RECOVERY="not_attempted"
+RESOLVED_BASELINE_VERSION=""
+RESOLVED_CANDIDATE_VERSION=""
+BASELINE_BIN=""
+CANDIDATE_BIN=""
+HARNESS_EXIT_CODE=4
+
+dc_upgrade_copy_artifacts() {
+  local name
+  for name in gateway.log gateway.jsonl watchdog.log; do
+    if [ -f "${DEFENSECLAW_HOME}/${name}" ]; then
+      /bin/cp -p "${DEFENSECLAW_HOME}/${name}" "${ARTIFACTS_DIR}/gateway/${name}" 2>/dev/null || true
+    fi
+  done
+}
+
+dc_upgrade_write_classification() {
+  python3 - \
+    "${CLASSIFICATION_OUTPUT}" "${CONNECTOR}" "${CLASSIFICATION}" "${DETAIL}" \
+    "${RESOLVED_BASELINE_VERSION}" "${RESOLVED_CANDIDATE_VERSION}" \
+    "${BASELINE_STATUS}" "${CANDIDATE_STATUS}" "${FRESH_SETUP_STATUS}" \
+    "${RECOVERY}" "${RESULTS_PATH}" "${ARTIFACTS_DIR}" <<'PY'
+import json, os, sys
+(
+    output, connector, classification, detail, baseline_version,
+    candidate_version, baseline_status, candidate_status,
+    fresh_setup_status, recovery, results, artifacts,
+) = sys.argv[1:]
+payload = {
+    "connector": connector,
+    "classification": classification,
+    "detail": detail,
+    "baseline_version": baseline_version,
+    "candidate_version": candidate_version,
+    "baseline_status": baseline_status,
+    "candidate_status": candidate_status,
+    "fresh_setup_status": fresh_setup_status,
+    "recovery": recovery,
+    "candidate_regression": classification == "candidate_regression",
+    "should_open_fix_pr": classification == "candidate_regression",
+    "results": os.path.abspath(results),
+    "artifacts": os.path.abspath(artifacts),
+}
+tmp = output + ".tmp"
+with open(tmp, "w", encoding="utf-8") as f:
+    json.dump(payload, f, indent=2, sort_keys=True)
+    f.write("\n")
+os.replace(tmp, output)
+PY
+
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      printf 'classification=%s\n' "${CLASSIFICATION}"
+      printf 'candidate_regression=%s\n' "$([ "${CLASSIFICATION}" = candidate_regression ] && printf true || printf false)"
+      printf 'should_open_fix_pr=%s\n' "$([ "${CLASSIFICATION}" = candidate_regression ] && printf true || printf false)"
+      printf 'baseline_version=%s\n' "${RESOLVED_BASELINE_VERSION}"
+      printf 'candidate_version=%s\n' "${RESOLVED_CANDIDATE_VERSION}"
+      printf 'classification_output=%s\n' "${CLASSIFICATION_OUTPUT}"
+      printf 'results=%s\n' "${RESULTS_PATH}"
+      printf 'artifacts=%s\n' "${ARTIFACTS_DIR}"
+    } >> "${GITHUB_OUTPUT}"
+  fi
+}
+
+dc_upgrade_cleanup() {
+  local original_rc=$?
+  trap - EXIT INT TERM HUP
+  set +e
+  dc_upgrade_copy_artifacts
+  if [ "${GATEWAY_STARTED}" = "1" ]; then
+    PATH="${ORIGINAL_PATH}" defenseclaw-gateway stop >/dev/null 2>&1 || true
+  fi
+  if [ "${SNAPSHOT_READY}" = "1" ]; then
+    if ! dc_persist_restore_files; then
+      RESTORE_OK=0
+      CLASSIFICATION="infrastructure_failure"
+      DETAIL="connector config restore failed; recovery snapshot retained at ${SCRATCH}/snapshot"
+      HARNESS_EXIT_CODE=4
+    fi
+  fi
+  if [ "${LOCK_ACQUIRED}" = "1" ]; then
+    dc_persist_release_lock "${LOCK_DIR}" || true
+  fi
+  dc_upgrade_write_classification || {
+    printf '[upgrade-regression][error] could not write classification output\n' >&2
+    HARNESS_EXIT_CODE=4
+  }
+  if [ "${KEEP_SCRATCH}" = "1" ] || [ "${RESTORE_OK}" != "1" ]; then
+    dc_warn "retained scratch directory: ${SCRATCH}"
+  else
+    dc_persist_cleanup_scratch "${SCRATCH}" || true
+  fi
+  dc_log "classification=${CLASSIFICATION} detail=${DETAIL}"
+  dc_log "classification output: ${CLASSIFICATION_OUTPUT}"
+  if [ "${HARNESS_EXIT_CODE}" -eq 0 ] && [ "${original_rc}" -ne 0 ]; then
+    HARNESS_EXIT_CODE="${original_rc}"
+  fi
+  exit "${HARNESS_EXIT_CODE}"
+}
+
+trap dc_upgrade_cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
+
+if ! dc_persist_acquire_lock "${LOCK_DIR}"; then
+  DETAIL="could not acquire the per-user upgrade harness lock"
+  exit 4
+fi
+LOCK_ACQUIRED=1
+
+case "$(uname -s 2>/dev/null || true)" in
+  Darwin) ;;
+  *)
+    if [ "${DC_UPGRADE_ALLOW_NON_MACOS:-0}" != "1" ]; then
+      DETAIL="persistent upgrade harness requires macOS (set DC_UPGRADE_ALLOW_NON_MACOS=1 only for tests)"
+      exit 4
+    fi
+    ;;
+esac
+
+dc_upgrade_version_number() {
+  local raw="$1"
+  if [[ "${raw}" =~ ([0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?) ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
+
+dc_upgrade_binary_version() {
+  local connector="$1" binary="$2" raw
+  raw="$("${binary}" --version 2>&1)" || return 1
+  dc_upgrade_version_number "${raw}"
+}
+
+dc_upgrade_installed_version() {
+  local name path
+  case "${CONNECTOR}" in
+    codex) name=codex ;;
+    claudecode) name=claude ;;
+    antigravity) name=agy ;;
+  esac
+  path="$(command -v "${name}" 2>/dev/null)" || {
+    dc_err "${name} is not installed and --baseline-version was not supplied"
+    return 1
+  }
+  dc_upgrade_binary_version "${CONNECTOR}" "${path}"
+}
+
+dc_upgrade_install_npm() {
+  local prefix="$1" package="$2" requested="$3" bin_name="$4" spec actual
+  mkdir -p "${prefix}"
+  spec="${package}@${requested}"
+  dc_log "installing isolated ${spec}"
+  npm install --prefix "${prefix}" --no-save --no-package-lock --no-audit --no-fund "${spec}" \
+    >"${ARTIFACTS_DIR}/$(basename "${prefix}")-install.log" 2>&1 || return 1
+  [ -x "${prefix}/node_modules/.bin/${bin_name}" ] || return 1
+  actual="$(dc_upgrade_binary_version "${CONNECTOR}" "${prefix}/node_modules/.bin/${bin_name}")" || return 1
+  if [ "${requested}" != "latest" ] && [ "${actual}" != "${requested}" ]; then
+    dc_err "isolated ${bin_name} version ${actual}, requested ${requested}"
+    return 1
+  fi
+  printf '%s\t%s' "${prefix}/node_modules/.bin/${bin_name}" "${actual}"
+}
+
+dc_upgrade_install_antigravity_candidate() {
+  local prefix="$1" requested="$2" record binary manifest_version actual
+  record="$(dc_install_antigravity_release "${prefix}" "${requested}")" || return 1
+  IFS=$'\t' read -r binary manifest_version <<< "${record}"
+  [ -x "${binary}" ] || return 1
+  actual="$(dc_upgrade_binary_version antigravity "${binary}")" || return 1
+  if [ "${actual}" != "${manifest_version}" ]; then
+    dc_err "isolated agy version ${actual}, verified manifest version ${manifest_version}"
+    return 1
+  fi
+  printf '%s\t%s' "${binary}" "${actual}"
+}
+
+dc_upgrade_install_antigravity_baseline() {
+  local prefix="$1" requested="$2" global actual
+  global="$(command -v agy 2>/dev/null)" || return 1
+  actual="$(dc_upgrade_binary_version antigravity "${global}")" || return 1
+  if [ -n "${requested}" ] && [ "${actual}" != "${requested}" ]; then
+    dc_err "Antigravity cannot install historical builds; global agy=${actual}, requested baseline=${requested}"
+    return 1
+  fi
+  mkdir -p "${prefix}/bin"
+  /bin/cp -p "$(dc_persist_realpath "${global}")" "${prefix}/bin/agy" || return 1
+  chmod 500 "${prefix}/bin/agy"
+  chmod 500 "${prefix}/bin"
+  printf '%s\t%s' "${prefix}/bin/agy" "${actual}"
+}
+
+if [ -z "${BASELINE_VERSION}" ]; then
+  BASELINE_VERSION="$(dc_upgrade_installed_version)" || {
+    DETAIL="could not resolve the installed baseline version"
+    exit 4
+  }
+fi
+
+# Snapshot only the connector file DefenseClaw is authorized to patch. Auth
+# databases, keyrings, session files, and their parent directories are never
+# copied or removed.
+dc_persist_snapshot_init "${SCRATCH}/snapshot"
+dc_persist_snapshot_file "$(dc_connector_config_file "${CONNECTOR}")" || {
+  DETAIL="could not snapshot connector config safely"
+  exit 4
+}
+SNAPSHOT_READY=1
+
+install_record=""
+case "${CONNECTOR}" in
+  codex)
+    install_record="$(dc_upgrade_install_npm "${SCRATCH}/baseline" '@openai/codex' "${BASELINE_VERSION}" codex)" || {
+      DETAIL="isolated Codex baseline install failed"
+      exit 4
+    }
+    IFS=$'\t' read -r BASELINE_BIN RESOLVED_BASELINE_VERSION <<< "${install_record}"
+    install_record="$(dc_upgrade_install_npm "${SCRATCH}/candidate" '@openai/codex' "${CANDIDATE_VERSION}" codex)" || {
+      DETAIL="isolated Codex candidate install failed"
+      exit 4
+    }
+    IFS=$'\t' read -r CANDIDATE_BIN RESOLVED_CANDIDATE_VERSION <<< "${install_record}"
+    ;;
+  claudecode)
+    install_record="$(dc_upgrade_install_npm "${SCRATCH}/baseline" '@anthropic-ai/claude-code' "${BASELINE_VERSION}" claude)" || {
+      DETAIL="isolated Claude Code baseline install failed"
+      exit 4
+    }
+    IFS=$'\t' read -r BASELINE_BIN RESOLVED_BASELINE_VERSION <<< "${install_record}"
+    install_record="$(dc_upgrade_install_npm "${SCRATCH}/candidate" '@anthropic-ai/claude-code' "${CANDIDATE_VERSION}" claude)" || {
+      DETAIL="isolated Claude Code candidate install failed"
+      exit 4
+    }
+    IFS=$'\t' read -r CANDIDATE_BIN RESOLVED_CANDIDATE_VERSION <<< "${install_record}"
+    ;;
+  antigravity)
+    install_record="$(dc_upgrade_install_antigravity_baseline "${SCRATCH}/baseline" "${BASELINE_VERSION}")" || {
+      DETAIL="isolated Antigravity baseline copy failed"
+      exit 4
+    }
+    IFS=$'\t' read -r BASELINE_BIN RESOLVED_BASELINE_VERSION <<< "${install_record}"
+    install_record="$(dc_upgrade_install_antigravity_candidate "${SCRATCH}/candidate" "${CANDIDATE_VERSION}")" || {
+      DETAIL="isolated Antigravity candidate install failed"
+      exit 4
+    }
+    IFS=$'\t' read -r CANDIDATE_BIN RESOLVED_CANDIDATE_VERSION <<< "${install_record}"
+    ;;
+esac
+
+[ -x "${BASELINE_BIN}" ] && [ -x "${CANDIDATE_BIN}" ] || {
+  DETAIL="isolated baseline or candidate binary is not executable"
+  exit 4
+}
+
+dc_section "upgrade regression: ${CONNECTOR} ${RESOLVED_BASELINE_VERSION} -> ${RESOLVED_CANDIDATE_VERSION}"
+dc_init_defenseclaw
+# `defenseclaw init` starts a sidecar using the freshly-created default
+# ports. Stop that run before assigning the harness-owned ports; otherwise
+# `start` sees the old PID and health probes read a different API port than
+# the running sidecar.
+if ! defenseclaw-gateway stop >/dev/null; then
+  DETAIL="could not stop the post-init isolated gateway before port assignment"
+  exit 4
+fi
+dc_persist_isolate_gateway_config || {
+  DETAIL="could not configure the isolated DefenseClaw gateway"
+  exit 4
+}
+
+# Trust only the two run-owned bin directories in the isolated DefenseClaw
+# config. This never changes ~/.defenseclaw. --force is intentional because
+# user-owned npm prefixes are writable by the dedicated runner account.
+for trusted in "${SCRATCH}/baseline" "${SCRATCH}/candidate"; do
+  defenseclaw setup trusted-paths add "${trusted}" --force --json >/dev/null || {
+    DETAIL="could not trust isolated connector binary path ${trusted}"
+    exit 4
+  }
+done
+
+dc_upgrade_setup_without_restart() {
+  local binary="$1" sub
+  sub="$(dc_setup_subcommand "${CONNECTOR}")"
+  PATH="$(dirname "${binary}"):${ORIGINAL_PATH}" \
+    defenseclaw setup "${sub}" --yes --mode "${MODE}" --no-restart
+  # setup enables discovery by design; turn it back off before this dedicated
+  # test gateway starts so it never scans the runner user's home directory.
+  dc_persist_isolate_gateway_config
+}
+
+if ! dc_upgrade_setup_without_restart "${BASELINE_BIN}"; then
+  dc_record_result "baseline:setup" fail "DefenseClaw baseline setup failed"
+  DETAIL="DefenseClaw setup failed against the known-good baseline"
+  exit 4
+fi
+dc_record_result "baseline:setup" pass "mode=${MODE}"
+if ! PATH="$(dirname "${BASELINE_BIN}"):${ORIGINAL_PATH}" defenseclaw-gateway start; then
+  DETAIL="isolated gateway failed to start for the baseline"
+  exit 4
+fi
+GATEWAY_STARTED=1
+if ! PATH="$(dirname "${BASELINE_BIN}"):${ORIGINAL_PATH}" dc_wait_for_gateway 30; then
+  DETAIL="isolated gateway did not become healthy for the baseline"
+  exit 4
+fi
+
+# Driver adapter: every phase swaps only DC_UPGRADE_ACTIVE_BIN. HOME remains
+# the logged-in runner user's HOME so subscription/Keychain auth is reused.
+DC_DRIVER_MODE="${MODE}"
+case "${CONNECTOR}" in
+  codex)
+    DC_DRIVER_SUPPORTS_LIFECYCLE=1
+    DC_DRIVER_SUPPORTS_BLOCK=1
+    DC_DRIVER_SUPPORTS_OTLP=1
+    ;;
+  claudecode)
+    DC_DRIVER_SUPPORTS_LIFECYCLE=1
+    DC_DRIVER_SUPPORTS_BLOCK=1
+    DC_DRIVER_SUPPORTS_OTLP=1
+    ;;
+  antigravity)
+    # PreToolUse is the currently proven headless event. Antigravity has no
+    # native OTLP export in the DefenseClaw connector contract.
+    DC_DRIVER_SUPPORTS_LIFECYCLE=0
+    DC_DRIVER_SUPPORTS_BLOCK=1
+    DC_DRIVER_SUPPORTS_OTLP=0
+    ;;
+esac
+
+agent_run() {
+  local prompt="$1"
+  (
+    cd "${DC_E2E_AGENT_WORKSPACE}"
+    case "${CONNECTOR}" in
+      codex)
+        dc_timeout 180 "${DC_UPGRADE_ACTIVE_BIN}" exec --json --full-auto \
+          --skip-git-repo-check "${prompt}"
+        ;;
+      claudecode)
+        dc_timeout 180 "${DC_UPGRADE_ACTIVE_BIN}" -p "${prompt}" \
+          --output-format json --permission-mode acceptEdits --allowedTools Bash
+        ;;
+      antigravity)
+        dc_timeout 180 "${DC_UPGRADE_ACTIVE_BIN}" --print \
+          --dangerously-skip-permissions "${prompt}"
+        ;;
+    esac
+  )
+}
+
+PHASE_AGENT_FAILURE=0
+PHASE_AUTH_FAILURE=0
+dc_upgrade_run_phase() {
+  local phase="$1" binary="$2" version="$3" rc=0
+  export DC_UPGRADE_ACTIVE_BIN="${binary}"
+  export DC_E2E_AGENT_VERSION="${version}"
+  export DC_E2E_PROBE_PREFIX="${phase}"
+  DC_DRIVER_RESULT_PREFIX="${phase}:"
+  PATH="$(dirname "${binary}"):${ORIGINAL_PATH}"
+  export PATH
+  if dc_driver_run_probes "${CONNECTOR}"; then
+    rc=0
+  else
+    rc=1
+  fi
+  PHASE_AGENT_FAILURE="${DC_DRIVER_LAST_AGENT_FAILURE}"
+  PHASE_AUTH_FAILURE="${DC_DRIVER_LAST_AUTH_FAILURE}"
+  return "${rc}"
+}
+
+if dc_upgrade_run_phase baseline "${BASELINE_BIN}" "${RESOLVED_BASELINE_VERSION}"; then
+  BASELINE_STATUS="pass"
+else
+  BASELINE_STATUS="fail"
+  if [ "${PHASE_AUTH_FAILURE}" = "1" ]; then
+    CLASSIFICATION="auth_failure"
+    DETAIL="known-good baseline could not authenticate; refresh the connector login"
+    HARNESS_EXIT_CODE=3
+  elif [ "${PHASE_AGENT_FAILURE}" = "1" ]; then
+    CLASSIFICATION="baseline_failure"
+    DETAIL="known-good baseline agent failed before compatibility could be established"
+    HARNESS_EXIT_CODE=5
+  else
+    CLASSIFICATION="baseline_failure"
+    DETAIL="known-good baseline no longer passes DefenseClaw live probes"
+    HARNESS_EXIT_CODE=5
+  fi
+  exit "${HARNESS_EXIT_CODE}"
+fi
+
+# Upgrade invariant: do not call setup here. The connector config hash is
+# recorded immediately before switching executable versions as audit evidence.
+BASELINE_SETUP_HASH="$(dc_persist_sha256 "$(dc_connector_config_file "${CONNECTOR}")")"
+printf '%s\n' "${BASELINE_SETUP_HASH}" > "${ARTIFACTS_DIR}/baseline-setup-config.sha256"
+dc_log "switching to isolated candidate without re-running DefenseClaw setup"
+
+if dc_upgrade_run_phase candidate-upgrade "${CANDIDATE_BIN}" "${RESOLVED_CANDIDATE_VERSION}"; then
+  CANDIDATE_STATUS="pass"
+  CLASSIFICATION="pass"
+  DETAIL="baseline and in-place candidate upgrade probes passed"
+  HARNESS_EXIT_CODE=0
+  exit 0
+fi
+
+CANDIDATE_STATUS="fail"
+CLASSIFICATION="candidate_regression"
+DETAIL="baseline passed but candidate failed without re-running DefenseClaw setup"
+HARNESS_EXIT_CODE=2
+
+if [ "${FRESH_SETUP_ON_FAILURE}" = "1" ]; then
+  RECOVERY="attempted"
+  dc_log "candidate failed; testing explicit DefenseClaw setup as recovery"
+  if dc_upgrade_setup_without_restart "${CANDIDATE_BIN}" && \
+     PATH="$(dirname "${CANDIDATE_BIN}"):${ORIGINAL_PATH}" defenseclaw-gateway restart && \
+     PATH="$(dirname "${CANDIDATE_BIN}"):${ORIGINAL_PATH}" dc_wait_for_gateway 30; then
+    if dc_upgrade_run_phase candidate-fresh "${CANDIDATE_BIN}" "${RESOLVED_CANDIDATE_VERSION}"; then
+      FRESH_SETUP_STATUS="pass"
+      RECOVERY="fresh_setup_passed"
+      DETAIL="candidate upgrade failed with baseline wiring but passed after fresh setup"
+    else
+      FRESH_SETUP_STATUS="fail"
+      RECOVERY="fresh_setup_failed"
+      DETAIL="candidate failed both in-place upgrade and fresh-setup probes"
+    fi
+  else
+    FRESH_SETUP_STATUS="setup_failed"
+    RECOVERY="fresh_setup_failed"
+    DETAIL="candidate upgrade failed and candidate DefenseClaw setup/restart also failed"
+  fi
+fi
+
+exit 2


### PR DESCRIPTION
Base: `main`. The dedicated `defenseclaw-macos` repository runner is already registered, online, and labeled `connector-lab` + `defenseclaw-macos`.

## Problem

Codex, Claude Code, and Antigravity ship independently of DefenseClaw. A connector CLI upgrade can change its hook behavior after the currently installed version has already been validated, and the existing contract matrix does not reproduce an authenticated in-place CLI upgrade on a persistent macOS login session.

## Current Situation

- Hosted runners do not have the connector subscription logins or macOS Keychain session needed for real CLI probes.
- The existing live workflow validates connector contracts, but it does not retain a last-known-good upstream version and compare it with each newly published stable release.
- A failed login, broken host, or known-good baseline failure must not be mislabeled as an upstream connector regression.
- Global upgrades on the authenticated host would make rollback and root-cause classification unsafe.

## Solution

### Daily version radar

Add a default-branch-only scheduled workflow that queries stable upstream versions for Codex, Claude Code, and Antigravity, persists attempted/passed state on the uniquely labeled macOS runner, and schedules only releases that need testing. The last passed release remains the comparison baseline even if a globally installed CLI later auto-updates.

### Isolated authenticated A/B harness

Install exact Codex/Claude baseline and candidate versions into run-owned npm prefixes. For Antigravity, download the versioned artifact named by Google's official manifest and verify its SHA-512 before execution. Reuse the logged-in user's `HOME` only for connector authentication, while isolating DefenseClaw state, ports, workspace, sentinels, logs, and binaries.

The harness performs DefenseClaw setup against the known-good baseline once, then switches to the candidate without rerunning setup. It restores the connector config exactly and classifies outcomes as `pass`, `candidate_regression`, `auth_failure`, `infrastructure_failure`, or `baseline_failure`.

### Reporting and repair boundary

Only `candidate_regression` opens or updates a `connector-regression` issue. Auth, baseline, and infrastructure failures remain retryable and cannot trigger a fix PR. A separate scheduled Codex repair task consumes those classified artifacts and is required to reproduce, patch, and rerun the exact comparison before it may open a draft fix PR.

```mermaid
flowchart LR
    S[Daily GitHub schedule] --> R[Unique authenticated macOS runner]
    R --> V[Stable-version radar]
    V -->|new candidate| H[Isolated baseline then candidate harness]
    H -->|pass| P[Record candidate as last passed]
    H -->|candidate-only failure| I[Deduplicated regression issue]
    H -->|auth, baseline, or infrastructure failure| O[Operational failure; retry, no fix PR]
    I --> C[Daily Codex repair task]
    C -->|reproduce + patch + exact retest| D[Draft fix PR]
```

Antigravity's publisher exposes only the current artifact. If the installed `agy` has already moved beyond the stored last-passed version, the harness reports an infrastructure limitation instead of manufacturing a passing historical baseline.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `.github/workflows/connector-version-radar.yml` | Adds the default-branch-only daily/manual radar, uniquely pinned self-hosted jobs, sequential live cells, durable state handling, artifacts, and hosted issue reporting. |
| `scripts/connector-version-radar.py` | Queries installed/latest stable versions, validates semver and release metadata, persists private atomic state, and emits the GitHub matrix. |
| `scripts/live-connector-e2e/upgrade-regression.sh` | Adds the isolated baseline-to-candidate transaction and strict regression classification. |
| `scripts/live-connector-e2e/lib/persistent-macos.sh` | Adds owned locks, safe scratch cleanup, exact config snapshot/restore, fixed isolated ports, and discovery isolation. |
| `scripts/live-connector-e2e/drivers/_driver_common.sh` | Makes live probes reusable by phases, records agent/auth failures, adds a stock-macOS timeout, and verifies Antigravity release artifacts. |
| `scripts/live-connector-e2e/drivers/antigravity.sh` | Adds the real headless Antigravity PreToolUse allow/block driver. |
| `scripts/live-connector-e2e/lib/assert.sh`, `scripts/live-connector-e2e/report.py`, `scripts/live-connector-e2e/run.sh` | Keeps observability data isolated, reports candidate versions accurately, and registers Antigravity as a live-driver connector. |
| `cli/tests/test_connector_version_radar.py`, `cli/tests/test_live_connector_upgrade_harness.py` | Covers version/state semantics, last-passed baselines, workflow outputs, config restoration, lock ownership, CLI safety, and candidate-version reporting. |

## Breaking Changes

None. This adds a scheduled trusted-runner workload and test harness; it does not change public APIs, operator defaults, or connector configuration outside the harness transaction.

## Open Issues / Follow-ups

None.

## Test Plan

1. Targeted lint and unit tests:

   ```bash
   uv run --offline ruff check scripts/connector-version-radar.py scripts/live-connector-e2e/report.py cli/tests/test_connector_version_radar.py cli/tests/test_live_connector_upgrade_harness.py
   uv run --offline pytest -q cli/tests/test_connector_version_radar.py cli/tests/test_live_connector_upgrade_harness.py
   ```

   Observed: Ruff passed; `17 passed`.

2. Shell and workflow validation:

   ```bash
   bash -n scripts/live-connector-e2e/upgrade-regression.sh scripts/live-connector-e2e/lib/persistent-macos.sh scripts/live-connector-e2e/drivers/_driver_common.sh scripts/live-connector-e2e/drivers/antigravity.sh scripts/live-connector-e2e/lib/assert.sh scripts/live-connector-e2e/run.sh
   go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -ignore 'label "connector-lab" is unknown' -ignore 'label "defenseclaw-macos" is unknown' .github/workflows/connector-version-radar.yml
   git diff --check origin/main...HEAD
   ```

   Observed: all passed. The two ignored diagnostics are the repository's registered custom self-hosted labels.

3. Full connector matrix after building its required OpenClaw fixture:

   ```bash
   make plugin
   make connector-matrix-test
   ```

   Observed: all selected Go packages passed; Python reported `257 passed, 112 subtests passed`.

4. Verified Antigravity artifact install path:

   ```bash
   dc_install_antigravity_release "$tmp/release" latest
   "$binary" --version
   ```

   Observed: official manifest version `1.1.1`; verified binary version `1.1.1`.

5. Live version radar on `defenseclaw-macos`:

   ```bash
   python3 scripts/connector-version-radar.py check --state "$state" --output "$output" --force
   ```

   Observed: no infrastructure errors; Codex `0.143.0 -> 0.144.1`, Claude Code `2.1.207`, and Antigravity `1.1.1` were resolved correctly.

6. Exact authenticated Codex dry run in the macOS GUI launch session:

   ```bash
   bash scripts/live-connector-e2e/upgrade-regression.sh \
     --connector codex \
     --baseline-version 0.142.5 \
     --candidate-version 0.144.1 \
     --results "$RUNNER_TEMP/codex-upgrade-results.jsonl" \
     --classification-output "$RUNNER_TEMP/codex-upgrade-classification.json" \
     --artifacts-dir "$RUNNER_TEMP/codex-upgrade-artifacts"
   ```

   Observed: `classification=pass`, baseline `pass`, candidate `pass`, 21 result rows. Both versions fired lifecycle/tool hooks, allowed the benign tool call, blocked the policy probe, emitted native telemetry, and passed observability assertions. No Codex 0.144.1 fix PR was opened because this host did not reproduce a candidate-only regression.
