### PR TITLE
fix(upgrade): make future release transitions dynamic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SOURCE_PLUGIN_INSTALL_TARGET = $(if $(filter openclaw,$(CONNECTOR)),plugin-insta
 GO_TEST_TIMEOUT ?= 60m
 
 DIST_DIR    := dist
-UPGRADE_SMOKE_FROM ?= 0.8.4 0.8.3 0.8.2 0.8.1 0.8.0 0.7.2 0.7.1 0.6.6 0.6.5 0.6.4 0.6.3 0.6.2 0.6.1 0.6.0 0.5.0 0.4.0
+UPGRADE_SMOKE_FROM ?=
 
 # Cross-platform virtualenv / executable layout. Windows Python venvs expose
 # console entry points under Scripts/ (not bin/) and binaries carry a .exe
@@ -40,6 +40,39 @@ endif
 # and otherwise use the host Python available on every supported installer/CI
 # platform. Dependency-bearing scripts continue to use $(VENV_BIN)/python.
 BOOTSTRAP_PYTHON := $(shell if [ -x "$(VENV_BIN)/python$(EXE)" ]; then printf '%s' "$(VENV_BIN)/python$(EXE)"; elif command -v python3 >/dev/null 2>&1; then command -v python3; elif command -v python >/dev/null 2>&1; then command -v python; else printf '%s' python; fi)
+
+# Resolve newly published stable baselines at execution time. Explicit
+# UPGRADE_SMOKE_FROM values still provide a deterministic developer override.
+# Dynamic resolution requires the exact candidate in ARGS so only older
+# releases can become upgrade baselines; the checked-in development VERSION is
+# intentionally not a release-selection fallback.
+define run_upgrade_matrix
+	@set -eu; \
+	from_versions='$(strip $(UPGRADE_SMOKE_FROM))'; \
+	target_version=''; \
+	set -- $(ARGS); \
+	while [ "$$#" -gt 0 ]; do \
+		case "$$1" in \
+			--target-version) shift; [ "$$#" -gt 0 ] || { echo 'missing value for --target-version' >&2; exit 2; }; target_version="$$1" ;; \
+			--target-version=*) target_version="$${1#--target-version=}" ;; \
+		esac; \
+		shift; \
+	done; \
+	resolution_dir=''; \
+	cleanup() { if [ -n "$$resolution_dir" ]; then rm -rf "$$resolution_dir"; fi; }; \
+	trap cleanup EXIT HUP INT TERM; \
+	if [ -z "$$from_versions" ]; then \
+		[ -n "$$target_version" ] || { echo 'dynamic upgrade matrix requires ARGS="--target-version X.Y.Z ..." (or explicit UPGRADE_SMOKE_FROM)' >&2; exit 2; }; \
+		resolution_dir="$$(mktemp -d "$${TMPDIR:-/tmp}/defenseclaw-baselines.XXXXXX")"; \
+		$(BOOTSTRAP_PYTHON) scripts/resolve_upgrade_baselines.py \
+			--target-version "$$target_version" \
+			--output "$$resolution_dir/effective.json"; \
+		from_versions="$$( $(BOOTSTRAP_PYTHON) -c \
+			'import json, sys; print(" ".join(json.load(open(sys.argv[1], encoding="utf-8"))["published_baselines"]))' \
+			"$$resolution_dir/effective.json" )"; \
+	fi; \
+	$(1) --from-versions "$$from_versions" $(2) $(ARGS)
+endef
 
 .PHONY: help all path doctor uninstall quickstart llm-setup \
         build install cli-install dev-install pycli dev-pycli gateway gateway-cross gateway-run start gateway-install \
@@ -869,7 +902,7 @@ upgrade-smoke:
 	@scripts/test-upgrade-protocol-release.sh --refusal-contract-only $(ARGS)
 
 upgrade-smoke-matrix:
-	@scripts/test-upgrade-protocol-release.sh --from-versions "$(UPGRADE_SMOKE_FROM)" --refusal-contract-only $(ARGS)
+	$(call run_upgrade_matrix,scripts/test-upgrade-protocol-release.sh,--refusal-contract-only)
 
 upgrade-refusal-contract-matrix: upgrade-smoke-matrix
 
@@ -880,13 +913,13 @@ upgrade-legacy-smoke:
 	@scripts/test-upgrade-release.sh $(ARGS)
 
 upgrade-legacy-smoke-matrix:
-	@scripts/test-upgrade-release.sh --from-versions "$(UPGRADE_SMOKE_FROM)" $(ARGS)
+	$(call run_upgrade_matrix,scripts/test-upgrade-release.sh,)
 
 upgrade-signed-protocol:
 	@scripts/test-upgrade-protocol-release.sh $(ARGS)
 
 upgrade-signed-protocol-matrix:
-	@scripts/test-upgrade-protocol-release.sh --from-versions "$(UPGRADE_SMOKE_FROM)" $(ARGS)
+	$(call run_upgrade_matrix,scripts/test-upgrade-protocol-release.sh,)
 
 # ---------------------------------------------------------------------------
 # Lint targets

--- a/cli/defenseclaw/bundle_refresh.py
+++ b/cli/defenseclaw/bundle_refresh.py
@@ -55,6 +55,7 @@ import base64
 import hashlib
 import json
 import os
+import re
 import secrets
 import shutil
 import socket
@@ -147,6 +148,15 @@ class LocalObservabilityUpgradeError(RuntimeError):
         self.code = code
         self.phase = phase
         super().__init__(f"local observability bundle upgrade failed ({code}, {phase})")
+
+
+@dataclass(frozen=True)
+class _LocalObservabilityBackupCustodyIdentity:
+    """Exact filesystem identities created before an external recorder runs."""
+
+    parent: os.stat_result
+    root: os.stat_result
+    restart_intent: os.stat_result
 
 
 class _WindowsSecuritySnapshot(Protocol):
@@ -270,7 +280,14 @@ _LOCAL_OBSERVABILITY_DEST_REL: str = "observability-stack"
 _LOCAL_OBSERVABILITY_MANIFEST = ".defenseclaw-bundle-manifest.json"
 _LOCAL_OBSERVABILITY_RESTART_INTENT = "restart-intent.json"
 _LOCAL_OBSERVABILITY_MANIFEST_SCHEMA = 1
+_BUNDLE_VERSION_RE = re.compile(r"^[0-9A-Za-z][0-9A-Za-z._+-]{0,63}$")
 _MAX_BUNDLE_ROLLBACK_METADATA_BYTES = 4 * 1024 * 1024
