### PR TITLE
ci(macos): avoid duplicate post-merge packaging

### DIFF
--- a/.github/workflows/macos-app.yml
+++ b/.github/workflows/macos-app.yml
@@ -17,32 +17,6 @@
 name: macOS App
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "macos/**"
-      - "scripts/build-macos-app-release.sh"
-      - "scripts/check-macos-upstream.py"
-      - "scripts/export-uv-overrides.py"
-      - "scripts/generate-upgrade-manifest.py"
-      - "scripts/macos_license_headers.py"
-      - "scripts/release_candidate.py"
-      - "scripts/source_release_identity.py"
-      - "scripts/stamp-version.sh"
-      - "scripts/test-upgrade-release.sh"
-      - "scripts/update-macos-app.sh"
-      - "scripts/verify-macos-app-release.sh"
-      - "release/source-install-identity.json"
-      - "release/upgrade-baselines.json"
-      - "Makefile"
-      - "pyproject.toml"
-      - "cli/**"
-      - "go.mod"
-      - "go.sum"
-      - "cmd/**"
-      - "internal/**"
-      - "extensions/defenseclaw/**"
-      - ".github/workflows/macos-app.yml"
   pull_request:
     paths:
       - "macos/**"

--- a/cli/tests/test_macos_runtime_installer_upgrade_guard.py
+++ b/cli/tests/test_macos_runtime_installer_upgrade_guard.py
@@ -234,6 +234,16 @@ def test_macos_release_signer_requirement_pins_production_team_only() -> None:
     assert 'codesign --verify --strict -R "${APP_REQUIREMENT}"' in verify
 
 
+def test_macos_package_ci_is_not_repeated_after_merge() -> None:
+    workflow = yaml.load(
+        MACOS_CI_WORKFLOW.read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+    triggers = workflow["on"]
+
+    assert set(triggers) == {"pull_request", "workflow_dispatch"}
+
+
 def test_macos_ci_builds_and_verifies_reviewed_runtime_fixture_first() -> None:
     workflow = MACOS_CI_WORKFLOW.read_text(encoding="utf-8")
     smoke = UPGRADE_RELEASE_SMOKE.read_text(encoding="utf-8")
@@ -304,7 +314,7 @@ def test_macos_ci_builds_and_verifies_reviewed_runtime_fixture_first() -> None:
         '"scripts/source_release_identity.py"',
         '"scripts/test-upgrade-release.sh"',
     ):
-        assert workflow.count(watched) == 2
+        assert workflow.count(watched) == 1
     assert 'make -C "${build_root}" dist-cli DIST_DIR="${out}"' in smoke
     assert 'make -C "${build_root}" dist-plugin DIST_DIR="${out}"' in smoke
     assert '"${build_root}/scripts/generate-upgrade-manifest.py"' in smoke

--- a/docs/RELEASE_VALIDATION.md
+++ b/docs/RELEASE_VALIDATION.md
@@ -13,6 +13,13 @@ observability, Docker, or provenance defects for the first time.
 | Pre-release certification | Nightly schedule or manual dispatch for a selected ref and candidate version | Signed candidate; behavior-class historical matrix; live migration and rollback/recovery; Docker/local observability continuity; native platform checks; bounded-retry provenance verification | One signed candidate artifact plus one certification receipt |
 | Release | Manual version input on protected `main` | Verify a recent receipt for the exact SHA, workflow version, candidate version, platform set, behavior-class baselines, artifact ID/digest, and run identity; then publish those same bytes | Reuse certified bytes without rebuilding |
 
+The standalone macOS app workflow builds the complete ad-hoc DMG on affected
+pull requests and on manual request. It does not repeat that disk-intensive
+package build after the same reviewed tree is merged to `main`; the main smoke
+already validates the exact merged runtime candidate. The protected Release
+workflow remains the only path that builds the publishable, conditionally
+notarized macOS assets.
+
 If a matching certification receipt is missing, failed, stale, or does not
 cover the exact release inputs, Release must invoke the full certification path
 and wait for it. It must never publish after only a reduced smoke and must never


### PR DESCRIPTION
Standalone focused follow-up against `main`. This removes a redundant post-merge macOS packaging run; it does not change product code, release assets, signing, notarization, or release environments.

## Problem

After PR #546 was squash-merged, the repository appeared red even though every main CI and release-smoke job passed. The separate macOS App workflow rebuilt the same reviewed Git tree and exhausted the GitHub-hosted runner's disk while `hdiutil` created an unverified DMG.

## Current Situation

- The affected PR-head macOS package build passed.
- The PR head and squash-merged main commit have the identical Git tree.
- All 42 post-merge CI jobs passed, including the exact-SHA main candidate and both representative upgrade canaries.
- The only failure was `hdiutil: create failed - No space left on device` in macOS App run 29546201188.
- The post-merge ad-hoc DMG is not consumed by another workflow and adds no exact-SHA evidence.

## Solution

Run the standalone full macOS ad-hoc package build once before merge for affected pull requests, retain manual dispatch for diagnostics, and leave publishable macOS packaging in the protected Release workflow. Main continues to run the exact-SHA runtime candidate smoke introduced by #546.

This removes the duplicate disk-heavy execution instead of adding runner-specific cleanup or retry machinery.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `.github/workflows/macos-app.yml` | Removed the `push`-to-`main` trigger; retained path-filtered PR and manual execution. |
| `cli/tests/test_macos_runtime_installer_upgrade_guard.py` | Enforced exactly the PR/manual trigger contract and updated path-count assertions. |
| `docs/RELEASE_VALIDATION.md` | Documented ownership of PR, main, and Release macOS validation. |

## Breaking Changes

None. The macOS app remains built on affected PRs, manual request, and Release. Only the redundant post-merge ad-hoc package build is removed.

## Open Issues / Follow-ups

None.

## Test Plan

Observed locally on macOS:

```bash
PYTHONPATH=. uv run --python 3.13 pytest -q \
  cli/tests/test_macos_runtime_installer_upgrade_guard.py \
  cli/tests/test_release_validation_strategy.py \
  cli/tests/test_release_workflow_staged.py
# 52 passed

actionlint .github/workflows/macos-app.yml
# passed

git diff --check
# passed
```

Post-merge evidence for main SHA `0d925f4518d54e43a78b848fda9ff1c31fd92455`:

- CI run 29546201212: success, including exact-SHA candidate and upgrade canaries.
- macOS App run 29546201188: product build/signing succeeded; the hosted runner exhausted disk only at DMG creation.
