### PR TITLE
fix(release): repair 0.8.6 field-recovery validation

### DIFF
--- a/cli/tests/test_cmd_misc.py
+++ b/cli/tests/test_cmd_misc.py
@@ -956,6 +956,9 @@ class TestSetupMCPScannerCommonConfig(unittest.TestCase):
 
 class TestSetupSplunkCommand(unittest.TestCase):
     def setUp(self):
+        self._environment = patch.dict(os.environ, {}, clear=False)
+        self._environment.start()
+        self.addCleanup(self._environment.stop)
         self.app, self.tmp_dir, self.db_path = make_app_context()
         self.runner = CliRunner()
         self._native_local_splunk = patch(

--- a/cli/tests/test_upgrade_release_smoke_contract.py
+++ b/cli/tests/test_upgrade_release_smoke_contract.py
@@ -1873,6 +1873,189 @@ def test_field_recovery_lane_reproduces_exact_clean_086_not_partial_cursor() -> 
     assert "Replayed every missing migration and repaired the cursor" not in protocol
     assert "local SMOKE_HOME=" not in recovery_function
     assert 'SMOKE_HOME="${WORKDIR}/field-recovery-${baseline}-${recovery_case}"' in recovery_function
+    assert 'stack = data_dir / "observability-stack"' in recovery_function
+    assert "if stack.is_symlink() or (stack.exists() and not stack.is_dir()):" in recovery_function
+    assert "if stack.exists():" in recovery_function
+    assert "field recovery left an unversioned local observability bundle" in recovery_function
+    assert "verify_upgrade recovered" in recovery_function
+
+    smoke = SCRIPT.read_text(encoding="utf-8")
+    verify_start = smoke.index("verify_upgrade() {")
+    verify_end = smoke.index("\n}\n\nrun_one_upgrade_smoke()", verify_start)
+    verification = smoke[verify_start:verify_end]
+    assert 'local audit_expectation="${1:-preserved}"' in verification
+    assert "preserved|recovered" in verification
+    assert "corrupt audit recovery retained the discarded legacy fixture" in verification
+    assert "corrupt_audit_recovery=fresh_mode_0600" in verification
+
+
+@pytest.mark.skipif(os.name == "nt", reason="executes the POSIX release harness")
+def test_field_recovery_serves_only_authenticated_086_source_contract(
+    tmp_path: Path,
+) -> None:
+    version = "0.8.6"
+    os_name = "linux"
+    arch = "amd64"
+    wheel = f"defenseclaw-{version}-2-py3-none-any.dcwheel"
+    gateway = f"defenseclaw_{version}_protocol2_{os_name}_{arch}.dcgateway"
+    authenticated_payloads = {
+        wheel: b"protected source wheel\n",
+        gateway: b"protected source gateway\n",
+        "upgrade-manifest.json": b'{"release_version":"0.8.6"}\n',
+        "release-provenance.json": b'{"release_version":"0.8.6"}\n',
+    }
+    published = tmp_path / "published"
+    published.mkdir()
+    for name, payload in authenticated_payloads.items():
+        (published / name).write_bytes(payload)
+    (published / "checksums.txt").write_text(
+        "".join(f"{hashlib.sha256(payload).hexdigest()}  {name}\n" for name, payload in authenticated_payloads.items()),
+        encoding="utf-8",
+    )
+    (published / "checksums.txt.sig").write_text("fixture signature\n", encoding="utf-8")
+    (published / "checksums.txt.pem").write_text(
+        "-----BEGIN CERTIFICATE-----\nZmFrZS1jZXJ0aWZpY2F0ZQ==\n-----END CERTIFICATE-----\n",
+        encoding="utf-8",
+    )
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    cosign = fake_bin / "cosign"
+    cosign.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    cosign.chmod(0o700)
+    workdir = tmp_path / "work"
+    release_root = workdir / "release-root"
+    workdir.mkdir()
+    release_root.mkdir()
+
+    completed = _source_script(
+        """
+trap - EXIT
+WORKDIR="$2"
+RELEASE_ROOT="$3"
+TARGET_VERSION=0.8.8
+OS_NAME=linux
+ARCH_NAME=amd64
+UPGRADE_SMOKE_FIELD_RECOVERY_CASES=1
+fixture="$4"
+download_old_asset() {
+    local name="$1"
+    local destination="$2"
+    local version="$3"
+    [[ "${version}" == "0.8.6" ]] || return 1
+    cp "${fixture}/${name}" "${destination}"
+}
+PATH="$5:${PATH}"
+prepare_field_recovery_source_assets
+""",
+        str(workdir),
+        str(release_root),
+        str(published),
+        str(fake_bin),
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    served = release_root / version
+    assert {path.name for path in served.iterdir()} == {
+        *authenticated_payloads,
+        "checksums.txt",
+        "checksums.txt.sig",
+        "checksums.txt.pem",
+    }
+    for name, payload in authenticated_payloads.items():
+        assert (served / name).read_bytes() == payload
+
+
+def test_field_recovery_source_authentication_precedes_local_server_start() -> None:
+    protocol = PROTOCOL_SCRIPT.read_text(encoding="utf-8")
+    main = protocol[protocol.index("main_protocol_gate() {") :]
+
+    bridge = main.index("prepare_required_bridge_assets")
+    source = main.index("prepare_field_recovery_source_assets")
+    server = main.index("start_release_server")
+
+    assert bridge < source < server
+
+
+@pytest.mark.skipif(os.name == "nt", reason="executes the POSIX field-recovery verifier")
+@pytest.mark.parametrize(
+    ("stack_state", "expected_success"),
+    (
+        ("absent", True),
+        ("target-version", True),
+        ("dangling-symlink", False),
+        ("unversioned", False),
+        ("wrong-version", False),
+    ),
+)
+def test_field_recovery_verifier_accepts_absent_optional_bundle_but_rejects_unsafe_state(
+    tmp_path: Path,
+    stack_state: str,
+    expected_success: bool,
+) -> None:
+    protocol = PROTOCOL_SCRIPT.read_text(encoding="utf-8")
+    failure = '|| die "clean 0.8.6 field-recovery verification failed"'
+    failure_offset = protocol.index(failure)
+    body = protocol.index("\n", failure_offset) + 1
+    end = protocol.index("\nPY\n", body)
+    verifier = protocol[body:end] + "\n"
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    manifest = tmp_path / "upgrade-manifest.json"
+    manifest.write_text(
+        json.dumps({"required_cli_migrations": ["0.8.5"]}),
+        encoding="utf-8",
+    )
+    (data_dir / ".migration_state.json").write_text(
+        json.dumps({"applied": ["0.8.5"]}),
+        encoding="utf-8",
+    )
+    source_config = b"config_version: 8\n"
+    source_environment = b"DEFENSECLAW_GATEWAY_TOKEN=fixture\n"
+    backup = data_dir / "backups/upgrade-fixture"
+    backup.mkdir(parents=True)
+    (backup / "config.yaml").write_bytes(source_config)
+    (backup / ".env").write_bytes(source_environment)
+
+    stack = data_dir / "observability-stack"
+    if stack_state == "target-version":
+        stack.mkdir()
+        (stack / ".defenseclaw-bundle-manifest.json").write_text(
+            json.dumps({"bundle_version": "0.8.8"}),
+            encoding="utf-8",
+        )
+    elif stack_state == "dangling-symlink":
+        stack.symlink_to(data_dir / "missing-stack")
+    elif stack_state == "unversioned":
+        stack.mkdir()
+    elif stack_state == "wrong-version":
+        stack.mkdir()
+        (stack / ".defenseclaw-bundle-manifest.json").write_text(
+            json.dumps({"bundle_version": "0.8.7"}),
+            encoding="utf-8",
+        )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-B",
+            "-",
+            str(data_dir),
+            str(manifest),
+            hashlib.sha256(source_config).hexdigest(),
+            hashlib.sha256(source_environment).hexdigest(),
+            "0.8.8",
+        ],
+        input=verifier,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert (completed.returncode == 0) is expected_success, completed.stderr
 
 
 def test_local_candidate_checksums_exclude_all_signature_family_outputs() -> None:

--- a/scripts/test-upgrade-protocol-release.sh
+++ b/scripts/test-upgrade-protocol-release.sh
@@ -950,13 +950,16 @@ if not any(
 ):
     raise SystemExit("field recovery retained no byte-exact clean 0.8.6 backup")
 
-bundle_manifest = json.loads(
-    (data_dir / "observability-stack/.defenseclaw-bundle-manifest.json").read_text(
-        encoding="utf-8"
-    )
-)
-if bundle_manifest.get("bundle_version") != target_version:
-    raise SystemExit("field recovery did not refresh the managed bundle to target")
+stack = data_dir / "observability-stack"
+if stack.is_symlink() or (stack.exists() and not stack.is_dir()):
+    raise SystemExit("field recovery left an unsafe local observability bundle")
+if stack.exists():
+    manifest_path = stack / ".defenseclaw-bundle-manifest.json"
+    if manifest_path.is_symlink() or not manifest_path.is_file():
+        raise SystemExit("field recovery left an unversioned local observability bundle")
+    bundle_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if bundle_manifest.get("bundle_version") != target_version:
+        raise SystemExit("field recovery did not refresh the managed bundle to target")
 
 database = data_dir / "audit.db"
 if database.exists():
@@ -980,7 +983,7 @@ PY
                 || die "field-recovery target gateway is not healthy"
             ;;
         corrupt-audit-same-version)
