### PR TITLE
fix(ci): classify radar startup auth failures

### DIFF
--- a/cli/tests/test_live_connector_upgrade_harness.py
+++ b/cli/tests/test_live_connector_upgrade_harness.py
@@ -114,6 +114,47 @@ def test_block_probe_forbids_model_retries() -> None:
     assert "Do not retry, rewrite, encode, split, or run an alternative command." in text
 
 
+def test_gateway_start_auth_failure_is_classified_as_credentials(tmp_path: Path) -> None:
+    auth_log = tmp_path / "auth.log"
+    infrastructure_log = tmp_path / "infrastructure.log"
+    auth_log.write_text(
+        "Your access token could not be refreshed because your refresh token was already used. "
+        "Please log out and sign in again.\n",
+        encoding="utf-8",
+    )
+    infrastructure_log.write_text(
+        "listen tcp 127.0.0.1:12345: bind: address already in use\n",
+        encoding="utf-8",
+    )
+
+    proc = _bash(
+        """
+        set -euo pipefail
+        . "${DRIVER_COMMON_PATH}"
+        dc_file_looks_like_auth_failure "${AUTH_LOG}"
+        if dc_file_looks_like_auth_failure "${INFRASTRUCTURE_LOG}"; then
+          exit 1
+        fi
+        """,
+        env={
+            "AUTH_LOG": str(auth_log),
+            "DRIVER_COMMON_PATH": str(DRIVER_COMMON),
+            "INFRASTRUCTURE_LOG": str(infrastructure_log),
+        },
+    )
+    assert proc.returncode == 0, proc.stderr
+
+    harness_text = HARNESS.read_text(encoding="utf-8")
+    start = harness_text.index(
+        'baseline_gateway_start_log="${ARTIFACTS_DIR}/gateway/baseline-start.log"'
+    )
+    end = harness_text.index("GATEWAY_STARTED=1")
+    start_block = harness_text[start:end]
+    assert 'dc_file_looks_like_auth_failure "${baseline_gateway_start_log}"' in start_block
+    assert 'CLASSIFICATION="auth_failure"' in start_block
+    assert "HARNESS_EXIT_CODE=3" in start_block
+
+
 def test_harness_captures_quiescent_v8_canonical_evidence() -> None:
     text = HARNESS.read_text(encoding="utf-8")
     assert "for name in gateway.log audit.db judge_bodies.db watchdog.log" in text

--- a/scripts/live-connector-e2e/drivers/_driver_common.sh
+++ b/scripts/live-connector-e2e/drivers/_driver_common.sh
@@ -271,16 +271,24 @@ dc_probe_log_file() {
   printf '%s/dc-agent-%s.log' "${log_dir}" "${probe_id}"
 }
 
