### PR TITLE
Fix Windows release uninstall acceptance

### DIFF
--- a/.github/workflows/release-candidate-smoke.yml
+++ b/.github/workflows/release-candidate-smoke.yml
@@ -229,6 +229,7 @@ jobs:
           ./scripts/test-fresh-install-release-windows.ps1 `
             -ReleaseDir "$env:GITHUB_WORKSPACE/release-candidate/dist" `
             -TargetVersion "$env:RELEASE_TAG" `
+            -UninstallContract deferred `
             -DiagnosticsRoot (Join-Path $env:RUNNER_TEMP 'defenseclaw-release-bootstrap-diagnostics')
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       - name: Upload Windows bootstrap diagnostics on failure

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -589,6 +589,7 @@ jobs:
           ./scripts/test-fresh-install-release-windows.ps1 `
             -ReleaseDir $env:DC_BOOTSTRAP_RELEASE_DIR `
             -TargetVersion $env:BOOTSTRAP_FIXTURE_VERSION `
+            -UninstallContract immediate `
             -StateRoot $bootstrapState `
             -DiagnosticsRoot $env:DC_DIAGNOSTICS
       - name: Capture bounded diagnostics

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -18,6 +18,10 @@ import yaml
 from defenseclaw import resolver_hint
 
 from scripts import release_candidate
+from tests.windows_release_contracts import (
+    DEFERRED_UNINSTALL_FORBIDDEN_MARKERS,
+    DEFERRED_UNINSTALL_REQUIRED_MARKERS,
+)
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github/workflows/release.yaml"
@@ -1037,6 +1041,7 @@ def test_windows_release_accepts_signed_or_explicitly_unverified_setup_and_is_fr
     assert windows_smoke["runs-on"] == "windows-latest"
     assert "scripts/test-fresh-install-release-windows.ps1" in str(windows_smoke)
     assert "-TargetVersion" in str(windows_smoke)
+    assert "-UninstallContract deferred" in str(windows_smoke)
     assert "-SuccessPathOnly" not in str(windows_smoke)
 
 
@@ -1048,6 +1053,7 @@ def test_windows_install_ps1_smoke_uses_disposable_native_profile_and_layout() -
     assert "-Mode bootstrap-acceptance" in smoke
     assert "-ArtifactRoot $ReleaseDir" in smoke
     assert "-TargetVersion $TargetVersion" in smoke
+    assert "-BootstrapUninstallContract $UninstallContract" in smoke
     assert '$installer = Join-Path $ReleaseDir "install.ps1"' in smoke
     assert '$installer = Join-Path $PSScriptRoot "install.ps1"' not in smoke
     assert "'bootstrap-acceptance'" in disposable
@@ -1079,18 +1085,10 @@ def test_windows_install_ps1_smoke_uses_disposable_native_profile_and_layout() -
     assert "$first = Invoke-CapturedProcess" in smoke
     assert "$second = Invoke-CapturedProcess" in smoke
     assert "DELETEUSERDATA=1" in smoke
-    assert "$uninstall.ExitCode -ne 3010" in smoke
-    assert "$uninstall.ExitCode -ne 0" not in smoke
-    assert "Assert-ExactDeferredUninstallState" in smoke
-    assert '"pending-reboot"' in smoke
-    assert '"converged"' in smoke
-    assert '"disabled"' in smoke
-    assert '"DefenseClawDeferredUninstallCleanup"' in smoke
-    assert "[Microsoft.Win32.RegistryValueKind]::String" in smoke
-    assert "cleanup record does not bind the exact release Setup digest" in smoke
-    assert "uninstall retained unrelated managed residue" in smoke
-    assert "Same-boot uninstall Run value is not the exact absolute cached Setup command" in smoke
-    assert "Wait-ForPathRemoval -Path $cacheRoot" not in smoke
+    for marker in DEFERRED_UNINSTALL_REQUIRED_MARKERS:
+        assert marker in smoke
+    for marker in DEFERRED_UNINSTALL_FORBIDDEN_MARKERS:
+        assert marker not in smoke
     assert 'GetEnvironmentVariable("Path", "User")' in smoke
     assert "uninstall did not restore the original user PATH exactly" in smoke
 
@@ -1123,7 +1121,9 @@ def test_windows_fresh_install_refuses_reparse_release_inputs_before_bootstrap()
     assert "[IO.FileAttributes]::ReparsePoint" in file_guard
 
     directory_check = smoke.index("$ReleaseDir = Resolve-RegularReleaseDirectory -Path $ReleaseDir")
-    release_file_check = smoke.index("foreach ($path in @($installer, $cosign, $setup))")
+    release_file_check = smoke.index(
+        "foreach ($path in @($installer, $cosign, $setup, $setupProvenance))"
+    )
     execute = smoke.index("$first = Invoke-CapturedProcess")
     assert directory_check < release_file_check < execute
     assert "Assert-RegularReleaseFile -Path $path" in smoke[release_file_check:execute]
@@ -1194,6 +1194,7 @@ def test_windows_pr_ci_executes_public_bootstrap_against_authenticated_fixture()
     assert "test-fresh-install-release-windows.ps1" in rendered
     assert "-ReleaseDir $env:DC_BOOTSTRAP_RELEASE_DIR" in rendered
     assert "-TargetVersion $env:BOOTSTRAP_FIXTURE_VERSION" in rendered
+    assert "-UninstallContract immediate" in rendered
     assert "-StateRoot $bootstrapState" in rendered
     assert "-DiagnosticsRoot $env:DC_DIAGNOSTICS" in rendered
     smoke = (ROOT / "scripts/test-fresh-install-release-windows.ps1").read_text(encoding="utf-8")

--- a/cli/tests/test_release_workflow_staged.py
+++ b/cli/tests/test_release_workflow_staged.py
@@ -1079,6 +1079,18 @@ def test_windows_install_ps1_smoke_uses_disposable_native_profile_and_layout() -
     assert "$first = Invoke-CapturedProcess" in smoke
     assert "$second = Invoke-CapturedProcess" in smoke
     assert "DELETEUSERDATA=1" in smoke
+    assert "$uninstall.ExitCode -ne 3010" in smoke
+    assert "$uninstall.ExitCode -ne 0" not in smoke
+    assert "Assert-ExactDeferredUninstallState" in smoke
+    assert '"pending-reboot"' in smoke
+    assert '"converged"' in smoke
+    assert '"disabled"' in smoke
+    assert '"DefenseClawDeferredUninstallCleanup"' in smoke
+    assert "[Microsoft.Win32.RegistryValueKind]::String" in smoke
+    assert "cleanup record does not bind the exact release Setup digest" in smoke
+    assert "uninstall retained unrelated managed residue" in smoke
+    assert "Same-boot uninstall Run value is not the exact absolute cached Setup command" in smoke
+    assert "Wait-ForPathRemoval -Path $cacheRoot" not in smoke
     assert 'GetEnvironmentVariable("Path", "User")' in smoke
     assert "uninstall did not restore the original user PATH exactly" in smoke
 

--- a/cli/tests/test_windows_release_certification.py
+++ b/cli/tests/test_windows_release_certification.py
@@ -10,6 +10,11 @@ from pathlib import Path
 
 import yaml
 
+from tests.windows_release_contracts import (
+    DEFERRED_UNINSTALL_FORBIDDEN_MARKERS,
+    DEFERRED_UNINSTALL_REQUIRED_MARKERS,
+)
+
 ROOT = Path(__file__).resolve().parents[2]
 HARNESS = (ROOT / "scripts" / "windows-native-ci.ps1").read_text(encoding="utf-8")
 PACKAGED_V8_VALIDATOR = (ROOT / "scripts" / "validate_packaged_v8_resources.py").read_text(encoding="utf-8")
@@ -123,6 +128,7 @@ def test_windows_release_is_fresh_install_only_and_uses_public_install_ps1() -> 
     assert "scripts/verify-sigstore-blob.py" in rendered
     assert "scripts/test-fresh-install-release-windows.ps1" in rendered
     assert "-TargetVersion" in rendered
+    assert "-UninstallContract deferred" in rendered
     assert "-SuccessPathOnly" not in rendered
     assert "defenseclaw-release-bootstrap-diagnostics" in rendered
     diagnostics = _step(job, "Upload Windows bootstrap diagnostics on failure")
@@ -146,6 +152,7 @@ def test_windows_release_is_fresh_install_only_and_uses_public_install_ps1() -> 
     assert "-Mode bootstrap-acceptance" in FRESH_INSTALL
     assert "-ArtifactRoot $ReleaseDir" in FRESH_INSTALL
     assert "-TargetVersion $TargetVersion" in FRESH_INSTALL
+    assert "-BootstrapUninstallContract $UninstallContract" in FRESH_INSTALL
     assert "$env:RUNNER_TEMP" in FRESH_INSTALL
     assert "$env:DC_WINDOWS_NATIVE_BASE_ROOT" in FRESH_INSTALL
     assert "Refusing to clean unexpected bootstrap acceptance state" in FRESH_INSTALL
@@ -189,22 +196,14 @@ def test_windows_release_is_fresh_install_only_and_uses_public_install_ps1() -> 
     assert "$second = Invoke-CapturedProcess" in FRESH_INSTALL
     assert "Out-String -Width 32768" in FRESH_INSTALL
     assert "DELETEUSERDATA=1" in FRESH_INSTALL
-    assert "$uninstall.ExitCode -ne 3010" in FRESH_INSTALL
-    assert "$uninstall.ExitCode -ne 0" not in FRESH_INSTALL
-    assert "Assert-ExactDeferredUninstallState" in FRESH_INSTALL
-    assert '"pending-reboot"' in FRESH_INSTALL
-    assert '"converged"' in FRESH_INSTALL
-    assert '"disabled"' in FRESH_INSTALL
-    assert '"DefenseClawDeferredUninstallCleanup"' in FRESH_INSTALL
-    assert "[Microsoft.Win32.RegistryValueKind]::String" in FRESH_INSTALL
-    assert "cleanup record does not bind the exact release Setup digest" in FRESH_INSTALL
-    assert "uninstall retained unrelated managed residue" in FRESH_INSTALL
-    assert "Same-boot uninstall Run value is not the exact absolute cached Setup command" in FRESH_INSTALL
-    assert "Wait-ForPathRemoval -Path $cacheRoot" not in FRESH_INSTALL
+    for marker in DEFERRED_UNINSTALL_REQUIRED_MARKERS:
+        assert marker in FRESH_INSTALL
+    for marker in DEFERRED_UNINSTALL_FORBIDDEN_MARKERS:
+        assert marker not in FRESH_INSTALL
     assert 'GetEnvironmentVariable("Path", "User")' in FRESH_INSTALL
     assert "uninstall did not restore the original user PATH exactly" in FRESH_INSTALL
     assert FRESH_INSTALL.rindex("$installed = $false") > FRESH_INSTALL.index(
-        "$uninstall.ExitCode -ne 3010"
+        "$uninstall.ExitCode -ne $expectedUninstallExitCode"
     )
     assert FRESH_INSTALL.rindex("$installed = $false") < FRESH_INSTALL.index(
         "Assert-ExactDeferredUninstallState `"

