### PR TITLE
fix(release): close Windows rollback gates

### DIFF
--- a/cli/tests/test_windows_powershell_upgrade_paths.py
+++ b/cli/tests/test_windows_powershell_upgrade_paths.py
@@ -116,6 +116,7 @@ def test_windows_fresh_installer_rolls_back_exact_attempt_owned_payloads() -> No
         "MOVEFILE_WRITE_THROUGH",
         "DeleteFileExact",
         "DeleteTreeExact",
+        "TREE_ROOT_DELETE_ATTEMPTS",
         "ConfigureTestMoveOutAfterSnapshot",
         "ClearTestMoveOutAfterSnapshot",
         "ConfigureTestEmptyDirectoryDeleteFailures",
@@ -174,6 +175,10 @@ def test_windows_fresh_installer_rolls_back_exact_attempt_owned_payloads() -> No
     assert "return false" in missing_child
     assert "continue" not in missing_child
     assert "InvokeTestMoveOutAfterSnapshot()" in tree_delete
+    assert "for (int attempt = 1; attempt <= TREE_ROOT_DELETE_ATTEMPTS; attempt++)" in tree_delete
+    assert "if (DeleteEmptyDirectoryExact())" in tree_delete
+    assert "System.Threading.Thread.Sleep(50 * attempt)" in tree_delete
+    assert tree_delete.count("SnapshotDirectory(path, 1, entries, ref bytes)") == 1
     assert "FreshInstallDestination" in source
     assert "$sourceStream" in source
     assert "$checksumDigests" in source
@@ -231,10 +236,14 @@ def test_windows_fresh_installer_rolls_back_exact_attempt_owned_payloads() -> No
     assert "Native snapshotted-child move-out refusal passed" in source
     assert "Native fresh directory fault boundaries passed" in source
     assert "Native empty directory rollback retry passed" in source
+    assert "Native tree-root rollback retry passed" in source
+    assert "Native tree-root rollback retry exhaustion passed" in source
+    assert "Native post-move rollback topology passed" in source
     assert "Native private-directory self-test accepted a file as its parent" in source
     assert "Fresh-install payload rollback completed; retry is safe" in harness
     assert "Concurrent unclaimed shim disappeared during rollback" in harness
     assert "Failed fresh install left installer-created binary directories behind" in harness
+    assert "Assert-NoFreshPayload -Context $postMove.Output" in harness
 
 
 def test_windows_private_custody_cleanup_is_creation_bound_and_identity_exact() -> None:
@@ -352,7 +361,7 @@ def test_windows_private_custody_cleanup_is_creation_bound_and_identity_exact() 
     assert "InjectConcurrentUserPathBeforePublish" not in source
     assert 'SetEnvironmentVariable("Path"' not in source
     assert "FreshInstallPublishedProcessPath" in undo
-    assert '$maximumAttempts = if ($entry.Kind -ceq "EmptyDirectory") { 5 } else { 1 }' in undo
+    assert '$maximumAttempts = if ($entry.Kind -ceq "EmptyDirectory") { 20 } else { 1 }' in undo
     assert "$removed = Remove-FreshInstallClaim -Entry $entry" in undo
     assert "Start-Sleep -Milliseconds (50 * $attempt)" in undo
     retry = undo[
@@ -771,6 +780,59 @@ def test_windows_release_authentication_output_cannot_pollute_manifest_return() 
         "$hardCut = Assert-CandidatePolicy -Manifest $candidateManifest"
     )
     assert "$candidateReleaseOutput" not in source
