### PR TITLE
Harden Windows release validation and native CI

### DIFF
--- a/.github/workflows/connector-live-e2e.yml
+++ b/.github/workflows/connector-live-e2e.yml
@@ -177,6 +177,7 @@ jobs:
             -e '^cli/defenseclaw/commands/windows_uninstall_helper\.py$' \
             -e '^cli/defenseclaw/windows_acl\.py$' \
             -e '^scripts/(build-windows-installer|initialize-windows-native-ci-paths|install|invoke-windows-setup-standard-user-ci|test-fresh-install-release-windows|test-upgrade-release-windows|test-windows-disposable-user-safety|test-windows-setup-wizard|upgrade|windows-authenticode|windows-binary-identity|windows-disposable-user-safety|windows-native-ci|windows-native-paths)\.ps1$' \
+            -e '^scripts/validate_packaged_v8_resources\.py$' \
             -e '^scripts/windows_installer_artifacts\.py$' \
             -e '^scripts/windows-(disposable-file-guard|disposable-standard-user-launcher|setup-standard-user-launcher)\.cs$' \
             -e '^\.github/workflows/connector-live-e2e\.yml$'; then

--- a/cli/tests/test_connector_live_e2e_path_policy.py
+++ b/cli/tests/test_connector_live_e2e_path_policy.py
@@ -79,6 +79,7 @@ def _selects_full_connector_matrix(path: str) -> bool:
         "scripts/test-windows-disposable-user-safety.ps1",
         "scripts/test-windows-setup-wizard.ps1",
         "scripts/upgrade.ps1",
+        "scripts/validate_packaged_v8_resources.py",
         "scripts/windows-authenticode.ps1",
         "scripts/windows-binary-identity.ps1",
         "scripts/windows-disposable-user-safety.ps1",

--- a/cli/tests/test_packaged_v8_resource_validator.py
+++ b/cli/tests/test_packaged_v8_resource_validator.py
@@ -1,0 +1,109 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR_PATH = ROOT / "scripts" / "validate_packaged_v8_resources.py"
+SPEC = importlib.util.spec_from_file_location("validate_packaged_v8_resources", VALIDATOR_PATH)
+assert SPEC and SPEC.loader
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+def _write_exact_inventory(package_root: Path) -> None:
+    for relative, names in validator.EXPECTED_V8_RESOURCES.items():
+        directory = package_root / relative
+        directory.mkdir(parents=True)
+        for name in names:
+            (directory / name).write_bytes(b"fixture\n")
+
+
+def test_exact_packaged_v8_inventory_is_accepted(tmp_path: Path) -> None:
+    package_root = tmp_path / "site-packages" / "defenseclaw"
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    _write_exact_inventory(package_root)
+
+    validator._validate_inventory(package_root, runtime_root, label="staged")
+
+
+def test_nested_entry_cannot_impersonate_a_packaged_v8_file(tmp_path: Path) -> None:
+    package_root = tmp_path / "site-packages" / "defenseclaw"
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    _write_exact_inventory(package_root)
+    nested = package_root / "_data/config/v8/observability.md"
+    nested.unlink()
+    nested.mkdir()
+    (nested / "payload").write_bytes(b"not a regular resource\n")
+
+    with pytest.raises(validator.PackagedV8ResourceError, match=r"non_files=.*observability\.md"):
+        validator._validate_inventory(package_root, runtime_root, label="staged")
+
+
+def test_runtime_fallback_tree_is_rejected(tmp_path: Path) -> None:
+    package_root = tmp_path / "site-packages" / "defenseclaw"
+    runtime_root = tmp_path / "runtime"
+    _write_exact_inventory(package_root)
+    (runtime_root / "Lib/schemas").mkdir(parents=True)
+
+    with pytest.raises(validator.PackagedV8ResourceError, match="Lib/schemas fallback"):
+        validator._validate_inventory(package_root, runtime_root, label="packaged")
+
+
+def test_public_validator_rejects_nested_import_shadow_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    canonical_root = site_packages / "defenseclaw"
+    shadow_root = site_packages / "vendor" / "defenseclaw"
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    _write_exact_inventory(canonical_root)
+    _write_exact_inventory(shadow_root)
+    monkeypatch.setattr(validator.resources, "files", lambda package: shadow_root)
+
+    with pytest.raises(
+        validator.PackagedV8ResourceError,
+        match="did not resolve to the canonical staged package root",
+    ):
+        validator.validate_packaged_v8_resources(
+            site_packages,
+            runtime_root,
+            label="staged",
+        )
+
+
+def test_public_validator_rejects_canonical_package_symlink_indirection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    canonical_root = site_packages / "defenseclaw"
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    _write_exact_inventory(canonical_root)
+    monkeypatch.setattr(validator.resources, "files", lambda package: canonical_root)
+    real_is_symlink = Path.is_symlink
+    monkeypatch.setattr(
+        Path,
+        "is_symlink",
+        lambda path: path == canonical_root or real_is_symlink(path),
+    )
+
+    with pytest.raises(
+        validator.PackagedV8ResourceError,
+        match="package root uses symlink or junction indirection",
+    ):
+        validator.validate_packaged_v8_resources(
+            site_packages,
+            runtime_root,
+            label="packaged",
+        )

--- a/cli/tests/test_release_candidate.py
+++ b/cli/tests/test_release_candidate.py
@@ -2861,6 +2861,31 @@ def test_non_bridge_candidate_rejects_symlink_v8_resource(tmp_path: Path) -> Non
         release_candidate._validate_wheel(wheel, HARD_CUT_VERSION)
 
 
+@pytest.mark.parametrize(
+    "package_root",
+    [
+        "DEFENS~1",
+        "defens~9",
+        "DEFEN~12",
+        "DE2C6E~1",
+    ],
+)
+def test_non_bridge_candidate_rejects_numeric_short_name_v8_package_root(
+    tmp_path: Path,
+    package_root: str,
+) -> None:
+    wheel = _non_bridge_candidate_wheel(tmp_path)
+    members = _read_wheel_members(wheel)
+    members[f"{package_root}/_data/telemetry/v8/catalog.json"] = b"{}\n"
+    _write_wheel_members(wheel, members)
+
+    with pytest.raises(
+        release_candidate.CandidateError,
+        match="resource inventory is invalid.*unexpected=",
+    ):
+        release_candidate._validate_wheel(wheel, HARD_CUT_VERSION)
+
+
 def test_non_bridge_candidate_rejects_duplicate_v8_resource(tmp_path: Path) -> None:
     wheel = _non_bridge_candidate_wheel(tmp_path)
     member_name = "defenseclaw/_data/telemetry/v8/catalog.json"

--- a/cli/tests/test_release_validation_strategy.py
+++ b/cli/tests/test_release_validation_strategy.py
@@ -105,7 +105,12 @@ def test_ordinary_ci_is_deterministic_and_selective_not_full_certification() -> 
         ".github/workflows/macos-app.yml",
         "scripts/export-uv-overrides.py",
         "scripts/telemetry_runtime_assets.py",
+        "scripts/validate_packaged_v8_resources.py",
     }.issubset(sensitive)
+    assert release_certification._is_sensitive(
+        ["scripts/validate_packaged_v8_resources.py"],
+        list(sensitive),
+    )
 
 
 def test_no_pull_request_workflow_can_run_full_or_signed_certification() -> None:

--- a/cli/tests/test_windows_installer_artifacts.py
+++ b/cli/tests/test_windows_installer_artifacts.py
@@ -13,7 +13,6 @@ import re
 import shutil
 import stat
 import subprocess
-import sys
 import time
 import warnings
 import zipfile
@@ -24,6 +23,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[2]
 HELPER_PATH = ROOT / "scripts" / "windows_installer_artifacts.py"
 BUILD_PS1 = ROOT / "scripts" / "build-windows-installer.ps1"
+PACKAGED_V8_VALIDATOR = ROOT / "scripts" / "validate_packaged_v8_resources.py"
 AUTHENTICODE_PS1 = ROOT / "scripts" / "windows-authenticode.ps1"
 BINARY_IDENTITY_PS1 = ROOT / "scripts" / "windows-binary-identity.ps1"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yaml"
@@ -56,6 +56,38 @@ def _write_zip_entries(
         with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
             for name, data in files:
                 archive.writestr(name, data)
+
+
+def _rewrite_zip_member_name_bytes(path: Path, old: str, new: str) -> None:
+    old_bytes = old.encode("utf-8")
+    new_bytes = new.encode("utf-8")
+    assert len(old_bytes) == len(new_bytes)
+    payload = path.read_bytes()
+    assert payload.count(old_bytes) == 2
+    path.write_bytes(payload.replace(old_bytes, new_bytes))
+
+
+WIN32_FORBIDDEN_WHEEL_MEMBERS = {
+    "forbidden-less-than": "defenseclaw/_data/config/v8/bad<name.json",
+    "forbidden-greater-than": "defenseclaw/_data/config/v8/bad>name.json",
+    "forbidden-quote": 'defenseclaw/_data/config/v8/bad"name.json',
+    "forbidden-pipe": "defenseclaw/_data/config/v8/bad|name.json",
+    "forbidden-question": "defenseclaw/_data/config/v8/bad?name.json",
+    "forbidden-star": "defenseclaw/_data/config/v8/bad*name.json",
+}
+
+RESERVED_DOS_WHEEL_MEMBERS = {
+    "device-con": "defenseclaw/_data/config/v8/con.json",
+    "device-con-space-extension": "defenseclaw/_data/config/v8/Con .json",
+    "device-prn": "defenseclaw/_data/config/v8/PrN.txt",
+    "device-aux": "defenseclaw/_data/config/v8/AUX",
+    "device-nul": "defenseclaw/_data/config/v8/nul.data",
+    "device-clock": "defenseclaw/_data/config/v8/clock$.txt",
+    "device-com1": "defenseclaw/_data/config/v8/com1.json",
+    "device-com9": "defenseclaw/_data/config/v8/COM9.data",
+    "device-lpt1": "defenseclaw/_data/config/v8/lpt1.json",
+    "device-lpt9": "defenseclaw/_data/config/v8/LPT9.data",
+}
 
 
 def _canonical_v8_wheel_entries() -> dict[str, bytes]:
@@ -112,6 +144,8 @@ def _run_v8_wheel_gate(tmp_path: Path, wheel: Path) -> subprocess.CompletedProce
             "Test-PathWithin",
             "Read-BoundedStreamBytes",
             "Read-CanonicalGzipBytes",
+            "Get-ValidatedWheelMemberPath",
+            "Test-DefenseClawV8WheelMember",
             "Assert-DefenseClawWheelV8Resources",
         )
     )
