### PR TITLE
Fix Windows release baseline handoff

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -754,6 +754,8 @@ jobs:
     name: Build and test signed native Windows Setup
     needs: [release-preflight, build-runtime-candidate]
     runs-on: windows-latest
+    env:
+      UPGRADE_BASELINE_POLICY: ${{ github.workspace }}/effective-upgrade-baselines.json
     environment: release
     permissions:
       contents: read
@@ -769,6 +771,11 @@ jobs:
           ref: ${{ needs.release-preflight.outputs.commit }}
           fetch-depth: 0
           persist-credentials: false
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ needs.release-preflight.outputs.baseline_artifact }}
+          path: .
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -274,12 +274,34 @@ def test_native_windows_setup_has_immutable_artifact_custody() -> None:
         assert "continue-on-error" not in str(job)
         assert job.get("if") != "${{ false }}"
 
+    installer_baseline_download = next(
+        step
+        for step in installer["steps"]
+        if step.get("with", {}).get("name")
+        == "${{ needs.release-preflight.outputs.baseline_artifact }}"
+    )
+    assert installer["env"]["UPGRADE_BASELINE_POLICY"] == (
+        "${{ github.workspace }}/effective-upgrade-baselines.json"
+    )
+    assert installer_baseline_download["with"]["path"] == "."
+
     installer_download = next(
-        step for step in installer["steps"] if step.get("uses", "").startswith("actions/download-artifact@")
+        step
+        for step in installer["steps"]
+        if step.get("with", {}).get("artifact-ids")
+        == "${{ needs.build-runtime-candidate.outputs.artifact_id }}"
     )
     assert installer_download["with"]["artifact-ids"] == ("${{ needs.build-runtime-candidate.outputs.artifact_id }}")
     assert installer_download["with"]["merge-multiple"] == "true"
     assert "needs.build-runtime-candidate.outputs.artifact_digest" in str(installer)
+
+    baseline_index = installer["steps"].index(installer_baseline_download)
+    extraction_index = next(
+        index
+        for index, step in enumerate(installer["steps"])
+        if step.get("name") == "Extract authenticated Windows installer inputs"
+    )
+    assert baseline_index < extraction_index
 
     certification_download = next(
         step for step in certification["steps"] if step.get("uses", "").startswith("actions/download-artifact@")

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -277,7 +277,8 @@ def test_native_windows_setup_has_immutable_artifact_custody() -> None:
     installer_baseline_download = next(
         step
         for step in installer["steps"]
-        if step.get("with", {}).get("name")
+        if step.get("uses", "").startswith("actions/download-artifact@")
+        and step.get("with", {}).get("name")
         == "${{ needs.release-preflight.outputs.baseline_artifact }}"
     )
     assert installer["env"]["UPGRADE_BASELINE_POLICY"] == (
@@ -288,7 +289,8 @@ def test_native_windows_setup_has_immutable_artifact_custody() -> None:
     installer_download = next(
         step
         for step in installer["steps"]
-        if step.get("with", {}).get("artifact-ids")
+        if step.get("uses", "").startswith("actions/download-artifact@")
+        and step.get("with", {}).get("artifact-ids")
         == "${{ needs.build-runtime-candidate.outputs.artifact_id }}"
     )
     assert installer_download["with"]["artifact-ids"] == ("${{ needs.build-runtime-candidate.outputs.artifact_id }}")


### PR DESCRIPTION
## What changed

- Download the authenticated `effective-upgrade-baselines.json` artifact in the Windows installer job.
- Bind `UPGRADE_BASELINE_POLICY` to that exact snapshot before runtime verification and installer-input extraction.
- Add a workflow regression assertion that the baseline artifact is downloaded before extraction and that the runtime artifact remains selected by immutable artifact ID.

## Root cause

Release run [29881797699](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29881797699) proved the GoReleaser archive fix: `Build gateway archives and SBOMs` and the full runtime-candidate job passed. The later Windows Setup job failed while extracting authenticated inputs because it fell back to the checked-in baseline policy (ending at 0.8.4), while the candidate manifest was correctly generated from the authenticated live snapshot containing 0.8.5 and 0.8.6. macOS already downloaded and bound this snapshot; Windows did not.

## User impact

The signed x64 Setup pipeline can validate the exact runtime candidate and proceed to Authenticode signing, standard-user acceptance, real-client certification, and publication. The final release still publishes exactly one Windows executable: `DefenseClawSetup-x64.exe`.

## Validation

- Downloaded the exact runtime and baseline artifacts from failed run 29881797699.
- Re-ran `extract-windows-installer-inputs` for 0.8.7 with the fixed baseline binding; extraction succeeded and produced the x64 gateway ZIP, wheel, and manifest.
- `34 passed, 4 skipped` in `cli/tests/test_release_workflow_staged.py`.
- Workflow YAML parse, Ruff, and `git diff --check` passed.