### PR TITLE
fix(release): restore staged upgrade matrix

### DIFF
--- a/cli/defenseclaw/commands/cmd_upgrade.py
+++ b/cli/defenseclaw/commands/cmd_upgrade.py
@@ -6461,6 +6461,26 @@ def _rollback_capture_identity(info: os.stat_result) -> tuple[int, int, int, int
     )
 
 
+def _rollback_named_capture_matches(named: os.stat_result, opened: os.stat_result) -> bool:
+    """Compare a named rollback source with its pinned descriptor.
+
+    Windows can expose different timestamp representations for ``lstat`` and
+    ``fstat`` even when both describe the same file object.  Object identity,
+    type, and size remain stable across those APIs.  The descriptor-only
+    before/after comparison still covers timestamp changes while the payload
+    is read, so this exception does not weaken concurrent-mutation detection.
+    POSIX retains the original exact metadata comparison.
+    """
+
+    if os.name != "nt":
+        return _rollback_capture_identity(named) == _rollback_capture_identity(opened)
+    return (
+        os.path.samestat(named, opened)
+        and stat.S_IFMT(named.st_mode) == stat.S_IFMT(opened.st_mode)
+        and named.st_size == opened.st_size
+    )
+
+
 def _v8_recovery_entries(
     path: str,
     descriptor: int | None,
@@ -6743,7 +6763,7 @@ def _capture_rollback_file(active_path: str, backup_path: str, *, required: bool
     try:
         opened = os.fstat(source_descriptor)
         opened_identity = _rollback_capture_identity(opened)
-        if not stat.S_ISREG(opened.st_mode) or opened_identity != _rollback_capture_identity(info):
+        if not stat.S_ISREG(opened.st_mode) or not _rollback_named_capture_matches(info, opened):
             raise OSError(f"rollback source changed while opening: {active_path}")
 
         if os.name == "nt":
@@ -6792,7 +6812,15 @@ def _capture_rollback_file(active_path: str, backup_path: str, *, required: bool
             or stat.S_ISLNK(named.st_mode)
             or getattr(named, "st_file_attributes", 0) & 0x00000400
             or not stat.S_ISREG(named.st_mode)
-            or _rollback_capture_identity(named) != opened_identity
+            or not _rollback_named_capture_matches(named, after)
+            # Windows named/handle timestamp representations can differ, but
+            # two lstat snapshots use the same API. Keep that exact
+            # named-before/named-after comparison so a same-object, same-size
+            # write after the descriptor read is still detected.
+            or (
+                os.name == "nt"
+                and _rollback_capture_identity(named) != _rollback_capture_identity(info)
+            )
         ):
             raise OSError(f"rollback source changed while being read: {active_path}")
 

--- a/cli/defenseclaw/windows_acl.py
+++ b/cli/defenseclaw/windows_acl.py
@@ -166,7 +166,7 @@ class _WindowsApi(Protocol):
 
     def _open_regular_mutator_exclusive(self, path: str) -> int: ...
 
-    def open_directory_no_delete(self, path: str) -> int: ...
+    def open_directory_no_delete(self, path: str, *, protect_name: bool = True) -> int: ...
 
     def assert_real_directory(self, handle: int) -> None: ...
 
@@ -440,12 +440,26 @@ class _CtypesWindowsApi:
             self._raise_last_error("CreateFileW(exclusive lease)")
         return int(handle)
 
-    def open_directory_no_delete(self, path: str) -> int:
-        """Bind a directory while denying rename/delete sharing to peers."""
+    def open_directory_no_delete(self, path: str, *, protect_name: bool = True) -> int:
+        """Bind a directory while denying rename/delete sharing to peers.
+
+        A name-protecting lease requests ``DELETE`` access itself.  Merely
+        omitting ``FILE_SHARE_DELETE`` is insufficient when the caller can
+        rename a directory through ``FILE_DELETE_CHILD`` on its parent.  The
+        requested delete access binds later rename/delete attempts to this
+        exact handle, while the omitted share flag denies competing handles.
+
+        Ancestor-validation handles do not request ``DELETE`` because a user
+        commonly lacks that right on volume roots and system-owned parents.
+        The final name-protecting descendant lease prevents those validated
+        ancestors from being renamed while the chain is held: Windows refuses
+        to rename a directory whose subtree contains an open handle that did
+        not grant delete sharing.
+        """
 
         handle = self._create_file(
             path,
-            _FILE_READ_ATTRIBUTES,
+            _FILE_READ_ATTRIBUTES | (_DELETE if protect_name else 0),
             _FILE_SHARE_READ | _FILE_SHARE_WRITE,
             None,
             _OPEN_EXISTING,
@@ -834,6 +848,7 @@ class _CtypesWindowsApi:
 
 
 _api: _WindowsApi | None = None
+_directory_name_leases = threading.local()
 
 
 def _get_api() -> _WindowsApi:
@@ -999,18 +1014,39 @@ def _windows_directory_prefixes(path: str) -> tuple[str, ...]:
     return tuple(prefixes)
 
 
+def _held_directory_name_keys() -> set[str]:
+    keys = getattr(_directory_name_leases, "keys", None)
+    if keys is None:
+        keys = set()
+        _directory_name_leases.keys = keys
+    return keys
+
+
 @contextmanager
-def hold_directory(path: str) -> Iterator[None]:
-    """Hold one real directory open without ``FILE_SHARE_DELETE``."""
+def hold_directory(path: str, *, protect_name: bool = True) -> Iterator[None]:
+    """Hold one real directory, optionally binding its namespace entry."""
 
     if os.name != "nt":
         raise WindowsAclError("Windows directory leases require Windows")
+    key = ntpath.normcase(_windows_directory_prefixes(path)[-1])
+    active_name_leases = _held_directory_name_keys()
+    if protect_name and key in active_name_leases:
+        # Handle-bound file mutators intentionally reacquire their parent
+        # chain. Reuse the already-held exact name lease in the same thread;
+        # opening another DELETE handle would correctly conflict with the
+        # first lease's missing FILE_SHARE_DELETE.
+        yield
+        return
     api = _get_api()
-    handle = api.open_directory_no_delete(path)
+    handle = api.open_directory_no_delete(path, protect_name=protect_name)
     try:
         api.assert_real_directory(handle)
+        if protect_name:
+            active_name_leases.add(key)
         yield
     finally:
+        if protect_name:
+            active_name_leases.discard(key)
         api.close_handle(handle)
 
 
@@ -1018,9 +1054,11 @@ def hold_directory(path: str) -> Iterator[None]:
 def hold_directory_chain(path: str) -> Iterator[None]:
     """Prevent every absolute-path ancestor from being renamed or replaced."""
 
+    prefixes = _windows_directory_prefixes(path)
     with ExitStack() as held:
-        for prefix in _windows_directory_prefixes(path):
-            held.enter_context(hold_directory(prefix))
+        for prefix in prefixes[:-1]:
+            held.enter_context(hold_directory(prefix, protect_name=False))
+        held.enter_context(hold_directory(prefixes[-1], protect_name=True))
         yield
 
 

--- a/cli/tests/test_cmd_upgrade_windows_rollback.py
+++ b/cli/tests/test_cmd_upgrade_windows_rollback.py
@@ -192,9 +192,26 @@ def test_windows_capture_uses_exact_handle_and_private_backup_before_return(
     active.write_bytes(b"SECRET=source\n")
     captured_descriptors: list[int] = []
     backup_security: dict[str, WindowsFileSecurity] = {}
+    timestamp_skew_observed = False
 
     class _WindowsOsProxy:
         name = "nt"
+
+        def lstat(self, path: str | os.PathLike[str]):
+            nonlocal timestamp_skew_observed
+            info = os.lstat(path)
+            if os.path.abspath(path) != os.path.abspath(active):
+                return info
+            timestamp_skew_observed = True
+
+            class _TimestampSkewedStat:
+                st_mtime_ns = info.st_mtime_ns + 1
+                st_ctime_ns = info.st_ctime_ns + 1
+
+                def __getattr__(self, name: str):
+                    return getattr(info, name)
+
+            return _TimestampSkewedStat()
 
         def __getattr__(self, name: str):
             return getattr(os, name)
@@ -218,6 +235,7 @@ def test_windows_capture_uses_exact_handle_and_private_backup_before_return(
 
     snapshot = cmd_upgrade._capture_rollback_file(str(active), str(backup), required=True)
 
+    assert timestamp_skew_observed
     assert captured_descriptors
     assert snapshot.windows_security == ORIGINAL
     assert snapshot.sha256 == hashlib.sha256(b"SECRET=source\n").hexdigest()

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -19,6 +19,7 @@ PROTOCOL_GATE = ROOT / "scripts/test-upgrade-protocol-release.sh"
 WINDOWS_PROTOCOL_GATE = ROOT / "scripts/test-upgrade-release-windows.ps1"
 MACOS_BUILD = ROOT / "scripts/build-macos-app-release.sh"
 POSIX_INSTALLER = ROOT / "scripts/install.sh"
+POSIX_FRESH_RELEASE = ROOT / "scripts/test-fresh-install-release.sh"
 
 
 def _workflow() -> dict[str, object]:
@@ -587,3 +588,13 @@ def test_protocol_refusal_contract_option_preserves_shared_matrix_arguments() ->
 
     assert completed.returncode == 0, completed.stderr
     assert completed.stdout.strip() == "0.8.3|seed|1"
+
+
+def test_posix_fresh_release_uses_physical_temp_home_and_surfaces_installer_log() -> None:
+    source = POSIX_FRESH_RELEASE.read_text(encoding="utf-8")
+
+    workdir = source.index('WORKDIR="$(mktemp -d')
+    canonical = source.index('WORKDIR="$(cd "${WORKDIR}" && pwd -P)"')
+    home = source.index('export HOME="${WORKDIR}/home"')
+    assert workdir < canonical < home
+    assert 'cat "${WORKDIR}/install.log" >&2' in source

--- a/cli/tests/test_upgrade_bridge_phase1_rollback.py
+++ b/cli/tests/test_upgrade_bridge_phase1_rollback.py
@@ -452,6 +452,15 @@ def test_bridge_start_failure_restores_source_artifacts_state_and_health(
     concurrent_divergence: bool,
     post_quarantine_write: bool,
 ) -> None:
+    bridge_install_failure = (
+        crash_point is None
+        and source_running
+        and not unrelated_pid
+        and not orphan_health
+        and openclaw_present
+        and not concurrent_divergence
+        and not post_quarantine_write
+    )
     fixtures = tmp_path / "fixtures"
     fake_bin = tmp_path / "fake-bin"
     home = tmp_path / "home"
@@ -479,7 +488,14 @@ def test_bridge_start_failure_restores_source_artifacts_state_and_health(
     _write_executable(
         source_cli,
         "#!/usr/bin/env bash\n"
-        "if [[ \"${1:-}\" == \"--version\" ]]; then printf '%s\\n' 'DefenseClaw 0.8.3'; exit 0; fi\n"
+        "if [[ \"${1:-}\" == \"--version\" ]]; then\n"
+        "  if [[ \"${MUTATE_SOURCE_CLI_ON_VERSION:-0}\" == '1' "
+        "&& \"${PYTHONDONTWRITEBYTECODE:-}\" != '1' ]]; then\n"
+        f"    printf '%s\\n' probe >> {str(source_venv / 'version-probe-cache')!r}\n"
+        "  fi\n"
+        "  printf '%s\\n' 'DefenseClaw 0.8.3'\n"
+        "  exit 0\n"
+        "fi\n"
         "exit 91\n",
     )
     _write_executable(
@@ -586,6 +602,17 @@ for arg in "$@"; do
   if [[ "${previous}" == 'venv' ]]; then venv="${arg}"; break; fi
   previous="${arg}"
 done
+if [[ "$*" == *"pip install"* ]]; then
+  wheel="${!#}"
+  wheel_name="${wheel##*/}"
+  if [[ ! "${wheel_name}" =~ ^defenseclaw-[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9]+)?-py3-none-any\\.whl$ ]]; then
+    printf 'invalid wheel filename: %s\n' "${wheel_name}" >&2
+    exit 88
+  fi
+  if [[ "${FAIL_BRIDGE_WHEEL_INSTALL:-0}" == '1' && "${wheel}" == */backups/* ]]; then
+    exit 89
+  fi
+fi
 if [[ -n "${venv}" ]]; then
   mkdir -p "${venv}/bin"
   cp "${TARGET_PYTHON_TEMPLATE}" "${venv}/bin/python"
@@ -676,6 +703,9 @@ cp "${FIXTURE_ROOT}/${version}/${name}" "${out}"
         env["INJECT_CONCURRENT_PHASE1_STATE"] = "1"
     if post_quarantine_write:
         env["INJECT_POST_QUARANTINE_WRITE"] = "1"
+    if bridge_install_failure:
+        env["FAIL_BRIDGE_WHEEL_INSTALL"] = "1"
+        env["MUTATE_SOURCE_CLI_ON_VERSION"] = "1"
     if crash_point == "migration-after-config":
         env["ALLOW_TARGET_GATEWAY_START"] = "1"
         env["TARGET_HEALTH_URL"] = "http://127.0.0.1:18971/health"
@@ -898,6 +928,22 @@ cp "${FIXTURE_ROOT}/${version}/${name}" "${out}"
     try:
         output = result.stdout + result.stderr
         assert result.returncode == 1, output
+        if bridge_install_failure:
+            assert "Failed to install the bridge CLI wheel" in output
+            assert "Source 0.8.3 artifacts and state restored" in output
+            assert "restored source venv identity changed" not in output
+            assert not (
+                controller_home / ".upgrade-recovery" / "phase-one-active.json"
+            ).exists()
+            assert (install_dir / "defenseclaw-gateway").read_bytes() == source_gateway_bytes
+            assert config_path.read_bytes() == config_original
+            events = event_log.read_text(encoding="utf-8")
+            assert "source-stop" in events
+            assert "source-start" in events
+            assert "target-start" not in events
+            assert restored_pid is not None
+            os.kill(restored_pid, 0)
+            return
         if crash_point is not None:
             assert "Recovering Interrupted Bridge Upgrade" in output
             assert "before detecting installed versions" in output
@@ -1037,6 +1083,12 @@ def test_bridge_rollback_health_is_version_bound_and_custody_is_collision_safe()
     assert "refusing to execute or overwrite an unrecognized phase-one gateway activation" in script
     assert "shutil.rmtree(active_venv)" not in script
     assert 'rm -rf "${DEFENSECLAW_VENV}"' not in script
+    assert "phase1-bridge-wheel.whl" not in script
+    assert 'f"defenseclaw-{bridge_version}-2-py3-none-any.whl"' in script
+    assert 'f"defenseclaw-{payload[\'bridge_version\']}-2-py3-none-any.whl"' in script
+    assert 'BRIDGE_WHEEL_CUSTODY_PATH="${BACKUP_DIR}/${whl_name}"' in script
+    assert 'PYTHONDONTWRITEBYTECODE=1 "${DEFENSECLAW_VENV}/bin/defenseclaw"' in script
+    assert 'probe_environment["PYTHONDONTWRITEBYTECODE"] = "1"' in script
 
 
 def test_gateway_pid_parser_accepts_legacy_integer_with_live_binary_identity(tmp_path: Path) -> None:

--- a/cli/tests/test_upgrade_release_smoke_contract.py
+++ b/cli/tests/test_upgrade_release_smoke_contract.py
@@ -51,6 +51,18 @@ def test_posix_install_upgrade_and_smoke_pin_private_umask() -> None:
         assert re.search(r"^set -euo pipefail\n(?:.*\n){0,8}umask 077$", text, re.MULTILINE), path
 
 
+def test_source_gateway_canary_waits_for_exact_version_bound_health() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+    canary = source[
+        source.index("start_source_gateway_canary()") : source.index("parse_args()")
+    ]
+
+    assert "http://127.0.0.1:18970/health" in canary
+    assert 'gateway.get("state") != "running"' in canary
+    assert 'provenance.get("binary_version") != sys.argv[2]' in canary
+    assert "did not reach version-bound health" in canary
+
+
 def test_protected_release_test_artifact_is_authenticated_before_private_decode(
     tmp_path: Path,
 ) -> None:

--- a/cli/tests/test_windows_acl.py
+++ b/cli/tests/test_windows_acl.py
@@ -79,10 +79,10 @@ class _FakeApi:
         self.events.append(("open", (path, access, directory)))
         return self.paths[path]
 
-    def open_directory_no_delete(self, path: str) -> int:
+    def open_directory_no_delete(self, path: str, *, protect_name: bool = True) -> int:
         handle = self.next_handle
         self.next_handle += 1
-        self.events.append(("lease-open", path))
+        self.events.append(("lease-open", (path, protect_name)))
         return handle
 
     def assert_real_directory(self, handle: int) -> None:
@@ -259,17 +259,16 @@ def test_windows_directory_chain_stays_held_across_handle_mutations(
 
     opened = [value for event, value in api.events if event == "lease-open"]
     assert opened[:4] == [
-        "C:\\",
-        r"C:\Users",
-        r"C:\Users\operator",
-        r"C:\Users\operator\.defenseclaw",
+        ("C:\\", False),
+        (r"C:\Users", False),
+        (r"C:\Users\operator", False),
+        (r"C:\Users\operator\.defenseclaw", True),
     ]
-    assert tuple(map(ntpath.normcase, opened[4:8])) == tuple(
-        map(ntpath.normcase, opened[:4]),
-    )
-    assert tuple(map(ntpath.normcase, opened[8:12])) == tuple(
-        map(ntpath.normcase, opened[:4]),
-    )
+    for nested_ancestors in (opened[4:7], opened[7:10]):
+        assert tuple(ntpath.normcase(path) for path, _protect_name in nested_ancestors) == tuple(
+            ntpath.normcase(path) for path, _protect_name in opened[:3]
+        )
+        assert all(not protect_name for _path, protect_name in nested_ancestors)
     replace_index = next(index for index, event in enumerate(api.events) if event[0] == "handle-replace")
     delete_index = next(index for index, event in enumerate(api.events) if event[0] == "handle-delete")
     outer_close_indexes = [
@@ -368,6 +367,42 @@ def test_native_exclusive_mutator_denies_write_and_delete_sharing() -> None:
         None,
     )
     api.close_handle.assert_not_called()
+
+
+def test_native_directory_name_lease_requests_delete_without_delete_sharing() -> None:
+    api = object.__new__(windows_acl._CtypesWindowsApi)
+    create_file = Mock(return_value=87)
+    api._create_file = create_file
+
+    assert api.open_directory_no_delete(r"C:\state", protect_name=True) == 87
+
+    create_file.assert_called_once_with(
+        r"C:\state",
+        windows_acl._FILE_READ_ATTRIBUTES | windows_acl._DELETE,
+        windows_acl._FILE_SHARE_READ | windows_acl._FILE_SHARE_WRITE,
+        None,
+        windows_acl._OPEN_EXISTING,
+        windows_acl._FILE_FLAG_OPEN_REPARSE_POINT | windows_acl._FILE_FLAG_BACKUP_SEMANTICS,
+        None,
+    )
+
+
+def test_native_directory_ancestor_lease_avoids_delete_access() -> None:
+    api = object.__new__(windows_acl._CtypesWindowsApi)
+    create_file = Mock(return_value=89)
+    api._create_file = create_file
+
+    assert api.open_directory_no_delete("C:\\", protect_name=False) == 89
+
+    create_file.assert_called_once_with(
+        "C:\\",
+        windows_acl._FILE_READ_ATTRIBUTES,
+        windows_acl._FILE_SHARE_READ | windows_acl._FILE_SHARE_WRITE,
+        None,
+        windows_acl._OPEN_EXISTING,
+        windows_acl._FILE_FLAG_OPEN_REPARSE_POINT | windows_acl._FILE_FLAG_BACKUP_SEMANTICS,
+        None,
+    )
 
 
 def test_native_handle_move_never_replaces_a_later_target() -> None:
@@ -503,6 +538,32 @@ def test_native_windows_directory_lease_and_handle_mutators(tmp_path) -> None:
     assert not source.exists()
     assert not retired.exists()
     parent.rename(moved)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires native Windows share modes")
+def test_native_windows_directory_name_lease_blocks_empty_directory_deletion(tmp_path) -> None:
+    held = tmp_path / "empty-held"
+    held.mkdir()
+
+    with windows_acl.hold_directory_chain(str(held)):
+        with pytest.raises(OSError):
+            held.rmdir()
+
+    held.rmdir()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires native Windows share modes")
+def test_native_windows_descendant_name_lease_blocks_ancestor_rename(tmp_path) -> None:
+    ancestor = tmp_path / "ancestor"
+    held = ancestor / "held"
+    moved = tmp_path / "moved-ancestor"
+    held.mkdir(parents=True)
+
+    with windows_acl.hold_directory_chain(str(held)):
+        with pytest.raises(OSError):
+            ancestor.rename(moved)
+
+    ancestor.rename(moved)
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/test_windows_powershell_upgrade_paths.py
+++ b/cli/tests/test_windows_powershell_upgrade_paths.py
@@ -135,6 +135,13 @@ def test_windows_fresh_installer_rolls_back_exact_attempt_owned_payloads() -> No
     ):
         assert contract in source
 
+    rollback_residue = source[
+        source.index("function Add-PrivateDirectoryRollbackResidue") : source.index(
+            "function Initialize-FreshInstallAttempt"
+        )
+    ]
+    assert "[AllowEmptyCollection()]" in rollback_residue
+
     open_handle_start = source.index("private static SafeFileHandle OpenHandle")
     open_handle_end = source.index("private static SafeFileHandle OpenParentHandle")
     assert open_handle_start < open_handle_end
@@ -327,7 +334,6 @@ def test_windows_private_custody_cleanup_is_creation_bound_and_identity_exact() 
     )
     assert "canonical binding and current location are unverified" in source
     assert "claim will close when the installer exits" in source
-
     path_publish = source[source.index("function Add-ToPath") : source.index("# -- Success")]
     assert "Persistent User PATH is shared registry state" in path_publish
     assert "Persistent User PATH was not modified" in path_publish
@@ -367,6 +373,18 @@ def test_windows_private_custody_cleanup_is_creation_bound_and_identity_exact() 
 
     legacy_gateway = source[source.index("function Install-Gateway") : source.index("function Install-Cli")]
     assert "Remove-PrivateDirectory -Path $tmp" in legacy_gateway
+
+
+def test_windows_phase_one_custody_keeps_pep427_wheel_names() -> None:
+    resolver = RESOLVER.read_text(encoding="utf-8")
+    harness = RELEASE_HARNESS.read_text(encoding="utf-8")
+
+    assert 'Join-Path $root "source.whl"' not in resolver
+    assert 'Join-Path $root "bridge.whl"' not in resolver
+    assert '"defenseclaw-$sourceVersion-py3-none-any.whl"' in resolver
+    assert '"defenseclaw-$bridgeVersion-py3-none-any.whl"' in resolver
+    assert '"defenseclaw-$([string]$payload.source_version)-py3-none-any.whl"' in harness
+    assert '"defenseclaw-$([string]$payload.bridge_version)-py3-none-any.whl"' in harness
 
 
 def test_windows_resolver_has_fail_closed_bridge_and_fresh_controller_contract() -> None:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1800,6 +1800,7 @@ function New-FreshInstallOwnedDirectory {
 function Add-PrivateDirectoryRollbackResidue {
     param(
         [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
         [System.Collections.Generic.List[string]]$Residue
     )
     foreach ($token in @($script:RollbackSafetyLedger.Keys | Sort-Object)) {

--- a/scripts/test-fresh-install-release.sh
+++ b/scripts/test-fresh-install-release.sh
@@ -30,6 +30,7 @@ for command_name in uv cosign python3; do
 done
 
 WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/defenseclaw-fresh-release.XXXXXX")"
+WORKDIR="$(cd "${WORKDIR}" && pwd -P)"
 cleanup() {
     local status=$?
     chmod -R u+w "${WORKDIR}" 2>/dev/null || true
@@ -95,11 +96,16 @@ if versions != [expected]:
 PY
 }
 
-VERSION="${VERSION}" bash "${ROOT}/scripts/install.sh" \
+if ! VERSION="${VERSION}" bash "${ROOT}/scripts/install.sh" \
     --local "${RELEASE_DIR}" \
     --yes \
     --connector none \
     >"${WORKDIR}/install.log" 2>&1
+then
+    echo "fresh installer failed; captured output follows:" >&2
+    cat "${WORKDIR}/install.log" >&2
+    exit 1
+fi
 
 assert_exact_version "${HOME}/.local/bin/defenseclaw"
 assert_exact_version "${HOME}/.local/bin/defenseclaw-gateway"

--- a/scripts/test-upgrade-release-windows.ps1
+++ b/scripts/test-upgrade-release-windows.ps1
@@ -1567,9 +1567,9 @@ function Assert-PhaseOneJournalCustody {
     $planRoot=Join-Path $recoveryRoot ([string]$payload.plan_id)
     Assert-PrivateDirectoryAcl -Path $planRoot
     foreach($custody in @(
-        @((Join-Path $planRoot "source.whl"),[string]$payload.wheel_sha256),
+        @((Join-Path $planRoot "defenseclaw-$([string]$payload.source_version)-py3-none-any.whl"),[string]$payload.wheel_sha256),
         @((Join-Path $planRoot "source-gateway.exe"),[string]$payload.gateway_sha256),
-        @((Join-Path $planRoot "bridge.whl"),[string]$payload.bridge_wheel_sha256),
+        @((Join-Path $planRoot "defenseclaw-$([string]$payload.bridge_version)-py3-none-any.whl"),[string]$payload.bridge_wheel_sha256),
         @((Join-Path $planRoot "bridge-gateway.exe"),[string]$payload.bridge_gateway_sha256)
     )){
         Assert-PrivateFileAcl -Path $custody[0]

--- a/scripts/test-upgrade-release.sh
+++ b/scripts/test-upgrade-release.sh
@@ -124,6 +124,7 @@ stop_smoke_gateway() {
 start_source_gateway_canary() {
     [[ "${START_SOURCE_GATEWAY}" == "1" ]] || return 0
     local start_log="${SMOKE_HOME}/source-gateway-start.log"
+    local health_response="${SMOKE_HOME}/source-gateway-health.json"
     if ! HOME="${SMOKE_HOME}" \
         DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \
         OPENCLAW_HOME="${SMOKE_HOME}/.openclaw" \
@@ -140,14 +141,34 @@ start_source_gateway_canary() {
             OPENCLAW_HOME="${SMOKE_HOME}/.openclaw" \
             PATH="${SMOKE_HOME}/.local/bin:${PATH}" \
                 "${SMOKE_HOME}/.local/bin/defenseclaw-gateway" status \
-                >>"${start_log}" 2>&1; then
+                >>"${start_log}" 2>&1 \
+            && curl -fsS --max-time 1 http://127.0.0.1:18970/health \
+                >"${health_response}" 2>>"${start_log}" \
+            && python3 - "${health_response}" "${FROM_VERSION}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as stream:
+    payload = json.load(stream)
+gateway = payload.get("gateway") if isinstance(payload, dict) else None
+provenance = payload.get("provenance") if isinstance(payload, dict) else None
+if (
+    not isinstance(gateway, dict)
+    or gateway.get("state") != "running"
+    or not isinstance(provenance, dict)
+    or provenance.get("binary_version") != sys.argv[2]
+):
+    raise SystemExit(1)
+PY
+        then
             ok "Published source gateway ${FROM_VERSION} is running before resolver handoff"
             return 0
         fi
         sleep 0.25
     done
     tail_log "${start_log}"
-    die "published source gateway ${FROM_VERSION} did not become healthy"
+    [[ ! -s "${health_response}" ]] || cat "${health_response}" >&2
+    die "published source gateway ${FROM_VERSION} did not reach version-bound health"
 }
 
 parse_args() {

--- a/scripts/upgrade.ps1
+++ b/scripts/upgrade.ps1
@@ -1808,11 +1808,15 @@ function New-PhaseOneRollbackPlan {
 
         $sourceWheelPath=Join-Path $SourceRelease.Directory $SourceRelease.Wheel
         Assert-RealFile $sourceWheelPath "Authenticated source wheel"
-        $wheel=Join-Path $root "source.whl";Write-SecuredRestoreCandidate -Source $sourceWheelPath -Destination $wheel -FinalSddl (Get-PrivateFileSddl)
+        $sourceWheelName=[IO.Path]::GetFileName($sourceWheelPath)
+        if($sourceWheelName -cne "defenseclaw-$SourceVersion-py3-none-any.whl"){Fail "Authenticated source wheel has a noncanonical materialized filename; no state changed."}
+        $wheel=Join-Path $root $sourceWheelName;Write-SecuredRestoreCandidate -Source $sourceWheelPath -Destination $wheel -FinalSddl (Get-PrivateFileSddl)
         $wheelSha=(Get-FileHash -LiteralPath $wheel -Algorithm SHA256).Hash.ToLowerInvariant()
         $bridgeWheelPath=Join-Path $Bridge.Directory $Bridge.Wheel
         Assert-RealFile $bridgeWheelPath "Authenticated bridge wheel"
-        $bridgeWheel=Join-Path $root "bridge.whl";Write-SecuredRestoreCandidate -Source $bridgeWheelPath -Destination $bridgeWheel -FinalSddl (Get-PrivateFileSddl)
+        $bridgeWheelName=[IO.Path]::GetFileName($bridgeWheelPath)
+        if($bridgeWheelName -cne "defenseclaw-$($Bridge.Version)-py3-none-any.whl"){Fail "Authenticated bridge wheel has a noncanonical materialized filename; no state changed."}
+        $bridgeWheel=Join-Path $root $bridgeWheelName;Write-SecuredRestoreCandidate -Source $bridgeWheelPath -Destination $bridgeWheel -FinalSddl (Get-PrivateFileSddl)
         $bridgeWheelSha=(Get-FileHash -LiteralPath $bridgeWheel -Algorithm SHA256).Hash.ToLowerInvariant()
         $gateway=Get-Gateway;Assert-RealFile $gateway "Installed source gateway"
         $gatewayStage=New-PrivateDirectory (Join-Path $root "gateway")
@@ -1903,7 +1907,7 @@ function Read-PhaseOneJournal {
     if(-not $controllerHome.Equals((Get-ControllerHome),[StringComparison]::OrdinalIgnoreCase) -or -not $recoveryRoot.Equals((Join-Path $controllerHome ".upgrade-recovery"),[StringComparison]::OrdinalIgnoreCase)){Fail "Phase-one recovery journal targets a different controller home."}
     $root=Join-Path $recoveryRoot $planId
     Assert-PrivateDirectoryAcl -Path $root -Expected (New-PrivateDirectoryAcl)
-    $wheel=Join-Path $root "source.whl";$sourceGateway=Join-Path $root "source-gateway.exe";$bridgeWheel=Join-Path $root "bridge.whl";$bridgeGateway=Join-Path $root "bridge-gateway.exe"
+    $wheel=Join-Path $root "defenseclaw-$sourceVersion-py3-none-any.whl";$sourceGateway=Join-Path $root "source-gateway.exe";$bridgeWheel=Join-Path $root "defenseclaw-$bridgeVersion-py3-none-any.whl";$bridgeGateway=Join-Path $root "bridge-gateway.exe"
     foreach($custody in @(@($wheel,$wheelSha),@($sourceGateway,$gatewaySha),@($bridgeWheel,$bridgeWheelSha),@($bridgeGateway,$bridgeGatewaySha))){
         Assert-PrivateFileAcl $custody[0]
         if((Get-FileHash -LiteralPath $custody[0] -Algorithm SHA256).Hash.ToLowerInvariant() -ne $custody[1]){Fail "Phase-one recovery custody digest changed: $($custody[0])"}

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1152,7 +1152,9 @@ if (
 gateway = os.path.join(backup_dir, "phase1-source-gateway")
 require_file(gateway)
 bridge_gateway = os.path.join(backup_dir, "phase1-bridge-gateway")
-bridge_wheel = os.path.join(backup_dir, "phase1-bridge-wheel.whl")
+bridge_wheel = os.path.join(
+    backup_dir, f"defenseclaw-{bridge_version}-2-py3-none-any.whl"
+)
 require_file(bridge_gateway)
 require_file(bridge_wheel)
 if digest(bridge_gateway) != bridge_gateway_sha256 or digest(bridge_wheel) != bridge_wheel_sha256:
@@ -1864,7 +1866,16 @@ def root_state() -> tuple[dict[str, int | None], dict[str, dict[str, int] | None
 
 
 def command_version(command):
-    completed = subprocess.run(command, capture_output=True, text=True, timeout=15, check=False)
+    probe_environment = os.environ.copy()
+    probe_environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    completed = subprocess.run(
+        command,
+        env=probe_environment,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
     match = re.search(r"(?<![\d.])(\d+\.\d+\.\d+)(?![\d.])", (completed.stdout or "") + (completed.stderr or ""))
     if completed.returncode != 0 or match is None:
         raise RuntimeError(f"could not verify restored command: {command[0]}")
@@ -2063,7 +2074,9 @@ if os.path.dirname(backup_dir) != backup_root:
 require_directory(backup_dir, private=True)
 source_gateway = os.path.join(backup_dir, "phase1-source-gateway")
 bridge_gateway = os.path.join(backup_dir, "phase1-bridge-gateway")
-bridge_wheel = os.path.join(backup_dir, "phase1-bridge-wheel.whl")
+bridge_wheel = os.path.join(
+    backup_dir, f"defenseclaw-{payload['bridge_version']}-2-py3-none-any.whl"
+)
 state_root = os.path.join(backup_dir, "phase1-state")
 state_manifest = os.path.join(state_root, "manifest.json")
 active_manifest = os.path.join(state_root, "active-manifest.json")
@@ -3326,6 +3339,7 @@ BRIDGE_RECOVERY_PLAN_ID=""
 BRIDGE_STATE_SNAPSHOT_READY=0
 BRIDGE_EXPECTED_GATEWAY_SHA256=""
 BRIDGE_EXPECTED_WHEEL_SHA256=""
+BRIDGE_WHEEL_CUSTODY_PATH=""
 BRIDGE_SOURCE_VENV_IDENTITY_SHA256=""
 
 upgrade_exit_trap() {
@@ -5023,12 +5037,15 @@ prepare_bridge_phase1_custody() {
             "${BACKUP_DIR}/phase1-bridge-gateway" 2>/dev/null \
             || die "Could not normalize the verified bridge gateway for rollback identity; no services changed."
     fi
-    cp "${STAGING_DIR}/${whl_name}" "${BACKUP_DIR}/phase1-bridge-wheel.whl" \
+    BRIDGE_WHEEL_CUSTODY_PATH="${BACKUP_DIR}/${whl_name}"
+    [[ "${whl_name}" == "defenseclaw-${RELEASE_VERSION}-2-py3-none-any.whl" ]] \
+        || die "Verified bridge wheel has a noncanonical materialized filename; no services changed."
+    cp "${STAGING_DIR}/${whl_name}" "${BRIDGE_WHEEL_CUSTODY_PATH}" \
         || die "Could not retain the verified bridge wheel activation; no services changed."
-    chmod 600 "${BACKUP_DIR}/phase1-bridge-wheel.whl"
+    chmod 600 "${BRIDGE_WHEEL_CUSTODY_PATH}"
     read -r BRIDGE_EXPECTED_GATEWAY_SHA256 BRIDGE_EXPECTED_WHEEL_SHA256 < <(python3 - \
         "${BACKUP_DIR}/phase1-bridge-gateway" \
-        "${BACKUP_DIR}/phase1-bridge-wheel.whl" <<'PY'
+        "${BRIDGE_WHEEL_CUSTODY_PATH}" <<'PY'
 import hashlib
 import sys
 
@@ -5102,7 +5119,7 @@ PY
 
 activate_bridge_phase1_cli() {
     local uv_bin source_venv_backup bridge_version bridge_seed
-    [[ -n "${whl_name:-}" && -f "${BACKUP_DIR}/phase1-bridge-wheel.whl" ]] \
+    [[ -n "${whl_name:-}" && -f "${BRIDGE_WHEEL_CUSTODY_PATH}" ]] \
         || die "Bridge CLI artifact is unavailable during activation"
     uv_bin="$(command -v uv 2>/dev/null || true)"
     source_venv_backup="${BACKUP_DIR}/phase1-source-venv"
@@ -5167,7 +5184,7 @@ PY
 
     "${uv_bin}" --no-config venv "${DEFENSECLAW_VENV}" --allow-existing --python "${BRIDGE_PYTHON_INTERPRETER}" --quiet \
         || die "Could not create the bridge CLI environment"
-    "${uv_bin}" --no-config pip install --python "${DEFENSECLAW_VENV}/bin/python" --quiet --offline "${BACKUP_DIR}/phase1-bridge-wheel.whl" \
+    "${uv_bin}" --no-config pip install --python "${DEFENSECLAW_VENV}/bin/python" --quiet --offline "${BRIDGE_WHEEL_CUSTODY_PATH}" \
         || die "Failed to install the bridge CLI wheel"
     bridge_version="$("${DEFENSECLAW_VENV}/bin/python" -c 'from defenseclaw import __version__; print(__version__)')" \
         || die "Could not import the installed bridge CLI"
@@ -5419,7 +5436,7 @@ PY
     restored_gateway_version="$("${INSTALL_DIR}/defenseclaw-gateway" --version 2>&1 \
         | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
     [[ "${restored_gateway_version}" == "${CURRENT_VERSION}" ]] || rollback_failed=1
-    restored_cli_version="$("${DEFENSECLAW_VENV}/bin/defenseclaw" --version 2>&1 \
+    restored_cli_version="$(PYTHONDONTWRITEBYTECODE=1 "${DEFENSECLAW_VENV}/bin/defenseclaw" --version 2>&1 \
         | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
     [[ "${restored_cli_version}" == "${CURRENT_VERSION}" ]] || rollback_failed=1
 


### PR DESCRIPTION
Release-unblock follow-up for failed workflow run #29209417227. Merge this before retrying the 0.8.4 release; it does not include observability v8 work.

## Problem

The sealed 0.8.4 candidate authenticated successfully, but downstream release gates found several cross-platform defects:

- POSIX and Windows phase-one custody renamed authenticated wheels to filenames that `uv` rejects as invalid wheels.
- A restored source CLI version probe could write bytecode before the recovery journal closed.
- macOS fresh-install testing used a logical temp path whose symlinked ancestor was correctly refused by the hardened installer.
- Windows PowerShell 5.1 rejected an empty rollback-residue list.
- Windows Server 2025 allowed directory rename under the prior lease access mode.
- Windows `lstat` and `fstat` timestamp representations could differ for the same object.
- The published-source canary treated `gateway status` as ready while exact health still reported `reconnecting`.

## Current Situation

Run #29209417227 ended in failure with publish skipped. No `0.8.4` tag or GitHub release was created, so no broken release reached users.

The candidate, checksums, and Sigstore verification passed. The failures were confined to upgrade execution and release test contracts.

## Solution

### Keep authenticated wheels installable

Retain each materialized wheel under its valid PEP 427 basename on POSIX and Windows, and reconstruct the same filename from the bound bridge/source version during recovery.

### Close rollback without mutating custody

Set `PYTHONDONTWRITEBYTECODE=1` for source-controller version probes and add a regression that forces bridge-wheel installation failure, restores the exact source controller, and proves the phase-one journal closes.

### Repair platform-specific release gates

- Canonicalize the macOS fresh-test work directory before using it as `HOME`, and print installer logs on failure.
- Permit an empty strongly typed PowerShell rollback-residue collection.
- Request `DELETE` access without `FILE_SHARE_DELETE` for the final Windows directory lease, retaining validation handles for the full ancestor chain and same-thread nested mutators.
- Compare Windows named paths to handles using stable object identity/type/size while retaining exact handle-before/after and named-before/after mutation checks.
- Wait for exact source `running` state and expected `binary_version` before resolver handoff.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `scripts/upgrade.sh`, `scripts/upgrade.ps1` | Preserve valid wheel basenames and make source version probes bytecode-free |
| `cli/defenseclaw/windows_acl.py` | Strengthen Windows directory rename/delete lease semantics |
| `cli/defenseclaw/commands/cmd_upgrade.py` | Tolerate Windows API timestamp representation differences without dropping mutation detection |
| `scripts/install.ps1` | Accept an empty rollback-residue collection on Windows PowerShell 5.1 |
| `scripts/test-fresh-install-release.sh` | Use a physical macOS temp path and surface captured installer failures |
| `scripts/test-upgrade-release.sh` | Require exact version-bound source health before handoff |
| `scripts/test-upgrade-release-windows.ps1` | Validate the new versioned wheel custody names |
| `cli/tests/...` | Add focused release, rollback, Windows ACL, identity, and readiness regressions |

## Breaking Changes

None. This restores the intended protocol-2 upgrade and release-test behavior.

## Open Issues / Follow-ups

None.

## Test Plan

```bash
uv run pytest -q \
  cli/tests/test_upgrade_bridge_phase1_rollback.py \
  cli/tests/test_windows_acl.py \
  cli/tests/test_cmd_upgrade_windows_rollback.py \
  cli/tests/test_windows_powershell_upgrade_paths.py \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_upgrade_release_smoke_contract.py
# 124 passed, 11 skipped

uv run pytest -q \
  cli/tests/test_cmd_upgrade_windows_rollback.py \
  cli/tests/test_windows_acl.py \
  cli/tests/test_windows_powershell_upgrade_paths.py::test_windows_phase_one_custody_keeps_pep427_wheel_names \
  cli/tests/test_upgrade_bridge_phase1_rollback.py::test_bridge_rollback_health_is_version_bound_and_custody_is_collision_safe
# 42 passed, 8 skipped

uv run ruff check \
  cli/defenseclaw/commands/cmd_upgrade.py \
  cli/defenseclaw/windows_acl.py \
  cli/tests/test_cmd_upgrade_windows_rollback.py \
  cli/tests/test_windows_acl.py
# All checks passed

bash -n \
  scripts/upgrade.sh \
  scripts/test-upgrade-release.sh \
  scripts/test-fresh-install-release.sh
# passed

git diff --check
# passed

PATH="/tmp/defenseclaw-tools:$PATH" \
  make upgrade-refusal-contract-matrix ARGS='--baseline-mode seed'
# Built and checksum-bound the 0.8.4 candidate; authenticated every published
# baseline from 0.8.3 through 0.4.0; both explicit and latest refusal contracts
# passed; emitted the complete success receipt. The local process was interrupted
# only while recursively deleting its large temporary build tree afterward.
```

A targeted Claude Opus review was also run over the release/recovery diff. Its filename and variable-binding concerns were checked against the complete materialization and journal code; no actionable issue remained.
