### PR TITLE
fix(gateway): avoid logging direct provider base URL

### DIFF
--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -2124,7 +2124,7 @@ func (p *GuardrailProxy) resolveConfiguredProvider(req *ChatRequest) LLMProvider
 	if instanceName != "" {
 		fmt.Fprintf(os.Stderr, "[guardrail] direct-provider mode: model=%q instance=%q\n", cfgModel, instanceName)
 	} else {
-		fmt.Fprintf(os.Stderr, "[guardrail] direct-provider mode: using configured model %q provider=%q base_url=%q\n", cfgModel, p.cfg.LLM.Provider, baseURL)
+		fmt.Fprintf(os.Stderr, "[guardrail] direct-provider mode: using configured model %q provider=%q\n", cfgModel, p.cfg.LLM.Provider)
 	}
 
 	registry, _, _ := providerRegistrySnapshot()

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -2044,6 +2044,30 @@ func TestHandlePassthrough_SSRFRejection(t *testing.T) {
 	}
 }
 
+func TestResolveConfiguredProviderDoesNotLogRawBaseURL(t *testing.T) {
+	proxy := newTestProxy(t, &mockProvider{}, newMockInspector(), "action")
+	proxy.cfg.Model = "openai/gpt-4"
+	proxy.cfg.LLM.Provider = "openai"
+	proxy.cfg.LLM.BaseURL = "https://user:secret@llm.example.test/v1?token=topsecret"
+
+	stderr := captureStderr(t, func() {
+		_ = proxy.resolveConfiguredProvider(&ChatRequest{
+			Model:        "gpt-4",
+			Messages:     []ChatMessage{{Role: "user", Content: "hi"}},
+			TargetAPIKey: "sk-test",
+		})
+	})
+	if strings.Contains(stderr, proxy.cfg.LLM.BaseURL) ||
+		strings.Contains(stderr, "secret") ||
+		strings.Contains(stderr, "topsecret") ||
+		strings.Contains(stderr, "base_url=") {
+		t.Fatalf("direct-provider log leaked configured base URL: %s", stderr)
+	}
+	if !strings.Contains(stderr, "direct-provider mode") {
+		t.Fatalf("direct-provider diagnostic was not emitted: %s", stderr)
+	}
+}
+
 func TestScrubURLSecrets(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Problem

Fixes #600.

The direct-provider chat path logged raw `llm.base_url` to stderr when no `llm.instance_name` was configured. A configured URL with userinfo or token-like query parameters could therefore be written into persisted gateway daemon logs.

## Solution

- Remove `base_url` from the direct-provider diagnostic line.
- Add a focused stderr regression test using a credentialed configured URL.

## Tests

```bash
go test ./internal/gateway -run TestResolveConfiguredProviderDoesNotLogRawBaseURL
```

Observed: `ok github.com/defenseclaw/defenseclaw/internal/gateway 1.641s`.

```bash
gofmt -w internal/gateway/proxy.go internal/gateway/proxy_test.go && git diff --check
```

Observed: passed with no output.

## CI Status

Pending: PR just opened; GitHub Actions has not completed yet.
