### PR TITLE
fix(release): fail fast before platform wait

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,13 +27,13 @@ on:
   workflow_dispatch:
     inputs:
       operation:
-        description: "Certify main, or publish it only after reusing exact certification."
+        description: "Certify reviewed main first (default), or release only after exact certification exists."
         required: true
         type: choice
-        default: release
+        default: certify
         options:
-          - release
           - certify
+          - release
       version:
         description: "Candidate version (X.Y.Z). Optional for nightly certification."
         required: false
@@ -261,197 +261,6 @@ jobs:
           fi
           echo "OK: $COMMIT is reviewed on origin/main ($RELEASE_OPERATION)"
           echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
-
-      - name: Require successful CI for the exact release commit
-        if: ${{ needs.release-mode.outputs.operation == 'release' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SELECTED_COMMIT: ${{ needs.release-mode.outputs.commit }}
-          # Main's release lane can legitimately consume 20 + 25 + 30 minutes
-          # across its sequential plan/build/smoke stages, while native Windows
-          # certification runs in parallel. Native Windows' package-to-
-          # acceptance critical path is bounded above two hours, so allow one
-          # shared three-hour window for every required workflow plus queueing.
-          CI_WAIT_ATTEMPTS: "360"
-          CI_WAIT_MAX_SECONDS: "10800"
-          CI_WAIT_INTERVAL_SECONDS: "30"
-          CI_API_TIMEOUT_SECONDS: "30"
-          REQUIRED_CI_WORKFLOWS: |-
-            ci.yml|CI
-            windows-native.yml|Windows Native CI
-            macos-app.yml|macOS App
-        run: |
-          set -euo pipefail
-          if [[ ! "$CI_WAIT_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] || \
-             [[ ! "$CI_WAIT_MAX_SECONDS" =~ ^[0-9]+$ ]] || \
-             [[ ! "$CI_WAIT_INTERVAL_SECONDS" =~ ^[0-9]+$ ]] || \
-             [[ ! "$CI_API_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error title=Invalid exact-SHA CI configuration::Wait attempts, deadline, interval, and API timeout must be bounded integers."
-            exit 1
-          fi
-          wait_started_at="$(date +%s)"
-          wait_deadline=$((wait_started_at + CI_WAIT_MAX_SECONDS))
-          for ((attempt = 1; attempt <= CI_WAIT_ATTEMPTS; attempt++)); do
-            required_count=0
-            passed_count=0
-            passed_details=""
-            pending_details=""
-            while IFS='|' read -r workflow_file workflow_name; do
-              [[ -n "$workflow_file" ]] || continue
-              required_count=$((required_count + 1))
-              if [[ ! "$workflow_file" =~ ^[A-Za-z0-9._-]+$ || -z "$workflow_name" ]]; then
-                echo "::error title=Invalid exact-SHA CI configuration::Invalid required workflow entry: $workflow_file|$workflow_name"
-                exit 1
-              fi
-
-              workflow_key="${workflow_file//./-}"
-              response_path="exact-commit-${workflow_key}-runs.json"
-              response_temp="${response_path}.tmp"
-              response_error="${response_path}.error"
-              now="$(date +%s)"
-              remaining_seconds=$((wait_deadline - now))
-              if [[ "$remaining_seconds" -le 0 ]]; then
-                state="pending"
-                detail="shared deadline reached before workflow query"
-              else
-                request_timeout="$CI_API_TIMEOUT_SECONDS"
-                if [[ "$remaining_seconds" -lt "$request_timeout" ]]; then
-                  request_timeout="$remaining_seconds"
-                fi
-                api_command=(gh)
-                gh_type="$(type -t gh || true)"
-                if [[ "$gh_type" != "function" ]] && command -v timeout >/dev/null 2>&1; then
-                  api_command=(
-                    timeout
-                    --signal=TERM
-                    --kill-after=5s
-                    "${request_timeout}s"
-                    gh
-                  )
-                fi
-                if "${api_command[@]}" api \
-                    -H "Accept: application/vnd.github+json" \
-                    "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow_file/runs?branch=main&event=push&head_sha=$SELECTED_COMMIT&per_page=100" \
-                    > "$response_temp" 2> "$response_error"; then
-                  mv -f "$response_temp" "$response_path"
-                  if parsed_result="$(
-                    python3 - "$response_path" "$SELECTED_COMMIT" 2> "$response_error" <<'PY'
-          import json
-          import sys
-
-          path, expected_sha = sys.argv[1:]
-          with open(path, encoding="utf-8") as stream:
-              payload = json.load(stream)
-          runs = [
-              run
-              for run in payload.get("workflow_runs", [])
-              if run.get("head_sha") == expected_sha
-              and run.get("head_branch") == "main"
-              and run.get("event") == "push"
-          ]
-          if not runs:
-              print("pending\tmissing")
-              raise SystemExit
-          selected = max(
-              runs,
-              key=lambda run: (
-                  int(run.get("run_number") or 0),
-                  int(run.get("run_attempt") or 0),
-                  int(run.get("id") or 0),
-              ),
-          )
-          status = selected.get("status", "unknown")
-          conclusion = selected.get("conclusion") or "pending"
-          detail = f"{status}/{conclusion}"
-          if status != "completed":
-              print(f"pending\t{detail}")
-          elif conclusion == "success":
-              print(f"success\t{selected.get('html_url', 'run URL unavailable')}")
-          else:
-              print(f"failure\t{detail}")
-          PY
-                  )" &&
-                     IFS=$'\t' read -r state detail <<< "$parsed_result"; then
-                    :
-                  else
-                    state="pending"
-                    detail="workflow API returned an invalid response"
-                  fi
-                else
-                  rm -f "$response_temp"
-                  api_error="$(
-                    tr '\r\n' '  ' < "$response_error" \
-                      | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' \
-                      | cut -c1-240
-                  )"
-                  if [[ "$api_error" =~ HTTP\ (401|404|422) ]]; then
-                    state="failure"
-                    detail="workflow API permanently rejected the request: $api_error"
-                  elif [[ -n "$api_error" ]]; then
-                    state="pending"
-                    detail="workflow API unavailable: $api_error"
-                  else
-                    state="pending"
-                    detail="workflow API unavailable or timed out after ${request_timeout}s"
-                  fi
-                fi
-              fi
-
-              case "$state" in
-                success)
-                  passed_count=$((passed_count + 1))
-                  passed_details="${passed_details}${passed_details:+; }$workflow_name: $detail"
-                  ;;
-                failure)
-                  echo "::error title=Exact-SHA CI failed::$workflow_name for $SELECTED_COMMIT failed ($detail)."
-                  exit 1
-                  ;;
-                pending)
-                  pending_details="${pending_details}${pending_details:+; }$workflow_name: $detail"
-                  ;;
-                *)
-                  echo "::error title=Invalid exact-SHA CI state::$workflow_name returned unexpected state: $state ($detail)"
-                  exit 1
-                  ;;
-              esac
-            done <<< "$REQUIRED_CI_WORKFLOWS"
-
-            if [[ "$required_count" -eq 0 ]]; then
-              echo "::error title=Invalid exact-SHA CI configuration::No required workflows were configured."
-              exit 1
-            fi
-            if [[ "$passed_count" -eq "$required_count" ]]; then
-              echo "OK: exact-SHA CI passed for $SELECTED_COMMIT ($passed_details)"
-              break
-            fi
-            now="$(date +%s)"
-            elapsed_seconds=$((now - wait_started_at))
-            remaining_seconds=$((wait_deadline - now))
-            if [[ "$attempt" -eq "$CI_WAIT_ATTEMPTS" || "$remaining_seconds" -le 0 ]]; then
-              echo "::error title=Exact-SHA CI has not passed::Required workflows for $SELECTED_COMMIT are not green after $elapsed_seconds elapsed seconds (shared deadline ${CI_WAIT_MAX_SECONDS} seconds) and $attempt checks ($pending_details)."
-              exit 1
-            fi
-            sleep_seconds="$CI_WAIT_INTERVAL_SECONDS"
-            if [[ "$remaining_seconds" -lt "$sleep_seconds" ]]; then
-              sleep_seconds="$remaining_seconds"
-            fi
-            echo "Waiting for exact-SHA CI ($pending_details; elapsed ${elapsed_seconds}s/${CI_WAIT_MAX_SECONDS}s; check $attempt/$CI_WAIT_ATTEMPTS) ..."
-            sleep "$sleep_seconds"
-          done
-
-      - name: Revalidate current main after exact-SHA CI
-        if: ${{ needs.release-mode.outputs.operation == 'release' }}
-        env:
-          SELECTED_COMMIT: ${{ needs.release-mode.outputs.commit }}
-        run: |
-          set -euo pipefail
-          git fetch --no-tags origin main
-          CURRENT_MAIN="$(git rev-parse origin/main)"
-          if [[ "$CURRENT_MAIN" != "$SELECTED_COMMIT" ]]; then
-            echo "::error title=Release commit superseded::$SELECTED_COMMIT passed CI, but current origin/main is $CURRENT_MAIN. Restart promotion from the current reviewed tip."
-            exit 1
-          fi
-          echo "OK: $SELECTED_COMMIT is still the current origin/main tip after exact-SHA CI"
 
       - uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
         with:
