### PR TITLE
fix(release): preserve Windows repair custody

### DIFF
--- a/cli/tests/test_release_channel_repair.py
+++ b/cli/tests/test_release_channel_repair.py
@@ -347,6 +347,75 @@ def test_read_regular_uses_binary_mode_when_platform_exposes_it(
     assert opened_flags and opened_flags[0] & synthetic_binary
 
 
+def test_windows_named_and_opened_timestamp_views_do_not_false_positive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proof = tmp_path / "proof"
+    payload = b"authenticated proof\n"
+    proof.write_bytes(payload)
+    real_lstat = Path.lstat
+    lstat_calls: list[Path] = []
+
+    def timestamp_skewed_lstat(candidate: Path):
+        lstat_calls.append(candidate)
+        info = real_lstat(candidate)
+
+        class _TimestampSkewedStat:
+            st_ctime_ns = info.st_ctime_ns + 1
+
+            def __getattr__(self, name: str):
+                return getattr(info, name)
+
+        return _TimestampSkewedStat()
+
+    monkeypatch.setattr(MODULE.os, "O_NOFOLLOW", 0, raising=False)
+    monkeypatch.setattr(Path, "lstat", timestamp_skewed_lstat)
+    expected_state = MODULE._file_state(proof.lstat())
+
+    assert (
+        MODULE._read_regular(
+            proof,
+            label="proof",
+            maximum=1024,
+            expected_identity=expected_state,
+        )
+        == payload
+    )
+    assert lstat_calls == [proof, proof, proof]
+
+
+def test_read_regular_retains_descriptor_ctime_mutation_detection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proof = tmp_path / "proof"
+    proof.write_bytes(b"authenticated proof\n")
+    real_fstat = MODULE.os.fstat
+    fstat_calls = 0
+
+    def ctime_changed_after_read(descriptor: int):
+        nonlocal fstat_calls
+        fstat_calls += 1
+        info = real_fstat(descriptor)
+        if fstat_calls == 1:
+            return info
+
+        class _CtimeChangedStat:
+            st_ctime_ns = info.st_ctime_ns + 1
+
+            def __getattr__(self, name: str):
+                return getattr(info, name)
+
+        return _CtimeChangedStat()
+
+    monkeypatch.setattr(MODULE.os, "fstat", ctime_changed_after_read)
+
+    with pytest.raises(RepairTargetError, match="changed while it was read"):
+        MODULE._read_regular(proof, label="proof", maximum=1024)
+    assert fstat_calls == 2
+
+
 @pytest.mark.skipif(os.name == "nt", reason="atomic replacement of an open file is POSIX-specific")
 def test_repair_rejects_proof_swapped_after_directory_snapshot(
     tmp_path: Path,

--- a/scripts/verify-release-channel-target.py
+++ b/scripts/verify-release-channel-target.py
@@ -89,19 +89,21 @@ def _is_link_or_reparse(value: stat_result) -> bool:
     return stat.S_ISLNK(value.st_mode) or bool(reparse_flag and file_attributes & reparse_flag)
 
 
-def _path_identity(value: stat_result) -> tuple[int, int, int, int, int, int]:
+def _file_identity(value: stat_result) -> tuple[int, int, int, int, int]:
     return (
         value.st_dev,
         value.st_ino,
         stat.S_IFMT(value.st_mode),
         value.st_size,
         value.st_mtime_ns,
-        value.st_ctime_ns,
     )
 
 
-_file_identity = _path_identity
-_directory_identity = _path_identity
+def _file_state(value: stat_result) -> tuple[int, int, int, int, int, int]:
+    return (*_file_identity(value), value.st_ctime_ns)
+
+
+_directory_identity = _file_state
 
 
 def _read_regular(
@@ -136,12 +138,20 @@ def _read_regular(
     try:
         before = os.fstat(descriptor)
         before_identity = _file_identity(before)
+        before_state = _file_state(before)
         if _is_link_or_reparse(before) or not stat.S_ISREG(before.st_mode):
             raise RepairTargetError(f"{label} must be a regular nonsymlink file")
-        if expected_identity is not None and before_identity != expected_identity:
-            raise RepairTargetError(f"{label} changed before it was read")
-        if named_before is not None and before_identity != _file_identity(named_before):
-            raise RepairTargetError(f"{label} changed while it was opened")
+        if expected_identity is not None:
+            observed_state = _file_state(named_before) if named_before is not None else before_state
+            if observed_state != expected_identity:
+                raise RepairTargetError(f"{label} changed before it was read")
+        if named_before is not None:
+            # CPython on Windows exposes creation time as pathname st_ctime,
+            # but NTFS change time as descriptor st_ctime. Bind the pathname
+            # to the descriptor without comparing those incompatible fields,
+            # then retain ctime in each same-API mutation check.
+            if before_identity != _file_identity(named_before):
+                raise RepairTargetError(f"{label} changed while it was opened")
         if not 0 < before.st_size <= maximum:
             raise RepairTargetError(f"{label} has invalid size: {before.st_size}")
 
@@ -158,14 +168,19 @@ def _read_regular(
 
     if len(payload) > maximum:
         raise RepairTargetError(f"{label} has invalid size: greater than {maximum}")
-    if len(payload) != before.st_size or before_identity != _file_identity(after):
+    if len(payload) != before.st_size or before_state != _file_state(after):
         raise RepairTargetError(f"{label} changed while it was read")
     if named_before is not None:
         try:
             named_after = path.lstat()
         except OSError as exc:
             raise RepairTargetError(f"could not re-inspect {label}: {exc}") from exc
-        if _is_link_or_reparse(named_after) or _file_identity(named_after) != before_identity:
+        if (
+            _is_link_or_reparse(named_after)
+            or not stat.S_ISREG(named_after.st_mode)
+            or _file_state(named_before) != _file_state(named_after)
+            or _file_identity(named_after) != _file_identity(after)
+        ):
             raise RepairTargetError(f"{label} changed while it was read")
     return bytes(payload)
 
@@ -193,7 +208,7 @@ def _download_snapshot(
     for entry, metadata in entry_rows:
         if entry.name in snapshot or _is_link_or_reparse(metadata) or not stat.S_ISREG(metadata.st_mode):
             raise RepairTargetError("repair custody directory does not contain the exact bounded proof set")
-        snapshot[entry.name] = (entry, _file_identity(metadata))
+        snapshot[entry.name] = (entry, _file_state(metadata))
     if set(snapshot) != DOWNLOADED_ASSET_NAMES:
         raise RepairTargetError("repair custody directory does not contain the exact bounded proof set")
     return snapshot, directory_identity


### PR DESCRIPTION
Base note: this is a fresh follow-up to merged #611 and contains only the Windows custody compatibility fix exposed by its native Windows matrix.

## Problem

The signed release-channel repair verifier used one identity tuple for both pathname metadata and opened-descriptor metadata. On CPython 3.12 for Windows, `Path.lstat().st_ctime_ns` is the file creation time while `os.fstat().st_ctime_ns` is the NTFS change time. Unchanged proof files therefore appeared to mutate, producing eight deterministic failures in [Windows Python shard 4](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/30307880741/job/90116962765).

## Current Situation

Merged #611 provides the signed stable-channel repair path. Its custody verifier is fail-closed, but the cross-API timestamp comparison is not portable to Windows. The verifier can reject valid, unchanged release proofs before their signed digests and provenance are evaluated.

## Solution

### Separate binding identity from mutation state

- Pathname-to-descriptor binding compares stable object/content fields: device, inode, file type, size, and modification time.
- Same-API before/after checks retain `ctime_ns`, so in-read and pathname mutation detection remains fail-closed.
- Existing bounded reads, exact directory snapshots, regular-file checks, `O_NOFOLLOW`, and Windows reparse-point rejection remain intact.

```mermaid
flowchart LR
    S["Directory snapshot"] -->|"same-view state + ctime"| N1["Path before open"]
    N1 -->|"cross-view stable identity"| F1["Opened descriptor"]
    F1 -->|"descriptor state + ctime"| F2["Descriptor after read"]
    N1 -->|"pathname state + ctime"| N2["Path after read"]
    F2 -->|"cross-view stable identity"| N2
```

### Add portable regressions

The tests synthesize the Windows creation-time/change-time split on every platform and prove both sides of the contract: unchanged files are accepted across API views, while a descriptor `ctime_ns` mutation during reading is still rejected.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `scripts/verify-release-channel-target.py` | Split cross-view file identity from same-view mutation state and apply each comparison in the correct domain. |
| `cli/tests/test_release_channel_repair.py` | Add deterministic Windows timestamp-view and retained mutation-detection regressions. |

## Breaking Changes

None. Release assets, channel schema, workflow inputs, signatures, installer behavior, and operator workflow are unchanged.

## Open Issues / Follow-ups

None.

## Test Plan

- `PYTHONPATH="$(pwd -P)" uv run --isolated --python 3.12 --frozen pytest cli/tests/test_release_channel_repair.py -q`
  - Observed: `24 passed`.
- `PYTHONPATH="$(pwd -P)" uv run --isolated --python 3.12 --frozen pytest cli/tests/test_historical_release_auth.py -q`
  - Observed: `9 passed`.
- `uv run --frozen ruff check scripts/verify-release-channel-target.py cli/tests/test_release_channel_repair.py`
  - Observed: all checks passed.
- `uv run --frozen ruff format --check scripts/verify-release-channel-target.py cli/tests/test_release_channel_repair.py`
  - Observed: both files already formatted.
- `git diff --check`
  - Observed: passed.