### PR TITLE
fix(release): recover stranded upgrades and add signed rescue channel

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 # Linux, macOS, and Windows runners. Keep their checkout representation stable.
 scripts/upgrade.sh text eol=lf
 scripts/upgrade.ps1 text eol=lf
+scripts/defenseclaw-rescue.sh text eol=lf
 cli/defenseclaw/install_publish.py text eol=lf
 schemas/config/v8/defenseclaw-config.schema.json text eol=lf
 schemas/config/v8/reference/observability.yaml text eol=lf

--- a/.github/workflows/pre-release-certification.yml
+++ b/.github/workflows/pre-release-certification.yml
@@ -116,6 +116,10 @@ jobs:
           RELEASE_TAG: ${{ inputs.version }}
           RELEASE_COMMIT: ${{ inputs.commit }}
           UPGRADE_SMOKE_SKIP_SOURCE_CONTRACTS: "1"
+          # The newest authenticated source also exercises the two field
+          # states that stranded real 0.8.6 hosts: a missing hard-cut cursor
+          # and an explicitly recovered corrupt local audit store.
+          UPGRADE_SMOKE_FIELD_RECOVERY_CASES: ${{ matrix.baseline == fromJSON(inputs.baselines)[0] && '1' || '0' }}
         run: |
           set -euo pipefail
           test "$RUNNER_ARCH" = "${{ matrix.platform.runner_arch }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -952,6 +952,7 @@ jobs:
     environment: release
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -1084,3 +1085,14 @@ jobs:
             --commit "$RELEASE_COMMIT" \
             --candidate-root release-candidate
           echo "Release $RELEASE_TAG published from tested commit $RELEASE_COMMIT"
+
+      # The tagged release remains immutable. Only after its exact remote
+      # custody is proved may the keyless-signed, fast-forward stable pointer
+      # advance to that tag.
+      - name: Sign and advance authenticated stable channel
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.release-preflight.outputs.tag }}
+          RELEASE_COMMIT: ${{ needs.release-preflight.outputs.commit }}
+          RELEASE_CHECKSUMS: ${{ github.workspace }}/release-candidate/dist/checksums.txt
+        run: scripts/publish-release-channel.sh

--- a/cli/defenseclaw/commands/cmd_upgrade.py
+++ b/cli/defenseclaw/commands/cmd_upgrade.py
@@ -39,6 +39,7 @@ import platform
 import re
 import secrets
 import shutil
+import sqlite3
 import stat
 import subprocess
 import sys
@@ -184,6 +185,18 @@ _V8_RECOVERY_ENTRY_RE = re.compile(r"^observability-v8-[0-9a-f]{32}$")
 _MAX_PREEXISTING_V8_RECOVERY_ENTRIES = 256
 _MAX_V8_RECOVERY_FILE_BYTES = 64 * 1024 * 1024
 _MAX_HARD_CUT_MIGRATION_SOURCE_BYTES = 4 * 1024 * 1024
+_AUDIT_DATABASE_FILENAME = "audit.db"
+_AUDIT_DATABASE_RECOVERY_DIRECTORY = "audit-corrupt"
+_AUDIT_DATABASE_RECOVERY_MARKER = ".audit-recovery.json"
+_AUDIT_DATABASE_RECOVERY_FILES = (
+    "audit.db-wal",
+    "audit.db-shm",
+    "audit.db-journal",
+    "audit.db",
+)
+_MAX_AUDIT_DATABASE_RECOVERY_MARKER_BYTES = 64 * 1024
+_AUDIT_DATABASE_PREFLIGHT_TIMEOUT_SECONDS = 5.0
+_AUDIT_DATABASE_MUTATION_TIMEOUT_SECONDS = 30.0
 _HELD_PHASE_TWO_MUTATOR_LEASE: object | None = None
 _PHASE_TWO_MUTATOR_SURVIVED_TIMEOUT = False
 
@@ -290,6 +303,21 @@ class _HardCutRollbackPlan:
     )
 
 
+@dataclass(frozen=True)
+class _InstalledStateRecoveryPlan:
+    """Read-only preflight result consumed only after backup and quiescence."""
+
+    replay_observability_v8: bool = False
+    reconstruct_pre_hard_cut_cursor: bool = False
+    recover_corrupt_audit: bool = False
+    audit_db_path: str | None = None
+    audit_db_identity: tuple[int, int] | None = None
+
+    @property
+    def required(self) -> bool:
+        return self.replay_observability_v8 or self.reconstruct_pre_hard_cut_cursor or self.recover_corrupt_audit
+
+
 _INSTALLED_MIGRATION_SCRIPT = """
 import inspect
 import json
@@ -364,6 +392,16 @@ class _LocalBundleUpgradeInvocationError(RuntimeError):
 @click.option("--version", "target_version", default=None, help="Upgrade to a specific release version (e.g. 0.3.1)")
 @click.option("--health-timeout", default=60, type=int, help="Seconds to wait for gateway health after restart")
 @click.option(
+    "--recover-corrupt-audit",
+    is_flag=True,
+    default=False,
+    help=(
+        "After corruption is proven by a bounded read-only SQLite check, "
+        "preserve audit.db and its sidecars in the upgrade backup and "
+        "activate a fresh local audit store."
+    ),
+)
+@click.option(
     "--allow-unverified",
     is_flag=True,
     default=False,
@@ -380,6 +418,7 @@ def upgrade(
     yes: bool,
     target_version: str | None,
     health_timeout: int,
+    recover_corrupt_audit: bool,
     allow_unverified: bool,
 ) -> None:
     """Upgrade DefenseClaw to the latest version.
