### PR TITLE
fix(installer): fail closed on explicit endpoint config errors

### DIFF
--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -462,6 +462,9 @@ Gateway options:
   --config-file PATH        Path to the AVC-authored env_config.json that
                             supplies cisco_ai_defense.endpoint. Default:
                             ${DEFAULT_CONFIG_FILE}
+                            Explicit override paths must exist and contain a
+                            valid endpoint; only the implicit default path can
+                            fall back during AVC packaging sequencing.
                             The file must be root-owned and non-writable by
                             group/other, per the managed_enterprise trust
                             contract. Expected JSON shape:
@@ -499,6 +502,7 @@ MODE="${DEFAULT_MODE}"
 CONNECTOR="${DEFAULT_CONNECTOR}"
 API_PORT="${DEFAULT_API_PORT}"
 CONFIG_FILE="${DEFAULT_CONFIG_FILE}"
+CONFIG_FILE_EXPLICIT="false"
 OVERRIDE_ENDPOINT=""
 ALLOW_EMPTY_USERS="false"
 
@@ -507,7 +511,7 @@ while [[ $# -gt 0 ]]; do
     --mode)             MODE="${2:?}"; shift 2;;
     --connector)        CONNECTOR="${2:?}"; shift 2;;
     --port)             API_PORT="${2:?}"; shift 2;;
-    --config-file)      CONFIG_FILE="${2:?}"; shift 2;;
+    --config-file)      CONFIG_FILE="${2:?}"; CONFIG_FILE_EXPLICIT="true"; shift 2;;
     --override-endpoint) OVERRIDE_ENDPOINT="${2:?}"; shift 2;;
     --disable-redaction|--no-redact) DISABLE_REDACTION="true"; shift;;
     --binary)           BINARY_SRC="${2:?}"; SKIP_BUILD="true"; shift 2;;
@@ -580,6 +584,9 @@ AID_ENDPOINT="$(resolve_aid_endpoint "${OVERRIDE_ENDPOINT}" "${CONFIG_FILE}")" |
 if (( _ep_rc == 3 )); then
   die "--override-endpoint must be an HTTPS bare origin (no userinfo, path, query, or fragment) — got: ${OVERRIDE_ENDPOINT}"
 elif (( _ep_rc == 2 )); then
+  if [[ "${CONFIG_FILE_EXPLICIT}" == "true" ]]; then
+    die "--config-file ${CONFIG_FILE} is malformed: expected a JSON object with a valid \"cisco_ai_defense_endpoint\" URL. Correct the file or pass --override-endpoint URL for adhoc testing."
+  fi
   # Malformed env_config.json (bad JSON, missing cisco_ai_defense_endpoint
   # field, or bad URL shape). Fall through to the US-prod default so a
   # stale, corrupt, or partially-written AVC drop can't brick the
@@ -591,6 +598,9 @@ elif (( _ep_rc == 2 )); then
   warn "env_config.json at ${CONFIG_FILE} is malformed (expected a JSON object with a valid \"cisco_ai_defense_endpoint\" URL). Installing with default endpoint ${DEFAULT_AID_ENDPOINT}."
   AID_ENDPOINT="${DEFAULT_AID_ENDPOINT}"
 elif (( _ep_rc == 1 )); then
+  if [[ "${CONFIG_FILE_EXPLICIT}" == "true" ]]; then
+    die "env_config.json not found at ${CONFIG_FILE}; correct the explicit --config-file path or pass --override-endpoint URL for adhoc testing."
+  fi
   # Missing env_config.json is expected under the AVC packaging
   # sequencing where AVC installs DefenseClaw before its own bundle
   # drops env_config.json. Fall through to the US-prod default so

--- a/packaging/macos/tests/test_arg_parsing.sh
+++ b/packaging/macos/tests/test_arg_parsing.sh
@@ -217,7 +217,7 @@ t_install_override_endpoint_rejects_path_query_fragment() {
   done
 }
 
