### PR TITLE
fix release upgrade certification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,6 +458,9 @@ jobs:
               "pyjwt": ">=2.13.0",
               "starlette": ">=1.3.1,<1.4",
               "fastapi": ">=0.137.1,<0.138",
+              # Keep the portable LiteLLM line in wheel metadata. A tool.uv
+              # override is not shipped and cannot protect installers.
+              "litellm": ">=1.84.0,<1.92.0",
           }
           with zipfile.ZipFile(wheel) as archive:
               metadata_name = next(
@@ -504,6 +507,18 @@ jobs:
                       f"wheel security floor drift for {name}: "
                       f"expected {expected}, found {specifier.strip()}"
                   )
+          scanner = requirements.get("cisco-ai-mcp-scanner")
+          if scanner is None:
+              raise SystemExit("wheel metadata omits cisco-ai-mcp-scanner")
+          scanner_requirement = scanner.partition(";")[0].strip()
+          if re.fullmatch(
+              r"@\s+https://files[.]pythonhosted[.]org/[A-Za-z0-9_./-]+[.]whl"
+              r"#sha256=[0-9a-f]{64}",
+              scanner_requirement,
+          ) is None:
+              raise SystemExit(
+                  "wheel metadata leaves cisco-ai-mcp-scanner floating instead of binding a hashed wheel"
+              )
           digest_path.write_text(json.dumps(digests), encoding="utf-8")
           PY
           uv --no-config venv "$tmp/venv" --python "${{ matrix.python-version }}"

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -103,6 +103,14 @@ def test_installed_release_artifacts_mount_the_full_tui() -> None:
     assert "post_status_mandatory_sqlite_write=ok" in smoke
 
 
+def test_ci_wheel_metadata_prevents_floating_nonportable_scanner_resolution() -> None:
+    ci = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    assert '"litellm": ">=1.84.0,<1.92.0"' in ci
+    assert "wheel metadata leaves cisco-ai-mcp-scanner floating" in ci
+    assert "#sha256=[0-9a-f]{64}" in ci
+
+
 def test_release_supports_nightly_certification_and_manual_promotion() -> None:
     workflow = _workflow()
     triggers = workflow["on"]

--- a/cli/tests/test_upgrade_release_smoke_contract.py
+++ b/cli/tests/test_upgrade_release_smoke_contract.py
@@ -1207,10 +1207,37 @@ def test_v8_verifier_proves_historical_and_bridge_backup_layers() -> None:
         "config.historical.source",
         "phase1-source-gateway",
         "phase two retained no distinct byte-exact config-v7 bridge backup",
-        'receipt_from="${REQUIRED_BRIDGE_VERSION}"',
+        "expected_upgrade_receipt_source",
     ):
         assert contract in text
     assert 'facts.get("from_version") != source' in RECEIPT_CHECK.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("source", "target", "required_bridge", "expected"),
