### PR TITLE
Fix Windows skill scan audit admission

### DIFF
--- a/cli/defenseclaw/scanner/rulepack.py
+++ b/cli/defenseclaw/scanner/rulepack.py
@@ -388,6 +388,12 @@ class RulePackOverlayScanner:
         existing = {(f.id, f.location) for f in result.findings}
         for f in new:
             if (f.id, f.location) not in existing:
+                # Canonical v8 attributes nested findings to the parent scan
+                # producer; retain the overlay engine as finding metadata.
+                provenance = f"analyzer:{f.scanner}" if f.scanner else ""
+                if provenance and provenance not in f.tags:
+                    f.tags.append(provenance)
+                f.scanner = result.scanner
                 result.findings.append(f)
 
 

--- a/cli/defenseclaw/scanner/skill.py
+++ b/cli/defenseclaw/scanner/skill.py
@@ -224,6 +224,7 @@ class SkillScannerWrapper:
 
     def _convert(self, sdk_result: object, target: str, elapsed: float) -> ScanResult:
         """Convert SDK ScanResult → DefenseClaw ScanResult."""
+        scanner_name = self.name()
         findings: list[Finding] = []
         for sf in getattr(sdk_result, "findings", []):
             location = getattr(sf, "file_path", "") or ""
@@ -236,6 +237,9 @@ class SkillScannerWrapper:
             if category:
                 cat_name = category.name if hasattr(category, "name") else str(category)
                 tags.append(cat_name)
+            analyzer = str(getattr(sf, "analyzer", "") or "")
+            if analyzer:
+                tags.append(f"analyzer:{analyzer}")
 
             severity = getattr(sf, "severity", None)
             sev_str = severity.name if hasattr(severity, "name") else str(severity)
@@ -247,12 +251,14 @@ class SkillScannerWrapper:
                 description=getattr(sf, "description", ""),
                 location=location,
                 remediation=getattr(sf, "remediation", "") or "",
-                scanner=getattr(sf, "analyzer", "") or "skill-scanner",
+                # Canonical finding identity names the producer, not the
+                # upstream SDK's internal analyzer, which remains in tags.
+                scanner=scanner_name,
                 tags=tags,
             ))
 
         return ScanResult(
-            scanner="skill-scanner",
+            scanner=scanner_name,
             target=target,
             timestamp=datetime.now(timezone.utc),
             findings=findings,

--- a/cli/tests/test_scanner_rulepack.py
+++ b/cli/tests/test_scanner_rulepack.py
@@ -244,6 +244,9 @@ class TestMaybeWrap(unittest.TestCase):
         ids = {f.id for f in result.findings}
         self.assertIn("EXISTING", ids)  # inner finding preserved
         self.assertIn("SEC-ANTHROPIC", ids)  # overlay finding added
+        overlay = next(f for f in result.findings if f.id == "SEC-ANTHROPIC")
+        self.assertEqual(overlay.scanner, result.scanner)
+        self.assertIn("analyzer:rule-pack", overlay.tags)
 
     def test_wrap_overlays_mcp_server_text(self):
         self.app.cfg.guardrail.rule_pack_dir = self.pack_dir

--- a/cli/tests/test_scanners.py
+++ b/cli/tests/test_scanners.py
@@ -393,9 +393,11 @@ class TestSkillScannerWrapper(unittest.TestCase):
 
     def test_convert_with_findings(self):
         from defenseclaw.config import SkillScannerConfig
+        from defenseclaw.logger import Logger
         from defenseclaw.scanner.skill import SkillScannerWrapper
 
         s = SkillScannerWrapper(SkillScannerConfig())
+        target = r"C:\disposable-codex-home\skills\dc-test-benign"
 
         finding = MagicMock()
         finding.id = "rule-001"
@@ -414,11 +416,28 @@ class TestSkillScannerWrapper(unittest.TestCase):
         sdk_result = MagicMock()
         sdk_result.findings = [finding]
 
-        result = s._convert(sdk_result, "/tmp/skill", 0.5)
+        result = s._convert(sdk_result, target, 0.5)
         self.assertEqual(len(result.findings), 1)
+        self.assertEqual(result.target, target)
         self.assertEqual(result.findings[0].severity, "HIGH")
         self.assertEqual(result.findings[0].location, "main.py:42")
+        self.assertEqual(result.findings[0].scanner, result.scanner)
+        self.assertEqual(result.findings[0].scanner, "skill-scanner")
         self.assertIn("injection", result.findings[0].tags)
+        self.assertIn("analyzer:static", result.findings[0].tags)
+
+        recorder = MagicMock()
+        Logger(recorder).log_scan(result)
+        payload = recorder.emit_cli_observability.call_args.args[0]
+        self.assertEqual(payload["scan"]["target"], target)
+        self.assertEqual(
+            payload["scan"]["findings"][0]["scanner"],
+            payload["scan"]["scanner"],
+        )
+        self.assertIn(
+            "analyzer:static",
+            payload["scan"]["findings"][0]["tags"],
+        )
 
     def test_scan_raises_system_exit_on_import_error(self):
         import builtins

--- a/internal/gateway/cli_observability_v8_test.go
+++ b/internal/gateway/cli_observability_v8_test.go
@@ -65,6 +65,73 @@ func TestCLIObservabilityV8RequestBoundary(t *testing.T) {
 	}
 }
 
