### PR TITLE
fix(release): allow explicit unverified macOS artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -375,7 +375,7 @@ jobs:
           compression-level: 0
 
   macos-app:
-    name: Build and notarize unified macOS app
+    name: Build and conditionally notarize unified macOS app
     needs: [release-preflight, build-runtime-candidate]
     runs-on: macos-15
     environment: release
@@ -427,18 +427,29 @@ jobs:
           MACOS_NOTARY_KEY_BASE64: ${{ secrets.MACOS_NOTARY_KEY_BASE64 }}
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
-          MACOS_REQUIRE_NOTARIZATION: "true"
+          # The build script notarizes when all five Apple credentials exist,
+          # emits explicitly suffixed ad-hoc assets when none exist, and rejects
+          # partial or invalid credential sets.
+          MACOS_REQUIRE_NOTARIZATION: "false"
           MACOS_GATEWAY_INPUT: ${{ github.workspace }}/macos-runtime/defenseclaw
         run: scripts/build-macos-app-release.sh "$RELEASE_VERSION" macos-candidate
 
-      - name: Refuse unnotarized production assets
+      - name: Require explicit macOS trust status
         env:
           VERIFICATION_STATUS: ${{ steps.app.outputs.verification_status }}
         run: |
-          if [[ "$VERIFICATION_STATUS" != "notarized" ]]; then
-            echo "::error title=macOS notarization required::status=$VERIFICATION_STATUS"
-            exit 1
-          fi
+          case "$VERIFICATION_STATUS" in
+            notarized)
+              echo "Developer ID signed and notarized macOS assets are ready."
+              ;;
+            unverified)
+              echo "::warning title=Unverified macOS assets::Apple credentials are unavailable; publishing only explicitly suffixed -unverified app assets."
+              ;;
+            *)
+              echo "::error title=Invalid macOS trust status::status=$VERIFICATION_STATUS"
+              exit 1
+              ;;
+          esac
 
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
@@ -646,7 +657,10 @@ jobs:
           import json
           import sys
 
-          from scripts.release_candidate import published_asset_names
+          from scripts.release_candidate import (
+              MACOS_VERIFICATION_STATUSES,
+              published_asset_names,
+          )
 
           expected, path = sys.argv[1:]
           with open(path, encoding="utf-8") as handle:
@@ -656,11 +670,21 @@ jobs:
           if release.get("isImmutable") is not True:
               raise SystemExit("required bridge release is not immutable")
           names = {item.get("name") for item in release.get("assets", []) if isinstance(item, dict)}
-          required = set(published_asset_names(expected))
-          missing = sorted(required - names)
-          if missing:
-              raise SystemExit(f"required bridge release is incomplete: {missing}")
-          print(f"immutable published bridge verified: {expected}")
+          variants = {
+              status: set(published_asset_names(expected, status))
+              for status in MACOS_VERIFICATION_STATUSES
+          }
+          matches = [status for status, required in variants.items() if names == required]
+          if len(matches) != 1:
+              missing = {
+                  status: sorted(required - names)
+                  for status, required in variants.items()
+              }
+              raise SystemExit(
+                  "required bridge release does not match one complete reviewed asset set: "
+                  f"missing={missing} unexpected={sorted(names - set().union(*variants.values()))}"
+              )
+          print(f"immutable published bridge verified: {expected} ({matches[0]})")
           PY
 
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/cli/tests/test_release_candidate.py
+++ b/cli/tests/test_release_candidate.py
@@ -400,27 +400,34 @@ def _runtime_dir(tmp_path: Path) -> Path:
     return runtime
 
 
-def _macos_dir(tmp_path: Path) -> Path:
+def _macos_dir(tmp_path: Path, macos_verification_status: str = "notarized") -> Path:
     macos = tmp_path / "macos"
     macos.mkdir()
-    (macos / f"DefenseClawMac-{VERSION}-macos-arm64.dmg").write_bytes(b"candidate dmg")
-    _write_zip(
-        macos / f"DefenseClawMac-{VERSION}-macos-arm64.zip",
-        "DefenseClawMac.app/Contents/Info.plist",
-        b"candidate app",
-    )
+    for name in release_candidate.macos_asset_names(VERSION, macos_verification_status):
+        path = macos / name
+        if name.endswith(".dmg"):
+            path.write_bytes(b"candidate dmg")
+        else:
+            _write_zip(
+                path,
+                "DefenseClawMac.app/Contents/Info.plist",
+                b"candidate app",
+            )
     return macos
 
 
