### PR TITLE
fix(ci): validate release proof before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,12 @@ jobs:
           else
             echo 'sensitive=false' >> "$GITHUB_OUTPUT"
           fi
+      # Resolve authenticated live state on every PR so a newly published
+      # immutable release cannot first break the unconditional main-push path
+      # after merge. Path sensitivity still controls the expensive candidate
+      # build and upgrade matrices below.
       - id: version
-        if: ${{ github.event_name == 'push' || steps.paths.outputs.sensitive == 'true' }}
-        name: Resolve candidate against live stable state when needed
+        name: Resolve candidate against live stable state
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -98,12 +101,10 @@ jobs:
             --published-releases published-releases.json \
             --github-output "$GITHUB_OUTPUT" >/dev/null
       - uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
-        if: ${{ github.event_name == 'push' || steps.paths.outputs.sensitive == 'true' }}
       - id: baseline-name
         if: ${{ github.event_name == 'push' || steps.paths.outputs.sensitive == 'true' }}
         run: echo "name=ci-effective-upgrade-baselines-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
       - id: baselines
-        if: ${{ github.event_name == 'push' || steps.paths.outputs.sensitive == 'true' }}
         name: Resolve one authenticated effective baseline snapshot
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -359,17 +360,20 @@ jobs:
 
   python-lint-test:
     # Preserve the existing required-check name while making it the single
-    # authority over lint, every isolated test partition, and combined coverage.
+    # authority over live release validation, lint, every isolated test
+    # partition, and combined coverage.
     name: Python Lint & Test
-    needs: [python-test, python-lint]
+    needs: [release-validation-plan, python-test, python-lint]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      - name: Require lint and every Python test partition
+      - name: Require release validation, lint, and every Python test partition
         env:
+          RELEASE_VALIDATION_RESULT: ${{ needs.release-validation-plan.result }}
           PYTHON_REGULAR_RESULT: ${{ needs.python-test.result }}
           PYTHON_LINT_RESULT: ${{ needs.python-lint.result }}
         run: |
+          test "$RELEASE_VALIDATION_RESULT" = success
           test "$PYTHON_REGULAR_RESULT" = success
           test "$PYTHON_LINT_RESULT" = success
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -94,7 +94,7 @@ jobs:
           ) -join '|') + ')$'
           # Keep package execution serial on the four-core hosted runner so
           # bounded discovery tests are not starved by concurrent packages.
-          Invoke-WindowsNativeProcess $go @('test', '-count=1', '-timeout=20m', '-p=1', '-skip', $windowsInapplicable, './...') -TimeoutSeconds 2100 -LogPath (Join-Path $env:DC_STATE_ROOT 'go-test.log') | Out-Null
+          Invoke-WindowsNativeProcess $go @('test', '-json', '-count=1', '-timeout=20m', '-p=1', '-skip', $windowsInapplicable, './...') -TimeoutSeconds 2100 -LogPath (Join-Path $env:DC_STATE_ROOT 'go-test.log') -GoTestFailureSummaryPath (Join-Path $env:DC_STATE_ROOT 'go-test-failure-summary.log') | Out-Null
           Invoke-WindowsNativeProcess $go @('vet', './...') -TimeoutSeconds 900 -LogPath (Join-Path $env:DC_STATE_ROOT 'go-vet.log') | Out-Null
           $bin = Join-Path $env:DC_STATE_ROOT 'bin'
           New-Item -ItemType Directory -Force -Path $bin | Out-Null

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -92,9 +92,57 @@ jobs:
             'TestAtomicWriteFile_PreservesSymlinkedDotfile',
             'TestOpenHandsHookScript_BlockExitsTwo'
           ) -join '|') + ')$'
