### PR TITLE
fix(release): finish Windows bridge gates

### DIFF
--- a/cli/tests/test_windows_powershell_upgrade_paths.py
+++ b/cli/tests/test_windows_powershell_upgrade_paths.py
@@ -118,6 +118,9 @@ def test_windows_fresh_installer_rolls_back_exact_attempt_owned_payloads() -> No
         "DeleteTreeExact",
         "ConfigureTestMoveOutAfterSnapshot",
         "ClearTestMoveOutAfterSnapshot",
+        "ConfigureTestEmptyDirectoryDeleteFailures",
+        "ClearTestEmptyDirectoryDeleteFailures",
+        "ConsumeTestEmptyDirectoryDeleteFailure",
         "DeleteEmptyDirectoryExact",
         "MAX_TREE_DEPTH",
         "MAX_TREE_NODES",
@@ -227,6 +230,7 @@ def test_windows_fresh_installer_rolls_back_exact_attempt_owned_payloads() -> No
     assert "Native private directory lifecycle passed" in source
     assert "Native snapshotted-child move-out refusal passed" in source
     assert "Native fresh directory fault boundaries passed" in source
+    assert "Native empty directory rollback retry passed" in source
     assert "Native private-directory self-test accepted a file as its parent" in source
     assert "Fresh-install payload rollback completed; retry is safe" in harness
     assert "Concurrent unclaimed shim disappeared during rollback" in harness
@@ -348,6 +352,14 @@ def test_windows_private_custody_cleanup_is_creation_bound_and_identity_exact() 
     assert "InjectConcurrentUserPathBeforePublish" not in source
     assert 'SetEnvironmentVariable("Path"' not in source
     assert "FreshInstallPublishedProcessPath" in undo
