### PR TITLE
fix(release): disable unused macOS uv cache

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -403,6 +403,10 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.13"
+          # This job consumes already-built runtime artifacts and never creates
+          # a uv dependency cache. Avoid a failing post-job upload of an absent
+          # cache directory.
+          enable-cache: false
 
       - name: Verify and extract exact runtime inputs
         env:

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -253,6 +253,13 @@ def test_macos_app_consumes_and_validates_sealed_runtime_gateway() -> None:
 def test_release_conditionally_notarizes_or_publishes_explicit_unverified_assets() -> None:
     workflow = _workflow()
     macos_job = workflow["jobs"]["macos-app"]
+    setup_uv_step = next(
+        step
+        for step in macos_job["steps"]
+        if step.get("uses", "").startswith("astral-sh/setup-uv@")
+    )
+    assert setup_uv_step["with"]["enable-cache"] == "false"
+
     build_step = next(
         step
         for step in macos_job["steps"]


### PR DESCRIPTION
Base: `main` after #487. This is the focused unblock for failed Release run [29208867452](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29208867452); no tag or GitHub Release was published by that run.

## Problem

The 0.8.4 Release workflow built the runtime candidate and the explicitly unverified macOS artifacts successfully, then failed during `setup-uv` post-job cleanup.

The macOS job does not install dependencies with uv, so it never creates the configured uv cache directory. The action nevertheless attempted to prune and upload that absent directory:

```text
No cache found at: /Users/runner/work/_temp/setup-uv-cache
Error: Cache path ... does not exist on disk.
```

That post-job failure skipped candidate sealing, the upgrade matrix, and publication.

## Current Situation

The standalone macOS application CI workflow already disables the setup-uv cache for its analogous macOS job. The Release workflow did not carry the same setting.

All release build and packaging steps before the post-job hook passed, including the unverified trust-status gate and artifact upload.

## Solution

Disable setup-uv caching only in the Release workflow's `macos-app` job. The job continues to install the requested Python runtime but no longer registers a post-job upload for a cache it never creates.

Add a workflow contract assertion so the release-specific macOS step cannot silently re-enable this unused cache.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `.github/workflows/release.yaml` | Set `enable-cache: false` on the `macos-app` setup-uv step only. |
| `cli/tests/test_release_workflow_staged.py` | Assert that the macOS release job keeps uv caching disabled. |

## Breaking Changes

None. Build inputs, runtime artifacts, macOS trust behavior, upgrade policy, and publish custody are unchanged.

## Open Issues / Follow-ups

None.

## Test Plan

```bash
/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/python -m pytest -q \
  cli/tests/test_release_workflow_staged.py
# 24 passed

/Users/vnarajal/Desktop/defenseclaw-1/.venv/bin/python - <<'PY'
from pathlib import Path
import yaml

workflow = yaml.load(
    Path('.github/workflows/release.yaml').read_text(encoding='utf-8'),
    Loader=yaml.BaseLoader,
)
steps = workflow['jobs']['macos-app']['steps']
setup_uv = next(
    step for step in steps
    if step.get('uses', '').startswith('astral-sh/setup-uv@')
)
assert setup_uv['with']['enable-cache'] == 'false'
PY
# passed

git diff --check
# passed
```
