### PR TITLE
fix(release): close final Windows 0.8.4 gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,6 +445,33 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
+      - name: Native installer rollback self-test (PowerShell 5.1 + 7)
+        shell: pwsh
+        run: |
+          foreach ($engine in @("powershell.exe", "pwsh")) {
+            $root = Join-Path $env:RUNNER_TEMP (
+              "defenseclaw-native-" +
+              [IO.Path]::GetFileNameWithoutExtension($engine) +
+              "-" + [guid]::NewGuid().ToString("N")
+            )
+            [void][IO.Directory]::CreateDirectory($root)
+            try {
+              & $engine -NoProfile -NonInteractive `
+                -File .\scripts\install.ps1 `
+                -TestMode `
+                -NativePrivateDirectorySelfTestRoot $root
+              if ($LASTEXITCODE -ne 0) {
+                throw "$engine native installer self-test failed: $LASTEXITCODE"
+              }
+              if (@(Get-ChildItem -LiteralPath $root -Force).Count -ne 0) {
+                throw "$engine native installer self-test left residue"
+              }
+            } finally {
+              if (Test-Path -LiteralPath $root) {
+                [IO.Directory]::Delete($root, $true)
+              }
+            }
+          }
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod

--- a/cli/tests/test_install_script_static.py
+++ b/cli/tests/test_install_script_static.py
@@ -94,9 +94,21 @@ def test_windows_installer_smoke_never_stubs_schema2_provenance() -> None:
     assert "installer smoke stub" not in job
     assert "DEFENSECLAW-PROTECTED-ARTIFACT-V1" not in job
     assert "did not report exact 0.8.3" in job
+    assert "Native installer rollback self-test (PowerShell 5.1 + 7)" in job
+    assert '@("powershell.exe", "pwsh")' in job
+    assert "-TestMode" in job
+    assert "-NativePrivateDirectorySelfTestRoot $root" in job
+    assert "native installer self-test failed" in job
+    assert "native installer self-test left residue" in job
 
+    native = job.index("Native installer rollback self-test (PowerShell 5.1 + 7)")
     policy = job.index("Build and verify legacy installer policy fixture")
     install = job.index("Run install.ps1 against local artifacts")
+    assert native < job.index("actions/setup-go")
+    assert native < job.index("astral-sh/setup-uv")
+    assert native < job.index("Stamp legacy schema-1 installer fixture")
+    assert native < job.index("Build gateway binary + CLI wheel")
+    assert native < policy < install
     assert policy < job.index("upgrade-manifest.json", policy) < install
     assert policy < job.index("make dist-upgrade-manifest", policy) < install
     assert policy < job.index('root / "checksums.txt"', policy) < install

--- a/cli/tests/test_windows_powershell_upgrade_paths.py
+++ b/cli/tests/test_windows_powershell_upgrade_paths.py
@@ -40,6 +40,12 @@ def _main_body(source: str) -> str:
     return source[source.index(marker) :]
 
 
+def _powershell_python_here_string(source: str, variable: str) -> str:
+    marker = f"${variable}=@'\n"
+    start = source.index(marker) + len(marker)
+    return source[start : source.index("\n'@", start)]
+
+
 def test_windows_installer_refuses_existing_install_before_any_dependency_or_artifact_work() -> None:
     source = INSTALLER.read_text(encoding="utf-8")
     main = _main_body(source)
@@ -116,7 +122,15 @@ def test_windows_fresh_installer_rolls_back_exact_attempt_owned_payloads() -> No
         "MOVEFILE_WRITE_THROUGH",
         "DeleteFileExact",
         "DeleteTreeExact",
-        "TREE_ROOT_DELETE_ATTEMPTS",
+        "RetirementState",
+        "NamespaceObservation",
+        "RetirementStateValue",
+        "MutationStarted",
+        "ObserveNamespace",
+        "WaitForNamespaceRetirement",
+        "NAMESPACE_RETIRE_TIMEOUT_MS",
+        "ConfigureTestNamespaceRetirementDelay",
+        "ClearTestNamespaceRetirementDelay",
         "ConfigureTestMoveOutAfterSnapshot",
         "ClearTestMoveOutAfterSnapshot",
         "ConfigureTestEmptyDirectoryDeleteFailures",
@@ -175,10 +189,28 @@ def test_windows_fresh_installer_rolls_back_exact_attempt_owned_payloads() -> No
     assert "return false" in missing_child
     assert "continue" not in missing_child
     assert "InvokeTestMoveOutAfterSnapshot()" in tree_delete
-    assert "for (int attempt = 1; attempt <= TREE_ROOT_DELETE_ATTEMPTS; attempt++)" in tree_delete
-    assert "if (DeleteEmptyDirectoryExact())" in tree_delete
-    assert "System.Threading.Thread.Sleep(50 * attempt)" in tree_delete
+    assert "TREE_ROOT_DELETE_ATTEMPTS" not in source
+    assert "WaitForNamespaceRetirement(" in tree_delete
+    assert tree_delete.index("current.Dispose()") < tree_delete.index("WaitForNamespaceRetirement(")
+    assert "return RetireRootNamespaceExact(" in tree_delete
+    assert "never resnapshot or acquire fresh delete authority" in tree_delete
     assert tree_delete.count("SnapshotDirectory(path, 1, entries, ref bytes)") == 1
+    observer = source[
+        source.index("private static NamespaceObservation ObserveNamespace") : source.index(
+            "private static long NewNamespaceRetirementDeadline"
+        )
+    ]
+    assert "FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE" in source[
+        source.index("private static SafeFileHandle OpenNamespaceObservationHandle") : source.index(
+            "private static TestRetainer TakeTestNamespaceRetainer"
+        )
+    ]
+    assert "ERROR_FILE_NOT_FOUND" in observer
+    assert "ERROR_PATH_NOT_FOUND" in observer
+    assert "ERROR_ACCESS_DENIED" in observer
+    assert "ERROR_SHARING_VIOLATION" in observer
+    assert "ERROR_DELETE_PENDING" in observer
+    assert "NamespaceObservation.Different" in observer
     assert "FreshInstallDestination" in source
     assert "$sourceStream" in source
     assert "$checksumDigests" in source
@@ -200,6 +232,11 @@ def test_windows_fresh_installer_rolls_back_exact_attempt_owned_payloads() -> No
     assert main.index("Undo-FreshInstallAttempt") < main.index(
         "Fresh-install payload rollback completed; retry is safe"
     )
+    self_test_branch = main.index("if ($NativePrivateDirectorySelfTestRoot)")
+    assert self_test_branch < main.index(
+        "Invoke-NativePrivateDirectorySelfTest -Root $NativePrivateDirectorySelfTestRoot",
+        self_test_branch,
+    ) < main.index("return", self_test_branch) < main.index("Assert-FreshInstall")
     assert "Fresh-install fault injection requires -TestMode" in main
     assert "[Parameter(DontShow = $true)][switch]$TestMode" in source
     assert "[Parameter(DontShow = $true)][switch]$InjectFailureBeforeShim" in source
@@ -232,18 +269,23 @@ def test_windows_fresh_installer_rolls_back_exact_attempt_owned_payloads() -> No
     assert "Windows PowerShell 5.1 could not parse/compile install.ps1" in harness
     assert "-NativePrivateDirectorySelfTestRoot $legacyNativeRoot" in harness
     assert "Windows PowerShell 5.1 native private lifecycle failed" in harness
+    assert "-NativePrivateDirectorySelfTestRoot $modernNativeRoot" in harness
+    assert "PowerShell 7 native private lifecycle failed" in harness
     assert "Native private directory lifecycle passed" in source
     assert "Native snapshotted-child move-out refusal passed" in source
     assert "Native fresh directory fault boundaries passed" in source
     assert "Native empty directory rollback retry passed" in source
-    assert "Native tree-root rollback retry passed" in source
-    assert "Native tree-root rollback retry exhaustion passed" in source
+    assert "Native delayed tree-root namespace retirement passed" in source
+    assert "Native delayed child namespace retirement passed" in source
+    assert "Native namespace retirement wait passed" in source
     assert "Native post-move rollback topology passed" in source
     assert "Native private-directory self-test accepted a file as its parent" in source
     assert "Fresh-install payload rollback completed; retry is safe" in harness
     assert "Concurrent unclaimed shim disappeared during rollback" in harness
     assert "Failed fresh install left installer-created binary directories behind" in harness
     assert "Assert-NoFreshPayload -Context $postMove.Output" in harness
+    assert "--- post-move installer output ---" in harness
+    assert "bounded residual path inventory (names and kinds only)" in harness
 
 
 def test_windows_private_custody_cleanup_is_creation_bound_and_identity_exact() -> None:
@@ -275,7 +317,12 @@ def test_windows_private_custody_cleanup_is_creation_bound_and_identity_exact() 
     assert "Sort-Object -Property Length -Descending" in cleanup
     assert "OpenIfExists" in cleanup
     assert "$cleanupClaim.Identity -cne $entry.Identity" in cleanup
-    assert "$cleanupClaim.DeleteTreeExact()" in cleanup
+    assert "$cleanupClaim.DeleteTreeExact($entry.Native)" in cleanup
+    assert "$cleanupClaim.DeleteEmptyDirectoryExact($entry.Native)" in cleanup
+    assert "$cleanupClaim.DeleteEmptyDirectoryExact($claim)" in create
+    assert "CleanupTerminal = $false" in create
+    assert "$entry.CleanupTerminal = $true" in cleanup
+    assert "refusing a second traversal" in cleanup
     assert "canonical binding was lost" in cleanup
     assert "current location is unknown" in cleanup
     assert "canonical path now names a different object" in cleanup
@@ -287,7 +334,7 @@ def test_windows_private_custody_cleanup_is_creation_bound_and_identity_exact() 
     ]
     assert "PrivateDirectoryClaims.Remove" not in missing_path
     assert ".Native.Dispose" not in missing_path
-    deletion = cleanup.index("$cleanupClaim.DeleteTreeExact()")
+    deletion = cleanup.index("$cleanupClaim.DeleteTreeExact($entry.Native)")
     release = cleanup.index("$entry.Native.Dispose()", deletion)
     forget = cleanup.index("$script:PrivateDirectoryClaims.Remove($claimKeyFull)", release)
     assert deletion < release < forget
@@ -347,6 +394,8 @@ def test_windows_private_custody_cleanup_is_creation_bound_and_identity_exact() 
     )
     assert "canonical binding and current location are unverified" in source
     assert "claim will close when the installer exits" in source
+    assert '$entry.Native.RetirementStateValue -cne "Bound"' in undo
+    assert "$entry.Native.MutationStarted" in undo
     path_publish = source[source.index("function Add-ToPath") : source.index("# -- Success")]
     assert "Persistent User PATH is shared registry state" in path_publish
     assert "Persistent User PATH was not modified" in path_publish
@@ -548,6 +597,22 @@ def test_windows_resolver_binds_hard_cut_provenance_before_mutation() -> None:
     ):
         assert runtime_field in source
     assert "Resolve-InstalledRuntimePaths" in source
+    runtime_paths = source[
+        source.index("function Resolve-InstalledRuntimePaths") : source.index("function Get-OpenClawHome")
+    ]
+    assert 'if "data_dir" in loader_parameters:' in runtime_paths
+    assert "cfg = config_module.load(data_dir=controller_home)" in runtime_paths
+    assert "config_module.CONFIG_FILE_NAME = config_path" in runtime_paths
+    assert "cfg = config_module.load()" in runtime_paths
+    assert "config_module.CONFIG_FILE_NAME = legacy_config_name" in runtime_paths
+    assert "installed source config loader has an unsupported signature" in runtime_paths
+    assert "except TypeError" not in runtime_paths
+    assert runtime_paths.index("$env:DEFENSECLAW_HOME=$controllerHome") < runtime_paths.index(
+        "(Get-Python) -I -c $resolver"
+    )
+    assert runtime_paths.index("$env:DEFENSECLAW_CONFIG=$configPath") < runtime_paths.index(
+        "(Get-Python) -I -c $resolver"
+    )
     assert "Get-ControllerHome" in source
     assert "Get-PhaseOneDirectoryIdentity" in source
     assert "Ambient DEFENSECLAW_HOME differs" in source
@@ -629,6 +694,142 @@ def test_windows_resolver_binds_hard_cut_provenance_before_mutation() -> None:
     assert "$createdQuarantine=Join-Path $createdParent" in source
     assert "$sourceStream=[IO.File]::OpenRead($Source)" in source
     assert "[IO.Directory]::CreateDirectory($Path, $acl)" in source
+
+
+@pytest.mark.parametrize(
+    ("legacy_loader", "configured_data_dir"),
+    [(True, True), (True, False), (False, True), (False, False)],
+)
+def test_windows_runtime_path_resolver_supports_published_and_scoped_loaders(
+    legacy_loader: bool,
+    configured_data_dir: bool,
+) -> None:
+    source = RESOLVER.read_text(encoding="utf-8")
+    runtime_paths = source[
+        source.index("function Resolve-InstalledRuntimePaths") : source.index("function Get-OpenClawHome")
+    ]
+    resolver = _powershell_python_here_string(runtime_paths, "resolver")
+
+    if legacy_loader:
+        loader = (
+            "def load():\n"
+            "    active = os.path.join(os.environ['DEFENSECLAW_HOME'], module.CONFIG_FILE_NAME)\n"
+            "    return make_config(active)\n"
+        )
+    else:
+        loader = (
+            "def load(*, data_dir=None):\n"
+            "    assert os.path.abspath(data_dir) == os.path.abspath(os.environ['DEFENSECLAW_HOME'])\n"
+            "    return make_config(os.environ['DEFENSECLAW_CONFIG'])\n"
+        )
+
+    module_prelude = (
+        "import json, os, sys, types\n"
+        "module = types.ModuleType('defenseclaw.config')\n"
+        "module.CONFIG_FILE_NAME = 'config.yaml'\n"
+        "class Config:\n"
+        "    def __init__(self, raw):\n"
+        "        self.raw = raw\n"
+        "        self.claw = types.SimpleNamespace(home_dir=raw.get('claw', {}).get('home_dir', '~/.openclaw'))\n"
+        "    @property\n"
+        "    def data_dir(self):\n"
+        "        assert module.CONFIG_FILE_NAME == 'config.yaml'\n"
+        "        return self.raw.get('data_dir', os.environ['DEFENSECLAW_HOME'])\n"
+        "def make_config(active):\n"
+        "    with open(active, encoding='utf-8') as stream:\n"
+        "        raw = json.load(stream)\n"
+        "    return Config(raw)\n"
+        + loader
+        + "module.load = load\n"
+        "package = types.ModuleType('defenseclaw')\n"
+        "package.__path__ = []\n"
+        "package.config = module\n"
+        "sys.modules['defenseclaw'] = package\n"
+        "sys.modules['defenseclaw.config'] = module\n"
+    )
+
+    with TemporaryDirectory() as root:
+        root_path = Path(root)
+        controller = root_path / "controller"
+        data_dir = root_path / "runtime-data"
+        external = root_path / "external" / "defenseclaw.yaml"
+        openclaw = root_path / "openclaw"
+        controller.mkdir()
+        data_dir.mkdir()
+        external.parent.mkdir()
+        raw: dict[str, object] = {"claw": {"home_dir": str(openclaw)}}
+        if configured_data_dir:
+            raw["data_dir"] = str(data_dir)
+        external.write_text(json.dumps(raw), encoding="utf-8")
+        env = os.environ.copy()
+        env["DEFENSECLAW_HOME"] = str(controller)
+        env["DEFENSECLAW_CONFIG"] = str(external)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-I",
+                "-c",
+                module_prelude + resolver,
+                str(controller),
+                str(external),
+                "0",
+                "__DEFENSECLAW_UNSET__",
+            ],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    contract = json.loads(result.stdout)
+    assert Path(contract["data_dir"]) == (data_dir if configured_data_dir else controller)
+    assert Path(contract["config_path"]) == external
+    assert Path(contract["openclaw_home"]) == openclaw
+
+
+def test_windows_runtime_path_resolver_rejects_unknown_loader_signature() -> None:
+    source = RESOLVER.read_text(encoding="utf-8")
+    runtime_paths = source[
+        source.index("function Resolve-InstalledRuntimePaths") : source.index("function Get-OpenClawHome")
+    ]
+    resolver = _powershell_python_here_string(runtime_paths, "resolver")
+    module_prelude = (
+        "import sys, types\n"
+        "module = types.ModuleType('defenseclaw.config')\n"
+        "module.CONFIG_FILE_NAME = 'config.yaml'\n"
+        "def load(path):\n"
+        "    raise AssertionError('unsupported loader must not be called')\n"
+        "module.load = load\n"
+        "package = types.ModuleType('defenseclaw')\n"
+        "package.__path__ = []\n"
+        "package.config = module\n"
+        "sys.modules['defenseclaw'] = package\n"
+        "sys.modules['defenseclaw.config'] = module\n"
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            module_prelude + resolver,
+            str(ROOT),
+            str(RESOLVER),
+            "0",
+            "__DEFENSECLAW_UNSET__",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        timeout=5,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "installed source config loader has an unsupported signature" in result.stderr
+    assert "unsupported loader must not be called" not in result.stderr
 
 
 def test_windows_success_health_is_bounded_healthy_and_version_bound() -> None:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -156,14 +156,33 @@ namespace DefenseClaw.Install.FreshV1 {
         private const int FILE_DISPOSITION_INFO_CLASS = 4;
         private const int ERROR_FILE_NOT_FOUND = 2;
         private const int ERROR_PATH_NOT_FOUND = 3;
+        private const int ERROR_ACCESS_DENIED = 5;
+        private const int ERROR_SHARING_VIOLATION = 32;
         private const int ERROR_FILE_EXISTS = 80;
         private const int ERROR_DIR_NOT_EMPTY = 145;
         private const int ERROR_ALREADY_EXISTS = 183;
+        private const int ERROR_DELETE_PENDING = 303;
         private const uint MOVEFILE_WRITE_THROUGH = 0x00000008;
         private const int MAX_TREE_DEPTH = 64;
         private const int MAX_TREE_NODES = 500000;
         private const long MAX_TREE_BYTES = 16L * 1024L * 1024L * 1024L;
-        private const int TREE_ROOT_DELETE_ATTEMPTS = 5;
+        private const int NAMESPACE_RETIRE_TIMEOUT_MS = 10000;
+        private const int NAMESPACE_RETIRE_POLL_MS = 50;
+
+        private enum RetirementState {
+            Bound,
+            DispositionAccepted,
+            Retired,
+            Replaced,
+            Unresolved
+        }
+
+        private enum NamespaceObservation {
+            Absent,
+            Expected,
+            Different,
+            Pending
+        }
 
         [StructLayout(LayoutKind.Sequential)]
         private struct FILETIME {
@@ -223,6 +242,11 @@ namespace DefenseClaw.Install.FreshV1 {
             public int Depth;
         }
 
+        private sealed class TestRetainer {
+            public SafeFileHandle Handle;
+            public int DelayMilliseconds;
+        }
+
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern SafeFileHandle CreateFile(
             string fileName,
@@ -277,9 +301,14 @@ namespace DefenseClaw.Install.FreshV1 {
         private readonly bool directory;
         private readonly bool deleteAccess;
         private readonly string path;
+        private RetirementState retirementState = RetirementState.Bound;
+        private bool mutationStarted;
         private static string testMoveOutSource;
         private static string testMoveOutDestination;
         private static int testEmptyDirectoryDeleteFailures;
+        private static readonly object testNamespaceRetirementLock = new object();
+        private static string testNamespaceRetirementPath;
+        private static int testNamespaceRetirementDelayMs;
 
         private FreshPathClaim(
             string claimedPath,
@@ -307,6 +336,8 @@ namespace DefenseClaw.Install.FreshV1 {
         public string Identity {
             get { return volume.ToString("x8") + ":" + index.ToString("x16"); }
         }
+        public string RetirementStateValue { get { return retirementState.ToString(); } }
+        public bool MutationStarted { get { return mutationStarted; } }
 
         public static FreshPathClaim Open(string path, bool directory, bool deleteAccess) {
             SafeFileHandle opened = OpenHandle(path, directory, deleteAccess, false);
@@ -500,6 +531,30 @@ namespace DefenseClaw.Install.FreshV1 {
             System.Threading.Interlocked.Exchange(ref testEmptyDirectoryDeleteFailures, 0);
         }
 
+        public static void ConfigureTestNamespaceRetirementDelay(
+            string path,
+            int delayMilliseconds) {
+            if (String.IsNullOrWhiteSpace(path)) {
+                throw new ArgumentException("test namespace-retirement path is empty");
+            }
+            if (delayMilliseconds < 1 ||
+                delayMilliseconds >
+                    NAMESPACE_RETIRE_TIMEOUT_MS - (2 * NAMESPACE_RETIRE_POLL_MS)) {
+                throw new ArgumentOutOfRangeException("delayMilliseconds");
+            }
+            lock (testNamespaceRetirementLock) {
+                testNamespaceRetirementPath = Path.GetFullPath(path);
+                testNamespaceRetirementDelayMs = delayMilliseconds;
+            }
+        }
+
+        public static void ClearTestNamespaceRetirementDelay() {
+            lock (testNamespaceRetirementLock) {
+                testNamespaceRetirementPath = null;
+                testNamespaceRetirementDelayMs = 0;
+            }
+        }
+
         private static bool ConsumeTestEmptyDirectoryDeleteFailure() {
             while (true) {
                 int current = System.Threading.Volatile.Read(
@@ -528,6 +583,192 @@ namespace DefenseClaw.Install.FreshV1 {
                 throw new Win32Exception(
                     error,
                     "could not inject a snapshotted-child move-out");
+            }
+        }
+
+        private static SafeFileHandle OpenNamespaceObservationHandle(string candidate) {
+            return CreateFile(
+                Path.GetFullPath(candidate),
+                FILE_READ_ATTRIBUTES,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                IntPtr.Zero,
+                OPEN_EXISTING,
+                FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
+                IntPtr.Zero);
+        }
+
+        private static TestRetainer TakeTestNamespaceRetainer(string candidate) {
+            int delay = 0;
+            lock (testNamespaceRetirementLock) {
+                if (String.IsNullOrEmpty(testNamespaceRetirementPath) ||
+                    !String.Equals(
+                        Path.GetFullPath(candidate),
+                        testNamespaceRetirementPath,
+                        StringComparison.OrdinalIgnoreCase)) {
+                    return null;
+                }
+                delay = testNamespaceRetirementDelayMs;
+            }
+            SafeFileHandle retained = OpenNamespaceObservationHandle(candidate);
+            if (retained.IsInvalid) {
+                int error = Marshal.GetLastWin32Error();
+                retained.Dispose();
+                throw new Win32Exception(
+                    error,
+                    "could not create the namespace-retirement test retainer");
+            }
+            TestRetainer result = new TestRetainer();
+            result.Handle = retained;
+            result.DelayMilliseconds = delay;
+            return result;
+        }
+
+        private static void CommitTestNamespaceRetainer(string candidate) {
+            lock (testNamespaceRetirementLock) {
+                if (!String.IsNullOrEmpty(testNamespaceRetirementPath) &&
+                    String.Equals(
+                        Path.GetFullPath(candidate),
+                        testNamespaceRetirementPath,
+                        StringComparison.OrdinalIgnoreCase)) {
+                    testNamespaceRetirementPath = null;
+                    testNamespaceRetirementDelayMs = 0;
+                }
+            }
+        }
+
+        private static void DisposeTestRetainer(TestRetainer retained) {
+            if (retained != null && retained.Handle != null) {
+                retained.Handle.Dispose();
+                retained.Handle = null;
+            }
+        }
+
+        private static void ReleaseTestRetainerAfterDisposition(TestRetainer retained) {
+            if (retained == null || retained.Handle == null) {
+                return;
+            }
+            SafeFileHandle delayedHandle = retained.Handle;
+            int delay = retained.DelayMilliseconds;
+            retained.Handle = null;
+            System.Threading.Thread releaser = new System.Threading.Thread(delegate() {
+                try {
+                    System.Threading.Thread.Sleep(delay);
+                } finally {
+                    delayedHandle.Dispose();
+                }
+            });
+            releaser.IsBackground = true;
+            try {
+                releaser.Start();
+            } catch {
+                delayedHandle.Dispose();
+                throw;
+            }
+        }
+
+        private static NamespaceObservation ObserveNamespace(
+            string candidate,
+            uint expectedVolume,
+            ulong expectedIndex,
+            bool expectedDirectory,
+            bool expectedReparse) {
+            SafeFileHandle observed = OpenNamespaceObservationHandle(candidate);
+            if (observed.IsInvalid) {
+                int error = Marshal.GetLastWin32Error();
+                observed.Dispose();
+                if (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND) {
+                    return NamespaceObservation.Absent;
+                }
+                if (error == ERROR_ACCESS_DENIED ||
+                    error == ERROR_SHARING_VIOLATION ||
+                    error == ERROR_DELETE_PENDING) {
+                    return NamespaceObservation.Pending;
+                }
+                throw new Win32Exception(
+                    error,
+                    "could not observe fresh-install namespace retirement: " + candidate);
+            }
+            try {
+                BY_HANDLE_FILE_INFORMATION information;
+                if (!GetFileInformationByHandle(observed, out information)) {
+                    int error = Marshal.GetLastWin32Error();
+                    if (error == ERROR_ACCESS_DENIED ||
+                        error == ERROR_SHARING_VIOLATION ||
+                        error == ERROR_DELETE_PENDING) {
+                        return NamespaceObservation.Pending;
+                    }
+                    throw new Win32Exception(
+                        error,
+                        "could not inspect fresh-install namespace retirement: " + candidate);
+                }
+                bool isDirectory =
+                    (information.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+                bool isReparse =
+                    (information.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
+                if (SameIdentity(information, expectedVolume, expectedIndex) &&
+                    isDirectory == expectedDirectory &&
+                    isReparse == expectedReparse) {
+                    return NamespaceObservation.Expected;
+                }
+                return NamespaceObservation.Different;
+            } finally {
+                observed.Dispose();
+            }
+        }
+
+        private static long NewNamespaceRetirementDeadline() {
+            long timeoutTicks =
+                (System.Diagnostics.Stopwatch.Frequency * NAMESPACE_RETIRE_TIMEOUT_MS) / 1000;
+            return System.Diagnostics.Stopwatch.GetTimestamp() + Math.Max(1L, timeoutTicks);
+        }
+
+        private static bool WaitForNamespaceRetirement(
+            string candidate,
+            uint expectedVolume,
+            ulong expectedIndex,
+            bool expectedDirectory,
+            bool expectedReparse,
+            long deadline,
+            out NamespaceObservation finalObservation) {
+            while (true) {
+                finalObservation = ObserveNamespace(
+                    candidate,
+                    expectedVolume,
+                    expectedIndex,
+                    expectedDirectory,
+                    expectedReparse);
+                if (finalObservation == NamespaceObservation.Absent) {
+                    return true;
+                }
+                if (finalObservation == NamespaceObservation.Different) {
+                    return false;
+                }
+                long remainingTicks = deadline - System.Diagnostics.Stopwatch.GetTimestamp();
+                if (remainingTicks <= 0) {
+                    return false;
+                }
+                long remainingMilliseconds =
+                    (remainingTicks * 1000) / System.Diagnostics.Stopwatch.Frequency;
+                int delay = (int)Math.Max(
+                    1L,
+                    Math.Min((long)NAMESPACE_RETIRE_POLL_MS, remainingMilliseconds));
+                System.Threading.Thread.Sleep(delay);
+            }
+        }
+
+        private void ValidateRetirementCompanion(FreshPathClaim companion) {
+            if (companion == null) {
+                return;
+            }
+            if (Object.ReferenceEquals(this, companion) ||
+                companion.handle == null ||
+                companion.handle.IsInvalid ||
+                companion.handle.IsClosed ||
+                companion.volume != volume ||
+                companion.index != index ||
+                companion.directory != directory) {
+                throw new InvalidOperationException(
+                    "fresh-install cleanup companion does not retain the exact claimed object");
             }
         }
 
@@ -622,6 +863,83 @@ namespace DefenseClaw.Install.FreshV1 {
             throw new Win32Exception(error, "could not delete exact fresh-install object");
         }
 
+        private bool RetireRootNamespaceExact(
+            FreshPathClaim companion,
+            bool allowNotEmpty,
+            bool consumeEmptyDirectoryFailure,
+            bool terminalOnDispositionRefusal,
+            long deadline) {
+            if (retirementState == RetirementState.Retired) {
+                return true;
+            }
+            if (retirementState != RetirementState.Bound) {
+                return false;
+            }
+            if (handle == null || handle.IsInvalid || handle.IsClosed) {
+                throw new InvalidOperationException(
+                    "fresh-install rollback claim closed before exact retirement");
+            }
+            ValidateRetirementCompanion(companion);
+            if (consumeEmptyDirectoryFailure && ConsumeTestEmptyDirectoryDeleteFailure()) {
+                if (terminalOnDispositionRefusal) {
+                    retirementState = RetirementState.Unresolved;
+                }
+                return false;
+            }
+
+            TestRetainer retained = TakeTestNamespaceRetainer(path);
+            bool accepted = false;
+            try {
+                accepted = MarkDelete(handle, allowNotEmpty);
+            } catch {
+                DisposeTestRetainer(retained);
+                throw;
+            }
+            if (!accepted) {
+                DisposeTestRetainer(retained);
+                if (terminalOnDispositionRefusal) {
+                    retirementState = RetirementState.Unresolved;
+                }
+                return false;
+            }
+
+            mutationStarted = true;
+            retirementState = RetirementState.DispositionAccepted;
+            CommitTestNamespaceRetainer(path);
+            Dispose();
+            if (companion != null) {
+                companion.Dispose();
+            }
+            try {
+                ReleaseTestRetainerAfterDisposition(retained);
+            } catch {
+                retirementState = RetirementState.Unresolved;
+                throw;
+            }
+
+            NamespaceObservation finalObservation;
+            try {
+                if (WaitForNamespaceRetirement(
+                    path,
+                    volume,
+                    index,
+                    directory,
+                    false,
+                    deadline,
+                    out finalObservation)) {
+                    retirementState = RetirementState.Retired;
+                    return true;
+                }
+            } catch {
+                retirementState = RetirementState.Unresolved;
+                throw;
+            }
+            retirementState = finalObservation == NamespaceObservation.Different
+                ? RetirementState.Replaced
+                : RetirementState.Unresolved;
+            return false;
+        }
+
         public bool DeleteFileExact() {
             if (directory) {
                 throw new InvalidOperationException("file rollback received a directory claim");
@@ -629,26 +947,37 @@ namespace DefenseClaw.Install.FreshV1 {
             if (!deleteAccess) {
                 throw new InvalidOperationException("file rollback claim lacks DELETE access");
             }
-            bool deleted = MarkDelete(handle, false);
-            Dispose();
-            return deleted;
+            if (mutationStarted && retirementState == RetirementState.Bound) {
+                return false;
+            }
+            return RetireRootNamespaceExact(
+                null,
+                false,
+                false,
+                true,
+                NewNamespaceRetirementDeadline());
         }
 
         public bool DeleteEmptyDirectoryExact() {
+            return DeleteEmptyDirectoryExact(null);
+        }
+
+        public bool DeleteEmptyDirectoryExact(FreshPathClaim companion) {
             if (!directory) {
                 throw new InvalidOperationException("directory rollback received a file claim");
             }
             if (!deleteAccess) {
                 throw new InvalidOperationException("directory rollback claim lacks DELETE access");
             }
-            if (ConsumeTestEmptyDirectoryDeleteFailure()) {
+            if (mutationStarted && retirementState == RetirementState.Bound) {
                 return false;
             }
-            bool deleted = MarkDelete(handle, true);
-            if (deleted) {
-                Dispose();
-            }
-            return deleted;
+            return RetireRootNamespaceExact(
+                companion,
+                true,
+                true,
+                false,
+                NewNamespaceRetirementDeadline());
         }
 
         private void SnapshotDirectory(
@@ -700,16 +1029,28 @@ namespace DefenseClaw.Install.FreshV1 {
         }
 
         public bool DeleteTreeExact() {
+            return DeleteTreeExact(null);
+        }
+
+        public bool DeleteTreeExact(FreshPathClaim companion) {
             if (!directory) {
                 throw new InvalidOperationException("tree rollback received a file claim");
             }
             if (!deleteAccess) {
                 throw new InvalidOperationException("tree rollback claim lacks DELETE access");
             }
+            if (retirementState == RetirementState.Retired) {
+                return true;
+            }
+            if (retirementState != RetirementState.Bound || mutationStarted) {
+                return false;
+            }
+            ValidateRetirementCompanion(companion);
             List<TreeEntry> entries = new List<TreeEntry>();
             long bytes = 0;
             SnapshotDirectory(path, 1, entries, ref bytes);
             InvokeTestMoveOutAfterSnapshot();
+            long deadline = NewNamespaceRetirementDeadline();
             entries.Sort(delegate(TreeEntry left, TreeEntry right) {
                 int depthOrder = right.Depth.CompareTo(left.Depth);
                 if (depthOrder != 0) {
@@ -724,37 +1065,71 @@ namespace DefenseClaw.Install.FreshV1 {
                     true,
                     true);
                 if (current == null) {
+                    retirementState = RetirementState.Replaced;
                     return false;
                 }
+                TestRetainer retained = null;
+                bool dispositionAccepted = false;
                 try {
                     BY_HANDLE_FILE_INFORMATION information = Information(current, entry.Path);
                     bool isDirectory = (information.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
                     bool isReparse = (information.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
                     if (!SameIdentity(information, entry.Volume, entry.Index) ||
                         isDirectory != entry.IsDirectory || isReparse != entry.IsReparse) {
+                        retirementState = RetirementState.Replaced;
                         return false;
                     }
+                    retained = TakeTestNamespaceRetainer(entry.Path);
                     if (!MarkDelete(current, entry.IsDirectory)) {
+                        DisposeTestRetainer(retained);
+                        retained = null;
+                        retirementState = RetirementState.Unresolved;
                         return false;
                     }
+                    mutationStarted = true;
+                    CommitTestNamespaceRetainer(entry.Path);
+                    dispositionAccepted = true;
                 } finally {
                     current.Dispose();
+                    if (!dispositionAccepted) {
+                        DisposeTestRetainer(retained);
+                    }
+                }
+                try {
+                    ReleaseTestRetainerAfterDisposition(retained);
+                } catch {
+                    retirementState = RetirementState.Unresolved;
+                    throw;
+                }
+                NamespaceObservation finalObservation;
+                try {
+                    if (!WaitForNamespaceRetirement(
+                        entry.Path,
+                        entry.Volume,
+                        entry.Index,
+                        entry.IsDirectory,
+                        entry.IsReparse,
+                        deadline,
+                        out finalObservation)) {
+                        retirementState = finalObservation == NamespaceObservation.Different
+                            ? RetirementState.Replaced
+                            : RetirementState.Unresolved;
+                        return false;
+                    }
+                } catch {
+                    retirementState = RetirementState.Unresolved;
+                    throw;
                 }
             }
-            // Child delete-on-close operations can leave the exact tree root
-            // transiently nonempty on Windows. Retry only the final root
-            // disposition through this claim's existing identity handle. Do
-            // not snapshot or traverse the tree again: any concurrent child
-            // must keep the root nonempty and be preserved.
-            for (int attempt = 1; attempt <= TREE_ROOT_DELETE_ATTEMPTS; attempt++) {
-                if (DeleteEmptyDirectoryExact()) {
-                    return true;
-                }
-                if (attempt < TREE_ROOT_DELETE_ATTEMPTS) {
-                    System.Threading.Thread.Sleep(50 * attempt);
-                }
-            }
-            return false;
+            // Every snapshotted child is now proven absent. A nonempty root at
+            // this point therefore contains concurrent state and is terminal;
+            // never resnapshot or acquire fresh delete authority.
+            return RetireRootNamespaceExact(
+                companion,
+                true,
+                true,
+                true,
+                deadline);
         }
 
         public void Dispose() {
@@ -895,6 +1270,7 @@ function New-PrivateDirectory {
             Identity = $claim.Identity
             Native = $claim
             CleanupMode = "Tree"
+            CleanupTerminal = $false
         }
         $registered = $true
         $claim = $null
@@ -922,8 +1298,7 @@ function New-PrivateDirectory {
                     $true
                 )
                 if ($cleanupClaim -and $cleanupClaim.Identity -ceq $claim.Identity) {
-                    if ($cleanupClaim.DeleteEmptyDirectoryExact()) {
-                        $claim.Dispose()
+                    if ($cleanupClaim.DeleteEmptyDirectoryExact($claim)) {
                         $claim = $null
                         $retired = $true
                     }
@@ -1022,6 +1397,12 @@ function Remove-PrivateDirectoryClaimAt {
         )
     }
     $entry = $script:PrivateDirectoryClaims[$claimKeyFull]
+    if ($entry.CleanupTerminal) {
+        Die (
+            "Private install directory cleanup already mutated the exact claimed tree " +
+            "without proving namespace retirement; refusing a second traversal: $candidateFull"
+        )
+    }
     $cleanupClaim = $null
     try {
         $cleanupClaim = [DefenseClaw.Install.FreshV1.FreshPathClaim]::OpenIfExists(
@@ -1046,9 +1427,9 @@ function Remove-PrivateDirectoryClaimAt {
         }
         Assert-PrivateDirectoryAcl -Path $candidateFull
         $removed = if ($RequireEmpty) {
-            $cleanupClaim.DeleteEmptyDirectoryExact()
+            $cleanupClaim.DeleteEmptyDirectoryExact($entry.Native)
         } else {
-            $cleanupClaim.DeleteTreeExact()
+            $cleanupClaim.DeleteTreeExact($entry.Native)
         }
         if (-not $removed) {
             Die (
@@ -1060,7 +1441,12 @@ function Remove-PrivateDirectoryClaimAt {
         [void]$script:PrivateDirectoryClaims.Remove($claimKeyFull)
         Complete-RollbackSafetyBoundary -Token $cleanupSafety
     } finally {
-        if ($cleanupClaim) { $cleanupClaim.Dispose() }
+        if ($cleanupClaim) {
+            if ($cleanupClaim.MutationStarted) {
+                $entry.CleanupTerminal = $true
+            }
+            $cleanupClaim.Dispose()
+        }
     }
 }
 
@@ -1232,50 +1618,69 @@ function Invoke-NativeFreshDirectoryBoundarySelfTest {
     }
     Write-Host "Native empty directory rollback retry passed" -ForegroundColor Green
 
-    $treeRetryTarget = Join-Path $Root ("fresh-tree-retry-" + [guid]::NewGuid().ToString("N"))
+    $retirementParent = Join-Path $Root ("fresh-retirement-parent-" + [guid]::NewGuid().ToString("N"))
+    $retirementTree = Join-Path $retirementParent "tree"
     $script:FreshInstallClaims = New-Object 'System.Collections.Generic.List[object]'
     $script:FreshInstallAttemptActive = $true
     $script:FreshInstallOriginalProcessPath = $env:PATH
     $script:FreshInstallPublishedProcessPath = $null
     try {
-        New-FreshInstallOwnedDirectory -Path $treeRetryTarget -Kind Tree
-        [IO.File]::WriteAllText(
-            (Join-Path $treeRetryTarget "owned.txt"),
-            "owned",
-            [Text.Encoding]::ASCII
+        New-FreshInstallOwnedDirectory -Path $retirementParent -Kind EmptyDirectory
+        New-FreshInstallOwnedDirectory -Path $retirementTree -Kind Tree
+        [DefenseClaw.Install.FreshV1.FreshPathClaim]::ConfigureTestNamespaceRetirementDelay(
+            $retirementTree,
+            250
         )
-        [DefenseClaw.Install.FreshV1.FreshPathClaim]::ConfigureTestEmptyDirectoryDeleteFailures(1)
-        $treeRetryResidue = @(Undo-FreshInstallAttempt)
-        if ($treeRetryResidue.Count -ne 0 -or (Test-InstallMarker -Path $treeRetryTarget)) {
-            Die "Native tree-root rollback did not recover from a transient nonempty result"
+        $retirementWatch = [Diagnostics.Stopwatch]::StartNew()
+        $retirementResidue = @(Undo-FreshInstallAttempt)
+        $retirementWatch.Stop()
+        if ($retirementResidue.Count -ne 0 -or
+            (Test-InstallMarker -Path $retirementTree) -or
+            (Test-InstallMarker -Path $retirementParent) -or
+            $retirementWatch.ElapsedMilliseconds -lt 150) {
+            Die "Native rollback did not wait for a delayed tree-root namespace retirement"
         }
     } finally {
-        [DefenseClaw.Install.FreshV1.FreshPathClaim]::ClearTestEmptyDirectoryDeleteFailures()
+        [DefenseClaw.Install.FreshV1.FreshPathClaim]::ClearTestNamespaceRetirementDelay()
         if ($script:FreshInstallAttemptActive) { [void](Undo-FreshInstallAttempt) }
+        if (Test-InstallMarker -Path $retirementParent) {
+            [IO.Directory]::Delete($retirementParent, $true)
+        }
     }
-    Write-Host "Native tree-root rollback retry passed" -ForegroundColor Green
+    Write-Host "Native delayed tree-root namespace retirement passed" -ForegroundColor Green
 
-    $treeExhaustedTarget = Join-Path $Root ("fresh-tree-exhausted-" + [guid]::NewGuid().ToString("N"))
+    $nestedTree = Join-Path $Root ("fresh-retirement-nested-" + [guid]::NewGuid().ToString("N"))
+    $nestedDirectory = Join-Path $nestedTree "nested"
+    $nestedFile = Join-Path $nestedDirectory "owned.txt"
     $script:FreshInstallClaims = New-Object 'System.Collections.Generic.List[object]'
     $script:FreshInstallAttemptActive = $true
     $script:FreshInstallOriginalProcessPath = $env:PATH
     $script:FreshInstallPublishedProcessPath = $null
     try {
-        New-FreshInstallOwnedDirectory -Path $treeExhaustedTarget -Kind Tree
-        [DefenseClaw.Install.FreshV1.FreshPathClaim]::ConfigureTestEmptyDirectoryDeleteFailures(5)
-        $treeExhaustedResidue = @(Undo-FreshInstallAttempt)
-        if ($treeExhaustedResidue.Count -eq 0 -or
-            -not (Test-InstallMarker -Path $treeExhaustedTarget)) {
-            Die "Native tree-root rollback did not preserve a root after bounded retry exhaustion"
+        New-FreshInstallOwnedDirectory -Path $nestedTree -Kind Tree
+        [void][IO.Directory]::CreateDirectory($nestedDirectory)
+        [IO.File]::WriteAllText($nestedFile, "owned", [Text.Encoding]::ASCII)
+        [DefenseClaw.Install.FreshV1.FreshPathClaim]::ConfigureTestNamespaceRetirementDelay(
+            $nestedFile,
+            250
+        )
+        $nestedWatch = [Diagnostics.Stopwatch]::StartNew()
+        $nestedResidue = @(Undo-FreshInstallAttempt)
+        $nestedWatch.Stop()
+        if ($nestedResidue.Count -ne 0 -or
+            (Test-InstallMarker -Path $nestedTree) -or
+            $nestedWatch.ElapsedMilliseconds -lt 150) {
+            Die "Native tree rollback did not wait for a delayed child namespace retirement"
         }
     } finally {
-        [DefenseClaw.Install.FreshV1.FreshPathClaim]::ClearTestEmptyDirectoryDeleteFailures()
+        [DefenseClaw.Install.FreshV1.FreshPathClaim]::ClearTestNamespaceRetirementDelay()
         if ($script:FreshInstallAttemptActive) { [void](Undo-FreshInstallAttempt) }
-        if (Test-InstallMarker -Path $treeExhaustedTarget) {
-            [IO.Directory]::Delete($treeExhaustedTarget)
+        if (Test-InstallMarker -Path $nestedTree) {
+            [IO.Directory]::Delete($nestedTree, $true)
         }
     }
-    Write-Host "Native tree-root rollback retry exhaustion passed" -ForegroundColor Green
+    Write-Host "Native delayed child namespace retirement passed" -ForegroundColor Green
+    Write-Host "Native namespace retirement wait passed" -ForegroundColor Green
 
     # Mirror the real post-publication failure topology: an attempt-owned home
     # with an empty tree child, plus a sibling bin parent whose publication
@@ -2032,16 +2437,19 @@ function Undo-FreshInstallAttempt {
             $entry = $script:FreshInstallClaims[$index]
             if ($entry.Kind -ne $kind) { continue }
             try {
-                # Windows can briefly report an installer-owned parent as
-                # nonempty while an exact child-tree deletion settles. Keep
-                # the same identity handle across a bounded retry window, but
-                # only for empty-directory deletion: file/tree retries could
-                # otherwise consume state that appeared concurrently.
+                # A pre-disposition empty-directory refusal is safe to retry
+                # through the same identity handle. Once any mutation begins,
+                # the native claim owns its one bounded retirement wait and a
+                # caller must never restart a partial tree traversal.
                 $maximumAttempts = if ($entry.Kind -ceq "EmptyDirectory") { 20 } else { 1 }
                 $removed = $false
                 for ($attempt = 1; $attempt -le $maximumAttempts; $attempt++) {
                     $removed = Remove-FreshInstallClaim -Entry $entry
                     if ($removed) { break }
+                    if ($entry.Native.MutationStarted -or
+                        $entry.Native.RetirementStateValue -cne "Bound") {
+                        break
+                    }
                     if ($attempt -lt $maximumAttempts) {
                         Start-Sleep -Milliseconds (50 * $attempt)
                     }

--- a/scripts/test-fresh-install-release-windows.ps1
+++ b/scripts/test-fresh-install-release-windows.ps1
@@ -236,6 +236,7 @@ try {
     if ($LASTEXITCODE -ne 0 -or
         $legacyNative -notmatch 'Native private directory lifecycle passed' -or
         $legacyNative -notmatch 'Native snapshotted-child move-out refusal passed' -or
+        $legacyNative -notmatch 'Native namespace retirement wait passed' -or
         $legacyNative -notmatch 'Native fresh directory fault boundaries passed') {
         throw "Windows PowerShell 5.1 native private lifecycle failed:`n$legacyNative"
     }
@@ -243,6 +244,26 @@ try {
         throw "Windows PowerShell 5.1 native private lifecycle left custody behind"
     }
     [IO.Directory]::Delete($legacyNativeRoot)
+
+    $modernNativeRoot = Join-Path $TempRoot "powershell-native-private"
+    [void](New-Item -ItemType Directory -Path $modernNativeRoot)
+    $modernNative = (& $PowerShell `
+        -NoProfile `
+        -NonInteractive `
+        -File $Installer `
+        -TestMode `
+        -NativePrivateDirectorySelfTestRoot $modernNativeRoot 2>&1 | Out-String)
+    if ($LASTEXITCODE -ne 0 -or
+        $modernNative -notmatch 'Native private directory lifecycle passed' -or
+        $modernNative -notmatch 'Native snapshotted-child move-out refusal passed' -or
+        $modernNative -notmatch 'Native namespace retirement wait passed' -or
+        $modernNative -notmatch 'Native fresh directory fault boundaries passed') {
+        throw "PowerShell 7 native private lifecycle failed:`n$modernNative"
+    }
+    if (@(Get-ChildItem -LiteralPath $modernNativeRoot -Force).Count -ne 0) {
+        throw "PowerShell 7 native private lifecycle left custody behind"
+    }
+    [IO.Directory]::Delete($modernNativeRoot)
 
     $mismatch = Invoke-FreshInstaller -RequestedVersion "999.999.999"
     if ($mismatch.ExitCode -eq 0 -or $mismatch.Output -notmatch 'does not match -Version') {
@@ -267,6 +288,25 @@ try {
         throw "Post-move fresh-directory cleanup was not exact:`n$($postMove.Output)"
     }
     Assert-NoInstallerCustody
+    if (Test-Path -LiteralPath $env:DEFENSECLAW_HOME) {
+        Write-Host "--- post-move installer output ---" -ForegroundColor Yellow
+        Write-Host $postMove.Output
+        Write-Host "--- bounded residual path inventory (names and kinds only) ---" -ForegroundColor Yellow
+        @(
+            Get-ChildItem -LiteralPath $HomeRoot -Force -Recurse -ErrorAction SilentlyContinue |
+                Select-Object -First 100
+        ) | ForEach-Object {
+            $relative = [IO.Path]::GetRelativePath($HomeRoot, $_.FullName)
+            $kind = if ($_.Attributes -band [IO.FileAttributes]::ReparsePoint) {
+                "reparse"
+            } elseif ($_.PSIsContainer) {
+                "directory"
+            } else {
+                "file"
+            }
+            Write-Host "$kind`t$relative"
+        }
+    }
     Assert-NoFreshPayload -Context $postMove.Output
     if (Test-Path -LiteralPath (Join-Path $HomeRoot ".local")) {
         throw "Post-move fresh-directory failure left .local or bin custody behind"

--- a/scripts/upgrade.ps1
+++ b/scripts/upgrade.ps1
@@ -135,13 +135,32 @@ function Resolve-InstalledRuntimePaths {
     $requestedOpenClaw=if($openClawWasExplicit){[IO.Path]::GetFullPath($env:OPENCLAW_HOME)}else{"__DEFENSECLAW_UNSET__"}
     $resolver=@'
 import json
+import inspect
 import os
 import sys
 
-from defenseclaw.config import load
+import defenseclaw.config as config_module
 
 controller_home, config_path, openclaw_explicit, requested_openclaw = sys.argv[1:]
-cfg = load(data_dir=controller_home)
+loader_parameters = inspect.signature(config_module.load).parameters
+if "data_dir" in loader_parameters:
+    cfg = config_module.load(data_dir=controller_home)
+elif not loader_parameters:
+    # Published 0.8.0-0.8.3 loaders have no scoped-load argument and ignore
+    # DEFENSECLAW_CONFIG.  Their loader joins CONFIG_FILE_NAME to
+    # DEFENSECLAW_HOME, and os.path.join preserves an absolute second path.
+    # Point that process-local constant at the already-validated active file
+    # so legacy upgrades retain both a split data_dir and an external config.
+    legacy_config_name = getattr(config_module, "CONFIG_FILE_NAME", None)
+    if not isinstance(legacy_config_name, str) or not legacy_config_name:
+        raise RuntimeError("installed source config loader lacks its legacy config-path contract")
+    try:
+        config_module.CONFIG_FILE_NAME = config_path
+        cfg = config_module.load()
+    finally:
+        config_module.CONFIG_FILE_NAME = legacy_config_name
+else:
+    raise RuntimeError("installed source config loader has an unsupported signature")
 configured_data_dir = os.path.expanduser(cfg.data_dir or controller_home)
 if not os.path.isabs(configured_data_dir):
     raise RuntimeError("configured data_dir must be absolute for a staged upgrade")


### PR DESCRIPTION
Release-only follow-up to failed Release run [29224783162](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29224783162). This PR is independent of observability v8 PR #490 and must merge to `main` before rerunning 0.8.4. It does not change teams, reviewers, branch rules, rulesets, release environments, signing, or unsigned macOS behavior.

## Problem

The sealed 0.8.4 candidate passed provenance, build, signing verification, Linux/macOS fresh installs, Linux/macOS published-baseline upgrades, and unsigned macOS trust gates. Five deterministic Windows jobs failed:

1. Real 0.8.0-0.8.3 upgrades stopped before mutation because their Python config loaders expose only `load()`, while the resolver called `load(data_dir=...)`.
2. The injected fresh-install rollback accepted Windows delete disposition but declared success before the `.defenseclaw` pathname actually retired. A share-delete scanner/runtime handle can keep that namespace visible after the installer closes its deletion handle.

Publish correctly remained skipped, so 0.8.4 was not tagged or released.

## Current Situation

- `main` and the failed candidate are both `1ebfed9f6f7e10b5f8ae4c56e26b32ecc14357db`.
- All non-Windows release gates were green.
- Windows upgrades failed during the installed-controller preflight with `TypeError: load() got an unexpected keyword argument 'data_dir'`; no installed state changed.
- Windows fresh rollback left only `home\.defenseclaw` visible after the injected child exited.
- PR #490 remains separate and held until 0.8.4 is published.

## Solution

### Preserve published-loader compatibility

The Windows resolver now inspects the installed loader signature:

- Current scoped loaders receive `load(data_dir=controller_home)` and retain authoritative `DEFENSECLAW_CONFIG` behavior.
- Published zero-argument loaders temporarily bind their process-local `CONFIG_FILE_NAME` to the already validated absolute active config path, call `load()`, and restore the constant in `finally`.
- Any unknown loader signature or missing legacy path contract fails closed before mutation.
- The shim preserves default controller-owned config, split `data_dir`, and explicit external config layouts.

### Require proven Windows namespace retirement

```mermaid
flowchart LR
    A["Verify exact volume, file ID, type, and reparse state"] --> B["Set delete disposition on existing DELETE handle"]
    B --> C["Close deletion and validated companion handles"]
    C --> D["Observe with read-only, share-delete handle"]
    D -->|"same object or delete pending"| E["Poll within one monotonic deadline"]
    E --> D
    D -->|"absent"| F["Declare rollback success"]
    D -->|"different, unreadable, or timeout"| G["Fail closed and report residue"]
```

The native rollback claim now tracks `Bound -> DispositionAccepted -> Retired | Replaced | Unresolved` and:

- never treats accepted disposition as completed deletion;
- never reacquires DELETE authority while polling;
- validates and closes the retained creation companion before waiting;
- confirms every tree child is absent before deleting its parent;
- uses one 10-second monotonic budget for the whole tree;
- never resnapshots or retries a partially mutated tree;
- preserves replacements and unresolved bindings.

### Exercise the real failure boundary in PR CI

The Windows installer smoke job now runs the source-only native rollback self-test under both Windows PowerShell 5.1 and PowerShell 7 before builds or artifacts. The test holds a real share-delete handle across disposition for a tree root and nested file, then proves rollback waits for namespace retirement and removes the parent hierarchy.

The protected release harness also runs both engines and prints bounded, content-free residual path diagnostics if the post-move rollback ever fails again.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `scripts/upgrade.ps1` | Dispatch safely between published zero-argument and current scoped config loaders. |
| `scripts/install.ps1` | Add exact namespace-retirement state, observation, companion ordering, one-budget tree cleanup, and delayed-handle native tests. |
| `scripts/test-fresh-install-release-windows.ps1` | Run native lifecycle tests under PowerShell 5.1 and 7 and expose bounded rollback diagnostics. |
| `.github/workflows/ci.yml` | Add source-only native Windows rollback coverage before build/setup work. |
| `cli/tests/test_windows_powershell_upgrade_paths.py` | Lock loader compatibility, retirement invariants, no-resnapshot behavior, and harness coverage. |
| `cli/tests/test_install_script_static.py` | Lock the early dual-engine Windows CI gate and provenance separation. |

## Breaking Changes

None. Successful install/upgrade behavior and release provenance are unchanged. Failure handling is stricter: rollback is successful only after the exact namespace is proven absent.

## Open Issues / Follow-ups

None.

## Test Plan

Observed locally:

```bash
git diff --check
# passed

uv run ruff check \
  cli/tests/test_windows_powershell_upgrade_paths.py \
  cli/tests/test_install_script_static.py
# passed

uv run python -m pytest -q \
  cli/tests/test_windows_powershell_upgrade_paths.py \
  cli/tests/test_install_script_static.py
# 24 passed, 5 skipped

uv run python -m pytest -q \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_release_candidate.py \
  cli/tests/test_upgrade_release_smoke_contract.py \
  cli/tests/test_upgrade_smoke_static.py
# 153 passed
```

The embedded C# was parsed with the repository environment's `tree_sitter_c_sharp` grammar with no syntax errors.

Required CI evidence before merge:

- `Windows Installer Smoke (install.ps1)` passes its new PowerShell 5.1 + 7 native retirement tests.
- All ordinary PR checks pass.
- After merge, rerun Release 0.8.4 and require all four real Windows published-baseline upgrades plus the protected Windows fresh-install rollback gate to pass before Publish.