-          # Keep package execution serial on the four-core hosted runner so
-          # bounded discovery tests are not starved by concurrent packages.
-          Invoke-WindowsNativeProcess $go @('test', '-json', '-count=1', '-timeout=20m', '-p=1', '-skip', $windowsInapplicable, './...') -TimeoutSeconds 2100 -LogPath (Join-Path $env:DC_STATE_ROOT 'go-test.log') -GoTestFailureSummaryPath (Join-Path $env:DC_STATE_ROOT 'go-test-failure-summary.log') | Out-Null
+          # The gateway package is large enough that Linux CI already shards
+          # its top-level tests. Partition the native Windows test list in the
+          # same process-isolation shape so one package binary cannot retain
+          # the full suite's resources or bury its terminal panic in a huge
+          # dump. Shards remain sequential on this four-core hosted runner.
+          $gatewayList = Invoke-WindowsNativeProcess $go @(
+            'test', '-list', '^(Test|Fuzz|Example)', './internal/gateway'
+          ) -TimeoutSeconds 600 -LogPath (Join-Path $env:DC_STATE_ROOT 'go-gateway-list.log')
+          $gatewayTests = @(
+            [regex]::Split([string]$gatewayList.StdOut, '\r?\n') |
+                Where-Object { $_ -match '^(Test|Fuzz|Example)\S*$' } |
+                Sort-Object -Unique
+          )
+          if ($gatewayTests.Count -lt 4) {
+            throw "native gateway sharding discovered only $($gatewayTests.Count) top-level tests"
+          }
+          $goTestLog = Join-Path $env:DC_STATE_ROOT 'go-test.log'
+          $goFailureSummary = Join-Path $env:DC_STATE_ROOT 'go-test-failure-summary.log'
+          foreach ($shard in 0..3) {
+            $shardTests = @(
+              for ($index = 0; $index -lt $gatewayTests.Count; $index++) {
+                if (($index % 4) -eq $shard) { [regex]::Escape($gatewayTests[$index]) }
+              }
+            )
+            $shardPattern = '^(' + ($shardTests -join '|') + ')$'
+            Invoke-WindowsNativeProcess $go @(
+              'test', '-json', '-count=1', '-timeout=20m', '-p=1',
+              '-skip', $windowsInapplicable, '-run', $shardPattern, './internal/gateway'
+            ) -TimeoutSeconds 1500 `
+              -LogPath (Join-Path $env:DC_STATE_ROOT ("go-gateway-shard-{0}.log" -f $shard)) `
+              -GoTestFailureSummaryPath $goFailureSummary | Out-Null
+          }
+          $packageList = Invoke-WindowsNativeProcess $go @(
+            'list', './...'
+          ) -TimeoutSeconds 600 -LogPath (Join-Path $env:DC_STATE_ROOT 'go-package-list.log')
+          $remainingPackages = @(
+            [regex]::Split([string]$packageList.StdOut, '\r?\n') |
+              Where-Object {
+                $_ -match '^github\.com/defenseclaw/defenseclaw/' -and
+                $_ -ne 'github.com/defenseclaw/defenseclaw/internal/gateway'
+              }
+          )
+          if (-not $remainingPackages) {
+            throw 'native Go package discovery selected no non-gateway packages'
+          }
+          $remainingArguments = @(
+            'test', '-json', '-count=1', '-timeout=20m', '-p=1',
+            '-skip', $windowsInapplicable
+          ) + $remainingPackages
+          Invoke-WindowsNativeProcess $go $remainingArguments -TimeoutSeconds 2100 `
+            -LogPath $goTestLog -GoTestFailureSummaryPath $goFailureSummary | Out-Null
           Invoke-WindowsNativeProcess $go @('vet', './...') -TimeoutSeconds 900 -LogPath (Join-Path $env:DC_STATE_ROOT 'go-vet.log') | Out-Null
           $bin = Join-Path $env:DC_STATE_ROOT 'bin'
           New-Item -ItemType Directory -Force -Path $bin | Out-Null

--- a/cli/tests/test_ci_workflow_efficiency.py
+++ b/cli/tests/test_ci_workflow_efficiency.py
@@ -37,7 +37,7 @@ def test_ci_shards_python_once_and_does_not_repeat_unified_corpus() -> None:
     assert "--dist=worksteal" in exhaustive
     assert "name: Python Lint" in workflow
     assert "name: Python Lint & Test" in workflow
-    assert "needs: [python-test, python-lint]" in workflow
+    assert "needs: [release-validation-plan, python-test, python-lint]" in workflow
     assert workflow.count("run: make py-lint") == 1
     assert "pattern: python-coverage-part-*" in workflow
     assert 'test "${#coverage_parts[@]}" -eq 4' in workflow

--- a/cli/tests/test_release_candidate.py
+++ b/cli/tests/test_release_candidate.py
@@ -3454,6 +3454,48 @@ def test_followup_candidate_accepts_published_v8_baseline(
     )
 
 
+def test_followup_candidate_accepts_direct_windows_v8_baseline_without_unpublished_bridge(
+    tmp_path: Path,
+) -> None:
+    policy = json.loads((ROOT / "release" / "upgrade-baselines.json").read_text(encoding="utf-8"))
+    policy["published_baselines"].insert(0, "0.8.7")
+    policy["published_baseline_config_versions"]["0.8.7"] = 8
+    policy["platform_published_baselines"]["windows"].insert(0, "0.8.7")
+    policy_path = tmp_path / "effective-upgrade-baselines.json"
+    policy_path.write_text(json.dumps(policy), encoding="utf-8")
+
+    manifest_path = tmp_path / "upgrade-manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "runtime_config_version": 8,
+                "release_version": "0.8.8",
+                "min_upgrade_protocol": 2,
+                "controller_upgrade_protocol": 2,
+                "migration_failure_policy": "fail",
+                "minimum_source_version": "0.8.4",
+                "required_bridge_version": "0.8.4",
+                "auto_bridge_from": [
+                    item
+                    for item in policy["published_baselines"]
+                    if tuple(map(int, item.split("."))) < (0, 8, 4)
+                ],
+                "tested_source_versions": policy["published_baselines"],
+                "platform_tested_source_versions": {"windows": ["0.8.7"]},
+                "release_artifacts": release_candidate._expected_release_artifacts("0.8.8"),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    release_candidate._validate_upgrade_manifest(
+        manifest_path,
+        "0.8.8",
+        baseline_policy_path=policy_path,
+    )
+
+
 def test_hard_cut_rejects_protocol_one_schema_two_manifest_without_bridge(
     tmp_path: Path,
 ) -> None:

--- a/cli/tests/test_release_validation_strategy.py
+++ b/cli/tests/test_release_validation_strategy.py
@@ -123,6 +123,37 @@ def test_ordinary_ci_is_deterministic_and_selective_not_full_certification() -> 
     )
 
 
+def test_every_pr_authenticates_live_baselines_inside_a_required_gate() -> None:
+    workflow = _workflow(CI_PATH)
+    assert {"push", "pull_request"}.issubset(workflow["on"])
+
+    jobs = workflow["jobs"]
+    plan = jobs["release-validation-plan"]
+    named_steps = {
+        step.get("name"): step
+        for step in plan["steps"]
+        if isinstance(step, dict) and step.get("name")
+    }
+    for name in (
+        "Resolve candidate against live stable state",
+        "Resolve one authenticated effective baseline snapshot",
+    ):
+        assert "if" not in named_steps[name]
+
+    cosign = next(
+        step
+        for step in plan["steps"]
+        if isinstance(step, dict)
+        and "sigstore/cosign-installer@" in str(step.get("uses", ""))
+    )
+    assert "if" not in cosign
+
+    required = jobs["python-lint-test"]
+    assert required["name"] == "Python Lint & Test"
+    assert "release-validation-plan" in required["needs"]
+    assert "needs.release-validation-plan.result" in _render(required)
+
+
 def test_no_pull_request_workflow_can_run_full_or_signed_certification() -> None:
     pull_request_workflows: list[Path] = []
     for path in sorted((ROOT / ".github/workflows").glob("*.y*ml")):

--- a/cli/tests/test_resolve_upgrade_baselines.py
+++ b/cli/tests/test_resolve_upgrade_baselines.py
@@ -89,6 +89,17 @@ def _release(
                 "browser_download_url": url,
             }
         )
+    if tuple(map(int, version.split("."))) >= (0, 8, 6):
+        bundle = b'{"proof":"rekor transparency bundle"}\n'
+        assets.append(
+            {
+                "name": "checksums.txt.bundle",
+                "digest": f"sha256:{_digest(bundle)}",
+                "browser_download_url": (
+                    f"https://downloads.example/{version}/checksums.txt.bundle"
+                ),
+            }
+        )
     return (
         {
             "tag_name": version,
@@ -185,6 +196,20 @@ def test_087_discovers_all_newer_immutable_stables_without_a_policy_edit() -> No
         "0.8.3",
     ]
     assert policy["published_baseline_config_versions"]["0.8.6"] == 8
+
+
+def test_signature_bundle_is_release_proof_not_signed_payload() -> None:
+    release, downloads = _release("0.8.6")
+    asset_names = {asset["name"] for asset in release["assets"]}
+
+    assert "checksums.txt.bundle" in asset_names
+    assert b"checksums.txt.bundle" not in downloads[
+        "https://downloads.example/0.8.6/checksums.txt"
+    ]
+
+    policy = _resolve("0.8.7", [(release, downloads)])
+
+    assert policy["published_baselines"][0] == "0.8.6"
 
 
 def test_candidate_below_checked_head_discovers_release_above_eligible_floor(

--- a/cli/tests/test_telemetry_ci_strategy.py
+++ b/cli/tests/test_telemetry_ci_strategy.py
@@ -67,7 +67,11 @@ def test_ordinary_ci_always_checks_real_registry_without_exhaustive_mutation_sui
         assert f"--exclude {test_file}" in regular
 
     aggregate = jobs["python-lint-test"]
-    assert set(aggregate["needs"]) == {"python-test", "python-lint"}
+    assert set(aggregate["needs"]) == {
+        "release-validation-plan",
+        "python-test",
+        "python-lint",
+    }
     rendered_aggregate = _render(aggregate)
     assert 'test "${#coverage_parts[@]}" -eq 4' in rendered_aggregate
     assert "PYTHON_TELEMETRY" not in rendered_aggregate

--- a/internal/gateway/connector/connector_cas_test.go
+++ b/internal/gateway/connector/connector_cas_test.go
@@ -796,6 +796,7 @@ func TestAtomicTransformCleanupDoesNotDeleteReplacedIntentIdentity(t *testing.T)
 		t.Fatal(err)
 	}
 	var phaseState atomicTransformPhaseState
+	var displacedIntent string
 	restoreHook := setAtomicTransformPhaseHookForTest(path, func(
 		phase atomicTransformPhase,
 		state atomicTransformPhaseState,
@@ -808,7 +809,8 @@ func TestAtomicTransformCleanupDoesNotDeleteReplacedIntentIdentity(t *testing.T)
 		if err != nil {
 			return err
 		}
-		if err := os.Remove(state.IntentPath); err != nil {
+		displacedIntent = state.IntentPath + ".test-held-original"
+		if err := os.Rename(state.IntentPath, displacedIntent); err != nil {
 			return err
 		}
 		return os.WriteFile(state.IntentPath, data, 0o600)
@@ -817,6 +819,11 @@ func TestAtomicTransformCleanupDoesNotDeleteReplacedIntentIdentity(t *testing.T)
 		return atomicTransformResult{Data: []byte(`{"new":true}`)}, nil
 	})
 	restoreHook()
+	if displacedIntent != "" {
+		if removeErr := os.Remove(displacedIntent); removeErr != nil {
+			t.Fatalf("remove held original intent: %v", removeErr)
+		}
+	}
 	if err == nil {
 		t.Fatal("cleanup deleted a replacement intent with different file identity")
 	}

--- a/internal/observability/runtime/e2e6_exporter_isolation_test.go
+++ b/internal/observability/runtime/e2e6_exporter_isolation_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/defenseclaw/defenseclaw/internal/config"
+	"github.com/defenseclaw/defenseclaw/internal/observability"
 	"github.com/defenseclaw/defenseclaw/internal/observability/delivery"
 	"github.com/defenseclaw/defenseclaw/internal/telemetry"
 )
@@ -21,6 +22,32 @@ type e2e6RuntimeBlockingAdapter struct {
 	started   chan struct{}
 	release   <-chan struct{}
 	startOnce sync.Once
+}
+
+// Keep the intentionally blocked export attempt alive while race/coverage
+// instrumentation projects and persists near-limit records. Runtime close
+// still cancels the attempt immediately if the test exits early.
+const e2e6RuntimeBlockingAttemptTimeoutMS = 120_000
+
+func e2e6RuntimeBlockingDestination(
+	name string,
+	queueItems int,
+	queueBytes int,
+) config.ObservabilityV8DestinationSource {
+	return config.ObservabilityV8DestinationSource{
+		Name: name, Kind: config.ObservabilityV8DestinationHTTPJSONL,
+		Endpoint:  "https://collector.example.test/events",
+		TimeoutMS: e2e6RuntimeBlockingAttemptTimeoutMS,
+		Send: &config.ObservabilityV8SendSource{
+			Signals:          []observability.Signal{observability.SignalLogs},
+			Buckets:          []observability.Bucket{"*"},
+			RedactionProfile: "none",
+		},
+		Batch: config.ObservabilityV8BatchSource{
+			MaxQueueSize: queueItems, MaxQueueBytes: queueBytes,
+			MaxExportBatchSize: 1, ScheduledDelayMS: 1,
+		},
+	}
 }
 
 func (*e2e6RuntimeBlockingAdapter) EncodedSize(sizes []int) (int, bool) {
@@ -71,10 +98,9 @@ func TestE2E6RuntimeQueuePressurePreservesSQLiteSiblingAndRecovery(t *testing.T)
 			dependencies := newRuntimeTestDependencies(t)
 			plan := runtimeTestPlan(t, dependencies.storePath, dependencies.judgePath, 90,
 				func(source *config.ObservabilityV8Source) {
-					blocked := runtimeConsoleDestination("blocked", "none", test.queueItems)
-					blocked.Batch.MaxQueueBytes = test.queueBytes
 					source.Destinations = []config.ObservabilityV8DestinationSource{
-						blocked, runtimeConsoleDestination("healthy", "none", len(test.contents)+1),
+						e2e6RuntimeBlockingDestination("blocked", test.queueItems, test.queueBytes),
+						runtimeConsoleDestination("healthy", "none", len(test.contents)+1),
 					}
 				},
 			)

--- a/scripts/live-connector-e2e/test-windows.ps1
+++ b/scripts/live-connector-e2e/test-windows.ps1
@@ -874,7 +874,8 @@ private-secret-name = "DefenseClaw must remain redacted"
         'full native Go suite shards the gateway process and separately selects every remaining package'
     Assert-True ($nativeWorkflowText -match '(?s)''-p=1''.*?''-skip''.*?\$windowsInapplicable') 'native Go suite serializes packages and excludes only declared Windows-inapplicable tests'
     Assert-True ($nativeWorkflowText -match '''test'', ''-json'', ''-count=1''' -and
-        $nativeWorkflowText -match '-GoTestFailureSummaryPath.*go-test-failure-summary\.log') `
+        $nativeWorkflowText -match '-GoTestFailureSummaryPath \$goFailureSummary' -and
+        $nativeWorkflowText -match 'go-test-failure-summary\.log') `
         'full Go suite retains a bounded structured failure summary'
     Assert-True ($nativeProcessFunction -match
         '(?s)\$exitCode = if \(\$timedOut\).*?if \(\$GoTestFailureSummaryPath -and.*?\$exitCode -notin \$AllowedExitCodes.*?Get-GoTestFailureSummary' -and

--- a/scripts/live-connector-e2e/test-windows.ps1
+++ b/scripts/live-connector-e2e/test-windows.ps1
@@ -872,7 +872,7 @@ private-secret-name = "DefenseClaw must remain redacted"
         $nativeWorkflowText -match '\$_ -ne ''github\.com/defenseclaw/defenseclaw/internal/gateway''' -and
         $nativeWorkflowText -match '\$remainingArguments = @\(') `
         'full native Go suite shards the gateway process and separately selects every remaining package'
