### PR TITLE
fix private upstream redirect handling

### DIFF
--- a/internal/gateway/private_upstream_audit_test.go
+++ b/internal/gateway/private_upstream_audit_test.go
@@ -123,3 +123,17 @@ func TestPrivateUpstreamObserverNeverAuditsHardDeniedPeer(t *testing.T) {
 		t.Fatalf("hard-denied peer was audited as allowlisted: %v", peers)
 	}
 }
+
+func TestProviderHTTPClientBlocksRedirects(t *testing.T) {
+	if providerHTTPClient.CheckRedirect == nil {
+		t.Fatal("providerHTTPClient must refuse redirects so validated upstreams cannot pivot after preflight")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "https://private-upstream.example/v1", nil)
+	err := providerHTTPClient.CheckRedirect(req, []*http.Request{
+		httptest.NewRequest(http.MethodGet, "https://public-provider.example/v1", nil),
+	})
+	if err != netguard.ErrRedirectBlocked {
+		t.Fatalf("CheckRedirect error = %v, want %v", err, netguard.ErrRedirectBlocked)
+	}
+}

--- a/internal/gateway/provider.go
+++ b/internal/gateway/provider.go
@@ -516,6 +516,7 @@ var providerHTTPClient = &http.Client{
 		MaxIdleConnsPerHost: 10,
 		IdleConnTimeout:     90 * time.Second,
 	},
+	CheckRedirect: netguard.BlockRedirects,
 }
 
 // privateUpstreamPeerObserver records the concrete remote peer selected by


### PR DESCRIPTION
## Problem
PR #472 adds an operator allowlist for private LLM upstream IPs, but the provider HTTP client still follows redirects after the original upstream preflight.

## Current Situation
`providerHTTPClient` validates each dial with `secureDialContext`, and allowlisted private IPs are intentionally permitted. Without a redirect policy, a public upstream can return a 307/308 redirect to an allowlisted private IP and move the request away from the originally selected upstream.

## Solution
Install `netguard.BlockRedirects` on `providerHTTPClient` so provider passthrough requests stay bound to the preflighted upstream and cannot pivot through HTTP redirects.

## Architecture Diagram
N/A - small transport policy hardening.

## What Changed
- Set `providerHTTPClient.CheckRedirect` to `netguard.BlockRedirects`.
- Added a focused regression test that fails if the provider client allows redirects again.

## Breaking Changes
None. Provider redirects are blocked for this guarded passthrough path.

## Open Issues / Follow-ups
None.

## Test Plan
```bash
go test ./internal/gateway -run 'TestProviderHTTPClientBlocksRedirects|TestPrivateUpstreamAuditUsesConnectedPeerNotPreflightDNS|TestPrivateUpstreamObserverNeverAuditsHardDeniedPeer'
```

Observed result: `ok github.com/defenseclaw/defenseclaw/internal/gateway 1.012s`.

## Linked Issue
Addresses the security review comment on #472: https://github.com/cisco-ai-defense/defenseclaw/pull/472#issuecomment-4966364223
