### PR TITLE
fix(release): restore dynamic cuts and shorten CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,9 @@ jobs:
           # push or fetch on our behalf if a transient compromise
           # injects shell.
           persist-credentials: false
-      # Catches drift between the four in-repo version sources (Makefile,
-      # pyproject.toml, cli/__init__.py, package.json) before it can ship
-      # in a release. The release workflow restamps from the git tag, but
-      # PRs still need to keep the in-repo defaults in sync so local dev
-      # builds (`make dist`) produce artifacts whose names match what
-      # install.sh / `defenseclaw upgrade` will look up at the next tag.
+      # Keep local-development package metadata internally consistent. The
+      # release workflow dynamically stamps its dispatch version, so this
+      # check does not pin or preselect the next release number.
       - run: make check-version-sync
 
   upgrade-manifest:
@@ -70,9 +67,14 @@ jobs:
       - run: make plugin
       - run: make go-lint
 
-  go-test:
-    name: Go Test
+  go-test-gateway:
+    name: Go Gateway Test (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
+    timeout-minutes: 50
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -86,7 +88,94 @@ jobs:
           cache: npm
           cache-dependency-path: extensions/defenseclaw/package-lock.json
       - run: make plugin
-      - run: make go-test-cov
+      - name: Run gateway race/coverage shard
+        env:
+          GO_TEST_SHARD: ${{ matrix.shard }}
+          GO_TEST_SHARDS: 4
+        run: |
+          set -euo pipefail
+          test_regex="$(python3 scripts/go_test_shards.py \
+            --package-dir internal/gateway \
+            --shard-count "$GO_TEST_SHARDS" \
+            --shard-index "$GO_TEST_SHARD")"
+          go test -race -count=1 -timeout 45m \
+            -coverprofile="coverage-go-gateway-$GO_TEST_SHARD.out" \
+            -run "$test_regex" \
+            ./internal/gateway
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: go-coverage-gateway-${{ matrix.shard }}
+          path: coverage-go-gateway-${{ matrix.shard }}.out
+          retention-days: 1
+
+  go-test-other:
+    name: Go Test (remaining packages)
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: extensions/defenseclaw/package-lock.json
+      - run: make plugin
+      - name: Run remaining Go race/coverage suite once
+        run: |
+          set -euo pipefail
+          mapfile -t packages < <(
+            go list ./... | grep -v '^github.com/defenseclaw/defenseclaw/internal/gateway$'
+          )
+          test "${#packages[@]}" -gt 0
+          go test -race -count=1 -timeout 45m \
+            -coverprofile=coverage-go-other.out \
+            "${packages[@]}"
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: go-coverage-other
+          path: coverage-go-other.out
+          retention-days: 1
+
+  go-test:
+    # Preserve the existing required-check name while combining the complete
+    # race/coverage suite from the gateway shards and all remaining packages.
+    name: Go Test
+    needs: [go-test-gateway, go-test-other]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every Go test partition
+        env:
+          GATEWAY_RESULT: ${{ needs.go-test-gateway.result }}
+          OTHER_RESULT: ${{ needs.go-test-other.result }}
+        run: test "$GATEWAY_RESULT" = success && test "$OTHER_RESULT" = success
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: go-coverage-*
+          path: coverage-parts
+          merge-multiple: true
+      - name: Combine Go coverage
+        run: |
+          set -euo pipefail
+          mapfile -t coverage_parts < <(
+            find coverage-parts -type f -name 'coverage-go-*.out' -print | sort
+          )
+          test "${#coverage_parts[@]}" -eq 5
+          python3 scripts/merge_go_coverage.py \
+            --output coverage.out \
+            "${coverage_parts[@]}"
+          go tool cover -func=coverage.out >/dev/null
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: go-coverage
@@ -118,17 +207,77 @@ jobs:
           name: defenseclaw-${{ matrix.goos }}-${{ matrix.goarch }}
           path: defenseclaw-${{ matrix.goos }}-${{ matrix.goarch }}
 
-  python-lint-test:
-    name: Python Lint & Test
+  python-test:
+    name: Python Test (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
+    timeout-minutes: 75
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - run: uv sync
+      - run: make _bundle-data
+      - name: Run Python coverage shard
+        env:
+          PYTHON_TEST_SHARD: ${{ matrix.shard }}
+          PYTHON_TEST_SHARDS: 4
+        run: |
+          set -euo pipefail
+          mapfile -t test_files < <(
+            python3 scripts/python_test_shards.py \
+              --shard-count "$PYTHON_TEST_SHARDS" \
+              --shard-index "$PYTHON_TEST_SHARD"
+          )
+          test "${#test_files[@]}" -gt 0
+          COVERAGE_FILE="coverage-py-shard-$PYTHON_TEST_SHARD" \
+            .venv/bin/python -m pytest "${test_files[@]}" \
+              -q --tb=short \
+              --durations=25 \
+              --cov=defenseclaw \
+              --cov-report=
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: python-coverage-shard-${{ matrix.shard }}
+          path: coverage-py-shard-${{ matrix.shard }}
+          retention-days: 1
+
+  python-lint-test:
+    # Preserve the existing required-check name while making it the single
+    # authority that verifies lint and combines all isolated coverage shards.
+    name: Python Lint & Test
+    needs: python-test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every Python test shard
+        env:
+          PYTHON_SHARD_RESULT: ${{ needs.python-test.result }}
+        run: test "$PYTHON_SHARD_RESULT" = success
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - run: uv sync
       - run: make py-lint
-      - run: make cli-test-cov
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: python-coverage-shard-*
+          path: coverage-parts
+          merge-multiple: true
+      - name: Combine Python coverage
+        run: |
+          set -euo pipefail
+          mapfile -t coverage_parts < <(
+            find coverage-parts -type f -name 'coverage-py-shard-*' -print | sort
+          )
+          test "${#coverage_parts[@]}" -eq 4
+          .venv/bin/coverage combine "${coverage_parts[@]}"
+          .venv/bin/coverage xml -o coverage-py.xml
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: python-coverage
@@ -459,33 +608,6 @@ jobs:
       - name: Stop the local observability stack
         if: ${{ always() }}
         run: bundles/local_observability_stack/bin/openclaw-observability-bridge reset
-
-  make-test:
-    name: make test (unified)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          persist-credentials: false
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version-file: go.mod
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
-        with:
-          node-version: "24"
-          cache: npm
-          cache-dependency-path: extensions/defenseclaw/package-lock.json
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-      - run: make plugin
-      # dev-pycli installs the [dev] group (pytest, jsonschema, ruff)
-      # which `make test → cli-test` indirectly needs at import time:
-      # several cli/tests/*.py files use pytest fixtures/parametrize
-      # and `python -m unittest discover` aborts on the first failed
-      # import. The non-dev `make pycli` target only installs runtime
-      # deps and broke this job after the S4.1/S4.2 connector_paths
-      # tests landed.
-      - run: make dev-pycli
-      - run: make test
 
   windows-hook-path:
     name: Windows Hook Path

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -296,28 +296,7 @@ jobs:
           git tag "$RELEASE_TAG"
           test "$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")" = "$GITHUB_SHA"
 
-      - name: Build OpenClaw plugin and populate embed tree
-        run: make extensions
-
-      - name: Restore tracked generated files before GoReleaser
-        run: |
-          set -euo pipefail
-          git restore --worktree -- \
-            extensions/defenseclaw/dist \
-            internal/gateway/connector/openclaw_extension/.placeholder
-          git diff --exit-code
-
-      - name: Build gateway archives and SBOMs
-        uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
-        with:
-          version: "v2.15.4"
-          # These archives are transformed into protected runtime envelopes
-          # below. Sign only the final sealed candidate, never transient bytes.
-          args: release --clean --skip=sign
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Build stamped CLI, plugin, and upgrade policy
+      - name: Stamp runtime source version before native builds
         env:
           RELEASE_TAG: ${{ needs.release-preflight.outputs.tag }}
         run: |
@@ -334,6 +313,35 @@ jobs:
           scripts/stamp-version.sh "$RELEASE_TAG"
           python3 scripts/source_release_identity.py check \
             --expected-release "$RELEASE_TAG"
+
+      - name: Build OpenClaw plugin and populate embed tree
+        run: make extensions
+
+      - name: Restore tracked generated files before GoReleaser
+        run: |
+          set -euo pipefail
+          git restore --worktree -- \
+            extensions/defenseclaw/dist \
+            internal/gateway/connector/openclaw_extension/.placeholder
+          git diff --exit-code -- \
+            extensions/defenseclaw/dist \
+            internal/gateway/connector/openclaw_extension/.placeholder
+
+      - name: Build gateway archives and SBOMs
+        uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
+        with:
+          version: "v2.15.4"
+          # These archives are transformed into protected runtime envelopes
+          # below. Sign only the final sealed candidate, never transient bytes.
+          args: release --clean --skip=sign
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Build stamped CLI, plugin, and upgrade policy
+        env:
+          RELEASE_TAG: ${{ needs.release-preflight.outputs.tag }}
+        run: |
+          set -euo pipefail
           make dist-cli
           make dist-plugin
           make dist-upgrade-manifest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,10 +55,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Require latest stable macOS app source
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: python3 scripts/check-macos-upstream.py
+      - name: Require reviewed macOS app source
+        # A DefenseClaw release must build the macOS source that was reviewed
+        # and merged with this exact main commit. Upstream freshness is tracked
+        # independently by macos-upstream.yml and must not make an unrelated
+        # product release fail after its PR checks have already passed.
+        run: python3 scripts/check-macos-upstream.py --offline
 
       - name: Require immutable GitHub releases
         env:
@@ -107,7 +109,7 @@ jobs:
             --releases-json published-releases.json
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-      - name: Require reviewed source release identity
+      - name: Validate release version stamping
         env:
           RELEASE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
@@ -121,22 +123,13 @@ jobs:
             extensions/defenseclaw/package-lock.json \
             macos/DefenseClawMac/DefenseClawMac.xcodeproj/project.pbxproj \
             release/source-install-identity.json >/dev/null
-          python3 scripts/source_release_identity.py check \
-            --expected-release "$RELEASE_TAG"
-          # The remote tag will point at this exact reviewed main commit. A
-          # workflow-only version rewrite would make GitHub source archives
-          # disagree with the signed wheel/gateway release, so prove the
-          # legacy stamp helper is already a byte-for-byte no-op.
+          SOURCE_DEFAULT="$(python3 scripts/source_release_identity.py check --machine | cut -f1)"
+          if [[ "$SOURCE_DEFAULT" != "$RELEASE_TAG" ]]; then
+            echo "::warning title=GitHub source snapshot uses development version::Installable assets will be stamped $RELEASE_TAG, while GitHub's automatic source archive remains the reviewed main snapshot with development version $SOURCE_DEFAULT."
+          fi
+          # The workflow-dispatch input is the release version authority. Prove
+          # the reviewed stamping code can apply it before native builders run.
           scripts/stamp-version.sh "$RELEASE_TAG"
-          git diff --exit-code -- \
-            Makefile \
-            pyproject.toml \
-            uv.lock \
-            cli/defenseclaw/__init__.py \
-            extensions/defenseclaw/package.json \
-            extensions/defenseclaw/package-lock.json \
-            macos/DefenseClawMac/DefenseClawMac.xcodeproj/project.pbxproj \
-            release/source-install-identity.json
 
       - name: Verify release commit is reviewed and branch-owned
         id: provenance
@@ -339,15 +332,6 @@ jobs:
             macos/DefenseClawMac/DefenseClawMac.xcodeproj/project.pbxproj \
             release/source-install-identity.json >/dev/null
           scripts/stamp-version.sh "$RELEASE_TAG"
-          git diff --exit-code -- \
-            Makefile \
-            pyproject.toml \
-            uv.lock \
-            cli/defenseclaw/__init__.py \
-            extensions/defenseclaw/package.json \
-            extensions/defenseclaw/package-lock.json \
-            macos/DefenseClawMac/DefenseClawMac.xcodeproj/project.pbxproj \
-            release/source-install-identity.json
           python3 scripts/source_release_identity.py check \
             --expected-release "$RELEASE_TAG"
           make dist-cli

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -324,8 +324,15 @@ jobs:
             extensions/defenseclaw/dist \
             internal/gateway/connector/openclaw_extension/.placeholder
           git diff --exit-code -- \
-            extensions/defenseclaw/dist \
-            internal/gateway/connector/openclaw_extension/.placeholder
+            . \
+            ':(exclude)Makefile' \
+            ':(exclude)pyproject.toml' \
+            ':(exclude)uv.lock' \
+            ':(exclude)cli/defenseclaw/__init__.py' \
+            ':(exclude)extensions/defenseclaw/package.json' \
+            ':(exclude)extensions/defenseclaw/package-lock.json' \
+            ':(exclude)macos/DefenseClawMac/DefenseClawMac.xcodeproj/project.pbxproj' \
+            ':(exclude)release/source-install-identity.json'
 
       - name: Build gateway archives and SBOMs
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0

--- a/Makefile
+++ b/Makefile
@@ -80,12 +80,11 @@ help:
 # ---------------------------------------------------------------------------
 # Version stamping
 # ---------------------------------------------------------------------------
-# The manually dispatched release workflow owns the candidate version and
-# creates the remote tag only after every native gate and the protected release
-# approval succeed. The reviewed main commit must already be stamped; the
-# workflow invokes `scripts/stamp-version.sh "$TAG"` only to prove it is a no-op.
-# Local devs who want to pre-stage a version (e.g. for a manual smoke test of
-# `make dist`) can use this target as a friendly wrapper.
+# The manually dispatched release workflow owns the candidate version, stamps
+# it into an isolated build checkout, and creates the remote tag only after
+# every native gate and the protected release approval succeed. A version-only
+# PR is not required. Local devs who want to stage a version for a manual smoke
+# test of `make dist` can use this target as a friendly wrapper.
 #
 #   make set-version VERSION=0.4.1
 #
@@ -941,8 +940,8 @@ dist: dist-cli dist-gateway dist-plugin dist-sandbox dist-upgrade-manifest dist-
 	@echo "  The protected release workflow wraps, signs, seals, and tests these inputs."
 	@echo ""
 	@echo "Cut a release (the protected workflow creates the tag + assets atomically):"
-	@echo "  Actions UI -> 'Release' workflow -> Run workflow -> enter $(VERSION)"
-	@echo "  Or from the CLI: gh workflow run release.yaml --ref main -f version=$(VERSION)"
+	@echo "  Actions UI -> 'Release' workflow -> Run workflow -> enter X.Y.Z"
+	@echo "  Or from the CLI: gh workflow run release.yaml --ref main -f version=X.Y.Z"
 	@echo ""
 	@echo "  NOTE: version must be bare X.Y.Z, no 'v' prefix — the release"
 	@echo "  workflow + scripts/install.sh + 'defenseclaw upgrade' all"

--- a/cli/tests/test_ci_workflow_efficiency.py
+++ b/cli/tests/test_ci_workflow_efficiency.py
@@ -65,7 +65,9 @@ def test_release_dispatch_version_is_stamped_without_a_version_only_pr() -> None
     identity_check = workflow.index(
         "python3 scripts/source_release_identity.py check", build_stamp
     )
-    assert build_stamp < identity_check
+    extension_build = workflow.index("run: make extensions", build_stamp)
+    gateway_build = workflow.index("goreleaser/goreleaser-action@", extension_build)
+    assert build_stamp < identity_check < extension_build < gateway_build
 
     macos_build = (ROOT / "scripts/build-macos-app-release.sh").read_text(
         encoding="utf-8"

--- a/cli/tests/test_ci_workflow_efficiency.py
+++ b/cli/tests/test_ci_workflow_efficiency.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_ci_shards_python_once_and_does_not_repeat_unified_corpus() -> None:
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    assert "name: Python Test (shard ${{ matrix.shard }})" in workflow
+    assert "shard: [0, 1, 2, 3]" in workflow
+    assert "python3 scripts/python_test_shards.py" in workflow
+    assert "name: Python Lint & Test" in workflow
+    assert "needs: python-test" in workflow
+    assert ".venv/bin/coverage combine" in workflow
+    assert "name: make test (unified)" not in workflow
+    assert "run: make test" not in workflow
+
+
+def test_ci_shards_slow_gateway_package_and_combines_go_coverage() -> None:
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    assert "name: Go Gateway Test (shard ${{ matrix.shard }})" in workflow
+    assert "python3 scripts/go_test_shards.py" in workflow
+    assert "name: Go Test (remaining packages)" in workflow
+    assert "needs: [go-test-gateway, go-test-other]" in workflow
+    assert "python3 scripts/merge_go_coverage.py" in workflow
+    assert "go tool cover -func=coverage.out" in workflow
+    assert "run: make go-test-cov" not in workflow
+
+    sharder = (ROOT / "scripts/go_test_shards.py").read_text(encoding="utf-8")
+    assert "Test|Fuzz|Example" in sharder
+
+
+def test_release_validates_reviewed_macos_pin_without_freshness_block() -> None:
+    workflow = (ROOT / ".github/workflows/release.yaml").read_text(encoding="utf-8")
+
+    assert "python3 scripts/check-macos-upstream.py --offline" in workflow
+    assert "Require latest stable macOS app source" not in workflow
+
+
+def test_release_dispatch_version_is_stamped_without_a_version_only_pr() -> None:
+    workflow = (ROOT / ".github/workflows/release.yaml").read_text(encoding="utf-8")
+
+    assert workflow.count('scripts/stamp-version.sh "$RELEASE_TAG"') >= 2
+    assert "Require reviewed source release identity" not in workflow
+    assert "GitHub source snapshot uses development version" in workflow
+    first_stamp = workflow.index('scripts/stamp-version.sh "$RELEASE_TAG"')
+    build_stamp = workflow.index('scripts/stamp-version.sh "$RELEASE_TAG"', first_stamp + 1)
+    identity_check = workflow.index(
+        "python3 scripts/source_release_identity.py check", build_stamp
+    )
+    assert build_stamp < identity_check
+
+    macos_build = (ROOT / "scripts/build-macos-app-release.sh").read_text(
+        encoding="utf-8"
+    )
+    assert 'MARKETING_VERSION="${VERSION}"' in macos_build
+    assert '-X main.version=${VERSION}' in macos_build

--- a/cli/tests/test_go_test_shards.py
+++ b/cli/tests/test_go_test_shards.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+from scripts.go_test_shards import discover_test_files, partition_test_files
+
+
+def test_go_test_file_shards_are_deterministic_and_exhaustive(tmp_path: Path) -> None:
+    (tmp_path / "small_test.go").write_text(
+        "package sample\n"
+        "func TestSmall(t *testing.T) {}\n"
+        "func FuzzInput(f *testing.F) {}\n"
+        "func ExampleSmall() {}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "large_test.go").write_text(
+        "package sample\n"
+        "func TestLargeA(t *testing.T) {}\n"
+        "func TestLargeB(t *testing.T) {}\n"
+        + ("// weight\n" * 50),
+        encoding="utf-8",
+    )
+
+    files = discover_test_files(tmp_path)
+    first = partition_test_files(files, 2)
+    second = partition_test_files(files, 2)
+
+    assert first == second
+    assert sorted(name for shard in first for name in shard) == [
+        "ExampleSmall",
+        "FuzzInput",
+        "TestLargeA",
+        "TestLargeB",
+        "TestSmall",
+    ]
+    assert set(first[0]).isdisjoint(first[1])
+    assert {"TestLargeA", "TestLargeB"} in (set(first[0]), set(first[1]))
+
+
+def test_go_test_shards_reject_invalid_count() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        partition_test_files([], 0)
+    with pytest.raises(ValueError, match="cannot exceed"):
+        partition_test_files([], 1)

--- a/cli/tests/test_merge_go_coverage.py
+++ b/cli/tests/test_merge_go_coverage.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+from scripts.merge_go_coverage import merge_profiles, write_profile
+
+
+def test_merge_go_coverage_sums_duplicate_blocks(tmp_path: Path) -> None:
+    first = tmp_path / "first.out"
+    second = tmp_path / "second.out"
+    output = tmp_path / "coverage.out"
+    first.write_text("mode: atomic\na.go:1.1,2.2 1 3\n", encoding="utf-8")
+    second.write_text(
+        "mode: atomic\na.go:1.1,2.2 1 4\nb.go:3.1,4.2 2 1\n",
+        encoding="utf-8",
+    )
+
+    mode, blocks = merge_profiles([first, second])
+    write_profile(output, mode, blocks)
+
+    assert output.read_text(encoding="utf-8") == (
+        "mode: atomic\na.go:1.1,2.2 1 7\nb.go:3.1,4.2 2 1\n"
+    )
+
+
+def test_merge_go_coverage_rejects_mixed_modes(tmp_path: Path) -> None:
+    first = tmp_path / "first.out"
+    second = tmp_path / "second.out"
+    first.write_text("mode: atomic\na.go:1.1,2.2 1 1\n", encoding="utf-8")
+    second.write_text("mode: set\na.go:1.1,2.2 1 1\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="mode mismatch"):
+        merge_profiles([first, second])
+
+
+def test_merge_go_coverage_uses_union_for_set_mode(tmp_path: Path) -> None:
+    first = tmp_path / "first.out"
+    second = tmp_path / "second.out"
+    first.write_text("mode: set\na.go:1.1,2.2 1 1\n", encoding="utf-8")
+    second.write_text("mode: set\na.go:1.1,2.2 1 1\n", encoding="utf-8")
+
+    mode, blocks = merge_profiles([first, second])
+
+    assert mode == "set"
+    assert blocks == {"a.go:1.1,2.2 1": 1}

--- a/cli/tests/test_python_test_shards.py
+++ b/cli/tests/test_python_test_shards.py
@@ -1,0 +1,61 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.python_test_shards import discover_test_files, partition_test_files
+
+
+def _write(path: Path, size: int) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("x" * size, encoding="utf-8")
+    return path.resolve()
+
+
+def test_discovers_pytest_modules_once(tmp_path: Path) -> None:
+    expected = {
+        _write(tmp_path / "test_alpha.py", 10),
+        _write(tmp_path / "nested" / "beta_test.py", 20),
+    }
+    _write(tmp_path / "helpers.py", 100)
+    _write(tmp_path / "nested" / "conftest.py", 100)
+
+    assert set(discover_test_files(tmp_path)) == expected
+
+
+def test_partition_is_deterministic_exhaustive_and_balanced(tmp_path: Path) -> None:
+    files = [_write(tmp_path / f"test_{index}.py", size) for index, size in enumerate((100, 80, 60, 40, 20, 10))]
+
+    first = partition_test_files(files, 3)
+    second = partition_test_files(list(reversed(files)), 3)
+
+    assert first == second
+    flattened = [path for shard in first for path in shard.files]
+    assert sorted(flattened) == sorted(files)
+    assert len(flattened) == len(set(flattened))
+    assert max(shard.weight for shard in first) - min(shard.weight for shard in first) <= 10
+
+
+@pytest.mark.parametrize("count", (0, -1, 7))
+def test_partition_rejects_invalid_shard_counts(tmp_path: Path, count: int) -> None:
+    files = [_write(tmp_path / f"test_{index}.py", 1) for index in range(6)]
+
+    with pytest.raises(ValueError):
+        partition_test_files(files, count)

--- a/cli/tests/test_python_test_shards.py
+++ b/cli/tests/test_python_test_shards.py
@@ -40,6 +40,17 @@ def test_discovers_pytest_modules_once(tmp_path: Path) -> None:
     assert set(discover_test_files(tmp_path)) == expected
 
 
+def test_discovers_modules_from_relative_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    test_root = Path("tests")
+    expected = {_write(test_root / "nested" / "test_relative.py", 10)}
+
+    assert set(discover_test_files(test_root)) == expected
+
+
 def test_partition_is_deterministic_exhaustive_and_balanced(tmp_path: Path) -> None:
     files = [_write(tmp_path / f"test_{index}.py", size) for index, size in enumerate((100, 80, 60, 40, 20, 10))]
 

--- a/cli/tests/test_source_release_identity.py
+++ b/cli/tests/test_source_release_identity.py
@@ -260,9 +260,11 @@ def test_release_workflow_stamps_dispatch_version_and_tags_reviewed_commit() -> 
     stamp = workflow.index('scripts/stamp-version.sh "$RELEASE_TAG"', tracked)
     build_stamp = workflow.index('scripts/stamp-version.sh "$RELEASE_TAG"', stamp + 1)
     expected = workflow.index('--expected-release "$RELEASE_TAG"', build_stamp)
+    extension_build = workflow.index("run: make extensions", expected)
+    gateway_build = workflow.index("goreleaser/goreleaser-action@", extension_build)
     publish = workflow.index('gh release create "$RELEASE_TAG"')
 
-    assert tracked < stamp < build_stamp < expected < publish
+    assert tracked < stamp < build_stamp < expected < extension_build < gateway_build < publish
     for relative in VERSION_PATHS:
         assert relative in workflow[tracked:stamp]
     assert "Require reviewed source release identity" not in workflow

--- a/cli/tests/test_source_release_identity.py
+++ b/cli/tests/test_source_release_identity.py
@@ -127,6 +127,18 @@ def test_reviewed_source_identity_binds_every_canonical_version_source() -> None
     assert release_candidate._reviewed_source_install_identity("0.8.5") == identity
 
 
+def test_dynamic_release_identity_uses_dispatch_version_with_reviewed_epoch() -> None:
+    identity = source_release_identity.release_identity_for_version("9.8.7", ROOT)
+
+    assert identity == {
+        "schema_version": 1,
+        "source_release": "9.8.7",
+        "source_install_compatibility_epoch": 2,
+        "runtime_config_version": 8,
+    }
+    assert release_candidate._reviewed_source_install_identity("9.8.7") == identity
+
+
 def test_hard_cut_cannot_reuse_bridge_source_identity(tmp_path: Path) -> None:
     repo = _copy_source_fixture(tmp_path)
     identity_path = repo / "release/source-install-identity.json"
@@ -142,7 +154,7 @@ def test_hard_cut_cannot_reuse_bridge_source_identity(tmp_path: Path) -> None:
         source_release_identity.validate_source_tree(repo)
 
 
-def test_release_stamp_is_provably_noop_for_reviewed_source(tmp_path: Path) -> None:
+def test_release_stamp_is_idempotent_for_checked_in_development_version(tmp_path: Path) -> None:
     repo = _copy_source_fixture(tmp_path)
     stamp = repo / "scripts/stamp-version.sh"
     shutil.copy2(ROOT / "scripts/stamp-version.sh", stamp)
@@ -159,6 +171,33 @@ def test_release_stamp_is_provably_noop_for_reviewed_source(tmp_path: Path) -> N
 
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert {relative: (repo / relative).read_bytes() for relative in VERSION_PATHS} == before
+
+
+def test_release_stamp_applies_dynamic_future_version_to_every_release_surface(
+    tmp_path: Path,
+) -> None:
+    repo = _copy_source_fixture(tmp_path)
+    stamp = repo / "scripts/stamp-version.sh"
+    shutil.copy2(ROOT / "scripts/stamp-version.sh", stamp)
+
+    completed = subprocess.run(
+        ["/bin/bash", str(stamp), "9.8.7"],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=15,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert set(source_release_identity.checked_in_version_sources(repo).values()) == {
+        "9.8.7"
+    }
+    identity = source_release_identity.validate_source_tree(
+        repo,
+        expected_release="9.8.7",
+    )
+    assert identity["source_release"] == "9.8.7"
 
 
 def test_hard_cut_source_cannot_be_restamped_as_the_bridge(tmp_path: Path) -> None:
@@ -215,18 +254,19 @@ def test_hard_cut_source_identity_rejects_either_config_literal_drifting(
         source_release_identity.validate_source_tree(repo, expected_release="0.8.5")
 
 
-def test_release_workflow_rejects_unstamped_source_before_publish_and_tags_reviewed_commit() -> None:
+def test_release_workflow_stamps_dispatch_version_and_tags_reviewed_commit() -> None:
     workflow = (ROOT / ".github/workflows/release.yaml").read_text(encoding="utf-8")
     tracked = workflow.index("git ls-files --error-unmatch --")
-    preflight = workflow.index("python3 scripts/source_release_identity.py check")
-    expected = workflow.index('--expected-release "$RELEASE_TAG"', preflight)
-    stamp = workflow.index('scripts/stamp-version.sh "$RELEASE_TAG"', preflight)
-    no_op_proof = workflow.index("git diff --exit-code --", stamp)
+    stamp = workflow.index('scripts/stamp-version.sh "$RELEASE_TAG"', tracked)
+    build_stamp = workflow.index('scripts/stamp-version.sh "$RELEASE_TAG"', stamp + 1)
+    expected = workflow.index('--expected-release "$RELEASE_TAG"', build_stamp)
     publish = workflow.index('gh release create "$RELEASE_TAG"')
 
-    assert tracked < preflight < expected < stamp < no_op_proof < publish
+    assert tracked < stamp < build_stamp < expected < publish
     for relative in VERSION_PATHS:
-        assert relative in workflow[tracked:preflight]
+        assert relative in workflow[tracked:stamp]
+    assert "Require reviewed source release identity" not in workflow
+    assert "git diff --exit-code --" not in workflow[tracked:expected]
     assert '--target "$RELEASE_COMMIT"' in workflow[publish:]
     assert 'test "$remote_commit" = "$RELEASE_COMMIT"' in workflow[publish:]
 

--- a/cli/tests/test_source_release_identity.py
+++ b/cli/tests/test_source_release_identity.py
@@ -261,12 +261,25 @@ def test_release_workflow_stamps_dispatch_version_and_tags_reviewed_commit() -> 
     build_stamp = workflow.index('scripts/stamp-version.sh "$RELEASE_TAG"', stamp + 1)
     expected = workflow.index('--expected-release "$RELEASE_TAG"', build_stamp)
     extension_build = workflow.index("run: make extensions", expected)
+    restore_generated = workflow.index("git restore --worktree --", extension_build)
+    cleanliness_check = workflow.index("git diff --exit-code --", restore_generated)
     gateway_build = workflow.index("goreleaser/goreleaser-action@", extension_build)
     publish = workflow.index('gh release create "$RELEASE_TAG"')
 
-    assert tracked < stamp < build_stamp < expected < extension_build < gateway_build < publish
+    assert (
+        tracked
+        < stamp
+        < build_stamp
+        < expected
+        < extension_build
+        < restore_generated
+        < cleanliness_check
+        < gateway_build
+        < publish
+    )
     for relative in VERSION_PATHS:
         assert relative in workflow[tracked:stamp]
+        assert f":(exclude){relative}" in workflow[cleanliness_check:gateway_build]
     assert "Require reviewed source release identity" not in workflow
     assert "git diff --exit-code --" not in workflow[tracked:expected]
     assert '--target "$RELEASE_COMMIT"' in workflow[publish:]

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -328,6 +328,17 @@ artifacts, runs the native upgrade gates, and creates the remote tag and GitHub
 release together only after protected release approval. This ordering keeps
 Immutable Releases from stranding half-built assets.
 
+The workflow input is the published-version authority. It stamps the requested
+version into its isolated build checkout before producing the CLI, gateway,
+plugin, wheel, macOS app, manifests, checksums, or attestations, so a separate
+version-bump PR is not required. The checked-in version remains a synchronized
+local-development default.
+
+GitHub's automatic “Source code” ZIP/tarball is a snapshot of the reviewed tag
+commit and is not an installer input. When the requested release differs from
+the checked-in development default, the workflow emits a warning; the signed,
+checksummed release assets still carry the requested version everywhere.
+
 Preferred — from the Actions UI:
 
 ```

--- a/scripts/go_test_shards.py
+++ b/scripts/go_test_shards.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Partition one Go package's top-level tests into deterministic file shards."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+TEST_FUNCTION_RE = re.compile(
+    r"^func\s+((?:Test|Fuzz|Example)[A-Za-z0-9_]*)\s*\(", re.MULTILINE
+)
+
+
+def discover_test_files(package_dir: Path) -> list[tuple[Path, tuple[str, ...]]]:
+    discovered: list[tuple[Path, tuple[str, ...]]] = []
+    for path in sorted(package_dir.glob("*_test.go")):
+        names = tuple(sorted(set(TEST_FUNCTION_RE.findall(path.read_text(encoding="utf-8")))))
+        if names:
+            discovered.append((path, names))
+    return discovered
+
+
+def partition_test_files(
+    files: list[tuple[Path, tuple[str, ...]]], shard_count: int
+) -> list[list[str]]:
+    if shard_count <= 0:
+        raise ValueError("shard_count must be positive")
+    if len(files) < shard_count:
+        raise ValueError("shard_count cannot exceed discovered test files")
+    shards: list[list[str]] = [[] for _ in range(shard_count)]
+    weights = [0] * shard_count
+    weighted_files = sorted(
+        files,
+        key=lambda item: (-item[0].stat().st_size, item[0].as_posix()),
+    )
+    for path, names in weighted_files:
+        shard = min(range(shard_count), key=lambda index: (weights[index], index))
+        shards[shard].extend(names)
+        weights[shard] += path.stat().st_size
+    for shard in shards:
+        shard.sort()
+    return shards
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--package-dir", type=Path, required=True)
+    parser.add_argument("--shard-count", type=int, required=True)
+    parser.add_argument("--shard-index", type=int, required=True)
+    args = parser.parse_args()
+
+    if not 0 <= args.shard_index < args.shard_count:
+        parser.error("shard-index must be within shard-count")
+    shards = partition_test_files(discover_test_files(args.package_dir), args.shard_count)
+    names = shards[args.shard_index]
+    if not names:
+        parser.error("selected shard contains no tests")
+    print("^(?:" + "|".join(re.escape(name) for name in names) + ")$")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/merge_go_coverage.py
+++ b/scripts/merge_go_coverage.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Merge disjoint or sharded Go coverprofiles without losing hit counts."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def merge_profiles(paths: list[Path]) -> tuple[str, dict[str, int]]:
+    mode: str | None = None
+    blocks: dict[str, int] = {}
+    for path in paths:
+        lines = path.read_text(encoding="utf-8").splitlines()
+        if not lines or not lines[0].startswith("mode: "):
+            raise ValueError(f"invalid Go coverprofile: {path}")
+        current_mode = lines[0].removeprefix("mode: ")
+        if mode is None:
+            mode = current_mode
+        elif current_mode != mode:
+            raise ValueError(f"coverage mode mismatch in {path}")
+        for line in lines[1:]:
+            block, separator, count_text = line.rpartition(" ")
+            if not separator:
+                raise ValueError(f"invalid coverage row in {path}: {line!r}")
+            count = int(count_text)
+            if current_mode == "set":
+                blocks[block] = max(blocks.get(block, 0), count)
+            else:
+                blocks[block] = blocks.get(block, 0) + count
+    if mode is None:
+        raise ValueError("at least one coverprofile is required")
+    return mode, blocks
+
+
+def write_profile(output: Path, mode: str, blocks: dict[str, int]) -> None:
+    lines = [f"mode: {mode}"]
+    lines.extend(f"{block} {blocks[block]}" for block in sorted(blocks))
+    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("profiles", nargs="+", type=Path)
+    args = parser.parse_args()
+    mode, blocks = merge_profiles(args.profiles)
+    write_profile(args.output, mode, blocks)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python_test_shards.py
+++ b/scripts/python_test_shards.py
@@ -36,6 +36,7 @@ class Shard:
 def discover_test_files(test_root: Path) -> list[Path]:
     """Return every pytest test module below *test_root* exactly once."""
 
+    test_root = test_root.resolve()
     files = {
         path.resolve()
         for pattern in ("test_*.py", "*_test.py")

--- a/scripts/python_test_shards.py
+++ b/scripts/python_test_shards.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Partition Python test files into deterministic, isolated CI shards."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_TEST_ROOT = ROOT / "cli" / "tests"
+
+
+@dataclass(frozen=True)
+class Shard:
+    files: tuple[Path, ...]
+    weight: int
+
+
+def discover_test_files(test_root: Path) -> list[Path]:
+    """Return every pytest test module below *test_root* exactly once."""
+
+    files = {
+        path.resolve()
+        for pattern in ("test_*.py", "*_test.py")
+        for path in test_root.rglob(pattern)
+        if path.is_file()
+    }
+    return sorted(files, key=lambda path: path.relative_to(test_root).as_posix())
+
+
+def partition_test_files(files: list[Path], shard_count: int) -> list[Shard]:
+    """Greedily balance files by source size without splitting a module."""
+
+    if shard_count < 1:
+        raise ValueError("shard_count must be positive")
+    if len(files) < shard_count:
+        raise ValueError("shard_count cannot exceed the number of test files")
+
+    buckets: list[list[Path]] = [[] for _ in range(shard_count)]
+    weights = [0] * shard_count
+    weighted_files = sorted(files, key=lambda path: (-path.stat().st_size, path.as_posix()))
+    for path in weighted_files:
+        shard_index = min(range(shard_count), key=lambda index: (weights[index], index))
+        buckets[shard_index].append(path)
+        weights[shard_index] += path.stat().st_size
+
+    return [
+        Shard(files=tuple(sorted(bucket, key=Path.as_posix)), weight=weights[index])
+        for index, bucket in enumerate(buckets)
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--shard-count", required=True, type=int)
+    parser.add_argument("--shard-index", required=True, type=int)
+    parser.add_argument("--test-root", type=Path, default=DEFAULT_TEST_ROOT)
+    args = parser.parse_args()
+
+    if args.shard_index < 0 or args.shard_index >= args.shard_count:
+        parser.error("--shard-index must be within [0, --shard-count)")
+    test_root = args.test_root.resolve()
+    try:
+        shards = partition_test_files(discover_test_files(test_root), args.shard_count)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    for path in shards[args.shard_index].files:
+        try:
+            print(path.relative_to(ROOT).as_posix())
+        except ValueError:
+            print(path.as_posix())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -47,9 +47,12 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 try:
-    from scripts.source_release_identity import SourceIdentityError, validate_source_tree
+    from scripts.source_release_identity import (
+        SourceIdentityError,
+        release_identity_for_version,
+    )
 except ModuleNotFoundError:  # Direct ``python scripts/release_candidate.py`` execution.
-    from source_release_identity import SourceIdentityError, validate_source_tree
+    from source_release_identity import SourceIdentityError, release_identity_for_version
 
 SCHEMA_VERSION = 2
 RUNTIME_ATTESTATION_FILENAME = "runtime-candidate-checksums.txt"
@@ -89,10 +92,10 @@ class CandidateError(RuntimeError):
 
 
 def _reviewed_source_install_identity(version: str) -> dict[str, int | str]:
-    """Bind candidate custody to the reviewed source/tag compatibility identity."""
+    """Bind candidate custody to reviewed compatibility plus the dispatch version."""
 
     try:
-        return validate_source_tree(ROOT, expected_release=version)
+        return release_identity_for_version(version, ROOT)
     except SourceIdentityError as exc:
         raise CandidateError(f"reviewed source-install identity is invalid: {exc}") from exc
 

--- a/scripts/source_release_identity.py
+++ b/scripts/source_release_identity.py
@@ -289,6 +289,34 @@ def validate_source_tree(
     return identity
 
 
+def release_identity_for_version(
+    version: str,
+    root: Path = ROOT,
+) -> dict[str, int | str]:
+    """Project a validated source tree's compatibility identity onto a release version.
+
+    The checked-in version is development metadata. Manually dispatched releases
+    stamp their validated version into isolated build checkouts, while later
+    verification jobs intentionally use a pristine checkout of the reviewed
+    commit. This helper keeps those jobs on the same compatibility epoch without
+    making the development version a release gate.
+    """
+
+    reviewed = validate_source_tree(root)
+    projected = {
+        **reviewed,
+        "source_release": version,
+    }
+    identity = _validate_identity_payload(projected)
+    source_runtime = runtime_config_version(root, source_release=version)
+    if identity["runtime_config_version"] != source_runtime:
+        raise SourceIdentityError(
+            "release identity runtime_config_version does not match gateway source: "
+            f"identity={identity['runtime_config_version']}, source={source_runtime}"
+        )
+    return identity
+
+
 def _read_opened_marker(path: Path) -> tuple[bytes, str]:
     flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     try:

--- a/scripts/stamp-version.sh
+++ b/scripts/stamp-version.sh
@@ -18,11 +18,10 @@
 #
 # Stamp a single semver across every in-repo version source.
 #
-# The reviewed commit is the source of truth for releases. The release workflow
-# accepts only a requested tag that already matches every source below, invokes
-# this legacy helper as an idempotence check, and proves its diff is empty before
-# building. That keeps GitHub's tag archive byte-for-byte aligned with the
-# wheel, plugin, gateway, and macOS artifacts built from the same commit.
+# The manually dispatched release workflow's validated version input is the
+# source of truth for published artifacts. It invokes this helper in each
+# isolated build checkout before building, so every release-owned package and
+# manifest receives the same version without requiring a version-only PR.
 #
 # Sources kept in lock-step:
 #   1. Makefile                                 (VERSION := X.Y.Z)


### PR DESCRIPTION
Stack/base note: standalone focused fix on top of the squash-merged observability v8 hard cut (#490). This does not alter teams, reviewers, branch rules, rulesets, release environments, or the unsigned macOS fallback.

## Problem

Release run 29511554381 failed before producing or publishing any assets because the release preflight required the checked-in macOS upstream lock to equal the newest standalone macOS release. That freshness policy made an otherwise reviewed DefenseClaw release depend on unrelated upstream timing.

The same merged CI run also spent about 86 minutes in Python coverage and 88 minutes in a second unified job that repeated the Python and Go suites. Go race/coverage took 39 minutes, of which the monolithic internal/gateway package consumed nearly 36 minutes.

## Current Situation

- The requested 0.8.5 version is already internally consistent in main.
- The Release workflow nevertheless blocked on macOS upstream v1.1.6, even though the current integrated app source remains buildable.
- A full Python corpus was executed twice.
- Go package parallelism could not shorten the single 35-minute gateway package.
- Required check names are Go Test and Python Lint & Test and must remain stable.

## Solution

### Restore release-owned version dispatch

The workflow-dispatch version is the authority for installable artifacts. The release preflight validates the reviewed macOS lock offline, stamps the requested version into the isolated build checkout, and projects that version onto the reviewed compatibility epoch in pristine verification jobs. No version-only PR is required.

For the concrete 0.8.5 cut, the checked-in development version is also 0.8.5, so GitHub automatic source snapshots and built artifacts agree. A future dispatch that differs from the development default emits an explicit source-snapshot warning.

### Decouple macOS freshness from release correctness

The protected release no longer fails merely because a newer standalone macOS tag exists. The existing scheduled freshness workflow continues to report upstream drift independently. The release builds the last successfully integrated source rather than attempting an unsafe release-time three-way merge.

### Shorten the CI critical path

```mermaid
flowchart LR
    P[Python corpus] --> P0[Shard 0]
    P --> P1[Shard 1]
    P --> P2[Shard 2]
    P --> P3[Shard 3]
    P0 --> PC[Python Lint and Test]
    P1 --> PC
    P2 --> PC
    P3 --> PC
    G[Go corpus] --> GG[Gateway shards]
    G --> GO[Remaining packages]
    GG --> GC[Go Test]
    GO --> GC
```

Python test files run once across four deterministic isolated shards; their raw coverage is combined by the existing Python Lint & Test check. The duplicate unified job is removed.

Gateway Test, Fuzz, and Example functions run across four race/coverage shards, while every other Go package runs once in parallel. A final Go Test check combines all five profiles and validates the result.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `.github/workflows/release.yaml` | Uses offline macOS lock validation and dynamic dispatch-version stamping |
| `scripts/source_release_identity.py` | Projects a validated compatibility identity onto the requested release version |
| `scripts/release_candidate.py` | Verifies candidates against the dynamic release identity |
| `scripts/stamp-version.sh`, `Makefile`, `docs/INSTALL.md` | Documents and exposes the dynamic release workflow |
| `.github/workflows/ci.yml` | Removes duplicate unified testing; shards Python and gateway Go tests; preserves required check names |
| `scripts/python_test_shards.py` | Deterministically partitions all pytest modules |
| `scripts/go_test_shards.py` | Deterministically partitions gateway Test, Fuzz, and Example functions by source file |
| `scripts/merge_go_coverage.py` | Combines atomic/count/set Go coverprofiles correctly |
| `cli/tests/test_*shards.py`, `test_merge_go_coverage.py`, `test_ci_workflow_efficiency.py` | Proves completeness, determinism, workflow wiring, and coverage behavior |

## Breaking Changes

- Release operators no longer need a version-only PR before dispatching Release; the UI/CLI version input controls published artifacts.
- CI now exposes shard jobs in addition to the unchanged aggregate Go Test and Python Lint & Test checks.
- macOS upstream freshness is report-only for DefenseClaw releases; the last integrated app source remains the release input until an upstream integration lands.

## Open Issues / Follow-ups

None.

## Test Plan

Observed locally:

```bash
# Full Python corpus, four concurrent isolated coverage shards
# 7,156 passed; 46 skipped; all subtests retained; combined XML generated
# Slowest shard: 15m28s (previous CI Python job: 86m34s)

PYTHONPATH=. .venv/bin/python -m pytest -q \
  cli/tests/test_ci_workflow_efficiency.py \
  cli/tests/test_go_test_shards.py \
  cli/tests/test_merge_go_coverage.py \
  cli/tests/test_python_test_shards.py \
  cli/tests/test_source_release_identity.py \
  cli/tests/test_release_candidate.py \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_install_docs_static.py
# passed

make check-version-sync
# version sync OK: 0.8.5 (source epoch 2, runtime 8)

go test -list . ./internal/gateway
# 1,841 Linux Test/Fuzz/Example targets; no target missing from shards

go test -race -count=1 -run TestOTLPPathAuthenticationFailureKeepsSpecializedTelemetryOwner \
  -coverprofile=/tmp/part-0.out ./internal/gateway
go test -race -count=1 -run FuzzOTLPInboundNoRawBypass \
  -coverprofile=/tmp/part-1.out ./internal/gateway
python3 scripts/merge_go_coverage.py --output /tmp/coverage.out /tmp/part-0.out /tmp/part-1.out
go tool cover -func=/tmp/coverage.out
# passed; fuzz seed corpus executed; merged profile accepted

go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 \
  .github/workflows/ci.yml .github/workflows/release.yaml
# passed

.venv/bin/ruff check scripts/go_test_shards.py scripts/merge_go_coverage.py \
  scripts/python_test_shards.py scripts/source_release_identity.py \
  scripts/release_candidate.py cli/tests/test_ci_workflow_efficiency.py \
  cli/tests/test_go_test_shards.py cli/tests/test_merge_go_coverage.py \
  cli/tests/test_python_test_shards.py cli/tests/test_source_release_identity.py
# passed

git diff --check
# passed
```

Targeted Claude Opus reviews were also run independently for release-version/provenance behavior and CI sharding. The CI review found the initial fuzz-target omission; this revision includes and tests Test, Fuzz, and Example targets.