### PR TITLE
fix(installer): fall back to US-prod endpoint when env_config.json missing or malformed

### DIFF
--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -580,9 +580,25 @@ AID_ENDPOINT="$(resolve_aid_endpoint "${OVERRIDE_ENDPOINT}" "${CONFIG_FILE}")" |
 if (( _ep_rc == 3 )); then
   die "--override-endpoint must be an HTTPS bare origin (no userinfo, path, query, or fragment) — got: ${OVERRIDE_ENDPOINT}"
 elif (( _ep_rc == 2 )); then
-  die "--config-file ${CONFIG_FILE} is malformed: expected a JSON object with a valid \"cisco_ai_defense_endpoint\" URL. If AVC's drop is missing, pass --override-endpoint URL for adhoc testing."
+  # Malformed env_config.json (bad JSON, missing cisco_ai_defense_endpoint
+  # field, or bad URL shape). Fall through to the US-prod default so a
+  # stale, corrupt, or partially-written AVC drop can't brick the
+  # install. Loud WARN so operators can still find the misconfig in
+  # install.log. Trust-check failures (root ownership / write bits /
+  # symlinks) are a separate concern — those still die at line 576
+  # BEFORE this resolver runs, so tampering with the file's perms
+  # cannot piggyback onto this fallback.
+  warn "env_config.json at ${CONFIG_FILE} is malformed (expected a JSON object with a valid \"cisco_ai_defense_endpoint\" URL). Installing with default endpoint ${DEFAULT_AID_ENDPOINT}."
+  AID_ENDPOINT="${DEFAULT_AID_ENDPOINT}"
 elif (( _ep_rc == 1 )); then
-  die "env_config.json not found at ${CONFIG_FILE}; the AVC module must drop this file before installing, or pass --override-endpoint URL for adhoc testing."
+  # Missing env_config.json is expected under the AVC packaging
+  # sequencing where AVC installs DefenseClaw before its own bundle
+  # drops env_config.json. Fall through to the US-prod default so
+  # the daemon boots and starts serving traffic; a later env_config
+  # arrival will require a reinstall (or a manual endpoint edit) to
+  # take effect on this branch.
+  warn "env_config.json not found at ${CONFIG_FILE}. Installing with default endpoint ${DEFAULT_AID_ENDPOINT}."
+  AID_ENDPOINT="${DEFAULT_AID_ENDPOINT}"
 elif (( _ep_rc != 0 )); then
   die "could not resolve AI Defense endpoint (rc=${_ep_rc})"
 fi

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -15,6 +15,23 @@
 #   - parse strings, render YAML, run pure file I/O against caller-owned
 #     paths (e.g. a tmpdir under /tmp/dctest-XXXX).
 
+# ---- shared constants --------------------------------------------------
+
+# Default AI Defense inspect endpoint used when env_config.json is absent
+# or malformed at install time. Must match
+# viper.SetDefault("cisco_ai_defense.endpoint", ...) in
+# internal/config/config.go so the shell + Go sides agree on the
+# managed_enterprise fallback. The sync-guard test
+# t_default_aid_endpoint_matches_go under packaging/macos/tests/
+# catches drift on every CI run.
+#
+# Declared conditionally so tests that re-source this library across
+# cases (the harness sources it per-test-file) don't trip the bash
+# "readonly variable" error on the second source. First definition wins.
+if [[ -z "${DEFAULT_AID_ENDPOINT:-}" ]]; then
+  readonly DEFAULT_AID_ENDPOINT="https://us.api.inspect.aidefense.security.cisco.com"
+fi
+
 # ---- connector list parsing --------------------------------------------
 
 # parse_connectors LIST -> echoes one normalized connector per line.

--- a/packaging/macos/tests/test_arg_parsing.sh
+++ b/packaging/macos/tests/test_arg_parsing.sh
@@ -217,36 +217,64 @@ t_install_override_endpoint_rejects_path_query_fragment() {
   done
 }
 
