### PR TITLE
fix(release): keep GoReleaser checkout clean

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -520,8 +520,6 @@ jobs:
         )
       }}
     runs-on: ubuntu-latest
-    env:
-      UPGRADE_BASELINE_POLICY: ${{ github.workspace }}/effective-upgrade-baselines.json
     permissions:
       contents: read
     outputs:
@@ -540,7 +538,10 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ needs.release-preflight.outputs.baseline_artifact }}
-          path: .
+          path: ${{ runner.temp }}/effective-baselines
+
+      - name: Bind effective baseline outside the source checkout
+        run: echo "UPGRADE_BASELINE_POLICY=$RUNNER_TEMP/effective-baselines/effective-upgrade-baselines.json" >> "$GITHUB_ENV"
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
@@ -588,22 +589,26 @@ jobs:
       - name: Build OpenClaw plugin and populate embed tree
         run: make extensions
 
-      - name: Restore tracked generated files before GoReleaser
+      - name: Restore a clean source checkout before GoReleaser
         run: |
           set -euo pipefail
           git restore --worktree -- \
+            Makefile \
+            pyproject.toml \
+            uv.lock \
+            cli/defenseclaw/__init__.py \
             extensions/defenseclaw/dist \
-            internal/gateway/connector/openclaw_extension/.placeholder
-          git diff --exit-code -- \
-            . \
-            ':(exclude)Makefile' \
-            ':(exclude)pyproject.toml' \
-            ':(exclude)uv.lock' \
-            ':(exclude)cli/defenseclaw/__init__.py' \
-            ':(exclude)extensions/defenseclaw/package.json' \
-            ':(exclude)extensions/defenseclaw/package-lock.json' \
-            ':(exclude)macos/DefenseClawMac/DefenseClawMac.xcodeproj/project.pbxproj' \
-            ':(exclude)release/source-install-identity.json'
+            extensions/defenseclaw/package.json \
+            extensions/defenseclaw/package-lock.json \
+            internal/gateway/connector/openclaw_extension/.placeholder \
+            macos/DefenseClawMac/DefenseClawMac.xcodeproj/project.pbxproj \
+            release/source-install-identity.json
+          dirty="$(git status --porcelain --untracked-files=all)"
+          if [[ -n "$dirty" ]]; then
+            echo "::error title=Dirty GoReleaser source checkout::Generated release inputs must stay outside the source checkout."
+            printf '%s\n' "$dirty"
+            exit 1
+          fi
 
       - name: Build gateway archives and SBOMs
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
@@ -620,6 +625,7 @@ jobs:
           RELEASE_TAG: ${{ needs.release-preflight.outputs.tag }}
         run: |
           set -euo pipefail
+          scripts/stamp-version.sh "$RELEASE_TAG"
           make dist-cli
           make dist-plugin
           make dist-upgrade-manifest

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -224,6 +224,44 @@ def test_build_once_candidate_is_reused_by_tests_and_publisher() -> None:
     )
 
 
+def test_runtime_candidate_keeps_generated_policy_outside_goreleaser_checkout() -> None:
+    job = _workflow()["jobs"]["build-runtime-candidate"]
+    steps = job["steps"]
+    rendered = str(job)
+
+    baseline_download = next(
+        step
+        for step in steps
+        if step.get("uses", "").startswith("actions/download-artifact@")
+    )
+    assert baseline_download["with"]["path"] == "${{ runner.temp }}/effective-baselines"
+    baseline_binding = next(
+        step
+        for step in steps
+        if step.get("name") == "Bind effective baseline outside the source checkout"
+    )
+    assert (
+        "UPGRADE_BASELINE_POLICY=$RUNNER_TEMP/effective-baselines/"
+        "effective-upgrade-baselines.json"
+    ) in baseline_binding["run"]
+
+    first_stamp = rendered.index('scripts/stamp-version.sh "$RELEASE_TAG"')
+    extension_build = rendered.index("make extensions", first_stamp)
+    clean_step = next(
+        step
+        for step in steps
+        if step.get("name") == "Restore a clean source checkout before GoReleaser"
+    )
+    clean = rendered.index(clean_step["name"])
+    goreleaser = rendered.index("goreleaser/goreleaser-action@")
+    second_stamp = rendered.index('scripts/stamp-version.sh "$RELEASE_TAG"', first_stamp + 1)
+    assert first_stamp < extension_build < clean < goreleaser < second_stamp
+    clean_run = clean_step["run"]
+    assert "git status --porcelain --untracked-files=all" in clean_run
+    assert 'if [[ -n "$dirty" ]]' in clean_run
+    assert "exit 1" in clean_run
+
+
 def test_unpublished_windows_runtime_requires_sealed_native_refusal() -> None:
     job = _certification_workflow()["jobs"]["windows-unpublished-refusal"]
     rendered = str(job)

