### PR TITLE
Restore Windows install and upgrade convergence

### DIFF
--- a/cli/defenseclaw/bootstrap.py
+++ b/cli/defenseclaw/bootstrap.py
@@ -619,7 +619,27 @@ def run_first_run(options: FirstRunOptions) -> FirstRunReport:
             )
     try:
         cfg = cfg_mod.load()
-    except Exception:
+    except Exception as exc:
+        if connector == "none" and not was_config_absent:
+            cfg = cfg_mod.default_config()
+            setup.append(
+                StepResult(
+                    "Config",
+                    "fail",
+                    f"existing configuration could not be loaded and was preserved: {exc}",
+                    "defenseclaw config validate",
+                )
+            )
+            return FirstRunReport(
+                status="needs_attention",
+                config_file=str(cfg_mod.config_path()),
+                data_dir=cfg.data_dir,
+                connector=connector,
+                profile=profile,
+                setup=setup,
+                next_commands=["defenseclaw config validate"],
+                connector_mode_warnings=connector_mode_warnings,
+            )
         cfg = cfg_mod.default_config()
         cfg_mod.prepare_fresh_v8_config(cfg)
         new_config = True
@@ -649,13 +669,14 @@ def run_first_run(options: FirstRunOptions) -> FirstRunReport:
         setup.append(StepResult("Migration State", "pass", "recovered pending fresh cursor"))
 
     cfg.environment = cfg_mod.detect_environment()
-    if profile == "action":
+    if connector != "none" and profile == "action":
         mode_warning = _first_run_action_mode_warning(connector, getattr(cfg, "data_dir", ""))
         if mode_warning:
             connector_mode_warnings.append(mode_warning)
             profile = "observe"
 
-    _apply_first_run_choices(cfg, options, connector, profile, scanner_mode)
+    if connector != "none":
+        _apply_first_run_choices(cfg, options, connector, profile, scanner_mode)
 
     try:
         cfg.save()
@@ -704,7 +725,10 @@ def run_first_run(options: FirstRunOptions) -> FirstRunReport:
         app.store = store
         app.logger = logger
 
-        setup.append(_quiet_guardrail_setup(app, connector, verbose=options.verbose))
+        if connector == "none":
+            setup.append(StepResult("Guardrail", "skip", "no connector requested"))
+        else:
+            setup.append(_quiet_guardrail_setup(app, connector, verbose=options.verbose))
         setup.extend(_connector_mode_warning_steps(connector_mode_warnings))
 
         if options.sandbox:
@@ -852,7 +876,9 @@ def _normalize_connector(raw: str | None) -> str:
     value = (raw or "").strip().lower()
     if value in {"claude", "claude-code", "claude_code"}:
         value = "claudecode"
-    if value in {"none", ""}:
+    if value == "none":
+        return "none"
+    if value == "":
         value = "codex"
     try:
         return connector_paths.normalize(value)
@@ -1374,6 +1400,8 @@ def _pid_looks_like_gateway(pid: int) -> bool:
 
 
 def _connector_readiness(cfg: Config, connector: str) -> StepResult:
+    if connector == "none":
+        return StepResult("Connector", "skip", "no connector requested")
     if connector == "openclaw":
         path = os.path.expanduser(cfg.claw.config_file)
         if os.path.isfile(path):

--- a/cli/defenseclaw/commands/cmd_init.py
+++ b/cli/defenseclaw/commands/cmd_init.py
@@ -79,6 +79,7 @@ _render_checkbox_menu = terminal_checkbox.render_checkbox_menu
             "antigravity",
             "opencode",
             "omnigent",
+            "none",
         ],
         case_sensitive=False,
     ),
