### PR TITLE
chore(macOS): import standalone app v1.1.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -791,6 +791,8 @@ macos-app-test:
 	macos/DefenseClawMac/script/test_first_run_connector_selection.sh
 	macos/DefenseClawMac/script/test_numeric_safety.sh
 	macos/DefenseClawMac/script/test_output_safety.sh
+	macos/DefenseClawMac/script/test_cli_cancellation.sh
+	macos/DefenseClawMac/script/test_structured_detail_parser.sh
 	macos/DefenseClawMac/script/test_secret_file_safety.sh
 	macos/DefenseClawMac/script/test_runtime_install_filesystem.sh
 	macos/DefenseClawMac/script/test_app_state_signal_safety.sh

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/AuditStore.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/AuditStore.swift
@@ -189,6 +189,16 @@ actor AuditStore {
         ).map(decodeAuditEvent)
     }
 
+    /// Loads the complete record for an inspector selection. Alert list rows
+    /// intentionally carry only a bounded details preview.
+    func event(id: String) -> AuditEvent? {
+        guard tableExists("audit_events"), !id.isEmpty else { return nil }
+        return query(
+            "SELECT * FROM audit_events WHERE id = ? LIMIT 1",
+            binds: [id]
+        ).first.map(decodeAuditEvent)
+    }
+
     func scanFindings(runID: String? = nil, target: String? = nil, limit: Int = 20) -> [ScanFindingEvent] {
         guard tableExists("scan_results") else { return [] }
         var conditions = ["raw_json IS NOT NULL", "raw_json != ''"]
@@ -242,7 +252,8 @@ actor AuditStore {
     func alertQueueEvents(limit: Int = 500) -> [AuditEvent] {
         guard tableExists("audit_events") else { return [] }
         let rows = query("""
-            SELECT * FROM audit_events
+            SELECT *, substr(COALESCE(details, ''), 1, 4096) AS details
+            FROM audit_events
             WHERE UPPER(severity) IN ('CRITICAL','HIGH','MEDIUM','LOW','WARNING','ERROR','INFO')
               AND action NOT LIKE 'dismiss%'
             ORDER BY timestamp DESC LIMIT ?

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/CLIRunner.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/CLIRunner.swift
@@ -26,7 +26,7 @@ struct CLIResult: Sendable {
     var output: String
     var cancelled: Bool = false
     var outputTruncated: Bool = false
-    var succeeded: Bool { exitCode == 0 && !outputTruncated }
+    var succeeded: Bool { exitCode == 0 && !cancelled && !outputTruncated }
 }
 
 enum CLIOutputLimits {
@@ -221,13 +221,50 @@ private struct BoundedCLILineStreamer: Sendable {
     }
 }
 
+enum CLICancellationDisposition: Sendable, Equatable {
+    case requested
+    case alreadyRequested
+    case finishing
+    case notFound
+}
+
+/// Coordinates the detached pipe reader with direct-process termination.
+/// Descendants may inherit stdout/stderr and keep the pipe open after the
+/// command itself exits, so EOF alone is not a reliable completion signal.
+private final class CLIOutputReadControl: @unchecked Sendable {
+    private let lock = NSLock()
+    private var parentExited = false
+
+    func markParentExited() {
+        lock.lock()
+        parentExited = true
+        lock.unlock()
+    }
+
+    var hasParentExited: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return parentExited
+    }
+}
+
 actor CLIRunner {
     /// User override (App Settings ▸ Connection) wins; otherwise search standard locations.
     static let pathOverrideKey = "defenseclawBinaryPath"
 
+    private struct ActiveRun {
+        let token: UUID
+        let process: Process
+        var cancellationRequested: Bool
+    }
+
+    private enum RunState {
+        case reserved(cancelRequested: Bool)
+        case running(ActiveRun)
+    }
+
     private var cachedPaths: [String: String] = [:]
-    private var runningProcesses: [UUID: Process] = [:]
-    private var cancellationRequests = Set<UUID>()
+    private var runStates: [UUID: RunState] = [:]
     private var installationContext: InstallationContext
 
     init(context: InstallationContext = .resolve()) {
@@ -237,13 +274,20 @@ actor CLIRunner {
     func rebind(to context: InstallationContext) {
         guard installationContext != context else { return }
         if installationContext.permitsMutation, !context.permitsMutation {
-            for (runID, process) in runningProcesses where process.isRunning {
-                cancellationRequests.insert(runID)
-                process.interrupt()
+            for executionID in Array(runStates.keys) {
+                _ = requestCancellation(executionID: executionID, token: nil)
             }
         }
         installationContext = context
         cachedPaths.removeAll()
+    }
+
+    /// Reserve an Activity run before its visible row is published so a
+    /// cancellation racing process launch is retained instead of discarded.
+    func reserve(runID: UUID) -> Bool {
+        guard runStates[runID] == nil else { return false }
+        runStates[runID] = .reserved(cancelRequested: false)
+        return true
     }
 
     func locateBinary() -> String? {
@@ -381,10 +425,33 @@ actor CLIRunner {
         runID: UUID? = nil,
         onLine: (@Sendable (String) async -> Void)? = nil
     ) async -> CLIResult {
+        let executionID = runID ?? UUID()
+        if runID != nil {
+            switch runStates[executionID] {
+            case .reserved(let cancelRequested):
+                runStates[executionID] = nil
+                if cancelRequested {
+                    return CLIResult(
+                        exitCode: 130,
+                        output: "Command cancelled before launch.\n",
+                        cancelled: true
+                    )
+                }
+            case .running:
+                return CLIResult(
+                    exitCode: 125,
+                    output: "A command with this run identifier is already active.\n"
+                )
+            case nil:
+                break
+            }
+        }
+
         if mutation, !installationContext.permitsMutation {
             let reason = installationContext.accessMode.reason ?? "This installation is read only."
             return CLIResult(exitCode: 77, output: "Operation refused by the Mac app: \(reason)")
         }
+
         guard let binary = locateBinary(named: binaryName) else {
             let setting = binaryName == "defenseclaw" ? " Set its path in Settings ▸ Connection." : ""
             return CLIResult(exitCode: 127, output: "\(binaryName) binary not found.\(setting)")
@@ -415,16 +482,28 @@ actor CLIRunner {
         } catch {
             return CLIResult(exitCode: 126, output: "Failed to launch \(binary): \(error.localizedDescription)")
         }
-        if let runID { runningProcesses[runID] = proc }
+        let runToken = UUID()
+        runStates[executionID] = .running(ActiveRun(
+            token: runToken,
+            process: proc,
+            cancellationRequested: false
+        ))
 
         if let standardInput, let inputPipe {
             inputPipe.fileHandleForWriting.write(Data((standardInput + "\n").utf8))
             try? inputPipe.fileHandleForWriting.close()
         }
 
-        // A detached reader keeps draining the pipe even if the calling Task is
-        // cancelled. Stopping reads early can otherwise leave the child blocked
-        // on a full pipe while its parent waits for termination.
+        let readControl = CLIOutputReadControl()
+        let terminationTask = Task.detached(priority: .utility) {
+            proc.waitUntilExit()
+            readControl.markParentExited()
+            return proc.terminationStatus
+        }
+
+        // Keep process waiting and bounded pipe reads off the actor so Cancel
+        // remains responsive. poll(2) also bounds a descendant-held output
+        // pipe after the direct command has exited.
         let outputTask = Task.detached(priority: .utility) {
             var collector = BoundedCLIOutputCollector()
             var streamer = BoundedCLILineStreamer()
@@ -438,7 +517,39 @@ actor CLIRunner {
             }
             let emitLines = lineContinuation != nil
             var readBuffer = [UInt8](repeating: 0, count: CLIOutputLimits.readChunkBytes)
+            var parentExitObservedAt: ContinuousClock.Instant?
             readLoop: while true {
+                if readControl.hasParentExited {
+                    let now = ContinuousClock.now
+                    if let observedAt = parentExitObservedAt,
+                       now - observedAt >= .milliseconds(500) {
+                        break readLoop
+                    }
+                    if parentExitObservedAt == nil { parentExitObservedAt = now }
+                }
+
+                var descriptor = pollfd(
+                    fd: pipe.fileHandleForReading.fileDescriptor,
+                    events: Int16(POLLIN | POLLHUP | POLLERR),
+                    revents: 0
+                )
+                let pollResult = Darwin.poll(&descriptor, 1, 100)
+                if pollResult == 0 {
+                    if readControl.hasParentExited { break readLoop }
+                    continue readLoop
+                }
+                if pollResult < 0 {
+                    if errno == EINTR { continue readLoop }
+                    let message = String(cString: strerror(errno))
+                    let lines = collector.appendStreamError(message, emitLines: emitLines)
+                    if lineContinuation != nil {
+                        for line in streamer.linesToEmit(from: lines) {
+                            lineContinuation?.yield(line)
+                        }
+                    }
+                    break readLoop
+                }
+
                 let byteCount = readBuffer.withUnsafeMutableBytes { buffer in
                     Darwin.read(
                         pipe.fileHandleForReading.fileDescriptor,
@@ -489,29 +600,84 @@ actor CLIRunner {
             return finished.capture
         }
 
-        let captured = await withTaskCancellationHandler {
-            await outputTask.value
+        let completion = await withTaskCancellationHandler {
+            let captured = await outputTask.value
+            let exitCode = await terminationTask.value
+            return (captured, exitCode)
         } onCancel: {
-            if proc.isRunning { proc.interrupt() }
+            Task {
+                await self.requestCancellation(executionID: executionID, token: runToken)
+            }
         }
-        proc.waitUntilExit()
-        let explicitlyCancelled = runID.map { cancellationRequests.remove($0) != nil } ?? false
-        let cancelled = Task.isCancelled || explicitlyCancelled
-        if let runID { runningProcesses[runID] = nil }
+
+        let explicitlyCancelled: Bool
+        if case .running(let active) = runStates[executionID], active.token == runToken {
+            explicitlyCancelled = active.cancellationRequested
+            runStates[executionID] = nil
+        } else {
+            explicitlyCancelled = false
+        }
         return CLIResult(
-            exitCode: proc.terminationStatus,
-            output: captured.output,
-            cancelled: cancelled,
-            outputTruncated: captured.truncated
+            exitCode: completion.1,
+            output: completion.0.output,
+            cancelled: Task.isCancelled || explicitlyCancelled,
+            outputTruncated: completion.0.truncated
         )
     }
 
-    /// Interrupt an Activity-owned process. The process remains registered
-    /// until its output stream closes, so the final exit status is retained.
-    func cancel(runID: UUID) {
-        guard let process = runningProcesses[runID], process.isRunning else { return }
-        cancellationRequests.insert(runID)
-        process.interrupt()
+    /// Request bounded cancellation of an Activity-owned process. Repeated
+    /// requests share one escalation ladder and cannot target a later run that
+    /// happens to reuse the same public identifier.
+    @discardableResult
+    func cancel(runID: UUID) -> CLICancellationDisposition {
+        requestCancellation(executionID: runID, token: nil)
+    }
+
+    private func requestCancellation(
+        executionID: UUID,
+        token expectedToken: UUID?
+    ) -> CLICancellationDisposition {
+        guard let state = runStates[executionID] else { return .notFound }
+        switch state {
+        case .reserved(let cancelRequested):
+            guard !cancelRequested else { return .alreadyRequested }
+            runStates[executionID] = .reserved(cancelRequested: true)
+            return .requested
+        case .running(var active):
+            if let expectedToken, active.token != expectedToken { return .notFound }
+            guard !active.cancellationRequested else { return .alreadyRequested }
+            guard active.process.isRunning else { return .finishing }
+            active.cancellationRequested = true
+            runStates[executionID] = .running(active)
+            active.process.interrupt()
+            scheduleCancellationEscalation(executionID: executionID, token: active.token)
+            return .requested
+        }
+    }
+
+    private func scheduleCancellationEscalation(executionID: UUID, token: UUID) {
+        Task.detached { [weak self] in
+            try? await Task.sleep(for: .milliseconds(500))
+            await self?.terminateIfNeeded(executionID: executionID, token: token)
+            try? await Task.sleep(for: .seconds(1))
+            await self?.killIfNeeded(executionID: executionID, token: token)
+        }
+    }
+
+    private func terminateIfNeeded(executionID: UUID, token: UUID) {
+        guard case .running(let active) = runStates[executionID],
+              active.token == token,
+              active.cancellationRequested,
+              active.process.isRunning else { return }
+        active.process.terminate()
+    }
+
+    private func killIfNeeded(executionID: UUID, token: UUID) {
+        guard case .running(let active) = runStates[executionID],
+              active.token == token,
+              active.cancellationRequested,
+              active.process.isRunning else { return }
+        Darwin.kill(active.process.processIdentifier, SIGKILL)
     }
 
     /// Lightweight doctor probe (TUI Shift+D) — parsed into check rows.

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/CommandActivityStore.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/CommandActivityStore.swift
@@ -19,9 +19,18 @@ import Observation
 
 enum CommandActivityStatus: String, Sendable {
     case running
+    case cancelling
+    case finishing
     case succeeded
     case failed
     case cancelled
+
+    var isActive: Bool {
+        switch self {
+        case .running, .cancelling, .finishing: true
+        case .succeeded, .failed, .cancelled: false
+        }
+    }
 }
 
 struct CommandActivityEntry: Identifiable, Sendable {
@@ -45,6 +54,8 @@ struct CommandActivityEntry: Identifiable, Sendable {
     var statusLabel: String {
         switch status {
         case .running: "Running"
+        case .cancelling: "Cancelling..."
+        case .finishing: "Finishing..."
         case .succeeded: "Exit 0"
         case .failed: "Exit \(exitCode ?? -1)"
         case .cancelled: "Cancelled"
@@ -81,6 +92,12 @@ final class CommandActivityStore {
         successEffects: [String] = [],
         suggestedNextAction: String = ""
     ) async -> CLIResult {
+        guard await runner.reserve(runID: id) else {
+            return CLIResult(
+                exitCode: 125,
+                output: "A command with this run identifier is already active.\n"
+            )
+        }
         entries.insert(
             CommandActivityEntry(
                 id: id,
@@ -132,11 +149,31 @@ final class CommandActivityStore {
     }
 
     func cancel(_ id: UUID) {
-        Task { await runner.cancel(runID: id) }
+        guard let index = entries.firstIndex(where: { $0.id == id }),
+              entries[index].status == .running else { return }
+        entries[index].status = .cancelling
+        Task {
+            let disposition = await runner.cancel(runID: id)
+            guard let index = entries.firstIndex(where: { $0.id == id }),
+                  entries[index].status == .cancelling else { return }
+            switch disposition {
+            case .requested, .alreadyRequested:
+                break
+            case .finishing:
+                entries[index].status = .finishing
+            case .notFound:
+                entries[index].finishedAt = Date()
+                entries[index].status = .cancelled
+                if entries[index].output.isEmpty {
+                    entries[index].output = "Cancellation requested after the command process was no longer active.\n"
+                }
+                entries[index].suggestedNextAction = "Refresh the affected view to verify its final state."
+            }
+        }
     }
 
     func clearCompleted() {
-        entries.removeAll { $0.status != .running }
+        entries.removeAll { !$0.status.isActive }
         if let selectedID, !entries.contains(where: { $0.id == selectedID }) {
             self.selectedID = entries.first?.id
         }

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/Models.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/Models.swift
@@ -504,34 +504,6 @@ struct ActivityMutation: Identifiable, Sendable, Hashable {
     var connector: String = ""
 }
 
-enum StructuredDetailParser {
-    static func pairs(_ details: String) -> [(String, String)] {
-        details.split(whereSeparator: \.isWhitespace).compactMap { token in
-            let components = token.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
-            guard components.count == 2 else { return nil }
-            let key = String(components[0])
-            let value = String(components[1])
-                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'`"))
-            guard !key.isEmpty, !value.isEmpty else { return nil }
-            return (label(key), value)
-        }
-    }
-
-    static func prettyJSON(_ raw: String) -> String {
-        guard let data = raw.data(using: .utf8),
-              let object = try? JSONSerialization.jsonObject(with: data),
-              JSONSerialization.isValidJSONObject(object),
-              let pretty = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys]),
-              let text = String(data: pretty, encoding: .utf8)
-        else { return raw }
-        return text
-    }
-
-    static func label(_ key: String) -> String {
-        key.split(separator: "_").map { $0.capitalized }.joined(separator: " ")
-    }
-}
-
 // MARK: - Logs
 
 enum LogStream: String, CaseIterable, Identifiable {

--- a/macos/DefenseClawMac/DefenseClawMac/DataLayer/StructuredDetailParser.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DataLayer/StructuredDetailParser.swift
@@ -1,0 +1,183 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+/// Parses the gateway's human-readable `key=value` detail format without
+/// mistaking metadata inside `<redacted ...>` placeholders for event fields.
+enum StructuredDetailParser {
+    private static let safeMetadataKeys: Set<String> = [
+        "action", "connector", "decision", "evaluation_id", "finding_count",
+        "findings", "max_severity", "rule_ids", "scan_id", "scanner",
+    ]
+
+    /// Parses a contiguous structured record. If the record starts with prose
+    /// or a redaction placeholder, callers should preserve it as raw text.
+    static func pairs(_ details: String) -> [(String, String)] {
+        let characters = Array(details)
+        var index = skipWhitespace(in: characters, from: 0)
+        var result: [(String, String)] = []
+
+        while index < characters.count {
+            guard let pair = parsePair(in: characters, from: index) else { break }
+            result.append((label(pair.key), displayValue(pair.value)))
+            index = skipWhitespace(in: characters, from: pair.nextIndex)
+        }
+        return result
+    }
+
+    /// Extracts only useful top-level metadata from an otherwise raw record.
+    /// Angle-bracket placeholders are skipped as a unit, so their `len` and
+    /// `sha` attributes can never become inspector rows.
+    static func safeMetadataPairs(_ details: String) -> [(String, String)] {
+        let characters = Array(details)
+        var index = 0
+        var seen = Set<String>()
+        var result: [(String, String)] = []
+
+        while index < characters.count {
+            index = skipWhitespace(in: characters, from: index)
+            guard index < characters.count else { break }
+
+            if characters[index] == "<" {
+                index = skipAngleGroup(in: characters, from: index)
+                continue
+            }
+
+            if let pair = parsePair(in: characters, from: index) {
+                let normalizedKey = pair.key.lowercased()
+                if safeMetadataKeys.contains(normalizedKey), seen.insert(normalizedKey).inserted {
+                    result.append((label(normalizedKey), displayValue(pair.value)))
+                }
+                index = pair.nextIndex
+            } else {
+                index = skipToken(in: characters, from: index)
+            }
+        }
+        return result
+    }
+
+    static func prettyJSON(_ raw: String) -> String {
+        guard let data = raw.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              JSONSerialization.isValidJSONObject(object),
+              let pretty = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys]),
+              let text = String(data: pretty, encoding: .utf8)
+        else { return raw }
+        return text
+    }
+
+    static func label(_ key: String) -> String {
+        switch key.lowercased() {
+        case "evaluation_id": return "Evaluation ID"
+        case "rule_ids": return "Rule IDs"
+        case "scan_id": return "Scan ID"
+        default:
+            return key.split(separator: "_").map { $0.capitalized }.joined(separator: " ")
+        }
+    }
+
+    private static func parsePair(
+        in characters: [Character],
+        from startIndex: Int
+    ) -> (key: String, value: String, nextIndex: Int)? {
+        var index = startIndex
+        let keyStart = index
+        while index < characters.count,
+              characters[index] != "=",
+              !characters[index].isWhitespace {
+            if characters[index] == "<" || characters[index] == ">" { return nil }
+            index += 1
+        }
+        guard index > keyStart, index < characters.count, characters[index] == "=" else { return nil }
+
+        let key = String(characters[keyStart..<index])
+        index += 1
+        guard index < characters.count else { return nil }
+
+        let valueStart = index
+        if characters[index] == "\"" || characters[index] == "'" || characters[index] == "`" {
+            let quote = characters[index]
+            index += 1
+            var value: [Character] = []
+            var escaped = false
+            while index < characters.count {
+                let character = characters[index]
+                index += 1
+                if escaped {
+                    value.append(character)
+                    escaped = false
+                } else if character == "\\" {
+                    escaped = true
+                } else if character == quote {
+                    return (key, String(value), index)
+                } else {
+                    value.append(character)
+                }
+            }
+            return nil
+        }
+
+        if characters[index] == "<" {
+            let nextIndex = skipAngleGroup(in: characters, from: index)
+            guard nextIndex > index, characters[nextIndex - 1] == ">" else { return nil }
+            return (key, String(characters[index..<nextIndex]), nextIndex)
+        }
+
+        while index < characters.count, !characters[index].isWhitespace { index += 1 }
+        guard index > valueStart else { return nil }
+        return (key, String(characters[valueStart..<index]), index)
+    }
+
+    private static func displayValue(_ value: String) -> String {
+        guard value.hasPrefix("<redacted"), value.hasSuffix(">") else { return value }
+        let body = value.dropFirst().dropLast()
+        let attributes = pairs(String(body.dropFirst("redacted".count)))
+        let length = attributes.first { $0.0 == "Len" }?.1
+        let digest = attributes.first { $0.0 == "Sha" }?.1
+        return [
+            "redacted",
+            length.map { "\($0) bytes" },
+            digest.map { "sha:\($0)" },
+        ].compactMap { $0 }.joined(separator: " · ")
+    }
+
+    private static func skipWhitespace(in characters: [Character], from startIndex: Int) -> Int {
+        var index = startIndex
+        while index < characters.count, characters[index].isWhitespace { index += 1 }
+        return index
+    }
+
+    private static func skipToken(in characters: [Character], from startIndex: Int) -> Int {
+        var index = startIndex
+        while index < characters.count, !characters[index].isWhitespace { index += 1 }
+        return index
+    }
+
+    private static func skipAngleGroup(in characters: [Character], from startIndex: Int) -> Int {
+        var index = startIndex
+        var depth = 0
+        while index < characters.count {
+            if characters[index] == "<" { depth += 1 }
+            if characters[index] == ">" {
+                depth -= 1
+                if depth == 0 { return index + 1 }
+            }
+            index += 1
+        }
+        return index
+    }
+}

--- a/macos/DefenseClawMac/DefenseClawMac/DesignSystem/Components.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/DesignSystem/Components.swift
@@ -246,11 +246,19 @@ struct KeyValueGrid: View {
         Grid(alignment: .leading, horizontalSpacing: 14, verticalSpacing: 5) {
             ForEach(Array(pairs.enumerated()), id: \.offset) { _, pair in
                 GridRow {
-                    Text(pair.0).font(.caption).foregroundStyle(.secondary)
-                    Text(pair.1).font(.caption).textSelection(.enabled)
+                    Text(pair.0)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: true, vertical: false)
+                    Text(pair.1)
+                        .font(.caption)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .textSelection(.enabled)
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/macos/DefenseClawMac/DefenseClawMac/Features/ActivityView.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/ActivityView.swift
@@ -93,7 +93,7 @@ struct ActivityView: View {
                     } label: {
                         Label("Clear Completed", systemImage: "trash")
                     }
-                    .disabled(!appState.activity.entries.contains { $0.status != .running })
+                    .disabled(!appState.activity.entries.contains { !$0.status.isActive })
                 } else {
                     Button { Task { await loadMutations() } } label: {
                         Label("Refresh", systemImage: "arrow.clockwise")
@@ -208,6 +208,18 @@ struct ActivityView: View {
                         Label("Cancel", systemImage: "stop.fill")
                     }
                     .controlSize(.small)
+                } else if entry.status == .cancelling {
+                    Button(role: .destructive) {} label: {
+                        Label("Cancelling...", systemImage: "stop.fill")
+                    }
+                    .controlSize(.small)
+                    .disabled(true)
+                } else if entry.status == .finishing {
+                    Button {} label: {
+                        Label("Finishing...", systemImage: "hourglass")
+                    }
+                    .controlSize(.small)
+                    .disabled(true)
                 }
                 Button { appState.activity.selectedID = nil } label: { Image(systemName: "xmark.circle.fill") }
                     .buttonStyle(.borderless)
@@ -237,7 +249,7 @@ struct ActivityView: View {
                 .accessibilityLabel("Copy command output")
             }
             ScrollView {
-                Text(entry.output.isEmpty ? (entry.status == .running ? "Waiting for output..." : "No output") : entry.output)
+                Text(entry.output.isEmpty ? emptyOutputLabel(entry.status) : entry.output)
                     .font(.system(.caption, design: .monospaced))
                     .textSelection(.enabled)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -291,6 +303,8 @@ struct ActivityView: View {
     private func statusIcon(_ status: CommandActivityStatus) -> String {
         switch status {
         case .running: "hourglass"
+        case .cancelling: "stop.circle"
+        case .finishing: "hourglass.circle"
         case .succeeded: "checkmark.circle.fill"
         case .failed: "xmark.circle.fill"
         case .cancelled: "stop.circle.fill"
@@ -300,9 +314,20 @@ struct ActivityView: View {
     private func statusColor(_ status: CommandActivityStatus) -> Color {
         switch status {
         case .running: Cisco.blue
+        case .cancelling: Cisco.orange
+        case .finishing: .secondary
         case .succeeded: Cisco.green
         case .failed: Cisco.red
         case .cancelled: .secondary
+        }
+    }
+
+    private func emptyOutputLabel(_ status: CommandActivityStatus) -> String {
+        switch status {
+        case .running: "Waiting for output..."
+        case .cancelling: "Stopping command..."
+        case .finishing: "Finalizing output..."
+        case .succeeded, .failed, .cancelled: "No output"
         }
     }
 

--- a/macos/DefenseClawMac/DefenseClawMac/Features/AlertsView.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/AlertsView.swift
@@ -31,6 +31,7 @@ struct AlertsView: View {
     @State private var confirmAck = false
     @State private var findingDetails: [ScanFindingEvent] = []
     @State private var findingHistory: [AuditEvent] = []
+    @State private var hydratedAuditEvent: AuditEvent?
 
     private var connectorScopedAlerts: [AlertRow] {
         appState.unackedAlerts.filter { appState.connectorFilterAllows($0.connectorName) }
@@ -60,6 +61,15 @@ struct AlertsView: View {
 
     private var selectedRow: AlertRow? {
         rows.first { selection.contains($0.id) }
+    }
+
+    private var selectedInspectorRow: AlertRow? {
+        guard let row = selectedRow,
+              case .audit(let summary) = row,
+              let hydratedAuditEvent,
+              hydratedAuditEvent.id == summary.id
+        else { return selectedRow }
+        return .audit(hydratedAuditEvent)
     }
 
     var body: some View {
@@ -122,7 +132,7 @@ struct AlertsView: View {
             get: { selectedRow != nil },
             set: { if !$0 { selection = [] } }
         )) {
-            if let row = selectedRow {
+            if let row = selectedInspectorRow {
                 alertInspector(row)
                     .inspectorColumnWidth(min: 340, ideal: 440)
             }
@@ -179,42 +189,57 @@ struct AlertsView: View {
     }
 
     private func alertInspector(_ row: AlertRow) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(row.action).font(.headline)
-                    HStack(spacing: 6) {
-                        SeverityBadge(severity: row.severity)
-                        Text(row.kind.capitalized).font(.caption).foregroundStyle(.secondary)
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(row.action).font(.headline)
+                        HStack(spacing: 6) {
+                            SeverityBadge(severity: row.severity)
+                            Text(row.kind.capitalized).font(.caption).foregroundStyle(.secondary)
+                        }
                     }
+                    Spacer()
+                    Button { selection = [] } label: { Image(systemName: "xmark.circle.fill") }
+                        .buttonStyle(.borderless)
+                        .accessibilityLabel("Close alert details")
                 }
-                Spacer()
-                Button { selection = [] } label: { Image(systemName: "xmark.circle.fill") }
-                    .buttonStyle(.borderless)
-                    .accessibilityLabel("Close alert details")
-            }
-            KeyValueGrid(pairs: [
-                ("Target", row.target),
-                ("Time", row.timestamp.formatted()),
-                ("Connector", row.connectorName),
-                ("Run ID", row.runID),
-            ].filter { !$0.1.isEmpty })
+                KeyValueGrid(pairs: [
+                    ("Target", row.target),
+                    ("Time", row.timestamp.formatted()),
+                    ("Connector", row.connectorName),
+                    ("Run ID", row.runID),
+                ].filter { !$0.1.isEmpty })
 
-            let structured = StructuredDetailParser.pairs(row.details)
-            if structured.isEmpty {
+                let structured = StructuredDetailParser.pairs(row.details)
+                let safeMetadata = structured.isEmpty
+                    ? StructuredDetailParser.safeMetadataPairs(row.details)
+                    : []
+                if !safeMetadata.isEmpty {
+                    Divider()
+                    Text("Security Metadata").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    KeyValueGrid(pairs: safeMetadata)
+                }
+                if !structured.isEmpty {
+                    Divider()
+                    Text("Event Details").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    KeyValueGrid(pairs: structured)
+                }
                 if !row.details.isEmpty {
-                    Text(row.details).font(.callout).textSelection(.enabled)
+                    Divider()
+                    Text("Raw Details").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    Text(row.details)
+                        .font(.system(.caption, design: .monospaced))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(8)
+                        .background(Cisco.surfacePanel, in: RoundedRectangle(cornerRadius: 6))
+                        .textSelection(.enabled)
                 }
-            } else {
-                Divider()
-                Text("Event Details").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-                KeyValueGrid(pairs: structured)
-            }
 
-            if !findingDetails.isEmpty {
-                Divider()
-                Text("Findings").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-                ScrollView {
+                if !findingDetails.isEmpty {
+                    Divider()
+                    Text("Findings").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
                     VStack(alignment: .leading, spacing: 8) {
                         ForEach(findingDetails) { finding in
                             VStack(alignment: .leading, spacing: 4) {
@@ -237,51 +262,64 @@ struct AlertsView: View {
                             .background(Cisco.surfacePanel, in: RoundedRectangle(cornerRadius: 6))
                         }
                     }
+                } else if case .scan(let scan) = row, !scan.findingTitles.isEmpty {
+                    Divider()
+                    Text("Findings").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    ForEach(scan.findingTitles, id: \.self) { Text($0).font(.caption) }
                 }
-                .frame(maxHeight: 230)
-            } else if case .scan(let scan) = row, !scan.findingTitles.isEmpty {
-                Divider()
-                Text("Findings").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-                ForEach(scan.findingTitles, id: \.self) { Text($0).font(.caption) }
-            }
 
-            if !findingHistory.isEmpty {
-                Divider()
-                Text("History for This Target").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
-                ForEach(findingHistory.prefix(5)) { event in
-                    HStack {
-                        Text(event.timestamp, format: .dateTime.month().day().hour().minute())
-                            .font(.caption2.monospacedDigit()).foregroundStyle(.secondary)
-                        Text(event.action).font(.caption).lineLimit(1)
-                        Spacer()
-                        SeverityBadge(severity: event.severity)
+                if !findingHistory.isEmpty {
+                    Divider()
+                    Text("History for This Target").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                    ForEach(findingHistory.prefix(5)) { event in
+                        HStack {
+                            Text(event.timestamp, format: .dateTime.month().day().hour().minute())
+                                .font(.caption2.monospacedDigit()).foregroundStyle(.secondary)
+                            Text(event.action).font(.caption).lineLimit(1)
+                            Spacer()
+                            SeverityBadge(severity: event.severity)
+                        }
                     }
                 }
             }
-            Spacer()
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(12)
     }
 
     private func loadSelectedDetail() {
         guard let row = selectedRow else {
+            hydratedAuditEvent = nil
             findingDetails = []
             findingHistory = []
             return
         }
-        let selectedID = row.id
+        hydratedAuditEvent = nil
+        let rowID = row.id
         Task {
             let installationGeneration = appState.installationGeneration
+            var detailRow = row
+            var selectedAuditID: String?
+            if case .audit(let event) = row {
+                selectedAuditID = event.id
+                if let fullEvent = await appState.audit.event(id: event.id) {
+                    detailRow = .audit(fullEvent)
+                }
+            }
+            guard installationGeneration == appState.installationGeneration else { return }
             let details = await appState.audit.scanFindings(
-                runID: row.runID.nonEmpty,
-                target: row.target.nonEmpty,
+                runID: detailRow.runID.nonEmpty,
+                target: detailRow.target.nonEmpty,
                 limit: 20
             )
             guard installationGeneration == appState.installationGeneration else { return }
-            let history = await appState.audit.relatedEvents(target: row.target, limit: 10)
-                .filter { $0.id != row.id }
+            let history = await appState.audit.relatedEvents(target: detailRow.target, limit: 10)
+                .filter { $0.id != selectedAuditID }
             guard installationGeneration == appState.installationGeneration,
-                  selectedRow?.id == selectedID else { return }
+                  selectedRow?.id == rowID else { return }
+            if case .audit(let fullEvent) = detailRow {
+                hydratedAuditEvent = fullEvent
+            }
             findingDetails = details
             findingHistory = history
         }

--- a/macos/DefenseClawMac/DefenseClawMac/Features/CatalogViews.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/CatalogViews.swift
@@ -412,8 +412,10 @@ private struct CatalogCommandSheet: View {
     @Environment(AppState.self) private var appState
     @Environment(\.dismiss) private var dismiss
     @State private var phase: Phase = .ready
-    @State private var output = ""
+    @State private var runID: UUID?
+    @State private var finalOutput = ""
     @State private var exitCode: Int32?
+    @State private var finalStatus: CommandActivityStatus?
 
     private enum Phase { case ready, running, done }
 
@@ -426,6 +428,8 @@ private struct CatalogCommandSheet: View {
                 Spacer()
                 Button { dismiss() } label: { Image(systemName: "xmark.circle.fill") }
                     .buttonStyle(.borderless)
+                    .disabled(phase == .running)
+                    .help(phase == .running ? "Cancel the command before closing" : "Close")
             }
 
             Text(invocation.detail).font(.callout).foregroundStyle(.secondary)
@@ -440,13 +444,13 @@ private struct CatalogCommandSheet: View {
                 HStack {
                     if phase == .running { ProgressView().controlSize(.small) }
                     if phase == .done {
-                        Image(systemName: exitCode == 0 ? "checkmark.circle.fill" : "xmark.circle.fill")
-                            .foregroundStyle(exitCode == 0 ? Cisco.green : Cisco.red)
+                        Image(systemName: terminalSystemImage)
+                            .foregroundStyle(terminalColor)
                     }
                     Text(statusText).font(.subheadline.weight(.semibold))
                 }
                 ScrollView {
-                    Text(output.isEmpty ? "Waiting for output…" : output)
+                    Text(displayedOutput.isEmpty ? "Waiting for output…" : displayedOutput)
                         .font(.system(.caption, design: .monospaced))
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -480,6 +484,9 @@ private struct CatalogCommandSheet: View {
                             invocation.requiresConfirmation
                                 && !appState.installationMutationsAllowed
                         )
+                } else if phase == .running {
+                    Button(runningActionTitle) { cancel() }
+                        .disabled(activityEntry?.status != .running)
                 } else if phase == .done {
                     Button("Close") { dismiss() }.keyboardShortcut(.defaultAction)
                 }
@@ -490,22 +497,69 @@ private struct CatalogCommandSheet: View {
         .task {
             if !invocation.requiresConfirmation && phase == .ready { run() }
         }
+        .interactiveDismissDisabled(phase == .running)
+    }
+
+    private var activityEntry: CommandActivityEntry? {
+        guard let runID else { return nil }
+        return appState.activity.entries.first(where: { $0.id == runID })
+    }
+
+    private var displayedOutput: String {
+        let liveOutput = activityEntry?.output ?? ""
+        return liveOutput.isEmpty ? finalOutput : liveOutput
+    }
+
+    private var displayedStatus: CommandActivityStatus? {
+        activityEntry?.status ?? finalStatus
+    }
+
+    private var runningActionTitle: String {
+        switch activityEntry?.status {
+        case .running: "Cancel Command"
+        case .cancelling: "Cancelling…"
+        case .finishing: "Finishing…"
+        case .succeeded, .failed, .cancelled: "Finishing…"
+        case nil: "Starting…"
+        }
+    }
+
+    private var terminalSystemImage: String {
+        switch displayedStatus {
+        case .succeeded: "checkmark.circle.fill"
+        case .cancelled: "stop.circle.fill"
+        default: "xmark.circle.fill"
+        }
+    }
+
+    private var terminalColor: Color {
+        switch displayedStatus {
+        case .succeeded: Cisco.green
+        case .cancelled: .secondary
+        default: Cisco.red
+        }
     }
 
     private var statusText: String {
         switch phase {
         case .ready: "Ready"
+        case .running where displayedStatus == .cancelling: "Cancelling…"
+        case .running where displayedStatus == .finishing: "Finishing…"
         case .running: "Running…"
-        case .done where exitCode == 0: "Completed"
+        case .done where displayedStatus == .succeeded: "Completed"
+        case .done where displayedStatus == .cancelled: "Cancelled"
         case .done: "Failed (exit \(exitCode ?? -1))"
         }
     }
 
     private func run() {
         guard phase == .ready else { return }
+        let commandID = UUID()
+        runID = commandID
         phase = .running
         Task {
             let result = await appState.runCommand(
+                runID: commandID,
                 title: invocation.title,
                 arguments: invocation.arguments,
                 mutation: invocation.requiresConfirmation,
@@ -513,14 +567,23 @@ private struct CatalogCommandSheet: View {
                 origin: "Catalog",
                 refreshOnSuccess: true
             )
-            if let entry = appState.activity.entries.first(where: { $0.id == appState.activity.selectedID }) {
-                output = entry.output
+            if let entry = appState.activity.entries.first(where: { $0.id == commandID }) {
+                finalOutput = entry.output
+                finalStatus = entry.status
             }
             exitCode = result.exitCode
-            if output.isEmpty { output = result.output }
+            if finalOutput.isEmpty { finalOutput = result.output }
+            if finalStatus == nil {
+                finalStatus = result.cancelled ? .cancelled : (result.succeeded ? .succeeded : .failed)
+            }
             phase = .done
             if result.succeeded { onComplete() }
         }
+    }
+
+    private func cancel() {
+        guard phase == .running, let runID else { return }
+        appState.activity.cancel(runID)
     }
 }
 

--- a/macos/DefenseClawMac/DefenseClawMac/Features/FirstRunView.swift
+++ b/macos/DefenseClawMac/DefenseClawMac/Features/FirstRunView.swift
@@ -81,7 +81,19 @@ struct FirstRunView: View {
         return appState.activity.entries.first { $0.id == runID }
     }
 
-    private var isRunning: Bool { runningEntry?.status == .running }
+    private var isRunning: Bool { runningEntry?.status.isActive == true }
+    private var isCancelling: Bool { runningEntry?.status == .cancelling }
+    private var isFinishing: Bool { runningEntry?.status == .finishing }
+
+    private var runtimeInstallIsCancelling: Bool {
+        guard let id = appState.runtimeInstallRunID else { return false }
+        return appState.activity.entries.first(where: { $0.id == id })?.status == .cancelling
+    }
+
+    private var runtimeInstallIsFinishing: Bool {
+        guard let id = appState.runtimeInstallRunID else { return false }
+        return appState.activity.entries.first(where: { $0.id == id })?.status == .finishing
+    }
 
     private var registeredSelection: [String] {
         detectedConnectors.filter { registeredConnectors.contains($0) }
@@ -138,14 +150,24 @@ struct FirstRunView: View {
                     Button(role: .destructive) {
                         if let id = appState.runtimeInstallRunID { appState.activity.cancel(id) }
                     } label: {
-                        Label("Cancel Install", systemImage: "stop.fill")
+                        Label(
+                            runtimeInstallIsCancelling
+                                ? "Cancelling..."
+                                : (runtimeInstallIsFinishing ? "Finishing..." : "Cancel Install"),
+                            systemImage: runtimeInstallIsFinishing ? "hourglass" : "stop.fill"
+                        )
                     }
+                    .disabled(runtimeInstallIsCancelling || runtimeInstallIsFinishing)
                 } else if isRunning {
                     Button(role: .destructive) {
                         if let runID { appState.activity.cancel(runID) }
                     } label: {
-                        Label("Cancel", systemImage: "stop.fill")
+                        Label(
+                            isCancelling ? "Cancelling..." : (isFinishing ? "Finishing..." : "Cancel"),
+                            systemImage: isFinishing ? "hourglass" : "stop.fill"
+                        )
                     }
+                    .disabled(isCancelling || isFinishing)
                 } else if cliFound {
                     if detectedConnectors.isEmpty, !detectedProxyConnectors.isEmpty {
                         Button {
@@ -387,7 +409,7 @@ struct FirstRunView: View {
         GroupBox("Setup Output") {
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
-                    if entry.status == .running { ProgressView().controlSize(.small) }
+                    if entry.status.isActive { ProgressView().controlSize(.small) }
                     Image(systemName: statusIcon(entry.status))
                         .foregroundStyle(entry.status == .failed ? Cisco.red : (entry.status == .succeeded ? Cisco.green : .secondary))
                     Text(entry.statusLabel).font(.callout.weight(.semibold))
@@ -554,6 +576,8 @@ struct FirstRunView: View {
     private func statusIcon(_ status: CommandActivityStatus) -> String {
         switch status {
         case .running: "hourglass"
+        case .cancelling: "stop.circle"
+        case .finishing: "hourglass.circle"
         case .succeeded: "checkmark.circle.fill"
         case .failed: "xmark.circle.fill"
         case .cancelled: "stop.circle.fill"

--- a/macos/DefenseClawMac/Tests/CLICancellationTests.swift
+++ b/macos/DefenseClawMac/Tests/CLICancellationTests.swift
@@ -1,0 +1,219 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Darwin
+import Foundation
+
+// Minimal standalone-test dependency for CLIRunner.doctor(). The app target
+// supplies the production model from DataLayer/Models.swift.
+struct DoctorCheck {
+    enum Result { case pass, warn, fail }
+    var name: String
+    var result: Result
+    var detail: String
+}
+
+@main
+struct CLICancellationTests {
+    static func main() async {
+        await explicitCancellationInterruptsChild()
+        await pendingCancellationIsHonoredAndConsumed()
+        await ignoredSignalsEscalateToForcedTermination()
+        await closedOutputDoesNotBlockCancellation()
+        await inheritedPipeDoesNotHoldRunOpen()
+        cancelledResultIsNotSuccessful()
+        print("CLICancellationTests passed")
+    }
+
+    private static func explicitCancellationInterruptsChild() async {
+        let runner = CLIRunner()
+        let runID = UUID()
+        let marker = temporaryMarker("explicit")
+        defer { try? FileManager.default.removeItem(at: marker) }
+        let childProgram = """
+        import signal
+        import sys
+        import time
+
+        def handle_interrupt(_signal, _frame):
+            print("explicit-sigint-drained", flush=True)
+            sys.exit(130)
+
+        signal.signal(signal.SIGINT, handle_interrupt)
+        signal.alarm(8)
+        with open(sys.argv[1], "w", encoding="utf-8") as ready:
+            ready.write("ready")
+        time.sleep(30)
+        """
+        let task = Task {
+            await runner.run(
+                binary: "/usr/bin/python3",
+                arguments: ["-c", childProgram, marker.path],
+                runID: runID
+            )
+        }
+        let childStarted = await waitForFile(marker)
+        expect(childStarted, "explicit-cancellation child starts")
+        let disposition = await runner.cancel(runID: runID)
+        expect(disposition == .requested, "explicit cancellation is accepted")
+        let result = await task.value
+        expect(result.cancelled, "explicit cancellation marks the result cancelled")
+        expect(!result.succeeded, "cancelled command is not successful")
+        expect(result.output.contains("explicit-sigint-drained"), "SIGINT output is drained")
+    }
+
+    private static func pendingCancellationIsHonoredAndConsumed() async {
+        let runner = CLIRunner()
+        let runID = UUID()
+        let reserved = await runner.reserve(runID: runID)
+        expect(reserved, "run ID can be reserved")
+        let cancellation = await runner.cancel(runID: runID)
+        expect(cancellation == .requested, "reserved run accepts cancellation")
+
+        let cancelled = await runner.run(
+            binary: "/usr/bin/python3",
+            arguments: ["-c", "print('must-not-launch')"],
+            runID: runID
+        )
+        expect(cancelled.cancelled, "pre-launch cancellation prevents launch")
+        expect(!cancelled.output.contains("must-not-launch"), "cancelled child did not execute")
+
+        let reused = await runner.run(
+            binary: "/usr/bin/python3",
+            arguments: ["-c", "print('run-id-reused')"],
+            runID: runID
+        )
+        expect(reused.succeeded, "pre-launch cancellation is consumed once")
+        expect(reused.output.contains("run-id-reused"), "run ID can be reused safely")
+    }
+
+    private static func ignoredSignalsEscalateToForcedTermination() async {
+        let runner = CLIRunner()
+        let runID = UUID()
+        let marker = temporaryMarker("forced")
+        defer { try? FileManager.default.removeItem(at: marker) }
+        let childProgram = """
+        import signal
+        import sys
+        import time
+
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        signal.alarm(8)
+        with open(sys.argv[1], "w", encoding="utf-8") as ready:
+            ready.write("ready")
+        time.sleep(30)
+        """
+        let task = Task {
+            await runner.run(
+                binary: "/usr/bin/python3",
+                arguments: ["-c", childProgram, marker.path],
+                runID: runID
+            )
+        }
+        let childStarted = await waitForFile(marker)
+        expect(childStarted, "signal-ignoring child starts")
+        let started = ContinuousClock.now
+        let cancellation = await runner.cancel(runID: runID)
+        expect(cancellation == .requested, "forced cancellation is accepted")
+        let result = await task.value
+        expect(result.cancelled, "forced termination remains cancelled")
+        expect(ContinuousClock.now - started < .seconds(4), "signals escalate promptly")
+    }
+
+    private static func closedOutputDoesNotBlockCancellation() async {
+        let runner = CLIRunner()
+        let runID = UUID()
+        let marker = temporaryMarker("closed-output")
+        defer { try? FileManager.default.removeItem(at: marker) }
+        let childProgram = """
+        import os
+        import signal
+        import sys
+        import time
+
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        signal.alarm(8)
+        os.close(1)
+        os.close(2)
+        with open(sys.argv[1], "w", encoding="utf-8") as ready:
+            ready.write("ready")
+        time.sleep(30)
+        """
+        let task = Task {
+            await runner.run(
+                binary: "/usr/bin/python3",
+                arguments: ["-c", childProgram, marker.path],
+                runID: runID
+            )
+        }
+        let childStarted = await waitForFile(marker)
+        expect(childStarted, "closed-output child starts")
+        let cancellation = await runner.cancel(runID: runID)
+        expect(cancellation == .requested, "runner remains responsive after EOF")
+        let result = await task.value
+        expect(result.cancelled, "closed-output child is cancelled")
+    }
+
+    private static func inheritedPipeDoesNotHoldRunOpen() async {
+        let runner = CLIRunner()
+        let childProgram = """
+        import subprocess
+        import sys
+
+        subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(3)"],
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
+        print("direct-parent-exited", flush=True)
+        """
+        let started = ContinuousClock.now
+        let result = await runner.run(
+            binary: "/usr/bin/python3",
+            arguments: ["-c", childProgram]
+        )
+        expect(result.succeeded, "direct parent exit succeeds")
+        expect(result.output.contains("direct-parent-exited"), "direct parent output is retained")
+        expect(ContinuousClock.now - started < .seconds(2), "descendant-held pipe is bounded")
+    }
+
+    private static func cancelledResultIsNotSuccessful() {
+        expect(!CLIResult(exitCode: 0, output: "", cancelled: true).succeeded,
+               "exit zero cannot override cancellation")
+    }
+
+    private static func temporaryMarker(_ name: String) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("defenseclaw-\(name)-\(UUID().uuidString)")
+    }
+
+    private static func waitForFile(_ url: URL, attempts: Int = 100) async -> Bool {
+        for _ in 0..<attempts {
+            if FileManager.default.fileExists(atPath: url.path) { return true }
+            try? await Task.sleep(for: .milliseconds(30))
+        }
+        return false
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        guard condition() else {
+            fputs("FAILED: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+}

--- a/macos/DefenseClawMac/Tests/StructuredDetailParserTests.swift
+++ b/macos/DefenseClawMac/Tests/StructuredDetailParserTests.swift
@@ -1,0 +1,82 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+
+@main
+struct StructuredDetailParserTests {
+    static func main() {
+        leadingRedactionFallsBackToRawDetails()
+        safeMetadataSkipsRedactionAttributes()
+        redactedValueRemainsOneField()
+        quotedValuesRemainIntact()
+        prettyJSONStillFormatsStructuredPayloads()
+        print("StructuredDetailParserTests passed")
+    }
+
+    private static func leadingRedactionFallsBackToRawDetails() {
+        let details = reportedDriftDetails
+        expect(StructuredDetailParser.pairs(details).isEmpty,
+               "a leading redaction placeholder must not become a key/value grid")
+    }
+
+    private static func safeMetadataSkipsRedactionAttributes() {
+        let metadata = StructuredDetailParser.safeMetadataPairs(reportedDriftDetails)
+        expect(metadata.count == 1, "only allowlisted top-level metadata is extracted")
+        expect(metadata.first?.0 == "Rule IDs", "rule_ids receives a readable label")
+        expect(metadata.first?.1 == "SRC-CHILD-PROC,STRUCT-SCRIPT,JSON-SEC-GENERIC",
+               "rule identifiers are preserved")
+        expect(!metadata.contains { $0.0 == "Len" || $0.0 == "Sha" },
+               "redaction attributes never become metadata rows")
+    }
+
+    private static func redactedValueRemainsOneField() {
+        let pairs = StructuredDetailParser.pairs(
+            "payload=<redacted len=174 sha=7d7f6a97> connector=codex reason=\"policy denied command\""
+        )
+        expect(pairs.count == 3, "redacted and quoted values stay grouped")
+        expect(pairs[0].0 == "Payload", "payload key is parsed")
+        expect(pairs[0].1 == "redacted · 174 bytes · sha:7d7f6a97",
+               "redaction placeholder is summarized without losing its boundary")
+        expect(pairs[1].1 == "codex", "following fields remain parseable")
+        expect(pairs[2].1 == "policy denied command", "quoted spaces remain in one value")
+    }
+
+    private static func quotedValuesRemainIntact() {
+        let pairs = StructuredDetailParser.pairs("action=block message='unsafe command detected'")
+        expect(pairs.count == 2, "quoted record parses completely")
+        expect(pairs[1].1 == "unsafe command detected", "single-quoted values retain spaces")
+    }
+
+    private static func prettyJSONStillFormatsStructuredPayloads() {
+        let formatted = StructuredDetailParser.prettyJSON("{\"b\":2,\"a\":1}")
+        expect(formatted.contains("\n"), "JSON is pretty printed")
+        expect(formatted.range(of: "\"a\"")?.lowerBound ?? formatted.endIndex
+               < formatted.range(of: "\"b\"")?.lowerBound ?? formatted.endIndex,
+               "JSON keys are sorted")
+    }
+
+    private static let reportedDriftDetails = """
+    <redacted len=13291 sha=20e286f0> rule_ids=SRC-CHILD-PROC,STRUCT-SCRIPT,JSON-SEC-GENERIC <redacted len=76 sha=757a90e1> <redacted len=174 sha=7d7f6a97>
+    """
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        guard condition() else {
+            fputs("FAILED: \(message)\n", stderr)
+            exit(1)
+        }
+    }
+}

--- a/macos/DefenseClawMac/UPSTREAM.md
+++ b/macos/DefenseClawMac/UPSTREAM.md
@@ -20,10 +20,10 @@ SPDX-License-Identifier: Apache-2.0
 
 The macOS app was imported from [`keitheobrien/defenseclaw_mac`](https://github.com/keitheobrien/defenseclaw_mac) at:
 
-- Stable release: `v1.1.5`
-- Commit: `c3b7681b082eefb8d8e21dc9347270b7bf803b0e`
-- Commit title: `Release DefenseClawMac 1.1.5`
-- Imported: 2026-07-10
+- Stable release: `v1.1.7`
+- Commit: `f8a79fe0ce86facd81205b7d6ff8a480c8e5a3b4`
+- Commit title: `Release DefenseClawMac 1.1.7`
+- Imported: 2026-07-21
 
 The import includes the Xcode project, Swift sources, tests, developer build/test scripts, icon-generation tool, asset catalog, and README images. It intentionally excludes the upstream repository's Git metadata, `.codex` configuration, personal signing identities, duplicate license file, and standalone release wrapper. The upstream `scripts/build_unified_dmg.sh` behavior is adapted into the monorepo's `scripts/build-macos-app-release.sh` so the unified DMG is built from the same unpublished commit as the backend release rather than downloading an already-published runtime.
 

--- a/macos/DefenseClawMac/script/test_cli_cancellation.sh
+++ b/macos/DefenseClawMac/script/test_cli_cancellation.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2026 Cisco Systems, Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +15,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-repository = "keitheobrien/defenseclaw_mac"
-tag = "v1.1.7"
-commit = "f8a79fe0ce86facd81205b7d6ff8a480c8e5a3b4"
-source_version = "1.1.7"
-imported_at = "2026-07-21"
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/defenseclaw-cancellation-tests.XXXXXX")"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+MODULE_CACHE="$BUILD_DIR/ModuleCache"
+mkdir -p "$MODULE_CACHE"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE" xcrun swiftc \
+  -module-cache-path "$MODULE_CACHE" \
+  "$ROOT/DefenseClawMac/DataLayer/InstallationContext.swift" \
+  "$ROOT/DefenseClawMac/DataLayer/ConfigStore.swift" \
+  "$ROOT/DefenseClawMac/DataLayer/CLIRunner.swift" \
+  "$ROOT/Tests/CLICancellationTests.swift" \
+  -o "$BUILD_DIR/CLICancellationTests"
+
+"$BUILD_DIR/CLICancellationTests"

--- a/macos/DefenseClawMac/script/test_structured_detail_parser.sh
+++ b/macos/DefenseClawMac/script/test_structured_detail_parser.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2026 Cisco Systems, Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +15,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-repository = "keitheobrien/defenseclaw_mac"
-tag = "v1.1.7"
-commit = "f8a79fe0ce86facd81205b7d6ff8a480c8e5a3b4"
-source_version = "1.1.7"
-imported_at = "2026-07-21"
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/defenseclaw-detail-parser-tests.XXXXXX")"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+MODULE_CACHE="$BUILD_DIR/ModuleCache"
+mkdir -p "$MODULE_CACHE"
+
+CLANG_MODULE_CACHE_PATH="$MODULE_CACHE" xcrun swiftc \
+  -module-cache-path "$MODULE_CACHE" \
+  "$ROOT/DefenseClawMac/DataLayer/StructuredDetailParser.swift" \
+  "$ROOT/Tests/StructuredDetailParserTests.swift" \
+  -o "$BUILD_DIR/StructuredDetailParserTests"
+
+"$BUILD_DIR/StructuredDetailParserTests"

--- a/scripts/update-macos-app.sh
+++ b/scripts/update-macos-app.sh
@@ -99,7 +99,9 @@ maintained_paths=(
     DefenseClawMac
     Tests
     script/build_and_run.sh
+    script/test_cli_cancellation.sh
     script/test_connector_onboarding.sh
+    script/test_structured_detail_parser.sh
     tools
     images
     .gitignore


### PR DESCRIPTION
## Problem

The weekly macOS Upstream Freshness run detected that the reviewed standalone app source was still pinned to v1.1.5 while v1.1.7 is the latest stable release. That intentionally failed the nightly freshness gate and opened #572.

## Current Situation

The monorepo carries Cisco-specific installation context, bounded subprocess output, the Cisco bundle identifier/version, and ad-hoc-by-default signing behavior on top of the standalone app. Importing v1.1.7 therefore required a three-way merge instead of copying upstream files wholesale.

Draft PR #511 addresses command cancellation separately, but it does not advance the immutable upstream pin or import v1.1.7's redacted audit-detail handling.

## Solution

Import the immutable v1.1.7 source commit through the repository updater and resolve the four integration conflicts by preserving both sides' safety properties:

- retain Cisco installation mutation controls, protected subprocess environment, bounded output capture/streaming, version, bundle identifier, and unsigned signing fallback;
- add bounded SIGINT → SIGTERM → SIGKILL cancellation, race-safe run reservation, and descendant-held pipe termination;
- hydrate bounded alert previews only when selected and parse redacted detail placeholders without treating placeholder metadata as event fields;
- retain and execute the new upstream cancellation and structured-detail regression harnesses on future imports.

Closes #572.

## Architecture Diagram

N/A.

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `macos/DefenseClawMac/upstream.lock.toml`, `UPSTREAM.md` | Pin stable v1.1.7 to immutable commit `f8a79fe0ce86facd81205b7d6ff8a480c8e5a3b4`. |
| `macos/DefenseClawMac/DefenseClawMac/**` | Import v1.1.7 cancellation and redacted audit-detail behavior while preserving Cisco runtime and output-safety integration. |
| `macos/DefenseClawMac/Tests/**`, `script/test_*.sh` | Add deterministic cancellation and structured-detail regression coverage. |
| `scripts/update-macos-app.sh`, `Makefile` | Preserve the new harnesses in later imports and run them in `macos-app-test`. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make macos-app-test` → all 14 macOS script suites passed; unsigned Release build completed with `CODE_SIGNING_ALLOWED=NO` and `** BUILD SUCCEEDED **`. The host emitted its known non-blocking out-of-date CoreSimulator warning.
- `python3 scripts/check-macos-upstream.py --json` → `status: current`, pinned/latest `v1.1.7@f8a79fe0ce86`.
- `make check-version-sync` → `version sync OK: 0.8.6 (source epoch 2, runtime 8)`.
- `python3 scripts/macos_license_headers.py` → `macOS app license headers OK`.
- `uv run --frozen pytest cli/tests/test_ci_workflow_efficiency.py -q` → `4 passed in 0.49s`.
- `bash -n scripts/update-macos-app.sh` → passed.
- `scripts/update-macos-app.sh v1.1.7` → `macOS app is already pinned to v1.1.7@f8a79fe0ce86`.
- `git diff --check` → passed.