### PR TITLE
fix(agent-control): keep gateway token on loopback

### DIFF
--- a/cli/defenseclaw/agent_control/publisher.py
+++ b/cli/defenseclaw/agent_control/publisher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import os
 import shutil
@@ -306,11 +307,25 @@ class NativeValidator:
                 raise PublicationError("native rule-pack validation failed; candidate was not published")
 
 
+def _is_loopback_host(host: str) -> bool:
+    candidate = (host or "").strip()
+    if candidate.startswith("[") and candidate.endswith("]"):
+        candidate = candidate[1:-1]
+    if not candidate or candidate == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(candidate).is_loopback
+    except ValueError:
+        return False
+
+
 class GatewayClient:
     def __init__(self, *, bind: str, port: int, token: str, timeout: float = 10.0) -> None:
         host = (bind or "127.0.0.1").strip()
         if host in {"0.0.0.0", "::", "[::]", "localhost"}:
             host = "127.0.0.1"
+        if token and not _is_loopback_host(host):
+            raise ActivationError("refusing to send gateway token to non-loopback api_bind")
         elif ":" in host and not host.startswith("["):
             host = f"[{host}]"
         self.base_url = f"http://{host}:{port}"

--- a/cli/tests/test_agent_control_sync.py
+++ b/cli/tests/test_agent_control_sync.py
@@ -362,6 +362,12 @@ class ConfigTests(unittest.TestCase):
         client = GatewayClient(bind="::1", port=43123, token="test-token")
         self.assertEqual(client.base_url, "http://[::1]:43123")
 
+    def test_gateway_client_refuses_token_for_non_loopback_bind(self) -> None:
+        for bind in ("attacker.invalid", "10.0.0.8", "192.168.65.2"):
+            with self.subTest(bind=bind):
+                with self.assertRaisesRegex(ActivationError, "non-loopback api_bind"):
+                    GatewayClient(bind=bind, port=43123, token="test-token")
+
     def test_gateway_client_rejects_malformed_artifact_status(self) -> None:
         client = GatewayClient(bind="127.0.0.1", port=43123, token="test-token")
         client._request = lambda *_args: {}  # type: ignore[method-assign]


### PR DESCRIPTION
## Summary
- fail Agent Control gateway activation before building authenticated requests to non-loopback `gateway.api_bind` hosts
- add regression coverage for tampered/non-loopback bind values so the sidecar token is not sent off-host

## Linked issue / review finding
- Addresses the July 15 automation review finding on PR #457: https://github.com/cisco-ai-defense/defenseclaw/pull/457#issuecomment-4989253728

## Test Plan
- `uv run pytest cli/tests/test_agent_control_sync.py -k 'gateway_client'`
  - Result: `3 passed, 65 deselected in 0.74s`
- `uv run pytest cli/tests/test_agent_control_sync.py`
  - Result: `68 passed in 0.38s`
- `git diff --check`
  - Result: passed with no output

## CI Status
- Pending immediately after PR creation; I will check GitHub Actions once the checks are registered.
