### PR TITLE
Fix runtime release metadata checks

### DIFF
--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/UpdateChecker.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/UpdateChecker.swift
@@ -73,12 +73,12 @@ actor UpdateChecker {
 
     /// Latest Mac-app release.
     func latestRelease() async -> ReleaseInfo? {
-        await fetchLatest(repo: Self.repo)
+        await fetchLatest(repo: Self.repo, requireSelfUpdateAsset: true)
     }
 
     /// Latest DefenseClaw runtime release (upstream repo).
     func latestRuntimeRelease() async -> ReleaseInfo? {
-        await fetchLatest(repo: Self.runtimeRepo)
+        await fetchLatest(repo: Self.runtimeRepo, requireSelfUpdateAsset: false)
     }
 
     /// Parse "defenseclaw, version 0.7.0"-style output into "0.7.0".
@@ -88,7 +88,7 @@ actor UpdateChecker {
         return String(output[range])
     }
 
-    private func fetchLatest(repo: String) async -> ReleaseInfo? {
+    private func fetchLatest(repo: String, requireSelfUpdateAsset: Bool) async -> ReleaseInfo? {
         guard let url = URL(string: "https://api.github.com/repos/\(repo)/releases/latest") else { return nil }
         var request = URLRequest(url: url, timeoutInterval: 10)
         request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
@@ -97,16 +97,31 @@ actor UpdateChecker {
               let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let tag = dict["tag_name"] as? String
         else { return nil }
+        return Self.releaseInfo(
+            from: dict,
+            repo: repo,
+            tag: tag,
+            requireSelfUpdateAsset: requireSelfUpdateAsset
+        )
+    }
+
+    nonisolated static func releaseInfo(
+        from dict: [String: Any],
+        repo: String,
+        tag: String,
+        requireSelfUpdateAsset: Bool
+    ) -> ReleaseInfo? {
         let assets = (dict["assets"] as? [[String: Any]]) ?? []
-        guard let zip = Self.selectSelfUpdateAsset(from: assets) else {
+        let zip = Self.selectSelfUpdateAsset(from: assets)
+        if requireSelfUpdateAsset && zip == nil {
             return nil
         }
         return ReleaseInfo(
             tag: tag,
             version: tag.hasPrefix("v") ? String(tag.dropFirst()) : tag,
-            assetName: (zip["name"] as? String) ?? "",
-            assetURL: (zip["browser_download_url"] as? String) ?? "",
-            assetSHA256: ((zip["digest"] as? String) ?? "")
+            assetName: (zip?["name"] as? String) ?? "",
+            assetURL: (zip?["browser_download_url"] as? String) ?? "",
+            assetSHA256: ((zip?["digest"] as? String) ?? "")
                 .replacingOccurrences(of: "sha256:", with: ""),
             htmlURL: (dict["html_url"] as? String) ?? "https://github.com/\(repo)/releases",
             notes: (dict["body"] as? String) ?? ""

--- a/macos/DefenseClawMac/Tests/UpdateCheckerVerificationTests.swift
+++ b/macos/DefenseClawMac/Tests/UpdateCheckerVerificationTests.swift
@@ -28,6 +28,7 @@ struct UpdateCheckerVerificationTests {
         rejectsUnverifiedSelfUpdateAssets()
         selectsVerifiedSelfUpdateAsset()
         rejectsNonAppZipAssets()
+        allowsRuntimeReleaseWithoutSelfUpdateAsset()
         print("Update checker verification tests passed")
     }
 
@@ -68,6 +69,35 @@ struct UpdateCheckerVerificationTests {
             ],
         ]
         expect(UpdateChecker.selectSelfUpdateAsset(from: assets) == nil, "runtime assets are not self-update assets")
+    }
+
+    private static func allowsRuntimeReleaseWithoutSelfUpdateAsset() {
+        let release = UpdateChecker.releaseInfo(
+            from: [
+                "html_url": "https://github.com/cisco-ai-defense/defenseclaw/releases/tag/v1.2.3",
+                "body": "Runtime-only release",
+                "assets": [
+                    [
+                        "name": "defenseclaw-1.2.3-py3-none-any.whl",
+                        "browser_download_url": "https://example.test/runtime.whl",
+                        "digest": "sha256:abc",
+                    ],
+                ],
+            ],
+            repo: "cisco-ai-defense/defenseclaw",
+            tag: "v1.2.3",
+            requireSelfUpdateAsset: false
+        )
+        expect(release?.version == "1.2.3", "runtime release metadata is preserved without an app zip")
+        expect(release?.assetName == "", "runtime release does not borrow non-app assets")
+
+        let appRelease = UpdateChecker.releaseInfo(
+            from: ["assets": []],
+            repo: "cisco-ai-defense/defenseclaw",
+            tag: "v1.2.3",
+            requireSelfUpdateAsset: true
+        )
+        expect(appRelease == nil, "app self-update still requires a verified app zip")
     }
 
     private static func expect(_ condition: @autoclosure () -> Bool, _ label: String) {

--- a/macos/DefenseClawMac/Tests/UpdateCheckerVerificationTests.swift
+++ b/macos/DefenseClawMac/Tests/UpdateCheckerVerificationTests.swift
@@ -29,6 +29,7 @@ struct UpdateCheckerVerificationTests {
         selectsVerifiedSelfUpdateAsset()
         rejectsNonAppZipAssets()
         allowsRuntimeReleaseWithoutSelfUpdateAsset()
+        returnsPopulatedReleaseInfoForAppSelfUpdate()
         print("Update checker verification tests passed")
     }
 
@@ -98,6 +99,28 @@ struct UpdateCheckerVerificationTests {
             requireSelfUpdateAsset: true
         )
         expect(appRelease == nil, "app self-update still requires a verified app zip")
+    }
+
+    private static func returnsPopulatedReleaseInfoForAppSelfUpdate() {
+        let release = UpdateChecker.releaseInfo(
+            from: [
+                "html_url": "https://github.com/cisco-ai-defense/defenseclaw/releases/tag/v1.2.3",
+                "body": "App release",
+                "assets": [
+                    [
+                        "name": "DefenseClawMac-1.2.3-macos-arm64.zip",
+                        "browser_download_url": "https://example.test/verified.zip",
+                        "digest": "sha256:def",
+                    ],
+                ],
+            ],
+            repo: "cisco-ai-defense/defenseclaw",
+            tag: "v1.2.3",
+            requireSelfUpdateAsset: true
+        )
+        expect(release?.assetName == "DefenseClawMac-1.2.3-macos-arm64.zip", "app release asset name is preserved")
+        expect(release?.assetURL == "https://example.test/verified.zip", "app release asset URL is preserved")
+        expect(release?.assetSHA256 == "def", "app release digest prefix is stripped")
     }
 
     private static func expect(_ condition: @autoclosure () -> Bool, _ label: String) {


### PR DESCRIPTION
## Problem

Fixes #481.

The macOS app's runtime update check can fail when the latest DefenseClaw runtime release does not include a verified Mac app self-update zip. That hides valid runtime updates even though `defenseclaw upgrade` does not consume the app zip.

## Current Situation

`UpdateChecker.fetchLatest(repo:)` is shared by the Mac app self-update path and the runtime update path. PR #467 made that helper require `selectSelfUpdateAsset(from:)`, which is correct for app self-updates but too strict for runtime release metadata.

## Solution

Split release metadata parsing from the self-update asset requirement. App self-update checks still require a verified `DefenseClawMac-*-macos-arm64.zip`; runtime checks can now return release metadata without borrowing runtime assets as app assets.

## Architecture Diagram

N/A

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `macos/DefenseClawMac/DefenseClawMac/DataLayer/UpdateChecker.swift` | Adds a `requireSelfUpdateAsset` switch and parser helper so only app updates require a verified app zip. |
| `macos/DefenseClawMac/Tests/UpdateCheckerVerificationTests.swift` | Adds coverage for runtime-only releases while preserving the app self-update guard. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

- `macos/DefenseClawMac/script/test_update_checker_verification.sh` - passed; output: `Update checker verification tests passed`.
