### PR TITLE
fix(release): omit Windows binaries until gates recover

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -754,6 +754,7 @@ jobs:
   windows-fresh-install:
     name: Fresh install sealed candidate (Windows)
     needs: [release-preflight, assemble-release-candidate]
+    if: ${{ false }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -963,6 +964,7 @@ jobs:
   windows-upgrade:
     name: Windows upgrade policy ${{ matrix.baseline }} → ${{ needs.release-preflight.outputs.tag }}
     needs: [release-preflight, assemble-release-candidate]
+    if: ${{ false }}
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -1114,6 +1116,19 @@ jobs:
       - historical-baseline-canary
       - windows-upgrade
       - live-continuity
+    if: >-
+      ${{
+        always() &&
+        needs.release-preflight.result == 'success' &&
+        needs.assemble-release-candidate.result == 'success' &&
+        needs.posix-fresh-install.result == 'success' &&
+        needs.linux-upgrade.result == 'success' &&
+        needs.macos-upgrade.result == 'success' &&
+        needs.historical-baseline-canary.result == 'success' &&
+        needs.live-continuity.result == 'success' &&
+        needs.windows-fresh-install.result == 'skipped' &&
+        needs.windows-upgrade.result == 'skipped'
+      }}
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -1163,18 +1178,20 @@ jobs:
           fi
 
       # With Immutable Releases enabled, current gh creates a draft, uploads
-      # every supplied asset, and only then publishes. This is the only step
+      # every selected sealed asset, and only then publishes. This is the only step
       # in the workflow that can create the remote release or tag.
-      - name: Publish tag and all sealed assets
+      - name: Publish tag and selected sealed assets
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.release-preflight.outputs.tag }}
           RELEASE_COMMIT: ${{ needs.release-preflight.outputs.commit }}
         run: |
           set -euo pipefail
+          echo "::warning title=POSIX-only release::Windows-specific binaries and SBOMs will not be published."
           mapfile -t names < <(
             python3 scripts/release_candidate.py list-assets \
-              --root release-candidate --version "$RELEASE_TAG" --commit "$RELEASE_COMMIT"
+              --root release-candidate --version "$RELEASE_TAG" --commit "$RELEASE_COMMIT" \
+              --omit-windows-binaries
           )
           assets=()
           for name in "${names[@]}"; do
@@ -1211,7 +1228,8 @@ jobs:
               --root release-candidate \
               --release-json published-release.json \
               --version "$RELEASE_TAG" \
-              --commit "$RELEASE_COMMIT"; then
+              --commit "$RELEASE_COMMIT" \
+              --omit-windows-binaries; then
               verified=1
               break
             fi

--- a/cli/tests/test_release_candidate.py
+++ b/cli/tests/test_release_candidate.py
@@ -493,6 +493,63 @@ def test_candidate_seals_and_verifies_exact_publish_set(tmp_path: Path) -> None:
     release_candidate.verify_published_release(root, release_json, VERSION, COMMIT)
 
 
