### PR TITLE
fix upgrade gateway start timeout budget

### DIFF
--- a/cli/defenseclaw/commands/cmd_upgrade.py
+++ b/cli/defenseclaw/commands/cmd_upgrade.py
@@ -1563,11 +1563,16 @@ def _start_and_verify_services(
         if rollback_plan is not None
         else _gateway_process_environment(data_dir, config_path=config_path)
     )
+    # Starting the gateway can include bounded stale-process reconciliation on
+    # persistent runners.  Give that command the same budget used by rollback
+    # starts, while retaining the independent version-bound health deadline.
+    gateway_start_timeout = max(health_timeout + 30, 90)
     if not _run_silent(
         [gateway_command, "start"],
         "Gateway started",
         "Could not start gateway",
         env=gateway_environment,
+        timeout_seconds=gateway_start_timeout,
     ):
         ux.err("Gateway failed to start; the upgrade cannot be marked successful.")
         raise SystemExit(1)

--- a/cli/tests/test_cmd_upgrade.py
+++ b/cli/tests/test_cmd_upgrade.py
@@ -5260,7 +5260,7 @@ class TestUpgradeServiceVerification(unittest.TestCase):
         with (
             patch("defenseclaw.commands.cmd_upgrade._refresh_target_dotenv_environment") as refresh,
             patch("defenseclaw.commands.cmd_upgrade._reload_post_upgrade_config") as reload_config,
-            patch("defenseclaw.commands.cmd_upgrade._run_silent", return_value=True),
+            patch("defenseclaw.commands.cmd_upgrade._run_silent", return_value=True) as run_silent,
             patch("defenseclaw.commands.cmd_upgrade._poll_health") as in_process_health,
             patch("defenseclaw.commands.cmd_upgrade._poll_installed_health") as installed_health,
         ):
@@ -5275,6 +5275,14 @@ class TestUpgradeServiceVerification(unittest.TestCase):
         refresh.assert_called_once_with(plan)
         reload_config.assert_not_called()
         in_process_health.assert_not_called()
+        self.assertEqual(
+            run_silent.call_args_list[0].args[0],
+            [plan.active_gateway_path, "start"],
+        )
+        self.assertEqual(
+            run_silent.call_args_list[0].kwargs["timeout_seconds"],
+            90,
+        )
         installed_health.assert_called_once_with(
             "/private/bridge-data",
             13,


### PR DESCRIPTION
## What changed

- Give the post-migration gateway start command the same bounded timeout policy already used by hard-cut rollback starts.
- Derive the command budget from the configured health timeout, with a 90-second floor, while retaining the independent version-bound health deadline.
- Add a hard-cut service-start regression assertion for the 90-second budget.

## Why

Release run [29984391692](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29984391692), job [Live Docker/local observability continuity](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29984391692/job/89138629902), completed the authenticated 0.8.4 -> 0.8.5 bridge, migrated the final target, and restarted the local observability stack. The final `defenseclaw-gateway start` was then killed by `_run_silent`'s generic 30-second command timeout before the existing 60-second version-bound health check could run.

Rollback starts already allow `max(health_timeout + 30, 90)` for bounded stale-process reconciliation. The successful target path did not, so persistent runners could time out a valid start earlier than rollback would.

## Impact

Upgrade activation still fails closed on a non-zero start, a bounded start timeout, or a failed version-bound health check. This only aligns the target start budget with the existing rollback contract; it does not change artifact verification, signatures, provenance, migration custody, rollback validation, or release artifact platforms.

## Validation

- `uv run --locked pytest -q cli/tests/test_cmd_upgrade.py -k 'hard_cut_restart_never_imports_the_target_config_in_source_process'`: 1 passed, 220 deselected
- `uv run --locked pytest -q cli/tests/test_cmd_upgrade.py -k 'not post_migration_health_failure_restores_exact_bridge_state_and_records_outcome'`: 220 passed, 1 deselected, 34 subtests passed
- `uv run --locked pytest -q cli/tests/test_upgrade_release_smoke_contract.py`: 69 passed
- `uv run --locked ruff check cli/defenseclaw/commands/cmd_upgrade.py cli/tests/test_cmd_upgrade.py`: passed
- `git diff --check`: passed
- Full `cli/tests/test_cmd_upgrade.py`: 220 passed, 1 failed, 34 subtests passed. The failing `TestHardCutRollbackTransaction::test_post_migration_health_failure_restores_exact_bridge_state_and_records_outcome` also fails unchanged on `origin/main` because its migration fixture lacks the generated v7 compatibility selection.
