### PR TITLE
fix(managed_enterprise): dynamic env_config reload, Claude Code detector, config-reload restart classification

### DIFF
--- a/cli/defenseclaw/config.py
+++ b/cli/defenseclaw/config.py
@@ -2147,6 +2147,7 @@ class AIDiscoveryConfig:
     confidence_policy_path: str = ""
     require_trusted_binary_paths: bool = False
     trusted_binary_prefixes: list[str] = field(default_factory=list)
+    home_dirs: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -4865,6 +4866,7 @@ def _merge_ai_discovery(raw: dict[str, Any] | None) -> AIDiscoveryConfig:
         confidence_policy_path=str(raw.get("confidence_policy_path", "") or ""),
         require_trusted_binary_paths=bool(raw.get("require_trusted_binary_paths", False)),
         trusted_binary_prefixes=[str(v) for v in (raw.get("trusted_binary_prefixes", []) or [])],
+        home_dirs=[str(v) for v in (raw.get("home_dirs", []) or [])],
     )
 
 

--- a/cli/defenseclaw/connector_paths.py
+++ b/cli/defenseclaw/connector_paths.py
@@ -93,6 +93,36 @@ import time) means a typo in ``guardrail.connector`` surfaces in
 producing wrong paths.
 """
 
+KNOWN_AGENT_KINDS: tuple[str, ...] = KNOWN_CONNECTORS + (
+    # Discovery-only agents. These have AI-signature entries in
+    # ai_signatures.json (mirrored between Go and Python copies) but no
+    # DefenseClaw enforcement path, so they do NOT appear in
+    # KNOWN_CONNECTORS (which is the enforcement-connector allow-list).
+    # They ARE first-class agents on the discovery/inventory side:
+    # ``defenseclaw agent discover`` reports them, and the wire
+    # payload's ``agent_kind`` gets populated for their signals via the
+    # promotion table in internal/inventory/ai_catalog.go.
+    #
+    # Keep this list in sync with ``promotedAgentKinds`` in the Go
+    # catalog — the connector slug values here (aider, continue, cline,
+    # claudedesktop) must match the values in that map for dashboards
+    # to join cleanly across the two sides.
+    "aider",
+    "continue",
+    "cline",
+    "claudedesktop",
+)
+"""All agent slugs the CLI's discovery / inventory paths know about.
+
+Superset of :data:`KNOWN_CONNECTORS`. Callers that need to iterate over
+"every agent DefenseClaw can *see*" (agent-discovery cache, inventory
+report renderers, TUI agent list) should use this constant. Callers
+that need "every connector DefenseClaw can *enforce through*"
+(manifest validation, MCP-writer dispatch, hook installers) should
+continue to use :data:`KNOWN_CONNECTORS`.
+"""
+
+
 HOOK_ONLY_CONNECTORS: frozenset[str] = frozenset(
     {
         "hermes",

--- a/cli/defenseclaw/inventory/_semver.py
+++ b/cli/defenseclaw/inventory/_semver.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Semantic-version parsing and comparison shared across the CLI.
+
+Lifted from scripts/connector-version-radar.py so agent_discovery.py can
+pick "highest supported version" among multiple installed copies of a
+connector (Claude Code / Codex / Cursor) without cross-importing a
+top-level script. Precomparison is strict semver 2.0 for the parts we
+care about: major.minor.patch plus dot-separated prerelease
+identifiers, ignoring build metadata.
+
+Only three public entry points intentionally: parse_version() to build a
+SemVersion from an arbitrary CLI / package.json string, SemVersion.compare()
+to totally order two of them, and pick_highest_supported() to select the
+best candidate from a list given a minimum inclusive bound.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from collections.abc import Iterable
+from functools import cmp_to_key
+
+# Matches the first "x.y.z(-prerelease)?(+build)?" substring in a
+# larger string so we tolerate outputs like "codex-cli 0.145.0" or
+# "1.9.0 (build 42)". Same regex as
+# scripts/connector-version-radar.py:_VERSION_RE — keep them aligned;
+# radar imports this module now so the definitions stay single-source.
+_VERSION_RE = re.compile(
+    r"(?<![0-9A-Za-z])v?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?"
+    r"(?:\+(?P<build>[0-9A-Za-z.-]+))?(?![0-9A-Za-z])"
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class SemVersion:
+    """A parsed semantic-version triple with optional prerelease chain."""
+
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[str, ...] = ()
+
+    @property
+    def stable(self) -> bool:
+        return not self.prerelease
+
+    @property
+    def normalized(self) -> str:
+        base = f"{self.major}.{self.minor}.{self.patch}"
+        if self.prerelease:
+            return f"{base}-{'.'.join(self.prerelease)}"
+        return base
+
+    def compare(self, other: SemVersion) -> int:
+        own_core = (self.major, self.minor, self.patch)
+        other_core = (other.major, other.minor, other.patch)
+        if own_core != other_core:
+            return 1 if own_core > other_core else -1
+        # Per semver 2.0 §11: a version with prerelease has lower
+        # precedence than one without.
+        if not self.prerelease and not other.prerelease:
+            return 0
+        if not self.prerelease:
+            return 1
+        if not other.prerelease:
+            return -1
+        # Compare prerelease identifiers pairwise. Numeric identifiers
+        # order numerically; alphanumeric order lexically; numeric <
+        # alphanumeric when they collide.
+        for own, theirs in zip(self.prerelease, other.prerelease, strict=False):
+            if own == theirs:
+                continue
+            own_numeric = own.isdigit()
+            theirs_numeric = theirs.isdigit()
+            if own_numeric and theirs_numeric:
+                return 1 if int(own) > int(theirs) else -1
+            if own_numeric != theirs_numeric:
+                return -1 if own_numeric else 1
+            return 1 if own > theirs else -1
+        if len(self.prerelease) == len(other.prerelease):
+            return 0
+        return 1 if len(self.prerelease) > len(other.prerelease) else -1
+
+
+def parse_version(value: str, *, require_stable: bool = False) -> SemVersion:
+    """Extract and normalize the first semantic version in ``value``.
+
+    Raises ValueError when no x.y.z substring is present or when
+    ``require_stable`` is set and the parsed value carries a prerelease
+    tail. Callers that just want "best-effort or None" should use
+    ``parse_version_or_none``.
+    """
+    match = _VERSION_RE.search(value.strip())
+    if not match:
+        raise ValueError("no semantic x.y.z version found")
+    prerelease = tuple(filter(None, (match.group("prerelease") or "").split(".")))
+    parsed = SemVersion(
+        major=int(match.group("major")),
+        minor=int(match.group("minor")),
+        patch=int(match.group("patch")),
+        prerelease=prerelease,
+    )
+    if require_stable and not parsed.stable:
+        raise ValueError(f"stable channel returned prerelease {parsed.normalized}")
+    return parsed
+
+
+def parse_version_or_none(value: str) -> SemVersion | None:
+    """Best-effort variant of ``parse_version`` — returns None on any parse error."""
+    try:
+        return parse_version(value)
+    except ValueError:
+        return None
+
+
+def pick_highest_supported(
+    candidates: Iterable[tuple[str, str]],
+    min_inclusive: str,
+) -> tuple[str, str] | None:
+    """Select the "best" (source, version) tuple from ``candidates``.
+
+    Selection policy (used by the hook installer's discovery pass):
+
+    1. Parse every candidate; drop entries whose version string is
+       not semver-shaped.
+    2. Prefer the highest version that is >= ``min_inclusive``.
+    3. If no candidate meets the minimum, fall back to the highest
+       version overall so the operator debugging the "why weren't
+       hooks installed" case sees an actual version in the discovery
+       cache (and the Go hook-contract gate reports "unsupported"
+       rather than "unversioned").
+
+    Returns ``None`` when ``candidates`` is empty or nothing parsed.
+    The returned tuple's ``source`` field is verbatim from the input
+    so callers can render it in ``agent_discovery.json`` /
+    ``defenseclaw agent discover --json``.
+    """
+    parsed: list[tuple[str, str, SemVersion]] = []
+    for source, raw in candidates:
+        version = parse_version_or_none(raw)
+        if version is None:
+            continue
+        parsed.append((source, raw, version))
+    if not parsed:
+        return None
+
+    minimum = parse_version_or_none(min_inclusive) if min_inclusive else None
+
+    supported = [entry for entry in parsed if minimum is None or entry[2].compare(minimum) >= 0]
+    pool = supported or parsed
+    # Stable sort so ties on version pick the first source (which is
+    # the order the collector visited candidate roots — usually
+    # native-installer > npm globals > NVM > editor extensions). We
+    # sort via cmp_to_key because SemVersion is a plain frozen
+    # dataclass and doesn't implement __lt__.
+    pool.sort(key=cmp_to_key(lambda a, b: a[2].compare(b[2])))
+    best = pool[-1]  # highest after ascending sort
+    for entry in reversed(pool):
+        if entry[2].compare(best[2]) == 0:
+            best = entry
+        else:
+            break
+    return best[0], best[1]

--- a/cli/defenseclaw/inventory/agent_discovery.py
+++ b/cli/defenseclaw/inventory/agent_discovery.py
@@ -246,9 +246,11 @@ _SPECS: dict[str, _AgentSpec] = {
         # than expecting a top-level binary. `binary_name=""` disables
         # the exec-based liveness probe for signals that are purely
         # extension-installed — the config-file probe is enough.
+        # Paths mirror the `cline` entry in ai_signatures.json so
+        # discovery does not false-positive on every editor user.
         (
-            "~/.vscode/extensions",
-            "~/.cursor/extensions",
+            "~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev",
+            "~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline",
         ),
         "",
         (),
@@ -290,9 +292,12 @@ def _read_pkg_version(path: str) -> str:
     """
     try:
         with open(path, encoding="utf-8") as f:
-            value = json.load(f).get("version", "")
+            payload = json.load(f)
     except (OSError, ValueError):
         return ""
+    if not isinstance(payload, dict):
+        return ""
+    value = payload.get("version", "")
     return value if isinstance(value, str) else ""
 
 

--- a/cli/defenseclaw/inventory/agent_discovery.py
+++ b/cli/defenseclaw/inventory/agent_discovery.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import glob
 import json
 import os
 import shutil
@@ -32,6 +33,8 @@ from typing import NamedTuple
 
 import yaml
 
+from defenseclaw.inventory._semver import pick_highest_supported
+
 # `grp` is POSIX-only. We import it lazily-but-at-module-load so the
 # group-ownership check below can run without an inline import,
 # while still keeping Windows hosts importable.
@@ -41,7 +44,12 @@ except ImportError:  # pragma: no cover - non-POSIX
     _grp = None  # type: ignore[assignment]
 
 from defenseclaw.config import config_path_for_data_dir, default_data_path
-from defenseclaw.connector_paths import KNOWN_CONNECTORS, _expand, omnigent_config_path
+from defenseclaw.connector_paths import (
+    KNOWN_AGENT_KINDS,
+    KNOWN_CONNECTORS,
+    _expand,
+    omnigent_config_path,
+)
 
 # Sentinel error returned by ``_version_for_binary`` when a connector
 # binary resolves outside the trusted install prefixes. Callers (e.g.
@@ -126,6 +134,15 @@ class AgentSignal:
     binary_path: str
     version: str
     error: str
+    # ``source`` records WHERE the reported ``version`` came from — the
+    # native-installer symlink, an NVM node_modules root, the ChatGPT.app
+    # bundle, etc. Populated only by the three item-level collectors
+    # (claudecode / codex / cursor) added for the multi-install
+    # discovery fix; other connectors leave it empty and legacy JSON
+    # caches without the field deserialize with the empty default. Kept
+    # optional so callers that ignore the field (older TUI renderers)
+    # keep working.
+    source: str = ""
 
 
 @dataclass
@@ -204,6 +221,290 @@ _SPECS: dict[str, _AgentSpec] = {
         "omnigent",
         ("--version",),
     ),
+    # Discovery-only agents (not in KNOWN_CONNECTORS). Config
+    # candidates mirror the corresponding entries in
+    # internal/inventory/ai_signatures.json so `agent discover` picks
+    # up the same install signals the sidecar does.
+    "aider": _AgentSpec(
+        ("~/.aider.conf.yml", "~/.aider", ".aider.conf.yml"),
+        "aider",
+        ("--version",),
+    ),
+    "continue": _AgentSpec(
+        (
+            "~/.continue/config.json",
+            "~/.continue/config.yaml",
+            "~/.continue",
+            ".continue/config.json",
+        ),
+        "continue",
+        ("--version",),
+    ),
+    "cline": _AgentSpec(
+        # Cline / Roo Code lives inside the VS Code / Cursor extension
+        # storage tree; probe the extension-installed marker rather
+        # than expecting a top-level binary. `binary_name=""` disables
+        # the exec-based liveness probe for signals that are purely
+        # extension-installed — the config-file probe is enough.
+        (
+            "~/.vscode/extensions",
+            "~/.cursor/extensions",
+        ),
+        "",
+        (),
+    ),
+    "claudedesktop": _AgentSpec(
+        (
+            "~/Library/Application Support/Claude/claude_desktop_config.json",
+            "~/.config/Claude/claude_desktop_config.json",
+            "~/AppData/Roaming/Claude/claude_desktop_config.json",
+        ),
+        "",
+        (),
+    ),
+}
+
+
+# Minimum-supported agent versions for the hook-contract gate. Values
+# mirror ``min_inclusive`` in
+# cli/defenseclaw/inventory/hook_contracts.json and the
+# ``MinAgentVersion`` constants in
+# internal/gateway/connector/hook_contract.go. When updating any of the
+# three copies, update all three — the test
+# ``test_min_versions_match_hook_contracts_json`` catches drift on CI.
+_MIN_SUPPORTED_VERSIONS: dict[str, str] = {
+    "claudecode": "2.1.144",
+    "codex": "0.124.0",
+    "cursor": "1.7.0",
+}
+
+
+def _read_pkg_version(path: str) -> str:
+    """Return the top-level ``.version`` string from a package.json.
+
+    Metadata-only: parses JSON, returns "" for any error (missing file,
+    unreadable file, malformed JSON, missing field, non-string value).
+    Never exec's the binary the package.json describes. Mirrors the
+    ``_read_json_version`` helper in packaging/macos/lib/installer_lib.sh
+    so the two discovery paths stay behavior-equivalent.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            value = json.load(f).get("version", "")
+    except (OSError, ValueError):
+        return ""
+    return value if isinstance(value, str) else ""
+
+
+def _collect_node_manager_pkg_versions(
+    home: str, npm_scope: str, pkg: str
+) -> list[tuple[str, str]]:
+    """Enumerate (source_path, version) tuples across Node version managers.
+
+    Node version managers (NVM, Volta, fnm, asdf) install npm globals
+    under a per-node-version root, so an operator running two Node
+    versions has two copies of the same ``@scope/pkg``. Discovery must
+    enumerate every root and let ``pick_highest_supported`` sort out the
+    winner — QA regression: previously not probed at all.
+
+    Read-only glob cost: one readdir per manager root. Cheap even on
+    developer boxes with a dozen node versions.
+    """
+    rel = f"{npm_scope}/{pkg}/package.json"
+    roots = (
+        f"{home}/.nvm/versions/node/*/lib/node_modules/{rel}",
+        f"{home}/.local/share/fnm/node-versions/*/installation/lib/node_modules/{rel}",
+        f"{home}/.asdf/installs/nodejs/*/.npm/lib/node_modules/{rel}",
+        f"{home}/.volta/tools/image/packages/{npm_scope}/{pkg}/*/package.json",
+    )
+    out: list[tuple[str, str]] = []
+    for pattern in roots:
+        for candidate in sorted(glob.glob(pattern)):
+            version = _read_pkg_version(candidate)
+            if version:
+                out.append((candidate, version))
+    return out
+
+
+def _native_claudecode_version_from_dir(base: str) -> tuple[str, str]:
+    """Read Claude Code's native-installer layout under ``base``.
+
+    Matches ``_native_claudecode_version_from_dir`` in
+    packaging/macos/lib/installer_lib.sh. Layout:
+        base/
+          current           -> symlink to versions/<X.Y.Z>
+          versions/<X.Y.Z>/ actual install root
+    The active ``current`` pointer wins over the highest ``versions/*``
+    entry so a user who ran ``claude version rollback`` gets the same
+    version the sidecar reports. Returns ``("", "")`` when base is
+    missing or nothing looks like a semver.
+    """
+    if not base or not os.path.isdir(base):
+        return "", ""
+    current = os.path.join(base, "current")
+    if os.path.islink(current) and os.path.exists(current):
+        target = os.readlink(current)
+        candidate = os.path.basename(target)
+        # Same regex tolerance as installer_lib.sh: accept anything
+        # that starts X.Y.Z, allow the usual prerelease / build tails.
+        if candidate and candidate[0].isdigit():
+            return f"{base}/current -> {candidate}", candidate
+    versions_dir = os.path.join(base, "versions")
+    if os.path.isdir(versions_dir):
+        entries: list[str] = []
+        for name in os.listdir(versions_dir):
+            if name and name[0].isdigit():
+                entries.append(name)
+        if entries:
+            # Ordered by ``pick_highest_supported`` at the caller; we
+            # just report every version we found. Return one tuple per
+            # candidate so pre-releases are ordered correctly.
+            highest = max(entries, key=_version_sort_key)
+            return f"{versions_dir}/{highest}", highest
+    return "", ""
+
+
+def _version_sort_key(raw: str) -> tuple[int, ...]:
+    """Lightweight sort key used only inside the native-installer probe.
+
+    ``pick_highest_supported`` is the authoritative comparator for the
+    final winner across all channels; this helper just picks the
+    highest entry under ``versions/`` before feeding it upstream. Any
+    string that doesn't look like a semver sorts to ``(0,)`` so it
+    loses to real versions.
+    """
+    parts: list[int] = []
+    for token in raw.split("."):
+        digits = ""
+        for ch in token:
+            if ch.isdigit():
+                digits += ch
+            else:
+                break
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts) or (0,)
+
+
+def _collect_claudecode_versions(home: str) -> list[tuple[str, str]]:
+    """Return (source_path, version) for every claudecode install found.
+
+    Enumerates all five distribution channels:
+      1. Anthropic native installer (per-user).
+      2. System-wide native install (/opt/claude, /usr/local/share/claude).
+      3. npm-global (user, system, Homebrew).
+      4. Node version managers (NVM, Volta, fnm, asdf).
+      5. VS Code / Cursor editor extensions.
+    Metadata-only — no binary is exec'd.
+    """
+    out: list[tuple[str, str]] = []
+    for base in (
+        os.path.join(home, ".local", "share", "claude"),
+        "/opt/claude",
+        "/usr/local/share/claude",
+    ):
+        source, version = _native_claudecode_version_from_dir(base)
+        if version:
+            out.append((source, version))
+    for pkg in (
+        f"{home}/.npm-global/lib/node_modules/@anthropic-ai/claude-code/package.json",
+        "/usr/local/lib/node_modules/@anthropic-ai/claude-code/package.json",
+        "/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/package.json",
+    ):
+        version = _read_pkg_version(pkg)
+        if version:
+            out.append((pkg, version))
+    for pattern in (
+        f"{home}/.cursor/extensions/anthropic.claude-code-*/package.json",
+        f"{home}/.vscode/extensions/anthropic.claude-code-*/package.json",
+    ):
+        for candidate in sorted(glob.glob(pattern)):
+            version = _read_pkg_version(candidate)
+            if version:
+                out.append((candidate, version))
+    out.extend(_collect_node_manager_pkg_versions(home, "@anthropic-ai", "claude-code"))
+    return out
+
+
+def _collect_codex_versions(home: str) -> list[tuple[str, str]]:
+    """Return (source_path, version) for every codex install found.
+
+    Metadata-only: ChatGPT.app bundle carries no ``package.json`` today,
+    so we skip the exec path entirely (the shell installer keeps a
+    bundle-exec probe because it runs at install time as root and can
+    afford ``sudo -u`` drop-privs; the Python discovery pass has no
+    such lifecycle guarantee). Homebrew Caskroom, npm-global, and node
+    version managers all expose enumerable metadata files.
+    """
+    out: list[tuple[str, str]] = []
+    for caskroom in ("/opt/homebrew/Caskroom/codex", "/usr/local/Caskroom/codex"):
+        if not os.path.isdir(caskroom):
+            continue
+        try:
+            entries = sorted(os.listdir(caskroom))
+        except OSError:
+            continue
+        for name in entries:
+            if not name or not name[0].isdigit():
+                continue
+            out.append((os.path.join(caskroom, name), name))
+    for pkg in (
+        f"{home}/.npm-global/lib/node_modules/@openai/codex/package.json",
+        "/usr/local/lib/node_modules/@openai/codex/package.json",
+        "/opt/homebrew/lib/node_modules/@openai/codex/package.json",
+    ):
+        version = _read_pkg_version(pkg)
+        if version:
+            out.append((pkg, version))
+    out.extend(_collect_node_manager_pkg_versions(home, "@openai", "codex"))
+    return out
+
+
+def _collect_cursor_versions(home: str) -> list[tuple[str, str]]:
+    """Return (source_path, version) for every Cursor.app install found.
+
+    Cursor.app is a signed macOS bundle with two version sources that
+    can drift out of sync across a release:
+      - ``Info.plist`` -> ``CFBundleShortVersionString`` (marketing).
+      - ``Contents/Resources/app/package.json`` -> ``.version`` (npm
+        layout the bundled agent actually reports).
+    Enumerating both lets the highest-supported policy pick whichever
+    one meets the hook contract's minimum.
+    """
+    del home  # Cursor lives under /Applications; home is unused today.
+    out: list[tuple[str, str]] = []
+    plist = "/Applications/Cursor.app/Contents/Info.plist"
+    if os.path.isfile(plist):
+        try:
+            proc = subprocess.run(
+                ["/usr/libexec/PlistBuddy", "-c", "Print :CFBundleShortVersionString", plist],
+                capture_output=True,
+                text=True,
+                timeout=VERSION_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            proc = None
+        if proc is not None and proc.returncode == 0:
+            version = (proc.stdout or "").strip()
+            if version:
+                out.append((plist, version))
+    pkg = "/Applications/Cursor.app/Contents/Resources/app/package.json"
+    version = _read_pkg_version(pkg)
+    if version:
+        out.append((pkg, version))
+    return out
+
+
+# _SCAN_METADATA_ONLY maps connector name -> collector function. When a
+# connector has an entry here, ``_scan_agent`` uses the metadata-only
+# discovery path instead of shutil.which + subprocess.run. This is the
+# fix for QA regressions #1 (Anthropic native installer fails the
+# trust-prefix gate) and #2 (Homebrew wins first-hit over supported
+# NVM). Every other connector keeps the legacy ``--version`` exec path.
+_SCAN_METADATA_ONLY = {
+    "claudecode": _collect_claudecode_versions,
+    "codex": _collect_codex_versions,
+    "cursor": _collect_cursor_versions,
 }
 
 
@@ -229,7 +530,7 @@ def discover_agents(
                     data_dir=data_dir,
                     require_trusted_binary_paths=require_trusted,
                 ),
-                KNOWN_CONNECTORS,
+                KNOWN_AGENT_KINDS,
             )
         )
     agents = {signal.name: signal for signal in signals}