-    Assert-True ($nativeWorkflowText -match '''-p=1''.*''-skip''.*\$windowsInapplicable') 'native Go suite serializes packages and excludes only declared Windows-inapplicable tests'
+    Assert-True ($nativeWorkflowText -match '(?s)''-p=1''.*?''-skip''.*?\$windowsInapplicable') 'native Go suite serializes packages and excludes only declared Windows-inapplicable tests'
     Assert-True ($nativeWorkflowText -match '''test'', ''-json'', ''-count=1''' -and
         $nativeWorkflowText -match '-GoTestFailureSummaryPath.*go-test-failure-summary\.log') `
         'full Go suite retains a bounded structured failure summary'

--- a/scripts/live-connector-e2e/test-windows.ps1
+++ b/scripts/live-connector-e2e/test-windows.ps1
@@ -859,6 +859,9 @@ private-secret-name = "DefenseClaw must remain redacted"
     Assert-True ($nativeWorkflowText -match '''test'', ''-v'', ''-count=1'', ''-run'', \$daclTestPattern, ''\./internal/safefile'', ''\./internal/managed'', ''\./internal/gateway/connector''') 'Go DACL regressions execute in every owning package without cache reuse'
     Assert-True ($nativeWorkflowText -match "'test'.*'\./\.\.\.'") 'full Go suite is required'
     Assert-True ($nativeWorkflowText -match '''-p=1''.*''-skip''.*\$windowsInapplicable') 'full Go suite serializes packages and excludes only declared Windows-inapplicable tests'
+    Assert-True ($nativeWorkflowText -match '''test'', ''-json'', ''-count=1''' -and
+        $nativeWorkflowText -match '-GoTestFailureSummaryPath.*go-test-failure-summary\.log') `
+        'full Go suite retains a bounded structured failure summary'
     Assert-True ($nativeWorkflowText -match 'Validate registered Windows Codex and Claude hook commands') 'native Windows workflow has a required Doctor hook-command step'
     Assert-True ($nativeWorkflowText -match "'pytest', 'cli/tests/test_cmd_doctor_windows_hooks\.py', '-q'") 'Doctor validates registered Windows hook commands explicitly'
     Assert-True ($nativeWorkflowText -match "Get-ChildItem cli/tests -Recurse -File -Filter 'test_\*\.py'") 'complete Python suite discovers every test file'

--- a/scripts/live-connector-e2e/test-windows.ps1
+++ b/scripts/live-connector-e2e/test-windows.ps1
@@ -781,6 +781,14 @@ private-secret-name = "DefenseClaw must remain redacted"
     $nativePathHelpersText = [IO.File]::ReadAllText($nativePathHelpers)
     $nativePathInitializerText = [IO.File]::ReadAllText($nativePathInitializer)
     $installerText = [IO.File]::ReadAllText($installer)
+    $nativeProcessFunction = [regex]::Match(
+        $nativeHarnessText,
+        '(?s)function Invoke-WindowsNativeProcess\b.*?(?=\r?\nfunction )'
+    ).Value
+    $diagnosticTailFunction = [regex]::Match(
+        $nativeHarnessText,
+        '(?s)function Add-WindowsNativeDiagnosticTail\b.*?(?=\r?\nfunction )'
+    ).Value
     Assert-True ($nativeWorkflowText -match '(?s)connector-contract:.*?connector: \[codex, claudecode\].*?windows-native-required:') 'required Windows contract matrix contains Codex and Claude'
     Assert-True ($nativeWorkflowText -match '(?m)^\s+name: Windows Native Required\s*$') 'stable aggregate check name exists'
     foreach ($job in @('windows-go', 'windows-python', 'powershell-static', 'package-artifact', 'packaged-acceptance', 'connector-contract')) {
@@ -857,11 +865,24 @@ private-secret-name = "DefenseClaw must remain redacted"
         Assert-True ($nativeWorkflowText -match [regex]::Escape($testName)) "native Windows Go DACL step reaches $testName"
     }
     Assert-True ($nativeWorkflowText -match '''test'', ''-v'', ''-count=1'', ''-run'', \$daclTestPattern, ''\./internal/safefile'', ''\./internal/managed'', ''\./internal/gateway/connector''') 'Go DACL regressions execute in every owning package without cache reuse'
-    Assert-True ($nativeWorkflowText -match "'test'.*'\./\.\.\.'") 'full Go suite is required'
-    Assert-True ($nativeWorkflowText -match '''-p=1''.*''-skip''.*\$windowsInapplicable') 'full Go suite serializes packages and excludes only declared Windows-inapplicable tests'
+    Assert-True ($nativeWorkflowText -match
+        '''test'', ''-list'', ''\^\(Test\|Fuzz\|Example\)'', ''\./internal/gateway''' -and
+        $nativeWorkflowText -match '\(\$index % 4\) -eq \$shard' -and
+        $nativeWorkflowText -match '''-run'', \$shardPattern, ''\./internal/gateway''' -and
+        $nativeWorkflowText -match '\$_ -ne ''github\.com/defenseclaw/defenseclaw/internal/gateway''' -and
+        $nativeWorkflowText -match '\$remainingArguments = @\(') `
+        'full native Go suite shards the gateway process and separately selects every remaining package'
+    Assert-True ($nativeWorkflowText -match '''-p=1''.*''-skip''.*\$windowsInapplicable') 'native Go suite serializes packages and excludes only declared Windows-inapplicable tests'
     Assert-True ($nativeWorkflowText -match '''test'', ''-json'', ''-count=1''' -and
         $nativeWorkflowText -match '-GoTestFailureSummaryPath.*go-test-failure-summary\.log') `
         'full Go suite retains a bounded structured failure summary'
+    Assert-True ($nativeProcessFunction -match
+        '(?s)\$exitCode = if \(\$timedOut\).*?if \(\$GoTestFailureSummaryPath -and.*?\$exitCode -notin \$AllowedExitCodes.*?Get-GoTestFailureSummary' -and
+        $nativeProcessFunction -match
+        '(?s)\$failureOutput = if \(\$goTestFailureSummary\).*?throw "\$FilePath \$reason`n\$failureOutput"' -and
+        $diagnosticTailFunction -match
+        '(?s)function Add-WindowsNativeDiagnosticTail.*?\$boundedText = Limit-WindowsNativeText.*?\$retainedBytes -gt \$MaxBytes') `
+        'native process harness parses Go JSON only on failure, bounds collection, and reports the focused summary instead of the full JSON stream'
     Assert-True ($nativeWorkflowText -match 'Validate registered Windows Codex and Claude hook commands') 'native Windows workflow has a required Doctor hook-command step'
     Assert-True ($nativeWorkflowText -match "'pytest', 'cli/tests/test_cmd_doctor_windows_hooks\.py', '-q'") 'Doctor validates registered Windows hook commands explicitly'
     Assert-True ($nativeWorkflowText -match "Get-ChildItem cli/tests -Recurse -File -Filter 'test_\*\.py'") 'complete Python suite discovers every test file'
@@ -1211,8 +1232,13 @@ private-secret-name = "DefenseClaw must remain redacted"
         'interactive Setup acceptance owns and cleans built-in-root fixtures without environment trust authority'
     Assert-True ($setupAcceptanceFunction -match '\$cachedSetup' -and
         $setupAcceptanceFunction -match 'Join-Path \$cacheRoot ''DefenseClawSetup-x64\.exe''' -and
+        $setupAcceptanceFunction -match '\$deferredCleanupWaitAttempts\s*=\s*520' -and
+        [regex]::Matches(
+            $setupAcceptanceFunction,
+            '\$attempt -lt \$deferredCleanupWaitAttempts'
+        ).Count -ge 2 -and
         $setupAcceptanceFunction -match 'cached setup self-uninstall left installer cache behind') `
-        'native Setup acceptance executes the cached Apps & Features binary and proves deferred self-delete removes InstallerCache'
+        'native Setup acceptance executes the cached Apps & Features binary and waits through the bounded deferred self-delete before proving InstallerCache removal'
     Assert-True ($nativeHarnessText -match '-StateRoot \$contractProfileRoot -HomeRoot \$contractHome -NativeDataRoot \$dataRoot' -and
         $nativeHarnessText -match '-AllowNativeDataRoot' -and
         $harnessText -match 'NativeDataRoot is restricted to an explicitly authorized packaged contract run' -and

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -1047,9 +1047,10 @@ def _validate_upgrade_manifest(
     if bridge in platform_configured["windows"]:
         if bridge not in platform_tested["windows"]:
             raise CandidateError(f"required bridge {bridge} is absent from the tested Windows baseline matrix")
-    elif platform_tested["windows"]:
+    elif any(tuple(map(int, item.split("."))) < (0, 8, 5) for item in platform_tested["windows"]):
         raise CandidateError(
-            f"Windows bridge {bridge} is unpublished; the tested Windows baseline matrix must be empty"
+            f"Windows bridge {bridge} is unpublished; the tested Windows baseline matrix "
+            "must contain only published post-hard-cut runtimes"
         )
     bridge_key = tuple(map(int, bridge.split(".")))
     expected_automatic = [item for item in configured if tuple(map(int, item.split("."))) < bridge_key]

--- a/scripts/resolve_upgrade_baselines.py
+++ b/scripts/resolve_upgrade_baselines.py
@@ -320,7 +320,16 @@ def _authenticate_release(
     # platform payloads intentionally omitted at publication (0.8.4's Windows
     # bytes are the precedent), so signed-but-unpublished entries do not widen
     # platform support and are not themselves an error.
-    authentication_assets = {"checksums.txt", "checksums.txt.pem", "checksums.txt.sig"}
+    # These files prove the checksum manifest rather than being payloads
+    # described by it. In particular, the transparency bundle is emitted by
+    # the act of signing checksums.txt, so requiring checksums.txt to cover the
+    # bundle would create an impossible self-reference.
+    authentication_assets = {
+        "checksums.txt",
+        "checksums.txt.bundle",
+        "checksums.txt.pem",
+        "checksums.txt.sig",
+    }
     for name, item in assets.items():
         if name in authentication_assets:
             continue

--- a/scripts/test-fresh-install-release-windows.ps1
+++ b/scripts/test-fresh-install-release-windows.ps1
@@ -125,7 +125,10 @@ function Get-UserPathEntryCount {
 function Wait-ForPathRemoval {
     param([Parameter(Mandatory = $true)][string]$Path)
 
-    for ($attempt = 0; $attempt -lt 80 -and (Test-Path -LiteralPath $Path); $attempt++) {
+    # Native Setup's transaction-bound helper may wait up to two minutes for
+    # its parent to exit. Keep release smoke aligned with that product bound
+    # plus scheduling margin while retaining the final fail-closed assertion.
+    for ($attempt = 0; $attempt -lt 520 -and (Test-Path -LiteralPath $Path); $attempt++) {
         Start-Sleep -Milliseconds 250
     }
 }

--- a/scripts/windows-native-ci.ps1
+++ b/scripts/windows-native-ci.ps1
@@ -601,10 +601,10 @@ function Get-GoTestFailureSummary(
     foreach ($failure in $failedPackages) {
         $elapsed = if ($failure.Elapsed) { " [$($failure.Elapsed)s]" } else { '' }
         [void]$summary.AppendLine("FAIL package $($failure.Package)$elapsed")
+        foreach ($line in $packageCriticalOutput[$failure.Package]) {
+            [void]$summary.AppendLine($line)
+        }
         if (-not ($failedTests | Where-Object { $_.Package -eq $failure.Package })) {
-            foreach ($line in $packageCriticalOutput[$failure.Package]) {
-                [void]$summary.AppendLine($line)
-            }
             foreach ($line in $packageOutput[$failure.Package]) {
                 [void]$summary.AppendLine($line)
             }
@@ -5350,6 +5350,16 @@ function Invoke-SelfTest {
             },
             [pscustomobject]@{
                 Action = 'output'
+                Package = 'example.invalid/pkg'
+                Output = "panic: package stopped after the test failure`n"
+            },
+            [pscustomobject]@{
+                Action = 'output'
+                Package = 'example.invalid/pkg'
+                Output = "goroutine 1 [running]:`n"
+            },
+            [pscustomobject]@{
+                Action = 'output'
                 Package = 'example.invalid/crash'
                 Test = 'TestActiveWhenProcessStopped'
                 Output = "active test before package termination`n"
@@ -5365,6 +5375,8 @@ function Invoke-SelfTest {
         if (-not $goTestSummary.Contains(
             '--- FAIL: TestFailing (example.invalid/pkg) [1.25s]'
         ) -or -not $goTestSummary.Contains('fixture assertion failed') -or
+            -not $goTestSummary.Contains('panic: package stopped after the test failure') -or
+            -not $goTestSummary.Contains('goroutine 1 [running]') -or
             -not $goTestSummary.Contains('FAIL package example.invalid/crash') -or
             -not $goTestSummary.Contains('active test before package termination') -or
             $goTestSummary.Contains('passing output must not be retained') -or

--- a/scripts/windows-native-ci.ps1
+++ b/scripts/windows-native-ci.ps1
@@ -467,14 +467,14 @@ function Get-GoTestFailureSummary(
     try {
         while ($null -ne ($line = $reader.ReadLine())) {
             try {
-                $event = $line.TrimStart([char]0xFEFF) | ConvertFrom-Json -ErrorAction Stop
+                $testEvent = $line.TrimStart([char]0xFEFF) | ConvertFrom-Json -ErrorAction Stop
             } catch {
                 continue
             }
-            if ((Get-WindowsNativeJsonString $event 'Action') -ne 'fail') { continue }
-            $package = Get-WindowsNativeJsonString $event 'Package'
+            if ((Get-WindowsNativeJsonString $testEvent 'Action') -ne 'fail') { continue }
+            $package = Get-WindowsNativeJsonString $testEvent 'Package'
             if (-not $package) { continue }
-            $test = Get-WindowsNativeJsonString $event 'Test'
+            $test = Get-WindowsNativeJsonString $testEvent 'Test'
             if ($test) {
                 $key = "$($package.Length):$package$test"
                 if ($failedTestKeys.Contains($key)) { continue }
@@ -485,13 +485,13 @@ function Get-GoTestFailureSummary(
                         Key = $key
                         Package = $package
                         Test = $test
-                        Elapsed = Get-WindowsNativeJsonString $event 'Elapsed'
+                        Elapsed = Get-WindowsNativeJsonString $testEvent 'Elapsed'
                     })
                 }
             } elseif ($failedPackageNames.Add($package)) {
                 $failedPackages.Add([pscustomobject]@{
                     Package = $package
-                    Elapsed = Get-WindowsNativeJsonString $event 'Elapsed'
+                    Elapsed = Get-WindowsNativeJsonString $testEvent 'Elapsed'
                 })
             }
         }
@@ -513,14 +513,14 @@ function Get-GoTestFailureSummary(
     try {
         while ($null -ne ($line = $reader.ReadLine())) {
             try {
-                $event = $line.TrimStart([char]0xFEFF) | ConvertFrom-Json -ErrorAction Stop
+                $testEvent = $line.TrimStart([char]0xFEFF) | ConvertFrom-Json -ErrorAction Stop
             } catch {
                 continue
             }
-            if ((Get-WindowsNativeJsonString $event 'Action') -ne 'output') { continue }
-            $package = Get-WindowsNativeJsonString $event 'Package'
-            $test = Get-WindowsNativeJsonString $event 'Test'
-            $output = Get-WindowsNativeJsonString $event 'Output'
+            if ((Get-WindowsNativeJsonString $testEvent 'Action') -ne 'output') { continue }
+            $package = Get-WindowsNativeJsonString $testEvent 'Package'
+            $test = Get-WindowsNativeJsonString $testEvent 'Test'
+            $output = Get-WindowsNativeJsonString $testEvent 'Output'
             if ($packageOutput.ContainsKey($package)) {
                 Add-WindowsNativeDiagnosticTail $packageOutput[$package] $output 160
             }

--- a/scripts/windows-native-ci.ps1
+++ b/scripts/windows-native-ci.ps1
@@ -430,6 +430,135 @@ function Limit-WindowsNativeText([AllowNull()][string]$Text, [int]$MaxBytes = 10
     return $head + [Text.Encoding]::UTF8.GetString($markerBytes) + $tail
 }
 
+function Add-WindowsNativeDiagnosticTail(
+    [Collections.Generic.Queue[string]]$Queue,
+    [AllowNull()][string]$Text,
+    [int]$MaxLines
+) {
+    foreach ($line in [regex]::Split([string]$Text, '\r?\n')) {
+        if (-not $line) { continue }
+        $Queue.Enqueue($line)
+        while ($Queue.Count -gt $MaxLines) { $null = $Queue.Dequeue() }
+    }
+}
+
+function Get-WindowsNativeJsonString([object]$Object, [string]$Name) {
+    $property = $Object.PSObject.Properties[$Name]
+    if ($null -eq $property) { return '' }
+    return [string]$property.Value
+}
+
+function Get-GoTestFailureSummary(
+    [AllowNull()][string]$Text,
+    [int]$MaxBytes = 262144
+) {
+    if (-not $Text) { return '' }
+
+    $failedTests = [Collections.Generic.List[object]]::new()
+    $failedTestKeys = [Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::Ordinal
+    )
+    $failedPackages = [Collections.Generic.List[object]]::new()
+    $failedPackageNames = [Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::Ordinal
+    )
+    $failedTestsOmitted = $false
+    $reader = [IO.StringReader]::new($Text)
+    try {
+        while ($null -ne ($line = $reader.ReadLine())) {
+            try {
+                $event = $line.TrimStart([char]0xFEFF) | ConvertFrom-Json -ErrorAction Stop
+            } catch {
+                continue
+            }
+            if ((Get-WindowsNativeJsonString $event 'Action') -ne 'fail') { continue }
+            $package = Get-WindowsNativeJsonString $event 'Package'
+            if (-not $package) { continue }
+            $test = Get-WindowsNativeJsonString $event 'Test'
+            if ($test) {
+                $key = "$($package.Length):$package$test"
+                if ($failedTestKeys.Contains($key)) { continue }
+                if ($failedTestKeys.Count -ge 128) {
+                    $failedTestsOmitted = $true
+                } elseif ($failedTestKeys.Add($key)) {
+                    $failedTests.Add([pscustomobject]@{
+                        Key = $key
+                        Package = $package
+                        Test = $test
+                        Elapsed = Get-WindowsNativeJsonString $event 'Elapsed'
+                    })
+                }
+            } elseif ($failedPackageNames.Add($package)) {
+                $failedPackages.Add([pscustomobject]@{
+                    Package = $package
+                    Elapsed = Get-WindowsNativeJsonString $event 'Elapsed'
+                })
+            }
+        }
+    } finally {
+        $reader.Dispose()
+    }
+    if ($failedTests.Count -eq 0 -and $failedPackages.Count -eq 0) { return '' }
+
+    $testOutput = @{}
+    foreach ($failure in $failedTests) {
+        $testOutput[$failure.Key] = [Collections.Generic.Queue[string]]::new()
+    }
+    $packageOutput = @{}
+    foreach ($failure in $failedPackages) {
+        $packageOutput[$failure.Package] = [Collections.Generic.Queue[string]]::new()
+    }
+
+    $reader = [IO.StringReader]::new($Text)
+    try {
+        while ($null -ne ($line = $reader.ReadLine())) {
+            try {
+                $event = $line.TrimStart([char]0xFEFF) | ConvertFrom-Json -ErrorAction Stop
+            } catch {
+                continue
+            }
+            if ((Get-WindowsNativeJsonString $event 'Action') -ne 'output') { continue }
+            $package = Get-WindowsNativeJsonString $event 'Package'
+            $test = Get-WindowsNativeJsonString $event 'Test'
+            $output = Get-WindowsNativeJsonString $event 'Output'
+            if ($packageOutput.ContainsKey($package)) {
+                Add-WindowsNativeDiagnosticTail $packageOutput[$package] $output 160
+            }
+            if ($test) {
+                $key = "$($package.Length):$package$test"
+                if ($testOutput.ContainsKey($key)) {
+                    Add-WindowsNativeDiagnosticTail $testOutput[$key] $output 120
+                }
+            }
+        }
+    } finally {
+        $reader.Dispose()
+    }
+
+    $summary = [Text.StringBuilder]::new()
+    [void]$summary.AppendLine('go test failure summary (bounded and redacted)')
+    foreach ($failure in $failedTests) {
+        $elapsed = if ($failure.Elapsed) { " [$($failure.Elapsed)s]" } else { '' }
+        [void]$summary.AppendLine("--- FAIL: $($failure.Test) ($($failure.Package))$elapsed")
+        foreach ($line in $testOutput[$failure.Key]) {
+            [void]$summary.AppendLine($line)
+        }
+    }
+    foreach ($failure in $failedPackages) {
+        $elapsed = if ($failure.Elapsed) { " [$($failure.Elapsed)s]" } else { '' }
+        [void]$summary.AppendLine("FAIL package $($failure.Package)$elapsed")
+        if (-not ($failedTests | Where-Object { $_.Package -eq $failure.Package })) {
+            foreach ($line in $packageOutput[$failure.Package]) {
+                [void]$summary.AppendLine($line)
+            }
+        }
+    }
+    if ($failedTestsOmitted) {
+        [void]$summary.AppendLine('[additional failed tests omitted]')
+    }
+    return Limit-WindowsNativeText ($summary.ToString()) $MaxBytes
+}
+
 function Write-BoundedText([string]$Path, [AllowNull()][string]$Text, [int]$MaxBytes = 1048576) {
     $safe = Limit-WindowsNativeText $Text $MaxBytes
     [IO.Directory]::CreateDirectory((Split-Path -Parent $Path)) | Out-Null
@@ -649,9 +778,13 @@ function Invoke-WindowsNativeProcess {
         [int[]]$AllowedExitCodes = @(0),
         [ValidateRange(1, 4200)][int]$TimeoutSeconds = 600,
         [string]$LogPath = '',
+        [string]$GoTestFailureSummaryPath = '',
         [string]$WorkingDirectory = '',
         [switch]$SuppressOutput
     )
+    if ($GoTestFailureSummaryPath -and $SuppressOutput) {
+        throw 'Go test failure summaries are prohibited for credential-bearing process output'
+    }
     $start = [Diagnostics.ProcessStartInfo]::new()
     $start.FileName = $FilePath
     $start.UseShellExecute = $false
@@ -717,8 +850,18 @@ function Invoke-WindowsNativeProcess {
             if (-not $stdoutTask.IsCompleted) { $process.StandardOutput.Dispose() }
             if (-not $stderrTask.IsCompleted) { $process.StandardError.Dispose() }
         }
-        $stdout = Limit-WindowsNativeText (Read-WindowsNativeOutputTask $stdoutTask)
-        $stderr = Limit-WindowsNativeText (Read-WindowsNativeOutputTask $stderrTask)
+        $rawStdout = Read-WindowsNativeOutputTask $stdoutTask
+        $rawStderr = Read-WindowsNativeOutputTask $stderrTask
+        if ($GoTestFailureSummaryPath) {
+            $goTestFailureSummary = Get-GoTestFailureSummary $rawStdout
+            if ($goTestFailureSummary) {
+                Write-BoundedText -Path $GoTestFailureSummaryPath `
+                    -Text $goTestFailureSummary -MaxBytes 262144
+                Write-Host $goTestFailureSummary
+            }
+        }
+        $stdout = Limit-WindowsNativeText $rawStdout
+        $stderr = Limit-WindowsNativeText $rawStderr
         if ($timedOut) {
             $stderr = @($stderr, "[timeout descendants: $timeoutIdentitySummary]" | Where-Object { $_ }) -join [Environment]::NewLine
         }
@@ -4963,7 +5106,7 @@ function Get-WindowsNativeCaptureFiles([string]$Root) {
             Sort-Object @{
                 Expression = {
                     if ($_.Name -eq 'wizard-driver.log') { 0 }
-                    elseif ($_.Name -eq 'go-test.log') { 1 }
+                    elseif ($_.Name -in @('go-test-failure-summary.log', 'go-test.log')) { 1 }
                     else { 2 }
                 }
             }, FullName |
@@ -5096,12 +5239,76 @@ function Invoke-SelfTest {
             throw 'bounded native text lost truncation, redaction, or UTF-8 integrity guarantees'
         }
 
+        $goTestJson = @(
+            [pscustomobject]@{
+                Action = 'output'
+                Package = 'example.invalid/pkg'
+                Test = 'TestPassing'
+                Output = "passing output must not be retained`n"
+            },
+            [pscustomobject]@{
+                Action = 'pass'
+                Package = 'example.invalid/pkg'
+                Test = 'TestPassing'
+                Elapsed = 0.01
+            },
+            [pscustomobject]@{
+                Action = 'output'
+                Package = 'example.invalid/pkg'
+                Test = 'TestFailing'
+                Output = "Authorization: Bearer $headerSecret`n"
+            },
+            [pscustomobject]@{
+                Action = 'output'
+                Package = 'example.invalid/pkg'
+                Test = 'TestFailing'
+                Output = "fixture assertion failed`n"
+            },
+            [pscustomobject]@{
+                Action = 'fail'
+                Package = 'example.invalid/pkg'
+                Test = 'TestFailing'
+                Elapsed = 1.25
+            },
+            [pscustomobject]@{
+                Action = 'fail'
+                Package = 'example.invalid/pkg'
+                Elapsed = 1.30
+            },
+            [pscustomobject]@{
+                Action = 'output'
+                Package = 'example.invalid/crash'
+                Test = 'TestActiveWhenProcessStopped'
+                Output = "active test before package termination`n"
+            },
+            [pscustomobject]@{
+                Action = 'fail'
+                Package = 'example.invalid/crash'
+            }
+        ) | ForEach-Object { $_ | ConvertTo-Json -Compress }
+        $goTestSummary = Get-GoTestFailureSummary (
+            $goTestJson -join [Environment]::NewLine
+        ) 1024
+        if (-not $goTestSummary.Contains(
+            '--- FAIL: TestFailing (example.invalid/pkg) [1.25s]'
+        ) -or -not $goTestSummary.Contains('fixture assertion failed') -or
+            -not $goTestSummary.Contains('FAIL package example.invalid/crash') -or
+            -not $goTestSummary.Contains('active test before package termination') -or
+            $goTestSummary.Contains('passing output must not be retained') -or
+            $goTestSummary.Contains($headerSecret) -or
+            -not $goTestSummary.Contains('Authorization: ***REDACTED***') -or
+            [Text.Encoding]::UTF8.GetByteCount($goTestSummary) -gt 1024) {
+            throw 'structured Go test summary lost failure identity, focus, redaction, or bounds'
+        }
+
         [IO.Directory]::CreateDirectory($captureFixture) | Out-Null
         $boundedPath = Join-Path $captureFixture 'go-test.log'
         Write-BoundedText $boundedPath $boundedInput $boundedLimit
         if ([IO.FileInfo]::new($boundedPath).Length -gt $boundedLimit) {
             throw 'bounded diagnostic file is too large for native capture'
         }
+        $goTestSummaryPath = Join-Path $captureFixture 'go-test-failure-summary.log'
+        Write-BoundedText $goTestSummaryPath $goTestSummary 262144
         foreach ($index in 0..30) {
             Write-BoundedText (Join-Path $captureFixture ("00-before-go-test-{0:D2}.log" -f $index)) 'decoy'
         }
@@ -5119,6 +5326,11 @@ function Invoke-SelfTest {
             $_.FullName.Equals($boundedPath, [StringComparison]::OrdinalIgnoreCase)
         })) {
             throw 'bounded go-test.log was not prioritized into native capture'
+        }
+        if (-not ($captureFiles | Where-Object {
+            $_.FullName.Equals($goTestSummaryPath, [StringComparison]::OrdinalIgnoreCase)
+        })) {
+            throw 'bounded Go failure summary was not prioritized into native capture'
         }
         if ($captureFiles | Where-Object {
             $_.FullName.Equals($oversizedPath, [StringComparison]::OrdinalIgnoreCase)

--- a/scripts/windows-native-ci.ps1
+++ b/scripts/windows-native-ci.ps1
@@ -433,12 +433,26 @@ function Limit-WindowsNativeText([AllowNull()][string]$Text, [int]$MaxBytes = 10
 function Add-WindowsNativeDiagnosticTail(
     [Collections.Generic.Queue[string]]$Queue,
     [AllowNull()][string]$Text,
-    [int]$MaxLines
+    [int]$MaxLines,
+    [int]$MaxBytes
 ) {
-    foreach ($line in [regex]::Split([string]$Text, '\r?\n')) {
+    if ($MaxLines -le 0 -or $MaxBytes -le 0) { return }
+    # Bound each event before splitting or retaining it. The primary process
+    # capture already owns the raw output; diagnostic queues must not multiply
+    # an oversized JSON Output event beyond the summary's independent budget.
+    $boundedText = Limit-WindowsNativeText ([string]$Text) $MaxBytes
+    $retainedBytes = 0
+    foreach ($retainedLine in $Queue) {
+        $retainedBytes += [Text.Encoding]::UTF8.GetByteCount($retainedLine)
+    }
+    foreach ($line in [regex]::Split($boundedText, '\r?\n')) {
         if (-not $line) { continue }
         $Queue.Enqueue($line)
-        while ($Queue.Count -gt $MaxLines) { $null = $Queue.Dequeue() }
+        $retainedBytes += [Text.Encoding]::UTF8.GetByteCount($line)
+        while ($Queue.Count -gt $MaxLines -or $retainedBytes -gt $MaxBytes) {
+            $removed = $Queue.Dequeue()
+            $retainedBytes -= [Text.Encoding]::UTF8.GetByteCount($removed)
+        }
     }
 }
 
@@ -463,6 +477,8 @@ function Get-GoTestFailureSummary(
         [StringComparer]::Ordinal
     )
     $failedTestsOmitted = $false
+    $failedPackagesOmitted = $false
+    $maxFailures = 128
     $reader = [IO.StringReader]::new($Text)
     try {
         while ($null -ne ($line = $reader.ReadLine())) {
@@ -472,27 +488,39 @@ function Get-GoTestFailureSummary(
                 continue
             }
             if ((Get-WindowsNativeJsonString $testEvent 'Action') -ne 'fail') { continue }
-            $package = Get-WindowsNativeJsonString $testEvent 'Package'
+            $package = Limit-WindowsNativeText (
+                Get-WindowsNativeJsonString $testEvent 'Package'
+            ) 1024
             if (-not $package) { continue }
-            $test = Get-WindowsNativeJsonString $testEvent 'Test'
+            $test = Limit-WindowsNativeText (
+                Get-WindowsNativeJsonString $testEvent 'Test'
+            ) 1024
             if ($test) {
                 $key = "$($package.Length):$package$test"
                 if ($failedTestKeys.Contains($key)) { continue }
-                if ($failedTestKeys.Count -ge 128) {
+                if ($failedTestKeys.Count -ge $maxFailures) {
                     $failedTestsOmitted = $true
                 } elseif ($failedTestKeys.Add($key)) {
                     $failedTests.Add([pscustomobject]@{
                         Key = $key
                         Package = $package
                         Test = $test
-                        Elapsed = Get-WindowsNativeJsonString $testEvent 'Elapsed'
+                        Elapsed = Limit-WindowsNativeText (
+                            Get-WindowsNativeJsonString $testEvent 'Elapsed'
+                        ) 64
                     })
                 }
-            } elseif ($failedPackageNames.Add($package)) {
-                $failedPackages.Add([pscustomobject]@{
-                    Package = $package
-                    Elapsed = Get-WindowsNativeJsonString $testEvent 'Elapsed'
-                })
+            } elseif (-not $failedPackageNames.Contains($package)) {
+                if ($failedPackageNames.Count -ge $maxFailures) {
+                    $failedPackagesOmitted = $true
+                } elseif ($failedPackageNames.Add($package)) {
+                    $failedPackages.Add([pscustomobject]@{
+                        Package = $package
+                        Elapsed = Limit-WindowsNativeText (
+                            Get-WindowsNativeJsonString $testEvent 'Elapsed'
+                        ) 64
+                    })
+                }
             }
         }
     } finally {
@@ -505,9 +533,21 @@ function Get-GoTestFailureSummary(
         $testOutput[$failure.Key] = [Collections.Generic.Queue[string]]::new()
     }
     $packageOutput = @{}
+    $packageCriticalOutput = @{}
+    $packageCriticalRemaining = @{}
     foreach ($failure in $failedPackages) {
         $packageOutput[$failure.Package] = [Collections.Generic.Queue[string]]::new()
+        $packageCriticalOutput[$failure.Package] = [Collections.Generic.Queue[string]]::new()
+        $packageCriticalRemaining[$failure.Package] = 0
     }
+    # At most 128 failed tests and 128 package-only failures are retained.
+    # Per-failure budgets cap aggregate tail queues relative to MaxBytes; the
+    # separate critical-context queues have a 2 KiB floor so panic headers and
+    # goroutine 1 survive deliberately tiny self-test budgets.
+    $tailBytesPerFailure = [Math]::Max(
+        256,
+        [int][Math]::Floor($MaxBytes / ($maxFailures * 2))
+    )
 
     $reader = [IO.StringReader]::new($Text)
     try {
@@ -518,16 +558,30 @@ function Get-GoTestFailureSummary(
                 continue
             }
             if ((Get-WindowsNativeJsonString $testEvent 'Action') -ne 'output') { continue }
-            $package = Get-WindowsNativeJsonString $testEvent 'Package'
-            $test = Get-WindowsNativeJsonString $testEvent 'Test'
+            $package = Limit-WindowsNativeText (
+                Get-WindowsNativeJsonString $testEvent 'Package'
+            ) 1024
+            $test = Limit-WindowsNativeText (
+                Get-WindowsNativeJsonString $testEvent 'Test'
+            ) 1024
             $output = Get-WindowsNativeJsonString $testEvent 'Output'
             if ($packageOutput.ContainsKey($package)) {
-                Add-WindowsNativeDiagnosticTail $packageOutput[$package] $output 160
+                Add-WindowsNativeDiagnosticTail -Queue $packageOutput[$package] `
+                    -Text $output -MaxLines 160 -MaxBytes $tailBytesPerFailure
+                if ($output -match '(?im)^(panic:|fatal error:|runtime: out of memory|.*test timed out after|exit status )') {
+                    $packageCriticalRemaining[$package] = 48
+                }
+                if ([int]$packageCriticalRemaining[$package] -gt 0) {
+                    Add-WindowsNativeDiagnosticTail -Queue $packageCriticalOutput[$package] `
+                        -Text $output -MaxLines 64 -MaxBytes ([Math]::Max(2048, $tailBytesPerFailure))
+                    $packageCriticalRemaining[$package] = [int]$packageCriticalRemaining[$package] - 1
+                }
             }
             if ($test) {
                 $key = "$($package.Length):$package$test"
                 if ($testOutput.ContainsKey($key)) {
-                    Add-WindowsNativeDiagnosticTail $testOutput[$key] $output 120
+                    Add-WindowsNativeDiagnosticTail -Queue $testOutput[$key] `
+                        -Text $output -MaxLines 120 -MaxBytes $tailBytesPerFailure
                 }
             }
         }
@@ -548,6 +602,9 @@ function Get-GoTestFailureSummary(
         $elapsed = if ($failure.Elapsed) { " [$($failure.Elapsed)s]" } else { '' }
         [void]$summary.AppendLine("FAIL package $($failure.Package)$elapsed")
         if (-not ($failedTests | Where-Object { $_.Package -eq $failure.Package })) {
+            foreach ($line in $packageCriticalOutput[$failure.Package]) {
+                [void]$summary.AppendLine($line)
+            }
             foreach ($line in $packageOutput[$failure.Package]) {
                 [void]$summary.AppendLine($line)
             }
@@ -555,6 +612,9 @@ function Get-GoTestFailureSummary(
     }
     if ($failedTestsOmitted) {
         [void]$summary.AppendLine('[additional failed tests omitted]')
+    }
+    if ($failedPackagesOmitted) {
+        [void]$summary.AppendLine('[additional failed packages omitted]')
     }
     return Limit-WindowsNativeText ($summary.ToString()) $MaxBytes
 }
@@ -852,7 +912,10 @@ function Invoke-WindowsNativeProcess {
         }
         $rawStdout = Read-WindowsNativeOutputTask $stdoutTask
         $rawStderr = Read-WindowsNativeOutputTask $stderrTask
-        if ($GoTestFailureSummaryPath) {
+        $exitCode = if ($timedOut) { 124 } else { $process.ExitCode }
+        $goTestFailureSummary = ''
+        if ($GoTestFailureSummaryPath -and
+            ($timedOut -or $outputReadFailed -or $exitCode -notin $AllowedExitCodes)) {
             $goTestFailureSummary = Get-GoTestFailureSummary $rawStdout
             if ($goTestFailureSummary) {
                 Write-BoundedText -Path $GoTestFailureSummaryPath `
@@ -865,9 +928,13 @@ function Invoke-WindowsNativeProcess {
         if ($timedOut) {
             $stderr = @($stderr, "[timeout descendants: $timeoutIdentitySummary]" | Where-Object { $_ }) -join [Environment]::NewLine
         }
-        $exitCode = if ($timedOut) { 124 } else { $process.ExitCode }
         $combined = @($stdout, $stderr | Where-Object { $_ }) -join [Environment]::NewLine
-        if ($combined -and -not $SuppressOutput) { Write-Host $combined }
+        # A structured Go failure summary is the bounded, relevant console
+        # diagnostic. Keep the full bounded JSON stream in LogPath without
+        # duplicating it into the exception and Actions log.
+        if ($combined -and -not $SuppressOutput -and -not $goTestFailureSummary) {
+            Write-Host $combined
+        }
         if ($LogPath) {
             $logText = if ($SuppressOutput) {
                 '[credential-bearing process output intentionally suppressed]'
@@ -886,12 +953,14 @@ function Invoke-WindowsNativeProcess {
         Write-WindowsNativeProcessPhase $FilePath $process.Id $(if ($timedOut) { 'failed-timeout' } elseif ($outputReadFailed) { 'failed-output' } elseif ($exitCode -in $AllowedExitCodes) { 'completed' } else { 'failed-exit' })
         if ($outputReadFailed) {
             if ($SuppressOutput) { throw "$FilePath redirected output capture failed" }
-            throw "$FilePath redirected output capture failed`n$combined"
+            $failureOutput = if ($goTestFailureSummary) { $goTestFailureSummary } else { $combined }
+            throw "$FilePath redirected output capture failed`n$failureOutput"
         }
         if ($exitCode -notin $AllowedExitCodes) {
             $reason = if ($timedOut) { "timed out after ${TimeoutSeconds}s" } else { "exited $exitCode" }
             if ($SuppressOutput) { throw "$FilePath $reason" }
-            throw "$FilePath $reason`n$combined"
+            $failureOutput = if ($goTestFailureSummary) { $goTestFailureSummary } else { $combined }
+            throw "$FilePath $reason`n$failureOutput"
         }
         return $result
     } finally {
@@ -3199,6 +3268,10 @@ function Invoke-SetupAcceptance {
     $installRoot = Join-Path $localAppData 'Programs\DefenseClaw'
     $dataRoot = Join-Path $userProfile '.defenseclaw'
     $cacheRoot = Join-Path $localAppData 'DefenseClaw\InstallerCache'
+    # The transaction-bound helper may spend up to two minutes waiting for
+    # Setup to exit. Allow that contract plus scheduling margin before judging
+    # the fail-closed self-delete assertion.
+    $deferredCleanupWaitAttempts = 520
     $arpKey = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\DefenseClaw'
     $connectorConfigPaths = @(
         (Join-Path $userProfile '.codex\config.toml'),
@@ -3686,7 +3759,7 @@ assert set(((document.get("guardrail") or {}).get("connectors") or {})) == {"cod
             -TimeoutSeconds 600 -LogPath (Join-Path $logs 'setup-uninstall-delete.log') | Out-Null
         if (Test-Path -LiteralPath $installRoot) { throw "setup uninstall left install root behind: $installRoot" }
         if (Test-Path -LiteralPath $dataRoot) { throw "setup uninstall with DELETEUSERDATA=1 left user data behind: $dataRoot" }
-        for ($attempt = 0; $attempt -lt 40 -and (Test-Path -LiteralPath $cacheRoot); $attempt++) {
+        for ($attempt = 0; $attempt -lt $deferredCleanupWaitAttempts -and (Test-Path -LiteralPath $cacheRoot); $attempt++) {
             Start-Sleep -Milliseconds 250
         }
         if (Test-Path -LiteralPath $cacheRoot) {
@@ -3720,7 +3793,7 @@ assert set(((document.get("guardrail") or {}).get("connectors") or {})) == {"cod
             } catch { Write-Warning "setup acceptance cleanup failed: $($_.Exception.Message)" }
         }
         Remove-WizardAgentFixtures $agentFixtures
-        for ($attempt = 0; $attempt -lt 40 -and (Test-Path -LiteralPath $cacheRoot); $attempt++) {
+        for ($attempt = 0; $attempt -lt $deferredCleanupWaitAttempts -and (Test-Path -LiteralPath $cacheRoot); $attempt++) {
             Start-Sleep -Milliseconds 250
         }
         $finalValidationFailures = [Collections.Generic.List[string]]::new()
@@ -5299,6 +5372,48 @@ function Invoke-SelfTest {
             -not $goTestSummary.Contains('Authorization: ***REDACTED***') -or
             [Text.Encoding]::UTF8.GetByteCount($goTestSummary) -gt 1024) {
             throw 'structured Go test summary lost failure identity, focus, redaction, or bounds'
+        }
+
+        $largeGoTestJson = @(
+            [pscustomobject]@{
+                Action = 'output'
+                Package = 'example.invalid/large'
+                Test = 'TestOversizedOutput'
+                Output = (('x' * 1048576) + "`nretained-large-output-tail`n")
+            },
+            [pscustomobject]@{
+                Action = 'fail'
+                Package = 'example.invalid/large'
+                Test = 'TestOversizedOutput'
+            }
+        )
+        $largeGoTestJson += [pscustomobject]@{
+            Action = 'output'
+            Package = 'example.invalid/package-0'
+            Output = "panic: test timed out after 20m0s`n"
+        }
+        $largeGoTestJson += [pscustomobject]@{
+            Action = 'output'
+            Package = 'example.invalid/package-0'
+            Output = "goroutine 1 [chan receive]:`n"
+        }
+        foreach ($index in 0..140) {
+            $largeGoTestJson += [pscustomobject]@{
+                Action = 'fail'
+                Package = "example.invalid/package-$index"
+            }
+        }
+        $largeGoTestSummary = Get-GoTestFailureSummary (
+            @($largeGoTestJson | ForEach-Object {
+                $_ | ConvertTo-Json -Compress
+            }) -join [Environment]::NewLine
+        ) 4096
+        if ([Text.Encoding]::UTF8.GetByteCount($largeGoTestSummary) -gt 4096 -or
+            -not $largeGoTestSummary.Contains('retained-large-output-tail') -or
+            -not $largeGoTestSummary.Contains('panic: test timed out after 20m0s') -or
+            -not $largeGoTestSummary.Contains('goroutine 1 [chan receive]') -or
+            -not $largeGoTestSummary.Contains('[additional failed packages omitted]')) {
+            throw 'structured Go test summary buffered oversized output or lost bounded omission evidence'
         }
 
         [IO.Directory]::CreateDirectory($captureFixture) | Out-Null


### PR DESCRIPTION
## Root cause

The current-main `CI` push run [30121320399](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/30121320399) at squash commit `51d7bb0a888d86dbd331486810574d4db104087c` failed deterministically in **Release Validation Plan** while resolving candidate 0.8.8:

> signed checksum and immutable GitHub asset disagree for 0.8.7/checksums.txt.bundle

Release 0.8.7 itself is intact. The `workflow_dispatch` release run [30072634038](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/30072634038) built, tested, signed, sealed, published, and then proved exact immutable custody from `57393d05a8fdbe4db86776d9108606939f5529e7`. `scripts/release_candidate.py` intentionally classifies `checksums.txt.bundle`, `.pem`, and `.sig` as proof files published outside `checksums.txt`: the bundle is generated by signing the checksum manifest and cannot be included in that same manifest without a self-reference. The historical baseline resolver had the matching exception for `.pem` and `.sig`, but omitted `.bundle`, so it incorrectly treated valid proof as an unsigned payload.

The failure first appeared after merge because the timing and trigger paths differed:

- The 0.8.7 release was published at 07:16Z, after the preceding main-push validation had already started against 0.8.6.
- PR #607's `pull_request` run [30113124462](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/30113124462) classified its five changed paths as non-release-sensitive and skipped candidate resolution plus live baseline authentication.
- The squash merge then invoked the unconditional `push` path, which discovered 0.8.7 and failed.
- `Release Validation Plan` was not a required ruleset context; `Python Lint & Test` is required.
- No `merge_group`, `workflow_run`, `release`, or deployment event was involved. The publishing path was the explicit release `workflow_dispatch`; this PR does not invoke it.

The first PR-head run then exposed an adjacent verifier inconsistency on the now-live 0.8.7 Windows baseline. The generator deliberately filters an unpublished historical Windows bridge out of the matrix while retaining authenticated post-hard-cut runtimes that can drive direct protocol-2 upgrades. The candidate verifier first calculated and required that exact filtered matrix, then a stale later check contradicted it by requiring the matrix to be empty. The fix retains exact policy equality and rejects all pre-hard-cut sources when the bridge is unpublished, while admitting only authenticated post-hard-cut runtimes.

The original current-main run also had an unrelated runtime queue-pressure test failure that had passed on the PR head. `Windows Native CI` [30121320347](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/30121320347) failed separately when GitHub's release asset host reset the TCP connection during a provenance download. Neither failure is caused by these release-policy corrections.

## Fix

- Treat `checksums.txt.bundle` consistently as checksum-manifest proof, alongside the detached certificate and signature.
- Continue comparing every actual published payload against both the authenticated checksum manifest and GitHub's immutable SHA-256 digest.
- Run authenticated live-baseline resolution on every PR, while keeping expensive candidate construction and upgrade matrices path-selective.
- Feed release-validation success into the already-required `Python Lint & Test` gate.
- Permit the exact authenticated Windows policy to contain direct post-hard-cut runtimes when the historical bridge was never published; continue rejecting pre-hard-cut Windows sources.
- Model real proof-bundle and direct-Windows-baseline cases in regression fixtures, and lock the PR trigger/required-gate behavior with a workflow contract.

## Security invariants

No release artifact was changed, replaced, or republished. Sigstore identity/issuer verification, immutable GitHub digest checks, exact payload checksum coverage, candidate custody, read-only CI permissions, exact reviewed baseline equality, and fail-closed behavior remain unchanged. The proof bundle is not used to establish payload authenticity; the resolver still verifies `checksums.txt` through its certificate/signature and authenticates every payload named by that signed manifest.

## Validation

- Deterministic release contracts plus the complete candidate-sealer tests: **464 passed, 1 skipped**.
- Original exact release-regression command used by CI: **282 passed, 1 skipped**.
- Focused resolver/workflow contracts: **34 passed**.
- Ruff on all changed Python: passed.
- `actionlint` v1.7.7 on `.github/workflows/ci.yml`: passed.
- Patched resolver against the live immutable 0.8.7 release with Cosign v2.6.2: three `Verified OK` results; global baseline `0.8.7`, Windows baseline `0.8.7`, runtime config `8`.
- `git diff --check`: clean.

No release or deployment was triggered.