+_NOFOLLOW_DIRECTORY_OPEN_FLAGS = (
+    getattr(os, "O_RDONLY", 0)
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
 _LOCAL_OBSERVABILITY_REQUIRED_FILES: tuple[str, ...] = (
     "bin/openclaw-observability-bridge",
     "docker-compose.yml",
@@ -366,7 +383,9 @@ def refresh_local_observability_stack(
             return result
         result.errors.extend(
             _ensure_local_observability_container_access(
-                Path(dest), Path(bundle), include_operator_custom=True,
+                Path(dest),
+                Path(bundle),
+                include_operator_custom=True,
             )
         )
         result.refreshed = True
@@ -398,7 +417,9 @@ def refresh_local_observability_stack(
 
     result.errors.extend(
         _ensure_local_observability_container_access(
-            Path(dest), Path(bundle), include_operator_custom=True,
+            Path(dest),
+            Path(bundle),
+            include_operator_custom=True,
         )
     )
     return result
@@ -410,6 +431,7 @@ def upgrade_local_observability_stack(
     *,
     bundle_version: str,
     fault_injector: Callable[[str, str | None], None] | None = None,
+    restart_intent_recorder: Callable[[bool], None] | None = None,
 ) -> LocalObservabilityUpgradeResult:
     """Safely refresh an installed local-observability stack during upgrade.
 
@@ -441,6 +463,19 @@ def upgrade_local_observability_stack(
         target_manifest_sha256=target.sha256,
         restart_required=was_running,
     )
+    if restart_intent_recorder is not None:
+        try:
+            backup_custody_identity = _snapshot_local_observability_backup_custody(backup_root)
+        except OSError as exc:
+            raise LocalObservabilityUpgradeError("backup_failed", "backup") from exc
+        try:
+            restart_intent_recorder(was_running)
+        except Exception as exc:
+            _discard_local_observability_backup_custody(
+                backup_root,
+                backup_custody_identity,
+            )
+            raise LocalObservabilityUpgradeError("backup_failed", "backup") from exc
     if fault_injector:
         try:
             fault_injector("after_restart_intent", None)
@@ -526,6 +561,149 @@ def _prepare_local_observability_backup_custody(
     return backup_root
 
 
+def _snapshot_local_observability_backup_custody(
+    backup_root: Path,
+) -> _LocalObservabilityBackupCustodyIdentity:
+    """Bind cleanup to the exact parent, root, and intent this attempt made."""
+
+    parent = os.lstat(backup_root.parent)
+    root = os.lstat(backup_root)
+    restart_intent = os.lstat(backup_root / _LOCAL_OBSERVABILITY_RESTART_INTENT)
+    if (
+        _is_rollback_link_or_reparse(parent)
+        or not stat.S_ISDIR(parent.st_mode)
+        or _is_rollback_link_or_reparse(root)
+        or not stat.S_ISDIR(root.st_mode)
+        or _is_rollback_link_or_reparse(restart_intent)
+        or not stat.S_ISREG(restart_intent.st_mode)
+    ):
+        raise OSError("unsafe local observability backup custody")
+    return _LocalObservabilityBackupCustodyIdentity(
+        parent=parent,
+        root=root,
+        restart_intent=restart_intent,
+    )
+
+
+def _discard_local_observability_backup_custody(
+    backup_root: Path,
+    expected: _LocalObservabilityBackupCustodyIdentity,
+) -> None:
+    """Best-effort removal of only this attempt's still-pristine custody.
+
+    The external receipt recorder runs before any service or bundle mutation.
+    If it fails, leaving our private restart-intent directory behind would make
+    an otherwise safe retry fail with ``backup_collision``.  Cleanup is bound
+    to the filesystem identities captured before the callback and refuses to
+    traverse links or remove a directory containing any unexpected member.
+    """
+
+    try:
+        if os.name == "posix":
+            _discard_local_observability_backup_custody_at(
+                backup_root,
+                expected,
+            )
+        else:
+            _discard_local_observability_backup_custody_by_path(
+                backup_root,
+                expected,
+            )
+    except OSError:
+        # The recorder's exception remains the authoritative failure. If the
+        # custody changed concurrently, retaining it is safer than deleting an
+        # artifact that no longer belongs exclusively to this attempt.
+        return
+
+
+def _discard_local_observability_backup_custody_at(
+    backup_root: Path,
+    expected: _LocalObservabilityBackupCustodyIdentity,
+) -> None:
+    """Remove pristine custody through no-follow directory descriptors."""
+
+    parent_descriptor = os.open(backup_root.parent, _NOFOLLOW_DIRECTORY_OPEN_FLAGS)
+    try:
+        if not os.path.samestat(os.fstat(parent_descriptor), expected.parent):
+            return
+        root_descriptor = os.open(
+            backup_root.name,
+            _NOFOLLOW_DIRECTORY_OPEN_FLAGS,
+            dir_fd=parent_descriptor,
+        )
+        try:
+            if not os.path.samestat(os.fstat(root_descriptor), expected.root):
+                return
+            intent_info = os.stat(
+                _LOCAL_OBSERVABILITY_RESTART_INTENT,
+                dir_fd=root_descriptor,
+                follow_symlinks=False,
+            )
+            if (
+                not stat.S_ISREG(intent_info.st_mode)
+                or not os.path.samestat(intent_info, expected.restart_intent)
+                or os.listdir(root_descriptor) != [_LOCAL_OBSERVABILITY_RESTART_INTENT]
+            ):
+                return
+            os.unlink(
+                _LOCAL_OBSERVABILITY_RESTART_INTENT,
+                dir_fd=root_descriptor,
+            )
+            os.fsync(root_descriptor)
+            named_root = os.stat(
+                backup_root.name,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
+            if not os.path.samestat(named_root, expected.root) or os.listdir(root_descriptor):
+                return
+            os.rmdir(backup_root.name, dir_fd=parent_descriptor)
+            os.fsync(parent_descriptor)
+        finally:
+            os.close(root_descriptor)
+    finally:
+        os.close(parent_descriptor)
+
+
+def _discard_local_observability_backup_custody_by_path(
+    backup_root: Path,
+    expected: _LocalObservabilityBackupCustodyIdentity,
+) -> None:
+    """Path-safe fallback for platforms without POSIX directory descriptors."""
+
+    parent = os.lstat(backup_root.parent)
+    root = os.lstat(backup_root)
+    intent_path = backup_root / _LOCAL_OBSERVABILITY_RESTART_INTENT
+    intent = os.lstat(intent_path)
+    if (
+        _is_rollback_link_or_reparse(parent)
+        or not stat.S_ISDIR(parent.st_mode)
+        or not os.path.samestat(parent, expected.parent)
+        or _is_rollback_link_or_reparse(root)
+        or not stat.S_ISDIR(root.st_mode)
+        or not os.path.samestat(root, expected.root)
+        or _is_rollback_link_or_reparse(intent)
+        or not stat.S_ISREG(intent.st_mode)
+        or not os.path.samestat(intent, expected.restart_intent)
+    ):
+        return
+    members = list(os.scandir(backup_root))
+    if len(members) != 1 or members[0].name != _LOCAL_OBSERVABILITY_RESTART_INTENT:
+        return
+    intent_path.unlink()
+    if os.listdir(backup_root):
+        return
+    current_parent = os.lstat(backup_root.parent)
+    current_root = os.lstat(backup_root)
+    if not os.path.samestat(current_parent, expected.parent) or not os.path.samestat(
+        current_root,
+        expected.root,
+    ):
+        return
+    backup_root.rmdir()
+    _fsync_directory(backup_root.parent)
+
+
 def restart_upgraded_local_observability_stack(
     data_dir: str,
     *,
@@ -575,6 +753,23 @@ def restart_upgraded_local_observability_stack(
         named_volumes=_LOCAL_OBSERVABILITY_NAMED_VOLUMES,
         degraded_errors=tuple(errors),
     )
+
+
+def installed_local_observability_bundle_version(data_dir: str) -> str | None:
+    """Return the installed bundle version without mutating the stack.
+
+    ``None`` means no local-observability stack is installed. An empty string
+    identifies a legacy installed stack with no managed manifest, which also
+    requires authenticated reconciliation before a same-version success.
+    """
+
+    destination = Path(data_dir).expanduser().absolute() / _LOCAL_OBSERVABILITY_DEST_REL
+    if not destination.exists() and not destination.is_symlink():
+        return None
+    if destination.is_symlink() or not destination.is_dir():
+        raise LocalObservabilityUpgradeError("unsafe_install_root", "preflight")
+    manifest = _read_installed_bundle_manifest(destination)
+    return manifest.bundle_version if manifest is not None else ""
 
 
 def _build_local_observability_manifest(source: Path, bundle_version: str) -> _BundleManifest:
@@ -693,7 +888,12 @@ def _read_installed_bundle_manifest(destination: Path) -> _BundleManifest | None
         files_raw = document["files"]
         dashboards_raw = document["dashboard_uids"]
         volumes_raw = document["named_volumes"]
-        if not isinstance(bundle_version, str) or not isinstance(files_raw, list) or len(files_raw) > 4096:
+        if (
+            not isinstance(bundle_version, str)
+            or _BUNDLE_VERSION_RE.fullmatch(bundle_version) is None
+            or not isinstance(files_raw, list)
+            or len(files_raw) > 4096
+        ):
             raise ValueError("invalid manifest fields")
         files: list[_BundleFile] = []
         seen: set[str] = set()
@@ -851,11 +1051,7 @@ def _activate_local_observability_manifest(
     # DefenseClaw-managed; destination-only paths remain operator-owned.
     target_paths = set(target_by_path) | {_LOCAL_OBSERVABILITY_MANIFEST}
     candidate_managed_paths = target_paths | managed_retired
-    existing_paths = {
-        relative
-        for relative in candidate_managed_paths
-        if (destination / relative).exists()
-    }
+    existing_paths = {relative for relative in candidate_managed_paths if (destination / relative).exists()}
     created_paths = candidate_managed_paths - existing_paths
     managed_paths = existing_paths | created_paths
     if created_paths - target_paths:
@@ -967,9 +1163,7 @@ def _activate_local_observability_manifest(
             target_entry = target_by_path.get(relative)
             expected_digest = target.sha256 if target_entry is None else target_entry.sha256
             expected_mode = 0o600 if target_entry is None else target_entry.mode
-            if old_sha256[relative] != expected_digest or (
-                os.name == "posix" and old_modes[relative] != expected_mode
-            ):
+            if old_sha256[relative] != expected_digest or (os.name == "posix" and old_modes[relative] != expected_mode):
                 changed.append(relative)
             if fault_injector:
                 fault_injector("before_activate", relative)
@@ -1164,9 +1358,7 @@ _WINDOWS_ROLLBACK_MEMBER_MAX_BYTES = 256 * 1024 * 1024
 
 
 def _is_rollback_link_or_reparse(info: os.stat_result) -> bool:
-    return stat.S_ISLNK(info.st_mode) or bool(
-        getattr(info, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
-    )
+    return stat.S_ISLNK(info.st_mode) or bool(getattr(info, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT)
 
 
 def _rollback_directory_info(path: Path) -> os.stat_result:
@@ -1264,14 +1456,8 @@ def _rollback_path_parts(relative: str) -> tuple[str, ...]:
 def _open_rollback_root_descriptor(path: Path) -> int:
     """Open and bind a real rollback root without accepting a swapped leaf."""
 
-    flags = (
-        os.O_RDONLY
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_DIRECTORY", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
     try:
-        descriptor = os.open(path, flags)
+        descriptor = os.open(path, _NOFOLLOW_DIRECTORY_OPEN_FLAGS)
     except OSError as exc:
         raise OSError("unsafe local observability rollback root") from exc
     try:
@@ -1298,17 +1484,11 @@ def _open_rollback_parent(
 ) -> int | None:
     """Open one managed file's parent without following any path component."""
 
-    flags = (
-        os.O_RDONLY
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_DIRECTORY", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
     current = os.dup(root_descriptor)
     try:
         for part in parts:
             try:
-                child = os.open(part, flags, dir_fd=current)
+                child = os.open(part, _NOFOLLOW_DIRECTORY_OPEN_FLAGS, dir_fd=current)
             except FileNotFoundError:
                 if not create:
                     os.close(current)
@@ -1321,7 +1501,7 @@ def _open_rollback_parent(
                 else:
                     os.fsync(current)
                 try:
-                    child = os.open(part, flags, dir_fd=current)
+                    child = os.open(part, _NOFOLLOW_DIRECTORY_OPEN_FLAGS, dir_fd=current)
                 except OSError as exc:
                     raise OSError("unsafe local observability rollback destination ancestor") from exc
             except OSError as exc:
@@ -1352,12 +1532,7 @@ def _restore_rollback_file_at(
 ) -> None:
     """Atomically restore, flush, and verify one file below a trusted dirfd."""
 
-    source_flags = (
-        os.O_RDONLY
-        | getattr(os, "O_BINARY", 0)
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
+    source_flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     try:
         source_descriptor = os.open(
             backup_name,
@@ -1386,13 +1561,7 @@ def _restore_rollback_file_at(
             destination_name,
             missing_ok=True,
         )
-        create_flags = (
-            os.O_RDWR
-            | os.O_CREAT
-            | os.O_EXCL
-            | getattr(os, "O_CLOEXEC", 0)
-            | getattr(os, "O_NOFOLLOW", 0)
-        )
+        create_flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
         for _ in range(128):
             temporary_name = f".rollback-{secrets.token_hex(8)}"
             try:
@@ -1427,9 +1596,8 @@ def _restore_rollback_file_at(
             )
         except OSError as exc:
             raise OSError("backup member changed during restore") from exc
-        if (
-            not _rollback_source_snapshot_unchanged(source_before, source_after)
-            or not os.path.samestat(source_before, source_named_after)
+        if not _rollback_source_snapshot_unchanged(source_before, source_after) or not os.path.samestat(
+            source_before, source_named_after
         ):
             raise OSError("backup member changed during restore")
         if _sha256_descriptor(temporary_descriptor) != expected_digest:
@@ -1466,7 +1634,6 @@ def _restore_rollback_file_at(
                 os.fsync(parent_descriptor)
             except OSError:
                 pass
-
 
 
 def _rollback_file_info_at(
@@ -1546,12 +1713,7 @@ def _restore_rollback_file_by_path(
     source_named_before = _rollback_file_info(backup_path, missing_ok=False)
     if source_named_before is None:
         raise OSError("backup member missing")
-    source_flags = (
-        os.O_RDONLY
-        | getattr(os, "O_BINARY", 0)
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
+    source_flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     try:
         source_descriptor = os.open(backup_path, source_flags)
     except OSError as exc:
@@ -1560,10 +1722,7 @@ def _restore_rollback_file_by_path(
     temporary_descriptor = -1
     try:
         source_before = os.fstat(source_descriptor)
-        if (
-            not stat.S_ISREG(source_before.st_mode)
-            or not os.path.samestat(source_before, source_named_before)
-        ):
+        if not stat.S_ISREG(source_before.st_mode) or not os.path.samestat(source_before, source_named_before):
             raise OSError("backup member missing")
         destination_before = _rollback_file_info(destination_path, missing_ok=True)
         if os.name == "nt":
@@ -1579,13 +1738,7 @@ def _restore_rollback_file_by_path(
                 expected_digest,
             )
             return
-        create_flags = (
-            os.O_RDWR
-            | os.O_CREAT
-            | os.O_EXCL
-            | getattr(os, "O_CLOEXEC", 0)
-            | getattr(os, "O_NOFOLLOW", 0)
-        )
+        create_flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
         for _ in range(128):
             candidate = destination_path.parent / f".rollback-{secrets.token_hex(8)}"
             try:
@@ -1713,10 +1866,7 @@ def _restore_windows_rollback_file_by_path(
         created = True
         os.chmod(temporary_path, mode)
         temporary_flags = (
-            os.O_RDWR
-            | getattr(os, "O_BINARY", 0)
-            | getattr(os, "O_CLOEXEC", 0)
-            | getattr(os, "O_NOFOLLOW", 0)
+            os.O_RDWR | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
         )
         temporary_descriptor = os.open(temporary_path, temporary_flags)
         try:
@@ -2629,9 +2779,7 @@ _WINDOWS_ROLLBACK_MEMBER_MAX_BYTES = 256 * 1024 * 1024
 
 
 def _is_rollback_link_or_reparse(info: os.stat_result) -> bool:
-    return stat.S_ISLNK(info.st_mode) or bool(
-        getattr(info, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
-    )
+    return stat.S_ISLNK(info.st_mode) or bool(getattr(info, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT)
 
 
 def _rollback_directory_info(path: Path) -> os.stat_result:
@@ -2729,14 +2877,8 @@ def _rollback_path_parts(relative: str) -> tuple[str, ...]:
 def _open_rollback_root_descriptor(path: Path) -> int:
     """Open and bind a real rollback root without accepting a swapped leaf."""
 
-    flags = (
-        os.O_RDONLY
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_DIRECTORY", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
     try:
-        descriptor = os.open(path, flags)
+        descriptor = os.open(path, _NOFOLLOW_DIRECTORY_OPEN_FLAGS)
     except OSError as exc:
         raise OSError("unsafe local observability rollback root") from exc
     try:
@@ -2763,17 +2905,11 @@ def _open_rollback_parent(
 ) -> int | None:
     """Open one managed file's parent without following any path component."""
 
-    flags = (
-        os.O_RDONLY
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_DIRECTORY", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
     current = os.dup(root_descriptor)
     try:
         for part in parts:
             try:
-                child = os.open(part, flags, dir_fd=current)
+                child = os.open(part, _NOFOLLOW_DIRECTORY_OPEN_FLAGS, dir_fd=current)
             except FileNotFoundError:
                 if not create:
                     os.close(current)
@@ -2786,7 +2922,7 @@ def _open_rollback_parent(
                 else:
                     os.fsync(current)
                 try:
-                    child = os.open(part, flags, dir_fd=current)
+                    child = os.open(part, _NOFOLLOW_DIRECTORY_OPEN_FLAGS, dir_fd=current)
                 except OSError as exc:
                     raise OSError("unsafe local observability rollback destination ancestor") from exc
             except OSError as exc:
@@ -2817,12 +2953,7 @@ def _restore_rollback_file_at(
 ) -> None:
     """Atomically restore, flush, and verify one file below a trusted dirfd."""
 
-    source_flags = (
-        os.O_RDONLY
-        | getattr(os, "O_BINARY", 0)
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
+    source_flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     try:
         source_descriptor = os.open(
             backup_name,
@@ -2851,13 +2982,7 @@ def _restore_rollback_file_at(
             destination_name,
             missing_ok=True,
         )
-        create_flags = (
-            os.O_RDWR
-            | os.O_CREAT
-            | os.O_EXCL
-            | getattr(os, "O_CLOEXEC", 0)
-            | getattr(os, "O_NOFOLLOW", 0)
-        )
+        create_flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
         for _ in range(128):
             temporary_name = f".rollback-{secrets.token_hex(8)}"
             try:
@@ -2892,9 +3017,8 @@ def _restore_rollback_file_at(
             )
         except OSError as exc:
             raise OSError("backup member changed during restore") from exc
-        if (
-            not _rollback_source_snapshot_unchanged(source_before, source_after)
-            or not os.path.samestat(source_before, source_named_after)
+        if not _rollback_source_snapshot_unchanged(source_before, source_after) or not os.path.samestat(
+            source_before, source_named_after
         ):
             raise OSError("backup member changed during restore")
         if _sha256_descriptor(temporary_descriptor) != expected_digest:
@@ -2931,7 +3055,6 @@ def _restore_rollback_file_at(
                 os.fsync(parent_descriptor)
             except OSError:
                 pass
-
 
 
 def _rollback_file_info_at(
@@ -2996,12 +3119,7 @@ def _restore_rollback_file_by_path(
     source_named_before = _rollback_file_info(backup_path, missing_ok=False)
     if source_named_before is None:
         raise OSError("backup member missing")
-    source_flags = (
-        os.O_RDONLY
-        | getattr(os, "O_BINARY", 0)
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
+    source_flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     try:
         source_descriptor = os.open(backup_path, source_flags)
     except OSError as exc:
@@ -3010,10 +3128,7 @@ def _restore_rollback_file_by_path(
     temporary_descriptor = -1
     try:
         source_before = os.fstat(source_descriptor)
-        if (
-            not stat.S_ISREG(source_before.st_mode)
-            or not os.path.samestat(source_before, source_named_before)
-        ):
+        if not stat.S_ISREG(source_before.st_mode) or not os.path.samestat(source_before, source_named_before):
             raise OSError("backup member missing")
         destination_before = _rollback_file_info(destination_path, missing_ok=True)
         if os.name == "nt":
@@ -3030,13 +3145,7 @@ def _restore_rollback_file_by_path(
                 windows_security,
             )
             return
-        create_flags = (
-            os.O_RDWR
-            | os.O_CREAT
-            | os.O_EXCL
-            | getattr(os, "O_CLOEXEC", 0)
-            | getattr(os, "O_NOFOLLOW", 0)
-        )
+        create_flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
         for _ in range(128):
             candidate = destination_path.parent / f".rollback-{secrets.token_hex(8)}"
             try:
@@ -3179,10 +3288,7 @@ def _restore_windows_rollback_file_by_path(
         # A POSIX mode cannot encode Windows ACE order or inheritance state.
         _ = mode
         temporary_flags = (
-            os.O_RDWR
-            | getattr(os, "O_BINARY", 0)
-            | getattr(os, "O_CLOEXEC", 0)
-            | getattr(os, "O_NOFOLLOW", 0)
+            os.O_RDWR | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
         )
         temporary_descriptor = os.open(temporary_path, temporary_flags)
         try:
@@ -3229,10 +3335,7 @@ def _restore_windows_rollback_file_by_path(
         if restored_info is None or not os.path.samestat(staged_info, restored_info):
             raise OSError("restored member identity changed during publish")
         restored_flags = (
-            os.O_RDONLY
-            | getattr(os, "O_BINARY", 0)
-            | getattr(os, "O_CLOEXEC", 0)
-            | getattr(os, "O_NOFOLLOW", 0)
+            os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
         )
         restored_descriptor = os.open(destination_path, restored_flags)
         try:
@@ -3299,11 +3402,7 @@ def _open_created_rollback_claim_at(
             dir_fd=parent_descriptor,
             follow_symlinks=False,
         )
-        if (
-            not stat.S_ISREG(before.st_mode)
-            or not stat.S_ISREG(named.st_mode)
-            or not os.path.samestat(before, named)
-        ):
+        if not stat.S_ISREG(before.st_mode) or not stat.S_ISREG(named.st_mode) or not os.path.samestat(before, named):
             raise OSError("target-created rollback claim is unsafe")
         if _sha256_descriptor(descriptor) != expected_digest:
             raise OSError("target-created rollback claim digest mismatch")
@@ -3367,13 +3466,16 @@ def _rename_no_replace_at(
         ctypes.c_uint,
     ]
     function.restype = ctypes.c_int
-    if function(
-        source_parent_descriptor,
-        os.fsencode(source_name),
-        destination_parent_descriptor,
-        os.fsencode(destination_name),
-        flag,
-    ) == 0:
+    if (
+        function(
+            source_parent_descriptor,
+            os.fsencode(source_name),
+            destination_parent_descriptor,
+            os.fsencode(destination_name),
+            flag,
+        )
+        == 0
+    ):
         return
     code = ctypes.get_errno()
     if code == errno.EEXIST:
@@ -3704,11 +3806,7 @@ def _open_created_rollback_claim_by_path(
                 str(claim_path),
             )
         else:
-            flags = (
-                os.O_RDONLY
-                | getattr(os, "O_CLOEXEC", 0)
-                | getattr(os, "O_NOFOLLOW", 0)
-            )
+            flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
             descriptor = os.open(claim_path, flags)
     except OSError as exc:
         raise OSError("target-created rollback claim is unavailable") from exc
@@ -3971,6 +4069,7 @@ __all__ = [
     "LocalObservabilityUpgradeResult",
     "RefreshResult",
     "SPLUNK_COMPOSE_PROJECT",
+    "installed_local_observability_bundle_version",
     "is_compose_project_running",
     "refresh_local_observability_stack",
     "refresh_splunk_bridge",

--- a/cli/defenseclaw/commands/cmd_upgrade.py
+++ b/cli/defenseclaw/commands/cmd_upgrade.py
@@ -60,10 +60,17 @@ from defenseclaw.context import AppContext, pass_ctx
 from defenseclaw.resolver_hint import authenticated_resolver_instructions
 from defenseclaw.upgrade_receipt import (
     begin_upgrade_receipt,
+    clear_local_bundle_restart_intent,
     complete_upgrade_receipt,
+    delegate_prior_upgrade_receipts,
     finalize_interrupted_upgrade_receipts,
+    find_resumable_upgrade_receipt,
+    find_verified_installed_upgrade_receipt,
+    load_local_bundle_restart_intent,
     load_upgrade_receipt,
+    record_local_bundle_restart_intent,
     record_upgrade_migrations,
+    supersede_prior_upgrade_receipts,
 )
 
 if TYPE_CHECKING:
@@ -133,12 +140,9 @@ _NO_OBSERVABILITY_V8_PREFLIGHT_BINDING = object()
 _MAX_WHEEL_MIGRATIONS_BYTES = 8 * 1024 * 1024
 _MAX_WHEEL_METADATA_BYTES = 256 * 1024
 _MAX_WHEEL_MUTATOR_WRAPPER_BYTES = 256 * 1024
-_HARD_CUT_PROMOTED_REQUIREMENTS = {
-    ("0.8.4", "0.8.5"): (
-        "jsonschema<5,>=4.23.0",
-        'mcp<2,>=1.28.1; python_version >= "3.11"',
-    ),
-}
+_MAX_INSTALLED_DISTRIBUTIONS = 4096
+_MAX_WHEEL_DESCRIPTOR_BYTES = 64 * 1024
+_DEPENDENCY_PREFLIGHT_TIMEOUT_SECONDS = 120
 _MACOS_GATEWAY_CODESIGN_IDENTIFIER = "com.cisco.defenseclaw.gateway"
 _PROTECTED_ARTIFACT_MAGIC = b"DEFENSECLAW-PROTECTED-ARTIFACT-V1\n"
 _V8_RECOVERY_ENTRY_RE = re.compile(r"^observability-v8-[0-9a-f]{32}$")
@@ -267,6 +271,14 @@ if bundle_parameter is not None and bundle_parameter.kind in (
     inspect.Parameter.KEYWORD_ONLY,
 ):
     kwargs["upgrade_handles_local_bundle"] = True
+bundle_transaction_parameter = inspect.signature(run_migrations).parameters.get(
+    "controller_owns_local_bundle_transaction"
+)
+if bundle_transaction_parameter is not None and bundle_transaction_parameter.kind in (
+    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    inspect.Parameter.KEYWORD_ONLY,
+):
+    kwargs["controller_owns_local_bundle_transaction"] = True
 count = run_migrations(
     sys.argv[1],
     sys.argv[2],
@@ -636,11 +648,128 @@ def upgrade(
         raise
 
     if target_version == current_version:
-        # Recovery and installed-source coherence have already run, and the
-        # signed release contract plus target artifacts were authenticated
-        # above.  A same-version resolver request is therefore a verified
-        # no-op, never a repair reinstall: there is no rollback transaction
-        # capable of making an in-place hard-cut reinstall safe.
+        try:
+            recovery_authority = find_resumable_upgrade_receipt(
+                data_dir,
+                target_version=current_version,
+            )
+        except ValueError:
+            try:
+                abandoned = finalize_interrupted_upgrade_receipts(
+                    data_dir,
+                    current_version=current_version,
+                )
+            except (OSError, ValueError):
+                abandoned = 0
+            ux.err("Pending upgrade recovery authority was unverified or ambiguous; refusing same-version activation.")
+            if abandoned:
+                ux.subhead(
+                    f"Marked {abandoned} abandoned attempt(s) interrupted; rerun the authenticated resolver.",
+                    indent="    ",
+                )
+            shutil.rmtree(staging_dir, ignore_errors=True)
+            raise SystemExit(1) from None
+        except OSError:
+            ux.err("Could not inspect the durable upgrade compliance receipts; installed state was not changed.")
+            shutil.rmtree(staging_dir, ignore_errors=True)
+            raise SystemExit(1) from None
+        try:
+            bundle_needs_reconciliation = _installed_local_observability_bundle_needs_reconciliation(
+                data_dir,
+                target_version,
+            )
+        except OSError:
+            ux.err(
+                "Could not safely inspect the installed local-observability bundle; installed state was not changed."
+            )
+            shutil.rmtree(staging_dir, ignore_errors=True)
+            raise SystemExit(1) from None
+        installed_authority: Path | None = None
+        if recovery_authority is None and bundle_needs_reconciliation:
+            try:
+                installed_authority = find_verified_installed_upgrade_receipt(
+                    data_dir,
+                    target_version=current_version,
+                )
+            except (OSError, ValueError):
+                ux.err(
+                    "Could not authenticate the installed target from its durable "
+                    "upgrade receipts; bundle reconciliation was refused."
+                )
+                shutil.rmtree(staging_dir, ignore_errors=True)
+                raise SystemExit(1) from None
+            if installed_authority is None:
+                ux.err(
+                    "The local-observability bundle does not match the installed "
+                    "version, but no verified target-install receipt exists."
+                )
+                ux.subhead(
+                    "No installed files or services were changed; reinstall through "
+                    "the authenticated release resolver.",
+                    indent="    ",
+                )
+                shutil.rmtree(staging_dir, ignore_errors=True)
+                raise SystemExit(1)
+
+        if recovery_authority is not None or installed_authority is not None:
+            ux.warn(
+                "Found an incomplete target transaction; reconciling the installed release before declaring success."
+            )
+            try:
+                recovery_receipt = recovery_authority
+                if recovery_receipt is not None:
+                    authority = load_upgrade_receipt(recovery_receipt)
+                    if authority.status != "pending":
+                        durable_bundle_restart = load_local_bundle_restart_intent(recovery_receipt)
+                        recovery_receipt = begin_upgrade_receipt(
+                            data_dir,
+                            from_version=authority.from_version,
+                            target_version=target_version,
+                            artifacts_verified=checksums is not None and not effective_allow_unverified,
+                        )
+                        if durable_bundle_restart is not None:
+                            record_local_bundle_restart_intent(
+                                recovery_receipt,
+                                restart_required=durable_bundle_restart,
+                            )
+                else:
+                    authority = load_upgrade_receipt(installed_authority)
+                    if (
+                        authority.target_version != target_version
+                        or not authority.artifacts_verified
+                        or authority.status not in {"succeeded", "partial"}
+                    ):
+                        raise ValueError("installed recovery authority changed")
+                    recovery_receipt = begin_upgrade_receipt(
+                        data_dir,
+                        from_version=target_version,
+                        target_version=target_version,
+                        artifacts_verified=True,
+                    )
+                delegate_prior_upgrade_receipts(recovery_receipt)
+            except (OSError, ValueError):
+                ux.err("Could not establish durable target-recovery authority; installed state was not changed.")
+                shutil.rmtree(staging_dir, ignore_errors=True)
+                raise SystemExit(1) from None
+            try:
+                _recover_interrupted_same_version_upgrade(
+                    app,
+                    receipt_path=recovery_receipt,
+                    data_dir=data_dir,
+                    target_version=target_version,
+                    os_name=os_name,
+                    health_timeout=health_timeout,
+                    config_path=active_config_path,
+                    recovery_home=recovery_home,
+                    upgrade_manifest=upgrade_manifest,
+                )
+            finally:
+                shutil.rmtree(staging_dir, ignore_errors=True)
+            return
+
+        # The signed release contract plus target artifacts were authenticated
+        # above. With no interrupted transaction to resume, a same-version
+        # request is a verified no-op rather than an unsafe repair reinstall.
         ux.banner("Version Already Verified")
         ux.ok(
             f"Authenticated the {target_version} release contract; "
@@ -728,8 +857,7 @@ def upgrade(
             _require_hard_cut_preflight_state_unchanged(rollback_plan)
         except OSError:
             ux.err(
-                "Configuration changed after target migration preflight; "
-                "refusing to stop services.",
+                "Configuration changed after target migration preflight; refusing to stop services.",
                 indent="  ",
             )
             ux.subhead(
@@ -747,6 +875,8 @@ def upgrade(
             target_version=target_version,
             artifacts_verified=checksums is not None and not effective_allow_unverified,
         )
+        if checksums is not None and not effective_allow_unverified:
+            delegate_prior_upgrade_receipts(receipt_path)
     except (OSError, ValueError):
         ux.err("Could not create the durable upgrade compliance receipt; installed state was not changed.")
         shutil.rmtree(staging_dir, ignore_errors=True)
@@ -803,8 +933,7 @@ def upgrade(
             finally:
                 shutil.rmtree(staging_dir, ignore_errors=True)
             ux.err(
-                "Configuration changed after rollback custody was committed; "
-                "refusing to stop services.",
+                "Configuration changed after rollback custody was committed; refusing to stop services.",
                 indent="  ",
             )
             ux.subhead(
@@ -917,9 +1046,7 @@ def upgrade(
                     _hard_cut_mutation_token(rollback_plan) if isinstance(rollback_plan, _HardCutRollbackPlan) else None
                 ),
                 observability_v8_preflight_binding=(
-                    hard_cut_preflight_binding
-                    if hard_cut_phase
-                    else _NO_OBSERVABILITY_V8_PREFLIGHT_BINDING
+                    hard_cut_preflight_binding if hard_cut_phase else _NO_OBSERVABILITY_V8_PREFLIGHT_BINDING
                 ),
             )
         except subprocess.CalledProcessError:
@@ -969,31 +1096,32 @@ def upgrade(
             raise
 
         upgrade_phase = "local_observability"
-        if rollback_plan is not None:
-            try:
-                bundle_destination = os.path.join(data_dir, "observability-stack")
-                if os.path.lexists(bundle_destination):
+        try:
+            bundle_destination = os.path.join(data_dir, "observability-stack")
+            if os.path.lexists(bundle_destination):
+                if rollback_plan is not None:
                     if hard_cut_recovery_journal is None:
                         raise OSError("hard-cut bundle refresh lacks durable recovery authority")
                     _mark_hard_cut_bundle_mutation_intent(hard_cut_recovery_journal)
                     local_bundle_mutation_intent = True
-                    local_bundle_upgrade = _run_installed_local_observability_bundle_upgrade(
-                        data_dir,
-                        backup_dir,
-                        target_version,
-                        os_name=os_name,
-                    )
-                else:
-                    local_bundle_upgrade = {"installed": False}
-            except _LocalBundleUpgradeInvocationError as exc:
-                restart_services = False
-                ux.err("Local observability bundle refresh failed; target services remain stopped.")
-                ux.subhead(
-                    f"failure={exc.code} phase={exc.phase}",
-                    indent="    ",
+                local_bundle_upgrade = _run_installed_local_observability_bundle_upgrade(
+                    data_dir,
+                    backup_dir,
+                    target_version,
+                    receipt_path=receipt_path,
+                    os_name=os_name,
                 )
-                ux.subhead(f"Recovery backup: {backup_dir}", indent="    ")
-                raise SystemExit(1) from None
+            else:
+                local_bundle_upgrade = {"installed": False}
+        except _LocalBundleUpgradeInvocationError as exc:
+            restart_services = False
+            ux.err("Local observability bundle refresh failed; target services remain stopped.")
+            ux.subhead(
+                f"failure={exc.code} phase={exc.phase}",
+                indent="    ",
+            )
+            ux.subhead(f"Recovery backup: {backup_dir}", indent="    ")
+            raise SystemExit(1) from None
 
         if local_bundle_upgrade and local_bundle_upgrade.get("installed"):
             changed = local_bundle_upgrade.get("changed_paths", [])
@@ -1115,6 +1243,8 @@ def upgrade(
                     raise
             else:
                 if not upgrade_body_failed:
+                    if checksums is not None and not effective_allow_unverified:
+                        supersede_prior_upgrade_receipts(receipt_path)
                     complete_upgrade_receipt(
                         receipt_path,
                         status="partial" if migration_failed else "succeeded",
@@ -1146,6 +1276,152 @@ def upgrade(
     click.echo()
 
 
+def _recover_interrupted_same_version_upgrade(
+    app: AppContext,
+    *,
+    receipt_path: Path,
+    data_dir: str,
+    target_version: str,
+    os_name: str,
+    health_timeout: int,
+    config_path: str | None,
+    recovery_home: str,
+    upgrade_manifest: dict[str, object] | None,
+) -> None:
+    """Finish target-owned bundle and health phases after an updater crash.
+
+    A normal v8-to-v8 controller installs the target wheel before the target
+    bundle refresh. If the controller is killed in that gap, the next resolver
+    invocation sees ``installed == target``. The pending receipt is the durable
+    authority to run only the unfinished target-owned reconciliation; ordinary
+    same-version requests remain authenticated no-ops.
+    """
+
+    ux.banner("Recovering Interrupted Upgrade")
+    try:
+        receipt = load_upgrade_receipt(receipt_path)
+        if (
+            receipt.status != "pending"
+            or receipt.target_version != target_version
+            or not receipt.artifacts_verified
+            or (
+                _version_key(target_version) >= _version_key(_OBSERVABILITY_V8_MIGRATION_VERSION)
+                and _version_key(receipt.from_version) < _version_key(_OBSERVABILITY_V8_MIGRATION_VERSION)
+            )
+        ):
+            raise ValueError("interrupted upgrade receipt is not resumable")
+        backup_dir = _create_backup(app.cfg, data_dir=data_dir)
+    except (OSError, ValueError):
+        ux.err("Could not establish durable custody for interrupted-upgrade recovery; installed state was not changed.")
+        raise SystemExit(1) from None
+
+    local_bundle_upgrade: dict[str, object] | None = None
+    migration_failed = receipt.migration_status == "degraded"
+    try:
+        if receipt.migration_status in {"pending", "degraded"}:
+            migration_failed = False
+            gateway_command = os.path.join(
+                os.path.expanduser("~/.local/bin"),
+                _installed_gateway_filename(os_name),
+            )
+            gateway_stop_ok = _run_silent(
+                [gateway_command, "stop"],
+                "Gateway stopped for interrupted migration recovery",
+                "Could not stop gateway for interrupted migration recovery",
+                env=_gateway_process_environment(data_dir, config_path=config_path),
+            )
+            _assert_gateway_quiesced(data_dir, gateway_path=gateway_command)
+            if not gateway_stop_ok:
+                ux.warn(
+                    "Gateway stop reported failure, but quiescence verification succeeded.",
+                    indent="  ",
+                )
+            openclaw_home = os.path.expanduser(app.cfg.claw.home_dir if app.cfg else "~/.openclaw")
+            try:
+                count = _run_installed_migrations(
+                    receipt.from_version,
+                    target_version,
+                    openclaw_home,
+                    data_dir,
+                    os_name=os_name,
+                    config_path=config_path,
+                    recovery_home=recovery_home,
+                )
+            except subprocess.CalledProcessError:
+                migration_failed = True
+                count = 0
+            record_upgrade_migrations(
+                receipt_path,
+                migration_count=count,
+                degraded=migration_failed,
+            )
+        _assert_required_cli_migrations(upgrade_manifest, data_dir)
+
+        bundle_destination = os.path.join(data_dir, "observability-stack")
+        if os.path.lexists(bundle_destination):
+            local_bundle_upgrade = _run_installed_local_observability_bundle_upgrade(
+                data_dir,
+                backup_dir,
+                target_version,
+                receipt_path=receipt_path,
+                os_name=os_name,
+            )
+
+        # Verify the already-installed target without reinstalling its wheel or
+        # rerunning migrations. Local-observability readiness is checked below
+        # as a fatal recovery condition instead of the ordinary degraded mode.
+        _start_and_verify_services(
+            app,
+            health_timeout,
+            data_dir=data_dir,
+            local_bundle_upgrade=local_bundle_upgrade,
+            os_name=os_name,
+            expected_version=target_version,
+            strict_local_observability=True,
+            config_path=config_path,
+            recovery_home=recovery_home,
+        )
+        supersede_prior_upgrade_receipts(receipt_path)
+        complete_upgrade_receipt(
+            receipt_path,
+            status="partial" if migration_failed else "succeeded",
+        )
+    except _LocalBundleUpgradeInvocationError as exc:
+        # Keep the recovery receipt pending. The next authenticated invocation
+        # will finalize it as interrupted and retry this bounded phase.
+        ux.err("Interrupted-upgrade local observability recovery did not complete.")
+        ux.subhead(f"failure={exc.code} phase={exc.phase}", indent="    ")
+        ux.subhead(f"Recovery backup: {backup_dir}", indent="    ")
+        raise SystemExit(1) from None
+    except BaseException:
+        # The pending receipt is deliberately retained for the same retry path.
+        ux.err("Interrupted-upgrade health recovery did not complete.")
+        ux.subhead(f"Recovery backup: {backup_dir}", indent="    ")
+        raise
+
+    ux.banner("Upgrade Recovery Complete")
+    ux.ok(f"DefenseClaw {target_version} artifacts, services, and local bundle are healthy")
+    ux.subhead(f"Recovery backup: {backup_dir}", indent="  ")
+
+
+def _installed_local_observability_bundle_needs_reconciliation(
+    data_dir: str,
+    target_version: str,
+) -> bool:
+    """Detect a stale installed bundle without changing operator state."""
+
+    from defenseclaw.bundle_refresh import (
+        LocalObservabilityUpgradeError,
+        installed_local_observability_bundle_version,
+    )
+
+    try:
+        installed_version = installed_local_observability_bundle_version(data_dir)
+    except LocalObservabilityUpgradeError as exc:
+        raise OSError("installed local-observability bundle is not safely readable") from exc
+    return installed_version is not None and installed_version != target_version
+
+
 def _print_hard_cut_rollback_outcome(*, succeeded: bool, backup_dir: str) -> None:
     """Emit one truthful summary for either rollback entry point."""
 
@@ -1175,6 +1451,7 @@ def _start_and_verify_services(
     rollback_plan: _HardCutRollbackPlan | None = None,
     config_path: str | None = None,
     recovery_home: str | None = None,
+    strict_local_observability: bool = False,
 ) -> None:
     """Restart and verify services after every required migration succeeds."""
 
@@ -1252,9 +1529,9 @@ def _start_and_verify_services(
                 os_name=os_name,
             )
         except _LocalBundleUpgradeInvocationError as exc:
-            if rollback_plan is not None:
+            if rollback_plan is not None or strict_local_observability:
                 ux.err(
-                    "Hard-cut local observability readiness failed; refusing target activation.",
+                    "Local observability readiness failed; refusing target activation.",
                     indent="  ",
                 )
                 ux.subhead(f"failure={exc.code} phase={exc.phase}", indent="    ")
@@ -1271,11 +1548,14 @@ def _start_and_verify_services(
         else:
             errors = restart.get("degraded_errors", [])
             if restart.get("restarted") is True and not errors:
+                custody_released = _clear_local_bundle_restart_custody(local_bundle_upgrade)
+                if not custody_released and (rollback_plan is not None or strict_local_observability):
+                    raise SystemExit(1)
                 ux.ok("Local observability restarted; services and dashboard inventory verified")
             else:
-                if rollback_plan is not None:
+                if rollback_plan is not None or strict_local_observability:
                     ux.err(
-                        "Hard-cut local observability stack did not reach the target readiness contract; "
+                        "Local observability stack did not reach the target readiness contract; "
                         "refusing target activation.",
                         indent="  ",
                     )
@@ -1292,9 +1572,36 @@ def _start_and_verify_services(
                     "Recover with: defenseclaw setup local-observability up",
                     indent="    ",
                 )
+    elif local_bundle_upgrade:
+        custody_released = _clear_local_bundle_restart_custody(local_bundle_upgrade)
+        if not custody_released and (rollback_plan is not None or strict_local_observability):
+            raise SystemExit(1)
 
     if isinstance(rollback_plan, _HardCutRollbackPlan):
         _cleanup_hard_cut_mutation_temporaries(rollback_plan)
+
+
+def _clear_local_bundle_restart_custody(local_bundle_upgrade: dict[str, object]) -> bool:
+    receipt_value = local_bundle_upgrade.get("_restart_intent_receipt")
+    if receipt_value is None:
+        return True
+    if not isinstance(receipt_value, str) or not receipt_value:
+        ux.warn(
+            "Local observability is healthy, but its restart custody metadata is invalid; "
+            "a later authenticated upgrade will reconcile it.",
+            indent="  ",
+        )
+        return False
+    try:
+        clear_local_bundle_restart_intent(Path(receipt_value))
+    except (OSError, ValueError, json.JSONDecodeError):
+        ux.warn(
+            "Local observability is healthy, but restart custody cleanup was deferred; "
+            "a later authenticated upgrade will reconcile it.",
+            indent="  ",
+        )
+        return False
+    return True
 
 
 def _reload_post_upgrade_config(
@@ -3845,10 +4152,10 @@ def _install_wheel(
         "--quiet",
     ]
     if exact_environment:
-        # The hard-cut bridge and target carry an authenticated identical
-        # Requires-Dist contract.  Keep the bridge environment byte-for-byte
-        # dependency-stable in both directions; this phase must not contact an
-        # index or rewrite shared packages.
+        # Preflight already proved that the authenticated target metadata is
+        # satisfied by the installed bridge graph. Keep that graph byte-for-byte
+        # stable during the rollback-capable phase: do not contact an index or
+        # rewrite shared packages.
         install_args.extend(("--offline", "--no-deps", "--reinstall"))
     install_args.append(whl_path)
     _run_phase_two_mutator(
@@ -3899,15 +4206,9 @@ def _run_installed_migrations(
     if os_name is None:
         os_name = platform.system().lower()
 
-    binding_supplied = (
-        observability_v8_preflight_binding
-        is not _NO_OBSERVABILITY_V8_PREFLIGHT_BINDING
-    )
+    binding_supplied = observability_v8_preflight_binding is not _NO_OBSERVABILITY_V8_PREFLIGHT_BINDING
     if (mutation_token is not None) != binding_supplied:
-        raise ValueError(
-            "hard-cut mutation token and observability v8 preflight binding "
-            "must be supplied together"
-        )
+        raise ValueError("hard-cut mutation token and observability v8 preflight binding must be supplied together")
 
     venv = _managed_venv_path()
     venv_python = _venv_python_path(venv, os_name)
@@ -3979,20 +4280,38 @@ def _run_installed_local_observability_bundle_upgrade(
     backup_dir: str,
     target_version: str,
     *,
+    receipt_path: Path,
     os_name: str | None = None,
 ) -> dict[str, object]:
     """Run the target wheel's fail-closed bundle transaction when installed."""
 
+    try:
+        receipt = load_upgrade_receipt(receipt_path)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise _LocalBundleUpgradeInvocationError("receipt_invalid", "invoke") from exc
+    if receipt.status != "pending" or not receipt.artifacts_verified or receipt.target_version != target_version:
+        raise _LocalBundleUpgradeInvocationError("receipt_invalid", "invoke")
+
     destination = os.path.join(data_dir, "observability-stack")
     if not os.path.lexists(destination):
-        return {"installed": False}
-    return _run_installed_local_observability_operation(
-        "refresh",
-        data_dir,
-        backup_dir,
-        target_version,
-        os_name=os_name,
-    )
+        result: dict[str, object] = {"installed": False}
+    else:
+        result = _run_installed_local_observability_operation(
+            "refresh",
+            data_dir,
+            backup_dir,
+            target_version,
+            receipt_path=str(receipt_path),
+            os_name=os_name,
+        )
+    durable_restart = load_local_bundle_restart_intent(receipt_path)
+    if durable_restart is not None:
+        reported_restart = result.get("restart_required")
+        if reported_restart is not None and not isinstance(reported_restart, bool):
+            raise _LocalBundleUpgradeInvocationError("result_invalid", "invoke")
+        result["restart_required"] = durable_restart or reported_restart is True
+        result["_restart_intent_receipt"] = str(receipt_path)
+    return result
 
 
 def _run_installed_local_observability_bundle_restart(
@@ -4008,6 +4327,7 @@ def _run_installed_local_observability_bundle_restart(
         data_dir,
         "",
         str(health_timeout),
+        receipt_path="",
         os_name=os_name,
     )
 
@@ -4018,6 +4338,7 @@ def _run_installed_local_observability_operation(
     backup_dir: str,
     value: str,
     *,
+    receipt_path: str,
     os_name: str | None,
 ) -> dict[str, object]:
     if os_name is None:
@@ -4039,19 +4360,26 @@ def _run_installed_local_observability_operation(
     script = """
 import json
 import sys
+from pathlib import Path
 
 from defenseclaw.bundle_refresh import (
     LocalObservabilityUpgradeError,
     restart_upgraded_local_observability_stack,
     upgrade_local_observability_stack,
 )
+from defenseclaw.upgrade_receipt import record_local_bundle_restart_intent
 
 try:
     if sys.argv[1] == "refresh":
+        receipt_path = Path(sys.argv[5])
         result = upgrade_local_observability_stack(
             sys.argv[2],
             sys.argv[3],
             bundle_version=sys.argv[4],
+            restart_intent_recorder=lambda required: record_local_bundle_restart_intent(
+                receipt_path,
+                restart_required=required,
+            ),
         )
     elif sys.argv[1] == "restart":
         result = restart_upgraded_local_observability_stack(
@@ -4066,7 +4394,7 @@ except LocalObservabilityUpgradeError as exc:
 except Exception:
     payload = {"ok": False, "code": "unexpected_failure", "phase": "invoke"}
 
-with open(sys.argv[5], "w", encoding="utf-8") as handle:
+with open(sys.argv[6], "w", encoding="utf-8") as handle:
     json.dump(payload, handle, sort_keys=True)
 sys.exit(0 if payload["ok"] else 1)
 """
@@ -4082,6 +4410,7 @@ sys.exit(0 if payload["ok"] else 1)
                 data_dir,
                 backup_dir,
                 value,
+                receipt_path,
                 result_path,
             ],
             capture_output=True,
@@ -4245,8 +4574,7 @@ def _preflight_hard_cut_observability_migration(
         raise SystemExit(1) from None
     except OSError:
         ux.err(
-            "Target observability migration preflight could not complete safely; "
-            "refusing to change installed state.",
+            "Target observability migration preflight could not complete safely; refusing to change installed state.",
             indent="  ",
         )
         ux.subhead(
@@ -4472,123 +4800,189 @@ def _wheel_dependency_contract(whl_path: str, expected_version: str) -> tuple[st
     return tuple(sorted(item.strip() for item in requirements))
 
 
-def _require_hard_cut_dependency_contract(
-    source_wheel: str,
-    target_wheel: str,
-    *,
-    source_version: str,
-    target_version: str,
-) -> None:
-    source = _wheel_dependency_contract(source_wheel, source_version)
-    target = _wheel_dependency_contract(target_wheel, target_version)
-    promoted = _HARD_CUT_PROMOTED_REQUIREMENTS.get((source_version, target_version), ())
-    expected = tuple(sorted((*source, *promoted)))
-    if target != expected:
-        raise ValueError(
-            "hard-cut target Requires-Dist differs from the authenticated bridge plus "
-            "the reviewed pre-existing runtime promotion; "
-            "publish an explicit dependency migration instead of mutating the bridge environment"
-        )
+def _venv_site_package_directories(python_path: str) -> tuple[str, ...]:
+    """Read the interpreter's import roots without importing target code."""
 
-
-def _canonical_hard_cut_runtime_version(value: object, package: str) -> tuple[int, int, int]:
-    if not isinstance(value, str):
-        raise ValueError(f"installed {package} version is missing")
-    match = re.fullmatch(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)", value)
-    if match is None:
-        raise ValueError(f"installed {package} version is not canonical")
-    return tuple(int(match.group(index)) for index in range(1, 4))
-
-
-def _compatible_hard_cut_dependency_version(value: object, package: str) -> tuple[int, ...]:
-    """Parse the final/post subset admitted by the promoted PEP 440 ranges.
-
-    Importing ``packaging`` here would add an unreviewed bootstrap dependency
-    to the 0.8.4 controller.  The hard-cut requirements exclude prereleases,
-    so the accepted installed forms are release segments with an optional
-    post release and local build label.  Those suffixes do not change whether
-    the release tuple falls inside either promoted runtime range.
-    """
-
-    if not isinstance(value, str):
-        raise ValueError(f"installed {package} version is missing")
-    match = re.fullmatch(
-        r"(?:0!)?"
-        r"(?P<release>\d+(?:\.\d+)*)"
-        r"(?:(?:[-_.]?post[-_.]?\d+)|(?:-\d+))?"
-        r"(?:\+[a-z0-9]+(?:[-_.][a-z0-9]+)*)?",
-        value,
-        flags=re.IGNORECASE,
-    )
-    if match is None:
-        raise ValueError(f"installed {package} version is not a supported PEP 440 final/post release")
-    release = tuple(int(part) for part in match.group("release").split("."))
-    if len(release) < 3:
-        release += (0,) * (3 - len(release))
-    return release
-
-
-def _validate_hard_cut_promoted_runtime_probe(probe: object) -> None:
-    if not isinstance(probe, dict):
-        raise ValueError("installed promoted runtime probe is invalid")
-
-    python_version = _canonical_hard_cut_runtime_version(probe.get("python_version"), "Python")
-    if python_version < (3, 10, 0):
-        raise ValueError("installed Python runtime is below the supported 3.10 floor")
-
-    jsonschema_version = _compatible_hard_cut_dependency_version(probe.get("jsonschema_version"), "jsonschema")
-    if not (jsonschema_version >= (4, 23, 0) and jsonschema_version < (5, 0, 0)):
-        raise ValueError("installed jsonschema runtime is outside 4.23.0 <= version < 5")
-    if probe.get("jsonschema_draft") != "https://json-schema.org/draft/2020-12/schema":
-        raise ValueError("installed jsonschema lacks the Draft 2020-12 validator contract")
-
-    if python_version >= (3, 11, 0):
-        mcp_version = _compatible_hard_cut_dependency_version(probe.get("mcp_version"), "mcp")
-        if not (mcp_version >= (1, 28, 1) and mcp_version < (2, 0, 0)):
-            raise ValueError("installed mcp runtime is outside 1.28.1 <= version < 2")
-        if probe.get("mcp_import") is not True:
-            raise ValueError("installed mcp runtime cannot be imported")
-
-
-def _require_hard_cut_preexisting_promoted_runtime(python_path: str) -> None:
-    """Prove every reviewed target-only runtime already exists without mutation."""
-
-    script = r"""
-import json
-from importlib.metadata import version
-import platform
-import sys
-
-from jsonschema import Draft202012Validator
-
-mcp_version = None
-mcp_import = None
-if sys.version_info >= (3, 11):
-    import mcp
-
-    mcp_version = version("mcp")
-    mcp_import = mcp.__name__ == "mcp"
-
-print(json.dumps({
-    "python_version": platform.python_version(),
-    "jsonschema_version": version("jsonschema"),
-    "jsonschema_draft": Draft202012Validator.META_SCHEMA.get("$schema"),
-    "mcp_version": mcp_version,
-    "mcp_import": mcp_import,
-}, sort_keys=True))
-"""
     completed = subprocess.run(
-        [python_path, "-I", "-B", "-c", script],
+        [
+            python_path,
+            "-I",
+            "-B",
+            "-c",
+            (
+                "import json, sysconfig; "
+                "print(json.dumps(sorted({sysconfig.get_path('purelib'), sysconfig.get_path('platlib')})))"
+            ),
+        ],
         check=True,
         capture_output=True,
         text=True,
         timeout=10,
     )
     try:
-        probe = json.loads(completed.stdout)
+        raw = json.loads(completed.stdout)
     except (json.JSONDecodeError, TypeError) as exc:
-        raise ValueError("installed promoted runtime probe is unreadable") from exc
-    _validate_hard_cut_promoted_runtime_probe(probe)
+        raise ValueError("Python environment paths are unreadable") from exc
+    if not isinstance(raw, list) or not 1 <= len(raw) <= 2 or any(not isinstance(item, str) for item in raw):
+        raise ValueError("Python environment paths are invalid")
+    if any(not os.path.isabs(item) or os.path.islink(item) or not os.path.isdir(item) for item in raw):
+        raise ValueError("Python environment paths are unsafe")
+    paths = tuple(dict.fromkeys(os.path.realpath(item) for item in raw))
+    return paths
+
+
+def _read_stable_distribution_metadata(path: Path, limit: int) -> bytes:
+    """Read one bounded regular metadata file without following replacements."""
+
+    before = path.lstat()
+    if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode) or not 0 < before.st_size <= limit:
+        raise ValueError("installed dependency metadata is incomplete")
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or not os.path.samestat(before, opened):
+            raise ValueError("installed dependency metadata changed while opening")
+        payload = bytearray()
+        while len(payload) <= limit:
+            block = os.read(descriptor, min(64 * 1024, limit + 1 - len(payload)))
+            if not block:
+                break
+            payload.extend(block)
+        after = os.fstat(descriptor)
+        named_after = path.lstat()
+        stable_fields = ("st_mode", "st_size", "st_mtime_ns", "st_ctime_ns")
+        if (
+            len(payload) > limit
+            or len(payload) != opened.st_size
+            or any(getattr(opened, field, None) != getattr(after, field, None) for field in stable_fields)
+            or stat.S_ISLNK(named_after.st_mode)
+            or not stat.S_ISREG(named_after.st_mode)
+            or not os.path.samestat(after, named_after)
+        ):
+            raise ValueError("installed dependency metadata changed while reading")
+        return bytes(payload)
+    finally:
+        os.close(descriptor)
+
+
+def _copy_distribution_metadata(source_directories: tuple[str, ...], destination: str) -> None:
+    """Build a metadata-only image of the installed dependency environment."""
+
+    destination_path = Path(destination)
+    seen: set[str] = set()
+    count = 0
+    for source in source_directories:
+        for entry in sorted(Path(source).iterdir(), key=lambda item: item.name):
+            if not entry.name.endswith(".dist-info"):
+                continue
+            count += 1
+            if count > _MAX_INSTALLED_DISTRIBUTIONS:
+                raise ValueError("installed dependency environment exceeds its distribution bound")
+            if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._+!-]*[.]dist-info", entry.name) is None:
+                raise ValueError("installed dependency metadata has an unsafe name")
+            info = entry.lstat()
+            if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+                raise ValueError("installed dependency metadata is unsafe")
+            metadata_path = entry / "METADATA"
+            wheel_path = entry / "WHEEL"
+            payloads: dict[str, bytes] = {}
+            for name, path, limit in (
+                ("METADATA", metadata_path, _MAX_WHEEL_METADATA_BYTES),
+                ("WHEEL", wheel_path, _MAX_WHEEL_DESCRIPTOR_BYTES),
+            ):
+                payloads[name] = _read_stable_distribution_metadata(path, limit)
+            try:
+                message = email.parser.Parser().parsestr(payloads["METADATA"].decode("utf-8"))
+            except (UnicodeDecodeError, ValueError) as exc:
+                raise ValueError("installed dependency metadata is unreadable") from exc
+            distribution_name = message.get("Name")
+            if not isinstance(distribution_name, str) or not distribution_name.strip():
+                raise ValueError("installed dependency metadata lacks a package name")
+            normalized = re.sub(r"[-_.]+", "-", distribution_name).lower()
+            if normalized == "defenseclaw":
+                continue
+            if normalized in seen:
+                raise ValueError("installed dependency metadata contains duplicate packages")
+            seen.add(normalized)
+            target = destination_path / entry.name
+            target.mkdir(mode=0o700)
+            for name, payload in payloads.items():
+                output = target / name
+                output.write_bytes(payload)
+                os.chmod(output, 0o600)
+
+
+def _require_bridge_environment_accepts_target_wheel(
+    uv: str,
+    venv_python: str,
+    source_wheel: str,
+    target_wheel: str,
+    *,
+    os_name: str,
+) -> None:
+    """Prove source and target metadata against one dependency graph offline.
+
+    The authenticated target wheel may add or tighten any reviewed direct
+    requirement. The handoff remains rollback-safe only when the installed
+    bridge dependency graph already satisfies that exact target metadata, so
+    validate both wheels in a private metadata-only shadow environment. This
+    delegates PEP 440/508 and marker evaluation to uv without release-number
+    or package-name allowlists and never mutates the live bridge venv.
+    """
+
+    shadow_root = tempfile.mkdtemp(prefix="defenseclaw-hard-cut-dependencies-")
+    shadow_venv = os.path.join(shadow_root, "venv")
+    try:
+        subprocess.run(
+            [
+                uv,
+                "--no-config",
+                "venv",
+                shadow_venv,
+                "--python",
+                venv_python,
+                "--offline",
+                "--quiet",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=_DEPENDENCY_PREFLIGHT_TIMEOUT_SECONDS,
+        )
+        shadow_python = _venv_python_path(shadow_venv, os_name)
+        source_directories = _venv_site_package_directories(venv_python)
+        shadow_directories = _venv_site_package_directories(shadow_python)
+        _copy_distribution_metadata(source_directories, shadow_directories[0])
+        for wheel in (source_wheel, target_wheel):
+            subprocess.run(
+                [
+                    uv,
+                    "--no-config",
+                    "pip",
+                    "install",
+                    "--python",
+                    shadow_python,
+                    "--offline",
+                    "--no-deps",
+                    "--reinstall",
+                    "--quiet",
+                    wheel,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=_DEPENDENCY_PREFLIGHT_TIMEOUT_SECONDS,
+            )
+            subprocess.run(
+                [uv, "--no-config", "pip", "check", "--python", shadow_python],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=_DEPENDENCY_PREFLIGHT_TIMEOUT_SECONDS,
+            )
+    finally:
+        shutil.rmtree(shadow_root, ignore_errors=True)
 
 
 def _require_target_phase_two_mutator_wrapper(whl_path: str) -> None:
@@ -4717,39 +5111,21 @@ def _preflight_wheel_install(
         if not os.path.isfile(venv_python):
             _fail_wheel_preflight("Hard-cut bridge managed environment is missing.")
         try:
-            _require_hard_cut_dependency_contract(
-                hard_cut_source_wheel,
-                whl_path,
-                source_version=source_version,
-                target_version=target_version,
-            )
-            _require_hard_cut_preexisting_promoted_runtime(venv_python)
             subprocess.run(
                 [uv, "--no-config", "pip", "check", "--python", venv_python],
                 check=True,
                 capture_output=True,
                 text=True,
+                timeout=_DEPENDENCY_PREFLIGHT_TIMEOUT_SECONDS,
             )
-            subprocess.run(
-                [
-                    uv,
-                    "--no-config",
-                    "pip",
-                    "install",
-                    "--python",
-                    venv_python,
-                    "--dry-run",
-                    "--offline",
-                    "--no-deps",
-                    "--reinstall",
-                    "--quiet",
-                    whl_path,
-                ],
-                check=True,
-                capture_output=True,
-                text=True,
+            _require_bridge_environment_accepts_target_wheel(
+                uv,
+                venv_python,
+                hard_cut_source_wheel,
+                whl_path,
+                os_name=os_name,
             )
-        except (ValueError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        except (OSError, ValueError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
             _fail_wheel_preflight(
                 "Hard-cut target cannot preserve the authenticated bridge dependency environment.",
                 exc if isinstance(exc, subprocess.CalledProcessError) else None,
@@ -4766,10 +5142,14 @@ def _preflight_wheel_install(
                 check=True,
                 capture_output=True,
                 text=True,
+                timeout=_DEPENDENCY_PREFLIGHT_TIMEOUT_SECONDS,
             )
-        except subprocess.CalledProcessError as exc:
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
             shutil.rmtree(cleanup_dir, ignore_errors=True)
-            _fail_wheel_preflight("Could not create Python CLI preflight environment.", exc)
+            _fail_wheel_preflight(
+                "Could not create Python CLI preflight environment.",
+                exc if isinstance(exc, subprocess.CalledProcessError) else None,
+            )
         venv_python = _venv_python_path(preflight_venv, os_name)
 
     try:
@@ -4778,9 +5158,13 @@ def _preflight_wheel_install(
             check=True,
             capture_output=True,
             text=True,
+            timeout=_DEPENDENCY_PREFLIGHT_TIMEOUT_SECONDS,
         )
-    except subprocess.CalledProcessError as exc:
-        _fail_wheel_preflight("Python CLI wheel dependencies are unsatisfiable.", exc)
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        _fail_wheel_preflight(
+            "Python CLI wheel dependencies are unsatisfiable.",
+            exc if isinstance(exc, subprocess.CalledProcessError) else None,
+        )
     finally:
         if cleanup_dir is not None:
             shutil.rmtree(cleanup_dir, ignore_errors=True)
@@ -5594,14 +5978,8 @@ def _require_hard_cut_preflight_binding_matches_rollback(
     if (
         not isinstance(expected_environment_present, bool)
         or environment_snapshot.existed != expected_environment_present
-        or (
-            expected_environment_present
-            and environment_snapshot.sha256 != expected_environment_sha256
-        )
-        or (
-            not expected_environment_present
-            and expected_environment_sha256 != hashlib.sha256(b"").hexdigest()
-        )
+        or (expected_environment_present and environment_snapshot.sha256 != expected_environment_sha256)
+        or (not expected_environment_present and expected_environment_sha256 != hashlib.sha256(b"").hexdigest())
     ):
         raise OSError("hard-cut migration preflight environment changed before rollback capture")
 
@@ -5645,12 +6023,7 @@ def _hash_stable_hard_cut_migration_source(
     ):
         raise OSError("hard-cut migration source changed after rollback capture")
 
-    flags = (
-        os.O_RDONLY
-        | getattr(os, "O_BINARY", 0)
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     try:
         descriptor = os.open(path, flags)
     except OSError:
@@ -5701,11 +6074,7 @@ def _hash_stable_hard_cut_migration_source(
             or getattr(named_after, "st_file_attributes", 0) & 0x00000400
             or not stat.S_ISREG(named_after.st_mode)
             or not _rollback_named_capture_matches(named_after, opened_after)
-            or (
-                os.name == "nt"
-                and _rollback_capture_identity(named_after)
-                != _rollback_capture_identity(named_before)
-            )
+            or (os.name == "nt" and _rollback_capture_identity(named_after) != _rollback_capture_identity(named_before))
             or stat.S_IMODE(named_after.st_mode) != snapshot.mode
         ):
             raise OSError("hard-cut migration source changed after rollback capture")
@@ -8675,14 +9044,10 @@ def _run_silent(
             kwargs["env"] = env
         result = _run_phase_two_mutator(cmd, **kwargs)
         combined_output = "\n".join(
-            stripped
-            for part in (result.stderr, result.stdout)
-            if isinstance(part, str) and (stripped := part.strip())
+            stripped for part in (result.stderr, result.stdout) if isinstance(part, str) and (stripped := part.strip())
         )
         output_casefold = combined_output.casefold()
-        matched_failure_marker = any(
-            marker.casefold() in output_casefold for marker in failure_output_markers
-        )
+        matched_failure_marker = any(marker.casefold() in output_casefold for marker in failure_output_markers)
         if result.returncode == 0 and not matched_failure_marker:
             ux.ok(ok_msg)
             return True

--- a/cli/defenseclaw/commands/cmd_upgrade.py
+++ b/cli/defenseclaw/commands/cmd_upgrade.py
@@ -1355,7 +1355,20 @@ def _recover_interrupted_same_version_upgrade(
                 migration_count=count,
                 degraded=migration_failed,
             )
-        _assert_required_cli_migrations(upgrade_manifest, data_dir)
+        try:
+            _assert_required_cli_migrations(upgrade_manifest, data_dir)
+        except BaseException:
+            # A migration child can exit successfully without recording every
+            # release-required cursor. Keep the pending receipt retryable so a
+            # later authenticated recovery reruns the target migrations.
+            latest_receipt = load_upgrade_receipt(receipt_path)
+            if latest_receipt.status == "pending" and latest_receipt.migration_status == "completed":
+                record_upgrade_migrations(
+                    receipt_path,
+                    migration_count=latest_receipt.migration_count or 0,
+                    degraded=True,
+                )
+            raise
 
         bundle_destination = os.path.join(data_dir, "observability-stack")
         if os.path.lexists(bundle_destination):

--- a/cli/defenseclaw/config.py
+++ b/cli/defenseclaw/config.py
@@ -95,8 +95,9 @@ def source_config_version(*, path: str | None = None) -> int | None:
     """Read only ``config_version`` without loading either runtime schema.
 
     The 0.8.4 bridge remains a config-v7 runtime.  It uses this bounded YAML
-    node inspection solely to prove that the separately verified 0.8.5 wheel
-    can migrate the source before any installed artifact is changed.
+    node inspection solely to prove that the separately verified first-v8-or-
+    later target wheel can migrate the source before any installed artifact is
+    changed.
 
     This preflight deliberately does not source ``.env``, construct legacy
     compatibility dataclasses, resolve secrets, or apply runtime defaults.

--- a/cli/defenseclaw/migrations.py
+++ b/cli/defenseclaw/migrations.py
@@ -274,8 +274,7 @@ class ObservabilityV8PreflightBinding:
         present = payload.get("environment_file_present")
         digests = {key: payload.get(key) for key in fields if key.endswith("_sha256")}
         if not isinstance(present, bool) or any(
-            not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{64}", value) is None
-            for value in digests.values()
+            not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{64}", value) is None for value in digests.values()
         ):
             raise ObservabilityV8UpgradeMigrationError("preflight_binding_invalid")
         return cls(
@@ -302,8 +301,8 @@ def _prepare_observability_v8_migration(
         # command creates a native v8 document.
         return None
 
-    environment, environment_file_present, environment_file_sha256 = (
-        _observability_v8_upgrade_environment_snapshot(environment_path)
+    environment, environment_file_present, environment_file_sha256 = _observability_v8_upgrade_environment_snapshot(
+        environment_path
     )
     environment.pop(_OBSERVABILITY_V8_PREFLIGHT_BINDING_ENV, None)
     environment.pop(_UPGRADE_MUTATION_TOKEN_ENV, None)
@@ -381,22 +380,13 @@ def _read_stable_observability_v8_upgrade_file(
         raise ObservabilityV8UpgradeMigrationError(failure_code) from None
     if (
         stat.S_ISLNK(named_before.st_mode)
-        or getattr(named_before, "st_file_attributes", 0)
-        & _WINDOWS_REPARSE_POINT_ATTRIBUTE
+        or getattr(named_before, "st_file_attributes", 0) & _WINDOWS_REPARSE_POINT_ATTRIBUTE
         or not stat.S_ISREG(named_before.st_mode)
-        or (
-            not allow_oversize_sentinel
-            and named_before.st_size > _MAX_OBSERVABILITY_V8_UPGRADE_FILE_BYTES
-        )
+        or (not allow_oversize_sentinel and named_before.st_size > _MAX_OBSERVABILITY_V8_UPGRADE_FILE_BYTES)
     ):
         raise ObservabilityV8UpgradeMigrationError(failure_code)
 
-    flags = (
-        os.O_RDONLY
-        | getattr(os, "O_BINARY", 0)
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     descriptor = -1
     try:
         descriptor = os.open(path, flags)
@@ -407,10 +397,7 @@ def _read_stable_observability_v8_upgrade_file(
                 opened_before,
                 named_before,
             )
-            or (
-                not allow_oversize_sentinel
-                and opened_before.st_size > _MAX_OBSERVABILITY_V8_UPGRADE_FILE_BYTES
-            )
+            or (not allow_oversize_sentinel and opened_before.st_size > _MAX_OBSERVABILITY_V8_UPGRADE_FILE_BYTES)
         ):
             raise ObservabilityV8UpgradeMigrationError(failure_code)
 
@@ -433,10 +420,7 @@ def _read_stable_observability_v8_upgrade_file(
         except OSError:
             raise ObservabilityV8UpgradeMigrationError(failure_code) from None
         if (
-            (
-                len(payload) > _MAX_OBSERVABILITY_V8_UPGRADE_FILE_BYTES
-                and not allow_oversize_sentinel
-            )
+            (len(payload) > _MAX_OBSERVABILITY_V8_UPGRADE_FILE_BYTES and not allow_oversize_sentinel)
             or not _observability_v8_upgrade_file_snapshot_unchanged(
                 opened_before,
                 opened_after,
@@ -446,17 +430,13 @@ def _read_stable_observability_v8_upgrade_file(
                 named_after,
             )
             or stat.S_ISLNK(named_after.st_mode)
-            or getattr(named_after, "st_file_attributes", 0)
-            & _WINDOWS_REPARSE_POINT_ATTRIBUTE
+            or getattr(named_after, "st_file_attributes", 0) & _WINDOWS_REPARSE_POINT_ATTRIBUTE
             or not stat.S_ISREG(named_after.st_mode)
             or not _observability_v8_upgrade_named_snapshot_unchanged(
                 opened_after,
                 named_after,
             )
-            or (
-                len(payload) <= _MAX_OBSERVABILITY_V8_UPGRADE_FILE_BYTES
-                and len(payload) != opened_after.st_size
-            )
+            or (len(payload) <= _MAX_OBSERVABILITY_V8_UPGRADE_FILE_BYTES and len(payload) != opened_after.st_size)
         ):
             raise ObservabilityV8UpgradeMigrationError(failure_code)
         return bytes(payload)
@@ -499,9 +479,7 @@ def preflight_observability_v8_upgrade(
         return None
 
     validation_environment = dict(prepared.environment)
-    validation_environment.update(
-        {edit.name: edit.value for edit in prepared.migration.environment_edits}
-    )
+    validation_environment.update({edit.name: edit.value for edit in prepared.migration.environment_edits})
     _validate_observability_v8_candidate(
         prepared.migration.candidate,
         validation_environment,
@@ -537,8 +515,7 @@ def _observability_v8_preflight_binding(
             for dependency in prepared.migration.environment_dependencies
         ),
         environment_edits_sha256=_observability_v8_binding_rows_sha256(
-            (edit.name, edit.value_sha256, edit.operation)
-            for edit in prepared.migration.environment_edits
+            (edit.name, edit.value_sha256, edit.operation) for edit in prepared.migration.environment_edits
         ),
     )
 
@@ -556,9 +533,15 @@ def _observability_v8_binding_rows_sha256(
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _expected_observability_v8_preflight_binding(
-) -> tuple[bool, ObservabilityV8PreflightBinding | None]:
-    if not os.environ.get(_UPGRADE_MUTATION_TOKEN_ENV):
+def _valid_upgrade_mutation_token() -> bool:
+    """Return whether the controller supplied one filename-safe capability."""
+
+    token = os.environ.get(_UPGRADE_MUTATION_TOKEN_ENV)
+    return isinstance(token, str) and re.fullmatch(r"[0-9a-f]{32}", token) is not None
+
+
+def _expected_observability_v8_preflight_binding() -> tuple[bool, ObservabilityV8PreflightBinding | None]:
+    if not _valid_upgrade_mutation_token():
         return False, None
     raw = os.environ.get(_OBSERVABILITY_V8_PREFLIGHT_BINDING_ENV)
     if raw is None:
@@ -572,6 +555,18 @@ def _expected_observability_v8_preflight_binding(
     if payload is None:
         return True, None
     return True, ObservabilityV8PreflightBinding.from_payload(payload)
+
+
+def _controller_has_hard_cut_bundle_custody() -> bool:
+    """Return whether the child received the paired hard-cut capability."""
+
+    if not _valid_upgrade_mutation_token():
+        return False
+    try:
+        binding_present, _binding = _expected_observability_v8_preflight_binding()
+    except ObservabilityV8UpgradeMigrationError:
+        return False
+    return binding_present
 
 
 def _migrate_observability_v8(ctx: MigrationContext) -> None:
@@ -594,17 +589,13 @@ def _migrate_observability_v8(ctx: MigrationContext) -> None:
     config_path = os.path.abspath(os.path.expanduser(ctx.active_config_path()))
     environment_path = os.path.join(data_dir, ".env")
     _assert_observability_v8_upgrade_quiesced(data_dir)
-    expected_binding_present, expected_binding = (
-        _expected_observability_v8_preflight_binding()
-    )
+    expected_binding_present, expected_binding = _expected_observability_v8_preflight_binding()
     prepared = _prepare_observability_v8_migration(
         data_dir=data_dir,
         config_path=config_path,
     )
     if expected_binding_present:
-        current_binding = (
-            _observability_v8_preflight_binding(prepared) if prepared is not None else None
-        )
+        current_binding = _observability_v8_preflight_binding(prepared) if prepared is not None else None
         if current_binding != expected_binding:
             raise ObservabilityV8UpgradeMigrationError("preflight_source_changed")
     if prepared is None:
@@ -646,9 +637,7 @@ def _migrate_observability_v8(ctx: MigrationContext) -> None:
         # of target-private exception classes. Preserve the value-free refusal
         # code used by the controller when a source changed after preflight.
         if getattr(exc, "code", None) == "preflight_source_changed":
-            raise ObservabilityV8UpgradeMigrationError(
-                "preflight_source_changed"
-            ) from None
+            raise ObservabilityV8UpgradeMigrationError("preflight_source_changed") from None
         raise
     _refresh_observability_v8_bundle_for_legacy_upgrader(ctx, data_dir, activation)
     if activation.activated:
@@ -659,6 +648,8 @@ def _refresh_observability_v8_bundle_for_legacy_upgrader(
     ctx: MigrationContext,
     data_dir: str,
     activation,
+    *,
+    restart_intent_receipt: str | None = None,
 ) -> None:
     """Bridge released upgrade clients to the target bundle transaction.
 
@@ -681,6 +672,7 @@ def _refresh_observability_v8_bundle_for_legacy_upgrader(
         data_dir,
         backup_directory,
         ctx.to_version,
+        restart_intent_receipt=restart_intent_receipt,
     )
     if result.get("installed") is True:
         ctx.changes.append("refreshed local observability bundle for the target release")
@@ -748,6 +740,8 @@ def _run_observability_v8_bundle_upgrade_in_target(
     data_dir: str,
     backup_directory: str,
     target_version: str,
+    *,
+    restart_intent_receipt: str | None = None,
 ) -> dict[str, object]:
     """Refresh/restart through a clean interpreter from the installed wheel."""
 
@@ -756,34 +750,59 @@ def _run_observability_v8_bundle_upgrade_in_target(
     script = """
 import json
 import sys
+from pathlib import Path
 
 from defenseclaw.bundle_refresh import (
     LocalObservabilityUpgradeError,
     restart_upgraded_local_observability_stack,
     upgrade_local_observability_stack,
 )
+from defenseclaw.upgrade_receipt import (
+    clear_local_bundle_restart_intent,
+    record_local_bundle_restart_intent,
+)
 
 try:
+    receipt = Path(sys.argv[4]) if sys.argv[4] else None
     result = upgrade_local_observability_stack(
         sys.argv[1],
         sys.argv[2],
         bundle_version=sys.argv[3],
+        restart_intent_recorder=(
+            None
+            if receipt is None
+            else lambda required: record_local_bundle_restart_intent(
+                receipt,
+                restart_required=required,
+            )
+        ),
     )
     payload = result.to_dict()
     payload["ok"] = True
+    restart_succeeded = not result.restart_required
     if result.restart_required:
         try:
             restarted = restart_upgraded_local_observability_stack(sys.argv[1])
             payload["restarted"] = restarted.restarted
             payload["degraded_errors"] = list(restarted.degraded_errors)
+            restart_succeeded = restarted.restarted and not restarted.degraded_errors
         except LocalObservabilityUpgradeError as exc:
             payload["degraded_errors"] = [f"{exc.code}:{exc.phase}"]
+    if receipt is not None and restart_succeeded:
+        try:
+            clear_local_bundle_restart_intent(receipt)
+        except Exception:
+            degraded_errors = payload.setdefault("degraded_errors", [])
+            if isinstance(degraded_errors, list):
+                degraded_errors.append("restart_intent_cleanup_failed")
+            else:
+                payload["degraded_errors"] = ["restart_intent_cleanup_failed"]
 except LocalObservabilityUpgradeError as exc:
     payload = {"ok": False, "code": exc.code, "phase": exc.phase}
 except Exception:
     payload = {"ok": False, "code": "unexpected_failure", "phase": "invoke"}
 
-with open(sys.argv[4], "w", encoding="utf-8") as handle:
+with open(sys.argv[5], "w", encoding="utf-8") as handle:
     json.dump(payload, handle, sort_keys=True)
 sys.exit(0 if payload["ok"] else 1)
 """
@@ -796,6 +815,7 @@ sys.exit(0 if payload["ok"] else 1)
                 data_dir,
                 backup_directory,
                 target_version,
+                restart_intent_receipt or "",
                 result_path,
             ],
             capture_output=True,
@@ -857,9 +877,7 @@ def _assert_observability_v8_upgrade_quiesced(data_dir: str) -> None:
 def _observability_v8_upgrade_environment(environment_path: str) -> dict[str, str]:
     """Return the active dotenv plus ambient overrides without mutation."""
 
-    snapshot, _present, _sha256 = _observability_v8_upgrade_environment_snapshot(
-        environment_path
-    )
+    snapshot, _present, _sha256 = _observability_v8_upgrade_environment_snapshot(environment_path)
     return snapshot
 
 
@@ -868,9 +886,7 @@ def _observability_v8_upgrade_environment_snapshot(
 ) -> tuple[dict[str, str], bool, str]:
     """Return parsed values and a value-free identity of the exact dotenv bytes."""
 
-    snapshot, present, digest = _read_observability_v8_upgrade_dotenv_snapshot(
-        environment_path
-    )
+    snapshot, present, digest = _read_observability_v8_upgrade_dotenv_snapshot(environment_path)
     snapshot.update(os.environ)
     return snapshot, present, digest
 
@@ -878,9 +894,7 @@ def _observability_v8_upgrade_environment_snapshot(
 def _read_observability_v8_upgrade_dotenv(environment_path: str) -> dict[str, str]:
     """Read the exact active dotenv without the legacy parser's silent loss."""
 
-    snapshot, _present, _sha256 = _read_observability_v8_upgrade_dotenv_snapshot(
-        environment_path
-    )
+    snapshot, _present, _sha256 = _read_observability_v8_upgrade_dotenv_snapshot(environment_path)
     return snapshot
 
 
@@ -3085,6 +3099,7 @@ def run_migrations(
     data_dir: str | None = None,
     *,
     upgrade_handles_local_bundle: bool = False,
+    controller_owns_local_bundle_transaction: bool = False,
 ) -> int:
     """Run all applicable migrations up to ``to_version``.
 
@@ -3131,6 +3146,15 @@ def run_migrations(
     so that operators with a non-default ``DEFENSECLAW_HOME`` get
     their migration applied at the right path.
 
+    ``controller_owns_local_bundle_transaction`` is a capability handshake,
+    not a release-version check. Controllers that advertise it reconcile the
+    installed local-observability bundle after migrations. A controller that
+    only advertises the older ``upgrade_handles_local_bundle`` boolean is the
+    published v8 controller whose normal v8-to-v8 path skipped that phase; the
+    target wheel repairs the omission after the migration loop. Authenticated
+    hard-cut controllers retain exclusive rollback custody and are never
+    repaired from inside the migration runner.
+
     Returns the number of migrations actually executed (excludes
     cursor-skipped ones). Failures don't increment the counter and
     don't leave a cursor entry — the next upgrade will retry them.
@@ -3162,6 +3186,7 @@ def run_migrations(
     to_t = _ver_tuple(to_version)
     same_version_reapply = from_t == to_t
     applied_count = 0
+    migration_failed = False
 
     # Load the cursor; treat "missing" / "unparseable" / "future
     # schema" as "first upgrade on this host" and bootstrap from
@@ -3241,12 +3266,13 @@ def run_migrations(
             data_dir=data_dir,
             from_version=from_version,
             to_version=to_version,
-            upgrade_handles_local_bundle=upgrade_handles_local_bundle,
+            upgrade_handles_local_bundle=(upgrade_handles_local_bundle or controller_owns_local_bundle_transaction),
         )
         try:
             fn(ctx)
             ux.ok(f"Migration {ver} applied.", indent="    ")
         except Exception as exc:  # noqa: BLE001 — never abort upgrade on migration error
+            migration_failed = True
             ux.err(f"migration {ver} failed: {exc}", indent="    ")
             ux.subhead(
                 "upgrade will continue; run 'defenseclaw doctor --fix' afterwards",
@@ -3273,5 +3299,61 @@ def run_migrations(
             migration_state.save(data_dir, state)
         except OSError as exc:
             ux.warn(f"could not persist migration cursor after {ver}: {exc}", indent="    ")
+
+    normalized_data_dir = os.path.abspath(os.path.expanduser(data_dir))
+    local_bundle_installed = os.path.lexists(os.path.join(normalized_data_dir, "observability-stack"))
+    if (
+        upgrade_handles_local_bundle
+        and not controller_owns_local_bundle_transaction
+        and not _controller_has_hard_cut_bundle_custody()
+        and not migration_failed
+        and local_bundle_installed
+    ):
+        # Compatibility with the immutable first v8 controller. It claimed
+        # ownership of bundle refresh but only executed that phase for a
+        # hard-cut rollback plan, so ordinary v8-to-v8 upgrades left the
+        # installed bundle stamped at the source release. Reconcile from the
+        # authenticated target wheel without naming either release. The
+        # mutation token suppresses this fallback during a staged hard cut,
+        # where the bridge controller owns the recovery journal and performs
+        # the refresh after required migrations.
+        legacy_context = MigrationContext(
+            openclaw_home=openclaw_home,
+            data_dir=normalized_data_dir,
+            from_version=from_version,
+            to_version=to_version,
+        )
+        try:
+            from defenseclaw.upgrade_receipt import find_resumable_upgrade_receipt
+
+            restart_intent_receipt = find_resumable_upgrade_receipt(
+                normalized_data_dir,
+                target_version=to_version,
+            )
+        except (OSError, ValueError):
+            raise ObservabilityV8UpgradeMigrationError("local_bundle_receipt_invalid") from None
+        if restart_intent_receipt is None:
+            # Every published controller that advertises the legacy bundle
+            # ownership flag creates this authenticated receipt before target
+            # mutation. Older pre-receipt controllers do not advertise the
+            # flag and run the migration-owned refresh path above instead.
+            raise ObservabilityV8UpgradeMigrationError("local_bundle_receipt_missing")
+        _refresh_observability_v8_bundle_for_legacy_upgrader(
+            legacy_context,
+            normalized_data_dir,
+            None,
+            restart_intent_receipt=os.fspath(restart_intent_receipt),
+        )
+    elif (
+        migration_failed
+        and upgrade_handles_local_bundle
+        and not controller_owns_local_bundle_transaction
+        and not _controller_has_hard_cut_bundle_custody()
+        and local_bundle_installed
+    ):
+        ux.warn(
+            "local observability bundle refresh was deferred because a target migration failed",
+            indent="    ",
+        )
 
     return applied_count

--- a/cli/defenseclaw/upgrade_receipt.py
+++ b/cli/defenseclaw/upgrade_receipt.py
@@ -26,6 +26,12 @@ UPGRADE_RECEIPT_DIRECTORY: Final[str] = ".upgrade-receipts"
 UPGRADE_RECEIPT_SCHEMA_VERSION: Final[int] = 1
 MAX_UPGRADE_RECEIPTS: Final[int] = 64
 MAX_UPGRADE_RECEIPT_BYTES: Final[int] = 16 * 1024
+MAX_LOCAL_BUNDLE_INTENT_BYTES: Final[int] = 1024
+MAX_UPGRADE_SUPERSESSION_BYTES: Final[int] = 1024
+_LOCAL_BUNDLE_INTENT_SCHEMA_VERSION: Final[int] = 1
+_LOCAL_BUNDLE_INTENT_SUFFIX: Final[str] = ".local-bundle-intent"
+_UPGRADE_SUPERSESSION_SCHEMA_VERSION: Final[int] = 1
+_UPGRADE_SUPERSESSION_SUFFIX: Final[str] = ".superseded-by"
 
 _VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
 _STATUSES = frozenset({"pending", "succeeded", "partial", "failed", "rolled_back"})
@@ -42,6 +48,16 @@ _FAILURE_CODES = frozenset(
         "health_check_failed",
         "interrupted",
         "rollback_detected",
+    }
+)
+_RECOVERABLE_TARGET_FAILURE_CODES = frozenset(
+    {
+        "migration_failed",
+        "required_migration_failed",
+        "local_observability_failed",
+        "startup_failed",
+        "health_check_failed",
+        "interrupted",
     }
 )
 
@@ -74,6 +90,14 @@ class UpgradeReceipt:
             "artifacts_verified": self.artifacts_verified,
             "failure_code": self.failure_code,
         }
+
+
+@dataclass(frozen=True)
+class UpgradeReceiptSupersession:
+    receipt_id: str
+    target_version: str
+    superseded_by_receipt_id: str
+    health_proven: bool
 
 
 def begin_upgrade_receipt(
@@ -149,7 +173,274 @@ def complete_upgrade_receipt(
     )
     _validate(updated)
     _atomic_write(path, updated)
+    remove_bundle_intent = status == "rolled_back"
+    if status in {"succeeded", "partial"}:
+        try:
+            remove_bundle_intent = load_local_bundle_restart_intent(path) is False
+        except (OSError, ValueError, json.JSONDecodeError):
+            remove_bundle_intent = False
+    if remove_bundle_intent:
+        try:
+            _local_bundle_intent_path(path, updated).unlink()
+        except OSError:
+            pass
     return updated
+
+
+def record_local_bundle_restart_intent(path: Path, *, restart_required: bool) -> bool:
+    """Durably bind a monotonic bundle restart requirement to one attempt."""
+
+    if not isinstance(restart_required, bool):
+        raise ValueError("local bundle restart intent must be boolean")
+    receipt = load_upgrade_receipt(path)
+    if receipt.status != "pending" or not receipt.artifacts_verified:
+        raise ValueError("local bundle restart intent requires a verified pending receipt")
+    existing = load_local_bundle_restart_intent(path)
+    durable = restart_required or existing is True
+    payload = {
+        "schema_version": _LOCAL_BUNDLE_INTENT_SCHEMA_VERSION,
+        "receipt_id": receipt.receipt_id,
+        "target_version": receipt.target_version,
+        "restart_required": durable,
+    }
+    _atomic_write_private_json(
+        _local_bundle_intent_path(path, receipt),
+        payload,
+        maximum=MAX_LOCAL_BUNDLE_INTENT_BYTES,
+    )
+    return durable
+
+
+def load_local_bundle_restart_intent(path: Path) -> bool | None:
+    """Read one receipt-bound restart requirement without following links."""
+
+    receipt = load_upgrade_receipt(path)
+    intent_path = _local_bundle_intent_path(path, receipt)
+    payload = _load_private_json(
+        intent_path,
+        maximum=MAX_LOCAL_BUNDLE_INTENT_BYTES,
+        kind="local bundle restart intent",
+    )
+    if payload is None:
+        return None
+    if (
+        not isinstance(payload, dict)
+        or set(payload) != {"schema_version", "receipt_id", "target_version", "restart_required"}
+        or payload["schema_version"] != _LOCAL_BUNDLE_INTENT_SCHEMA_VERSION
+        or payload["receipt_id"] != receipt.receipt_id
+        or payload["target_version"] != receipt.target_version
+        or not isinstance(payload["restart_required"], bool)
+    ):
+        raise ValueError("local bundle restart intent is invalid")
+    return payload["restart_required"]
+
+
+def record_upgrade_receipt_supersession(
+    path: Path,
+    *,
+    replacement_path: Path,
+    health_proven: bool,
+) -> str:
+    """Durably transfer retry authority from one terminal receipt to a pending one."""
+
+    receipt = load_upgrade_receipt(path)
+    replacement = load_upgrade_receipt(replacement_path)
+    if (
+        receipt.status not in _TERMINAL_STATUSES
+        or not receipt.artifacts_verified
+        or replacement.status != "pending"
+        or not replacement.artifacts_verified
+        or receipt.target_version != replacement.target_version
+        or path.parent != replacement_path.parent
+        or path == replacement_path
+    ):
+        raise ValueError("upgrade receipt supersession requires one verified target retry")
+    if not isinstance(health_proven, bool):
+        raise ValueError("upgrade receipt supersession phase must be boolean")
+    existing = load_upgrade_receipt_supersession(path)
+    if existing is not None and existing.health_proven:
+        return existing.superseded_by_receipt_id
+    payload = {
+        "schema_version": _UPGRADE_SUPERSESSION_SCHEMA_VERSION,
+        "receipt_id": receipt.receipt_id,
+        "target_version": receipt.target_version,
+        "superseded_by_receipt_id": replacement.receipt_id,
+        "health_proven": health_proven,
+    }
+    _atomic_write_private_json(
+        _upgrade_supersession_path(path, receipt),
+        payload,
+        maximum=MAX_UPGRADE_SUPERSESSION_BYTES,
+    )
+    return replacement.receipt_id
+
+
+def load_upgrade_receipt_supersession(path: Path) -> UpgradeReceiptSupersession | None:
+    """Return the receipt ID that durably owns a superseded attempt."""
+
+    receipt = load_upgrade_receipt(path)
+    payload = _load_private_json(
+        _upgrade_supersession_path(path, receipt),
+        maximum=MAX_UPGRADE_SUPERSESSION_BYTES,
+        kind="upgrade receipt supersession",
+    )
+    if payload is None:
+        return None
+    if (
+        not isinstance(payload, dict)
+        or set(payload)
+        != {
+            "schema_version",
+            "receipt_id",
+            "target_version",
+            "superseded_by_receipt_id",
+            "health_proven",
+        }
+        or payload["schema_version"] != _UPGRADE_SUPERSESSION_SCHEMA_VERSION
+        or payload["receipt_id"] != receipt.receipt_id
+        or payload["target_version"] != receipt.target_version
+        or not isinstance(payload["health_proven"], bool)
+    ):
+        raise ValueError("upgrade receipt supersession is invalid")
+    replacement_id = payload["superseded_by_receipt_id"]
+    try:
+        parsed_id = uuid.UUID(replacement_id)
+    except (ValueError, TypeError, AttributeError) as exc:
+        raise ValueError("upgrade receipt supersession is invalid") from exc
+    if str(parsed_id) != replacement_id or replacement_id == receipt.receipt_id:
+        raise ValueError("upgrade receipt supersession is invalid")
+    return UpgradeReceiptSupersession(
+        receipt_id=receipt.receipt_id,
+        target_version=receipt.target_version,
+        superseded_by_receipt_id=replacement_id,
+        health_proven=payload["health_proven"],
+    )
+
+
+def clear_local_bundle_restart_intent(path: Path) -> None:
+    """Clear restart custody after readiness or a newer receipt supersedes it."""
+
+    receipt = load_upgrade_receipt(path)
+    if not receipt.artifacts_verified:
+        raise ValueError("local bundle restart intent requires a verified receipt")
+    if load_local_bundle_restart_intent(path) is None:
+        return
+    intent_path = _local_bundle_intent_path(path, receipt)
+    try:
+        intent_path.unlink()
+    except FileNotFoundError:
+        # Another recovery process may clear the same receipt-bound intent
+        # after the validated read above. The desired durable state is already
+        # present, while every other unlink failure must remain actionable.
+        return
+    if os.name == "posix":
+        directory_fd = os.open(intent_path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+
+
+def _verified_pending_target_queue(
+    receipt_path: Path,
+) -> tuple[UpgradeReceipt, list[tuple[Path, UpgradeReceipt]]]:
+    """Validate one pending retry and return its bounded receipt queue."""
+
+    current = load_upgrade_receipt(receipt_path)
+    if current.status != "pending" or not current.artifacts_verified:
+        raise ValueError("bundle restart recovery requires a verified pending receipt")
+    if receipt_path.parent.name != UPGRADE_RECEIPT_DIRECTORY:
+        raise ValueError("bundle restart recovery receipt is outside its private queue")
+    queue = _read_verified_receipt_queue(str(receipt_path.parent.parent))
+    pending = [
+        receipt.receipt_id
+        for _, receipt in queue
+        if receipt.target_version == current.target_version and receipt.status == "pending"
+    ]
+    if pending != [current.receipt_id]:
+        raise ValueError("bundle restart recovery requires one pending target receipt")
+    return current, queue
+
+
+def delegate_prior_upgrade_receipts(receipt_path: Path) -> int:
+    """Delegate prior retry authority to a newly verified pending attempt."""
+
+    current, queue = _verified_pending_target_queue(receipt_path)
+    delegated = 0
+    for path, receipt in queue:
+        if (
+            path == receipt_path
+            or receipt.target_version != current.target_version
+            or not receipt.artifacts_verified
+            or receipt.status == "pending"
+        ):
+            continue
+        existing = load_upgrade_receipt_supersession(path)
+        if existing is not None and existing.health_proven:
+            continue
+        restart_intent = load_local_bundle_restart_intent(path)
+        if not _is_recoverable_target(receipt, restart_intent):
+            continue
+        record_upgrade_receipt_supersession(
+            path,
+            replacement_path=receipt_path,
+            health_proven=False,
+        )
+        delegated += 1
+    return delegated
+
+
+def supersede_prior_upgrade_receipts(receipt_path: Path) -> int:
+    """Promote prior target delegations after the pending retry proves health."""
+
+    current, queue = _verified_pending_target_queue(receipt_path)
+    superseded = 0
+    for path, receipt in queue:
+        if (
+            path == receipt_path
+            or receipt.target_version != current.target_version
+            or not receipt.artifacts_verified
+            or receipt.status == "pending"
+        ):
+            continue
+        restart_intent = load_local_bundle_restart_intent(path)
+        if not _is_recoverable_target(receipt, restart_intent):
+            continue
+        marker = load_upgrade_receipt_supersession(path)
+        if marker is not None and marker.health_proven:
+            continue
+        record_upgrade_receipt_supersession(
+            path,
+            replacement_path=receipt_path,
+            health_proven=True,
+        )
+        superseded += 1
+    return superseded
+
+
+def _local_bundle_intent_path(path: Path, receipt: UpgradeReceipt) -> Path:
+    if path.name != f"{receipt.receipt_id}.json":
+        raise ValueError("upgrade receipt identity mismatch")
+    return path.with_name(f"{receipt.receipt_id}{_LOCAL_BUNDLE_INTENT_SUFFIX}")
+
+
+def _upgrade_supersession_path(path: Path, receipt: UpgradeReceipt) -> Path:
+    if path.name != f"{receipt.receipt_id}.json":
+        raise ValueError("upgrade receipt identity mismatch")
+    return path.with_name(f"{receipt.receipt_id}{_UPGRADE_SUPERSESSION_SUFFIX}")
+
+
+def _is_recoverable_target(
+    receipt: UpgradeReceipt,
+    restart_intent: bool | None = None,
+) -> bool:
+    """Return whether a receipt retains authenticated target recovery custody."""
+
+    if not receipt.artifacts_verified:
+        return False
+    if receipt.status == "failed":
+        return receipt.failure_code in _RECOVERABLE_TARGET_FAILURE_CODES
+    return receipt.status in {"succeeded", "partial"} and restart_intent is True
 
 
 def finalize_interrupted_upgrade_receipts(data_dir: str, *, current_version: str) -> int:
@@ -180,6 +471,148 @@ def finalize_interrupted_upgrade_receipts(data_dir: str, *, current_version: str
         )
         changed += 1
     return changed
+
+
+def find_resumable_upgrade_receipt(data_dir: str, *, target_version: str) -> Path | None:
+    """Return durable recovery authority for an installed target.
+
+    This lookup is deliberately read-only when the queue does not exist. The
+    sole pending receipt remains the retry authority until fresh target health
+    checks complete. A bounded delegation marker makes one pending retry the
+    sole authority; only its health-proven promotion can suppress the older
+    authority after the retry receipt itself has been acknowledged.
+    """
+
+    if _VERSION_RE.fullmatch(target_version) is None:
+        raise ValueError("invalid resumable upgrade target version")
+    queue = _read_verified_receipt_queue(data_dir)
+    matches: list[tuple[Path, UpgradeReceipt]] = []
+    for path, receipt in queue:
+        if receipt.target_version != target_version:
+            continue
+        if receipt.status == "pending" and not receipt.artifacts_verified:
+            raise ValueError("pending upgrade receipt did not authenticate target artifacts")
+        matches.append((path, receipt))
+    pending = [(path, receipt) for path, receipt in matches if receipt.status == "pending"]
+    if len(pending) > 1:
+        raise ValueError("multiple pending upgrade receipts target the installed version")
+    by_id = {receipt.receipt_id: receipt for _, receipt in queue}
+    superseded: set[Path] = set()
+    for path, receipt in matches:
+        if receipt.status == "pending":
+            continue
+        marker = load_upgrade_receipt_supersession(path)
+        if marker is None:
+            continue
+        replacement = by_id.get(marker.superseded_by_receipt_id)
+        if marker.health_proven:
+            superseded.add(path)
+        elif replacement is not None:
+            if not replacement.artifacts_verified or replacement.target_version != target_version:
+                raise ValueError("upgrade receipt delegation points to an invalid target retry")
+            superseded.add(path)
+    if pending:
+        return pending[0][0]
+    authorities: list[Path] = []
+    for path, receipt in matches:
+        if receipt.status == "pending":
+            continue
+        if path in superseded:
+            continue
+        restart_intent = None
+        if receipt.status in {"succeeded", "partial"}:
+            restart_intent = load_local_bundle_restart_intent(path)
+        if _is_recoverable_target(receipt, restart_intent):
+            authorities.append(path)
+    if len(authorities) > 1:
+        raise ValueError("multiple terminal receipts claim target recovery authority")
+    return authorities[0] if authorities else None
+
+
+def find_verified_installed_upgrade_receipt(
+    data_dir: str,
+    *,
+    target_version: str,
+) -> Path | None:
+    """Return the latest verified receipt proving target installation.
+
+    This is narrower than resumable recovery authority: a terminal success or
+    partial receipt cannot itself be mutated, but it can authenticate the
+    already-installed target before a fresh receipt reconciles target-owned
+    bundle state. Hosts without that durable evidence fail closed instead of
+    trusting a version string alone.
+    """
+
+    if _VERSION_RE.fullmatch(target_version) is None:
+        raise ValueError("invalid installed upgrade target version")
+    matches = [
+        (path, receipt)
+        for path, receipt in _read_verified_receipt_queue(data_dir)
+        if receipt.target_version == target_version
+        and receipt.artifacts_verified
+        and receipt.status in {"succeeded", "partial"}
+    ]
+    if not matches:
+        return None
+    return max(
+        matches,
+        key=lambda item: (item[1].created_at, item[1].status == "succeeded"),
+    )[0]
+
+
+def _read_verified_receipt_queue(data_dir: str) -> list[tuple[Path, UpgradeReceipt]]:
+    """Read the bounded private receipt queue or fail closed.
+
+    Receipts are local durable authority, so silently skipping a malformed or
+    replaceable entry could turn an interrupted same-version transaction into
+    a false no-op. POSIX queues and records must remain owned by the current
+    account and inaccessible to group/other users.
+    """
+
+    root = Path(os.path.abspath(os.path.expanduser(data_dir)))
+    try:
+        root_info = root.lstat()
+    except FileNotFoundError:
+        return []
+    if stat.S_ISLNK(root_info.st_mode) or not stat.S_ISDIR(root_info.st_mode):
+        raise OSError("upgrade receipt root is not a directory")
+    receipt_dir = root / UPGRADE_RECEIPT_DIRECTORY
+    try:
+        receipt_info = receipt_dir.lstat()
+    except FileNotFoundError:
+        return []
+    if stat.S_ISLNK(receipt_info.st_mode) or not stat.S_ISDIR(receipt_info.st_mode):
+        raise OSError("upgrade receipt location is not a private directory")
+    _require_private_posix_receipt_path(receipt_info, kind="directory")
+
+    entries = sorted(receipt_dir.glob("*.json"))
+    if len(entries) > MAX_UPGRADE_RECEIPTS:
+        raise OSError("upgrade receipt queue exceeds its bound")
+    receipts: list[tuple[Path, UpgradeReceipt]] = []
+    for path in entries:
+        try:
+            info = path.lstat()
+        except OSError as exc:
+            raise ValueError("upgrade receipt queue changed while reading") from exc
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+            raise ValueError("upgrade receipt queue contains an unsafe entry")
+        _require_private_posix_receipt_path(info, kind="record")
+        try:
+            receipt = load_upgrade_receipt(path)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            raise ValueError("upgrade receipt queue contains an invalid entry") from exc
+        receipts.append((path, receipt))
+    return receipts
+
+
+def _require_private_posix_receipt_path(info: os.stat_result, *, kind: str) -> None:
+    if os.name != "posix":
+        return
+    geteuid = getattr(os, "geteuid", None)
+    if geteuid is not None and info.st_uid != geteuid():
+        raise OSError(f"upgrade receipt {kind} is not owned by the current account")
+    if stat.S_IMODE(info.st_mode) & 0o077:
+        raise OSError(f"upgrade receipt {kind} is accessible to other accounts")
 
 
 def load_upgrade_receipt(path: Path) -> UpgradeReceipt:
@@ -251,7 +684,9 @@ def _atomic_write(path: Path, receipt: UpgradeReceipt) -> None:
     try:
         if os.name == "posix":
             os.fchmod(fd, 0o600)
-        with os.fdopen(fd, "wb") as stream:
+        stream = os.fdopen(fd, "wb")
+        fd = -1
+        with stream:
             stream.write(encoded)
             stream.flush()
             os.fsync(stream.fileno())
@@ -264,15 +699,86 @@ def _atomic_write(path: Path, receipt: UpgradeReceipt) -> None:
             finally:
                 os.close(directory_fd)
     except BaseException:
-        try:
-            os.close(fd)
-        except OSError:
-            pass
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
         try:
             os.unlink(temporary)
         except OSError:
             pass
         raise
+
+
+def _atomic_write_private_json(path: Path, payload: dict[str, object], *, maximum: int) -> None:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    if not encoded or len(encoded) > maximum:
+        raise ValueError("private receipt metadata exceeds its size bound")
+    fd, temporary = tempfile.mkstemp(prefix=".receipt-metadata-", suffix=".tmp", dir=path.parent)
+    try:
+        if os.name == "posix":
+            os.fchmod(fd, 0o600)
+        stream = os.fdopen(fd, "wb")
+        fd = -1
+        with stream:
+            stream.write(encoded)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        if os.name == "posix":
+            os.chmod(path, 0o600)
+            directory_fd = os.open(path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+    except BaseException:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def _load_private_json(path: Path, *, maximum: int, kind: str) -> object | None:
+    """Read bounded private receipt metadata without following replacements."""
+
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return None
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise ValueError(f"{kind} must be a regular file")
+    _require_private_posix_receipt_path(info, kind=kind)
+    if info.st_size <= 0 or info.st_size > maximum:
+        raise ValueError(f"{kind} has invalid size")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise ValueError(f"{kind} could not be opened safely") from exc
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_size <= 0
+            or opened.st_size > maximum
+            or not os.path.samestat(info, opened)
+        ):
+            raise ValueError(f"{kind} changed while opening")
+        raw = os.read(descriptor, maximum + 1)
+    finally:
+        os.close(descriptor)
+    try:
+        return json.loads(raw)
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{kind} is invalid") from exc
 
 
 def _validate(receipt: UpgradeReceipt) -> None:
@@ -336,11 +842,22 @@ def _utc_now() -> str:
 __all__ = [
     "MAX_UPGRADE_RECEIPT_BYTES",
     "MAX_UPGRADE_RECEIPTS",
+    "MAX_UPGRADE_SUPERSESSION_BYTES",
     "UPGRADE_RECEIPT_DIRECTORY",
     "UpgradeReceipt",
+    "UpgradeReceiptSupersession",
     "begin_upgrade_receipt",
+    "clear_local_bundle_restart_intent",
     "complete_upgrade_receipt",
+    "delegate_prior_upgrade_receipts",
+    "find_resumable_upgrade_receipt",
+    "find_verified_installed_upgrade_receipt",
     "finalize_interrupted_upgrade_receipts",
+    "load_local_bundle_restart_intent",
     "load_upgrade_receipt",
+    "load_upgrade_receipt_supersession",
+    "record_local_bundle_restart_intent",
+    "record_upgrade_receipt_supersession",
     "record_upgrade_migrations",
+    "supersede_prior_upgrade_receipts",
 ]

--- a/cli/defenseclaw/upgrade_receipt.py
+++ b/cli/defenseclaw/upgrade_receipt.py
@@ -510,7 +510,15 @@ def find_resumable_upgrade_receipt(data_dir: str, *, target_version: str) -> Pat
         elif replacement is not None:
             if not replacement.artifacts_verified or replacement.target_version != target_version:
                 raise ValueError("upgrade receipt delegation points to an invalid target retry")
-            superseded.add(path)
+            replacement_restart_intent = None
+            if replacement.status in {"succeeded", "partial"}:
+                replacement_path = path.with_name(f"{replacement.receipt_id}.json")
+                replacement_restart_intent = load_local_bundle_restart_intent(replacement_path)
+            if replacement.status == "pending" or _is_recoverable_target(
+                replacement,
+                replacement_restart_intent,
+            ):
+                superseded.add(path)
     if pending:
         return pending[0][0]
     authorities: list[Path] = []
@@ -556,7 +564,7 @@ def find_verified_installed_upgrade_receipt(
         return None
     return max(
         matches,
-        key=lambda item: (item[1].created_at, item[1].status == "succeeded"),
+        key=lambda item: (_parse_time(item[1].created_at), item[1].status == "succeeded"),
     )[0]
 
 

--- a/cli/tests/test_bundle_refresh.py
+++ b/cli/tests/test_bundle_refresh.py
@@ -26,6 +26,7 @@ mocked ``subprocess.run``.
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import shutil
 import stat
@@ -609,6 +610,44 @@ class TestIsComposeProjectRunning(unittest.TestCase):
         # OSError must NOT propagate — callers treat False as
         # "nothing to stop".
         self.assertFalse(is_compose_project_running("any-project"))
+
+
+class TestInstalledBundleVersion(unittest.TestCase):
+    def test_manifest_version_is_a_bounded_safe_string(self) -> None:
+        from defenseclaw.bundle_refresh import (
+            LocalObservabilityUpgradeError,
+            installed_local_observability_bundle_version,
+        )
+
+        with tempfile.TemporaryDirectory() as root:
+            destination = Path(root, "observability-stack")
+            destination.mkdir()
+            self.assertEqual(installed_local_observability_bundle_version(root), "")
+
+            manifest = destination / ".defenseclaw-bundle-manifest.json"
+            document = {
+                "schema_version": 1,
+                "bundle_version": "",
+                "files": [],
+                "dashboard_uids": [],
+                "named_volumes": [],
+            }
+            for accepted in ("dev", "01.2.3", "0.8.6-rc.1+build.7"):
+                with self.subTest(bundle_version=accepted):
+                    document["bundle_version"] = accepted
+                    manifest.write_text(json.dumps(document), encoding="utf-8")
+                    self.assertEqual(
+                        installed_local_observability_bundle_version(root),
+                        accepted,
+                    )
+
+            for invalid in ("", "a" * 65, "0.8.6/rc1", "0.8.6 rc1"):
+                with self.subTest(bundle_version=invalid):
+                    document["bundle_version"] = invalid
+                    manifest.write_text(json.dumps(document), encoding="utf-8")
+                    with self.assertRaises(LocalObservabilityUpgradeError) as raised:
+                        installed_local_observability_bundle_version(root)
+                    self.assertEqual(raised.exception.code, "installed_manifest_invalid")
 
 
 if __name__ == "__main__":

--- a/cli/tests/test_cmd_upgrade.py
+++ b/cli/tests/test_cmd_upgrade.py
@@ -4273,6 +4273,84 @@ class TestUpgradeSameVersionRepair(unittest.TestCase):
             required.assert_called_once()
             start.assert_called_once()
 
+    def test_required_migration_assertion_failure_keeps_recovery_retryable(self):
+        app = AppContext()
+        app.cfg = Config()
+
+        with TemporaryDirectory() as data_dir, ExitStack() as stack:
+            app.cfg.data_dir = data_dir
+            app.cfg.claw.home_dir = data_dir
+            receipt_path = begin_upgrade_receipt(
+                data_dir,
+                from_version="9.9.8",
+                target_version="9.9.9",
+                artifacts_verified=True,
+            )
+            stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._create_backup",
+                    return_value=os.path.join(data_dir, "backup"),
+                )
+            )
+            stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._run_silent", return_value=True))
+            stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._assert_gateway_quiesced"))
+            run_migrations = stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._run_installed_migrations",
+                    return_value=1,
+                )
+            )
+            required = stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._assert_required_cli_migrations",
+                    side_effect=[SystemExit(1), None],
+                )
+            )
+            start = stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._start_and_verify_services"))
+
+            with self.assertRaises(SystemExit):
+                cmd_upgrade_module._recover_interrupted_same_version_upgrade(
+                    app,
+                    receipt_path=receipt_path,
+                    data_dir=data_dir,
+                    target_version="9.9.9",
+                    os_name="linux",
+                    health_timeout=60,
+                    config_path=os.path.join(data_dir, "config.yaml"),
+                    recovery_home=data_dir,
+                    upgrade_manifest={
+                        "migration_failure_policy": "fail",
+                        "required_cli_migrations": ["9.9.9"],
+                    },
+                )
+
+            failed_attempt = load_upgrade_receipt(receipt_path)
+            self.assertEqual(failed_attempt.status, "pending")
+            self.assertEqual(failed_attempt.migration_status, "degraded")
+            start.assert_not_called()
+
+            cmd_upgrade_module._recover_interrupted_same_version_upgrade(
+                app,
+                receipt_path=receipt_path,
+                data_dir=data_dir,
+                target_version="9.9.9",
+                os_name="linux",
+                health_timeout=60,
+                config_path=os.path.join(data_dir, "config.yaml"),
+                recovery_home=data_dir,
+                upgrade_manifest={
+                    "migration_failure_policy": "fail",
+                    "required_cli_migrations": ["9.9.9"],
+                },
+            )
+
+            recovered = load_upgrade_receipt(receipt_path)
+            self.assertEqual(recovered.status, "succeeded")
+            self.assertEqual(recovered.migration_status, "completed")
+            self.assertEqual(run_migrations.call_count, 2)
+            self.assertEqual(required.call_count, 2)
+            start.assert_called_once()
+
     def test_required_migration_failure_leaves_target_services_stopped(self):
         runner = CliRunner()
         app = AppContext()
@@ -4722,9 +4800,7 @@ class TestUpgradeServiceVerification(unittest.TestCase):
 
         def assert_receipt_before_migration(*args, **_kwargs):
             data_dir = args[3]
-            receipt_paths = list(
-                (Path(data_dir) / UPGRADE_RECEIPT_DIRECTORY).glob("*.json")
-            )
+            receipt_paths = list((Path(data_dir) / UPGRADE_RECEIPT_DIRECTORY).glob("*.json"))
             self.assertEqual(len(receipt_paths), 1)
             receipt = load_upgrade_receipt(receipt_paths[0])
             self.assertEqual(receipt.status, "pending")

--- a/cli/tests/test_cmd_upgrade.py
+++ b/cli/tests/test_cmd_upgrade.py
@@ -36,6 +36,7 @@ from defenseclaw.commands.cmd_upgrade import (
     _capture_source_gateway_running_state,
     _check_post_upgrade_drift,
     _cleanup_hard_cut_mutation_temporaries,
+    _copy_distribution_metadata,
     _crash_bundle_rollback_result,
     _create_backup,
     _detect_platform,
@@ -79,9 +80,8 @@ from defenseclaw.commands.cmd_upgrade import (
     _refresh_target_dotenv_environment,
     _release_download_base,
     _require_bridge_checksums_provenance,
-    _require_hard_cut_dependency_contract,
+    _require_bridge_environment_accepts_target_wheel,
     _require_hard_cut_manifest_contract,
-    _require_hard_cut_preexisting_promoted_runtime,
     _require_release_owned_hard_cut_handoff,
     _require_target_phase_two_mutator_wrapper,
     _resolve_upgrade_source_version,
@@ -96,7 +96,6 @@ from defenseclaw.commands.cmd_upgrade import (
     _start_and_verify_services,
     _target_migration_capabilities,
     _TargetMigrationCapabilities,
-    _validate_hard_cut_promoted_runtime_probe,
     _validate_staged_bridge_artifact_set,
     _validate_target_migration_capabilities,
     _validate_upgrade_manifest,
@@ -114,7 +113,11 @@ from defenseclaw.migrations import ObservabilityV8PreflightBinding, run_migratio
 from defenseclaw.upgrade_receipt import (
     UPGRADE_RECEIPT_DIRECTORY,
     begin_upgrade_receipt,
+    clear_local_bundle_restart_intent,
+    load_local_bundle_restart_intent,
     load_upgrade_receipt,
+    load_upgrade_receipt_supersession,
+    record_local_bundle_restart_intent,
 )
 
 
@@ -1686,6 +1689,7 @@ class TestHardCutRollbackTransaction(unittest.TestCase):
                     app.cfg.claw.home_dir,
                     app.cfg.data_dir,
                     upgrade_handles_local_bundle=True,
+                    controller_owns_local_bundle_transaction=True,
                 )
 
             self.assertEqual(applied, 1)
@@ -2029,9 +2033,7 @@ class TestHardCutRollbackTransaction(unittest.TestCase):
             self.assertTrue(restored)
             self.assertEqual(poll_health.call_count, 2)
             start_calls = [
-                call
-                for call in run_silent.call_args_list
-                if call.args[0] == [plan.active_gateway_path, "start"]
+                call for call in run_silent.call_args_list if call.args[0] == [plan.active_gateway_path, "start"]
             ]
             self.assertEqual(len(start_calls), 2)
             receipt = load_upgrade_receipt(receipt_path)
@@ -2828,6 +2830,22 @@ class TestTargetWheelMigrationCapabilities(unittest.TestCase):
             calls.append((args, {"upgrade_handles_local_bundle": upgrade_handles_local_bundle}))
             return 1
 
+        def capable(
+            *args,
+            upgrade_handles_local_bundle=False,
+            controller_owns_local_bundle_transaction=False,
+        ):
+            calls.append(
+                (
+                    args,
+                    {
+                        "upgrade_handles_local_bundle": upgrade_handles_local_bundle,
+                        "controller_owns_local_bundle_transaction": controller_owns_local_bundle_transaction,
+                    },
+                )
+            )
+            return 1
+
         def positional_only(
             from_version,
             to_version,
@@ -2846,10 +2864,18 @@ class TestTargetWheelMigrationCapabilities(unittest.TestCase):
 
         execute(legacy)
         execute(current)
+        execute(capable)
         execute(positional_only)
         self.assertEqual(calls[0][1], {})
         self.assertEqual(calls[1][1], {"upgrade_handles_local_bundle": True})
-        self.assertEqual(calls[2][1], {"upgrade_handles_local_bundle": False})
+        self.assertEqual(
+            calls[2][1],
+            {
+                "upgrade_handles_local_bundle": True,
+                "controller_owns_local_bundle_transaction": True,
+            },
+        )
+        self.assertEqual(calls[3][1], {"upgrade_handles_local_bundle": False})
 
     def test_upgrade_rejects_hard_cut_wheel_without_v8_capability_before_mutation(self):
         runner = CliRunner()
@@ -3026,156 +3052,145 @@ class TestUpgradeWheelInstall(unittest.TestCase):
         self.assertIn("--reinstall", args)
         self.assertEqual(args[-1], "/tmp/defenseclaw-0.8.5.whl")
 
-    def test_hard_cut_requires_exact_authenticated_dependency_contract(self):
-        def write_wheel(path: Path, version: str, requirements: list[str]) -> None:
-            metadata = f"Metadata-Version: 2.4\nName: defenseclaw\nVersion: {version}\n"
-            metadata += "".join(f"Requires-Dist: {requirement}\n" for requirement in requirements)
-            with zipfile.ZipFile(path, "w") as archive:
-                archive.writestr(
-                    f"defenseclaw-{version}.dist-info/METADATA",
-                    metadata,
-                )
-
-        with TemporaryDirectory() as root:
-            source = Path(root, "source.whl")
-            target = Path(root, "target.whl")
-            write_wheel(source, "0.8.4", ["requests>=2.32"])
-            write_wheel(
-                target,
-                "0.8.5",
-                [
-                    "requests>=2.32",
-                    "jsonschema<5,>=4.23.0",
-                    'mcp<2,>=1.28.1; python_version >= "3.11"',
-                ],
-            )
-            _require_hard_cut_dependency_contract(
-                str(source),
-                str(target),
-                source_version="0.8.4",
-                target_version="0.8.5",
-            )
-
-            write_wheel(
-                target,
-                "0.8.5",
-                ["requests>=2.32", "jsonschema<5,>=4.23.0"],
-            )
-            with self.assertRaisesRegex(ValueError, "Requires-Dist differs"):
-                _require_hard_cut_dependency_contract(
-                    str(source),
-                    str(target),
-                    source_version="0.8.4",
-                    target_version="0.8.5",
-                )
-
-            write_wheel(
-                target,
-                "0.8.5",
-                [
-                    "requests>=2.32",
-                    "jsonschema<5,>=4.23.0",
-                    'mcp<2,>=1.28.0; python_version >= "3.11"',
-                ],
-            )
-            with self.assertRaisesRegex(ValueError, "Requires-Dist differs"):
-                _require_hard_cut_dependency_contract(
-                    str(source),
-                    str(target),
-                    source_version="0.8.4",
-                    target_version="0.8.5",
-                )
-
     @staticmethod
-    def _valid_hard_cut_promoted_runtime_probe() -> dict[str, object]:
-        return {
-            "python_version": "3.11.0",
-            "jsonschema_version": "4.23.0",
-            "jsonschema_draft": "https://json-schema.org/draft/2020-12/schema",
-            "mcp_version": "1.28.1",
-            "mcp_import": True,
+    def _write_dependency_contract_wheel(
+        path: Path,
+        version: str,
+        requirements: list[str],
+    ) -> None:
+        metadata = f"Metadata-Version: 2.4\nName: defenseclaw\nVersion: {version}\n"
+        metadata += "".join(f"Requires-Dist: {requirement}\n" for requirement in requirements)
+        dist_info = f"defenseclaw-{version}.dist-info"
+        members = {
+            "defenseclaw/__init__.py": f'__version__ = "{version}"\n',
+            f"{dist_info}/METADATA": metadata,
+            f"{dist_info}/WHEEL": (
+                "Wheel-Version: 1.0\nGenerator: defenseclaw-test\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+            ),
         }
+        record = "".join(f"{name},,\n" for name in members)
+        record += f"{dist_info}/RECORD,,\n"
+        with zipfile.ZipFile(path, "w") as archive:
+            for name, payload in members.items():
+                archive.writestr(name, payload)
+            archive.writestr(f"{dist_info}/RECORD", record)
 
-    def test_hard_cut_requires_preexisting_promoted_runtime_in_bridge_venv(self):
-        probe = self._valid_hard_cut_promoted_runtime_probe()
-        with patch(
-            "subprocess.run",
-            return_value=Mock(returncode=0, stdout=json.dumps(probe)),
-        ) as run_mock:
-            _require_hard_cut_preexisting_promoted_runtime("/managed/bridge/bin/python")
-
-        args = run_mock.call_args.args[0]
-        self.assertEqual(args[:4], ["/managed/bridge/bin/python", "-I", "-B", "-c"])
-        self.assertIn("Draft202012Validator", args[4])
-        self.assertIn("import mcp", args[4])
-        self.assertIn('version("mcp")', args[4])
-        self.assertIn("sys.version_info >= (3, 11)", args[4])
-        self.assertTrue(run_mock.call_args.kwargs["check"])
-        self.assertEqual(run_mock.call_args.kwargs["timeout"], 10)
-
-    def test_hard_cut_promoted_runtime_accepts_exact_floors(self):
-        _validate_hard_cut_promoted_runtime_probe(self._valid_hard_cut_promoted_runtime_probe())
-
-    def test_hard_cut_promoted_runtime_accepts_pep440_post_and_local_builds(self):
-        for jsonschema_version, mcp_version in (
-            ("4.23.0.post1", "1.28.1.post1"),
-            ("4.23.0+vendor.1", "1.28.1+vendor.1"),
-            ("4.23", "1.28.1.0"),
-        ):
-            probe = self._valid_hard_cut_promoted_runtime_probe()
-            probe.update(
-                {
-                    "jsonschema_version": jsonschema_version,
-                    "mcp_version": mcp_version,
-                }
+    @unittest.skipUnless(cmd_upgrade_module.shutil.which("uv"), "uv required")
+    def test_dynamic_hard_cut_contract_accepts_arbitrary_future_versions(self):
+        uv = cmd_upgrade_module.shutil.which("uv") or ""
+        os_name, _arch = _detect_platform()
+        with TemporaryDirectory() as root:
+            bridge_venv = Path(root, "bridge")
+            subprocess.run(
+                [uv, "--no-config", "venv", str(bridge_venv), "--python", sys.executable, "--offline", "--quiet"],
+                check=True,
             )
-            with self.subTest(jsonschema=jsonschema_version, mcp=mcp_version):
-                _validate_hard_cut_promoted_runtime_probe(probe)
+            bridge_python = cmd_upgrade_module._venv_python_path(str(bridge_venv), os_name)
+            site_packages = Path(cmd_upgrade_module._venv_site_package_directories(bridge_python)[0])
+            runtime_info = site_packages / "runtime_support-3.7.0.dist-info"
+            runtime_info.mkdir()
+            (runtime_info / "METADATA").write_text(
+                "Metadata-Version: 2.4\nName: runtime-support\nVersion: 3.7.0\n",
+                encoding="utf-8",
+            )
+            (runtime_info / "WHEEL").write_text(
+                "Wheel-Version: 1.0\nGenerator: defenseclaw-test\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+                encoding="utf-8",
+            )
+            source = Path(root, "defenseclaw-0.8.4-py3-none-any.whl")
+            self._write_dependency_contract_wheel(source, "0.8.4", ["runtime-support>=3"])
+            for version in ("0.8.5", "0.8.6", "0.9.0", "1.0.0"):
+                target = Path(root, f"defenseclaw-{version}-py3-none-any.whl")
+                self._write_dependency_contract_wheel(target, version, ["runtime-support>=3.5"])
+                with self.subTest(version=version):
+                    _require_bridge_environment_accepts_target_wheel(
+                        uv,
+                        bridge_python,
+                        str(source),
+                        str(target),
+                        os_name=os_name,
+                    )
 
-    def test_hard_cut_promoted_runtime_allows_python_310_without_marker_gated_mcp(self):
-        probe = self._valid_hard_cut_promoted_runtime_probe()
-        probe.update(
-            {
-                "python_version": "3.10.14",
-                "mcp_version": None,
-                "mcp_import": None,
+    @unittest.skipUnless(cmd_upgrade_module.shutil.which("uv"), "uv required")
+    def test_dynamic_hard_cut_contract_rejects_missing_or_incompatible_requirements(self):
+        uv = cmd_upgrade_module.shutil.which("uv") or ""
+        os_name, _arch = _detect_platform()
+        with TemporaryDirectory() as root:
+            bridge_venv = Path(root, "bridge")
+            subprocess.run(
+                [uv, "--no-config", "venv", str(bridge_venv), "--python", sys.executable, "--offline", "--quiet"],
+                check=True,
+            )
+            bridge_python = cmd_upgrade_module._venv_python_path(str(bridge_venv), os_name)
+            site_packages = Path(cmd_upgrade_module._venv_site_package_directories(bridge_python)[0])
+            runtime_info = site_packages / "runtime_support-3.7.0.dist-info"
+            runtime_info.mkdir()
+            (runtime_info / "METADATA").write_text(
+                "Metadata-Version: 2.4\nName: runtime-support\nVersion: 3.7.0\n",
+                encoding="utf-8",
+            )
+            (runtime_info / "WHEEL").write_text(
+                "Wheel-Version: 1.0\nGenerator: defenseclaw-test\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+                encoding="utf-8",
+            )
+            source = Path(root, "defenseclaw-0.8.4-py3-none-any.whl")
+            self._write_dependency_contract_wheel(source, "0.8.4", ["runtime-support>=3"])
+            cases = {
+                "missing": ["runtime-support>=3", "future-runtime>=1"],
+                "incompatible": ["runtime-support>=4"],
             }
-        )
+            for name, requirements in cases.items():
+                target = Path(root, f"defenseclaw-9.9.{len(requirements)}-py3-none-any.whl")
+                self._write_dependency_contract_wheel(target, f"9.9.{len(requirements)}", requirements)
+                with self.subTest(name=name), self.assertRaises(subprocess.CalledProcessError):
+                    _require_bridge_environment_accepts_target_wheel(
+                        uv,
+                        bridge_python,
+                        str(source),
+                        str(target),
+                        os_name=os_name,
+                    )
 
-        _validate_hard_cut_promoted_runtime_probe(probe)
+    def test_distribution_metadata_copy_excludes_defenseclaw_and_rejects_duplicates(self):
+        with TemporaryDirectory() as root:
+            source = Path(root, "source")
+            destination = Path(root, "destination")
+            source.mkdir()
+            destination.mkdir()
 
-    def test_hard_cut_promoted_runtime_rejects_version_and_import_boundaries(self):
-        cases = {
-            "python_below_floor": ({"python_version": "3.9.20"}, "Python runtime"),
-            "jsonschema_below_floor": ({"jsonschema_version": "4.22.9"}, "jsonschema runtime"),
-            "jsonschema_upper_bound": ({"jsonschema_version": "5.0.0"}, "jsonschema runtime"),
-            "jsonschema_prerelease": ({"jsonschema_version": "4.23.0rc1"}, "not a supported PEP 440"),
-            "jsonschema_malformed": ({"jsonschema_version": "release-4.23.0"}, "not a supported PEP 440"),
-            "jsonschema_wrong_draft": ({"jsonschema_draft": "draft-07"}, "Draft 2020-12"),
-            "mcp_below_floor": ({"mcp_version": "1.28.0"}, "mcp runtime"),
-            "mcp_upper_bound": ({"mcp_version": "2.0.0"}, "mcp runtime"),
-            "mcp_prerelease": ({"mcp_version": "1.28.1rc1"}, "not a supported PEP 440"),
-            "mcp_import_failed": ({"mcp_import": False}, "cannot be imported"),
-        }
-        for name, (override, message) in cases.items():
-            probe = self._valid_hard_cut_promoted_runtime_probe()
-            probe.update(override)
-            with self.subTest(name=name), self.assertRaisesRegex(ValueError, message):
-                _validate_hard_cut_promoted_runtime_probe(probe)
+            def write_metadata(directory: str, name: str, version: str) -> None:
+                info = source / directory
+                info.mkdir()
+                (info / "METADATA").write_text(
+                    f"Metadata-Version: 2.4\nName: {name}\nVersion: {version}\n",
+                    encoding="utf-8",
+                )
+                (info / "WHEEL").write_text("Wheel-Version: 1.0\n", encoding="utf-8")
 
-    def test_hard_cut_preflight_rejects_missing_promoted_runtime_before_uv(self):
+            write_metadata("defenseclaw-0.8.4.dist-info", "DefenseClaw", "0.8.4")
+            write_metadata("runtime_support-3.7.dist-info", "runtime-support", "3.7")
+            _copy_distribution_metadata((str(source),), str(destination))
+            self.assertFalse((destination / "defenseclaw-0.8.4.dist-info").exists())
+            self.assertTrue((destination / "runtime_support-3.7.dist-info/METADATA").is_file())
+
+            write_metadata("runtime.support-3.7.dist-info", "runtime.support", "3.7")
+            duplicate = Path(root, "duplicate")
+            duplicate.mkdir()
+            with self.assertRaisesRegex(ValueError, "duplicate packages"):
+                _copy_distribution_metadata((str(source),), str(duplicate))
+
+    def test_hard_cut_preflight_rejects_dynamic_contract_failure_before_mutation(self):
         with (
             TemporaryDirectory() as home,
             patch.dict(os.environ, {"DEFENSECLAW_HOME": home}),
             patch("shutil.which", return_value="/usr/bin/uv"),
             patch("os.path.isfile", return_value=True),
             patch("defenseclaw.commands.cmd_upgrade._preflight_target_wheel_migrations"),
-            patch("defenseclaw.commands.cmd_upgrade._require_hard_cut_dependency_contract"),
             patch(
-                "defenseclaw.commands.cmd_upgrade._require_hard_cut_preexisting_promoted_runtime",
-                side_effect=ValueError("installed mcp runtime is outside 1.28.1 <= version < 2"),
+                "defenseclaw.commands.cmd_upgrade._require_bridge_environment_accepts_target_wheel",
+                side_effect=ValueError("target dependency is absent"),
             ),
-            patch("subprocess.run") as run_mock,
+            patch("subprocess.run", return_value=Mock(returncode=0)) as run_mock,
         ):
             with self.assertRaises(SystemExit):
                 _preflight_wheel_install(
@@ -3186,25 +3201,29 @@ class TestUpgradeWheelInstall(unittest.TestCase):
                     source_version="0.8.4",
                 )
 
-        run_mock.assert_not_called()
+        self.assertEqual(run_mock.call_count, 1)
+        self.assertEqual(run_mock.call_args.args[0][2:4], ["pip", "check"])
+        self.assertEqual(
+            run_mock.call_args.kwargs["timeout"],
+            cmd_upgrade_module._DEPENDENCY_PREFLIGHT_TIMEOUT_SECONDS,
+        )
 
-    def test_hard_cut_preflight_reports_promoted_runtime_timeout_before_uv(self):
+    def test_hard_cut_preflight_reports_dynamic_contract_timeout(self):
         with (
             TemporaryDirectory() as home,
             patch.dict(os.environ, {"DEFENSECLAW_HOME": home}),
             patch("shutil.which", return_value="/usr/bin/uv"),
             patch("os.path.isfile", return_value=True),
             patch("defenseclaw.commands.cmd_upgrade._preflight_target_wheel_migrations"),
-            patch("defenseclaw.commands.cmd_upgrade._require_hard_cut_dependency_contract"),
             patch(
-                "defenseclaw.commands.cmd_upgrade._require_hard_cut_preexisting_promoted_runtime",
+                "defenseclaw.commands.cmd_upgrade._require_bridge_environment_accepts_target_wheel",
                 side_effect=subprocess.TimeoutExpired(["bridge-python", "-I", "-B"], 10),
             ),
             patch(
                 "defenseclaw.commands.cmd_upgrade._fail_wheel_preflight",
                 side_effect=SystemExit(1),
             ) as fail_mock,
-            patch("subprocess.run") as run_mock,
+            patch("subprocess.run", return_value=Mock(returncode=0)) as run_mock,
         ):
             with self.assertRaises(SystemExit):
                 _preflight_wheel_install(
@@ -3219,7 +3238,11 @@ class TestUpgradeWheelInstall(unittest.TestCase):
             "Hard-cut target cannot preserve the authenticated bridge dependency environment.",
             None,
         )
-        run_mock.assert_not_called()
+        self.assertEqual(run_mock.call_count, 1)
+        self.assertEqual(
+            run_mock.call_args.kwargs["timeout"],
+            cmd_upgrade_module._DEPENDENCY_PREFLIGHT_TIMEOUT_SECONDS,
+        )
 
     def test_restored_bridge_verifies_exact_package_metadata(self):
         with TemporaryDirectory() as root:
@@ -3289,6 +3312,58 @@ class TestUpgradeWheelInstall(unittest.TestCase):
         self.assertEqual(calls[1][:5], ["/usr/bin/uv", "--no-config", "pip", "install", "--python"])
         self.assertIn("--dry-run", calls[1])
         self.assertEqual(calls[1][-1], "/tmp/defenseclaw.whl")
+        for call in run_mock.call_args_list:
+            self.assertEqual(
+                call.kwargs["timeout"],
+                cmd_upgrade_module._DEPENDENCY_PREFLIGHT_TIMEOUT_SECONDS,
+            )
+
+    def test_preflight_wheel_install_fails_closed_on_resolver_timeout(self):
+        with (
+            TemporaryDirectory() as home,
+            patch.dict(os.environ, {"DEFENSECLAW_HOME": home}),
+            patch("shutil.which", return_value="/usr/bin/uv"),
+            patch(
+                "defenseclaw.commands.cmd_upgrade._fail_wheel_preflight",
+                side_effect=SystemExit(1),
+            ) as fail_mock,
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.TimeoutExpired(["uv", "pip", "install"], 120),
+            ),
+        ):
+            venv_python = os.path.join(home, ".venv", "bin", "python")
+            os.makedirs(os.path.dirname(venv_python), exist_ok=True)
+            Path(venv_python).write_text("# python", encoding="utf-8")
+            with self.assertRaises(SystemExit):
+                _preflight_wheel_install("/tmp/defenseclaw.whl", "linux")
+
+        fail_mock.assert_called_once_with(
+            "Python CLI wheel dependencies are unsatisfiable.",
+            None,
+        )
+
+    def test_preflight_wheel_install_fails_closed_on_venv_timeout(self):
+        with (
+            TemporaryDirectory() as home,
+            patch.dict(os.environ, {"HOME": home}),
+            patch("shutil.which", return_value="/usr/bin/uv"),
+            patch(
+                "defenseclaw.commands.cmd_upgrade._fail_wheel_preflight",
+                side_effect=SystemExit(1),
+            ) as fail_mock,
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.TimeoutExpired(["uv", "venv"], 120),
+            ),
+        ):
+            with self.assertRaises(SystemExit):
+                _preflight_wheel_install("/tmp/defenseclaw.whl", "linux")
+
+        fail_mock.assert_called_once_with(
+            "Could not create Python CLI preflight environment.",
+            None,
+        )
 
     def test_run_installed_migrations_uses_managed_venv_python(self):
         with (
@@ -3334,6 +3409,7 @@ class TestUpgradeWheelInstall(unittest.TestCase):
         self.assertEqual(call[1:4], ["-I", "-B", "-c"])
         self.assertIn("inspect.signature(run_migrations).parameters", call[4])
         self.assertIn('kwargs["upgrade_handles_local_bundle"] = True', call[4])
+        self.assertIn('kwargs["controller_owns_local_bundle_transaction"] = True', call[4])
         self.assertNotIn("upgrade_handles_local_bundle=True", call[4])
         self.assertEqual(call[5:9], ["0.7.0", "0.8.0", "/tmp/openclaw", "/tmp/defenseclaw"])
         child_environment = run_mock.call_args.kwargs["env"]
@@ -3464,6 +3540,7 @@ class TestUpgradeWheelInstall(unittest.TestCase):
                     custom_home,
                     os.path.join(home, "backup"),
                     "0.8.5",
+                    receipt_path=os.path.join(home, "receipt.json"),
                     os_name="linux",
                 )
 
@@ -3667,6 +3744,36 @@ class TestUpgradeFreshProcessHandoff(unittest.TestCase):
 
 
 class TestUpgradeSameVersionRepair(unittest.TestCase):
+    def test_same_version_bundle_mismatch_requires_reconciliation(self):
+        with patch(
+            "defenseclaw.bundle_refresh.installed_local_observability_bundle_version",
+            side_effect=[None, "9.9.9", "9.9.8", ""],
+        ):
+            self.assertFalse(
+                cmd_upgrade_module._installed_local_observability_bundle_needs_reconciliation(
+                    "/tmp/data",
+                    "9.9.9",
+                )
+            )
+            self.assertFalse(
+                cmd_upgrade_module._installed_local_observability_bundle_needs_reconciliation(
+                    "/tmp/data",
+                    "9.9.9",
+                )
+            )
+            self.assertTrue(
+                cmd_upgrade_module._installed_local_observability_bundle_needs_reconciliation(
+                    "/tmp/data",
+                    "9.9.9",
+                )
+            )
+            self.assertTrue(
+                cmd_upgrade_module._installed_local_observability_bundle_needs_reconciliation(
+                    "/tmp/data",
+                    "9.9.9",
+                )
+            )
+
     def test_same_version_is_authenticated_noop(self):
         runner = CliRunner()
         app = AppContext()
@@ -3736,10 +3843,98 @@ class TestUpgradeSameVersionRepair(unittest.TestCase):
             run_migrations = stack.enter_context(
                 patch("defenseclaw.commands.cmd_upgrade._run_installed_migrations", return_value=1)
             )
+            recover_interrupted = stack.enter_context(
+                patch("defenseclaw.commands.cmd_upgrade._recover_interrupted_same_version_upgrade")
+            )
             result = runner.invoke(upgrade, ["--yes", "--version", "9.9.9"], obj=app)
 
             receipts = list((Path(data_dir) / UPGRADE_RECEIPT_DIRECTORY).glob("*.json"))
             self.assertEqual(receipts, [])
+            self.assertFalse((Path(data_dir) / UPGRADE_RECEIPT_DIRECTORY).exists())
+            recover_interrupted.assert_not_called()
+
+            installed = begin_upgrade_receipt(
+                data_dir,
+                from_version="0.8.4",
+                target_version="9.9.9",
+                artifacts_verified=True,
+            )
+            cmd_upgrade_module.complete_upgrade_receipt(installed, status="succeeded")
+            with patch(
+                "defenseclaw.commands.cmd_upgrade._installed_local_observability_bundle_needs_reconciliation",
+                return_value=True,
+            ):
+                installed_reconciliation_result = runner.invoke(
+                    upgrade,
+                    ["--yes", "--version", "9.9.9"],
+                    obj=app,
+                )
+            recover_interrupted.assert_called_once()
+            installed_recovery_receipt = recover_interrupted.call_args.kwargs["receipt_path"]
+            installed_recovery = load_upgrade_receipt(installed_recovery_receipt)
+            self.assertEqual(installed_recovery.from_version, "9.9.9")
+            self.assertEqual(installed_recovery.target_version, "9.9.9")
+            installed_recovery_receipt.unlink()
+            recover_interrupted.reset_mock()
+
+            pending = begin_upgrade_receipt(
+                data_dir,
+                from_version="9.9.8",
+                target_version="9.9.9",
+                artifacts_verified=True,
+            )
+            recovery_result = runner.invoke(
+                upgrade,
+                ["--yes", "--version", "9.9.9"],
+                obj=app,
+            )
+            recover_interrupted.assert_called_once()
+            self.assertEqual(
+                recover_interrupted.call_args.kwargs["receipt_path"],
+                pending,
+            )
+
+            record_local_bundle_restart_intent(pending, restart_required=True)
+            cmd_upgrade_module.complete_upgrade_receipt(
+                pending,
+                status="failed",
+                failure_code="local_observability_failed",
+            )
+            recover_interrupted.reset_mock()
+            terminal_recovery_result = runner.invoke(
+                upgrade,
+                ["--yes", "--version", "9.9.9"],
+                obj=app,
+            )
+            recover_interrupted.assert_called_once()
+            terminal_recovery_receipt = recover_interrupted.call_args.kwargs["receipt_path"]
+            self.assertNotEqual(terminal_recovery_receipt, pending)
+            replacement = load_upgrade_receipt(terminal_recovery_receipt)
+            self.assertEqual(replacement.status, "pending")
+            self.assertEqual(replacement.from_version, "9.9.8")
+            self.assertIs(load_local_bundle_restart_intent(terminal_recovery_receipt), True)
+
+            recover_interrupted.reset_mock()
+            with (
+                patch(
+                    "defenseclaw.commands.cmd_upgrade.find_resumable_upgrade_receipt",
+                    return_value=None,
+                ),
+                patch(
+                    "defenseclaw.commands.cmd_upgrade.find_verified_installed_upgrade_receipt",
+                    return_value=None,
+                ),
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._installed_local_observability_bundle_needs_reconciliation",
+                    return_value=True,
+                ),
+            ):
+                unproven_bundle_result = runner.invoke(
+                    upgrade,
+                    ["--yes", "--version", "9.9.9"],
+                    obj=app,
+                )
+            recover_interrupted.assert_not_called()
 
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertIn("Version Already Verified", result.output)
@@ -3748,6 +3943,335 @@ class TestUpgradeSameVersionRepair(unittest.TestCase):
         install_gateway.assert_not_called()
         install_wheel.assert_not_called()
         run_migrations.assert_not_called()
+        self.assertEqual(
+            installed_reconciliation_result.exit_code,
+            0,
+            msg=installed_reconciliation_result.output,
+        )
+        self.assertEqual(recovery_result.exit_code, 0, msg=recovery_result.output)
+        self.assertIn("Found an incomplete target transaction", recovery_result.output)
+        self.assertEqual(
+            terminal_recovery_result.exit_code,
+            0,
+            msg=terminal_recovery_result.output,
+        )
+        self.assertEqual(unproven_bundle_result.exit_code, 1)
+        self.assertIn("no verified target-install receipt exists", unproven_bundle_result.output)
+
+    def test_interrupted_same_version_bundle_recovery_is_retryable(self):
+        app = AppContext()
+        app.cfg = Config()
+
+        with TemporaryDirectory() as data_dir, ExitStack() as stack:
+            app.cfg.data_dir = data_dir
+            app.cfg.claw.home_dir = data_dir
+            Path(data_dir, "observability-stack").mkdir()
+            receipt_path = begin_upgrade_receipt(
+                data_dir,
+                from_version="9.9.8",
+                target_version="9.9.9",
+                artifacts_verified=True,
+            )
+            cmd_upgrade_module.record_upgrade_migrations(
+                receipt_path,
+                migration_count=1,
+                degraded=False,
+            )
+            stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._create_backup",
+                    return_value=os.path.join(data_dir, "backup"),
+                )
+            )
+            refresh = stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._run_installed_local_observability_bundle_upgrade",
+                    side_effect=[
+                        _LocalBundleUpgradeInvocationError("child_failed", "refresh"),
+                        {"installed": True, "restart_required": False},
+                    ],
+                )
+            )
+            start = stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._start_and_verify_services"))
+            required = stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._assert_required_cli_migrations"))
+            run_migrations = stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._run_installed_migrations"))
+
+            with self.assertRaises(SystemExit):
+                cmd_upgrade_module._recover_interrupted_same_version_upgrade(
+                    app,
+                    receipt_path=receipt_path,
+                    data_dir=data_dir,
+                    target_version="9.9.9",
+                    os_name="darwin",
+                    health_timeout=60,
+                    config_path=os.path.join(data_dir, "config.yaml"),
+                    recovery_home=data_dir,
+                    upgrade_manifest={"required_cli_migrations": ["9.9.9"]},
+                )
+            self.assertEqual(load_upgrade_receipt(receipt_path).status, "pending")
+
+            cmd_upgrade_module._recover_interrupted_same_version_upgrade(
+                app,
+                receipt_path=receipt_path,
+                data_dir=data_dir,
+                target_version="9.9.9",
+                os_name="darwin",
+                health_timeout=60,
+                config_path=os.path.join(data_dir, "config.yaml"),
+                recovery_home=data_dir,
+                upgrade_manifest={"required_cli_migrations": ["9.9.9"]},
+            )
+
+            self.assertEqual(load_upgrade_receipt(receipt_path).status, "succeeded")
+            self.assertEqual(
+                list((Path(data_dir) / UPGRADE_RECEIPT_DIRECTORY).glob("*.json")),
+                [receipt_path],
+            )
+            self.assertEqual(refresh.call_count, 2)
+            run_migrations.assert_not_called()
+            required.assert_called()
+            start.assert_called_once()
+            self.assertTrue(start.call_args.kwargs["strict_local_observability"])
+            self.assertEqual(start.call_args.kwargs["expected_version"], "9.9.9")
+
+    def test_terminal_restart_custody_is_superseded_before_replacement_success(self):
+        app = AppContext()
+        app.cfg = Config()
+
+        with TemporaryDirectory() as data_dir, ExitStack() as stack:
+            app.cfg.data_dir = data_dir
+            app.cfg.claw.home_dir = data_dir
+            Path(data_dir, "observability-stack").mkdir()
+            superseded = begin_upgrade_receipt(
+                data_dir,
+                from_version="9.9.8",
+                target_version="9.9.9",
+                artifacts_verified=True,
+            )
+            record_local_bundle_restart_intent(superseded, restart_required=True)
+            cmd_upgrade_module.complete_upgrade_receipt(
+                superseded,
+                status="failed",
+                failure_code="local_observability_failed",
+            )
+            replacement = begin_upgrade_receipt(
+                data_dir,
+                from_version="9.9.8",
+                target_version="9.9.9",
+                artifacts_verified=True,
+            )
+            cmd_upgrade_module.record_upgrade_migrations(
+                replacement,
+                migration_count=0,
+                degraded=False,
+            )
+            record_local_bundle_restart_intent(replacement, restart_required=True)
+
+            stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._create_backup",
+                    return_value=os.path.join(data_dir, "backup"),
+                )
+            )
+            stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._assert_required_cli_migrations"))
+            stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._run_installed_local_observability_bundle_upgrade",
+                    return_value={
+                        "installed": True,
+                        "restart_required": True,
+                        "_restart_intent_receipt": str(replacement),
+                    },
+                )
+            )
+            start_attempts = 0
+
+            def start_then_recover(*_args, **_kwargs):
+                nonlocal start_attempts
+                start_attempts += 1
+                if start_attempts == 1:
+                    raise SystemExit(1)
+                clear_local_bundle_restart_intent(replacement)
+
+            stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._start_and_verify_services",
+                    side_effect=start_then_recover,
+                )
+            )
+            original_complete = cmd_upgrade_module.complete_upgrade_receipt
+
+            def complete_after_old_custody_is_superseded(path, **kwargs):
+                marker = load_upgrade_receipt_supersession(superseded)
+                self.assertIsNotNone(marker)
+                self.assertTrue(marker.health_proven)
+                self.assertEqual(
+                    marker.superseded_by_receipt_id,
+                    load_upgrade_receipt(replacement).receipt_id,
+                )
+                self.assertIs(load_local_bundle_restart_intent(superseded), True)
+                return original_complete(path, **kwargs)
+
+            stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade.complete_upgrade_receipt",
+                    side_effect=complete_after_old_custody_is_superseded,
+                )
+            )
+
+            with self.assertRaises(SystemExit):
+                cmd_upgrade_module._recover_interrupted_same_version_upgrade(
+                    app,
+                    receipt_path=replacement,
+                    data_dir=data_dir,
+                    target_version="9.9.9",
+                    os_name="darwin",
+                    health_timeout=60,
+                    config_path=os.path.join(data_dir, "config.yaml"),
+                    recovery_home=data_dir,
+                    upgrade_manifest={"required_cli_migrations": ["9.9.9"]},
+                )
+            self.assertEqual(load_upgrade_receipt(replacement).status, "pending")
+            self.assertIs(load_local_bundle_restart_intent(superseded), True)
+
+            cmd_upgrade_module._recover_interrupted_same_version_upgrade(
+                app,
+                receipt_path=replacement,
+                data_dir=data_dir,
+                target_version="9.9.9",
+                os_name="darwin",
+                health_timeout=60,
+                config_path=os.path.join(data_dir, "config.yaml"),
+                recovery_home=data_dir,
+                upgrade_manifest={"required_cli_migrations": ["9.9.9"]},
+            )
+
+            self.assertEqual(load_upgrade_receipt(replacement).status, "succeeded")
+            self.assertIsNone(load_local_bundle_restart_intent(replacement))
+            replacement.unlink()
+            self.assertIsNone(
+                cmd_upgrade_module.find_resumable_upgrade_receipt(
+                    data_dir,
+                    target_version="9.9.9",
+                )
+            )
+
+    def test_same_version_recovery_rejects_pre_v8_bridge_receipt(self):
+        app = AppContext()
+        app.cfg = Config()
+
+        with TemporaryDirectory() as data_dir:
+            app.cfg.data_dir = data_dir
+            app.cfg.claw.home_dir = data_dir
+            receipt_path = begin_upgrade_receipt(
+                data_dir,
+                from_version="0.8.4",
+                target_version="9.9.9",
+                artifacts_verified=True,
+            )
+            with (
+                patch("defenseclaw.commands.cmd_upgrade._create_backup") as backup,
+                self.assertRaises(SystemExit),
+            ):
+                cmd_upgrade_module._recover_interrupted_same_version_upgrade(
+                    app,
+                    receipt_path=receipt_path,
+                    data_dir=data_dir,
+                    target_version="9.9.9",
+                    os_name="linux",
+                    health_timeout=60,
+                    config_path=os.path.join(data_dir, "config.yaml"),
+                    recovery_home=data_dir,
+                    upgrade_manifest={"required_cli_migrations": ["0.8.5"]},
+                )
+
+            backup.assert_not_called()
+            self.assertEqual(load_upgrade_receipt(receipt_path).status, "pending")
+
+    def test_interrupted_same_version_replays_pending_migrations_before_health(self):
+        app = AppContext()
+        app.cfg = Config()
+
+        with TemporaryDirectory() as data_dir, ExitStack() as stack:
+            app.cfg.data_dir = data_dir
+            app.cfg.claw.home_dir = data_dir
+            receipt_path = begin_upgrade_receipt(
+                data_dir,
+                from_version="9.9.8",
+                target_version="9.9.9",
+                artifacts_verified=True,
+            )
+            stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._create_backup",
+                    return_value=os.path.join(data_dir, "backup"),
+                )
+            )
+            stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._run_silent", return_value=True))
+            quiesced = stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._assert_gateway_quiesced"))
+            run_migrations = stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._run_installed_migrations",
+                    return_value=2,
+                )
+            )
+            required = stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._assert_required_cli_migrations"))
+            start = stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._start_and_verify_services"))
+
+            cmd_upgrade_module._recover_interrupted_same_version_upgrade(
+                app,
+                receipt_path=receipt_path,
+                data_dir=data_dir,
+                target_version="9.9.9",
+                os_name="linux",
+                health_timeout=60,
+                config_path=os.path.join(data_dir, "config.yaml"),
+                recovery_home=data_dir,
+                upgrade_manifest={"required_cli_migrations": ["9.9.9"]},
+            )
+
+            receipt = load_upgrade_receipt(receipt_path)
+            self.assertEqual(receipt.status, "succeeded")
+            self.assertEqual(receipt.migration_status, "completed")
+            self.assertEqual(receipt.migration_count, 2)
+            run_migrations.assert_called_once()
+            self.assertEqual(run_migrations.call_args.args[:2], ("9.9.8", "9.9.9"))
+            quiesced.assert_called_once()
+            required.assert_called_once()
+            start.assert_called_once()
+            self.assertIsNone(start.call_args.kwargs["local_bundle_upgrade"])
+
+            degraded_path = begin_upgrade_receipt(
+                data_dir,
+                from_version="9.9.8",
+                target_version="9.9.9",
+                artifacts_verified=True,
+            )
+            cmd_upgrade_module.record_upgrade_migrations(
+                degraded_path,
+                migration_count=0,
+                degraded=True,
+            )
+            run_migrations.reset_mock()
+            required.reset_mock()
+            start.reset_mock()
+            cmd_upgrade_module._recover_interrupted_same_version_upgrade(
+                app,
+                receipt_path=degraded_path,
+                data_dir=data_dir,
+                target_version="9.9.9",
+                os_name="linux",
+                health_timeout=60,
+                config_path=os.path.join(data_dir, "config.yaml"),
+                recovery_home=data_dir,
+                upgrade_manifest={"required_cli_migrations": ["9.9.9"]},
+            )
+            degraded = load_upgrade_receipt(degraded_path)
+            self.assertEqual(degraded.status, "succeeded")
+            self.assertEqual(degraded.migration_status, "completed")
+            run_migrations.assert_called_once()
+            required.assert_called_once()
+            start.assert_called_once()
 
     def test_required_migration_failure_leaves_target_services_stopped(self):
         runner = CliRunner()
@@ -3944,6 +4468,8 @@ class TestUpgradeServiceVerification(unittest.TestCase):
         recovery_journal_removal_side_effect=None,
         unset_config_data_dir: bool = False,
         controller_home_override: bool = False,
+        installed_local_bundle: bool = False,
+        bundle_refresh_side_effect=None,
     ):
         runner = CliRunner()
         app = AppContext()
@@ -3970,6 +4496,11 @@ class TestUpgradeServiceVerification(unittest.TestCase):
                 "DEFENSECLAW_STAGED_BRIDGE_ARTIFACT_DIR": "/tmp/staged-bridge-artifacts",
             }
             selected_data_dir = data_dir if not unset_config_data_dir else recovery_home
+            if installed_local_bundle:
+                os.makedirs(
+                    os.path.join(selected_data_dir, "observability-stack"),
+                    exist_ok=True,
+                )
             self.invocation_data_dir = selected_data_dir
             self.invocation_recovery_home = recovery_home
             stack.enter_context(patch.dict(os.environ, environment))
@@ -4077,6 +4608,18 @@ class TestUpgradeServiceVerification(unittest.TestCase):
             self.assert_required_migrations = stack.enter_context(
                 patch("defenseclaw.commands.cmd_upgrade._assert_required_cli_migrations")
             )
+            self.local_bundle_refresh = stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._run_installed_local_observability_bundle_upgrade",
+                    return_value={
+                        "installed": True,
+                        "refreshed": True,
+                        "restart_required": False,
+                        "changed_paths": ["docker-compose.yml"],
+                    },
+                    side_effect=bundle_refresh_side_effect,
+                )
+            )
             stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._check_post_upgrade_drift"))
             self.prepare_rollback = stack.enter_context(
                 patch(
@@ -4173,6 +4716,67 @@ class TestUpgradeServiceVerification(unittest.TestCase):
         self.assertEqual(receipt.failure_code, "")
         self.assertIn("Upgrade Complete", result.output)
         poll_health.assert_called_once()
+
+    def test_verified_receipt_precedes_target_migrations_and_bundle_refresh(self):
+        observed_receipts: list[Path] = []
+
+        def assert_receipt_before_migration(*args, **_kwargs):
+            data_dir = args[3]
+            receipt_paths = list(
+                (Path(data_dir) / UPGRADE_RECEIPT_DIRECTORY).glob("*.json")
+            )
+            self.assertEqual(len(receipt_paths), 1)
+            receipt = load_upgrade_receipt(receipt_paths[0])
+            self.assertEqual(receipt.status, "pending")
+            self.assertTrue(receipt.artifacts_verified)
+            self.assertEqual(receipt.from_version, "9.9.8")
+            self.assertEqual(receipt.target_version, "9.9.9")
+            observed_receipts.append(receipt_paths[0])
+            return 0
+
+        result, receipt, _poll_health = self._invoke_upgrade(
+            installed_local_bundle=True,
+            migration_side_effect=assert_receipt_before_migration,
+        )
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(receipt.status, "succeeded")
+        self.assertEqual(len(observed_receipts), 1)
+        self.assertEqual(
+            self.local_bundle_refresh.call_args.kwargs["receipt_path"],
+            observed_receipts[0],
+        )
+
+    def test_normal_future_upgrade_refreshes_installed_bundle_without_rollback_plan(self):
+        result, receipt, poll_health = self._invoke_upgrade(
+            installed_local_bundle=True,
+        )
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(receipt.status, "succeeded")
+        self.local_bundle_refresh.assert_called_once()
+        call = self.local_bundle_refresh.call_args
+        self.assertEqual(call.args[0], self.invocation_data_dir)
+        self.assertEqual(call.args[2], "9.9.9")
+        poll_health.assert_called_once()
+
+    def test_normal_future_bundle_refresh_failure_prevents_target_restart(self):
+        result, receipt, poll_health = self._invoke_upgrade(
+            installed_local_bundle=True,
+            bundle_refresh_side_effect=_LocalBundleUpgradeInvocationError(
+                "activation_failed",
+                "activate",
+            ),
+        )
+
+        self.assertEqual(result.exit_code, 1, msg=result.output)
+        self.assertEqual(receipt.status, "failed")
+        self.assertIn("Local observability bundle refresh failed", result.output)
+        poll_health.assert_not_called()
+        gateway_starts = [
+            call for call in self.run_silent.call_args_list if len(call.args[0]) == 2 and call.args[0][1] == "start"
+        ]
+        self.assertEqual(gateway_starts, [])
 
     def test_unset_config_data_dir_reuses_controller_override_for_all_phases(self):
         result, receipt, _poll_health = self._invoke_upgrade(

--- a/cli/tests/test_local_observability_bundle_upgrade.py
+++ b/cli/tests/test_local_observability_bundle_upgrade.py
@@ -368,6 +368,120 @@ def test_post_stop_backup_failure_retains_exact_restart_intent_before_descriptor
     assert run.call_args.args[0][-1] == "down"
 
 
+def test_receipt_restart_intent_is_recorded_before_stack_stop(
+    installed_bundle: tuple[Path, Path, Path],
+    tmp_path: Path,
+) -> None:
+    source, data_dir, _destination = installed_bundle
+    recorded: list[bool] = []
+
+    def fail_after_intent(event: str, _path: str | None) -> None:
+        if event == "after_restart_intent":
+            raise OSError("stop before stack mutation")
+
+    with (
+        patch("defenseclaw.bundle_refresh.bundled_local_observability_dir", return_value=source),
+        patch("defenseclaw.bundle_refresh._strict_compose_project_running", return_value=True),
+        patch("defenseclaw.bundle_refresh.subprocess.run") as run,
+        pytest.raises(LocalObservabilityUpgradeError, match="backup_failed"),
+    ):
+        upgrade_local_observability_stack(
+            str(data_dir),
+            str(tmp_path / "backup"),
+            bundle_version="8.0.0",
+            fault_injector=fail_after_intent,
+            restart_intent_recorder=recorded.append,
+        )
+
+    assert recorded == [True]
+    run.assert_not_called()
+
+
+def test_failed_receipt_recorder_discards_only_new_custody_and_allows_retry(
+    installed_bundle: tuple[Path, Path, Path],
+    tmp_path: Path,
+) -> None:
+    source, data_dir, destination = installed_bundle
+    before = _managed_snapshot(destination)
+    backup_dir = tmp_path / "backup"
+    recorder_error = OSError("receipt write failed")
+
+    def fail_recorder(_required: bool) -> None:
+        raise recorder_error
+
+    with (
+        patch("defenseclaw.bundle_refresh.bundled_local_observability_dir", return_value=source),
+        patch("defenseclaw.bundle_refresh._strict_compose_project_running", return_value=True),
+        patch("defenseclaw.bundle_refresh.subprocess.run") as run,
+        pytest.raises(LocalObservabilityUpgradeError, match="backup_failed") as raised,
+    ):
+        upgrade_local_observability_stack(
+            str(data_dir),
+            str(backup_dir),
+            bundle_version="8.0.0",
+            restart_intent_recorder=fail_recorder,
+        )
+
+    assert raised.value.__cause__ is recorder_error
+    assert not (backup_dir / "local-observability-stack").exists()
+    assert _managed_snapshot(destination) == before
+    run.assert_not_called()
+
+    with (
+        patch("defenseclaw.bundle_refresh.bundled_local_observability_dir", return_value=source),
+        patch("defenseclaw.bundle_refresh._strict_compose_project_running", return_value=False),
+    ):
+        retried = upgrade_local_observability_stack(
+            str(data_dir),
+            str(backup_dir),
+            bundle_version="8.0.0",
+            restart_intent_recorder=lambda _required: None,
+        )
+
+    assert retried.installed is True
+    assert (backup_dir / "local-observability-stack/refresh-backup.json").is_file()
+
+
+def test_failed_receipt_recorder_cleanup_does_not_follow_replaced_intent_symlink(
+    installed_bundle: tuple[Path, Path, Path],
+    tmp_path: Path,
+) -> None:
+    if os.name != "posix":
+        pytest.skip("symlink race regression requires POSIX")
+    source, data_dir, destination = installed_bundle
+    before = _managed_snapshot(destination)
+    backup_dir = tmp_path / "backup"
+    backup_root = backup_dir / "local-observability-stack"
+    intent = backup_root / "restart-intent.json"
+    sentinel = tmp_path / "must-not-delete"
+    sentinel.write_text("sentinel\n", encoding="utf-8")
+    recorder_error = OSError("receipt write failed")
+
+    def replace_intent_then_fail(_required: bool) -> None:
+        intent.unlink()
+        intent.symlink_to(sentinel)
+        raise recorder_error
+
+    with (
+        patch("defenseclaw.bundle_refresh.bundled_local_observability_dir", return_value=source),
+        patch("defenseclaw.bundle_refresh._strict_compose_project_running", return_value=True),
+        patch("defenseclaw.bundle_refresh.subprocess.run") as run,
+        pytest.raises(LocalObservabilityUpgradeError, match="backup_failed") as raised,
+    ):
+        upgrade_local_observability_stack(
+            str(data_dir),
+            str(backup_dir),
+            bundle_version="8.0.0",
+            restart_intent_recorder=replace_intent_then_fail,
+        )
+
+    assert raised.value.__cause__ is recorder_error
+    assert intent.is_symlink()
+    assert sentinel.read_text(encoding="utf-8") == "sentinel\n"
+    assert _managed_snapshot(destination) == before
+    run.assert_not_called()
+
+
 def test_backup_source_race_fails_before_descriptor_or_bundle_mutation(
     installed_bundle: tuple[Path, Path, Path],
     tmp_path: Path,

--- a/cli/tests/test_local_observability_upgrade_wiring.py
+++ b/cli/tests/test_local_observability_upgrade_wiring.py
@@ -24,8 +24,10 @@ from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import pytest
 from click.testing import CliRunner
 from defenseclaw.commands.cmd_upgrade import (
+    _clear_local_bundle_restart_custody,
     _LocalBundleUpgradeInvocationError,
     _run_installed_local_observability_bundle_upgrade,
     _start_and_verify_services,
@@ -33,14 +35,27 @@ from defenseclaw.commands.cmd_upgrade import (
 )
 from defenseclaw.config import Config
 from defenseclaw.context import AppContext
+from defenseclaw.upgrade_receipt import (
+    begin_upgrade_receipt,
+    load_local_bundle_restart_intent,
+    record_local_bundle_restart_intent,
+)
 
 
 def test_absent_install_skips_target_interpreter(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    receipt_path = begin_upgrade_receipt(
+        str(data_dir),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
     with patch("defenseclaw.commands.cmd_upgrade.subprocess.run") as run:
         result = _run_installed_local_observability_bundle_upgrade(
-            str(tmp_path / "data"),
+            str(data_dir),
             str(tmp_path / "backup"),
             "8.0.0",
+            receipt_path=receipt_path,
             os_name="darwin",
         )
     assert result == {"installed": False}
@@ -54,6 +69,12 @@ def test_target_interpreter_returns_validated_refresh_result(tmp_path: Path) -> 
     python = home / ".defenseclaw/.venv/bin/python"
     python.parent.mkdir(parents=True)
     python.write_text("python\n", encoding="utf-8")
+    receipt_path = begin_upgrade_receipt(
+        str(data_dir),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
 
     def child(args, **_kwargs):
         result_path = args[-1]
@@ -81,6 +102,7 @@ def test_target_interpreter_returns_validated_refresh_result(tmp_path: Path) -> 
             str(data_dir),
             str(tmp_path / "backup"),
             "8.0.0",
+            receipt_path=receipt_path,
             os_name="darwin",
         )
 
@@ -94,8 +116,56 @@ def test_target_interpreter_returns_validated_refresh_result(tmp_path: Path) -> 
         str(data_dir),
         str(tmp_path / "backup"),
         "8.0.0",
+        str(receipt_path),
         command[-1],
     ]
+
+
+def test_refresh_preserves_durable_restart_intent_across_retry(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    (data_dir / "observability-stack").mkdir(parents=True)
+    home = tmp_path / "home"
+    python = home / ".defenseclaw/.venv/bin/python"
+    python.parent.mkdir(parents=True)
+    python.write_text("python\n", encoding="utf-8")
+    receipt_path = begin_upgrade_receipt(
+        str(data_dir),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    record_local_bundle_restart_intent(receipt_path, restart_required=True)
+
+    def child(args, **_kwargs):
+        Path(args[-1]).write_text(
+            json.dumps(
+                {
+                    "ok": True,
+                    "result": {
+                        "installed": True,
+                        "refreshed": False,
+                        "restart_required": False,
+                        "changed_paths": [],
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return Mock(returncode=0, stdout="", stderr="")
+
+    with (
+        patch.dict(os.environ, {"DEFENSECLAW_HOME": str(home / ".defenseclaw")}),
+        patch("defenseclaw.commands.cmd_upgrade.subprocess.run", side_effect=child),
+    ):
+        result = _run_installed_local_observability_bundle_upgrade(
+            str(data_dir),
+            str(tmp_path / "backup"),
+            "8.0.0",
+            receipt_path=receipt_path,
+            os_name="darwin",
+        )
+
+    assert result["restart_required"] is True
 
 
 def test_local_stack_restart_occurs_only_when_preupgrade_stack_was_running() -> None:
@@ -130,6 +200,94 @@ def test_local_stack_restart_occurs_only_when_preupgrade_stack_was_running() -> 
         health_timeout=5,
         os_name="darwin",
     )
+
+
+def test_successful_restart_releases_receipt_bound_restart_custody(tmp_path: Path) -> None:
+    app = AppContext()
+    app.cfg = Config(data_dir=str(tmp_path))
+    receipt_path = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    record_local_bundle_restart_intent(receipt_path, restart_required=True)
+
+    with (
+        patch("defenseclaw.commands.cmd_upgrade._run_silent", return_value=True),
+        patch("defenseclaw.commands.cmd_upgrade._poll_health"),
+        patch(
+            "defenseclaw.commands.cmd_upgrade._run_installed_local_observability_bundle_restart",
+            return_value={"installed": True, "restarted": True, "degraded_errors": []},
+        ),
+    ):
+        _start_and_verify_services(
+            app,
+            5,
+            data_dir=str(tmp_path),
+            local_bundle_upgrade={
+                "installed": True,
+                "restart_required": True,
+                "_restart_intent_receipt": str(receipt_path),
+            },
+            os_name="darwin",
+        )
+
+    assert load_local_bundle_restart_intent(receipt_path) is None
+
+
+def test_successful_restart_custody_cleanup_failure_is_deferred() -> None:
+    with (
+        patch(
+            "defenseclaw.commands.cmd_upgrade.clear_local_bundle_restart_intent",
+            side_effect=OSError("temporary filesystem failure"),
+        ),
+        patch("defenseclaw.commands.cmd_upgrade.ux.warn") as warn,
+    ):
+        cleared = _clear_local_bundle_restart_custody(
+            {"_restart_intent_receipt": "/tmp/restart-receipt.json"}
+        )
+
+    assert cleared is False
+    warn.assert_called_once()
+
+
+def test_strict_restart_custody_cleanup_failure_prevents_success(tmp_path: Path) -> None:
+    app = AppContext()
+    app.cfg = Config(data_dir=str(tmp_path))
+    receipt_path = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    record_local_bundle_restart_intent(receipt_path, restart_required=True)
+
+    with (
+        patch("defenseclaw.commands.cmd_upgrade._run_silent", return_value=True),
+        patch("defenseclaw.commands.cmd_upgrade._poll_health"),
+        patch(
+            "defenseclaw.commands.cmd_upgrade._run_installed_local_observability_bundle_restart",
+            return_value={"installed": True, "restarted": True, "degraded_errors": []},
+        ),
+        patch(
+            "defenseclaw.commands.cmd_upgrade.clear_local_bundle_restart_intent",
+            side_effect=OSError("temporary filesystem failure"),
+        ),
+        pytest.raises(SystemExit),
+    ):
+        _start_and_verify_services(
+            app,
+            5,
+            data_dir=str(tmp_path),
+            local_bundle_upgrade={
+                "installed": True,
+                "restart_required": True,
+                "_restart_intent_receipt": str(receipt_path),
+            },
+            os_name="darwin",
+            strict_local_observability=True,
+        )
 
 
 def test_bundle_refresh_failure_prevents_all_target_restarts(tmp_path: Path) -> None:

--- a/cli/tests/test_observability_v8_upgrade_migration.py
+++ b/cli/tests/test_observability_v8_upgrade_migration.py
@@ -24,6 +24,7 @@ from defenseclaw.migrations import (
     _allocate_observability_v8_bundle_backup,
     _migrate_observability_v8,
     _observability_v8_upgrade_environment,
+    _valid_upgrade_mutation_token,
     _validate_observability_v8_candidate,
     preflight_observability_v8_upgrade,
     run_migrations,
@@ -31,6 +32,7 @@ from defenseclaw.migrations import (
 from defenseclaw.observability.v8_activation import V8ActivationError
 from defenseclaw.observability.v8_config import MAX_SOURCE_BYTES
 from defenseclaw.observability.v8_migration import V8MigrationError
+from defenseclaw.upgrade_receipt import begin_upgrade_receipt
 
 
 class TestObservabilityV8UpgradeMigration(unittest.TestCase):
@@ -59,6 +61,16 @@ class TestObservabilityV8UpgradeMigration(unittest.TestCase):
     def tearDown(self) -> None:
         self.root.cleanup()
 
+    def _begin_verified_upgrade_receipt(self, target_version: str = "9.9.9") -> str:
+        return os.fspath(
+            begin_upgrade_receipt(
+                self.data_dir,
+                from_version="0.8.5",
+                target_version=target_version,
+                artifacts_verified=True,
+            )
+        )
+
     def test_registry_runs_migration_only_at_forward_release_key(self) -> None:
         rows = [(version, fn) for version, _description, fn in MIGRATIONS if fn is _migrate_observability_v8]
         self.assertEqual(rows, [("0.8.5", _migrate_observability_v8)])
@@ -83,9 +95,7 @@ class TestObservabilityV8UpgradeMigration(unittest.TestCase):
             candidate=b"config_version: 8\n",
             source_sha256="1" * 64,
             candidate_sha256="2" * 64,
-            environment_dependencies=(
-                SimpleNamespace(name="DOTENV_ONLY", present=True, value_sha256="3" * 64),
-            ),
+            environment_dependencies=(SimpleNamespace(name="DOTENV_ONLY", present=True, value_sha256="3" * 64),),
             environment_edits=(
                 SimpleNamespace(
                     name="MOVED_SECRET",
@@ -114,9 +124,7 @@ class TestObservabilityV8UpgradeMigration(unittest.TestCase):
             patch.dict(os.environ, {}, clear=True),
             patch("defenseclaw.migrations.convert_v7_observability_to_v8", return_value=migration) as convert,
             patch("defenseclaw.migrations.inspect_v8_config", side_effect=inspect),
-            patch(
-                "defenseclaw.migrations.preflight_v8_migration_activation"
-            ) as activation_preflight,
+            patch("defenseclaw.migrations.preflight_v8_migration_activation") as activation_preflight,
             patch("defenseclaw.migrations.activate_v8_migration") as activate,
         ):
             binding = preflight_observability_v8_upgrade(
@@ -210,9 +218,7 @@ class TestObservabilityV8UpgradeMigration(unittest.TestCase):
 
     def _real_preflight_binding(self) -> ObservabilityV8PreflightBinding:
         with open(self.config_path, "wb") as config_file:
-            config_file.write(
-                f"config_version: 7\ndata_dir: {self.data_dir}\n".encode()
-            )
+            config_file.write(f"config_version: 7\ndata_dir: {self.data_dir}\n".encode())
         with (
             patch.dict(os.environ, {}, clear=True),
             patch(
@@ -380,6 +386,18 @@ class TestObservabilityV8UpgradeMigration(unittest.TestCase):
         self.assertEqual(raised.exception.code, "preflight_binding_missing")
         activate.assert_not_called()
 
+    def test_malformed_target_mutation_token_is_not_a_hard_cut_capability(self) -> None:
+        for token in ("a" * 31, "A" * 32, "g" * 32):
+            with (
+                self.subTest(token=token),
+                patch.dict(
+                    os.environ,
+                    {"DEFENSECLAW_UPGRADE_MUTATION_TOKEN": token},
+                    clear=True,
+                ),
+            ):
+                self.assertFalse(_valid_upgrade_mutation_token())
+
     @unittest.skipIf(os.name == "nt", "POSIX backup-root mode assertion")
     def test_target_rejects_config_changed_after_real_locks_before_any_activation_mutation(
         self,
@@ -407,11 +425,7 @@ class TestObservabilityV8UpgradeMigration(unittest.TestCase):
         os.chmod(backup_root, 0o755)
         binding = self._real_preflight_binding()
         config_before = open(self.config_path, "rb").read()
-        environment_before = (
-            open(self.environment_path, "rb").read()
-            if os.path.exists(self.environment_path)
-            else None
-        )
+        environment_before = open(self.environment_path, "rb").read() if os.path.exists(self.environment_path) else None
         config_mutation = b"# post-lock uncooperative config edit\n"
         environment_mutation = b"# post-lock comment-only dotenv edit\n"
         created_environment = b"POST_LOCK_CREATED=1\n"
@@ -767,7 +781,12 @@ audit_sinks:
         ):
             _migrate_observability_v8(self.ctx)
 
-        refresh.assert_called_once_with(self.data_dir, backup, "0.8.5")
+        refresh.assert_called_once_with(
+            self.data_dir,
+            backup,
+            "0.8.5",
+            restart_intent_receipt=None,
+        )
         self.assertEqual(
             self.ctx.changes,
             [
@@ -792,6 +811,235 @@ audit_sinks:
             _migrate_observability_v8(self.ctx)
 
         refresh.assert_not_called()
+
+    def test_immutable_v8_controller_repairs_bundle_after_noop_future_upgrade(self) -> None:
+        os.makedirs(os.path.join(self.data_dir, "observability-stack"))
+        receipt_path = self._begin_verified_upgrade_receipt()
+        with (
+            patch.dict(
+                os.environ,
+                {"DEFENSECLAW_UPGRADE_MUTATION_TOKEN": ""},
+                clear=True,
+            ),
+            patch(
+                "defenseclaw.migrations._run_observability_v8_bundle_upgrade_in_target",
+                return_value={"installed": True, "degraded_errors": []},
+            ) as refresh,
+        ):
+            count = run_migrations(
+                "0.8.5",
+                "9.9.9",
+                self.ctx.openclaw_home,
+                self.data_dir,
+                upgrade_handles_local_bundle=True,
+            )
+
+        self.assertEqual(count, 0)
+        refresh.assert_called_once()
+        self.assertEqual(refresh.call_args.args[0], self.data_dir)
+        self.assertEqual(refresh.call_args.args[2], "9.9.9")
+        self.assertEqual(refresh.call_args.kwargs["restart_intent_receipt"], receipt_path)
+
+    def test_immutable_v8_controller_requires_durable_bundle_recovery_authority(self) -> None:
+        os.makedirs(os.path.join(self.data_dir, "observability-stack"))
+        with (
+            patch.dict(
+                os.environ,
+                {"DEFENSECLAW_UPGRADE_MUTATION_TOKEN": ""},
+                clear=True,
+            ),
+            patch("defenseclaw.migrations._run_observability_v8_bundle_upgrade_in_target") as refresh,
+            self.assertRaisesRegex(
+                ObservabilityV8UpgradeMigrationError,
+                "local_bundle_receipt_missing",
+            ),
+        ):
+            run_migrations(
+                "0.8.5",
+                "9.9.9",
+                self.ctx.openclaw_home,
+                self.data_dir,
+                upgrade_handles_local_bundle=True,
+            )
+
+        refresh.assert_not_called()
+
+    def test_immutable_v8_controller_skips_receipt_when_no_bundle_is_installed(self) -> None:
+        with (
+            patch.dict(
+                os.environ,
+                {"DEFENSECLAW_UPGRADE_MUTATION_TOKEN": ""},
+                clear=True,
+            ),
+            patch("defenseclaw.migrations._run_observability_v8_bundle_upgrade_in_target") as refresh,
+        ):
+            count = run_migrations(
+                "0.8.5",
+                "9.9.9",
+                self.ctx.openclaw_home,
+                self.data_dir,
+                upgrade_handles_local_bundle=True,
+            )
+
+        self.assertEqual(count, 0)
+        refresh.assert_not_called()
+
+    def test_immutable_controller_defers_bundle_refresh_after_future_migration_failure(self) -> None:
+        os.makedirs(os.path.join(self.data_dir, "observability-stack"))
+
+        def fail_future_migration(_ctx: MigrationContext) -> None:
+            raise RuntimeError("future migration failed")
+
+        with (
+            patch.dict(
+                os.environ,
+                {"DEFENSECLAW_UPGRADE_MUTATION_TOKEN": ""},
+                clear=True,
+            ),
+            patch(
+                "defenseclaw.migrations.MIGRATIONS",
+                [("9.9.9", "future migration", fail_future_migration)],
+            ),
+            patch("defenseclaw.migrations._run_observability_v8_bundle_upgrade_in_target") as refresh,
+        ):
+            count = run_migrations(
+                "0.8.5",
+                "9.9.9",
+                self.ctx.openclaw_home,
+                self.data_dir,
+                upgrade_handles_local_bundle=True,
+            )
+
+        self.assertEqual(count, 0)
+        refresh.assert_not_called()
+
+    def test_capable_controller_suppresses_target_bundle_fallback(self) -> None:
+        os.makedirs(os.path.join(self.data_dir, "observability-stack"))
+        with (
+            patch.dict(
+                os.environ,
+                {"DEFENSECLAW_UPGRADE_MUTATION_TOKEN": ""},
+                clear=True,
+            ),
+            patch("defenseclaw.migrations._run_observability_v8_bundle_upgrade_in_target") as refresh,
+        ):
+            count = run_migrations(
+                "0.8.5",
+                "9.9.9",
+                self.ctx.openclaw_home,
+                self.data_dir,
+                upgrade_handles_local_bundle=True,
+                controller_owns_local_bundle_transaction=True,
+            )
+
+        self.assertEqual(count, 0)
+        refresh.assert_not_called()
+
+    def test_controller_bundle_ownership_is_effective_migration_context_capability(self) -> None:
+        observed: list[bool] = []
+
+        def capture_context(ctx: MigrationContext) -> None:
+            observed.append(ctx.upgrade_handles_local_bundle)
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "defenseclaw.migrations.MIGRATIONS",
+                [("9.9.9", "future migration", capture_context)],
+            ),
+            patch("defenseclaw.migrations._run_observability_v8_bundle_upgrade_in_target") as refresh,
+        ):
+            count = run_migrations(
+                "0.8.5",
+                "9.9.9",
+                self.ctx.openclaw_home,
+                self.data_dir,
+                upgrade_handles_local_bundle=False,
+                controller_owns_local_bundle_transaction=True,
+            )
+
+        self.assertEqual(count, 1)
+        self.assertEqual(observed, [True])
+        refresh.assert_not_called()
+
+    def test_hard_cut_mutation_token_suppresses_target_bundle_fallback(self) -> None:
+        os.makedirs(os.path.join(self.data_dir, "observability-stack"))
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "DEFENSECLAW_UPGRADE_MUTATION_TOKEN": "a" * 32,
+                    "DEFENSECLAW_OBSERVABILITY_V8_PREFLIGHT_BINDING": "null",
+                },
+                clear=True,
+            ),
+            patch("defenseclaw.migrations._run_observability_v8_bundle_upgrade_in_target") as refresh,
+        ):
+            count = run_migrations(
+                "0.8.5",
+                "9.9.9",
+                self.ctx.openclaw_home,
+                self.data_dir,
+                upgrade_handles_local_bundle=True,
+            )
+
+        self.assertEqual(count, 0)
+        refresh.assert_not_called()
+
+    def test_unpaired_ambient_mutation_token_does_not_suppress_bundle_repair(self) -> None:
+        os.makedirs(os.path.join(self.data_dir, "observability-stack"))
+        receipt_path = self._begin_verified_upgrade_receipt()
+        with (
+            patch.dict(
+                os.environ,
+                {"DEFENSECLAW_UPGRADE_MUTATION_TOKEN": "a" * 32},
+                clear=True,
+            ),
+            patch(
+                "defenseclaw.migrations._run_observability_v8_bundle_upgrade_in_target",
+                return_value={"installed": True, "degraded_errors": []},
+            ) as refresh,
+        ):
+            count = run_migrations(
+                "0.8.5",
+                "9.9.9",
+                self.ctx.openclaw_home,
+                self.data_dir,
+                upgrade_handles_local_bundle=True,
+            )
+
+        self.assertEqual(count, 0)
+        refresh.assert_called_once()
+        self.assertEqual(refresh.call_args.kwargs["restart_intent_receipt"], receipt_path)
+
+    def test_malformed_hard_cut_binding_does_not_grant_bundle_custody(self) -> None:
+        os.makedirs(os.path.join(self.data_dir, "observability-stack"))
+        receipt_path = self._begin_verified_upgrade_receipt()
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "DEFENSECLAW_UPGRADE_MUTATION_TOKEN": "a" * 32,
+                    "DEFENSECLAW_OBSERVABILITY_V8_PREFLIGHT_BINDING": "{}",
+                },
+                clear=True,
+            ),
+            patch(
+                "defenseclaw.migrations._run_observability_v8_bundle_upgrade_in_target",
+                return_value={"installed": True, "degraded_errors": []},
+            ) as refresh,
+        ):
+            count = run_migrations(
+                "0.8.5",
+                "9.9.9",
+                self.ctx.openclaw_home,
+                self.data_dir,
+                upgrade_handles_local_bundle=True,
+            )
+
+        self.assertEqual(count, 0)
+        refresh.assert_called_once()
+        self.assertEqual(refresh.call_args.kwargs["restart_intent_receipt"], receipt_path)
 
     @unittest.skipIf(os.name != "posix", "descriptor-relative backup creation is POSIX-only")
     def test_retry_allocates_private_bundle_backup_directory(self) -> None:

--- a/cli/tests/test_resolve_upgrade_baselines.py
+++ b/cli/tests/test_resolve_upgrade_baselines.py
@@ -61,9 +61,7 @@ def _release(
     windows_assets = RESOLVER._required_windows_assets(version)
     for name in windows_assets:
         payload_digests[name] = _digest(f"payload:{name}".encode())
-    checksums = "".join(
-        f"{digest}  {name}\n" for name, digest in sorted(payload_digests.items())
-    ).encode()
+    checksums = "".join(f"{digest}  {name}\n" for name, digest in sorted(payload_digests.items())).encode()
     downloaded = {
         f"https://downloads.example/{version}/checksums.txt": checksums,
         f"https://downloads.example/{version}/checksums.txt.pem": b"certificate\n",
@@ -106,13 +104,13 @@ def _resolve(
     target: str,
     releases_and_downloads: list[tuple[dict[str, object], dict[str, bytes]]],
     *,
+    candidate_runtime_config_version: int = 8,
+    checked_policy_path: Path | None = None,
     verify=None,
 ) -> dict[str, object]:
     releases = [item[0] for item in releases_and_downloads]
     downloads = {
-        url: payload
-        for _, release_downloads in releases_and_downloads
-        for url, payload in release_downloads.items()
+        url: payload for _, release_downloads in releases_and_downloads for url, payload in release_downloads.items()
     }
 
     def download(url: str, maximum: int) -> bytes:
@@ -122,9 +120,9 @@ def _resolve(
 
     return RESOLVER.resolve_effective_policy(
         target_version=target,
-        candidate_runtime_config_version=8,
+        candidate_runtime_config_version=candidate_runtime_config_version,
         releases=releases,
-        checked_policy_path=ROOT / "release" / "upgrade-baselines.json",
+        checked_policy_path=checked_policy_path or ROOT / "release" / "upgrade-baselines.json",
         download=download,
         verify=verify or (lambda *_: None),
     )
@@ -165,6 +163,74 @@ def test_087_discovers_all_newer_immutable_stables_without_a_policy_edit() -> No
         "0.8.3",
     ]
     assert policy["published_baseline_config_versions"]["0.8.6"] == 8
+
+
+def test_candidate_below_checked_head_discovers_release_above_eligible_floor(
+    tmp_path: Path,
+) -> None:
+    checked_policy = tmp_path / "upgrade-baselines.json"
+    checked_policy.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "published_baselines": ["0.8.4", "0.8.1", "0.8.0"],
+                "published_baseline_config_versions": {
+                    "0.8.4": 7,
+                    "0.8.1": 6,
+                    "0.8.0": 6,
+                },
+                "platform_published_baselines": {"windows": ["0.8.0"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    policy = _resolve(
+        "0.8.3",
+        [_release("0.8.2")],
+        checked_policy_path=checked_policy,
+    )
+
+    assert policy["published_baselines"] == ["0.8.2", "0.8.1", "0.8.0"]
+
+
+def test_legacy_candidate_filters_checked_baselines_that_are_not_older() -> None:
+    policy = _resolve("0.8.3", [])
+
+    assert policy["published_baselines"][:3] == ["0.8.2", "0.8.1", "0.8.0"]
+    assert "0.8.4" not in policy["published_baselines"]
+    assert "0.8.3" not in policy["published_baselines"]
+    assert "0.8.4" not in policy["published_baseline_config_versions"]
+
+
+def test_ineligible_newer_config_does_not_reject_legacy_candidate() -> None:
+    policy = _resolve("0.8.3", [], candidate_runtime_config_version=6)
+
+    assert policy["published_baselines"][0] == "0.8.2"
+    assert set(policy["published_baseline_config_versions"].values()) <= {5, 6}
+
+
+def test_eligible_newer_config_still_rejects_candidate() -> None:
+    with pytest.raises(
+        RESOLVER.BaselineResolutionError,
+        match="eligible checked baseline config version is newer",
+    ):
+        _resolve("0.8.5", [], candidate_runtime_config_version=6)
+
+
+def test_candidate_at_or_below_support_floor_requires_explicit_fixture() -> None:
+    checked_policy = json.loads(
+        (ROOT / "release" / "upgrade-baselines.json").read_text(encoding="utf-8")
+    )
+    support_floor = checked_policy["published_baselines"][-1]
+    assert tuple(map(int, support_floor.split("."))) > (0, 0, 0)
+
+    for candidate in ("0.0.0", support_floor):
+        with pytest.raises(
+            RESOLVER.BaselineResolutionError,
+            match="no supported published baseline",
+        ):
+            _resolve(candidate, [])
 
 
 def test_actual_complete_windows_assets_control_platform_availability(
@@ -214,7 +280,7 @@ def test_manifest_must_be_covered_by_authenticated_checksums() -> None:
     release, downloads = _release("0.8.5")
     downloads = dict(downloads)
     manifest_url = "https://downloads.example/0.8.5/upgrade-manifest.json"
-    downloads[manifest_url] = b'{}'
+    downloads[manifest_url] = b"{}"
     for asset in release["assets"]:
         if asset["name"] == "upgrade-manifest.json":
             asset["digest"] = f"sha256:{_digest(downloads[manifest_url])}"
@@ -291,9 +357,6 @@ def test_sigstore_verification_uses_bounded_wrapper_and_exact_release_identity(
     assert str(ROOT / "scripts/verify-sigstore-blob.py") in observed
     identity = observed[observed.index("--certificate-identity") + 1]
     assert identity == (
-        "https://github.com/cisco-ai-defense/defenseclaw/"
-        ".github/workflows/release.yaml@refs/heads/main"
+        "https://github.com/cisco-ai-defense/defenseclaw/.github/workflows/release.yaml@refs/heads/main"
     )
-    assert observed[observed.index("--certificate-oidc-issuer") + 1] == (
-        "https://token.actions.githubusercontent.com"
-    )
+    assert observed[observed.index("--certificate-oidc-issuer") + 1] == ("https://token.actions.githubusercontent.com")

--- a/cli/tests/test_upgrade_receipt.py
+++ b/cli/tests/test_upgrade_receipt.py
@@ -5,18 +5,72 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import stat
 from pathlib import Path
 
 import pytest
+from defenseclaw import upgrade_receipt as upgrade_receipt_module
 from defenseclaw.upgrade_receipt import (
+    MAX_UPGRADE_RECEIPTS,
     UPGRADE_RECEIPT_DIRECTORY,
     begin_upgrade_receipt,
+    clear_local_bundle_restart_intent,
     complete_upgrade_receipt,
+    delegate_prior_upgrade_receipts,
     finalize_interrupted_upgrade_receipts,
+    find_resumable_upgrade_receipt,
+    find_verified_installed_upgrade_receipt,
+    load_local_bundle_restart_intent,
     load_upgrade_receipt,
+    load_upgrade_receipt_supersession,
+    record_local_bundle_restart_intent,
     record_upgrade_migrations,
+    record_upgrade_receipt_supersession,
+    supersede_prior_upgrade_receipts,
 )
+
+
+def _symlink_or_skip(
+    link: Path,
+    target: Path,
+    *,
+    target_is_directory: bool = False,
+) -> None:
+    if not hasattr(os, "symlink"):
+        pytest.skip("symlinks unavailable")
+    try:
+        link.symlink_to(target, target_is_directory=target_is_directory)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+
+def test_python_and_go_recoverable_failure_codes_match() -> None:
+    repository_root = Path(__file__).resolve().parents[2]
+    go_source = (repository_root / "internal/gateway/upgrade_receipt.go").read_text(encoding="utf-8")
+    function_marker = "func upgradeReceiptRecoverableFailure("
+    authority_marker = "\nfunc upgradeReceiptRecoveryAuthority"
+    assert function_marker in go_source, "Go recovery failure-code function is missing"
+    function_start = go_source.index(function_marker)
+    assert authority_marker in go_source[function_start:], "Go recovery-authority function is missing"
+    function_end = go_source.index(authority_marker, function_start)
+    function_source = go_source[function_start:function_end]
+    switch_body = re.search(
+        r"switch receipt\.FailureCode \{(?P<body>.*?)\n\tdefault:",
+        function_source,
+        flags=re.DOTALL,
+    )
+
+    assert switch_body is not None, "Go recoverable failure-code switch is missing"
+    case_labels = re.findall(
+        r'(?m)^\s*case\s+("[a-z_]+"(?:\s*,\s*"[a-z_]+")*)\s*:',
+        switch_body.group("body"),
+    )
+    assert case_labels, "Go recoverable failure-code case labels are missing"
+    go_failure_codes = frozenset(
+        code for labels in case_labels for code in re.findall(r'"([a-z_]+)"', labels)
+    )
+    assert go_failure_codes == upgrade_receipt_module._RECOVERABLE_TARGET_FAILURE_CODES
 
 
 def test_receipt_is_private_atomic_and_contains_only_bounded_facts(tmp_path: Path) -> None:
@@ -100,6 +154,159 @@ def test_retry_never_promotes_an_abandoned_attempt_to_success(tmp_path: Path) ->
     assert receipt.artifacts_verified is False
 
 
+def test_resumable_lookup_is_read_only_and_requires_one_verified_target(tmp_path: Path) -> None:
+    receipt_dir = tmp_path / UPGRADE_RECEIPT_DIRECTORY
+    assert find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0") is None
+    assert not receipt_dir.exists()
+
+    path = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    assert find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0") == path
+    assert find_resumable_upgrade_receipt(str(tmp_path), target_version="8.1.0") is None
+
+
+def test_resumable_lookup_refuses_unverified_or_ambiguous_target(tmp_path: Path) -> None:
+    begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=False,
+    )
+    with pytest.raises(ValueError, match="did not authenticate"):
+        find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0")
+
+    other = tmp_path / "other"
+    begin_upgrade_receipt(
+        str(other),
+        from_version="7.8.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    begin_upgrade_receipt(
+        str(other),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    with pytest.raises(ValueError, match="multiple pending"):
+        find_resumable_upgrade_receipt(str(other), target_version="8.0.0")
+
+
+def test_resumable_lookup_uses_failed_target_until_health_proven_success(tmp_path: Path) -> None:
+    failed = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    record_upgrade_migrations(failed, migration_count=1, degraded=False)
+    complete_upgrade_receipt(
+        failed,
+        status="failed",
+        failure_code="local_observability_failed",
+    )
+    assert find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0") == failed
+
+    succeeded = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="8.0.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    record_upgrade_migrations(succeeded, migration_count=0, degraded=False)
+    record_upgrade_receipt_supersession(
+        failed,
+        replacement_path=succeeded,
+        health_proven=True,
+    )
+    complete_upgrade_receipt(succeeded, status="succeeded")
+    assert find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0") is None
+    assert find_verified_installed_upgrade_receipt(str(tmp_path), target_version="8.0.0") == succeeded
+
+
+def test_installed_authority_requires_verified_terminal_success(tmp_path: Path) -> None:
+    unverified = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=False,
+    )
+    record_upgrade_migrations(unverified, migration_count=1, degraded=False)
+    complete_upgrade_receipt(unverified, status="succeeded")
+    assert find_verified_installed_upgrade_receipt(str(tmp_path), target_version="8.0.0") is None
+
+    verified = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    record_upgrade_migrations(verified, migration_count=1, degraded=True)
+    complete_upgrade_receipt(verified, status="partial")
+    assert find_verified_installed_upgrade_receipt(str(tmp_path), target_version="8.0.0") == verified
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX ownership and mode contract")
+def test_recovery_lookup_rejects_replaceable_or_malformed_queue_entries(tmp_path: Path) -> None:
+    path = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    os.chmod(path.parent, 0o755)
+    with pytest.raises(OSError, match="accessible to other accounts"):
+        find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0")
+
+    os.chmod(path.parent, 0o700)
+    path.write_text("not-json", encoding="utf-8")
+    os.chmod(path, 0o600)
+    with pytest.raises(ValueError, match="invalid entry"):
+        find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0")
+
+
+def test_recovery_lookup_rejects_symlinked_queue_or_record(tmp_path: Path) -> None:
+    actual_root = tmp_path / "actual"
+    begin_upgrade_receipt(
+        str(actual_root),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    linked_root = tmp_path / "linked"
+    linked_root.mkdir()
+    _symlink_or_skip(
+        linked_root / UPGRADE_RECEIPT_DIRECTORY,
+        actual_root / UPGRADE_RECEIPT_DIRECTORY,
+        target_is_directory=True,
+    )
+    with pytest.raises(OSError, match="private directory"):
+        find_resumable_upgrade_receipt(str(linked_root), target_version="8.0.0")
+
+    receipt_dir = actual_root / UPGRADE_RECEIPT_DIRECTORY
+    target = next(receipt_dir.glob("*.json"))
+    symlink = receipt_dir / "00000000-0000-0000-0000-000000000000.json"
+    _symlink_or_skip(symlink, target)
+    with pytest.raises(ValueError, match="unsafe entry"):
+        find_resumable_upgrade_receipt(str(actual_root), target_version="8.0.0")
+
+
+def test_recovery_lookup_enforces_receipt_queue_bound(tmp_path: Path) -> None:
+    receipt_dir = tmp_path / UPGRADE_RECEIPT_DIRECTORY
+    receipt_dir.mkdir(mode=0o700)
+    for index in range(MAX_UPGRADE_RECEIPTS + 1):
+        path = receipt_dir / f"{index:064x}.json"
+        path.write_text("{}", encoding="utf-8")
+        if os.name == "posix":
+            os.chmod(path, 0o600)
+    with pytest.raises(OSError, match="exceeds its bound"):
+        find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0")
+
+
 def test_unknown_fields_and_symlink_receipts_are_rejected(tmp_path: Path) -> None:
     path = begin_upgrade_receipt(
         str(tmp_path),
@@ -116,7 +323,290 @@ def test_unknown_fields_and_symlink_receipts_are_rejected(tmp_path: Path) -> Non
     target = tmp_path / "target.json"
     target.write_text("{}", encoding="utf-8")
     symlink = path.parent / "00000000-0000-0000-0000-000000000000.json"
-    if hasattr(os, "symlink"):
-        symlink.symlink_to(target)
-        with pytest.raises(ValueError, match="regular"):
-            load_upgrade_receipt(symlink)
+    _symlink_or_skip(symlink, target)
+    with pytest.raises(ValueError, match="regular"):
+        load_upgrade_receipt(symlink)
+
+
+@pytest.mark.parametrize("writer", ["receipt", "metadata"])
+def test_atomic_writers_do_not_close_transferred_descriptor_twice(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    writer: str,
+) -> None:
+    path = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    original_mkstemp = upgrade_receipt_module.tempfile.mkstemp
+    original_close = upgrade_receipt_module.os.close
+    descriptors: list[int] = []
+    explicit_closes: list[int] = []
+
+    def tracked_mkstemp(*args: object, **kwargs: object) -> tuple[int, str]:
+        descriptor, temporary = original_mkstemp(*args, **kwargs)
+        explicit_closes.clear()
+        descriptors.append(descriptor)
+        return descriptor, temporary
+
+    def tracked_close(descriptor: int) -> None:
+        explicit_closes.append(descriptor)
+        original_close(descriptor)
+
+    def fail_replace(_source: object, _target: object) -> None:
+        raise OSError("injected replace failure")
+
+    monkeypatch.setattr(upgrade_receipt_module.tempfile, "mkstemp", tracked_mkstemp)
+    monkeypatch.setattr(upgrade_receipt_module.os, "close", tracked_close)
+    monkeypatch.setattr(upgrade_receipt_module.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="injected replace failure"):
+        if writer == "receipt":
+            record_upgrade_migrations(path, migration_count=1, degraded=False)
+        else:
+            record_local_bundle_restart_intent(path, restart_required=True)
+
+    assert len(descriptors) == 1
+    assert descriptors[0] not in explicit_closes
+
+
+def test_local_bundle_restart_intent_is_private_monotonic_and_receipt_bound(
+    tmp_path: Path,
+) -> None:
+    path = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    assert load_local_bundle_restart_intent(path) is None
+    assert record_local_bundle_restart_intent(path, restart_required=False) is False
+    assert record_local_bundle_restart_intent(path, restart_required=True) is True
+    assert record_local_bundle_restart_intent(path, restart_required=False) is True
+    assert load_local_bundle_restart_intent(path) is True
+
+    intent_path = next(path.parent.glob("*.local-bundle-intent"))
+    if os.name == "posix":
+        assert stat.S_IMODE(intent_path.stat().st_mode) == 0o600
+    complete_upgrade_receipt(
+        path,
+        status="failed",
+        failure_code="local_observability_failed",
+    )
+    assert load_local_bundle_restart_intent(path) is True
+
+
+def test_cleared_local_bundle_restart_intent_stays_absent_after_success(
+    tmp_path: Path,
+) -> None:
+    path = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    record_local_bundle_restart_intent(path, restart_required=True)
+    intent_path = next(path.parent.glob("*.local-bundle-intent"))
+    clear_local_bundle_restart_intent(path)
+    complete_upgrade_receipt(path, status="succeeded")
+    assert not intent_path.exists()
+
+
+def test_clear_local_bundle_restart_intent_preserves_unlink_errors(
+    tmp_path: Path,
+) -> None:
+    path = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    record_local_bundle_restart_intent(path, restart_required=True)
+
+    def fail_unlink(*_args: object, **_kwargs: object) -> None:
+        raise PermissionError
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(Path, "unlink", fail_unlink)
+        with pytest.raises(PermissionError):
+            clear_local_bundle_restart_intent(path)
+
+
+def test_clear_local_bundle_restart_intent_tolerates_missing_file_race(
+    tmp_path: Path,
+) -> None:
+    path = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    record_local_bundle_restart_intent(path, restart_required=True)
+    intent_path = next(path.parent.glob("*.local-bundle-intent"))
+    original_unlink = Path.unlink
+
+    def race_unlink(candidate: Path, *, missing_ok: bool = False) -> None:
+        original_unlink(candidate, missing_ok=missing_ok)
+        raise FileNotFoundError(candidate)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(Path, "unlink", race_unlink)
+        clear_local_bundle_restart_intent(path)
+
+    assert not intent_path.exists()
+
+
+def test_old_controller_terminal_intent_authorizes_one_strict_recovery(tmp_path: Path) -> None:
+    old = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    record_local_bundle_restart_intent(old, restart_required=True)
+    payload = json.loads(old.read_text(encoding="utf-8"))
+    payload.update(
+        {
+            "status": "partial",
+            "migration_status": "degraded",
+            "migration_count": 0,
+            "completed_at": payload["created_at"],
+        }
+    )
+    old.write_text(json.dumps(payload), encoding="utf-8")
+    if os.name == "posix":
+        os.chmod(old, 0o600)
+
+    assert find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0") == old
+
+    recovered = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    record_local_bundle_restart_intent(recovered, restart_required=True)
+    clear_local_bundle_restart_intent(recovered)
+    assert supersede_prior_upgrade_receipts(recovered) == 1
+    complete_upgrade_receipt(recovered, status="succeeded")
+    assert find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0") is None
+    assert load_local_bundle_restart_intent(old) is True
+
+
+def test_health_proven_supersession_survives_success_acknowledgement(tmp_path: Path) -> None:
+    failed = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    complete_upgrade_receipt(
+        failed,
+        status="failed",
+        failure_code="health_check_failed",
+    )
+    replacement = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+
+    assert (
+        record_upgrade_receipt_supersession(
+            failed,
+            replacement_path=replacement,
+            health_proven=True,
+        )
+        == load_upgrade_receipt(replacement).receipt_id
+    )
+    assert find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0") == replacement
+
+    complete_upgrade_receipt(replacement, status="succeeded")
+    replacement.unlink()
+    assert load_upgrade_receipt_supersession(failed) is not None
+    assert find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0") is None
+
+
+def test_retry_delegation_keeps_one_authority_across_repeated_failures(tmp_path: Path) -> None:
+    first = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    complete_upgrade_receipt(first, status="failed", failure_code="interrupted")
+    second = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    assert delegate_prior_upgrade_receipts(second) == 1
+    complete_upgrade_receipt(second, status="failed", failure_code="migration_failed")
+    assert find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0") == second
+
+    third = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    assert delegate_prior_upgrade_receipts(third) == 2
+    assert find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0") == third
+    assert supersede_prior_upgrade_receipts(third) == 2
+    complete_upgrade_receipt(third, status="succeeded")
+    third.unlink()
+
+    assert find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0") is None
+
+
+def test_supersession_metadata_fails_closed_when_identity_is_changed(tmp_path: Path) -> None:
+    failed = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    complete_upgrade_receipt(
+        failed,
+        status="failed",
+        failure_code="health_check_failed",
+    )
+    replacement = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    record_upgrade_receipt_supersession(
+        failed,
+        replacement_path=replacement,
+        health_proven=True,
+    )
+    marker = next(failed.parent.glob("*.superseded-by"))
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    payload["target_version"] = "8.1.0"
+    marker.write_text(json.dumps(payload), encoding="utf-8")
+    if os.name == "posix":
+        os.chmod(marker, 0o600)
+
+    with pytest.raises(ValueError, match="supersession is invalid"):
+        find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0")
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX mode contract")
+def test_local_bundle_restart_intent_rejects_replaceable_metadata(tmp_path: Path) -> None:
+    path = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    record_local_bundle_restart_intent(path, restart_required=True)
+    intent_path = next(path.parent.glob("*.local-bundle-intent"))
+    os.chmod(intent_path, 0o644)
+    with pytest.raises(OSError, match="accessible to other accounts"):
+        load_local_bundle_restart_intent(path)

--- a/cli/tests/test_upgrade_receipt.py
+++ b/cli/tests/test_upgrade_receipt.py
@@ -67,9 +67,7 @@ def test_python_and_go_recoverable_failure_codes_match() -> None:
         switch_body.group("body"),
     )
     assert case_labels, "Go recoverable failure-code case labels are missing"
-    go_failure_codes = frozenset(
-        code for labels in case_labels for code in re.findall(r'"([a-z_]+)"', labels)
-    )
+    go_failure_codes = frozenset(code for labels in case_labels for code in re.findall(r'"([a-z_]+)"', labels))
     assert go_failure_codes == upgrade_receipt_module._RECOVERABLE_TARGET_FAILURE_CODES
 
 
@@ -248,6 +246,31 @@ def test_installed_authority_requires_verified_terminal_success(tmp_path: Path) 
     record_upgrade_migrations(verified, migration_count=1, degraded=True)
     complete_upgrade_receipt(verified, status="partial")
     assert find_verified_installed_upgrade_receipt(str(tmp_path), target_version="8.0.0") == verified
+
+
+def test_installed_authority_orders_mixed_iso_timestamps_chronologically(tmp_path: Path) -> None:
+    receipts: list[tuple[Path, str]] = []
+    for created_at in (
+        "2026-01-01T00:00:00Z",
+        "2026-01-01T00:00:00.500000Z",
+    ):
+        path = begin_upgrade_receipt(
+            str(tmp_path),
+            from_version="7.9.0",
+            target_version="8.0.0",
+            artifacts_verified=True,
+        )
+        record_upgrade_migrations(path, migration_count=1, degraded=False)
+        complete_upgrade_receipt(path, status="succeeded")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload["created_at"] = created_at
+        payload["completed_at"] = created_at
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        if os.name == "posix":
+            os.chmod(path, 0o600)
+        receipts.append((path, created_at))
+
+    assert find_verified_installed_upgrade_receipt(str(tmp_path), target_version="8.0.0") == receipts[1][0]
 
 
 @pytest.mark.skipif(os.name != "posix", reason="POSIX ownership and mode contract")
@@ -561,6 +584,26 @@ def test_retry_delegation_keeps_one_authority_across_repeated_failures(tmp_path:
     third.unlink()
 
     assert find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0") is None
+
+
+def test_nonrecoverable_replacement_restores_delegated_authority(tmp_path: Path) -> None:
+    prior = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    complete_upgrade_receipt(prior, status="failed", failure_code="interrupted")
+    replacement = begin_upgrade_receipt(
+        str(tmp_path),
+        from_version="7.9.0",
+        target_version="8.0.0",
+        artifacts_verified=True,
+    )
+    assert delegate_prior_upgrade_receipts(replacement) == 1
+    complete_upgrade_receipt(replacement, status="failed", failure_code="install_failed")
+
+    assert find_resumable_upgrade_receipt(str(tmp_path), target_version="8.0.0") == prior
 
 
 def test_supersession_metadata_fails_closed_when_identity_is_changed(tmp_path: Path) -> None:

--- a/cli/tests/test_upgrade_release_smoke_contract.py
+++ b/cli/tests/test_upgrade_release_smoke_contract.py
@@ -31,6 +31,7 @@ import pytest
 import yaml
 from defenseclaw.migrations import run_migrations
 from defenseclaw.observability.v8_config import load_validate_v8
+from defenseclaw.upgrade_receipt import begin_upgrade_receipt
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "test-upgrade-release.sh"
@@ -66,6 +67,7 @@ def test_developer_activation_is_isolated_from_every_production_upgrade_surface(
     assert 'source "${ROOT}/scripts/test-upgrade-release.sh"' in source
     assert "run_migrations(" in source
     assert "upgrade_handles_local_bundle=True" in source
+    assert "controller_owns_local_bundle_transaction=True" in source
     assert "_poll_health(configuration" in source
     assert '[[ -n "${RELEASE_ROOT}" ]]' in source
     assert '[[ "${BASELINE_MODE}" == "seed" ]]' in source
@@ -376,9 +378,7 @@ def test_bridge_comment_restore_is_ordered_before_seal_and_uses_source_snapshot(
             "removed_activation_temp = False", recovery_start
         )
     ]
-    assert resume.index("cleanup_owned_temporaries()") < resume.index(
-        'print(f"bridge\\t{bridge_version}\\t{plan_id}")'
-    )
+    assert resume.index("cleanup_owned_temporaries()") < resume.index('print(f"bridge\\t{bridge_version}\\t{plan_id}")')
     cleanup_start = source.index("def cleanup_owned_temporaries() -> None:")
     cleanup_end = source.index("\n\ndef restore_state_before_artifacts()", cleanup_start)
     cleanup = source[cleanup_start:cleanup_end]
@@ -536,9 +536,7 @@ def test_bridge_comment_restore_crash_temp_is_cleaned_before_resumed_custody_clo
     assert program.count(needle) == 1
     program = program.replace(
         needle,
-        "    atomic_exchange(active_path, temporary)\n"
-        "    os.kill(os.getpid(), 9)\n"
-        "    swapped = True",
+        "    atomic_exchange(active_path, temporary)\n    os.kill(os.getpid(), 9)\n    swapped = True",
         1,
     )
 
@@ -622,10 +620,7 @@ def test_resumed_cleanup_entry_replacement_is_quarantined_not_deleted(tmp_path: 
     temporary = config_parent / temporary_name
     temporary.write_text("inspected-sensitive-bytes\n", encoding="utf-8")
     program = _phase_one_recovery_cleanup_program()
-    needle = (
-        "            quarantine_name = quarantine_no_replace("
-        "descriptor, entry.name, info)"
-    )
+    needle = "            quarantine_name = quarantine_no_replace(descriptor, entry.name, info)"
     assert program.count(needle) == 1
     program = program.replace(
         needle,
@@ -664,9 +659,7 @@ def test_resumed_cleanup_entry_replacement_is_quarantined_not_deleted(tmp_path: 
     inspected = config_parent / f"{temporary_name}.inspected"
     assert inspected.read_text(encoding="utf-8") == "inspected-sensitive-bytes\n"
     assert not temporary.exists()
-    quarantines = list(
-        config_parent.glob(f".defenseclaw-cleanup-{token}-*.quarantine")
-    )
+    quarantines = list(config_parent.glob(f".defenseclaw-cleanup-{token}-*.quarantine"))
     assert len(quarantines) == 1
     assert quarantines[0].read_text(encoding="utf-8") == "replacement-must-survive\n"
 
@@ -697,10 +690,7 @@ def test_resumed_cleanup_replays_matching_crash_left_quarantine(tmp_path: Path) 
     temporary = config_parent / temporary_name
     temporary.write_text("crash-left-sensitive-bytes\n", encoding="utf-8")
     program = _phase_one_recovery_cleanup_program()
-    needle = (
-        "            quarantine_name = quarantine_no_replace("
-        "descriptor, entry.name, info)"
-    )
+    needle = "            quarantine_name = quarantine_no_replace(descriptor, entry.name, info)"
     assert program.count(needle) == 1
     program = program.replace(
         needle,
@@ -718,9 +708,7 @@ def test_resumed_cleanup_replays_matching_crash_left_quarantine(tmp_path: Path) 
 
     assert crashed.returncode < 0
     assert not temporary.exists()
-    quarantines = list(
-        config_parent.glob(f".defenseclaw-cleanup-{token}-*.quarantine")
-    )
+    quarantines = list(config_parent.glob(f".defenseclaw-cleanup-{token}-*.quarantine"))
     assert len(quarantines) == 1
     assert quarantines[0].read_text(encoding="utf-8") == "crash-left-sensitive-bytes\n"
 
@@ -732,9 +720,7 @@ def test_resumed_cleanup_replays_matching_crash_left_quarantine(tmp_path: Path) 
     )
 
     assert replay.returncode == 0, replay.stderr
-    assert not list(
-        config_parent.glob(f".defenseclaw-cleanup-{token}-*.quarantine")
-    )
+    assert not list(config_parent.glob(f".defenseclaw-cleanup-{token}-*.quarantine"))
 
 
 @pytest.mark.parametrize(
@@ -1004,6 +990,12 @@ exec "{ROOT / ".venv/bin/python"}" "$@"
     assert baseline_bundle_manifest["bundle_version"] == "0.8.5"
 
     monkeypatch.setenv("DEFENSECLAW_HOME", str(data_dir))
+    begin_upgrade_receipt(
+        str(data_dir),
+        from_version="0.8.5",
+        target_version="0.8.6",
+        artifacts_verified=True,
+    )
     count = run_migrations(
         "0.8.5",
         "0.8.6",
@@ -1014,7 +1006,10 @@ exec "{ROOT / ".venv/bin/python"}" "$@"
     assert count == 0
     assert config_path.read_bytes() == config_before
     assert environment_path.read_bytes() == environment_before
-    assert not list((data_dir / "backups").glob("observability-v8-*/manifest.json"))
+    refreshed_bundle_manifest = json.loads(
+        (data_dir / "observability-stack/.defenseclaw-bundle-manifest.json").read_text(encoding="utf-8")
+    )
+    assert refreshed_bundle_manifest["bundle_version"] == "0.8.6"
     cursor = json.loads((data_dir / ".migration_state.json").read_text(encoding="utf-8"))
     assert "0.8.5" in cursor["applied"]
 
@@ -1061,6 +1056,12 @@ def test_matrix_matches_every_reviewed_published_baseline_and_schema() -> None:
     baselines = policy["published_baselines"]
 
     assert policy["schema_version"] == 2
+    assert line.strip() == "UPGRADE_SMOKE_FROM ?="
+    makefile = MAKEFILE.read_text(encoding="utf-8")
+    assert "target_version=''" in makefile
+    assert "dynamic upgrade matrix requires" in makefile
+    assert '--target-version "$$target_version"' in makefile
+    assert '--target-version=*) target_version="$${1#--target-version=}"' in makefile
     assert baselines[0] == "0.8.4"
     assert policy["published_baseline_config_versions"] == {
         "0.8.4": 7,
@@ -1086,7 +1087,6 @@ def test_matrix_matches_every_reviewed_published_baseline_and_schema() -> None:
         "0.8.1",
         "0.8.0",
     ]
-    assert line.split("?=", 1)[1].split() == baselines
 
 
 def test_bridge_harness_keeps_v8_source_contracts_strictly_target_gated() -> None:

--- a/cli/tests/test_upgrade_smoke_static.py
+++ b/cli/tests/test_upgrade_smoke_static.py
@@ -46,28 +46,133 @@ UPGRADE_SMOKE_BASELINES = (
 
 def test_makefile_upgrade_smoke_matrix_tracks_supported_baselines() -> None:
     text = (ROOT / "Makefile").read_text()
-    match = re.search(r"^UPGRADE_SMOKE_FROM \?= (.+)$", text, re.MULTILINE)
+    match = re.search(r"^UPGRADE_SMOKE_FROM \?=\s*$", text, re.MULTILINE)
     assert match is not None
-    assert tuple(match.group(1).split()) == UPGRADE_SMOKE_BASELINES
 
     policy = json.loads((ROOT / "release" / "upgrade-baselines.json").read_text())
     assert tuple(policy["published_baselines"]) == UPGRADE_SMOKE_BASELINES
+    assert "scripts/resolve_upgrade_baselines.py" in text
+    assert "from_versions='$(strip $(UPGRADE_SMOKE_FROM))'" in text
+    assert "target_version=''" in text
+    assert "dynamic upgrade matrix requires" in text
+    assert '--target-version "$$target_version"' in text
+    assert '--target-version=*) target_version="$${1#--target-version=}"' in text
 
     assert "upgrade-refusal-contract-matrix: upgrade-smoke-matrix" in text
     assert "upgrade-developer-activation:" in text
     assert "scripts/test-developer-target-activation.sh $(ARGS)" in text
-    assert (
-        'scripts/test-upgrade-protocol-release.sh --from-versions "$(UPGRADE_SMOKE_FROM)" '
-        "--refusal-contract-only $(ARGS)"
-    ) in text
+    assert "$(call run_upgrade_matrix,scripts/test-upgrade-protocol-release.sh,--refusal-contract-only)" in text
     assert "upgrade-legacy-smoke-matrix:" in text
-    assert 'scripts/test-upgrade-release.sh --from-versions "$(UPGRADE_SMOKE_FROM)" $(ARGS)' in text
+    assert "$(call run_upgrade_matrix,scripts/test-upgrade-release.sh,)" in text
     assert "upgrade-signed-protocol-matrix:" in text
+
+
+def test_makefile_upgrade_matrix_executes_dynamic_and_explicit_baselines(tmp_path: Path) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    resolver = scripts / "resolve_upgrade_baselines.py"
+    resolver.write_text(
+        """import json, pathlib, sys
+args = sys.argv[1:]
+target = args[args.index('--target-version') + 1]
+output = pathlib.Path(args[args.index('--output') + 1])
+pathlib.Path('resolver-observed.json').write_text(json.dumps({'target': target, 'output': str(output)}))
+output.write_text(json.dumps({'published_baselines': ['0.8.5', '0.8.4']}))
+""",
+        encoding="utf-8",
+    )
+    runner = scripts / "test-upgrade-protocol-release.sh"
+    runner.write_text(
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > runner-args.txt\n",
+        encoding="utf-8",
+    )
+    runner.chmod(0o700)
+
+    environment = os.environ.copy()
+    environment.pop("UPGRADE_SMOKE_FROM", None)
+
+    subprocess.run(
+        [
+            "make",
+            "-s",
+            "-f",
+            str(ROOT / "Makefile"),
+            "upgrade-smoke-matrix",
+            "ARGS=--target-version 0.8.6 --health-timeout 3",
+        ],
+        cwd=tmp_path,
+        env=environment,
+        timeout=30,
+        check=True,
+    )
+    observed = json.loads((tmp_path / "resolver-observed.json").read_text(encoding="utf-8"))
+    assert observed["target"] == "0.8.6"
+    assert not Path(observed["output"]).parent.exists()
+    assert (tmp_path / "runner-args.txt").read_text(encoding="utf-8").splitlines() == [
+        "--from-versions",
+        "0.8.5 0.8.4",
+        "--refusal-contract-only",
+        "--target-version",
+        "0.8.6",
+        "--health-timeout",
+        "3",
+    ]
+
+    (tmp_path / "resolver-observed.json").unlink()
+    subprocess.run(
+        [
+            "make",
+            "-s",
+            "-f",
+            str(ROOT / "Makefile"),
+            "upgrade-smoke-matrix",
+            "ARGS=--target-version=0.8.6 --health-timeout 4",
+        ],
+        cwd=tmp_path,
+        env=environment,
+        timeout=30,
+        check=True,
+    )
+    observed = json.loads((tmp_path / "resolver-observed.json").read_text(encoding="utf-8"))
+    assert observed["target"] == "0.8.6"
+    assert not Path(observed["output"]).parent.exists()
+    assert (tmp_path / "runner-args.txt").read_text(encoding="utf-8").splitlines() == [
+        "--from-versions",
+        "0.8.5 0.8.4",
+        "--refusal-contract-only",
+        "--target-version=0.8.6",
+        "--health-timeout",
+        "4",
+    ]
+
+    (tmp_path / "resolver-observed.json").unlink()
+    subprocess.run(
+        [
+            "make",
+            "-s",
+            "-f",
+            str(ROOT / "Makefile"),
+            "upgrade-smoke-matrix",
+            "UPGRADE_SMOKE_FROM=0.8.3 0.8.2",
+            "ARGS=--target-version=0.8.6",
+        ],
+        cwd=tmp_path,
+        env=environment,
+        timeout=30,
+        check=True,
+    )
+    assert not (tmp_path / "resolver-observed.json").exists()
+    assert (tmp_path / "runner-args.txt").read_text(encoding="utf-8").splitlines() == [
+        "--from-versions",
+        "0.8.3 0.8.2",
+        "--refusal-contract-only",
+        "--target-version=0.8.6",
+    ]
 
 
 def test_upgrade_smoke_docs_cover_default_matrix() -> None:
     text = (ROOT / "docs" / "TESTING.md").read_text()
-    default_line = next(line for line in text.splitlines() if line.startswith("The default matrix covers"))
+    default_line = next(line for line in text.splitlines() if "default matrix covers" in line)
     for version in UPGRADE_SMOKE_BASELINES:
         assert f"`{version}`" in default_line
 
@@ -385,7 +490,7 @@ def test_live_continuity_reopens_v8_database_with_actual_published_bridge_binary
     assert '"SELECT COUNT(*) FROM audit_events WHERE target = ?"' in compatibility
     assert 'event.get("target") == probe_target' in compatibility
     assert 'event.get("details") == marker' not in compatibility
-    api_read_start = compatibility.index('read = urllib.request.Request(')
+    api_read_start = compatibility.index("read = urllib.request.Request(")
     api_read_end = compatibility.index("\nPY\n", api_read_start)
     assert 'event.get("binary_version")' not in compatibility[api_read_start:api_read_end]
     assert "SELECT COUNT(*), COALESCE(MAX(binary_version), '')" in compatibility
@@ -413,7 +518,7 @@ def test_live_continuity_fixture_has_no_implicit_openclaw_fleet_dependency() -> 
     verification = continuity[verify_start:verify_end]
 
     assert '"claw:\\n"' in fixture
-    assert '"  mode: \'\'\\n"' in fixture
+    assert "\"  mode: ''\\n\"" in fixture
     assert '"  connector:' not in fixture
     assert '"gateway:\\n"' in fixture
     assert '"  fleet_mode: disabled\\n"' in fixture
@@ -712,12 +817,10 @@ def test_release_resolver_isolated_python_never_writes_bytecode() -> None:
     assert '"${DEFENSECLAW_VENV}/bin/python" - <<' not in posix
 
     installed_version = windows[
-        windows.index("function Get-InstalledVersion") : windows.index(
-            "function Get-CanonicalVersionOutput"
-        )
+        windows.index("function Get-InstalledVersion") : windows.index("function Get-CanonicalVersionOutput")
     ]
     assert "[void](Get-Cli)" in installed_version
-    assert "-Arguments @(\"-I\", \"-B\", \"-c\"" in installed_version
+    assert '-Arguments @("-I", "-B", "-c"' in installed_version
     assert "Get-CanonicalVersionOutput -Command $cli" not in installed_version
     assert 'Assert-VersionOutput (Get-Cli) $SourceVersion "source CLI"' not in windows
 
@@ -792,8 +895,7 @@ def test_release_owned_embedded_python_remains_apple_python39_compatible() -> No
         f"with Apple Python 3.9: {incompatible_annotations}"
     )
     assert not incompatible_calls, (
-        "release-owned embedded Python cannot use zip(strict=...) before Python 3.10: "
-        f"{incompatible_calls}"
+        f"release-owned embedded Python cannot use zip(strict=...) before Python 3.10: {incompatible_calls}"
     )
 
 
@@ -812,7 +914,7 @@ def test_posix_upgrade_fixture_seeds_gateway_token_before_historical_evidence() 
     )
     assert "python3 -I -B -c 'import secrets" in native_fixture
     assert native_fixture.index("DEFENSECLAW_GATEWAY_TOKEN=${gateway_token}") < native_fixture.index(
-        'environment.historical.source'
+        "environment.historical.source"
     )
     invariant_start = smoke.index("assert_source_gateway_canary_preserved_fixture() {")
     invariant_end = smoke.index("\n}\n", invariant_start)
@@ -820,9 +922,11 @@ def test_posix_upgrade_fixture_seeds_gateway_token_before_historical_evidence() 
     assert 'cmp -s "${evidence_dir}/config.historical.source" "${data_dir}/config.yaml"' in invariant
     assert 'cmp -s "${evidence_dir}/environment.historical.source" "${data_dir}/.env"' in invariant
     run_one = smoke[smoke.index("run_one_upgrade_smoke() {") : smoke.index("\n}\n\nmain()")]
-    assert run_one.index("start_source_gateway_canary") < run_one.index(
-        "assert_source_gateway_canary_preserved_fixture"
-    ) < run_one.index("patch_installed_upgrade_endpoint")
+    assert (
+        run_one.index("start_source_gateway_canary")
+        < run_one.index("assert_source_gateway_canary_preserved_fixture")
+        < run_one.index("patch_installed_upgrade_endpoint")
+    )
     assert 'actual_environment.get("DEFENSECLAW_GATEWAY_TOKEN") != historical_gateway_token' in smoke
     assert 'raise SystemExit("gateway token changed across the staged upgrade")' in smoke
     assert "historical_gateway_token," in smoke
@@ -954,13 +1058,16 @@ def test_posix_resolver_releases_only_the_lock_custody_it_created(
         advisory_lock.write_bytes(b"")
         advisory_lock.chmod(0o600)
 
-    script = _posix_resolver_lock_harness() + """
+    script = (
+        _posix_resolver_lock_harness()
+        + """
 acquire_upgrade_lock
 test -f "${UPGRADE_LOCK_FILE}"
 test -f "${UPGRADE_ADVISORY_LOCK_FILE}"
 release_upgrade_lock
 test ! -e "${UPGRADE_LOCK_FILE}"
 """
+    )
     if preexisting_recovery_root:
         script += """
 test -d "${UPGRADE_RECOVERY_ROOT}"
@@ -988,13 +1095,16 @@ test -f "${UPGRADE_ADVISORY_LOCK_FILE}"
 def test_posix_resolver_parent_wait_refusal_runs_exit_cleanup(tmp_path: Path) -> None:
     data_home = tmp_path / "data"
     data_home.mkdir(mode=0o700)
-    script = _posix_resolver_lock_harness() + """
+    script = (
+        _posix_resolver_lock_harness()
+        + """
 trap release_upgrade_lock EXIT
 acquire_upgrade_lock
 target_status=0
 bash -c 'exit 42' || target_status=$?
 exit "${target_status}"
 """
+    )
     environment = os.environ.copy()
     environment["TEST_DATA_HOME"] = str(data_home)
     completed = subprocess.run(
@@ -1015,7 +1125,9 @@ exit "${target_status}"
 def test_posix_resolver_never_deletes_replacement_advisory_inode(tmp_path: Path) -> None:
     data_home = tmp_path / "data"
     data_home.mkdir(mode=0o700)
-    script = _posix_resolver_lock_harness() + """
+    script = (
+        _posix_resolver_lock_harness()
+        + """
 acquire_upgrade_lock
 mv "${UPGRADE_ADVISORY_LOCK_FILE}" "${UPGRADE_ADVISORY_LOCK_FILE}.displaced"
 printf 'replacement\n' >"${UPGRADE_ADVISORY_LOCK_FILE}"
@@ -1025,6 +1137,7 @@ test ! -e "${UPGRADE_LOCK_FILE}"
 test -f "${UPGRADE_ADVISORY_LOCK_FILE}"
 test -f "${UPGRADE_ADVISORY_LOCK_FILE}.displaced"
 """
+    )
     environment = os.environ.copy()
     environment["TEST_DATA_HOME"] = str(data_home)
     completed = subprocess.run(
@@ -1051,7 +1164,9 @@ def test_posix_resolver_keeps_kernel_lease_until_created_path_is_removed(
     data_home.mkdir(mode=0o700)
     ready = tmp_path / "observer-ready"
     result = tmp_path / "observer-result"
-    script = _posix_resolver_lock_harness() + """
+    script = (
+        _posix_resolver_lock_harness()
+        + """
 acquire_upgrade_lock
 (
     exec 9>&-
@@ -1101,6 +1216,7 @@ wait "${observer_pid}"
     esac
     test ! -e "${UPGRADE_RECOVERY_ROOT}"
 """
+    )
     environment = os.environ.copy()
     environment.update(
         {
@@ -1128,7 +1244,9 @@ def test_posix_resolver_retry_waits_for_surviving_mutation_child(tmp_path: Path)
     data_home.mkdir(mode=0o700)
     ready = tmp_path / "parent-ready"
     child_pid_path = tmp_path / "child-pid"
-    parent_script = _posix_resolver_lock_harness() + """
+    parent_script = (
+        _posix_resolver_lock_harness()
+        + """
 acquire_upgrade_lock
 bash -c 'sleep 4' &
 child_pid=$!
@@ -1136,6 +1254,7 @@ printf '%s\n' "${child_pid}" >"$TEST_CHILD_PID"
 printf 'ready\n' >"$TEST_READY"
 wait "${child_pid}"
 """
+    )
     environment = os.environ.copy()
     environment.update(
         {
@@ -1161,10 +1280,13 @@ wait "${child_pid}"
     assert parent.wait(timeout=5) != 0
     os.kill(child_pid, 0)
 
-    retry_script = _posix_resolver_lock_harness() + """
+    retry_script = (
+        _posix_resolver_lock_harness()
+        + """
 trap release_upgrade_lock EXIT
 acquire_upgrade_lock
 """
+    )
     refused = subprocess.run(
         ["bash", "-c", retry_script],
         cwd=ROOT,
@@ -1206,7 +1328,9 @@ def test_posix_resolver_exit_cleanup_keeps_surviving_child_advisory_lease(tmp_pa
     data_home.mkdir(mode=0o700)
     ready = tmp_path / "parent-ready"
     child_pid_path = tmp_path / "child-pid"
-    parent_script = _posix_resolver_lock_harness() + """
+    parent_script = (
+        _posix_resolver_lock_harness()
+        + """
 trap release_upgrade_lock EXIT
 acquire_upgrade_lock
 bash -c 'sleep 4' &
@@ -1215,6 +1339,7 @@ printf '%s\n' "${child_pid}" >"$TEST_CHILD_PID"
 printf 'ready\n' >"$TEST_READY"
 exit 0
 """
+    )
     environment = os.environ.copy()
     environment.update(
         {
@@ -1240,10 +1365,13 @@ exit 0
 
     advisory_lock = data_home / ".upgrade-recovery" / "upgrade.advisory.lock"
     assert advisory_lock.is_file()
-    retry_script = _posix_resolver_lock_harness() + """
+    retry_script = (
+        _posix_resolver_lock_harness()
+        + """
 trap release_upgrade_lock EXIT
 acquire_upgrade_lock
 """
+    )
     refused = subprocess.run(
         ["bash", "-c", retry_script],
         cwd=ROOT,
@@ -1284,7 +1412,9 @@ def test_posix_resolver_reclaims_reused_pid_schema_v2_claim(tmp_path: Path) -> N
     """A reused PID must not permanently block a stale diagnostic claim."""
     data_home = tmp_path / "data"
     data_home.mkdir(mode=0o700)
-    script = _posix_resolver_lock_harness() + """
+    script = (
+        _posix_resolver_lock_harness()
+        + """
 mkdir -p "${UPGRADE_RECOVERY_ROOT}"
 chmod 700 "${UPGRADE_RECOVERY_ROOT}"
 python3 - "${UPGRADE_LOCK_FILE}" "$$" <<'PY'
@@ -1318,6 +1448,7 @@ assert claim["process_start"] != "linux:0"
 PY
 release_upgrade_lock
 """
+    )
     environment = os.environ.copy()
     environment["TEST_DATA_HOME"] = str(data_home)
     completed = subprocess.run(
@@ -1339,7 +1470,9 @@ def test_posix_resolver_schema1_live_pid_claim_fails_closed(tmp_path: Path) -> N
 
     data_home = tmp_path / "data"
     data_home.mkdir(mode=0o700)
-    script = _posix_resolver_lock_harness() + """
+    script = (
+        _posix_resolver_lock_harness()
+        + """
 mkdir -p "${UPGRADE_RECOVERY_ROOT}"
 chmod 700 "${UPGRADE_RECOVERY_ROOT}"
 python3 - "${UPGRADE_LOCK_FILE}" "$$" <<'PY'
@@ -1359,6 +1492,7 @@ PY
 chmod 600 "${UPGRADE_LOCK_FILE}"
 acquire_upgrade_lock
 """
+    )
     environment = os.environ.copy()
     environment["TEST_DATA_HOME"] = str(data_home)
     completed = subprocess.run(
@@ -1381,7 +1515,9 @@ def test_posix_resolver_legacy_schema2_live_pid_claim_fails_closed(tmp_path: Pat
 
     data_home = tmp_path / "data"
     data_home.mkdir(mode=0o700)
-    script = _posix_resolver_lock_harness() + """
+    script = (
+        _posix_resolver_lock_harness()
+        + """
 mkdir -p "${UPGRADE_RECOVERY_ROOT}"
 chmod 700 "${UPGRADE_RECOVERY_ROOT}"
 python3 - "${UPGRADE_LOCK_FILE}" "$$" <<'PY'
@@ -1406,6 +1542,7 @@ PY
 chmod 600 "${UPGRADE_LOCK_FILE}"
 acquire_upgrade_lock
 """
+    )
     environment = os.environ.copy()
     environment["TEST_DATA_HOME"] = str(data_home)
     completed = subprocess.run(
@@ -1428,7 +1565,9 @@ def test_posix_resolver_preserves_nonempty_created_recovery_root_in_place(
 ) -> None:
     data_home = tmp_path / "data"
     data_home.mkdir(mode=0o700)
-    script = _posix_resolver_lock_harness() + """
+    script = (
+        _posix_resolver_lock_harness()
+        + """
 acquire_upgrade_lock
 printf '{"schema_version":4}\n' >"${UPGRADE_RECOVERY_ROOT}/phase-two-active.json"
 chmod 600 "${UPGRADE_RECOVERY_ROOT}/phase-two-active.json"
@@ -1438,6 +1577,7 @@ test -f "${UPGRADE_RECOVERY_ROOT}/phase-two-active.json"
 test ! -e "${UPGRADE_LOCK_FILE}"
 test ! -e "${UPGRADE_ADVISORY_LOCK_FILE}"
 """
+    )
     environment = os.environ.copy()
     environment["TEST_DATA_HOME"] = str(data_home)
     completed = subprocess.run(

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -72,7 +72,7 @@ make upgrade-smoke ARGS="--from-version 0.7.2"
 
 # Optional developer diagnostic across the complete reviewed historical floor.
 # Ordinary PR CI uses a smaller path-sensitive behavior-class selection.
-make upgrade-smoke-matrix
+make upgrade-smoke-matrix ARGS="--target-version X.Y.Z"
 
 # Fast positive target-owned migration/health check for an unsigned local
 # candidate. This never calls or weakens the production upgrade resolver.
@@ -81,7 +81,7 @@ make upgrade-developer-activation ARGS="--release-root /path/to/candidate-root -
 # Full positive protocol matrix. This requires the sealed, release-workflow-
 # signed candidate; it must not be pointed at unsigned local artifacts.
 make upgrade-signed-protocol-matrix \
-  ARGS="--release-dir release-candidate/dist --baseline-mode seed"
+  ARGS="--target-version X.Y.Z --release-dir release-candidate/dist --baseline-mode seed"
 
 # Legacy schema-1 positive harness, retained only for old release fixtures.
 make upgrade-legacy-smoke-matrix \
@@ -100,10 +100,10 @@ ssh openclaw-vineeth 'scripts/test-developer-target-activation.sh --release-root
 ssh openclaw-vineeth 'scripts/test-upgrade-protocol-release.sh --release-root /tmp/candidate-release --target-version 0.8.5 --from-version 0.8.3 --baseline-mode seed --refusal-contract-only'
 ```
 
-The default matrix covers the required schema-v7 bridge plus every supported 0.4.0+ historical source: `0.8.4`, `0.8.3`, `0.8.2`, `0.8.1`, `0.8.0`, `0.7.2`, `0.7.1`, `0.6.6`, `0.6.5`, `0.6.4`, `0.6.3`, `0.6.2`, `0.6.1`, `0.6.0`, `0.5.0`, and `0.4.0`. Its single source is `release/upgrade-baselines.json`; the Make target and smoke-contract tests must match that reviewed data exactly. Release `0.7.0` has no downloadable release assets, and `0.2.0` predates the upgrade command, so neither is eligible for automatic staging. The `0.8.4` entry deliberately makes the `0.8.5` gate fail until that bridge has actually been published with its complete signed POSIX asset set. Targets before `0.8.5` retain schema-v7 checks. A hard-cut manifest (`min_upgrade_protocol >= 2`) must prove pre-mutation refusal for incapable baselines, a verified `0.8.4` bridge handoff for every listed older POSIX source, and full v7-to-v8 observability, private-secret, rollback, local-bundle, SQLite, and fresh-process health checks from the bridge.
+For routine candidates newer than the reviewed support list, the default matrix covers the required schema-v7 bridge plus every supported 0.4.0+ historical source: `0.8.4`, `0.8.3`, `0.8.2`, `0.8.1`, `0.8.0`, `0.7.2`, `0.7.1`, `0.6.6`, `0.6.5`, `0.6.4`, `0.6.3`, `0.6.2`, `0.6.1`, `0.6.0`, `0.5.0`, and `0.4.0`. That reviewed floor lives in `release/upgrade-baselines.json`; at execution time the Make target also authenticates and prepends every newer immutable stable release that is older than the exact `--target-version` in `ARGS`, so a newly published source version is tested without editing the Makefile. Legacy fixture candidates dynamically exclude reviewed sources that are not older than the candidate, and fail clearly if no supported predecessor remains. Dynamic matrix targets require that candidate argument because the checked-in development version is not release selection; set `UPGRADE_SMOKE_FROM` only when intentionally selecting an explicit developer subset. Release `0.7.0` has no downloadable release assets, and `0.2.0` predates the upgrade command, so neither is eligible for automatic staging. Targets before `0.8.5` retain schema-v7 checks. A hard-cut manifest (`min_upgrade_protocol >= 2`) must prove pre-mutation refusal for incapable baselines, a verified `0.8.4` bridge handoff for every listed older POSIX source, and full v7-to-v8 observability, private-secret, rollback, local-bundle, SQLite, and fresh-process health checks from the bridge.
 
-After 0.8.5 is published, the effective baseline resolver adds it dynamically
-as config version 8. The harness then seeds canonical v8 config, migration
+The effective baseline resolver adds published 0.8.5 dynamically as config
+version 8. The harness then seeds canonical v8 config, migration
 cursor, and baseline-owned bundle state; it requires later targets to preserve
 config/environment bytes, avoid replaying the one-time v8 activation, refresh
 managed bundle bytes, and retain operator files. Unknown future config families

--- a/docs/design/observability-v8/07-verification-and-acceptance.md
+++ b/docs/design/observability-v8/07-verification-and-acceptance.md
@@ -1490,7 +1490,7 @@ make check-schemas
 make check-grafana-dashboards
 uv run python -m pytest cli/tests/test_agent360_dashboard.py cli/tests/test_grafana_dashboards.py -q
 make check-upgrade-manifest
-make upgrade-smoke-matrix ARGS="--baseline-mode seed"
+make upgrade-smoke-matrix ARGS="--target-version X.Y.Z --baseline-mode seed"
 ```
 
 Phase PRs may run a justified subset while stacked, but the final integration PR

--- a/internal/gateway/upgrade_receipt.go
+++ b/internal/gateway/upgrade_receipt.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -23,12 +24,16 @@ import (
 )
 
 const (
-	upgradeReceiptDirectory  = ".upgrade-receipts"
-	upgradeRecoveryDirectory = ".upgrade-recovery"
-	hardCutRecoveryJournal   = "phase-two-active.json"
-	upgradeReceiptMaxBytes   = 16 * 1024
-	upgradeReceiptMaxFiles   = 64
-	upgradeReceiptPoll       = 500 * time.Millisecond
+	upgradeReceiptDirectory     = ".upgrade-receipts"
+	upgradeRecoveryDirectory    = ".upgrade-recovery"
+	hardCutRecoveryJournal      = "phase-two-active.json"
+	upgradeReceiptMaxBytes      = 16 * 1024
+	upgradeReceiptMaxFiles      = 64
+	upgradeReceiptPoll          = 500 * time.Millisecond
+	upgradeBundleIntentSuffix   = ".local-bundle-intent"
+	upgradeBundleIntentMaxBytes = 1024
+	upgradeSupersessionSuffix   = ".superseded-by"
+	upgradeSupersessionMaxBytes = 1024
 )
 
 var upgradeReceiptSemver = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
@@ -45,6 +50,33 @@ type upgradeReceipt struct {
 	MigrationCount    *int64     `json:"migration_count"`
 	ArtifactsVerified bool       `json:"artifacts_verified"`
 	FailureCode       string     `json:"failure_code"`
+}
+
+type upgradeReceiptSupersession struct {
+	SchemaVersion         int    `json:"schema_version"`
+	ReceiptID             string `json:"receipt_id"`
+	TargetVersion         string `json:"target_version"`
+	SupersededByReceiptID string `json:"superseded_by_receipt_id"`
+	HealthProven          *bool  `json:"health_proven"`
+}
+
+type upgradeBundleRestartIntent struct {
+	SchemaVersion   int    `json:"schema_version"`
+	ReceiptID       string `json:"receipt_id"`
+	TargetVersion   string `json:"target_version"`
+	RestartRequired *bool  `json:"restart_required"`
+}
+
+type upgradeReceiptSupersessionState struct {
+	active        bool
+	healthProven  bool
+	replacementID string
+	path          string
+}
+
+type localBundleRestartCustodyState struct {
+	active bool
+	path   string
 }
 
 func (s *Sidecar) runUpgradeReceiptConsumer(ctx context.Context) {
@@ -117,6 +149,9 @@ func (s *Sidecar) consumeUpgradeReceipts(ctx context.Context, afterPersist func(
 		return errors.New("upgrade receipt directory unavailable")
 	}
 	var firstErr error
+	if err := cleanupOrphanedUpgradeReceiptMetadata(directory, entries); err != nil {
+		firstErr = err
+	}
 	seen := 0
 	for _, entry := range entries {
 		if seen >= upgradeReceiptMaxFiles {
@@ -129,6 +164,78 @@ func (s *Sidecar) consumeUpgradeReceipts(ctx context.Context, afterPersist func(
 		path := filepath.Join(directory, entry.Name())
 		if err := s.consumeUpgradeReceipt(ctx, path, afterPersist); err != nil && firstErr == nil {
 			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func cleanupOrphanedUpgradeReceiptMetadata(directory string, entries []os.DirEntry) error {
+	seen := 0
+	removed := false
+	var firstErr error
+	rememberError := func(err error) {
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		suffix := ""
+		maximum := int64(0)
+		switch {
+		case strings.HasSuffix(name, upgradeBundleIntentSuffix):
+			suffix, maximum = upgradeBundleIntentSuffix, upgradeBundleIntentMaxBytes
+		case strings.HasSuffix(name, upgradeSupersessionSuffix):
+			suffix, maximum = upgradeSupersessionSuffix, upgradeSupersessionMaxBytes
+		default:
+			continue
+		}
+		seen++
+		if seen > upgradeReceiptMaxFiles*2 {
+			rememberError(errors.New("upgrade receipt metadata exceeds its bound"))
+			break
+		}
+		path := filepath.Join(directory, name)
+		base := strings.TrimSuffix(name, suffix)
+		parsed, err := uuid.Parse(base)
+		if err != nil || parsed.String() != base {
+			rememberError(errors.New("invalid orphaned upgrade receipt metadata identity"))
+			if err := os.Remove(path); err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					rememberError(errors.New("orphaned upgrade receipt metadata cleanup failed"))
+				}
+			} else {
+				removed = true
+			}
+			continue
+		}
+		receiptPath := filepath.Join(directory, base+".json")
+		if _, err := os.Lstat(receiptPath); err == nil {
+			continue
+		} else if !errors.Is(err, os.ErrNotExist) {
+			rememberError(errors.New("upgrade receipt metadata owner unavailable"))
+			continue
+		}
+		info, lstatErr := os.Lstat(path)
+		if lstatErr != nil && !errors.Is(lstatErr, os.ErrNotExist) {
+			rememberError(errors.New("orphaned upgrade receipt metadata lookup failed"))
+			continue
+		}
+		if lstatErr == nil && (info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() ||
+			info.Size() <= 0 || info.Size() > maximum) {
+			rememberError(errors.New("invalid orphaned upgrade receipt metadata"))
+		}
+		if err := os.Remove(path); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				rememberError(errors.New("orphaned upgrade receipt metadata cleanup failed"))
+			}
+			continue
+		}
+		removed = true
+	}
+	if removed {
+		if err := syncUpgradeReceiptDirectory(directory); err != nil {
+			rememberError(err)
 		}
 	}
 	return firstErr
@@ -151,6 +258,31 @@ func (s *Sidecar) consumeUpgradeReceipt(ctx context.Context, path string, afterP
 	if err != nil || !terminal {
 		return err
 	}
+	restartCustody, err := localBundleRestartCustodyActive(path, receipt)
+	if err != nil {
+		return err
+	}
+	supersession, err := upgradeReceiptSupersessionActive(
+		path,
+		receipt,
+	)
+	if err != nil {
+		return err
+	}
+	if supersession.active && !upgradeReceiptRecoveryAuthority(receipt, restartCustody.active) {
+		return errors.New("unexpected upgrade receipt supersession")
+	}
+	delegationDurable := false
+	if supersession.active && !supersession.healthProven {
+		delegationDurable, err = upgradeReceiptDelegationReplacementValid(
+			path,
+			receipt.TargetVersion,
+			supersession.replacementID,
+		)
+		if err != nil {
+			return err
+		}
+	}
 	recorded, err := s.store.UpgradeReceiptEventRecorded(receipt.ReceiptID)
 	if err != nil {
 		return errors.New("upgrade receipt idempotency check failed")
@@ -172,31 +304,171 @@ func (s *Sidecar) consumeUpgradeReceipt(ctx context.Context, path string, afterP
 			}
 		}
 	}
+	if (!supersession.active || (!supersession.healthProven && !delegationDurable)) &&
+		(restartCustody.active || upgradeReceiptRecoverableFailure(receipt)) {
+		// The target bundle transaction has not yet proven restart/readiness.
+		// Persist the compliance event above, but retain its local recovery
+		// authority until a verified replacement assumes it or a retry proves health.
+		return nil
+	}
 	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return errors.New("upgrade receipt acknowledgement failed")
+	}
+	if supersession.active && (supersession.healthProven || delegationDurable) {
+		if err := syncUpgradeReceiptDirectory(filepath.Dir(path)); err != nil {
+			return err
+		}
+		if err := os.Remove(restartCustody.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return errors.New("upgrade receipt restart metadata cleanup failed")
+		}
+		if err := os.Remove(supersession.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return errors.New("upgrade receipt supersession cleanup failed")
+		}
+		if err := syncUpgradeReceiptDirectory(filepath.Dir(path)); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
-func readUpgradeReceipt(path string) (upgradeReceipt, bool, error) {
-	info, err := os.Lstat(path)
-	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() ||
-		info.Size() <= 0 || info.Size() > upgradeReceiptMaxBytes {
-		return upgradeReceipt{}, false, errors.New("invalid upgrade receipt file")
+func syncUpgradeReceiptDirectory(directory string) error {
+	if runtime.GOOS == "windows" {
+		return nil
 	}
-	file, err := os.Open(path)
+	handle, err := os.Open(directory)
 	if err != nil {
-		return upgradeReceipt{}, false, errors.New("upgrade receipt unavailable")
+		return errors.New("upgrade receipt directory unavailable for sync")
 	}
-	defer file.Close()
-	opened, err := file.Stat()
-	if err != nil || !opened.Mode().IsRegular() || !os.SameFile(info, opened) {
-		return upgradeReceipt{}, false, errors.New("upgrade receipt changed while opening")
+	defer handle.Close()
+	if err := handle.Sync(); err != nil {
+		return errors.New("upgrade receipt directory sync failed")
 	}
-	raw, err := io.ReadAll(io.LimitReader(file, upgradeReceiptMaxBytes+1))
-	if err != nil || len(raw) == 0 || len(raw) > upgradeReceiptMaxBytes || !utf8.Valid(raw) ||
-		!cliObservabilityV8JSONHasUniqueKeys(raw) {
-		return upgradeReceipt{}, false, errors.New("invalid upgrade receipt encoding")
+	return nil
+}
+
+func upgradeReceiptRecoverableFailure(receipt upgradeReceipt) bool {
+	if receipt.Status != "failed" || !receipt.ArtifactsVerified {
+		return false
+	}
+	switch receipt.FailureCode {
+	case "migration_failed", "required_migration_failed", "local_observability_failed",
+		"startup_failed", "health_check_failed", "interrupted":
+		return true
+	default:
+		return false
+	}
+}
+
+func upgradeReceiptRecoveryAuthority(receipt upgradeReceipt, restartCustody bool) bool {
+	return upgradeReceiptRecoverableFailure(receipt) ||
+		((receipt.Status == "succeeded" || receipt.Status == "partial") &&
+			receipt.ArtifactsVerified && restartCustody)
+}
+
+func upgradeReceiptSupersessionActive(
+	receiptPath string,
+	receipt upgradeReceipt,
+) (upgradeReceiptSupersessionState, error) {
+	path := strings.TrimSuffix(receiptPath, ".json") + upgradeSupersessionSuffix
+	raw, err := readPrivateBoundedUniqueJSON(path, upgradeSupersessionMaxBytes)
+	if errors.Is(err, os.ErrNotExist) {
+		return upgradeReceiptSupersessionState{path: path}, nil
+	}
+	if err != nil {
+		return upgradeReceiptSupersessionState{}, errors.New("invalid upgrade receipt supersession")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var marker upgradeReceiptSupersession
+	if err := decoder.Decode(&marker); err != nil {
+		return upgradeReceiptSupersessionState{}, errors.New("invalid upgrade receipt supersession")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return upgradeReceiptSupersessionState{}, errors.New("invalid upgrade receipt supersession trailing data")
+	}
+	replacement, err := uuid.Parse(marker.SupersededByReceiptID)
+	if marker.SchemaVersion != 1 || marker.ReceiptID != receipt.ReceiptID ||
+		marker.TargetVersion != receipt.TargetVersion || marker.HealthProven == nil || err != nil ||
+		replacement.String() != marker.SupersededByReceiptID ||
+		marker.SupersededByReceiptID == receipt.ReceiptID {
+		return upgradeReceiptSupersessionState{}, errors.New("invalid upgrade receipt supersession identity")
+	}
+	return upgradeReceiptSupersessionState{
+		active:        true,
+		healthProven:  *marker.HealthProven,
+		replacementID: marker.SupersededByReceiptID,
+		path:          path,
+	}, nil
+}
+
+func upgradeReceiptDelegationReplacementValid(
+	receiptPath string,
+	targetVersion string,
+	replacementID string,
+) (bool, error) {
+	replacementPath := filepath.Join(filepath.Dir(receiptPath), replacementID+".json")
+	replacement, terminal, err := readUpgradeReceipt(replacementPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, errors.New("upgrade receipt delegation target is invalid")
+	}
+	if replacement.ReceiptID != replacementID || replacement.TargetVersion != targetVersion ||
+		!replacement.ArtifactsVerified {
+		return false, errors.New("upgrade receipt delegation target identity is invalid")
+	}
+	if !terminal {
+		// Python promotes every predecessor only after this pending attempt
+		// proves target health. Retaining the predecessors until then prevents
+		// the gateway consumer from racing that fail-closed promotion scan.
+		return false, nil
+	}
+	restartCustody, err := localBundleRestartCustodyActive(replacementPath, replacement)
+	if err != nil {
+		return false, err
+	}
+	return upgradeReceiptRecoveryAuthority(replacement, restartCustody.active), nil
+}
+
+func localBundleRestartCustodyActive(
+	receiptPath string,
+	receipt upgradeReceipt,
+) (localBundleRestartCustodyState, error) {
+	base := strings.TrimSuffix(filepath.Base(receiptPath), ".json")
+	if base == filepath.Base(receiptPath) {
+		return localBundleRestartCustodyState{}, errors.New("invalid upgrade receipt path")
+	}
+	path := filepath.Join(filepath.Dir(receiptPath), base+upgradeBundleIntentSuffix)
+	raw, err := readPrivateBoundedUniqueJSON(path, upgradeBundleIntentMaxBytes)
+	if errors.Is(err, os.ErrNotExist) {
+		return localBundleRestartCustodyState{path: path}, nil
+	}
+	if err != nil {
+		return localBundleRestartCustodyState{}, errors.New("invalid local bundle restart custody")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var intent upgradeBundleRestartIntent
+	if err := decoder.Decode(&intent); err != nil {
+		return localBundleRestartCustodyState{}, errors.New("invalid local bundle restart custody")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return localBundleRestartCustodyState{}, errors.New("invalid local bundle restart custody trailing data")
+	}
+	if intent.SchemaVersion != 1 || intent.ReceiptID != receipt.ReceiptID ||
+		intent.TargetVersion != receipt.TargetVersion || intent.RestartRequired == nil {
+		return localBundleRestartCustodyState{}, errors.New("invalid local bundle restart custody identity")
+	}
+	return localBundleRestartCustodyState{active: *intent.RestartRequired, path: path}, nil
+}
+
+func readUpgradeReceipt(path string) (upgradeReceipt, bool, error) {
+	raw, err := readPrivateBoundedUniqueJSON(path, upgradeReceiptMaxBytes)
+	if err != nil {
+		return upgradeReceipt{}, false, fmt.Errorf("invalid upgrade receipt file: %w", err)
 	}
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.DisallowUnknownFields()
@@ -210,6 +482,33 @@ func readUpgradeReceipt(path string) (upgradeReceipt, bool, error) {
 	}
 	terminal, err := validateUpgradeReceipt(receipt, filepath.Base(path))
 	return receipt, terminal, err
+}
+
+func readPrivateBoundedUniqueJSON(path string, maximum int64) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if maximum <= 0 || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() ||
+		info.Size() <= 0 || info.Size() > maximum ||
+		(runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0) {
+		return nil, errors.New("invalid private bounded JSON file")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil || !opened.Mode().IsRegular() || !os.SameFile(info, opened) {
+		return nil, errors.New("private bounded JSON file changed while opening")
+	}
+	raw, err := io.ReadAll(io.LimitReader(file, maximum+1))
+	if err != nil || len(raw) == 0 || int64(len(raw)) > maximum || !utf8.Valid(raw) ||
+		!cliObservabilityV8JSONHasUniqueKeys(raw) {
+		return nil, errors.New("invalid private bounded JSON encoding")
+	}
+	return raw, nil
 }
 
 func validateUpgradeReceipt(receipt upgradeReceipt, filename string) (bool, error) {

--- a/internal/gateway/upgrade_receipt_test.go
+++ b/internal/gateway/upgrade_receipt_test.go
@@ -4,11 +4,13 @@
 package gateway
 
 import (
+	"bytes"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,7 +45,6 @@ func TestUpgradeReceiptTerminalStatesUseMandatoryCanonicalCompliance(t *testing.
 	}{
 		{name: "succeeded", status: "succeeded", wantOutcome: string(observability.OutcomeApplied)},
 		{name: "partial", status: "partial", wantOutcome: string(observability.OutcomePartial)},
-		{name: "failed-health", status: "failed", failureCode: "health_check_failed", wantOutcome: string(observability.OutcomeFailed)},
 		{name: "rolled-back-detected", status: "rolled_back", failureCode: "rollback_detected", wantOutcome: string(observability.OutcomeRevoked)},
 		{name: "rolled-back-install", status: "rolled_back", failureCode: "install_failed", wantOutcome: string(observability.OutcomeRevoked)},
 		{name: "rolled-back-health", status: "rolled_back", failureCode: "health_check_failed", wantOutcome: string(observability.OutcomeRevoked)},
@@ -65,6 +66,149 @@ func TestUpgradeReceiptTerminalStatesUseMandatoryCanonicalCompliance(t *testing.
 			}
 			assertUpgradeReceiptRecord(t, fixture.store.DatabasePath(), receipt.ReceiptID, test.wantOutcome)
 		})
+	}
+}
+
+func TestUpgradeReceiptConsumerRetainsRecoverableFailureUntilHealthProvenRetry(t *testing.T) {
+	fixture := upgradeReceiptFixture(t)
+	receipt := validUpgradeReceipt("failed")
+	receipt.FailureCode = "health_check_failed"
+	path := writeUpgradeReceipt(t, fixture.dataDir, receipt)
+
+	if err := fixture.sidecar.consumeUpgradeReceipt(t.Context(), path, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("recoverable failure was acknowledged before a retry: %v", err)
+	}
+	assertUpgradeReceiptRecord(
+		t,
+		fixture.store.DatabasePath(),
+		receipt.ReceiptID,
+		string(observability.OutcomeFailed),
+	)
+
+	replacementID := uuid.NewString()
+	healthProven := false
+	marker := upgradeReceiptSupersession{
+		SchemaVersion: 1, ReceiptID: receipt.ReceiptID, TargetVersion: receipt.TargetVersion,
+		SupersededByReceiptID: replacementID, HealthProven: &healthProven,
+	}
+	raw, err := json.Marshal(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	markerPath := strings.TrimSuffix(path, ".json") + upgradeSupersessionSuffix
+	if err := os.WriteFile(markerPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.sidecar.consumeUpgradeReceipt(t.Context(), path, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("delegated failure was acknowledged before retry health: %v", err)
+	}
+	healthProven = true
+	marker.HealthProven = &healthProven
+	raw, err = json.Marshal(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(markerPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.sidecar.consumeUpgradeReceipt(t.Context(), path, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("superseded failure was not acknowledged: %v", err)
+	}
+	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("supersession marker was not cleaned: %v", err)
+	}
+}
+
+func TestUpgradeReceiptConsumerAcknowledgesDelegationAfterReplacementFailure(t *testing.T) {
+	fixture := upgradeReceiptFixture(t)
+	failed := validUpgradeReceipt("failed")
+	failed.FailureCode = "migration_failed"
+	failedPath := writeUpgradeReceipt(t, fixture.dataDir, failed)
+	replacement := validUpgradeReceipt("pending")
+	replacementPath := writeUpgradeReceipt(t, fixture.dataDir, replacement)
+	healthProven := false
+	marker := upgradeReceiptSupersession{
+		SchemaVersion: 1, ReceiptID: failed.ReceiptID, TargetVersion: failed.TargetVersion,
+		SupersededByReceiptID: replacement.ReceiptID, HealthProven: &healthProven,
+	}
+	raw, err := json.Marshal(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	markerPath := strings.TrimSuffix(failedPath, ".json") + upgradeSupersessionSuffix
+	if err := os.WriteFile(markerPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fixture.sidecar.consumeUpgradeReceipt(t.Context(), failedPath, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(failedPath); err != nil {
+		t.Fatalf("pending replacement allowed predecessor acknowledgement: %v", err)
+	}
+	replacement = validUpgradeReceipt("failed")
+	replacement.ReceiptID = strings.TrimSuffix(filepath.Base(replacementPath), ".json")
+	replacement.FailureCode = "migration_failed"
+	writeUpgradeReceipt(t, fixture.dataDir, replacement)
+	if err := fixture.sidecar.consumeUpgradeReceipt(t.Context(), failedPath, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(failedPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failed replacement did not assume delegated authority: %v", err)
+	}
+	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("delegation marker was not cleaned: %v", err)
+	}
+	if _, err := os.Stat(replacementPath); err != nil {
+		t.Fatalf("pending replacement authority was removed: %v", err)
+	}
+}
+
+func TestUpgradeReceiptDelegationsKeepTheBoundedQueueReclaimable(t *testing.T) {
+	fixture := upgradeReceiptFixture(t)
+	replacement := validUpgradeReceipt("failed")
+	replacement.FailureCode = "migration_failed"
+	replacementPath := writeUpgradeReceipt(t, fixture.dataDir, replacement)
+	healthProven := false
+	for range upgradeReceiptMaxFiles - 1 {
+		failed := validUpgradeReceipt("failed")
+		failed.FailureCode = "interrupted"
+		failedPath := writeUpgradeReceipt(t, fixture.dataDir, failed)
+		marker := upgradeReceiptSupersession{
+			SchemaVersion: 1, ReceiptID: failed.ReceiptID, TargetVersion: failed.TargetVersion,
+			SupersededByReceiptID: replacement.ReceiptID, HealthProven: &healthProven,
+		}
+		raw, err := json.Marshal(marker)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(
+			strings.TrimSuffix(failedPath, ".json")+upgradeSupersessionSuffix,
+			raw,
+			0o600,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := fixture.sidecar.consumeUpgradeReceipts(t.Context(), nil); err != nil {
+		t.Fatal(err)
+	}
+	matches, err := filepath.Glob(filepath.Join(fixture.dataDir, upgradeReceiptDirectory, "*.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 || matches[0] != replacementPath {
+		t.Fatalf("bounded queue retained obsolete delegations: %v", matches)
 	}
 }
 
@@ -140,6 +284,271 @@ func TestUpgradeReceiptCrashAfterPersistenceRetriesIdempotently(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("canonical receipt rows=%d, want exactly one", count)
+	}
+}
+
+func TestUpgradeReceiptConsumerRetainsReceiptWhileBundleRestartCustodyExists(t *testing.T) {
+	fixture := upgradeReceiptFixture(t)
+	receipt := validUpgradeReceipt("succeeded")
+	path := writeUpgradeReceipt(t, fixture.dataDir, receipt)
+	intent := filepath.Join(
+		filepath.Dir(path),
+		receipt.ReceiptID+upgradeBundleIntentSuffix,
+	)
+	restartRequired := true
+	raw, err := json.Marshal(upgradeBundleRestartIntent{
+		SchemaVersion:   1,
+		ReceiptID:       receipt.ReceiptID,
+		TargetVersion:   receipt.TargetVersion,
+		RestartRequired: &restartRequired,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(intent, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fixture.sidecar.consumeUpgradeReceipt(t.Context(), path, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("restart custody did not retain receipt: %v", err)
+	}
+	assertUpgradeReceiptRecord(
+		t,
+		fixture.store.DatabasePath(),
+		receipt.ReceiptID,
+		string(observability.OutcomeApplied),
+	)
+
+	if err := os.Remove(intent); err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.sidecar.consumeUpgradeReceipt(t.Context(), path, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("receipt remained after restart custody was released: %v", err)
+	}
+}
+
+func TestUpgradeReceiptFalseBundleIntentDoesNotClaimRestartCustody(t *testing.T) {
+	fixture := upgradeReceiptFixture(t)
+	receipt := validUpgradeReceipt("succeeded")
+	path := writeUpgradeReceipt(t, fixture.dataDir, receipt)
+	restartRequired := false
+	raw, err := json.Marshal(upgradeBundleRestartIntent{
+		SchemaVersion:   1,
+		ReceiptID:       receipt.ReceiptID,
+		TargetVersion:   receipt.TargetVersion,
+		RestartRequired: &restartRequired,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	intent := strings.TrimSuffix(path, ".json") + upgradeBundleIntentSuffix
+	if err := os.WriteFile(intent, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	custody, err := localBundleRestartCustodyActive(path, receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if custody.active || custody.path != intent {
+		t.Fatalf("restart custody active=%t path=%q, want false and %q", custody.active, custody.path, intent)
+	}
+
+	if err := fixture.sidecar.consumeUpgradeReceipt(t.Context(), path, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("false restart intent retained a terminal success: %v", err)
+	}
+}
+
+func TestUpgradeReceiptConsumerCleansBoundedOrphanedRecoveryMetadata(t *testing.T) {
+	fixture := upgradeReceiptFixture(t)
+	directory := filepath.Join(fixture.dataDir, upgradeReceiptDirectory)
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	base := uuid.NewString()
+	paths := []string{
+		filepath.Join(directory, base+upgradeBundleIntentSuffix),
+		filepath.Join(directory, base+upgradeSupersessionSuffix),
+	}
+	for _, path := range paths {
+		if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := fixture.sidecar.consumeUpgradeReceipts(t.Context(), nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range paths {
+		if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("orphaned recovery metadata was not removed: %s: %v", path, err)
+		}
+	}
+}
+
+func TestUpgradeReceiptConsumerProcessesValidReceiptAfterOrphanCleanupErrors(t *testing.T) {
+	fixture := upgradeReceiptFixture(t)
+	directory := filepath.Join(fixture.dataDir, upgradeReceiptDirectory)
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	invalidIdentity := filepath.Join(directory, "!invalid"+upgradeBundleIntentSuffix)
+	if err := os.WriteFile(invalidIdentity, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	symlinkBase := "00000000-0000-4000-8000-000000000001"
+	symlinkTarget := filepath.Join(t.TempDir(), "target")
+	if err := os.WriteFile(symlinkTarget, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	symlinkPath := filepath.Join(directory, symlinkBase+upgradeSupersessionSuffix)
+	symlinkCreated := true
+	if err := os.Symlink(
+		symlinkTarget,
+		symlinkPath,
+	); err != nil {
+		symlinkCreated = false
+		t.Logf("symlink unavailable; continuing with the other invalid metadata cases: %v", err)
+	}
+
+	oversizedBase := "00000000-0000-4000-8000-000000000002"
+	oversized := filepath.Join(directory, oversizedBase+upgradeBundleIntentSuffix)
+	if err := os.WriteFile(oversized, bytes.Repeat([]byte("x"), upgradeBundleIntentMaxBytes+1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	validOrphanBase := "00000000-0000-4000-8000-000000000003"
+	validOrphan := filepath.Join(directory, validOrphanBase+upgradeBundleIntentSuffix)
+	if err := os.WriteFile(validOrphan, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	receipt := validUpgradeReceipt("succeeded")
+	receipt.ReceiptID = "00000000-0000-4000-8000-000000000004"
+	receiptPath := writeUpgradeReceipt(t, fixture.dataDir, receipt)
+	if err := fixture.sidecar.consumeUpgradeReceipts(t.Context(), nil); err == nil {
+		t.Fatal("invalid orphan metadata did not report an error")
+	}
+	if _, err := os.Stat(validOrphan); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("valid orphan after invalid entries was not cleaned: %v", err)
+	}
+	if _, err := os.Stat(invalidIdentity); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("malformed orphan metadata was not removed: %v", err)
+	}
+	if symlinkCreated {
+		if _, err := os.Lstat(symlinkPath); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("orphaned symlink metadata was not removed: %v", err)
+		}
+	}
+	if _, err := os.Stat(oversized); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("orphaned oversized metadata was not removed: %v", err)
+	}
+	if _, err := os.Stat(receiptPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("valid receipt was not acknowledged after cleanup error: %v", err)
+	}
+	assertUpgradeReceiptRecord(
+		t,
+		fixture.store.DatabasePath(),
+		receipt.ReceiptID,
+		string(observability.OutcomeApplied),
+	)
+}
+
+func TestUpgradeReceiptOrphanCleanupToleratesStaleDirectoryEntry(t *testing.T) {
+	directory := t.TempDir()
+	stale := filepath.Join(
+		directory,
+		"00000000-0000-4000-8000-000000000001"+upgradeBundleIntentSuffix,
+	)
+	valid := filepath.Join(
+		directory,
+		"00000000-0000-4000-8000-000000000002"+upgradeBundleIntentSuffix,
+	)
+	for _, path := range []string{stale, valid} {
+		if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(stale); err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanupOrphanedUpgradeReceiptMetadata(directory, entries); err != nil {
+		t.Fatalf("stale metadata entry should be a benign concurrent removal: %v", err)
+	}
+	if _, err := os.Stat(valid); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("valid orphan after stale entry was not cleaned: %v", err)
+	}
+}
+
+func TestUpgradeReceiptPrivateBoundedReaderRejectsDuplicateKeys(t *testing.T) {
+	directory := t.TempDir()
+	for _, test := range []struct {
+		name    string
+		maximum int64
+		raw     string
+	}{
+		{
+			name:    "receipt",
+			maximum: upgradeReceiptMaxBytes,
+			raw:     `{"schema_version":1,"schema_version":1}`,
+		},
+		{
+			name:    "restart-intent",
+			maximum: upgradeBundleIntentMaxBytes,
+			raw:     `{"restart_required":true,"restart_required":false}`,
+		},
+		{
+			name:    "supersession",
+			maximum: upgradeSupersessionMaxBytes,
+			raw:     `{"health_proven":false,"health_proven":true}`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(directory, test.name+".json")
+			if err := os.WriteFile(path, []byte(test.raw), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := readPrivateBoundedUniqueJSON(path, test.maximum); err == nil {
+				t.Fatal("duplicate JSON member was accepted")
+			}
+		})
+	}
+}
+
+func TestReadUpgradeReceiptPreservesMissingFileIdentity(t *testing.T) {
+	path := filepath.Join(t.TempDir(), uuid.NewString()+".json")
+	if _, _, err := readUpgradeReceipt(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("missing receipt error=%v, want os.ErrNotExist identity", err)
+	}
+}
+
+func TestUpgradeReceiptDelegationDistinguishesMissingAndInvalidTarget(t *testing.T) {
+	directory := t.TempDir()
+	receiptPath := filepath.Join(directory, uuid.NewString()+".json")
+	replacementID := uuid.NewString()
+	valid, err := upgradeReceiptDelegationReplacementValid(receiptPath, "8.0.0", replacementID)
+	if err != nil || valid {
+		t.Fatalf("missing delegation target valid=%t error=%v, want false and nil", valid, err)
+	}
+
+	replacementPath := filepath.Join(directory, replacementID+".json")
+	if err := os.WriteFile(replacementPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	valid, err = upgradeReceiptDelegationReplacementValid(receiptPath, "8.0.0", replacementID)
+	if err == nil || valid || err.Error() != "upgrade receipt delegation target is invalid" {
+		t.Fatalf("invalid delegation target valid=%t error=%v", valid, err)
 	}
 }
 

--- a/scripts/resolve_upgrade_baselines.py
+++ b/scripts/resolve_upgrade_baselines.py
@@ -56,7 +56,7 @@ def _sha256(payload: bytes) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
-def _checked_policy(path: Path, candidate_runtime_config_version: int) -> dict[str, Any]:
+def _checked_policy(path: Path) -> dict[str, Any]:
     try:
         document = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError) as exc:
@@ -78,22 +78,15 @@ def _checked_policy(path: Path, candidate_runtime_config_version: int) -> dict[s
         raise BaselineResolutionError("checked baseline floor is empty")
     if any(not isinstance(item, str) or SEMVER.fullmatch(item) is None for item in versions):
         raise BaselineResolutionError("checked baseline floor contains a non-canonical version")
-    if len(versions) != len(set(versions)) or versions != sorted(
-        versions, key=_version_key, reverse=True
-    ):
+    if len(versions) != len(set(versions)) or versions != sorted(versions, key=_version_key, reverse=True):
         raise BaselineResolutionError("checked baseline floor must be unique descending semver")
     if not isinstance(configs, dict) or set(configs) != set(versions):
         raise BaselineResolutionError("checked baseline config map does not match its versions")
     if any(
-        not isinstance(value, int)
-        or isinstance(value, bool)
-        or value < 1
-        or value > candidate_runtime_config_version
+        not isinstance(value, int) or isinstance(value, bool) or value < 1
         for value in configs.values()
     ):
-        raise BaselineResolutionError(
-            "checked baseline config versions must be positive and no newer than the candidate runtime"
-        )
+        raise BaselineResolutionError("checked baseline config versions must be positive")
     if not isinstance(platforms, dict) or set(platforms) != {"windows"}:
         raise BaselineResolutionError("checked baseline platforms must contain exactly windows")
     windows = platforms["windows"]
@@ -270,9 +263,7 @@ def _authenticate_release(
     }
     missing = sorted(set(required_metadata) - set(assets))
     if missing:
-        raise BaselineResolutionError(
-            f"immutable release {version} lacks authentication assets: {missing}"
-        )
+        raise BaselineResolutionError(f"immutable release {version} lacks authentication assets: {missing}")
     fetched: dict[str, bytes] = {}
     for name, maximum in required_metadata.items():
         item = assets[name]
@@ -295,9 +286,7 @@ def _authenticate_release(
     checksums = _parse_checksums(fetched["checksums.txt"])
     manifest_digest = checksums.get("upgrade-manifest.json")
     if manifest_digest is None or manifest_digest != _sha256(fetched["upgrade-manifest.json"]):
-        raise BaselineResolutionError(
-            f"upgrade manifest for {version} is not covered by authenticated checksums"
-        )
+        raise BaselineResolutionError(f"upgrade manifest for {version} is not covered by authenticated checksums")
     # Every actually published payload must be covered by the signed checksum
     # manifest and GitHub's immutable digest. The sealed candidate may contain
     # platform payloads intentionally omitted at publication (0.8.4's Windows
@@ -309,9 +298,7 @@ def _authenticate_release(
             continue
         digest = checksums.get(name)
         if digest is None or item["digest"].removeprefix("sha256:") != digest:
-            raise BaselineResolutionError(
-                f"signed checksum and immutable GitHub asset disagree for {version}/{name}"
-            )
+            raise BaselineResolutionError(f"signed checksum and immutable GitHub asset disagree for {version}/{name}")
     try:
         manifest = json.loads(fetched["upgrade-manifest.json"].decode("utf-8"))
     except (UnicodeError, json.JSONDecodeError) as exc:
@@ -326,18 +313,14 @@ def _authenticate_release(
         or runtime_config < 1
         or runtime_config > candidate_runtime_config_version
     ):
-        raise BaselineResolutionError(
-            f"published upgrade manifest for {version} has invalid release/config identity"
-        )
+        raise BaselineResolutionError(f"published upgrade manifest for {version} has invalid release/config identity")
     posix = _required_posix_assets(version)
     if not posix.issubset(checksums) or not posix.issubset(assets):
         raise BaselineResolutionError(f"published release {version} lacks its complete POSIX runtime")
     windows = _required_windows_assets(version)
     published_windows = windows & set(assets)
     if published_windows and published_windows != windows:
-        raise BaselineResolutionError(
-            f"published release {version} has a partial Windows runtime capability"
-        )
+        raise BaselineResolutionError(f"published release {version} has a partial Windows runtime capability")
     return runtime_config, published_windows == windows
 
 
@@ -357,9 +340,22 @@ def resolve_effective_policy(
         or candidate_runtime_config_version < 1
     ):
         raise BaselineResolutionError("candidate runtime config version must be positive")
-    checked = _checked_policy(checked_policy_path, candidate_runtime_config_version)
+    checked = _checked_policy(checked_policy_path)
     checked_versions = list(checked["published_baselines"])
-    floor_key = _version_key(checked_versions[0])
+    eligible_checked_versions = [
+        version for version in checked_versions if _version_key(version) < target_key
+    ]
+    dynamic_floor_key = max(
+        (_version_key(version) for version in eligible_checked_versions),
+        default=None,
+    )
+    if any(
+        checked["published_baseline_config_versions"][version] > candidate_runtime_config_version
+        for version in eligible_checked_versions
+    ):
+        raise BaselineResolutionError(
+            "eligible checked baseline config version is newer than the candidate runtime"
+        )
     candidates: dict[str, dict[str, Any]] = {}
     for release in releases:
         if not isinstance(release, dict):
@@ -368,7 +364,7 @@ def resolve_effective_policy(
         if not isinstance(tag, str) or SEMVER.fullmatch(tag) is None:
             continue
         key = _version_key(tag)
-        if not floor_key < key < target_key:
+        if dynamic_floor_key is None or not dynamic_floor_key < key < target_key:
             continue
         if release.get("draft") is not False or release.get("prerelease") is not False:
             continue
@@ -379,8 +375,15 @@ def resolve_effective_policy(
         candidates[tag] = release
 
     dynamic_versions = sorted(candidates, key=_version_key, reverse=True)
-    configs = dict(checked["published_baseline_config_versions"])
-    windows = list(checked["platform_published_baselines"]["windows"])
+    configs = {
+        version: checked["published_baseline_config_versions"][version]
+        for version in eligible_checked_versions
+    }
+    windows = [
+        version
+        for version in checked["platform_published_baselines"]["windows"]
+        if version in eligible_checked_versions
+    ]
     dynamic_windows: list[str] = []
     for version in dynamic_versions:
         runtime_config, has_windows = _authenticate_release(
@@ -394,7 +397,11 @@ def resolve_effective_policy(
         if has_windows:
             dynamic_windows.append(version)
 
-    versions = [*dynamic_versions, *checked_versions]
+    versions = [*dynamic_versions, *eligible_checked_versions]
+    if not versions:
+        raise BaselineResolutionError(
+            f"no supported published baseline predates candidate {target_version}"
+        )
     ordered_configs = {version: configs[version] for version in versions}
     return {
         "schema_version": 2,

--- a/scripts/source_release_identity.py
+++ b/scripts/source_release_identity.py
@@ -3,10 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Validate the reviewed source-release and source-install identity.
 
-Release assets are built from a reviewed commit and the published Git tag points
-to that same commit.  Consequently the checked-in version sources must already
-match the requested release; an ephemeral workflow-only version stamp is not a
-valid source-distribution identity.
+Release assets are built from an isolated checkout of a reviewed commit, stamped
+with the manually selected release version, while the published Git tag points
+to the original reviewed commit. The checked-in version is development metadata;
+release verification projects the requested version onto the validated source
+compatibility identity instead of requiring a routine version-bump commit.
 
 The source-install marker is deliberately separate from release-managed upgrade
 state.  It permits rebuilds only while the checkout remains in the same reviewed

--- a/scripts/test-developer-target-activation.sh
+++ b/scripts/test-developer-target-activation.sh
@@ -276,6 +276,7 @@ count = run_migrations(
     sys.argv[3],
     sys.argv[4],
     upgrade_handles_local_bundle=True,
+    controller_owns_local_bundle_transaction=True,
 )
 print(f"developer_target_migrations={count}")
 PY

--- a/scripts/test-upgrade-release.sh
+++ b/scripts/test-upgrade-release.sh
@@ -80,7 +80,7 @@ Options:
 
 Examples:
   make upgrade-legacy-smoke
-  make upgrade-legacy-smoke-matrix
+  make upgrade-legacy-smoke-matrix ARGS="--target-version X.Y.Z"
   scripts/test-upgrade-release.sh --from-version 0.7.2
   scripts/test-upgrade-release.sh --from-versions "0.8.3,0.8.2,0.8.1,0.8.0,0.7.2,0.7.1"
   scripts/test-upgrade-release.sh --release-dir dist --baseline-mode seed

--- a/spec.md
+++ b/spec.md
@@ -613,7 +613,7 @@ make check-schemas
 make check-grafana-dashboards
 uv run python -m pytest cli/tests/test_agent360_dashboard.py cli/tests/test_grafana_dashboards.py -q
 make check-upgrade-manifest
-make upgrade-smoke-matrix ARGS="--baseline-mode seed"
+make upgrade-smoke-matrix ARGS="--target-version X.Y.Z --baseline-mode seed"
 python scripts/check_grafana_dashboards.py --live --inventory --require-packaged
 ```
 


### PR DESCRIPTION
Standalone PR against `main`. This is the focused post-0.8.6 release/upgrade repair; it does not change teams, reviewers, branch rules, rulesets, release environments, or the unsigned macOS fallback.

## Problem

The 0.8.6 certification exposed two version-coupled upgrade defects:

- `0.8.4 and older → 0.8.6` validated dependencies with a package/version contract written specifically for `0.8.4 → 0.8.5`, rejecting valid target requirements such as `jsonschema`, `mcp`, and `textual`.
- `0.8.5 → 0.8.6` refreshed the native-v8 observability bundle only when a hard-cut rollback plan existed, leaving an installed bundle stamped at 0.8.5 during an ordinary v8-to-v8 upgrade.

The historical upgrade matrix also required editing a checked-in baseline list as each stable release was published.

## Current Situation

Release version selection and artifact stamping are already dynamic, but upgrade compatibility still contained transition-specific assumptions. This made Release discover failures that should have been handled by generic target metadata and durable upgrade state.

The immutable compatibility boundaries remain valid:

- 0.8.4 is the config-v7/protocol-2 bridge.
- 0.8.5 is the first-v8 migration boundary.
- Later routine releases must not require new version literals or dependency allowlists.

## Solution

### Metadata-driven dependency validation

Build a bounded offline shadow of the installed environment from wheel metadata, install the authenticated target wheel into that shadow, and run `uv pip check`. Compatibility now follows the source/target wheel requirements without naming packages or release versions.

### Durable bundle transaction and recovery

Introduce a capability handshake for controllers that own the local-observability transaction. Ordinary v8-to-v8 upgrades now refresh the bundle after migrations, record restart custody in the verified upgrade receipt, recover interrupted same-version attempts, and declare success only after health and restart state are reconciled.

Receipt, supersession, and restart-intent metadata are private, bounded, identity-checked, atomically written, and consumed consistently by Python and Go.

### Dynamic authenticated baselines

Resolve stable releases between the reviewed support floor and the selected candidate at execution time. Each discovered release must have immutable GitHub asset digests, signed checksums, a covered upgrade manifest, and a complete supported platform runtime. Explicit developer overrides remain available.

```mermaid
flowchart LR
    A["Selected release version"] --> B["Authenticated candidate artifacts"]
    B --> C["Target wheel dependency metadata"]
    C --> D["Offline compatibility check"]
    B --> E["Dynamic authenticated baseline resolver"]
    D --> F["Verified upgrade receipt"]
    E --> F
    F --> G["Install and target migrations"]
    G --> H["Bundle refresh and restart custody"]
    H --> I["Fresh-process health checks"]
    I --> J["Success receipt"]
```

### Fail-closed compatibility

The immutable 0.8.4 and 0.8.5 controllers both create a verified receipt before invoking target migrations. The compatibility fallback therefore continues to require that receipt; it does not permit unauthenticated bundle mutation.

## What Changed (Where & How)

| Area | Paths | Change |
|---|---|---|
| Upgrade controller | `cli/defenseclaw/commands/cmd_upgrade.py` | Metadata-driven dependency checks, capability negotiation, bundle refresh, same-version recovery |
| Bundle transaction | `cli/defenseclaw/bundle_refresh.py`, `cli/defenseclaw/migrations.py` | Durable restart custody, safe cleanup, normal v8-to-v8 refresh |
| Durable receipts | `cli/defenseclaw/upgrade_receipt.py`, `internal/gateway/upgrade_receipt.go` | Bounded intent/supersession records and restart-safe consumption |
| Baseline selection | `Makefile`, `scripts/resolve_upgrade_baselines.py` | Dynamic authenticated stable-release discovery with explicit candidate selection |
| Verification | `cli/tests/`, `internal/gateway/*_test.go`, upgrade harnesses | Future-version, recovery, race, refusal, and no-hardcoding regressions |
| Documentation | `docs/TESTING.md`, `spec.md`, observability verification docs | Dynamic matrix usage and exact candidate requirements |

## Breaking Changes

No supported user upgrade path is removed.

Developer matrix targets now require `ARGS="--target-version X.Y.Z"` unless `UPGRADE_SMOKE_FROM` is explicitly supplied. This prevents the checked-in development version from accidentally selecting release baselines.

## Open Issues / Follow-ups

None.

## Test Plan

Observed locally:

```text
Python CI shard 0: 1682 passed, 6 skipped, 149 subtests
Python CI shard 1: 1639 passed, 11 skipped, 24 subtests
Python CI shard 2: 1793 passed, 18 skipped, 131 subtests
Python CI shard 3: 1638 passed, 23 skipped, 107 subtests
Changed Python tests: 453 passed, 1 skipped, 47 subtests
Deterministic release regression: 230 passed, 1 skipped
Focused migration tests: 52 passed, 9 subtests
Focused Go receipt tests: passed
Focused Go receipt race tests: passed
Full go test ./...: passed
make py-lint: passed
make telemetry-check: passed
make check-version-sync: passed
make check-upgrade-manifest: passed
git diff --check: passed
```

Exact unsigned-candidate validation passed for:

```text
local: 0.8.5 → 0.8.6
local: 0.8.4 → 0.8.6
local: 0.8.3 explicit/latest pre-mutation refusal
local: 0.4.0 success and refusal
remote macOS: 0.8.5 and 0.8.4 → 0.8.6; 0.8.3 refusal
remote Linux arm64: 0.8.5, 0.8.4, and 0.4.0 → 0.8.6; 0.8.3 refusal
```

Both remote success paths verified CLI/gateway 0.8.6 identity, fresh-process health, v7-to-v8 migration where applicable, SQLite integrity/correlation tables, target bundle stamp/payload, preserved operator state, and restart-intent cleanup. Refusal paths were byte-identical before and after.