+    [
+        ("0.8.4", "0.8.7", "0.8.4", "0.8.5"),
+        ("0.8.3", "0.8.7", "0.8.4", "0.8.5"),
+        ("0.8.3", "0.8.5", "0.8.4", "0.8.4"),
+        ("0.8.5", "0.8.7", "0.8.4", "0.8.5"),
+        ("0.8.6", "0.8.7", "0.8.4", "0.8.6"),
+    ],
+)
+def test_expected_upgrade_receipt_source_matches_final_transaction(
+    source: str,
+    target: str,
+    required_bridge: str,
+    expected: str,
+) -> None:
+    completed = _source_script(
+        'expected_upgrade_receipt_source "$2" "$3" "$4"',
+        source,
+        target,
+        required_bridge,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert completed.stdout.strip() == expected
 
 
 def test_hard_cut_source_tree_ships_the_v8_runtime_and_forward_keyed_migration() -> None:

--- a/cli/tests/test_upgrade_smoke_static.py
+++ b/cli/tests/test_upgrade_smoke_static.py
@@ -236,6 +236,15 @@ def test_historical_baselines_are_authenticated_and_real_dependency_mode_is_expl
     assert 'if [[ "${SUCCESS_PATH_ONLY}" == "1" ]]' in protocol
 
 
+def test_live_continuity_uses_the_published_bridge_dependency_graph() -> None:
+    continuity = (ROOT / "scripts/test-observability-v8-upgrade-continuity.sh").read_text(encoding="utf-8")
+
+    dependency_mode = continuity.index('BASELINE_DEPENDENCIES="published"')
+    main = continuity.index("main_continuity() {")
+    install = continuity.index("install_baseline", main)
+    assert dependency_mode < main < install
+
+
 @pytest.mark.skipif(os.name == "nt", reason="executes the POSIX release shell and symlink contract")
 def test_bridge_auth_resolves_a_symlinked_cosign_binary(tmp_path: Path) -> None:
     real_bin = tmp_path / "real-bin"
@@ -1064,6 +1073,11 @@ def test_posix_resolver_hands_both_hard_cut_paths_to_authenticated_target_contro
     assert capture < bridge_switch
     target_command = '"${TARGET_CONTROLLER_CLI}" upgrade --yes --version "${final_version}"'
     assert resolver.count(target_command) == 2
+    scoped_target_command = (
+        'UV_OVERRIDE="${HISTORICAL_BOOTSTRAP_OVERRIDES_FILE}" \\\n'
+        f"        {target_command}"
+    )
+    assert resolver.count(scoped_target_command) == 2
     assert f"exec {target_command}" not in resolver
     assert resolver.count("|| target_status=$?") == 2
     assert resolver.count('exit "${target_status}"') == 2
@@ -1085,9 +1099,46 @@ def test_posix_resolver_hands_both_hard_cut_paths_to_authenticated_target_contro
     assert continuation.index("unset DEFENSECLAW_STAGED_TARGET_CONTROLLER_VERSION") < remove_staging
     assert "release_upgrade_lock" not in continuation
     assert "trap - EXIT" not in continuation
+    assert "HISTORICAL_BOOTSTRAP_OVERRIDES_FILE" not in continuation
     assert 'readonly OBSERVABILITY_V8_HARD_CUT_VERSION="0.8.5"' in resolver
     assert 'POST_HARD_CUT_FINAL_VERSION="${RELEASE_VERSION}"' in resolver
     assert resolver.count("continue_post_hard_cut_upgrade") == 3
+
+
+def test_posix_resolver_pins_historical_bootstrap_dependencies_to_signed_lock_wheels() -> None:
+    resolver = (ROOT / "scripts" / "upgrade.sh").read_text(encoding="utf-8")
+    for artifact in (
+        "cisco_ai_mcp_scanner-4.7.2-py3-none-any.whl",
+        "sha256=6ed0b8ced168886f572aec30a971c7b0e2e1de7eea489d3821627184fd271ac8",
+        "litellm-1.89.1-py3-none-any.whl",
+        "sha256=a52a67625d89cb1787ef48c4b3c1ab9c2574ea304f56900bc631844297a13bd4",
+    ):
+        assert artifact in resolver
+
+    helper_start = resolver.index("prepare_historical_bootstrap_overrides() {")
+    helper_end = resolver.index("\n}\n\nprepare_bridge_phase1_cli_preflight() {", helper_start)
+    helper = resolver[helper_start:helper_end]
+    assert 'historical-bootstrap-overrides.txt' in helper
+    assert 'chmod 600 "${overrides}"' in helper
+
+    function_boundaries = (
+        ("preflight_python_wheel", "begin_release_upgrade_receipt"),
+        ("prepare_bridge_phase1_cli_preflight", "bridge_source_health_observation"),
+        ("activate_bridge_phase1_cli", "bridge_source_health_check"),
+        ("prepare_hard_cut_target_controller", "verify_hard_cut_target_controller_handoff"),
+    )
+    for name, next_name in function_boundaries:
+        start = resolver.index(f"{name}() {{")
+        end = resolver.index(f"\n}}\n\n{next_name}() {{", start)
+        function = resolver[start:end]
+        assert "--only-binary litellm" in function
+        assert "HISTORICAL_BOOTSTRAP_OVERRIDES_FILE" in function
+
+    ordinary_install = resolver.rindex('UV_OVERRIDE= "${UV_BIN}" --no-config pip install')
+    ordinary_install_end = resolver.index('|| die "Failed to install CLI wheel"', ordinary_install)
+    ordinary = resolver[ordinary_install:ordinary_install_end]
+    assert "--only-binary litellm" in ordinary
+    assert "HISTORICAL_BOOTSTRAP_OVERRIDES_FILE" not in ordinary
 
 
 def _posix_resolver_lock_functions() -> str:

--- a/scripts/test-observability-v8-upgrade-continuity.sh
+++ b/scripts/test-observability-v8-upgrade-continuity.sh
@@ -29,6 +29,10 @@ FROM_VERSION=""
 FROM_VERSIONS=""
 FROM_VERSION_EXPLICIT="0"
 BASELINE_MODE="seed"
+# This gate claims to exercise the authenticated published bridge. Install its
+# real dependency graph and validate it instead of overlaying the old wheel on
+# the candidate's intentionally different dependencies.
+BASELINE_DEPENDENCIES="published"
 HEALTH_TIMEOUT="60"
 KEEP_WORKDIR="0"
 RELEASE_ROOT=""

--- a/scripts/test-upgrade-release.sh
+++ b/scripts/test-upgrade-release.sh
@@ -458,6 +458,25 @@ raise SystemExit(0 if parse(sys.argv[1]) <= parse(sys.argv[2]) else 1)
 PY
 }
 