--- a/cli/tests/test_source_release_identity.py
+++ b/cli/tests/test_source_release_identity.py
@@ -262,8 +262,13 @@ def test_release_workflow_stamps_dispatch_version_and_tags_reviewed_commit() -> 
     expected = workflow.index('--expected-release "$RELEASE_TAG"', build_stamp)
     extension_build = workflow.index("run: make extensions", expected)
     restore_generated = workflow.index("git restore --worktree --", extension_build)
-    cleanliness_check = workflow.index("git diff --exit-code --", restore_generated)
+    cleanliness_check = workflow.index(
+        "git status --porcelain --untracked-files=all", restore_generated
+    )
     gateway_build = workflow.index("goreleaser/goreleaser-action@", extension_build)
+    package_stamp = workflow.index(
+        'scripts/stamp-version.sh "$RELEASE_TAG"', build_stamp + 1
+    )
     publish = workflow.index('gh release create "$RELEASE_TAG"')
 
     assert (
@@ -275,11 +280,12 @@ def test_release_workflow_stamps_dispatch_version_and_tags_reviewed_commit() -> 
         < restore_generated
         < cleanliness_check
         < gateway_build
+        < package_stamp
         < publish
     )
     for relative in VERSION_PATHS:
         assert relative in workflow[tracked:stamp]
-        assert f":(exclude){relative}" in workflow[cleanliness_check:gateway_build]
+        assert relative in workflow[restore_generated:cleanliness_check]
     assert "Require reviewed source release identity" not in workflow
     assert "git diff --exit-code --" not in workflow[tracked:expected]
     assert '--target "$RELEASE_COMMIT"' in workflow[publish:]


### PR DESCRIPTION
Standalone release-workflow fix against `main`. This does not alter PR #490's v8 behavior, the upgrade matrix, signing policy, release environments, or repository governance.

## Problem

[Release run 29548571494](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29548571494) failed in `Build runtime candidate once` before signing or publishing. The release preflight generated `effective-upgrade-baselines.json`, and the runtime job downloaded that artifact into the Git checkout. GoReleaser then refused the dirty source tree:

```text
git is in a dirty state
?? effective-upgrade-baselines.json
```

The same dirty-tree class would recur on a later dynamic release version when `stamp-version.sh` changes tracked source-version files before GoReleaser.

## Current Situation

The selected release SHA, baseline resolution, and preflight checks completed successfully. No release assets were signed or published. Candidate construction could not start because workflow-generated inputs and tracked version stamps were present in GoReleaser's source checkout.

## Solution

### Keep generated policy outside the checkout

Download the effective baseline artifact under `RUNNER_TEMP` and bind `UPGRADE_BASELINE_POLICY` through `GITHUB_ENV` for later build steps.

### Give GoReleaser a pristine exact-SHA tree

Build the release-stamped embedded plugin first, then restore every tracked source-version/generated path. Fail explicitly if any tracked or untracked file remains before GoReleaser.

### Restamp packaged artifacts

After GoReleaser creates native archives from the local release tag, reapply the dispatch version before building the CLI, plugin, and upgrade manifest packages. This preserves dynamic release versioning without requiring a version-only PR.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `.github/workflows/release.yaml` | Moves the generated baseline outside the checkout, enforces a clean GoReleaser tree, and restamps later package outputs. |
| `cli/tests/test_release_workflow_staged.py` | Verifies the external baseline path, fail-closed dirty-tree guard, and stamp/build/restore/GoReleaser/restamp order. |
| `cli/tests/test_source_release_identity.py` | Updates the source-identity contract to require restoring stamped files before GoReleaser and restamping packages afterward. |

## Breaking Changes

None. Release inputs, signatures, artifacts, upgrade behavior, and operator commands are unchanged.

## Open Issues / Follow-ups

None.

## Test Plan

Observed locally:

```text
PYTHONPATH=. uv run --python 3.13 pytest -q \
  cli/tests/test_release_candidate.py \
  cli/tests/test_release_certification.py \
  cli/tests/test_release_invariants.py \
  cli/tests/test_release_validation_strategy.py \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_source_release_identity.py \
  cli/tests/test_ci_workflow_efficiency.py
# 256 passed in 12.74s

actionlint -shellcheck= .github/workflows/release.yaml
# passed

git diff --check
# passed
```

Dynamic-version rehearsal:

```text
scripts/stamp-version.sh 0.8.6
make extensions
# restore the workflow's exact tracked path set
# compare full porcelain status before and after
# dynamic-version-cleanup rehearsal: PASS
```

The repository's exact fast deterministic Release Regression command also passed: 175 tests in 10.07s.
