### PR TITLE
Fix legacy upgrade tool handoff

### DIFF
--- a/.github/workflows/release-candidate-smoke.yml
+++ b/.github/workflows/release-candidate-smoke.yml
@@ -166,8 +166,14 @@ jobs:
             *) echo "invalid release validation lane: $lane_role" >&2; exit 1 ;;
           esac
           export UPGRADE_SMOKE_FIELD_RECOVERY_CASES
+          smoke_baselines="$BASELINE"
+          if [[ "$BASELINE" == "0.8.5" ]]; then
+            # Keep the selected seven-lane policy compact while proving the
+            # exact public source that exercises the longest supported bridge.
+            smoke_baselines="${BASELINE},0.8.1"
+          fi
           bash scripts/test-upgrade-protocol-release.sh \
-            --from-version "$BASELINE" \
+            --from-versions "$smoke_baselines" \
             --target-version "$RELEASE_TAG" \
             --release-dir "$GITHUB_WORKSPACE/release-candidate/dist" \
             --baseline-mode seed \

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -879,7 +879,10 @@ def test_exact_posix_fresh_install_and_twelve_upgrade_cells_gate_publication() -
     assert "scripts/release_candidate.py verify" in upgrade
     assert "scripts/verify-sigstore-blob.py" in upgrade
     assert "bash scripts/test-upgrade-protocol-release.sh" in upgrade
-    assert '--from-version "$BASELINE"' in upgrade
+    assert '--from-versions "$smoke_baselines"' in upgrade
+    assert 'smoke_baselines="$BASELINE"' in upgrade
+    assert 'if [[ "$BASELINE" == "0.8.5" ]]' in upgrade
+    assert 'smoke_baselines="${BASELINE},0.8.1"' in upgrade
     assert "--success-path-only" in upgrade
     assert "--baseline-mode seed" in upgrade
     assert "baseline_dependencies=published" in upgrade

--- a/cli/tests/test_upgrade_gateway_start_readiness_handoff.py
+++ b/cli/tests/test_upgrade_gateway_start_readiness_handoff.py
@@ -31,12 +31,15 @@ def test_post_hard_cut_continuation_scopes_fresh_process_marker_to_frozen_contro
         "DEFENSECLAW_STAGED_TARGET_CONTROLLER_VERSION",
     ):
         assert continuation.index(f"unset {staged_name}") < continuation.index(marker)
-    assert continuation.index("cleanup_upgrade_staging") < continuation.index(marker)
+    assert "cleanup_upgrade_staging" not in continuation
+    assert continuation.index("retain_authenticated_upgrade_uv_staging") < continuation.index(marker)
     assert 'STAGING_DIR=""' in cleanup
     assert 'UV_BIN=""' in cleanup
     assert continuation.index(marker) < continuation.index(controller)
     assert (
-        f"env -u UV_CONSTRAINT -u UV_OVERRIDE -u UV_EXCLUDE_NEWER \\\n        {marker} \\\n        {controller}"
+        "env -u UV_CONSTRAINT -u UV_OVERRIDE -u UV_EXCLUDE_NEWER \\\n"
+        '        PATH="${UV_BIN%/*}:${INSTALL_DIR}:${PATH}" \\\n'
+        f"        {marker} \\\n        {controller}"
     ) in continuation
 
 

--- a/cli/tests/test_upgrade_release_smoke_contract.py
+++ b/cli/tests/test_upgrade_release_smoke_contract.py
@@ -1569,6 +1569,10 @@ def test_historical_release_matrix_does_not_repeat_source_contract_suite() -> No
     assert "bridge-dependency-drift" in posix
     assert "baseline_dependencies=target" in posix
     assert '--baseline-dependencies "$baseline_dependencies"' in posix