+expected_upgrade_receipt_source() {
+    local source_version="$1" target_version="$2" required_bridge_version="${3:-}"
+    local receipt_source="${source_version}"
+
+    # A request that crosses beyond the v8 activation release completes as two
+    # transactions: source -> 0.8.5, then 0.8.5 -> target. The canonical target
+    # receipt truthfully records the final transaction rather than the original
+    # request. A request ending at 0.8.5 still records the required bridge as
+    # its source, including legacy routes that first stage through that bridge.
+    if ! version_lte "${V8_ACTIVATION_VERSION}" "${source_version}" \
+        && ! version_lte "${target_version}" "${V8_ACTIVATION_VERSION}"; then
+        receipt_source="${V8_ACTIVATION_VERSION}"
+    elif [[ -n "${required_bridge_version}" ]] \
+        && ! version_lte "${required_bridge_version}" "${source_version}"; then
+        receipt_source="${required_bridge_version}"
+    fi
+    printf '%s\n' "${receipt_source}"
+}
+
 target_uses_observability_v8() {
     version_lte "${V8_ACTIVATION_VERSION}" "${TARGET_VERSION}"
 }
@@ -2588,11 +2607,10 @@ print("local_bundle_manifest=target_exact_custom_preserved")
 PY
         fi
 
-        local receipt_from="${FROM_VERSION}"
-        if [[ -n "${REQUIRED_BRIDGE_VERSION}" ]] \
-            && ! version_lte "${REQUIRED_BRIDGE_VERSION}" "${FROM_VERSION}"; then
-            receipt_from="${REQUIRED_BRIDGE_VERSION}"
-        fi
+        local receipt_from
+        receipt_from="$(expected_upgrade_receipt_source \
+            "${FROM_VERSION}" "${TARGET_VERSION}" "${REQUIRED_BRIDGE_VERSION}")" \
+            || die "could not resolve the canonical target receipt source"
         "${venv_python}" "${ROOT}/scripts/check_upgrade_receipt.py" \
             --data-dir "${SMOKE_HOME}/.defenseclaw" \
             --from-version "${receipt_from}" \

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -90,6 +90,8 @@ readonly COSIGN_BOOTSTRAP_VERSION="2.6.3"
 readonly COSIGN_BOOTSTRAP_MAX_BYTES="209715200"
 readonly UPGRADE_MANIFEST_NAME="upgrade-manifest.json"
 readonly RELEASE_PROVENANCE_NAME="release-provenance.json"
