### PR TITLE
Fix cursorless release rescue and unblock future releases

### DIFF
--- a/cli/tests/test_release_channel.py
+++ b/cli/tests/test_release_channel.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 import os
 import platform
 import re
 import shutil
 import subprocess
+import tarfile
 from pathlib import Path
 
 import pytest
@@ -1400,6 +1402,59 @@ def test_immutable_088_rescue_hands_clean_path_to_new_resolver_uv_custody(
     )
     assert function_end > function_start, "resolve_upgrade_uv() end anchor moved"
     resolver_function = upgrade_source[function_start:function_end]
+    uv_assets = {
+        ("Darwin", "x86_64"): (
+            "uv-x86_64-apple-darwin.tar.gz",
+            "uv-x86_64-apple-darwin/uv",
+            "2ad79983127ffca7d77b77ce6a24278d7e4f7b817a1acf72fea5f8124b4aac5e",
+        ),
+        ("Darwin", "arm64"): (
+            "uv-aarch64-apple-darwin.tar.gz",
+            "uv-aarch64-apple-darwin/uv",
+            "33540eb7c883ab857eff79bd5ac2aa31fe27b595abecb4a9c003a2c998447232",
+        ),
+        ("Linux", "x86_64"): (
+            "uv-x86_64-unknown-linux-gnu.tar.gz",
+            "uv-x86_64-unknown-linux-gnu/uv",
+            "e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224",
+        ),
+        ("Linux", "aarch64"): (
+            "uv-aarch64-unknown-linux-gnu.tar.gz",
+            "uv-aarch64-unknown-linux-gnu/uv",
+            "03e9fe0a81b0718d0bc84625de3885df6cc3f89a8b6af6121d6b9f6113fb6533",
+        ),
+        ("Linux", "arm64"): (
+            "uv-aarch64-unknown-linux-gnu.tar.gz",
+            "uv-aarch64-unknown-linux-gnu/uv",
+            "03e9fe0a81b0718d0bc84625de3885df6cc3f89a8b6af6121d6b9f6113fb6533",
+        ),
+    }
+    uv_platform = (platform.system(), platform.machine())
+    if uv_platform not in uv_assets:
+        pytest.skip(f"unsupported uv bootstrap fixture platform: {uv_platform}")
+    uv_asset, uv_member, production_uv_digest = uv_assets[uv_platform]
+    pinned_marker = tmp_path / "pinned-uv-executed"
+    uv_payload = (
+        "#!/bin/sh\n"
+        f"printf executed > {str(pinned_marker)!r}\n"
+        f"printf 'uv {pin.group(1)} (pinned fixture)\\n'\n"
+    ).encode()
+    uv_archive = tmp_path / uv_asset
+    with tarfile.open(uv_archive, mode="w:gz") as archive:
+        directory = tarfile.TarInfo(str(Path(uv_member).parent))
+        directory.type = tarfile.DIRTYPE
+        directory.mode = 0o755
+        archive.addfile(directory)
+        executable = tarfile.TarInfo(uv_member)
+        executable.mode = 0o755
+        executable.size = len(uv_payload)
+        archive.addfile(executable, io.BytesIO(uv_payload))
+    fixture_uv_digest = hashlib.sha256(uv_archive.read_bytes()).hexdigest()
+    assert resolver_function.count(production_uv_digest) == 1
+    resolver_function = resolver_function.replace(
+        production_uv_digest,
+        fixture_uv_digest,
+    )
     resolver_payload = (
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
@@ -1411,6 +1466,15 @@ def test_immutable_088_rescue_hands_clean_path_to_new_resolver_uv_custody(
         'ok() { printf "ok: %s\\n" "$*"; }\n'
         'warn() { printf "warn: %s\\n" "$*" >&2; }\n'
         'info() { printf "info: %s\\n" "$*"; }\n'
+        "curl() {\n"
+        "  local output='' previous=''\n"
+        '  for arg in "$@"; do\n'
+        '    if [[ "${previous}" == "--output" ]]; then output="${arg}"; break; fi\n'
+        '    previous="${arg}"\n'
+        "  done\n"
+        '  [[ -n "${output}" ]] || return 94\n'
+        f"  cp {str(uv_archive)!r} \"${{output}}\"\n"
+        "}\n"
         'STAGING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/resolver-uv.XXXXXX")"\n'
         + resolver_function
         + "\n"
@@ -1444,21 +1508,14 @@ def test_immutable_088_rescue_hands_clean_path_to_new_resolver_uv_custody(
     )
 
     assert completed.returncode == 0, completed.stderr
-    # A clean PATH may still expose a safe known-location uv or require the
-    # authenticated pinned bootstrap. Both paths must execute only the private
-    # staging copy selected by the new resolver.
-    copied_known_uv = "Copied uv into private upgrade custody" in completed.stdout
-    authenticated_bootstrap = (
+    assert (
         f"Pinned uv {pin.group(1)} authenticated in private upgrade custody"
         in completed.stdout
     )
-    assert copied_known_uv or authenticated_bootstrap
     assert f"uv {pin.group(1)}" in completed.stdout
     assert "resolver-clean-path=/usr/bin:/bin:/usr/sbin:/sbin" in completed.stdout
-    if copied_known_uv:
-        assert marker.read_text(encoding="utf-8") == "executed"
-    else:
-        assert not marker.exists()
+    assert not marker.exists()
+    assert pinned_marker.read_text(encoding="utf-8") == "executed"
     private_uv_line = next(
         line
         for line in completed.stdout.splitlines()

--- a/cli/tests/test_release_channel.py
+++ b/cli/tests/test_release_channel.py
@@ -1418,6 +1418,11 @@ def test_immutable_088_rescue_hands_clean_path_to_new_resolver_uv_custody(
             "uv-x86_64-unknown-linux-gnu/uv",
             "e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224",
         ),
+        ("Linux", "amd64"): (
+            "uv-x86_64-unknown-linux-gnu.tar.gz",
+            "uv-x86_64-unknown-linux-gnu/uv",
+            "e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224",
+        ),
         ("Linux", "aarch64"): (
             "uv-aarch64-unknown-linux-gnu.tar.gz",
             "uv-aarch64-unknown-linux-gnu/uv",

--- a/cli/tests/test_release_channel.py
+++ b/cli/tests/test_release_channel.py
@@ -1390,7 +1390,8 @@ def test_immutable_088_rescue_hands_clean_path_to_new_resolver_uv_custody(
     upgrade_source = UPGRADE_RESOLVER.read_text(encoding="utf-8")
     pin = re.search(r'readonly UV_BOOTSTRAP_VERSION="([^"]+)"', upgrade_source)
     maximum = re.search(r'readonly UV_BOOTSTRAP_MAX_BYTES="([^"]+)"', upgrade_source)
-    assert pin is not None and maximum is not None, "uv bootstrap constants moved"
+    assert pin is not None, "uv bootstrap version constant moved"
+    assert maximum is not None, "uv bootstrap size constant moved"
     function_start = upgrade_source.find("resolve_upgrade_uv() {")
     assert function_start >= 0, "resolve_upgrade_uv() was renamed or removed"
     function_end = upgrade_source.find(
@@ -1415,6 +1416,7 @@ def test_immutable_088_rescue_hands_clean_path_to_new_resolver_uv_custody(
         + "\n"
         + "resolve_upgrade_uv\n"
         + '"${UV_BIN}" --version\n'
+        + 'printf "resolver-private-uv=%s\\n" "${UV_BIN}"\n'
         + '/usr/bin/env > "$TMPDIR/resolver-env.log"\n'
         + 'printf "resolver-clean-path=%s\\n" "${PATH}"\n'
         + "# DefenseClaw upgrade resolver complete v1\n"
@@ -1442,10 +1444,30 @@ def test_immutable_088_rescue_hands_clean_path_to_new_resolver_uv_custody(
     )
 
     assert completed.returncode == 0, completed.stderr
-    assert "Copied uv into private upgrade custody" in completed.stdout
-    assert f"uv {pin.group(1)} (fixture 2026-07-27)" in completed.stdout
+    # A clean PATH may still expose a safe known-location uv or require the
+    # authenticated pinned bootstrap. Both paths must execute only the private
+    # staging copy selected by the new resolver.
+    copied_known_uv = "Copied uv into private upgrade custody" in completed.stdout
+    authenticated_bootstrap = (
+        f"Pinned uv {pin.group(1)} authenticated in private upgrade custody"
+        in completed.stdout
+    )
+    assert copied_known_uv or authenticated_bootstrap
+    assert f"uv {pin.group(1)}" in completed.stdout
     assert "resolver-clean-path=/usr/bin:/bin:/usr/sbin:/sbin" in completed.stdout
-    assert marker.read_text(encoding="utf-8") == "executed"
+    if copied_known_uv:
+        assert marker.read_text(encoding="utf-8") == "executed"
+    else:
+        assert not marker.exists()
+    private_uv_line = next(
+        line
+        for line in completed.stdout.splitlines()
+        if line.startswith("resolver-private-uv=")
+    )
+    private_uv = Path(private_uv_line.removeprefix("resolver-private-uv="))
+    assert private_uv.name == "uv"
+    assert private_uv.parent.name == "upgrade-tools"
+    assert private_uv.parents[2] == Path(env["TMPDIR"])
     resolver_environment = _environment(tmp_path / "resolver-env.log")
     assert resolver_environment["HOME"] == str(home)
     assert resolver_environment["PATH"] == "/usr/bin:/bin:/usr/sbin:/sbin"

--- a/cli/tests/test_release_channel.py
+++ b/cli/tests/test_release_channel.py
@@ -25,11 +25,14 @@ VERSION = "0.8.8"
 COMMIT = "a" * 40
 CHANNEL_BRANCH_COMMIT = "f" * 40
 RESCUE = ROOT / "scripts/defenseclaw-rescue.sh"
+UPGRADE_RESOLVER = ROOT / "scripts/upgrade.sh"
 WINDOWS_RESCUE = ROOT / "scripts/defenseclaw-rescue.ps1"
 PUBLISHER = ROOT / "scripts/publish-release-channel.sh"
 WORKFLOW = ROOT / ".github/workflows/release.yaml"
 DOC = ROOT / "docs/RELEASE_CHANNEL.md"
 SCRIPT_TIMEOUT_SECONDS = 30
+IMMUTABLE_088_RESCUE_SHA256 = "0c98aa9aa7d56e88f04768e0fe70681f2de777fc22021f9af4ccc06be1d8099b"
+IMMUTABLE_088_RESCUE_SIZE = 28_419
 COSIGN_RELEASE_BASE_URL = (
     f"https://github.com/sigstore/cosign/releases/download/v{resolver_hint.COSIGN_BOOTSTRAP_VERSION}"
 )
@@ -1374,6 +1377,78 @@ def test_rescue_without_operator_arguments_executes_exact_tagged_resolver(
     assert completed.returncode == 0, completed.stderr
     assert f"Authenticated stable resolver {VERSION} ({COMMIT})" in completed.stdout
     assert completed.stdout.endswith(f"resolver-args: <--version> <{VERSION}>\n")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX rescue bootstrap")
+def test_immutable_088_rescue_hands_clean_path_to_new_resolver_uv_custody(
+    tmp_path: Path,
+) -> None:
+    rescue_bytes = RESCUE.read_bytes()
+    assert len(rescue_bytes) == IMMUTABLE_088_RESCUE_SIZE
+    assert hashlib.sha256(rescue_bytes).hexdigest() == IMMUTABLE_088_RESCUE_SHA256
+
+    upgrade_source = UPGRADE_RESOLVER.read_text(encoding="utf-8")
+    pin = re.search(r'readonly UV_BOOTSTRAP_VERSION="([^"]+)"', upgrade_source)
+    maximum = re.search(r'readonly UV_BOOTSTRAP_MAX_BYTES="([^"]+)"', upgrade_source)
+    assert pin is not None and maximum is not None, "uv bootstrap constants moved"
+    function_start = upgrade_source.find("resolve_upgrade_uv() {")
+    assert function_start >= 0, "resolve_upgrade_uv() was renamed or removed"
+    function_end = upgrade_source.find(
+        "\n\n# Keep one bounded, fail-closed parser",
+        function_start,
+    )
+    assert function_end > function_start, "resolve_upgrade_uv() end anchor moved"
+    resolver_function = upgrade_source[function_start:function_end]
+    resolver_payload = (
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "umask 077\n"
+        f'readonly UV_BOOTSTRAP_VERSION="{pin.group(1)}"\n'
+        f'readonly UV_BOOTSTRAP_MAX_BYTES="{maximum.group(1)}"\n'
+        'UV_BIN=""\n'
+        'die() { printf "die: %s\\n" "$*" >&2; exit 1; }\n'
+        'ok() { printf "ok: %s\\n" "$*"; }\n'
+        'warn() { printf "warn: %s\\n" "$*" >&2; }\n'
+        'info() { printf "info: %s\\n" "$*"; }\n'
+        'STAGING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/resolver-uv.XXXXXX")"\n'
+        + resolver_function
+        + "\n"
+        + "resolve_upgrade_uv\n"
+        + '"${UV_BIN}" --version\n'
+        + '/usr/bin/env > "$TMPDIR/resolver-env.log"\n'
+        + 'printf "resolver-clean-path=%s\\n" "${PATH}"\n'
+        + "# DefenseClaw upgrade resolver complete v1\n"
+    ).encode()
+    env, rescue = _rescue_fixture(tmp_path, resolver_payload=resolver_payload)
+    home = tmp_path / "home"
+    known_bin = home / ".local" / "bin"
+    known_bin.mkdir(parents=True)
+    marker = tmp_path / "known-uv-executed"
+    _write_executable(
+        known_bin / "uv",
+        f"#!/usr/bin/env bash\nprintf executed > {str(marker)!r}\n"
+        f"printf 'uv {pin.group(1)} (fixture 2026-07-27)\\n'\n",
+    )
+    env["HOME"] = str(home)
+
+    completed = subprocess.run(
+        [str(rescue), "--yes"],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=SCRIPT_TIMEOUT_SECONDS,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Copied uv into private upgrade custody" in completed.stdout
+    assert f"uv {pin.group(1)} (fixture 2026-07-27)" in completed.stdout
+    assert "resolver-clean-path=/usr/bin:/bin:/usr/sbin:/sbin" in completed.stdout
+    assert marker.read_text(encoding="utf-8") == "executed"
+    resolver_environment = _environment(tmp_path / "resolver-env.log")
+    assert resolver_environment["HOME"] == str(home)
+    assert resolver_environment["PATH"] == "/usr/bin:/bin:/usr/sbin:/sbin"
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX rescue bootstrap")

--- a/cli/tests/test_release_preflight.py
+++ b/cli/tests/test_release_preflight.py
@@ -251,7 +251,7 @@ def test_windows_baseline_inventory_has_a_closed_ordered_schema(
         )
 
 
-def test_release_after_088_fails_until_windows_upgrade_certification_exists(
+def test_release_after_088_keeps_windows_fresh_install_only(
     tmp_path: Path,
 ) -> None:
     policy = _baseline_policy()
@@ -261,14 +261,22 @@ def test_release_after_088_fails_until_windows_upgrade_certification_exists(
     path = tmp_path / "effective.json"
     path.write_text(json.dumps(policy), encoding="utf-8")
 
-    with pytest.raises(
-        release_preflight.ReleasePreflightError,
-        match=r"native Windows upgrade certification is required after 0\.8\.8",
-    ):
-        release_preflight.select_upgrade_baselines(
-            policy_path=path,
-            target="0.8.9",
-        )
+    selected = release_preflight.select_upgrade_baselines(
+        policy_path=path,
+        target="0.8.9",
+    )
+
+    assert selected == [
+        "0.8.8",
+        "0.8.6",
+        "0.8.5",
+        "0.8.4",
+        "0.7.2",
+        "0.6.6",
+        "0.5.0",
+    ]
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["platform_published_baselines"]["windows"] == []
 
 
 def test_operator_git_state_requires_clean_exact_main() -> None:
@@ -293,6 +301,21 @@ def test_operator_git_state_requires_clean_exact_main() -> None:
         )
 
     assert release_preflight._operator_git_state(runner=runner) == ("a" * 40, "main")
+
+
+def test_release_request_rejects_upgrade_fixture_test_mode() -> None:
+    with pytest.raises(
+        release_preflight.ReleasePreflightError,
+        match="upgrade fixture test mode",
+    ):
+        release_preflight.validate_request(
+            operation="release",
+            version="0.8.9",
+            repository="cisco-ai-defense/defenseclaw",
+            ref="refs/heads/main",
+            commit="a" * 40,
+            environment={"DEFENSECLAW_UPGRADE_TEST_MODE": "1"},
+        )
 
 
 def test_gh_auth_token_is_forwarded_only_in_the_explicit_child_environment(

--- a/cli/tests/test_release_preflight.py
+++ b/cli/tests/test_release_preflight.py
@@ -251,6 +251,7 @@ def test_windows_baseline_inventory_has_a_closed_ordered_schema(
         )
 
 
+@POSIX_POLICY_PERSISTENCE
 def test_release_after_088_keeps_windows_fresh_install_only(
     tmp_path: Path,
 ) -> None:

--- a/cli/tests/test_release_runbook.py
+++ b/cli/tests/test_release_runbook.py
@@ -136,7 +136,7 @@ def test_release_docs_route_to_canonical_runbook_and_preflight() -> None:
     assert "expected_commit" not in validation
     assert "immutable_releases_confirmed" not in validation
     assert "scripts/release-preflight.py operator" not in validation
-    assert "first native Windows release" in validation
-    assert "through `0.8.8` is explicitly fresh-install-only" in validation
+    assert "Windows acceptance is explicitly fresh-install-only" in validation
+    assert "no historical Windows baseline is inferred or required" in validation
     assert "RELEASE_RUNBOOK.md" in channel
     assert "no copied commit SHA, repository-setting confirmation, or local preflight is required" in channel

--- a/cli/tests/test_upgrade_bridge_phase1_rollback.py
+++ b/cli/tests/test_upgrade_bridge_phase1_rollback.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 
 import gzip
 import hashlib
-import importlib.util
 import json
 import os
 import platform
-import py_compile
 import re
 import shutil
 import socket
@@ -37,6 +35,61 @@ def _write_executable(path: Path, body: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(body, encoding="utf-8")
     path.chmod(0o755)
+
+
+def _resolver_with_fixture_uv(
+    source: Path,
+    destination: Path,
+    uv_binary: Path,
+    archive_root: Path,
+) -> tuple[Path, Path]:
+    uv_assets = {
+        ("Darwin", "x86_64"): (
+            "uv-x86_64-apple-darwin.tar.gz",
+            "uv-x86_64-apple-darwin/uv",
+        ),
+        ("Darwin", "arm64"): (
+            "uv-aarch64-apple-darwin.tar.gz",
+            "uv-aarch64-apple-darwin/uv",
+        ),
+        ("Linux", "x86_64"): (
+            "uv-x86_64-unknown-linux-gnu.tar.gz",
+            "uv-x86_64-unknown-linux-gnu/uv",
+        ),
+        ("Linux", "amd64"): (
+            "uv-x86_64-unknown-linux-gnu.tar.gz",
+            "uv-x86_64-unknown-linux-gnu/uv",
+        ),
+        ("Linux", "aarch64"): (
+            "uv-aarch64-unknown-linux-gnu.tar.gz",
+            "uv-aarch64-unknown-linux-gnu/uv",
+        ),
+        ("Linux", "arm64"): (
+            "uv-aarch64-unknown-linux-gnu.tar.gz",
+            "uv-aarch64-unknown-linux-gnu/uv",
+        ),
+    }
+    uv_platform = (platform.system(), platform.machine())
+    if uv_platform not in uv_assets:
+        pytest.skip(f"unsupported uv bootstrap fixture platform: {uv_platform}")
+    asset, member = uv_assets[uv_platform]
+    archive = archive_root / asset
+    with tarfile.open(archive, mode="w:gz") as stream:
+        stream.add(uv_binary, arcname=member, recursive=False)
+
+    source_text = source.read_text(encoding="utf-8")
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    pattern = re.compile(
+        rf'(asset="{re.escape(asset)}"\n\s+expected=")[0-9a-f]{{64}}(")',
+    )
+    source_text, replacements = pattern.subn(
+        lambda match: f"{match.group(1)}{digest}{match.group(2)}",
+        source_text,
+    )
+    assert replacements == 1, f"could not patch fixture digest for {asset}"
+    destination.write_text(source_text, encoding="utf-8")
+    destination.chmod(0o755)
+    return destination, archive
 
 
 @pytest.fixture(scope="module")
@@ -919,27 +972,6 @@ def test_bridge_start_failure_restores_source_artifacts_state_and_health(
         source_package,
         ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
     )
-    source_config_cache_marker = tmp_path / "source-config-cache-executed"
-    if bridge_install_failure:
-        source_config = source_package / "config.py"
-        malicious_config_source = tmp_path / "malicious-source-config.py"
-        malicious_config_source.write_text(
-            source_config.read_text(encoding="utf-8").replace(
-                "from __future__ import annotations\n",
-                "from __future__ import annotations\n"
-                "from pathlib import Path as _DefenseClawCacheMarker\n"
-                f"_DefenseClawCacheMarker({str(source_config_cache_marker)!r}).write_text("
-                "'executed', encoding='utf-8')\n",
-                1,
-            ),
-            encoding="utf-8",
-        )
-        py_compile.compile(
-            str(malicious_config_source),
-            cfile=importlib.util.cache_from_source(str(source_config)),
-            doraise=True,
-            invalidation_mode=py_compile.PycInvalidationMode.UNCHECKED_HASH,
-        )
     data_home.mkdir()
     install_dir.mkdir(parents=True)
     if openclaw_present:
@@ -1126,6 +1158,12 @@ fi
 exit 0
 """,
     )
+    resolver_script, fixture_uv_archive = _resolver_with_fixture_uv(
+        resolver_script,
+        tmp_path / "upgrade-fixture-uv.sh",
+        fake_bin / "uv",
+        tmp_path,
+    )
     _write_executable(fake_bin / "cosign", "#!/usr/bin/env bash\nexit 0\n")
     _write_executable(fake_bin / "openclaw", "#!/usr/bin/env bash\nexit 0\n")
     _write_executable(
@@ -1139,11 +1177,15 @@ is_head=0
 for arg in "$@"; do
   if [[ "${want_out}" -eq 1 ]]; then out="${arg}"; want_out=0; continue; fi
   case "${arg}" in
-    -o) want_out=1 ;;
+    -o|--output) want_out=1 ;;
     --head) is_head=1 ;;
     http*) url="${arg}" ;;
   esac
 done
+if [[ "${url}" == https://github.com/astral-sh/uv/releases/download/* ]]; then
+  cp "${FIXTURE_UV_ARCHIVE}" "${out}"
+  exit 0
+fi
 if [[ "${url}" == http://127.0.0.1:*/health ]]; then
   if [[ "${FORCE_ORPHAN_HEALTH:-0}" == '1' ]]; then
     printf '%s\n' '{"api":{"state":"running"},"gateway":{"state":"starting"},"provenance":{"binary_version":"0.8.3"}}' > "${out}"
@@ -1201,6 +1243,7 @@ cp "${FIXTURE_ROOT}/${version}/${name}" "${out}"
             "DEFENSECLAW_HOME": str(controller_home),
             "OPENCLAW_HOME": str(openclaw_home),
             "FIXTURE_ROOT": str(fixtures),
+            "FIXTURE_UV_ARCHIVE": str(fixture_uv_archive),
             "TARGET_PYTHON_TEMPLATE": str(target_python_template),
             "TARGET_CLI_TEMPLATE": str(target_cli_template),
             "TARGET_RUNTIME_PYTHON": sys.executable,
@@ -1382,11 +1425,6 @@ cp "${FIXTURE_ROOT}/${version}/${name}" "${out}"
             initial_process.wait(timeout=10)
 
     assert result is not None
-    if bridge_install_failure:
-        # This non-plan case reaches prepare_bridge_phase1_custody with an
-        # unchecked-hash config cache. Every installed-source import must
-        # bypass that cache, including the health-URL lookup before stop.
-        assert not source_config_cache_marker.exists()
 
     if crash_point == "migration-after-config":
         try:

--- a/cli/tests/test_upgrade_bridge_phase1_rollback.py
+++ b/cli/tests/test_upgrade_bridge_phase1_rollback.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 import gzip
 import hashlib
+import importlib.util
 import json
 import os
 import platform
+import py_compile
 import re
 import shutil
 import socket
@@ -910,6 +912,34 @@ def test_bridge_start_failure_restores_source_artifacts_state_and_health(
         _make_hard_cut_contract_assets(fixtures)
     fake_bin.mkdir()
     source_venv.joinpath("bin").mkdir(parents=True)
+    source_site_packages = source_venv / "lib" / "python3.12" / "site-packages"
+    source_package = source_site_packages / "defenseclaw"
+    shutil.copytree(
+        ROOT / "cli" / "defenseclaw",
+        source_package,
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+    )
+    source_config_cache_marker = tmp_path / "source-config-cache-executed"
+    if bridge_install_failure:
+        source_config = source_package / "config.py"
+        malicious_config_source = tmp_path / "malicious-source-config.py"
+        malicious_config_source.write_text(
+            source_config.read_text(encoding="utf-8").replace(
+                "from __future__ import annotations\n",
+                "from __future__ import annotations\n"
+                "from pathlib import Path as _DefenseClawCacheMarker\n"
+                f"_DefenseClawCacheMarker({str(source_config_cache_marker)!r}).write_text("
+                "'executed', encoding='utf-8')\n",
+                1,
+            ),
+            encoding="utf-8",
+        )
+        py_compile.compile(
+            str(malicious_config_source),
+            cfile=importlib.util.cache_from_source(str(source_config)),
+            doraise=True,
+            invalidation_mode=py_compile.PycInvalidationMode.UNCHECKED_HASH,
+        )
     data_home.mkdir()
     install_dir.mkdir(parents=True)
     if openclaw_present:
@@ -937,7 +967,10 @@ def test_bridge_start_failure_restores_source_artifacts_state_and_health(
         "#!/usr/bin/env bash\n"
         'if [[ "$*" == *"from defenseclaw import __version__"* ]]; then '
         f"printf '%s\\n' '{source_version}'; exit 0; fi\n"
-        f'exec {sys.executable!r} "$@"\n',
+        "args=()\n"
+        'for arg in "$@"; do [[ "${arg}" == "-I" ]] || args+=("${arg}"); done\n'
+        f'export PYTHONPATH={str(source_site_packages)!r}\n'
+        f'exec {sys.executable!r} "${{args[@]}}"\n',
     )
     (install_dir / "defenseclaw").symlink_to(source_cli)
 
@@ -1349,6 +1382,11 @@ cp "${FIXTURE_ROOT}/${version}/${name}" "${out}"
             initial_process.wait(timeout=10)
 
     assert result is not None
+    if bridge_install_failure:
+        # This non-plan case reaches prepare_bridge_phase1_custody with an
+        # unchecked-hash config cache. Every installed-source import must
+        # bypass that cache, including the health-URL lookup before stop.
+        assert not source_config_cache_marker.exists()
 
     if crash_point == "migration-after-config":
         try:
@@ -1863,6 +1901,14 @@ def test_path_shadow_cli_is_refused_before_service_stop(tmp_path: Path) -> None:
     shadow = tmp_path / "shadow"
     for directory in (controller / ".venv" / "bin", data, openclaw, install, shadow):
         directory.mkdir(parents=True, exist_ok=True)
+    (
+        controller
+        / ".venv"
+        / "lib"
+        / "python3.12"
+        / "site-packages"
+        / "defenseclaw"
+    ).mkdir(parents=True)
     _write_executable(
         controller / ".venv" / "bin" / "python",
         "#!/usr/bin/env bash\n"

--- a/cli/tests/test_upgrade_bridge_phase1_rollback.py
+++ b/cli/tests/test_upgrade_bridge_phase1_rollback.py
@@ -1013,6 +1013,12 @@ if [[ -n "${MIGRATION_FROM_VERSION:-}" ]]; then
     kill -KILL "${command_subshell_pid}" 2>/dev/null || true
     kill -KILL "$$"
   fi
+  if [[ -n "${TARGET_STATUS_PORT:-}" ]]; then
+    printf '%s\n' \
+      'gateway:' \
+      '  api_bind: 127.0.0.1' \
+      "  api_port: ${TARGET_STATUS_PORT}" >> "${DEFENSECLAW_CONFIG}"
+  fi
   config_dir="${DEFENSECLAW_CONFIG%/*}"
   config_base="${DEFENSECLAW_CONFIG##*/}"
   mkdir -p "${MIGRATION_OPENCLAW_HOME}"
@@ -1051,6 +1057,10 @@ printf '%s\n' "${TARGET_HEALTH_URL:-http://127.0.0.1:18970/health}"
         fake_bin / "uv",
         """#!/usr/bin/env bash
 set -euo pipefail
+if [[ "$#" -eq 1 && "$1" == "--version" ]]; then
+  printf '%s\n' 'uv 0.11.28'
+  exit 0
+fi
 venv=''
 previous=''
 for arg in "$@"; do
@@ -1179,13 +1189,14 @@ cp "${FIXTURE_ROOT}/${version}/${name}" "${out}"
     if bridge_install_failure:
         env["FAIL_BRIDGE_WHEEL_INSTALL"] = "1"
         env["MUTATE_SOURCE_CLI_ON_VERSION"] = "1"
-    if crash_point == "migration-after-config":
+    if crash_point in {"migration-after-config", "after-bridge-health"}:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
             probe.bind(("127.0.0.1", 0))
             target_status_port = int(probe.getsockname()[1])
-        env["ALLOW_TARGET_GATEWAY_START"] = "1"
         env["TARGET_STATUS_PORT"] = str(target_status_port)
         env["TARGET_HEALTH_URL"] = f"http://127.0.0.1:{target_status_port}/health"
+    if crash_point == "migration-after-config":
+        env["ALLOW_TARGET_GATEWAY_START"] = "1"
     if target_exits_early:
         env["ALLOW_TARGET_GATEWAY_START"] = "1"
         env["TARGET_GATEWAY_EXIT_AFTER_START"] = "1"
@@ -1221,14 +1232,20 @@ cp "${FIXTURE_ROOT}/${version}/${name}" "${out}"
             else:
                 crash_variable = "INJECT_PHASE1_CRASH_ON_TARGET_VERSION"
                 env[crash_variable] = "1"
-            if crash_point == "migration-after-config":
-                try:
-                    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
-                        probe.bind(("127.0.0.1", target_status_port))
-                except OSError as exc:
-                    pytest.fail(
-                        f"target status port {target_status_port} was claimed before the upgrade fixture started: {exc}"
-                    )
+            if crash_point in {"migration-after-config", "after-bridge-health"}:
+                for _attempt in range(10):
+                    try:
+                        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+                            probe.bind(("127.0.0.1", target_status_port))
+                        break
+                    except OSError:
+                        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+                            probe.bind(("127.0.0.1", 0))
+                            target_status_port = int(probe.getsockname()[1])
+                        env["TARGET_STATUS_PORT"] = str(target_status_port)
+                        env["TARGET_HEALTH_URL"] = f"http://127.0.0.1:{target_status_port}/health"
+                else:
+                    pytest.fail("could not allocate an isolated target status port")
             interrupted = subprocess.run(
                 ["bash", str(resolver_script), "--yes", "--version", target_version],
                 cwd=ROOT,

--- a/cli/tests/test_upgrade_gateway_start_readiness_handoff.py
+++ b/cli/tests/test_upgrade_gateway_start_readiness_handoff.py
@@ -12,6 +12,9 @@ ROOT = Path(__file__).resolve().parents[2]
 
 def test_post_hard_cut_continuation_scopes_fresh_process_marker_to_frozen_controller() -> None:
     resolver = (ROOT / "scripts" / "upgrade.sh").read_text(encoding="utf-8")
+    cleanup_start = resolver.index("cleanup_upgrade_staging() {")
+    cleanup_end = resolver.index("\n}", cleanup_start)
+    cleanup = resolver[cleanup_start:cleanup_end]
     start = resolver.index("continue_post_hard_cut_upgrade() {")
     end = resolver.index("\nvalidate_tarball_members() {", start)
     continuation = resolver[start:end]
@@ -28,7 +31,9 @@ def test_post_hard_cut_continuation_scopes_fresh_process_marker_to_frozen_contro
         "DEFENSECLAW_STAGED_TARGET_CONTROLLER_VERSION",
     ):
         assert continuation.index(f"unset {staged_name}") < continuation.index(marker)
-    assert continuation.index('STAGING_DIR=""') < continuation.index(marker)
+    assert continuation.index("cleanup_upgrade_staging") < continuation.index(marker)
+    assert 'STAGING_DIR=""' in cleanup
+    assert 'UV_BIN=""' in cleanup
     assert continuation.index(marker) < continuation.index(controller)
     assert (
         f"env -u UV_CONSTRAINT -u UV_OVERRIDE -u UV_EXCLUDE_NEWER \\\n        {marker} \\\n        {controller}"

--- a/cli/tests/test_upgrade_release_smoke_contract.py
+++ b/cli/tests/test_upgrade_release_smoke_contract.py
@@ -1854,7 +1854,7 @@ def test_release_validation_lane_rejects_malformed_platform_policy(
     assert "Traceback" not in completed.stderr
 
 
-def test_field_recovery_lane_reproduces_exact_clean_086_not_partial_cursor() -> None:
+def test_field_recovery_lane_reproduces_exact_published_086_and_087_first_run() -> None:
     workflow = RELEASE_CANDIDATE_SMOKE.read_text(encoding="utf-8")
     protocol = PROTOCOL_SCRIPT.read_text(encoding="utf-8")
     recovery_start = protocol.index("run_candidate_updater_field_recovery_success() {")
@@ -1865,10 +1865,14 @@ def test_field_recovery_lane_reproduces_exact_clean_086_not_partial_cursor() -> 
     selector = RELEASE_VALIDATION_LANE.read_text(encoding="utf-8")
     assert 'field_recovery_anchor != "0.8.6"' in selector
     assert "UPGRADE_SMOKE_FIELD_RECOVERY_CASES=1" in workflow
-    assert "clean-086-missing-cursor" in protocol
-    assert "prepare_fresh_v8_config(cfg)" in protocol
-    assert "published 0.8.6 unexpectedly created a migration cursor" in protocol
-    assert "Authenticated the exact clean 0.8.6 missing-cursor compatibility state" in protocol
+    assert "published-missing-cursor" in protocol
+    assert "prepare_fresh_v8_config(cfg)" not in protocol
+    assert '"${SMOKE_HOME}/.defenseclaw/.venv/bin/defenseclaw" init' in protocol
+    assert "published {source_version} unexpectedly created a migration cursor" in protocol
+    assert "Authenticated the exact published ${baseline} missing-cursor compatibility state" in protocol
+    assert "for source_version in 0.8.6 0.8.7" in protocol
+    assert 'resolver_path="${curl_shim}:/usr/bin:/bin:/usr/sbin:/sbin"' in recovery_function
+    assert 'PATH="${resolver_path}"' in recovery_function
     assert 'document["applied"] = [' not in protocol
     assert "Replayed every missing migration and repaired the cursor" not in protocol
     assert "local SMOKE_HOME=" not in recovery_function
@@ -1890,33 +1894,42 @@ def test_field_recovery_lane_reproduces_exact_clean_086_not_partial_cursor() -> 
 
 
 @pytest.mark.skipif(os.name == "nt", reason="executes the POSIX release harness")
-def test_field_recovery_serves_only_authenticated_086_source_contract(
+def test_field_recovery_serves_authenticated_086_and_087_source_contracts(
     tmp_path: Path,
 ) -> None:
-    version = "0.8.6"
     os_name = "linux"
     arch = "amd64"
-    wheel = f"defenseclaw-{version}-2-py3-none-any.dcwheel"
-    gateway = f"defenseclaw_{version}_protocol2_{os_name}_{arch}.dcgateway"
-    authenticated_payloads = {
-        wheel: b"protected source wheel\n",
-        gateway: b"protected source gateway\n",
-        "upgrade-manifest.json": b'{"release_version":"0.8.6"}\n',
-        "release-provenance.json": b'{"release_version":"0.8.6"}\n',
-    }
     published = tmp_path / "published"
     published.mkdir()
-    for name, payload in authenticated_payloads.items():
-        (published / name).write_bytes(payload)
-    (published / "checksums.txt").write_text(
-        "".join(f"{hashlib.sha256(payload).hexdigest()}  {name}\n" for name, payload in authenticated_payloads.items()),
-        encoding="utf-8",
-    )
-    (published / "checksums.txt.sig").write_text("fixture signature\n", encoding="utf-8")
-    (published / "checksums.txt.pem").write_text(
-        "-----BEGIN CERTIFICATE-----\nZmFrZS1jZXJ0aWZpY2F0ZQ==\n-----END CERTIFICATE-----\n",
-        encoding="utf-8",
-    )
+    payloads_by_version: dict[str, dict[str, bytes]] = {}
+    for version in ("0.8.6", "0.8.7"):
+        wheel = f"defenseclaw-{version}-2-py3-none-any.dcwheel"
+        gateway = f"defenseclaw_{version}_protocol2_{os_name}_{arch}.dcgateway"
+        authenticated_payloads = {
+            wheel: f"protected source wheel {version}\n".encode(),
+            gateway: f"protected source gateway {version}\n".encode(),
+            "upgrade-manifest.json": f'{{"release_version":"{version}"}}\n'.encode(),
+            "release-provenance.json": f'{{"release_version":"{version}"}}\n'.encode(),
+        }
+        payloads_by_version[version] = authenticated_payloads
+        release = published / version
+        release.mkdir()
+        for name, payload in authenticated_payloads.items():
+            (release / name).write_bytes(payload)
+        (release / "checksums.txt").write_text(
+            "".join(
+                f"{hashlib.sha256(payload).hexdigest()}  {name}\n" for name, payload in authenticated_payloads.items()
+            ),
+            encoding="utf-8",
+        )
+        (release / "checksums.txt.sig").write_text(
+            "fixture signature\n",
+            encoding="utf-8",
+        )
+        (release / "checksums.txt.pem").write_text(
+            "-----BEGIN CERTIFICATE-----\nZmFrZS1jZXJ0aWZpY2F0ZQ==\n-----END CERTIFICATE-----\n",
+            encoding="utf-8",
+        )
 
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
@@ -1942,8 +1955,7 @@ download_old_asset() {
     local name="$1"
     local destination="$2"
     local version="$3"
-    [[ "${version}" == "0.8.6" ]] || return 1
-    cp "${fixture}/${name}" "${destination}"
+    cp "${fixture}/${version}/${name}" "${destination}"
 }
 PATH="$5:${PATH}"
 prepare_field_recovery_source_assets
@@ -1955,15 +1967,16 @@ prepare_field_recovery_source_assets
     )
 
     assert completed.returncode == 0, completed.stderr
-    served = release_root / version
-    assert {path.name for path in served.iterdir()} == {
-        *authenticated_payloads,
-        "checksums.txt",
-        "checksums.txt.sig",
-        "checksums.txt.pem",
-    }
-    for name, payload in authenticated_payloads.items():
-        assert (served / name).read_bytes() == payload
+    for version, authenticated_payloads in payloads_by_version.items():
+        served = release_root / version
+        assert {path.name for path in served.iterdir()} == {
+            *authenticated_payloads,
+            "checksums.txt",
+            "checksums.txt.sig",
+            "checksums.txt.pem",
+        }
+        for name, payload in authenticated_payloads.items():
+            assert (served / name).read_bytes() == payload
 
 
 def test_field_recovery_source_authentication_precedes_local_server_start() -> None:
@@ -1994,7 +2007,7 @@ def test_field_recovery_verifier_accepts_absent_optional_bundle_but_rejects_unsa
     expected_success: bool,
 ) -> None:
     protocol = PROTOCOL_SCRIPT.read_text(encoding="utf-8")
-    failure = '|| die "clean 0.8.6 field-recovery verification failed"'
+    failure = '|| die "published ${baseline} field-recovery verification failed"'
     failure_offset = protocol.index(failure)
     body = protocol.index("\n", failure_offset) + 1
     end = protocol.index("\nPY\n", body)
@@ -2047,6 +2060,7 @@ def test_field_recovery_verifier_accepts_absent_optional_bundle_but_rejects_unsa
             hashlib.sha256(source_config).hexdigest(),
             hashlib.sha256(source_environment).hexdigest(),
             "0.8.8",
+            "0.8.6",
         ],
         input=verifier,
         text=True,

--- a/cli/tests/test_upgrade_release_smoke_contract.py
+++ b/cli/tests/test_upgrade_release_smoke_contract.py
@@ -1885,7 +1885,7 @@ def test_field_recovery_lane_reproduces_exact_published_086_and_087_first_run() 
     assert "prepare_fresh_v8_config(cfg)" not in protocol
     assert '"${SMOKE_HOME}/.defenseclaw/.venv/bin/defenseclaw" init' in protocol
     assert "published {source_version} unexpectedly created a migration cursor" in protocol
-    assert "Authenticated the exact published ${baseline} missing-cursor compatibility state" in protocol
+    assert "Accepted exact public ${baseline} cursorless first-run state" in protocol
     assert "for source_version in 0.8.6 0.8.7" in protocol
     assert 'resolver_path="${curl_shim}:/usr/bin:/bin:/usr/sbin:/sbin"' in recovery_function
     assert 'PATH="${resolver_path}"' in recovery_function
@@ -1907,103 +1907,6 @@ def test_field_recovery_lane_reproduces_exact_published_086_and_087_first_run() 
     assert "preserved|recovered" in verification
     assert "corrupt audit recovery retained the discarded legacy fixture" in verification
     assert "corrupt_audit_recovery=fresh_mode_0600" in verification
-
-
-@pytest.mark.skipif(os.name == "nt", reason="executes the POSIX release harness")
-def test_field_recovery_serves_authenticated_086_and_087_source_contracts(
-    tmp_path: Path,
-) -> None:
-    os_name = "linux"
-    arch = "amd64"
-    published = tmp_path / "published"
-    published.mkdir()
-    payloads_by_version: dict[str, dict[str, bytes]] = {}
-    for version in ("0.8.6", "0.8.7"):
-        wheel = f"defenseclaw-{version}-2-py3-none-any.dcwheel"
-        gateway = f"defenseclaw_{version}_protocol2_{os_name}_{arch}.dcgateway"
-        authenticated_payloads = {
-            wheel: f"protected source wheel {version}\n".encode(),
-            gateway: f"protected source gateway {version}\n".encode(),
-            "upgrade-manifest.json": f'{{"release_version":"{version}"}}\n'.encode(),
-            "release-provenance.json": f'{{"release_version":"{version}"}}\n'.encode(),
-        }
-        payloads_by_version[version] = authenticated_payloads
-        release = published / version
-        release.mkdir()
-        for name, payload in authenticated_payloads.items():
-            (release / name).write_bytes(payload)
-        (release / "checksums.txt").write_text(
-            "".join(
-                f"{hashlib.sha256(payload).hexdigest()}  {name}\n" for name, payload in authenticated_payloads.items()
-            ),
-            encoding="utf-8",
-        )
-        (release / "checksums.txt.sig").write_text(
-            "fixture signature\n",
-            encoding="utf-8",
-        )
-        (release / "checksums.txt.pem").write_text(
-            "-----BEGIN CERTIFICATE-----\nZmFrZS1jZXJ0aWZpY2F0ZQ==\n-----END CERTIFICATE-----\n",
-            encoding="utf-8",
-        )
-
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    cosign = fake_bin / "cosign"
-    cosign.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-    cosign.chmod(0o700)
-    workdir = tmp_path / "work"
-    release_root = workdir / "release-root"
-    workdir.mkdir()
-    release_root.mkdir()
-
-    completed = _source_script(
-        """
-trap - EXIT
-WORKDIR="$2"
-RELEASE_ROOT="$3"
-TARGET_VERSION=0.8.8
-OS_NAME=linux
-ARCH_NAME=amd64
-UPGRADE_SMOKE_FIELD_RECOVERY_CASES=1
-fixture="$4"
-download_old_asset() {
-    local name="$1"
-    local destination="$2"
-    local version="$3"
-    cp "${fixture}/${version}/${name}" "${destination}"
-}
-PATH="$5:${PATH}"
-prepare_field_recovery_source_assets
-""",
-        str(workdir),
-        str(release_root),
-        str(published),
-        str(fake_bin),
-    )
-
-    assert completed.returncode == 0, completed.stderr
-    for version, authenticated_payloads in payloads_by_version.items():
-        served = release_root / version
-        assert {path.name for path in served.iterdir()} == {
-            *authenticated_payloads,
-            "checksums.txt",
-            "checksums.txt.sig",
-            "checksums.txt.pem",
-        }
-        for name, payload in authenticated_payloads.items():
-            assert (served / name).read_bytes() == payload
-
-
-def test_field_recovery_source_authentication_precedes_local_server_start() -> None:
-    protocol = PROTOCOL_SCRIPT.read_text(encoding="utf-8")
-    main = protocol[protocol.index("main_protocol_gate() {") :]
-
-    bridge = main.index("prepare_required_bridge_assets")
-    source = main.index("prepare_field_recovery_source_assets")
-    server = main.index("start_release_server")
-
-    assert bridge < source < server
 
 
 @pytest.mark.skipif(os.name == "nt", reason="executes the POSIX field-recovery verifier")

--- a/cli/tests/test_upgrade_release_smoke_contract.py
+++ b/cli/tests/test_upgrade_release_smoke_contract.py
@@ -1325,6 +1325,22 @@ def test_future_candidate_fails_closed_for_unreviewed_source_config_family(
     assert "no reviewed upgrade fixture exists for config-v9 baseline 0.8.6" in completed.stderr
 
 
+def test_missing_cursor_first_run_verifier_uses_published_source_python() -> None:
+    script = PROTOCOL_SCRIPT.read_text(encoding="utf-8")
+    start = script.index(
+        "# Reproduce the real field state through the exact authenticated"
+    )
+    end = script.index("source_config_sha256=", start)
+    verifier = script[start:end]
+
+    assert (
+        '"${SMOKE_HOME}/.defenseclaw/.venv/bin/python" -I -B - \\\n'
+        '            "${SMOKE_HOME}/.defenseclaw" "${baseline}"'
+    ) in verifier
+    assert "\n        python3 -" not in verifier
+    assert "import yaml" in verifier
+
+
 @POSIX_UPGRADE_CUSTODY
 def test_native_v8_fixture_is_strict_and_later_migration_preserves_it(
     tmp_path: Path,

--- a/cli/tests/test_upgrade_smoke_static.py
+++ b/cli/tests/test_upgrade_smoke_static.py
@@ -12,12 +12,15 @@ from __future__ import annotations
 
 import ast
 import hashlib
+import io
 import json
 import os
+import platform
 import re
 import stat
 import subprocess
 import sys
+import tarfile
 import time
 from pathlib import Path
 
@@ -1036,26 +1039,25 @@ def test_posix_resolver_bootstraps_recovery_under_fixed_mutator_lease() -> None:
     assert "_recover_interrupted_hard_cut" in text
 
 
-def test_missing_cursor_authenticator_restores_requested_contract_before_return() -> None:
-    resolver = (ROOT / "scripts/upgrade.sh").read_text(encoding="utf-8")
-    function_start = resolver.index(
-        "authenticate_release_owned_missing_cursor_source() {"
-    )
+def test_cursorless_field_gate_keeps_the_requested_target_contract() -> None:
+    resolver = (ROOT / "scripts" / "upgrade.sh").read_text(encoding="utf-8")
+    function_start = resolver.index("authorize_cursorless_field_recovery() {")
     function_end = resolver.index(
         "\n}\n\n\ncapture_hard_cut_target_controller_contract() {",
         function_start,
     )
-    authenticator = resolver[function_start:function_end]
+    field_gate = resolver[function_start:function_end]
 
-    restore = authenticator.index('RELEASE_VERSION="${requested_version}"')
-    configure = authenticator.index("configure_release", restore)
-    prepare = authenticator.index("prepare_release_contract", configure)
-    success = authenticator.index(
-        'ok "Authenticated the exact published ${source_version}',
-        prepare,
-    )
-    assert restore < configure < prepare < success
-    assert authenticator.count("prepare_release_contract") == 2
+    assert 'CURRENT_VERSION}" == "${source_version}' in field_gate
+    assert 'CURRENT_GATEWAY_VERSION}" == "${source_version}' in field_gate
+    assert 'config["config_version"] != 8' in field_gate
+    assert "migration cursor must be wholly absent" in field_gate
+    assert "phase-one-active.json" in field_gate
+    assert "phase-two-active.json" in field_gate
+    assert field_gate.count("prepare_release_contract") == 1
+    assert 'RELEASE_VERSION="' not in field_gate
+    assert "configure_release" not in field_gate
+    assert "authenticated-source-" not in field_gate
 
     caller_start = resolver.rindex(
         'if [[ -n "${HARD_CUT_CURSOR_RECOVERY_SOURCE_VERSION}" ]]; then'
@@ -1067,7 +1069,7 @@ def test_missing_cursor_authenticator_restores_requested_contract_before_return(
     caller = resolver[caller_start:caller_end]
     assert (
         "then\n"
-        "    authenticate_release_owned_missing_cursor_source\n"
+        "    authorize_cursorless_field_recovery\n"
         "else\n"
         "    prepare_release_contract\n"
         "fi\n"
@@ -1075,7 +1077,7 @@ def test_missing_cursor_authenticator_restores_requested_contract_before_return(
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX phase-two recovery")
-def test_interrupted_phase_two_bootstraps_private_uv_under_clean_path(
+def test_interrupted_phase_two_downloads_pinned_uv_under_clean_path(
     tmp_path: Path,
 ) -> None:
     resolver = (ROOT / "scripts/upgrade.sh").read_text(encoding="utf-8")
@@ -1098,6 +1100,62 @@ def test_interrupted_phase_two_bootstraps_private_uv_under_clean_path(
         resolve_start,
     )
     resolve_function = resolver[resolve_start:resolve_end]
+    uv_assets = {
+        ("Darwin", "x86_64"): (
+            "uv-x86_64-apple-darwin.tar.gz",
+            "uv-x86_64-apple-darwin/uv",
+            "2ad79983127ffca7d77b77ce6a24278d7e4f7b817a1acf72fea5f8124b4aac5e",
+        ),
+        ("Darwin", "arm64"): (
+            "uv-aarch64-apple-darwin.tar.gz",
+            "uv-aarch64-apple-darwin/uv",
+            "33540eb7c883ab857eff79bd5ac2aa31fe27b595abecb4a9c003a2c998447232",
+        ),
+        ("Linux", "x86_64"): (
+            "uv-x86_64-unknown-linux-gnu.tar.gz",
+            "uv-x86_64-unknown-linux-gnu/uv",
+            "e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224",
+        ),
+        ("Linux", "aarch64"): (
+            "uv-aarch64-unknown-linux-gnu.tar.gz",
+            "uv-aarch64-unknown-linux-gnu/uv",
+            "03e9fe0a81b0718d0bc84625de3885df6cc3f89a8b6af6121d6b9f6113fb6533",
+        ),
+        ("Linux", "arm64"): (
+            "uv-aarch64-unknown-linux-gnu.tar.gz",
+            "uv-aarch64-unknown-linux-gnu/uv",
+            "03e9fe0a81b0718d0bc84625de3885df6cc3f89a8b6af6121d6b9f6113fb6533",
+        ),
+    }
+    uv_platform = (platform.system(), platform.machine())
+    if uv_platform not in uv_assets:
+        pytest.skip(f"unsupported uv bootstrap fixture platform: {uv_platform}")
+    uv_asset, uv_member, production_uv_digest = uv_assets[uv_platform]
+    pinned_marker = tmp_path / "pinned-uv-executed"
+    uv_payload = (
+        "#!/bin/sh\n"
+        f"printf executed > {str(pinned_marker)!r}\n"
+        f"if [ \"$#\" -eq 1 ] && [ \"$1\" = \"--version\" ]; then "
+        f"printf 'uv {version_match.group(1)}\\n'; exit 0; fi\n"
+        'printf \'%s|%s\\n\' "$0" "$*" >> "${UV_LOG:?}"\n'
+        "exit 0\n"
+    ).encode()
+    uv_archive = tmp_path / uv_asset
+    with tarfile.open(uv_archive, mode="w:gz") as archive:
+        directory = tarfile.TarInfo(str(Path(uv_member).parent))
+        directory.type = tarfile.DIRTYPE
+        directory.mode = 0o755
+        archive.addfile(directory)
+        executable = tarfile.TarInfo(uv_member)
+        executable.mode = 0o755
+        executable.size = len(uv_payload)
+        archive.addfile(executable, io.BytesIO(uv_payload))
+    fixture_uv_digest = hashlib.sha256(uv_archive.read_bytes()).hexdigest()
+    assert resolve_function.count(production_uv_digest) == 1
+    resolve_function = resolve_function.replace(
+        production_uv_digest,
+        fixture_uv_digest,
+    )
     recovery_start = resolver.index("recover_interrupted_phase_two() {")
     recovery_end = resolver.index(
         "\n}\n\nacquire_upgrade_lock() {",
@@ -1148,14 +1206,11 @@ def test_interrupted_phase_two_bootstraps_private_uv_under_clean_path(
     config.write_text("config_version: 8\n", encoding="utf-8")
     uv_log = tmp_path / "uv.log"
     recovery_log = tmp_path / "recovery-python.log"
+    known_marker = tmp_path / "known-uv-executed"
     known_uv.write_text(
         "#!/bin/sh\n"
-        'if [ "$#" -eq 1 ] && [ "$1" = "--version" ]; then\n'
-        f"  printf '%s\\n' 'uv {version_match.group(1)}'\n"
-        "  exit 0\n"
-        "fi\n"
-        'printf \'%s|%s\\n\' "$0" "$*" >> "${UV_LOG:?}"\n'
-        "exit 0\n",
+        f"printf executed > {str(known_marker)!r}\n"
+        f"printf '%s\\n' 'uv {version_match.group(1)}'\n",
         encoding="utf-8",
     )
     known_uv.chmod(0o755)
@@ -1179,13 +1234,21 @@ def test_interrupted_phase_two_bootstraps_private_uv_under_clean_path(
         "UV_BIN=\"\"\n"
         f'UV_BOOTSTRAP_VERSION="{version_match.group(1)}"\n'
         f'UV_BOOTSTRAP_MAX_BYTES="{maximum_match.group(1)}"\n'
-        'MANAGED_PYTHON_NO_LOCAL_BYTECODE="pycache_prefix=/dev/null"\n'
         "RED=\"\"; GREEN=\"\"; YELLOW=\"\"; BLUE=\"\"; CYAN=\"\"; BOLD=\"\"; DIM=\"\"; NC=\"\"\n"
         'die() { printf "die: %s\\n" "$*" >&2; exit 1; }\n'
         'ok() { printf "ok: %s\\n" "$*"; }\n'
         'warn() { printf "warn: %s\\n" "$*" >&2; }\n'
         'info() { printf "info: %s\\n" "$*"; }\n'
         'section() { printf "section: %s\\n" "$*"; }\n'
+        "curl() {\n"
+        "  local output='' previous=''\n"
+        '  for arg in "$@"; do\n'
+        '    if [[ "${previous}" == "--output" ]]; then output="${arg}"; break; fi\n'
+        '    previous="${arg}"\n'
+        "  done\n"
+        '  [[ -n "${output}" ]] || return 94\n'
+        f"  cp {str(uv_archive)!r} \"${{output}}\"\n"
+        "}\n"
         + staging_functions
         + resolve_function
         + "\n"
@@ -1221,6 +1284,8 @@ def test_interrupted_phase_two_bootstraps_private_uv_under_clean_path(
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert "private-uv=" in completed.stdout
     assert "/upgrade-tools/uv" in completed.stdout
+    assert not known_marker.exists()
+    assert pinned_marker.read_text(encoding="utf-8") == "executed"
     assert str(known_uv) not in uv_log.read_text(encoding="utf-8")
 
 

--- a/cli/tests/test_upgrade_smoke_static.py
+++ b/cli/tests/test_upgrade_smoke_static.py
@@ -1036,6 +1036,44 @@ def test_posix_resolver_bootstraps_recovery_under_fixed_mutator_lease() -> None:
     assert "_recover_interrupted_hard_cut" in text
 
 
+def test_missing_cursor_authenticator_restores_requested_contract_before_return() -> None:
+    resolver = (ROOT / "scripts/upgrade.sh").read_text(encoding="utf-8")
+    function_start = resolver.index(
+        "authenticate_release_owned_missing_cursor_source() {"
+    )
+    function_end = resolver.index(
+        "\n}\n\n\ncapture_hard_cut_target_controller_contract() {",
+        function_start,
+    )
+    authenticator = resolver[function_start:function_end]
+
+    restore = authenticator.index('RELEASE_VERSION="${requested_version}"')
+    configure = authenticator.index("configure_release", restore)
+    prepare = authenticator.index("prepare_release_contract", configure)
+    success = authenticator.index(
+        'ok "Authenticated the exact published ${source_version}',
+        prepare,
+    )
+    assert restore < configure < prepare < success
+    assert authenticator.count("prepare_release_contract") == 2
+
+    caller_start = resolver.rindex(
+        'if [[ -n "${HARD_CUT_CURSOR_RECOVERY_SOURCE_VERSION}" ]]; then'
+    )
+    caller_end = resolver.index(
+        'FINAL_RELEASE_PROVENANCE_BRIDGE_CHECKSUMS_SHA256="',
+        caller_start,
+    )
+    caller = resolver[caller_start:caller_end]
+    assert (
+        "then\n"
+        "    authenticate_release_owned_missing_cursor_source\n"
+        "else\n"
+        "    prepare_release_contract\n"
+        "fi\n"
+    ) in caller
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX phase-two recovery")
 def test_interrupted_phase_two_bootstraps_private_uv_under_clean_path(
     tmp_path: Path,
@@ -1049,7 +1087,8 @@ def test_interrupted_phase_two_bootstraps_private_uv_under_clean_path(
         r'readonly UV_BOOTSTRAP_MAX_BYTES="([^"]+)"',
         resolver,
     )
-    assert version_match is not None and maximum_match is not None
+    assert version_match is not None
+    assert maximum_match is not None
 
     staging_start = resolver.index("prepare_upgrade_staging() {")
     resolve_start = resolver.index("resolve_upgrade_uv() {", staging_start)

--- a/cli/tests/test_upgrade_smoke_static.py
+++ b/cli/tests/test_upgrade_smoke_static.py
@@ -1087,6 +1087,14 @@ def test_interrupted_phase_two_bootstraps_private_uv_under_clean_path(
     recovery.mkdir(parents=True)
     recovery.chmod(0o700)
     venv_python.parent.mkdir(parents=True)
+    (
+        controller_home
+        / ".venv"
+        / "lib"
+        / "python3.12"
+        / "site-packages"
+        / "defenseclaw"
+    ).mkdir(parents=True)
     known_uv.parent.mkdir(parents=True)
     journal = recovery / "phase-two-active.json"
     journal.write_text("{}\n", encoding="utf-8")
@@ -1132,6 +1140,7 @@ def test_interrupted_phase_two_bootstraps_private_uv_under_clean_path(
         "UV_BIN=\"\"\n"
         f'UV_BOOTSTRAP_VERSION="{version_match.group(1)}"\n'
         f'UV_BOOTSTRAP_MAX_BYTES="{maximum_match.group(1)}"\n'
+        'MANAGED_PYTHON_NO_LOCAL_BYTECODE="pycache_prefix=/dev/null"\n'
         "RED=\"\"; GREEN=\"\"; YELLOW=\"\"; BLUE=\"\"; CYAN=\"\"; BOLD=\"\"; DIM=\"\"; NC=\"\"\n"
         'die() { printf "die: %s\\n" "$*" >&2; exit 1; }\n'
         'ok() { printf "ok: %s\\n" "$*"; }\n'

--- a/cli/tests/test_upgrade_smoke_static.py
+++ b/cli/tests/test_upgrade_smoke_static.py
@@ -1030,7 +1030,150 @@ def test_posix_resolver_bootstraps_recovery_under_fixed_mutator_lease() -> None:
     assert 'for name in ("UV_CONSTRAINT", "UV_OVERRIDE", "UV_EXCLUDE_NEWER")' in recovery
     assert "uv_environment.pop(name, None)" in recovery
     assert "env=uv_environment" in recovery
+    assert "command -v uv" not in recovery
+    assert recovery.index("prepare_upgrade_staging") < recovery.index("resolve_upgrade_uv")
+    assert 'uv_bin="${UV_BIN}"' in recovery
     assert "_recover_interrupted_hard_cut" in text
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX phase-two recovery")
+def test_interrupted_phase_two_bootstraps_private_uv_under_clean_path(
+    tmp_path: Path,
+) -> None:
+    resolver = (ROOT / "scripts/upgrade.sh").read_text(encoding="utf-8")
+    version_match = re.search(
+        r'readonly UV_BOOTSTRAP_VERSION="([^"]+)"',
+        resolver,
+    )
+    maximum_match = re.search(
+        r'readonly UV_BOOTSTRAP_MAX_BYTES="([^"]+)"',
+        resolver,
+    )
+    assert version_match is not None and maximum_match is not None
+
+    staging_start = resolver.index("prepare_upgrade_staging() {")
+    resolve_start = resolver.index("resolve_upgrade_uv() {", staging_start)
+    staging_functions = resolver[staging_start:resolve_start]
+    resolve_end = resolver.index(
+        "\n\n# Keep one bounded, fail-closed parser",
+        resolve_start,
+    )
+    resolve_function = resolver[resolve_start:resolve_end]
+    recovery_start = resolver.index("recover_interrupted_phase_two() {")
+    recovery_end = resolver.index(
+        "\n}\n\nacquire_upgrade_lock() {",
+        recovery_start,
+    ) + len("\n}\n")
+    recovery_function = resolver[recovery_start:recovery_end]
+    parser_start = recovery_function.index(
+        '    recovery_fields="$(python3 - "${journal}" "${DEFENSECLAW_HOME}"'
+    )
+    parser_end = recovery_function.index(
+        '    wheel="$(printf',
+        parser_start,
+    )
+    recovery_function = (
+        recovery_function[:parser_start]
+        + "    recovery_fields=\"$(printf '%s\\n' "
+        + '"${TEST_WHEEL}" "${TEST_WHEEL_SHA256}" pending "${TEST_CONFIG}")"\n'
+        + recovery_function[parser_end:]
+    )
+
+    home = tmp_path / "home"
+    controller_home = home / ".defenseclaw"
+    recovery = controller_home / ".upgrade-recovery"
+    venv_python = controller_home / ".venv" / "bin" / "python"
+    known_uv = home / ".local" / "bin" / "uv"
+    recovery.mkdir(parents=True)
+    recovery.chmod(0o700)
+    venv_python.parent.mkdir(parents=True)
+    known_uv.parent.mkdir(parents=True)
+    journal = recovery / "phase-two-active.json"
+    journal.write_text("{}\n", encoding="utf-8")
+    journal.chmod(0o600)
+    lease = recovery / "phase-two-mutator.lease"
+    lease.write_text("", encoding="utf-8")
+    lease.chmod(0o600)
+    wheel = tmp_path / "retained-bridge.whl"
+    wheel.write_bytes(b"authenticated retained bridge")
+    wheel_sha256 = hashlib.sha256(wheel.read_bytes()).hexdigest()
+    config = controller_home / "config.yaml"
+    config.write_text("config_version: 8\n", encoding="utf-8")
+    uv_log = tmp_path / "uv.log"
+    recovery_log = tmp_path / "recovery-python.log"
+    known_uv.write_text(
+        "#!/bin/sh\n"
+        'if [ "$#" -eq 1 ] && [ "$1" = "--version" ]; then\n'
+        f"  printf '%s\\n' 'uv {version_match.group(1)}'\n"
+        "  exit 0\n"
+        "fi\n"
+        'printf \'%s|%s\\n\' "$0" "$*" >> "${UV_LOG:?}"\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    known_uv.chmod(0o755)
+    venv_python.write_text(
+        "#!/bin/sh\n"
+        'printf \'%s\\n\' "$*" >> "${RECOVERY_PYTHON_LOG:?}"\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    venv_python.chmod(0o755)
+
+    harness = (
+        "set -euo pipefail\n"
+        "umask 077\n"
+        'HOME="${TEST_HOME}"\n'
+        'DEFENSECLAW_HOME="${TEST_CONTROLLER_HOME}"\n'
+        'CONTROLLER_HOME="${DEFENSECLAW_HOME}"\n'
+        'DEFENSECLAW_VENV="${DEFENSECLAW_HOME}/.venv"\n'
+        "PLAN_ONLY=0\n"
+        "STAGING_DIR=\"\"\n"
+        "UV_BIN=\"\"\n"
+        f'UV_BOOTSTRAP_VERSION="{version_match.group(1)}"\n'
+        f'UV_BOOTSTRAP_MAX_BYTES="{maximum_match.group(1)}"\n'
+        "RED=\"\"; GREEN=\"\"; YELLOW=\"\"; BLUE=\"\"; CYAN=\"\"; BOLD=\"\"; DIM=\"\"; NC=\"\"\n"
+        'die() { printf "die: %s\\n" "$*" >&2; exit 1; }\n'
+        'ok() { printf "ok: %s\\n" "$*"; }\n'
+        'warn() { printf "warn: %s\\n" "$*" >&2; }\n'
+        'info() { printf "info: %s\\n" "$*"; }\n'
+        'section() { printf "section: %s\\n" "$*"; }\n'
+        + staging_functions
+        + resolve_function
+        + "\n"
+        + recovery_function
+        + "\nrecover_interrupted_phase_two\n"
+        + 'case "${UV_BIN}" in "${STAGING_DIR}/upgrade-tools/uv") ;; *) exit 97 ;; esac\n'
+        + 'grep -F -- "--offline --no-deps --reinstall" "${UV_LOG}" >/dev/null\n'
+        + 'grep -F -- "_recover_interrupted_hard_cut" "${RECOVERY_PYTHON_LOG}" >/dev/null\n'
+        + 'printf "private-uv=%s\\n" "${UV_BIN}"\n'
+        + "cleanup_upgrade_staging\n"
+    )
+    environment = {
+        **os.environ,
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+        "TEST_HOME": str(home),
+        "TEST_CONTROLLER_HOME": str(controller_home),
+        "TEST_WHEEL": str(wheel),
+        "TEST_WHEEL_SHA256": wheel_sha256,
+        "TEST_CONFIG": str(config),
+        "UV_LOG": str(uv_log),
+        "RECOVERY_PYTHON_LOG": str(recovery_log),
+    }
+    completed = subprocess.run(
+        ["/bin/bash", "-c", harness],
+        cwd=ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "private-uv=" in completed.stdout
+    assert "/upgrade-tools/uv" in completed.stdout
+    assert str(known_uv) not in uv_log.read_text(encoding="utf-8")
 
 
 def test_release_resolver_isolated_python_never_writes_bytecode() -> None:
@@ -1267,7 +1410,7 @@ def test_posix_resolver_normalizes_every_bridge_through_one_authenticated_handof
     continuation_start = resolver.index("continue_post_hard_cut_upgrade() {")
     continuation_end = resolver.index("\n}\n\nvalidate_tarball_members() {", continuation_start)
     continuation = resolver[continuation_start:continuation_end]
-    remove_staging = continuation.index('rm -rf "${STAGING_DIR}"')
+    remove_staging = continuation.index("cleanup_upgrade_staging")
     final_upgrade = continuation.index(
         '"${DEFENSECLAW_VENV}/bin/defenseclaw" upgrade --yes --version "${final_version}"',
         remove_staging,

--- a/cli/tests/test_upgrade_smoke_static.py
+++ b/cli/tests/test_upgrade_smoke_static.py
@@ -1116,6 +1116,11 @@ def test_interrupted_phase_two_downloads_pinned_uv_under_clean_path(
             "uv-x86_64-unknown-linux-gnu/uv",
             "e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224",
         ),
+        ("Linux", "amd64"): (
+            "uv-x86_64-unknown-linux-gnu.tar.gz",
+            "uv-x86_64-unknown-linux-gnu/uv",
+            "e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224",
+        ),
         ("Linux", "aarch64"): (
             "uv-aarch64-unknown-linux-gnu.tar.gz",
             "uv-aarch64-unknown-linux-gnu/uv",

--- a/cli/tests/test_upgrade_staged_resolver.py
+++ b/cli/tests/test_upgrade_staged_resolver.py
@@ -20,29 +20,60 @@ import hashlib
 import io
 import json
 import os
+import platform
+import re
 import shutil
 import sqlite3
 import subprocess
 import sys
 import tarfile
 import zipfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import pytest
 from defenseclaw import resolver_hint
 
 ROOT = Path(__file__).resolve().parents[2]
 UPGRADE_SCRIPT = ROOT / "scripts" / "upgrade.sh"
-_CLEAN_086_GATEWAY_PAYLOAD = (
-    b"#!/usr/bin/env bash\n"
-    b'if [[ "${1:-}" == "--version" ]]; then echo \'DefenseClaw gateway 0.8.6\'; exit 0; fi\n'
-    b"exit 0\n"
+_UPGRADE_SOURCE = UPGRADE_SCRIPT.read_text(encoding="utf-8")
+_UV_BOOTSTRAP_VERSION_MATCH = re.search(
+    r'readonly UV_BOOTSTRAP_VERSION="([^"]+)"',
+    _UPGRADE_SOURCE,
 )
+assert _UV_BOOTSTRAP_VERSION_MATCH is not None, "uv bootstrap version constant moved"
+UV_BOOTSTRAP_VERSION = _UV_BOOTSTRAP_VERSION_MATCH.group(1)
 _STAGED_COSIGN_SHA256_BY_ASSET = {
     "cosign-darwin-amd64": resolver_hint.COSIGN_BOOTSTRAP_SHA256[("darwin", "amd64")],
     "cosign-darwin-arm64": resolver_hint.COSIGN_BOOTSTRAP_SHA256[("darwin", "arm64")],
     "cosign-linux-amd64": resolver_hint.COSIGN_BOOTSTRAP_SHA256[("linux", "amd64")],
     "cosign-linux-arm64": resolver_hint.COSIGN_BOOTSTRAP_SHA256[("linux", "arm64")],
+}
+_UV_BOOTSTRAP_ASSETS = {
+    ("Darwin", "x86_64"): (
+        "uv-x86_64-apple-darwin.tar.gz",
+        "uv-x86_64-apple-darwin/uv",
+        "2ad79983127ffca7d77b77ce6a24278d7e4f7b817a1acf72fea5f8124b4aac5e",
+    ),
+    ("Darwin", "arm64"): (
+        "uv-aarch64-apple-darwin.tar.gz",
+        "uv-aarch64-apple-darwin/uv",
+        "33540eb7c883ab857eff79bd5ac2aa31fe27b595abecb4a9c003a2c998447232",
+    ),
+    ("Linux", "x86_64"): (
+        "uv-x86_64-unknown-linux-gnu.tar.gz",
+        "uv-x86_64-unknown-linux-gnu/uv",
+        "e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224",
+    ),
+    ("Linux", "aarch64"): (
+        "uv-aarch64-unknown-linux-gnu.tar.gz",
+        "uv-aarch64-unknown-linux-gnu/uv",
+        "03e9fe0a81b0718d0bc84625de3885df6cc3f89a8b6af6121d6b9f6113fb6533",
+    ),
+    ("Linux", "arm64"): (
+        "uv-aarch64-unknown-linux-gnu.tar.gz",
+        "uv-aarch64-unknown-linux-gnu/uv",
+        "03e9fe0a81b0718d0bc84625de3885df6cc3f89a8b6af6121d6b9f6113fb6533",
+    ),
 }
 
 pytestmark = pytest.mark.skipif(
@@ -54,6 +85,32 @@ pytestmark = pytest.mark.skipif(
 def _write_executable(path: Path, body: str) -> None:
     path.write_text(body, encoding="utf-8")
     path.chmod(0o755)
+
+
+def _uv_shim_payload() -> bytes:
+    return (
+        b"#!/usr/bin/env bash\n"
+        b"set -euo pipefail\n"
+        b'if [[ "$#" -eq 1 && "$1" == "--version" ]]; then\n'
+        + f"    printf 'uv {UV_BOOTSTRAP_VERSION}\\n'\n".encode()
+        + b"    exit 0\n"
+        b"fi\n"
+        b"""printf '%s\\n' "$*" >> "${UV_LOG}"\n"""
+        b'if [[ "$#" -eq 10'
+        b' && "$1" == "--no-config"'
+        b' && "$2" == "pip"'
+        b' && "$3" == "install"'
+        b' && "$4" == "--python"'
+        b' && "$5" == "${DEFENSECLAW_HOME}/.venv/bin/python"'
+        b' && "$6" == "--dry-run"'
+        b' && "$7" == "--quiet"'
+        b' && "$8" == "--only-binary"'
+        b' && "$9" == "litellm"'
+        b' && "${10}" == */authenticated-source-0.8.[67]/defenseclaw-0.8.[67]-2-py3-none-any.whl ]]; then\n'
+        b"    exit 0\n"
+        b"fi\n"
+        b"exit 99\n"
+    )
 
 
 def _manifest(version: str) -> dict[str, object]:
@@ -141,15 +198,28 @@ def _protected(payload: bytes) -> bytes:
     return b"DEFENSECLAW-PROTECTED-ARTIFACT-V1\n" + bytes(value ^ 0xA5 for value in payload)
 
 
-def _clean_086_package_files() -> dict[str, bytes]:
+def _source_gateway_payload(version: str) -> bytes:
+    assert version in {"0.8.6", "0.8.7"}
+    return (
+        b"#!/usr/bin/env bash\n"
+        + f'if [[ "${{1:-}}" == "--version" ]]; then echo \'DefenseClaw gateway {version}\'; exit 0; fi\n'.encode()
+        + b"exit 0\n"
+    )
+
+
+def _source_package_files(version: str) -> dict[str, bytes]:
+    assert version in {"0.8.6", "0.8.7"}
     return {
-        "defenseclaw/__init__.py": b'__version__ = "0.8.6"\n',
+        "defenseclaw/__init__.py": f'__version__ = "{version}"\n'.encode(),
         "defenseclaw/config.py": (
-            b"import os\n"
+            b"import json, os\n"
             b"from types import SimpleNamespace\n"
             b"def load():\n"
             b"    home = os.environ['DEFENSECLAW_HOME']\n"
-            b"    return SimpleNamespace(data_dir=home, claw=SimpleNamespace(home_dir=os.path.join(os.environ['HOME'], '.openclaw')))\n"
+            b"    with open(os.environ.get('DEFENSECLAW_CONFIG', os.path.join(home, 'config.yaml')), encoding='utf-8') as stream:\n"
+            b"        config = json.load(stream)\n"
+            b"    return SimpleNamespace(data_dir=config.get('data_dir', home), audit_db=config.get('audit_db', ''), "
+            b"claw=SimpleNamespace(home_dir=os.path.join(os.environ['HOME'], '.openclaw')))\n"
         ),
         "defenseclaw/observability/__init__.py": b"",
         "defenseclaw/observability/v8_config.py": (
@@ -164,35 +234,36 @@ def _clean_086_package_files() -> dict[str, bytes]:
             b"    if type(source.get('config_version')) is not int or source['config_version'] != 8: raise ValueError('invalid v8 config')\n"
             b"    return Validated(source)\n"
         ),
-        "defenseclaw/_data/local_observability_stack/README.md": b"authenticated clean 0.8.6 stack\n",
+        "defenseclaw/_data/local_observability_stack/README.md": (f"authenticated clean {version} stack\n".encode()),
     }
 
 
-def _clean_086_wheel() -> bytes:
+def _source_wheel(version: str) -> bytes:
     output = io.BytesIO()
-    package_files = _clean_086_package_files()
+    package_files = _source_package_files(version)
     with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         for name, payload in package_files.items():
             archive.writestr(name, payload)
         archive.writestr(
-            "defenseclaw-0.8.6.dist-info/METADATA",
-            "Metadata-Version: 2.1\nName: defenseclaw\nVersion: 0.8.6\n",
+            f"defenseclaw-{version}.dist-info/METADATA",
+            f"Metadata-Version: 2.1\nName: defenseclaw\nVersion: {version}\n",
         )
         archive.writestr(
-            "defenseclaw-0.8.6.dist-info/WHEEL",
+            f"defenseclaw-{version}.dist-info/WHEEL",
             "Wheel-Version: 1.0\nGenerator: test\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
         )
-        archive.writestr("defenseclaw-0.8.6.dist-info/RECORD", "")
+        archive.writestr(f"defenseclaw-{version}.dist-info/RECORD", "")
     return output.getvalue()
 
 
-def _clean_086_gateway_archive() -> bytes:
+def _source_gateway_archive(version: str) -> bytes:
     output = io.BytesIO()
     with tarfile.open(fileobj=output, mode="w:gz") as archive:
         info = tarfile.TarInfo("defenseclaw")
         info.mode = 0o755
-        info.size = len(_CLEAN_086_GATEWAY_PAYLOAD)
-        archive.addfile(info, io.BytesIO(_CLEAN_086_GATEWAY_PAYLOAD))
+        payload = _source_gateway_payload(version)
+        info.size = len(payload)
+        archive.addfile(info, io.BytesIO(payload))
     return output.getvalue()
 
 
@@ -230,6 +301,22 @@ def resolver_env(tmp_path: Path):
         fake_bin.mkdir(exist_ok=True)
         home.mkdir(exist_ok=True)
 
+        uv_platform = (platform.system(), platform.machine())
+        if uv_platform not in _UV_BOOTSTRAP_ASSETS:
+            pytest.skip(f"unsupported uv bootstrap fixture platform: {uv_platform}")
+        uv_asset, uv_member, uv_production_digest = _UV_BOOTSTRAP_ASSETS[uv_platform]
+        uv_archive = fixtures / uv_asset
+        with tarfile.open(uv_archive, mode="w:gz") as archive:
+            directory = tarfile.TarInfo(str(PurePosixPath(uv_member).parent))
+            directory.type = tarfile.DIRTYPE
+            directory.mode = 0o755
+            archive.addfile(directory)
+            payload = _uv_shim_payload()
+            executable = tarfile.TarInfo(uv_member)
+            executable.mode = 0o755
+            executable.size = len(payload)
+            archive.addfile(executable, io.BytesIO(payload))
+
         bridge_checksums_sha256 = ""
         for version in ("0.8.4", "0.8.5", "0.8.6", "0.8.7", "0.8.8"):
             release_dir = fixtures / version
@@ -243,7 +330,9 @@ def resolver_env(tmp_path: Path):
             wheel_name = release_artifacts["wheel"]
             assert isinstance(wheel_name, str)
             wheel = release_dir / wheel_name
-            wheel_payload = _clean_086_wheel() if version == "0.8.6" else b"resolver target wheel fixture"
+            wheel_payload = (
+                _source_wheel(version) if version in {"0.8.6", "0.8.7"} else b"resolver target wheel fixture"
+            )
             wheel.write_bytes(_protected(wheel_payload))
             checksum_rows.append(f"{hashlib.sha256(wheel.read_bytes()).hexdigest()}  {wheel.name}")
             gateways = release_artifacts["gateways"]
@@ -254,11 +343,13 @@ def resolver_env(tmp_path: Path):
                     assert isinstance(gateway_name, str)
                     gateway = release_dir / gateway_name
                     gateway_payload = (
-                        _clean_086_gateway_archive()
-                        if version == "0.8.6"
+                        _source_gateway_archive(version)
+                        if version in {"0.8.6", "0.8.7"}
                         else f"gateway fixture {gateway_name}\n".encode()
                     )
-                    gateway.write_bytes(_protected(gateway_payload) if version == "0.8.6" else gateway_payload)
+                    gateway.write_bytes(
+                        _protected(gateway_payload) if version in {"0.8.6", "0.8.7"} else gateway_payload
+                    )
                     checksum_rows.append(f"{hashlib.sha256(gateway.read_bytes()).hexdigest()}  {gateway.name}")
             if version in {"0.8.5", "0.8.6", "0.8.7", "0.8.8"}:
                 provenance = (
@@ -298,26 +389,9 @@ def resolver_env(tmp_path: Path):
             fake_bin / "cosign",
             '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "${COSIGN_LOG}"\nexit 0\n',
         )
-        _write_executable(
-            fake_bin / "uv",
-            "#!/usr/bin/env bash\n"
-            "set -euo pipefail\n"
-            'printf \'%s\\n\' "$*" >> "${UV_LOG}"\n'
-            'if [[ "$#" -eq 10'
-            ' && "$1" == "--no-config"'
-            ' && "$2" == "pip"'
-            ' && "$3" == "install"'
-            ' && "$4" == "--python"'
-            ' && "$5" == "${DEFENSECLAW_HOME}/.venv/bin/python"'
-            ' && "$6" == "--dry-run"'
-            ' && "$7" == "--quiet"'
-            ' && "$8" == "--only-binary"'
-            ' && "$9" == "litellm"'
-            ' && "${10}" == */authenticated-source-0.8.6/defenseclaw-0.8.6-2-py3-none-any.whl ]]; then\n'
-            "    exit 0\n"
-            "fi\n"
-            "exit 99\n",
-        )
+        uv_path = fake_bin / "uv"
+        uv_path.write_bytes(_uv_shim_payload())
+        uv_path.chmod(0o755)
         _write_executable(
             fake_bin / "sha256sum",
             """#!/usr/bin/env bash
@@ -378,6 +452,11 @@ exit 0
 COSIGN
     exit 0
 fi
+if [[ "${url}" == https://github.com/astral-sh/uv/releases/download/* ]]; then
+    [[ -n "${out}" ]] || exit 94
+    cp "${UV_BOOTSTRAP_ARCHIVE}" "${out}"
+    exit 0
+fi
 version=''
 case "${url}" in
     */releases/download/0.8.4/*) version='0.8.4' ;;
@@ -389,6 +468,12 @@ esac
 [[ -n "${version}" && -n "${out}" ]] || exit 96
 name="${url##*/}"
 cp "${FIXTURE_ROOT}/${version}/${name}" "${out}"
+if [[ "${name}" == defenseclaw_*_protocol2_darwin_* \
+      && "${OMIT_GATEWAY_FIXTURE_MARKER:-0}" != '1' ]]; then
+    printf '%s\n' 'defenseclaw-gateway-fixture-v1' \
+        > "$(dirname -- "${out}")/.defenseclaw-gateway-fixture-v1"
+    chmod 600 "$(dirname -- "${out}")/.defenseclaw-gateway-fixture-v1"
+fi
 """,
         )
 
@@ -414,6 +499,10 @@ cp "${FIXTURE_ROOT}/${version}/${name}" "${out}"
                 "CURL_LOG": str(curl_log),
                 "COSIGN_LOG": str(cosign_log),
                 "UV_LOG": str(uv_log),
+                "UV_BOOTSTRAP_ARCHIVE": str(uv_archive),
+                "UV_BOOTSTRAP_ASSET": uv_asset,
+                "UV_BOOTSTRAP_PRODUCTION_DIGEST": uv_production_digest,
+                "DEFENSECLAW_UPGRADE_TEST_MODE": "1",
                 "NO_COLOR": "1",
             }
         )
@@ -440,7 +529,11 @@ def test_resolver_env_excludes_ambient_observability_decisions(
     assert all(name not in env for name in names)
 
 
-def _install_clean_086_state(env: dict[str, str]) -> tuple[Path, Path]:
+def _install_release_owned_missing_cursor_state(
+    env: dict[str, str],
+    version: str,
+) -> tuple[Path, Path]:
+    assert version in {"0.8.6", "0.8.7"}
     data_home = Path(env["DEFENSECLAW_HOME"])
     data_home.mkdir()
     config_path = data_home / "config.yaml"
@@ -466,7 +559,7 @@ def _install_clean_086_state(env: dict[str, str]) -> tuple[Path, Path]:
     site_packages = data_home / ".venv" / "lib" / "python3.12" / "site-packages"
     package_root = site_packages / "defenseclaw"
     package_root.mkdir(parents=True)
-    for name, payload in _clean_086_package_files().items():
+    for name, payload in _source_package_files(version).items():
         relative = Path(name).relative_to("defenseclaw")
         destination = package_root / relative
         destination.parent.mkdir(parents=True, exist_ok=True)
@@ -486,14 +579,22 @@ def _install_clean_086_state(env: dict[str, str]) -> tuple[Path, Path]:
     )
 
     gateway = Path(env["HOME"]) / ".local" / "bin" / "defenseclaw-gateway"
-    gateway.write_bytes(_CLEAN_086_GATEWAY_PAYLOAD)
+    gateway.write_bytes(_source_gateway_payload(version))
     gateway.chmod(0o755)
     return config_path, stack
 
 
 def _run(env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
+    return _run_script(UPGRADE_SCRIPT, env, *args)
+
+
+def _run_script(
+    script: Path,
+    env: dict[str, str],
+    *args: str,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["bash", str(UPGRADE_SCRIPT), "--yes", *args],
+        ["bash", str(script), "--yes", *args],
         cwd=ROOT,
         env=env,
         text=True,
@@ -805,28 +906,30 @@ def test_manual_hard_cut_artifacts_over_v7_state_refuse_before_release_download(
     ((False, False), (True, False), (False, True)),
     ids=("retained-clean-no-stack", "exact-authenticated-stack", "valid-unrelated-llm-change"),
 )
-def test_clean_086_missing_cursor_authenticates_recovery_without_mutation(
+@pytest.mark.parametrize("source_version", ("0.8.6", "0.8.7"))
+def test_release_owned_missing_cursor_authenticates_recovery_without_mutation(
     resolver_env,
     local_stack: bool,
     unrelated_change: bool,
+    source_version: str,
 ) -> None:
-    env, mutation_log, curl_log = resolver_env("0.8.6")
-    config_path, stack = _install_clean_086_state(env)
+    env, mutation_log, curl_log = resolver_env(source_version)
+    config_path, stack = _install_release_owned_missing_cursor_state(env, source_version)
     if local_stack:
         stack.mkdir()
-        (stack / "README.md").write_bytes(b"authenticated clean 0.8.6 stack\n")
+        (stack / "README.md").write_bytes(f"authenticated clean {source_version} stack\n".encode())
     if unrelated_change:
         document = json.loads(config_path.read_text(encoding="utf-8"))
         document["llm"]["model"] = "operator-selected-model"
         config_path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
     before = config_path.read_bytes()
 
-    result = _run(env, "--version", "0.8.7", "--plan")
+    result = _run(env, "--version", "0.8.8", "--plan")
 
     output = result.stdout + result.stderr
     assert result.returncode == 0, output
-    assert "Authenticated the exact clean 0.8.6 missing-cursor compatibility state" in output
-    assert "0.8.6 → 0.8.7" in output
+    assert f"Authenticated the exact published {source_version} missing-cursor compatibility state" in output
+    assert f"{source_version} → 0.8.8" in output
     assert config_path.read_bytes() == before
     assert not (Path(env["DEFENSECLAW_HOME"]) / ".migration_state.json").exists()
     assert not mutation_log.exists()
@@ -834,10 +937,185 @@ def test_clean_086_missing_cursor_authenticates_recovery_without_mutation(
     assert uv_invocation[:4] == ["--no-config", "pip", "install", "--python"]
     assert uv_invocation[4] == f"{env['DEFENSECLAW_HOME']}/.venv/bin/python"
     assert uv_invocation[5:9] == ["--dry-run", "--quiet", "--only-binary", "litellm"]
-    assert Path(uv_invocation[9]).name == "defenseclaw-0.8.6-2-py3-none-any.whl"
+    assert Path(uv_invocation[9]).name == f"defenseclaw-{source_version}-2-py3-none-any.whl"
     downloads = curl_log.read_text(encoding="utf-8")
-    assert "/releases/download/0.8.6/release-provenance.json" in downloads
-    assert "defenseclaw-0.8.6-2-py3-none-any.dcwheel" in downloads
+    assert f"/releases/download/{source_version}/release-provenance.json" in downloads
+    assert f"defenseclaw-{source_version}-2-py3-none-any.dcwheel" in downloads
+    assert f"defenseclaw_{source_version}_protocol2_" in downloads
+
+
+def test_release_owned_missing_cursor_uses_known_uv_outside_clean_path(
+    resolver_env,
+) -> None:
+    env, mutation_log, _curl_log = resolver_env("0.8.7")
+    config_path, _stack = _install_release_owned_missing_cursor_state(env, "0.8.7")
+    fake_bin = Path(env["PATH"].split(os.pathsep, 1)[0])
+    known_uv = Path(env["HOME"]) / ".local" / "bin" / "uv"
+    shutil.move(fake_bin / "uv", known_uv)
+    env["PATH"] = f"{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin"
+    assert shutil.which("uv", path=env["PATH"]) is None
+
+    result = _run(env, "--version", "0.8.8", "--plan")
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert "Copied uv into private upgrade custody" in output
+    assert "Pinned uv" not in output
+    assert "Authenticated the exact published 0.8.7 missing-cursor compatibility state" in output
+    assert config_path.is_file()
+    assert not mutation_log.exists()
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="macOS gateway format gate")
+@pytest.mark.parametrize("missing_gate", ("fixture-marker", "test-mode"))
+def test_non_macho_gateway_fixture_requires_test_mode_and_private_marker(
+    resolver_env,
+    missing_gate: str,
+) -> None:
+    env, mutation_log, _curl_log = resolver_env("0.8.7")
+    _install_release_owned_missing_cursor_state(env, "0.8.7")
+    assert env["DEFENSECLAW_UPGRADE_TEST_MODE"] == "1"
+    if missing_gate == "fixture-marker":
+        env["OMIT_GATEWAY_FIXTURE_MARKER"] = "1"
+    else:
+        env.pop("DEFENSECLAW_UPGRADE_TEST_MODE")
+
+    result = _run(env, "--version", "0.8.8", "--plan")
+
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "Installed macOS gateway format differs from its authenticated source" in output
+    assert not mutation_log.exists()
+
+
+def test_stale_known_uv_falls_back_to_pinned_bootstrap(
+    resolver_env,
+    tmp_path: Path,
+) -> None:
+    env, mutation_log, curl_log = resolver_env("0.8.7")
+    _install_release_owned_missing_cursor_state(env, "0.8.7")
+    fake_bin = Path(env["PATH"].split(os.pathsep, 1)[0])
+    (fake_bin / "uv").unlink()
+    env["PATH"] = f"{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin"
+
+    marker = tmp_path / "stale-uv-inspected"
+    known_uv = Path(env["HOME"]) / ".local" / "bin" / "uv"
+    _write_executable(
+        known_uv,
+        f"#!/usr/bin/env bash\nprintf inspected > {str(marker)!r}\nprintf 'uv 0.10.0\\n'\n",
+    )
+
+    archive = Path(env["UV_BOOTSTRAP_ARCHIVE"])
+    fixture_digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    production_digest = env["UV_BOOTSTRAP_PRODUCTION_DIGEST"]
+    resolver_source = UPGRADE_SCRIPT.read_text(encoding="utf-8")
+    assert resolver_source.count(production_digest) == 1
+    resolver_under_test = tmp_path / "defenseclaw-upgrade-under-test.sh"
+    resolver_under_test.write_text(
+        resolver_source.replace(production_digest, fixture_digest),
+        encoding="utf-8",
+    )
+    resolver_under_test.chmod(0o755)
+
+    result = _run_script(
+        resolver_under_test,
+        env,
+        "--version",
+        "0.8.8",
+        "--plan",
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert marker.read_text(encoding="utf-8") == "inspected"
+    assert f"Ignoring a non-{UV_BOOTSTRAP_VERSION} uv candidate" in output
+    assert f"Pinned uv {UV_BOOTSTRAP_VERSION} authenticated" in output
+    assert f"/astral-sh/uv/releases/download/{UV_BOOTSTRAP_VERSION}/" in curl_log.read_text(
+        encoding="utf-8",
+    )
+    assert not mutation_log.exists()
+
+
+@pytest.mark.parametrize("unsafe_kind", ("group-writable", "unsafe-symlink"))
+def test_unsafe_known_uv_is_never_executed_and_pinned_bootstrap_succeeds(
+    resolver_env,
+    tmp_path: Path,
+    unsafe_kind: str,
+) -> None:
+    env, mutation_log, curl_log = resolver_env("0.8.7")
+    _install_release_owned_missing_cursor_state(env, "0.8.7")
+    fake_bin = Path(env["PATH"].split(os.pathsep, 1)[0])
+    (fake_bin / "uv").unlink()
+    env["PATH"] = f"{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin"
+    assert shutil.which("uv", path=env["PATH"]) is None
+
+    marker = tmp_path / "unsafe-uv-executed"
+    managed_bin = Path(env["HOME"]) / ".local" / "bin"
+    unsafe_target = managed_bin / ("uv" if unsafe_kind == "group-writable" else "unsafe-uv")
+    _write_executable(
+        unsafe_target,
+        f"#!/usr/bin/env bash\nprintf executed > {str(marker)!r}\nexit 93\n",
+    )
+    unsafe_target.chmod(0o777)
+    if unsafe_kind == "unsafe-symlink":
+        (managed_bin / "uv").symlink_to(unsafe_target.name)
+
+    archive = Path(env["UV_BOOTSTRAP_ARCHIVE"])
+    fixture_digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    production_digest = env["UV_BOOTSTRAP_PRODUCTION_DIGEST"]
+    resolver_source = UPGRADE_SCRIPT.read_text(encoding="utf-8")
+    assert resolver_source.count(production_digest) == 1
+    resolver_under_test = tmp_path / "defenseclaw-upgrade-under-test.sh"
+    resolver_under_test.write_text(
+        resolver_source.replace(production_digest, fixture_digest),
+        encoding="utf-8",
+    )
+    resolver_under_test.chmod(0o755)
+
+    result = _run_script(
+        resolver_under_test,
+        env,
+        "--version",
+        "0.8.8",
+        "--plan",
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert "Ignoring an unsafe or unstable uv candidate" in output
+    assert f"Pinned uv {UV_BOOTSTRAP_VERSION} authenticated in private upgrade custody" in output
+    assert not marker.exists()
+    assert not mutation_log.exists()
+    assert (
+        f"https://github.com/astral-sh/uv/releases/download/{UV_BOOTSTRAP_VERSION}/"
+        f"{env['UV_BOOTSTRAP_ASSET']}"
+    ) in curl_log.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("source_version", ("0.8.6", "0.8.7"))
+@pytest.mark.parametrize("drifted_component", ("cli-package", "gateway"))
+def test_missing_cursor_recovery_rejects_mixed_or_copied_components(
+    resolver_env,
+    source_version: str,
+    drifted_component: str,
+) -> None:
+    env, mutation_log, _curl_log = resolver_env(source_version)
+    _install_release_owned_missing_cursor_state(env, source_version)
+    data_home = Path(env["DEFENSECLAW_HOME"])
+    if drifted_component == "cli-package":
+        package_config = data_home / ".venv" / "lib" / "python3.12" / "site-packages" / "defenseclaw" / "config.py"
+        package_config.write_bytes(package_config.read_bytes() + b"\n# copied package drift\n")
+    else:
+        gateway = Path(env["HOME"]) / ".local" / "bin" / "defenseclaw-gateway"
+        gateway.write_bytes(gateway.read_bytes() + b"\n# copied gateway drift\n")
+
+    result = _run(env, "--version", "0.8.8", "--plan")
+
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "not the exact release-owned missing-cursor shape" in output
+    assert "No changes were made" in output
+    assert not mutation_log.exists()
 
 
 @pytest.mark.parametrize("path_kind", ("relative", "absolute"))
@@ -847,8 +1125,12 @@ def test_staged_runtime_resolves_configured_audit_path_like_source_controller(
     path_kind: str,
 ) -> None:
     env, mutation_log, _curl_log = resolver_env("0.8.6")
-    config_path, _stack = _install_clean_086_state(env)
+    config_path, _stack = _install_release_owned_missing_cursor_state(env, "0.8.6")
     data_home = Path(env["DEFENSECLAW_HOME"])
+    (data_home / ".migration_state.json").write_text(
+        '{"schema":1,"applied":["0.8.5"]}\n',
+        encoding="utf-8",
+    )
     configured_audit_db = (
         "audit-state/custom.sqlite"
         if path_kind == "relative"
@@ -863,16 +1145,9 @@ def test_staged_runtime_resolves_configured_audit_path_like_source_controller(
         connection.execute("CREATE TABLE audit_path_fixture (value TEXT NOT NULL)")
         connection.execute("INSERT INTO audit_path_fixture VALUES ('configured-path-probe')")
         connection.commit()
-        package_config = data_home / ".venv" / "lib" / "python3.12" / "site-packages" / "defenseclaw" / "config.py"
-        package_config.write_text(
-            "import os\n"
-            "from types import SimpleNamespace\n"
-            "def load():\n"
-            "    home = os.environ['DEFENSECLAW_HOME']\n"
-            f"    return SimpleNamespace(data_dir=home, audit_db={configured_audit_db!r}, "
-            "claw=SimpleNamespace(home_dir=os.path.join(os.environ['HOME'], '.openclaw')))\n",
-            encoding="utf-8",
-        )
+        document = json.loads(config_path.read_text(encoding="utf-8"))
+        document["audit_db"] = configured_audit_db
+        config_path.write_text(json.dumps(document, separators=(",", ":")) + "\n", encoding="utf-8")
 
         result = _run(env, "--version", "0.8.7", "--plan")
         output = result.stdout + result.stderr
@@ -946,7 +1221,7 @@ def test_clean_086_missing_cursor_recovery_rejects_near_miss_state(
     near_miss: str,
 ) -> None:
     env, mutation_log, _curl_log = resolver_env("0.8.6")
-    config_path, stack = _install_clean_086_state(env)
+    config_path, stack = _install_release_owned_missing_cursor_state(env, "0.8.6")
     if near_miss == "cursor":
         (Path(env["DEFENSECLAW_HOME"]) / ".migration_state.json").write_text("{broken", encoding="utf-8")
     elif near_miss == "legacy-root":
@@ -978,7 +1253,7 @@ def test_clean_086_missing_cursor_recovery_rejects_near_miss_state(
     assert (
         "config-v8 migration state is absent or invalid" in output
         if near_miss == "cursor"
-        else "not the exact clean missing-cursor shape" in output
+        else "not the exact release-owned missing-cursor shape" in output
     )
     assert config_path.read_bytes() == before
     assert not mutation_log.exists()

--- a/cli/tests/test_upgrade_staged_resolver.py
+++ b/cli/tests/test_upgrade_staged_resolver.py
@@ -1019,6 +1019,66 @@ def test_missing_cursor_recovery_never_executes_local_package_bytecode(
     assert not mutation_log.exists()
 
 
+@pytest.mark.parametrize(
+    "shadow_custody",
+    ("directory", "symlink", "linked-lib", "linked-runtime"),
+)
+def test_missing_cursor_recovery_rejects_sourceless_package_shadow_bytecode(
+    resolver_env,
+    tmp_path: Path,
+    shadow_custody: str,
+) -> None:
+    env, mutation_log, _curl_log = resolver_env("0.8.7")
+    _install_release_owned_missing_cursor_state(env, "0.8.7")
+    package_root = (
+        Path(env["DEFENSECLAW_HOME"])
+        / ".venv"
+        / "lib"
+        / "python3.12"
+        / "site-packages"
+        / "defenseclaw"
+    )
+    package_shadow = package_root / "config"
+    if shadow_custody != "symlink":
+        package_shadow.mkdir()
+        bytecode_root = package_shadow
+    else:
+        bytecode_root = tmp_path / "sourceless-package-shadow"
+        bytecode_root.mkdir()
+        package_shadow.symlink_to(bytecode_root, target_is_directory=True)
+    marker = tmp_path / "sourceless-package-shadow-executed"
+    malicious_source = tmp_path / "malicious-config-package.py"
+    malicious_source.write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text('executed', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    py_compile.compile(
+        str(malicious_source),
+        cfile=str(bytecode_root / "__init__.pyc"),
+        doraise=True,
+        invalidation_mode=py_compile.PycInvalidationMode.UNCHECKED_HASH,
+    )
+    if shadow_custody == "linked-lib":
+        lib_root = package_root.parents[2]
+        linked_root = tmp_path / "linked-lib"
+        lib_root.rename(linked_root)
+        lib_root.symlink_to(linked_root, target_is_directory=True)
+    elif shadow_custody == "linked-runtime":
+        runtime_root = package_root.parents[1]
+        linked_root = tmp_path / "linked-runtime"
+        runtime_root.rename(linked_root)
+        runtime_root.symlink_to(linked_root, target_is_directory=True)
+
+    result = _run(env, "--version", "0.8.8", "--plan")
+
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "executable bytecode outside __pycache__" in output
+    assert not marker.exists()
+    assert not mutation_log.exists()
+
+
 @pytest.mark.skipif(platform.system() != "Darwin", reason="macOS gateway format gate")
 @pytest.mark.parametrize("missing_gate", ("fixture-marker", "test-mode"))
 def test_non_macho_gateway_fixture_requires_test_mode_and_private_marker(

--- a/cli/tests/test_upgrade_staged_resolver.py
+++ b/cli/tests/test_upgrade_staged_resolver.py
@@ -17,65 +17,24 @@
 from __future__ import annotations
 
 import hashlib
-import importlib.util
-import io
 import json
 import os
-import platform
-import py_compile
-import re
 import shutil
 import sqlite3
 import subprocess
 import sys
-import tarfile
-import zipfile
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 
 import pytest
 from defenseclaw import resolver_hint
 
 ROOT = Path(__file__).resolve().parents[2]
 UPGRADE_SCRIPT = ROOT / "scripts" / "upgrade.sh"
-_UPGRADE_SOURCE = UPGRADE_SCRIPT.read_text(encoding="utf-8")
-_UV_BOOTSTRAP_VERSION_MATCH = re.search(
-    r'readonly UV_BOOTSTRAP_VERSION="([^"]+)"',
-    _UPGRADE_SOURCE,
-)
-assert _UV_BOOTSTRAP_VERSION_MATCH is not None, "uv bootstrap version constant moved"
-UV_BOOTSTRAP_VERSION = _UV_BOOTSTRAP_VERSION_MATCH.group(1)
 _STAGED_COSIGN_SHA256_BY_ASSET = {
     "cosign-darwin-amd64": resolver_hint.COSIGN_BOOTSTRAP_SHA256[("darwin", "amd64")],
     "cosign-darwin-arm64": resolver_hint.COSIGN_BOOTSTRAP_SHA256[("darwin", "arm64")],
     "cosign-linux-amd64": resolver_hint.COSIGN_BOOTSTRAP_SHA256[("linux", "amd64")],
     "cosign-linux-arm64": resolver_hint.COSIGN_BOOTSTRAP_SHA256[("linux", "arm64")],
-}
-_UV_BOOTSTRAP_ASSETS = {
-    ("Darwin", "x86_64"): (
-        "uv-x86_64-apple-darwin.tar.gz",
-        "uv-x86_64-apple-darwin/uv",
-        "2ad79983127ffca7d77b77ce6a24278d7e4f7b817a1acf72fea5f8124b4aac5e",
-    ),
-    ("Darwin", "arm64"): (
-        "uv-aarch64-apple-darwin.tar.gz",
-        "uv-aarch64-apple-darwin/uv",
-        "33540eb7c883ab857eff79bd5ac2aa31fe27b595abecb4a9c003a2c998447232",
-    ),
-    ("Linux", "x86_64"): (
-        "uv-x86_64-unknown-linux-gnu.tar.gz",
-        "uv-x86_64-unknown-linux-gnu/uv",
-        "e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224",
-    ),
-    ("Linux", "aarch64"): (
-        "uv-aarch64-unknown-linux-gnu.tar.gz",
-        "uv-aarch64-unknown-linux-gnu/uv",
-        "03e9fe0a81b0718d0bc84625de3885df6cc3f89a8b6af6121d6b9f6113fb6533",
-    ),
-    ("Linux", "arm64"): (
-        "uv-aarch64-unknown-linux-gnu.tar.gz",
-        "uv-aarch64-unknown-linux-gnu/uv",
-        "03e9fe0a81b0718d0bc84625de3885df6cc3f89a8b6af6121d6b9f6113fb6533",
-    ),
 }
 
 pytestmark = pytest.mark.skipif(
@@ -87,32 +46,6 @@ pytestmark = pytest.mark.skipif(
 def _write_executable(path: Path, body: str) -> None:
     path.write_text(body, encoding="utf-8")
     path.chmod(0o755)
-
-
-def _uv_shim_payload() -> bytes:
-    return (
-        b"#!/usr/bin/env bash\n"
-        b"set -euo pipefail\n"
-        b'if [[ "$#" -eq 1 && "$1" == "--version" ]]; then\n'
-        + f"    printf 'uv {UV_BOOTSTRAP_VERSION}\\n'\n".encode()
-        + b"    exit 0\n"
-        b"fi\n"
-        b"""printf '%s\\n' "$*" >> "${UV_LOG}"\n"""
-        b'if [[ "$#" -eq 10'
-        b' && "$1" == "--no-config"'
-        b' && "$2" == "pip"'
-        b' && "$3" == "install"'
-        b' && "$4" == "--python"'
-        b' && "$5" == "${DEFENSECLAW_HOME}/.venv/bin/python"'
-        b' && "$6" == "--dry-run"'
-        b' && "$7" == "--quiet"'
-        b' && "$8" == "--only-binary"'
-        b' && "$9" == "litellm"'
-        b' && "${10}" == */authenticated-source-0.8.[67]/defenseclaw-0.8.[67]-2-py3-none-any.whl ]]; then\n'
-        b"    exit 0\n"
-        b"fi\n"
-        b"exit 99\n"
-    )
 
 
 def _manifest(version: str) -> dict[str, object]:
@@ -240,35 +173,6 @@ def _source_package_files(version: str) -> dict[str, bytes]:
     }
 
 
-def _source_wheel(version: str) -> bytes:
-    output = io.BytesIO()
-    package_files = _source_package_files(version)
-    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
-        for name, payload in package_files.items():
-            archive.writestr(name, payload)
-        archive.writestr(
-            f"defenseclaw-{version}.dist-info/METADATA",
-            f"Metadata-Version: 2.1\nName: defenseclaw\nVersion: {version}\n",
-        )
-        archive.writestr(
-            f"defenseclaw-{version}.dist-info/WHEEL",
-            "Wheel-Version: 1.0\nGenerator: test\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
-        )
-        archive.writestr(f"defenseclaw-{version}.dist-info/RECORD", "")
-    return output.getvalue()
-
-
-def _source_gateway_archive(version: str) -> bytes:
-    output = io.BytesIO()
-    with tarfile.open(fileobj=output, mode="w:gz") as archive:
-        info = tarfile.TarInfo("defenseclaw")
-        info.mode = 0o755
-        payload = _source_gateway_payload(version)
-        info.size = len(payload)
-        archive.addfile(info, io.BytesIO(payload))
-    return output.getvalue()
-
-
 def _release_provenance(version: str, bridge_checksums_sha256: str) -> dict[str, object]:
     return {
         "schema_version": 1,
@@ -303,22 +207,6 @@ def resolver_env(tmp_path: Path):
         fake_bin.mkdir(exist_ok=True)
         home.mkdir(exist_ok=True)
 
-        uv_platform = (platform.system(), platform.machine())
-        if uv_platform not in _UV_BOOTSTRAP_ASSETS:
-            pytest.skip(f"unsupported uv bootstrap fixture platform: {uv_platform}")
-        uv_asset, uv_member, uv_production_digest = _UV_BOOTSTRAP_ASSETS[uv_platform]
-        uv_archive = fixtures / uv_asset
-        with tarfile.open(uv_archive, mode="w:gz") as archive:
-            directory = tarfile.TarInfo(str(PurePosixPath(uv_member).parent))
-            directory.type = tarfile.DIRTYPE
-            directory.mode = 0o755
-            archive.addfile(directory)
-            payload = _uv_shim_payload()
-            executable = tarfile.TarInfo(uv_member)
-            executable.mode = 0o755
-            executable.size = len(payload)
-            archive.addfile(executable, io.BytesIO(payload))
-
         bridge_checksums_sha256 = ""
         for version in ("0.8.4", "0.8.5", "0.8.6", "0.8.7", "0.8.8"):
             release_dir = fixtures / version
@@ -332,9 +220,7 @@ def resolver_env(tmp_path: Path):
             wheel_name = release_artifacts["wheel"]
             assert isinstance(wheel_name, str)
             wheel = release_dir / wheel_name
-            wheel_payload = (
-                _source_wheel(version) if version in {"0.8.6", "0.8.7"} else b"resolver target wheel fixture"
-            )
+            wheel_payload = b"resolver target wheel fixture"
             wheel.write_bytes(_protected(wheel_payload))
             checksum_rows.append(f"{hashlib.sha256(wheel.read_bytes()).hexdigest()}  {wheel.name}")
             gateways = release_artifacts["gateways"]
@@ -344,14 +230,7 @@ def resolver_env(tmp_path: Path):
                 for gateway_name in platform_gateways.values():
                     assert isinstance(gateway_name, str)
                     gateway = release_dir / gateway_name
-                    gateway_payload = (
-                        _source_gateway_archive(version)
-                        if version in {"0.8.6", "0.8.7"}
-                        else f"gateway fixture {gateway_name}\n".encode()
-                    )
-                    gateway.write_bytes(
-                        _protected(gateway_payload) if version in {"0.8.6", "0.8.7"} else gateway_payload
-                    )
+                    gateway.write_bytes(f"gateway fixture {gateway_name}\n".encode())
                     checksum_rows.append(f"{hashlib.sha256(gateway.read_bytes()).hexdigest()}  {gateway.name}")
             if version in {"0.8.5", "0.8.6", "0.8.7", "0.8.8"}:
                 provenance = (
@@ -391,9 +270,6 @@ def resolver_env(tmp_path: Path):
             fake_bin / "cosign",
             '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "${COSIGN_LOG}"\nexit 0\n',
         )
-        uv_path = fake_bin / "uv"
-        uv_path.write_bytes(_uv_shim_payload())
-        uv_path.chmod(0o755)
         _write_executable(
             fake_bin / "sha256sum",
             """#!/usr/bin/env bash
@@ -454,11 +330,6 @@ exit 0
 COSIGN
     exit 0
 fi
-if [[ "${url}" == https://github.com/astral-sh/uv/releases/download/* ]]; then
-    [[ -n "${out}" ]] || exit 94
-    cp "${UV_BOOTSTRAP_ARCHIVE}" "${out}"
-    exit 0
-fi
 version=''
 case "${url}" in
     */releases/download/0.8.4/*) version='0.8.4' ;;
@@ -470,19 +341,12 @@ esac
 [[ -n "${version}" && -n "${out}" ]] || exit 96
 name="${url##*/}"
 cp "${FIXTURE_ROOT}/${version}/${name}" "${out}"
-if [[ "${name}" == defenseclaw_*_protocol2_darwin_* \
-      && "${OMIT_GATEWAY_FIXTURE_MARKER:-0}" != '1' ]]; then
-    printf '%s\n' 'defenseclaw-gateway-fixture-v1' \
-        > "$(dirname -- "${out}")/.defenseclaw-gateway-fixture-v1"
-    chmod 600 "$(dirname -- "${out}")/.defenseclaw-gateway-fixture-v1"
-fi
 """,
         )
 
         mutation_log = tmp_path / "mutations.log"
         curl_log = tmp_path / "curl.log"
         cosign_log = tmp_path / "cosign.log"
-        uv_log = tmp_path / "uv.log"
         env = os.environ.copy()
         for name in tuple(env):
             if name in {
@@ -500,10 +364,6 @@ fi
                 "MUTATION_LOG": str(mutation_log),
                 "CURL_LOG": str(curl_log),
                 "COSIGN_LOG": str(cosign_log),
-                "UV_LOG": str(uv_log),
-                "UV_BOOTSTRAP_ARCHIVE": str(uv_archive),
-                "UV_BOOTSTRAP_ASSET": uv_asset,
-                "UV_BOOTSTRAP_PRODUCTION_DIGEST": uv_production_digest,
                 "DEFENSECLAW_UPGRADE_TEST_MODE": "1",
                 "NO_COLOR": "1",
             }
@@ -685,7 +545,6 @@ def test_explicit_final_target_still_resolves_verified_two_hop_plan(
     assert "No changes were made" in output
     assert not mutation_log.exists()
     assert not Path(env["DEFENSECLAW_HOME"]).exists()
-    assert not Path(env["UV_LOG"]).exists()
     downloads = curl_log.read_text(encoding="utf-8")
     assert "/releases/download/0.8.5/upgrade-manifest.json" in downloads
     assert "/releases/download/0.8.4/upgrade-manifest.json" in downloads
@@ -906,10 +765,10 @@ def test_manual_hard_cut_artifacts_over_v7_state_refuse_before_release_download(
 @pytest.mark.parametrize(
     ("local_stack", "unrelated_change"),
     ((False, False), (True, False), (False, True)),
-    ids=("retained-clean-no-stack", "exact-authenticated-stack", "valid-unrelated-llm-change"),
+    ids=("no-stack", "replaceable-local-stack", "configured-v8-state"),
 )
 @pytest.mark.parametrize("source_version", ("0.8.6", "0.8.7"))
-def test_release_owned_missing_cursor_authenticates_recovery_without_mutation(
+def test_public_cursorless_first_run_authorizes_recovery_without_mutation(
     resolver_env,
     local_stack: bool,
     unrelated_change: bool,
@@ -923,6 +782,7 @@ def test_release_owned_missing_cursor_authenticates_recovery_without_mutation(
     if unrelated_change:
         document = json.loads(config_path.read_text(encoding="utf-8"))
         document["llm"]["model"] = "operator-selected-model"
+        document["observability"] = {"destinations": [{"name": "operator-selected"}]}
         config_path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
     before = config_path.read_bytes()
 
@@ -930,305 +790,14 @@ def test_release_owned_missing_cursor_authenticates_recovery_without_mutation(
 
     output = result.stdout + result.stderr
     assert result.returncode == 0, output
-    assert f"Authenticated the exact published {source_version} missing-cursor compatibility state" in output
+    assert f"Accepted exact public {source_version} cursorless first-run state" in output
     assert f"{source_version} → 0.8.8" in output
     assert config_path.read_bytes() == before
     assert not (Path(env["DEFENSECLAW_HOME"]) / ".migration_state.json").exists()
     assert not mutation_log.exists()
-    uv_invocation = Path(env["UV_LOG"]).read_text(encoding="utf-8").split()
-    assert uv_invocation[:4] == ["--no-config", "pip", "install", "--python"]
-    assert uv_invocation[4] == f"{env['DEFENSECLAW_HOME']}/.venv/bin/python"
-    assert uv_invocation[5:9] == ["--dry-run", "--quiet", "--only-binary", "litellm"]
-    assert Path(uv_invocation[9]).name == f"defenseclaw-{source_version}-2-py3-none-any.whl"
     downloads = curl_log.read_text(encoding="utf-8")
-    assert f"/releases/download/{source_version}/release-provenance.json" in downloads
-    assert f"defenseclaw-{source_version}-2-py3-none-any.dcwheel" in downloads
-    assert f"defenseclaw_{source_version}_protocol2_" in downloads
-
-
-def test_release_owned_missing_cursor_uses_known_uv_outside_clean_path(
-    resolver_env,
-) -> None:
-    env, mutation_log, _curl_log = resolver_env("0.8.7")
-    config_path, _stack = _install_release_owned_missing_cursor_state(env, "0.8.7")
-    fake_bin = Path(env["PATH"].split(os.pathsep, 1)[0])
-    known_uv = Path(env["HOME"]) / ".local" / "bin" / "uv"
-    shutil.move(fake_bin / "uv", known_uv)
-    env["PATH"] = f"{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin"
-    assert shutil.which("uv", path=env["PATH"]) is None
-
-    result = _run(env, "--version", "0.8.8", "--plan")
-
-    output = result.stdout + result.stderr
-    assert result.returncode == 0, output
-    assert "Copied uv into private upgrade custody" in output
-    assert "Pinned uv" not in output
-    assert "Authenticated the exact published 0.8.7 missing-cursor compatibility state" in output
-    assert config_path.is_file()
-    assert not mutation_log.exists()
-
-
-@pytest.mark.parametrize("cache_custody", ("directory", "symlink"))
-def test_missing_cursor_recovery_never_executes_local_package_bytecode(
-    resolver_env,
-    tmp_path: Path,
-    cache_custody: str,
-) -> None:
-    env, mutation_log, _curl_log = resolver_env("0.8.7")
-    _install_release_owned_missing_cursor_state(env, "0.8.7")
-    package_root = (
-        Path(env["DEFENSECLAW_HOME"])
-        / ".venv"
-        / "lib"
-        / "python3.12"
-        / "site-packages"
-        / "defenseclaw"
-    )
-    local_cache = package_root / "__pycache__"
-    if cache_custody == "directory":
-        local_cache.mkdir()
-        bytecode_root = local_cache
-    else:
-        bytecode_root = tmp_path / "attacker-bytecode"
-        bytecode_root.mkdir()
-        local_cache.symlink_to(bytecode_root, target_is_directory=True)
-    marker = tmp_path / "malicious-bytecode-executed"
-    malicious_source = tmp_path / "malicious-init.py"
-    malicious_source.write_text(
-        "from pathlib import Path\n"
-        f"Path({str(marker)!r}).write_text('executed', encoding='utf-8')\n"
-        "__version__ = '0.8.7'\n",
-        encoding="utf-8",
-    )
-    cache_name = Path(
-        importlib.util.cache_from_source(str(package_root / "__init__.py"))
-    ).name
-    py_compile.compile(
-        str(malicious_source),
-        cfile=str(bytecode_root / cache_name),
-        doraise=True,
-        invalidation_mode=py_compile.PycInvalidationMode.UNCHECKED_HASH,
-    )
-
-    result = _run(env, "--version", "0.8.8", "--plan")
-
-    output = result.stdout + result.stderr
-    assert result.returncode == 0, output
-    assert "Authenticated the exact published 0.8.7 missing-cursor compatibility state" in output
-    assert not marker.exists()
-    assert not mutation_log.exists()
-
-
-@pytest.mark.parametrize(
-    "shadow_custody",
-    ("directory", "symlink", "linked-lib", "linked-runtime"),
-)
-def test_missing_cursor_recovery_rejects_sourceless_package_shadow_bytecode(
-    resolver_env,
-    tmp_path: Path,
-    shadow_custody: str,
-) -> None:
-    env, mutation_log, _curl_log = resolver_env("0.8.7")
-    _install_release_owned_missing_cursor_state(env, "0.8.7")
-    package_root = (
-        Path(env["DEFENSECLAW_HOME"])
-        / ".venv"
-        / "lib"
-        / "python3.12"
-        / "site-packages"
-        / "defenseclaw"
-    )
-    package_shadow = package_root / "config"
-    if shadow_custody != "symlink":
-        package_shadow.mkdir()
-        bytecode_root = package_shadow
-    else:
-        bytecode_root = tmp_path / "sourceless-package-shadow"
-        bytecode_root.mkdir()
-        package_shadow.symlink_to(bytecode_root, target_is_directory=True)
-    marker = tmp_path / "sourceless-package-shadow-executed"
-    malicious_source = tmp_path / "malicious-config-package.py"
-    malicious_source.write_text(
-        "from pathlib import Path\n"
-        f"Path({str(marker)!r}).write_text('executed', encoding='utf-8')\n",
-        encoding="utf-8",
-    )
-    py_compile.compile(
-        str(malicious_source),
-        cfile=str(bytecode_root / "__init__.pyc"),
-        doraise=True,
-        invalidation_mode=py_compile.PycInvalidationMode.UNCHECKED_HASH,
-    )
-    if shadow_custody == "linked-lib":
-        lib_root = package_root.parents[2]
-        linked_root = tmp_path / "linked-lib"
-        lib_root.rename(linked_root)
-        lib_root.symlink_to(linked_root, target_is_directory=True)
-    elif shadow_custody == "linked-runtime":
-        runtime_root = package_root.parents[1]
-        linked_root = tmp_path / "linked-runtime"
-        runtime_root.rename(linked_root)
-        runtime_root.symlink_to(linked_root, target_is_directory=True)
-
-    result = _run(env, "--version", "0.8.8", "--plan")
-
-    output = result.stdout + result.stderr
-    assert result.returncode != 0, output
-    assert "executable bytecode outside __pycache__" in output
-    assert not marker.exists()
-    assert not mutation_log.exists()
-
-
-@pytest.mark.skipif(platform.system() != "Darwin", reason="macOS gateway format gate")
-@pytest.mark.parametrize("missing_gate", ("fixture-marker", "test-mode"))
-def test_non_macho_gateway_fixture_requires_test_mode_and_private_marker(
-    resolver_env,
-    missing_gate: str,
-) -> None:
-    env, mutation_log, _curl_log = resolver_env("0.8.7")
-    _install_release_owned_missing_cursor_state(env, "0.8.7")
-    assert env["DEFENSECLAW_UPGRADE_TEST_MODE"] == "1"
-    if missing_gate == "fixture-marker":
-        env["OMIT_GATEWAY_FIXTURE_MARKER"] = "1"
-    else:
-        env.pop("DEFENSECLAW_UPGRADE_TEST_MODE")
-
-    result = _run(env, "--version", "0.8.8", "--plan")
-
-    output = result.stdout + result.stderr
-    assert result.returncode != 0
-    assert "Installed macOS gateway format differs from its authenticated source" in output
-    assert not mutation_log.exists()
-
-
-def test_stale_known_uv_falls_back_to_pinned_bootstrap(
-    resolver_env,
-    tmp_path: Path,
-) -> None:
-    env, mutation_log, curl_log = resolver_env("0.8.7")
-    _install_release_owned_missing_cursor_state(env, "0.8.7")
-    fake_bin = Path(env["PATH"].split(os.pathsep, 1)[0])
-    (fake_bin / "uv").unlink()
-    env["PATH"] = f"{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin"
-
-    marker = tmp_path / "stale-uv-inspected"
-    known_uv = Path(env["HOME"]) / ".local" / "bin" / "uv"
-    _write_executable(
-        known_uv,
-        f"#!/usr/bin/env bash\nprintf inspected > {str(marker)!r}\nprintf 'uv 0.10.0\\n'\n",
-    )
-
-    archive = Path(env["UV_BOOTSTRAP_ARCHIVE"])
-    fixture_digest = hashlib.sha256(archive.read_bytes()).hexdigest()
-    production_digest = env["UV_BOOTSTRAP_PRODUCTION_DIGEST"]
-    resolver_source = UPGRADE_SCRIPT.read_text(encoding="utf-8")
-    assert resolver_source.count(production_digest) == 1
-    resolver_under_test = tmp_path / "defenseclaw-upgrade-under-test.sh"
-    resolver_under_test.write_text(
-        resolver_source.replace(production_digest, fixture_digest),
-        encoding="utf-8",
-    )
-    resolver_under_test.chmod(0o755)
-
-    result = _run_script(
-        resolver_under_test,
-        env,
-        "--version",
-        "0.8.8",
-        "--plan",
-    )
-
-    output = result.stdout + result.stderr
-    assert result.returncode == 0, output
-    assert marker.read_text(encoding="utf-8") == "inspected"
-    assert f"Ignoring a non-{UV_BOOTSTRAP_VERSION} uv candidate" in output
-    assert f"Pinned uv {UV_BOOTSTRAP_VERSION} authenticated" in output
-    assert f"/astral-sh/uv/releases/download/{UV_BOOTSTRAP_VERSION}/" in curl_log.read_text(
-        encoding="utf-8",
-    )
-    assert not mutation_log.exists()
-
-
-@pytest.mark.parametrize("unsafe_kind", ("group-writable", "unsafe-symlink"))
-def test_unsafe_known_uv_is_never_executed_and_pinned_bootstrap_succeeds(
-    resolver_env,
-    tmp_path: Path,
-    unsafe_kind: str,
-) -> None:
-    env, mutation_log, curl_log = resolver_env("0.8.7")
-    _install_release_owned_missing_cursor_state(env, "0.8.7")
-    fake_bin = Path(env["PATH"].split(os.pathsep, 1)[0])
-    (fake_bin / "uv").unlink()
-    env["PATH"] = f"{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin"
-    assert shutil.which("uv", path=env["PATH"]) is None
-
-    marker = tmp_path / "unsafe-uv-executed"
-    managed_bin = Path(env["HOME"]) / ".local" / "bin"
-    unsafe_target = managed_bin / ("uv" if unsafe_kind == "group-writable" else "unsafe-uv")
-    _write_executable(
-        unsafe_target,
-        f"#!/usr/bin/env bash\nprintf executed > {str(marker)!r}\nexit 93\n",
-    )
-    unsafe_target.chmod(0o777)
-    if unsafe_kind == "unsafe-symlink":
-        (managed_bin / "uv").symlink_to(unsafe_target.name)
-
-    archive = Path(env["UV_BOOTSTRAP_ARCHIVE"])
-    fixture_digest = hashlib.sha256(archive.read_bytes()).hexdigest()
-    production_digest = env["UV_BOOTSTRAP_PRODUCTION_DIGEST"]
-    resolver_source = UPGRADE_SCRIPT.read_text(encoding="utf-8")
-    assert resolver_source.count(production_digest) == 1
-    resolver_under_test = tmp_path / "defenseclaw-upgrade-under-test.sh"
-    resolver_under_test.write_text(
-        resolver_source.replace(production_digest, fixture_digest),
-        encoding="utf-8",
-    )
-    resolver_under_test.chmod(0o755)
-
-    result = _run_script(
-        resolver_under_test,
-        env,
-        "--version",
-        "0.8.8",
-        "--plan",
-    )
-
-    output = result.stdout + result.stderr
-    assert result.returncode == 0, output
-    assert "Ignoring an unsafe or unstable uv candidate" in output
-    assert f"Pinned uv {UV_BOOTSTRAP_VERSION} authenticated in private upgrade custody" in output
-    assert not marker.exists()
-    assert not mutation_log.exists()
-    assert (
-        f"https://github.com/astral-sh/uv/releases/download/{UV_BOOTSTRAP_VERSION}/"
-        f"{env['UV_BOOTSTRAP_ASSET']}"
-    ) in curl_log.read_text(encoding="utf-8")
-
-
-@pytest.mark.parametrize("source_version", ("0.8.6", "0.8.7"))
-@pytest.mark.parametrize("drifted_component", ("cli-package", "gateway"))
-def test_missing_cursor_recovery_rejects_mixed_or_copied_components(
-    resolver_env,
-    source_version: str,
-    drifted_component: str,
-) -> None:
-    env, mutation_log, _curl_log = resolver_env(source_version)
-    _install_release_owned_missing_cursor_state(env, source_version)
-    data_home = Path(env["DEFENSECLAW_HOME"])
-    if drifted_component == "cli-package":
-        package_config = data_home / ".venv" / "lib" / "python3.12" / "site-packages" / "defenseclaw" / "config.py"
-        package_config.write_bytes(package_config.read_bytes() + b"\n# copied package drift\n")
-    else:
-        gateway = Path(env["HOME"]) / ".local" / "bin" / "defenseclaw-gateway"
-        gateway.write_bytes(gateway.read_bytes() + b"\n# copied gateway drift\n")
-
-    result = _run(env, "--version", "0.8.8", "--plan")
-
-    output = result.stdout + result.stderr
-    assert result.returncode != 0
-    assert "not the exact release-owned missing-cursor shape" in output
-    assert "No changes were made" in output
-    assert not mutation_log.exists()
+    assert "/releases/download/0.8.8/release-provenance.json" in downloads
+    assert f"/releases/download/{source_version}/" not in downloads
 
 
 @pytest.mark.parametrize("path_kind", ("relative", "absolute"))
@@ -1321,9 +890,6 @@ def test_same_version_086_cursor_bootstrap_preserves_unrelated_v8_config_bytes(
     "near_miss",
     (
         "cursor",
-        "legacy-root",
-        "observability",
-        "stack",
         "migration-backup",
         "pending-cursor-retry",
         "receipt",
@@ -1334,20 +900,9 @@ def test_clean_086_missing_cursor_recovery_rejects_near_miss_state(
     near_miss: str,
 ) -> None:
     env, mutation_log, _curl_log = resolver_env("0.8.6")
-    config_path, stack = _install_release_owned_missing_cursor_state(env, "0.8.6")
+    config_path, _stack = _install_release_owned_missing_cursor_state(env, "0.8.6")
     if near_miss == "cursor":
         (Path(env["DEFENSECLAW_HOME"]) / ".migration_state.json").write_text("{broken", encoding="utf-8")
-    elif near_miss == "legacy-root":
-        document = json.loads(config_path.read_text(encoding="utf-8"))
-        document["otel"] = {}
-        config_path.write_text(json.dumps(document), encoding="utf-8")
-    elif near_miss == "observability":
-        document = json.loads(config_path.read_text(encoding="utf-8"))
-        document["observability"] = {"destinations": [{"name": "custom"}]}
-        config_path.write_text(json.dumps(document), encoding="utf-8")
-    elif near_miss == "stack":
-        stack.mkdir()
-        (stack / "README.md").write_bytes(b"operator drift\n")
     elif near_miss == "migration-backup":
         Path(f"{config_path}.pre-observability-migration.bak").write_bytes(b"residue\n")
     elif near_miss == "pending-cursor-retry":
@@ -1366,7 +921,7 @@ def test_clean_086_missing_cursor_recovery_rejects_near_miss_state(
     assert (
         "config-v8 migration state is absent or invalid" in output
         if near_miss == "cursor"
-        else "not the exact release-owned missing-cursor shape" in output
+        else "not the supported public cursorless first-run shape" in output
     )
     assert config_path.read_bytes() == before
     assert not mutation_log.exists()

--- a/cli/tests/test_upgrade_staged_resolver.py
+++ b/cli/tests/test_upgrade_staged_resolver.py
@@ -17,10 +17,12 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.util
 import io
 import json
 import os
 import platform
+import py_compile
 import re
 import shutil
 import sqlite3
@@ -963,6 +965,57 @@ def test_release_owned_missing_cursor_uses_known_uv_outside_clean_path(
     assert "Pinned uv" not in output
     assert "Authenticated the exact published 0.8.7 missing-cursor compatibility state" in output
     assert config_path.is_file()
+    assert not mutation_log.exists()
+
+
+@pytest.mark.parametrize("cache_custody", ("directory", "symlink"))
+def test_missing_cursor_recovery_never_executes_local_package_bytecode(
+    resolver_env,
+    tmp_path: Path,
+    cache_custody: str,
+) -> None:
+    env, mutation_log, _curl_log = resolver_env("0.8.7")
+    _install_release_owned_missing_cursor_state(env, "0.8.7")
+    package_root = (
+        Path(env["DEFENSECLAW_HOME"])
+        / ".venv"
+        / "lib"
+        / "python3.12"
+        / "site-packages"
+        / "defenseclaw"
+    )
+    local_cache = package_root / "__pycache__"
+    if cache_custody == "directory":
+        local_cache.mkdir()
+        bytecode_root = local_cache
+    else:
+        bytecode_root = tmp_path / "attacker-bytecode"
+        bytecode_root.mkdir()
+        local_cache.symlink_to(bytecode_root, target_is_directory=True)
+    marker = tmp_path / "malicious-bytecode-executed"
+    malicious_source = tmp_path / "malicious-init.py"
+    malicious_source.write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text('executed', encoding='utf-8')\n"
+        "__version__ = '0.8.7'\n",
+        encoding="utf-8",
+    )
+    cache_name = Path(
+        importlib.util.cache_from_source(str(package_root / "__init__.py"))
+    ).name
+    py_compile.compile(
+        str(malicious_source),
+        cfile=str(bytecode_root / cache_name),
+        doraise=True,
+        invalidation_mode=py_compile.PycInvalidationMode.UNCHECKED_HASH,
+    )
+
+    result = _run(env, "--version", "0.8.8", "--plan")
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert "Authenticated the exact published 0.8.7 missing-cursor compatibility state" in output
+    assert not marker.exists()
     assert not mutation_log.exists()
 
 

--- a/cli/tests/test_windows_release_certification.py
+++ b/cli/tests/test_windows_release_certification.py
@@ -263,9 +263,13 @@ def test_release_documentation_matches_the_fresh_only_gate() -> None:
     assert ".certification.json" not in installer
     assert "A merge to `main` is the review-and-CI boundary" in ci
     assert "does not poll or replay `Windows Native CI`" in ci
-    assert "first native Windows release" in release
-    assert "has no older native Windows baseline" in release
-    assert "fresh-install only" in release
+    assert "Windows acceptance is" in release
+    assert "fresh-install-only" in release
+    assert re.search(
+        r"no historical Windows baseline is inferred or\s+required",
+        release,
+    )
+    assert "first native Windows release" not in release
 
 
 def test_native_wheel_stages_and_verifies_v8_runtime_assets() -> None:

--- a/docs/RELEASE_CHANNEL.md
+++ b/docs/RELEASE_CHANNEL.md
@@ -166,24 +166,29 @@ The rescue bootstrap:
    installer's `VERSION`, then passes only compatible operator arguments.
 
 The authenticated target resolver keeps that clean `PATH` boundary. When it
-needs `uv`, it copies a stable trusted-owner executable from an explicit known
-location into private upgrade custody; if none is safe, it downloads the
-platform archive for pinned `uv` `0.11.28`, verifies its reviewed SHA-256, and
-safely extracts only the executable into the same custody. It never restores
-the ambient interactive `PATH`, never executes an unsafe discovered candidate,
-and never streams an upstream installer.
+needs `uv`, it always downloads the platform archive for pinned `uv` `0.11.28`,
+verifies its reviewed SHA-256, and extracts only the explicit platform
+executable into private upgrade custody. It never discovers, copies,
+version-probes, or executes a `uv` from `PATH` or a local known location, and it
+never streams an upstream installer. The private extracted binary is cached
+only for that resolver process.
+
+Interrupted phase-two recovery uses the same authenticated uv bootstrap before
+it can reinstall the retained bridge wheel. That recovery therefore requires
+network access to the pinned upstream archive; a coincidentally cached local
+`uv` no longer creates an undocumented offline recovery path.
 
 The target resolver also owns the narrow field compatibility rule for
-cursorless `0.8.6` and `0.8.7` installations. It accepts that state only after
-authenticating the exact published source release and proving that the
-installed CLI package and gateway match it, the config is clean config-v8
-state, and no migration or upgrade residue exists. On macOS, the resolver
-verifies the installed release-owned signature, copies both gateways into
-private custody, applies the installer’s deterministic ad-hoc signature
-normalization to those copies, and then compares their bytes; it never rewrites
-the live gateway during source authentication. A partial cursor, mixed/copied
-component, or modified observability state still fails before service or
-installed-state mutation.
+cursorless `0.8.6` and `0.8.7` installations. This is deliberately a
+same-user repair rule, not an attempt to authenticate every byte of the
+installed source. It requires matching CLI and gateway versions, the known
+public integer config-v8 boundary, a wholly absent migration cursor, and no
+active or incomplete upgrade transaction. A partial cursor, mixed component
+version, invalid config-version boundary, or upgrade residue still fails before
+service or installed-state mutation. The resolver then relies on its existing
+backup and rollback transaction while authenticating every downloaded target
+artifact through the signed release contract and requiring final
+version-bound health.
 
 The bootstrap rejects an operator-supplied `--version` and
 `--allow-unverified`; neither command-line nor ambient legacy overrides may
@@ -192,7 +197,7 @@ replace the signed stable target or bypass its authentication.
 For the two field-recovery cases:
 
 ```bash
-# Recover an authenticated 0.8.6 or 0.8.7 installation whose cursor is absent.
+# Recover a supported 0.8.6 or 0.8.7 public first-run state whose cursor is absent.
 /bin/sh ./defenseclaw-rescue.sh --yes
 
 # Preserve a proven-corrupt audit SQLite tuple and activate a fresh store.

--- a/docs/RELEASE_CHANNEL.md
+++ b/docs/RELEASE_CHANNEL.md
@@ -165,6 +165,26 @@ The rescue bootstrap:
 7. Supplies the authenticated channel version as the resolver target or the
    installer's `VERSION`, then passes only compatible operator arguments.
 
+The authenticated target resolver keeps that clean `PATH` boundary. When it
+needs `uv`, it copies a stable trusted-owner executable from an explicit known
+location into private upgrade custody; if none is safe, it downloads the
+platform archive for pinned `uv` `0.11.28`, verifies its reviewed SHA-256, and
+safely extracts only the executable into the same custody. It never restores
+the ambient interactive `PATH`, never executes an unsafe discovered candidate,
+and never streams an upstream installer.
+
+The target resolver also owns the narrow field compatibility rule for
+cursorless `0.8.6` and `0.8.7` installations. It accepts that state only after
+authenticating the exact published source release and proving that the
+installed CLI package and gateway match it, the config is clean config-v8
+state, and no migration or upgrade residue exists. On macOS, the resolver
+verifies the installed release-owned signature, copies both gateways into
+private custody, applies the installer’s deterministic ad-hoc signature
+normalization to those copies, and then compares their bytes; it never rewrites
+the live gateway during source authentication. A partial cursor, mixed/copied
+component, or modified observability state still fails before service or
+installed-state mutation.
+
 The bootstrap rejects an operator-supplied `--version` and
 `--allow-unverified`; neither command-line nor ambient legacy overrides may
 replace the signed stable target or bypass its authentication.
@@ -172,7 +192,7 @@ replace the signed stable target or bypass its authentication.
 For the two field-recovery cases:
 
 ```bash
-# Recover an authenticated clean 0.8.6 installation whose cursor is absent.
+# Recover an authenticated 0.8.6 or 0.8.7 installation whose cursor is absent.
 /bin/sh ./defenseclaw-rescue.sh --yes
 
 # Preserve a proven-corrupt audit SQLite tuple and activate a fresh store.

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -151,16 +151,19 @@ Confirm that the exact run shows:
 - every baseline selected by workflow request validation upgraded on both
   Linux and macOS, including the `0.8.4` bridge and `0.8.5` forward handoff
   for pre-`0.8.4` sources;
+- exact published `0.8.6` and `0.8.7` install-plus-first-run field states with
+  an absent migration cursor recovered through the candidate resolver on both
+  Linux and macOS under the immutable rescue bootstrap’s clean tool path;
 - native Windows x64 fresh install through `install.ps1` and
   `DefenseClawSetup-x64.exe`;
 - exact CLI and gateway version plus healthy gateway checks;
 - sealed-candidate verification before publication; and
 - immutable remote asset custody before stable-channel advancement.
 
-Windows is explicitly fresh-install-only through `0.8.8`. Request validation
-blocks a later release until [#619](https://github.com/cisco-ai-defense/defenseclaw/issues/619)
-adds a native upgrade lane from an authenticated published Windows Setup.
-Do not discard Windows baselines or invent an unauthenticated historical lane.
+Windows acceptance is explicitly fresh-install-only. Every release still
+builds and exercises the exact native Setup and `install.ps1` candidate, but
+the release matrix does not claim or require a historical native Windows
+upgrade path. Do not invent an unauthenticated historical lane.
 
 ### Public release and asset inventory
 

--- a/docs/RELEASE_VALIDATION.md
+++ b/docs/RELEASE_VALIDATION.md
@@ -80,9 +80,9 @@ omitting an unavailable lane.
 
 Field-recovery acceptance additionally installs and runs first setup through
 the authenticated published `0.8.6` and `0.8.7` controllers without
-manufacturing a cursor. The candidate resolver must authenticate the installed
-source bytes and recover both real cursorless field states on Linux and macOS
-while running with the immutable rescue bootstrap’s minimal
+manufacturing a cursor. The candidate resolver must recognize only those two
+real public cursorless field states and recover them on Linux and macOS while
+running with the immutable rescue bootstrap’s minimal
 `/usr/bin:/bin:/usr/sbin:/sbin` tool path. This keeps the seven-lane matrix
 compact while retaining the exact `0.8.7` regression after it stops being the
 latest-older lane.

--- a/docs/RELEASE_VALIDATION.md
+++ b/docs/RELEASE_VALIDATION.md
@@ -57,11 +57,10 @@ publication:
 | macOS | Intel and Apple Silicon gateway archives, shared CLI/plugin assets, and the unified macOS app | Install the exact sealed candidate with `install.sh`; run the same target-specific authenticated upgrade paths; with a complete Apple credential set, require Developer ID signing and notarization; with no Apple credentials, require ad-hoc signing and explicit `-unverified` artifact names |
 | Windows | amd64 and arm64 gateway binaries, shared CLI assets, and the x64 `DefenseClawSetup-x64.exe` | Exercise the exact x64 candidate through `install.ps1` and native Setup; verify the installed CLI/gateway versions; with both Windows credentials, require Cisco Authenticode; with neither, require explicit unverified provenance and exact `NotSigned` state |
 
-This is the complete release acceptance scope. The first native Windows release
-has no older native Windows baseline, and all Windows acceptance through
-`0.8.8` is explicitly fresh-install-only. Request validation blocks any later
-target until native Windows upgrade certification exists.
-This is a fresh-install only gate, not evidence of a native upgrade path.
+This is the complete release acceptance scope. Windows acceptance is
+explicitly fresh-install-only. Every target must pass the exact native Setup
+and `install.ps1` lifecycle, but no historical Windows baseline is inferred or
+required. This gate is not evidence of a native Windows upgrade path.
 
 The POSIX upgrade sources are resolved from authenticated published release
 metadata: the latest supported version older than the target, the exact
@@ -78,6 +77,15 @@ fixture, exact `0.8.5`, exact `0.8.4`, newest `0.7.x` (`0.7.2` today), newest
 `0.6.x` (`0.6.6` today), and newest `0.5.x` (`0.5.0` today). Fixed anchors and
 family selectors are mandatory; baseline resolution fails instead of silently
 omitting an unavailable lane.
+
+Field-recovery acceptance additionally installs and runs first setup through
+the authenticated published `0.8.6` and `0.8.7` controllers without
+manufacturing a cursor. The candidate resolver must authenticate the installed
+source bytes and recover both real cursorless field states on Linux and macOS
+while running with the immutable rescue bootstrap’s minimal
+`/usr/bin:/bin:/usr/sbin:/sbin` tool path. This keeps the seven-lane matrix
+compact while retaining the exact `0.8.7` regression after it stops being the
+latest-older lane.
 
 Platform signing credentials are optional as complete groups. For macOS, all
 five Developer ID and notary values produce signed, notarized artifacts with

--- a/docs/WINDOWS_RESCUE.md
+++ b/docs/WINDOWS_RESCUE.md
@@ -51,7 +51,7 @@ fresh-install target.
 
 The downloaded `install.ps1` continues to own native Setup authentication,
 fresh installation, repair, and same-version servicing behavior. Windows
-release acceptance is fresh-install-only through `0.8.8`; this rescue path
+release acceptance is fresh-install-only; this rescue path
 does not create or claim a certified native Windows upgrade lane. A
 `repair-channel` workflow operation repairs only the signed discovery pointer,
 while native Setup repair services an installation already on the selected

--- a/scripts/release-preflight.py
+++ b/scripts/release-preflight.py
@@ -47,7 +47,6 @@ except ModuleNotFoundError:  # Direct ``python scripts/release-preflight.py`` ex
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_REPOSITORY = "cisco-ai-defense/defenseclaw"
-WINDOWS_FRESH_INSTALL_ONLY_THROUGH = "0.8.8"
 VERSION_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 GITHUB_CLI_UNTRUSTED_ENVIRONMENT = frozenset(
@@ -159,9 +158,13 @@ def validate_request(
     repository: str,
     ref: str,
     commit: str,
+    environment: Mapping[str, str] | None = None,
 ) -> None:
     """Validate the request GitHub bound to the selected ``main`` commit."""
 
+    request_environment = os.environ if environment is None else environment
+    if request_environment.get("DEFENSECLAW_UPGRADE_TEST_MODE"):
+        raise ReleasePreflightError("release requests cannot run with upgrade fixture test mode enabled")
     _version_key(version)
     if operation not in {"release", "repair-channel"}:
         raise ReleasePreflightError(f"unsupported release operation: {operation!r}")
@@ -243,12 +246,6 @@ def select_upgrade_baselines(
     if len(selected) != expected_lanes:
         raise ReleasePreflightError(
             f"target {target} requires exactly {expected_lanes} distinct POSIX release lanes; selected {len(selected)}"
-        )
-    if target_key > _version_key(WINDOWS_FRESH_INSTALL_ONLY_THROUGH):
-        raise ReleasePreflightError(
-            "native Windows upgrade certification is required after "
-            f"{WINDOWS_FRESH_INSTALL_ONLY_THROUGH}; add the Windows upgrade lane before "
-            f"releasing {target} (https://github.com/cisco-ai-defense/defenseclaw/issues/619)"
         )
     document["platform_published_baselines"]["windows"] = []
     payload = (json.dumps(document, indent=2, sort_keys=True) + "\n").encode("utf-8")

--- a/scripts/test-upgrade-protocol-release.sh
+++ b/scripts/test-upgrade-protocol-release.sh
@@ -814,7 +814,8 @@ run_candidate_updater_field_recovery_success() {
             tail_log "${SMOKE_HOME}/published-first-run.stderr"
             die "published ${baseline} could not complete its real first-run path"
         fi
-        python3 - "${SMOKE_HOME}/.defenseclaw" "${baseline}" <<'PY' \
+        "${SMOKE_HOME}/.defenseclaw/.venv/bin/python" -I -B - \
+            "${SMOKE_HOME}/.defenseclaw" "${baseline}" <<'PY' \
             || die "published ${baseline} did not reproduce its release-owned missing-cursor state"
 import json
 import os

--- a/scripts/test-upgrade-protocol-release.sh
+++ b/scripts/test-upgrade-protocol-release.sh
@@ -762,6 +762,7 @@ run_candidate_updater_field_recovery_success() {
     local audit_db=""
     local source_config_sha256=""
     local source_environment_sha256=""
+    local resolver_path=""
     log "Proving release-owned resolver field recovery (${recovery_case}) ${baseline} -> ${TARGET_VERSION}"
     if [[ "${recovery_case}" == "corrupt-audit-same-version" ]]; then
         [[ -n "${recovery_home}" \
@@ -774,9 +775,9 @@ run_candidate_updater_field_recovery_success() {
         # shellcheck disable=SC2034
         FROM_VERSION="${TARGET_VERSION}"
     else
-        [[ "${recovery_case}" == "clean-086-missing-cursor" \
-            && "${baseline}" == "0.8.6" ]] \
-            || die "missing-cursor field recovery is bound to exact published 0.8.6"
+        [[ "${recovery_case}" == "published-missing-cursor" \
+            && "${baseline}" =~ ^0[.]8[.][67]$ ]] \
+            || die "missing-cursor field recovery is bound to exact published 0.8.6 or 0.8.7"
         # install_baseline reads this global through the sourced release harness.
         # shellcheck disable=SC2034
         FROM_VERSION="${baseline}"
@@ -787,42 +788,89 @@ run_candidate_updater_field_recovery_success() {
         mkdir -p "${SMOKE_HOME}/.openclaw"
         chmod 700 "${SMOKE_HOME}/.openclaw"
 
-        # Reproduce the actual published 0.8.6 first-run defect through that
-        # release's own config API: clean config v8 was published, while the
-        # migration cursor was never created. Do not manufacture a partial
-        # cursor; that is an ambiguous damaged state the resolver must reject.
-        HOME="${SMOKE_HOME}" \
-        DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \
-        DEFENSECLAW_CONFIG="${SMOKE_HOME}/.defenseclaw/config.yaml" \
-            "${SMOKE_HOME}/.defenseclaw/.venv/bin/python" -I -B - <<'PY' \
-            || die "published 0.8.6 could not reproduce its clean first-run config"
+        # Reproduce the real field state through the exact authenticated
+        # published source controller. Both 0.8.6 and 0.8.7 can complete
+        # ordinary first-run setup with healthy release-owned components but
+        # without writing the 0.8.5 migration cursor. Never manufacture a
+        # cursor in the acceptance fixture.
+        if ! HOME="${SMOKE_HOME}" \
+            DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \
+            DEFENSECLAW_CONFIG="${SMOKE_HOME}/.defenseclaw/config.yaml" \
+            OPENCLAW_HOME="${SMOKE_HOME}/.openclaw" \
+            PATH="${SMOKE_HOME}/.local/bin:${PATH}" \
+                "${SMOKE_HOME}/.defenseclaw/.venv/bin/defenseclaw" init \
+                    --non-interactive \
+                    --yes \
+                    --connector codex \
+                    --profile observe \
+                    --scanner-mode local \
+                    --no-judge \
+                    --skip-install \
+                    --no-start-gateway \
+                    --no-verify \
+                    --json-summary \
+                    >"${SMOKE_HOME}/published-first-run.json" \
+                    2>"${SMOKE_HOME}/published-first-run.stderr"; then
+            tail_log "${SMOKE_HOME}/published-first-run.stderr"
+            die "published ${baseline} could not complete its real first-run path"
+        fi
+        python3 - "${SMOKE_HOME}/.defenseclaw" "${baseline}" <<'PY' \
+            || die "published ${baseline} did not reproduce its release-owned missing-cursor state"
+import json
 import os
 from pathlib import Path
-import secrets
+import stat
+import sys
 
-from defenseclaw.config import default_config, prepare_fresh_v8_config
+import yaml
 
-data_dir = Path(os.environ["DEFENSECLAW_HOME"])
-cfg = default_config()
-prepare_fresh_v8_config(cfg)
-cfg.save()
+
+def assert_owned_regular_file(path: Path, source_version: str) -> None:
+    info = path.lstat()
+    if (
+        stat.S_ISLNK(info.st_mode)
+        or not stat.S_ISREG(info.st_mode)
+        or info.st_uid != os.geteuid()
+        or stat.S_IMODE(info.st_mode) & 0o077
+    ):
+        raise SystemExit(
+            f"published {source_version} first-run custody is unsafe: {path.name}"
+        )
+
+
+data_dir = Path(sys.argv[1])
+source_version = sys.argv[2]
 cursor = data_dir / ".migration_state.json"
 if cursor.exists() or cursor.is_symlink():
-    raise SystemExit("published 0.8.6 unexpectedly created a migration cursor")
-(data_dir / ".env").write_text(
-    "DEFENSECLAW_GATEWAY_TOKEN=" + secrets.token_hex(32) + "\n",
-    encoding="utf-8",
-)
-os.chmod(data_dir / ".env", 0o600)
+    raise SystemExit(f"published {source_version} unexpectedly created a migration cursor")
+config_path = data_dir / "config.yaml"
+environment_path = data_dir / ".env"
+assert_owned_regular_file(config_path, source_version)
+if environment_path.exists() or environment_path.is_symlink():
+    assert_owned_regular_file(environment_path, source_version)
+config = json.loads(json.dumps(yaml.safe_load(config_path.read_text(encoding="utf-8"))))
+if (
+    not isinstance(config, dict)
+    or config.get("config_version") != 8
+    or config.get("observability") != {}
+):
+    raise SystemExit(f"published {source_version} first-run config is not clean v8")
 PY
         source_config_sha256="$(protocol_sha256_file "${SMOKE_HOME}/.defenseclaw/config.yaml")"
-        source_environment_sha256="$(protocol_sha256_file "${SMOKE_HOME}/.defenseclaw/.env")"
+        if [[ -f "${SMOKE_HOME}/.defenseclaw/.env" \
+              && ! -L "${SMOKE_HOME}/.defenseclaw/.env" ]]; then
+            source_environment_sha256="$(
+                protocol_sha256_file "${SMOKE_HOME}/.defenseclaw/.env"
+            )"
+        else
+            source_environment_sha256="absent"
+        fi
         prepare_isolated_docker_path
         start_source_gateway_canary
     fi
 
     case "${recovery_case}" in
-        clean-086-missing-cursor) ;;
+        published-missing-cursor) ;;
         corrupt-audit-same-version)
             stop_smoke_gateway
             audit_db="$(
@@ -884,6 +932,14 @@ PY
     local real_curl
     local log_file="${SMOKE_HOME}/upgrade.log"
     real_curl="$(install_curl_rewrite_probe "${curl_shim}")"
+    resolver_path="${curl_shim}:${SMOKE_HOME}/.local/bin:${PATH}"
+    if [[ "${recovery_case}" == "published-missing-cursor" ]]; then
+        # The immutable 0.8.8 rescue bootstrap deliberately hands the target
+        # resolver this minimal PATH. Keep release acceptance on the exact
+        # field boundary so an ambient developer/runner uv cannot mask a
+        # broken explicit discovery or authenticated bootstrap path.
+        resolver_path="${curl_shim}:/usr/bin:/bin:/usr/sbin:/sbin"
+    fi
 
     if ! HOME="${SMOKE_HOME}" \
         DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \
@@ -895,7 +951,7 @@ PY
         UPGRADE_GATE_REAL_CURL="${real_curl}" \
         UPGRADE_GATE_RELEASE_URL="${RELEASE_URL}" \
         UPGRADE_GATE_TARGET_VERSION="${TARGET_VERSION}" \
-        PATH="${curl_shim}:${SMOKE_HOME}/.local/bin:${PATH}" \
+        PATH="${resolver_path}" \
             bash "${RELEASE_ROOT}/${TARGET_VERSION}/defenseclaw-upgrade.sh" \
             "${resolver_args[@]}" >"${log_file}" 2>&1; then
         tail_v8_upgrade_log_secret_safe "${log_file}"
@@ -903,17 +959,18 @@ PY
     fi
 
     case "${recovery_case}" in
-        clean-086-missing-cursor)
-            grep -Fq "Authenticated the exact clean 0.8.6 missing-cursor compatibility state" \
+        published-missing-cursor)
+            grep -Fq "Authenticated the exact published ${baseline} missing-cursor compatibility state" \
                 "${log_file}" \
-                || die "field recovery did not authenticate the exact clean 0.8.6 source"
+                || die "field recovery did not authenticate the exact published ${baseline} source"
             python3 - \
                 "${SMOKE_HOME}/.defenseclaw" \
                 "${RELEASE_ROOT}/${TARGET_VERSION}/upgrade-manifest.json" \
                 "${source_config_sha256}" \
                 "${source_environment_sha256}" \
-                "${TARGET_VERSION}" <<'PY' \
-                || die "clean 0.8.6 field-recovery verification failed"
+                "${TARGET_VERSION}" \
+                "${baseline}" <<'PY' \
+                || die "published ${baseline} field-recovery verification failed"
 import hashlib
 import json
 from pathlib import Path
@@ -922,7 +979,7 @@ import sys
 
 data_dir = Path(sys.argv[1])
 manifest = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
-source_config_sha256, source_environment_sha256, target_version = sys.argv[3:]
+source_config_sha256, source_environment_sha256, target_version, source_version = sys.argv[3:]
 cursor = json.loads((data_dir / ".migration_state.json").read_text(encoding="utf-8"))
 applied = set(cursor.get("applied", []))
 required = set(manifest.get("required_cli_migrations", []))
@@ -936,6 +993,18 @@ if (data_dir / ".migration_state.fresh.pending.json").exists():
 def digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
+
+def environment_matches(path: Path) -> bool:
+    environment = path / ".env"
+    if source_environment_sha256 == "absent":
+        return not environment.exists() and not environment.is_symlink()
+    return (
+        environment.is_file()
+        and not environment.is_symlink()
+        and digest(environment) == source_environment_sha256
+    )
+
+
 backups = [
     path
     for path in (data_dir / "backups").glob("upgrade-*")
@@ -943,12 +1012,11 @@ backups = [
 ]
 if not any(
     (path / "config.yaml").is_file()
-    and (path / ".env").is_file()
     and digest(path / "config.yaml") == source_config_sha256
-    and digest(path / ".env") == source_environment_sha256
+    and environment_matches(path)
     for path in backups
 ):
-    raise SystemExit("field recovery retained no byte-exact clean 0.8.6 backup")
+    raise SystemExit(f"field recovery retained no byte-exact published {source_version} backup")
 
 stack = data_dir / "observability-stack"
 if stack.is_symlink() or (stack.exists() and not stack.is_dir()):
@@ -1039,8 +1107,11 @@ run_candidate_updater_field_recovery_cases() (
     trap restore_field_recovery_harness_state EXIT
 
     if [[ "${baseline}" == "0.8.6" ]]; then
-        run_candidate_updater_field_recovery_success \
-            "${baseline}" clean-086-missing-cursor
+        local source_version
+        for source_version in 0.8.6 0.8.7; do
+            run_candidate_updater_field_recovery_success \
+                "${source_version}" published-missing-cursor
+        done
     fi
     run_candidate_updater_field_recovery_success \
         "${TARGET_VERSION}" corrupt-audit-same-version "${installed_target_home}"

--- a/scripts/test-upgrade-protocol-release.sh
+++ b/scripts/test-upgrade-protocol-release.sh
@@ -961,9 +961,9 @@ PY
 
     case "${recovery_case}" in
         published-missing-cursor)
-            grep -Fq "Authenticated the exact published ${baseline} missing-cursor compatibility state" \
+            grep -Fq "Accepted exact public ${baseline} cursorless first-run state" \
                 "${log_file}" \
-                || die "field recovery did not authenticate the exact published ${baseline} source"
+                || die "field recovery did not accept the exact public ${baseline} cursorless state"
             python3 - \
                 "${SMOKE_HOME}/.defenseclaw" \
                 "${RELEASE_ROOT}/${TARGET_VERSION}/upgrade-manifest.json" \
@@ -1338,7 +1338,6 @@ main_protocol_gate() {
         assert_reviewed_resolver_asset_contract
     else
         prepare_required_bridge_assets
-        prepare_field_recovery_source_assets
     fi
     start_release_server
     if [[ "${REFUSAL_CONTRACT_ONLY}" != "1" ]]; then

--- a/scripts/test-upgrade-release.sh
+++ b/scripts/test-upgrade-release.sh
@@ -970,22 +970,6 @@ prepare_required_bridge_assets() {
     fi
 }
 
-prepare_field_recovery_source_assets() {
-    [[ "${UPGRADE_SMOKE_FIELD_RECOVERY_CASES:-0}" == "1" ]] || return 0
-
-    # The missing-cursor resolver re-authenticates the exact published 0.8.6
-    # or 0.8.7 source contract before accepting the field state produced by
-    # that release's own installer and first-run command. Stage both bounded
-    # source views before the local server starts. The shared helper
-    # authenticates the checksum proof first, then every served wheel, gateway,
-    # manifest, and provenance payload.
-    local source_version
-    for source_version in 0.8.6 0.8.7; do
-        prepare_authenticated_upgrade_release_assets \
-            "${source_version}" "field-recovery source" 1
-    done
-}
-
 tail_log() {
     local file="$1"
     if [[ -f "${file}" ]]; then

--- a/scripts/test-upgrade-release.sh
+++ b/scripts/test-upgrade-release.sh
@@ -973,14 +973,17 @@ prepare_required_bridge_assets() {
 prepare_field_recovery_source_assets() {
     [[ "${UPGRADE_SMOKE_FIELD_RECOVERY_CASES:-0}" == "1" ]] || return 0
 
-    # The clean missing-cursor resolver re-authenticates the exact published
-    # 0.8.6 source contract before it accepts that compatibility state. The
-    # smoke curl shim points versioned GitHub release URLs at RELEASE_ROOT, so
-    # stage this bounded source view before the local server starts. Reuse the
-    # same helper as bridge staging: it authenticates the checksum proof first,
-    # then every served wheel, gateway, manifest, and provenance payload.
-    prepare_authenticated_upgrade_release_assets \
-        "0.8.6" "field-recovery source" 1
+    # The missing-cursor resolver re-authenticates the exact published 0.8.6
+    # or 0.8.7 source contract before accepting the field state produced by
+    # that release's own installer and first-run command. Stage both bounded
+    # source views before the local server starts. The shared helper
+    # authenticates the checksum proof first, then every served wheel, gateway,
+    # manifest, and provenance payload.
+    local source_version
+    for source_version in 0.8.6 0.8.7; do
+        prepare_authenticated_upgrade_release_assets \
+            "${source_version}" "field-recovery source" 1
+    done
 }
 
 tail_log() {

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -6756,6 +6756,7 @@ PY
     HARD_CUT_CURSOR_RECOVERY=1
     RELEASE_VERSION="${requested_version}"
     configure_release
+    prepare_release_contract
     ok "Authenticated the exact published ${source_version} missing-cursor compatibility state"
 }
 
@@ -8137,7 +8138,9 @@ if not os.path.islink(launcher) or os.path.realpath(launcher) != os.path.realpat
     )
 PY
 
-    BRIDGE_PYTHON_INTERPRETER="$("${DEFENSECLAW_VENV}/bin/python" -I -B -c 'import os,sys; print(os.path.realpath(getattr(sys, "_base_executable", "") or sys.executable))')" \
+    BRIDGE_PYTHON_INTERPRETER="$("${DEFENSECLAW_VENV}/bin/python" \
+        -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B -c \
+        'import os,sys; print(os.path.realpath(getattr(sys, "_base_executable", "") or sys.executable))')" \
         || die "Could not resolve the source Python interpreter; no services changed."
     [[ -x "${BRIDGE_PYTHON_INTERPRETER}" ]] \
         || die "The source Python interpreter is unavailable; no services changed."
@@ -8271,7 +8274,8 @@ PY
 
     BRIDGE_SOURCE_HEALTH_URL="$(DEFENSECLAW_HOME="${DATA_DIR}" \
         DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
-        "${DEFENSECLAW_VENV}/bin/python" -I -B - <<'PY' 2>/dev/null || true
+        "${DEFENSECLAW_VENV}/bin/python" \
+            -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B - <<'PY' 2>/dev/null || true
 from defenseclaw.config import load
 
 cfg = load()
@@ -8983,8 +8987,9 @@ validate_tarball_members() {
 
 if [[ -n "${HARD_CUT_CURSOR_RECOVERY_SOURCE_VERSION}" ]]; then
     authenticate_release_owned_missing_cursor_source
+else
+    prepare_release_contract
 fi
-prepare_release_contract
 FINAL_RELEASE_PROVENANCE_BRIDGE_CHECKSUMS_SHA256="${RELEASE_PROVENANCE_BRIDGE_CHECKSUMS_SHA256}"
 resolve_staged_upgrade
 if version_lt "${RELEASE_VERSION}" "0.8.4"; then

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -93,6 +93,7 @@ readonly COSIGN_BOOTSTRAP_VERSION="2.6.3"
 readonly COSIGN_BOOTSTRAP_MAX_BYTES="209715200"
 readonly UV_BOOTSTRAP_VERSION="0.11.28"
 readonly UV_BOOTSTRAP_MAX_BYTES="209715200"
+readonly MANAGED_PYTHON_NO_LOCAL_BYTECODE="pycache_prefix=/dev/null"
 readonly UPGRADE_MANIFEST_NAME="upgrade-manifest.json"
 readonly RELEASE_PROVENANCE_NAME="release-provenance.json"
 readonly HISTORICAL_BOOTSTRAP_MCP_SCANNER_CONSTRAINT='cisco-ai-mcp-scanner @ https://files.pythonhosted.org/packages/5d/74/6e72cbd496c0d33dfab1b4aee62792620236e63cccf278a8c896c6feb740/cisco_ai_mcp_scanner-4.7.2-py3-none-any.whl#sha256=6ed0b8ced168886f572aec30a971c7b0e2e1de7eea489d3821627184fd271ac8'
@@ -119,6 +120,7 @@ UPGRADE_ADVISORY_LOCK_INODE=""
 BRIDGE_PHASE1_RECOVERY_TERMINAL_CONTROLLER=""
 BRIDGE_PHASE1_RECOVERY_TERMINAL_VERSION=""
 UV_BIN=""
+STAGING_DIR=""
 
 # ── Terminal Formatting ───────────────────────────────────────────────────────
 
@@ -163,6 +165,37 @@ PY
 
 version_gte() {
     ! version_lt "$1" "$2"
+}
+
+prepare_upgrade_staging() {
+    if [[ -z "${STAGING_DIR}" ]]; then
+        STAGING_DIR="$(mktemp -d)" \
+            || die "Could not create private upgrade staging. No changes were made."
+        chmod 700 "${STAGING_DIR}" \
+            || die "Could not protect private upgrade staging. No changes were made."
+    fi
+    python3 - "${STAGING_DIR}" <<'PY' \
+        || die "Private upgrade staging is unsafe. No changes were made."
+import os
+import stat
+import sys
+
+path = os.path.abspath(sys.argv[1])
+info = os.lstat(path)
+if (
+    stat.S_ISLNK(info.st_mode)
+    or not stat.S_ISDIR(info.st_mode)
+    or info.st_uid != os.geteuid()
+    or stat.S_IMODE(info.st_mode) != 0o700
+):
+    raise SystemExit(1)
+PY
+}
+
+cleanup_upgrade_staging() {
+    [[ -z "${STAGING_DIR:-}" ]] || rm -rf -- "${STAGING_DIR}"
+    STAGING_DIR=""
+    UV_BIN=""
 }
 
 resolve_upgrade_uv() {
@@ -768,7 +801,8 @@ begin_release_upgrade_receipt() {
 
     local receipt_path receipt_name
     receipt_path="$(
-        DEFENSECLAW_HOME="${DATA_DIR}" "${source_python}" -I -B - \
+        DEFENSECLAW_HOME="${DATA_DIR}" "${source_python}" \
+            -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B - \
             "${DATA_DIR}" "${CURRENT_VERSION}" "${RELEASE_VERSION}" <<'PY'
 import os
 import sys
@@ -1152,9 +1186,9 @@ PY
        && -n "${recorded_config_path}" ]] \
         || die "Interrupted phase-two recovery journal did not yield a pending bridge plan."
 
-    uv_bin="$(command -v uv 2>/dev/null || true)"
-    [[ -n "${uv_bin}" ]] \
-        || die "uv is required to bootstrap the retained 0.8.4 recovery controller."
+    prepare_upgrade_staging
+    resolve_upgrade_uv
+    uv_bin="${UV_BIN}"
     venv_python="${DEFENSECLAW_VENV}/bin/python"
     python3 - "${journal_root}/phase-two-mutator.lease" "${uv_bin}" \
         "${DEFENSECLAW_VENV}" "${venv_python}" "${wheel}" "${expected_digest}" <<'PY' \
@@ -4360,7 +4394,8 @@ ensure_upgrade_lock_before_mutation() {
     recover_interrupted_phase_two
     recover_interrupted_bridge_phase1
     if [[ -x "${DEFENSECLAW_VENV}/bin/python" ]]; then
-        observed_version="$("${DEFENSECLAW_VENV}/bin/python" -I -B -c \
+        observed_version="$("${DEFENSECLAW_VENV}/bin/python" \
+            -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B -c \
             'from defenseclaw import __version__; print(__version__)' 2>/dev/null \
             | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
     elif has defenseclaw; then
@@ -4378,6 +4413,14 @@ ensure_upgrade_lock_before_mutation() {
           || "${observed_gateway_version}" != "${CURRENT_GATEWAY_VERSION}" ]]; then
         die "Installed components changed while the upgrade was being prepared (CLI ${CURRENT_VERSION} → ${observed_version}; gateway ${CURRENT_GATEWAY_VERSION} → ${observed_gateway_version}). No services were stopped; re-run the release-owned resolver."
     fi
+}
+
+early_recovery_exit_trap() {
+    local status=$?
+    trap - EXIT
+    cleanup_upgrade_staging
+    release_upgrade_lock
+    exit "${status}"
 }
 
 # ── Argument Parsing ──────────────────────────────────────────────────────────
@@ -4436,7 +4479,7 @@ if [[ -e "${UPGRADE_RECOVERY_ROOT}/phase-one-active.json" \
       || -e "${UPGRADE_RECOVERY_ROOT}/phase-two-active.json" \
       || -L "${UPGRADE_RECOVERY_ROOT}/phase-two-active.json" ]]; then
     acquire_upgrade_lock
-    trap release_upgrade_lock EXIT
+    trap early_recovery_exit_trap EXIT
     recover_interrupted_phase_two
     recover_interrupted_bridge_phase1
     if [[ "${BRIDGE_PHASE1_RECOVERY_TERMINAL_CONTROLLER}" == "bridge" \
@@ -4444,6 +4487,7 @@ if [[ -e "${UPGRADE_RECOVERY_ROOT}/phase-one-active.json" \
           && "${RELEASE_VERSION#v}" == "${BRIDGE_PHASE1_RECOVERY_TERMINAL_VERSION}" ]]; then
         section "Upgrade Complete"
         ok "Recovered and verified DefenseClaw ${BRIDGE_PHASE1_RECOVERY_TERMINAL_VERSION}"
+        cleanup_upgrade_staging
         release_upgrade_lock
         trap - EXIT
         exit 0
@@ -4506,7 +4550,8 @@ HARD_CUT_CURSOR_RECOVERY_SOURCE_VERSION=""
 
 CURRENT_VERSION="unknown"
 if [[ -x "${DEFENSECLAW_VENV}/bin/python" ]]; then
-    CURRENT_VERSION="$("${DEFENSECLAW_VENV}/bin/python" -I -B -c \
+    CURRENT_VERSION="$("${DEFENSECLAW_VENV}/bin/python" \
+        -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B -c \
         'from defenseclaw import __version__; print(__version__)' 2>/dev/null \
         | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
 elif has defenseclaw; then
@@ -4568,7 +4613,8 @@ if [[ "${CURRENT_VERSION}" != "unknown" && -x "${DEFENSECLAW_VENV}/bin/python" ]
     runtime_paths="$(
         DEFENSECLAW_HOME="${CONTROLLER_HOME}" \
         DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
-        "${DEFENSECLAW_VENV}/bin/python" -I -B - \
+        "${DEFENSECLAW_VENV}/bin/python" \
+            -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B - \
             "${CONTROLLER_HOME}" \
             "${CONFIG_PATH}" \
             "${OPENCLAW_HOME_EXPLICIT}" \
@@ -4686,7 +4732,8 @@ if [[ "${COMPONENT_VERSION_SPLIT}" -eq 1 ]]; then
           && -x "${DEFENSECLAW_VENV}/bin/python" ]] \
         && version_lt "${CURRENT_VERSION}" "${CURRENT_GATEWAY_VERSION}"; then
         split_recovery="$(
-            DEFENSECLAW_HOME="${DATA_DIR}" "${DEFENSECLAW_VENV}/bin/python" -I -B - \
+            DEFENSECLAW_HOME="${DATA_DIR}" "${DEFENSECLAW_VENV}/bin/python" \
+                -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B - \
                 "${DATA_DIR}" "${CURRENT_VERSION}" "${RELEASE_VERSION}" <<'PY'
 from datetime import datetime
 import os
@@ -4781,7 +4828,8 @@ AUDIT_DB_RECOVERY_CUSTODY=""
 AUDIT_DB_PREFLIGHT_IDENTITY=""
 
 if [[ "${CURRENT_VERSION}" != "unknown" ]] && version_gte "${CURRENT_VERSION}" "0.8.5"; then
-    hard_cut_state="$("${DEFENSECLAW_VENV}/bin/python" -I -B - "${CONFIG_PATH}" \
+    hard_cut_state="$("${DEFENSECLAW_VENV}/bin/python" \
+        -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B - "${CONFIG_PATH}" \
         "${DATA_DIR}/.migration_state.json" "${CURRENT_VERSION}" <<'PY' 2>/dev/null || true
 import json
 import os
@@ -5287,7 +5335,7 @@ configure_release
 
 section "Downloading Artifacts"
 
-STAGING_DIR="$(mktemp -d)"
+prepare_upgrade_staging
 BRIDGE_PHASE1=0
 BRIDGE_ROLLBACK_ARMED=0
 BRIDGE_ROLLBACK_RUNNING=0
@@ -5323,7 +5371,7 @@ upgrade_exit_trap() {
     fi
     [[ -z "${BRIDGE_GATEWAY_INSTALL_TEMP:-}" ]] || rm -f "${BRIDGE_GATEWAY_INSTALL_TEMP}"
     [[ -z "${BRIDGE_CANDIDATE_VENV:-}" ]] || rm -rf "${BRIDGE_CANDIDATE_VENV}"
-    [[ -z "${STAGING_DIR:-}" ]] || rm -rf "${STAGING_DIR}"
+    cleanup_upgrade_staging
     release_upgrade_lock
     if [[ "${rollback_status}" -ne 0 ]]; then
         err "Automatic source rollback was incomplete. Recovery evidence was preserved at ${BACKUP_DIR:-unknown}."
@@ -6335,7 +6383,8 @@ PY
     preflight_python_wheel "${source_wheel}"
 
     DEFENSECLAW_HOME="${DATA_DIR}" DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
-        "${DEFENSECLAW_VENV}/bin/python" -I -B - \
+        "${DEFENSECLAW_VENV}/bin/python" \
+            -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B - \
         "${source_wheel}" "${source_gateway}" "${CONFIG_PATH}" "${DATA_DIR}" \
         "${BACKUP_ROOT}" "${DEFENSECLAW_VENV}" \
         "${installed_gateway_comparison}" "${source_version}" <<'PY' \
@@ -8825,8 +8874,7 @@ continue_post_hard_cut_upgrade() {
     unset DEFENSECLAW_STAGED_BRIDGE_VERSION
     unset DEFENSECLAW_STAGED_BRIDGE_ARTIFACT_DIR
     unset DEFENSECLAW_STAGED_TARGET_CONTROLLER_VERSION
-    [[ -z "${STAGING_DIR:-}" ]] || rm -rf "${STAGING_DIR}"
-    STAGING_DIR=""
+    cleanup_upgrade_staging
     # The immutable 0.8.5 controller gives child commands 30 seconds but owns
     # a separate 60-second, version-aware gateway health poll. Current gateway
     # binaries consume this process-scoped handoff marker after safe launch so

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -91,6 +91,8 @@ readonly UPGRADE_PROTOCOL_VERSION=2
 readonly OBSERVABILITY_V8_HARD_CUT_VERSION="0.8.5"
 readonly COSIGN_BOOTSTRAP_VERSION="2.6.3"
 readonly COSIGN_BOOTSTRAP_MAX_BYTES="209715200"
+readonly UV_BOOTSTRAP_VERSION="0.11.28"
+readonly UV_BOOTSTRAP_MAX_BYTES="209715200"
 readonly UPGRADE_MANIFEST_NAME="upgrade-manifest.json"
 readonly RELEASE_PROVENANCE_NAME="release-provenance.json"
 readonly HISTORICAL_BOOTSTRAP_MCP_SCANNER_CONSTRAINT='cisco-ai-mcp-scanner @ https://files.pythonhosted.org/packages/5d/74/6e72cbd496c0d33dfab1b4aee62792620236e63cccf278a8c896c6feb740/cisco_ai_mcp_scanner-4.7.2-py3-none-any.whl#sha256=6ed0b8ced168886f572aec30a971c7b0e2e1de7eea489d3821627184fd271ac8'
@@ -116,6 +118,7 @@ UPGRADE_ADVISORY_LOCK_DEVICE=""
 UPGRADE_ADVISORY_LOCK_INODE=""
 BRIDGE_PHASE1_RECOVERY_TERMINAL_CONTROLLER=""
 BRIDGE_PHASE1_RECOVERY_TERMINAL_VERSION=""
+UV_BIN=""
 
 # ── Terminal Formatting ───────────────────────────────────────────────────────
 
@@ -160,6 +163,340 @@ PY
 
 version_gte() {
     ! version_lt "$1" "$2"
+}
+
+resolve_upgrade_uv() {
+    [[ -n "${UV_BIN}" && -x "${UV_BIN}" ]] && return 0
+    [[ -n "${STAGING_DIR:-}" && -d "${STAGING_DIR}" && ! -L "${STAGING_DIR}" ]] \
+        || die "Private staging is unavailable for Python tool custody. No changes were made."
+
+    local tool_root="${STAGING_DIR}/upgrade-tools"
+    local candidate=""
+    local discovered=""
+    local archive=""
+    local asset=""
+    local expected=""
+    local member=""
+    mkdir -p "${tool_root}" \
+        || die "Could not create private Python tool custody. No changes were made."
+    chmod 700 "${tool_root}" \
+        || die "Could not protect private Python tool custody. No changes were made."
+
+    discovered="$(type -P uv 2>/dev/null || true)"
+    if [[ -n "${discovered}" ]]; then
+        candidate="${discovered}"
+    else
+        local known
+        for known in \
+            "${HOME}/.local/bin/uv" \
+            "${HOME}/.cargo/bin/uv" \
+            "/opt/homebrew/bin/uv" \
+            "/usr/local/bin/uv"; do
+            if [[ -e "${known}" || -L "${known}" ]]; then
+                candidate="${known}"
+                break
+            fi
+        done
+    fi
+
+    if [[ -n "${candidate}" ]]; then
+        if python3 - "${candidate}" "${tool_root}/uv" "${UV_BOOTSTRAP_MAX_BYTES}" <<'PY' 2>/dev/null
+import hashlib
+import os
+import stat
+import sys
+
+source_name, destination, maximum_raw = sys.argv[1:]
+maximum = int(maximum_raw)
+uid = os.geteuid()
+source = os.path.realpath(os.path.abspath(os.path.expanduser(source_name)))
+parent = os.path.dirname(destination)
+
+parent_info = os.lstat(parent)
+if (
+    stat.S_ISLNK(parent_info.st_mode)
+    or not stat.S_ISDIR(parent_info.st_mode)
+    or parent_info.st_uid != uid
+    or stat.S_IMODE(parent_info.st_mode) & 0o077
+):
+    raise RuntimeError("private uv custody directory is unsafe")
+
+source_info = os.lstat(source)
+source_fd = os.open(
+    source,
+    os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+)
+created = False
+try:
+    opened = os.fstat(source_fd)
+    if (
+        not stat.S_ISREG(opened.st_mode)
+        or not os.path.samestat(source_info, opened)
+        or opened.st_uid not in {0, uid}
+        or stat.S_IMODE(opened.st_mode) & 0o022
+        or stat.S_IMODE(opened.st_mode) & 0o111 == 0
+        or not 0 < opened.st_size <= maximum
+    ):
+        raise RuntimeError("discovered uv is not a bounded trusted-owner executable")
+    source_identity = (
+        opened.st_dev,
+        opened.st_ino,
+        opened.st_uid,
+        opened.st_mode,
+        opened.st_size,
+        opened.st_mtime_ns,
+        opened.st_ctime_ns,
+    )
+    destination_fd = os.open(
+        destination,
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0),
+        0o700,
+    )
+    created = True
+    copied = hashlib.sha256()
+    try:
+        while True:
+            chunk = os.read(source_fd, 1024 * 1024)
+            if not chunk:
+                break
+            copied.update(chunk)
+            view = memoryview(chunk)
+            while view:
+                written = os.write(destination_fd, view)
+                if written <= 0:
+                    raise RuntimeError("uv custody copy made no progress")
+                view = view[written:]
+        os.fchmod(destination_fd, 0o700)
+        os.fsync(destination_fd)
+    finally:
+        os.close(destination_fd)
+
+    os.lseek(source_fd, 0, os.SEEK_SET)
+    reread = hashlib.sha256()
+    while True:
+        chunk = os.read(source_fd, 1024 * 1024)
+        if not chunk:
+            break
+        reread.update(chunk)
+    final_opened = os.fstat(source_fd)
+    final_named = os.lstat(source)
+    final_identity = (
+        final_opened.st_dev,
+        final_opened.st_ino,
+        final_opened.st_uid,
+        final_opened.st_mode,
+        final_opened.st_size,
+        final_opened.st_mtime_ns,
+        final_opened.st_ctime_ns,
+    )
+    if (
+        final_identity != source_identity
+        or not os.path.samestat(final_opened, final_named)
+        or copied.digest() != reread.digest()
+    ):
+        raise RuntimeError("discovered uv changed while entering private custody")
+    destination_info = os.lstat(destination)
+    if (
+        stat.S_ISLNK(destination_info.st_mode)
+        or not stat.S_ISREG(destination_info.st_mode)
+        or destination_info.st_uid != uid
+        or stat.S_IMODE(destination_info.st_mode) != 0o700
+        or destination_info.st_size != source_identity[4]
+    ):
+        raise RuntimeError("private uv custody is invalid")
+    with open(destination, "rb") as stream:
+        if hashlib.sha256(stream.read()).digest() != copied.digest():
+            raise RuntimeError("private uv custody changed after publication")
+    directory_fd = os.open(parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+except BaseException:
+    if created:
+        try:
+            os.unlink(destination)
+        except FileNotFoundError:
+            pass
+    raise
+finally:
+    os.close(source_fd)
+PY
+        then
+            if python3 - "${tool_root}/uv" "${UV_BOOTSTRAP_VERSION}" <<'PY' 2>/dev/null
+import os
+import re
+import subprocess
+import sys
+
+executable, expected_version = sys.argv[1:]
+environment = {
+    "HOME": os.environ.get("HOME", "/"),
+    "LANG": "C",
+    "LC_ALL": "C",
+    "PATH": "/usr/bin:/bin",
+}
+try:
+    completed = subprocess.run(
+        [executable, "--version"],
+        check=False,
+        env=environment,
+        stderr=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        timeout=10,
+    )
+except (OSError, subprocess.TimeoutExpired):
+    raise SystemExit(1)
+if completed.returncode != 0:
+    raise SystemExit(1)
+try:
+    reported = completed.stdout.decode("ascii").strip()
+except UnicodeDecodeError:
+    raise SystemExit(1)
+if len(reported) > 256:
+    raise SystemExit(1)
+match = re.fullmatch(
+    r"uv ([0-9]+\.[0-9]+\.[0-9]+)(?: \([ -~]{1,200}\))?",
+    reported,
+)
+raise SystemExit(0 if match is not None and match.group(1) == expected_version else 1)
+PY
+            then
+                UV_BIN="${tool_root}/uv"
+                ok "Copied uv into private upgrade custody (${UV_BOOTSTRAP_VERSION})"
+                return 0
+            fi
+            rm -f -- "${tool_root}/uv"
+            warn "Ignoring a non-${UV_BOOTSTRAP_VERSION} uv candidate at ${candidate}; using the pinned bootstrap instead"
+        else
+            warn "Ignoring an unsafe or unstable uv candidate at ${candidate}; using the pinned bootstrap instead"
+        fi
+    fi
+
+    case "$(uname -s)/$(uname -m)" in
+        Darwin/x86_64)
+            asset="uv-x86_64-apple-darwin.tar.gz"
+            expected="2ad79983127ffca7d77b77ce6a24278d7e4f7b817a1acf72fea5f8124b4aac5e"
+            member="uv-x86_64-apple-darwin/uv"
+            ;;
+        Darwin/arm64)
+            asset="uv-aarch64-apple-darwin.tar.gz"
+            expected="33540eb7c883ab857eff79bd5ac2aa31fe27b595abecb4a9c003a2c998447232"
+            member="uv-aarch64-apple-darwin/uv"
+            ;;
+        Linux/x86_64|Linux/amd64)
+            asset="uv-x86_64-unknown-linux-gnu.tar.gz"
+            expected="e490a6464492183c5d4534a5527fb4440f7f2bb2f228162ad7e4afe076dc0224"
+            member="uv-x86_64-unknown-linux-gnu/uv"
+            ;;
+        Linux/aarch64|Linux/arm64)
+            asset="uv-aarch64-unknown-linux-gnu.tar.gz"
+            expected="03e9fe0a81b0718d0bc84625de3885df6cc3f89a8b6af6121d6b9f6113fb6533"
+            member="uv-aarch64-unknown-linux-gnu/uv"
+            ;;
+        *)
+            die "Automatic uv bootstrap is unavailable on this platform. No changes were made."
+            ;;
+    esac
+    archive="${tool_root}/${asset}"
+    info "uv was not available in trusted custody; authenticating temporary uv ${UV_BOOTSTRAP_VERSION}..."
+    curl --fail --silent --show-error --location \
+        --proto '=https' --proto-redir '=https' --tlsv1.2 \
+        --max-filesize "${UV_BOOTSTRAP_MAX_BYTES}" \
+        --output "${archive}" \
+        "https://github.com/astral-sh/uv/releases/download/${UV_BOOTSTRAP_VERSION}/${asset}" \
+        || die "Could not download the pinned uv bootstrap. No changes were made."
+    python3 - \
+        "${archive}" "${expected}" "${member}" "${tool_root}/uv" \
+        "${UV_BOOTSTRAP_MAX_BYTES}" <<'PY' \
+        || die "Pinned uv bootstrap authentication failed. No changes were made."
+import hashlib
+import os
+from pathlib import PurePosixPath
+import stat
+import sys
+import tarfile
+
+archive_name, expected, expected_member, destination, maximum_raw = sys.argv[1:]
+maximum = int(maximum_raw)
+uid = os.geteuid()
+archive_info = os.lstat(archive_name)
+if (
+    stat.S_ISLNK(archive_info.st_mode)
+    or not stat.S_ISREG(archive_info.st_mode)
+    or archive_info.st_uid != uid
+    or not 0 < archive_info.st_size <= maximum
+):
+    raise RuntimeError("downloaded uv archive is outside private bounded custody")
+
+archive_digest = hashlib.sha256()
+with open(archive_name, "rb") as stream:
+    while chunk := stream.read(1024 * 1024):
+        archive_digest.update(chunk)
+if archive_digest.hexdigest() != expected:
+    raise RuntimeError("downloaded uv archive digest mismatch")
+
+with tarfile.open(archive_name, mode="r:gz") as archive:
+    members = archive.getmembers()
+    if not members or len(members) > 16 or len({item.name for item in members}) != len(members):
+        raise RuntimeError("uv archive member inventory is invalid")
+    selected = None
+    for item in members:
+        path = PurePosixPath(item.name)
+        if path.is_absolute() or ".." in path.parts or item.issym() or item.islnk():
+            raise RuntimeError("uv archive contains an unsafe member")
+        if not (item.isdir() or item.isreg()):
+            raise RuntimeError("uv archive contains an unsupported member")
+        if item.name == expected_member:
+            selected = item
+    if selected is None or not selected.isreg() or not 0 < selected.size <= maximum:
+        raise RuntimeError("uv archive lacks the bounded expected executable")
+    source = archive.extractfile(selected)
+    if source is None:
+        raise RuntimeError("uv archive executable could not be opened")
+    descriptor = os.open(
+        destination,
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0),
+        0o700,
+    )
+    written = 0
+    try:
+        while True:
+            chunk = source.read(1024 * 1024)
+            if not chunk:
+                break
+            written += len(chunk)
+            if written > selected.size:
+                raise RuntimeError("uv archive executable exceeded its declared size")
+            view = memoryview(chunk)
+            while view:
+                count = os.write(descriptor, view)
+                if count <= 0:
+                    raise RuntimeError("uv bootstrap extraction made no progress")
+                view = view[count:]
+        if written != selected.size:
+            raise RuntimeError("uv archive executable was truncated")
+        os.fchmod(descriptor, 0o700)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+        source.close()
+directory_fd = os.open(os.path.dirname(destination), os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+try:
+    os.fsync(directory_fd)
+finally:
+    os.close(directory_fd)
+PY
+    UV_BIN="${tool_root}/uv"
+    ok "Pinned uv ${UV_BOOTSTRAP_VERSION} authenticated in private upgrade custody"
 }
 
 # Keep one bounded, fail-closed parser for every phase-one gateway.pid
@@ -389,9 +726,8 @@ preflight_python_wheel() {
     local wheel="$1"
     local uv_bin
     local -a dependency_args=(--only-binary litellm)
-    uv_bin="$(command -v uv 2>/dev/null || true)"
-    [[ -z "${uv_bin}" ]] \
-        && die "uv not found on PATH — cannot update Python CLI. Install uv, then re-run the upgrade."
+    resolve_upgrade_uv
+    uv_bin="${UV_BIN}"
 
     local preflight_python="${DEFENSECLAW_VENV}/bin/python"
     if [[ ! -x "${preflight_python}" ]]; then
@@ -4164,7 +4500,7 @@ STAGED_FINAL_MIN_PROTOCOL=""
 POST_HARD_CUT_FINAL_VERSION=""
 EXISTING_BRIDGE_REFRESH=0
 HARD_CUT_CURSOR_RECOVERY=0
-HARD_CUT_CURSOR_RECOVERY_CANDIDATE=0
+HARD_CUT_CURSOR_RECOVERY_SOURCE_VERSION=""
 
 # ── Detect currently installed version ───────────────────────────────────────
 
@@ -4480,18 +4816,26 @@ valid = (
     and isinstance(cursor.get("applied"), list)
     and "0.8.5" in cursor["applied"]
 )
-clean_086_candidate = (
-    current_version == "0.8.6"
+release_owned_missing_cursor_candidate = (
+    current_version in {"0.8.6", "0.8.7"}
     and cursor_absent
     and isinstance(config, dict)
     and type(config.get("config_version")) is int
     and config["config_version"] == 8
 )
-print("valid" if valid else ("clean-0.8.6-missing-cursor" if clean_086_candidate else "invalid"))
+print(
+    "valid"
+    if valid
+    else (
+        f"release-owned-missing-cursor:{current_version}"
+        if release_owned_missing_cursor_candidate
+        else "invalid"
+    )
+)
 PY
 )"
-    if [[ "${hard_cut_state}" == "clean-0.8.6-missing-cursor" ]]; then
-        HARD_CUT_CURSOR_RECOVERY_CANDIDATE=1
+    if [[ "${hard_cut_state}" == "release-owned-missing-cursor:"* ]]; then
+        HARD_CUT_CURSOR_RECOVERY_SOURCE_VERSION="${hard_cut_state#*:}"
     elif [[ "${hard_cut_state}" != "valid" ]]; then
         die "CLI and gateway report hard-cut version ${CURRENT_VERSION}, but config-v8 migration state is absent or invalid and no recoverable journal is active. No changes were made.
   Unsupported manual overwrite detected.
@@ -5694,18 +6038,26 @@ prepare_release_contract() {
     preflight_release_artifacts
 }
 
-authenticate_clean_086_missing_cursor_source() {
+authenticate_release_owned_missing_cursor_source() {
+    local source_version="${HARD_CUT_CURSOR_RECOVERY_SOURCE_VERSION}"
     local requested_version="${RELEASE_VERSION}"
-    local source_root="${STAGING_DIR}/authenticated-source-0.8.6"
-    local source_wheel
+    local source_root="${STAGING_DIR}/authenticated-source-${source_version}"
+    local source_wheel source_gateway_archive source_gateway
+    local installed_gateway_comparison="${INSTALL_DIR}/defenseclaw-gateway"
+    local gateway_comparison_kind=""
+    local source_wheel_sha256 source_gateway_sha256
+    [[ "${source_version}" =~ ^0[.]8[.][67]$ \
+       && "${CURRENT_VERSION}" == "${source_version}" ]] \
+        || die "Missing-cursor recovery is restricted to exact published 0.8.6 or 0.8.7 source state. No changes were made."
     mkdir -p "${source_root}"
 
-    RELEASE_VERSION="0.8.6"
+    RELEASE_VERSION="${source_version}"
     configure_release
-    section "Authenticating Published 0.8.6 Source"
+    section "Authenticating Published ${source_version} Source"
     prepare_release_contract
-    python3 - "${RELEASE_PROVENANCE_FILE}" "${UPGRADE_MANIFEST_FILE}" <<'PY' \
-        || die "Published 0.8.6 lacks the exact source-install identity required for missing-cursor recovery. No changes were made."
+    python3 - \
+        "${RELEASE_PROVENANCE_FILE}" "${UPGRADE_MANIFEST_FILE}" "${source_version}" <<'PY' \
+        || die "Published ${source_version} lacks the exact source-install identity required for missing-cursor recovery. No changes were made."
 import json
 import sys
 
@@ -5713,60 +6065,317 @@ with open(sys.argv[1], encoding="utf-8") as stream:
     provenance = json.load(stream)
 with open(sys.argv[2], encoding="utf-8") as stream:
     manifest = json.load(stream)
+source_version = sys.argv[3]
+if source_version not in {"0.8.6", "0.8.7"}:
+    raise SystemExit("unsupported missing-cursor source")
 identity = provenance.get("source_install_identity")
 if not (
-    provenance.get("release_version") == "0.8.6"
+    provenance.get("release_version") == source_version
     and isinstance(identity, dict)
     and identity.get("schema_version") == 1
-    and identity.get("source_release") == "0.8.6"
+    and identity.get("source_release") == source_version
     and type(identity.get("source_install_compatibility_epoch")) is int
     and identity["source_install_compatibility_epoch"] == 2
     and type(identity.get("runtime_config_version")) is int
     and identity["runtime_config_version"] == 8
     and manifest.get("schema_version") == 2
-    and manifest.get("release_version") == "0.8.6"
+    and manifest.get("release_version") == source_version
     and type(manifest.get("runtime_config_version")) is int
     and manifest["runtime_config_version"] == 8
     and manifest.get("required_bridge_version") == "0.8.4"
     and "0.8.5" in manifest.get("required_cli_migrations", [])
 ):
-    raise SystemExit("0.8.6 source-install identity differs")
+    raise SystemExit(f"{source_version} source-install identity differs")
 PY
 
     fetch_artifact "${WHL_URL}" "${source_root}/${WHL_NAME}"
     verify_checksum "${source_root}/${WHL_NAME}" "${WHL_NAME}"
+    source_wheel_sha256="${VERIFIED_CHECKSUM}"
     source_wheel="${source_root}/${MATERIALIZED_WHL_NAME}"
     materialize_protected_artifact \
-        "${source_root}/${WHL_NAME}" "${source_wheel}" "${VERIFIED_CHECKSUM}" \
-        || die "Could not materialize the authenticated 0.8.6 source wheel. No changes were made."
+        "${source_root}/${WHL_NAME}" "${source_wheel}" "${source_wheel_sha256}" \
+        || die "Could not materialize the authenticated ${source_version} source wheel. No changes were made."
+
+    fetch_artifact "${TARBALL_URL}" "${source_root}/${TARBALL_NAME}"
+    verify_checksum "${source_root}/${TARBALL_NAME}" "${TARBALL_NAME}"
+    source_gateway_sha256="${VERIFIED_CHECKSUM}"
+    source_gateway_archive="${source_root}/${MATERIALIZED_TARBALL_NAME}"
+    materialize_protected_artifact \
+        "${source_root}/${TARBALL_NAME}" \
+        "${source_gateway_archive}" \
+        "${source_gateway_sha256}" \
+        || die "Could not materialize the authenticated ${source_version} source gateway. No changes were made."
+    validate_tarball_members "${source_gateway_archive}"
+    mkdir "${source_root}/gateway"
+    tar -xzf "${source_gateway_archive}" -C "${source_root}/gateway" \
+        || die "Could not extract the authenticated ${source_version} source gateway. No changes were made."
+    source_gateway="${source_root}/gateway/defenseclaw"
+    [[ -f "${source_gateway}" && ! -L "${source_gateway}" ]] \
+        || die "Authenticated ${source_version} source gateway archive has no canonical executable. No changes were made."
+    if [[ "${OS}" == "darwin" ]]; then
+        # Fresh installs and upgrades deterministically replace the linker
+        # signature with this release-owned ad-hoc identity before publishing.
+        # First bind the installed bytes into private custody, validate the
+        # installer-owned signature there, then apply the current host's exact
+        # transform to both private copies. This tolerates a codesign-format
+        # change after an OS upgrade without ever modifying the live gateway.
+        installed_gateway_comparison="${source_root}/gateway/installed-normalized"
+        python3 - \
+            "${INSTALL_DIR}/defenseclaw-gateway" \
+            "${installed_gateway_comparison}" \
+            "536870912" <<'PY' \
+            || die "Could not bind the installed macOS gateway into private comparison custody. No changes were made."
+import hashlib
+import os
+import stat
+import sys
+
+source = os.path.abspath(sys.argv[1])
+destination = os.path.abspath(sys.argv[2])
+limit_raw = sys.argv[3]
+limit = int(limit_raw)
+uid = os.geteuid()
+parent = os.path.dirname(destination)
+
+
+def identity(value):
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_uid,
+        value.st_gid,
+        value.st_mode,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+
+parent_info = os.lstat(parent)
+if (
+    stat.S_ISLNK(parent_info.st_mode)
+    or not stat.S_ISDIR(parent_info.st_mode)
+    or parent_info.st_uid != uid
+    or stat.S_IMODE(parent_info.st_mode) & 0o077
+):
+    raise RuntimeError("private gateway comparison custody is unsafe")
+named = os.lstat(source)
+if (
+    stat.S_ISLNK(named.st_mode)
+    or not stat.S_ISREG(named.st_mode)
+    or named.st_uid != uid
+    or stat.S_IMODE(named.st_mode) & 0o022
+    or stat.S_IMODE(named.st_mode) & 0o111 == 0
+    or not 0 < named.st_size <= limit
+):
+    raise RuntimeError("installed gateway is not a bounded current-user executable")
+expected_identity = identity(named)
+source_fd = os.open(
+    source,
+    os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+)
+destination_fd = None
+created = False
+try:
+    opened = os.fstat(source_fd)
+    if identity(opened) != expected_identity:
+        raise RuntimeError("installed gateway changed while opening")
+    destination_fd = os.open(
+        destination,
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0),
+        0o700,
+    )
+    created = True
+    copied = hashlib.sha256()
+    total = 0
+    while True:
+        chunk = os.read(source_fd, 1024 * 1024)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > named.st_size:
+            raise RuntimeError("installed gateway changed while copying")
+        copied.update(chunk)
+        view = memoryview(chunk)
+        while view:
+            written = os.write(destination_fd, view)
+            if written <= 0:
+                raise RuntimeError("installed gateway custody copy made no progress")
+            view = view[written:]
+    if total != named.st_size:
+        raise RuntimeError("installed gateway changed while copying")
+    os.fchmod(destination_fd, 0o700)
+    os.fsync(destination_fd)
+    os.close(destination_fd)
+    destination_fd = None
+
+    os.lseek(source_fd, 0, os.SEEK_SET)
+    reread = hashlib.sha256()
+    while True:
+        chunk = os.read(source_fd, 1024 * 1024)
+        if not chunk:
+            break
+        reread.update(chunk)
+    if copied.digest() != reread.digest():
+        raise RuntimeError("installed gateway changed while entering custody")
+    if (
+        identity(os.fstat(source_fd)) != expected_identity
+        or identity(os.lstat(source)) != expected_identity
+    ):
+        raise RuntimeError("installed gateway changed after entering custody")
+    destination_info = os.lstat(destination)
+    if (
+        stat.S_ISLNK(destination_info.st_mode)
+        or not stat.S_ISREG(destination_info.st_mode)
+        or destination_info.st_uid != uid
+        or stat.S_IMODE(destination_info.st_mode) != 0o700
+        or destination_info.st_size != named.st_size
+    ):
+        raise RuntimeError("private installed-gateway custody is invalid")
+    destination_digest = hashlib.sha256()
+    with open(destination, "rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            destination_digest.update(chunk)
+    if destination_digest.digest() != copied.digest():
+        raise RuntimeError("private installed-gateway custody changed after publication")
+    directory_fd = os.open(parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+except BaseException:
+    if destination_fd is not None:
+        os.close(destination_fd)
+    if created:
+        try:
+            os.unlink(destination)
+        except FileNotFoundError:
+            pass
+    raise
+finally:
+    os.close(source_fd)
+PY
+        local gateway_fixture_marker="${source_root}/.defenseclaw-gateway-fixture-v1"
+        gateway_comparison_kind="$(python3 - \
+            "${source_gateway}" \
+            "${installed_gateway_comparison}" \
+            "${gateway_fixture_marker}" \
+            "${STAGING_DIR}" \
+            "${DEFENSECLAW_UPGRADE_TEST_MODE:-0}" <<'PY'
+import os
+from pathlib import Path
+import stat
+import sys
+
+source_path, installed_path, marker_path, staging_path = map(Path, sys.argv[1:5])
+test_mode = sys.argv[5]
+with source_path.open("rb") as stream:
+    source_magic = stream.read(4)
+with installed_path.open("rb") as stream:
+    installed_magic = stream.read(4)
+macho64_little = b"\xcf\xfa\xed\xfe"
+if source_magic == macho64_little and installed_magic == macho64_little:
+    print("macho")
+elif source_magic != macho64_little and source_magic == installed_magic:
+    if test_mode != "1":
+        raise SystemExit("non-Mach-O gateway fixtures require explicit test mode")
+    expected_marker = b"defenseclaw-gateway-fixture-v1\n"
+    staging = Path(os.path.realpath(staging_path))
+    source_parent = Path(os.path.realpath(source_path.parent))
+    marker_parent = Path(os.path.realpath(marker_path.parent))
+    if (
+        marker_path.name != ".defenseclaw-gateway-fixture-v1"
+        or marker_parent != source_parent.parent
+        or (staging != marker_parent and staging not in marker_parent.parents)
+    ):
+        raise SystemExit("macOS gateway fixture marker escaped private staging")
+    try:
+        marker_info = marker_path.lstat()
+    except OSError:
+        raise SystemExit("macOS gateway fixture marker is unavailable") from None
+    if (
+        stat.S_ISLNK(marker_info.st_mode)
+        or not stat.S_ISREG(marker_info.st_mode)
+        or marker_info.st_uid != os.geteuid()
+        or stat.S_IMODE(marker_info.st_mode) != 0o600
+        or marker_info.st_size != len(expected_marker)
+    ):
+        raise SystemExit("macOS gateway fixture marker custody is unsafe")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(marker_path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        payload = os.read(descriptor, len(expected_marker) + 1)
+    finally:
+        os.close(descriptor)
+    if not os.path.samestat(marker_info, opened) or payload != expected_marker:
+        raise SystemExit("macOS gateway fixture marker changed")
+    print("fixture")
+else:
+    raise SystemExit("authenticated and installed macOS gateway formats differ")
+PY
+        )" || die "Installed macOS gateway format differs from its authenticated source. No changes were made."
+        if [[ "${gateway_comparison_kind}" == "macho" ]]; then
+            /usr/bin/codesign --verify --strict \
+                -R '=identifier "com.cisco.defenseclaw.gateway"' \
+                "${installed_gateway_comparison}" 2>/dev/null \
+                || die "Installed macOS gateway lacks the release-owned installer signature. No changes were made."
+        fi
+        /usr/bin/codesign -f -s - -i com.cisco.defenseclaw.gateway \
+            "${source_gateway}" 2>/dev/null \
+            || die "Could not normalize the authenticated ${source_version} macOS source gateway. No changes were made."
+        /usr/bin/codesign -f -s - -i com.cisco.defenseclaw.gateway \
+            "${installed_gateway_comparison}" 2>/dev/null \
+            || die "Could not normalize the private installed macOS gateway comparison copy. No changes were made."
+    fi
     preflight_python_wheel "${source_wheel}"
 
     DEFENSECLAW_HOME="${DATA_DIR}" DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
         "${DEFENSECLAW_VENV}/bin/python" -I -B - \
-        "${source_wheel}" "${CONFIG_PATH}" "${DATA_DIR}" "${BACKUP_ROOT}" <<'PY' \
-        || die "Installed 0.8.6 mutable state is not the exact clean missing-cursor shape. No changes were made."
+        "${source_wheel}" "${source_gateway}" "${CONFIG_PATH}" "${DATA_DIR}" \
+        "${BACKUP_ROOT}" "${DEFENSECLAW_VENV}" \
+        "${installed_gateway_comparison}" "${source_version}" <<'PY' \
+        || die "Installed ${source_version} state is not the exact release-owned missing-cursor shape. No changes were made."
 import hashlib
+import importlib.util
 import os
 from pathlib import Path, PurePosixPath
 import stat
 import sys
 import zipfile
 
-wheel_path, config_path, data_dir, backup_root = map(os.path.abspath, sys.argv[1:])
+(
+    wheel_path,
+    source_gateway,
+    config_path,
+    data_dir,
+    backup_root,
+    venv,
+    installed_gateway,
+) = map(os.path.abspath, sys.argv[1:8])
+source_version = sys.argv[8]
 uid = os.geteuid()
-sys.path.insert(0, wheel_path)
-from defenseclaw.observability.v8_config import load_validate_v8  # noqa: E402
+if source_version not in {"0.8.6", "0.8.7"}:
+    raise RuntimeError("unsupported missing-cursor source")
 
 
-def read_regular(path, limit):
+def read_regular(path, limit, *, executable=False, allow_empty=False):
     info = os.lstat(path)
     if (
         stat.S_ISLNK(info.st_mode)
         or not stat.S_ISREG(info.st_mode)
         or info.st_uid != uid
-        or not 0 < info.st_size <= limit
+        or stat.S_IMODE(info.st_mode) & 0o022
+        or (executable and stat.S_IMODE(info.st_mode) & 0o111 == 0)
+        or info.st_size < 0
+        or info.st_size > limit
+        or (not allow_empty and info.st_size == 0)
     ):
-        raise RuntimeError(f"unsafe clean 0.8.6 file: {path}")
+        raise RuntimeError(f"unsafe release-owned source file: {path}")
     descriptor = os.open(
         path,
         os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
@@ -5774,7 +6383,7 @@ def read_regular(path, limit):
     try:
         opened = os.fstat(descriptor)
         if not os.path.samestat(info, opened):
-            raise RuntimeError("clean 0.8.6 file changed while opening")
+            raise RuntimeError("release-owned source file changed while opening")
         raw = b""
         while len(raw) <= info.st_size:
             chunk = os.read(descriptor, info.st_size + 1 - len(raw))
@@ -5782,14 +6391,148 @@ def read_regular(path, limit):
                 break
             raw += chunk
         if len(raw) != info.st_size:
-            raise RuntimeError("clean 0.8.6 file changed while reading")
+            raise RuntimeError("release-owned source file changed while reading")
+        final = os.fstat(descriptor)
+        named = os.lstat(path)
+        if not os.path.samestat(opened, final) or not os.path.samestat(final, named):
+            raise RuntimeError("release-owned source file changed after reading")
         return raw
     finally:
         os.close(descriptor)
 
 
+def digest_regular(path, limit, *, executable=False):
+    info = os.lstat(path)
+    if (
+        stat.S_ISLNK(info.st_mode)
+        or not stat.S_ISREG(info.st_mode)
+        or info.st_uid != uid
+        or stat.S_IMODE(info.st_mode) & 0o022
+        or (executable and stat.S_IMODE(info.st_mode) & 0o111 == 0)
+        or not 0 < info.st_size <= limit
+    ):
+        raise RuntimeError(f"unsafe release-owned source file: {path}")
+
+    def identity(value):
+        return (
+            value.st_dev,
+            value.st_ino,
+            value.st_uid,
+            value.st_gid,
+            value.st_mode,
+            value.st_size,
+            value.st_mtime_ns,
+            value.st_ctime_ns,
+        )
+
+    expected_identity = identity(info)
+    descriptor = os.open(
+        path,
+        os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+    )
+    try:
+        opened = os.fstat(descriptor)
+        if identity(opened) != expected_identity:
+            raise RuntimeError("release-owned source file changed while opening")
+        digest = hashlib.sha256()
+        total = 0
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > info.st_size:
+                raise RuntimeError("release-owned source file changed while reading")
+            digest.update(chunk)
+        if total != info.st_size:
+            raise RuntimeError("release-owned source file changed while reading")
+        final = os.fstat(descriptor)
+        named = os.lstat(path)
+        if identity(final) != expected_identity or identity(named) != expected_identity:
+            raise RuntimeError("release-owned source file changed after reading")
+        return digest.digest()
+    finally:
+        os.close(descriptor)
+
+
+source_gateway_digest = digest_regular(
+    source_gateway,
+    512 * 1024 * 1024,
+    executable=True,
+)
+installed_gateway_digest = digest_regular(
+    installed_gateway,
+    512 * 1024 * 1024,
+    executable=True,
+)
+if source_gateway_digest != installed_gateway_digest:
+    raise RuntimeError("installed gateway differs from the authenticated source release")
+
+expected_package = {}
+with zipfile.ZipFile(wheel_path) as archive:
+    infos = archive.infolist()
+    if len(infos) > 8192 or len({info.filename for info in infos}) != len(infos):
+        raise RuntimeError("authenticated source wheel has an unsafe inventory")
+    for info in infos:
+        path = PurePosixPath(info.filename)
+        if path.is_absolute() or ".." in path.parts:
+            raise RuntimeError("authenticated source wheel has an unsafe path")
+        encoded_mode = (info.external_attr >> 16) & 0xFFFF
+        kind = stat.S_IFMT(encoded_mode)
+        if kind not in {0, stat.S_IFREG, stat.S_IFDIR}:
+            raise RuntimeError("authenticated source wheel has a non-regular package member")
+        if info.is_dir() or not path.parts or path.parts[0] != "defenseclaw":
+            continue
+        if info.file_size > 64 * 1024 * 1024:
+            raise RuntimeError("authenticated source package member exceeds its bound")
+        relative = "/".join(path.parts[1:])
+        expected_package[relative] = hashlib.sha256(archive.read(info)).hexdigest()
+if not expected_package:
+    raise RuntimeError("authenticated source wheel lacks the DefenseClaw package")
+
+venv = os.path.realpath(venv)
+package_spec = importlib.util.find_spec("defenseclaw")
+if package_spec is None or not isinstance(package_spec.origin, str):
+    raise RuntimeError("installed source package cannot be resolved")
+package_root = os.path.realpath(os.path.dirname(package_spec.origin))
+if (
+    os.path.basename(package_root) != "defenseclaw"
+    or os.path.commonpath((package_root, venv)) != venv
+):
+    raise RuntimeError("installed source package escaped the managed venv")
+actual_package = {}
+for current, names, files in os.walk(package_root, topdown=True, followlinks=False):
+    current_info = os.lstat(current)
+    if (
+        stat.S_ISLNK(current_info.st_mode)
+        or not stat.S_ISDIR(current_info.st_mode)
+        or current_info.st_uid != uid
+        or stat.S_IMODE(current_info.st_mode) & 0o022
+    ):
+        raise RuntimeError("installed source package has unsafe directory custody")
+    names[:] = [name for name in names if name != "__pycache__"]
+    for name in names:
+        child = os.lstat(os.path.join(current, name))
+        if stat.S_ISLNK(child.st_mode) or not stat.S_ISDIR(child.st_mode):
+            raise RuntimeError("installed source package has an unsafe child")
+    for name in files:
+        path = os.path.join(current, name)
+        relative = os.path.relpath(path, package_root).replace(os.sep, "/")
+        if "__pycache__" in PurePosixPath(relative).parts or relative.endswith(".pyc"):
+            continue
+        if len(actual_package) >= 8192:
+            raise RuntimeError("installed source package exceeds its file bound")
+        actual_package[relative] = hashlib.sha256(
+            read_regular(path, 64 * 1024 * 1024, allow_empty=True)
+        ).hexdigest()
+if actual_package != expected_package:
+    raise RuntimeError("installed CLI package differs from the authenticated source release")
+
+sys.path.insert(0, wheel_path)
+from defenseclaw.observability.v8_config import load_validate_v8  # noqa: E402
+
 if os.path.lexists(os.path.join(data_dir, ".migration_state.json")):
-    raise RuntimeError("clean 0.8.6 recovery requires a completely absent migration cursor")
+    raise RuntimeError("release-owned recovery requires a completely absent migration cursor")
 source = load_validate_v8(
     read_regular(config_path, 4 * 1024 * 1024),
     source_name="config.yaml",
@@ -5802,7 +6545,7 @@ if (
     or source["observability"] != {}
     or any(name in source for name in legacy_roots)
 ):
-    raise RuntimeError("clean 0.8.6 config has migration or observability residue")
+    raise RuntimeError("release-owned source config has migration or observability residue")
 
 
 def decision_name(name):
@@ -5818,7 +6561,7 @@ def decision_name(name):
 
 
 if any(decision_name(name) for name in os.environ):
-    raise RuntimeError("clean 0.8.6 recovery refuses ambient observability decisions")
+    raise RuntimeError("release-owned recovery refuses ambient observability decisions")
 environment_path = os.path.join(data_dir, ".env")
 if os.path.lexists(environment_path):
     environment = read_regular(environment_path, 1024 * 1024).decode("utf-8")
@@ -5827,7 +6570,7 @@ if os.path.lexists(environment_path):
         if line and not line.startswith("#") and "=" in line:
             name = line.removeprefix("export ").split("=", 1)[0].strip()
             if decision_name(name):
-                raise RuntimeError("clean 0.8.6 environment has observability decisions")
+                raise RuntimeError("release-owned environment has observability decisions")
 
 for residue in (
     config_path + ".pre-observability-migration.bak",
@@ -5836,7 +6579,7 @@ for residue in (
     os.path.join(data_dir, ".upgrade-recovery"),
 ):
     if os.path.lexists(residue):
-        raise RuntimeError("clean 0.8.6 state has upgrade or migration residue")
+        raise RuntimeError("release-owned state has upgrade or migration residue")
 if os.path.lexists(backup_root):
     backup_info = os.lstat(backup_root)
     if (
@@ -5845,25 +6588,27 @@ if os.path.lexists(backup_root):
         or backup_info.st_uid != uid
         or any(Path(backup_root).iterdir())
     ):
-        raise RuntimeError("clean 0.8.6 state has prior or unsafe upgrade backups")
+        raise RuntimeError("release-owned state has prior or unsafe upgrade backups")
 
 expected = {}
 with zipfile.ZipFile(wheel_path) as archive:
     infos = archive.infolist()
     if len(infos) > 8192 or len({info.filename for info in infos}) != len(infos):
-        raise RuntimeError("authenticated 0.8.6 wheel has unsafe members")
+        raise RuntimeError(f"authenticated {source_version} wheel has unsafe members")
     for info in infos:
         path = PurePosixPath(info.filename)
         prefix = ("defenseclaw", "_data", "local_observability_stack")
         if path.is_absolute() or ".." in path.parts:
-            raise RuntimeError("authenticated 0.8.6 wheel has an unsafe path")
+            raise RuntimeError(f"authenticated {source_version} wheel has an unsafe path")
         if info.is_dir() or path.parts[:3] != prefix or len(path.parts) <= 3:
             continue
         if info.file_size > 64 * 1024 * 1024:
-            raise RuntimeError("authenticated 0.8.6 stack member exceeds its bound")
+            raise RuntimeError(
+                f"authenticated {source_version} stack member exceeds its bound"
+            )
         expected["/".join(path.parts[3:])] = hashlib.sha256(archive.read(info)).hexdigest()
 if not expected:
-    raise RuntimeError("authenticated 0.8.6 wheel lacks its local stack")
+    raise RuntimeError(f"authenticated {source_version} wheel lacks its local stack")
 
 stack_root = os.path.join(data_dir, "observability-stack")
 if not os.path.lexists(stack_root):
@@ -5874,30 +6619,30 @@ if (
     or not stat.S_ISDIR(stack_info.st_mode)
     or stack_info.st_uid != uid
 ):
-    raise RuntimeError("clean 0.8.6 local stack is missing or unsafe")
+    raise RuntimeError("release-owned local stack is missing or unsafe")
 actual = {}
 for current, names, files in os.walk(stack_root, topdown=True, followlinks=False):
     current_info = os.lstat(current)
     if stat.S_ISLNK(current_info.st_mode) or not stat.S_ISDIR(current_info.st_mode):
-        raise RuntimeError("clean 0.8.6 local stack has an unsafe directory")
+        raise RuntimeError("release-owned local stack has an unsafe directory")
     for name in names:
         child = os.lstat(os.path.join(current, name))
         if stat.S_ISLNK(child.st_mode) or not stat.S_ISDIR(child.st_mode):
-            raise RuntimeError("clean 0.8.6 local stack has an unsafe child")
+            raise RuntimeError("release-owned local stack has an unsafe child")
     for name in files:
         path = os.path.join(current, name)
         relative = os.path.relpath(path, stack_root).replace(os.sep, "/")
         if len(actual) >= 4096:
-            raise RuntimeError("clean 0.8.6 local stack exceeds its file bound")
+            raise RuntimeError("release-owned local stack exceeds its file bound")
         actual[relative] = hashlib.sha256(read_regular(path, 64 * 1024 * 1024)).hexdigest()
 if actual != expected:
-    raise RuntimeError("clean 0.8.6 local stack differs from the authenticated release")
+    raise RuntimeError("release-owned local stack differs from the authenticated release")
 PY
 
     HARD_CUT_CURSOR_RECOVERY=1
     RELEASE_VERSION="${requested_version}"
     configure_release
-    ok "Authenticated the exact clean 0.8.6 missing-cursor compatibility state"
+    ok "Authenticated the exact published ${source_version} missing-cursor compatibility state"
 }
 
 
@@ -7256,9 +8001,8 @@ prepare_bridge_phase1_cli_preflight() {
     local uv_bin preflight_venv preflight_version
     [[ -n "${whl_name:-}" && -f "${STAGING_DIR}/${whl_name}" ]] \
         || die "Bridge CLI artifact is unavailable for preflight; no services changed."
-    uv_bin="$(command -v uv 2>/dev/null || true)"
-    [[ -n "${uv_bin}" ]] \
-        || die "uv not found on PATH — cannot prepare the 0.8.4 bridge without a rollback-safe CLI replacement. No services changed."
+    resolve_upgrade_uv
+    uv_bin="${UV_BIN}"
 
     [[ -d "${DEFENSECLAW_VENV}" && ! -L "${DEFENSECLAW_VENV}" ]] \
         || die "The installed CLI environment is not a managed regular directory at ${DEFENSECLAW_VENV}. No services changed."
@@ -7467,7 +8211,8 @@ activate_bridge_phase1_cli() {
     local uv_bin source_venv_backup bridge_version bridge_seed
     [[ -n "${whl_name:-}" && -f "${BRIDGE_WHEEL_CUSTODY_PATH}" ]] \
         || die "Bridge CLI artifact is unavailable during activation"
-    uv_bin="$(command -v uv 2>/dev/null || true)"
+    resolve_upgrade_uv
+    uv_bin="${UV_BIN}"
     source_venv_backup="${BACKUP_DIR}/phase1-source-venv"
     [[ ! -e "${source_venv_backup}" && ! -L "${source_venv_backup}" ]] \
         || die "Phase-1 source CLI custody path already exists"
@@ -7872,9 +8617,8 @@ prepare_hard_cut_target_controller() {
         || die "Could not materialize the authenticated hard-cut target controller. No services changed."
     preflight_python_wheel "${materialized_wheel}"
 
-    uv_bin="$(command -v uv 2>/dev/null || true)"
-    [[ -n "${uv_bin}" ]] \
-        || die "uv not found on PATH — cannot prepare the fresh target controller. No services changed."
+    resolve_upgrade_uv
+    uv_bin="${UV_BIN}"
     [[ -x "${DEFENSECLAW_VENV}/bin/python" ]] \
         || die "The installed bridge Python environment is unavailable. No services changed."
     base_python="$("${DEFENSECLAW_VENV}"/bin/python -I -B -c \
@@ -8124,8 +8868,8 @@ validate_tarball_members() {
     done <<< "${details}"
 }
 
-if [[ "${HARD_CUT_CURSOR_RECOVERY_CANDIDATE}" -eq 1 ]]; then
-    authenticate_clean_086_missing_cursor_source
+if [[ -n "${HARD_CUT_CURSOR_RECOVERY_SOURCE_VERSION}" ]]; then
+    authenticate_release_owned_missing_cursor_source
 fi
 prepare_release_contract
 FINAL_RELEASE_PROVENANCE_BRIDGE_CHECKSUMS_SHA256="${RELEASE_PROVENANCE_BRIDGE_CHECKSUMS_SHA256}"
@@ -9172,9 +9916,7 @@ else
     die "Gateway version verification failed: expected ${RELEASE_VERSION}; binary reported: $(printf '%s' "${gw_version_output}" | head -n1 | cut -c1-200)"
 fi
 
-UV_BIN="$(command -v uv 2>/dev/null || true)"
-[[ -z "${UV_BIN}" ]] \
-    && die "uv not found on PATH — cannot update Python CLI. Install: curl -LsSf https://astral.sh/uv/install.sh | sh"
+resolve_upgrade_uv
 
 if [[ "${BRIDGE_PHASE1}" -eq 1 ]]; then
     activate_bridge_phase1_cli

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -198,6 +198,53 @@ cleanup_upgrade_staging() {
     UV_BIN=""
 }
 
+reject_managed_sourceless_bytecode() {
+    local managed_venv="$1"
+    [[ -d "${managed_venv}/lib" && ! -L "${managed_venv}/lib" ]] \
+        || die "Installed source package has executable bytecode outside __pycache__. No changes were made."
+    python3 - "${managed_venv}" <<'PY' \
+        || die "Installed source package has executable bytecode outside __pycache__. No changes were made."
+import os
+import re
+import stat
+import sys
+
+venv = os.path.abspath(sys.argv[1])
+lib_root = os.path.join(venv, "lib")
+found_package = False
+for runtime in os.scandir(lib_root):
+    if re.fullmatch(r"python[0-9]+(?:[.][0-9]+)*", runtime.name) is None:
+        continue
+    if not runtime.is_dir(follow_symlinks=False):
+        raise SystemExit(1)
+    package_root = os.path.join(runtime.path, "site-packages", "defenseclaw")
+    if not os.path.lexists(package_root):
+        continue
+    found_package = True
+    root_info = os.lstat(package_root)
+    if stat.S_ISLNK(root_info.st_mode) or not stat.S_ISDIR(root_info.st_mode):
+        raise SystemExit(1)
+    for current, names, files in os.walk(
+        package_root,
+        topdown=True,
+        followlinks=False,
+    ):
+        retained = []
+        for name in names:
+            if name == "__pycache__":
+                continue
+            child = os.lstat(os.path.join(current, name))
+            if stat.S_ISLNK(child.st_mode) or not stat.S_ISDIR(child.st_mode):
+                raise SystemExit(1)
+            retained.append(name)
+        names[:] = retained
+        if any(name.endswith(".pyc") for name in files):
+            raise SystemExit(1)
+if not found_package:
+    raise SystemExit(1)
+PY
+}
+
 resolve_upgrade_uv() {
     [[ -n "${UV_BIN}" && -x "${UV_BIN}" ]] && return 0
     [[ -n "${STAGING_DIR:-}" && -d "${STAGING_DIR}" && ! -L "${STAGING_DIR}" ]] \
@@ -867,6 +914,9 @@ recover_interrupted_phase_two() {
     [[ -e "${journal}" || -L "${journal}" ]] || return 0
     [[ "${PLAN_ONLY}" -eq 0 ]] \
         || die "An interrupted hard-cut recovery is active. Re-run without --plan so the authenticated 0.8.4 bridge can be restored first."
+    if [[ -x "${DEFENSECLAW_VENV}/bin/python" ]]; then
+        reject_managed_sourceless_bytecode "${DEFENSECLAW_VENV}"
+    fi
 
     section "Recovering Interrupted Hard-Cut Upgrade"
     local recovery_fields wheel expected_digest receipt_status recorded_config_path uv_bin venv_python
@@ -1137,7 +1187,15 @@ if status in {"succeeded", "rolled_back"}:
     if gateway_version.returncode != 0 or reported_versions != [expected_version]:
         raise SystemExit("terminal phase-two gateway version is not proven")
     cli_version = subprocess.run(
-        [str(venv_python), "-I", "-B", "-c", "from defenseclaw import __version__; print(__version__)"],
+        [
+            str(venv_python),
+            "-X",
+            "pycache_prefix=/dev/null",
+            "-I",
+            "-B",
+            "-c",
+            "from defenseclaw import __version__; print(__version__)",
+        ],
         capture_output=True,
         text=True,
         timeout=10,
@@ -1237,8 +1295,9 @@ try:
 finally:
     os.close(descriptor)
 PY
+    reject_managed_sourceless_bytecode "${DEFENSECLAW_VENV}"
     DEFENSECLAW_HOME="${CONTROLLER_HOME}" DEFENSECLAW_CONFIG="${recorded_config_path}" \
-        "${venv_python}" -I -B -c \
+        "${venv_python}" -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B -c \
         'from defenseclaw.commands.cmd_upgrade import _recover_interrupted_hard_cut; raise SystemExit(0 if _recover_interrupted_hard_cut() else 1)' \
         || die "The retained 0.8.4 controller could not complete interrupted hard-cut recovery."
     ok "Interrupted phase two rolled back to a healthy authenticated bridge"
@@ -4394,6 +4453,7 @@ ensure_upgrade_lock_before_mutation() {
     recover_interrupted_phase_two
     recover_interrupted_bridge_phase1
     if [[ -x "${DEFENSECLAW_VENV}/bin/python" ]]; then
+        reject_managed_sourceless_bytecode "${DEFENSECLAW_VENV}"
         observed_version="$("${DEFENSECLAW_VENV}/bin/python" \
             -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B -c \
             'from defenseclaw import __version__; print(__version__)' 2>/dev/null \
@@ -4550,6 +4610,7 @@ HARD_CUT_CURSOR_RECOVERY_SOURCE_VERSION=""
 
 CURRENT_VERSION="unknown"
 if [[ -x "${DEFENSECLAW_VENV}/bin/python" ]]; then
+    reject_managed_sourceless_bytecode "${DEFENSECLAW_VENV}"
     CURRENT_VERSION="$("${DEFENSECLAW_VENV}/bin/python" \
         -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B -c \
         'from defenseclaw import __version__; print(__version__)' 2>/dev/null \
@@ -6567,8 +6628,12 @@ for current, names, files in os.walk(package_root, topdown=True, followlinks=Fal
     for name in files:
         path = os.path.join(current, name)
         relative = os.path.relpath(path, package_root).replace(os.sep, "/")
-        if "__pycache__" in PurePosixPath(relative).parts or relative.endswith(".pyc"):
+        if "__pycache__" in PurePosixPath(relative).parts:
             continue
+        if relative.endswith(".pyc"):
+            raise RuntimeError(
+                "installed source package has executable bytecode outside __pycache__"
+            )
         if len(actual_package) >= 8192:
             raise RuntimeError("installed source package exceeds its file bound")
         actual_package[relative] = hashlib.sha256(

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -93,7 +93,6 @@ readonly COSIGN_BOOTSTRAP_VERSION="2.6.3"
 readonly COSIGN_BOOTSTRAP_MAX_BYTES="209715200"
 readonly UV_BOOTSTRAP_VERSION="0.11.28"
 readonly UV_BOOTSTRAP_MAX_BYTES="209715200"
-readonly MANAGED_PYTHON_NO_LOCAL_BYTECODE="pycache_prefix=/dev/null"
 readonly UPGRADE_MANIFEST_NAME="upgrade-manifest.json"
 readonly RELEASE_PROVENANCE_NAME="release-provenance.json"
 readonly HISTORICAL_BOOTSTRAP_MCP_SCANNER_CONSTRAINT='cisco-ai-mcp-scanner @ https://files.pythonhosted.org/packages/5d/74/6e72cbd496c0d33dfab1b4aee62792620236e63cccf278a8c896c6feb740/cisco_ai_mcp_scanner-4.7.2-py3-none-any.whl#sha256=6ed0b8ced168886f572aec30a971c7b0e2e1de7eea489d3821627184fd271ac8'
@@ -198,61 +197,12 @@ cleanup_upgrade_staging() {
     UV_BIN=""
 }
 
-reject_managed_sourceless_bytecode() {
-    local managed_venv="$1"
-    [[ -d "${managed_venv}/lib" && ! -L "${managed_venv}/lib" ]] \
-        || die "Installed source package has executable bytecode outside __pycache__. No changes were made."
-    python3 - "${managed_venv}" <<'PY' \
-        || die "Installed source package has executable bytecode outside __pycache__. No changes were made."
-import os
-import re
-import stat
-import sys
-
-venv = os.path.abspath(sys.argv[1])
-lib_root = os.path.join(venv, "lib")
-found_package = False
-for runtime in os.scandir(lib_root):
-    if re.fullmatch(r"python[0-9]+(?:[.][0-9]+)*", runtime.name) is None:
-        continue
-    if not runtime.is_dir(follow_symlinks=False):
-        raise SystemExit(1)
-    package_root = os.path.join(runtime.path, "site-packages", "defenseclaw")
-    if not os.path.lexists(package_root):
-        continue
-    found_package = True
-    root_info = os.lstat(package_root)
-    if stat.S_ISLNK(root_info.st_mode) or not stat.S_ISDIR(root_info.st_mode):
-        raise SystemExit(1)
-    for current, names, files in os.walk(
-        package_root,
-        topdown=True,
-        followlinks=False,
-    ):
-        retained = []
-        for name in names:
-            if name == "__pycache__":
-                continue
-            child = os.lstat(os.path.join(current, name))
-            if stat.S_ISLNK(child.st_mode) or not stat.S_ISDIR(child.st_mode):
-                raise SystemExit(1)
-            retained.append(name)
-        names[:] = retained
-        if any(name.endswith(".pyc") for name in files):
-            raise SystemExit(1)
-if not found_package:
-    raise SystemExit(1)
-PY
-}
-
 resolve_upgrade_uv() {
     [[ -n "${UV_BIN}" && -x "${UV_BIN}" ]] && return 0
     [[ -n "${STAGING_DIR:-}" && -d "${STAGING_DIR}" && ! -L "${STAGING_DIR}" ]] \
         || die "Private staging is unavailable for Python tool custody. No changes were made."
 
     local tool_root="${STAGING_DIR}/upgrade-tools"
-    local candidate=""
-    local discovered=""
     local archive=""
     local asset=""
     local expected=""
@@ -261,201 +211,6 @@ resolve_upgrade_uv() {
         || die "Could not create private Python tool custody. No changes were made."
     chmod 700 "${tool_root}" \
         || die "Could not protect private Python tool custody. No changes were made."
-
-    discovered="$(type -P uv 2>/dev/null || true)"
-    if [[ -n "${discovered}" ]]; then
-        candidate="${discovered}"
-    else
-        local known
-        for known in \
-            "${HOME}/.local/bin/uv" \
-            "${HOME}/.cargo/bin/uv" \
-            "/opt/homebrew/bin/uv" \
-            "/usr/local/bin/uv"; do
-            if [[ -e "${known}" || -L "${known}" ]]; then
-                candidate="${known}"
-                break
-            fi
-        done
-    fi
-
-    if [[ -n "${candidate}" ]]; then
-        if python3 - "${candidate}" "${tool_root}/uv" "${UV_BOOTSTRAP_MAX_BYTES}" <<'PY' 2>/dev/null
-import hashlib
-import os
-import stat
-import sys
-
-source_name, destination, maximum_raw = sys.argv[1:]
-maximum = int(maximum_raw)
-uid = os.geteuid()
-source = os.path.realpath(os.path.abspath(os.path.expanduser(source_name)))
-parent = os.path.dirname(destination)
-
-parent_info = os.lstat(parent)
-if (
-    stat.S_ISLNK(parent_info.st_mode)
-    or not stat.S_ISDIR(parent_info.st_mode)
-    or parent_info.st_uid != uid
-    or stat.S_IMODE(parent_info.st_mode) & 0o077
-):
-    raise RuntimeError("private uv custody directory is unsafe")
-
-source_info = os.lstat(source)
-source_fd = os.open(
-    source,
-    os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
-)
-created = False
-try:
-    opened = os.fstat(source_fd)
-    if (
-        not stat.S_ISREG(opened.st_mode)
-        or not os.path.samestat(source_info, opened)
-        or opened.st_uid not in {0, uid}
-        or stat.S_IMODE(opened.st_mode) & 0o022
-        or stat.S_IMODE(opened.st_mode) & 0o111 == 0
-        or not 0 < opened.st_size <= maximum
-    ):
-        raise RuntimeError("discovered uv is not a bounded trusted-owner executable")
-    source_identity = (
-        opened.st_dev,
-        opened.st_ino,
-        opened.st_uid,
-        opened.st_mode,
-        opened.st_size,
-        opened.st_mtime_ns,
-        opened.st_ctime_ns,
-    )
-    destination_fd = os.open(
-        destination,
-        os.O_WRONLY
-        | os.O_CREAT
-        | os.O_EXCL
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_NOFOLLOW", 0),
-        0o700,
-    )
-    created = True
-    copied = hashlib.sha256()
-    try:
-        while True:
-            chunk = os.read(source_fd, 1024 * 1024)
-            if not chunk:
-                break
-            copied.update(chunk)
-            view = memoryview(chunk)
-            while view:
-                written = os.write(destination_fd, view)
-                if written <= 0:
-                    raise RuntimeError("uv custody copy made no progress")
-                view = view[written:]
-        os.fchmod(destination_fd, 0o700)
-        os.fsync(destination_fd)
-    finally:
-        os.close(destination_fd)
-
-    os.lseek(source_fd, 0, os.SEEK_SET)
-    reread = hashlib.sha256()
-    while True:
-        chunk = os.read(source_fd, 1024 * 1024)
-        if not chunk:
-            break
-        reread.update(chunk)
-    final_opened = os.fstat(source_fd)
-    final_named = os.lstat(source)
-    final_identity = (
-        final_opened.st_dev,
-        final_opened.st_ino,
-        final_opened.st_uid,
-        final_opened.st_mode,
-        final_opened.st_size,
-        final_opened.st_mtime_ns,
-        final_opened.st_ctime_ns,
-    )
-    if (
-        final_identity != source_identity
-        or not os.path.samestat(final_opened, final_named)
-        or copied.digest() != reread.digest()
-    ):
-        raise RuntimeError("discovered uv changed while entering private custody")
-    destination_info = os.lstat(destination)
-    if (
-        stat.S_ISLNK(destination_info.st_mode)
-        or not stat.S_ISREG(destination_info.st_mode)
-        or destination_info.st_uid != uid
-        or stat.S_IMODE(destination_info.st_mode) != 0o700
-        or destination_info.st_size != source_identity[4]
-    ):
-        raise RuntimeError("private uv custody is invalid")
-    with open(destination, "rb") as stream:
-        if hashlib.sha256(stream.read()).digest() != copied.digest():
-            raise RuntimeError("private uv custody changed after publication")
-    directory_fd = os.open(parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
-    try:
-        os.fsync(directory_fd)
-    finally:
-        os.close(directory_fd)
-except BaseException:
-    if created:
-        try:
-            os.unlink(destination)
-        except FileNotFoundError:
-            pass
-    raise
-finally:
-    os.close(source_fd)
-PY
-        then
-            if python3 - "${tool_root}/uv" "${UV_BOOTSTRAP_VERSION}" <<'PY' 2>/dev/null
-import os
-import re
-import subprocess
-import sys
-
-executable, expected_version = sys.argv[1:]
-environment = {
-    "HOME": os.environ.get("HOME", "/"),
-    "LANG": "C",
-    "LC_ALL": "C",
-    "PATH": "/usr/bin:/bin",
-}
-try:
-    completed = subprocess.run(
-        [executable, "--version"],
-        check=False,
-        env=environment,
-        stderr=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        timeout=10,
-    )
-except (OSError, subprocess.TimeoutExpired):
-    raise SystemExit(1)
-if completed.returncode != 0:
-    raise SystemExit(1)
-try:
-    reported = completed.stdout.decode("ascii").strip()
-except UnicodeDecodeError:
-    raise SystemExit(1)
-if len(reported) > 256:
-    raise SystemExit(1)
-match = re.fullmatch(
-    r"uv ([0-9]+\.[0-9]+\.[0-9]+)(?: \([ -~]{1,200}\))?",
-    reported,
-)
-raise SystemExit(0 if match is not None and match.group(1) == expected_version else 1)
-PY
-            then
-                UV_BIN="${tool_root}/uv"
-                ok "Copied uv into private upgrade custody (${UV_BOOTSTRAP_VERSION})"
-                return 0
-            fi
-            rm -f -- "${tool_root}/uv"
-            warn "Ignoring a non-${UV_BOOTSTRAP_VERSION} uv candidate at ${candidate}; using the pinned bootstrap instead"
-        else
-            warn "Ignoring an unsafe or unstable uv candidate at ${candidate}; using the pinned bootstrap instead"
-        fi
-    fi
 
     case "$(uname -s)/$(uname -m)" in
         Darwin/x86_64)
@@ -483,98 +238,48 @@ PY
             ;;
     esac
     archive="${tool_root}/${asset}"
-    info "uv was not available in trusted custody; authenticating temporary uv ${UV_BOOTSTRAP_VERSION}..."
+    info "Authenticating temporary pinned uv ${UV_BOOTSTRAP_VERSION}..."
     curl --fail --silent --show-error --location \
         --proto '=https' --proto-redir '=https' --tlsv1.2 \
         --max-filesize "${UV_BOOTSTRAP_MAX_BYTES}" \
         --output "${archive}" \
         "https://github.com/astral-sh/uv/releases/download/${UV_BOOTSTRAP_VERSION}/${asset}" \
         || die "Could not download the pinned uv bootstrap. No changes were made."
-    python3 - \
-        "${archive}" "${expected}" "${member}" "${tool_root}/uv" \
-        "${UV_BOOTSTRAP_MAX_BYTES}" <<'PY' \
+    python3 - "${archive}" "${expected}" "${UV_BOOTSTRAP_MAX_BYTES}" <<'PY' \
         || die "Pinned uv bootstrap authentication failed. No changes were made."
 import hashlib
 import os
-from pathlib import PurePosixPath
 import stat
 import sys
-import tarfile
 
-archive_name, expected, expected_member, destination, maximum_raw = sys.argv[1:]
+path, expected, maximum_raw = sys.argv[1:]
 maximum = int(maximum_raw)
-uid = os.geteuid()
-archive_info = os.lstat(archive_name)
+info = os.lstat(path)
 if (
-    stat.S_ISLNK(archive_info.st_mode)
-    or not stat.S_ISREG(archive_info.st_mode)
-    or archive_info.st_uid != uid
-    or not 0 < archive_info.st_size <= maximum
+    stat.S_ISLNK(info.st_mode)
+    or not stat.S_ISREG(info.st_mode)
+    or info.st_uid != os.geteuid()
+    or not 0 < info.st_size <= maximum
 ):
-    raise RuntimeError("downloaded uv archive is outside private bounded custody")
-
-archive_digest = hashlib.sha256()
-with open(archive_name, "rb") as stream:
-    while chunk := stream.read(1024 * 1024):
-        archive_digest.update(chunk)
-if archive_digest.hexdigest() != expected:
-    raise RuntimeError("downloaded uv archive digest mismatch")
-
-with tarfile.open(archive_name, mode="r:gz") as archive:
-    members = archive.getmembers()
-    if not members or len(members) > 16 or len({item.name for item in members}) != len(members):
-        raise RuntimeError("uv archive member inventory is invalid")
-    selected = None
-    for item in members:
-        path = PurePosixPath(item.name)
-        if path.is_absolute() or ".." in path.parts or item.issym() or item.islnk():
-            raise RuntimeError("uv archive contains an unsafe member")
-        if not (item.isdir() or item.isreg()):
-            raise RuntimeError("uv archive contains an unsupported member")
-        if item.name == expected_member:
-            selected = item
-    if selected is None or not selected.isreg() or not 0 < selected.size <= maximum:
-        raise RuntimeError("uv archive lacks the bounded expected executable")
-    source = archive.extractfile(selected)
-    if source is None:
-        raise RuntimeError("uv archive executable could not be opened")
-    descriptor = os.open(
-        destination,
-        os.O_WRONLY
-        | os.O_CREAT
-        | os.O_EXCL
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_NOFOLLOW", 0),
-        0o700,
-    )
-    written = 0
-    try:
-        while True:
-            chunk = source.read(1024 * 1024)
-            if not chunk:
-                break
-            written += len(chunk)
-            if written > selected.size:
-                raise RuntimeError("uv archive executable exceeded its declared size")
-            view = memoryview(chunk)
-            while view:
-                count = os.write(descriptor, view)
-                if count <= 0:
-                    raise RuntimeError("uv bootstrap extraction made no progress")
-                view = view[count:]
-        if written != selected.size:
-            raise RuntimeError("uv archive executable was truncated")
-        os.fchmod(descriptor, 0o700)
-        os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
-        source.close()
-directory_fd = os.open(os.path.dirname(destination), os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
-try:
-    os.fsync(directory_fd)
-finally:
-    os.close(directory_fd)
+    raise SystemExit(1)
+digest = hashlib.sha256()
+with open(path, "rb") as stream:
+    for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+        digest.update(chunk)
+raise SystemExit(0 if digest.hexdigest() == expected else 1)
 PY
+    tar -xOzf "${archive}" "${member}" > "${tool_root}/uv" \
+        || die "Could not extract the pinned uv executable. No changes were made."
+    [[ -s "${tool_root}/uv" \
+       && "$(wc -c < "${tool_root}/uv" | tr -d ' ')" -le "${UV_BOOTSTRAP_MAX_BYTES}" ]] \
+        || die "Pinned uv executable is empty or oversized. No changes were made."
+    chmod 700 "${tool_root}/uv" \
+        || die "Could not protect pinned uv private custody. No changes were made."
+    local uv_reported
+    uv_reported="$(env -i HOME="${HOME}" LANG=C LC_ALL=C PATH=/usr/bin:/bin \
+        "${tool_root}/uv" --version 2>/dev/null || true)"
+    [[ "${uv_reported}" == "uv ${UV_BOOTSTRAP_VERSION}"* ]] \
+        || die "Pinned uv executable reported an unexpected version. No changes were made."
     UV_BIN="${tool_root}/uv"
     ok "Pinned uv ${UV_BOOTSTRAP_VERSION} authenticated in private upgrade custody"
 }
@@ -848,8 +553,7 @@ begin_release_upgrade_receipt() {
 
     local receipt_path receipt_name
     receipt_path="$(
-        DEFENSECLAW_HOME="${DATA_DIR}" "${source_python}" \
-            -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B - \
+        DEFENSECLAW_HOME="${DATA_DIR}" "${source_python}" -I -B - \
             "${DATA_DIR}" "${CURRENT_VERSION}" "${RELEASE_VERSION}" <<'PY'
 import os
 import sys
@@ -914,10 +618,6 @@ recover_interrupted_phase_two() {
     [[ -e "${journal}" || -L "${journal}" ]] || return 0
     [[ "${PLAN_ONLY}" -eq 0 ]] \
         || die "An interrupted hard-cut recovery is active. Re-run without --plan so the authenticated 0.8.4 bridge can be restored first."
-    if [[ -x "${DEFENSECLAW_VENV}/bin/python" ]]; then
-        reject_managed_sourceless_bytecode "${DEFENSECLAW_VENV}"
-    fi
-
     section "Recovering Interrupted Hard-Cut Upgrade"
     local recovery_fields wheel expected_digest receipt_status recorded_config_path uv_bin venv_python
     recovery_fields="$(python3 - "${journal}" "${DEFENSECLAW_HOME}" <<'PY'
@@ -1295,9 +995,8 @@ try:
 finally:
     os.close(descriptor)
 PY
-    reject_managed_sourceless_bytecode "${DEFENSECLAW_VENV}"
     DEFENSECLAW_HOME="${CONTROLLER_HOME}" DEFENSECLAW_CONFIG="${recorded_config_path}" \
-        "${venv_python}" -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B -c \
+        "${venv_python}" -I -B -c \
         'from defenseclaw.commands.cmd_upgrade import _recover_interrupted_hard_cut; raise SystemExit(0 if _recover_interrupted_hard_cut() else 1)' \
         || die "The retained 0.8.4 controller could not complete interrupted hard-cut recovery."
     ok "Interrupted phase two rolled back to a healthy authenticated bridge"
@@ -4453,9 +4152,7 @@ ensure_upgrade_lock_before_mutation() {
     recover_interrupted_phase_two
     recover_interrupted_bridge_phase1
     if [[ -x "${DEFENSECLAW_VENV}/bin/python" ]]; then
-        reject_managed_sourceless_bytecode "${DEFENSECLAW_VENV}"
-        observed_version="$("${DEFENSECLAW_VENV}/bin/python" \
-            -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B -c \
+        observed_version="$("${DEFENSECLAW_VENV}/bin/python" -I -B -c \
             'from defenseclaw import __version__; print(__version__)' 2>/dev/null \
             | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
     elif has defenseclaw; then
@@ -4610,9 +4307,7 @@ HARD_CUT_CURSOR_RECOVERY_SOURCE_VERSION=""
 
 CURRENT_VERSION="unknown"
 if [[ -x "${DEFENSECLAW_VENV}/bin/python" ]]; then
-    reject_managed_sourceless_bytecode "${DEFENSECLAW_VENV}"
-    CURRENT_VERSION="$("${DEFENSECLAW_VENV}/bin/python" \
-        -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B -c \
+    CURRENT_VERSION="$("${DEFENSECLAW_VENV}/bin/python" -I -B -c \
         'from defenseclaw import __version__; print(__version__)' 2>/dev/null \
         | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
 elif has defenseclaw; then
@@ -4674,8 +4369,7 @@ if [[ "${CURRENT_VERSION}" != "unknown" && -x "${DEFENSECLAW_VENV}/bin/python" ]
     runtime_paths="$(
         DEFENSECLAW_HOME="${CONTROLLER_HOME}" \
         DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
-        "${DEFENSECLAW_VENV}/bin/python" \
-            -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B - \
+        "${DEFENSECLAW_VENV}/bin/python" -I -B - \
             "${CONTROLLER_HOME}" \
             "${CONFIG_PATH}" \
             "${OPENCLAW_HOME_EXPLICIT}" \
@@ -4793,8 +4487,7 @@ if [[ "${COMPONENT_VERSION_SPLIT}" -eq 1 ]]; then
           && -x "${DEFENSECLAW_VENV}/bin/python" ]] \
         && version_lt "${CURRENT_VERSION}" "${CURRENT_GATEWAY_VERSION}"; then
         split_recovery="$(
-            DEFENSECLAW_HOME="${DATA_DIR}" "${DEFENSECLAW_VENV}/bin/python" \
-                -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B - \
+            DEFENSECLAW_HOME="${DATA_DIR}" "${DEFENSECLAW_VENV}/bin/python" -I -B - \
                 "${DATA_DIR}" "${CURRENT_VERSION}" "${RELEASE_VERSION}" <<'PY'
 from datetime import datetime
 import os
@@ -4889,8 +4582,7 @@ AUDIT_DB_RECOVERY_CUSTODY=""
 AUDIT_DB_PREFLIGHT_IDENTITY=""
 
 if [[ "${CURRENT_VERSION}" != "unknown" ]] && version_gte "${CURRENT_VERSION}" "0.8.5"; then
-    hard_cut_state="$("${DEFENSECLAW_VENV}/bin/python" \
-        -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B - "${CONFIG_PATH}" \
+    hard_cut_state="$("${DEFENSECLAW_VENV}/bin/python" -I -B - "${CONFIG_PATH}" \
         "${DATA_DIR}/.migration_state.json" "${CURRENT_VERSION}" <<'PY' 2>/dev/null || true
 import json
 import os
@@ -6147,617 +5839,73 @@ prepare_release_contract() {
     preflight_release_artifacts
 }
 
-authenticate_release_owned_missing_cursor_source() {
+authorize_cursorless_field_recovery() {
     local source_version="${HARD_CUT_CURSOR_RECOVERY_SOURCE_VERSION}"
-    local requested_version="${RELEASE_VERSION}"
-    local source_root="${STAGING_DIR}/authenticated-source-${source_version}"
-    local source_wheel source_gateway_archive source_gateway
-    local installed_gateway_comparison="${INSTALL_DIR}/defenseclaw-gateway"
-    local gateway_comparison_kind=""
-    local source_wheel_sha256 source_gateway_sha256
     [[ "${source_version}" =~ ^0[.]8[.][67]$ \
-       && "${CURRENT_VERSION}" == "${source_version}" ]] \
-        || die "Missing-cursor recovery is restricted to exact published 0.8.6 or 0.8.7 source state. No changes were made."
-    mkdir -p "${source_root}"
+       && "${CURRENT_VERSION}" == "${source_version}" \
+       && "${CURRENT_GATEWAY_VERSION}" == "${source_version}" ]] \
+        || die "Cursorless field recovery is restricted to matching 0.8.6 or 0.8.7 CLI and gateway versions. No changes were made."
 
-    RELEASE_VERSION="${source_version}"
-    configure_release
-    section "Authenticating Published ${source_version} Source"
-    prepare_release_contract
-    python3 - \
-        "${RELEASE_PROVENANCE_FILE}" "${UPGRADE_MANIFEST_FILE}" "${source_version}" <<'PY' \
-        || die "Published ${source_version} lacks the exact source-install identity required for missing-cursor recovery. No changes were made."
-import json
-import sys
-
-with open(sys.argv[1], encoding="utf-8") as stream:
-    provenance = json.load(stream)
-with open(sys.argv[2], encoding="utf-8") as stream:
-    manifest = json.load(stream)
-source_version = sys.argv[3]
-if source_version not in {"0.8.6", "0.8.7"}:
-    raise SystemExit("unsupported missing-cursor source")
-identity = provenance.get("source_install_identity")
-if not (
-    provenance.get("release_version") == source_version
-    and isinstance(identity, dict)
-    and identity.get("schema_version") == 1
-    and identity.get("source_release") == source_version
-    and type(identity.get("source_install_compatibility_epoch")) is int
-    and identity["source_install_compatibility_epoch"] == 2
-    and type(identity.get("runtime_config_version")) is int
-    and identity["runtime_config_version"] == 8
-    and manifest.get("schema_version") == 2
-    and manifest.get("release_version") == source_version
-    and type(manifest.get("runtime_config_version")) is int
-    and manifest["runtime_config_version"] == 8
-    and manifest.get("required_bridge_version") == "0.8.4"
-    and "0.8.5" in manifest.get("required_cli_migrations", [])
-):
-    raise SystemExit(f"{source_version} source-install identity differs")
-PY
-
-    fetch_artifact "${WHL_URL}" "${source_root}/${WHL_NAME}"
-    verify_checksum "${source_root}/${WHL_NAME}" "${WHL_NAME}"
-    source_wheel_sha256="${VERIFIED_CHECKSUM}"
-    source_wheel="${source_root}/${MATERIALIZED_WHL_NAME}"
-    materialize_protected_artifact \
-        "${source_root}/${WHL_NAME}" "${source_wheel}" "${source_wheel_sha256}" \
-        || die "Could not materialize the authenticated ${source_version} source wheel. No changes were made."
-
-    fetch_artifact "${TARBALL_URL}" "${source_root}/${TARBALL_NAME}"
-    verify_checksum "${source_root}/${TARBALL_NAME}" "${TARBALL_NAME}"
-    source_gateway_sha256="${VERIFIED_CHECKSUM}"
-    source_gateway_archive="${source_root}/${MATERIALIZED_TARBALL_NAME}"
-    materialize_protected_artifact \
-        "${source_root}/${TARBALL_NAME}" \
-        "${source_gateway_archive}" \
-        "${source_gateway_sha256}" \
-        || die "Could not materialize the authenticated ${source_version} source gateway. No changes were made."
-    validate_tarball_members "${source_gateway_archive}"
-    mkdir "${source_root}/gateway"
-    tar -xzf "${source_gateway_archive}" -C "${source_root}/gateway" \
-        || die "Could not extract the authenticated ${source_version} source gateway. No changes were made."
-    source_gateway="${source_root}/gateway/defenseclaw"
-    [[ -f "${source_gateway}" && ! -L "${source_gateway}" ]] \
-        || die "Authenticated ${source_version} source gateway archive has no canonical executable. No changes were made."
-    if [[ "${OS}" == "darwin" ]]; then
-        # Fresh installs and upgrades deterministically replace the linker
-        # signature with this release-owned ad-hoc identity before publishing.
-        # First bind the installed bytes into private custody, validate the
-        # installer-owned signature there, then apply the current host's exact
-        # transform to both private copies. This tolerates a codesign-format
-        # change after an OS upgrade without ever modifying the live gateway.
-        installed_gateway_comparison="${source_root}/gateway/installed-normalized"
-        python3 - \
-            "${INSTALL_DIR}/defenseclaw-gateway" \
-            "${installed_gateway_comparison}" \
-            "536870912" <<'PY' \
-            || die "Could not bind the installed macOS gateway into private comparison custody. No changes were made."
-import hashlib
+    "${DEFENSECLAW_VENV}/bin/python" -I -B - \
+        "${CONFIG_PATH}" "${DATA_DIR}" "${UPGRADE_RECOVERY_ROOT}" \
+        "${source_version}" <<'PY' \
+        || die "Installed ${source_version} state is not the supported public cursorless first-run shape. No changes were made."
 import os
 import stat
 import sys
 
-source = os.path.abspath(sys.argv[1])
-destination = os.path.abspath(sys.argv[2])
-limit_raw = sys.argv[3]
-limit = int(limit_raw)
-uid = os.geteuid()
-parent = os.path.dirname(destination)
+import yaml
 
-
-def identity(value):
-    return (
-        value.st_dev,
-        value.st_ino,
-        value.st_uid,
-        value.st_gid,
-        value.st_mode,
-        value.st_size,
-        value.st_mtime_ns,
-        value.st_ctime_ns,
-    )
-
-
-parent_info = os.lstat(parent)
-if (
-    stat.S_ISLNK(parent_info.st_mode)
-    or not stat.S_ISDIR(parent_info.st_mode)
-    or parent_info.st_uid != uid
-    or stat.S_IMODE(parent_info.st_mode) & 0o077
-):
-    raise RuntimeError("private gateway comparison custody is unsafe")
-named = os.lstat(source)
-if (
-    stat.S_ISLNK(named.st_mode)
-    or not stat.S_ISREG(named.st_mode)
-    or named.st_uid != uid
-    or stat.S_IMODE(named.st_mode) & 0o022
-    or stat.S_IMODE(named.st_mode) & 0o111 == 0
-    or not 0 < named.st_size <= limit
-):
-    raise RuntimeError("installed gateway is not a bounded current-user executable")
-expected_identity = identity(named)
-source_fd = os.open(
-    source,
-    os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
-)
-destination_fd = None
-created = False
-try:
-    opened = os.fstat(source_fd)
-    if identity(opened) != expected_identity:
-        raise RuntimeError("installed gateway changed while opening")
-    destination_fd = os.open(
-        destination,
-        os.O_WRONLY
-        | os.O_CREAT
-        | os.O_EXCL
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_NOFOLLOW", 0),
-        0o700,
-    )
-    created = True
-    copied = hashlib.sha256()
-    total = 0
-    while True:
-        chunk = os.read(source_fd, 1024 * 1024)
-        if not chunk:
-            break
-        total += len(chunk)
-        if total > named.st_size:
-            raise RuntimeError("installed gateway changed while copying")
-        copied.update(chunk)
-        view = memoryview(chunk)
-        while view:
-            written = os.write(destination_fd, view)
-            if written <= 0:
-                raise RuntimeError("installed gateway custody copy made no progress")
-            view = view[written:]
-    if total != named.st_size:
-        raise RuntimeError("installed gateway changed while copying")
-    os.fchmod(destination_fd, 0o700)
-    os.fsync(destination_fd)
-    os.close(destination_fd)
-    destination_fd = None
-
-    os.lseek(source_fd, 0, os.SEEK_SET)
-    reread = hashlib.sha256()
-    while True:
-        chunk = os.read(source_fd, 1024 * 1024)
-        if not chunk:
-            break
-        reread.update(chunk)
-    if copied.digest() != reread.digest():
-        raise RuntimeError("installed gateway changed while entering custody")
-    if (
-        identity(os.fstat(source_fd)) != expected_identity
-        or identity(os.lstat(source)) != expected_identity
-    ):
-        raise RuntimeError("installed gateway changed after entering custody")
-    destination_info = os.lstat(destination)
-    if (
-        stat.S_ISLNK(destination_info.st_mode)
-        or not stat.S_ISREG(destination_info.st_mode)
-        or destination_info.st_uid != uid
-        or stat.S_IMODE(destination_info.st_mode) != 0o700
-        or destination_info.st_size != named.st_size
-    ):
-        raise RuntimeError("private installed-gateway custody is invalid")
-    destination_digest = hashlib.sha256()
-    with open(destination, "rb") as stream:
-        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-            destination_digest.update(chunk)
-    if destination_digest.digest() != copied.digest():
-        raise RuntimeError("private installed-gateway custody changed after publication")
-    directory_fd = os.open(parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
-    try:
-        os.fsync(directory_fd)
-    finally:
-        os.close(directory_fd)
-except BaseException:
-    if destination_fd is not None:
-        os.close(destination_fd)
-    if created:
-        try:
-            os.unlink(destination)
-        except FileNotFoundError:
-            pass
-    raise
-finally:
-    os.close(source_fd)
-PY
-        local gateway_fixture_marker="${source_root}/.defenseclaw-gateway-fixture-v1"
-        gateway_comparison_kind="$(python3 - \
-            "${source_gateway}" \
-            "${installed_gateway_comparison}" \
-            "${gateway_fixture_marker}" \
-            "${STAGING_DIR}" \
-            "${DEFENSECLAW_UPGRADE_TEST_MODE:-0}" <<'PY'
-import os
-from pathlib import Path
-import stat
-import sys
-
-source_path, installed_path, marker_path, staging_path = map(Path, sys.argv[1:5])
-test_mode = sys.argv[5]
-with source_path.open("rb") as stream:
-    source_magic = stream.read(4)
-with installed_path.open("rb") as stream:
-    installed_magic = stream.read(4)
-macho64_little = b"\xcf\xfa\xed\xfe"
-if source_magic == macho64_little and installed_magic == macho64_little:
-    print("macho")
-elif source_magic != macho64_little and source_magic == installed_magic:
-    if test_mode != "1":
-        raise SystemExit("non-Mach-O gateway fixtures require explicit test mode")
-    expected_marker = b"defenseclaw-gateway-fixture-v1\n"
-    staging = Path(os.path.realpath(staging_path))
-    source_parent = Path(os.path.realpath(source_path.parent))
-    marker_parent = Path(os.path.realpath(marker_path.parent))
-    if (
-        marker_path.name != ".defenseclaw-gateway-fixture-v1"
-        or marker_parent != source_parent.parent
-        or (staging != marker_parent and staging not in marker_parent.parents)
-    ):
-        raise SystemExit("macOS gateway fixture marker escaped private staging")
-    try:
-        marker_info = marker_path.lstat()
-    except OSError:
-        raise SystemExit("macOS gateway fixture marker is unavailable") from None
-    if (
-        stat.S_ISLNK(marker_info.st_mode)
-        or not stat.S_ISREG(marker_info.st_mode)
-        or marker_info.st_uid != os.geteuid()
-        or stat.S_IMODE(marker_info.st_mode) != 0o600
-        or marker_info.st_size != len(expected_marker)
-    ):
-        raise SystemExit("macOS gateway fixture marker custody is unsafe")
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
-    descriptor = os.open(marker_path, flags)
-    try:
-        opened = os.fstat(descriptor)
-        payload = os.read(descriptor, len(expected_marker) + 1)
-    finally:
-        os.close(descriptor)
-    if not os.path.samestat(marker_info, opened) or payload != expected_marker:
-        raise SystemExit("macOS gateway fixture marker changed")
-    print("fixture")
-else:
-    raise SystemExit("authenticated and installed macOS gateway formats differ")
-PY
-        )" || die "Installed macOS gateway format differs from its authenticated source. No changes were made."
-        if [[ "${gateway_comparison_kind}" == "macho" ]]; then
-            /usr/bin/codesign --verify --strict \
-                -R '=identifier "com.cisco.defenseclaw.gateway"' \
-                "${installed_gateway_comparison}" 2>/dev/null \
-                || die "Installed macOS gateway lacks the release-owned installer signature. No changes were made."
-        fi
-        /usr/bin/codesign -f -s - -i com.cisco.defenseclaw.gateway \
-            "${source_gateway}" 2>/dev/null \
-            || die "Could not normalize the authenticated ${source_version} macOS source gateway. No changes were made."
-        /usr/bin/codesign -f -s - -i com.cisco.defenseclaw.gateway \
-            "${installed_gateway_comparison}" 2>/dev/null \
-            || die "Could not normalize the private installed macOS gateway comparison copy. No changes were made."
-    fi
-    preflight_python_wheel "${source_wheel}"
-
-    DEFENSECLAW_HOME="${DATA_DIR}" DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
-        "${DEFENSECLAW_VENV}/bin/python" \
-            -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B - \
-        "${source_wheel}" "${source_gateway}" "${CONFIG_PATH}" "${DATA_DIR}" \
-        "${BACKUP_ROOT}" "${DEFENSECLAW_VENV}" \
-        "${installed_gateway_comparison}" "${source_version}" <<'PY' \
-        || die "Installed ${source_version} state is not the exact release-owned missing-cursor shape. No changes were made."
-import hashlib
-import importlib.util
-import os
-from pathlib import Path, PurePosixPath
-import stat
-import sys
-import zipfile
-
-(
-    wheel_path,
-    source_gateway,
-    config_path,
-    data_dir,
-    backup_root,
-    venv,
-    installed_gateway,
-) = map(os.path.abspath, sys.argv[1:8])
-source_version = sys.argv[8]
+config_path, data_dir, recovery_root = map(os.path.abspath, sys.argv[1:4])
+source_version = sys.argv[4]
 uid = os.geteuid()
 if source_version not in {"0.8.6", "0.8.7"}:
-    raise RuntimeError("unsupported missing-cursor source")
+    raise RuntimeError("unsupported cursorless source version")
 
 
-def read_regular(path, limit, *, executable=False, allow_empty=False):
+def read_regular(path, limit):
     info = os.lstat(path)
     if (
         stat.S_ISLNK(info.st_mode)
         or not stat.S_ISREG(info.st_mode)
         or info.st_uid != uid
         or stat.S_IMODE(info.st_mode) & 0o022
-        or (executable and stat.S_IMODE(info.st_mode) & 0o111 == 0)
-        or info.st_size < 0
-        or info.st_size > limit
-        or (not allow_empty and info.st_size == 0)
-    ):
-        raise RuntimeError(f"unsafe release-owned source file: {path}")
-    descriptor = os.open(
-        path,
-        os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
-    )
-    try:
-        opened = os.fstat(descriptor)
-        if not os.path.samestat(info, opened):
-            raise RuntimeError("release-owned source file changed while opening")
-        raw = b""
-        while len(raw) <= info.st_size:
-            chunk = os.read(descriptor, info.st_size + 1 - len(raw))
-            if not chunk:
-                break
-            raw += chunk
-        if len(raw) != info.st_size:
-            raise RuntimeError("release-owned source file changed while reading")
-        final = os.fstat(descriptor)
-        named = os.lstat(path)
-        if not os.path.samestat(opened, final) or not os.path.samestat(final, named):
-            raise RuntimeError("release-owned source file changed after reading")
-        return raw
-    finally:
-        os.close(descriptor)
-
-
-def digest_regular(path, limit, *, executable=False):
-    info = os.lstat(path)
-    if (
-        stat.S_ISLNK(info.st_mode)
-        or not stat.S_ISREG(info.st_mode)
-        or info.st_uid != uid
-        or stat.S_IMODE(info.st_mode) & 0o022
-        or (executable and stat.S_IMODE(info.st_mode) & 0o111 == 0)
         or not 0 < info.st_size <= limit
     ):
-        raise RuntimeError(f"unsafe release-owned source file: {path}")
-
-    def identity(value):
-        return (
-            value.st_dev,
-            value.st_ino,
-            value.st_uid,
-            value.st_gid,
-            value.st_mode,
-            value.st_size,
-            value.st_mtime_ns,
-            value.st_ctime_ns,
-        )
-
-    expected_identity = identity(info)
-    descriptor = os.open(
-        path,
-        os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
-    )
-    try:
-        opened = os.fstat(descriptor)
-        if identity(opened) != expected_identity:
-            raise RuntimeError("release-owned source file changed while opening")
-        digest = hashlib.sha256()
-        total = 0
-        while True:
-            chunk = os.read(descriptor, 1024 * 1024)
-            if not chunk:
-                break
-            total += len(chunk)
-            if total > info.st_size:
-                raise RuntimeError("release-owned source file changed while reading")
-            digest.update(chunk)
-        if total != info.st_size:
-            raise RuntimeError("release-owned source file changed while reading")
-        final = os.fstat(descriptor)
-        named = os.lstat(path)
-        if identity(final) != expected_identity or identity(named) != expected_identity:
-            raise RuntimeError("release-owned source file changed after reading")
-        return digest.digest()
-    finally:
-        os.close(descriptor)
+        raise RuntimeError(f"unsafe cursorless field-state file: {path}")
+    with open(path, "rb") as stream:
+        raw = stream.read(limit + 1)
+    if len(raw) != info.st_size:
+        raise RuntimeError("cursorless field-state file changed while reading")
+    return raw
 
 
-source_gateway_digest = digest_regular(
-    source_gateway,
-    512 * 1024 * 1024,
-    executable=True,
-)
-installed_gateway_digest = digest_regular(
-    installed_gateway,
-    512 * 1024 * 1024,
-    executable=True,
-)
-if source_gateway_digest != installed_gateway_digest:
-    raise RuntimeError("installed gateway differs from the authenticated source release")
-
-expected_package = {}
-with zipfile.ZipFile(wheel_path) as archive:
-    infos = archive.infolist()
-    if len(infos) > 8192 or len({info.filename for info in infos}) != len(infos):
-        raise RuntimeError("authenticated source wheel has an unsafe inventory")
-    for info in infos:
-        path = PurePosixPath(info.filename)
-        if path.is_absolute() or ".." in path.parts:
-            raise RuntimeError("authenticated source wheel has an unsafe path")
-        encoded_mode = (info.external_attr >> 16) & 0xFFFF
-        kind = stat.S_IFMT(encoded_mode)
-        if kind not in {0, stat.S_IFREG, stat.S_IFDIR}:
-            raise RuntimeError("authenticated source wheel has a non-regular package member")
-        if info.is_dir() or not path.parts or path.parts[0] != "defenseclaw":
-            continue
-        if info.file_size > 64 * 1024 * 1024:
-            raise RuntimeError("authenticated source package member exceeds its bound")
-        relative = "/".join(path.parts[1:])
-        expected_package[relative] = hashlib.sha256(archive.read(info)).hexdigest()
-if not expected_package:
-    raise RuntimeError("authenticated source wheel lacks the DefenseClaw package")
-
-venv = os.path.realpath(venv)
-package_spec = importlib.util.find_spec("defenseclaw")
-if package_spec is None or not isinstance(package_spec.origin, str):
-    raise RuntimeError("installed source package cannot be resolved")
-package_root = os.path.realpath(os.path.dirname(package_spec.origin))
+config = yaml.safe_load(read_regular(config_path, 4 * 1024 * 1024))
 if (
-    os.path.basename(package_root) != "defenseclaw"
-    or os.path.commonpath((package_root, venv)) != venv
+    not isinstance(config, dict)
+    or type(config.get("config_version")) is not int
+    or config["config_version"] != 8
 ):
-    raise RuntimeError("installed source package escaped the managed venv")
-actual_package = {}
-for current, names, files in os.walk(package_root, topdown=True, followlinks=False):
-    current_info = os.lstat(current)
-    if (
-        stat.S_ISLNK(current_info.st_mode)
-        or not stat.S_ISDIR(current_info.st_mode)
-        or current_info.st_uid != uid
-        or stat.S_IMODE(current_info.st_mode) & 0o022
-    ):
-        raise RuntimeError("installed source package has unsafe directory custody")
-    names[:] = [name for name in names if name != "__pycache__"]
-    for name in names:
-        child = os.lstat(os.path.join(current, name))
-        if stat.S_ISLNK(child.st_mode) or not stat.S_ISDIR(child.st_mode):
-            raise RuntimeError("installed source package has an unsafe child")
-    for name in files:
-        path = os.path.join(current, name)
-        relative = os.path.relpath(path, package_root).replace(os.sep, "/")
-        if "__pycache__" in PurePosixPath(relative).parts:
-            continue
-        if relative.endswith(".pyc"):
-            raise RuntimeError(
-                "installed source package has executable bytecode outside __pycache__"
-            )
-        if len(actual_package) >= 8192:
-            raise RuntimeError("installed source package exceeds its file bound")
-        actual_package[relative] = hashlib.sha256(
-            read_regular(path, 64 * 1024 * 1024, allow_empty=True)
-        ).hexdigest()
-if actual_package != expected_package:
-    raise RuntimeError("installed CLI package differs from the authenticated source release")
+    raise RuntimeError("config does not declare integer config_version 8")
 
-sys.path.insert(0, wheel_path)
-from defenseclaw.observability.v8_config import load_validate_v8  # noqa: E402
-
-if os.path.lexists(os.path.join(data_dir, ".migration_state.json")):
-    raise RuntimeError("release-owned recovery requires a completely absent migration cursor")
-source = load_validate_v8(
-    read_regular(config_path, 4 * 1024 * 1024),
-    source_name="config.yaml",
-).source
-legacy_roots = {"audit_db", "audit_sinks", "judge_bodies_db", "otel", "splunk"}
-if (
-    type(source.get("config_version")) is not int
-    or source["config_version"] != 8
-    or "observability" not in source
-    or source["observability"] != {}
-    or any(name in source for name in legacy_roots)
-):
-    raise RuntimeError("release-owned source config has migration or observability residue")
-
-
-def decision_name(name):
-    return (
-        name in {
-            "DEFENSECLAW_DISABLE_REDACTION",
-            "DEFENSECLAW_JSONL_DISABLE",
-            "DEFENSECLAW_PERSIST_JUDGE",
-            "OTEL_SERVICE_NAME",
-        }
-        or name.startswith(("OTEL_", "DEFENSECLAW_OTEL_", "OPENCLAW_OTEL_"))
-    )
-
-
-if any(decision_name(name) for name in os.environ):
-    raise RuntimeError("release-owned recovery refuses ambient observability decisions")
-environment_path = os.path.join(data_dir, ".env")
-if os.path.lexists(environment_path):
-    environment = read_regular(environment_path, 1024 * 1024).decode("utf-8")
-    for raw_line in environment.splitlines():
-        line = raw_line.strip()
-        if line and not line.startswith("#") and "=" in line:
-            name = line.removeprefix("export ").split("=", 1)[0].strip()
-            if decision_name(name):
-                raise RuntimeError("release-owned environment has observability decisions")
+cursor_path = os.path.join(data_dir, ".migration_state.json")
+if os.path.lexists(cursor_path):
+    raise RuntimeError("migration cursor must be wholly absent")
 
 for residue in (
     config_path + ".pre-observability-migration.bak",
     os.path.join(data_dir, ".migration_state.fresh.pending.json"),
     os.path.join(data_dir, ".upgrade-receipts"),
-    os.path.join(data_dir, ".upgrade-recovery"),
+    os.path.join(recovery_root, "phase-one-active.json"),
+    os.path.join(recovery_root, "phase-two-active.json"),
 ):
     if os.path.lexists(residue):
-        raise RuntimeError("release-owned state has upgrade or migration residue")
-if os.path.lexists(backup_root):
-    backup_info = os.lstat(backup_root)
-    if (
-        stat.S_ISLNK(backup_info.st_mode)
-        or not stat.S_ISDIR(backup_info.st_mode)
-        or backup_info.st_uid != uid
-        or any(Path(backup_root).iterdir())
-    ):
-        raise RuntimeError("release-owned state has prior or unsafe upgrade backups")
-
-expected = {}
-with zipfile.ZipFile(wheel_path) as archive:
-    infos = archive.infolist()
-    if len(infos) > 8192 or len({info.filename for info in infos}) != len(infos):
-        raise RuntimeError(f"authenticated {source_version} wheel has unsafe members")
-    for info in infos:
-        path = PurePosixPath(info.filename)
-        prefix = ("defenseclaw", "_data", "local_observability_stack")
-        if path.is_absolute() or ".." in path.parts:
-            raise RuntimeError(f"authenticated {source_version} wheel has an unsafe path")
-        if info.is_dir() or path.parts[:3] != prefix or len(path.parts) <= 3:
-            continue
-        if info.file_size > 64 * 1024 * 1024:
-            raise RuntimeError(
-                f"authenticated {source_version} stack member exceeds its bound"
-            )
-        expected["/".join(path.parts[3:])] = hashlib.sha256(archive.read(info)).hexdigest()
-if not expected:
-    raise RuntimeError(f"authenticated {source_version} wheel lacks its local stack")
-
-stack_root = os.path.join(data_dir, "observability-stack")
-if not os.path.lexists(stack_root):
-    raise SystemExit(0)
-stack_info = os.lstat(stack_root)
-if (
-    stat.S_ISLNK(stack_info.st_mode)
-    or not stat.S_ISDIR(stack_info.st_mode)
-    or stack_info.st_uid != uid
-):
-    raise RuntimeError("release-owned local stack is missing or unsafe")
-actual = {}
-for current, names, files in os.walk(stack_root, topdown=True, followlinks=False):
-    current_info = os.lstat(current)
-    if stat.S_ISLNK(current_info.st_mode) or not stat.S_ISDIR(current_info.st_mode):
-        raise RuntimeError("release-owned local stack has an unsafe directory")
-    for name in names:
-        child = os.lstat(os.path.join(current, name))
-        if stat.S_ISLNK(child.st_mode) or not stat.S_ISDIR(child.st_mode):
-            raise RuntimeError("release-owned local stack has an unsafe child")
-    for name in files:
-        path = os.path.join(current, name)
-        relative = os.path.relpath(path, stack_root).replace(os.sep, "/")
-        if len(actual) >= 4096:
-            raise RuntimeError("release-owned local stack exceeds its file bound")
-        actual[relative] = hashlib.sha256(read_regular(path, 64 * 1024 * 1024)).hexdigest()
-if actual != expected:
-    raise RuntimeError("release-owned local stack differs from the authenticated release")
+        raise RuntimeError("active or incomplete upgrade state is present")
 PY
 
     HARD_CUT_CURSOR_RECOVERY=1
-    RELEASE_VERSION="${requested_version}"
-    configure_release
     prepare_release_contract
-    ok "Authenticated the exact published ${source_version} missing-cursor compatibility state"
+    ok "Accepted exact public ${source_version} cursorless first-run state"
 }
 
 
@@ -8138,8 +7286,7 @@ if not os.path.islink(launcher) or os.path.realpath(launcher) != os.path.realpat
     )
 PY
 
-    BRIDGE_PYTHON_INTERPRETER="$("${DEFENSECLAW_VENV}/bin/python" \
-        -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B -c \
+    BRIDGE_PYTHON_INTERPRETER="$("${DEFENSECLAW_VENV}/bin/python" -I -B -c \
         'import os,sys; print(os.path.realpath(getattr(sys, "_base_executable", "") or sys.executable))')" \
         || die "Could not resolve the source Python interpreter; no services changed."
     [[ -x "${BRIDGE_PYTHON_INTERPRETER}" ]] \
@@ -8274,8 +7421,7 @@ PY
 
     BRIDGE_SOURCE_HEALTH_URL="$(DEFENSECLAW_HOME="${DATA_DIR}" \
         DEFENSECLAW_CONFIG="${CONFIG_PATH}" \
-        "${DEFENSECLAW_VENV}/bin/python" \
-            -X "${MANAGED_PYTHON_NO_LOCAL_BYTECODE}" -I -B - <<'PY' 2>/dev/null || true
+        "${DEFENSECLAW_VENV}/bin/python" -I -B - <<'PY' 2>/dev/null || true
 from defenseclaw.config import load
 
 cfg = load()
@@ -8986,7 +8132,7 @@ validate_tarball_members() {
 }
 
 if [[ -n "${HARD_CUT_CURSOR_RECOVERY_SOURCE_VERSION}" ]]; then
-    authenticate_release_owned_missing_cursor_source
+    authorize_cursorless_field_recovery
 else
     prepare_release_contract
 fi


### PR DESCRIPTION
Standalone PR based directly on current `main` at `40efab1d6326a86925dfd5150d5621d0efc2fabb`. No stack dependency.

## Problem

The immutable 0.8.8 rescue bootstrap correctly hands control to a signed target resolver with a minimal `PATH`, but the target resolver still assumed `uv` was already installed. A real 0.8.7 field installation could therefore authenticate the release and then fail before repair. The same clean cursorless first-run state exists in both public 0.8.6 and 0.8.7 installations.

Release request validation also imposed an artificial stop after 0.8.8 until historical Windows upgrade coverage existed, even though Windows is currently supported as a fresh install.

## Current Situation

- The stable signed channel already makes future upgrade orchestration repairable by moving the authenticated pointer to a newer immutable resolver.
- The target resolver must work under `/usr/bin:/bin:/usr/sbin:/sbin`; Homebrew, Cargo, or another ambient `uv` cannot be assumed.
- Healthy public 0.8.6 and 0.8.7 first-run installations can have config version 8 with the migration cursor wholly absent.
- Windows has no historical native upgrade promise yet; each release still proves its current `install.ps1` and Setup/fresh-install lifecycle.

## Solution

### Resolver-owned pinned `uv`

The target resolver always downloads the official platform-specific `uv` 0.11.28 archive, verifies its exact reviewed SHA-256, extracts the explicit `uv` member into private staging, and checks the reported version before use. It never trusts or executes an ambient `uv` and never streams an upstream installer script.

The same helper is used by normal installation and interrupted phase-two recovery, so rescue works with a clean path.

### Narrow cursorless field recovery

Recovery accepts only the known public first-run shape:

- CLI and gateway versions match exactly and are either 0.8.6 or 0.8.7;
- configuration declares integer `config_version: 8`;
- the migration cursor is wholly absent; and
- no active receipt, phase journal, pending cursor, or config-migration residue exists.

The installed old release is treated as same-user repair input, not as a trust authority. The resolver still authenticates the target release's checksums, Sigstore identity, provenance, manifest, wheel, and gateway before mutation, then retains the existing backup, rollback, migration, strict-health, and durable-receipt contracts.

### Simple future-release acceptance

The hard-coded post-0.8.8 Windows ceiling is removed. Windows baselines remain empty, so releases continue to require the current native x64 `install.ps1` and Setup/fresh-install lifecycle without claiming a historical Windows upgrade path.

```mermaid
flowchart LR
    A["Immutable rescue bootstrap"] --> B["Signed stable pointer"]
    B --> C["Immutable target resolver"]
    C --> D["Private pinned uv"]
    D --> E["Authenticate target release"]
    E --> F["Backup, install, migrate"]
    F --> G["Strict health + durable receipt"]
```

## What Changed (Where & How)

| Path | Change |
|---|---|
| `scripts/upgrade.sh` | Added one pinned-uv bootstrap path for normal and interrupted recovery, added the narrow 0.8.6/0.8.7 cursorless state gate, and removed the earlier installed-source self-authentication machinery. |
| `scripts/test-upgrade-protocol-release.sh` | Reproduces real public cursorless 0.8.6 and 0.8.7 states on Linux and macOS and verifies the final state. |
| `scripts/test-upgrade-release.sh` | Removed staging that was needed only by the discarded source self-authentication design. |
| `scripts/release-preflight.py` | Removed the artificial post-0.8.8 Windows ceiling while retaining the POSIX upgrade lanes and current Windows fresh-install contract. |
| `cli/tests/test_upgrade_staged_resolver.py` | Covers clean-path pinned-uv use, exact cursorless acceptance, near-miss rejection, and interrupted recovery. |
| `cli/tests/test_release_channel.py` | Freezes the public 0.8.8 rescue bytes and proves composition with the current target resolver under a clean path. |
| `cli/tests/test_upgrade_bridge_phase1_rollback.py` | Covers pinned-uv use in the crash/rollback matrix and isolates live-gateway tests on retry-safe ports. |
| `cli/tests/test_upgrade_smoke_static.py`, `cli/tests/test_upgrade_release_smoke_contract.py` | Lock the simpler release and upgrade contracts. |
| `docs/RELEASE_CHANNEL.md`, `docs/RELEASE_RUNBOOK.md`, `docs/RELEASE_VALIDATION.md`, `docs/WINDOWS_RESCUE.md` | Document mutable signed discovery, immutable payloads, field recovery, and Windows fresh-install-only acceptance. |

The final PR is 1,043 additions and 516 deletions across implementation, tests, and documentation. `scripts/upgrade.sh` itself is 213 additions and 207 deletions: **+6 net production lines**.

## Breaking Changes

- Ambient/local `uv` is never used during upgrade; the resolver requires network access to authenticate its pinned temporary copy.
- Cursorless repair is limited to matching public 0.8.6 or 0.8.7 CLI/gateway state with config version 8 and no partial upgrade residue.
- Release requests newer than 0.8.8 are no longer blocked on an unsupported historical Windows upgrade lane.
- No public CLI, configuration, or stable-channel format changes.

## Open Issues / Follow-ups

- [#619](https://github.com/cisco-ai-defense/defenseclaw/issues/619) tracks optional native Windows historical upgrade coverage as a non-blocking future enhancement.

## Test Plan

Exact local commands and observed results:

- `PYTHONPATH=. uv run pytest -q cli/tests/test_release_channel.py cli/tests/test_upgrade_smoke_static.py` — **154 passed, 1 skipped**.
- `PYTHONPATH=. uv run pytest -q cli/tests/test_upgrade_staged_resolver.py` — **41 passed**.
- `PYTHONPATH=. uv run pytest -q cli/tests/test_upgrade_release_smoke_contract.py cli/tests/test_upgrade_bridge_phase1_rollback.py cli/tests/test_upgrade_gateway_start_readiness_handoff.py` — **136 passed**, including the **19/19** crash/rollback matrix.
- `PYTHONPATH=. uv run pytest -q cli/tests/test_release_preflight.py cli/tests/test_release_runbook.py cli/tests/test_windows_release_certification.py` — **33 passed**.
- Focused pinned-uv/cursorless recovery lane — **23 passed**.
- `git diff --check` — passed.
- `bash -n scripts/upgrade.sh scripts/test-upgrade-release.sh scripts/test-upgrade-protocol-release.sh` — passed.
- Ruff and Python compile checks for the changed Python/tests — passed.

Connected macOS arm64 proof:

- Authenticated the exact public 0.8.7 wheel and gateway in a disposable first-run home.
- Ran this resolver to public 0.8.8 under `/usr/bin:/bin:/usr/sbin:/sbin` with no ambient `uv`.
- Verified CLI/gateway 0.8.8, strict health/provenance, the complete migration cursor, acknowledged success receipt, byte-exact source backup, and no recovery residue.
- Stopped the isolated gateway/watchdog, released the high port, removed the fixture, and verified the user's live installation and port 18970 listener were unchanged.

Connected Linux arm64 proof:

- Authenticated the exact public 0.8.7 wheel and gateway in a disposable first-run home.
- Ran this resolver to public 0.8.8 under `/usr/bin:/bin:/usr/sbin:/sbin` with no ambient `uv`.
- Verified CLI/gateway 0.8.8, strict subsystem health/provenance, the complete migration cursor, acknowledged success receipt, exact config/gateway backup, and no recovery residue.
- Stopped the isolated gateway/watchdog, released the high port, copied the evidence locally, removed the fixture, and confirmed the pre-existing host fingerprint was byte-for-byte unchanged.