### PR TITLE
Fix release archive topology for x64 Setup

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,9 +11,46 @@ builds:
     goos:
       - linux
       - darwin
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -buildid=defenseclaw-{{.Commit}}-{{.Os}}-{{.Arch}} -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+    hooks:
+      post:
+        - cmd: go run ./internal/tools/windowsresources -target {{ .Os }}_{{ .Arch }} -executable "{{ .Path }}" -component gateway -version {{ .Version }} -icon macos/DefenseClawMac/DefenseClawMac/Assets.xcassets/AppIcon.appiconset/icon_256.png
+          output: true
+
+  - id: defenseclaw-windows-amd64
+    main: ./cmd/defenseclaw
+    binary: defenseclaw
+    env:
+      - CGO_ENABLED=0
+    goos:
       - windows
     goarch:
       - amd64
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w -buildid=defenseclaw-{{.Commit}}-{{.Os}}-{{.Arch}} -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+    hooks:
+      post:
+        - cmd: go run ./internal/tools/windowsresources -target {{ .Os }}_{{ .Arch }} -executable "{{ .Path }}" -component gateway -version {{ .Version }} -icon macos/DefenseClawMac/DefenseClawMac/Assets.xcassets/AppIcon.appiconset/icon_256.png
+          output: true
+
+  - id: defenseclaw-windows-arm64
+    main: ./cmd/defenseclaw
+    binary: defenseclaw
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - windows
+    goarch:
       - arm64
     flags:
       - -trimpath
@@ -46,16 +83,39 @@ builds:
 
 archives:
   - id: default
-    # tar.gz everywhere except Windows, which ships .zip (the native archive
-    # format Windows users and PowerShell's Expand-Archive expect). Windows
-    # archives contain defenseclaw.exe plus the GUI-subsystem
-    # defenseclaw-hook.exe; scripts/install.ps1 installs both.
+    ids:
+      - defenseclaw
     formats:
       - tar.gz
-    format_overrides:
-      - goos: windows
-        formats:
-          - zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE*
+      - README*
+      - CHANGELOG.md
+      - packaging/**/*
+
+  - id: windows-amd64
+    # Keep the internal GUI-subsystem hook beside the x64 gateway so the
+    # native installer can stage both binaries from one canonical archive.
+    ids:
+      - defenseclaw-windows-amd64
+      - defenseclaw-hook
+    formats:
+      - zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE*
+      - README*
+      - CHANGELOG.md
+      - packaging/**/*
+
+  - id: windows-arm64
+    # Existing clients require the ARM64 gateway entry in the internal release
+    # manifest, but ARM64 is not part of the certified native installer.
+    ids:
+      - defenseclaw-windows-arm64
+    formats:
+      - zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE*

--- a/cli/tests/test_windows_release_claims.py
+++ b/cli/tests/test_windows_release_claims.py
@@ -5,6 +5,8 @@
 
 from pathlib import Path
 
