### PR TITLE
Fix Windows hook provenance sealing

### DIFF
--- a/cli/tests/test_release_candidate.py
+++ b/cli/tests/test_release_candidate.py
@@ -823,6 +823,7 @@ def _windows_setup_dir(
         release_candidate.WINDOWS_PYTHON_EMBED_NAME: release_candidate.WINDOWS_PYTHON_EMBED_SHA256,
         release_candidate.WINDOWS_YARA_COMPAT_WHEEL: "a" * 64,
         "site-packages.zip": "9" * 64,
+        "defenseclaw-hook-launcher.exe": "4" * 64,
         "defenseclaw-launcher.exe": "d" * 64,
         "defenseclaw-startup.exe": "e" * 64,
         "cosign.exe": release_candidate.WINDOWS_COSIGN_SHA256,
@@ -834,6 +835,7 @@ def _windows_setup_dir(
         "gateway_archive_sha256": "6" * 64,
         "embedded_gateway_archive_sha256": payload_files[gateway_archive],
         "embedded_payload_sha256": "7" * 64,
+        "hook_launcher_sha256": payload_files["defenseclaw-hook-launcher.exe"],
         "product_executables_authenticode_signed": signed,
         "wheel": wheel,
         "wheel_sha256": payload_files[wheel],
@@ -1580,6 +1582,19 @@ def test_windows_setup_provenance_rejects_inconsistent_payload_digest(
     document = json.loads(path.read_text(encoding="utf-8"))
     document["inputs"]["payload_files"][document["inputs"]["wheel"]] = "1" * 64
     path.write_text(json.dumps(document), encoding="utf-8")
+    with pytest.raises(release_candidate.CandidateError, match="payload digests"):
+        release_candidate._validate_windows_installer_assets(windows, WINDOWS_SETUP_VERSION, COMMIT)
+
+
+def test_windows_setup_provenance_binds_hook_launcher_digest(
+    tmp_path: Path,
+) -> None:
+    windows = _windows_setup_dir(tmp_path)
+    path = windows / f"{release_candidate.WINDOWS_SETUP_ASSET}.provenance.json"
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["inputs"]["hook_launcher_sha256"] = "1" * 64
+    path.write_text(json.dumps(document), encoding="utf-8")
+
     with pytest.raises(release_candidate.CandidateError, match="payload digests"):
         release_candidate._validate_windows_installer_assets(windows, WINDOWS_SETUP_VERSION, COMMIT)
 

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -4283,6 +4283,7 @@ def _validate_windows_setup_provenance(
             "gateway_archive_sha256",
             "embedded_gateway_archive_sha256",
             "embedded_payload_sha256",
+            "hook_launcher_sha256",
             "product_executables_authenticode_signed",
             "wheel",
             "wheel_sha256",
@@ -4307,6 +4308,7 @@ def _validate_windows_setup_provenance(
             "gateway_archive_sha256",
             "embedded_gateway_archive_sha256",
             "embedded_payload_sha256",
+            "hook_launcher_sha256",
             "wheel_sha256",
             "python_embed_sha256",
             "site_packages_sha256",
@@ -4341,6 +4343,7 @@ def _validate_windows_setup_provenance(
             WINDOWS_PYTHON_EMBED_NAME,
             WINDOWS_YARA_COMPAT_WHEEL,
             "site-packages.zip",
+            "defenseclaw-hook-launcher.exe",
             "defenseclaw-launcher.exe",
             "defenseclaw-startup.exe",
             "cosign.exe",
@@ -4360,6 +4363,7 @@ def _validate_windows_setup_provenance(
         WINDOWS_PYTHON_EMBED_NAME: "python_embed_sha256",
         WINDOWS_YARA_COMPAT_WHEEL: "yara_compat_wheel_sha256",
         "site-packages.zip": "site_packages_sha256",
+        "defenseclaw-hook-launcher.exe": "hook_launcher_sha256",
         "cosign.exe": "cosign_sha256",
     }
     if any(payload_files[name] != inputs[field] for name, field in payload_bindings.items()):


### PR DESCRIPTION
## Summary

- admit the Windows HookRuntime launcher digest into the release sealer's strict provenance schema
- require `hook_launcher_sha256` to be a canonical SHA-256 value and bind it to `payload_files["defenseclaw-hook-launcher.exe"]`
- update the release-candidate fixture and add a negative digest-mismatch regression test

## Root cause

Release workflow run [#75](https://github.com/cisco-ai-defense/defenseclaw/actions/runs/30465926402), targeting `0.8.10` at `8b6329d862fe15e3e041ee1fd21c8bca63ac9393`, failed in **Seal exact release candidate** with:

```
release candidate verification failed: Windows Setup provenance inputs does not use its closed field set
```

The Windows installer producer added `inputs.hook_launcher_sha256` and `payload_files["defenseclaw-hook-launcher.exe"]`, while `scripts/release_candidate.py` and its synthetic test fixture still enforced the previous closed field sets. Platform builds succeeded, but candidate assembly correctly failed closed before publication.

## Impact

The exact Windows artifact generated by Release #75 can now pass strict candidate validation without weakening the closed schema. The new digest is independently shape-validated and must match the payload-file digest, preserving tamper detection.

## Validation

- exact Release #75 `release-windows-installer-30465926402-1` artifact: `_validate_windows_installer_assets(..., exact_file_set=True)` passes
- `uv run python -m pytest cli/tests/test_release_candidate.py -q` — 201 passed, 7 skipped
- `uv run ruff check scripts/release_candidate.py cli/tests/test_release_candidate.py`
- `uv run python -m py_compile scripts/release_candidate.py cli/tests/test_release_candidate.py`
- `git diff --check`

No release rerun was triggered.