@@ -226,6 +227,8 @@ def init_cmd(  # noqa: PLR0913 - first-run CLI mirrors the setup surface.
         requested_connectors.append(_normalize_connector_arg(connector))
     requested_connectors.extend(_parse_connector_list(action_connectors))
     for requested in requested_connectors:
+        if requested == "none":
+            continue
         support = platform_support.connector_platform_support(requested)
         if not support.available:
             raise click.ClickException(
@@ -766,7 +769,7 @@ def _run_first_run_cmd(  # noqa: PLR0913 - mirrors click options.
         _render_first_run_report(report, CLIRenderer())
         raise SystemExit(1)
 
-    activated = [primary["connector"]]
+    activated = [] if primary["connector"] == "none" else [primary["connector"]]
     if extras:
         activated, sidecar_step = _activate_additional_connectors(
             primary,

--- a/cli/defenseclaw/commands/cmd_upgrade.py
+++ b/cli/defenseclaw/commands/cmd_upgrade.py
@@ -522,6 +522,10 @@ def upgrade(
     recovery_home = _upgrade_recovery_home()
     data_dir = _resolved_upgrade_data_dir(app.cfg, recovery_home=recovery_home)
     active_config_path = _active_upgrade_config_path(recovery_home)
+    native_windows_state = _native_windows_install_state(
+        os_name,
+        expected_version=current_version,
+    )
     if current_version != controller_version:
         _preflight_staged_target_controller_source(
             source_version=current_version,
@@ -529,12 +533,21 @@ def upgrade(
             target_version=target_version,
             recovery_home=recovery_home,
         )
-    _preflight_installed_source_coherence(
-        current_version,
-        os_name,
-        data_dir,
-        config_path=active_config_path,
-    )
+    if native_windows_state is None:
+        _preflight_installed_source_coherence(
+            current_version,
+            os_name,
+            data_dir,
+            config_path=active_config_path,
+        )
+    else:
+        _preflight_installed_source_coherence(
+            current_version,
+            os_name,
+            data_dir,
+            config_path=active_config_path,
+            native_windows_state=native_windows_state,
+        )
 
     # ── Pre-flight: verify artifacts exist ───────────────────────────────────
 
@@ -563,7 +576,6 @@ def upgrade(
         # predate goreleaser's checksum publication; in that case we proceed
         # with a clear warning rather than hard-failing operators on a
         # version they could otherwise install.
-        native_windows_state = _native_windows_install_state(os_name)
         if native_windows_state is not None and allow_unverified:
             ux.err(
                 "--allow-unverified is not permitted for native Windows setup handoff.",
@@ -2734,7 +2746,11 @@ def _detect_platform() -> tuple[str, str]:
     return system, arch
 
 
-def _native_windows_install_state(os_name: str) -> dict[str, object] | None:
+def _native_windows_install_state(
+    os_name: str,
+    *,
+    expected_version: str | None = None,
+) -> dict[str, object] | None:
     """Return installer state for native Windows EXE installs, if present."""
     if os_name != "windows":
         return None
@@ -2748,52 +2764,106 @@ def _native_windows_install_state(os_name: str) -> dict[str, object] | None:
     install_root = _trusted_child_path(local_appdata, "Programs", "DefenseClaw")
     state_path = os.path.join(install_root, "installer", _WINDOWS_INSTALL_STATE)
     try:
+        state_info = os.lstat(state_path)
+        if stat.S_ISLNK(state_info.st_mode) or not stat.S_ISREG(state_info.st_mode):
+            raise OSError("installer state is not a regular file")
+        from defenseclaw import windows_acl
+
+        state_security = windows_acl.capture_path(state_path)
+        windows_acl.assert_trusted_owner(state_security)
+        windows_acl.assert_not_broadly_writable(state_security)
         with open(state_path, encoding="utf-8") as stream:
             state = json.load(stream)
+        state_after = os.lstat(state_path)
+        if (
+            stat.S_ISLNK(state_after.st_mode)
+            or not stat.S_ISREG(state_after.st_mode)
+            or (state_info.st_dev, state_info.st_ino) != (state_after.st_dev, state_after.st_ino)
+            or windows_acl.capture_path(state_path) != state_security
+        ):
+            raise OSError("installer state changed during validation")
     except FileNotFoundError:
         return None
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
         ux.err(f"Native installer state could not be read safely: {exc}", indent="  ")
         raise SystemExit(1) from exc
     if not isinstance(state, dict):
         ux.err("Native installer state must be a JSON object.", indent="  ")
         raise SystemExit(1)
-    if state.get("install_kind") != "native-windows-exe":
-        ux.err("Native installer state has an unexpected install kind.", indent="  ")
+    if (
+        state.get("schema_version") != 1
+        or state.get("install_kind") != "native-windows-exe"
+        or state.get("install_scope") != "user"
+        or not isinstance(state.get("version"), str)
+        or _CANONICAL_VERSION_RE.fullmatch(state["version"]) is None
+        or state.get("connector") not in {"none", "codex", "claudecode"}
+        or state.get("mode") not in {"observe", "action"}
+    ):
+        ux.err("Native installer state is not a supported native Windows install.", indent="  ")
+        raise SystemExit(1)
+    if expected_version is not None and state["version"] != expected_version:
+        ux.err(
+            f"Native installer state version {state['version']} does not match the installed CLI {expected_version}.",
+            indent="  ",
+        )
+        raise SystemExit(1)
+    source_commit = state.get("source_commit")
+    if source_commit not in (None, "") and (
+        not isinstance(source_commit, str) or re.fullmatch(r"[0-9a-f]{40}", source_commit) is None
+    ):
+        ux.err("Native installer state has an invalid source build identity.", indent="  ")
+        raise SystemExit(1)
+    if state.get("path_value_created") is True and state.get("path_entry_owned") is not True:
+        ux.err("Native installer state has inconsistent PATH ownership.", indent="  ")
+        raise SystemExit(1)
+    if state.get("path_value_created") is True and state.get("path_separator_reused") is True:
+        ux.err("Native installer state has inconsistent PATH separator ownership.", indent="  ")
         raise SystemExit(1)
 
     root = _trusted_child_path(install_root)
     command_dir = _trusted_child_path(root, "bin")
     expected_root = _trusted_child_path(local_appdata, "Programs", "DefenseClaw")
-    if os.path.normcase(root) != os.path.normcase(expected_root):
-        ux.err(f"Native installer state has an unexpected install root: {root}", indent="  ")
-        raise SystemExit(1)
+    try:
+        from defenseclaw import windows_acl
+
+        for managed_directory in (
+            root,
+            command_dir,
+            _trusted_child_path(root, "installer"),
+        ):
+            managed_security = windows_acl.capture_path(managed_directory, directory=True)
+            windows_acl.assert_trusted_owner(managed_security)
+            windows_acl.assert_not_broadly_writable(managed_security)
+    except (OSError, windows_acl.WindowsAclError) as exc:
+        ux.err(f"Native installer directory custody could not be verified: {exc}", indent="  ")
+        raise SystemExit(1) from exc
     setup = _trusted_child_path(
         local_appdata,
         "DefenseClaw",
         "InstallerCache",
         _WINDOWS_SETUP_ASSET,
     )
-    recorded_setup = state.get("maintenance_path")
-    if recorded_setup and (
-        not isinstance(recorded_setup, str)
-        or os.path.normcase(os.path.realpath(recorded_setup)) != os.path.normcase(setup)
-    ):
-        ux.err("Native installer state has an unexpected maintenance path.", indent="  ")
-        raise SystemExit(1)
-    data_root = state.get("data_root")
     expected_data_root = _trusted_child_path(profile, ".defenseclaw")
-    if data_root and (
-        not isinstance(data_root, str)
-        or os.path.normcase(os.path.realpath(data_root)) != os.path.normcase(expected_data_root)
-    ):
-        ux.err("Native installer state has an unexpected data root.", indent="  ")
-        raise SystemExit(1)
+    expected_paths = {
+        "install root": (state.get("install_root"), expected_root),
+        "command directory": (state.get("command_dir"), command_dir),
+        "data root": (state.get("data_root"), expected_data_root),
+        "runtime": (state.get("runtime"), _trusted_child_path(root, "runtime", "python")),
+        "maintenance path": (state.get("maintenance_path"), setup),
+    }
+    for label, (recorded, expected) in expected_paths.items():
+        if (
+            not isinstance(recorded, str)
+            or os.path.normcase(os.path.realpath(recorded)) != os.path.normcase(expected)
+        ):
+            ux.err(f"Native installer state has an unexpected {label}.", indent="  ")
+            raise SystemExit(1)
+    gateway_path = _trusted_child_path(command_dir, _installed_gateway_filename(os_name))
     state["install_root"] = root
     state["command_dir"] = command_dir
+    state["gateway_path"] = gateway_path
     state["setup_path"] = setup
     state["maintenance_path"] = setup
-    state["install_scope"] = state.get("install_scope", "user")
     state["data_root"] = expected_data_root
     return state
 
@@ -3108,13 +3178,31 @@ def _preflight_installed_source_coherence(
     data_dir: str,
     *,
     config_path: str | None = None,
+    native_windows_state: dict[str, object] | None = None,
 ) -> None:
     """Reject manual/partial release overwrites before target I/O or mutation."""
 
     if _version_key(current_version) < _version_key(_STRICT_SIGSTORE_RELEASE_VERSION):
         return
 
-    gateway_path = os.path.expanduser(os.path.join("~/.local/bin", _installed_gateway_filename(os_name)))
+    native_gateway = native_windows_state is not None
+    if native_gateway:
+        gateway_path = native_windows_state.get("gateway_path")
+        if not isinstance(gateway_path, str) or not gateway_path:
+            _fail_installed_source_coherence(
+                f"Installed DefenseClaw {current_version} native installer state has no canonical gateway."
+            )
+        legacy_gateway = os.path.expanduser(
+            os.path.join("~/.local/bin", _installed_gateway_filename(os_name))
+        )
+        if os.path.lexists(legacy_gateway):
+            _fail_installed_source_coherence(
+                f"Installed DefenseClaw {current_version} has a shadow gateway outside native installer custody."
+            )
+    else:
+        gateway_path = os.path.expanduser(
+            os.path.join("~/.local/bin", _installed_gateway_filename(os_name))
+        )
     try:
         gateway_stat = os.lstat(gateway_path)
     except OSError:
@@ -3125,9 +3213,20 @@ def _preflight_installed_source_coherence(
         _fail_installed_source_coherence(
             f"Installed DefenseClaw {current_version} gateway is not a regular release-managed file."
         )
+    if native_gateway:
+        try:
+            from defenseclaw import windows_acl
+
+            gateway_security = windows_acl.capture_path(gateway_path)
+            windows_acl.assert_trusted_owner(gateway_security)
+            windows_acl.assert_not_broadly_writable(gateway_security)
+        except (OSError, windows_acl.WindowsAclError):
+            _fail_installed_source_coherence(
+                f"Installed DefenseClaw {current_version} gateway is not owned by the native installer."
+            )
     try:
         result = subprocess.run(
-            [gateway_path, "--version"],
+            [gateway_path, "--version-json" if native_gateway else "--version"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -3138,10 +3237,61 @@ def _preflight_installed_source_coherence(
             f"Installed DefenseClaw {current_version} gateway version could not be verified."
         )
     output = (result.stdout or "") + (result.stderr or "")
-    reported = _VERSION_TOKEN_RE.findall(output)
-    if result.returncode != 0 or reported != [current_version]:
-        actual = reported[0] if len(reported) == 1 else "unverifiable"
-        _fail_installed_source_coherence(f"Installed component version drift: CLI={current_version}, gateway={actual}.")
+    if native_gateway:
+        try:
+            identity = json.loads(output)
+        except (TypeError, json.JSONDecodeError):
+            identity = None
+        expected_commit = native_windows_state.get("source_commit")
+        if (
+            result.returncode != 0
+            or not isinstance(identity, dict)
+            or identity.get("schema_version") != 1
+            or identity.get("name") != "defenseclaw-gateway"
+            or identity.get("version") != current_version
+        ):
+            actual = identity.get("version", "unverifiable") if isinstance(identity, dict) else "unverifiable"
+            _fail_installed_source_coherence(
+                f"Installed component version drift: CLI={current_version}, gateway={actual}."
+            )
+        if expected_commit not in (None, "") and identity.get("commit") != expected_commit:
+            _fail_installed_source_coherence(
+                f"Installed DefenseClaw {current_version} gateway build identity does not match installer state."
+            )
+        try:
+            gateway_after = os.lstat(gateway_path)
+        except OSError:
+            _fail_installed_source_coherence(
+                f"Installed DefenseClaw {current_version} gateway changed during validation."
+            )
+        if (
+            stat.S_ISLNK(gateway_after.st_mode)
+            or not stat.S_ISREG(gateway_after.st_mode)
+            or (gateway_stat.st_dev, gateway_stat.st_ino)
+            != (gateway_after.st_dev, gateway_after.st_ino)
+        ):
+            _fail_installed_source_coherence(
+                f"Installed DefenseClaw {current_version} gateway changed during validation."
+            )
+        try:
+            gateway_security_after = windows_acl.capture_path(gateway_path)
+            windows_acl.assert_trusted_owner(gateway_security_after)
+            windows_acl.assert_not_broadly_writable(gateway_security_after)
+        except (OSError, windows_acl.WindowsAclError):
+            _fail_installed_source_coherence(
+                f"Installed DefenseClaw {current_version} gateway ownership changed during validation."
+            )
+        if gateway_security_after != gateway_security:
+            _fail_installed_source_coherence(
+                f"Installed DefenseClaw {current_version} gateway ownership changed during validation."
+            )
+    else:
+        reported = _VERSION_TOKEN_RE.findall(output)
+        if result.returncode != 0 or reported != [current_version]:
+            actual = reported[0] if len(reported) == 1 else "unverifiable"
+            _fail_installed_source_coherence(
+                f"Installed component version drift: CLI={current_version}, gateway={actual}."
+            )
 
     if _version_key(current_version) < _version_key(_OBSERVABILITY_V8_MIGRATION_VERSION):
         return

--- a/cli/tests/test_bootstrap.py
+++ b/cli/tests/test_bootstrap.py
@@ -274,6 +274,90 @@ class FreshMigrationCursorTests(unittest.TestCase):
         self.assertEqual(state.applied_at["0.8.5"], migration_state.BOOTSTRAP_SENTINEL)
         self.assertTrue(all(state.applied_at[version] == migration_state.BOOTSTRAP_SENTINEL for version in expected))
 
+    def test_no_connector_first_run_creates_canonical_config_and_cursor_without_connector_setup(self):
+        from defenseclaw import migration_state
+        from defenseclaw.bootstrap import FirstRunOptions, run_first_run
+
+        data_dir = os.path.join(self._tmp.name, "none")
+        with (
+            patch.dict(os.environ, {"DEFENSECLAW_HOME": data_dir}),
+            patch("defenseclaw.bootstrap._quiet_guardrail_setup") as connector_setup,
+        ):
+            report = run_first_run(
+                FirstRunOptions(
+                    connector="none",
+                    profile="observe",
+                    skip_install=True,
+                    start_gateway=False,
+                    verify=False,
+                )
+            )
+
+        self.assertNotEqual(report.status, "needs_attention")
+        self.assertTrue(os.path.isfile(os.path.join(data_dir, "config.yaml")))
+        self.assertIsNotNone(migration_state.load(data_dir))
+        connector_setup.assert_not_called()
+        self.assertTrue(
+            any(step.name == "Guardrail" and step.status == "skip" for step in report.setup)
+        )
+
+    def test_no_connector_first_run_preserves_existing_connector_selection(self):
+        from defenseclaw.bootstrap import FirstRunOptions, run_first_run
+        from defenseclaw.config import default_config, load, prepare_fresh_v8_config
+
+        data_dir = os.path.join(self._tmp.name, "none-existing")
+        with patch.dict(os.environ, {"DEFENSECLAW_HOME": data_dir}):
+            cfg = default_config()
+            prepare_fresh_v8_config(cfg)
+            cfg.claw.mode = "claudecode"
+            cfg.guardrail.connector = "claudecode"
+            cfg.guardrail.mode = "action"
+            cfg.save()
+
+            report = run_first_run(
+                FirstRunOptions(
+                    connector="none",
+                    profile="observe",
+                    skip_install=True,
+                    start_gateway=False,
+                    verify=False,
+                )
+            )
+            preserved = load()
+
+        self.assertNotEqual(report.status, "needs_attention")
+        self.assertEqual(preserved.claw.mode, "claudecode")
+        self.assertEqual(preserved.guardrail.connector, "claudecode")
+        self.assertEqual(preserved.guardrail.mode, "action")
+
+    def test_no_connector_first_run_preserves_unloadable_existing_config(self):
+        from defenseclaw.bootstrap import FirstRunOptions, run_first_run
+
+        data_dir = os.path.join(self._tmp.name, "none-unloadable")
+        config_path = os.path.join(data_dir, "config.yaml")
+        os.makedirs(data_dir)
+        original = b"config_version: 8\noperator_extension: preserve-me\n"
+        with open(config_path, "wb") as stream:
+            stream.write(original)
+
+        with (
+            patch.dict(os.environ, {"DEFENSECLAW_HOME": data_dir}),
+            patch("defenseclaw.config.load", side_effect=OSError("injected load failure")),
+        ):
+            report = run_first_run(
+                FirstRunOptions(
+                    connector="none",
+                    profile="observe",
+                    skip_install=True,
+                    start_gateway=False,
+                    verify=False,
+                )
+            )
+
+        self.assertEqual(report.status, "needs_attention")
+        with open(config_path, "rb") as stream:
+            self.assertEqual(stream.read(), original)
+
     def test_rerun_preserves_bootstrapped_cursor_byte_for_byte(self):
         from defenseclaw import migration_state
 

--- a/cli/tests/test_cmd_init.py
+++ b/cli/tests/test_cmd_init.py
@@ -62,6 +62,28 @@ class TestInitCommand(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn("Initialize DefenseClaw environment", result.output)
 
+    @patch("defenseclaw.commands.cmd_init._run_first_run_cmd")
+    def test_explicit_no_connector_uses_canonical_first_run_backend(self, run_first_run):
+        result = self.runner.invoke(
+            init_cmd,
+            [
+                "--skip-install",
+                "--non-interactive",
+                "--yes",
+                "--connector",
+                "none",
+                "--profile",
+                "observe",
+                "--no-start-gateway",
+                "--no-verify",
+            ],
+            obj=AppContext(),
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output + (result.stderr or ""))
+        run_first_run.assert_called_once()
+        self.assertEqual(run_first_run.call_args.kwargs["connector"], "none")
+
     @patch("defenseclaw.commands.cmd_init.shutil.which", return_value=None)
     @patch("defenseclaw.commands.cmd_init._install_guardrail")
     @patch("defenseclaw.commands.cmd_init._install_scanners")

--- a/cli/tests/test_cmd_upgrade.py
+++ b/cli/tests/test_cmd_upgrade.py
@@ -14,7 +14,7 @@ import time
 import types
 import unittest
 import zipfile
-from contextlib import ExitStack, nullcontext
+from contextlib import AbstractContextManager, ExitStack, nullcontext
 from dataclasses import replace
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -6706,7 +6706,7 @@ class TestUpgradeManifest(unittest.TestCase):
     policy even when the local upgrade script is older than the release."""
 
     @staticmethod
-    def _native_windows_acl_fixture():
+    def _native_windows_acl_fixture() -> AbstractContextManager[object]:
         """Use real ACLs on Windows and stable custody evidence elsewhere."""
         if os.name == "nt":
             return nullcontext()

--- a/cli/tests/test_cmd_upgrade.py
+++ b/cli/tests/test_cmd_upgrade.py
@@ -6706,6 +6706,22 @@ class TestUpgradeManifest(unittest.TestCase):
     policy even when the local upgrade script is older than the release."""
 
     @staticmethod
+    def _native_windows_acl_fixture():
+        """Use real ACLs on Windows and stable custody evidence elsewhere."""
+        if os.name == "nt":
+            return nullcontext()
+        stack = ExitStack()
+        security = Mock(name="native-windows-security")
+        stack.enter_context(
+            patch("defenseclaw.windows_acl.capture_path", return_value=security)
+        )
+        stack.enter_context(patch("defenseclaw.windows_acl.assert_trusted_owner"))
+        stack.enter_context(
+            patch("defenseclaw.windows_acl.assert_not_broadly_writable")
+        )
+        return stack
+
+    @staticmethod
     def _native_install_state_fixture(
         temp: str,
         *,
@@ -7569,7 +7585,7 @@ class TestUpgradeManifest(unittest.TestCase):
             with patch(
                 "defenseclaw.commands.cmd_upgrade._windows_known_folder",
                 side_effect=[local_appdata, profile],
-            ):
+            ), self._native_windows_acl_fixture():
                 loaded = _native_windows_install_state("windows", expected_version="0.8.7")
 
         self.assertIsNotNone(loaded)
@@ -7595,6 +7611,7 @@ class TestUpgradeManifest(unittest.TestCase):
                     "defenseclaw.commands.cmd_upgrade._windows_known_folder",
                     side_effect=[local_appdata, profile],
                 ),
+                self._native_windows_acl_fixture(),
             ):
                 loaded = _native_windows_install_state("windows")
 
@@ -7611,6 +7628,7 @@ class TestUpgradeManifest(unittest.TestCase):
                     "defenseclaw.commands.cmd_upgrade._windows_known_folder",
                     side_effect=[local_appdata, profile],
                 ),
+                self._native_windows_acl_fixture(),
                 self.assertRaises(SystemExit) as ctx,
             ):
                 _native_windows_install_state("windows", expected_version="0.8.7")
@@ -7632,6 +7650,7 @@ class TestUpgradeManifest(unittest.TestCase):
                     "defenseclaw.commands.cmd_upgrade._windows_known_folder",
                     side_effect=[local_appdata, profile],
                 ),
+                self._native_windows_acl_fixture(),
                 self.assertRaises(SystemExit) as ctx,
             ):
                 _native_windows_install_state("windows")
@@ -7670,6 +7689,7 @@ class TestUpgradeManifest(unittest.TestCase):
                     "defenseclaw.commands.cmd_upgrade._windows_known_folder",
                     side_effect=[local_appdata, profile],
                 ),
+                self._native_windows_acl_fixture(),
             ):
                 state = _native_windows_install_state("windows", expected_version="0.8.7")
                 with patch(
@@ -7758,6 +7778,7 @@ class TestUpgradeManifest(unittest.TestCase):
                         "defenseclaw.commands.cmd_upgrade._windows_known_folder",
                         side_effect=[local_appdata, profile],
                     ),
+                    self._native_windows_acl_fixture(),
                 ):
                     state = _native_windows_install_state("windows", expected_version="0.8.7")
                     ownership = (

--- a/cli/tests/test_cmd_upgrade.py
+++ b/cli/tests/test_cmd_upgrade.py
@@ -6706,6 +6706,51 @@ class TestUpgradeManifest(unittest.TestCase):
     policy even when the local upgrade script is older than the release."""
 
     @staticmethod
+    def _native_install_state_fixture(
+        temp: str,
+        *,
+        version: str = "0.8.7",
+        source_commit: str = "a" * 40,
+        recorded_install_root: str | None = None,
+    ) -> tuple[str, str, dict[str, object]]:
+        local_appdata = os.path.join(temp, "LocalAppData")
+        profile = os.path.join(temp, "Profile")
+        install_root = os.path.join(local_appdata, "Programs", "DefenseClaw")
+        command_dir = os.path.join(install_root, "bin")
+        maintenance = os.path.join(
+            local_appdata,
+            "DefenseClaw",
+            "InstallerCache",
+            "DefenseClawSetup-x64.exe",
+        )
+        os.makedirs(os.path.join(install_root, "installer"))
+        os.makedirs(command_dir)
+        os.makedirs(profile)
+        state: dict[str, object] = {
+            "schema_version": 1,
+            "version": version,
+            "source_commit": source_commit,
+            "distribution_flavor": "release",
+            "install_kind": "native-windows-exe",
+            "install_scope": "user",
+            "install_root": recorded_install_root or install_root,
+            "command_dir": command_dir,
+            "data_root": os.path.join(profile, ".defenseclaw"),
+            "runtime": os.path.join(install_root, "runtime", "python"),
+            "maintenance_path": maintenance,
+            "path_entry_owned": True,
+            "connector": "codex",
+            "mode": "action",
+        }
+        with open(
+            os.path.join(install_root, "installer", "install-state.json"),
+            "w",
+            encoding="utf-8",
+        ) as stream:
+            json.dump(state, stream)
+        return local_appdata, profile, state
+
+    @staticmethod
     def _hard_cut_manifest(**overrides):
         payload = {
             "schema_version": 2,
@@ -7519,30 +7564,21 @@ class TestUpgradeManifest(unittest.TestCase):
 
     def test_native_windows_install_state_reads_marker_and_normalizes_paths(self):
         with TemporaryDirectory() as temp:
-            local_appdata = os.path.join(temp, "LocalAppData")
-            profile = os.path.join(temp, "Profile")
-            os.makedirs(local_appdata)
-            os.makedirs(profile)
-            root = os.path.join(local_appdata, "Programs", "DefenseClaw")
-            installer = os.path.join(root, "installer")
-            os.makedirs(installer)
-            state = {
-                "install_kind": "native-windows-exe",
-                "connector": "codex",
-                "mode": "action",
-                "data_root": os.path.join(profile, ".defenseclaw"),
-            }
-            with open(os.path.join(installer, "install-state.json"), "w", encoding="utf-8") as stream:
-                json.dump(state, stream)
+            local_appdata, profile, _state = self._native_install_state_fixture(temp)
 
             with patch(
                 "defenseclaw.commands.cmd_upgrade._windows_known_folder",
                 side_effect=[local_appdata, profile],
             ):
-                loaded = _native_windows_install_state("windows")
+                loaded = _native_windows_install_state("windows", expected_version="0.8.7")
 
         self.assertIsNotNone(loaded)
         self.assertEqual(loaded["connector"], "codex")
+        self.assertTrue(
+            loaded["gateway_path"].endswith(
+                os.path.join("DefenseClaw", "bin", "defenseclaw-gateway.exe"),
+            ),
+        )
         self.assertTrue(
             loaded["setup_path"].endswith(
                 os.path.join("DefenseClaw", "InstallerCache", "DefenseClawSetup-x64.exe"),
@@ -7551,13 +7587,7 @@ class TestUpgradeManifest(unittest.TestCase):
 
     def test_native_windows_install_state_ignores_environment_install_root(self):
         with TemporaryDirectory() as temp:
-            local_appdata = os.path.join(temp, "LocalAppData")
-            profile = os.path.join(temp, "Profile")
-            installer = os.path.join(local_appdata, "Programs", "DefenseClaw", "installer")
-            os.makedirs(installer)
-            os.makedirs(profile)
-            with open(os.path.join(installer, "install-state.json"), "w", encoding="utf-8") as stream:
-                json.dump({"install_kind": "native-windows-exe"}, stream)
+            local_appdata, profile, _state = self._native_install_state_fixture(temp)
 
             with (
                 patch.dict(os.environ, {"DEFENSECLAW_INSTALL_ROOT": os.path.join(temp, "Untrusted")}),
@@ -7569,6 +7599,23 @@ class TestUpgradeManifest(unittest.TestCase):
                 loaded = _native_windows_install_state("windows")
 
         self.assertTrue(loaded["install_root"].startswith(os.path.realpath(local_appdata)))
+
+    def test_native_windows_install_state_rejects_foreign_recorded_root(self):
+        with TemporaryDirectory() as temp:
+            local_appdata, profile, _state = self._native_install_state_fixture(
+                temp,
+                recorded_install_root=os.path.join(temp, "Foreign"),
+            )
+            with (
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._windows_known_folder",
+                    side_effect=[local_appdata, profile],
+                ),
+                self.assertRaises(SystemExit) as ctx,
+            ):
+                _native_windows_install_state("windows", expected_version="0.8.7")
+
+        self.assertEqual(ctx.exception.code, 1)
 
     def test_native_windows_install_state_rejects_corrupt_marker(self):
         with TemporaryDirectory() as temp:
@@ -7590,6 +7637,195 @@ class TestUpgradeManifest(unittest.TestCase):
                 _native_windows_install_state("windows")
 
         self.assertEqual(ctx.exception.code, 1)
+
+    def test_native_gateway_only_in_known_folder_passes_installed_source_coherence(self):
+        from defenseclaw import migration_state
+
+        with TemporaryDirectory() as temp:
+            local_appdata, profile, _state = self._native_install_state_fixture(temp)
+            data_dir = os.path.join(profile, ".defenseclaw")
+            os.makedirs(data_dir)
+            config_path = os.path.join(data_dir, "config.yaml")
+            Path(config_path).write_text("config_version: 8\n", encoding="utf-8")
+            migration_state.save(
+                data_dir,
+                migration_state.MigrationState(
+                    package_version="0.8.7",
+                    applied=["0.8.5"],
+                    applied_at={"0.8.5": "2026-07-28T00:00:00Z"},
+                ),
+            )
+            gateway = os.path.join(
+                local_appdata,
+                "Programs",
+                "DefenseClaw",
+                "bin",
+                "defenseclaw-gateway.exe",
+            )
+            Path(gateway).write_bytes(b"native gateway fixture")
+            legacy = os.path.join(profile, ".local", "bin", "defenseclaw-gateway.exe")
+            with (
+                patch.dict(os.environ, {"HOME": profile, "USERPROFILE": profile}),
+                patch(
+                    "defenseclaw.commands.cmd_upgrade._windows_known_folder",
+                    side_effect=[local_appdata, profile],
+                ),
+            ):
+                state = _native_windows_install_state("windows", expected_version="0.8.7")
+                with patch(
+                    "defenseclaw.commands.cmd_upgrade.subprocess.run",
+                    return_value=Mock(
+                        returncode=0,
+                        stdout=json.dumps(
+                            {
+                                "schema_version": 1,
+                                "name": "defenseclaw-gateway",
+                                "version": "0.8.7",
+                                "commit": "a" * 40,
+                                "built": "2026-07-28T00:00:00Z",
+                            }
+                        ),
+                        stderr="",
+                    ),
+                ) as run:
+                    _preflight_installed_source_coherence(
+                        "0.8.7",
+                        "windows",
+                        data_dir,
+                        config_path=config_path,
+                        native_windows_state=state,
+                    )
+
+            self.assertFalse(os.path.lexists(legacy))
+            self.assertEqual(run.call_args.args[0], [gateway, "--version-json"])
+
+    def test_native_gateway_coherence_rejects_unsafe_and_mismatched_sources_without_changes(self):
+        from defenseclaw import migration_state, windows_acl
+
+        cases = ("missing", "replaced", "version", "build", "non-regular", "unowned", "shadow")
+        for case in cases:
+            with self.subTest(case=case), TemporaryDirectory() as temp:
+                local_appdata, profile, _state = self._native_install_state_fixture(temp)
+                data_dir = os.path.join(profile, ".defenseclaw")
+                os.makedirs(data_dir)
+                config_path = os.path.join(data_dir, "config.yaml")
+                Path(config_path).write_text("config_version: 8\noperator: preserve\n", encoding="utf-8")
+                migration_state.save(
+                    data_dir,
+                    migration_state.MigrationState(
+                        package_version="0.8.7",
+                        applied=["0.8.5"],
+                        applied_at={"0.8.5": "2026-07-28T00:00:00Z"},
+                    ),
+                )
+                gateway = os.path.join(
+                    local_appdata,
+                    "Programs",
+                    "DefenseClaw",
+                    "bin",
+                    "defenseclaw-gateway.exe",
+                )
+                if case != "missing":
+                    if case == "non-regular":
+                        os.makedirs(gateway)
+                    else:
+                        Path(gateway).write_bytes(b"native gateway fixture")
+                if case == "shadow":
+                    shadow = os.path.join(profile, ".local", "bin", "defenseclaw-gateway.exe")
+                    os.makedirs(os.path.dirname(shadow))
+                    Path(shadow).write_bytes(b"shadow")
+                before = {
+                    config_path: Path(config_path).read_bytes(),
+                    os.path.join(data_dir, ".migration_state.json"): Path(
+                        os.path.join(data_dir, ".migration_state.json")
+                    ).read_bytes(),
+                }
+                identity = {
+                    "schema_version": 1,
+                    "name": "defenseclaw-gateway",
+                    "version": "0.8.7",
+                    "commit": "a" * 40,
+                }
+                if case == "replaced":
+                    identity["name"] = "unmanaged-gateway"
+                elif case == "version":
+                    identity["version"] = "0.8.6"
+                elif case == "build":
+                    identity["commit"] = "b" * 40
+                with (
+                    patch.dict(os.environ, {"HOME": profile, "USERPROFILE": profile}),
+                    patch(
+                        "defenseclaw.commands.cmd_upgrade._windows_known_folder",
+                        side_effect=[local_appdata, profile],
+                    ),
+                ):
+                    state = _native_windows_install_state("windows", expected_version="0.8.7")
+                    ownership = (
+                        patch(
+                            "defenseclaw.windows_acl.assert_trusted_owner",
+                            side_effect=windows_acl.WindowsAclError("foreign owner"),
+                        )
+                        if case == "unowned"
+                        else nullcontext()
+                    )
+                    with (
+                        ownership,
+                        patch(
+                            "defenseclaw.commands.cmd_upgrade.subprocess.run",
+                            return_value=Mock(returncode=0, stdout=json.dumps(identity), stderr=""),
+                        ),
+                        self.assertRaises(SystemExit) as ctx,
+                    ):
+                        _preflight_installed_source_coherence(
+                            "0.8.7",
+                            "windows",
+                            data_dir,
+                            config_path=config_path,
+                            native_windows_state=state,
+                        )
+                self.assertEqual(ctx.exception.code, 1)
+                for path, payload in before.items():
+                    self.assertEqual(Path(path).read_bytes(), payload)
+
+    def test_upgrade_resolves_native_state_before_installed_source_coherence(self):
+        runner = CliRunner()
+        app = AppContext()
+        app.cfg = Config()
+        state = {"gateway_path": r"C:\trusted\defenseclaw-gateway.exe"}
+        order: list[str] = []
+
+        def resolve(_os_name, *, expected_version=None):
+            order.append(f"state:{expected_version}")
+            return state
+
+        def coherence(*_args, **kwargs):
+            order.append("coherence")
+            self.assertIs(kwargs["native_windows_state"], state)
+            raise SystemExit(1)
+
+        with (
+            patch("defenseclaw.__version__", "0.8.7"),
+            patch(
+                "defenseclaw.commands.cmd_upgrade._detect_platform",
+                return_value=("windows", "amd64"),
+            ),
+            patch(
+                "defenseclaw.commands.cmd_upgrade._native_windows_install_state",
+                side_effect=resolve,
+            ),
+            patch(
+                "defenseclaw.commands.cmd_upgrade._preflight_installed_source_coherence",
+                side_effect=coherence,
+            ),
+        ):
+            result = runner.invoke(
+                upgrade,
+                ["--yes", "--version", "0.8.8"],
+                obj=app,
+            )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertEqual(order, ["state:0.8.7", "coherence"])
 
     def _download_windows_setup_fixture(
         self,
@@ -7793,16 +8029,27 @@ class TestUpgradeManifest(unittest.TestCase):
         with TemporaryDirectory() as temp:
             source = os.path.join(temp, "download", "DefenseClawSetup-x64.exe")
             cache = os.path.join(temp, "cache", "DefenseClawSetup-x64.exe")
+            data_root = os.path.join(temp, "data")
             os.makedirs(os.path.dirname(source))
+            os.makedirs(data_root)
             with open(source, "wb") as stream:
                 stream.write(b"verified setup")
+            preserved = {
+                os.path.join(data_root, "config.yaml"): b"config_version: 8\noperator: preserve\n",
+                os.path.join(data_root, ".migration_state.json"): b'{"applied":["0.8.5"]}\n',
+                os.path.join(data_root, "connector-state.json"): b'{"connector":"claudecode"}\n',
+            }
+            for path, payload in preserved.items():
+                Path(path).write_bytes(payload)
             state = {
+                "version": "0.8.7",
                 "connector": "claudecode",
                 "mode": "action",
+                "data_root": data_root,
                 "maintenance_path": cache,
             }
             with patch("defenseclaw.commands.cmd_upgrade.subprocess.Popen") as popen_mock:
-                with runner.isolation():
+                with runner.isolation() as (out, _err, _):
                     _handoff_windows_setup_upgrade(
                         source,
                         "DefenseClawSetup-x64.exe",
@@ -7811,6 +8058,9 @@ class TestUpgradeManifest(unittest.TestCase):
                         manifest,
                         yes=True,
                     )
+                    output = out.getvalue().decode()
+            for path, payload in preserved.items():
+                self.assertEqual(Path(path).read_bytes(), payload)
 
         args = popen_mock.call_args.args[0]
         self.assertEqual(args[0], cache)
@@ -7820,7 +8070,9 @@ class TestUpgradeManifest(unittest.TestCase):
         self.assertIn("INSTALLSCOPE=user", args)
         self.assertIn("CONNECTOR=claudecode", args)
         self.assertIn("MODE=action", args)
+        self.assertIn("FROMVERSION=0.8.7", args)
         self.assertTrue(any(arg.startswith("WAITPID=") for arg in args))
+        self.assertIn("DefenseClaw 9.9.9", output)
 
     def test_machine_install_self_update_is_rejected(self):
         with self.assertRaises(SystemExit) as ctx:

--- a/cmd/defenseclaw-setup/main.go
+++ b/cmd/defenseclaw-setup/main.go
@@ -1580,20 +1580,35 @@ func validateMachineVersion(output []byte, expectedName, expectedVersion, expect
 }
 
 func runInitialConfigurationWithEnv(root, dataRoot string, opts options, env []string) error {
-	if opts.Connector == "none" {
-		return nil
+	args := initialConfigurationArgs(opts)
+	output, err := runCapturedSetupCommand(
+		setupConfigurationTimeout,
+		env,
+		filepath.Join(root, "bin", "defenseclaw.exe"),
+		args...,
+	)
+	if err != nil {
+		return fmt.Errorf("connector configuration failed: %w: %s", err, strings.TrimSpace(string(output)))
 	}
-	args := []string{
+	return nil
+}
+
+func initialConfigurationArgs(opts options) []string {
+	return []string{
 		"init", "--skip-install", "--non-interactive", "--yes",
 		"--connector", opts.Connector,
 		"--profile", opts.Mode,
 		"--no-start-gateway", "--no-verify",
 	}
-	output, err := runCapturedSetupCommand(setupConfigurationTimeout, env, filepath.Join(root, "bin", "defenseclaw.exe"), args...)
-	if err != nil {
-		return fmt.Errorf("connector configuration failed: %w: %s", err, strings.TrimSpace(string(output)))
-	}
-	return nil
+}
+
+func runCanonicalInitializationWithEnv(root, dataRoot string, env []string) error {
+	return runInitialConfigurationWithEnv(
+		root,
+		dataRoot,
+		options{Connector: "none", Mode: "observe", Quiet: true},
+		env,
+	)
 }
 
 const packagedMigrationScript = `import inspect, json, sys
@@ -1640,6 +1655,33 @@ if missing:
     raise SystemExit("required migrations are missing: " + ", ".join(missing))
 print(count)`
 
+const packagedCanonicalStateValidationScript = `import json, sys
+from defenseclaw import migration_state
+from defenseclaw.config import load, require_v8_config
+data_root, target_version, manifest_path = sys.argv[1:]
+with open(manifest_path, encoding="utf-8") as stream:
+    manifest = json.load(stream)
+if manifest.get("release_version") != target_version:
+    raise SystemExit("upgrade manifest version mismatch")
+require_v8_config()
+load()
+state = migration_state.load(data_root)
+if state is None:
+    raise SystemExit("migration cursor is missing")
+if state.package_version != target_version:
+    raise SystemExit(
+        "migration cursor package version mismatch: "
+        + str(state.package_version)
+        + " != "
+        + target_version
+    )
+required = tuple(manifest.get("required_cli_migrations", ()))
+applied = set(state.applied)
+missing = [value for value in required if value not in applied]
+if missing:
+    raise SystemExit("required migrations are missing: " + ", ".join(missing))
+print("ok")`
+
 const packagedMigrationPreflightScript = `import json, sys
 from defenseclaw.migrations import preflight_required_migrations
 from_version, to_version, openclaw_home, data_root, manifest_path, scratch_dir = sys.argv[1:]
@@ -1679,6 +1721,48 @@ func runPackagedMigrationsWithEnv(root, dataRoot, fromVersion, toVersion string,
 		return fmt.Errorf("run packaged migrations: %w: %s", err, strings.TrimSpace(string(output)))
 	}
 	return nil
+}
+
+func validateCanonicalReleaseStateWithEnv(root, dataRoot, targetVersion string, env []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), setupMigrationTimeout)
+	defer cancel()
+	cmd := newCanonicalStateValidationCommand(ctx, root, dataRoot, targetVersion)
+	cmd.Env = packagedTargetRuntimeEnv(env, root, dataRoot)
+	output, err := processutil.CombinedOutputTree(cmd, false)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return fmt.Errorf(
+			"validate canonical release state timed out after %s: %w: %s",
+			setupMigrationTimeout,
+			ctxErr,
+			strings.TrimSpace(string(output)),
+		)
+	}
+	if err != nil {
+		return fmt.Errorf("validate canonical release state: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func newCanonicalStateValidationCommand(
+	ctx context.Context,
+	root, dataRoot, targetVersion string,
+) *exec.Cmd {
+	python := filepath.Join(root, "runtime", "python", "python.exe")
+	manifest := filepath.Join(root, "installer", "upgrade-manifest.json")
+	cmd := newCapturedSetupCommand(
+		ctx,
+		python,
+		"-I",
+		"-X",
+		"utf8",
+		"-c",
+		packagedCanonicalStateValidationScript,
+		dataRoot,
+		targetVersion,
+		manifest,
+	)
+	cmd.Dir = root
+	return cmd
 }
 
 func runPackagedMigrationPreflightWithEnv(

--- a/cmd/defenseclaw-setup/main_test.go
+++ b/cmd/defenseclaw-setup/main_test.go
@@ -235,6 +235,168 @@ func TestConfiguredConnectorRequiresPersistentGateway(t *testing.T) {
 	}
 }
 
+func TestCanonicalInitializationUsesExplicitNoConnectorAuthority(t *testing.T) {
+	args := initialConfigurationArgs(options{Connector: "none", Mode: "observe"})
+	want := []string{
+		"init", "--skip-install", "--non-interactive", "--yes",
+		"--connector", "none",
+		"--profile", "observe",
+		"--no-start-gateway", "--no-verify",
+	}
+	if !slices.Equal(args, want) {
+		t.Fatalf("canonical initialization args = %v, want %v", args, want)
+	}
+}
+
+func TestCanonicalStateValidationUsesPackagedRuntimeAndManifest(t *testing.T) {
+	root := t.TempDir()
+	dataRoot := filepath.Join(root, "profile", ".defenseclaw")
+	cmd := newCanonicalStateValidationCommand(context.Background(), root, dataRoot, "0.8.9")
+	want := []string{
+		filepath.Join(root, "runtime", "python", "python.exe"),
+		"-I",
+		"-X",
+		"utf8",
+		"-c",
+		packagedCanonicalStateValidationScript,
+		dataRoot,
+		"0.8.9",
+		filepath.Join(root, "installer", "upgrade-manifest.json"),
+	}
+	if !slices.Equal(cmd.Args, want) {
+		t.Fatalf("canonical validation args = %v, want %v", cmd.Args, want)
+	}
+	if cmd.Dir != root {
+		t.Fatalf("canonical validation directory = %q, want %q", cmd.Dir, root)
+	}
+}
+
+func TestPackagedCanonicalStateValidationFailsClosed(t *testing.T) {
+	tests := []struct {
+		name           string
+		stateSource    string
+		required       []string
+		wantErr        bool
+		wantDiagnostic string
+	}{
+		{
+			name: "valid",
+			stateSource: `class State:
+    applied = ("0.8.5",)
+    package_version = "0.8.9"
+
+def load(data_root):
+    return State()
+`,
+			required: []string{"0.8.5"},
+		},
+		{
+			name: "missing-cursor",
+			stateSource: `def load(data_root):
+    return None
+`,
+			wantErr:        true,
+			wantDiagnostic: "migration cursor is missing",
+		},
+		{
+			name: "missing-required-migration",
+			stateSource: `class State:
+    applied = ()
+    package_version = "0.8.9"
+
+def load(data_root):
+    return State()
+`,
+			required:       []string{"0.8.5"},
+			wantErr:        true,
+			wantDiagnostic: "required migrations are missing: 0.8.5",
+		},
+		{
+			name: "wrong-package-version",
+			stateSource: `class State:
+    applied = ("0.8.5",)
+    package_version = "0.8.8"
+
+def load(data_root):
+    return State()
+`,
+			required:       []string{"0.8.5"},
+			wantErr:        true,
+			wantDiagnostic: "migration cursor package version mismatch: 0.8.8 != 0.8.9",
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			output, err := runPackagedCanonicalStateValidationFixture(
+				t,
+				test.stateSource,
+				test.required,
+			)
+			if test.wantErr != (err != nil) {
+				t.Fatalf("validation error = %v, output = %s", err, strings.TrimSpace(string(output)))
+			}
+			if test.wantDiagnostic != "" && !strings.Contains(string(output), test.wantDiagnostic) {
+				t.Fatalf("validation output = %q, want %q", strings.TrimSpace(string(output)), test.wantDiagnostic)
+			}
+		})
+	}
+}
+
+func runPackagedCanonicalStateValidationFixture(
+	t *testing.T,
+	migrationStateSource string,
+	required []string,
+) ([]byte, error) {
+	t.Helper()
+	python, err := exec.LookPath("python")
+	if err != nil {
+		t.Skipf("python is unavailable: %v", err)
+	}
+	root := t.TempDir()
+	packageRoot := filepath.Join(root, "defenseclaw")
+	if err := os.MkdirAll(packageRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		"__init__.py":        "",
+		"config.py":          "def require_v8_config():\n    return None\n\ndef load():\n    return object()\n",
+		"migration_state.py": migrationStateSource,
+	} {
+		if err := os.WriteFile(filepath.Join(packageRoot, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	manifest, err := json.Marshal(map[string]interface{}{
+		"release_version":         "0.8.9",
+		"required_cli_migrations": required,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(root, "upgrade-manifest.json")
+	if err := os.WriteFile(manifestPath, manifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dataRoot := filepath.Join(root, "data")
+	if err := os.Mkdir(dataRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(
+		python,
+		"-X",
+		"utf8",
+		"-c",
+		packagedCanonicalStateValidationScript,
+		dataRoot,
+		"0.8.9",
+		manifestPath,
+	)
+	cmd.Dir = root
+	cmd.Env = sanitizePythonEnv(os.Environ())
+	return cmd.CombinedOutput()
+}
+
 func TestOrdinaryInstallOfNewerPackageRunsMigrations(t *testing.T) {
 	state := &installState{Version: "0.8.3"}
 	if got := migrationSource(state, "0.8.4", ""); got != "0.8.3" {

--- a/cmd/defenseclaw-setup/main_test.go
+++ b/cmd/defenseclaw-setup/main_test.go
@@ -349,9 +349,15 @@ func runPackagedCanonicalStateValidationFixture(
 	required []string,
 ) ([]byte, error) {
 	t.Helper()
-	python, err := exec.LookPath("python")
-	if err != nil {
-		t.Skipf("python is unavailable: %v", err)
+	var python string
+	for _, name := range []string{"python", "python3"} {
+		if path, err := exec.LookPath(name); err == nil {
+			python = path
+			break
+		}
+	}
+	if python == "" {
+		t.Skip("python is unavailable")
 	}
 	root := t.TempDir()
 	packageRoot := filepath.Join(root, "defenseclaw")
@@ -382,12 +388,16 @@ func runPackagedCanonicalStateValidationFixture(
 	if err := os.Mkdir(dataRoot, 0o700); err != nil {
 		t.Fatal(err)
 	}
+	fixtureScript := "import sys\nsys.path.insert(0, sys.argv.pop(1))\n" +
+		packagedCanonicalStateValidationScript
 	cmd := exec.Command(
 		python,
+		"-I",
 		"-X",
 		"utf8",
 		"-c",
-		packagedCanonicalStateValidationScript,
+		fixtureScript,
+		root,
 		dataRoot,
 		"0.8.9",
 		manifestPath,

--- a/cmd/defenseclaw-setup/transaction.go
+++ b/cmd/defenseclaw-setup/transaction.go
@@ -2221,6 +2221,14 @@ func convergeCommittedSetupTransaction(transaction setupTransaction) error {
 	childEnv := transactionChildEnv(transaction)
 	previousChildEnv := transactionPreviousChildEnv(transaction)
 	gatewayPath := filepath.Join(transaction.InstallRoot, "bin", "defenseclaw-gateway.exe")
+	if err := initializeCanonicalReleaseState(
+		transaction,
+		childEnv,
+		runCanonicalInitializationWithEnv,
+		validateCanonicalReleaseStateWithEnv,
+	); err != nil {
+		return err
+	}
 	// Publish the signed no-console launcher outside both InstallRoot and
 	// DataRoot before connector configuration writes absolute commands. The
 	// publishing/active handshake makes this step idempotent under committed
@@ -2363,6 +2371,26 @@ func convergeCommittedSetupTransaction(transaction setupTransaction) error {
 		transaction.TargetServices,
 		nativeInstallRuntimeConvergenceOps(),
 	)
+}
+
+func initializeCanonicalReleaseState(
+	transaction setupTransaction,
+	env []string,
+	initialize func(string, string, []string) error,
+	validate func(string, string, string, []string) error,
+) error {
+	if err := initialize(transaction.InstallRoot, transaction.DataRoot, env); err != nil {
+		return fmt.Errorf("initialize canonical release state: %w", err)
+	}
+	if err := validate(
+		transaction.InstallRoot,
+		transaction.DataRoot,
+		transaction.TargetVersion,
+		env,
+	); err != nil {
+		return fmt.Errorf("validate canonical release state before runtime activation: %w", err)
+	}
+	return nil
 }
 
 func uninstallPathOwnership(transaction setupTransaction) (owned, reusedSeparator, valueCreated bool) {

--- a/cmd/defenseclaw-setup/transaction_test.go
+++ b/cmd/defenseclaw-setup/transaction_test.go
@@ -1875,7 +1875,7 @@ func TestConvergeInstallRuntimeActivatesOnlyAfterReconciliation(t *testing.T) {
 	}
 }
 
-func TestCanonicalReleaseStatePrecedesConnectorAndRuntimeConvergence(t *testing.T) {
+func TestCanonicalReleaseStateInitializesBeforeValidation(t *testing.T) {
 	t.Parallel()
 	transaction := setupTransaction{
 		InstallRoot:   "install",
@@ -1907,9 +1907,8 @@ func TestCanonicalReleaseStatePrecedesConnectorAndRuntimeConvergence(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	calls = append(calls, "optional-connector", "gateway-start", "authenticated-readiness")
-	if got := strings.Join(calls, ","); got != "canonical-base+migration-cursor,validate-config+cursor,optional-connector,gateway-start,authenticated-readiness" {
-		t.Fatalf("fresh install ordering = %q", got)
+	if got := strings.Join(calls, ","); got != "canonical-base+migration-cursor,validate-config+cursor" {
+		t.Fatalf("canonical state ordering = %q", got)
 	}
 }
 

--- a/cmd/defenseclaw-setup/transaction_test.go
+++ b/cmd/defenseclaw-setup/transaction_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -1871,6 +1872,134 @@ func TestConvergeInstallRuntimeActivatesOnlyAfterReconciliation(t *testing.T) {
 	}
 	if got := strings.Join(calls, ","); got != "autostart,start,verify" {
 		t.Fatalf("runtime convergence calls = %q", got)
+	}
+}
+
+func TestCanonicalReleaseStatePrecedesConnectorAndRuntimeConvergence(t *testing.T) {
+	t.Parallel()
+	transaction := setupTransaction{
+		InstallRoot:   "install",
+		DataRoot:      "data",
+		TargetVersion: "0.8.9",
+	}
+	var calls []string
+	err := initializeCanonicalReleaseState(
+		transaction,
+		[]string{"MANAGED=1"},
+		func(root, dataRoot string, env []string) error {
+			if root != transaction.InstallRoot || dataRoot != transaction.DataRoot ||
+				!slices.Equal(env, []string{"MANAGED=1"}) {
+				t.Fatalf("initialize arguments = %q, %q, %v", root, dataRoot, env)
+			}
+			calls = append(calls, "canonical-base+migration-cursor")
+			return nil
+		},
+		func(root, dataRoot, targetVersion string, env []string) error {
+			if root != transaction.InstallRoot || dataRoot != transaction.DataRoot ||
+				targetVersion != transaction.TargetVersion ||
+				!slices.Equal(env, []string{"MANAGED=1"}) {
+				t.Fatalf("validate arguments = %q, %q, %q, %v", root, dataRoot, targetVersion, env)
+			}
+			calls = append(calls, "validate-config+cursor")
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls = append(calls, "optional-connector", "gateway-start", "authenticated-readiness")
+	if got := strings.Join(calls, ","); got != "canonical-base+migration-cursor,validate-config+cursor,optional-connector,gateway-start,authenticated-readiness" {
+		t.Fatalf("fresh install ordering = %q", got)
+	}
+}
+
+func TestCommittedRecoveryRetriesCanonicalReleaseStateIdempotently(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name               string
+		failInitialization bool
+	}{
+		{name: "before-initialization", failInitialization: true},
+		{name: "after-initialization"},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			phase := setupPhaseCommitted
+			transaction := setupTransaction{
+				Action:          "install",
+				InstallRoot:     "install",
+				DataRoot:        "data",
+				TargetVersion:   "0.8.9",
+				TargetConnector: "none",
+				TargetServices:  serviceState{Gateway: true},
+			}
+			journal := setupJournal{
+				SchemaVersion: setupJournalSchemaVersion,
+				Phase:         setupPhaseCommitted,
+				Transaction:   transaction,
+			}
+			injectedErr := errors.New("injected canonical-state failure")
+			initializeCalls := 0
+			validateCalls := 0
+			converge := func(setupTransaction) error {
+				return initializeCanonicalReleaseState(
+					transaction,
+					nil,
+					func(string, string, []string) error {
+						initializeCalls++
+						if test.failInitialization && initializeCalls == 1 {
+							return injectedErr
+						}
+						return nil
+					},
+					func(string, string, string, []string) error {
+						validateCalls++
+						if !test.failInitialization && validateCalls == 1 {
+							return injectedErr
+						}
+						return nil
+					},
+				)
+			}
+			recoverOnce := func() error {
+				return recoverSetupJournalPhase(journal, setupRecoveryOps{
+					Converge: converge,
+					Cleanup:  func(setupTransaction) error { return nil },
+					Transition: func(_ setupTransaction, from, to string) error {
+						if phase != from {
+							return fmt.Errorf("transition from %s while phase is %s", from, phase)
+						}
+						phase = to
+						journal.Phase = to
+						return nil
+					},
+				})
+			}
+			if err := recoverOnce(); !errors.Is(err, injectedErr) {
+				t.Fatalf("first recovery error = %v, want injected failure", err)
+			}
+			if phase != setupPhaseCommitted {
+				t.Fatalf("failed recovery advanced journal to %q", phase)
+			}
+			if err := recoverOnce(); err != nil {
+				t.Fatalf("second recovery: %v", err)
+			}
+			if phase != setupPhaseComplete || initializeCalls != 2 {
+				t.Fatalf("recovery phase=%s initialize=%d validate=%d", phase, initializeCalls, validateCalls)
+			}
+			completedInitializeCalls, completedValidateCalls := initializeCalls, validateCalls
+			if err := recoverOnce(); err != nil {
+				t.Fatalf("completed recovery replay: %v", err)
+			}
+			if initializeCalls != completedInitializeCalls || validateCalls != completedValidateCalls {
+				t.Fatalf(
+					"completed rescue replayed initialization: initialize=%d validate=%d",
+					initializeCalls,
+					validateCalls,
+				)
+			}
+		})
 	}
 }
 

--- a/scripts/windows-native-ci.ps1
+++ b/scripts/windows-native-ci.ps1
@@ -3475,6 +3475,7 @@ function Invoke-SetupAcceptance {
         $installedState.version = '0.8.0'
         $installedState | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $statePath -Encoding UTF8
         $configPath = Join-Path $dataRoot 'config.yaml'
+        [IO.Directory]::CreateDirectory((Join-Path $dataRoot 'state')) | Out-Null
         $yamlDataRoot = $dataRoot.Replace("'", "''")
         $v7Fixture = @"
 # native Setup 0.8.0 observability migration acceptance fixture

--- a/scripts/windows-native-ci.ps1
+++ b/scripts/windows-native-ci.ps1
@@ -3089,8 +3089,11 @@ function Invoke-WizardConfigureLaterAcceptance(
     Invoke-WizardInstall $Setup $Root 'none' 'observe' $false `
         (Join-Path $Logs 'wizard-configure-later.json')
     Assert-SetupInstallState $InstallRoot 'none' 'observe'
-    if (Test-Path -LiteralPath (Join-Path $DataRoot 'config.yaml')) {
-        throw 'Configure later unexpectedly wrote a DefenseClaw connector configuration'
+    if (-not (Test-Path -LiteralPath (Join-Path $DataRoot 'config.yaml') -PathType Leaf)) {
+        throw 'Configure later did not create the canonical DefenseClaw configuration'
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $DataRoot '.migration_state.json') -PathType Leaf)) {
+        throw 'Configure later did not create the release-bound migration cursor'
     }
     $hookDir = Join-Path $DataRoot 'hooks'
     if (Test-Path -LiteralPath $hookDir) {


### PR DESCRIPTION
## Problem

Two Windows release-lifecycle paths could not converge on the release-owned state:

- Fresh native Setup with `CONNECTOR=none` skipped the packaged initialization authority, so Setup could publish a runtime without first creating and validating canonical config v8 plus the release-bound migration cursor. A committed transaction replay could repeat the same gap before hook publication or service startup.
- An older native Windows CLI checked the legacy `~/.local/bin` gateway before resolving installer custody, even though native Setup owns the gateway under the Local AppData Known Folder. That made a healthy native upgrade fail and left the coherence boundary tied to the wrong path.

## Fix

- Treat `connector=none` as an explicit canonical initialization mode: create fresh defaults and the migration cursor without configuring a connector; preserve valid existing connector choices; refuse unreadable existing config.
- Have native Setup invoke that packaged authority after the target tree and packaged migrations are active, then validate exact config v8, target package version, required migrations, and cursor presence before publishing the stable hook, configuring connectors, enabling startup, or starting services.
- Resolve and validate native installer state before installed-source coherence. Derive install, data, maintenance, and gateway paths only from Windows Known Folders; require supported marker identity and exact installed version; verify directory/file custody, gateway `--version-json` identity and source commit, and reject missing, replaced, non-regular, foreign-owned, or legacy-shadow gateways.
- Preserve the native source version in the Setup handoff so an authenticated older-release upgrade runs the correct migration boundary.

Scope is limited to fresh native Setup, committed install rescue, and healthy older native-release upgrade. It does not change quickstart, uninstall behavior, journal format/compatibility, v8 packaging, or the separate POSIX bridge cleanup in #628.

## Proof

- Focused Go Setup/transaction tests: 5 top-level tests passed, including 6 validation/recovery subtests.
- Focused Python bootstrap/init/upgrade tests: 59 passed, 7 expected platform skips, and 27 parameterized subtests passed.
- Covered fresh `connector=none`, existing connector preservation, unreadable config refusal, cursor absence/migration/package mismatch, committed replay/idempotency, pre-start ordering, positive Local AppData custody with no `~/.local/bin` gateway, the negative custody/identity/shadow matrix, and the non-Windows coherence contract.
- `go vet ./cmd/defenseclaw-setup`, Ruff lint, Python compileall, and `git diff --check` passed.
- Final CodeGuard review passed; no new credential, command-execution, deserialization, crypto, network, SQL, or path-traversal finding.

## Risk and manual acceptance

Primary residual risk is native Windows integration behavior that mocks cannot fully reproduce: real Known Folder resolution, Windows ACL descriptors, process replacement, Setup recovery, and service restart/readiness. Keep the PR draft until one Windows x64 standard-user VM runs this sequence serially against signed release artifacts:

1. Fresh install the candidate with `DefenseClawSetup-x64.exe /quiet /norestart INSTALLSCOPE=user CONNECTOR=none MODE=observe STARTGATEWAY=0`; verify config v8 and a cursor whose `package_version` equals the candidate, with no connector mutation or early gateway/startup activation.
2. From that same machine, create the controlled committed-but-incomplete Setup recovery fixture used by `scripts/windows-native-ci.ps1`, rerun the candidate Setup, then rerun it once more; verify the journal converges to complete, config/cursor bytes remain stable after recovery, and only the intended owned runtime is restored.
3. On a clean VM with a healthy signed older native release, preserve its config/cursor/connector roster, run `defenseclaw upgrade --yes` to the candidate, and verify the gateway used for coherence is `%LOCALAPPDATA%\Programs\DefenseClaw\bin\defenseclaw-gateway.exe`, `~\.local\bin` is absent, Setup receives the exact older `FROMVERSION`, migrations complete, and authenticated readiness passes.
4. Run `DefenseClawSetup-x64.exe /repair /quiet /norestart INSTALLSCOPE=user`; verify config, cursor, connector roster, and user data are preserved, the owned gateway/watchdog restart when previously running, and Doctor/readiness remains healthy.