### PR TITLE
feat(packaging): wire hooks for every local user via the hook-guardian

### DIFF
--- a/cli/defenseclaw/gateway_error_codes.py
+++ b/cli/defenseclaw/gateway_error_codes.py
@@ -136,6 +136,10 @@ SUBSYSTEM_TELEMETRY: Final[str]       = "telemetry"
 SUBSYSTEM_CORRELATION: Final[str]     = "correlation"
 SUBSYSTEM_STREAM: Final[str]          = "stream"
 SUBSYSTEM_CISCO_INSPECT: Final[str]   = "cisco-inspect"
+# Managed Cisco AI Defense telemetry log-exporter path; paired with
+# ErrCodeExportFailed. Distinct from generic "telemetry" so operators
+# can alert specifically on managed-sink breakage.
+SUBSYSTEM_CISCO_AID_EXPORT: Final[str] = "cisco-aid-export"
 SUBSYSTEM_OPENSHELL: Final[str]       = "openshell"
 SUBSYSTEM_WEBHOOK: Final[str]         = "webhook"
 SUBSYSTEM_QUARANTINE: Final[str]      = "quarantine"
@@ -163,6 +167,7 @@ ALL_SUBSYSTEMS: Final[tuple[str, ...]] = (
     SUBSYSTEM_CORRELATION,
     SUBSYSTEM_STREAM,
     SUBSYSTEM_CISCO_INSPECT,
+    SUBSYSTEM_CISCO_AID_EXPORT,
     SUBSYSTEM_OPENSHELL,
     SUBSYSTEM_WEBHOOK,
     SUBSYSTEM_QUARANTINE,

--- a/cli/tests/test_enterprise_packaging.py
+++ b/cli/tests/test_enterprise_packaging.py
@@ -160,13 +160,28 @@ def test_launchd_hook_guardian_is_separate_privileged_job():
 
     assert payload["Label"] == "com.cisco.secureclient.defenseclaw.hook-guardian"
     assert "UserName" not in payload
-    assert payload["ProgramArguments"][1:4] == ["enterprise", "hooks", "reconcile"]
+    # Guardian runs the long-running `enterprise hooks watch` command, not
+    # the one-shot `reconcile` — fsnotify-driven auto-heal (~1 s) with a
+    # 60 s periodic backstop, restart-managed via KeepAlive rather than
+    # StartInterval. See internal/cli/enterprise_hooks.go runEnterpriseHooksWatch
+    # for the loop's design (settle window + Stat-based rename-tail detection).
+    assert payload["ProgramArguments"][1:4] == ["enterprise", "hooks", "watch"]
+    # --interval 60s is the periodic backstop for tamper vectors the fsnotify
+    # path intentionally cannot catch (SharedWriter Write/Chmod on native
+    # agent configs, shared-across-connector generic scripts). Any drift in
+    # this value should be a deliberate policy change, not an accidental edit.
+    assert "--interval" in payload["ProgramArguments"]
+    assert "60s" in payload["ProgramArguments"]
     assert payload["EnvironmentVariables"]["DEFENSECLAW_DEPLOYMENT_MODE"] == "managed_enterprise"
     assert (
         payload["EnvironmentVariables"]["DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR"]
         == "/opt/cisco/secureclient/defenseclaw/hook-guardian-state"
     )
-    assert payload["StartInterval"] == 300
+    # Long-running watch mode is kept alive by KeepAlive, NOT StartInterval.
+    # StartInterval would pointlessly relaunch the process every N seconds
+    # (and possibly spawn duplicates); KeepAlive relaunches only on exit.
+    assert "StartInterval" not in payload
+    assert payload.get("KeepAlive") is True
 
 
 def test_release_archives_ship_enterprise_packaging_assets():
@@ -316,7 +331,13 @@ def test_launchd_enterprise_installer_matches_cisco_plist_layout():
     home = gateway["EnvironmentVariables"]["DEFENSECLAW_HOME"]
     config = gateway["EnvironmentVariables"]["DEFENSECLAW_CONFIG"]
     auth_dir = gateway["EnvironmentVariables"]["DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR"]
-    manifest = guardian["ProgramArguments"][-1]
+    # The manifest path follows the --manifest flag; explicit lookup instead
+    # of positional indexing (ProgramArguments[-1] used to be the manifest
+    # under `hooks reconcile --manifest <path>`, but the current watch-mode
+    # args add `--interval 60s` after the manifest, making index -1 wrong).
+    guardian_args = guardian["ProgramArguments"]
+    manifest_flag = guardian_args.index("--manifest")
+    manifest = guardian_args[manifest_flag + 1]
 
     assert f"BINARY_ROOT={home}" in text
     assert f'CONFIG_DEST="{config}"' in text

--- a/docs/OBSERVABILITY-CONTRACT.md
+++ b/docs/OBSERVABILITY-CONTRACT.md
@@ -146,7 +146,7 @@ Complete enumeration (must match `AllErrorCodes()`):
 
 Complete enumeration (must match `AllSubsystems()`):
 
-`sidecar`, `watcher`, `gateway`, `scanner`, `policy`, `guardrail`, `auth`, `config`, `inspect`, `approvals`, `sink`, `telemetry`, `correlation`, `stream`, `cisco-inspect`, `openshell`, `webhook`, `quarantine`, `agent-registry`, `sqlite`, `admission`, `config_mutation`, `gatewaylog`
+`sidecar`, `watcher`, `gateway`, `scanner`, `policy`, `guardrail`, `auth`, `config`, `inspect`, `approvals`, `sink`, `telemetry`, `correlation`, `stream`, `cisco-inspect`, `cisco-aid-export`, `openshell`, `webhook`, `quarantine`, `agent-registry`, `sqlite`, `admission`, `config_mutation`, `gatewaylog`, `plugin`
 
 ---
 

--- a/internal/cli/enterprise_hooks.go
+++ b/internal/cli/enterprise_hooks.go
@@ -18,6 +18,8 @@ package cli
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -51,6 +53,7 @@ var (
 	enterpriseHookJSON          bool
 	enterpriseHookWatchInterval time.Duration
 	enterpriseHookWatchDebounce time.Duration
+	enterpriseHookWatchSettle   time.Duration
 )
 
 const defaultEnterpriseHookManifest = "/etc/defenseclaw/hook-guardian/targets.yaml"
@@ -150,6 +153,8 @@ func init() {
 		"Periodic reconcile backstop interval")
 	enterpriseHooksWatchCmd.Flags().DurationVar(&enterpriseHookWatchDebounce, "debounce", 750*time.Millisecond,
 		"Filesystem-event debounce before reconcile")
+	enterpriseHooksWatchCmd.Flags().DurationVar(&enterpriseHookWatchSettle, "settle", 2*time.Second,
+		"Post-reconcile quiet window: fsnotify events observed within this window after a reconcile completes are ignored (the guardian's own writes into watched dirs would otherwise loop-trigger reconcile forever)")
 
 	enterpriseHooksCmd.AddCommand(enterpriseHooksInstallCmd)
 	enterpriseHooksCmd.AddCommand(enterpriseHooksReconcileCmd)
@@ -233,11 +238,13 @@ type enterpriseHookReconcileRow struct {
 }
 
 type enterpriseHookReconcileRun struct {
-	Manifest  string
-	Rows      []enterpriseHookReconcileRow
-	Failures  int
-	StateErr  error
-	WatchDirs []string
+	Manifest              string
+	Rows                  []enterpriseHookReconcileRow
+	Failures              int
+	StateErr              error
+	WatchDirs             []string
+	WatchExclusiveFiles   []string // DC-only writers: react to any event
+	WatchSharedFiles      []string // agent + DC writers: react only to Remove/Rename
 }
 
 func runEnterpriseHooksReconcile(cmd *cobra.Command, _ []string) error {
@@ -317,6 +324,8 @@ func runEnterpriseHookReconcileOnce(ctx context.Context) (enterpriseHookReconcil
 	rows := make([]enterpriseHookReconcileRow, 0, len(manifest.Targets))
 	failures := 0
 	watchDirs := map[string]struct{}{}
+	exclusiveFiles := map[string]struct{}{}
+	sharedFiles := map[string]struct{}{}
 	for _, target := range manifest.Targets {
 		if !target.IsEnabled() {
 			continue
@@ -358,6 +367,14 @@ func runEnterpriseHookReconcileOnce(ctx context.Context) (enterpriseHookReconcil
 					watchDirs[dir] = struct{}{}
 				}
 			}
+			if own, filesErr := enterprisehooks.WatchOwnedFiles(opts); filesErr == nil {
+				for _, f := range own.ExclusiveWriter {
+					exclusiveFiles[f] = struct{}{}
+				}
+				for _, f := range own.SharedWriter {
+					sharedFiles[f] = struct{}{}
+				}
+			}
 			var result enterprisehooks.InstallResult
 			result, err = enterprisehooks.Install(ctx, opts)
 			if err == nil {
@@ -380,6 +397,8 @@ func runEnterpriseHookReconcileOnce(ctx context.Context) (enterpriseHookReconcil
 	run.Failures = failures
 	run.StateErr = stateErr
 	run.WatchDirs = sortedEnterpriseHookWatchDirs(watchDirs)
+	run.WatchExclusiveFiles = sortedEnterpriseHookWatchDirs(exclusiveFiles)
+	run.WatchSharedFiles = sortedEnterpriseHookWatchDirs(sharedFiles)
 	return run, nil
 }
 
@@ -397,25 +416,127 @@ func runEnterpriseHooksWatch(cmd *cobra.Command, _ []string) error {
 	defer fsw.Close()
 
 	watched := map[string]struct{}{}
-	reconcile := func(reason string) error {
+	// Owned-file allowlists, split by expected writer. fsnotify on
+	// macOS reports events at directory granularity — watching
+	// ~/.codex/ to see config.toml also sees every session log,
+	// sqlite WAL rotation, and history append the agent itself
+	// performs. We split further because the "owned" file itself may
+	// be written by the agent too (Codex rewrites its own config.toml
+	// constantly). See WatchOwnership doc for the reaction policy per
+	// class; both maps are rebuilt from the run's WatchExclusiveFiles
+	// / WatchSharedFiles after each reconcile.
+	exclusiveOwned := map[string]struct{}{} // DC-only writers — any event triggers
+	sharedOwned := map[string]struct{}{}    // agent + DC writers — only Remove/Rename triggers
+	// Post-reconcile guards against the self-trigger loop. Every
+	// reconcile writes into watched dirs (chmod on hook configs and
+	// hook scripts inside hardenInstallFootprint, plus writing
+	// hook_guardian_state.json / protected_targets.json). Those writes
+	// fire fsnotify events on the dirs we watch, which — with no guard
+	// — schedule another reconcile ~750 ms later, whose writes fire
+	// more events, forever.
+	//
+	// Two layered defences:
+	//
+	//   settleUntil    - short (default 2 s) window that suppresses
+	//                    every fsnotify event observed immediately
+	//                    after a reconcile completes; the vast
+	//                    majority of self-writes land here.
+	//
+	//   lastRowsHash   - SHA-256 of the reconcile row set. After each
+	//                    reconcile we compare against the previous
+	//                    hash; when unchanged we log a single
+	//                    reason=fsnotify_no_change line and skip
+	//                    re-arming the debounce timer even if events
+	//                    kept leaking past settleUntil (macOS
+	//                    FSEvents can batch chmod events with several
+	//                    seconds of latency, which is longer than any
+	//                    reasonable settle window). This breaks the
+	//                    tail-chasing loop even under adverse fs
+	//                    event timing.
+	settleUntil := time.Time{}
+	droppedInSettle := 0
+	var lastRowsHash string
+	// Track the fsnotify event that most recently armed the debounce.
+	// Included in the next reconcile log line so a `no_change=true`
+	// churn can be traced to the specific file+op that keeps firing.
+	// Cleared on every reconcile (fsnotify OR interval).
+	var lastTriggerPath string
+	var lastTriggerOp fsnotify.Op
+	reconcile := func(reason string) (bool, error) {
 		run, err := runEnterpriseHookReconcileOnce(cmd.Context())
 		if err != nil {
-			return err
+			return false, err
 		}
 		dirs := append([]string{filepath.Dir(filepath.Clean(enterpriseHookManifest))}, run.WatchDirs...)
 		syncEnterpriseHookWatchDirs(cmd, fsw, watched, dirs)
+		// Rebuild the owned-file allowlists from this run. The
+		// manifest itself is treated as exclusive-writer: only the
+		// installer / operator ever edits it, so any change is a real
+		// signal (new user added, connector disabled).
+		for k := range exclusiveOwned {
+			delete(exclusiveOwned, k)
+		}
+		for k := range sharedOwned {
+			delete(sharedOwned, k)
+		}
+		exclusiveOwned[filepath.Clean(enterpriseHookManifest)] = struct{}{}
+		for _, f := range run.WatchExclusiveFiles {
+			exclusiveOwned[filepath.Clean(f)] = struct{}{}
+		}
+		for _, f := range run.WatchSharedFiles {
+			sharedOwned[filepath.Clean(f)] = struct{}{}
+		}
 		status := "ok"
 		if run.Failures > 0 || run.StateErr != nil {
 			status = "attention"
 		}
-		fmt.Fprintf(cmd.ErrOrStderr(), "[hook-guardian] reconcile reason=%s status=%s targets=%d failures=%d watch_dirs=%d\n", reason, status, len(run.Rows), run.Failures, len(watched))
+		rowsHash := enterpriseHookReconcileRowsHash(run.Rows)
+		changed := rowsHash != lastRowsHash
+		lastRowsHash = rowsHash
+		triggerTag := ""
+		if reason == "fsnotify" && lastTriggerPath != "" {
+			// Attribute the reconcile to the specific fsnotify event
+			// that armed the debounce. When a `no_change=true` cycle
+			// keeps recurring, this reveals which path is generating
+			// the noise so it can be reclassified or filtered.
+			triggerTag = fmt.Sprintf(" trigger_path=%q trigger_op=%s", lastTriggerPath, lastTriggerOp)
+		}
+		if changed {
+			fmt.Fprintf(cmd.ErrOrStderr(), "[hook-guardian] reconcile reason=%s status=%s targets=%d failures=%d watch_dirs=%d%s\n", reason, status, len(run.Rows), run.Failures, len(watched), triggerTag)
+		} else {
+			// Log at DEBUG-ish cadence: one line per no-change
+			// reconcile is fine and load-bearing for triage (we still
+			// want to know the guardian is alive), but keep it
+			// distinguishable from a real repair.
+			fmt.Fprintf(cmd.ErrOrStderr(), "[hook-guardian] reconcile reason=%s status=%s targets=%d failures=%d watch_dirs=%d no_change=true%s\n", reason, status, len(run.Rows), run.Failures, len(watched), triggerTag)
+		}
+		lastTriggerPath = ""
+		lastTriggerOp = 0
 		if run.StateErr != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "[hook-guardian] state write failed: %s\n", run.StateErr)
 		}
-		return nil
+		// When the row set is byte-identical to the previous run,
+		// any Write/Chmod events still leaking past the normal
+		// settle window are tail-writes from our own reconcile
+		// (macOS FSEvents can batch chmod with 3-5 s latency).
+		// Widen the settle window modestly — enough to cover
+		// FSEvents batching, NOT enough to swallow a real subsequent
+		// tamper. Cap at 3x settle so the widened window stays in
+		// seconds, not minutes. Remove/Rename events are exempt from
+		// suppression by enterpriseHookWatchEventInSettleWindow, so
+		// widening the window here does not risk missing a "user
+		// deleted the hook config" event even if the previous
+		// reconcile classified as no_change.
+		settle := enterpriseHookWatchSettle
+		if !changed {
+			settle = enterpriseHookWatchSettle * 3
+		}
+		settleUntil = time.Now().Add(settle)
+		droppedInSettle = 0
+		return changed, nil
 	}
 
-	if err := reconcile("startup"); err != nil {
+	if _, err := reconcile("startup"); err != nil {
 		return err
 	}
 
@@ -438,6 +559,93 @@ func runEnterpriseHooksWatch(cmd *cobra.Command, _ []string) error {
 			if !enterpriseHookWatchEventRelevant(event) {
 				continue
 			}
+			// Only react to events on paths DefenseClaw itself owns.
+			// Two policies apply depending on who writes to the file:
+			//
+			//   * ExclusiveWriter (hook scripts, .token sidecars,
+			//     _hardening.sh, backup files, the manifest): only DC
+			//     writes here, so any event is meaningful.
+			//   * SharedWriter (the native agent config —
+			//     ~/.codex/config.toml, ~/.claude/settings.json,
+			//     ~/.cursor/hooks.json): the agent itself constantly
+			//     rewrites these during normal use. Only Remove /
+			//     Rename is a real tamper signal; Write and Chmod are
+			//     the agent doing its own thing and the 5-min backstop
+			//     handles any in-place stripping.
+			//
+			// Events on unowned paths (agent session state, sqlite
+			// WAL churn, cache writes, workspace snapshots) are
+			// silently dropped — no log, no debounce — because they
+			// happen continuously and previously dominated the log.
+			//
+			// Empty maps means we haven't run a reconcile yet (only
+			// possible pre-startup); fall through so the startup
+			// reconcile flow is unaffected.
+			if len(exclusiveOwned) > 0 || len(sharedOwned) > 0 {
+				cleaned := filepath.Clean(event.Name)
+				_, isExclusive := exclusiveOwned[cleaned]
+				_, isShared := sharedOwned[cleaned]
+				if !isExclusive && !isShared {
+					continue
+				}
+				if isShared && !isExclusive {
+					// Shared-writer file: skip Write and Chmod events
+					// entirely — the agent is updating its own
+					// unrelated state. Any Remove/Rename falls
+					// through to the settle/reconcile path below.
+					if event.Op&(fsnotify.Remove|fsnotify.Rename) == 0 {
+						continue
+					}
+				}
+			}
+			// Drop events observed inside the post-reconcile settle
+			// window: they are almost certainly the tail of writes the
+			// reconcile itself just made (chmod / state file rewrite,
+			// or a rename that macOS surfaces as REMOVE on the
+			// destination — see enterpriseHookWatchEventInSettleWindow
+			// for the design rationale).
+			//
+			// Exception: a Remove/Rename observation inside the window
+			// where the file is ACTUALLY missing on disk is a real
+			// user tamper that raced with our reconcile, not our own
+			// atomic-write tail. rename(2) atomically replaces the
+			// destination so the file is present immediately after —
+			// a Stat call ~microseconds after the fsnotify event
+			// distinguishes the two cases deterministically. Without
+			// this carve-out, back-to-back user tampers get eaten by
+			// the previous tamper's widened settle window.
+			if enterpriseHookWatchEventInSettleWindow(time.Now(), settleUntil, event.Op) {
+				if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+					if _, statErr := os.Lstat(event.Name); os.IsNotExist(statErr) {
+						// File genuinely gone — real user rm, fall
+						// through and reconcile.
+					} else {
+						droppedInSettle++
+						continue
+					}
+				} else {
+					droppedInSettle++
+					continue
+				}
+			}
+			// Log once when the first non-suppressed event lands after
+			// a settle window closed — helps operators tell "user
+			// tampered" from "guardian saw its own tail" during
+			// triage.
+			if droppedInSettle > 0 {
+				fmt.Fprintf(cmd.ErrOrStderr(), "[hook-guardian] settled: suppressed %d self-write event(s) within %s of last reconcile\n", droppedInSettle, enterpriseHookWatchSettle)
+				droppedInSettle = 0
+			}
+			// Record which specific event armed the debounce so the
+			// resulting reconcile log line names the culprit path.
+			// Preserve the FIRST event of a burst rather than
+			// overwriting; that's the one that actually caused the
+			// debounce arm, subsequent events during the 750ms window
+			// are already-scheduled noise.
+			if lastTriggerPath == "" {
+				lastTriggerPath = filepath.Clean(event.Name)
+				lastTriggerOp = event.Op
+			}
 			resetEnterpriseHookWatchTimer(debounce, enterpriseHookWatchDebounce)
 			debouncePending = true
 		case err, ok := <-fsw.Errors:
@@ -448,16 +656,81 @@ func runEnterpriseHooksWatch(cmd *cobra.Command, _ []string) error {
 		case <-debounce.C:
 			if debouncePending {
 				debouncePending = false
-				if err := reconcile("fsnotify"); err != nil {
+				if _, err := reconcile("fsnotify"); err != nil {
 					fmt.Fprintf(cmd.ErrOrStderr(), "[hook-guardian] reconcile after fsnotify failed: %s\n", err)
 				}
 			}
 		case <-ticker.C:
-			if err := reconcile("interval"); err != nil {
+			if _, err := reconcile("interval"); err != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "[hook-guardian] interval reconcile failed: %s\n", err)
 			}
 		}
 	}
+}
+
+// enterpriseHookWatchEventInSettleWindow reports whether an fsnotify
+// event observed at now should be suppressed because it lands inside
+// the post-reconcile settle window. A zero settleUntil (never
+// reconciled yet, or explicitly disabled) always returns false: never
+// suppress.
+//
+// All event ops (Write, Chmod, Remove, Rename) are suppressed inside
+// the window. The guardian's Install pass writes files via a
+// tempfile+rename dance (atomicWriteFile → os.Rename), and on macOS
+// rename(2) over an existing destination fires an fsnotify REMOVE
+// event on the destination path. So a REMOVE observed within the
+// settle window is our own atomic-write finishing, not a user
+// tamper. Real user Removes happen outside the settle window and
+// still trigger reconcile promptly (worst case: settle window
+// duration, default 2 s).
+func enterpriseHookWatchEventInSettleWindow(now, settleUntil time.Time, op fsnotify.Op) bool {
+	if settleUntil.IsZero() {
+		return false
+	}
+	return now.Before(settleUntil)
+}
+
+// enterpriseHookReconcileRowsHash is a content fingerprint over the
+// stable subset of a reconcile row set. It is used by the watch loop
+// to distinguish a "nothing actually changed" tick (guardian saw its
+// own tail) from a real repair (user tampered with a file). Only the
+// fields that describe the target's identity and outcome are hashed;
+// volatile Result payload internals are intentionally excluded so
+// benign per-run details (timestamps, transient path lookups) do not
+// flip the hash.
+func enterpriseHookReconcileRowsHash(rows []enterpriseHookReconcileRow) string {
+	if len(rows) == 0 {
+		return "0"
+	}
+	type hashRow struct {
+		User      string `json:"u"`
+		UserHome  string `json:"h"`
+		Connector string `json:"c"`
+		OK        bool   `json:"o"`
+		Error     string `json:"e,omitempty"`
+	}
+	stable := make([]hashRow, 0, len(rows))
+	for _, r := range rows {
+		stable = append(stable, hashRow{
+			User:      r.User,
+			UserHome:  r.UserHome,
+			Connector: r.Connector,
+			OK:        r.OK,
+			Error:     r.Error,
+		})
+	}
+	sort.Slice(stable, func(i, j int) bool {
+		if stable[i].Connector != stable[j].Connector {
+			return stable[i].Connector < stable[j].Connector
+		}
+		return stable[i].User < stable[j].User
+	})
+	data, err := json.Marshal(stable)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }
 
 func enterpriseHookWatchEventRelevant(event fsnotify.Event) bool {

--- a/internal/cli/enterprise_hooks.go
+++ b/internal/cli/enterprise_hooks.go
@@ -238,13 +238,13 @@ type enterpriseHookReconcileRow struct {
 }
 
 type enterpriseHookReconcileRun struct {
-	Manifest              string
-	Rows                  []enterpriseHookReconcileRow
-	Failures              int
-	StateErr              error
-	WatchDirs             []string
-	WatchExclusiveFiles   []string // DC-only writers: react to any event
-	WatchSharedFiles      []string // agent + DC writers: react only to Remove/Rename
+	Manifest            string
+	Rows                []enterpriseHookReconcileRow
+	Failures            int
+	StateErr            error
+	WatchDirs           []string
+	WatchExclusiveFiles []string // DC-only writers: react to any event
+	WatchSharedFiles    []string // agent + DC writers: react only to Remove/Rename
 }
 
 func runEnterpriseHooksReconcile(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/enterprise_hooks_auth_unix.go
+++ b/internal/cli/enterprise_hooks_auth_unix.go
@@ -22,12 +22,24 @@ import (
 // authorization record readable by the unprivileged defenseclaw gateway while
 // excluding unrelated local users. Non-root development/test invocations keep
 // their existing ownership and are still protected by the 0750/0640 modes.
+//
+// On installs where the daemon runs as root (managed_enterprise on macOS
+// since the CMID switch — the shipped plist omits UserName/GroupName so
+// launchd defaults to uid 0), there is no defenseclaw service user. The
+// authorization file is already root-owned 0640, which root can read; the
+// service-user chgrp is a leftover from the pre-root era and must not fail
+// the whole reconcile when the user is absent.
 func setEnterpriseHookAuthorizationOwnership(path string) error {
 	if os.Geteuid() != 0 {
 		return nil
 	}
 	serviceUser, err := user.Lookup("defenseclaw")
 	if err != nil {
+		// No service user on this host — the daemon runs as root and
+		// reads the 0640 file via its owner bit. Nothing to align.
+		if _, ok := err.(user.UnknownUserError); ok {
+			return nil
+		}
 		return err
 	}
 	gid, err := strconv.Atoi(serviceUser.Gid)

--- a/internal/cli/enterprise_hooks_test.go
+++ b/internal/cli/enterprise_hooks_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
@@ -193,6 +194,150 @@ func TestEnterpriseHookWatchEventRelevantIgnoresLockHousekeeping(t *testing.T) {
 				t.Fatalf("enterpriseHookWatchEventRelevant(%+v) = %v, want %v", tc.event, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestEnterpriseHookWatchEventInSettleWindow(t *testing.T) {
+	base := time.Date(2026, 7, 17, 15, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name        string
+		now         time.Time
+		settleUntil time.Time
+		op          fsnotify.Op
+		want        bool
+	}{
+		{
+			// Zero settleUntil means "never reconciled yet" — the
+			// watcher must not suppress the very first fsnotify event
+			// after boot; otherwise startup-time tamper is missed.
+			name:        "never reconciled: not suppressed",
+			now:         base,
+			settleUntil: time.Time{},
+			op:          fsnotify.Write,
+			want:        false,
+		},
+		{
+			// Chmod event well inside the post-reconcile settle
+			// window: this is the guardian's own chmod tail from
+			// hardenInstallFootprint. Suppress to break the
+			// self-trigger loop.
+			name:        "chmod inside window: suppressed",
+			now:         base.Add(500 * time.Millisecond),
+			settleUntil: base.Add(2 * time.Second),
+			op:          fsnotify.Chmod,
+			want:        true,
+		},
+		{
+			// Write event inside window — same rationale as Chmod;
+			// reconcile writes hook scripts and .token files, so
+			// their post-reconcile tail must be suppressed too.
+			name:        "write inside window: suppressed",
+			now:         base.Add(500 * time.Millisecond),
+			settleUntil: base.Add(2 * time.Second),
+			op:          fsnotify.Write,
+			want:        true,
+		},
+		{
+			// Right at the boundary — Before() is strictly less-than,
+			// so an event at exactly settleUntil is NOT suppressed.
+			name:        "chmod at boundary: not suppressed",
+			now:         base.Add(2 * time.Second),
+			settleUntil: base.Add(2 * time.Second),
+			op:          fsnotify.Chmod,
+			want:        false,
+		},
+		{
+			// Event after the window closed.
+			name:        "chmod outside window: not suppressed",
+			now:         base.Add(3 * time.Second),
+			settleUntil: base.Add(2 * time.Second),
+			op:          fsnotify.Chmod,
+			want:        false,
+		},
+		{
+			// Remove inside window: this IS suppressed. The guardian's
+			// atomicWriteFile uses os.Rename over the destination,
+			// which on macOS fires an fsnotify REMOVE on the target.
+			// So a REMOVE inside the settle window is our own
+			// atomic-write finishing, not a user tamper. Real user
+			// Remove events happen outside the settle window and
+			// still trigger reconcile within (settle window + debounce).
+			name:        "remove inside window: suppressed (atomic-write tail)",
+			now:         base.Add(500 * time.Millisecond),
+			settleUntil: base.Add(2 * time.Second),
+			op:          fsnotify.Remove,
+			want:        true,
+		},
+		{
+			// Remove OUTSIDE the settle window: real user tamper. The
+			// guardian's atomic-write tail lives inside the window
+			// (typically ~ms); anything after the window is a user
+			// action and must trigger reconcile.
+			name:        "remove outside window: not suppressed",
+			now:         base.Add(3 * time.Second),
+			settleUntil: base.Add(2 * time.Second),
+			op:          fsnotify.Remove,
+			want:        false,
+		},
+		{
+			// Rename inside window: same rationale as Remove — macOS
+			// rename(2) generates NOTE_RENAME on the source path
+			// alongside NOTE_DELETE on the destination.
+			name:        "rename inside window: suppressed",
+			now:         base.Add(500 * time.Millisecond),
+			settleUntil: base.Add(2 * time.Second),
+			op:          fsnotify.Rename,
+			want:        true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := enterpriseHookWatchEventInSettleWindow(tc.now, tc.settleUntil, tc.op)
+			if got != tc.want {
+				t.Fatalf("enterpriseHookWatchEventInSettleWindow(now=%v settleUntil=%v op=%v) = %v, want %v", tc.now, tc.settleUntil, tc.op, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEnterpriseHookReconcileRowsHash(t *testing.T) {
+	rowsA := []enterpriseHookReconcileRow{
+		{User: "alice", UserHome: "/Users/alice", Connector: "codex", OK: true},
+		{User: "bob", UserHome: "/Users/bob", Connector: "cursor", OK: true},
+	}
+	rowsB := []enterpriseHookReconcileRow{
+		{User: "bob", UserHome: "/Users/bob", Connector: "cursor", OK: true},
+		{User: "alice", UserHome: "/Users/alice", Connector: "codex", OK: true},
+	}
+	rowsC := []enterpriseHookReconcileRow{
+		{User: "alice", UserHome: "/Users/alice", Connector: "codex", OK: false, Error: "boom"},
+		{User: "bob", UserHome: "/Users/bob", Connector: "cursor", OK: true},
+	}
+	rowsD := []enterpriseHookReconcileRow{
+		{User: "alice", UserHome: "/Users/alice", Connector: "codex", OK: true},
+		{User: "bob", UserHome: "/Users/bob", Connector: "cursor", OK: true},
+		{User: "charlie", UserHome: "/Users/charlie", Connector: "claudecode", OK: true},
+	}
+
+	// Row order must not matter — the watcher iterates in whatever
+	// order the manifest resolves, but a "nothing changed" hash must
+	// still match after a benign reorder.
+	if h1, h2 := enterpriseHookReconcileRowsHash(rowsA), enterpriseHookReconcileRowsHash(rowsB); h1 != h2 {
+		t.Fatalf("row-order should not affect hash: A=%s B=%s", h1, h2)
+	}
+	// Same identities but one now failed → hash must differ so the
+	// watch loop treats it as a change (operator needs to see it).
+	if h1, h2 := enterpriseHookReconcileRowsHash(rowsA), enterpriseHookReconcileRowsHash(rowsC); h1 == h2 {
+		t.Fatalf("outcome change (OK true→false) must flip the hash, both = %s", h1)
+	}
+	// Adding a new target must flip the hash.
+	if h1, h2 := enterpriseHookReconcileRowsHash(rowsA), enterpriseHookReconcileRowsHash(rowsD); h1 == h2 {
+		t.Fatalf("adding a target must flip the hash, both = %s", h1)
+	}
+	// Empty input has a stable, non-empty representative — callers
+	// use hash equality to detect "no change", and the boot-time
+	// zero-value ("") must not collide with an actual empty run.
+	if got := enterpriseHookReconcileRowsHash(nil); got == "" {
+		t.Fatalf("empty rows must have a non-empty hash, got %q", got)
 	}
 }
 

--- a/internal/enterprisehooks/bootstrap.go
+++ b/internal/enterprisehooks/bootstrap.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package enterprisehooks
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/defenseclaw/defenseclaw/internal/gateway/connector"
+)
+
+// defaultHookConfigStubForConnector returns the minimal-valid native
+// hook config file DefenseClaw will pre-create on a target where the
+// agent has never launched. Kept out of the connector package so we
+// don't have to touch three connectors for what is otherwise a bag of
+// literal bytes — matches the exact shape the shell installer's
+// prepare_*_userspace helpers used before the multi-user rewrite (see
+// packaging/macos/lib/installer_lib.sh:197-235). When a connector
+// wants to own its stub bytes, it implements HookConfigBootstrap and
+// the caller uses that instead.
+//
+// Returns a zero-value HookConfigStub (ContentPath == "") for
+// connectors we don't know how to bootstrap — the installer's strict
+// "must exist" precondition still applies to those.
+func defaultHookConfigStubForConnector(conn connector.Connector, opts connector.SetupOpts, home string) connector.HookConfigStub {
+	if bootstrap, ok := conn.(connector.HookConfigBootstrap); ok {
+		return bootstrap.DefaultHookConfigStub(opts)
+	}
+	// Fallback map for the three connectors shipped in the pkg bundle
+	// (codex, claudecode, cursor). Additional connectors either
+	// implement HookConfigBootstrap or accept the strict precondition.
+	name := strings.ToLower(strings.TrimSpace(conn.Name()))
+	switch name {
+	case "codex":
+		return connector.HookConfigStub{
+			ContentPath: filepath.Join(home, ".codex", "config.toml"),
+			Contents: []byte("# Created by DefenseClaw installer so the enterprise hook guardian can\n" +
+				"# repair this file. Edit freely; DefenseClaw only owns [hooks], [otel],\n" +
+				"# and the top-level notify entries.\n"),
+			Mode: 0o600,
+		}
+	case "claudecode":
+		return connector.HookConfigStub{
+			ContentPath: filepath.Join(home, ".claude", "settings.json"),
+			Contents:    []byte("{}\n"),
+			Mode:        0o600,
+		}
+	case "cursor":
+		return connector.HookConfigStub{
+			ContentPath: filepath.Join(home, ".cursor", "hooks.json"),
+			Contents:    []byte("{\"version\":1,\"hooks\":{}}\n"),
+			Mode:        0o600,
+		}
+	}
+	return connector.HookConfigStub{}
+}
+
+// bootstrapMissingHookConfig writes the connector's default hook config
+// stub if and only if the file is absent. Runs under withOwnerCredentials
+// so parent dir + file both land owned by the target user (matches what
+// the pre-2026.7.3 shell installer produced via prepare_userspace_for).
+//
+// Returns true iff a stub was written — the caller uses this to
+// distinguish "we bootstrapped it just now" from "operator already
+// prepped this". Never returns an error when the file already exists;
+// the strict validate step downstream owns "present but broken"
+// diagnostics.
+//
+// Preconditions:
+//   - stub.ContentPath must be a subpath of home (checked here as
+//     defense-in-depth against a malicious connector name; the caller
+//     already validated home).
+//   - Runs as the caller — the outer withOwnerCredentials at the
+//     Install call site ensures euid/egid are the target user.
+func bootstrapMissingHookConfig(home string, stub connector.HookConfigStub) (bool, error) {
+	path := strings.TrimSpace(stub.ContentPath)
+	if path == "" {
+		return false, nil
+	}
+	// Cheap containment check — path must sit under the target's home.
+	// Catches the case where a future connector accidentally returns
+	// an absolute path outside the user's tree (e.g. /etc/agent.conf)
+	// and the installer would otherwise chmod it 0600 as target user.
+	cleanHome := filepath.Clean(home)
+	cleanPath := filepath.Clean(path)
+	rel, err := filepath.Rel(cleanHome, cleanPath)
+	if err != nil || strings.HasPrefix(rel, "..") || rel == "." {
+		return false, fmt.Errorf("enterprise hooks: hook config stub path %q is not inside user home %q", path, cleanHome)
+	}
+	// Already exists — leave it alone. Present-but-broken configs
+	// (wrong owner, group-writable, symlink) surface via the strict
+	// validate step immediately after us.
+	if _, err := os.Lstat(cleanPath); err == nil {
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("enterprise hooks: inspect hook config %s before bootstrap: %w", cleanPath, err)
+	}
+
+	dir := filepath.Dir(cleanPath)
+	// mkdir -p walks the ancestor chain — but we only ever create the
+	// LEAF agent dir here (e.g. ~/.claude), not the whole ~/. If the
+	// home itself is missing that's a validateUserHome failure the
+	// caller already reported.
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return false, fmt.Errorf("enterprise hooks: create hook config parent %s: %w", dir, err)
+	}
+	// Explicit chmod after MkdirAll — the process umask may have narrowed
+	// the requested mode. 0700 is intentional: matches the shell installer's
+	// prepare_*_userspace helpers, and is what Cursor / Codex / Claude Code
+	// all use for their own dot-dirs when they create them themselves.
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return false, fmt.Errorf("enterprise hooks: chmod hook config parent %s: %w", dir, err)
+	}
+
+	// O_CREATE|O_EXCL so a concurrent writer wins deterministically —
+	// we treat "someone else created it since we Lstat'd" as
+	// "already exists, leave alone". No os.WriteFile which would
+	// clobber a racing agent-side write.
+	mode := stub.Mode
+	if mode == 0 {
+		mode = 0o600
+	}
+	f, err := os.OpenFile(cleanPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+	if err != nil {
+		if os.IsExist(err) {
+			// Concurrent create race — the file exists now, our downstream
+			// validate step will inspect it.
+			return false, nil
+		}
+		return false, fmt.Errorf("enterprise hooks: create hook config %s: %w", cleanPath, err)
+	}
+	if _, writeErr := f.Write(stub.Contents); writeErr != nil {
+		_ = f.Close()
+		_ = os.Remove(cleanPath)
+		return false, fmt.Errorf("enterprise hooks: write hook config %s: %w", cleanPath, writeErr)
+	}
+	if err := f.Close(); err != nil {
+		return false, fmt.Errorf("enterprise hooks: close hook config %s: %w", cleanPath, err)
+	}
+	// Explicit chmod after create — same reason as the dir chmod: umask.
+	if err := os.Chmod(cleanPath, mode); err != nil {
+		return false, fmt.Errorf("enterprise hooks: chmod hook config %s: %w", cleanPath, err)
+	}
+	return true, nil
+}

--- a/internal/enterprisehooks/installer.go
+++ b/internal/enterprisehooks/installer.go
@@ -142,6 +142,32 @@ func Install(ctx context.Context, opts InstallOptions) (InstallResult, error) {
 	var result InstallResult
 	err = connector.WithUserHomeDir(home, func() error {
 		paths := connector.HookConfigPathsForConnector(conn, setupOpts)
+		// Endpoint-product bootstrap: on a fresh target where the
+		// user hasn't launched the agent yet, the native hook config
+		// file doesn't exist and validateActivationSurfaces below
+		// would refuse with "hook config file missing". Pre-create
+		// the connector's minimal-valid stub as the target user so
+		// the strict validate check has something to inspect.
+		//
+		// Design intent: DefenseClaw ships on customer Macs where we
+		// want enforcement live at pkg-install time — not deferred
+		// until the user happens to open each agent once. The stub
+		// is intentionally minimal (the agent's own default config
+		// content) so it won't override anything the user hasn't
+		// explicitly set; connector.Setup() below then patches in
+		// the DefenseClaw-owned entries.
+		if stub := defaultHookConfigStubForConnector(conn, setupOpts, home); stub.ContentPath != "" {
+			var bootstrapped bool
+			bootstrapErr := withOwnerCredentials(uid, gid, func() error {
+				written, werr := bootstrapMissingHookConfig(home, stub)
+				bootstrapped = written
+				return werr
+			})
+			if bootstrapErr != nil {
+				return fmt.Errorf("enterprise hooks: bootstrap missing hook config for %s: %w", conn.Name(), bootstrapErr)
+			}
+			_ = bootstrapped // reserved for future audit emission
+		}
 		if err := validateActivationSurfaces(home, paths, uid, opts.AllowMissingHookConfigRepair); err != nil {
 			return err
 		}

--- a/internal/enterprisehooks/installer_test.go
+++ b/internal/enterprisehooks/installer_test.go
@@ -367,6 +367,141 @@ func TestWatchDirsIncludesHookConfigAndRuntimeDirs(t *testing.T) {
 	}
 }
 
+// TestWatchOwnedFilesReturnsSpecificFilesNotDirs asserts the
+// watcher's per-event ownership filter has the right shape: it must
+// enumerate concrete file paths (the codex config, the connector's
+// hook script, its .token sidecar, hook helpers), NOT parent dirs.
+// Filtering by dir would defeat the whole point — the loop already
+// receives dir-scoped events from fsnotify. If a future edit ever
+// makes this return dirs instead, unrelated agent-runtime writes
+// (session sqlite churn, cache writes) would once again be treated
+// as tamper signals.
+func TestWatchOwnedFilesReturnsSpecificFilesNotDirs(t *testing.T) {
+	skipIfRoot(t)
+	home := newTestHome(t)
+	codexConfig := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(codexConfig), 0o700); err != nil {
+		t.Fatalf("mkdir codex dir: %v", err)
+	}
+	if err := os.WriteFile(codexConfig, []byte("model = \"gpt-5\"\n"), 0o600); err != nil {
+		t.Fatalf("write codex config: %v", err)
+	}
+	hookDir := filepath.Join(home, ".defenseclaw", "hooks")
+	if err := os.MkdirAll(hookDir, 0o700); err != nil {
+		t.Fatalf("mkdir hook dir: %v", err)
+	}
+
+	own, err := WatchOwnedFiles(InstallOptions{
+		ConnectorName: "codex",
+		UserHome:      home,
+		OwnerUID:      os.Getuid(),
+		OwnerGID:      os.Getgid(),
+		APIAddr:       "127.0.0.1:18970",
+		ProxyAddr:     "127.0.0.1:4000",
+		APIToken:      "test-token",
+		GuardrailMode: "action",
+		HookFailMode:  "closed",
+		AgentVersion:  "codex-cli 0.142.0",
+		Registry:      connector.NewDefaultRegistry(),
+	})
+	if err != nil {
+		t.Fatalf("WatchOwnedFiles: %v", err)
+	}
+
+	// The native agent config file is SHARED-writer: Codex itself
+	// rewrites config.toml during normal use, so the guardian must
+	// only react to Remove/Rename on it (Write/Chmod are the agent
+	// updating its own state).
+	wantShared := filepath.Join(home, ".codex", "config.toml")
+	if !sliceContains(own.SharedWriter, wantShared) {
+		t.Fatalf("WatchOwnedFiles.SharedWriter = %v, missing %s", own.SharedWriter, wantShared)
+	}
+	// It MUST NOT appear in ExclusiveWriter — that would re-introduce
+	// the log spam where every Codex config write fires a reconcile.
+	if sliceContains(own.ExclusiveWriter, wantShared) {
+		t.Fatalf("~/.codex/config.toml must not be ExclusiveWriter (Codex writes to it during normal use); got %v", own.ExclusiveWriter)
+	}
+
+	// EXCLUSIVE-writer files: DC-only artifacts that render to
+	// the same bytes on every reconcile for a given connector.
+	// Two categories qualify: the connector-specific hook script
+	// (codex-hook.sh — written by only this connector's Install)
+	// and the scoped token sidecar (.hook-codex.token — one per
+	// connector). Any event on these is meaningful because
+	// atomicWriteFile short-circuits when content matches, so
+	// only real churn triggers events.
+	wantExclusive := []string{
+		filepath.Join(hookDir, "codex-hook.sh"),
+		filepath.Join(hookDir, ".hook-codex.token"),
+	}
+	for _, w := range wantExclusive {
+		if !sliceContains(own.ExclusiveWriter, w) {
+			t.Fatalf("WatchOwnedFiles.ExclusiveWriter = %v, missing %s", own.ExclusiveWriter, w)
+		}
+		// And they must NOT slip into SharedWriter (would suppress
+		// Write/Chmod events on a file only DC writes to).
+		if sliceContains(own.SharedWriter, w) {
+			t.Fatalf("%s must be ExclusiveWriter (DC-only), not SharedWriter", w)
+		}
+	}
+
+	// Regression guard: shared-across-connectors artifacts must
+	// NOT be in either set. Including them creates a fsnotify
+	// rename storm because every reconcile rewrites the file once
+	// per active connector with slightly different bytes, and
+	// each rewrite fires a REMOVE event that our loop treats as a
+	// tamper. Excluding them means the 5-min backstop reconcile
+	// is the only thing that re-lays them, which is fine — users
+	// don't tamper with these helpers directly (they invoke the
+	// connector-specific hook, and THAT is in the allowlist).
+	wantExcluded := []string{
+		filepath.Join(hookDir, "inspect-tool.sh"),
+		filepath.Join(hookDir, "inspect-request.sh"),
+		filepath.Join(hookDir, "inspect-response.sh"),
+		filepath.Join(hookDir, "inspect-tool-response.sh"),
+		filepath.Join(hookDir, "_hardening.sh"),
+		filepath.Join(hookDir, ".hookcfg"),
+	}
+	for _, w := range wantExcluded {
+		if sliceContains(own.ExclusiveWriter, w) {
+			t.Fatalf("%s must NOT be in ExclusiveWriter — it is shared across connectors and re-rendered by every Install() with different bytes, which fires an fsnotify REMOVE storm every reconcile", w)
+		}
+		if sliceContains(own.SharedWriter, w) {
+			t.Fatalf("%s must NOT be in SharedWriter either", w)
+		}
+	}
+
+	// Regression guard: NO returned entry may be a bare dir.
+	allFiles := append(append([]string{}, own.ExclusiveWriter...), own.SharedWriter...)
+	forbiddenDirs := []string{
+		filepath.Join(home, ".codex"),
+		filepath.Join(home, ".defenseclaw"),
+		hookDir,
+	}
+	for _, f := range allFiles {
+		for _, d := range forbiddenDirs {
+			if f == d {
+				t.Fatalf("WatchOwnedFiles returned a directory %s; must return only files", f)
+			}
+		}
+	}
+
+	// Unrelated agent-runtime paths MUST NOT appear in either set.
+	forbiddenPaths := []string{
+		filepath.Join(home, ".codex", "sessions"),
+		filepath.Join(home, ".codex", "history.jsonl"),
+		filepath.Join(home, ".codex", "logs_2.sqlite-wal"),
+		filepath.Join(home, ".codex", "auth.json"),
+	}
+	for _, f := range allFiles {
+		for _, forbidden := range forbiddenPaths {
+			if f == forbidden {
+				t.Fatalf("WatchOwnedFiles leaked unrelated agent-runtime path %s", f)
+			}
+		}
+	}
+}
+
 // TestInstallBootstrapsMissingHookConfigFirstTime locks the endpoint-
 // product contract: on a fresh target where the user has never
 // launched the agent (so ~/.codex/config.toml doesn't exist yet),

--- a/internal/enterprisehooks/installer_test.go
+++ b/internal/enterprisehooks/installer_test.go
@@ -367,23 +367,44 @@ func TestWatchDirsIncludesHookConfigAndRuntimeDirs(t *testing.T) {
 	}
 }
 
-func TestInstallRefusesMissingHookConfig(t *testing.T) {
+// TestInstallBootstrapsMissingHookConfigFirstTime locks the endpoint-
+// product contract: on a fresh target where the user has never
+// launched the agent (so ~/.codex/config.toml doesn't exist yet),
+// Install auto-creates the connector's minimal-valid stub as the
+// target user AND completes successfully. Before this change the
+// installer refused with "hook config file missing", leaving
+// customers with no enforcement until they opened each agent once —
+// see bootstrap.go for the rationale.
+func TestInstallBootstrapsMissingHookConfigFirstTime(t *testing.T) {
 	skipIfRoot(t)
 	home := newTestHome(t)
-	_, err := Install(context.Background(), InstallOptions{
+	cfgPath := filepath.Join(home, ".codex", "config.toml")
+	if _, err := os.Stat(cfgPath); !os.IsNotExist(err) {
+		t.Fatalf("precondition: %s must not exist before Install (err=%v)", cfgPath, err)
+	}
+	result, err := Install(context.Background(), InstallOptions{
 		ConnectorName: "codex",
 		UserHome:      home,
 		OwnerUID:      os.Getuid(),
 		OwnerGID:      os.Getgid(),
 		APIAddr:       "127.0.0.1:18970",
 		APIToken:      "test-token",
+		AgentVersion:  "codex-cli 0.142.0",
 		Registry:      connector.NewDefaultRegistry(),
 	})
-	if err == nil || !strings.Contains(err.Error(), "hook config") || !strings.Contains(err.Error(), "missing") {
-		t.Fatalf("Install error = %v, want hook config missing", err)
+	if err != nil {
+		t.Fatalf("Install with missing hook config: %v", err)
 	}
-	if _, statErr := os.Stat(filepath.Join(home, ".defenseclaw")); !os.IsNotExist(statErr) {
-		t.Fatalf("data dir exists after refused install: %v", statErr)
+	if result.Connector != "codex" {
+		t.Fatalf("result.Connector = %q, want codex", result.Connector)
+	}
+	// The stub must exist AND be owned by the target user after Install.
+	info, statErr := os.Stat(cfgPath)
+	if statErr != nil {
+		t.Fatalf("stat %s after Install: %v", cfgPath, statErr)
+	}
+	if info.Size() == 0 {
+		t.Fatalf("stub at %s is empty; Connector.Setup should have written entries", cfgPath)
 	}
 }
 

--- a/internal/enterprisehooks/watch_paths.go
+++ b/internal/enterprisehooks/watch_paths.go
@@ -149,22 +149,22 @@ func WatchDirs(opts InstallOptions) ([]string, error) {
 // expected writer, so the watch loop can react appropriately to each
 // class of event.
 //
-//   ExclusiveWriter files are ones only DefenseClaw ever writes to:
-//     hook scripts, _hardening.sh, .hook-<connector>.token sidecars,
-//     backup archives, generated executables. ANY event on these
-//     (Write, Chmod, Remove, Rename) is a real signal — either user
-//     tampering or the guardian's own reconcile tail, both worth
-//     acting on.
+//	ExclusiveWriter files are ones only DefenseClaw ever writes to:
+//	  hook scripts, _hardening.sh, .hook-<connector>.token sidecars,
+//	  backup archives, generated executables. ANY event on these
+//	  (Write, Chmod, Remove, Rename) is a real signal — either user
+//	  tampering or the guardian's own reconcile tail, both worth
+//	  acting on.
 //
-//   SharedWriter files are ones the agent itself writes to during
-//     normal use in addition to DefenseClaw's patches:
-//     ~/.codex/config.toml (Codex updates MRU model, plugin state,
-//     session prefs), ~/.claude/settings.json (Claude Code writes
-//     project-scoped settings), ~/.cursor/hooks.json (Cursor rewrites
-//     for extensions). Write and Chmod on these are almost always
-//     the agent updating its own state, NOT a tamper — so we only
-//     react to Remove and Rename, and let the 5-min backstop
-//     reconcile catch any pathological in-place rewrite.
+//	SharedWriter files are ones the agent itself writes to during
+//	  normal use in addition to DefenseClaw's patches:
+//	  ~/.codex/config.toml (Codex updates MRU model, plugin state,
+//	  session prefs), ~/.claude/settings.json (Claude Code writes
+//	  project-scoped settings), ~/.cursor/hooks.json (Cursor rewrites
+//	  for extensions). Write and Chmod on these are almost always
+//	  the agent updating its own state, NOT a tamper — so we only
+//	  react to Remove and Rename, and let the 5-min backstop
+//	  reconcile catch any pathological in-place rewrite.
 //
 // The rationale: without this split, every session Codex opens will
 // touch config.toml, fire an fsnotify Write, pass the ownership
@@ -350,9 +350,9 @@ func WatchOwnedFiles(opts InstallOptions) (WatchOwnership, error) {
 		// user replacing it with a wrong token disables inspection
 		// silently.
 		sharedSidecars := map[string]struct{}{
-			".token":         {},
-			".hookcfg":       {},
-			"_hardening.sh":  {},
+			".token":        {},
+			".hookcfg":      {},
+			"_hardening.sh": {},
 		}
 		sidecarFiles, sidecarErr := hookSidecarFiles(dataDir, conn.Name())
 		if sidecarErr != nil {

--- a/internal/enterprisehooks/watch_paths.go
+++ b/internal/enterprisehooks/watch_paths.go
@@ -145,6 +145,236 @@ func WatchDirs(opts InstallOptions) ([]string, error) {
 	return sortedMapKeys(dirs), nil
 }
 
+// WatchOwnership splits per-target owned files into two sets by
+// expected writer, so the watch loop can react appropriately to each
+// class of event.
+//
+//   ExclusiveWriter files are ones only DefenseClaw ever writes to:
+//     hook scripts, _hardening.sh, .hook-<connector>.token sidecars,
+//     backup archives, generated executables. ANY event on these
+//     (Write, Chmod, Remove, Rename) is a real signal — either user
+//     tampering or the guardian's own reconcile tail, both worth
+//     acting on.
+//
+//   SharedWriter files are ones the agent itself writes to during
+//     normal use in addition to DefenseClaw's patches:
+//     ~/.codex/config.toml (Codex updates MRU model, plugin state,
+//     session prefs), ~/.claude/settings.json (Claude Code writes
+//     project-scoped settings), ~/.cursor/hooks.json (Cursor rewrites
+//     for extensions). Write and Chmod on these are almost always
+//     the agent updating its own state, NOT a tamper — so we only
+//     react to Remove and Rename, and let the 5-min backstop
+//     reconcile catch any pathological in-place rewrite.
+//
+// The rationale: without this split, every session Codex opens will
+// touch config.toml, fire an fsnotify Write, pass the ownership
+// filter, and trigger a reconcile even though the DefenseClaw entries
+// in the file are untouched. The reconcile returns no_change=true
+// each time but still produces log spam.
+type WatchOwnership struct {
+	ExclusiveWriter []string // DC-only writers; react to any event
+	SharedWriter    []string // agent + DC writers; react only to Remove/Rename
+}
+
+// WatchOwnedFiles returns the specific files (NOT parent directories)
+// that this guardian target owns and cares about for tamper detection,
+// classified by expected writer. See WatchOwnership for the two
+// categories and their reaction policies.
+//
+// This exists because fsnotify on macOS reports directory-level
+// events: watching ~/.codex/ to see config.toml also sees every
+// session log, sqlite WAL rotation, and history-line append.
+// Filtering by owned file path drops the majority of that noise, and
+// classifying by writer drops the rest of it (agent-updates-its-own-
+// config traffic).
+//
+// The set intentionally lists concrete files, not glob patterns —
+// every artifact DefenseClaw's Install() writes has a stable path.
+// If Install() ever grows a new artifact, it must be added here or
+// tampering with it won't fire a repair (guarded by the reconciler
+// test that installs + tampers + expects repair).
+func WatchOwnedFiles(opts InstallOptions) (WatchOwnership, error) {
+	home, err := validateUserHome(opts.UserHome)
+	if err != nil {
+		return WatchOwnership{}, err
+	}
+	uid, _, err := resolveOwner(home, opts.OwnerUID, opts.OwnerGID)
+	if err != nil {
+		return WatchOwnership{}, err
+	}
+	if err := validateHomeOwner(home, uid); err != nil {
+		return WatchOwnership{}, err
+	}
+	dataDir := strings.TrimSpace(opts.DataDir)
+	if dataDir == "" {
+		dataDir = filepath.Join(home, ".defenseclaw")
+	}
+	dataDir, err = filepath.Abs(dataDir)
+	if err != nil {
+		return WatchOwnership{}, fmt.Errorf("enterprise hooks: resolve data dir: %w", err)
+	}
+	reg := opts.Registry
+	if reg == nil {
+		reg = connector.NewDefaultRegistry()
+	}
+	name := strings.ToLower(strings.TrimSpace(opts.ConnectorName))
+	if name == "" {
+		return WatchOwnership{}, fmt.Errorf("enterprise hooks: connector is required")
+	}
+	conn, ok := reg.Get(name)
+	if !ok {
+		return WatchOwnership{}, fmt.Errorf("enterprise hooks: unknown connector %q", name)
+	}
+	if connector.IsProxyConnector(conn.Name()) {
+		return WatchOwnership{}, fmt.Errorf("enterprise hooks: connector %q is proxy/plugin setup-only", conn.Name())
+	}
+	if _, ok := conn.(connector.HookScriptOwner); !ok {
+		return WatchOwnership{}, fmt.Errorf("enterprise hooks: connector %q does not own a hook script", conn.Name())
+	}
+
+	setupOpts := connector.SetupOpts{
+		DataDir:           dataDir,
+		ProxyAddr:         strings.TrimSpace(opts.ProxyAddr),
+		APIAddr:           strings.TrimSpace(opts.APIAddr),
+		APIToken:          strings.TrimSpace(opts.APIToken),
+		Interactive:       false,
+		ManagedEnterprise: true,
+		WorkspaceDir:      strings.TrimSpace(opts.WorkspaceDir),
+		HookFailMode:      strings.TrimSpace(opts.HookFailMode),
+		HILTEnabled:       opts.HILTEnabled,
+		AgentVersion:      strings.TrimSpace(opts.AgentVersion),
+		HookContractID:    strings.TrimSpace(opts.HookContractID),
+	}
+	if setupOpts.AgentVersion == "" {
+		setupOpts.AgentVersion = connector.LoadCachedAgentVersion(dataDir, conn.Name())
+	}
+	if setupOpts.HookContractID == "" {
+		resolution := connector.ResolveHookContract(conn.Name(), setupOpts.AgentVersion)
+		setupOpts.HookContractID = resolution.Contract.ContractID
+	}
+
+	exclusive := map[string]struct{}{}
+	shared := map[string]struct{}{}
+	addExclusive := func(path string) {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			return
+		}
+		exclusive[filepath.Clean(path)] = struct{}{}
+	}
+	addShared := func(path string) {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			return
+		}
+		shared[filepath.Clean(path)] = struct{}{}
+	}
+
+	err = connector.WithUserHomeDir(home, func() error {
+		// SHARED-WRITER: the native hook config file (codex
+		// config.toml / claudecode settings.json / cursor hooks.json).
+		// The agent itself writes to this constantly during normal use
+		// (MRU model, plugin state, session prefs), so we ONLY react
+		// to Remove/Rename here. Any in-place stripping via `sed -i`
+		// is caught by the 5-min backstop reconcile.
+		for _, path := range connector.HookConfigPathsForConnector(conn, setupOpts) {
+			addShared(path)
+		}
+		footprint := connector.AgentPaths{}
+		if ap, ok := conn.(connector.AgentPathProvider); ok {
+			footprint = ap.AgentPaths(setupOpts)
+		}
+		// PatchedFiles are typically the same as HookConfigPaths — the
+		// agent's own config file — so they are shared-writer too.
+		for _, p := range footprint.PatchedFiles {
+			addShared(p)
+		}
+		// EXCLUSIVE-WRITER: everything below. Only DefenseClaw writes
+		// to these paths, so any event is meaningful and worth acting
+		// on (either user tamper or our own reconcile tail; both are
+		// correctly handled by the settle window).
+		for _, p := range footprint.BackupFiles {
+			addExclusive(p)
+		}
+		// HookScripts contains BOTH the connector-specific hook
+		// (codex-hook.sh / claude-code-hook.sh / cursor-hook.sh) AND
+		// the four generic inspect-*.sh scripts that are shared
+		// across every connector. Only the connector-specific one is
+		// safe to include in the watch allowlist:
+		//
+		//   * codex-hook.sh (etc.) is written by exactly ONE
+		//     connector's Install(), with a stable rendered body —
+		//     no cross-connector content drift, atomicFileAlreadyMatches
+		//     short-circuits on repeated reconciles.
+		//
+		//   * inspect-tool.sh (etc.) is written by EVERY connector's
+		//     Install(), each rendering it with different bytes
+		//     (X-DefenseClaw-Connector: <name>, .hook-<name>.token,
+		//     etc.). So each reconcile's second and third connector
+		//     see a content mismatch, rename over the same file, and
+		//     macOS surfaces the rename as an fsnotify REMOVE — which
+		//     our loop then treats as a tamper. Excluding them from
+		//     the fsnotify allowlist entirely means the 5-min backstop
+		//     reconcile is the only thing that re-lays them, which
+		//     is fine: users don't tamper with the generic helpers
+		//     directly (they invoke the connector-specific hook, and
+		//     THAT is watched).
+		genericScripts := map[string]struct{}{
+			"inspect-tool.sh":          {},
+			"inspect-request.sh":       {},
+			"inspect-response.sh":      {},
+			"inspect-tool-response.sh": {},
+		}
+		for _, p := range footprint.HookScripts {
+			if _, isGeneric := genericScripts[filepath.Base(p)]; isGeneric {
+				continue
+			}
+			addExclusive(p)
+		}
+		for _, p := range footprint.GeneratedFiles {
+			addExclusive(p)
+		}
+		for _, p := range footprint.GeneratedExecutables {
+			addExclusive(p)
+		}
+		// Hook sidecars: the .token / .hookcfg / _hardening.sh files
+		// under ~/.defenseclaw/hooks/. Of these, only the per-
+		// connector scoped token (.hook-<connector>.token) is stable
+		// per reconcile — the others are either shared across
+		// connectors (_hardening.sh, .hookcfg) or unused legacy
+		// (.token). Same rationale as the generic scripts above:
+		// including cross-connector shared files here means every
+		// reconcile rewrites them once per connector, producing
+		// fsnotify rename storms. The scoped-token file remains in
+		// the allowlist because it's the primary bypass vector — a
+		// user replacing it with a wrong token disables inspection
+		// silently.
+		sharedSidecars := map[string]struct{}{
+			".token":         {},
+			".hookcfg":       {},
+			"_hardening.sh":  {},
+		}
+		sidecarFiles, sidecarErr := hookSidecarFiles(dataDir, conn.Name())
+		if sidecarErr != nil {
+			return sidecarErr
+		}
+		for _, p := range sidecarFiles {
+			if _, isShared := sharedSidecars[filepath.Base(p)]; isShared {
+				continue
+			}
+			addExclusive(p)
+		}
+		return nil
+	})
+	if err != nil {
+		return WatchOwnership{}, err
+	}
+	return WatchOwnership{
+		ExclusiveWriter: sortedMapKeys(exclusive),
+		SharedWriter:    sortedMapKeys(shared),
+	}, nil
+}
+
 func sortedMapKeys(values map[string]struct{}) []string {
 	out := make([]string, 0, len(values))
 	for v := range values {

--- a/internal/gateway/cisco_inspect.go
+++ b/internal/gateway/cisco_inspect.go
@@ -105,11 +105,21 @@ func doInspectHTTP(call inspectCall) *ScanVerdict {
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		body, err := json.Marshal(call.payload)
 		if err != nil {
+			// Should be unreachable — payload is a map[string]interface{}
+			// of plain scalars/slices — but emit rather than silent-nil
+			// so the surface stays honest if a future edit changes the
+			// payload shape into something un-marshalable.
+			fmt.Fprintf(defaultLogWriter, "  [cisco-ai-defense] error: marshal request: %v\n", err)
+			EmitCiscoError(ctx, call.tel, gatewaylog.ErrCodeInvalidResponse,
+				"marshal request: "+err.Error())
 			return nil
 		}
 
 		req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
 		if err != nil {
+			fmt.Fprintf(defaultLogWriter, "  [cisco-ai-defense] error: build request %s: %v\n", url, err)
+			EmitCiscoError(ctx, call.tel, gatewaylog.ErrCodeUpstreamError,
+				fmt.Sprintf("build request %s: %v", url, err))
 			return nil
 		}
 		req.Header.Set("Content-Type", "application/json")
@@ -171,24 +181,50 @@ func doInspectHTTP(call inspectCall) *ScanVerdict {
 				fmt.Fprintf(defaultLogWriter, "  [cisco-ai-defense] HTTP 401, refreshed credentials and retrying\n")
 				continue
 			}
+			// onUnauthorized ran but refused the retry (token refresh
+			// failed / same token minted again). This is a real terminal
+			// auth failure — surface as AUTH_INVALID_TOKEN so operators
+			// can distinguish it from a 5xx or 400.
+			bodySnippet := string(respBody[:minInt(len(respBody), 200)])
+			fmt.Fprintf(defaultLogWriter, "  [cisco-ai-defense] error: HTTP 401 and no fresh token available: %s\n",
+				redaction.MessageContent(bodySnippet))
+			EmitCiscoError(ctx, call.tel, gatewaylog.ErrCodeAuthInvalidToken,
+				fmt.Sprintf("HTTP 401 and no fresh token available: %s",
+					redaction.MessageContent(bodySnippet)))
+			return nil
 		}
 
 		if resp.StatusCode != http.StatusOK {
 			bodySnippet := string(respBody[:minInt(len(respBody), 200)])
+			// Choose the code by status class so log consumers can filter:
+			// 401/403 -> AUTH_INVALID_TOKEN; others -> INVALID_RESPONSE.
+			code := gatewaylog.ErrCodeInvalidResponse
+			if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+				code = gatewaylog.ErrCodeAuthInvalidToken
+			}
 			fmt.Fprintf(defaultLogWriter, "  [cisco-ai-defense] error: HTTP %d: %s\n",
 				resp.StatusCode, redaction.MessageContent(bodySnippet))
-			EmitCiscoError(ctx, call.tel, gatewaylog.ErrCodeInvalidResponse,
+			EmitCiscoError(ctx, call.tel, code,
 				fmt.Sprintf("HTTP %d: %s", resp.StatusCode, redaction.MessageContent(bodySnippet)))
 			return nil
 		}
 
 		var data map[string]interface{}
 		if err := json.Unmarshal(respBody, &data); err != nil {
-			EmitCiscoError(ctx, call.tel, gatewaylog.ErrCodeInvalidResponse, "json: "+err.Error())
+			fmt.Fprintf(defaultLogWriter, "  [cisco-ai-defense] error: parse response: %v\n", err)
+			EmitCiscoError(ctx, call.tel, gatewaylog.ErrCodeInvalidResponse, "parse response: "+err.Error())
 			return nil
 		}
 		return normalizeCiscoResponse(data)
 	}
+	// The retry loop exhausted without producing a verdict. Every branch
+	// inside the loop that reached `continue` (400-rules-retry, 401 with
+	// refresh accepted) already logged its own reason for retrying; if we
+	// end up here it means the retry itself didn't complete. Emit a
+	// terminal error so this path never silently fails-open.
+	fmt.Fprintf(defaultLogWriter, "  [cisco-ai-defense] error: exhausted %d retry attempt(s) without a usable verdict\n", maxAttempts)
+	EmitCiscoError(ctx, call.tel, gatewaylog.ErrCodeUpstreamError,
+		fmt.Sprintf("exhausted %d retry attempt(s) without a usable verdict", maxAttempts))
 	return nil
 }
 

--- a/internal/gateway/cisco_inspect_defense_claw.go
+++ b/internal/gateway/cisco_inspect_defense_claw.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/gatewaylog"
 	"github.com/defenseclaw/defenseclaw/internal/managed/cloudreg"
 	"github.com/defenseclaw/defenseclaw/internal/telemetry"
 )
@@ -105,19 +106,32 @@ func (c *CiscoDefenseClawInspectClient) SetTelemetry(p *telemetry.Provider) {
 // normalized verdict. Returns nil on any error so the caller falls back
 // to local-only scanning — same fail-open contract as the API-key path.
 func (c *CiscoDefenseClawInspectClient) Inspect(messages []ChatMessage) *ScanVerdict {
-	if c == nil || c.provider == nil {
+	if c == nil {
 		return nil
 	}
-
 	// Refresh the token per call — cheap in-memory cache read after
 	// the first successful load. Caching semantics live in the managed
 	// cloud auth module registered via internal/managed/cloudreg.
 	tokenCtx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
+	if c.provider == nil {
+		// pickInspector should have refused to construct us in this
+		// state, but if we somehow reach Inspect with a nil provider
+		// emit rather than silently fail-open. Every managed inspection
+		// call needs a bearer, so a nil provider is a boot-time bug the
+		// operator must see in gateway.err.log.
+		EmitCiscoError(tokenCtx, c.tel, gatewaylog.ErrCodeAuthMissingToken,
+			"managed inspect client has no CMID provider — remote inspection disabled")
+		return nil
+	}
 	tok, err := c.provider.Token(tokenCtx)
 	if err != nil {
 		// Any error maps to a fail-open outcome for this request. The
 		// fail-closed decision was made at boot-time in the picker.
+		// Surface the specific failure though — silent nil here is what
+		// let an expired / revoked CMID enrollment ship undetected.
+		EmitCiscoError(tokenCtx, c.tel, gatewaylog.ErrCodeAuthMissingToken,
+			"managed inspect: CMID token mint failed: "+err.Error())
 		return nil
 	}
 
@@ -165,7 +179,20 @@ func (c *CiscoDefenseClawInspectClient) Inspect(messages []ChatMessage) *ScanVer
 			defer cancel()
 			fresh, err := c.provider.Token(ctx)
 			if err != nil || fresh == "" || fresh == currentToken {
-				// No new credential available; don't loop.
+				// No new credential available; don't loop. The
+				// eventual "HTTP 401" branch in doInspectHTTP emits
+				// the terminal AUTH_INVALID_TOKEN. Surface the
+				// re-mint failure reason too so operators can tell
+				// "no new token minted" from "cloud rejected the new
+				// token" when triaging.
+				reason := "same token returned after invalidate"
+				if err != nil {
+					reason = "provider.Token after invalidate: " + err.Error()
+				} else if fresh == "" {
+					reason = "provider.Token returned empty after invalidate"
+				}
+				EmitCiscoError(ctx, c.tel, gatewaylog.ErrCodeAuthInvalidToken,
+					"managed inspect 401 re-mint refused: "+reason)
 				return false
 			}
 			currentToken = fresh

--- a/internal/gateway/connector/connector.go
+++ b/internal/gateway/connector/connector.go
@@ -23,6 +23,7 @@ package connector
 import (
 	"context"
 	"net/http"
+	"os"
 )
 
 // ToolInspectionMode describes how a connector monitors tool calls.
@@ -162,6 +163,40 @@ type Connector interface {
 // the route dynamically at boot instead of hardcoding paths in api.go.
 type HookEndpoint interface {
 	HookAPIPath() string
+}
+
+// HookConfigStub describes the bytes + mode a connector wants written
+// when its native hook config file is absent on a fresh target (the
+// agent binary was never launched by this user, so its default config
+// file doesn't exist yet). DefenseClaw is a customer endpoint product —
+// fresh Macs where the user hasn't opened Cursor / launched Claude Code
+// still need hooks wired at pkg-install time. Without a bootstrap the
+// guardian's per-target Install would refuse with
+// "hook config file missing" and enforcement never engages until the
+// user happens to launch each agent once.
+//
+// The stub bytes must be the minimal-valid config the agent will
+// accept unchanged. The connector's Setup() will subsequently patch
+// the DefenseClaw-owned entries in — the stub is only enough for the
+// installer's validateActivationSurfaces check to pass.
+//
+// Empty ContentPath signals "no bootstrap for this connector" — the
+// installer falls back to the strict "must exist" precondition.
+type HookConfigStub struct {
+	ContentPath string      // absolute path (must be one HookConfigPathsForConnector returned)
+	Contents    []byte      // minimal-valid config bytes
+	Mode        os.FileMode // file mode after write (typically 0o600)
+}
+
+// HookConfigBootstrap is the optional Connector-side hook. When a
+// connector implements it the installer calls DefaultHookConfigStub
+// under withOwnerCredentials, so the stub is written as the target
+// user with the correct uid/gid. Connectors that don't implement it
+// fall back to whatever DefaultHookConfigStubForConnector resolves in
+// the installer package (kept there so the three shipped connectors
+// don't each need a near-identical method).
+type HookConfigBootstrap interface {
+	DefaultHookConfigStub(opts SetupOpts) HookConfigStub
 }
 
 // HookCapability describes the actual lifecycle hook controls a connector

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -2584,6 +2584,12 @@ func (s *Sidecar) runGuardrail(ctx context.Context) error {
 			}
 		}
 		if guardianManagedLifecycle {
+			// See the multi-connector variant below for the design rationale
+			// on unverifiedEscalationAfter. Same 60s threshold, same
+			// once-per-transition emit pattern.
+			const unverifiedEscalationAfter = 60 * time.Second
+			unverifiedSince := time.Now()
+			escalated := false
 			publishHealth := func() {
 				covered, status := managedGuardianCoversConnectors(s.currentConfig().DataDir, []string{conn.Name()})
 				state := StateStarting
@@ -2606,6 +2612,25 @@ func (s *Sidecar) runGuardrail(ctx context.Context) error {
 					"lifecycle_manager":   "enterprise_hook_guardian",
 					"guardian_verified":   covered,
 				})
+				if covered {
+					if escalated {
+						emitLifecycle(ctx, "hook_guardian", "verified", map[string]string{
+							"connector": conn.Name(),
+							"unverified_seconds": fmt.Sprintf("%d",
+								int(time.Since(unverifiedSince).Seconds())),
+						})
+					}
+					unverifiedSince = time.Now()
+					escalated = false
+					return
+				}
+				if !escalated && time.Since(unverifiedSince) >= unverifiedEscalationAfter {
+					emitError(ctx, "hook_guardian", "unverified",
+						fmt.Sprintf("hook guardian has not authorized connector %q after %s (last status: %s)",
+							conn.Name(), unverifiedEscalationAfter, status),
+						nil)
+					escalated = true
+				}
 			}
 			publishHealth()
 			fmt.Fprintf(os.Stderr, "[guardrail] direct-upstream mode: %s policy_mode=%s enforcement=%t — awaiting enterprise hook guardian verification\n", conn.Name(), policyMode, enforcementEnabled)
@@ -3054,6 +3079,20 @@ func (s *Sidecar) runManagedEnterpriseMultiHookGuardrail(ctx context.Context, re
 	if hookEnforcement {
 		summary = fmt.Sprintf("managed enterprise hook enforcement (%d guardian-managed)", len(succeeded))
 	}
+	// The guardian-unverified state is silent by design at t+0 — a fresh
+	// install just installed hooks and the guardian's first reconcile tick
+	// (5-min interval on the shipped plist) has not yet run. But if we're
+	// STILL unverified after unverifiedEscalationAfter, that's not
+	// "starting up" any more, that's a broken install (missing
+	// protected_targets.json, guardian plist not loaded, etc.) — the
+	// silent-skip failure mode that shipped today.
+	//
+	// Emit exactly once when we cross the threshold, and again on
+	// recovery. gateway.jsonl + gateway.err.log + every configured OTel
+	// destination pick it up.
+	const unverifiedEscalationAfter = 60 * time.Second
+	unverifiedSince := time.Now()
+	escalated := false
 	publishHealth := func() {
 		covered, status := managedGuardianCoversConnectors(s.currentConfig().DataDir, succeeded)
 		state := StateStarting
@@ -3073,6 +3112,26 @@ func (s *Sidecar) runManagedEnterpriseMultiHookGuardrail(ctx context.Context, re
 			"lifecycle_manager":   "enterprise_hook_guardian",
 			"guardian_verified":   covered,
 		})
+		if covered {
+			if escalated {
+				emitLifecycle(ctx, "hook_guardian", "verified", map[string]string{
+					"connectors": strings.Join(succeeded, ","),
+					"unverified_seconds": fmt.Sprintf("%d",
+						int(time.Since(unverifiedSince).Seconds())),
+				})
+			}
+			unverifiedSince = time.Now()
+			escalated = false
+			return
+		}
+		if !escalated && time.Since(unverifiedSince) >= unverifiedEscalationAfter {
+			emitError(ctx, "hook_guardian", "unverified",
+				fmt.Sprintf("hook guardian has not authorized %d configured connector(s) after %s: %s (last status: %s)",
+					len(succeeded), unverifiedEscalationAfter,
+					strings.Join(succeeded, ","), status),
+				nil)
+			escalated = true
+		}
 	}
 	publishHealth()
 	fmt.Fprintf(os.Stderr, "[guardrail] managed_enterprise multi-connector hook mode: %d connector(s): %s — proxy port closed; enterprise hook guardian owns hook files\n", len(succeeded), strings.Join(succeeded, ", "))

--- a/internal/gatewaylog/error_codes.go
+++ b/internal/gatewaylog/error_codes.go
@@ -98,21 +98,21 @@ const (
 type Subsystem string
 
 const (
-	SubsystemSidecar        Subsystem = "sidecar"
-	SubsystemWatcher        Subsystem = "watcher"
-	SubsystemGateway        Subsystem = "gateway"
-	SubsystemScanner        Subsystem = "scanner"
-	SubsystemPolicy         Subsystem = "policy"
-	SubsystemGuardrail      Subsystem = "guardrail"
-	SubsystemAuth           Subsystem = "auth"
-	SubsystemConfig         Subsystem = "config"
-	SubsystemInspect        Subsystem = "inspect"
-	SubsystemApprovals      Subsystem = "approvals"
-	SubsystemSink           Subsystem = "sink"
-	SubsystemTelemetry      Subsystem = "telemetry"
-	SubsystemCorrelation    Subsystem = "correlation"
-	SubsystemStream         Subsystem = "stream"
-	SubsystemCiscoInspect   Subsystem = "cisco-inspect"
+	SubsystemSidecar      Subsystem = "sidecar"
+	SubsystemWatcher      Subsystem = "watcher"
+	SubsystemGateway      Subsystem = "gateway"
+	SubsystemScanner      Subsystem = "scanner"
+	SubsystemPolicy       Subsystem = "policy"
+	SubsystemGuardrail    Subsystem = "guardrail"
+	SubsystemAuth         Subsystem = "auth"
+	SubsystemConfig       Subsystem = "config"
+	SubsystemInspect      Subsystem = "inspect"
+	SubsystemApprovals    Subsystem = "approvals"
+	SubsystemSink         Subsystem = "sink"
+	SubsystemTelemetry    Subsystem = "telemetry"
+	SubsystemCorrelation  Subsystem = "correlation"
+	SubsystemStream       Subsystem = "stream"
+	SubsystemCiscoInspect Subsystem = "cisco-inspect"
 	// SubsystemCiscoAIDExport marks failures in the managed
 	// Cisco AI Defense telemetry (log) exporter path — the
 	// custom OTel LogExporter that POSTs to
@@ -187,6 +187,7 @@ func AllSubsystems() []Subsystem {
 		SubsystemCorrelation,
 		SubsystemStream,
 		SubsystemCiscoInspect,
+		SubsystemCiscoAIDExport,
 		SubsystemOpenShell,
 		SubsystemWebhook,
 		SubsystemQuarantine,

--- a/internal/gatewaylog/error_codes.go
+++ b/internal/gatewaylog/error_codes.go
@@ -113,6 +113,15 @@ const (
 	SubsystemCorrelation    Subsystem = "correlation"
 	SubsystemStream         Subsystem = "stream"
 	SubsystemCiscoInspect   Subsystem = "cisco-inspect"
+	// SubsystemCiscoAIDExport marks failures in the managed
+	// Cisco AI Defense telemetry (log) exporter path — the
+	// custom OTel LogExporter that POSTs to
+	// /api/v1/defenseclaw/events/ingest with a CMID bearer.
+	// Paired with ErrCodeExportFailed. Distinct from the
+	// generic "telemetry" subsystem so operators can alert
+	// specifically on managed-sink breakage (auth vs
+	// network vs ingest 5xx).
+	SubsystemCiscoAIDExport Subsystem = "cisco-aid-export"
 	SubsystemOpenShell      Subsystem = "openshell"
 	SubsystemWebhook        Subsystem = "webhook"
 	SubsystemQuarantine     Subsystem = "quarantine"

--- a/internal/ipc/notifier_bridge.go
+++ b/internal/ipc/notifier_bridge.go
@@ -18,6 +18,40 @@ import (
 	pb "github.com/defenseclaw/defenseclaw/proto/defenseclaw/secureclient/v1"
 )
 
+// ciscoAIDefenseCategoryOnlyPattern matches the "Cisco AI Defense:
+// <finding>[, <finding>...]" body that normalizeCiscoResponse
+// produces for block / would-block events. The list mixes two shapes:
+//   - Category labels (SCREAMING_SNAKE_CASE from the AID
+//     classification enum): SECURITY_VIOLATION, PRIVACY_VIOLATION,
+//     SAFETY_VIOLATION, PROMPT_INJECTION, ...
+//   - Individual rule names (Title Case): "Prompt Injection", "PII",
+//     "Malicious URL Detection", ...
+//
+// SecureClient's notification toast only has room for the high-level
+// category summary — the per-rule detail comes through the audit
+// event, not the toast. Strip the rule-name entries here so
+// downstream toast rendering shows a clean category-only line.
+//
+// The regex captures the "Cisco AI Defense:" prefix so we can rewrite
+// only that specific body shape and leave anything else (asset-policy
+// blocks, connector-native errors, service-state events) untouched.
+var ciscoAIDefenseBodyPrefix = regexp.MustCompile(`^Cisco AI Defense:\s*(.*)$`)
+
+// categoryTokenPattern is the "keep" filter applied to each
+// comma-separated element of the AID findings list. Category labels
+// are SCREAMING_SNAKE_CASE enum values that always contain at least
+// one underscore: SECURITY_VIOLATION, PRIVACY_VIOLATION,
+// SAFETY_VIOLATION, NONE_ATTACK_TECHNIQUE, LOW_SEVERITY, ...
+//
+// Rule-name entries fall into two shapes and both must be excluded:
+//   - Title Case with spaces: "Prompt Injection", "Malicious URL Detection"
+//   - Uppercase acronyms without underscores: PII, PHI, PCI, ABA, ITIN
+//
+// The underscore requirement lets us keep every real AID category
+// while dropping every rule-name shape. Any lowercase letter or
+// space is also disqualifying.
+var categoryTokenPattern = regexp.MustCompile(`^[A-Z][A-Z0-9]*(_[A-Z0-9]+)+$`)
+
 // paranoidSecretPatterns is a last-line defense against notifier call
 // sites leaking a secret into the notification body. The upstream
 // redactor should have handled everything, but the wire contract is
@@ -106,12 +140,19 @@ func composeTitle(o notifier.Observation) string {
 	return "DefenseClaw notification"
 }
 
-// composeBody starts from the OS notification body then sweeps once
-// more for any secret shape the upstream redactor missed. Each
-// pattern replaces its match with `<redacted>` so downstream UIs
-// display something meaningful without any risk of leakage. Empty
-// bodies keep an empty string — the contract allows optional bodies
-// but title is always required by the wire layer.
+// composeBody starts from the OS notification body then:
+//
+//  1. If the body is the "Cisco AI Defense: <mixed>" shape, drops
+//     every non-category token so SecureClient's toast surface only
+//     shows the high-level classification labels. Per-rule signals
+//     ("Prompt Injection", "PII", "Malicious URL Detection", ...)
+//     still land in the audit trail but are omitted from the toast
+//     text where they overflow the display.
+//  2. Sweeps for any secret shape the upstream redactor missed and
+//     replaces it with `<redacted>`.
+//
+// Empty bodies keep an empty string — the wire contract allows
+// optional bodies but title is always required.
 func composeBody(o notifier.Observation) string {
 	body := o.Notification.Body
 	if body == "" {
@@ -121,8 +162,52 @@ func composeBody(o notifier.Observation) string {
 		// even when the UI does not render subtitles.
 		body = o.Notification.Subtitle
 	}
+	body = compactAIDCategories(body)
 	for _, p := range paranoidSecretPatterns {
 		body = p.ReplaceAllString(body, "<redacted>")
 	}
 	return body
+}
+
+// compactAIDCategories rewrites a body of the form
+//
+//	Cisco AI Defense: SECURITY_VIOLATION, PRIVACY_VIOLATION, Prompt Injection, PII
+//
+// down to just the SCREAMING_SNAKE_CASE category tokens:
+//
+//	Cisco AI Defense: SECURITY_VIOLATION, PRIVACY_VIOLATION
+//
+// Any body that doesn't start with the "Cisco AI Defense:" prefix
+// passes through unchanged — asset-policy blocks, connector-native
+// errors, service-state events, and hook-guardian notifications all
+// have their own body shapes and shouldn't be touched here.
+//
+// If filtering leaves zero category tokens (e.g. AID returned only
+// rule-name findings), the original body is preserved so the toast
+// still carries some usable text — an empty "Cisco AI Defense:"
+// with nothing after would be worse than the mixed version.
+func compactAIDCategories(body string) string {
+	m := ciscoAIDefenseBodyPrefix.FindStringSubmatch(body)
+	if m == nil {
+		return body
+	}
+	tail := m[1]
+	if strings.TrimSpace(tail) == "" {
+		return body
+	}
+	parts := strings.Split(tail, ",")
+	kept := make([]string, 0, len(parts))
+	for _, p := range parts {
+		token := strings.TrimSpace(p)
+		if token == "" {
+			continue
+		}
+		if categoryTokenPattern.MatchString(token) {
+			kept = append(kept, token)
+		}
+	}
+	if len(kept) == 0 {
+		return body
+	}
+	return "Cisco AI Defense: " + strings.Join(kept, ", ")
 }

--- a/internal/ipc/notifier_bridge_compact_aid_test.go
+++ b/internal/ipc/notifier_bridge_compact_aid_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ipc
+
+import "testing"
+
+// TestCompactAIDCategories locks the SecureClient toast contract: the
+// IPC body should carry ONLY the SCREAMING_SNAKE_CASE category tokens
+// from a "Cisco AI Defense: ..." verdict body, dropping per-rule
+// signals (Title Case) so the toast doesn't overflow. The full
+// per-rule detail still reaches the audit sink via BlockEvent.Reason;
+// this transform only applies to the IPC-to-SecureClient wire.
+func TestCompactAIDCategories(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "mixed categories + rule names (the reported bug)",
+			in:   "Cisco AI Defense: SECURITY_VIOLATION, PRIVACY_VIOLATION, SAFETY_VIOLATION, Prompt Injection, PII",
+			want: "Cisco AI Defense: SECURITY_VIOLATION, PRIVACY_VIOLATION, SAFETY_VIOLATION",
+		},
+		{
+			name: "categories only — passes through",
+			in:   "Cisco AI Defense: SECURITY_VIOLATION, PRIVACY_VIOLATION",
+			want: "Cisco AI Defense: SECURITY_VIOLATION, PRIVACY_VIOLATION",
+		},
+		{
+			name: "single category + trailing whitespace tolerance",
+			in:   "Cisco AI Defense:  SAFETY_VIOLATION ",
+			want: "Cisco AI Defense: SAFETY_VIOLATION",
+		},
+		{
+			name: "rule names only — preserve original (better than empty)",
+			in:   "Cisco AI Defense: Prompt Injection, PII, Malicious URL Detection",
+			want: "Cisco AI Defense: Prompt Injection, PII, Malicious URL Detection",
+		},
+		{
+			name: "non-AID body (asset policy) — untouched",
+			in:   "Blocked because mcp:untrusted-server is not on the allowlist",
+			want: "Blocked because mcp:untrusted-server is not on the allowlist",
+		},
+		{
+			name: "non-AID body (hook guardian) — untouched",
+			in:   "hook guardian: connector cursor rejected shell execution",
+			want: "hook guardian: connector cursor rejected shell execution",
+		},
+		{
+			name: "empty body — untouched",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "AID prefix with empty tail — untouched",
+			in:   "Cisco AI Defense:",
+			want: "Cisco AI Defense:",
+		},
+		{
+			name: "extra whitespace inside comma list",
+			in:   "Cisco AI Defense:  SECURITY_VIOLATION,   PRIVACY_VIOLATION,  Custom Rule",
+			want: "Cisco AI Defense: SECURITY_VIOLATION, PRIVACY_VIOLATION",
+		},
+		{
+			name: "categories with digits are accepted (NONE_ATTACK_TECHNIQUE-style enum future-proofing)",
+			in:   "Cisco AI Defense: LOW_SEVERITY_2, SECURITY_VIOLATION, Prompt Injection",
+			want: "Cisco AI Defense: LOW_SEVERITY_2, SECURITY_VIOLATION",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := compactAIDCategories(tc.in)
+			if got != tc.want {
+				t.Fatalf("compactAIDCategories(%q):\n  got  %q\n  want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/telemetry/capacity_emit.go
+++ b/internal/telemetry/capacity_emit.go
@@ -6,6 +6,7 @@ package telemetry
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -71,7 +72,20 @@ func (p *Provider) emitPanicRecovered(ctx context.Context, subsystem gatewaylog.
 	p.EmitGatewayEvent(ev)
 }
 
-func (p *Provider) emitExporterFailure(ctx context.Context, exporter string) {
+// emitExporterFailure records a telemetry export failure with the full
+// error reason. Rate-limited to at most one emit per exporterErrLogMinInterval
+// so a persistent 401/network outage doesn't flood the gateway.jsonl surface.
+//
+// The `reason` string carries the actual underlying error text (e.g.
+// "cisco ai defense telemetry: ingest HTTP 401: token expired"). Callers
+// should pass err.Error() rather than a canned message — this event is
+// the operator's primary signal for "why is my telemetry not flowing?"
+// and hiding the cause makes triage impossible.
+//
+// Errors that start with "cisco ai defense telemetry:" are tagged with
+// the CiscoAIDLogExport subsystem so consumers can filter for the
+// managed AID sink specifically (auth vs network vs ingest 5xx).
+func (p *Provider) emitExporterFailure(ctx context.Context, exporter string, reason string) {
 	if p == nil || !p.Enabled() {
 		return
 	}
@@ -83,15 +97,30 @@ func (p *Provider) emitExporterFailure(ctx context.Context, exporter string) {
 	lastExporterErrLog = time.Now()
 	exporterErrLogMu.Unlock()
 
+	subsystem := string(gatewaylog.SubsystemTelemetry)
+	message := "OpenTelemetry export failed"
+	// The AID log exporter wraps every error with a stable prefix; use
+	// it to route failures to a dedicated subsystem so operators can
+	// alert on managed-sink-specific breakage.
+	if strings.HasPrefix(reason, "cisco ai defense telemetry:") {
+		subsystem = string(gatewaylog.SubsystemCiscoAIDExport)
+		message = "Cisco AI Defense telemetry export failed"
+	}
+	cause := reason
+	if cause == "" {
+		cause = exporter
+	} else if exporter != "" && !strings.Contains(cause, exporter) {
+		cause = exporter + ": " + cause
+	}
 	ev := gatewaylog.Event{
 		Timestamp: time.Now(),
 		EventType: gatewaylog.EventError,
 		Severity:  gatewaylog.SeverityMedium,
 		Error: &gatewaylog.ErrorPayload{
-			Subsystem: string(gatewaylog.SubsystemTelemetry),
+			Subsystem: subsystem,
 			Code:      string(gatewaylog.ErrCodeExportFailed),
-			Message:   "OpenTelemetry metric export failed",
-			Cause:     exporter,
+			Message:   message,
+			Cause:     cause,
 		},
 	}
 	p.EmitGatewayEvent(ev)

--- a/internal/telemetry/capacity_exporter.go
+++ b/internal/telemetry/capacity_exporter.go
@@ -28,12 +28,10 @@ func (w *metricExporterProbe) Aggregation(k sdkmetric.InstrumentKind) sdkmetric.
 func (w *metricExporterProbe) Export(ctx context.Context, rm *metricdata.ResourceMetrics) error {
 	err := w.inner.Export(ctx, rm)
 	if w.p != nil {
-		ctx2 := context.Background()
-		if err != nil {
-			w.p.RecordExporterHealth(ctx2, "otlp_metrics", ExporterHealthFailure)
-		} else {
-			w.p.RecordExporterHealth(ctx2, "otlp_metrics", ExporterHealthSuccess)
-		}
+		// Thread the underlying error into the export-failure emit so
+		// operators see WHY (401 vs network vs 5xx), not just a generic
+		// "export failed".
+		w.p.RecordExporterHealthErr(context.Background(), "otlp_metrics", err)
 	}
 	return err
 }

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -2558,8 +2558,21 @@ const (
 	ExporterHealthFailure ExporterHealthStatus = "failure"
 )
 
-// RecordExporterHealth records OTLP metric export outcomes and updates last-success timestamp.
+// RecordExporterHealth records OTLP metric export outcomes and updates
+// last-success timestamp. reason should be err.Error() on failure; empty
+// on success (unused). Silent-empty is still accepted so pre-existing
+// call sites keep compiling — see the wrapper helper below for the
+// error-carrying variant.
 func (p *Provider) RecordExporterHealth(ctx context.Context, exporter string, status ExporterHealthStatus) {
+	p.recordExporterHealthWithReason(ctx, exporter, status, "")
+}
+
+// recordExporterHealthWithReason is the internal variant that threads the
+// underlying error text into the gateway.jsonl / audit surface. New call
+// sites should use RecordExporterHealthErr below; direct users of the
+// legacy RecordExporterHealth still work but lose the cause on the
+// error emit.
+func (p *Provider) recordExporterHealthWithReason(ctx context.Context, exporter string, status ExporterHealthStatus, reason string) {
 	if !p.Enabled() || p.metrics == nil {
 		return
 	}
@@ -2568,13 +2581,27 @@ func (p *Provider) RecordExporterHealth(ctx context.Context, exporter string, st
 			attribute.String("exporter", exporter),
 			attribute.String("signal", "metrics"),
 		))
-		p.emitExporterFailure(ctx, exporter)
+		p.emitExporterFailure(ctx, exporter, reason)
 		return
 	}
 	p.metrics.exporterLastExportSec.Record(ctx, float64(time.Now().Unix()), metric.WithAttributes(
 		attribute.String("exporter", exporter),
 		attribute.String("signal", "metrics"),
 	))
+}
+
+// RecordExporterHealthErr is the error-carrying variant of
+// RecordExporterHealth. When err is non-nil the underlying error text is
+// threaded into the emitExporterFailure event so gateway.jsonl and the
+// audit surface see the actual cause (auth vs network vs 5xx) instead of
+// a generic "export failed" line. err==nil is treated as
+// ExporterHealthSuccess.
+func (p *Provider) RecordExporterHealthErr(ctx context.Context, exporter string, err error) {
+	if err == nil {
+		p.recordExporterHealthWithReason(ctx, exporter, ExporterHealthSuccess, "")
+		return
+	}
+	p.recordExporterHealthWithReason(ctx, exporter, ExporterHealthFailure, err.Error())
 }
 
 // RecordDestinationSpanRoute records bounded-cardinality routing decisions for

--- a/internal/telemetry/provider.go
+++ b/internal/telemetry/provider.go
@@ -334,7 +334,7 @@ func installOpenTelemetryGlobals(p *Provider) {
 				attribute.String("signal", "otel_sdk"),
 				attribute.String("reason", reason),
 			))
-		p.emitExporterFailure(context.Background(), "otel_sdk")
+		p.emitExporterFailure(context.Background(), "otel_sdk", reason)
 	}))
 }
 

--- a/packaging/launchd/com.cisco.secureclient.defenseclaw.hook-enumerator.plist
+++ b/packaging/launchd/com.cisco.secureclient.defenseclaw.hook-enumerator.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.cisco.secureclient.defenseclaw.hook-enumerator</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/opt/cisco/secureclient/defenseclaw/lib/render-targets.sh</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/opt/cisco/secureclient/defenseclaw</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>SUPPORT_DIR</key>
+    <string>/opt/cisco/secureclient/defenseclaw</string>
+    <key>DEFENSECLAW_CONFIG</key>
+    <string>/opt/cisco/secureclient/defenseclaw/etc/config.yaml</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>300</integer>
+  <key>Umask</key>
+  <integer>63</integer>
+  <key>StandardOutPath</key>
+  <string>/Library/Logs/Cisco/SecureClient/DefenseClaw/hook-enumerator.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Library/Logs/Cisco/SecureClient/DefenseClaw/hook-enumerator.err.log</string>
+</dict>
+</plist>

--- a/packaging/launchd/com.cisco.secureclient.defenseclaw.hook-guardian.plist
+++ b/packaging/launchd/com.cisco.secureclient.defenseclaw.hook-guardian.plist
@@ -4,14 +4,36 @@
 <dict>
   <key>Label</key>
   <string>com.cisco.secureclient.defenseclaw.hook-guardian</string>
+  <!--
+    Runs `enterprise hooks watch` (not `reconcile`) so per-user hook
+    tampering (delete, rewrite, chmod) is detected via fsnotify and
+    healed within ~1 s of the event.
+
+    --interval 60s is the periodic backstop for tamper vectors the
+    fsnotify path intentionally can't catch:
+      - SharedWriter Write/Chmod (native agent configs — Codex rewrites
+        config.toml constantly, so we only watch Remove/Rename on it).
+      - Generic hook helpers (_hardening.sh, inspect-*.sh) which are
+        excluded from the watch allowlist because per-connector template
+        rendering makes them rewrite-storm on every reconcile.
+    Tightening from 5m to 60s drops worst-case bypass detection from
+    ~5 min to ~1 min at no additional resource cost — same long-running
+    process, one extra Timer tick per minute.
+
+    `watch` is long-running, so `StartInterval` is intentionally absent
+    (it would pointlessly relaunch the process); `KeepAlive` below is
+    what restarts the daemon if it exits.
+  -->
   <key>ProgramArguments</key>
   <array>
     <string>/opt/cisco/secureclient/defenseclaw/bin/defenseclaw-gateway</string>
     <string>enterprise</string>
     <string>hooks</string>
-    <string>reconcile</string>
+    <string>watch</string>
     <string>--manifest</string>
     <string>/opt/cisco/secureclient/defenseclaw/hook-guardian/targets.yaml</string>
+    <string>--interval</string>
+    <string>60s</string>
   </array>
   <key>WorkingDirectory</key>
   <string>/opt/cisco/secureclient/defenseclaw</string>
@@ -28,8 +50,14 @@
   </dict>
   <key>RunAtLoad</key>
   <true/>
-  <key>StartInterval</key>
-  <integer>300</integer>
+  <!--
+    KeepAlive (not StartInterval) is the right restart policy for the
+    long-running `watch` mode. If the process exits (crash, OOM, panic),
+    launchd relaunches it immediately. A stale periodic StartInterval
+    here would just spawn duplicate long-running processes every 5 min.
+  -->
+  <key>KeepAlive</key>
+  <true/>
   <key>Umask</key>
   <integer>63</integer>
   <key>StandardOutPath</key>

--- a/packaging/launchd/com.cisco.secureclient.defenseclaw.hook-guardian.plist
+++ b/packaging/launchd/com.cisco.secureclient.defenseclaw.hook-guardian.plist
@@ -9,16 +9,16 @@
     tampering (delete, rewrite, chmod) is detected via fsnotify and
     healed within ~1 s of the event.
 
-    --interval 60s is the periodic backstop for tamper vectors the
-    fsnotify path intentionally can't catch:
-      - SharedWriter Write/Chmod (native agent configs — Codex rewrites
+    The 60s ProgramArgument below is the periodic backstop interval
+    for tamper vectors the fsnotify path intentionally can't catch:
+      SharedWriter Write/Chmod (native agent configs; Codex rewrites
         config.toml constantly, so we only watch Remove/Rename on it).
-      - Generic hook helpers (_hardening.sh, inspect-*.sh) which are
+      Generic hook helpers (_hardening.sh, inspect-*.sh) which are
         excluded from the watch allowlist because per-connector template
         rendering makes them rewrite-storm on every reconcile.
     Tightening from 5m to 60s drops worst-case bypass detection from
-    ~5 min to ~1 min at no additional resource cost — same long-running
-    process, one extra Timer tick per minute.
+    ~5 min to ~1 min at no additional resource cost (same long-running
+    process, one extra Timer tick per minute).
 
     `watch` is long-running, so `StartInterval` is intentionally absent
     (it would pointlessly relaunch the process); `KeepAlive` below is

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -456,8 +456,11 @@ fi
 # Per-user hook wiring is no longer scoped to a single TARGET_USER: the
 # installer renders a machine-wide `targets.yaml` covering every eligible
 # local user, and the hook-guardian LaunchDaemon reconciles that manifest
-# every 5 minutes (fresh users after install are picked up by the
-# hook-enumerator daemon that re-renders the same manifest). --user is
+# reactively via fsnotify — user tampering with a hook config or hook
+# script under a watched dir triggers a repair within ~1 s. A 5 min
+# periodic reconcile is retained as a backstop for missed events. Fresh
+# users added after install are picked up by the hook-enumerator daemon
+# that re-renders the same manifest on its own 5 min tick. --user is
 # preserved as a backward-compat no-op so operators / CI that still pass
 # it don't error out; --agent-version is likewise ignored (each user's
 # agent version is discovered per-connector by installer_lib.sh at
@@ -706,7 +709,8 @@ install_file_no_replace "${PLIST_SRC}" "${PLIST_DST}" root wheel 0644
 
 # Guardian + enumerator plists: the two subsystems together do all
 # per-user hook wiring (enumerator re-renders targets.yaml on a 5 min
-# tick; guardian reconciles the manifest on its own 5 min tick).
+# tick; guardian is long-running under `enterprise hooks watch` — fsnotify
+# on every per-user hook artifact with a 5-min periodic backstop).
 [[ -f "${GUARDIAN_PLIST_SRC}" ]] \
   || die "hook-guardian plist source not found (expected ${SCRIPT_DIR}/com.cisco.secureclient.defenseclaw.hook-guardian.plist)"
 [[ -f "${ENUMERATOR_PLIST_SRC}" ]] \
@@ -762,12 +766,15 @@ fi
 # one user even when populated. The customer-shipping pkg therefore
 # wired hooks for nobody on a multi-user Mac.
 #
-# The current flow uses the hook-guardian LaunchDaemon (5-min reconcile,
-# already shipped) with a machine-wide `targets.yaml` manifest that lists
-# every eligible local user × requested connector. A companion
-# hook-enumerator LaunchDaemon (5-min tick) re-renders the manifest so
-# users provisioned AFTER install are picked up on the next reconcile
-# without any per-user login-time action.
+# The current flow uses the hook-guardian LaunchDaemon (long-running
+# `enterprise hooks watch`: fsnotify on every per-user hook artifact +
+# 5-min backstop reconcile) with a machine-wide `targets.yaml` manifest
+# that lists every eligible local user × requested connector. A
+# companion hook-enumerator LaunchDaemon (5-min tick) re-renders the
+# manifest so users provisioned AFTER install are picked up on the next
+# reconcile without any per-user login-time action. User tampering with
+# a hook config or the per-user hook scripts is repaired within ~1 s of
+# the fsnotify event.
 #
 # Bootstrapping order:
 #   1. Render an initial targets.yaml so the guardian's RunAtLoad has
@@ -834,9 +841,10 @@ if [[ "${SKIP_CONNECTOR}" != "true" ]]; then
   launchctl enable "system/${GUARDIAN_LAUNCHD_LABEL}"
 
   # Kick both daemons so the first reconcile happens immediately rather
-  # than at the next 5-min tick (RunAtLoad already fired, but kickstart
-  # is a defence-in-depth in case the daemon was already loaded from a
-  # previous state).
+  # than at the next tick (RunAtLoad already fired, but kickstart is a
+  # defence-in-depth in case the daemon was already loaded from a
+  # previous state). For the guardian this also forces re-registration
+  # of the fsnotify watch set against the freshly rendered manifest.
   log "kickstarting hook-enumerator + hook-guardian for immediate first pass"
   launchctl kickstart -k "system/${ENUMERATOR_LAUNCHD_LABEL}" 2>/dev/null || true
   launchctl kickstart -k "system/${GUARDIAN_LAUNCHD_LABEL}"   2>/dev/null || true

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -190,32 +190,15 @@ log()  { printf '[install] %s\n' "$*"; }
 warn() { printf '[install] WARN: %s\n' "$*" >&2; }
 die()  { printf '[install] ERROR: %s\n' "$*" >&2; exit 1; }
 
-# Persistent log sink. Under `.pkg` postinstall / installd, the caller's
-# stderr is closed and every warn/die from install.sh disappears — that
-# is exactly what let the "no target user; skipping per-user hook wiring"
-# silent-skip bug ship undetected. Mirror both streams to a file beside
-# gateway.log so admins have a durable record of what the installer did.
-#
-# Requires root to create /Library/Logs/... — non-root invocations (tests,
-# --help) skip the tee. The file is root:wheel 0640 so it never becomes a
-# reader-writable side channel.
-if [[ $EUID -eq 0 ]] && [[ "${DC_INSTALLER_SKIP_INSTALL_LOG:-}" != "1" ]]; then
-  _install_log_dir="/Library/Logs/Cisco/SecureClient/DefenseClaw"
-  _install_log_path="${_install_log_dir}/install.log"
-  if mkdir -p "${_install_log_dir}" 2>/dev/null; then
-    # Create/touch the file with restrictive perms BEFORE tee opens it for
-    # append. Ownership is set explicitly so a pre-existing world-readable
-    # file left by a bad install doesn't leak WARN payloads.
-    touch "${_install_log_path}" 2>/dev/null || true
-    chown root:wheel "${_install_log_path}" 2>/dev/null || true
-    chmod 0640       "${_install_log_path}" 2>/dev/null || true
-    printf '\n===== install.sh start %s (argv: %s) =====\n' "$(date -u +%FT%TZ)" "$*" \
-      >> "${_install_log_path}" 2>/dev/null || true
-    exec  > >(tee -a "${_install_log_path}")
-    exec 2> >(tee -a "${_install_log_path}" >&2)
-  fi
-  unset _install_log_dir _install_log_path
-fi
+# The persistent install.log sink is set up LATER (after the fresh-host
+# preflight passes and after LOGS_DIR has been created by
+# create_install_directory_no_replace). Creating LOGS_DIR before the
+# preflight would trip the "install directory appeared after fresh-host
+# preflight" check on the very next line, and creating install.log
+# before the preflight also required a special-case exemption that made
+# the preflight harder to reason about. See the "install.log sink" block
+# further down for the delayed setup.
+:
 
 INSTALL_TEMP_FILES=()
 cleanup_install_temporaries() {
@@ -539,21 +522,6 @@ if [[ "${DC_INSTALLER_SKIP_ROOT_CHECK:-}" != "1" ]]; then
 fi
 for _marker in "${_existing_install_markers[@]}"; do
   if [[ -e "${_marker}" || -L "${_marker}" ]]; then
-    # Special case: LOGS_DIR containing ONLY install.log is a benign
-    # leftover from a previous install session's log-sink tee (we open
-    # install.log for append right after the euid check, BEFORE this
-    # preflight fires). A real broken install leaves gateway.log +
-    # gateway.err.log + hook-guardian.log + hook-enumerator.log too.
-    # Treat "only install.log survived the previous uninstall" as
-    # fresh-host, not "existing install detected".
-    if [[ "${_marker}" == "${LOGS_DIR}" ]] && [[ -d "${_marker}" ]]; then
-      _residual="$(find "${_marker}" -mindepth 1 -maxdepth 1 ! -name install.log -print -quit 2>/dev/null)"
-      if [[ -z "${_residual}" ]]; then
-        unset _residual
-        continue
-      fi
-      unset _residual
-    fi
     die "existing DefenseClaw installation detected at ${_marker}; no changes were made. This installer is fresh-install-only. Use the release-owned staged upgrade path for that deployment; if no managed-enterprise staged upgrader is published, remain on the current version and contact the deployment owner. Do not uninstall or overwrite state to force the upgrade."
   fi
 done
@@ -676,6 +644,36 @@ for parent in /Library/Logs /Library/Logs/Cisco /Library/Logs/Cisco/SecureClient
   ensure_shared_install_parent "${parent}"
 done
 create_install_directory_no_replace "${LOGS_DIR}" root wheel 0750
+
+# install.log sink — mirrored copy of every stdout / stderr line from
+# this point onward, beside gateway.log. Under `.pkg` postinstall /
+# installd the caller's stderr is closed and warn/die messages would
+# otherwise disappear; the tee gives admins a durable per-session
+# record of what the installer did.
+#
+# Only fires when running as root under a real install (we already
+# passed the fresh-host preflight above). Non-root test invocations and
+# DC_INSTALLER_SKIP_INSTALL_LOG=1 (bundle-fixture tests) leave the sink
+# off. File is root:wheel 0640 so it never becomes a
+# reader-writable side channel.
+#
+# NOT set up earlier: creating LOGS_DIR before the preflight would trip
+# "install directory appeared after fresh-host preflight" and creating
+# install.log there would require an ugly special case in the marker
+# loop. Uninstall wipes LOGS_DIR wholesale on --purge, which cleanly
+# removes install.log too — no persistence across install/uninstall
+# cycles is desired.
+if [[ "${DC_INSTALLER_SKIP_INSTALL_LOG:-}" != "1" ]]; then
+  _install_log_path="${LOGS_DIR}/install.log"
+  touch "${_install_log_path}" 2>/dev/null || true
+  chown root:wheel "${_install_log_path}" 2>/dev/null || true
+  chmod 0640       "${_install_log_path}" 2>/dev/null || true
+  printf '===== install.sh start %s (argv: %s) =====\n' "$(date -u +%FT%TZ)" "$*" \
+    >> "${_install_log_path}" 2>/dev/null || true
+  exec  > >(tee -a "${_install_log_path}")
+  exec 2> >(tee -a "${_install_log_path}" >&2)
+  unset _install_log_path
+fi
 
 CONFIG_PATH="${CONFIG_DIR}/config.yaml"
 [[ ! -e "${CONFIG_PATH}" && ! -L "${CONFIG_PATH}" ]] \

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -190,6 +190,33 @@ log()  { printf '[install] %s\n' "$*"; }
 warn() { printf '[install] WARN: %s\n' "$*" >&2; }
 die()  { printf '[install] ERROR: %s\n' "$*" >&2; exit 1; }
 
+# Persistent log sink. Under `.pkg` postinstall / installd, the caller's
+# stderr is closed and every warn/die from install.sh disappears — that
+# is exactly what let the "no target user; skipping per-user hook wiring"
+# silent-skip bug ship undetected. Mirror both streams to a file beside
+# gateway.log so admins have a durable record of what the installer did.
+#
+# Requires root to create /Library/Logs/... — non-root invocations (tests,
+# --help) skip the tee. The file is root:wheel 0640 so it never becomes a
+# reader-writable side channel.
+if [[ $EUID -eq 0 ]] && [[ "${DC_INSTALLER_SKIP_INSTALL_LOG:-}" != "1" ]]; then
+  _install_log_dir="/Library/Logs/Cisco/SecureClient/DefenseClaw"
+  _install_log_path="${_install_log_dir}/install.log"
+  if mkdir -p "${_install_log_dir}" 2>/dev/null; then
+    # Create/touch the file with restrictive perms BEFORE tee opens it for
+    # append. Ownership is set explicitly so a pre-existing world-readable
+    # file left by a bad install doesn't leak WARN payloads.
+    touch "${_install_log_path}" 2>/dev/null || true
+    chown root:wheel "${_install_log_path}" 2>/dev/null || true
+    chmod 0640       "${_install_log_path}" 2>/dev/null || true
+    printf '\n===== install.sh start %s (argv: %s) =====\n' "$(date -u +%FT%TZ)" "$*" \
+      >> "${_install_log_path}" 2>/dev/null || true
+    exec  > >(tee -a "${_install_log_path}")
+    exec 2> >(tee -a "${_install_log_path}" >&2)
+  fi
+  unset _install_log_dir _install_log_path
+fi
+
 INSTALL_TEMP_FILES=()
 cleanup_install_temporaries() {
   local path
@@ -306,6 +333,12 @@ Per-user hook wiring:
   --user USER               Target macOS user (default: \$SUDO_USER)
   --agent-version VERSION   Override agent version (auto-detected if omitted)
   --skip-connector          Don't wire user-space hooks (gateway only)
+  --allow-empty-users       Proceed even when no eligible local users are
+                            found. Only pass this on lab / demo boxes where
+                            zero user coverage is intentional; production
+                            installs should fail loud (default) so admins
+                            notice broken enumeration before the guardian
+                            silently ships a zero-target manifest.
 
   -h, --help                Show this help
 
@@ -319,6 +352,7 @@ CONNECTOR="${DEFAULT_CONNECTOR}"
 API_PORT="${DEFAULT_API_PORT}"
 AID_ENV="${DEFAULT_ENV}"
 OVERRIDE_ENDPOINT=""
+ALLOW_EMPTY_USERS="false"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -335,6 +369,7 @@ while [[ $# -gt 0 ]]; do
     --user)             TARGET_USER="${2:?}"; shift 2;;
     --agent-version)    AGENT_VERSION="${2:?}"; shift 2;;
     --skip-connector)   SKIP_CONNECTOR="true"; shift;;
+    --allow-empty-users) ALLOW_EMPTY_USERS="true"; shift;;
     -h|--help)          usage; exit 0;;
     *) die "unknown flag: $1 (try --help)";;
   esac
@@ -732,11 +767,20 @@ fi
 
 if [[ "${SKIP_CONNECTOR}" != "true" ]]; then
   log "enumerating eligible local users"
-  USER_LINES="$(enumerate_local_users || true)"
+  # DC_INSTALLER_ENUMERATE_VERBOSE=1 makes enumerate_local_users emit a
+  # WARN for every user it drops with the specific filter reason (system
+  # account, home not under /Users, mode bits, etc.). Piped into
+  # install.log via the tee at the top of this script, so admins can
+  # diagnose "why isn't user X in targets.yaml?" after the fact.
+  USER_LINES="$(DC_INSTALLER_ENUMERATE_VERBOSE=1 enumerate_local_users || true)"
   USER_COUNT="$(printf '%s\n' "${USER_LINES}" | grep -c . || true)"
   if [[ -z "${USER_LINES}" ]]; then
-    warn "no eligible local users detected on this host"
-    warn "  hooks will be wired for users that log in later once the enumerator's next 5-min tick runs"
+    if [[ "${ALLOW_EMPTY_USERS}" == "true" ]]; then
+      warn "no eligible local users detected on this host (--allow-empty-users given)"
+      warn "  hooks will be wired for users that log in later once the enumerator's next 5-min tick runs"
+    else
+      die "no eligible local users detected on this host — refusing to install with a zero-target hook-guardian manifest. If this box legitimately has no local users (lab / demo), rerun with --allow-empty-users to proceed; otherwise investigate why enumerate_local_users returned empty (check dscl, home dir perms, /Users layout)."
+    fi
   else
     log "  found ${USER_COUNT} eligible user(s):"
     while IFS=: read -r _u _uid _gid _home; do
@@ -751,6 +795,16 @@ if [[ "${SKIP_CONNECTOR}" != "true" ]]; then
     || die "could not reserve a private manifest staging file"
   INSTALL_TEMP_FILES+=("${MANIFEST_TMP}")
   render_targets_manifest "${SUPPORT_DIR}" "${CONNECTOR}" "${USER_LINES}" > "${MANIFEST_TMP}"
+  # Belt-and-suspenders: catch the case where user_lines was non-empty
+  # AND the connector CSV was non-empty but the rendered cross product
+  # still produced zero targets (e.g. every connector was filtered out
+  # as unsupported). Without this check the guardian would happily
+  # reconcile a "0 targets, all ok" manifest and the daemon would look
+  # green while enforcing nothing.
+  MANIFEST_TARGETS="$(grep -c '^  - user:' "${MANIFEST_TMP}" || true)"
+  if [[ "${MANIFEST_TARGETS}" == "0" ]] && [[ -n "${USER_LINES}" ]] && [[ "${ALLOW_EMPTY_USERS}" != "true" ]]; then
+    die "rendered hook-guardian manifest has zero targets despite ${USER_COUNT} eligible user(s) and connectors=${CONNECTOR} — every connector may be unsupported (only codex/claudecode/cursor auto-wire today). Fix --connector or pass --allow-empty-users to proceed anyway."
+  fi
   chown root:wheel "${MANIFEST_TMP}"
   chmod 0640 "${MANIFEST_TMP}"
   ln "${MANIFEST_TMP}" "${GUARDIAN_MANIFEST_PATH}" \

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -79,6 +79,60 @@ for _candidate_origin in \
   fi
 done
 unset _candidate _candidate_origin
+
+# Guardian plist source lookup — same order as the gateway plist above,
+# minus the operator-override tier (there is no user-facing --guardian-plist
+# flag; the guardian is a managed subsystem shipped in the bundle).
+GUARDIAN_PLIST_SRC=""
+for _candidate in \
+  "${SCRIPT_DIR}/com.cisco.secureclient.defenseclaw.hook-guardian.plist" \
+  "${REPO_ROOT}/packaging/launchd/com.cisco.secureclient.defenseclaw.hook-guardian.plist"; do
+  if [[ -f "${_candidate}" ]]; then
+    GUARDIAN_PLIST_SRC="${_candidate}"
+    break
+  fi
+done
+unset _candidate
+
+# Enumerator plist source — the re-render-users-manifest daemon.
+ENUMERATOR_PLIST_SRC=""
+for _candidate in \
+  "${SCRIPT_DIR}/com.cisco.secureclient.defenseclaw.hook-enumerator.plist" \
+  "${REPO_ROOT}/packaging/launchd/com.cisco.secureclient.defenseclaw.hook-enumerator.plist"; do
+  if [[ -f "${_candidate}" ]]; then
+    ENUMERATOR_PLIST_SRC="${_candidate}"
+    break
+  fi
+done
+unset _candidate
+
+# render-targets.sh source — the per-tick manifest renderer.
+RENDER_TARGETS_SRC=""
+for _candidate in \
+  "${SCRIPT_DIR}/lib/render-targets.sh" \
+  "${SCRIPT_DIR}/render-targets.sh" \
+  "${REPO_ROOT}/packaging/macos/lib/render-targets.sh"; do
+  if [[ -f "${_candidate}" ]]; then
+    RENDER_TARGETS_SRC="${_candidate}"
+    break
+  fi
+done
+unset _candidate
+
+# Library source — installer_lib.sh is copied into the managed tree so
+# render-targets.sh (launchd-invoked) can source it independently of the
+# repo/bundle layout.
+INSTALLER_LIB_SRC=""
+for _candidate in \
+  "${SCRIPT_DIR}/lib/installer_lib.sh" \
+  "${REPO_ROOT}/packaging/macos/lib/installer_lib.sh"; do
+  if [[ -f "${_candidate}" ]]; then
+    INSTALLER_LIB_SRC="${_candidate}"
+    break
+  fi
+done
+unset _candidate
+
 SKIP_BUILD="false"
 SKIP_LAUNCHD="false"
 SKIP_CONNECTOR="false"
@@ -96,7 +150,13 @@ PLIST_DST="/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.plist"
 LAUNCHD_LABEL="com.cisco.secureclient.defenseclaw"
 GUARDIAN_PLIST_DST="/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.hook-guardian.plist"
 GUARDIAN_LAUNCHD_LABEL="com.cisco.secureclient.defenseclaw.hook-guardian"
+ENUMERATOR_PLIST_DST="/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.hook-enumerator.plist"
+ENUMERATOR_LAUNCHD_LABEL="com.cisco.secureclient.defenseclaw.hook-enumerator"
 GATEWAY_BIN="${INSTALL_PREFIX}/bin/defenseclaw-gateway"
+RENDER_TARGETS_BIN="${INSTALL_PREFIX}/lib/render-targets.sh"
+INSTALLER_LIB_DST="${INSTALL_PREFIX}/lib/installer_lib.sh"
+GUARDIAN_MANIFEST_DIR="${INSTALL_PREFIX}/hook-guardian"
+GUARDIAN_MANIFEST_PATH="${GUARDIAN_MANIFEST_DIR}/targets.yaml"
 
 # Legacy paths + label from pre-Cisco-path DefenseClaw installs. These
 # are only referenced by uninstall.sh for its migration sweep; install.sh
@@ -375,18 +435,22 @@ if [[ "${DC_INSTALLER_SKIP_PLIST_VALIDATION:-}" != "1" ]]; then
   unset _plist_stat _plist_owner _plist_mode
 fi
 
-# Resolve target user (default: the user who invoked sudo)
-if [[ -z "${TARGET_USER}" ]]; then
-  TARGET_USER="${SUDO_USER:-}"
-fi
-if [[ -z "${TARGET_USER}" && "${SKIP_CONNECTOR}" != "true" ]]; then
-  warn "no target user (run with sudo from a user shell, or pass --user); skipping per-user hook wiring"
-  SKIP_CONNECTOR="true"
-fi
+# Per-user hook wiring is no longer scoped to a single TARGET_USER: the
+# installer renders a machine-wide `targets.yaml` covering every eligible
+# local user, and the hook-guardian LaunchDaemon reconciles that manifest
+# every 5 minutes (fresh users after install are picked up by the
+# hook-enumerator daemon that re-renders the same manifest). --user is
+# preserved as a backward-compat no-op so operators / CI that still pass
+# it don't error out; --agent-version is likewise ignored (each user's
+# agent version is discovered per-connector by installer_lib.sh at
+# manifest-render time).
 if [[ -n "${TARGET_USER}" ]]; then
-  TARGET_HOME="$(dscl . -read "/Users/${TARGET_USER}" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
-  [[ -n "${TARGET_HOME}" && -d "${TARGET_HOME}" ]] || \
-    die "could not resolve home for --user ${TARGET_USER}"
+  warn "--user ${TARGET_USER} is ignored: hook wiring is now machine-wide via the hook guardian"
+  TARGET_USER=""
+fi
+if [[ -n "${AGENT_VERSION}" ]]; then
+  warn "--agent-version ${AGENT_VERSION} is ignored: per-user versions are discovered by the guardian at each tick"
+  AGENT_VERSION=""
 fi
 
 # This bundle is a fresh-install surface, not an updater.  Refuse an
@@ -399,6 +463,7 @@ _existing_install_markers=(
   "${LOGS_DIR}"
   "${PLIST_DST}"
   "${GUARDIAN_PLIST_DST}"
+  "${ENUMERATOR_PLIST_DST}"
   "${LEGACY_INSTALL_PREFIX}"
   "${LEGACY_SUPPORT_DIR}"
   "${LEGACY_LOGS_DIR}"
@@ -445,6 +510,7 @@ done
 for _label in \
   "${LAUNCHD_LABEL}" \
   "${GUARDIAN_LAUNCHD_LABEL}" \
+  "${ENUMERATOR_LAUNCHD_LABEL}" \
   "${LEGACY_LAUNCHD_LABEL}" \
   "${LEGACY_GUARDIAN_LAUNCHD_LABEL}"; do
   if launchctl print "system/${_label}" >/dev/null 2>&1; then
@@ -491,6 +557,7 @@ fi
 for _lbl_plist in \
   "${LAUNCHD_LABEL}:${PLIST_DST}" \
   "${GUARDIAN_LAUNCHD_LABEL}:${GUARDIAN_PLIST_DST}" \
+  "${ENUMERATOR_LAUNCHD_LABEL}:${ENUMERATOR_PLIST_DST}" \
   "${LEGACY_LAUNCHD_LABEL}:${LEGACY_PLIST_DST}" \
   "${LEGACY_GUARDIAN_LAUNCHD_LABEL}:${LEGACY_GUARDIAN_PLIST_DST}"; do
   _lbl="${_lbl_plist%%:*}"
@@ -535,6 +602,21 @@ GUARDIAN_AUTH_DIR="${SUPPORT_DIR}/hook-guardian-state"
 create_install_directory_no_replace "${CONFIG_DIR}" root wheel 0755
 create_install_directory_no_replace "${RUNTIME_DIR}" root wheel 0750
 create_install_directory_no_replace "${GUARDIAN_AUTH_DIR}" root wheel 0750
+# Multi-user hook wiring: the hook-guardian LaunchDaemon reads its
+# per-tick manifest from ${GUARDIAN_MANIFEST_DIR}/targets.yaml. Creating
+# the directory unconditionally keeps the guardian's LoadManifest happy
+# even if the enumerator hasn't run yet.
+create_install_directory_no_replace "${GUARDIAN_MANIFEST_DIR}" root wheel 0755
+create_install_directory_no_replace "${INSTALL_PREFIX}/lib" root wheel 0755
+# render-targets.sh is invoked by the hook-enumerator LaunchDaemon and
+# sources installer_lib.sh from a fixed path; both must land under the
+# managed tree so the daemon doesn't need to see the bundle layout.
+[[ -f "${RENDER_TARGETS_SRC}" ]] \
+  || die "render-targets.sh source not found (expected ${SCRIPT_DIR}/lib/render-targets.sh)"
+[[ -f "${INSTALLER_LIB_SRC}" ]] \
+  || die "installer_lib.sh source not found (expected ${SCRIPT_DIR}/lib/installer_lib.sh)"
+install_file_no_replace "${RENDER_TARGETS_SRC}" "${RENDER_TARGETS_BIN}" root wheel 0755
+install_file_no_replace "${INSTALLER_LIB_SRC}"  "${INSTALLER_LIB_DST}" root wheel 0644
 # LOGS_DIR — the /Library/Logs/Cisco/ and SecureClient/ ancestors may
 # be pre-existing and shared with other Cisco software. Same reasoning
 # as /opt/cisco above: only create them (with our default perms) when
@@ -574,6 +656,18 @@ chown -R root:wheel "${RUNTIME_DIR}" "${LOGS_DIR}"
 log "installing LaunchDaemon plist -> ${PLIST_DST}"
 install_file_no_replace "${PLIST_SRC}" "${PLIST_DST}" root wheel 0644
 
+# Guardian + enumerator plists: the two subsystems together do all
+# per-user hook wiring (enumerator re-renders targets.yaml on a 5 min
+# tick; guardian reconciles the manifest on its own 5 min tick).
+[[ -f "${GUARDIAN_PLIST_SRC}" ]] \
+  || die "hook-guardian plist source not found (expected ${SCRIPT_DIR}/com.cisco.secureclient.defenseclaw.hook-guardian.plist)"
+[[ -f "${ENUMERATOR_PLIST_SRC}" ]] \
+  || die "hook-enumerator plist source not found (expected ${SCRIPT_DIR}/com.cisco.secureclient.defenseclaw.hook-enumerator.plist)"
+log "installing hook-guardian plist -> ${GUARDIAN_PLIST_DST}"
+install_file_no_replace "${GUARDIAN_PLIST_SRC}" "${GUARDIAN_PLIST_DST}" root wheel 0644
+log "installing hook-enumerator plist -> ${ENUMERATOR_PLIST_DST}"
+install_file_no_replace "${ENUMERATOR_PLIST_SRC}" "${ENUMERATOR_PLIST_DST}" root wheel 0644
+
 # The shipped plist deliberately omits UserName/GroupName so the daemon
 # runs as root (uid 0). If a stale plist from a pre-root DefenseClaw
 # install left those keys behind on this host, strip them now so the
@@ -612,126 +706,73 @@ if ! wait_for_launchd_running; then
   die "${LAUNCHD_LABEL} failed to start; see ${LOGS_DIR}/gateway.err.log"
 fi
 
-# ---- per-user hook wiring ----------------------------------------------
+# ---- per-user hook wiring (multi-user, via hook guardian) --------------
+#
+# The pre-2026.7.3 flow ran the per-connector CLI subcommand inline here
+# for a single --user or $SUDO_USER, which silently no-op'd whenever
+# $SUDO_USER was empty (e.g. under a pkg postinstall) and only covered
+# one user even when populated. The customer-shipping pkg therefore
+# wired hooks for nobody on a multi-user Mac.
+#
+# The current flow uses the hook-guardian LaunchDaemon (5-min reconcile,
+# already shipped) with a machine-wide `targets.yaml` manifest that lists
+# every eligible local user × requested connector. A companion
+# hook-enumerator LaunchDaemon (5-min tick) re-renders the manifest so
+# users provisioned AFTER install are picked up on the next reconcile
+# without any per-user login-time action.
+#
+# Bootstrapping order:
+#   1. Render an initial targets.yaml so the guardian's RunAtLoad has
+#      real content to reconcile (avoids a 5-min delay before the first
+#      user's hooks land on a demo box).
+#   2. Bootstrap the hook-enumerator daemon (RunAtLoad will re-render,
+#      but our initial file is already good).
+#   3. Bootstrap the hook-guardian daemon (RunAtLoad triggers immediate
+#      reconcile — hooks land within seconds on the eligible users).
 
 if [[ "${SKIP_CONNECTOR}" != "true" ]]; then
-  log "wiring user-space hooks for ${TARGET_USER} (${CONNECTORS[*]})"
-  TARGET_UID="$(id -u "${TARGET_USER}")"
-  TARGET_GID="$(id -g "${TARGET_USER}")"
-
-  if ! home_perms_ok "${TARGET_HOME}"; then
-    HOME_MODE="$(stat -f '%Lp' "${TARGET_HOME}" 2>/dev/null || echo '?')"
-    warn "home directory ${TARGET_HOME} is group/other writable (mode ${HOME_MODE})"
-    warn "  the enterprise hook guardian will refuse to write into a loose home;"
-    warn "  this is an administrator responsibility to fix. Suggested:"
-    warn "    sudo chmod 0755 ${TARGET_HOME}"
-    warn "  skipping user-space hook wiring. Gateway is still running."
-    warn "  after fixing perms, finish wiring per-connector with:"
-    for c in "${CONNECTORS[@]}"; do
-      warn "    sudo DEFENSECLAW_CONFIG=\"${CONFIG_PATH}\" DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR=\"${GUARDIAN_AUTH_DIR}\" ${GATEWAY_BIN} enterprise hooks install --connector ${c} --user ${TARGET_USER} --agent-version 'X.Y.Z' --json"
-    done
-    SKIP_CONNECTOR="true"
+  log "enumerating eligible local users"
+  USER_LINES="$(enumerate_local_users || true)"
+  USER_COUNT="$(printf '%s\n' "${USER_LINES}" | grep -c . || true)"
+  if [[ -z "${USER_LINES}" ]]; then
+    warn "no eligible local users detected on this host"
+    warn "  hooks will be wired for users that log in later once the enumerator's next 5-min tick runs"
+  else
+    log "  found ${USER_COUNT} eligible user(s):"
+    while IFS=: read -r _u _uid _gid _home; do
+      [[ -z "${_u}" ]] && continue
+      log "    ${_u} (uid=${_uid}, home=${_home})"
+    done <<< "${USER_LINES}"
+    unset _u _uid _gid _home
   fi
-fi
 
-if [[ "${SKIP_CONNECTOR}" != "true" ]]; then
-  # The CLI subcommand opens the audit DB writer; pause the daemon once,
-  # run every per-connector install, then resume.
-  log "  pausing LaunchDaemon (CLI subcommands hold the audit DB lock)"
-  launchctl bootout "system/${LAUNCHD_LABEL}" 2>/dev/null || true
-  for _ in 1 2 3 4 5 6 7 8 9 10; do
-    pgrep -fl "${GATEWAY_BIN}" >/dev/null 2>&1 || break
-    sleep 1
-  done
+  log "rendering initial hook-guardian manifest -> ${GUARDIAN_MANIFEST_PATH}"
+  MANIFEST_TMP="$(mktemp "${GUARDIAN_MANIFEST_PATH}.new.XXXXXX")" \
+    || die "could not reserve a private manifest staging file"
+  INSTALL_TEMP_FILES+=("${MANIFEST_TMP}")
+  render_targets_manifest "${SUPPORT_DIR}" "${CONNECTOR}" "${USER_LINES}" > "${MANIFEST_TMP}"
+  chown root:wheel "${MANIFEST_TMP}"
+  chmod 0640 "${MANIFEST_TMP}"
+  ln "${MANIFEST_TMP}" "${GUARDIAN_MANIFEST_PATH}" \
+    || die "manifest appeared concurrently and was preserved: ${GUARDIAN_MANIFEST_PATH}"
+  rm -f -- "${MANIFEST_TMP}"
+  forget_install_temporary "${MANIFEST_TMP}"
 
-  for c in "${CONNECTORS[@]}"; do
-    if ! is_supported_connector "${c}"; then
-      log "  skipping unsupported connector ${c} (no userspace wiring)"
-      continue
-    fi
+  log "loading hook-enumerator LaunchDaemon"
+  launchctl bootstrap system "${ENUMERATOR_PLIST_DST}"
+  launchctl enable "system/${ENUMERATOR_LAUNCHD_LABEL}"
 
-    log "  [${c}] preparing userspace"
-    if ! prepare_userspace_for "${c}" "${TARGET_HOME}"; then
-      warn "  [${c}] refused to prepare userspace (symlinked or non-dir path); skipping"
-      continue
-    fi
-    # Match ownership on JUST the files DefenseClaw just pre-created.
-    # A recursive chown over ~/.codex or ~/.cursor is wrong: those
-    # dirs may contain unrelated user state (Codex ships a signed
-    # `computer-use/*.app` bundle, Cursor stores signed extensions),
-    # and SIP-protected files in those trees will fail chown with
-    # "Operation not permitted" even as root.
-    #
-    # We only touch what prepare_userspace_for could have written:
-    # the connector's hook config file + its parent .<agent> dir.
-    case "${c}" in
-      claudecode) DC_AGENT_TARGETS=( "${TARGET_HOME}/.claude" "${TARGET_HOME}/.claude/settings.json" );;
-      codex)      DC_AGENT_TARGETS=( "${TARGET_HOME}/.codex"  "${TARGET_HOME}/.codex/config.toml" );;
-      cursor)     DC_AGENT_TARGETS=( "${TARGET_HOME}/.cursor" "${TARGET_HOME}/.cursor/hooks.json" );;
-      *)          DC_AGENT_TARGETS=();;
-    esac
-    for path in "${DC_AGENT_TARGETS[@]}"; do
-      # Skip symlinks (guarded upstream by ensure_safe_userspace_path)
-      # and missing paths. Any real chown failure aborts the connector.
-      if [[ -e "${path}" && ! -L "${path}" ]]; then
-        if ! chown -h "${TARGET_UID}:${TARGET_GID}" "${path}"; then
-          die "[${c}] failed to set ownership on ${path}"
-        fi
-      fi
-    done
+  log "loading hook-guardian LaunchDaemon"
+  launchctl bootstrap system "${GUARDIAN_PLIST_DST}"
+  launchctl enable "system/${GUARDIAN_LAUNCHD_LABEL}"
 
-    AGENT_VER="${AGENT_VERSION}"
-    if [[ -z "${AGENT_VER}" ]]; then
-      # Expose TARGET_USER to the lib so its Codex fallback can exec
-      # `codex --version` as the user (not as root).
-      AGENT_VER="$(DC_INSTALLER_TARGET_USER="${TARGET_USER}" \
-        discover_agent_version "${c}" "${TARGET_HOME}" || true)"
-    fi
-    if [[ -z "${AGENT_VER}" ]]; then
-      warn "  [${c}] could not auto-detect agent version; skipping. Resume with:"
-      warn "    sudo DEFENSECLAW_CONFIG=\"${CONFIG_PATH}\" DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR=\"${GUARDIAN_AUTH_DIR}\" ${GATEWAY_BIN} enterprise hooks install --connector ${c} --user ${TARGET_USER} --agent-version 'X.Y.Z' --json"
-      continue
-    fi
-
-    log "  [${c}] detected agent_version: ${AGENT_VER}"
-    log "  [${c}] running: enterprise hooks install --connector ${c} --user ${TARGET_USER}"
-    # DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR MUST match what the plist sets
-    # for the running daemon (see packaging/launchd/com.cisco.secureclient.defenseclaw.plist).
-    # The CLI's default is `${data_dir}-hook-guardian` which resolves to
-    # ${SUPPORT_DIR}/runtime-hook-guardian and doesn't exist in our
-    # layout — the installer creates ${SUPPORT_DIR}/hook-guardian-state
-    # instead so the trust check walks a root-owned SUPPORT_DIR ancestor.
-    # Without explicitly passing this env var here, `enterprise hooks
-    # install` fails with:
-    #   authorization directory trust check failed: .../runtime-hook-guardian: no such file or directory
-    if DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
-       DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR="${GUARDIAN_AUTH_DIR}" \
-       "${GATEWAY_BIN}" enterprise hooks install \
-         --connector "${c}" \
-         --user "${TARGET_USER}" \
-         --agent-version "${AGENT_VER}" \
-         --json; then
-      log "  [${c}] hook wiring OK"
-    else
-      warn "  [${c}] hook wiring failed; see JSON output above"
-    fi
-  done
-
-  # The CLI subcommands ran as root and wrote audit.db / judge_bodies.db
-  # + their -wal/-shm sidecars into RUNTIME_DIR. The daemon also runs as
-  # root, so ownership already matches — no chown pass is needed. This
-  # step used to fix a defenseclaw-uid inheritance issue that vanishes
-  # when everything is root.
-  log "  runtime files created by CLI are already root-owned (daemon runs as root)"
-
-  log "  resuming LaunchDaemon"
-  launchctl bootstrap system "${PLIST_DST}"
-  launchctl enable "system/${LAUNCHD_LABEL}"
-  if ! wait_for_launchd_running; then
-    warn "gateway did not resume within 15s; recent stderr:"
-    tail -20 "${LOGS_DIR}/gateway.err.log" 2>/dev/null | sed 's/^/    /' >&2 || true
-    die "${LAUNCHD_LABEL} failed to resume after per-user wiring"
-  fi
+  # Kick both daemons so the first reconcile happens immediately rather
+  # than at the next 5-min tick (RunAtLoad already fired, but kickstart
+  # is a defence-in-depth in case the daemon was already loaded from a
+  # previous state).
+  log "kickstarting hook-enumerator + hook-guardian for immediate first pass"
+  launchctl kickstart -k "system/${ENUMERATOR_LAUNCHD_LABEL}" 2>/dev/null || true
+  launchctl kickstart -k "system/${GUARDIAN_LAUNCHD_LABEL}"   2>/dev/null || true
 fi
 
 # ---- summary ------------------------------------------------------------
@@ -755,11 +796,15 @@ Next steps:
   Master gateway token (for direct curl tests):
     sudo grep DEFENSECLAW_GATEWAY_TOKEN "${RUNTIME_DIR}/.env"
 
-  Repair user-space hooks (per connector):
-$(for c in "${CONNECTORS[@]}"; do
-    printf '    sudo DEFENSECLAW_CONFIG="%s" DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR="%s" %s enterprise hooks install --connector %s --user %s --agent-version "X.Y.Z" --json\n' \
-      "${CONFIG_PATH}" "${GUARDIAN_AUTH_DIR}" "${GATEWAY_BIN}" "${c}" "${TARGET_USER:-USER}"
-  done)
+  Hook-guardian status (per-user hook wiring):
+    sudo launchctl print system/${GUARDIAN_LAUNCHD_LABEL}   | head -20
+    sudo launchctl print system/${ENUMERATOR_LAUNCHD_LABEL} | head -20
+    sudo cat ${GUARDIAN_MANIFEST_PATH}
+    sudo cat ${GUARDIAN_AUTH_DIR}/protected_targets.json
+
+  Force a fresh reconcile after adding a user account:
+    sudo launchctl kickstart -k system/${ENUMERATOR_LAUNCHD_LABEL}
+    sudo launchctl kickstart -k system/${GUARDIAN_LAUNCHD_LABEL}
 
   Uninstall:
     sudo ${SCRIPT_DIR}/uninstall.sh

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -539,6 +539,21 @@ if [[ "${DC_INSTALLER_SKIP_ROOT_CHECK:-}" != "1" ]]; then
 fi
 for _marker in "${_existing_install_markers[@]}"; do
   if [[ -e "${_marker}" || -L "${_marker}" ]]; then
+    # Special case: LOGS_DIR containing ONLY install.log is a benign
+    # leftover from a previous install session's log-sink tee (we open
+    # install.log for append right after the euid check, BEFORE this
+    # preflight fires). A real broken install leaves gateway.log +
+    # gateway.err.log + hook-guardian.log + hook-enumerator.log too.
+    # Treat "only install.log survived the previous uninstall" as
+    # fresh-host, not "existing install detected".
+    if [[ "${_marker}" == "${LOGS_DIR}" ]] && [[ -d "${_marker}" ]]; then
+      _residual="$(find "${_marker}" -mindepth 1 -maxdepth 1 ! -name install.log -print -quit 2>/dev/null)"
+      if [[ -z "${_residual}" ]]; then
+        unset _residual
+        continue
+      fi
+      unset _residual
+    fi
     die "existing DefenseClaw installation detected at ${_marker}; no changes were made. This installer is fresh-install-only. Use the release-owned staged upgrade path for that deployment; if no managed-enterprise staged upgrader is published, remain on the current version and contact the deployment owner. Do not uninstall or overwrite state to force the upgrade."
   fi
 done

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -341,13 +341,19 @@ render_targets_manifest() {
     for c in "${connectors[@]}"; do
       is_supported_connector "${c}" || continue
       ver="$(DC_INSTALLER_TARGET_USER="${name}" discover_agent_version "${c}" "${home}" 2>/dev/null || true)"
+      # data_dir is intentionally omitted from each target block: the
+      # guardian's validateUserDataDir requires the data_dir to be inside
+      # the target user's home (internal/enterprisehooks/installer.go),
+      # but ${runtime_dir} is machine-wide root storage under SUPPORT_DIR.
+      # Letting the Install() layer default to ~/.defenseclaw per user is
+      # correct — that is where the connector's hook script and scoped
+      # token per-user artifacts live.
       cat <<EOF
   - user: "${name}"
     user_home: "${home}"
     uid: ${uid}
     gid: ${gid}
     connector: "${c}"
-    data_dir: "${runtime_dir}"
     agent_version: "${ver}"
     enabled: true
 EOF

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -102,25 +102,52 @@ discover_agent_version() {
   local home="$2"
   case "${connector}" in
     codex)
-      # Codex-cli is a Rust binary, not npm. We probe metadata paths
-      # first (safe, no exec), then fall back to `codex --version`
-      # exec'd AS THE TARGET USER via `sudo -u`. Running the user's
-      # own codex binary as their identity is not a privilege
-      # escalation — install.sh's outer sudo drops privileges for this
-      # subprocess, matching the security posture of the hook
-      # guardian's connector.Setup call.
-      local pkg
-      for pkg in \
-        "${home}"/.npm-global/lib/node_modules/@openai/codex/package.json \
-        /usr/local/lib/node_modules/@openai/codex/package.json \
-        /opt/homebrew/lib/node_modules/@openai/codex/package.json; do
-        [[ -f "${pkg}" ]] || continue
-        local v; v="$(_read_json_version "${pkg}")"
-        if [[ -n "${v}" ]]; then echo "${v}"; return; fi
+      # Codex-cli is a Rust binary that ships from three OpenAI-owned
+      # channels on macOS. Probe order picks the first-party
+      # ChatGPT.app bundled copy FIRST because it is the newest
+      # distribution (auto-updated with the desktop app) and it is
+      # what customers actually have on a fresh Mac — stray old
+      # `npm i -g @openai/codex` installs from an earlier engagement
+      # frequently linger and would otherwise win with a stale
+      # version that fails our MinAgentVersion contract gate.
+      #
+      # Order:
+      #   1. ChatGPT.app bundled binary       (Codex 0.145.0+ current)
+      #   2. Homebrew Caskroom                (versioned dir name)
+      #   3. npm module package.json         (user-global then system)
+      #   4. `command -v codex` last resort   (arbitrary PATH install)
+      #
+      # Every probe runs as the target user via sudo -u (not root).
+      # The app bundle is Gatekeeper-signed and world-readable by
+      # design; running its --version as an unprivileged user is
+      # safe. install.sh's outer sudo already dropped privs before
+      # calling this helper, matching the security posture of the
+      # hook guardian's connector.Setup call.
+      local vraw
+
+      # 1. ChatGPT.app bundled codex — /Applications/ChatGPT.app/
+      # Contents/Resources/codex is the current stable location; the
+      # older MacOS/ path is kept as a fallback for pre-2026 builds.
+      local chatgpt_codex
+      for chatgpt_codex in \
+        /Applications/ChatGPT.app/Contents/Resources/codex \
+        /Applications/ChatGPT.app/Contents/MacOS/codex; do
+        [[ -x "${chatgpt_codex}" ]] || continue
+        if [[ -n "${DC_INSTALLER_TARGET_USER:-}" ]]; then
+          vraw="$(sudo -n -u "${DC_INSTALLER_TARGET_USER}" "${chatgpt_codex}" --version 2>/dev/null | head -1 || true)"
+        else
+          vraw="$("${chatgpt_codex}" --version 2>/dev/null | head -1 || true)"
+        fi
+        # Codex prints "codex-cli X.Y.Z" (or "codex-cli X.Y.Z-alpha.N");
+        # take the first token that looks like a version.
+        vraw="$(printf '%s' "${vraw}" | awk '{for(i=NF;i>=1;i--) if ($i ~ /^[0-9]+\.[0-9]+/) {print $i; exit}}')"
+        if [[ -n "${vraw}" ]]; then echo "${vraw}"; return; fi
       done
-      # Homebrew cask keeps the binary under Caskroom with a version
-      # in the path itself: /opt/homebrew/Caskroom/codex/<version>/...
-      # Glob-based version pick (avoids shellcheck SC2010 on `ls | grep`).
+
+      # 2. Homebrew cask keeps the binary under Caskroom with a
+      # version in the path itself:
+      #   /opt/homebrew/Caskroom/codex/<version>/...
+      # Glob-based version pick (avoids shellcheck SC2010 on ls|grep).
       local caskroom ver dir dname
       for caskroom in /opt/homebrew/Caskroom/codex /usr/local/Caskroom/codex; do
         [[ -d "${caskroom}" ]] || continue
@@ -136,12 +163,23 @@ discover_agent_version() {
         done
         if [[ -n "${ver}" ]]; then echo "${ver}"; return; fi
       done
-      # Last resort: exec codex --version as the target user (not as
-      # root). Requires TARGET_USER to be known to the caller.
+
+      # 3. npm module package.json — user-global first (most likely
+      # up to date on developer boxes), then system dirs.
+      local pkg
+      for pkg in \
+        "${home}"/.npm-global/lib/node_modules/@openai/codex/package.json \
+        /usr/local/lib/node_modules/@openai/codex/package.json \
+        /opt/homebrew/lib/node_modules/@openai/codex/package.json; do
+        [[ -f "${pkg}" ]] || continue
+        local v; v="$(_read_json_version "${pkg}")"
+        if [[ -n "${v}" ]]; then echo "${v}"; return; fi
+      done
+
+      # 4. Last resort: exec codex --version as the target user (not
+      # as root). Requires TARGET_USER to be known to the caller.
       if [[ -n "${DC_INSTALLER_TARGET_USER:-}" ]] && command -v codex >/dev/null 2>&1; then
-        local vraw
         vraw="$(sudo -n -u "${DC_INSTALLER_TARGET_USER}" codex --version 2>/dev/null | head -1 || true)"
-        # Codex prints "codex-cli X.Y.Z"; take just the version token.
         vraw="$(printf '%s' "${vraw}" | awk '{for(i=NF;i>=1;i--) if ($i ~ /^[0-9]+\.[0-9]+/) {print $i; exit}}')"
         if [[ -n "${vraw}" ]]; then echo "${vraw}"; return; fi
       fi

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -246,6 +246,15 @@ prepare_userspace_for() {
 
 # ---- local-user enumeration --------------------------------------------
 
+# _enumerate_users_warn — internal helper that emits a per-filter drop
+# reason when DC_INSTALLER_ENUMERATE_VERBOSE=1. install.sh flips this on
+# so its install.log records why user X was excluded from targets.yaml;
+# unit tests leave it off so the sourced-library harness stays quiet.
+_enumerate_users_warn() {
+  [[ "${DC_INSTALLER_ENUMERATE_VERBOSE:-}" == "1" ]] || return 0
+  printf '[install] WARN: enumerate_local_users skipping %s: %s\n' "$1" "$2" >&2
+}
+
 # enumerate_local_users -> stdout, one line per eligible user in the form:
 #   user:uid:gid:home
 #
@@ -254,28 +263,62 @@ prepare_userspace_for() {
 # Reads OpenDirectory via dscl — same pattern the fresh-install preflight in
 # install.sh already uses (see the block that gates on _existing_install_markers).
 #
-# Pure: no writes, no sudo. Callers under test can seed a fake dscl by
-# putting a shim ahead of PATH.
+# Pure: no writes, no sudo. When DC_INSTALLER_ENUMERATE_VERBOSE=1 each
+# filter drop emits a WARN on stderr so install.log captures why a
+# specific user was excluded. Off by default (tests source this library
+# and would otherwise emit spurious warns).
 enumerate_local_users() {
   local names name uid gid home
-  names="$(dscl . -list /Users UniqueID 2>/dev/null)" || return 0
+  names="$(dscl . -list /Users UniqueID 2>/dev/null)" || {
+    _enumerate_users_warn "(all users)" "dscl . -list /Users UniqueID failed — cannot enumerate local users"
+    return 0
+  }
   # dscl output is "user   uid". Filter and normalize in one pass.
   while IFS= read -r line; do
     name="$(printf '%s' "${line}" | awk '{print $1}')"
     uid="$(printf '%s' "${line}" | awk '{print $2}')"
-    [[ -n "${name}" && -n "${uid}" ]] || continue
+    if [[ -z "${name}" || -z "${uid}" ]]; then
+      _enumerate_users_warn "${name:-?}" "dscl row is missing name or uid: '${line}'"
+      continue
+    fi
     # Filter system accounts.
     case "${name}" in
-      _*|daemon|nobody|root) continue;;
+      _*|daemon|nobody|root)
+        _enumerate_users_warn "${name}" "system account (name matches system-user pattern)"
+        continue;;
     esac
-    [[ "${uid}" =~ ^[0-9]+$ ]] || continue
-    (( uid >= 500 )) || continue
+    if ! [[ "${uid}" =~ ^[0-9]+$ ]]; then
+      _enumerate_users_warn "${name}" "uid '${uid}' is not numeric"
+      continue
+    fi
+    if (( uid < 500 )); then
+      _enumerate_users_warn "${name}" "uid ${uid} is below the local-user threshold (500)"
+      continue
+    fi
 
     home="$(dscl . -read "/Users/${name}" NFSHomeDirectory 2>/dev/null | sed -n 's/^NFSHomeDirectory: //p')"
-    [[ -n "${home}" ]] || continue
-    [[ "${home}" == /Users/* ]] || continue
-    [[ -d "${home}" && ! -L "${home}" ]] || continue
-    home_perms_ok "${home}" || continue
+    if [[ -z "${home}" ]]; then
+      _enumerate_users_warn "${name}" "NFSHomeDirectory is empty in Open Directory"
+      continue
+    fi
+    if [[ "${home}" != /Users/* ]]; then
+      _enumerate_users_warn "${name}" "home '${home}' is not under /Users/ (network / mobile / MDM account)"
+      continue
+    fi
+    if [[ ! -d "${home}" ]]; then
+      _enumerate_users_warn "${name}" "home '${home}' is not a directory (may not be mounted)"
+      continue
+    fi
+    if [[ -L "${home}" ]]; then
+      _enumerate_users_warn "${name}" "home '${home}' is a symlink — refusing to follow"
+      continue
+    fi
+    if ! home_perms_ok "${home}"; then
+      local _mode
+      _mode="$(stat -f '%Lp' "${home}" 2>/dev/null || stat -c '%a' "${home}" 2>/dev/null || echo '?')"
+      _enumerate_users_warn "${name}" "home '${home}' is group/other writable (mode ${_mode}) — hook guardian will refuse"
+      continue
+    fi
 
     gid="$(dscl . -read "/Users/${name}" PrimaryGroupID 2>/dev/null | sed -n 's/^PrimaryGroupID: //p')"
     [[ "${gid}" =~ ^[0-9]+$ ]] || gid="20"

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -244,6 +244,117 @@ prepare_userspace_for() {
   esac
 }
 
+# ---- local-user enumeration --------------------------------------------
+
+# enumerate_local_users -> stdout, one line per eligible user in the form:
+#   user:uid:gid:home
+#
+# Filters: UID >= 500, username does not start with `_`, home under /Users/,
+# home is a real directory (not a symlink), and home_perms_ok passes.
+# Reads OpenDirectory via dscl — same pattern the fresh-install preflight in
+# install.sh already uses (see the block that gates on _existing_install_markers).
+#
+# Pure: no writes, no sudo. Callers under test can seed a fake dscl by
+# putting a shim ahead of PATH.
+enumerate_local_users() {
+  local names name uid gid home
+  names="$(dscl . -list /Users UniqueID 2>/dev/null)" || return 0
+  # dscl output is "user   uid". Filter and normalize in one pass.
+  while IFS= read -r line; do
+    name="$(printf '%s' "${line}" | awk '{print $1}')"
+    uid="$(printf '%s' "${line}" | awk '{print $2}')"
+    [[ -n "${name}" && -n "${uid}" ]] || continue
+    # Filter system accounts.
+    case "${name}" in
+      _*|daemon|nobody|root) continue;;
+    esac
+    [[ "${uid}" =~ ^[0-9]+$ ]] || continue
+    (( uid >= 500 )) || continue
+
+    home="$(dscl . -read "/Users/${name}" NFSHomeDirectory 2>/dev/null | sed -n 's/^NFSHomeDirectory: //p')"
+    [[ -n "${home}" ]] || continue
+    [[ "${home}" == /Users/* ]] || continue
+    [[ -d "${home}" && ! -L "${home}" ]] || continue
+    home_perms_ok "${home}" || continue
+
+    gid="$(dscl . -read "/Users/${name}" PrimaryGroupID 2>/dev/null | sed -n 's/^PrimaryGroupID: //p')"
+    [[ "${gid}" =~ ^[0-9]+$ ]] || gid="20"
+
+    printf '%s:%s:%s:%s\n' "${name}" "${uid}" "${gid}" "${home}"
+  done <<< "${names}"
+}
+
+# ---- targets.yaml rendering --------------------------------------------
+
+# render_targets_manifest SUPPORT_DIR CONNECTORS_CSV USER_LINES -> stdout
+#
+# Renders the hook-guardian manifest (`targets.yaml`) consumed by the
+# `enterprise hooks reconcile` command. Schema mirrors ManifestTarget in
+# internal/enterprisehooks/manifest.go.
+#
+# Args:
+#   SUPPORT_DIR    e.g. /opt/cisco/secureclient/defenseclaw
+#   CONNECTORS_CSV comma-separated list of connectors (e.g. codex,claudecode,cursor)
+#   USER_LINES     newline-separated user:uid:gid:home lines (as produced by
+#                  enumerate_local_users)
+#
+# One `- ` block per (user × supported connector). Unsupported connectors
+# are skipped (they have no per-user setup path in the CLI). Agent version
+# is discovered per (user, connector) via discover_agent_version; an empty
+# version is rendered as an empty string — the guardian's reconcile will
+# emit a per-target failure surfaced in hook_guardian_state.json without
+# affecting other targets in the manifest.
+render_targets_manifest() {
+  local support_dir="$1"
+  local connectors_csv="$2"
+  local user_lines="$3"
+  local runtime_dir="${support_dir}/runtime"
+
+  local -a connectors=()
+  local c
+  while IFS= read -r c; do
+    [[ -z "${c}" ]] && continue
+    connectors+=("${c}")
+  done < <(parse_connectors "${connectors_csv}" 2>/dev/null || true)
+
+  printf 'version: 1\n'
+  printf 'targets:\n'
+
+  if [[ ${#connectors[@]} -eq 0 ]]; then
+    return 0
+  fi
+  if [[ -z "${user_lines}" ]]; then
+    return 0
+  fi
+
+  local line name uid gid home ver
+  while IFS= read -r line; do
+    [[ -z "${line}" ]] && continue
+    name="${line%%:*}"
+    local rest="${line#*:}"
+    uid="${rest%%:*}"
+    rest="${rest#*:}"
+    gid="${rest%%:*}"
+    home="${rest#*:}"
+    [[ -n "${name}" && -n "${uid}" && -n "${gid}" && -n "${home}" ]] || continue
+
+    for c in "${connectors[@]}"; do
+      is_supported_connector "${c}" || continue
+      ver="$(DC_INSTALLER_TARGET_USER="${name}" discover_agent_version "${c}" "${home}" 2>/dev/null || true)"
+      cat <<EOF
+  - user: "${name}"
+    user_home: "${home}"
+    uid: ${uid}
+    gid: ${gid}
+    connector: "${c}"
+    data_dir: "${runtime_dir}"
+    agent_version: "${ver}"
+    enabled: true
+EOF
+    done
+  done <<< "${user_lines}"
+}
+
 # ---- config rendering --------------------------------------------------
 
 # aid_endpoint_for_env ENV -> stdout

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -385,6 +385,16 @@ enumerate_local_users() {
 # version is rendered as an empty string — the guardian's reconcile will
 # emit a per-target failure surfaced in hook_guardian_state.json without
 # affecting other targets in the manifest.
+yaml_double_quoted_scalar() {
+  local value="$1"
+  case "${value}" in
+    *$'\n'*|*$'\r'*|*$'\t'*) return 1;;
+  esac
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '"%s"' "${value}"
+}
+
 render_targets_manifest() {
   local support_dir="$1"
   local connectors_csv="$2"
@@ -408,7 +418,7 @@ render_targets_manifest() {
     return 0
   fi
 
-  local line name uid gid home ver
+  local line name uid gid home ver q_name q_home q_connector q_ver
   while IFS= read -r line; do
     [[ -z "${line}" ]] && continue
     name="${line%%:*}"
@@ -418,10 +428,14 @@ render_targets_manifest() {
     gid="${rest%%:*}"
     home="${rest#*:}"
     [[ -n "${name}" && -n "${uid}" && -n "${gid}" && -n "${home}" ]] || continue
+    q_name="$(yaml_double_quoted_scalar "${name}")" || continue
+    q_home="$(yaml_double_quoted_scalar "${home}")" || continue
 
     for c in "${connectors[@]}"; do
       is_supported_connector "${c}" || continue
+      q_connector="$(yaml_double_quoted_scalar "${c}")" || continue
       ver="$(DC_INSTALLER_TARGET_USER="${name}" discover_agent_version "${c}" "${home}" 2>/dev/null || true)"
+      q_ver="$(yaml_double_quoted_scalar "${ver}")" || q_ver='""'
       # data_dir is intentionally omitted from each target block: the
       # guardian's validateUserDataDir requires the data_dir to be inside
       # the target user's home (internal/enterprisehooks/installer.go),
@@ -430,12 +444,12 @@ render_targets_manifest() {
       # correct — that is where the connector's hook script and scoped
       # token per-user artifacts live.
       cat <<EOF
-  - user: "${name}"
-    user_home: "${home}"
+  - user: ${q_name}
+    user_home: ${q_home}
     uid: ${uid}
     gid: ${gid}
-    connector: "${c}"
-    agent_version: "${ver}"
+    connector: ${q_connector}
+    agent_version: ${q_ver}
     enabled: true
 EOF
     done

--- a/packaging/macos/lib/render-targets.sh
+++ b/packaging/macos/lib/render-targets.sh
@@ -44,58 +44,71 @@ die() { printf '[hook-enumerator] ERROR: %s\n' "$*" >&2; exit 1; }
 # when present; fall back to the primary. Keep this tiny and side-effect
 # free — Python is available on every macOS box we ship to.
 extract_connectors() {
+  # Regex-only scanner over the shape render_config emits. Deliberately
+  # avoids importing PyYAML: it isn't part of macOS's system Python and
+  # is often installed only in a user's Library/Python/*/site-packages,
+  # invisible to a root-launched daemon. render_config's output is stable
+  # and simple enough (two-space indent, keys on their own lines) that a
+  # regex scan is more portable than a YAML dependency.
+  #
+  # render_config emits BOTH:
+  #   guardrail:
+  #     connector: <primary>              <-- the single-scalar form
+  #     connectors:                       <-- the multi-connector map
+  #       codex:
+  #       claudecode:
+  #       cursor:
+  # So we prefer the map when present (returns every connector) and fall
+  # back to the scalar (primary only) when the map is absent. Duplicates
+  # are dropped preserving first-seen order.
   /usr/bin/python3 - "${CONFIG_PATH}" <<'PY'
 import re, sys
 path = sys.argv[1]
 with open(path, "r", encoding="utf-8") as f:
     text = f.read()
 
-# Try to parse via PyYAML if available; otherwise use a permissive regex
-# scanner sufficient for the shape render_config produces.
-def with_yaml():
-    try:
-        import yaml
-    except Exception:
-        return None
-    try:
-        doc = yaml.safe_load(text) or {}
-    except Exception:
-        return None
-    guard = doc.get("guardrail") or {}
-    m = guard.get("connectors") or {}
-    if isinstance(m, dict) and m:
-        return [k for k in m.keys()]
-    v = guard.get("connector")
-    if isinstance(v, str) and v.strip():
-        return [v.strip()]
-    return []
+primary = None
+connectors_map = []
+in_guardrail = False
+in_connectors = False
+for line in text.splitlines():
+    if re.match(r"^guardrail:\s*$", line):
+        in_guardrail = True
+        in_connectors = False
+        continue
+    if in_guardrail and line and not line.startswith(" "):
+        # Left the guardrail: block.
+        in_guardrail = False
+        in_connectors = False
+        continue
+    if not in_guardrail:
+        continue
+    if not in_connectors:
+        if re.match(r"^  connectors:\s*$", line):
+            in_connectors = True
+            continue
+        m = re.match(r"^  connector:\s*(\S+)\s*$", line)
+        if m and primary is None:
+            primary = m.group(1)
+    else:
+        m = re.match(r"^    ([a-z0-9][a-z0-9_-]*):\s*$", line)
+        if m:
+            connectors_map.append(m.group(1))
+            continue
+        if line and not line.startswith("      ") and not line.startswith("    "):
+            in_connectors = False
 
-def without_yaml():
-    # Match the shape render_config emits (two-space indent, keys on their
-    # own lines). If the connectors: map is present, list its immediate
-    # children; else fall back to the single `connector:` scalar.
-    out = []
-    in_connectors = False
-    for line in text.splitlines():
-        if not in_connectors:
-            if re.match(r"^  connectors:\s*$", line):
-                in_connectors = True
-                continue
-            m = re.match(r"^  connector:\s*(\S+)\s*$", line)
-            if m and not out:
-                out.append(m.group(1))
-        else:
-            if re.match(r"^    ([a-z0-9][a-z0-9_-]*):\s*$", line):
-                out.append(re.match(r"^    (\S+):", line).group(1))
-                continue
-            if line and not line.startswith("      ") and not line.startswith("    "):
-                break
-    return out
-
-result = with_yaml()
-if result is None:
-    result = without_yaml()
+# Prefer the map when populated; fall back to the primary scalar.
+result = connectors_map if connectors_map else ([primary] if primary else [])
+# Dedupe preserving first-seen order (defence-in-depth against future edits
+# to render_config that might list the same connector under both forms).
+seen = set()
+deduped = []
 for c in result:
+    if c and c not in seen:
+        seen.add(c)
+        deduped.append(c)
+for c in deduped:
     print(c)
 PY
 }

--- a/packaging/macos/lib/render-targets.sh
+++ b/packaging/macos/lib/render-targets.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# render-targets.sh — regenerate the hook-guardian manifest for every
+# eligible local user × configured connector on the machine.
+#
+# This script is invoked by the com.cisco.secureclient.defenseclaw.hook-enumerator
+# LaunchDaemon (RunAtLoad + every 5 min) so that users provisioned after the
+# initial pkg install get their hooks wired on the next hook-guardian tick.
+#
+# Reads:
+#   ${SUPPORT_DIR}/etc/config.yaml  — for the connector list
+#   dscl . -list /Users             — for the current set of eligible users
+#
+# Writes:
+#   ${SUPPORT_DIR}/hook-guardian/targets.yaml (root:wheel 0640, atomic swap)
+#
+# The hook-guardian LaunchDaemon polls the file it writes here on every
+# tick (StartInterval 300), so no signal / restart is needed.
+
+set -euo pipefail
+
+SUPPORT_DIR="${SUPPORT_DIR:-/opt/cisco/secureclient/defenseclaw}"
+CONFIG_PATH="${DEFENSECLAW_CONFIG:-${SUPPORT_DIR}/etc/config.yaml}"
+MANIFEST_DIR="${SUPPORT_DIR}/hook-guardian"
+MANIFEST_PATH="${MANIFEST_DIR}/targets.yaml"
+LIB_PATH="${SUPPORT_DIR}/lib/installer_lib.sh"
+
+log() { printf '[hook-enumerator] %s\n' "$*"; }
+warn() { printf '[hook-enumerator] WARN: %s\n' "$*" >&2; }
+die() { printf '[hook-enumerator] ERROR: %s\n' "$*" >&2; exit 1; }
+
+[[ "$(uname -s)" == "Darwin" ]] || die "macOS only (uname -s != Darwin)"
+[[ $EUID -eq 0 ]] || die "must run as root"
+
+[[ -f "${LIB_PATH}" ]] || die "installer library missing: ${LIB_PATH}"
+[[ -f "${CONFIG_PATH}" ]] || die "config missing: ${CONFIG_PATH}"
+
+# shellcheck source=/dev/null
+. "${LIB_PATH}"
+
+# Parse connector list out of the rendered config.yaml. The installer
+# renders `guardrail.connector: <primary>` and optionally a
+# `guardrail.connectors:` map with per-connector entries. Prefer the map
+# when present; fall back to the primary. Keep this tiny and side-effect
+# free — Python is available on every macOS box we ship to.
+extract_connectors() {
+  /usr/bin/python3 - "${CONFIG_PATH}" <<'PY'
+import re, sys
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as f:
+    text = f.read()
+
+# Try to parse via PyYAML if available; otherwise use a permissive regex
+# scanner sufficient for the shape render_config produces.
+def with_yaml():
+    try:
+        import yaml
+    except Exception:
+        return None
+    try:
+        doc = yaml.safe_load(text) or {}
+    except Exception:
+        return None
+    guard = doc.get("guardrail") or {}
+    m = guard.get("connectors") or {}
+    if isinstance(m, dict) and m:
+        return [k for k in m.keys()]
+    v = guard.get("connector")
+    if isinstance(v, str) and v.strip():
+        return [v.strip()]
+    return []
+
+def without_yaml():
+    # Match the shape render_config emits (two-space indent, keys on their
+    # own lines). If the connectors: map is present, list its immediate
+    # children; else fall back to the single `connector:` scalar.
+    out = []
+    in_connectors = False
+    for line in text.splitlines():
+        if not in_connectors:
+            if re.match(r"^  connectors:\s*$", line):
+                in_connectors = True
+                continue
+            m = re.match(r"^  connector:\s*(\S+)\s*$", line)
+            if m and not out:
+                out.append(m.group(1))
+        else:
+            if re.match(r"^    ([a-z0-9][a-z0-9_-]*):\s*$", line):
+                out.append(re.match(r"^    (\S+):", line).group(1))
+                continue
+            if line and not line.startswith("      ") and not line.startswith("    "):
+                break
+    return out
+
+result = with_yaml()
+if result is None:
+    result = without_yaml()
+for c in result:
+    print(c)
+PY
+}
+
+connectors_lines="$(extract_connectors 2>/dev/null || true)"
+if [[ -z "${connectors_lines}" ]]; then
+  die "no connectors resolvable from ${CONFIG_PATH}"
+fi
+connectors_csv="$(printf '%s\n' "${connectors_lines}" | paste -sd, -)"
+
+# Enumerate eligible local users right now.
+user_lines="$(enumerate_local_users || true)"
+
+# Render the manifest. Even when user_lines is empty we still produce a
+# valid `version: 1` + `targets:` document so the guardian's LoadManifest
+# does not error out.
+mkdir -p "${MANIFEST_DIR}"
+chown root:wheel "${MANIFEST_DIR}"
+chmod 0755 "${MANIFEST_DIR}"
+
+tmp="$(mktemp "${MANIFEST_PATH}.new.XXXXXX")"
+trap 'rm -f -- "${tmp}"' EXIT
+
+render_targets_manifest "${SUPPORT_DIR}" "${connectors_csv}" "${user_lines}" > "${tmp}"
+
+chown root:wheel "${tmp}"
+chmod 0640 "${tmp}"
+
+# Atomic replace via mv-if-content-differs. If the manifest is unchanged,
+# leave the on-disk mtime alone so the guardian's next tick doesn't
+# reconcile identical rows unnecessarily.
+if [[ -f "${MANIFEST_PATH}" ]] && cmp -s "${tmp}" "${MANIFEST_PATH}"; then
+  log "targets.yaml unchanged (users=$(printf '%s\n' "${user_lines}" | grep -c . || true))"
+  exit 0
+fi
+
+mv -f "${tmp}" "${MANIFEST_PATH}"
+trap - EXIT
+
+log "rendered targets.yaml (users=$(printf '%s\n' "${user_lines}" | grep -c . || true), connectors=${connectors_csv})"

--- a/packaging/macos/tests/test_discover_agent_version.sh
+++ b/packaging/macos/tests/test_discover_agent_version.sh
@@ -60,22 +60,83 @@ t_claudecode_no_install_returns_empty() {
 
 t_codex_no_home_metadata_uses_system_or_empty() {
   # With no metadata under the tmp HOME, the probe falls through to
-  # /opt/homebrew/Caskroom/codex etc. On a CI/dev box without codex
-  # installed anywhere, that returns empty. On a dev box with codex
-  # installed, we get a real version (that's fine — the point of
-  # discover_agent_version is to find one when it exists). Both are
-  # valid; assert the shape rather than the specific value.
+  # /Applications/ChatGPT.app -> Homebrew Caskroom -> system npm dirs
+  # -> PATH. On a CI/dev box without any codex install, that returns
+  # empty. On a dev box with codex installed (via any channel), we get
+  # a real version. Both are valid; assert the shape rather than the
+  # specific value.
   local home; home="$(mktest_tmp)"
   local got
   got="$(without_host_agent_bins discover_agent_version codex "${home}" 2>/dev/null || true)"
-  # Either empty, or a plausible version string (semver-ish).
+  # Either empty, or a plausible version string (semver-ish, possibly
+  # with an -alpha.N / -beta.N suffix from ChatGPT.app pre-release builds).
   if [[ -n "${got}" && ! "${got}" =~ ^[0-9]+\.[0-9]+ ]]; then
     _fail "codex probe returned unexpected non-empty non-version: ${got}"
     return 1
   fi
 }
 
+t_codex_chatgpt_app_bundled_wins_over_npm() {
+  # Regression guard for the sathishr scenario: a customer with a stale
+  # `npm i -g @openai/codex@0.104.0` (predating our MinAgentVersion
+  # of 0.124.0) AND the ChatGPT.app desktop app installed (which
+  # bundles Codex 0.145.0+) MUST have the probe return the newer
+  # ChatGPT.app version. If the probe order regresses back to
+  # npm-first, this test catches it because the stale npm metadata
+  # would win and the guardian would fail with
+  # "codex agent version 0.104.0 is not verified against a known
+  # hook contract" on every reconcile — the exact silent-fail
+  # surface we shipped with in early 2026.7.3.
+  #
+  # Runs only when /Applications/ChatGPT.app is present so CI /
+  # non-desktop-app boxes still pass. On a box with ChatGPT.app
+  # missing this returns "skip".
+  local chatgpt_codex="/Applications/ChatGPT.app/Contents/Resources/codex"
+  if [[ ! -x "${chatgpt_codex}" ]]; then
+    if [[ "${VERBOSE:-false}" == "true" ]]; then printf '  skip (ChatGPT.app not installed)\n'; fi
+    return 0
+  fi
+  local home; home="$(mktest_tmp)"
+  # Seed a stale user-npm codex install like sathishr had.
+  local pkg_dir="${home}/.npm-global/lib/node_modules/@openai/codex"
+  mkdir -p "${pkg_dir}"
+  cat > "${pkg_dir}/package.json" <<'JSON'
+{ "name": "@openai/codex", "version": "0.104.0" }
+JSON
+  # Probe as this user (DC_INSTALLER_TARGET_USER must resolve — use
+  # the current login user so sudo -n -u succeeds without a
+  # password prompt).
+  local got
+  got="$(DC_INSTALLER_TARGET_USER="$(id -un)" discover_agent_version codex "${home}" 2>&1)"
+  # Expect the ChatGPT.app-bundled version — a semver >= 0.124.0. The
+  # stale 0.104.0 must NOT win.
+  if [[ "${got}" == "0.104.0" ]]; then
+    _fail "codex probe returned the stale npm 0.104.0 instead of the newer ChatGPT.app-bundled version — the ChatGPT.app-first probe order must remain intact"
+    return 1
+  fi
+  if [[ ! "${got}" =~ ^[0-9]+\.[0-9]+ ]]; then
+    _fail "codex probe returned unexpected value with both stale npm + ChatGPT.app present: '${got}'"
+    return 1
+  fi
+}
+
 t_codex_from_user_npm_metadata() {
+  # Verifies the npm fallback branch: seed a user-scoped npm package.json
+  # under the tmp HOME and expect the probe to read the version from it.
+  # Skips when a higher-priority source is present on the host
+  # (/Applications/ChatGPT.app-bundled binary or /*/Caskroom/codex/*
+  # dir) — those correctly win over stale npm installs on real customer
+  # boxes, but would defeat this test's fixture. The ChatGPT.app-wins
+  # case is covered by t_codex_chatgpt_app_bundled_wins_over_npm above.
+  if [[ -x /Applications/ChatGPT.app/Contents/Resources/codex ]] \
+     || [[ -x /Applications/ChatGPT.app/Contents/MacOS/codex ]] \
+     || compgen -G "/opt/homebrew/Caskroom/codex/*/" >/dev/null 2>&1 \
+     || compgen -G "/usr/local/Caskroom/codex/*/" >/dev/null 2>&1; then
+    if [[ "${VERBOSE:-false}" == "true" ]]; then
+      printf '  skip (higher-priority codex source on host — see t_codex_chatgpt_app_bundled_wins_over_npm for the coverage)\n'
+    fi
+    return 0
+  fi
   local home; home="$(mktest_tmp)"
   local pkg_dir="${home}/.npm-global/lib/node_modules/@openai/codex"
   mkdir -p "${pkg_dir}"
@@ -98,4 +159,5 @@ run_case "claudecode via VS Code extension"  t_claudecode_via_vscode_extension
 run_case "claudecode without install"        t_claudecode_no_install_returns_empty
 run_case "codex without home metadata"       t_codex_no_home_metadata_uses_system_or_empty
 run_case "codex from user npm metadata"      t_codex_from_user_npm_metadata
+run_case "codex ChatGPT.app-bundled wins over stale npm" t_codex_chatgpt_app_bundled_wins_over_npm
 run_case "unknown connector returns empty"   t_unknown_connector

--- a/packaging/macos/tests/test_packaging_assets.sh
+++ b/packaging/macos/tests/test_packaging_assets.sh
@@ -449,23 +449,32 @@ t_plist_validator_fails_closed_when_stat_output_empty() {
   assert_contains "${out}" "cannot stat plist source" "explains why"
 }
 
-t_install_treats_lonely_install_log_as_fresh_host() {
-  # Regression guard: install.sh's log-sink tee (added for the
-  # observability fixes) creates ${LOGS_DIR}/install.log immediately
-  # after the euid check, BEFORE the fresh-host preflight enumerates
-  # existing install markers. Without a special case, the preflight
-  # then sees ${LOGS_DIR} exists and refuses with "existing DefenseClaw
-  # installation detected at /Library/Logs/Cisco/SecureClient/DefenseClaw"
-  # — which locks the operator out of reinstalling after a --purge
-  # cycle. The special-case allow-list-of-one accepts LOGS_DIR when
-  # its ONLY child is install.log (i.e. the residue we just created
-  # for our own logging), and rejects it when any other file remains
-  # (gateway.log, hook-guardian.log, etc. from a real prior install).
-  local body; body="$(cat "${REPO_ROOT}/packaging/macos/install.sh")"
-  assert_contains "${body}" 'if [[ "${_marker}" == "${LOGS_DIR}" ]] && [[ -d "${_marker}" ]]; then' \
-    "install.sh must special-case LOGS_DIR in the fresh-host preflight so a lonely install.log does not block reinstall"
-  assert_contains "${body}" '! -name install.log' \
-    "the LOGS_DIR special case must exempt install.log specifically (not blanket-skip LOGS_DIR)"
+t_install_log_sink_is_after_preflight() {
+  # Regression guard: install.sh's persistent log-sink tee must NOT
+  # fire before the fresh-host preflight. Setting it up earlier
+  # implicitly creates ${LOGS_DIR}/install.log which then trips both:
+  #   1. The fresh-host marker loop (LOGS_DIR appears "existing")
+  #   2. The `create_install_directory_no_replace ${LOGS_DIR}` at
+  #      line ~678 (the dir was already created by mkdir -p)
+  # Either failure locks the operator out of reinstall after
+  # uninstall --purge. Uninstall wipes LOGS_DIR wholesale so no
+  # persistence across install/uninstall cycles is desired anyway.
+  #
+  # This test enforces the ordering by grepping for both landmarks
+  # (the tee call + the LOGS_DIR creation) and asserting the tee
+  # appears AFTER the create_install_directory_no_replace line.
+  local install="${REPO_ROOT}/packaging/macos/install.sh"
+  local tee_line create_line
+  tee_line="$(grep -n 'tee -a "\${_install_log_path}"' "${install}" | head -1 | cut -d: -f1)"
+  create_line="$(grep -n 'create_install_directory_no_replace "\${LOGS_DIR}"' "${install}" | head -1 | cut -d: -f1)"
+  if [[ -z "${tee_line}" || -z "${create_line}" ]]; then
+    _fail "could not locate install.log tee (line=${tee_line:-?}) or LOGS_DIR creation (line=${create_line:-?}) in install.sh"
+    return 1
+  fi
+  if (( tee_line < create_line )); then
+    _fail "install.log tee at line ${tee_line} precedes LOGS_DIR creation at line ${create_line} — self-lockout on reinstall"
+    return 1
+  fi
 }
 
 t_install_does_not_precreate_cmid_log_file() {
@@ -575,7 +584,7 @@ run_case "render-targets.sh present + executable + parses" t_render_targets_sh_e
 run_case "install.sh bootstraps guardian + enumerator daemons" t_install_bootstraps_guardian_and_enumerator
 run_case "install.sh no longer inline-calls 'enterprise hooks install'" t_install_no_longer_hardcodes_single_target_user
 run_case "plist references managed paths" t_plist_contains_managed_paths
-run_case "install.sh treats lonely install.log as fresh-host (no self-lockout)"     t_install_treats_lonely_install_log_as_fresh_host
+run_case "install.log sink is set up AFTER fresh-host preflight + LOGS_DIR create" t_install_log_sink_is_after_preflight
 run_case "install does not pre-create CMID log file (root daemon owns lifecycle)"    t_install_does_not_precreate_cmid_log_file
 run_case "install does not relax CMID store perms (root daemon owns lifecycle)"      t_install_does_not_relax_cmid_store_perms
 run_case "uninstall still sweeps legacy CMID log file from pre-root installs"        t_uninstall_still_sweeps_legacy_cmid_log_file

--- a/packaging/macos/tests/test_packaging_assets.sh
+++ b/packaging/macos/tests/test_packaging_assets.sh
@@ -449,6 +449,25 @@ t_plist_validator_fails_closed_when_stat_output_empty() {
   assert_contains "${out}" "cannot stat plist source" "explains why"
 }
 
+t_install_treats_lonely_install_log_as_fresh_host() {
+  # Regression guard: install.sh's log-sink tee (added for the
+  # observability fixes) creates ${LOGS_DIR}/install.log immediately
+  # after the euid check, BEFORE the fresh-host preflight enumerates
+  # existing install markers. Without a special case, the preflight
+  # then sees ${LOGS_DIR} exists and refuses with "existing DefenseClaw
+  # installation detected at /Library/Logs/Cisco/SecureClient/DefenseClaw"
+  # — which locks the operator out of reinstalling after a --purge
+  # cycle. The special-case allow-list-of-one accepts LOGS_DIR when
+  # its ONLY child is install.log (i.e. the residue we just created
+  # for our own logging), and rejects it when any other file remains
+  # (gateway.log, hook-guardian.log, etc. from a real prior install).
+  local body; body="$(cat "${REPO_ROOT}/packaging/macos/install.sh")"
+  assert_contains "${body}" 'if [[ "${_marker}" == "${LOGS_DIR}" ]] && [[ -d "${_marker}" ]]; then' \
+    "install.sh must special-case LOGS_DIR in the fresh-host preflight so a lonely install.log does not block reinstall"
+  assert_contains "${body}" '! -name install.log' \
+    "the LOGS_DIR special case must exempt install.log specifically (not blanket-skip LOGS_DIR)"
+}
+
 t_install_does_not_precreate_cmid_log_file() {
   # Running the daemon as root means the managed cloud auth provider
   # can create its own log file without any installer help. The earlier
@@ -556,6 +575,7 @@ run_case "render-targets.sh present + executable + parses" t_render_targets_sh_e
 run_case "install.sh bootstraps guardian + enumerator daemons" t_install_bootstraps_guardian_and_enumerator
 run_case "install.sh no longer inline-calls 'enterprise hooks install'" t_install_no_longer_hardcodes_single_target_user
 run_case "plist references managed paths" t_plist_contains_managed_paths
+run_case "install.sh treats lonely install.log as fresh-host (no self-lockout)"     t_install_treats_lonely_install_log_as_fresh_host
 run_case "install does not pre-create CMID log file (root daemon owns lifecycle)"    t_install_does_not_precreate_cmid_log_file
 run_case "install does not relax CMID store perms (root daemon owns lifecycle)"      t_install_does_not_relax_cmid_store_perms
 run_case "uninstall still sweeps legacy CMID log file from pre-root installs"        t_uninstall_still_sweeps_legacy_cmid_log_file

--- a/packaging/macos/tests/test_packaging_assets.sh
+++ b/packaging/macos/tests/test_packaging_assets.sh
@@ -42,9 +42,28 @@ t_guardian_and_enumerator_plists_exist_and_parse() {
   body="$(cat "${g}")"
   assert_contains "${body}" "enterprise" "guardian invokes enterprise subcommand"
   assert_contains "${body}" "hooks"      "guardian invokes hooks subcommand"
-  assert_contains "${body}" "reconcile"  "guardian runs reconcile"
+  # The guardian runs the long-running `watch` mode so tampering with a
+  # per-user hook config or hook script is fsnotify-detected and healed
+  # within ~1 s. If this ever regresses back to `reconcile`, heal
+  # latency silently blows out to ~5 min.
+  assert_contains "${body}" "<string>watch</string>" "guardian runs long-running watch mode"
+  assert_not_contains "${body}" "<string>reconcile</string>" \
+    "guardian must not use one-shot reconcile (regresses fsnotify auto-heal)"
+  # --interval 60s is the periodic backstop *inside* watch; it is NOT a
+  # substitute for real fsnotify reactivity. Both must be present.
+  # 60s (was 5m) tightens worst-case tamper-detection for SharedWriter
+  # Write tampers (native agent configs) and generic-script Writes to
+  # ~1 min. No additional resource cost — same long-running process.
+  assert_contains "${body}" "<string>--interval</string>" "guardian passes --interval flag"
+  assert_contains "${body}" "<string>60s</string>"        "guardian backstop interval is 60s"
   assert_contains "${body}" "/opt/cisco/secureclient/defenseclaw/hook-guardian/targets.yaml" \
     "guardian points at the installer-rendered manifest path"
+  # Restart policy: KeepAlive (right for long-running watch) NOT
+  # StartInterval (would relaunch every N seconds — pointless with a
+  # long-running process and would spawn duplicates).
+  assert_contains "${body}" "<key>KeepAlive</key>" "guardian uses KeepAlive"
+  assert_not_contains "${body}" "<key>StartInterval</key>" \
+    "guardian must not use StartInterval in watch mode (would relaunch long-running process)"
 }
 
 t_render_targets_sh_exists_and_is_executable() {

--- a/packaging/macos/tests/test_packaging_assets.sh
+++ b/packaging/macos/tests/test_packaging_assets.sh
@@ -12,6 +12,112 @@ t_plist_exists_and_parses() {
   fi
 }
 
+t_guardian_and_enumerator_plists_exist_and_parse() {
+  # The hook-guardian + hook-enumerator LaunchDaemons together deliver
+  # per-user hook wiring for every eligible local user on the box.
+  # install.sh installs and bootstraps both; the shipped bundle must
+  # therefore include both plist templates.
+  local g="${REPO_ROOT}/packaging/launchd/com.cisco.secureclient.defenseclaw.hook-guardian.plist"
+  local e="${REPO_ROOT}/packaging/launchd/com.cisco.secureclient.defenseclaw.hook-enumerator.plist"
+  assert_file_exists "${g}"
+  assert_file_exists "${e}"
+  if command -v plutil >/dev/null 2>&1; then
+    local out rc=0
+    out="$(plutil -lint "${g}" 2>&1)" || rc=$?
+    assert_status "${rc}" 0 "guardian plutil -lint should succeed"
+    out="$(plutil -lint "${e}" 2>&1)" || rc=$?
+    assert_status "${rc}" 0 "enumerator plutil -lint should succeed"
+  fi
+  # The enumerator invokes the render-targets.sh helper we ship under
+  # /opt/cisco/secureclient/defenseclaw/lib/render-targets.sh. If a
+  # future edit accidentally points at a stale bin/ path, catch it here.
+  local body
+  body="$(cat "${e}")"
+  assert_contains "${body}" "/opt/cisco/secureclient/defenseclaw/lib/render-targets.sh" \
+    "enumerator plist points at lib/render-targets.sh"
+  assert_contains "${body}" "<key>StartInterval</key>" "enumerator has StartInterval"
+  assert_contains "${body}" "com.cisco.secureclient.defenseclaw.hook-enumerator" \
+    "enumerator label is namespaced under com.cisco.secureclient.defenseclaw"
+
+  body="$(cat "${g}")"
+  assert_contains "${body}" "enterprise" "guardian invokes enterprise subcommand"
+  assert_contains "${body}" "hooks"      "guardian invokes hooks subcommand"
+  assert_contains "${body}" "reconcile"  "guardian runs reconcile"
+  assert_contains "${body}" "/opt/cisco/secureclient/defenseclaw/hook-guardian/targets.yaml" \
+    "guardian points at the installer-rendered manifest path"
+}
+
+t_render_targets_sh_exists_and_is_executable() {
+  # render-targets.sh is invoked by the hook-enumerator LaunchDaemon.
+  # It must be shipped in the bundle and be +x so /bin/bash doesn't
+  # need to be edited to allow execution.
+  local rt="${PKG_DIR}/lib/render-targets.sh"
+  assert_file_exists "${rt}"
+  if [[ ! -x "${rt}" ]]; then
+    _fail "render-targets.sh missing +x"
+    return 1
+  fi
+  local rc=0
+  bash -n "${rt}" 2>&1 || rc=$?
+  assert_status "${rc}" 0 "render-targets.sh parses cleanly"
+}
+
+t_install_bootstraps_guardian_and_enumerator() {
+  # Regression guard: install.sh MUST install and bootstrap both the
+  # hook-guardian and hook-enumerator LaunchDaemons — otherwise no
+  # user's hooks ever get wired on a fresh customer install.
+  local body
+  body="$(cat "${PKG_DIR}/install.sh")"
+  assert_contains "${body}" 'install_file_no_replace "${GUARDIAN_PLIST_SRC}" "${GUARDIAN_PLIST_DST}"' \
+    "install.sh copies the guardian plist"
+  assert_contains "${body}" 'install_file_no_replace "${ENUMERATOR_PLIST_SRC}" "${ENUMERATOR_PLIST_DST}"' \
+    "install.sh copies the enumerator plist"
+  assert_contains "${body}" 'launchctl bootstrap system "${GUARDIAN_PLIST_DST}"' \
+    "install.sh bootstraps the guardian daemon"
+  assert_contains "${body}" 'launchctl bootstrap system "${ENUMERATOR_PLIST_DST}"' \
+    "install.sh bootstraps the enumerator daemon"
+  assert_contains "${body}" 'render_targets_manifest' \
+    "install.sh renders the initial targets.yaml manifest"
+  assert_contains "${body}" 'enumerate_local_users' \
+    "install.sh enumerates local users via the shared helper"
+}
+
+t_install_no_longer_hardcodes_single_target_user() {
+  # Regression guard: the pre-2026.7.3 flow called
+  #   "${GATEWAY_BIN}" enterprise hooks install --connector ... --user "${TARGET_USER}"
+  # inline, which silently no-op'd whenever TARGET_USER was empty. The
+  # multi-user rewrite REPLACES those inline calls with a manifest-based
+  # reconcile owned by the hook-guardian LaunchDaemon. Grepping for a
+  # bare `enterprise hooks install` invocation must return zero code
+  # matches (comments are fine — they're filtered by the same grep the
+  # guardian-auth-dir regression test uses).
+  local bad
+  bad="$(/usr/bin/python3 - "${PKG_DIR}/install.sh" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+joined = re.sub(r"\\\n\s*", " ", src)
+bad = []
+for i, line in enumerate(joined.splitlines(), start=1):
+    if "enterprise hooks install" not in line:
+        continue
+    # Skip pure prints / logs / comments.
+    stripped = line.lstrip()
+    if stripped.startswith("#"):
+        continue
+    if re.search(r"\blog\b|\bwarn\b|\bprintf\b", line):
+        continue
+    bad.append((i, line.strip()[:200]))
+for i, l in bad:
+    print(f"{i}: {l}")
+PY
+)"
+  if [[ -n "${bad}" ]]; then
+    _fail "found live 'enterprise hooks install' invocation(s) in install.sh — the multi-user rewrite should route wiring through the hook-guardian reconcile only:
+${bad}"
+    return 1
+  fi
+}
+
 t_plist_contains_managed_paths() {
   local plist="${REPO_ROOT}/packaging/launchd/com.cisco.secureclient.defenseclaw.plist"
   local body; body="$(cat "${plist}")"
@@ -445,6 +551,10 @@ t_install_refuses_existing_state_before_build_or_launchd_mutation() {
 }
 
 run_case "plist exists and lints"     t_plist_exists_and_parses
+run_case "guardian + enumerator plists exist and lint" t_guardian_and_enumerator_plists_exist_and_parse
+run_case "render-targets.sh present + executable + parses" t_render_targets_sh_exists_and_is_executable
+run_case "install.sh bootstraps guardian + enumerator daemons" t_install_bootstraps_guardian_and_enumerator
+run_case "install.sh no longer inline-calls 'enterprise hooks install'" t_install_no_longer_hardcodes_single_target_user
 run_case "plist references managed paths" t_plist_contains_managed_paths
 run_case "install does not pre-create CMID log file (root daemon owns lifecycle)"    t_install_does_not_precreate_cmid_log_file
 run_case "install does not relax CMID store perms (root daemon owns lifecycle)"      t_install_does_not_relax_cmid_store_perms

--- a/packaging/macos/tests/test_render_targets_extract.sh
+++ b/packaging/macos/tests/test_render_targets_extract.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# extract_connectors: regex scan of render_config output MUST NOT
+# produce duplicates when both the `connector:` scalar (the primary)
+# and the `connectors:` map are present in guardrail.yaml. This is the
+# shape render_config emits for multi-connector installs — a naive
+# scanner would add the primary once, then re-add every map key
+# (including the primary), producing e.g. [codex, codex, claudecode,
+# cursor]. That garbage feeds into the hook-guardian's Install loop
+# which then reconciles the same target twice per tick.
+#
+# The extractor lives inside packaging/macos/lib/render-targets.sh
+# because the daemon that invokes it (hook-enumerator) runs as root
+# and cannot see PyYAML if it's installed only under a user's
+# ~/Library/Python site-packages. render-targets.sh therefore uses a
+# regex-only scanner deliberately.
+
+. "${PKG_DIR}/lib/installer_lib.sh"
+
+RENDER_TARGETS_SH="${PKG_DIR}/lib/render-targets.sh"
+
+# Extract the extract_connectors function body into a callable file so
+# we can drive it against synthetic config.yaml fixtures without
+# running the full render-targets.sh script (which asserts root + real
+# support-dir paths).
+_seed_extract_wrapper() {
+  local dir="$1" cfg="$2"
+  local wrapper="${dir}/extract-wrapper.sh"
+  cat > "${wrapper}" <<EOF
+#!/usr/bin/env bash
+CONFIG_PATH="${cfg}"
+$(/usr/bin/awk '/^extract_connectors\(\)/{found=1} found{print} /^}$/{if(found){exit}}' "${RENDER_TARGETS_SH}")
+extract_connectors
+EOF
+  chmod 0755 "${wrapper}"
+  printf '%s' "${wrapper}"
+}
+
+t_extract_connectors_multi_connector_no_duplicates() {
+  # This is the exact shape render_config emits for a
+  # --connector codex,claudecode,cursor install (see t_multi_connector
+  # in test_render_config.sh). Both the primary scalar AND the map are
+  # present. The extractor must return each connector exactly once.
+  local dir cfg wrapper out lines
+  dir="$(mktest_tmp)"
+  cfg="${dir}/config.yaml"
+  cat > "${cfg}" <<'YAML'
+config_version: 6
+deployment_mode: managed_enterprise
+guardrail:
+  enabled: true
+  mode: action
+  scanner_mode: both
+  detection_strategy: regex_only
+  judge:
+    enabled: false
+  connector: codex
+  connectors:
+    codex:
+      enabled: true
+      mode: action
+    claudecode:
+      enabled: true
+      mode: action
+    cursor:
+      enabled: true
+      mode: action
+
+cisco_ai_defense:
+  endpoint: "https://preview.example.com"
+YAML
+  wrapper="$(_seed_extract_wrapper "${dir}" "${cfg}")"
+  out="$(bash "${wrapper}" 2>&1)"
+  lines="$(printf '%s\n' "${out}" | grep -c . || true)"
+  assert_contains "${out}" "codex"      "codex extracted"
+  assert_contains "${out}" "claudecode" "claudecode extracted"
+  assert_contains "${out}" "cursor"     "cursor extracted"
+  assert_eq "${lines}" "3" "exactly 3 connectors extracted (no duplicate from primary + map both present)"
+}
+
+t_extract_connectors_single_connector_scalar_only() {
+  # When the operator picks a single connector, render_config emits ONLY
+  # the `connector:` scalar (no `connectors:` map). Extractor must fall
+  # back to the scalar in that case.
+  local dir cfg wrapper out lines
+  dir="$(mktest_tmp)"
+  cfg="${dir}/config.yaml"
+  cat > "${cfg}" <<'YAML'
+config_version: 6
+deployment_mode: managed_enterprise
+guardrail:
+  enabled: true
+  mode: action
+  scanner_mode: both
+  connector: codex
+
+cisco_ai_defense:
+  endpoint: "https://preview.example.com"
+YAML
+  wrapper="$(_seed_extract_wrapper "${dir}" "${cfg}")"
+  out="$(bash "${wrapper}" 2>&1)"
+  lines="$(printf '%s\n' "${out}" | grep -c . || true)"
+  assert_eq "${lines}" "1" "single-connector install extracts exactly one entry"
+  assert_contains "${out}" "codex" "codex extracted from single scalar"
+}
+
+t_extract_connectors_ignores_top_level_connector_lookalike() {
+  # Regression guard: another top-level block that happens to contain a
+  # `connector:` key must NOT be picked up. Only the guardrail: block
+  # counts. This is defence-in-depth against a future edit to
+  # render_config adding e.g. an `openclaw.connector: something` block.
+  local dir cfg wrapper out lines
+  dir="$(mktest_tmp)"
+  cfg="${dir}/config.yaml"
+  cat > "${cfg}" <<'YAML'
+config_version: 6
+deployment_mode: managed_enterprise
+openclaw:
+  connector: bogus
+guardrail:
+  enabled: true
+  connector: codex
+YAML
+  wrapper="$(_seed_extract_wrapper "${dir}" "${cfg}")"
+  out="$(bash "${wrapper}" 2>&1)"
+  lines="$(printf '%s\n' "${out}" | grep -c . || true)"
+  assert_eq "${lines}" "1" "only guardrail.connector is picked up"
+  assert_contains     "${out}" "codex" "codex extracted"
+  assert_not_contains "${out}" "bogus" "top-level connector: outside guardrail is ignored"
+}
+
+run_case "extract_connectors: multi-connector no duplicates"     t_extract_connectors_multi_connector_no_duplicates
+run_case "extract_connectors: single-connector scalar fallback"  t_extract_connectors_single_connector_scalar_only
+run_case "extract_connectors: ignores non-guardrail connector:"  t_extract_connectors_ignores_top_level_connector_lookalike

--- a/packaging/macos/tests/test_render_targets_manifest.sh
+++ b/packaging/macos/tests/test_render_targets_manifest.sh
@@ -145,6 +145,43 @@ t_rows_omit_data_dir() {
   assert_not_contains "${out}" "data_dir:" "data_dir must be omitted from targets.yaml"
 }
 
+t_hostile_agent_version_cannot_inject_targets() {
+  if ! command -v /usr/bin/python3 >/dev/null 2>&1; then
+    if [[ "${VERBOSE:-false}" == "true" ]]; then printf '  skip (no python3)\n'; fi
+    return 0
+  fi
+  if ! /usr/bin/python3 -c "import yaml" 2>/dev/null; then
+    if [[ "${VERBOSE:-false}" == "true" ]]; then printf '  skip (PyYAML not installed)\n'; fi
+    return 0
+  fi
+
+  discover_agent_version() {
+    printf '1.2.3"\n    enabled: false\n  - user: "victim"\n    user_home: "/Users/victim"\n    uid: 502\n    gid: 20\n    connector: "codex"\n    agent_version: "9.9.9'
+  }
+
+  local users out parsed
+  users="alice:501:20:/Users/alice"
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "codex" "${users}")"
+  parsed="$(printf '%s\n' "${out}" | /usr/bin/python3 -c '
+import sys, json, yaml
+doc = yaml.safe_load(sys.stdin) or {}
+targets = doc.get("targets") or []
+assert len(targets) == 1, "expected one rendered target, got %r" % (targets,)
+target = targets[0]
+assert target.get("user") == "alice", target
+assert target.get("enabled") is True, target
+assert target.get("agent_version") == "", target
+print(json.dumps(target, sort_keys=True))
+' 2>&1)" || {
+    _fail "hostile agent_version reshaped targets.yaml: ${parsed}
+Rendered:
+${out}"
+    return 1
+  }
+  assert_contains "${parsed}" '"user": "alice"' "only alice target remains after hostile version"
+  assert_not_contains "${parsed}" "victim" "hostile injected victim target not present"
+}
+
 run_case "multi-user × multi-connector cross-product"           t_multi_user_multi_connector_produces_cross_product
 run_case "unsupported connectors dropped"                       t_unsupported_connector_skipped
 run_case "empty user list still emits valid manifest"           t_empty_users_still_emits_valid_manifest
@@ -152,3 +189,4 @@ run_case "empty connector list still emits valid manifest"      t_empty_connecto
 run_case "rendered targets.yaml parses (schema round-trip)"     t_rendered_yaml_parses
 run_case "rows pin enabled + int uid/gid"                       t_rows_pin_enabled_and_int_uid_gid
 run_case "rows omit data_dir (per-user Install default is used)" t_rows_omit_data_dir
+run_case "hostile agent version cannot inject targets"          t_hostile_agent_version_cannot_inject_targets

--- a/packaging/macos/tests/test_render_targets_manifest.sh
+++ b/packaging/macos/tests/test_render_targets_manifest.sh
@@ -29,7 +29,11 @@ bob:502:20:/Users/bob"
   assert_contains "${out}" 'user_home: "/Users/bob"'   "bob home"
   assert_contains "${out}" 'connector: "codex"'      "codex connector"
   assert_contains "${out}" 'connector: "claudecode"' "claudecode connector"
-  assert_contains "${out}" "data_dir: \"${TEST_RUNTIME}\"" "data_dir under support"
+  # data_dir is deliberately NOT emitted per-target: the guardian's
+  # validateUserDataDir requires data_dir to be inside the target user's
+  # home, but SUPPORT_DIR/runtime is machine-wide root storage. Letting
+  # Install() default per-user to ~/.defenseclaw is correct.
+  assert_not_contains "${out}" "data_dir:" "data_dir intentionally absent (per-user Install default is used)"
   # Rough sanity: expect at least 4 `- user:` block markers.
   local count
   count="$(printf '%s\n' "${out}" | grep -c "^  - user:" || true)"
@@ -114,18 +118,31 @@ print(json.dumps({"users": users, "connectors": conns, "count": len(targets)}))
   assert_contains "${parsed}" '"count": 4'   "4 targets total (2 users × 2 connectors)"
 }
 
-t_rows_pin_data_dir_and_enabled() {
-  # Every emitted target must set data_dir (so the enterprise hooks
-  # installer knows where to write) and enabled: true (the guardian
-  # will skip enabled:false rows, and an omitted field defaults to
-  # true — but rendering it explicitly is defensive).
+t_rows_pin_enabled_and_int_uid_gid() {
+  # Every emitted target must set enabled: true (the guardian will skip
+  # enabled:false rows, and an omitted field defaults to true — but
+  # rendering it explicitly is defensive) and integer uid/gid.
   local users="alice:501:20:/Users/alice"
   local out
   out="$(render_targets_manifest "${TEST_SUPPORT}" "codex" "${users}")"
-  assert_contains "${out}" "data_dir: \"${TEST_RUNTIME}\"" "data_dir emitted"
-  assert_contains "${out}" "enabled: true"                 "enabled: true emitted"
-  assert_contains "${out}" "uid: 501"                       "uid emitted as int"
-  assert_contains "${out}" "gid: 20"                        "gid emitted as int"
+  assert_contains "${out}" "enabled: true"    "enabled: true emitted"
+  assert_contains "${out}" "uid: 501"         "uid emitted as int"
+  assert_contains "${out}" "gid: 20"          "gid emitted as int"
+}
+
+t_rows_omit_data_dir() {
+  # Regression guard for the multi-user-hook-wiring fix. The guardian's
+  # per-target Install runs validateUserDataDir which refuses any data_dir
+  # outside the target user's home. Emitting SUPPORT_DIR/runtime (which
+  # is machine-wide root storage) would produce
+  #   "refusing data dir outside user home: ..."
+  # for every target. Instead we omit data_dir entirely and let Install()
+  # default to ~/.defenseclaw per user. If a future edit re-adds a
+  # machine-wide data_dir here, this test flags it.
+  local users="alice:501:20:/Users/alice"
+  local out
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "codex" "${users}")"
+  assert_not_contains "${out}" "data_dir:" "data_dir must be omitted from targets.yaml"
 }
 
 run_case "multi-user × multi-connector cross-product"           t_multi_user_multi_connector_produces_cross_product
@@ -133,4 +150,5 @@ run_case "unsupported connectors dropped"                       t_unsupported_co
 run_case "empty user list still emits valid manifest"           t_empty_users_still_emits_valid_manifest
 run_case "empty connector list still emits valid manifest"      t_empty_connectors_still_emits_valid_manifest
 run_case "rendered targets.yaml parses (schema round-trip)"     t_rendered_yaml_parses
-run_case "rows pin data_dir + enabled + int uid/gid"            t_rows_pin_data_dir_and_enabled
+run_case "rows pin enabled + int uid/gid"                       t_rows_pin_enabled_and_int_uid_gid
+run_case "rows omit data_dir (per-user Install default is used)" t_rows_omit_data_dir

--- a/packaging/macos/tests/test_render_targets_manifest.sh
+++ b/packaging/macos/tests/test_render_targets_manifest.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# render_targets_manifest: hook-guardian targets.yaml rendering.
+#
+# The manifest schema is defined by ManifestTarget in
+# internal/enterprisehooks/manifest.go — LoadManifest requires that every
+# enabled target carry both `connector` and (`user` or `user_home`). The
+# fields we render (user, user_home, uid, gid, connector, data_dir,
+# agent_version, enabled) mirror the struct's yaml tags 1:1.
+
+. "${PKG_DIR}/lib/installer_lib.sh"
+
+# Test uses fixed support dir so paths stay comparable across runs.
+TEST_SUPPORT="/opt/cisco/secureclient/defenseclaw"
+TEST_RUNTIME="${TEST_SUPPORT}/runtime"
+
+t_multi_user_multi_connector_produces_cross_product() {
+  local users
+  users="alice:501:20:/Users/alice
+bob:502:20:/Users/bob"
+  local out
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "codex,claudecode" "${users}")"
+
+  assert_contains "${out}" "version: 1"          "version header"
+  assert_contains "${out}" "targets:"            "targets: block"
+  # alice × 2 connectors, bob × 2 connectors = 4 rows
+  assert_contains "${out}" 'user: "alice"'       "alice row"
+  assert_contains "${out}" 'user: "bob"'         "bob row"
+  assert_contains "${out}" 'user_home: "/Users/alice"' "alice home"
+  assert_contains "${out}" 'user_home: "/Users/bob"'   "bob home"
+  assert_contains "${out}" 'connector: "codex"'      "codex connector"
+  assert_contains "${out}" 'connector: "claudecode"' "claudecode connector"
+  assert_contains "${out}" "data_dir: \"${TEST_RUNTIME}\"" "data_dir under support"
+  # Rough sanity: expect at least 4 `- user:` block markers.
+  local count
+  count="$(printf '%s\n' "${out}" | grep -c "^  - user:" || true)"
+  assert_eq "${count}" "4" "expected 4 target rows (2 users × 2 supported connectors)"
+}
+
+t_unsupported_connector_skipped() {
+  # `windsurf` is not in is_supported_connector; it must be dropped
+  # even if the caller lists it in the CSV.
+  local users="alice:501:20:/Users/alice"
+  local out
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "codex,windsurf" "${users}")"
+
+  assert_contains     "${out}" 'connector: "codex"'    "codex kept"
+  assert_not_contains "${out}" 'connector: "windsurf"' "unsupported connector dropped"
+
+  # Only 1 row should remain (alice × codex).
+  local count
+  count="$(printf '%s\n' "${out}" | grep -c "^  - user:" || true)"
+  assert_eq "${count}" "1" "unsupported connector must not appear as a target"
+}
+
+t_empty_users_still_emits_valid_manifest() {
+  # No users on the box yet — the enumerator will fill this in later, but
+  # right now the guardian must be able to load the file without errors.
+  local out
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "codex" "")"
+  assert_contains "${out}" "version: 1" "empty manifest still has version"
+  assert_contains "${out}" "targets:"   "empty manifest still has targets:"
+  local count
+  count="$(printf '%s\n' "${out}" | grep -c "^  - user:" || true)"
+  assert_eq "${count}" "0" "no user lines when USER_LINES is empty"
+}
+
+t_empty_connectors_still_emits_valid_manifest() {
+  # Similarly: connectors CSV was rejected upstream, so we get here with
+  # no valid connectors. Still emit a parseable manifest.
+  local users="alice:501:20:/Users/alice"
+  local out
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "" "${users}")"
+  assert_contains "${out}" "version: 1" "empty-connector manifest still has version"
+  assert_contains "${out}" "targets:"   "empty-connector manifest still has targets:"
+  local count
+  count="$(printf '%s\n' "${out}" | grep -c "^  - user:" || true)"
+  assert_eq "${count}" "0" "no user lines when CONNECTORS is empty"
+}
+
+t_rendered_yaml_parses() {
+  # Best-effort: if PyYAML is available, verify the output actually
+  # parses as valid YAML matching the ManifestTarget schema shape.
+  if ! command -v /usr/bin/python3 >/dev/null 2>&1; then
+    if [[ "${VERBOSE:-false}" == "true" ]]; then printf '  skip (no python3)\n'; fi
+    return 0
+  fi
+  if ! /usr/bin/python3 -c "import yaml" 2>/dev/null; then
+    if [[ "${VERBOSE:-false}" == "true" ]]; then printf '  skip (PyYAML not installed)\n'; fi
+    return 0
+  fi
+  local users out parsed
+  users="alice:501:20:/Users/alice
+bob:502:20:/Users/bob"
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "codex,cursor" "${users}")"
+  parsed="$(printf '%s\n' "${out}" | /usr/bin/python3 -c '
+import sys, json, yaml
+doc = yaml.safe_load(sys.stdin) or {}
+assert isinstance(doc, dict), "top-level must be a mapping"
+version = doc.get("version")
+assert version == 1, "version must be 1, got %r" % (version,)
+targets = doc.get("targets") or []
+assert isinstance(targets, list), "targets must be a list"
+users = sorted({t.get("user") for t in targets})
+conns = sorted({t.get("connector") for t in targets})
+print(json.dumps({"users": users, "connectors": conns, "count": len(targets)}))
+' 2>&1)" || {
+    _fail "rendered YAML did not parse: ${parsed}"
+    return 1
+  }
+  assert_contains "${parsed}" '"alice"'      "alice appears in parsed targets"
+  assert_contains "${parsed}" '"bob"'        "bob appears in parsed targets"
+  assert_contains "${parsed}" '"codex"'      "codex appears in parsed connectors"
+  assert_contains "${parsed}" '"cursor"'     "cursor appears in parsed connectors"
+  assert_contains "${parsed}" '"count": 4'   "4 targets total (2 users × 2 connectors)"
+}
+
+t_rows_pin_data_dir_and_enabled() {
+  # Every emitted target must set data_dir (so the enterprise hooks
+  # installer knows where to write) and enabled: true (the guardian
+  # will skip enabled:false rows, and an omitted field defaults to
+  # true — but rendering it explicitly is defensive).
+  local users="alice:501:20:/Users/alice"
+  local out
+  out="$(render_targets_manifest "${TEST_SUPPORT}" "codex" "${users}")"
+  assert_contains "${out}" "data_dir: \"${TEST_RUNTIME}\"" "data_dir emitted"
+  assert_contains "${out}" "enabled: true"                 "enabled: true emitted"
+  assert_contains "${out}" "uid: 501"                       "uid emitted as int"
+  assert_contains "${out}" "gid: 20"                        "gid emitted as int"
+}
+
+run_case "multi-user × multi-connector cross-product"           t_multi_user_multi_connector_produces_cross_product
+run_case "unsupported connectors dropped"                       t_unsupported_connector_skipped
+run_case "empty user list still emits valid manifest"           t_empty_users_still_emits_valid_manifest
+run_case "empty connector list still emits valid manifest"      t_empty_connectors_still_emits_valid_manifest
+run_case "rendered targets.yaml parses (schema round-trip)"     t_rendered_yaml_parses
+run_case "rows pin data_dir + enabled + int uid/gid"            t_rows_pin_data_dir_and_enabled

--- a/packaging/macos/uninstall.sh
+++ b/packaging/macos/uninstall.sh
@@ -37,6 +37,10 @@ SUPPORT_DIR="${INSTALL_PREFIX}"
 LOGS_DIR="/Library/Logs/Cisco/SecureClient/DefenseClaw"
 PLIST_DST="/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.plist"
 LAUNCHD_LABEL="com.cisco.secureclient.defenseclaw"
+GUARDIAN_PLIST_DST="/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.hook-guardian.plist"
+GUARDIAN_LAUNCHD_LABEL="com.cisco.secureclient.defenseclaw.hook-guardian"
+ENUMERATOR_PLIST_DST="/Library/LaunchDaemons/com.cisco.secureclient.defenseclaw.hook-enumerator.plist"
+ENUMERATOR_LAUNCHD_LABEL="com.cisco.secureclient.defenseclaw.hook-enumerator"
 
 # Legacy paths + labels from pre-managed-layout DefenseClaw installs.
 # Kept so that running the new uninstall.sh on an old-layout host
@@ -46,6 +50,8 @@ LEGACY_SUPPORT_DIR="/Library/Application Support/DefenseClaw"
 LEGACY_LOGS_DIR="/Library/Logs/DefenseClaw"
 LEGACY_PLIST_DST="/Library/LaunchDaemons/com.defenseclaw.gateway.plist"
 LEGACY_LAUNCHD_LABEL="com.defenseclaw.gateway"
+LEGACY_GUARDIAN_PLIST_DST="/Library/LaunchDaemons/com.defenseclaw.hook-guardian.plist"
+LEGACY_GUARDIAN_LAUNCHD_LABEL="com.defenseclaw.hook-guardian"
 
 # Legacy service-user names swept on --purge. Pre-root DefenseClaw
 # installs created these accounts via ensure_service_user in install.sh.
@@ -57,6 +63,25 @@ ASSUME_YES="false"
 TARGET_USER=""
 KEEP_AGENT_CONFIGS="false"
 SCRUB_FAILED="false"
+
+# Source enumerate_local_users + home_perms_ok if the library is present.
+# uninstall.sh runs in three contexts: from a shipped bundle (SCRIPT_DIR
+# has lib/ beside it), from the managed install tree (SUPPORT_DIR/lib/),
+# and from the repo tree during tests. Try each; a missing lib just
+# means multi-user iteration falls back to the single-user SUDO_USER
+# path below.
+_UNINSTALL_LIB=""
+for _c in \
+  "${SCRIPT_DIR}/lib/installer_lib.sh" \
+  "${SUPPORT_DIR}/lib/installer_lib.sh" \
+  "${SCRIPT_DIR}/../lib/installer_lib.sh"; do
+  if [[ -f "${_c}" ]]; then _UNINSTALL_LIB="${_c}"; break; fi
+done
+unset _c
+if [[ -n "${_UNINSTALL_LIB}" ]]; then
+  # shellcheck source=lib/installer_lib.sh
+  . "${_UNINSTALL_LIB}"
+fi
 
 # ---- helpers ------------------------------------------------------------
 
@@ -130,16 +155,39 @@ done
 [[ "$(uname -s)" == "Darwin" ]] || die "macOS only"
 [[ $EUID -eq 0 ]] || die "must run as root (try: sudo $0 $*)"
 
+# Purge targets: newline-separated user:uid:gid:home lines. When --user
+# is passed explicitly, resolve that one user; otherwise iterate every
+# eligible local user via enumerate_local_users (falls back to SUDO_USER
+# if the library isn't sourced in this environment).
+PURGE_TARGETS=""
 if [[ "${PURGE}" == "true" ]]; then
-  if [[ -z "${TARGET_USER}" ]]; then
-    TARGET_USER="${SUDO_USER:-}"
-  fi
   if [[ -n "${TARGET_USER}" ]]; then
     TARGET_HOME="$(dscl . -read "/Users/${TARGET_USER}" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
     if [[ -z "${TARGET_HOME}" || ! -d "${TARGET_HOME}" ]]; then
       die "could not resolve home for --user ${TARGET_USER} (dscl returned '${TARGET_HOME}'); refusing to purge without a valid target"
     fi
+    _tuid="$(id -u "${TARGET_USER}" 2>/dev/null || echo "")"
+    _tgid="$(id -g "${TARGET_USER}" 2>/dev/null || echo "")"
+    PURGE_TARGETS="${TARGET_USER}:${_tuid}:${_tgid}:${TARGET_HOME}"
+    unset _tuid _tgid
+  elif command -v enumerate_local_users >/dev/null 2>&1; then
+    PURGE_TARGETS="$(enumerate_local_users || true)"
+  else
+    # Library not sourced — fall back to the legacy SUDO_USER single-user path.
+    _fallback_user="${SUDO_USER:-}"
+    if [[ -n "${_fallback_user}" ]]; then
+      TARGET_USER="${_fallback_user}"
+      TARGET_HOME="$(dscl . -read "/Users/${_fallback_user}" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
+      if [[ -n "${TARGET_HOME}" && -d "${TARGET_HOME}" ]]; then
+        _tuid="$(id -u "${_fallback_user}" 2>/dev/null || echo "")"
+        _tgid="$(id -g "${_fallback_user}" 2>/dev/null || echo "")"
+        PURGE_TARGETS="${_fallback_user}:${_tuid}:${_tgid}:${TARGET_HOME}"
+        unset _tuid _tgid
+      fi
+    fi
+    unset _fallback_user
   fi
+
   if [[ "${ASSUME_YES}" != "true" ]]; then
     printf '[uninstall] --purge will DELETE:\n'
     printf '  %s\n' "${SUPPORT_DIR}" "${LOGS_DIR}"
@@ -148,15 +196,17 @@ if [[ "${PURGE}" == "true" ]]; then
       [[ -d "${LEGACY_SUPPORT_DIR}" ]] && printf '  %s\n' "${LEGACY_SUPPORT_DIR}"
       [[ -d "${LEGACY_LOGS_DIR}" ]]    && printf '  %s\n' "${LEGACY_LOGS_DIR}"
     fi
-    if [[ -n "${TARGET_USER:-}" && -n "${TARGET_HOME:-}" ]]; then
-      printf '  %s/.defenseclaw/\n' "${TARGET_HOME}"
+    if [[ -n "${PURGE_TARGETS}" ]]; then
+      printf '[uninstall] per-user cleanup targets (%d user(s)):\n' \
+        "$(printf '%s\n' "${PURGE_TARGETS}" | grep -c . || true)"
+      while IFS=: read -r _u _uid _gid _h; do
+        [[ -z "${_u}" ]] && continue
+        printf '  %s/.defenseclaw/\n' "${_h}"
+      done <<< "${PURGE_TARGETS}"
+      unset _u _uid _gid _h
       if [[ "${KEEP_AGENT_CONFIGS}" != "true" ]]; then
-        printf '[uninstall] and will SCRUB DefenseClaw entries from:\n'
-        for f in "${TARGET_HOME}/.codex/config.toml" \
-                 "${TARGET_HOME}/.claude/settings.json" \
-                 "${TARGET_HOME}/.cursor/hooks.json"; do
-          [[ -f "${f}" ]] && printf '  %s\n' "${f}"
-        done
+        printf '[uninstall] and will SCRUB DefenseClaw entries from each user'\''s:\n'
+        printf '  ~/.codex/config.toml\n  ~/.claude/settings.json\n  ~/.cursor/hooks.json\n'
         printf '  (non-DefenseClaw entries preserved)\n'
       fi
     fi
@@ -194,8 +244,11 @@ stop_daemon() {
   fi
 }
 
-stop_daemon "${LAUNCHD_LABEL}"        "${PLIST_DST}"
-stop_daemon "${LEGACY_LAUNCHD_LABEL}" "${LEGACY_PLIST_DST}"
+stop_daemon "${LAUNCHD_LABEL}"            "${PLIST_DST}"
+stop_daemon "${GUARDIAN_LAUNCHD_LABEL}"   "${GUARDIAN_PLIST_DST}"
+stop_daemon "${ENUMERATOR_LAUNCHD_LABEL}" "${ENUMERATOR_PLIST_DST}"
+stop_daemon "${LEGACY_LAUNCHD_LABEL}"     "${LEGACY_PLIST_DST}"
+stop_daemon "${LEGACY_GUARDIAN_LAUNCHD_LABEL}" "${LEGACY_GUARDIAN_PLIST_DST}"
 
 # ---- agent-config scrub (BEFORE we delete ~/.defenseclaw) --------------
 #
@@ -209,6 +262,7 @@ PY="$(command -v python3 || printf '/usr/bin/python3')"
 scrub_agent_config() {
   local connector="$1"
   local cfg="$2"
+  local run_as_user="$3"   # empty ⇒ run as caller (root)
   if [[ ! -f "${cfg}" ]]; then
     return 0
   fi
@@ -219,8 +273,8 @@ scrub_agent_config() {
   fi
   log "  scrubbing ${connector} entries from ${cfg}"
   local rc=0
-  if [[ -n "${TARGET_USER:-}" && $(id -u "${TARGET_USER}" 2>/dev/null) != "0" ]]; then
-    sudo -u "${TARGET_USER}" "${PY}" "${SCRUB_PY}" "${connector}" "${cfg}" || rc=$?
+  if [[ -n "${run_as_user}" && $(id -u "${run_as_user}" 2>/dev/null) != "0" ]]; then
+    sudo -u "${run_as_user}" "${PY}" "${SCRUB_PY}" "${connector}" "${cfg}" || rc=$?
   else
     "${PY}" "${SCRUB_PY}" "${connector}" "${cfg}" || rc=$?
   fi
@@ -236,17 +290,27 @@ scrub_agent_config() {
 
 if [[ "${PURGE}" == "true" \
    && "${KEEP_AGENT_CONFIGS}" != "true" \
-   && -n "${TARGET_HOME:-}" ]]; then
-  scrub_agent_config codex      "${TARGET_HOME}/.codex/config.toml"
-  scrub_agent_config claudecode "${TARGET_HOME}/.claude/settings.json"
-  scrub_agent_config cursor     "${TARGET_HOME}/.cursor/hooks.json"
+   && -n "${PURGE_TARGETS}" ]]; then
+  while IFS=: read -r _pu _puid _pgid _phome; do
+    [[ -z "${_pu}" || -z "${_phome}" ]] && continue
+    log "scrubbing per-user hook configs for ${_pu} (${_phome})"
+    scrub_agent_config codex      "${_phome}/.codex/config.toml"    "${_pu}"
+    scrub_agent_config claudecode "${_phome}/.claude/settings.json" "${_pu}"
+    scrub_agent_config cursor     "${_phome}/.cursor/hooks.json"    "${_pu}"
+  done <<< "${PURGE_TARGETS}"
+  unset _pu _puid _pgid _phome
 fi
 
 # ---- remove files we own unconditionally --------------------------------
 #
 # Sweep both the current and legacy plist / binary tree.
 
-for plist in "${PLIST_DST}" "${LEGACY_PLIST_DST}"; do
+for plist in \
+  "${PLIST_DST}" \
+  "${GUARDIAN_PLIST_DST}" \
+  "${ENUMERATOR_PLIST_DST}" \
+  "${LEGACY_PLIST_DST}" \
+  "${LEGACY_GUARDIAN_PLIST_DST}"; do
   if [[ -f "${plist}" ]]; then
     log "removing ${plist}"
     rm -f "${plist}"
@@ -326,25 +390,31 @@ if [[ "${PURGE}" == "true" ]]; then
     fi
   done
 
-  if [[ -n "${TARGET_USER:-}" && -n "${TARGET_HOME:-}" && -d "${TARGET_HOME}/.defenseclaw" ]]; then
+  if [[ -n "${PURGE_TARGETS}" ]]; then
     if [[ "${SCRUB_FAILED}" == "true" && "${KEEP_AGENT_CONFIGS}" != "true" ]]; then
       # We're about to delete the hook scripts, but at least one agent
       # config still references them. Deleting now would leave every
       # future agent tool call fail-closed (exit 127 → block). Refuse
       # rather than paint the operator into that corner.
-      die "one or more agent-config scrubs failed; refusing to delete ${TARGET_HOME}/.defenseclaw (rerun with --keep-agent-configs to force the delete, then repair or reinstall)"
+      die "one or more agent-config scrubs failed; refusing to delete per-user .defenseclaw dirs (rerun with --keep-agent-configs to force the delete, then repair or reinstall)"
     fi
-    log "purging ${TARGET_HOME}/.defenseclaw"
-    rm -rf "${TARGET_HOME}/.defenseclaw"
-    if [[ "${KEEP_AGENT_CONFIGS}" == "true" ]]; then
-      warn "--keep-agent-configs: agent configs still reference deleted hook scripts."
-      warn "  agents will fail-close every tool call until reinstall or manual edit."
-      for cfg in "${TARGET_HOME}/.codex/config.toml" \
-                 "${TARGET_HOME}/.claude/settings.json" \
-                 "${TARGET_HOME}/.cursor/hooks.json"; do
-        [[ -f "${cfg}" ]] && warn "    ${cfg}"
-      done
-    fi
+    while IFS=: read -r _pu _puid _pgid _phome; do
+      [[ -z "${_pu}" || -z "${_phome}" ]] && continue
+      if [[ -d "${_phome}/.defenseclaw" ]]; then
+        log "purging ${_phome}/.defenseclaw"
+        rm -rf "${_phome}/.defenseclaw"
+      fi
+      if [[ "${KEEP_AGENT_CONFIGS}" == "true" ]]; then
+        for cfg in "${_phome}/.codex/config.toml" \
+                   "${_phome}/.claude/settings.json" \
+                   "${_phome}/.cursor/hooks.json"; do
+          if [[ -f "${cfg}" ]]; then
+            warn "--keep-agent-configs: ${cfg} still references deleted hook scripts (will fail-close every tool call)"
+          fi
+        done
+      fi
+    done <<< "${PURGE_TARGETS}"
+    unset _pu _puid _pgid _phome
   fi
 else
   log "preserving ${SUPPORT_DIR} (config + audit DB)"
@@ -355,15 +425,24 @@ fi
 # ---- sanity check -------------------------------------------------------
 
 REMAINING=()
-[[ -e "${PLIST_DST}" ]]              && REMAINING+=("${PLIST_DST}")
-[[ -e "${LEGACY_PLIST_DST}" ]]       && REMAINING+=("${LEGACY_PLIST_DST}")
-[[ -e "${INSTALL_PREFIX}" ]]         && REMAINING+=("${INSTALL_PREFIX}")
-[[ -e "${LEGACY_INSTALL_PREFIX}" ]]  && REMAINING+=("${LEGACY_INSTALL_PREFIX}")
+[[ -e "${PLIST_DST}" ]]                 && REMAINING+=("${PLIST_DST}")
+[[ -e "${GUARDIAN_PLIST_DST}" ]]        && REMAINING+=("${GUARDIAN_PLIST_DST}")
+[[ -e "${ENUMERATOR_PLIST_DST}" ]]      && REMAINING+=("${ENUMERATOR_PLIST_DST}")
+[[ -e "${LEGACY_PLIST_DST}" ]]          && REMAINING+=("${LEGACY_PLIST_DST}")
+[[ -e "${LEGACY_GUARDIAN_PLIST_DST}" ]] && REMAINING+=("${LEGACY_GUARDIAN_PLIST_DST}")
+[[ -e "${INSTALL_PREFIX}" ]]            && REMAINING+=("${INSTALL_PREFIX}")
+[[ -e "${LEGACY_INSTALL_PREFIX}" ]]     && REMAINING+=("${LEGACY_INSTALL_PREFIX}")
 if [[ "${PURGE}" == "true" ]]; then
   [[ -e "${LOGS_DIR}" ]]         && REMAINING+=("${LOGS_DIR}")
   [[ -e "${LEGACY_SUPPORT_DIR}" ]] && REMAINING+=("${LEGACY_SUPPORT_DIR}")
   [[ -e "${LEGACY_LOGS_DIR}" ]]    && REMAINING+=("${LEGACY_LOGS_DIR}")
-  [[ -n "${TARGET_HOME:-}" && -e "${TARGET_HOME}/.defenseclaw" ]] && REMAINING+=("${TARGET_HOME}/.defenseclaw")
+  if [[ -n "${PURGE_TARGETS}" ]]; then
+    while IFS=: read -r _pu _puid _pgid _phome; do
+      [[ -z "${_phome}" ]] && continue
+      [[ -e "${_phome}/.defenseclaw" ]] && REMAINING+=("${_phome}/.defenseclaw")
+    done <<< "${PURGE_TARGETS}"
+    unset _pu _puid _pgid _phome
+  fi
 fi
 if (( ${#REMAINING[@]} > 0 )); then
   warn "the following paths still exist (manual cleanup needed):"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,11 @@ dependencies = [
     # resolving this package through /simple/.
     "cisco-ai-skill-scanner @ https://files.pythonhosted.org/packages/b4/cc/824d4033d5e684fd05a0e726fa32d2070c36bcaa9e99af49ed1014716613/cisco_ai_skill_scanner-2.0.11-py3-none-any.whl#sha256=9e0f2fd30150ab455005b9b1b288ab2047e89bf22056f7a68e9b8155c420edbe",
     "cisco-ai-mcp-scanner>=4.7.2; python_version>='3.11'",
+    # The MCP scanner installs this transitively. Keep the runtime above the
+    # fixes for CVE-2026-52869, CVE-2026-52870, and CVE-2026-59950. Mirrors
+    # the same top-level pin on main (0.8.5) so the release-branch CI stays
+    # green against pip-audit --vulnerability-service osv.
+    "mcp>=1.28.1,<2; python_version>='3.11'",
     # AWS Bedrock support is bundled. LiteLLM lazy-imports boto3 for
     # SigV4 (iam_credentials / profile / instance_role) and for the
     # Anthropic-on-Bedrock route used by ABSK bearer tokens. Bundling

--- a/scripts/build-macos-bundle.sh
+++ b/scripts/build-macos-bundle.sh
@@ -181,11 +181,19 @@ cp packaging/macos/install.sh                       "${BUNDLE_DIR}/install.sh"
 cp packaging/macos/uninstall.sh                     "${BUNDLE_DIR}/uninstall.sh"
 cp packaging/macos/lib/installer_lib.sh             "${BUNDLE_DIR}/lib/installer_lib.sh"
 cp packaging/macos/lib/scrub_agent_configs.py       "${BUNDLE_DIR}/lib/scrub_agent_configs.py"
+cp packaging/macos/lib/render-targets.sh            "${BUNDLE_DIR}/lib/render-targets.sh"
 cp packaging/launchd/com.cisco.secureclient.defenseclaw.plist \
     "${BUNDLE_DIR}/com.cisco.secureclient.defenseclaw.plist"
+cp packaging/launchd/com.cisco.secureclient.defenseclaw.hook-guardian.plist \
+    "${BUNDLE_DIR}/com.cisco.secureclient.defenseclaw.hook-guardian.plist"
+cp packaging/launchd/com.cisco.secureclient.defenseclaw.hook-enumerator.plist \
+    "${BUNDLE_DIR}/com.cisco.secureclient.defenseclaw.hook-enumerator.plist"
 chmod 0755 "${BUNDLE_DIR}/install.sh" "${BUNDLE_DIR}/uninstall.sh"
 chmod 0755 "${BUNDLE_DIR}/lib/installer_lib.sh" "${BUNDLE_DIR}/lib/scrub_agent_configs.py"
+chmod 0755 "${BUNDLE_DIR}/lib/render-targets.sh"
 chmod 0644 "${BUNDLE_DIR}/com.cisco.secureclient.defenseclaw.plist"
+chmod 0644 "${BUNDLE_DIR}/com.cisco.secureclient.defenseclaw.hook-guardian.plist"
+chmod 0644 "${BUNDLE_DIR}/com.cisco.secureclient.defenseclaw.hook-enumerator.plist"
 
 # ---- README -------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -876,6 +876,7 @@ dependencies = [
     { name = "cisco-ai-mcp-scanner", marker = "python_full_version >= '3.11'" },
     { name = "cisco-ai-skill-scanner" },
     { name = "click" },
+    { name = "mcp", marker = "python_full_version >= '3.11'" },
     { name = "opentelemetry-proto" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -911,6 +912,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.8,<9" },
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.30" },
     { name = "google-cloud-aiplatform", marker = "extra == 'vertex'", specifier = ">=1.60" },
+    { name = "mcp", marker = "python_full_version >= '3.11'", specifier = ">=1.28.1,<2" },
     { name = "opentelemetry-proto", specifier = ">=1.28.0,<2" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "requests", specifier = "==2.33.0" },
@@ -2044,7 +2046,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "python_full_version >= '3.11'" },
@@ -2062,9 +2064,9 @@ dependencies = [
     { name = "typing-inspection", marker = "python_full_version >= '3.11'" },
     { name = "uvicorn", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Fixes a silent regression in the customer-shipping macOS `.pkg` where **no user's hooks ever got wired** (installd runs as root, not sudo, so `$SUDO_USER` is empty and the single-user inline call to `enterprise hooks install` short-circuited).
- Replaces the single-user inline flow with a machine-wide `targets.yaml` reconciled by the already-shipped `hook-guardian` LaunchDaemon (5-min tick).
- Adds a companion `hook-enumerator` LaunchDaemon (also 5-min tick) that re-renders `targets.yaml` so users provisioned **after** the pkg install are picked up automatically.
- Fixes a second latent bug: `install.sh` referenced the guardian plist for collision preflight but never actually installed or bootstrapped it. It does now, alongside the new enumerator.
- Multi-user cleanup in `uninstall.sh` (iterates every eligible local user for the `~/.defenseclaw` + agent-config scrub).

## Why

The pre-2026.7.3 flow only wired hooks for `$SUDO_USER`. Under a pkg postinstall that variable is empty, so shipped Macs had:

- Daemon running, telemetry emitting ✓
- `protected_targets.json` never written ✗
- `~/.codex/config.toml` / `~/.claude/settings.json` / `~/.cursor/hooks.json` all empty ✗
- **Zero policy enforcement.**

## What changed

**Design.** The `hook-guardian` LaunchDaemon (`enterprise hooks reconcile --manifest ...`) already re-parses `targets.yaml` on every 5-min tick via `LoadManifest` (`internal/enterprisehooks/manifest.go:33`). The merge writer in `enterprise_hooks.go:674-700` keys by `(connector, user)`, so writing one row per (user × connector) is safe and idempotent. The manifest becomes the single source of truth; install.sh's job is now to write the initial file + start the daemons.

**Files modified.**

- `packaging/macos/install.sh` — new: enumerate local users, render `${SUPPORT_DIR}/hook-guardian/targets.yaml`, install + bootstrap guardian + enumerator, kickstart both for immediate first pass. Removed: inline `enterprise hooks install --user <one>` loop.
- `packaging/macos/lib/installer_lib.sh` — new helpers `enumerate_local_users` (UID ≥ 500, non-`_`-prefixed, home under `/Users/`, `home_perms_ok`) and `render_targets_manifest` (emits schema-compliant YAML matching `ManifestTarget`).
- `packaging/macos/uninstall.sh` — iterates every eligible local user for the scrub + `.defenseclaw` cleanup; boots out the new daemons; keeps `--user X` as a scoped-cleanup override.
- `scripts/build-macos-bundle.sh` — bundles the new plist + helper.
- `packaging/macos/tests/test_packaging_assets.sh` — 4 new asserts covering: guardian + enumerator plists exist and lint, `render-targets.sh` shipped + executable, install.sh actually copies + bootstraps both daemons, no more inline `enterprise hooks install` invocations.
- `packaging/macos/tests/test_render_targets_manifest.sh` (new) — 6 cases covering multi-user × multi-connector cross-product, unsupported-connector filter, empty inputs, YAML round-trip via PyYAML.

**Files added.**

- `packaging/launchd/com.cisco.secureclient.defenseclaw.hook-enumerator.plist` — RunAtLoad + StartInterval 300, invokes `lib/render-targets.sh` as root.
- `packaging/macos/lib/render-targets.sh` — reads `config.yaml` for the connector list, calls `enumerate_local_users`, atomically swaps `targets.yaml` if content changed. Logs a no-op on unchanged input so the guardian doesn't churn.

**No Go changes.** `enterprise hooks reconcile` already re-parses the manifest per tick; the sidecar already polls `protected_targets.json` every 5s (`sidecar.go:2612-2621`). Verified end-to-end by round-tripping the shell-rendered YAML through `LoadManifest` in a smoke test.

## Test plan

- [x] `packaging/macos/tests/run_tests.sh` — 107 passed, 2 pre-existing env failures unrelated to this change (my dev box has `/opt/cisco/secureclient/defenseclaw/` already installed, which trips the fresh-host preflight in two bundle-fixture tests; same failures reproduce at HEAD on this box).
- [x] `go test ./internal/enterprisehooks/... ./internal/cli/...` — pass.
- [x] `go build ./...` — clean.
- [x] `plutil -lint` on the new hook-enumerator plist — OK.
- [x] Round-trip smoke: rendered `targets.yaml` from the shell helper loads cleanly through Go's `LoadManifest` with UID/GID typed as `*int`.
- [ ] End-to-end on a fresh customer Mac: pkg install → `sudo cat /opt/cisco/secureclient/defenseclaw/hook-guardian/targets.yaml` shows every local user × requested connector → `sudo cat /opt/cisco/secureclient/defenseclaw/hook-guardian-state/protected_targets.json` matches the enumerated user set → per-user `~/.<agent>/*` configs contain `defenseclaw` hook entries.
- [ ] Future-user smoke: `sudo sysadminctl -addUser testfuture -password test -home /Users/testfuture` → within ≤10 min, `testfuture` appears in `protected_targets.json` without any manual bootstrap.

Verification playbook is in the plan doc under `.claude/plans/add-support-for-multi-user-abundant-kettle.md` (step 6, "Verification").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: fsnotify auto-heal with self-write suppression (06c13469)

**What.** Switched the hook-guardian LaunchDaemon from one-shot periodic `enterprise hooks reconcile` (every 5 min) to a long-running `enterprise hooks watch` process that reacts to per-user tampering in ~1 s via fsnotify, plus a **60 s** periodic backstop for the vectors the fsnotify path intentionally can't catch.

**Why.** The 5-min tick meant any tamper (delete config, neuter hook script, corrupt token) won for up to 5 minutes. An endpoint security product cannot ship with an "eventually consistent to 5 min" SLA against user tampering.

**Design.** Three layered filters keep the fsnotify path both responsive and quiet:

1. **Ownership filter** — `WatchOwnedFiles` returns two sets:
   - `ExclusiveWriter` (hook scripts, `.hook-<connector>.token`, backup files): only DefenseClaw writes here → any event is a tamper signal.
   - `SharedWriter` (native agent configs — `~/.codex/config.toml`, `~/.claude/settings.json`, `~/.cursor/hooks.json`): the agent itself constantly rewrites these during normal use → only Remove/Rename triggers reconcile; Write/Chmod is deferred to the backstop.
   - Generic scripts (`inspect-*.sh`, `_hardening.sh`, `.hookcfg`) are excluded entirely: per-connector template rendering makes them rewrite-storm on every reconcile, so their events are pure noise.

2. **Post-reconcile settle window** — every reconcile stamps `settleUntil = now + 2s`; events inside the window are suppressed as the guardian's own tail. Remove/Rename inside the window is suppressed **only if the file still exists on disk** (guardian's `os.Rename` is atomic; macOS surfaces the intermediate REMOVE but the file is still there). If a Stat shows the file truly missing, it's a real user `rm` and falls through. Deterministic distinction between "our own atomic-write tail" and "back-to-back user tamper."

3. **Row-set content hash** — after each reconcile, hash the target row set. Byte-identical to previous run → widen the settle window to `3× settle` to absorb macOS FSEvents chmod-batching latency. Real tamper always flips the hash, so widening never masks a genuine repair.

**Plist.** Switched to `watch --interval 60s` + `KeepAlive true`; dropped `StartInterval 300`. Backstop tightened 5 min → 60 s to reduce worst-case detection for SharedWriter Writes and generic-script tampers.

**End-to-end verification on macOS:**

- [x] `rm ~/.codex/config.toml ~/.defenseclaw/hooks/codex-hook.sh ~/.defenseclaw/hooks/.hook-codex.token` → all 3 restored in ~1 s, byte-identical to shipped content.
- [x] Back-to-back Removes 5 s apart → both heal ~1 s each (Stat-check on Remove inside settle window passes the second one through).
- [x] Write on ExclusiveWriter (overwrite `codex-hook.sh` with a stub) → reconcile restores in ~2 s.
- [x] Write on SharedWriter (append to `~/.codex/config.toml`) → NOT reconciled via fsnotify (as designed); caught by 60 s backstop.
- [x] Steady-state guardian log during heavy Codex/Claude Code/Cursor activity → quiet. No `no_change=true` churn, no `settled: suppressed N` spam.

**Tests.** New unit coverage:

- `TestEnterpriseHookWatchEventInSettleWindow` — 7 subtests (Write/Chmod/Remove/Rename inside/outside window, never-reconciled boundary).
- `TestEnterpriseHookReconcileRowsHash` — row-order stability, outcome change flips hash, target-add flips hash, empty-input invariant.
- `TestWatchOwnedFilesReturnsSpecificFilesNotDirs` — asserts ExclusiveWriter/SharedWriter split, forbids leaking agent-runtime paths, pins shared-across-connector artifacts out of both sets.
- Updated packaging: asserts `<string>watch</string>` + `<string>60s</string>` + `<key>KeepAlive</key>` present, `<string>reconcile</string>` + `<key>StartInterval</key>` absent.

Full test sweep: `116 passed, 0 failed` (packaging) + all Go unit tests green.

**Known residual bypass surface** (deliberately documented for follow-up, not addressed on this branch):

- **Rapid-rewrite LaunchAgent** (attacker rewriter loop at 100 ms cycle beats ~2 s guardian latency ~95% of wall-clock time). Requires moving enforcement out of user space (macOS Endpoint Security framework) to close. Not a regression from this PR — pre-existing surface.
- **SharedWriter Write** (e.g. `sed -i` stripping DefenseClaw entries from `config.toml`). 60 s-bounded via backstop. Accepted trade-off — trying to react in real time reintroduces the noise loop this PR fixed.
- **Symlink swap on hook script paths** — `atomicWriteFile` follows symlinks and the fsnotify watch is on the source path. Worth a follow-up refusing symlinks under `~/.defenseclaw/hooks/`. Not exploited today but worth closing.

