### PR TITLE
Allow unverified Windows releases when signing is unavailable

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -751,7 +751,7 @@ jobs:
           compression-level: 0
 
   windows-installer:
-    name: Build and test signed native Windows Setup
+    name: Build and test native Windows Setup
     needs: [release-preflight, build-runtime-candidate]
     runs-on: windows-latest
     env:
@@ -762,6 +762,7 @@ jobs:
     outputs:
       artifact_id: ${{ steps.windows-installer-artifact.outputs.artifact-id }}
       artifact_digest: ${{ steps.windows-installer-artifact.outputs.artifact-digest }}
+      verification_status: ${{ steps.windows-trust.outputs.verification_status }}
     defaults:
       run:
         shell: pwsh
@@ -806,17 +807,26 @@ jobs:
             --version "$env:RELEASE_TAG"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: Require real Authenticode release credentials
+      - name: Resolve Windows Authenticode trust mode
+        id: windows-trust
         env:
           WINDOWS_SIGNING_CERT_BASE64: ${{ secrets.WINDOWS_SIGNING_CERT_BASE64 }}
           WINDOWS_SIGNING_CERT_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERT_PASSWORD }}
         run: |
-          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_SIGNING_CERT_BASE64) -or
-              [string]::IsNullOrWhiteSpace($env:WINDOWS_SIGNING_CERT_PASSWORD)) {
-            throw 'Authenticode credentials are required for DefenseClawSetup-x64.exe.'
+          $hasCertificate = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_SIGNING_CERT_BASE64)
+          $hasPassword = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_SIGNING_CERT_PASSWORD)
+          if ($hasCertificate -xor $hasPassword) {
+            throw 'Windows Authenticode signing is partially configured; provide both certificate and password, or neither.'
+          }
+          if ($hasCertificate) {
+            'verification_status=signed' >> $env:GITHUB_OUTPUT
+            Write-Host 'Complete Authenticode credentials detected; signing is mandatory.'
+          } else {
+            'verification_status=unverified' >> $env:GITHUB_OUTPUT
+            Write-Warning 'Authenticode credentials are unavailable; publishing an explicitly unverified Setup.'
           }
 
-      - name: Build and Authenticode-sign native Setup
+      - name: Build native Setup with optional Authenticode
         env:
           RELEASE_TAG: ${{ needs.release-preflight.outputs.tag }}
           WINDOWS_SIGNING_CERT_BASE64: ${{ secrets.WINDOWS_SIGNING_CERT_BASE64 }}
@@ -830,7 +840,27 @@ jobs:
           -Version $env:RELEASE_TAG
           -DistributionFlavor oss
 
-      - name: Validate the exact signed Setup lifecycle as a standard user
+      - name: Require explicit Windows trust status
+        env:
+          EXPECTED_VERIFICATION_STATUS: ${{ steps.windows-trust.outputs.verification_status }}
+        run: |
+          $provenance = Get-Content `
+            -LiteralPath windows-installer-output/DefenseClawSetup-x64.exe.provenance.json `
+            -Raw -Encoding UTF8 | ConvertFrom-Json
+          if ($provenance.unsigned -eq $false -and
+              $provenance.inputs.product_executables_authenticode_signed -eq $true) {
+            $actual = 'signed'
+          } elseif ($provenance.unsigned -eq $true -and
+                    $provenance.inputs.product_executables_authenticode_signed -eq $false) {
+            $actual = 'unverified'
+          } else {
+            throw 'Windows Setup provenance contains a mixed signing state.'
+          }
+          if ($actual -cne $env:EXPECTED_VERIFICATION_STATUS) {
+            throw "Windows trust status mismatch: expected=$env:EXPECTED_VERIFICATION_STATUS actual=$actual"
+          }
+
+      - name: Validate the exact Setup lifecycle as a standard user
         run: >-
           ./scripts/invoke-windows-setup-standard-user-ci.ps1
           -Mode setup-acceptance
@@ -839,7 +869,7 @@ jobs:
           -DiagnosticsRoot (Join-Path $env:RUNNER_TEMP 'defenseclaw-signed-setup-diagnostics')
           -TimeoutSeconds 4500
 
-      - name: Upload exact signed Windows Setup metadata
+      - name: Upload exact Windows Setup metadata
         id: windows-installer-artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -854,7 +884,7 @@ jobs:
           compression-level: 0
 
   windows-real-client-certification:
-    name: Certify signed Setup with real Windows clients
+    name: Certify signed Setup or record unverified custody
     needs: [release-preflight, windows-installer]
     runs-on: windows-latest
     timeout-minutes: 180
@@ -889,6 +919,7 @@ jobs:
           merge-multiple: true
 
       - name: Require both real-client provider credentials
+        if: ${{ needs.windows-installer.outputs.verification_status == 'signed' }}
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -899,6 +930,7 @@ jobs:
           }
 
       - name: Certify the exact signed Setup with pinned Codex and Claude Code
+        if: ${{ needs.windows-installer.outputs.verification_status == 'signed' }}
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -909,6 +941,20 @@ jobs:
           -Operation release-certification
           -ArtifactRoot windows-certified
           -StateRoot (Join-Path $env:RUNNER_TEMP 'defenseclaw-real-client-certification')
+
+      - name: Record explicit unverified Windows Setup custody
+        if: ${{ needs.windows-installer.outputs.verification_status == 'unverified' }}
+        env:
+          RELEASE_TAG: ${{ needs.release-preflight.outputs.tag }}
+          RELEASE_COMMIT: ${{ needs.release-preflight.outputs.commit }}
+          WINDOWS_RELEASE_ARTIFACT_DIGEST: ${{ needs.windows-installer.outputs.artifact_digest }}
+        run: >-
+          python scripts/release_candidate.py record-windows-unverified
+          --windows-dir windows-certified
+          --version "$env:RELEASE_TAG"
+          --commit "$env:RELEASE_COMMIT"
+          --artifact-digest "$env:WINDOWS_RELEASE_ARTIFACT_DIGEST"
+          --run-url "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
 
       - name: Upload real-client diagnostics on failure
         if: ${{ failure() || cancelled() }}
@@ -923,7 +969,7 @@ jobs:
           retention-days: 7
           include-hidden-files: true
 
-      - name: Upload certified native Windows Setup assets
+      - name: Upload certified or explicitly unverified Windows Setup assets
         id: windows-certified-artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -1370,7 +1416,7 @@ jobs:
           fi
 
   full-certification:
-    name: Run full signed pre-release certification
+    name: Run full pre-release certification
     needs:
       - release-preflight
       - lookup-certification
@@ -1635,7 +1681,7 @@ jobs:
           RELEASE_COMMIT: ${{ needs.release-preflight.outputs.commit }}
         run: |
           set -euo pipefail