+    assert 'smoke_baselines="$BASELINE"' in posix
+    assert 'if [[ "$BASELINE" == "0.8.5" ]]' in posix
+    assert 'smoke_baselines="${BASELINE},0.8.1"' in posix
+    assert '--from-versions "$smoke_baselines"' in posix
 
 
 def test_release_validation_lanes_are_derived_from_authenticated_policy(
@@ -1887,7 +1891,8 @@ def test_field_recovery_lane_reproduces_exact_published_086_and_087_first_run() 
     assert "published {source_version} unexpectedly created a migration cursor" in protocol
     assert "Accepted exact public ${baseline} cursorless first-run state" in protocol
     assert "for source_version in 0.8.6 0.8.7" in protocol
-    assert 'resolver_path="${curl_shim}:/usr/bin:/bin:/usr/sbin:/sbin"' in recovery_function
+    assert 'resolver_path="${curl_shim}:${RESOLVER_SYSTEM_TOOL_PATH}"' in recovery_function
+    assert 'assert_resolver_path_has_no_uv "${resolver_path}"' in recovery_function
     assert 'PATH="${resolver_path}"' in recovery_function
     assert 'document["applied"] = [' not in protocol
     assert "Replayed every missing migration and repaired the cursor" not in protocol
@@ -1907,6 +1912,26 @@ def test_field_recovery_lane_reproduces_exact_published_086_and_087_first_run() 
     assert "preserved|recovered" in verification
     assert "corrupt audit recovery retained the discarded legacy fixture" in verification
     assert "corrupt_audit_recovery=fresh_mode_0600" in verification
+
+
+def test_candidate_resolver_paths_do_not_inherit_runner_uv() -> None:
+    protocol = PROTOCOL_SCRIPT.read_text(encoding="utf-8")
+    assert 'readonly RESOLVER_SYSTEM_TOOL_PATH="/usr/bin:/bin:/usr/sbin:/sbin"' in protocol
+    assert 'PATH="${resolver_path}" /bin/sh -c \'command -v uv\'' in protocol
+    assert 'PATH="${resolver_path}" command -v uv' not in protocol
+
+    for function_name, following_name in (
+        ("run_candidate_updater_refusal", "run_candidate_updater_staged_success"),
+        ("run_candidate_updater_staged_success", "run_candidate_updater_direct_success"),
+        ("run_candidate_updater_direct_success", "run_candidate_updater_field_recovery_success"),
+        ("run_candidate_updater_field_recovery_success", "run_protocol_case"),
+    ):
+        start = protocol.index(f"{function_name}() {{")
+        end = protocol.index(f"\n{following_name}() {{", start)
+        function = protocol[start:end]
+        assert 'resolver_path="${curl_shim}:${RESOLVER_SYSTEM_TOOL_PATH}"' in function
+        assert 'assert_resolver_path_has_no_uv "${resolver_path}"' in function
+        assert 'PATH="${resolver_path}"' in function
 
 
 @pytest.mark.skipif(os.name == "nt", reason="executes the POSIX field-recovery verifier")

--- a/cli/tests/test_upgrade_smoke_static.py
+++ b/cli/tests/test_upgrade_smoke_static.py
@@ -1494,6 +1494,18 @@ def test_bridge_controller_hard_cut_establishes_rollback_custody_before_mutation
 def test_posix_resolver_normalizes_every_bridge_through_one_authenticated_handoff() -> None:
     resolver = (ROOT / "scripts" / "upgrade.sh").read_text(encoding="utf-8")
 
+    guard_start = resolver.index("require_authenticated_upgrade_uv_handoff() {")
+    guard_end = resolver.index("\n}\n\nretain_authenticated_upgrade_uv_staging() {", guard_start)
+    guard = resolver[guard_start:guard_end]
+    assert '"${UV_BIN}" == "${STAGING_DIR}/upgrade-tools/uv"' in guard
+    assert '-f "${UV_BIN}"' in guard
+    assert '! -L "${UV_BIN}"' in guard
+    assert '"${UV_BIN%/*}" != *:*' in guard
+    assert '-f "${INSTALL_DIR}/defenseclaw-gateway"' in guard
+    assert '-x "${INSTALL_DIR}/defenseclaw-gateway"' in guard
+    assert '! -L "${INSTALL_DIR}/defenseclaw-gateway"' in guard
+    assert '"${INSTALL_DIR}" != *:*' in guard
+
     resolve_start = resolver.index("resolve_staged_upgrade() {")
     resolve_end = resolver.index("\n}\n\npreflight_bridge_rollback_capability() {", resolve_start)
     resolve = resolver[resolve_start:resolve_end]
@@ -1514,6 +1526,7 @@ def test_posix_resolver_normalizes_every_bridge_through_one_authenticated_handof
         "env -u UV_OVERRIDE \\\n"
         '        UV_CONSTRAINT="${HISTORICAL_BOOTSTRAP_CONSTRAINTS_FILE}" \\\n'
         '        UV_EXCLUDE_NEWER="${HISTORICAL_BOOTSTRAP_EXCLUDE_NEWER}" \\\n'
+        '        PATH="${UV_BIN%/*}:${INSTALL_DIR}:${PATH}" \\\n'
         f"        {target_command}"
     )
     assert resolver.count(scoped_target_command) == 1
