### PR TITLE
fix(windows): tolerate watchdog PID publication race

### DIFF
--- a/cmd/defenseclaw-setup/managed_process_windows_test.go
+++ b/cmd/defenseclaw-setup/managed_process_windows_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestReadManagedPIDRecordTreatsMissingPathAsAbsent(t *testing.T) {
 	pidPath := filepath.Join(t.TempDir(), "watchdog.pid")
-	state, exists, err := readManagedPIDRecord(pidPath)
+	state, exists, err := readManagedPIDRecord(pidPath, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +38,7 @@ func TestReadManagedPIDRecordReturnsDecodedState(t *testing.T) {
 	}
 	writeManagedPIDRecordTestFixture(t, pidPath, want)
 
-	got, exists, err := readManagedPIDRecord(pidPath)
+	got, exists, err := readManagedPIDRecord(pidPath, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestReadManagedPIDRecordWaitsForInPlacePublication(t *testing.T) {
 	}
 	resultCh := make(chan result, 1)
 	go func() {
-		state, exists, err := readManagedPIDRecordWithRetry(pidPath, 2, func() {
+		state, exists, err := readManagedPIDRecordWithPolicy(pidPath, true, 2, func() {
 			close(retryStarted)
 			<-publicationComplete
 		})
@@ -113,7 +113,7 @@ func TestReadManagedPIDRecordRejectsPersistentMalformedRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 	retries := 0
-	_, exists, err := readManagedPIDRecordWithRetry(pidPath, 3, func() {
+	_, exists, err := readManagedPIDRecordWithPolicy(pidPath, true, 3, func() {
 		retries++
 	})
 	if exists {
@@ -133,7 +133,7 @@ func TestReadManagedPIDRecordDoesNotRetrySemanticCorruption(t *testing.T) {
 		t.Fatal(err)
 	}
 	retries := 0
-	_, exists, err := readManagedPIDRecordWithRetry(pidPath, 3, func() {
+	_, exists, err := readManagedPIDRecordWithPolicy(pidPath, true, 3, func() {
 		retries++
 	})
 	if exists {
@@ -145,6 +145,36 @@ func TestReadManagedPIDRecordDoesNotRetrySemanticCorruption(t *testing.T) {
 	}
 	if retries != 0 {
 		t.Fatalf("semantic corruption retries = %d, want 0", retries)
+	}
+}
+
+func TestReadManagedGatewayPIDRecordDoesNotRetrySyntaxError(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "gateway.pid")
+	if err := os.WriteFile(pidPath, []byte(`{"pid":`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	retries := 0
+	_, exists, err := readManagedPIDRecordWithPolicy(pidPath, false, 3, func() {
+		retries++
+	})
+	if exists {
+		t.Fatal("malformed gateway PID record was reported as usable")
+	}
+	if err == nil || !strings.Contains(err.Error(), "unexpected end of JSON input") {
+		t.Fatalf("gateway syntax error = %v", err)
+	}
+	if retries != 0 {
+		t.Fatalf("gateway syntax retries = %d, want 0", retries)
+	}
+}
+
+func TestManagedPIDRecordPublicationDoesNotRetryCloseFailure(t *testing.T) {
+	syntaxErr := &json.SyntaxError{Offset: 1}
+	if managedPIDRecordPublicationInFlight(syntaxErr, errors.New("close failed")) {
+		t.Fatal("JSON syntax error joined with close failure was treated as retryable")
+	}
+	if !managedPIDRecordPublicationInFlight(syntaxErr, nil) {
+		t.Fatal("isolated JSON syntax error was not treated as retryable")
 	}
 }
 
@@ -260,7 +290,7 @@ func TestReadManagedPIDRecordRejectsOversizeRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, exists, err := readManagedPIDRecord(pidPath)
+	_, exists, err := readManagedPIDRecord(pidPath, false)
 	if exists {
 		t.Fatal("oversize PID record was reported as usable")
 	}

--- a/cmd/defenseclaw-setup/managed_process_windows_test.go
+++ b/cmd/defenseclaw-setup/managed_process_windows_test.go
@@ -75,7 +75,7 @@ func TestReadManagedPIDRecordWaitsForInPlacePublication(t *testing.T) {
 
 	select {
 	case <-retryStarted:
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("reader did not observe the truncated in-flight publication")
 	}
 	data, err := json.Marshal(want)
@@ -102,7 +102,7 @@ func TestReadManagedPIDRecordWaitsForInPlacePublication(t *testing.T) {
 				want,
 			)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("reader did not finish after publication completed")
 	}
 }

--- a/cmd/defenseclaw-setup/managed_process_windows_test.go
+++ b/cmd/defenseclaw-setup/managed_process_windows_test.go
@@ -7,11 +7,13 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/sys/windows"
 )
@@ -42,6 +44,107 @@ func TestReadManagedPIDRecordReturnsDecodedState(t *testing.T) {
 	}
 	if !exists || got != want {
 		t.Fatalf("valid PID record returned state=%+v exists=%t; want state=%+v exists=true", got, exists, want)
+	}
+}
+
+func TestReadManagedPIDRecordWaitsForInPlacePublication(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "watchdog.pid")
+	if err := os.WriteFile(pidPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	want := pidState{
+		PID:           4242,
+		Executable:    `C:\DefenseClaw\gateway.exe`,
+		StartIdentity: "start-identity",
+	}
+	retryStarted := make(chan struct{})
+	publicationComplete := make(chan struct{})
+	type result struct {
+		state  pidState
+		exists bool
+		err    error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		state, exists, err := readManagedPIDRecordWithRetry(pidPath, 2, func() {
+			close(retryStarted)
+			<-publicationComplete
+		})
+		resultCh <- result{state: state, exists: exists, err: err}
+	}()
+
+	select {
+	case <-retryStarted:
+	case <-time.After(time.Second):
+		t.Fatal("reader did not observe the truncated in-flight publication")
+	}
+	data, err := json.Marshal(want)
+	if err != nil {
+		close(publicationComplete)
+		t.Fatal(err)
+	}
+	err = os.WriteFile(pidPath, data, 0o600)
+	close(publicationComplete)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case got := <-resultCh:
+		if got.err != nil {
+			t.Fatal(got.err)
+		}
+		if !got.exists || got.state != want {
+			t.Fatalf(
+				"published PID record returned state=%+v exists=%t; want state=%+v exists=true",
+				got.state,
+				got.exists,
+				want,
+			)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("reader did not finish after publication completed")
+	}
+}
+
+func TestReadManagedPIDRecordRejectsPersistentMalformedRecord(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "watchdog.pid")
+	if err := os.WriteFile(pidPath, []byte(`{"pid":`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	retries := 0
+	_, exists, err := readManagedPIDRecordWithRetry(pidPath, 3, func() {
+		retries++
+	})
+	if exists {
+		t.Fatal("malformed PID record was reported as usable")
+	}
+	if err == nil || !strings.Contains(err.Error(), "unexpected end of JSON input") {
+		t.Fatalf("persistent malformed PID record error = %v", err)
+	}
+	if retries != 2 {
+		t.Fatalf("publication retries = %d, want 2", retries)
+	}
+}
+
+func TestReadManagedPIDRecordDoesNotRetrySemanticCorruption(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "watchdog.pid")
+	if err := os.WriteFile(pidPath, []byte(`{"pid":"bad"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	retries := 0
+	_, exists, err := readManagedPIDRecordWithRetry(pidPath, 3, func() {
+		retries++
+	})
+	if exists {
+		t.Fatal("semantically invalid PID record was reported as usable")
+	}
+	var typeErr *json.UnmarshalTypeError
+	if !errors.As(err, &typeErr) {
+		t.Fatalf("semantic corruption error = %T %v, want *json.UnmarshalTypeError", err, err)
+	}
+	if retries != 0 {
+		t.Fatalf("semantic corruption retries = %d, want 0", retries)
 	}
 }
 

--- a/cmd/defenseclaw-setup/platform_windows.go
+++ b/cmd/defenseclaw-setup/platform_windows.go
@@ -108,6 +108,11 @@ type pidState struct {
 
 const maxManagedPIDRecordBytes = 64 << 10
 
+const (
+	managedPIDRecordReadAttempts = 50
+	managedPIDRecordReadInterval = 10 * time.Millisecond
+)
+
 func acquireSetupLock() (func() error, error) {
 	user, err := windows.GetCurrentProcessToken().GetTokenUser()
 	if err != nil {
@@ -199,6 +204,34 @@ func managedProcessProofFor(gatewayPath, dataRoot, pidFile string) (managedProce
 }
 
 func readManagedPIDRecord(pidPath string) (pidState, bool, error) {
+	return readManagedPIDRecordWithRetry(
+		pidPath,
+		managedPIDRecordReadAttempts,
+		func() { time.Sleep(managedPIDRecordReadInterval) },
+	)
+}
+
+func readManagedPIDRecordWithRetry(
+	pidPath string,
+	attempts int,
+	wait func(),
+) (pidState, bool, error) {
+	if attempts < 1 {
+		attempts = 1
+	}
+	if wait == nil {
+		wait = func() {}
+	}
+	for attempt := 0; ; attempt++ {
+		state, exists, err := readManagedPIDRecordOnce(pidPath)
+		if err == nil || attempt+1 >= attempts || !managedPIDRecordPublicationInFlight(err) {
+			return state, exists, err
+		}
+		wait()
+	}
+}
+
+func readManagedPIDRecordOnce(pidPath string) (pidState, bool, error) {
 	file, exists, err := openManagedPIDRecord(pidPath)
 	if err != nil || !exists {
 		return pidState{}, exists, err
@@ -211,12 +244,20 @@ func readManagedPIDRecord(pidPath string) (pidState, bool, error) {
 	return state, true, nil
 }
 
+func managedPIDRecordPublicationInFlight(err error) bool {
+	var syntaxErr *json.SyntaxError
+	return errors.As(err, &syntaxErr)
+}
+
 // openManagedPIDRecord binds validation and decoding to one Windows file
 // object. Gateway PID records are atomically replaced during startup, so
 // separate Lstat/GetFileAttributes/ReadFile lookups can observe three
 // different pathname states and leak a transient not-found error into Setup
 // convergence. Delete sharing lets the publisher proceed while this handle
-// keeps the verified object stable for the reader.
+// keeps the verified object stable for the reader. watchdog.pid predates the
+// atomic publisher and is rewritten in place while retaining its lifetime
+// ownership lock, so readManagedPIDRecord retries only JSON syntax errors for
+// a bounded interval. A persistently malformed identity remains fail-closed.
 func openManagedPIDRecord(pidPath string) (*os.File, bool, error) {
 	pathPtr, err := winpath.UTF16Ptr(pidPath)
 	if err != nil {

--- a/cmd/defenseclaw-setup/platform_windows.go
+++ b/cmd/defenseclaw-setup/platform_windows.go
@@ -154,7 +154,7 @@ func managedProcessOwnedBy(gatewayPath, dataRoot, pidFile string) (bool, error) 
 
 func managedProcessProofFor(gatewayPath, dataRoot, pidFile string) (managedProcessProof, bool, error) {
 	pidPath := filepath.Join(dataRoot, pidFile)
-	state, exists, err := readManagedPIDRecord(pidPath)
+	state, exists, err := readManagedPIDRecord(pidPath, pidFile == "watchdog.pid")
 	if err != nil {
 		return managedProcessProof{}, false, err
 	}
@@ -203,16 +203,18 @@ func managedProcessProofFor(gatewayPath, dataRoot, pidFile string) (managedProce
 	}, true, nil
 }
 
-func readManagedPIDRecord(pidPath string) (pidState, bool, error) {
-	return readManagedPIDRecordWithRetry(
+func readManagedPIDRecord(pidPath string, retryInPlacePublication bool) (pidState, bool, error) {
+	return readManagedPIDRecordWithPolicy(
 		pidPath,
+		retryInPlacePublication,
 		managedPIDRecordReadAttempts,
 		func() { time.Sleep(managedPIDRecordReadInterval) },
 	)
 }
 
-func readManagedPIDRecordWithRetry(
+func readManagedPIDRecordWithPolicy(
 	pidPath string,
+	retryInPlacePublication bool,
 	attempts int,
 	wait func(),
 ) (pidState, bool, error) {
@@ -223,30 +225,34 @@ func readManagedPIDRecordWithRetry(
 		wait = func() {}
 	}
 	for attempt := 0; ; attempt++ {
-		state, exists, err := readManagedPIDRecordOnce(pidPath)
-		if err == nil || attempt+1 >= attempts || !managedPIDRecordPublicationInFlight(err) {
+		state, exists, retryable, err := readManagedPIDRecordAttempt(pidPath)
+		if err == nil || !retryInPlacePublication || attempt+1 >= attempts || !retryable {
 			return state, exists, err
 		}
 		wait()
 	}
 }
 
-func readManagedPIDRecordOnce(pidPath string) (pidState, bool, error) {
+func readManagedPIDRecordAttempt(pidPath string) (pidState, bool, bool, error) {
 	file, exists, err := openManagedPIDRecord(pidPath)
 	if err != nil || !exists {
-		return pidState{}, exists, err
+		return pidState{}, exists, false, err
 	}
 	state, readErr := decodeManagedPIDRecord(file, pidPath)
 	closeErr := file.Close()
 	if readErr != nil || closeErr != nil {
-		return pidState{}, false, errors.Join(readErr, closeErr)
+		return pidState{}, false, managedPIDRecordPublicationInFlight(readErr, closeErr),
+			errors.Join(readErr, closeErr)
 	}
-	return state, true, nil
+	return state, true, false, nil
 }
 
-func managedPIDRecordPublicationInFlight(err error) bool {
+func managedPIDRecordPublicationInFlight(readErr, closeErr error) bool {
+	if closeErr != nil {
+		return false
+	}
 	var syntaxErr *json.SyntaxError
-	return errors.As(err, &syntaxErr)
+	return errors.As(readErr, &syntaxErr)
 }
 
 // openManagedPIDRecord binds validation and decoding to one Windows file
@@ -256,8 +262,8 @@ func managedPIDRecordPublicationInFlight(err error) bool {
 // convergence. Delete sharing lets the publisher proceed while this handle
 // keeps the verified object stable for the reader. watchdog.pid predates the
 // atomic publisher and is rewritten in place while retaining its lifetime
-// ownership lock, so readManagedPIDRecord retries only JSON syntax errors for
-// a bounded interval. A persistently malformed identity remains fail-closed.
+// ownership lock, so its caller enables bounded JSON-syntax retries. Gateway
+// reads and every persistently malformed identity remain fail-closed.
 func openManagedPIDRecord(pidPath string) (*os.File, bool, error) {
 	pathPtr, err := winpath.UTF16Ptr(pidPath)
 	if err != nil {


### PR DESCRIPTION
Standalone fix on `main` at `d3635d3fa33ca599d27bb2a8ae58546ff558c5e6`; no stack dependency.

## Problem

[Windows Native CI run 30321542493, job 90159644585](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/30321542493/job/90159644585) committed the native Setup install, started the managed services, and then failed convergence with:

```text
invalid managed gateway PID file ...\watchdog.pid: unexpected end of JSON input
```

The watchdog retains a lifetime `LockFileEx` ownership lock on `watchdog.pid`, so unlike `gateway.pid` it rewrites its JSON identity in place: truncate, encode, sync. Setup opened that path with write sharing and could decode it in the small interval after truncate but before the complete JSON write.

## Current Situation

The file is not corrupt and the watchdog is not unhealthy in this case. Setup simply observes an in-flight publication and converts a transient empty/truncated read into a committed-install failure. Retrying every PID error would be unsafe, while atomically renaming the watchdog record would break the pathname-bound lifetime ownership lock.

## Solution

### Bounded syntax-only stable read

Setup now closes and reopens the PID path after a JSON syntax error, preserving the existing per-handle path/type/reparse validation on every attempt. It retries at most 50 times at 10 ms intervals (under 500 ms total).

```mermaid
flowchart LR
    A["Watchdog owns lifetime PID lock"] --> B["Truncate and publish JSON"]
    B --> C{"Setup decode"}
    C -->|"complete JSON"| D["Verify PID, image, and start identity"]
    C -->|"JSON syntax error only"| E["Close, wait 10 ms, reopen and revalidate"]
    E --> C
    C -->|"semantic/type/security error"| F["Fail immediately"]
    E -->|"50th syntax failure"| G["Return final error"]
```

### Fail-closed boundaries

- A complete process identity is still mandatory.
- Only `watchdog.pid` opts into publication retries; atomically published `gateway.pid` remains a one-shot validated read.
- Semantic JSON corruption such as `{"pid":"bad"}` is not retried.
- Oversized records, reparse points, directories, access errors, and process identity mismatches are not retried.
- Persistently truncated JSON returns the final decode error after the bound; it is never accepted as absent or healthy.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `cmd/defenseclaw-setup/platform_windows.go` | Added bounded close/reopen retries for `*json.SyntaxError` only, retaining all existing handle-bound validation and the final error. |
| `cmd/defenseclaw-setup/managed_process_windows_test.go` | Added deterministic tests for in-place truncate/publish recovery, bounded persistent truncation failure, and zero-retry semantic corruption. |

## Breaking Changes

None. No CLI, configuration, installer UI, release input, or process identity format changes.

## Open Issues / Follow-ups

None.

## Test Plan

- `go test ./cmd/defenseclaw-setup -count=1`
  - PASS (`ok`, 0.985s)
- `go test ./internal/cli -run 'Watchdog|watchdog' -count=1`
  - PASS (`ok`, 2.878s)
- `go test ./internal/daemon -count=1`
  - PASS (`ok`, 1.667s)
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c -o /tmp/defenseclaw-setup-windows-watchdog-fix.test.exe ./cmd/defenseclaw-setup`
  - PASS; produced a PE32+ Windows x86-64 test executable containing the executable race regressions.
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go vet ./cmd/defenseclaw-setup`
  - PASS
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o /tmp/DefenseClawSetup-watchdog-fix-x64.exe ./cmd/defenseclaw-setup`
  - PASS; produced a PE32+ Windows x86-64 Setup executable.
- `git diff --check`
  - PASS

A broader local macOS `go test ./internal/cli` also exposed unrelated existing host-state failures involving `/var` versus `/private/var` path identity and an ambient authenticated-listener 401. The affected Setup package, focused watchdog suite, daemon suite, Windows cross-build, and Windows vet all pass; the PR's Windows Native CI executes the new Windows-only regression tests natively.\n\n- [Windows Native CI run 30323878832, attempt 2](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/30323878832)
  - PASS; aggregate `Windows Native Required` is green.
- [Windows native Setup install and lifecycle acceptance](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/30323878832/job/90172224251)
  - PASS; native Setup install, CLI/TUI smoke, repair, uninstall, and cleanup completed on `windows-latest`.
- [Windows x64 Go suite retry](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/30323878832/job/90172223257)
  - PASS; the first attempt had one unrelated, non-reproducible `internal/gateway` capacity-metric test failure. The exact base passed, the focused test passed 600/600 local repetitions and 20/20 under `-race`, and the failed-only rerun passed without code changes.