-          echo "::notice title=Native Windows Setup included::Legacy raw Windows archives remain omitted; the signed, certified DefenseClawSetup-x64.exe is published."
+          echo "::notice title=Native Windows Setup included::Legacy raw Windows archives remain omitted; exactly one DefenseClawSetup-x64.exe is published, and its verification status is recorded in its provenance and certification metadata."
           mapfile -t names < <(
             python3 scripts/release_candidate.py list-assets \
               --root release-candidate --version "$RELEASE_TAG" --commit "$RELEASE_COMMIT" \

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ High-risk deployments should pair DefenseClaw with human review, least-privilege
 |-------|-------------|
 | [Quick Start](docs/QUICKSTART.md) | First successful local setup and scan flow |
 | [Install](docs/INSTALL.md) | Windows, macOS, Linux, DGX Spark, source builds, and release installation |
-| [Native Windows](https://cisco-ai-defense.github.io/defenseclaw/docs/get-started/windows/) | Certified x64 scope, signed Setup lifecycle, connectors, commands, security, and troubleshooting |
+| [Native Windows](https://cisco-ai-defense.github.io/defenseclaw/docs/get-started/windows/) | x64 Setup lifecycle, optional Authenticode status, connectors, commands, security, and troubleshooting |
 | [CLI Reference](docs/CLI.md) | Python CLI commands and operator workflows |
 | [API Reference](docs/API.md) | Gateway REST API and sidecar endpoints |
 | [Architecture](docs/ARCHITECTURE.md) | Component model, data flow, and responsibilities |
@@ -138,7 +138,7 @@ defenseclaw init --enable-guardrail
 
 For platform-specific steps, see [docs/INSTALL.md](docs/INSTALL.md).
 
-On native Windows x64, use the signed native Setup EXE and hook-only connector path in
+On native Windows x64, use the native Setup EXE and hook-only connector path in
 the [Native Windows guide](https://cisco-ai-defense.github.io/defenseclaw/docs/get-started/windows/).
 WSL is unsupported. Codex CLI and Claude Code are the only certified Windows connectors.
 

--- a/cli/tests/test_release_candidate.py
+++ b/cli/tests/test_release_candidate.py
@@ -26,11 +26,7 @@ from scripts import release_candidate
 ROOT = Path(__file__).resolve().parents[2]
 VERSION = "0.8.4"
 COMMIT = "a" * 40
-TEST_CERTIFICATE_PEM = (
-    b"-----BEGIN CERTIFICATE-----\n"
-    b"MAMCAQA=\n"
-    b"-----END CERTIFICATE-----\n"
-)
+TEST_CERTIFICATE_PEM = b"-----BEGIN CERTIFICATE-----\nMAMCAQA=\n-----END CERTIFICATE-----\n"
 # The unit fixture only exercises canonical PEM/DER framing.  The release workflow
 # immediately asks Cosign to validate the real X.509 certificate and exact OIDC identity.
 TEST_CERTIFICATE_WRAPPER = base64.b64encode(TEST_CERTIFICATE_PEM)
@@ -497,6 +493,7 @@ def _windows_setup_dir(
     *,
     version: str = WINDOWS_SETUP_VERSION,
     commit: str = COMMIT,
+    signed: bool = True,
 ) -> Path:
     windows = tmp_path / "windows"
     windows.mkdir()
@@ -512,8 +509,9 @@ def _windows_setup_dir(
     struct.pack_into("<H", payload, optional_offset, 0x20B)
     struct.pack_into("<H", payload, optional_offset + 68, 2)
     struct.pack_into("<I", payload, optional_offset + 108, 16)
-    struct.pack_into("<II", payload, optional_offset + 112 + 4 * 8, 0x180, 16)
-    payload[0x180:0x190] = b"SIGNED-CMS-BYTES"
+    if signed:
+        struct.pack_into("<II", payload, optional_offset + 112 + 4 * 8, 0x180, 16)
+        payload[0x180:0x190] = b"SIGNED-CMS-BYTES"
     setup.write_bytes(payload)
     setup_hash = release_candidate._sha256(setup)
     (windows / f"{setup.name}.sha256").write_text(
@@ -523,12 +521,8 @@ def _windows_setup_dir(
     signer = "1" * 64
     timestamp_signer = "2" * 64
     timestamp_token = "3" * 64
-    authenticode_evidence = {
-        "schema_version": 1,
-        "installed_path": setup.name,
-        "sbom_file_name": f"./{setup.name}",
-        "sha256": setup_hash,
-        "expected": {
+    if signed:
+        expected_authenticode = {
             "policy": "defenseclaw-product-publisher",
             "status": "Valid",
             "publisher": release_candidate.WINDOWS_SETUP_PUBLISHER,
@@ -538,8 +532,8 @@ def _windows_setup_dir(
             "signer_thumbprint_sha256": signer,
             "timestamp_signer_thumbprint_sha256": timestamp_signer,
             "timestamp_token_sha256": timestamp_token,
-        },
-        "observed": {
+        }
+        observed_authenticode = {
             "status": "Valid",
             "publisher": release_candidate.WINDOWS_SETUP_PUBLISHER,
             "signature_type": "Authenticode",
@@ -563,7 +557,41 @@ def _windows_setup_dir(
                     },
                 }
             ],
-        },
+        }
+    else:
+        expected_authenticode = {
+            "policy": "defenseclaw-product-publisher",
+            "status": "NotSigned",
+            "publisher": "",
+            "signature_type": "None",
+            "platform_identity_required": True,
+            "timestamp_required": False,
+            "signer_thumbprint_sha256": "",
+            "timestamp_signer_thumbprint_sha256": "",
+            "timestamp_token_sha256": "",
+        }
+        observed_authenticode = {
+            "status": "NotSigned",
+            "publisher": "",
+            "signature_type": "None",
+            "signer": None,
+            "chain": None,
+            "timestamp": {
+                "present": False,
+                "format": "",
+                "token_sha256": "",
+                "signing_time_utc": "",
+                "certificate": None,
+            },
+            "embedded_signatures": [],
+        }
+    authenticode_evidence = {
+        "schema_version": 1,
+        "installed_path": setup.name,
+        "sbom_file_name": f"./{setup.name}",
+        "sha256": setup_hash,
+        "expected": expected_authenticode,
+        "observed": observed_authenticode,
     }
     gateway_archive = f"defenseclaw_{version}_windows_amd64.zip"
     wheel = f"defenseclaw-{version}-py3-none-any.whl"
@@ -584,7 +612,7 @@ def _windows_setup_dir(
         "gateway_archive_sha256": "6" * 64,
         "embedded_gateway_archive_sha256": payload_files[gateway_archive],
         "embedded_payload_sha256": "7" * 64,
-        "product_executables_authenticode_signed": True,
+        "product_executables_authenticode_signed": signed,
         "wheel": wheel,
         "wheel_sha256": payload_files[wheel],
         "python_embed": release_candidate.WINDOWS_PYTHON_EMBED_NAME,
@@ -608,7 +636,7 @@ def _windows_setup_dir(
         "source_commit": commit,
         "distribution_flavor": "oss",
         "built_at_utc": "2026-07-15T01:02:03.0000000Z",
-        "unsigned": False,
+        "unsigned": not signed,
         "authenticode": {
             "schema_version": 1,
             "files": {setup.name: authenticode_evidence},
@@ -619,14 +647,10 @@ def _windows_setup_dir(
             "uv": "uv 0.9.26 (test fixture)",
             "python_embed_url": release_candidate.WINDOWS_PYTHON_EMBED_URL,
             "python_embed_sha256": release_candidate.WINDOWS_PYTHON_EMBED_SHA256,
-            "python_runtime_review_deadline_utc": (
-                release_candidate.WINDOWS_PYTHON_RUNTIME_REVIEW_DEADLINE
-            ),
+            "python_runtime_review_deadline_utc": (release_candidate.WINDOWS_PYTHON_RUNTIME_REVIEW_DEADLINE),
             "yara_compat_sha256": payload_files[release_candidate.WINDOWS_YARA_COMPAT_WHEEL],
             "win_unicode_console_source_url": release_candidate.WINDOWS_WIN_UNICODE_SOURCE_URL,
-            "win_unicode_console_source_sha256": (
-                release_candidate.WINDOWS_WIN_UNICODE_SOURCE_SHA256
-            ),
+            "win_unicode_console_source_sha256": (release_candidate.WINDOWS_WIN_UNICODE_SOURCE_SHA256),
             "cosign_version": release_candidate.WINDOWS_COSIGN_VERSION,
             "cosign_url": release_candidate.WINDOWS_COSIGN_URL,
             "cosign_sha256": release_candidate.WINDOWS_COSIGN_SHA256,
@@ -769,16 +793,21 @@ def _windows_setup_dir(
     )
     certification = {
         "schema_version": 1,
-        "status": "passed",
+        "status": "passed" if signed else "unverified",
+        "verification_status": "signed" if signed else "unverified",
         "platform": "windows-x64",
         "setup": {
             "name": setup.name,
             "sha256": setup_hash,
-            "publisher": release_candidate.WINDOWS_SETUP_PUBLISHER,
+            "publisher": release_candidate.WINDOWS_SETUP_PUBLISHER if signed else "",
         },
-        "clients": release_candidate.WINDOWS_SETUP_CLIENTS,
-        "connectors": ["codex", "claudecode"],
-        "requirements": list(release_candidate.WINDOWS_SETUP_CERTIFICATION_REQUIREMENTS),
+        "clients": release_candidate.WINDOWS_SETUP_CLIENTS if signed else {},
+        "connectors": ["codex", "claudecode"] if signed else [],
+        "requirements": list(
+            release_candidate.WINDOWS_SETUP_CERTIFICATION_REQUIREMENTS
+            if signed
+            else release_candidate.WINDOWS_SETUP_UNVERIFIED_REQUIREMENTS
+        ),
         "source_commit": commit,
         "release_version": version,
         "staging_artifact_digest": "4" * 64,
@@ -908,9 +937,7 @@ def test_hard_cut_release_provenance_is_deterministic_signed_payload(
         "version": VERSION,
         "commit": HARD_CUT_PROVENANCE_ARGS["bridge_commit"],
         "tree": HARD_CUT_PROVENANCE_ARGS["bridge_tree"],
-        "checksums_sha256": HARD_CUT_PROVENANCE_ARGS[
-            "bridge_checksums_sha256"
-        ],
+        "checksums_sha256": HARD_CUT_PROVENANCE_ARGS["bridge_checksums_sha256"],
     }
     expected_source_map = {
         "schema_version": 1,
@@ -935,18 +962,10 @@ def test_hard_cut_release_provenance_is_deterministic_signed_payload(
         "source_install_identity": HARD_CUT_IDENTITY,
         "bridge": expected_bridge,
     }
-    assert "release-provenance.json" not in release_candidate.published_asset_names(
-        VERSION, "notarized"
-    )
-    assert "release-provenance.json" in release_candidate.payload_asset_names(
-        HARD_CUT_VERSION, "notarized"
-    )
-    assert "release-source-map.json" in release_candidate.payload_asset_names(
-        HARD_CUT_VERSION, "notarized"
-    )
-    assert "release-provenance.json" in release_candidate.published_asset_names(
-        HARD_CUT_VERSION, "notarized"
-    )
+    assert "release-provenance.json" not in release_candidate.published_asset_names(VERSION, "notarized")
+    assert "release-provenance.json" in release_candidate.payload_asset_names(HARD_CUT_VERSION, "notarized")
+    assert "release-source-map.json" in release_candidate.payload_asset_names(HARD_CUT_VERSION, "notarized")
+    assert "release-provenance.json" in release_candidate.published_asset_names(HARD_CUT_VERSION, "notarized")
 
     (first / "dist/checksums.txt.sig").write_bytes(b"sigstore signature")
     (first / "dist/checksums.txt.pem").write_bytes(TEST_CERTIFICATE_PEM)
@@ -955,9 +974,7 @@ def test_hard_cut_release_provenance_is_deterministic_signed_payload(
 
     checksums = release_candidate._parse_checksums(first / "dist/checksums.txt")
     assert set(checksums) == {"release-provenance.json", "release-source-map.json"}
-    manifest = json.loads(
-        (first / "release-candidate.json").read_text(encoding="utf-8")
-    )
+    manifest = json.loads((first / "release-candidate.json").read_text(encoding="utf-8"))
     manifest_names = {item["name"] for item in manifest["assets"]}
     assert {"release-provenance.json", "release-source-map.json"} <= manifest_names
     published = tmp_path / "published-hard-cut.json"
@@ -1077,7 +1094,11 @@ def test_hard_cut_seal_rejects_extra_provenance_field(
     [
         ("release_version", "0.8.6", "version mismatch"),
         ("source_commit", "9" * 40, "source_commit mismatch"),
-        ("source_install_identity", {**HARD_CUT_IDENTITY, "runtime_config_version": 7}, "identity mismatch"),
+        (
+            "source_install_identity",
+            {**HARD_CUT_IDENTITY, "runtime_config_version": 7},
+            "identity mismatch",
+        ),
         ("bridge.version", "0.8.3", "bridge version mismatch"),
     ],
 )
@@ -1189,8 +1210,9 @@ def test_windows_setup_custody_starts_at_086_and_survives_legacy_omission() -> N
     assert not setup_assets & set(release_candidate.windows_release_binary_names(WINDOWS_SETUP_VERSION))
 
 
-def test_windows_setup_exact_artifact_set_validates(tmp_path: Path) -> None:
-    windows = _windows_setup_dir(tmp_path)
+@pytest.mark.parametrize("signed", [True, False])
+def test_windows_setup_exact_artifact_set_validates(tmp_path: Path, signed: bool) -> None:
+    windows = _windows_setup_dir(tmp_path, signed=signed)
 
     release_candidate._validate_windows_installer_assets(
         windows,
@@ -1203,10 +1225,20 @@ def test_windows_setup_exact_artifact_set_validates(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("metadata_suffix", "field", "value", "match"),
     [
-        ("provenance.json", "unsigned", True, "release identity"),
+        ("provenance.json", "unsigned", True, "signing state"),
         ("sbom.json", "documentNamespace", "https://example.invalid", "SBOM document"),
-        ("certification.json", "clients", {"codex": "latest"}, "certification identity"),
-        ("certification.json", "requirements", ["manual-trust"], "certification identity"),
+        (
+            "certification.json",
+            "clients",
+            {"codex": "latest"},
+            "certification identity",
+        ),
+        (
+            "certification.json",
+            "requirements",
+            ["manual-trust"],
+            "certification identity",
+        ),
     ],
 )
 def test_windows_setup_metadata_tampering_fails_closed(
@@ -1231,16 +1263,77 @@ def test_windows_setup_metadata_tampering_fails_closed(
         )
 
 
-def test_windows_setup_provenance_rejects_open_or_unpinned_build_inputs(tmp_path: Path) -> None:
+def test_windows_setup_rejects_pe_and_provenance_signing_state_mismatch(
+    tmp_path: Path,
+) -> None:
+    windows = _windows_setup_dir(tmp_path, signed=False)
+    path = windows / f"{release_candidate.WINDOWS_SETUP_ASSET}.provenance.json"
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["unsigned"] = False
+    document["inputs"]["product_executables_authenticode_signed"] = True
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(release_candidate.CandidateError, match="signing state"):
+        release_candidate._validate_windows_installer_assets(
+            windows,
+            WINDOWS_SETUP_VERSION,
+            COMMIT,
+            exact_file_set=True,
+        )
+
+
+def test_record_windows_unverified_creates_explicit_non_certification(
+    tmp_path: Path,
+) -> None:
+    windows = _windows_setup_dir(tmp_path, signed=False)
+    certification = windows / f"{release_candidate.WINDOWS_SETUP_ASSET}.certification.json"
+    certification.unlink()
+
+    release_candidate.record_windows_unverified(
+        windows,
+        WINDOWS_SETUP_VERSION,
+        COMMIT,
+        "sha256:" + "4" * 64,
+        "https://github.com/cisco-ai-defense/defenseclaw/actions/runs/123456",
+    )
+
+    document = json.loads(certification.read_text(encoding="utf-8"))
+    assert document["status"] == "unverified"
+    assert document["verification_status"] == "unverified"
+    assert document["setup"]["publisher"] == ""
+    assert document["clients"] == {}
+    release_candidate._validate_windows_installer_assets(
+        windows,
+        WINDOWS_SETUP_VERSION,
+        COMMIT,
+        exact_file_set=True,
+    )
+
+
+def test_record_windows_unverified_rejects_signed_setup(tmp_path: Path) -> None:
+    windows = _windows_setup_dir(tmp_path)
+    (windows / f"{release_candidate.WINDOWS_SETUP_ASSET}.certification.json").unlink()
+
+    with pytest.raises(release_candidate.CandidateError, match="signed Windows Setup"):
+        release_candidate.record_windows_unverified(
+            windows,
+            WINDOWS_SETUP_VERSION,
+            COMMIT,
+            "4" * 64,
+            "https://github.com/cisco-ai-defense/defenseclaw/actions/runs/123456",
+        )
+
+
+def test_windows_setup_provenance_rejects_open_or_unpinned_build_inputs(
+    tmp_path: Path,
+) -> None:
     windows = _windows_setup_dir(tmp_path)
     path = windows / f"{release_candidate.WINDOWS_SETUP_ASSET}.provenance.json"
     document = json.loads(path.read_text(encoding="utf-8"))
     document["inputs"].pop("cosign_sha256")
     path.write_text(json.dumps(document), encoding="utf-8")
     with pytest.raises(release_candidate.CandidateError, match="closed field set"):
-        release_candidate._validate_windows_installer_assets(
-            windows, WINDOWS_SETUP_VERSION, COMMIT
-        )
+        release_candidate._validate_windows_installer_assets(windows, WINDOWS_SETUP_VERSION, COMMIT)
 
     unpinned = tmp_path / "unpinned"
     unpinned.mkdir()
@@ -1250,62 +1343,49 @@ def test_windows_setup_provenance_rejects_open_or_unpinned_build_inputs(tmp_path
     document["toolchain"]["cosign_version"] = "2.6.1"
     path.write_text(json.dumps(document), encoding="utf-8")
     with pytest.raises(release_candidate.CandidateError, match="reviewed pin"):
-        release_candidate._validate_windows_installer_assets(
-            windows, WINDOWS_SETUP_VERSION, COMMIT
-        )
+        release_candidate._validate_windows_installer_assets(windows, WINDOWS_SETUP_VERSION, COMMIT)
 
 
-def test_windows_setup_provenance_rejects_inconsistent_payload_digest(tmp_path: Path) -> None:
+def test_windows_setup_provenance_rejects_inconsistent_payload_digest(
+    tmp_path: Path,
+) -> None:
     windows = _windows_setup_dir(tmp_path)
     path = windows / f"{release_candidate.WINDOWS_SETUP_ASSET}.provenance.json"
     document = json.loads(path.read_text(encoding="utf-8"))
     document["inputs"]["payload_files"][document["inputs"]["wheel"]] = "1" * 64
     path.write_text(json.dumps(document), encoding="utf-8")
     with pytest.raises(release_candidate.CandidateError, match="payload digests"):
-        release_candidate._validate_windows_installer_assets(
-            windows, WINDOWS_SETUP_VERSION, COMMIT
-        )
+        release_candidate._validate_windows_installer_assets(windows, WINDOWS_SETUP_VERSION, COMMIT)
 
 
-def test_windows_setup_sbom_requires_every_payload_custody_relationship(tmp_path: Path) -> None:
+def test_windows_setup_sbom_requires_every_payload_custody_relationship(
+    tmp_path: Path,
+) -> None:
     windows = _windows_setup_dir(tmp_path)
     path = windows / f"{release_candidate.WINDOWS_SETUP_ASSET}.sbom.json"
     document = json.loads(path.read_text(encoding="utf-8"))
     manifest_package = next(
-        item["SPDXID"]
-        for item in document["packages"]
-        if item.get("packageFileName") == "manifest.json"
+        item["SPDXID"] for item in document["packages"] if item.get("packageFileName") == "manifest.json"
     )
     document["relationships"] = [
         row
         for row in document["relationships"]
-        if not (
-            row["relationshipType"] == "CONTAINS"
-            and row["relatedSpdxElement"] == manifest_package
-        )
+        if not (row["relationshipType"] == "CONTAINS" and row["relatedSpdxElement"] == manifest_package)
     ]
     path.write_text(json.dumps(document), encoding="utf-8")
     with pytest.raises(release_candidate.CandidateError, match="custody relationships"):
-        release_candidate._validate_windows_installer_assets(
-            windows, WINDOWS_SETUP_VERSION, COMMIT
-        )
+        release_candidate._validate_windows_installer_assets(windows, WINDOWS_SETUP_VERSION, COMMIT)
 
 
 def test_windows_setup_sbom_rejects_payload_digest_substitution(tmp_path: Path) -> None:
     windows = _windows_setup_dir(tmp_path)
     path = windows / f"{release_candidate.WINDOWS_SETUP_ASSET}.sbom.json"
     document = json.loads(path.read_text(encoding="utf-8"))
-    manifest_package = next(
-        item
-        for item in document["packages"]
-        if item.get("packageFileName") == "manifest.json"
-    )
+    manifest_package = next(item for item in document["packages"] if item.get("packageFileName") == "manifest.json")
     manifest_package["checksums"] = [{"algorithm": "SHA256", "checksumValue": "1" * 64}]
     path.write_text(json.dumps(document), encoding="utf-8")
     with pytest.raises(release_candidate.CandidateError, match="payload digest"):
-        release_candidate._validate_windows_installer_assets(
-            windows, WINDOWS_SETUP_VERSION, COMMIT
-        )
+        release_candidate._validate_windows_installer_assets(windows, WINDOWS_SETUP_VERSION, COMMIT)
 
 
 @pytest.mark.parametrize(
@@ -1402,9 +1482,7 @@ def test_086_assemble_seals_the_exact_windows_setup_bytes(
     root = tmp_path / "candidate"
     source_hashes = {
         name: release_candidate._sha256(windows / name)
-        for name in release_candidate.windows_installer_asset_names(
-            WINDOWS_SETUP_VERSION
-        )
+        for name in release_candidate.windows_installer_asset_names(WINDOWS_SETUP_VERSION)
     }
     monkeypatch.setattr(
         release_candidate,
@@ -1477,9 +1555,7 @@ def test_086_assemble_seals_the_exact_windows_setup_bytes(
     )
 
     dist = root / "dist"
-    assert {
-        name: release_candidate._sha256(dist / name) for name in source_hashes
-    } == source_hashes
+    assert {name: release_candidate._sha256(dist / name) for name in source_hashes} == source_hashes
     assert release_candidate._parse_checksums(dist / "checksums.txt") == source_hashes
     (dist / "checksums.txt.sig").write_bytes(b"sigstore signature")
     (dist / "checksums.txt.pem").write_bytes(TEST_CERTIFICATE_PEM)
@@ -1491,9 +1567,7 @@ def test_086_assemble_seals_the_exact_windows_setup_bytes(
     recorded = {item["name"]: item["sha256"] for item in manifest["assets"]}
     for name, digest in source_hashes.items():
         assert recorded[name] == digest
-    assert recorded["checksums.txt.bundle"] == release_candidate._sha256(
-        dist / "checksums.txt.bundle"
-    )
+    assert recorded["checksums.txt.bundle"] == release_candidate._sha256(dist / "checksums.txt.bundle")
 
     setup = dist / release_candidate.WINDOWS_SETUP_ASSET
     setup.write_bytes(setup.read_bytes() + b"tampered")
@@ -1528,18 +1602,12 @@ def test_windows_setup_provenance_binds_exact_runtime_candidate(
     inputs["gateway_archive_sha256"] = hashlib.sha256(gateway_payload).hexdigest()
     inputs["wheel_sha256"] = hashlib.sha256(wheel_payload).hexdigest()
     inputs["payload_files"][inputs["wheel"]] = inputs["wheel_sha256"]
-    inputs["payload_files"]["upgrade-manifest.json"] = hashlib.sha256(
-        manifest_payload
-    ).hexdigest()
+    inputs["payload_files"]["upgrade-manifest.json"] = hashlib.sha256(manifest_payload).hexdigest()
 
-    release_candidate._validate_windows_setup_runtime_inputs(
-        provenance, runtime, WINDOWS_SETUP_VERSION
-    )
+    release_candidate._validate_windows_setup_runtime_inputs(provenance, runtime, WINDOWS_SETUP_VERSION)
     manifest_path.write_bytes(b"substituted")
     with pytest.raises(release_candidate.CandidateError, match="exact runtime candidate"):
-        release_candidate._validate_windows_setup_runtime_inputs(
-            provenance, runtime, WINDOWS_SETUP_VERSION
-        )
+        release_candidate._validate_windows_setup_runtime_inputs(provenance, runtime, WINDOWS_SETUP_VERSION)
 
 
 def test_windows_installer_input_extractor_is_exclusive_and_canonical(
@@ -1618,19 +1686,13 @@ def test_candidate_seals_and_verifies_exact_publish_set(tmp_path: Path) -> None:
 
     manifest = json.loads((root / "release-candidate.json").read_text(encoding="utf-8"))
     effective_policy = root / release_candidate.EFFECTIVE_UPGRADE_BASELINES_FILENAME
-    assert effective_policy.read_bytes() == (
-        ROOT / "release/upgrade-baselines.json"
-    ).read_bytes()
-    assert manifest["effective_upgrade_baselines_sha256"] == hashlib.sha256(
-        effective_policy.read_bytes()
-    ).hexdigest()
+    assert effective_policy.read_bytes() == (ROOT / "release/upgrade-baselines.json").read_bytes()
+    assert manifest["effective_upgrade_baselines_sha256"] == hashlib.sha256(effective_policy.read_bytes()).hexdigest()
     assert [item["name"] for item in manifest["assets"]] == list(
         release_candidate.published_asset_names(VERSION, "notarized")
     )
     checksums = release_candidate._parse_checksums(root / "dist/checksums.txt")
-    assert tuple(sorted(checksums)) == release_candidate.payload_asset_names(
-        VERSION, "notarized"
-    )
+    assert tuple(sorted(checksums)) == release_candidate.payload_asset_names(VERSION, "notarized")
     for name in release_candidate.resolver_asset_names(VERSION):
         assert (root / "dist" / name).read_bytes() == (release_candidate.RESOLVER_ASSET_SOURCES[name].read_bytes())
     assert (root / "RELEASE_NOTES.md").read_text(encoding="utf-8") == "# Candidate notes\n"
@@ -1739,9 +1801,7 @@ def test_certificate_command_canonicalizes_strict_cosign_wrapper_atomically(
         original_replace(source, destination)
 
     monkeypatch.setattr(release_candidate.os, "replace", record_replace)
-    status = release_candidate.main(
-        ["canonicalize-certificate", "--certificate", str(certificate)]
-    )
+    status = release_candidate.main(["canonicalize-certificate", "--certificate", str(certificate)])
 
     assert status == 0
     assert certificate.read_bytes() == TEST_CERTIFICATE_PEM
@@ -1875,7 +1935,9 @@ def test_certificate_atomic_publication_failure_preserves_cosign_output(
     assert not list(tmp_path.glob(".checksums.txt.pem.canonical-*"))
 
 
-def test_seal_and_verify_reject_base64_wrapped_modern_certificate(tmp_path: Path) -> None:
+def test_seal_and_verify_reject_base64_wrapped_modern_certificate(
+    tmp_path: Path,
+) -> None:
     unsealed = _candidate_before_seal(tmp_path)
     certificate = unsealed / "dist/checksums.txt.pem"
     certificate.write_bytes(TEST_CERTIFICATE_WRAPPER)
@@ -1905,14 +1967,9 @@ def test_candidate_seals_and_verifies_explicit_unverified_macos_assets(
         f"DefenseClawMac-{VERSION}-macos-arm64-unverified.dmg",
         f"DefenseClawMac-{VERSION}-macos-arm64-unverified.zip",
     )
-    assert not any(
-        name in expected_names
-        for name in release_candidate.macos_asset_names(VERSION, "notarized")
-    )
+    assert not any(name in expected_names for name in release_candidate.macos_asset_names(VERSION, "notarized"))
     checksums = release_candidate._parse_checksums(root / "dist/checksums.txt")
-    assert tuple(sorted(checksums)) == release_candidate.payload_asset_names(
-        VERSION, "unverified"
-    )
+    assert tuple(sorted(checksums)) == release_candidate.payload_asset_names(VERSION, "unverified")
 
     release_json = tmp_path / "published-unverified.json"
     release_json.write_text(
@@ -1958,13 +2015,9 @@ def test_local_release_harness_stages_exact_reviewed_resolvers(tmp_path: Path) -
 
     release_candidate.stage_resolvers(release_dir, VERSION)
 
-    assert {path.name for path in release_dir.iterdir()} == set(
-        release_candidate.resolver_asset_names(VERSION)
-    )
+    assert {path.name for path in release_dir.iterdir()} == set(release_candidate.resolver_asset_names(VERSION))
     for name in release_candidate.resolver_asset_names(VERSION):
-        assert (release_dir / name).read_bytes() == release_candidate.RESOLVER_ASSET_SOURCES[
-            name
-        ].read_bytes()
+        assert (release_dir / name).read_bytes() == release_candidate.RESOLVER_ASSET_SOURCES[name].read_bytes()
 
     with pytest.raises(release_candidate.CandidateError, match="destination already exists"):
         release_candidate.stage_resolvers(release_dir, VERSION)
@@ -1988,7 +2041,9 @@ def test_exact_reviewed_release_sources_have_cross_platform_lf_attributes() -> N
         assert b"\r\n" not in (ROOT / relative).read_bytes()
 
 
-def test_exact_gateway_is_safely_extracted_from_runtime_candidate(tmp_path: Path) -> None:
+def test_exact_gateway_is_safely_extracted_from_runtime_candidate(
+    tmp_path: Path,
+) -> None:
     runtime = _runtime_dir(tmp_path)
     output = tmp_path / "extracted/defenseclaw"
 
@@ -2103,13 +2158,16 @@ def test_gateway_archive_attestation_rejects_version_or_commit_drift(
         release_candidate._validate_gateway_archives(runtime, VERSION, commit="b" * 40)
 
 
-def test_only_manifest_bound_protocol_two_artifacts_are_installable(tmp_path: Path) -> None:
+def test_only_manifest_bound_protocol_two_artifacts_are_installable(
+    tmp_path: Path,
+) -> None:
     runtime = _runtime_dir(tmp_path)
 
     protected_gateway = runtime / RELEASE_ARTIFACTS["gateways"]["linux"]["amd64"]
     assert protected_gateway.read_bytes().startswith(release_candidate.PROTECTED_ARTIFACT_MAGIC)
     with tarfile.open(
-        fileobj=io.BytesIO(release_candidate._protected_payload(protected_gateway)), mode="r:gz"
+        fileobj=io.BytesIO(release_candidate._protected_payload(protected_gateway)),
+        mode="r:gz",
     ) as archive:
         assert any(Path(member.name).name == "defenseclaw" for member in archive.getmembers())
     with pytest.raises(tarfile.TarError):
@@ -2178,7 +2236,9 @@ def test_published_protected_wheel_is_rejected_by_package_managers_before_instal
         assert not target.exists() or {entry.name for entry in target.iterdir()} <= {".lock"}
 
 
-def test_manifest_cannot_point_resolvers_at_legacy_refusal_names(tmp_path: Path) -> None:
+def test_manifest_cannot_point_resolvers_at_legacy_refusal_names(
+    tmp_path: Path,
+) -> None:
     runtime = _runtime_dir(tmp_path)
     manifest_path = runtime / "upgrade-manifest.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -2281,7 +2341,9 @@ def test_candidate_verification_binds_unverified_names_to_unverified_status(
         release_candidate.verify(root, VERSION, COMMIT)
 
 
-def test_runtime_verification_rejects_mismatched_upgrade_manifest(tmp_path: Path) -> None:
+def test_runtime_verification_rejects_mismatched_upgrade_manifest(
+    tmp_path: Path,
+) -> None:
     runtime = _runtime_dir(tmp_path)
     manifest = json.loads((runtime / "upgrade-manifest.json").read_text(encoding="utf-8"))
     manifest["release_version"] = "9.9.9"
@@ -2302,7 +2364,9 @@ def test_bridge_candidate_rejects_wheel_protocol_drift(tmp_path: Path) -> None:
         release_candidate.verify_runtime(runtime, VERSION)
 
 
-def test_bridge_candidate_requires_protocol_two_even_when_manifest_matches(tmp_path: Path) -> None:
+def test_bridge_candidate_requires_protocol_two_even_when_manifest_matches(
+    tmp_path: Path,
+) -> None:
     runtime = _runtime_dir(tmp_path)
     wheel = runtime / PROTECTED_WHEEL
     _rewrite_wheel_controller(wheel, protocol=1)
@@ -2331,24 +2395,17 @@ def test_bridge_candidate_requires_release_owned_handoff_call(tmp_path: Path) ->
 
 
 def test_repository_controller_handoff_is_the_first_guarded_call() -> None:
-    source = (
-        ROOT / "cli" / "defenseclaw" / "commands" / "cmd_upgrade.py"
-    ).read_text(encoding="utf-8")
+    source = (ROOT / "cli" / "defenseclaw" / "commands" / "cmd_upgrade.py").read_text(encoding="utf-8")
     tree = ast.parse(source)
     entrypoints = [
         node
         for node in tree.body
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        and node.name == "upgrade"
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "upgrade"
     ]
     assert len(entrypoints) == 1
     calls = release_candidate._upgrade_controller_calls(entrypoints[0])
     guarded_first = release_candidate._direct_hard_cut_guard_first_calls(entrypoints[0])
-    handoffs = [
-        (line, guarded)
-        for name, line, guarded in calls
-        if name == "_require_release_owned_hard_cut_handoff"
-    ]
+    handoffs = [(line, guarded) for name, line, guarded in calls if name == "_require_release_owned_hard_cut_handoff"]
     assert len(handoffs) == 1
     assert handoffs[0][1]
     assert ("_require_release_owned_hard_cut_handoff", handoffs[0][0]) in guarded_first
@@ -2378,7 +2435,9 @@ def test_bridge_candidate_rejects_inverted_or_dead_handoff_guard(
         release_candidate.verify_runtime(runtime, VERSION)
 
 
-def test_bridge_candidate_requires_handoff_before_acquisition_or_backup(tmp_path: Path) -> None:
+def test_bridge_candidate_requires_handoff_before_acquisition_or_backup(
+    tmp_path: Path,
+) -> None:
     runtime = _runtime_dir(tmp_path)
     wheel = runtime / PROTECTED_WHEEL
     original = (
@@ -2402,7 +2461,9 @@ def test_bridge_candidate_requires_handoff_before_acquisition_or_backup(tmp_path
         release_candidate.verify_runtime(runtime, VERSION)
 
 
-def test_bridge_candidate_requires_schema_two_tested_source_policy(tmp_path: Path) -> None:
+def test_bridge_candidate_requires_schema_two_tested_source_policy(
+    tmp_path: Path,
+) -> None:
     runtime = _runtime_dir(tmp_path)
     manifest_path = runtime / "upgrade-manifest.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -2443,7 +2504,9 @@ def test_bridge_candidate_requires_exact_wheel_shipped_install_publisher(
         release_candidate.verify_runtime(runtime, VERSION)
 
 
-def test_bridge_candidate_rejects_duplicate_wheel_publisher_member(tmp_path: Path) -> None:
+def test_bridge_candidate_rejects_duplicate_wheel_publisher_member(
+    tmp_path: Path,
+) -> None:
     runtime = _runtime_dir(tmp_path)
     wheel = runtime / PROTECTED_WHEEL
     members = _read_wheel_members(wheel)
@@ -2496,7 +2559,9 @@ def test_bridge_candidate_rejects_dead_branch_lease_decoy(tmp_path: Path) -> Non
 
 
 @pytest.mark.skipif(os.name != "posix", reason="POSIX descriptor inheritance canary")
-def test_candidate_wheel_mutator_supervisor_holds_lease_for_real_child_lifetime(tmp_path: Path) -> None:
+def test_candidate_wheel_mutator_supervisor_holds_lease_for_real_child_lifetime(
+    tmp_path: Path,
+) -> None:
     import fcntl
 
     runtime = _runtime_dir(tmp_path)
@@ -2513,8 +2578,8 @@ def test_candidate_wheel_mutator_supervisor_holds_lease_for_real_child_lifetime(
         "import pathlib, sys, time; "
         "started,release,completed=map(pathlib.Path,sys.argv[1:]); "
         "started.touch(); deadline=time.monotonic()+10; "
-        "exec(\"while not release.exists():\\n"
-        " assert time.monotonic()<deadline\\n time.sleep(0.02)\"); "
+        'exec("while not release.exists():\\n'
+        ' assert time.monotonic()<deadline\\n time.sleep(0.02)"); '
         "completed.write_text('held', encoding='utf-8')"
     )
     process = subprocess.Popen(
@@ -2767,9 +2832,7 @@ def test_non_bridge_candidate_allows_forward_keyed_migration(tmp_path: Path) -> 
     release_candidate._validate_wheel(wheel, HARD_CUT_VERSION)
 
     members = _read_wheel_members(wheel)
-    members["defenseclaw/commands/cmd_upgrade.py"] = members[
-        "defenseclaw/commands/cmd_upgrade.py"
-    ].replace(
+    members["defenseclaw/commands/cmd_upgrade.py"] = members["defenseclaw/commands/cmd_upgrade.py"].replace(
         b'_STAGED_TARGET_CONTROLLER_VERSION_ENV = "DEFENSECLAW_STAGED_TARGET_CONTROLLER_VERSION"\n',
         b"",
     )
@@ -2826,13 +2889,9 @@ def test_non_bridge_candidate_rejects_incomplete_or_altered_v8_resources(
     elif mutation == "windows-trailing-alias":
         members["defenseclaw./_data./config/v8 /unexpected.json"] = b"{}\n"
     elif mutation == "ntfs-short-name-alias-1":
-        members["DEFENS~1/_data/telemetry/v8/catalog.json"] = members[
-            "defenseclaw/_data/telemetry/v8/catalog.json"
-        ]
+        members["DEFENS~1/_data/telemetry/v8/catalog.json"] = members["defenseclaw/_data/telemetry/v8/catalog.json"]
     elif mutation == "ntfs-short-name-alias-2":
-        members["DEFENS~2/_data/config/v8/defenseclaw-config.schema.json"] = members[
-            config_schema
-        ]
+        members["DEFENS~2/_data/config/v8/defenseclaw-config.schema.json"] = members[config_schema]
     elif mutation == "directory-entry":
         members["defenseclaw/_data/config/v8/unexpected/"] = b""
     else:
@@ -2997,15 +3056,15 @@ def test_non_bridge_candidate_rejects_malformed_canonical_telemetry_input(
         ),
         (
             HARD_CUT_BUNDLE_TRANSACTION_SOURCE.replace(
-                "    serialized_metadata = json.dumps(backup_metadata, sort_keys=True).encode(\"utf-8\")\n",
-                "    serialized_metadata = b\"not the metadata object\"\n",
+                '    serialized_metadata = json.dumps(backup_metadata, sort_keys=True).encode("utf-8")\n',
+                '    serialized_metadata = b"not the metadata object"\n',
             ),
             "publish its exact schema-2 metadata object",
         ),
         (
             HARD_CUT_BUNDLE_TRANSACTION_SOURCE.replace(
                 "    if not 0 < len(serialized_metadata) <= _MAX_BUNDLE_ROLLBACK_METADATA_BYTES:\n"
-                "        raise OSError(\"rollback metadata exceeds the bridge reader bound\")\n",
+                '        raise OSError("rollback metadata exceeds the bridge reader bound")\n',
                 "",
             ),
             "serialized metadata is not bounded",
@@ -3105,25 +3164,25 @@ def test_non_bridge_candidate_rejects_malformed_canonical_telemetry_input(
         ),
         (
             HARD_CUT_BUNDLE_TRANSACTION_SOURCE.replace(
-                "    serialized_metadata = json.dumps(backup_metadata, sort_keys=True).encode(\"utf-8\")\n",
+                '    serialized_metadata = json.dumps(backup_metadata, sort_keys=True).encode("utf-8")\n',
                 '    _atomic_copy_file("stage", path)\n'
-                "    serialized_metadata = json.dumps(backup_metadata, sort_keys=True).encode(\"utf-8\")\n",
+                '    serialized_metadata = json.dumps(backup_metadata, sort_keys=True).encode("utf-8")\n',
             ),
             "ambiguous copy mutation",
         ),
         (
             HARD_CUT_BUNDLE_TRANSACTION_SOURCE.replace(
-                "    serialized_metadata = json.dumps(backup_metadata, sort_keys=True).encode(\"utf-8\")\n",
+                '    serialized_metadata = json.dumps(backup_metadata, sort_keys=True).encode("utf-8")\n',
                 '    _atomic_write_bytes("canonical", b"early mutation")\n'
-                "    serialized_metadata = json.dumps(backup_metadata, sort_keys=True).encode(\"utf-8\")\n",
+                '    serialized_metadata = json.dumps(backup_metadata, sort_keys=True).encode("utf-8")\n',
             ),
             "ambiguous direct file write",
         ),
         (
             HARD_CUT_BUNDLE_TRANSACTION_SOURCE.replace(
-                "    serialized_metadata = json.dumps(backup_metadata, sort_keys=True).encode(\"utf-8\")\n",
+                '    serialized_metadata = json.dumps(backup_metadata, sort_keys=True).encode("utf-8")\n',
                 '    path.write_bytes(b"early mutation")\n'
-                "    serialized_metadata = json.dumps(backup_metadata, sort_keys=True).encode(\"utf-8\")\n",
+                '    serialized_metadata = json.dumps(backup_metadata, sort_keys=True).encode("utf-8")\n',
             ),
             "bypasses its reviewed publication primitives",
         ),
@@ -3136,12 +3195,12 @@ def test_non_bridge_candidate_rejects_malformed_canonical_telemetry_input(
         ),
         (
             HARD_CUT_BUNDLE_TRANSACTION_SOURCE.replace(
-                "    _atomic_write_bytes(backup_root / \"refresh-backup.json\", serialized_metadata)\n"
+                '    _atomic_write_bytes(backup_root / "refresh-backup.json", serialized_metadata)\n'
                 "    mutation_started = False\n"
                 "    mutation_started = True\n",
                 "    mutation_started = False\n"
                 "    mutation_started = True\n"
-                "    _atomic_write_bytes(backup_root / \"refresh-backup.json\", serialized_metadata)\n",
+                '    _atomic_write_bytes(backup_root / "refresh-backup.json", serialized_metadata)\n',
             ),
             "not durable before first mutation",
         ),
@@ -3501,7 +3560,9 @@ def test_sealer_requires_digest_exceptions_for_exact_unsigned_baseline_suffix(
         release_candidate._validate_historical_artifact_digest_policy(["0.6.1", "0.6.0", "0.5.0"])
 
 
-def test_bridge_candidate_runtime_attestation_matches_gateway_source(tmp_path: Path) -> None:
+def test_bridge_candidate_runtime_attestation_matches_gateway_source(
+    tmp_path: Path,
+) -> None:
     manifest_path = _runtime_dir(tmp_path) / "upgrade-manifest.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     manifest["runtime_config_version"] = 8

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -25,12 +25,8 @@ WINDOWS_PROTOCOL_GATE = ROOT / "scripts/test-upgrade-release-windows.ps1"
 MACOS_BUILD = ROOT / "scripts/build-macos-app-release.sh"
 POSIX_INSTALLER = ROOT / "scripts/install.sh"
 POSIX_FRESH_RELEASE = ROOT / "scripts/test-fresh-install-release.sh"
-DIGEST_CAPABLE_UPLOAD_ACTION = (
-    "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
-)
-COSIGN_INSTALLER_ACTION = (
-    "sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da"
-)
+DIGEST_CAPABLE_UPLOAD_ACTION = "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+COSIGN_INSTALLER_ACTION = "sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da"
 
 
 def _bash_executable() -> str:
@@ -238,7 +234,7 @@ def test_native_windows_setup_is_required_while_raw_archives_remain_omitted() ->
     assert workflow_text.count("--omit-windows-binaries") == 4
     assert "publish_windows_binaries" not in workflow_text
     assert "Legacy raw Windows archives remain omitted" in workflow_text
-    assert "signed, certified DefenseClawSetup-x64.exe is published" in workflow_text
+    assert "verification status is recorded in its provenance and certification metadata" in workflow_text
 
 
 def test_native_windows_setup_has_immutable_artifact_custody() -> None:
@@ -250,9 +246,7 @@ def test_native_windows_setup_has_immutable_artifact_custody() -> None:
 
     for job in (runtime, installer, certification, assemble):
         upload_actions = [
-            step["uses"]
-            for step in job.get("steps", [])
-            if step.get("uses", "").startswith("actions/upload-artifact@")
+            step["uses"] for step in job.get("steps", []) if step.get("uses", "").startswith("actions/upload-artifact@")
         ]
         assert upload_actions
         assert set(upload_actions) == {DIGEST_CAPABLE_UPLOAD_ACTION}
@@ -262,6 +256,7 @@ def test_native_windows_setup_has_immutable_artifact_custody() -> None:
     assert installer["outputs"] == {
         "artifact_id": "${{ steps.windows-installer-artifact.outputs.artifact-id }}",
         "artifact_digest": "${{ steps.windows-installer-artifact.outputs.artifact-digest }}",
+        "verification_status": "${{ steps.windows-trust.outputs.verification_status }}",
     }
     assert certification["outputs"] == {
         "artifact_id": "${{ steps.windows-certified-artifact.outputs.artifact-id }}",
@@ -278,20 +273,16 @@ def test_native_windows_setup_has_immutable_artifact_custody() -> None:
         step
         for step in installer["steps"]
         if step.get("uses", "").startswith("actions/download-artifact@")
-        and step.get("with", {}).get("name")
-        == "${{ needs.release-preflight.outputs.baseline_artifact }}"
+        and step.get("with", {}).get("name") == "${{ needs.release-preflight.outputs.baseline_artifact }}"
     )
-    assert installer["env"]["UPGRADE_BASELINE_POLICY"] == (
-        "${{ github.workspace }}/effective-upgrade-baselines.json"
-    )
+    assert installer["env"]["UPGRADE_BASELINE_POLICY"] == ("${{ github.workspace }}/effective-upgrade-baselines.json")
     assert installer_baseline_download["with"]["path"] == "."
 
     installer_download = next(
         step
         for step in installer["steps"]
         if step.get("uses", "").startswith("actions/download-artifact@")
-        and step.get("with", {}).get("artifact-ids")
-        == "${{ needs.build-runtime-candidate.outputs.artifact_id }}"
+        and step.get("with", {}).get("artifact-ids") == "${{ needs.build-runtime-candidate.outputs.artifact_id }}"
     )
     assert installer_download["with"]["artifact-ids"] == ("${{ needs.build-runtime-candidate.outputs.artifact_id }}")
     assert installer_download["with"]["merge-multiple"] == "true"
@@ -349,13 +340,52 @@ def test_native_windows_setup_has_immutable_artifact_custody() -> None:
     setup_acceptance = next(
         step
         for step in installer["steps"]
-        if step.get("name")
-        == "Validate the exact signed Setup lifecycle as a standard user"
+        if step.get("name") == "Validate the exact Setup lifecycle as a standard user"
     )["run"]
     assert "scripts/invoke-windows-setup-standard-user-ci.ps1" in setup_acceptance
     assert "-Mode setup-acceptance" in setup_acceptance
     assert "-ArtifactRoot windows-installer-output" in setup_acceptance
     assert "-TimeoutSeconds 4500" in setup_acceptance
+
+
+def test_windows_authenticode_is_optional_but_partial_or_invalid_configuration_fails() -> None:
+    jobs = _workflow()["jobs"]
+    installer = jobs["windows-installer"]
+    certification = jobs["windows-real-client-certification"]
+    trust = next(step for step in installer["steps"] if step.get("id") == "windows-trust")
+    rendered = trust["run"]
+
+    assert "-xor" in rendered
+    assert "provide both certificate and password, or neither" in rendered
+    assert "verification_status=signed" in rendered
+    assert "verification_status=unverified" in rendered
+    assert "continue-on-error" not in str(installer)
+
+    build = next(
+        step for step in installer["steps"] if step.get("name") == "Build native Setup with optional Authenticode"
+    )
+    assert "secrets.WINDOWS_SIGNING_CERT_BASE64" in str(build)
+    assert "secrets.WINDOWS_SIGNING_CERT_PASSWORD" in str(build)
+
+    provider_gate = next(
+        step for step in certification["steps"] if step.get("name") == "Require both real-client provider credentials"
+    )
+    signed_certification = next(
+        step
+        for step in certification["steps"]
+        if step.get("name") == "Certify the exact signed Setup with pinned Codex and Claude Code"
+    )
+    unverified = next(
+        step
+        for step in certification["steps"]
+        if step.get("name") == "Record explicit unverified Windows Setup custody"
+    )
+    signed_condition = "${{ needs.windows-installer.outputs.verification_status == 'signed' }}"
+    unverified_condition = "${{ needs.windows-installer.outputs.verification_status == 'unverified' }}"
+    assert provider_gate["if"] == signed_condition
+    assert signed_certification["if"] == signed_condition
+    assert unverified["if"] == unverified_condition
+    assert "record-windows-unverified" in unverified["run"]
 
 
 def test_build_once_candidate_is_reused_by_tests_and_publisher() -> None:
@@ -382,22 +412,14 @@ def test_build_once_candidate_is_reused_by_tests_and_publisher() -> None:
     assert "cosign sign-blob" in assemble_rendered
     assert text.count("cosign sign-blob") == 1
     candidate_upload_index = next(
-        index
-        for index, step in enumerate(assemble_job["steps"])
-        if step.get("id") == "upload"
+        index for index, step in enumerate(assemble_job["steps"]) if step.get("id") == "upload"
     )
     candidate_upload = assemble_job["steps"][candidate_upload_index]
-    assert candidate_upload["uses"] == (
-        "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
-    )
-    assert assemble_job["outputs"]["artifact_digest"] == (
-        "${{ steps.upload.outputs.artifact-digest }}"
-    )
+    assert candidate_upload["uses"] == ("actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02")
+    assert assemble_job["outputs"]["artifact_digest"] == ("${{ steps.upload.outputs.artifact-digest }}")
     digest_guard = assemble_job["steps"][candidate_upload_index + 1]
     assert digest_guard["name"] == "Require candidate artifact digest output"
-    assert digest_guard["env"]["CANDIDATE_ARTIFACT_DIGEST"] == (
-        "${{ steps.upload.outputs.artifact-digest }}"
-    )
+    assert digest_guard["env"]["CANDIDATE_ARTIFACT_DIGEST"] == ("${{ steps.upload.outputs.artifact-digest }}")
     assert "Missing candidate artifact digest" in digest_guard["run"]
 
     macos_job = str(jobs["macos-app"])

--- a/cli/tests/test_windows_installer_artifacts.py
+++ b/cli/tests/test_windows_installer_artifacts.py
@@ -439,10 +439,7 @@ def test_builder_pins_a_project_supported_embedded_python_and_checks_metadata() 
     build = BUILD_PS1.read_text(encoding="utf-8")
     assert '$PythonVersion = "3.13.14"' in build
     assert '$PythonTargetVersion = "3.13"' in build
-    assert (
-        '$PythonEmbedSha256 = "90B4E5B9898B72D744650524BFF92377C367F44BD5FBD09E3148656C080AD907"'
-        in build
-    )
+    assert '$PythonEmbedSha256 = "90B4E5B9898B72D744650524BFF92377C367F44BD5FBD09E3148656C080AD907"' in build
     assert "dist.metadata.get('Requires-Python')" in build
     assert "SpecifierSet(requires_python).contains(platform.python_version(), prereleases=True)" in build
     assert "if not magika_result.ok or not magika_result.output.is_text:" in build
@@ -664,11 +661,25 @@ def test_builder_checks_distroot_gateway_and_hook_identity_before_signing() -> N
     assert build.index(hook_check) < build.index(signing_call)
 
 
+def test_authenticode_credentials_use_strict_three_state_policy() -> None:
+    build = BUILD_PS1.read_text(encoding="utf-8")
+    signing = re.search(
+        r"(?ms)^function Set-FileSignaturesIfConfigured\b.*?(?=^function |^if \(-not \$IsWindows\))",
+        build,
+    )
+    assert signing
+    body = signing.group(0)
+    assert "$hasCertificate -xor $hasPassword" in body
+    assert "provide both WINDOWS_SIGNING_CERT_BASE64 and WINDOWS_SIGNING_CERT_PASSWORD, or neither" in body
+    assert "artifact is explicitly unverified" in body
+    assert body.index("$hasCertificate -xor $hasPassword") < body.rindex("return $false")
+    assert "signtool.exe" in body
+    assert "Cisco Systems, Inc." in body
+
+
 def test_reproducible_launcher_builds_include_final_pe_resources() -> None:
     build = BUILD_PS1.read_text(encoding="utf-8")
-    function = re.search(
-        r"(?ms)^function Build-VerifiedGoBinary\b.*?(?=^function |\Z)", build
-    )
+    function = re.search(r"(?ms)^function Build-VerifiedGoBinary\b.*?(?=^function |\Z)", build)
     assert function
     body = function.group(0)
     assert "foreach ($target in @($verification, $Output))" in body
@@ -721,11 +732,11 @@ def test_stale_or_off_commit_distroot_binary_identity_is_rejected(tmp_path: Path
     source = tmp_path / "main.go"
     source.write_text(
         "package main\n"
-        "import (\"encoding/json\"; \"os\")\n"
+        'import ("encoding/json"; "os")\n'
         "func main() { _ = json.NewEncoder(os.Stdout).Encode(map[string]any{"
-        "\"schema_version\": 1, \"name\": os.Getenv(\"DC_IDENTITY_NAME\"), "
-        "\"version\": os.Getenv(\"DC_IDENTITY_VERSION\"), "
-        "\"commit\": os.Getenv(\"DC_IDENTITY_COMMIT\")}) }\n",
+        '"schema_version": 1, "name": os.Getenv("DC_IDENTITY_NAME"), '
+        '"version": os.Getenv("DC_IDENTITY_VERSION"), '
+        '"commit": os.Getenv("DC_IDENTITY_COMMIT")}) }\n',
         encoding="utf-8",
     )
     executable = tmp_path / "distroot-binary.exe"

--- a/cli/tests/test_windows_release_certification.py
+++ b/cli/tests/test_windows_release_certification.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Cisco Systems, Inc. and its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
-"""Fail-closed contracts for the signed Windows real-client release gate."""
+"""Fail-closed contracts for signed and explicitly unverified Windows releases."""
 
 import json
 import re
@@ -11,9 +11,7 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 HARNESS = (ROOT / "scripts" / "windows-native-ci.ps1").read_text(encoding="utf-8")
-PACKAGED_V8_VALIDATOR = (
-    ROOT / "scripts" / "validate_packaged_v8_resources.py"
-).read_text(encoding="utf-8")
+PACKAGED_V8_VALIDATOR = (ROOT / "scripts" / "validate_packaged_v8_resources.py").read_text(encoding="utf-8")
 LIVE = (ROOT / "scripts" / "live-connector-e2e" / "run-windows.ps1").read_text(encoding="utf-8")
 RELEASE = (ROOT / ".github" / "workflows" / "release.yaml").read_text(encoding="utf-8")
 
@@ -95,6 +93,7 @@ def test_certification_evidence_derives_versions_from_installed_specs() -> None:
     evidence = gate.split("$evidence = [ordered]@{", 1)[1]
     assert "[string]$clients['codex'].Specification.Version" in evidence
     assert "[string]$clients['claudecode'].Specification.Version" in evidence
+    assert "verification_status = 'signed'" in evidence
     assert "codex = '0.144.3'" not in evidence
     assert "claudecode = '2.1.208'" not in evidence
 
@@ -179,6 +178,20 @@ def test_publish_has_non_advisory_real_client_certification_custody() -> None:
     )
     assert certification_index < upload_index
     assert int(certification["timeout-minutes"]) >= 90
+
+    provider_gate = next(
+        step for step in certification["steps"] if step.get("name") == "Require both real-client provider credentials"
+    )
+    certify_step = certification["steps"][certification_index]
+    unverified_step = next(
+        step
+        for step in certification["steps"]
+        if step.get("name") == "Record explicit unverified Windows Setup custody"
+    )
+    assert provider_gate["if"] == "${{ needs.windows-installer.outputs.verification_status == 'signed' }}"
+    assert certify_step["if"] == "${{ needs.windows-installer.outputs.verification_status == 'signed' }}"
+    assert unverified_step["if"] == ("${{ needs.windows-installer.outputs.verification_status == 'unverified' }}")
+    assert "record-windows-unverified" in unverified_step["run"]
 
     assert "windows-real-client-certification" in assemble["needs"]
     assert "windows-real-client-certification" in full["needs"]

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -132,9 +132,11 @@ Nightly/manual certification seals one candidate, then runs
 Linux/macOS baselines plus native fresh-install and live-continuity gates.
 The final release reuses those exact certified bytes, or invokes that complete
 certification workflow on a cache miss. Legacy raw Windows runtime archives
-remain omitted, while the signed `DefenseClawSetup-x64.exe` and its custody
-sidecars are built, certified with real Codex and Claude clients, and promoted
-from the same sealed candidate. A broken refusal, bridge handoff, migration,
+remain omitted, while exactly one `DefenseClawSetup-x64.exe` and its custody
+sidecars are promoted from the same sealed candidate. Complete Authenticode
+credentials require signing plus real Codex and Claude certification; absent
+credentials produce an explicitly unverified lifecycle-tested Setup, while a
+partial or invalid credential set aborts. A broken refusal, bridge handoff, migration,
 rollback, installer lifecycle, health, or history path aborts before publication.
 
 ### 0.8.4 bridge rollout order

--- a/docs/WINDOWS-NATIVE-CI.md
+++ b/docs/WINDOWS-NATIVE-CI.md
@@ -41,25 +41,29 @@ cleanup step.
 
 The pull-request gate remains secretless. Manual real-client cells in
 `Connector Live E2E` are an alerting/regression radar and are not a fork-PR
-merge gate. Production publication has a separate required Windows release
-cell: it installs the exact Authenticode-signed Setup artifact, installs exact
-official Codex and Claude Code versions, fails closed when either provider
-credential is unavailable, and requires both connectors' live allow/block,
-audit, and OTLP evidence, plus Codex automatic-trust evidence. The
-`publish-release` job depends directly on that cell, and
-the resulting `DefenseClawSetup-x64.exe.certification.json` is included in the
-signed release checksum set. Its bounded three-hour job budget leaves time for
-cleanup and failure-diagnostics upload after every bounded child operation. The
-certification cell never builds or installs
-DefenseClaw from the source checkout.
+merge gate. Production publication has a separate required Windows custody
+cell. When Authenticode credentials are complete, it installs the exact signed
+Setup artifact and exact official Codex and Claude Code versions, fails closed
+when either provider credential is unavailable, and requires both connectors'
+live allow/block, audit, and OTLP evidence, plus Codex automatic-trust evidence.
+When both signing credentials are absent, those signed-only client checks are
+skipped and the prior standard-user lifecycle result is recorded explicitly as
+`unverified`, without publisher, client, or connector claims. Partial or invalid
+signing credentials always fail. The `publish-release` job depends directly on
+that cell, and the resulting `DefenseClawSetup-x64.exe.certification.json` is
+included in the signed release checksum set. Its bounded three-hour job budget
+leaves time for cleanup and failure-diagnostics upload after every bounded child
+operation. The certification cell never builds or installs DefenseClaw from the
+source checkout.
 
 Starting with the 0.8.6 release, the Windows release path is a non-advisory
 chain: `windows-installer` consumes the protected runtime artifact by immutable
-artifact ID and digest; `windows-real-client-certification` consumes the signed
-Setup bundle the same way; and `assemble-release-candidate` accepts the five
-certified assets only through `--windows-dir` after validating the
-certification artifact's emitted SHA-256 digest. Those assets are the Setup EXE,
-its SHA-256 sidecar, provenance, SPDX SBOM, and real-client certification.
+artifact ID and digest; `windows-real-client-certification` consumes the Setup
+bundle the same way and either certifies the signed branch or records explicit
+unverified custody; and `assemble-release-candidate` accepts the five assets
+only through `--windows-dir` after validating the custody artifact's emitted
+SHA-256 digest. Those assets are the Setup EXE, its SHA-256 sidecar, provenance,
+SPDX SBOM, and certification/status record.
 Every sealed-candidate consumer authenticates `checksums.txt` with
 `checksums.txt.bundle` in offline mode and the exact protected-main Sigstore
 identity before using any asset. Only `publish-release` has `contents: write`.
@@ -70,7 +74,7 @@ same-version servicing, and uninstall. The separate `windows-upgrade` matrix
 is deliberately skipped for 0.8.6 because the immediately preceding 0.8.5
 release has no native Setup baseline. The publish step still passes
 `--omit-windows-binaries` at both selection and custody verification so legacy
-raw Windows archives remain absent; the signed, certified Setup and its four
+raw Windows archives remain absent; exactly one Setup EXE and its four custody
 sidecars are nevertheless published from the sealed candidate.
 
 GitHub-hosted Windows runners do not provide the certified Docker Desktop

--- a/docs/WINDOWS-NATIVE-INSTALLER.md
+++ b/docs/WINDOWS-NATIVE-INSTALLER.md
@@ -84,8 +84,9 @@ The release also publishes `checksums.txt.bundle` beside the detached
 signature and certificate. The compatibility bootstrap passes that bundled
 transparency-log proof to pinned Cosign with `--offline`. The authenticated
 checksum root must contain exactly one entry each for Setup, its provenance,
-and the upgrade manifest. The provenance must describe a signed schema-1 OSS
-artifact and repeat Setup's exact authenticated SHA-256. Local mode requires
+and the upgrade manifest. The provenance must describe an internally consistent
+signed or explicitly unverified schema-1 OSS artifact and repeat Setup's exact
+authenticated SHA-256. Local mode requires
 the complete release bundle plus the pinned Cosign executable and performs no
 network access.
 
@@ -110,14 +111,14 @@ metadata, then repairs the affected wheel `RECORD` files. Release CI pins Go
 through `go.mod`, pins `uv`, and executes ZIP generation with the pinned
 embedded CPython runtime.
 
-The Setup SBOM is one merged SPDX 2.3 JSON document generated after the outer
-EXE is signed. It describes the exact outer checksum and exact embedded payload
+The Setup SBOM is one merged SPDX 2.3 JSON document generated after the
+Authenticode decision. It describes the exact outer checksum and exact embedded payload
 archive, records every payload digest, and expands the CPython standard
 library, complete `site-packages.zip`, project and YARA compatibility wheels,
-and signed gateway archive. Python distribution metadata, dependencies,
+and gateway archive. Python distribution metadata, dependencies,
 licenses, and every embedded file are included alongside the gateway, hook,
 launchers, and pinned Cosign verifier. Go build information is read from the
-exact signed Setup, gateway, hook, launchers, and Cosign bytes; their runtime
+exact Setup, gateway, hook, launchers, and Cosign bytes; their runtime
 and transitive modules are emitted with purls and Go module sums. Generation
 fails closed if the staged payload differs from its manifest, an expected
 component is absent, a Python distribution lacks metadata, a Go binary digest
@@ -136,15 +137,19 @@ treated as a managed release. An OSS Windows install configured as
 requested instead of silently degrading to an unusable provider.
 
 Local and pull-request builds are unsigned and are labeled as such in Installed
-Apps. Release builds require real Authenticode credentials. Before the payload
-manifest is hashed, the builder signs the native CLI launcher, console-free
-startup helper, gateway, and hook entry point; the installed scanner launchers
-are byte-identical copies of that signed CLI launcher. It then signs the outer
-setup executable. The build imports
-the PFX temporarily into the current-user certificate store, invokes SignTool
-by certificate thumbprint, uses an allowlisted HTTPS timestamp endpoint,
-verifies the exact publisher `Cisco Systems, Inc.` on every signed executable,
-and removes the certificate and private build directory in a `finally` path. No
+Apps. Release signing follows the same all-or-none policy as macOS credentials:
+when both Authenticode secrets are absent the workflow publishes an explicitly
+unverified Setup, when exactly one is present the release fails, and when both
+are present signing is mandatory and any certificate, password, SignTool,
+timestamp, or publisher failure aborts instead of falling back to unsigned.
+For the signed path, before the payload manifest is hashed, the builder signs
+the native CLI launcher, console-free startup helper, gateway, and hook entry
+point; the installed scanner launchers are byte-identical copies of that signed
+CLI launcher. It then signs the outer setup executable. The build imports the
+PFX temporarily into the current-user certificate store, invokes SignTool by
+certificate thumbprint, uses an allowlisted HTTPS timestamp endpoint, verifies
+the exact publisher `Cisco Systems, Inc.` on every signed executable, and
+removes the certificate and private build directory in a `finally` path. No
 development certificate or fabricated Cisco signature is generated.
 
 ### Native executable resources
@@ -269,7 +274,7 @@ Before the private staging tree can be published, Setup requires an exact
 one-to-one match between its Authenticode inventory and every extracted PE,
 checks each file digest, and enforces the recorded Windows trust policy. Signed
 DefenseClaw executables must retain the Cisco publisher, signer identity, and
-RFC 3161 timestamp; unsigned PR/local builds are accepted only when the
+RFC 3161 timestamp; unsigned builds are accepted only when the
 manifest explicitly declares the unsigned policy. Setup repeats inventory
 verification after publication and verifies the maintenance and stable-hook
 copies so extraction or copy-time tampering cannot silently cross the install
@@ -290,33 +295,37 @@ Those installations must be serviced by the enterprise deployment channel.
 
 ## Release and certification gate
 
-Starting with 0.8.6, the release workflow builds setup on `windows-latest`,
-requires real signing credentials, and runs the full native
-install/repair/connector/uninstall acceptance
-suite against that exact signed EXE (including installed-publisher validation),
-uploads the staging bundle, and passes its immutable artifact ID and SHA-256
-digest to a separate non-advisory real-client job. That job downloads the exact
-bundle by ID, verifies the Cisco signature plus installer sidecar/provenance
-digests, requires provenance and installed payload state to match the exact
-workflow `GITHUB_SHA`, and installs that same EXE. The gate installs
-exact official Codex CLI `0.144.3` and Claude Code `2.1.208` packages, requires
-both provider credentials, verifies automatic Codex hook trust without a manual
-`/hooks` approval, and requires lifecycle, tool allow/block, gateway JSONL,
-SQLite audit correlation, and connector-tagged OTLP evidence from both clients.
-It then runs repair and same-version upgrade with the same signed Setup bytes and
-requires uninstall itself to remove both connectors, user data, Installed Apps,
-and the user PATH entry while preserving a seeded unrelated `~/.codex/hooks.json`
-handler byte-for-byte. Missing secrets, either skipped connector, an unsigned
-or non-Cisco executable, a client-version mismatch, or missing evidence fails the
-release before publication. The workflow emits SHA-256, merged SPDX SBOM,
-provenance, and `DefenseClawSetup-x64.exe.certification.json`, then adds every
-artifact to the final checksum manifest before the immutable release is created.
-macOS and Linux artifacts continue through their existing build path.
+Starting with 0.8.6, the release workflow builds Setup on `windows-latest` and
+runs the full native install/repair/connector/uninstall acceptance suite against
+the exact EXE. The Authenticode branch is selected before the build and bound to
+the resulting provenance. With complete credentials, the workflow passes the
+immutable staging artifact to a separate non-advisory real-client job. That job
+verifies the Cisco signature plus installer sidecar/provenance digests, requires
+provenance and installed payload state to match the exact workflow `GITHUB_SHA`,
+and installs that same EXE. The signed gate installs exact official
+Codex CLI `0.144.3` and Claude Code `2.1.208` packages, requires both provider credentials,
+verifies automatic Codex hook trust without a manual
+`/hooks` approval, and
+requires lifecycle, tool allow/block, gateway JSONL, SQLite audit correlation,
+and connector-tagged OTLP evidence from both clients. It then runs repair and
+same-version upgrade with the same Setup bytes and requires uninstall itself to
+remove both connectors, user data, Installed Apps, and the user PATH entry while
+preserving a seeded unrelated `~/.codex/hooks.json` handler byte-for-byte.
+
+When both Authenticode credentials are absent, the signed real-client cell is
+skipped and the already-passed standard-user lifecycle result is recorded as
+explicitly `unverified`; the certification sidecar has no publisher, clients, or
+connector claims. Partial signing credentials, invalid signing material, a bad
+publisher or timestamp, and any signed-branch certification failure still abort
+before publication. The workflow emits SHA-256, merged SPDX SBOM, provenance,
+and `DefenseClawSetup-x64.exe.certification.json`, then adds every artifact to
+the final checksum manifest before the immutable release is created. macOS and
+Linux artifacts continue through their existing build path.
 
 The Windows chain transfers each intermediate by immutable GitHub Actions
-artifact ID and digest; assembly rejects a missing or malformed certification
-artifact digest before processing its exact-ID download. Certification emits
-exactly five release assets:
+artifact ID and digest; assembly rejects a missing or malformed custody artifact
+digest before processing its exact-ID download. The signed and unverified paths
+both emit exactly five release assets:
 `DefenseClawSetup-x64.exe`, its `.sha256`, `.provenance.json`, `.sbom.json`, and
 `.certification.json` sidecars. Assembly consumes that directory explicitly via
 `--windows-dir`, seals all five bytes into the candidate, and signs
@@ -330,7 +339,11 @@ because 0.8.5 did not publish a native Setup baseline; the fresh gate still
 exercises install, repair, same-version servicing, and uninstall. Both publish
 selection and post-publish custody verification retain
 `--omit-windows-binaries` to exclude legacy raw Windows archives only. They do
-not exclude the signed Setup or its four certified sidecars.
+not exclude Setup or its four custody sidecars. The unverified EXE can be
+downloaded and run directly for a fresh install. The authenticated PowerShell
+bootstrap and automatic upgrade path deliberately continue to reject unsigned
+Setup targets rather than silently weakening an existing installation's trust
+policy.
 
 Pull-request CI builds an unsigned setup and runs setup acceptance only on the
 disposable GitHub Actions user. Local setup acceptance refuses to mutate the

--- a/scripts/build-windows-installer.ps1
+++ b/scripts/build-windows-installer.ps1
@@ -648,8 +648,13 @@ function Set-FileSignaturesIfConfigured([string[]]$Paths, [string]$BuildRoot) {
     }
     $cert64 = [Environment]::GetEnvironmentVariable("WINDOWS_SIGNING_CERT_BASE64")
     $certPassword = [Environment]::GetEnvironmentVariable("WINDOWS_SIGNING_CERT_PASSWORD")
-    if ([string]::IsNullOrWhiteSpace($cert64) -or [string]::IsNullOrWhiteSpace($certPassword)) {
-        Write-Warning "No real Authenticode credentials provided; artifact is an unsigned local/PR build."
+    $hasCertificate = -not [string]::IsNullOrWhiteSpace($cert64)
+    $hasPassword = -not [string]::IsNullOrWhiteSpace($certPassword)
+    if ($hasCertificate -xor $hasPassword) {
+        throw 'Authenticode signing is partially configured; provide both WINDOWS_SIGNING_CERT_BASE64 and WINDOWS_SIGNING_CERT_PASSWORD, or neither.'
+    }
+    if (-not $hasCertificate) {
+        Write-Warning "No real Authenticode credentials provided; artifact is explicitly unverified."
         return $false
     }
     $signtool = (Get-Command 'signtool.exe' -ErrorAction Stop).Source

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -52,7 +52,10 @@ try:
         release_identity_for_version,
     )
 except ModuleNotFoundError:  # Direct ``python scripts/release_candidate.py`` execution.
-    from source_release_identity import SourceIdentityError, release_identity_for_version
+    from source_release_identity import (
+        SourceIdentityError,
+        release_identity_for_version,
+    )
 
 try:
     from scripts.telemetry_runtime_assets import RuntimeAssetError, read_logical_asset
@@ -72,9 +75,7 @@ WINDOWS_NUMERIC_SHORT_NAME_RE = re.compile(r"^[a-z0-9]{1,6}~[0-9]+$")
 MAX_GATEWAY_BINARY_BYTES = 512 * 1024 * 1024
 PROTECTED_ARTIFACT_MAGIC = b"DEFENSECLAW-PROTECTED-ARTIFACT-V1\n"
 PROTECTED_ARTIFACT_XOR_BYTE = 0xA5
-PROTECTED_ARTIFACT_TRANSLATION = bytes(
-    value ^ PROTECTED_ARTIFACT_XOR_BYTE for value in range(256)
-)
+PROTECTED_ARTIFACT_TRANSLATION = bytes(value ^ PROTECTED_ARTIFACT_XOR_BYTE for value in range(256))
 MAX_PROTECTED_ARTIFACT_BYTES = MAX_GATEWAY_BINARY_BYTES + len(PROTECTED_ARTIFACT_MAGIC)
 ROOT = Path(__file__).resolve().parents[1]
 V8_CONFIG_WHEEL_RESOURCES = (
@@ -134,9 +135,7 @@ MAX_RESOLVER_BYTES = 4 * 1024 * 1024
 MAX_RELEASE_CERTIFICATE_BYTES = 64 * 1024
 MAX_EFFECTIVE_UPGRADE_BASELINES_BYTES = 1024 * 1024
 EFFECTIVE_UPGRADE_BASELINES_FILENAME = "effective-upgrade-baselines.json"
-STRICT_BASE64_RE = re.compile(
-    rb"(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?"
-)
+STRICT_BASE64_RE = re.compile(rb"(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?")
 MACOS_VERIFICATION_STATUSES = ("notarized", "unverified")
 WINDOWS_SETUP_START_VERSION = (0, 8, 6)
 WINDOWS_SETUP_ASSET = "DefenseClawSetup-x64.exe"
@@ -157,14 +156,13 @@ WINDOWS_SETUP_CERTIFICATION_REQUIREMENTS = (
     "upgrade",
     "uninstall",
 )
+WINDOWS_SETUP_UNVERIFIED_REQUIREMENTS = ("setup-acceptance",)
 CHECKSUMS_BUNDLE_FILENAME = "checksums.txt.bundle"
 MAX_WINDOWS_SETUP_BYTES = 2 * 1024 * 1024 * 1024
 MAX_WINDOWS_SETUP_METADATA_BYTES = 128 * 1024 * 1024
 MAX_LEGACY_COSIGN_BUNDLE_BYTES = 16 * 1024 * 1024
 WINDOWS_PYTHON_EMBED_NAME = "python-3.13.14-embed-amd64.zip"
-WINDOWS_PYTHON_EMBED_URL = (
-    "https://www.python.org/ftp/python/3.13.14/python-3.13.14-embed-amd64.zip"
-)
+WINDOWS_PYTHON_EMBED_URL = "https://www.python.org/ftp/python/3.13.14/python-3.13.14-embed-amd64.zip"
 WINDOWS_PYTHON_EMBED_SHA256 = "90b4e5b9898b72d744650524bff92377c367f44bd5fbd09e3148656c080ad907"
 WINDOWS_PYTHON_RUNTIME_REVIEW_DEADLINE = "2026-09-10T00:00:00.0000000+00:00"
 WINDOWS_YARA_COMPAT_WHEEL = "yara_python-4.5.4.post1-py3-none-any.whl"
@@ -177,9 +175,7 @@ WINDOWS_COSIGN_VERSION = "2.6.2"
 WINDOWS_COSIGN_URL = "https://github.com/sigstore/cosign/releases/download/v2.6.2/cosign-windows-amd64.exe"
 WINDOWS_COSIGN_SHA256 = "dd6c61e510da627bcaed4cd9db844ec11cacd09826d814d89f7f68d40feb07be"
 WINDOWS_RESOURCE_POLICY = "internal/windowsresources"
-WINDOWS_RESOURCE_ICON = (
-    "macos/DefenseClawMac/DefenseClawMac/Assets.xcassets/AppIcon.appiconset/icon_256.png"
-)
+WINDOWS_RESOURCE_ICON = "macos/DefenseClawMac/DefenseClawMac/Assets.xcassets/AppIcon.appiconset/icon_256.png"
 WINDOWS_RESOURCE_ICON_SHA256 = "4425858688397762266ceb5304dcbca7afe330ec1c262dd2addcb7539b14b2bf"
 
 
@@ -266,7 +262,9 @@ def _directory_identity(info: os.stat_result) -> tuple[int, int, int]:
     return (info.st_dev, info.st_ino, stat.S_IFMT(info.st_mode))
 
 
-def _read_release_certificate(path: Path) -> tuple[bytes, os.stat_result, os.stat_result]:
+def _read_release_certificate(
+    path: Path,
+) -> tuple[bytes, os.stat_result, os.stat_result]:
     """Read one bounded regular certificate file without following a symlink."""
 
     try:
@@ -390,10 +388,9 @@ def _atomic_replace_release_certificate(
 
         current_file = path.lstat()
         current_parent = path.parent.lstat()
-        if (
-            _file_state(current_file) != _file_state(expected_file)
-            or _directory_identity(current_parent) != _directory_identity(expected_parent)
-        ):
+        if _file_state(current_file) != _file_state(expected_file) or _directory_identity(
+            current_parent
+        ) != _directory_identity(expected_parent):
             raise CandidateError("release certificate path changed before atomic publication")
         os.replace(temporary_name, path)
         temporary_name = ""
@@ -472,9 +469,7 @@ def _write_protected_artifact(source: Path, destination: Path) -> None:
             destination.unlink()
         except FileNotFoundError:
             pass
-        raise CandidateError(
-            f"could not create protected runtime artifact {destination.name}: {exc}"
-        ) from exc
+        raise CandidateError(f"could not create protected runtime artifact {destination.name}: {exc}") from exc
 
 
 def _validate_version(version: str) -> None:
@@ -509,7 +504,10 @@ def runtime_asset_names(version: str) -> tuple[str, ...]:
             for arch in ("amd64", "arm64")
         )
         wheel = protected["wheel"]
-        refusal_assets = (*canonical_archives, f"defenseclaw-{version}-py3-none-any.whl")
+        refusal_assets = (
+            *canonical_archives,
+            f"defenseclaw-{version}-py3-none-any.whl",
+        )
     return tuple(
         sorted(
             (
@@ -527,8 +525,7 @@ def runtime_asset_names(version: str) -> tuple[str, ...]:
 def _validate_macos_verification_status(status: object) -> str:
     if not isinstance(status, str) or status not in MACOS_VERIFICATION_STATUSES:
         raise CandidateError(
-            "macOS verification status must be exactly one of "
-            f"{MACOS_VERIFICATION_STATUSES!r}, got {status!r}"
+            f"macOS verification status must be exactly one of {MACOS_VERIFICATION_STATUSES!r}, got {status!r}"
         )
     return status
 
@@ -561,7 +558,7 @@ def release_identity_asset_names(version: str) -> tuple[str, ...]:
 
 
 def windows_installer_asset_names(version: str) -> tuple[str, ...]:
-    """Return the exact signed native-Setup custody set for 0.8.6+."""
+    """Return the exact native-Setup custody set for 0.8.6+."""
 
     _validate_version(version)
     if tuple(map(int, version.split("."))) < WINDOWS_SETUP_START_VERSION:
@@ -627,9 +624,7 @@ def windows_release_binary_names(version: str) -> tuple[str, ...]:
     """Return Windows runtime binaries and SBOMs, excluding the refusal resolver."""
 
     _validate_version(version)
-    canonical = tuple(
-        f"defenseclaw_{version}_windows_{arch}.zip" for arch in ("amd64", "arm64")
-    )
+    canonical = tuple(f"defenseclaw_{version}_windows_{arch}.zip" for arch in ("amd64", "arm64"))
     if tuple(map(int, version.split("."))) < (0, 8, 4):
         archives = canonical
         sboms = tuple(f"{name}.sbom.json" for name in archives)
@@ -717,12 +712,16 @@ def _load_upgrade_baseline_policy(
     if candidate_version is None:
         try:
             source_identity = json.loads(
-                (ROOT / "release" / "source-install-identity.json").read_text(
-                    encoding="utf-8"
-                )
+                (ROOT / "release" / "source-install-identity.json").read_text(encoding="utf-8")
             )
             candidate_version = source_identity["source_release"]
-        except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        except (
+            OSError,
+            UnicodeError,
+            json.JSONDecodeError,
+            KeyError,
+            TypeError,
+        ) as exc:
             raise CandidateError("could not resolve source release for baseline validation") from exc
         if not isinstance(candidate_version, str) or not VERSION_RE.fullmatch(candidate_version):
             raise CandidateError("source release for baseline validation is invalid")
@@ -758,10 +757,7 @@ def _load_upgrade_baseline_policy(
             or value > _runtime_config_version_from_source(candidate_version)
             for value in config_versions.values()
         )
-        or (
-            "0.8.4" in config_versions
-            and config_versions.get("0.8.4") != 7
-        )
+        or ("0.8.4" in config_versions and config_versions.get("0.8.4") != 7)
         or not isinstance(platforms, dict)
         or set(platforms) != {"windows"}
     ):
@@ -782,9 +778,7 @@ def _load_upgrade_baseline_policy(
 
 def _validate_historical_artifact_digest_policy(configured: list[str]) -> None:
     try:
-        document = json.loads(
-            HISTORICAL_ARTIFACT_DIGESTS_PATH.read_text(encoding="utf-8")
-        )
+        document = json.loads(HISTORICAL_ARTIFACT_DIGESTS_PATH.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise CandidateError(f"could not load historical artifact digest policy: {exc}") from exc
     if not isinstance(document, dict) or set(document) != {
@@ -802,16 +796,14 @@ def _validate_historical_artifact_digest_policy(configured: list[str]) -> None:
         or not isinstance(exceptions, dict)
     ):
         raise CandidateError("historical artifact digest policy is invalid")
+
     def version_key(value: str) -> tuple[int, int, int]:
         return tuple(map(int, value.split(".")))
 
-    expected_versions = {
-        version for version in configured if version_key(version) < version_key(coverage_start)
-    }
+    expected_versions = {version for version in configured if version_key(version) < version_key(coverage_start)}
     if set(exceptions) != expected_versions:
         raise CandidateError(
-            "historical artifact digest exceptions must exactly match tested baselines "
-            "below signed-wheel coverage"
+            "historical artifact digest exceptions must exactly match tested baselines below signed-wheel coverage"
         )
     for version, artifacts in exceptions.items():
         expected_name = f"defenseclaw-{version}-py3-none-any.whl"
@@ -821,9 +813,7 @@ def _validate_historical_artifact_digest_policy(configured: list[str]) -> None:
             or not isinstance(artifacts.get(expected_name), str)
             or not SHA256_RE.fullmatch(artifacts[expected_name])
         ):
-            raise CandidateError(
-                f"historical digest exception for {version} must be one canonical wheel digest"
-            )
+            raise CandidateError(f"historical digest exception for {version} must be one canonical wheel digest")
 
 
 def validate_release_progression(target: str, releases_json: Path) -> tuple[str, str]:
@@ -855,9 +845,7 @@ def validate_release_progression(target: str, releases_json: Path) -> tuple[str,
             continue
         tag = row.get("tag_name")
         if not isinstance(tag, str) or not VERSION_RE.fullmatch(tag):
-            raise CandidateError(
-                f"published stable release has a non-canonical tag: {tag!r}"
-            )
+            raise CandidateError(f"published stable release has a non-canonical tag: {tag!r}")
         stable_versions.append(tag)
 
     def version_key(value: str) -> tuple[int, int, int]:
@@ -919,8 +907,7 @@ def _expected_release_artifacts(version: str) -> dict[str, Any]:
     gateways: dict[str, dict[str, str]] = {}
     for os_name in ("darwin", "linux", "windows"):
         gateways[os_name] = {
-            arch: f"defenseclaw_{version}_protocol2_{os_name}_{arch}.dcgateway"
-            for arch in ("amd64", "arm64")
+            arch: f"defenseclaw_{version}_protocol2_{os_name}_{arch}.dcgateway" for arch in ("amd64", "arm64")
         }
     return {
         "wheel": f"defenseclaw-{version}-2-py3-none-any.dcwheel",
@@ -939,15 +926,11 @@ def _validate_upgrade_manifest(
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise CandidateError(f"invalid upgrade manifest {path}: {exc}") from exc
     if document.get("release_version") != version:
-        raise CandidateError(
-            f"upgrade manifest release_version={document.get('release_version')!r}; want {version!r}"
-        )
+        raise CandidateError(f"upgrade manifest release_version={document.get('release_version')!r}; want {version!r}")
     version_key = tuple(map(int, version.split(".")))
     expected_schema = 2 if version_key >= (0, 8, 4) else 1
     if document.get("schema_version") != expected_schema:
-        raise CandidateError(
-            f"upgrade manifest schema_version must be {expected_schema} for release {version}"
-        )
+        raise CandidateError(f"upgrade manifest schema_version must be {expected_schema} for release {version}")
     if document.get("migration_failure_policy") != "fail":
         raise CandidateError("release upgrade manifest must fail closed on required migration errors")
     min_protocol = document.get("min_upgrade_protocol", 1)
@@ -973,16 +956,10 @@ def _validate_upgrade_manifest(
         if not isinstance(tested, list) or not isinstance(platform_tested, dict):
             raise CandidateError("schema-2 manifest lacks its complete tested-source policy")
         if set(platform_tested) != {"windows"} or not isinstance(platform_tested["windows"], list):
-            raise CandidateError(
-                "platform_tested_source_versions must contain exactly the Windows source list"
-            )
-        expected_tested = [
-            item for item in configured if tuple(map(int, item.split("."))) < version_key
-        ]
+            raise CandidateError("platform_tested_source_versions must contain exactly the Windows source list")
+        expected_tested = [item for item in configured if tuple(map(int, item.split("."))) < version_key]
         expected_windows = [
-            item
-            for item in platform_configured["windows"]
-            if tuple(map(int, item.split("."))) < version_key
+            item for item in platform_configured["windows"] if tuple(map(int, item.split("."))) < version_key
         ]
         manifest_bridge = document.get("required_bridge_version")
         if manifest_bridge and manifest_bridge not in expected_windows:
@@ -990,11 +967,7 @@ def _validate_upgrade_manifest(
             # from older sources unsupported on that platform. Retain only
             # actually published post-hard-cut runtimes, which can drive a
             # direct protocol-2 transition without the bridge.
-            expected_windows = [
-                item
-                for item in expected_windows
-                if tuple(map(int, item.split("."))) >= (0, 8, 5)
-            ]
+            expected_windows = [item for item in expected_windows if tuple(map(int, item.split("."))) >= (0, 8, 5)]
         if tested != expected_tested:
             raise CandidateError(
                 "tested_source_versions must exactly match every reviewed baseline older than the candidate"
@@ -1012,23 +985,12 @@ def _validate_upgrade_manifest(
             )
         source_runtime = _runtime_config_version_from_source(version)
         if source_runtime != expected_runtime:
-            literal = (
-                "ObservabilityV8ConfigVersion"
-                if version_key >= (0, 8, 5)
-                else "CurrentConfigVersion"
-            )
+            literal = "ObservabilityV8ConfigVersion" if version_key >= (0, 8, 5) else "CurrentConfigVersion"
             raise CandidateError(
-                f"release {version} requires gateway {literal}={expected_runtime}, "
-                f"got {source_runtime}"
+                f"release {version} requires gateway {literal}={expected_runtime}, got {source_runtime}"
             )
-        if (
-            not isinstance(runtime_config, int)
-            or isinstance(runtime_config, bool)
-            or runtime_config != source_runtime
-        ):
-            raise CandidateError(
-                "runtime_config_version must match the release-selected gateway config literal"
-            )
+        if not isinstance(runtime_config, int) or isinstance(runtime_config, bool) or runtime_config != source_runtime:
+            raise CandidateError("runtime_config_version must match the release-selected gateway config literal")
         if release_artifacts != _expected_release_artifacts(version):
             raise CandidateError(
                 "release_artifacts must explicitly name the exact protected wheel and platform gateways"
@@ -1038,26 +1000,21 @@ def _validate_upgrade_manifest(
             for os_name in ("darwin", "linux", "windows")
             for arch in ("amd64", "arm64")
         ]
-        if len(flattened) != len(set(flattened)) or any(
-            Path(name).name != name for name in flattened
-        ):
+        if len(flattened) != len(set(flattened)) or any(Path(name).name != name for name in flattened):
             raise CandidateError("release_artifacts names must be unique basenames")
     elif (
-        tested is not None
-        or platform_tested is not None
-        or runtime_config is not None
-        or release_artifacts is not None
+        tested is not None or platform_tested is not None or runtime_config is not None or release_artifacts is not None
     ):
         raise CandidateError("schema-1 candidate must not declare schema-2 policy")
 
-    bridge_keys = ("minimum_source_version", "required_bridge_version", "auto_bridge_from")
+    bridge_keys = (
+        "minimum_source_version",
+        "required_bridge_version",
+        "auto_bridge_from",
+    )
     bridge_presence = [key in document for key in bridge_keys]
-    if version_key >= (0, 8, 5) and (
-        min_protocol != 2 or not all(bridge_presence)
-    ):
-        raise CandidateError(
-            "0.8.5+ hard-cut release requires upgrade protocol 2 and a complete bridge contract"
-        )
+    if version_key >= (0, 8, 5) and (min_protocol != 2 or not all(bridge_presence)):
+        raise CandidateError("0.8.5+ hard-cut release requires upgrade protocol 2 and a complete bridge contract")
     if any(bridge_presence) and not all(bridge_presence):
         raise CandidateError("upgrade manifest bridge contract is incomplete")
     if min_protocol > 1 and not all(bridge_presence):
@@ -1084,33 +1041,23 @@ def _validate_upgrade_manifest(
         raise CandidateError("upgrade manifest auto_bridge_from must contain unique X.Y.Z versions")
 
     if tested is None or platform_tested is None:
-        raise CandidateError(
-            "upgrade manifest bridge contract requires the schema-2 tested-source policy"
-        )
+        raise CandidateError("upgrade manifest bridge contract requires the schema-2 tested-source policy")
     if bridge not in configured:
         raise CandidateError(f"required bridge {bridge} is absent from the tested baseline matrix")
     if bridge not in tested:
-        raise CandidateError(
-            f"required bridge {bridge} is absent from the signed global tested-source matrix"
-        )
+        raise CandidateError(f"required bridge {bridge} is absent from the signed global tested-source matrix")
     if bridge in platform_configured["windows"]:
         if bridge not in platform_tested["windows"]:
-            raise CandidateError(
-                f"required bridge {bridge} is absent from the tested Windows baseline matrix"
-            )
+            raise CandidateError(f"required bridge {bridge} is absent from the tested Windows baseline matrix")
     elif platform_tested["windows"]:
         raise CandidateError(
-            f"Windows bridge {bridge} is unpublished; the tested Windows baseline matrix "
-            "must be empty"
+            f"Windows bridge {bridge} is unpublished; the tested Windows baseline matrix must be empty"
         )
     bridge_key = tuple(map(int, bridge.split(".")))
-    expected_automatic = [
-        item for item in configured if tuple(map(int, item.split("."))) < bridge_key
-    ]
+    expected_automatic = [item for item in configured if tuple(map(int, item.split("."))) < bridge_key]
     if automatic != expected_automatic:
         raise CandidateError(
-            "auto_bridge_from must exactly match every published baseline older than "
-            f"required_bridge_version {bridge}"
+            f"auto_bridge_from must exactly match every published baseline older than required_bridge_version {bridge}"
         )
 
 
@@ -1189,9 +1136,7 @@ def _upgrade_controller_calls(
 
         def visit_Call(self, node: ast.Call) -> None:
             if isinstance(node.func, ast.Name):
-                calls.append(
-                    (node.func.id, node.lineno, self.hard_cut_guard_depth > 0)
-                )
+                calls.append((node.func.id, node.lineno, self.hard_cut_guard_depth > 0))
             self.generic_visit(node)
 
     visitor = CallVisitor()
@@ -1265,9 +1210,7 @@ def _validate_phase_two_mutator_wrapper(source: str) -> None:
     if markers != ["--defenseclaw-phase-two-mutator"]:
         raise CandidateError("0.8.4+ mutator wrapper lacks its exact private marker")
     entrypoints = [
-        node
-        for node in tree.body
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "main"
+        node for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "main"
     ]
     if len(entrypoints) != 1:
         raise CandidateError("0.8.4+ mutator wrapper must define one main entrypoint")
@@ -1285,17 +1228,12 @@ def _validate_phase_two_mutator_wrapper(source: str) -> None:
         "subprocess.run",
     ):
         if required not in call_names:
-            raise CandidateError(
-                f"0.8.4+ mutator wrapper lacks lease/child contract call {required}"
-            )
+            raise CandidateError(f"0.8.4+ mutator wrapper lacks lease/child contract call {required}")
     if len([node for node in calls if _ast_call_name(node) == "subprocess.run"]) != 1 or any(
-        _ast_call_name(node) in {"subprocess.Popen", "os.system", "os.popen"}
-        for node in calls
+        _ast_call_name(node) in {"subprocess.Popen", "os.system", "os.popen"} for node in calls
     ):
         raise CandidateError("0.8.4+ mutator wrapper has an unbound child launch")
-    inheritable_calls = [
-        node for node in calls if _ast_call_name(node) == "os.set_inheritable"
-    ]
+    inheritable_calls = [node for node in calls if _ast_call_name(node) == "os.set_inheritable"]
     if not (
         len(inheritable_calls) == 1
         and len(inheritable_calls[0].args) == 2
@@ -1327,10 +1265,7 @@ def _validate_phase_two_mutator_wrapper(source: str) -> None:
     ):
         raise CandidateError("0.8.4+ mutator wrapper child command is not argument-bound")
     keywords = {keyword.arg: keyword.value for keyword in child_launch.keywords if keyword.arg}
-    if not (
-        isinstance(keywords.get("check"), ast.Constant)
-        and keywords["check"].value is False
-    ):
+    if not (isinstance(keywords.get("check"), ast.Constant) and keywords["check"].value is False):
         raise CandidateError("0.8.4+ mutator wrapper child launch must return its status")
     close_fds = keywords.get("close_fds")
     pass_fds = keywords.get("pass_fds")
@@ -1355,14 +1290,8 @@ def _validate_phase_two_mutator_wrapper(source: str) -> None:
         node
         for node in tree.body
         if isinstance(node, ast.If)
-        and any(
-            isinstance(candidate, ast.Name) and candidate.id == "__name__"
-            for candidate in ast.walk(node.test)
-        )
-        and any(
-            isinstance(candidate, ast.Call) and _ast_call_name(candidate) == "main"
-            for candidate in ast.walk(node)
-        )
+        and any(isinstance(candidate, ast.Name) and candidate.id == "__name__" for candidate in ast.walk(node.test))
+        and any(isinstance(candidate, ast.Call) and _ast_call_name(candidate) == "main" for candidate in ast.walk(node))
     ]
     if len(module_guards) != 1:
         raise CandidateError("0.8.4+ mutator wrapper is not executable as a private child")
@@ -1377,17 +1306,10 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         raise CandidateError("0.8.5+ candidate wheel bundle transaction is invalid") from exc
 
     def references_name(node: ast.AST, name: str) -> bool:
-        return any(
-            isinstance(candidate, ast.Name) and candidate.id == name
-            for candidate in ast.walk(node)
-        )
+        return any(isinstance(candidate, ast.Name) and candidate.id == name for candidate in ast.walk(node))
 
     def static_int(node: ast.AST | None) -> int | None:
-        if (
-            isinstance(node, ast.Constant)
-            and isinstance(node.value, int)
-            and not isinstance(node.value, bool)
-        ):
+        if isinstance(node, ast.Constant) and isinstance(node.value, int) and not isinstance(node.value, bool):
             return node.value
         if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Mult):
             left = static_int(node.left)
@@ -1400,8 +1322,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
     for node in tree.body:
         value: ast.AST | None = None
         if isinstance(node, ast.Assign) and any(
-            isinstance(target, ast.Name)
-            and target.id == "_MAX_BUNDLE_ROLLBACK_METADATA_BYTES"
+            isinstance(target, ast.Name) and target.id == "_MAX_BUNDLE_ROLLBACK_METADATA_BYTES"
             for target in node.targets
         ):
             value = node.value
@@ -1415,26 +1336,19 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         if static_value is not None:
             metadata_bounds.append(static_value)
     if metadata_bounds != [4 * 1024 * 1024]:
-        raise CandidateError(
-            "0.8.5+ bundle transaction lacks the bridge metadata size bound"
-        )
+        raise CandidateError("0.8.5+ bundle transaction lacks the bridge metadata size bound")
 
     serializers = [
         node
         for node in tree.body
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        and node.name == "_serialize_windows_security"
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "_serialize_windows_security"
     ]
     if len(serializers) != 1:
-        raise CandidateError(
-            "0.8.5+ bundle transaction lacks one exact Windows security serializer"
-        )
+        raise CandidateError("0.8.5+ bundle transaction lacks one exact Windows security serializer")
     serializer = serializers[0]
     serializer_arguments = [argument.arg for argument in serializer.args.args]
     serializer_returns = [
-        node.value
-        for node in ast.walk(serializer)
-        if isinstance(node, ast.Return) and isinstance(node.value, ast.Dict)
+        node.value for node in ast.walk(serializer) if isinstance(node, ast.Return) and isinstance(node.value, ast.Dict)
     ]
     if (
         serializer.args.posonlyargs
@@ -1446,9 +1360,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         or serializer.args.kw_defaults
         or len(serializer_returns) != 1
     ):
-        raise CandidateError(
-            "0.8.5+ bundle Windows security serializer has an invalid signature"
-        )
+        raise CandidateError("0.8.5+ bundle Windows security serializer has an invalid signature")
     serialized_security = serializer_returns[0]
     serialized_values = {
         key.value: value
@@ -1464,9 +1376,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         or len(serialized_values) != 3
         or set(serialized_values) != {"owner", "dacl", "dacl_protected"}
     ):
-        raise CandidateError(
-            "0.8.5+ bundle Windows security serializer lacks exact owner/DACL fields"
-        )
+        raise CandidateError("0.8.5+ bundle Windows security serializer lacks exact owner/DACL fields")
 
     def is_canonical_security_bytes(value: ast.AST, field: str) -> bool:
         if not (
@@ -1493,9 +1403,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
 
     for field in ("owner", "dacl"):
         if not is_canonical_security_bytes(serialized_values[field], field):
-            raise CandidateError(
-                "0.8.5+ bundle Windows owner/DACL bytes are not canonically serialized"
-            )
+            raise CandidateError("0.8.5+ bundle Windows owner/DACL bytes are not canonically serialized")
     protected_value = serialized_values["dacl_protected"]
     if not (
         isinstance(protected_value, ast.Attribute)
@@ -1503,14 +1411,11 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         and isinstance(protected_value.value, ast.Name)
         and protected_value.value.id == "security"
     ):
-        raise CandidateError(
-            "0.8.5+ bundle Windows DACL protection state is not serialized exactly"
-        )
+        raise CandidateError("0.8.5+ bundle Windows DACL protection state is not serialized exactly")
     directory_chain_helpers = [
         node
         for node in tree.body
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        and node.name == "_fsync_directory_chain"
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "_fsync_directory_chain"
     ]
     if len(directory_chain_helpers) != 1:
         raise CandidateError("0.8.5+ bundle transaction lacks one directory fsync-chain helper")
@@ -1522,36 +1427,24 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
             *directory_chain_helper.args.kwonlyargs,
         )
     }
-    helper_calls = [
-        node
-        for node in ast.walk(directory_chain_helper)
-        if isinstance(node, ast.Call)
-    ]
+    helper_calls = [node for node in ast.walk(directory_chain_helper) if isinstance(node, ast.Call)]
     if (
         helper_arguments != {"path", "stop"}
         or not any(isinstance(node, ast.While) for node in ast.walk(directory_chain_helper))
         or not any(_ast_call_name(node) == "_fsync_directory" for node in helper_calls)
         or not any(
             isinstance(node, ast.Compare)
-            and any(
-                isinstance(candidate, ast.Name) and candidate.id == "stop"
-                for candidate in ast.walk(node)
-            )
+            and any(isinstance(candidate, ast.Name) and candidate.id == "stop" for candidate in ast.walk(node))
             for node in ast.walk(directory_chain_helper)
         )
         or not any(isinstance(node, ast.Break) for node in ast.walk(directory_chain_helper))
         or not any(
             isinstance(node, (ast.Assign, ast.AnnAssign))
-            and any(
-                isinstance(candidate, ast.Attribute) and candidate.attr == "parent"
-                for candidate in ast.walk(node)
-            )
+            and any(isinstance(candidate, ast.Attribute) and candidate.attr == "parent" for candidate in ast.walk(node))
             for node in ast.walk(directory_chain_helper)
         )
     ):
-        raise CandidateError(
-            "0.8.5+ bundle directory fsync-chain helper does not walk to its stop root"
-        )
+        raise CandidateError("0.8.5+ bundle directory fsync-chain helper does not walk to its stop root")
     functions = [
         node
         for node in tree.body
@@ -1562,9 +1455,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         raise CandidateError("0.8.5+ candidate wheel lacks one bundle activation transaction")
     transaction = functions[0]
     was_running_args = [
-        argument
-        for argument in (*transaction.args.args, *transaction.args.kwonlyargs)
-        if argument.arg == "was_running"
+        argument for argument in (*transaction.args.args, *transaction.args.kwonlyargs) if argument.arg == "was_running"
     ]
     if not (
         len(was_running_args) == 1
@@ -1577,11 +1468,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
     for node in ast.walk(transaction):
         if not isinstance(node, ast.Dict):
             continue
-        keys = {
-            key.value
-            for key in node.keys
-            if isinstance(key, ast.Constant) and isinstance(key.value, str)
-        }
+        keys = {key.value for key in node.keys if isinstance(key, ast.Constant) and isinstance(key.value, str)}
         if "managed_paths" in keys or "restart_required" in keys:
             metadata_dicts.append(node)
     if len(metadata_dicts) != 1:
@@ -1610,8 +1497,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         missing = sorted(expected_metadata_fields - set(metadata_values))
         extra = sorted(set(metadata_values) - expected_metadata_fields)
         raise CandidateError(
-            "0.8.5+ bundle rollback metadata lacks the exact schema-2 inventory "
-            f"(missing={missing!r}, extra={extra!r})"
+            f"0.8.5+ bundle rollback metadata lacks the exact schema-2 inventory (missing={missing!r}, extra={extra!r})"
         )
     schema_value = metadata_values["schema_version"]
     if not (
@@ -1632,22 +1518,14 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
             and isinstance(value.args[0], ast.Name)
             and value.args[0].id == binding
         ):
-            raise CandidateError(
-                f"0.8.5+ bundle rollback metadata {field} is not bound to its exact inventory"
-            )
+            raise CandidateError(f"0.8.5+ bundle rollback metadata {field} is not bound to its exact inventory")
     for field in ("old_sha256", "old_modes", "created_sha256", "old_windows_security"):
         value = metadata_values[field]
         if not (isinstance(value, ast.Name) and value.id == field):
-            raise CandidateError(
-                f"0.8.5+ bundle rollback metadata {field} is not bound to its exact inventory"
-            )
+            raise CandidateError(f"0.8.5+ bundle rollback metadata {field} is not bound to its exact inventory")
     restart_value = metadata_values.get("restart_required")
-    if not (
-        isinstance(restart_value, ast.Name) and restart_value.id == "was_running"
-    ):
-        raise CandidateError(
-            "0.8.5+ bundle rollback metadata lacks boolean restart_required"
-        )
+    if not (isinstance(restart_value, ast.Name) and restart_value.id == "was_running"):
+        raise CandidateError("0.8.5+ bundle rollback metadata lacks boolean restart_required")
 
     calls = [node for node in ast.walk(transaction) if isinstance(node, ast.Call)]
     metadata_writes = [
@@ -1655,21 +1533,16 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         for node in calls
         if _ast_call_name(node) == "_atomic_write_bytes"
         and any(
-            isinstance(candidate, ast.Constant)
-            and candidate.value == "refresh-backup.json"
+            isinstance(candidate, ast.Constant) and candidate.value == "refresh-backup.json"
             for candidate in ast.walk(node)
         )
     ]
     if len(metadata_writes) != 1:
         raise CandidateError("0.8.5+ bundle transaction must durably publish one backup manifest")
     metadata_write = metadata_writes[0]
-    all_atomic_writes = [
-        node for node in calls if _ast_call_name(node) == "_atomic_write_bytes"
-    ]
+    all_atomic_writes = [node for node in calls if _ast_call_name(node) == "_atomic_write_bytes"]
     if len(all_atomic_writes) != 1 or all_atomic_writes[0] is not metadata_write:
-        raise CandidateError(
-            "0.8.5+ bundle transaction has an ambiguous direct file write"
-        )
+        raise CandidateError("0.8.5+ bundle transaction has an ambiguous direct file write")
     metadata_write_line = metadata_write.lineno
     if metadata.lineno >= metadata_write_line:
         raise CandidateError("0.8.5+ bundle rollback authority is not built before publication")
@@ -1679,10 +1552,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         if (
             isinstance(node, ast.Assign)
             and node.value is metadata
-            and any(
-                isinstance(target, ast.Name) and target.id == "backup_metadata"
-                for target in node.targets
-            )
+            and any(isinstance(target, ast.Name) and target.id == "backup_metadata" for target in node.targets)
         )
         or (
             isinstance(node, ast.AnnAssign)
@@ -1697,10 +1567,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         for node in ast.walk(transaction)
         if (
             isinstance(node, ast.Assign)
-            and any(
-                isinstance(target, ast.Name) and target.id == "serialized_metadata"
-                for target in node.targets
-            )
+            and any(isinstance(target, ast.Name) and target.id == "serialized_metadata" for target in node.targets)
         )
         or (
             isinstance(node, ast.AnnAssign)
@@ -1708,9 +1575,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
             and node.target.id == "serialized_metadata"
         )
     ]
-    serialized_value = (
-        serialized_assignments[0].value if len(serialized_assignments) == 1 else None
-    )
+    serialized_value = serialized_assignments[0].value if len(serialized_assignments) == 1 else None
     serialized_json_call = (
         serialized_value.func.value
         if isinstance(serialized_value, ast.Call)
@@ -1747,9 +1612,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         and isinstance(serialized_keywords["sort_keys"], ast.Constant)
         and serialized_keywords["sort_keys"].value is True
     ):
-        raise CandidateError(
-            "0.8.5+ bundle transaction does not publish its exact schema-2 metadata object"
-        )
+        raise CandidateError("0.8.5+ bundle transaction does not publish its exact schema-2 metadata object")
     metadata_bound_guards = [
         node
         for node in ast.walk(transaction)
@@ -1767,9 +1630,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         and any(isinstance(candidate, ast.Raise) for candidate in ast.walk(node))
     ]
     if len(metadata_bound_guards) != 1:
-        raise CandidateError(
-            "0.8.5+ bundle serialized metadata is not bounded before publication"
-        )
+        raise CandidateError("0.8.5+ bundle serialized metadata is not bounded before publication")
     bound_test = metadata_bound_guards[0].test
     bound_comparison = bound_test.operand if isinstance(bound_test, ast.UnaryOp) else None
     if not (
@@ -1790,9 +1651,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         and isinstance(bound_comparison.comparators[1], ast.Name)
         and bound_comparison.comparators[1].id == "_MAX_BUNDLE_ROLLBACK_METADATA_BYTES"
     ):
-        raise CandidateError(
-            "0.8.5+ bundle serialized metadata uses an invalid size bound"
-        )
+        raise CandidateError("0.8.5+ bundle serialized metadata uses an invalid size bound")
 
     parent: dict[ast.AST, ast.AST] = {}
     for ancestor in ast.walk(transaction):
@@ -1817,21 +1676,14 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         or condition_between(serialized_assignments[0], transaction)
         or condition_between(metadata_write, transaction)
     ):
-        raise CandidateError(
-            "0.8.5+ bundle rollback metadata construction or publication is conditional"
-        )
+        raise CandidateError("0.8.5+ bundle rollback metadata construction or publication is conditional")
 
     def assignment_value(node: ast.AST, name: str) -> ast.AST | None:
         if isinstance(node, ast.Assign) and any(
-            isinstance(target, ast.Name) and target.id == name
-            for target in node.targets
+            isinstance(target, ast.Name) and target.id == name for target in node.targets
         ):
             return node.value
-        if (
-            isinstance(node, ast.AnnAssign)
-            and isinstance(node.target, ast.Name)
-            and node.target.id == name
-        ):
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.target.id == name:
             return node.value
         return None
 
@@ -1878,20 +1730,12 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
             and (value := assignment_value(node, binding)) is not None
         ]
         if len(assignments) != 1 or not child_path(assignments[0], "backup_root", leaf):
-            raise CandidateError(
-                f"0.8.5+ bundle transaction lacks exact {leaf} rollback custody"
-            )
+            raise CandidateError(f"0.8.5+ bundle transaction lacks exact {leaf} rollback custody")
         mkdir_calls = exact_root_call("_mkdir_private", binding)
         fsync_calls = exact_root_call("_fsync_directory_chain", binding)
         if len(mkdir_calls) != 1 or len(fsync_calls) != 1:
-            raise CandidateError(
-                f"0.8.5+ bundle {leaf} rollback custody is not durably created"
-            )
-        stop_values = [
-            keyword.value
-            for keyword in fsync_calls[0].keywords
-            if keyword.arg == "stop"
-        ]
+            raise CandidateError(f"0.8.5+ bundle {leaf} rollback custody is not durably created")
+        stop_values = [keyword.value for keyword in fsync_calls[0].keywords if keyword.arg == "stop"]
         if not (
             len(mkdir_calls[0].args) == 1
             and not mkdir_calls[0].keywords
@@ -1904,11 +1748,14 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
             and isinstance(stop_values[0], ast.Name)
             and stop_values[0].id == "backup_root"
         ):
-            raise CandidateError(
-                f"0.8.5+ bundle {leaf} rollback custody is not fsynced to its root"
-            )
+            raise CandidateError(f"0.8.5+ bundle {leaf} rollback custody is not fsynced to its root")
 
-    for binding in ("old_sha256", "old_modes", "created_sha256", "old_windows_security"):
+    for binding in (
+        "old_sha256",
+        "old_modes",
+        "created_sha256",
+        "old_windows_security",
+    ):
         initializers = [
             value
             for node in ast.walk(transaction)
@@ -1917,9 +1764,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
             and isinstance(value, ast.Dict)
         ]
         if len(initializers) != 1 or initializers[0].keys:
-            raise CandidateError(
-                f"0.8.5+ bundle transaction lacks one empty {binding} inventory"
-            )
+            raise CandidateError(f"0.8.5+ bundle transaction lacks one empty {binding} inventory")
 
     managed_inventory_values = [
         value
@@ -1939,9 +1784,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         }
         == {"existing_paths", "created_paths"}
     ):
-        raise CandidateError(
-            "0.8.5+ bundle managed inventory is not the exact existing/created union"
-        )
+        raise CandidateError("0.8.5+ bundle managed inventory is not the exact existing/created union")
 
     backup_copies = [
         node
@@ -1968,16 +1811,11 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
     if copy_loop is None:
         raise CandidateError("0.8.5+ bundle backup copy is outside its managed inventory loop")
     if condition_between(copy_call, copy_loop) or not (
-        isinstance(copy_loop.iter, ast.Name)
-        and copy_loop.iter.id == "existing_paths"
+        isinstance(copy_loop.iter, ast.Name) and copy_loop.iter.id == "existing_paths"
     ):
-        raise CandidateError(
-            "0.8.5+ bundle backup copy does not exactly cover existing paths"
-        )
+        raise CandidateError("0.8.5+ bundle backup copy does not exactly cover existing paths")
     backup_path_values = [
-        value
-        for node in ast.walk(copy_loop)
-        if (value := assignment_value(node, "backup_path")) is not None
+        value for node in ast.walk(copy_loop) if (value := assignment_value(node, "backup_path")) is not None
     ]
     backup_path_value = backup_path_values[0] if len(backup_path_values) == 1 else None
     if not (
@@ -1988,9 +1826,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         and isinstance(backup_path_value.right, ast.Name)
         and backup_path_value.right.id == "path"
     ):
-        raise CandidateError(
-            "0.8.5+ bundle existing backup is outside managed rollback custody"
-        )
+        raise CandidateError("0.8.5+ bundle existing backup is outside managed rollback custody")
 
     def inventory_writes(scope: ast.AST, binding: str) -> list[ast.Assign | ast.AnnAssign]:
         writes: list[ast.Assign | ast.AnnAssign] = []
@@ -2003,9 +1839,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
             else:
                 continue
             if any(
-                isinstance(target, ast.Subscript)
-                and isinstance(target.value, ast.Name)
-                and target.value.id == binding
+                isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name) and target.value.id == binding
                 for target in targets
             ):
                 writes.append(node)
@@ -2057,29 +1891,19 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         or old_mode_value.args[0].value.args
         or old_mode_value.args[0].value.keywords
     ):
-        raise CandidateError(
-            "0.8.5+ bundle backup loop lacks exact digest and mode inventory"
-        )
+        raise CandidateError("0.8.5+ bundle backup loop lacks exact digest and mode inventory")
 
     windows_writes = inventory_writes(copy_loop, "old_windows_security")
     if len(windows_writes) != 1:
-        raise CandidateError(
-            "0.8.5+ bundle backup loop lacks exact per-path Windows security inventory"
-        )
+        raise CandidateError("0.8.5+ bundle backup loop lacks exact per-path Windows security inventory")
     windows_write = windows_writes[0]
     if not exact_inventory_key(windows_write, "old_windows_security"):
-        raise CandidateError(
-            "0.8.5+ bundle Windows security inventory is not keyed by its exact path"
-        )
+        raise CandidateError("0.8.5+ bundle Windows security inventory is not keyed by its exact path")
     windows_value = windows_write.value
     if windows_value is None:
-        raise CandidateError(
-            "0.8.5+ bundle Windows security inventory has no serialized value"
-        )
+        raise CandidateError("0.8.5+ bundle Windows security inventory has no serialized value")
     captured_security = (
-        windows_value.args[0]
-        if isinstance(windows_value, ast.Call) and len(windows_value.args) == 1
-        else None
+        windows_value.args[0] if isinstance(windows_value, ast.Call) and len(windows_value.args) == 1 else None
     )
     if (
         not isinstance(windows_value, ast.Call)
@@ -2092,9 +1916,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         or not isinstance(captured_security.args[0], ast.Name)
         or captured_security.args[0].id != "path"
     ):
-        raise CandidateError(
-            "0.8.5+ bundle Windows security inventory is not captured and serialized exactly"
-        )
+        raise CandidateError("0.8.5+ bundle Windows security inventory is not captured and serialized exactly")
     current = windows_write
     windows_guard: ast.If | None = None
     while current in parent and current is not copy_loop:
@@ -2127,9 +1949,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
             )
         )
     ):
-        raise CandidateError(
-            "0.8.5+ bundle Windows security inventory is not platform-exact"
-        )
+        raise CandidateError("0.8.5+ bundle Windows security inventory is not platform-exact")
     durable_backup_calls = [
         node
         for node in ast.walk(copy_loop)
@@ -2143,13 +1963,9 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         and node.args[0].id == "backup_path"
     ]
     if not durable_backup_calls:
-        raise CandidateError(
-            "0.8.5+ bundle backup files are not fsynced before metadata publication"
-        )
+        raise CandidateError("0.8.5+ bundle backup files are not fsynced before metadata publication")
     if any(condition_between(node, copy_loop) for node in durable_backup_calls):
-        raise CandidateError(
-            "0.8.5+ bundle backup file durability is conditional"
-        )
+        raise CandidateError("0.8.5+ bundle backup file durability is conditional")
     durable_directory_calls = [
         node
         for node in ast.walk(copy_loop)
@@ -2165,29 +1981,15 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         and node.args[0].value.id == "backup_path"
     ]
     if len(durable_directory_calls) != 1:
-        raise CandidateError(
-            "0.8.5+ bundle backup directory entries are not fsynced before metadata publication"
-        )
+        raise CandidateError("0.8.5+ bundle backup directory entries are not fsynced before metadata publication")
     if condition_between(durable_directory_calls[0], copy_loop):
-        raise CandidateError(
-            "0.8.5+ bundle backup directory durability is conditional"
-        )
+        raise CandidateError("0.8.5+ bundle backup directory durability is conditional")
     directory_call = durable_directory_calls[0]
-    stop_values = [
-        keyword.value for keyword in directory_call.keywords if keyword.arg == "stop"
-    ]
-    if not (
-        len(stop_values) == 1
-        and isinstance(stop_values[0], ast.Name)
-        and stop_values[0].id == "backup_root"
-    ):
-        raise CandidateError(
-            "0.8.5+ bundle directory fsync chain must include the backup root"
-        )
+    stop_values = [keyword.value for keyword in directory_call.keywords if keyword.arg == "stop"]
+    if not (len(stop_values) == 1 and isinstance(stop_values[0], ast.Name) and stop_values[0].id == "backup_root"):
+        raise CandidateError("0.8.5+ bundle directory fsync chain must include the backup root")
     if not any(node.lineno < directory_call.lineno for node in durable_backup_calls):
-        raise CandidateError(
-            "0.8.5+ bundle backup files must be fsynced before directory entries"
-        )
+        raise CandidateError("0.8.5+ bundle backup files must be fsynced before directory entries")
 
     claim_copies = [
         node
@@ -2200,9 +2002,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         and node.args[1].id == "created_claim"
     ]
     if len(claim_copies) != 1:
-        raise CandidateError(
-            "0.8.5+ bundle transaction lacks one retained target-created claim loop"
-        )
+        raise CandidateError("0.8.5+ bundle transaction lacks one retained target-created claim loop")
     claim_copy = claim_copies[0]
     claim_loop: ast.For | None = None
     current = claim_copy
@@ -2211,17 +2011,14 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         if isinstance(current, ast.For):
             claim_loop = current
             break
-    if claim_loop is None or condition_between(claim_copy, claim_loop) or not (
-        isinstance(claim_loop.iter, ast.Name)
-        and claim_loop.iter.id == "created_paths"
+    if (
+        claim_loop is None
+        or condition_between(claim_copy, claim_loop)
+        or not (isinstance(claim_loop.iter, ast.Name) and claim_loop.iter.id == "created_paths")
     ):
-        raise CandidateError(
-            "0.8.5+ bundle target-created claims do not exactly cover created paths"
-        )
+        raise CandidateError("0.8.5+ bundle target-created claims do not exactly cover created paths")
     claim_bindings = [
-        value
-        for node in ast.walk(claim_loop)
-        if (value := assignment_value(node, "created_claim")) is not None
+        value for node in ast.walk(claim_loop) if (value := assignment_value(node, "created_claim")) is not None
     ]
     claim_binding = claim_bindings[0] if len(claim_bindings) == 1 else None
     if not (
@@ -2232,9 +2029,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         and isinstance(claim_binding.right, ast.Name)
         and claim_binding.right.id == "path"
     ):
-        raise CandidateError(
-            "0.8.5+ bundle target-created claims are outside retained custody"
-        )
+        raise CandidateError("0.8.5+ bundle target-created claims are outside retained custody")
     claim_file_fsyncs = [
         node
         for node in ast.walk(claim_loop)
@@ -2258,37 +2053,22 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         and node.args[0].value.id == "created_claim"
     ]
     if len(claim_file_fsyncs) != 1 or len(claim_directory_fsyncs) != 1:
-        raise CandidateError(
-            "0.8.5+ bundle target-created claims are not durably retained"
-        )
+        raise CandidateError("0.8.5+ bundle target-created claims are not durably retained")
     if condition_between(claim_file_fsyncs[0], claim_loop) or condition_between(
         claim_directory_fsyncs[0],
         claim_loop,
     ):
-        raise CandidateError(
-            "0.8.5+ bundle target-created claim durability is conditional"
-        )
-    claim_stop_values = [
-        keyword.value
-        for keyword in claim_directory_fsyncs[0].keywords
-        if keyword.arg == "stop"
-    ]
+        raise CandidateError("0.8.5+ bundle target-created claim durability is conditional")
+    claim_stop_values = [keyword.value for keyword in claim_directory_fsyncs[0].keywords if keyword.arg == "stop"]
     if not (
-        claim_copy.lineno
-        < claim_file_fsyncs[0].lineno
-        < claim_directory_fsyncs[0].lineno
-        < metadata_write_line
+        claim_copy.lineno < claim_file_fsyncs[0].lineno < claim_directory_fsyncs[0].lineno < metadata_write_line
         and len(claim_stop_values) == 1
         and isinstance(claim_stop_values[0], ast.Name)
         and claim_stop_values[0].id == "backup_root"
     ):
-        raise CandidateError(
-            "0.8.5+ bundle target-created claims are not fsynced to the backup root"
-        )
+        raise CandidateError("0.8.5+ bundle target-created claims are not fsynced to the backup root")
     created_digest_writes = inventory_writes(claim_loop, "created_sha256")
-    created_digest_value = (
-        created_digest_writes[0].value if len(created_digest_writes) == 1 else None
-    )
+    created_digest_value = created_digest_writes[0].value if len(created_digest_writes) == 1 else None
     if not (
         len(created_digest_writes) == 1
         and created_digest_value is not None
@@ -2302,9 +2082,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         and isinstance(created_digest_value.args[0], ast.Name)
         and created_digest_value.args[0].id == "created_claim"
     ):
-        raise CandidateError(
-            "0.8.5+ bundle target-created claim digest inventory is incomplete"
-        )
+        raise CandidateError("0.8.5+ bundle target-created claim digest inventory is incomplete")
 
     claim_publications = [
         node
@@ -2319,9 +2097,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         and node.args[1].id == "destination"
     ]
     if len(claim_publications) != 1:
-        raise CandidateError(
-            "0.8.5+ bundle target-created claims lack one no-replace publication"
-        )
+        raise CandidateError("0.8.5+ bundle target-created claims lack one no-replace publication")
     claim_publication = claim_publications[0]
     publication_loop: ast.For | None = None
     current = claim_publication
@@ -2330,34 +2106,23 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         if isinstance(current, ast.For):
             publication_loop = current
             break
-    if publication_loop is None or condition_between(
-        claim_publication,
-        publication_loop,
-    ) or not (
-        isinstance(publication_loop.iter, ast.Name)
-        and publication_loop.iter.id == "created_paths"
-    ):
-        raise CandidateError(
-            "0.8.5+ bundle target-created publication does not cover its exact inventory"
+    if (
+        publication_loop is None
+        or condition_between(
+            claim_publication,
+            publication_loop,
         )
+        or not (isinstance(publication_loop.iter, ast.Name) and publication_loop.iter.id == "created_paths")
+    ):
+        raise CandidateError("0.8.5+ bundle target-created publication does not cover its exact inventory")
     publication_claim_values = [
-        value
-        for node in ast.walk(publication_loop)
-        if (value := assignment_value(node, "created_claim")) is not None
+        value for node in ast.walk(publication_loop) if (value := assignment_value(node, "created_claim")) is not None
     ]
     publication_destination_values = [
-        value
-        for node in ast.walk(publication_loop)
-        if (value := assignment_value(node, "destination")) is not None
+        value for node in ast.walk(publication_loop) if (value := assignment_value(node, "destination")) is not None
     ]
-    published_claim = (
-        publication_claim_values[0] if len(publication_claim_values) == 1 else None
-    )
-    published_destination = (
-        publication_destination_values[0]
-        if len(publication_destination_values) == 1
-        else None
-    )
+    published_claim = publication_claim_values[0] if len(publication_claim_values) == 1 else None
+    published_destination = publication_destination_values[0] if len(publication_destination_values) == 1 else None
     if not (
         isinstance(published_claim, ast.BinOp)
         and isinstance(published_claim.op, ast.Div)
@@ -2368,9 +2133,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         and isinstance(published_destination, ast.Name)
         and published_destination.id == "path"
     ):
-        raise CandidateError(
-            "0.8.5+ bundle target-created publication is not claim-bound"
-        )
+        raise CandidateError("0.8.5+ bundle target-created publication is not claim-bound")
 
     mutation_nodes = [
         node
@@ -2379,10 +2142,7 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         and (
             (
                 isinstance(node, ast.Assign)
-                and any(
-                    isinstance(target, ast.Name) and target.id == "mutation_started"
-                    for target in node.targets
-                )
+                and any(isinstance(target, ast.Name) and target.id == "mutation_started" for target in node.targets)
             )
             or (
                 isinstance(node, ast.AnnAssign)
@@ -2400,15 +2160,11 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         or mutation_lines[0] >= claim_publication.lineno
         or condition_between(mutation_nodes[0], transaction)
     ):
-        raise CandidateError(
-            "0.8.5+ bundle rollback metadata is not durable before first mutation"
-        )
+        raise CandidateError("0.8.5+ bundle rollback metadata is not durable before first mutation")
     mutation_line = mutation_lines[0]
     all_link_calls = [node for node in calls if _ast_call_name(node) == "os.link"]
     if len(all_link_calls) != 1:
-        raise CandidateError(
-            "0.8.5+ bundle transaction has ambiguous target-created publication"
-        )
+        raise CandidateError("0.8.5+ bundle transaction has ambiguous target-created publication")
     managed_publications = [
         node
         for node in calls
@@ -2420,21 +2176,14 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         and node.args[1].id == "destination"
     ]
     if len(managed_publications) != 1:
-        raise CandidateError(
-            "0.8.5+ bundle transaction lacks one authenticated managed-file publication"
-        )
-    all_atomic_copies = [
-        node for node in calls if _ast_call_name(node) == "_atomic_copy_file"
-    ]
-    all_legacy_copies = [
-        node for node in calls if _ast_call_name(node) == "shutil.copy2"
-    ]
-    if set(all_atomic_copies) != {claim_copy, managed_publications[0]} or all_legacy_copies != [
-        copy_call
-    ]:
-        raise CandidateError(
-            "0.8.5+ bundle transaction has an ambiguous copy mutation"
-        )
+        raise CandidateError("0.8.5+ bundle transaction lacks one authenticated managed-file publication")
+    all_atomic_copies = [node for node in calls if _ast_call_name(node) == "_atomic_copy_file"]
+    all_legacy_copies = [node for node in calls if _ast_call_name(node) == "shutil.copy2"]
+    if set(all_atomic_copies) != {
+        claim_copy,
+        managed_publications[0],
+    } or all_legacy_copies != [copy_call]:
+        raise CandidateError("0.8.5+ bundle transaction has an ambiguous copy mutation")
     managed_publication = managed_publications[0]
     managed_publication_loop: ast.For | None = None
     current = managed_publication
@@ -2443,16 +2192,17 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         if isinstance(current, ast.For):
             managed_publication_loop = current
             break
-    if managed_publication_loop is None or condition_between(
-        managed_publication,
-        managed_publication_loop,
-    ) or not (
-        isinstance(managed_publication_loop.iter, ast.Name)
-        and managed_publication_loop.iter.id == "existing_paths"
-    ):
-        raise CandidateError(
-            "0.8.5+ bundle managed-file publication does not cover existing paths"
+    if (
+        managed_publication_loop is None
+        or condition_between(
+            managed_publication,
+            managed_publication_loop,
         )
+        or not (
+            isinstance(managed_publication_loop.iter, ast.Name) and managed_publication_loop.iter.id == "existing_paths"
+        )
+    ):
+        raise CandidateError("0.8.5+ bundle managed-file publication does not cover existing paths")
     managed_destination_values = [
         value
         for node in ast.walk(managed_publication_loop)
@@ -2463,29 +2213,19 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         and isinstance(managed_destination_values[0], ast.Name)
         and managed_destination_values[0].id == "path"
     ):
-        raise CandidateError(
-            "0.8.5+ bundle managed-file publication is not destination-bound"
-        )
+        raise CandidateError("0.8.5+ bundle managed-file publication is not destination-bound")
     canonical_mutations = [*all_link_calls, *managed_publications]
     if any(node.lineno <= mutation_line for node in canonical_mutations):
-        raise CandidateError(
-            "0.8.5+ bundle mutation begins before durable rollback authority"
-        )
-    transaction_returns = [
-        node for node in ast.walk(transaction) if isinstance(node, ast.Return)
-    ]
+        raise CandidateError("0.8.5+ bundle mutation begins before durable rollback authority")
+    transaction_returns = [node for node in ast.walk(transaction) if isinstance(node, ast.Return)]
     if not (
         len(transaction_returns) == 1
-        and transaction_returns[0].lineno > max(
-            node.lineno for node in canonical_mutations
-        )
+        and transaction_returns[0].lineno > max(node.lineno for node in canonical_mutations)
         and isinstance(transaction_returns[0].value, ast.Name)
         and transaction_returns[0].value.id == "mutation_started"
         and not condition_between(transaction_returns[0], transaction)
     ):
-        raise CandidateError(
-            "0.8.5+ bundle transaction has an ambiguous completion path"
-        )
+        raise CandidateError("0.8.5+ bundle transaction has an ambiguous completion path")
     forbidden_direct_mutators = {
         "open",
         "os.open",
@@ -2514,15 +2254,10 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
     )
     if any(
         (name := _ast_call_name(node)) is not None
-        and (
-            name in forbidden_direct_mutators
-            or name.endswith(forbidden_mutator_suffixes)
-        )
+        and (name in forbidden_direct_mutators or name.endswith(forbidden_mutator_suffixes))
         for node in calls
     ):
-        raise CandidateError(
-            "0.8.5+ bundle transaction bypasses its reviewed publication primitives"
-        )
+        raise CandidateError("0.8.5+ bundle transaction bypasses its reviewed publication primitives")
     forbidden_before_metadata = {
         "os.link",
         "os.replace",
@@ -2531,14 +2266,8 @@ def _validate_fixture_hard_cut_bundle_transaction(source: str) -> None:
         "os.remove",
         "shutil.rmtree",
     }
-    if any(
-        (_ast_call_name(node) in forbidden_before_metadata)
-        and node.lineno < metadata_write_line
-        for node in calls
-    ):
-        raise CandidateError(
-            "0.8.5+ bundle transaction mutates canonical paths before rollback metadata"
-        )
+    if any((_ast_call_name(node) in forbidden_before_metadata) and node.lineno < metadata_write_line for node in calls):
+        raise CandidateError("0.8.5+ bundle transaction mutates canonical paths before rollback metadata")
 
 
 def _validate_runtime_hard_cut_bundle_transaction(source: str) -> None:
@@ -2567,11 +2296,7 @@ def _validate_runtime_hard_cut_bundle_transaction(source: str) -> None:
         return matches[0]
 
     def calls(scope: ast.AST, name: str) -> list[ast.Call]:
-        return [
-            node
-            for node in ast.walk(scope)
-            if isinstance(node, ast.Call) and _ast_call_name(node) == name
-        ]
+        return [node for node in ast.walk(scope) if isinstance(node, ast.Call) and _ast_call_name(node) == name]
 
     def references(node: ast.AST, name: str) -> bool:
         return any(isinstance(item, ast.Name) and item.id == name for item in ast.walk(node))
@@ -2600,11 +2325,7 @@ def _validate_runtime_hard_cut_bundle_transaction(source: str) -> None:
             and value.left.id == root
             and (
                 (child is None and isinstance(value.right, ast.Name))
-                or (
-                    child is not None
-                    and isinstance(value.right, ast.Constant)
-                    and value.right.value == child
-                )
+                or (child is not None and isinstance(value.right, ast.Constant) and value.right.value == child)
             )
         )
 
@@ -2646,9 +2367,7 @@ def _validate_runtime_hard_cut_bundle_transaction(source: str) -> None:
         "security.dacl_protected",
     ):
         if fragment not in serializer_source:
-            raise CandidateError(
-                "0.8.5+ bundle Windows owner/DACL bytes are not canonically serialized"
-            )
+            raise CandidateError("0.8.5+ bundle Windows owner/DACL bytes are not canonically serialized")
 
     fsync_chain = one_function("_fsync_directory_chain")
     if not (
@@ -2664,9 +2383,7 @@ def _validate_runtime_hard_cut_bundle_transaction(source: str) -> None:
         node
         for node in ast.walk(prepare)
         if isinstance(node, ast.Dict)
-        and {
-            key.value for key in node.keys if isinstance(key, ast.Constant)
-        }
+        and {key.value for key in node.keys if isinstance(key, ast.Constant)}
         == {"schema_version", "target_manifest_sha256", "restart_required"}
     ]
     intent_writes = calls(prepare, "_atomic_write_bytes")
@@ -2705,9 +2422,7 @@ def _validate_runtime_hard_cut_bundle_transaction(source: str) -> None:
 
     transaction = one_function("_activate_local_observability_manifest")
     was_running = [
-        argument
-        for argument in (*transaction.args.args, *transaction.args.kwonlyargs)
-        if argument.arg == "was_running"
+        argument for argument in (*transaction.args.args, *transaction.args.kwonlyargs) if argument.arg == "was_running"
     ]
     if not (
         len(was_running) == 1
@@ -2730,9 +2445,7 @@ def _validate_runtime_hard_cut_bundle_transaction(source: str) -> None:
     for node in ast.walk(transaction):
         if not isinstance(node, ast.Dict):
             continue
-        keys = {
-            key.value for key in node.keys if isinstance(key, ast.Constant) and isinstance(key.value, str)
-        }
+        keys = {key.value for key in node.keys if isinstance(key, ast.Constant) and isinstance(key.value, str)}
         if keys & {"managed_paths", "restart_required"}:
             metadata_dicts.append(node)
     if len(metadata_dicts) != 1:
@@ -2765,10 +2478,7 @@ def _validate_runtime_hard_cut_bundle_transaction(source: str) -> None:
     metadata_writes = [
         call
         for call in calls(transaction, "_atomic_write_bytes")
-        if any(
-            isinstance(node, ast.Constant) and node.value == "refresh-backup.json"
-            for node in ast.walk(call)
-        )
+        if any(isinstance(node, ast.Constant) and node.value == "refresh-backup.json" for node in ast.walk(call))
     ]
     if len(metadata_writes) != 1 or len(calls(transaction, "_atomic_write_bytes")) != 1:
         raise CandidateError("0.8.5+ bundle transaction has ambiguous metadata publication")
@@ -2776,8 +2486,7 @@ def _validate_runtime_hard_cut_bundle_transaction(source: str) -> None:
     metadata_line = metadata_write.lineno
     serialized = assignment(transaction, "serialized_metadata")
     if not (
-        len(serialized) == 1
-        and _ast_call_name(serialized[0].func.value) == "json.dumps"
+        len(serialized) == 1 and _ast_call_name(serialized[0].func.value) == "json.dumps"
         if isinstance(serialized[0], ast.Call)
         and isinstance(serialized[0].func, ast.Attribute)
         and isinstance(serialized[0].func.value, ast.Call)
@@ -2982,13 +2691,9 @@ def _canonical_v8_wheel_resources() -> dict[str, bytes]:
             try:
                 document = json.loads(payload)
             except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-                raise CandidateError(
-                    f"canonical v8 wheel resource is malformed JSON: {member_name}"
-                ) from exc
+                raise CandidateError(f"canonical v8 wheel resource is malformed JSON: {member_name}") from exc
             if not isinstance(document, dict):
-                raise CandidateError(
-                    f"canonical v8 wheel resource must be a JSON object: {member_name}"
-                )
+                raise CandidateError(f"canonical v8 wheel resource must be a JSON object: {member_name}")
     return resources
 
 
@@ -2997,10 +2702,8 @@ def _is_v8_package_data_member(member_name: str) -> bool:
     # Windows can still assign path meaning to backslashes. Classify aliases
     # from the entire normalized member so absolute, drive-prefixed, and
     # dot-segment forms cannot hide an extra package-local v8 resource.
-    parts = tuple(
-        part.rstrip(" .").casefold()
-        for part in PurePosixPath(member_name.replace("\\", "/")).parts
-    )
+    parts = tuple(part.rstrip(" .").casefold() for part in PurePosixPath(member_name.replace("\\", "/")).parts)
+
     # An NTFS 8.3 alias may use either a stem-derived form (DEFENS~1) or a
     # volume-assigned/hash-derived form. Without the destination volume there
     # is no safe way to prove which package directory a numeric short name
@@ -3009,16 +2712,12 @@ def _is_v8_package_data_member(member_name: str) -> bool:
     def is_package_root(part: str) -> bool:
         candidate = re.sub(r"^[a-z]:", "", part, count=1)
         return candidate == "defenseclaw" or (
-            len(candidate) <= 8
-            and WINDOWS_NUMERIC_SHORT_NAME_RE.fullmatch(candidate) is not None
+            len(candidate) <= 8 and WINDOWS_NUMERIC_SHORT_NAME_RE.fullmatch(candidate) is not None
         )
 
     return any(
         any(is_package_root(part) for part in parts[:data_index])
-        and any(
-            part == "v8" or part.startswith(("v8_", "v8."))
-            for part in parts[data_index + 1 :]
-        )
+        and any(part == "v8" or part.startswith(("v8_", "v8.")) for part in parts[data_index + 1 :])
         for data_index, part in enumerate(parts)
         if part == "_data"
     )
@@ -3036,17 +2735,11 @@ def _validate_v8_wheel_resources(
         and (
             info.is_dir()
             or bool(info.external_attr & 0x10)
-            or (
-                info.create_system == 3
-                and stat.S_IFMT(info.external_attr >> 16) not in {0, stat.S_IFREG}
-            )
+            or (info.create_system == 3 and stat.S_IFMT(info.external_attr >> 16) not in {0, stat.S_IFREG})
         )
     )
     if non_files:
-        raise CandidateError(
-            "0.8.5+ candidate wheel contains non-file v8 runtime resources: "
-            f"{non_files!r}"
-        )
+        raise CandidateError(f"0.8.5+ candidate wheel contains non-file v8 runtime resources: {non_files!r}")
     observed = {name for name in member_names if _is_v8_package_data_member(name)}
     missing = sorted(set(expected) - observed)
     unexpected = sorted(observed - set(expected))
@@ -3056,27 +2749,18 @@ def _validate_v8_wheel_resources(
             details.append(f"missing={missing!r}")
         if unexpected:
             details.append(f"unexpected={unexpected!r}")
-        raise CandidateError(
-            "0.8.5+ candidate wheel v8 runtime resource inventory is invalid: "
-            + "; ".join(details)
-        )
+        raise CandidateError("0.8.5+ candidate wheel v8 runtime resource inventory is invalid: " + "; ".join(details))
 
     for member_name, canonical_payload in expected.items():
         info = archive.getinfo(member_name)
         if info.file_size != len(canonical_payload):
-            raise CandidateError(
-                f"0.8.5+ candidate wheel v8 runtime resource is altered: {member_name}"
-            )
+            raise CandidateError(f"0.8.5+ candidate wheel v8 runtime resource is altered: {member_name}")
         try:
             candidate_payload = archive.read(member_name)
         except (OSError, RuntimeError, zipfile.BadZipFile) as exc:
-            raise CandidateError(
-                f"0.8.5+ candidate wheel v8 runtime resource is unreadable: {member_name}"
-            ) from exc
+            raise CandidateError(f"0.8.5+ candidate wheel v8 runtime resource is unreadable: {member_name}") from exc
         if candidate_payload != canonical_payload:
-            raise CandidateError(
-                f"0.8.5+ candidate wheel v8 runtime resource is altered: {member_name}"
-            )
+            raise CandidateError(f"0.8.5+ candidate wheel v8 runtime resource is altered: {member_name}")
 
 
 def _validate_wheel(path: Path, version: str) -> None:
@@ -3089,37 +2773,25 @@ def _validate_wheel(path: Path, version: str) -> None:
             names = set(member_names)
             if len(names) != len(member_names):
                 raise CandidateError("candidate wheel contains duplicate member names")
-            bytecode = [
-                name
-                for name in names
-                if "/__pycache__/" in name or name.endswith((".pyc", ".pyo"))
-            ]
+            bytecode = [name for name in names if "/__pycache__/" in name or name.endswith((".pyc", ".pyo"))]
             if bytecode:
                 raise CandidateError(f"candidate wheel contains Python bytecode: {bytecode[:3]!r}")
             if metadata_name not in names:
                 raise CandidateError(f"candidate wheel is missing {metadata_name}")
             metadata = archive.read(metadata_name).decode("utf-8", errors="strict")
-            controller_source = archive.read("defenseclaw/commands/cmd_upgrade.py").decode(
-                "utf-8", errors="strict"
-            )
-            migrations_source = archive.read("defenseclaw/migrations.py").decode(
-                "utf-8", errors="strict"
-            )
+            controller_source = archive.read("defenseclaw/commands/cmd_upgrade.py").decode("utf-8", errors="strict")
+            migrations_source = archive.read("defenseclaw/migrations.py").decode("utf-8", errors="strict")
             mutator_source = ""
             bundle_transaction_source = ""
             install_publish_source = b""
             if tuple(map(int, version.split("."))) >= (0, 8, 4):
-                mutator_source = archive.read("defenseclaw/phase_two_mutator.py").decode(
-                    "utf-8", errors="strict"
-                )
-                install_publish_source = archive.read(
-                    "defenseclaw/install_publish.py"
-                )
+                mutator_source = archive.read("defenseclaw/phase_two_mutator.py").decode("utf-8", errors="strict")
+                install_publish_source = archive.read("defenseclaw/install_publish.py")
             if tuple(map(int, version.split("."))) >= (0, 8, 5):
                 _validate_v8_wheel_resources(archive, member_names)
-                bundle_transaction_source = archive.read(
-                    "defenseclaw/bundle_refresh.py"
-                ).decode("utf-8", errors="strict")
+                bundle_transaction_source = archive.read("defenseclaw/bundle_refresh.py").decode(
+                    "utf-8", errors="strict"
+                )
     except (KeyError, OSError, UnicodeDecodeError, zipfile.BadZipFile) as exc:
         raise CandidateError(f"invalid candidate wheel {path}: {exc}") from exc
     if f"\nVersion: {version}\n" not in f"\n{metadata}":
@@ -3132,8 +2804,7 @@ def _validate_wheel(path: Path, version: str) -> None:
     for node in tree.body:
         value: ast.AST | None = None
         if isinstance(node, ast.Assign) and any(
-            isinstance(target, ast.Name) and target.id == "_UPGRADE_PROTOCOL_VERSION"
-            for target in node.targets
+            isinstance(target, ast.Name) and target.id == "_UPGRADE_PROTOCOL_VERSION" for target in node.targets
         ):
             value = node.value
         elif (
@@ -3142,9 +2813,7 @@ def _validate_wheel(path: Path, version: str) -> None:
             and node.target.id == "_UPGRADE_PROTOCOL_VERSION"
         ):
             value = node.value
-        if isinstance(value, ast.Constant) and isinstance(value.value, int) and not isinstance(
-            value.value, bool
-        ):
+        if isinstance(value, ast.Constant) and isinstance(value.value, int) and not isinstance(value.value, bool):
             protocol_values.append(value.value)
     if len(protocol_values) != 1 or protocol_values[0] < 1:
         raise CandidateError("candidate wheel must declare one positive upgrade protocol")
@@ -3154,15 +2823,10 @@ def _validate_wheel(path: Path, version: str) -> None:
         v8_members = sorted(
             name
             for name in names
-            if any(
-                part == "v8" or part.startswith(("v8_", "v8."))
-                for part in PurePosixPath(name).parts
-            )
+            if any(part == "v8" or part.startswith(("v8_", "v8.")) for part in PurePosixPath(name).parts)
         )
         if v8_members:
-            raise CandidateError(
-                f"0.8.4 bridge wheel contains v8 runtime resources: {v8_members[:3]!r}"
-            )
+            raise CandidateError(f"0.8.4 bridge wheel contains v8 runtime resources: {v8_members[:3]!r}")
         if any(tuple(map(int, item.split("."))) > (0, 8, 4) for item in migration_versions):
             raise CandidateError("0.8.4 bridge wheel contains a post-bridge migration")
     candidate_key = tuple(map(int, version.split(".")))
@@ -3176,21 +2840,13 @@ def _validate_wheel(path: Path, version: str) -> None:
     if tuple(map(int, version.split("."))) >= (0, 8, 4) and protocol_values[0] < 2:
         raise CandidateError("0.8.4+ candidate wheel must ship the protocol-2 bridge controller")
     if tuple(map(int, version.split("."))) >= (0, 8, 4):
-        expected_install_publish_source = (
-            ROOT / "cli" / "defenseclaw" / "install_publish.py"
-        ).read_bytes()
+        expected_install_publish_source = (ROOT / "cli" / "defenseclaw" / "install_publish.py").read_bytes()
         if install_publish_source != expected_install_publish_source:
-            raise CandidateError(
-                "0.8.4+ candidate wheel does not contain the exact reviewed install publisher"
-            )
+            raise CandidateError("0.8.4+ candidate wheel does not contain the exact reviewed install publisher")
         _validate_phase_two_mutator_wrapper(mutator_source)
         if tuple(map(int, version.split("."))) >= (0, 8, 5):
             _validate_hard_cut_bundle_transaction(bundle_transaction_source)
-        functions = {
-            node.name
-            for node in tree.body
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        }
+        functions = {node.name for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))}
         for name in (
             "_require_release_owned_hard_cut_handoff",
             "_acquire_bridge_rollback_artifacts",
@@ -3206,8 +2862,7 @@ def _validate_wheel(path: Path, version: str) -> None:
         entrypoints = [
             node
             for node in tree.body
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-            and node.name == "upgrade"
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "upgrade"
         ]
         if len(entrypoints) != 1:
             raise CandidateError("0.8.4+ controller must define one upgrade entrypoint")
@@ -3219,9 +2874,7 @@ def _validate_wheel(path: Path, version: str) -> None:
             if name == "_require_release_owned_hard_cut_handoff"
         ]
         acquisition_calls = [
-            (line, guarded)
-            for name, line, guarded in controller_calls
-            if name == "_acquire_bridge_rollback_artifacts"
+            (line, guarded) for name, line, guarded in controller_calls if name == "_acquire_bridge_rollback_artifacts"
         ]
         if (
             len(handoff_calls) != 1
@@ -3233,8 +2886,7 @@ def _validate_wheel(path: Path, version: str) -> None:
             not in direct_guard_first_calls
         ):
             raise CandidateError(
-                "0.8.4+ controller must invoke the release-owned handoff gate once "
-                "inside the bridge-to-hard-cut path"
+                "0.8.4+ controller must invoke the release-owned handoff gate once inside the bridge-to-hard-cut path"
             )
         if (
             len(acquisition_calls) != 1
@@ -3246,8 +2898,7 @@ def _validate_wheel(path: Path, version: str) -> None:
             not in direct_guard_first_calls
         ):
             raise CandidateError(
-                "0.8.4+ controller must acquire bridge rollback artifacts once "
-                "inside the bridge-to-hard-cut path"
+                "0.8.4+ controller must acquire bridge rollback artifacts once inside the bridge-to-hard-cut path"
             )
         protected_calls = [
             (name, line)
@@ -3264,14 +2915,11 @@ def _validate_wheel(path: Path, version: str) -> None:
             "_create_backup",
             "_prepare_hard_cut_rollback_plan",
         }:
-            raise CandidateError(
-                "0.8.4+ controller lacks required bridge acquisition or backup calls"
-            )
+            raise CandidateError("0.8.4+ controller lacks required bridge acquisition or backup calls")
         handoff_line = handoff_calls[0][0]
         if any(line <= handoff_line for _name, line in protected_calls):
             raise CandidateError(
-                "0.8.4+ controller must enforce the release-owned handoff before "
-                "bridge artifact acquisition or backup"
+                "0.8.4+ controller must enforce the release-owned handoff before bridge artifact acquisition or backup"
             )
         assignments = {
             target.id: node.value.value
@@ -3282,16 +2930,14 @@ def _validate_wheel(path: Path, version: str) -> None:
             for target in node.targets
             if isinstance(target, ast.Name)
         }
-        if assignments.get("_STAGED_BRIDGE_ARTIFACT_DIR_ENV") != (
-            "DEFENSECLAW_STAGED_BRIDGE_ARTIFACT_DIR"
-        ):
+        if assignments.get("_STAGED_BRIDGE_ARTIFACT_DIR_ENV") != ("DEFENSECLAW_STAGED_BRIDGE_ARTIFACT_DIR"):
             raise CandidateError("0.8.4+ controller lacks the authenticated bridge handoff contract")
-        if candidate_key >= (0, 8, 5) and assignments.get(
-            "_STAGED_TARGET_CONTROLLER_VERSION_ENV"
-        ) != "DEFENSECLAW_STAGED_TARGET_CONTROLLER_VERSION":
-            raise CandidateError(
-                "0.8.5+ controller lacks the authenticated target-controller handoff contract"
-            )
+        if (
+            candidate_key >= (0, 8, 5)
+            and assignments.get("_STAGED_TARGET_CONTROLLER_VERSION_ENV")
+            != "DEFENSECLAW_STAGED_TARGET_CONTROLLER_VERSION"
+        ):
+            raise CandidateError("0.8.5+ controller lacks the authenticated target-controller handoff contract")
 
 
 def _safe_archive_member_path(name: str, archive_name: str) -> PurePosixPath:
@@ -3344,13 +2990,10 @@ def _validate_gateway_binary(
 
     if observed_machine != expected_machine:
         raise CandidateError(
-            f"gateway architecture mismatch in {archive_name}: "
-            f"got 0x{observed_machine:x}, want {os_name}/{arch}"
+            f"gateway architecture mismatch in {archive_name}: got 0x{observed_machine:x}, want {os_name}/{arch}"
         )
 
-    version_pattern = (
-        rb"(?<![0-9.])" + re.escape(version.encode("ascii")) + rb"(?![0-9.])"
-    )
+    version_pattern = rb"(?<![0-9.])" + re.escape(version.encode("ascii")) + rb"(?![0-9.])"
     if re.search(version_pattern, payload) is None:
         raise CandidateError(f"gateway in {archive_name} does not embed release version {version}")
     if commit is not None and commit.encode("ascii") not in payload:
@@ -3419,23 +3062,15 @@ def _validate_gateway_archives(
                     seen: set[PurePosixPath] = set()
                     gateway_payloads: list[bytes] = []
                     for member in archive.getmembers():
-                        raw_name = (
-                            member.name[:-1]
-                            if member.isdir() and member.name.endswith("/")
-                            else member.name
-                        )
+                        raw_name = member.name[:-1] if member.isdir() and member.name.endswith("/") else member.name
                         member_path = _safe_archive_member_path(raw_name, path.name)
                         if member_path in seen:
-                            raise CandidateError(
-                                f"duplicate member in gateway archive {path.name}: {member.name}"
-                            )
+                            raise CandidateError(f"duplicate member in gateway archive {path.name}: {member.name}")
                         seen.add(member_path)
                         if member.isdir():
                             continue
                         if not member.isfile():
-                            raise CandidateError(
-                                f"non-regular member in gateway archive {path.name}: {member.name}"
-                            )
+                            raise CandidateError(f"non-regular member in gateway archive {path.name}: {member.name}")
                         if member_path != PurePosixPath("defenseclaw"):
                             continue
                         if member.size <= 0 or member.size > MAX_GATEWAY_BINARY_BYTES:
@@ -3449,9 +3084,7 @@ def _validate_gateway_archives(
             except (OSError, tarfile.TarError) as exc:
                 raise CandidateError(f"invalid gateway archive {path}: {exc}") from exc
             if len(gateway_payloads) != 1:
-                raise CandidateError(
-                    f"gateway archive {path.name} must contain exactly one root defenseclaw binary"
-                )
+                raise CandidateError(f"gateway archive {path.name} must contain exactly one root defenseclaw binary")
             _validate_gateway_binary(
                 gateway_payloads[0],
                 os_name=os_name,
@@ -3474,15 +3107,12 @@ def _validate_gateway_archives(
 
 def _refusal_envelope_payload(version: str) -> bytes:
     if version == "0.8.4":
-        boundary = (
-            "DefenseClaw 0.8.4 must be installed by the release-owned staged upgrade resolver.\n"
-        )
+        boundary = "DefenseClaw 0.8.4 must be installed by the release-owned staged upgrade resolver.\n"
     else:
         boundary = f"DefenseClaw {version} requires the 0.8.4 upgrade bridge.\n"
-    return (
-        boundary
-        + "No changes were made. Run the release-owned upgrade resolver without a version.\n"
-    ).encode("utf-8")
+    return (boundary + "No changes were made. Run the release-owned upgrade resolver without a version.\n").encode(
+        "utf-8"
+    )
 
 
 def _validate_legacy_refusal_envelopes(directory: Path, version: str) -> None:
@@ -3548,18 +3178,12 @@ def prepare_runtime(directory: Path, version: str) -> None:
     plain_payload = _refusal_envelope_payload(version)
     for os_name in ("darwin", "linux"):
         for arch in ("amd64", "arm64"):
-            (directory / f"defenseclaw_{version}_{os_name}_{arch}.tar.gz").write_bytes(
-                plain_payload
-            )
+            (directory / f"defenseclaw_{version}_{os_name}_{arch}.tar.gz").write_bytes(plain_payload)
     for arch in ("amd64", "arm64"):
-        (directory / f"defenseclaw_{version}_windows_{arch}.zip").write_bytes(
-            plain_payload
-        )
+        (directory / f"defenseclaw_{version}_windows_{arch}.zip").write_bytes(plain_payload)
     canonical_wheel.write_bytes(plain_payload)
     _validate_legacy_refusal_envelopes(directory, version)
-    checksum_lines = [
-        f"{_sha256(directory / name)}  {name}" for name in runtime_asset_names(version)
-    ]
+    checksum_lines = [f"{_sha256(directory / name)}  {name}" for name in runtime_asset_names(version)]
     (directory / RUNTIME_ATTESTATION_FILENAME).write_text(
         "\n".join(checksum_lines) + "\n",
         encoding="utf-8",
@@ -3576,9 +3200,7 @@ def verify_runtime(directory: Path, version: str) -> None:
     if tuple(map(int, version.split("."))) >= (0, 8, 4):
         _validate_legacy_refusal_envelopes(directory, version)
         runtime_checksums = _parse_checksums(directory / RUNTIME_ATTESTATION_FILENAME)
-        expected_runtime_checksums = {
-            name: _sha256(directory / name) for name in runtime_asset_names(version)
-        }
+        expected_runtime_checksums = {name: _sha256(directory / name) for name in runtime_asset_names(version)}
         if runtime_checksums != expected_runtime_checksums:
             raise CandidateError("runtime checksums do not cover the exact protected candidate")
     for name in names:
@@ -3618,9 +3240,7 @@ def extract_gateway(release_dir: Path, output: Path, version: str, os_name: str,
     verify_runtime(release_dir, version)
     archive_path = release_dir / _expected_release_artifacts(version)["gateways"][os_name][arch]
     try:
-        with tarfile.open(
-            fileobj=io.BytesIO(_protected_payload(archive_path)), mode="r:gz"
-        ) as archive:
+        with tarfile.open(fileobj=io.BytesIO(_protected_payload(archive_path)), mode="r:gz") as archive:
             matches = []
             for member in archive.getmembers():
                 member_path = PurePosixPath(member.name)
@@ -3715,9 +3335,7 @@ def extract_windows_installer_inputs(
             output_dir.mkdir(parents=True, mode=0o700)
             output_dir.chmod(0o700)
         except OSError as exc:
-            raise CandidateError(
-                f"could not create private Windows installer input directory: {exc}"
-            ) from exc
+            raise CandidateError(f"could not create private Windows installer input directory: {exc}") from exc
         for name, payload in (
             (gateway_name, gateway_payload),
             (wheel_name, wheel_payload),
@@ -3779,26 +3397,19 @@ def _release_identity_documents(
     if tuple(map(int, version.split("."))) < (0, 8, 5):
         supplied = sorted(name for name, value in fields.items() if value is not None)
         if supplied:
-            raise CandidateError(
-                f"release {version} forbids hard-cut provenance fields: {supplied!r}"
-            )
+            raise CandidateError(f"release {version} forbids hard-cut provenance fields: {supplied!r}")
         return None, None
 
     missing = sorted(name for name, value in fields.items() if value is None)
     if missing:
-        raise CandidateError(
-            f"release {version} requires hard-cut provenance fields: {missing!r}"
-        )
+        raise CandidateError(f"release {version} requires hard-cut provenance fields: {missing!r}")
     for name in ("source_tree", "bridge_commit", "bridge_tree"):
         value = fields[name]
         if not isinstance(value, str) or not COMMIT_RE.fullmatch(value):
             raise CandidateError(f"{name} must be a full lowercase SHA-1, got {value!r}")
-    if not isinstance(bridge_checksums_sha256, str) or not SHA256_RE.fullmatch(
-        bridge_checksums_sha256
-    ):
+    if not isinstance(bridge_checksums_sha256, str) or not SHA256_RE.fullmatch(bridge_checksums_sha256):
         raise CandidateError(
-            "bridge_checksums_sha256 must be a full lowercase SHA-256, "
-            f"got {bridge_checksums_sha256!r}"
+            f"bridge_checksums_sha256 must be a full lowercase SHA-256, got {bridge_checksums_sha256!r}"
         )
 
     identity = _reviewed_source_install_identity(version)
@@ -3819,9 +3430,7 @@ def _release_identity_documents(
         "source_install_identity": identity,
         "bridge": bridge,
     }
-    source_map_sha256 = hashlib.sha256(
-        _canonical_json(source_map).encode("utf-8")
-    ).hexdigest()
+    source_map_sha256 = hashlib.sha256(_canonical_json(source_map).encode("utf-8")).hexdigest()
     provenance = {
         "schema_version": RELEASE_PROVENANCE_SCHEMA_VERSION,
         "release_version": version,
@@ -3895,7 +3504,10 @@ def _validate_release_identity(
     if source_map.get("policy_mode") != "same_as_release_source":
         raise CandidateError("release source map policy_mode mismatch")
 
-    for document, label in ((source_map, "release source map"), (provenance, "release provenance")):
+    for document, label in (
+        (source_map, "release source map"),
+        (provenance, "release provenance"),
+    ):
         identity = document.get("source_install_identity")
         bridge = document.get("bridge")
         if not isinstance(identity, dict) or set(identity) != identity_keys:
@@ -3943,14 +3555,12 @@ def _validate_release_identity(
         raise CandidateError("release source map JSON is not canonical or changed")
     if provenance_text != _canonical_json(provenance):
         raise CandidateError("release provenance JSON is not canonical or changed")
-    if provenance.get("release_source_map_sha256") != hashlib.sha256(
-        source_map_bytes
-    ).hexdigest():
+    if provenance.get("release_source_map_sha256") != hashlib.sha256(source_map_bytes).hexdigest():
         raise CandidateError("release provenance does not authenticate its source map")
     return provenance
 
 
-def _validate_windows_setup_pe(path: Path) -> str:
+def _validate_windows_setup_pe(path: Path) -> tuple[str, bool]:
     try:
         size = path.stat().st_size
         if not 0 < size <= MAX_WINDOWS_SETUP_BYTES:
@@ -3976,11 +3586,15 @@ def _validate_windows_setup_pe(path: Path) -> str:
         raise CandidateError("Windows Setup is not a Windows GUI executable")
     directory_count = struct.unpack_from("<I", payload, optional_offset + 108)[0]
     if directory_count < 5:
-        raise CandidateError("Windows Setup lacks an Authenticode certificate directory")
+        raise CandidateError("Windows Setup lacks a PE security-directory entry")
     certificate_offset, certificate_size = struct.unpack_from("<II", payload, optional_offset + 112 + 4 * 8)
-    if certificate_offset <= 0 or certificate_size < 8 or certificate_offset > len(payload) - certificate_size:
+    if certificate_offset == 0 and certificate_size == 0:
+        embedded_signature_present = False
+    elif certificate_offset <= 0 or certificate_size < 8 or certificate_offset > len(payload) - certificate_size:
         raise CandidateError("Windows Setup lacks a complete embedded Authenticode signature")
-    return hashlib.sha256(payload).hexdigest()
+    else:
+        embedded_signature_present = True
+    return hashlib.sha256(payload).hexdigest(), embedded_signature_present
 
 
 def _require_object_fields(
@@ -3996,10 +3610,7 @@ def _require_object_fields(
 def _read_windows_setup_json(path: Path, label: str) -> dict[str, Any]:
     try:
         info = path.lstat()
-        if (
-            not stat.S_ISREG(info.st_mode)
-            or not 0 < info.st_size <= MAX_WINDOWS_SETUP_METADATA_BYTES
-        ):
+        if not stat.S_ISREG(info.st_mode) or not 0 < info.st_size <= MAX_WINDOWS_SETUP_METADATA_BYTES:
             raise CandidateError(f"{label} has an invalid file type or size")
         payload = path.read_bytes()
         if len(payload) != info.st_size:
@@ -4031,6 +3642,7 @@ def _validate_windows_setup_provenance(
     version: str,
     commit: str,
     setup_sha256: str,
+    embedded_signature_present: bool,
 ) -> dict[str, Any]:
     document = _read_windows_setup_json(path, "Windows Setup provenance")
     _require_object_fields(
@@ -4057,9 +3669,12 @@ def _validate_windows_setup_provenance(
         or document.get("version") != version
         or document.get("source_commit") != commit
         or document.get("distribution_flavor") != "oss"
-        or document.get("unsigned") is not False
     ):
         raise CandidateError("Windows Setup provenance release identity mismatch")
+    unsigned = document.get("unsigned")
+    if not isinstance(unsigned, bool) or embedded_signature_present != (not unsigned):
+        raise CandidateError("Windows Setup provenance signing state does not match the PE signature")
+    signed = not unsigned
     built_at = document.get("built_at_utc")
     if not isinstance(built_at, str) or re.fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z", built_at) is None:
         raise CandidateError("Windows Setup provenance build timestamp is invalid")
@@ -4114,7 +3729,7 @@ def _validate_windows_setup_provenance(
         or inputs.get("python_embed_sha256") != WINDOWS_PYTHON_EMBED_SHA256
         or inputs.get("yara_compat_wheel") != WINDOWS_YARA_COMPAT_WHEEL
         or inputs.get("cosign_sha256") != WINDOWS_COSIGN_SHA256
-        or inputs.get("product_executables_authenticode_signed") is not True
+        or inputs.get("product_executables_authenticode_signed") is not signed
         or inputs.get("windows_resource_policy") != WINDOWS_RESOURCE_POLICY
         or inputs.get("windows_resource_icon") != WINDOWS_RESOURCE_ICON
         or inputs.get("windows_resource_icon_sha256") != WINDOWS_RESOURCE_ICON_SHA256
@@ -4171,15 +3786,13 @@ def _validate_windows_setup_provenance(
     )
     if (
         not isinstance(toolchain.get("go"), str)
-        or re.fullmatch(r"go version go[0-9]+\.[0-9]+(?:\.[0-9]+)? windows/amd64", toolchain["go"])
-        is None
+        or re.fullmatch(r"go version go[0-9]+\.[0-9]+(?:\.[0-9]+)? windows/amd64", toolchain["go"]) is None
         or not isinstance(toolchain.get("uv"), str)
         or re.fullmatch(r"uv [0-9]+\.[0-9]+\.[0-9]+(?: .*)?", toolchain["uv"]) is None
         or toolchain.get("python_embed_url") != WINDOWS_PYTHON_EMBED_URL
         or toolchain.get("python_embed_sha256") != WINDOWS_PYTHON_EMBED_SHA256
         or toolchain.get("python_embed_sha256") != inputs.get("python_embed_sha256")
-        or toolchain.get("python_runtime_review_deadline_utc")
-        != WINDOWS_PYTHON_RUNTIME_REVIEW_DEADLINE
+        or toolchain.get("python_runtime_review_deadline_utc") != WINDOWS_PYTHON_RUNTIME_REVIEW_DEADLINE
         or toolchain.get("yara_compat_sha256") != inputs.get("yara_compat_wheel_sha256")
         or toolchain.get("win_unicode_console_source_url") != WINDOWS_WIN_UNICODE_SOURCE_URL
         or toolchain.get("win_unicode_console_source_sha256") != WINDOWS_WIN_UNICODE_SOURCE_SHA256
@@ -4234,20 +3847,33 @@ def _validate_windows_setup_provenance(
     )
     if (
         expected.get("policy") != "defenseclaw-product-publisher"
-        or expected.get("status") != "Valid"
-        or expected.get("publisher") != WINDOWS_SETUP_PUBLISHER
-        or expected.get("signature_type") != "Authenticode"
         or expected.get("platform_identity_required") is not True
-        or expected.get("timestamp_required") is not True
     ):
-        raise CandidateError("Windows Setup does not require Cisco Authenticode and RFC3161")
-    for field in (
+        raise CandidateError("Windows Setup Authenticode policy identity is invalid")
+    identity_fields = (
         "signer_thumbprint_sha256",
         "timestamp_signer_thumbprint_sha256",
         "timestamp_token_sha256",
+    )
+    if signed:
+        if (
+            expected.get("status") != "Valid"
+            or expected.get("publisher") != WINDOWS_SETUP_PUBLISHER
+            or expected.get("signature_type") != "Authenticode"
+            or expected.get("timestamp_required") is not True
+        ):
+            raise CandidateError("Signed Windows Setup does not require Cisco Authenticode and RFC3161")
+        for field in identity_fields:
+            if not isinstance(expected.get(field), str) or SHA256_RE.fullmatch(expected[field]) is None:
+                raise CandidateError(f"Windows Setup Authenticode {field} is invalid")
+    elif (
+        expected.get("status") != "NotSigned"
+        or expected.get("publisher") != ""
+        or expected.get("signature_type") != "None"
+        or expected.get("timestamp_required") is not False
+        or any(expected.get(field) != "" for field in identity_fields)
     ):
-        if not isinstance(expected.get(field), str) or SHA256_RE.fullmatch(expected[field]) is None:
-            raise CandidateError(f"Windows Setup Authenticode {field} is invalid")
+        raise CandidateError("Unverified Windows Setup contains a signed Authenticode policy")
 
     observed = _require_object_fields(
         evidence.get("observed"),
@@ -4262,47 +3888,63 @@ def _validate_windows_setup_provenance(
         },
         "Windows Setup observed Authenticode evidence",
     )
-    if (
-        observed.get("status") != "Valid"
-        or observed.get("publisher") != WINDOWS_SETUP_PUBLISHER
-        or observed.get("signature_type") != "Authenticode"
-    ):
-        raise CandidateError("Windows Setup observed Authenticode identity is invalid")
     signer = observed.get("signer")
     timestamp = observed.get("timestamp")
-    if not isinstance(signer, dict) or signer.get("thumbprint_sha256") != expected.get("signer_thumbprint_sha256"):
-        raise CandidateError("Windows Setup Authenticode signer identity is inconsistent")
-    if (
-        not isinstance(timestamp, dict)
-        or timestamp.get("present") is not True
-        or timestamp.get("format") != "rfc3161"
-        or timestamp.get("token_sha256") != expected.get("timestamp_token_sha256")
-        or not isinstance(timestamp.get("signing_time_utc"), str)
-        or not timestamp.get("signing_time_utc")
-    ):
-        raise CandidateError("Windows Setup RFC3161 timestamp evidence is invalid")
-    timestamp_certificate = timestamp.get("certificate")
-    if not isinstance(timestamp_certificate, dict) or timestamp_certificate.get("thumbprint_sha256") != expected.get(
-        "timestamp_signer_thumbprint_sha256"
-    ):
-        raise CandidateError("Windows Setup RFC3161 signer identity is inconsistent")
     embedded = observed.get("embedded_signatures")
-    if not isinstance(embedded, list) or len(embedded) != 1:
-        raise CandidateError("Windows Setup must contain exactly one embedded Authenticode signature")
-    embedded_signature = embedded[0]
-    if not isinstance(embedded_signature, dict) or embedded_signature.get("publisher") != WINDOWS_SETUP_PUBLISHER:
-        raise CandidateError("Windows Setup embedded Authenticode publisher is invalid")
-    embedded_signer = embedded_signature.get("signer")
-    embedded_timestamp = embedded_signature.get("timestamp")
-    if (
-        not isinstance(embedded_signer, dict)
-        or embedded_signer.get("thumbprint_sha256") != expected.get("signer_thumbprint_sha256")
-        or not isinstance(embedded_timestamp, dict)
-        or embedded_timestamp.get("present") is not True
-        or embedded_timestamp.get("format") != "rfc3161"
-        or embedded_timestamp.get("token_sha256") != expected.get("timestamp_token_sha256")
+    if signed:
+        if (
+            observed.get("status") != "Valid"
+            or observed.get("publisher") != WINDOWS_SETUP_PUBLISHER
+            or observed.get("signature_type") != "Authenticode"
+        ):
+            raise CandidateError("Windows Setup observed Authenticode identity is invalid")
+        if not isinstance(signer, dict) or signer.get("thumbprint_sha256") != expected.get("signer_thumbprint_sha256"):
+            raise CandidateError("Windows Setup Authenticode signer identity is inconsistent")
+        if (
+            not isinstance(timestamp, dict)
+            or timestamp.get("present") is not True
+            or timestamp.get("format") != "rfc3161"
+            or timestamp.get("token_sha256") != expected.get("timestamp_token_sha256")
+            or not isinstance(timestamp.get("signing_time_utc"), str)
+            or not timestamp.get("signing_time_utc")
+        ):
+            raise CandidateError("Windows Setup RFC3161 timestamp evidence is invalid")
+        timestamp_certificate = timestamp.get("certificate")
+        if not isinstance(timestamp_certificate, dict) or timestamp_certificate.get(
+            "thumbprint_sha256"
+        ) != expected.get("timestamp_signer_thumbprint_sha256"):
+            raise CandidateError("Windows Setup RFC3161 signer identity is inconsistent")
+        if not isinstance(embedded, list) or len(embedded) != 1:
+            raise CandidateError("Windows Setup must contain exactly one embedded Authenticode signature")
+        embedded_signature = embedded[0]
+        if not isinstance(embedded_signature, dict) or embedded_signature.get("publisher") != WINDOWS_SETUP_PUBLISHER:
+            raise CandidateError("Windows Setup embedded Authenticode publisher is invalid")
+        embedded_signer = embedded_signature.get("signer")
+        embedded_timestamp = embedded_signature.get("timestamp")
+        if (
+            not isinstance(embedded_signer, dict)
+            or embedded_signer.get("thumbprint_sha256") != expected.get("signer_thumbprint_sha256")
+            or not isinstance(embedded_timestamp, dict)
+            or embedded_timestamp.get("present") is not True
+            or embedded_timestamp.get("format") != "rfc3161"
+            or embedded_timestamp.get("token_sha256") != expected.get("timestamp_token_sha256")
+        ):
+            raise CandidateError("Windows Setup embedded Authenticode timestamp identity is invalid")
+    elif (
+        observed.get("status") != "NotSigned"
+        or observed.get("publisher") != ""
+        or observed.get("signature_type") != "None"
+        or signer is not None
+        or observed.get("chain") not in (None, [])
+        or not isinstance(timestamp, dict)
+        or timestamp.get("present") is not False
+        or timestamp.get("format") != ""
+        or timestamp.get("token_sha256") != ""
+        or timestamp.get("signing_time_utc") != ""
+        or timestamp.get("certificate") is not None
+        or embedded != []
     ):
-        raise CandidateError("Windows Setup embedded Authenticode timestamp identity is invalid")
+        raise CandidateError("Unverified Windows Setup exposes Authenticode signer or timestamp evidence")
     return document
 
 
@@ -4335,19 +3977,11 @@ def _validate_windows_setup_runtime_inputs(
 def _spdx_sha256(element: dict[str, Any], label: str) -> str:
     checksums = element.get("checksums")
     matches = (
-        [
-            row.get("checksumValue")
-            for row in checksums
-            if isinstance(row, dict) and row.get("algorithm") == "SHA256"
-        ]
+        [row.get("checksumValue") for row in checksums if isinstance(row, dict) and row.get("algorithm") == "SHA256"]
         if isinstance(checksums, list)
         else []
     )
-    if (
-        len(matches) != 1
-        or not isinstance(matches[0], str)
-        or SHA256_RE.fullmatch(matches[0]) is None
-    ):
+    if len(matches) != 1 or not isinstance(matches[0], str) or SHA256_RE.fullmatch(matches[0]) is None:
         raise CandidateError(f"{label} does not contain exactly one lowercase SHA-256 digest")
     return matches[0]
 
@@ -4416,11 +4050,7 @@ def _validate_windows_setup_sbom(
         if not isinstance(element, dict):
             raise CandidateError("Windows Setup SBOM contains a non-object element")
         identifier = element.get("SPDXID")
-        if (
-            not isinstance(identifier, str)
-            or not identifier.startswith("SPDXRef-")
-            or identifier in identifiers
-        ):
+        if not isinstance(identifier, str) or not identifier.startswith("SPDXRef-") or identifier in identifiers:
             raise CandidateError("Windows Setup SBOM contains a duplicate or invalid SPDXID")
         identifiers.add(identifier)
 
@@ -4508,9 +4138,7 @@ def _validate_windows_setup_sbom(
     ):
         raise CandidateError("Windows Setup SBOM embedded payload package is invalid")
     embedded_files = [
-        item
-        for item in files
-        if isinstance(item, dict) and item.get("fileName") == "./embedded/installer-payload.zip"
+        item for item in files if isinstance(item, dict) and item.get("fileName") == "./embedded/installer-payload.zip"
     ]
     if len(embedded_files) != 1:
         raise CandidateError("Windows Setup SBOM must contain exactly one embedded payload file")
@@ -4566,6 +4194,7 @@ def _validate_windows_setup_certification(
     version: str,
     commit: str,
     setup_sha256: str,
+    signed: bool,
 ) -> None:
     document = _read_windows_setup_json(path, "Windows Setup certification")
     _require_object_fields(
@@ -4573,6 +4202,7 @@ def _validate_windows_setup_certification(
         {
             "schema_version",
             "status",
+            "verification_status",
             "platform",
             "setup",
             "clients",
@@ -4586,22 +4216,41 @@ def _validate_windows_setup_certification(
         "Windows Setup certification",
     )
     setup = document.get("setup")
-    if (
+    common_mismatch = (
         document.get("schema_version") != 1
-        or document.get("status") != "passed"
         or document.get("platform") != "windows-x64"
-        or setup
-        != {
-            "name": WINDOWS_SETUP_ASSET,
-            "sha256": setup_sha256,
-            "publisher": WINDOWS_SETUP_PUBLISHER,
-        }
-        or document.get("clients") != WINDOWS_SETUP_CLIENTS
-        or document.get("connectors") != ["codex", "claudecode"]
-        or document.get("requirements") != list(WINDOWS_SETUP_CERTIFICATION_REQUIREMENTS)
         or document.get("source_commit") != commit
         or document.get("release_version") != version
-    ):
+    )
+    if signed:
+        mode_mismatch = (
+            document.get("status") != "passed"
+            or document.get("verification_status") != "signed"
+            or setup
+            != {
+                "name": WINDOWS_SETUP_ASSET,
+                "sha256": setup_sha256,
+                "publisher": WINDOWS_SETUP_PUBLISHER,
+            }
+            or document.get("clients") != WINDOWS_SETUP_CLIENTS
+            or document.get("connectors") != ["codex", "claudecode"]
+            or document.get("requirements") != list(WINDOWS_SETUP_CERTIFICATION_REQUIREMENTS)
+        )
+    else:
+        mode_mismatch = (
+            document.get("status") != "unverified"
+            or document.get("verification_status") != "unverified"
+            or setup
+            != {
+                "name": WINDOWS_SETUP_ASSET,
+                "sha256": setup_sha256,
+                "publisher": "",
+            }
+            or document.get("clients") != {}
+            or document.get("connectors") != []
+            or document.get("requirements") != list(WINDOWS_SETUP_UNVERIFIED_REQUIREMENTS)
+        )
+    if common_mismatch or mode_mismatch:
         raise CandidateError("Windows Setup certification identity or required evidence mismatch")
     staging_digest = document.get("staging_artifact_digest")
     if not isinstance(staging_digest, str) or re.fullmatch(r"(?:sha256:)?[0-9a-f]{64}", staging_digest) is None:
@@ -4633,7 +4282,7 @@ def _validate_windows_installer_assets(
     if exact_file_set and _strict_file_names(directory, "Windows installer artifact") != names:
         raise CandidateError("Windows installer artifact directory must contain exactly five files")
     setup_path = directory / WINDOWS_SETUP_ASSET
-    setup_sha256 = _validate_windows_setup_pe(setup_path)
+    setup_sha256, embedded_signature_present = _validate_windows_setup_pe(setup_path)
     sidecar = directory / f"{WINDOWS_SETUP_ASSET}.sha256"
     try:
         sidecar_payload = sidecar.read_bytes()
@@ -4650,6 +4299,7 @@ def _validate_windows_installer_assets(
         version=version,
         commit=commit,
         setup_sha256=setup_sha256,
+        embedded_signature_present=embedded_signature_present,
     )
     if runtime_directory is not None:
         _validate_windows_setup_runtime_inputs(provenance, runtime_directory, version)
@@ -4665,7 +4315,105 @@ def _validate_windows_installer_assets(
         version=version,
         commit=commit,
         setup_sha256=setup_sha256,
+        signed=not provenance["unsigned"],
     )
+
+
+def record_windows_unverified(
+    directory: Path,
+    version: str,
+    commit: str,
+    artifact_digest: str,
+    run_url: str,
+) -> None:
+    """Record an explicit non-certification for an unsigned Setup artifact."""
+
+    _validate_version(version)
+    _validate_commit(commit)
+    payload_names = (
+        WINDOWS_SETUP_ASSET,
+        f"{WINDOWS_SETUP_ASSET}.provenance.json",
+        f"{WINDOWS_SETUP_ASSET}.sbom.json",
+        f"{WINDOWS_SETUP_ASSET}.sha256",
+    )
+    _require_regular_files(directory, payload_names, "unverified Windows installer artifact")
+    if _strict_file_names(directory, "unverified Windows installer artifact") != tuple(sorted(payload_names)):
+        raise CandidateError("unverified Windows installer artifact directory must contain exactly four files")
+
+    setup_path = directory / WINDOWS_SETUP_ASSET
+    setup_sha256, embedded_signature_present = _validate_windows_setup_pe(setup_path)
+    if embedded_signature_present:
+        raise CandidateError("refusing to mark an Authenticode-signed Windows Setup as unverified")
+    sidecar = directory / f"{WINDOWS_SETUP_ASSET}.sha256"
+    try:
+        sidecar_payload = sidecar.read_bytes()
+    except OSError as exc:
+        raise CandidateError(f"could not read Windows Setup SHA-256 sidecar: {exc}") from exc
+    match = re.fullmatch(
+        rb"([0-9a-f]{64})  DefenseClawSetup-x64\.exe(?:\r\n|\n)",
+        sidecar_payload,
+    )
+    if match is None or match.group(1).decode("ascii") != setup_sha256:
+        raise CandidateError("Windows Setup SHA-256 sidecar does not bind the exact executable")
+    provenance = _validate_windows_setup_provenance(
+        directory / f"{WINDOWS_SETUP_ASSET}.provenance.json",
+        version=version,
+        commit=commit,
+        setup_sha256=setup_sha256,
+        embedded_signature_present=False,
+    )
+    if provenance["unsigned"] is not True:
+        raise CandidateError("Windows Setup provenance does not declare the unverified signing state")
+    _validate_windows_setup_sbom(
+        directory / f"{WINDOWS_SETUP_ASSET}.sbom.json",
+        version=version,
+        commit=commit,
+        setup_sha256=setup_sha256,
+        provenance=provenance,
+    )
+    if re.fullmatch(r"(?:sha256:)?[0-9a-f]{64}", artifact_digest) is None:
+        raise CandidateError("unverified Windows Setup staging digest is invalid")
+    if (
+        re.fullmatch(
+            r"https://github\.com/cisco-ai-defense/defenseclaw/actions/runs/[1-9][0-9]*",
+            run_url,
+        )
+        is None
+    ):
+        raise CandidateError("unverified Windows Setup run URL is invalid")
+
+    certification = {
+        "schema_version": 1,
+        "status": "unverified",
+        "verification_status": "unverified",
+        "platform": "windows-x64",
+        "setup": {
+            "name": WINDOWS_SETUP_ASSET,
+            "sha256": setup_sha256,
+            "publisher": "",
+        },
+        "clients": {},
+        "connectors": [],
+        "requirements": list(WINDOWS_SETUP_UNVERIFIED_REQUIREMENTS),
+        "source_commit": commit,
+        "release_version": version,
+        "staging_artifact_digest": artifact_digest,
+        "run_url": run_url,
+    }
+    certification_path = directory / f"{WINDOWS_SETUP_ASSET}.certification.json"
+    certification_path.write_text(
+        json.dumps(certification, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _validate_windows_setup_certification(
+        certification_path,
+        version=version,
+        commit=commit,
+        setup_sha256=setup_sha256,
+        signed=False,
+    )
+
+
 def _validated_effective_upgrade_baselines(root: Path, version: str) -> str:
     path = root / EFFECTIVE_UPGRADE_BASELINES_FILENAME
     before = _read_bounded_regular_file(
@@ -4701,9 +4449,7 @@ def assemble(
 ) -> None:
     _validate_version(version)
     _validate_commit(commit)
-    macos_verification_status = _validate_macos_verification_status(
-        macos_verification_status
-    )
+    macos_verification_status = _validate_macos_verification_status(macos_verification_status)
     source_map, provenance = _release_identity_documents(
         version,
         commit,
@@ -4775,8 +4521,7 @@ def assemble(
         shutil.copy2(notes, root / "RELEASE_NOTES.md")
 
     checksum_lines = [
-        f"{_sha256(dist / name)}  {name}"
-        for name in payload_asset_names(version, macos_verification_status)
+        f"{_sha256(dist / name)}  {name}" for name in payload_asset_names(version, macos_verification_status)
     ]
     (dist / "checksums.txt").write_text("\n".join(checksum_lines) + "\n", encoding="utf-8")
 
@@ -4839,10 +4584,7 @@ def _validate_legacy_cosign_bundle(path: Path) -> None:
 
     try:
         info = path.lstat()
-        if (
-            not stat.S_ISREG(info.st_mode)
-            or not 0 < info.st_size <= MAX_LEGACY_COSIGN_BUNDLE_BYTES
-        ):
+        if not stat.S_ISREG(info.st_mode) or not 0 < info.st_size <= MAX_LEGACY_COSIGN_BUNDLE_BYTES:
             raise CandidateError("legacy Cosign bundle has an invalid file type or size")
         payload = path.read_bytes()
         if len(payload) != info.st_size:
@@ -4891,9 +4633,7 @@ def seal(root: Path, version: str, commit: str) -> None:
     _validate_version(version)
     _validate_commit(commit)
     metadata = _read_json_object(root / "candidate-metadata.json", "candidate metadata")
-    macos_verification_status = _validate_macos_verification_status(
-        metadata.get("macos_verification_status")
-    )
+    macos_verification_status = _validate_macos_verification_status(metadata.get("macos_verification_status"))
     effective_policy_sha256 = _validated_effective_upgrade_baselines(root, version)
     expected_metadata = {
         "schema_version": SCHEMA_VERSION,
@@ -4918,10 +4658,7 @@ def seal(root: Path, version: str, commit: str) -> None:
     _require_regular_files(dist, names, "release candidate")
     actual_names = _strict_file_names(dist, "release candidate")
     if actual_names != names:
-        raise CandidateError(
-            "release candidate contains an unexpected file set: "
-            f"got {actual_names!r}, want {names!r}"
-        )
+        raise CandidateError(f"release candidate contains an unexpected file set: got {actual_names!r}, want {names!r}")
     _require_canonical_release_certificate(dist / "checksums.txt.pem")
     if tuple(map(int, version.split("."))) >= WINDOWS_SETUP_START_VERSION:
         _validate_legacy_cosign_bundle(dist / CHECKSUMS_BUNDLE_FILENAME)
@@ -4961,9 +4698,7 @@ def verify(root: Path, version: str, commit: str) -> None:
         raise CandidateError("release candidate version mismatch")
     if manifest.get("commit") != commit:
         raise CandidateError("release candidate commit mismatch")
-    macos_verification_status = _validate_macos_verification_status(
-        manifest.get("macos_verification_status")
-    )
+    macos_verification_status = _validate_macos_verification_status(manifest.get("macos_verification_status"))
     if manifest.get("source_install_identity") != _reviewed_source_install_identity(version):
         raise CandidateError("release candidate source-install identity mismatch")
     effective_policy_sha256 = _validated_effective_upgrade_baselines(root, version)
@@ -5018,9 +4753,7 @@ def verify(root: Path, version: str, commit: str) -> None:
         raise CandidateError("sealed release notes are missing")
 
     checksums = _parse_checksums(dist / "checksums.txt")
-    if tuple(sorted(checksums)) != payload_asset_names(
-        version, macos_verification_status
-    ):
+    if tuple(sorted(checksums)) != payload_asset_names(version, macos_verification_status):
         raise CandidateError("checksums.txt coverage changed after sealing")
     for name, expected in checksums.items():
         if _sha256(dist / name) != expected:
@@ -5119,6 +4852,13 @@ def _parser() -> argparse.ArgumentParser:
     extract_windows_parser.add_argument("--output-dir", type=Path, required=True)
     extract_windows_parser.add_argument("--version", required=True)
 
+    record_windows_parser = subparsers.add_parser("record-windows-unverified")
+    record_windows_parser.add_argument("--windows-dir", type=Path, required=True)
+    record_windows_parser.add_argument("--version", required=True)
+    record_windows_parser.add_argument("--commit", required=True)
+    record_windows_parser.add_argument("--artifact-digest", required=True)
+    record_windows_parser.add_argument("--run-url", required=True)
+
     assemble_parser = subparsers.add_parser("assemble")
     assemble_parser.add_argument("--runtime-dir", type=Path, required=True)
     assemble_parser.add_argument("--macos-dir", type=Path, required=True)
@@ -5170,8 +4910,7 @@ def main(argv: list[str] | None = None) -> int:
                 args.releases_json,
             )
             print(
-                "release progression verified: "
-                f"target={args.target} reviewed_max={reviewed} published_max={published}"
+                f"release progression verified: target={args.target} reviewed_max={reviewed} published_max={published}"
             )
         elif args.command == "verify-runtime":
             verify_runtime(args.release_dir, args.version)
@@ -5191,6 +4930,15 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "extract-windows-installer-inputs":
             extract_windows_installer_inputs(args.release_dir, args.output_dir, args.version)
             print(f"Windows installer inputs extracted: {args.output_dir}")
+        elif args.command == "record-windows-unverified":
+            record_windows_unverified(
+                args.windows_dir,
+                args.version,
+                args.commit,
+                args.artifact_digest,
+                args.run_url,
+            )
+            print(f"unverified Windows installer custody recorded: {args.windows_dir}")
         elif args.command == "assemble":
             assemble(
                 args.runtime_dir,

--- a/scripts/windows-native-ci.ps1
+++ b/scripts/windows-native-ci.ps1
@@ -4172,6 +4172,7 @@ function Invoke-WindowsReleaseCertification {
         $evidence = [ordered]@{
             schema_version = 1
             status = 'passed'
+            verification_status = 'signed'
             platform = 'windows-x64'
             setup = [ordered]@{
                 name = 'DefenseClawSetup-x64.exe'


### PR DESCRIPTION
## What changed

- Use a strict three-state Windows Authenticode policy:
  - neither signing secret: publish one explicitly unverified `DefenseClawSetup-x64.exe`
  - only one secret: fail immediately
  - both secrets: signing, Cisco publisher validation, RFC3161 timestamping, and real-client certification remain mandatory
- Bind signed/unverified status across the PE, provenance, SBOM, certification sidecar, immutable artifact custody, candidate sealing, and publication.
- Keep the public Windows payload to exactly one x64 Setup executable; no ARM installer and no second EXE.
- Keep `install.ps1` and automatic upgrades signed-only and fail-closed.
- Update release documentation and regression contracts for both trust modes.

## Root cause

The release workflow unconditionally required `WINDOWS_SIGNING_CERT_BASE64` and `WINDOWS_SIGNING_CERT_PASSWORD`, so repositories without those secrets failed before building the Windows Setup even though the existing builder could produce an unsigned local artifact.

## User impact

A release can now complete without Windows signing credentials and publish a directly downloadable x64 Setup marked as unverified. If signing is configured, any certificate, password, SignTool, publisher, or timestamp problem still fails the release instead of silently falling back to unsigned output.

## Validation

- `59 passed` — complete Windows installer artifact suite
- `52 passed, 4 skipped` — staged release workflow and Windows release certification contracts
- `180 passed, 2 skipped` — release-candidate suite
- `20 passed` — final Windows signed/unverified candidate regression selection
- Ruff checks, YAML parsing, PowerShell parsing, and `git diff --check`
- Independent final security review: no blockers
