### PR TITLE
Retry transient GitHub release publication failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,6 +530,7 @@ jobs:
             cli/tests/test_verify_sigstore_blob.py \
             cli/tests/test_observability_v8_upgrade_continuity_checker.py \
             cli/tests/test_resolve_upgrade_baselines.py \
+            cli/tests/test_release_api_retry.py \
             cli/tests/test_release_workflow_staged.py \
             cli/tests/test_upgrade_smoke_static.py \
             cli/tests/test_upgrade_release_smoke_contract.py \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1451,7 +1451,8 @@ jobs:
               --tag "$RELEASE_TAG" \
               --commit "$RELEASE_COMMIT" \
               --candidate-root release-candidate \
-              --omit-windows-binaries
+              --omit-windows-binaries \
+              --check-main
             reconcile_status=$?
             set -e
             if [[ "$reconcile_status" == "0" ]]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -189,6 +189,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION_INPUT: ${{ needs.release-mode.outputs.version }}
+          RELEASE_COMMIT: ${{ needs.release-mode.outputs.commit }}
         run: |
           set -euo pipefail
           TAG="$RELEASE_VERSION_INPUT"
@@ -200,14 +201,10 @@ jobs:
             echo "::error title=Tag already exists::Tag '$TAG' already exists locally."
             exit 1
           fi
-          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "::error title=Tag already exists on remote::Tag '$TAG' already exists on origin."
-            exit 1
-          fi
-          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "::error title=Release already exists::A draft or published release for '$TAG' already exists."
-            exit 1
-          fi
+          python3 scripts/release_api_retry.py require-absent \
+            --repository "$GITHUB_REPOSITORY" \
+            --tag "$TAG" \
+            --commit "$RELEASE_COMMIT"
           gh api --paginate --slurp \
             -H "Accept: application/vnd.github+json" \
             "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
@@ -1346,6 +1343,7 @@ jobs:
         needs.select-candidate.result == 'success'
       }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     environment: release
     permissions:
       contents: write
@@ -1381,32 +1379,34 @@ jobs:
             release-candidate/dist/checksums.txt
 
       - name: Recheck remote release namespace
+        id: release-namespace
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.release-preflight.outputs.tag }}
           RELEASE_COMMIT: ${{ needs.release-preflight.outputs.commit }}
         run: |
           set -euo pipefail
-          remote_main="$(
-            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq .object.sha
-          )"
-          if [[ "$remote_main" != "$RELEASE_COMMIT" ]]; then
-            echo "::error title=Main advanced during certification::Expected $RELEASE_COMMIT but protected main is now $remote_main. Certify the new exact main SHA before publishing."
-            exit 1
-          fi
-          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
-            echo "::error title=Tag appeared during release gates::$RELEASE_TAG already exists."
-            exit 1
-          fi
-          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "::error title=Release appeared during release gates::$RELEASE_TAG already exists."
-            exit 1
-          fi
+          set +e
+          python3 scripts/release_api_retry.py reconcile-create \
+            --repository "$GITHUB_REPOSITORY" \
+            --tag "$RELEASE_TAG" \
+            --commit "$RELEASE_COMMIT" \
+            --candidate-root release-candidate \
+            --omit-windows-binaries \
+            --check-main
+          namespace_status=$?
+          set -e
+          case "$namespace_status" in
+            0) echo "create_required=false" >> "$GITHUB_OUTPUT" ;;
+            10) echo "create_required=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error title=Release namespace conflict::Remote custody is neither absent nor the exact immutable candidate."; exit 1 ;;
+          esac
 
       # With Immutable Releases enabled, current gh creates a draft, uploads
       # every selected sealed asset, and only then publishes. This is the only step
       # in the workflow that can create the remote release or tag.
       - name: Publish tag and selected sealed assets
+        if: steps.release-namespace.outputs.create_required == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.release-preflight.outputs.tag }}
@@ -1431,12 +1431,44 @@ jobs:
             notes_args=(--generate-notes)
           fi
 
-          gh release create "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --target "$RELEASE_COMMIT" \
-            --title "$RELEASE_TAG" \
-            "${notes_args[@]}" \
-            "${assets[@]}"
+          published=0
+          for attempt in 1 2 3; do
+            if timeout --signal=TERM --kill-after=30s 10m \
+              gh release create "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --target "$RELEASE_COMMIT" \
+              --title "$RELEASE_TAG" \
+              "${notes_args[@]}" \
+              "${assets[@]}"; then
+              published=1
+              break
+            fi
+
+            echo "::warning title=Release create returned an error::Reconciling remote custody before considering attempt $((attempt + 1))."
+            set +e
+            python3 scripts/release_api_retry.py reconcile-create \
+              --repository "$GITHUB_REPOSITORY" \
+              --tag "$RELEASE_TAG" \
+              --commit "$RELEASE_COMMIT" \
+              --candidate-root release-candidate \
+              --omit-windows-binaries
+            reconcile_status=$?
+            set -e
+            if [[ "$reconcile_status" == "0" ]]; then
+              published=1
+              break
+            fi
+            if [[ "$reconcile_status" != "10" ]]; then
+              echo "::error title=Ambiguous release create::Remote custody is neither absent nor the exact immutable candidate; refusing another create."
+              exit 1
+            fi
+            if [[ "$attempt" == "3" ]]; then
+              echo "::error title=Release API retries exhausted::The tag and release remained absent after three bounded create attempts."
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
+          [[ "$published" == "1" ]]
 
       - name: Prove published asset custody
         env:
@@ -1445,26 +1477,10 @@ jobs:
           RELEASE_COMMIT: ${{ needs.release-preflight.outputs.commit }}
         run: |
           set -euo pipefail
-          verified=0
-          for attempt in 1 2 3 4 5 6; do
-            gh release view "$RELEASE_TAG" \
-              --repo "$GITHUB_REPOSITORY" \
-              --json tagName,isDraft,isImmutable,assets > published-release.json
-            if python3 scripts/release_candidate.py verify-published \
-              --root release-candidate \
-              --release-json published-release.json \
-              --version "$RELEASE_TAG" \
-              --commit "$RELEASE_COMMIT" \
-              --omit-windows-binaries; then
-              verified=1
-              break
-            fi
-            sleep 5
-          done
-          [[ "$verified" == "1" ]] || {
-            echo "::error title=Published custody proof failed::GitHub asset digests did not converge to the sealed candidate."
-            exit 1
-          }
-          remote_commit="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" --jq .object.sha)"
-          test "$remote_commit" = "$RELEASE_COMMIT"
+          python3 scripts/release_api_retry.py prove-published \
+            --repository "$GITHUB_REPOSITORY" \
+            --tag "$RELEASE_TAG" \
+            --commit "$RELEASE_COMMIT" \
+            --candidate-root release-candidate \
+            --omit-windows-binaries
           echo "Release $RELEASE_TAG published from tested commit $RELEASE_COMMIT"

