### PR TITLE
fix(release): unblock 0.8.4 Windows gates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -512,12 +512,21 @@ jobs:
             --commit "$RELEASE_COMMIT" \
             --macos-verification-status "$MACOS_STATUS"
 
-      - name: Sign public checksum manifest
+      - name: Sign and authenticate public checksum manifest
         run: |
+          set -euo pipefail
           cosign sign-blob \
             --yes \
             --output-certificate=release-candidate/dist/checksums.txt.pem \
             --output-signature=release-candidate/dist/checksums.txt.sig \
+            release-candidate/dist/checksums.txt
+          python3 scripts/release_candidate.py canonicalize-certificate \
+            --certificate release-candidate/dist/checksums.txt.pem
+          cosign verify-blob \
+            --certificate release-candidate/dist/checksums.txt.pem \
+            --signature release-candidate/dist/checksums.txt.sig \
+            --certificate-identity "https://github.com/$GITHUB_REPOSITORY/.github/workflows/release.yaml@refs/heads/main" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             release-candidate/dist/checksums.txt
 
       - name: Seal all candidate bytes

--- a/cli/tests/test_release_candidate.py
+++ b/cli/tests/test_release_candidate.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import ast
+import base64
 import io
 import json
 import os
@@ -23,6 +24,14 @@ from scripts import release_candidate
 ROOT = Path(__file__).resolve().parents[2]
 VERSION = "0.8.4"
 COMMIT = "a" * 40
+TEST_CERTIFICATE_PEM = (
+    b"-----BEGIN CERTIFICATE-----\n"
+    b"MAMCAQA=\n"
+    b"-----END CERTIFICATE-----\n"
+)
+# The unit fixture only exercises canonical PEM/DER framing.  The release workflow
+# immediately asks Cosign to validate the real X.509 certificate and exact OIDC identity.
+TEST_CERTIFICATE_WRAPPER = base64.b64encode(TEST_CERTIFICATE_PEM)
 RELEASE_ARTIFACTS = release_candidate._expected_release_artifacts(VERSION)
 PROTECTED_WHEEL = RELEASE_ARTIFACTS["wheel"]
 PHASE_TWO_MUTATOR_SOURCE = (ROOT / "cli/defenseclaw/phase_two_mutator.py").read_text(encoding="utf-8")
@@ -416,7 +425,7 @@ def _macos_dir(tmp_path: Path, macos_verification_status: str = "notarized") -> 
     return macos
 
 