--- a/cli/tests/test_windows_release_certification.py
+++ b/cli/tests/test_windows_release_certification.py
@@ -189,10 +189,25 @@ def test_windows_release_is_fresh_install_only_and_uses_public_install_ps1() -> 
     assert "$second = Invoke-CapturedProcess" in FRESH_INSTALL
     assert "Out-String -Width 32768" in FRESH_INSTALL
     assert "DELETEUSERDATA=1" in FRESH_INSTALL
+    assert "$uninstall.ExitCode -ne 3010" in FRESH_INSTALL
+    assert "$uninstall.ExitCode -ne 0" not in FRESH_INSTALL
+    assert "Assert-ExactDeferredUninstallState" in FRESH_INSTALL
+    assert '"pending-reboot"' in FRESH_INSTALL
+    assert '"converged"' in FRESH_INSTALL
+    assert '"disabled"' in FRESH_INSTALL
+    assert '"DefenseClawDeferredUninstallCleanup"' in FRESH_INSTALL
+    assert "[Microsoft.Win32.RegistryValueKind]::String" in FRESH_INSTALL
+    assert "cleanup record does not bind the exact release Setup digest" in FRESH_INSTALL
+    assert "uninstall retained unrelated managed residue" in FRESH_INSTALL
+    assert "Same-boot uninstall Run value is not the exact absolute cached Setup command" in FRESH_INSTALL
+    assert "Wait-ForPathRemoval -Path $cacheRoot" not in FRESH_INSTALL
     assert 'GetEnvironmentVariable("Path", "User")' in FRESH_INSTALL
     assert "uninstall did not restore the original user PATH exactly" in FRESH_INSTALL
     assert FRESH_INSTALL.rindex("$installed = $false") > FRESH_INSTALL.index(
-        "uninstall did not restore the original user PATH exactly"
+        "$uninstall.ExitCode -ne 3010"
+    )
+    assert FRESH_INSTALL.rindex("$installed = $false") < FRESH_INSTALL.index(
+        "Assert-ExactDeferredUninstallState `"
     )
     canonical_version = "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
     assert canonical_version in FRESH_INSTALL