@@ -422,13 +456,15 @@ def test_v8_config_sources_are_pinned_to_cross_platform_lf_bytes() -> None:
 def test_builder_gates_exact_v8_wheel_resources_before_dependency_or_network_work() -> None:
     build = BUILD_PS1.read_text(encoding="utf-8")
     validator = _builder_function("Assert-DefenseClawWheelV8Resources")
+    raw_path_validator = _builder_function("Get-ValidatedWheelMemberPath")
+    packaged_validator = PACKAGED_V8_VALIDATOR.read_text(encoding="utf-8")
     required = tuple(_canonical_v8_wheel_entries())
 
     for member in required:
         assert member in validator
     for contract in (
         "duplicate v8 resource",
-        "colliding v8 extraction destinations",
+        "OrdinalIgnoreCase path collision",
         "non-file v8 resource",
         "unexpected v8 resources",
         "missing required v8 resources",
@@ -437,84 +473,40 @@ def test_builder_gates_exact_v8_wheel_resources_before_dependency_or_network_wor
         "CryptographicOperations]::FixedTimeEquals",
     ):
         assert contract in validator
+    for rejected_alias in (
+        "backslash",
+        "absolute or UNC",
+        "drive-qualified",
+        "dot or empty",
+        "trailing-dot-or-space",
+        "DOS short-name",
+        "Win32-forbidden",
+        "reserved DOS device",
+    ):
+        assert rejected_alias in raw_path_validator
+    assert ".Replace('\\', '/')" not in validator
 
     gate = "Assert-DefenseClawWheelV8Resources $wheel $repoRoot"
     assert build.index(gate) < build.index("$yaraCompatSource")
     assert build.index(gate) < build.index("Invoke-WebRequest")
+    staged_probe = build.index("'-I', $PackagedV8ResourceValidator")
     dependency_probe = build.index("$dependencyCheck = @'")
-    staged_probe = build.index("_schema_validator()", dependency_probe)
     site_archive = build.index("$siteZip = Join-Path $payload")
-    assert staged_probe < site_archive
+    assert staged_probe < dependency_probe < site_archive
+    assert "'--site-packages', $validationSite" in build[staged_probe:dependency_probe]
+    assert "'--runtime-root', $validationRuntime" in build[staged_probe:dependency_probe]
+    assert "'--label', 'staged'" in build[staged_probe:dependency_probe]
     for loader in (
         "telemetry_v8_schema_bytes()",
         "telemetry_v8_catalog_bytes()",
         "v7_exporter_selection_bytes()",
-        "telemetry_v8_compatibility_profile_bytes('galileo-rich-v2')",
-        "telemetry_v8_compatibility_profile_bytes('local-observability-v1')",
-        "telemetry_v8_compatibility_profile_bytes('openinference-v1')",
+        '"galileo-rich-v2"',
+        '"local-observability-v1"',
+        '"openinference-v1"',
     ):