@@ -1528,18 +1541,22 @@ def test_posix_resolver_normalizes_every_bridge_through_one_authenticated_handof
     continuation_start = resolver.index("continue_post_hard_cut_upgrade() {")
     continuation_end = resolver.index("\n}\n\nvalidate_tarball_members() {", continuation_start)
     continuation = resolver[continuation_start:continuation_end]
-    remove_staging = continuation.index("cleanup_upgrade_staging")
+    uv_guard = continuation.index("retain_authenticated_upgrade_uv_staging")
     final_upgrade = continuation.index(
         '"${DEFENSECLAW_VENV}/bin/defenseclaw" upgrade --yes --version "${final_version}"',
-        remove_staging,
+        uv_guard,
     )
     final_exit = continuation.index('exit "${final_status}"', final_upgrade)
-    assert remove_staging < final_upgrade < final_exit
-    assert continuation.index("unset DEFENSECLAW_STAGED_TARGET_CONTROLLER_VERSION") < remove_staging
+    assert uv_guard < final_upgrade < final_exit
+    assert continuation.index("unset DEFENSECLAW_STAGED_TARGET_CONTROLLER_VERSION") < uv_guard
+    assert "cleanup_upgrade_staging" not in continuation
     assert "release_upgrade_lock" not in continuation
     assert "trap - EXIT" not in continuation
     assert "HISTORICAL_BOOTSTRAP_CONSTRAINTS_FILE" not in continuation
     assert "env -u UV_CONSTRAINT -u UV_OVERRIDE -u UV_EXCLUDE_NEWER" in continuation
+    assert 'PATH="${UV_BIN%/*}:${INSTALL_DIR}:${PATH}"' in continuation
+    assert resolver.count("require_authenticated_upgrade_uv_handoff") == 4
+    assert resolver.count("retain_authenticated_upgrade_uv_staging") == 2
     assert "UV_CONSTRAINT=''" not in resolver
     assert "UV_OVERRIDE=''" not in resolver
     assert "UV_EXCLUDE_NEWER=''" not in resolver

--- a/docs/RELEASE_CHANNEL.md
+++ b/docs/RELEASE_CHANNEL.md
@@ -170,8 +170,11 @@ needs `uv`, it always downloads the platform archive for pinned `uv` `0.11.28`,
 verifies its reviewed SHA-256, and extracts only the explicit platform
 executable into private upgrade custody. It never discovers, copies,
 version-probes, or executes a `uv` from `PATH` or a local known location, and it
-never streams an upstream installer. The private extracted binary is cached
-only for that resolver process.
+never streams an upstream installer. The resolver places that authenticated
+binary and the already verified installed gateway directory first on `PATH`
+only for the immutable `0.8.5` controller children that still discover those
+tools by name. It retains only the private `uv` between the hard-cut and final
+child, then the existing resolver exit cleanup removes it.
 
 Interrupted phase-two recovery uses the same authenticated uv bootstrap before
 it can reinstall the retained bridge wheel. That recovery therefore requires

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -151,9 +151,14 @@ Confirm that the exact run shows:
 - every baseline selected by workflow request validation upgraded on both
   Linux and macOS, including the `0.8.4` bridge and `0.8.5` forward handoff
   for pre-`0.8.4` sources;
+- exact public `0.8.1` upgraded through the full `0.8.4` and `0.8.5` bridge
+  route on both Linux and macOS as a companion case in the selected `0.8.5`
+  lane;
 - exact published `0.8.6` and `0.8.7` install-plus-first-run field states with
   an absent migration cursor recovered through the candidate resolver on both
   Linux and macOS under the immutable rescue bootstrap’s clean tool path;
+- every candidate resolver success case ran without a runner-installed `uv`
+  on `PATH`, proving the authenticated private bootstrap and handoffs;
 - native Windows x64 fresh install through `install.ps1` and
   `DefenseClawSetup-x64.exe`;
 - exact CLI and gateway version plus healthy gateway checks;

