### PR TITLE
fix(release): complete POSIX upgrade handoff

### DIFF
--- a/cli/defenseclaw/migrations.py
+++ b/cli/defenseclaw/migrations.py
@@ -65,6 +65,7 @@ _OBSERVABILITY_V8_PREFLIGHT_BINDING_ENV = "DEFENSECLAW_OBSERVABILITY_V8_PREFLIGH
 _UPGRADE_MUTATION_TOKEN_ENV = "DEFENSECLAW_UPGRADE_MUTATION_TOKEN"
 _MAX_OBSERVABILITY_V8_UPGRADE_FILE_BYTES = 4 * 1024 * 1024
 _WINDOWS_REPARSE_POINT_ATTRIBUTE = 0x00000400
+_ENVIRONMENT_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 # These target-wheel dependencies are resolved lazily. Older upgrade clients
@@ -889,7 +890,16 @@ def _observability_v8_upgrade_environment_snapshot(
     """Return parsed values and a value-free identity of the exact dotenv bytes."""
 
     snapshot, present, digest = _read_observability_v8_upgrade_dotenv_snapshot(environment_path)
-    snapshot.update(os.environ)
+    # POSIX permits exported shell functions and other ambient entries whose
+    # names cannot be referenced by the v8 ``$NAME`` grammar (for example,
+    # ``BASH_FUNC_which%%``). They are unrelated to config conversion and must
+    # not make an otherwise valid upgrade fail. The managed dotenv remains
+    # strict: its parser rejects every malformed assignment before this merge.
+    snapshot.update(
+        (name, value)
+        for name, value in os.environ.items()
+        if _ENVIRONMENT_NAME.fullmatch(name) is not None
+    )
     return snapshot, present, digest
 
 

--- a/cli/defenseclaw/migrations.py
+++ b/cli/defenseclaw/migrations.py
@@ -810,6 +810,8 @@ sys.exit(0 if payload["ok"] else 1)
         completed = subprocess.run(
             [
                 sys.executable,
+                "-I",
+                "-B",
                 "-c",
                 script,
                 data_dir,

--- a/cli/tests/test_observability_v8_upgrade_migration.py
+++ b/cli/tests/test_observability_v8_upgrade_migration.py
@@ -75,7 +75,10 @@ class TestObservabilityV8UpgradeMigration(unittest.TestCase):
     def test_target_bundle_subprocess_uses_isolated_python(self) -> None:
         observed: list[str] = []
 
-        def complete(command, **_kwargs):
+        def complete(
+            command: list[str],
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
             observed.extend(command)
             with open(command[-1], "w", encoding="utf-8") as result_file:
                 json.dump({"ok": True, "installed": False}, result_file)

--- a/cli/tests/test_observability_v8_upgrade_migration.py
+++ b/cli/tests/test_observability_v8_upgrade_migration.py
@@ -658,6 +658,7 @@ audit_sinks:
             self.assertEqual(environment["DOTENV_ONLY"], "dotenv-value")
             self.assertEqual(environment["SHARED"], "ambient-wins")
             self.assertEqual(environment["AMBIENT_ONLY"], "ambient-value")
+            self.assertNotIn("BASH_FUNC_which%%", environment)
             self.assertEqual(kwargs["source_name"], os.path.abspath(self.config_path))
             self.assertEqual(kwargs["effective_data_dir"], os.path.abspath(self.data_dir))
             return migration
@@ -691,7 +692,11 @@ audit_sinks:
         with (
             patch.dict(
                 os.environ,
-                {"SHARED": "ambient-wins", "AMBIENT_ONLY": "ambient-value"},
+                {
+                    "SHARED": "ambient-wins",
+                    "AMBIENT_ONLY": "ambient-value",
+                    "BASH_FUNC_which%%": "() { :; }",
+                },
                 clear=True,
             ),
             patch("defenseclaw.migrations.convert_v7_observability_to_v8", side_effect=convert),
@@ -1177,6 +1182,19 @@ audit_sinks:
     def test_missing_environment_uses_ambient_snapshot(self) -> None:
         os.remove(self.environment_path)
         with patch.dict(os.environ, {"AMBIENT_ONLY": "present"}, clear=True):
+            snapshot = _observability_v8_upgrade_environment(self.environment_path)
+        self.assertEqual(snapshot, {"AMBIENT_ONLY": "present"})
+
+    def test_ambient_snapshot_ignores_unreferenceable_shell_function_names(self) -> None:
+        os.remove(self.environment_path)
+        with patch.dict(
+            os.environ,
+            {
+                "AMBIENT_ONLY": "present",
+                "BASH_FUNC_which%%": "() { :; }",
+            },
+            clear=True,
+        ):
             snapshot = _observability_v8_upgrade_environment(self.environment_path)
         self.assertEqual(snapshot, {"AMBIENT_ONLY": "present"})
 

--- a/cli/tests/test_observability_v8_upgrade_migration.py
+++ b/cli/tests/test_observability_v8_upgrade_migration.py
@@ -24,6 +24,7 @@ from defenseclaw.migrations import (
     _allocate_observability_v8_bundle_backup,
     _migrate_observability_v8,
     _observability_v8_upgrade_environment,
+    _run_observability_v8_bundle_upgrade_in_target,
     _valid_upgrade_mutation_token,
     _validate_observability_v8_candidate,
     preflight_observability_v8_upgrade,
@@ -70,6 +71,25 @@ class TestObservabilityV8UpgradeMigration(unittest.TestCase):
                 artifacts_verified=True,
             )
         )
+
+    def test_target_bundle_subprocess_uses_isolated_python(self) -> None:
+        observed: list[str] = []
+
+        def complete(command, **_kwargs):
+            observed.extend(command)
+            with open(command[-1], "w", encoding="utf-8") as result_file:
+                json.dump({"ok": True, "installed": False}, result_file)
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        with patch("defenseclaw.migrations.subprocess.run", side_effect=complete):
+            result = _run_observability_v8_bundle_upgrade_in_target(
+                self.data_dir,
+                os.path.join(self.data_dir, "backups", "bundle"),
+                "9.9.9",
+            )
+
+        self.assertEqual(result, {"ok": True, "installed": False})
+        self.assertEqual(observed[:4], [sys.executable, "-I", "-B", "-c"])
 
     def test_registry_runs_migration_only_at_forward_release_key(self) -> None:
         rows = [(version, fn) for version, _description, fn in MIGRATIONS if fn is _migrate_observability_v8]

--- a/cli/tests/test_upgrade_release_smoke_contract.py
+++ b/cli/tests/test_upgrade_release_smoke_contract.py
@@ -174,17 +174,125 @@ def test_source_gateway_canary_waits_for_exact_version_bound_health() -> None:
     assert "did not reach version-bound health" in canary
 
 
-def test_post_status_write_probe_satisfies_gateway_csrf_contract() -> None:
+def test_audit_event_probe_is_policy_independent_and_satisfies_gateway_contract() -> None:
     source = SCRIPT.read_text(encoding="utf-8")
-    start = source.index('request = Request(\n    f"http://127.0.0.1:{port}/policy/reload"')
-    end = source.index("\n)\nwith urlopen(request, timeout=10)", start)
+    start = source.index("probe_id = str(uuid.uuid4())")
+    end = source.index("\nlocal = (config.get(\"observability\")", start)
     request = source[start:end]
 
-    assert 'data=b"{}"' in request
+    assert '"action": "policy-reload"' in request
+    assert '"id": probe_id' in request
+    assert '"target": "release-upgrade-smoke:" + probe_id' in request
+    assert '"actor": "release-upgrade-smoke"' in request
+    assert '"details": "synthetic post-status SQLite continuity probe; no policy state changed"' in request
+    assert '"severity": "INFO"' in request
+    assert 'f"http://127.0.0.1:{port}/audit/event"' in request
+    assert "data=body" in request
     assert '"Authorization": "Bearer " + token' in request
     assert '"Content-Type": "application/json"' in request
     assert '"X-DefenseClaw-Client": "release-upgrade-smoke"' in request
     assert '"X-DefenseClaw-Token": token' in request
+    assert "/policy/reload" not in request
+    assert "response.status != 200" in request
+    assert 'result != {"status": "ok"}' in request
+
+    persistence = source[end : source.index('print("post_status_mandatory_sqlite_write=ok")', end)]
+    assert "WHERE id = ? AND action = 'policy-reload'" in persistence
+    assert "AND event_name = 'policy.updated' AND mandatory = 1" in persistence
+    assert "(probe_id,)" in persistence
+    assert 'getattr(sqlite3, "SQLITE_BUSY", 5)' in persistence
+    assert 'getattr(sqlite3, "SQLITE_LOCKED", 6)' in persistence
+    assert 'message == "database is busy"' in persistence
+    assert '"database table is locked"' in persistence
+    assert "timeout=0.2" in persistence
+    assert "if after == 1:" in persistence
+
+
+def test_posix_resolver_owns_dynamic_receipt_and_bundle_phases() -> None:
+    source = UPGRADE_SCRIPT.read_text(encoding="utf-8")
+
+    receipt_function = source[
+        source.index("begin_release_upgrade_receipt() {") : source.index(
+            "\n}\n\nfinish_release_upgrade_receipt()", source.index("begin_release_upgrade_receipt() {")
+        )
+    ]
+    backup = source.index('ok "Backup saved to: ${BACKUP_DIR}"')
+    receipt = source.index("begin_release_upgrade_receipt\n", backup)
+    stop = source.index('# ── Stop services', receipt)
+    gateway_activation = source.index('mv -f "${BRIDGE_GATEWAY_INSTALL_TEMP}"', stop)
+    target_activation = source.index(
+        'UPGRADE_RECEIPT_FAILURE_CODE="interrupted"', gateway_activation
+    )
+    launcher = source.index('ln -sf "${DEFENSECLAW_VENV}/bin/defenseclaw"', target_activation)
+    migration = source.index('kwargs = {"upgrade_handles_local_bundle": True}', stop)
+    required = source.index('if [[ "${UPGRADE_INCOMPLETE}" -eq 1 ]]', migration)
+    start = source.index('# ── Start services', required)
+    health = source.index('if [[ "${HEALTH_OK}" -eq 0 ]]', start)
+    suppress_failed_trap = source.index("UPGRADE_RECEIPT_TERMINAL=1", health)
+    complete = source.index("finish_release_upgrade_receipt succeeded", suppress_failed_trap)
+
+    assert (
+        backup
+        < receipt
+        < stop
+        < gateway_activation
+        < target_activation
+        < launcher
+        < migration
+        < required
+        < start
+        < health
+        < suppress_failed_trap
+        < complete
+    )
+    assert receipt_function.index('local receipt_path receipt_name') < receipt_function.index(
+        'UPGRADE_RECEIPT_PATH="${receipt_path}"'
+    )
+    assert "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}" in receipt_function
+    migration_phase = source[stop:required]
+    assert "TARGET_PYTHON_STDIN_ARGS=(-)" in migration_phase
+    assert "TARGET_PYTHON_STDIN_ARGS=(-I -B -)" in migration_phase
+    assert (
+        '"${VENV_PYTHON}" "${TARGET_PYTHON_STDIN_ARGS[@]}" "${UPGRADE_RECEIPT_PATH}"'
+        in migration_phase
+    )
+    assert "delegate_prior_upgrade_receipts(Path(receipt_path))" in migration_phase
+    assert 'os.environ["MIGRATION_TO_VERSION"]' in migration_phase
+    assert "record_upgrade_migrations(" in migration_phase
+    assert (
+        '"${VENV_PYTHON}" "${TARGET_PYTHON_STDIN_ARGS[@]}" "${UPGRADE_MANIFEST_FILE}"'
+        in source[migration:required]
+    )
+    assert '"${VENV_PYTHON}" "${TARGET_PYTHON_STDIN_ARGS[@]}" <<\'PY\'' in source[start:health]
+
+    same_version = source.index('same_version_recovery="clean"')
+    recovery = source.index('section "Recovering Incomplete Upgrade"', same_version)
+    clean_noop = source.index('section "Version Already Verified"', recovery)
+    assert same_version < recovery < clean_noop < backup
+    same_version_phase = source[same_version:clean_noop]
+    assert "find_resumable_upgrade_receipt" in same_version_phase
+    assert "find_verified_installed_upgrade_receipt" in same_version_phase
+    assert "installed_local_observability_bundle_version" in same_version_phase
+    assert 'print("untrusted-bundle-drift")' in same_version_phase
+    assert '"${DEFENSECLAW_VENV}/bin/defenseclaw" upgrade --yes' in same_version_phase
+
+    split = source.index('if [[ "${COMPONENT_VERSION_SPLIT}" -eq 1 ]]')
+    hard_cut_state = source.index('hard_cut_state="$(', split)
+    split_phase = source[split:hard_cut_state]
+    assert "find_resumable_upgrade_receipt" not in split_phase
+    assert "MAX_UPGRADE_RECEIPTS" in split_phase
+    assert "UPGRADE_RECEIPT_DIRECTORY" in split_phase
+    assert "load_upgrade_receipt" in split_phase
+    assert 'receipt.from_version == source_version' in split_phase
+    assert 'receipt.target_version == target_version' in split_phase
+    assert 'receipt.artifacts_verified' in split_phase
+    assert 'receipt.migration_status == "pending"' in split_phase
+    assert "receipt.migration_count is None" in split_phase
+    assert 'receipt.status == "pending" and receipt.failure_code == ""' in split_phase
+    assert 'receipt.status == "failed" and receipt.failure_code == "interrupted"' in split_phase
+    assert "latest_created_at = max(" in split_phase
+    assert "if created_at == latest_created_at" in split_phase
+    assert 'print("recover" if len(latest) == 1 else "invalid")' in split_phase
 
 
 @pytest.mark.parametrize(("baseline", "config_version"), [("0.8.3", 7), ("0.4.0", 5)])

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -3458,6 +3458,7 @@ func TestAPIAlertsAndAuditEventHandlers(t *testing.T) {
 	api := &APIServer{health: NewSidecarHealth(), store: store, logger: logger}
 
 	body := []byte(`{
+		"id":"5e897a6d-428a-4438-a014-33b6116ccbf2",
 		"action":"gateway-tool-call",
 		"target":"/tmp/bad-plugin",
 		"actor":"plugin-test",
@@ -3491,8 +3492,9 @@ func TestAPIAlertsAndAuditEventHandlers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(events) != 1 || events[0].Action != string(audit.ActionGatewayToolCall) {
-		t.Fatalf("canonical event history = %#v, want one %q row", events, audit.ActionGatewayToolCall)
+	if len(events) != 1 || events[0].ID != "5e897a6d-428a-4438-a014-33b6116ccbf2" ||
+		events[0].Action != string(audit.ActionGatewayToolCall) {
+		t.Fatalf("canonical event history = %#v, want one caller-identified %q row", events, audit.ActionGatewayToolCall)
 	}
 }
 

--- a/scripts/test-upgrade-release.sh
+++ b/scripts/test-upgrade-release.sh
@@ -2498,50 +2498,20 @@ print("installed_target_tui_origin=venv")
 print("installed_target_tui_mount=ok")
 PY
 
-    local policy_rows_before=""
     if target_uses_observability_v8; then
-        policy_rows_before="$("${venv_python}" -I -B - "${SMOKE_HOME}/.defenseclaw" <<'PY'
-from pathlib import Path
-import sqlite3
-import sys
-
-import yaml
-
-data_dir = Path(sys.argv[1])
-config = yaml.safe_load((data_dir / "config.yaml").read_text(encoding="utf-8")) or {}
-configured = (((config.get("observability") or {}).get("local") or {}).get("path"))
-if configured is None:
-    database = data_dir / "audit.db"
-elif not isinstance(configured, str) or not configured.strip():
-    raise SystemExit("configured audit database path is invalid")
-else:
-    database = Path(configured).expanduser()
-    if not database.is_absolute():
-        database = data_dir / database
-connection = sqlite3.connect(f"file:{database}?mode=ro", uri=True)
-try:
-    count = connection.execute(
-        "SELECT COUNT(*) FROM audit_events WHERE event_name = 'policy.updated' AND mandatory = 1"
-    ).fetchone()[0]
-finally:
-    connection.close()
-print(count)
-PY
-)" || die "could not snapshot mandatory policy rows immediately before reload"
-        [[ "${policy_rows_before}" =~ ^[0-9]+$ ]] \
-            || die "invalid mandatory policy row count immediately before reload"
-
-        "${venv_python}" -I -B - "${SMOKE_HOME}/.defenseclaw" "${policy_rows_before}" <<'PY'
+        "${venv_python}" -I -B - "${SMOKE_HOME}/.defenseclaw" <<'PY'
+import json
 from pathlib import Path
 import sqlite3
 import sys
 import time
+import uuid
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 import yaml
 
 data_dir = Path(sys.argv[1])
-before = int(sys.argv[2])
 config = yaml.safe_load((data_dir / "config.yaml").read_text(encoding="utf-8")) or {}
 port = int((config.get("gateway") or {}).get("api_port") or 18970)
 token = ""
@@ -2553,9 +2523,20 @@ for line in (data_dir / ".env").read_text(encoding="utf-8").splitlines():
 if not token:
     raise SystemExit("target gateway token is unavailable for the post-status write probe")
 
+probe_id = str(uuid.uuid4())
+body = json.dumps(
+    {
+        "id": probe_id,
+        "action": "policy-reload",
+        "target": "release-upgrade-smoke:" + probe_id,
+        "actor": "release-upgrade-smoke",
+        "details": "synthetic post-status SQLite continuity probe; no policy state changed",
+        "severity": "INFO",
+    }
+).encode("utf-8")
 request = Request(
-    f"http://127.0.0.1:{port}/policy/reload",
-    data=b"{}",
+    f"http://127.0.0.1:{port}/audit/event",
+    data=body,
     method="POST",
     headers={
         "Authorization": "Bearer " + token,
@@ -2564,9 +2545,27 @@ request = Request(
         "X-DefenseClaw-Token": token,
     },
 )
-with urlopen(request, timeout=10) as response:
-    if response.status != 200:
-        raise SystemExit(f"post-status policy reload returned HTTP {response.status}")
+try:
+    with urlopen(request, timeout=10) as response:
+        response_body = response.read(4097)
+        if len(response_body) > 4096:
+            raise SystemExit("post-status audit write returned an oversized response")
+        result = json.loads(response_body)
+        if response.status != 200 or result != {"status": "ok"}:
+            raise SystemExit("post-status audit write was not acknowledged")
+except HTTPError as exc:
+    try:
+        response_body = exc.read(4096).decode("utf-8", errors="replace")
+    except OSError:
+        response_body = "<response body unavailable after read timeout>"
+    raise SystemExit(
+        f"post-status audit write returned HTTP {exc.code}: {response_body}"
+    ) from exc
+except (URLError, OSError) as exc:
+    reason = getattr(exc, "reason", type(exc).__name__)
+    raise SystemExit(f"post-status audit write request/read failed: {reason}") from exc
+except (json.JSONDecodeError, UnicodeError) as exc:
+    raise SystemExit("post-status audit write returned invalid JSON") from exc
 
 local = (config.get("observability") or {}).get("local") or {}
 configured = local.get("path")
@@ -2580,14 +2579,35 @@ else:
         database = data_dir / database
 deadline = time.monotonic() + 10
 while True:
-    connection = sqlite3.connect(f"file:{database}?mode=ro", uri=True)
+    connection = None
     try:
+        connection = sqlite3.connect(f"file:{database}?mode=ro", uri=True, timeout=0.2)
         after = connection.execute(
-            "SELECT COUNT(*) FROM audit_events WHERE event_name = 'policy.updated' AND mandatory = 1"
+            "SELECT COUNT(*) FROM audit_events "
+            "WHERE id = ? AND action = 'policy-reload' "
+            "AND event_name = 'policy.updated' AND mandatory = 1",
+            (probe_id,),
         ).fetchone()[0]
+    except sqlite3.OperationalError as exc:
+        code = getattr(exc, "sqlite_errorcode", None)
+        busy_code = getattr(sqlite3, "SQLITE_BUSY", 5)
+        locked_code = getattr(sqlite3, "SQLITE_LOCKED", 6)
+        retryable = code is not None and (code & 0xFF) in {
+            busy_code,
+            locked_code,
+        }
+        if code is None:
+            message = str(exc).lower()
+            retryable = message == "database is busy" or message.startswith(
+                ("database is locked", "database table is locked", "database schema is locked")
+            )
+        if not retryable:
+            raise
+        after = 0
     finally:
-        connection.close()
-    if after > before:
+        if connection is not None:
+            connection.close()
+    if after == 1:
         break
     if time.monotonic() >= deadline:
         raise SystemExit("fresh SQLite readers cannot see the mandatory write made after status")

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -393,6 +393,77 @@ preflight_python_wheel() {
     ok "Python CLI dependency preflight passed"
 }
 
+begin_release_upgrade_receipt() {
+    [[ "${BRIDGE_PHASE1}" -ne 1 && "${CURRENT_VERSION}" != "unknown" \
+        && -n "${RELEASE_PROVENANCE_FILE}" ]] || return 0
+
+    local source_python="${DEFENSECLAW_VENV}/bin/python"
+    [[ -x "${source_python}" ]] \
+        || die "The provenance-authenticated source controller cannot create a durable upgrade receipt. No services changed."
+    [[ "${CHECKSUMS_SIGNATURE_VERIFIED}" -eq 1 ]] \
+        || die "The modern release artifacts were not authenticated; no upgrade receipt or service mutation was attempted."
+
+    local receipt_path receipt_name
+    receipt_path="$(
+        DEFENSECLAW_HOME="${DATA_DIR}" "${source_python}" -I -B - \
+            "${DATA_DIR}" "${CURRENT_VERSION}" "${RELEASE_VERSION}" <<'PY'
+import os
+import sys
+
+from defenseclaw.upgrade_receipt import (
+    begin_upgrade_receipt,
+    finalize_interrupted_upgrade_receipts,
+)
+
+data_dir, source_version, target_version = sys.argv[1:]
+finalize_interrupted_upgrade_receipts(data_dir, current_version=source_version)
+receipt = begin_upgrade_receipt(
+    data_dir,
+    from_version=source_version,
+    target_version=target_version,
+    artifacts_verified=True,
+)
+print(os.fspath(receipt))
+PY
+    )" || die "Could not create the durable upgrade compliance receipt; no services changed."
+    receipt_name="${receipt_path#"${DATA_DIR}/.upgrade-receipts/"}"
+    [[ -n "${receipt_path}" \
+        && "${receipt_path}" == "${DATA_DIR}/.upgrade-receipts/"* \
+        && "${receipt_name}" != */* \
+        && "${receipt_name}" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}[.]json$ ]] \
+        || die "The durable upgrade receipt escaped the managed controller directory; no services changed."
+    UPGRADE_RECEIPT_PATH="${receipt_path}"
+    UPGRADE_RECEIPT_FAILURE_CODE="install_failed"
+    ok "Durable upgrade receipt committed before mutation"
+}
+
+finish_release_upgrade_receipt() {
+    local status="$1" failure_code="${2:-}"
+    [[ -n "${UPGRADE_RECEIPT_PATH}" ]] || return 0
+    DEFENSECLAW_HOME="${DATA_DIR}" "${VENV_PYTHON}" -I -B - \
+        "${UPGRADE_RECEIPT_PATH}" "${status}" "${failure_code}" <<'PY'
+from pathlib import Path
+import sys
+
+from defenseclaw import upgrade_receipt
+
+path = Path(sys.argv[1])
+status, failure_code = sys.argv[2:]
+if status == "succeeded":
+    supersede = getattr(upgrade_receipt, "supersede_prior_upgrade_receipts", None)
+    if supersede is not None:
+        supersede(path)
+upgrade_receipt.complete_upgrade_receipt(
+    path,
+    status=status,
+    failure_code=failure_code,
+)
+PY
+    local transition_status=$?
+    [[ "${transition_status}" -eq 0 ]] || return "${transition_status}"
+    UPGRADE_RECEIPT_TERMINAL=1
+}
+
 recover_interrupted_phase_two() {
     local journal_root="${DEFENSECLAW_HOME}/.upgrade-recovery"
     local journal="${journal_root}/phase-two-active.json"
@@ -3696,11 +3767,10 @@ if [[ "${CURRENT_VERSION}" != "unknown" && "${CURRENT_GATEWAY_VERSION}" == "unkn
     die "Could not determine the installed gateway version while CLI ${CURRENT_VERSION} is present. No changes were made.
   Recovery path: restore the gateway artifact from the same signed ${CURRENT_VERSION} release, verify both --version outputs match, then run this release-owned resolver without --version."
 fi
+COMPONENT_VERSION_SPLIT=0
 if [[ "${CURRENT_VERSION}" != "unknown" && "${CURRENT_GATEWAY_VERSION}" != "unknown" \
       && "${CURRENT_VERSION}" != "${CURRENT_GATEWAY_VERSION}" ]]; then
-    die "Installed component versions are inconsistent: CLI ${CURRENT_VERSION}, gateway ${CURRENT_GATEWAY_VERSION}. No changes were made.
-  This commonly means a package manager or manual artifact copy bypassed the staged upgrade.
-  Recovery path: restore the CLI from the same signed ${CURRENT_GATEWAY_VERSION} release as the gateway, verify both --version outputs match, then run this release-owned resolver without --version."
+    COMPONENT_VERSION_SPLIT=1
 fi
 
 # The managed Python environment belongs to CONTROLLER_HOME, while an
@@ -3813,6 +3883,99 @@ fi
    && -n "${CONFIG_PATH}" && "${CONFIG_PATH}" == /* \
    && -n "${OPENCLAW_HOME}" && "${OPENCLAW_HOME}" == /* ]] \
     || die "Resolved runtime paths are invalid; no changes were made."
+
+if [[ "${COMPONENT_VERSION_SPLIT}" -eq 1 ]]; then
+    split_recovery="invalid"
+    if [[ "${CURRENT_GATEWAY_VERSION}" == "${RELEASE_VERSION}" \
+          && -x "${DEFENSECLAW_VENV}/bin/python" ]] \
+        && version_lt "${CURRENT_VERSION}" "${CURRENT_GATEWAY_VERSION}"; then
+        split_recovery="$(
+            DEFENSECLAW_HOME="${DATA_DIR}" "${DEFENSECLAW_VENV}/bin/python" -I -B - \
+                "${DATA_DIR}" "${CURRENT_VERSION}" "${RELEASE_VERSION}" <<'PY'
+from datetime import datetime
+import os
+from pathlib import Path
+import stat
+import sys
+import uuid
+
+from defenseclaw.upgrade_receipt import (
+    MAX_UPGRADE_RECEIPTS,
+    UPGRADE_RECEIPT_DIRECTORY,
+    load_upgrade_receipt,
+)
+
+data_dir, source_version, target_version = sys.argv[1:]
+root = Path(os.path.abspath(os.path.expanduser(data_dir)))
+receipt_dir = root / UPGRADE_RECEIPT_DIRECTORY
+try:
+    root_info = root.lstat()
+    receipt_info = receipt_dir.lstat()
+except FileNotFoundError:
+    print("invalid")
+    raise SystemExit(0)
+if (
+    stat.S_ISLNK(root_info.st_mode)
+    or not stat.S_ISDIR(root_info.st_mode)
+    or stat.S_ISLNK(receipt_info.st_mode)
+    or not stat.S_ISDIR(receipt_info.st_mode)
+):
+    raise SystemExit("unsafe upgrade receipt directory")
+if os.name == "posix":
+    geteuid = getattr(os, "geteuid", None)
+    if (
+        (geteuid is not None and (root_info.st_uid != geteuid() or receipt_info.st_uid != geteuid()))
+        or stat.S_IMODE(receipt_info.st_mode) & 0o077
+    ):
+        raise SystemExit("upgrade receipt directory is not private")
+
+entries = sorted(receipt_dir.glob("*.json"))
+if len(entries) > MAX_UPGRADE_RECEIPTS:
+    raise SystemExit("upgrade receipt queue exceeds its bound")
+authorities = []
+for path in entries:
+    info = path.lstat()
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise SystemExit("upgrade receipt queue contains an unsafe entry")
+    if os.name == "posix" and (
+        (geteuid is not None and info.st_uid != geteuid())
+        or stat.S_IMODE(info.st_mode) & 0o077
+    ):
+        raise SystemExit("upgrade receipt record is not private")
+    receipt = load_upgrade_receipt(path)
+    phase_matches = (
+        receipt.migration_status == "pending"
+        and receipt.migration_count is None
+        and (
+            (receipt.status == "pending" and receipt.failure_code == "")
+            or (receipt.status == "failed" and receipt.failure_code == "interrupted")
+        )
+    )
+    if (
+        receipt.from_version == source_version
+        and receipt.target_version == target_version
+        and receipt.artifacts_verified
+        and uuid.UUID(receipt.receipt_id).version == 4
+        and phase_matches
+    ):
+        created_at = datetime.fromisoformat(receipt.created_at.replace("Z", "+00:00"))
+        authorities.append((created_at, path))
+if not authorities:
+    print("invalid")
+else:
+    latest_created_at = max(created_at for created_at, _path in authorities)
+    latest = [path for created_at, path in authorities if created_at == latest_created_at]
+    print("recover" if len(latest) == 1 else "invalid")
+PY
+        )" || split_recovery="invalid"
+    fi
+    if [[ "${split_recovery}" != "recover" ]]; then
+        die "Installed component versions are inconsistent: CLI ${CURRENT_VERSION}, gateway ${CURRENT_GATEWAY_VERSION}. No changes were made.
+  This commonly means a package manager or manual artifact copy bypassed the staged upgrade.
+  Recovery path: restore the CLI from the same signed ${CURRENT_GATEWAY_VERSION} release as the gateway, verify both --version outputs match, then run this release-owned resolver without --version."
+    fi
+    warn "Found an authenticated interrupted ${CURRENT_VERSION} → ${RELEASE_VERSION} artifact activation; the resolver will re-verify the release and resume it."
+fi
 
 if [[ "${CURRENT_VERSION}" != "unknown" ]] && version_gte "${CURRENT_VERSION}" "0.8.5"; then
     hard_cut_state="$("${DEFENSECLAW_VENV}/bin/python" -I -B - "${CONFIG_PATH}" \
@@ -4052,6 +4215,9 @@ BRIDGE_EXPECTED_GATEWAY_SHA256=""
 BRIDGE_EXPECTED_WHEEL_SHA256=""
 BRIDGE_WHEEL_CUSTODY_PATH=""
 BRIDGE_SOURCE_VENV_IDENTITY_SHA256=""
+UPGRADE_RECEIPT_PATH=""
+UPGRADE_RECEIPT_FAILURE_CODE="install_failed"
+UPGRADE_RECEIPT_TERMINAL=0
 
 upgrade_exit_trap() {
     local status=$?
@@ -4060,6 +4226,13 @@ upgrade_exit_trap() {
     set +e
     if [[ "${BRIDGE_ROLLBACK_ARMED:-0}" -eq 1 ]]; then
         rollback_bridge_phase1 || rollback_status=$?
+    fi
+    if [[ "${status}" -ne 0 && -n "${UPGRADE_RECEIPT_PATH:-}" \
+        && "${UPGRADE_RECEIPT_TERMINAL:-0}" -eq 0 \
+        && -x "${DEFENSECLAW_VENV}/bin/python" ]]; then
+        VENV_PYTHON="${DEFENSECLAW_VENV}/bin/python"
+        finish_release_upgrade_receipt failed "${UPGRADE_RECEIPT_FAILURE_CODE:-install_failed}" \
+            || true
     fi
     [[ -z "${BRIDGE_GATEWAY_INSTALL_TEMP:-}" ]] || rm -f "${BRIDGE_GATEWAY_INSTALL_TEMP}"
     [[ -z "${BRIDGE_CANDIDATE_VENV:-}" ]] || rm -rf "${BRIDGE_CANDIDATE_VENV}"
@@ -6928,6 +7101,64 @@ resolve_staged_upgrade
 if [[ "${CURRENT_VERSION}" != "unknown" \
       && "${CURRENT_VERSION}" == "${RELEASE_VERSION}" \
       && -z "${STAGED_FINAL_VERSION}" ]]; then
+    same_version_recovery="clean"
+    if [[ -n "${RELEASE_PROVENANCE_FILE}" ]]; then
+        [[ -x "${DEFENSECLAW_VENV}/bin/python" \
+            && -x "${DEFENSECLAW_VENV}/bin/defenseclaw" ]] \
+            || die "The installed target controller is incomplete; authenticated recovery cannot continue."
+        same_version_recovery="$(
+            DEFENSECLAW_HOME="${DATA_DIR}" "${DEFENSECLAW_VENV}/bin/python" -I -B - \
+                "${DATA_DIR}" "${RELEASE_VERSION}" <<'PY'
+import sys
+
+from defenseclaw.bundle_refresh import installed_local_observability_bundle_version
+from defenseclaw.upgrade_receipt import (
+    find_resumable_upgrade_receipt,
+    find_verified_installed_upgrade_receipt,
+)
+
+data_dir, target_version = sys.argv[1:]
+receipt = find_resumable_upgrade_receipt(data_dir, target_version=target_version)
+bundle_version = installed_local_observability_bundle_version(data_dir)
+needs_bundle_repair = bundle_version is not None and bundle_version != target_version
+installed_receipt = None
+if receipt is None and needs_bundle_repair:
+    installed_receipt = find_verified_installed_upgrade_receipt(
+        data_dir,
+        target_version=target_version,
+    )
+if receipt is not None or installed_receipt is not None:
+    print("recover")
+elif needs_bundle_repair:
+    print("untrusted-bundle-drift")
+else:
+    print("clean")
+PY
+        )" || die "Could not inspect authenticated same-version recovery state; no mutation was attempted."
+        [[ "${same_version_recovery}" == "clean" \
+            || "${same_version_recovery}" == "recover" \
+            || "${same_version_recovery}" == "untrusted-bundle-drift" ]] \
+            || die "The installed target controller returned invalid recovery state; no mutation was attempted."
+    fi
+    if [[ "${same_version_recovery}" == "untrusted-bundle-drift" ]]; then
+        die "The installed local-observability bundle differs from ${RELEASE_VERSION}, but no verified target-install receipt remains. No changes were made.
+  The resolver will not trust a version string alone. Use an isolated fresh install or contact DefenseClaw support for state-aware recovery."
+    fi
+    if [[ "${same_version_recovery}" == "recover" ]]; then
+        section "Recovering Incomplete Upgrade"
+        if [[ "${PLAN_ONLY}" -eq 1 ]]; then
+            ok "Authenticated recovery authority exists for ${RELEASE_VERSION}"
+            info "Re-run without --plan to reconcile the receipt, bundle, and target health."
+            exit 0
+        fi
+        recovery_status=0
+        DEFENSECLAW_HOME="${DATA_DIR}" DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
+            OPENCLAW_HOME="${OPENCLAW_HOME}" \
+            "${DEFENSECLAW_VENV}/bin/defenseclaw" upgrade --yes \
+                --version "${RELEASE_VERSION}" --health-timeout 60 \
+            || recovery_status=$?
+        exit "${recovery_status}"
+    fi
     section "Version Already Verified"
     if [[ "${CHECKSUMS_SIGNATURE_VERIFIED}" -eq 1 ]]; then
         ok "Authenticated the ${RELEASE_VERSION} release contract; installed version ${CURRENT_VERSION} is already current"
@@ -7081,6 +7312,11 @@ fi
 
 ok "Backup saved to: ${BACKUP_DIR}"
 
+# Provenance-authenticated direct upgrades commit their receipt before the
+# first service or installed-file mutation. Staged hard cuts keep receipt and
+# rollback custody in the fresh target controller instead.
+begin_release_upgrade_receipt
+
 if [[ "${BRIDGE_PHASE1}" -eq 1 ]]; then
     prepare_bridge_phase1_custody
 fi
@@ -7202,6 +7438,10 @@ finally:
 PY
 else
     mv -f "${BRIDGE_GATEWAY_INSTALL_TEMP}" "${INSTALL_DIR}/defenseclaw-gateway"
+    # A graceful failure from this point until target CLI activation must
+    # remain eligible for exact receipt-bound component-split recovery. A
+    # process crash in the same window leaves the pending receipt authoritative.
+    UPGRADE_RECEIPT_FAILURE_CODE="interrupted"
 fi
 BRIDGE_GATEWAY_INSTALL_TEMP=""
 ok "Gateway binary installed"
@@ -7247,7 +7487,12 @@ section "Running Migrations"
 # Run migrations with the freshly-installed CLI environment. The Python
 # helper is intentionally verbose (click.echo); redirect that progress to
 # stderr so command substitution captures only the numeric count.
+TARGET_PYTHON_STDIN_ARGS=(-)
+if [[ "${BRIDGE_PHASE1}" -ne 1 ]]; then
+    TARGET_PYTHON_STDIN_ARGS=(-I -B -)
+fi
 MIGRATION_FAILED=0
+UPGRADE_RECEIPT_FAILURE_CODE="migration_failed"
 if ! MIGRATION_COUNT=$(MIGRATION_FROM_VERSION="${CURRENT_VERSION}" \
     MIGRATION_TO_VERSION="${RELEASE_VERSION}" \
     MIGRATION_OPENCLAW_HOME="${OPENCLAW_HOME}" \
@@ -7256,19 +7501,35 @@ if ! MIGRATION_COUNT=$(MIGRATION_FROM_VERSION="${CURRENT_VERSION}" \
     DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
     OPENCLAW_HOME="${OPENCLAW_HOME}" \
     DEFENSECLAW_UPGRADE_MUTATION_TOKEN="${BRIDGE_RECOVERY_PLAN_ID#phase-one-}" \
-    "${VENV_PYTHON}" - <<'PY'
+    "${VENV_PYTHON}" "${TARGET_PYTHON_STDIN_ARGS[@]}" "${UPGRADE_RECEIPT_PATH}" <<'PY'
 import contextlib
 import os
+from pathlib import Path
 import sys
 
 from defenseclaw.migrations import run_migrations
 
+receipt_path = sys.argv[1]
+kwargs = {"upgrade_handles_local_bundle": True} if receipt_path else {}
+if receipt_path:
+    from defenseclaw.upgrade_receipt import delegate_prior_upgrade_receipts
+
+    delegate_prior_upgrade_receipts(Path(receipt_path))
 with contextlib.redirect_stdout(sys.stderr):
     count = run_migrations(
         os.environ["MIGRATION_FROM_VERSION"],
         os.environ["MIGRATION_TO_VERSION"],
         os.environ["MIGRATION_OPENCLAW_HOME"],
         os.environ["MIGRATION_DEFENSECLAW_HOME"],
+        **kwargs,
+    )
+if receipt_path:
+    from defenseclaw.upgrade_receipt import record_upgrade_migrations
+
+    record_upgrade_migrations(
+        Path(receipt_path),
+        migration_count=count,
+        degraded=False,
     )
 print(count)
 PY
@@ -7297,7 +7558,7 @@ if [[ -n "${UPGRADE_MANIFEST_FILE}" ]]; then
         DEFENSECLAW_HOME="${DATA_DIR}" \
         DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
         DEFENSECLAW_UPGRADE_MUTATION_TOKEN="${BRIDGE_RECOVERY_PLAN_ID#phase-one-}" \
-        "${VENV_PYTHON}" - "${UPGRADE_MANIFEST_FILE}" <<'PY'
+        "${VENV_PYTHON}" "${TARGET_PYTHON_STDIN_ARGS[@]}" "${UPGRADE_MANIFEST_FILE}" <<'PY'
 import json
 import os
 import sys
@@ -7332,6 +7593,8 @@ if [[ -n "${REQUIRED_MIGRATIONS_MISSING}" ]]; then
     warn "${migration_label} migration(s) were not recorded: $(printf '%s' "${REQUIRED_MIGRATIONS_MISSING}" | tr '\n' ' ')"
     MIGRATION_FAILED=1
 fi
+
+UPGRADE_RECEIPT_FAILURE_CODE="required_migration_failed"
 
 if [[ "${MIGRATION_FAILURE_POLICY}" == "fail" && "${MIGRATION_FAILED}" -eq 1 ]]; then
     UPGRADE_INCOMPLETE=1
@@ -7368,6 +7631,7 @@ fi
 
 section "Starting Services"
 
+UPGRADE_RECEIPT_FAILURE_CODE="startup_failed"
 step "Starting defenseclaw-gateway ..."
 DEFENSECLAW_HOME="${DATA_DIR}" DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
     OPENCLAW_HOME="${OPENCLAW_HOME}" \
@@ -7382,6 +7646,7 @@ OPENCLAW_HOME="${OPENCLAW_HOME}" openclaw gateway restart 9>&- 2>/dev/null \
 
 # ── Health verification ───────────────────────────────────────────────────────
 
+UPGRADE_RECEIPT_FAILURE_CODE="health_check_failed"
 section "Verifying Gateway Health"
 
 HEALTH_TIMEOUT=60
@@ -7390,7 +7655,7 @@ ELAPSED=0
 HEALTH_OK=0
 HEALTH_URL="$(DEFENSECLAW_HOME="${DATA_DIR}" DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
     OPENCLAW_HOME="${OPENCLAW_HOME}" \
-    "${VENV_PYTHON}" - <<'PY' 2>/dev/null || true
+    "${VENV_PYTHON}" "${TARGET_PYTHON_STDIN_ARGS[@]}" <<'PY' 2>/dev/null || true
 from defenseclaw.config import load
 
 cfg = load()
@@ -7476,6 +7741,16 @@ if [[ "${HEALTH_OK}" -eq 0 ]]; then
     info "Check ${DATA_DIR}/gateway.log (process log); gateway.jsonl exists only when an optional JSONL destination is configured"
     info "Run:  defenseclaw-gateway status"
     exit 1
+fi
+
+if [[ -n "${UPGRADE_RECEIPT_PATH}" ]]; then
+    # Target health is already proven. If the final receipt write itself
+    # fails, preserve the pending recovery authority instead of letting the
+    # exit trap rewrite this healthy attempt as a failed upgrade.
+    UPGRADE_RECEIPT_TERMINAL=1
+    finish_release_upgrade_receipt succeeded \
+        || die "Could not commit the successful upgrade receipt after target health verification."
+    ok "Successful upgrade receipt committed"
 fi
 
 if [[ "${BRIDGE_PHASE1}" -eq 1 \


### PR DESCRIPTION
Standalone focused release fix against `main`.

## Problem

[Release run 29694716279](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29694716279) upgraded every historical Linux and macOS fixture to a healthy 0.8.6 candidate, then failed the post-status SQLite continuity probe. The probe called `/policy/reload`, but historical seed fixtures intentionally do not install a policy data file, so the unrelated policy reload returned HTTP 500 before the WAL assertion could run.

Live replay also exposed a second masked gap in the release-owned POSIX resolver: its direct native-v8 path installed the target wheel but did not establish the same receipt-bound bundle-refresh transaction used by the installed controller. A 0.8.5 → 0.8.6 resolver upgrade could therefore leave the local-observability bundle stamped at 0.8.5.

## Current Situation

- Candidate build, signing, provenance, fresh install, Docker/local-observability, health, and TUI checks passed in the failed release run.
- Historical jobs failed only after successful upgrade verification when the policy-dependent write probe returned HTTP 500.
- The installed-controller upgrade path already owns durable receipts, retries, and target bundle reconciliation; the standalone POSIX resolver did not reuse that transaction for direct v8-to-v8 upgrades.

## Solution

### Make the post-status WAL probe policy-independent

Post one authenticated, CSRF-valid synthetic event to `/audit/event`, preserve its caller-generated UUID through the gateway, and require exactly that mandatory canonical row from a fresh read-only SQLite connection. This tests the intended API → canonical logger → WAL → fresh-reader path without loading or mutating policy state.

### Give the POSIX resolver the same target transaction

The resolver now creates a verified pending receipt before its first installed-state mutation, delegates older retry authority, runs direct-v8 target migrations in the isolated target interpreter, lets the target wheel reconcile an installed native-v8 bundle, and marks success only after target health passes. Failures receive phase-specific terminal codes, and an authenticated rerun delegates to the installed controller's same-version recovery path.

If interruption lands after target gateway activation but before target CLI activation, the resolver accepts the CLI/gateway version split only when the published source controller can validate the unique newest private UUIDv4 receipt for that exact source, target, and pre-migration phase. Manual, unauthenticated, unsafe, and ambiguous splits still fail before service mutation. The protocol-2 bridge keeps its published Python execution semantics and rollback custody.

The v7→v8 converter now ignores ambient process-environment entries whose names cannot be referenced by the v8 `$NAME` grammar, such as exported Bash functions. Managed `.env` files remain strictly parsed and malformed managed data still fails closed.

```mermaid
flowchart LR
    A[Authenticated release artifacts] --> B[Pending upgrade receipt]
    B --> C[Install target controller]
    C --> D[Target migrations and bundle refresh]
    D --> E[Start and health-check target]
    E --> F[Terminal success receipt]
    E -->|failure| G[Recoverable failure receipt]
    G --> H[Authenticated same-version retry]
```

No release number is introduced into this repair. The source, target, manifest, receipt, and bundle versions remain runtime-derived.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `scripts/test-upgrade-release.sh` | Replace `/policy/reload` with a bounded authenticated `/audit/event` request and exact UUID SQLite/WAL readback. |
| `internal/gateway/gateway_test.go` | Prove `/audit/event` preserves a valid caller-supplied event ID. |
| `scripts/upgrade.sh` | Add pre-mutation receipt custody, target-owned bundle refresh, isolated direct-v8 Python probes, phase-specific failure recovery, receipt-bound component-split recovery, and authenticated same-version handoff. |
| `cli/defenseclaw/migrations.py` | Isolate the nested target bundle subprocess and ignore ambient names that the v8 config grammar cannot reference. |
| `cli/tests/test_upgrade_release_smoke_contract.py` | Pin the policy-independent probe and receipt/migration/health ordering contracts. |
| `cli/tests/test_observability_v8_upgrade_migration.py` | Prove isolated target Python and strict managed-environment conversion that tolerates unrelated exported shell functions. |

## Breaking Changes

None. Staged hard-cut behavior and bridge rollback custody are unchanged. A clean authenticated same-version request remains a no-op; only a verified incomplete transaction is recovered.

## Open Issues / Follow-ups

None.

## Test Plan

- `bash -n scripts/upgrade.sh scripts/test-upgrade-release.sh` — passed.
- `shellcheck -S error scripts/upgrade.sh scripts/test-upgrade-release.sh` — passed.
- `git diff --check` — passed.
- `uv run --project cli ruff check cli/defenseclaw/migrations.py cli/tests/test_observability_v8_upgrade_migration.py cli/tests/test_upgrade_release_smoke_contract.py` — passed.
- Exact Python shard 0 with an exported `BASH_FUNC_which%%` ambient key — 1,712 passed, 1 skipped, 120 subtests passed.
- Fast release-regression suite from `.github/workflows/ci.yml` — 232 passed, 1 skipped.
- Upgrade/migration/receipt/command suites — 615 passed, 7 skipped, 63 subtests passed.
- Protocol-2 bridge regression cases, including post-quarantine divergence and both migration-crash recovery states — passed.
- `go test ./internal/gateway/... -count=1` — passed.
- CodeRabbit CLI final review — 0 issues.
- Linux ARM64 isolated exact-candidate replay: installed-controller and release-owned resolver 0.8.5 → 0.8.6 passed; config, bundle, receipt, health, TUI, and exact UUID WAL assertions passed.
- Linux ARM64 same-version failure recovery: verified failed receipt plus stale bundle recovered to 0.8.6, returned healthy, and cleared recovery authority.
- Linux ARM64 exact-final resolver: published 0.8.5 → signed 0.8.6 passed CLI, gateway, bundle, health, TUI, SQLite, and receipt checks; receipt-bound CLI/gateway split recovered, while the same split without a receipt refused before mutation with byte-identical state.
- macOS ARM64 isolated exact-candidate replay: installed-controller and release-owned resolver 0.8.5 → 0.8.6 passed; config, bundle, receipt, health, TUI, and exact UUID WAL assertions passed.
- macOS ARM64 interrupted component activation: CLI 0.8.5 + gateway 0.8.6 without receipt refused without mutation; an older failed receipt plus a newer pending receipt recovered fully to 0.8.6, refreshed the bundle, preserved operator data, admitted receipt history to SQLite, and kept the production gateway healthy.

The remote candidate replays used the sealed wheel, gateway, manifest, checksums, and signature with the reviewed resolver injected into an isolated candidate copy. CI remains the authority for the newly built resolver asset's final checksum/signature binding.
