### PR TITLE
fix(release): authenticate post-upgrade write probe

### DIFF
--- a/cli/tests/test_upgrade_release_smoke_contract.py
+++ b/cli/tests/test_upgrade_release_smoke_contract.py
@@ -174,6 +174,19 @@ def test_source_gateway_canary_waits_for_exact_version_bound_health() -> None:
     assert "did not reach version-bound health" in canary
 
 
+def test_post_status_write_probe_satisfies_gateway_csrf_contract() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+    start = source.index('request = Request(\n    f"http://127.0.0.1:{port}/policy/reload"')
+    end = source.index("\n)\nwith urlopen(request, timeout=10)", start)
+    request = source[start:end]
+
+    assert 'data=b"{}"' in request
+    assert '"Authorization": "Bearer " + token' in request
+    assert '"Content-Type": "application/json"' in request
+    assert '"X-DefenseClaw-Client": "release-upgrade-smoke"' in request
+    assert '"X-DefenseClaw-Token": token' in request
+
+
 @pytest.mark.parametrize(("baseline", "config_version"), [("0.8.3", 7), ("0.4.0", 5)])
 def test_historical_canary_fixture_is_hermetic_before_gateway_start(
     tmp_path: Path,

--- a/scripts/test-upgrade-release.sh
+++ b/scripts/test-upgrade-release.sh
@@ -2555,10 +2555,12 @@ if not token:
 
 request = Request(
     f"http://127.0.0.1:{port}/policy/reload",
-    data=b"",
+    data=b"{}",
     method="POST",
     headers={
         "Authorization": "Bearer " + token,
+        "Content-Type": "application/json",
+        "X-DefenseClaw-Client": "release-upgrade-smoke",
         "X-DefenseClaw-Token": token,
     },
 )


### PR DESCRIPTION
Base: `main`. Focused follow-up to failed Release run [29692598795](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29692598795); this does not change production upgrade, installer, gateway, signing, or release-environment behavior.

## Problem

The signed 0.8.6 historical upgrade matrix completed each upgrade successfully, then every Linux and macOS cell failed the certification harness's post-upgrade `POST /policy/reload` probe with HTTP 403.

## Current Situation

The upgraded installations reached all important success gates before the failure: migration completed, the upgrade receipt was acknowledged, the observability bundle was stamped 0.8.6, the target gateway became healthy, and the installed TUI mounted.

The probe sent valid bearer and gateway-token authentication, but omitted the gateway's established CSRF client header. The gateway correctly returned 403. It also omitted the required JSON content type, which would have caused HTTP 415 after fixing only the first omission.

## Solution

### Match the existing gateway write contract

Send an empty JSON object and include both `Content-Type: application/json` and `X-DefenseClaw-Client: release-upgrade-smoke`, while retaining both existing token headers. This mirrors the production CLI's authenticated policy-reload request and does not weaken gateway enforcement.

### Prevent promotion-only regressions

Add a fast deterministic contract test that pins the post-status write probe's JSON body, bearer authentication, gateway token, client identity, and content type. Ordinary PR CI can now catch this exact harness regression without moving the expensive signed historical matrix back into PR CI.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `scripts/test-upgrade-release.sh` | Make the post-upgrade policy reload probe satisfy the authenticated JSON/CSRF contract. |
| `cli/tests/test_upgrade_release_smoke_contract.py` | Assert the certification probe retains every required request field. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

- `bash -n scripts/test-upgrade-release.sh` — passed
- `uv run --project cli pytest -q cli/tests/test_upgrade_release_smoke_contract.py cli/tests/test_upgrade_smoke_static.py` — 103 passed, 1 skipped
- `go test ./internal/gateway -run 'Test.*(CSRF|Auth)' -count=1` — passed
- `uv run --project cli ruff check cli/tests/test_upgrade_release_smoke_contract.py` — passed
- `git diff --check` — passed
- `coderabbit review --agent -t uncommitted -c AGENTS.md` — 0 issues
