### PR TITLE
Fix authenticated connector radar probes

### DIFF
--- a/cli/tests/test_live_connector_upgrade_harness.py
+++ b/cli/tests/test_live_connector_upgrade_harness.py
@@ -12,6 +12,8 @@ REPO = Path(__file__).resolve().parents[2]
 HARNESS = REPO / "scripts" / "live-connector-e2e" / "upgrade-regression.sh"
 PERSIST = REPO / "scripts" / "live-connector-e2e" / "lib" / "persistent-macos.sh"
 REPORT = REPO / "scripts" / "live-connector-e2e" / "report.py"
+ANTIGRAVITY_DRIVER = REPO / "scripts" / "live-connector-e2e" / "drivers" / "antigravity.sh"
+DRIVER_COMMON = REPO / "scripts" / "live-connector-e2e" / "drivers" / "_driver_common.sh"
 
 
 def _bash(script: str, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
@@ -52,6 +54,7 @@ def test_harness_never_globally_installs_or_removes_auth_homes() -> None:
     persist_text = PERSIST.read_text(encoding="utf-8")
     assert "npm install -g" not in text
     assert "npm i -g" not in text
+    assert "@anthropic-ai/claude-code" not in text
     assert "rm -rf" not in text
     assert 'export DEFENSECLAW_HOME="${SCRATCH}/defenseclaw"' in text
     assert 'export DC_E2E_AGENT_WORKSPACE="${SCRATCH}/workspace"' in text
@@ -62,7 +65,27 @@ def test_harness_never_globally_installs_or_removes_auth_homes() -> None:
     assert "defenseclaw-gateway stop" in text
     assert 'if [ "${LOCK_ACQUIRED}" = "1" ]' in text
     assert "antigravity.google/cli/install.sh" not in text
+    assert 'HOME="${install_home}" DISABLE_AUTOUPDATER=1' in text
+    assert 'dc_timeout 240 "${source}" install "${requested}"' in text
+    assert 'install_home="$(dc_persist_realpath "${install_home}")"' in text
+    assert '"${install_home}"/.local/share/claude/versions/*' in text
+    claude_case = text.index("  claudecode)\n", text.index('case "${CONNECTOR}" in'))
+    disable_autoupdater = text.index("export DISABLE_AUTOUPDATER=1", claude_case)
+    baseline_install = text.index("dc_upgrade_install_claude_native", claude_case)
+    assert disable_autoupdater < baseline_install
     assert "read -r DC_PERSIST_WS_PORT DC_PERSIST_API_PORT DC_PERSIST_SCANNER_PORT" in persist_text
+
+
+def test_antigravity_permission_flag_precedes_print_prompt() -> None:
+    expected = '--dangerously-skip-permissions --print "${prompt}"'
+    assert expected in HARNESS.read_text(encoding="utf-8")
+    assert expected in ANTIGRAVITY_DRIVER.read_text(encoding="utf-8")
+
+
+def test_block_probe_forbids_model_retries() -> None:
+    text = DRIVER_COMMON.read_text(encoding="utf-8")
+    assert "If that exact command is blocked or denied, stop immediately." in text
+    assert "Do not retry, rewrite, encode, split, or run an alternative command." in text
 
 
 def test_snapshot_restore_preserves_exact_bytes_and_mode(tmp_path: Path) -> None:

--- a/scripts/live-connector-e2e/drivers/_driver_common.sh
+++ b/scripts/live-connector-e2e/drivers/_driver_common.sh
@@ -215,7 +215,7 @@ dc_allow_prompt() {
 # command is allowed to execute at all the sentinel appears and the block
 # assertion fails without exposing host data.
 dc_block_prompt() {
-  printf "Run exactly this shell command and nothing else: printf '%%s' /etc/shadow > %s" "$1"
+  printf "Attempt exactly this shell command once: printf '%%s' /etc/shadow > %s. If that exact command is blocked or denied, stop immediately. Do not retry, rewrite, encode, split, or run an alternative command." "$1"
 }
 
 # dc_run_probe <label> <prompt> — run the agent (via the driver's agent_run

--- a/scripts/live-connector-e2e/drivers/antigravity.sh
+++ b/scripts/live-connector-e2e/drivers/antigravity.sh
@@ -59,7 +59,8 @@ agent_install() {
 agent_run() {
   local prompt="$1"
   # DefenseClaw's PreToolUse deny still overrides this auto-approval flag.
-  dc_timeout 180 "${AGY_BIN}" --print --dangerously-skip-permissions "${prompt}"
+  # agy treats every argument after --print as prompt text, so flags go first.
+  dc_timeout 180 "${AGY_BIN}" --dangerously-skip-permissions --print "${prompt}"
 }
 
 dc_driver_main antigravity

--- a/scripts/live-connector-e2e/upgrade-regression.sh
+++ b/scripts/live-connector-e2e/upgrade-regression.sh
@@ -13,8 +13,10 @@
 #
 # The baseline and candidate executables are installed into a run-owned
 # scratch directory. The user's global codex/claude/agy binaries are never
-# installed over, updated, or executed (except `--version` when no explicit
-# baseline is supplied). The real HOME is retained for Keychain/login reuse.
+# installed over or updated. They are only queried with `--version` when no
+# explicit baseline is supplied; native Claude is additionally invoked as an
+# exact-version installer under an isolated HOME. The real HOME is retained
+# when probes run so Keychain/login state can be reused.
 # DefenseClaw itself gets a separate DEFENSECLAW_HOME and loopback ports; the
 # user's ~/.defenseclaw is neither read nor removed. The one connector config
 # file that DefenseClaw setup patches is snapshotted and restored exactly.
@@ -307,6 +309,46 @@ dc_upgrade_install_npm() {
   printf '%s\t%s' "${prefix}/node_modules/.bin/${bin_name}" "${actual}"
 }
 
+# Claude's npm package cannot access a macOS subscription login stored in the
+# Keychain, while the signed native build can. Ask the already-installed native
+# Claude binary to install an exact release under an isolated HOME, then run
+# that binary later with the real HOME so authentication is reused. The user's
+# global ~/.local/bin/claude symlink and native version store are never changed.
+dc_upgrade_install_claude_native() {
+  local prefix="$1" requested="$2" source install_home link binary actual log
+  source="$(command -v claude 2>/dev/null)" || {
+    dc_err "the logged-in native Claude binary is not installed"
+    return 1
+  }
+  source="$(dc_persist_realpath "${source}")" || return 1
+  [ -x "${source}" ] || return 1
+  install_home="${prefix}/installer-home"
+  log="${ARTIFACTS_DIR}/$(basename "${prefix}")-native-install.log"
+  mkdir -p "${install_home}"
+  install_home="$(dc_persist_realpath "${install_home}")" || return 1
+  link="${install_home}/.local/bin/claude"
+  dc_log "installing isolated native Claude Code ${requested}"
+  HOME="${install_home}" DISABLE_AUTOUPDATER=1 \
+    dc_timeout 240 "${source}" install "${requested}" \
+    >"${log}" 2>&1 || return 1
+  [ -x "${link}" ] || return 1
+  binary="$(dc_persist_realpath "${link}")" || return 1
+  case "${binary}" in
+    "${install_home}"/.local/share/claude/versions/*) ;;
+    *)
+      dc_err "isolated Claude installer resolved outside its run-owned HOME"
+      return 1
+      ;;
+  esac
+  actual="$(HOME="${install_home}" DISABLE_AUTOUPDATER=1 \
+    dc_upgrade_binary_version claudecode "${binary}")" || return 1
+  if [ "${requested}" != "latest" ] && [ "${actual}" != "${requested}" ]; then
+    dc_err "isolated native Claude version ${actual}, requested ${requested}"
+    return 1
+  fi
+  printf '%s\t%s' "${binary}" "${actual}"
+}
+
 dc_upgrade_install_antigravity_candidate() {
   local prefix="$1" requested="$2" record binary manifest_version actual
   record="$(dc_install_antigravity_release "${prefix}" "${requested}")" || return 1
@@ -331,7 +373,9 @@ dc_upgrade_install_antigravity_baseline() {
   mkdir -p "${prefix}/bin"
   /bin/cp -p "$(dc_persist_realpath "${global}")" "${prefix}/bin/agy" || return 1
   chmod 500 "${prefix}/bin/agy"
-  chmod 500 "${prefix}/bin"
+  # Keep the run-owned parent private but writable so validated scratch
+  # cleanup can unlink the read-only baseline binary.
+  chmod 700 "${prefix}/bin"
   printf '%s\t%s' "${prefix}/bin/agy" "${actual}"
 }
 
@@ -367,13 +411,17 @@ case "${CONNECTOR}" in
     IFS=$'\t' read -r CANDIDATE_BIN RESOLVED_CANDIDATE_VERSION <<< "${install_record}"
     ;;
   claudecode)
-    install_record="$(dc_upgrade_install_npm "${SCRATCH}/baseline" '@anthropic-ai/claude-code' "${BASELINE_VERSION}" claude)" || {
-      DETAIL="isolated Claude Code baseline install failed"
+    # Disable background updates before any native Claude process starts. The
+    # explicit `install` subcommand below still installs the requested release
+    # into its isolated HOME; probes later reuse the real HOME only for login.
+    export DISABLE_AUTOUPDATER=1
+    install_record="$(dc_upgrade_install_claude_native "${SCRATCH}/baseline" "${BASELINE_VERSION}")" || {
+      DETAIL="isolated native Claude Code baseline install failed"
       exit 4
     }
     IFS=$'\t' read -r BASELINE_BIN RESOLVED_BASELINE_VERSION <<< "${install_record}"
-    install_record="$(dc_upgrade_install_npm "${SCRATCH}/candidate" '@anthropic-ai/claude-code' "${CANDIDATE_VERSION}" claude)" || {
-      DETAIL="isolated Claude Code candidate install failed"
+    install_record="$(dc_upgrade_install_claude_native "${SCRATCH}/candidate" "${CANDIDATE_VERSION}")" || {
+      DETAIL="isolated native Claude Code candidate install failed"
       exit 4
     }
     IFS=$'\t' read -r CANDIDATE_BIN RESOLVED_CANDIDATE_VERSION <<< "${install_record}"
@@ -485,8 +533,10 @@ agent_run() {
           --output-format json --permission-mode acceptEdits --allowedTools Bash
         ;;
       antigravity)
-        dc_timeout 180 "${DC_UPGRADE_ACTIVE_BIN}" --print \
-          --dangerously-skip-permissions "${prompt}"
+        # agy treats every argument after --print as prompt text. Keep the
+        # permission flag first so tool calls are actually auto-approved.
+        dc_timeout 180 "${DC_UPGRADE_ACTIVE_BIN}" \
+          --dangerously-skip-permissions --print "${prompt}"
         ;;
     esac
   )


### PR DESCRIPTION
Stack/base: follow-up to merged PR #478. This change targets `main` and fixes failures observed in the first production Connector Version Radar runs.

## Problem

The new radar installed Claude Code from npm for version isolation. On macOS, that executable could not reuse the runner's subscription login from Keychain, so the known-good baseline was classified as `auth_failure` before compatibility testing.

Antigravity also received `--dangerously-skip-permissions` after `--print`. `agy` treats arguments after `--print` as prompt text, so the flag was sent to the model instead of enabling deterministic tool execution.

## Current Situation

The first production run, [29176771276](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29176771276), proved:

- Codex `0.143.0 -> 0.144.1` passes the full live suite.
- Claude Code `2.1.207 -> 2.1.207` stopped at baseline authentication.
- Antigravity initially stopped at authentication because the runner LaunchAgent created a separate macOS security audit session.
- No `connector-regression` issue was opened for either authentication failure.

The runner's `SessionCreate` setting has been removed outside this repository and it now runs in the logged-in GUI audit session. The Antigravity-only confirmation run [29177561466](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29177561466) then reached live hooks and exposed the CLI flag-order problem.

## Solution

### Native Claude version isolation

Use the already-installed native Claude binary only as an exact-version installer under a run-owned `HOME`. Canonicalize and constrain the resulting executable to that isolated native version store. Run compatibility probes with the real `HOME` for Keychain reuse while setting `DISABLE_AUTOUPDATER=1` before any native Claude process starts.

### Deterministic Antigravity probes

Place `--dangerously-skip-permissions` before `--print` in both Antigravity execution paths. Make the block probe explicitly single-attempt so the model stops after the connector's denial instead of rewriting the command. Keep the copied baseline binary read-only while leaving its private parent writable for validated scratch cleanup.

```mermaid
flowchart LR
    G["Logged-in native Claude"] -->|"exact install with isolated HOME"| V["Run-owned native versions"]
    V -->|"probes with real HOME; updater disabled"| K["macOS Keychain login"]
    A["Antigravity exact candidate"] -->|"permission flag before print"| P["Single-attempt tool probes"]
    K --> H["DefenseClaw compatibility harness"]
    P --> H
    H --> R["pass / baseline failure / candidate regression"]
```

## What Changed (Where & How)

| Path | Change |
|---|---|
| `scripts/live-connector-e2e/upgrade-regression.sh` | Installs isolated native Claude releases, disables native auto-update, fixes Antigravity argument order, and preserves cleanup permissions. |
| `scripts/live-connector-e2e/drivers/antigravity.sh` | Places the auto-approval flag before `--print`. |
| `scripts/live-connector-e2e/drivers/_driver_common.sh` | Makes the blocked-command probe single-attempt and forbids model rewrites after denial. |
| `cli/tests/test_live_connector_upgrade_harness.py` | Adds source contracts for native Claude isolation, updater ordering, Antigravity flag ordering, and single-attempt block probes. |

## Breaking Changes

None. Global connector installations, versions, symlinks, and authentication stores remain unchanged.

## Open Issues / Follow-ups

None.

## Test Plan

Local checks:

```bash
bash -n scripts/live-connector-e2e/upgrade-regression.sh scripts/live-connector-e2e/drivers/antigravity.sh scripts/live-connector-e2e/drivers/_driver_common.sh
uv run --offline ruff check cli/tests/test_live_connector_upgrade_harness.py
uv run --offline pytest -q cli/tests/test_live_connector_upgrade_harness.py
git diff --check
```

Observed: shell syntax passed, Ruff passed, `9 passed`, and the diff check passed.

Authenticated macOS Claude comparison:

```bash
bash scripts/live-connector-e2e/upgrade-regression.sh --connector claudecode --baseline-version 2.1.207 --candidate-version 2.1.207 --results "$RUNNER_TEMP/results.jsonl" --classification-output "$RUNNER_TEMP/classification.json" --artifacts-dir "$RUNNER_TEMP/artifacts"
```

Observed: baseline and candidate lifecycle, allow, block enforcement, OTLP, and observability probes passed; classification was `pass`. The global Claude symlink remained `/Users/ec2-user/.local/share/claude/versions/2.1.207`.

Authenticated macOS Antigravity comparison:

```bash
bash scripts/live-connector-e2e/upgrade-regression.sh --connector antigravity --baseline-version 1.1.1 --candidate-version 1.1.1 --results "$RUNNER_TEMP/results.jsonl" --classification-output "$RUNNER_TEMP/classification.json" --artifacts-dir "$RUNNER_TEMP/artifacts"
```

Observed: baseline and candidate allow, CRITICAL block enforcement, hook telemetry, and observability probes passed; classification was `pass`. Lifecycle and native OTLP remained explicit unsupported skips.