-t_install_missing_config_file_falls_back_to_default() {
+t_install_default_missing_config_file_falls_back_to_default() {
   # Missing env_config.json is expected under the AVC packaging
   # sequencing where AVC installs DefenseClaw before its own bundle
   # drops env_config.json. Installer must warn and continue with the
@@ -230,9 +230,8 @@ t_install_missing_config_file_falls_back_to_default() {
   # longer says "not found ... die" — it says "warn and default".
   # Grep for the warn substring plus the default endpoint URL; the
   # non-zero exit code comes from a downstream stage, not this branch.
-  local case_dir; case_dir="$(mktest_tmp)"
   local out rc=0
-  out="$("${INSTALL_SH}" --config-file "${case_dir}/does-not-exist.json" 2>&1)" || rc=$?
+  out="$("${INSTALL_SH}" 2>&1)" || rc=$?
   assert_contains "${out}" "env_config.json not found at" \
     "installer names the missing env_config.json in the warn line"
   assert_contains "${out}" "https://us.api.inspect.aidefense.security.cisco.com" \
@@ -245,36 +244,41 @@ t_install_missing_config_file_falls_back_to_default() {
     "old fail-fast message must be gone (variant)"
 }
 
-t_install_malformed_config_file_falls_back_to_default() {
-  # A dummy / partially-written / stale env_config.json (bad JSON,
-  # missing field, or bad URL shape) must not brick the install either.
-  # The AVC installer sometimes drops a placeholder before its real
-  # bundle lands; treating that as fatal would create a support burden
-  # every time AVC's ordering slipped. Fall through to US-prod default
-  # with a WARN so operators can still find the misconfig in install.log.
-  #
-  # Trust-check failures (root ownership / write bits / symlinks) are
-  # separate and still hard-fail before the resolver runs — this
-  # relaxation applies only to the content branch.
+t_install_explicit_missing_config_file_exits_nonzero() {
+  # An explicit --config-file is an operator/fleet override, not the
+  # AVC default-drop sequencing path. A typo here must fail closed
+  # rather than silently sending managed traffic to the US-prod
+  # default.
+  local case_dir; case_dir="$(mktest_tmp)"
+  local out rc=0
+  out="$("${INSTALL_SH}" --config-file "${case_dir}/does-not-exist.json" 2>&1)" || rc=$?
+  assert_status "${rc}" 1 "explicit missing --config-file should exit non-zero"
+  assert_contains "${out}" "correct the explicit --config-file path" \
+    "explains explicit config path failure"
+  assert_contains "${out}" "--override-endpoint URL" \
+    "points adhoc users at the explicit override seam"
+  assert_not_contains "${out}" "Installing with default endpoint" \
+    "explicit config override must not fall back to the default endpoint"
+}
+
+t_install_explicit_malformed_config_file_exits_nonzero() {
+  # A dummy / partially-written / stale explicit env_config.json (bad
+  # JSON, missing field, or bad URL shape) must fail closed. Only the
+  # implicit default AVC path has the packaging-sequencing fallback.
   local case_dir; case_dir="$(mktest_tmp)"
   local cfg="${case_dir}/env_config.json"
   printf '{"cisco_ai_defense_endpoint":"not-a-url"}\n' >"${cfg}"
   local out rc=0
   out="$(DC_INSTALLER_SKIP_ROOT_CHECK=1 "${INSTALL_SH}" --config-file "${cfg}" 2>&1)" || rc=$?
+  assert_status "${rc}" 1 "explicit malformed --config-file should exit non-zero"
   assert_contains "${out}" "is malformed" \
-    "installer names the malformed condition in the warn line"
+    "installer names the malformed condition"
   assert_contains "${out}" "${cfg}" \
-    "warn line names the offending file"
-  assert_contains "${out}" "https://us.api.inspect.aidefense.security.cisco.com" \
-    "installer falls through to the US-prod default endpoint on malformed"
-  assert_contains "${out}" "Installing with default endpoint" \
-    "warn line spells out the fallback"
-  # The new contract prefixes the message with the WARN label; a
-  # regression to the die() path would emit an ERROR prefix instead.
-  # This is the cleanest signal of "did we go the warn+fallback way
-  # vs the old fail-hard way" without pinning brittle exact wording.
-  assert_contains "${out}" "WARN" \
-    "malformed env_config.json emits a WARN, not a fatal error"
+    "error names the offending file"
+  assert_contains "${out}" "--override-endpoint URL" \
+    "points adhoc users at the explicit override seam"
+  assert_not_contains "${out}" "Installing with default endpoint" \
+    "explicit malformed config must not fall back to the default endpoint"
 }
 
 t_install_config_file_trust_check_fires_on_world_writable() {
@@ -374,8 +378,9 @@ run_case "install --override-endpoint garbage rejected"  t_install_bad_override_
 run_case "install --override-endpoint plaintext http:// rejected" t_install_override_endpoint_rejects_plaintext_http
 run_case "install --override-endpoint userinfo rejected"          t_install_override_endpoint_rejects_userinfo
 run_case "install --override-endpoint path/query/fragment rejected" t_install_override_endpoint_rejects_path_query_fragment
-run_case "install missing --config-file falls back to US-prod default"     t_install_missing_config_file_falls_back_to_default
-run_case "install malformed --config-file falls back to US-prod default"   t_install_malformed_config_file_falls_back_to_default
+run_case "install default missing config falls back to US-prod default"    t_install_default_missing_config_file_falls_back_to_default
+run_case "install explicit missing --config-file rejected"                 t_install_explicit_missing_config_file_exits_nonzero
+run_case "install explicit malformed --config-file rejected"               t_install_explicit_malformed_config_file_exits_nonzero
 run_case "install world-writable --config-file rejected" t_install_config_file_trust_check_fires_on_world_writable
 run_case "install DEFAULT_CONFIG_FILE=AVC path"          t_install_default_config_file_path
 run_case "install DEFAULT_MODE=action (managed_enterprise)" t_install_default_mode_is_action

--- a/packaging/macos/tests/test_arg_parsing.sh
+++ b/packaging/macos/tests/test_arg_parsing.sh
@@ -224,6 +224,32 @@ t_install_default_missing_config_file_falls_back_to_default() {
   # US-prod default rather than fail-close — a dummy or absent file
   # from a broken AVC drop must not brick the install.
   #
+  # Use an isolated installer copy whose implicit default points at a
+  # guaranteed-absent fixture. Invoking the real installer directly
+  # would make this test depend on whether the host already has AVC's
+  # default env_config.json.
+  local case_dir; case_dir="$(mktest_tmp)"
+  local isolated_install="${case_dir}/install.sh"
+  local line
+  while IFS= read -r line; do
+    case "${line}" in
+      DEFAULT_CONFIG_FILE=*)
+        printf 'DEFAULT_CONFIG_FILE=%q\n' \
+          "${case_dir}/does-not-exist.json"
+        ;;
+      *)
+        printf '%s\n' "${line}"
+        ;;
+    esac
+  done <"${INSTALL_SH}" >"${isolated_install}"
+  chmod +x "${isolated_install}"
+  mkdir -p "${case_dir}/lib"
+  cp "${PKG_DIR}/lib/installer_lib.sh" "${case_dir}/lib/installer_lib.sh"
+  assert_file_exists "${isolated_install}"
+  assert_file_exists "${case_dir}/lib/installer_lib.sh"
+  [[ ! -e "${case_dir}/does-not-exist.json" ]] \
+    || _fail "isolated implicit config fixture must be absent"
+  #
   # We can't drive install.sh far enough to complete a real install
   # in this harness (it eventually needs root, a real binary, and
   # launchctl). What we CAN prove is that the resolver branch no
@@ -231,9 +257,11 @@ t_install_default_missing_config_file_falls_back_to_default() {
   # Grep for the warn substring plus the default endpoint URL; the
   # non-zero exit code comes from a downstream stage, not this branch.
   local out rc=0
-  out="$("${INSTALL_SH}" 2>&1)" || rc=$?
+  out="$("${isolated_install}" 2>&1)" || rc=$?
   assert_contains "${out}" "env_config.json not found at" \
     "installer names the missing env_config.json in the warn line"
+  assert_contains "${out}" "${case_dir}/does-not-exist.json" \
+    "installer uses the isolated implicit config path"
   assert_contains "${out}" "https://us.api.inspect.aidefense.security.cisco.com" \
     "installer falls through to the US-prod default endpoint"
   assert_contains "${out}" "Installing with default endpoint" \


### PR DESCRIPTION
## Summary

Fixes #615.

This keeps the PR #605 fallback for the implicit AVC-authored default `env_config.json` path, but restores fail-closed behavior when an operator explicitly supplies `--config-file PATH` and that path is missing or malformed. That prevents fleet override typos or stale override files from silently routing managed_enterprise traffic to the hardcoded US-prod default endpoint.

## What changes

| Path | Change |
|---|---|
| `packaging/macos/install.sh` | Track whether `--config-file` was explicitly supplied; fail closed on rc-1/rc-2 for explicit paths; document the distinction in `--help` |
| `packaging/macos/tests/test_arg_parsing.sh` | Preserve the implicit default missing-file fallback test and add explicit missing/malformed rejection coverage |

## Test plan

- [x] `bash packaging/macos/tests/run_tests.sh` — 137 passed, 0 failed in 13s
- [x] `git diff --check` — no output

## CI status

Pending GitHub Actions on this PR.

## Reviewer notes

- Base branch: `release-defenseclaw-enterprise-26.7.3`
- Scope is intentionally limited to the managed macOS installer endpoint-resolution contract.
- The implicit default path still falls back for AVC packaging sequencing; only explicit operator/fleet config paths fail closed.