+
+
+def test_windows_release_snapshot_accumulators_accept_their_initial_empty_list() -> None:
+    source = RELEASE_HARNESS.read_text(encoding="utf-8")
+    snapshot_path = source[
+        source.index("function Add-SnapshotPath") : source.index("function Add-SnapshotTree")
+    ]
+    snapshot_tree = source[
+        source.index("function Add-SnapshotTree") : source.index("function Write-InstalledStateSnapshot")
+    ]
+
+    for helper in (snapshot_path, snapshot_tree):
+        rows_type = helper.index("[System.Collections.Generic.List[object]]$Rows")
+        rows_parameter = helper[:rows_type]
+        assert "[Parameter(Mandatory = $true)]" in rows_parameter
+        assert "[AllowEmptyCollection()]" in rows_parameter
+
+    assert "$rows = New-Object System.Collections.Generic.List[object]" in source
+    assert "Add-SnapshotPath -Rows $rows" in source
+    assert "Add-SnapshotTree -Rows $rows" in source
+
+
+@pytest.mark.skipif(
+    not (shutil.which("pwsh") or shutil.which("powershell.exe") or shutil.which("powershell")),
+    reason="PowerShell is unavailable on this host",
+)
+def test_powershell_release_snapshot_helpers_bind_an_empty_accumulator() -> None:
+    executable = shutil.which("pwsh") or shutil.which("powershell.exe") or shutil.which("powershell")
+    assert executable is not None
+    source = RELEASE_HARNESS.read_text(encoding="utf-8")
+    helpers = source[
+        source.index("function Add-SnapshotPath") : source.index("function Write-InstalledStateSnapshot")
+    ]
+    command = (
+        "$ErrorActionPreference='Stop'\n"
+        + helpers
+        + "\n$rows=New-Object System.Collections.Generic.List[object]\n"
+        + "$seen=@{}\n"
+        + "$case=[pscustomobject]@{Root=[IO.Path]::GetTempPath()}\n"
+        + "$missing=Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString('N'))\n"
+        + "Add-SnapshotPath -Rows $rows -Seen $seen -Case $case -Path $missing\n"
+        + "Add-SnapshotTree -Rows $rows -Seen $seen -Case $case -Path $missing\n"
+        + "if($rows.Count -ne 0){exit 9}\n"
+    )
+    completed = subprocess.run(
+        [executable, "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        env={**os.environ, "POWERSHELL_TELEMETRY_OPTOUT": "1"},
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
 @pytest.mark.skipif(

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -163,6 +163,7 @@ namespace DefenseClaw.Install.FreshV1 {
         private const int MAX_TREE_DEPTH = 64;
         private const int MAX_TREE_NODES = 500000;
         private const long MAX_TREE_BYTES = 16L * 1024L * 1024L * 1024L;
+        private const int TREE_ROOT_DELETE_ATTEMPTS = 5;
 
         [StructLayout(LayoutKind.Sequential)]
         private struct FILETIME {
@@ -740,7 +741,20 @@ namespace DefenseClaw.Install.FreshV1 {
                     current.Dispose();
                 }
             }
-            return DeleteEmptyDirectoryExact();
+            // Child delete-on-close operations can leave the exact tree root
+            // transiently nonempty on Windows. Retry only the final root
+            // disposition through this claim's existing identity handle. Do
+            // not snapshot or traverse the tree again: any concurrent child
+            // must keep the root nonempty and be preserved.
+            for (int attempt = 1; attempt <= TREE_ROOT_DELETE_ATTEMPTS; attempt++) {
+                if (DeleteEmptyDirectoryExact()) {
+                    return true;
+                }
+                if (attempt < TREE_ROOT_DELETE_ATTEMPTS) {
+                    System.Threading.Thread.Sleep(50 * attempt);
+                }
+            }
+            return false;
         }
 
         public void Dispose() {
@@ -1217,6 +1231,98 @@ function Invoke-NativeFreshDirectoryBoundarySelfTest {
         if ($script:FreshInstallAttemptActive) { [void](Undo-FreshInstallAttempt) }
     }
     Write-Host "Native empty directory rollback retry passed" -ForegroundColor Green
+
+    $treeRetryTarget = Join-Path $Root ("fresh-tree-retry-" + [guid]::NewGuid().ToString("N"))
+    $script:FreshInstallClaims = New-Object 'System.Collections.Generic.List[object]'
+    $script:FreshInstallAttemptActive = $true
+    $script:FreshInstallOriginalProcessPath = $env:PATH
+    $script:FreshInstallPublishedProcessPath = $null
+    try {
+        New-FreshInstallOwnedDirectory -Path $treeRetryTarget -Kind Tree
+        [IO.File]::WriteAllText(
+            (Join-Path $treeRetryTarget "owned.txt"),
+            "owned",
+            [Text.Encoding]::ASCII
+        )
+        [DefenseClaw.Install.FreshV1.FreshPathClaim]::ConfigureTestEmptyDirectoryDeleteFailures(1)
+        $treeRetryResidue = @(Undo-FreshInstallAttempt)
+        if ($treeRetryResidue.Count -ne 0 -or (Test-InstallMarker -Path $treeRetryTarget)) {
+            Die "Native tree-root rollback did not recover from a transient nonempty result"
+        }
+    } finally {
+        [DefenseClaw.Install.FreshV1.FreshPathClaim]::ClearTestEmptyDirectoryDeleteFailures()
+        if ($script:FreshInstallAttemptActive) { [void](Undo-FreshInstallAttempt) }
+    }
+    Write-Host "Native tree-root rollback retry passed" -ForegroundColor Green
+
+    $treeExhaustedTarget = Join-Path $Root ("fresh-tree-exhausted-" + [guid]::NewGuid().ToString("N"))
+    $script:FreshInstallClaims = New-Object 'System.Collections.Generic.List[object]'
+    $script:FreshInstallAttemptActive = $true
+    $script:FreshInstallOriginalProcessPath = $env:PATH
+    $script:FreshInstallPublishedProcessPath = $null
+    try {
+        New-FreshInstallOwnedDirectory -Path $treeExhaustedTarget -Kind Tree
+        [DefenseClaw.Install.FreshV1.FreshPathClaim]::ConfigureTestEmptyDirectoryDeleteFailures(5)
+        $treeExhaustedResidue = @(Undo-FreshInstallAttempt)
+        if ($treeExhaustedResidue.Count -eq 0 -or
+            -not (Test-InstallMarker -Path $treeExhaustedTarget)) {
+            Die "Native tree-root rollback did not preserve a root after bounded retry exhaustion"
+        }
+    } finally {
+        [DefenseClaw.Install.FreshV1.FreshPathClaim]::ClearTestEmptyDirectoryDeleteFailures()
+        if ($script:FreshInstallAttemptActive) { [void](Undo-FreshInstallAttempt) }
+        if (Test-InstallMarker -Path $treeExhaustedTarget) {
+            [IO.Directory]::Delete($treeExhaustedTarget)
+        }
+    }
+    Write-Host "Native tree-root rollback retry exhaustion passed" -ForegroundColor Green
+
+    # Mirror the real post-publication failure topology: an attempt-owned home
+    # with an empty tree child, plus a sibling bin parent whose publication
+    # fails after its staging directory has moved and been rekeyed. This is the
+    # boundary exercised by the signed fresh-release gate.
+    $topologyRoot = Join-Path $Root ("fresh-post-move-" + [guid]::NewGuid().ToString("N"))
+    $topologyHome = Join-Path $topologyRoot ".defenseclaw"
+    $topologyVenv = Join-Path $topologyHome ".venv"
+    $topologyLocal = Join-Path $topologyRoot ".local"
+    $topologyBin = Join-Path $topologyLocal "bin"
+    [void][IO.Directory]::CreateDirectory($topologyRoot)
+    $script:FreshInstallClaims = New-Object 'System.Collections.Generic.List[object]'
+    $script:FreshInstallAttemptActive = $true
+    $script:FreshInstallOriginalProcessPath = $env:PATH
+    $script:FreshInstallPublishedProcessPath = $null
+    $script:FreshDirectoryFaultMode = "open-failure"
+    $script:FreshDirectoryFaultTarget = $topologyBin
+    $topologyFailure = ""
+    try {
+        New-FreshInstallOwnedDirectory -Path $topologyHome -Kind EmptyDirectory
+        New-FreshInstallOwnedDirectory -Path $topologyVenv -Kind Tree
+        New-FreshInstallOwnedDirectory -Path $topologyLocal -Kind EmptyDirectory
+        try {
+            New-FreshInstallOwnedDirectory -Path $topologyBin -Kind EmptyDirectory
+        } catch {
+            $topologyFailure = [string]$_.Exception.Message
+        }
+        $topologyResidue = @(Undo-FreshInstallAttempt)
+        $topologySafetyResidue = @($topologyResidue | Where-Object {
+            $_ -match 'rollback safety boundary did not complete'
+        })
+        if (-not $topologyFailure -or
+            $topologySafetyResidue.Count -eq 0 -or
+            (Test-InstallMarker -Path $topologyHome) -or
+            (Test-InstallMarker -Path $topologyLocal)) {
+            Die "Native post-move rollback topology left attempt-owned payload"
+        }
+    } finally {
+        if ($script:FreshInstallAttemptActive) { [void](Undo-FreshInstallAttempt) }
+        $script:FreshDirectoryFaultMode = ""
+        $script:FreshDirectoryFaultTarget = ""
+        $script:RollbackSafetyLedger.Clear()
+        if (Test-InstallMarker -Path $topologyRoot) {
+            [IO.Directory]::Delete($topologyRoot)
+        }
+    }
+    Write-Host "Native post-move rollback topology passed" -ForegroundColor Green
 
     $exactCleanupModes = @(
         "pre-registration",
@@ -1931,7 +2037,7 @@ function Undo-FreshInstallAttempt {
                 # the same identity handle across a bounded retry window, but
                 # only for empty-directory deletion: file/tree retries could
                 # otherwise consume state that appeared concurrently.
-                $maximumAttempts = if ($entry.Kind -ceq "EmptyDirectory") { 5 } else { 1 }
+                $maximumAttempts = if ($entry.Kind -ceq "EmptyDirectory") { 20 } else { 1 }
                 $removed = $false
                 for ($attempt = 1; $attempt -le $maximumAttempts; $attempt++) {
                     $removed = Remove-FreshInstallClaim -Entry $entry

--- a/scripts/test-fresh-install-release-windows.ps1
+++ b/scripts/test-fresh-install-release-windows.ps1
@@ -141,13 +141,15 @@ function Assert-NoInstallerCustody {
 }
 
 function Assert-NoFreshPayload {
+    param([string]$Context = "")
     foreach ($path in @(
         $env:DEFENSECLAW_HOME,
         (Join-Path $HomeRoot ".local\bin\defenseclaw-gateway.exe"),
         (Join-Path $HomeRoot ".local\bin\defenseclaw.cmd")
     )) {
         if (Test-Path -LiteralPath $path) {
-            throw "Failed fresh install left a managed payload marker: $path"
+            $diagnostic = if ($Context) { "`nInstaller output:`n$Context" } else { "" }
+            throw "Failed fresh install left a managed payload marker: $path$diagnostic"
         }
     }
 }
@@ -265,7 +267,7 @@ try {
         throw "Post-move fresh-directory cleanup was not exact:`n$($postMove.Output)"
     }
     Assert-NoInstallerCustody
-    Assert-NoFreshPayload
+    Assert-NoFreshPayload -Context $postMove.Output
     if (Test-Path -LiteralPath (Join-Path $HomeRoot ".local")) {
         throw "Post-move fresh-directory failure left .local or bin custody behind"
     }

--- a/scripts/test-upgrade-release-windows.ps1
+++ b/scripts/test-upgrade-release-windows.ps1
@@ -979,7 +979,9 @@ notifications:
 
 function Add-SnapshotPath {
     param(
-        [Parameter(Mandatory = $true)][System.Collections.Generic.List[object]]$Rows,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [System.Collections.Generic.List[object]]$Rows,
         [Parameter(Mandatory = $true)][hashtable]$Seen,
         [Parameter(Mandatory = $true)][object]$Case,
         [Parameter(Mandatory = $true)][string]$Path
@@ -1016,7 +1018,9 @@ function Add-SnapshotPath {
 
 function Add-SnapshotTree {
     param(
-        [Parameter(Mandatory = $true)][System.Collections.Generic.List[object]]$Rows,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [System.Collections.Generic.List[object]]$Rows,
         [Parameter(Mandatory = $true)][hashtable]$Seen,
         [Parameter(Mandatory = $true)][object]$Case,
         [Parameter(Mandatory = $true)][string]$Path


### PR DESCRIPTION
Standalone release fix against `main`, following merged PR #493. This remains intentionally separate from observability v8 PR #490.

## Problem

Post-merge Release run [29223077113](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29223077113) passed 39 jobs but failed its five Windows gates, preventing publication of the 0.8.4 bridge.

## Current Situation

- PR #493 fixed sealed-candidate manifest output pollution: all four Windows 0.8.x upgrade jobs now authenticate the candidate and published baseline, start the loopback server, and seed the real installation.
- Those four jobs then fail before upgrade execution because the refusal snapshot passes an intentionally empty `List[object]` to mandatory `Rows` parameters that reject empty collections.
- The Windows fresh-install gate still leaves `.defenseclaw` after the post-directory-move rollback injection. The prior retry covered only outer empty-directory claims, not the exact tree root whose child delete-on-close operations may still be settling.
- Candidate provenance is exact: checkout, run-local artifact, signed checksums, certificate, manifest, and metadata all pin main commit `4f1b2308`.

## Solution

```mermaid
flowchart LR
    A["Authenticated published baseline"] --> B["Create empty snapshot accumulator"]
    B --> C["Bind with AllowEmptyCollection"]
    C --> D["Prove installer refusal without mutation"]
    E["Delete exact snapshotted tree children once"] --> F["Retry only exact tree root handle"]
    F --> G["Retry exact empty parent handle"]
    G --> H["Preserve any concurrent child and report residue"]
```

### Accept the real empty snapshot accumulator

Keep both snapshot helpers mandatory and strongly typed, while explicitly allowing the initially empty collection. The snapshot contents and refusal gate remain unchanged.

### Settle exact Windows directory deletion without re-scanning

After tree children have been identity-checked and deleted exactly once, retry only final disposition of the tree root through its existing native identity handle. Never enumerate the tree again, so a concurrent child keeps the root nonempty and is preserved.

Outer `EmptyDirectory` claims receive a longer bounded same-handle settling window. File deletion and full tree traversal remain single-shot; no retry can consume newly appeared contents.

### Exercise the actual rollback topology

The native Windows self-test now covers:

- one transient final tree-root deletion failure followed by success;
- bounded tree-root retry exhaustion preserving the root and reporting residue;
- the release gate's post-move topology: attempt-owned home, empty `.venv` tree, sibling `.local`, and a `bin` publication failure after move/rekey.

The fresh-install harness also includes captured installer output if a managed marker remains, so any future residue is diagnosable from the failed job rather than just its parent path.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `scripts/install.ps1` | Add bounded same-handle tree-root settling, extend safe empty-parent settling, and exercise success/exhaustion/post-move native rollback topologies. |
| `scripts/test-upgrade-release-windows.ps1` | Allow the snapshot helpers' mandatory generic accumulator to start empty. |
| `scripts/test-fresh-install-release-windows.ps1` | Include child installer output when post-move rollback leaves a managed marker. |
| `cli/tests/test_windows_powershell_upgrade_paths.py` | Cover retry scope, no re-snapshot invariant, native topology tests, static binding contract, and executable PowerShell empty-list binding. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

Observed locally:

```bash
git diff --check
uv run ruff check cli/tests/test_windows_powershell_upgrade_paths.py

uv run python -m pytest -q \
  cli/tests/test_windows_powershell_upgrade_paths.py \
  cli/tests/test_install_script_static.py
# 19 passed, 5 skipped (PowerShell unavailable locally)

uv run python -m pytest -q \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_release_candidate.py \
  cli/tests/test_upgrade_release_smoke_contract.py \
  cli/tests/test_upgrade_smoke_static.py
# 153 passed
```

Targeted independent review: Claude Opus, medium effort. No findings in the identity-preserving tree-root retry, concurrent-content preservation, or empty-accumulator binding fix.
