### PR TITLE
fix(release): avoid admin-only immutable preflight

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,11 @@ on:
         description: "Version to release (X.Y.Z, no v prefix). Tag must not already exist."
         required: true
         type: string
+      immutable_releases_confirmed:
+        description: "Confirm repository release immutability is enabled in Settings."
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -57,12 +62,15 @@ jobs:
 
       - name: Require immutable GitHub releases
         env:
-          GH_TOKEN: ${{ github.token }}
+          IMMUTABLE_RELEASES_CONFIRMED: ${{ inputs.immutable_releases_confirmed }}
         run: |
           set -euo pipefail
-          enabled="$(gh api "repos/$GITHUB_REPOSITORY/immutable-releases" --jq .enabled)"
-          if [[ "$enabled" != "true" ]]; then
-            echo "::error title=Immutable Releases required::Enable release immutability before cutting a release."
+          # GitHub's immutable-release settings endpoint requires repository
+          # Administration: read, which is not available to GITHUB_TOKEN. Keep
+          # this preflight fail-closed without introducing an administrator PAT;
+          # the publish job separately proves the resulting release is immutable.
+          if [[ "$IMMUTABLE_RELEASES_CONFIRMED" != "true" ]]; then
+            echo "::error title=Immutable Releases confirmation required::Verify repository release immutability in Settings, then confirm it when dispatching the workflow."
             exit 1
           fi
 

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -61,11 +61,28 @@ def test_release_is_manual_and_default_permissions_are_read_only() -> None:
                     "description": "Version to release (X.Y.Z, no v prefix). Tag must not already exist.",
                     "required": "true",
                     "type": "string",
-                }
+                },
+                "immutable_releases_confirmed": {
+                    "description": "Confirm repository release immutability is enabled in Settings.",
+                    "required": "true",
+                    "type": "boolean",
+                    "default": "false",
+                },
             }
         }
     }
     assert workflow["permissions"] == {"contents": "read"}
+
+
+def test_release_immutability_preflight_uses_operator_confirmation_without_admin_token() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'repos/$GITHUB_REPOSITORY/immutable-releases' not in text
+    assert "IMMUTABLE_RELEASES_CONFIRMED" in text
+    assert "inputs.immutable_releases_confirmed" in text
+    assert "Immutable Releases confirmation required" in text
+    assert "--json tagName,isDraft,isImmutable,assets" in text
+    assert "scripts/release_candidate.py verify-published" in text
 
 
 def test_release_automation_never_publishes_runtime_to_python_package_indexes() -> None:


### PR DESCRIPTION
Focused follow-up to #451 against `main`. Squash merge this fix, then dispatch a **new** `0.8.4` Release run before merging any v8 work. The failed run is pinned to the old workflow and must not be rerun.

## Problem

Release run [29207208797](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29207208797) failed before building anything. Its immutable-release preflight called:

```text
GET /repos/cisco-ai-defense/defenseclaw/immutable-releases
```

with `${{ github.token }}`, and GitHub returned `403 Resource not accessible by integration`.

GitHub requires repository `Administration: read` for that endpoint, but `Administration` is not an available `GITHUB_TOKEN` workflow permission. Increasing `contents` permissions cannot make the call succeed. [GitHub endpoint permissions](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#check-if-immutable-releases-are-enabled-for-a-repository), [GITHUB_TOKEN guidance](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token#granting-additional-permissions).

## Current Situation

Repository release immutability is already enabled. The failed run created no tag, release, Actions artifact, candidate, or uploaded asset; every downstream build/test/publish job was skipped.

The workflow already proves `isImmutable == true` after publication and verifies the exact published asset custody. The broken admin-only API call was an additional pre-publish check that could never run with the deliberately least-privileged Actions token.

## Solution

### Fail-closed operator confirmation

Add a required boolean `workflow_dispatch` input, defaulting to `false`. The release preflight exits unless the trusted dispatcher explicitly confirms that repository release immutability is enabled.

### Preserve machine-verifiable publication proof

Keep the existing post-publish `isImmutable` and sealed-asset verification unchanged. No administrator PAT, GitHub App, repository secret, release-environment change, or repository-setting mutation is introduced.

```mermaid
flowchart LR
    D["Manual dispatch: version + confirmation"] --> P{"Confirmation true?"}
    P -->|no| F["Fail before build or mutation"]
    P -->|yes| G["Build, seal, and run native gates"]
    G --> R["Publish draft and assets"]
    R --> I{"GitHub reports isImmutable"}
    I -->|no| X["Fail custody proof"]
    I -->|yes| S["Release succeeds"]
```

## What Changed (Where & How)

| Path | Change |
|---|---|
| `.github/workflows/release.yaml` | Replaces the impossible admin API call with the required fail-closed dispatch confirmation while retaining post-publish immutability proof. |
| `cli/tests/test_release_workflow_staged.py` | Locks the new input contract, rejects reintroduction of the admin endpoint, and requires the downstream `isImmutable` verification to remain. |

## Breaking Changes

- Release dispatchers must check `immutable_releases_confirmed` when starting a release.
- There is no DefenseClaw runtime, configuration, installer, artifact, or upgrade-protocol behavior change.

## Open Issues / Follow-ups

None.

## Test Plan

```bash
python -m pytest -q \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_release_invariants.py

python -m pytest -q \
  cli/tests/test_release_candidate.py \
  cli/tests/test_release_workflow_staged.py

python scripts/source_release_identity.py check --expected-release 0.8.4
ruff check cli/tests/test_release_workflow_staged.py
git diff --check
```

Observed results:

- Workflow and invariant tests: **32 passed**.
- Release-candidate and workflow tests: **104 passed**.
- Source identity: `0.8.4 / source epoch 1 / runtime config 7`.
- Workflow YAML/input validation, Ruff, and `git diff --check`: passed.
- Targeted Claude Opus/high review: no blockers or regressions; ship verdict.
- Failed-run state audit: no `0.8.4` tag, release, artifact, candidate, or uploaded asset exists.
