### PR TITLE
fix(ipc): parse untruncated BlockEvent.Reason for AVC wire body

### DIFF
--- a/internal/ipc/notifier_bridge.go
+++ b/internal/ipc/notifier_bridge.go
@@ -258,7 +258,7 @@ func composeManaged(o notifier.Observation) (string, string) {
 // naturally. When no signals are present the "signals" clause is
 // dropped entirely.
 func composeBlockManaged(o notifier.Observation) (string, string) {
-	cats, sigs := parseAIDReason(o.Notification.Body)
+	cats, sigs := parseAIDReason(reasonForParse(o))
 	return "DefenseClaw blocked the request",
 		blockLikeBody("The request was blocked for", cats, sigs, "")
 }
@@ -277,7 +277,7 @@ func composeWouldBlockManaged(o notifier.Observation) (string, string) {
 		titleVerb = "have asked about"
 	}
 	title := "DefenseClaw would " + titleVerb + " the request"
-	cats, sigs := parseAIDReason(o.Notification.Body)
+	cats, sigs := parseAIDReason(reasonForParse(o))
 	body := blockLikeBody(
 		"The request would have been "+verb+" for",
 		cats, sigs,
@@ -352,6 +352,39 @@ func blockLikeBody(prefix string, cats, sigs []string, trailer string) string {
 	}
 	body += trailer
 	return body
+}
+
+// reasonForParse returns the RICHEST available body string for the
+// managed-mode composer to hand to parseAIDReason. Prefers the typed
+// event's Reason field (BlockEvent.Reason / ApprovalEvent.Reason)
+// which is UNTRUNCATED, and falls back to o.Notification.Body which
+// the notifier package pre-truncates to 140 chars via truncateReason
+// for OS-toast readability.
+//
+// The truncation cap on the toast is deliberate — a macOS Notification
+// Center toast cannot render more than a few lines cleanly. But AVC's
+// Message History surface renders the wire body inline with far more
+// room, and truncation there lost the tail of long violation lists
+// like "Violence & Public Safety Threats" (visible as "Safety Th..."
+// before this fix). Feeding the untruncated Reason into parseAIDReason
+// closes that gap without changing the OS-toast body path.
+//
+// For CategoryApproval the ApprovalEvent.Reason isn't AID-shaped, but
+// keeping the same helper shape avoids caller-side type-switch churn;
+// parseAIDReason returns ([], []) on any non-AID prefix and every
+// caller already handles that case.
+func reasonForParse(o notifier.Observation) string {
+	switch ev := o.Event.(type) {
+	case notifier.BlockEvent:
+		if r := strings.TrimSpace(ev.Reason); r != "" {
+			return r
+		}
+	case notifier.ApprovalEvent:
+		if r := strings.TrimSpace(ev.Reason); r != "" {
+			return r
+		}
+	}
+	return o.Notification.Body
 }
 
 // parseAIDReason splits a "Cisco AI Defense: <mixed>" body into its

--- a/internal/ipc/notifier_bridge_test.go
+++ b/internal/ipc/notifier_bridge_test.go
@@ -363,6 +363,87 @@ func TestParseAIDReason(t *testing.T) {
 	}
 }
 
+// TestManagedCopy_UsesUntruncatedReason pins the contract that the
+// managed-mode composer parses the FULL BlockEvent.Reason rather than
+// the pre-truncated OS-toast body when constructing the AVC wire
+// notification. The notifier package caps toast bodies at 140 chars
+// with a trailing "..." (see truncateReason in
+// internal/gateway/notifier/notifier.go) so a long violation list
+// like the one below gets clipped mid-signal on the toast surface.
+// AVC's Message History pane, however, has room for the full text —
+// and clipping there loses information operators need to triage.
+// This test asserts the wire body includes the tail signal that
+// would be lost to truncation.
+func TestManagedCopy_UsesUntruncatedReason(t *testing.T) {
+	// Real production-shaped reason string from a QA-observed block:
+	// well over the notifier's 140-char toast cap, forces the
+	// truncator to clip "Public Safety Threats" mid-word into
+	// "Public Safety Th...". Kept intentionally long (>140) so the
+	// truncated-vs-untruncated distinction is materially observable.
+	fullReason := "Cisco AI Defense: SECURITY_VIOLATION, SAFETY_VIOLATION, PRIVACY_VIOLATION, POLICY_VIOLATION, Prompt Injection, PII, Malicious URL Detection, Violence & Public Safety Threats"
+	if len(fullReason) <= 140 {
+		t.Fatalf("test fixture must exceed the toast truncation cap of 140 chars; got %d", len(fullReason))
+	}
+	// Simulate the notifier layer's contribution: Notification.Body
+	// is truncated per truncateReason's 140-char cap; the BlockEvent
+	// carries the original untruncated Reason. reasonForParse must
+	// prefer BlockEvent.Reason so the AVC wire body sees every signal.
+	truncatedToastBody := fullReason[:137] + "..."
+
+	obs := notifier.Observation{
+		Category: notifier.CategoryBlock,
+		Notification: notify.Notification{
+			Title: "DefenseClaw blocked prompt",
+			Body:  truncatedToastBody,
+		},
+		Event: notifier.BlockEvent{Reason: fullReason},
+	}
+	got := recordFromObservation(obs, true)
+	if got == nil {
+		t.Fatal("expected non-nil record")
+	}
+	// Tail signal that would be dropped if the composer parsed the
+	// truncated toast body. Its presence proves reasonForParse pulled
+	// from BlockEvent.Reason.
+	if !strings.Contains(got.Body, "Violence & Public Safety Threats") {
+		t.Errorf("managed body dropped a tail signal (composer parsed truncated toast body?): %q", got.Body)
+	}
+	// Belt-and-braces: no truncation ellipsis leaked into the wire
+	// body. If this fires the composer regressed to reading
+	// Notification.Body directly.
+	if strings.Contains(got.Body, "...") {
+		t.Errorf("managed body contains a toast-truncation ellipsis; expected untruncated Reason: %q", got.Body)
+	}
+	// Every category token should appear as a humanized phrase.
+	for _, cat := range []string{"security violation", "safety violation", "privacy violation"} {
+		if !strings.Contains(got.Body, cat) {
+			t.Errorf("managed body missing category %q: %q", cat, got.Body)
+		}
+	}
+}
+
+// TestManagedCopy_FallsBackToNotificationBody proves reasonForParse
+// gracefully falls back to Notification.Body when the typed event
+// carries no Reason. Guards against a future refactor that made the
+// BlockEvent-preference branch too eager (e.g. returning "" on empty
+// Reason instead of falling through).
+func TestManagedCopy_FallsBackToNotificationBody(t *testing.T) {
+	obs := notifier.Observation{
+		Category: notifier.CategoryBlock,
+		Notification: notify.Notification{
+			Body: "Cisco AI Defense: SECURITY_VIOLATION",
+		},
+		Event: notifier.BlockEvent{Reason: ""}, // no event-level reason
+	}
+	got := recordFromObservation(obs, true)
+	if got == nil {
+		t.Fatal("expected non-nil record")
+	}
+	if !strings.Contains(got.Body, "security violation") {
+		t.Errorf("managed body should still parse the toast body when BlockEvent.Reason is empty: %q", got.Body)
+	}
+}
+
 // TestHumanizeAIDCategory covers both the curated-map path and the
 // mechanical fallback. A regression that dropped the fallback would
 // make new AID categories render as raw SCREAMING_SNAKE_CASE tokens