-            verify_upgrade
+            verify_upgrade recovered
             grep -Fq "Preserved corrupt audit SQLite set:" "${log_file}" \
                 || die "field recovery did not report corrupt audit custody"
             python3 - "${SMOKE_HOME}/.defenseclaw" "${audit_db}" <<'PY' \
@@ -1263,6 +1266,7 @@ main_protocol_gate() {
         assert_reviewed_resolver_asset_contract
     else
         prepare_required_bridge_assets
+        prepare_field_recovery_source_assets
     fi
     start_release_server
     if [[ "${REFUSAL_CONTRACT_ONLY}" != "1" ]]; then

--- a/scripts/test-upgrade-release.sh
+++ b/scripts/test-upgrade-release.sh
@@ -970,6 +970,19 @@ prepare_required_bridge_assets() {
     fi
 }
 
+prepare_field_recovery_source_assets() {
+    [[ "${UPGRADE_SMOKE_FIELD_RECOVERY_CASES:-0}" == "1" ]] || return 0
+
+    # The clean missing-cursor resolver re-authenticates the exact published
+    # 0.8.6 source contract before it accepts that compatibility state. The
+    # smoke curl shim points versioned GitHub release URLs at RELEASE_ROOT, so
+    # stage this bounded source view before the local server starts. Reuse the
+    # same helper as bridge staging: it authenticates the checksum proof first,
+    # then every served wheel, gateway, manifest, and provenance payload.
+    prepare_authenticated_upgrade_release_assets \
+        "0.8.6" "field-recovery source" 1
+}
+
 tail_log() {
     local file="$1"
     if [[ -f "${file}" ]]; then
@@ -1994,6 +2007,11 @@ verify_upgrade() {
     local venv_python="${SMOKE_HOME}/.defenseclaw/.venv/bin/python"
     local release_dir="${RELEASE_ROOT}/${TARGET_VERSION}"
     local require_v8=0
+    local audit_expectation="${1:-preserved}"
+    case "${audit_expectation}" in
+        preserved|recovered) ;;
+        *) die "invalid upgrade audit verification mode: ${audit_expectation}" ;;
+    esac
     if target_uses_observability_v8; then
         require_v8=1
     fi
@@ -2681,13 +2699,15 @@ print("local_bundle_manifest=target_exact_custom_preserved")
 PY
         fi
 
-        "${venv_python}" -I -B - "${SMOKE_HOME}/.defenseclaw" <<'PY'
+        "${venv_python}" -I -B - \
+            "${SMOKE_HOME}/.defenseclaw" "${audit_expectation}" <<'PY'
 from pathlib import Path
 import sqlite3
 import stat
 import sys
 
 database = Path(sys.argv[1]) / "state/audit-custom.db"
+expectation = sys.argv[2]
 info = database.lstat()
 if (
     database.is_symlink()
@@ -2696,12 +2716,29 @@ if (
 ):
     raise SystemExit("legacy-readable audit fixture was not tightened to mode 0600")
 with sqlite3.connect(f"file:{database}?mode=ro", uri=True, timeout=1.0) as connection:
-    row = connection.execute(
-        "SELECT value FROM release_upgrade_legacy_mode_fixture"
+    if connection.execute("PRAGMA quick_check").fetchone() != ("ok",):
+        raise SystemExit("target audit fixture failed quick_check")
+    table = connection.execute(
+        "SELECT 1 FROM sqlite_master "
+        "WHERE type = 'table' AND name = 'release_upgrade_legacy_mode_fixture'"
     ).fetchone()
-if row != ("preserved",):
-    raise SystemExit("legacy-readable audit fixture did not survive the upgrade")
-print("legacy_audit_mode_0644=tightened_to_0600")
+    if expectation == "preserved":
+        if table != (1,):
+            raise SystemExit("legacy-readable audit fixture table did not survive the upgrade")
+        row = connection.execute(
+            "SELECT value FROM release_upgrade_legacy_mode_fixture"
+        ).fetchone()
+        if row != ("preserved",):
+            raise SystemExit("legacy-readable audit fixture did not survive the upgrade")
+    elif expectation == "recovered":
+        if table is not None:
+            raise SystemExit("corrupt audit recovery retained the discarded legacy fixture")
+    else:
+        raise SystemExit("invalid audit verification expectation")
+if expectation == "preserved":
+    print("legacy_audit_mode_0644=tightened_to_0600")
+else:
+    print("corrupt_audit_recovery=fresh_mode_0600")
 PY
 
         local receipt_from


### PR DESCRIPTION
Base: `main`. This unblocks rerunning the unpublished `0.8.8` release after Actions run `30318217193` failed only in its 0.8.6 field-recovery fixture.

## Problem

The release candidate itself passed platform builds, all three fresh installs, and every ordinary Linux/macOS upgrade lane. The special clean `0.8.6` missing-cursor recovery then failed before mutation because its target-owned resolver requested the authenticated `0.8.6` contract through the local test server, but the harness had staged those source files in a private directory outside the server root.

The merged-main Python shard also exposed a separate deterministic test-isolation leak: the Splunk setup test intentionally loads `OTEL_SERVICE_NAME` into the process environment and did not restore it, causing a later historical-upgrade fixture to be misclassified.

## Current Situation

- Release run `30318217193`: 20 jobs passed; only the Linux and macOS `0.8.6` field-recovery jobs failed at the same missing local `checksums.txt` boundary.
- Both ordinary `0.8.6 → 0.8.8` upgrades passed before that special subcase.
- No `0.8.8` tag, GitHub release, or stable channel was published; the version is safe to reuse.
- Main CI's Python shard failure reproduces only when the leaking Splunk test precedes the rollback fixture.

## Solution

### Serve only authenticated 0.8.6 source bytes

Before starting the local release server, the field-recovery lane now reuses the existing historical-release authenticator to stage exactly the `0.8.6` checksum proof, wheel, platform gateway, manifest, and provenance under the server root.

```mermaid
flowchart LR
    A["Immutable 0.8.6 release"] --> B["Sigstore + signed checksums authentication"]
    B --> C["Bounded RELEASE_ROOT/0.8.6 view"]
    C --> D["Local release server"]
    D --> E["0.8.8 resolver re-authenticates installed source"]
    E --> F["Missing-cursor recovery"]
```

No production resolver or trust check is relaxed.

### Make recovery verification match intentional state

The exact replay exposed two stale verifier assumptions after the original 404 was fixed:

- A clean `0.8.6` first-run state may legitimately have no optional local observability bundle. Absence is accepted; unsafe, unversioned, or wrong-version bundle state still fails.
- Corrupt-audit recovery intentionally creates a fresh healthy database. The verifier now requires the discarded synthetic legacy table to be absent while retaining mode `0600`, `quick_check`, corrupt-file custody, receipt, version, and gateway-health checks.

### Isolate intentional environment mutation

`TestSetupSplunkCommand` now snapshots and restores `os.environ` around every test, preserving production's same-process dotenv behavior without contaminating later tests.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `scripts/test-upgrade-release.sh` | Authenticates/stages the 0.8.6 field-recovery source contract and adds explicit preserved-vs-recovered audit verification. |
| `scripts/test-upgrade-protocol-release.sh` | Stages recovery assets before server startup and uses recovery-aware bundle/audit assertions. |
| `cli/tests/test_upgrade_release_smoke_contract.py` | Adds executable custody, ordering, optional-bundle, and recovery contracts. |
| `cli/tests/test_cmd_misc.py` | Restores environment state after Splunk setup tests. |

## Breaking Changes

None. Release inputs, published artifacts, updater behavior, signatures, and client trust boundaries are unchanged.

## Open Issues / Follow-ups

None.

## Test Plan

Observed results:

- `pytest` combined release/field-recovery suites: **293 passed, 1 skipped**.
- Exact Linux CI Python shard 0 after environment isolation: **1,927 passed, 32 skipped, 308 subtests, 0 failed**.
- Causal Splunk leak + rollback pair: **2 passed**.
- Splunk class + rollback target: **33 passed**.
- `bash -n` and ShellCheck (excluding pre-existing SC2034): passed.
- Ruff check and focused format check: passed.
- Exact failed-run candidate replay on connected macOS arm64:
  - ordinary `0.8.6 → 0.8.8`: passed;
  - clean missing-cursor recovery: passed;
  - corrupt-audit same-version rescue: passed;
  - exact CLI/gateway versions, receipts, SQLite integrity/mode, custody, and gateway health: passed.
- The same exact replay on connected Ubuntu Linux arm64: all checks passed.