-        assert loader in build[staged_probe:site_archive]
-    assert (
-        "staged runtime unexpectedly contains a Lib/schemas fallback tree"
-        in build[dependency_probe:site_archive]
-    )
-    staged_contract = build[dependency_probe:site_archive]
-    assert "children = list(directory.iterdir())" in staged_contract
-    assert "entry.is_symlink() or not entry.is_file()" in staged_contract
-    assert "if non_files or actual_names != expected_names:" in staged_contract
-
-
-def test_staged_v8_inventory_behaviorally_rejects_unexpected_directory(tmp_path: Path) -> None:
-    build = BUILD_PS1.read_text(encoding="utf-8")
-    here_string = re.search(r"(?ms)^\$dependencyCheck = @'\n(.*?)\n'@", build)
-    assert here_string
-    source = here_string.group(1)
-    start = source.index("expected_v8 = {")
-    end = source.index("\nfrom defenseclaw.observability", start)
-    inventory_probe = (
-        "import pathlib\n"
-        "import sys\n"
-        "package_root = pathlib.Path(sys.argv[1])\n"
-        f"{source[start:end]}\n"
-    )
-
-    package_root = tmp_path / "defenseclaw"
-    for relative in (
-        "_data/config/v8/defenseclaw-config.schema.json",
-        "_data/config/v8/observability.yaml",
-        "_data/config/v8/observability.md",
-        "_data/telemetry/v8/telemetry.schema.json",
-        "_data/telemetry/v8/catalog.json",
-        "_data/telemetry/v8/v7-exporter-selection.json",
-        "_data/telemetry/v8/galileo-rich-v2.json",
-        "_data/telemetry/v8/local-observability-v1.json",
-        "_data/telemetry/v8/openinference-v1.json",
-    ):
-        destination = package_root / relative
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        destination.write_bytes(b"fixture\n")
-
-    valid = subprocess.run(
-        [sys.executable, "-I", "-c", inventory_probe, str(package_root)],
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    assert valid.returncode == 0, valid.stdout + valid.stderr
-
-    (package_root / "_data/config/v8/unexpected").mkdir()
-    invalid = subprocess.run(
-        [sys.executable, "-I", "-c", inventory_probe, str(package_root)],
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    combined = invalid.stdout + invalid.stderr
-    assert invalid.returncode != 0
-    assert "staged DefenseClaw v8 resource inventory mismatch" in combined
-    assert "non_files=['unexpected']" in combined
+        assert loader in packaged_validator
+    assert "runtime unexpectedly contains a Lib/schemas fallback tree" in packaged_validator
+    assert "entry.is_symlink() or not entry.is_file()" in packaged_validator
 
 
 @pytest.mark.parametrize(
@@ -524,17 +516,21 @@ def test_staged_v8_inventory_behaviorally_rejects_unexpected_directory(tmp_path:
         ("missing", "missing required v8 resources"),
         ("duplicate", "duplicate v8 resource"),
         ("unexpected", "unexpected v8 resources"),
-        ("backslash-alias", "unexpected v8 resources"),
-        ("absolute-alias", "colliding v8 extraction destinations"),
-        ("drive-absolute-alias", "unexpected v8 resources"),
-        ("drive-relative-alias", "unexpected v8 resources"),
-        ("unc-alias", "unexpected v8 resources"),
-        ("parent-alias", "colliding v8 extraction destinations"),
-        ("dot-segment-alias", "colliding v8 extraction destinations"),
-        ("case-collision", "colliding v8 extraction destinations"),
-        ("windows-trailing-collision", "colliding v8 extraction destinations"),
-        ("ntfs-short-name-alias-1", "colliding v8 extraction destinations"),
-        ("ntfs-short-name-alias-2", "colliding v8 extraction destinations"),
+        ("backslash", "non-canonical wheel member path with a backslash"),
+        ("absolute", "non-canonical absolute or UNC wheel member path"),
+        ("drive", "non-canonical drive-qualified wheel member path"),
+        ("drive-relative", "non-canonical drive-qualified wheel member path"),
+        ("unc", "non-canonical absolute or UNC wheel member path"),
+        ("parent", "non-canonical dot or empty path component"),
+        ("dot", "non-canonical dot or empty path component"),
+        ("case-alias", "unexpected v8 resources"),
+        ("trailing-dot", "non-canonical trailing-dot-or-space alias"),
+        ("trailing-space", "non-canonical trailing-dot-or-space alias"),
+        ("case-collision", "OrdinalIgnoreCase path collision"),
+        ("short-name", "non-canonical DOS short-name alias"),
+        *((mutation, "non-canonical Win32-forbidden character") for mutation in WIN32_FORBIDDEN_WHEEL_MEMBERS),
+        *((mutation, "non-canonical reserved DOS device name") for mutation in RESERVED_DOS_WHEEL_MEMBERS),
+        ("device-boundaries-allowed", None),
         ("directory-entry", "non-file v8 resource"),
         ("directory-attribute-entry", "non-file v8 resource"),
         ("symlink-entry", "non-file v8 resource"),
@@ -557,41 +553,45 @@ def test_installer_v8_wheel_gate_fails_closed(
         files.append(canonical[0])
     elif mutation == "unexpected":
         files.append(("defenseclaw/_data/config/v8/unexpected.json", b"{}\n"))
-    elif mutation == "absolute-alias":
-        target, payload = canonical[1]
-        files.append((f"/{target}", payload))
-    elif mutation == "drive-absolute-alias":
-        target, payload = canonical[1]
-        files.append((f"C:/{target}", payload))
-    elif mutation == "drive-relative-alias":
-        target, payload = canonical[1]
-        files.append((f"C:{target}", payload))
-    elif mutation == "unc-alias":
-        target, payload = canonical[1]
-        files.append((f"//server/share/{target}", payload))
-    elif mutation == "parent-alias":
-        target, payload = canonical[1]
-        files.append((f"../{target}", payload))
-    elif mutation == "dot-segment-alias":
-        target, payload = canonical[1]
-        alias = target.replace("defenseclaw/_data", "defenseclaw/staging/../_data")
-        files.append((alias, payload))
+    elif mutation == "backslash":
+        files.append((r"defenseclaw\_data\config\v8\unexpected.json", b"{}\n"))
+    elif mutation == "absolute":
+        files.append(("/defenseclaw/_data/config/v8/unexpected.json", b"{}\n"))
+    elif mutation == "drive":
+        files.append(("C:/defenseclaw/_data/config/v8/unexpected.json", b"{}\n"))
+    elif mutation == "drive-relative":
+        files.append(("C:defenseclaw/_data/config/v8/unexpected.json", b"{}\n"))
+    elif mutation == "unc":
+        files.append(("//server/share/defenseclaw/_data/config/v8/unexpected.json", b"{}\n"))
+    elif mutation == "parent":
+        files.append(("defenseclaw/_data/config/v8/../v8/unexpected.json", b"{}\n"))
+    elif mutation == "dot":
+        files.append(("defenseclaw/./_data/config/v8/unexpected.json", b"{}\n"))
+    elif mutation == "case-alias":
+        files.append(("DefenseClaw/_DATA/config/V8/unexpected.json", b"{}\n"))
+    elif mutation == "trailing-dot":
+        files.append(("defenseclaw./_data/config/v8/unexpected.json", b"{}\n"))
+    elif mutation == "trailing-space":
+        files.append(("defenseclaw/_data/config/v8 /unexpected.json", b"{}\n"))
     elif mutation == "case-collision":
-        target, payload = canonical[1]
-        files.append((target.replace("defenseclaw", "DefenseClaw"), payload))
-    elif mutation == "windows-trailing-collision":
-        target, payload = canonical[1]
-        alias = target.replace(
-            "defenseclaw/_data/config/v8",
-            "defenseclaw./_data./config./v8 ",
+        files.append((canonical[0][0].upper(), canonical[0][1]))
+    elif mutation == "short-name":
+        files.append(("DEFENS~1/_data/config/v8/unexpected.json", b"{}\n"))
+    elif mutation in WIN32_FORBIDDEN_WHEEL_MEMBERS:
+        files.append((WIN32_FORBIDDEN_WHEEL_MEMBERS[mutation], b"{}\n"))
+    elif mutation in RESERVED_DOS_WHEEL_MEMBERS:
+        files.append((RESERVED_DOS_WHEEL_MEMBERS[mutation], b"{}\n"))
+    elif mutation == "device-boundaries-allowed":
+        files.extend(
+            (name, b"allowed boundary\n")
+            for name in (
+                "metadata/COM0.txt",
+                "metadata/COM10.txt",
+                "metadata/LPT0.txt",
+                "metadata/LPT10.txt",
+                "metadata/CLOCK.txt",
+            )
         )
-        files.append((alias, payload))
-    elif mutation == "ntfs-short-name-alias-1":
-        target, payload = canonical[1]
-        files.append((target.replace("defenseclaw", "DEFENS~1"), payload))
-    elif mutation == "ntfs-short-name-alias-2":
-        target, payload = canonical[1]
-        files.append((target.replace("defenseclaw", "DEFENS~2"), payload))
     elif mutation == "directory-entry":
         files.append(("defenseclaw/_data/config/v8/unexpected/", b""))
     elif mutation == "directory-attribute-entry":
@@ -620,14 +620,12 @@ def test_installer_v8_wheel_gate_fails_closed(
         wheel.write_bytes(b"not a wheel")
     if mutation != "malformed":
         _write_zip_entries(wheel, files)
-        if mutation == "backslash-alias":
-            # ZipFile treats backslashes differently by host OS, so patch the
-            # canonical local-header and central-directory names directly.
-            canonical_name = canonical[1][0].encode("ascii")
-            alias_name = canonical[1][0].replace("/", "\\").encode("ascii")
-            archive_bytes = wheel.read_bytes()
-            assert archive_bytes.count(canonical_name) == 2
-            wheel.write_bytes(archive_bytes.replace(canonical_name, alias_name))
+    if mutation == "backslash":
+        _rewrite_zip_member_name_bytes(
+            wheel,
+            "defenseclaw/_data/config/v8/unexpected.json",
+            r"defenseclaw\_data\config\v8\unexpected.json",
+        )
 
     result = _run_v8_wheel_gate(tmp_path, wheel)
 

--- a/cli/tests/test_windows_installer_artifacts.py
+++ b/cli/tests/test_windows_installer_artifacts.py
@@ -154,9 +154,14 @@ def _run_v8_wheel_gate(tmp_path: Path, wheel: Path) -> subprocess.CompletedProce
         "$ErrorActionPreference = 'Stop'\n"
         "Add-Type -AssemblyName System.IO.Compression.FileSystem\n"
         f"{functions}\n"
-        "Assert-DefenseClawWheelV8Resources "
+        "try {\n"
+        "    Assert-DefenseClawWheelV8Resources "
         "-WheelPath ([Environment]::GetEnvironmentVariable('DC_TEST_V8_WHEEL')) "
-        "-RepositoryRoot ([Environment]::GetEnvironmentVariable('DC_TEST_V8_REPOSITORY'))\n",
+        "-RepositoryRoot ([Environment]::GetEnvironmentVariable('DC_TEST_V8_REPOSITORY'))\n"
+        "} catch {\n"
+        "    [Console]::Error.WriteLine($_.Exception.Message)\n"
+        "    exit 1\n"
+        "}\n",
         encoding="utf-8",
     )
     env = os.environ.copy()
@@ -554,7 +559,11 @@ def test_installer_v8_wheel_gate_fails_closed(
     elif mutation == "unexpected":
         files.append(("defenseclaw/_data/config/v8/unexpected.json", b"{}\n"))
     elif mutation == "backslash":
-        files.append((r"defenseclaw\_data\config\v8\unexpected.json", b"{}\n"))
+        # Write a canonical same-length name first, then patch the raw local
+        # and central-directory bytes below. ``zipfile`` normalizes a
+        # backslash name on Windows but preserves it on POSIX, so passing the
+        # malformed name directly would make the fixture host-dependent.
+        files.append(("defenseclaw/_data/config/v8/unexpected.json", b"{}\n"))
     elif mutation == "absolute":
         files.append(("/defenseclaw/_data/config/v8/unexpected.json", b"{}\n"))
     elif mutation == "drive":

--- a/cli/tests/test_windows_release_certification.py
+++ b/cli/tests/test_windows_release_certification.py
@@ -11,6 +11,9 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 HARNESS = (ROOT / "scripts" / "windows-native-ci.ps1").read_text(encoding="utf-8")
+PACKAGED_V8_VALIDATOR = (
+    ROOT / "scripts" / "validate_packaged_v8_resources.py"
+).read_text(encoding="utf-8")
 LIVE = (ROOT / "scripts" / "live-connector-e2e" / "run-windows.ps1").read_text(encoding="utf-8")
 RELEASE = (ROOT / ".github" / "workflows" / "release.yaml").read_text(encoding="utf-8")
 
@@ -257,21 +260,24 @@ def test_packaged_v8_resources_are_loaded_before_hooks_and_after_installer_maint
         "local-observability-v1.json",
         "openinference-v1.json",
     ):
-        assert resource in resource_contract
+        assert resource in PACKAGED_V8_VALIDATOR
     for loader in (
         "_schema_validator()",
         "telemetry_v8_schema_bytes()",
         "telemetry_v8_catalog_bytes()",
         "v7_exporter_selection_bytes()",
-        "telemetry_v8_compatibility_profile_bytes('galileo-rich-v2')",
-        "telemetry_v8_compatibility_profile_bytes('local-observability-v1')",
-        "telemetry_v8_compatibility_profile_bytes('openinference-v1')",
+        '"galileo-rich-v2"',
+        '"local-observability-v1"',
+        '"openinference-v1"',
     ):
-        assert loader in resource_contract
-    assert "packaged runtime unexpectedly contains a Lib/schemas fallback tree" in resource_contract
-    assert "children = list(directory.iterdir())" in resource_contract
-    assert "entry.is_symlink() or not entry.is_file()" in resource_contract
-    assert "if non_files or actual_names != expected_names:" in resource_contract
+        assert loader in PACKAGED_V8_VALIDATOR
+    assert "runtime unexpectedly contains a Lib/schemas fallback tree" in PACKAGED_V8_VALIDATOR
+    assert "scripts\\validate_packaged_v8_resources.py" in resource_contract
+    assert "Test-Path -LiteralPath $validator -PathType Leaf" in resource_contract
+    assert "'-I', $validator" in resource_contract
+    assert "'--site-packages', $sitePackages" in resource_contract
+    assert "'--runtime-root', $RuntimeRoot" in resource_contract
+    assert "'--label', 'packaged'" in resource_contract
 
     probe = "Assert-PackagedV8ResourceContract $python (Join-Path $installRoot 'runtime\\python')"
     assert acceptance.index(probe) < acceptance.index("'init', '--skip-install'")

--- a/cli/tests/test_windows_release_claims.py
+++ b/cli/tests/test_windows_release_claims.py
@@ -134,3 +134,18 @@ def test_disposable_connector_workspace_includes_the_v8_jsonl_validator() -> Non
     ]
 
     assert "'assert-observability-v8-jsonl.py'" in contract_files
+
+
+def test_disposable_setup_workspace_includes_the_packaged_v8_validator() -> None:
+    launcher = (ROOT / "scripts/invoke-windows-setup-standard-user-ci.ps1").read_text(
+        encoding="utf-8"
+    )
+    harness_files_start = launcher.index("$harnessFiles = @(")
+    harness_files = launcher[
+        harness_files_start : launcher.index(
+            "if ($Mode -eq 'contract')", harness_files_start
+        )
+    ]
+
+    assert "'windows-native-ci.ps1'" in harness_files
+    assert "'validate_packaged_v8_resources.py'" in harness_files

--- a/internal/gateway/codex_registration_recovery_windows_test.go
+++ b/internal/gateway/codex_registration_recovery_windows_test.go
@@ -304,11 +304,7 @@ func TestCodexRegistrationRecoversOnAuthenticatedSessionStartAfterReadditionAndR
 		api.tokenAuth(api.handleAgentHook("codex")).ServeHTTP(recorder, req)
 		close(requestDone)
 	}()
-	select {
-	case <-requestDone:
-		t.Fatalf("authenticated SessionStart completed before its startup registration owner was ready: status=%d body=%s", recorder.Code, recorder.Body.String())
-	case <-time.After(50 * time.Millisecond):
-	}
+	waitForHookRegistrationOwnerWaiter(t, sidecar, requestDone, recorder)
 
 	// The API listener becomes healthy before the multi-connector guardrail
 	// lane finishes Setup and registers its exact hook guard. An authenticated
@@ -318,6 +314,16 @@ func TestCodexRegistrationRecoversOnAuthenticatedSessionStartAfterReadditionAndR
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	replacementGuard := NewHookConfigGuard(nil, nil, time.Hour)
+	repairHealed := make(chan []string, 1)
+	replacementGuard.SetHealNotifier(func(connectorName string, changed []string) {
+		if connectorName != "codex" {
+			return
+		}
+		select {
+		case repairHealed <- append([]string(nil), changed...):
+		default:
+		}
+	})
 	if !replacementGuard.Start(ctx, conn, restartOpts) {
 		t.Fatal("start replacement gateway hook guard")
 	}
@@ -326,10 +332,53 @@ func TestCodexRegistrationRecoversOnAuthenticatedSessionStartAfterReadditionAndR
 		sidecar.unregisterHookConfigGuard(replacementGuard)
 		replacementGuard.Stop()
 	}()
+	repairDeadline := time.NewTimer(hookRegistrationOwnerWaitTimeout + hookGuardSetupTimeout)
+	defer repairDeadline.Stop()
+	requestFinished := false
+	var repairReasons []string
 	select {
+	case repairReasons = <-repairHealed:
 	case <-requestDone:
-	case <-time.After(3 * time.Second):
-		t.Fatal("authenticated SessionStart did not hand off to the startup registration owner")
+		requestFinished = true
+		select {
+		case repairReasons = <-repairHealed:
+		default:
+			t.Fatalf("authenticated SessionStart completed without a successful registration repair: status=%d body=%s", recorder.Code, recorder.Body.String())
+		}
+	case <-repairDeadline.C:
+		present, presentErr := connector.OwnedHooksPresent(conn, restartOpts)
+		lock := connector.LoadHookContractLockEntry(dataDir, "codex")
+		runtimeBody, runtimeErr := os.ReadFile(filepath.Join(dataDir, "hooks", ".hookcfg.codex"))
+		t.Fatalf(
+			"authenticated SessionStart did not complete registration repair: guard_active=%v present=%v present_err=%v lock=%+v runtime_err=%v runtime=%q",
+			replacementGuard.MatchesActiveConnector("codex", dataDir),
+			present,
+			presentErr,
+			lock,
+			runtimeErr,
+			runtimeBody,
+		)
+	}
+	foundAuthenticatedReason := false
+	for _, reason := range repairReasons {
+		if reason == "authenticated SessionStart" {
+			foundAuthenticatedReason = true
+			break
+		}
+	}
+	if !foundAuthenticatedReason {
+		t.Fatalf("registration repair notification omitted authenticated SessionStart reason: %v", repairReasons)
+	}
+	if !requestFinished {
+		select {
+		case <-requestDone:
+		case <-repairDeadline.C:
+			t.Fatalf(
+				"authenticated SessionStart repair completed but HTTP handoff did not return: guard_active=%v reasons=%v",
+				replacementGuard.MatchesActiveConnector("codex", dataDir),
+				repairReasons,
+			)
+		}
 	}
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("authenticated Codex SessionStart status=%d body=%s", recorder.Code, recorder.Body.String())
@@ -384,7 +433,44 @@ func TestCodexRegistrationRecoversOnAuthenticatedSessionStartAfterReadditionAndR
 	}
 
 	assertOperatorCodexStatePreserved(t, configPath, managedPath, foreignPath, operatorManaged, foreignManaged)
-	assertPythonGuardrailStatusHasNoCodexRegistrationDrift(t, codexHome, dataDir)
+	assertPythonCodexFailModeReportIsCurrent(t, codexHome, dataDir)
+}
+
+func waitForHookRegistrationOwnerWaiter(
+	t *testing.T,
+	sidecar *Sidecar,
+	requestDone <-chan struct{},
+	recorder *httptest.ResponseRecorder,
+) {
+	t.Helper()
+	deadline := time.NewTimer(hookRegistrationOwnerWaitTimeout)
+	defer deadline.Stop()
+	poll := time.NewTicker(time.Millisecond)
+	defer poll.Stop()
+	for {
+		sidecar.hookGuardsMu.Lock()
+		waitChannelReady := sidecar.hookGuardsChanged != nil
+		guardCount := len(sidecar.hookGuards)
+		sidecar.hookGuardsMu.Unlock()
+		if waitChannelReady {
+			if guardCount != 0 {
+				t.Fatalf("startup registration waiter observed %d guards before owner publication", guardCount)
+			}
+			select {
+			case <-requestDone:
+				t.Fatalf("authenticated SessionStart completed before its startup registration owner was ready: status=%d body=%s", recorder.Code, recorder.Body.String())
+			default:
+				return
+			}
+		}
+		select {
+		case <-requestDone:
+			t.Fatalf("authenticated SessionStart completed before entering the startup owner wait: status=%d body=%s", recorder.Code, recorder.Body.String())
+		case <-deadline.C:
+			t.Fatal("authenticated SessionStart did not enter the startup registration-owner wait")
+		case <-poll.C:
+		}
+	}
 }
 
 func managedConfigMatchesOperatorSeed(raw []byte) bool {
@@ -563,7 +649,7 @@ func TestAuthenticatedSessionStartRejectsUnsafeRuntimeEvidenceWithoutMutation(t 
 	}
 }
 
-func assertPythonGuardrailStatusHasNoCodexRegistrationDrift(t *testing.T, codexHome, dataDir string) {
+func assertPythonCodexFailModeReportIsCurrent(t *testing.T, codexHome, dataDir string) {
 	t.Helper()
 	python, err := exec.LookPath("python.exe")
 	if err != nil {
@@ -592,10 +678,8 @@ yaml_fixture = types.ModuleType("yaml")
 yaml_fixture.safe_load = json.load
 sys.modules["yaml"] = yaml_fixture
 
-from click.testing import CliRunner
 from defenseclaw import config as dcconfig
-from defenseclaw.commands import cmd_guardrail
-from defenseclaw.context import AppContext
+from defenseclaw.fail_mode import connector_fail_mode_report
 guardrail = dcconfig.GuardrailConfig()
 guardrail.enabled = True
 guardrail.mode = "observe"
@@ -610,21 +694,16 @@ cfg.active_connector = lambda: "codex"
 cfg.active_connectors = lambda: ["codex"]
 cfg.has_connector_configured = lambda: True
 cfg.connector_workspace_dir = lambda: ""
-app = AppContext()
-app.cfg = cfg
-app.logger = None
-result = CliRunner().invoke(cmd_guardrail.status_cmd, [], obj=app)
-print(result.output)
-if result.exit_code != 0:
-    raise SystemExit(result.exit_code)
-if not all(expected in result.output for expected in ("Codex", "codex", "open")):
-    raise SystemExit("Codex open runtime row is missing from guardrail status")
-if "registration-missing" in result.output or "runtime fail-mode drift" in result.output:
-    raise SystemExit("Codex guardrail status still reports registration drift")
+report = connector_fail_mode_report(cfg, "codex")
+print(json.dumps(report, sort_keys=True))
+if report["effective"] != "open" or report["runtime"] != "open":
+    raise SystemExit("Codex runtime fail-mode report is not open")
+if report["current"] is not True or report["drift"]:
+    raise SystemExit("Codex runtime fail-mode report is not current: " + ", ".join(report["drift"]))
 `
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, python, "-c", script)
+	cmd := exec.CommandContext(ctx, python, "-S", "-c", script)
 	overrides := map[string]string{
 		"PYTHONPATH":             pythonPath,
 		"PYTHONUTF8":             "1",
@@ -645,15 +724,15 @@ if "registration-missing" in result.output or "runtime fail-mode drift" in resul
 	cmd.Env = env
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("Python guardrail status acceptance failed: %v\n%s", err, output)
+		t.Fatalf("Python Codex fail-mode report acceptance failed: %v\n%s", err, output)
 	}
-	if !bytes.Contains(output, []byte("Codex")) ||
-		!bytes.Contains(output, []byte("codex")) ||
-		!bytes.Contains(output, []byte("open")) {
-		t.Fatalf("Python guardrail status omitted the Codex open runtime row:\n%s", output)
+	if !bytes.Contains(output, []byte(`"effective": "open"`)) ||
+		!bytes.Contains(output, []byte(`"runtime": "open"`)) ||
+		!bytes.Contains(output, []byte(`"current": true`)) {
+		t.Fatalf("Python Codex fail-mode report omitted current open runtime state:\n%s", output)
 	}
-	if bytes.Contains(output, []byte("registration-missing")) || bytes.Contains(output, []byte("runtime fail-mode drift")) {
-		t.Fatalf("Python guardrail status retained Codex registration drift:\n%s", output)
+	if !bytes.Contains(output, []byte(`"drift": []`)) || bytes.Contains(output, []byte("registration-missing")) {
+		t.Fatalf("Python Codex fail-mode report retained registration drift:\n%s", output)
 	}
 }
 

--- a/release/certification-policy.json
+++ b/release/certification-policy.json
@@ -75,6 +75,7 @@
     "scripts/source_release_identity.py",
     "scripts/stamp-version.sh",
     "scripts/telemetry_runtime_assets.py",
+    "scripts/validate_packaged_v8_resources.py",
     "scripts/test-upgrade-**",
     "scripts/check_observability_v8_upgrade_continuity.py",
     "scripts/test-observability-v8-upgrade-continuity.sh",

--- a/scripts/build-windows-installer.ps1
+++ b/scripts/build-windows-installer.ps1
@@ -49,6 +49,7 @@ $CosignSha256 = 'DD6C61E510DA627BCAED4CD9DB844EC11CACD09826D814D89F7F68D40FEB07B
 $WindowsArtifactHelper = Join-Path $PSScriptRoot 'windows_installer_artifacts.py'
 $WindowsAuthenticodeHelper = Join-Path $PSScriptRoot 'windows-authenticode.ps1'
 $WindowsBinaryIdentityHelper = Join-Path $PSScriptRoot 'windows-binary-identity.ps1'
+$PackagedV8ResourceValidator = Join-Path $PSScriptRoot 'validate_packaged_v8_resources.py'
 
 function Resolve-FullPath([string]$Path) {
     return [IO.Path]::GetFullPath($Path)
@@ -318,6 +319,92 @@ function Read-CanonicalGzipBytes([string]$Path, [long]$MaximumBytes) {
     return ,$decoded
 }
 
+function Get-ValidatedWheelMemberPath([string]$RawName) {
+    if ([string]::IsNullOrEmpty($RawName)) {
+        throw 'DefenseClaw wheel contains an empty member path.'
+    }
+    if ($RawName.Contains('\')) {
+        throw "DefenseClaw wheel contains a non-canonical wheel member path with a backslash: $RawName"
+    }
+    if ($RawName.StartsWith('/', [StringComparison]::Ordinal)) {
+        throw "DefenseClaw wheel contains a non-canonical absolute or UNC wheel member path: $RawName"
+    }
+    if ($RawName.IndexOf(':') -ge 0) {
+        throw "DefenseClaw wheel contains a non-canonical drive-qualified wheel member path: $RawName"
+    }
+    foreach ($character in $RawName.ToCharArray()) {
+        if ([char]::IsControl($character)) {
+            throw "DefenseClaw wheel contains a non-canonical control character in a member path: $RawName"
+        }
+    }
+
+    $isDirectory = $RawName.EndsWith('/', [StringComparison]::Ordinal)
+    $identity = if ($isDirectory) {
+        $RawName.Substring(0, $RawName.Length - 1)
+    } else {
+        $RawName
+    }
+    if ([string]::IsNullOrEmpty($identity) -or
+        $identity.Contains('//')) {
+        throw "DefenseClaw wheel contains a non-canonical empty path component: $RawName"
+    }
+    foreach ($component in $identity.Split([char]'/', [StringSplitOptions]::None)) {
+        if ([string]::IsNullOrEmpty($component) -or $component -eq '.' -or $component -eq '..') {
+            throw "DefenseClaw wheel contains a non-canonical dot or empty path component: $RawName"
+        }
+        if ($component.IndexOfAny([char[]]'<>"|?*') -ge 0) {
+            throw "DefenseClaw wheel contains a non-canonical Win32-forbidden character: $RawName"
+        }
+        if ($component.EndsWith('.', [StringComparison]::Ordinal) -or
+            $component.EndsWith(' ', [StringComparison]::Ordinal)) {
+            throw "DefenseClaw wheel contains a non-canonical trailing-dot-or-space alias: $RawName"
+        }
+        $stem = $component
+        $extensionIndex = $component.IndexOf('.')
+        if ($extensionIndex -ge 0) {
+            $stem = $component.Substring(0, $extensionIndex)
+        }
+        $stem = $stem.TrimEnd([char[]]' .')
+        if ($stem -match '(?i)^(?:CON|PRN|AUX|NUL|CLOCK\$|COM[1-9]|LPT[1-9])$') {
+            throw "DefenseClaw wheel contains a non-canonical reserved DOS device name: $RawName"
+        }
+        if ($component -match '(?i)^[A-Z0-9_]{1,6}~[1-9][0-9]*(?:\.[A-Z0-9_]{0,3})?$') {
+            throw "DefenseClaw wheel contains a non-canonical DOS short-name alias: $RawName"
+        }
+    }
+    return [pscustomobject]@{
+        Name = $RawName
+        Identity = $identity
+        IsDirectory = $isDirectory
+    }
+}
+
+function Test-DefenseClawV8WheelMember([string]$Name) {
+    $parts = @($Name.Split([char]'/', [StringSplitOptions]::None))
+    for ($dataIndex = 0; $dataIndex -lt $parts.Count; $dataIndex++) {
+        if (-not $parts[$dataIndex].Equals('_data', [StringComparison]::OrdinalIgnoreCase)) {
+            continue
+        }
+        $hasPackageRoot = $false
+        for ($packageIndex = 0; $packageIndex -lt $dataIndex; $packageIndex++) {
+            if ($parts[$packageIndex].Equals('defenseclaw', [StringComparison]::OrdinalIgnoreCase)) {
+                $hasPackageRoot = $true
+                break
+            }
+        }
+        if (-not $hasPackageRoot) { continue }
+        for ($resourceIndex = $dataIndex + 1; $resourceIndex -lt $parts.Count; $resourceIndex++) {
+            $component = $parts[$resourceIndex]
+            if ($component.Equals('v8', [StringComparison]::OrdinalIgnoreCase) -or
+                $component.StartsWith('v8_', [StringComparison]::OrdinalIgnoreCase) -or
+                $component.StartsWith('v8.', [StringComparison]::OrdinalIgnoreCase)) {
+                return $true
+            }
+        }
+    }
+    return $false
+}
+
 function Assert-DefenseClawWheelV8Resources(
     [string]$WheelPath,
     [string]$RepositoryRoot
@@ -387,107 +474,39 @@ function Assert-DefenseClawWheelV8Resources(
         $entries = [Collections.Generic.Dictionary[string, IO.Compression.ZipArchiveEntry]]::new(
             [StringComparer]::Ordinal
         )
-        $windowsDestinations = [Collections.Generic.Dictionary[string, string]]::new(
+        $pathIdentities = [Collections.Generic.Dictionary[string, string]]::new(
             [StringComparer]::OrdinalIgnoreCase
         )
         $unexpected = [Collections.Generic.List[string]]::new()
         foreach ($entry in $archive.Entries) {
-            # Use Windows-equivalent components only to classify unsafe aliases
-            # and collisions. Acceptance below always uses the untouched ZIP name.
-            $rawName = [string]$entry.FullName
-            $rawComponents = [Collections.Generic.List[string]]::new()
-            $resolvedComponents = [Collections.Generic.List[string]]::new()
-            foreach ($rawComponent in $rawName.Replace('\', '/').Split(
-                [char[]]@('/'),
-                [StringSplitOptions]::None
-            )) {
-                if ($rawComponent.Length -eq 0) { continue }
-                $dotComponent = $rawComponent.TrimEnd([char[]]@(' '))
-                if ($dotComponent -eq '.') { continue }
-                if ($dotComponent -eq '..') {
-                    [void]$rawComponents.Add('..')
-                    if ($resolvedComponents.Count -gt 0) {
-                        $resolvedComponents.RemoveAt($resolvedComponents.Count - 1)
-                    }
-                    continue
+            $member = Get-ValidatedWheelMemberPath ([string]$entry.FullName)
+            $name = [string]$member.Name
+            $identity = [string]$member.Identity
+            if ($pathIdentities.ContainsKey($identity)) {
+                $existingName = $pathIdentities[$identity]
+                if (Test-DefenseClawV8WheelMember $name) {
+                    throw "DefenseClaw wheel contains a duplicate v8 resource or OrdinalIgnoreCase path collision: '$name' conflicts with '$existingName'"
                 }
-                $component = $rawComponent.TrimEnd([char[]]@(' ', '.')).ToLowerInvariant()
-                if ($component.Length -eq 0) { continue }
-                if (
-                    $component.Length -gt 2 -and
-                    [char]::IsLetter($component[0]) -and
-                    $component[1] -eq [char]':'
-                ) {
-                    $drivePrefix = $component.Substring(0, 2)
-                    [void]$rawComponents.Add($drivePrefix)
-                    [void]$resolvedComponents.Add($drivePrefix)
-                    $component = $component.Substring(2)
-                }
-                if ([Text.RegularExpressions.Regex]::IsMatch(
-                    $component,
-                    '\Adefens~[0-9]+\z',
-                    [Text.RegularExpressions.RegexOptions]::CultureInvariant
-                )) {
-                    $component = 'defenseclaw'
-                } elseif ([Text.RegularExpressions.Regex]::IsMatch(
-                    $component,
-                    '\Ateleme~[0-9]+\z',
-                    [Text.RegularExpressions.RegexOptions]::CultureInvariant
-                )) {
-                    $component = 'telemetry'
-                }
-                [void]$rawComponents.Add($component)
-                [void]$resolvedComponents.Add($component)
+                throw "DefenseClaw wheel contains an OrdinalIgnoreCase path collision: '$name' conflicts with '$existingName'"
             }
+            $pathIdentities.Add($identity, $name)
 
-            $isV8Resource = $false
-            $componentSets = [Collections.Generic.List[object]]::new()
-            [void]$componentSets.Add($rawComponents.ToArray())
-            [void]$componentSets.Add($resolvedComponents.ToArray())
-            foreach ($componentSet in $componentSets) {
-                [string[]]$components = $componentSet
-                for ($index = 0; $index -le $components.Length - 4; $index++) {
-                    if (
-                        $components[$index] -ceq 'defenseclaw' -and
-                        $components[$index + 1] -ceq '_data' -and
-                        (
-                            $components[$index + 2] -ceq 'config' -or
-                            $components[$index + 2] -ceq 'telemetry'
-                        ) -and
-                        $components[$index + 3] -ceq 'v8'
-                    ) {
-                        $isV8Resource = $true
-                        break
-                    }
-                }
-                if ($isV8Resource) { break }
-            }
-            if (-not $isV8Resource) { continue }
-
-            $destinationKey = [string]::Join('/', $resolvedComponents.ToArray())
-            if ($windowsDestinations.ContainsKey($destinationKey)) {
-                $owner = $windowsDestinations[$destinationKey]
-                if ($owner.Equals($rawName, [StringComparison]::Ordinal)) {
-                    throw "DefenseClaw wheel contains a duplicate v8 resource: $rawName"
-                }
-                throw "DefenseClaw wheel contains colliding v8 extraction destinations: $owner, $rawName"
-            }
-            $windowsDestinations.Add($destinationKey, $rawName)
-
+            $isV8Resource = Test-DefenseClawV8WheelMember $name
             $unixFileType = (($entry.ExternalAttributes -shr 16) -band 0xF000)
-            if (
-                $rawName.EndsWith('/', [StringComparison]::Ordinal) -or
-                $rawName.EndsWith('\', [StringComparison]::Ordinal) -or
+            if ($isV8Resource -and (
+                [bool]$member.IsDirectory -or
                 (($entry.ExternalAttributes -band 0x10) -ne 0) -or
                 ($unixFileType -ne 0 -and $unixFileType -ne 0x8000)
-            ) {
-                throw "DefenseClaw wheel contains a non-file v8 resource: $rawName"
+            )) {
+                throw "DefenseClaw wheel contains a non-file v8 resource: $name"
             }
-            if (-not $expectedNames.Contains($rawName)) {
-                [void]$unexpected.Add($rawName)
+            if ([bool]$member.IsDirectory) { continue }
+            if (-not $isV8Resource) { continue }
+            if (-not $expectedNames.Contains($name)) {
+                [void]$unexpected.Add($name)
                 continue
             }
-            $entries.Add($rawName, $entry)
+            $entries.Add($name, $entry)
         }
         if ($unexpected.Count -gt 0) {
             $names = @($unexpected | Sort-Object -Unique) -join ', '
@@ -697,7 +716,7 @@ Set-Location $repoRoot
 $resourceIcon = Join-Path $repoRoot 'macos\DefenseClawMac\DefenseClawMac\Assets.xcassets\AppIcon.appiconset\icon_256.png'
 foreach ($requiredSetupInput in @(
     $resourceIcon, $WindowsArtifactHelper, $WindowsAuthenticodeHelper,
-    $WindowsBinaryIdentityHelper
+    $WindowsBinaryIdentityHelper, $PackagedV8ResourceValidator
 )) {
     if (-not (Test-Path -LiteralPath $requiredSetupInput -PathType Leaf)) {
         throw "Required Windows installer input is missing: $requiredSetupInput"
@@ -902,75 +921,18 @@ $validationSite = Join-Path $validationRuntime 'Lib\site-packages'
 foreach ($item in Get-ChildItem -LiteralPath $sitePackages -Force) {
     Copy-Item -LiteralPath $item.FullName -Destination $validationSite -Recurse -Force
 }
+Invoke-CheckedProcess $validationPython @(
+    '-I', $PackagedV8ResourceValidator,
+    '--site-packages', $validationSite,
+    '--runtime-root', $validationRuntime,
+    '--label', 'staged'
+)
 $dependencyCheck = @'
 import importlib.metadata as metadata
-import json
-import pathlib
 import platform
-import sys
-from importlib import resources
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
-
-site_packages = pathlib.Path(sys.argv[1]).resolve()
-runtime_root = pathlib.Path(sys.argv[2]).resolve()
-package_root = pathlib.Path(str(resources.files('defenseclaw'))).resolve()
-try:
-    package_root.relative_to(site_packages)
-except ValueError as exc:
-    raise SystemExit(f'DefenseClaw resources resolved outside staged site-packages: {package_root}') from exc
-if (runtime_root / 'Lib' / 'schemas').exists():
-    raise SystemExit('staged runtime unexpectedly contains a Lib/schemas fallback tree')
-
-expected_v8 = {
-    '_data/config/v8': {
-        'defenseclaw-config.schema.json', 'observability.yaml', 'observability.md',
-    },
-    '_data/telemetry/v8': {
-        'telemetry.schema.json', 'catalog.json', 'v7-exporter-selection.json',
-        'galileo-rich-v2.json', 'local-observability-v1.json', 'openinference-v1.json',
-    },
-}
-for relative, expected_names in expected_v8.items():
-    directory = package_root.joinpath(relative)
-    children = list(directory.iterdir())
-    actual_names = {entry.name for entry in children}
-    non_files = sorted(
-        entry.name for entry in children if entry.is_symlink() or not entry.is_file()
-    )
-    if non_files or actual_names != expected_names:
-        raise SystemExit(
-            f'staged DefenseClaw v8 resource inventory mismatch in {relative}: '
-            f'actual={sorted(actual_names)!r} expected={sorted(expected_names)!r} '
-            f'non_files={non_files!r}'
-        )
-
-from defenseclaw.observability.v8_config import _schema_validator
-from defenseclaw.observability.schema_resources import (
-    telemetry_v8_catalog_bytes,
-    telemetry_v8_compatibility_profile_bytes,
-    telemetry_v8_schema_bytes,
-    v7_exporter_selection_bytes,
-)
-
-_schema_validator()
-for reference in ('observability.yaml', 'observability.md'):
-    if not package_root.joinpath('_data/config/v8', reference).read_bytes():
-        raise SystemExit(f'staged DefenseClaw v8 reference is empty: {reference}')
-telemetry_payloads = {
-    'telemetry.schema.json': telemetry_v8_schema_bytes(),
-    'catalog.json': telemetry_v8_catalog_bytes(),
-    'v7-exporter-selection.json': v7_exporter_selection_bytes(),
-    'galileo-rich-v2.json': telemetry_v8_compatibility_profile_bytes('galileo-rich-v2'),
-    'local-observability-v1.json': telemetry_v8_compatibility_profile_bytes('local-observability-v1'),
-    'openinference-v1.json': telemetry_v8_compatibility_profile_bytes('openinference-v1'),
-}
-for name, payload in telemetry_payloads.items():
-    try:
-        json.loads(payload)
-    except (TypeError, ValueError) as exc:
-        raise SystemExit(f'staged DefenseClaw v8 resource is not valid JSON: {name}') from exc
 
 installed = {canonicalize_name(dist.metadata['Name']): dist.version for dist in metadata.distributions() if dist.metadata.get('Name')}
 problems = []
@@ -1004,9 +966,9 @@ if not magika_result.ok or not magika_result.output.is_text:
 findings = asyncio.run(YaraAnalyzer().analyze('os.system("calc.exe")', {'tool_name': 'release-probe'}))
 if not findings or not any(finding.analyzer == 'YARA' for finding in findings):
     raise SystemExit('MCP Scanner YARA compatibility probe did not return the expected finding')
-print(f'validated nine DefenseClaw v8 resources and {len(installed)} embedded distributions')
+print(f'validated {len(installed)} embedded distributions')
 '@
-Invoke-CheckedProcess $validationPython @('-I', '-c', $dependencyCheck, $validationSite, $validationRuntime)
+Invoke-CheckedProcess $validationPython @('-I', '-c', $dependencyCheck)
 
 $siteZip = Join-Path $payload "site-packages.zip"
 Write-ZipFromDirectory $sitePackages $siteZip $validationPython $sourceDateEpoch $reproducibilityRoot

--- a/scripts/invoke-windows-setup-standard-user-ci.ps1
+++ b/scripts/invoke-windows-setup-standard-user-ci.ps1
@@ -873,6 +873,7 @@ try {
     # authority.
     $harnessFiles = @(
         'invoke-windows-setup-standard-user-ci.ps1',
+        'validate_packaged_v8_resources.py',
         'windows-native-ci.ps1',
         'windows-native-paths.ps1',
         'windows-disposable-file-guard.cs',

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -68,6 +68,7 @@ RELEASE_PROVENANCE_SCHEMA_VERSION = 1
 VERSION_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+WINDOWS_NUMERIC_SHORT_NAME_RE = re.compile(r"^[a-z0-9]{1,6}~[0-9]+$")
 MAX_GATEWAY_BINARY_BYTES = 512 * 1024 * 1024
 PROTECTED_ARTIFACT_MAGIC = b"DEFENSECLAW-PROTECTED-ARTIFACT-V1\n"
 PROTECTED_ARTIFACT_XOR_BYTE = 0xA5
@@ -3000,11 +3001,20 @@ def _is_v8_package_data_member(member_name: str) -> bool:
         part.rstrip(" .").casefold()
         for part in PurePosixPath(member_name.replace("\\", "/")).parts
     )
-    return any(
-        any(
-            re.fullmatch(r"(?:[a-z]:)?(?:defenseclaw|defens~[0-9]+)", root) is not None
-            for root in parts[:data_index]
+    # An NTFS 8.3 alias may use either a stem-derived form (DEFENS~1) or a
+    # volume-assigned/hash-derived form. Without the destination volume there
+    # is no safe way to prove which package directory a numeric short name
+    # resolves to, so treat every valid numeric 8.3 directory component before
+    # ``_data`` as a potential alias for the DefenseClaw package root.
+    def is_package_root(part: str) -> bool:
+        candidate = re.sub(r"^[a-z]:", "", part, count=1)
+        return candidate == "defenseclaw" or (
+            len(candidate) <= 8
+            and WINDOWS_NUMERIC_SHORT_NAME_RE.fullmatch(candidate) is not None
         )
+
+    return any(
+        any(is_package_root(part) for part in parts[:data_index])
         and any(
             part == "v8" or part.startswith(("v8_", "v8."))
             for part in parts[data_index + 1 :]

--- a/scripts/validate_packaged_v8_resources.py
+++ b/scripts/validate_packaged_v8_resources.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate the installed DefenseClaw v8 resource contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from importlib import resources
+from pathlib import Path
+from typing import Final
+
+EXPECTED_V8_RESOURCES: Final[dict[str, frozenset[str]]] = {
+    "_data/config/v8": frozenset(
+        {
+            "defenseclaw-config.schema.json",
+            "observability.yaml",
+            "observability.md",
+        }
+    ),
+    "_data/telemetry/v8": frozenset(
+        {
+            "telemetry.schema.json",
+            "catalog.json",
+            "v7-exporter-selection.json",
+            "galileo-rich-v2.json",
+            "local-observability-v1.json",
+            "openinference-v1.json",
+        }
+    ),
+}
+
+
+class PackagedV8ResourceError(RuntimeError):
+    """Raised when installed v8 resources violate the release contract."""
+
+
+def _validate_inventory(package_root: Path, runtime_root: Path, *, label: str) -> None:
+    fallback_root = runtime_root / "Lib" / "schemas"
+    if fallback_root.exists() or fallback_root.is_symlink():
+        raise PackagedV8ResourceError(f"{label} runtime unexpectedly contains a Lib/schemas fallback tree")
+
+    for relative, expected_names in EXPECTED_V8_RESOURCES.items():
+        directory = package_root.joinpath(relative)
+        if directory.is_symlink() or not directory.is_dir():
+            raise PackagedV8ResourceError(
+                f"{label} DefenseClaw v8 resource directory is not a regular directory: {relative}"
+            )
+
+        entries = tuple(directory.iterdir())
+        non_files = sorted(entry.name for entry in entries if entry.is_symlink() or not entry.is_file())
+        actual_names = {entry.name for entry in entries}
+        if non_files or actual_names != expected_names:
+            raise PackagedV8ResourceError(
+                f"{label} DefenseClaw v8 resource inventory mismatch in {relative}: "
+                f"actual={sorted(actual_names)!r} expected={sorted(expected_names)!r} "
+                f"non_files={non_files!r}"
+            )
+
+
+def validate_packaged_v8_resources(
+    site_packages: Path,
+    runtime_root: Path,
+    *,
+    label: str,
+) -> None:
+    """Validate exact package-local inventory and exercise every resource loader."""
+
+    site_packages = site_packages.resolve(strict=True)
+    runtime_root = runtime_root.resolve(strict=True)
+    package_root = Path(str(resources.files("defenseclaw"))).resolve(strict=True)
+    canonical_package_path = site_packages / "defenseclaw"
+    is_junction = getattr(canonical_package_path, "is_junction", None)
+    if canonical_package_path.is_symlink() or (is_junction is not None and is_junction()):
+        raise PackagedV8ResourceError(
+            f"{label} DefenseClaw package root uses symlink or junction indirection: {canonical_package_path}"
+        )
+    canonical_package_root = canonical_package_path.resolve(strict=True)
+    if not canonical_package_root.is_dir():
+        raise PackagedV8ResourceError(f"{label} DefenseClaw package root is not a directory: {canonical_package_root}")
+    if package_root != canonical_package_root:
+        raise PackagedV8ResourceError(
+            f"DefenseClaw resources did not resolve to the canonical {label} package root: "
+            f"actual={package_root} expected={canonical_package_root}"
+        )
+
+    _validate_inventory(package_root, runtime_root, label=label)
+
+    from defenseclaw.observability.schema_resources import (
+        telemetry_v8_catalog_bytes,
+        telemetry_v8_compatibility_profile_bytes,
+        telemetry_v8_schema_bytes,
+        v7_exporter_selection_bytes,
+    )
+    from defenseclaw.observability.v8_config import _schema_validator
+
+    _schema_validator()
+    for reference in ("observability.yaml", "observability.md"):
+        if not package_root.joinpath("_data/config/v8", reference).read_bytes():
+            raise PackagedV8ResourceError(f"{label} DefenseClaw v8 reference is empty: {reference}")
+
+    telemetry_payloads = {
+        "telemetry.schema.json": telemetry_v8_schema_bytes(),
+        "catalog.json": telemetry_v8_catalog_bytes(),
+        "v7-exporter-selection.json": v7_exporter_selection_bytes(),
+        "galileo-rich-v2.json": telemetry_v8_compatibility_profile_bytes("galileo-rich-v2"),
+        "local-observability-v1.json": telemetry_v8_compatibility_profile_bytes("local-observability-v1"),
+        "openinference-v1.json": telemetry_v8_compatibility_profile_bytes("openinference-v1"),
+    }
+    for name, payload in telemetry_payloads.items():
+        try:
+            json.loads(payload)
+        except (TypeError, ValueError) as exc:
+            raise PackagedV8ResourceError(f"{label} DefenseClaw v8 resource is not valid JSON: {name}") from exc
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--site-packages", required=True, type=Path)
+    parser.add_argument("--runtime-root", required=True, type=Path)
+    parser.add_argument("--label", required=True, choices=("staged", "packaged"))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        validate_packaged_v8_resources(
+            args.site_packages,
+            args.runtime_root,
+            label=args.label,
+        )
+    except (ImportError, OSError, PackagedV8ResourceError) as exc:
+        print(f"packaged v8 resource validation failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"validated nine package-local DefenseClaw v8 resources in {args.label} runtime")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/windows-native-ci.ps1
+++ b/scripts/windows-native-ci.ps1
@@ -55,7 +55,42 @@ function Protect-WindowsNativeText([AllowNull()][string]$Text) {
     if ($null -eq $Text) { return '' }
     $safe = $Text
     foreach ($value in Get-RedactionValues) { $safe = $safe.Replace($value, '***REDACTED***') }
-    return $safe -replace '(?im)(api[_-]?key|access[_-]?token|secret[_-]?key|authorization)\s*[:=]\s*\S+', '$1=***REDACTED***'
+
+    # Keep JSON structure intact while replacing the complete quoted value.
+    # This must run separately from the line-oriented HTTP-header rule below;
+    # otherwise one sensitive field could consume unrelated sibling keys.
+    $safe = [regex]::Replace(
+        $safe,
+        '(?i)(?<prefix>"(?:api[_-]?key|access[_-]?token|secret[_-]?key|authorization)"\s*:\s*")(?<value>(?:\\.|[^"\\])*)(?<suffix>")',
+        '${prefix}***REDACTED***${suffix}'
+    )
+
+    # Authorization credentials commonly contain a scheme and a credential
+    # separated by whitespace. Redact the entire header value, not just the
+    # first token. Limit this rule to an HTTP-style header line so prose and
+    # JSON content later on the same line are not swallowed.
+    $safe = [regex]::Replace(
+        $safe,
+        '(?im)(?<prefix>^[ \t]*[<>]?[ \t]*authorization[ \t]*:[ \t]*)[^\r\n]*',
+        '${prefix}***REDACTED***'
+    )
+
+    # Compact logs can render the same header inline with either separator.
+    # Consume a complete scheme-plus-credential pair, but stop at whitespace
+    # after the credential so unrelated diagnostic fields remain visible.
+    $safe = [regex]::Replace(
+        $safe,
+        '(?im)(?<prefix>\bauthorization\b[ \t]*[:=][ \t]*)(?:"(?:\\.|[^"\\])*"|''(?:\\.|[^''\\])*''|[A-Za-z][A-Za-z0-9._~+/-]*[ \t]+[^\s,;]+|[^\s,;]+)',
+        '${prefix}***REDACTED***'
+    )
+
+    # Preserve the existing key/value protection for compact diagnostics such
+    # as ``api_key=...``.
+    return [regex]::Replace(
+        $safe,
+        '(?im)(?<prefix>\b(?:api[_-]?key|access[_-]?token|secret[_-]?key)\b\s*[:=]\s*)(?:"(?:\\.|[^"\\])*"|''(?:\\.|[^''\\])*''|\S+)',
+        '${prefix}***REDACTED***'
+    )
 }
 
 function Assert-NativeWindowsX64 {
@@ -361,10 +396,38 @@ function Initialize-WindowsNativeTestEnvironment([string]$Root) {
 }
 
 function Limit-WindowsNativeText([AllowNull()][string]$Text, [int]$MaxBytes = 1048576) {
+    if ($MaxBytes -lt 0) { throw 'MaxBytes must be non-negative' }
     $safe = Protect-WindowsNativeText $Text
     $bytes = [Text.Encoding]::UTF8.GetBytes($safe)
     if ($bytes.Length -le $MaxBytes) { return $safe }
-    return [Text.Encoding]::UTF8.GetString($bytes, 0, $MaxBytes) + "`n[truncated]`n"
+
+    $markerBytes = [Text.Encoding]::UTF8.GetBytes("`n[truncated]`n")
+    if ($markerBytes.Length -ge $MaxBytes) {
+        return [Text.Encoding]::UTF8.GetString($markerBytes, 0, $MaxBytes)
+    }
+
+    # Preserve the start for command context and give two thirds of the
+    # remaining budget to the tail, where test runners emit their failure.
+    $contentBudget = $MaxBytes - $markerBytes.Length
+    $headBudget = [int][Math]::Floor($contentBudget / 3)
+    $tailBudget = $contentBudget - $headBudget
+
+    # A byte budget can land inside a multi-byte UTF-8 scalar. Move each cut
+    # to a code-point boundary so decoding never inserts a replacement rune.
+    $headLength = $headBudget
+    while ($headLength -gt 0 -and $headLength -lt $bytes.Length -and
+        (($bytes[$headLength] -band 0xC0) -eq 0x80)) {
+        $headLength--
+    }
+    $tailStart = $bytes.Length - $tailBudget
+    while ($tailStart -lt $bytes.Length -and
+        (($bytes[$tailStart] -band 0xC0) -eq 0x80)) {
+        $tailStart++
+    }
+
+    $head = [Text.Encoding]::UTF8.GetString($bytes, 0, $headLength)
+    $tail = [Text.Encoding]::UTF8.GetString($bytes, $tailStart, $bytes.Length - $tailStart)
+    return $head + [Text.Encoding]::UTF8.GetString($markerBytes) + $tail
 }
 
 function Write-BoundedText([string]$Path, [AllowNull()][string]$Text, [int]$MaxBytes = 1048576) {
@@ -1474,73 +1537,17 @@ print(f'validated {len(projects)} unique managed distributions')
 }
 
 function Assert-PackagedV8ResourceContract([string]$Python, [string]$RuntimeRoot) {
-    $code = @'
-import json
-import pathlib
-import sys
-from importlib import resources
-
-runtime_root = pathlib.Path(sys.argv[1]).resolve()
-site_packages = (runtime_root / 'Lib' / 'site-packages').resolve()
-package_root = pathlib.Path(str(resources.files('defenseclaw'))).resolve()
-try:
-    package_root.relative_to(site_packages)
-except ValueError as exc:
-    raise SystemExit(f'DefenseClaw resources resolved outside packaged site-packages: {package_root}') from exc
-if (runtime_root / 'Lib' / 'schemas').exists():
-    raise SystemExit('packaged runtime unexpectedly contains a Lib/schemas fallback tree')
-
-expected_v8 = {
-    '_data/config/v8': {
-        'defenseclaw-config.schema.json', 'observability.yaml', 'observability.md',
-    },
-    '_data/telemetry/v8': {
-        'telemetry.schema.json', 'catalog.json', 'v7-exporter-selection.json',
-        'galileo-rich-v2.json', 'local-observability-v1.json', 'openinference-v1.json',
-    },
-}
-for relative, expected_names in expected_v8.items():
-    directory = package_root.joinpath(relative)
-    children = list(directory.iterdir())
-    actual_names = {entry.name for entry in children}
-    non_files = sorted(
-        entry.name for entry in children if entry.is_symlink() or not entry.is_file()
-    )
-    if non_files or actual_names != expected_names:
-        raise SystemExit(
-            f'packaged DefenseClaw v8 resource inventory mismatch in {relative}: '
-            f'actual={sorted(actual_names)!r} expected={sorted(expected_names)!r} '
-            f'non_files={non_files!r}'
-        )
-
-from defenseclaw.observability.v8_config import _schema_validator
-from defenseclaw.observability.schema_resources import (
-    telemetry_v8_catalog_bytes,
-    telemetry_v8_compatibility_profile_bytes,
-    telemetry_v8_schema_bytes,
-    v7_exporter_selection_bytes,
-)
-
-_schema_validator()
-for reference in ('observability.yaml', 'observability.md'):
-    if not package_root.joinpath('_data/config/v8', reference).read_bytes():
-        raise SystemExit(f'packaged DefenseClaw v8 reference is empty: {reference}')
-telemetry_payloads = {
-    'telemetry.schema.json': telemetry_v8_schema_bytes(),
-    'catalog.json': telemetry_v8_catalog_bytes(),
-    'v7-exporter-selection.json': v7_exporter_selection_bytes(),
-    'galileo-rich-v2.json': telemetry_v8_compatibility_profile_bytes('galileo-rich-v2'),
-    'local-observability-v1.json': telemetry_v8_compatibility_profile_bytes('local-observability-v1'),
-    'openinference-v1.json': telemetry_v8_compatibility_profile_bytes('openinference-v1'),
-}
-for name, payload in telemetry_payloads.items():
-    try:
-        json.loads(payload)
-    except (TypeError, ValueError) as exc:
-        raise SystemExit(f'packaged DefenseClaw v8 resource is not valid JSON: {name}') from exc
-print('validated nine package-local DefenseClaw v8 resources without a Lib/schemas fallback')
-'@
-    Invoke-Installed $Python @('-I', '-c', $code, $RuntimeRoot) -Timeout 120 | Out-Null
+    $validator = Join-Path $WorkspaceRoot 'scripts\validate_packaged_v8_resources.py'
+    if (-not (Test-Path -LiteralPath $validator -PathType Leaf)) {
+        throw "Packaged v8 resource validator is missing: $validator"
+    }
+    $sitePackages = Join-Path $RuntimeRoot 'Lib\site-packages'
+    Invoke-Installed $Python @(
+        '-I', $validator,
+        '--site-packages', $sitePackages,
+        '--runtime-root', $RuntimeRoot,
+        '--label', 'packaged'
+    ) -Timeout 120 | Out-Null
 }
 
 function Add-DamagedManagedEnvironmentFixture([object]$Profile) {
@@ -4944,6 +4951,25 @@ function Stop-StateProcesses([string]$Root) {
     if ($remaining.Count) { throw "isolated process cleanup timed out: $($remaining -join ', ')" }
 }
 
+function Get-WindowsNativeCaptureFiles([string]$Root) {
+    if (-not (Test-Path -LiteralPath $Root)) { return @() }
+    return @(
+        Get-ChildItem -LiteralPath $Root -Recurse -File -ErrorAction SilentlyContinue |
+            Where-Object {
+                $_.Name -match '^(gateway|watchdog|results|doctor|.*\.log)' -and
+                    $_.Length -le 1048576
+            } |
+            Sort-Object @{
+                Expression = {
+                    if ($_.Name -eq 'wizard-driver.log') { 0 }
+                    elseif ($_.Name -eq 'go-test.log') { 1 }
+                    else { 2 }
+                }
+            }, FullName |
+            Select-Object -First 30
+    )
+}
+
 function Invoke-Capture {
     $root = Assert-SafeStateRoot $StateRoot
     $destination = if ($DiagnosticsRoot) {
@@ -4965,12 +4991,7 @@ function Invoke-Capture {
     }
     Write-BoundedText (Join-Path $destination 'listeners.txt') ($listeners -join [Environment]::NewLine)
     if (Test-Path -LiteralPath $root) {
-        $interesting = Get-ChildItem -LiteralPath $root -Recurse -File -ErrorAction SilentlyContinue | Where-Object {
-            $_.Name -match '^(gateway|watchdog|results|doctor|.*\.log)' -and $_.Length -le 1048576
-        } | Sort-Object @{
-            Expression = { if ($_.Name -eq 'wizard-driver.log') { 0 } else { 1 } }
-        }, FullName | Select-Object -First 30
-        foreach ($file in $interesting) {
+        foreach ($file in @(Get-WindowsNativeCaptureFiles $root)) {
             $relative = [IO.Path]::GetRelativePath($root, $file.FullName) -replace '[\\/:*?"<>|]', '_'
             Write-BoundedText (Join-Path $destination $relative) ([IO.File]::ReadAllText($file.FullName))
         }
@@ -5020,6 +5041,95 @@ function Invoke-SelfTest {
         }
     }
     if (-not (Test-Path -LiteralPath (Join-Path $root 'tools\uv.exe') -PathType Leaf)) { throw 'uv was not isolated' }
+
+    $boundedLimit = 256
+    $boundedSecret = 'bounded-secret-value'
+    $captureFixture = Join-Path $root 'bounded-capture-selection'
+    $originalBoundedSecret = [Environment]::GetEnvironmentVariable('DC_E2E_TEST_SECRET')
+    try {
+        $env:DC_E2E_TEST_SECRET = $boundedSecret
+        $headerSecret = 'header-bearer-secret'
+        $inlineEqualsSecret = 'inline-equals-bearer-secret'
+        $inlineColonSecret = 'inline-colon-bearer-secret'
+        $jsonSecret = 'json-bearer-secret'
+        $jsonApiKeySecret = 'json-api-key-secret'
+        $redactionProbe = @(
+            "Authorization: Bearer $headerSecret",
+            "trace authorization=Bearer $inlineEqualsSecret status=preserve",
+            "trace Authorization: Bearer $inlineColonSecret status=preserve",
+            ('{"authorization": "Bearer ' + $jsonSecret + '", "status": "preserve"}'),
+            ('{"api_key": "' + $jsonApiKeySecret + '", "status": "preserve"}'),
+            "environment-secret=$boundedSecret"
+        ) -join [Environment]::NewLine
+        $redactedProbe = Protect-WindowsNativeText $redactionProbe
+        if ($redactedProbe.Contains($headerSecret) -or
+            $redactedProbe.Contains($inlineEqualsSecret) -or
+            $redactedProbe.Contains($inlineColonSecret) -or
+            $redactedProbe.Contains($jsonSecret) -or
+            $redactedProbe.Contains($jsonApiKeySecret) -or
+            $redactedProbe.Contains($boundedSecret)) {
+            throw 'native diagnostic redaction leaked a header, JSON, or environment secret'
+        }
+        if (-not $redactedProbe.Contains('Authorization: ***REDACTED***') -or
+            -not $redactedProbe.Contains('trace authorization=***REDACTED*** status=preserve') -or
+            -not $redactedProbe.Contains('trace Authorization: ***REDACTED*** status=preserve') -or
+            -not $redactedProbe.Contains('{"authorization": "***REDACTED***", "status": "preserve"}') -or
+            -not $redactedProbe.Contains('{"api_key": "***REDACTED***", "status": "preserve"}') -or
+            -not $redactedProbe.Contains('environment-secret=***REDACTED***')) {
+            throw 'native diagnostic redaction damaged structure or omitted a supported credential form'
+        }
+
+        $boundedInput = 'HEAD authorization=' + $boundedSecret + ' ' +
+            ('unicode-漢🚀-' * 80) + 'TAIL decisive failure'
+        $bounded = Limit-WindowsNativeText $boundedInput $boundedLimit
+        $boundedBytes = [Text.Encoding]::UTF8.GetByteCount($bounded)
+        if ($boundedBytes -gt $boundedLimit) {
+            throw "bounded native text exceeded ${boundedLimit} UTF-8 bytes: $boundedBytes"
+        }
+        if (-not $bounded.StartsWith('HEAD authorization=***REDACTED***') -or
+            -not $bounded.EndsWith('TAIL decisive failure')) {
+            throw 'bounded native text did not retain both diagnostic head and failure tail'
+        }
+        if ($bounded -notmatch '(?m)^\[truncated\]$' -or
+            $bounded.Contains($boundedSecret) -or $bounded.Contains([char]0xFFFD)) {
+            throw 'bounded native text lost truncation, redaction, or UTF-8 integrity guarantees'
+        }
+
+        [IO.Directory]::CreateDirectory($captureFixture) | Out-Null
+        $boundedPath = Join-Path $captureFixture 'go-test.log'
+        Write-BoundedText $boundedPath $boundedInput $boundedLimit
+        if ([IO.FileInfo]::new($boundedPath).Length -gt $boundedLimit) {
+            throw 'bounded diagnostic file is too large for native capture'
+        }
+        foreach ($index in 0..30) {
+            Write-BoundedText (Join-Path $captureFixture ("00-before-go-test-{0:D2}.log" -f $index)) 'decoy'
+        }
+        $oversizedPath = Join-Path $captureFixture '00-oversized.log'
+        $oversized = [IO.File]::Open(
+            $oversizedPath,
+            [IO.FileMode]::CreateNew,
+            [IO.FileAccess]::Write,
+            [IO.FileShare]::None
+        )
+        try { $oversized.SetLength(1048577) } finally { $oversized.Dispose() }
+
+        $captureFiles = @(Get-WindowsNativeCaptureFiles $root)
+        if (-not ($captureFiles | Where-Object {
+            $_.FullName.Equals($boundedPath, [StringComparison]::OrdinalIgnoreCase)
+        })) {
+            throw 'bounded go-test.log was not prioritized into native capture'
+        }
+        if ($captureFiles | Where-Object {
+            $_.FullName.Equals($oversizedPath, [StringComparison]::OrdinalIgnoreCase)
+        }) {
+            throw 'oversized diagnostic bypassed the native capture size guard'
+        }
+    } finally {
+        [Environment]::SetEnvironmentVariable('DC_E2E_TEST_SECRET', $originalBoundedSecret)
+        if (Test-Path -LiteralPath $captureFixture) {
+            Remove-SafeDisposableTree -Path $captureFixture -Root $root
+        }
+    }
 
     $healthyOutput = [Threading.Tasks.TaskCompletionSource[string]]::new()
     $healthyOutput.SetResult('complete')


### PR DESCRIPTION
## Stack

This draft PR is stacked directly on #576 and targets `windows-release-packaging`. Its base SHA is PR576's current head, so it contains only the additional release and CI hardening and must not merge into `main` independently.

## Why

PR576 restores the Windows release path and downloadable `DefenseClawSetup-x64.exe`. Final review found remaining fail-closed gaps in wheel/resource validation, and native CI needed a hermetic gateway recovery test plus safer bounded diagnostics.

## Changes

- Reject numeric/hash NTFS 8.3 package-root aliases and raw Windows path ambiguities before wheel extraction, including absolute/UNC/drive paths, dot segments, trailing aliases, forbidden characters, reserved device names, and case-insensitive collisions.
- Replace duplicated staged/packaged V8 checks with one shared validator enforcing the exact nine-file inventory, regular files only, loader/JSON validity, no `Lib/schemas` fallback, and the canonical `site-packages/defenseclaw` import root.
- Carry that validator into the immutable disposable standard-user Setup workspace and keep all release-sensitive CI path policies synchronized.
- Make native diagnostics UTF-8 byte-bounded, head/tail preserving, capture-count limited, and safe against Authorization/header/JSON/environment secret leakage.
- Make the Windows gateway recovery acceptance hermetic with Python `-S`, the direct fail-mode report API, actual Sidecar owner-wait synchronization, successful guard-heal notification, and production-bounded deadlines.

## Validation

- [Core CI](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29865851131): all Python, gateway, Go race/coverage, schema/parity, connector, release, and selective-upgrade gates passed; Python shard 0 reported 2100 passed and 49 skipped.
- [Windows Native CI](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29865851070): all jobs passed, including the PowerShell harness, packaged Setup build, wizard responsiveness, connector contracts, all Python shards, full native Go test/vet/build, and the [Setup install/CLI-TUI smoke/repair/uninstall lifecycle](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29865851070/job/88756382635).
- [Connector Live E2E](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29865850610) and [macOS App](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29865850975): passed.
- Local Windows gateway package in the protected native-CI environment: passed in 343.692s; changed recovery test also passed 3/3 stress runs.
- Local focused suites: 20 release-candidate tests, 41 installer/V8 mutation tests, and 94 policy/resource/claims/path tests passed; PowerShell parsing and diff hygiene passed.

## Release outcome

After PR576 and this stack land, the controlled post-merge Release workflow requires real Cisco Authenticode credentials, timestamps and validates the signed installer, certifies its lifecycle with real Windows clients, and publishes the final downloadable `DefenseClawSetup-x64.exe` asset. PR CI intentionally builds an unsigned release-shaped installer; Windows ARM64 remains gateway-only and the installer is Windows x64.