### PR TITLE
fix(upgrade): clarify POSIX hard-cut recovery

### DIFF
--- a/cli/tests/test_upgrade_staged_resolver.py
+++ b/cli/tests/test_upgrade_staged_resolver.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -598,6 +599,46 @@ def test_manual_hard_cut_artifacts_over_v7_state_refuse_before_release_download(
     assert not curl_log.exists()
 
 
+def test_stale_pre_cut_cursor_without_recovery_journal_fails_closed(resolver_env) -> None:
+    env, mutation_log, curl_log = resolver_env("0.8.6")
+    data_home = Path(env["DEFENSECLAW_HOME"])
+    data_home.mkdir()
+    managed_python = data_home / ".venv" / "bin" / "python"
+    managed_python.parent.mkdir(parents=True)
+    _write_executable(
+        managed_python,
+        f'#!/bin/sh\nexec {shlex.quote(sys.executable)} "$@"\n',
+    )
+    (data_home / "config.yaml").write_text(
+        f"config_version: 8\ndata_dir: {json.dumps(str(data_home))}\n",
+        encoding="utf-8",
+    )
+    (data_home / ".migration_state.json").write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "package_version": "0.8.1",
+                "applied": ["0.8.0"],
+                "applied_at": {"0.8.0": "2026-07-24T00:00:00Z"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run(env, "--version", "0.8.7", "--plan")
+
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "config-v8 migration state is absent or invalid and no recoverable journal is active" in output
+    assert "private phase-two journal remains present" in output
+    assert "A receipt or version string alone is not rollback authority" in output
+    assert "Do not mark 0.8.5 applied or copy individual artifacts" in output
+    assert "No changes were made" in output
+    assert not mutation_log.exists()
+    assert not curl_log.exists()
+
+
 def test_bridge_source_refreshes_before_direct_hard_cut(resolver_env) -> None:
     env, mutation_log, curl_log = resolver_env("0.8.4")
 
@@ -630,7 +671,7 @@ def test_bridge_source_stages_hard_cut_before_post_cut_target(resolver_env, targ
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX release-owned resolver")
 def test_modern_resolver_bootstraps_cosign_before_mutation(resolver_env) -> None:
-    env, mutation_log, _curl_log = resolver_env("0.8.3")
+    env, mutation_log, _curl_log = resolver_env("0.8.1")
     fake_bin = Path(env["PATH"].split(os.pathsep, 1)[0])
     (fake_bin / "cosign").unlink()
     controlled_system_bin = fake_bin.parent / "system-bin"
@@ -653,6 +694,7 @@ def test_modern_resolver_bootstraps_cosign_before_mutation(resolver_env) -> None
     assert result.returncode == 0, output
     assert "Cosign was not found; authenticating temporary Cosign 2.6.3" in output
     assert "Temporary Cosign verifier authenticated" in output
+    assert "0.8.1 → 0.8.4 bridge → fresh controller → 0.8.5 → 0.8.7" in output
     assert not mutation_log.exists()
 
 

--- a/cli/tests/test_upgrade_staged_resolver.py
+++ b/cli/tests/test_upgrade_staged_resolver.py
@@ -633,6 +633,11 @@ def test_stale_pre_cut_cursor_without_recovery_journal_fails_closed(resolver_env
     assert "config-v8 migration state is absent or invalid and no recoverable journal is active" in output
     assert "private phase-two journal remains present" in output
     assert "A receipt or version string alone is not rollback authority" in output
+    assert "same resolver-owned pre-hard-cut backup" in output
+    assert (
+        "If no complete resolver-owned backup exists, preserve the installation and contact DefenseClaw support"
+        in output
+    )
     assert "Do not mark 0.8.5 applied or copy individual artifacts" in output
     assert "No changes were made" in output
     assert not mutation_log.exists()

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -4045,7 +4045,9 @@ PY
     if [[ "${hard_cut_state}" != "valid" ]]; then
         die "CLI and gateway report hard-cut version ${CURRENT_VERSION}, but config-v8 migration state is absent or invalid and no recoverable journal is active. No changes were made.
   Unsupported manual overwrite detected.
-  Recovery path: restore the exact 0.8.4 CLI, gateway, config, environment, and migration cursor from the pre-hard-cut backup, verify 0.8.4 health, then run this release-owned resolver without --version."
+  Authenticated interrupted hard-cut transactions are recovered before this check only while their private phase-two journal remains present. A receipt or version string alone is not rollback authority.
+  Recovery path: restore the exact 0.8.4 CLI, gateway, config, environment, and migration cursor together from the same resolver-owned pre-hard-cut backup, verify 0.8.4 health, then run this release-owned resolver without --version.
+  If no complete resolver-owned backup exists, preserve the installation and contact DefenseClaw support. Do not mark 0.8.5 applied or copy individual artifacts."
     fi
 fi
 


### PR DESCRIPTION
## Problem

The immutable DefenseClaw 0.8.1 built-in upgrader fails closed when Cosign is absent, while a later partial/manual artifact overwrite can leave post-hard-cut CLI and gateway versions over stale migration state. Operators need the current release-owned staged path and precise guidance that does not mistake version strings, receipts, or cursor edits for rollback authority.

## Current Situation

Current `main` already authenticates a pinned temporary Cosign and resolves supported POSIX sources through `source -> 0.8.4 -> fresh controller -> 0.8.5 -> final`. It also recovers an authenticated interrupted hard cut before coherence checks when the durable private phase-two journal remains present.

Without that journal, a coherent post-hard-cut CLI/gateway pair over missing or stale `0.8.5` migration state correctly fails closed. The existing message did not explain why a receipt/version string is insufficient or what to do when no complete resolver-owned backup exists. The exact 0.8.1/no-Cosign and 0.8.6/stale-cursor incident shapes lacked focused regression coverage.

## Solution

Clarify the POSIX no-journal refusal and protect the complete recovery contract with exact fixtures. The message now states that only the private phase-two journal authorizes interrupted hard-cut recovery, directs restoration of one complete resolver-owned 0.8.4 backup, preserves the installation and escalates to support when that backup is unavailable, and forbids manually marking `0.8.5` applied or copying individual artifacts.

Security invariants remain unchanged: Sigstore identity, checksum verification, pinned temporary-Cosign digest checks, staged bridge selection, and the modern-release prohibition on `--allow-unverified` are untouched. Windows behavior and packaging are unchanged.

## Architecture Diagram

N/A. This PR changes one fail-closed POSIX diagnostic and its regression fixtures; it does not change the upgrade architecture or recovery authority.

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `scripts/upgrade.sh` | Explains the phase-two journal authority, complete-backup recovery, support escalation, and prohibited manual repairs. |
| `cli/tests/test_upgrade_staged_resolver.py` | Covers the exact 0.8.1/no-Cosign staged route and 0.8.6/stale-cursor no-journal refusal, including the full operator guidance and zero-download/zero-mutation assertions. |

## Breaking Changes

None.

## Open Issues / Follow-ups

None.

## Test Plan

- `PYTHONPATH=. uv run --frozen pytest -q cli/tests/test_upgrade_staged_resolver.py cli/tests/test_upgrade_smoke_static.py cli/tests/test_release_workflow_staged.py cli/tests/test_resolve_upgrade_baselines.py` — 136 passed, 1 skipped (independent overseer validation).
- `uv run --frozen pytest -q cli/tests/test_upgrade_staged_resolver.py cli/tests/test_upgrade_smoke_static.py::test_posix_resolver_bootstraps_recovery_under_fixed_mutator_lease cli/tests/test_upgrade_smoke_static.py::test_posix_terminal_journal_is_cleared_only_after_exact_state_proof cli/tests/test_cmd_upgrade.py::TestUpgradeManifest::test_v8_installed_state_requires_config_and_cursor_coherence` — 23 passed.
- `uv run --frozen pytest -q cli/tests/test_upgrade_staged_resolver.py::test_stale_pre_cut_cursor_without_recovery_journal_fails_closed` — 1 passed after review assertion update.
- `uv run --frozen ruff check cli/tests/test_upgrade_staged_resolver.py` — passed.
- `uv run --frozen ruff format --check cli/tests/test_upgrade_staged_resolver.py` — passed.
- `bash -n scripts/upgrade.sh` — passed.
- `git diff --check` — passed.