--- a/docs/RELEASE_VALIDATION.md
+++ b/docs/RELEASE_VALIDATION.md
@@ -78,6 +78,11 @@ fixture, exact `0.8.5`, exact `0.8.4`, newest `0.7.x` (`0.7.2` today), newest
 family selectors are mandatory; baseline resolution fails instead of silently
 omitting an unavailable lane.
 
+The exact `0.8.5` lane also runs exact authenticated public `0.8.1` as a
+companion case through `0.8.4`, `0.8.5`, and the final target. This keeps the
+selected policy at seven lanes while continuously proving the longest
+supported bridge path that exposed the historical controller’s `uv` lookup.
+
 Field-recovery acceptance additionally installs and runs first setup through
 the authenticated published `0.8.6` and `0.8.7` controllers without
 manufacturing a cursor. The candidate resolver must recognize only those two
@@ -86,6 +91,11 @@ running with the immutable rescue bootstrap’s minimal
 `/usr/bin:/bin:/usr/sbin:/sbin` tool path. This keeps the seven-lane matrix
 compact while retaining the exact `0.8.7` regression after it stops being the
 latest-older lane.
+
+Every positive resolver case, not only field recovery, runs with only the test
+release-server `curl` shim plus that minimal system tool path. A runner- or
+developer-installed `uv` is explicitly absent, so release acceptance cannot
+mask a broken authenticated private-`uv` handoff.
 
 Platform signing credentials are optional as complete groups. For macOS, all
 five Developer ID and notary values produce signed, notarized artifacts with

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -148,6 +148,9 @@ One manual release dispatch builds and seals one candidate, then runs
 lanes above on Linux and macOS. This includes the exact `0.8.6`
 missing-cursor recovery fixture, not merely a normal `0.8.6` install. Five
 ordinary seeded sources resolve their published wheel dependency graph.
+The exact `0.8.5` lane additionally runs exact public `0.8.1` through the full
+bridge route. Every candidate resolver invocation excludes ambient `uv` from
+`PATH`, requiring the resolver's authenticated private tool handoff to work.
 The `0.8.4` boundary instead starts with deliberate dependency drift and must
 prove the authenticated rollback-safe bridge refresh before the `0.8.5`
 handoff. It also runs the public POSIX installer on Linux

--- a/scripts/test-historical-bootstrap-dependencies.sh
+++ b/scripts/test-historical-bootstrap-dependencies.sh
@@ -145,10 +145,15 @@ def function(name: str, following: str) -> str:
 post_cut = function("continue_post_hard_cut_upgrade", "validate_tarball_members")
 if not (
     "env -u UV_CONSTRAINT -u UV_OVERRIDE -u UV_EXCLUDE_NEWER \\\n"
+    '        PATH="${UV_BIN%/*}:${INSTALL_DIR}:${PATH}" \\\n'
     "        DEFENSECLAW_UPGRADE_FRESH_PROCESS=1 \\\n"
     '        "${DEFENSECLAW_VENV}/bin/defenseclaw" upgrade'
 ) in post_cut:
-    raise SystemExit("post-hard-cut final hop does not clear historical resolver constraints")
+    raise SystemExit("post-hard-cut final hop does not receive authenticated uv with clean constraints")
+if "cleanup_upgrade_staging" in post_cut:
+    raise SystemExit("post-hard-cut final hop drops authenticated uv staging before the frozen controller exits")
+if "retain_authenticated_upgrade_uv_staging" not in post_cut:
+    raise SystemExit("post-hard-cut final hop does not retain only authenticated uv custody")
 
 install_start = source.index("# ── Install from staging (fast, no network)")
 install_end = source.index("# ── Run migrations", install_start)
@@ -163,6 +168,7 @@ historical_handoff = (
     'env -u UV_OVERRIDE \\\n'
     '        UV_CONSTRAINT="${HISTORICAL_BOOTSTRAP_CONSTRAINTS_FILE}" \\\n'
     '        UV_EXCLUDE_NEWER="${HISTORICAL_BOOTSTRAP_EXCLUDE_NEWER}" \\\n'
+    '        PATH="${UV_BIN%/*}:${INSTALL_DIR}:${PATH}" \\\n'
     '        "${TARGET_CONTROLLER_CLI}" upgrade'
 )
 if source.count(historical_handoff) != 1:

