### PR TITLE
fix(release): preserve candidate artifact digest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1136,7 +1136,9 @@ jobs:
               )
           PY
 
-      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+      # v4.5.0+ is required here because certification binds the GitHub
+      # artifact archive through the action's artifact-digest output.
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         id: upload
         with:
           name: ${{ steps.names.outputs.candidate }}
@@ -1144,6 +1146,16 @@ jobs:
           if-no-files-found: error
           retention-days: 7
           compression-level: 0
+
+      - name: Require candidate artifact digest output
+        env:
+          CANDIDATE_ARTIFACT_DIGEST: ${{ steps.upload.outputs.artifact-digest }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$CANDIDATE_ARTIFACT_DIGEST" =~ ^(sha256:)?[0-9a-f]{64}$ ]]; then
+            echo "::error title=Missing candidate artifact digest::The pinned upload action did not return a lowercase SHA-256 digest."
+            exit 1
+          fi
 
   full-certification:
     name: Run full signed pre-release certification

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -193,6 +193,24 @@ def test_build_once_candidate_is_reused_by_tests_and_publisher() -> None:
     assert "sigstore/cosign-installer@" in assemble_rendered
     assert "cosign sign-blob" in assemble_rendered
     assert text.count("cosign sign-blob") == 1
+    candidate_upload_index = next(
+        index
+        for index, step in enumerate(assemble_job["steps"])
+        if step.get("id") == "upload"
+    )
+    candidate_upload = assemble_job["steps"][candidate_upload_index]
+    assert candidate_upload["uses"] == (
+        "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+    )
+    assert assemble_job["outputs"]["artifact_digest"] == (
+        "${{ steps.upload.outputs.artifact-digest }}"
+    )
+    digest_guard = assemble_job["steps"][candidate_upload_index + 1]
+    assert digest_guard["name"] == "Require candidate artifact digest output"
+    assert digest_guard["env"]["CANDIDATE_ARTIFACT_DIGEST"] == (
+        "${{ steps.upload.outputs.artifact-digest }}"
+    )
+    assert "Missing candidate artifact digest" in digest_guard["run"]
 
     macos_job = str(jobs["macos-app"])
     assert "scripts/release_candidate.py extract-gateway" in macos_job


### PR DESCRIPTION
Standalone focused follow-up to #560. Merge this before starting a new `0.8.5` Release run; do not rerun failed run 29650844361.

## Problem

Release run 29650844361 built, signed, sealed, and fully certified the `0.8.5` candidate, but failed while recording the golden-candidate metadata. The workflow consumed `steps.upload.outputs.artifact-digest` from `actions/upload-artifact` v4.4.3, which does not define that output.

## Current Situation

All substantive release lanes passed: fresh installs, Docker/local observability continuity, rollback/recovery, and every selected Linux/macOS historical upgrade. The final metadata job received an empty candidate artifact digest, failed closed, skipped promotion, and left `0.8.5` unpublished.

The existing regression test only proved that the consumer expression existed; it did not prove that the pinned action supplied the referenced output.

## Solution

Use the official `actions/upload-artifact` v4.6.2 commit for the sealed candidate upload. That action declares and emits `artifact-digest`.

Immediately validate the output after upload. A missing or malformed digest now stops candidate assembly before the expensive full certification matrix starts.

Strengthen the static workflow test to bind the exact digest-capable action, output expression, guard placement, and error contract.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `.github/workflows/release.yaml` | Upgrade only the sealed-candidate upload step to pinned upload-artifact v4.6.2 and fail fast unless it emits a lowercase SHA-256 digest. |
| `cli/tests/test_release_workflow_staged.py` | Verify the action/output compatibility contract and immediate digest guard. |

## Breaking Changes

None. Release candidate bytes and upgrade behavior are unchanged.

## Open Issues / Follow-ups

None.

## Test Plan

Observed locally:

```text
uv run python -m pytest -q \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_release_validation_strategy.py \
  cli/tests/test_release_certification.py
# 74 passed

uv run ruff check \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_release_validation_strategy.py \
  cli/tests/test_release_certification.py
# All checks passed

actionlint -ignore 'SC2129' -ignore 'SC2034' .github/workflows/release.yaml
# passed; the ignored findings are unchanged warnings already present on main

git diff --check
# passed
```

Run 29650844361 also established that all signed candidate, install, continuity, rollback/recovery, and selected historical upgrade lanes pass. A fresh Release run is still required after this workflow fix merges because release promotion is bound to the exact merged SHA.