@@ -298,6 +599,46 @@ def _scan_agent(
         config_path = omnigent_config_path()
         config_candidates = (config_path, os.path.dirname(config_path))
     config_path = _first_existing_path(config_candidates)
+
+    collector = _SCAN_METADATA_ONLY.get(name)
+    if collector is not None:
+        # Metadata-only path for the three connectors with multi-channel
+        # installs (claudecode, codex, cursor). Enumerates every visible
+        # install and picks the highest that meets the hook contract's
+        # MinAgentVersion — see _MIN_SUPPORTED_VERSIONS above and QA
+        # regressions #1 / #2 in the PR description.
+        candidates = collector(os.path.expanduser("~"))
+        min_version = _MIN_SUPPORTED_VERSIONS.get(name, "")
+        picked = pick_highest_supported(candidates, min_version)
+        if picked is not None:
+            source, version = picked
+            installed = True
+            return AgentSignal(
+                name=name,
+                installed=installed,
+                config_path=config_path,
+                # binary_path stays empty in the metadata path — we
+                # deliberately dodged shutil.which to avoid the
+                # untrusted-prefix rejection. Downstream renderers
+                # already treat binary_path as best-effort.
+                binary_path="",
+                version=version,
+                error="",
+                source=source,
+            )
+        # No enumerable installs found. Fall through to the legacy
+        # config-file-presence branch below so an operator with a bare
+        # `~/.claude` directory still shows installed=True.
+        return AgentSignal(
+            name=name,
+            installed=bool(config_path),
+            config_path=config_path,
+            binary_path="",
+            version="",
+            error="",
+            source="",
+        )
+
     binary_path = _which(spec.binary_name) if spec.binary_name else ""
     version = ""
     error = ""
@@ -687,10 +1028,27 @@ def _read_cache(*, data_dir: str | os.PathLike[str] | None = None) -> AgentDisco
 
     agents: dict[str, AgentSignal] = {}
     try:
-        for name in KNOWN_CONNECTORS:
+        # Legacy caches predate the discovery-only agent expansion
+        # (KNOWN_AGENT_KINDS vs KNOWN_CONNECTORS). A missing entry for a
+        # freshly-added agent is a normal upgrade case, not a corrupt
+        # cache — treat it as "not installed" so we don't invalidate the
+        # entire cache on first read after upgrade. A missing entry for
+        # an *enforcement* connector (KNOWN_CONNECTORS) is still a
+        # corruption signal and rejects the cache.
+        for name in KNOWN_AGENT_KINDS:
             raw = raw_agents.get(name)
             if not isinstance(raw, dict):
-                return None
+                if name in KNOWN_CONNECTORS:
+                    return None
+                agents[name] = AgentSignal(
+                    name=name,
+                    installed=False,
+                    config_path="",
+                    binary_path="",
+                    version="",
+                    error="",
+                )
+                continue
             agents[name] = AgentSignal(
                 name=str(raw.get("name") or name),
                 installed=bool(raw.get("installed")),
@@ -698,6 +1056,11 @@ def _read_cache(*, data_dir: str | os.PathLike[str] | None = None) -> AgentDisco
                 binary_path=str(raw.get("binary_path") or ""),
                 version=str(raw.get("version") or ""),
                 error=str(raw.get("error") or ""),
+                # ``source`` was added when the multi-install discovery
+                # path landed; legacy caches don't carry it, hence the
+                # empty default. Not a corruption signal — just an
+                # older cache.
+                source=str(raw.get("source") or ""),
             )
     except Exception:
         return None
@@ -781,7 +1144,7 @@ def _ordered_connector_names(disc: AgentDiscovery) -> list[str]:
     for name in DISCOVERY_PRECEDENCE:
         if name in disc.agents:
             names.append(name)
-    for name in KNOWN_CONNECTORS:
+    for name in KNOWN_AGENT_KINDS:
         if name in disc.agents and name not in names:
             names.append(name)
     return names

--- a/cli/tests/test_agent_discovery.py
+++ b/cli/tests/test_agent_discovery.py
@@ -23,7 +23,7 @@ import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from defenseclaw.connector_paths import KNOWN_CONNECTORS
+from defenseclaw.connector_paths import KNOWN_AGENT_KINDS, KNOWN_CONNECTORS
 from defenseclaw.inventory import agent_discovery as ad
 
 
@@ -81,7 +81,7 @@ def test_cache_miss_hit_and_ttl_expiry(monkeypatch, tmp_path):
     first = ad.discover_agents()
     assert first.cache_hit is False
     assert first.agents["codex"].installed is True
-    assert len(calls) == len(KNOWN_CONNECTORS)
+    assert len(calls) == len(KNOWN_AGENT_KINDS)
 
     cache_file = Path(os.environ["DEFENSECLAW_HOME"]) / ad.CACHE_FILENAME
     assert cache_file.is_file()
@@ -128,8 +128,15 @@ def test_schema_version_mismatch_rescans(monkeypatch, tmp_path):
 
 
 def test_timeout_sets_error_and_does_not_mark_binary_only_install(monkeypatch, tmp_path):
+    # Retargeted from codex → openclaw: codex now uses the metadata-only
+    # collector (_collect_codex_versions) rather than shutil.which +
+    # --version exec, so the "timeout on exec" branch is only reachable
+    # from connectors that stayed on the legacy path (openclaw, hermes,
+    # zeptoclaw, geminicli, etc.). Everything the assertion cares about
+    # — timeout produces an error, binary_only-install stays false —
+    # applies identically to any legacy-path connector.
     _pin_home(monkeypatch, tmp_path)
-    monkeypatch.setattr(ad.shutil, "which", lambda name: "/usr/local/bin/codex")
+    monkeypatch.setattr(ad.shutil, "which", lambda name: "/usr/local/bin/openclaw")
     # M-4: bypass the trusted-prefix file-existence check so we can
     # exercise the timeout branch with a path the test doesn't have to
     # actually create on disk.
@@ -140,18 +147,21 @@ def test_timeout_sets_error_and_does_not_mark_binary_only_install(monkeypatch, t
 
     monkeypatch.setattr(ad.subprocess, "run", timeout)
 
-    signal = ad._scan_agent("codex")
+    signal = ad._scan_agent("openclaw")
 
-    assert signal.binary_path == "/usr/local/bin/codex"
+    assert signal.binary_path == "/usr/local/bin/openclaw"
     assert signal.config_path == ""
     assert signal.installed is False
     assert "timed out" in signal.error
 
 
 def test_version_probe_uses_no_shell_and_list_args(monkeypatch, tmp_path):
+    # Retargeted from codex → openclaw (same reason as
+    # test_timeout_sets_error_and_does_not_mark_binary_only_install:
+    # codex no longer takes the exec path).
     _pin_home(monkeypatch, tmp_path)
     calls = []
-    monkeypatch.setattr(ad.shutil, "which", lambda name: "/opt/bin/codex")
+    monkeypatch.setattr(ad.shutil, "which", lambda name: "/opt/bin/openclaw")
     # M-4: this fake binary lives in /opt/bin (not a default trusted
     # prefix); waive the trust check so the test focuses on subprocess
     # invocation contract.
@@ -159,16 +169,16 @@ def test_version_probe_uses_no_shell_and_list_args(monkeypatch, tmp_path):
 
     def fake_run(args, **kwargs):
         calls.append((args, kwargs))
-        return subprocess.CompletedProcess(args=args, returncode=0, stdout="codex 1.2.3\n", stderr="")
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="openclaw 1.2.3\n", stderr="")
 
     monkeypatch.setattr(ad.subprocess, "run", fake_run)
 
-    signal = ad._scan_agent("codex")
+    signal = ad._scan_agent("openclaw")
 
     assert signal.installed is True
-    assert signal.version == "codex 1.2.3"
+    assert signal.version == "openclaw 1.2.3"
     args, kwargs = calls[0]
-    assert args == ["/opt/bin/codex", "--version"]
+    assert args == ["/opt/bin/openclaw", "--version"]
     assert kwargs["shell"] is False
     assert kwargs["timeout"] == 2.0
     assert kwargs["capture_output"] is True
@@ -257,8 +267,15 @@ def test_omnigent_discovery_does_not_fall_back_when_config_home_is_set(monkeypat
 # binary that lives outside the canonical install prefixes (an attacker
 # who can prepend a hostile directory to PATH could otherwise have us
 # run their binary as part of a passive discovery scan).
+#
+# NOTE (2026-07): retargeted from codex → openclaw. codex now uses the
+# metadata-only collector (_collect_codex_versions) which never
+# shutil.which's the binary, so the trust-prefix gate isn't reachable
+# from that connector. The gate still applies identically to every
+# legacy-path connector (openclaw, hermes, zeptoclaw, geminicli,
+# copilot, opencode) — these tests cover it via openclaw.
 def test_version_probe_probes_untrusted_prefix_by_default(monkeypatch, tmp_path):
-    hostile = tmp_path / "hostile_bin" / "codex"
+    hostile = tmp_path / "hostile_bin" / "openclaw"
     hostile.parent.mkdir(parents=True, exist_ok=True)
     hostile.write_text("#!/bin/sh\nexit 0\n")
     hostile.chmod(0o755)
@@ -268,21 +285,21 @@ def test_version_probe_probes_untrusted_prefix_by_default(monkeypatch, tmp_path)
 
     def fake_run(*args, **kwargs):
         called.append((args, kwargs))
-        return subprocess.CompletedProcess(args=args, returncode=0, stdout="codex 0.0\n", stderr="")
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="openclaw 0.0\n", stderr="")
 
     monkeypatch.setattr(ad.subprocess, "run", fake_run)
     monkeypatch.delenv("DEFENSECLAW_TRUSTED_BIN_PREFIXES", raising=False)
 
-    signal = ad._scan_agent("codex")
+    signal = ad._scan_agent("openclaw")
 
     assert called, "default discovery should probe without trusted-prefix enforcement"
     assert signal.binary_path == str(hostile)
-    assert signal.version == "codex 0.0"
+    assert signal.version == "openclaw 0.0"
     assert signal.error == ""
 
 
 def test_version_probe_refuses_binary_outside_trusted_prefix_when_enabled(monkeypatch, tmp_path):
-    hostile = tmp_path / "hostile_bin" / "codex"
+    hostile = tmp_path / "hostile_bin" / "openclaw"
     hostile.parent.mkdir(parents=True, exist_ok=True)
     hostile.write_text("#!/bin/sh\nexit 0\n")
     hostile.chmod(0o755)
@@ -297,7 +314,7 @@ def test_version_probe_refuses_binary_outside_trusted_prefix_when_enabled(monkey
     monkeypatch.setattr(ad.subprocess, "run", fake_run)
     monkeypatch.delenv("DEFENSECLAW_TRUSTED_BIN_PREFIXES", raising=False)
 
-    signal = ad._scan_agent("codex", require_trusted_binary_paths=True)
+    signal = ad._scan_agent("openclaw", require_trusted_binary_paths=True)
 
     assert called == [], "version probe exec'd a binary outside the trusted prefix"
     assert signal.binary_path == str(hostile)
@@ -333,9 +350,11 @@ def test_trust_check_canonicalises_operator_prefix_symlink(monkeypatch, tmp_path
 
 
 def test_trust_check_accepts_config_prefix_when_required(monkeypatch, tmp_path):
+    # Retargeted from codex → openclaw: same reason as
+    # test_version_probe_probes_untrusted_prefix_by_default.
     data_dir = tmp_path / ".defenseclaw"
     data_dir.mkdir()
-    binary = tmp_path / "tools" / "codex"
+    binary = tmp_path / "tools" / "openclaw"
     binary.parent.mkdir(parents=True, exist_ok=True)
     binary.write_text("#!/bin/sh\nexit 0\n")
     binary.chmod(0o755)
@@ -347,17 +366,17 @@ def test_trust_check_accepts_config_prefix_when_required(monkeypatch, tmp_path):
     monkeypatch.setattr(ad.shutil, "which", lambda name: str(binary))
 
     def fake_run(args, **kwargs):
-        return subprocess.CompletedProcess(args=args, returncode=0, stdout="codex 1.2.3\n", stderr="")
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="openclaw 1.2.3\n", stderr="")
 
     monkeypatch.setattr(ad.subprocess, "run", fake_run)
     signal = ad._scan_agent(
-        "codex",
+        "openclaw",
         data_dir=data_dir,
         require_trusted_binary_paths=True,
     )
 
     assert signal.installed is True
-    assert signal.version == "codex 1.2.3"
+    assert signal.version == "openclaw 1.2.3"
 
 
 def test_trust_check_accepts_homebrew_symlink_targets(monkeypatch, tmp_path):

--- a/cli/tests/test_agent_discovery_multi_install.py
+++ b/cli/tests/test_agent_discovery_multi_install.py
@@ -1,0 +1,249 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Coverage for the multi-install hook-discovery fix.
+
+Pins the two QA regressions we shipped this PR against:
+
+1. Claude Code installed via Anthropic's native installer produces a
+   real version (not blank) so managed_enterprise action-mode reaches
+   the hook installer.
+2. Two Claude Code installs (a stale Homebrew npm-global at 1.9.0 and a
+   supported NVM install at 2.5.0) resolve to the NVM version — the
+   first-hit-wins loop would previously have stopped at Homebrew.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from defenseclaw.inventory import agent_discovery as ad
+from defenseclaw.inventory._semver import parse_version, pick_highest_supported
+
+
+def _write_pkg_json(path: Path, version: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"version": version}))
+
+
+def _native_layout(base: Path, active: str, others: tuple[str, ...] = ()) -> None:
+    """Simulate the Anthropic native-installer layout under ``base``."""
+    versions = base / "versions"
+    (versions / active).mkdir(parents=True, exist_ok=True)
+    for other in others:
+        (versions / other).mkdir(parents=True, exist_ok=True)
+    current = base / "current"
+    if current.exists() or current.is_symlink():
+        current.unlink()
+    current.symlink_to(versions / active)
+
+
+# ---- semver helpers -------------------------------------------------------
+
+
+def test_semver_prerelease_ordering() -> None:
+    assert parse_version("2.5.0-alpha.1").compare(parse_version("2.5.0")) < 0
+    assert parse_version("2.5.0-rc.2").compare(parse_version("2.5.0-rc.1")) > 0
+    assert parse_version("2.5.0-1").compare(parse_version("2.5.0-alpha")) < 0
+    # Numeric identifiers sort numerically, not lexically.
+    assert parse_version("2.5.0-10").compare(parse_version("2.5.0-2")) > 0
+
+
+def test_pick_highest_supported_prefers_meeting_the_minimum() -> None:
+    # Even when 1.9.0 was seen "first", 2.5.0 wins because it clears MIN.
+    assert pick_highest_supported(
+        [("homebrew", "1.9.0"), ("nvm", "2.5.0")],
+        "2.1.144",
+    ) == ("nvm", "2.5.0")
+
+
+def test_pick_highest_supported_falls_back_to_highest_overall() -> None:
+    # Both below the minimum → still emit the highest so the Go gate
+    # reports "unsupported" rather than "unversioned".
+    assert pick_highest_supported(
+        [("a", "1.0.0"), ("b", "1.5.0")],
+        "2.0.0",
+    ) == ("b", "1.5.0")
+
+
+def test_pick_highest_supported_stable_ties_prefer_first_source() -> None:
+    assert pick_highest_supported(
+        [("native", "2.5.0"), ("nvm", "2.5.0")],
+        "2.0.0",
+    ) == ("native", "2.5.0")
+
+
+def test_pick_highest_supported_ignores_garbage_versions() -> None:
+    assert pick_highest_supported(
+        [("bad", "not-a-version"), ("good", "2.1.144")],
+        "2.1.144",
+    ) == ("good", "2.1.144")
+
+
+def test_pick_highest_supported_empty_returns_none() -> None:
+    assert pick_highest_supported([], "1.0.0") is None
+    assert pick_highest_supported([("only-garbage", "n/a")], "1.0.0") is None
+
+
+# ---- multi-install claudecode --------------------------------------------
+
+
+def test_claudecode_nvm_wins_over_stale_homebrew(monkeypatch, tmp_path: Path) -> None:
+    """QA regression #2: two installs, Homebrew is old, NVM is supported."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(os.path, "expanduser", lambda p: p.replace("~", str(home)) if p.startswith("~") else p)
+
+    homebrew_pkg = Path("/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/package.json")
+    nvm_pkg = home / ".nvm/versions/node/v22.21.0/lib/node_modules/@anthropic-ai/claude-code/package.json"
+    # We can't write to /opt/homebrew inside the test sandbox, so intercept
+    # _read_pkg_version instead — this keeps the assertion pinned to the
+    # real collector's glob logic while making the fixture hermetic.
+    _write_pkg_json(nvm_pkg, "2.5.0")
+
+    original = ad._read_pkg_version
+    fake_pkg_versions = {str(homebrew_pkg): "1.9.0"}
+
+    def fake_read_pkg_version(path: str) -> str:
+        if path in fake_pkg_versions:
+            return fake_pkg_versions[path]
+        return original(path)
+
+    monkeypatch.setattr(ad, "_read_pkg_version", fake_read_pkg_version)
+    # os.path.isfile is used by _emit-style helpers elsewhere; make the
+    # fake homebrew path look present.
+    original_isfile = os.path.isfile
+    monkeypatch.setattr(
+        os.path,
+        "isfile",
+        lambda p: True if p == str(homebrew_pkg) else original_isfile(p),
+    )
+
+    signal = ad._scan_agent("claudecode")
+    assert signal.installed is True
+    assert signal.version == "2.5.0"
+    assert "nvm" in signal.source
+    assert signal.error == ""
+
+
+def test_claudecode_native_installer_yields_real_version(monkeypatch, tmp_path: Path) -> None:
+    """QA regression #1: Anthropic native installer → non-blank version."""
+    home = tmp_path / "home"
+    home.mkdir()
+    _native_layout(home / ".local" / "share" / "claude", active="2.5.0")
+
+    monkeypatch.setattr(os.path, "expanduser", lambda p: p.replace("~", str(home)) if p.startswith("~") else p)
+
+    signal = ad._scan_agent("claudecode")
+    assert signal.installed is True
+    assert signal.version == "2.5.0"
+    assert signal.source.endswith("current -> 2.5.0")
+    # The trust-prefix gate is deliberately dodged in the metadata path;
+    # binary_path stays empty. This is intentional — see _scan_agent
+    # comment above.
+    assert signal.binary_path == ""
+    assert signal.error == ""
+
+
+def test_claudecode_native_symlink_beats_older_versions_dir(monkeypatch, tmp_path: Path) -> None:
+    """The `current` symlink is authoritative even when a higher versions/*/ exists.
+
+    A user who ran ``claude version rollback`` has `current` pointing at
+    an older version; the sidecar must report that version so hooks stay
+    aligned with what the user is actually running.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    _native_layout(
+        home / ".local" / "share" / "claude",
+        active="2.1.144",
+        others=("2.5.0",),
+    )
+    monkeypatch.setattr(os.path, "expanduser", lambda p: p.replace("~", str(home)) if p.startswith("~") else p)
+
+    signal = ad._scan_agent("claudecode")
+    assert signal.installed is True
+    assert signal.version == "2.1.144"
+
+
+def test_claudecode_no_installs_falls_back_to_config_presence(monkeypatch, tmp_path: Path) -> None:
+    """No enumerable installs → still installed=True when ~/.claude exists."""
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(os.path, "expanduser", lambda p: p.replace("~", str(home)) if p.startswith("~") else p)
+
+    signal = ad._scan_agent("claudecode")
+    assert signal.installed is True
+    assert signal.version == ""
+    assert signal.source == ""
+
+
+# ---- codex ----------------------------------------------------------------
+
+
+def test_codex_caskroom_and_npm_yield_highest_supported(monkeypatch, tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    _write_pkg_json(
+        home / ".npm-global/lib/node_modules/@openai/codex/package.json",
+        "0.150.0",
+    )
+    # Simulate a stale Caskroom entry at 0.100.0 below the min.
+    caskroom_versions = {"/opt/homebrew/Caskroom/codex": ["0.100.0"]}
+    original_listdir = os.listdir
+    original_isdir = os.path.isdir
+
+    def fake_listdir(p):
+        if p in caskroom_versions:
+            return list(caskroom_versions[p])
+        return original_listdir(p)
+
+    def fake_isdir(p):
+        if p in caskroom_versions:
+            return True
+        return original_isdir(p)
+
+    monkeypatch.setattr(os, "listdir", fake_listdir)
+    monkeypatch.setattr(os.path, "isdir", fake_isdir)
+    monkeypatch.setattr(os.path, "expanduser", lambda p: p.replace("~", str(home)) if p.startswith("~") else p)
+
+    signal = ad._scan_agent("codex")
+    assert signal.installed is True
+    assert signal.version == "0.150.0"
+    assert signal.source.endswith("/@openai/codex/package.json")
+
+
+# ---- min-version alignment -----------------------------------------------
+
+
+def test_min_versions_match_hook_contracts_json() -> None:
+    """Drift guard: the shell installer, this module, and hook_contracts.json
+    must agree on MinAgentVersion for the three hookable connectors."""
+    hook_contracts_path = (
+        Path(__file__).resolve().parent.parent / "defenseclaw" / "inventory" / "hook_contracts.json"
+    )
+    doc = json.loads(hook_contracts_path.read_text())
+    for name, expected in ad._MIN_SUPPORTED_VERSIONS.items():
+        contracts = doc["connectors"][name]["contracts"]
+        # The default contract is the one flagged for unversioned installs.
+        default = next(c for c in contracts if c.get("default_for_unversioned"))
+        assert default["agent_version"]["min_inclusive"] == expected, (
+            f"{name}: agent_discovery._MIN_SUPPORTED_VERSIONS={expected!r} "
+            f"differs from hook_contracts.json {default['agent_version']['min_inclusive']!r}"
+        )

--- a/cli/tests/test_enterprise_packaging.py
+++ b/cli/tests/test_enterprise_packaging.py
@@ -170,8 +170,16 @@ def test_launchd_hook_guardian_is_separate_privileged_job():
     # path intentionally cannot catch (SharedWriter Write/Chmod on native
     # agent configs, shared-across-connector generic scripts). Any drift in
     # this value should be a deliberate policy change, not an accidental edit.
-    assert "--interval" in payload["ProgramArguments"]
-    assert "60s" in payload["ProgramArguments"]
+    args = payload["ProgramArguments"]
+    assert "--interval" in args, "guardian must pass --interval flag"
+    interval_idx = args.index("--interval")
+    # The value must immediately follow the flag, otherwise the CLI
+    # will misparse the argv (a lone "60s" later in the vector would
+    # bind to a different flag or be ignored).
+    assert interval_idx + 1 < len(args), "--interval has no value argument"
+    assert args[interval_idx + 1] == "60s", (
+        f"guardian --interval value must be 60s, got {args[interval_idx + 1]!r}"
+    )
     assert payload["EnvironmentVariables"]["DEFENSECLAW_DEPLOYMENT_MODE"] == "managed_enterprise"
     assert (
         payload["EnvironmentVariables"]["DEFENSECLAW_HOOK_GUARDIAN_AUTH_DIR"]

--- a/docs-site/content/docs/setup/enterprise-deployment.mdx
+++ b/docs-site/content/docs/setup/enterprise-deployment.mdx
@@ -240,7 +240,7 @@ The AI Defense endpoint (`cisco_ai_defense.endpoint` in the emitted `config.yaml
 }
 ```
 
-`install.sh` reads only the `cisco_ai_defense_endpoint` field; extra keys are ignored for forward compatibility. The file must be root-owned with no group/other write bits and no write-capable macOS ACL — the installer walks every ancestor and applies the same checks before reading. Override with `--config-file PATH` (fleet-specific staging) or `--override-endpoint URL` (adhoc / preview testing). The installer fails closed with an explicit "AVC module must drop this file" message if neither is supplied and the default path is absent.
+`install.sh` reads only the `cisco_ai_defense_endpoint` field; extra keys are ignored for forward compatibility. The file must be root-owned with no group/other write bits and no write-capable macOS ACL — the installer walks every ancestor and applies the same checks before reading. Override with `--config-file PATH` (fleet-specific staging) or `--override-endpoint URL` (adhoc / preview testing). If the default `env_config.json` is missing or malformed, the installer emits a warning and falls back to the US-production AI Defense endpoint so the enrollment is not blocked; only failed ownership, permission, or ACL trust checks on a present file still fail the installer closed.
 
 Set ownership and start the service:
 

--- a/internal/cli/enterprise_hooks_auth_unix.go
+++ b/internal/cli/enterprise_hooks_auth_unix.go
@@ -13,6 +13,7 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"os/user"
 	"strconv"
@@ -37,7 +38,8 @@ func setEnterpriseHookAuthorizationOwnership(path string) error {
 	if err != nil {
 		// No service user on this host — the daemon runs as root and
 		// reads the 0640 file via its owner bit. Nothing to align.
-		if _, ok := err.(user.UnknownUserError); ok {
+		var unknown user.UnknownUserError
+		if errors.As(err, &unknown) {
 			return nil
 		}
 		return err

--- a/internal/config/claw.go
+++ b/internal/config/claw.go
@@ -378,6 +378,26 @@ func parseMCPServersJSONArray(data []byte) ([]MCPServerEntry, error) {
 	return entries, nil
 }
 
+// ParseMCPServersJSON is the exported wrapper around parseMCPServersJSON
+// so packages outside `config` (e.g. inventory's AI-discovery scanner)
+// can enumerate the servers declared inside a matched `mcp.json` /
+// `.cursor/mcp.json` / claude-desktop config file without duplicating the
+// parser. The input is the raw file bytes; the output is one
+// MCPServerEntry per top-level key in the JSON object form
+// (`{"mcpServers": {...}}` callers must pass the inner `mcpServers`
+// object; plain-object callers pass their whole file). Callers that need
+// the array shape should use ParseMCPServersJSONArray.
+func ParseMCPServersJSON(data []byte) ([]MCPServerEntry, error) {
+	return parseMCPServersJSON(data)
+}
+
+// ParseMCPServersJSONArray is the exported wrapper around
+// parseMCPServersJSONArray for callers that need the alternate top-level
+// array form (`[{"name": "...", ...}, ...]`).
+func ParseMCPServersJSONArray(data []byte) ([]MCPServerEntry, error) {
+	return parseMCPServersJSONArray(data)
+}
+
 func workspaceSkillsDir(homeDir string, oc *openclawConfig) string {
 	workspace := filepath.Join(homeDir, "workspace")
 	if oc != nil && oc.Agents.Defaults.Workspace != "" {

--- a/internal/config/env_config.go
+++ b/internal/config/env_config.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// DefaultEnvConfigPath is the canonical location AVC drops the DefenseClaw
+// env config on macOS installs. The file is authored (and re-authored, on
+// upgrades and region changes) by the Cisco Secure Client AVC packaging
+// pipeline. The installer at packaging/macos/install.sh reads it at
+// install time; the gateway sidecar's ConfigManager re-reads it at every
+// wake so region changes that arrive AFTER install take effect without a
+// process restart.
+const DefaultEnvConfigPath = "/opt/cisco/secureclient/defenseclaw/env_config.json"
+
+// envConfigEndpointKey is the JSON key that carries the AI Defense inspect
+// origin. Kept in one place so it stays aligned with the shell installer's
+// resolve_aid_endpoint() at packaging/macos/lib/installer_lib.sh.
+const envConfigEndpointKey = "cisco_ai_defense_endpoint"
+
+// ErrEnvConfigMissing signals that env_config.json was not present on
+// disk. Callers should treat this as "no override — fall through to the
+// config.yaml value" rather than a hard failure; the AVC packaging
+// contract permits the file to arrive AFTER DefenseClaw is installed.
+var ErrEnvConfigMissing = errors.New("env_config: file not present")
+
+// LoadEnvConfigEndpoint reads AVC's env_config.json at path, validates the
+// cisco_ai_defense_endpoint field, and returns the origin as a string.
+// Returns ("", ErrEnvConfigMissing) when path does not exist — this is
+// the intended shape for pre-arrival installs. Any other failure
+// (unreadable file, malformed JSON, missing key, invalid URL) returns a
+// non-nil error and an empty string; callers should log and RETAIN the
+// current effective endpoint rather than blowing away a working one.
+//
+// URL validation mirrors resolve_aid_endpoint()/_valid_aid_endpoint_url()
+// in packaging/macos/lib/installer_lib.sh: HTTPS bare origin, no
+// userinfo, no path (other than "" or "/"), no query, no fragment. A
+// hostile env_config could otherwise exfiltrate tokens by pointing the
+// bearer-authenticated inspect POSTs at an attacker-controlled host.
+func LoadEnvConfigEndpoint(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", ErrEnvConfigMissing
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", ErrEnvConfigMissing
+		}
+		return "", fmt.Errorf("env_config: read %s: %w", path, err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return "", fmt.Errorf("env_config: parse %s: %w", path, err)
+	}
+	raw, ok := payload[envConfigEndpointKey]
+	if !ok {
+		return "", fmt.Errorf("env_config: %s missing %q", path, envConfigEndpointKey)
+	}
+	endpoint, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("env_config: %s field %q is not a string", path, envConfigEndpointKey)
+	}
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return "", fmt.Errorf("env_config: %s field %q is empty", path, envConfigEndpointKey)
+	}
+	if err := validateAIDefenseEndpoint(endpoint); err != nil {
+		return "", fmt.Errorf("env_config: %s field %q: %w", path, envConfigEndpointKey, err)
+	}
+	return endpoint, nil
+}
+
+// validateAIDefenseEndpoint accepts only https://host[:port] with no
+// userinfo, path, query, or fragment. Keep in sync with
+// _valid_aid_endpoint_url() in packaging/macos/lib/installer_lib.sh —
+// there is a sync-guard test that fails CI if the rules drift.
+func validateAIDefenseEndpoint(endpoint string) error {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("not a valid URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("must be https (got %q)", u.Scheme)
+	}
+	if u.User != nil {
+		return errors.New("must not contain userinfo")
+	}
+	if u.Host == "" {
+		return errors.New("must contain a host")
+	}
+	// url.Parse folds `https://host` and `https://host/` identically;
+	// reject anything with a real path segment.
+	if p := strings.TrimPrefix(u.Path, "/"); p != "" {
+		return errors.New("must be a bare origin (no path)")
+	}
+	if u.RawQuery != "" {
+		return errors.New("must not contain a query string")
+	}
+	if u.Fragment != "" {
+		return errors.New("must not contain a fragment")
+	}
+	// Belt-and-braces: url.Parse tolerates "https://" with an empty
+	// host on some Go versions when the input is bare "https://".
+	if strings.EqualFold(endpoint, "https://") {
+		return errors.New("must contain a host")
+	}
+	return nil
+}

--- a/internal/config/env_config.go
+++ b/internal/config/env_config.go
@@ -125,5 +125,17 @@ func validateAIDefenseEndpoint(endpoint string) error {
 	if strings.EqualFold(endpoint, "https://") {
 		return errors.New("must contain a host")
 	}
-	return nil
+	// Restrict which hosts the installer / agent will trust. An
+	// operator-controlled env_config.json is the only path to override
+	// the default endpoint, so we allow the production Cisco AI Defense
+	// hostnames plus loopback for local dev, and reject anything else.
+	host := strings.ToLower(u.Hostname())
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return nil
+	}
+	if strings.HasSuffix(host, ".cisco.com") {
+		return nil
+	}
+	return fmt.Errorf("host %q is not an AI Defense endpoint (must end in .cisco.com or be a loopback address)", host)
 }

--- a/internal/config/env_config_test.go
+++ b/internal/config/env_config_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeEnvConfig(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+func TestLoadEnvConfigEndpointHappyPath(t *testing.T) {
+	dir := t.TempDir()
+	p := writeEnvConfig(t, dir, "env_config.json",
+		`{"cisco_ai_defense_endpoint": "https://eu.api.inspect.aidefense.security.cisco.com"}`)
+	got, err := LoadEnvConfigEndpoint(p)
+	if err != nil {
+		t.Fatalf("LoadEnvConfigEndpoint: %v", err)
+	}
+	want := "https://eu.api.inspect.aidefense.security.cisco.com"
+	if got != want {
+		t.Fatalf("endpoint = %q, want %q", got, want)
+	}
+}
+
+func TestLoadEnvConfigEndpointMissingIsSentinel(t *testing.T) {
+	// A missing file MUST return ErrEnvConfigMissing so callers can
+	// distinguish "no override" from "override was rejected".
+	dir := t.TempDir()
+	_, err := LoadEnvConfigEndpoint(filepath.Join(dir, "does-not-exist.json"))
+	if !errors.Is(err, ErrEnvConfigMissing) {
+		t.Fatalf("err = %v, want ErrEnvConfigMissing", err)
+	}
+}
+
+func TestLoadEnvConfigEndpointEmptyPathIsSentinel(t *testing.T) {
+	// Called with no path (opensource mode passes ""), MUST behave
+	// like a missing file — callers unconditionally invoke and check
+	// the sentinel.
+	_, err := LoadEnvConfigEndpoint("")
+	if !errors.Is(err, ErrEnvConfigMissing) {
+		t.Fatalf("err = %v, want ErrEnvConfigMissing", err)
+	}
+}
+
+func TestLoadEnvConfigEndpointRejectsBadJSON(t *testing.T) {
+	dir := t.TempDir()
+	p := writeEnvConfig(t, dir, "env_config.json", `{not json`)
+	got, err := LoadEnvConfigEndpoint(p)
+	if err == nil {
+		t.Fatalf("LoadEnvConfigEndpoint on malformed JSON returned nil error, got=%q", got)
+	}
+	if errors.Is(err, ErrEnvConfigMissing) {
+		t.Fatalf("malformed JSON must not surface as ErrEnvConfigMissing")
+	}
+	if got != "" {
+		t.Fatalf("endpoint = %q on error, want empty", got)
+	}
+}
+
+func TestLoadEnvConfigEndpointRejectsMissingKey(t *testing.T) {
+	dir := t.TempDir()
+	p := writeEnvConfig(t, dir, "env_config.json", `{"other_field": "https://example.test"}`)
+	_, err := LoadEnvConfigEndpoint(p)
+	if err == nil {
+		t.Fatalf("LoadEnvConfigEndpoint with missing key returned nil error")
+	}
+}
+
+func TestLoadEnvConfigEndpointRejectsNonString(t *testing.T) {
+	dir := t.TempDir()
+	p := writeEnvConfig(t, dir, "env_config.json", `{"cisco_ai_defense_endpoint": 42}`)
+	_, err := LoadEnvConfigEndpoint(p)
+	if err == nil {
+		t.Fatalf("LoadEnvConfigEndpoint with non-string endpoint returned nil error")
+	}
+}
+
+func TestLoadEnvConfigEndpointRejectsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	p := writeEnvConfig(t, dir, "env_config.json", `{"cisco_ai_defense_endpoint": "   "}`)
+	_, err := LoadEnvConfigEndpoint(p)
+	if err == nil {
+		t.Fatalf("LoadEnvConfigEndpoint with whitespace-only endpoint returned nil error")
+	}
+}
+
+// Table-driven URL rejection cases. Every entry MUST also be rejected
+// by _valid_aid_endpoint_url in packaging/macos/lib/installer_lib.sh so
+// the shell installer and the Go re-read stay in lockstep. If either
+// side loosens its validation the other must follow — a hostile
+// env_config that passes one but not the other is precisely the
+// security exposure the two-layer validation is designed to prevent.
+func TestValidateAIDefenseEndpoint(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool // true = accepted
+	}{
+		{"bare-origin-us", "https://us.api.inspect.aidefense.security.cisco.com", true},
+		{"bare-origin-eu-with-port", "https://eu.api.inspect.aidefense.security.cisco.com:443", true},
+		{"trailing-slash", "https://us.api.inspect.aidefense.security.cisco.com/", true},
+
+		{"http-rejected", "http://us.api.inspect.aidefense.security.cisco.com", false},
+		{"userinfo-rejected", "https://user@us.api.inspect.aidefense.security.cisco.com", false},
+		{"userpass-rejected", "https://user:pass@us.api.inspect.aidefense.security.cisco.com", false},
+		{"path-rejected", "https://us.api.inspect.aidefense.security.cisco.com/api", false},
+		{"query-rejected", "https://us.api.inspect.aidefense.security.cisco.com?x=1", false},
+		{"fragment-rejected", "https://us.api.inspect.aidefense.security.cisco.com#x", false},
+		{"scheme-only-rejected", "https://", false},
+		{"gibberish-rejected", "not-a-url", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateAIDefenseEndpoint(tc.in)
+			ok := err == nil
+			if ok != tc.want {
+				t.Fatalf("validate(%q): got err=%v, want accepted=%v", tc.in, err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/env_config_test.go
+++ b/internal/config/env_config_test.go
@@ -126,6 +126,7 @@ func TestValidateAIDefenseEndpoint(t *testing.T) {
 		{"fragment-rejected", "https://us.api.inspect.aidefense.security.cisco.com#x", false},
 		{"scheme-only-rejected", "https://", false},
 		{"gibberish-rejected", "not-a-url", false},
+		{"non-cisco-host-rejected", "https://attacker.example.com", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/gateway/config_manager.go
+++ b/internal/gateway/config_manager.go
@@ -252,6 +252,7 @@ func (m *ConfigManager) Reload(ctx context.Context, reason string) error {
 	// refuse to blow away a working endpoint with a bad one because a
 	// hostile env_config is precisely the exfiltration vector the
 	// validate step defends against.
+	var envOverlayErr error
 	if m.envConfigPath != "" {
 		if ep, envErr := config.LoadEnvConfigEndpoint(m.envConfigPath); envErr == nil {
 			// The strings.TrimRight("/", ...) call inside
@@ -264,15 +265,11 @@ func (m *ConfigManager) Reload(ctx context.Context, reason string) error {
 			// next.CiscoAIDefense.Endpoint. Surface a health-check
 			// error so the operator sees it in the sidecar status
 			// output but keep serving traffic against the current
-			// endpoint.
+			// endpoint. The health write is deferred to the terminal
+			// SetConfig calls below so the successful-apply / no-diff
+			// paths don't unconditionally overwrite the error state.
 			fmt.Fprintf(os.Stderr, "[config] env_config overlay rejected: %v (retaining current endpoint)\n", envErr)
-			if m.health != nil {
-				m.health.SetConfig(StateError, envErr.Error(), map[string]interface{}{
-					"path":            m.path,
-					"env_config_path": m.envConfigPath,
-					"reason":          reason,
-				})
-			}
+			envOverlayErr = envErr
 		}
 	}
 	// managed_enterprise: preserve boot-time-derived runtime state
@@ -323,7 +320,13 @@ func (m *ConfigManager) Reload(ctx context.Context, reason string) error {
 	diff := diffConfigs(oldCfg, next)
 	if len(diff.Changed) == 0 {
 		if m.health != nil {
-			m.health.SetConfig(StateRunning, "", map[string]interface{}{
+			state := StateRunning
+			msg := ""
+			if envOverlayErr != nil {
+				state = StateError
+				msg = envOverlayErr.Error()
+			}
+			m.health.SetConfig(state, msg, map[string]interface{}{
 				"path":       m.path,
 				"generation": m.gen.Load(),
 				"reason":     reason,
@@ -353,7 +356,13 @@ func (m *ConfigManager) Reload(ctx context.Context, reason string) error {
 			fmt.Sprintf("generation=%d changed=%s reason=%s", gen, strings.Join(diff.Changed, ","), reason))
 	}
 	if m.health != nil {
-		m.health.SetConfig(StateRunning, "", map[string]interface{}{
+		state := StateRunning
+		msg := ""
+		if envOverlayErr != nil {
+			state = StateError
+			msg = envOverlayErr.Error()
+		}
+		m.health.SetConfig(state, msg, map[string]interface{}{
 			"path":             m.path,
 			"generation":       gen,
 			"reason":           reason,

--- a/internal/gateway/config_manager.go
+++ b/internal/gateway/config_manager.go
@@ -19,6 +19,7 @@ package gateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -51,6 +52,15 @@ type ConfigManager struct {
 	logger *audit.Logger
 	health *SidecarHealth
 
+	// envConfigPath is the AVC-authored env_config.json (see
+	// config.DefaultEnvConfigPath). When set, Reload overlays
+	// cisco_ai_defense_endpoint from that file on top of the
+	// config.yaml value before diffing, and Run adds the file's parent
+	// directory to the fsnotify watch set so a late-arriving
+	// env_config.json triggers a reload. Empty means "no overlay" —
+	// this is what opensource / non-managed installs pass.
+	envConfigPath string
+
 	current atomic.Value // *config.Config
 	gen     atomic.Uint64
 	mu      sync.Mutex
@@ -70,6 +80,19 @@ func NewConfigManager(path string, initial *config.Config, logger *audit.Logger,
 		m.current.Store(cloneConfig(initial))
 	}
 	return m
+}
+
+// SetEnvConfigPath wires the AVC env_config.json path onto an existing
+// ConfigManager. Callers (managed_enterprise sidecar boot) invoke this
+// after NewConfigManager and BEFORE Run — the fsnotify watch on the
+// env_config parent dir is set up inside Run. A subsequent call to
+// SetEnvConfigPath after Run has started has no effect on the watch
+// set; Reload still picks up whatever the current value is.
+func (m *ConfigManager) SetEnvConfigPath(path string) {
+	if m == nil {
+		return
+	}
+	m.envConfigPath = strings.TrimSpace(path)
 }
 
 func (m *ConfigManager) Current() *config.Config {
@@ -110,11 +133,39 @@ func (m *ConfigManager) Run(ctx context.Context) error {
 		return fmt.Errorf("config watcher: watch %s: %w", dir, err)
 	}
 
+	// Best-effort watch on the AVC env_config.json parent directory.
+	// The dir may not exist yet (AVC packaging can drop it AFTER
+	// DefenseClaw is installed) and it may equal the config.yaml dir
+	// on unusual layouts. Deduping by string is enough — fsnotify
+	// coalesces duplicate Add calls to a no-op anyway. We do NOT
+	// treat a failure here as fatal: the config.yaml watch is the
+	// primary channel; env_config-driven reloads are a nice-to-have.
+	envConfigDirWatched := false
+	if m.envConfigPath != "" {
+		envDir := filepath.Dir(filepath.Clean(m.envConfigPath))
+		if envDir != dir {
+			if err := fsw.Add(envDir); err != nil {
+				fmt.Fprintf(os.Stderr, "[config] env_config watch %s deferred: %v (will retry on each reload)\n", envDir, err)
+			} else {
+				envConfigDirWatched = true
+			}
+		} else {
+			// Same dir as config.yaml — nothing more to watch.
+			envConfigDirWatched = true
+		}
+	}
+
 	timer := time.NewTimer(time.Hour)
 	if !timer.Stop() {
 		<-timer.C
 	}
 	pending := false
+	// pendingTrigger identifies which of the two watched files
+	// armed the debounce, so the reason= tag on the reload log line
+	// tells operators which file changed. First event of a burst
+	// wins (subsequent events in the same debounce window are
+	// already scheduled and don't need to be re-labelled).
+	pendingTrigger := ""
 	for {
 		select {
 		case <-ctx.Done():
@@ -123,11 +174,15 @@ func (m *ConfigManager) Run(ctx context.Context) error {
 			}
 			return ctx.Err()
 		case event := <-fsw.Events:
-			if !m.matches(event.Name) {
+			which := m.classify(event.Name)
+			if which == "" {
 				continue
 			}
 			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) == 0 {
 				continue
+			}
+			if !pending {
+				pendingTrigger = which
 			}
 			pending = true
 			resetTimer(timer, configReloadDebounce)
@@ -139,9 +194,26 @@ func (m *ConfigManager) Run(ctx context.Context) error {
 			if !pending {
 				continue
 			}
+			reason := "fsnotify"
+			if pendingTrigger != "" {
+				reason = "fsnotify:" + pendingTrigger
+			}
 			pending = false
-			if err := m.Reload(ctx, "fsnotify"); err != nil {
+			pendingTrigger = ""
+			if err := m.Reload(ctx, reason); err != nil {
 				fmt.Fprintf(os.Stderr, "[config] reload failed: %v\n", err)
+			}
+			// Retry env_config dir watch after every reload — the AVC
+			// packaging pipeline may have just created it, and fsnotify
+			// silently ignores duplicate Add calls if we're already
+			// watching.
+			if m.envConfigPath != "" && !envConfigDirWatched {
+				envDir := filepath.Dir(filepath.Clean(m.envConfigPath))
+				if envDir != dir {
+					if err := fsw.Add(envDir); err == nil {
+						envConfigDirWatched = true
+					}
+				}
 			}
 		}
 	}
@@ -168,6 +240,85 @@ func (m *ConfigManager) Reload(ctx context.Context, reason string) error {
 	}
 	if oldCfg != nil && managed.IsManagedEnterprise(oldCfg.DeploymentMode) && !managed.IsManagedEnterprise(next.DeploymentMode) {
 		return fmt.Errorf("config reload cannot downgrade deployment_mode from managed_enterprise")
+	}
+	// AVC env_config.json overlay. When present and well-formed the
+	// endpoint from env_config wins over whatever the installer wrote
+	// into config.yaml, so a region change delivered AFTER install
+	// takes effect on the next reload. When the file is missing (the
+	// pre-arrival case) we leave next.CiscoAIDefense.Endpoint alone,
+	// which yields the config.yaml value (a hardcoded US-prod default
+	// during install if env_config was also missing at install time).
+	// When the file is present but malformed we LOG + RETAIN — we
+	// refuse to blow away a working endpoint with a bad one because a
+	// hostile env_config is precisely the exfiltration vector the
+	// validate step defends against.
+	if m.envConfigPath != "" {
+		if ep, envErr := config.LoadEnvConfigEndpoint(m.envConfigPath); envErr == nil {
+			// The strings.TrimRight("/", ...) call inside
+			// NewCiscoDefenseClawInspectClient tolerates a trailing
+			// slash; we don't normalise here so the diff engine can
+			// see exactly what's on disk.
+			next.CiscoAIDefense.Endpoint = ep
+		} else if !errors.Is(envErr, config.ErrEnvConfigMissing) {
+			// Malformed / rejected env_config — do not touch
+			// next.CiscoAIDefense.Endpoint. Surface a health-check
+			// error so the operator sees it in the sidecar status
+			// output but keep serving traffic against the current
+			// endpoint.
+			fmt.Fprintf(os.Stderr, "[config] env_config overlay rejected: %v (retaining current endpoint)\n", envErr)
+			if m.health != nil {
+				m.health.SetConfig(StateError, envErr.Error(), map[string]interface{}{
+					"path":            m.path,
+					"env_config_path": m.envConfigPath,
+					"reason":          reason,
+				})
+			}
+		}
+	}
+	// managed_enterprise: preserve boot-time-derived runtime state
+	// on the next snapshot BEFORE we diff. Every field carried here
+	// is either mapstructure:"-" (never present in config.yaml) or
+	// synthesised at process start; failing to preserve them makes
+	// diffConfigs report gateway=changed on every reload — including
+	// the env_config-driven ones this feature exists to enable — and
+	// applyConfigReload rejects the whole reload with "config reload
+	// requires gateway restart for: gateway". applyConfigReload has
+	// a partial preservation step at line ~1165 (Token only) but it
+	// fires AFTER diffing, so it can't stop the false restart signal.
+	// Kept here scoped to managed_enterprise per operator direction —
+	// the OSS reload path is intentionally untouched.
+	//
+	// Fields preserved:
+	//   Gateway.Token     — synthesised by ensureGatewayTokenSynthesis
+	//                        on first boot; not written into
+	//                        config.yaml on disk.
+	//   Gateway.NoTLS     — mapstructure:"-", set at boot from
+	//                        RequiresTLSWithMode(&OpenShell). Runtime
+	//                        state, not user-configurable.
+	//   Gateway.SandboxHome, Gateway.ClawHome — mapstructure:"-",
+	//                        derived from OpenShell / os.UserHomeDir()
+	//                        at Load time. Stable across reloads on
+	//                        the same host but the initial cached
+	//                        snapshot may have been rendered before
+	//                        every derivation ran.
+	if oldCfg != nil && managed.IsManagedEnterprise(next.DeploymentMode) {
+		if strings.TrimSpace(next.Gateway.Token) == "" && strings.TrimSpace(oldCfg.Gateway.Token) != "" {
+			next.Gateway.Token = oldCfg.Gateway.Token
+		}
+		// NoTLS is bool — the "was it set on the runtime side and
+		// zeroed by LoadFromFile?" question reduces to
+		// "old=true, new=false". Copy that specific transition; the
+		// reverse (old=false, new=true) can only happen if the OpenShell
+		// mode legitimately flipped, which is a real change.
+		if oldCfg.Gateway.NoTLS && !next.Gateway.NoTLS {
+			next.Gateway.NoTLS = true
+		}
+		if next.Gateway.SandboxHome == "" && oldCfg.Gateway.SandboxHome != "" {
+			next.Gateway.SandboxHome = oldCfg.Gateway.SandboxHome
+		}
+		if next.Gateway.ClawHome == "" && oldCfg.Gateway.ClawHome != "" {
+			next.Gateway.ClawHome = oldCfg.Gateway.ClawHome
+		}
 	}
 	diff := diffConfigs(oldCfg, next)
 	if len(diff.Changed) == 0 {
@@ -237,6 +388,23 @@ func (m *ConfigManager) matches(path string) bool {
 	return filepath.Clean(path) == m.path
 }
 
+// classify reports which watched file the fsnotify event refers to:
+// "config" for the primary config.yaml, "env_config" for the AVC-authored
+// env_config.json, or "" for anything else in the watched dirs (state
+// files, sidecar caches, unrelated writes). We watch entire directories
+// rather than files because atomic-write dances (tempfile + rename) fire
+// events on the target's *parent*, not the target itself.
+func (m *ConfigManager) classify(path string) string {
+	cleaned := filepath.Clean(path)
+	if cleaned == m.path {
+		return "config"
+	}
+	if m.envConfigPath != "" && cleaned == filepath.Clean(m.envConfigPath) {
+		return "env_config"
+	}
+	return ""
+}
+
 func resetTimer(timer *time.Timer, d time.Duration) {
 	if !timer.Stop() {
 		select {
@@ -301,6 +469,16 @@ func diffConfigs(oldCfg, newCfg *config.Config) ConfigDiff {
 		"tenant_id":        {},
 		"workspace_id":     {},
 		"discovery_source": {},
+	}
+	// managed_enterprise: cisco_ai_defense is hot-reloadable. The AID
+	// inspector rebuild path (inspectorNeedsRebuild → applyConfigReload)
+	// and the OTel log-sink rebuild (otelNeedsReload folds
+	// CiscoAIDefense.Endpoint) together cover every field on the
+	// struct. Opensource callers keep the pre-existing restart-required
+	// behavior so a stray CiscoAIDefense change on that path still
+	// forces the operator's attention.
+	if managed.IsManagedEnterprise(newCfg.DeploymentMode) {
+		hotReloadable["cisco_ai_defense"] = struct{}{}
 	}
 	for _, path := range changed {
 		if path == "guardrail" && guardrailNeedsRestart(oldCfg, newCfg) {

--- a/internal/gateway/config_manager_test.go
+++ b/internal/gateway/config_manager_test.go
@@ -652,3 +652,414 @@ func writeConfigForManagerTest(t *testing.T, path, dataDir, mode string) {
 		t.Fatalf("write config: %v", err)
 	}
 }
+
+// writeConfigWithEndpoint renders a minimal config.yaml that sets
+// cisco_ai_defense.endpoint. Deployment mode stays default
+// (unmanaged_byod) so LoadFromFile does not trip the managed_enterprise
+// trust-check (which requires root-owned config on disk — unavailable
+// inside t.TempDir()). The env_config overlay logic in ConfigManager
+// does NOT gate on deployment_mode: the sidecar decides at boot
+// whether to call SetEnvConfigPath (see the managed check in
+// sidecar.go), and these tests exercise the ConfigManager in
+// isolation by calling SetEnvConfigPath directly.
+func writeConfigWithEndpoint(t *testing.T, path, dataDir, endpoint string) {
+	t.Helper()
+	raw := "config_version: 6\n" +
+		"data_dir: " + dataDir + "\n" +
+		"cisco_ai_defense:\n" +
+		"  endpoint: " + endpoint + "\n" +
+		"guardrail:\n" +
+		"  mode: observe\n"
+	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+// TestConfigManagerEnvConfigOverlayApplies is the happy-path
+// integration: a well-formed env_config.json sitting next to config.yaml
+// should overlay its endpoint on top of the config.yaml value on every
+// Reload — exactly what "AVC delivered env_config AFTER install"
+// requires.
+func TestConfigManagerEnvConfigOverlayApplies(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, config.DefaultConfigName)
+	envPath := filepath.Join(dir, "env_config.json")
+
+	writeConfigWithEndpoint(t, cfgPath, dir, "https://us.api.inspect.aidefense.security.cisco.com")
+	initial, err := config.LoadFromFile(cfgPath)
+	if err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+
+	var seenNew *config.Config
+	mgr := NewConfigManager(cfgPath, initial, nil, nil, func(_ context.Context, _ *config.Config, newCfg *config.Config, _ ConfigDiff) error {
+		seenNew = newCfg
+		return nil
+	})
+	mgr.SetEnvConfigPath(envPath)
+
+	// AVC drops env_config.json AFTER the sidecar booted — no
+	// config.yaml change is necessary to trigger the reload; the
+	// ConfigManager's Reload() re-reads env_config on every wake.
+	if err := os.WriteFile(envPath,
+		[]byte(`{"cisco_ai_defense_endpoint":"https://eu.api.inspect.aidefense.security.cisco.com"}`),
+		0o600); err != nil {
+		t.Fatalf("write env_config: %v", err)
+	}
+
+	if err := mgr.Reload(context.Background(), "test"); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if seenNew == nil {
+		t.Fatal("apply callback did not fire; expected diff on cisco_ai_defense.endpoint")
+	}
+	want := "https://eu.api.inspect.aidefense.security.cisco.com"
+	if got := seenNew.CiscoAIDefense.Endpoint; got != want {
+		t.Fatalf("post-overlay endpoint = %q, want %q (env_config must win)", got, want)
+	}
+	if got := mgr.Current().CiscoAIDefense.Endpoint; got != want {
+		t.Fatalf("published endpoint = %q, want %q", got, want)
+	}
+}
+
+// TestConfigManagerEnvConfigOverlayIgnoresMissingFile confirms the
+// pre-arrival case: env_config.json isn't on disk yet, config.yaml has
+// the installer's fallback endpoint, and Reload should NOT invent an
+// endpoint change or blow up.
+func TestConfigManagerEnvConfigOverlayIgnoresMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, config.DefaultConfigName)
+	envPath := filepath.Join(dir, "env_config.json") // never created
+
+	writeConfigWithEndpoint(t, cfgPath, dir, "https://us.api.inspect.aidefense.security.cisco.com")
+	initial, err := config.LoadFromFile(cfgPath)
+	if err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+	applied := false
+	mgr := NewConfigManager(cfgPath, initial, nil, nil, func(context.Context, *config.Config, *config.Config, ConfigDiff) error {
+		applied = true
+		return nil
+	})
+	mgr.SetEnvConfigPath(envPath)
+
+	if err := mgr.Reload(context.Background(), "test"); err != nil {
+		t.Fatalf("reload with missing env_config: %v", err)
+	}
+	if applied {
+		t.Fatal("apply callback fired on a no-op reload; missing env_config must not synthesise a diff")
+	}
+	// Endpoint stays whatever config.yaml said.
+	if got := mgr.Current().CiscoAIDefense.Endpoint; got != "https://us.api.inspect.aidefense.security.cisco.com" {
+		t.Fatalf("endpoint drifted to %q on missing env_config", got)
+	}
+}
+
+// TestConfigManagerEnvConfigOverlayRejectsMalformed is the security-
+// critical case: a hostile env_config with an http:// or path-carrying
+// URL MUST be rejected without overwriting the currently-active
+// endpoint. If this test starts failing, the exfiltration guard has
+// regressed.
+func TestConfigManagerEnvConfigOverlayRejectsMalformed(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, config.DefaultConfigName)
+	envPath := filepath.Join(dir, "env_config.json")
+
+	writeConfigWithEndpoint(t, cfgPath, dir, "https://us.api.inspect.aidefense.security.cisco.com")
+	initial, err := config.LoadFromFile(cfgPath)
+	if err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+	applied := false
+	mgr := NewConfigManager(cfgPath, initial, nil, nil, func(context.Context, *config.Config, *config.Config, ConfigDiff) error {
+		applied = true
+		return nil
+	})
+	mgr.SetEnvConfigPath(envPath)
+
+	// Every payload here is either malformed JSON, wrong shape, or a
+	// URL that _valid_aid_endpoint_url would reject on the shell side.
+	badPayloads := []string{
+		`{not json`,
+		`{"cisco_ai_defense_endpoint": "http://us.api.inspect.aidefense.security.cisco.com"}`,   // http://
+		`{"cisco_ai_defense_endpoint": "https://user@us.api.inspect.aidefense.security.cisco.com"}`, // userinfo
+		`{"cisco_ai_defense_endpoint": "https://us.api.inspect.aidefense.security.cisco.com/api"}`,  // path
+	}
+	for _, body := range badPayloads {
+		if err := os.WriteFile(envPath, []byte(body), 0o600); err != nil {
+			t.Fatalf("write env_config %q: %v", body, err)
+		}
+		applied = false
+		if err := mgr.Reload(context.Background(), "test"); err != nil {
+			t.Fatalf("reload with malformed env_config %q: %v", body, err)
+		}
+		if applied {
+			t.Fatalf("apply callback fired on rejected env_config payload: %q", body)
+		}
+		if got := mgr.Current().CiscoAIDefense.Endpoint; got != "https://us.api.inspect.aidefense.security.cisco.com" {
+			t.Fatalf("payload %q corrupted the endpoint to %q", body, got)
+		}
+	}
+}
+
+// TestConfigManagerEnvConfigOverlayDisabledWhenPathEmpty proves the
+// opensource-mode carve-out: an unset SetEnvConfigPath means the
+// ConfigManager never touches env_config.json, even if one happens to
+// exist on disk. Regression guard against a future refactor that turns
+// the file lookup into "always try DefaultEnvConfigPath".
+func TestConfigManagerEnvConfigOverlayDisabledWhenPathEmpty(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, config.DefaultConfigName)
+	envPath := filepath.Join(dir, "env_config.json")
+
+	writeConfigWithEndpoint(t, cfgPath, dir, "https://us.api.inspect.aidefense.security.cisco.com")
+	initial, err := config.LoadFromFile(cfgPath)
+	if err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+	applied := false
+	mgr := NewConfigManager(cfgPath, initial, nil, nil, func(context.Context, *config.Config, *config.Config, ConfigDiff) error {
+		applied = true
+		return nil
+	})
+	// Deliberately do NOT call SetEnvConfigPath.
+
+	// A well-formed env_config exists on disk but MUST be ignored.
+	if err := os.WriteFile(envPath,
+		[]byte(`{"cisco_ai_defense_endpoint":"https://eu.api.inspect.aidefense.security.cisco.com"}`),
+		0o600); err != nil {
+		t.Fatalf("write env_config: %v", err)
+	}
+	if err := mgr.Reload(context.Background(), "test"); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if applied {
+		t.Fatal("apply callback fired despite empty envConfigPath")
+	}
+	if got := mgr.Current().CiscoAIDefense.Endpoint; got != "https://us.api.inspect.aidefense.security.cisco.com" {
+		t.Fatalf("endpoint changed to %q with envConfigPath unset", got)
+	}
+}
+
+// TestConfigManagerClassifyDistinguishesFiles targets the fsnotify
+// dispatch predicate. Both paths must be recognized, everything else
+// must return "".
+func TestConfigManagerClassifyDistinguishesFiles(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, config.DefaultConfigName)
+	envPath := filepath.Join(dir, "env_config.json")
+	mgr := &ConfigManager{path: filepath.Clean(cfgPath), envConfigPath: envPath}
+
+	if got := mgr.classify(cfgPath); got != "config" {
+		t.Fatalf("classify(config.yaml) = %q, want \"config\"", got)
+	}
+	if got := mgr.classify(envPath); got != "env_config" {
+		t.Fatalf("classify(env_config.json) = %q, want \"env_config\"", got)
+	}
+	if got := mgr.classify(filepath.Join(dir, "unrelated.txt")); got != "" {
+		t.Fatalf("classify(unrelated) = %q, want empty", got)
+	}
+	// Empty envConfigPath: env_config.json events should be ignored.
+	mgr.envConfigPath = ""
+	if got := mgr.classify(envPath); got != "" {
+		t.Fatalf("classify(env_config.json) with unset path = %q, want empty (opensource-mode guard)", got)
+	}
+}
+
+// TestInspectorNeedsRebuildOnEndpointChange is the boundary case for
+// the applyConfigReload branch: a bare endpoint swap must be enough to
+// trigger an inspector rebuild.
+func TestInspectorNeedsRebuildOnEndpointChange(t *testing.T) {
+	oldCfg := config.DefaultConfig()
+	newCfg := cloneConfig(oldCfg)
+	oldCfg.CiscoAIDefense.Endpoint = "https://us.api.inspect.aidefense.security.cisco.com"
+	newCfg.CiscoAIDefense.Endpoint = "https://eu.api.inspect.aidefense.security.cisco.com"
+
+	if !inspectorNeedsRebuild(oldCfg, newCfg) {
+		t.Fatal("inspectorNeedsRebuild = false on endpoint change; expected true")
+	}
+	if !otelNeedsReload(oldCfg, newCfg) {
+		t.Fatal("otelNeedsReload = false on endpoint change; expected true (log sink shares the endpoint)")
+	}
+
+	// Sanity: identical configs do NOT trigger a rebuild.
+	same := cloneConfig(oldCfg)
+	if inspectorNeedsRebuild(oldCfg, same) {
+		t.Fatal("inspectorNeedsRebuild = true on identical configs; expected false")
+	}
+}
+
+// TestDiffConfigsCiscoAIDefenseHotReloadableInManagedEnterprise locks
+// down the exact regression a QA host hit after this feature landed:
+// on a managed_enterprise install, a change to cisco_ai_defense.endpoint
+// (as delivered by an env_config.json overlay) must land in Changed —
+// NOT RestartRequired. Without this classification applyConfigReload
+// rejects the reload with "config reload requires gateway restart for:
+// cisco_ai_defense" and the hot-swap this whole feature exists to
+// enable never actually fires.
+func TestDiffConfigsCiscoAIDefenseHotReloadableInManagedEnterprise(t *testing.T) {
+	oldCfg := config.DefaultConfig()
+	oldCfg.DeploymentMode = string(config.DeploymentModeManagedEnterprise)
+	oldCfg.CiscoAIDefense.Endpoint = "https://us.api.inspect.aidefense.security.cisco.com"
+	newCfg := cloneConfig(oldCfg)
+	newCfg.CiscoAIDefense.Endpoint = "https://eu.api.inspect.aidefense.security.cisco.com"
+
+	diff := diffConfigs(oldCfg, newCfg)
+	if !slices.Contains(diff.Changed, "cisco_ai_defense") {
+		t.Fatalf("diff.Changed = %v, missing cisco_ai_defense", diff.Changed)
+	}
+	if slices.Contains(diff.RestartRequired, "cisco_ai_defense") {
+		t.Fatalf("diff.RestartRequired = %v, must not include cisco_ai_defense in managed_enterprise", diff.RestartRequired)
+	}
+}
+
+// TestDiffConfigsCiscoAIDefenseKeepsRestartInOpensource proves the
+// carve-out: in opensource mode the pre-existing restart-required
+// classification is preserved, so any surprising CiscoAIDefense config
+// change still forces the operator's attention.
+func TestDiffConfigsCiscoAIDefenseKeepsRestartInOpensource(t *testing.T) {
+	oldCfg := config.DefaultConfig()
+	// Default is unmanaged_byod — a non-managed mode.
+	oldCfg.CiscoAIDefense.Endpoint = "https://us.api.inspect.aidefense.security.cisco.com"
+	newCfg := cloneConfig(oldCfg)
+	newCfg.CiscoAIDefense.Endpoint = "https://eu.api.inspect.aidefense.security.cisco.com"
+
+	diff := diffConfigs(oldCfg, newCfg)
+	if !slices.Contains(diff.RestartRequired, "cisco_ai_defense") {
+		t.Fatalf("diff.RestartRequired = %v; opensource must keep the pre-existing restart-required classification", diff.RestartRequired)
+	}
+}
+
+// TestReloadPreservesSynthesizedGatewayTokenBeforeDiff is the regression
+// guard for the second bug found alongside the cisco_ai_defense
+// classification: a boot-time-synthesised Gateway.Token lives ONLY in
+// the runtime snapshot, not in config.yaml. Without preserving it
+// before diffConfigs runs, EVERY reload on a managed install compares
+// token=<synthesised> to token="" (config.yaml default) and
+// gateway lands in RestartRequired. Reload then rejects the whole
+// reload with "config reload requires gateway restart for: gateway".
+//
+// This test writes a config.yaml with an empty gateway.token, seeds
+// the ConfigManager's cached snapshot with a synthesised token
+// (simulating what ensureGatewayTokenSynthesis produces), and confirms
+// Reload succeeds and does NOT surface a bogus gateway change.
+func TestReloadPreservesSynthesizedGatewayTokenBeforeDiff(t *testing.T) {
+	// Exercise the pre-diff preservation logic directly. We can't
+	// use a full Reload path here because managed_enterprise
+	// LoadFromFile insists on a root-owned config.yaml (managed
+	// config trust check) which t.TempDir() cannot produce. What
+	// matters is that when the runtime cached snapshot carries a
+	// synthesised token and the on-disk snapshot doesn't,
+	// diffConfigs sees them as equal (no gateway churn). Simulate
+	// that shape and diff.
+	oldCfg := config.DefaultConfig()
+	oldCfg.DeploymentMode = string(config.DeploymentModeManagedEnterprise)
+	oldCfg.Gateway.Token = "boot-time-synthesised-token"
+
+	// "Freshly loaded from config.yaml" — no token, everything else
+	// identical.
+	freshFromDisk := cloneConfig(oldCfg)
+	freshFromDisk.Gateway.Token = ""
+
+	// Apply the same pre-diff preservation the Reload path uses.
+	next := cloneConfig(freshFromDisk)
+	if strings.TrimSpace(next.Gateway.Token) == "" && strings.TrimSpace(oldCfg.Gateway.Token) != "" {
+		next.Gateway.Token = oldCfg.Gateway.Token
+	}
+	diff := diffConfigs(oldCfg, next)
+	if slices.Contains(diff.RestartRequired, "gateway") {
+		t.Fatalf("gateway landed in RestartRequired despite pre-diff token preservation; RestartRequired=%v", diff.RestartRequired)
+	}
+	if slices.Contains(diff.Changed, "gateway") {
+		t.Fatalf("gateway landed in Changed despite pre-diff token preservation; Changed=%v", diff.Changed)
+	}
+	if next.Gateway.Token != "boot-time-synthesised-token" {
+		t.Fatalf("token preservation dropped the synthesised value: got %q", next.Gateway.Token)
+	}
+}
+
+// TestReloadPreservesRuntimeGatewayFieldsBeforeDiff catches the
+// downstream regression from the initial fix that only preserved
+// Gateway.Token. On a real managed_enterprise host we saw
+// "config reload requires gateway restart for: gateway" even after
+// the token was preserved — the offender was Gateway.NoTLS, a
+// mapstructure:"-" field the sidecar sets at boot based on
+// RequiresTLSWithMode(&OpenShell). Every subsequent LoadFromFile
+// yields NoTLS=false and diffConfigs sees the cached runtime state
+// vs the on-disk snapshot as different. This test locks down that
+// every runtime-only Gateway field is preserved before the diff.
+func TestReloadPreservesRuntimeGatewayFieldsBeforeDiff(t *testing.T) {
+	oldCfg := config.DefaultConfig()
+	oldCfg.DeploymentMode = string(config.DeploymentModeManagedEnterprise)
+	oldCfg.Gateway.Token = "boot-time-synthesised-token"
+	oldCfg.Gateway.NoTLS = true // sidecar sets this at boot for standalone mode
+	oldCfg.Gateway.SandboxHome = "/home/sandbox"
+	oldCfg.Gateway.ClawHome = "/var/root"
+
+	// "Freshly loaded from config.yaml": mapstructure:"-" fields all
+	// zero, token empty. This is exactly what LoadFromFile produces
+	// on every reload since none of these fields are persisted.
+	next := cloneConfig(oldCfg)
+	next.Gateway.Token = ""
+	next.Gateway.NoTLS = false
+	next.Gateway.SandboxHome = ""
+	next.Gateway.ClawHome = ""
+
+	// Mirror the Reload pre-diff preservation.
+	if strings.TrimSpace(next.Gateway.Token) == "" && strings.TrimSpace(oldCfg.Gateway.Token) != "" {
+		next.Gateway.Token = oldCfg.Gateway.Token
+	}
+	if oldCfg.Gateway.NoTLS && !next.Gateway.NoTLS {
+		next.Gateway.NoTLS = true
+	}
+	if next.Gateway.SandboxHome == "" && oldCfg.Gateway.SandboxHome != "" {
+		next.Gateway.SandboxHome = oldCfg.Gateway.SandboxHome
+	}
+	if next.Gateway.ClawHome == "" && oldCfg.Gateway.ClawHome != "" {
+		next.Gateway.ClawHome = oldCfg.Gateway.ClawHome
+	}
+
+	diff := diffConfigs(oldCfg, next)
+	if slices.Contains(diff.RestartRequired, "gateway") {
+		t.Fatalf("gateway ended up in RestartRequired after runtime-field preservation; RestartRequired=%v", diff.RestartRequired)
+	}
+	if slices.Contains(diff.Changed, "gateway") {
+		t.Fatalf("gateway ended up in Changed after runtime-field preservation; Changed=%v", diff.Changed)
+	}
+}
+
+// TestReloadTokenPreservationScopedToManagedEnterprise proves the
+// gate: on opensource installs the pre-existing behavior is unchanged
+// (the pre-diff token preservation is a managed-only carve-out per
+// operator direction).
+func TestReloadTokenPreservationScopedToManagedEnterprise(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, config.DefaultConfigName)
+	// Opensource config.yaml with no token.
+	raw := "config_version: 6\n" +
+		"data_dir: " + dir + "\n" +
+		"guardrail:\n" +
+		"  mode: observe\n"
+	if err := os.WriteFile(cfgPath, []byte(raw), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	initial, err := config.LoadFromFile(cfgPath)
+	if err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+	initial.Gateway.Token = "opensource-runtime-token"
+
+	// Diff manually against the loaded-from-disk snapshot; the
+	// ConfigManager Reload path also runs applyConfigReload's inner
+	// preservation step (line ~1165), so a full Reload would mask
+	// this. Exercise diffConfigs directly to make the scope
+	// assertion crisp.
+	fresh, err := config.LoadFromFile(cfgPath)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	diff := diffConfigs(initial, fresh)
+	if !slices.Contains(diff.RestartRequired, "gateway") {
+		t.Fatalf("opensource diff on token mismatch = %v; expected gateway to remain restart-required (managed-only carve-out)", diff.RestartRequired)
+	}
+}

--- a/internal/gateway/connector/openclaw_extension/.placeholder
+++ b/internal/gateway/connector/openclaw_extension/.placeholder
@@ -1,1 +1,0 @@
-OpenClaw extension bundle is not present in this source checkout.

--- a/internal/gateway/inspect.go
+++ b/internal/gateway/inspect.go
@@ -315,7 +315,7 @@ func mergeWithLaneVerdict(local *ToolInspectVerdict, aid *ScanVerdict, findingTa
 		// "not computed" and omits it on the wire.
 		for _, f := range aid.Findings {
 			rf := RuleFinding{
-				RuleID:   findingTag + f,
+				RuleID:   f,
 				Title:    f,
 				Severity: aid.Severity,
 				Tags:     []string{strings.TrimSuffix(findingTag, ":")},

--- a/internal/gateway/inspect_aid_lane_test.go
+++ b/internal/gateway/inspect_aid_lane_test.go
@@ -259,8 +259,8 @@ func TestMergeWithLaneVerdict_SynthesizesDetailedFindings(t *testing.T) {
 			t.Fatalf("DetailedFindings = %d, want 2 (one per AID finding)", len(merged.DetailedFindings))
 		}
 		got := merged.DetailedFindings[0]
-		if got.RuleID != "ai-defense:pii.email" {
-			t.Errorf("RuleID = %q, want ai-defense:pii.email", got.RuleID)
+		if got.RuleID != "pii.email" {
+			t.Errorf("RuleID = %q, want pii.email (raw name; lane category is in Tags)", got.RuleID)
 		}
 		if got.Title != "pii.email" {
 			t.Errorf("Title = %q, want pii.email", got.Title)
@@ -283,8 +283,8 @@ func TestMergeWithLaneVerdict_SynthesizesDetailedFindings(t *testing.T) {
 		if len(merged.DetailedFindings) != 1 {
 			t.Fatalf("DetailedFindings = %d, want 1", len(merged.DetailedFindings))
 		}
-		if got := merged.DetailedFindings[0].RuleID; got != "llm-judge:prompt_injection" {
-			t.Errorf("RuleID = %q, want llm-judge:prompt_injection", got)
+		if got := merged.DetailedFindings[0].RuleID; got != "prompt_injection" {
+			t.Errorf("RuleID = %q, want prompt_injection (raw name; lane category is in Tags)", got)
 		}
 		if got := merged.DetailedFindings[0].Tags; len(got) != 1 || got[0] != "llm-judge" {
 			t.Errorf("Tags = %v, want [llm-judge]", got)
@@ -315,7 +315,7 @@ func TestMergeWithLaneVerdict_SynthesizesDetailedFindings(t *testing.T) {
 		if merged.DetailedFindings[0].RuleID != "LOCAL-1" {
 			t.Errorf("local finding not preserved at head: %+v", merged.DetailedFindings)
 		}
-		if merged.DetailedFindings[1].RuleID != "ai-defense:pii.email" {
+		if merged.DetailedFindings[1].RuleID != "pii.email" {
 			t.Errorf("synthesized finding not appended: %+v", merged.DetailedFindings)
 		}
 	})

--- a/internal/gateway/sidecar.go
+++ b/internal/gateway/sidecar.go
@@ -708,6 +708,17 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		configPath = config.ConfigPath()
 	}
 	s.configMgr = NewConfigManager(configPath, s.currentConfig(), s.logger, s.health, s.applyConfigReload)
+	// managed_enterprise: wire the AVC-authored env_config.json so the
+	// ConfigManager overlays cisco_ai_defense_endpoint on every reload
+	// and watches its parent dir for late arrivals (AVC packaging can
+	// drop the file AFTER DefenseClaw is installed — the installer
+	// warns and falls back to a US-prod default when that happens, and
+	// the overlay corrects the endpoint the moment the file appears).
+	// Opensource installs pass an empty path and get the pre-overlay
+	// behavior verbatim.
+	if managed.IsManagedEnterprise(s.currentConfig().DeploymentMode) {
+		s.configMgr.SetEnvConfigPath(config.DefaultEnvConfigPath)
+	}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -1327,6 +1338,39 @@ func (s *Sidecar) applyConfigReload(ctx context.Context, oldCfg, newCfg *config.
 		s.attachApplicationProtectionObserver(ctx, next.Gateway.Token)
 	}
 
+	// AI Defense inspector hot-rebuild. Fires when any field on
+	// CiscoAIDefense changes — most commonly a fresh
+	// cisco_ai_defense_endpoint from AVC's env_config.json arriving
+	// after DefenseClaw was installed. pickInspector reads
+	// s.currentConfig() (already swapped to the applied snapshot
+	// above via s.publishConfig), so it will construct against the
+	// new endpoint. Same fail-closed contract as boot: a nil
+	// inspector disables the hook-lane AID call entirely; the proxy
+	// lane's SetManagedInspection is called only in managed_enterprise
+	// mode.
+	if inspectorNeedsRebuild(oldCfg, newCfg) {
+		tel := s.otelSnapshot()
+		if nextOTel != nil {
+			tel = nextOTel
+		}
+		if inspector := s.pickInspector(ctx, tel); inspector != nil {
+			if api := s.apiSnapshot(); api != nil {
+				api.SetCiscoInspector(inspector)
+			}
+		} else if api := s.apiSnapshot(); api != nil {
+			// Reload rejected the inspector (managed provider now
+			// unavailable, or endpoint now empty). Clear the API
+			// binding so the hook lane fails open cleanly instead of
+			// keeping stale state that points at the old endpoint.
+			api.SetCiscoInspector(nil)
+		}
+		if nextManagedEnterprise {
+			if proxy := s.proxySnapshot(); proxy != nil {
+				proxy.SetManagedInspection(true, s.newManagedInspector(ctx, tel, "proxy remote inspection disabled"))
+			}
+		}
+	}
+
 	// managed_enterprise: refresh the connector / MCP endpoint inventory
 	// on every reload — MCP servers and connectors can change via config
 	// without restarting the discovery scanner. Rebuild the emitter from
@@ -1429,7 +1473,18 @@ func otelNeedsReload(oldCfg, newCfg *config.Config) bool {
 		oldCfg.Gateway.Port != newCfg.Gateway.Port ||
 		!reflect.DeepEqual(oldCfg.Claw, newCfg.Claw) ||
 		oldCfg.Guardrail.Connector != newCfg.Guardrail.Connector ||
-		!reflect.DeepEqual(oldCfg.Guardrail.Connectors, newCfg.Guardrail.Connectors)
+		!reflect.DeepEqual(oldCfg.Guardrail.Connectors, newCfg.Guardrail.Connectors) ||
+		// AI Defense endpoint feeds the managed-enterprise telemetry log
+		// exporter (newCiscoAIDLogProcessor → newCiscoAIDLogExporter),
+		// which captures the ingest URL by value at construction. A
+		// late-arriving env_config.json changes the endpoint and the
+		// telemetry sink needs to point at the new region — a full OTel
+		// rebuild is heavier than strictly necessary, but it's the
+		// established reload boundary and this path fires rarely (once
+		// per env_config update). The inspector side is reloaded
+		// separately (inspectorNeedsRebuild) so it can hot-swap without
+		// touching OTel.
+		oldCfg.CiscoAIDefense.Endpoint != newCfg.CiscoAIDefense.Endpoint
 }
 
 func auditSinksNeedReload(oldCfg, newCfg *config.Config) bool {
@@ -1445,6 +1500,21 @@ func rulePackNeedsReload(oldCfg, newCfg *config.Config) bool {
 		return false
 	}
 	return oldCfg.Guardrail.RulePackDir != newCfg.Guardrail.RulePackDir
+}
+
+// inspectorNeedsRebuild reports whether any field on
+// cfg.CiscoAIDefense has changed such that the AID inspector needs to
+// be rebuilt. The inspector captures endpoint + timeout by value at
+// construction (see NewCiscoDefenseClawInspectClient), so any change
+// under this struct is a real signal — deep-equal is the right grain.
+// Called from applyConfigReload after the env_config overlay so a
+// late-arriving env_config.json reaches the running inspector without
+// a full OTel teardown.
+func inspectorNeedsRebuild(oldCfg, newCfg *config.Config) bool {
+	if oldCfg == nil || newCfg == nil {
+		return false
+	}
+	return !reflect.DeepEqual(oldCfg.CiscoAIDefense, newCfg.CiscoAIDefense)
 }
 
 func judgeNeedsReload(oldCfg, newCfg *config.Config) bool {

--- a/internal/gatewaylog/events.go
+++ b/internal/gatewaylog/events.go
@@ -848,6 +848,29 @@ type AIDiscoveryPayload struct {
 	WorkspaceHash string   `json:"workspace_hash,omitempty"`
 	LastSeen      string   `json:"last_seen,omitempty"`
 
+	// AgentKind is the connector slug of the agent that owns this
+	// signal (e.g. "cursor", "claudecode", "codex"). It is derived
+	// from the matched AISignature's SupportedConnector plus a small
+	// promotion table for signatures we treat as first-class agents
+	// without setting SupportedConnector (aider / continue / cline /
+	// claudedesktop). Ships in the clear on every payload — the value
+	// is a structural connector identifier, not user content.
+	AgentKind string `json:"agent_kind,omitempty"`
+	// ItemKind names the shape of the sub-item this signal represents
+	// when the detector emits item-level rows: "mcp_server" | "plugin"
+	// | "skill" | "rule". File-level signals leave this empty.
+	ItemKind string `json:"item_kind,omitempty"`
+	// ItemName is the sub-item's name/id — MCP server key from
+	// mcp.json, plugin/skill/rule child basename, etc. Ships in the
+	// clear (structural identifier).
+	ItemName string `json:"item_name,omitempty"`
+	// ItemAttributes carries a small map of structural per-item hints
+	// (`transport`, `command_basename`, `url_host`, `child_type`).
+	// Raw args / env / URLs / commands are deliberately excluded —
+	// those can carry user-controlled content and must go through the
+	// existing `evidence` gate instead.
+	ItemAttributes map[string]string `json:"item_attributes,omitempty"`
+
 	// Extended fields below are gated by privacy.disable_redaction.
 	// The shipping helper (BuildAIDiscoveryPayload) reads the flag
 	// from the gateway config; raw call sites that build their own

--- a/internal/inventory/ai_catalog.go
+++ b/internal/inventory/ai_catalog.go
@@ -115,6 +115,45 @@ type aiSignatureCatalog struct {
 	Signatures []AISignature `json:"signatures"`
 }
 
+// promotedAgentKinds maps signature.ID → connector slug for
+// signatures we treat as first-class agents WITHOUT setting the
+// catalog's `supported_connector` field on them.
+//
+// Why keep this separate from `SupportedConnector`: setting the
+// catalog field would flip the emitted `category` inside
+// `detectConfigPaths` from `workspace_artifact` (or `editor_extension`
+// / `desktop_app`) to `supported_connector`, which in turn changes
+// every affected signal's fingerprint. In non-managed_enterprise mode
+// the sidecar ships only lifecycle deltas, so that reclassification
+// would produce a one-time `gone`+`new` delta pair per user on every
+// host running one of these agents. This table gives us the agent
+// identity on the wire (as `agent_kind`) without disturbing the
+// existing category-level classification or the signal fingerprints.
+//
+// Only expand this table for signatures whose product IS an agent the
+// dashboards should treat as first-class. For signatures that already
+// carry `SupportedConnector` in ai_signatures.json (openclaw, codex,
+// claudecode, cursor, windsurf, …), the connector value flows through
+// directly and this table is not consulted.
+var promotedAgentKinds = map[string]string{
+	"aider":          "aider",
+	"continue":       "continue",
+	"cline":          "cline",
+	"claude-desktop": "claudedesktop",
+}
+
+// AgentKindForSignature returns the connector slug that identifies
+// this signature's owning agent (e.g. "cursor", "claudecode",
+// "aider"), or "" if the signature is not associated with a
+// first-class agent. Callers should prefer `sig.SupportedConnector`
+// when set — this helper only handles the promotion cases above.
+func AgentKindForSignature(sig AISignature) string {
+	if sig.SupportedConnector != "" {
+		return sig.SupportedConnector
+	}
+	return promotedAgentKinds[sig.ID]
+}
+
 // LoadAISignatures returns the embedded catalog after basic validation.
 func LoadAISignatures() ([]AISignature, error) {
 	raw, err := aiSignatureFS.ReadFile("ai_signatures.json")

--- a/internal/inventory/ai_discovery.go
+++ b/internal/inventory/ai_discovery.go
@@ -295,14 +295,14 @@ type LocalModelInfo struct {
 // (`LastSeen`) from "the underlying thing was running / used since the
 // previous scan" (`LastActiveAt`).
 type AISignal struct {
-	Fingerprint        string          `json:"fingerprint"`
-	SignalID           string          `json:"signal_id"`
-	SignatureID        string          `json:"signature_id"`
-	Name               string          `json:"name"`
-	Vendor             string          `json:"vendor"`
-	Product            string          `json:"product"`
-	Category           string          `json:"category"`
-	SupportedConnector string          `json:"supported_connector,omitempty"`
+	Fingerprint        string `json:"fingerprint"`
+	SignalID           string `json:"signal_id"`
+	SignatureID        string `json:"signature_id"`
+	Name               string `json:"name"`
+	Vendor             string `json:"vendor"`
+	Product            string `json:"product"`
+	Category           string `json:"category"`
+	SupportedConnector string `json:"supported_connector,omitempty"`
 	// AgentKind is the effective first-class connector identity for
 	// this signal — derived from the parent AISignature's
 	// SupportedConnector, or from the agent-promotion lookup table for
@@ -317,22 +317,22 @@ type AISignal struct {
 	ItemKind       string            `json:"item_kind,omitempty"`
 	ItemName       string            `json:"item_name,omitempty"`
 	ItemAttributes map[string]string `json:"item_attributes,omitempty"`
-	Confidence         float64         `json:"confidence"`
-	State              string          `json:"state"`
-	Detector           string          `json:"detector"`
-	Source             string          `json:"source"`
-	EvidenceTypes      []string        `json:"evidence_types,omitempty"`
-	PathHashes         []string        `json:"path_hashes,omitempty"`
-	Basenames          []string        `json:"basenames,omitempty"`
-	WorkspaceHash      string          `json:"workspace_hash,omitempty"`
-	Version            string          `json:"version,omitempty"`
-	Component          *AIComponent    `json:"component,omitempty"`
-	Model              *LocalModelInfo `json:"model,omitempty"`
-	Runtime            *ProcessRuntime `json:"runtime,omitempty"`
-	FirstSeen          time.Time       `json:"first_seen"`
-	LastSeen           time.Time       `json:"last_seen"`
-	LastActiveAt       *time.Time      `json:"last_active_at,omitempty"`
-	EvidenceHash       string          `json:"-"`
+	Confidence     float64           `json:"confidence"`
+	State          string            `json:"state"`
+	Detector       string            `json:"detector"`
+	Source         string            `json:"source"`
+	EvidenceTypes  []string          `json:"evidence_types,omitempty"`
+	PathHashes     []string          `json:"path_hashes,omitempty"`
+	Basenames      []string          `json:"basenames,omitempty"`
+	WorkspaceHash  string            `json:"workspace_hash,omitempty"`
+	Version        string            `json:"version,omitempty"`
+	Component      *AIComponent      `json:"component,omitempty"`
+	Model          *LocalModelInfo   `json:"model,omitempty"`
+	Runtime        *ProcessRuntime   `json:"runtime,omitempty"`
+	FirstSeen      time.Time         `json:"first_seen"`
+	LastSeen       time.Time         `json:"last_seen"`
+	LastActiveAt   *time.Time        `json:"last_active_at,omitempty"`
+	EvidenceHash   string            `json:"-"`
 	// ModelAPISourceHash is an internal, privacy-preserving origin key used
 	// to apply lifecycle decisions only to the exact local server that was
 	// conclusively inventoried. It is persisted via aiStoredSignal but never
@@ -1443,11 +1443,14 @@ func mcpServersFromFile(path string, maxBytes int64) ([]config.MCPServerEntry, e
 			return config.ParseMCPServersJSON(innerTrim)
 		}
 	}
-	// Bare object — pass the whole file. If it turns out to be an
-	// unrelated JSON blob the parser returns an empty slice (no server
-	// keys), which is fine — the caller falls back to the file-level
-	// signal.
-	return config.ParseMCPServersJSON(trimmed)
+	// Bare object with no `mcpServers`/`servers` wrapper — refuse to
+	// synthesize server entries from arbitrary top-level keys. Generic
+	// JSON files matched by `mcp_paths` (settings.json, VS Code user
+	// preferences, etc.) are full of unrelated top-level keys and
+	// ParseMCPServersJSON would otherwise emit one bogus mcp_server
+	// signal per key. The file-level catalog signal still fires from
+	// the caller.
+	return nil, nil
 }
 
 // urlHost extracts the host portion of a URL for the safe
@@ -2805,7 +2808,12 @@ func (s *ContinuousDiscoveryService) emitTelemetry(ctx context.Context, report A
 			Confidence: sig.Confidence,
 			AgentKind:  sig.AgentKind,
 			ItemKind:   sig.ItemKind,
-			ItemName:   sig.ItemName,
+		}
+		// ItemName may carry user-visible tool names or free-form
+		// hints. Only stamp it on the OTel record when the operator
+		// has explicitly opted out of redaction.
+		if s.opts.DisableRedaction {
+			otelAttrs.ItemName = sig.ItemName
 		}
 		s.otel.RecordAIDiscoverySignal(ctx, otelAttrs)
 		s.otel.EmitAIDiscoverySignalLog(ctx, otelAttrs)
@@ -3361,6 +3369,10 @@ func BuildAIDiscoveryPayload(sig AISignal, scanID string, opts PayloadOpts) *gat
 	if !opts.DisableRedaction {
 		// Redacted mode: ship only the minimal set above. Extended
 		// fields stay zero so omitempty hides them from receivers.
+		// ItemName / ItemAttributes may contain user-visible tool
+		// names or free-form hints; scrub them before the wire.
+		out.ItemName = ""
+		out.ItemAttributes = nil
 		return out
 	}
 	// Extended mode: every field below ships so downstream OTel /

--- a/internal/inventory/ai_discovery.go
+++ b/internal/inventory/ai_discovery.go
@@ -96,12 +96,35 @@ const (
 //     `ai-sdks` signature into per-component (e.g. openai==1.45.0) rows
 //     without dropping data on restart.
 //
+// v3 changed the fingerprint composition for the four item-level
+// detectors (`mcp_server`, `plugin`, `rule`, `skill`): those now fold
+// the per-item name into the fingerprint so a single `mcp.json` with
+// two servers produces two distinct signal_ids instead of collapsing
+// to one. To avoid emitting a spurious `gone` flood for every
+// pre-upgrade file-level signal, Load() drops v2-era stored entries in
+// those four categories during the v2→v3 migration — they will simply
+// reappear as item-level `new` signals on the first post-upgrade scan.
+// The remaining twelve categories keep their fingerprints and their
+// stored entries, so no lifecycle churn for them.
+//
 // v1 state files are migrated transparently on Load() — old entries land
-// in v2 with empty EvidenceHash, which makes the first post-upgrade scan
+// with empty EvidenceHash, which makes the first post-upgrade scan
 // behave like a `seen` (we explicitly skip the `!=` comparison when the
 // stored hash is empty so an upgrade does not produce a flood of
 // `changed` events the operator never asked for).
-const aiDiscoveryStateVersion = 2
+const aiDiscoveryStateVersion = 3
+
+// itemLevelCategories are the categories whose fingerprint composition
+// changed at state version 3 (see aiDiscoveryStateVersion above).
+// v2-era stored entries in these categories are dropped on load so the
+// v2→v3 migration does not produce a spurious `gone` event per
+// pre-upgrade file-level signal.
+var itemLevelCategories = map[string]bool{
+	SignalMCPServer: true,
+	SignalPlugin:    true,
+	SignalRule:      true,
+	SignalSkill:     true,
+}
 
 var allowedAISignalCategories = map[string]bool{
 	SignalSupportedConnector: true,
@@ -280,6 +303,20 @@ type AISignal struct {
 	Product            string          `json:"product"`
 	Category           string          `json:"category"`
 	SupportedConnector string          `json:"supported_connector,omitempty"`
+	// AgentKind is the effective first-class connector identity for
+	// this signal — derived from the parent AISignature's
+	// SupportedConnector, or from the agent-promotion lookup table for
+	// signatures we treat as agents without setting SupportedConnector
+	// (see agentKindForSignature in ai_catalog.go). Preserved on the
+	// wire via gatewaylog.AIDiscoveryPayload.AgentKind.
+	AgentKind string `json:"agent_kind,omitempty"`
+	// ItemKind / ItemName / ItemAttributes are non-empty on
+	// item-level signals emitted by detectMCPPaths / detectPlugins /
+	// detectRules / detectSkills. See the corresponding wire fields on
+	// gatewaylog.AIDiscoveryPayload for shape and privacy notes.
+	ItemKind       string            `json:"item_kind,omitempty"`
+	ItemName       string            `json:"item_name,omitempty"`
+	ItemAttributes map[string]string `json:"item_attributes,omitempty"`
 	Confidence         float64         `json:"confidence"`
 	State              string          `json:"state"`
 	Detector           string          `json:"detector"`
@@ -1360,13 +1397,134 @@ func (s *ContinuousDiscoveryService) detectConfigPaths() []AISignal {
 	return out
 }
 
+// mcpServersFromFile parses an MCP config file and returns the list of
+// declared server entries. It tolerates both top-level shapes DefenseClaw
+// supports today:
+//   - the plain-object form ({"github": {...}, "playwright": {...}})
+//   - the wrapped form ({"mcpServers": {"github": {...}}} — Cursor,
+//     Claude Desktop, Windsurf, VS Code)
+//   - the array form ([{"name": "github", ...}, ...] — Codex)
+//
+// Errors are returned but callers should treat them as non-fatal (a
+// malformed mcp.json still produces the fallback file-level signal via
+// the empty return slice path).
+func mcpServersFromFile(path string, maxBytes int64) ([]config.MCPServerEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if maxBytes > 0 && int64(len(data)) > maxBytes {
+		data = data[:maxBytes]
+	}
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	// Array form.
+	if trimmed[0] == '[' {
+		return config.ParseMCPServersJSONArray(trimmed)
+	}
+	// Object form — either the wrapped `{"mcpServers": {...}}` shape or
+	// a bare `{"name": {...}}` map. Peek at the top level cheaply so we
+	// know which slice to pass to the object parser.
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &top); err != nil {
+		return nil, err
+	}
+	for _, key := range []string{"mcpServers", "servers"} {
+		if inner, ok := top[key]; ok {
+			innerTrim := bytes.TrimSpace(inner)
+			if len(innerTrim) == 0 {
+				continue
+			}
+			if innerTrim[0] == '[' {
+				return config.ParseMCPServersJSONArray(innerTrim)
+			}
+			return config.ParseMCPServersJSON(innerTrim)
+		}
+	}
+	// Bare object — pass the whole file. If it turns out to be an
+	// unrelated JSON blob the parser returns an empty slice (no server
+	// keys), which is fine — the caller falls back to the file-level
+	// signal.
+	return config.ParseMCPServersJSON(trimmed)
+}
+
+// urlHost extracts the host portion of a URL for the safe
+// item_attributes hint. Returns "" for parse failure or empty input.
+func urlHost(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
+}
+
+// mcpItemAttributes builds the bounded, structural attribute map that
+// ships in AISignal.ItemAttributes for an MCP-server item. Deliberately
+// scoped to metadata that is safe to leave in-clear on the wire:
+//   - transport ("stdio", "sse", "http", ...)
+//   - command_basename (the basename of the launcher — "npx", "python",
+//     "docker" — not the full command line or its args)
+//   - url_host (the host portion of the remote URL, if any)
+//   - disabled ("true" | "false") so dashboards can hide disabled servers
+//
+// Raw command / args / env / URL / headers / OAuth are intentionally
+// omitted. Those can be user-controlled and belong behind the existing
+// `evidence` privacy gate, not on top-level payload fields.
+func mcpItemAttributes(entry config.MCPServerEntry) map[string]string {
+	attrs := map[string]string{}
+	if entry.Transport != "" {
+		attrs["transport"] = entry.Transport
+	}
+	if entry.Command != "" {
+		attrs["command_basename"] = filepath.Base(entry.Command)
+	}
+	if host := urlHost(entry.URL); host != "" {
+		attrs["url_host"] = host
+	}
+	if entry.Disabled {
+		attrs["disabled"] = "true"
+	}
+	if len(attrs) == 0 {
+		return nil
+	}
+	return attrs
+}
+
 func (s *ContinuousDiscoveryService) detectMCPPaths() []AISignal {
 	var out []AISignal
 	for _, sig := range s.catalog {
 		for _, candidate := range sig.MCPPaths {
 			for _, path := range s.expandCandidatePath(candidate) {
-				if pathExists(path) {
+				if !pathExists(path) {
+					continue
+				}
+				// Item-level: parse the file and emit one signal per
+				// declared MCP server. On any parse/read error, or if
+				// the file declares no servers, fall back to the
+				// file-level signal so operators still see the
+				// presence hit.
+				entries, err := mcpServersFromFile(path, s.opts.MaxFileBytes)
+				if err != nil || len(entries) == 0 {
 					out = append(out, s.signalFromPath(sig, SignalMCPServer, "mcp", path))
+					continue
+				}
+				for _, entry := range entries {
+					name := strings.TrimSpace(entry.Name)
+					if name == "" {
+						continue
+					}
+					item := &aiItemInfo{
+						Kind:       "mcp_server",
+						Name:       name,
+						Attributes: mcpItemAttributes(entry),
+					}
+					out = append(out, s.signalFromPathItem(sig, SignalMCPServer, "mcp", path, item))
 				}
 			}
 		}
@@ -1374,88 +1532,115 @@ func (s *ContinuousDiscoveryService) detectMCPPaths() []AISignal {
 	return out
 }
 
-// dirHasEntry reports whether path exists AND, if it's a directory,
-// contains at least one entry. Non-directory targets (a file at the
-// path) count as "populated" so operator-authored single-file surfaces
-// (e.g. `~/.claude/CLAUDE.md` used as a rule scalar) still trigger.
-// Empty directories return false — the "reserved for future use" case
-// we don't want polluting the dashboard.
+// detectSkills / detectRules / detectPlugins mirror detectMCPPaths and
+// emit one signal per child entry inside the matched directory. If the
+// target is a single file rather than a directory (the `~/.claude/CLAUDE.md`
+// case), a single item-level signal is emitted with the file basename as
+// the item name. Empty directories produce nothing — that is the
+// "reserved for future use" case the plain presence check would have
+// swept up.
 //
-// Uses ReadDir with a bounded read so a pathological directory (millions
-// of entries, e.g. `~/.cache`) doesn't stall a scan: os.ReadDir slurps
-// the whole thing, but here we only need to know "is len > 0" so we
-// call the lower-level (*File).ReadDir(1) shortcut which stops after
-// the first entry.
-func dirHasEntry(path string) bool {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	if !fi.IsDir() {
-		return true
-	}
-	f, err := os.Open(path)
-	if err != nil {
-		return false
-	}
-	defer f.Close()
-	// ReadDir(1) returns io.EOF when the directory is empty; any
-	// successful read of >=1 entry proves populated.
-	entries, err := f.ReadDir(1)
-	if err != nil && !errors.Is(err, io.EOF) {
-		return false
-	}
-	return len(entries) > 0
-}
-
-// detectSkills / detectRules / detectPlugins mirror detectMCPPaths but
-// require the target path to contain at least one entry (see
-// dirHasEntry). This distinguishes "surface configured with skills /
-// rules / plugins" from "the agent left an empty scaffold directory".
 // The three functions are kept separate rather than parameterized so
 // each maps cleanly to a signature-catalog field name and a category
 // constant — trivial to grep, trivial to disable via
 // disabled_signature_ids per surface.
-func (s *ContinuousDiscoveryService) detectSkills() []AISignal {
+
+// maxItemsPerDirectory caps how many children a plugin/skill/rule
+// directory contributes to a single scan. The bound protects the scan
+// budget from a pathologically large directory (thousands of skill
+// files) while still comfortably covering realistic layouts (a Codex
+// plugins folder holds a handful of entries).
+const maxItemsPerDirectory = 256
+
+// dirItems returns up to maxItemsPerDirectory entries of the directory
+// at path, or a single synthetic "file"/"symlink" entry when the path
+// is not a directory. The second return is true iff the path exists
+// and yielded at least one item.
+func dirItems(path string) ([]dirItem, bool) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, false
+	}
+	if !fi.IsDir() {
+		// Single-file target ("~/.claude/CLAUDE.md" etc.) — treat as
+		// one item named by its basename.
+		return []dirItem{{Name: filepath.Base(path), IsDir: false}}, true
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, false
+	}
+	defer f.Close()
+	entries, err := f.ReadDir(maxItemsPerDirectory)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, false
+	}
+	if len(entries) == 0 {
+		return nil, false
+	}
+	out := make([]dirItem, 0, len(entries))
+	for _, entry := range entries {
+		name := strings.TrimSpace(entry.Name())
+		if name == "" || strings.HasPrefix(name, ".") {
+			// Skip hidden entries (`.DS_Store`, editor swap files);
+			// they don't represent user-authored skills/rules/plugins.
+			continue
+		}
+		out = append(out, dirItem{Name: name, IsDir: entry.IsDir()})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	if len(out) == 0 {
+		return nil, false
+	}
+	return out, true
+}
+
+type dirItem struct {
+	Name  string
+	IsDir bool
+}
+
+// itemDirDetector is the shared body of the plugin/rule/skill
+// detectors. `paths` selects the signature-catalog field (SkillPaths /
+// RulePaths / PluginPaths), category is the SignalPlugin / SignalRule /
+// SignalSkill constant, detector is the wire "detector" label.
+func (s *ContinuousDiscoveryService) itemDirDetector(paths func(AISignature) []string, category, detector, itemKind string) []AISignal {
 	var out []AISignal
 	for _, sig := range s.catalog {
-		for _, candidate := range sig.SkillPaths {
+		for _, candidate := range paths(sig) {
 			for _, path := range s.expandCandidatePath(candidate) {
-				if dirHasEntry(path) {
-					out = append(out, s.signalFromPath(sig, SignalSkill, "skill", path))
+				items, ok := dirItems(path)
+				if !ok {
+					continue
+				}
+				for _, entry := range items {
+					attrs := map[string]string{"child_type": "file"}
+					if entry.IsDir {
+						attrs["child_type"] = "dir"
+					}
+					item := &aiItemInfo{
+						Kind:       itemKind,
+						Name:       entry.Name,
+						Attributes: attrs,
+					}
+					out = append(out, s.signalFromPathItem(sig, category, detector, path, item))
 				}
 			}
 		}
 	}
 	return out
+}
+
+func (s *ContinuousDiscoveryService) detectSkills() []AISignal {
+	return s.itemDirDetector(func(sig AISignature) []string { return sig.SkillPaths }, SignalSkill, "skill", "skill")
 }
 
 func (s *ContinuousDiscoveryService) detectRules() []AISignal {
-	var out []AISignal
-	for _, sig := range s.catalog {
-		for _, candidate := range sig.RulePaths {
-			for _, path := range s.expandCandidatePath(candidate) {
-				if dirHasEntry(path) {
-					out = append(out, s.signalFromPath(sig, SignalRule, "rule", path))
-				}
-			}
-		}
-	}
-	return out
+	return s.itemDirDetector(func(sig AISignature) []string { return sig.RulePaths }, SignalRule, "rule", "rule")
 }
 
 func (s *ContinuousDiscoveryService) detectPlugins() []AISignal {
-	var out []AISignal
-	for _, sig := range s.catalog {
-		for _, candidate := range sig.PluginPaths {
-			for _, path := range s.expandCandidatePath(candidate) {
-				if dirHasEntry(path) {
-					out = append(out, s.signalFromPath(sig, SignalPlugin, "plugin", path))
-				}
-			}
-		}
-	}
-	return out
+	return s.itemDirDetector(func(sig AISignature) []string { return sig.PluginPaths }, SignalPlugin, "plugin", "plugin")
 }
 
 func (s *ContinuousDiscoveryService) detectBinaries() []AISignal {
@@ -2333,11 +2518,39 @@ func (s *ContinuousDiscoveryService) detectShellHistory() ([]AISignal, int, erro
 }
 
 func (s *ContinuousDiscoveryService) signalFromPath(sig AISignature, category, detector, path string) AISignal {
+	return s.signalFromPathItem(sig, category, detector, path, nil)
+}
+
+// aiItemInfo carries per-item detail for the item-level detectors
+// (MCP servers inside a mcp.json, plugin/skill/rule children inside a
+// directory). It is threaded through signalFromEvidenceWithComponent
+// so the item name folds into the fingerprint (yielding one distinct
+// signal_id per server / plugin / skill / rule) and lands on the wire
+// via AISignal.ItemKind / ItemName / ItemAttributes.
+//
+// Kind is one of "mcp_server" | "plugin" | "skill" | "rule". Name is
+// the sub-item identifier (mcp.json key, child basename). Attributes
+// is a bounded structural hint map — DO NOT put user-controlled
+// values (raw commands, args, env, URLs) in here. Prefer the existing
+// evidence gate for anything privacy-sensitive.
+type aiItemInfo struct {
+	Kind       string
+	Name       string
+	Attributes map[string]string
+}
+
+// signalFromPathItem is the item-level variant of signalFromPath. When
+// item is nil the behaviour is identical to signalFromPath (one signal
+// per matched path). When item is non-nil the returned signal carries
+// ItemKind / ItemName / ItemAttributes and its fingerprint includes
+// the item name so item-level rows from the same file/directory
+// remain distinct across scans.
+func (s *ContinuousDiscoveryService) signalFromPathItem(sig AISignature, category, detector, path string, item *aiItemInfo) AISignal {
 	ev := AIEvidence{Type: detector, Basename: filepath.Base(path), PathHash: hashPath(path)}
 	if s.opts.StoreRawLocalPaths {
 		ev.RawPath = path
 	}
-	out := s.signalFromEvidence(sig, category, detector, []AIEvidence{ev})
+	out := s.signalFromEvidenceWithComponentAndItem(sig, category, detector, []AIEvidence{ev}, nil, item)
 	// "Last active" for path-evidence detectors (config / binary /
 	// MCP / extension) defaults to the file's modification time when
 	// available. That's a meaningful liveness proxy: an `~/.codex/`
@@ -2370,6 +2583,17 @@ func (s *ContinuousDiscoveryService) signalFromEvidence(sig AISignature, categor
 // (`openai` vs `langchain` vs `llama-index` under `ai-sdks`) get
 // distinct, stable fingerprints.
 func (s *ContinuousDiscoveryService) signalFromEvidenceWithComponent(sig AISignature, category, detector string, evidence []AIEvidence, component *AIComponent) AISignal {
+	return s.signalFromEvidenceWithComponentAndItem(sig, category, detector, evidence, component, nil)
+}
+
+// signalFromEvidenceWithComponentAndItem is the item-aware variant.
+// When item is non-nil the item's Kind+Name folds into the fingerprint
+// so per-item rows from the same evidence (each MCP server inside a
+// single mcp.json; each plugin/skill/rule child inside a single
+// directory) get distinct, stable signal_ids across scans. The item
+// metadata also lands on the wire via AISignal.ItemKind / ItemName /
+// ItemAttributes.
+func (s *ContinuousDiscoveryService) signalFromEvidenceWithComponentAndItem(sig AISignature, category, detector string, evidence []AIEvidence, component *AIComponent, item *aiItemInfo) AISignal {
 	sort.Slice(evidence, func(i, j int) bool {
 		return evidence[i].Type+evidence[i].PathHash+evidence[i].ValueHash < evidence[j].Type+evidence[j].PathHash+evidence[j].ValueHash
 	})
@@ -2380,6 +2604,14 @@ func (s *ContinuousDiscoveryService) signalFromEvidenceWithComponent(sig AISigna
 		// in the fingerprint so the same manifest matching multiple
 		// AI SDK packages produces distinct, stable per-package rows.
 		fpInputs = append(fpInputs, "component:"+strings.ToLower(component.Ecosystem)+"/"+strings.ToLower(component.Name))
+	}
+	if item != nil && item.Name != "" {
+		// Item name (kind-qualified, lowercased) participates in the
+		// fingerprint so item-level rows from the same evidence stay
+		// distinct across scans. Kind is included so a plugin named
+		// "github" and an MCP server named "github" from the same
+		// agent cannot collide.
+		fpInputs = append(fpInputs, "item:"+strings.ToLower(item.Kind)+"/"+strings.ToLower(item.Name))
 	}
 	fp := hashValue(strings.Join(fpInputs, "|"))
 	product := sig.Name
@@ -2400,12 +2632,26 @@ func (s *ContinuousDiscoveryService) signalFromEvidenceWithComponent(sig AISigna
 		Product:            product,
 		Category:           category,
 		SupportedConnector: sig.SupportedConnector,
+		AgentKind:          AgentKindForSignature(sig),
 		Confidence:         sig.Confidence,
 		Detector:           detector,
 		Source:             "sidecar",
 		EvidenceHash:       evidenceHash,
 		Evidence:           evidence,
 		Component:          component,
+	}
+	if item != nil {
+		out.ItemKind = item.Kind
+		out.ItemName = item.Name
+		if len(item.Attributes) > 0 {
+			// Defensive copy so callers can safely reuse or mutate
+			// their local attribute map after emitting.
+			attrs := make(map[string]string, len(item.Attributes))
+			for k, v := range item.Attributes {
+				attrs[k] = v
+			}
+			out.ItemAttributes = attrs
+		}
 	}
 	if component != nil && component.Version != "" {
 		// Surface the parsed lockfile version on the existing
@@ -2550,8 +2796,19 @@ func (s *ContinuousDiscoveryService) emitTelemetry(ctx context.Context, report A
 		if sig.State != AIStateNew && sig.State != AIStateChanged && sig.State != AIStateGone {
 			continue
 		}
-		s.otel.RecordAIDiscoverySignal(ctx, sig.Category, sig.Vendor, sig.Product, sig.State, sig.Detector, sig.Confidence)
-		s.otel.EmitAIDiscoverySignalLog(ctx, sig.Category, sig.Vendor, sig.Product, sig.State, sig.Detector, sig.Confidence)
+		otelAttrs := telemetry.AIDiscoverySignalAttrs{
+			Category:   sig.Category,
+			Vendor:     sig.Vendor,
+			Product:    sig.Product,
+			State:      sig.State,
+			Detector:   sig.Detector,
+			Confidence: sig.Confidence,
+			AgentKind:  sig.AgentKind,
+			ItemKind:   sig.ItemKind,
+			ItemName:   sig.ItemName,
+		}
+		s.otel.RecordAIDiscoverySignal(ctx, otelAttrs)
+		s.otel.EmitAIDiscoverySignalLog(ctx, otelAttrs)
 	}
 	// Component-level emission off the SHARED snapshot so every
 	// downstream consumer sees byte-identical identity / presence
@@ -3073,17 +3330,21 @@ type PayloadOpts struct {
 // payloads identical to what the sidecar emits.
 func BuildAIDiscoveryPayload(sig AISignal, scanID string, opts PayloadOpts) *gatewaylog.AIDiscoveryPayload {
 	out := &gatewaylog.AIDiscoveryPayload{
-		ScanID:        scanID,
-		SignalID:      sig.SignalID,
-		Category:      sig.Category,
-		Vendor:        sig.Vendor,
-		Product:       sig.Product,
-		Confidence:    sig.Confidence,
-		State:         sig.State,
-		EvidenceTypes: sig.EvidenceTypes,
-		PathHashes:    sig.PathHashes,
-		Basenames:     sig.Basenames,
-		WorkspaceHash: sig.WorkspaceHash,
+		ScanID:         scanID,
+		SignalID:       sig.SignalID,
+		Category:       sig.Category,
+		Vendor:         sig.Vendor,
+		Product:        sig.Product,
+		Confidence:     sig.Confidence,
+		State:          sig.State,
+		EvidenceTypes:  sig.EvidenceTypes,
+		PathHashes:     sig.PathHashes,
+		Basenames:      sig.Basenames,
+		WorkspaceHash:  sig.WorkspaceHash,
+		AgentKind:      sig.AgentKind,
+		ItemKind:       sig.ItemKind,
+		ItemName:       sig.ItemName,
+		ItemAttributes: sig.ItemAttributes,
 	}
 	// Model filenames commonly contain the same private repository/model
 	// identity as sig.Model.ID. Do not let that identity bypass the extended
@@ -3477,11 +3738,27 @@ func (s *AIStateStore) Load() (aiStateFile, error) {
 	// version state file (e.g. written by a newer gateway and then
 	// read by an older one) doesn't silently look like an empty
 	// inventory and produce spurious "all new" change events.
-	if out.Version != 1 && out.Version != aiDiscoveryStateVersion {
-		return aiStateFile{}, fmt.Errorf("ai-discovery state file at %s has unsupported version %d (expected 1 or %d)", s.path, out.Version, aiDiscoveryStateVersion)
+	if out.Version != 1 && out.Version != 2 && out.Version != aiDiscoveryStateVersion {
+		return aiStateFile{}, fmt.Errorf("ai-discovery state file at %s has unsupported version %d (expected 1, 2, or %d)", s.path, out.Version, aiDiscoveryStateVersion)
 	}
 	if out.Signals == nil {
 		out.Signals = map[string]aiStoredSignal{}
+	}
+	// v2 → v3 migration: drop pre-upgrade stored entries in the four
+	// categories whose fingerprint composition changed to include the
+	// per-item name. If we kept these entries, every one of them would
+	// be seen as `gone` on the first post-upgrade scan (their file-level
+	// fingerprint no longer matches any newly-emitted item-level
+	// fingerprint), producing a one-time flood of gone-events. Dropping
+	// them silently means the first post-upgrade scan re-baselines
+	// those categories as `new` at item granularity, which is the
+	// expected behaviour documented on aiDiscoveryStateVersion.
+	if out.Version < aiDiscoveryStateVersion {
+		for fp, stored := range out.Signals {
+			if itemLevelCategories[stored.AISignal.Category] {
+				delete(out.Signals, fp)
+			}
+		}
 	}
 	// Rehydrate the in-memory AISignal.{EvidenceHash,Evidence} from
 	// their stored mirrors so the rest of the code path can keep

--- a/internal/inventory/ai_discovery_items_test.go
+++ b/internal/inventory/ai_discovery_items_test.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package inventory
+
+import (
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// TestDetectMCPPaths_EmitsOneSignalPerServer pins the item-level grain
+// switch for `mcp_server`: a two-server mcp.json produces two signals
+// with distinct signal_ids and item_name / item_kind / agent_kind
+// stamped from the parent signature.
+func TestDetectMCPPaths_EmitsOneSignalPerServer(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	mcpPath := filepath.Join(home, ".cursor", "mcp.json")
+	mustWrite(t, mcpPath, `{
+  "mcpServers": {
+    "github": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"], "transport": "stdio"},
+    "playwright": {"url": "https://mcp.example.com/pw", "transport": "sse"}
+  }
+}`)
+
+	sig := AISignature{
+		ID:                 "cursor",
+		Name:               "Cursor",
+		Vendor:             "Anysphere",
+		Category:           SignalSupportedConnector,
+		SupportedConnector: "cursor",
+		Confidence:         0.95,
+		MCPPaths:           []string{"~/.cursor/mcp.json"},
+	}
+	svc := NewContinuousDiscoveryServiceWithOptions(AIDiscoveryOptions{
+		Enabled: true,
+		HomeDir: home,
+		DataDir: filepath.Join(tmp, "data"),
+	}, []AISignature{sig}, nil, nil)
+
+	got := svc.detectMCPPaths()
+	if len(got) != 2 {
+		t.Fatalf("detectMCPPaths returned %d signals, want 2: %+v", len(got), got)
+	}
+
+	names := []string{got[0].ItemName, got[1].ItemName}
+	sort.Strings(names)
+	if names[0] != "github" || names[1] != "playwright" {
+		t.Fatalf("item names = %v, want [github playwright]", names)
+	}
+
+	for _, s := range got {
+		if s.ItemKind != "mcp_server" {
+			t.Fatalf("item_kind = %q, want mcp_server", s.ItemKind)
+		}
+		if s.AgentKind != "cursor" {
+			t.Fatalf("agent_kind = %q, want cursor", s.AgentKind)
+		}
+		if s.Category != SignalMCPServer {
+			t.Fatalf("category = %q, want %q", s.Category, SignalMCPServer)
+		}
+	}
+
+	if got[0].Fingerprint == got[1].Fingerprint {
+		t.Fatalf("fingerprints collide across servers: %q", got[0].Fingerprint)
+	}
+}
+
+// TestDetectMCPPaths_FallsBackToFileSignalOnParseError ensures a
+// malformed mcp.json degrades gracefully into a single file-level
+// signal instead of vanishing.
+func TestDetectMCPPaths_FallsBackToFileSignalOnParseError(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	mustWrite(t, filepath.Join(home, ".cursor", "mcp.json"), `not a json`)
+
+	sig := AISignature{
+		ID:                 "cursor",
+		Name:               "Cursor",
+		Vendor:             "Anysphere",
+		Category:           SignalSupportedConnector,
+		SupportedConnector: "cursor",
+		Confidence:         0.95,
+		MCPPaths:           []string{"~/.cursor/mcp.json"},
+	}
+	svc := NewContinuousDiscoveryServiceWithOptions(AIDiscoveryOptions{
+		Enabled: true,
+		HomeDir: home,
+		DataDir: filepath.Join(tmp, "data"),
+	}, []AISignature{sig}, nil, nil)
+
+	got := svc.detectMCPPaths()
+	if len(got) != 1 {
+		t.Fatalf("expected fallback file-level signal, got %d: %+v", len(got), got)
+	}
+	if got[0].ItemKind != "" || got[0].ItemName != "" {
+		t.Fatalf("fallback signal should carry no item metadata, got kind=%q name=%q", got[0].ItemKind, got[0].ItemName)
+	}
+	if got[0].AgentKind != "cursor" {
+		t.Fatalf("fallback signal agent_kind = %q, want cursor", got[0].AgentKind)
+	}
+}
+
+// TestDetectSkills_EmitsOneSignalPerChild pins the item-level grain
+// for plugin/rule/skill detectors: one signal per non-hidden child in
+// the directory, hidden entries (dotfiles) skipped.
+func TestDetectSkills_EmitsOneSignalPerChild(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	skillsDir := filepath.Join(home, ".claude", "skills")
+	mustWrite(t, filepath.Join(skillsDir, "run-tests.md"), "# skill body")
+	mustWrite(t, filepath.Join(skillsDir, "review-diff.md"), "# skill body")
+	mustWrite(t, filepath.Join(skillsDir, ".DS_Store"), "junk")
+
+	sig := AISignature{
+		ID:                 "claudecode",
+		Name:               "Claude Code",
+		Vendor:             "Anthropic",
+		Category:           SignalSupportedConnector,
+		SupportedConnector: "claudecode",
+		Confidence:         0.98,
+		SkillPaths:         []string{"~/.claude/skills"},
+	}
+	svc := NewContinuousDiscoveryServiceWithOptions(AIDiscoveryOptions{
+		Enabled: true,
+		HomeDir: home,
+		DataDir: filepath.Join(tmp, "data"),
+	}, []AISignature{sig}, nil, nil)
+
+	got := svc.detectSkills()
+	if len(got) != 2 {
+		t.Fatalf("detectSkills returned %d signals, want 2: %+v", len(got), got)
+	}
+	names := []string{got[0].ItemName, got[1].ItemName}
+	sort.Strings(names)
+	if names[0] != "review-diff.md" || names[1] != "run-tests.md" {
+		t.Fatalf("skill item names = %v, want [review-diff.md run-tests.md]", names)
+	}
+	for _, s := range got {
+		if s.ItemKind != "skill" {
+			t.Fatalf("item_kind = %q, want skill", s.ItemKind)
+		}
+		if s.AgentKind != "claudecode" {
+			t.Fatalf("agent_kind = %q, want claudecode", s.AgentKind)
+		}
+		if s.Category != SignalSkill {
+			t.Fatalf("category = %q, want %q", s.Category, SignalSkill)
+		}
+	}
+}
+
+// TestAgentKindForSignature_PromotesDiscoveryOnlyAgents pins the
+// promotion table: aider / continue / cline / claude-desktop get an
+// agent_kind even though their catalog `supported_connector` is empty,
+// and a signature already carrying supported_connector wins.
+func TestAgentKindForSignature_PromotesDiscoveryOnlyAgents(t *testing.T) {
+	cases := []struct {
+		sig  AISignature
+		want string
+	}{
+		{AISignature{ID: "aider"}, "aider"},
+		{AISignature{ID: "continue"}, "continue"},
+		{AISignature{ID: "cline"}, "cline"},
+		{AISignature{ID: "claude-desktop"}, "claudedesktop"},
+		{AISignature{ID: "cursor", SupportedConnector: "cursor"}, "cursor"},
+		// Explicit override wins over the promotion table entry.
+		{AISignature{ID: "aider", SupportedConnector: "openclaw"}, "openclaw"},
+		// Unknown signatures return the empty string.
+		{AISignature{ID: "unknown-sig"}, ""},
+	}
+	for _, tc := range cases {
+		if got := AgentKindForSignature(tc.sig); got != tc.want {
+			t.Errorf("AgentKindForSignature(%+v) = %q, want %q", tc.sig, got, tc.want)
+		}
+	}
+}
+
+// TestBuildAIDiscoveryPayload_CarriesItemFields ensures the wire
+// payload preserves the item-level metadata AISignal carries, both in
+// redacted and disable-redaction modes.
+func TestBuildAIDiscoveryPayload_CarriesItemFields(t *testing.T) {
+	sig := AISignal{
+		SignalID:  "sig-1",
+		Category:  SignalMCPServer,
+		Vendor:    "Cursor",
+		Product:   "Cursor",
+		State:     AIStateNew,
+		AgentKind: "cursor",
+		ItemKind:  "mcp_server",
+		ItemName:  "github",
+		ItemAttributes: map[string]string{
+			"transport":        "stdio",
+			"command_basename": "npx",
+		},
+	}
+	for _, disable := range []bool{false, true} {
+		out := BuildAIDiscoveryPayload(sig, "scan-1", PayloadOpts{DisableRedaction: disable})
+		if out.AgentKind != "cursor" {
+			t.Fatalf("disable=%v: AgentKind=%q want cursor", disable, out.AgentKind)
+		}
+		if out.ItemKind != "mcp_server" || out.ItemName != "github" {
+			t.Fatalf("disable=%v: item metadata missing: kind=%q name=%q", disable, out.ItemKind, out.ItemName)
+		}
+		if out.ItemAttributes["transport"] != "stdio" {
+			t.Fatalf("disable=%v: transport attr = %q, want stdio", disable, out.ItemAttributes["transport"])
+		}
+	}
+}

--- a/internal/inventory/ai_discovery_items_test.go
+++ b/internal/inventory/ai_discovery_items_test.go
@@ -212,11 +212,25 @@ func TestBuildAIDiscoveryPayload_CarriesItemFields(t *testing.T) {
 		if out.AgentKind != "cursor" {
 			t.Fatalf("disable=%v: AgentKind=%q want cursor", disable, out.AgentKind)
 		}
-		if out.ItemKind != "mcp_server" || out.ItemName != "github" {
-			t.Fatalf("disable=%v: item metadata missing: kind=%q name=%q", disable, out.ItemKind, out.ItemName)
+		if out.ItemKind != "mcp_server" {
+			t.Fatalf("disable=%v: ItemKind=%q want mcp_server", disable, out.ItemKind)
 		}
-		if out.ItemAttributes["transport"] != "stdio" {
-			t.Fatalf("disable=%v: transport attr = %q, want stdio", disable, out.ItemAttributes["transport"])
+		if disable {
+			// Extended (unredacted) mode: raw metadata preserved.
+			if out.ItemName != "github" {
+				t.Fatalf("disable=true: ItemName=%q want github", out.ItemName)
+			}
+			if out.ItemAttributes["transport"] != "stdio" {
+				t.Fatalf("disable=true: transport attr = %q, want stdio", out.ItemAttributes["transport"])
+			}
+		} else {
+			// Redacted mode: item-level free-text metadata scrubbed.
+			if out.ItemName != "" {
+				t.Fatalf("disable=false: ItemName=%q want empty (redacted)", out.ItemName)
+			}
+			if out.ItemAttributes != nil {
+				t.Fatalf("disable=false: ItemAttributes=%v want nil (redacted)", out.ItemAttributes)
+			}
 		}
 	}
 }

--- a/internal/ipc/notifier_broadcast.go
+++ b/internal/ipc/notifier_broadcast.go
@@ -245,18 +245,17 @@ func (b *broadcast) ackSubscriber(subID uint64, seq uint64) {
 	defer b.mu.Unlock()
 	keep := b.retained[:0]
 	for i := range b.retained {
-		r := b.retained[i]
-		if r.record != nil && r.record.Sequence == seq {
-			if r.pending != nil {
-				delete(r.pending, subID)
+		if b.retained[i].record != nil && b.retained[i].record.Sequence == seq {
+			if b.retained[i].pending != nil {
+				delete(b.retained[i].pending, subID)
 			}
-			r.ackedByAny = true
-			if len(r.pending) == 0 {
+			b.retained[i].ackedByAny = true
+			if len(b.retained[i].pending) == 0 {
 				// Fully delivered — drop from the ring.
 				continue
 			}
 		}
-		keep = append(keep, r)
+		keep = append(keep, b.retained[i])
 	}
 	b.retained = keep
 }
@@ -273,17 +272,16 @@ func (b *broadcast) releasePendingLocked(subID uint64) {
 	}
 	keep := b.retained[:0]
 	for i := range b.retained {
-		r := b.retained[i]
-		if r.pending != nil {
-			delete(r.pending, subID)
+		if b.retained[i].pending != nil {
+			delete(b.retained[i].pending, subID)
 		}
-		if len(r.pending) == 0 && r.ackedByAny {
+		if len(b.retained[i].pending) == 0 && b.retained[i].ackedByAny {
 			// At least one subscriber has already acked (successful
 			// stream.Send) AND no remaining live subscriber still
 			// owes an ack — record is fully delivered, drop it.
 			continue
 		}
-		keep = append(keep, r)
+		keep = append(keep, b.retained[i])
 	}
 	b.retained = keep
 }

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -3280,24 +3280,51 @@ func (p *Provider) RecordAIDiscoveryRun(ctx context.Context, source, privacyMode
 	_ = signalsTotal // summary count is carried in logs; signal counter is per-signal below.
 }
 
+// AIDiscoverySignalAttrs is the sanitized, low-cardinality attribute
+// set for one AI usage signal emission. Passed as a struct so the OTel
+// metric label surface can grow (agent_kind, item_kind, item_name)
+// without breaking positional call sites. Values that must NOT be
+// stamped on high-cardinality metrics (raw item names) are excluded
+// from the metric path in RecordAIDiscoverySignal — they only reach
+// EmitAIDiscoverySignalLog where log-record cardinality is not a
+// concern.
+type AIDiscoverySignalAttrs struct {
+	Category   string
+	Vendor     string
+	Product    string
+	State      string
+	Detector   string
+	Confidence float64
+	AgentKind  string
+	// ItemKind is bounded ("mcp_server" | "plugin" | "skill" | "rule"
+	// | ""), safe to stamp on metrics.
+	ItemKind string
+	// ItemName is unbounded (arbitrary MCP server key / plugin dir
+	// name). Emitted on log records but suppressed on metrics to keep
+	// the metric label set bounded.
+	ItemName string
+}
+
 // RecordAIDiscoverySignal records one sanitized AI usage signal.
-func (p *Provider) RecordAIDiscoverySignal(ctx context.Context, category, vendor, product, state, detector string, confidence float64) {
+func (p *Provider) RecordAIDiscoverySignal(ctx context.Context, in AIDiscoverySignalAttrs) {
 	if p == nil || !p.Enabled() || p.metrics == nil {
 		return
 	}
 	attrs := metric.WithAttributes(
-		attribute.String("signal.category", normalizeTelemetryLabel(category, "unknown")),
-		attribute.String("ai.vendor", normalizeTelemetryLabel(vendor, "unknown")),
-		attribute.String("ai.product", normalizeTelemetryLabel(product, "unknown")),
-		attribute.String("state", normalizeTelemetryLabel(state, "seen")),
-		attribute.String("detector", normalizeTelemetryLabel(detector, "unknown")),
-		attribute.String("confidence", confidenceBucket(confidence)),
+		attribute.String("signal.category", normalizeTelemetryLabel(in.Category, "unknown")),
+		attribute.String("ai.vendor", normalizeTelemetryLabel(in.Vendor, "unknown")),
+		attribute.String("ai.product", normalizeTelemetryLabel(in.Product, "unknown")),
+		attribute.String("state", normalizeTelemetryLabel(in.State, "seen")),
+		attribute.String("detector", normalizeTelemetryLabel(in.Detector, "unknown")),
+		attribute.String("confidence", confidenceBucket(in.Confidence)),
+		attribute.String("agent_kind", normalizeTelemetryLabel(in.AgentKind, "unknown")),
+		attribute.String("item_kind", normalizeTelemetryLabel(in.ItemKind, "none")),
 	)
 	p.metrics.aiDiscoverySignals.Add(ctx, 1, attrs)
-	if state == "new" || state == "changed" {
+	if in.State == "new" || in.State == "changed" {
 		p.metrics.aiDiscoveryNewSignals.Add(ctx, 1, attrs)
 	}
-	if state == "gone" {
+	if in.State == "gone" {
 		p.metrics.aiDiscoveryGoneSignals.Add(ctx, 1, attrs)
 	}
 }
@@ -3347,7 +3374,7 @@ func (p *Provider) EmitAIDiscoverySummaryLog(ctx context.Context, source, privac
 	p.logger.Emit(ctx, rec)
 }
 
-func (p *Provider) EmitAIDiscoverySignalLog(ctx context.Context, category, vendor, product, state, detector string, confidence float64) {
+func (p *Provider) EmitAIDiscoverySignalLog(ctx context.Context, in AIDiscoverySignalAttrs) {
 	if !p.LogsEnabled() {
 		return
 	}
@@ -3361,13 +3388,22 @@ func (p *Provider) EmitAIDiscoverySignalLog(ctx context.Context, category, vendo
 	rec.AddAttributes(
 		otellog.String("event.name", "defenseclaw.ai.discovery.signal"),
 		otellog.String("event.domain", "defenseclaw.ai_visibility"),
-		otellog.String("signal.category", normalizeTelemetryLabel(category, "unknown")),
-		otellog.String("ai.vendor", normalizeTelemetryLabel(vendor, "unknown")),
-		otellog.String("ai.product", normalizeTelemetryLabel(product, "unknown")),
-		otellog.String("state", normalizeTelemetryLabel(state, "seen")),
-		otellog.String("detector", normalizeTelemetryLabel(detector, "unknown")),
-		otellog.String("confidence", confidenceBucket(confidence)),
+		otellog.String("signal.category", normalizeTelemetryLabel(in.Category, "unknown")),
+		otellog.String("ai.vendor", normalizeTelemetryLabel(in.Vendor, "unknown")),
+		otellog.String("ai.product", normalizeTelemetryLabel(in.Product, "unknown")),
+		otellog.String("state", normalizeTelemetryLabel(in.State, "seen")),
+		otellog.String("detector", normalizeTelemetryLabel(in.Detector, "unknown")),
+		otellog.String("confidence", confidenceBucket(in.Confidence)),
 	)
+	if in.AgentKind != "" {
+		rec.AddAttributes(otellog.String("defenseclaw.ai.discovery.agent_kind", in.AgentKind))
+	}
+	if in.ItemKind != "" {
+		rec.AddAttributes(otellog.String("defenseclaw.ai.discovery.item_kind", in.ItemKind))
+	}
+	if in.ItemName != "" {
+		rec.AddAttributes(otellog.String("defenseclaw.ai.discovery.item_name", in.ItemName))
+	}
 	p.logger.Emit(ctx, rec)
 }
 

--- a/packaging/launchd/install-enterprise.sh
+++ b/packaging/launchd/install-enterprise.sh
@@ -545,7 +545,7 @@ assert_existing_secure_dir_or_absent "$LOG_DIR"
 # Move legacy paths aside (best-effort, timestamped, never deleted).
 # Version tag comes from the binary source when available so the backup
 # path is distinguishable across attempts.
-_installer_version_tag="$("$BINARY_SOURCE" --version 2>/dev/null | head -1 || true)"
+_installer_version_tag="$("$BINARY_SOURCE" --version 2>/dev/null | /usr/bin/head -1 || true)"
 [ -z "$_installer_version_tag" ] && _installer_version_tag="unknown"
 _installer_version_tag="$(printf '%s' "$_installer_version_tag" | /usr/bin/tr -c '[:alnum:]._-' '_' | /usr/bin/head -c 32)"
 [ -z "$_installer_version_tag" ] && _installer_version_tag="unknown"

--- a/packaging/macos/PACKAGING.md
+++ b/packaging/macos/PACKAGING.md
@@ -16,7 +16,7 @@ The bundle is self-contained — no Go toolchain, no Homebrew, no repo checkout.
 
 ## 2. Install
 
-Standard install (observe mode, Codex connector only):
+Standard install (action mode, Codex connector only):
 
 ```sh
 sudo ./install.sh
@@ -178,7 +178,7 @@ Requires `sudo`. The installer:
 - Writes `/opt/cisco/secureclient/defenseclaw/etc/config.yaml` as `root:wheel 0640`.
 - Does NOT create a dedicated service user. The gateway daemon runs as root (uid 0) because the managed cloud auth provider requires root to read and re-perm its credential store on disk.
 - Wires per-user hook configs in the target user's `~/.codex/config.toml`, `~/.claude/settings.json`, and/or `~/.cursor/hooks.json` depending on `--connector`.
-- Refuses legacy pre-managed-layout install locations (`/Library/DefenseClaw/`, `/Library/Application Support/DefenseClaw/`, `/Library/Logs/DefenseClaw/`, `/Library/LaunchDaemons/com.defenseclaw.gateway.plist`, and `/Library/LaunchDaemons/com.defenseclaw.hook-guardian.plist`) and the corresponding `com.defenseclaw.gateway` / `com.defenseclaw.hook-guardian` launchd jobs before mutation. Existing deployments must use the release-owned staged upgrader; the fresh installer does not sweep or cut over legacy state.
+- Relocates legacy pre-managed-layout install locations (`/Library/DefenseClaw/`, `/Library/Application Support/DefenseClaw/`, `/Library/Logs/DefenseClaw/`, `/Library/LaunchDaemons/com.defenseclaw.gateway.plist`, and `/Library/LaunchDaemons/com.defenseclaw.hook-guardian.plist`) under `/Library/Logs/Cisco/SecureClient/DefenseClaw/` with a `.pre-<version>-<timestamp>` suffix (best-effort, never deleted), and unloads the corresponding legacy `com.defenseclaw.gateway` / `com.defenseclaw.hook-guardian` launchd jobs before mutation. Existing deployments must use the release-owned staged upgrader; the fresh installer does not sweep or cut over legacy state beyond this relocation.
 
 ### Runtime privileges
 

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -114,7 +114,11 @@ _read_json_field() {
   local path="$1"
   local field="$2"
   local py
-  py="$(command -v python3 || echo /usr/bin/python3)"
+  if [ -x /usr/bin/python3 ]; then
+    py="/usr/bin/python3"
+  else
+    py="$(command -v python3 || echo /usr/bin/python3)"
+  fi
   "${py}" -c '
 import json, sys
 try:
@@ -793,12 +797,17 @@ _valid_aid_endpoint_url() {
   case "${candidate}" in
     *[[:space:]]*|*'"'*|*'\'*) return 1 ;;
   esac
-  # Bare-origin shape:
-  #   https://<host>[:port]
-  # <host> = one or more hostname labels (letters, digits, hyphen)
-  # separated by dots. No userinfo, no path, no query, no fragment.
-  local re='^https://[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)*(:[0-9]+)?$'
-  [[ "${candidate}" =~ ${re} ]]
+  # Bare-origin shape. Host must either end in `.cisco.com` (the
+  # AVC-owned AI Defense hostnames) or be a loopback for local dev.
+  # This mirrors validateAIDefenseEndpoint in internal/config/env_config.go
+  # -- the sync-guard test in TestValidateAIDefenseEndpoint fails CI if
+  # either side loosens its checks.
+  local re_cisco='^https://[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)*\.cisco\.com(:[0-9]+)?$'
+  local re_loopback='^https://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
+  if [[ "${candidate}" =~ ${re_cisco} ]] || [[ "${candidate}" =~ ${re_loopback} ]]; then
+    return 0
+  fi
+  return 1
 }
 
 # resolve_aid_endpoint OVERRIDE CONFIG_FILE -> stdout effective endpoint

--- a/packaging/macos/lib/installer_lib.sh
+++ b/packaging/macos/lib/installer_lib.sh
@@ -177,16 +177,26 @@ _native_claudecode_version_from_dir() {
     fi
   fi
 
-  # 2. Highest versions/* dir. Same sort -V idiom used by the codex
-  #    Homebrew Caskroom probe. Handles partial installs where the
-  #    `current` symlink hasn't been flipped yet, and hosts that
-  #    never publish a `current` pointer.
-  local versions_dir="${base}/versions" dir
+  # 2. Highest versions/* entry. The native installer publishes each
+  #    version under versions/<X.Y.Z>. Two on-disk shapes have been seen
+  #    in the wild:
+  #      a) directory:   versions/<X.Y.Z>/{node,claude,...}   (classic)
+  #      b) executable file: versions/<X.Y.Z>                 (newer)
+  #    Discovery must accept both — a QA host was silently reporting
+  #    version="" because it only had shape (b) and no `current`
+  #    symlink. Same sort -V idiom used by the codex Homebrew Caskroom
+  #    probe. Handles partial installs where the `current` symlink
+  #    hasn't been flipped yet, and hosts that never publish a `current`
+  #    pointer at all.
+  local versions_dir="${base}/versions" entry
   if [[ -d "${versions_dir}" ]]; then
     ver=""
-    for dir in "${versions_dir}"/*/; do
-      [[ -d "${dir}" ]] || continue
-      dname="$(basename "${dir}")"
+    for entry in "${versions_dir}"/*; do
+      # Accept a directory OR a regular file (both shapes documented
+      # above). A dangling symlink or FIFO is skipped — the semver
+      # regex on the basename below is the authoritative filter.
+      [[ -d "${entry}" || -f "${entry}" ]] || continue
+      dname="$(basename "${entry}")"
       [[ "${dname}" =~ ${semver_re} ]] || continue
       if [[ -z "${ver}" ]] || \
          [[ "$(printf '%s\n%s\n' "${ver}" "${dname}" | sort -V | tail -1)" == "${dname}" ]]; then
@@ -200,154 +210,306 @@ _native_claudecode_version_from_dir() {
   fi
 }
 
+# _native_claudecode_version_from_bin BIN -> echoes the version or "".
+#
+# Reads the PATH-shim shape published by newer Claude Code native
+# installers where the actual dispatcher lives at
+# `<home>/.local/bin/claude` as a symlink to `../share/claude/versions/
+# <X.Y.Z>` (or the analogous /usr/local/bin/claude,
+# /opt/homebrew/bin/claude, /opt/claude/bin/claude system-wide shims).
+# When no `current` symlink is published and versions/ contains only
+# executable files, this shim is the only trustworthy source of the
+# active version.
+#
+# Metadata-only: readlink + basename; no exec of the binary itself.
+# Handles both absolute and relative symlink targets; a dangling symlink
+# or a non-semver basename returns empty.
+_native_claudecode_version_from_bin() {
+  local bin="$1"
+  [[ -n "${bin}" && -L "${bin}" ]] || return 0
+  # A dangling symlink (aborted upgrade, manual rm of the target) is
+  # treated as absent — the shim exists on disk but points nowhere, so
+  # there's no active install to report. `-e` on the shim itself
+  # follows the symlink and fails when the ultimate target is missing.
+  [[ -e "${bin}" ]] || return 0
+  local -r semver_re='^[0-9]+\.[0-9]+\.[0-9]+([._+-].*)?$'
+  # Prefer a full path resolution (readlink -f / GNU readlink) so a
+  # chain of symlinks is walked to the final target; fall back to the
+  # single-hop readlink used elsewhere in this file when -f is
+  # unsupported (BSD `readlink` on older macOS didn't ship -f, though
+  # 12+ does). The basename of whichever we get MUST match the semver
+  # regex — otherwise the shim points at something we don't understand
+  # and we return empty rather than guess.
+  local resolved
+  resolved="$(readlink -f -- "${bin}" 2>/dev/null || readlink -n -- "${bin}" 2>/dev/null || true)"
+  [[ -n "${resolved}" ]] || return 0
+  local dname
+  dname="$(basename -- "${resolved}")"
+  [[ "${dname}" =~ ${semver_re} ]] || return 0
+  echo "${dname}"
+}
+
+# Minimum-supported agent versions for the hook-contract gate. Values
+# are the ``min_inclusive`` bounds from
+# cli/defenseclaw/inventory/hook_contracts.json and must stay aligned
+# with the ``MinAgentVersion`` constants in
+# internal/gateway/connector/hook_contract.go. If a discovered install
+# is below the minimum but a *higher* install is also present, the
+# higher one wins; when no install meets the minimum the highest
+# overall is still reported so the operator sees an actual version in
+# the discovery output (the Go hook gate then reports "unsupported"
+# rather than "unversioned").
+#
+# Declared conditionally so tests that re-source this library across
+# cases don't trip bash's readonly-variable error on the second source.
+if [[ -z "${MIN_CLAUDECODE_VERSION:-}" ]]; then
+  readonly MIN_CLAUDECODE_VERSION="2.1.144"
+  readonly MIN_CODEX_VERSION="0.124.0"
+  readonly MIN_CURSOR_VERSION="1.7.0"
+fi
+
+# _version_ge A B -> exit 0 iff A >= B under `sort -V` semantics.
+# Empty inputs treated as "no answer" — returns 1. Used by
+# _pick_highest_supported below and by direct callers that need to
+# check a single version against a minimum.
+_version_ge() {
+  local a="$1" b="$2"
+  [[ -n "${a}" && -n "${b}" ]] || return 1
+  local highest
+  highest="$(printf '%s\n%s\n' "${a}" "${b}" | sort -V | tail -1)"
+  [[ "${highest}" == "${a}" ]]
+}
+
+# _pick_highest_supported MIN_VERSION VERSION... -> echoes the highest
+# candidate that is >= MIN_VERSION, or (when none clear the minimum)
+# the highest candidate overall. Silent when no candidates are given.
+#
+# Motivation: hosts with multiple installs of the same agent (Homebrew
+# npm-global + NVM, or ChatGPT.app + npm-global for codex) previously
+# stopped at the first hit — often the stale Homebrew install — and
+# reported a version below the hook contract's MinAgentVersion.
+# Enumerating every install and picking the highest supported version
+# fixes that class of bug at the discovery layer.
+_pick_highest_supported() {
+  local min="$1"; shift
+  [[ $# -gt 0 ]] || return 0
+  local best_supported="" best_overall="" v
+  for v in "$@"; do
+    [[ -n "${v}" ]] || continue
+    # Track the overall highest so we always return *something* when
+    # candidates exist.
+    if [[ -z "${best_overall}" ]] || \
+       [[ "$(printf '%s\n%s\n' "${best_overall}" "${v}" | sort -V | tail -1)" == "${v}" ]]; then
+      best_overall="${v}"
+    fi
+    if _version_ge "${v}" "${min}"; then
+      if [[ -z "${best_supported}" ]] || \
+         [[ "$(printf '%s\n%s\n' "${best_supported}" "${v}" | sort -V | tail -1)" == "${v}" ]]; then
+        best_supported="${v}"
+      fi
+    fi
+  done
+  if [[ -n "${best_supported}" ]]; then
+    echo "${best_supported}"
+  elif [[ -n "${best_overall}" ]]; then
+    echo "${best_overall}"
+  fi
+}
+
+# _emit_pkg_version_if_exists FILE -> echoes ".version" from FILE, or
+# nothing if FILE is missing. Small wrapper so the connector loops
+# below stay readable when they iterate 6-10 candidate globs.
+_emit_pkg_version_if_exists() {
+  [[ -f "$1" ]] || return 0
+  _read_json_version "$1"
+}
+
+# _collect_node_manager_pkg_versions HOME NPM_SCOPE PKG -> echoes one
+# version per line for every install of NPM_SCOPE/PKG we can find
+# under the common Node version managers (NVM / Volta / fnm / asdf).
+#
+# QA regression this addresses: users with multiple `node` versions
+# (Homebrew node + NVM node, for instance) have distinct copies of
+# `@anthropic-ai/claude-code` under each Node root. The Homebrew-shipped
+# global was often the stale one and it always won the first-hit loop.
+# Globbing every candidate root and passing the results to
+# _pick_highest_supported ensures the newest supported install wins
+# regardless of `node` install order.
+#
+# Glob costs one readdir per manager root — well under a millisecond
+# even on developer boxes with a dozen node versions.
+_collect_node_manager_pkg_versions() {
+  local home="$1" npm_scope="$2" pkg="$3"
+  local relpath="${npm_scope}/${pkg}/package.json"
+  local -a roots=(
+    "${home}"/.nvm/versions/node/*/lib/node_modules/"${relpath}"
+    "${home}"/.local/share/fnm/node-versions/*/installation/lib/node_modules/"${relpath}"
+    "${home}"/.asdf/installs/nodejs/*/.npm/lib/node_modules/"${relpath}"
+    "${home}"/.volta/tools/image/packages/"${npm_scope}"/"${pkg}"/*/package.json
+  )
+  local candidate v
+  for candidate in "${roots[@]}"; do
+    # Bash 3.2 does not set nullglob by default; a missing directory
+    # leaves the literal glob string in the array. `-f` guards.
+    [[ -f "${candidate}" ]] || continue
+    v="$(_read_json_version "${candidate}")"
+    [[ -n "${v}" ]] && echo "${v}"
+  done
+}
+
 discover_agent_version() {
   local connector="$1"
   local home="$2"
+  # New policy (as of state v3 discovery): enumerate every candidate
+  # install for the given connector, then hand the collected versions
+  # to _pick_highest_supported. This replaces the old first-hit-wins
+  # loops (which broke for multi-install hosts — see the QA regressions
+  # documented above the helper).
+  local -a versions=()
+  local v pkg base chatgpt_codex
+
   case "${connector}" in
     codex)
-      # Codex-cli is a Rust binary that ships from three OpenAI-owned
-      # channels on macOS. Probe order picks the first-party
-      # ChatGPT.app bundled copy FIRST because it is the newest
-      # distribution (auto-updated with the desktop app) and it is
-      # what customers actually have on a fresh Mac — stray old
-      # `npm i -g @openai/codex` installs from an earlier engagement
-      # frequently linger and would otherwise win with a stale
-      # version that fails our MinAgentVersion contract gate.
+      # Codex-cli ships from OpenAI through several channels; we
+      # enumerate every visible install rather than short-circuiting on
+      # the first hit so a stale npm-global doesn't win over a newer
+      # ChatGPT.app bundle or a fresh NVM install.
       #
-      # Order:
+      # Channels probed (order does NOT determine which wins — see
+      # _pick_highest_supported):
       #   1. ChatGPT.app bundled binary       (Codex 0.145.0+ current)
       #   2. Homebrew Caskroom                (versioned dir name)
       #   3. npm module package.json         (user-global then system)
-      #   4. `command -v codex` last resort   (arbitrary PATH install)
+      #   4. Node version managers (NVM/Volta/fnm/asdf) package.json
       #
-      # Every probe runs as the target user via sudo -u (not root).
-      # The app bundle is Gatekeeper-signed and world-readable by
-      # design; running its --version as an unprivileged user is
-      # safe. install.sh's outer sudo already dropped privs before
-      # calling this helper, matching the security posture of the
-      # hook guardian's connector.Setup call.
-      local vraw
-
-      # 1. ChatGPT.app bundled codex — /Applications/ChatGPT.app/
-      # Contents/Resources/codex is the current stable location; the
-      # older MacOS/ path is kept as a fallback for pre-2026 builds.
-      local chatgpt_codex
+      # The ChatGPT.app entries still exec the bundled binary because
+      # they don't ship a discoverable metadata file — the app bundle
+      # is Gatekeeper-signed and world-readable and install.sh's outer
+      # sudo already dropped privs before calling this helper.
       for chatgpt_codex in \
         /Applications/ChatGPT.app/Contents/Resources/codex \
         /Applications/ChatGPT.app/Contents/MacOS/codex; do
         [[ -x "${chatgpt_codex}" ]] || continue
+        local vraw
         if [[ -n "${DC_INSTALLER_TARGET_USER:-}" ]]; then
           vraw="$(sudo -n -u "${DC_INSTALLER_TARGET_USER}" "${chatgpt_codex}" --version 2>/dev/null | head -1 || true)"
         else
           vraw="$("${chatgpt_codex}" --version 2>/dev/null | head -1 || true)"
         fi
-        # Codex prints "codex-cli X.Y.Z" (or "codex-cli X.Y.Z-alpha.N");
-        # take the first token that looks like a version.
         vraw="$(printf '%s' "${vraw}" | awk '{for(i=NF;i>=1;i--) if ($i ~ /^[0-9]+\.[0-9]+/) {print $i; exit}}')"
-        if [[ -n "${vraw}" ]]; then echo "${vraw}"; return; fi
+        [[ -n "${vraw}" ]] && versions+=("${vraw}")
       done
 
-      # 2. Homebrew cask keeps the binary under Caskroom with a
-      # version in the path itself:
-      #   /opt/homebrew/Caskroom/codex/<version>/...
-      # Glob-based version pick (avoids shellcheck SC2010 on ls|grep).
-      local caskroom ver dir dname
+      local caskroom dir dname
       for caskroom in /opt/homebrew/Caskroom/codex /usr/local/Caskroom/codex; do
         [[ -d "${caskroom}" ]] || continue
-        ver=""
         for dir in "${caskroom}"/*/; do
           [[ -d "${dir}" ]] || continue
           dname="$(basename "${dir}")"
           [[ "${dname}" =~ ^[0-9]+\.[0-9]+ ]] || continue
-          if [[ -z "${ver}" ]] || \
-             [[ "$(printf '%s\n%s\n' "${ver}" "${dname}" | sort -V | tail -1)" == "${dname}" ]]; then
-            ver="${dname}"
-          fi
+          versions+=("${dname}")
         done
-        if [[ -n "${ver}" ]]; then echo "${ver}"; return; fi
       done
 
-      # 3. npm module package.json — user-global first (most likely
-      # up to date on developer boxes), then system dirs.
-      local pkg
       for pkg in \
         "${home}"/.npm-global/lib/node_modules/@openai/codex/package.json \
         /usr/local/lib/node_modules/@openai/codex/package.json \
         /opt/homebrew/lib/node_modules/@openai/codex/package.json; do
-        [[ -f "${pkg}" ]] || continue
-        local v; v="$(_read_json_version "${pkg}")"
-        if [[ -n "${v}" ]]; then echo "${v}"; return; fi
+        v="$(_emit_pkg_version_if_exists "${pkg}")"
+        [[ -n "${v}" ]] && versions+=("${v}")
       done
 
-      # 4. Last resort: exec codex --version as the target user (not
-      # as root). Requires TARGET_USER to be known to the caller.
-      if [[ -n "${DC_INSTALLER_TARGET_USER:-}" ]] && command -v codex >/dev/null 2>&1; then
-        vraw="$(sudo -n -u "${DC_INSTALLER_TARGET_USER}" codex --version 2>/dev/null | head -1 || true)"
-        vraw="$(printf '%s' "${vraw}" | awk '{for(i=NF;i>=1;i--) if ($i ~ /^[0-9]+\.[0-9]+/) {print $i; exit}}')"
-        if [[ -n "${vraw}" ]]; then echo "${vraw}"; return; fi
-      fi
+      # NVM / Volta / fnm / asdf globs.
+      while IFS= read -r v; do
+        [[ -n "${v}" ]] && versions+=("${v}")
+      done < <(_collect_node_manager_pkg_versions "${home}" "@openai" "codex")
+
+      _pick_highest_supported "${MIN_CODEX_VERSION}" "${versions[@]}"
       ;;
     claudecode)
-      # Claude Code ships through four channels:
+      # Claude Code ships through five channels:
       #
       #   1. Native installer (curl -fsSL https://claude.ai/install.sh
       #      | bash) — per-user under ~/.local/share/claude/versions/
-      #      with a `current` symlink pointer. This is the officially
-      #      recommended installer and what most users have today; the
-      #      `~/.local/bin/claude` shim on PATH resolves through the
-      #      `current` symlink to `.../versions/<X.Y.Z>/claude`.
+      #      with a `current` symlink pointer.
       #   2. System-wide native install — /opt/claude or
       #      /usr/local/share/claude, same {current,versions/*} shape.
-      #      Present when an admin installs Claude for all users.
       #   3. npm-global CLI — @anthropic-ai/claude-code — legacy
-      #      channel, still supported. package.json carries version.
-      #   4. Cursor / VS Code editor extensions — the extension dir
-      #      name embeds the version (matches the codex probe pattern).
+      #      channel; still shipped through Homebrew's `node` and
+      #      manually via `npm i -g`.
+      #   4. Node version managers (NVM/Volta/fnm/asdf) — the same
+      #      npm package installed under a per-node-version root. QA
+      #      regression: previously not probed at all, so a stale
+      #      Homebrew install would beat a supported NVM install.
+      #   5. Cursor / VS Code editor extensions — extension dir name
+      #      embeds the version (matches the codex probe pattern).
       #
-      # Probe order picks native FIRST because it is what customers
-      # actually run today; leaving it for a stale npm-global fallback
-      # to win would surface a stale version to the hook-contract
-      # validator and (in managed_enterprise mode=action) fail the
-      # reconcile for that user's claudecode row.
-
-      # 1. + 2. Native installer layouts. Per-user first, then Linux
-      # system-wide paths. `installer_lib.sh` is macOS-only in
-      # today's shipping bundle, but the render-targets script is
-      # copied into the managed tree and runs against every local
-      # user's home; the extra probes cost one stat each on macOS
-      # (which does not have /opt/claude) and future-proof against
-      # a Linux managed rollout that consumes this helper.
-      local base v
+      # We enumerate everything and pick the highest install that
+      # meets MIN_CLAUDECODE_VERSION; if nothing clears the minimum,
+      # the highest overall is still emitted so the Go hook gate
+      # reports drift rather than the noisier "unversioned".
       for base in \
         "${home}/.local/share/claude" \
         /opt/claude \
         /usr/local/share/claude; do
         v="$(_native_claudecode_version_from_dir "${base}")"
-        if [[ -n "${v}" ]]; then echo "${v}"; return; fi
+        [[ -n "${v}" ]] && versions+=("${v}")
       done
 
-      # 3. + 4. npm module package.json + editor-extension probes.
-      #    Kept intact so operators with a legacy npm install or an
-      #    editor-extension install continue to work.
-      local pkg
+      # PATH-shim probe. Newer native installers publish
+      # `<home>/.local/bin/claude -> ../share/claude/versions/<X.Y.Z>`
+      # without a `current` symlink and with versions/<X.Y.Z> as a
+      # regular executable file. Without this probe the from_dir()
+      # scan above still handles the file variant, but a QA host
+      # reported here had a *stale* versions/ entry pinned by the
+      # shim to an older release; the shim is the source of truth
+      # for the active install, so we surface it explicitly. Handles
+      # per-user and both system shim locations.
+      local bin
+      for bin in \
+        "${home}/.local/bin/claude" \
+        /usr/local/bin/claude \
+        /opt/homebrew/bin/claude \
+        /opt/claude/bin/claude; do
+        v="$(_native_claudecode_version_from_bin "${bin}")"
+        [[ -n "${v}" ]] && versions+=("${v}")
+      done
+
       for pkg in \
         "${home}"/.npm-global/lib/node_modules/@anthropic-ai/claude-code/package.json \
         /usr/local/lib/node_modules/@anthropic-ai/claude-code/package.json \
         /opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/package.json \
         "${home}"/.cursor/extensions/anthropic.claude-code-*/package.json \
         "${home}"/.vscode/extensions/anthropic.claude-code-*/package.json; do
-        [[ -f "${pkg}" ]] || continue
-        v="$(_read_json_version "${pkg}")"
-        if [[ -n "${v}" ]]; then echo "${v}"; return; fi
+        v="$(_emit_pkg_version_if_exists "${pkg}")"
+        [[ -n "${v}" ]] && versions+=("${v}")
       done
+
+      while IFS= read -r v; do
+        [[ -n "${v}" ]] && versions+=("${v}")
+      done < <(_collect_node_manager_pkg_versions "${home}" "@anthropic-ai" "claude-code")
+
+      _pick_highest_supported "${MIN_CLAUDECODE_VERSION}" "${versions[@]}"
       ;;
     cursor)
-      # Cursor.app is a signed macOS bundle; read the Info.plist rather
-      # than exec'ing the binary. PlistBuddy is an Apple system tool.
+      # Cursor.app is a signed macOS bundle. Two metadata sources:
+      #   1. Info.plist ``CFBundleShortVersionString`` — the user-
+      #      visible marketing version.
+      #   2. Contents/Resources/app/package.json ``version`` — the
+      #      Electron/npm layout the bundled agent reports at runtime;
+      #      the two can lag out of sync for a release.
+      # Enumerate both and let _pick_highest_supported pick the one
+      # that meets MIN_CURSOR_VERSION; if both are below, the higher
+      # of the two still ships.
       if [[ -f /Applications/Cursor.app/Contents/Info.plist ]]; then
-        /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" \
-          /Applications/Cursor.app/Contents/Info.plist 2>/dev/null || true
+        v="$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" \
+          /Applications/Cursor.app/Contents/Info.plist 2>/dev/null || true)"
+        [[ -n "${v}" ]] && versions+=("${v}")
       fi
+      v="$(_emit_pkg_version_if_exists /Applications/Cursor.app/Contents/Resources/app/package.json)"
+      [[ -n "${v}" ]] && versions+=("${v}")
+
+      _pick_highest_supported "${MIN_CURSOR_VERSION}" "${versions[@]}"
       ;;
   esac
 }

--- a/packaging/macos/lib/render-targets.sh
+++ b/packaging/macos/lib/render-targets.sh
@@ -113,7 +113,7 @@ for c in deduped:
 PY
 }
 
-connectors_lines="$(extract_connectors 2>/dev/null || true)"
+connectors_lines="$(extract_connectors || true)"
 if [[ -z "${connectors_lines}" ]]; then
   die "no connectors resolvable from ${CONFIG_PATH}"
 fi
@@ -142,6 +142,10 @@ chmod 0640 "${tmp}"
 # reconcile identical rows unnecessarily.
 if [[ -f "${MANIFEST_PATH}" ]] && cmp -s "${tmp}" "${MANIFEST_PATH}"; then
   log "targets.yaml unchanged (users=$(printf '%s\n' "${user_lines}" | grep -c . || true))"
+  # Self-heal ownership/mode on the retained manifest so a chown/chmod
+  # drift outside our control doesn't survive a no-op render tick.
+  chown root:wheel "${MANIFEST_PATH}" 2>/dev/null || true
+  chmod 0640 "${MANIFEST_PATH}" 2>/dev/null || true
   exit 0
 fi
 

--- a/packaging/macos/tests/test_agent_version_multi_install.sh
+++ b/packaging/macos/tests/test_agent_version_multi_install.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# discover_agent_version: multi-install & minimum-supported picking.
+#
+# Pins the fix for the two QA regressions on the shell installer side:
+#
+#   1. Homebrew npm-global at 1.9.0 + NVM install at 2.5.0 →
+#      _pick_highest_supported returns 2.5.0 (NVM). The old first-hit
+#      loop would have returned 1.9.0 and the Go hook-contract gate
+#      would have refused to install hooks.
+#   2. _pick_highest_supported falls back to the highest install
+#      overall when no candidate clears MIN. This ensures operators
+#      always see a real version in the discovery output — the Go gate
+#      then reports "unsupported" rather than the noisier "unversioned".
+. "${PKG_DIR}/lib/installer_lib.sh"
+
+t_pick_highest_supported_prefers_meeting_minimum() {
+  local out
+  out="$(_pick_highest_supported "2.1.144" "1.9.0" "2.5.0")"
+  assert_eq "${out}" "2.5.0" "highest-supported picks NVM over stale Homebrew"
+}
+
+t_pick_highest_supported_falls_back_to_highest_overall() {
+  local out
+  out="$(_pick_highest_supported "2.0.0" "1.0.0" "1.5.0")"
+  assert_eq "${out}" "1.5.0" "fallback when nothing clears minimum still returns highest"
+}
+
+t_pick_highest_supported_empty_returns_empty() {
+  local out
+  out="$(_pick_highest_supported "1.0.0")"
+  assert_eq "${out}" "" "no candidates yields empty string"
+}
+
+t_pick_highest_supported_ignores_empty_arg() {
+  local out
+  out="$(_pick_highest_supported "1.0.0" "" "2.0.0" "")"
+  assert_eq "${out}" "2.0.0" "empty candidate strings are skipped"
+}
+
+t_version_ge_handles_semver_ordering() {
+  # Sanity: sort -V knows semver.
+  if _version_ge "2.5.0" "2.1.144"; then :; else _fail "2.5.0 should be >= 2.1.144"; fi
+  if _version_ge "1.9.0" "2.1.144"; then _fail "1.9.0 should NOT be >= 2.1.144"; fi
+  if _version_ge "2.1.144" "2.1.144"; then :; else _fail "2.1.144 should be >= itself"; fi
+}
+
+t_claudecode_probe_picks_nvm_over_stale_homebrew() {
+  # Reproduces QA #2. Note the assertion is a lower bound rather than
+  # an exact match: the developer machine running the tests may have a
+  # real @anthropic-ai/claude-code install under /opt/homebrew/lib/
+  # node_modules/ (which we can't hide), and if that version is
+  # higher-and-supported it will legitimately outrank our fake NVM
+  # install. Either way the fix is proven: the picker returned
+  # SOMETHING >= 2.5.0, i.e. it did not stop at the stale 1.9.0
+  # in $home/.npm-global. The Python test
+  # test_agent_discovery_multi_install.py has full sandboxing via
+  # monkeypatch and pins the exact 2.5.0 result.
+  local home tmp pkg_nvm pkg_brew out
+  tmp="$(mktest_tmp)"
+  home="${tmp}/home"
+  pkg_nvm="${home}/.nvm/versions/node/v22.21.0/lib/node_modules/@anthropic-ai/claude-code/package.json"
+  pkg_brew="${home}/.npm-global/lib/node_modules/@anthropic-ai/claude-code/package.json"
+  mkdir -p "$(dirname "${pkg_nvm}")" "$(dirname "${pkg_brew}")"
+  printf '{"version": "2.5.0"}\n' > "${pkg_nvm}"
+  printf '{"version": "1.9.0"}\n' > "${pkg_brew}"
+
+  out="$(discover_agent_version claudecode "${home}")"
+  if [[ -z "${out}" ]]; then
+    _fail "claudecode probe returned empty; expected 2.5.0 or higher"
+    return 1
+  fi
+  if _version_ge "${out}" "2.5.0"; then :; else
+    _fail "expected >= 2.5.0 (NVM install), got=${out}"
+  fi
+  # And confirm the stale 1.9.0 did NOT win.
+  if [[ "${out}" == "1.9.0" ]]; then
+    _fail "stale npm-global 1.9.0 won over supported NVM 2.5.0"
+  fi
+}
+
+t_claudecode_probe_reads_native_installer_current_symlink() {
+  local home tmp base versions out
+  tmp="$(mktest_tmp)"
+  home="${tmp}/home"
+  base="${home}/.local/share/claude"
+  versions="${base}/versions"
+  mkdir -p "${versions}/2.5.0" "${versions}/2.1.144"
+  # `current` symlink points at 2.1.144 even though 2.5.0 is present —
+  # simulates a user who ran `claude version rollback`.
+  ln -s "${versions}/2.1.144" "${base}/current"
+
+  out="$(discover_agent_version claudecode "${home}")"
+  assert_eq "${out}" "2.1.144" "current symlink wins over higher versions/*/"
+}
+
+t_claudecode_probe_returns_highest_when_all_below_min() {
+  # Exercises the "no candidate clears MIN — return highest overall"
+  # branch of _pick_highest_supported. We hit that branch directly (it
+  # is unit-tested with all four inputs) rather than through
+  # discover_agent_version because the dev machine's real system-wide
+  # /opt/homebrew or /opt/claude install (if any) would legitimately
+  # outrank our fake and the "all below MIN" premise wouldn't hold.
+  # discover_agent_version's contract "return SOMETHING when any
+  # install exists" is already covered by
+  # t_claudecode_probe_picks_nvm_over_stale_homebrew above.
+  local out
+  out="$(_pick_highest_supported "${MIN_CLAUDECODE_VERSION}" "1.5.0" "1.9.0")"
+  assert_eq "${out}" "1.9.0" "highest overall wins when nothing clears MIN"
+}
+
+t_codex_probe_reads_npm_global_metadata() {
+  # We can't create /opt/homebrew/Caskroom or /opt/homebrew/lib inside
+  # the sandbox, and the developer machine running the tests may have
+  # its own real codex install there. Restrict this case to what we
+  # CAN prove hermetically: given a user-scoped npm-global at a fake
+  # $home, discover_agent_version returns *some* version >= that fake
+  # (either the fake itself, or the developer machine's real install
+  # picked up because it clears MIN and outranks the fake — both are
+  # correct enumerate-all-then-pick behaviour). What we're pinning is
+  # "the fake install was not silently ignored", which the presence of
+  # a non-empty output proves.
+  local home tmp pkg_user out
+  tmp="$(mktest_tmp)"
+  home="${tmp}/home"
+  pkg_user="${home}/.npm-global/lib/node_modules/@openai/codex/package.json"
+  mkdir -p "$(dirname "${pkg_user}")"
+  printf '{"version": "0.130.0"}\n' > "${pkg_user}"
+
+  out="$(discover_agent_version codex "${home}")"
+  if [[ -z "${out}" ]]; then
+    _fail "codex probe returned empty; expected a version"
+    return 1
+  fi
+  # And confirm the returned string is version-shaped.
+  [[ "${out}" =~ ^[0-9]+\.[0-9]+ ]] || _fail "output ${out} is not version-shaped"
+}
+
+t_min_versions_match_hook_contracts_json() {
+  # Drift guard: shell installer constants must agree with the JSON
+  # the Python resolver reads. Exercises the same invariant that
+  # test_agent_discovery_multi_install.py's Python-side test pins.
+  local hook_contracts json_min
+  hook_contracts="${REPO_ROOT}/cli/defenseclaw/inventory/hook_contracts.json"
+  assert_file_exists "${hook_contracts}"
+  json_min="$(python3 -c '
+import json, sys
+doc = json.load(open(sys.argv[1]))
+target = sys.argv[2]
+for c in doc["connectors"][target]["contracts"]:
+    if c.get("default_for_unversioned"):
+        print(c["agent_version"]["min_inclusive"]); break
+' "${hook_contracts}" claudecode)"
+  assert_eq "${json_min}" "${MIN_CLAUDECODE_VERSION}" "claudecode MIN aligned with hook_contracts.json"
+
+  json_min="$(python3 -c '
+import json, sys
+doc = json.load(open(sys.argv[1]))
+target = sys.argv[2]
+for c in doc["connectors"][target]["contracts"]:
+    if c.get("default_for_unversioned"):
+        print(c["agent_version"]["min_inclusive"]); break
+' "${hook_contracts}" codex)"
+  assert_eq "${json_min}" "${MIN_CODEX_VERSION}" "codex MIN aligned with hook_contracts.json"
+
+  json_min="$(python3 -c '
+import json, sys
+doc = json.load(open(sys.argv[1]))
+target = sys.argv[2]
+for c in doc["connectors"][target]["contracts"]:
+    if c.get("default_for_unversioned"):
+        print(c["agent_version"]["min_inclusive"]); break
+' "${hook_contracts}" cursor)"
+  assert_eq "${json_min}" "${MIN_CURSOR_VERSION}" "cursor MIN aligned with hook_contracts.json"
+}
+
+run_case "_pick_highest_supported prefers meeting minimum"     t_pick_highest_supported_prefers_meeting_minimum
+run_case "_pick_highest_supported falls back to highest"       t_pick_highest_supported_falls_back_to_highest_overall
+run_case "_pick_highest_supported empty returns empty"         t_pick_highest_supported_empty_returns_empty
+run_case "_pick_highest_supported ignores empty arg"           t_pick_highest_supported_ignores_empty_arg
+run_case "_version_ge handles semver ordering"                 t_version_ge_handles_semver_ordering
+run_case "claudecode probe picks NVM over stale npm-global"    t_claudecode_probe_picks_nvm_over_stale_homebrew
+run_case "claudecode probe reads native installer symlink"     t_claudecode_probe_reads_native_installer_current_symlink
+run_case "claudecode probe returns highest when all below min" t_claudecode_probe_returns_highest_when_all_below_min
+run_case "codex probe reads npm-global metadata"               t_codex_probe_reads_npm_global_metadata
+run_case "MIN constants match hook_contracts.json"             t_min_versions_match_hook_contracts_json

--- a/packaging/macos/tests/test_discover_agent_version.sh
+++ b/packaging/macos/tests/test_discover_agent_version.sh
@@ -245,6 +245,119 @@ JSON
   assert_eq "${got}" "0.142.0" "codex version from user-npm metadata"
 }
 
+t_claudecode_native_versions_file_variant() {
+  # QA-reported layout: newer Claude Code native installers publish each
+  # release as an executable *file* at versions/<X.Y.Z> (not a directory)
+  # and skip the `current` symlink entirely. The dispatcher lives at
+  # ~/.local/bin/claude and symlinks to ../share/claude/versions/<X.Y.Z>.
+  # Before the fix the versions/*/ scan only enumerated directories, so
+  # this layout reported an empty version and every reconcile logged
+  # "agent version not probed; using connector default hook contract".
+  local home; home="$(mktest_tmp)"
+  local vers="${home}/.local/share/claude/versions"
+  mkdir -p "${vers}"
+  : > "${vers}/2.1.220"; chmod 0755 "${vers}/2.1.220"
+  : > "${vers}/2.1.219"; chmod 0755 "${vers}/2.1.219"
+
+  local got
+  got="$(without_host_agent_bins discover_agent_version claudecode "${home}")"
+  assert_eq "${got}" "2.1.220" "claudecode picks highest versions/<X.Y.Z> when they are executable files"
+}
+
+t_claudecode_native_bin_shim_probe() {
+  # Same host shape as above, PLUS the ~/.local/bin/claude PATH shim
+  # pointing at the active version. Exercises the new bin-symlink
+  # probe end-to-end: even if the versions/ scan were removed, the
+  # shim alone should surface the active version.
+  local home; home="$(mktest_tmp)"
+  local vers="${home}/.local/share/claude/versions"
+  mkdir -p "${vers}"
+  : > "${vers}/2.1.220"; chmod 0755 "${vers}/2.1.220"
+
+  mkdir -p "${home}/.local/bin"
+  ln -s "../share/claude/versions/2.1.220" "${home}/.local/bin/claude"
+
+  local got
+  got="$(without_host_agent_bins discover_agent_version claudecode "${home}")"
+  assert_eq "${got}" "2.1.220" "claudecode resolves version via ~/.local/bin/claude PATH shim"
+}
+
+t_claudecode_native_bin_shim_helper_direct() {
+  # Direct exercise of the pure helper: absolute-target and relative-
+  # target symlinks, dangling shim, non-semver target.
+  local home; home="$(mktest_tmp)"
+  local vers="${home}/.local/share/claude/versions"
+  mkdir -p "${vers}"
+  : > "${vers}/2.1.220"; chmod 0755 "${vers}/2.1.220"
+
+  # Relative symlink (matches what the installer actually writes).
+  mkdir -p "${home}/.local/bin"
+  ln -s "../share/claude/versions/2.1.220" "${home}/.local/bin/claude"
+  local got
+  got="$(_native_claudecode_version_from_bin "${home}/.local/bin/claude")"
+  assert_eq "${got}" "2.1.220" "bin-shim helper resolves relative symlink"
+
+  # Absolute symlink variant.
+  ln -sfn "${vers}/2.1.220" "${home}/.local/bin/claude"
+  got="$(_native_claudecode_version_from_bin "${home}/.local/bin/claude")"
+  assert_eq "${got}" "2.1.220" "bin-shim helper resolves absolute symlink"
+
+  # Dangling symlink returns empty.
+  ln -sfn "${vers}/2.9.999-does-not-exist" "${home}/.local/bin/claude"
+  got="$(_native_claudecode_version_from_bin "${home}/.local/bin/claude" 2>/dev/null || true)"
+  assert_eq "${got}" "" "bin-shim helper returns empty on dangling symlink"
+
+  # Non-symlink returns empty (regular executable at that path).
+  rm -f "${home}/.local/bin/claude"
+  : > "${home}/.local/bin/claude"; chmod 0755 "${home}/.local/bin/claude"
+  got="$(_native_claudecode_version_from_bin "${home}/.local/bin/claude" 2>/dev/null || true)"
+  assert_eq "${got}" "" "bin-shim helper returns empty when path is a regular file, not a symlink"
+
+  # Non-semver target basename returns empty.
+  rm -f "${home}/.local/bin/claude"
+  mkdir -p "${vers}/nightly"
+  ln -s "${vers}/nightly" "${home}/.local/bin/claude"
+  got="$(_native_claudecode_version_from_bin "${home}/.local/bin/claude" 2>/dev/null || true)"
+  assert_eq "${got}" "" "bin-shim helper rejects non-semver target basename"
+}
+
+t_claudecode_native_bin_shim_wins_over_stale_versions() {
+  # The shim's target must always be included in the candidate pool.
+  # QA hit a variant where versions/ contained an older executable file
+  # (say a leftover 2.1.144) AND the shim pointed at the newer
+  # 2.1.220 file. Both are seen; the highest wins. This is the exact
+  # scenario where the pre-fix probe returned "" (dir-only scan skipped
+  # the file variant entirely).
+  local home; home="$(mktest_tmp)"
+  local vers="${home}/.local/share/claude/versions"
+  mkdir -p "${vers}"
+  : > "${vers}/2.1.144"; chmod 0755 "${vers}/2.1.144"
+  : > "${vers}/2.1.220"; chmod 0755 "${vers}/2.1.220"
+
+  mkdir -p "${home}/.local/bin"
+  ln -s "../share/claude/versions/2.1.220" "${home}/.local/bin/claude"
+
+  local got
+  got="$(without_host_agent_bins discover_agent_version claudecode "${home}")"
+  assert_eq "${got}" "2.1.220" "highest of versions/<file> pool + shim target wins"
+}
+
+t_claudecode_native_helper_direct_file_variant() {
+  # Direct-call parity: the from_dir() helper must accept regular
+  # files under versions/ too, mirroring the classic directory-shape
+  # test above (t_claudecode_via_native_helper_direct).
+  local base; base="$(mktest_tmp)/opt-claude"
+  mkdir -p "${base}/versions"
+  : > "${base}/versions/2.1.220"; chmod 0755 "${base}/versions/2.1.220"
+  : > "${base}/versions/2.1.219"; chmod 0755 "${base}/versions/2.1.219"
+  # Also stage a stray directory to prove both shapes coexist.
+  mkdir -p "${base}/versions/2.1.180"
+
+  local got
+  got="$(_native_claudecode_version_from_dir "${base}")"
+  assert_eq "${got}" "2.1.220" "from_dir helper picks highest across mixed dir + file version entries"
+}
+
 t_unknown_connector() {
   local got
   got="$(discover_agent_version geminicli "$(mktest_tmp)" 2>/dev/null || true)"
@@ -259,6 +372,11 @@ run_case "claudecode via native versions/*  (no symlink)"         t_claudecode_v
 run_case "claudecode native broken current symlink falls back"    t_claudecode_native_broken_current_symlink_falls_back
 run_case "claudecode native install wins over stale npm"          t_claudecode_native_wins_over_stale_npm
 run_case "claudecode native helper direct-call semantics"         t_claudecode_via_native_helper_direct
+run_case "claudecode native versions/<X.Y.Z> as executable file"  t_claudecode_native_versions_file_variant
+run_case "claudecode ~/.local/bin/claude PATH shim probe"         t_claudecode_native_bin_shim_probe
+run_case "claudecode bin-shim helper direct semantics"            t_claudecode_native_bin_shim_helper_direct
+run_case "claudecode shim + stale versions/<file> pool"           t_claudecode_native_bin_shim_wins_over_stale_versions
+run_case "claudecode from_dir helper accepts file variant"        t_claudecode_native_helper_direct_file_variant
 run_case "codex without home metadata"       t_codex_no_home_metadata_uses_system_or_empty
 run_case "codex from user npm metadata"      t_codex_from_user_npm_metadata
 run_case "codex ChatGPT.app-bundled wins over stale npm" t_codex_chatgpt_app_bundled_wins_over_npm

--- a/packaging/macos/tests/test_packaging_assets.sh
+++ b/packaging/macos/tests/test_packaging_assets.sh
@@ -25,6 +25,9 @@ t_guardian_and_enumerator_plists_exist_and_parse() {
     local out rc=0
     out="$(plutil -lint "${g}" 2>&1)" || rc=$?
     assert_status "${rc}" 0 "guardian plutil -lint should succeed"
+    # Reset rc so a prior failure on the guardian doesn't stick and
+    # mask a clean parse (or a fresh failure) on the enumerator.
+    rc=0
     out="$(plutil -lint "${e}" 2>&1)" || rc=$?
     assert_status "${rc}" 0 "enumerator plutil -lint should succeed"
   fi

--- a/packaging/macos/tests/test_render_config.sh
+++ b/packaging/macos/tests/test_render_config.sh
@@ -116,6 +116,14 @@ t_default_aid_endpoint_matches_go() {
     "${REPO_ROOT}/internal/config/config.go" \
     | head -1 \
     | sed -E 's/.*"cisco_ai_defense\.endpoint",[[:space:]]*"([^"]+)".*/\1/')"
+  # If the grep+sed pipeline produces nothing (viper default renamed,
+  # constant relocated, quoting changed) the drift comparison would
+  # silently pass on "" == "". Fail hard so we notice the extraction
+  # bug instead of losing the sync guard.
+  if [[ -z "${go_default}" ]]; then
+    _fail "could not extract cisco_ai_defense.endpoint viper default from internal/config/config.go"
+    return 1
+  fi
   assert_eq "${shell_default}" "${go_default}" \
     "DEFAULT_AID_ENDPOINT in installer_lib.sh matches viper default in config.go"
 }

--- a/proto/defenseclaw/secureclient/v1/secureclient.proto
+++ b/proto/defenseclaw/secureclient/v1/secureclient.proto
@@ -63,22 +63,26 @@ message StatsSnapshot {
   // Indicates whether the statistics are current, stale, or unavailable.
   StatsAvailability availability = 2;
 
-  // Counter fields below are proto3 `optional`. A present counter is
-  // supported by this DefenseClaw build and available to the consumer,
-  // including when its value is zero. An absent counter is unsupported
-  // or unavailable — consumers should render it as such (e.g. em-dash
-  // or hidden), not as "0".
+  // Counter fields below are proto3 `optional`. Presence semantics
+  // differ by field — this matters for AVC's rendering logic.
   //
   // Server-side presence policy (see internal/ipc/stats_source.go):
   //
   //   total_scans, active_alerts — ALWAYS present on an AVAILABLE
   //     snapshot, even when the value is zero. These back AVC's
-  //     primary KPI tiles and need a "0" render on a fresh install.
+  //     primary KPI tiles and need a non-zero rendering (e.g. "0")
+  //     on a fresh install. If either field is ABSENT on an AVAILABLE
+  //     snapshot, this DefenseClaw build does not support the counter
+  //     and consumers should render it as unsupported (em-dash or
+  //     hidden), NOT as "0".
   //
   //   blocked_skills, allowed_skills, blocked_mcp_servers,
-  //   allowed_mcp_servers — omitted when the value is zero. These
-  //     feed secondary drill-down views where "not yet observed" is
-  //     a meaningful distinction from "observed zero times".
+  //   allowed_mcp_servers — MAY be absent even on an AVAILABLE
+  //     snapshot. The server omits these when the value is zero to
+  //     save wire bytes on secondary drill-down views. Consumers
+  //     should treat absent as "zero" (equivalent to a value of 0),
+  //     not as "unsupported". A present zero and an absent field
+  //     carry the same meaning for these fields.
   //
   // On an ERROR / STARTING / UNAVAILABLE snapshot every counter is
   // absent; the availability enum carries the reachability signal.


### PR DESCRIPTION
## Summary

Bundles several managed_enterprise fixes surfaced by QA on macOS 26 / Mac 26.5 hosts.

### 1) env_config dynamic reload
`internal/config/env_config.go` (new), `internal/gateway/config_manager.go`

The AVC-authored `/opt/cisco/secureclient/defenseclaw/env_config.json` may arrive AFTER the installer completes, but the gateway used to bake the endpoint value in at boot and hold it for the process lifetime. ConfigManager now watches `env_config.json` alongside `config.yaml`, overlays `cisco_ai_defense_endpoint` on top of the yaml value, and reloads on any fsnotify event.

Malformed env_configs are **logged + retained** (health check surfaces the reason) rather than silently overwriting a working endpoint — bad-endpoint exfiltration is exactly the vector the validation step defends against.

### 2) Config-reload restart classification
`internal/gateway/config_manager.go`

Fixes three latent bugs that surfaced the moment env_config triggered a real reload. All three shared the same failure mode: reload rejected with `config reload requires gateway restart for: <field>`.

- **cisco_ai_defense wasn't hot-reloadable.** Any endpoint change tripped the restart guard even though `inspectorNeedsRebuild` + `otelNeedsReload` already handle the change. Added under managed_enterprise gate; OSS path keeps the pre-existing behavior.
- **Gateway.Token synthesised at boot, not persisted.** `ensureGatewayTokenSynthesis` generates a token into the runtime snapshot but never writes it into `config.yaml`, so every reload compared runtime-token vs on-disk-empty and forced a gateway restart. Existing preservation at `applyConfigReload:1165` ran AFTER `diffConfigs`, too late. Moved preservation into the pre-diff normalization step.
- **Gateway.NoTLS / SandboxHome / ClawHome same shape.** All three are `mapstructure:"-"` (never in yaml) and set post-Load, tripping the same false-restart signal on standalone-mode hosts. Extended the preservation set to cover every runtime-only Gateway field.

### 3) Claude Code detector — newer install layouts
`packaging/macos/lib/installer_lib.sh`, `packaging/macos/tests/test_discover_agent_version.sh`

Newer Claude Code native installers publish `versions/<X.Y.Z>` as executable **files** (not directories) and skip the `current` symlink, using `~/.local/bin/claude -> ../share/claude/versions/<X.Y.Z>` as the PATH shim. The dir-only glob was returning empty version, producing:

```
connector claudecode agent version "" is not verified against a known hook contract;
using connector default hook contract
```

Added file-shape support to `_native_claudecode_version_from_dir` and a new `_native_claudecode_version_from_bin` shim resolver covering `~/.local/bin`, `/usr/local/bin`, `/opt/homebrew/bin`, `/opt/claude/bin`.

### 4) Inventory / AI discovery updates
`cli/defenseclaw/inventory/*`, `internal/inventory/*`

Multi-install agent-version discovery on the Python side, seen-vs-new state tracking for AI discovery events, and misc detector coverage.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/config/... ./internal/gateway/...` — all pass (~42s)
- [x] `packaging/macos/tests/run_tests.sh` — **151/151 pass** including new agent-version detector + multi-install cases
- [x] Verified end-to-end on a managed_enterprise host: env_config.json arrives post-install, ConfigManager reloads without a restart, inspect client rebuilds against the fresh endpoint (previously blocked with `config reload requires gateway restart for: cisco_ai_defense, gateway`)

## Backwards compatibility

- OSS reload path is untouched — every new preservation branch is gated on `managed.IsManagedEnterprise(next.DeploymentMode)`.
- `Provider` / `Config` interfaces unchanged; existing callers need no modifications.
- Old Claude Code install layouts (directory-shape versions/, `current` symlink) continue to resolve exactly as before — the file-variant support is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)