### PR TITLE
ci: run exhaustive telemetry tests selectively

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,45 +346,6 @@ jobs:
           path: coverage-py-shard-${{ matrix.shard }}
           retention-days: 1
 
-  python-telemetry-test:
-    name: Python Telemetry Test (${{ matrix.suite }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 50
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - suite: registry-generator
-            test_file: cli/tests/test_telemetry_registry_generator.py
-          - suite: candidate-renderer
-            test_file: cli/tests/test_telemetry_registry_candidate_renderer.py
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          persist-credentials: false
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-      - run: uv sync
-      - run: make _bundle-data
-      - name: Run telemetry registry suite with node-level workers
-        env:
-          PYTHON_TELEMETRY_SUITE: ${{ matrix.suite }}
-          PYTHON_TELEMETRY_TEST_FILE: ${{ matrix.test_file }}
-        run: |
-          set -euo pipefail
-          COVERAGE_FILE="coverage-py-telemetry-$PYTHON_TELEMETRY_SUITE" \
-            .venv/bin/python -m pytest "$PYTHON_TELEMETRY_TEST_FILE" \
-              -q --tb=short \
-              --durations=25 \
-              --numprocesses=4 \
-              --dist=worksteal \
-              --cov=defenseclaw \
-              --cov-report=
-      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: python-coverage-part-telemetry-${{ matrix.suite }}
-          path: coverage-py-telemetry-${{ matrix.suite }}
-          retention-days: 1
-
   python-lint:
     name: Python Lint
     runs-on: ubuntu-latest
@@ -400,18 +361,16 @@ jobs:
     # Preserve the existing required-check name while making it the single
     # authority over lint, every isolated test partition, and combined coverage.
     name: Python Lint & Test
-    needs: [python-test, python-telemetry-test, python-lint]
+    needs: [python-test, python-lint]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Require lint and every Python test partition
         env:
           PYTHON_REGULAR_RESULT: ${{ needs.python-test.result }}
-          PYTHON_TELEMETRY_RESULT: ${{ needs.python-telemetry-test.result }}
           PYTHON_LINT_RESULT: ${{ needs.python-lint.result }}
         run: |
           test "$PYTHON_REGULAR_RESULT" = success
-          test "$PYTHON_TELEMETRY_RESULT" = success
           test "$PYTHON_LINT_RESULT" = success
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -429,7 +388,7 @@ jobs:
           mapfile -t coverage_parts < <(
             find coverage-parts -type f -name 'coverage-py-*' -print | sort
           )
-          test "${#coverage_parts[@]}" -eq 6
+          test "${#coverage_parts[@]}" -eq 4
           .venv/bin/coverage combine "${coverage_parts[@]}"
           .venv/bin/coverage xml -o coverage-py.xml
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -898,6 +857,11 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - run: make plugin
       - run: make dev-pycli
+      # Keep the ordinary gate small: compile the real registry once and prove
+      # that every checked-in runtime/Go output is current. Exhaustive mutation
+      # coverage runs only when its inputs change, plus nightly/manual.
+      - name: Verify canonical telemetry registry outputs
+        run: make telemetry-check
       - run: make check VERIFY_OBSERVABILITY_BASELINE_ANCESTRY=1
 
   local-observability-golden:

--- a/.github/workflows/telemetry-registry.yml
+++ b/.github/workflows/telemetry-registry.yml
@@ -1,0 +1,76 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+name: Telemetry Registry Exhaustive
+
+on:
+  pull_request:
+    paths:
+      - "schemas/telemetry/**"
+      - "scripts/generate_telemetry_registry.py"
+      - "scripts/update_telemetry_registry_upstream.py"
+      - "scripts/render_telemetry_*.py"
+      - "scripts/telemetry_*.py"
+      - "cli/tests/conftest.py"
+      - "cli/tests/test_telemetry_ci_strategy.py"
+      - "cli/tests/test_telemetry_registry_*.py"
+      - "cli/tests/support/telemetry_registry_manifest_driver.py"
+      - "docs/design/observability-v8/current-state-inventory.yaml"
+      - "internal/observability/zz_generated_telemetry_*.go"
+      - "Makefile"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/telemetry-registry.yml"
+  schedule:
+    - cron: "47 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: telemetry-registry-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  exhaustive:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Registry generator mutation suite
+            test_file: cli/tests/test_telemetry_registry_generator.py
+          - name: Candidate renderer mutation suite
+            test_file: cli/tests/test_telemetry_registry_candidate_renderer.py
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - run: uv sync
+      - run: make _bundle-data
+      - name: Run exhaustive telemetry registry suite
+        env:
+          PYTHON_TELEMETRY_TEST_FILE: ${{ matrix.test_file }}
+        run: |
+          set -euo pipefail
+          .venv/bin/python -m pytest "$PYTHON_TELEMETRY_TEST_FILE" \
+            -q --tb=short \
+            --durations=25 \
+            --numprocesses=4 \
+            --dist=worksteal
+
+  complete:
+    name: Telemetry Registry Exhaustive
+    needs: exhaustive
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every exhaustive suite
+        env:
+          EXHAUSTIVE_RESULT: ${{ needs.exhaustive.result }}
+        run: test "$EXHAUSTIVE_RESULT" = success

--- a/cli/tests/test_ci_workflow_efficiency.py
+++ b/cli/tests/test_ci_workflow_efficiency.py
@@ -21,6 +21,7 @@ ROOT = Path(__file__).resolve().parents[2]
 
 def test_ci_shards_python_once_and_does_not_repeat_unified_corpus() -> None:
     workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    exhaustive = (ROOT / ".github/workflows/telemetry-registry.yml").read_text(encoding="utf-8")
 
     assert "name: Python Test (shard ${{ matrix.shard }})" in workflow
     assert "shard: [0, 1, 2, 3]" in workflow
@@ -30,16 +31,16 @@ def test_ci_shards_python_once_and_does_not_repeat_unified_corpus() -> None:
         "cli/tests/test_telemetry_registry_candidate_renderer.py",
     ):
         assert workflow.count(f"--exclude {isolated}") == 1
-        assert workflow.count(f"test_file: {isolated}") == 1
-    assert "name: Python Telemetry Test (${{ matrix.suite }})" in workflow
-    assert "--numprocesses=4" in workflow
-    assert "--dist=worksteal" in workflow
+        assert exhaustive.count(f"test_file: {isolated}") == 1
+    assert "name: Python Telemetry Test (${{ matrix.suite }})" not in workflow
+    assert "--numprocesses=4" in exhaustive
+    assert "--dist=worksteal" in exhaustive
     assert "name: Python Lint" in workflow
     assert "name: Python Lint & Test" in workflow
-    assert "needs: [python-test, python-telemetry-test, python-lint]" in workflow
+    assert "needs: [python-test, python-lint]" in workflow
     assert workflow.count("run: make py-lint") == 1
     assert "pattern: python-coverage-part-*" in workflow
-    assert 'test "${#coverage_parts[@]}" -eq 6' in workflow
+    assert 'test "${#coverage_parts[@]}" -eq 4' in workflow
     assert ".venv/bin/coverage combine" in workflow
     assert "name: make test (unified)" not in workflow
     assert "run: make test" not in workflow

--- a/cli/tests/test_telemetry_ci_strategy.py
+++ b/cli/tests/test_telemetry_ci_strategy.py
@@ -1,0 +1,192 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+CI_PATH = ROOT / ".github/workflows/ci.yml"
+RELEASE_PATH = ROOT / ".github/workflows/release.yaml"
+EXHAUSTIVE_PATH = ROOT / ".github/workflows/telemetry-registry.yml"
+
+EXHAUSTIVE_TESTS = {
+    "cli/tests/test_telemetry_registry_generator.py",
+    "cli/tests/test_telemetry_registry_candidate_renderer.py",
+}
+
+
+def _workflow(path: Path) -> dict[str, Any]:
+    return yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _render(value: object) -> str:
+    return str(value)
+
+
+def _pull_request_paths() -> set[str]:
+    pull_request = _workflow(EXHAUSTIVE_PATH)["on"]["pull_request"]
+    return set(pull_request["paths"])
+
+
+def _matches_any(path: Path, patterns: set[str]) -> bool:
+    relative = path.relative_to(ROOT).as_posix()
+    return any(fnmatch.fnmatchcase(relative, pattern) for pattern in patterns)
+
+
+def test_ordinary_ci_always_checks_real_registry_without_exhaustive_mutation_suites() -> None:
+    workflow = _workflow(CI_PATH)
+    jobs = workflow["jobs"]
+    schema_steps = jobs["schema-parity"]["steps"]
+
+    telemetry_steps = [step for step in schema_steps if step.get("run") == "make telemetry-check"]
+    assert len(telemetry_steps) == 1
+    assert "if" not in telemetry_steps[0]
+    assert "python-telemetry-test" not in jobs
+
+    regular = _render(jobs["python-test"])
+    for test_file in EXHAUSTIVE_TESTS:
+        assert f"--exclude {test_file}" in regular
+
+    aggregate = jobs["python-lint-test"]
+    assert set(aggregate["needs"]) == {"python-test", "python-lint"}
+    rendered_aggregate = _render(aggregate)
+    assert 'test "${#coverage_parts[@]}" -eq 4' in rendered_aggregate
+    assert "PYTHON_TELEMETRY" not in rendered_aggregate
+    assert "python-coverage-part-telemetry" not in CI_PATH.read_text(encoding="utf-8")
+
+
+def test_exhaustive_registry_workflow_is_path_filtered_nightly_and_manual() -> None:
+    workflow = _workflow(EXHAUSTIVE_PATH)
+    triggers = workflow["on"]
+    jobs = workflow["jobs"]
+    text = EXHAUSTIVE_PATH.read_text(encoding="utf-8")
+
+    assert set(triggers) == {"pull_request", "schedule", "workflow_dispatch"}
+    assert triggers["schedule"] == [{"cron": "47 3 * * *"}]
+    assert workflow["permissions"] == {"contents": "read"}
+    assert workflow["concurrency"] == {
+        "group": "telemetry-registry-${{ github.event.pull_request.number || github.ref }}",
+        "cancel-in-progress": "${{ github.event_name == 'pull_request' }}",
+    }
+
+    exhaustive = jobs["exhaustive"]
+    cases = exhaustive["strategy"]["matrix"]["include"]
+    assert {case["test_file"] for case in cases} == EXHAUSTIVE_TESTS
+    assert exhaustive["timeout-minutes"] == "50"
+    assert "--numprocesses=4" in _render(exhaustive)
+    assert "--dist=worksteal" in _render(exhaustive)
+    assert "--cov" not in text
+    assert "coverage-py-telemetry" not in text
+    assert "upload-artifact" not in text
+
+    complete = jobs["complete"]
+    assert complete["needs"] == "exhaustive"
+    assert complete["if"] == "${{ always() }}"
+    assert 'test "$EXHAUSTIVE_RESULT" = success' in _render(complete)
+
+
+def test_exhaustive_path_filter_covers_every_registry_input_and_test_dependency() -> None:
+    patterns = _pull_request_paths()
+    required_patterns = {
+        "schemas/telemetry/**",
+        "scripts/generate_telemetry_registry.py",
+        "scripts/update_telemetry_registry_upstream.py",
+        "scripts/render_telemetry_*.py",
+        "scripts/telemetry_*.py",
+        "cli/tests/conftest.py",
+        "cli/tests/test_telemetry_ci_strategy.py",
+        "cli/tests/test_telemetry_registry_*.py",
+        "cli/tests/support/telemetry_registry_manifest_driver.py",
+        "docs/design/observability-v8/current-state-inventory.yaml",
+        "internal/observability/zz_generated_telemetry_*.go",
+        "Makefile",
+        "pyproject.toml",
+        "uv.lock",
+        ".github/workflows/ci.yml",
+        ".github/workflows/telemetry-registry.yml",
+    }
+    assert patterns == required_patterns
+
+    concrete_inputs = {
+        ROOT / "scripts/generate_telemetry_registry.py",
+        ROOT / "scripts/update_telemetry_registry_upstream.py",
+        ROOT / "cli/tests/conftest.py",
+        ROOT / "cli/tests/support/telemetry_registry_manifest_driver.py",
+        ROOT / "docs/design/observability-v8/current-state-inventory.yaml",
+        ROOT / "Makefile",
+        ROOT / "pyproject.toml",
+        ROOT / "uv.lock",
+        CI_PATH,
+        EXHAUSTIVE_PATH,
+        *ROOT.glob("scripts/render_telemetry_*.py"),
+        *ROOT.glob("scripts/telemetry_*.py"),
+        *ROOT.glob("cli/tests/test_telemetry_registry_*.py"),
+        *ROOT.glob("internal/observability/zz_generated_telemetry_*.go"),
+        *ROOT.glob("schemas/telemetry/**/*"),
+    }
+    assert concrete_inputs
+    uncovered = sorted(
+        path.relative_to(ROOT).as_posix() for path in concrete_inputs if not _matches_any(path, patterns)
+    )
+    assert uncovered == []
+
+
+def test_exhaustive_suites_cannot_drift_back_into_ordinary_ci_or_release() -> None:
+    ci = _workflow(CI_PATH)
+    release = _workflow(RELEASE_PATH)
+    release_text = RELEASE_PATH.read_text(encoding="utf-8")
+    exhaustive_text = EXHAUSTIVE_PATH.read_text(encoding="utf-8")
+
+    for job_name, job in ci["jobs"].items():
+        rendered = _render(job)
+        if job_name == "python-test":
+            for test_file in EXHAUSTIVE_TESTS:
+                assert f"--exclude {test_file}" in rendered
+            continue
+        for test_file in EXHAUSTIVE_TESTS:
+            assert test_file not in rendered, job_name
+
+    for test_file in EXHAUSTIVE_TESTS:
+        assert test_file not in release_text
+        assert exhaustive_text.count(test_file) == 1
+    assert "telemetry-registry.yml" not in release_text
+    assert "uses: ./.github/workflows/telemetry-registry.yml" not in CI_PATH.read_text(encoding="utf-8")
+
+    broad_make = re.compile(r"(?:^|[\n;&])\s*make\s+(?:test|cli-test|cli-test-cov)(?=\s|$)")
+    broad_cli_path = re.compile(r"(?<![\w/])cli(?:/tests/?)?(?=\s|\\|;|&|$)")
+    explicit_test_file = re.compile(r"(?:^|\s)[^\s\\;&*]+\.py(?=\s|\\|;|&|$)")
+    for workflow_name, workflow in (("CI", ci), ("Release", release)):
+        for job_name, job in workflow["jobs"].items():
+            for step in job.get("steps", []):
+                run = step.get("run", "")
+                assert not broad_make.search(run), (workflow_name, job_name, run)
+                if "pytest" not in run:
+                    continue
+                if job_name == "python-test":
+                    assert '"${test_files[@]}"' in run
+                    for test_file in EXHAUSTIVE_TESTS:
+                        assert f"--exclude {test_file}" in run
+                    continue
+                assert '"${test_files[@]}"' not in run, (workflow_name, job_name)
+                assert not broad_cli_path.search(run), (workflow_name, job_name, run)
+                assert "cli/tests/*" not in run, (workflow_name, job_name, run)
+                assert explicit_test_file.search(run), (workflow_name, job_name, run)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -140,9 +140,18 @@ and exact operator commands.
 | Workflow | Purpose |
 |----------|---------|
 | `.github/workflows/ci.yml` | Fast deterministic release regressions on every PR; a five-class unsigned success/refusal matrix only for release-sensitive PRs; and an exact-SHA medium upgrade canary on every main merge, alongside the normal language/parity checks |
+| `.github/workflows/telemetry-registry.yml` | Exhaustive telemetry-registry mutation, provenance, and failure-atomicity suites for telemetry-sensitive PRs, nightly, and manual dispatch |
 | `.github/workflows/e2e.yml` | Self-hosted end-to-end suites and scheduled validation |
 | `.github/workflows/release.yaml` | Nightly/manual certification and promotion of exact certified release bytes |
 | `.github/workflows/pre-release-certification.yml` | Reusable expensive signed historical, rollback, native, and live-continuity gates |
+
+Ordinary PR and main CI always run `make telemetry-check`, which compiles the
+real registry and rejects stale generated runtime or Go outputs. The two
+exhaustive telemetry mutation suites are excluded from the regular Python
+shards and run only when their registry, compiler, renderer, schema, generated
+output, test, or dependency inputs change. They also run nightly and through
+manual dispatch. This keeps the common CI path fast without weakening the
+exhaustive gate for changes that can affect telemetry generation.
 
 ## Before a PR
 


### PR DESCRIPTION
Standalone CI-runtime optimization against `main`. PR #550 is the urgent Release fix and should land first operationally, but there is no Git dependency between the PRs.

## Problem

The two exhaustive telemetry registry suites dominate ordinary CI even when a PR cannot affect telemetry generation. Recent successful runs show:

| Suite | Typical duration |
|---|---:|
| Registry generator mutation suite | 25–28 minutes |
| Candidate renderer mutation suite | 20–27 minutes |
| Regular Python shards | 4–10 minutes |

Both telemetry jobs also uploaded `--cov=defenseclaw` databases with zero measured files because the expensive code under test lives in repository scripts, not the `defenseclaw` package. Unrelated PRs therefore wait roughly 28 minutes for exhaustive mutation/provenance coverage that cannot be affected by their diff.

## Current Situation

Ordinary CI always runs all 691 telemetry mutation, provenance, updater-attack, and failure-atomicity tests. The regular Python aggregate waits for six coverage files even though the two telemetry files are empty. The real-registry generated-output check is available as `make telemetry-check`, but was not the lightweight ordinary-CI authority.

## Solution

### Keep a real deterministic gate on every PR and main merge

Run `make telemetry-check` unconditionally in Schema & Parity Checks. It compiles the canonical registry and rejects stale runtime and generated Go output in about 22 seconds locally.

### Run exhaustive suites only where they add evidence

Move both mutation suites to a dedicated workflow that runs:

- on telemetry-sensitive pull-request paths;
- nightly at 03:47 UTC;
- on manual dispatch.

The workflow remains read-only and preserves the two independent four-worker suites plus one aggregate result.

### Remove empty coverage work

Exclude both exhaustive files from the four regular Python shards, stop producing their empty coverage artifacts, and aggregate the four real Python coverage fragments.

### Prevent policy drift

Regression tests own the exact path-filter inventory, require the fast gate, forbid the exhaustive tests or reusable workflow from entering ordinary CI/Release, and reject broad `make test`/`pytest` collectors that could silently collect the long suites again.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `.github/workflows/ci.yml` | Removes unconditional exhaustive telemetry jobs and empty coverage artifacts; adds unconditional `make telemetry-check`; aggregates four regular coverage parts. |
| `.github/workflows/telemetry-registry.yml` | Adds path-filtered PR, nightly, and manual exhaustive telemetry validation with read-only permissions. |
| `cli/tests/test_telemetry_ci_strategy.py` | Enforces triggers, exact path ownership, fast gating, coverage shape, and no broad-collector/full-suite drift into CI or Release. |
| `cli/tests/test_ci_workflow_efficiency.py` | Updates the established CI efficiency contract for the selective workflow. |
| `docs/TESTING.md` | Documents which telemetry checks run ordinarily versus on sensitive PR/nightly/manual execution. |

## Breaking Changes

CI behavior only: unrelated PRs no longer show the two `Python Telemetry Test (...)` jobs. Telemetry-sensitive PRs instead show the dedicated `Telemetry Registry Exhaustive` workflow. Application, release, upgrade, and operator behavior are unchanged.

## Open Issues / Follow-ups

None.

## Test Plan

Observed locally:

```text
PYTHONPATH=. uv run --python 3.13 pytest -q \
  cli/tests/test_telemetry_ci_strategy.py \
  cli/tests/test_ci_workflow_efficiency.py \
  cli/tests/test_release_validation_strategy.py
# 14 passed in 0.58s

uv run ruff check \
  cli/tests/test_telemetry_ci_strategy.py \
  cli/tests/test_ci_workflow_efficiency.py
# passed

uv run ruff format --check cli/tests/test_telemetry_ci_strategy.py
# passed

actionlint -shellcheck= \
  .github/workflows/ci.yml \
  .github/workflows/telemetry-registry.yml
# passed

make telemetry-check
# passed locally in approximately 22 seconds

git diff --check
# passed
```