+# dc_file_looks_like_auth_failure <path> — conservative diagnostic for a
+# command that already failed. Callers must never use successful command output
+# as an authentication signal because normal model text may mention login.
+dc_file_looks_like_auth_failure() {
+  local log_file="$1"
+  [ -f "${log_file}" ] || return 1
+  grep -Eqi \
+    'not logged in|login required|please (sign|log) in|please log out and sign in again|authentication (failed|required)|unauthorized|forbidden|invalid (api )?key|expired (token|session)|access token could not be refreshed|refresh token.*(already used|expired|invalid|revoked)|(^|[^0-9])(401|403)([^0-9]|$)|oauth|keychain|credential.*(missing|expired|invalid)' \
+    "${log_file}"
+}
+
 # dc_probe_looks_like_auth_failure <label> — conservative diagnostic only.
 # It is consulted only after the agent returned non-zero, so a model response
 # that happens to mention "login" cannot relabel a successful probe.
 dc_probe_looks_like_auth_failure() {
   local log_file
   log_file="$(dc_probe_log_file "$1")"
-  [ -f "${log_file}" ] || return 1
-  grep -Eqi \
-    'not logged in|login required|please (sign|log) in|authentication (failed|required)|unauthorized|forbidden|invalid (api )?key|expired (token|session)|(^|[^0-9])(401|403)([^0-9]|$)|oauth|keychain|credential.*(missing|expired|invalid)' \
-    "${log_file}"
+  dc_file_looks_like_auth_failure "${log_file}"
 }
 
 dc_driver_event() {

--- a/scripts/live-connector-e2e/upgrade-regression.sh
+++ b/scripts/live-connector-e2e/upgrade-regression.sh
@@ -488,9 +488,17 @@ if ! dc_upgrade_setup_without_restart "${BASELINE_BIN}"; then
   exit 4
 fi
 dc_record_result "baseline:setup" pass "mode=${MODE}"
-if ! PATH="$(dirname "${BASELINE_BIN}"):${ORIGINAL_PATH}" defenseclaw-gateway start; then
-  DETAIL="isolated gateway failed to start for the baseline"
-  exit 4
+baseline_gateway_start_log="${ARTIFACTS_DIR}/gateway/baseline-start.log"
+if ! PATH="$(dirname "${BASELINE_BIN}"):${ORIGINAL_PATH}" \
+  defenseclaw-gateway start 2>&1 | tee "${baseline_gateway_start_log}"; then
+  if dc_file_looks_like_auth_failure "${baseline_gateway_start_log}"; then
+    CLASSIFICATION="auth_failure"
+    DETAIL="known-good baseline login prevented isolated gateway startup; refresh the connector login"
+    HARNESS_EXIT_CODE=3
+  else
+    DETAIL="isolated gateway failed to start for the baseline"
+  fi
+  exit "${HARNESS_EXIT_CODE}"
 fi
 GATEWAY_STARTED=1
 if ! PATH="$(dirname "${BASELINE_BIN}"):${ORIGINAL_PATH}" dc_wait_for_gateway 30; then


### PR DESCRIPTION
## Problem

The scheduled Connector Version Radar run classified an explicit Codex login-refresh failure as `infrastructure_failure` when it occurred while the known-good baseline gateway was starting. That obscures the credential/environment remediation and groups a stale runner login with genuine setup, port, or gateway failures.

## Current Situation

Run [30155050049](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/30155050049) failed the Codex baseline before candidate testing. The startup error stated that the access token could not be refreshed because the refresh token had already been used and required a fresh login, but `upgrade-regression.sh` assigned every baseline gateway-start failure exit code 4.

The harness already detects authentication failures conservatively after a failed agent probe and maps them to `auth_failure` / exit code 3. It did not apply that logic to a failed gateway-start command.

## Solution

- Reuse one conservative failed-command auth detector for probe and gateway-start transcripts.
- Capture the failed baseline gateway-start transcript in the existing run-owned artifact directory.
- Map recognized login/refresh failures to `auth_failure` / exit code 3.
- Preserve `infrastructure_failure` / exit code 4 for non-authentication startup failures.

The detector is only consulted after a command fails, so successful model output that happens to discuss login cannot affect classification.

## Architecture Diagram

N/A

## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `scripts/live-connector-e2e/drivers/_driver_common.sh` | Extract the existing conservative auth diagnostic into a failed-file helper and recognize refresh-token renewal failures. |
| `scripts/live-connector-e2e/upgrade-regression.sh` | Capture baseline gateway-start output and classify recognized login failures as credentials instead of infrastructure. |
| `cli/tests/test_live_connector_upgrade_harness.py` | Cover the observed refresh-token message, a non-auth bind failure control, and the startup classification contract. |

## Breaking Changes

None

## Open Issues / Follow-ups

None

## Test Plan

- `uv run pytest cli/tests/test_live_connector_upgrade_harness.py cli/tests/test_connector_version_radar.py cli/tests/test_connector_live_e2e_path_policy.py -q` — 82 passed in 0.78s.
- `uv run ruff check cli/tests/test_live_connector_upgrade_harness.py` — passed.
- `bash -n scripts/live-connector-e2e/drivers/_driver_common.sh scripts/live-connector-e2e/upgrade-regression.sh` — passed.
- `actionlint -ignore 'label ".*" is unknown' .github/workflows/connector-version-radar.yml` — passed; the ignored diagnostics are the repository's existing custom self-hosted runner labels.
- `shellcheck --shell=bash -e SC1091,SC2034,SC2329 scripts/live-connector-e2e/drivers/_driver_common.sh scripts/live-connector-e2e/upgrade-regression.sh` — passed; exclusions cover established sourced-file and cross-file callback diagnostics.
- `git diff --check` — passed.