+    assert '$maximumAttempts = if ($entry.Kind -ceq "EmptyDirectory") { 5 } else { 1 }' in undo
+    assert "$removed = Remove-FreshInstallClaim -Entry $entry" in undo
+    assert "Start-Sleep -Milliseconds (50 * $attempt)" in undo
+    retry = undo[
+        undo.index("$maximumAttempts = if") : undo.index("if (-not $removed)")
+    ]
+    assert retry.index("Remove-FreshInstallClaim") < retry.index("Start-Sleep")
+    assert undo.index("if (-not $removed)") < undo.index("$entry.Native.Dispose()")
 
     no_stage_identity = fresh_directory[
         fresh_directory.index("if (-not $stageIdentity)") : fresh_directory.index('$cleanupFailure = ""')
@@ -748,6 +760,46 @@ def test_windows_release_authentication_output_cannot_pollute_manifest_return() 
     assert capture in release_set
     assert release_set.index(capture) < release_set.index(status) < release_set.index(host)
     assert release_set.index(host) < release_set.index(gate)
+    assert "[void](Add-Type -AssemblyName System.IO.Compression.FileSystem)" in release_set
+    assert "[void](Expand-Archive -LiteralPath $protectedGateway" in release_set
+    assert "[void](Assert-ReleaseSet -Directory $destination -Version $TargetVersion)" in source
+    assert "[void](Copy-CandidateRelease)" in source
+    assert "$candidateManifestPath = Join-Path (Join-Path $script:ReleaseRoot $TargetVersion)" in source
+    assert "Get-Content -LiteralPath $candidateManifestPath" in source
+    assert "$candidateManifest -isnot [pscustomobject]" in source
+    assert source.index("[void](Copy-CandidateRelease)") < source.index(
+        "$hardCut = Assert-CandidatePolicy -Manifest $candidateManifest"
+    )
+    assert "$candidateReleaseOutput" not in source
+
+
+@pytest.mark.skipif(
+    not (shutil.which("pwsh") or shutil.which("powershell.exe") or shutil.which("powershell")),
+    reason="PowerShell is unavailable on this host",
+)
+def test_powershell_archive_refusal_preserves_scalar_manifest_output() -> None:
+    executable = shutil.which("pwsh") or shutil.which("powershell.exe") or shutil.which("powershell")
+    assert executable is not None
+    command = (
+        "$archive=[IO.Path]::GetTempFileName(); "
+        "$destination=$archive + '-out'; "
+        "function Get-Manifest([string]$path,[string]$destination) { "
+        "try{[void](Expand-Archive -LiteralPath $path -DestinationPath $destination -ErrorAction Stop)}catch{}; "
+        "return [pscustomobject]@{schema_version=2} }; "
+        "try{$result=@(Get-Manifest $archive $destination); "
+        "if($result.Count -ne 1 -or $result[0].schema_version -ne 2){exit 1}} "
+        "finally{Remove-Item -LiteralPath $archive -Force -ErrorAction SilentlyContinue; "
+        "Remove-Item -LiteralPath $destination -Recurse -Force -ErrorAction SilentlyContinue}"
+    )
+    completed = subprocess.run(
+        [executable, "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        env={**os.environ, "POWERSHELL_TELEMETRY_OPTOUT": "1"},
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
 def test_windows_release_harness_accepts_both_reviewed_config_map_topologies() -> None:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -278,6 +278,7 @@ namespace DefenseClaw.Install.FreshV1 {
         private readonly string path;
         private static string testMoveOutSource;
         private static string testMoveOutDestination;
+        private static int testEmptyDirectoryDeleteFailures;
 
         private FreshPathClaim(
             string claimedPath,
@@ -485,6 +486,35 @@ namespace DefenseClaw.Install.FreshV1 {
             testMoveOutDestination = null;
         }
 
+        public static void ConfigureTestEmptyDirectoryDeleteFailures(int failures) {
+            if (failures < 0) {
+                throw new ArgumentOutOfRangeException("failures");
+            }
+            System.Threading.Interlocked.Exchange(
+                ref testEmptyDirectoryDeleteFailures,
+                failures);
+        }
+
+        public static void ClearTestEmptyDirectoryDeleteFailures() {
+            System.Threading.Interlocked.Exchange(ref testEmptyDirectoryDeleteFailures, 0);
+        }
+
+        private static bool ConsumeTestEmptyDirectoryDeleteFailure() {
+            while (true) {
+                int current = System.Threading.Volatile.Read(
+                    ref testEmptyDirectoryDeleteFailures);
+                if (current <= 0) {
+                    return false;
+                }
+                if (System.Threading.Interlocked.CompareExchange(
+                    ref testEmptyDirectoryDeleteFailures,
+                    current - 1,
+                    current) == current) {
+                    return true;
+                }
+            }
+        }
+
         private static void InvokeTestMoveOutAfterSnapshot() {
             string source = testMoveOutSource;
             string destination = testMoveOutDestination;
@@ -609,6 +639,9 @@ namespace DefenseClaw.Install.FreshV1 {
             }
             if (!deleteAccess) {
                 throw new InvalidOperationException("directory rollback claim lacks DELETE access");
+            }
+            if (ConsumeTestEmptyDirectoryDeleteFailure()) {
+                return false;
             }
             bool deleted = MarkDelete(handle, true);
             if (deleted) {
@@ -1167,6 +1200,24 @@ function New-PrivateFileStream {
 
 function Invoke-NativeFreshDirectoryBoundarySelfTest {
     param([Parameter(Mandatory = $true)][string]$Root)
+    $retryTarget = Join-Path $Root ("fresh-empty-retry-" + [guid]::NewGuid().ToString("N"))
+    $script:FreshInstallClaims = New-Object 'System.Collections.Generic.List[object]'
+    $script:FreshInstallAttemptActive = $true
+    $script:FreshInstallOriginalProcessPath = $env:PATH
+    $script:FreshInstallPublishedProcessPath = $null
+    try {
+        New-FreshInstallOwnedDirectory -Path $retryTarget -Kind EmptyDirectory
+        [DefenseClaw.Install.FreshV1.FreshPathClaim]::ConfigureTestEmptyDirectoryDeleteFailures(1)
+        $retryResidue = @(Undo-FreshInstallAttempt)
+        if ($retryResidue.Count -ne 0 -or (Test-InstallMarker -Path $retryTarget)) {
+            Die "Native empty-directory rollback did not recover from a transient nonempty result"
+        }
+    } finally {
+        [DefenseClaw.Install.FreshV1.FreshPathClaim]::ClearTestEmptyDirectoryDeleteFailures()
+        if ($script:FreshInstallAttemptActive) { [void](Undo-FreshInstallAttempt) }
+    }
+    Write-Host "Native empty directory rollback retry passed" -ForegroundColor Green
+
     $exactCleanupModes = @(
         "pre-registration",
         "pre-rekey",
@@ -1875,7 +1926,21 @@ function Undo-FreshInstallAttempt {
             $entry = $script:FreshInstallClaims[$index]
             if ($entry.Kind -ne $kind) { continue }
             try {
-                if (-not (Remove-FreshInstallClaim -Entry $entry)) {
+                # Windows can briefly report an installer-owned parent as
+                # nonempty while an exact child-tree deletion settles. Keep
+                # the same identity handle across a bounded retry window, but
+                # only for empty-directory deletion: file/tree retries could
+                # otherwise consume state that appeared concurrently.
+                $maximumAttempts = if ($entry.Kind -ceq "EmptyDirectory") { 5 } else { 1 }
+                $removed = $false
+                for ($attempt = 1; $attempt -le $maximumAttempts; $attempt++) {
+                    $removed = Remove-FreshInstallClaim -Entry $entry
+                    if ($removed) { break }
+                    if ($attempt -lt $maximumAttempts) {
+                        Start-Sleep -Milliseconds (50 * $attempt)
+                    }
+                }
+                if (-not $removed) {
                     [void]$residue.Add(
                         "changed or nonempty attempt path was preserved: $($entry.Path)"
                     )

--- a/scripts/test-upgrade-release-windows.ps1
+++ b/scripts/test-upgrade-release-windows.ps1
@@ -537,7 +537,7 @@ function Assert-ReleaseSet {
         Fail "Signed release authentication failed for $Version"
     }
     if((Compare-Version $Version $script:BridgeVersion)-ge 0){
-        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        [void](Add-Type -AssemblyName System.IO.Compression.FileSystem)
         $protectedWheel=Join-Path $Directory "defenseclaw-$Version-2-py3-none-any.dcwheel"
         $protectedGateway=Join-Path $Directory "defenseclaw_$($Version)_protocol2_windows_amd64.dcgateway"
         foreach($path in @($protectedWheel,$protectedGateway)){
@@ -552,7 +552,7 @@ function Assert-ReleaseSet {
         $expandDestination=Join-Path $script:WorkRoot ("protected-expand-refusal-"+[guid]::NewGuid().ToString("N"))
         try{
             $expanded=$false
-            try{Expand-Archive -LiteralPath $protectedGateway -DestinationPath $expandDestination -ErrorAction Stop;$expanded=$true}catch{}
+            try{[void](Expand-Archive -LiteralPath $protectedGateway -DestinationPath $expandDestination -ErrorAction Stop);$expanded=$true}catch{}
             if($expanded){Fail "Protected .dcgateway remained directly consumable by Expand-Archive"}
         }finally{Remove-Item -LiteralPath $expandDestination -Recurse -Force -ErrorAction SilentlyContinue}
         foreach($name in @("defenseclaw-$Version-py3-none-any.whl","defenseclaw_${Version}_windows_amd64.zip")){
@@ -635,9 +635,8 @@ function Copy-CandidateRelease {
             Set-PrivatePathAcl -Path $copied
         }
     }
-    $manifest = Assert-ReleaseSet -Directory $destination -Version $TargetVersion
+    [void](Assert-ReleaseSet -Directory $destination -Version $TargetVersion)
     [void](Assert-SealedCandidateResolver -Directory $destination)
-    return $manifest
 }
 
 function Get-PublishedAsset {
@@ -2642,7 +2641,17 @@ function Main {
     $script:ReleaseRoot = New-PrivateDirectory -Path (Join-Path $script:WorkRoot "releases")
 
     Write-Step "Authenticating sealed candidate $TargetVersion"
-    $candidateManifest = Copy-CandidateRelease
+    [void](Copy-CandidateRelease)
+    $candidateManifestPath = Join-Path (Join-Path $script:ReleaseRoot $TargetVersion) "upgrade-manifest.json"
+    try {
+        $candidateManifest = Get-Content -LiteralPath $candidateManifestPath `
+            -Raw -Encoding UTF8 | ConvertFrom-Json
+    } catch {
+        Fail "Authenticated sealed candidate manifest could not be read"
+    }
+    if ($candidateManifest -isnot [pscustomobject]) {
+        Fail "Authenticated sealed candidate manifest is not one JSON object"
+    }
     $hardCut = Assert-CandidatePolicy -Manifest $candidateManifest
     [void](Ensure-PublishedRelease -Version $script:OldBaseline)
     if ($hardCut) {


### PR DESCRIPTION
Standalone release fix against `main`, following merged PR #492. This remains intentionally separate from observability v8 PR #490.

## Problem

Post-merge Release run 29221447688 passed 39 jobs but failed its five Windows gates, preventing publication of the 0.8.4 bridge.

## Current Situation

- All four Windows 0.8.x upgrade jobs authenticated the sealed candidate and passed 48 native tests, then rejected a valid manifest as missing its tested-source policy.
- The Windows fresh-install job verified the candidate and signature, then found `.defenseclaw` after the post-directory-move rollback injection.
- The signed candidate manifest contains both required tested-source fields; Linux and macOS release matrices are green.

## Solution

```mermaid
flowchart LR
    A["Signed candidate"] --> B["Private candidate directory"]
    B --> C["Suppress procedural PowerShell output"]
    B --> D["Read one authenticated manifest object"]
    D --> E["Validate release policy before mutation"]
    F["Exact child rollback"] --> G["Retry empty parent with same identity handle"]
    G --> H["Delete only if still empty"]
```

### Make manifest policy input scalar and explicit

`Expand-Archive` can emit a `RuntimeAssembly` while auto-loading its module, even though the intentionally invalid protected envelope then throws. Suppress that procedural output, invoke candidate copying for side effects only, and read the already authenticated manifest directly from the private release directory. Require exactly one JSON object before policy validation.

### Retry only safe empty-directory rollback

Windows can briefly report an installer-owned parent as nonempty while an exact child-tree deletion settles. Retry only `EmptyDirectory` claims, with five bounded attempts and the same creation-bound native identity handle. File and tree claims remain single-shot; concurrent contents are never deleted.

### Exercise the native retry path

Add a thread-safe test hook that returns one synthetic transient-empty-directory failure without disposing the claim. The existing native Windows installer self-test now proves the retry succeeds and leaves no payload or custody behind.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `scripts/test-upgrade-release-windows.ps1` | Suppress archive/module output and re-read the authenticated private manifest as one object. |
| `scripts/install.ps1` | Add bounded identity-preserving retries for empty-directory rollback plus a native fault test. |
| `cli/tests/test_windows_powershell_upgrade_paths.py` | Cover scalar manifest flow, archive emission suppression, retry scope/order, and native test contracts. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

Observed locally:

```bash
git diff --check
uv run ruff check cli/tests/test_windows_powershell_upgrade_paths.py

uv run python -m pytest -q \
  cli/tests/test_windows_powershell_upgrade_paths.py \
  cli/tests/test_install_script_static.py
# 18 passed, 4 skipped (PowerShell unavailable locally)

uv run python -m pytest -q \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_release_candidate.py \
  cli/tests/test_upgrade_release_smoke_contract.py \
  cli/tests/test_upgrade_smoke_static.py
# 153 passed
```

Targeted independent review: Claude Opus 4.8, medium effort. No product-code findings; its one low-severity synthetic-test cleanup concern was addressed before commit.
