### PR TITLE
Preserve radar candidates on partial errors

### DIFF
--- a/cli/tests/test_connector_version_radar.py
+++ b/cli/tests/test_connector_version_radar.py
@@ -373,6 +373,51 @@ class ConnectorVersionRadarTests(unittest.TestCase):
         )
         self.assertEqual(json.loads(github_values["radar_json"]), stdout_payload)
 
+    def test_cli_partial_infrastructure_error_preserves_candidate_outputs(self):
+        fixture = self.root / "fixture.json"
+        github_output = self.root / "github-output.txt"
+        fixture.write_text(
+            json.dumps(
+                {
+                    "codex": {"installed": "codex-cli 0.142.5", "latest": '"0.144.1"'},
+                    "claudecode": {"installed": "2.1.207", "latest": {"error": "simulated timeout"}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            exit_code = radar.main(
+                [
+                    "check",
+                    "--state",
+                    str(self.state),
+                    "--fixture",
+                    str(fixture),
+                    "--github-output",
+                    str(github_output),
+                    "--connector",
+                    "codex",
+                    "--connector",
+                    "claudecode",
+                ]
+            )
+
+        self.assertEqual(exit_code, radar.EXIT_OK)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["status"], "infrastructure_error")
+        self.assertTrue(payload["has_candidates"])
+        self.assertEqual(payload["candidates"][0]["connector"], "codex")
+        self.assertEqual(payload["infrastructure_errors"][0]["connector"], "claudecode")
+
+        github_values = dict(
+            line.split("=", 1)
+            for line in github_output.read_text(encoding="utf-8").splitlines()
+        )
+        self.assertEqual(github_values["status"], "infrastructure_error")
+        self.assertEqual(github_values["any_new"], "true")
+        self.assertEqual(json.loads(github_values["matrix"])["include"][0]["connector"], "codex")
+
     def test_corrupt_state_returns_distinct_infrastructure_exit(self):
         self.state.write_text("not-json", encoding="utf-8")
         fixture = self.root / "fixture.json"

--- a/scripts/connector-version-radar.py
+++ b/scripts/connector-version-radar.py
@@ -762,7 +762,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             payload = infrastructure_payload(f"could not write GitHub outputs {args.github_output}: {exc}")
 
     print(json.dumps(payload, sort_keys=True))
-    return EXIT_OK if payload["status"] == "ok" else EXIT_INFRASTRUCTURE_ERROR
+    return EXIT_OK if payload["status"] == "ok" or payload.get("has_candidates") else EXIT_INFRASTRUCTURE_ERROR
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Fixes #482.

A transient infrastructure error for one connector can suppress live testing for another connector that already produced a valid candidate matrix.

## Current Situation

`scripts/connector-version-radar.py check` can emit `any_new=true` and a populated matrix while also setting `status=infrastructure_error`. The workflow detect step runs under `set -e`, so exit code 2 stops the job before the live matrix can run.

## Solution

Keep reporting the infrastructure-error status in outputs, but return success when the payload contains candidates. No-candidate infrastructure failures still return the infrastructure error exit code.

## Architecture Diagram

N/A

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `scripts/connector-version-radar.py` | Returns success for candidate-producing mixed-status runs while preserving infrastructure-error output fields. |
| `cli/tests/test_connector_version_radar.py` | Adds CLI regression coverage for a healthy candidate plus a separate connector infrastructure failure. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

- `python3 -m unittest cli.tests.test_connector_version_radar` - passed; 11 tests ran in 0.021s.
- `git diff --check` - passed with no output.
