### PR TITLE
fix(managed_enterprise): surface hook alerts/scans on IPC stats API

### DIFF
--- a/internal/audit/network_egress_test.go
+++ b/internal/audit/network_egress_test.go
@@ -398,6 +398,82 @@ func TestStore_GetCounts_IncludesBlockedEgress(t *testing.T) {
 	}
 }
 
+// TestStore_GetCounts_AlertsIncludesConnectorHookEnvelopeSeverity is the
+// regression pin for the IPC ActiveAlerts stat surface. Connector-hook
+// rows land with severity=INFO on the column (a deliberate
+// noise-reduction choice in gateway.logConnectorHookAuditEnvelope — every
+// tool call produces one) while the real verdict severity lives on the
+// structured_json envelope. Counts.Alerts feeds the IPC GetStatsSnapshot
+// ActiveAlerts field; before this branch was added the counter stayed at
+// zero in managed_enterprise, where hook inspections are the sole
+// enforcement path.
+func TestStore_GetCounts_AlertsIncludesConnectorHookEnvelopeSeverity(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	// Non-hook row with a real severity — counts via the column branch.
+	if err := store.LogEvent(Event{
+		Action:   "guardrail-inspection",
+		Target:   "gpt-5",
+		Severity: "HIGH",
+	}); err != nil {
+		t.Fatalf("LogEvent guardrail: %v", err)
+	}
+
+	// Benign connector-hook row: column=INFO, envelope severity=NONE.
+	// Must NOT count as an alert.
+	if err := store.LogEvent(Event{
+		Action:   "connector-hook",
+		Target:   "PreToolUse",
+		Severity: "INFO",
+		Structured: map[string]any{
+			"schema":   "defenseclaw.hook.v1",
+			"severity": "NONE",
+		},
+	}); err != nil {
+		t.Fatalf("LogEvent hook NONE: %v", err)
+	}
+
+	// Real block from a hook: column=INFO, envelope severity=HIGH.
+	// This is the row that used to be invisible; must now count.
+	if err := store.LogEvent(Event{
+		Action:   "connector-hook",
+		Target:   "PreToolUse",
+		Severity: "INFO",
+		Structured: map[string]any{
+			"schema":   "defenseclaw.hook.v1",
+			"severity": "HIGH",
+			"action":   "block",
+		},
+	}); err != nil {
+		t.Fatalf("LogEvent hook HIGH: %v", err)
+	}
+
+	// Critical hook row for good measure.
+	if err := store.LogEvent(Event{
+		Action:   "connector-hook",
+		Target:   "PreToolUse",
+		Severity: "INFO",
+		Structured: map[string]any{
+			"schema":   "defenseclaw.hook.v1",
+			"severity": "CRITICAL",
+			"action":   "block",
+		},
+	}); err != nil {
+		t.Fatalf("LogEvent hook CRITICAL: %v", err)
+	}
+
+	counts, err := store.GetCounts()
+	if err != nil {
+		t.Fatalf("GetCounts: %v", err)
+	}
+	// Expected: 1 (guardrail HIGH via column) + 2 (hook HIGH/CRITICAL via
+	// JSON) = 3. The benign hook row is excluded.
+	if counts.Alerts != 3 {
+		t.Errorf("Alerts = %d, want 3 (column-severity + hook envelope-severity)", counts.Alerts)
+	}
+}
+
 // --- Logger ---
 
 func TestLogger_LogNetworkEgress(t *testing.T) {

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -2866,7 +2866,22 @@ func (s *Store) GetCounts() (Counts, error) {
 		{`SELECT COUNT(*) FROM actions WHERE target_type = 'skill' AND json_extract(actions_json, '$.install') = 'allow'`, &c.AllowedSkills},
 		{`SELECT COUNT(*) FROM actions WHERE target_type = 'mcp' AND json_extract(actions_json, '$.install') = 'block'`, &c.BlockedMCPs},
 		{`SELECT COUNT(*) FROM actions WHERE target_type = 'mcp' AND json_extract(actions_json, '$.install') = 'allow'`, &c.AllowedMCPs},
-		{`SELECT COUNT(*) FROM audit_events WHERE severity IN ('CRITICAL','HIGH','MEDIUM','LOW')`, &c.Alerts},
+		// Alerts feeds the IPC GetStatsSnapshot ActiveAlerts field. The
+		// severity column is the primary source, but connector-hook rows
+		// are hardcoded to INFO on the column (see
+		// gateway.logConnectorHookAuditEnvelope — a deliberate
+		// noise-reduction choice because every tool call produces a row).
+		// The real verdict severity for those rows lives on the
+		// structured_json envelope, so we OR in a JSON-extract branch
+		// scoped to action='connector-hook' to pick up enforced blocks /
+		// high-severity findings that would otherwise be invisible on the
+		// IPC stat (the managed_enterprise deployment mode's sole
+		// enforcement path is hooks, which is where this used to pin at 0).
+		// The two branches are disjoint by column value, so no double-count.
+		{`SELECT COUNT(*) FROM audit_events
+			 WHERE severity IN ('CRITICAL','HIGH','MEDIUM','LOW')
+			    OR (action = 'connector-hook'
+			        AND json_extract(structured_json, '$.severity') IN ('CRITICAL','HIGH','MEDIUM','LOW'))`, &c.Alerts},
 		{`SELECT COUNT(*) FROM scan_results`, &c.TotalScans},
 		{`SELECT COUNT(*) FROM network_egress_events WHERE blocked = 1`, &c.BlockedEgressCalls},
 	}

--- a/internal/gateway/inspect.go
+++ b/internal/gateway/inspect.go
@@ -299,6 +299,29 @@ func mergeWithLaneVerdict(local *ToolInspectVerdict, aid *ScanVerdict, findingTa
 		for _, f := range aid.Findings {
 			local.Findings = append(local.Findings, findingTag+f)
 		}
+		// Synthesize structured DetailedFindings from each lane finding so
+		// the downstream emission pipeline (emitInspectVerdictFindings →
+		// scanner.EmitInspectFindings → EmitScanResult) writes a
+		// scan_results row and per-finding scan_findings rows. Without
+		// this, the AID / LLM-judge lanes only populated the stringy
+		// Findings slice, emitInspectVerdictFindings early-returned on
+		// empty DetailedFindings, and managed_enterprise deployments
+		// (where AID is the sole detector) never advanced total_scans on
+		// the IPC stats surface even though every hook call ran an
+		// inspection. Severity comes from the lane verdict; RuleID uses
+		// the raw finding name so SIEM pivots by rule_id work identically
+		// across the AID / judge / regex lanes. Confidence stays at 0
+		// (lane doesn't self-report one); the emitter treats zero as
+		// "not computed" and omits it on the wire.
+		for _, f := range aid.Findings {
+			rf := RuleFinding{
+				RuleID:   findingTag + f,
+				Title:    f,
+				Severity: aid.Severity,
+				Tags:     []string{strings.TrimSuffix(findingTag, ":")},
+			}
+			local.DetailedFindings = append(local.DetailedFindings, rf)
+		}
 	}
 	if aid.Reason != "" {
 		if local.Reason != "" {

--- a/internal/gateway/inspect_aid_lane_test.go
+++ b/internal/gateway/inspect_aid_lane_test.go
@@ -239,6 +239,88 @@ func TestMergeWithAIDVerdict_StrictestWins(t *testing.T) {
 	})
 }
 
+// TestMergeWithLaneVerdict_SynthesizesDetailedFindings pins the fix for
+// the IPC total_scans stat: the AID / LLM-judge lanes only populate the
+// stringy verdict.Findings slice, so before this synthesis step
+// emitInspectVerdictFindings early-returned on empty DetailedFindings and
+// no scan_results row was ever written for a managed_enterprise hook
+// inspection — total_scans stayed at 0 even though every hook call ran
+// an inspection. The merge helper must synthesize one DetailedFinding
+// per lane finding so the downstream pipeline persists a scan row.
+func TestMergeWithLaneVerdict_SynthesizesDetailedFindings(t *testing.T) {
+	t.Run("aid_findings_become_detailed_findings", func(t *testing.T) {
+		aid := &ScanVerdict{
+			Action:   "block",
+			Severity: "HIGH",
+			Findings: []string{"pii.email", "policy.jira"},
+		}
+		merged := mergeWithAIDVerdict(nil, aid)
+		if len(merged.DetailedFindings) != 2 {
+			t.Fatalf("DetailedFindings = %d, want 2 (one per AID finding)", len(merged.DetailedFindings))
+		}
+		got := merged.DetailedFindings[0]
+		if got.RuleID != "ai-defense:pii.email" {
+			t.Errorf("RuleID = %q, want ai-defense:pii.email", got.RuleID)
+		}
+		if got.Title != "pii.email" {
+			t.Errorf("Title = %q, want pii.email", got.Title)
+		}
+		if got.Severity != "HIGH" {
+			t.Errorf("Severity = %q, want HIGH (from verdict)", got.Severity)
+		}
+		if len(got.Tags) != 1 || got.Tags[0] != "ai-defense" {
+			t.Errorf("Tags = %v, want [ai-defense]", got.Tags)
+		}
+	})
+
+	t.Run("judge_findings_become_detailed_findings_with_judge_tag", func(t *testing.T) {
+		judge := &ScanVerdict{
+			Action:   "alert",
+			Severity: "MEDIUM",
+			Findings: []string{"prompt_injection"},
+		}
+		merged := mergeWithJudgeVerdict(nil, judge)
+		if len(merged.DetailedFindings) != 1 {
+			t.Fatalf("DetailedFindings = %d, want 1", len(merged.DetailedFindings))
+		}
+		if got := merged.DetailedFindings[0].RuleID; got != "llm-judge:prompt_injection" {
+			t.Errorf("RuleID = %q, want llm-judge:prompt_injection", got)
+		}
+		if got := merged.DetailedFindings[0].Tags; len(got) != 1 || got[0] != "llm-judge" {
+			t.Errorf("Tags = %v, want [llm-judge]", got)
+		}
+	})
+
+	t.Run("no_findings_no_synthesis", func(t *testing.T) {
+		aid := &ScanVerdict{Action: "block", Severity: "HIGH"}
+		merged := mergeWithAIDVerdict(nil, aid)
+		if len(merged.DetailedFindings) != 0 {
+			t.Errorf("DetailedFindings = %d, want 0 when lane returned no findings", len(merged.DetailedFindings))
+		}
+	})
+
+	t.Run("preserves_existing_detailed_findings", func(t *testing.T) {
+		local := &ToolInspectVerdict{
+			Action:   "alert",
+			Severity: "MEDIUM",
+			DetailedFindings: []RuleFinding{
+				{RuleID: "LOCAL-1", Severity: "MEDIUM"},
+			},
+		}
+		aid := &ScanVerdict{Action: "block", Severity: "HIGH", Findings: []string{"pii.email"}}
+		merged := mergeWithAIDVerdict(local, aid)
+		if len(merged.DetailedFindings) != 2 {
+			t.Fatalf("DetailedFindings = %d, want 2 (local + synthesized)", len(merged.DetailedFindings))
+		}
+		if merged.DetailedFindings[0].RuleID != "LOCAL-1" {
+			t.Errorf("local finding not preserved at head: %+v", merged.DetailedFindings)
+		}
+		if merged.DetailedFindings[1].RuleID != "ai-defense:pii.email" {
+			t.Errorf("synthesized finding not appended: %+v", merged.DetailedFindings)
+		}
+	})
+}
+
 // TestInspectToolPolicy_AIDLaneFiresWhenLocalAllow drives the full
 // inspectToolPolicy path end-to-end with no local-rule match,
 // asserting that an AID Block escalates the verdict from allow to


### PR DESCRIPTION
## Summary

In `managed_enterprise` deployments, both `ActiveAlerts` and `TotalScans` on the IPC `GetStatsSnapshot` RPC stayed pinned at 0 even while connector hooks (Claude Code / Codex / agent hook) actively inspected and blocked traffic. Two independent gaps in the audit pipeline caused it — one for each counter.

### ActiveAlerts gap

`gateway.logConnectorHookAuditEnvelope` hardcodes `audit_events.severity=INFO` on every hook row — a deliberate noise-reduction choice since every tool call produces one. The real verdict severity already lives on the row's `structured_json` envelope, but `audit.Counts.Alerts` only queries the severity **column**, so hook-driven blocks were invisible to the IPC stat.

**Fix:** teach `Store.GetCounts()` to OR in a JSON-extract branch scoped to `action='connector-hook'` so it picks up the envelope severity that's already there. Column branch and JSON branch are disjoint by column value — no double-count. Every other consumer (sinks, `ListAlerts`, `AcknowledgeAlerts`) keeps its historical shape.

### TotalScans gap

In managed_enterprise the hook lane runs through `inspectManagedAIDOnly` → `mergeWithAIDVerdict(nil, aid)`, which populates only the stringy `verdict.Findings` slice, never the structured `DetailedFindings`. `emitInspectVerdictFindings` early-returns on empty `DetailedFindings`, so `scanner.EmitInspectFindings` → `EmitScanResult` → `InsertScanSummary` never fired for a hook inspection and `scan_results` never grew.

**Fix:** synthesize one `RuleFinding` per lane finding in `mergeWithLaneVerdict` (RuleID = `<tag>:<name>`, Severity carried from the lane verdict) so the downstream emission pipeline persists a `scan_results` row for every real AID / LLM-judge hit. Applies symmetrically to the LLM-judge lane — same code path, same gap.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/audit/...` — new `TestStore_GetCounts_AlertsIncludesConnectorHookEnvelopeSeverity` covers the JSON-extract branch (guardrail HIGH via column + hook HIGH/CRITICAL via envelope = 3 alerts; benign hook NONE excluded)
- [x] `go test ./internal/gateway/...` — new `TestMergeWithLaneVerdict_SynthesizesDetailedFindings` with four subtests: AID findings → tagged `DetailedFindings`; judge findings → judge-tagged; no findings → no synthesis; existing local `DetailedFindings` preserved and appended to
- [x] `go test ./internal/ipc/...` and `go test ./internal/scanner/...` — no regressions
- [ ] Verify against a real managed_enterprise install with hooks active: run a blocking inspection, confirm `ActiveAlerts` and `TotalScans` both increment on `GetStatsSnapshot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)