### PR TITLE
docs(release): clarify install trust boundary

### DIFF
--- a/cli/tests/test_install_docs_static.py
+++ b/cli/tests/test_install_docs_static.py
@@ -1834,8 +1834,11 @@ def test_release_docs_use_one_dispatch_and_never_precreate_tag() -> None:
     assert "operation: release" in install
     assert f"version: {RELEASE_DOC_EXAMPLE_VERSION}" in install
     assert "Selecting **main**, the operation, and the version is the whole release" in install
-    assert "automatically freezes the run's exact `github.sha`" in install
     normalized = " ".join(install.split())
+    assert "automatically freezes the run's exact `github.sha`" in normalized
+    assert "protected `main` is source-certified only while required checks" in normalized
+    assert "reviewed release workflow and signing identity remain protected" in normalized
+    assert "administrator-level bypass" in normalized
     assert "operators do not copy a commit SHA or confirm repository settings" in normalized
     assert r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$" in install
     assert "Do not create or push the tag yourself" in install

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -407,9 +407,11 @@ gh workflow run release.yaml \
 ```
 
 Selecting **main**, the operation, and the version is the whole release
-request. Anything merged to `main` is source-certified, and GitHub
-automatically freezes the run's exact `github.sha`; operators do not copy a
-commit SHA or confirm repository settings.
+request. Anything merged to protected `main` is source-certified only while
+required checks and the reviewed release workflow and signing identity remain
+protected from administrator-level bypass. GitHub automatically freezes the
+run's exact `github.sha`; operators do not copy a commit SHA or confirm
+repository settings.
 
 Do not create or push the tag yourself. The workflow must retain exclusive
 ownership of that namespace until its tested candidate is approved and


### PR DESCRIPTION
## Summary

- Clarify that install-doc release source certification depends on protected `main`, required checks, and the reviewed release workflow/signing identity remaining protected from administrator-level bypass.
- Add a static docs assertion so the protected-main trust-boundary wording stays covered.

Fixes #626.

## Test Plan

```bash
uv run --frozen python -m pytest -q cli/tests/test_install_docs_static.py::test_release_docs_use_one_dispatch_and_never_precreate_tag
# 1 passed in 0.24s

git diff --check
# no output
```

## CI Status

Pending; PR just opened from this automation run.