### PR TITLE
fix(release): pad macOS DMG capacity

### DIFF
--- a/cli/tests/test_macos_runtime_installer_upgrade_guard.py
+++ b/cli/tests/test_macos_runtime_installer_upgrade_guard.py
@@ -332,10 +332,24 @@ def test_macos_release_reclaims_build_intermediates_and_avoids_dmg_app_copy() ->
     plain_sign = build.index('codesign "${sign_args[@]}" "${PLAIN_APP}"', derived_cleanup)
     dmg = build.index('echo "Creating unified drag-to-Applications DMG"')
     staging_link = build.index('ln -s /Applications "${UNIFIED_STAGE}/Applications"', dmg)
+    source_size = build.index('DMG_SOURCE_KIB="$(du -sk "${UNIFIED_STAGE}"', staging_link)
+    padded_size = build.index("DMG_SIZE_KIB=$((DMG_SOURCE_KIB + DMG_SOURCE_KIB / 5 + 65536))", source_size)
     image_create = build.index('hdiutil create', staging_link)
     unified_source = build.index('-srcfolder "${UNIFIED_STAGE}"', image_create)
+    explicit_size = build.index('-size "${DMG_SIZE_KIB}k"', unified_source)
 
-    assert app_copy < derived_cleanup < plain_sign < dmg < staging_link < image_create < unified_source
+    assert (
+        app_copy
+        < derived_cleanup
+        < plain_sign
+        < dmg
+        < staging_link
+        < source_size
+        < padded_size
+        < image_create
+        < unified_source
+        < explicit_size
+    )
     assert 'DMG_STAGE=' not in build
     assert 'ditto "${APP}" "${DMG_STAGE}/DefenseClawMac.app"' not in build
 

--- a/scripts/build-macos-app-release.sh
+++ b/scripts/build-macos-app-release.sh
@@ -404,9 +404,20 @@ echo "Creating unified drag-to-Applications DMG"
 }
 ln -s /Applications "${UNIFIED_STAGE}/Applications"
 TEMP_DMG="${WORK}/DefenseClawMac-${VERSION}-macos-arm64.dmg"
+# hdiutil's automatic -srcfolder sizing can leave too little filesystem
+# headroom for the final copy. Size the image from the staged bytes with 20%
+# growth room plus 64 MiB for filesystem metadata and copy variance.
+DMG_SOURCE_KIB="$(du -sk "${UNIFIED_STAGE}" | awk '{print $1}')"
+[[ "${DMG_SOURCE_KIB}" =~ ^[0-9]+$ ]] || {
+    echo "could not determine unified DMG staging size" >&2
+    exit 1
+}
+DMG_SIZE_KIB=$((DMG_SOURCE_KIB + DMG_SOURCE_KIB / 5 + 65536))
+echo "Unified DMG source: ${DMG_SOURCE_KIB} KiB; capacity: ${DMG_SIZE_KIB} KiB"
 hdiutil create \
     -volname DefenseClawMac \
     -srcfolder "${UNIFIED_STAGE}" \
+    -size "${DMG_SIZE_KIB}k" \
     -ov -format UDZO \
     "${TEMP_DMG}"
 


### PR DESCRIPTION
## Summary

- give the unified macOS DMG explicit capacity based on its staged contents
- add 20% growth headroom plus 64 MiB for filesystem metadata and copy variance
- guard the sizing and `hdiutil -size` ordering with a regression test

## Root cause

Release run https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29930695529 built the macOS app and verified its ad-hoc signatures successfully, then failed while `hdiutil` copied the embedded gateway into `/Volumes/DefenseClawMac`:

`hdiutil: create failed - No space left on device`

The `-srcfolder` auto-sized DMG filesystem landed without enough free blocks. The previous successful run used the same runner image and a runtime artifact only 421 bytes smaller, which exposed this as a tight auto-sizing boundary rather than a signing, upgrade, Windows, or Linux failure.

## Fix

The packaging script now measures the staged tree with macOS-compatible `du -sk`, validates that measurement, adds proportional and minimum headroom, and passes the resulting capacity through `hdiutil -size`. This directly sizes the mounted DMG filesystem that ran out of space and scales as the payload grows.

No release workflow, Windows installer, Linux build, signing policy, or staged-upgrade behavior changes.

## Validation

- `48 passed, 6 skipped` — macOS packaging and release workflow tests
- `69 passed` — CI efficiency, path policy, and release validation tests
- `bash -n scripts/build-macos-app-release.sh`
- Ruff lint passed
- `git diff --check`