+func TestCLIObservabilityV8SkillFindingScannerContract(t *testing.T) {
+	fixture, api, capture := newCLIObservabilityV8Fixture(t)
+	const target = `C:\disposable-codex-home\skills\dc-test-benign`
+	const canonical = `{"kind":"scan","run_id":"skill-python-run","scan":{"scanner":"skill-scanner","target":"C:\\disposable-codex-home\\skills\\dc-test-benign","timestamp":"2026-07-24T16:00:00Z","findings":[{"id":"MANIFEST_MISSING_LICENSE_c5ae9be793","severity":"INFO","title":"Skill does not specify a license","description":"","location":"SKILL.md","remediation":"","scanner":"skill-scanner","tags":["analyzer:static"]}],"duration_ms":125}}`
+	const leakedAnalyzer = `{"kind":"scan","run_id":"malformed-skill-run","scan":{"scanner":"skill-scanner","target":"C:\\disposable-codex-home\\skills\\dc-test-benign","timestamp":"2026-07-24T16:00:00Z","findings":[{"id":"MANIFEST_MISSING_LICENSE_c5ae9be793","severity":"INFO","title":"Skill does not specify a license","description":"","location":"SKILL.md","remediation":"","scanner":"static","tags":[]}],"duration_ms":125}}`
+
+	request := httptest.NewRequest(http.MethodPost, cliObservabilityV8Path, strings.NewReader(canonical))
+	response := httptest.NewRecorder()
+	api.handleCLIObservabilityV8(response, request)
+	if response.Code != http.StatusNoContent || response.Body.Len() != 0 {
+		t.Fatalf("canonical skill payload status=%d response=%q", response.Code, response.Body.String())
+	}
+
+	database, err := sql.Open("sqlite", fixture.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	for _, check := range []struct {
+		query string
+		args  []any
+		want  int
+	}{
+		{
+			query: `SELECT COUNT(*) FROM scan_results WHERE run_id = 'skill-python-run' AND scanner = 'skill-scanner' AND target = ?`,
+			args:  []any{target},
+			want:  1,
+		},
+		{
+			query: `SELECT COUNT(*) FROM scan_findings WHERE run_id = 'skill-python-run' AND scanner = 'skill-scanner'`,
+			want:  1,
+		},
+		{
+			query: `SELECT COUNT(*) FROM audit_events WHERE run_id = 'skill-python-run' AND action IN ('scan', 'scan-finding')`,
+			want:  2,
+		},
+	} {
+		var count int
+		if err := database.QueryRow(check.query, check.args...).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != check.want {
+			t.Fatalf("query=%q rows=%d want=%d", check.query, count, check.want)
+		}
+	}
+	if len(capture.traces) != 1 {
+		t.Fatalf("asset scan traces=%d, want one", len(capture.traces))
+	}
+
+	request = httptest.NewRequest(http.MethodPost, cliObservabilityV8Path, strings.NewReader(leakedAnalyzer))
+	response = httptest.NewRecorder()
+	api.handleCLIObservabilityV8(response, request)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("malformed skill payload status=%d response=%q", response.Code, response.Body.String())
+	}
+	for _, table := range []string{"scan_results", "scan_findings", "audit_events"} {
+		var count int
+		query := "SELECT COUNT(*) FROM " + table + " WHERE run_id = 'malformed-skill-run'"
+		if err := database.QueryRow(query).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != 0 {
+			t.Fatalf("%s rows=%d after rejected skill payload", table, count)
+		}
+	}
+}
+
 func TestCLIObservabilityV8RejectsMalformedScanBeforeForensicPersistence(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## User-visible problem

On the official DefenseClaw 0.8.7 Windows installation, `skill scan` completed analysis but failed while recording the result. The canonical observability POST returned HTTP 400, the CLI raised `CanonicalObservabilityError`, exited 1, emitted a traceback instead of the JSON verdict, and created no scan/audit row.

## Independent reproduction

I independently reproduced this against the official 0.8.7 CLI and gateway (`57393d05a8fdbe4db86776d9108606939f5529e7`) using a disposable Codex home and the benign `dc-test-benign` fixture:

```powershell
defenseclaw skill scan dc-test-benign `
  --path "C:\disposable-codex-home\skills\dc-test-benign" `
  --connector codex `
  --json
```

The scan reached `app.logger.log_scan(result)`, then POST `/api/v1/observability/cli` returned 400 (`{"error":"invalid canonical observability request"}`). Exit code was 1 and scan/audit row counts did not change. A findings-bearing plugin scan against the same gateway exited 0 and persisted its scan, finding, and audit rows, proving the endpoint and gateway were generally working.

## Exact root cause

`SkillScannerWrapper._convert()` copied the upstream SDK analyzer name (for the benign fixture, `static`) into each nested DefenseClaw `Finding.scanner`, while the parent `ScanResult.scanner` was `skill-scanner`. Canonical Observability v8 requires a nonempty nested finding scanner to equal its parent scan scanner, so the gateway correctly rejected the malformed producer payload before persistence.

The real command can also wrap the skill scanner with `RulePackOverlayScanner`; that adapter previously appended `scanner="rule-pack"` findings unchanged and could recreate the same contract violation. Plugin scan worked because its adapter already emits `plugin-scanner` for both parent and nested findings.

There is no OS-conditional code in this path. This is a producer-contract bug exposed by the Windows installer reproduction, not evidence of a Windows-only defect.

## Minimal fix

- Attribute SDK findings to the canonical `skill-scanner` producer and retain the SDK analyzer as an `analyzer:<name>` tag.
- When the rule-pack overlay appends a finding, bind it to the parent scan producer and retain `analyzer:rule-pack` provenance.
- Add focused Python producer/logger and overlay contracts plus a gateway canonical-positive/malformed-negative persistence contract using the Windows path.

No gateway admission rule, schema, logger behavior, installer, or release surface changed.

## Security invariants preserved

Canonical Observability v8 admission remains strict and fail-closed. The CLI still fails if the event is not admitted; audit errors are not swallowed. Connector identity, timestamps, run IDs, content hashes, finding/verdict data, provenance, request authentication/bounds, and audit linkage remain intact. The gateway still rejects mismatched nested scanner identities before writing scan, finding, or audit rows.

## Validation

- Focused Python scanner/logger/rule-pack/skill UX contracts: **101 passed**.
- Ruff lint: passed for all four changed Python files.
- `gofmt -d` and `git diff --check`: clean.
- Targeted gateway test compiles and covers canonical admission/persistence plus malformed rejection/zero persistence. Its local Windows persistence fixture is stopped before admission by the repository's strict ACL guard for this worktree; the equivalent isolated source-gateway HTTP proof below passed, and CI is expected to execute the committed fixture in its protected environment.
- Isolated malformed payload: HTTP **400**, with **0** `scan_results`, `scan_findings`, and `audit_events` rows.
- Plugin control: exit **0**, six findings all attributed to `plugin-scanner`, with **1** scan row, **6** finding rows, and **7** audit rows.
- Final CodeGuard scan and manual diff review: no valid finding in the changed production logic; reports were pre-existing documentation/test literals.

## Windows proof

Against the isolated fixed source CLI and source gateway, the original user-facing command with an explicit disposable Windows Codex skill path and `--connector codex --json` exited **0** with no stderr. It emitted one INFO finding with parent and nested `skill-scanner`, persisted verdict `clean`/exit code 0, wrote one scan row and one finding row, and emitted both `scan.completed` and `finding.observed` audit events with matching content hash.

## Remaining risk

The patch intentionally changes only the two adapters in the reproduced skill-scan composition. No production gateway code changed. The committed Go persistence contract could not execute locally because the repository's Windows ACL guard rejected the test fixture directory before the handler ran; initial CI should confirm it in the normal protected runner environment.

## Manual Windows retest

```powershell
defenseclaw skill scan dc-test-benign `
  --path "C:\Users\kevin\.codex\skills\dc-test-benign" `
  --connector codex `
  --json
```

Expected: valid JSON, benign/clean result, exit code 0, and matching scan/finding audit evidence.