### PR DESCRIPTION
## Summary

AVC's Message History surface was rendering DefenseClaw block notifications with the signal list truncated mid-word, e.g. `... Violence & Public Safety Th...`. Root cause: the managed-mode composer was reading `o.Notification.Body`, which the notifier package pre-truncates to 140 chars for macOS toast readability. Toasts need that cap, but AVC's Message History pane has room for the full text — and clipping there loses signals operators need to triage a block.

Fix: introduce a small `reasonForParse(o)` helper in `internal/ipc/notifier_bridge.go` that prefers the untruncated `BlockEvent.Reason` / `ApprovalEvent.Reason` carried on `o.Event`, falling back to `o.Notification.Body` when the typed event has no reason set. `composeBlockManaged` and `composeWouldBlockManaged` now feed the untruncated string into `parseAIDReason`, so every category and signal from the original block decision reaches the wire `NotificationRecord`.

**No change to the OS-toast body path.** The 140-char cap in `truncateReason` (`internal/gateway/notifier/notifier.go:674`) is deliberate for macOS Notification Center — a toast can't render more than a few lines cleanly. That flow still consumes the capped body. Only the IPC wire body — which AVC's Message History renders — carries the full pre-truncation text.

## Repro / before-after

Before, with a real production-shaped block reason (>140 chars):
```
DefenseClaw blocked the request: The request was blocked for security violation, safety
violation, and custom guardrail profile violation and the following signals: Prompt
Injection, Violence & Public Safety Th...
```

After: the trailing `Public Safety Threats` signal survives on the AVC-side body. Toast still shows `Th...` (unchanged; correct given the toast cap).

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l $(git ls-files '*.go')` clean
- [x] `go test ./internal/ipc/... ./test/e2e/... ./internal/gateway/notifier/... -count=1` — pass (including two new regression tests below)
- [x] `TestManagedCopy_UsesUntruncatedReason` drives a >140-char AID reason through `recordFromObservation` with a truncated `Notification.Body` fixture and asserts the wire body includes the tail signal (`Violence & Public Safety Threats`). Also asserts no `...` leaks into the wire body — that would signal a regression to parsing the truncated body.
- [x] `TestManagedCopy_FallsBackToNotificationBody` proves the fallback branch still works when `BlockEvent.Reason` is empty (asset-policy blocks, hook-guardian denies) — the composer keeps parsing `Notification.Body`.
- [ ] Manual AVC verification on the QA host: block-bait prompt → toast body shows the truncated form (still readable), Message History pane shows the full category + signal list with no `...`.

## Reviewer notes

- **Blast radius:** two files, one new helper, three call-site changes. Non-block observations (`ApprovalEvent`, `ServiceStateEvent`) pick up the same helper trivially — the type switch in `reasonForParse` handles both. Unmanaged (`managedEnterprise=false`) path is untouched; it still goes through `composeBody`.
- **Wire compatibility:** no schema change. The `NotificationRecord.body` field's meaning is unchanged; the bytes it carries are just longer.
- **Non-managed clients:** `composeBody` (non-managed path) intentionally still uses the truncated `Notification.Body`. Widening that path would change customer-facing copy for unmanaged installs and is out of scope for this fix.
- **Secret sweep:** `redactSecretsInBody` still runs on the composed managed body (untouched); untruncated input doesn't bypass the paranoid credential-shape sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)