-def _sealed_candidate(
+def _candidate_before_seal(
     tmp_path: Path,
     macos_verification_status: str = "notarized",
 ) -> Path:
@@ -430,7 +439,17 @@ def _sealed_candidate(
         macos_verification_status,
     )
     (root / "dist/checksums.txt.sig").write_bytes(b"sigstore signature")
-    (root / "dist/checksums.txt.pem").write_bytes(b"sigstore certificate")
+    return root
+
+
+def _sealed_candidate(
+    tmp_path: Path,
+    macos_verification_status: str = "notarized",
+) -> Path:
+    root = _candidate_before_seal(tmp_path, macos_verification_status)
+    certificate = root / "dist/checksums.txt.pem"
+    certificate.write_bytes(TEST_CERTIFICATE_WRAPPER)
+    release_candidate.canonicalize_release_certificate(certificate)
     release_candidate.seal(root, VERSION, COMMIT)
     return root
 
@@ -439,6 +458,7 @@ def test_candidate_seals_and_verifies_exact_publish_set(tmp_path: Path) -> None:
     root = _sealed_candidate(tmp_path)
 
     release_candidate.verify(root, VERSION, COMMIT)
+    assert (root / "dist/checksums.txt.pem").read_bytes() == TEST_CERTIFICATE_PEM
 
     manifest = json.loads((root / "release-candidate.json").read_text(encoding="utf-8"))
     assert [item["name"] for item in manifest["assets"]] == list(
@@ -471,6 +491,101 @@ def test_candidate_seals_and_verifies_exact_publish_set(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     release_candidate.verify_published_release(root, release_json, VERSION, COMMIT)
+
+
+def test_certificate_command_canonicalizes_strict_cosign_wrapper_atomically(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    certificate = tmp_path / "checksums.txt.pem"
+    certificate.write_bytes(TEST_CERTIFICATE_WRAPPER)
+    original_replace = release_candidate.os.replace
+    replacements: list[tuple[Path, Path]] = []
+
+    def record_replace(source: str | Path, destination: str | Path) -> None:
+        replacements.append((Path(source), Path(destination)))
+        original_replace(source, destination)
+
+    monkeypatch.setattr(release_candidate.os, "replace", record_replace)
+    status = release_candidate.main(
+        ["canonicalize-certificate", "--certificate", str(certificate)]
+    )
+
+    assert status == 0
+    assert certificate.read_bytes() == TEST_CERTIFICATE_PEM
+    assert len(replacements) == 1
+    assert replacements[0][0].parent == certificate.parent
+    assert replacements[0][1] == certificate
+    assert "release certificate canonicalized" in capsys.readouterr().out
+
+
+def test_certificate_canonicalization_accepts_canonical_raw_pem(tmp_path: Path) -> None:
+    certificate = tmp_path / "checksums.txt.pem"
+    certificate.write_bytes(TEST_CERTIFICATE_PEM)
+
+    release_candidate.canonicalize_release_certificate(certificate)
+
+    assert certificate.read_bytes() == TEST_CERTIFICATE_PEM
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"",
+        TEST_CERTIFICATE_WRAPPER + b"\n",
+        base64.b64encode(TEST_CERTIFICATE_PEM.rstrip(b"\n")),
+        base64.b64encode(TEST_CERTIFICATE_PEM + TEST_CERTIFICATE_PEM),
+        TEST_CERTIFICATE_PEM + TEST_CERTIFICATE_PEM,
+        TEST_CERTIFICATE_PEM.replace(b"\n", b"\r\n"),
+        b"\xef\xbb\xbf" + TEST_CERTIFICATE_PEM,
+        b"A" * (release_candidate.MAX_RELEASE_CERTIFICATE_BYTES + 1),
+    ],
+)
+def test_certificate_canonicalization_rejects_noncanonical_or_ambiguous_input(
+    tmp_path: Path,
+    payload: bytes,
+) -> None:
+    certificate = tmp_path / "checksums.txt.pem"
+    certificate.write_bytes(payload)
+
+    with pytest.raises(release_candidate.CandidateError, match="release certificate"):
+        release_candidate.canonicalize_release_certificate(certificate)
+
+    assert certificate.read_bytes() == payload
+
+
+def test_certificate_atomic_publication_failure_preserves_cosign_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    certificate = tmp_path / "checksums.txt.pem"
+    certificate.write_bytes(TEST_CERTIFICATE_WRAPPER)
+
+    def fail_replace(_source: str | Path, _destination: str | Path) -> None:
+        raise OSError("injected replace failure")
+
+    monkeypatch.setattr(release_candidate.os, "replace", fail_replace)
+    with pytest.raises(release_candidate.CandidateError, match="atomically publish"):
+        release_candidate.canonicalize_release_certificate(certificate)
+
+    assert certificate.read_bytes() == TEST_CERTIFICATE_WRAPPER
+    assert not list(tmp_path.glob(".checksums.txt.pem.canonical-*"))
+
+
+def test_seal_and_verify_reject_base64_wrapped_modern_certificate(tmp_path: Path) -> None:
+    unsealed = _candidate_before_seal(tmp_path)
+    certificate = unsealed / "dist/checksums.txt.pem"
+    certificate.write_bytes(TEST_CERTIFICATE_WRAPPER)
+    with pytest.raises(release_candidate.CandidateError, match="canonical raw PEM"):
+        release_candidate.seal(unsealed, VERSION, COMMIT)
+
+    sealed_root = tmp_path / "sealed-case"
+    sealed_root.mkdir()
+    sealed = _sealed_candidate(sealed_root)
+    (sealed / "dist/checksums.txt.pem").write_bytes(TEST_CERTIFICATE_WRAPPER)
+    with pytest.raises(release_candidate.CandidateError, match="canonical raw PEM"):
+        release_candidate.verify(sealed, VERSION, COMMIT)
 
 
 def test_candidate_seals_and_verifies_explicit_unverified_macos_assets(

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -209,6 +209,42 @@ def test_build_once_candidate_is_reused_by_tests_and_publisher() -> None:
         assert "scripts/release_candidate.py verify" in rendered
 
 
+def test_release_certificate_is_canonicalized_and_authenticated_before_seal() -> None:
+    assemble_job = _workflow()["jobs"]["assemble-release-candidate"]
+    steps = assemble_job["steps"]
+    sign_index, sign_step = next(
+        (index, step)
+        for index, step in enumerate(steps)
+        if step.get("name") == "Sign and authenticate public checksum manifest"
+    )
+    seal_index, seal_step = next(
+        (index, step)
+        for index, step in enumerate(steps)
+        if step.get("name") == "Seal all candidate bytes"
+    )
+    sign_script = sign_step["run"]
+    seal_script = seal_step["run"]
+
+    sign = sign_script.index("cosign sign-blob")
+    canonicalize = sign_script.index(
+        "scripts/release_candidate.py canonicalize-certificate"
+    )
+    authenticate = sign_script.index("cosign verify-blob")
+    assert sign < canonicalize < authenticate
+    assert sign_index + 1 == seal_index
+    assert sign_script.count("canonicalize-certificate") == 1
+    assert "--certificate release-candidate/dist/checksums.txt.pem" in sign_script
+    assert (
+        '--certificate-identity "https://github.com/$GITHUB_REPOSITORY/'
+        '.github/workflows/release.yaml@refs/heads/main"'
+    ) in sign_script
+    assert (
+        '--certificate-oidc-issuer "https://token.actions.githubusercontent.com"'
+    ) in sign_script
+    assert "--certificate-identity-regexp" not in sign_script
+    assert "scripts/release_candidate.py seal" in seal_script
+
+
 def test_sealed_candidate_must_pass_native_fresh_install_and_second_run_refusal() -> None:
     jobs = _workflow()["jobs"]
     posix = str(jobs["posix-fresh-install"])

--- a/cli/tests/test_windows_powershell_upgrade_paths.py
+++ b/cli/tests/test_windows_powershell_upgrade_paths.py
@@ -131,6 +131,10 @@ def test_windows_fresh_installer_rolls_back_exact_attempt_owned_payloads() -> No
         "NAMESPACE_RETIRE_TIMEOUT_MS",
         "ConfigureTestNamespaceRetirementDelay",
         "ClearTestNamespaceRetirementDelay",
+        "ConfigureTestDeleteBindingDelay",
+        "ClearTestDeleteBindingDelay",
+        "OpenSnapshotObservationHandle",
+        "OpenRetirementHandle",
         "ConfigureTestMoveOutAfterSnapshot",
         "ClearTestMoveOutAfterSnapshot",
         "ConfigureTestEmptyDirectoryDeleteFailures",
@@ -194,7 +198,26 @@ def test_windows_fresh_installer_rolls_back_exact_attempt_owned_payloads() -> No
     assert tree_delete.index("current.Dispose()") < tree_delete.index("WaitForNamespaceRetirement(")
     assert "return RetireRootNamespaceExact(" in tree_delete
     assert "never resnapshot or acquire fresh delete authority" in tree_delete
-    assert tree_delete.count("SnapshotDirectory(path, 1, entries, ref bytes)") == 1
+    assert tree_delete.count("SnapshotDirectory(path, 1, entries, ref bytes, deadline)") == 1
+    assert "StartTestDeleteBindingDelay()" in tree_delete
+    snapshot = source[
+        source.index("private void SnapshotDirectory") : source.index(
+            "public bool DeleteTreeExact()"
+        )
+    ]
+    assert "OpenSnapshotObservationHandle(child, deadline)" in snapshot
+    assert "OpenRetirementHandle" not in snapshot
+    retirement_open = source[
+        source.index("private static SafeFileHandle OpenRetirementHandle") : source.index(
+            "private static SafeFileHandle OpenParentHandle"
+        )
+    ]
+    assert "FILE_SHARE_READ | FILE_SHARE_WRITE" in retirement_open
+    assert "FILE_SHARE_DELETE" not in retirement_open
+    assert "ERROR_ACCESS_DENIED" in retirement_open
+    assert "ERROR_SHARING_VIOLATION" in retirement_open
+    assert "ERROR_DELETE_PENDING" in retirement_open
+    assert "timed out binding exact fresh-install path for retirement" in retirement_open
     observer = source[
         source.index("private static NamespaceObservation ObserveNamespace") : source.index(
             "private static long NewNamespaceRetirementDeadline"
@@ -277,13 +300,17 @@ def test_windows_fresh_installer_rolls_back_exact_attempt_owned_payloads() -> No
     assert "Native empty directory rollback retry passed" in source
     assert "Native delayed tree-root namespace retirement passed" in source
     assert "Native delayed child namespace retirement passed" in source
+    assert "Native delayed exact DELETE binding passed" in source
     assert "Native namespace retirement wait passed" in source
     assert "Native post-move rollback topology passed" in source
     assert "Native private-directory self-test accepted a file as its parent" in source
     assert "Fresh-install payload rollback completed; retry is safe" in harness
     assert "Concurrent unclaimed shim disappeared during rollback" in harness
     assert "Failed fresh install left installer-created binary directories behind" in harness
-    assert "Assert-NoFreshPayload -Context $postMove.Output" in harness
+    assert '-Phase "post-directory-publication injection" -Context $postMove.Output' in harness
+    assert '-Phase "post-venv policy-cleanup injection"' in harness
+    assert '-Phase "moved policy-custody injection"' in harness
+    assert '-Phase "concurrent shim collision"' in harness
     assert "--- post-move installer output ---" in harness
     assert "bounded residual path inventory (names and kinds only)" in harness
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -309,6 +309,9 @@ namespace DefenseClaw.Install.FreshV1 {
         private static readonly object testNamespaceRetirementLock = new object();
         private static string testNamespaceRetirementPath;
         private static int testNamespaceRetirementDelayMs;
+        private static readonly object testDeleteBindingLock = new object();
+        private static string testDeleteBindingPath;
+        private static int testDeleteBindingDelayMs;
 
         private FreshPathClaim(
             string claimedPath,
@@ -555,6 +558,30 @@ namespace DefenseClaw.Install.FreshV1 {
             }
         }
 
+        public static void ConfigureTestDeleteBindingDelay(
+            string path,
+            int delayMilliseconds) {
+            if (String.IsNullOrWhiteSpace(path)) {
+                throw new ArgumentException("test delete-binding path is empty");
+            }
+            if (delayMilliseconds < 1 ||
+                delayMilliseconds >
+                    NAMESPACE_RETIRE_TIMEOUT_MS - (2 * NAMESPACE_RETIRE_POLL_MS)) {
+                throw new ArgumentOutOfRangeException("delayMilliseconds");
+            }
+            lock (testDeleteBindingLock) {
+                testDeleteBindingPath = Path.GetFullPath(path);
+                testDeleteBindingDelayMs = delayMilliseconds;
+            }
+        }
+
+        public static void ClearTestDeleteBindingDelay() {
+            lock (testDeleteBindingLock) {
+                testDeleteBindingPath = null;
+                testDeleteBindingDelayMs = 0;
+            }
+        }
+
         private static bool ConsumeTestEmptyDirectoryDeleteFailure() {
             while (true) {
                 int current = System.Threading.Volatile.Read(
@@ -663,6 +690,85 @@ namespace DefenseClaw.Install.FreshV1 {
             } catch {
                 delayedHandle.Dispose();
                 throw;
+            }
+        }
+
+        private static void StartTestDeleteBindingDelay() {
+            string candidate = null;
+            int delay = 0;
+            lock (testDeleteBindingLock) {
+                if (String.IsNullOrEmpty(testDeleteBindingPath)) {
+                    return;
+                }
+                candidate = testDeleteBindingPath;
+                delay = testDeleteBindingDelayMs;
+                testDeleteBindingPath = null;
+                testDeleteBindingDelayMs = 0;
+            }
+            SafeFileHandle retained = CreateFile(
+                Path.GetFullPath(candidate),
+                FILE_READ_ATTRIBUTES,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                IntPtr.Zero,
+                OPEN_EXISTING,
+                FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
+                IntPtr.Zero);
+            if (retained.IsInvalid) {
+                int error = Marshal.GetLastWin32Error();
+                retained.Dispose();
+                throw new Win32Exception(
+                    error,
+                    "could not create the delete-binding test retainer");
+            }
+            System.Threading.Thread releaser = new System.Threading.Thread(delegate() {
+                try {
+                    System.Threading.Thread.Sleep(delay);
+                } finally {
+                    retained.Dispose();
+                }
+            });
+            releaser.IsBackground = true;
+            try {
+                releaser.Start();
+            } catch {
+                retained.Dispose();
+                throw;
+            }
+        }
+
+        private static SafeFileHandle OpenSnapshotObservationHandle(
+            string candidate,
+            long deadline) {
+            // Snapshot through read-only, share-delete handles. Scanner custody
+            // may briefly deny even this observation, but absence or a different
+            // identity is never inferred from a transient open failure.
+            string full = Path.GetFullPath(candidate);
+            while (true) {
+                SafeFileHandle opened = OpenNamespaceObservationHandle(full);
+                if (!opened.IsInvalid) {
+                    return opened;
+                }
+                int error = Marshal.GetLastWin32Error();
+                opened.Dispose();
+                if (error != ERROR_ACCESS_DENIED &&
+                    error != ERROR_SHARING_VIOLATION &&
+                    error != ERROR_DELETE_PENDING) {
+                    throw new Win32Exception(
+                        error,
+                        "could not observe fresh-install path for rollback snapshot: " + full);
+                }
+                long remainingTicks = deadline - System.Diagnostics.Stopwatch.GetTimestamp();
+                if (remainingTicks <= 0) {
+                    throw new Win32Exception(
+                        error,
+                        "timed out observing fresh-install path for rollback snapshot: " + full);
+                }
+                long remainingMilliseconds =
+                    (remainingTicks * 1000) / System.Diagnostics.Stopwatch.Frequency;
+                int delay = (int)Math.Max(
+                    1L,
+                    Math.Min((long)NAMESPACE_RETIRE_POLL_MS, remainingMilliseconds));
+                System.Threading.Thread.Sleep(delay);
             }
         }
 
@@ -798,6 +904,58 @@ namespace DefenseClaw.Install.FreshV1 {
                 return null;
             }
             throw new Win32Exception(error, "could not bind fresh-install path: " + path);
+        }
+
+        private static SafeFileHandle OpenRetirementHandle(
+            string path,
+            bool directory,
+            bool allowMissing,
+            long deadline) {
+            // Retry only acquisition of DELETE authority for this snapshotted
+            // pathname and only inside the tree's one monotonic budget. The
+            // caller revalidates identity, kind, and reparse state before the
+            // first disposition; a partial traversal is never restarted.
+            string full = Path.GetFullPath(path);
+            uint access = FILE_READ_ATTRIBUTES | (directory ? FILE_TRAVERSE : 0) | DELETE;
+            uint flags = FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS;
+            while (true) {
+                SafeFileHandle opened = CreateFile(
+                    full,
+                    access,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE,
+                    IntPtr.Zero,
+                    OPEN_EXISTING,
+                    flags,
+                    IntPtr.Zero);
+                if (!opened.IsInvalid) {
+                    return opened;
+                }
+                int error = Marshal.GetLastWin32Error();
+                opened.Dispose();
+                if (allowMissing &&
+                    (error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND)) {
+                    return null;
+                }
+                if (error != ERROR_ACCESS_DENIED &&
+                    error != ERROR_SHARING_VIOLATION &&
+                    error != ERROR_DELETE_PENDING) {
+                    throw new Win32Exception(
+                        error,
+                        "could not bind fresh-install path for retirement: " + full);
+                }
+                long remainingTicks = deadline - System.Diagnostics.Stopwatch.GetTimestamp();
+                if (remainingTicks <= 0) {
+                    throw new Win32Exception(
+                        error,
+                        "timed out binding exact fresh-install path for retirement: " + full);
+                }
+                long remainingMilliseconds =
+                    (remainingTicks * 1000) / System.Diagnostics.Stopwatch.Frequency;
+                int delay = (int)Math.Max(
+                    1L,
+                    Math.Min((long)NAMESPACE_RETIRE_POLL_MS, remainingMilliseconds));
+                System.Threading.Thread.Sleep(delay);
+            }
         }
 
         private static SafeFileHandle OpenParentHandle(string path) {
@@ -984,12 +1142,13 @@ namespace DefenseClaw.Install.FreshV1 {
             string current,
             int depth,
             List<TreeEntry> entries,
-            ref long bytes) {
+            ref long bytes,
+            long deadline) {
             if (depth > MAX_TREE_DEPTH) {
                 throw new InvalidOperationException("fresh-install tree exceeds rollback depth bound");
             }
             foreach (string child in Directory.GetFileSystemEntries(current)) {
-                SafeFileHandle opened = OpenHandle(child, false, true, false);
+                SafeFileHandle opened = OpenSnapshotObservationHandle(child, deadline);
                 BY_HANDLE_FILE_INFORMATION information;
                 try {
                     information = Information(opened, child);
@@ -999,13 +1158,6 @@ namespace DefenseClaw.Install.FreshV1 {
                 }
                 bool isDirectory = (information.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
                 bool isReparse = (information.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
-                if (isDirectory) {
-                    opened.Dispose();
-                    opened = OpenHandle(child, true, true, false);
-                    information = Information(opened, child);
-                    isDirectory = (information.FileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
-                    isReparse = (information.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
-                }
                 TreeEntry entry = new TreeEntry();
                 entry.Path = child;
                 entry.Volume = information.VolumeSerialNumber;
@@ -1023,7 +1175,7 @@ namespace DefenseClaw.Install.FreshV1 {
                     throw new InvalidOperationException("fresh-install tree crosses a volume boundary");
                 }
                 if (isDirectory && !isReparse) {
-                    SnapshotDirectory(child, depth + 1, entries, ref bytes);
+                    SnapshotDirectory(child, depth + 1, entries, ref bytes, deadline);
                 }
             }
         }
@@ -1048,9 +1200,10 @@ namespace DefenseClaw.Install.FreshV1 {
             ValidateRetirementCompanion(companion);
             List<TreeEntry> entries = new List<TreeEntry>();
             long bytes = 0;
-            SnapshotDirectory(path, 1, entries, ref bytes);
-            InvokeTestMoveOutAfterSnapshot();
             long deadline = NewNamespaceRetirementDeadline();
+            SnapshotDirectory(path, 1, entries, ref bytes, deadline);
+            StartTestDeleteBindingDelay();
+            InvokeTestMoveOutAfterSnapshot();
             entries.Sort(delegate(TreeEntry left, TreeEntry right) {
                 int depthOrder = right.Depth.CompareTo(left.Depth);
                 if (depthOrder != 0) {
@@ -1059,11 +1212,11 @@ namespace DefenseClaw.Install.FreshV1 {
                 return StringComparer.OrdinalIgnoreCase.Compare(right.Path, left.Path);
             });
             foreach (TreeEntry entry in entries) {
-                SafeFileHandle current = OpenHandle(
+                SafeFileHandle current = OpenRetirementHandle(
                     entry.Path,
                     entry.IsDirectory,
                     true,
-                    true);
+                    deadline);
                 if (current == null) {
                     retirementState = RetirementState.Replaced;
                     return false;
@@ -1680,6 +1833,38 @@ function Invoke-NativeFreshDirectoryBoundarySelfTest {
         }
     }
     Write-Host "Native delayed child namespace retirement passed" -ForegroundColor Green
+
+    $bindingTree = Join-Path $Root ("fresh-delete-binding-" + [guid]::NewGuid().ToString("N"))
+    $bindingDirectory = Join-Path $bindingTree "nested"
+    $bindingFile = Join-Path $bindingDirectory "owned.txt"
+    $script:FreshInstallClaims = New-Object 'System.Collections.Generic.List[object]'
+    $script:FreshInstallAttemptActive = $true
+    $script:FreshInstallOriginalProcessPath = $env:PATH
+    $script:FreshInstallPublishedProcessPath = $null
+    try {
+        New-FreshInstallOwnedDirectory -Path $bindingTree -Kind Tree
+        [void][IO.Directory]::CreateDirectory($bindingDirectory)
+        [IO.File]::WriteAllText($bindingFile, "owned", [Text.Encoding]::ASCII)
+        [DefenseClaw.Install.FreshV1.FreshPathClaim]::ConfigureTestDeleteBindingDelay(
+            $bindingFile,
+            250
+        )
+        $bindingWatch = [Diagnostics.Stopwatch]::StartNew()
+        $bindingResidue = @(Undo-FreshInstallAttempt)
+        $bindingWatch.Stop()
+        if ($bindingResidue.Count -ne 0 -or
+            (Test-InstallMarker -Path $bindingTree) -or
+            $bindingWatch.ElapsedMilliseconds -lt 150) {
+            Die "Native tree rollback did not wait for an exact DELETE binding"
+        }
+    } finally {
+        [DefenseClaw.Install.FreshV1.FreshPathClaim]::ClearTestDeleteBindingDelay()
+        if ($script:FreshInstallAttemptActive) { [void](Undo-FreshInstallAttempt) }
+        if (Test-InstallMarker -Path $bindingTree) {
+            [IO.Directory]::Delete($bindingTree, $true)
+        }
+    }
+    Write-Host "Native delayed exact DELETE binding passed" -ForegroundColor Green
     Write-Host "Native namespace retirement wait passed" -ForegroundColor Green
 
     # Mirror the real post-publication failure topology: an attempt-owned home

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -28,16 +28,20 @@ from __future__ import annotations
 
 import argparse
 import ast
+import base64
+import binascii
 import hashlib
 import io
 import json
 import os
 import re
 import shutil
+import ssl
 import stat
 import struct
 import sys
 import tarfile
+import tempfile
 import zipfile
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -69,6 +73,10 @@ RESOLVER_ASSET_SOURCES = {
     "defenseclaw-upgrade.ps1": ROOT / "scripts" / "upgrade.ps1",
 }
 MAX_RESOLVER_BYTES = 4 * 1024 * 1024
+MAX_RELEASE_CERTIFICATE_BYTES = 64 * 1024
+STRICT_BASE64_RE = re.compile(
+    rb"(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?"
+)
 MACOS_VERIFICATION_STATUSES = ("notarized", "unverified")
 
 
@@ -91,6 +99,184 @@ def _sha256(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _file_identity(info: os.stat_result) -> tuple[int, int, int, int, int, int]:
+    return (
+        info.st_dev,
+        info.st_ino,
+        stat.S_IFMT(info.st_mode),
+        info.st_size,
+        info.st_mtime_ns,
+        info.st_ctime_ns,
+    )
+
+
+def _directory_identity(info: os.stat_result) -> tuple[int, int, int]:
+    return (info.st_dev, info.st_ino, stat.S_IFMT(info.st_mode))
+
+
+def _read_release_certificate(path: Path) -> tuple[bytes, os.stat_result, os.stat_result]:
+    """Read one bounded regular certificate file without following a symlink."""
+
+    try:
+        parent_info = path.parent.lstat()
+    except OSError as exc:
+        raise CandidateError(f"release certificate parent is unavailable: {path.parent}") from exc
+    if not stat.S_ISDIR(parent_info.st_mode):
+        raise CandidateError(f"release certificate parent must be a real directory: {path.parent}")
+
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise CandidateError(f"release certificate is unavailable: {path}") from exc
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
+            raise CandidateError(f"release certificate must be a regular file: {path}")
+        if not 0 < opened.st_size <= MAX_RELEASE_CERTIFICATE_BYTES:
+            raise CandidateError(f"release certificate has an invalid size: {path}")
+        chunks: list[bytes] = []
+        bytes_read = 0
+        while True:
+            chunk = os.read(
+                descriptor,
+                min(64 * 1024, MAX_RELEASE_CERTIFICATE_BYTES + 1 - bytes_read),
+            )
+            if not chunk:
+                break
+            chunks.append(chunk)
+            bytes_read += len(chunk)
+            if bytes_read > MAX_RELEASE_CERTIFICATE_BYTES:
+                raise CandidateError(f"release certificate has an invalid size: {path}")
+        opened_after = os.fstat(descriptor)
+        try:
+            named_after = path.lstat()
+        except OSError as exc:
+            raise CandidateError(f"release certificate disappeared while being read: {path}") from exc
+        if (
+            _file_identity(opened) != _file_identity(opened_after)
+            or _file_identity(opened_after) != _file_identity(named_after)
+            or bytes_read != opened_after.st_size
+        ):
+            raise CandidateError(f"release certificate changed while being read: {path}")
+        return b"".join(chunks), opened_after, parent_info
+    finally:
+        os.close(descriptor)
+
+
+def _canonical_pem_certificate(raw: bytes) -> bytes:
+    try:
+        text = raw.decode("ascii")
+        der = ssl.PEM_cert_to_DER_cert(text)
+        canonical = ssl.DER_cert_to_PEM_cert(der).encode("ascii")
+    except (binascii.Error, UnicodeDecodeError, ValueError) as exc:
+        raise CandidateError("release certificate is not exactly one PEM certificate") from exc
+    if not der or raw != canonical:
+        raise CandidateError("release certificate is not canonical raw PEM")
+    return canonical
+
+
+def _release_certificate_payload(raw: bytes, *, allow_base64_wrapper: bool) -> bytes:
+    if not 0 < len(raw) <= MAX_RELEASE_CERTIFICATE_BYTES:
+        raise CandidateError("release certificate has an invalid size")
+    if raw.startswith(b"-----BEGIN CERTIFICATE-----\n"):
+        return _canonical_pem_certificate(raw)
+    if not allow_base64_wrapper:
+        raise CandidateError("sealed release certificate must be canonical raw PEM")
+    if STRICT_BASE64_RE.fullmatch(raw) is None:
+        raise CandidateError("post-cosign release certificate is not strict base64 or raw PEM")
+    try:
+        decoded = base64.b64decode(raw, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise CandidateError("post-cosign release certificate has invalid base64") from exc
+    if base64.b64encode(decoded) != raw:
+        raise CandidateError("post-cosign release certificate base64 is noncanonical")
+    canonical = _canonical_pem_certificate(decoded)
+    if decoded != canonical:
+        raise CandidateError("post-cosign release certificate does not wrap canonical PEM")
+    return canonical
+
+
+def _atomic_replace_release_certificate(
+    path: Path,
+    payload: bytes,
+    *,
+    expected_file: os.stat_result,
+    expected_parent: os.stat_result,
+) -> None:
+    descriptor = -1
+    temporary_name = ""
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{path.name}.canonical-",
+            dir=path.parent,
+        )
+        if hasattr(os, "fchmod"):
+            os.fchmod(descriptor, stat.S_IMODE(expected_file.st_mode))
+        offset = 0
+        while offset < len(payload):
+            written = os.write(descriptor, payload[offset:])
+            if written <= 0:
+                raise OSError("short write while canonicalizing release certificate")
+            offset += written
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+
+        current_file = path.lstat()
+        current_parent = path.parent.lstat()
+        if (
+            _file_identity(current_file) != _file_identity(expected_file)
+            or _directory_identity(current_parent) != _directory_identity(expected_parent)
+        ):
+            raise CandidateError("release certificate path changed before atomic publication")
+        os.replace(temporary_name, path)
+        temporary_name = ""
+        if os.name == "posix":
+            parent_descriptor = os.open(
+                path.parent,
+                os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0),
+            )
+            try:
+                os.fsync(parent_descriptor)
+            finally:
+                os.close(parent_descriptor)
+    except CandidateError:
+        raise
+    except OSError as exc:
+        raise CandidateError(f"could not atomically publish canonical release certificate: {path}") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if temporary_name:
+            try:
+                os.unlink(temporary_name)
+            except OSError:
+                pass
+
+
+def canonicalize_release_certificate(path: Path) -> None:
+    """Canonicalize trusted Cosign output before candidate bytes are sealed."""
+
+    raw, file_info, parent_info = _read_release_certificate(path)
+    canonical = _release_certificate_payload(raw, allow_base64_wrapper=True)
+    _atomic_replace_release_certificate(
+        path,
+        canonical,
+        expected_file=file_info,
+        expected_parent=parent_info,
+    )
+    published, _, _ = _read_release_certificate(path)
+    if published != canonical:
+        raise CandidateError("canonical release certificate changed after atomic publication")
+
+
+def _require_canonical_release_certificate(path: Path) -> None:
+    raw, _, _ = _read_release_certificate(path)
+    _release_certificate_payload(raw, allow_base64_wrapper=False)
 
 
 def _protected_payload(path: Path) -> bytes:
@@ -2728,6 +2914,7 @@ def seal(root: Path, version: str, commit: str) -> None:
             "release candidate contains an unexpected file set: "
             f"got {actual_names!r}, want {names!r}"
         )
+    _require_canonical_release_certificate(dist / "checksums.txt.pem")
 
     checksums = _parse_checksums(dist / "checksums.txt")
     payload_names = payload_asset_names(version, macos_verification_status)
@@ -2776,6 +2963,7 @@ def verify(root: Path, version: str, commit: str) -> None:
     actual_names = _strict_file_names(dist, "release candidate")
     if actual_names != expected_names:
         raise CandidateError("release candidate file set changed after sealing")
+    _require_canonical_release_certificate(dist / "checksums.txt.pem")
 
     assets = manifest.get("assets")
     if not isinstance(assets, list):
@@ -2898,6 +3086,9 @@ def _parser() -> argparse.ArgumentParser:
     assemble_parser.add_argument("--commit", required=True)
     assemble_parser.add_argument("--macos-verification-status", required=True)
 
+    canonicalize_certificate_parser = subparsers.add_parser("canonicalize-certificate")
+    canonicalize_certificate_parser.add_argument("--certificate", type=Path, required=True)
+
     seal_parser = subparsers.add_parser("seal")
     seal_parser.add_argument("--root", type=Path, required=True)
     seal_parser.add_argument("--version", required=True)
@@ -2958,6 +3149,9 @@ def main(argv: list[str] | None = None) -> int:
                 args.macos_verification_status,
             )
             print(f"release candidate assembled: {args.root}")
+        elif args.command == "canonicalize-certificate":
+            canonicalize_release_certificate(args.certificate)
+            print(f"release certificate canonicalized: {args.certificate}")
         elif args.command == "seal":
             seal(args.root, args.version, args.commit)
             print(f"release candidate sealed: {args.version} at {args.commit}")

--- a/scripts/test-fresh-install-release-windows.ps1
+++ b/scripts/test-fresh-install-release-windows.ps1
@@ -141,7 +141,10 @@ function Assert-NoInstallerCustody {
 }
 
 function Assert-NoFreshPayload {
-    param([string]$Context = "")
+    param(
+        [string]$Phase = "fresh-install rollback",
+        [string]$Context = ""
+    )
     foreach ($path in @(
         $env:DEFENSECLAW_HOME,
         (Join-Path $HomeRoot ".local\bin\defenseclaw-gateway.exe"),
@@ -149,7 +152,7 @@ function Assert-NoFreshPayload {
     )) {
         if (Test-Path -LiteralPath $path) {
             $diagnostic = if ($Context) { "`nInstaller output:`n$Context" } else { "" }
-            throw "Failed fresh install left a managed payload marker: $path$diagnostic"
+            throw "Failed fresh install left a managed payload marker during ${Phase}: $path$diagnostic"
         }
     }
 }
@@ -307,7 +310,7 @@ try {
             Write-Host "$kind`t$relative"
         }
     }
-    Assert-NoFreshPayload -Context $postMove.Output
+    Assert-NoFreshPayload -Phase "post-directory-publication injection" -Context $postMove.Output
     if (Test-Path -LiteralPath (Join-Path $HomeRoot ".local")) {
         throw "Post-move fresh-directory failure left .local or bin custody behind"
     }
@@ -330,7 +333,9 @@ try {
     }
     [void](Remove-InjectedPolicyResidue -Output $injected.Output)
     Assert-NoInstallerCustody
-    Assert-NoFreshPayload
+    Assert-NoFreshPayload `
+        -Phase "post-venv policy-cleanup injection" `
+        -Context $injected.Output
     if (Test-Path -LiteralPath (Join-Path $HomeRoot ".local")) {
         throw "Failed fresh install left installer-created binary directories behind"
     }
@@ -353,7 +358,9 @@ try {
     }
     Remove-MovedPolicyCustodyResidue -Output $movedCustody.Output
     Assert-NoInstallerCustody
-    Assert-NoFreshPayload
+    Assert-NoFreshPayload `
+        -Phase "moved policy-custody injection" `
+        -Context $movedCustody.Output
     if (Test-Path -LiteralPath (Join-Path $HomeRoot ".local")) {
         throw "Moved policy custody left installer-created binary directories behind"
     }
@@ -386,7 +393,7 @@ try {
     [IO.File]::Delete($unclaimedShim)
     [IO.Directory]::Delete((Join-Path $HomeRoot ".local\bin"))
     [IO.Directory]::Delete((Join-Path $HomeRoot ".local"))
-    Assert-NoFreshPayload
+    Assert-NoFreshPayload -Phase "concurrent shim collision" -Context $collision.Output
 
     $first = Invoke-FreshInstaller -InjectPolicyCleanupFailure
     $expectedInstallDir = Join-Path $HomeRoot ".local\bin"


### PR DESCRIPTION
Release-only follow-up to failed Release run [29249432165](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29249432165). This PR is independent of observability v8 PR #490 and must merge to `main` before rerunning 0.8.4. It does not change teams, reviewers, branch rules, rulesets, release environments, or unsigned macOS behavior.

## Problem

The sealed 0.8.4 candidate passed provenance, build, macOS/Linux release gates, and 39 of 44 completed jobs, but five deterministic Windows jobs failed and Publish correctly remained skipped:

1. All four published Windows baselines (0.8.0 through 0.8.3) authenticated the candidate, then refused it because Cosign 2.4.1 emitted `checksums.txt.pem` as base64-wrapped PEM while the modern resolver correctly requires raw PEM.
2. The protected Windows fresh-install gate failed after the first post-venv fault injection because a transient Defender/runtime handle without `FILE_SHARE_DELETE` could block exact DELETE-handle acquisition. The rollback wait covered namespace retirement only after disposition, so `.venv` and then `.defenseclaw` were preserved.

## Current Situation

- `main` and the failed candidate are both `bb62bc55e29b1f3bbfaa7fe4ba4ea18ca16dcad1`.
- 0.8.4 has not been published or tagged by the failed run.
- The sealed candidate certificate is a strict base64 encoding of one canonical PEM certificate, not raw PEM.
- The Windows resolver is behaving correctly and remains fail-closed for wrapped certificates at 0.8.4 and newer.
- The fresh-install failure occurs after `uv pip install`; the earlier pre-venv rollback boundary passes.
- PR #490 remains separate and held until 0.8.4 is published.

## Solution

### Canonicalize trusted signing output before sealing

The release candidate builder now:

- reads one bounded regular certificate without following symlinks;
- accepts a strict Cosign base64 wrapper only in the explicit post-signing canonicalization command;
- atomically publishes canonical raw PEM and re-reads it;
- immediately runs `cosign verify-blob` with the exact main-workflow identity and GitHub OIDC issuer;
- refuses wrapped or noncanonical certificate bytes in both candidate sealing and verification.

The Windows resolver is unchanged: modern releases still require raw PEM and never normalize legacy wrappers.

### Tolerate transient Windows scanner custody without weakening identity

Tree rollback now uses the existing single monotonic deadline across every stage:

- snapshot children with read-only, share-delete observation handles;
- retry exact DELETE-handle acquisition only for access denied, sharing violation, or delete pending;
- revalidate volume, file ID, directory kind, and reparse state before disposition;
- never resnapshot or restart a partially mutated traversal;
- preserve missing, replaced, conflicting, or unresolved state.

```mermaid
flowchart LR
    A["Cosign sign"] --> B["Strict post-sign canonicalization"]
    B --> C["Exact identity and issuer verification"]
    C --> D["Seal immutable candidate"]
    D --> E["Windows baseline matrix"]

    F["Read-only tree snapshot"] --> G["Bounded exact DELETE acquisition"]
    G --> H["Identity, kind, and reparse revalidation"]
    H --> I["Delete disposition"]
    I --> J["Prove namespace absent"]
```

### Exercise the missing failure boundary

The native Windows self-test now holds a snapshotted nested file without `FILE_SHARE_DELETE` for 250 ms after snapshot. Both Windows PowerShell 5.1 and PowerShell 7 must prove rollback waits, deletes the exact tree, and removes its parent. Protected fresh-install assertions now report the exact injected phase and captured installer output on residue.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `.github/workflows/release.yaml` | Canonicalize and authenticate the signed checksum certificate before sealing. |
| `scripts/release_candidate.py` | Add strict certificate custody/canonicalization and raw-only seal/verify gates. |
| `scripts/install.ps1` | Add read-only snapshot handles, bounded exact DELETE acquisition, and a deterministic scanner-custody native test. |
| `scripts/test-fresh-install-release-windows.ps1` | Attribute any residual payload to the exact injected rollback phase. |
| `cli/tests/test_release_candidate.py` | Cover canonicalization, atomic publication, ambiguity refusal, and raw-only sealing. |
| `cli/tests/test_release_workflow_staged.py` | Lock sign -> canonicalize -> exact verification -> seal ordering. |
| `cli/tests/test_windows_powershell_upgrade_paths.py` | Lock the one-deadline, no-resnapshot, exact-acquisition, and dual-engine test invariants. |

## Breaking Changes

None. Successful install/upgrade behavior, release provenance, and unsigned macOS behavior are unchanged. Windows rollback may now wait within its existing 10-second tree budget for transient scanner custody instead of immediately preserving installer-owned residue.

## Open Issues / Follow-ups

None.

## Test Plan

Observed locally:

```bash
git diff --check
# passed

uv run ruff check \
  scripts/release_candidate.py \
  cli/tests/test_release_candidate.py \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_windows_powershell_upgrade_paths.py
# passed

uv run python -m pytest -q \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_release_candidate.py \
  cli/tests/test_upgrade_release_smoke_contract.py \
  cli/tests/test_upgrade_smoke_static.py \
  cli/tests/test_windows_powershell_upgrade_paths.py
# 184 passed, 5 skipped
```

Additional validation:

- Release workflow YAML parsed successfully.
- Embedded Windows C# parsed with `tree_sitter_c_sharp` with no syntax errors.
- Two targeted Claude Opus 4.8 reviews (certificate custody and Windows rollback) reported no findings.

Required CI evidence before merge:

- `Windows Installer Smoke (install.ps1)` passes the PowerShell 5.1 and 7 exact DELETE-acquisition self-test.
- All ordinary actionable PR checks pass.
- After merge, rerun Release 0.8.4 and require all four Windows published-baseline upgrades plus protected Windows fresh install to pass before Publish.