-def _sealed_candidate(tmp_path: Path) -> Path:
+def _sealed_candidate(
+    tmp_path: Path,
+    macos_verification_status: str = "notarized",
+) -> Path:
     root = tmp_path / "candidate"
     release_candidate.assemble(
         _runtime_dir(tmp_path),
-        _macos_dir(tmp_path),
+        _macos_dir(tmp_path, macos_verification_status),
         root,
         VERSION,
         COMMIT,
-        "notarized",
+        macos_verification_status,
     )
     (root / "dist/checksums.txt.sig").write_bytes(b"sigstore signature")
     (root / "dist/checksums.txt.pem").write_bytes(b"sigstore certificate")
@@ -434,14 +441,63 @@ def test_candidate_seals_and_verifies_exact_publish_set(tmp_path: Path) -> None:
     release_candidate.verify(root, VERSION, COMMIT)
 
     manifest = json.loads((root / "release-candidate.json").read_text(encoding="utf-8"))
-    assert [item["name"] for item in manifest["assets"]] == list(release_candidate.published_asset_names(VERSION))
+    assert [item["name"] for item in manifest["assets"]] == list(
+        release_candidate.published_asset_names(VERSION, "notarized")
+    )
     checksums = release_candidate._parse_checksums(root / "dist/checksums.txt")
-    assert tuple(sorted(checksums)) == release_candidate.payload_asset_names(VERSION)
+    assert tuple(sorted(checksums)) == release_candidate.payload_asset_names(
+        VERSION, "notarized"
+    )
     for name in release_candidate.resolver_asset_names(VERSION):
         assert (root / "dist" / name).read_bytes() == (release_candidate.RESOLVER_ASSET_SOURCES[name].read_bytes())
     assert (root / "RELEASE_NOTES.md").read_text(encoding="utf-8") == "# Candidate notes\n"
 
     release_json = tmp_path / "published.json"