--- a/scripts/test-upgrade-protocol-release.sh
+++ b/scripts/test-upgrade-protocol-release.sh
@@ -13,6 +13,7 @@ umask 077
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly FIRST_SCHEMA2_RELEASE="0.8.4"
 readonly OBSERVABILITY_V8_HARD_CUT_VERSION="0.8.5"
+readonly RESOLVER_SYSTEM_TOOL_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 REFUSAL_CONTRACT_ONLY=0
 
 # shellcheck source=scripts/test-upgrade-release.sh
@@ -131,6 +132,15 @@ manifest_array_contains() {
     local values
     values="$(manifest_array_values "${key}")" || return 1
     grep -Fxq "${expected}" <<<"${values}"
+}
+
+assert_resolver_path_has_no_uv() {
+    local resolver_path="$1"
+    # Use a fresh shell so a uv path cached while constructing the historical
+    # fixture cannot make the clean resolver PATH look polluted.
+    if PATH="${resolver_path}" /bin/sh -c 'command -v uv' >/dev/null 2>&1; then
+        die "release resolver test PATH unexpectedly exposes ambient uv"
+    fi
 }
 
 protocol_sha256_file() {
@@ -625,6 +635,8 @@ run_candidate_updater_refusal() {
     local before="${WORKDIR}/${baseline}-candidate-updater.before.json"
     local after="${WORKDIR}/${baseline}-candidate-updater.after.json"
     local log_file="${WORKDIR}/${baseline}-candidate-updater-refusal.log"
+    local resolver_path="${curl_shim}:${RESOLVER_SYSTEM_TOOL_PATH}"
+    assert_resolver_path_has_no_uv "${resolver_path}"
     snapshot_state "${before}"
 
     set +e
@@ -636,7 +648,7 @@ run_candidate_updater_refusal() {
     UPGRADE_GATE_REAL_GATEWAY="${REFUSAL_REAL_GATEWAY}" \
     UPGRADE_GATE_REAL_CURL="${real_curl}" \
     UPGRADE_GATE_RELEASE_URL="${RELEASE_URL}" \
-    PATH="${curl_shim}:${SMOKE_HOME}/.local/bin:${PATH}" \
+    PATH="${resolver_path}" \
         bash "${RELEASE_ROOT}/${TARGET_VERSION}/defenseclaw-upgrade.sh" \
         --yes --version "${TARGET_VERSION}" \
         >"${log_file}" 2>&1
@@ -672,6 +684,8 @@ run_candidate_updater_staged_success() {
     local real_curl
     local log_file="${SMOKE_HOME}/upgrade.log"
     real_curl="$(install_curl_rewrite_probe "${curl_shim}")"
+    local resolver_path="${curl_shim}:${RESOLVER_SYSTEM_TOOL_PATH}"
+    assert_resolver_path_has_no_uv "${resolver_path}"
 
     if ! HOME="${SMOKE_HOME}" \
         DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \
@@ -683,7 +697,7 @@ run_candidate_updater_staged_success() {
         UPGRADE_GATE_REAL_CURL="${real_curl}" \
         UPGRADE_GATE_RELEASE_URL="${RELEASE_URL}" \
         UPGRADE_GATE_TARGET_VERSION="${TARGET_VERSION}" \
-        PATH="${curl_shim}:${SMOKE_HOME}/.local/bin:${PATH}" \
+        PATH="${resolver_path}" \
             bash "${RELEASE_ROOT}/${TARGET_VERSION}/defenseclaw-upgrade.sh" \
             "${resolver_args[@]}" >"${log_file}" 2>&1; then
         tail_v8_upgrade_log_secret_safe "${log_file}"
@@ -723,6 +737,8 @@ run_candidate_updater_direct_success() {
     local real_curl
     local log_file="${SMOKE_HOME}/upgrade.log"
     real_curl="$(install_curl_rewrite_probe "${curl_shim}")"
+    local resolver_path="${curl_shim}:${RESOLVER_SYSTEM_TOOL_PATH}"
+    assert_resolver_path_has_no_uv "${resolver_path}"
 
     if ! HOME="${SMOKE_HOME}" \
         DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \
@@ -734,7 +750,7 @@ run_candidate_updater_direct_success() {
         UPGRADE_GATE_REAL_CURL="${real_curl}" \
         UPGRADE_GATE_RELEASE_URL="${RELEASE_URL}" \
         UPGRADE_GATE_TARGET_VERSION="${TARGET_VERSION}" \
-        PATH="${curl_shim}:${SMOKE_HOME}/.local/bin:${PATH}" \
+        PATH="${resolver_path}" \
             bash "${RELEASE_ROOT}/${TARGET_VERSION}/defenseclaw-upgrade.sh" \
             --yes >"${log_file}" 2>&1; then
         tail_v8_upgrade_log_secret_safe "${log_file}"
@@ -933,14 +949,11 @@ PY
     local real_curl
     local log_file="${SMOKE_HOME}/upgrade.log"
     real_curl="$(install_curl_rewrite_probe "${curl_shim}")"
-    resolver_path="${curl_shim}:${SMOKE_HOME}/.local/bin:${PATH}"
-    if [[ "${recovery_case}" == "published-missing-cursor" ]]; then
-        # The immutable 0.8.8 rescue bootstrap deliberately hands the target
-        # resolver this minimal PATH. Keep release acceptance on the exact
-        # field boundary so an ambient developer/runner uv cannot mask a
-        # broken explicit discovery or authenticated bootstrap path.
-        resolver_path="${curl_shim}:/usr/bin:/bin:/usr/sbin:/sbin"
-    fi
+    # The immutable rescue bootstrap deliberately hands the target resolver a
+    # minimal PATH. Keep every positive resolver proof on that exact boundary
+    # so an ambient developer/runner uv cannot mask a broken private bootstrap.
+    resolver_path="${curl_shim}:${RESOLVER_SYSTEM_TOOL_PATH}"
+    assert_resolver_path_has_no_uv "${resolver_path}"
 
     if ! HOME="${SMOKE_HOME}" \
         DEFENSECLAW_HOME="${SMOKE_HOME}/.defenseclaw" \

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -284,6 +284,43 @@ PY
     ok "Pinned uv ${UV_BOOTSTRAP_VERSION} authenticated in private upgrade custody"
 }
 
+require_authenticated_upgrade_uv_handoff() {
+    [[ -n "${UV_BIN:-}" \
+       && "${UV_BIN}" == "${STAGING_DIR}/upgrade-tools/uv" \
+       && -f "${UV_BIN}" \
+       && -x "${UV_BIN}" \
+       && ! -L "${UV_BIN}" \
+       && "${UV_BIN%/*}" != *:* \
+       && -f "${INSTALL_DIR}/defenseclaw-gateway" \
+       && -x "${INSTALL_DIR}/defenseclaw-gateway" \
+       && ! -L "${INSTALL_DIR}/defenseclaw-gateway" \
+       && "${INSTALL_DIR}" != *:* ]] \
+        || die "Authenticated private uv or installed gateway is unavailable for the historical controller handoff."
+}
+
+retain_authenticated_upgrade_uv_staging() {
+    require_authenticated_upgrade_uv_handoff
+    local previous_staging="${STAGING_DIR}"
+    local retained_staging=""
+    retained_staging="$(mktemp -d "${STAGING_DIR%/*}/defenseclaw-upgrade-uv.XXXXXX")" \
+        || die "Could not retain authenticated uv for the historical controller handoff."
+    if ! chmod 700 "${retained_staging}" \
+        || ! mkdir "${retained_staging}/upgrade-tools" \
+        || ! chmod 700 "${retained_staging}/upgrade-tools"; then
+        rm -rf -- "${retained_staging}"
+        die "Could not protect retained authenticated uv custody."
+    fi
+    if ! mv -- "${UV_BIN}" "${retained_staging}/upgrade-tools/uv"; then
+        rm -rf -- "${retained_staging}"
+        die "Could not retain authenticated uv for the historical controller handoff."
+    fi
+    STAGING_DIR="${retained_staging}"
+    UV_BIN="${STAGING_DIR}/upgrade-tools/uv"
+    rm -rf -- "${previous_staging}" \
+        || die "Could not retire completed hard-cut staging."
+    require_authenticated_upgrade_uv_handoff
+}
+
 # Keep one bounded, fail-closed parser for every phase-one gateway.pid
 # decision, including crash recovery. Published gateways write a JSON pidInfo
 # object; legacy integer files remain supported for older/manual installs.
@@ -8081,20 +8118,22 @@ continue_post_hard_cut_upgrade() {
     ok "${OBSERVABILITY_V8_HARD_CUT_VERSION} is healthy; continuing to ${final_version}"
 
     # The authenticated bootstrap controller is now installed outside the
-    # private target staging directory.  Drop the completed hard-cut handoff
-    # custody, but keep this resolver's cross-process lock until the ordinary
-    # post-cut child and any inherited mutators have exited.  The completed
-    # 0.8.4 hard-cut rollback is not re-armed for this later transaction.
+    # private target staging directory. Keep the authenticated private uv
+    # available to its frozen final-hop controller; the existing exit trap
+    # removes staging after that child and any inherited mutators have exited.
+    # The completed 0.8.4 hard-cut rollback is not re-armed for this later
+    # transaction.
     unset DEFENSECLAW_STAGED_UPGRADE
     unset DEFENSECLAW_STAGED_BRIDGE_VERSION
     unset DEFENSECLAW_STAGED_BRIDGE_ARTIFACT_DIR
     unset DEFENSECLAW_STAGED_TARGET_CONTROLLER_VERSION
-    cleanup_upgrade_staging
+    retain_authenticated_upgrade_uv_staging
     # The immutable 0.8.5 controller gives child commands 30 seconds but owns
     # a separate 60-second, version-aware gateway health poll. Current gateway
     # binaries consume this process-scoped handoff marker after safe launch so
     # that the controller, rather than both layers, owns the readiness wait.
     env -u UV_CONSTRAINT -u UV_OVERRIDE -u UV_EXCLUDE_NEWER \
+        PATH="${UV_BIN%/*}:${INSTALL_DIR}:${PATH}" \
         DEFENSECLAW_UPGRADE_FRESH_PROCESS=1 \
         "${DEFENSECLAW_VENV}/bin/defenseclaw" upgrade --yes --version "${final_version}" \
         || final_status=$?
@@ -9461,9 +9500,11 @@ if [[ -n "${STAGED_FINAL_VERSION}" ]]; then
     export DEFENSECLAW_CONFIG="${CONFIG_PATH}"
     export OPENCLAW_HOME="${OPENCLAW_HOME}"
     target_status=0
+    require_authenticated_upgrade_uv_handoff
     env -u UV_OVERRIDE \
         UV_CONSTRAINT="${HISTORICAL_BOOTSTRAP_CONSTRAINTS_FILE}" \
         UV_EXCLUDE_NEWER="${HISTORICAL_BOOTSTRAP_EXCLUDE_NEWER}" \
+        PATH="${UV_BIN%/*}:${INSTALL_DIR}:${PATH}" \
         "${TARGET_CONTROLLER_CLI}" upgrade --yes --version "${final_version}" \
         || target_status=$?
     if [[ "${target_status}" -eq 0 ]]; then


### PR DESCRIPTION
Base: `main` at `f11b47215eb9367420ec2c4c33ab86b91f163f08`. This is an unstacked updater/release-gate fix.

## Problem

The authenticated rescue resolver could not complete the longest supported
upgrade path when the machine did not already expose `uv` on `PATH`.

An exact public `0.8.1` install reached a healthy `0.8.4` bridge, but the fresh
immutable `0.8.5` controller still discovers `uv` and
`defenseclaw-gateway` by name. The current resolver had authenticated a private
pinned `uv`, but did not place it on the child controller's `PATH`; it also
removed that staging before the final child completed. Once `uv` was handed
through, the same clean-path proof exposed the frozen controller's gateway
lookup.

## Current Situation

- The resolver already downloads and authenticates pinned `uv 0.11.28` in
  private staging.
- The installed bridge gateway is already checksum- and version-verified.
- CI installs ambient `uv` to construct historical fixtures, then previously
  inherited that runner `PATH` while exercising the resolver. That masked the
  broken cross-process handoff.
- Exact public `0.8.1` was not one of the selected seven release lanes, so the
  longest supported `0.8.1 -> 0.8.4 -> 0.8.5 -> current` path was not exercised
  continuously.

## Solution

### Authenticated historical-controller handoff

The resolver now validates that:

- `uv` is the regular, executable, non-symlink file in its private
  `upgrade-tools` custody;
- the installed gateway is a regular, executable, non-symlink file; and
- neither directory can inject another `PATH` component.

It places the authenticated private-`uv` directory and verified installed
gateway directory first on `PATH` only for the immutable historical controller
children. Between the hard cut and final child, it moves only `uv` into a small
private retained directory, deletes the completed large staging tree, and lets
the existing resolver exit trap remove the retained tool.

```mermaid
flowchart LR
    A["Current signed resolver"] --> B["Authenticated private uv"]
    A --> C["Verified installed bridge gateway"]
    B --> D["Immutable 0.8.5 controller"]
    C --> D
    D --> E["Signed final release"]
    E --> F["Existing EXIT cleanup removes retained uv"]
```

### Release acceptance without another lane

The selected `0.8.5` Linux and macOS jobs also run exact authenticated public
`0.8.1` as a companion case. The policy remains seven lanes.

Every candidate resolver case now runs with only the release-server `curl` shim
and `/usr/bin:/bin:/usr/sbin:/sbin`. Setup `uv` remains available to construct
the historical fixture, but cannot satisfy the resolver or its child
controllers.

## What Changed (Where & How)

| Path | Change |
|---|---|
| `scripts/upgrade.sh` | Validate and retain authenticated `uv` custody; hand private `uv` and the verified installed gateway path to both frozen controller boundaries. |
| `scripts/test-upgrade-protocol-release.sh` | Run every resolver case without ambient `uv`; use a fresh shell for the absence check so Bash's command hash cannot create a false result. |
| `.github/workflows/release-candidate-smoke.yml` | Add exact public `0.8.1` to the existing `0.8.5` Linux/macOS lane instead of adding another job. |
| `scripts/test-historical-bootstrap-dependencies.sh` | Assert both immutable-controller handoffs retain the authenticated tool path and final-hop constraint behavior. |
| `cli/tests/` | Lock the workflow, clean-path, custody, cleanup, and child-environment contracts. |
| `docs/RELEASE_CHANNEL.md`, `docs/RELEASE_RUNBOOK.md`, `docs/RELEASE_VALIDATION.md`, `docs/TESTING.md` | Document the private-tool handoff and exact longest-path release gate. |

## Breaking Changes

None. Release dispatch, signing behavior, versioned assets, and the seven-lane
selection policy are unchanged.

## Open Issues / Follow-ups

None.

## Test Plan

### Automated

```bash
./.venv/bin/python -m pytest -q \
  cli/tests/test_upgrade_smoke_static.py \
  cli/tests/test_upgrade_gateway_start_readiness_handoff.py \
  cli/tests/test_upgrade_release_smoke_contract.py \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_release_runbook.py
```

Observed: `208 passed, 1 skipped`.

```bash
bash scripts/test-historical-bootstrap-dependencies.sh
```

Observed: authenticated immutable `0.8.4` and `0.8.5` dependency environments,
metadata consistency, launch handoff, and strict readiness handoff all passed.

```bash
/bin/bash -n \
  scripts/upgrade.sh \
  scripts/test-historical-bootstrap-dependencies.sh \
  scripts/test-upgrade-protocol-release.sh

shellcheck -x -S error \
  scripts/upgrade.sh \
  scripts/test-historical-bootstrap-dependencies.sh \
  scripts/test-upgrade-protocol-release.sh

./.venv/bin/ruff check \
  cli/tests/test_release_workflow_staged.py \
  cli/tests/test_upgrade_gateway_start_readiness_handoff.py \
  cli/tests/test_upgrade_release_smoke_contract.py \
  cli/tests/test_upgrade_smoke_static.py

git diff --check
```

Observed: all passed.

### Connected-host signed public upgrade proofs

On connected Linux amd64 and macOS arm64 hosts, an exact authenticated public
`0.8.1` fixture was stopped and the patched resolver was invoked with:

```bash
PATH=/usr/bin:/bin:/usr/sbin:/sbin \
  /bin/bash scripts/upgrade.sh --yes --version 0.8.9
```

Both hosts completed:

```text
0.8.1 -> 0.8.4 -> 0.8.5 -> 0.8.9
```

All bridge, hard-cut, and final artifacts came from the signed public releases.
On both hosts the canonical verifier confirmed:

- CLI, gateway, and plugin `0.8.9` in sync;
- complete migration cursor through `0.8.5`;
- historical and bridge backups byte-exact;
- v8 secret promotion and target-exact managed observability bundle;
- preserved operator-managed files and tightened audit database mode;
- admitted and acknowledged `0.8.5 -> 0.8.9` receipt;
- healthy gateway, installed-wheel TUI, and post-status SQLite write.

The isolated test homes and gateways were removed afterward. The pre-existing
macOS `0.8.4` test service was restored on its original port with unchanged
gateway, config, and environment hashes.