+def test_publication_can_omit_every_windows_specific_asset(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = _sealed_candidate(tmp_path)
+    manifest = json.loads((root / "release-candidate.json").read_text(encoding="utf-8"))
+    omitted = set(release_candidate.windows_release_binary_names(VERSION))
+    assert len(omitted) == 6
+    published_assets = [
+        {
+            "name": item["name"],
+            "digest": f"sha256:{item['sha256']}",
+        }
+        for item in manifest["assets"]
+        if item["name"] not in omitted
+    ]
+    release_json = tmp_path / "published-without-windows.json"
+    release_json.write_text(
+        json.dumps(
+            {
+                "tagName": VERSION,
+                "isDraft": False,
+                "isImmutable": True,
+                "assets": published_assets,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    release_candidate.verify_published_release(
+        root,
+        release_json,
+        VERSION,
+        COMMIT,
+        omit_windows_binaries=True,
+    )
+    with pytest.raises(release_candidate.CandidateError, match="differ from the sealed candidate"):
+        release_candidate.verify_published_release(root, release_json, VERSION, COMMIT)
+
+    status = release_candidate.main(
+        [
+            "list-assets",
+            "--root",
+            str(root),
+            "--version",
+            VERSION,
+            "--commit",
+            COMMIT,
+            "--omit-windows-binaries",
+        ]
+    )
+    listed = set(capsys.readouterr().out.splitlines())
+    assert status == 0
+    assert listed == {item["name"] for item in published_assets}
+    assert listed.isdisjoint(omitted)
+
+
 def test_certificate_command_canonicalizes_strict_cosign_wrapper_atomically(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -165,6 +165,32 @@ def test_publish_job_is_downstream_of_every_native_upgrade_gate() -> None:
             assert job.get("permissions") != {"contents": "write"}
 
 
+def test_windows_release_binaries_are_disabled_and_omitted() -> None:
+    jobs = _workflow()["jobs"]
+    for name in ("windows-fresh-install", "windows-upgrade"):
+        assert jobs[name]["if"] == "${{ false }}"
+
+    publish_condition = jobs["publish-release"]["if"]
+    assert "always()" in publish_condition
+    for required in (
+        "release-preflight",
+        "assemble-release-candidate",
+        "posix-fresh-install",
+        "linux-upgrade",
+        "macos-upgrade",
+        "historical-baseline-canary",
+        "live-continuity",
+    ):
+        assert f"needs.{required}.result == 'success'" in publish_condition
+    assert "needs.windows-fresh-install.result == 'skipped'" in publish_condition
+    assert "needs.windows-upgrade.result == 'skipped'" in publish_condition
+
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    assert workflow_text.count("--omit-windows-binaries") == 2
+    assert "publish_windows_binaries" not in workflow_text
+    assert "Windows-specific binaries and SBOMs will not be published" in workflow_text
+
+
 def test_build_once_candidate_is_reused_by_tests_and_publisher() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
     assert text.count("goreleaser/goreleaser-action@") == 1
@@ -379,7 +405,7 @@ def test_only_final_step_can_create_remote_release_or_tag() -> None:
     assert "gh release upload" not in text
     assert "git push" not in text
     assert "push:\n" not in text
-    assert "Publish tag and all sealed assets" in text
+    assert "Publish tag and selected sealed assets" in text
     assert "verify-published" in text
 
 

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -437,6 +437,24 @@ def published_asset_names(
     )
 
 
+def windows_release_binary_names(version: str) -> tuple[str, ...]:
+    """Return Windows runtime binaries and SBOMs, excluding the refusal resolver."""
+
+    _validate_version(version)
+    canonical = tuple(
+        f"defenseclaw_{version}_windows_{arch}.zip" for arch in ("amd64", "arm64")
+    )
+    if tuple(map(int, version.split("."))) < (0, 8, 4):
+        archives = canonical
+        sboms = tuple(f"{name}.sbom.json" for name in archives)
+    else:
+        protected = _expected_release_artifacts(version)["gateways"]["windows"]
+        archives = tuple(protected[arch] for arch in ("amd64", "arm64"))
+        sboms = tuple(f"{name}.sbom.json" for name in archives)
+        archives = (*archives, *canonical)
+    return tuple(sorted((*archives, *sboms)))
+
+
 def _require_regular_files(directory: Path, names: tuple[str, ...], label: str) -> None:
     if not directory.is_dir():
         raise CandidateError(f"{label} directory not found: {directory}")
@@ -3030,7 +3048,14 @@ def verify(root: Path, version: str, commit: str) -> None:
         _validate_wheel(dist / f"defenseclaw-{version}-py3-none-any.whl", version)
 
 
-def verify_published_release(root: Path, release_json: Path, version: str, commit: str) -> None:
+def verify_published_release(
+    root: Path,
+    release_json: Path,
+    version: str,
+    commit: str,
+    *,
+    omit_windows_binaries: bool = False,
+) -> None:
     """Confirm GitHub exposes the exact sealed bytes after publication."""
 
     verify(root, version, commit)
@@ -3056,6 +3081,9 @@ def verify_published_release(root: Path, release_json: Path, version: str, commi
 
     dist = root / "dist"
     names = _strict_file_names(dist, "release candidate")
+    if omit_windows_binaries:
+        omitted = set(windows_release_binary_names(version))
+        names = tuple(name for name in names if name not in omitted)
     expected = {name: _sha256(dist / name) for name in names}
     if published != expected:
         raise CandidateError("published GitHub asset names or digests differ from the sealed candidate")
@@ -3118,12 +3146,14 @@ def _parser() -> argparse.ArgumentParser:
     list_parser.add_argument("--root", type=Path, required=True)
     list_parser.add_argument("--version", required=True)
     list_parser.add_argument("--commit", required=True)
+    list_parser.add_argument("--omit-windows-binaries", action="store_true")
 
     published_parser = subparsers.add_parser("verify-published")
     published_parser.add_argument("--root", type=Path, required=True)
     published_parser.add_argument("--release-json", type=Path, required=True)
     published_parser.add_argument("--version", required=True)
     published_parser.add_argument("--commit", required=True)
+    published_parser.add_argument("--omit-windows-binaries", action="store_true")
     return parser
 
 
@@ -3175,10 +3205,20 @@ def main(argv: list[str] | None = None) -> int:
             print(f"release candidate verified: {args.version} at {args.commit}")
         elif args.command == "list-assets":
             verify(args.root, args.version, args.commit)
-            for name in _strict_file_names(args.root / "dist", "release candidate"):
+            names = _strict_file_names(args.root / "dist", "release candidate")
+            if args.omit_windows_binaries:
+                omitted = set(windows_release_binary_names(args.version))
+                names = tuple(name for name in names if name not in omitted)
+            for name in names:
                 print(name)
         elif args.command == "verify-published":
-            verify_published_release(args.root, args.release_json, args.version, args.commit)
+            verify_published_release(
+                args.root,
+                args.release_json,
+                args.version,
+                args.commit,
+                omit_windows_binaries=args.omit_windows_binaries,
+            )
             print(f"published release verified: {args.version} at {args.commit}")
         else:  # pragma: no cover - argparse enforces the subcommand set
             raise AssertionError(args.command)


### PR DESCRIPTION
Focused release unblock against `main`. PR #490 remains untouched and held until the POSIX-only 0.8.4 release is published.

## Problem

Release run [29263406750](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29263406750) failed all five Windows gates again while Linux and macOS remained healthy. Waiting for the complete release matrix on every Windows iteration is too slow, and publishing the failing Windows gateway binaries would expose an unvalidated install/upgrade path.

## Current Situation

The failures are deterministic Windows behavior:

- fresh-install rollback encounters a packaged path longer than the legacy Win32 path limit;
- upgrades from 0.8.0–0.8.3 fail because Windows canonicalizes the applied SDDL differently from the resolver's raw string.

The exact Windows fixes can be validated on a Windows VM or targeted PR runner in minutes, independently of a release cut.

## Solution

### Make this release POSIX-only

- Hard-disable both Windows release jobs.
- Keep every Linux, macOS, historical dependency, continuity, source, and custody gate mandatory.
- Omit all six Windows-specific gateway/refusal/SBOM assets from the GitHub release.
- Keep the signed PowerShell resolver available; without the Windows gateway assets it fails during authenticated staging, before install or upgrade mutation.

### Preserve exact publication custody

```mermaid
flowchart LR
    A["Fully sealed internal candidate"] --> B["Linux and macOS release gates"]
    B --> C["Select sealed POSIX assets"]
    C --> D["Immutable GitHub release"]
    D --> E["Published-subset digest proof"]
    A -. "Windows binaries withheld" .-> X["Not published"]
```

The internal candidate remains fully sealed and verified. Publication selects a deterministic subset, and `verify-published` proves GitHub contains exactly that subset—no extra or missing asset.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `.github/workflows/release.yaml` | Skip Windows jobs, keep all non-Windows results mandatory, publish the POSIX subset, and verify its remote digests. |
| `scripts/release_candidate.py` | Define the exact Windows binary/SBOM set and add explicit list/verification flags that omit it. |
| `cli/tests/test_release_candidate.py` | Prove all six Windows assets are absent and that custody verification rejects the reduced release without the explicit policy. |
| `cli/tests/test_release_workflow_staged.py` | Prove Windows cannot run/publish and every non-Windows gate remains required. |

## Breaking Changes

0.8.4 will not contain Windows gateway binaries and cannot install or upgrade DefenseClaw on Windows. Because GitHub releases are immutable, Windows binaries cannot be added to 0.8.4 later. The current Windows 0.8.4 → 0.8.5 bridge path in PR #490 must remain disabled; restoring Windows requires a new reviewed bridge/hard-cut sequence.

## Open Issues / Follow-ups

None.

## Test Plan

Observed locally:

```text
uv run python -m pytest -q \
  cli/tests/test_release_candidate.py \
  cli/tests/test_release_workflow_staged.py
# 129 passed

uv run ruff check \
  scripts/release_candidate.py \
  cli/tests/test_release_candidate.py \
  cli/tests/test_release_workflow_staged.py
# All checks passed!

go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 \
  .github/workflows/release.yaml
# clean

git diff --check
# clean
```