+readonly HISTORICAL_MCP_SCANNER_REQUIREMENT='cisco-ai-mcp-scanner @ https://files.pythonhosted.org/packages/5d/74/6e72cbd496c0d33dfab1b4aee62792620236e63cccf278a8c896c6feb740/cisco_ai_mcp_scanner-4.7.2-py3-none-any.whl#sha256=6ed0b8ced168886f572aec30a971c7b0e2e1de7eea489d3821627184fd271ac8'
+readonly HISTORICAL_LITELLM_REQUIREMENT='litellm @ https://files.pythonhosted.org/packages/ec/24/81f03088876a13b628fdbaf746ee746e1dff127d63f339ef72f1a3801c91/litellm-1.89.1-py3-none-any.whl#sha256=a52a67625d89cb1787ef48c4b3c1ab9c2574ea304f56900bc631844297a13bd4'
 readonly UPGRADE_RECOVERY_ROOT="${DEFENSECLAW_HOME}/.upgrade-recovery"
 readonly UPGRADE_LOCK_FILE="${UPGRADE_RECOVERY_ROOT}/upgrade.lock"
 readonly UPGRADE_ADVISORY_LOCK_FILE="${UPGRADE_RECOVERY_ROOT}/upgrade.advisory.lock"
@@ -376,6 +378,7 @@ gateway_pid_status() {
 preflight_python_wheel() {
     local wheel="$1"
     local uv_bin
+    local -a dependency_args=(--only-binary litellm)
     uv_bin="$(command -v uv 2>/dev/null || true)"
     [[ -z "${uv_bin}" ]] \
         && die "uv not found on PATH — cannot update Python CLI. Install uv, then re-run the upgrade."
@@ -388,8 +391,16 @@ preflight_python_wheel() {
         preflight_python="${preflight_venv}/bin/python"
     fi
 
+    case "${RELEASE_VERSION}" in
+        0.8.4|0.8.5)
+            prepare_historical_bootstrap_overrides
+            dependency_args+=(--overrides "${HISTORICAL_BOOTSTRAP_OVERRIDES_FILE}")
+            ;;
+    esac
     step "Resolving Python CLI dependencies ..."
-    "${uv_bin}" --no-config pip install --python "${preflight_python}" --dry-run --quiet "${wheel}" \
+    UV_OVERRIDE= "${uv_bin}" --no-config pip install \
+        --python "${preflight_python}" --dry-run --quiet \
+        "${dependency_args[@]}" "${wheel}" \
         || die "Python CLI wheel dependencies are unsatisfiable; no services changed."
     ok "Python CLI dependency preflight passed"
 }
@@ -4270,6 +4281,7 @@ FINAL_RELEASE_WHL_SHA256=""
 TARGET_CONTROLLER_PROTECTED_WHEEL=""
 TARGET_CONTROLLER_VENV=""
 TARGET_CONTROLLER_CLI=""
+HISTORICAL_BOOTSTRAP_OVERRIDES_FILE=""
 CONTRACT_DIR=""
 MIGRATION_FAILURE_POLICY="warn"
 REQUIRED_MIGRATIONS_MISSING=""
@@ -6276,6 +6288,23 @@ for root in roots:
 PY
 }
 