@@ -435,15 +474,6 @@ def upgrade(
     ux.kv("Installed version", current_version, indent="  ", key_width=22)
     ux.kv("Target version", target_version, indent="  ", key_width=22)
 
-    # ── Same-version repair ──────────────────────────────────────────────────
-
-    if target_version == current_version:
-        click.echo()
-        ux.subhead(
-            f"Already at version {current_version}; verifying the release contract "
-            "without re-installing or re-running migrations.",
-        )
-
     # ── Platform detection ───────────────────────────────────────────────────
 
     os_name, arch = _detect_platform()
@@ -451,6 +481,14 @@ def upgrade(
     recovery_home = _upgrade_recovery_home()
     data_dir = _resolved_upgrade_data_dir(app.cfg, recovery_home=recovery_home)
     active_config_path = _active_upgrade_config_path(recovery_home)
+    configured_audit_db = getattr(app.cfg, "audit_db", "") if app.cfg is not None else ""
+    audit_db_path = os.path.abspath(
+        os.path.expanduser(
+            configured_audit_db
+            if isinstance(configured_audit_db, str) and configured_audit_db.strip()
+            else os.path.join(data_dir, _AUDIT_DATABASE_FILENAME)
+        )
+    )
     if current_version != controller_version:
         _preflight_staged_target_controller_source(
             source_version=current_version,
@@ -458,12 +496,38 @@ def upgrade(
             target_version=target_version,
             recovery_home=recovery_home,
         )
-    _preflight_installed_source_coherence(
+    recovery_plan_result = _preflight_installed_source_coherence(
         current_version,
         os_name,
         data_dir,
         config_path=active_config_path,
+        recover_corrupt_audit=recover_corrupt_audit,
+        audit_db_path=audit_db_path,
+        recovery_home=recovery_home,
     )
+    # A large number of focused upgrade tests patch the historical preflight
+    # as a void function. Treat non-plan test doubles as the legacy no-op result
+    # while production always receives the frozen plan returned below.
+    recovery_plan = (
+        recovery_plan_result
+        if isinstance(recovery_plan_result, _InstalledStateRecoveryPlan)
+        else _InstalledStateRecoveryPlan()
+    )
+
+    # ── Same-version repair ──────────────────────────────────────────────────
+
+    if target_version == current_version:
+        click.echo()
+        if recovery_plan.required:
+            ux.warn(
+                f"DefenseClaw {current_version} requires authenticated local-state recovery; "
+                "the same-version release will be reinstalled and health-checked."
+            )
+        else:
+            ux.subhead(
+                f"Already at version {current_version}; verifying the release contract "
+                "without re-installing or re-running migrations.",
+            )
 
     # ── Pre-flight: verify artifacts exist ───────────────────────────────────
 
@@ -742,7 +806,7 @@ def upgrade(
         shutil.rmtree(staging_dir, ignore_errors=True)
         raise
 
-    if target_version == current_version:
+    if target_version == current_version and not recovery_plan.required:
         try:
             recovery_authority = find_resumable_upgrade_receipt(
                 data_dir,
@@ -888,6 +952,15 @@ def upgrade(
             f"    {ux.dim('3.')} Run version-specific migrations and refresh any installed local observability bundle"
         )
         click.echo(f"    {ux.dim('4.')} Restart services and verify health")
+        recovery_step = 5
+        if recovery_plan.replay_observability_v8:
+            click.echo(f"    {ux.dim(str(recovery_step) + '.')} Replay every missing idempotent migration")
+            recovery_step += 1
+        if recovery_plan.recover_corrupt_audit:
+            click.echo(
+                f"    {ux.dim(str(recovery_step) + '.')} "
+                "Preserve a proven-corrupt audit database in private backup custody"
+            )
         click.echo()
         if not click.confirm("  Proceed?", default=False):
             ux.subhead("Aborted.")
@@ -1100,10 +1173,52 @@ def upgrade(
             )
         raise SystemExit(1) from None
 
-    upgrade_phase = "install"
+    upgrade_phase = "source_repair"
     upgrade_body_failed = False
     migration_failed = False
+    restart_expected_version = current_version
     try:
+        openclaw_home = os.path.expanduser(app.cfg.claw.home_dir if app.cfg else "~/.openclaw")
+        if recovery_plan.replay_observability_v8:
+            ux.banner("Repairing Migration Cursor")
+            _replay_missing_observability_v8_migration(
+                current_version,
+                openclaw_home,
+                data_dir,
+                config_path=active_config_path,
+                reconstruct_pre_hard_cut_cursor=recovery_plan.reconstruct_pre_hard_cut_cursor,
+            )
+            ux.ok("Replayed every missing migration and durably repaired the migration cursor")
+
+        if recovery_plan.recover_corrupt_audit:
+            ux.banner("Preserving Corrupt Audit Store")
+            audit_path = recovery_plan.audit_db_path
+            if not isinstance(audit_path, str) or not audit_path:
+                restart_services = False
+                raise OSError("corrupt-audit recovery plan lacks the resolved database path")
+            try:
+                audit_custody = _quarantine_corrupt_audit_database(
+                    data_dir,
+                    backup_dir,
+                    audit_db_path=audit_path,
+                    recovery_home=recovery_home,
+                    expected_identity=recovery_plan.audit_db_identity,
+                )
+            except BaseException:
+                # Restarting the source is safe when no move marker was
+                # published: the active SQLite tuple is still authoritative.
+                # Once a durable marker exists, one or more tuple members may
+                # already be in custody, so only an exact flagged retry may
+                # resume the transaction.
+                restart_services = not os.path.lexists(os.path.join(data_dir, _AUDIT_DATABASE_RECOVERY_MARKER))
+                raise
+            if audit_custody is None:
+                ux.ok("Post-quiescence audit database is healthy; no audit files were moved")
+            else:
+                ux.ok(f"Preserved corrupt audit SQLite files: {audit_custody}")
+                ux.ok("The restarted gateway will initialize and health-check a fresh local audit store")
+
+        upgrade_phase = "install"
         ux.banner("Installing Artifacts")
 
         # Pass backup_dir so the previous gateway binary is snapshotted
@@ -1112,6 +1227,7 @@ def upgrade(
         # incident.
         installed_gateway_path = _install_gateway(gw_binary_path, os_name, backup_dir=backup_dir)
         _verify_installed_gateway_version(installed_gateway_path, target_version)
+        restart_expected_version = target_version
         _install_wheel(
             whl_path,
             os_name,
@@ -1120,7 +1236,6 @@ def upgrade(
 
         ux.banner("Running Migrations")
 
-        openclaw_home = os.path.expanduser(app.cfg.claw.home_dir if app.cfg else "~/.openclaw")
         # Thread the operator's data_dir through so migrations that
         # touch ``<data_dir>/.env`` / ``<data_dir>/active_connector.json``
         # / etc. (introduced in the connector-v3 wave, PR #194) hit the
@@ -1286,11 +1401,20 @@ def upgrade(
             )
         elif not restart_services:
             ux.banner("Services Remain Stopped")
-            ux.subhead(
-                "Keep the recovery journal and run the release-owned resolver with no version override; "
-                "it will wait for any mutator and recover from the retained bridge state.",
-                indent="  ",
-            )
+            if recovery_plan.recover_corrupt_audit and os.path.lexists(
+                os.path.join(data_dir, _AUDIT_DATABASE_RECOVERY_MARKER)
+            ):
+                ux.subhead(
+                    "Keep the private audit recovery marker and re-run this authenticated "
+                    "upgrade with --recover-corrupt-audit to resume exact custody.",
+                    indent="  ",
+                )
+            else:
+                ux.subhead(
+                    "Keep the recovery journal and run the release-owned resolver with no version override; "
+                    "it will wait for any mutator and recover from the retained bridge state.",
+                    indent="  ",
+                )
         else:
             try:
                 _start_and_verify_services(
@@ -1299,7 +1423,7 @@ def upgrade(
                     data_dir=data_dir,
                     local_bundle_upgrade=local_bundle_upgrade,
                     os_name=os_name,
-                    expected_version=target_version,
+                    expected_version=restart_expected_version,
                     rollback_plan=rollback_plan,
                     config_path=active_config_path,
                     recovery_home=recovery_home,
@@ -1760,6 +1884,7 @@ def _reload_post_upgrade_config(
 
 def _upgrade_failure_code(phase: str) -> str:
     return {
+        "source_repair": "migration_failed",
         "install": "install_failed",
         "migration": "migration_failed",
         "required_migration": "required_migration_failed",
@@ -2286,17 +2411,484 @@ def _fail_installed_source_coherence(message: str) -> NoReturn:
     raise SystemExit(1)
 
 
+def _is_private_regular_file(info: os.stat_result) -> bool:
+    if (
+        stat.S_ISLNK(info.st_mode)
+        or getattr(info, "st_file_attributes", 0) & 0x00000400
+        or not stat.S_ISREG(info.st_mode)
+        or info.st_nlink != 1
+    ):
+        return False
+    if os.name == "posix":
+        current_uid = getattr(os, "geteuid", os.getuid)()
+        if info.st_uid != current_uid or stat.S_IMODE(info.st_mode) & 0o077:
+            return False
+    return True
+
+
+def _audit_sqlite_error_is_proven_corruption(exc: sqlite3.DatabaseError) -> bool:
+    """Recognize only SQLite's value-safe corruption result codes.
+
+    Busy/locked databases, permission failures, I/O errors, and bounded-check
+    interrupts are deliberately indeterminate. They must never authorize moving
+    a durable audit store out of the active data directory.
+    """
+
+    code = getattr(exc, "sqlite_errorcode", None)
+    if isinstance(code, bool) or not isinstance(code, int):
+        return False
+    primary = code & 0xFF
+    return primary in {sqlite3.SQLITE_CORRUPT, sqlite3.SQLITE_NOTADB}
+
+
+def _classify_audit_database(
+    data_dir: str,
+    *,
+    audit_db_path: str | None = None,
+    timeout_seconds: float = _AUDIT_DATABASE_PREFLIGHT_TIMEOUT_SECONDS,
+    include_wal: bool = False,
+) -> str:
+    """Return absent/healthy/wal-pending/corrupt/indeterminate/unsafe.
+
+    The live preflight uses SQLite's immutable mode so it cannot write even
+    the shared-memory sidecar. Immutable mode deliberately ignores WAL
+    contents, so a successful main-database check is ``wal-pending`` whenever
+    a WAL exists. After the gateway is quiesced, ``include_wal`` uses a
+    read-only connection to validate the logical database including WAL while
+    proving that the durable main/WAL inodes did not change. SQLite may rebuild
+    the disposable SHM index during that second probe.
+    """
+
+    path = os.path.abspath(os.path.expanduser(audit_db_path or os.path.join(data_dir, _AUDIT_DATABASE_FILENAME)))
+    try:
+        before = os.lstat(path)
+    except FileNotFoundError:
+        return "absent"
+    except OSError:
+        return "indeterminate"
+    if not _is_private_regular_file(before):
+        return "unsafe"
+
+    durable_paths = (path, path + "-wal") if include_wal and os.path.lexists(path + "-wal") else (path,)
+    durable_before: dict[str, os.stat_result] = {}
+    for durable_path in durable_paths:
+        try:
+            info = os.lstat(durable_path)
+        except OSError:
+            return "indeterminate"
+        if not _is_private_regular_file(info):
+            return "unsafe"
+        durable_before[durable_path] = info
+
+    connection: sqlite3.Connection | None = None
+    deadline = time.monotonic() + max(0.01, timeout_seconds)
+    result = "indeterminate"
+    try:
+        query = "?mode=ro" if include_wal else "?mode=ro&immutable=1"
+        connection = sqlite3.connect(
+            Path(path).as_uri() + query,
+            uri=True,
+            timeout=min(max(0.01, timeout_seconds), 1.0),
+        )
+        connection.execute("PRAGMA query_only=ON")
+        connection.set_progress_handler(
+            lambda: int(time.monotonic() >= deadline),
+            1_000,
+        )
+        row = connection.execute("PRAGMA quick_check(1)").fetchone()
+    except sqlite3.DatabaseError as exc:
+        result = "corrupt" if _audit_sqlite_error_is_proven_corruption(exc) else "indeterminate"
+    else:
+        if row == ("ok",):
+            result = "healthy"
+        elif row is not None:
+            result = "corrupt"
+    finally:
+        if connection is not None:
+            connection.close()
+
+    for durable_path, durable_info in durable_before.items():
+        try:
+            after = os.lstat(durable_path)
+        except OSError:
+            return "indeterminate"
+        if (
+            not _is_private_regular_file(after)
+            or not os.path.samestat(durable_info, after)
+            or durable_info.st_size != after.st_size
+            or durable_info.st_mtime_ns != after.st_mtime_ns
+        ):
+            # A live gateway may legitimately write during preflight. The
+            # result cannot authorize custody mutation unless the durable
+            # database view remained stable.
+            return "indeterminate"
+    if result == "healthy" and not include_wal and os.path.lexists(path + "-wal"):
+        return "wal-pending"
+    return result
+
+
+def _private_directory_info(path: str) -> os.stat_result:
+    info = os.lstat(path)
+    if (
+        stat.S_ISLNK(info.st_mode)
+        or getattr(info, "st_file_attributes", 0) & 0x00000400
+        or not stat.S_ISDIR(info.st_mode)
+    ):
+        raise OSError("recovery custody is not a real directory")
+    if os.name == "posix":
+        current_uid = getattr(os, "geteuid", os.getuid)()
+        if info.st_uid != current_uid or stat.S_IMODE(info.st_mode) & 0o077:
+            raise OSError("recovery custody is not private and current-user-owned")
+    return info
+
+
+def _stable_owned_directory_info(path: str) -> os.stat_result:
+    """Require a real current-user directory that others cannot modify."""
+
+    info = os.lstat(path)
+    if (
+        stat.S_ISLNK(info.st_mode)
+        or getattr(info, "st_file_attributes", 0) & 0x00000400
+        or not stat.S_ISDIR(info.st_mode)
+    ):
+        raise OSError("audit database parent is not a real directory")
+    if os.name == "posix":
+        current_uid = getattr(os, "geteuid", os.getuid)()
+        if info.st_uid != current_uid or stat.S_IMODE(info.st_mode) & 0o022:
+            raise OSError("audit database parent is not stable and current-user-owned")
+    return info
+
+
+def _audit_database_recovery_sources(audit_db_path: str) -> tuple[tuple[str, str], ...]:
+    """Map a configured SQLite tuple to the marker's canonical custody names."""
+
+    source = os.path.abspath(os.path.expanduser(audit_db_path))
+    return (
+        ("audit.db-wal", source + "-wal"),
+        ("audit.db-shm", source + "-shm"),
+        ("audit.db-journal", source + "-journal"),
+        ("audit.db", source),
+    )
+
+
+def _audit_database_inode_identity(audit_db_path: str) -> tuple[int, int] | None:
+    try:
+        info = os.lstat(os.path.abspath(os.path.expanduser(audit_db_path)))
+    except FileNotFoundError:
+        return None
+    if not _is_private_regular_file(info):
+        raise OSError("audit database identity is unsafe")
+    return info.st_dev, info.st_ino
+
+
+def _audit_recovery_backup_roots(
+    data_dir: str,
+    *,
+    recovery_home: str | None,
+) -> frozenset[str]:
+    controller_home = os.path.abspath(os.path.expanduser(recovery_home or _upgrade_recovery_home()))
+    return frozenset(
+        {
+            os.path.abspath(os.path.join(data_dir, "backups")),
+            os.path.join(controller_home, "backups"),
+        }
+    )
+
+
+def _validated_audit_recovery_custody(
+    custody_value: object,
+    *,
+    data_dir: str,
+    recovery_home: str | None,
+) -> str:
+    if not isinstance(custody_value, str) or not os.path.isabs(custody_value):
+        raise OSError("audit recovery custody path is invalid")
+    custody = os.path.abspath(custody_value)
+    if custody != custody_value:
+        raise OSError("audit recovery custody path is not canonical")
+    backup_roots = _audit_recovery_backup_roots(
+        data_dir,
+        recovery_home=recovery_home,
+    )
+    matching_roots = [root for root in backup_roots if os.path.dirname(os.path.dirname(custody)) == root]
+    if (
+        len(matching_roots) != 1
+        or os.path.basename(custody) != _AUDIT_DATABASE_RECOVERY_DIRECTORY
+        or not os.path.basename(os.path.dirname(custody)).startswith("upgrade-")
+    ):
+        raise OSError("audit recovery custody escapes the trusted backup roots")
+    _private_directory_info(matching_roots[0])
+    _private_directory_info(os.path.dirname(custody))
+    _private_directory_info(custody)
+    return custody
+
+
+def _audit_recovery_identity_record_is_valid(record: object) -> bool:
+    return (
+        isinstance(record, dict)
+        and set(record) == {"device", "inode", "size", "mtime_ns"}
+        and all(isinstance(value, int) and not isinstance(value, bool) and value >= 0 for value in record.values())
+    )
+
+
+def _load_audit_recovery_marker(
+    data_dir: str,
+    *,
+    recovery_home: str | None = None,
+) -> dict[str, object] | None:
+    marker_path = os.path.join(data_dir, _AUDIT_DATABASE_RECOVERY_MARKER)
+    try:
+        before = os.lstat(marker_path)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise OSError("audit recovery marker could not be inspected") from exc
+    if not _is_private_regular_file(before) or not 0 < before.st_size <= _MAX_AUDIT_DATABASE_RECOVERY_MARKER_BYTES:
+        raise OSError("audit recovery marker is unsafe")
+    try:
+        with open(marker_path, encoding="utf-8") as stream:
+            payload = json.load(stream)
+        after = os.lstat(marker_path)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise OSError("audit recovery marker is invalid") from exc
+    if (
+        not _is_private_regular_file(after)
+        or not os.path.samestat(before, after)
+        or before.st_size != after.st_size
+        or before.st_mtime_ns != after.st_mtime_ns
+        or not isinstance(payload, dict)
+        or set(payload) != {"schema", "source", "custody", "files", "identities"}
+        or type(payload.get("schema")) is not int
+        or payload.get("schema") != 2
+        or not isinstance(payload.get("source"), str)
+        or not isinstance(payload.get("custody"), str)
+        or payload.get("files") != list(_AUDIT_DATABASE_RECOVERY_FILES)
+        or not isinstance(payload.get("identities"), dict)
+    ):
+        raise OSError("audit recovery marker is invalid")
+
+    source = payload["source"]
+    if not os.path.isabs(source) or os.path.abspath(source) != source:
+        raise OSError("audit recovery source path is not canonical")
+    identities = payload["identities"]
+    if (
+        set(identities) - set(_AUDIT_DATABASE_RECOVERY_FILES)
+        or "audit.db" not in identities
+        or any(not _audit_recovery_identity_record_is_valid(record) for record in identities.values())
+    ):
+        raise OSError("audit recovery identity set is invalid")
+    _validated_audit_recovery_custody(
+        payload["custody"],
+        data_dir=data_dir,
+        recovery_home=recovery_home,
+    )
+    return payload
+
+
+def _fail_audit_database_preflight(message: str) -> NoReturn:
+    ux.err(message, indent="  ")
+    ux.subhead(
+        "No changes were made: no target artifacts were downloaded, no services were stopped, "
+        "and no installed files were changed.",
+        indent="    ",
+    )
+    raise SystemExit(1)
+
+
+def _preflight_audit_database_recovery(
+    data_dir: str,
+    *,
+    recover_corrupt_audit: bool,
+    audit_db_path: str,
+    recovery_home: str | None = None,
+) -> bool:
+    try:
+        marker = _load_audit_recovery_marker(
+            data_dir,
+            recovery_home=recovery_home,
+        )
+    except OSError:
+        _fail_audit_database_preflight(
+            "An audit recovery marker exists but its private custody cannot be authenticated."
+        )
+    if marker is not None:
+        marker_audit_path = marker.get("source")
+        if not isinstance(marker_audit_path, str) or os.path.abspath(
+            os.path.expanduser(marker_audit_path)
+        ) != os.path.abspath(audit_db_path):
+            _fail_audit_database_preflight(
+                "The active audit database path does not match the interrupted recovery marker."
+            )
+        if not recover_corrupt_audit:
+            _fail_audit_database_preflight(
+                "An interrupted corrupt-audit recovery is pending. Re-run with "
+                "--recover-corrupt-audit to resume its authenticated private-custody transaction."
+            )
+        ux.warn("Resuming an interrupted corrupt-audit private-custody transaction.")
+        return True
+
+    state = _classify_audit_database(data_dir, audit_db_path=audit_db_path)
+    if state == "unsafe":
+        _fail_audit_database_preflight("The local audit database is not a private, current-user-owned regular file.")
+    if state in {"corrupt", "wal-pending"}:
+        if not recover_corrupt_audit:
+            if state == "corrupt":
+                _fail_audit_database_preflight(
+                    "The local audit SQLite store is corrupt. Re-run with "
+                    "--recover-corrupt-audit to preserve it in private backup custody "
+                    "and activate a fresh store."
+                )
+            ux.warn(
+                "The active audit database has a WAL that immutable live preflight "
+                "cannot inspect; normal upgrade will continue without moving audit data."
+            )
+            return False
+        if os.name != "posix":
+            _fail_audit_database_preflight(
+                "Built-in corrupt-audit recovery is currently supported on macOS and Linux only; "
+                "use the authenticated Windows release resolver."
+            )
+        try:
+            audit_parent_info = _stable_owned_directory_info(
+                os.path.dirname(os.path.abspath(audit_db_path)) or os.curdir
+            )
+            data_dir_info = _private_directory_info(os.path.abspath(data_dir))
+        except OSError:
+            _fail_audit_database_preflight("The corrupt audit database cannot enter stable private backup custody.")
+        if audit_parent_info.st_dev != data_dir_info.st_dev:
+            _fail_audit_database_preflight(
+                "The corrupt audit database is on a different filesystem from the managed backup root; "
+                "non-atomic cross-filesystem recovery is refused."
+            )
+        if state == "corrupt":
+            ux.warn(
+                "The local audit SQLite store is corrupt; exact durable database bytes will be "
+                "preserved in the upgrade backup after the gateway is stopped."
+            )
+        else:
+            ux.warn(
+                "The active audit database has a WAL; corruption recovery will run a "
+                "WAL-aware read-only integrity check after the gateway is stopped."
+            )
+        return True
+    if state == "indeterminate":
+        if recover_corrupt_audit:
+            _fail_audit_database_preflight(
+                "The bounded audit SQLite check could not prove corruption; "
+                "--recover-corrupt-audit therefore refuses to move the database."
+            )
+        ux.warn(
+            "The bounded read-only audit SQLite check was inconclusive; "
+            "normal fail-closed gateway readiness remains in effect."
+        )
+    elif recover_corrupt_audit:
+        ux.subhead(
+            "--recover-corrupt-audit was requested, but the local audit database "
+            f"is {state}; no audit files will be moved.",
+            indent="  ",
+        )
+    return False
+
+
+def _observability_v8_cursor_recovery_mode(data_dir: str, current_version: str) -> str:
+    """Return valid/replay/bootstrap/invalid for a hard-cut cursor.
+
+    A missing or JSON-damaged private cursor can be reconstructed from a
+    config-v8 installation by inferring only pre-hard-cut history, then running
+    the real 0.8.5 callable. A structurally valid partial cursor is preserved
+    and every missing idempotent callable runs; no valid record is synthesized.
+    """
+
+    from defenseclaw.migrations import MIGRATIONS
+
+    path = os.path.join(data_dir, ".migration_state.json")
+    try:
+        before = os.lstat(path)
+    except FileNotFoundError:
+        return "bootstrap"
+    except OSError:
+        return "invalid"
+    if not _is_private_regular_file(before) or not 0 < before.st_size <= 1024 * 1024:
+        return "invalid"
+    try:
+        with open(path, encoding="utf-8") as stream:
+            raw = json.load(stream)
+        after = os.lstat(path)
+    except (UnicodeError, json.JSONDecodeError):
+        return "bootstrap"
+    except OSError:
+        return "invalid"
+    if (
+        not _is_private_regular_file(after)
+        or not os.path.samestat(before, after)
+        or before.st_size != after.st_size
+        or before.st_mtime_ns != after.st_mtime_ns
+        or not isinstance(raw, dict)
+        or raw.get("schema") != 1
+    ):
+        return "invalid"
+
+    package_version = raw.get("package_version")
+    applied = raw.get("applied")
+    applied_at = raw.get("applied_at")
+    if (
+        not isinstance(package_version, str)
+        or _CANONICAL_VERSION_RE.fullmatch(package_version) is None
+        or _version_key(package_version) > _version_key(current_version)
+        or not isinstance(applied, list)
+        or any(not isinstance(item, str) for item in applied)
+        or len(applied) != len(set(applied))
+        or not isinstance(applied_at, dict)
+        or set(applied_at) != set(applied)
+        or any(not isinstance(value, str) or not value for value in applied_at.values())
+    ):
+        return "invalid"
+
+    expected = [
+        version
+        for version, _description, _function in MIGRATIONS
+        if _version_key(version) <= _version_key(current_version)
+    ]
+    if (
+        _OBSERVABILITY_V8_MIGRATION_VERSION not in expected
+        or any(_CANONICAL_VERSION_RE.fullmatch(version) is None for version in applied)
+        or any(version not in expected for version in applied)
+        or applied != sorted(applied, key=_version_key)
+    ):
+        return "invalid"
+    return "valid" if applied == expected else "replay"
+
+
 def _preflight_installed_source_coherence(
     current_version: str,
     os_name: str,
     data_dir: str,
     *,
     config_path: str | None = None,
-) -> None:
-    """Reject manual/partial release overwrites before target I/O or mutation."""
+    recover_corrupt_audit: bool = False,
+    audit_db_path: str | None = None,
+    recovery_home: str | None = None,
+) -> _InstalledStateRecoveryPlan:
+    """Reject incoherent state and return a read-only, narrowly scoped plan."""
+
+    replay_observability_v8 = False
+    reconstruct_pre_hard_cut_cursor = False
+    resolved_audit_db_path = os.path.abspath(
+        os.path.expanduser(audit_db_path or os.path.join(data_dir, _AUDIT_DATABASE_FILENAME))
+    )
 
     if _version_key(current_version) < _version_key(_STRICT_SIGSTORE_RELEASE_VERSION):
-        return
+        recover_audit = _preflight_audit_database_recovery(
+            data_dir,
+            recover_corrupt_audit=recover_corrupt_audit,
+            audit_db_path=resolved_audit_db_path,
+            recovery_home=recovery_home,
+        )
+        return _InstalledStateRecoveryPlan(
+            recover_corrupt_audit=recover_audit,
+            audit_db_path=resolved_audit_db_path,
+            audit_db_identity=(_audit_database_inode_identity(resolved_audit_db_path) if recover_audit else None),
+        )
 
     gateway_path = os.path.expanduser(os.path.join("~/.local/bin", _installed_gateway_filename(os_name)))
     try:
@@ -2327,29 +2919,47 @@ def _preflight_installed_source_coherence(
         actual = reported[0] if len(reported) == 1 else "unverifiable"
         _fail_installed_source_coherence(f"Installed component version drift: CLI={current_version}, gateway={actual}.")
 
-    if _version_key(current_version) < _version_key(_OBSERVABILITY_V8_MIGRATION_VERSION):
-        return
+    if _version_key(current_version) >= _version_key(_OBSERVABILITY_V8_MIGRATION_VERSION):
+        from defenseclaw.config import ConfigVersionError, source_config_version
 
-    from defenseclaw import migration_state
-    from defenseclaw.config import ConfigVersionError, source_config_version
+        try:
+            config_version = source_config_version(path=config_path or _active_upgrade_config_path())
+        except ConfigVersionError:
+            _fail_installed_source_coherence(
+                f"Installed DefenseClaw {current_version} configuration schema could not be verified."
+            )
+        if config_version != _TARGET_CONFIG_VERSION:
+            _fail_installed_source_coherence(
+                f"Installed DefenseClaw {current_version} requires config_version "
+                f"{_TARGET_CONFIG_VERSION}; found {config_version!r}."
+            )
+        cursor_recovery_mode = _observability_v8_cursor_recovery_mode(data_dir, current_version)
+        if cursor_recovery_mode == "invalid":
+            _fail_installed_source_coherence(
+                f"Installed DefenseClaw {current_version} has invalid migration cursor metadata."
+            )
+        if cursor_recovery_mode != "valid":
+            replay_observability_v8 = True
+            reconstruct_pre_hard_cut_cursor = cursor_recovery_mode == "bootstrap"
+            detail = "a missing or damaged cursor" if reconstruct_pre_hard_cut_cursor else "a valid partial cursor"
+            ux.warn(
+                f"Installed DefenseClaw {current_version} has {detail}; every missing "
+                "idempotent migration will be replayed after backup and gateway quiescence."
+            )
 
-    try:
-        config_version = source_config_version(path=config_path or _active_upgrade_config_path())
-    except ConfigVersionError:
-        _fail_installed_source_coherence(
-            f"Installed DefenseClaw {current_version} configuration schema could not be verified."
-        )
-    if config_version != _TARGET_CONFIG_VERSION:
-        _fail_installed_source_coherence(
-            f"Installed DefenseClaw {current_version} requires config_version "
-            f"{_TARGET_CONFIG_VERSION}; found {config_version!r}."
-        )
-    state = migration_state.load(data_dir)
-    if not migration_state.is_applied(state, _OBSERVABILITY_V8_MIGRATION_VERSION):
-        _fail_installed_source_coherence(
-            f"Installed DefenseClaw {current_version} lacks the applied "
-            f"{_OBSERVABILITY_V8_MIGRATION_VERSION} migration cursor."
-        )
+    recover_audit = _preflight_audit_database_recovery(
+        data_dir,
+        recover_corrupt_audit=recover_corrupt_audit,
+        audit_db_path=resolved_audit_db_path,
+        recovery_home=recovery_home,
+    )
+    return _InstalledStateRecoveryPlan(
+        replay_observability_v8=replay_observability_v8,
+        reconstruct_pre_hard_cut_cursor=reconstruct_pre_hard_cut_cursor,
+        recover_corrupt_audit=recover_audit,
+        audit_db_path=resolved_audit_db_path,
+        audit_db_identity=(_audit_database_inode_identity(resolved_audit_db_path) if recover_audit else None),
+    )
 
 
 def _preflight_check(
@@ -6413,6 +7023,238 @@ def _assert_gateway_quiesced(data_dir: str, *, gateway_path: str | None = None) 
         raise OSError("exact gateway status still reports a live service after stop")
 
 
+def _replay_missing_observability_v8_migration(
+    current_version: str,
+    openclaw_home: str,
+    data_dir: str,
+    *,
+    config_path: str,
+    reconstruct_pre_hard_cut_cursor: bool = False,
+) -> int:
+    """Run every missing callable and require a complete durable cursor."""
+
+    from defenseclaw import migration_state
+    from defenseclaw.migrations import MIGRATIONS, run_migrations
+
+    expected = [
+        version
+        for version, _description, _function in MIGRATIONS
+        if _version_key(version) <= _version_key(current_version)
+    ]
+    if reconstruct_pre_hard_cut_cursor:
+        state = migration_state.bootstrap(
+            None,
+            from_version="0.8.4",
+            package_version=current_version,
+            registry_versions=expected,
+        )
+        if migration_state.is_applied(state, _OBSERVABILITY_V8_MIGRATION_VERSION):
+            raise OSError("migration cursor reconstruction synthesized the hard-cut entry")
+        migration_state.save(data_dir, state)
+
+    previous_home = os.environ.get("DEFENSECLAW_HOME")
+    previous_config = os.environ.get("DEFENSECLAW_CONFIG")
+    os.environ["DEFENSECLAW_HOME"] = os.path.abspath(data_dir)
+    os.environ["DEFENSECLAW_CONFIG"] = os.path.abspath(config_path)
+    try:
+        count = run_migrations(
+            current_version,
+            current_version,
+            openclaw_home,
+            data_dir,
+            upgrade_handles_local_bundle=True,
+            strict_required=(_OBSERVABILITY_V8_MIGRATION_VERSION,),
+            controller_owns_local_bundle_transaction=True,
+        )
+    finally:
+        if previous_home is None:
+            os.environ.pop("DEFENSECLAW_HOME", None)
+        else:
+            os.environ["DEFENSECLAW_HOME"] = previous_home
+        if previous_config is None:
+            os.environ.pop("DEFENSECLAW_CONFIG", None)
+        else:
+            os.environ["DEFENSECLAW_CONFIG"] = previous_config
+
+    state = migration_state.load(data_dir)
+    if (
+        count < 1
+        or state is None
+        or any(not migration_state.is_applied(state, version) for version in expected)
+        or state.applied_at.get(_OBSERVABILITY_V8_MIGRATION_VERSION) in {None, migration_state.BOOTSTRAP_SENTINEL}
+    ):
+        raise OSError("idempotent migration replay did not durably repair the complete cursor")
+    return count
+
+
+def _audit_recovery_identity(info: os.stat_result) -> dict[str, int]:
+    return {
+        "device": info.st_dev,
+        "inode": info.st_ino,
+        "size": info.st_size,
+        "mtime_ns": info.st_mtime_ns,
+    }
+
+
+def _audit_recovery_identity_matches(info: os.stat_result, expected: object) -> bool:
+    if not _is_private_regular_file(info) or not _audit_recovery_identity_record_is_valid(expected):
+        return False
+    actual = _audit_recovery_identity(info)
+    return actual == expected
+
+
+def _write_private_json(path: str, payload: dict[str, object], *, protect_parent: bool) -> None:
+    from defenseclaw.file_permissions import atomic_write_private_bytes
+
+    encoded = (json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True) + "\n").encode("ascii")
+    if len(encoded) > _MAX_AUDIT_DATABASE_RECOVERY_MARKER_BYTES:
+        raise OSError("audit recovery metadata exceeds its bounded envelope")
+    atomic_write_private_bytes(path, encoded, protect_parent=protect_parent)
+
+
+def _quarantine_corrupt_audit_database(
+    data_dir: str,
+    backup_dir: str,
+    *,
+    audit_db_path: str,
+    recovery_home: str | None = None,
+    expected_identity: tuple[int, int] | None = None,
+) -> str | None:
+    """Move one proven-corrupt SQLite tuple into resumable private custody."""
+
+    if os.name != "posix":
+        raise OSError("corrupt-audit private custody is supported on POSIX only")
+
+    normalized_data_dir = os.path.abspath(data_dir)
+    normalized_backup_dir = os.path.abspath(backup_dir)
+    normalized_audit_db_path = os.path.abspath(os.path.expanduser(audit_db_path))
+    audit_parent = os.path.dirname(normalized_audit_db_path) or os.curdir
+    recovery_sources = _audit_database_recovery_sources(normalized_audit_db_path)
+    _private_directory_info(normalized_data_dir)
+    audit_parent_info = _stable_owned_directory_info(audit_parent)
+
+    marker_path = os.path.join(normalized_data_dir, _AUDIT_DATABASE_RECOVERY_MARKER)
+    marker = _load_audit_recovery_marker(
+        normalized_data_dir,
+        recovery_home=recovery_home,
+    )
+    if marker is None:
+        backup_info = _private_directory_info(normalized_backup_dir)
+        matching_backup_roots = [
+            root
+            for root in _audit_recovery_backup_roots(
+                normalized_data_dir,
+                recovery_home=recovery_home,
+            )
+            if os.path.dirname(normalized_backup_dir) == root
+        ]
+        if len(matching_backup_roots) != 1 or not os.path.basename(normalized_backup_dir).startswith("upgrade-"):
+            raise OSError("audit recovery backup escapes the managed private root")
+        _private_directory_info(matching_backup_roots[0])
+        if audit_parent_info.st_dev != backup_info.st_dev:
+            raise OSError("audit recovery custody must share the audit database filesystem")
+
+        current_identity = _audit_database_inode_identity(normalized_audit_db_path)
+        if expected_identity is not None and current_identity != expected_identity:
+            raise OSError("audit database inode changed after the live integrity probe")
+        state = _classify_audit_database(
+            normalized_data_dir,
+            audit_db_path=normalized_audit_db_path,
+            timeout_seconds=_AUDIT_DATABASE_MUTATION_TIMEOUT_SECONDS,
+            include_wal=True,
+        )
+        if state in {"healthy", "absent"}:
+            return None
+        if state != "corrupt":
+            raise OSError(
+                "post-quiescence audit check did not prove SQLITE_CORRUPT/SQLITE_NOTADB; the database was not moved"
+            )
+
+        custody = os.path.join(normalized_backup_dir, _AUDIT_DATABASE_RECOVERY_DIRECTORY)
+        if os.path.lexists(custody):
+            raise OSError("audit recovery custody target already exists")
+        os.mkdir(custody, 0o700)
+        os.chmod(custody, 0o700)
+        custody_info = _private_directory_info(custody)
+        if custody_info.st_dev != audit_parent_info.st_dev:
+            raise OSError("audit recovery custody is not on the database filesystem")
+        _fsync_posix_directory(normalized_backup_dir)
+
+        identities: dict[str, dict[str, int]] = {}
+        for name, source in recovery_sources:
+            try:
+                info = os.lstat(source)
+            except FileNotFoundError:
+                continue
+            if not _is_private_regular_file(info) or info.st_dev != audit_parent_info.st_dev:
+                raise OSError(f"audit recovery input is unsafe: {name}")
+            identities[name] = _audit_recovery_identity(info)
+        if "audit.db" not in identities:
+            raise OSError("proven-corrupt audit database disappeared before custody")
+
+        marker = {
+            "schema": 2,
+            "source": normalized_audit_db_path,
+            "custody": custody,
+            "files": list(_AUDIT_DATABASE_RECOVERY_FILES),
+            "identities": identities,
+        }
+        _write_private_json(marker_path, marker, protect_parent=False)
+        _fsync_posix_directory(normalized_data_dir)
+    else:
+        custody = _validated_audit_recovery_custody(
+            marker.get("custody"),
+            data_dir=normalized_data_dir,
+            recovery_home=recovery_home,
+        )
+
+    custody_info = _private_directory_info(custody)
+    if custody_info.st_dev != audit_parent_info.st_dev:
+        raise OSError("audit recovery custody changed filesystems")
+    marker_audit_path = marker.get("source")
+    if (
+        not isinstance(marker_audit_path, str)
+        or marker_audit_path != normalized_audit_db_path
+        or marker.get("files") != list(_AUDIT_DATABASE_RECOVERY_FILES)
+    ):
+        raise OSError("audit recovery marker does not match the active configured store")
+    records = marker.get("identities")
+    if not isinstance(records, dict) or "audit.db" not in records:
+        raise OSError("audit recovery inventory lacks the main database")
+
+    for name, source in recovery_sources:
+        destination = os.path.join(custody, name)
+        source_exists = os.path.lexists(source)
+        destination_exists = os.path.lexists(destination)
+        expected = records.get(name)
+        if expected is None:
+            if source_exists or destination_exists:
+                raise OSError(f"unexpected audit recovery file appeared: {name}")
+            continue
+        if source_exists == destination_exists:
+            raise OSError(f"audit recovery cannot establish unique custody for {name}")
+        observed = os.lstat(source if source_exists else destination)
+        if not _audit_recovery_identity_matches(observed, expected):
+            raise OSError(f"audit recovery file identity changed: {name}")
+        if source_exists:
+            os.rename(source, destination)
+            _fsync_posix_directory(custody)
+            _fsync_posix_directory(audit_parent)
+
+    main_source = normalized_audit_db_path
+    main_destination = os.path.join(custody, "audit.db")
+    if os.path.lexists(main_source) or not _audit_recovery_identity_matches(
+        os.lstat(main_destination),
+        records["audit.db"],
+    ):
+        raise OSError("audit recovery did not establish main-database custody")
+
+    os.unlink(marker_path)
+    _fsync_posix_directory(normalized_data_dir)
+    _fsync_posix_directory(custody)
+    return custody
+
+
 def _capture_source_gateway_running_state(gateway_path: str, data_dir: str) -> bool:
     """Prove whether the authenticated source gateway is running before mutation."""
 
@@ -6544,6 +7386,7 @@ def _create_backup(cfg, *, data_dir: str | None = None) -> str:
     for fname in (
         "config.yaml",
         ".env",
+        ".migration_state.json",
         "guardrail_runtime.json",
         "device.key",
         "active_connector.json",

--- a/cli/tests/test_cmd_upgrade.py
+++ b/cli/tests/test_cmd_upgrade.py
@@ -3,6 +3,7 @@ import io
 import json
 import os
 import signal
+import sqlite3
 import stat
 import subprocess
 import sys
@@ -35,6 +36,7 @@ from defenseclaw.commands.cmd_upgrade import (
     _capture_rollback_file,
     _capture_source_gateway_running_state,
     _check_post_upgrade_drift,
+    _classify_audit_database,
     _cleanup_hard_cut_mutation_temporaries,
     _copy_distribution_metadata,
     _crash_bundle_rollback_result,
@@ -62,6 +64,7 @@ from defenseclaw.commands.cmd_upgrade import (
     _hold_phase_two_lease_for_command_lifetime,
     _install_gateway,
     _install_wheel,
+    _InstalledStateRecoveryPlan,
     _load_hard_cut_recovery_journal,
     _LocalBundleUpgradeInvocationError,
     _mark_hard_cut_bundle_mutation_intent,
@@ -80,9 +83,11 @@ from defenseclaw.commands.cmd_upgrade import (
     _preflight_wheel_install,
     _prepare_hard_cut_rollback_plan,
     _print_migration_cursor_summary,
+    _quarantine_corrupt_audit_database,
     _recover_interrupted_hard_cut,
     _refresh_target_dotenv_environment,
     _release_download_base,
+    _replay_missing_observability_v8_migration,
     _require_bridge_checksums_provenance,
     _require_bridge_environment_accepts_target_wheel,
     _require_hard_cut_manifest_contract,
@@ -656,6 +661,22 @@ class TestUpgradeBackup(unittest.TestCase):
             )
             self.assertTrue(os.path.isfile(copied))
 
+    def test_create_backup_captures_migration_cursor_before_replay(self):
+        cfg = Config()
+        with TemporaryDirectory() as data_dir:
+            cfg.data_dir = data_dir
+            cfg.claw.home_dir = os.path.join(data_dir, "openclaw")
+            cursor = Path(data_dir, ".migration_state.json")
+            cursor.write_text('{"schema":1,"applied":[]}\n', encoding="utf-8")
+            cursor.chmod(0o600)
+
+            backup_dir = _create_backup(cfg)
+
+            self.assertEqual(
+                Path(backup_dir, ".migration_state.json").read_bytes(),
+                cursor.read_bytes(),
+            )
+
     @unittest.skipIf(os.name != "posix", "POSIX mode contract")
     def test_create_backup_tightens_legacy_root_and_makes_unique_private_directories(self):
         cfg = Config()
@@ -691,6 +712,201 @@ class TestUpgradeBackup(unittest.TestCase):
                 _create_backup(cfg)
 
             self.assertEqual(os.listdir(target), [])
+
+
+@unittest.skipIf(os.name != "posix", "POSIX SQLite custody fixture")
+class TestUpgradeAuditRecovery(unittest.TestCase):
+    @staticmethod
+    def _private_file(path: Path, payload: bytes) -> None:
+        path.write_bytes(payload)
+        path.chmod(0o600)
+
+    def test_classifier_uses_configured_audit_path_and_proves_notadb(self):
+        with TemporaryDirectory() as data_dir:
+            configured = Path(data_dir, "custom-events.sqlite")
+            self._private_file(configured, b"not-a-sqlite-database")
+
+            state = _classify_audit_database(
+                data_dir,
+                audit_db_path=str(configured),
+            )
+
+            self.assertEqual(state, "corrupt")
+            self.assertFalse(Path(data_dir, "audit.db").exists())
+
+    def test_busy_or_locked_database_never_authorizes_recovery(self):
+        with TemporaryDirectory() as data_dir:
+            configured = Path(data_dir, "custom-events.sqlite")
+            with sqlite3.connect(configured) as connection:
+                connection.execute("CREATE TABLE events(id INTEGER PRIMARY KEY)")
+            configured.chmod(0o600)
+            locked = sqlite3.OperationalError("database is locked")
+            locked.sqlite_errorcode = sqlite3.SQLITE_BUSY
+
+            with patch(
+                "defenseclaw.commands.cmd_upgrade.sqlite3.connect",
+                side_effect=locked,
+            ):
+                state = _classify_audit_database(
+                    data_dir,
+                    audit_db_path=str(configured),
+                )
+
+            self.assertEqual(state, "indeterminate")
+            self.assertTrue(configured.exists())
+
+    def test_classifier_does_not_rewrite_live_wal_sidecars(self):
+        with TemporaryDirectory() as data_dir:
+            configured = Path(data_dir, "audit.db")
+            with sqlite3.connect(configured) as writer:
+                writer.execute("PRAGMA journal_mode=WAL")
+                writer.execute("CREATE TABLE events(id INTEGER PRIMARY KEY)")
+                writer.commit()
+                configured.chmod(0o600)
+                sidecars = [
+                    path
+                    for path in (
+                        Path(str(configured) + "-wal"),
+                        Path(str(configured) + "-shm"),
+                    )
+                    if path.exists()
+                ]
+                for path in sidecars:
+                    path.chmod(0o600)
+                before = {path: (path.read_bytes(), path.stat().st_mtime_ns) for path in sidecars}
+
+                state = _classify_audit_database(
+                    data_dir,
+                    audit_db_path=str(configured),
+                )
+
+                self.assertEqual(state, "wal-pending")
+                self.assertTrue(sidecars)
+                self.assertEqual(
+                    {path: (path.read_bytes(), path.stat().st_mtime_ns) for path in sidecars},
+                    before,
+                )
+                durable = [configured, Path(str(configured) + "-wal")]
+                durable_before = {path: (path.read_bytes(), path.stat().st_mtime_ns) for path in durable}
+
+                wal_aware_state = _classify_audit_database(
+                    data_dir,
+                    audit_db_path=str(configured),
+                    include_wal=True,
+                )
+
+                self.assertEqual(wal_aware_state, "healthy")
+                self.assertEqual(
+                    {path: (path.read_bytes(), path.stat().st_mtime_ns) for path in durable},
+                    durable_before,
+                )
+
+    def test_quarantine_moves_configured_sqlite_tuple_and_keeps_default_store(self):
+        with TemporaryDirectory() as data_dir:
+            root = Path(data_dir)
+            audit_parent = root / "local-state"
+            audit_parent.mkdir(mode=0o700)
+            configured = audit_parent / "events.sqlite"
+            self._private_file(configured, b"not-a-sqlite-database")
+            self._private_file(Path(str(configured) + "-wal"), b"wal-bytes")
+            self._private_file(Path(str(configured) + "-shm"), b"shm-bytes")
+            default_store = root / "audit.db"
+            with sqlite3.connect(default_store) as connection:
+                connection.execute("CREATE TABLE preserved(id INTEGER PRIMARY KEY)")
+            default_store.chmod(0o600)
+            backup = root / "backups" / "upgrade-test"
+            backup.mkdir(parents=True, mode=0o700)
+            (root / "backups").chmod(0o700)
+            backup.chmod(0o700)
+
+            custody = _quarantine_corrupt_audit_database(
+                data_dir,
+                str(backup),
+                audit_db_path=str(configured),
+            )
+
+            self.assertEqual(custody, str(backup / "audit-corrupt"))
+            self.assertFalse(configured.exists())
+            self.assertEqual(Path(custody, "audit.db").read_bytes(), b"not-a-sqlite-database")
+            self.assertEqual(Path(custody, "audit.db-wal").read_bytes(), b"wal-bytes")
+            # A WAL-aware read-only probe may rebuild SQLite's disposable SHM
+            # index. Durable main/WAL bytes remain exact and are what carry
+            # audit history.
+            self.assertTrue(Path(custody, "audit.db-shm").is_file())
+            self.assertEqual(stat.S_IMODE(os.stat(custody).st_mode), 0o700)
+            self.assertTrue(default_store.exists())
+            self.assertFalse((root / ".audit-recovery.json").exists())
+            self.assertEqual(
+                sorted(path.name for path in Path(custody).iterdir()),
+                ["audit.db", "audit.db-shm", "audit.db-wal"],
+            )
+
+    def test_python_resumes_exact_shell_schema_two_marker_from_controller_backup(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            data_dir = root / "data"
+            data_dir.mkdir(mode=0o700)
+            controller_home = root / "controller"
+            controller_home.mkdir(mode=0o700)
+            controller_backups = controller_home / "backups"
+            controller_backups.mkdir(mode=0o700)
+            old_backup = controller_backups / "upgrade-shell"
+            old_backup.mkdir(mode=0o700)
+            custody = old_backup / "audit-corrupt"
+            custody.mkdir(mode=0o700)
+
+            audit_parent = root / "local-state"
+            audit_parent.mkdir(mode=0o700)
+            configured = audit_parent / "events.sqlite"
+            wal = Path(str(configured) + "-wal")
+            self._private_file(custody / "audit.db", b"not-a-sqlite-database")
+            self._private_file(wal, b"wal-bytes")
+
+            def identity(path: Path) -> dict[str, int]:
+                info = path.lstat()
+                return {
+                    "device": info.st_dev,
+                    "inode": info.st_ino,
+                    "size": info.st_size,
+                    "mtime_ns": info.st_mtime_ns,
+                }
+
+            marker = {
+                "schema": 2,
+                "source": str(configured),
+                "custody": str(custody),
+                "files": [
+                    "audit.db-wal",
+                    "audit.db-shm",
+                    "audit.db-journal",
+                    "audit.db",
+                ],
+                "identities": {
+                    "audit.db": identity(custody / "audit.db"),
+                    "audit.db-wal": identity(wal),
+                },
+            }
+            marker_path = data_dir / ".audit-recovery.json"
+            marker_path.write_text(json.dumps(marker) + "\n", encoding="utf-8")
+            marker_path.chmod(0o600)
+
+            current_backup_root = data_dir / "backups"
+            current_backup_root.mkdir(mode=0o700)
+            current_backup = current_backup_root / "upgrade-python"
+            current_backup.mkdir(mode=0o700)
+
+            resumed = _quarantine_corrupt_audit_database(
+                str(data_dir),
+                str(current_backup),
+                audit_db_path=str(configured),
+                recovery_home=str(controller_home),
+            )
+
+            self.assertEqual(resumed, str(custody))
+            self.assertFalse(marker_path.exists())
+            self.assertFalse(wal.exists())
+            self.assertEqual((custody / "audit.db").read_bytes(), b"not-a-sqlite-database")
+            self.assertEqual((custody / "audit.db-wal").read_bytes(), b"wal-bytes")
 
 
 @unittest.skipIf(os.name == "nt", "POSIX hard-cut rollback fixture")
@@ -3986,6 +4202,78 @@ class TestUpgradeSameVersionRepair(unittest.TestCase):
         self.assertEqual(unproven_bundle_result.exit_code, 1)
         self.assertIn("no verified target-install receipt exists", unproven_bundle_result.output)
 
+    def test_same_version_recovery_plan_bypasses_authenticated_noop(self):
+        class StopAtBackupError(RuntimeError):
+            pass
+
+        runner = CliRunner()
+        app = AppContext()
+        app.cfg = Config()
+        with TemporaryDirectory() as data_dir, ExitStack() as stack:
+            app.cfg.data_dir = data_dir
+            app.cfg.claw.home_dir = data_dir
+            stack.enter_context(patch("defenseclaw.__version__", "9.9.9"))
+            stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._preflight_installed_source_coherence",
+                    return_value=_InstalledStateRecoveryPlan(replay_observability_v8=True),
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._detect_platform",
+                    return_value=("darwin", "arm64"),
+                )
+            )
+            stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._preflight_check"))
+            stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._require_hard_cut_manifest_contract"))
+            stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._download_checksums",
+                    return_value={
+                        "defenseclaw_9.9.9_darwin_arm64.tar.gz": "0" * 64,
+                        "defenseclaw-9.9.9-py3-none-any.whl": "0" * 64,
+                        "upgrade-manifest.json": "0" * 64,
+                    },
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._download_upgrade_manifest",
+                    return_value=None,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._download_gateway",
+                    return_value=("/tmp/defenseclaw-gateway", "gateway.tar.gz"),
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._download_wheel",
+                    return_value=("/tmp/defenseclaw.whl", "defenseclaw.whl"),
+                )
+            )
+            stack.enter_context(patch("defenseclaw.commands.cmd_upgrade._preflight_wheel_install"))
+            create_backup = stack.enter_context(
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._create_backup",
+                    side_effect=StopAtBackupError,
+                )
+            )
+
+            result = runner.invoke(
+                upgrade,
+                ["--yes", "--version", "9.9.9"],
+                obj=app,
+            )
+
+        self.assertIsInstance(result.exception, StopAtBackupError)
+        self.assertIn("same-version release will be reinstalled", result.output)
+        self.assertNotIn("Version Already Verified", result.output)
+        create_backup.assert_called_once()
+
     def test_interrupted_same_version_bundle_recovery_is_retryable(self):
         app = AppContext()
         app.cfg = Config()
@@ -4900,6 +5188,9 @@ class TestUpgradeServiceVerification(unittest.TestCase):
             "darwin",
             selected,
             config_path=config_path,
+            recover_corrupt_audit=False,
+            audit_db_path=os.path.join(selected, "audit.db"),
+            recovery_home=recovery_home,
         )
         self.assertEqual(self.create_backup.call_args.kwargs["data_dir"], selected)
         migration_call = self.run_installed_migrations.call_args
@@ -6994,22 +7285,127 @@ class TestUpgradeManifest(unittest.TestCase):
 
             config.write_text("config_version: 8\n", encoding="utf-8")
             with runner.isolation() as (out, _err, _):
-                with self.assertRaises(SystemExit):
-                    _preflight_installed_source_coherence("0.8.5", "linux", str(data_dir))
-                self.assertIn("lacks the applied 0.8.5 migration cursor", out.getvalue().decode())
+                plan = _preflight_installed_source_coherence(
+                    "0.8.5",
+                    "linux",
+                    str(data_dir),
+                )
+                self.assertTrue(plan.replay_observability_v8)
+                self.assertTrue(plan.reconstruct_pre_hard_cut_cursor)
+                self.assertIn("missing or damaged cursor", out.getvalue().decode())
 
+            cursor.write_text("{broken\n", encoding="utf-8")
+            cursor.chmod(0o600)
+            damaged_plan = _preflight_installed_source_coherence(
+                "0.8.5",
+                "linux",
+                str(data_dir),
+            )
+            self.assertTrue(damaged_plan.replay_observability_v8)
+            self.assertTrue(damaged_plan.reconstruct_pre_hard_cut_cursor)
+
+            from defenseclaw.migrations import MIGRATIONS
+
+            expected = [version for version, _description, _function in MIGRATIONS]
             cursor.write_text(
                 json.dumps(
                     {
                         "schema": 1,
                         "package_version": "0.8.5",
-                        "applied": ["0.8.5"],
-                        "applied_at": {"0.8.5": "test"},
+                        "applied": expected,
+                        "applied_at": {version: "test" for version in expected},
                     }
                 ),
                 encoding="utf-8",
             )
-            _preflight_installed_source_coherence("0.8.5", "linux", str(data_dir))
+            cursor.chmod(0o600)
+            valid_plan = _preflight_installed_source_coherence("0.8.5", "linux", str(data_dir))
+            self.assertFalse(valid_plan.replay_observability_v8)
+
+    @unittest.skipIf(os.name == "nt", "POSIX installed-source fixture")
+    def test_v8_cursor_missing_only_085_returns_real_replay_plan(self):
+        from defenseclaw import migration_state
+        from defenseclaw.migrations import MIGRATIONS
+
+        with (
+            TemporaryDirectory() as root,
+            patch.dict(os.environ, {"HOME": root}),
+            patch(
+                "defenseclaw.commands.cmd_upgrade.subprocess.run",
+                return_value=Mock(
+                    returncode=0,
+                    stdout="defenseclaw version 0.8.6\n",
+                    stderr="",
+                ),
+            ),
+        ):
+            home = Path(root)
+            gateway = home / ".local/bin/defenseclaw-gateway"
+            gateway.parent.mkdir(parents=True)
+            gateway.write_bytes(b"gateway")
+            gateway.chmod(0o755)
+            data_dir = home / ".defenseclaw"
+            data_dir.mkdir(mode=0o700)
+            (data_dir / "config.yaml").write_text("config_version: 8\n", encoding="utf-8")
+            expected = [version for version, _description, _function in MIGRATIONS if version != "0.8.5"]
+            migration_state.save(
+                str(data_dir),
+                migration_state.MigrationState(
+                    package_version="0.8.6",
+                    applied=expected,
+                    applied_at={version: "bootstrap" for version in expected},
+                ),
+            )
+
+            plan = _preflight_installed_source_coherence(
+                "0.8.6",
+                "linux",
+                str(data_dir),
+                audit_db_path=str(data_dir / "custom-audit.db"),
+            )
+
+            self.assertTrue(plan.replay_observability_v8)
+            self.assertFalse(plan.recover_corrupt_audit)
+            self.assertEqual(plan.audit_db_path, str(data_dir / "custom-audit.db"))
+
+    def test_cursor_repair_calls_real_migration_runner_instead_of_synthesizing_bit(self):
+        from defenseclaw import migration_state
+
+        with TemporaryDirectory() as data_dir:
+            initial = migration_state.MigrationState(
+                package_version="0.8.6",
+                applied=["0.3.0", "0.4.0", "0.5.0", "0.7.0", "0.8.0"],
+                applied_at={version: "bootstrap" for version in ("0.3.0", "0.4.0", "0.5.0", "0.7.0", "0.8.0")},
+            )
+            migration_state.save(data_dir, initial)
+
+            def run_real_callable(*args, **kwargs):
+                self.assertEqual(args[:2], ("0.8.6", "0.8.6"))
+                self.assertEqual(kwargs["strict_required"], ("0.8.5",))
+                state = migration_state.load(data_dir)
+                migration_state.mark_applied(state, "0.8.5", package_version="0.8.6")
+                migration_state.save(data_dir, state)
+                return 1
+
+            with patch(
+                "defenseclaw.migrations.run_migrations",
+                side_effect=run_real_callable,
+            ) as migration_runner:
+                count = _replay_missing_observability_v8_migration(
+                    "0.8.6",
+                    data_dir,
+                    data_dir,
+                    config_path=os.path.join(data_dir, "config.yaml"),
+                )
+
+            self.assertEqual(count, 1)
+            migration_runner.assert_called_once()
+            self.assertTrue(
+                migration_state.is_applied(
+                    migration_state.load(data_dir),
+                    "0.8.5",
+                )
+            )
 
     def test_downgrade_refusal_precedes_platform_network_and_mutation(self):
         runner = CliRunner()

--- a/cli/tests/test_install_docs_static.py
+++ b/cli/tests/test_install_docs_static.py
@@ -1960,12 +1960,13 @@ def test_windows_bootstrap_binds_native_setup_to_authenticated_signed_outer_byte
     assert execute < main.index("} finally {") < cleanup
 
 
-def test_cli_docs_describe_authenticated_same_version_upgrade_as_noop() -> None:
+def test_cli_docs_describe_authenticated_same_version_upgrade_recovery_exception() -> None:
     cli = (ROOT / "docs/CLI.md").read_text(encoding="utf-8")
     normalized = " ".join(cli.split())
 
-    assert "An authenticated same-version request is a no-op" in normalized
-    assert "it does not reinstall artifacts or run migrations" in normalized
+    assert "An authenticated same-version request is normally a no-op" in normalized
+    assert "--recover-corrupt-audit" in normalized
+    assert "field-recovery cases below are the exceptions" in normalized
     assert "run automatically even during same-version upgrades" not in normalized
 
 

--- a/cli/tests/test_release_candidate.py
+++ b/cli/tests/test_release_candidate.py
@@ -1157,6 +1157,15 @@ def test_posix_only_publish_set_omits_only_windows_binaries() -> None:
     } <= posix_only
 
 
+def test_signed_rescue_bootstrap_starts_with_release_channel_protocol() -> None:
+    assert "defenseclaw-rescue.sh" not in release_candidate.resolver_asset_names("0.8.7")
+    assert "defenseclaw-rescue.sh" in release_candidate.resolver_asset_names("0.8.8")
+    assert (
+        release_candidate.RESOLVER_COMPLETENESS_MARKERS["defenseclaw-rescue.sh"]
+        == b"# DefenseClaw rescue bootstrap complete v1"
+    )
+
+
 def test_windows_setup_custody_starts_at_086_and_survives_legacy_omission() -> None:
     assert release_candidate.windows_installer_asset_names("0.8.5") == ()
     assert release_candidate.release_proof_asset_names("0.8.5") == (
@@ -1978,6 +1987,7 @@ def test_local_release_harness_stages_exact_reviewed_resolvers(tmp_path: Path) -
 
 def test_exact_reviewed_release_sources_have_cross_platform_lf_attributes() -> None:
     reviewed = (
+        "scripts/defenseclaw-rescue.sh",
         "scripts/upgrade.sh",
         "scripts/upgrade.ps1",
         "cli/defenseclaw/install_publish.py",

--- a/cli/tests/test_release_channel.py
+++ b/cli/tests/test_release_channel.py
@@ -1,0 +1,392 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts import release_candidate, release_channel
+
+ROOT = Path(__file__).resolve().parents[2]
+REPOSITORY = "cisco-ai-defense/defenseclaw"
+VERSION = "0.8.8"
+COMMIT = "a" * 40
+RESCUE = ROOT / "scripts/defenseclaw-rescue.sh"
+PUBLISHER = ROOT / "scripts/publish-release-channel.sh"
+WORKFLOW = ROOT / ".github/workflows/release.yaml"
+DOC = ROOT / "docs/RELEASE_CHANNEL.md"
+
+
+def _record(*, digest: str = "b" * 64) -> dict[str, str]:
+    return release_channel.build_channel(
+        repository=REPOSITORY,
+        version=VERSION,
+        commit=COMMIT,
+        resolver_sha256=digest,
+    )
+
+
+def test_channel_manifest_canonically_binds_immutable_resolver(tmp_path: Path) -> None:
+    checksums = tmp_path / "checksums.txt"
+    checksums.write_text(
+        f"{'1' * 64}  unrelated.bin\n{'b' * 64}  defenseclaw-upgrade.sh\n",
+        encoding="ascii",
+    )
+
+    digest = release_channel.resolver_digest_from_checksums(checksums)
+    payload = release_channel.render_channel(_record(digest=digest))
+    parsed = release_channel.parse_channel(payload)
+
+    assert digest == "b" * 64
+    assert list(parsed) == list(release_channel.FIELD_ORDER)
+    assert parsed == {
+        "schema": "defenseclaw-release-channel-v1",
+        "channel": "stable",
+        "repository": REPOSITORY,
+        "target_version": VERSION,
+        "target_tag": VERSION,
+        "target_ref": f"refs/tags/{VERSION}",
+        "target_commit": COMMIT,
+        "resolver_name": "defenseclaw-upgrade.sh",
+        "resolver_url": (f"https://github.com/{REPOSITORY}/releases/download/{VERSION}/defenseclaw-upgrade.sh"),
+        "resolver_sha256": "b" * 64,
+    }
+    assert payload.endswith(b"\n")
+    assert len(payload.splitlines()) == 10
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("target_tag", "v0.8.8", "tag does not equal"),
+        ("target_ref", "refs/heads/main", "exact immutable tag ref"),
+        ("target_commit", "A" * 40, "lowercase Git object ID"),
+        ("resolver_name", "bootstrap.sh", "reviewed POSIX resolver"),
+        (
+            "resolver_url",
+            "https://attacker.invalid/defenseclaw-upgrade.sh",
+            "not derived",
+        ),
+        ("resolver_sha256", "B" * 64, "lowercase SHA-256"),
+    ],
+)
+def test_channel_manifest_rejects_unbound_target_fields(
+    field: str,
+    value: str,
+    message: str,
+) -> None:
+    record = _record()
+    record[field] = value
+
+    with pytest.raises(release_channel.ChannelError, match=message):
+        release_channel.validate_channel(record)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"",
+        release_channel.render_channel_without_validation(_record()).rstrip(b"\n"),
+        release_channel.render_channel_without_validation(_record()).replace(
+            b"channel=stable\nrepository=",
+            b"repository=cisco-ai-defense/defenseclaw\nchannel=",
+        ),
+        release_channel.render_channel_without_validation(_record()) + b"extra=x\n",
+        release_channel.render_channel_without_validation(_record()).replace(
+            b"stable\n",
+            b"stabl\xc3\xa9\n",
+            1,
+        ),
+    ],
+)
+def test_channel_parser_rejects_noncanonical_wire_encodings(payload: bytes) -> None:
+    with pytest.raises(release_channel.ChannelError):
+        release_channel.parse_channel(payload)
+
+
+def test_channel_comparison_is_idempotent_and_monotonic() -> None:
+    current = _record()
+    assert release_channel.compare_channels(current, dict(current)) == "same"
+
+    advanced = release_channel.build_channel(
+        repository=REPOSITORY,
+        version="0.8.9",
+        commit="c" * 40,
+        resolver_sha256="d" * 64,
+    )
+    assert release_channel.compare_channels(current, advanced) == "advance"
+
+    with pytest.raises(release_channel.ChannelError, match="roll back"):
+        release_channel.compare_channels(advanced, current)
+
+    conflict = dict(current)
+    conflict["target_commit"] = "e" * 40
+    with pytest.raises(release_channel.ChannelError, match="already-published"):
+        release_channel.compare_channels(current, conflict)
+
+
+def test_channel_checksum_extraction_rejects_missing_duplicate_or_malformed(
+    tmp_path: Path,
+) -> None:
+    checksums = tmp_path / "checksums.txt"
+    checksums.write_text(f"{'a' * 64}  other.bin\n", encoding="ascii")
+    with pytest.raises(release_channel.ChannelError, match="does not bind"):
+        release_channel.resolver_digest_from_checksums(checksums)
+
+    checksums.write_text(
+        f"{'a' * 64}  defenseclaw-upgrade.sh\n{'b' * 64}  defenseclaw-upgrade.sh\n",
+        encoding="ascii",
+    )
+    with pytest.raises(release_channel.ChannelError, match="duplicate"):
+        release_channel.resolver_digest_from_checksums(checksums)
+
+    checksums.write_text(
+        f"{'a' * 64} *defenseclaw-upgrade.sh\n",
+        encoding="ascii",
+    )
+    with pytest.raises(release_channel.ChannelError, match="invalid"):
+        release_channel.resolver_digest_from_checksums(checksums)
+
+
+def _write_executable(path: Path, source: str) -> None:
+    path.write_text(source, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _rescue_fixture(
+    tmp_path: Path,
+    *,
+    channel_payload: bytes | None = None,
+    resolver_payload: bytes | None = None,
+    cosign_exit: int = 0,
+) -> tuple[dict[str, str], Path]:
+    fixture = tmp_path / "fixture"
+    fake_bin = tmp_path / "bin"
+    fixture.mkdir()
+    fake_bin.mkdir()
+    resolver_payload = resolver_payload or (
+        b"#!/usr/bin/env bash\n"
+        b"printf 'resolver-args:'\n"
+        b"printf ' <%s>' \"$@\"\n"
+        b"printf '\\n'\n"
+        b"# DefenseClaw upgrade resolver complete v1\n"
+    )
+    (fixture / "resolver.sh").write_bytes(resolver_payload)
+    digest = hashlib.sha256(resolver_payload).hexdigest()
+    channel_payload = channel_payload or release_channel.render_channel(_record(digest=digest))
+    (fixture / "stable.txt").write_bytes(channel_payload)
+    (fixture / "stable.txt.bundle").write_text("fixture bundle\n", encoding="ascii")
+
+    _write_executable(
+        fake_bin / "curl",
+        """#!/usr/bin/env bash
+set -euo pipefail
+destination=""
+url=""
+while (($#)); do
+  case "$1" in
+    --output) destination="$2"; shift 2 ;;
+    https://*) url="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+printf '%s\\n' "$url" >> "$RESCUE_CURL_LOG"
+case "$url" in
+  */release-channel/stable.txt) source="$RESCUE_FIXTURE/stable.txt" ;;
+  */release-channel/stable.txt.bundle) source="$RESCUE_FIXTURE/stable.txt.bundle" ;;
+  */releases/download/*/defenseclaw-upgrade.sh) source="$RESCUE_FIXTURE/resolver.sh" ;;
+  *) printf 'unexpected URL: %s\\n' "$url" >&2; exit 90 ;;
+esac
+cp "$source" "$destination"
+""",
+    )
+    _write_executable(
+        fake_bin / "cosign",
+        f"""#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$RESCUE_COSIGN_LOG"
+exit {cosign_exit}
+""",
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+            "RESCUE_FIXTURE": str(fixture),
+            "RESCUE_CURL_LOG": str(tmp_path / "curl.log"),
+            "RESCUE_COSIGN_LOG": str(tmp_path / "cosign.log"),
+            "TMPDIR": str(tmp_path),
+        }
+    )
+    return env, fixture
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX rescue bootstrap")
+def test_rescue_authenticates_channel_then_executes_exact_tagged_resolver(
+    tmp_path: Path,
+) -> None:
+    env, _fixture = _rescue_fixture(tmp_path)
+
+    completed = subprocess.run(
+        [str(RESCUE), "--yes", "--recover-corrupt-audit"],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert f"Authenticated stable resolver {VERSION} ({COMMIT})" in completed.stdout
+    assert (f"resolver-args: <--version> <{VERSION}> <--yes> <--recover-corrupt-audit>") in completed.stdout
+    curl_log = (tmp_path / "curl.log").read_text(encoding="utf-8").splitlines()
+    assert curl_log[:2] == [
+        f"https://raw.githubusercontent.com/{REPOSITORY}/release-channel/stable.txt",
+        f"https://raw.githubusercontent.com/{REPOSITORY}/release-channel/stable.txt.bundle",
+    ]
+    assert curl_log[2] == (f"https://github.com/{REPOSITORY}/releases/download/{VERSION}/defenseclaw-upgrade.sh")
+    cosign_log = (tmp_path / "cosign.log").read_text(encoding="utf-8")
+    assert "verify-blob" in cosign_log
+    assert "--bundle" in cosign_log
+    assert (f"https://github.com/{REPOSITORY}/.github/workflows/release.yaml@refs/heads/main") in cosign_log
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX rescue bootstrap")
+def test_rescue_rejects_signed_but_redirected_channel_before_resolver_download(
+    tmp_path: Path,
+) -> None:
+    payload = release_channel.render_channel_without_validation(_record()).replace(
+        (f"resolver_url=https://github.com/{REPOSITORY}/releases/download/{VERSION}/defenseclaw-upgrade.sh").encode(),
+        b"resolver_url=https://attacker.invalid/defenseclaw-upgrade.sh",
+    )
+    env, _fixture = _rescue_fixture(tmp_path, channel_payload=payload)
+
+    completed = subprocess.run(
+        [str(RESCUE), "--yes"],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode != 0
+    assert "resolver URL is not derived" in completed.stderr
+    curl_log = (tmp_path / "curl.log").read_text(encoding="utf-8").splitlines()
+    assert len(curl_log) == 2
+    assert all("attacker.invalid" not in line for line in curl_log)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX rescue bootstrap")
+def test_rescue_signature_failure_stops_before_channel_parse_or_resolver_download(
+    tmp_path: Path,
+) -> None:
+    env, _fixture = _rescue_fixture(
+        tmp_path,
+        channel_payload=b"not a channel\n",
+        cosign_exit=42,
+    )
+
+    completed = subprocess.run(
+        [str(RESCUE), "--yes"],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 42
+    assert "unsupported channel schema" not in completed.stderr
+    assert len((tmp_path / "curl.log").read_text().splitlines()) == 2
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX rescue bootstrap")
+@pytest.mark.parametrize(
+    "forbidden",
+    ["--version", "--version=0.8.7", "--allow-unverified"],
+)
+def test_rescue_refuses_target_or_authentication_override_before_network(
+    tmp_path: Path,
+    forbidden: str,
+) -> None:
+    env, _fixture = _rescue_fixture(tmp_path)
+
+    completed = subprocess.run(
+        [str(RESCUE), forbidden],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode != 0
+    assert not (tmp_path / "curl.log").exists()
+
+
+def test_release_workflow_advances_channel_only_after_immutable_custody() -> None:
+    workflow = yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    publish = workflow["jobs"]["publish-release"]
+    assert publish["permissions"] == {"contents": "write", "id-token": "write"}
+    names = [step.get("name") for step in publish["steps"]]
+    assert names.index("Prove published asset custody") < names.index("Sign and advance authenticated stable channel")
+    channel_step = next(
+        step for step in publish["steps"] if step.get("name") == "Sign and advance authenticated stable channel"
+    )
+    assert channel_step["run"] == "scripts/publish-release-channel.sh"
+    assert channel_step["env"]["RELEASE_CHECKSUMS"].endswith("/release-candidate/dist/checksums.txt")
+
+    publisher = PUBLISHER.read_text(encoding="utf-8")
+    assert "cosign sign-blob" in publisher
+    assert "scripts/verify-sigstore-blob.py" in publisher
+    assert 'scripts/release_channel.py" compare' in publisher
+    assert "git/matching-refs/heads/${CHANNEL_BRANCH}" in publisher
+    assert '"parents": [parent] if parent else []' in publisher
+    assert "-F force=false" in publisher
+    assert "force=true" not in publisher
+    assert "git push" not in publisher
+
+
+def test_rescue_is_an_immutable_signed_asset_from_088_forward(
+    tmp_path: Path,
+) -> None:
+    assert "defenseclaw-rescue.sh" not in release_candidate.payload_asset_names("0.8.7", "unverified")
+    assert "defenseclaw-rescue.sh" in release_candidate.payload_asset_names("0.8.8", "unverified")
+    assert release_candidate.RESOLVER_ASSET_SOURCES["defenseclaw-rescue.sh"] == RESCUE
+    assert release_candidate._validated_resolver_source("defenseclaw-rescue.sh") == RESCUE
+    assert RESCUE.read_bytes().splitlines()[-1] == (release_candidate.RESCUE_COMPLETENESS_MARKER)
+    staged = tmp_path / "staged"
+    staged.mkdir()
+    release_candidate.stage_resolvers(staged, "0.8.8")
+    assert (staged / "defenseclaw-rescue.sh").read_bytes() == RESCUE.read_bytes()
+
+
+def test_release_channel_scripts_have_valid_bash_syntax() -> None:
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is unavailable")
+    subprocess.run(
+        [bash, "-n", str(RESCUE), str(PUBLISHER)],
+        cwd=ROOT,
+        check=True,
+    )
+
+
+def test_release_channel_documentation_preserves_trust_boundary() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    for required in (
+        "mutable pointer to immutable code",
+        "`release-channel` branch",
+        "`release.yaml@main` Fulcio identity",
+        "Do not stream a raw branch or release response directly into a shell.",
+        "The bootstrap rejects an operator-supplied `--version`",
+        "non-forced, fast-forward Git",
+    ):
+        assert required in text

--- a/cli/tests/test_release_validation_strategy.py
+++ b/cli/tests/test_release_validation_strategy.py
@@ -236,9 +236,13 @@ def test_release_builds_tests_and_publishes_in_one_dispatch() -> None:
         "assemble-release-candidate",
         "release-smoke",
     ]
-    assert publish["permissions"] == {"contents": "write"}
+    assert publish["permissions"] == {
+        "contents": "write",
+        "id-token": "write",
+    }
     assert "scripts/release_candidate.py verify" in _render(publish)
     assert "scripts/release_candidate.py list-assets" in _render(publish)
+    assert "scripts/publish-release-channel.sh" in _render(publish)
     for name, job in jobs.items():
         if name != "publish-release":
             assert job.get("permissions") != {"contents": "write"}

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -821,7 +821,7 @@ def test_publish_uses_all_assets_from_the_exact_tested_candidate() -> None:
     jobs = _workflow()["jobs"]
     publish = jobs["publish-release"]
     assert publish["environment"] == "release"
-    assert publish["permissions"] == {"contents": "write"}
+    assert publish["permissions"] == {"contents": "write", "id-token": "write"}
     for name, job in jobs.items():
         if name != "publish-release":
             assert job.get("permissions") != {"contents": "write"}

--- a/cli/tests/test_resolve_upgrade_baselines.py
+++ b/cli/tests/test_resolve_upgrade_baselines.py
@@ -69,6 +69,10 @@ def _release(
         f"https://downloads.example/{version}/checksums.txt.sig": b"signature\n",
         f"https://downloads.example/{version}/upgrade-manifest.json": manifest,
     }
+    if tuple(map(int, version.split("."))) >= RESOLVER.SIGSTORE_BUNDLE_START_VERSION:
+        downloaded[f"https://downloads.example/{version}/checksums.txt.bundle"] = (
+            b'{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json"}\n'
+        )
     assets: list[dict[str, object]] = []
     for name, digest in payload_digests.items():
         if name in windows_assets and not windows:
@@ -80,7 +84,10 @@ def _release(
                 "browser_download_url": f"https://downloads.example/{version}/{name}",
             }
         )
-    for name in ("checksums.txt", "checksums.txt.pem", "checksums.txt.sig"):
+    proof_names = ["checksums.txt", "checksums.txt.pem", "checksums.txt.sig"]
+    if tuple(map(int, version.split("."))) >= RESOLVER.SIGSTORE_BUNDLE_START_VERSION:
+        proof_names.append("checksums.txt.bundle")
+    for name in proof_names:
         url = f"https://downloads.example/{version}/{name}"
         assets.append(
             {
@@ -332,6 +339,74 @@ def test_github_asset_digest_mismatch_fails_before_signature_use() -> None:
 
     with pytest.raises(RESOLVER.BaselineResolutionError, match="GitHub asset digest mismatch"):
         _resolve("0.8.6", [(release, downloads)])
+
+
+def test_checksum_proof_bundle_is_required_but_not_self_referential() -> None:
+    release, downloads = _release("0.8.7")
+
+    checksums = downloads["https://downloads.example/0.8.7/checksums.txt"]
+    assert b"checksums.txt.bundle" not in checksums
+    policy = _resolve("0.8.8", [(release, downloads)])
+
+    assert policy["published_baselines"][0] == "0.8.7"
+
+
+def test_checksum_proof_bundle_must_have_exact_immutable_custody() -> None:
+    release, downloads = _release("0.8.7")
+    release = copy.deepcopy(release)
+    for asset in release["assets"]:
+        if asset["name"] == "checksums.txt.bundle":
+            asset["digest"] = f"sha256:{'0' * 64}"
+
+    with pytest.raises(
+        RESOLVER.BaselineResolutionError,
+        match=r"GitHub asset digest mismatch for 0\.8\.7/checksums\.txt\.bundle",
+    ):
+        _resolve("0.8.8", [(release, downloads)])
+
+
+def test_checksum_proof_bundle_cannot_be_omitted_from_new_release() -> None:
+    release, downloads = _release("0.8.7")
+    release = copy.deepcopy(release)
+    release["assets"] = [asset for asset in release["assets"] if asset["name"] != "checksums.txt.bundle"]
+
+    with pytest.raises(
+        RESOLVER.BaselineResolutionError,
+        match=r"immutable release 0\.8\.7 lacks authentication assets.*checksums\.txt\.bundle",
+    ):
+        _resolve("0.8.8", [(release, downloads)])
+
+
+def test_checksum_proof_exception_does_not_admit_unknown_release_assets() -> None:
+    release, downloads = _release("0.8.7")
+    release = copy.deepcopy(release)
+    release["assets"].append(
+        {
+            "name": "unexpected.bin",
+            "digest": f"sha256:{_digest(b'unexpected')}",
+            "browser_download_url": "https://downloads.example/0.8.7/unexpected.bin",
+        }
+    )
+
+    with pytest.raises(
+        RESOLVER.BaselineResolutionError,
+        match=r"signed checksum and immutable GitHub asset disagree for 0\.8\.7/unexpected\.bin",
+    ):
+        _resolve("0.8.8", [(release, downloads)])
+
+
+def test_checksum_proof_exception_does_not_relax_payload_digest_binding() -> None:
+    release, downloads = _release("0.8.7")
+    release = copy.deepcopy(release)
+    for asset in release["assets"]:
+        if asset["name"] == "upgrade-manifest.json":
+            asset["digest"] = f"sha256:{'0' * 64}"
+
+    with pytest.raises(
+        RESOLVER.BaselineResolutionError,
+        match=r"GitHub asset digest mismatch for 0\.8\.7/upgrade-manifest\.json",
+    ):
+        _resolve("0.8.8", [(release, downloads)])
 
 
 def test_dynamic_runtime_config_cannot_exceed_the_candidate() -> None:

--- a/cli/tests/test_upgrade_field_recovery.py
+++ b/cli/tests/test_upgrade_field_recovery.py
@@ -1,0 +1,290 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+RESOLVER = ROOT / "scripts" / "upgrade.sh"
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt",
+    reason="release-owned resolver field recovery is POSIX-only",
+)
+
+
+def _embedded_python(after: str) -> str:
+    source = RESOLVER.read_text(encoding="utf-8")
+    start = source.index(after)
+    heredoc = source.index("<<'PY'", start)
+    body = source.index("\n", heredoc) + 1
+    end = source.index("\nPY\n", body)
+    return source[body:end] + "\n"
+
+
+def _private_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    path.chmod(0o700)
+    return path
+
+
+def _write_private(path: Path, payload: bytes) -> None:
+    path.write_bytes(payload)
+    path.chmod(0o600)
+
+
+def _run_quarantine(
+    program: str,
+    *,
+    data_dir: Path,
+    backup_dir: Path,
+    audit_db: Path,
+    backup_root: Path,
+    preflight_identity: str,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-B",
+            "-",
+            str(data_dir),
+            str(backup_dir),
+            str(audit_db),
+            str(backup_root),
+            preflight_identity,
+        ],
+        input=program,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+
+def _identity(path: Path) -> dict[str, int]:
+    info = path.lstat()
+    return {
+        "device": info.st_dev,
+        "inode": info.st_ino,
+        "size": info.st_size,
+        "mtime_ns": info.st_mtime_ns,
+    }
+
+
+def test_corrupt_custom_audit_store_moves_exact_bytes_to_private_custody(tmp_path: Path) -> None:
+    program = _embedded_python("quarantine_corrupt_audit_store() {")
+    data_dir = _private_dir(tmp_path / "data")
+    audit_parent = _private_dir(data_dir / "state")
+    backup_root = _private_dir(tmp_path / "controller" / "backups")
+    backup_dir = _private_dir(backup_root / "upgrade-test")
+    audit_db = audit_parent / "custom.sqlite"
+    payloads = {
+        audit_db: b"not a sqlite database\n",
+        Path(f"{audit_db}-wal"): b"wal custody\n",
+        Path(f"{audit_db}-shm"): b"shm custody\n",
+    }
+    for path, payload in payloads.items():
+        _write_private(path, payload)
+    info = audit_db.lstat()
+
+    completed = _run_quarantine(
+        program,
+        data_dir=data_dir,
+        backup_dir=backup_dir,
+        audit_db=audit_db,
+        backup_root=backup_root,
+        preflight_identity=f"{info.st_dev}:{info.st_ino}",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    custody = backup_dir / "audit-corrupt"
+    assert completed.stdout.strip() == str(custody)
+    assert (custody / "audit.db").read_bytes() == payloads[audit_db]
+    assert (custody / "audit.db-wal").read_bytes() == payloads[Path(f"{audit_db}-wal")]
+    assert (custody / "audit.db-shm").is_file()
+    assert stat.S_IMODE(custody.stat().st_mode) == 0o700
+    assert not audit_db.exists()
+    assert not (data_dir / ".audit-recovery.json").exists()
+
+
+def test_audit_custody_resumes_cross_controller_from_recorded_identities(tmp_path: Path) -> None:
+    program = _embedded_python("quarantine_corrupt_audit_store() {")
+    data_dir = _private_dir(tmp_path / "data")
+    audit_parent = _private_dir(data_dir / "state")
+    controller_backup_root = _private_dir(tmp_path / "controller" / "backups")
+    new_backup_dir = _private_dir(controller_backup_root / "upgrade-shell-retry")
+    cli_backup_root = _private_dir(data_dir / "backups")
+    cli_backup_dir = _private_dir(cli_backup_root / "upgrade-cli-attempt")
+    custody = _private_dir(cli_backup_dir / "audit-corrupt")
+    audit_db = audit_parent / "custom.sqlite"
+    sources = {
+        "audit.db": audit_db,
+        "audit.db-wal": Path(f"{audit_db}-wal"),
+        "audit.db-shm": Path(f"{audit_db}-shm"),
+    }
+    for name, path in sources.items():
+        _write_private(path, f"{name} exact bytes\n".encode())
+    identities = {name: _identity(path) for name, path in sources.items()}
+    os.rename(sources["audit.db-wal"], custody / "audit.db-wal")
+    marker = data_dir / ".audit-recovery.json"
+    marker.write_text(
+        json.dumps(
+            {
+                "schema": 2,
+                "source": str(audit_db),
+                "custody": str(custody),
+                "files": [
+                    "audit.db-wal",
+                    "audit.db-shm",
+                    "audit.db-journal",
+                    "audit.db",
+                ],
+                "identities": identities,
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    marker.chmod(0o600)
+
+    completed = _run_quarantine(
+        program,
+        data_dir=data_dir,
+        backup_dir=new_backup_dir,
+        audit_db=audit_db,
+        backup_root=controller_backup_root,
+        preflight_identity="",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == str(custody)
+    for name, record in identities.items():
+        retained = custody / name
+        assert _identity(retained) == record
+        assert not sources[name].exists()
+    assert not marker.exists()
+
+
+def test_missing_hard_cut_cursor_replays_real_migration_not_bootstrap(tmp_path: Path) -> None:
+    program = _embedded_python("repair_hard_cut_migration_cursor() {")
+    data_dir = _private_dir(tmp_path / "data")
+    config = data_dir / "config.yaml"
+    config.write_text(
+        f"config_version: 8\ndata_dir: {data_dir}\nobservability: {{}}\n",
+        encoding="utf-8",
+    )
+    config.chmod(0o600)
+    cursor = data_dir / ".migration_state.json"
+    applied = ["0.3.0", "0.4.0", "0.5.0", "0.7.0", "0.8.0"]
+    cursor.write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "package_version": "0.8.6",
+                "applied": applied,
+                "applied_at": {version: "bootstrap" for version in applied},
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    cursor.chmod(0o600)
+    openclaw_home = _private_dir(tmp_path / "openclaw")
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "DEFENSECLAW_HOME": str(data_dir),
+            "DEFENSECLAW_CONFIG": str(config),
+        }
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-B",
+            "-",
+            str(data_dir),
+            str(config),
+            str(openclaw_home),
+            "0.8.6",
+            "0",
+        ],
+        input=program,
+        text=True,
+        capture_output=True,
+        env=environment,
+        check=False,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    repaired = json.loads(cursor.read_text(encoding="utf-8"))
+    assert "0.8.5" in repaired["applied"]
+    assert repaired["applied_at"]["0.8.5"] != "bootstrap"
+
+
+def test_absent_cursor_reconstructs_only_pre_hard_cut_then_runs_real_migration(
+    tmp_path: Path,
+) -> None:
+    program = _embedded_python("repair_hard_cut_migration_cursor() {")
+    data_dir = _private_dir(tmp_path / "data")
+    config = data_dir / "config.yaml"
+    config.write_text(
+        f"config_version: 8\ndata_dir: {data_dir}\nobservability: {{}}\n",
+        encoding="utf-8",
+    )
+    config.chmod(0o600)
+    openclaw_home = _private_dir(tmp_path / "openclaw")
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-B",
+            "-",
+            str(data_dir),
+            str(config),
+            str(openclaw_home),
+            "0.8.6",
+            "1",
+        ],
+        input=program,
+        text=True,
+        capture_output=True,
+        env={
+            **os.environ,
+            "DEFENSECLAW_HOME": str(data_dir),
+            "DEFENSECLAW_CONFIG": str(config),
+        },
+        check=False,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    repaired = json.loads((data_dir / ".migration_state.json").read_text(encoding="utf-8"))
+    assert repaired["applied"] == ["0.3.0", "0.4.0", "0.5.0", "0.7.0", "0.8.0", "0.8.5"]
+    assert repaired["applied_at"]["0.8.5"] != "bootstrap"

--- a/cli/tests/test_upgrade_release_smoke_contract.py
+++ b/cli/tests/test_upgrade_release_smoke_contract.py
@@ -259,7 +259,10 @@ def test_posix_resolver_owns_dynamic_receipt_and_bundle_phases() -> None:
     gateway_activation = source.index('mv -f "${BRIDGE_GATEWAY_INSTALL_TEMP}"', stop)
     target_activation = source.index('UPGRADE_RECEIPT_FAILURE_CODE="interrupted"', gateway_activation)
     launcher = source.index('ln -sf "${DEFENSECLAW_VENV}/bin/defenseclaw"', target_activation)
-    migration = source.index('kwargs = {"upgrade_handles_local_bundle": True}', stop)
+    # Cursor repair may invoke the installed release's migration runner before
+    # target activation. This assertion is about the target-owned migration
+    # phase, so select the invocation that follows launcher activation.
+    migration = source.index('kwargs = {"upgrade_handles_local_bundle": True}', launcher)
     required = source.index('if [[ "${UPGRADE_INCOMPLETE}" -eq 1 ]]', migration)
     start = source.index("# ── Start services", required)
     health = source.index('if [[ "${HEALTH_OK}" -eq 0 ]]', start)

--- a/cli/tests/test_upgrade_staged_resolver.py
+++ b/cli/tests/test_upgrade_staged_resolver.py
@@ -590,9 +590,8 @@ def test_manual_hard_cut_artifacts_over_v7_state_refuse_before_release_download(
 
     output = result.stdout + result.stderr
     assert result.returncode != 0
-    assert "config-v8 migration state is absent or invalid" in output
-    assert "Unsupported manual overwrite detected" in output
-    assert "restore the exact 0.8.4 CLI, gateway, config, environment, and migration cursor" in output
+    assert "config-v8 migration state is invalid and cannot be reconstructed safely" in output
+    assert "restore one exact release-owned backup or contact support" in output
     assert "No changes were made" in output
     assert not mutation_log.exists()
     assert not curl_log.exists()

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -532,9 +532,14 @@ environment, cursor, and managed bundle before reporting rollback.
 
 **Version-specific migrations** are defined in `cli/defenseclaw/migrations.py`
 and run while an authenticated upgrade advances across the release boundary
-that owns them. An authenticated same-version request is a no-op: it does not
-reinstall artifacts or run migrations. Each migration is keyed to the release
-it ships with. For example, the v0.3.0 migration removes
+that owns them. An authenticated same-version request is normally a no-op.
+The two explicit field-recovery cases below are the exceptions: incomplete
+hard-cut cursor metadata replays every missing idempotent migration, and
+`--recover-corrupt-audit` replaces an explicitly proven-corrupt active store
+only after preserving its exact durable database and WAL bytes. A WAL-aware
+read-only probe may rebuild SQLite's disposable shared-memory index before the
+tuple enters custody. Each migration is keyed to the release it ships with. For
+example, the v0.3.0 migration removes
 legacy `models.providers.defenseclaw`, `models.providers.litellm`, and
 `agents.defaults.model.primary` prefixed entries from `openclaw.json` (written
 by 0.2.0's guardrail setup) while preserving plugin registration.
@@ -555,6 +560,10 @@ the v7 file.
 - `--yes`, `-y` — skip confirmation prompts
 - `--version VERSION` — select a specific final release; required bridges are
   still staged (default: latest)
+- `--recover-corrupt-audit` — after a bounded immutable SQLite integrity check
+  proves corruption, preserve the configured audit database and its WAL/SHM
+  sidecars in private, crash-resumable upgrade-backup custody and activate a
+  fresh local store. This separate opt-in is required even with `--yes`.
 - `--allow-unverified` — legacy-only unsafe override. It cannot bypass the
   signed manifest, checksum, bridge, or migration requirements for `0.8.4+`.
 
@@ -579,6 +588,22 @@ matrix is empty. Use the current target-release POSIX resolver on every
 | Any Windows source | The `0.8.4` release contains no Windows gateway/rollback binary, so no Windows hard-cut path is published. The PowerShell resolver fails closed before stopping services. Keep the current installation unchanged. |
 | A source outside the published matrix, including assetless `0.7.0`, `0.2.x`, or historical `0.3.x` releases | No tested in-place path is inferred. Remain on the current version and contact support for a source-specific, state-aware recovery plan. Do not uninstall, overwrite state, or force an intermediate hop. |
 | Direct installer from `0.8.3 → 0.8.5` | Refused before service stop or installed mutation. Manual artifact copying is unsupported because it bypasses bridge selection and rollback. Use the release-owned resolver; selecting a final version there does not bypass the bridge. |
+
+If a valid config-v8 installation is missing only its `0.8.5` migration-cursor
+record, use the authenticated current target-release resolver. After backup and
+verified gateway quiescence, it reconstructs pre-hard-cut cursor history,
+executes the real idempotent `0.8.5` migration, and requires a non-bootstrap
+cursor record before installing target artifacts. Frozen installed CLIs cannot
+gain this repair retroactively.
+
+If gateway startup reports SQLite corruption in the configured local audit
+store, rerun that same authenticated resolver with
+`--recover-corrupt-audit`. The resolver never treats a timeout, lock, generic
+I/O error, or unsafe path as proof of corruption. A successful recovery moves
+the exact main database and present SQLite sidecars into
+`backups/upgrade-*/audit-corrupt/`, retains them for offline forensics, and
+health-checks a newly initialized active store. Historical records in that
+custody file are not automatically imported into the fresh active database.
 
 **Examples:**
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -975,6 +975,40 @@ release-owned resolver materializes them privately. The conventional `.whl`,
 extracting, or package-installing either form is not a supported manual path;
 use the resolver so the bridge and rollback contract cannot be skipped.
 
+#### Recovering incomplete field state
+
+The current target-release POSIX resolver also handles two field states that a
+frozen installed CLI cannot repair retroactively:
+
+- A config-v8 installation with a missing, damaged, or valid-but-incomplete
+  cursor is backed up and stopped. Missing pre-hard-cut history can be inferred,
+  but every absent idempotent migration is executed and `0.8.5` must earn a
+  real timestamp; the resolver never synthesizes the hard-cut record from a
+  version string.
+- A configured local audit SQLite store that a bounded integrity probe proves
+  corrupt can be moved into private upgrade-backup custody before a fresh store
+  is initialized:
+
+  ```bash
+  bash defenseclaw-upgrade.sh --yes --recover-corrupt-audit
+  ```
+
+  The separate flag is required even with `--yes` because the retained
+  historical audit records are no longer queried by the new active database.
+  Live preflight uses immutable mode. If a WAL exists, the resolver waits until
+  the gateway is stopped and performs a WAL-aware read-only check while proving
+  the durable database and WAL identities did not change. Those durable bytes,
+  plus the post-probe SHM index and any journal, are retained under
+  `backups/upgrade-*/audit-corrupt/`; do not delete that custody directory. A
+  timeout, lock, generic I/O error, unsafe path, or changed inode is never
+  reclassified as corruption and never authorizes moving the store.
+
+Use the authenticated current target-release resolver asset, not the frozen
+installed command, when an older release refuses before downloading target
+artifacts. The resolver supports the same recovery when the target artifacts
+were already installed but gateway readiness failed, so a same-version retry
+does not leave the host stranded.
+
 #### 0.8.5 hard cut and the 0.8.4 bridge
 
 An installed `0.8.3` or older controller must not install `0.8.5` directly.

--- a/docs/RELEASE_CHANNEL.md
+++ b/docs/RELEASE_CHANNEL.md
@@ -1,0 +1,143 @@
+# Authenticated release channel and rescue bootstrap
+
+DefenseClaw keeps every versioned release immutable. A published tag is never
+edited to repair an installer or upgrade resolver. Starting with `0.8.8`, each
+release instead includes a small, checksummed `defenseclaw-rescue.sh` asset
+that discovers the current resolver through an authenticated stable channel.
+
+The result is a mutable pointer to immutable code:
+
+```mermaid
+flowchart LR
+    A["Signed defenseclaw-rescue.sh<br/>(immutable tagged asset)"]
+    B["stable.txt + Sigstore proof<br/>(mutable release-channel branch)"]
+    C["defenseclaw-upgrade.sh<br/>(immutable target-tag asset)"]
+    D["Signed checksums and release payloads<br/>(immutable target tag)"]
+
+    A -->|"verify release.yaml@main identity"| B
+    B -->|"exact tag URL + SHA-256"| C
+    C -->|"existing release authentication"| D
+```
+
+This separation lets a later release repair orchestration for older
+installations without replacing anything attached to an existing tag. The
+channel changes; the referenced resolver and all installable payloads do not.
+
+## Channel contract
+
+The release workflow publishes four files on the dedicated
+`release-channel` branch:
+
+- `stable.txt`
+- `stable.txt.sig`
+- `stable.txt.pem`
+- `stable.txt.bundle`
+
+`stable.txt` is fixed-order ASCII with exactly these fields:
+
+| Field | Binding |
+| --- | --- |
+| `schema` | `defenseclaw-release-channel-v1` |
+| `channel` | `stable` |
+| `repository` | `cisco-ai-defense/defenseclaw` |
+| `target_version` | Canonical `X.Y.Z` |
+| `target_tag` | Exactly equal to `target_version` |
+| `target_ref` | Exactly `refs/tags/<target_version>` |
+| `target_commit` | Lowercase 40-character commit ID |
+| `resolver_name` | Exactly `defenseclaw-upgrade.sh` |
+| `resolver_url` | Derived exactly from repository, tag, and resolver name |
+| `resolver_sha256` | Digest copied from the immutable release's signed `checksums.txt` |
+
+The document is not shell code and is never sourced or evaluated. Its
+fixed-order line format lets the rescue bootstrap parse it without depending
+on a working DefenseClaw Python environment, `python3`, or `jq`.
+
+## Publication order
+
+The release workflow advances the channel only after all of the following are
+true:
+
+1. The exact tested release candidate has been published under its version
+   tag.
+2. GitHub reports that release as immutable and every remote asset digest
+   matches the sealed candidate.
+3. The channel candidate is generated from that candidate's
+   `checksums.txt`.
+4. Cosign signs the channel with the keyless identity
+   `https://github.com/cisco-ai-defense/defenseclaw/.github/workflows/release.yaml@refs/heads/main`.
+5. The workflow verifies its own signature and the existing channel's
+   signature.
+6. The existing channel is either identical (an idempotent rerun) or points
+   to an older version. Same-version rebinding and version rollback are
+   rejected.
+7. The `release-channel` branch is updated with a non-forced, fast-forward Git
+   commit, and the workflow reads back and verifies the published bytes.
+
+If channel publication fails after the immutable release was created, the
+release remains valid but the stable pointer stays on the previous version.
+Rerunning the release workflow reconciles the already-published exact
+candidate and can safely retry the channel advance.
+
+Repository rules should protect `release-channel` from deletion, force pushes,
+and ordinary contributor writes. The release workflow's protected `release`
+environment is the intended publisher. Git history provides an audit trail,
+while the Sigstore proof prevents an unsigned branch edit from redirecting
+clients.
+
+## Rescue behavior
+
+Run `defenseclaw-rescue.sh` only after obtaining it from an authenticated
+`0.8.8` or later release (or another trusted distribution of those exact
+bytes). A `releases/latest/download` URL is only a locator; authenticate the
+bootstrap through that release's signed `checksums.txt` before its first use.
+Do not stream a raw branch or release response directly into a shell.
+
+The rescue bootstrap:
+
+1. Downloads `stable.txt` and its Sigstore bundle over HTTPS.
+2. Uses an existing Cosign, or downloads a platform-specific Cosign `2.6.3`
+   binary and verifies its hard-coded SHA-256.
+3. Verifies the bundle's transparency-log inclusion proof and requires the
+   exact `release.yaml@main` Fulcio identity and GitHub Actions OIDC issuer.
+4. Validates every channel field and reconstructs the canonical bytes so
+   duplicate, reordered, redirected, or extra fields fail closed.
+5. Downloads only the exact version-tagged resolver URL derived from the
+   authenticated channel.
+6. Verifies the resolver SHA-256, completeness marker, and Bash syntax.
+7. Supplies the authenticated channel version as the resolver's target and
+   passes the operator's recovery arguments.
+
+The bootstrap rejects an operator-supplied `--version` and
+`--allow-unverified`; neither command-line nor ambient legacy overrides may
+replace the signed stable target or bypass its authentication.
+
+For the two field-recovery cases:
+
+```bash
+# Repair an incomplete migration cursor with the current resolver.
+bash defenseclaw-rescue.sh --yes
+
+# Preserve a proven-corrupt audit SQLite tuple and activate a fresh store.
+bash defenseclaw-rescue.sh --yes --recover-corrupt-audit
+```
+
+The bootstrap itself never stops services or changes installed state. All
+preflight checks, backup, recovery custody, bridge selection, rollback, and
+post-install health checks remain owned by the authenticated target resolver.
+
+## Trust and failure boundaries
+
+- A mutable channel is not permission to mutate tagged artifacts. Resolver
+  bytes are fetched from an exact version tag and must match the signed
+  channel digest.
+- TLS is transport protection, not artifact authentication. The Sigstore
+  workflow identity authenticates the channel; SHA-256 then binds the tagged
+  resolver.
+- An unsigned channel edit, arbitrary URL, changed resolver name, tag/ref
+  mismatch, same-version digest change, or rollback publication is rejected.
+- A repository administrator could replay an older, previously valid signed
+  channel by bypassing branch rules. That is a freshness/availability risk,
+  not authority to execute modified bytes: the resolver is still an immutable
+  signed release asset, and normal upgrade policy refuses downgrades.
+- Windows continues to use native Setup and its signed release contract. This
+  initial rescue bootstrap is for supported macOS and Linux upgrade paths.

--- a/docs/RELEASE_VALIDATION.md
+++ b/docs/RELEASE_VALIDATION.md
@@ -20,7 +20,7 @@ already-selected reviewed commit while its release is running.
 
 ```bash
 gh workflow run release.yaml --ref main \
-  -f version=0.8.7 \
+  -f version=0.8.8 \
   -f immutable_releases_confirmed=true
 ```
 
@@ -84,6 +84,16 @@ immutable GitHub release. It publishes the selected Linux, macOS, and Windows
 assets from the sealed candidate and verifies the remote asset bytes. A failed
 gate leaves no release to promote and requires a new dispatch after the problem
 is fixed.
+
+Starting with `0.8.8`, the sealed candidate also contains the external
+`defenseclaw-rescue.sh` bootstrap. After proving the immutable remote release,
+the workflow signs a strict stable-channel document and fast-forwards the
+dedicated `release-channel` branch. The channel may point to a newer immutable
+resolver; no workflow replaces assets on an existing tag. If that final pointer
+update fails, the release remains valid and the prior stable pointer remains in
+place for a safe retry. See
+[Authenticated release channel and rescue bootstrap](RELEASE_CHANNEL.md) for
+the field-level trust and recovery contract.
 
 ## What belongs before merge
 

--- a/scripts/defenseclaw-rescue.sh
+++ b/scripts/defenseclaw-rescue.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Minimal external recovery entry point. It authenticates the mutable stable
+# channel, validates that every target locator is derived from the immutable
+# tag, verifies the exact tagged resolver digest, and only then executes it.
+
+set -euo pipefail
+umask 077
+
+readonly REPOSITORY="cisco-ai-defense/defenseclaw"
+readonly CHANNEL_BASE_URL="https://raw.githubusercontent.com/${REPOSITORY}/release-channel"
+readonly RELEASE_WORKFLOW_IDENTITY="https://github.com/${REPOSITORY}/.github/workflows/release.yaml@refs/heads/main"
+readonly SIGSTORE_OIDC_ISSUER="https://token.actions.githubusercontent.com"
+readonly COSIGN_VERSION="2.6.3"
+readonly COSIGN_RELEASE_URL="https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}"
+readonly CHANNEL_SCHEMA="defenseclaw-release-channel-v1"
+readonly CHANNEL_NAME="stable"
+readonly RESOLVER_NAME="defenseclaw-upgrade.sh"
+readonly RESOLVER_COMPLETENESS_MARKER="# DefenseClaw upgrade resolver complete v1"
+readonly MAX_CHANNEL_FILE_BYTES=65536
+readonly MAX_RESOLVER_BYTES=4194304
+readonly MAX_COSIGN_BYTES=209715200
+
+die() {
+    printf 'DefenseClaw rescue failed: %s\n' "$*" >&2
+    exit 1
+}
+
+download() {
+    local url="$1" destination="$2" max_bytes="$3"
+    for _ in 1 2 3; do
+        if curl --fail --silent --show-error --location \
+            --proto '=https' --proto-redir '=https' --tlsv1.2 \
+            --max-filesize "${max_bytes}" \
+            --output "${destination}" "${url}"; then
+            [[ -f "${destination}" && ! -L "${destination}" ]] \
+                || die "download did not create a regular file: ${url}"
+            local size
+            size="$(wc -c < "${destination}" | tr -d '[:space:]')"
+            [[ "${size}" =~ ^[0-9]+$ && "${size}" -gt 0 && "${size}" -le "${max_bytes}" ]] \
+                || die "download has invalid size: ${url}"
+            return 0
+        fi
+    done
+    die "could not download ${url}"
+}
+
+sha256_file() {
+    local path="$1"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "${path}" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "${path}" | awk '{print $1}'
+    else
+        die "sha256sum or shasum is required"
+    fi
+}
+
+command -v curl >/dev/null 2>&1 || die "curl is required"
+command -v bash >/dev/null 2>&1 || die "bash is required"
+for argument in "$@"; do
+    case "${argument}" in
+        --version | --version=*)
+            die "the authenticated stable channel owns the rescue target version"
+            ;;
+        --allow-unverified)
+            die "the authenticated rescue path does not permit --allow-unverified"
+            ;;
+    esac
+done
+
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/defenseclaw-rescue.XXXXXX")"
+readonly workdir
+cleanup() {
+    local status=$?
+    rm -rf -- "${workdir}"
+    return "${status}"
+}
+trap cleanup EXIT
+
+cosign_bin="$(command -v cosign || true)"
+if [[ -z "${cosign_bin}" ]]; then
+    platform="$(uname -s | tr '[:upper:]' '[:lower:]')/$(uname -m)"
+    case "${platform}" in
+        darwin/x86_64)
+            cosign_asset="cosign-darwin-amd64"
+            cosign_sha256="5715d61dd00a9b6dcb344de14910b434145855b7f82690b94183c553ac1b68be"
+            ;;
+        darwin/arm64)
+            cosign_asset="cosign-darwin-arm64"
+            cosign_sha256="ff497a698f125f3130b04f000b2cb0dd163bcaf00b5e776ef536035e6d0b3f3e"
+            ;;
+        linux/x86_64 | linux/amd64)
+            cosign_asset="cosign-linux-amd64"
+            cosign_sha256="7c78a7f2efc00088bd788a758db6e0928e79f3e0eb83eb5d3c499ed98da4c4f4"
+            ;;
+        linux/aarch64 | linux/arm64)
+            cosign_asset="cosign-linux-arm64"
+            cosign_sha256="b7c23659a50a59fd8eec44b87188e9062157d0c87796cac7b38727e5390c4917"
+            ;;
+        *)
+            die "unsupported platform for automatic Cosign verification: ${platform}"
+            ;;
+    esac
+    cosign_bin="${workdir}/${cosign_asset}"
+    download \
+        "${COSIGN_RELEASE_URL}/${cosign_asset}" \
+        "${cosign_bin}" \
+        "${MAX_COSIGN_BYTES}"
+    [[ "$(sha256_file "${cosign_bin}")" == "${cosign_sha256}" ]] \
+        || die "downloaded Cosign digest mismatch"
+    chmod 700 "${cosign_bin}"
+fi
+
+channel="${workdir}/stable.txt"
+for suffix in "" ".bundle"; do
+    download \
+        "${CHANNEL_BASE_URL}/stable.txt${suffix}" \
+        "${channel}${suffix}" \
+        "${MAX_CHANNEL_FILE_BYTES}"
+done
+
+"${cosign_bin}" verify-blob \
+    --bundle "${channel}.bundle" \
+    --certificate-identity "${RELEASE_WORKFLOW_IDENTITY}" \
+    --certificate-oidc-issuer "${SIGSTORE_OIDC_ISSUER}" \
+    "${channel}" >/dev/null
+
+line_count="$(wc -l < "${channel}" | tr -d '[:space:]')"
+[[ "${line_count}" == "10" ]] \
+    || die "authenticated channel must contain exactly 10 canonical fields"
+
+schema="$(sed -n '1s/^schema=//p' "${channel}")"
+channel_name="$(sed -n '2s/^channel=//p' "${channel}")"
+repository="$(sed -n '3s/^repository=//p' "${channel}")"
+target_version="$(sed -n '4s/^target_version=//p' "${channel}")"
+target_tag="$(sed -n '5s/^target_tag=//p' "${channel}")"
+target_ref="$(sed -n '6s/^target_ref=//p' "${channel}")"
+target_commit="$(sed -n '7s/^target_commit=//p' "${channel}")"
+resolver_name="$(sed -n '8s/^resolver_name=//p' "${channel}")"
+resolver_url="$(sed -n '9s/^resolver_url=//p' "${channel}")"
+resolver_sha256="$(sed -n '10s/^resolver_sha256=//p' "${channel}")"
+
+[[ "${schema}" == "${CHANNEL_SCHEMA}" ]] || die "unsupported channel schema"
+[[ "${channel_name}" == "${CHANNEL_NAME}" ]] || die "unexpected release channel"
+[[ "${repository}" == "${REPOSITORY}" ]] || die "channel repository mismatch"
+[[ "${target_version}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] \
+    || die "channel target version is not canonical"
+[[ "${target_tag}" == "${target_version}" ]] || die "channel tag/version mismatch"
+[[ "${target_ref}" == "refs/tags/${target_version}" ]] \
+    || die "channel ref is not the exact target tag"
+[[ "${target_commit}" =~ ^[0-9a-f]{40}$ ]] \
+    || die "channel target commit is invalid"
+[[ "${resolver_name}" == "${RESOLVER_NAME}" ]] || die "channel resolver name mismatch"
+expected_resolver_url="https://github.com/${REPOSITORY}/releases/download/${target_version}/${RESOLVER_NAME}"
+[[ "${resolver_url}" == "${expected_resolver_url}" ]] \
+    || die "channel resolver URL is not derived from its immutable tag"
+[[ "${resolver_sha256}" =~ ^[0-9a-f]{64}$ ]] \
+    || die "channel resolver digest is invalid"
+
+canonical="${workdir}/stable.canonical"
+printf '%s\n' \
+    "schema=${schema}" \
+    "channel=${channel_name}" \
+    "repository=${repository}" \
+    "target_version=${target_version}" \
+    "target_tag=${target_tag}" \
+    "target_ref=${target_ref}" \
+    "target_commit=${target_commit}" \
+    "resolver_name=${resolver_name}" \
+    "resolver_url=${resolver_url}" \
+    "resolver_sha256=${resolver_sha256}" \
+    > "${canonical}"
+cmp -s "${channel}" "${canonical}" || die "channel encoding is not canonical"
+
+resolver="${workdir}/${RESOLVER_NAME}"
+download "${resolver_url}" "${resolver}" "${MAX_RESOLVER_BYTES}"
+[[ "$(sha256_file "${resolver}")" == "${resolver_sha256}" ]] \
+    || die "tagged resolver digest does not match the authenticated channel"
+[[ "$(tail -n 1 "${resolver}")" == "${RESOLVER_COMPLETENESS_MARKER}" ]] \
+    || die "tagged resolver is incomplete"
+bash -n "${resolver}" || die "tagged resolver has invalid shell syntax"
+
+printf 'Authenticated stable resolver %s (%s); starting recovery controller.\n' \
+    "${target_version}" "${target_commit}"
+unset VERSION
+unset DEFENSECLAW_UPGRADE_ALLOW_UNVERIFIED
+bash "${resolver}" --version "${target_version}" "$@"
+# DefenseClaw rescue bootstrap complete v1

--- a/scripts/publish-release-channel.sh
+++ b/scripts/publish-release-channel.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Advance the mutable stable pointer only after the immutable target release has
+# been proved. The pointer bytes are signed by the release workflow's keyless
+# Sigstore identity and every update is a non-forced, fast-forward Git commit.
+
+set -euo pipefail
+umask 077
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly ROOT
+readonly CHANNEL_BRANCH="release-channel"
+readonly CHANNEL_REF="refs/heads/${CHANNEL_BRANCH}"
+readonly CHANNEL_MANIFEST="stable.txt"
+readonly CHANNEL_MAX_PUBLISHED_BYTES=1048576
+readonly SIGNING_IDENTITY_PREFIX="https://github.com"
+readonly SIGNING_OIDC_ISSUER="https://token.actions.githubusercontent.com"
+readonly CHANNEL_FILES=(
+    "stable.txt"
+    "stable.txt.sig"
+    "stable.txt.pem"
+    "stable.txt.bundle"
+)
+
+die() {
+    printf 'release channel publication failed: %s\n' "$*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || die "required command is unavailable: $1"
+}
+
+for name in GITHUB_REPOSITORY RELEASE_TAG RELEASE_COMMIT RELEASE_CHECKSUMS GH_TOKEN; do
+    [[ -n "${!name:-}" ]] || die "required environment variable is empty: ${name}"
+done
+[[ "${RELEASE_TAG}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] \
+    || die "RELEASE_TAG must be canonical X.Y.Z"
+[[ "${RELEASE_COMMIT}" =~ ^[0-9a-f]{40}$ ]] \
+    || die "RELEASE_COMMIT must be a lowercase 40-character Git object ID"
+[[ -f "${RELEASE_CHECKSUMS}" && ! -L "${RELEASE_CHECKSUMS}" ]] \
+    || die "RELEASE_CHECKSUMS must be a regular file"
+
+require_command base64
+require_command cosign
+require_command gh
+require_command python3
+
+WORKDIR="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/defenseclaw-release-channel.XXXXXX")"
+readonly WORKDIR
+cleanup() {
+    local status=$?
+    rm -rf -- "${WORKDIR}"
+    return "${status}"
+}
+trap cleanup EXIT
+
+candidate="${WORKDIR}/${CHANNEL_MANIFEST}"
+python3 "${ROOT}/scripts/release_channel.py" create \
+    --repository "${GITHUB_REPOSITORY}" \
+    --version "${RELEASE_TAG}" \
+    --commit "${RELEASE_COMMIT}" \
+    --checksums "${RELEASE_CHECKSUMS}" \
+    --output "${candidate}"
+
+cosign sign-blob \
+    --yes \
+    --bundle="${candidate}.bundle" \
+    --output-certificate="${candidate}.pem" \
+    --output-signature="${candidate}.sig" \
+    "${candidate}"
+python3 "${ROOT}/scripts/release_candidate.py" canonicalize-certificate \
+    --certificate "${candidate}.pem"
+python3 "${ROOT}/scripts/verify-sigstore-blob.py" \
+    --certificate "${candidate}.pem" \
+    --signature "${candidate}.sig" \
+    --certificate-identity \
+      "${SIGNING_IDENTITY_PREFIX}/${GITHUB_REPOSITORY}/.github/workflows/release.yaml@refs/heads/main" \
+    --certificate-oidc-issuer "${SIGNING_OIDC_ISSUER}" \
+    "${candidate}"
+cosign verify-blob \
+    --bundle "${candidate}.bundle" \
+    --certificate-identity \
+      "${SIGNING_IDENTITY_PREFIX}/${GITHUB_REPOSITORY}/.github/workflows/release.yaml@refs/heads/main" \
+    --certificate-oidc-issuer "${SIGNING_OIDC_ISSUER}" \
+    "${candidate}" >/dev/null
+
+refs_json="${WORKDIR}/refs.json"
+gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/heads/${CHANNEL_BRANCH}" \
+    > "${refs_json}"
+current_sha="$(
+    python3 - "${refs_json}" "${CHANNEL_REF}" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+path, expected_ref = sys.argv[1:]
+document = json.loads(Path(path).read_text(encoding="utf-8"))
+if not isinstance(document, list):
+    raise SystemExit("matching-refs response is not a list")
+matches = [row for row in document if isinstance(row, dict) and row.get("ref") == expected_ref]
+if len(matches) > 1:
+    raise SystemExit("release channel ref is ambiguous")
+if not matches:
+    print("")
+    raise SystemExit(0)
+obj = matches[0].get("object")
+sha = obj.get("sha") if isinstance(obj, dict) else None
+if not isinstance(sha, str) or re.fullmatch(r"[0-9a-f]{40}", sha) is None:
+    raise SystemExit("release channel ref lacks a canonical commit ID")
+print(sha)
+PY
+)"
+
+download_channel_file() {
+    local commit="$1" name="$2" destination="$3"
+    local response="${WORKDIR}/content-${name//[^A-Za-z0-9]/_}.json"
+    gh api --method GET \
+        "repos/${GITHUB_REPOSITORY}/contents/${name}" \
+        -f "ref=${commit}" > "${response}"
+    python3 - "${response}" "${name}" "${destination}" \
+        "${CHANNEL_MAX_PUBLISHED_BYTES}" <<'PY'
+import base64
+import binascii
+import json
+import os
+import sys
+from pathlib import Path
+
+response_path, expected_name, output_path, max_bytes_text = sys.argv[1:]
+document = json.loads(Path(response_path).read_text(encoding="utf-8"))
+if not isinstance(document, dict):
+    raise SystemExit("channel content response is not an object")
+if document.get("type") != "file":
+    raise SystemExit(f"published channel object is not a file: {expected_name}")
+if document.get("name") != expected_name or document.get("path") != expected_name:
+    raise SystemExit(f"published channel path mismatch: {expected_name}")
+if document.get("encoding") != "base64" or not isinstance(document.get("content"), str):
+    raise SystemExit(f"published channel encoding mismatch: {expected_name}")
+encoded = document["content"]
+if any(character not in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=\r\n" for character in encoded):
+    raise SystemExit(f"published channel base64 contains invalid characters: {expected_name}")
+try:
+    payload = base64.b64decode(encoded.replace("\r", "").replace("\n", ""), validate=True)
+except (ValueError, binascii.Error) as exc:
+    raise SystemExit(f"published channel base64 is invalid: {expected_name}") from exc
+size = document.get("size")
+if type(size) is not int or size != len(payload):
+    raise SystemExit(f"published channel size mismatch: {expected_name}")
+if not payload or len(payload) > int(max_bytes_text):
+    raise SystemExit(f"published channel file has invalid size: {expected_name}")
+descriptor = os.open(output_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+try:
+    view = memoryview(payload)
+    while view:
+        written = os.write(descriptor, view)
+        if written <= 0:
+            raise SystemExit(f"published channel write stalled: {expected_name}")
+        view = view[written:]
+    os.fsync(descriptor)
+finally:
+    os.close(descriptor)
+PY
+}
+
+if [[ -n "${current_sha}" ]]; then
+    current_dir="${WORKDIR}/current"
+    mkdir -m 700 "${current_dir}"
+    for name in "${CHANNEL_FILES[@]}"; do
+        download_channel_file "${current_sha}" "${name}" "${current_dir}/${name}"
+    done
+    python3 "${ROOT}/scripts/verify-sigstore-blob.py" \
+        --certificate "${current_dir}/${CHANNEL_MANIFEST}.pem" \
+        --signature "${current_dir}/${CHANNEL_MANIFEST}.sig" \
+        --certificate-identity \
+          "${SIGNING_IDENTITY_PREFIX}/${GITHUB_REPOSITORY}/.github/workflows/release.yaml@refs/heads/main" \
+        --certificate-oidc-issuer "${SIGNING_OIDC_ISSUER}" \
+        "${current_dir}/${CHANNEL_MANIFEST}"
+    cosign verify-blob \
+        --bundle "${current_dir}/${CHANNEL_MANIFEST}.bundle" \
+        --certificate-identity \
+          "${SIGNING_IDENTITY_PREFIX}/${GITHUB_REPOSITORY}/.github/workflows/release.yaml@refs/heads/main" \
+        --certificate-oidc-issuer "${SIGNING_OIDC_ISSUER}" \
+        "${current_dir}/${CHANNEL_MANIFEST}" >/dev/null
+    comparison="$(
+        python3 "${ROOT}/scripts/release_channel.py" compare \
+            --current "${current_dir}/${CHANNEL_MANIFEST}" \
+            --candidate "${candidate}"
+    )"
+    if [[ "${comparison}" == "same" ]]; then
+        printf 'Stable release channel already points to authenticated %s\n' \
+            "${RELEASE_TAG}"
+        exit 0
+    fi
+    [[ "${comparison}" == "advance" ]] \
+        || die "unexpected channel comparison result: ${comparison}"
+fi
+
+declare -A blob_sha=()
+for name in "${CHANNEL_FILES[@]}"; do
+    payload="$(base64 < "${WORKDIR}/${name}" | tr -d '\n')"
+    response="${WORKDIR}/blob-${name//[^A-Za-z0-9]/_}.json"
+    gh api --method POST "repos/${GITHUB_REPOSITORY}/git/blobs" \
+        -f "content=${payload}" \
+        -f "encoding=base64" > "${response}"
+    blob_sha["${name}"]="$(
+        python3 - "${response}" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+document = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+sha = document.get("sha") if isinstance(document, dict) else None
+if not isinstance(sha, str) or re.fullmatch(r"[0-9a-f]{40}", sha) is None:
+    raise SystemExit("created channel blob lacks a canonical Git object ID")
+print(sha)
+PY
+    )"
+done
+
+tree_request="${WORKDIR}/tree-request.json"
+python3 - "${tree_request}" \
+    "${blob_sha[stable.txt]}" \
+    "${blob_sha[stable.txt.sig]}" \
+    "${blob_sha[stable.txt.pem]}" \
+    "${blob_sha[stable.txt.bundle]}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+output = Path(sys.argv[1])
+names = ("stable.txt", "stable.txt.sig", "stable.txt.pem", "stable.txt.bundle")
+shas = sys.argv[2:]
+document = {
+    "tree": [
+        {"path": name, "mode": "100644", "type": "blob", "sha": sha}
+        for name, sha in zip(names, shas, strict=True)
+    ]
+}
+output.write_text(json.dumps(document, separators=(",", ":")) + "\n", encoding="utf-8")
+PY
+tree_response="${WORKDIR}/tree-response.json"
+gh api --method POST "repos/${GITHUB_REPOSITORY}/git/trees" \
+    --input "${tree_request}" > "${tree_response}"
+tree_sha="$(
+    python3 - "${tree_response}" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+document = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+sha = document.get("sha") if isinstance(document, dict) else None
+if not isinstance(sha, str) or re.fullmatch(r"[0-9a-f]{40}", sha) is None:
+    raise SystemExit("created channel tree lacks a canonical Git object ID")
+print(sha)
+PY
+)"
+
+commit_request="${WORKDIR}/commit-request.json"
+python3 - "${commit_request}" "${tree_sha}" "${current_sha}" "${RELEASE_TAG}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+output, tree, parent, version = sys.argv[1:]
+document = {
+    "message": f"release-channel: stable -> {version}",
+    "tree": tree,
+    "parents": [parent] if parent else [],
+}
+Path(output).write_text(
+    json.dumps(document, separators=(",", ":")) + "\n",
+    encoding="utf-8",
+)
+PY
+commit_response="${WORKDIR}/commit-response.json"
+gh api --method POST "repos/${GITHUB_REPOSITORY}/git/commits" \
+    --input "${commit_request}" > "${commit_response}"
+published_commit="$(
+    python3 - "${commit_response}" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+document = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+sha = document.get("sha") if isinstance(document, dict) else None
+if not isinstance(sha, str) or re.fullmatch(r"[0-9a-f]{40}", sha) is None:
+    raise SystemExit("created channel commit lacks a canonical Git object ID")
+print(sha)
+PY
+)"
+
+if [[ -n "${current_sha}" ]]; then
+    gh api --method PATCH \
+        "repos/${GITHUB_REPOSITORY}/git/refs/heads/${CHANNEL_BRANCH}" \
+        -f "sha=${published_commit}" \
+        -F force=false >/dev/null
+else
+    gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+        -f "ref=${CHANNEL_REF}" \
+        -f "sha=${published_commit}" >/dev/null
+fi
+
+published_refs="${WORKDIR}/published-refs.json"
+gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/heads/${CHANNEL_BRANCH}" \
+    > "${published_refs}"
+python3 - "${published_refs}" "${CHANNEL_REF}" "${published_commit}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, expected_ref, expected_commit = sys.argv[1:]
+document = json.loads(Path(path).read_text(encoding="utf-8"))
+if not isinstance(document, list):
+    raise SystemExit("published matching-refs response is not a list")
+matches = [row for row in document if isinstance(row, dict) and row.get("ref") == expected_ref]
+if len(matches) != 1:
+    raise SystemExit("published release channel ref is absent or ambiguous")
+obj = matches[0].get("object")
+actual_commit = obj.get("sha") if isinstance(obj, dict) else None
+if actual_commit != expected_commit:
+    raise SystemExit("published release channel ref does not point to the new commit")
+PY
+
+published_dir="${WORKDIR}/published"
+mkdir -m 700 "${published_dir}"
+for name in "${CHANNEL_FILES[@]}"; do
+    download_channel_file "${published_commit}" "${name}" "${published_dir}/${name}"
+done
+cmp -s "${candidate}" "${published_dir}/${CHANNEL_MANIFEST}" \
+    || die "published channel manifest differs from the signed candidate"
+python3 "${ROOT}/scripts/verify-sigstore-blob.py" \
+    --certificate "${published_dir}/${CHANNEL_MANIFEST}.pem" \
+    --signature "${published_dir}/${CHANNEL_MANIFEST}.sig" \
+    --certificate-identity \
+      "${SIGNING_IDENTITY_PREFIX}/${GITHUB_REPOSITORY}/.github/workflows/release.yaml@refs/heads/main" \
+    --certificate-oidc-issuer "${SIGNING_OIDC_ISSUER}" \
+    "${published_dir}/${CHANNEL_MANIFEST}"
+cosign verify-blob \
+    --bundle "${published_dir}/${CHANNEL_MANIFEST}.bundle" \
+    --certificate-identity \
+      "${SIGNING_IDENTITY_PREFIX}/${GITHUB_REPOSITORY}/.github/workflows/release.yaml@refs/heads/main" \
+    --certificate-oidc-issuer "${SIGNING_OIDC_ISSUER}" \
+    "${published_dir}/${CHANNEL_MANIFEST}" >/dev/null
+python3 "${ROOT}/scripts/release_channel.py" validate \
+    --repository "${GITHUB_REPOSITORY}" \
+    --version "${RELEASE_TAG}" \
+    "${published_dir}/${CHANNEL_MANIFEST}"
+
+printf 'Stable release channel advanced to authenticated %s at %s\n' \
+    "${RELEASE_TAG}" "${published_commit}"

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -127,10 +127,18 @@ UPGRADE_BASELINES_PATH = Path(
 HISTORICAL_ARTIFACT_DIGESTS_PATH = ROOT / "release" / "historical-artifact-digests.json"
 RUNTIME_CONFIG_PATH = ROOT / "internal" / "config" / "config.go"
 RESOLVER_COMPLETENESS_MARKER = b"# DefenseClaw upgrade resolver complete v1"
+RESCUE_COMPLETENESS_MARKER = b"# DefenseClaw rescue bootstrap complete v1"
 RESOLVER_ASSET_SOURCES = {
     "defenseclaw-upgrade.sh": ROOT / "scripts" / "upgrade.sh",
     "defenseclaw-upgrade.ps1": ROOT / "scripts" / "upgrade.ps1",
+    "defenseclaw-rescue.sh": ROOT / "scripts" / "defenseclaw-rescue.sh",
 }
+RESOLVER_COMPLETENESS_MARKERS = {
+    "defenseclaw-upgrade.sh": RESOLVER_COMPLETENESS_MARKER,
+    "defenseclaw-upgrade.ps1": RESOLVER_COMPLETENESS_MARKER,
+    "defenseclaw-rescue.sh": RESCUE_COMPLETENESS_MARKER,
+}
+RELEASE_CHANNEL_BOOTSTRAP_START_VERSION = (0, 8, 8)
 MAX_RESOLVER_BYTES = 4 * 1024 * 1024
 MAX_RELEASE_CERTIFICATE_BYTES = 64 * 1024
 MAX_EFFECTIVE_UPGRADE_BASELINES_BYTES = 1024 * 1024
@@ -547,7 +555,10 @@ def resolver_asset_names(version: str) -> tuple[str, ...]:
     _validate_version(version)
     if tuple(map(int, version.split("."))) < (0, 8, 4):
         return ()
-    return tuple(sorted(RESOLVER_ASSET_SOURCES))
+    names = {"defenseclaw-upgrade.sh", "defenseclaw-upgrade.ps1"}
+    if tuple(map(int, version.split("."))) >= RELEASE_CHANNEL_BOOTSTRAP_START_VERSION:
+        names.add("defenseclaw-rescue.sh")
+    return tuple(sorted(names))
 
 
 def release_identity_asset_names(version: str) -> tuple[str, ...]:
@@ -665,7 +676,7 @@ def _validated_resolver_source(name: str) -> Path:
         raise CandidateError(f"reviewed resolver source is not a regular file: {source}")
     if not payload or len(payload) > MAX_RESOLVER_BYTES or b"\0" in payload:
         raise CandidateError(f"reviewed resolver source has invalid content: {source}")
-    if payload.splitlines()[-1] != RESOLVER_COMPLETENESS_MARKER:
+    if payload.splitlines()[-1] != RESOLVER_COMPLETENESS_MARKERS[name]:
         raise CandidateError(f"reviewed resolver source lacks its completeness marker: {source}")
     # Windows does not preserve Git's POSIX executable bit in os.stat().
     # Enforce the reviewed mode where the host exposes POSIX permissions;

--- a/scripts/release_channel.py
+++ b/scripts/release_channel.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Create and validate the authenticated DefenseClaw stable release channel.
+
+The channel document is deliberately a fixed-order line protocol rather than
+JSON.  The external POSIX rescue bootstrap can therefore validate it without
+``jq``, Python, or evaluating network-controlled shell text.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import stat
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+SCHEMA = "defenseclaw-release-channel-v1"
+CHANNEL = "stable"
+RESOLVER_NAME = "defenseclaw-upgrade.sh"
+MAX_CHANNEL_BYTES = 16 * 1024
+MAX_CHECKSUMS_BYTES = 4 * 1024 * 1024
+VERSION_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+REPOSITORY_RE = re.compile(
+    r"^[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,99})/"
+    r"[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,99})$"
+)
+CHECKSUM_RE = re.compile(r"^([0-9a-f]{64})  ([A-Za-z0-9._-]+)$")
+FIELD_ORDER = (
+    "schema",
+    "channel",
+    "repository",
+    "target_version",
+    "target_tag",
+    "target_ref",
+    "target_commit",
+    "resolver_name",
+    "resolver_url",
+    "resolver_sha256",
+)
+
+
+class ChannelError(RuntimeError):
+    """The release channel is malformed, inconsistent, or regressive."""
+
+
+def _read_bounded_regular_file(path: Path, *, label: str, max_bytes: int) -> bytes:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise ChannelError(f"could not inspect {label} {path}: {exc}") from exc
+    if path.is_symlink() or not stat.S_ISREG(info.st_mode):
+        raise ChannelError(f"{label} must be a regular file: {path}")
+    if info.st_size <= 0 or info.st_size > max_bytes:
+        raise ChannelError(f"{label} has invalid size: {info.st_size}")
+    try:
+        payload = path.read_bytes()
+    except OSError as exc:
+        raise ChannelError(f"could not read {label} {path}: {exc}") from exc
+    if len(payload) != info.st_size:
+        raise ChannelError(f"{label} changed while it was read: {path}")
+    return payload
+
+
+def _validate_version(value: str) -> tuple[int, int, int]:
+    if VERSION_RE.fullmatch(value) is None:
+        raise ChannelError(f"target version must be canonical X.Y.Z: {value!r}")
+    return tuple(map(int, value.split(".")))  # type: ignore[return-value]
+
+
+def _validate_repository(value: str) -> None:
+    if REPOSITORY_RE.fullmatch(value) is None or ".." in value:
+        raise ChannelError(f"repository is not a canonical owner/name slug: {value!r}")
+
+
+def _resolver_url(repository: str, version: str) -> str:
+    return f"https://github.com/{repository}/releases/download/{version}/{RESOLVER_NAME}"
+
+
+def build_channel(
+    *,
+    repository: str,
+    version: str,
+    commit: str,
+    resolver_sha256: str,
+) -> dict[str, str]:
+    """Return one strict, self-consistent stable-channel record."""
+
+    _validate_repository(repository)
+    _validate_version(version)
+    if COMMIT_RE.fullmatch(commit) is None:
+        raise ChannelError("target commit must be a lowercase 40-character Git object ID")
+    if SHA256_RE.fullmatch(resolver_sha256) is None:
+        raise ChannelError("resolver digest must be a lowercase SHA-256")
+    return {
+        "schema": SCHEMA,
+        "channel": CHANNEL,
+        "repository": repository,
+        "target_version": version,
+        "target_tag": version,
+        "target_ref": f"refs/tags/{version}",
+        "target_commit": commit,
+        "resolver_name": RESOLVER_NAME,
+        "resolver_url": _resolver_url(repository, version),
+        "resolver_sha256": resolver_sha256,
+    }
+
+
+def render_channel(channel: dict[str, str]) -> bytes:
+    """Validate and render the canonical signed bytes."""
+
+    validated = validate_channel(channel)
+    return ("".join(f"{name}={validated[name]}\n" for name in FIELD_ORDER)).encode("ascii")
+
+
+def parse_channel(payload: bytes) -> dict[str, str]:
+    """Parse only the exact canonical line encoding accepted by the bootstrap."""
+
+    if not payload or len(payload) > MAX_CHANNEL_BYTES:
+        raise ChannelError("channel document has invalid size")
+    if b"\0" in payload or b"\r" in payload or not payload.endswith(b"\n"):
+        raise ChannelError("channel document must be NUL-free canonical LF text")
+    try:
+        text = payload.decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise ChannelError("channel document must contain only ASCII") from exc
+    lines = text.splitlines()
+    if len(lines) != len(FIELD_ORDER):
+        raise ChannelError(f"channel document must contain exactly {len(FIELD_ORDER)} fields")
+    values: dict[str, str] = {}
+    for expected_name, line in zip(FIELD_ORDER, lines, strict=True):
+        prefix = f"{expected_name}="
+        if not line.startswith(prefix):
+            raise ChannelError(f"channel field order mismatch: expected {expected_name!r}")
+        value = line[len(prefix) :]
+        if not value:
+            raise ChannelError(f"channel field {expected_name!r} is empty")
+        values[expected_name] = value
+    validated = validate_channel(values)
+    if render_channel_without_validation(validated) != payload:
+        raise ChannelError("channel document is not canonically encoded")
+    return validated
+
+
+def render_channel_without_validation(channel: dict[str, str]) -> bytes:
+    return "".join(f"{name}={channel[name]}\n" for name in FIELD_ORDER).encode("ascii")
+
+
+def validate_channel(
+    channel: dict[str, str],
+    *,
+    expected_repository: str | None = None,
+    expected_version: str | None = None,
+) -> dict[str, str]:
+    """Reject ambiguity and verify every derived target binding."""
+
+    if set(channel) != set(FIELD_ORDER):
+        missing = sorted(set(FIELD_ORDER) - set(channel))
+        extra = sorted(set(channel) - set(FIELD_ORDER))
+        raise ChannelError(f"channel fields differ from schema (missing={missing}, extra={extra})")
+    if channel["schema"] != SCHEMA:
+        raise ChannelError(f"unsupported channel schema: {channel['schema']!r}")
+    if channel["channel"] != CHANNEL:
+        raise ChannelError(f"unsupported release channel: {channel['channel']!r}")
+    repository = channel["repository"]
+    _validate_repository(repository)
+    if expected_repository is not None and repository != expected_repository:
+        raise ChannelError(f"channel repository mismatch: got {repository!r}, expected {expected_repository!r}")
+    version = channel["target_version"]
+    _validate_version(version)
+    if expected_version is not None and version != expected_version:
+        raise ChannelError(f"channel target mismatch: got {version!r}, expected {expected_version!r}")
+    if channel["target_tag"] != version:
+        raise ChannelError("channel target tag does not equal target version")
+    if channel["target_ref"] != f"refs/tags/{version}":
+        raise ChannelError("channel target ref is not the exact immutable tag ref")
+    if COMMIT_RE.fullmatch(channel["target_commit"]) is None:
+        raise ChannelError("channel target commit is not a lowercase Git object ID")
+    if channel["resolver_name"] != RESOLVER_NAME:
+        raise ChannelError("channel resolver name is not the reviewed POSIX resolver")
+    if channel["resolver_url"] != _resolver_url(repository, version):
+        raise ChannelError("channel resolver URL is not derived from repository and tag")
+    if SHA256_RE.fullmatch(channel["resolver_sha256"]) is None:
+        raise ChannelError("channel resolver digest is not a lowercase SHA-256")
+    return dict(channel)
+
+
+def resolver_digest_from_checksums(path: Path) -> str:
+    """Extract exactly one reviewed POSIX resolver digest."""
+
+    payload = _read_bounded_regular_file(
+        path,
+        label="release checksum manifest",
+        max_bytes=MAX_CHECKSUMS_BYTES,
+    )
+    try:
+        lines = payload.decode("ascii").splitlines()
+    except UnicodeDecodeError as exc:
+        raise ChannelError("release checksum manifest must contain only ASCII") from exc
+    entries: dict[str, str] = {}
+    for line_number, line in enumerate(lines, start=1):
+        match = CHECKSUM_RE.fullmatch(line)
+        if match is None:
+            raise ChannelError(f"invalid release checksum line {line_number}: {line!r}")
+        digest, name = match.groups()
+        if name in entries:
+            raise ChannelError(f"duplicate release checksum entry: {name}")
+        entries[name] = digest
+    try:
+        return entries[RESOLVER_NAME]
+    except KeyError as exc:
+        raise ChannelError(f"release checksum manifest does not bind {RESOLVER_NAME}") from exc
+
+
+def compare_channels(current: dict[str, str], candidate: dict[str, str]) -> str:
+    """Return ``same`` or ``advance``; reject conflicts and rollbacks."""
+
+    current = validate_channel(current)
+    candidate = validate_channel(candidate)
+    if current["repository"] != candidate["repository"]:
+        raise ChannelError("candidate channel changes repository ownership")
+    current_version = _validate_version(current["target_version"])
+    candidate_version = _validate_version(candidate["target_version"])
+    if candidate_version < current_version:
+        raise ChannelError("candidate channel would roll back the stable target")
+    if candidate_version == current_version:
+        if current != candidate:
+            raise ChannelError("candidate changes an already-published stable version binding")
+        return "same"
+    return "advance"
+
+
+def _load_channel(path: Path) -> dict[str, str]:
+    return parse_channel(
+        _read_bounded_regular_file(
+            path,
+            label="release channel",
+            max_bytes=MAX_CHANNEL_BYTES,
+        )
+    )
+
+
+def _write_new(path: Path, payload: bytes) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        view = memoryview(payload)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise ChannelError(f"writing release channel stalled: {path}")
+            view = view[written:]
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create = subparsers.add_parser("create")
+    create.add_argument("--repository", required=True)
+    create.add_argument("--version", required=True)
+    create.add_argument("--commit", required=True)
+    create.add_argument("--checksums", type=Path, required=True)
+    create.add_argument("--output", type=Path, required=True)
+
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--repository")
+    validate.add_argument("--version")
+    validate.add_argument("channel", type=Path)
+
+    compare = subparsers.add_parser("compare")
+    compare.add_argument("--current", type=Path, required=True)
+    compare.add_argument("--candidate", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "create":
+            digest = resolver_digest_from_checksums(args.checksums)
+            channel = build_channel(
+                repository=args.repository,
+                version=args.version,
+                commit=args.commit,
+                resolver_sha256=digest,
+            )
+            _write_new(args.output, render_channel(channel))
+            print(f"stable channel candidate created: {args.version}")
+        elif args.command == "validate":
+            validate_channel(
+                _load_channel(args.channel),
+                expected_repository=args.repository,
+                expected_version=args.version,
+            )
+            print("stable channel document valid")
+        elif args.command == "compare":
+            print(
+                compare_channels(
+                    _load_channel(args.current),
+                    _load_channel(args.candidate),
+                )
+            )
+        else:  # pragma: no cover - argparse owns command selection.
+            raise AssertionError(args.command)
+    except ChannelError as exc:
+        print(f"release channel error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/resolve_upgrade_baselines.py
+++ b/scripts/resolve_upgrade_baselines.py
@@ -40,11 +40,13 @@ MAX_RELEASE_INVENTORY_BYTES = 8 * 1024 * 1024
 MAX_CHECKSUMS_BYTES = 8 * 1024 * 1024
 MAX_CERTIFICATE_BYTES = 64 * 1024
 MAX_SIGNATURE_BYTES = 16 * 1024
+MAX_BUNDLE_BYTES = 16 * 1024 * 1024
 MAX_MANIFEST_BYTES = 1024 * 1024
 MAX_RELEASE_PAGES = 20
 MAX_DOWNLOAD_ATTEMPTS = 4
 INITIAL_DOWNLOAD_RETRY_DELAY_SECONDS = 1.0
 TRANSIENT_HTTP_STATUSES = frozenset({408, 425, 429})
+SIGSTORE_BUNDLE_START_VERSION = (0, 8, 7)
 
 
 class BaselineResolutionError(RuntimeError):
@@ -289,6 +291,21 @@ def _authenticate_release(
         "checksums.txt.sig": MAX_SIGNATURE_BYTES,
         "upgrade-manifest.json": MAX_MANIFEST_BYTES,
     }
+    authentication_assets = {
+        "checksums.txt",
+        "checksums.txt.pem",
+        "checksums.txt.sig",
+    }
+    # The Sigstore bundle is proof *about* checksums.txt and is necessarily
+    # created after that signed manifest. Like the detached certificate and
+    # signature, it cannot be self-referentially listed inside checksums.txt.
+    # It is nevertheless a required immutable release asset starting with the
+    # first published release that shipped one (0.8.7), and its downloaded
+    # bytes must match GitHub's immutable asset digest before it is admitted.
+    # The immutable 0.8.6 release predates bundle publication.
+    if _version_key(version) >= SIGSTORE_BUNDLE_START_VERSION:
+        required_metadata["checksums.txt.bundle"] = MAX_BUNDLE_BYTES
+        authentication_assets.add("checksums.txt.bundle")
     missing = sorted(set(required_metadata) - set(assets))
     if missing:
         raise BaselineResolutionError(f"immutable release {version} lacks authentication assets: {missing}")
@@ -320,7 +337,6 @@ def _authenticate_release(
     # platform payloads intentionally omitted at publication (0.8.4's Windows
     # bytes are the precedent), so signed-but-unpublished entries do not widen
     # platform support and are not themselves an error.
-    authentication_assets = {"checksums.txt", "checksums.txt.pem", "checksums.txt.sig"}
     for name, item in assets.items():
         if name in authentication_assets:
             continue

--- a/scripts/test-upgrade-protocol-release.sh
+++ b/scripts/test-upgrade-protocol-release.sh
@@ -743,6 +743,144 @@ run_candidate_updater_direct_success() {
     ok "Release-owned resolver upgrade passed: ${baseline} -> ${TARGET_VERSION}"
 }
 
+run_candidate_updater_field_recovery_success() {
+    local baseline="$1"
+    local recovery_case="$2"
+    local -a resolver_args=(--yes)
+    local audit_db=""
+    local inherited_smoke_home="${SMOKE_HOME}"
+    local SMOKE_HOME="${inherited_smoke_home}"
+    local FROM_VERSION="${FROM_VERSION}"
+    log "Proving release-owned resolver field recovery (${recovery_case}) ${baseline} -> ${TARGET_VERSION}"
+    if [[ "${recovery_case}" == "corrupt-audit-same-version" ]]; then
+        [[ "${baseline}" == "${TARGET_VERSION}" \
+            && -x "${SMOKE_HOME}/.defenseclaw/.venv/bin/python" ]] \
+            || die "same-version field recovery requires an installed target fixture"
+        FROM_VERSION="${TARGET_VERSION}"
+    else
+        FROM_VERSION="${baseline}"
+        SMOKE_HOME="${WORKDIR}/field-recovery-${baseline}-${recovery_case}"
+        rm -rf "${SMOKE_HOME}"
+        mkdir -p "${SMOKE_HOME}"
+        install_baseline
+        seed_upgrade_fixture
+        prepare_isolated_docker_path
+        start_source_gateway_canary
+    fi
+
+    case "${recovery_case}" in
+        missing-v8-cursor)
+            python3 - "${SMOKE_HOME}/.defenseclaw/.migration_state.json" <<'PY' \
+                || die "field-recovery migration cursor fixture could not be written"
+import json
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+document = json.loads(path.read_text(encoding="utf-8"))
+document["applied"] = [item for item in document["applied"] if item != "0.8.5"]
+document.setdefault("applied_at", {}).pop("0.8.5", None)
+path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+            ;;
+        corrupt-audit|corrupt-audit-same-version)
+            stop_smoke_gateway
+            audit_db="$(
+                HOME="${SMOKE_HOME}" \
+                DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \
+                PYTHONDONTWRITEBYTECODE=1 \
+                    "${SMOKE_HOME}/.defenseclaw/.venv/bin/python" -I -B - <<'PY'
+from defenseclaw.config import load
+
+print(load().audit_db)
+PY
+            )" || die "field-recovery audit fixture path could not be resolved"
+            [[ -n "${audit_db}" && "${audit_db}" == "${SMOKE_HOME}/"* ]] \
+                || die "field-recovery audit fixture escaped its isolated home"
+            python3 - "${audit_db}" <<'PY' \
+                || die "field-recovery corrupt audit fixture could not be written"
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+if not path.is_file() or path.is_symlink():
+    raise SystemExit("field-recovery audit fixture is unavailable")
+path.write_bytes(b"DefenseClaw corrupt audit fixture\n")
+path.chmod(0o600)
+PY
+            resolver_args+=(--recover-corrupt-audit)
+            ;;
+        *) die "unknown field-recovery case: ${recovery_case}" ;;
+    esac
+
+    local curl_shim="${SMOKE_HOME}/.upgrade-test-bin"
+    local real_curl
+    local log_file="${SMOKE_HOME}/upgrade.log"
+    real_curl="$(install_curl_rewrite_probe "${curl_shim}")"
+
+    if ! HOME="${SMOKE_HOME}" \
+        DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \
+        OPENCLAW_HOME="${SMOKE_HOME}/.openclaw" \
+        PYTHONDONTWRITEBYTECODE=1 \
+        DOCKER_HOST="${UPGRADE_SMOKE_DOCKER_HOST:-unix://${SMOKE_HOME}/no-docker.sock}" \
+        DEFENSECLAW_UPGRADE_TEST_MODE=1 \
+        DEFENSECLAW_UPGRADE_TEST_RELEASE_BASE_URL="${RELEASE_URL}" \
+        UPGRADE_GATE_REAL_CURL="${real_curl}" \
+        UPGRADE_GATE_RELEASE_URL="${RELEASE_URL}" \
+        UPGRADE_GATE_TARGET_VERSION="${TARGET_VERSION}" \
+        PATH="${curl_shim}:${SMOKE_HOME}/.local/bin:${PATH}" \
+            bash "${RELEASE_ROOT}/${TARGET_VERSION}/defenseclaw-upgrade.sh" \
+            "${resolver_args[@]}" >"${log_file}" 2>&1; then
+        tail_v8_upgrade_log_secret_safe "${log_file}"
+        die "release-owned resolver field recovery failed (${recovery_case}): ${baseline} -> ${TARGET_VERSION}"
+    fi
+
+    verify_upgrade
+    case "${recovery_case}" in
+        missing-v8-cursor)
+            grep -Fq "Replayed every missing migration and repaired the cursor" "${log_file}" \
+                || die "field recovery did not report idempotent 0.8.5 migration replay"
+            python3 - "${SMOKE_HOME}/.defenseclaw/.migration_state.json" <<'PY' \
+                || die "field-recovery migration cursor verification failed"
+import json
+from pathlib import Path
+import sys
+
+document = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if "0.8.5" not in document.get("applied", []):
+    raise SystemExit("field recovery did not record 0.8.5")
+if document.get("applied_at", {}).get("0.8.5") in {None, "bootstrap"}:
+    raise SystemExit("field recovery synthesized rather than executing 0.8.5")
+PY
+            ;;
+        corrupt-audit|corrupt-audit-same-version)
+            grep -Fq "Preserved corrupt audit SQLite set:" "${log_file}" \
+                || die "field recovery did not report corrupt audit custody"
+            python3 - "${SMOKE_HOME}/.defenseclaw" "${audit_db}" <<'PY' \
+                || die "field-recovery audit custody verification failed"
+from pathlib import Path
+import sqlite3
+import sys
+
+data_dir = Path(sys.argv[1])
+audit_db = Path(sys.argv[2])
+custody = list((data_dir / "backups").glob("upgrade-*/audit-corrupt/audit.db"))
+if len(custody) != 1:
+    raise SystemExit(f"expected one corrupt audit custody file, found {len(custody)}")
+if custody[0].read_bytes() != b"DefenseClaw corrupt audit fixture\n":
+    raise SystemExit("corrupt audit custody did not preserve exact source bytes")
+if (data_dir / ".audit-recovery.json").exists():
+    raise SystemExit("completed audit recovery retained its in-progress marker")
+with sqlite3.connect(audit_db) as connection:
+    if connection.execute("PRAGMA quick_check(1)").fetchone() != ("ok",):
+        raise SystemExit("fresh target audit database failed quick_check")
+PY
+            ;;
+    esac
+    stop_smoke_gateway
+    ok "Release-owned resolver field recovery passed (${recovery_case}): ${baseline} -> ${TARGET_VERSION}"
+}
+
 run_protocol_case() {
     local baseline="$1"
     if version_lte "${TARGET_VERSION}" "${baseline}"; then
@@ -835,6 +973,10 @@ run_protocol_case() {
                 run_candidate_updater_staged_success "${baseline}"
             else
                 run_candidate_updater_direct_success "${baseline}"
+                if [[ "${UPGRADE_SMOKE_FIELD_RECOVERY_CASES:-0}" == "1" ]]; then
+                    run_candidate_updater_field_recovery_success "${baseline}" missing-v8-cursor
+                    run_candidate_updater_field_recovery_success "${TARGET_VERSION}" corrupt-audit-same-version
+                fi
             fi
             return
         fi
@@ -871,6 +1013,10 @@ run_protocol_case() {
             run_candidate_updater_staged_success "${baseline}" explicit
         else
             run_candidate_updater_direct_success "${baseline}"
+            if [[ "${UPGRADE_SMOKE_FIELD_RECOVERY_CASES:-0}" == "1" ]]; then
+                run_candidate_updater_field_recovery_success "${baseline}" missing-v8-cursor
+                run_candidate_updater_field_recovery_success "${TARGET_VERSION}" corrupt-audit-same-version
+            fi
         fi
         return
     fi

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -28,11 +28,14 @@
 # release install (install.sh) and is release-specific.
 #
 # Usage:
-#   ./scripts/upgrade.sh [--yes] [--version VERSION] [--plan] [--help]
+#   ./scripts/upgrade.sh [--yes] [--version VERSION] [--recover-corrupt-audit] [--plan] [--help]
 #
 # Options:
 #   --yes, -y             Skip confirmation prompts
 #   --version VERSION     Select a specific final release (required bridges are still staged)
+#   --recover-corrupt-audit
+#                         Preserve a corrupt audit SQLite set in upgrade backup
+#                         custody and activate a fresh local audit store
 #   --plan                Verify contracts and print the resolved path only
 #   --help, -h            Show this help
 #
@@ -3640,12 +3643,16 @@ ensure_upgrade_lock_before_mutation() {
 
 YES=0
 PLAN_ONLY=0
+RECOVER_CORRUPT_AUDIT=0
 RELEASE_VERSION="${VERSION:-}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --yes|-y)   YES=1; shift ;;
         --plan)     PLAN_ONLY=1; shift ;;
+        --recover-corrupt-audit)
+            RECOVER_CORRUPT_AUDIT=1
+            shift ;;
         --version)
             [[ $# -lt 2 ]] && die "--version requires a value"
             RELEASE_VERSION="$2"; shift 2 ;;
@@ -3659,6 +3666,9 @@ while [[ $# -gt 0 ]]; do
   Options:
     --yes, -y             Skip confirmation prompts
     --version VERSION     Select a specific final release; required bridges are still staged
+    --recover-corrupt-audit
+                          Preserve a corrupt audit SQLite set in upgrade backup
+                          custody and activate a fresh local audit store
     --plan                Verify release contracts and print the path; make no changes
     --help, -h            Show this help
 
@@ -3830,12 +3840,14 @@ configured_data_dir = os.path.expanduser(cfg.data_dir or controller_home)
 if not os.path.isabs(configured_data_dir):
     raise RuntimeError("configured data_dir must be absolute for a staged upgrade")
 data_dir = os.path.abspath(configured_data_dir)
+audit_db = os.path.abspath(os.path.expanduser(cfg.audit_db or os.path.join(data_dir, "audit.db")))
 openclaw_home = os.path.abspath(
     os.path.expanduser(requested_openclaw if openclaw_explicit == "1" else cfg.claw.home_dir)
 )
 for label, value in (
     ("configured data_dir", data_dir),
     ("active config path", config_path),
+    ("configured audit database", audit_db),
     ("resolved OpenClaw home", openclaw_home),
 ):
     if any(character in value for character in ("\n", "\r", "\t")):
@@ -3883,14 +3895,16 @@ if (
     or config_info.st_uid != os.geteuid()
 ):
     raise RuntimeError("active config path must be a stable current-user-owned real file")
-print("\t".join((data_dir, config_path, openclaw_home)))
+print("\t".join((data_dir, config_path, openclaw_home, audit_db)))
 PY
     )" || die "Could not resolve a stable controller-home/data-dir/config-path split from the installed source controller. No changes were made."
-    IFS=$'\t' read -r DATA_DIR CONFIG_PATH RESOLVED_OPENCLAW_HOME <<< "${runtime_paths}"
-    [[ -n "${DATA_DIR}" && -n "${CONFIG_PATH}" && -n "${RESOLVED_OPENCLAW_HOME}" ]] \
+    IFS=$'\t' read -r DATA_DIR CONFIG_PATH RESOLVED_OPENCLAW_HOME AUDIT_DB_PATH <<< "${runtime_paths}"
+    [[ -n "${DATA_DIR}" && -n "${CONFIG_PATH}" && -n "${RESOLVED_OPENCLAW_HOME}" \
+        && -n "${AUDIT_DB_PATH}" ]] \
         || die "Installed source returned an incomplete runtime path contract. No changes were made."
     OPENCLAW_HOME="${RESOLVED_OPENCLAW_HOME}"
 else
+    AUDIT_DB_PATH="${DATA_DIR}/audit.db"
     CONFIG_PATH="$(python3 - "${CONFIG_PATH}" <<'PY'
 import os
 import sys
@@ -3910,7 +3924,8 @@ PY
 fi
 [[ -n "${DATA_DIR}" && "${DATA_DIR}" == /* \
    && -n "${CONFIG_PATH}" && "${CONFIG_PATH}" == /* \
-   && -n "${OPENCLAW_HOME}" && "${OPENCLAW_HOME}" == /* ]] \
+   && -n "${OPENCLAW_HOME}" && "${OPENCLAW_HOME}" == /* \
+   && -n "${AUDIT_DB_PATH}" && "${AUDIT_DB_PATH}" == /* ]] \
     || die "Resolved runtime paths are invalid; no changes were made."
 
 if [[ "${COMPONENT_VERSION_SPLIT}" -eq 1 ]]; then
@@ -4006,15 +4021,26 @@ PY
     warn "Found an authenticated interrupted ${CURRENT_VERSION} → ${RELEASE_VERSION} artifact activation; the resolver will re-verify the release and resume it."
 fi
 
+MIGRATION_CURSOR_REPAIR_NEEDED=0
+MIGRATION_CURSOR_RECONSTRUCT_NEEDED=0
+AUDIT_DB_RECOVERY_NEEDED=0
+AUDIT_DB_RECOVERY_USE_DATA_ROOT=0
+AUDIT_DB_RECOVERY_BACKUP_ROOT="${BACKUP_ROOT}"
+AUDIT_DB_RECOVERY_BACKUP_DIR=""
+AUDIT_DB_RECOVERY_CUSTODY=""
+AUDIT_DB_PREFLIGHT_IDENTITY=""
+
 if [[ "${CURRENT_VERSION}" != "unknown" ]] && version_gte "${CURRENT_VERSION}" "0.8.5"; then
     hard_cut_state="$("${DEFENSECLAW_VENV}/bin/python" -I -B - "${CONFIG_PATH}" \
-        "${DATA_DIR}/.migration_state.json" <<'PY' 2>/dev/null || true
+        "${DATA_DIR}/.migration_state.json" "${CURRENT_VERSION}" <<'PY' 2>/dev/null || true
 import json
 import os
+import re
 import stat
 import sys
 
 import yaml
+from defenseclaw.migrations import MIGRATIONS
 
 
 def bounded_regular(path, limit):
@@ -4024,30 +4050,340 @@ def bounded_regular(path, limit):
     return info
 
 
-config_path, cursor_path = sys.argv[1:]
+config_path, cursor_path, current_version = sys.argv[1:]
 bounded_regular(config_path, 4 * 1024 * 1024)
 with open(config_path, encoding="utf-8") as stream:
     config = yaml.safe_load(stream)
-bounded_regular(cursor_path, 1024 * 1024)
-with open(cursor_path, encoding="utf-8") as stream:
-    cursor = json.load(stream)
-valid = (
-    isinstance(config, dict)
-    and config.get("config_version") == 8
-    and isinstance(cursor, dict)
-    and cursor.get("schema") == 1
-    and isinstance(cursor.get("applied"), list)
-    and "0.8.5" in cursor["applied"]
+if not isinstance(config, dict) or config.get("config_version") != 8:
+    print("invalid")
+    raise SystemExit
+
+try:
+    bounded_regular(cursor_path, 1024 * 1024)
+except FileNotFoundError:
+    print("repairable-bootstrap")
+    raise SystemExit
+except (OSError, ValueError):
+    print("invalid")
+    raise SystemExit
+
+try:
+    with open(cursor_path, encoding="utf-8") as stream:
+        cursor = json.load(stream)
+except (OSError, UnicodeError, json.JSONDecodeError):
+    # The exact original remains available for backup custody before this
+    # resolver replaces it with release-derived bootstrap metadata.
+    print("repairable-bootstrap")
+    raise SystemExit
+
+if (
+    not isinstance(cursor, dict)
+    or isinstance(cursor.get("schema"), bool)
+    or cursor.get("schema") != 1
+):
+    print("invalid")
+    raise SystemExit
+applied = cursor.get("applied")
+if not isinstance(applied, list) or any(not isinstance(item, str) for item in applied):
+    print("invalid")
+    raise SystemExit
+
+canonical = re.compile(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)")
+registry_versions = {version for version, _description, _function in MIGRATIONS}
+version_key = lambda value: tuple(map(int, value.split(".")))
+applied_at = cursor.get("applied_at", {})
+if (
+    len(applied) != len(set(applied))
+    or any(canonical.fullmatch(item) is None for item in applied)
+    or any(item not in registry_versions for item in applied)
+    or any(version_key(item) > version_key(current_version) for item in applied)
+    or applied != sorted(applied, key=version_key)
+    or not isinstance(applied_at, dict)
+    or set(applied_at) != set(applied)
+    or any(
+        not isinstance(key, str)
+        or key not in applied
+        or not isinstance(value, str)
+        or not value
+        for key, value in applied_at.items()
+    )
+):
+    print("invalid")
+    raise SystemExit
+
+package_version = cursor.get("package_version", "")
+if package_version:
+    try:
+        if (
+            not isinstance(package_version, str)
+            or canonical.fullmatch(package_version) is None
+            or tuple(map(int, package_version.split("."))) > tuple(map(int, current_version.split(".")))
+        ):
+            print("invalid")
+            raise SystemExit
+    except (AttributeError, TypeError, ValueError):
+        print("invalid")
+        raise SystemExit
+expected = sorted(
+    (version for version in registry_versions if version_key(version) <= version_key(current_version)),
+    key=version_key,
 )
-print("valid" if valid else "invalid")
+if applied == expected:
+    print("valid")
+    raise SystemExit
+if any(item not in expected for item in applied):
+    print("invalid")
+    raise SystemExit
+print("repairable-replay")
 PY
 )"
-    if [[ "${hard_cut_state}" != "valid" ]]; then
-        die "CLI and gateway report hard-cut version ${CURRENT_VERSION}, but config-v8 migration state is absent or invalid and no recoverable journal is active. No changes were made.
-  Unsupported manual overwrite detected.
-  Recovery path: restore the exact 0.8.4 CLI, gateway, config, environment, and migration cursor from the pre-hard-cut backup, verify 0.8.4 health, then run this release-owned resolver without --version."
-    fi
+    case "${hard_cut_state}" in
+        valid) ;;
+        repairable-bootstrap)
+            MIGRATION_CURSOR_REPAIR_NEEDED=1
+            MIGRATION_CURSOR_RECONSTRUCT_NEEDED=1
+            warn "DefenseClaw ${CURRENT_VERSION} has config-v8 state but a missing or damaged migration cursor; the authenticated resolver will reconstruct pre-hard-cut history and replay every missing migration after backup and service stop."
+            ;;
+        repairable-replay)
+            MIGRATION_CURSOR_REPAIR_NEEDED=1
+            warn "DefenseClaw ${CURRENT_VERSION} has valid config-v8 state but an incomplete migration cursor; the authenticated resolver will replay every missing migration after backup and service stop."
+            ;;
+        *)
+            die "CLI and gateway report hard-cut version ${CURRENT_VERSION}, but config-v8 migration state is invalid and cannot be reconstructed safely. No changes were made.
+  Recovery path: restore one exact release-owned backup or contact support; do not copy individual wheel or gateway artifacts over this installation."
+            ;;
+    esac
 fi
+
+audit_db_probe="$(python3 - "${DATA_DIR}" "${AUDIT_DB_PATH}" "${BACKUP_ROOT}" <<'PY' 2>/dev/null || true
+import json
+import os
+import sqlite3
+import stat
+import sys
+import time
+from pathlib import Path
+
+data_dir = Path(sys.argv[1])
+path = Path(sys.argv[2])
+backup_root = Path(sys.argv[3]).absolute()
+marker = data_dir / ".audit-recovery.json"
+
+
+def corrupt_state() -> str:
+    try:
+        audit_device = path.parent.stat().st_dev
+        if audit_device == backup_root.parent.stat().st_dev:
+            return "corrupt"
+        if audit_device == data_dir.stat().st_dev:
+            return "corrupt-data-backup"
+        return "corrupt-cross-device"
+    except OSError:
+        return "unavailable"
+
+
+if os.path.lexists(marker):
+    try:
+        marker_info = marker.lstat()
+    except OSError:
+        print("invalid")
+        raise SystemExit
+    if (
+        stat.S_ISLNK(marker_info.st_mode)
+        or not stat.S_ISREG(marker_info.st_mode)
+        or marker_info.st_uid != os.geteuid()
+        or stat.S_IMODE(marker_info.st_mode) & 0o077
+        or not 0 < marker_info.st_size <= 64 * 1024
+    ):
+        print("invalid")
+    else:
+        try:
+            payload = json.loads(marker.read_text(encoding="utf-8"))
+            custody = Path(payload["custody"]).absolute()
+            allowed_roots = {
+                backup_root,
+                (data_dir / "backups").absolute(),
+            }
+            matching_roots = [
+                root
+                for root in allowed_roots
+                if os.path.commonpath((str(custody), str(root))) == str(root)
+                and custody.parent.parent == root
+            ]
+            valid_marker = (
+                isinstance(payload, dict)
+                and payload.get("schema") == 2
+                and payload.get("source") == str(path.absolute())
+                and payload.get("files") == [
+                    "audit.db-wal",
+                    "audit.db-shm",
+                    "audit.db-journal",
+                    "audit.db",
+                ]
+                and isinstance(payload.get("custody"), str)
+                and isinstance(payload.get("identities"), dict)
+                and len(matching_roots) == 1
+                and custody.name == "audit-corrupt"
+                and custody.parent.name.startswith("upgrade-")
+            )
+        except (KeyError, OSError, UnicodeError, ValueError, json.JSONDecodeError):
+            valid_marker = False
+        print("interrupted" if valid_marker else "invalid")
+    raise SystemExit
+try:
+    info = path.lstat()
+except FileNotFoundError:
+    print("absent")
+    raise SystemExit
+except OSError:
+    print("invalid")
+    raise SystemExit
+
+if (
+    stat.S_ISLNK(info.st_mode)
+    or not stat.S_ISREG(info.st_mode)
+    or info.st_uid != os.geteuid()
+    or stat.S_IMODE(info.st_mode) & 0o077
+):
+    print("invalid")
+    raise SystemExit
+
+identity = f"{info.st_dev}:{info.st_ino}"
+deadline = time.monotonic() + 15.0
+connection = None
+try:
+    connection = sqlite3.connect(path.as_uri() + "?mode=ro&immutable=1", uri=True, timeout=1.0)
+    connection.set_progress_handler(lambda: int(time.monotonic() >= deadline), 1000)
+    row = connection.execute("PRAGMA quick_check(1)").fetchone()
+except sqlite3.OperationalError as exc:
+    code = getattr(exc, "sqlite_errorcode", 0) & 0xFF
+    corrupt_codes = {
+        getattr(sqlite3, "SQLITE_CORRUPT", 11),
+        getattr(sqlite3, "SQLITE_NOTADB", 26),
+    }
+    if code in corrupt_codes:
+        print(f"{corrupt_state()}\t{identity}")
+    elif "interrupted" in str(exc).lower():
+        print("unchecked")
+    else:
+        print("unavailable")
+except sqlite3.DatabaseError as exc:
+    code = getattr(exc, "sqlite_errorcode", 0) & 0xFF
+    corrupt_codes = {
+        getattr(sqlite3, "SQLITE_CORRUPT", 11),
+        getattr(sqlite3, "SQLITE_NOTADB", 26),
+    }
+    print(f"{corrupt_state()}\t{identity}" if code in corrupt_codes else f"unavailable\t{identity}")
+else:
+    wal = Path(f"{path}-wal")
+    if row == ("ok",) and os.path.lexists(wal):
+        try:
+            wal_info = wal.lstat()
+        except OSError:
+            state = "unavailable"
+        else:
+            if (
+                stat.S_ISLNK(wal_info.st_mode)
+                or not stat.S_ISREG(wal_info.st_mode)
+                or wal_info.st_uid != os.geteuid()
+                or stat.S_IMODE(wal_info.st_mode) & 0o077
+            ):
+                state = "invalid"
+            else:
+                custody_state = corrupt_state()
+                state = (
+                    "wal-pending-cross-device"
+                    if custody_state == "corrupt-cross-device"
+                    else "wal-pending-data-backup"
+                    if custody_state == "corrupt-data-backup"
+                    else "wal-pending"
+                    if custody_state == "corrupt"
+                    else "unavailable"
+                )
+    else:
+        state = "healthy" if row == ("ok",) else corrupt_state()
+    print(f"{state}\t{identity}")
+finally:
+    if connection is not None:
+        connection.close()
+PY
+)"
+IFS=$'\t' read -r audit_db_state AUDIT_DB_PREFLIGHT_IDENTITY <<< "${audit_db_probe}"
+case "${audit_db_state}" in
+    healthy|absent) ;;
+    wal-pending)
+        if [[ "${RECOVER_CORRUPT_AUDIT}" -eq 1 ]]; then
+            AUDIT_DB_RECOVERY_NEEDED=1
+            warn "The active audit database has a WAL; corruption recovery will run a WAL-aware read-only integrity check after the gateway is stopped."
+        else
+            warn "The active audit database has a WAL that immutable live preflight cannot inspect; normal upgrade will continue without moving audit data."
+        fi
+        ;;
+    wal-pending-data-backup)
+        if [[ "${RECOVER_CORRUPT_AUDIT}" -eq 1 ]]; then
+            AUDIT_DB_RECOVERY_NEEDED=1
+            AUDIT_DB_RECOVERY_USE_DATA_ROOT=1
+            AUDIT_DB_RECOVERY_BACKUP_ROOT="${DATA_DIR}/backups"
+            warn "The active audit database has a WAL; corruption recovery will use same-filesystem data-directory custody and a WAL-aware read-only check after the gateway is stopped."
+        else
+            warn "The active audit database has a WAL that immutable live preflight cannot inspect; normal upgrade will continue without moving audit data."
+        fi
+        ;;
+    wal-pending-cross-device)
+        if [[ "${RECOVER_CORRUPT_AUDIT}" -eq 1 ]]; then
+            die "The configured audit SQLite store has a WAL but resides on a different filesystem from the managed backup root. No changes were made.
+  Move the configured audit store onto the DefenseClaw data filesystem or preserve it manually before selecting a fresh local store; the resolver will not perform a non-atomic cross-filesystem recovery."
+        fi
+        warn "The active audit database has a WAL that immutable live preflight cannot inspect; normal upgrade will continue without moving audit data."
+        ;;
+    unchecked)
+        if [[ "${RECOVER_CORRUPT_AUDIT}" -eq 1 ]]; then
+            die "The bounded read-only audit database integrity probe did not finish. No changes were made.
+  Retry after local audit activity settles; the resolver will not move audit bytes without an explicit SQLite corruption result."
+        fi
+        warn "The bounded read-only audit integrity probe did not finish; normal upgrade will continue without moving audit data."
+        ;;
+    unavailable)
+        if [[ "${RECOVER_CORRUPT_AUDIT}" -eq 1 ]]; then
+            die "The local audit database could not be checked safely. No changes were made.
+  Retry after local audit activity settles; only SQLite's explicit corruption result may authorize fresh-store recovery."
+        fi
+        warn "The live audit database could not be checked conclusively; normal upgrade will continue without moving audit data."
+        ;;
+    corrupt)
+        if [[ "${RECOVER_CORRUPT_AUDIT}" -ne 1 ]]; then
+            die "The local audit SQLite store is corrupt. No target artifacts were downloaded and no installed state changed.
+  Re-run this authenticated resolver with --recover-corrupt-audit to move audit.db and its SQLite sidecars into private upgrade-backup custody, activate a fresh local audit store, and retain the corrupt bytes for offline forensics."
+        fi
+        AUDIT_DB_RECOVERY_NEEDED=1
+        warn "The local audit SQLite store is corrupt; exact database bytes will be preserved in private upgrade-backup custody before a fresh store is activated."
+        ;;
+    corrupt-data-backup)
+        if [[ "${RECOVER_CORRUPT_AUDIT}" -ne 1 ]]; then
+            die "The local audit SQLite store is corrupt. No target artifacts were downloaded and no installed state changed.
+  Re-run this authenticated resolver with --recover-corrupt-audit to move audit.db and its SQLite sidecars into private same-filesystem data-directory custody, activate a fresh local audit store, and retain the corrupt bytes for offline forensics."
+        fi
+        AUDIT_DB_RECOVERY_NEEDED=1
+        AUDIT_DB_RECOVERY_USE_DATA_ROOT=1
+        AUDIT_DB_RECOVERY_BACKUP_ROOT="${DATA_DIR}/backups"
+        warn "The local audit SQLite store is corrupt; exact database bytes will be preserved in private same-filesystem data-directory custody before a fresh store is activated."
+        ;;
+    corrupt-cross-device)
+        die "The configured audit SQLite store is corrupt but resides on a different filesystem from the managed backup root. No changes were made.
+  Move the configured audit store onto the DefenseClaw data filesystem or preserve it manually before selecting a fresh local store; the resolver will not perform a non-atomic cross-filesystem recovery."
+        ;;
+    interrupted)
+        if [[ "${RECOVER_CORRUPT_AUDIT}" -ne 1 ]]; then
+            die "An interrupted audit-store recovery marker is present. No changes were made.
+  Re-run this authenticated resolver with --recover-corrupt-audit to resume the exact private-custody operation before upgrading."
+        fi
+        AUDIT_DB_RECOVERY_NEEDED=1
+        warn "An interrupted audit-store recovery will be resumed from its durable private-custody marker."
+        ;;
+    *)
+        die "The local audit database path is unsafe or unreadable. No changes were made."
+        ;;
+esac
 
 if [[ "${CURRENT_VERSION}" != "unknown" ]]; then
     validate_version "${CURRENT_VERSION}"
@@ -7209,7 +7545,9 @@ resolve_staged_upgrade
 
 if [[ "${CURRENT_VERSION}" != "unknown" \
       && "${CURRENT_VERSION}" == "${RELEASE_VERSION}" \
-      && -z "${STAGED_FINAL_VERSION}" ]]; then
+      && -z "${STAGED_FINAL_VERSION}" \
+      && "${MIGRATION_CURSOR_REPAIR_NEEDED}" -eq 0 \
+      && "${AUDIT_DB_RECOVERY_NEEDED}" -eq 0 ]]; then
     same_version_recovery="clean"
     if [[ -n "${RELEASE_PROVENANCE_FILE}" ]]; then
         [[ -x "${DEFENSECLAW_VENV}/bin/python" \
@@ -7352,6 +7690,14 @@ if [[ "${YES}" -eq 0 ]]; then
     printf "    2. Stop gateway, install pre-downloaded artifacts\n"
     printf "    3. Run version-specific migrations\n"
     printf "    4. Restart services and verify health\n"
+    recovery_step=5
+    if [[ "${MIGRATION_CURSOR_REPAIR_NEEDED}" -eq 1 ]]; then
+        printf "    %s. Replay every missing idempotent migration\n" "${recovery_step}"
+        recovery_step=$((recovery_step + 1))
+    fi
+    if [[ "${AUDIT_DB_RECOVERY_NEEDED}" -eq 1 ]]; then
+        printf "    %s. Preserve the corrupt audit SQLite set in backup custody and activate a fresh store\n" "${recovery_step}"
+    fi
     printf "       ${DIM}Source: github.com/${REPO}/releases/tag/${RELEASE_VERSION}${NC}\n\n"
     read -r -p "  Proceed? [y/N] " REPLY
     case "$REPLY" in
@@ -7428,6 +7774,47 @@ fi
 
 ok "Backup saved to: ${BACKUP_DIR}"
 
+AUDIT_DB_RECOVERY_BACKUP_DIR="${BACKUP_DIR}"
+if [[ "${AUDIT_DB_RECOVERY_NEEDED}" -eq 1 \
+      && "${AUDIT_DB_RECOVERY_USE_DATA_ROOT}" -eq 1 ]]; then
+    AUDIT_DB_RECOVERY_BACKUP_DIR="$(python3 - \
+        "${AUDIT_DB_RECOVERY_BACKUP_ROOT}" "${TIMESTAMP}" <<'PY'
+import os
+import stat
+import sys
+import tempfile
+
+root = os.path.abspath(os.path.expanduser(sys.argv[1]))
+timestamp = sys.argv[2]
+parent = os.path.dirname(root)
+parent_info = os.lstat(parent)
+if (
+    stat.S_ISLNK(parent_info.st_mode)
+    or not stat.S_ISDIR(parent_info.st_mode)
+    or parent_info.st_uid != os.geteuid()
+    or stat.S_IMODE(parent_info.st_mode) & 0o022
+):
+    raise SystemExit("audit backup parent must be a stable current-user-owned directory")
+try:
+    os.mkdir(root, 0o700)
+except FileExistsError:
+    pass
+root_info = os.lstat(root)
+if (
+    stat.S_ISLNK(root_info.st_mode)
+    or not stat.S_ISDIR(root_info.st_mode)
+    or root_info.st_uid != os.geteuid()
+):
+    raise SystemExit("audit backup root must be a current-user-owned real directory")
+os.chmod(root, 0o700)
+directory = tempfile.mkdtemp(prefix=f"upgrade-{timestamp}-audit-", dir=root)
+os.chmod(directory, 0o700)
+print(directory)
+PY
+)" || die "Could not create private same-filesystem audit recovery custody; no services changed."
+    ok "Audit recovery custody prepared: ${AUDIT_DB_RECOVERY_BACKUP_DIR}"
+fi
+
 # Provenance-authenticated direct upgrades commit their receipt before the
 # first service or installed-file mutation. Staged hard cuts keep receipt and
 # rollback custody in the fresh target controller instead.
@@ -7438,6 +7825,368 @@ if [[ "${BRIDGE_PHASE1}" -eq 1 ]]; then
 fi
 
 # ── Stop services ─────────────────────────────────────────────────────────────
+
+repair_hard_cut_migration_cursor() {
+    [[ "${MIGRATION_CURSOR_REPAIR_NEEDED}" -eq 1 ]] || return 0
+    if ! DEFENSECLAW_HOME="${DATA_DIR}" DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
+        "${DEFENSECLAW_VENV}/bin/python" -I -B - \
+        "${DATA_DIR}" "${CONFIG_PATH}" "${OPENCLAW_HOME}" "${CURRENT_VERSION}" \
+        "${MIGRATION_CURSOR_RECONSTRUCT_NEEDED}" <<'PY'
+import inspect
+import os
+import stat
+import sys
+
+from defenseclaw import migration_state
+from defenseclaw.config import ConfigVersionError, source_config_version
+from defenseclaw.migrations import MIGRATIONS, run_migrations
+
+data_dir, config_path, openclaw_home, current_version, reconstruct_raw = sys.argv[1:]
+reconstruct = reconstruct_raw == "1"
+data_info = os.lstat(data_dir)
+if (
+    stat.S_ISLNK(data_info.st_mode)
+    or not stat.S_ISDIR(data_info.st_mode)
+    or data_info.st_uid != os.geteuid()
+    or stat.S_IMODE(data_info.st_mode) & 0o077
+):
+    raise RuntimeError("migration cursor repair data directory is unsafe")
+try:
+    if source_config_version(path=config_path) != 8:
+        raise RuntimeError("migration cursor repair requires config-v8")
+except ConfigVersionError as exc:
+    raise RuntimeError("migration cursor repair could not validate config-v8") from exc
+
+cursor_path = migration_state.state_path(data_dir)
+if os.path.lexists(cursor_path):
+    cursor_info = os.lstat(cursor_path)
+    if (
+        stat.S_ISLNK(cursor_info.st_mode)
+        or not stat.S_ISREG(cursor_info.st_mode)
+        or cursor_info.st_uid != os.geteuid()
+        or stat.S_IMODE(cursor_info.st_mode) & 0o077
+        or not 0 < cursor_info.st_size <= 1024 * 1024
+    ):
+        raise RuntimeError("migration cursor repair input is unsafe")
+if migration_state.is_future_schema(data_dir):
+    raise RuntimeError("migration cursor repair refuses a future-schema cursor")
+
+expected = [
+    version
+    for version, _description, _function in MIGRATIONS
+    if tuple(map(int, version.split("."))) <= tuple(map(int, current_version.split(".")))
+]
+if reconstruct:
+    # Infer only pre-hard-cut history. The actual 0.8.5 migration must execute
+    # below and earn its cursor entry; never manufacture the hard-cut bit from
+    # a package-version claim.
+    state = migration_state.bootstrap(
+        None,
+        from_version="0.8.4",
+        package_version=current_version,
+        registry_versions=expected,
+    )
+    migration_state.save(data_dir, state)
+    if migration_state.is_applied(state, "0.8.5"):
+        raise RuntimeError("migration cursor repair unexpectedly synthesized the hard-cut entry")
+
+run_kwargs = {"upgrade_handles_local_bundle": True}
+if "controller_owns_local_bundle_transaction" in inspect.signature(run_migrations).parameters:
+    run_kwargs["controller_owns_local_bundle_transaction"] = True
+count = run_migrations(
+    current_version,
+    current_version,
+    openclaw_home,
+    data_dir,
+    **run_kwargs,
+)
+repaired = migration_state.load(data_dir)
+if (
+    count < 1
+    or repaired is None
+    or any(not migration_state.is_applied(repaired, version) for version in expected)
+    or repaired.applied_at.get("0.8.5") in {None, migration_state.BOOTSTRAP_SENTINEL}
+):
+    raise RuntimeError("idempotent migration replay did not durably repair the complete cursor")
+PY
+    then
+        return 1
+    fi
+    ok "Replayed every missing migration and repaired the cursor for ${CURRENT_VERSION}"
+}
+
+quarantine_corrupt_audit_store() {
+    [[ "${AUDIT_DB_RECOVERY_NEEDED}" -eq 1 ]] || return 0
+    if ! AUDIT_DB_RECOVERY_CUSTODY="$(python3 - \
+        "${DATA_DIR}" \
+        "${AUDIT_DB_RECOVERY_BACKUP_DIR}" \
+        "${AUDIT_DB_PATH}" \
+        "${AUDIT_DB_RECOVERY_BACKUP_ROOT}" \
+        "${AUDIT_DB_PREFLIGHT_IDENTITY}" <<'PY'
+import json
+import os
+from pathlib import Path
+import secrets
+import sqlite3
+import stat
+import sys
+import time
+
+data_dir = Path(sys.argv[1]).absolute()
+backup_dir = Path(sys.argv[2]).absolute()
+audit_db = Path(sys.argv[3]).absolute()
+backup_root = Path(sys.argv[4]).absolute()
+preflight_identity = sys.argv[5]
+marker = data_dir / ".audit-recovery.json"
+names = ("audit.db-wal", "audit.db-shm", "audit.db-journal", "audit.db")
+sources = (
+    ("audit.db-wal", Path(f"{audit_db}-wal")),
+    ("audit.db-shm", Path(f"{audit_db}-shm")),
+    ("audit.db-journal", Path(f"{audit_db}-journal")),
+    ("audit.db", audit_db),
+)
+
+
+def private_directory(path: Path) -> os.stat_result:
+    info = path.lstat()
+    if (
+        stat.S_ISLNK(info.st_mode)
+        or not stat.S_ISDIR(info.st_mode)
+        or info.st_uid != os.geteuid()
+        or stat.S_IMODE(info.st_mode) & 0o077
+    ):
+        raise RuntimeError(f"unsafe private directory: {path}")
+    return info
+
+
+def sync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def safe_file_identity(path: Path) -> dict:
+    info = path.lstat()
+    if (
+        stat.S_ISLNK(info.st_mode)
+        or not stat.S_ISREG(info.st_mode)
+        or info.st_uid != os.geteuid()
+        or stat.S_IMODE(info.st_mode) & 0o077
+        or info.st_nlink != 1
+    ):
+        raise RuntimeError(f"unsafe audit recovery input: {path.name}")
+    return {
+        "device": info.st_dev,
+        "inode": info.st_ino,
+        "size": info.st_size,
+        "mtime_ns": info.st_mtime_ns,
+    }
+
+
+def identity_string(identity: dict) -> str:
+    return f"{identity['device']}:{identity['inode']}"
+
+
+def validate_record(record: object) -> dict:
+    if not isinstance(record, dict) or set(record) != {
+        "device",
+        "inode",
+        "size",
+        "mtime_ns",
+    }:
+        raise RuntimeError("invalid audit recovery identity record")
+    if any(not isinstance(value, int) or isinstance(value, bool) or value < 0 for value in record.values()):
+        raise RuntimeError("invalid audit recovery identity value")
+    return record
+
+
+def require_still_corrupt(path: Path) -> bool:
+    wal = Path(f"{path}-wal")
+    durable_paths = [path]
+    if os.path.lexists(wal):
+        durable_paths.append(wal)
+    before = {str(item): safe_file_identity(item) for item in durable_paths}
+    deadline = time.monotonic() + 15.0
+    connection = None
+    result = "indeterminate"
+    try:
+        query = "?mode=ro" if len(durable_paths) > 1 else "?mode=ro&immutable=1"
+        connection = sqlite3.connect(path.as_uri() + query, uri=True, timeout=1.0)
+        connection.execute("PRAGMA query_only=ON")
+        connection.set_progress_handler(lambda: int(time.monotonic() >= deadline), 1000)
+        row = connection.execute("PRAGMA quick_check(1)").fetchone()
+    except sqlite3.DatabaseError as exc:
+        code = getattr(exc, "sqlite_errorcode", 0) & 0xFF
+        if code in {
+            getattr(sqlite3, "SQLITE_CORRUPT", 11),
+            getattr(sqlite3, "SQLITE_NOTADB", 26),
+        }:
+            result = "corrupt"
+    else:
+        if row == ("ok",):
+            result = "healthy"
+        elif row is not None:
+            result = "corrupt"
+    finally:
+        if connection is not None:
+            connection.close()
+    after = {str(item): safe_file_identity(item) for item in durable_paths}
+    if before != after:
+        raise RuntimeError("durable audit database bytes changed during the quiesced integrity probe")
+    if result == "indeterminate":
+        raise RuntimeError("quiesced audit database corruption could not be established")
+    return result == "corrupt"
+
+
+private_directory(data_dir)
+audit_parent_info = audit_db.parent.lstat()
+if (
+    stat.S_ISLNK(audit_parent_info.st_mode)
+    or not stat.S_ISDIR(audit_parent_info.st_mode)
+    or audit_parent_info.st_uid != os.geteuid()
+    or stat.S_IMODE(audit_parent_info.st_mode) & 0o022
+):
+    raise RuntimeError("unsafe audit database parent")
+
+if os.path.lexists(marker):
+    marker_info = marker.lstat()
+    if (
+        stat.S_ISLNK(marker_info.st_mode)
+        or not stat.S_ISREG(marker_info.st_mode)
+        or marker_info.st_uid != os.geteuid()
+        or stat.S_IMODE(marker_info.st_mode) & 0o077
+        or not 0 < marker_info.st_size <= 64 * 1024
+    ):
+        raise RuntimeError("unsafe interrupted audit recovery marker")
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema") != 2
+        or payload.get("files") != list(names)
+        or payload.get("source") != str(audit_db)
+        or not isinstance(payload.get("custody"), str)
+        or not isinstance(payload.get("identities"), dict)
+    ):
+        raise RuntimeError("invalid interrupted audit recovery marker")
+    custody = Path(payload["custody"]).absolute()
+    allowed_roots = {
+        backup_root,
+        (data_dir / "backups").absolute(),
+    }
+    matching_roots = [
+        root
+        for root in allowed_roots
+        if os.path.commonpath((str(custody), str(root))) == str(root)
+        and custody.parent.parent == root
+    ]
+    if (
+        len(matching_roots) != 1
+        or custody.name != "audit-corrupt"
+        or not custody.parent.name.startswith("upgrade-")
+    ):
+        raise RuntimeError("audit recovery custody escapes the backup root")
+    private_directory(matching_roots[0])
+    private_directory(custody.parent)
+    private_directory(custody)
+    identities = payload["identities"]
+    if set(identities) - set(names) or "audit.db" not in identities:
+        raise RuntimeError("invalid interrupted audit recovery identity set")
+    for record in identities.values():
+        validate_record(record)
+else:
+    private_directory(backup_root)
+    private_directory(backup_dir)
+    if audit_db.parent.stat().st_dev != backup_dir.stat().st_dev:
+        raise RuntimeError("audit recovery requires same-filesystem private backup custody")
+    main_identity = safe_file_identity(audit_db)
+    if not preflight_identity or identity_string(main_identity) != preflight_identity:
+        raise RuntimeError("audit database identity changed after the live integrity probe")
+    if not require_still_corrupt(audit_db):
+        print("__healthy__")
+        raise SystemExit
+    identities = {}
+    for name, source in sources:
+        if os.path.lexists(source):
+            identities[name] = safe_file_identity(source)
+    if "audit.db" not in identities:
+        raise RuntimeError("audit database disappeared before recovery custody")
+    custody = backup_dir / "audit-corrupt"
+    if os.path.lexists(custody):
+        raise RuntimeError("audit recovery custody target already exists")
+    custody.mkdir(mode=0o700)
+    private_directory(custody)
+    sync_directory(backup_dir)
+    payload = {
+        "schema": 2,
+        "source": str(audit_db),
+        "custody": str(custody),
+        "files": list(names),
+        "identities": identities,
+    }
+    temporary = data_dir / f".audit-recovery.{secrets.token_hex(16)}.tmp"
+    descriptor = os.open(
+        temporary,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0),
+        0o600,
+    )
+    try:
+        encoded = (json.dumps(payload, sort_keys=True) + "\n").encode()
+        view = memoryview(encoded)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError("short audit recovery marker write")
+            view = view[written:]
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    os.rename(temporary, marker)
+    sync_directory(data_dir)
+
+for name, source in sources:
+    destination = custody / name
+    source_exists = os.path.lexists(source)
+    destination_exists = os.path.lexists(destination)
+    recorded = identities.get(name)
+    if recorded is None:
+        if source_exists or destination_exists:
+            raise RuntimeError(f"unexpected audit recovery file appeared: {name}")
+        continue
+    if source_exists and destination_exists:
+        raise RuntimeError(f"audit recovery source and custody both contain {name}")
+    if not source_exists and not destination_exists:
+        raise RuntimeError(f"audit recovery lost recorded file: {name}")
+    observed = safe_file_identity(source if source_exists else destination)
+    if observed != validate_record(recorded):
+        raise RuntimeError(f"audit recovery identity changed: {name}")
+    if source_exists:
+        os.rename(source, destination)
+        sync_directory(custody)
+        sync_directory(source.parent)
+
+if (
+    safe_file_identity(custody / "audit.db") != validate_record(identities["audit.db"])
+    or os.path.lexists(audit_db)
+):
+    raise RuntimeError("audit recovery did not establish exact main-database custody")
+marker.unlink()
+sync_directory(data_dir)
+print(custody)
+PY
+    )"; then
+        return 1
+    fi
+    if [[ "${AUDIT_DB_RECOVERY_CUSTODY}" == "__healthy__" ]]; then
+        AUDIT_DB_RECOVERY_CUSTODY=""
+        ok "Post-quiescence audit database is healthy; no audit files were moved"
+        return 0
+    fi
+    [[ -n "${AUDIT_DB_RECOVERY_CUSTODY}" ]] || return 1
+    ok "Preserved corrupt audit SQLite set: ${AUDIT_DB_RECOVERY_CUSTODY}"
+    ok "Fresh local audit store will be initialized and health-checked by the target gateway"
+}
 
 assert_gateway_quiesced() {
     local pid_path="${DATA_DIR}/gateway.pid" pid_fields pid_state pid
@@ -7452,6 +8201,14 @@ assert_gateway_quiesced() {
 
 section "Stopping Services"
 
+SOURCE_GATEWAY_WAS_RUNNING=0
+source_gateway_pid_fields="$(gateway_pid_status \
+    "${DATA_DIR}/gateway.pid" "${INSTALL_DIR}/defenseclaw-gateway")" \
+    || die "Gateway PID custody is invalid before stop; refusing field-state recovery"
+if [[ "${source_gateway_pid_fields%%$'\t'*}" == "live" ]]; then
+    SOURCE_GATEWAY_WAS_RUNNING=1
+fi
+
 step "Stopping defenseclaw-gateway ..."
 if [[ "${BRIDGE_PHASE1}" -eq 1 ]]; then
     # Arm rollback before the stop: even a stop command that exits non-zero may
@@ -7462,6 +8219,28 @@ DEFENSECLAW_HOME="${DATA_DIR}" DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
     "${INSTALL_DIR}/defenseclaw-gateway" stop 2>/dev/null \
     && ok "Gateway stopped" || warn "Gateway was not running"
 assert_gateway_quiesced
+if ! repair_hard_cut_migration_cursor; then
+    if [[ "${SOURCE_GATEWAY_WAS_RUNNING}" -eq 1 ]]; then
+        DEFENSECLAW_HOME="${DATA_DIR}" DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
+            "${INSTALL_DIR}/defenseclaw-gateway" start 9>&- >/dev/null 2>&1 \
+            && warn "Migration-cursor repair failed; the source gateway was restarted." \
+            || warn "Migration-cursor repair failed and the source gateway could not be restarted."
+    fi
+    die "Could not reconstruct migration cursor metadata; target artifacts were not installed."
+fi
+if ! quarantine_corrupt_audit_store; then
+    if [[ ! -e "${DATA_DIR}/.audit-recovery.json" \
+        && ! -L "${DATA_DIR}/.audit-recovery.json" \
+        && "${SOURCE_GATEWAY_WAS_RUNNING}" -eq 1 ]]; then
+        DEFENSECLAW_HOME="${DATA_DIR}" DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
+            "${INSTALL_DIR}/defenseclaw-gateway" start 9>&- >/dev/null 2>&1 \
+            && warn "Audit-store recovery was refused safely; the source gateway was restarted." \
+            || warn "Audit-store recovery was refused and the source gateway could not be restarted."
+    else
+        warn "Audit-store recovery custody is incomplete; its durable marker was retained for an exact retry."
+    fi
+    die "Could not preserve the corrupt audit SQLite set; target artifacts were not installed."
+fi
 if [[ "${BRIDGE_PHASE1}" -eq 1 ]]; then
     post_stop_health="$(bridge_source_health_observation)" \
         || die "Could not verify source health quiescence after stop; the source will be restored."


### PR DESCRIPTION
> Base: `main`. This PR is not stacked. The recovery behavior, release-gate
> regressions, rescue asset, and signed channel publisher land together so the
> next immutable release cannot publish only part of the recovery contract.

## Problem

Two independent field states stranded real `0.8.6` installations during the
`0.8.7` upgrade:

1. One installation had config-v8 state but lacked the applied `0.8.5`
   migration cursor. The strict coherence check correctly refused to pretend
   the wheel, gateway, config, and migration history described one
   release-owned state, but it offered no authenticated repair path.
2. Another installation downloaded and installed `0.8.7`, then the gateway
   exited before readiness because its existing audit SQLite database was
   corrupt. The upgrade reported only a gateway-start failure, retained no
   explicit corrupt-store recovery transaction, and a same-version retry could
   collapse into a no-op.

Those failures look different because one is rejected before mutation and the
other appears only when the new gateway opens existing local state. They share
the same missing capability: the authenticated target resolver could validate
release artifacts, but could not safely reconcile damaged field state.

The already-published `0.8.7` resolver must remain immutable, so future
orchestration fixes also need a trustworthy path that does not replace assets
on an old tag.

## Current Situation

- `0.8.6` and `0.8.7` installations may contain a missing/damaged/partial
  migration cursor or a corrupt audit database.
- Audit data can be security evidence. `--yes` is not consent to discard or
  overwrite it.
- SQLite WAL mode makes a main-file-only corruption decision unsafe: live WAL
  bytes may contain the state needed to read the database.
- A failed custody move must be resumable without mixing bytes from different
  database generations.
- Tagged release assets are immutable and cannot be silently repaired in
  place.

On the affected connected Mac, a read-only plan authenticated the published
`0.8.7` release, classified the configured audit store as corrupt, selected
same-version recovery, and left the database, WAL, and SHM device/inode/size/
mtime tuple exactly unchanged.

## Solution

### Recover incomplete migration state without inventing the hard cut

For config-v8 installations with a missing or JSON-damaged cursor, reconstruct
only the known pre-hard-cut history through `0.8.4`, then execute the real
idempotent `0.8.5` migration. For a valid partial cursor, preserve the recorded
entries and execute every missing migration callable.

Recovery succeeds only when every migration expected for the installed version
is durably present and `0.8.5` has a real, non-bootstrap application record.
The shell resolver and Python controller implement and test the same contract.

### Preserve corrupt audit bytes before activating a fresh store

Add an explicit `--recover-corrupt-audit` authority. Without it, a proven
corrupt store fails closed with recovery instructions.

The recovery path:

1. performs a bounded read-only immutable check while services are live;
2. if WAL exists, stops the gateway and repeats a WAL-aware, query-only check;
3. binds the durable main/WAL identities before and after classification;
4. creates private custody on the audit store's filesystem;
5. writes and fsyncs a schema-2 recovery marker containing exact source,
   custody, file, and identity bindings;
6. moves sidecars first and the main database last, fsyncing custody and source
   directories; and
7. resumes safely from the marker after interruption.

SHM is treated as disposable SQLite coordination state; the durable main/WAL
bytes remain identity-bound. Custom audit paths, controller-home/data-directory
filesystem splits, and same-version reinstall/health-check recovery are
supported. A true third-filesystem custody request is refused.

### Add a signed mutable pointer to immutable future resolvers

Starting with `0.8.8`, each immutable release contains
`defenseclaw-rescue.sh`. After the exact candidate is published and remote
custody is proved, the release workflow signs a strict `stable.txt` channel
document with the protected
`release.yaml@refs/heads/main` Sigstore identity and fast-forwards the dedicated
`release-channel` branch without force.

The rescue bootstrap verifies the Sigstore bundle and exact workflow identity,
validates a fixed-order channel schema, derives the immutable tagged resolver
URL, verifies its channel-bound SHA-256 and completeness marker, then invokes
that resolver with the authenticated target version. It rejects arbitrary
URLs, target overrides, `--allow-unverified`, rollback, and same-version
rebinding.

Tagged assets remain immutable. Only the signed pointer advances.

### Gate the two real field states before publication

The newest authenticated Linux and macOS upgrade baseline now also exercises:

- a missing `0.8.5` migration cursor while upgrading to the candidate; and
- a corrupt audit store repaired through an exact same-version candidate
  reinstall.

Both cases must end with a complete non-bootstrap cursor, retained corrupt
custody, no recovery marker, a writable fresh audit database, a successful
upgrade receipt, and a healthy target gateway.

## Architecture

```mermaid
flowchart LR
    M["Reviewed main commit"] --> R["Immutable tagged release"]
    R --> A["Signed checksums + resolver + rescue asset"]
    A --> C["Sigstore-signed stable channel"]
    C -->|"exact tag URL + SHA-256"| T["Immutable target resolver"]
    T --> P{"Field-state preflight"}
    P -->|"missing/partial cursor"| V["Replay real missing migrations"]
    P -->|"proven corrupt audit + explicit authority"| Q["Crash-resumable private custody"]
    V --> H["Install/reinstall and target health"]
    Q --> H
```

## What Changed (Where & How)

| File / path | Summary |
| --- | --- |
| `scripts/upgrade.sh` | Adds cursor repair, WAL-aware audit classification, explicit corrupt-store custody, crash-resume markers, custom-path/split-filesystem handling, and same-version recovery |
| `cli/defenseclaw/commands/cmd_upgrade.py` | Implements the same field-recovery contract in the Python controller, including rollback-safe restart behavior |
| `scripts/test-upgrade-protocol-release.sh` | Adds exact candidate field-recovery fixtures and post-upgrade cursor/custody/database/receipt/health assertions |
| `.github/workflows/pre-release-certification.yml` | Runs both field cases on the newest authenticated source for Linux and macOS |
| `scripts/defenseclaw-rescue.sh` | Adds the minimal external authenticated rescue bootstrap |
| `scripts/release_channel.py` | Defines canonical channel creation, validation, checksum binding, monotonic comparison, and anti-rebinding rules |
| `scripts/publish-release-channel.sh` | Signs, verifies, fast-forwards, reads back, and re-verifies the stable channel through GitHub's Git Data API |
| `scripts/release_candidate.py`, `.gitattributes` | Adds the rescue bootstrap to exact `0.8.8+` release custody with LF and completeness enforcement |
| `scripts/resolve_upgrade_baselines.py` | Classifies the `0.8.7+` Sigstore bundle as non-self-referential proof, requires and GitHub-digest-checks its immutable custody, and keeps unknown/payload assets fail-closed |
| `.github/workflows/release.yaml` | Grants publication OIDC only where needed and advances the channel only after immutable remote release proof |
| `cli/tests/test_cmd_upgrade.py`, `cli/tests/test_upgrade_field_recovery.py` | Covers cursor reconstruction/replay, corrupt/WAL decisions, identity-bound custody, interruption, custom paths, and same-version repair |
| `cli/tests/test_release_channel.py`, release/static tests | Covers canonical parsing, signature invocation, URL/digest binding, rollback/rebind refusal, Git publication behavior, and candidate inclusion |
| `docs/CLI.md`, `docs/INSTALL.md`, `docs/RELEASE_CHANNEL.md`, `docs/RELEASE_VALIDATION.md` | Documents operator recovery, evidence preservation, immutable assets, signed channel trust, and release gates |

## Breaking Changes

- `--yes` alone never authorizes moving a corrupt audit database. Operators
  must pass `--recover-corrupt-audit` after the resolver proves corruption.
- A same-version request is no longer always a no-op: authenticated,
  preflighted field recovery reinstalls the exact release and requires target
  health before success.
- Starting with `0.8.8`, release publication requires OIDC to sign and advance
  the stable channel after the immutable release is proved.
- No existing tag or asset is changed. `0.8.7` and earlier remain byte-for-byte
  immutable.

## Open Issues / Follow-ups

- [#608](https://github.com/cisco-ai-defense/defenseclaw/issues/608) makes the
  normal `0.8.8+` `defenseclaw upgrade` command a thin signed-channel discovery
  front end with an internal non-recursive handoff. The external rescue
  boundary lands here first because it can unstrand frozen older controllers
  without adding recursion risk to this urgent recovery patch.

## Test Plan

- Combined Python upgrade, recovery, channel, workflow, candidate, docs, and
  static regression:

  ```bash
  uv run --frozen python -m pytest -q \
    cli/tests/test_cmd_upgrade.py \
    cli/tests/test_upgrade_field_recovery.py \
    cli/tests/test_upgrade_staged_resolver.py \
    cli/tests/test_upgrade_release_smoke_contract.py \
    cli/tests/test_upgrade_smoke_static.py \
    cli/tests/test_release_workflow_staged.py \
    cli/tests/test_install_docs_static.py \
    cli/tests/test_release_channel.py \
    cli/tests/test_release_candidate.py
  ```

  Observed: **682 passed, 1 skipped, 46 subtests passed in 232.49s**.

- Deterministic release regression and live authenticated baseline resolution:

  ```bash
  uv run --frozen python -m pytest -q \
    cli/tests/test_verify_sigstore_blob.py \
    cli/tests/test_observability_v8_upgrade_continuity_checker.py \
    cli/tests/test_resolve_upgrade_baselines.py \
    cli/tests/test_release_api_retry.py \
    cli/tests/test_release_workflow_staged.py \
    cli/tests/test_upgrade_smoke_static.py \
    cli/tests/test_upgrade_release_smoke_contract.py \
    cli/tests/test_release_certification.py \
    cli/tests/test_release_validation_strategy.py

  release_api_token="$(gh auth token)"
  GITHUB_TOKEN="$release_api_token" \
    uv run --frozen python scripts/resolve_upgrade_baselines.py \
      --target-version 0.8.8 \
      --output /private/tmp/defenseclaw-baselines-pr609.json
  unset release_api_token
  ```

  Observed: **285 passed, 1 skipped**. The live resolver downloaded and
  GitHub-digest-checked the immutable `0.8.7` Sigstore bundle, authenticated
  each dynamic release, and produced the supported `0.8.7 → 0.4.0` baseline
  policy. Immutable `0.8.6` remains valid without a bundle because it predates
  bundle publication.

- Exact published-dependency Mac release harness:

  ```bash
  cp scripts/upgrade.sh \
    /private/tmp/defenseclaw-field-recovery.OffLZ8/0.8.7/defenseclaw-upgrade.sh
  UPGRADE_BASELINE_POLICY=/private/tmp/defenseclaw-field-recovery.OffLZ8/policy/effective-upgrade-baselines.json \
  UPGRADE_SMOKE_SKIP_SOURCE_CONTRACTS=1 \
  UPGRADE_SMOKE_FIELD_RECOVERY_CASES=1 \
  TMPDIR=/private/tmp \
  bash scripts/test-upgrade-protocol-release.sh \
    --from-version 0.8.6 \
    --target-version 0.8.7 \
    --release-root /private/tmp/defenseclaw-field-recovery.OffLZ8 \
    --baseline-mode seed \
    --baseline-dependencies published \
    --success-path-only \
    --health-timeout 60 \
    --keep-workdir
  ```

  Observed: clean `0.8.6 → 0.8.7`, missing-cursor
  `0.8.6 → 0.8.7`, and corrupt-audit same-version `0.8.7 → 0.8.7`
  all passed with complete migration state, receipts, writable SQLite, and a
  healthy target gateway.

- Read-only plan against the affected connected Mac:

  ```bash
  bash scripts/upgrade.sh \
    --plan \
    --version 0.8.7 \
    --recover-corrupt-audit
  ```

  Observed: published checksums, provenance, manifest, gateway, and wheel were
  authenticated; the audit database classified as corrupt; same-version
  recovery was selected; the command reported `No changes were made`; exact
  pre/post device, inode, size, and mtime values for the main/WAL/SHM tuple were
  unchanged.

- Clean Linux/arm64 container with Go 1.26.4 and Python 3.11:

  ```bash
  go build -o /root/.local/bin/defenseclaw-gateway ./cmd/defenseclaw
  PATH=/root/.local/bin:/venv/bin:$PATH \
    python -m pytest -q \
      cli/tests/test_upgrade_field_recovery.py \
      cli/tests/test_release_channel.py
  bash -n \
    scripts/upgrade.sh \
    scripts/defenseclaw-rescue.sh \
    scripts/publish-release-channel.sh
  ```

  Observed: the real gateway built and executed; **28 passed**; Bash syntax
  passed.

- Formatting, workflow, shell, and diff validation:

  ```bash
  uv run --frozen ruff check \
    cli/defenseclaw/commands/cmd_upgrade.py \
    cli/tests/test_cmd_upgrade.py \
    cli/tests/test_install_docs_static.py \
    cli/tests/test_release_candidate.py \
    cli/tests/test_release_channel.py \
    cli/tests/test_release_validation_strategy.py \
    cli/tests/test_release_workflow_staged.py \
    cli/tests/test_resolve_upgrade_baselines.py \
    cli/tests/test_upgrade_field_recovery.py \
    cli/tests/test_upgrade_release_smoke_contract.py \
    cli/tests/test_upgrade_staged_resolver.py \
    scripts/release_candidate.py \
    scripts/release_channel.py \
    scripts/resolve_upgrade_baselines.py
  uv run --frozen ruff format --check \
    cli/defenseclaw/commands/cmd_upgrade.py \
    cli/tests/test_cmd_upgrade.py \
    cli/tests/test_install_docs_static.py \
    cli/tests/test_release_candidate.py \
    cli/tests/test_release_channel.py \
    cli/tests/test_release_validation_strategy.py \
    cli/tests/test_release_workflow_staged.py \
    cli/tests/test_resolve_upgrade_baselines.py \
    cli/tests/test_upgrade_field_recovery.py \
    cli/tests/test_upgrade_release_smoke_contract.py \
    cli/tests/test_upgrade_staged_resolver.py \
    scripts/release_candidate.py \
    scripts/release_channel.py \
    scripts/resolve_upgrade_baselines.py
  actionlint \
    .github/workflows/release.yaml \
    .github/workflows/pre-release-certification.yml
  shellcheck \
    scripts/defenseclaw-rescue.sh \
    scripts/publish-release-channel.sh
  bash -n \
    scripts/upgrade.sh \
    scripts/test-upgrade-protocol-release.sh \
    scripts/defenseclaw-rescue.sh \
    scripts/publish-release-channel.sh
  git diff --check
  ```

  Observed: Ruff, actionlint, ShellCheck, Bash syntax, and diff checks passed.

- Pinned Cosign fallback digests:

  ```bash
  gh release download v2.6.3 \
    --repo sigstore/cosign \
    --pattern cosign_checksums.txt \
    --dir /private/tmp/defenseclaw-cosign-checksums.LTBvmC
  rg 'cosign-(darwin|linux)-(amd64|arm64)$' \
    /private/tmp/defenseclaw-cosign-checksums.LTBvmC/cosign_checksums.txt
  ```

  Observed: all four embedded macOS/Linux Cosign SHA-256 values exactly match
  the official `v2.6.3` checksum manifest.