--- a/cli/tests/test_release_api_retry.py
+++ b/cli/tests/test_release_api_retry.py
@@ -1,0 +1,500 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import release_api_retry
+
+COMMIT = "a" * 40
+TAG = "0.8.6"
+REPOSITORY = "example/defenseclaw"
+
+
+def _completed(status: int | None, *, body: str = "{}", stderr: str = "") -> subprocess.CompletedProcess[str]:
+    if status is None:
+        stdout = ""
+        returncode = 1
+    else:
+        stdout = f"HTTP/2.0 {status} status\ncontent-type: application/json\n\n{body}"
+        returncode = 0 if 200 <= status < 300 else 1
+    return subprocess.CompletedProcess(
+        args=["gh", "api"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _api(responses: list[subprocess.CompletedProcess[str]], sleeps: list[float]) -> release_api_retry.GitHubReleaseAPI:
+    queue = list(responses)
+
+    def runner(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert queue, "unexpected GitHub API request"
+        return queue.pop(0)
+
+    return release_api_retry.GitHubReleaseAPI(
+        repository=REPOSITORY,
+        attempts=3,
+        delay_seconds=0.25,
+        runner=runner,
+        sleep=sleeps.append,
+    )
+
+
+def test_absence_is_only_an_explicit_404_after_transient_retry() -> None:
+    sleeps: list[float] = []
+    api = _api(
+        [
+            _completed(503, stderr="gh: unavailable (HTTP 503)"),
+            _completed(404, body='{"message":"Not Found"}', stderr="gh: Not Found (HTTP 404)"),
+        ],
+        sleeps,
+    )
+
+    assert api.release_by_tag(TAG) is None
+    assert sleeps == [0.25]
+
+
+def test_transient_exhaustion_is_never_reported_as_absence() -> None:
+    sleeps: list[float] = []
+    api = _api(
+        [
+            _completed(503, stderr="first"),
+            _completed(None, stderr="transport reset"),
+            _completed(503, stderr="last"),
+        ],
+        sleeps,
+    )
+
+    with pytest.raises(release_api_retry.ReleaseAPIError, match="after 3 attempt"):
+        api.tag_ref(TAG)
+    assert sleeps == [0.25, 0.5]
+
+
+def test_api_timeout_is_retried_and_never_reported_as_absence() -> None:
+    sleeps: list[float] = []
+    calls = 0
+
+    def runner(*_args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        nonlocal calls
+        calls += 1
+        assert kwargs["timeout"] == release_api_retry.DEFAULT_API_TIMEOUT_SECONDS
+        if calls == 1:
+            raise subprocess.TimeoutExpired(cmd=["gh", "api"], timeout=20)
+        return _completed(404, body='{"message":"Not Found"}', stderr="gh: Not Found (HTTP 404)")
+
+    api = release_api_retry.GitHubReleaseAPI(
+        repository=REPOSITORY,
+        attempts=2,
+        delay_seconds=0.25,
+        runner=runner,
+        sleep=sleeps.append,
+    )
+
+    assert api.release_by_tag(TAG) is None
+    assert calls == 2
+    assert sleeps == [0.25]
+
+
+def test_api_timeout_exhaustion_fails_closed() -> None:
+    def runner(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(cmd=["gh", "api"], timeout=20)
+
+    api = release_api_retry.GitHubReleaseAPI(
+        repository=REPOSITORY,
+        attempts=2,
+        delay_seconds=0,
+        runner=runner,
+        sleep=lambda _delay: None,
+    )
+
+    with pytest.raises(release_api_retry.ReleaseAPIError, match="timed out"):
+        api.tag_ref(TAG)
+
+
+def test_permanent_api_failure_does_not_retry_or_look_absent() -> None:
+    sleeps: list[float] = []
+    api = _api([_completed(403, stderr="forbidden")], sleeps)
+
+    with pytest.raises(release_api_retry.ReleaseAPIError, match="forbidden"):
+        api.release_by_tag(TAG)
+    assert sleeps == []
+
+
+def test_annotated_tag_chain_resolves_to_commit() -> None:
+    sleeps: list[float] = []
+    api = _api(
+        [
+            _completed(
+                200,
+                body='{"object":{"type":"commit","sha":"' + COMMIT + '"}}',
+            ),
+        ],
+        sleeps,
+    )
+
+    commit = api.resolve_tag_commit({"object": {"type": "tag", "sha": "b" * 40}})
+
+    assert commit == COMMIT
+    assert sleeps == []
+
+
+def test_annotated_tag_chain_depth_is_bounded() -> None:
+    sleeps: list[float] = []
+    api = _api(
+        [
+            _completed(
+                200,
+                body='{"object":{"type":"tag","sha":"' + str(index) * 40 + '"}}',
+            )
+            for index in range(1, 6)
+        ],
+        sleeps,
+    )
+
+    with pytest.raises(release_api_retry.ReleaseAPIError, match="exceeds the depth bound"):
+        api.resolve_tag_commit({"object": {"type": "tag", "sha": "b" * 40}})
+    assert sleeps == []
+
+
+def test_cli_reports_invalid_repository_without_traceback(capsys: pytest.CaptureFixture[str]) -> None:
+    result = release_api_retry.main(
+        [
+            "require-absent",
+            "--repository",
+            "invalid",
+            "--tag",
+            TAG,
+            "--commit",
+            COMMIT,
+        ]
+    )
+
+    assert result == 1
+    assert "repository must be OWNER/REPO" in capsys.readouterr().err
+
+
+def test_cli_reports_os_failure_without_traceback(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fail_api(**_kwargs: object) -> object:
+        raise FileNotFoundError("gh executable is unavailable")
+
+    monkeypatch.setattr(release_api_retry, "GitHubReleaseAPI", fail_api)
+
+    result = release_api_retry.main(
+        [
+            "require-absent",
+            "--repository",
+            REPOSITORY,
+            "--tag",
+            TAG,
+            "--commit",
+            COMMIT,
+        ]
+    )
+
+    assert result == 1
+    assert "gh executable is unavailable" in capsys.readouterr().err
+
+
+class _NamespaceAPI:
+    def __init__(
+        self,
+        observations: list[tuple[dict[str, object] | None, dict[str, object] | None]],
+        *,
+        main: str = COMMIT,
+        tag_commit: str = COMMIT,
+    ) -> None:
+        self.observations = list(observations)
+        self.main = main
+        self.tag_commit = tag_commit
+        self._current: tuple[dict[str, object] | None, dict[str, object] | None] | None = None
+
+    def main_commit(self) -> str:
+        return self.main
+
+    def tag_ref(self, _tag: str) -> dict[str, object] | None:
+        assert self.observations
+        self._current = self.observations.pop(0)
+        return self._current[0]
+
+    def release_by_tag(self, _tag: str) -> dict[str, object] | None:
+        assert self._current is not None
+        return self._current[1]
+
+    def resolve_tag_commit(self, _payload: dict[str, object]) -> str:
+        return self.tag_commit
+
+
+def test_namespace_preflight_checks_main_and_both_namespaces() -> None:
+    absent = _NamespaceAPI([(None, None)])
+    release_api_retry.require_absent_namespace(
+        absent,
+        tag=TAG,
+        expected_main_commit=COMMIT,
+    )
+
+    advanced = _NamespaceAPI([(None, None)], main="b" * 40)
+    with pytest.raises(release_api_retry.ReleaseAPIError, match="main advanced"):
+        release_api_retry.require_absent_namespace(
+            advanced,
+            tag=TAG,
+            expected_main_commit=COMMIT,
+        )
+
+    occupied = _NamespaceAPI([({"object": {}}, None)])
+    with pytest.raises(release_api_retry.ReleaseAPIError, match="occupied by tag"):
+        release_api_retry.require_absent_namespace(occupied, tag=TAG)
+
+    release_only = _NamespaceAPI([(None, {"tag_name": TAG})])
+    with pytest.raises(release_api_retry.ReleaseAPIError, match="occupied by release"):
+        release_api_retry.require_absent_namespace(release_only, tag=TAG)
+
+
+def test_ambiguous_create_retries_only_after_bounded_proof_of_absence(tmp_path: Path) -> None:
+    api = _NamespaceAPI([(None, None), (None, None), (None, None)])
+    sleeps: list[float] = []
+
+    state = release_api_retry.reconcile_create(
+        api,  # type: ignore[arg-type]
+        tag=TAG,
+        expected_commit=COMMIT,
+        candidate_root=tmp_path,
+        omit_windows_binaries=True,
+        attempts=3,
+        delay_seconds=0.5,
+        sleep=sleeps.append,
+    )
+
+    assert state is release_api_retry.ReconcileState.ABSENT
+    assert sleeps == [0.5, 0.5]
+
+
+def test_ambiguous_create_accepts_exact_remote_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    tag_payload = {"object": {"type": "commit", "sha": COMMIT}}
+    release_payload = {"tag_name": TAG, "draft": False, "immutable": True, "assets": []}
+    api = _NamespaceAPI([(tag_payload, release_payload)])
+    verified: list[tuple[str, str]] = []
+
+    def verify(**kwargs: object) -> None:
+        verified.append((str(kwargs["tag"]), str(kwargs["expected_commit"])))
+
+    monkeypatch.setattr(release_api_retry, "_verify_exact_candidate", verify)
+
+    state = release_api_retry.reconcile_create(
+        api,  # type: ignore[arg-type]
+        tag=TAG,
+        expected_commit=COMMIT,
+        candidate_root=tmp_path,
+        omit_windows_binaries=True,
+        attempts=1,
+    )
+
+    assert state is release_api_retry.ReconcileState.EXACT
+    assert verified == [(TAG, COMMIT)]
+
+
+def test_nonimmutable_remote_candidate_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        release_api_retry.release_candidate,
+        "verify",
+        lambda *_args, **_kwargs: None,
+    )
+    api = _NamespaceAPI([], tag_commit=COMMIT)
+
+    with pytest.raises(release_api_retry.ReleaseAPIError, match="not immutable"):
+        release_api_retry._verify_exact_candidate(
+            tag_payload={"object": {"type": "commit", "sha": COMMIT}},
+            release_payload={"tag_name": TAG, "draft": False, "immutable": False, "assets": []},
+            api=api,  # type: ignore[arg-type]
+            tag=TAG,
+            expected_commit=COMMIT,
+            candidate_root=tmp_path,
+            omit_windows_binaries=True,
+        )
+
+
+def test_partial_remote_namespace_fails_closed_without_becoming_absent(tmp_path: Path) -> None:
+    api = _NamespaceAPI(
+        [
+            ({"object": {}}, None),
+            (None, None),
+        ]
+    )
+
+    with pytest.raises(release_api_retry.ReleaseAPIError, match="disappeared after being observed"):
+        release_api_retry.reconcile_create(
+            api,  # type: ignore[arg-type]
+            tag=TAG,
+            expected_commit=COMMIT,
+            candidate_root=tmp_path,
+            omit_windows_binaries=True,
+            attempts=2,
+            delay_seconds=0,
+        )
+
+
+def test_wrong_remote_tag_commit_fails_closed(tmp_path: Path) -> None:
+    tag_payload = {"object": {"type": "commit", "sha": "b" * 40}}
+    release_payload = {"tag_name": TAG, "draft": False, "immutable": True, "assets": []}
+    api = _NamespaceAPI([(tag_payload, release_payload)], tag_commit="b" * 40)
+
+    with pytest.raises(release_api_retry.ReleaseAPIError, match="points to"):
+        release_api_retry.reconcile_create(
+            api,  # type: ignore[arg-type]
+            tag=TAG,
+            expected_commit=COMMIT,
+            candidate_root=tmp_path,
+            omit_windows_binaries=True,
+            attempts=1,
+            delay_seconds=0,
+        )
+
+
+def test_rest_release_shape_is_normalized_for_sealed_candidate_verification() -> None:
+    normalized = release_api_retry._candidate_release_json(
+        {
+            "tag_name": TAG,
+            "draft": False,
+            "immutable": True,
+            "assets": [{"name": "checksums.txt", "digest": "sha256:" + "c" * 64}],
+        }
+    )
+
+    assert normalized == {
+        "tagName": TAG,
+        "isDraft": False,
+        "isImmutable": True,
+        "assets": [{"name": "checksums.txt", "digest": "sha256:" + "c" * 64}],
+    }
+
+
+@pytest.mark.parametrize(
+    ("command", "state", "expected_exit"),
+    [
+        ("reconcile-create", release_api_retry.ReconcileState.ABSENT, release_api_retry.ABSENT_EXIT_CODE),
+        ("prove-published", release_api_retry.ReconcileState.EXACT, 0),
+    ],
+)
+def test_cli_reconciliation_exit_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    command: str,
+    state: release_api_retry.ReconcileState,
+    expected_exit: int,
+) -> None:
+    monkeypatch.setattr(release_api_retry, "GitHubReleaseAPI", lambda **_kwargs: object())
+    monkeypatch.setattr(release_api_retry, "reconcile_create", lambda *_args, **_kwargs: state)
+
+    result = release_api_retry.main(
+        [
+            command,
+            "--repository",
+            REPOSITORY,
+            "--tag",
+            TAG,
+            "--commit",
+            COMMIT,
+            "--candidate-root",
+            str(tmp_path),
+        ]
+    )
+
+    assert result == expected_exit
+
+
+def test_cli_publish_precheck_accepts_existing_exact_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    tag_payload = {"object": {"type": "commit", "sha": COMMIT}}
+    release_payload = {"tag_name": TAG, "draft": False, "immutable": True, "assets": []}
+    api = _NamespaceAPI([(tag_payload, release_payload)], main=COMMIT)
+    monkeypatch.setattr(release_api_retry, "GitHubReleaseAPI", lambda **_kwargs: api)
+    monkeypatch.setattr(release_api_retry, "_verify_exact_candidate", lambda **_kwargs: None)
+
+    result = release_api_retry.main(
+        [
+            "reconcile-create",
+            "--repository",
+            REPOSITORY,
+            "--tag",
+            TAG,
+            "--commit",
+            COMMIT,
+            "--candidate-root",
+            str(tmp_path),
+            "--check-main",
+        ]
+    )
+
+    assert result == 0
+
+
+def test_cli_publish_precheck_rechecks_main_after_absence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class ChangingMainAPI:
+        def __init__(self) -> None:
+            self.commits = iter((COMMIT, "b" * 40))
+
+        def main_commit(self) -> str:
+            return next(self.commits)
+
+    api = ChangingMainAPI()
+    monkeypatch.setattr(release_api_retry, "GitHubReleaseAPI", lambda **_kwargs: api)
+    monkeypatch.setattr(
+        release_api_retry,
+        "reconcile_create",
+        lambda *_args, **_kwargs: release_api_retry.ReconcileState.ABSENT,
+    )
+
+    result = release_api_retry.main(
+        [
+            "reconcile-create",
+            "--repository",
+            REPOSITORY,
+            "--tag",
+            TAG,
+            "--commit",
+            COMMIT,
+            "--candidate-root",
+            str(tmp_path),
+            "--check-main",
+        ]
+    )
+
+    assert result == 1
+    assert "main advanced during certification" in capsys.readouterr().err
+
+
+def test_cli_candidate_commands_require_candidate_root(capsys: pytest.CaptureFixture[str]) -> None:
+    result = release_api_retry.main(
+        [
+            "prove-published",
+            "--repository",
+            REPOSITORY,
+            "--tag",
+            TAG,
+            "--commit",
+            COMMIT,
+        ]
+    )
+
+    assert result == 1
+    assert "requires --candidate-root" in capsys.readouterr().err

--- a/cli/tests/test_release_api_retry.py
+++ b/cli/tests/test_release_api_retry.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
@@ -46,7 +47,7 @@ def _api(responses: list[subprocess.CompletedProcess[str]], sleeps: list[float])
     )
 
 
-def test_absence_is_only_an_explicit_404_after_transient_retry() -> None:
+def test_tag_absence_is_only_an_explicit_404_after_transient_retry() -> None:
     sleeps: list[float] = []
     api = _api(
         [
@@ -56,8 +57,41 @@ def test_absence_is_only_an_explicit_404_after_transient_retry() -> None:
         sleeps,
     )
 
-    assert api.release_by_tag(TAG) is None
+    assert api.tag_ref(TAG) is None
     assert sleeps == [0.25]
+
+
+def test_release_absence_requires_successful_authenticated_listing() -> None:
+    sleeps: list[float] = []
+    api = _api([_completed(200, body="[]")], sleeps)
+
+    assert api.release_by_tag(TAG) is None
+    assert sleeps == []
+
+
+def test_release_listing_includes_draft_with_no_tag_ref() -> None:
+    sleeps: list[float] = []
+    draft = {"tag_name": TAG, "draft": True, "immutable": False, "assets": []}
+    api = _api([_completed(200, body=json.dumps([draft]))], sleeps)
+
+    assert api.release_by_tag(TAG) == draft
+    assert sleeps == []
+
+
+def test_release_listing_paginates_before_declaring_absence() -> None:
+    sleeps: list[float] = []
+    first_page = [{"tag_name": f"old-{index}"} for index in range(100)]
+    target = {"tag_name": TAG, "draft": True, "immutable": False, "assets": []}
+    api = _api(
+        [
+            _completed(200, body=json.dumps(first_page)),
+            _completed(200, body=json.dumps([target])),
+        ],
+        sleeps,
+    )
+
+    assert api.release_by_tag(TAG) == target
+    assert sleeps == []
 
 
 def test_transient_exhaustion_is_never_reported_as_absence() -> None:
@@ -96,7 +130,7 @@ def test_api_timeout_is_retried_and_never_reported_as_absence() -> None:
         sleep=sleeps.append,
     )
 
-    assert api.release_by_tag(TAG) is None
+    assert api.tag_ref(TAG) is None
     assert calls == 2
     assert sleeps == [0.25]
 
@@ -451,7 +485,7 @@ def test_cli_publish_precheck_rechecks_main_after_absence(
 ) -> None:
     class ChangingMainAPI:
         def __init__(self) -> None:
-            self.commits = iter((COMMIT, "b" * 40))
+            self.commits = iter(("b" * 40,))
 
         def main_commit(self) -> str:
             return next(self.commits)

--- a/cli/tests/test_release_validation_strategy.py
+++ b/cli/tests/test_release_validation_strategy.py
@@ -35,6 +35,7 @@ def test_ordinary_ci_is_deterministic_and_selective_not_full_certification() -> 
     assert "if" not in deterministic
     assert deterministic["name"] == "Release Regression (deterministic)"
     assert "test_release_certification.py" in _render(deterministic)
+    assert "test_release_api_retry.py" in _render(deterministic)
 
     plan = _render(jobs["release-validation-plan"])
     assert "scripts/release_certification.py paths" in plan
@@ -89,6 +90,7 @@ def test_ordinary_ci_is_deterministic_and_selective_not_full_certification() -> 
         "extensions/defenseclaw/package-lock.json",
         "macos/DefenseClawMac/DefenseClawMac.xcodeproj/project.pbxproj",
         "scripts/resolve_upgrade_baselines.py",
+        "scripts/release_api_retry.py",
         "scripts/generate-upgrade-manifest.py",
         "scripts/verify-sigstore-blob.py",
         "scripts/check_observability_v8_upgrade_continuity.py",
@@ -214,8 +216,22 @@ def test_release_is_certified_promotion_with_full_fallback_and_no_inline_matrix(
     assert "needs.select-candidate.result == 'success'" in publish["if"]
     assert publish["permissions"] == {"contents": "write"}
     rendered_publish = _render(publish)
-    assert 'git/ref/heads/main" --jq .object.sha' in rendered_publish
-    assert 'remote_main" != "$RELEASE_COMMIT' in rendered_publish
+    assert "scripts/release_api_retry.py reconcile-create" in rendered_publish
+    preflight = next(
+        step["run"]
+        for step in publish["steps"]
+        if step.get("name") == "Recheck remote release namespace"
+    )
+    assert "scripts/release_api_retry.py reconcile-create" in preflight
+    assert '--commit "$RELEASE_COMMIT"' in preflight
+    assert "--candidate-root release-candidate" in preflight
+    assert "--check-main" in preflight
+    create = next(
+        step
+        for step in publish["steps"]
+        if step.get("name") == "Publish tag and selected sealed assets"
+    )
+    assert create["if"] == "steps.release-namespace.outputs.create_required == 'true'"
 
     # Release owns the unchanged Fulcio identity and candidate construction,
     # while expensive test implementations stay in the reusable workflow.

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -524,6 +524,7 @@ def test_release_publish_retries_only_after_absence_and_reconciles_ambiguity() -
     assert "for attempt in 1 2 3" in rendered
     assert "timeout --signal=TERM --kill-after=30s 10m" in rendered
     assert "scripts/release_api_retry.py reconcile-create" in rendered
+    assert rendered.count("--check-main") == 2
     assert 'reconcile_status" != "10"' in rendered
     assert "refusing another create" in rendered
     assert "Release API retries exhausted" in rendered

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -100,8 +100,10 @@ def test_release_immutability_preflight_uses_operator_confirmation_without_admin
     assert "IMMUTABLE_RELEASES_CONFIRMED" in text
     assert "inputs.immutable_releases_confirmed" in text
     assert "Immutable Releases confirmation required" in text
-    assert "--json tagName,isDraft,isImmutable,assets" in text
-    assert "scripts/release_candidate.py verify-published" in text
+    assert "scripts/release_api_retry.py prove-published" in text
+    helper = (ROOT / "scripts/release_api_retry.py").read_text(encoding="utf-8")
+    assert '"isImmutable": payload.get("immutable")' in helper
+    assert "verify_published_release" in helper
 
 
 def test_release_automation_never_publishes_runtime_to_python_package_indexes() -> None:
@@ -186,7 +188,7 @@ def test_windows_release_binaries_are_disabled_and_omitted() -> None:
     assert "windows_prebridge_baselines == '[]'" in certification["windows-unpublished-refusal"]["if"]
 
     workflow_text = WORKFLOW.read_text(encoding="utf-8")
-    assert workflow_text.count("--omit-windows-binaries") == 2
+    assert workflow_text.count("--omit-windows-binaries") == 4
     assert "publish_windows_binaries" not in workflow_text
     assert "Windows-specific binaries and SBOMs will not be published" in workflow_text
 
@@ -498,7 +500,41 @@ def test_only_final_step_can_create_remote_release_or_tag() -> None:
     assert "git push" not in text
     assert "push:\n" not in text
     assert "Publish tag and selected sealed assets" in text
-    assert "verify-published" in text
+    assert "prove-published" in text
+
+
+def test_release_publish_retries_only_after_absence_and_reconciles_ambiguity() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    publish = _workflow()["jobs"]["publish-release"]
+    rendered = "\n".join(step.get("run", "") for step in publish["steps"])
+    namespace_step = next(step for step in publish["steps"] if step.get("id") == "release-namespace")
+    create_step = next(
+        step for step in publish["steps"] if step.get("name") == "Publish tag and selected sealed assets"
+    )
+
+    assert publish["timeout-minutes"] == "45"
+    assert text.count("scripts/release_api_retry.py require-absent") == 1
+    assert "scripts/release_api_retry.py reconcile-create" in namespace_step["run"]
+    assert "--candidate-root release-candidate" in namespace_step["run"]
+    assert "--omit-windows-binaries" in namespace_step["run"]
+    assert "--check-main" in namespace_step["run"]
+    assert "create_required=false" in namespace_step["run"]
+    assert "create_required=true" in namespace_step["run"]
+    assert create_step["if"] == "steps.release-namespace.outputs.create_required == 'true'"
+    assert "for attempt in 1 2 3" in rendered
+    assert "timeout --signal=TERM --kill-after=30s 10m" in rendered
+    assert "scripts/release_api_retry.py reconcile-create" in rendered
+    assert 'reconcile_status" != "10"' in rendered
+    assert "refusing another create" in rendered
+    assert "Release API retries exhausted" in rendered
+    assert "scripts/release_api_retry.py prove-published" in rendered
+    create_index = rendered.index('gh release create "$RELEASE_TAG"')
+    precheck_index = rendered.index("scripts/release_api_retry.py reconcile-create")
+    reconcile_index = rendered.rindex("scripts/release_api_retry.py reconcile-create")
+    prove_index = rendered.index("scripts/release_api_retry.py prove-published")
+    assert precheck_index < create_index < reconcile_index < prove_index
+    assert 'git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG"' not in rendered
+    assert 'gh release view "$RELEASE_TAG"' not in rendered
 
 
 def test_every_remote_action_is_commit_pinned() -> None:

--- a/cli/tests/test_source_release_identity.py
+++ b/cli/tests/test_source_release_identity.py
@@ -289,7 +289,13 @@ def test_release_workflow_stamps_dispatch_version_and_tags_reviewed_commit() -> 
     assert "Require reviewed source release identity" not in workflow
     assert "git diff --exit-code --" not in workflow[tracked:expected]
     assert '--target "$RELEASE_COMMIT"' in workflow[publish:]
-    assert 'test "$remote_commit" = "$RELEASE_COMMIT"' in workflow[publish:]
+    proof = workflow.index("scripts/release_api_retry.py prove-published", publish)
+    assert publish < proof
+    proof_command = workflow[proof : proof + 500]
+    assert '--tag "$RELEASE_TAG"' in proof_command
+    assert '--commit "$RELEASE_COMMIT"' in proof_command
+    assert "--candidate-root release-candidate" in proof_command
+    assert "--omit-windows-binaries" in proof_command
 
 
 @pytest.mark.skipif(os.name == "nt", reason="source ownership uses POSIX symlinks")

--- a/release/certification-policy.json
+++ b/release/certification-policy.json
@@ -55,6 +55,7 @@
     "scripts/upgrade.ps1",
     "scripts/release_candidate.py",
     "scripts/release_certification.py",
+    "scripts/release_api_retry.py",
     "scripts/resolve_upgrade_baselines.py",
     "scripts/generate-upgrade-manifest.py",
     "scripts/historical_release_auth.py",

--- a/scripts/release_api_retry.py
+++ b/scripts/release_api_retry.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fail-closed GitHub release namespace probes and create reconciliation.
+
+GitHub can return a transient error after accepting a mutating request.  A
+release publisher must therefore never retry ``gh release create`` merely
+because the client returned non-zero.  This helper distinguishes an HTTP 404
+from transport/server failures and reconciles an ambiguous create against the
+exact sealed candidate before deciding whether another create is safe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from urllib.parse import quote
+
+try:
+    from scripts import release_candidate
+except ModuleNotFoundError:  # Direct ``python scripts/release_api_retry.py`` execution.
+    import release_candidate  # type: ignore[no-redef]
+
+TRANSIENT_HTTP_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
+DEFAULT_API_ATTEMPTS = 4
+DEFAULT_API_DELAY_SECONDS = 2.0
+DEFAULT_API_TIMEOUT_SECONDS = 20.0
+# Preserve the former publication-custody convergence window: immutable
+# release asset digests can take several observations to become available.
+# The same window also makes an absence result strong enough to authorize a
+# second create after an ambiguous client failure.
+DEFAULT_RECONCILE_ATTEMPTS = 6
+DEFAULT_RECONCILE_DELAY_SECONDS = 5.0
+ABSENT_EXIT_CODE = 10
+_HTTP_STATUS_RE = re.compile(r"^HTTP/\S+\s+(\d{3})(?:\s|$)")
+
+
+class ReleaseAPIError(RuntimeError):
+    """GitHub state could not be established safely."""
+
+
+class ReconcileState(str, Enum):
+    EXACT = "exact"
+    ABSENT = "absent"
+
+
+@dataclass(frozen=True)
+class APIResponse:
+    status: int | None
+    body: str
+    stderr: str
+    returncode: int
+
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+Sleeper = Callable[[float], None]
+
+
+def _bounded_detail(value: str, *, limit: int = 500) -> str:
+    detail = " ".join(value.strip().split())
+    if len(detail) <= limit:
+        return detail
+    return f"{detail[:limit]}..."
+
+
+def _parse_included_response(
+    completed: subprocess.CompletedProcess[str],
+) -> APIResponse:
+    normalized = completed.stdout.replace("\r\n", "\n")
+    first_line, _, remainder = normalized.partition("\n")
+    match = _HTTP_STATUS_RE.match(first_line)
+    status = int(match.group(1)) if match else None
+    _, separator, body = remainder.partition("\n\n")
+    if not separator:
+        body = ""
+    return APIResponse(
+        status=status,
+        body=body,
+        stderr=completed.stderr,
+        returncode=completed.returncode,
+    )
+
+
+class GitHubReleaseAPI:
+    def __init__(
+        self,
+        *,
+        repository: str,
+        attempts: int = DEFAULT_API_ATTEMPTS,
+        delay_seconds: float = DEFAULT_API_DELAY_SECONDS,
+        timeout_seconds: float = DEFAULT_API_TIMEOUT_SECONDS,
+        runner: Runner = subprocess.run,
+        sleep: Sleeper = time.sleep,
+    ) -> None:
+        if not repository or "/" not in repository:
+            raise ValueError("repository must be OWNER/REPO")
+        if attempts < 1:
+            raise ValueError("attempts must be positive")
+        if delay_seconds < 0:
+            raise ValueError("delay_seconds cannot be negative")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self.repository = repository
+        self.attempts = attempts
+        self.delay_seconds = delay_seconds
+        self.timeout_seconds = timeout_seconds
+        self._runner = runner
+        self._sleep = sleep
+
+    def _request(self, endpoint: str) -> APIResponse:
+        try:
+            completed = self._runner(
+                [
+                    "gh",
+                    "api",
+                    "--include",
+                    "-H",
+                    "Accept: application/vnd.github+json",
+                    endpoint,
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+            )
+        except subprocess.TimeoutExpired:
+            return APIResponse(
+                status=None,
+                body="",
+                stderr="GitHub API request timed out",
+                returncode=124,
+            )
+        return _parse_included_response(completed)
+
+    def get_json(self, endpoint: str, *, absent_ok: bool) -> dict[str, object] | None:
+        last: APIResponse | None = None
+        for attempt in range(1, self.attempts + 1):
+            response = self._request(endpoint)
+            last = response
+            if response.returncode == 0 and response.status is not None and 200 <= response.status < 300:
+                try:
+                    value = json.loads(response.body)
+                except json.JSONDecodeError as exc:
+                    raise ReleaseAPIError(f"GitHub returned invalid JSON for {endpoint}: {exc}") from exc
+                if not isinstance(value, dict):
+                    raise ReleaseAPIError(f"GitHub returned a non-object response for {endpoint}")
+                return value
+            if response.status == 404 and absent_ok:
+                return None
+
+            transient = response.status in TRANSIENT_HTTP_STATUSES or response.status is None
+            if transient and attempt < self.attempts:
+                self._sleep(self.delay_seconds * attempt)
+                continue
+            break
+
+        if last is None:
+            raise ReleaseAPIError(f"no GitHub API attempt was made for {endpoint}")
+        if last.status == 404:
+            detail = "required namespace does not exist"
+        elif last.status is None:
+            detail = _bounded_detail(last.stderr) or "transport failure without an HTTP status"
+        else:
+            detail = _bounded_detail(last.stderr) or f"HTTP {last.status}"
+        raise ReleaseAPIError(
+            f"could not establish GitHub state for {endpoint} after {self.attempts} attempt(s): {detail}"
+        )
+
+    def _endpoint(self, suffix: str) -> str:
+        return f"repos/{self.repository}/{suffix}"
+
+    def main_commit(self) -> str:
+        payload = self.get_json(self._endpoint("git/ref/heads/main"), absent_ok=False)
+        if payload is None:
+            raise ReleaseAPIError("GitHub main ref unexpectedly does not exist")
+        object_value = payload.get("object")
+        if not isinstance(object_value, dict) or not isinstance(object_value.get("sha"), str):
+            raise ReleaseAPIError("GitHub main ref response lacks object.sha")
+        return object_value["sha"]
+
+    def tag_ref(self, tag: str) -> dict[str, object] | None:
+        encoded = quote(tag, safe="")
+        return self.get_json(self._endpoint(f"git/ref/tags/{encoded}"), absent_ok=True)
+
+    def release_by_tag(self, tag: str) -> dict[str, object] | None:
+        encoded = quote(tag, safe="")
+        return self.get_json(self._endpoint(f"releases/tags/{encoded}"), absent_ok=True)
+
+    def resolve_tag_commit(self, payload: dict[str, object]) -> str:
+        current = payload
+        for _ in range(5):
+            object_value = current.get("object")
+            if not isinstance(object_value, dict):
+                raise ReleaseAPIError("GitHub tag response lacks object metadata")
+            object_type = object_value.get("type")
+            object_sha = object_value.get("sha")
+            if not isinstance(object_sha, str):
+                raise ReleaseAPIError("GitHub tag response lacks object.sha")
+            if object_type == "commit":
+                return object_sha
+            if object_type != "tag":
+                raise ReleaseAPIError(f"GitHub tag points to unsupported object type {object_type!r}")
+            next_value = self.get_json(
+                self._endpoint(f"git/tags/{quote(object_sha, safe='')}"),
+                absent_ok=False,
+            )
+            if next_value is None:
+                raise ReleaseAPIError(f"GitHub annotated tag object {object_sha} unexpectedly does not exist")
+            current = next_value
+        raise ReleaseAPIError("GitHub annotated tag chain exceeds the depth bound")
+
+
+def require_absent_namespace(
+    api: GitHubReleaseAPI,
+    *,
+    tag: str,
+    expected_main_commit: str | None = None,
+) -> None:
+    if expected_main_commit is not None:
+        require_main_commit(api, expected_main_commit)
+    tag_payload = api.tag_ref(tag)
+    release_payload = api.release_by_tag(tag)
+    if tag_payload is not None or release_payload is not None:
+        occupied = []
+        if tag_payload is not None:
+            occupied.append("tag")
+        if release_payload is not None:
+            occupied.append("release")
+        raise ReleaseAPIError(f"remote release namespace {tag!r} is occupied by {', '.join(occupied)}")
+
+
+def require_main_commit(api: GitHubReleaseAPI, expected_commit: str) -> None:
+    remote_main = api.main_commit()
+    if remote_main != expected_commit:
+        raise ReleaseAPIError(
+            f"main advanced during certification: expected {expected_commit}, found {remote_main}"
+        )
+
+
+def _candidate_release_json(payload: dict[str, object]) -> dict[str, object]:
+    assets = payload.get("assets")
+    if not isinstance(assets, list):
+        raise ReleaseAPIError("GitHub release response lacks an assets list")
+    return {
+        "tagName": payload.get("tag_name"),
+        "isDraft": payload.get("draft"),
+        "isImmutable": payload.get("immutable"),
+        "assets": [
+            {"name": item.get("name"), "digest": item.get("digest")} if isinstance(item, dict) else item
+            for item in assets
+        ],
+    }
+
+
+def _verify_exact_candidate(
+    *,
+    tag_payload: dict[str, object],
+    release_payload: dict[str, object],
+    api: GitHubReleaseAPI,
+    tag: str,
+    expected_commit: str,
+    candidate_root: Path,
+    omit_windows_binaries: bool,
+) -> None:
+    remote_commit = api.resolve_tag_commit(tag_payload)
+    if remote_commit != expected_commit:
+        raise ReleaseAPIError(f"remote tag {tag!r} points to {remote_commit}, expected {expected_commit}")
+    normalized = _candidate_release_json(release_payload)
+    # Use a directory-backed path rather than reopening a named temporary file
+    # while it is still held open.  The latter is not portable to Windows.
+    with tempfile.TemporaryDirectory(prefix="defenseclaw-release-") as directory:
+        release_json = Path(directory) / "published-release.json"
+        release_json.write_text(json.dumps(normalized, sort_keys=True), encoding="utf-8")
+        try:
+            release_candidate.verify_published_release(
+                candidate_root,
+                release_json,
+                tag,
+                expected_commit,
+                omit_windows_binaries=omit_windows_binaries,
+            )
+        except release_candidate.CandidateError as exc:
+            raise ReleaseAPIError(str(exc)) from exc
+
+
+def reconcile_create(
+    api: GitHubReleaseAPI,
+    *,
+    tag: str,
+    expected_commit: str,
+    candidate_root: Path,
+    omit_windows_binaries: bool,
+    attempts: int = DEFAULT_RECONCILE_ATTEMPTS,
+    delay_seconds: float = DEFAULT_RECONCILE_DELAY_SECONDS,
+    sleep: Sleeper = time.sleep,
+) -> ReconcileState:
+    if attempts < 1:
+        raise ValueError("attempts must be positive")
+    if delay_seconds < 0:
+        raise ValueError("delay_seconds cannot be negative")
+
+    observed_remote = False
+    last_mismatch = ""
+    for attempt in range(1, attempts + 1):
+        tag_payload = api.tag_ref(tag)
+        release_payload = api.release_by_tag(tag)
+        if tag_payload is None and release_payload is None:
+            if attempt < attempts:
+                sleep(delay_seconds)
+                continue
+            if not observed_remote:
+                return ReconcileState.ABSENT
+            last_mismatch = "remote namespace disappeared after being observed"
+            break
+
+        observed_remote = True
+        if tag_payload is None or release_payload is None:
+            last_mismatch = "remote tag/release namespace is only partially populated"
+        else:
+            try:
+                _verify_exact_candidate(
+                    tag_payload=tag_payload,
+                    release_payload=release_payload,
+                    api=api,
+                    tag=tag,
+                    expected_commit=expected_commit,
+                    candidate_root=candidate_root,
+                    omit_windows_binaries=omit_windows_binaries,
+                )
+            except ReleaseAPIError as exc:
+                last_mismatch = str(exc)
+            else:
+                return ReconcileState.EXACT
+        if attempt < attempts:
+            sleep(delay_seconds)
+
+    raise ReleaseAPIError(
+        f"remote release namespace {tag!r} is not the exact sealed candidate: "
+        f"{last_mismatch or 'unknown custody mismatch'}"
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("require-absent", "reconcile-create", "prove-published"))
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--candidate-root", type=Path)
+    parser.add_argument("--omit-windows-binaries", action="store_true")
+    parser.add_argument("--check-main", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        api = GitHubReleaseAPI(repository=args.repository)
+        if args.command == "require-absent":
+            require_absent_namespace(
+                api,
+                tag=args.tag,
+                expected_main_commit=args.commit if args.check_main else None,
+            )
+            print(f"remote release namespace is absent: {args.tag}")
+            return 0
+        if args.candidate_root is None:
+            raise ReleaseAPIError(f"{args.command} requires --candidate-root")
+        if args.check_main:
+            require_main_commit(api, args.commit)
+        state = reconcile_create(
+            api,
+            tag=args.tag,
+            expected_commit=args.commit,
+            candidate_root=args.candidate_root,
+            omit_windows_binaries=args.omit_windows_binaries,
+        )
+        # Absence permits the next step to mutate the release namespace.  The
+        # reconciliation window is deliberately long enough for GitHub's
+        # eventual consistency, so recheck main at the mutation boundary.
+        if state is ReconcileState.ABSENT and args.check_main:
+            require_main_commit(api, args.commit)
+        if state is ReconcileState.EXACT:
+            print(f"exact immutable release custody verified: {args.tag}")
+            return 0
+        if args.command == "reconcile-create":
+            print(f"remote release namespace remained absent: {args.tag}", file=sys.stderr)
+            return ABSENT_EXIT_CODE
+        raise ReleaseAPIError(f"published release {args.tag!r} is absent")
+    except (OSError, ReleaseAPIError, ValueError) as exc:
+        print(f"release API verification failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_api_retry.py
+++ b/scripts/release_api_retry.py
@@ -48,6 +48,7 @@ TRANSIENT_HTTP_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
 DEFAULT_API_ATTEMPTS = 4
 DEFAULT_API_DELAY_SECONDS = 2.0
 DEFAULT_API_TIMEOUT_SECONDS = 20.0
+MAX_RELEASE_LIST_PAGES = 10
 # Preserve the former publication-custody convergence window: immutable
 # release asset digests can take several observations to become available.
 # The same window also makes an absence result strong enough to authorize a
@@ -155,7 +156,7 @@ class GitHubReleaseAPI:
             )
         return _parse_included_response(completed)
 
-    def get_json(self, endpoint: str, *, absent_ok: bool) -> dict[str, object] | None:
+    def _get_json_value(self, endpoint: str, *, absent_ok: bool) -> object | None:
         last: APIResponse | None = None
         for attempt in range(1, self.attempts + 1):
             response = self._request(endpoint)
@@ -165,8 +166,6 @@ class GitHubReleaseAPI:
                     value = json.loads(response.body)
                 except json.JSONDecodeError as exc:
                     raise ReleaseAPIError(f"GitHub returned invalid JSON for {endpoint}: {exc}") from exc
-                if not isinstance(value, dict):
-                    raise ReleaseAPIError(f"GitHub returned a non-object response for {endpoint}")
                 return value
             if response.status == 404 and absent_ok:
                 return None
@@ -189,6 +188,20 @@ class GitHubReleaseAPI:
             f"could not establish GitHub state for {endpoint} after {self.attempts} attempt(s): {detail}"
         )
 
+    def get_json(self, endpoint: str, *, absent_ok: bool) -> dict[str, object] | None:
+        value = self._get_json_value(endpoint, absent_ok=absent_ok)
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise ReleaseAPIError(f"GitHub returned a non-object response for {endpoint}")
+        return value
+
+    def get_json_list(self, endpoint: str) -> list[object]:
+        value = self._get_json_value(endpoint, absent_ok=False)
+        if not isinstance(value, list):
+            raise ReleaseAPIError(f"GitHub returned a non-list response for {endpoint}")
+        return value
+
     def _endpoint(self, suffix: str) -> str:
         return f"repos/{self.repository}/{suffix}"
 
@@ -206,8 +219,22 @@ class GitHubReleaseAPI:
         return self.get_json(self._endpoint(f"git/ref/tags/{encoded}"), absent_ok=True)
 
     def release_by_tag(self, tag: str) -> dict[str, object] | None:
-        encoded = quote(tag, safe="")
-        return self.get_json(self._endpoint(f"releases/tags/{encoded}"), absent_ok=True)
+        # The tag-specific endpoint returns published releases only. During an
+        # ambiguous immutable-release create, GitHub may already hold a draft
+        # with no tag ref. Authenticated release listing includes that draft.
+        for page in range(1, MAX_RELEASE_LIST_PAGES + 1):
+            endpoint = self._endpoint(f"releases?per_page=100&page={page}")
+            releases = self.get_json_list(endpoint)
+            for item in releases:
+                if not isinstance(item, dict):
+                    raise ReleaseAPIError(f"GitHub returned an invalid release row for {endpoint}")
+                if item.get("tag_name") == tag:
+                    return item
+            if len(releases) < 100:
+                return None
+        raise ReleaseAPIError(
+            f"GitHub release listing exceeded {MAX_RELEASE_LIST_PAGES} pages while probing {tag!r}"
+        )
 
     def resolve_tag_commit(self, payload: dict[str, object]) -> str:
         current = payload
@@ -389,8 +416,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
         if args.candidate_root is None:
             raise ReleaseAPIError(f"{args.command} requires --candidate-root")
-        if args.check_main:
-            require_main_commit(api, args.commit)
         state = reconcile_create(
             api,
             tag=args.tag,


### PR DESCRIPTION
Base: `main` after the immutable `0.8.6` publication from certified SHA `28afb1e567c65f165b1e2e43747bb52f31d41668`.

## Problem

[Release run 29708566535](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29708566535) completed every build, signed install, rollback, observability, Docker, and historical upgrade gate, then failed because GitHub's Releases API returned HTTP 503 at `gh release create`.

The publication step could not safely retry a mutating request: a client error does not prove that GitHub rejected the create. It also was not idempotent if publication succeeded but a later custody read failed, because a failed-job rerun rejected the existing exact release as merely occupied.

## Current Situation

The operational incident is resolved: promotion-only attempt 3 succeeded and [0.8.6](https://github.com/cisco-ai-defense/defenseclaw/releases/tag/0.8.6) is immutable at the exact certified SHA. No runtime, installer, upgrade, or observability defect was involved.

Without this change, a future transient GitHub API failure can still require a manual failed-job rerun, and a failure after publication can leave that rerun unable to turn green even when the published bytes are correct.

## Solution

### Classify remote state without guessing

Use explicit GitHub REST status codes so only HTTP 404 means absent. Retry bounded 408/429/5xx and transport failures. Resolve lightweight and annotated tags to the exact expected commit.

### Reconcile every ambiguous create

Before another create, classify custody as:

- exact immutable candidate: accept it and continue to final proof;
- repeatedly absent tag and release: permit another bounded create attempt;
- partial, mismatched, or unknown: fail closed without another mutation.

### Make failed-job reruns idempotent

The promotion precheck now reconciles against the downloaded sealed candidate. If the exact immutable release already exists, it skips `gh release create` and re-runs custody proof. It rechecks exact `main` after the absence observation window immediately before authorizing creation.

```mermaid
flowchart TD
    P["Promotion precheck"] --> R{"Remote custody"}
    R -->|"exact candidate"| S["Skip create"]
    R -->|"repeatedly absent"| C["Bounded release create"]
    R -->|"partial / mismatch / unknown"| F["Fail closed"]
    C -->|"success"| V["Prove tag and immutable asset custody"]
    C -->|"client error"| A["Reconcile ambiguous result"]
    A -->|"exact"| V
    A -->|"absent"| C
    A -->|"conflict"| F
    S --> V
```

## What Changed (Where & How)

| Path | Change |
|---|---|
| `.github/workflows/release.yaml` | Adds bounded create retries, exact/absent/conflict reconciliation, idempotent rerun behavior, command/job timeouts, and final custody proof. |
| `scripts/release_api_retry.py` | Adds fail-closed GitHub API probing, annotated-tag resolution, exact candidate verification, and CLI exit contracts. |
| `.github/workflows/ci.yml` | Runs the new deterministic retry contracts in ordinary PR CI. |
| `release/certification-policy.json` | Marks publication retry logic as release-sensitive. |
| `cli/tests/test_release_api_retry.py` | Covers 404/503/timeout behavior, ambiguity, immutability, exact reruns, conflicts, main advancement, and CLI contracts. |
| `cli/tests/test_release_workflow_staged.py`, `cli/tests/test_release_validation_strategy.py`, `cli/tests/test_source_release_identity.py` | Lock workflow ordering, exact arguments, selective-CI placement, and source identity behavior. |

## Breaking Changes

None. This changes release automation only. Runtime binaries, installers, upgrade manifests, observability, and user-facing commands are unchanged.

## Open Issues / Follow-ups

None.

## Test Plan

Observed locally on this branch:

```text
.venv/bin/python -m pytest -q \
  cli/tests/test_verify_sigstore_blob.py \
  cli/tests/test_observability_v8_upgrade_continuity_checker.py \
  cli/tests/test_resolve_upgrade_baselines.py \
  cli/tests/test_release_api_retry.py \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_upgrade_smoke_static.py \
  cli/tests/test_upgrade_release_smoke_contract.py \
  cli/tests/test_release_certification.py \
  cli/tests/test_release_validation_strategy.py \
  cli/tests/test_source_release_identity.py --tb=short
# 287 passed, 1 skipped

.venv/bin/ruff check scripts/release_api_retry.py cli/tests/test_release_api_retry.py \
  cli/tests/test_release_validation_strategy.py cli/tests/test_release_workflow_staged.py \
  cli/tests/test_source_release_identity.py
# All checks passed

git diff --check
# passed

actionlint .github/workflows/ci.yml
# passed

actionlint .github/workflows/release.yaml
# only the unchanged pre-existing SC2129 style warning at release.yaml:795
```

Read-only live API probes also confirmed that the helper accepts an absent future namespace and rejects the occupied immutable `0.8.6` namespace. Two independent targeted reviews found no remaining blocker, and the GitHub CodeRabbit review approved the PR. The two actionable Codex inline findings (draft custody and retry-time main validation) are included in the final implementation and regression tests.