+import yaml
+
 from defenseclaw.platform_support import (
     WINDOWS_CERTIFIED_ARCHITECTURES,
     WINDOWS_NOT_CERTIFIED_ARCHITECTURES,
@@ -73,11 +75,46 @@ def test_windows_guide_has_unambiguous_claims_and_powershell_examples() -> None:
         assert label in text
 
 
-def test_release_runtime_custody_includes_arm64_without_certifying_arm64_setup() -> None:
-    release = (ROOT / ".goreleaser.yaml").read_text(encoding="utf-8")
-    assert "goos:\n      - linux\n      - darwin\n      - windows" in release
-    assert "goarch:\n      - amd64\n      - arm64" in release
-    assert "ignore:\n      - goos: windows\n        goarch: arm64" not in release
+def test_release_runtime_custody_splits_certified_x64_from_compatibility_arm64() -> None:
+    release = yaml.safe_load((ROOT / ".goreleaser.yaml").read_text(encoding="utf-8"))
+    builds = {build["id"]: build for build in release["builds"]}
+
+    assert set(builds) == {
+        "defenseclaw",
+        "defenseclaw-windows-amd64",
+        "defenseclaw-windows-arm64",
+        "defenseclaw-hook",
+    }
+    assert builds["defenseclaw"]["goos"] == ["linux", "darwin"]
+    assert builds["defenseclaw"]["goarch"] == ["amd64", "arm64"]
+    assert builds["defenseclaw-windows-amd64"]["goos"] == ["windows"]
+    assert builds["defenseclaw-windows-amd64"]["goarch"] == ["amd64"]
+    assert builds["defenseclaw-windows-arm64"]["goos"] == ["windows"]
+    assert builds["defenseclaw-windows-arm64"]["goarch"] == ["arm64"]
+    assert builds["defenseclaw-hook"]["goos"] == ["windows"]
+    assert builds["defenseclaw-hook"]["goarch"] == ["amd64"]
+
+    archives = {archive["id"]: archive for archive in release["archives"]}
+    canonical_name = "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    assert set(archives) == {"default", "windows-amd64", "windows-arm64"}
+    assert archives["default"]["ids"] == ["defenseclaw"]
+    assert archives["default"]["formats"] == ["tar.gz"]
+    assert archives["default"]["name_template"] == canonical_name
+    assert archives["windows-amd64"]["ids"] == [
+        "defenseclaw-windows-amd64",
+        "defenseclaw-hook",
+    ]
+    assert archives["windows-amd64"]["formats"] == ["zip"]
+    assert archives["windows-amd64"]["name_template"] == canonical_name
+    assert archives["windows-arm64"]["ids"] == ["defenseclaw-windows-arm64"]
+    assert archives["windows-arm64"]["formats"] == ["zip"]
+    assert archives["windows-arm64"]["name_template"] == canonical_name
+    assert all(
+        "defenseclaw-hook" not in archive["ids"]
+        for archive_id, archive in archives.items()
+        if archive_id != "windows-amd64"
+    )
+
     installer = (ROOT / "scripts/install.ps1").read_text(encoding="utf-8")
     assert '"ARM64" { Die "Windows ARM64 is not certified' in installer
     assert '"codex",\n    "claudecode",\n    "none"' in installer

--- a/internal/tools/windowsresources/main_test.go
+++ b/internal/tools/windowsresources/main_test.go
@@ -74,8 +74,8 @@ func TestGoReleaserHooksUseCanonicalWindowsTarget(t *testing.T) {
 	if err := scanner.Err(); err != nil {
 		t.Fatal(err)
 	}
-	if len(commands) != 2 {
-		t.Fatalf("GoReleaser Windows resource hook count = %d, want 2", len(commands))
+	if len(commands) != 4 {
+		t.Fatalf("GoReleaser Windows resource hook count = %d, want 4", len(commands))
 	}
 
 	for _, architecture := range []string{"amd64", "arm64"} {
@@ -121,9 +121,15 @@ func TestGoReleaserHooksUseCanonicalWindowsTarget(t *testing.T) {
 					t.Fatalf("hook %d selected %d supported components, want 1: %s", index, matches, actual)
 				}
 			}
+			expectedComponents := map[string]int{"gateway": 3, "hook": 1}
 			for component, count := range components {
-				if count != 1 {
-					t.Errorf("GoReleaser resource hooks for component %q = %d, want 1", component, count)
+				if count != expectedComponents[component] {
+					t.Errorf(
+						"GoReleaser resource hooks for component %q = %d, want %d",
+						component,
+						count,
+						expectedComponents[component],
+					)
 				}
 			}
 		})


### PR DESCRIPTION
## What changed

- Split the GoReleaser gateway builds into disjoint Unix, Windows x64, and Windows ARM64 compatibility groups.
- Package `defenseclaw.exe` and the internal `defenseclaw-hook.exe` together only in the Windows x64 ZIP consumed by native Setup.
- Keep the ARM64 gateway ZIP only inside the compatibility pipeline so existing 0.8.6 clients retain their signed manifest contract; raw Windows ZIPs remain excluded from publication.
- Strengthen Python and Go invariants around archive membership and resource hooks.

## Root cause

PR444 added the Windows-only hook binary to one cross-platform archive definition. GoReleaser v2.15.4 then saw two binaries for Windows x64 but one for every other platform and stopped with `archive has different count of binaries for each platform` before signing or installer creation.

## User impact

The release pipeline can now reach native installer signing and certification. The final GitHub Release still publishes exactly one Windows executable: `DefenseClawSetup-x64.exe`. The hook is embedded inside Setup and is not a second download; there is no ARM installer.

## Validation

- Pinned GoReleaser v2.15.4 snapshot release completed all builds, six archives, six SBOMs, and checksums.
- Verified x64 ZIP executables are exactly `defenseclaw.exe` and `defenseclaw-hook.exe`.
- Verified ARM compatibility ZIP contains only `defenseclaw.exe`.
- Verified release asset selection exposes exactly one `.exe`: `DefenseClawSetup-x64.exe`.
- `54 passed, 5 skipped` across focused Python release/packaging tests.
- `go test ./internal/tools/windowsresources ./internal/windowsresources` passed.
- `goreleaser check` and `git diff --check` passed.