--- a/cli/tests/windows_release_contracts.py
+++ b/cli/tests/windows_release_contracts.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared static markers for the Windows release uninstall contract."""
+
+DEFERRED_UNINSTALL_REQUIRED_MARKERS = (
+    '$expectedUninstallExitCode = if ($UninstallContract -ceq "deferred") {',
+    "$uninstall.ExitCode -ne $expectedUninstallExitCode",
+    'if ($UninstallContract -ceq "deferred") {',
+    "Assert-ExactDeferredUninstallState",
+    "Assert-NoReparsePathChain",
+    "Assert-PrivatePathCustody",
+    "Assert-WindowsAMD64Executable",
+    "Get-AuthenticodeSignature -FilePath $hookLauncher",
+    "hook_launcher_sha256",
+    "product_executables_authenticode_signed",
+    "SignatureStatus]::NotSigned",
+    "cleanup_boot_identifier",
+    "uninstall_boot_identifier",
+    "retired_launcher_path",
+    "previous_maintenance_sha256",
+    "verified_connectors",
+    '"pending-reboot"',
+    '"converged"',
+    '"disabled"',
+    '"DefenseClawDeferredUninstallCleanup"',
+    "[Microsoft.Win32.RegistryValueKind]::String",
+    "cleanup record does not bind the exact release Setup digest",
+    "uninstall retained unrelated managed residue",
+    "Same-boot uninstall Run value is not the exact absolute cached Setup command",
+    "Wait-ForPathRemoval -Path $cacheRoot",
+)
+
+DEFERRED_UNINSTALL_FORBIDDEN_MARKERS = (
+    "$uninstall.ExitCode -ne 0",
+    "$uninstall.ExitCode -ne 3010",
+    "$uninstall.ExitCode -notin @(0, 3010)",
+    '"S-1-5-32-544"',
+)

--- a/scripts/invoke-windows-setup-standard-user-ci.ps1
+++ b/scripts/invoke-windows-setup-standard-user-ci.ps1
@@ -23,6 +23,8 @@ param(
     [Parameter(Mandatory)][string]$ArtifactRoot,
     [Parameter(Mandatory)][string]$StateRoot,
     [string]$TargetVersion = '',
+    [ValidateSet('immediate', 'deferred')]
+    [string]$BootstrapUninstallContract = 'deferred',
     [string]$DiagnosticsRoot = '',
     [ValidateRange(60, 7200)][int]$TimeoutSeconds = 4500,
     [switch]$Child,
@@ -389,6 +391,7 @@ function Invoke-ChildMode {
             & (Join-Path $PSScriptRoot 'test-fresh-install-release-windows.ps1') `
                 -ReleaseDir $artifacts `
                 -TargetVersion $TargetVersion `
+                -UninstallContract $BootstrapUninstallContract `
                 -StateRoot $state `
                 -Child
         } elseif ($Mode -eq 'contract') {
@@ -1139,7 +1142,10 @@ try {
         $arguments += @('-Connector', $Connector)
     }
     if ($Mode -eq 'bootstrap-acceptance') {
-        $arguments += @('-TargetVersion', $TargetVersion)
+        $arguments += @(
+            '-TargetVersion', $TargetVersion,
+            '-BootstrapUninstallContract', $BootstrapUninstallContract
+        )
     }
     if ($Mode -eq 'setup-acceptance') {
         $arguments += '-ExerciseWmiEscape'

--- a/scripts/test-fresh-install-release-windows.ps1
+++ b/scripts/test-fresh-install-release-windows.ps1
@@ -12,7 +12,8 @@
     standard-user launcher. Child mode runs with a real isolated profile and
     HKCU hive, installs through the exact sealed install.ps1 release asset,
     repeats the authenticated handoff, verifies the installed version, and
-    proves complete uninstall.
+    proves immediate uninstall plus the exact authenticated cleanup state that
+    must remain until Windows restarts.
 #>
 
 [CmdletBinding()]
@@ -148,14 +149,148 @@ function Get-UserPathEntryCount {
     ).Count
 }
 
-function Wait-ForPathRemoval {
-    param([Parameter(Mandatory = $true)][string]$Path)
+function Assert-ExactDeferredUninstallState {
+    param(
+        [Parameter(Mandatory = $true)][string]$LocalAppData,
+        [Parameter(Mandatory = $true)][string]$CacheRoot,
+        [Parameter(Mandatory = $true)][string]$ExpectedSetup
+    )
 
-    # Native Setup's transaction-bound helper may wait up to two minutes for
-    # its parent to exit. Keep release smoke aligned with that product bound
-    # plus scheduling margin while retaining the final fail-closed assertion.
-    for ($attempt = 0; $attempt -lt 520 -and (Test-Path -LiteralPath $Path); $attempt++) {
-        Start-Sleep -Milliseconds 250
+    $productRoot = Join-Path $LocalAppData "DefenseClaw"
+    $hookRuntimeRoot = Join-Path $productRoot "HookRuntime"
+    $installerStateRoot = Join-Path $productRoot "InstallerState"
+    $cachedSetup = Join-Path $CacheRoot "DefenseClawSetup-x64.exe"
+    $hookLauncher = Join-Path $hookRuntimeRoot "defenseclaw-hook.exe"
+    $hookStatePath = Join-Path $hookRuntimeRoot "hook-runtime-state.json"
+    $cleanupRecordPath = Join-Path $installerStateRoot "uninstall-cleanup.json"
+    $transactionJournalPath = Join-Path $installerStateRoot "setup-transaction.json"
+
+    foreach ($requiredResidue in @(
+        $cachedSetup,
+        $hookLauncher,
+        $hookStatePath,
+        $cleanupRecordPath,
+        $transactionJournalPath
+    )) {
+        if (-not (Test-Path -LiteralPath $requiredResidue -PathType Leaf)) {
+            throw "Same-boot uninstall did not retain authenticated cleanup authority: $requiredResidue"
+        }
+    }
+
+    $cleanupRecord = Get-Content -LiteralPath $cleanupRecordPath -Raw -Encoding UTF8 |
+        ConvertFrom-Json
+    $transactionJournal = Get-Content -LiteralPath $transactionJournalPath -Raw -Encoding UTF8 |
+        ConvertFrom-Json
+    $hookState = Get-Content -LiteralPath $hookStatePath -Raw -Encoding UTF8 |
+        ConvertFrom-Json
+
+    if ([int]$cleanupRecord.schema_version -ne 1 -or
+        [string]$cleanupRecord.status -cne "pending-reboot" -or
+        [string]$cleanupRecord.transaction_id -cnotmatch "^[0-9a-f]{32}$") {
+        throw "Same-boot uninstall did not retain the exact pending cleanup record"
+    }
+    if (-not ([IO.Path]::GetFullPath([string]$cleanupRecord.maintenance_path)).Equals(
+            [IO.Path]::GetFullPath($cachedSetup),
+            [StringComparison]::OrdinalIgnoreCase
+        ) -or
+        [string]$cleanupRecord.run_value_name -cne "DefenseClawDeferredUninstallCleanup") {
+        throw "Same-boot uninstall cleanup record does not bind the canonical cached Setup authority"
+    }
+    $expectedSetupDigest = (Get-FileHash -LiteralPath $ExpectedSetup -Algorithm SHA256).Hash.ToLowerInvariant()
+    $cachedSetupDigest = (Get-FileHash -LiteralPath $cachedSetup -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($cachedSetupDigest -cne $expectedSetupDigest -or
+        [string]$cleanupRecord.maintenance_sha256 -cne $cachedSetupDigest) {
+        throw "Same-boot uninstall cleanup record does not bind the exact release Setup digest"
+    }
+    if ([int]$transactionJournal.schema_version -ne 2 -or
+        [string]$transactionJournal.phase -cne "converged" -or
+        [string]$transactionJournal.transaction.action -cne "uninstall" -or
+        [string]$transactionJournal.transaction.id -cne [string]$cleanupRecord.transaction_id) {
+        throw "Same-boot uninstall did not retain the exact converged uninstall journal"
+    }
+    if ([int]$hookState.schema_version -ne 2 -or
+        [string]$hookState.status -cne "disabled" -or
+        [string]$hookState.transaction_id -cne [string]$cleanupRecord.transaction_id) {
+        throw "Same-boot uninstall did not retain the exact disabled HookRuntime state"
+    }
+
+    $hookRuntimeNames = @(
+        Get-ChildItem -LiteralPath $hookRuntimeRoot -Force |
+            ForEach-Object Name |
+            Sort-Object
+    )
+    $expectedHookRuntimeNames = @("defenseclaw-hook.exe", "hook-runtime-state.json")
+    if (($hookRuntimeNames -join "`0") -cne ($expectedHookRuntimeNames -join "`0")) {
+        throw "Same-boot uninstall retained unexpected HookRuntime residue: $($hookRuntimeNames -join ', ')"
+    }
+
+    $installerStateNames = @(
+        Get-ChildItem -LiteralPath $installerStateRoot -Force |
+            ForEach-Object Name |
+            Sort-Object
+    )
+    $unexpectedInstallerState = @(
+        $installerStateNames |
+            Where-Object {
+                $_ -notin @(
+                    "setup-transaction.json",
+                    "setup.log",
+                    "uninstall-cleanup.json"
+                )
+            }
+    )
+    if ($unexpectedInstallerState.Count -ne 0) {
+        throw "Same-boot uninstall retained unrelated InstallerState: $($unexpectedInstallerState -join ', ')"
+    }
+
+    $cacheNames = @(
+        Get-ChildItem -LiteralPath $CacheRoot -Force |
+            ForEach-Object Name |
+            Sort-Object
+    )
+    if (($cacheNames -join "`0") -cne "DefenseClawSetup-x64.exe") {
+        throw "Same-boot uninstall retained unexpected installer-cache residue: $($cacheNames -join ', ')"
+    }
+
+    $productRootNames = @(
+        Get-ChildItem -LiteralPath $productRoot -Force |
+            ForEach-Object Name |
+            Sort-Object
+    )
+    $expectedProductRootNames = @("HookRuntime", "InstallerCache", "InstallerState")
+    if (($productRootNames -join "`0") -cne ($expectedProductRootNames -join "`0")) {
+        throw "Same-boot uninstall retained unrelated managed residue: $($productRootNames -join ', ')"
+    }
+
+    $runKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey(
+        "Software\Microsoft\Windows\CurrentVersion\Run",
+        $false
+    )
+    if ($null -eq $runKey) {
+        throw "Same-boot uninstall did not retain the cleanup Run key"
+    }
+    try {
+        $runCommand = $runKey.GetValue(
+            "DefenseClawDeferredUninstallCleanup",
+            $null,
+            [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames
+        )
+        $runValueKind = if ($null -eq $runCommand) {
+            $null
+        } else {
+            $runKey.GetValueKind("DefenseClawDeferredUninstallCleanup")
+        }
+    } finally {
+        $runKey.Dispose()
+    }
+    if ($runValueKind -ne [Microsoft.Win32.RegistryValueKind]::String -or
+        [string]$runCommand -cne [string]$cleanupRecord.run_command) {
+        throw "Same-boot uninstall Run value differs from the authenticated cleanup record"
+    }
+    $expectedRunCommand = '"' + $cachedSetup + '" /cleanup /quiet CLEANUPTRANSACTION=' +
+        [string]$cleanupRecord.transaction_id
+    if ([string]$runCommand -cne $expectedRunCommand) {
+        throw "Same-boot uninstall Run value is not the exact absolute cached Setup command"
     }
 }
 
@@ -355,13 +490,16 @@ try {
     $uninstall = Invoke-CapturedProcess `
         -FilePath $setup `
         -ArgumentList @("/uninstall", "/quiet", "DELETEUSERDATA=1")
-    if ($uninstall.ExitCode -ne 0) {
-        throw "Native uninstall failed ($($uninstall.ExitCode)):`n$($uninstall.Output)"
+    if ($uninstall.ExitCode -ne 3010) {
+        throw (
+            "Native uninstall did not return the required Windows restart result " +
+            "3010 ($($uninstall.ExitCode)):`n$($uninstall.Output)"
+        )
     }
-    Wait-ForPathRemoval -Path $cacheRoot
-    foreach ($path in @($installRoot, $dataRoot, $cacheRoot, $arpKey)) {
+    $installed = $false
+    foreach ($path in @($installRoot, $dataRoot, $arpKey)) {
         if (Test-Path -LiteralPath $path) {
-            throw "Public bootstrap uninstall left managed state behind: $path"
+            throw "Public bootstrap uninstall left active managed state behind: $path"
         }
     }
     if (-not [string]::Equals(
@@ -371,7 +509,10 @@ try {
         )) {
         throw "Public bootstrap uninstall did not restore the original user PATH exactly"
     }
-    $installed = $false
+    Assert-ExactDeferredUninstallState `
+        -LocalAppData $localAppData `
+        -CacheRoot $cacheRoot `
+        -ExpectedSetup $setup
     Write-Host "Fresh Windows public bootstrap passed: $TargetVersion" -ForegroundColor Green
 } finally {
     if ($installed -or (Test-Path -LiteralPath $installRoot)) {
@@ -379,7 +520,7 @@ try {
             $cleanup = Invoke-CapturedProcess `
                 -FilePath $setup `
                 -ArgumentList @("/uninstall", "/quiet", "DELETEUSERDATA=1")
-            if ($cleanup.ExitCode -ne 0) {
+            if ($cleanup.ExitCode -notin @(0, 3010)) {
                 Write-Warning "Emergency native uninstall failed ($($cleanup.ExitCode))"
             }
         } catch {

--- a/scripts/test-fresh-install-release-windows.ps1
+++ b/scripts/test-fresh-install-release-windows.ps1
@@ -20,6 +20,9 @@
 param(
     [Parameter(Mandatory = $true)][string]$ReleaseDir,
     [Parameter(Mandatory = $true)][string]$TargetVersion,
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("immediate", "deferred")]
+    [string]$UninstallContract,
     [Parameter(DontShow = $true)][switch]$Child,
     [Parameter(DontShow = $true)][string]$StateRoot = "",
     [Parameter(DontShow = $true)][string]$DiagnosticsRoot = ""
@@ -149,11 +152,150 @@ function Get-UserPathEntryCount {
     ).Count
 }
 
+function Assert-NoReparsePathChain {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $current = [IO.Path]::GetFullPath($Path)
+    while ($true) {
+        try {
+            $attributes = [IO.File]::GetAttributes($current)
+            if ($attributes -band [IO.FileAttributes]::ReparsePoint) {
+                throw "Deferred uninstall authority crosses a reparse point: $current"
+            }
+        } catch [IO.FileNotFoundException] {
+            # Missing transaction artifacts are expected after convergence.
+        } catch [IO.DirectoryNotFoundException] {
+            # Continue with the first existing ancestor.
+        }
+        $parent = [IO.Directory]::GetParent($current)
+        if ($null -eq $parent) {
+            break
+        }
+        $current = $parent.FullName
+    }
+}
+
+function Assert-CanonicalPathBinding {
+    param(
+        [Parameter(Mandatory = $true)][string]$Actual,
+        [Parameter(Mandatory = $true)][string]$Expected,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    if (-not [IO.Path]::IsPathFullyQualified($Actual)) {
+        throw "$Label is not an absolute filesystem path"
+    }
+    $normalizedActual = [IO.Path]::GetFullPath($Actual)
+    $normalizedExpected = [IO.Path]::GetFullPath($Expected)
+    if (-not $Actual.Equals($normalizedActual, [StringComparison]::OrdinalIgnoreCase) -or
+        -not $normalizedActual.Equals(
+            $normalizedExpected,
+            [StringComparison]::OrdinalIgnoreCase
+        )) {
+        throw "$Label is not bound to the exact canonical path"
+    }
+}
+
+function Assert-PrivatePathCustody {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [switch]$Directory
+    )
+
+    Assert-NoReparsePathChain -Path $Path
+    $item = Get-Item -LiteralPath $Path -Force -ErrorAction Stop
+    if ([bool]$item.PSIsContainer -ne [bool]$Directory -or
+        ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) {
+        throw "Deferred uninstall authority is not the required regular path: $Path"
+    }
+
+    $acl = Get-Acl -LiteralPath $Path -ErrorAction Stop
+    $owner = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+    $actualOwner = $acl.GetOwner([Security.Principal.SecurityIdentifier]).Value
+    if (-not $acl.AreAccessRulesProtected -or $actualOwner -cne $owner) {
+        throw "Deferred uninstall authority is not owner-controlled with a protected DACL: $Path"
+    }
+    $systemSid = "S-1-5-18"
+    $creatorOwnerSid = "S-1-3-0"
+    $foundOwner = $false
+    $foundSystem = $false
+    foreach ($rule in $acl.GetAccessRules(
+            $true,
+            $true,
+            [Security.Principal.SecurityIdentifier]
+        )) {
+        $sid = $rule.IdentityReference.Value
+        if ($rule.AccessControlType -ne [Security.AccessControl.AccessControlType]::Allow) {
+            throw (
+                "Deferred uninstall authority contains a non-allow ACE " +
+                "($sid): $Path"
+            )
+        }
+        if ([int64]$rule.FileSystemRights -eq 0) {
+            continue
+        }
+        if ($sid -ceq $owner -or $sid -ceq $creatorOwnerSid) {
+            $foundOwner = $true
+            continue
+        }
+        if ($sid -ceq $systemSid) {
+            $foundSystem = $true
+            continue
+        }
+        throw "Deferred uninstall authority grants access to an unexpected SID ($sid): $Path"
+    }
+    if (-not $foundOwner -or -not $foundSystem) {
+        throw "Deferred uninstall authority lacks required owner and SYSTEM access: $Path"
+    }
+}
+
+function Assert-WindowsAMD64Executable {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $stream = [IO.File]::Open(
+        $Path,
+        [IO.FileMode]::Open,
+        [IO.FileAccess]::Read,
+        [IO.FileShare]::Read
+    )
+    $reader = [IO.BinaryReader]::new($stream)
+    try {
+        if ($stream.Length -lt 70 -or $reader.ReadUInt16() -ne 0x5A4D) {
+            throw "Deferred HookRuntime launcher is not a valid PE executable"
+        }
+        $stream.Position = 0x3C
+        $peOffset = [int64]$reader.ReadUInt32()
+        if ($peOffset -lt 64 -or $peOffset -gt ($stream.Length - 6)) {
+            throw "Deferred HookRuntime launcher has an invalid PE header offset"
+        }
+        $stream.Position = $peOffset
+        if ($reader.ReadUInt32() -ne 0x00004550 -or $reader.ReadUInt16() -ne 0x8664) {
+            throw "Deferred HookRuntime launcher is not a Windows AMD64 executable"
+        }
+    } finally {
+        $reader.Dispose()
+        $stream.Dispose()
+    }
+}
+
+function Wait-ForPathRemoval {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    # Historical installers use a transaction-bound post-exit helper that may
+    # wait up to two minutes for its parent to exit. The current deferred
+    # cleanup contract returns 3010 and must never enter this compatibility
+    # wait.
+    for ($attempt = 0; $attempt -lt 520 -and (Test-Path -LiteralPath $Path); $attempt++) {
+        Start-Sleep -Milliseconds 250
+    }
+}
+
 function Assert-ExactDeferredUninstallState {
     param(
         [Parameter(Mandatory = $true)][string]$LocalAppData,
         [Parameter(Mandatory = $true)][string]$CacheRoot,
-        [Parameter(Mandatory = $true)][string]$ExpectedSetup
+        [Parameter(Mandatory = $true)][string]$ExpectedSetup,
+        [Parameter(Mandatory = $true)][string]$ExpectedProvenance
     )
 
     $productRoot = Join-Path $LocalAppData "DefenseClaw"
@@ -164,7 +306,16 @@ function Assert-ExactDeferredUninstallState {
     $hookStatePath = Join-Path $hookRuntimeRoot "hook-runtime-state.json"
     $cleanupRecordPath = Join-Path $installerStateRoot "uninstall-cleanup.json"
     $transactionJournalPath = Join-Path $installerStateRoot "setup-transaction.json"
+    $cacheAckPath = Join-Path $CacheRoot "uninstall-cleanup-ack.json"
+    $installRoot = Join-Path $LocalAppData "Programs\DefenseClaw"
+    $dataRoot = Join-Path (
+        [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
+    ) ".defenseclaw"
+    $expectedHookPath = Join-Path $installRoot "bin\defenseclaw-hook.exe"
 
+    foreach ($authorityRoot in @($hookRuntimeRoot, $CacheRoot, $installerStateRoot)) {
+        Assert-PrivatePathCustody -Path $authorityRoot -Directory
+    }
     foreach ($requiredResidue in @(
         $cachedSetup,
         $hookLauncher,
@@ -175,6 +326,7 @@ function Assert-ExactDeferredUninstallState {
         if (-not (Test-Path -LiteralPath $requiredResidue -PathType Leaf)) {
             throw "Same-boot uninstall did not retain authenticated cleanup authority: $requiredResidue"
         }
+        Assert-PrivatePathCustody -Path $requiredResidue
     }
 
     $cleanupRecord = Get-Content -LiteralPath $cleanupRecordPath -Raw -Encoding UTF8 |
@@ -183,17 +335,55 @@ function Assert-ExactDeferredUninstallState {
         ConvertFrom-Json
     $hookState = Get-Content -LiteralPath $hookStatePath -Raw -Encoding UTF8 |
         ConvertFrom-Json
+    $provenance = Get-Content -LiteralPath $ExpectedProvenance -Raw -Encoding UTF8 |
+        ConvertFrom-Json
+    $releaseUnsigned = [bool]$provenance.unsigned
+    $productExecutablesSigned = [bool]$provenance.inputs.product_executables_authenticode_signed
+    if ($releaseUnsigned -eq $productExecutablesSigned) {
+        throw "Release provenance has an inconsistent Windows signing posture"
+    }
 
     if ([int]$cleanupRecord.schema_version -ne 1 -or
         [string]$cleanupRecord.status -cne "pending-reboot" -or
-        [string]$cleanupRecord.transaction_id -cnotmatch "^[0-9a-f]{32}$") {
+        [string]$cleanupRecord.transaction_id -cnotmatch "^[0-9a-f]{32}$" -or
+        [string]$cleanupRecord.cleanup_boot_identifier -cne "" -or
+        [string]$cleanupRecord.uninstall_boot_identifier -cnotmatch (
+            "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-" +
+            "[0-9a-f]{4}-[0-9a-f]{12}$"
+        )) {
         throw "Same-boot uninstall did not retain the exact pending cleanup record"
     }
-    if (-not ([IO.Path]::GetFullPath([string]$cleanupRecord.maintenance_path)).Equals(
-            [IO.Path]::GetFullPath($cachedSetup),
-            [StringComparison]::OrdinalIgnoreCase
-        ) -or
-        [string]$cleanupRecord.run_value_name -cne "DefenseClawDeferredUninstallCleanup") {
+    $transactionID = [string]$cleanupRecord.transaction_id
+    foreach ($pathBinding in @(
+        @([string]$cleanupRecord.runtime_root, $hookRuntimeRoot, "cleanup runtime root"),
+        @([string]$cleanupRecord.launcher_path, $hookLauncher, "cleanup launcher"),
+        @([string]$cleanupRecord.state_path, $hookStatePath, "cleanup state"),
+        @(
+            [string]$cleanupRecord.retired_launcher_path,
+            "$hookLauncher.retired.$transactionID",
+            "retired cleanup launcher"
+        ),
+        @(
+            [string]$cleanupRecord.retired_state_path,
+            "$hookStatePath.retired.$transactionID",
+            "retired cleanup state"
+        ),
+        @([string]$cleanupRecord.hook_path, $expectedHookPath, "cleanup hook target"),
+        @([string]$cleanupRecord.maintenance_path, $cachedSetup, "cleanup maintenance executable"),
+        @([string]$cleanupRecord.installer_state_root, $installerStateRoot, "installer-state root"),
+        @([string]$cleanupRecord.journal_path, $transactionJournalPath, "cleanup journal"),
+        @([string]$cleanupRecord.record_path, $cleanupRecordPath, "cleanup record"),
+        @([string]$cleanupRecord.cache_ack_path, $cacheAckPath, "cleanup cache acknowledgement"),
+        @([string]$hookState.runtime_root, $hookRuntimeRoot, "HookRuntime state root"),
+        @([string]$hookState.launcher_path, $hookLauncher, "HookRuntime state launcher"),
+        @([string]$hookState.hook_path, $expectedHookPath, "HookRuntime state hook target")
+    )) {
+        Assert-CanonicalPathBinding `
+            -Actual ([string]$pathBinding[0]) `
+            -Expected ([string]$pathBinding[1]) `
+            -Label ([string]$pathBinding[2])
+    }
+    if ([string]$cleanupRecord.run_value_name -cne "DefenseClawDeferredUninstallCleanup") {
         throw "Same-boot uninstall cleanup record does not bind the canonical cached Setup authority"
     }
     $expectedSetupDigest = (Get-FileHash -LiteralPath $ExpectedSetup -Algorithm SHA256).Hash.ToLowerInvariant()
@@ -202,16 +392,144 @@ function Assert-ExactDeferredUninstallState {
         [string]$cleanupRecord.maintenance_sha256 -cne $cachedSetupDigest) {
         throw "Same-boot uninstall cleanup record does not bind the exact release Setup digest"
     }
+    $transaction = $transactionJournal.transaction
     if ([int]$transactionJournal.schema_version -ne 2 -or
         [string]$transactionJournal.phase -cne "converged" -or
-        [string]$transactionJournal.transaction.action -cne "uninstall" -or
-        [string]$transactionJournal.transaction.id -cne [string]$cleanupRecord.transaction_id) {
+        [int]$transaction.schema_version -ne 1 -or
+        [string]$transaction.action -cne "uninstall" -or
+        [string]$transaction.id -cne $transactionID -or
+        [bool]$transaction.maintenance_existed -ne $true -or
+        [string]$transaction.previous_maintenance_sha256 -cne $cachedSetupDigest -or
+        [string]$transaction.previous_maintenance_sha256 -cne (
+            [string]$cleanupRecord.maintenance_sha256
+        ) -or
+        [string]$transaction.maintenance_sha256 -cne "" -or
+        [bool]$transaction.had_install -ne $true -or
+        $null -eq $transaction.previous_state -or
+        [bool]$transaction.delete_user_data -ne $true -or
+        [string]$transaction.target_connector -cne "none" -or
+        [bool]$transaction.target_services.gateway -ne $false -or
+        [bool]$transaction.target_services.watchdog -ne $false) {
         throw "Same-boot uninstall did not retain the exact converged uninstall journal"
+    }
+    $previousState = $transaction.previous_state
+    if ([int]$previousState.schema_version -ne 1 -or
+        [string]$previousState.install_kind -cne "native-windows-exe" -or
+        [string]$previousState.install_scope -cne "user" -or
+        [string]$previousState.connector -cne "none" -or
+        [bool]$previousState.unsigned_local_artifact -ne $releaseUnsigned -or
+        [bool]$previousState.release_signing_required -ne $true) {
+        throw "Converged uninstall journal does not bind the authenticated native installation"
+    }
+    foreach ($previousStateBinding in @(
+        @([string]$previousState.install_root, $installRoot, "previous install root"),
+        @([string]$previousState.data_root, $dataRoot, "previous install data root"),
+        @([string]$previousState.maintenance_path, $cachedSetup, "previous maintenance executable")
+    )) {
+        Assert-CanonicalPathBinding `
+            -Actual ([string]$previousStateBinding[0]) `
+            -Expected ([string]$previousStateBinding[1]) `
+            -Label ([string]$previousStateBinding[2])
+    }
+    foreach ($transactionPathBinding in @(
+        @([string]$transaction.install_root, $installRoot, "transaction install root"),
+        @([string]$transaction.data_root, $dataRoot, "transaction data root"),
+        @([string]$transaction.maintenance_path, $cachedSetup, "transaction maintenance executable"),
+        @([string]$transaction.staging_path, "$installRoot.staging.$transactionID", "transaction staging"),
+        @([string]$transaction.backup_path, "$installRoot.backup.$transactionID", "transaction backup"),
+        @([string]$transaction.trash_path, "$installRoot.uninstall.$transactionID", "transaction trash"),
+        @(
+            [string]$transaction.maintenance_new,
+            "$cachedSetup.new.$transactionID",
+            "transaction maintenance staging"
+        ),
+        @(
+            [string]$transaction.maintenance_backup,
+            "$cachedSetup.backup.$transactionID",
+            "transaction maintenance backup"
+        )
+    )) {
+        Assert-CanonicalPathBinding `
+            -Actual ([string]$transactionPathBinding[0]) `
+            -Expected ([string]$transactionPathBinding[1]) `
+            -Label ([string]$transactionPathBinding[2])
+        Assert-NoReparsePathChain -Path ([string]$transactionPathBinding[0])
+    }
+    foreach ($transactionArtifact in @(
+        [string]$transaction.install_root,
+        [string]$transaction.staging_path,
+        [string]$transaction.backup_path,
+        [string]$transaction.trash_path,
+        [string]$transaction.maintenance_new,
+        [string]$transaction.maintenance_backup
+    )) {
+        if (Test-Path -LiteralPath $transactionArtifact) {
+            throw "Converged uninstall retained a transaction artifact: $transactionArtifact"
+        }
+    }
+    $recordConnectors = @($cleanupRecord.verified_connectors | ForEach-Object { [string]$_ })
+    $journalConnectors = @($transaction.previous_connectors | ForEach-Object { [string]$_ })
+    if ($recordConnectors.Count -ne 0 -or $journalConnectors.Count -ne 0) {
+        throw "Connector-none release uninstall retained connector cleanup authority"
     }
     if ([int]$hookState.schema_version -ne 2 -or
         [string]$hookState.status -cne "disabled" -or
-        [string]$hookState.transaction_id -cne [string]$cleanupRecord.transaction_id) {
+        [string]$hookState.transaction_id -cne $transactionID -or
+        [string]$hookState.data_root -cne "" -or
+        [string]$hookState.gateway_path -cne "" -or
+        [string]$hookState.gateway_sha256 -cne "") {
         throw "Same-boot uninstall did not retain the exact disabled HookRuntime state"
+    }
+    $expectedHookLauncherDigest = [string]$provenance.inputs.hook_launcher_sha256
+    $actualHookLauncherDigest = (
+        Get-FileHash -LiteralPath $hookLauncher -Algorithm SHA256
+    ).Hash.ToLowerInvariant()
+    $hookLauncherItem = Get-Item -LiteralPath $hookLauncher -Force
+    if ($expectedHookLauncherDigest -cnotmatch "^[0-9a-f]{64}$" -or
+        $actualHookLauncherDigest -cne $expectedHookLauncherDigest -or
+        [string]$cleanupRecord.launcher_sha256 -cne $expectedHookLauncherDigest -or
+        [string]$hookState.launcher_sha256 -cne $expectedHookLauncherDigest -or
+        [int64]$cleanupRecord.launcher_size -ne [int64]$hookLauncherItem.Length -or
+        [string]$cleanupRecord.launcher_kind -cne "trampoline" -or
+        [string]$hookState.launcher_kind -cne "trampoline" -or
+        [string]$cleanupRecord.hook_sha256 -cnotmatch "^[0-9a-f]{64}$" -or
+        [string]$cleanupRecord.hook_sha256 -cne [string]$hookState.hook_sha256) {
+        throw "Same-boot uninstall did not cross-bind the exact sealed HookRuntime launcher"
+    }
+    Assert-WindowsAMD64Executable -Path $hookLauncher
+    $hookSignature = Get-AuthenticodeSignature -FilePath $hookLauncher
+    $hookPublisher = if ($null -eq $hookSignature.SignerCertificate) {
+        ""
+    } else {
+        $hookSignature.SignerCertificate.GetNameInfo(
+            [Security.Cryptography.X509Certificates.X509NameType]::SimpleName,
+            $false
+        )
+    }
+    if ($releaseUnsigned) {
+        if ($hookSignature.Status -ne [System.Management.Automation.SignatureStatus]::NotSigned -or
+            $null -ne $hookSignature.SignerCertificate -or
+            [bool]$cleanupRecord.launcher_signed -ne $false -or
+            [bool]$cleanupRecord.unsigned_local_artifact -ne $true -or
+            [string]$cleanupRecord.signer_thumbprint_sha256 -cne "") {
+            throw "Explicitly unverified release retained inconsistent unsigned-local HookRuntime authority"
+        }
+    } else {
+        if ($hookSignature.Status -ne [System.Management.Automation.SignatureStatus]::Valid -or
+            $null -eq $hookSignature.SignerCertificate -or
+            $hookPublisher -cne "Cisco Systems, Inc." -or
+            [bool]$cleanupRecord.launcher_signed -ne $true -or
+            [bool]$cleanupRecord.unsigned_local_artifact -ne $false) {
+            throw "Signed release retained a HookRuntime launcher without valid Cisco Authenticode"
+        }
+        $actualSignerDigest = [Convert]::ToHexString(
+            [Security.Cryptography.SHA256]::HashData(
+                $hookSignature.SignerCertificate.RawData
+            )
+        ).ToLowerInvariant()
+        if ([string]$cleanupRecord.signer_thumbprint_sha256 -cne $actualSignerDigest) {
+            throw "Same-boot uninstall HookRuntime signer differs from the authenticated cleanup record"
+        }
     }
 
     $hookRuntimeNames = @(
@@ -241,6 +559,9 @@ function Assert-ExactDeferredUninstallState {
     )
     if ($unexpectedInstallerState.Count -ne 0) {
         throw "Same-boot uninstall retained unrelated InstallerState: $($unexpectedInstallerState -join ', ')"
+    }
+    foreach ($installerStateName in $installerStateNames) {
+        Assert-PrivatePathCustody -Path (Join-Path $installerStateRoot $installerStateName)
     }
 
     $cacheNames = @(
@@ -287,9 +608,28 @@ function Assert-ExactDeferredUninstallState {
         [string]$runCommand -cne [string]$cleanupRecord.run_command) {
         throw "Same-boot uninstall Run value differs from the authenticated cleanup record"
     }
-    $expectedRunCommand = '"' + $cachedSetup + '" /cleanup /quiet CLEANUPTRANSACTION=' +
+    $runCommandMatch = [regex]::Match(
+        [string]$runCommand,
+        '^"(?<path>[^"]+)" (?<tail>/cleanup /quiet CLEANUPTRANSACTION=[0-9a-f]{32})$'
+    )
+    $expectedTail = "/cleanup /quiet CLEANUPTRANSACTION=" +
         [string]$cleanupRecord.transaction_id
-    if ([string]$runCommand -cne $expectedRunCommand) {
+    $rawRunPath = [string]$runCommandMatch.Groups["path"].Value
+    $normalizedRunPath = if ($runCommandMatch.Success) {
+        [IO.Path]::GetFullPath($rawRunPath)
+    } else {
+        ""
+    }
+    if (-not $runCommandMatch.Success -or
+        [string]$runCommandMatch.Groups["tail"].Value -cne $expectedTail -or
+        -not $rawRunPath.Equals(
+            $normalizedRunPath,
+            [StringComparison]::OrdinalIgnoreCase
+        ) -or
+        -not $normalizedRunPath.Equals(
+                [IO.Path]::GetFullPath($cachedSetup),
+                [StringComparison]::OrdinalIgnoreCase
+            )) {
         throw "Same-boot uninstall Run value is not the exact absolute cached Setup command"
     }
 }
@@ -320,6 +660,7 @@ if (-not $Child) {
             -ArtifactRoot $ReleaseDir `
             -StateRoot $stateBase `
             -TargetVersion $TargetVersion `
+            -BootstrapUninstallContract $UninstallContract `
             -DiagnosticsRoot $DiagnosticsRoot `
             -TimeoutSeconds 1800
         $helperCompleted = $true
@@ -388,6 +729,7 @@ $installer = Join-Path $ReleaseDir "install.ps1"
 $powerShell = Join-Path $PSHOME "pwsh.exe"
 $cosign = Join-Path $ReleaseDir "cosign-windows-amd64.exe"
 $setup = Join-Path $ReleaseDir "DefenseClawSetup-x64.exe"
+$setupProvenance = Join-Path $ReleaseDir "DefenseClawSetup-x64.exe.provenance.json"
 $installRoot = Join-Path $localAppData "Programs\DefenseClaw"
 $dataRoot = Join-Path $userProfile ".defenseclaw"
 $cacheRoot = Join-Path $localAppData "DefenseClaw\InstallerCache"
@@ -410,7 +752,7 @@ foreach ($path in @(
 if (-not (Test-Path -LiteralPath $powerShell -PathType Leaf)) {
     throw "Bootstrap acceptance input is missing: $powerShell"
 }
-foreach ($path in @($installer, $cosign, $setup)) {
+foreach ($path in @($installer, $cosign, $setup, $setupProvenance)) {
     Assert-RegularReleaseFile -Path $path
 }
 
@@ -490,10 +832,15 @@ try {
     $uninstall = Invoke-CapturedProcess `
         -FilePath $setup `
         -ArgumentList @("/uninstall", "/quiet", "DELETEUSERDATA=1")
-    if ($uninstall.ExitCode -ne 3010) {
+    $expectedUninstallExitCode = if ($UninstallContract -ceq "deferred") {
+        3010
+    } else {
+        0
+    }
+    if ($uninstall.ExitCode -ne $expectedUninstallExitCode) {
         throw (
-            "Native uninstall did not return the required Windows restart result " +
-            "3010 ($($uninstall.ExitCode)):`n$($uninstall.Output)"
+            "Native uninstall did not return the required $UninstallContract " +
+            "result $expectedUninstallExitCode ($($uninstall.ExitCode)):`n$($uninstall.Output)"
         )
     }
     $installed = $false
@@ -509,10 +856,18 @@ try {
         )) {
         throw "Public bootstrap uninstall did not restore the original user PATH exactly"
     }
-    Assert-ExactDeferredUninstallState `
-        -LocalAppData $localAppData `
-        -CacheRoot $cacheRoot `
-        -ExpectedSetup $setup
+    if ($UninstallContract -ceq "deferred") {
+        Assert-ExactDeferredUninstallState `
+            -LocalAppData $localAppData `
+            -CacheRoot $cacheRoot `
+            -ExpectedSetup $setup `
+            -ExpectedProvenance $setupProvenance
+    } else {
+        Wait-ForPathRemoval -Path $cacheRoot
+        if (Test-Path -LiteralPath $cacheRoot) {
+            throw "Historical immediate uninstall left installer-cache state behind: $cacheRoot"
+        }
+    }
     Write-Host "Fresh Windows public bootstrap passed: $TargetVersion" -ForegroundColor Green
 } finally {
     if ($installed -or (Test-Path -LiteralPath $installRoot)) {


### PR DESCRIPTION
## Problem

Release #76 failed after the Windows candidate correctly returned `3010` (`ERROR_SUCCESS_REBOOT_REQUIRED`) from native uninstall. The release smoke treated that success code as an error and expected authenticated deferred-cleanup state to disappear before restart.

## Current Situation

The current Windows installer intentionally removes active product state immediately, returns `3010`, and retains only transaction-bound cleanup authority until the next genuine restart. The same smoke script is also used by the pinned historical `0.8.7` CI fixture, whose older installer correctly completes immediately with exit `0`.

The first PR revision required `3010` unconditionally, which fixed the release candidate path but broke that historical fixture. CodeRabbit also identified duplicated test markers and a case-sensitive filesystem-path comparison in the Run command.

## Solution

Make the caller select an explicit uninstall contract:

- `deferred` for current release candidates: require exactly `3010` and validate the complete authenticated pending-cleanup state.
- `immediate` for the pinned historical fixture: require exactly `0` and wait for legacy cache removal.

The deferred lane now validates private owner+SYSTEM custody and the full reparse chain; exact record, boot, retired-path, hook, journal, transaction, connector, and artifact bindings; cached Setup and launcher digests; AMD64 identity; and the signing posture authenticated by provenance. Signed candidates require valid Cisco Authenticode and signer binding. Explicitly unverified candidates must be genuinely unsigned with no signer identity.

The Run executable path is canonicalized and compared with `OrdinalIgnoreCase`, while switches and transaction ID remain exact. Shared required/forbidden marker tuples keep both static contract suites aligned.

## Architecture Diagram


## What Changed (Where & How)

| File | Summary |
| --- | --- |
| `.github/workflows/release-candidate-smoke.yml` | Select the current deferred/3010 contract. |
| `.github/workflows/windows-native.yml` | Select the historical immediate/0 contract for the pinned fixture. |
| `scripts/test-fresh-install-release-windows.ps1` | Implement explicit contracts and strict deferred-state custody/authentication validation. |
| `scripts/invoke-windows-setup-standard-user-ci.ps1` | Propagate the selected bootstrap uninstall contract into the disposable user. |
| `cli/tests/windows_release_contracts.py` | Define one shared set of required and forbidden contract markers. |
| `cli/tests/test_windows_release_certification.py` | Assert the deferred release contract and shared security markers. |
| `cli/tests/test_release_workflow_staged.py` | Assert explicit workflow selection, propagation, and shared security markers. |

## Breaking Changes

None. Product behavior and public interfaces are unchanged; only internal release/CI callers must select the intended acceptance contract.

## Open Issues / Follow-ups

None.

## Test Plan

- PowerShell parser validation for both changed `.ps1` files: PASS.
- `uv run python -m pytest cli/tests/test_windows_release_certification.py cli/tests/test_release_workflow_staged.py -q -k 'not test_post_cut_bridge_uses_staged_release_resolver'`: 49 passed, 7 skipped, 1 deselected.
- The deselected test is a known local Git Bash/Python app-alias environment failure unrelated to this patch; the 14 directly affected contract tests pass independently.
- `uv run ruff check cli/tests/windows_release_contracts.py cli/tests/test_windows_release_certification.py cli/tests/test_release_workflow_staged.py`: PASS.
- Python `py_compile` for the three changed test modules: PASS.
- `git diff --check`: PASS.
- Independent focused security/contract review: PASS with no remaining blocker.

No release, merge, or tag was performed.