@@ -698,16 +507,243 @@ jobs:
           if-no-files-found: error
           retention-days: 2
 
+  platform-readiness:
+    name: Require certified platform readiness
+    needs: [release-mode, release-preflight, lookup-certification]
+    if: >-
+      ${{
+        always() &&
+        needs.release-mode.result == 'success' &&
+        needs.release-preflight.result == 'success' &&
+        needs.lookup-certification.result == 'success'
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require verified certification before platform wait
+        env:
+          RELEASE_OPERATION: ${{ needs.release-mode.outputs.operation }}
+          REUSE_CERTIFICATION: ${{ needs.lookup-certification.outputs.reuse }}
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_OPERATION" == "certify" ]]; then
+            echo "Certification mode does not wait for exact-SHA platform workflows."
+            exit 0
+          fi
+          if [[ "$REUSE_CERTIFICATION" != "true" ]]; then
+            echo "::error title=Verified certification required before platform wait::Release promotion cannot wait for platform workflows until lookup-certification verifies an exact reusable receipt."
+            exit 1
+          fi
+          echo "OK: exact reusable certification verified before platform readiness wait"
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        if: ${{ needs.release-mode.outputs.operation == 'release' }}
+        with:
+          ref: ${{ needs.release-preflight.outputs.commit }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Require successful CI for the exact release commit
+        if: ${{ needs.release-mode.outputs.operation == 'release' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SELECTED_COMMIT: ${{ needs.release-mode.outputs.commit }}
+          # Main's release lane can legitimately consume 20 + 25 + 30 minutes
+          # across its sequential plan/build/smoke stages, while native Windows
+          # certification runs in parallel. Native Windows' package-to-
+          # acceptance critical path is bounded above two hours, so allow one
+          # shared three-hour window for every required workflow plus queueing.
+          CI_WAIT_ATTEMPTS: "360"
+          CI_WAIT_MAX_SECONDS: "10800"
+          CI_WAIT_INTERVAL_SECONDS: "30"
+          CI_API_TIMEOUT_SECONDS: "30"
+          REQUIRED_CI_WORKFLOWS: |-
+            ci.yml|CI
+            windows-native.yml|Windows Native CI
+            macos-app.yml|macOS App
+        run: |
+          set -euo pipefail
+          if [[ ! "$CI_WAIT_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] || \
+             [[ ! "$CI_WAIT_MAX_SECONDS" =~ ^[0-9]+$ ]] || \
+             [[ ! "$CI_WAIT_INTERVAL_SECONDS" =~ ^[0-9]+$ ]] || \
+             [[ ! "$CI_API_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error title=Invalid exact-SHA CI configuration::Wait attempts, deadline, interval, and API timeout must be bounded integers."
+            exit 1
+          fi
+          wait_started_at="$(date +%s)"
+          wait_deadline=$((wait_started_at + CI_WAIT_MAX_SECONDS))
+          for ((attempt = 1; attempt <= CI_WAIT_ATTEMPTS; attempt++)); do
+            required_count=0
+            passed_count=0
+            passed_details=""
+            pending_details=""
+            while IFS='|' read -r workflow_file workflow_name; do
+              [[ -n "$workflow_file" ]] || continue
+              required_count=$((required_count + 1))
+              if [[ ! "$workflow_file" =~ ^[A-Za-z0-9._-]+$ || -z "$workflow_name" ]]; then
+                echo "::error title=Invalid exact-SHA CI configuration::Invalid required workflow entry: $workflow_file|$workflow_name"
+                exit 1
+              fi
+
+              workflow_key="${workflow_file//./-}"
+              response_path="exact-commit-${workflow_key}-runs.json"
+              response_temp="${response_path}.tmp"
+              response_error="${response_path}.error"
+              now="$(date +%s)"
+              remaining_seconds=$((wait_deadline - now))
+              if [[ "$remaining_seconds" -le 0 ]]; then
+                state="pending"
+                detail="shared deadline reached before workflow query"
+              else
+                request_timeout="$CI_API_TIMEOUT_SECONDS"
+                if [[ "$remaining_seconds" -lt "$request_timeout" ]]; then
+                  request_timeout="$remaining_seconds"
+                fi
+                api_command=(gh)
+                gh_type="$(type -t gh || true)"
+                if [[ "$gh_type" != "function" ]] && command -v timeout >/dev/null 2>&1; then
+                  api_command=(
+                    timeout
+                    --signal=TERM
+                    --kill-after=5s
+                    "${request_timeout}s"
+                    gh
+                  )
+                fi
+                if "${api_command[@]}" api \
+                    -H "Accept: application/vnd.github+json" \
+                    "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow_file/runs?branch=main&event=push&head_sha=$SELECTED_COMMIT&per_page=100" \
+                    > "$response_temp" 2> "$response_error"; then
+                  mv -f "$response_temp" "$response_path"
+                  if parsed_result="$(
+                    python3 - "$response_path" "$SELECTED_COMMIT" 2> "$response_error" <<'PY'
+          import json
+          import sys
+
+          path, expected_sha = sys.argv[1:]
+          with open(path, encoding="utf-8") as stream:
+              payload = json.load(stream)
+          runs = [
+              run
+              for run in payload.get("workflow_runs", [])
+              if run.get("head_sha") == expected_sha
+              and run.get("head_branch") == "main"
+              and run.get("event") == "push"
+          ]
+          if not runs:
+              print("pending\tmissing")
+              raise SystemExit
+          selected = max(
+              runs,
+              key=lambda run: (
+                  int(run.get("run_number") or 0),
+                  int(run.get("run_attempt") or 0),
+                  int(run.get("id") or 0),
+              ),
+          )
+          status = selected.get("status", "unknown")
+          conclusion = selected.get("conclusion") or "pending"
+          detail = f"{status}/{conclusion}"
+          if status != "completed":
+              print(f"pending\t{detail}")
+          elif conclusion == "success":
+              print(f"success\t{selected.get('html_url', 'run URL unavailable')}")
+          else:
+              print(f"failure\t{detail}")
+          PY
+                  )" &&
+                     IFS=$'\t' read -r state detail <<< "$parsed_result"; then
+                    :
+                  else
+                    state="pending"
+                    detail="workflow API returned an invalid response"
+                  fi
+                else
+                  rm -f "$response_temp"
+                  api_error="$(
+                    tr '\r\n' '  ' < "$response_error" \
+                      | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' \
+                      | cut -c1-240
+                  )"
+                  if [[ "$api_error" =~ HTTP\ (401|404|422) ]]; then
+                    state="failure"
+                    detail="workflow API permanently rejected the request: $api_error"
+                  elif [[ -n "$api_error" ]]; then
+                    state="pending"
+                    detail="workflow API unavailable: $api_error"
+                  else
+                    state="pending"
+                    detail="workflow API unavailable or timed out after ${request_timeout}s"
+                  fi
+                fi
+              fi
+
+              case "$state" in
+                success)
+                  passed_count=$((passed_count + 1))
+                  passed_details="${passed_details}${passed_details:+; }$workflow_name: $detail"
+                  ;;
+                failure)
+                  echo "::error title=Exact-SHA CI failed::$workflow_name for $SELECTED_COMMIT failed ($detail)."
+                  exit 1
+                  ;;
+                pending)
+                  pending_details="${pending_details}${pending_details:+; }$workflow_name: $detail"
+                  ;;
+                *)
+                  echo "::error title=Invalid exact-SHA CI state::$workflow_name returned unexpected state: $state ($detail)"
+                  exit 1
+                  ;;
+              esac
+            done <<< "$REQUIRED_CI_WORKFLOWS"
+
+            if [[ "$required_count" -eq 0 ]]; then
+              echo "::error title=Invalid exact-SHA CI configuration::No required workflows were configured."
+              exit 1
+            fi
+            if [[ "$passed_count" -eq "$required_count" ]]; then
+              echo "OK: exact-SHA CI passed for $SELECTED_COMMIT ($passed_details)"
+              break
+            fi
+            now="$(date +%s)"
+            elapsed_seconds=$((now - wait_started_at))
+            remaining_seconds=$((wait_deadline - now))
+            if [[ "$attempt" -eq "$CI_WAIT_ATTEMPTS" || "$remaining_seconds" -le 0 ]]; then
+              echo "::error title=Exact-SHA CI has not passed::Required workflows for $SELECTED_COMMIT are not green after $elapsed_seconds elapsed seconds (shared deadline ${CI_WAIT_MAX_SECONDS} seconds) and $attempt checks ($pending_details)."
+              exit 1
+            fi
+            sleep_seconds="$CI_WAIT_INTERVAL_SECONDS"
+            if [[ "$remaining_seconds" -lt "$sleep_seconds" ]]; then
+              sleep_seconds="$remaining_seconds"
+            fi
+            echo "Waiting for exact-SHA CI ($pending_details; elapsed ${elapsed_seconds}s/${CI_WAIT_MAX_SECONDS}s; check $attempt/$CI_WAIT_ATTEMPTS) ..."
+            sleep "$sleep_seconds"
+          done
+
+      - name: Revalidate current main after exact-SHA CI
+        if: ${{ needs.release-mode.outputs.operation == 'release' }}
+        env:
+          SELECTED_COMMIT: ${{ needs.release-mode.outputs.commit }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          CURRENT_MAIN="$(git rev-parse origin/main)"
+          if [[ "$CURRENT_MAIN" != "$SELECTED_COMMIT" ]]; then
+            echo "::error title=Release commit superseded::$SELECTED_COMMIT passed CI, but current origin/main is $CURRENT_MAIN. Restart promotion from the current reviewed tip."
+            exit 1
+          fi
+          echo "OK: $SELECTED_COMMIT is still the current origin/main tip after exact-SHA CI"
+
   build-runtime-candidate:
     name: Build runtime candidate once
-    needs: [release-mode, release-preflight, lookup-certification]
+    needs: [release-mode, release-preflight, lookup-certification, platform-readiness]
     if: >-
       ${{
         always() &&
         needs.release-mode.outputs.operation == 'certify' &&
         needs.release-preflight.result == 'success' &&
         needs.lookup-certification.result == 'success' &&
-        needs.lookup-certification.outputs.reuse != 'true'
+        needs.lookup-certification.outputs.reuse != 'true' &&
+        needs.platform-readiness.result == 'success'
       }}
     runs-on: ubuntu-latest
     permissions:
@@ -1745,6 +1781,7 @@ jobs:
       - release-mode
       - release-preflight
       - lookup-certification
+      - platform-readiness
       - assemble-release-candidate
       - full-certification
       - record-certification
@@ -1752,6 +1789,7 @@ jobs:
       ${{
         always() &&
         needs.release-preflight.result == 'success' &&
+        needs.platform-readiness.result == 'success' &&
         (
           (
             needs.release-mode.outputs.operation == 'release' &&
@@ -1794,12 +1832,14 @@ jobs:
     needs:
       - release-mode
       - release-preflight
+      - platform-readiness
       - select-candidate
     if: >-
       ${{
         always() &&
         needs.release-mode.outputs.operation == 'release' &&
         needs.release-preflight.result == 'success' &&
+        needs.platform-readiness.result == 'success' &&
         needs.select-candidate.result == 'success'
       }}
     runs-on: ubuntu-latest

--- a/cli/tests/test_release_validation_strategy.py
+++ b/cli/tests/test_release_validation_strategy.py
@@ -191,9 +191,11 @@ def test_release_requires_prior_certification_and_never_tests_during_promotion()
     assert "schedule" in triggers
     assert "workflow_dispatch" in triggers
     operation = triggers["workflow_dispatch"]["inputs"]["operation"]
-    assert set(operation["options"]) == {"certify", "release"}
+    assert operation["default"] == "certify"
+    assert operation["options"] == ["certify", "release"]
     assert operation["description"] == (
-        "Certify main, or publish it only after reusing exact certification."
+        "Certify reviewed main first (default), or release only after exact "
+        "certification exists."
     )
     assert workflow["concurrency"] == {
         "group": "release-promotion-${{ github.repository }}",
@@ -222,9 +224,11 @@ def test_release_requires_prior_certification_and_never_tests_during_promotion()
         "release-mode",
         "release-preflight",
         "lookup-certification",
+        "platform-readiness",
     }
     assert "needs.release-mode.outputs.operation == 'certify'" in build["if"]
     assert "needs.lookup-certification.result == 'success'" in build["if"]
+    assert "needs.platform-readiness.result == 'success'" in build["if"]
     assert "needs.lookup-certification.result != 'success'" not in build["if"]
     full = jobs["full-certification"]
     assert full["uses"] == "./.github/workflows/pre-release-certification.yml"
@@ -237,8 +241,10 @@ def test_release_requires_prior_certification_and_never_tests_during_promotion()
     selection = jobs["select-candidate"]
     condition = selection["if"]
     assert "release-mode" in selection["needs"]
+    assert "platform-readiness" in selection["needs"]
     assert "needs.release-mode.outputs.operation == 'release'" in condition
     assert "needs.release-mode.outputs.operation == 'certify'" in condition
+    assert "needs.platform-readiness.result == 'success'" in condition
     assert "lookup-certification.outputs.reuse == 'true'" in condition
     assert "lookup-certification.outputs.reuse != 'true'" in condition
     assert "lookup-certification.result == 'success'" in condition
@@ -259,8 +265,10 @@ def test_release_requires_prior_certification_and_never_tests_during_promotion()
     assert set(publish["needs"]) == {
         "release-mode",
         "release-preflight",
+        "platform-readiness",
         "select-candidate",
     }
+    assert "needs.platform-readiness.result == 'success'" in publish["if"]
     assert "needs.select-candidate.result == 'success'" in publish["if"]
     assert publish["permissions"] == {"contents": "write"}
     rendered_publish = _render(publish)

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -59,6 +59,10 @@ def _workflow() -> dict[str, object]:
     return yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
 
 
+def _platform_readiness_steps() -> list[dict[str, object]]:
+    return _workflow()["jobs"]["platform-readiness"]["steps"]
+
+
 def _ci_workflow() -> dict[str, object]:
     return yaml.load(CI_WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
 
@@ -173,7 +177,12 @@ def test_release_supports_nightly_certification_and_manual_promotion() -> None:
     triggers = workflow["on"]
     assert triggers["schedule"] == [{"cron": "17 5 * * *"}]
     inputs = triggers["workflow_dispatch"]["inputs"]
-    assert inputs["operation"]["options"] == ["release", "certify"]
+    assert inputs["operation"]["description"] == (
+        "Certify reviewed main first (default), or release only after exact "
+        "certification exists."
+    )
+    assert inputs["operation"]["default"] == "certify"
+    assert inputs["operation"]["options"] == ["certify", "release"]
     assert inputs["version"]["required"] == "false"
     assert inputs["candidate_ref"]["required"] == "false"
     assert inputs["immutable_releases_confirmed"]["default"] == "false"
@@ -259,8 +268,9 @@ def test_release_requires_current_main_without_prescribing_repository_governance
 
 def test_release_requires_successful_main_ci_for_the_exact_candidate_sha() -> None:
     workflow = _workflow()
-    preflight = workflow["jobs"]["release-preflight"]
-    steps = preflight["steps"]
+    preflight_steps = workflow["jobs"]["release-preflight"]["steps"]
+    readiness = workflow["jobs"]["platform-readiness"]
+    steps = readiness["steps"]
     step = next(
         step
         for step in steps
@@ -312,14 +322,107 @@ def test_release_requires_successful_main_ci_for_the_exact_candidate_sha() -> No
     assert 'CURRENT_MAIN="$(git rev-parse origin/main)"' in revalidation_command
     assert '"$CURRENT_MAIN" != "$SELECTED_COMMIT"' in revalidation_command
     assert "Release commit superseded" in revalidation_command
+    assert not any(
+        candidate.get("name")
+        in {
+            "Require successful CI for the exact release commit",
+            "Revalidate current main after exact-SHA CI",
+        }
+        for candidate in preflight_steps
+    )
     ci_index = steps.index(step)
     revalidation_index = steps.index(revalidation)
-    cosign_index = next(
+    checkout_index = next(
         index
         for index, candidate in enumerate(steps)
-        if candidate.get("uses", "").startswith("sigstore/cosign-installer@")
+        if candidate.get("uses", "").startswith("actions/checkout@")
     )
-    assert ci_index < revalidation_index < cosign_index
+    assert checkout_index < ci_index < revalidation_index
+
+
+def test_release_verifies_receipt_before_long_platform_wait_and_guards_downstream_dag() -> None:
+    jobs = _workflow()["jobs"]
+    lookup = jobs["lookup-certification"]
+    readiness = jobs["platform-readiness"]
+
+    assert set(lookup["needs"]) == {"release-mode", "release-preflight"}
+    assert set(readiness["needs"]) == {
+        "release-mode",
+        "release-preflight",
+        "lookup-certification",
+    }
+    assert "always()" in readiness["if"]
+    for predecessor in ("release-mode", "release-preflight", "lookup-certification"):
+        assert f"needs.{predecessor}.result == 'success'" in readiness["if"]
+
+    guard = readiness["steps"][0]
+    assert guard["name"] == "Require verified certification before platform wait"
+    assert guard["env"] == {
+        "RELEASE_OPERATION": "${{ needs.release-mode.outputs.operation }}",
+        "REUSE_CERTIFICATION": "${{ needs.lookup-certification.outputs.reuse }}",
+    }
+    assert 'if [[ "$RELEASE_OPERATION" == "certify" ]]' in guard["run"]
+    assert "does not wait for exact-SHA platform workflows" in guard["run"]
+    assert 'if [[ "$REUSE_CERTIFICATION" != "true" ]]' in guard["run"]
+    assert "Verified certification required before platform wait" in guard["run"]
+
+    checkout = readiness["steps"][1]
+    assert checkout["uses"].startswith("actions/checkout@")
+    assert checkout["if"] == "${{ needs.release-mode.outputs.operation == 'release' }}"
+    for gated_job in ("build-runtime-candidate", "select-candidate", "publish-release"):
+        job = jobs[gated_job]
+        assert "platform-readiness" in job["needs"]
+        assert "needs.platform-readiness.result == 'success'" in job["if"]
+
+
+@pytest.mark.parametrize(
+    ("operation", "reuse", "expected_returncode", "expected_fragment"),
+    [
+        (
+            "certify",
+            "false",
+            0,
+            "Certification mode does not wait for exact-SHA platform workflows.",
+        ),
+        (
+            "release",
+            "true",
+            0,
+            "OK: exact reusable certification verified before platform readiness wait",
+        ),
+        (
+            "release",
+            "false",
+            1,
+            "Verified certification required before platform wait",
+        ),
+    ],
+)
+def test_platform_readiness_requires_a_verified_receipt_before_waiting(
+    operation: str,
+    reuse: str,
+    expected_returncode: int,
+    expected_fragment: str,
+) -> None:
+    guard = _platform_readiness_steps()[0]
+    env = os.environ.copy()
+    env.update(
+        {
+            "RELEASE_OPERATION": operation,
+            "REUSE_CERTIFICATION": reuse,
+        }
+    )
+    completed = subprocess.run(
+        [_bash_executable(), "-c", guard["run"]],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert completed.returncode == expected_returncode, completed.stdout + completed.stderr
+    assert expected_fragment in completed.stdout
 
 
 @pytest.mark.parametrize(
@@ -338,7 +441,7 @@ def test_post_ci_main_revalidation_rejects_a_superseded_commit(
     selected_commit = "e" * 40
     step = next(
         step
-        for step in _workflow()["jobs"]["release-preflight"]["steps"]
+        for step in _platform_readiness_steps()
         if step.get("name") == "Revalidate current main after exact-SHA CI"
     )
     env = os.environ.copy()
@@ -380,7 +483,7 @@ def test_exact_sha_ci_gate_retries_a_transient_api_failure(tmp_path: Path) -> No
     commit = "d" * 40
     step = next(
         step
-        for step in _workflow()["jobs"]["release-preflight"]["steps"]
+        for step in _platform_readiness_steps()
         if step.get("name") == "Require successful CI for the exact release commit"
     )
     payload = {
@@ -444,7 +547,7 @@ def test_exact_sha_ci_gate_retries_an_invalid_successful_api_response(
     commit = "6" * 40
     step = next(
         step
-        for step in _workflow()["jobs"]["release-preflight"]["steps"]
+        for step in _platform_readiness_steps()
         if step.get("name") == "Require successful CI for the exact release commit"
     )
     payload = {
@@ -510,7 +613,7 @@ def test_exact_sha_ci_gate_fails_closed_after_invalid_responses_are_exhausted(
 ) -> None:
     step = next(
         step
-        for step in _workflow()["jobs"]["release-preflight"]["steps"]
+        for step in _platform_readiness_steps()
         if step.get("name") == "Require successful CI for the exact release commit"
     )
     env = os.environ.copy()
@@ -563,7 +666,7 @@ def test_exact_sha_ci_gate_rejects_every_state_except_success(
     commit = "a" * 40
     step = next(
         step
-        for step in _workflow()["jobs"]["release-preflight"]["steps"]
+        for step in _platform_readiness_steps()
         if step.get("name") == "Require successful CI for the exact release commit"
     )
     payload = {
@@ -614,7 +717,7 @@ def test_exact_sha_ci_gate_rejects_missing_or_unrelated_runs(tmp_path: Path) -> 
     commit = "b" * 40
     step = next(
         step
-        for step in _workflow()["jobs"]["release-preflight"]["steps"]
+        for step in _platform_readiness_steps()
         if step.get("name") == "Require successful CI for the exact release commit"
     )
     payload = {
@@ -676,7 +779,7 @@ def test_exact_sha_ci_gate_rejects_a_terminal_windows_failure_after_ci_passes(
     commit = "9" * 40
     step = next(
         step
-        for step in _workflow()["jobs"]["release-preflight"]["steps"]
+        for step in _platform_readiness_steps()
         if step.get("name") == "Require successful CI for the exact release commit"
     )
     successful_ci = {
@@ -762,7 +865,7 @@ def test_exact_sha_ci_gate_selects_the_latest_successful_rerun(
     commit = "8" * 40
     step = next(
         step
-        for step in _workflow()["jobs"]["release-preflight"]["steps"]
+        for step in _platform_readiness_steps()
         if step.get("name") == "Require successful CI for the exact release commit"
     )
     payload = {
@@ -840,7 +943,7 @@ def test_exact_sha_ci_gate_never_reuses_an_older_success_over_a_newer_attempt(
     commit = "4" * 40
     step = next(
         step
-        for step in _workflow()["jobs"]["release-preflight"]["steps"]
+        for step in _platform_readiness_steps()
         if step.get("name") == "Require successful CI for the exact release commit"
     )
     payload = {
@@ -907,7 +1010,7 @@ def test_exact_sha_ci_gate_fails_closed_when_the_api_outage_exhausts_deadline(
     commit = "7" * 40
     step = next(
         step
-        for step in _workflow()["jobs"]["release-preflight"]["steps"]
+        for step in _platform_readiness_steps()
         if step.get("name") == "Require successful CI for the exact release commit"
     )
     env = os.environ.copy()
@@ -948,7 +1051,7 @@ def test_exact_sha_ci_gate_treats_permanent_workflow_api_errors_as_terminal(
 ) -> None:
     step = next(
         step
-        for step in _workflow()["jobs"]["release-preflight"]["steps"]
+        for step in _platform_readiness_steps()
         if step.get("name") == "Require successful CI for the exact release commit"
     )
     env = os.environ.copy()
@@ -995,7 +1098,7 @@ def test_exact_sha_ci_gate_enforces_the_absolute_deadline_before_api_calls(
 ) -> None:
     step = next(
         step
-        for step in _workflow()["jobs"]["release-preflight"]["steps"]
+        for step in _platform_readiness_steps()
         if step.get("name") == "Require successful CI for the exact release commit"
     )
     env = os.environ.copy()
@@ -1105,9 +1208,11 @@ def test_publish_job_promotes_only_a_selected_certified_candidate() -> None:
     assert set(publish["needs"]) == {
         "release-mode",
         "release-preflight",
+        "platform-readiness",
         "select-candidate",
     }
     assert "needs.release-mode.outputs.operation == 'release'" in publish["if"]
+    assert "needs.platform-readiness.result == 'success'" in publish["if"]
     assert "needs.select-candidate.result == 'success'" in publish["if"]
     assert publish["environment"] == "release"
     assert publish["permissions"] == {"contents": "write"}

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -337,14 +337,15 @@ installation before dependency or artifact changes.
 ### Cut a GitHub Release
 
 The manually dispatched `Release` GitHub Actions workflow is the only supported
-way to cut a release. Its explicit `certify` operation validates the requested
+way to cut a release. Its default `certify` operation validates the requested
 version, builds and signs all artifacts, runs the native upgrade gates, and
 records the exact golden candidate without publishing. After that run succeeds,
-the `release` operation verifies exact-SHA platform CI and the matching
-certification receipt, then creates the remote tag and GitHub release from
-those same bytes. A missing or rejected receipt stops before candidate
-construction or platform packaging. This ordering keeps Release from becoming
-a test bed and keeps Immutable Releases from stranding half-built assets.
+the `release` operation verifies the matching certification receipt before it
+begins the potentially long exact-SHA platform CI wait, then creates the remote
+tag and GitHub release from those same bytes. A missing or rejected receipt
+stops before candidate construction or platform packaging, and before the
+potentially long platform wait. This ordering keeps Release from becoming a
+test bed and keeps Immutable Releases from stranding half-built assets.
 
 The workflow input is the published-version authority. It stamps the requested
 version into its isolated build checkout before producing the CLI, gateway,

--- a/docs/RELEASE_VALIDATION.md
+++ b/docs/RELEASE_VALIDATION.md
@@ -11,16 +11,17 @@ observability, Docker, or provenance defects for the first time.
 | Pull request | Every PR, with a path-filtered selective upgrade job for release-sensitive changes | Fast deterministic release regressions; risky PRs add current stable, previous stable, the `0.8.4` bridge boundary, an explicit direct-skip refusal, and the oldest-supported smoke/refusal | Unsigned PR candidate; direct target activation plus production pre-mutation refusal, never release certification |
 | Main smoke | Every merge to `main` | Medium candidate smoke for the exact merged SHA and at least one representative published target-activation canary | Exact merged SHA; no publication or provenance claim |
 | Pre-release certification | Nightly schedule or manual dispatch for a selected ref and candidate version | Signed candidate; behavior-class historical matrix; live migration and rollback/recovery; Docker/local observability continuity; native platform checks; bounded-retry provenance verification | One signed candidate artifact plus one certification receipt |
-| Release | Manual version input on protected `main` | Require successful main CI, native Windows CI, and macOS app CI for the exact SHA; verify a recent receipt for that SHA, workflow version, candidate version, platform set, behavior-class baselines, artifact ID/digest, and run identity; then publish those same bytes | Reuse certified bytes without rebuilding |
+| Release | Manual version input on protected `main` | First verify a recent receipt for the exact SHA, workflow version, candidate version, platform set, behavior-class baselines, artifact ID/digest, and run identity; only then wait for successful main CI, native Windows CI, and macOS app CI for that SHA and publish those same bytes | Reuse certified bytes without rebuilding |
 
-A release dispatched immediately after a merge may wait up to three hours for
-that exact SHA's main CI, native Windows CI, and macOS app CI. All three
-workflows execute independently and are checked under one absolute deadline
-with bounded API requests. The window covers the native Windows package and
-acceptance critical path plus normal runner setup and queueing. After all three
-workflows succeed, Release refetches `main` and aborts if another commit has
-superseded the selected SHA; the operator must then promote the new reviewed
-tip instead.
+The manual workflow defaults to `operation=certify`. For
+`operation=release`, exact receipt lookup and verification finish before the
+workflow begins its potentially three-hour wait for that SHA's main CI, native
+Windows CI, and macOS app CI. All three workflows execute independently and
+are checked under one absolute deadline with bounded API requests. The window
+covers the native Windows package and acceptance critical path plus normal
+runner setup and queueing. After all three workflows succeed, Release refetches
+`main` and aborts if another commit has superseded the selected SHA; the
+operator must then promote the new reviewed tip instead.
 
 The standalone macOS app workflow builds the complete ad-hoc DMG on affected
 pull requests, every exact `main` SHA, and manual requests. Its stable


### PR DESCRIPTION
Follow-up to #593, based on merged `main` at `ec8f194da640e9763b54e22fbac72c1f4688aecf`.

## Problem

The first post-#593 `operation=release` dispatch correctly refused to publish because no exact pre-release certification receipt existed, but it waited about 37 minutes for exact-SHA CI, Windows, and macOS readiness before reporting that actionable error. The manual dispatch also defaulted to `release`, making the wrong first operation too easy to select.

Observed run: [Release run 30043081051](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/30043081051), failed in `Find exact recent pre-release certification` with no tag or GitHub release created.

## Current Situation

#593 fixed the original macOS Bash 3.2 release failure and made promotion fail closed. Release now requires exact certified bytes and exact-SHA platform checks, but the sequencing was inefficient for a missing, stale, or invalid receipt:

1. perform the potentially long exact-SHA platform wait;
2. then locate and verify the certification receipt;
3. fail without publishing if that receipt is unavailable.

That was secure, but operationally slow and confusing.

## Solution

### Verify certification before waiting

`lookup-certification` now completes before a new `platform-readiness` barrier. Missing, stale, invalid, expired, or unavailable certification evidence fails before the long platform poll begins.

### Make certification the safe default

Manual workflow dispatch now defaults to `operation=certify`, with `certify` listed before `release`. Explicit API/CLI callers that set an operation are unchanged.

### Preserve every promotion gate

A valid release receipt does not bypass platform readiness. Promotion still requires successful exact-SHA `CI`, `Windows Native CI`, and `macOS App`, followed by a fresh `origin/main` tip check. Build, candidate selection, and publication all require the readiness barrier to succeed.

```mermaid
flowchart TD
  D["Manual dispatch"] --> P["Version, provenance, and baseline preflight"]
  P --> L["Locate and cryptographically verify exact certification"]
  L -->|"missing / stale / invalid"| F["Fail fast; publish nothing"]
  L -->|"certify"| N["Readiness no-op"]
  N --> C["Build and certify one golden candidate"]
  L -->|"release + verified receipt"| R["Wait for exact-SHA CI + Windows + macOS"]
  R --> M["Revalidate current main tip"]
  M --> S["Select certified bytes"]
  S --> G["Create immutable tag and GitHub release"]
```

## What Changed (Where & How)

| Path | Change |
|---|---|
| `.github/workflows/release.yaml` | Default dispatch to `certify`; move the unchanged exact-SHA wait and post-wait main revalidation behind verified receipt lookup; add the readiness barrier to build, selection, and publication. |
| `cli/tests/test_release_workflow_staged.py` | Assert receipt-first DAG ordering, safe default, downstream barriers, preserved exact-SHA gates, and execute three certify/release guard cases. |
| `cli/tests/test_release_validation_strategy.py` | Lock the default and readiness dependencies into the release strategy contract. |
| `docs/INSTALL.md` | Document the certify-first operator flow and early receipt failure. |
| `docs/RELEASE_VALIDATION.md` | Document receipt-first promotion and the bounded exact-platform wait. |

## Breaking Changes

The GitHub Actions manual-dispatch default changes from `release` to `certify`. Operators who omit the operation will now certify without publishing. Explicit `operation=certify` and `operation=release` callers are unchanged. There are no artifact, API, configuration, or installer format changes.

## Open Issues / Follow-ups

- Repository-side enforcement of the release environment/ruleset remains tracked in #592.

## Test Plan

### macOS connected host

```bash
DEFENSECLAW_TEST_BASH=/bin/bash uv run --frozen python -m pytest -q \
  cli/tests/test_resolve_upgrade_baselines.py \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_release_validation_strategy.py \
  cli/tests/test_windows_release_certification.py \
  cli/tests/test_install_docs_static.py
actionlint -ignore 'SC2129' .github/workflows/release.yaml
uv run --frozen ruff check \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_release_validation_strategy.py
git diff --check
```

Observed: `170 passed`; actionlint, Ruff, YAML parse, and whitespace checks passed. A broader local release regression run observed `305 passed, 1 skipped`.

### Connected Ubuntu host — exact patch replay

```bash
uv run --frozen python -m pytest -q \
  cli/tests/test_verify_sigstore_blob.py \
  cli/tests/test_observability_v8_upgrade_continuity_checker.py \
  cli/tests/test_resolve_upgrade_baselines.py \
  cli/tests/test_release_api_retry.py \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_upgrade_smoke_static.py \
  cli/tests/test_upgrade_release_smoke_contract.py \
  cli/tests/test_release_certification.py \
  cli/tests/test_release_validation_strategy.py
.venv/bin/python -m pytest -q cli/tests/test_install_docs_static.py
.venv/bin/ruff check \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_release_validation_strategy.py
actionlint -ignore SC2129 .github/workflows/release.yaml
```

Observed: `309 passed` in the canonical release suite; docs `52 passed, 1 skipped` (expected macOS-only codesign test); Ruff/actionlint passed. Exact five-file patch SHA-256: `218723aa197387f45f4bc9fb16c272b9a14c98481344ee940be5a015a4305014`. Forward/reverse apply, whitespace, and the 2,889-file snapshot manifest all passed.