### PR TITLE
Fix release validation for owner-relative Windows ACLs

### DIFF
--- a/cli/tests/test_windows_release_certification.py
+++ b/cli/tests/test_windows_release_certification.py
@@ -5,9 +5,13 @@
 
 from __future__ import annotations
 
+import os
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 from tests.windows_release_contracts import (
@@ -40,10 +44,121 @@ def _function(name: str) -> str:
     return match.group(0)
 
 
+def _fresh_install_function(name: str) -> str:
+    match = re.search(
+        rf"(?ms)^function {re.escape(name)}\b.*?(?=^function |\Z)",
+        FRESH_INSTALL,
+    )
+    assert match, f"missing PowerShell function {name}"
+    return match.group(0)
+
+
+def _set_private_custody_acl(path: Path, *extra_rules: str) -> None:
+    subprocess.run(
+        ["icacls.exe", str(path), "/inheritance:r"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        [
+            "icacls.exe",
+            str(path),
+            "/grant:r",
+            "*S-1-3-4:(OI)(CI)F",
+            "*S-1-5-18:(OI)(CI)F",
+            *extra_rules,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _run_private_custody_assertion(path: Path) -> subprocess.CompletedProcess[str]:
+    powershell = shutil.which("powershell.exe") or shutil.which("pwsh")
+    assert powershell is not None
+    environment = {
+        **os.environ,
+        "POWERSHELL_TELEMETRY_OPTOUT": "1",
+        "DC_TEST_CUSTODY_PATH": str(path),
+    }
+    if Path(powershell).name.casefold() == "powershell.exe":
+        environment["PSModulePath"] = str(Path(powershell).parent / "Modules")
+    functions = "\n\n".join(
+        _fresh_install_function(name)
+        for name in (
+            "Assert-NoReparsePathChain",
+            "Assert-PrivatePathCustody",
+        )
+    )
+    command = (
+        "$ErrorActionPreference = 'Stop'\n"
+        f"{functions}\n"
+        "try {\n"
+        "    Assert-PrivatePathCustody "
+        "-Path ([Environment]::GetEnvironmentVariable('DC_TEST_CUSTODY_PATH')) "
+        "-Directory\n"
+        "} catch {\n"
+        "    [Console]::Error.WriteLine($_.Exception.Message)\n"
+        "    exit 1\n"
+        "}\n"
+    )
+    return subprocess.run(
+        [
+            powershell,
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            command,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=environment,
+    )
+
+
 def _step(job: dict[str, object], name: str) -> dict[str, object]:
     matches = [step for step in job["steps"] if step.get("name") == name]
     assert len(matches) == 1, f"missing unique step: {name}"
     return matches[0]
+
+
+@pytest.mark.skipif(
+    os.name != "nt"
+    or not (shutil.which("pwsh") or shutil.which("powershell.exe")),
+    reason="validates native Windows release-custody ACLs",
+)
+@pytest.mark.allow_subprocess
+@pytest.mark.parametrize(
+    ("extra_rules", "expected_returncode", "expected_error"),
+    [
+        ((), 0, ""),
+        (
+            ("*S-1-5-32-545:(OI)(CI)M",),
+            1,
+            "unexpected SID (S-1-5-32-545)",
+        ),
+    ],
+)
+def test_deferred_uninstall_custody_accepts_only_owner_rights_and_system(
+    tmp_path: Path,
+    extra_rules: tuple[str, ...],
+    expected_returncode: int,
+    expected_error: str,
+) -> None:
+    custody = tmp_path / "custody"
+    custody.mkdir()
+    _set_private_custody_acl(custody, *extra_rules)
+
+    completed = _run_private_custody_assertion(custody)
+    output = completed.stdout + completed.stderr
+
+    assert completed.returncode == expected_returncode, output
+    assert expected_error in output
 
 
 def test_release_accepts_signed_or_explicitly_unverified_setup_and_exact_four_sidecars() -> None:

--- a/cli/tests/windows_release_contracts.py
+++ b/cli/tests/windows_release_contracts.py
@@ -10,6 +10,7 @@ DEFERRED_UNINSTALL_REQUIRED_MARKERS = (
     "Assert-ExactDeferredUninstallState",
     "Assert-NoReparsePathChain",
     "Assert-PrivatePathCustody",
+    '$ownerRightsSid = "S-1-3-4"',
     "Assert-WindowsAMD64Executable",
     "Get-AuthenticodeSignature -FilePath $hookLauncher",
     "hook_launcher_sha256",

--- a/scripts/test-fresh-install-release-windows.ps1
+++ b/scripts/test-fresh-install-release-windows.ps1
@@ -217,6 +217,7 @@ function Assert-PrivatePathCustody {
     }
     $systemSid = "S-1-5-18"
     $creatorOwnerSid = "S-1-3-0"
+    $ownerRightsSid = "S-1-3-4"
     $foundOwner = $false
     $foundSystem = $false
     foreach ($rule in $acl.GetAccessRules(
@@ -234,7 +235,11 @@ function Assert-PrivatePathCustody {
         if ([int64]$rule.FileSystemRights -eq 0) {
             continue
         }
-        if ($sid -ceq $owner -or $sid -ceq $creatorOwnerSid) {
+        # OWNER RIGHTS is owner-relative, so it is safe only after the
+        # concrete current-user owner and protected DACL checks above.
+        if ($sid -ceq $owner -or
+            $sid -ceq $creatorOwnerSid -or
+            $sid -ceq $ownerRightsSid) {
             $foundOwner = $true
             continue
         }


### PR DESCRIPTION
## Summary

- accept the Windows OWNER RIGHTS SID (`S-1-3-4`) in deferred-uninstall custody validation only after the path's concrete owner is verified as the disposable current user and the DACL is verified protected
- continue requiring SYSTEM and rejecting every unrelated allow ACE
- add a native Windows regression that executes the exact release-harness functions against real ACLs: OWNER RIGHTS + SYSTEM passes, while an added Builtin Users ACE fails

## Root cause

Release run 30483820818, job 90693178400 reached the deferred-uninstall custody check and rejected `S-1-3-4`. The product intentionally creates the private directory with OWNER RIGHTS + SYSTEM and separately verifies its concrete owner. The release harness duplicated that ACL policy but omitted OWNER RIGHTS from its allowlist, so it rejected the secure product ACL.

This is separate from the Linux test-isolation failure fixed by #637 and from the earlier Windows exit-code-3010 handling. Those fixes allowed the release to progress far enough to expose this next release-acceptance assertion.

## Validation

- `uv run python -m pytest cli/tests/test_windows_release_certification.py cli/tests/test_release_workflow_staged.py::test_windows_install_ps1_smoke_uses_disposable_native_profile_and_layout cli/tests/test_release_workflow_staged.py::test_windows_fresh_install_refuses_reparse_release_inputs_before_bootstrap -q` — 14 passed
- `uv run ruff check cli/tests/windows_release_contracts.py cli/tests/test_windows_release_certification.py` — passed
- Python compilation, PowerShell parser validation, and `git diff --check` — passed
- CodeGuard review — fixed executable argument lists, no shell mode, no path interpolation into PowerShell source, no credential/network changes