### PR TITLE
fix(upgrade): repair staged 0.8.5 upgrades and release runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,9 +465,32 @@ jobs:
           uv --no-config venv "$tmp/venv" --python "${{ matrix.python-version }}"
           uv --no-config pip install --python "$tmp/venv/bin/python" "$whl"
           "$tmp/venv/bin/defenseclaw" --help >/dev/null
+          HOME="$tmp/home" DEFENSECLAW_HOME="$tmp/home/.defenseclaw" \
+            PYTHONNOUSERSITE=1 PYTHONPATH='' "$tmp/venv/bin/python" - <<'PY'
+          import asyncio
+          import sys
+          from pathlib import Path
+
+          import textual
+          import defenseclaw.tui.app as tui_app
+
+          module_path = Path(tui_app.__file__).resolve()
+          if not module_path.is_relative_to(Path(sys.prefix).resolve()):
+              raise SystemExit(f"TUI imported outside wheel environment: {module_path}")
+          DefenseClawTUI = tui_app.DefenseClawTUI
+
+          async def main() -> None:
+              app = DefenseClawTUI()
+              async with app.run_test(size=(120, 40)) as pilot:
+                  await pilot.pause()
+
+          asyncio.run(main())
+          print("installed_wheel_tui_origin=venv")
+          print("installed_wheel_tui_mount=ok textual=" + getattr(textual, "__version__", "unknown"))
+          PY
           (
             cd "$tmp"
-            PYTHONNOUSERSITE=1 PYTHONPATH= "$tmp/venv/bin/python" - "$tmp/telemetry-resource-digests.json" <<'PY'
+            PYTHONNOUSERSITE=1 PYTHONPATH='' "$tmp/venv/bin/python" - "$tmp/telemetry-resource-digests.json" <<'PY'
           import hashlib
           import json
           import sys

--- a/cli/defenseclaw/observability/v8_migration.py
+++ b/cli/defenseclaw/observability/v8_migration.py
@@ -162,6 +162,95 @@ _V7_OTEL_BATCH_DEFAULTS: Final = {
     "max_export_batch_size": 512,
     "scheduled_delay_ms": 5000,
 }
+_V7_FRESH_080_FLAT_OTEL_PLACEHOLDER: Final = {
+    "enabled": False,
+    "endpoint": "",
+    "protocol": "grpc",
+    "headers": {},
+    "tls": {"ca_cert": "", "insecure": False},
+    "batch": _V7_OTEL_BATCH_DEFAULTS,
+    "traces": {
+        "enabled": True,
+        "sampler": "always_on",
+        "sampler_arg": "1.0",
+        "endpoint": "",
+        "protocol": "",
+        "url_path": "",
+    },
+    "logs": {
+        "enabled": True,
+        "emit_individual_findings": False,
+        "endpoint": "",
+        "protocol": "",
+        "url_path": "",
+    },
+    "metrics": {
+        "enabled": True,
+        "endpoint": "",
+        "protocol": "",
+        "url_path": "",
+        "export_interval_s": 60,
+    },
+    "resource": {"attributes": {}},
+}
+_V7_FRESH_080_NAMED_OTEL_PLACEHOLDER: Final = {
+    "name": "generic-otlp",
+    "preset": "generic-otlp",
+    "enabled": False,
+    "endpoint": "",
+    "protocol": "grpc",
+    "tls": {"ca_cert": "", "insecure": False},
+    "batch": _V7_OTEL_BATCH_DEFAULTS,
+    "traces": {"enabled": True, "endpoint": "", "protocol": "", "url_path": ""},
+    "logs": {"enabled": True, "endpoint": "", "protocol": "", "url_path": ""},
+    "metrics": {
+        "enabled": True,
+        "endpoint": "",
+        "protocol": "",
+        "url_path": "",
+        "export_interval_s": 60,
+    },
+}
+
+
+def _type_sensitive_equal(actual: Any, expected: Any) -> bool:
+    """Compare frozen source shapes without Python's scalar coercions.
+
+    Historical placeholder recognition is a fail-closed release boundary.
+    Ordinary equality is unsafe here because ``False == 0`` and
+    ``60 == 60.0``; an operator-edited value must never be mistaken for an
+    immutable installer default and silently omitted.
+    """
+
+    if isinstance(actual, Mapping) or isinstance(expected, Mapping):
+        if not isinstance(actual, Mapping) or not isinstance(expected, Mapping):
+            return False
+        if len(actual) != len(expected):
+            return False
+        for expected_key, expected_value in expected.items():
+            matching_keys = [
+                actual_key
+                for actual_key in actual
+                if type(actual_key) is type(expected_key) and actual_key == expected_key
+            ]
+            if len(matching_keys) != 1:
+                return False
+            if not _type_sensitive_equal(actual[matching_keys[0]], expected_value):
+                return False
+        return True
+
+    sequence_types = (list, tuple)
+    if isinstance(actual, sequence_types) or isinstance(expected, sequence_types):
+        if not isinstance(actual, sequence_types) or not isinstance(expected, sequence_types):
+            return False
+        return len(actual) == len(expected) and all(
+            _type_sensitive_equal(actual_item, expected_item)
+            for actual_item, expected_item in zip(actual, expected, strict=True)
+        )
+
+    return type(actual) is type(expected) and actual == expected
+
+
 # Exact historical Galileo v7 preset filter accepted by the upgrade boundary.
 # Keep this source-shape constant local: an upgrade runs inside the already
 # imported baseline CLI after replacing its wheel, so importing the target
@@ -1134,6 +1223,13 @@ def _build_observability(
     result["trace_policy"] = _trace_policy(otel, ctx)
     master_enabled = _effective_otel_enabled(otel, ctx)
     flat_otel_destination = _flat_otel_destination(otel, ctx)
+    if _is_fresh_080_unconfigured_flat_otel(otel, flat_otel_destination):
+        # Fresh 0.8.0 init wrote this exact disabled, endpointless flat block
+        # even when the operator never configured OTLP. The effective shape is
+        # checked too, so an environment-supplied endpoint or other override
+        # remains on the normal migration path instead of being discarded.
+        ctx.warning("legacy_unconfigured_generic_otlp_placeholder_omitted")
+        flat_otel_destination = None
     metric_policy = _metric_policy(otel, master_enabled, flat_otel_destination, ctx)
     if metric_policy:
         result["metric_policy"] = metric_policy
@@ -1449,6 +1545,12 @@ def _convert_otel(
     effective_global_batch = _effective_otel_batch(global_batch, {}, "$.otel.batch", ctx)
     for raw, source_path in raw_destinations:
         source = dict(_mapping(raw, source_path, ctx))
+        if _type_sensitive_equal(source, _V7_FRESH_080_NAMED_OTEL_PLACEHOLDER):
+            # The immutable 0.8.0 release installer wrote this second exact
+            # endpointless default shape. As with the flat quickstart shape,
+            # any additional or changed field stays fail closed.
+            ctx.warning("legacy_unconfigured_generic_otlp_placeholder_omitted")
+            continue
         destination_batch = (
             _mapping(source.get("batch"), f"{source_path}.batch", ctx) if "batch" in source else {}
         )
@@ -1469,6 +1571,13 @@ def _convert_otel(
         active_signals.update(active)
         if local_full is not None:
             local_coverage.append(local_full)
+    if master_enabled and not result:
+        raise _error(
+            ctx,
+            "invalid_v7_otel",
+            "$.otel.destinations",
+            "configure at least one destination with a real endpoint before upgrading",
+        )
     local_state = "not-configured"
     if local_coverage:
         local_state = "full" if all(local_coverage) else "partial"
@@ -1627,6 +1736,41 @@ def _flat_otel_destination(otel: Mapping[str, Any], ctx: _Context) -> dict[str, 
         for signal in _SIGNALS:
             source[signal]["enabled"] = True
     return source
+
+
+def _is_fresh_080_unconfigured_flat_otel(
+    otel: Mapping[str, Any],
+    effective: Mapping[str, Any] | None,
+) -> bool:
+    if not _type_sensitive_equal(otel, _V7_FRESH_080_FLAT_OTEL_PLACEHOLDER):
+        return False
+    return _type_sensitive_equal(effective, {
+        "__flat_otel_destination": True,
+        "name": "generic-otlp",
+        "preset": "generic-otlp",
+        "enabled": False,
+        "endpoint": "",
+        "protocol": "grpc",
+        "headers": {},
+        "tls": {"ca_cert": "", "insecure": False},
+        "batch": _V7_OTEL_BATCH_DEFAULTS,
+        "traces": {
+            "enabled": True,
+            "sampler": "always_on",
+            "sampler_arg": "1.0",
+            "url_path": "",
+        },
+        "logs": {
+            "enabled": True,
+            "emit_individual_findings": False,
+            "url_path": "",
+        },
+        "metrics": {
+            "enabled": True,
+            "export_interval_s": 60,
+            "url_path": "",
+        },
+    })
 
 
 def _convert_otel_destination(

--- a/cli/defenseclaw/observability/v8_migration.py
+++ b/cli/defenseclaw/observability/v8_migration.py
@@ -193,7 +193,7 @@ _V7_FRESH_080_FLAT_OTEL_PLACEHOLDER: Final = {
     },
     "resource": {"attributes": {}},
 }
-_V7_FRESH_080_NAMED_OTEL_PLACEHOLDER: Final = {
+_V7_FRESH_080_NAMED_OTEL_DESTINATION_PLACEHOLDER: Final = {
     "name": "generic-otlp",
     "preset": "generic-otlp",
     "enabled": False,
@@ -210,6 +210,13 @@ _V7_FRESH_080_NAMED_OTEL_PLACEHOLDER: Final = {
         "url_path": "",
         "export_interval_s": 60,
     },
+}
+_V7_FRESH_080_NAMED_OTEL_PLACEHOLDER: Final = {
+    "enabled": False,
+    "traces": {"sampler": "always_on", "sampler_arg": "1.0"},
+    "logs": {"emit_individual_findings": False},
+    "destinations": [_V7_FRESH_080_NAMED_OTEL_DESTINATION_PLACEHOLDER],
+    "resource": {"attributes": {}},
 }
 
 
@@ -1523,10 +1530,18 @@ def _convert_otel(
     flat_destination: Mapping[str, Any] | None,
     ctx: _Context,
 ) -> tuple[list[dict[str, Any]], tuple[str, ...], str]:
-    raw_destinations = [
-        (raw, f"$.otel.destinations[{index}]")
-        for index, raw in enumerate(otel.get("destinations", []) or [])
-    ]
+    if _type_sensitive_equal(otel, _V7_FRESH_080_NAMED_OTEL_PLACEHOLDER):
+        # The immutable 0.8.0 macOS installer wrote this complete second
+        # endpointless default shape. Match the whole OTel block: inherited
+        # batch, signal, and resource changes are operator state and must stay
+        # on the normal fail-closed conversion path.
+        ctx.warning("legacy_unconfigured_generic_otlp_placeholder_omitted")
+        raw_destinations: list[tuple[Any, str]] = []
+    else:
+        raw_destinations = [
+            (raw, f"$.otel.destinations[{index}]")
+            for index, raw in enumerate(otel.get("destinations", []) or [])
+        ]
     if flat_destination is not None:
         raw_destinations.insert(0, (flat_destination, "$.otel"))
     if master_enabled and not raw_destinations:
@@ -1545,12 +1560,6 @@ def _convert_otel(
     effective_global_batch = _effective_otel_batch(global_batch, {}, "$.otel.batch", ctx)
     for raw, source_path in raw_destinations:
         source = dict(_mapping(raw, source_path, ctx))
-        if _type_sensitive_equal(source, _V7_FRESH_080_NAMED_OTEL_PLACEHOLDER):
-            # The immutable 0.8.0 release installer wrote this second exact
-            # endpointless default shape. As with the flat quickstart shape,
-            # any additional or changed field stays fail closed.
-            ctx.warning("legacy_unconfigured_generic_otlp_placeholder_omitted")
-            continue
         destination_batch = (
             _mapping(source.get("batch"), f"{source_path}.batch", ctx) if "batch" in source else {}
         )

--- a/cli/defenseclaw/resolver_hint.py
+++ b/cli/defenseclaw/resolver_hint.py
@@ -42,6 +42,7 @@ def authenticated_resolver_instructions(
         "POSIX:\n"
         "(\n"
         "  set -eu\n"
+        "  unset VERSION\n"
         "  umask 077\n"
         '  d="$(mktemp -d "${TMPDIR:-/tmp}/defenseclaw-upgrade.XXXXXX")"\n'
         "  trap 'rm -rf \"$d\"' EXIT\n"

--- a/cli/defenseclaw/tui/app.py
+++ b/cli/defenseclaw/tui/app.py
@@ -1722,12 +1722,14 @@ class DefenseClawTUI(App[None]):
             text = f"{key} {label}"
             if unread:
                 text = f"{text} ({unread})"
-            # Textual >=8.0 ``Tabs.get_tab(id) -> Tab | None`` replaces
-            # the older ``query_one("#tab-id", Tab)`` + NoMatches dance.
-            # It returns the tab widget directly (or None for unknown
-            # ids), so we skip exception-as-control-flow.
-            tab = tabs.get_tab(f"tab-{name}")
-            if tab is None:
+            # ``query_one`` is public in both Textual 7.x (installed by the
+            # published scanner dependency) and 8.x (used by the source
+            # development lock). Do not use the 8.x-only ``Tabs.get_tab``
+            # convenience method here: release wheels must run with their
+            # declared transitive dependency set, not only the dev override.
+            try:
+                tab = tabs.query_one(f"#tab-{name}", Tab)
+            except NoMatches:
                 continue
             if self._tab_label_cache.get(name) == text:
                 continue

--- a/cli/tests/test_install_docs_static.py
+++ b/cli/tests/test_install_docs_static.py
@@ -1847,6 +1847,7 @@ def test_installed_user_upgrade_docs_require_authenticated_resolver_assets() -> 
 
     assert "defenseclaw-upgrade.sh" in cli
     assert "verify-blob" in cli
+    assert "unset VERSION" in cli
     latest_assets = "releases/latest/download/"
     assert cli.count(latest_assets) == 1
     assert re.search(r"releases/download/\d+\.\d+\.\d+/", cli) is None
@@ -1854,6 +1855,7 @@ def test_installed_user_upgrade_docs_require_authenticated_resolver_assets() -> 
     assert "That URL is only a locator" in " ".join(cli.split())
     generated = authenticated_resolver_instructions(CURRENT_RELEASE)
     assert "Preflight refusal only" in generated
+    assert "unset VERSION" in generated
     assert "does not require a source checkout" in quickstart
     assert "does not require a source checkout" in site
     expected_reference = "https://github.com/cisco-ai-defense/defenseclaw/blob/main/docs/CLI.md#upgrade"

--- a/cli/tests/test_macos_runtime_installer_upgrade_guard.py
+++ b/cli/tests/test_macos_runtime_installer_upgrade_guard.py
@@ -106,6 +106,7 @@ def test_bundled_runtime_refusal_names_exact_supported_upgrade_path() -> None:
         "sha256sum",
         "shasum -a 256",
         "DefenseClaw upgrade resolver complete v1",
+        "unset VERSION",
         "bash <(printf '%s\\\\n' \"$resolver\") --yes",
     ):
         assert required in refusal
@@ -411,6 +412,9 @@ def test_mac_app_resolver_command_is_raw_canonical_semver_gated_and_bash_syntax_
     assert "printf '%s\\n' \"$resolver\" | sha" in command
     assert "bash -n <(printf '%s\\n' \"$resolver\")" in command
     assert "bash <(printf '%s\\n' \"$resolver\") --yes" in command
+    assert command.index("unset VERSION") < command.index(
+        "bash <(printf '%s\\n' \"$resolver\") --yes"
+    )
     result = subprocess.run(
         ["/bin/bash", "-n"],
         input=command,

--- a/cli/tests/test_observability_v8_migration.py
+++ b/cli/tests/test_observability_v8_migration.py
@@ -2315,6 +2315,38 @@ def test_named_release_placeholder_with_operator_field_is_not_silently_omitted()
 
 
 @pytest.mark.parametrize(
+    ("original", "replacement"),
+    (
+        (
+            "  logs:\n    emit_individual_findings: false",
+            "  logs:\n    emit_individual_findings: true",
+        ),
+        (
+            "  logs:\n    emit_individual_findings: false",
+            "  batch: {scheduled_delay_ms: 1000}\n"
+            "  logs:\n"
+            "    emit_individual_findings: false",
+        ),
+        (
+            "  traces:\n    sampler: always_on",
+            "  traces:\n    sampler: parentbased_traceidratio",
+        ),
+    ),
+    ids=("inherited-logs", "inherited-batch", "inherited-traces"),
+)
+def test_named_release_placeholder_with_inherited_operator_change_fails_closed(
+    original: str,
+    replacement: str,
+) -> None:
+    source = _FRESH_080_NAMED_OTEL_CONFIG.replace(original, replacement, 1)
+    assert source != _FRESH_080_NAMED_OTEL_CONFIG
+    with pytest.raises(V8MigrationError) as captured:
+        _convert(source)
+    assert captured.value.code == "candidate_validation_failed"
+    assert captured.value.path == "$.observability"
+
+
+@pytest.mark.parametrize(
     ("source", "original", "replacement"),
     (
         (_FRESH_080_DEFAULT_OTEL_CONFIG, "  enabled: false", "  enabled: 0"),

--- a/cli/tests/test_observability_v8_migration.py
+++ b/cli/tests/test_observability_v8_migration.py
@@ -38,6 +38,64 @@ _GENERATED_COMPATIBILITY = json.loads(v7_exporter_selection_bytes())
 _TYPED_COMPATIBILITY = V7CompatibilitySelection.from_mapping(_GENERATED_COMPATIBILITY)
 _ALL_BUCKETS = list(BUCKETS)
 _TEST_DATA_DIR = str(Path(Path.cwd().anchor) / "var" / "lib" / "defenseclaw")
+_FRESH_080_DEFAULT_OTEL_CONFIG = """config_version: 7
+otel:
+  enabled: false
+  endpoint: ""
+  protocol: grpc
+  headers: {}
+  tls: {ca_cert: "", insecure: false}
+  batch:
+    max_queue_size: 2048
+    max_export_batch_size: 512
+    scheduled_delay_ms: 5000
+  traces:
+    enabled: true
+    sampler: always_on
+    sampler_arg: "1.0"
+    endpoint: ""
+    protocol: ""
+    url_path: ""
+  logs:
+    enabled: true
+    emit_individual_findings: false
+    endpoint: ""
+    protocol: ""
+    url_path: ""
+  metrics:
+    enabled: true
+    export_interval_s: 60
+    endpoint: ""
+    protocol: ""
+    url_path: ""
+  resource:
+    attributes: {}
+"""
+_FRESH_080_NAMED_OTEL_CONFIG = """config_version: 7
+otel:
+  enabled: false
+  traces:
+    sampler: always_on
+    sampler_arg: "1.0"
+  logs:
+    emit_individual_findings: false
+  destinations:
+    - name: generic-otlp
+      preset: generic-otlp
+      enabled: false
+      endpoint: ""
+      protocol: grpc
+      tls: {ca_cert: "", insecure: false}
+      batch:
+        max_queue_size: 2048
+        max_export_batch_size: 512
+        scheduled_delay_ms: 5000
+      traces: {enabled: true, endpoint: "", protocol: "", url_path: ""}
+      logs: {enabled: true, endpoint: "", protocol: "", url_path: ""}
+      metrics: {enabled: true, endpoint: "", protocol: "", url_path: "", export_interval_s: 60}
+  resource:
+    attributes: {}
+"""
 _ALL_SPAN_EVENT_NAMES = [
     "span.admin.operation",
     "span.agent.invoke",
@@ -2181,6 +2239,129 @@ otel:
             "action": "drop",
         }
     ]
+
+
+@pytest.mark.parametrize(
+    "source",
+    (_FRESH_080_DEFAULT_OTEL_CONFIG, _FRESH_080_NAMED_OTEL_CONFIG),
+    ids=("flat-quickstart", "named-release-installer"),
+)
+def test_fresh_080_disabled_otel_placeholder_migrates_without_inventing_endpoint(source: str) -> None:
+    result = _convert(source)
+    assert all(
+        destination.get("name") != "generic-otlp"
+        for destination in _document(result)["observability"].get("destinations", [])
+    )
+    assert "legacy_unconfigured_generic_otlp_placeholder_omitted" in result.warnings
+    load_validate_v8(result.candidate)
+
+
+def test_custom_disabled_endpointless_otel_destination_still_fails_closed() -> None:
+    with pytest.raises(V8MigrationError) as captured:
+        _convert(
+            """config_version: 7
+otel:
+  enabled: false
+  destinations:
+    - name: operator-destination
+      preset: generic-otlp
+      enabled: false
+      protocol: grpc
+      traces: {enabled: true}
+      logs: {enabled: true}
+      metrics: {enabled: true}
+"""
+        )
+
+    assert captured.value.code == "candidate_validation_failed"
+
+
+@pytest.mark.parametrize(
+    ("original", "replacement"),
+    (
+        ("  headers: {}", "  headers: {X-Operator: custom}"),
+        ("    sampler: always_on", "    sampler: parentbased_traceidratio"),
+        ("    export_interval_s: 60", "    export_interval_s: 30"),
+    ),
+)
+def test_fresh_placeholder_with_operator_changes_is_not_silently_omitted(
+    original: str,
+    replacement: str,
+) -> None:
+    source = _FRESH_080_DEFAULT_OTEL_CONFIG.replace(original, replacement)
+    with pytest.raises(V8MigrationError):
+        _convert(source)
+
+
+def test_fresh_placeholder_with_environment_endpoint_preserves_effective_transport() -> None:
+    result = _convert(
+        _FRESH_080_DEFAULT_OTEL_CONFIG,
+        {"OTEL_EXPORTER_OTLP_ENDPOINT": "collector.example.test:4317"},
+    )
+    destination = _destination(_document(result), "generic-otlp")
+
+    assert destination["endpoint"] == "collector.example.test:4317"
+    assert "legacy_unconfigured_generic_otlp_placeholder_omitted" not in result.warnings
+    load_validate_v8(result.candidate)
+
+
+def test_named_release_placeholder_with_operator_field_is_not_silently_omitted() -> None:
+    source = _FRESH_080_NAMED_OTEL_CONFIG.replace(
+        "      tls: {ca_cert: \"\", insecure: false}",
+        "      headers: {}\n      tls: {ca_cert: \"\", insecure: false}",
+    )
+    with pytest.raises(V8MigrationError):
+        _convert(source)
+
+
+@pytest.mark.parametrize(
+    ("source", "original", "replacement"),
+    (
+        (_FRESH_080_DEFAULT_OTEL_CONFIG, "  enabled: false", "  enabled: 0"),
+        (
+            _FRESH_080_DEFAULT_OTEL_CONFIG,
+            '    sampler_arg: "1.0"',
+            "    sampler_arg: 1.0",
+        ),
+        (
+            _FRESH_080_DEFAULT_OTEL_CONFIG,
+            "    export_interval_s: 60",
+            "    export_interval_s: 60.0",
+        ),
+        (_FRESH_080_NAMED_OTEL_CONFIG, "      enabled: false", "      enabled: 0"),
+        (
+            _FRESH_080_NAMED_OTEL_CONFIG,
+            "export_interval_s: 60}",
+            "export_interval_s: 60.0}",
+        ),
+    ),
+    ids=(
+        "flat-bool-to-int",
+        "flat-string-to-float",
+        "flat-int-to-float",
+        "named-bool-to-int",
+        "named-int-to-float",
+    ),
+)
+def test_historical_placeholder_scalar_types_must_match_exactly(
+    source: str,
+    original: str,
+    replacement: str,
+) -> None:
+    altered = source.replace(original, replacement, 1)
+    assert altered != source
+    with pytest.raises(V8MigrationError):
+        _convert(altered)
+
+
+def test_named_release_placeholder_with_master_enabled_still_fails_closed() -> None:
+    with pytest.raises(V8MigrationError) as captured:
+        _convert(
+            _FRESH_080_NAMED_OTEL_CONFIG,
+            {"DEFENSECLAW_OTEL_ENABLED": "true"},
+        )
+
+    assert captured.value.code == "invalid_v7_otel"
 
 
 def test_disabled_destination_without_any_transport_fails_instead_of_disappearing() -> None:

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -76,6 +76,8 @@ def test_installed_release_artifacts_mount_the_full_tui() -> None:
         assert marker in source
     assert "fresh_080_default_migration=ok" in smoke
     assert "legacy_unconfigured_generic_otlp_placeholder_omitted" in smoke
+    assert "load_packaged_v7_compatibility_selection" in smoke
+    assert "compatibility_selection=compatibility_selection" in smoke
     assert "post_status_mandatory_sqlite_write=ok" in smoke
 
 

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -60,6 +60,25 @@ def test_sensitive_plan_installs_cosign_before_historical_authentication() -> No
     assert "nightly/manual certification" in workflow_text
 
 
+def test_installed_release_artifacts_mount_the_full_tui() -> None:
+    ci = CI_WORKFLOW.read_text(encoding="utf-8")
+    smoke = (ROOT / "scripts/test-upgrade-release.sh").read_text(encoding="utf-8")
+
+    for source, marker in (
+        (ci, "installed_wheel_tui_mount=ok"),
+        (ci, "installed_wheel_tui_origin=venv"),
+        (smoke, "installed_target_tui_mount=ok"),
+        (smoke, "installed_target_tui_origin=venv"),
+    ):
+        assert "import defenseclaw.tui.app as tui_app" in source
+        assert "TUI imported outside wheel environment" in source
+        assert "app.run_test(size=(120, 40))" in source
+        assert marker in source
+    assert "fresh_080_default_migration=ok" in smoke
+    assert "legacy_unconfigured_generic_otlp_placeholder_omitted" in smoke
+    assert "post_status_mandatory_sqlite_write=ok" in smoke
+
+
 def test_release_supports_nightly_certification_and_manual_promotion() -> None:
     workflow = _workflow()
     triggers = workflow["on"]
@@ -513,7 +532,6 @@ def test_protocol_gate_proves_both_refusal_paths_and_full_success() -> None:
         'patch_installed_upgrade_endpoint "${TARGET_VERSION}"',
         'defenseclaw "${command_args[@]}"',
         "run_candidate_updater_refusal",
-        "run_candidate_explicit_bridge_refusal",
         "run_candidate_updater_staged_success",
         "run_candidate_updater_direct_success",
         "manifest_windows_sources_are_empty",
@@ -529,7 +547,8 @@ def test_protocol_gate_proves_both_refusal_paths_and_full_success() -> None:
         "manifest_array_contains tested_source_versions",
         "canonical gateway refusal envelope",
         "artifact-envelope",
-        "there is intentionally no --version argument",
+        'resolver_args+=(--version "${TARGET_VERSION}")',
+        'run_candidate_updater_staged_success "${baseline}" explicit',
         "stage_authenticated_baseline",
         "SUCCESS_PATH_ONLY",
         "REFUSAL_CONTRACT_ONLY",
@@ -547,7 +566,7 @@ def test_protocol_gate_proves_both_refusal_paths_and_full_success() -> None:
     ):
         assert contract in text
     sealed_resolver = 'bash "${RELEASE_ROOT}/${TARGET_VERSION}/defenseclaw-upgrade.sh"'
-    assert text.count(sealed_resolver) >= 4
+    assert text.count(sealed_resolver) >= 3
     assert 'scripts/upgrade.sh" --yes' not in text
     assert not re.search(r"TARGET_VERSION[^\n]*0\.8\.", text)
     smoke = (ROOT / "scripts/test-upgrade-release.sh").read_text(encoding="utf-8")
@@ -564,7 +583,6 @@ def test_external_resolver_boundaries_disable_python_bytecode() -> None:
     text = PROTOCOL_GATE.read_text(encoding="utf-8")
     for function_name in (
         "run_candidate_updater_refusal",
-        "run_candidate_explicit_bridge_refusal",
         "run_candidate_updater_staged_success",
         "run_candidate_updater_direct_success",
     ):

--- a/cli/tests/test_resolver_hint.py
+++ b/cli/tests/test_resolver_hint.py
@@ -31,6 +31,7 @@ def test_authenticated_resolver_hint_is_copy_pasteable_and_fail_closed() -> None
     assert "sha256sum" in output and "shasum -a 256" in output
     assert "--proto-redir '=https'" in output
     assert "DefenseClaw upgrade resolver complete v1" in output
+    assert "unset VERSION" in output
     assert "raw.githubusercontent.com" not in output
     assert "upgrade.sh | bash" not in output
     assert "--version" not in output
@@ -53,6 +54,7 @@ def test_authenticated_resolver_hint_is_copy_pasteable_and_fail_closed() -> None
     assert "$matches" not in windows
 
     posix = output.split("POSIX:\n", 1)[1].split("\nWindows PowerShell:", 1)[0]
+    assert posix.index("unset VERSION") < posix.index("bash \"$d/defenseclaw-upgrade.sh\" --yes")
     completed = subprocess.run(
         ["bash", "-n"],
         input=posix,

--- a/cli/tests/test_upgrade_staged_resolver.py
+++ b/cli/tests/test_upgrade_staged_resolver.py
@@ -373,25 +373,24 @@ def _rewrite_manifest(env: dict[str, str], version: str, payload: dict[str, obje
     )
 
 
-def test_explicit_hard_cut_from_0_8_3_refuses_before_mutation(resolver_env) -> None:
-    env, mutation_log, _curl_log = resolver_env("0.8.3")
+@pytest.mark.parametrize("current_version", ("0.8.3", "0.8.0"))
+def test_explicit_final_target_still_resolves_verified_two_hop_plan(
+    resolver_env,
+    current_version: str,
+) -> None:
+    env, mutation_log, curl_log = resolver_env(current_version)
 
     result = _run(env, "--version", "0.8.5", "--plan")
 
     output = result.stdout + result.stderr
-    assert result.returncode != 0
-    assert "0.8.5 requires the 0.8.4 upgrade bridge" in output
+    assert result.returncode == 0, output
+    assert f"{current_version} → 0.8.4 bridge → fresh controller → 0.8.5" in output
     assert "No changes were made" in output
-    assert "there is intentionally no --version argument" in output
-    assert "defenseclaw-upgrade.XXXXXX" in output
-    assert "releases/download/0.8.5/" in output
-    assert "defenseclaw-upgrade.sh" in output
-    assert "cosign verify-blob" in output
-    assert "DefenseClaw upgrade resolver complete v1" in output
-    assert 'bash "$d/defenseclaw-upgrade.sh" --yes' in output
-    assert "upgrade.sh | bash" not in output
     assert not mutation_log.exists()
     assert not Path(env["DEFENSECLAW_HOME"]).exists()
+    downloads = curl_log.read_text(encoding="utf-8")
+    assert "/releases/download/0.8.5/upgrade-manifest.json" in downloads
+    assert "/releases/download/0.8.4/upgrade-manifest.json" in downloads
 
 
 def test_bridge_manifest_runtime_config_boundary_is_fail_closed(resolver_env) -> None:

--- a/cli/tests/tui/test_app_shell.py
+++ b/cli/tests/tui/test_app_shell.py
@@ -767,7 +767,7 @@ async def test_tool_policy_tab_is_removed() -> None:
         await pilot.pause()
 
         tabs = app.query_one("#tabs", Tabs)
-        assert tabs.get_tab("tab-tools") is None
+        assert not list(tabs.query("#tab-tools"))
         assert all("Tool Policy" not in str(tab.label) for tab in tabs.query(Tab))
 
         await pilot.press("T")
@@ -797,8 +797,7 @@ async def test_unchanged_status_and_tab_labels_skip_widget_updates(monkeypatch) 
         assert len(status_updates) == 1
 
         tabs = app.query_one("#tabs", Tabs)
-        audit_tab = tabs.get_tab("tab-audit")
-        assert audit_tab is not None
+        audit_tab = tabs.query_one("#tab-audit", Tab)
         app._update_tab_labels()  # noqa: SLF001
         first_label = audit_tab.label
         app._update_tab_labels()  # noqa: SLF001

--- a/docs-site/content/docs/get-started/upgrade.mdx
+++ b/docs-site/content/docs/get-started/upgrade.mdx
@@ -41,11 +41,12 @@ path. Do not copy POSIX artifacts onto Windows.
 
 Do not use the built-in form to cross a manifest-required bridge. A
 `0.8.3`-or-older POSIX host must use the authenticated current release-owned
-shell resolver in latest mode, as shown below. Its immutable built-in
-command and an explicit hard-cut target both refuse before stopping services or
-changing installed state. Some frozen controllers then print an obsolete raw
-network-to-shell hint; do not execute it. Use the authenticated bootstrap from
-this page instead.
+shell resolver, as shown below. Its immutable built-in command refuses before
+stopping services or changing installed state. Some frozen controllers then
+print an obsolete raw network-to-shell hint; do not execute it. Use the
+authenticated bootstrap from this page instead. Release `0.8.5` is immutable,
+so its resolver must be invoked in latest mode with no `VERSION` environment
+variable and no `--version` argument.
 
 <Callout title="Never re-run the fresh installer over an existing host">
 The install scripts are fresh-install-only and refuse an existing DefenseClaw
@@ -63,12 +64,13 @@ Release `0.8.4` deliberately keeps configuration and runtime schema v7. It does
 not contain or run the observability-v8 migration. Its purpose is to install a
 protocol-2 upgrade controller that can safely drive the later v8 hard cut.
 
-For an existing `0.8.3`-or-older installation, run the release-owned resolver
-without a target version. Latest mode is allowed to follow a manifest-declared
-bridge; an explicit request that skips a required bridge is refused before
-services or installed files change. A host already on `0.8.4` uses that same
-target-release resolver; the frozen built-in parser cannot accept the truthful
-empty Windows matrix.
+For an existing `0.8.3`-or-older installation, prefer the release-owned resolver
+without a target version. A current resolver also treats `--version` as the
+final target selection, never as permission to skip a manifest-declared bridge;
+this keeps the immutable handoff printed by older controllers usable. Direct
+installer and manual-artifact paths still refuse a hard cut that bypasses the
+bridge. A host already on `0.8.4` uses that same target-release resolver; the
+frozen built-in parser cannot accept the truthful empty Windows matrix.
 
 Installed users must download and authenticate the release-owned resolver
 asset before running it. Use the complete POSIX `cosign` and SHA-256 bootstrap in the

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -499,8 +499,7 @@ is required.
 6. Report success only after version-bound health checks pass; otherwise restore and verify the exact source state.
 
 Crossing the observability-v8 hard cut requires the `0.8.4` bridge. The
-release-owned POSIX shell resolver performs the supported one-command path when
-invoked without an explicit target:
+release-owned POSIX shell resolver performs the supported one-command path:
 
 ```text
 reviewed 0.8.3-or-older source
@@ -513,9 +512,11 @@ An already-published `0.8.3`-or-older built-in CLI cannot be taught this
 two-process orchestration retroactively. Its protocol check therefore refuses
 a hard-cut latest release before stopping services. Some frozen releases print
 an obsolete raw-network shell hint after that safe refusal; it must not be
-executed. Use the authenticated resolver-asset bootstrap below instead.
-Likewise, an explicit request for `0.8.5` from a pre-bridge source
-refuses before mutation; explicit targets never hide an intermediate release.
+executed. Use the authenticated resolver-asset bootstrap below instead. A
+current resolver treats `--version` as the selected final release and still
+inserts every manifest-required bridge; the option never authorizes a direct
+hard-cut install. The immutable `0.8.5` resolver predates that repair and must
+be invoked without `--version` and with no exported `VERSION` value.
 
 POSIX rollback retains any plan-owned inode that might still receive a late
 open-descriptor write. The payload is placed in a plan-scoped, mode-0700
@@ -552,7 +553,8 @@ the v7 file.
 
 **Flags:**
 - `--yes`, `-y` — skip confirmation prompts
-- `--version VERSION` — upgrade to a specific release (default: latest)
+- `--version VERSION` — select a specific final release; required bridges are
+  still staged (default: latest)
 - `--allow-unverified` — legacy-only unsafe override. It cannot bypass the
   signed manifest, checksum, bridge, or migration requirements for `0.8.4+`.
 
@@ -576,7 +578,7 @@ matrix is empty. Use the current target-release POSIX resolver on every
 | `0.8.0` or `0.8.1` | Use the current release-owned POSIX resolver without `--version`; no system-wide Cosign installation is required. Do not use `--allow-unverified`; strict bridge provenance cannot be bypassed. |
 | Any Windows source | The `0.8.4` release contains no Windows gateway/rollback binary, so no Windows hard-cut path is published. The PowerShell resolver fails closed before stopping services. Keep the current installation unchanged. |
 | A source outside the published matrix, including assetless `0.7.0`, `0.2.x`, or historical `0.3.x` releases | No tested in-place path is inferred. Remain on the current version and contact support for a source-specific, state-aware recovery plan. Do not uninstall, overwrite state, or force an intermediate hop. |
-| Direct `0.8.3 → 0.8.5` request | Refused before service stop or installed mutation. Remove the explicit target and use the release-owned resolver. |
+| Direct installer from `0.8.3 → 0.8.5` | Refused before service stop or installed mutation. Manual artifact copying is unsupported because it bypasses bridge selection and rollback. Use the release-owned resolver; selecting a final version there does not bypass the bridge. |
 
 **Examples:**
 
@@ -589,6 +591,7 @@ completeness marker, and syntax check authenticate the bytes before execution.
 # POSIX: one-command staged resolver (do not add --version)
 (
   set -eu
+  unset VERSION
   umask 077
   d="$(mktemp -d "${TMPDIR:-/tmp}/defenseclaw-upgrade.XXXXXX")"
   trap 'rm -rf "$d"' EXIT

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -67,23 +67,11 @@ and exposes a local REST API for the Python CLI.
 
 Run without arguments to start the sidecar daemon.`,
 	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-		// Cobra normally executes this process once, but tests and embedders can
-		// execute the command tree repeatedly. Never retain a previous source.
-		activeObservabilityV8Startup = nil
-
-		// Load the default installation .env before strict v8 compilation so
-		// destination token_env/bearer_env references work for a daemon without
-		// an interactive shell. loadConfigV8File repeats this for the source's
-		// resolved data_dir before validating destination secrets.
-		loadDotEnvIntoOS(filepath.Join(config.DefaultDataPath(), ".env"))
+		if err := loadGatewayCommandConfigOnly(); err != nil {
+			return err
+		}
 
 		var err error
-		cfg, activeObservabilityV8Startup, err = loadGatewayConfigV8(config.ConfigPath())
-		if err != nil {
-			return fmt.Errorf("failed to load v8 config — run 'defenseclaw upgrade' first: %w", err)
-		}
-		version.SetBinaryVersion(appVersion)
-
 		auditStore, err = audit.NewStore(cfg.AuditDB)
 		if err != nil {
 			return fmt.Errorf("failed to open audit store: %w", err)
@@ -101,11 +89,6 @@ Run without arguments to start the sidecar daemon.`,
 		// stack is unaffected.
 		installCorrelator(auditStore, os.Stderr)
 
-		// Re-run with the resolved data dir in case DEFENSECLAW_HOME
-		// redirected it; second call is a no-op when paths match.
-		if resolved := filepath.Join(cfg.DataDir, ".env"); resolved != filepath.Join(config.DefaultDataPath(), ".env") {
-			loadDotEnvIntoOS(resolved)
-		}
 		return nil
 	},
 	PersistentPostRun: func(_ *cobra.Command, _ []string) {
@@ -118,6 +101,37 @@ Run without arguments to start the sidecar daemon.`,
 	},
 	RunE:         runSidecar,
 	SilenceUsage: true,
+}
+
+// loadGatewayCommandConfigOnly performs the strict v8 configuration phase
+// shared by the daemon and read-only control commands. It deliberately does
+// not open audit.db: a short-lived `status` process must never become a second
+// SQLite owner beside the running daemon, because closing that connection can
+// unlink the daemon's live WAL/SHM files on supported SQLite implementations.
+func loadGatewayCommandConfigOnly() error {
+	// Cobra normally executes this process once, but tests and embedders can
+	// execute the command tree repeatedly. Never retain a previous source.
+	activeObservabilityV8Startup = nil
+
+	// Load the default installation .env before strict v8 compilation so
+	// destination token_env/bearer_env references work for a daemon without
+	// an interactive shell. loadConfigV8File repeats this for the source's
+	// resolved data_dir before validating destination secrets.
+	loadDotEnvIntoOS(filepath.Join(config.DefaultDataPath(), ".env"))
+
+	var err error
+	cfg, activeObservabilityV8Startup, err = loadGatewayConfigV8(config.ConfigPath())
+	if err != nil {
+		return fmt.Errorf("failed to load v8 config — run 'defenseclaw upgrade' first: %w", err)
+	}
+	version.SetBinaryVersion(appVersion)
+
+	// Re-run with the resolved data dir in case DEFENSECLAW_HOME redirected
+	// it; the second call is a no-op when paths match.
+	if resolved := filepath.Join(cfg.DataDir, ".env"); resolved != filepath.Join(config.DefaultDataPath(), ".env") {
+		loadDotEnvIntoOS(resolved)
+	}
+	return nil
 }
 
 // loadGatewayConfigV8 strict-parses and compiles the exact source snapshot

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -39,7 +39,14 @@ var statusCmd = &cobra.Command{
 gateway connection, skill watcher, and API server.
 
 The sidecar must be running for this command to work.`,
-	RunE: runSidecarStatus,
+	// Status only needs the strict runtime config to locate the health API.
+	// Do not inherit root's audit-store lifecycle: a second short-lived Store
+	// can unlink the running daemon's WAL/SHM and strand later audit writes.
+	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+		return loadGatewayCommandConfigOnly()
+	},
+	PersistentPostRun: func(_ *cobra.Command, _ []string) {},
+	RunE:              runSidecarStatus,
 }
 
 func init() {

--- a/internal/cli/status_lifecycle_test.go
+++ b/internal/cli/status_lifecycle_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/defenseclaw/defenseclaw/internal/gateway"
+)
+
+func TestStatusLoadsStrictConfigWithoutOpeningAuditStore(t *testing.T) {
+	dataDir := t.TempDir()
+	if err := os.Chmod(dataDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEFENSECLAW_HOME", dataDir)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/health":
+			if err := json.NewEncoder(w).Encode(gateway.HealthSnapshot{}); err != nil {
+				t.Errorf("encode health: %v", err)
+			}
+		case "/status":
+			if err := json.NewEncoder(w).Encode(map[string]any{}); err != nil {
+				t.Errorf("encode status: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	port := server.Listener.Addr().(*net.TCPAddr).Port
+	configPath := filepath.Join(dataDir, "config.yaml")
+	raw := "config_version: 8\ndata_dir: " + dataDir + "\ngateway:\n  api_port: " + strconv.Itoa(port) + "\nobservability: {}\n"
+	if err := os.WriteFile(configPath, []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	previousConfig, previousStore, previousLog, previousStartup := cfg, auditStore, auditLog, activeObservabilityV8Startup
+	cfg, auditStore, auditLog, activeObservabilityV8Startup = nil, nil, nil, nil
+	t.Cleanup(func() {
+		cfg, auditStore, auditLog, activeObservabilityV8Startup =
+			previousConfig, previousStore, previousLog, previousStartup
+	})
+
+	rootCmd.SetArgs([]string{"status"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	if _, err := rootCmd.ExecuteC(); err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg == nil || cfg.Gateway.APIPort != port {
+		t.Fatalf("status config = %#v, want strict config-only load", cfg)
+	}
+	if auditStore != nil || auditLog != nil {
+		t.Fatal("status opened the daemon audit store")
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "audit.db")); !os.IsNotExist(err) {
+		t.Fatalf("status created audit.db: %v", err)
+	}
+}

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/RuntimeInstaller.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/RuntimeInstaller.swift
@@ -914,6 +914,7 @@ extension AppState {
         return """
         (
           set -eu
+          unset VERSION
           umask 077
           command -v cosign >/dev/null
           checksums="$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' --tlsv1.2 '\(assetBase)/checksums.txt')"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ dependencies = [
     "pyyaml==6.0.3",
     "requests==2.33.0",
     "rich>=13.0",
+    # Bare `defenseclaw` and `defenseclaw tui` launch the Python Textual UI.
+    # The scanner currently resolves 7.x while source development exercises
+    # 8.x; the runtime and installed-wheel gates cover both supported majors.
+    "textual>=7.5,<9",
     # Runtime validation of config_version: 8 uses the schema bundled in the
     # wheel. The 0.8.4 bridge already carries this transitively; the hard-cut
     # controller verifies that exact pre-existing runtime before mutation.
@@ -46,11 +50,6 @@ dependencies = [
     # so it must be installed there to parse TOML.
     "tomli>=2.0.1; python_version < '3.11'",
 ]
-
-# P3-#20: the legacy Textual TUI (`defenseclaw alerts --tui`) was
-# retired in favour of the Go-based TUI launched via `defenseclaw tui`.
-# No Python-side TUI extra is shipped anymore; the alerts command now
-# renders a plain Rich table.
 
 [project.optional-dependencies]
 # Vertex AI auth (service-account JSON, ADC, workload identity).
@@ -208,7 +207,7 @@ override-dependencies = [
     # auto-scroll on select, weak-ref DOM GC). No ``Select.BLANK``
     # usage in our TUI (the only documented 8.0 breaking rename),
     # verified via grep.
-    "textual>=8.2.7",
+    "textual>=8.2.7,<9",
     # ``pytest-textual-snapshot==1.1.0`` transitively pins
     # ``syrupy==4.8.0``, which in turn pins ``pytest>=7,<9``. We are on
     # pytest 9.x project-wide, so override to a syrupy version that

--- a/scripts/test-upgrade-protocol-release.sh
+++ b/scripts/test-upgrade-protocol-release.sh
@@ -625,58 +625,16 @@ run_candidate_updater_refusal() {
     ok "Candidate-owned updater refused source ${baseline} pre-mutation"
 }
 
-run_candidate_explicit_bridge_refusal() {
-    local baseline="$1"
-    log "Proving the release-owned resolver repairs the immutable explicit-target hint"
-    prepare_refusal_home "${baseline}" "candidate-explicit-bridge"
-
-    local curl_shim="${SMOKE_HOME}/.upgrade-test-bin"
-    local real_curl
-    real_curl="$(install_curl_rewrite_probe "${curl_shim}")"
-    local before="${WORKDIR}/${baseline}-candidate-explicit.before.json"
-    local after="${WORKDIR}/${baseline}-candidate-explicit.after.json"
-    local log_file="${WORKDIR}/${baseline}-candidate-explicit-refusal.log"
-    snapshot_state "${before}"
-
-    set +e
-    HOME="${SMOKE_HOME}" \
-    DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \
-    OPENCLAW_HOME="${SMOKE_HOME}/.openclaw" \
-    PYTHONDONTWRITEBYTECODE=1 \
-    UPGRADE_GATE_STOP_MARKER="${REFUSAL_STOP_MARKER}" \
-    UPGRADE_GATE_REAL_GATEWAY="${REFUSAL_REAL_GATEWAY}" \
-    UPGRADE_GATE_REAL_CURL="${real_curl}" \
-    UPGRADE_GATE_RELEASE_URL="${RELEASE_URL}" \
-    PATH="${curl_shim}:${SMOKE_HOME}/.local/bin:${PATH}" \
-        bash "${RELEASE_ROOT}/${TARGET_VERSION}/defenseclaw-upgrade.sh" \
-        --yes --version "${TARGET_VERSION}" \
-        >"${log_file}" 2>&1
-    local status=$?
-    set -e
-
-    verify_refusal_invariants "${before}" "${after}" "${baseline}" "${log_file}" "${status}"
-    grep -Fq "defenseclaw-upgrade.XXXXXX" "${log_file}" \
-        || die "release-owned explicit-target refusal omitted unique temporary custody"
-    grep -Fq "releases/download/${TARGET_VERSION}/" "${log_file}" \
-        || die "release-owned explicit-target refusal omitted the target release asset URL"
-    grep -Fq "cosign verify-blob" "${log_file}" \
-        || die "release-owned explicit-target refusal omitted resolver provenance verification"
-    grep -Fq "DefenseClaw upgrade resolver complete v1" "${log_file}" \
-        || die "release-owned explicit-target refusal omitted the completeness check"
-    grep -Fq 'bash "$d/defenseclaw-upgrade.sh" --yes' "${log_file}" \
-        || die "release-owned explicit-target refusal omitted the exact no-version invocation"
-    if grep -Fq "upgrade.sh | bash" "${log_file}"; then
-        die "release-owned explicit-target refusal still streams a network response into bash"
-    fi
-    grep -Fq "there is intentionally no --version argument" "${log_file}" \
-        || die "release-owned explicit-target refusal did not disambiguate the immutable hint"
-    restore_stop_probe
-    ok "Release-owned resolver converted the immutable explicit hint into the exact staged command"
-}
-
 run_candidate_updater_staged_success() {
     local baseline="$1"
-    log "Proving one-command staged upgrade ${baseline} -> ${REQUIRED_BRIDGE_VERSION} -> ${TARGET_VERSION}"
+    local invocation="${2:-latest}"
+    local -a resolver_args=(--yes)
+    case "${invocation}" in
+        latest) ;;
+        explicit) resolver_args+=(--version "${TARGET_VERSION}") ;;
+        *) die "unknown staged resolver invocation: ${invocation}" ;;
+    esac
+    log "Proving ${invocation} resolver staging ${baseline} -> ${REQUIRED_BRIDGE_VERSION} -> ${TARGET_VERSION}"
     FROM_VERSION="${baseline}"
     SMOKE_HOME="${WORKDIR}/staged-${baseline}"
     rm -rf "${SMOKE_HOME}"
@@ -703,7 +661,7 @@ run_candidate_updater_staged_success() {
         UPGRADE_GATE_TARGET_VERSION="${TARGET_VERSION}" \
         PATH="${curl_shim}:${SMOKE_HOME}/.local/bin:${PATH}" \
             bash "${RELEASE_ROOT}/${TARGET_VERSION}/defenseclaw-upgrade.sh" \
-            --yes >"${log_file}" 2>&1; then
+            "${resolver_args[@]}" >"${log_file}" 2>&1; then
         tail_v8_upgrade_log_secret_safe "${log_file}"
         die "one-command staged upgrade failed: ${baseline} -> ${TARGET_VERSION}"
     fi
@@ -712,7 +670,7 @@ run_candidate_updater_staged_success() {
         "${log_file}" || die "staged upgrade log did not prove the resolved bridge handoff"
     verify_upgrade
     stop_smoke_gateway
-    ok "One-command staged upgrade passed: ${baseline} -> ${REQUIRED_BRIDGE_VERSION} -> ${TARGET_VERSION}"
+    ok "${invocation} resolver staged upgrade passed: ${baseline} -> ${REQUIRED_BRIDGE_VERSION} -> ${TARGET_VERSION}"
 }
 
 run_candidate_updater_direct_success() {
@@ -861,8 +819,11 @@ run_protocol_case() {
                 || die "tested source ${baseline} requires a bridge, but the signed bridge contract is absent"
             manifest_array_contains auto_bridge_from "${baseline}" \
                 || die "tested pre-bridge source ${baseline} is absent from auto_bridge_from"
-            run_candidate_explicit_bridge_refusal "${baseline}"
-            run_candidate_updater_staged_success "${baseline}"
+            # Frozen schema-1 controllers hand their selected target to the
+            # current release-owned resolver with --version.  Prove that exact
+            # immutable handoff now stages the bridge instead of producing a
+            # second refusal and another command for the operator.
+            run_candidate_updater_staged_success "${baseline}" explicit
         else
             run_candidate_updater_direct_success "${baseline}"
         fi

--- a/scripts/test-upgrade-release.sh
+++ b/scripts/test-upgrade-release.sh
@@ -1796,6 +1796,7 @@ PY
 from pathlib import Path
 import sys
 
+from defenseclaw.observability.v8_compatibility import load_packaged_v7_compatibility_selection
 from defenseclaw.observability.v8_config import load_validate_v8
 from defenseclaw.observability.v8_migration import convert_v7_observability_to_v8
 
@@ -1858,10 +1859,12 @@ otel:
   resource:
     attributes: {}
 """
+compatibility_selection = load_packaged_v7_compatibility_selection()
 for label, historical_source in (("flat", source), ("named", named_source)):
     result = convert_v7_observability_to_v8(
         historical_source,
         {},
+        compatibility_selection=compatibility_selection,
         effective_data_dir=str(data_dir),
     )
     candidate = load_validate_v8(result.candidate).source

--- a/scripts/test-upgrade-release.sh
+++ b/scripts/test-upgrade-release.sh
@@ -1792,6 +1792,91 @@ print("cursor_applied=" + ",".join(cursor.get("applied", [])))
 PY
 
     if target_uses_observability_v8; then
+        "${venv_python}" -I -B - "${SMOKE_HOME}/.defenseclaw" <<'PY'
+from pathlib import Path
+import sys
+
+from defenseclaw.observability.v8_config import load_validate_v8
+from defenseclaw.observability.v8_migration import convert_v7_observability_to_v8
+
+data_dir = Path(sys.argv[1])
+source = b"""config_version: 7
+otel:
+  enabled: false
+  endpoint: ''
+  protocol: grpc
+  headers: {}
+  tls: {ca_cert: '', insecure: false}
+  batch:
+    max_queue_size: 2048
+    max_export_batch_size: 512
+    scheduled_delay_ms: 5000
+  traces:
+    enabled: true
+    sampler: always_on
+    sampler_arg: '1.0'
+    endpoint: ''
+    protocol: ''
+    url_path: ''
+  logs:
+    enabled: true
+    emit_individual_findings: false
+    endpoint: ''
+    protocol: ''
+    url_path: ''
+  metrics:
+    enabled: true
+    export_interval_s: 60
+    endpoint: ''
+    protocol: ''
+    url_path: ''
+  resource:
+    attributes: {}
+"""
+named_source = b"""config_version: 7
+otel:
+  enabled: false
+  traces:
+    sampler: always_on
+    sampler_arg: '1.0'
+  logs:
+    emit_individual_findings: false
+  destinations:
+    - name: generic-otlp
+      preset: generic-otlp
+      enabled: false
+      endpoint: ''
+      protocol: grpc
+      tls: {ca_cert: '', insecure: false}
+      batch:
+        max_queue_size: 2048
+        max_export_batch_size: 512
+        scheduled_delay_ms: 5000
+      traces: {enabled: true, endpoint: '', protocol: '', url_path: ''}
+      logs: {enabled: true, endpoint: '', protocol: '', url_path: ''}
+      metrics: {enabled: true, endpoint: '', protocol: '', url_path: '', export_interval_s: 60}
+  resource:
+    attributes: {}
+"""
+for label, historical_source in (("flat", source), ("named", named_source)):
+    result = convert_v7_observability_to_v8(
+        historical_source,
+        {},
+        effective_data_dir=str(data_dir),
+    )
+    candidate = load_validate_v8(result.candidate).source
+    destinations = {
+        item.get("name")
+        for item in (candidate.get("observability") or {}).get("destinations", [])
+        if isinstance(item, dict)
+    }
+    if "generic-otlp" in destinations:
+        raise SystemExit(f"fresh 0.8.0 {label} endpointless OTLP placeholder survived artifact migration")
+    if "legacy_unconfigured_generic_otlp_placeholder_omitted" not in result.warnings:
+        raise SystemExit(f"fresh 0.8.0 {label} artifact migration omitted no explicit diagnostic")
+print("fresh_080_default_migration=ok")
+PY
+
         if (( FROM_CONFIG_VERSION == 8 )); then
             "${venv_python}" - \
                 "${SMOKE_HOME}/.defenseclaw" \
@@ -2385,24 +2470,132 @@ PY
     fi
     ok "Fresh target gateway is running and healthy"
 
-    "${venv_python}" - <<'PY'
-import textual
-from defenseclaw.tui.widgets.native_metrics import MetricDatum, MetricTile
+    HOME="${SMOKE_HOME}" DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \
+        PYTHONNOUSERSITE=1 PYTHONPATH='' "${venv_python}" - <<'PY'
+import asyncio
+import sys
+from pathlib import Path
 
-metric = MetricDatum(
-    key="hook_calls",
-    label="Hook Calls",
-    value=0,
-    progress=0.0,
-    detail="gateway offline",
-    state="error",
-    target_panel="logs",
-)
-tile = MetricTile(metric)
-tile.refresh_metric(metric)
+import textual
+import defenseclaw.tui.app as tui_app
+
+module_path = Path(tui_app.__file__).resolve()
+if not module_path.is_relative_to(Path(sys.prefix).resolve()):
+    raise SystemExit(f"TUI imported outside wheel environment: {module_path}")
+DefenseClawTUI = tui_app.DefenseClawTUI
+
+async def main() -> None:
+    app = DefenseClawTUI()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+
+asyncio.run(main())
 print("textual_version=" + getattr(textual, "__version__", "unknown"))
-print("metric_tile_refresh=ok")
+print("installed_target_tui_origin=venv")
+print("installed_target_tui_mount=ok")
 PY
+
+    local policy_rows_before=""
+    if target_uses_observability_v8; then
+        policy_rows_before="$("${venv_python}" -I -B - "${SMOKE_HOME}/.defenseclaw" <<'PY'
+from pathlib import Path
+import sqlite3
+import sys
+
+import yaml
+
+data_dir = Path(sys.argv[1])
+config = yaml.safe_load((data_dir / "config.yaml").read_text(encoding="utf-8")) or {}
+configured = (((config.get("observability") or {}).get("local") or {}).get("path"))
+if configured is None:
+    database = data_dir / "audit.db"
+elif not isinstance(configured, str) or not configured.strip():
+    raise SystemExit("configured audit database path is invalid")
+else:
+    database = Path(configured).expanduser()
+    if not database.is_absolute():
+        database = data_dir / database
+connection = sqlite3.connect(f"file:{database}?mode=ro", uri=True)
+try:
+    count = connection.execute(
+        "SELECT COUNT(*) FROM audit_events WHERE event_name = 'policy.updated' AND mandatory = 1"
+    ).fetchone()[0]
+finally:
+    connection.close()
+print(count)
+PY
+)" || die "could not snapshot mandatory policy rows immediately before reload"
+        [[ "${policy_rows_before}" =~ ^[0-9]+$ ]] \
+            || die "invalid mandatory policy row count immediately before reload"
+
+        "${venv_python}" -I -B - "${SMOKE_HOME}/.defenseclaw" "${policy_rows_before}" <<'PY'
+from pathlib import Path
+import sqlite3
+import sys
+import time
+from urllib.request import Request, urlopen
+
+import yaml
+
+data_dir = Path(sys.argv[1])
+before = int(sys.argv[2])
+config = yaml.safe_load((data_dir / "config.yaml").read_text(encoding="utf-8")) or {}
+port = int((config.get("gateway") or {}).get("api_port") or 18970)
+token = ""
+for line in (data_dir / ".env").read_text(encoding="utf-8").splitlines():
+    name, separator, value = line.partition("=")
+    if separator and name.strip() == "DEFENSECLAW_GATEWAY_TOKEN":
+        token = value.strip()
+        break
+if not token:
+    raise SystemExit("target gateway token is unavailable for the post-status write probe")
+
+request = Request(
+    f"http://127.0.0.1:{port}/policy/reload",
+    data=b"",
+    method="POST",
+    headers={
+        "Authorization": "Bearer " + token,
+        "X-DefenseClaw-Token": token,
+    },
+)
+with urlopen(request, timeout=10) as response:
+    if response.status != 200:
+        raise SystemExit(f"post-status policy reload returned HTTP {response.status}")
+
+local = (config.get("observability") or {}).get("local") or {}
+configured = local.get("path")
+if configured is None:
+    database = data_dir / "audit.db"
+elif not isinstance(configured, str) or not configured.strip():
+    raise SystemExit("configured audit database path is invalid")
+else:
+    database = Path(configured).expanduser()
+    if not database.is_absolute():
+        database = data_dir / database
+deadline = time.monotonic() + 10
+while True:
+    connection = sqlite3.connect(f"file:{database}?mode=ro", uri=True)
+    try:
+        after = connection.execute(
+            "SELECT COUNT(*) FROM audit_events WHERE event_name = 'policy.updated' AND mandatory = 1"
+        ).fetchone()[0]
+    finally:
+        connection.close()
+    if after > before:
+        break
+    if time.monotonic() >= deadline:
+        raise SystemExit("fresh SQLite readers cannot see the mandatory write made after status")
+    time.sleep(0.1)
+print("post_status_mandatory_sqlite_write=ok")
+PY
+        "${venv_python}" "${ROOT}/scripts/check_upgrade_receipt.py" \
+            --data-dir "${SMOKE_HOME}/.defenseclaw" \
+            --from-version "${receipt_from}" \
+            --target-version "${TARGET_VERSION}" \
+            --timeout-seconds 10 \
+            || die "read-only status/TUI commands detached the target gateway audit WAL"
+    fi
 }
 
 run_one_upgrade_smoke() {

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -32,7 +32,7 @@
 #
 # Options:
 #   --yes, -y             Skip confirmation prompts
-#   --version VERSION     Upgrade to a specific release (default: latest)
+#   --version VERSION     Select a specific final release (required bridges are still staged)
 #   --plan                Verify contracts and print the resolved path only
 #   --help, -h            Show this help
 #
@@ -3542,8 +3542,6 @@ ensure_upgrade_lock_before_mutation() {
 YES=0
 PLAN_ONLY=0
 RELEASE_VERSION="${VERSION:-}"
-TARGET_VERSION_EXPLICIT=0
-[[ -n "${RELEASE_VERSION}" ]] && TARGET_VERSION_EXPLICIT=1
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -3551,7 +3549,7 @@ while [[ $# -gt 0 ]]; do
         --plan)     PLAN_ONLY=1; shift ;;
         --version)
             [[ $# -lt 2 ]] && die "--version requires a value"
-            RELEASE_VERSION="$2"; TARGET_VERSION_EXPLICIT=1; shift 2 ;;
+            RELEASE_VERSION="$2"; shift 2 ;;
         --help|-h)
             cat <<EOF
 
@@ -3561,7 +3559,7 @@ while [[ $# -gt 0 ]]; do
 
   Options:
     --yes, -y             Skip confirmation prompts
-    --version VERSION     Upgrade to a specific release (e.g. 0.2.0)
+    --version VERSION     Select a specific final release; required bridges are still staged
     --plan                Verify release contracts and print the path; make no changes
     --help, -h            Show this help
 
@@ -4297,6 +4295,7 @@ print_new_upgrade_script_hint() {
     cat >&2 <<EOF
     (
       set -eu
+      unset VERSION
       umask 077
       d="\$(mktemp -d "\${TMPDIR:-/tmp}/defenseclaw-upgrade.XXXXXX")"
       trap 'rm -rf "\$d"' EXIT
@@ -4816,12 +4815,11 @@ resolve_staged_upgrade() {
         return 0
     fi
 
-    if [[ "${TARGET_VERSION_EXPLICIT}" -eq 1 ]]; then
-        err "${RELEASE_VERSION} requires the ${MANIFEST_REQUIRED_BRIDGE} upgrade bridge. No changes were made."
-        info "  Run the release-owned resolver in latest mode; there is intentionally no --version argument."
-        print_new_upgrade_script_hint latest
-        exit 1
-    fi
+    # A version override selects the final release; it never authorizes a
+    # direct hard-cut install.  Legacy controllers that cannot parse schema 2
+    # hand off to the target resolver with exactly this override, so the
+    # release-owned resolver must preserve that target intent while still
+    # inserting every manifest-required bridge.
     if ! manifest_array_contains "auto_bridge_from" "${CURRENT_VERSION}" "${UPGRADE_MANIFEST_FILE}"; then
         supported="$(manifest_array_values "auto_bridge_from" "${UPGRADE_MANIFEST_FILE}" | paste -sd ',' - | sed 's/,/, /g')"
         die "Installed version ${CURRENT_VERSION} is outside the tested automatic bridge matrix. No changes were made.

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,7 @@ overrides = [
     { name = "rich", specifier = ">=13.7.1,<14.0.0" },
     { name = "starlette", specifier = ">=1.3.1,<1.4" },
     { name = "syrupy", specifier = ">=4.9.1" },
-    { name = "textual", specifier = ">=8.2.7" },
+    { name = "textual", specifier = ">=8.2.7,<9" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
@@ -882,6 +882,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
+    { name = "textual" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
@@ -920,6 +921,7 @@ requires-dist = [
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "requests", specifier = "==2.33.0" },
     { name = "rich", specifier = ">=13.0" },
+    { name = "textual", specifier = ">=7.5,<9" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
 ]
 provides-extras = ["vertex"]


### PR DESCRIPTION
Standalone hotfix against `main` at the immutable `0.8.5` release commit. This is the single PR for the runtime and staged-upgrade failures found while exercising the published artifacts.

## Problem

The published `0.8.5` path exposed four connected release-runtime defects:

- The wheel resolves Textual 7.5 through the scanner dependency, but the TUI called the Textual 8-only `Tabs.get_tab()` API and crashed at startup.
- A frozen pre-schema-2 controller handed its selected target to the current resolver with `--version 0.8.5`; the resolver then refused the same bridge requirement a second time instead of staging `source → 0.8.4 → target`.
- Fresh `0.8.0` installers emitted two exact disabled, endpointless OTel placeholder shapes that the strict v7→v8 converter treated as operator destinations.
- `defenseclaw-gateway status` inherited the daemon audit-store lifecycle, allowing a short-lived status process to detach a running daemon from its SQLite WAL/SHM files.

## Current Situation

The immutable `0.8.5` assets cannot be changed. The affected local installation was repaired in place for diagnosis and now mounts the full TUI with Textual 7.5, but a repository hotfix and a new release are required for every other installation.

## Solution

### Runtime compatibility

- Declare Textual as a direct supported runtime dependency (`>=7.5,<9`).
- Use the public `query_one` API shared by Textual 7 and 8.
- Mount the complete TUI from a freshly installed wheel in CI and from the installed target wheel in release smoke tests.
- Assert the imported module lives under the temporary/install venv so the source checkout cannot satisfy the gate accidentally.

### One-command staged resolver

Treat `--version` as the final target selection, not permission to bypass a bridge. The resolver still authenticates manifests and inserts the required `0.8.4` bridge before re-executing under the fresh controller. Direct installer and manual-artifact paths remain outside this staged resolver path.

```mermaid
flowchart LR
    A["0.8.3 or older controller"] --> B["Authenticated current resolver"]
    B --> C["Verified 0.8.4 bridge"]
    C --> D["Fresh 0.8.4 controller"]
    D --> E["Verified target release"]
    E --> F["Health and rollback checks"]
```

### Exact v7→v8 migration boundary

Recognize only the two byte-semantic `0.8.0` installer placeholder shapes and omit them with an explicit diagnostic. Comparison is recursive and type-sensitive, so operator changes such as `false → 0` or `60 → 60.0`, environment endpoints, TLS changes, and any near-match remain on the normal fail-closed migration path.

### SQLite status lifecycle

Split strict configuration loading from audit-store initialization. Read-only `status` loads configuration and calls the running gateway health API without opening or closing a second audit store. Release smoke now proves a mandatory post-status write is visible to a fresh SQLite reader.

## What Changed (Where & How)

| Area | Paths | Change |
| --- | --- | --- |
| TUI runtime | `pyproject.toml`, `uv.lock`, `cli/defenseclaw/tui/app.py` | Support the released Textual 7.5 environment and the dev Textual 8 environment. |
| Staged upgrades | `scripts/upgrade.sh`, protocol tests, resolver hints, macOS runtime installer | Preserve explicit final-target intent while inserting required bridges; clear stale ambient `VERSION` in generated bootstrap commands. |
| v7→v8 conversion | `cli/defenseclaw/observability/v8_migration.py` and tests | Omit only exact immutable endpointless defaults with type-sensitive comparison; fail closed on altered inputs. |
| SQLite lifecycle | `internal/cli/root.go`, `internal/cli/status.go`, `internal/cli/status_lifecycle_test.go` | Keep status config-only and prove it never creates an audit database. |
| Release gates | `.github/workflows/ci.yml`, `scripts/test-upgrade-release.sh` | Mount the installed full TUI, exercise both real historical config shapes, and verify post-status SQLite continuity. |
| Operator guidance | `docs/CLI.md`, upgrade docs | Document the repaired resolver behavior and the immutable `0.8.5` bootstrap constraint. |

## Breaking Changes

- `upgrade.sh --version X` now selects final release `X` while still staging any signed manifest-required bridge.
- No configuration/API break is introduced. Existing non-placeholder OTel configuration remains fail closed and is never silently discarded.

## Open Issues / Follow-ups

None.

## Test Plan

- `uv run pytest -q cli/tests/test_observability_v8_migration.py cli/tests/test_release_workflow_staged.py cli/tests/test_upgrade_staged_resolver.py cli/tests/test_resolver_hint.py cli/tests/test_install_docs_static.py cli/tests/test_macos_runtime_installer_upgrade_guard.py cli/tests/tui/test_app_shell.py` — `610 passed, 2 skipped`.
- Final migration/docs rerun after the type-sensitive comparison fix — `396 passed`.
- Scalar-type placeholder regressions — `13 passed` in the focused selection.
- `go test -race ./internal/cli ./internal/config -count=1` — passed.
- `bash -n scripts/test-upgrade-release.sh scripts/upgrade.sh scripts/test-upgrade-protocol-release.sh` — passed.
- `actionlint .github/workflows/ci.yml` — passed.
- Ruff on all changed Python files and `git diff --check` — passed.
- Fresh wheel install with resolved Textual 7.5 and full `DefenseClawTUI.run_test()` mount — passed.
- Exact local managed `0.8.5` environment (`textual=7.5.0`) full TUI mount — passed.
- Linux live preserved-fixture validation: genuine flat `0.8.0` conversion, healthy migrated target, WAL/SHM preservation across status, authenticated post-status policy write, receipt and health checks — passed.
- macOS live preserved-fixture validation: genuine nested `0.8.0` conversion, expected omission diagnostic, no invented OTel destination, no source config/environment mutation — passed.
