### PR TITLE
fix(observability): inherit redaction for default routes

### DIFF
--- a/cli/defenseclaw/commands/cmd_setup_observability.py
+++ b/cli/defenseclaw/commands/cmd_setup_observability.py
@@ -467,7 +467,6 @@ def _build_v8_preset_destination(
         destination["send"] = {
             "signals": list(selected),
             "buckets": ["*"],
-            "redaction_profile": "none",
         }
     return destination
 

--- a/cli/tests/test_cmd_setup_observability_v8.py
+++ b/cli/tests/test_cmd_setup_observability_v8.py
@@ -849,7 +849,7 @@ def test_every_setup_preset_builds_a_schema_valid_v8_destination(
     assert validated["observability"]["destinations"][0]["name"] == "target"
 
 
-def test_v8_otlp_default_is_all_capabilities_unredacted_and_explicit_signals_narrow() -> None:
+def test_v8_otlp_default_uses_capabilities_and_explicit_signals_inherit_redaction() -> None:
     preset = PRESETS["otlp"]
     default = _build_v8_preset_destination(
         preset,
@@ -872,7 +872,6 @@ def test_v8_otlp_default_is_all_capabilities_unredacted_and_explicit_signals_nar
     assert narrowed["send"] == {
         "signals": ["logs"],
         "buckets": ["*"],
-        "redaction_profile": "none",
     }
 
 

--- a/internal/config/observability_v8_compile.go
+++ b/internal/config/observability_v8_compile.go
@@ -525,7 +525,7 @@ func compileObservabilityV8CapabilityRoute(capabilities ObservabilityV8Destinati
 		Action:   ObservabilityV8RouteSend,
 	}
 	if observabilityV8HasContentSignal(route.Signals) {
-		route.RedactionProfileByBucket = observabilityV8RouteProfiles(allBuckets, "none", buckets)
+		route.RedactionProfileByBucket = observabilityV8RouteProfiles(allBuckets, "", buckets)
 	}
 	return route
 }

--- a/internal/config/observability_v8_compile_test.go
+++ b/internal/config/observability_v8_compile_test.go
@@ -175,6 +175,32 @@ func TestCompileObservabilityV8CapabilityDefaultsAndEnabledPointer(t *testing.T)
 	}
 }
 
+func TestCompileObservabilityV8CapabilityDefaultInheritsBucketRedaction(t *testing.T) {
+	plan := mustCompileObservabilityV8(t, &ObservabilityV8Source{
+		Defaults: ObservabilityV8BucketPolicySource{RedactionProfile: "strict"},
+		Buckets: map[observability.Bucket]ObservabilityV8BucketPolicySource{
+			observability.BucketModelIO: {RedactionProfile: "sensitive"},
+		},
+		Destinations: []ObservabilityV8DestinationSource{
+			validObservabilityV8Destination("otel", ObservabilityV8DestinationOTLP),
+		},
+	})
+	destination, ok := plan.Destination("otel")
+	if !ok {
+		t.Fatal("compiled destination not found")
+	}
+	if destination.PolicyForm != ObservabilityV8PolicyCapabilityDefault || len(destination.Routes) != 1 {
+		t.Fatalf("destination = %+v", destination)
+	}
+	profiles := destination.Routes[0].RedactionProfileByBucket
+	if profiles[observability.BucketSecurityFinding] != "strict" {
+		t.Fatalf("security finding profile = %q, want strict", profiles[observability.BucketSecurityFinding])
+	}
+	if profiles[observability.BucketModelIO] != "sensitive" {
+		t.Fatalf("model I/O profile = %q, want sensitive", profiles[observability.BucketModelIO])
+	}
+}
+
 func TestCompileObservabilityV8TransportDefaultsAndPresetExpansion(t *testing.T) {
 	maxBackups, maxAge, compress := 0, 0, false
 	source := &ObservabilityV8Source{Destinations: []ObservabilityV8DestinationSource{


### PR DESCRIPTION
## Problem

PR #490 generates observability routes for destinations without explicit routes, and the setup command can also generate concise `send` routes when an operator narrows selected signals. Both paths forced `redaction_profile: none`, which can override configured global or bucket redaction policy for logs and traces.

## Current Situation

An operator can configure `observability.defaults.redaction_profile: strict` or a bucket-level profile such as `sensitive`, then add an OTLP/HTTP/console destination through setup or by relying on generated capability defaults. The compiler/setup output can still export content-bearing buckets with `redaction_profile: none`, so model I/O, evidence, errors, paths, or credential-class fields may be exported unredacted contrary to configured policy.

## Solution

Make generated capability-default routes pass no explicit route profile. That preserves the intended fallback chain in `observabilityV8RouteProfiles`: explicit route profile when configured, otherwise each effective bucket policy. Also stop setup-generated concise sends from writing an explicit `none`, so narrowed signal selections inherit the same policy.

## Architecture Diagram

N/A

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `internal/config/observability_v8_compile.go` | Generated capability-default routes now inherit effective bucket redaction instead of forcing `none`. |
| `internal/config/observability_v8_compile_test.go` | Added regression coverage for a generated OTLP route inheriting strict defaults and sensitive bucket override. |
| `cli/defenseclaw/commands/cmd_setup_observability.py` | Setup-generated concise sends no longer force `redaction_profile: none`. |
| `cli/tests/test_cmd_setup_observability_v8.py` | Updated setup regression coverage to assert explicit signal narrowing inherits redaction. |

## Breaking Changes

None. This makes generated default routes honor already-configured redaction policy.

## Open Issues / Follow-ups

None

## Test Plan

- `go test ./internal/config -run 'TestCompileObservabilityV8CapabilityDefaultsAndEnabledPointer|TestCompileObservabilityV8CapabilityDefaultInheritsBucketRedaction'` — passed (`ok github.com/defenseclaw/defenseclaw/internal/config (cached)`)
- `go test ./internal/config` — passed (`ok github.com/defenseclaw/defenseclaw/internal/config 1.396s`)
- `uv run python -m pytest cli/tests/test_cmd_setup_observability_v8.py -k 'otlp_default_uses_capabilities or galileo_update_deletes_only_prior_generated_concise_send' -q` — passed (`2 passed, 46 deselected in 1.69s`)
- `git diff --check` — passed with no output

CI status: pending on GitHub Actions for commit `7eed848ae`.
