### PR TITLE
fix(release): restore Windows source stability gates

### DIFF
--- a/cli/tests/test_release_candidate.py
+++ b/cli/tests/test_release_candidate.py
@@ -529,6 +529,67 @@ def test_certificate_canonicalization_accepts_canonical_raw_pem(tmp_path: Path) 
     assert certificate.read_bytes() == TEST_CERTIFICATE_PEM
 
 
+def test_windows_named_and_opened_certificate_timestamp_views_do_not_false_positive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    certificate = tmp_path / "checksums.txt.pem"
+    certificate.write_bytes(TEST_CERTIFICATE_WRAPPER)
+    real_lstat = Path.lstat
+
+    def timestamp_skewed_lstat(candidate: Path):
+        info = real_lstat(candidate)
+        if candidate != certificate:
+            return info
+
+        class _TimestampSkewedStat:
+            st_ctime_ns = info.st_ctime_ns + 1
+
+            def __getattr__(self, name: str):
+                return getattr(info, name)
+
+        return _TimestampSkewedStat()
+
+    monkeypatch.setattr(Path, "lstat", timestamp_skewed_lstat)
+
+    release_candidate.canonicalize_release_certificate(certificate)
+
+    assert certificate.read_bytes() == TEST_CERTIFICATE_PEM
+
+
+def test_release_certificate_same_api_timestamp_change_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    certificate = tmp_path / "checksums.txt.pem"
+    certificate.write_bytes(TEST_CERTIFICATE_WRAPPER)
+    real_lstat = Path.lstat
+    certificate_lstat_calls = 0
+
+    def timestamp_mutating_lstat(candidate: Path):
+        nonlocal certificate_lstat_calls
+        info = real_lstat(candidate)
+        if candidate != certificate:
+            return info
+        certificate_lstat_calls += 1
+        changed = certificate_lstat_calls > 1
+
+        class _TimestampMutatedStat:
+            st_ctime_ns = info.st_ctime_ns + int(changed)
+
+            def __getattr__(self, name: str):
+                return getattr(info, name)
+
+        return _TimestampMutatedStat()
+
+    monkeypatch.setattr(Path, "lstat", timestamp_mutating_lstat)
+
+    with pytest.raises(release_candidate.CandidateError, match="changed while being read"):
+        release_candidate.canonicalize_release_certificate(certificate)
+
+    assert certificate.read_bytes() == TEST_CERTIFICATE_WRAPPER
+
+
 @pytest.mark.parametrize(
     "payload",
     [

--- a/cli/tests/test_windows_powershell_upgrade_paths.py
+++ b/cli/tests/test_windows_powershell_upgrade_paths.py
@@ -46,6 +46,154 @@ def _powershell_python_here_string(source: str, variable: str) -> str:
     return source[start : source.index("\n'@", start)]
 
 
+def _powershell_checksum_parser(source: str) -> str:
+    version_helpers = source[
+        source.index("function Assert-Version {") : source.index("function Test-Integer {")
+    ]
+    checksum_parser = source[
+        source.index("function Read-Checksums {") : source.index("function Assert-Hash {")
+    ]
+    return (
+        "Set-StrictMode -Version Latest\n"
+        "$ErrorActionPreference='Stop'\n"
+        "$script:VersionPattern='^\\d+\\.\\d+\\.\\d+$'\n"
+        "function Fail { param([string]$Message) throw $Message }\n"
+        + version_helpers
+        + checksum_parser
+    )
+
+
+@pytest.mark.skipif(
+    not (shutil.which("pwsh") or shutil.which("powershell.exe") or shutil.which("powershell")),
+    reason="PowerShell is unavailable on this host",
+)
+def test_windows_checksum_parser_accepts_only_signed_legacy_goreleaser_rows(
+    tmp_path: Path,
+) -> None:
+    executable = shutil.which("pwsh") or shutil.which("powershell.exe") or shutil.which("powershell")
+    assert executable is not None
+    source = RESOLVER.read_text(encoding="utf-8")
+    parser = _powershell_checksum_parser(source)
+    checksums = tmp_path / "checksums.txt"
+    digest = "a" * 64
+    artifact = "defenseclaw-0.8.3-py3-none-any.whl"
+    checksums.write_text(
+        "\n".join(
+            (
+                f"{digest}  defenseclaw_darwin_amd64_v1/defenseclaw",
+                f"{digest}  defenseclaw_darwin_arm64_v8.0/defenseclaw",
+                f"{digest}  defenseclaw_linux_amd64_v1/defenseclaw",
+                f"{digest}  defenseclaw_linux_arm64_v8.0/defenseclaw",
+                f"{digest}  defenseclaw_windows_amd64_v1/defenseclaw.exe",
+                f"{digest}  defenseclaw_windows_arm64_v8.0/defenseclaw.exe",
+                f"{digest}  {artifact}",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    command = (
+        parser
+        + "\n$parsed=Read-Checksums -Path $env:CHECKSUMS -ReleaseVersion '0.8.3'\n"
+        + f"if($parsed.Count -ne 1 -or -not $parsed.ContainsKey('{artifact}')){{exit 9}}\n"
+    )
+
+    completed = subprocess.run(
+        [executable, "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        env={
+            **os.environ,
+            "POWERSHELL_TELEMETRY_OPTOUT": "1",
+            "CHECKSUMS": str(checksums),
+        },
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+@pytest.mark.skipif(
+    not (shutil.which("pwsh") or shutil.which("powershell.exe") or shutil.which("powershell")),
+    reason="PowerShell is unavailable on this host",
+)
+def test_windows_checksum_parser_accepts_modern_flat_manifest(tmp_path: Path) -> None:
+    executable = shutil.which("pwsh") or shutil.which("powershell.exe") or shutil.which("powershell")
+    assert executable is not None
+    source = RESOLVER.read_text(encoding="utf-8")
+    parser = _powershell_checksum_parser(source)
+    checksums = tmp_path / "checksums.txt"
+    artifact = "defenseclaw-0.8.4-py3-none-any.whl"
+    checksums.write_text(f"{'a' * 64}  {artifact}\n", encoding="utf-8")
+    command = (
+        parser
+        + "\n$parsed=Read-Checksums -Path $env:CHECKSUMS -ReleaseVersion '0.8.4'\n"
+        + f"if($parsed.Count -ne 1 -or -not $parsed.ContainsKey('{artifact}')){{exit 9}}\n"
+    )
+
+    completed = subprocess.run(
+        [executable, "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        env={
+            **os.environ,
+            "POWERSHELL_TELEMETRY_OPTOUT": "1",
+            "CHECKSUMS": str(checksums),
+        },
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+@pytest.mark.skipif(
+    not (shutil.which("pwsh") or shutil.which("powershell.exe") or shutil.which("powershell")),
+    reason="PowerShell is unavailable on this host",
+)
+@pytest.mark.parametrize(
+    ("release_version", "nested_name"),
+    [
+        ("0.8.4", "defenseclaw_windows_amd64_v1/defenseclaw.exe"),
+        ("0.8.3", "unknown/path"),
+        ("0.8.3", "../checksums.txt"),
+        ("0.8.3", r"unknown\path"),
+    ],
+)
+def test_windows_checksum_parser_rejects_modern_or_unknown_nested_rows(
+    tmp_path: Path,
+    release_version: str,
+    nested_name: str,
+) -> None:
+    executable = shutil.which("pwsh") or shutil.which("powershell.exe") or shutil.which("powershell")
+    assert executable is not None
+    source = RESOLVER.read_text(encoding="utf-8")
+    parser = _powershell_checksum_parser(source)
+    checksums = tmp_path / "checksums.txt"
+    checksums.write_text(f"{'a' * 64}  {nested_name}\n", encoding="utf-8")
+    command = (
+        parser
+        + f"\nRead-Checksums -Path $env:CHECKSUMS -ReleaseVersion '{release_version}'\n"
+    )
+
+    completed = subprocess.run(
+        [executable, "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        env={
+            **os.environ,
+            "POWERSHELL_TELEMETRY_OPTOUT": "1",
+            "CHECKSUMS": str(checksums),
+        },
+    )
+
+    assert completed.returncode != 0
+    assert "Invalid checksum artifact name." in completed.stderr
+
+
 def test_windows_installer_refuses_existing_install_before_any_dependency_or_artifact_work() -> None:
     source = INSTALLER.read_text(encoding="utf-8")
     main = _main_body(source)

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -101,15 +101,18 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _file_identity(info: os.stat_result) -> tuple[int, int, int, int, int, int]:
+def _file_identity(info: os.stat_result) -> tuple[int, int, int, int, int]:
     return (
         info.st_dev,
         info.st_ino,
         stat.S_IFMT(info.st_mode),
         info.st_size,
         info.st_mtime_ns,
-        info.st_ctime_ns,
     )
+
+
+def _file_state(info: os.stat_result) -> tuple[int, int, int, int, int, int]:
+    return (*_file_identity(info), info.st_ctime_ns)
 
 
 def _directory_identity(info: os.stat_result) -> tuple[int, int, int]:
@@ -125,6 +128,12 @@ def _read_release_certificate(path: Path) -> tuple[bytes, os.stat_result, os.sta
         raise CandidateError(f"release certificate parent is unavailable: {path.parent}") from exc
     if not stat.S_ISDIR(parent_info.st_mode):
         raise CandidateError(f"release certificate parent must be a real directory: {path.parent}")
+    try:
+        named_before = path.lstat()
+    except OSError as exc:
+        raise CandidateError(f"release certificate is unavailable: {path}") from exc
+    if not stat.S_ISREG(named_before.st_mode):
+        raise CandidateError(f"release certificate must be a regular file: {path}")
 
     flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0)
     flags |= getattr(os, "O_NOFOLLOW", 0)
@@ -157,12 +166,18 @@ def _read_release_certificate(path: Path) -> tuple[bytes, os.stat_result, os.sta
         except OSError as exc:
             raise CandidateError(f"release certificate disappeared while being read: {path}") from exc
         if (
-            _file_identity(opened) != _file_identity(opened_after)
-            or _file_identity(opened_after) != _file_identity(named_after)
+            # CPython on Windows exposes creation time as pathname st_ctime,
+            # but NTFS change time as descriptor st_ctime. Bind the pathname
+            # to the descriptor without comparing those incompatible fields,
+            # then retain ctime in each same-API mutation check.
+            _file_identity(named_before) != _file_identity(opened)
+            or _file_identity(named_after) != _file_identity(opened_after)
+            or _file_state(named_before) != _file_state(named_after)
+            or _file_state(opened) != _file_state(opened_after)
             or bytes_read != opened_after.st_size
         ):
             raise CandidateError(f"release certificate changed while being read: {path}")
-        return b"".join(chunks), opened_after, parent_info
+        return b"".join(chunks), named_after, parent_info
     finally:
         os.close(descriptor)
 
@@ -229,7 +244,7 @@ def _atomic_replace_release_certificate(
         current_file = path.lstat()
         current_parent = path.parent.lstat()
         if (
-            _file_identity(current_file) != _file_identity(expected_file)
+            _file_state(current_file) != _file_state(expected_file)
             or _directory_identity(current_parent) != _directory_identity(expected_parent)
         ):
             raise CandidateError("release certificate path changed before atomic publication")

--- a/scripts/upgrade.ps1
+++ b/scripts/upgrade.ps1
@@ -404,7 +404,9 @@ function Download {
     try { Invoke-WebRequest -Uri $url -OutFile $Destination -UseBasicParsing | Out-Null } catch { Fail "Failed to download $url" }
 }
 function Read-Checksums {
-    param([string]$Path)
+    param([string]$Path,[string]$ReleaseVersion)
+    Assert-Version $ReleaseVersion "checksum release version"
+    $allowLegacyGoReleaserRows = (Compare-Version $ReleaseVersion "0.8.4") -lt 0
     $result = @{}
     foreach ($raw in Get-Content -LiteralPath $Path -Encoding UTF8) {
         $line = $raw.Trim()
@@ -413,7 +415,16 @@ function Read-Checksums {
         $digest = $Matches[1].ToLowerInvariant(); $name = $Matches[2].Trim()
         if ($name.StartsWith("*")) { $name = $name.Substring(1) }
         if ($name.StartsWith("./")) { $name = $name.Substring(2) }
-        if (-not $name -or $name -in @(".", "..") -or [IO.Path]::GetFileName($name) -ne $name -or $result.ContainsKey($name)) { Fail "Invalid checksum artifact name." }
+        $legacyGoReleaserRow = $name -cmatch '^(?:defenseclaw_(?:darwin|linux)_(?:amd64_v1|arm64_v8\.0)/defenseclaw|defenseclaw_windows_(?:amd64_v1|arm64_v8\.0)/defenseclaw\.exe)$'
+        if ($allowLegacyGoReleaserRows -and $legacyGoReleaserRow) { continue }
+        if (
+            -not $name -or
+            $name -in @(".", "..") -or
+            $name.Contains("/") -or
+            $name.Contains('\') -or
+            [IO.Path]::GetFileName($name) -ne $name -or
+            $result.ContainsKey($name)
+        ) { Fail "Invalid checksum artifact name." }
         $result[$name] = $digest
     }
     if ($result.Count -eq 0) { Fail "checksums.txt has no valid entries." }
@@ -742,7 +753,7 @@ function Stage-Release {
     foreach ($name in @("checksums.txt","checksums.txt.sig","checksums.txt.pem")) { Download $ReleaseVersion $name (Join-Path $directory $name) }
     $certificate=Normalize-ReleaseCertificate $ReleaseVersion (Join-Path $directory "checksums.txt.pem") $directory
     Verify-Signature $ReleaseVersion (Join-Path $directory "checksums.txt") (Join-Path $directory "checksums.txt.sig") $certificate
-    $checksums = Read-Checksums (Join-Path $directory "checksums.txt")
+    $checksums = Read-Checksums (Join-Path $directory "checksums.txt") $ReleaseVersion
     $checksumsSha256=(Get-FileHash -LiteralPath (Join-Path $directory "checksums.txt") -Algorithm SHA256).Hash.ToLowerInvariant()
     $provenance=$null
     if((Compare-Version $ReleaseVersion "0.8.5") -ge 0){


### PR DESCRIPTION
Focused release fix against `main`. This deliberately does not modify PR #490 or its v8 upgrade matrix.

## Problem

Release run [29260474396](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29260474396) passed its Linux and macOS gates but failed five Windows gates:

- sealed candidate verification falsely reported that `checksums.txt.pem` changed while being read;
- upgrades from published 0.8.0–0.8.3 rejected the signed historical checksum manifests while staging rollback sources.

## Current Situation

The Windows certificate reader compared `st_ctime_ns` across pathname `lstat()` and descriptor `fstat()`. CPython exposes different NTFS timestamp views through those APIs, so an unchanged file can compare unequal.

Published 0.8.0–0.8.3 checksum manifests also contain six signed nested GoReleaser bookkeeping rows. The Windows resolver required every row to be a flat release asset name, even though those historical nested rows are immutable and are not downloaded.

```mermaid
flowchart LR
    A["Sealed 0.8.4 candidate"] --> B["Windows certificate verification"]
    C["Signed 0.8.0-0.8.3 checksums"] --> D["Rollback-source staging"]
    B --> E["Fresh install gate"]
    D --> F["Historical upgrade gates"]
```

## Solution

### Preserve certificate TOCTOU checks across Windows timestamp APIs

- Bind pathname and descriptor views using device, inode, file type, size, and mtime.
- Retain ctime in same-API before/after mutation checks.
- Carry the final pathname snapshot into atomic publication so the pre-replace comparison also uses one API view.

### Parse immutable legacy checksums narrowly

- Make Windows checksum parsing release-aware.
- For releases older than 0.8.4, ignore only the exact six known GoReleaser internal binary rows after signature verification.
- Continue rejecting nested names for 0.8.4+ and reject traversal, backslash, unknown nested, and duplicate artifact names.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `scripts/release_candidate.py` | Split cross-API identity from same-API state comparisons and preserve atomic certificate custody. |
| `scripts/upgrade.ps1` | Pass the authenticated release version into checksum parsing and narrowly recognize legacy GoReleaser bookkeeping rows. |
| `cli/tests/test_release_candidate.py` | Cover Windows timestamp-view skew and prove genuine same-API mutation is still rejected. |
| `cli/tests/test_windows_powershell_upgrade_paths.py` | Cover exact legacy acceptance, modern flat acceptance, and fail-closed nested/traversal cases under StrictMode. |

## Breaking Changes

None. Modern release manifests remain flat-name-only. This restores compatibility only for immutable, signed pre-0.8.4 checksum manifests.

## Open Issues / Follow-ups

None.

## Test Plan

Observed locally:

```text
uv run python -m pytest -q \
  cli/tests/test_historical_release_auth.py \
  cli/tests/test_release_candidate.py \
  cli/tests/test_windows_powershell_upgrade_paths.py
# 128 passed, 11 skipped in 8.09s

uv run ruff check \
  scripts/release_candidate.py \
  cli/tests/test_release_candidate.py \
  cli/tests/test_windows_powershell_upgrade_paths.py
# All checks passed!

git diff --check
# clean
```

The 11 local skips are PowerShell execution tests on macOS without PowerShell installed; the PR Windows runner executes them.
