### PR TITLE
Filter radar regression issue rows

### DIFF
--- a/cli/tests/test_live_connector_upgrade_harness.py
+++ b/cli/tests/test_live_connector_upgrade_harness.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import runpy
 import stat
@@ -181,3 +182,58 @@ def test_report_prefers_candidate_version_over_known_good_baseline() -> None:
     )
     assert versions[("codex", "macos")] == "0.144.1"
     assert failures == [("codex", "macos", "candidate-upgrade:lifecycle:fires", "hook missing")]
+
+
+def test_report_issue_rows_only_include_candidate_regressions(tmp_path: Path) -> None:
+    report_module = runpy.run_path(str(REPORT))
+    load_candidate_regression_results = report_module["load_candidate_regression_results"]
+    summarize = report_module["summarize"]
+
+    candidate = tmp_path / "connector-version-radar-codex-0.144.1"
+    auth_failure = tmp_path / "connector-version-radar-claudecode-2.1.208"
+    candidate.mkdir()
+    auth_failure.mkdir()
+    (candidate / "classification.json").write_text(
+        json.dumps({"classification": "candidate_regression"}),
+        encoding="utf-8",
+    )
+    (auth_failure / "classification.json").write_text(
+        json.dumps({"classification": "auth_failure"}),
+        encoding="utf-8",
+    )
+    (candidate / "results.jsonl").write_text(
+        json.dumps(
+            {
+                "connector": "codex",
+                "os": "macos",
+                "event": "candidate-upgrade:tool-block:enforced",
+                "status": "fail",
+                "version": "0.144.1",
+                "detail": "block verdict missing",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (auth_failure / "results.jsonl").write_text(
+        json.dumps(
+            {
+                "connector": "claudecode",
+                "os": "macos",
+                "event": "baseline:lifecycle:agent",
+                "status": "fail",
+                "version": "2.1.208",
+                "detail": "login expired",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rows = load_candidate_regression_results(tmp_path)
+    _cells, versions, failures = summarize(rows)
+
+    assert versions[("codex", "macos")] == "0.144.1"
+    assert failures == [
+        ("codex", "macos", "candidate-upgrade:tool-block:enforced", "block verdict missing")
+    ]

--- a/scripts/live-connector-e2e/report.py
+++ b/scripts/live-connector-e2e/report.py
@@ -19,9 +19,9 @@
 # and:
 #   1. Renders a connector x os x event matrix to the GitHub job summary.
 #   2. Records the resolved upstream version per connector x os.
-#   3. On ANY failing cell, builds a regression issue body and (when
-#      --open-issue is passed and gh is authenticated) opens or updates a
-#      GitHub issue labeled `connector-regression`.
+#   3. On candidate-regression classified failures, builds a regression issue
+#      body and (when --open-issue is passed and gh is authenticated) opens or
+#      updates a GitHub issue labeled `connector-regression`.
 #   4. Exits non-zero when failures exist so the report job is red — but it
 #      NEVER edits validated_versions.json or hook_contracts.json. Bumping a
 #      validated/approved version is a deliberate human action.
@@ -41,9 +41,19 @@ ISSUE_LABEL = "connector-regression"
 ISSUE_TITLE = "Connector live E2E regression"
 
 
-def load_results(results_dir: Path) -> list[dict]:
+def _path_under(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def load_results(results_dir: Path, *, roots: list[Path] | None = None) -> list[dict]:
     rows: list[dict] = []
     for path in sorted(results_dir.rglob("*.jsonl")):
+        if roots is not None and not any(_path_under(path, root) for root in roots):
+            continue
         try:
             with path.open(encoding="utf-8") as f:
                 for line in f:
@@ -57,6 +67,25 @@ def load_results(results_dir: Path) -> list[dict]:
         except OSError:
             continue
     return rows
+
+
+def candidate_regression_roots(results_dir: Path) -> list[Path]:
+    roots: list[Path] = []
+    for path in sorted(results_dir.rglob("classification.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if payload.get("classification") == "candidate_regression":
+            roots.append(path.parent)
+    return roots
+
+
+def load_candidate_regression_results(results_dir: Path) -> list[dict]:
+    roots = candidate_regression_roots(results_dir)
+    if not roots:
+        return []
+    return load_results(results_dir, roots=roots)
 
 
 def summarize(rows: list[dict]):
@@ -236,10 +265,17 @@ def main() -> int:
             print(f"[report] could not write summary: {exc}", file=sys.stderr)
 
     if failures:
-        body = build_issue_body(failures, versions, args.run_url)
-        print("\n----- regression issue body -----\n" + body, file=sys.stderr)
+        issue_failures = failures
+        issue_versions = versions
         if args.open_issue:
+            issue_rows = load_candidate_regression_results(args.results_dir)
+            _issue_cells, issue_versions, issue_failures = summarize(issue_rows)
+        body = build_issue_body(issue_failures, issue_versions, args.run_url)
+        print("\n----- regression issue body -----\n" + body, file=sys.stderr)
+        if args.open_issue and issue_failures:
             open_or_update_issue(body, args.run_url)
+        elif args.open_issue:
+            print("[report] no candidate-regression failures to file.", file=sys.stderr)
         return 1
 
     print("[report] all cells green.")


### PR DESCRIPTION
## Problem

Fixes #480.

The connector-version radar can open a connector-regression issue that mixes true candidate regressions with unrelated auth, baseline, or infrastructure failures from other connector artifacts in the same workflow run.

## Current Situation

The workflow enables one global `--open-issue` flag when any `classification.json` reports `candidate_regression`. `report.py` then builds the issue body from every failing JSONL row under `radar-results`, regardless of each artifact's classification.

## Solution

Keep the broad job summary and failing report status across all result rows, but filter issue rows to artifact directories whose `classification.json` is `candidate_regression` before opening/updating the connector-regression issue.

## Architecture Diagram

N/A

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `scripts/live-connector-e2e/report.py` | Adds candidate-regression artifact discovery and uses it to scope issue body creation when `--open-issue` is set. |
| `cli/tests/test_live_connector_upgrade_harness.py` | Adds regression coverage proving auth-failure rows are excluded from issue rows when a candidate-regression artifact is present. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

- `pytest -q cli/tests/test_live_connector_upgrade_harness.py` - passed; 8 tests ran in 0.45s.
- `git diff --check` - passed with no output.