+prepare_historical_bootstrap_overrides() {
+    [[ -z "${HISTORICAL_BOOTSTRAP_OVERRIDES_FILE:-}" ]] || return 0
+    [[ -n "${STAGING_DIR:-}" && -d "${STAGING_DIR}" && ! -L "${STAGING_DIR}" ]] \
+        || die "Private staging is unavailable for the historical dependency lock. No services changed."
+
+    local overrides="${STAGING_DIR}/historical-bootstrap-overrides.txt"
+    [[ ! -e "${overrides}" && ! -L "${overrides}" ]] \
+        || die "Historical dependency-lock custody is occupied. No services changed."
+    printf '%s\n%s\n' \
+        "${HISTORICAL_MCP_SCANNER_REQUIREMENT}" \
+        "${HISTORICAL_LITELLM_REQUIREMENT}" >"${overrides}" \
+        || die "Could not materialize the signed historical dependency lock. No services changed."
+    chmod 600 "${overrides}" \
+        || die "Could not protect the signed historical dependency lock. No services changed."
+    HISTORICAL_BOOTSTRAP_OVERRIDES_FILE="${overrides}"
+}
+
 prepare_bridge_phase1_cli_preflight() {
     local uv_bin preflight_venv preflight_version
     [[ -n "${whl_name:-}" && -f "${STAGING_DIR}/${whl_name}" ]] \
@@ -6321,9 +6350,13 @@ raise SystemExit(1 if inside_source else 0)
 PY
 
     preflight_venv="${STAGING_DIR}/bridge-cli-preflight"
+    prepare_historical_bootstrap_overrides
     "${uv_bin}" --no-config venv "${preflight_venv}" --python "${BRIDGE_PYTHON_INTERPRETER}" --quiet \
         || die "Could not create the bridge CLI preflight environment; no services changed."
-    "${uv_bin}" --no-config pip install --python "${preflight_venv}/bin/python" --quiet "${STAGING_DIR}/${whl_name}" \
+    UV_OVERRIDE= "${uv_bin}" --no-config pip install \
+        --python "${preflight_venv}/bin/python" --quiet \
+        --overrides "${HISTORICAL_BOOTSTRAP_OVERRIDES_FILE}" \
+        --only-binary litellm "${STAGING_DIR}/${whl_name}" \
         || die "Could not install the bridge CLI in its preflight environment; no services changed."
     preflight_version="$("${preflight_venv}/bin/python" -I -B -c 'from defenseclaw import __version__; print(__version__)')" \
         || die "Could not import the preflighted bridge CLI; no services changed."
@@ -6545,7 +6578,11 @@ PY
 
     "${uv_bin}" --no-config venv "${DEFENSECLAW_VENV}" --allow-existing --python "${BRIDGE_PYTHON_INTERPRETER}" --quiet \
         || die "Could not create the bridge CLI environment"
-    "${uv_bin}" --no-config pip install --python "${DEFENSECLAW_VENV}/bin/python" --quiet --offline "${BRIDGE_WHEEL_CUSTODY_PATH}" \
+    prepare_historical_bootstrap_overrides
+    UV_OVERRIDE= "${uv_bin}" --no-config pip install \
+        --python "${DEFENSECLAW_VENV}/bin/python" --quiet --offline \
+        --overrides "${HISTORICAL_BOOTSTRAP_OVERRIDES_FILE}" \
+        --only-binary litellm "${BRIDGE_WHEEL_CUSTODY_PATH}" \
         || die "Failed to install the bridge CLI wheel"
     bridge_version="$("${DEFENSECLAW_VENV}/bin/python" -I -B -c 'from defenseclaw import __version__; print(__version__)')" \
         || die "Could not import the installed bridge CLI"
@@ -6900,11 +6937,14 @@ raise SystemExit(1 if inside else 0)
 PY
 
     TARGET_CONTROLLER_VENV="${STAGING_DIR}/target-controller-venv"
+    prepare_historical_bootstrap_overrides
     "${uv_bin}" --no-config venv "${TARGET_CONTROLLER_VENV}" --python "${base_python}" --quiet \
         || die "Could not create the private target-controller venv. No services changed."
     chmod 700 "${TARGET_CONTROLLER_VENV}"
-    "${uv_bin}" --no-config pip install \
-        --python "${TARGET_CONTROLLER_VENV}/bin/python" --quiet "${materialized_wheel}" \
+    UV_OVERRIDE= "${uv_bin}" --no-config pip install \
+        --python "${TARGET_CONTROLLER_VENV}/bin/python" --quiet \
+        --overrides "${HISTORICAL_BOOTSTRAP_OVERRIDES_FILE}" \
+        --only-binary litellm "${materialized_wheel}" \
         || die "Could not install the authenticated target controller in private custody. No services changed."
     observed="$(PYTHONDONTWRITEBYTECODE=1 "${TARGET_CONTROLLER_VENV}/bin/python" -I -B -c \
         'from defenseclaw import __version__; print(__version__)')" \
@@ -7130,7 +7170,8 @@ handoff_existing_bridge_to_hard_cut() {
     export DEFENSECLAW_CONFIG="${CONFIG_PATH}"
     export OPENCLAW_HOME="${OPENCLAW_HOME}"
     local target_status=0
-    "${TARGET_CONTROLLER_CLI}" upgrade --yes --version "${final_version}" \
+    UV_OVERRIDE="${HISTORICAL_BOOTSTRAP_OVERRIDES_FILE}" \
+        "${TARGET_CONTROLLER_CLI}" upgrade --yes --version "${final_version}" \
         || target_status=$?
     if [[ "${target_status}" -eq 0 ]]; then
         continue_post_hard_cut_upgrade
@@ -7546,7 +7587,9 @@ else
         "${UV_BIN}" --no-config venv "${DEFENSECLAW_VENV}" --python 3.12
     fi
     VENV_PYTHON="${DEFENSECLAW_VENV}/bin/python"
-    "${UV_BIN}" --no-config pip install --python "${VENV_PYTHON}" --quiet "${STAGING_DIR}/${whl_name}" \
+    UV_OVERRIDE= "${UV_BIN}" --no-config pip install \
+        --python "${VENV_PYTHON}" --quiet --only-binary litellm \
+        "${STAGING_DIR}/${whl_name}" \
         || die "Failed to install CLI wheel"
     "${DEFENSECLAW_VENV}/bin/defenseclaw" --help >/dev/null 2>&1 \
         || die "CLI validation failed before launcher publication"
@@ -7871,7 +7914,8 @@ if [[ -n "${STAGED_FINAL_VERSION}" ]]; then
     export DEFENSECLAW_CONFIG="${CONFIG_PATH}"
     export OPENCLAW_HOME="${OPENCLAW_HOME}"
     target_status=0
-    "${TARGET_CONTROLLER_CLI}" upgrade --yes --version "${final_version}" \
+    UV_OVERRIDE="${HISTORICAL_BOOTSTRAP_OVERRIDES_FILE}" \
+        "${TARGET_CONTROLLER_CLI}" upgrade --yes --version "${final_version}" \
         || target_status=$?
     if [[ "${target_status}" -eq 0 ]]; then
         continue_post_hard_cut_upgrade


### PR DESCRIPTION
## What changed

- Correct the expected canonical receipt source for upgrades that cross the 0.8.5 hard cut.
- Pin the 0.8.4/0.8.5 bootstrap controllers to their reviewed MCP Scanner 4.7.2 and LiteLLM 1.89.1 wheels, with exact PyPI URLs and SHA-256 hashes.
- Keep the compatibility override scoped to historical controller handoffs; the final 0.8.7 install clears it and uses normal candidate dependencies.
- Make the live continuity gate install the published baseline dependency graph.
- Add CI wheel-metadata guards so future releases cannot ship a floating MCP Scanner requirement or lose the portable LiteLLM range.

## Why

Release run [29933598141](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29933598141) built and certified the Windows x64 Setup EXE and macOS DMG, but full certification failed for three independent reasons:

1. the harness searched for a fictitious 0.8.4 -> 0.8.7 receipt even though the final authenticated transaction is 0.8.5 -> 0.8.7;
2. newly published transitive dependencies changed how historical 0.8.4/0.8.5 wheels resolved on macOS and triggered a source build requiring Rust;
3. the Docker continuity harness seeded candidate dependencies into an old baseline.

The production receipt admission and dependency preflight remain fail-closed.

## Impact

Historical upgrade paths are deterministic across Linux and macOS, the certification harness now represents the real staged transaction, and future candidate wheels fail CI if they reintroduce the dependency-drift condition. The release remains a single Windows x64 Setup EXE; this patch does not add ARM or duplicate Windows artifacts.

## Validation

- 114 passed, 42 skipped: upgrade smoke/static/workflow contract suite
- 16 passed, 45 skipped: staged resolver, bridge rollback, and dependency contracts
- 6 passed: release validation strategy
- 94 passed, 4 skipped: certification, receipt, and baseline resolution suites
- Bash syntax, Ruff, and git diff checks passed
- Built-wheel metadata gate passed
- Exact historical override dry-run resolved MCP Scanner 4.7.2 and LiteLLM 1.89.1