+    release_json.write_text(
+        json.dumps(
+            {
+                "tagName": VERSION,
+                "isDraft": False,
+                "isImmutable": True,
+                "assets": [
+                    {
+                        "name": item["name"],
+                        "digest": f"sha256:{item['sha256']}",
+                    }
+                    for item in manifest["assets"]
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    release_candidate.verify_published_release(root, release_json, VERSION, COMMIT)
+
+
+def test_candidate_seals_and_verifies_explicit_unverified_macos_assets(
+    tmp_path: Path,
+) -> None:
+    root = _sealed_candidate(tmp_path, "unverified")
+
+    release_candidate.verify(root, VERSION, COMMIT)
+
+    manifest = json.loads((root / "release-candidate.json").read_text(encoding="utf-8"))
+    expected_names = release_candidate.published_asset_names(VERSION, "unverified")
+    assert manifest["macos_verification_status"] == "unverified"
+    assert [item["name"] for item in manifest["assets"]] == list(expected_names)
+    assert release_candidate.macos_asset_names(VERSION, "unverified") == (
+        f"DefenseClawMac-{VERSION}-macos-arm64-unverified.dmg",
+        f"DefenseClawMac-{VERSION}-macos-arm64-unverified.zip",
+    )
+    assert not any(
+        name in expected_names
+        for name in release_candidate.macos_asset_names(VERSION, "notarized")
+    )
+    checksums = release_candidate._parse_checksums(root / "dist/checksums.txt")
+    assert tuple(sorted(checksums)) == release_candidate.payload_asset_names(
+        VERSION, "unverified"
+    )
+
+    release_json = tmp_path / "published-unverified.json"
     release_json.write_text(
         json.dumps(
             {
@@ -749,16 +805,62 @@ def test_candidate_verification_rejects_unsealed_directory(tmp_path: Path) -> No
         release_candidate.verify(root, VERSION, COMMIT)
 
 
-def test_candidate_assembly_requires_notarized_macos_artifacts(tmp_path: Path) -> None:
-    with pytest.raises(release_candidate.CandidateError, match="requires a notarized macOS app"):
+@pytest.mark.parametrize("status", ["", "adhoc", "signed-unnotarized"])
+def test_candidate_assembly_rejects_unsupported_macos_status(
+    tmp_path: Path,
+    status: str,
+) -> None:
+    with pytest.raises(release_candidate.CandidateError, match="verification status"):
         release_candidate.assemble(
             _runtime_dir(tmp_path),
             _macos_dir(tmp_path),
             tmp_path / "candidate",
             VERSION,
             COMMIT,
-            "adhoc",
+            status,
         )
+
+
+def test_candidate_assembly_rejects_macos_names_that_disagree_with_status(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(release_candidate.CandidateError, match="missing regular file"):
+        release_candidate.assemble(
+            _runtime_dir(tmp_path),
+            _macos_dir(tmp_path),
+            tmp_path / "candidate",
+            VERSION,
+            COMMIT,
+            "unverified",
+        )
+
+
+def test_candidate_assembly_rejects_mixed_macos_asset_sets(tmp_path: Path) -> None:
+    macos = _macos_dir(tmp_path, "unverified")
+    (macos / f"DefenseClawMac-{VERSION}-macos-arm64.dmg").write_bytes(b"unexpected")
+
+    with pytest.raises(release_candidate.CandidateError, match="does not match"):
+        release_candidate.assemble(
+            _runtime_dir(tmp_path),
+            macos,
+            tmp_path / "candidate",
+            VERSION,
+            COMMIT,
+            "unverified",
+        )
+
+
+def test_candidate_verification_binds_unverified_names_to_unverified_status(
+    tmp_path: Path,
+) -> None:
+    root = _sealed_candidate(tmp_path, "unverified")
+    manifest_path = root / "release-candidate.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["macos_verification_status"] = "notarized"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(release_candidate.CandidateError, match="missing regular file"):
+        release_candidate.verify(root, VERSION, COMMIT)
 
 
 def test_runtime_verification_rejects_mismatched_upgrade_manifest(tmp_path: Path) -> None:

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -250,6 +250,40 @@ def test_macos_app_consumes_and_validates_sealed_runtime_gateway() -> None:
     assert "gateway candidate version mismatch" in text
 
 
+def test_release_conditionally_notarizes_or_publishes_explicit_unverified_assets() -> None:
+    workflow = _workflow()
+    macos_job = workflow["jobs"]["macos-app"]
+    build_step = next(
+        step
+        for step in macos_job["steps"]
+        if step.get("name") == "Build, sign, notarize, and package app"
+    )
+    assert build_step["env"]["MACOS_REQUIRE_NOTARIZATION"] == "false"
+
+    rendered = str(macos_job)
+    for secret in (
+        "MACOS_DEVELOPER_ID_P12_BASE64",
+        "MACOS_DEVELOPER_ID_P12_PASSWORD",
+        "MACOS_NOTARY_KEY_BASE64",
+        "MACOS_NOTARY_KEY_ID",
+        "MACOS_NOTARY_ISSUER_ID",
+    ):
+        assert f"secrets.{secret}" in rendered
+    assert "notarized)" in rendered
+    assert "unverified)" in rendered
+    assert "explicitly suffixed -unverified app assets" in rendered
+    assert "signed-unnotarized)" not in rendered
+
+    release_text = WORKFLOW.read_text(encoding="utf-8")
+    assert "MACOS_VERIFICATION_STATUSES" in release_text
+    assert "names == required" in release_text
+
+    build_text = MACOS_BUILD.read_text(encoding="utf-8")
+    assert 'VERIFICATION_STATUS="unverified"' in build_text
+    assert '[[ "${VERIFICATION_STATUS}" != "notarized" ]]' in build_text
+    assert '[[ "${VERIFICATION_STATUS}" != "unverified" ]]' in build_text
+
+
 def test_posix_installer_cannot_bypass_upgrade_graph_on_existing_install() -> None:
     text = POSIX_INSTALLER.read_text(encoding="utf-8")
     assert "An existing DefenseClaw installation was detected. No changes were made." in text
@@ -291,7 +325,7 @@ def test_upgrade_matrix_is_manifest_and_reviewed_data_driven() -> None:
     assert "auto_bridge_from does not match the reviewed pre-bridge matrix" in text
     assert "Require immutable published bridge" in text
     assert 'release.get("isImmutable") is not True' in text
-    assert "set(published_asset_names(expected))" in text
+    assert "published_asset_names(expected, status)" in text
     assert not re.search(r"\b0\.8\.[45]\b", text)
 
 

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/UpdateChecker.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/UpdateChecker.swift
@@ -116,13 +116,14 @@ actor UpdateChecker {
         requireSelfUpdateAsset: Bool
     ) -> ReleaseInfo? {
         let assets = (dict["assets"] as? [[String: Any]]) ?? []
-        let zip = Self.selectSelfUpdateAsset(from: assets)
+        let version = tag.hasPrefix("v") ? String(tag.dropFirst()) : tag
+        let zip = Self.selectSelfUpdateAsset(from: assets, version: version)
         if requireSelfUpdateAsset && zip == nil {
             return nil
         }
         return ReleaseInfo(
             tag: tag,
-            version: tag.hasPrefix("v") ? String(tag.dropFirst()) : tag,
+            version: version,
             assetName: (zip?["name"] as? String) ?? "",
             assetURL: (zip?["browser_download_url"] as? String) ?? "",
             assetSHA256: ((zip?["digest"] as? String) ?? "")
@@ -132,13 +133,17 @@ actor UpdateChecker {
         )
     }
 
-    nonisolated static func selectSelfUpdateAsset(from assets: [[String: Any]]) -> [String: Any]? {
+    nonisolated static func isEligibleSelfUpdateAsset(name: String, version: String) -> Bool {
+        name == "DefenseClawMac-\(version)-macos-arm64.zip"
+    }
+
+    nonisolated static func selectSelfUpdateAsset(
+        from assets: [[String: Any]],
+        version: String
+    ) -> [String: Any]? {
         assets.first {
             let name = ($0["name"] as? String) ?? ""
-            return name.hasPrefix("DefenseClawMac-")
-                && name.contains("-macos-arm64")
-                && name.hasSuffix(".zip")
-                && !name.contains("-unverified")
+            return Self.isEligibleSelfUpdateAsset(name: name, version: version)
         }
     }
 
@@ -159,6 +164,9 @@ actor UpdateChecker {
     func downloadAndInstall(_ release: ReleaseInfo, progress: @Sendable @escaping (UpgradeState) -> Void) async -> String? {
         guard Self.isNewer(release.version, than: Self.currentVersion) else {
             return "Refusing to install version \(release.version) over \(Self.currentVersion)."
+        }
+        guard Self.isEligibleSelfUpdateAsset(name: release.assetName, version: release.version) else {
+            return "The release asset is not the exact verified macOS app update for \(release.version)."
         }
         guard let assetURL = URL(string: release.assetURL), !release.assetURL.isEmpty else {
             return "The latest release has no downloadable zip asset."

--- a/macos/DefenseClawMac/README.md
+++ b/macos/DefenseClawMac/README.md
@@ -38,11 +38,11 @@ The app inside the DMG contains an embedded `Contents/Resources/RuntimePayload` 
 
 On first run, the app installs that payload into the user's normal DefenseClaw locations. It can download Python dependencies from PyPI and install `uv` or Python if they are missing, so the installer is unified but not fully offline. Configuration, tokens, and the audit database are preserved during install or repair.
 
-The production GitHub release workflow defaults to failing closed unless the macOS app is Developer ID signed and notarized. Local builds without Apple credentials may still produce clearly labeled `-unverified` artifacts for manual testing, but the in-app self-updater ignores them and always requires code-signature and Gatekeeper validation.
+The production GitHub release workflow Developer ID signs and notarizes the macOS app when all Apple credentials are configured. Without Apple credentials it publishes only clearly labeled `-unverified` artifacts; the in-app self-updater ignores those assets and always requires code-signature and Gatekeeper validation. Partial or invalid Apple credentials fail the build.
 
 Before extracting an accepted update ZIP, the app verifies its GitHub-provided SHA-256 digest and inspects the archive manifest. It rejects empty archives, absolute or traversal paths, link entries, multiple app bundles, and content outside one top-level `.app`. After extraction it validates the bundle identity, version, runtime boundary, code signature, and Gatekeeper assessment before replacing the running app.
 
-### Production Apple verification
+### Optional production Apple verification
 
 Add these secrets to the GitHub `release` environment:
 
@@ -53,7 +53,7 @@ Add these secrets to the GitHub `release` environment:
 - `MACOS_NOTARY_KEY_ID`: App Store Connect API key ID.
 - `MACOS_NOTARY_ISSUER_ID`: App Store Connect issuer ID.
 
-All signing and notary values must be present to remove the `-unverified` suffix. Certificates are imported into a temporary keychain, sensitive temporary files are removed on exit, and the original user keychain search list is restored.
+Provide either all five required signing/notary values or none. A complete valid set removes the `-unverified` suffix after successful notarization; no credentials produce ad-hoc-signed, explicitly unverified artifacts; partial or invalid credentials fail. Certificates are imported into a temporary keychain, sensitive temporary files are removed on exit, and the original user keychain search list is restored.
 
 ## Requirements
 
@@ -79,7 +79,7 @@ make dist-cli
 make macos-app-release
 ```
 
-The last target writes the unified DMG and app-only update zip to `dist/`. A local invocation without Apple credentials produces ad-hoc artifacts carrying the `-unverified` suffix; the production release workflow sets `MACOS_REQUIRE_NOTARIZATION=true` and refuses that fallback.
+The last target writes the unified DMG and app-only update zip to `dist/`. Local and production invocations without Apple credentials produce ad-hoc artifacts carrying the `-unverified` suffix. Supplying the complete credential set automatically signs and notarizes the same artifacts instead.
 
 ## Runtime connections
 

--- a/macos/DefenseClawMac/Tests/UpdateCheckerVerificationTests.swift
+++ b/macos/DefenseClawMac/Tests/UpdateCheckerVerificationTests.swift
@@ -27,6 +27,7 @@ struct UpdateCheckerVerificationTests {
     static func main() {
         rejectsUnverifiedSelfUpdateAssets()
         selectsVerifiedSelfUpdateAsset()
+        rejectsQualifiedAndMismatchedSelfUpdateAssets()
         rejectsNonAppZipAssets()
         allowsRuntimeReleaseWithoutSelfUpdateAsset()
         returnsPopulatedReleaseInfoForAppSelfUpdate()
@@ -41,7 +42,10 @@ struct UpdateCheckerVerificationTests {
                 "digest": "sha256:abc",
             ],
         ]
-        expect(UpdateChecker.selectSelfUpdateAsset(from: assets) == nil, "unverified app zip is not eligible")
+        expect(
+            UpdateChecker.selectSelfUpdateAsset(from: assets, version: "1.2.3") == nil,
+            "unverified app zip is not eligible"
+        )
     }
 
     private static func selectsVerifiedSelfUpdateAsset() {
@@ -57,8 +61,20 @@ struct UpdateCheckerVerificationTests {
                 "digest": "sha256:def",
             ],
         ]
-        let selected = UpdateChecker.selectSelfUpdateAsset(from: assets)
+        let selected = UpdateChecker.selectSelfUpdateAsset(from: assets, version: "1.2.3")
         expect(selected?["name"] as? String == "DefenseClawMac-1.2.3-macos-arm64.zip", "verified app zip is selected")
+    }
+
+    private static func rejectsQualifiedAndMismatchedSelfUpdateAssets() {
+        let assets: [[String: Any]] = [
+            ["name": "DefenseClawMac-1.2.3-macos-arm64-preview.zip"],
+            ["name": "DefenseClawMac-9.9.9-macos-arm64.zip"],
+            ["name": "DefenseClawMac-1.2.3-MACOS-arm64.zip"],
+        ]
+        expect(
+            UpdateChecker.selectSelfUpdateAsset(from: assets, version: "1.2.3") == nil,
+            "only the exact versioned canonical app zip is eligible"
+        )
     }
 
     private static func rejectsNonAppZipAssets() {
@@ -69,7 +85,10 @@ struct UpdateCheckerVerificationTests {
                 "digest": "sha256:abc",
             ],
         ]
-        expect(UpdateChecker.selectSelfUpdateAsset(from: assets) == nil, "runtime assets are not self-update assets")
+        expect(
+            UpdateChecker.selectSelfUpdateAsset(from: assets, version: "1.2.3") == nil,
+            "runtime assets are not self-update assets"
+        )
     }
 
     private static func allowsRuntimeReleaseWithoutSelfUpdateAsset() {

--- a/macos/DefenseClawMac/UPDATING.md
+++ b/macos/DefenseClawMac/UPDATING.md
@@ -110,7 +110,7 @@ Confirm the app-only ZIP contains exactly one top-level `.app` bundle and no abs
 
 The first-run runtime installer pins its fallback `uv` download by version and SHA-256 in `RuntimeInstaller.swift`. When updating that pin, use an immutable `astral-sh/uv` release, copy the Apple Silicon archive digest from the release asset, and verify the archive locally before changing both constants together.
 
-Production releases must publish verified macOS app-update assets. Configure all five release-environment secrets together (`MACOS_DEVELOPER_ID_P12_BASE64`, `MACOS_DEVELOPER_ID_P12_PASSWORD`, `MACOS_NOTARY_KEY_BASE64`, `MACOS_NOTARY_KEY_ID`, and `MACOS_NOTARY_ISSUER_ID`). The release workflow defaults `MACOS_REQUIRE_NOTARIZATION=true`, so missing credentials fail the build instead of publishing self-update assets that bypass Developer ID and Gatekeeper verification. Partial credentials fail the build as well.
+Production releases publish verified macOS app-update assets when all five release-environment secrets are configured together (`MACOS_DEVELOPER_ID_P12_BASE64`, `MACOS_DEVELOPER_ID_P12_PASSWORD`, `MACOS_NOTARY_KEY_BASE64`, `MACOS_NOTARY_KEY_ID`, and `MACOS_NOTARY_ISSUER_ID`). With none configured, the workflow publishes only ad-hoc-signed `-unverified` assets, which the in-app self-updater rejects. Partial or invalid credentials fail the build rather than silently downgrading a configured signing path.
 
 ## 5. Review before merging
 

--- a/scripts/build-macos-app-release.sh
+++ b/scripts/build-macos-app-release.sh
@@ -161,7 +161,7 @@ rm -rf "${WORK}"
 mkdir -p "${WORK}" "${PLAIN_STAGE}" "${UNIFIED_STAGE}" "${OUT_DIR}"
 
 SIGNING_IDENTITY="-"
-VERIFICATION_STATUS="adhoc"
+VERIFICATION_STATUS="unverified"
 
 APPLE_CREDENTIAL_VALUES=(
     "${MACOS_DEVELOPER_ID_P12_BASE64:-}"
@@ -423,6 +423,17 @@ if [[ "${NOTARY_READY}" == "1" ]]; then
     xcrun stapler validate "${TEMP_DMG}"
     spctl -a -t open --context context:primary-signature -vv "${TEMP_DMG}"
     VERIFICATION_STATUS="notarized"
+fi
+
+if (( APPLE_CREDENTIAL_COUNT == ${#APPLE_CREDENTIAL_VALUES[@]} )) \
+    && [[ "${VERIFICATION_STATUS}" != "notarized" ]]; then
+    echo "complete Apple credentials were configured, but signing and notarization did not complete" >&2
+    exit 1
+fi
+if (( APPLE_CREDENTIAL_COUNT == 0 )) \
+    && [[ "${VERIFICATION_STATUS}" != "unverified" ]]; then
+    echo "credential-free macOS builds must remain explicitly unverified" >&2
+    exit 1
 fi
 
 if [[ "${VERIFICATION_STATUS}" == "notarized" ]]; then

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -69,6 +69,7 @@ RESOLVER_ASSET_SOURCES = {
     "defenseclaw-upgrade.ps1": ROOT / "scripts" / "upgrade.ps1",
 }
 MAX_RESOLVER_BYTES = 4 * 1024 * 1024
+MACOS_VERIFICATION_STATUSES = ("notarized", "unverified")
 
 
 class CandidateError(RuntimeError):
@@ -175,11 +176,25 @@ def runtime_asset_names(version: str) -> tuple[str, ...]:
     )
 
 
-def macos_asset_names(version: str) -> tuple[str, ...]:
+def _validate_macos_verification_status(status: object) -> str:
+    if not isinstance(status, str) or status not in MACOS_VERIFICATION_STATUSES:
+        raise CandidateError(
+            "macOS verification status must be exactly one of "
+            f"{MACOS_VERIFICATION_STATUSES!r}, got {status!r}"
+        )
+    return status
+
+
+def macos_asset_names(
+    version: str,
+    macos_verification_status: str,
+) -> tuple[str, ...]:
     _validate_version(version)
+    status = _validate_macos_verification_status(macos_verification_status)
+    suffix = "" if status == "notarized" else "-unverified"
     return (
-        f"DefenseClawMac-{version}-macos-arm64.dmg",
-        f"DefenseClawMac-{version}-macos-arm64.zip",
+        f"DefenseClawMac-{version}-macos-arm64{suffix}.dmg",
+        f"DefenseClawMac-{version}-macos-arm64{suffix}.zip",
     )
 
 
@@ -190,23 +205,29 @@ def resolver_asset_names(version: str) -> tuple[str, ...]:
     return tuple(sorted(RESOLVER_ASSET_SOURCES))
 
 
-def payload_asset_names(version: str) -> tuple[str, ...]:
+def payload_asset_names(
+    version: str,
+    macos_verification_status: str,
+) -> tuple[str, ...]:
     return tuple(
         sorted(
             (
                 *runtime_asset_names(version),
-                *macos_asset_names(version),
+                *macos_asset_names(version, macos_verification_status),
                 *resolver_asset_names(version),
             )
         )
     )
 
 
-def published_asset_names(version: str) -> tuple[str, ...]:
+def published_asset_names(
+    version: str,
+    macos_verification_status: str,
+) -> tuple[str, ...]:
     return tuple(
         sorted(
             (
-                *payload_asset_names(version),
+                *payload_asset_names(version, macos_verification_status),
                 "checksums.txt",
                 "checksums.txt.pem",
                 "checksums.txt.sig",
@@ -2607,22 +2628,27 @@ def assemble(
 ) -> None:
     _validate_version(version)
     _validate_commit(commit)
-    if macos_verification_status != "notarized":
-        raise CandidateError(
-            "production release candidate requires a notarized macOS app; "
-            f"got {macos_verification_status!r}"
-        )
+    macos_verification_status = _validate_macos_verification_status(
+        macos_verification_status
+    )
     if root.exists():
         raise CandidateError(f"candidate output already exists: {root}")
 
     verify_runtime(runtime_dir, version)
     _validate_gateway_archives(runtime_dir, version, commit=commit)
-    _require_regular_files(macos_dir, macos_asset_names(version), "macOS artifact")
+    macos_names = macos_asset_names(version, macos_verification_status)
+    _require_regular_files(macos_dir, macos_names, "macOS artifact")
+    actual_macos_names = _strict_file_names(macos_dir, "macOS artifact")
+    if actual_macos_names != tuple(sorted(macos_names)):
+        raise CandidateError(
+            "macOS artifact directory does not match its verification status: "
+            f"got {actual_macos_names!r}, want {tuple(sorted(macos_names))!r}"
+        )
 
     dist = root / "dist"
     dist.mkdir(parents=True)
     _copy_exact(runtime_dir, dist, runtime_asset_names(version))
-    _copy_exact(macos_dir, dist, macos_asset_names(version))
+    _copy_exact(macos_dir, dist, macos_names)
     _copy_resolver_assets(dist, version)
     _validate_resolver_assets(dist, version)
 
@@ -2630,7 +2656,10 @@ def assemble(
     if notes.is_file() and not notes.is_symlink():
         shutil.copy2(notes, root / "RELEASE_NOTES.md")
 
-    checksum_lines = [f"{_sha256(dist / name)}  {name}" for name in payload_asset_names(version)]
+    checksum_lines = [
+        f"{_sha256(dist / name)}  {name}"
+        for name in payload_asset_names(version, macos_verification_status)
+    ]
     (dist / "checksums.txt").write_text("\n".join(checksum_lines) + "\n", encoding="utf-8")
 
     metadata = {
@@ -2677,18 +2706,21 @@ def seal(root: Path, version: str, commit: str) -> None:
     _validate_version(version)
     _validate_commit(commit)
     metadata = _read_json_object(root / "candidate-metadata.json", "candidate metadata")
+    macos_verification_status = _validate_macos_verification_status(
+        metadata.get("macos_verification_status")
+    )
     expected_metadata = {
         "schema_version": SCHEMA_VERSION,
         "release_version": version,
         "commit": commit,
-        "macos_verification_status": "notarized",
+        "macos_verification_status": macos_verification_status,
         "source_install_identity": _reviewed_source_install_identity(version),
     }
     if metadata != expected_metadata:
         raise CandidateError(f"candidate metadata mismatch: got {metadata!r}")
 
     dist = root / "dist"
-    names = published_asset_names(version)
+    names = published_asset_names(version, macos_verification_status)
     _require_regular_files(dist, names, "release candidate")
     actual_names = _strict_file_names(dist, "release candidate")
     if actual_names != names:
@@ -2698,7 +2730,7 @@ def seal(root: Path, version: str, commit: str) -> None:
         )
 
     checksums = _parse_checksums(dist / "checksums.txt")
-    payload_names = payload_asset_names(version)
+    payload_names = payload_asset_names(version, macos_verification_status)
     if tuple(sorted(checksums)) != payload_names:
         raise CandidateError("checksums.txt does not cover the exact publish payload")
     for name, expected in checksums.items():
@@ -2732,13 +2764,14 @@ def verify(root: Path, version: str, commit: str) -> None:
         raise CandidateError("release candidate version mismatch")
     if manifest.get("commit") != commit:
         raise CandidateError("release candidate commit mismatch")
-    if manifest.get("macos_verification_status") != "notarized":
-        raise CandidateError("release candidate macOS app is not notarized")
+    macos_verification_status = _validate_macos_verification_status(
+        manifest.get("macos_verification_status")
+    )
     if manifest.get("source_install_identity") != _reviewed_source_install_identity(version):
         raise CandidateError("release candidate source-install identity mismatch")
 
     dist = root / "dist"
-    expected_names = published_asset_names(version)
+    expected_names = published_asset_names(version, macos_verification_status)
     _require_regular_files(dist, expected_names, "release candidate")
     actual_names = _strict_file_names(dist, "release candidate")
     if actual_names != expected_names:
@@ -2775,7 +2808,9 @@ def verify(root: Path, version: str, commit: str) -> None:
         raise CandidateError("sealed release notes are missing")
 
     checksums = _parse_checksums(dist / "checksums.txt")
-    if tuple(sorted(checksums)) != payload_asset_names(version):
+    if tuple(sorted(checksums)) != payload_asset_names(
+        version, macos_verification_status
+    ):
         raise CandidateError("checksums.txt coverage changed after sealing")
     for name, expected in checksums.items():
         if _sha256(dist / name) != expected:
@@ -2931,7 +2966,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"release candidate verified: {args.version} at {args.commit}")
         elif args.command == "list-assets":
             verify(args.root, args.version, args.commit)
-            for name in published_asset_names(args.version):
+            for name in _strict_file_names(args.root / "dist", "release candidate"):
                 print(name)
         elif args.command == "verify-published":
             verify_published_release(args.root, args.release_json, args.version, args.commit)


### PR DESCRIPTION
Base: `main` after the merged 0.8.4 bridge and release-preflight fixes (#451 and #486). Merge this before starting a new 0.8.4 Release workflow run.

## Problem

The release workflow required a Developer ID certificate and App Store Connect notarization credentials. Those credentials are not available yet, so an otherwise healthy 0.8.4 release could not pass the macOS job.

We need a temporary credential-free path without allowing an unverified macOS app to masquerade as a normal self-update asset.

## Current Situation

The macOS builder already supported local ad-hoc builds named with an `-unverified` suffix, and it already rejected partially configured Apple credentials. Production still failed because the workflow required notarization and the sealed release-candidate policy accepted only canonical notarized filenames.

The future 0.8.5 hard-cut release also required canonical macOS filenames when validating the immutable 0.8.4 bridge, which would reject a legitimate unverified bridge release.

## Solution

### Explicit two-state macOS release policy

```mermaid
flowchart TD
    S["Read five required Apple credentials"] --> Z{"Credential count"}
    Z -->|"0"| U["Ad-hoc sign for macOS structure"]
    U --> UN["Publish only *-unverified.dmg and *-unverified.zip"]
    UN --> M["Manual installation only"]
    Z -->|"5"| N["Developer ID sign, notarize, staple, and assess"]
    N --> V["Publish canonical .dmg and .zip"]
    V --> A["Eligible for in-app self-update"]
    Z -->|"1-4"| F["Fail before publication"]
    N -->|"Any signing or notarization failure"| F
```

- Zero Apple credentials produce ad-hoc-signed artifacts carrying the explicit `-unverified` suffix.
- All five credentials must complete Developer ID signing and notarization.
- Partial, invalid, or internally inconsistent credential states fail closed.
- The release candidate seals the trust status and derives the exact filenames, checksum set, and published custody proof from it.

### Preserve the updater trust boundary

The macOS updater now accepts only the exact canonical versioned ZIP and repeats that check immediately before download/install. `-unverified`, preview, case-variant, and wrong-version ZIPs are never eligible.

### Preserve the staged upgrade path

The 0.8.5 bridge preflight accepts an immutable 0.8.4 release only when its asset set exactly matches one complete reviewed variant: notarized or explicitly unverified. Mixed, missing, or additional assets still fail.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `.github/workflows/release.yaml` | Made notarization conditional, enforced terminal trust states, and made immutable bridge validation status-aware. |
| `scripts/build-macos-app-release.sh` | Renamed the credential-free state to `unverified` and enforced zero-or-five credential terminal invariants. |
| `scripts/release_candidate.py` | Bound macOS status to exact names through assembly, checksums, seal, verify, asset listing, and published custody. |
| `macos/DefenseClawMac/DefenseClawMac/DataLayer/UpdateChecker.swift` | Restricted self-update selection and installation to the exact canonical versioned ZIP. |
| `cli/tests/`, `macos/DefenseClawMac/Tests/` | Added notarized/unverified, tamper, mixed-set, bridge, and updater eligibility coverage. |
| macOS release docs | Documented optional Apple verification and the manual-only unverified path. |

## Breaking Changes

When Apple credentials are absent, the release succeeds but publishes no macOS asset eligible for in-app self-update. macOS users must manually install the clearly labeled `-unverified` DMG and accept the platform trust implications. Runtime CLI/gateway artifacts and their signed checksum custody are unchanged.

When all five Apple credentials are added later, the same workflow automatically returns to canonical Developer ID signed and notarized assets.

## Open Issues / Follow-ups

None.

## Test Plan

Observed locally on macOS:

```bash
/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/python -m pytest -q \
  cli/tests/test_release_candidate.py \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_macos_runtime_installer_upgrade_guard.py
# 124 passed

/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/python -m pytest -q \
  cli/tests/test_historical_release_auth.py \
  cli/tests/test_release_invariants.py \
  cli/tests/test_source_release_identity.py \
  cli/tests/test_upgrade_release_smoke_contract.py
# 64 passed

macos/DefenseClawMac/script/test_update_checker_verification.sh
# Update checker verification tests passed

macos/DefenseClawMac/script/test_update_checker_safety.sh
# Update checker safety tests passed

/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/ruff check \
  scripts/release_candidate.py \
  cli/tests/test_release_candidate.py \
  cli/tests/test_release_workflow_staged.py
# All checks passed

bash -n scripts/build-macos-app-release.sh scripts/verify-macos-app-release.sh

python3 scripts/source_release_identity.py check --expected-release 0.8.4
# version sync OK: 0.8.4 (source epoch 1, runtime 7)
```

The release workflow YAML was also parsed with PyYAML `BaseLoader`. A targeted Claude Opus high-effort review of only this diff reported no actionable findings.
