### PR TITLE
Make sandbox tests independent of host binaries

### DIFF
--- a/cli/tests/test_cmd_init.py
+++ b/cli/tests/test_cmd_init.py
@@ -1959,8 +1959,14 @@ class TestSaveOwnershipBackup(unittest.TestCase):
             stat_paths.append(os.path.normcase(os.path.realpath(path)))
             return real_stat(path, *args, **kwargs)
 
+        # This test covers the parent walk, not host system-binary custody.
         with (
             patch.object(cmd_init_sandbox.os, "stat", side_effect=recording_stat),
+            patch.object(
+                cmd_init_sandbox,
+                "_trusted_privileged_argv",
+                return_value=["/usr/bin/chmod"],
+            ),
             patch.object(cmd_init_sandbox.subprocess, "run", return_value=MagicMock(returncode=0)),
         ):
             cmd_init_sandbox._ensure_parent_traversal(os.path.join(self.oc_home, "target"))

--- a/cli/tests/test_remediation_setup_sandbox.py
+++ b/cli/tests/test_remediation_setup_sandbox.py
@@ -273,12 +273,18 @@ class TestInitSandboxChownTOCTOU(unittest.TestCase):
                     chown_calls.append(args)
                 return MagicMock(returncode=0, stdout="", stderr="")
 
+            # This test covers the symlink recheck, not host system-binary custody.
             with patch.object(mod.shutil, "which", return_value="openshell-sandbox"), \
                  patch.object(mod, "_create_sandbox_user"), \
                  patch.object(mod, "_integrate_openclaw_home", return_value=True), \
                  patch.object(mod, "_copy_openshell_policies"), \
                  patch.object(mod, "_pinned_openclaw_home", return_value=os.path.realpath(pinned)), \
                  patch.object(mod, "_needs_sudo", return_value=False), \
+                 patch.object(
+                     mod,
+                     "_trusted_privileged_argv",
+                     side_effect=lambda name, *args: [f"/usr/bin/{name}", *args],
+                 ), \
                  patch.object(mod.subprocess, "run", side_effect=fake_run):
                 result = mod._init_sandbox(cfg, logger)
 


### PR DESCRIPTION
## Root cause

Two Linux sandbox tests mock privileged process execution but still route argv construction through the production root-owned system-binary resolver. Their actual assertions cover parent traversal and a pre-chown symlink recheck, not host `/usr` custody. This makes them depend on GitHub runner filesystem metadata before their mocked subprocess can run.

The same runner image (`ubuntu-24.04` version `20260726.254.1`) exposed both variants independently:

- main run `30472181492`, shard 0: `test_f0421_rechecks_pinned_home_before_chown` failed resolving `mkdir`.
- PR #636 run `30478575878`, shard 3: `test_traversal_parent_walk_does_not_process_filesystem_root` failed resolving `chmod`.

PR #636 did not change either sandbox module or test and has already merged, so this is an independent CI-isolation fix.

## Fix

Stub `_trusted_privileged_argv` only inside the two unrelated tests, alongside their existing `subprocess.run` mocks. Production resolution remains fail-closed, with no PATH fallback or relaxation of ownership, mode, symlink, or executable checks. Dedicated trusted-resolver tests remain unchanged.

## Validation

- `uv run python -m pytest cli/tests/test_cmd_setup_sandbox.py::TestTrustedPrivilegedCommands cli/tests/test_cmd_init.py::TestSaveOwnershipBackup cli/tests/test_remediation_setup_sandbox.py::TestInitSandboxChownTOCTOU -q` — 10 passed, 5 platform-skipped on Windows.
- Direct invocation of the Linux-only parent-walk body on Windows — passed; the TOCTOU body requires unavailable Windows symlink privilege.
- `uv run ruff check cli/tests/test_cmd_init.py cli/tests/test_remediation_setup_sandbox.py` — passed.
- `uv run python -m py_compile cli/tests/test_cmd_init.py cli/tests/test_remediation_setup_sandbox.py` — passed.
- `git diff --check` — passed.
- CodeGuard review — no findings; test-only mocks add no command execution, credential, path-traversal, network, deserialization, SQL, or cryptographic behavior.