-t_install_missing_config_file_exits_nonzero() {
-  # No --override-endpoint AND a --config-file path that doesn't
-  # exist → fail-closed with a message that names the missing file
-  # and points operators at either the AVC drop or --override-endpoint.
+t_install_missing_config_file_falls_back_to_default() {
+  # Missing env_config.json is expected under the AVC packaging
+  # sequencing where AVC installs DefenseClaw before its own bundle
+  # drops env_config.json. Installer must warn and continue with the
+  # US-prod default rather than fail-close — a dummy or absent file
+  # from a broken AVC drop must not brick the install.
+  #
+  # We can't drive install.sh far enough to complete a real install
+  # in this harness (it eventually needs root, a real binary, and
+  # launchctl). What we CAN prove is that the resolver branch no
+  # longer says "not found ... die" — it says "warn and default".
+  # Grep for the warn substring plus the default endpoint URL; the
+  # non-zero exit code comes from a downstream stage, not this branch.
   local case_dir; case_dir="$(mktest_tmp)"
   local out rc=0
   out="$("${INSTALL_SH}" --config-file "${case_dir}/does-not-exist.json" 2>&1)" || rc=$?
-  assert_status "${rc}" 1 "missing --config-file should exit non-zero"
-  assert_contains "${out}" "env_config.json not found at" "names the missing file"
-  assert_contains "${out}" "AVC module must drop this file" "explains next step"
-  assert_contains "${out}" "--override-endpoint URL for adhoc testing" \
-    "points operators at the adhoc-testing seam"
+  assert_contains "${out}" "env_config.json not found at" \
+    "installer names the missing env_config.json in the warn line"
+  assert_contains "${out}" "https://us.api.inspect.aidefense.security.cisco.com" \
+    "installer falls through to the US-prod default endpoint"
+  assert_contains "${out}" "Installing with default endpoint" \
+    "warn line spells out the fallback"
+  assert_not_contains "${out}" "AVC module must drop this file before installing" \
+    "old fail-fast message must be gone"
+  assert_not_contains "${out}" "the AVC module must drop this file" \
+    "old fail-fast message must be gone (variant)"
 }
 
-t_install_malformed_config_file_exits_nonzero() {
-  # Config file exists but is not a JSON object with a valid
-  # "cisco_ai_defense_endpoint" URL. Installer must die() before any
-  # mutation with a message that names the offending file. Skips the
-  # trust check via DC_INSTALLER_SKIP_ROOT_CHECK=1 (test fixtures under
-  # a tmpdir cannot be root-owned; the trust check is exercised end-
-  # to-end in the manual verification steps).
+t_install_malformed_config_file_falls_back_to_default() {
+  # A dummy / partially-written / stale env_config.json (bad JSON,
+  # missing field, or bad URL shape) must not brick the install either.
+  # The AVC installer sometimes drops a placeholder before its real
+  # bundle lands; treating that as fatal would create a support burden
+  # every time AVC's ordering slipped. Fall through to US-prod default
+  # with a WARN so operators can still find the misconfig in install.log.
+  #
+  # Trust-check failures (root ownership / write bits / symlinks) are
+  # separate and still hard-fail before the resolver runs — this
+  # relaxation applies only to the content branch.
   local case_dir; case_dir="$(mktest_tmp)"
   local cfg="${case_dir}/env_config.json"
   printf '{"cisco_ai_defense_endpoint":"not-a-url"}\n' >"${cfg}"
   local out rc=0
   out="$(DC_INSTALLER_SKIP_ROOT_CHECK=1 "${INSTALL_SH}" --config-file "${cfg}" 2>&1)" || rc=$?
-  assert_status "${rc}" 1 "malformed --config-file should exit non-zero"
-  assert_contains "${out}" "--config-file ${cfg} is malformed" "names the offending file"
-  assert_contains "${out}" "cisco_ai_defense_endpoint" \
-    "identifies the required field"
+  assert_contains "${out}" "is malformed" \
+    "installer names the malformed condition in the warn line"
+  assert_contains "${out}" "${cfg}" \
+    "warn line names the offending file"
+  assert_contains "${out}" "https://us.api.inspect.aidefense.security.cisco.com" \
+    "installer falls through to the US-prod default endpoint on malformed"
+  assert_contains "${out}" "Installing with default endpoint" \
+    "warn line spells out the fallback"
+  # The new contract prefixes the message with the WARN label; a
+  # regression to the die() path would emit an ERROR prefix instead.
+  # This is the cleanest signal of "did we go the warn+fallback way
+  # vs the old fail-hard way" without pinning brittle exact wording.
+  assert_contains "${out}" "WARN" \
+    "malformed env_config.json emits a WARN, not a fatal error"
 }
 
 t_install_config_file_trust_check_fires_on_world_writable() {
@@ -346,8 +374,8 @@ run_case "install --override-endpoint garbage rejected"  t_install_bad_override_
 run_case "install --override-endpoint plaintext http:// rejected" t_install_override_endpoint_rejects_plaintext_http
 run_case "install --override-endpoint userinfo rejected"          t_install_override_endpoint_rejects_userinfo
 run_case "install --override-endpoint path/query/fragment rejected" t_install_override_endpoint_rejects_path_query_fragment
-run_case "install missing --config-file rejected"        t_install_missing_config_file_exits_nonzero
-run_case "install malformed --config-file rejected"      t_install_malformed_config_file_exits_nonzero
+run_case "install missing --config-file falls back to US-prod default"     t_install_missing_config_file_falls_back_to_default
+run_case "install malformed --config-file falls back to US-prod default"   t_install_malformed_config_file_falls_back_to_default
 run_case "install world-writable --config-file rejected" t_install_config_file_trust_check_fires_on_world_writable
 run_case "install DEFAULT_CONFIG_FILE=AVC path"          t_install_default_config_file_path
 run_case "install DEFAULT_MODE=action (managed_enterprise)" t_install_default_mode_is_action

--- a/packaging/macos/tests/test_render_config.sh
+++ b/packaging/macos/tests/test_render_config.sh
@@ -100,6 +100,26 @@ t_redaction_pass_through_off() {
   assert_contains "${out}" "disable_redaction: true" "renderer emits redaction OFF when true is passed"
 }
 
+t_default_aid_endpoint_matches_go() {
+  # Sync guard: the shell-side DEFAULT_AID_ENDPOINT constant in
+  # installer_lib.sh must match the Go viper default in
+  # internal/config/config.go. install.sh's rc-1 / rc-2 fallback
+  # renders this URL into config.yaml, and the daemon on boot also
+  # falls back to the viper default when config.yaml omits the
+  # cisco_ai_defense block — the two must agree or a manually-edited
+  # config that drops the block would silently swap the endpoint. If
+  # either side moves the URL, this test fails at CI time so drift is
+  # caught immediately.
+  local shell_default go_default
+  shell_default="${DEFAULT_AID_ENDPOINT}"
+  go_default="$(grep -oE 'viper\.SetDefault\("cisco_ai_defense\.endpoint",[[:space:]]*"[^"]+"' \
+    "${REPO_ROOT}/internal/config/config.go" \
+    | head -1 \
+    | sed -E 's/.*"cisco_ai_defense\.endpoint",[[:space:]]*"([^"]+)".*/\1/')"
+  assert_eq "${shell_default}" "${go_default}" \
+    "DEFAULT_AID_ENDPOINT in installer_lib.sh matches viper default in config.go"
+}
+
 t_yaml_parses() {
   # Best-effort: if python3 + a yaml module exist, parse the output to
   # catch indentation regressions.
@@ -350,4 +370,5 @@ run_case "_read_json_field reads AVC env_config.json shape"       t_read_json_fi
 run_case "otel block enabled for managed AID sink"               t_otel_block_enabled_for_managed_sink
 run_case "ai_discovery enabled for endpoint inventory"           t_ai_discovery_enabled_for_endpoint_inventory
 run_case "resolve_aid_endpoint precedence + validation"           t_resolve_aid_endpoint_precedence
+run_case "DEFAULT_AID_ENDPOINT matches Go viper default"          t_default_aid_endpoint_matches_go
 run_case "rendered YAML parses"     t_yaml_parses


### PR DESCRIPTION
## Summary

The managed_enterprise installer previously hard-failed when the AVC-authored `env_config.json` was missing (`resolve_aid_endpoint` rc-1) or malformed (rc-2). Both are real conditions on customer endpoints — AVC's packaging sequencing sometimes runs DefenseClaw's postinstall before its own env_config drop lands, and stale / partially-written files linger from earlier install attempts. A dummy or bad file must not brick DefenseClaw install.

**Change both branches to warn + fall back to the US-prod default** (`https://us.api.inspect.aidefense.security.cisco.com`), matching the Go daemon's viper default at [internal/config/config.go:3176](internal/config/config.go#L3176). Operators still see the misconfig in `install.log` via the WARN line so a real problem isn't hidden, but the install completes and the daemon boots against a working endpoint.

`--override-endpoint` malformed (rc-3) still hard-fails — that's operator-supplied input and a typo there should stop. The trust check (`_assert_trusted_env_config_file_or_die`) is also unchanged and still hard-fails on ownership / write-bit / symlink violations, so tampering with the file's perms cannot piggyback onto the content-level fallback.

## What changes

| Path | Change |
|---|---|
| `packaging/macos/lib/installer_lib.sh` | Add `readonly DEFAULT_AID_ENDPOINT` shell constant pinned to the Go viper default; guarded with an unset-check so the test harness (per-file source) doesn't trip readonly-reassignment |
| `packaging/macos/install.sh` | rc-1 and rc-2 branches: `die` → `warn` + `AID_ENDPOINT=$DEFAULT_AID_ENDPOINT`; rc-3 unchanged |
| `packaging/macos/tests/test_arg_parsing.sh` | Two existing test cases renamed and rewritten to assert the new WARN+fallback contract |
| `packaging/macos/tests/test_render_config.sh` | New sync-guard test `t_default_aid_endpoint_matches_go` — greps the Go viper default and asserts equality with the shell `DEFAULT_AID_ENDPOINT`, so CI catches drift if either side moves the URL |

## Test plan

- [x] `bash packaging/macos/tests/run_tests.sh` — 136 passed (was 135; the +1 is the new sync-guard case)
- [x] `pytest cli/tests/test_enterprise_packaging.py` — 8 passed
- [x] `go build ./...` clean
- [x] `gofmt -l $(git ls-files '*.go')` clean
- [ ] Manual on the QA host: (a) install without env_config.json → daemon boots on US-prod; (b) install with dummy `{"cisco_ai_defense_endpoint":"garbage"}` → warn + install completes; (c) install with a valid env_config.json → unchanged, the file's URL wins; (d) `--override-endpoint http://not-a-url` still hard-fails at rc-3.

## Reviewer notes

- **Blast radius:** four files, all in `packaging/macos/`. Zero Go changes, zero daemon changes, zero proto changes.
- **Failure surface preserved:** `--override-endpoint` malformed still dies (operator input). Trust check still dies (ownership tampering). Only content-level malformed / missing on the AVC drop path falls back.
- **Wire-level effect:** the endpoint that gets rendered into `config.yaml` in the fallback case is byte-identical to what the daemon would use if you deleted the `cisco_ai_defense:` block entirely (Go viper default). This is exactly the "silently defaults to prod" behavior that customers expect when AVC hasn't dropped a file yet.
- **Sync-guard test rationale:** the fallback default lives in two places now — shell (`installer_lib.sh`) and Go (`config.go`). If either moves the URL and the other doesn't follow, the resulting behavior split (installer bakes URL A into config.yaml, daemon's viper default is URL B) would be subtle. The greps-config.go-at-CI-time test fails fast when either side drifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)