### PR TITLE
fix(release): validate Windows bootstrap before release

### DIFF
--- a/.github/workflows/pre-release-certification.yml
+++ b/.github/workflows/pre-release-certification.yml
@@ -145,7 +145,7 @@ jobs:
   windows-fresh-install:
     name: Fresh install exact candidate (windows-amd64)
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     defaults:
       run:
         shell: pwsh
@@ -181,5 +181,4 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           ./scripts/test-fresh-install-release-windows.ps1 `
             -ReleaseDir "$env:GITHUB_WORKSPACE/release-candidate/dist" `
-            -TargetVersion "$env:RELEASE_TAG" `
-            -SuccessPathOnly
+            -TargetVersion "$env:RELEASE_TAG"

--- a/.github/workflows/pre-release-certification.yml
+++ b/.github/workflows/pre-release-certification.yml
@@ -181,4 +181,13 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           ./scripts/test-fresh-install-release-windows.ps1 `
             -ReleaseDir "$env:GITHUB_WORKSPACE/release-candidate/dist" `
-            -TargetVersion "$env:RELEASE_TAG"
+            -TargetVersion "$env:RELEASE_TAG" `
+            -DiagnosticsRoot (Join-Path $env:RUNNER_TEMP 'defenseclaw-release-bootstrap-diagnostics')
+      - name: Upload Windows bootstrap diagnostics on failure
+        if: ${{ failure() || cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-windows-bootstrap-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/defenseclaw-release-bootstrap-diagnostics/**
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -616,6 +616,15 @@ jobs:
           -DiagnosticsRoot (Join-Path $env:RUNNER_TEMP 'defenseclaw-release-setup-diagnostics')
           -TimeoutSeconds 2400
 
+      - name: Upload native Setup diagnostics on failure
+        if: ${{ failure() || cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-windows-setup-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/defenseclaw-release-setup-diagnostics/**
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Upload exact Windows Setup metadata
         id: windows-installer-artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -384,6 +384,10 @@ jobs:
           } else {
             'source=candidate' >> $env:GITHUB_OUTPUT
           }
+          # GitHub's pwsh wrapper exits with the last native exit code. A
+          # missing release is the expected pre-publication branch, not an
+          # error after its candidate fallback has been selected.
+          $global:LASTEXITCODE = 0
       - name: Download authenticated public bootstrap fixture
         if: ${{ steps.fixture.outputs.source == 'release' }}
         env:

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -340,6 +340,117 @@ jobs:
         if: ${{ always() }}
         run: ./scripts/windows-native-ci.ps1 -Operation cleanup -StateRoot $env:DC_STATE_ROOT
 
+  public-bootstrap-acceptance:
+    name: Windows public install.ps1 acceptance
+    runs-on: windows-latest
+    timeout-minutes: 50
+    permissions:
+      actions: read
+      contents: read
+    env:
+      BOOTSTRAP_FIXTURE_VERSION: 0.8.7
+      # Before 0.8.7 exists, replay the sealed candidate that exposed the
+      # fake-profile harness defect. Once published, the job automatically uses
+      # permanent release assets and this fallback remains fail-closed evidence.
+      BOOTSTRAP_FIXTURE_RUN_ID: "30063491006"
+      BOOTSTRAP_FIXTURE_ARTIFACT: release-candidate-30063491006-1
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - name: Initialize isolated paths
+        run: ./scripts/initialize-windows-native-ci-paths.ps1 -Leaf bootstrap -DiagnosticsLeaf windows-native-diagnostics-bootstrap -ArtifactLeaf windows-bootstrap-fixture
+      - uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+        with:
+          cosign-release: "v2.6.2"
+      - name: Select permanent release or sealed candidate fixture
+        id: fixture
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $previousErrorActionPreference = $ErrorActionPreference
+          try {
+            $ErrorActionPreference = 'Continue'
+            $draft = gh release view $env:BOOTSTRAP_FIXTURE_VERSION `
+              --repo $env:GITHUB_REPOSITORY `
+              --json isDraft `
+              --jq '.isDraft' 2> $null
+            $published = $LASTEXITCODE -eq 0 -and $draft.Trim() -ceq 'false'
+          } finally {
+            $ErrorActionPreference = $previousErrorActionPreference
+          }
+          if ($published) {
+            'source=release' >> $env:GITHUB_OUTPUT
+          } else {
+            'source=candidate' >> $env:GITHUB_OUTPUT
+          }
+      - name: Download authenticated public bootstrap fixture
+        if: ${{ steps.fixture.outputs.source == 'release' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $fixture = Join-Path $env:DC_ARTIFACT_ROOT 'release'
+          [IO.Directory]::CreateDirectory($fixture) | Out-Null
+          foreach ($asset in @(
+            'DefenseClawSetup-x64.exe',
+            'DefenseClawSetup-x64.exe.provenance.json',
+            'upgrade-manifest.json',
+            'checksums.txt',
+            'checksums.txt.sig',
+            'checksums.txt.pem',
+            'checksums.txt.bundle'
+          )) {
+            gh release download $env:BOOTSTRAP_FIXTURE_VERSION `
+              --repo $env:GITHUB_REPOSITORY `
+              --pattern $asset `
+              --dir $fixture
+            if ($LASTEXITCODE -ne 0) {
+              throw "Could not download authenticated bootstrap fixture asset: $asset"
+            }
+          }
+          "DC_BOOTSTRAP_RELEASE_DIR=$fixture" >> $env:GITHUB_ENV
+      - name: Download sealed pre-publication bootstrap fixture
+        if: ${{ steps.fixture.outputs.source == 'candidate' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ env.BOOTSTRAP_FIXTURE_ARTIFACT }}
+          path: ${{ env.DC_ARTIFACT_ROOT }}\candidate
+          repository: cisco-ai-defense/defenseclaw
+          run-id: ${{ env.BOOTSTRAP_FIXTURE_RUN_ID }}
+          github-token: ${{ github.token }}
+      - name: Select sealed candidate distribution
+        if: ${{ steps.fixture.outputs.source == 'candidate' }}
+        run: |
+          $fixture = Join-Path $env:DC_ARTIFACT_ROOT 'candidate\dist'
+          if (-not (Test-Path -LiteralPath $fixture -PathType Container)) {
+            throw "Sealed bootstrap candidate distribution is missing: $fixture"
+          }
+          "DC_BOOTSTRAP_RELEASE_DIR=$fixture" >> $env:GITHUB_ENV
+      - name: Exercise current public bootstrap under a real disposable user
+        run: |
+          $bootstrapState = Join-Path $env:DC_STATE_ROOT (
+            'defenseclaw-bootstrap-acceptance-' + [guid]::NewGuid().ToString('N')
+          )
+          ./scripts/test-fresh-install-release-windows.ps1 `
+            -ReleaseDir $env:DC_BOOTSTRAP_RELEASE_DIR `
+            -TargetVersion $env:BOOTSTRAP_FIXTURE_VERSION `
+            -StateRoot $bootstrapState `
+            -DiagnosticsRoot $env:DC_DIAGNOSTICS
+      - name: Capture bounded diagnostics
+        if: ${{ failure() || cancelled() }}
+        run: ./scripts/windows-native-ci.ps1 -Operation capture -StateRoot $env:DC_STATE_ROOT -DiagnosticsRoot $env:DC_DIAGNOSTICS
+      - name: Upload diagnostics on failure
+        if: ${{ failure() || cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: windows-native-bootstrap-diagnostics
+          path: ${{ env.DC_DIAGNOSTICS }}\**
+          if-no-files-found: ignore
+          retention-days: 5
+      - name: Always clean isolated processes, listeners, and temp state
+        if: ${{ always() }}
+        run: ./scripts/windows-native-ci.ps1 -Operation cleanup -StateRoot $env:DC_STATE_ROOT
+
   connector-contract:
     name: Windows x64 connector contract / ${{ matrix.connector }}
     needs: [powershell-static, package-artifact]
@@ -407,6 +518,7 @@ jobs:
       - powershell-static
       - package-artifact
       - packaged-acceptance
+      - public-bootstrap-acceptance
       - connector-contract
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -371,13 +371,23 @@ jobs:
           $previousErrorActionPreference = $ErrorActionPreference
           try {
             $ErrorActionPreference = 'Continue'
-            $draft = gh release view $env:BOOTSTRAP_FIXTURE_VERSION `
-              --repo $env:GITHUB_REPOSITORY `
-              --json isDraft `
-              --jq '.isDraft' 2> $null
-            $published = $LASTEXITCODE -eq 0 -and $draft.Trim() -ceq 'false'
+            $lookup = (
+              gh release view $env:BOOTSTRAP_FIXTURE_VERSION `
+                --repo $env:GITHUB_REPOSITORY `
+                --json isDraft `
+                --jq '.isDraft' 2>&1 |
+                Out-String -Width 32768
+            ).Trim()
+            $lookupExit = $LASTEXITCODE
           } finally {
             $ErrorActionPreference = $previousErrorActionPreference
+          }
+          if ($lookupExit -eq 0) {
+            $published = $lookup -ceq 'false'
+          } elseif ($lookup -ceq 'release not found') {
+            $published = $false
+          } else {
+            throw "Could not resolve bootstrap fixture release: $lookup"
           }
           if ($published) {
             'source=release' >> $env:GITHUB_OUTPUT

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -66,6 +66,10 @@ def _certification_workflow() -> dict[str, object]:
     return yaml.load(CERTIFICATION_WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
 
 
+def _windows_ci_workflow() -> dict[str, object]:
+    return yaml.load(WINDOWS_CI_WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
 def test_sensitive_plan_installs_cosign_before_historical_authentication() -> None:
     workflow = _ci_workflow()
     steps = workflow["jobs"]["release-validation-plan"]["steps"]
@@ -518,7 +522,7 @@ def test_exact_posix_fresh_install_and_twelve_upgrade_cells_gate_publication() -
     }
     assert jobs["posix-fresh-install"]["timeout-minutes"] == "30"
     assert jobs["posix-upgrade"]["timeout-minutes"] == "60"
-    assert jobs["windows-fresh-install"]["timeout-minutes"] == "30"
+    assert jobs["windows-fresh-install"]["timeout-minutes"] == "45"
 
     assert jobs["posix-fresh-install"]["strategy"] == {
         "fail-fast": "false",
@@ -715,24 +719,89 @@ def test_windows_release_accepts_signed_or_explicitly_unverified_setup_and_is_fr
     windows_smoke = _certification_workflow()["jobs"]["windows-fresh-install"]
     assert windows_smoke["runs-on"] == "windows-latest"
     assert "scripts/test-fresh-install-release-windows.ps1" in str(windows_smoke)
-    assert "-SuccessPathOnly" in str(windows_smoke)
+    assert "-TargetVersion" in str(windows_smoke)
+    assert "-SuccessPathOnly" not in str(windows_smoke)
 
 
-def test_windows_install_ps1_smoke_exercises_public_fresh_path() -> None:
+def test_windows_install_ps1_smoke_uses_disposable_native_profile_and_layout() -> None:
     smoke = (ROOT / "scripts/test-fresh-install-release-windows.ps1").read_text(encoding="utf-8")
+    disposable = (ROOT / "scripts/invoke-windows-setup-standard-user-ci.ps1").read_text(encoding="utf-8")
 
-    assert '$Installer = Join-Path $Root "scripts\\install.ps1"' in smoke
-    assert '"-Local", $ReleaseDir' in smoke
-    assert '"-Version", $RequestedVersion' in smoke
-    assert "[switch]$SuccessPathOnly" in smoke
-    assert "$first = if ($SuccessPathOnly)" in smoke
-    assert "Invoke-FreshInstaller\n    } else {" in smoke
-    assert "DefenseClaw installed successfully" in smoke
-    assert "Assert-ExactVersion -Command $cli" in smoke
-    assert "Assert-ExactVersion -Command $gateway" in smoke
-    assert "$second = Invoke-FreshInstaller" in smoke
-    assert "Second fresh-installer invocation unexpectedly succeeded" in smoke
-    assert "existing DefenseClaw installation" in smoke
+    assert "invoke-windows-setup-standard-user-ci.ps1" in smoke
+    assert "-Mode bootstrap-acceptance" in smoke
+    assert "-ArtifactRoot $ReleaseDir" in smoke
+    assert "-TargetVersion $TargetVersion" in smoke
+    assert "'bootstrap-acceptance'" in disposable
+    assert "test-fresh-install-release-windows.ps1" in disposable
+    assert "install.ps1" in disposable
+    for asset in (
+        "DefenseClawSetup-x64.exe",
+        "DefenseClawSetup-x64.exe.provenance.json",
+        "upgrade-manifest.json",
+        "checksums.txt",
+        "checksums.txt.sig",
+        "checksums.txt.pem",
+        "checksums.txt.bundle",
+        "cosign-windows-amd64.exe",
+    ):
+        assert asset in disposable
+
+    assert "GetFolderPath([Environment+SpecialFolder]::UserProfile)" in smoke
+    assert "[Environment+SpecialFolder]::LocalApplicationData" in smoke
+    assert "Programs\\DefenseClaw" in smoke
+    assert "DefenseClaw\\InstallerCache" in smoke
+    assert "Uninstall\\DefenseClaw" in smoke
+    assert re.search(r"""['"]-Local['"]""", smoke)
+    assert re.search(r"""['"]-Version['"]""", smoke)
+    assert re.search(r"""['"]-CosignPath['"]""", smoke)
+    assert "Native DefenseClaw Setup completed successfully" in smoke
+    assert "Assert-ExactVersion -Executable $launcher" in smoke
+    assert "Assert-ExactVersion -Executable $gateway" in smoke
+    assert "$first = Invoke-CapturedProcess" in smoke
+    assert "$second = Invoke-CapturedProcess" in smoke
+    assert "DELETEUSERDATA=1" in smoke
+    assert 'GetEnvironmentVariable("Path", "User")' in smoke
+    assert "uninstall did not restore the original user PATH exactly" in smoke
+
+    # Environment strings do not change Windows Known Folder resolution. The
+    # release regression must never recreate the legacy fake-home test bed that
+    # let direct Setup pass while the public bootstrap failed.
+    assert "$env:USERPROFILE = $HomeRoot" not in smoke
+    assert "$env:DEFENSECLAW_HOME = Join-Path $HomeRoot" not in smoke
+    assert '".defenseclaw/.venv/Scripts/defenseclaw.exe"' not in smoke
+    assert '".local\\bin\\defenseclaw-gateway.exe"' not in smoke
+    assert "Second fresh-installer invocation unexpectedly succeeded" not in smoke
+
+
+def test_windows_pr_ci_executes_public_bootstrap_against_authenticated_fixture() -> None:
+    jobs = _windows_ci_workflow()["jobs"]
+    bootstrap = jobs["public-bootstrap-acceptance"]
+    rendered = str(bootstrap)
+
+    assert bootstrap["runs-on"] == "windows-latest"
+    assert int(bootstrap["timeout-minutes"]) >= 50
+    assert bootstrap["permissions"] == {
+        "actions": "read",
+        "contents": "read",
+    }
+    assert bootstrap["env"]["BOOTSTRAP_FIXTURE_VERSION"] == "0.8.7"
+    assert bootstrap["env"]["BOOTSTRAP_FIXTURE_RUN_ID"] == "30063491006"
+    assert bootstrap["env"]["BOOTSTRAP_FIXTURE_ARTIFACT"] == ("release-candidate-30063491006-1")
+    assert "sigstore/cosign-installer@" in rendered
+    assert "gh release view" in rendered
+    assert "gh release download" in rendered
+    assert "actions/download-artifact@" in rendered
+    assert "checksums.txt.bundle" in rendered
+    assert "test-fresh-install-release-windows.ps1" in rendered
+    assert "-ReleaseDir $env:DC_BOOTSTRAP_RELEASE_DIR" in rendered
+    assert "-TargetVersion $env:BOOTSTRAP_FIXTURE_VERSION" in rendered
+    assert "-StateRoot $bootstrapState" in rendered
+    assert "-DiagnosticsRoot $env:DC_DIAGNOSTICS" in rendered
+    smoke = (ROOT / "scripts/test-fresh-install-release-windows.ps1").read_text(encoding="utf-8")
+    assert "-TimeoutSeconds 1800" in smoke
+
+    required = jobs["windows-native-required"]
+    assert "public-bootstrap-acceptance" in required["needs"]
 
 
 def test_posix_installer_cannot_bypass_upgrade_graph_on_existing_install() -> None:

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -681,6 +681,8 @@ def test_windows_release_accepts_signed_or_explicitly_unverified_setup_and_is_fr
     assert "invoke-windows-setup-standard-user-ci.ps1" in rendered
     assert "-Mode setup-acceptance" in rendered
     assert "-AllowCurrentUserSetupAcceptance" not in rendered
+    assert "Upload native Setup diagnostics on failure" in rendered
+    assert "defenseclaw-release-setup-diagnostics/**" in rendered
     windows_contract = (ROOT / "scripts/live-connector-e2e/test-windows.ps1").read_text(encoding="utf-8")
     assert "production release does not depend on provider-backed Windows live radar" in (windows_contract)
     assert "needs\\.windows-installer\\.outputs\\.artifact_id" in windows_contract

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -789,6 +789,7 @@ def test_windows_pr_ci_executes_public_bootstrap_against_authenticated_fixture()
     assert bootstrap["env"]["BOOTSTRAP_FIXTURE_ARTIFACT"] == ("release-candidate-30063491006-1")
     assert "sigstore/cosign-installer@" in rendered
     assert "gh release view" in rendered
+    assert "$global:LASTEXITCODE = 0" in rendered
     assert "gh release download" in rendered
     assert "actions/download-artifact@" in rendered
     assert "checksums.txt.bundle" in rendered

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -789,6 +789,8 @@ def test_windows_pr_ci_executes_public_bootstrap_against_authenticated_fixture()
     assert bootstrap["env"]["BOOTSTRAP_FIXTURE_ARTIFACT"] == ("release-candidate-30063491006-1")
     assert "sigstore/cosign-installer@" in rendered
     assert "gh release view" in rendered
+    assert "release not found" in rendered
+    assert "Could not resolve bootstrap fixture release" in rendered
     assert "$global:LASTEXITCODE = 0" in rendered
     assert "gh release download" in rendered
     assert "actions/download-artifact@" in rendered

--- a/cli/tests/test_windows_powershell_upgrade_paths.py
+++ b/cli/tests/test_windows_powershell_upgrade_paths.py
@@ -283,9 +283,7 @@ def test_windows_checksum_parser_rejects_modern_or_unknown_nested_rows(
 def test_windows_native_bootstrap_delegates_authenticated_install_lifecycle() -> None:
     source = INSTALLER.read_text(encoding="utf-8")
     main = _main_body(source)
-    handoff = source[
-        source.index("function Invoke-NativeSetup") : source.index("function Main")
-    ]
+    handoff = source[source.index("function Invoke-NativeSetup") : source.index("function Main")]
 
     assert not LEGACY_INLINE_INSTALLER
     assert "function Ensure-Python {" not in source
@@ -297,9 +295,7 @@ def test_windows_native_bootstrap_delegates_authenticated_install_lifecycle() ->
     assert main.index("Stage-LocalBundle") < main.index("Invoke-NativeSetup")
     assert "Remove-PrivateStageRoot -Path $bundle.Root" in main
     assert handoff.index("Assert-Sha256") < handoff.index("Assert-SetupAuthenticode")
-    assert handoff.index("Assert-SetupAuthenticode") < handoff.index(
-        "Invoke-BoundedNativeProcess"
-    )
+    assert handoff.index("Assert-SetupAuthenticode") < handoff.index("Invoke-BoundedNativeProcess")
 
 
 @pytest.mark.skipif(
@@ -541,31 +537,6 @@ def test_windows_fresh_installer_rolls_back_exact_attempt_owned_payloads() -> No
     assert "[Parameter(DontShow = $true)][switch]$InjectFailureAfterFreshDirectoryMove" in source
     assert '[Parameter(DontShow = $true)][string]$NativePrivateDirectorySelfTestRoot = ""' in source
 
-    harness = (ROOT / "scripts/test-fresh-install-release-windows.ps1").read_text(encoding="utf-8")
-    assert "-InjectFailureBeforeShim" in harness
-    assert "Invoke-FreshInstaller -InjectConcurrentShimBeforePublish" in harness
-    assert "InjectPolicyCleanupFailure" in harness
-    assert "InjectPolicyCustodyMoveBeforeCleanup" in harness
-    assert "Invoke-FreshInstaller -InjectFailureAfterFreshDirectoryMove" in harness
-    assert "Post-move fresh-directory cleanup was not exact" in harness
-    assert "Persistent User PATH was not modified" in harness
-    assert "Modern fresh install mutated the persistent user PATH" in harness
-    assert 'defenseclaw.cmd`" init' in harness
-    assert 'Join-Path $HomeRoot ".local\\bin"' in harness
-    assert 'Join-Path $HomeRoot ".local/bin"' not in harness
-    assert "Remove-MovedPolicyCustodyResidue" in harness
-    assert "Creation-bound policy custody was not preserved" in harness
-    assert "Remove-InjectedPolicyResidue" in harness
-    assert "Fresh Windows install did not survive policy cleanup failure" in harness
-    assert "Policy cleanup failure or residual retirement changed installed bytes" in harness
-    assert "powershell.exe" in harness
-    assert "Get-Command powershell.exe -CommandType Application -ErrorAction Stop" in harness
-    assert "WindowsPowerShellCommand" not in harness
-    assert "Windows PowerShell 5.1 could not parse/compile install.ps1" in harness
-    assert "-NativePrivateDirectorySelfTestRoot $legacyNativeRoot" in harness
-    assert "Windows PowerShell 5.1 native private lifecycle failed" in harness
-    assert "-NativePrivateDirectorySelfTestRoot $modernNativeRoot" in harness
-    assert "PowerShell 7 native private lifecycle failed" in harness
     assert "Native private directory lifecycle passed" in source
     assert "Native snapshotted-child move-out refusal passed" in source
     assert "Native fresh directory fault boundaries passed" in source
@@ -576,15 +547,63 @@ def test_windows_fresh_installer_rolls_back_exact_attempt_owned_payloads() -> No
     assert "Native namespace retirement wait passed" in source
     assert "Native post-move rollback topology passed" in source
     assert "Native private-directory self-test accepted a file as its parent" in source
-    assert "Fresh-install payload rollback completed; retry is safe" in harness
-    assert "Concurrent unclaimed shim disappeared during rollback" in harness
-    assert "Failed fresh install left installer-created binary directories behind" in harness
-    assert '-Phase "post-directory-publication injection" -Context $postMove.Output' in harness
-    assert '-Phase "post-venv policy-cleanup injection"' in harness
-    assert '-Phase "moved policy-custody injection"' in harness
-    assert '-Phase "concurrent shim collision"' in harness
-    assert "--- post-move installer output ---" in harness
-    assert "bounded residual path inventory (names and kinds only)" in harness
+
+
+def test_windows_release_bootstrap_smoke_tracks_native_setup_layout() -> None:
+    harness = (ROOT / "scripts/test-fresh-install-release-windows.ps1").read_text(encoding="utf-8")
+    disposable = (ROOT / "scripts/invoke-windows-setup-standard-user-ci.ps1").read_text(encoding="utf-8")
+
+    # Both the release candidate and PR-native regression must enter through the
+    # same disposable real-user profile. Environment-variable fake homes cannot
+    # model Windows Known Folders or the native Setup registry surface.
+    assert "invoke-windows-setup-standard-user-ci.ps1" in harness
+    assert "-Mode bootstrap-acceptance" in harness
+    assert "-ArtifactRoot $ReleaseDir" in harness
+    assert "-TargetVersion $TargetVersion" in harness
+    assert "'bootstrap-acceptance'" in disposable
+    assert "test-fresh-install-release-windows.ps1" in disposable
+    assert "install.ps1" in disposable
+
+    for asset in (
+        "DefenseClawSetup-x64.exe",
+        "DefenseClawSetup-x64.exe.provenance.json",
+        "upgrade-manifest.json",
+        "checksums.txt",
+        "checksums.txt.sig",
+        "checksums.txt.pem",
+        "checksums.txt.bundle",
+        "cosign-windows-amd64.exe",
+    ):
+        assert asset in disposable
+
+    assert "GetFolderPath([Environment+SpecialFolder]::UserProfile)" in harness
+    assert "[Environment+SpecialFolder]::LocalApplicationData" in harness
+    assert "Programs\\DefenseClaw" in harness
+    assert "DefenseClaw\\InstallerCache" in harness
+    assert "Uninstall\\DefenseClaw" in harness
+    assert "Native DefenseClaw Setup completed successfully" in harness
+    assert "Assert-ExactVersion -Executable $launcher" in harness
+    assert "Assert-ExactVersion -Executable $gateway" in harness
+    assert "$first = Invoke-CapturedProcess" in harness
+    assert "$second = Invoke-CapturedProcess" in harness
+    assert "DELETEUSERDATA=1" in harness
+    assert 'GetEnvironmentVariable("Path", "User")' in harness
+    assert "uninstall did not restore the original user PATH exactly" in harness
+
+    for obsolete in (
+        "$env:USERPROFILE = $HomeRoot",
+        "$env:DEFENSECLAW_HOME = Join-Path $HomeRoot",
+        '".defenseclaw/.venv/Scripts/defenseclaw.exe"',
+        '".local\\bin\\defenseclaw-gateway.exe"',
+        "Persistent User PATH was not modified",
+        "Second fresh-installer invocation unexpectedly succeeded",
+        "InjectFailureBeforeShim",
+        "InjectConcurrentShimBeforePublish",
+        "InjectPolicyCleanupFailure",
+        "InjectPolicyCustodyMoveBeforeCleanup",
+        "InjectFailureAfterFreshDirectoryMove",
+    ):
+        assert obsolete not in harness
 
 
 @pytest.mark.skipif(
@@ -1415,16 +1434,17 @@ def test_windows_hard_cut_refusal_exercises_a_cold_cache_without_env_suppression
 
     cold_cache = refusal.index('Get-ChildItem -LiteralPath $packageRoot -Directory -Filter "__pycache__"')
     snapshot = refusal.index("Write-InstalledStateSnapshot -Case $Case -Output $before")
-    unsuppress = refusal.index(
-        '[Environment]::SetEnvironmentVariable("PYTHONDONTWRITEBYTECODE", $null, "Process")'
-    )
+    unsuppress = refusal.index('[Environment]::SetEnvironmentVariable("PYTHONDONTWRITEBYTECODE", $null, "Process")')
     invoke = refusal.index("Invoke-ExternalLogged", unsuppress)
     after_snapshot = refusal.index("Write-InstalledStateSnapshot -Case $Case -Output $after")
 
     assert cold_cache < snapshot < unsuppress < invoke < after_snapshot
-    assert refusal.count(
-        '[Environment]::SetEnvironmentVariable("PYTHONDONTWRITEBYTECODE", $bytecodeEnvironment, "Process")'
-    ) >= 2
+    assert (
+        refusal.count(
+            '[Environment]::SetEnvironmentVariable("PYTHONDONTWRITEBYTECODE", $bytecodeEnvironment, "Process")'
+        )
+        >= 2
+    )
 
 
 @pytest.mark.skipif(
@@ -1550,15 +1570,25 @@ def test_windows_release_harness_accepts_both_reviewed_config_map_topologies() -
         assert set(config_versions) == set(published)
         for version in published:
             major, minor, patch = (int(component) for component in version.split("."))
-            expected = 8 if (major, minor, patch) >= (0, 8, 5) else 7 if (
-                major,
-                minor,
-                patch,
-            ) >= (0, 8, 3) else 6 if (
-                major,
-                minor,
-                patch,
-            ) >= (0, 7, 1) else 5
+            expected = (
+                8
+                if (major, minor, patch) >= (0, 8, 5)
+                else 7
+                if (
+                    major,
+                    minor,
+                    patch,
+                )
+                >= (0, 8, 3)
+                else 6
+                if (
+                    major,
+                    minor,
+                    patch,
+                )
+                >= (0, 7, 1)
+                else 5
+            )
             assert config_versions[version] == expected
         if "0.8.4" in config_versions:
             assert config_versions["0.8.4"] == 7

--- a/cli/tests/test_windows_release_certification.py
+++ b/cli/tests/test_windows_release_certification.py
@@ -17,6 +17,9 @@ RELEASE_PATH = ROOT / ".github" / "workflows" / "release.yaml"
 SMOKE_PATH = ROOT / ".github" / "workflows" / "pre-release-certification.yml"
 FRESH_INSTALL = (ROOT / "scripts" / "test-fresh-install-release-windows.ps1").read_text(encoding="utf-8")
 DISPOSABLE_LAUNCHER = (ROOT / "scripts" / "invoke-windows-setup-standard-user-ci.ps1").read_text(encoding="utf-8")
+STANDARD_USER_PROCESS_LAUNCHER = (ROOT / "scripts" / "windows-disposable-standard-user-launcher.cs").read_text(
+    encoding="utf-8"
+)
 
 
 def _workflow(path: Path) -> dict[str, object]:
@@ -150,6 +153,15 @@ def test_windows_release_is_fresh_install_only_and_uses_public_install_ps1() -> 
     ):
         assert asset in DISPOSABLE_LAUNCHER
     assert "disposable-user bootstrap copy does not match the exact input" in DISPOSABLE_LAUNCHER
+    for compact_argument in (
+        r"..\workspace\scripts\invoke-windows-setup-standard-user-ci.ps1",
+        r"..\artifacts",
+        r"..\diagnostics",
+        r"..\results\result.json",
+    ):
+        assert compact_argument in DISPOSABLE_LAUNCHER
+    assert "commandLine.Length > 1024" in STANDARD_USER_PROCESS_LAUNCHER
+    assert "CreateProcessWithLogonW 1024-character limit" in STANDARD_USER_PROCESS_LAUNCHER
 
     assert "GetFolderPath([Environment+SpecialFolder]::UserProfile)" in FRESH_INSTALL
     assert "[Environment+SpecialFolder]::LocalApplicationData" in FRESH_INSTALL
@@ -168,6 +180,12 @@ def test_windows_release_is_fresh_install_only_and_uses_public_install_ps1() -> 
     assert "DELETEUSERDATA=1" in FRESH_INSTALL
     assert 'GetEnvironmentVariable("Path", "User")' in FRESH_INSTALL
     assert "uninstall did not restore the original user PATH exactly" in FRESH_INSTALL
+    assert FRESH_INSTALL.rindex("$installed = $false") > FRESH_INSTALL.index(
+        "uninstall did not restore the original user PATH exactly"
+    )
+    canonical_version = "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+    assert canonical_version in FRESH_INSTALL
+    assert canonical_version in DISPOSABLE_LAUNCHER
 
     for obsolete in (
         "$env:USERPROFILE = $HomeRoot",

--- a/cli/tests/test_windows_release_certification.py
+++ b/cli/tests/test_windows_release_certification.py
@@ -70,8 +70,14 @@ def test_release_accepts_signed_or_explicitly_unverified_setup_and_exact_four_si
     assert "-DiagnosticsRoot (Join-Path $env:RUNNER_TEMP" in acceptance_run
     assert "-TimeoutSeconds 2400" in acceptance_run
 
+    diagnostics = _step(windows, "Upload native Setup diagnostics on failure")
+    assert diagnostics["if"] == "${{ failure() || cancelled() }}"
+    assert diagnostics["with"]["path"] == ("${{ runner.temp }}/defenseclaw-release-setup-diagnostics/**")
+    assert diagnostics["with"]["if-no-files-found"] == "warn"
+
     upload = next(step for step in windows["steps"] if step.get("id") == "windows-installer-artifact")
-    assert windows["steps"].index(acceptance) < windows["steps"].index(upload)
+    assert windows["steps"].index(acceptance) < windows["steps"].index(diagnostics)
+    assert windows["steps"].index(diagnostics) < windows["steps"].index(upload)
     assert upload["with"]["path"] == (
         "windows-installer-output/DefenseClawSetup-x64.exe\n"
         "windows-installer-output/DefenseClawSetup-x64.exe.sha256\n"
@@ -118,6 +124,11 @@ def test_windows_release_is_fresh_install_only_and_uses_public_install_ps1() -> 
     assert "scripts/test-fresh-install-release-windows.ps1" in rendered
     assert "-TargetVersion" in rendered
     assert "-SuccessPathOnly" not in rendered
+    assert "defenseclaw-release-bootstrap-diagnostics" in rendered
+    diagnostics = _step(job, "Upload Windows bootstrap diagnostics on failure")
+    assert diagnostics["if"] == "${{ failure() || cancelled() }}"
+    assert diagnostics["with"]["path"] == ("${{ runner.temp }}/defenseclaw-release-bootstrap-diagnostics/**")
+    assert diagnostics["with"]["if-no-files-found"] == "warn"
 
     smoke_text = SMOKE_PATH.read_text(encoding="utf-8")
     for retired in (

--- a/cli/tests/test_windows_release_certification.py
+++ b/cli/tests/test_windows_release_certification.py
@@ -199,6 +199,29 @@ def test_windows_release_is_fresh_install_only_and_uses_public_install_ps1() -> 
         assert obsolete not in FRESH_INSTALL
 
 
+def test_disposable_setup_failure_preserves_bounded_native_log_before_profile_cleanup() -> None:
+    fixed_source = r"DefenseClaw\InstallerState\setup.log"
+    fixed_destination = "native-setup.log"
+    capture = "Copy-DisposableNativeSetupLog"
+    generic_handoff = "Copy-BoundedDisposableDiagnostics"
+    profile_cleanup = "Remove-DisposableProfileAndAccount $accountName $accountSid"
+
+    assert fixed_source in DISPOSABLE_LAUNCHER
+    assert fixed_destination in DISPOSABLE_LAUNCHER
+    assert "[Environment+SpecialFolder]::LocalApplicationData" in DISPOSABLE_LAUNCHER
+    assert "DisposableFileGuard]::CopyBoundedRegularFile(" in DISPOSABLE_LAUNCHER
+    assert re.search(
+        r"(?s)CopyBoundedRegularFile\(\s*\$source,\s*\$destination,\s*65536\s*\)",
+        DISPOSABLE_LAUNCHER,
+    )
+    assert "-AllowedRoot $localAppData -RequireExists" in DISPOSABLE_LAUNCHER
+    assert "-AllowedRoot $SandboxRoot -RequireExists" in DISPOSABLE_LAUNCHER
+    assert "native Setup log preservation failed" in DISPOSABLE_LAUNCHER
+    assert DISPOSABLE_LAUNCHER.rindex(capture) < DISPOSABLE_LAUNCHER.rindex(generic_handoff)
+    assert DISPOSABLE_LAUNCHER.rindex(generic_handoff) < DISPOSABLE_LAUNCHER.index(profile_cleanup)
+    assert "Copy-Item" not in DISPOSABLE_LAUNCHER
+
+
 def test_publish_includes_windows_binaries_without_an_omission_mode() -> None:
     workflow = _workflow(RELEASE_PATH)
     jobs = workflow["jobs"]

--- a/cli/tests/test_windows_release_certification.py
+++ b/cli/tests/test_windows_release_certification.py
@@ -16,6 +16,7 @@ PACKAGED_V8_VALIDATOR = (ROOT / "scripts" / "validate_packaged_v8_resources.py")
 RELEASE_PATH = ROOT / ".github" / "workflows" / "release.yaml"
 SMOKE_PATH = ROOT / ".github" / "workflows" / "pre-release-certification.yml"
 FRESH_INSTALL = (ROOT / "scripts" / "test-fresh-install-release-windows.ps1").read_text(encoding="utf-8")
+DISPOSABLE_LAUNCHER = (ROOT / "scripts" / "invoke-windows-setup-standard-user-ci.ps1").read_text(encoding="utf-8")
 
 
 def _workflow(path: Path) -> dict[str, object]:
@@ -107,11 +108,13 @@ def test_windows_release_is_fresh_install_only_and_uses_public_install_ps1() -> 
     rendered = str(job)
 
     assert job["runs-on"] == "windows-latest"
+    assert int(job["timeout-minutes"]) >= 45
     assert "inputs.candidate_artifact" in rendered
     assert "scripts/release_candidate.py verify" in rendered
     assert "scripts/verify-sigstore-blob.py" in rendered
     assert "scripts/test-fresh-install-release-windows.ps1" in rendered
-    assert "-SuccessPathOnly" in rendered
+    assert "-TargetVersion" in rendered
+    assert "-SuccessPathOnly" not in rendered
 
     smoke_text = SMOKE_PATH.read_text(encoding="utf-8")
     for retired in (
@@ -125,17 +128,57 @@ def test_windows_release_is_fresh_install_only_and_uses_public_install_ps1() -> 
     ):
         assert retired not in smoke_text
 
-    assert '$Installer = Join-Path $Root "scripts\\install.ps1"' in FRESH_INSTALL
-    assert '"-Local", $ReleaseDir' in FRESH_INSTALL
-    assert '"-Version", $RequestedVersion' in FRESH_INSTALL
-    assert "[switch]$SuccessPathOnly" in FRESH_INSTALL
-    assert "$first = if ($SuccessPathOnly)" in FRESH_INSTALL
-    assert "Invoke-FreshInstaller\n    } else {" in FRESH_INSTALL
-    assert "DefenseClaw installed successfully" in FRESH_INSTALL
-    assert "Assert-ExactVersion -Command $cli" in FRESH_INSTALL
-    assert "Assert-ExactVersion -Command $gateway" in FRESH_INSTALL
-    assert "$second = Invoke-FreshInstaller" in FRESH_INSTALL
-    assert "Second fresh-installer invocation unexpectedly succeeded" in FRESH_INSTALL
+    assert "invoke-windows-setup-standard-user-ci.ps1" in FRESH_INSTALL
+    assert "-Mode bootstrap-acceptance" in FRESH_INSTALL
+    assert "-ArtifactRoot $ReleaseDir" in FRESH_INSTALL
+    assert "-TargetVersion $TargetVersion" in FRESH_INSTALL
+    assert "$env:RUNNER_TEMP" in FRESH_INSTALL
+    assert "$env:DC_WINDOWS_NATIVE_BASE_ROOT" in FRESH_INSTALL
+    assert "Refusing to clean unexpected bootstrap acceptance state" in FRESH_INSTALL
+    assert "'bootstrap-acceptance'" in DISPOSABLE_LAUNCHER
+    assert "test-fresh-install-release-windows.ps1" in DISPOSABLE_LAUNCHER
+    assert "install.ps1" in DISPOSABLE_LAUNCHER
+    for asset in (
+        "DefenseClawSetup-x64.exe",
+        "DefenseClawSetup-x64.exe.provenance.json",
+        "upgrade-manifest.json",
+        "checksums.txt",
+        "checksums.txt.sig",
+        "checksums.txt.pem",
+        "checksums.txt.bundle",
+        "cosign-windows-amd64.exe",
+    ):
+        assert asset in DISPOSABLE_LAUNCHER
+    assert "disposable-user bootstrap copy does not match the exact input" in DISPOSABLE_LAUNCHER
+
+    assert "GetFolderPath([Environment+SpecialFolder]::UserProfile)" in FRESH_INSTALL
+    assert "[Environment+SpecialFolder]::LocalApplicationData" in FRESH_INSTALL
+    assert "Programs\\DefenseClaw" in FRESH_INSTALL
+    assert "DefenseClaw\\InstallerCache" in FRESH_INSTALL
+    assert "Uninstall\\DefenseClaw" in FRESH_INSTALL
+    assert re.search(r"""['"]-Local['"]""", FRESH_INSTALL)
+    assert re.search(r"""['"]-Version['"]""", FRESH_INSTALL)
+    assert re.search(r"""['"]-CosignPath['"]""", FRESH_INSTALL)
+    assert "Native DefenseClaw Setup completed successfully" in FRESH_INSTALL
+    assert "Assert-ExactVersion -Executable $launcher" in FRESH_INSTALL
+    assert "Assert-ExactVersion -Executable $gateway" in FRESH_INSTALL
+    assert "$first = Invoke-CapturedProcess" in FRESH_INSTALL
+    assert "$second = Invoke-CapturedProcess" in FRESH_INSTALL
+    assert "Out-String -Width 32768" in FRESH_INSTALL
+    assert "DELETEUSERDATA=1" in FRESH_INSTALL
+    assert 'GetEnvironmentVariable("Path", "User")' in FRESH_INSTALL
+    assert "uninstall did not restore the original user PATH exactly" in FRESH_INSTALL
+
+    for obsolete in (
+        "$env:USERPROFILE = $HomeRoot",
+        "$env:DEFENSECLAW_HOME = Join-Path $HomeRoot",
+        '".defenseclaw/.venv/Scripts/defenseclaw.exe"',
+        '".local\\bin\\defenseclaw-gateway.exe"',
+        "Second fresh-installer invocation unexpectedly succeeded",
+        "InjectFailureBeforeShim",
+        "InjectPolicyCleanupFailure",
+    ):
+        assert obsolete not in FRESH_INSTALL
 
 
 def test_publish_includes_windows_binaries_without_an_omission_mode() -> None:

--- a/cmd/defenseclaw-setup/managed_process_windows_test.go
+++ b/cmd/defenseclaw-setup/managed_process_windows_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestReadManagedPIDRecordTreatsMissingPathAsAbsent(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "watchdog.pid")
+	state, exists, err := readManagedPIDRecord(pidPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists || state != (pidState{}) {
+		t.Fatalf("missing PID record returned state=%+v exists=%t", state, exists)
+	}
+}
+
+func TestManagedPIDRecordAbsentErrorsIncludeDeletePending(t *testing.T) {
+	for name, err := range map[string]error{
+		"file missing":   windows.ERROR_FILE_NOT_FOUND,
+		"path missing":   windows.ERROR_PATH_NOT_FOUND,
+		"delete pending": windows.ERROR_DELETE_PENDING,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !isManagedPIDRecordAbsentError(fmt.Errorf("open PID record: %w", err)) {
+				t.Fatalf("%v was not treated as logical absence", err)
+			}
+		})
+	}
+	if isManagedPIDRecordAbsentError(windows.ERROR_ACCESS_DENIED) {
+		t.Fatal("access denied was treated as logical absence")
+	}
+}
+
+func TestDecodeManagedPIDRecordUsesOpenedHandleAfterPathReplacement(t *testing.T) {
+	dataRoot := t.TempDir()
+	pidPath := filepath.Join(dataRoot, "watchdog.pid")
+	openedPath := filepath.Join(dataRoot, "watchdog.opened.pid")
+	original := pidState{
+		PID:           101,
+		Executable:    `C:\DefenseClaw\original.exe`,
+		StartIdentity: "original-start",
+	}
+	replacement := pidState{
+		PID:           202,
+		Executable:    `C:\DefenseClaw\replacement.exe`,
+		StartIdentity: "replacement-start",
+	}
+	writeManagedPIDRecordTestFixture(t, pidPath, original)
+
+	file, exists, err := openManagedPIDRecord(pidPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists || file == nil {
+		t.Fatal("existing PID record was not opened")
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			t.Errorf("close opened PID record: %v", err)
+		}
+	}()
+
+	// FILE_SHARE_DELETE permits the publisher to atomically replace the record
+	// while the verifier retains an identity-stable handle to the old object.
+	if err := os.Rename(pidPath, openedPath); err != nil {
+		t.Fatalf("rename opened PID record: %v", err)
+	}
+	writeManagedPIDRecordTestFixture(t, pidPath, replacement)
+
+	got, err := decodeManagedPIDRecord(file, pidPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != original {
+		t.Fatalf("decoded replacement path instead of opened record: got %+v want %+v", got, original)
+	}
+}
+
+func TestOpenManagedPIDRecordRejectsReparsePoint(t *testing.T) {
+	dataRoot := t.TempDir()
+	target := filepath.Join(dataRoot, "target.pid")
+	pidPath := filepath.Join(dataRoot, "watchdog.pid")
+	writeManagedPIDRecordTestFixture(t, target, pidState{
+		PID:        101,
+		Executable: `C:\DefenseClaw\gateway.exe`,
+	})
+	if err := os.Symlink(target, pidPath); err != nil {
+		t.Skipf("creating a file symlink requires Windows Developer Mode or elevation: %v", err)
+	}
+
+	file, exists, err := openManagedPIDRecord(pidPath)
+	if file != nil {
+		_ = file.Close()
+		t.Fatal("reparse-point PID record returned an open file")
+	}
+	if exists {
+		t.Fatal("reparse-point PID record was reported as usable")
+	}
+	if err == nil || !strings.Contains(err.Error(), "is a reparse point") {
+		t.Fatalf("reparse-point error = %v", err)
+	}
+}
+
+func TestReadManagedPIDRecordRejectsOversizeRecord(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "watchdog.pid")
+	if err := os.WriteFile(
+		pidPath,
+		[]byte(strings.Repeat("x", maxManagedPIDRecordBytes+1)),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	_, exists, err := readManagedPIDRecord(pidPath)
+	if exists {
+		t.Fatal("oversize PID record was reported as usable")
+	}
+	if err == nil || !strings.Contains(err.Error(), "exceeds 65536 bytes") {
+		t.Fatalf("oversize PID record error = %v", err)
+	}
+}
+
+func writeManagedPIDRecordTestFixture(t *testing.T, path string, state pidState) {
+	t.Helper()
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/defenseclaw-setup/managed_process_windows_test.go
+++ b/cmd/defenseclaw-setup/managed_process_windows_test.go
@@ -27,6 +27,24 @@ func TestReadManagedPIDRecordTreatsMissingPathAsAbsent(t *testing.T) {
 	}
 }
 
+func TestReadManagedPIDRecordReturnsDecodedState(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "watchdog.pid")
+	want := pidState{
+		PID:           4242,
+		Executable:    `C:\DefenseClaw\gateway.exe`,
+		StartIdentity: "start-identity",
+	}
+	writeManagedPIDRecordTestFixture(t, pidPath, want)
+
+	got, exists, err := readManagedPIDRecord(pidPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists || got != want {
+		t.Fatalf("valid PID record returned state=%+v exists=%t; want state=%+v exists=true", got, exists, want)
+	}
+}
+
 func TestManagedPIDRecordAbsentErrorsIncludeDeletePending(t *testing.T) {
 	for name, err := range map[string]error{
 		"file missing":   windows.ERROR_FILE_NOT_FOUND,
@@ -86,6 +104,21 @@ func TestDecodeManagedPIDRecordUsesOpenedHandleAfterPathReplacement(t *testing.T
 	}
 	if got != original {
 		t.Fatalf("decoded replacement path instead of opened record: got %+v want %+v", got, original)
+	}
+}
+
+func TestOpenManagedPIDRecordRejectsDirectory(t *testing.T) {
+	pidPath := t.TempDir()
+	file, exists, err := openManagedPIDRecord(pidPath)
+	if file != nil {
+		_ = file.Close()
+		t.Fatal("directory PID record returned an open file")
+	}
+	if exists {
+		t.Fatal("directory PID record was reported as usable")
+	}
+	if err == nil || !strings.Contains(err.Error(), "is not a regular file") {
+		t.Fatalf("directory PID record error = %v", err)
 	}
 }
 

--- a/cmd/defenseclaw-setup/platform_windows.go
+++ b/cmd/defenseclaw-setup/platform_windows.go
@@ -205,6 +205,10 @@ func openManagedPIDRecord(pidPath string) (*os.File, bool, error) {
 		err := fmt.Errorf("managed gateway PID path is not a regular file: %s", pidPath)
 		return nil, false, errors.Join(err, windows.CloseHandle(handle))
 	}
+	// PID records are process-identity proofs, not user documents. Reject every
+	// reparse tag—not only name-surrogate links—so validation never depends on
+	// cloud hydration, compression, deduplication, or another filter driver's
+	// interpretation of the record.
 	if info.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
 		err := fmt.Errorf("managed gateway PID path is a reparse point: %s", pidPath)
 		return nil, false, errors.Join(err, windows.CloseHandle(handle))

--- a/cmd/defenseclaw-setup/platform_windows.go
+++ b/cmd/defenseclaw-setup/platform_windows.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -65,6 +66,8 @@ type pidState struct {
 	StartIdentity string `json:"start_identity"`
 }
 
+const maxManagedPIDRecordBytes = 64 << 10
+
 func acquireSetupLock() (func() error, error) {
 	user, err := windows.GetCurrentProcessToken().GetTokenUser()
 	if err != nil {
@@ -106,28 +109,12 @@ func managedProcessOwnedBy(gatewayPath, dataRoot, pidFile string) (bool, error) 
 
 func managedProcessProofFor(gatewayPath, dataRoot, pidFile string) (managedProcessProof, bool, error) {
 	pidPath := filepath.Join(dataRoot, pidFile)
-	info, err := os.Lstat(pidPath)
-	if errors.Is(err, os.ErrNotExist) {
+	state, exists, err := readManagedPIDRecord(pidPath)
+	if err != nil {
+		return managedProcessProof{}, false, err
+	}
+	if !exists {
 		return managedProcessProof{}, false, nil
-	}
-	if err != nil {
-		return managedProcessProof{}, false, err
-	}
-	if info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
-		return managedProcessProof{}, false, fmt.Errorf("managed gateway PID path is not a regular file: %s", pidPath)
-	}
-	if reparse, err := isReparsePoint(pidPath); err != nil {
-		return managedProcessProof{}, false, err
-	} else if reparse {
-		return managedProcessProof{}, false, fmt.Errorf("managed gateway PID path is a reparse point: %s", pidPath)
-	}
-	data, err := os.ReadFile(pidPath)
-	if err != nil {
-		return managedProcessProof{}, false, err
-	}
-	var state pidState
-	if err := json.Unmarshal(data, &state); err != nil {
-		return managedProcessProof{}, false, fmt.Errorf("invalid managed gateway PID file %s: %w", pidPath, err)
 	}
 	if state.PID <= 0 || strings.TrimSpace(state.Executable) == "" {
 		return managedProcessProof{}, false, fmt.Errorf("managed gateway PID file lacks a complete process identity: %s", pidPath)
@@ -169,6 +156,90 @@ func managedProcessProofFor(gatewayPath, dataRoot, pidFile string) (managedProce
 		StartIdentity: identity,
 		ProcessHandle: uintptr(handle),
 	}, true, nil
+}
+
+func readManagedPIDRecord(pidPath string) (pidState, bool, error) {
+	file, exists, err := openManagedPIDRecord(pidPath)
+	if err != nil || !exists {
+		return pidState{}, exists, err
+	}
+	state, readErr := decodeManagedPIDRecord(file, pidPath)
+	closeErr := file.Close()
+	if readErr != nil || closeErr != nil {
+		return pidState{}, false, errors.Join(readErr, closeErr)
+	}
+	return state, true, nil
+}
+
+// openManagedPIDRecord binds validation and decoding to one Windows file
+// object. Gateway PID records are atomically replaced during startup, so
+// separate Lstat/GetFileAttributes/ReadFile lookups can observe three
+// different pathname states and leak a transient not-found error into Setup
+// convergence. Delete sharing lets the publisher proceed while this handle
+// keeps the verified object stable for the reader.
+func openManagedPIDRecord(pidPath string) (*os.File, bool, error) {
+	pathPtr, err := winpath.UTF16Ptr(pidPath)
+	if err != nil {
+		return nil, false, err
+	}
+	handle, err := windows.CreateFile(
+		pathPtr,
+		windows.GENERIC_READ,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if isManagedPIDRecordAbsentError(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		return nil, false, errors.Join(err, windows.CloseHandle(handle))
+	}
+	if info.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0 {
+		err := fmt.Errorf("managed gateway PID path is not a regular file: %s", pidPath)
+		return nil, false, errors.Join(err, windows.CloseHandle(handle))
+	}
+	if info.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		err := fmt.Errorf("managed gateway PID path is a reparse point: %s", pidPath)
+		return nil, false, errors.Join(err, windows.CloseHandle(handle))
+	}
+	file := os.NewFile(uintptr(handle), pidPath)
+	if file == nil {
+		err := fmt.Errorf("wrap managed gateway PID file handle: %s", pidPath)
+		return nil, false, errors.Join(err, windows.CloseHandle(handle))
+	}
+	return file, true, nil
+}
+
+func isManagedPIDRecordAbsentError(err error) bool {
+	return errors.Is(err, windows.ERROR_FILE_NOT_FOUND) ||
+		errors.Is(err, windows.ERROR_PATH_NOT_FOUND) ||
+		errors.Is(err, windows.ERROR_DELETE_PENDING)
+}
+
+func decodeManagedPIDRecord(file *os.File, pidPath string) (pidState, error) {
+	data, err := io.ReadAll(io.LimitReader(file, maxManagedPIDRecordBytes+1))
+	if err != nil {
+		return pidState{}, fmt.Errorf("read managed gateway PID file %s: %w", pidPath, err)
+	}
+	if len(data) > maxManagedPIDRecordBytes {
+		return pidState{}, fmt.Errorf(
+			"managed gateway PID file exceeds %d bytes: %s",
+			maxManagedPIDRecordBytes,
+			pidPath,
+		)
+	}
+	var state pidState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return pidState{}, fmt.Errorf("invalid managed gateway PID file %s: %w", pidPath, err)
+	}
+	return state, nil
 }
 
 func closeManagedProcessProof(proof managedProcessProof) error {

--- a/docs/WINDOWS-NATIVE-CI.md
+++ b/docs/WINDOWS-NATIVE-CI.md
@@ -15,13 +15,19 @@ The merge gate covers:
 - PowerShell parsing, timeout, redaction, and process-tree cleanup contracts;
 - a release-shaped Windows amd64 gateway archive and Python wheel;
 - a disposable-user fresh installation;
+- the public `install.ps1` authentication and native handoff path under a
+  token-bound disposable Windows profile;
 - installed CLI, gateway lifecycle, doctor, scanner, and dependency checks;
 - Setup build and native install/repair/uninstall acceptance; and
 - deterministic Codex and Claude Code connector contract tests.
 
 The packaged test artifact is built once and reused by the disposable lifecycle
-jobs. Failure diagnostics are bounded, secret-redacted, retained for five days,
-and followed by unconditional process, listener, and temporary-state cleanup.
+jobs. The public-bootstrap shard uses the authenticated `0.8.7` release as its
+compatibility fixture; before that release exists, it replays the immutable
+sealed candidate from the failed release run that exposed the fake-profile
+harness defect. Failure diagnostics are bounded, secret-redacted, retained for
+five days, and followed by unconditional process, listener, account/profile,
+and temporary-state cleanup.
 
 ## Relationship to Release
 

--- a/docs/WINDOWS-NATIVE-CI.md
+++ b/docs/WINDOWS-NATIVE-CI.md
@@ -25,9 +25,11 @@ The packaged test artifact is built once and reused by the disposable lifecycle
 jobs. The public-bootstrap shard uses the authenticated `0.8.7` release as its
 compatibility fixture; before that release exists, it replays the immutable
 sealed candidate from the failed release run that exposed the fake-profile
-harness defect. Failure diagnostics are bounded, secret-redacted, retained for
-five days, and followed by unconditional process, listener, account/profile,
-and temporary-state cleanup.
+harness defect. Its child launch uses sandbox-relative arguments to stay
+deterministically below `CreateProcessWithLogonW`'s 1,024-character command-line
+limit even when the parent state root is deeply nested. Failure diagnostics are
+bounded, secret-redacted, retained for five days, and followed by unconditional
+process, listener, account/profile, and temporary-state cleanup.
 
 ## Relationship to Release
 

--- a/scripts/invoke-windows-setup-standard-user-ci.ps1
+++ b/scripts/invoke-windows-setup-standard-user-ci.ps1
@@ -219,6 +219,41 @@ function Test-ActualChildFilesystemBoundary {
     }
 }
 
+function Copy-DisposableNativeSetupLog {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$DiagnosticsRoot,
+        [Parameter(Mandatory)][string]$SandboxRoot
+    )
+
+    $localAppData = [Environment]::GetFolderPath(
+        [Environment+SpecialFolder]::LocalApplicationData
+    )
+    if ([string]::IsNullOrWhiteSpace($localAppData)) {
+        throw 'disposable user has no LocalApplicationData known folder'
+    }
+    $source = Join-Path $localAppData 'DefenseClaw\InstallerState\setup.log'
+    if (-not (Test-Path -LiteralPath $source -PathType Leaf)) { return }
+
+    $source = Assert-DisposableNoReparseAncestors -Path $source `
+        -AllowedRoot $localAppData -RequireExists
+    $destinationRoot = Assert-DisposableNoReparseAncestors `
+        -Path $DiagnosticsRoot -AllowedRoot $SandboxRoot -RequireExists
+    $destinationRootItem = Get-Item -LiteralPath $destinationRoot `
+        -Force -ErrorAction Stop
+    if (-not $destinationRootItem.PSIsContainer) {
+        throw 'disposable native Setup diagnostic destination is not a directory'
+    }
+    $destination = Join-Path $destinationRoot 'native-setup.log'
+    $null = Assert-DisposableNoReparseAncestors -Path $destination `
+        -AllowedRoot $destinationRoot
+    [void][DefenseClaw.DisposableFileGuard]::CopyBoundedRegularFile(
+        $source,
+        $destination,
+        65536
+    )
+}
+
 function Invoke-ChildMode {
     $result = [IO.Path]::GetFullPath($ResultPath)
     $state = [IO.Path]::GetFullPath($StateRoot)
@@ -371,6 +406,21 @@ function Invoke-ChildMode {
         Write-ChildProgress $progress "${Mode}-failed"
         $failure = $_
         if (-not [string]::IsNullOrWhiteSpace($DiagnosticsRoot)) {
+            try {
+                Copy-DisposableNativeSetupLog `
+                    -DiagnosticsRoot ([IO.Path]::GetFullPath($DiagnosticsRoot)) `
+                    -SandboxRoot $sandboxRoot
+            } catch {
+                $failure = [Management.Automation.ErrorRecord]::new(
+                    [InvalidOperationException]::new(
+                        "$($failure.Exception.Message); native Setup log preservation failed: $($_.Exception.Message)",
+                        $failure.Exception
+                    ),
+                    'DisposableNativeSetupLogPreservationFailed',
+                    [Management.Automation.ErrorCategory]::OperationStopped,
+                    $state
+                )
+            }
             try {
                 & $nativeHarness -Operation capture -StateRoot $state `
                     -DiagnosticsRoot ([IO.Path]::GetFullPath($DiagnosticsRoot))

--- a/scripts/invoke-windows-setup-standard-user-ci.ps1
+++ b/scripts/invoke-windows-setup-standard-user-ci.ps1
@@ -17,11 +17,12 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)]
-    [ValidateSet('setup-acceptance', 'wizard-smoke', 'contract')]
+    [ValidateSet('setup-acceptance', 'bootstrap-acceptance', 'wizard-smoke', 'contract')]
     [string]$Mode,
     [ValidateSet('codex', 'claudecode')][string]$Connector = 'codex',
     [Parameter(Mandatory)][string]$ArtifactRoot,
     [Parameter(Mandatory)][string]$StateRoot,
+    [string]$TargetVersion = '',
     [string]$DiagnosticsRoot = '',
     [ValidateRange(60, 7200)][int]$TimeoutSeconds = 4500,
     [switch]$Child,
@@ -349,6 +350,12 @@ function Invoke-ChildMode {
                 -WorkspaceRoot (Split-Path -Parent $PSScriptRoot) `
                 -StateRoot $state -ArtifactRoot $artifacts `
                 -AllowCurrentUserSetupAcceptance
+        } elseif ($Mode -eq 'bootstrap-acceptance') {
+            & (Join-Path $PSScriptRoot 'test-fresh-install-release-windows.ps1') `
+                -ReleaseDir $artifacts `
+                -TargetVersion $TargetVersion `
+                -StateRoot $state `
+                -Child
         } elseif ($Mode -eq 'contract') {
             & $nativeHarness -Operation contract -Connector $Connector `
                 -WorkspaceRoot (Split-Path -Parent $PSScriptRoot) `
@@ -720,6 +727,10 @@ if ($env:GITHUB_ACTIONS -ne 'true' -or $env:RUNNER_ENVIRONMENT -ne 'github-hoste
 if (-not (Test-IsAdministrator)) {
     throw 'disposable Setup acceptance account provisioning requires the hosted runner administrator'
 }
+if ($Mode -eq 'bootstrap-acceptance' -and
+    $TargetVersion -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$') {
+    throw 'bootstrap acceptance requires a canonical TargetVersion'
+}
 
 $stateBase = [IO.Path]::GetFullPath($StateRoot).TrimEnd('\')
 $artifactSource = [IO.Path]::GetFullPath($ArtifactRoot).TrimEnd('\')
@@ -749,11 +760,15 @@ $setupSourceItem = Get-Item -LiteralPath $setupSource -Force -ErrorAction Stop
 if ($setupSourceItem.Attributes -band [IO.FileAttributes]::ReparsePoint) {
     throw 'native setup input must be a regular file, not a reparse point'
 }
-$resourceVerifierInputs = @(
-    'DefenseClawWindowsResourceVerifier-x64.exe',
-    'DefenseClawWindowsResourceIcon.png',
-    'DefenseClawWindowsResourceVersion.txt'
-)
+$resourceVerifierInputs = if ($Mode -eq 'bootstrap-acceptance') {
+    @()
+} else {
+    @(
+        'DefenseClawWindowsResourceVerifier-x64.exe',
+        'DefenseClawWindowsResourceIcon.png',
+        'DefenseClawWindowsResourceVersion.txt'
+    )
+}
 foreach ($resourceInputName in $resourceVerifierInputs) {
     $resourceInput = Join-Path $artifactSource $resourceInputName
     $null = Assert-DisposableNoReparseAncestors -Path $resourceInput `
@@ -764,6 +779,48 @@ foreach ($resourceInputName in $resourceVerifierInputs) {
         continue
     }
     throw "Windows resource verifier input must be a regular file: $resourceInput"
+}
+$bootstrapCandidateAssets = @()
+$bootstrapSourceHashes = @{}
+$bootstrapCosignSource = ''
+$bootstrapCosignSha256 = 'DD6C61E510DA627BCAED4CD9DB844EC11CACD09826D814D89F7F68D40FEB07BE'
+if ($Mode -eq 'bootstrap-acceptance') {
+    $bootstrapCandidateAssets = @(
+        'DefenseClawSetup-x64.exe.provenance.json',
+        'upgrade-manifest.json',
+        'checksums.txt',
+        'checksums.txt.sig',
+        'checksums.txt.pem',
+        'checksums.txt.bundle'
+    )
+    foreach ($assetName in $bootstrapCandidateAssets) {
+        $assetPath = Join-Path $artifactSource $assetName
+        $null = Assert-DisposableNoReparseAncestors -Path $assetPath `
+            -AllowedRoot $artifactSource -RequireExists
+        $assetItem = Get-Item -LiteralPath $assetPath -Force -ErrorAction Stop
+        if ($assetItem.PSIsContainer -or
+            ($assetItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -or
+            $assetItem.Length -le 0) {
+            throw "bootstrap release input must be a non-empty regular file: $assetPath"
+        }
+        $bootstrapSourceHashes[$assetName] = (
+            Get-FileHash -LiteralPath $assetPath -Algorithm SHA256
+        ).Hash
+    }
+    $cosignCommand = Get-Command cosign.exe -CommandType Application `
+        -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($null -eq $cosignCommand) {
+        throw 'bootstrap acceptance requires pinned Cosign v2.6.2 on PATH'
+    }
+    $bootstrapCosignSource = [IO.Path]::GetFullPath($cosignCommand.Source)
+    $cosignItem = Get-Item -LiteralPath $bootstrapCosignSource -Force -ErrorAction Stop
+    if ($cosignItem.PSIsContainer -or
+        ($cosignItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -or
+        $cosignItem.Length -le 0 -or
+        (Get-FileHash -LiteralPath $bootstrapCosignSource -Algorithm SHA256).Hash -cne
+        $bootstrapCosignSha256) {
+        throw 'bootstrap acceptance Cosign does not match the reviewed v2.6.2 Windows verifier'
+    }
 }
 $expectedSetupHash = [DefenseClaw.DisposableFileGuard]::ComputeSha256Hex(
     $setupSource,
@@ -892,6 +949,11 @@ try {
             "live-connector-e2e\golden\$Connector\pre_tool_block.json",
             "live-connector-e2e\golden\$Connector\session_start.json"
         )
+    } elseif ($Mode -eq 'bootstrap-acceptance') {
+        $harnessFiles += @(
+            'install.ps1',
+            'test-fresh-install-release-windows.ps1'
+        )
     }
     foreach ($file in $harnessFiles) {
         $source = Join-Path $PSScriptRoot $file
@@ -918,6 +980,26 @@ try {
         ) -cne
         $expectedSetupHash) {
         throw 'disposable-user Setup copy does not match the exact input artifact'
+    }
+    if ($Mode -eq 'bootstrap-acceptance') {
+        foreach ($assetName in $bootstrapCandidateAssets) {
+            $childAsset = Join-Path $childArtifacts $assetName
+            [IO.File]::Copy(
+                (Join-Path $artifactSource $assetName),
+                $childAsset,
+                $false
+            )
+            if ((Get-FileHash -LiteralPath $childAsset -Algorithm SHA256).Hash -cne
+                [string]$bootstrapSourceHashes[$assetName]) {
+                throw "disposable-user bootstrap copy does not match the exact input: $assetName"
+            }
+        }
+        $childCosign = Join-Path $childArtifacts 'cosign-windows-amd64.exe'
+        [IO.File]::Copy($bootstrapCosignSource, $childCosign, $false)
+        if ((Get-FileHash -LiteralPath $childCosign -Algorithm SHA256).Hash -cne
+            $bootstrapCosignSha256) {
+            throw 'disposable-user Cosign copy does not match the reviewed v2.6.2 verifier'
+        }
     }
 
     Set-DisposableProtectedDirectoryAcl $workspace $sidObject `
@@ -1006,6 +1088,9 @@ try {
     if ($Mode -eq 'contract') {
         $arguments += @('-Connector', $Connector)
     }
+    if ($Mode -eq 'bootstrap-acceptance') {
+        $arguments += @('-TargetVersion', $TargetVersion)
+    }
     if ($Mode -eq 'setup-acceptance') {
         $arguments += '-ExerciseWmiEscape'
     }
@@ -1093,6 +1178,26 @@ try {
     if ($sourceHashAfter -cne $expectedSetupHash -or
         $childHashAfter -cne $expectedSetupHash) {
         throw 'exact Setup artifact hash changed during disposable-user lifecycle acceptance'
+    }
+    if ($Mode -eq 'bootstrap-acceptance') {
+        foreach ($assetName in $bootstrapCandidateAssets) {
+            $expectedHash = [string]$bootstrapSourceHashes[$assetName]
+            $sourcePath = Join-Path $artifactSource $assetName
+            $childPath = Join-Path $childArtifacts $assetName
+            if ((Get-FileHash -LiteralPath $sourcePath -Algorithm SHA256).Hash -cne
+                $expectedHash -or
+                (Get-FileHash -LiteralPath $childPath -Algorithm SHA256).Hash -cne
+                $expectedHash) {
+                throw "exact bootstrap release input changed during acceptance: $assetName"
+            }
+        }
+        if ((Get-FileHash `
+                -LiteralPath (Join-Path $childArtifacts 'cosign-windows-amd64.exe') `
+                -Algorithm SHA256).Hash -cne $bootstrapCosignSha256 -or
+            (Get-FileHash -LiteralPath $bootstrapCosignSource -Algorithm SHA256).Hash -cne
+            $bootstrapCosignSha256) {
+            throw 'exact bootstrap Cosign verifier changed during acceptance'
+        }
     }
     if ($Mode -eq 'setup-acceptance') {
         $fixturePidText = Read-BoundedDisposableResult $wmiFixtureRecord $childResults 4096

--- a/scripts/invoke-windows-setup-standard-user-ci.ps1
+++ b/scripts/invoke-windows-setup-standard-user-ci.ps1
@@ -728,7 +728,7 @@ if (-not (Test-IsAdministrator)) {
     throw 'disposable Setup acceptance account provisioning requires the hosted runner administrator'
 }
 if ($Mode -eq 'bootstrap-acceptance' -and
-    $TargetVersion -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$') {
+    $TargetVersion -notmatch '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$') {
     throw 'bootstrap acceptance requires a canonical TargetVersion'
 }
 
@@ -1077,12 +1077,12 @@ try {
     $pwsh = Join-Path $PSHOME 'pwsh.exe'
     $arguments = @(
         '-NoLogo', '-NoProfile', '-NonInteractive', '-File',
-        (Join-Path $scripts 'invoke-windows-setup-standard-user-ci.ps1'),
+        '..\workspace\scripts\invoke-windows-setup-standard-user-ci.ps1',
         '-Child', '-Mode', $Mode,
-        '-ArtifactRoot', $childArtifacts,
-        '-StateRoot', $childState,
-        '-DiagnosticsRoot', $childDiagnostics,
-        '-ResultPath', $result,
+        '-ArtifactRoot', '..\artifacts',
+        '-StateRoot', '.',
+        '-DiagnosticsRoot', '..\diagnostics',
+        '-ResultPath', '..\results\result.json',
         '-ExpectedChildSid', $accountSid
     )
     if ($Mode -eq 'contract') {

--- a/scripts/live-connector-e2e/test-windows.ps1
+++ b/scripts/live-connector-e2e/test-windows.ps1
@@ -1034,7 +1034,8 @@ private-secret-name = "DefenseClaw must remain redacted"
         $nativeHarnessText -match '\./internal/tools/windowsresources' -and
         $nativeHarnessText -match 'DefenseClawWindowsResourceIcon\.png' -and
         $nativeHarnessText -match 'DefenseClawWindowsResourceVersion\.txt' -and
-        $standardUserCIText -match '\$resourceVerifierInputs = @\(' -and
+        $standardUserCIText -match
+            '(?s)\$resourceVerifierInputs = if \(\$Mode -eq ''bootstrap-acceptance''\) \{\s*@\(\)\s*\} else \{\s*@\(' -and
         $standardUserCIText -match '\[IO\.File\]::Copy\(\$source, \$destination, \$false\)') `
         'packaged lifecycle carries an offline immutable Windows resource verifier into the disposable child'
     Assert-True ($standardUserCIText -match 'Publish-BoundedDisposableContractResults' -and

--- a/scripts/live-connector-e2e/test-windows.ps1
+++ b/scripts/live-connector-e2e/test-windows.ps1
@@ -793,13 +793,14 @@ private-secret-name = "DefenseClaw must remain redacted"
     Assert-True ([regex]::Matches(
         $nativeWorkflowText,
         '(?m)^\s*run: \./scripts/initialize-windows-native-ci-paths\.ps1 '
-    ).Count -eq 6) 'every native Windows job uses the shared isolated-path initializer'
+    ).Count -eq 7) 'every native Windows job uses the shared isolated-path initializer'
     foreach ($leafContract in @(
         '-Leaf go -DiagnosticsLeaf windows-native-diagnostics-go',
         "-Leaf ('py-' + `$env:PYTHON_SHARD) -DiagnosticsLeaf ('windows-native-diagnostics-python-' + `$env:PYTHON_SHARD)",
         '-Leaf ps -DiagnosticsLeaf windows-native-diagnostics-powershell',
         '-Leaf pkg -DiagnosticsLeaf windows-native-diagnostics-package -ArtifactLeaf windows-native-dist',
         '-Leaf acc -DiagnosticsLeaf windows-native-diagnostics-acceptance -ArtifactLeaf windows-native-dist',
+        '-Leaf bootstrap -DiagnosticsLeaf windows-native-diagnostics-bootstrap -ArtifactLeaf windows-bootstrap-fixture',
         "-Leaf ('ct-' + `$env:CONNECTOR) -DiagnosticsLeaf ('windows-native-diagnostics-' + `$env:CONNECTOR) -ArtifactLeaf windows-native-dist"
     )) {
         Assert-True ($nativeWorkflowText.Contains($leafContract)) `

--- a/scripts/test-fresh-install-release-windows.ps1
+++ b/scripts/test-fresh-install-release-windows.ps1
@@ -2,15 +2,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 <#
-Exercise the exact sealed candidate through install.ps1 in an isolated profile.
-The second invocation must refuse before changing any installed file or attribute.
+.SYNOPSIS
+    Exercises the public Windows bootstrap against one exact sealed candidate.
+
+.DESCRIPTION
+    Native Setup derives its per-user layout from token-bound Windows Known
+    Folders. Environment-variable profile spoofing is intentionally unsupported.
+    The parent mode therefore delegates to the repository's disposable
+    standard-user launcher. Child mode runs with a real isolated profile and
+    HKCU hive, installs through scripts/install.ps1, repeats the authenticated
+    handoff, verifies the installed version, and proves complete uninstall.
 #>
 
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)][string]$ReleaseDir,
     [Parameter(Mandatory = $true)][string]$TargetVersion,
-    [switch]$SuccessPathOnly
+    [Parameter(DontShow = $true)][switch]$Child,
+    [Parameter(DontShow = $true)][string]$StateRoot = "",
+    [Parameter(DontShow = $true)][string]$DiagnosticsRoot = ""
 )
 
 Set-StrictMode -Version Latest
@@ -20,456 +30,325 @@ if ($TargetVersion -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$') {
     throw "TargetVersion must be canonical X.Y.Z"
 }
 
+$ReleaseDir = (Resolve-Path -LiteralPath $ReleaseDir -ErrorAction Stop).Path
 $Root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
-$Installer = Join-Path $Root "scripts\install.ps1"
-$ReleaseDir = (Resolve-Path -LiteralPath $ReleaseDir).Path
-$PowerShell = (Get-Command pwsh -CommandType Application -ErrorAction Stop).Source
-$WindowsPowerShell = (Get-Command powershell.exe -CommandType Application -ErrorAction Stop).Source
-$WorkRoot = Join-Path ([IO.Path]::GetTempPath()) (
-    "defenseclaw-fresh-release-" + [guid]::NewGuid().ToString("N")
-)
-$HomeRoot = Join-Path $WorkRoot "home"
-$TempRoot = Join-Path $WorkRoot "temp"
-$savedUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
-$savedEnvironment = @{}
-foreach ($name in @("USERPROFILE", "HOME", "DEFENSECLAW_HOME", "TEMP", "TMP")) {
-    $savedEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, "Process")
-}
 
-function Get-TreeSnapshot {
-    param([Parameter(Mandatory = $true)][string]$Path)
-
-    $rootItem = Get-Item -LiteralPath $Path -Force
-    $items = @($rootItem) + @(
-        Get-ChildItem -LiteralPath $Path -Force -Recurse |
-            Sort-Object -Property FullName
-    )
-    $rows = foreach ($item in $items) {
-        $relative = if ($item.FullName -eq $rootItem.FullName) {
-            "."
-        } else {
-            [IO.Path]::GetRelativePath($rootItem.FullName, $item.FullName).Replace('\', '/')
-        }
-        $row = [ordered]@{
-            path = $relative
-            attributes = [string]$item.Attributes
-            last_write_utc_ticks = $item.LastWriteTimeUtc.Ticks
-            kind = if ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) {
-                "reparse"
-            } elseif ($item.PSIsContainer) {
-                "directory"
-            } else {
-                "file"
-            }
-        }
-        if ($row["kind"] -eq "reparse") {
-            $row["target"] = [string]($item.Target -join "|")
-        } elseif ($row["kind"] -eq "file") {
-            $row["length"] = [long]$item.Length
-            $row["sha256"] = (Get-FileHash -LiteralPath $item.FullName -Algorithm SHA256).Hash
-        }
-        [pscustomobject]$row
-    }
-    return ($rows | ConvertTo-Json -Compress -Depth 4)
-}
-
-function Invoke-FreshInstaller {
+function Invoke-CapturedProcess {
     param(
-        [string]$RequestedVersion = $TargetVersion,
-        [switch]$InjectFailureBeforeShim,
-        [switch]$InjectConcurrentShimBeforePublish,
-        [switch]$InjectPolicyCleanupFailure,
-        [switch]$InjectPolicyCustodyMoveBeforeCleanup,
-        [switch]$InjectFailureAfterFreshDirectoryMove
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$ArgumentList
     )
-    $arguments = @(
-        "-NoProfile", "-NonInteractive", "-File", $Installer,
-        "-Local", $ReleaseDir,
-        "-Version", $RequestedVersion,
-        "-Connector", "none",
-        "-Yes"
-    )
-    if ($InjectFailureBeforeShim -or
-        $InjectConcurrentShimBeforePublish -or
-        $InjectPolicyCleanupFailure -or
-        $InjectPolicyCustodyMoveBeforeCleanup -or
-        $InjectFailureAfterFreshDirectoryMove) {
-        $arguments += "-TestMode"
+
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $output = (& $FilePath @ArgumentList 2>&1 | Out-String -Width 32768)
+        $exitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
     }
-    if ($InjectFailureBeforeShim) { $arguments += "-InjectFailureBeforeShim" }
-    if ($InjectConcurrentShimBeforePublish) {
-        $arguments += "-InjectConcurrentShimBeforePublish"
+    return [pscustomobject]@{
+        ExitCode = [int]$exitCode
+        Output = [string]$output
     }
-    if ($InjectPolicyCleanupFailure) { $arguments += "-InjectPolicyCleanupFailure" }
-    if ($InjectPolicyCustodyMoveBeforeCleanup) {
-        $arguments += "-InjectPolicyCustodyMoveBeforeCleanup"
-    }
-    if ($InjectFailureAfterFreshDirectoryMove) {
-        $arguments += "-InjectFailureAfterFreshDirectoryMove"
-    }
-    $output = (& $PowerShell @arguments 2>&1 | Out-String)
-    return [pscustomobject]@{ ExitCode = $LASTEXITCODE; Output = $output }
 }
 
 function Assert-ExactVersion {
-    param([Parameter(Mandatory = $true)][string]$Command)
+    param(
+        [Parameter(Mandatory = $true)][string]$Executable,
+        [Parameter(Mandatory = $true)][string]$ExpectedVersion
+    )
 
-    $output = (& $Command --version 2>&1 | Out-String).Trim()
-    if ($LASTEXITCODE -ne 0) { throw "Version probe failed: $Command`n$output" }
+    $probe = Invoke-CapturedProcess -FilePath $Executable -ArgumentList @("--version")
+    if ($probe.ExitCode -ne 0) {
+        throw "Version probe failed for ${Executable}:`n$($probe.Output)"
+    }
     $versions = @(
         [regex]::Matches(
-            $output,
+            $probe.Output,
             '(?<![0-9.])([0-9]+\.[0-9]+\.[0-9]+)(?![0-9.])'
         ) | ForEach-Object { $_.Groups[1].Value }
     )
-    if ($versions.Count -ne 1 -or $versions[0] -cne $TargetVersion) {
-        throw "Version output did not report exact ${TargetVersion}: $output"
+    if ($versions.Count -ne 1 -or $versions[0] -cne $ExpectedVersion) {
+        throw "${Executable} did not report exact version ${ExpectedVersion}: $($probe.Output)"
     }
 }
 
-function Assert-NoInstallerCustody {
-    $leftovers = @(
-        Get-ChildItem -LiteralPath $TempRoot -Force -ErrorAction SilentlyContinue |
-            Where-Object {
-                $_.Name -like "defenseclaw-install-policy-*" -or
-                $_.Name -like "dc-gw-*" -or
-                $_.Name -like "dc-cli-*"
-            }
-    )
-    if ($leftovers.Count -ne 0) {
-        throw "Fresh Windows installer left plaintext/private custody behind: $($leftovers.FullName -join ', ')"
-    }
-}
-
-function Assert-NoFreshPayload {
+function Assert-BootstrapSucceeded {
     param(
-        [string]$Phase = "fresh-install rollback",
-        [string]$Context = ""
+        [Parameter(Mandatory = $true)][object]$Result,
+        [Parameter(Mandatory = $true)][string]$ExpectedVersion,
+        [Parameter(Mandatory = $true)][string]$Phase
     )
-    foreach ($path in @(
-        $env:DEFENSECLAW_HOME,
-        (Join-Path $HomeRoot ".local\bin\defenseclaw-gateway.exe"),
-        (Join-Path $HomeRoot ".local\bin\defenseclaw.cmd")
+
+    foreach ($expected in @(
+        "Release checksum signature verified (Sigstore)",
+        "Authenticated DefenseClawSetup-x64.exe for DefenseClaw $ExpectedVersion",
+        "Starting authenticated native Setup",
+        "Native DefenseClaw Setup completed successfully"
     )) {
-        if (Test-Path -LiteralPath $path) {
-            $diagnostic = if ($Context) { "`nInstaller output:`n$Context" } else { "" }
-            throw "Failed fresh install left a managed payload marker during ${Phase}: $path$diagnostic"
+        if ($Result.Output -notmatch [regex]::Escape($expected)) {
+            throw "${Phase} did not report '$expected':`n$($Result.Output)"
         }
     }
+    if ($Result.Output -notmatch (
+            "Setup Authenticode signature verified" +
+            "|Setup is explicitly unverified by Authenticode"
+        )) {
+        throw "${Phase} did not report an explicit Setup signing state:`n$($Result.Output)"
+    }
+    if ($Result.ExitCode -ne 0) {
+        throw "${Phase} failed ($($Result.ExitCode)):`n$($Result.Output)"
+    }
 }
 
-function Remove-InjectedPolicyResidue {
-    param([Parameter(Mandatory = $true)][string]$Output)
-
-    $match = [regex]::Match(
-        $Output,
-        "Last expected path: '([^']+)'\. Last cleanup error:"
+function Get-UserPathEntryCount {
+    param(
+        [AllowNull()][string]$Value,
+        [Parameter(Mandatory = $true)][string]$ExpectedEntry
     )
-    if (-not $match.Success) {
-        throw "Policy cleanup failure did not report its private residual path:`n$Output"
-    }
-    $residual = [IO.Path]::GetFullPath($match.Groups[1].Value)
-    $separator = [IO.Path]::DirectorySeparatorChar
-    $tempPrefix = [IO.Path]::GetFullPath($TempRoot).TrimEnd($separator) + $separator
-    if (-not $residual.StartsWith($tempPrefix, [StringComparison]::OrdinalIgnoreCase) -or
-        (Split-Path -Leaf $residual) -notlike 'defenseclaw-install-policy-*') {
-        throw "Policy cleanup warning reported an unsafe residual path: $residual"
-    }
-    if (-not (Test-Path -LiteralPath $residual -PathType Container)) {
-        throw "Policy cleanup warning residual does not exist: $residual"
-    }
-    Remove-Item -LiteralPath $residual -Recurse -Force -ErrorAction Stop
-    if (Test-Path -LiteralPath $residual) {
-        throw "Could not retire injected policy cleanup residual: $residual"
-    }
-    return $residual
+
+    if ([string]::IsNullOrWhiteSpace($Value)) { return 0 }
+    return @(
+        $Value.Split(
+            [char[]]@(";"),
+            [StringSplitOptions]::RemoveEmptyEntries
+        ) | Where-Object {
+            ([IO.Path]::GetFullPath($_.Trim())).TrimEnd('\').Equals(
+                ([IO.Path]::GetFullPath($ExpectedEntry)).TrimEnd('\'),
+                [StringComparison]::OrdinalIgnoreCase
+            )
+        }
+    ).Count
 }
 
-function Remove-MovedPolicyCustodyResidue {
-    param([Parameter(Mandatory = $true)][string]$Output)
+function Wait-ForPathRemoval {
+    param([Parameter(Mandatory = $true)][string]$Path)
 
-    $match = [regex]::Match(
-        $Output,
-        "Last expected path: '([^']+)'\. Last cleanup error:"
-    )
-    if (-not $match.Success) {
-        throw "Moved policy custody did not report its preserved canonical path:`n$Output"
+    for ($attempt = 0; $attempt -lt 80 -and (Test-Path -LiteralPath $Path); $attempt++) {
+        Start-Sleep -Milliseconds 250
     }
-    $canonical = [IO.Path]::GetFullPath($match.Groups[1].Value)
-    $displaced = "$canonical.installer-owned-original"
-    $separator = [IO.Path]::DirectorySeparatorChar
-    $tempPrefix = [IO.Path]::GetFullPath($TempRoot).TrimEnd($separator) + $separator
-    if (-not $canonical.StartsWith($tempPrefix, [StringComparison]::OrdinalIgnoreCase) -or
-        (Split-Path -Leaf $canonical) -notlike 'defenseclaw-install-policy-*') {
-        throw "Moved policy cleanup reported an unsafe canonical path: $canonical"
-    }
-    if (Test-Path -LiteralPath $canonical) {
-        throw "Moved policy cleanup recreated or deleted through the canonical namespace: $canonical"
-    }
-    if (-not (Test-Path -LiteralPath $displaced -PathType Container)) {
-        throw "Creation-bound policy custody was not preserved at its moved path: $displaced"
-    }
-    if (@(Get-ChildItem -LiteralPath $displaced -Force).Count -eq 0) {
-        throw "Preserved moved policy custody unexpectedly lost its authenticated contents"
-    }
-    Remove-Item -LiteralPath $displaced -Recurse -Force -ErrorAction Stop
 }
+
+if (-not $Child) {
+    if (-not $IsWindows) {
+        throw "Fresh Windows release smoke requires native Windows"
+    }
+    if ($env:GITHUB_ACTIONS -ne "true" -or $env:RUNNER_ENVIRONMENT -ne "github-hosted") {
+        throw "Fresh Windows release smoke is restricted to GitHub-hosted Windows CI"
+    }
+    if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+        throw "RUNNER_TEMP is required for disposable Windows release smoke"
+    }
+
+    $helper = Join-Path $Root "scripts\invoke-windows-setup-standard-user-ci.ps1"
+    $stateBase = if ([string]::IsNullOrWhiteSpace($StateRoot)) {
+        Join-Path $env:RUNNER_TEMP (
+            "defenseclaw-bootstrap-acceptance-" + [guid]::NewGuid().ToString("N")
+        )
+    } else {
+        [IO.Path]::GetFullPath($StateRoot)
+    }
+    $helperCompleted = $false
+    try {
+        & $helper `
+            -Mode bootstrap-acceptance `
+            -ArtifactRoot $ReleaseDir `
+            -StateRoot $stateBase `
+            -TargetVersion $TargetVersion `
+            -DiagnosticsRoot $DiagnosticsRoot `
+            -TimeoutSeconds 1800
+        $helperCompleted = $true
+    } finally {
+        $resolvedState = [IO.Path]::GetFullPath($stateBase).TrimEnd('\')
+        $approvedStateBases = @(
+            $env:RUNNER_TEMP,
+            $env:DC_WINDOWS_NATIVE_BASE_ROOT
+        ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            ForEach-Object { [IO.Path]::GetFullPath($_).TrimEnd('\') }
+        $approvedBoundary = $approvedStateBases | Where-Object {
+            $resolvedState.StartsWith(
+                $_ + [IO.Path]::DirectorySeparatorChar,
+                [StringComparison]::OrdinalIgnoreCase
+            )
+        } | Select-Object -First 1
+        if ([string]::IsNullOrWhiteSpace([string]$approvedBoundary) -or
+            -not ([IO.Path]::GetFileName($resolvedState)).StartsWith(
+                "defenseclaw-bootstrap-acceptance-",
+                [StringComparison]::Ordinal
+            )) {
+            throw "Refusing to clean unexpected bootstrap acceptance state: $resolvedState"
+        }
+        if (Test-Path -LiteralPath $resolvedState) {
+            if ($helperCompleted) {
+                Remove-Item -LiteralPath $resolvedState -Recurse -Force -ErrorAction Stop
+            } else {
+                Write-Warning (
+                    "Disposable bootstrap state was preserved after failure: $resolvedState"
+                )
+            }
+        }
+    }
+    return
+}
+
+if (-not $IsWindows) {
+    throw "Disposable bootstrap acceptance child requires native Windows"
+}
+if ([string]::IsNullOrWhiteSpace($StateRoot)) {
+    throw "Disposable bootstrap acceptance child requires StateRoot"
+}
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$accountName = ($identity.Name -split '\\')[-1]
+$principal = [Security.Principal.WindowsPrincipal]::new($identity)
+if ($accountName -notmatch '^dcacc[0-9a-f]{10}$' -or
+    $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw "Bootstrap acceptance child must be a disposable real Windows standard user"
+}
+
+$profile = [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
+$localAppData = [Environment]::GetFolderPath(
+    [Environment+SpecialFolder]::LocalApplicationData
+)
+if ([string]::IsNullOrWhiteSpace($profile) -or
+    [string]::IsNullOrWhiteSpace($localAppData) -or
+    [string]::IsNullOrWhiteSpace($env:USERPROFILE) -or
+    -not ([IO.Path]::GetFullPath($env:USERPROFILE)).TrimEnd('\').Equals(
+        ([IO.Path]::GetFullPath($profile)).TrimEnd('\'),
+        [StringComparison]::OrdinalIgnoreCase
+    )) {
+    throw "Disposable bootstrap child does not have a token-bound real user profile"
+}
+
+$installer = Join-Path $PSScriptRoot "install.ps1"
+$powerShell = Join-Path $PSHOME "pwsh.exe"
+$cosign = Join-Path $ReleaseDir "cosign-windows-amd64.exe"
+$setup = Join-Path $ReleaseDir "DefenseClawSetup-x64.exe"
+$installRoot = Join-Path $localAppData "Programs\DefenseClaw"
+$dataRoot = Join-Path $profile ".defenseclaw"
+$cacheRoot = Join-Path $localAppData "DefenseClaw\InstallerCache"
+$arpKey = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\DefenseClaw"
+$launcher = Join-Path $installRoot "bin\defenseclaw.exe"
+$gateway = Join-Path $installRoot "bin\defenseclaw-gateway.exe"
+$installed = $false
+$userPathBefore = [Environment]::GetEnvironmentVariable("Path", "User")
+
+foreach ($path in @(
+    $installRoot,
+    $dataRoot,
+    $cacheRoot,
+    $arpKey
+)) {
+    if (Test-Path -LiteralPath $path) {
+        throw "Bootstrap acceptance refuses pre-existing product state: $path"
+    }
+}
+foreach ($path in @($installer, $powerShell, $cosign, $setup)) {
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "Bootstrap acceptance input is missing: $path"
+    }
+}
+
+# The supported public path has no custom home override. Setup and the
+# compatibility bootstrap must agree on the account's real Known Folder.
+Remove-Item Env:DEFENSECLAW_HOME -ErrorAction SilentlyContinue
+
+$bootstrapArguments = @(
+    "-NoLogo",
+    "-NoProfile",
+    "-NonInteractive",
+    "-File",
+    $installer,
+    "-Local",
+    $ReleaseDir,
+    "-CosignPath",
+    $cosign,
+    "-Version",
+    $TargetVersion,
+    "-Connector",
+    "none",
+    "-Yes"
+)
 
 try {
-    [void](New-Item -ItemType Directory -Path $HomeRoot -Force)
-    [void](New-Item -ItemType Directory -Path $TempRoot -Force)
-    $env:USERPROFILE = $HomeRoot
-    $env:HOME = $HomeRoot
-    $env:DEFENSECLAW_HOME = Join-Path $HomeRoot ".defenseclaw"
-    $env:TEMP = $TempRoot
-    $env:TMP = $TempRoot
+    $first = Invoke-CapturedProcess `
+        -FilePath $powerShell `
+        -ArgumentList $bootstrapArguments
+    Assert-BootstrapSucceeded `
+        -Result $first `
+        -ExpectedVersion $TargetVersion `
+        -Phase "First public bootstrap"
+    $installed = $true
 
-    $legacyHelp = (& $WindowsPowerShell -NoProfile -NonInteractive -File $Installer -Help 2>&1 |
-        Out-String)
-    if ($LASTEXITCODE -ne 0 -or $legacyHelp -notmatch 'DefenseClaw native Windows bootstrap') {
-        throw "Windows PowerShell 5.1 could not parse/compile install.ps1:`n$legacyHelp"
-    }
-    $userPathBeforeFailure = [Environment]::GetEnvironmentVariable("Path", "User")
-    if (-not $SuccessPathOnly) {
-        $legacyNativeRoot = Join-Path $TempRoot "windows-powershell-native-private"
-    [void](New-Item -ItemType Directory -Path $legacyNativeRoot)
-    $legacyNative = (& $WindowsPowerShell `
-        -NoProfile `
-        -NonInteractive `
-        -File $Installer `
-        -TestMode `
-        -NativePrivateDirectorySelfTestRoot $legacyNativeRoot 2>&1 | Out-String)
-    if ($LASTEXITCODE -ne 0 -or
-        $legacyNative -notmatch 'Native private directory lifecycle passed' -or
-        $legacyNative -notmatch 'Native snapshotted-child move-out refusal passed' -or
-        $legacyNative -notmatch 'Native namespace retirement wait passed' -or
-        $legacyNative -notmatch 'Native fresh directory fault boundaries passed') {
-        throw "Windows PowerShell 5.1 native private lifecycle failed:`n$legacyNative"
-    }
-    if (@(Get-ChildItem -LiteralPath $legacyNativeRoot -Force).Count -ne 0) {
-        throw "Windows PowerShell 5.1 native private lifecycle left custody behind"
-    }
-    [IO.Directory]::Delete($legacyNativeRoot)
-
-    $modernNativeRoot = Join-Path $TempRoot "powershell-native-private"
-    [void](New-Item -ItemType Directory -Path $modernNativeRoot)
-    $modernNative = (& $PowerShell `
-        -NoProfile `
-        -NonInteractive `
-        -File $Installer `
-        -TestMode `
-        -NativePrivateDirectorySelfTestRoot $modernNativeRoot 2>&1 | Out-String)
-    if ($LASTEXITCODE -ne 0 -or
-        $modernNative -notmatch 'Native private directory lifecycle passed' -or
-        $modernNative -notmatch 'Native snapshotted-child move-out refusal passed' -or
-        $modernNative -notmatch 'Native namespace retirement wait passed' -or
-        $modernNative -notmatch 'Native fresh directory fault boundaries passed') {
-        throw "PowerShell 7 native private lifecycle failed:`n$modernNative"
-    }
-    if (@(Get-ChildItem -LiteralPath $modernNativeRoot -Force).Count -ne 0) {
-        throw "PowerShell 7 native private lifecycle left custody behind"
-    }
-    [IO.Directory]::Delete($modernNativeRoot)
-
-    $mismatch = Invoke-FreshInstaller -RequestedVersion "999.999.999"
-    if ($mismatch.ExitCode -eq 0 -or $mismatch.Output -notmatch 'does not match -Version') {
-        throw "Manifest-version refusal did not fail inside authenticated policy setup:`n$($mismatch.Output)"
-    }
-    Assert-NoInstallerCustody
-    if (
-        (Test-Path -LiteralPath $env:DEFENSECLAW_HOME) -or
-        (Test-Path -LiteralPath (Join-Path $HomeRoot ".local\bin\defenseclaw-gateway.exe")) -or
-        (Test-Path -LiteralPath (Join-Path $HomeRoot ".local\bin\defenseclaw.cmd"))
-    ) {
-        throw "Manifest-version refusal left installed state behind"
-    }
-
-    $postMove = Invoke-FreshInstaller -InjectFailureAfterFreshDirectoryMove
-    if ($postMove.ExitCode -eq 0 -or
-        $postMove.Output -notmatch 'Injected fresh-install directory failure after publishing' -or
-        $postMove.Output -notmatch 'rollback safety boundary did not complete' -or
-        $postMove.Output -notmatch 'rollback preserved changed or concurrent state' -or
-        $postMove.Output -match 'Fresh-install payload rollback completed; retry is safe') {
-        throw "Post-move fresh-directory cleanup was not exact:`n$($postMove.Output)"
-    }
-    Assert-NoInstallerCustody
-    if (Test-Path -LiteralPath $env:DEFENSECLAW_HOME) {
-        Write-Host "--- post-move installer output ---" -ForegroundColor Yellow
-        Write-Host $postMove.Output
-        Write-Host "--- bounded residual path inventory (names and kinds only) ---" -ForegroundColor Yellow
-        @(
-            Get-ChildItem -LiteralPath $HomeRoot -Force -Recurse -ErrorAction SilentlyContinue |
-                Select-Object -First 100
-        ) | ForEach-Object {
-            $relative = [IO.Path]::GetRelativePath($HomeRoot, $_.FullName)
-            $kind = if ($_.Attributes -band [IO.FileAttributes]::ReparsePoint) {
-                "reparse"
-            } elseif ($_.PSIsContainer) {
-                "directory"
-            } else {
-                "file"
-            }
-            Write-Host "$kind`t$relative"
+    foreach ($path in @($launcher, $gateway)) {
+        if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+            throw "Public bootstrap did not install native executable: $path"
         }
     }
-    Assert-NoFreshPayload -Phase "post-directory-publication injection" -Context $postMove.Output
-    if (Test-Path -LiteralPath (Join-Path $HomeRoot ".local")) {
-        throw "Post-move fresh-directory failure left .local or bin custody behind"
+    if (-not (Test-Path -LiteralPath $arpKey)) {
+        throw "Public bootstrap did not publish the per-user Installed Apps registration"
     }
-    if ([Environment]::GetEnvironmentVariable("Path", "User") -cne $userPathBeforeFailure) {
-        throw "Post-move fresh-directory failure changed the user PATH"
-    }
-
-    $injected = Invoke-FreshInstaller `
-        -InjectFailureBeforeShim `
-        -InjectPolicyCleanupFailure
-    if ($injected.ExitCode -eq 0 -or
-        $injected.Output -notmatch 'Injected fresh-install failure before CLI shim publication' -or
-        $injected.Output -notmatch 'Injected private release-policy cleanup failure' -or
-        $injected.Output -notmatch 'Gateway installed' -or
-        $injected.Output -notmatch 'Installing DefenseClaw CLI' -or
-        $injected.Output -notmatch 'rollback preserved changed or concurrent state' -or
-        $injected.Output -notmatch 'creation-bound private directory cleanup remains incomplete' -or
-        $injected.Output -match 'Fresh-install payload rollback completed; retry is safe') {
-        throw "Post-venv fresh-install rollback injection was not exercised:`n$($injected.Output)"
-    }
-    [void](Remove-InjectedPolicyResidue -Output $injected.Output)
-    Assert-NoInstallerCustody
-    Assert-NoFreshPayload `
-        -Phase "post-venv policy-cleanup injection" `
-        -Context $injected.Output
-    if (Test-Path -LiteralPath (Join-Path $HomeRoot ".local")) {
-        throw "Failed fresh install left installer-created binary directories behind"
-    }
-    if ([Environment]::GetEnvironmentVariable("Path", "User") -cne $userPathBeforeFailure) {
-        throw "Failed fresh install changed the user PATH"
+    Assert-ExactVersion -Executable $launcher -ExpectedVersion $TargetVersion
+    Assert-ExactVersion -Executable $gateway -ExpectedVersion $TargetVersion
+    if ((Get-UserPathEntryCount `
+            -Value ([Environment]::GetEnvironmentVariable("Path", "User")) `
+            -ExpectedEntry (Join-Path $installRoot "bin")) -ne 1) {
+        throw "Public bootstrap did not publish exactly one native user PATH entry"
     }
 
-    $movedCustody = Invoke-FreshInstaller `
-        -InjectFailureBeforeShim `
-        -InjectPolicyCustodyMoveBeforeCleanup
-    if ($movedCustody.ExitCode -eq 0 -or
-        $movedCustody.Output -notmatch 'Injected fresh-install failure before CLI shim publication' -or
-        $movedCustody.Output -notmatch 'canonical binding was lost' -or
-        $movedCustody.Output -notmatch 'current location of installer-owned custody may be unknown' -or
-        $movedCustody.Output -notmatch 'Retained creation identity:' -or
-        $movedCustody.Output -notmatch 'creation-bound private directory cleanup remains incomplete' -or
-        $movedCustody.Output -notmatch 'rollback preserved changed or concurrent state' -or
-        $movedCustody.Output -match 'Fresh-install payload rollback completed; retry is safe') {
-        throw "Moved private-policy custody was not retained:`n$($movedCustody.Output)"
-    }
-    Remove-MovedPolicyCustodyResidue -Output $movedCustody.Output
-    Assert-NoInstallerCustody
-    Assert-NoFreshPayload `
-        -Phase "moved policy-custody injection" `
-        -Context $movedCustody.Output
-    if (Test-Path -LiteralPath (Join-Path $HomeRoot ".local")) {
-        throw "Moved policy custody left installer-created binary directories behind"
-    }
-    if ([Environment]::GetEnvironmentVariable("Path", "User") -cne $userPathBeforeFailure) {
-        throw "Moved policy custody changed the user PATH"
+    $firstHashes = @(
+        (Get-FileHash -LiteralPath $launcher -Algorithm SHA256).Hash,
+        (Get-FileHash -LiteralPath $gateway -Algorithm SHA256).Hash
+    )
+    $second = Invoke-CapturedProcess `
+        -FilePath $powerShell `
+        -ArgumentList $bootstrapArguments
+    Assert-BootstrapSucceeded `
+        -Result $second `
+        -ExpectedVersion $TargetVersion `
+        -Phase "Repeated public bootstrap"
+    Assert-ExactVersion -Executable $launcher -ExpectedVersion $TargetVersion
+    Assert-ExactVersion -Executable $gateway -ExpectedVersion $TargetVersion
+    $secondHashes = @(
+        (Get-FileHash -LiteralPath $launcher -Algorithm SHA256).Hash,
+        (Get-FileHash -LiteralPath $gateway -Algorithm SHA256).Hash
+    )
+    if (($firstHashes -join ":") -cne ($secondHashes -join ":")) {
+        throw "Repeated public bootstrap changed the exact installed candidate bytes"
     }
 
-    $collision = Invoke-FreshInstaller -InjectConcurrentShimBeforePublish
-    $unclaimedShim = Join-Path $HomeRoot ".local\bin\defenseclaw.cmd"
-    if ($collision.ExitCode -eq 0 -or
-        $collision.Output -notmatch 'CLI appeared during installation; it was preserved' -or
-        $collision.Output -notmatch 'rollback preserved changed or concurrent state') {
-        throw "Concurrent fresh-install shim collision was not preserved:`n$($collision.Output)"
+    $uninstall = Invoke-CapturedProcess `
+        -FilePath $setup `
+        -ArgumentList @("/uninstall", "/quiet", "DELETEUSERDATA=1")
+    if ($uninstall.ExitCode -ne 0) {
+        throw "Native uninstall failed ($($uninstall.ExitCode)):`n$($uninstall.Output)"
     }
-    Assert-NoInstallerCustody
-    if (-not (Test-Path -LiteralPath $unclaimedShim -PathType Leaf)) {
-        throw "Concurrent unclaimed shim disappeared during rollback"
-    }
-    $unclaimedBytes = [IO.File]::ReadAllText($unclaimedShim, [Text.Encoding]::ASCII)
-    if ($unclaimedBytes -cne "@echo off`r`necho concurrent-unclaimed-shim`r`n") {
-        throw "Concurrent unclaimed shim bytes changed during rollback"
-    }
-    if ((Test-Path -LiteralPath $env:DEFENSECLAW_HOME) -or
-        (Test-Path -LiteralPath (Join-Path $HomeRoot ".local\bin\defenseclaw-gateway.exe"))) {
-        throw "Concurrent shim collision retained installer-owned gateway or venv state"
-    }
-    if ([Environment]::GetEnvironmentVariable("Path", "User") -cne $userPathBeforeFailure) {
-        throw "Concurrent shim collision changed the user PATH"
-    }
-    [IO.File]::Delete($unclaimedShim)
-    [IO.Directory]::Delete((Join-Path $HomeRoot ".local\bin"))
-    [IO.Directory]::Delete((Join-Path $HomeRoot ".local"))
-    Assert-NoFreshPayload -Phase "concurrent shim collision" -Context $collision.Output
-    }
-
-    $first = if ($SuccessPathOnly) {
-        Invoke-FreshInstaller
-    } else {
-        Invoke-FreshInstaller -InjectPolicyCleanupFailure
-    }
-    $expectedInstallDir = Join-Path $HomeRoot ".local\bin"
-    if ($first.ExitCode -ne 0 -or
-        $first.Output -notmatch 'DefenseClaw installed successfully' -or
-        $first.Output -notmatch 'Persistent User PATH was not modified' -or
-        $first.Output -notmatch "Edit environment variables for your account" -or
-        -not $first.Output.Contains($expectedInstallDir) -or
-        -not $first.Output.Contains("& `"$expectedInstallDir\defenseclaw.cmd`" init") -or
-        $first.Output -match 'Added .* to your user PATH') {
-        throw "Fresh Windows install failed ($($first.ExitCode)):`n$($first.Output)"
-    }
-    if ($SuccessPathOnly) {
-        if ($first.Output -match 'Private release-policy cleanup was incomplete') {
-            throw "Fresh Windows success path retained private policy custody:`n$($first.Output)"
+    $installed = $false
+    Wait-ForPathRemoval -Path $cacheRoot
+    foreach ($path in @($installRoot, $dataRoot, $cacheRoot, $arpKey)) {
+        if (Test-Path -LiteralPath $path) {
+            throw "Public bootstrap uninstall left managed state behind: $path"
         }
-    } elseif ($first.Output -notmatch 'Private release-policy cleanup was incomplete') {
-        throw "Fresh Windows install did not exercise policy cleanup failure:`n$($first.Output)"
     }
-    if ([Environment]::GetEnvironmentVariable("Path", "User") -cne $userPathBeforeFailure) {
-        throw "Modern fresh install mutated the persistent user PATH"
+    if (-not [string]::Equals(
+            $userPathBefore,
+            [Environment]::GetEnvironmentVariable("Path", "User"),
+            [StringComparison]::Ordinal
+        )) {
+        throw "Public bootstrap uninstall did not restore the original user PATH exactly"
     }
-
-    $cli = Join-Path $HomeRoot ".defenseclaw/.venv/Scripts/defenseclaw.exe"
-    $gateway = Join-Path $HomeRoot ".local\bin\defenseclaw-gateway.exe"
-    $installedBeforeCleanup = @(
-        (Get-FileHash -LiteralPath $cli -Algorithm SHA256).Hash,
-        (Get-FileHash -LiteralPath $gateway -Algorithm SHA256).Hash
-    )
-    if (-not $SuccessPathOnly) {
-        [void](Remove-InjectedPolicyResidue -Output $first.Output)
-    }
-    $installedAfterCleanup = @(
-        (Get-FileHash -LiteralPath $cli -Algorithm SHA256).Hash,
-        (Get-FileHash -LiteralPath $gateway -Algorithm SHA256).Hash
-    )
-    if (($installedBeforeCleanup -join ':') -cne ($installedAfterCleanup -join ':')) {
-        throw "Policy cleanup failure or residual retirement changed installed bytes"
-    }
-    Assert-NoInstallerCustody
-    Assert-ExactVersion -Command $cli
-    Assert-ExactVersion -Command $gateway
-    $before = Get-TreeSnapshot -Path $HomeRoot
-    $userPathBeforeSecond = [Environment]::GetEnvironmentVariable("Path", "User")
-
-    $second = Invoke-FreshInstaller
-    if ($second.ExitCode -eq 0) { throw "Second fresh-installer invocation unexpectedly succeeded" }
-    if ($second.Output -notmatch 'existing DefenseClaw installation' -or
-        $second.Output -notmatch 'No changes were made') {
-        throw "Second invocation did not report the pre-mutation refusal:`n$($second.Output)"
-    }
-    if ($second.Output -match 'Detecting platform') {
-        throw "Second invocation crossed the fresh-install preflight boundary"
-    }
-    $after = Get-TreeSnapshot -Path $HomeRoot
-    if ($after -cne $before) { throw "Second fresh-installer invocation changed installed state" }
-    $userPathAfterSecond = [Environment]::GetEnvironmentVariable("Path", "User")
-    if ($userPathAfterSecond -cne $userPathBeforeSecond) {
-        throw "Second fresh-installer invocation changed the user PATH"
-    }
-    Assert-NoInstallerCustody
-
-    Write-Host "Fresh Windows install passed: $TargetVersion" -ForegroundColor Green
+    Write-Host "Fresh Windows public bootstrap passed: $TargetVersion" -ForegroundColor Green
 } finally {
-    [Environment]::SetEnvironmentVariable("Path", $savedUserPath, "User")
-    foreach ($name in $savedEnvironment.Keys) {
-        [Environment]::SetEnvironmentVariable($name, $savedEnvironment[$name], "Process")
-    }
-    if (Test-Path -LiteralPath $WorkRoot) {
-        Remove-Item -LiteralPath $WorkRoot -Recurse -Force -ErrorAction SilentlyContinue
+    if ($installed -or (Test-Path -LiteralPath $installRoot)) {
+        try {
+            $cleanup = Invoke-CapturedProcess `
+                -FilePath $setup `
+                -ArgumentList @("/uninstall", "/quiet", "DELETEUSERDATA=1")
+            if ($cleanup.ExitCode -ne 0) {
+                Write-Warning "Emergency native uninstall failed ($($cleanup.ExitCode))"
+            }
+        } catch {
+            Write-Warning "Emergency native uninstall failed: $($_.Exception.Message)"
+        }
     }
 }

--- a/scripts/test-fresh-install-release-windows.ps1
+++ b/scripts/test-fresh-install-release-windows.ps1
@@ -206,15 +206,15 @@ if ($accountName -notmatch '^dcacc[0-9a-f]{10}$' -or
     throw "Bootstrap acceptance child must be a disposable real Windows standard user"
 }
 
-$profile = [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
+$userProfile = [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
 $localAppData = [Environment]::GetFolderPath(
     [Environment+SpecialFolder]::LocalApplicationData
 )
-if ([string]::IsNullOrWhiteSpace($profile) -or
+if ([string]::IsNullOrWhiteSpace($userProfile) -or
     [string]::IsNullOrWhiteSpace($localAppData) -or
     [string]::IsNullOrWhiteSpace($env:USERPROFILE) -or
     -not ([IO.Path]::GetFullPath($env:USERPROFILE)).TrimEnd('\').Equals(
-        ([IO.Path]::GetFullPath($profile)).TrimEnd('\'),
+        ([IO.Path]::GetFullPath($userProfile)).TrimEnd('\'),
         [StringComparison]::OrdinalIgnoreCase
     )) {
     throw "Disposable bootstrap child does not have a token-bound real user profile"
@@ -225,7 +225,7 @@ $powerShell = Join-Path $PSHOME "pwsh.exe"
 $cosign = Join-Path $ReleaseDir "cosign-windows-amd64.exe"
 $setup = Join-Path $ReleaseDir "DefenseClawSetup-x64.exe"
 $installRoot = Join-Path $localAppData "Programs\DefenseClaw"
-$dataRoot = Join-Path $profile ".defenseclaw"
+$dataRoot = Join-Path $userProfile ".defenseclaw"
 $cacheRoot = Join-Path $localAppData "DefenseClaw\InstallerCache"
 $arpKey = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\DefenseClaw"
 $launcher = Join-Path $installRoot "bin\defenseclaw.exe"
@@ -309,6 +309,11 @@ try {
         -Phase "Repeated public bootstrap"
     Assert-ExactVersion -Executable $launcher -ExpectedVersion $TargetVersion
     Assert-ExactVersion -Executable $gateway -ExpectedVersion $TargetVersion
+    if ((Get-UserPathEntryCount `
+            -Value ([Environment]::GetEnvironmentVariable("Path", "User")) `
+            -ExpectedEntry (Join-Path $installRoot "bin")) -ne 1) {
+        throw "Repeated public bootstrap changed the native user PATH entry count"
+    }
     $secondHashes = @(
         (Get-FileHash -LiteralPath $launcher -Algorithm SHA256).Hash,
         (Get-FileHash -LiteralPath $gateway -Algorithm SHA256).Hash

--- a/scripts/test-fresh-install-release-windows.ps1
+++ b/scripts/test-fresh-install-release-windows.ps1
@@ -26,7 +26,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-if ($TargetVersion -notmatch '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$') {
+if ($TargetVersion -notmatch '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$') {
     throw "TargetVersion must be canonical X.Y.Z"
 }
 
@@ -323,7 +323,6 @@ try {
     if ($uninstall.ExitCode -ne 0) {
         throw "Native uninstall failed ($($uninstall.ExitCode)):`n$($uninstall.Output)"
     }
-    $installed = $false
     Wait-ForPathRemoval -Path $cacheRoot
     foreach ($path in @($installRoot, $dataRoot, $cacheRoot, $arpKey)) {
         if (Test-Path -LiteralPath $path) {
@@ -337,6 +336,7 @@ try {
         )) {
         throw "Public bootstrap uninstall did not restore the original user PATH exactly"
     }
+    $installed = $false
     Write-Host "Fresh Windows public bootstrap passed: $TargetVersion" -ForegroundColor Green
 } finally {
     if ($installed -or (Test-Path -LiteralPath $installRoot)) {

--- a/scripts/windows-disposable-standard-user-launcher.cs
+++ b/scripts/windows-disposable-standard-user-launcher.cs
@@ -703,6 +703,16 @@ namespace DefenseClaw
                 commandLine.Append(' ');
                 commandLine.Append(QuoteWindowsArgument(argument));
             }
+            // CreateProcessWithLogonW has a 1,024-character lpCommandLine
+            // ceiling, unlike CreateProcessW's much larger limit. Reject an
+            // unsafe harness shape before Windows reports an opaque logon
+            // failure that looks like bad disposable-user credentials.
+            if (commandLine.Length > 1024)
+            {
+                throw new ArgumentException(
+                    "disposable standard-user command line exceeds the " +
+                    "CreateProcessWithLogonW 1024-character limit");
+            }
             return commandLine;
         }
 


### PR DESCRIPTION
> Base: `main`. Follow-up to #595 and failed 0.8.7 release run [30063491006](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/30063491006).

## Problem

The simplified release built and authenticated the complete 0.8.7 candidate, then failed only in the Windows public-bootstrap smoke. The legacy smoke replaced `USERPROFILE`, `HOME`, and `DEFENSECLAW_HOME` with temporary environment strings. Native Setup intentionally resolves Windows Known Folders from the process token, so it correctly rejected the fake home:

```text
Native Windows Setup uses C:\Users\runneradmin\.defenseclaw;
custom DEFENSECLAW_HOME '...\defenseclaw-fresh-release-...\home\.defenseclaw'
is not supported by this compatibility bootstrap.
```

Release was being used to discover a test-harness mismatch even though the exact native Setup lifecycle had already passed.

## Current Situation

Run 30063491006 produced one sealed candidate and passed:

- runtime, Windows Setup, and macOS app builds;
- the exact native Windows install/repair/uninstall lifecycle;
- Linux and macOS fresh installs; and
- Linux/macOS upgrades from 0.8.6, 0.8.5, 0.8.4, 0.7.2, 0.6.6, and 0.5.0.

Only `Fresh install exact candidate (windows-amd64)` failed. `Publish tested release` was skipped, and no `0.8.7` release or remote tag was created.

The failed smoke also asserted obsolete pre-native paths and expected a repeated install to be refused. Current native Setup installs under `%LOCALAPPDATA%\Programs\DefenseClaw`, registers in HKCU Installed Apps, owns one user PATH entry, and supports servicing an existing valid installation.

## Solution

### Exercise the supported Windows profile model

The public-bootstrap smoke now delegates to the existing disposable-user launcher. It creates a real short-lived standard Windows account with its own token-bound profile and HKCU hive, then runs the current `install.ps1` against the exact authenticated candidate.

The child proves:

1. Sigstore checksum authentication and explicit Authenticode/unverified state;
2. authenticated handoff to native Setup;
3. exact launcher and gateway versions in the native install layout;
4. exactly one native user PATH entry;
5. a safe repeated public-bootstrap invocation with unchanged installed hashes; and
6. complete native uninstall, user-data/cache/ARP removal, and exact PATH restoration.

Candidate assets, current bootstrap scripts, and the pinned Cosign verifier are copied into child-read-only roots and hash-checked before and after execution. Failure state and bounded diagnostics are preserved; successful state is removed only beneath the same reviewed temporary roots accepted by the launcher.

### Move the regression before release

`windows-native.yml` adds a parallel required `Windows public install.ps1 acceptance` shard. Before 0.8.7 is published, it replays the immutable sealed candidate from run 30063491006. After publication, it automatically uses permanent 0.8.7 release assets. This tests the current branch's `install.ps1` and real-profile handoff without weakening the production Sigstore identity contract.

The first PR replay also exposed `CreateProcessWithLogonW`'s documented
1,024-character command-line ceiling: repeated absolute sandbox paths produced
a 1,217-character launch. Child arguments now use sandbox-relative paths
(approximately 460 characters), and the native launcher explicitly rejects any
future command that exceeds the API limit instead of surfacing an opaque logon
error.

The release workflow calls the same harness against the exact candidate it may publish.

### Make native Setup convergence race-safe

The required Windows lifecycle then exposed a separate pre-existing timing race in Setup convergence. The same signature existed before this PR in [Windows Native CI job 88785222773](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/29875004195/job/88785222773): a gateway or watchdog PID record could be atomically replaced between pathname validation and reading, so a transient `file does not exist` escaped after installation had already committed.

Setup now opens each PID record once with Windows no-follow semantics, validates the held handle, and reads that same object. Missing and delete-pending records mean the process is not yet converged; access, reparse-point, directory, and oversized-record failures still fail closed. Deterministic Windows tests replace the pathname after open and prove Setup reads the original held object.

If the disposable-user lifecycle fails, the child also copies the native `setup.log` through the existing bounded no-follow guard before its profile is removed, so future failures preserve the decisive diagnostic without weakening the log DACL.

## Architecture Diagram

```mermaid
flowchart LR
    B["PR or main commit"] --> I["Current install.ps1 + smoke harness"]
    F["Authenticated 0.8.7 fixture"] --> I
    I --> U["Disposable real Windows user/profile"]
    U --> A["Install + authenticate + exact versions"]
    A --> R["Repeat bootstrap; hashes unchanged"]
    R --> X["Uninstall; data/cache/ARP/PATH restored"]
    X --> G["Required Windows Native aggregate"]

    C["Sealed release candidate"] --> S["Same smoke harness"]
    S --> P["Publish only if green"]
```

## What Changed (Where & How)

| File / path | Summary |
| --- | --- |
| `scripts/test-fresh-install-release-windows.ps1` | Replaced fake-profile/legacy-layout checks with real disposable-user native install, repeat, version, PATH, registry, and uninstall acceptance |
| `scripts/invoke-windows-setup-standard-user-ci.ps1` | Added bootstrap mode, immutable script/candidate/Cosign custody, immediate and post-run hash checks, target-version propagation, and bounded diagnostics |
| `scripts/windows-disposable-standard-user-launcher.cs` | Keeps child arguments below and explicitly enforces `CreateProcessWithLogonW`'s 1,024-character command-line limit |
| `.github/workflows/pre-release-certification.yml` | Runs the corrected exact-candidate smoke with enough time for account/profile lifecycle cleanup |
| `.github/workflows/windows-native.yml` | Adds the parallel required public-bootstrap replay shard using permanent release assets or the sealed pre-publication fixture |
| `cli/tests/test_release_workflow_staged.py` | Locks the normal-PR replay job, fixture trust inputs, timeouts, cleanup roots, and aggregate dependency |
| `cli/tests/test_windows_powershell_upgrade_paths.py` | Replaces obsolete fake-home assertions with the native Setup layout and disposable-user contract |
| `cli/tests/test_windows_release_certification.py` | Locks release smoke delegation, authenticated assets, real profile roots, exact cleanup, and output/hash safeguards |
| `docs/WINDOWS-NATIVE-CI.md` | Documents public-bootstrap acceptance and the pre-publication/permanent fixture transition |
| `cmd/defenseclaw-setup/platform_windows.go`, `cmd/defenseclaw-setup/managed_process_windows_test.go` | Makes convergence PID-record inspection single-handle, race-safe, bounded, and fail-closed; adds deterministic Windows replacement/reparse/size regressions |
| `scripts/invoke-windows-setup-standard-user-ci.ps1`, `cli/tests/test_windows_release_certification.py` | Preserves bounded native Setup diagnostics from the disposable child before profile teardown and locks the custody/order contract |

## Breaking Changes

None. Public installer and release behavior are unchanged. This corrects the release test model and adds one parallel required Windows CI shard.

## Open Issues / Follow-ups

None.

## Test Plan

- Release-focused regression:

  ```bash
  uv run python -m pytest -q \
    cli/tests/test_connector_live_e2e_path_policy.py \
    cli/tests/test_install_docs_static.py \
    cli/tests/test_install_ps1.py \
    cli/tests/test_release_candidate.py \
    cli/tests/test_release_invariants.py \
    cli/tests/test_release_validation_strategy.py \
    cli/tests/test_release_workflow_staged.py \
    cli/tests/test_windows_powershell_upgrade_paths.py \
    cli/tests/test_windows_release_certification.py \
    cli/tests/test_windows_release_claims.py
  ```

  Observed: **394 passed, 36 skipped**.

- Workflow, formatting, and diff validation:

  ```bash
  actionlint \
    .github/workflows/pre-release-certification.yml \
    .github/workflows/windows-native.yml
  uv run ruff check \
    cli/tests/test_release_workflow_staged.py \
    cli/tests/test_windows_powershell_upgrade_paths.py \
    cli/tests/test_windows_release_certification.py
  uv run ruff format --check \
    cli/tests/test_release_workflow_staged.py \
    cli/tests/test_windows_powershell_upgrade_paths.py \
    cli/tests/test_windows_release_certification.py
  git diff --check
  ```

  Observed: all passed.

- PowerShell parser validation on connected macOS arm64 with official PowerShell 7.6.4 arm64:

  ```powershell
  [System.Management.Automation.Language.Parser]::ParseFile(
      $file, [ref]$tokens, [ref]$errors
  )
  ```

  Observed: zero parser errors for both modified PowerShell scripts.

- Sealed fixture inspection:

  ```bash
  gh run download 30063491006 \
    --repo cisco-ai-defense/defenseclaw \
    --name release-candidate-30063491006-1 \
    --dir <temporary-directory>
  ```

  Observed: the fixture contains Setup, Setup provenance, upgrade manifest, all four checksum proof files, and both Windows binary archives under `dist/`.

- Exact Windows execution:
  - [`Windows public install.ps1 acceptance`](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/30067074195/job/89400419512)
    passed against the authenticated sealed 0.8.7 candidate.
  - Observed child result: `bootstrap-acceptance passed under a disposable
    standard user` with `elevated=false`.
  - The job exercised checksum/provenance verification, native install,
    repeated bootstrap with unchanged installed hashes, exact launcher/gateway
    versions, user PATH/registry assertions, and complete uninstall.

- Final convergence-race validation on `e86b05061`:

  ```bash
  go test ./cmd/defenseclaw-setup
  GOOS=windows GOARCH=amd64 go vet ./cmd/defenseclaw-setup
  GOOS=windows GOARCH=amd64 go test -c ./cmd/defenseclaw-setup
  GOOS=windows GOARCH=arm64 go test -c ./cmd/defenseclaw-setup
  uv run --frozen python -m pytest -q \
    cli/tests/test_windows_release_certification.py \
    cli/tests/test_windows_powershell_upgrade_paths.py \
    cli/tests/test_release_workflow_staged.py
  ```

  Observed: Go tests, Windows amd64/arm64 cross-compilation, and vet passed; the focused Python suite reported **67 passed, 19 skipped**. PowerShell 7.6.4 arm64 parsed the changed wrapper with zero errors; Ruff and diff checks passed. The exact native Setup install, CLI/TUI smoke, repair, and uninstall lifecycle passed in [Windows Native CI job 89409687147](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/30069907843/job/89409687147).

- Failure-diagnostic custody on `acb68eaca`:

  ```bash
  actionlint \
    .github/workflows/release.yaml \
    .github/workflows/pre-release-certification.yml \
    .github/workflows/windows-native.yml
  uv run --frozen python -m pytest -q \
    cli/tests/test_windows_release_certification.py \
    cli/tests/test_release_workflow_staged.py \
    cli/tests/test_windows_powershell_upgrade_paths.py
  ```

  Observed: actionlint passed and the focused suite reported **67 passed, 19 skipped**. Release-native Setup and sealed-candidate bootstrap failures now upload bounded diagnostics before disposable-profile cleanup. Final-SHA GitHub checks are in progress.


- Review-feedback validation on `6031a133e`:

  ```bash
  go test ./cmd/defenseclaw-setup
  GOOS=windows GOARCH=amd64 go vet ./cmd/defenseclaw-setup
  GOOS=windows GOARCH=amd64 go test -c ./cmd/defenseclaw-setup
  GOOS=windows GOARCH=arm64 go test -c ./cmd/defenseclaw-setup
  ```

  Observed: local tests and vet passed and both Windows test binaries cross-compiled. Added native Windows coverage for a valid handle-bound read and directory rejection. All reparse-tagged PID records remain intentionally fail-closed because they are process-identity proofs, not user documents. Final-SHA native Windows execution is in progress.
