### PR TITLE
fix(release): repair cross-platform sealed upgrade gates

### DIFF
--- a/cli/defenseclaw/commands/cmd_upgrade.py
+++ b/cli/defenseclaw/commands/cmd_upgrade.py
@@ -4053,10 +4053,11 @@ def _poll_health(
 
     ``gateway.state=running`` alone is insufficient during a replacement or
     rollback: a target process that failed to stop can keep answering on the
-    old socket and make the transaction look successful.  Release gateways
-    expose their binary version in the health provenance quartet, so callers
-    that know the expected release require an exact match before accepting the
-    response.
+    old socket and make the transaction look successful. An intentionally
+    disabled fleet uplink is also healthy when the local API is serving.
+    Release gateways expose their binary version in the health provenance
+    quartet, so callers that know the expected release require an exact match
+    before accepting either state.
     """
     from defenseclaw.gateway import OrchestratorClient
 
@@ -4103,7 +4104,7 @@ def _poll_health(
                 if gw_state != last_state:
                     click.echo(f"    {ux.dim('gateway:')} {gw_state}")
                     last_state = gw_state
-                if gw_state == "running":
+                if gw_state in {"running", "disabled"}:
                     if expected_version is not None:
                         provenance = snap.get("provenance")
                         reported_version = provenance.get("binary_version") if isinstance(provenance, dict) else None
@@ -4118,7 +4119,10 @@ def _poll_health(
                                 last_reported_version = version_label
                             time.sleep(2)
                             continue
-                    ux.ok("Gateway is healthy")
+                    if gw_state == "disabled":
+                        ux.ok("Gateway API is healthy; fleet uplink is disabled by configuration")
+                    else:
+                        ux.ok("Gateway is healthy")
                     return
             else:
                 # 2xx with an empty/non-dict body — treat like unreachable so

--- a/cli/tests/test_cmd_upgrade.py
+++ b/cli/tests/test_cmd_upgrade.py
@@ -3773,6 +3773,38 @@ class TestUpgradeServiceVerification(unittest.TestCase):
 
         self.assertEqual(client.health.call_count, 2)
 
+    def test_health_accepts_disabled_fleet_only_with_expected_binary_provenance(self):
+        client = Mock()
+        client.health.side_effect = [
+            {
+                "gateway": {"state": "disabled"},
+                "provenance": {},
+            },
+            {
+                "gateway": {"state": "disabled"},
+                "provenance": {"binary_version": "0.8.3"},
+            },
+            {
+                "gateway": {"state": "disabled"},
+                "provenance": {"binary_version": "0.8.4"},
+            },
+        ]
+        with (
+            patch("defenseclaw.gateway.OrchestratorClient", return_value=client),
+            patch(
+                "defenseclaw.commands.cmd_upgrade.time.monotonic",
+                side_effect=[0.0, 0.0, 0.0, 0.0],
+            ),
+            patch("defenseclaw.commands.cmd_upgrade.time.sleep"),
+        ):
+            _poll_health(
+                Config(),
+                timeout_seconds=1,
+                expected_version="0.8.4",
+            )
+
+        self.assertEqual(client.health.call_count, 3)
+
     def test_restart_and_health_use_fresh_post_migration_config_and_dotenv(self):
         app = AppContext()
         app.cfg = Config(gateway=GatewayConfig(api_port=19001, token="stale-value"))

--- a/cli/tests/test_cmd_upgrade.py
+++ b/cli/tests/test_cmd_upgrade.py
@@ -3791,6 +3791,7 @@ class TestUpgradeServiceVerification(unittest.TestCase):
         ]
         with (
             patch("defenseclaw.gateway.OrchestratorClient", return_value=client),
+            patch("defenseclaw.commands.cmd_upgrade.ux.ok") as ok,
             patch(
                 "defenseclaw.commands.cmd_upgrade.time.monotonic",
                 side_effect=[0.0, 0.0, 0.0, 0.0],
@@ -3804,6 +3805,9 @@ class TestUpgradeServiceVerification(unittest.TestCase):
             )
 
         self.assertEqual(client.health.call_count, 3)
+        ok.assert_called_once_with(
+            "Gateway API is healthy; fleet uplink is disabled by configuration"
+        )
 
     def test_restart_and_health_use_fresh_post_migration_config_and_dotenv(self):
         app = AppContext()

--- a/cli/tests/test_historical_release_auth.py
+++ b/cli/tests/test_historical_release_auth.py
@@ -72,6 +72,42 @@ def test_legacy_base64_certificate_is_normalized(tmp_path: Path) -> None:
     assert historical_release_auth.normalized_certificate_bytes(encoded) == PEM
 
 
+def test_windows_named_and_opened_timestamp_views_do_not_false_positive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "checksums.txt"
+    payload = b"authenticated checksums\n"
+    path.write_bytes(payload)
+    real_os = os
+
+    class _WindowsOsProxy:
+        name = "nt"
+        path = real_os.path
+
+        def lstat(self, candidate: str | os.PathLike[str]):
+            info = real_os.lstat(candidate)
+
+            class _TimestampSkewedStat:
+                st_ctime_ns = info.st_ctime_ns + 1
+
+                def __getattr__(self, name: str):
+                    return getattr(info, name)
+
+            return _TimestampSkewedStat()
+
+        def __getattr__(self, name: str):
+            return getattr(real_os, name)
+
+    monkeypatch.setattr(historical_release_auth, "os", _WindowsOsProxy())
+
+    assert historical_release_auth._read_bounded_regular_file(
+        path,
+        "historical checksums",
+        max_bytes=1024,
+    ) == payload
+
+
 def test_oversized_historical_trust_input_fails_before_verification(tmp_path: Path) -> None:
     release, cosign, policy, asset = _release_fixture(tmp_path)
     (release / "checksums.txt.pem").write_bytes(

--- a/cli/tests/test_historical_release_auth.py
+++ b/cli/tests/test_historical_release_auth.py
@@ -79,33 +79,29 @@ def test_windows_named_and_opened_timestamp_views_do_not_false_positive(
     path = tmp_path / "checksums.txt"
     payload = b"authenticated checksums\n"
     path.write_bytes(payload)
-    real_os = os
+    real_lstat = Path.lstat
+    lstat_calls: list[Path] = []
 
-    class _WindowsOsProxy:
-        name = "nt"
-        path = real_os.path
+    def timestamp_skewed_lstat(candidate: Path):
+        lstat_calls.append(candidate)
+        info = real_lstat(candidate)
 
-        def lstat(self, candidate: str | os.PathLike[str]):
-            info = real_os.lstat(candidate)
+        class _TimestampSkewedStat:
+            st_ctime_ns = info.st_ctime_ns + 1
 
-            class _TimestampSkewedStat:
-                st_ctime_ns = info.st_ctime_ns + 1
+            def __getattr__(self, name: str):
+                return getattr(info, name)
 
-                def __getattr__(self, name: str):
-                    return getattr(info, name)
+        return _TimestampSkewedStat()
 
-            return _TimestampSkewedStat()
-
-        def __getattr__(self, name: str):
-            return getattr(real_os, name)
-
-    monkeypatch.setattr(historical_release_auth, "os", _WindowsOsProxy())
+    monkeypatch.setattr(Path, "lstat", timestamp_skewed_lstat)
 
     assert historical_release_auth._read_bounded_regular_file(
         path,
         "historical checksums",
         max_bytes=1024,
     ) == payload
+    assert lstat_calls == [path, path]
 
 
 def test_oversized_historical_trust_input_fails_before_verification(tmp_path: Path) -> None:

--- a/cli/tests/test_install_docs_static.py
+++ b/cli/tests/test_install_docs_static.py
@@ -1890,6 +1890,11 @@ def test_windows_install_protected_materialization_binds_exact_signed_outer_byte
     assert "$script:WheelInnerSha256 = Copy-AuthenticatedPrivateArtifact" in installer
     assert "$script:GatewayArchiveInnerSha256 = Copy-AuthenticatedPrivateArtifact" in installer
     assert "Assert-ExactPrivateArtifactDigest -Path $gatewayZip" in installer
+    assert "$expandedGateway=Join-Path $extract \"defenseclaw.exe\"" in installer
+    assert "$expandedGatewaySha256=(Get-FileHash -LiteralPath $expandedGateway" in installer
+    assert "$script:GatewayBinary=Join-Path $script:PolicyDir \"defenseclaw.exe\"" in installer
+    assert "$script:GatewayBinarySha256=Copy-AuthenticatedPrivateArtifact -Source $expandedGateway" in installer
+    assert "Set-PrivateFileAcl -Path $script:GatewayBinary" not in installer
     assert "Assert-ExactPrivateArtifactDigest -Path $script:GatewayBinary" in installer
     assert "Assert-ExactPrivateArtifactDigest -Path $whlPath" in installer
     main = installer[installer.index("function Main {") :]

--- a/cli/tests/test_upgrade_bridge_phase1_rollback.py
+++ b/cli/tests/test_upgrade_bridge_phase1_rollback.py
@@ -642,7 +642,7 @@ for arg in "$@"; do
 done
 if [[ "${url}" == http://127.0.0.1:*/health ]]; then
   if [[ "${FORCE_ORPHAN_HEALTH:-0}" == '1' ]]; then
-    printf '%s\n' '{"gateway":{"state":"running"},"provenance":{"binary_version":"0.8.3"}}' > "${out}"
+    printf '%s\n' '{"gateway":{"state":"starting"},"provenance":{"binary_version":"0.8.3"}}' > "${out}"
     printf '200'
     exit 0
   fi
@@ -666,7 +666,7 @@ PY
           && "${url}" != "${TARGET_HEALTH_URL}" ]]; then
       : > "${out}"
       printf '000'
-      exit 0
+      exit 7
     fi
     printf '{"gateway":{"state":"running"},"provenance":{"binary_version":"%s"}}\n' \
       "${gateway_version}" > "${out}"
@@ -674,6 +674,7 @@ PY
   else
     : > "${out}"
     printf '000'
+    exit 7
   fi
   exit 0
 fi
@@ -894,7 +895,7 @@ cp "${FIXTURE_ROOT}/${version}/${name}" "${out}"
     if orphan_health:
         output = result.stdout + result.stderr
         assert result.returncode == 1, output
-        assert "healthy without verified live PID custody" in output
+        assert "not proven unreachable (starting) without verified live PID custody" in output
         assert not event_log.exists() or "source-stop" not in event_log.read_text(encoding="utf-8")
         assert not (controller_home / ".upgrade-recovery" / "phase-one-active.json").exists()
         assert (install_dir / "defenseclaw-gateway").read_bytes() == source_gateway_bytes

--- a/cli/tests/test_upgrade_release_smoke_contract.py
+++ b/cli/tests/test_upgrade_release_smoke_contract.py
@@ -58,8 +58,9 @@ def test_source_gateway_canary_waits_for_exact_version_bound_health() -> None:
     ]
 
     assert "http://127.0.0.1:18970/health" in canary
-    assert 'gateway.get("state") != "running"' in canary
+    assert 'gateway.get("state") not in {"running", "disabled"}' in canary
     assert 'provenance.get("binary_version") != sys.argv[2]' in canary
+    assert "version-bound healthy before resolver handoff" in canary
     assert "did not reach version-bound health" in canary
 
 

--- a/cli/tests/test_upgrade_smoke_static.py
+++ b/cli/tests/test_upgrade_smoke_static.py
@@ -112,10 +112,30 @@ def test_historical_baselines_are_authenticated_and_real_dependency_mode_is_expl
     assert 'pip check --python "${venv_python}"' in smoke
     assert "Resolved the published ${FROM_VERSION} wheel's own dependency graph" in smoke
     assert "start_source_gateway_canary" in smoke
-    assert "is running before resolver handoff" in smoke
+    assert "is version-bound healthy before resolver handoff" in smoke
     assert 'stage_authenticated_baseline "${baseline}"' in protocol
     assert "required bridge authentication failed" in protocol
     assert 'if [[ "${SUCCESS_PATH_ONLY}" == "1" ]]' in protocol
+
+
+def test_pre_v8_positive_upgrade_fixture_is_hermetic_and_non_mutating() -> None:
+    smoke = (ROOT / "scripts" / "test-upgrade-release.sh").read_text()
+    start = smoke.index("seed_pre_v8_otel_fixture() {")
+    end = smoke.index("\n}\n\nseed_v8_observability_fixture()", start)
+    fixture = smoke[start:end]
+
+    assert "guardrail:\n  enabled: false" in fixture
+    assert "gateway:\n  fleet_mode: disabled" in fixture
+    assert "watcher:\n    enabled: false" in fixture
+
+    resolver = (ROOT / "scripts" / "upgrade.sh").read_text()
+    assert '"${GW_STATE}" == "running" || "${GW_STATE}" == "disabled"' in resolver
+    assert '"${GW_VERSION}" == "${RELEASE_VERSION}"' in resolver
+    assert "fleet uplink is disabled by configuration" in resolver
+    assert 'gateway_health.get("state") in {"running", "disabled"}' in resolver
+    assert 'gateway.get("state") in {"running", "disabled"}' in resolver
+    assert '"${health_state}" == "running" || "${health_state}" == "disabled"' in resolver
+    assert '"${health_state}" != "running" && "${health_state}" != "disabled"' in resolver
 
 
 def _posix_protected_materializer_program() -> str:

--- a/cli/tests/test_upgrade_smoke_static.py
+++ b/cli/tests/test_upgrade_smoke_static.py
@@ -135,7 +135,18 @@ def test_pre_v8_positive_upgrade_fixture_is_hermetic_and_non_mutating() -> None:
     assert 'gateway_health.get("state") in {"running", "disabled"}' in resolver
     assert 'gateway.get("state") in {"running", "disabled"}' in resolver
     assert '"${health_state}" == "running" || "${health_state}" == "disabled"' in resolver
-    assert '"${health_state}" != "running" && "${health_state}" != "disabled"' in resolver
+    assert '[[ "${health_state}" == "unreachable" ]]' in resolver
+    assert "health_probe.returncode != 7" in resolver
+    assert "gateway health endpoint was not proven unreachable during phase-one recovery" in resolver
+    assert "The source health endpoint is not proven unreachable (${health_state})" in resolver
+    post_stop = resolver[
+        resolver.index('post_stop_health="$(bridge_source_health_observation)"') : resolver.index(
+            "bridge_phase1_state_transaction snapshot"
+        )
+    ]
+    assert 'post_stop_state="${post_stop_health%%$\'\\t\'*}"' in post_stop
+    assert '[[ "${post_stop_state}" == "unreachable" ]]' in post_stop
+    assert "remains live without PID custody after stop" in post_stop
 
 
 def _posix_protected_materializer_program() -> str:

--- a/cli/tests/test_windows_powershell_upgrade_paths.py
+++ b/cli/tests/test_windows_powershell_upgrade_paths.py
@@ -610,7 +610,7 @@ def test_windows_resolver_binds_hard_cut_provenance_before_mutation() -> None:
     assert "[IO.Directory]::CreateDirectory($Path, $acl)" in source
 
 
-def test_windows_success_health_is_bounded_running_and_version_bound() -> None:
+def test_windows_success_health_is_bounded_healthy_and_version_bound() -> None:
     source = RESOLVER.read_text(encoding="utf-8")
     helper = source[
         source.index("function Test-VersionBoundGatewayHealth") : source.index("function Assert-PhaseTwoGatewayStopped")
@@ -621,7 +621,7 @@ def test_windows_success_health_is_bounded_running_and_version_bound() -> None:
         "http.client.HTTPConnection",
         'connection.request("GET", "/health", headers=headers)',
         "response.read((1 << 20) + 1)",
-        'gateway.get("state") == "running"',
+        'gateway.get("state") in {"running", "disabled"}',
         'provenance.get("binary_version") == expected_version',
         "cfg.gateway.resolved_token() if loopback else",
         "-I -c $probe",
@@ -714,6 +714,14 @@ def test_windows_version_bound_health_probe_rejects_false_green_and_polls() -> N
         "gateway": {"state": "running"},
         "provenance": {"binary_version": "0.8.3"},
     }
+    disabled_wrong_version = {
+        "gateway": {"state": "disabled"},
+        "provenance": {"binary_version": "0.8.3"},
+    }
+    disabled_expected = {
+        "gateway": {"state": "disabled"},
+        "provenance": {"binary_version": "0.8.4"},
+    }
     expected = {
         "gateway": {"state": "running"},
         "provenance": {"binary_version": "0.8.4"},
@@ -721,6 +729,8 @@ def test_windows_version_bound_health_probe_rejects_false_green_and_polls() -> N
 
     assert run_probe([unhealthy]).returncode != 0
     assert run_probe([wrong_version]).returncode != 0
+    assert run_probe([disabled_wrong_version]).returncode != 0
+    assert run_probe([disabled_expected]).returncode == 0
     delayed = run_probe([unhealthy, wrong_version, expected])
     assert delayed.returncode == 0, delayed.stdout + delayed.stderr
 

--- a/scripts/historical_release_auth.py
+++ b/scripts/historical_release_auth.py
@@ -46,14 +46,17 @@ def _version_key(version: str) -> tuple[int, int, int]:
     return tuple(map(int, version.split(".")))
 
 
-def _opened_file_identity(metadata: os.stat_result) -> tuple[int, int, int, int, int]:
+def _opened_file_identity(metadata: os.stat_result) -> tuple[int, int, int, int]:
     return (
         metadata.st_dev,
         metadata.st_ino,
         metadata.st_size,
         metadata.st_mtime_ns,
-        metadata.st_ctime_ns,
     )
+
+
+def _opened_file_state(metadata: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (*_opened_file_identity(metadata), metadata.st_ctime_ns)
 
 
 def _open_bounded_regular_file(
@@ -86,8 +89,13 @@ def _open_bounded_regular_file(
         if (
             not stat.S_ISREG(opened.st_mode)
             or not stat.S_ISREG(path_after.st_mode)
+            # CPython on Windows exposes creation time as pathname st_ctime,
+            # but NTFS change time as descriptor st_ctime. Bind the pathname
+            # to the descriptor without comparing those incompatible fields,
+            # then retain ctime in each same-API mutation check.
             or _opened_file_identity(path_before) != _opened_file_identity(opened)
             or _opened_file_identity(path_after) != _opened_file_identity(opened)
+            or _opened_file_state(path_before) != _opened_file_state(path_after)
         ):
             raise HistoricalReleaseAuthError(f"{label} changed while being opened: {path}")
         if opened.st_size <= 0 or opened.st_size > max_bytes:
@@ -108,7 +116,7 @@ def _assert_open_file_unchanged(
 ) -> None:
     metadata = os.fstat(descriptor)
     if (
-        _opened_file_identity(metadata) != _opened_file_identity(expected_metadata)
+        _opened_file_state(metadata) != _opened_file_state(expected_metadata)
         or bytes_read != expected_metadata.st_size
     ):
         raise HistoricalReleaseAuthError(f"{label} changed while being read: {path}")

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2164,10 +2164,11 @@ function Initialize-ReleasePolicy {
         $extract=New-PrivateDirectory -Path (Join-Path $script:PolicyDir "gateway")
         Assert-ExactPrivateArtifactDigest -Path $gatewayZip -ExpectedSha256 $script:GatewayArchiveInnerSha256 -Label "protected gateway archive"
         Expand-Archive -LiteralPath $gatewayZip -DestinationPath $extract
-        $script:GatewayBinary=Join-Path $extract "defenseclaw.exe"
-        if(-not(Test-Path -LiteralPath $script:GatewayBinary -PathType Leaf)){Die "Protected gateway archive lacks defenseclaw.exe"}
-        Set-PrivateFileAcl -Path $script:GatewayBinary
-        $script:GatewayBinarySha256=(Get-FileHash -LiteralPath $script:GatewayBinary -Algorithm SHA256).Hash.ToLowerInvariant()
+        $expandedGateway=Join-Path $extract "defenseclaw.exe"
+        if(-not(Test-Path -LiteralPath $expandedGateway -PathType Leaf)){Die "Protected gateway archive lacks defenseclaw.exe"}
+        $expandedGatewaySha256=(Get-FileHash -LiteralPath $expandedGateway -Algorithm SHA256).Hash.ToLowerInvariant()
+        $script:GatewayBinary=Join-Path $script:PolicyDir "defenseclaw.exe"
+        $script:GatewayBinarySha256=Copy-AuthenticatedPrivateArtifact -Source $expandedGateway -Destination $script:GatewayBinary -ExpectedSha256 $expandedGatewaySha256
     }else{
         if(-not $schemaProperty -or [int]$schemaProperty.Value -ne 1 -or $releaseArtifactsProperty){Die "Legacy release policy is invalid"}
     }

--- a/scripts/test-upgrade-release.sh
+++ b/scripts/test-upgrade-release.sh
@@ -154,14 +154,14 @@ gateway = payload.get("gateway") if isinstance(payload, dict) else None
 provenance = payload.get("provenance") if isinstance(payload, dict) else None
 if (
     not isinstance(gateway, dict)
-    or gateway.get("state") != "running"
+    or gateway.get("state") not in {"running", "disabled"}
     or not isinstance(provenance, dict)
     or provenance.get("binary_version") != sys.argv[2]
 ):
     raise SystemExit(1)
 PY
         then
-            ok "Published source gateway ${FROM_VERSION} is running before resolver handoff"
+            ok "Published source gateway ${FROM_VERSION} is version-bound healthy before resolver handoff"
             return 0
         fi
         sleep 0.25
@@ -1109,6 +1109,12 @@ seed_pre_v8_otel_fixture() {
     mkdir -p "${SMOKE_HOME}/.defenseclaw"
     cat >"${SMOKE_HOME}/.defenseclaw/config.yaml" <<YAML
 config_version: ${FROM_CONFIG_VERSION}
+guardrail:
+  enabled: false
+gateway:
+  fleet_mode: disabled
+  watcher:
+    enabled: false
 otel:
   enabled: true
   protocol: grpc

--- a/scripts/upgrade.ps1
+++ b/scripts/upgrade.ps1
@@ -2499,7 +2499,7 @@ while time.monotonic() < deadline:
             provenance = payload.get("provenance") if isinstance(payload, dict) else None
             if (
                 isinstance(gateway, dict)
-                and gateway.get("state") == "running"
+                and gateway.get("state") in {"running", "disabled"}
                 and isinstance(provenance, dict)
                 and provenance.get("binary_version") == expected_version
             ):

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2492,7 +2492,7 @@ if resume_unsealed_bridge:
                 probe.returncode == 0
                 and (probe.stdout or "").strip() == "200"
                 and isinstance(gateway_health, dict)
-                and gateway_health.get("state") == "running"
+                and gateway_health.get("state") in {"running", "disabled"}
                 and isinstance(provenance, dict)
                 and provenance.get("binary_version") == bridge_version
             ):
@@ -2732,7 +2732,7 @@ if source_was_running:
                 probe.returncode == 0
                 and (probe.stdout or "").strip() == "200"
                 and isinstance(gateway, dict)
-                and gateway.get("state") == "running"
+                and gateway.get("state") in {"running", "disabled"}
                 and isinstance(provenance, dict)
                 and provenance.get("binary_version") == source_version
             ):
@@ -5098,7 +5098,7 @@ PY
         || die "Could not inspect source gateway health before stopping services."
     health_state="${health_fields%%$'\t'*}"
     health_version="${health_fields#*$'\t'}"
-    if [[ "${health_state}" == "running" ]]; then
+    if [[ "${health_state}" == "running" || "${health_state}" == "disabled" ]]; then
         [[ "${health_version}" == "${CURRENT_VERSION}" ]] \
             || die "A gateway is healthy but reports ${health_version:-missing}, not source ${CURRENT_VERSION}; refusing before stopping services."
         [[ "${pid_state}" == "live" ]] \
@@ -5199,7 +5199,8 @@ bridge_source_health_check() {
         health_fields="$(bridge_source_health_observation)" || return 1
         state="${health_fields%%$'\t'*}"
         version="${health_fields#*$'\t'}"
-        if [[ "${state}" == "running" && "${version}" == "${CURRENT_VERSION}" ]]; then
+        if [[ ( "${state}" == "running" || "${state}" == "disabled" ) \
+              && "${version}" == "${CURRENT_VERSION}" ]]; then
             return 0
         fi
         sleep 1
@@ -5215,7 +5216,7 @@ bridge_phase1_gateway_quiesced() {
     [[ "${pid_state}" != "live" ]] || return 1
     health_fields="$(bridge_source_health_observation)" || return 1
     health_state="${health_fields%%$'\t'*}"
-    [[ "${health_state}" != "running" ]]
+    [[ "${health_state}" != "running" && "${health_state}" != "disabled" ]]
 }
 
 bridge_phase1_gateway_activation_owned() {
@@ -5460,7 +5461,8 @@ PY
         [[ "${pid_state}" != "live" ]] || rollback_failed=1
         health_fields="$(bridge_source_health_observation)" || rollback_failed=1
         health_state="${health_fields%%$'\t'*}"
-        [[ "${health_state}" != "running" ]] || rollback_failed=1
+        [[ "${health_state}" != "running" && "${health_state}" != "disabled" ]] \
+            || rollback_failed=1
     fi
     if [[ "${rollback_failed}" -eq 0 ]] && command -v openclaw >/dev/null 2>&1; then
         OPENCLAW_HOME="${OPENCLAW_HOME}" openclaw gateway restart 9>&- >/dev/null 2>&1 \
@@ -6088,12 +6090,18 @@ print(f"{state}\t{version}")
         LAST_STATE="${GW_STATE}"
     fi
 
-    if [[ "${GW_STATE}" == "running" && "${GW_VERSION}" != "${RELEASE_VERSION}" ]]; then
+    if [[ ( "${GW_STATE}" == "running" || "${GW_STATE}" == "disabled" ) \
+          && "${GW_VERSION}" != "${RELEASE_VERSION}" ]]; then
         info "    gateway version: ${GW_VERSION} (expected ${RELEASE_VERSION})"
     fi
 
-    if [[ "${GW_STATE}" == "running" && "${GW_VERSION}" == "${RELEASE_VERSION}" ]]; then
-        ok "Gateway is healthy"
+    if [[ ( "${GW_STATE}" == "running" || "${GW_STATE}" == "disabled" ) \
+          && "${GW_VERSION}" == "${RELEASE_VERSION}" ]]; then
+        if [[ "${GW_STATE}" == "disabled" ]]; then
+            ok "Gateway API is healthy; fleet uplink is disabled by configuration"
+        else
+            ok "Gateway is healthy"
+        fi
         HEALTH_OK=1
         break
     fi

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -2355,6 +2355,31 @@ for _attempt in range(6):
 else:
     raise RuntimeError("gateway did not quiesce during phase-one recovery")
 
+curl = shutil.which("curl")
+if not curl:
+    raise RuntimeError("curl is required for phase-one recovery health verification")
+health_probe = subprocess.run(
+    [
+        curl,
+        "-s",
+        "-o",
+        os.devnull,
+        "-w",
+        "%{http_code}",
+        "--max-time",
+        "2",
+        source_health_url,
+    ],
+    capture_output=True,
+    text=True,
+    timeout=5,
+    check=False,
+)
+if health_probe.returncode != 7 or (health_probe.stdout or "").strip() != "000":
+    raise RuntimeError(
+        "gateway health endpoint was not proven unreachable during phase-one recovery"
+    )
+
 restore_state_before_artifacts()
 
 if resume_unsealed_bridge:
@@ -4980,11 +5005,15 @@ PY
 }
 
 bridge_source_health_observation() {
-    local response_file http_code health_fields
+    local response_file http_code curl_status health_fields
     response_file="$(mktemp "${STAGING_DIR}/phase1-source-health.XXXXXX")" || return 1
-    http_code="$(DEFENSECLAW_HOME="${DATA_DIR}" DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
+    if http_code="$(DEFENSECLAW_HOME="${DATA_DIR}" DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
         curl -s -o "${response_file}" -w "%{http_code}" --max-time 2 \
-        "${BRIDGE_SOURCE_HEALTH_URL}" 2>/dev/null || echo "000")"
+        "${BRIDGE_SOURCE_HEALTH_URL}" 2>/dev/null)"; then
+        curl_status=0
+    else
+        curl_status=$?
+    fi
     health_fields="$(python3 - "${response_file}" <<'PY' 2>/dev/null || true
 import json
 import os
@@ -5007,8 +5036,12 @@ print(f"{state}\t{version}")
 PY
 )"
     rm -f "${response_file}"
-    if [[ "${http_code}" != "200" ]]; then
+    if [[ "${curl_status}" -eq 7 && "${http_code}" == "000" ]]; then
         printf 'unreachable\tmissing\n'
+    elif [[ "${curl_status}" -ne 0 ]]; then
+        printf 'indeterminate\tmissing\n'
+    elif [[ "${http_code}" != "200" ]]; then
+        printf 'reachable\tmissing\n'
     elif [[ -z "${health_fields}" ]]; then
         printf 'invalid\tmissing\n'
     else
@@ -5106,8 +5139,8 @@ PY
         BRIDGE_SOURCE_WAS_RUNNING=1
     elif [[ "${pid_state}" == "live" ]]; then
         die "Verified source gateway PID ${pid} is live but version-bound health is ${health_state}; refusing before stopping services."
-    elif [[ "${health_state}" == "invalid" ]]; then
-        die "The source health endpoint returned an invalid response without verified PID custody; refusing before stopping services."
+    elif [[ "${health_state}" != "unreachable" ]]; then
+        die "The source health endpoint is not proven unreachable (${health_state}) without verified live PID custody; refusing before stopping services."
     fi
     register_bridge_phase1_recovery_journal
     # The durable journal is the recovery authority. Arm the ordinary EXIT
@@ -5216,7 +5249,7 @@ bridge_phase1_gateway_quiesced() {
     [[ "${pid_state}" != "live" ]] || return 1
     health_fields="$(bridge_source_health_observation)" || return 1
     health_state="${health_fields%%$'\t'*}"
-    [[ "${health_state}" != "running" && "${health_state}" != "disabled" ]]
+    [[ "${health_state}" == "unreachable" ]]
 }
 
 bridge_phase1_gateway_activation_owned() {
@@ -5461,8 +5494,7 @@ PY
         [[ "${pid_state}" != "live" ]] || rollback_failed=1
         health_fields="$(bridge_source_health_observation)" || rollback_failed=1
         health_state="${health_fields%%$'\t'*}"
-        [[ "${health_state}" != "running" && "${health_state}" != "disabled" ]] \
-            || rollback_failed=1
+        [[ "${health_state}" == "unreachable" ]] || rollback_failed=1
     fi
     if [[ "${rollback_failed}" -eq 0 ]] && command -v openclaw >/dev/null 2>&1; then
         OPENCLAW_HOME="${OPENCLAW_HOME}" openclaw gateway restart 9>&- >/dev/null 2>&1 \
@@ -5753,8 +5785,9 @@ assert_gateway_quiesced
 if [[ "${BRIDGE_PHASE1}" -eq 1 ]]; then
     post_stop_health="$(bridge_source_health_observation)" \
         || die "Could not verify source health quiescence after stop; the source will be restored."
-    [[ "${post_stop_health%%$'\t'*}" != "running" ]] \
-        || die "The source health endpoint remains running without PID custody after stop; the source will be restored."
+    post_stop_state="${post_stop_health%%$'\t'*}"
+    [[ "${post_stop_state}" == "unreachable" ]] \
+        || die "The source health endpoint remains live without PID custody after stop; the source will be restored."
     bridge_phase1_state_transaction snapshot \
         || die "Could not create an exact quiesced phase-one state snapshot; the source will be restored."
     seal_bridge_phase1_state_snapshot_journal \


### PR DESCRIPTION
Standalone release fix against `main`. This intentionally remains separate from the observability v8 PR (#490) and changes no GitHub teams, reviewers, rulesets, branch rules, or release environments.

## Problem

[Release run 29216060076](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29216060076) built, sealed, and verified the 0.8.4 candidate, but its cross-platform install/upgrade gates failed before publication.

## Current Situation

The failed jobs reduce to three independent implementation defects:

- Windows fresh install tried to retrofit a private DACL onto an `Expand-Archive` output, whose inherited/canonicalized ACL did not match the exact private-file contract.
- Python 3.13 on Windows exposes pathname `st_ctime` as creation time while descriptor `st_ctime` is NTFS change time, so the historical checksum reader falsely reported an authenticated file replacement.
- The hermetic POSIX upgrade fixture implicitly enabled an unavailable OpenClaw fleet and its watcher. The gateway remained `reconnecting`, the watcher created post-seal state, and the deliberately fail-closed rollback CAS then rejected that divergence.

The review also found the Windows resolver lacked parity with the POSIX/Python controllers for an intentionally disabled fleet uplink.

## Solution

### Preserve Windows private artifact custody

Re-materialize the authenticated, extracted gateway into a fresh creation-bound private file. The existing private-copy primitive verifies bytes and the exact DACL while its exclusive creation handle still pins the object.

### Compare compatible Windows file metadata

Use device/inode/size/mtime to bind a pathname to its opened descriptor. Retain ctime in pathname-to-pathname and descriptor-to-descriptor comparisons so replacement and mutation detection remain fail closed without comparing incompatible Windows API views.

### Make non-fleet upgrades deterministic

Seed the release fixture with guardrail, fleet uplink, and watcher explicitly disabled. Treat `gateway.state=disabled` as healthy only when the API reports the exact expected binary version, across POSIX, Python, and PowerShell controllers. Quiescence still treats both `running` and `disabled` as a live server, and the rollback state/root CAS is unchanged.

```mermaid
flowchart TD
    A["Authenticated source installation"] --> B{"API serving at exact source version?"}
    B -->|"running or disabled"| C["Stop and stage bridge/target"]
    B -->|"no"| X["Refuse before mutation"]
    C --> D["Start staged controller"]
    D --> E{"API serving at exact target version?"}
    E -->|"yes"| F["Commit success"]
    E -->|"no"| G["CAS-guarded rollback"]
    G --> H["Restore exact source and recheck health"]
```

## What Changed (Where & How)

| Path | Change |
|---|---|
| `scripts/install.ps1` | Re-materializes the expanded Windows gateway through the creation-bound private artifact primitive. |
| `scripts/historical_release_auth.py` | Separates cross-API file identity from same-API mutation state. |
| `scripts/test-upgrade-release.sh` | Makes the legacy fixture non-fleet/non-watching and accepts exact-version `disabled` source health. |
| `scripts/upgrade.sh` | Applies exact-version `running`/`disabled` semantics to preflight, recovery, rollback, quiescence, and target health. |
| `scripts/upgrade.ps1` | Gives the Windows staged resolver the same exact-version health semantics. |
| `cli/defenseclaw/commands/cmd_upgrade.py` | Accepts intentional disabled-fleet health only with matching target provenance. |
| `cli/tests/` | Adds Windows timestamp, disabled-provenance, hermetic-fixture, private-materialization, and PowerShell resolver regressions. |

## Breaking Changes

None. An intentionally disabled fleet uplink is now recognized as healthy only when the local gateway API is serving and reports the exact expected release version.

## Open Issues / Follow-ups

None.

## Test Plan

Passed:

```bash
bash -n scripts/upgrade.sh scripts/test-upgrade-release.sh scripts/test-upgrade-protocol-release.sh

uv run ruff check \
  scripts/historical_release_auth.py \
  cli/defenseclaw/commands/cmd_upgrade.py \
  cli/tests/test_cmd_upgrade.py \
  cli/tests/test_historical_release_auth.py \
  cli/tests/test_install_docs_static.py \
  cli/tests/test_upgrade_release_smoke_contract.py \
  cli/tests/test_upgrade_smoke_static.py \
  cli/tests/test_windows_powershell_upgrade_paths.py

uv run python -m pytest -q \
  cli/tests/test_historical_release_auth.py \
  cli/tests/test_install_docs_static.py \
  cli/tests/test_windows_powershell_upgrade_paths.py \
  cli/tests/test_upgrade_smoke_static.py \
  cli/tests/test_upgrade_release_smoke_contract.py \
  cli/tests/test_upgrade_bridge_phase1_rollback.py \
  cli/tests/test_cmd_upgrade_windows_rollback.py \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_release_candidate.py
# 245 passed, 4 skipped

uv run python -m pytest -q cli/tests/test_cmd_upgrade.py
# 171 passed, 21 subtests passed

uv run python -m pytest -q \
  cli/tests/test_windows_powershell_upgrade_paths.py \
  cli/tests/test_upgrade_smoke_static.py \
  cli/tests/test_upgrade_release_smoke_contract.py
# 52 passed, 3 skipped

uv run python -m pytest -q \
  cli/tests/test_historical_release_auth.py \
  cli/tests/test_upgrade_smoke_static.py \
  cli/tests/test_upgrade_release_smoke_contract.py \
  cli/tests/test_cmd_upgrade.py::TestUpgradeServiceVerification::test_health_accepts_disabled_fleet_only_with_expected_binary_provenance \
  cli/tests/test_upgrade_bridge_phase1_rollback.py
# 72 passed

go test ./internal/gateway -run '^TestRunGatewayLoop_StandaloneRespectsFleetModeOverride$' -count=1
# pass

git diff --check
```

Targeted Claude Opus and independent release-safety reviews were run before publication and after review-feedback fixes. Their actionable parity and post-stop quiescence findings are included here with executable regression coverage.
