### PR TITLE
fix(windows): repair TUI tab navigation and alert filters

### DIFF
--- a/cli/defenseclaw/tui/app.py
+++ b/cli/defenseclaw/tui/app.py
@@ -1743,6 +1743,19 @@ class DefenseClawTUI(App[None]):
             event.prevent_default()
             return
 
+        # Textual treats Tab/Shift+Tab as focus traversal before ordinary
+        # bindings can reliably route them.  Handle the advertised panel
+        # navigation here, after command-palette and panel-local handlers have
+        # had first refusal (Setup forms, for example, use Tab between fields).
+        if event.key in {"tab", "shift+tab"}:
+            if event.key == "tab":
+                self.action_next_panel()
+            else:
+                self.action_previous_panel()
+            event.stop()
+            event.prevent_default()
+            return
+
         panel = PANEL_SHORTCUTS.get(event.key.lower())
         if panel is None:
             return
@@ -11895,6 +11908,11 @@ def _panel_key(event: events.Key) -> str:
     if event.key == "escape":
         return "escape"
     if event.key in {"up", "down"}:
+        return event.key
+    # Textual supplies Tab's control character (\t) in ``event.character``.
+    # Preserve the logical key before generic character handling so Setup
+    # forms and menus can consume Tab/Shift+Tab locally.
+    if event.key in {"tab", "shift+tab"}:
         return event.key
     # Normalize backspace/delete BEFORE the event.character branch. Textual
     # delivers the DEL control char (\x7f) as event.character, so without this

--- a/cli/defenseclaw/tui/panels/alerts.py
+++ b/cli/defenseclaw/tui/panels/alerts.py
@@ -395,6 +395,12 @@ class AlertsPanelModel:
     def set_severity_filter_exact(self, severity: SeverityFilter) -> None:
         self.severity_filter = severity
         self.show_all_severities = True
+        if self.store is not None and severity in {"", "MEDIUM", "LOW"}:
+            # The default alert load is intentionally limited to actionable
+            # severities. Toolbar buttons must hydrate the complete store just
+            # like their keyboard equivalents before showing All/Medium/Low.
+            self.refresh()
+            return
         self.apply_filter()
 
     def set_severity_filter(self, severity: SeverityFilter) -> None:

--- a/cli/tests/tui/test_alerts_panel.py
+++ b/cli/tests/tui/test_alerts_panel.py
@@ -95,6 +95,27 @@ def test_alerts_refresh_preserves_last_good_rows_when_database_is_locked() -> No
     assert [row.event.id for row in model.filtered] == ["cached"]
 
 
+def test_alerts_exact_low_signal_filter_refreshes_store() -> None:
+    class CountingStore:
+        calls = 0
+
+        def list_alerts(self, _limit: int) -> list[Event]:
+            self.calls += 1
+            return [
+                Event(id="high", severity="HIGH", action="block", target="skill://one"),
+                Event(id="low", severity="LOW", action="allow", target="gateway"),
+            ]
+
+    store = CountingStore()
+    model = AlertsPanelModel(store=store)
+    model.set_events([AlertEvent(id="high", severity="HIGH", action="block", target="skill://one")])
+
+    model.set_severity_filter_exact("LOW")
+
+    assert store.calls == 1
+    assert [row.event.id for row in model.filtered] == ["low"]
+
+
 def test_alerts_default_hides_low_signal_rows_until_all_opt_in() -> None:
     model = AlertsPanelModel()
     model.set_events(

--- a/cli/tests/tui/test_app_shell.py
+++ b/cli/tests/tui/test_app_shell.py
@@ -898,6 +898,44 @@ async def test_mouse_click_opens_command_drawer() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tab_and_shift_tab_switch_panels_from_chrome_focus() -> None:
+    app = DefenseClawTUI()
+
+    async with app.run_test(size=(140, 40)) as pilot:
+        app.query_one("#tabs", Tabs).focus()
+
+        await pilot.press("tab")
+        await pilot.pause()
+        assert app.active_panel == "alerts"
+
+        await pilot.press("shift+tab")
+        await pilot.pause()
+        assert app.active_panel == "overview"
+
+
+@pytest.mark.asyncio
+async def test_setup_form_consumes_tab_before_global_panel_navigation() -> None:
+    app = DefenseClawTUI()
+
+    async with app.run_test(size=(180, 50)) as pilot:
+        app._handle_overview_control("overview-setup-connector")  # noqa: SLF001
+        await pilot.pause()
+        assert app.active_panel == "setup"
+        assert app.setup_model.form_active is True
+        assert app.setup_model.form_cursor == 0
+
+        await pilot.press("tab")
+        await pilot.pause()
+        assert app.active_panel == "setup"
+        assert app.setup_model.form_cursor == 1
+
+        await pilot.press("shift+tab")
+        await pilot.pause()
+        assert app.active_panel == "setup"
+        assert app.setup_model.form_cursor == 0
+
+
+@pytest.mark.asyncio
 async def test_command_palette_suggestions_tab_complete_and_click_execute() -> None:
     app = DefenseClawTUI()
     seen: dict[str, tuple[str, tuple[str, ...]]] = {}


### PR DESCRIPTION
## What changed

- route `Tab` / `Shift+Tab` panel navigation before Textual focus traversal can consume it
- preserve Setup form/menu/config Tab handling by normalizing the logical key before `event.character`
- refresh the audit store when Alerts toolbar selects All, Medium, or Low so mouse and keyboard filters show the same rows
- add Textual and model regression coverage for global and Setup-local Tab behavior plus low-severity hydration

## Why

Native Windows live TUI testing of the exact PR 534 installer reproduced two parity defects: advertised Tab navigation moved focus instead of panels, and the Alerts toolbar reused the actionable-only cache while keyboard filters refreshed the full audit store.

## Validation

- affected TUI suites: 212 passed, 1 skipped
- focused key/filter regressions: 4 passed
- Ruff and `git diff --check`: passed
- exact commit `361334776fc89508a004daaf23a91812f52082db` built into and installed from the unsigned local x64 Setup artifact (`SHA-256 557469F34718FF01C25B6489D53FF541F7C7C5BB77FECCCF9D797C02FD575EC1`)
- packaged installed-runtime TUI: global Tab/Shift+Tab switched panels, Setup focus moved `0 -> 1 -> 0`, and Alerts All hydrated 156 rows containing both Codex and Claude activity
- installed CLI command tree: 212/212 help paths passed; seven representative live JSON reads passed without user/config file drift
- real Codex CLI 0.144.3 and Claude Code 2.1.207: benign commands executed; destructive `Remove-Item -Recurse -Force` commands were blocked before execution with `enforced=true` and targets preserved
- Codex live run used persisted hook trust and did not use `--dangerously-bypass-hook-trust`
- installed Doctor: 41 passed, 0 failed, 11 skipped
- PR checks: 39 passed, 2 expected credentialed live-matrix skips; CodeRabbit approved with no actionable comments

This PR is intentionally stacked on PR 534.