### PR TITLE
Fix Windows release state validation

### DIFF
--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -690,6 +690,8 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 50
     permissions:
+      # Download the sealed candidate from its producing run and check out the
+      # repository containing the replay validator and signature verifier.
       actions: read
       contents: read
     env:

--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -13,6 +13,23 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      release_candidate_replay_run_id:
+        description: Actions run ID that produced the sealed release candidate to replay.
+        required: false
+        type: string
+      release_candidate_replay_artifact:
+        description: Exact release-candidate artifact name from that run.
+        required: false
+        type: string
+      release_candidate_replay_version:
+        description: Canonical X.Y.Z version bound into the candidate.
+        required: false
+        type: string
+      release_candidate_replay_commit:
+        description: Exact lowercase 40-character commit bound into the candidate.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -662,6 +679,111 @@ jobs:
           if-no-files-found: ignore
           retention-days: 5
       - name: Always clean isolated processes, listeners, and temp state
+        if: ${{ always() }}
+        run: ./scripts/windows-native-ci.ps1 -Operation cleanup -StateRoot $env:DC_STATE_ROOT
+
+  release-validator-replay:
+    name: Windows exact release validator replay
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.release_candidate_replay_run_id != ''
+    runs-on: windows-latest
+    timeout-minutes: 50
+    permissions:
+      actions: read
+      contents: read
+    env:
+      REPLAY_RUN_ID: ${{ inputs.release_candidate_replay_run_id }}
+      REPLAY_ARTIFACT: ${{ inputs.release_candidate_replay_artifact }}
+      REPLAY_VERSION: ${{ inputs.release_candidate_replay_version }}
+      REPLAY_COMMIT: ${{ inputs.release_candidate_replay_commit }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - name: Validate exact replay identity
+        run: |
+          if ($env:REPLAY_RUN_ID -notmatch '^[1-9][0-9]*$') {
+            throw 'release candidate replay run ID must be a positive integer'
+          }
+          $escapedRunID = [regex]::Escape($env:REPLAY_RUN_ID)
+          if ($env:REPLAY_ARTIFACT -notmatch (
+              "^release-candidate-${escapedRunID}-[1-9][0-9]*$"
+          )) {
+            throw 'release candidate replay artifact must bind the exact run ID and attempt'
+          }
+          if ($env:REPLAY_VERSION -notmatch (
+              '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          )) {
+            throw 'release candidate replay version must be canonical X.Y.Z'
+          }
+          if ($env:REPLAY_COMMIT -cnotmatch '^[0-9a-f]{40}$') {
+            throw 'release candidate replay commit must be an exact lowercase SHA'
+          }
+      - name: Initialize isolated replay paths
+        run: >-
+          ./scripts/initialize-windows-native-ci-paths.ps1
+          -Leaf release-replay
+          -DiagnosticsLeaf windows-release-validator-replay-diagnostics
+          -ArtifactLeaf windows-release-validator-replay
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.28"
+          python-version: "3.13"
+      - uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+        with:
+          cosign-release: "v2.6.2"
+      - name: Download exact sealed release candidate
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ inputs.release_candidate_replay_artifact }}
+          path: ${{ env.DC_ARTIFACT_ROOT }}\transport
+          repository: cisco-ai-defense/defenseclaw
+          run-id: ${{ inputs.release_candidate_replay_run_id }}
+          github-token: ${{ github.token }}
+      - name: Restore and authenticate exact release candidate
+        run: |
+          $candidateRoot = Join-Path $env:DC_ARTIFACT_ROOT 'candidate'
+          python scripts/release_candidate.py unpack-transport `
+            --archive (Join-Path $env:DC_ARTIFACT_ROOT 'transport\release-candidate.tar') `
+            --destination $candidateRoot
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python scripts/release_candidate.py verify `
+            --root $candidateRoot `
+            --version $env:REPLAY_VERSION `
+            --commit $env:REPLAY_COMMIT
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $certificateIdentity = (
+            "https://github.com/$env:GITHUB_REPOSITORY/.github/workflows/release.yaml@refs/heads/main"
+          )
+          python scripts/verify-sigstore-blob.py `
+            --certificate (Join-Path $candidateRoot 'dist\checksums.txt.pem') `
+            --signature (Join-Path $candidateRoot 'dist\checksums.txt.sig') `
+            --certificate-identity $certificateIdentity `
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' `
+            (Join-Path $candidateRoot 'dist\checksums.txt')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          "DC_REPLAY_RELEASE_DIR=$(Join-Path $candidateRoot 'dist')" >> $env:GITHUB_ENV
+      - name: Replay current validator against exact failed candidate
+        run: |
+          $replayState = Join-Path $env:DC_STATE_ROOT (
+            'defenseclaw-bootstrap-acceptance-' + [guid]::NewGuid().ToString('N')
+          )
+          ./scripts/test-fresh-install-release-windows.ps1 `
+            -ReleaseDir $env:DC_REPLAY_RELEASE_DIR `
+            -TargetVersion $env:REPLAY_VERSION `
+            -UninstallContract deferred `
+            -StateRoot $replayState `
+            -DiagnosticsRoot $env:DC_DIAGNOSTICS
+      - name: Upload exact replay diagnostics on failure
+        if: ${{ failure() || cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: windows-release-validator-replay-diagnostics
+          path: ${{ env.DC_DIAGNOSTICS }}\**
+          if-no-files-found: warn
+          retention-days: 7
+      - name: Always clean exact replay state
         if: ${{ always() }}
         run: ./scripts/windows-native-ci.ps1 -Operation cleanup -StateRoot $env:DC_STATE_ROOT
 

--- a/cli/tests/test_windows_release_certification.py
+++ b/cli/tests/test_windows_release_certification.py
@@ -483,6 +483,15 @@ def test_windows_release_is_fresh_install_only_and_uses_public_install_ps1() -> 
         "$hookState.gateway_sha256",
     ):
         assert unsafe_access not in FRESH_INSTALL
+    for precise_cleanup_record_failure in (
+        "unsupported cleanup record schema",
+        "cleanup record is not pending reboot",
+        "invalid transaction identity",
+        "prematurely names a cleanup boot",
+        "invalid uninstall boot identity",
+    ):
+        assert precise_cleanup_record_failure in FRESH_INSTALL
+    assert "did not retain the exact pending cleanup record" not in FRESH_INSTALL
     assert 'GetEnvironmentVariable("Path", "User")' in FRESH_INSTALL
     assert "uninstall did not restore the original user PATH exactly" in FRESH_INSTALL
     assert FRESH_INSTALL.rindex("$installed = $false") > FRESH_INSTALL.index(

--- a/cli/tests/test_windows_release_certification.py
+++ b/cli/tests/test_windows_release_certification.py
@@ -158,6 +158,7 @@ def _run_optional_json_property(
         for name in (
             "Get-OptionalJsonPropertyValue",
             "Get-OptionalJsonStringValue",
+            "Get-OptionalJsonStringArrayValue",
         )
     )
     command = (
@@ -167,8 +168,9 @@ def _run_optional_json_property(
         "$record = [Environment]::GetEnvironmentVariable('DC_TEST_JSON') | "
         "ConvertFrom-Json\n"
         "$propertyName = [Environment]::GetEnvironmentVariable('DC_TEST_PROPERTY')\n"
-        "if ($propertyName -ceq 'previous_connectors') {\n"
-        "    $values = @(Get-OptionalJsonPropertyValue "
+        "$isStringArray = $propertyName -in @('previous_connectors', 'verified_connectors')\n"
+        "if ($isStringArray) {\n"
+        "    $values = @(Get-OptionalJsonStringArrayValue "
         "-InputObject $record -PropertyName $propertyName)\n"
         "} else {\n"
         "    $value = Get-OptionalJsonStringValue "
@@ -177,7 +179,7 @@ def _run_optional_json_property(
         "}\n"
         "[Console]::Out.WriteLine('count={0}' -f $values.Count)\n"
         "[Console]::Out.WriteLine('value=<{0}>' -f ($values -join ','))\n"
-        "if ($propertyName -cne 'previous_connectors') {\n"
+        "if (-not $isStringArray) {\n"
         "    [Console]::Out.WriteLine('is_null={0}' -f ($null -eq $value))\n"
         "    [Console]::Out.WriteLine('equals_empty={0}' -f ($value -ceq ''))\n"
         "}\n"
@@ -304,9 +306,16 @@ def test_deferred_uninstall_custody_rejects_inherit_only_creator_owner(
             "count=1\nvalue=<>\nis_null=False\nequals_empty=True",
         ),
         ('{"target_connector":"none"}', "previous_connectors", "count=0\nvalue=<>"),
+        ('{"verified_connectors":null}', "verified_connectors", "count=0\nvalue=<>"),
+        ('{"verified_connectors":[]}', "verified_connectors", "count=0\nvalue=<>"),
         (
             '{"previous_connectors":["codex","claudecode"]}',
             "previous_connectors",
+            "count=2\nvalue=<codex,claudecode>",
+        ),
+        (
+            '{"verified_connectors":["codex","claudecode"]}',
+            "verified_connectors",
             "count=2\nvalue=<codex,claudecode>",
         ),
         (
@@ -505,6 +514,7 @@ def test_windows_release_is_fresh_install_only_and_uses_public_install_ps1() -> 
         "cleanup_boot_identifier",
         "maintenance_sha256",
         "previous_connectors",
+        "verified_connectors",
         "data_root",
         "gateway_path",
         "gateway_sha256",

--- a/cli/tests/test_windows_release_certification.py
+++ b/cli/tests/test_windows_release_certification.py
@@ -582,6 +582,12 @@ def test_windows_release_validator_can_replay_an_exact_failed_candidate() -> Non
         "actions": "read",
         "contents": "read",
     }
+    assert replay["env"] == {
+        "REPLAY_RUN_ID": "${{ inputs.release_candidate_replay_run_id }}",
+        "REPLAY_ARTIFACT": "${{ inputs.release_candidate_replay_artifact }}",
+        "REPLAY_VERSION": "${{ inputs.release_candidate_replay_version }}",
+        "REPLAY_COMMIT": "${{ inputs.release_candidate_replay_commit }}",
+    }
     assert "github.event_name == 'workflow_dispatch'" in replay["if"]
     assert "inputs.release_candidate_replay_run_id != ''" in replay["if"]
 

--- a/cli/tests/test_windows_release_certification.py
+++ b/cli/tests/test_windows_release_certification.py
@@ -24,11 +24,16 @@ HARNESS = (ROOT / "scripts" / "windows-native-ci.ps1").read_text(encoding="utf-8
 PACKAGED_V8_VALIDATOR = (ROOT / "scripts" / "validate_packaged_v8_resources.py").read_text(encoding="utf-8")
 RELEASE_PATH = ROOT / ".github" / "workflows" / "release.yaml"
 SMOKE_PATH = ROOT / ".github" / "workflows" / "release-candidate-smoke.yml"
+WINDOWS_NATIVE_PATH = ROOT / ".github" / "workflows" / "windows-native.yml"
 FRESH_INSTALL = (ROOT / "scripts" / "test-fresh-install-release-windows.ps1").read_text(encoding="utf-8")
 DISPOSABLE_LAUNCHER = (ROOT / "scripts" / "invoke-windows-setup-standard-user-ci.ps1").read_text(encoding="utf-8")
 STANDARD_USER_PROCESS_LAUNCHER = (ROOT / "scripts" / "windows-disposable-standard-user-launcher.cs").read_text(
     encoding="utf-8"
 )
+OWNER_RIGHTS_FULL_CONTROL_ACE = "(A;OICI;FA;;;OW)"
+SYSTEM_FULL_CONTROL_ACE = "(A;OICI;FA;;;SY)"
+CREATOR_OWNER_INHERIT_ONLY_FULL_CONTROL_ACE = "(A;OICIIO;FA;;;CO)"
+BUILTIN_USERS_FULL_CONTROL_ACE = "(A;OICI;FA;;;S-1-5-32-545)"
 
 
 def _workflow(path: Path) -> dict[str, object]:
@@ -53,22 +58,68 @@ def _fresh_install_function(name: str) -> str:
     return match.group(0)
 
 
-def _set_private_custody_acl(path: Path, *extra_rules: str) -> None:
-    subprocess.run(
-        ["icacls.exe", str(path), "/inheritance:r"],
-        check=True,
+def _run_powershell(
+    command: str,
+    environment_overrides: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    powershell = shutil.which("powershell.exe") or shutil.which("pwsh")
+    assert powershell is not None
+    environment = {
+        **os.environ,
+        "POWERSHELL_TELEMETRY_OPTOUT": "1",
+        **environment_overrides,
+    }
+    if Path(powershell).name.casefold() == "powershell.exe":
+        environment["PSModulePath"] = str(Path(powershell).parent / "Modules")
+    return subprocess.run(
+        [
+            powershell,
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            command,
+        ],
+        check=False,
         capture_output=True,
         text=True,
+        timeout=30,
+        env=environment,
     )
+
+
+def _set_private_custody_acl(path: Path, *extra_rules: str) -> None:
+    _replace_private_custody_acl(
+        path,
+        OWNER_RIGHTS_FULL_CONTROL_ACE,
+        SYSTEM_FULL_CONTROL_ACE,
+        *extra_rules,
+    )
+
+
+def _replace_private_custody_acl(path: Path, *rules: str) -> None:
+    command = """
+$ErrorActionPreference = 'Stop'
+$currentSid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+$dacl = [Environment]::GetEnvironmentVariable('DC_TEST_DACL_SDDL')
+$descriptor = [Security.AccessControl.DirectorySecurity]::new()
+$descriptor.SetSecurityDescriptorSddlForm(('O:{0}{1}' -f $currentSid, $dacl))
+Set-Acl -LiteralPath ([Environment]::GetEnvironmentVariable('DC_TEST_CUSTODY_PATH')) `
+    -AclObject $descriptor
+"""
+    completed = _run_powershell(
+        command,
+        {
+            "DC_TEST_CUSTODY_PATH": str(path),
+            "DC_TEST_DACL_SDDL": "D:P" + "".join(rules),
+        },
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def _restore_inherited_test_acl(path: Path) -> None:
     subprocess.run(
-        [
-            "icacls.exe",
-            str(path),
-            "/grant:r",
-            "*S-1-3-4:(OI)(CI)F",
-            "*S-1-5-18:(OI)(CI)F",
-            *extra_rules,
-        ],
+        ["icacls.exe", str(path), "/inheritance:e"],
         check=True,
         capture_output=True,
         text=True,
@@ -76,15 +127,6 @@ def _set_private_custody_acl(path: Path, *extra_rules: str) -> None:
 
 
 def _run_private_custody_assertion(path: Path) -> subprocess.CompletedProcess[str]:
-    powershell = shutil.which("powershell.exe") or shutil.which("pwsh")
-    assert powershell is not None
-    environment = {
-        **os.environ,
-        "POWERSHELL_TELEMETRY_OPTOUT": "1",
-        "DC_TEST_CUSTODY_PATH": str(path),
-    }
-    if Path(powershell).name.casefold() == "powershell.exe":
-        environment["PSModulePath"] = str(Path(powershell).parent / "Modules")
     functions = "\n\n".join(
         _fresh_install_function(name)
         for name in (
@@ -104,20 +146,43 @@ def _run_private_custody_assertion(path: Path) -> subprocess.CompletedProcess[st
         "    exit 1\n"
         "}\n"
     )
-    return subprocess.run(
-        [
-            powershell,
-            "-NoLogo",
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            command,
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=30,
-        env=environment,
+    return _run_powershell(command, {"DC_TEST_CUSTODY_PATH": str(path)})
+
+
+def _run_optional_json_property(
+    json_value: str,
+    property_name: str,
+) -> subprocess.CompletedProcess[str]:
+    functions = "\n\n".join(
+        _fresh_install_function(name)
+        for name in (
+            "Get-OptionalJsonPropertyValue",
+            "Get-OptionalJsonStringValue",
+        )
+    )
+    command = (
+        "$ErrorActionPreference = 'Stop'\n"
+        "Set-StrictMode -Version Latest\n"
+        f"{functions}\n"
+        "$record = [Environment]::GetEnvironmentVariable('DC_TEST_JSON') | "
+        "ConvertFrom-Json\n"
+        "$propertyName = [Environment]::GetEnvironmentVariable('DC_TEST_PROPERTY')\n"
+        "if ($propertyName -ceq 'previous_connectors') {\n"
+        "    $values = @(Get-OptionalJsonPropertyValue "
+        "-InputObject $record -PropertyName $propertyName)\n"
+        "} else {\n"
+        "    $values = @(Get-OptionalJsonStringValue "
+        "-InputObject $record -PropertyName $propertyName)\n"
+        "}\n"
+        "[Console]::Out.WriteLine('count={0}' -f $values.Count)\n"
+        "[Console]::Out.WriteLine('value=<{0}>' -f ($values -join ','))\n"
+    )
+    return _run_powershell(
+        command,
+        {
+            "DC_TEST_JSON": json_value,
+            "DC_TEST_PROPERTY": property_name,
+        },
     )
 
 
@@ -128,8 +193,7 @@ def _step(job: dict[str, object], name: str) -> dict[str, object]:
 
 
 @pytest.mark.skipif(
-    os.name != "nt"
-    or not (shutil.which("pwsh") or shutil.which("powershell.exe")),
+    os.name != "nt" or not (shutil.which("pwsh") or shutil.which("powershell.exe")),
     reason="validates native Windows release-custody ACLs",
 )
 @pytest.mark.allow_subprocess
@@ -138,7 +202,7 @@ def _step(job: dict[str, object], name: str) -> dict[str, object]:
     [
         ((), 0, ""),
         (
-            ("*S-1-5-32-545:(OI)(CI)M",),
+            (BUILTIN_USERS_FULL_CONTROL_ACE,),
             1,
             "unexpected SID (S-1-5-32-545)",
         ),
@@ -152,13 +216,97 @@ def test_deferred_uninstall_custody_accepts_only_owner_rights_and_system(
 ) -> None:
     custody = tmp_path / "custody"
     custody.mkdir()
-    _set_private_custody_acl(custody, *extra_rules)
+    subprocess.run(
+        [
+            "icacls.exe",
+            str(custody),
+            "/grant:r",
+            "*S-1-5-32-544:(OI)(CI)F",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
-    completed = _run_private_custody_assertion(custody)
-    output = completed.stdout + completed.stderr
+    try:
+        _set_private_custody_acl(custody, *extra_rules)
+        completed = _run_private_custody_assertion(custody)
+        output = completed.stdout + completed.stderr
 
-    assert completed.returncode == expected_returncode, output
-    assert expected_error in output
+        assert completed.returncode == expected_returncode, output
+        assert expected_error in output
+    finally:
+        _restore_inherited_test_acl(custody)
+
+
+@pytest.mark.skipif(
+    os.name != "nt" or not (shutil.which("pwsh") or shutil.which("powershell.exe")),
+    reason="validates native Windows release-custody ACLs",
+)
+@pytest.mark.allow_subprocess
+def test_deferred_uninstall_custody_rejects_inherit_only_creator_owner(
+    tmp_path: Path,
+) -> None:
+    custody = tmp_path / "custody"
+    custody.mkdir()
+    _replace_private_custody_acl(
+        custody,
+        CREATOR_OWNER_INHERIT_ONLY_FULL_CONTROL_ACE,
+        SYSTEM_FULL_CONTROL_ACE,
+    )
+
+    try:
+        completed = _run_private_custody_assertion(custody)
+        output = completed.stdout + completed.stderr
+
+        assert completed.returncode == 1, output
+        assert "lacks required owner and SYSTEM access" in output
+    finally:
+        _restore_inherited_test_acl(custody)
+
+
+@pytest.mark.skipif(
+    os.name != "nt" or not (shutil.which("pwsh") or shutil.which("powershell.exe")),
+    reason="validates PowerShell JSON handling under StrictMode",
+)
+@pytest.mark.allow_subprocess
+@pytest.mark.parametrize(
+    ("json_value", "property_name", "expected"),
+    [
+        ('{"status":"pending-reboot"}', "cleanup_boot_identifier", "count=1\nvalue=<>"),
+        ('{"cleanup_boot_identifier":""}', "cleanup_boot_identifier", "count=1\nvalue=<>"),
+        (
+            '{"cleanup_boot_identifier":"next-boot"}',
+            "cleanup_boot_identifier",
+            "count=1\nvalue=<next-boot>",
+        ),
+        ('{"action":"uninstall"}', "maintenance_sha256", "count=1\nvalue=<>"),
+        ('{"target_connector":"none"}', "previous_connectors", "count=0\nvalue=<>"),
+        (
+            '{"previous_connectors":["codex","claudecode"]}',
+            "previous_connectors",
+            "count=2\nvalue=<codex,claudecode>",
+        ),
+        ('{"status":"disabled"}', "data_root", "count=1\nvalue=<>"),
+        ('{"status":"disabled"}', "gateway_path", "count=1\nvalue=<>"),
+        ('{"status":"disabled"}', "gateway_sha256", "count=1\nvalue=<>"),
+        ('{"launcher_signed":false}', "signer_thumbprint_sha256", "count=1\nvalue=<>"),
+        (
+            '{"signer_thumbprint_sha256":"aaaaaaaa"}',
+            "signer_thumbprint_sha256",
+            "count=1\nvalue=<aaaaaaaa>",
+        ),
+    ],
+)
+def test_optional_release_state_property_is_strict_mode_safe(
+    json_value: str,
+    property_name: str,
+    expected: str,
+) -> None:
+    completed = _run_optional_json_property(json_value, property_name)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert completed.stdout.strip().replace("\r\n", "\n") == expected
 
 
 def test_release_accepts_signed_or_explicitly_unverified_setup_and_exact_four_sidecars() -> None:
@@ -315,14 +463,32 @@ def test_windows_release_is_fresh_install_only_and_uses_public_install_ps1() -> 
         assert marker in FRESH_INSTALL
     for marker in DEFERRED_UNINSTALL_FORBIDDEN_MARKERS:
         assert marker not in FRESH_INSTALL
+    for optional_property in (
+        "cleanup_boot_identifier",
+        "maintenance_sha256",
+        "previous_connectors",
+        "data_root",
+        "gateway_path",
+        "gateway_sha256",
+        "signer_thumbprint_sha256",
+    ):
+        assert f'-PropertyName "{optional_property}"' in FRESH_INSTALL
+    for unsafe_access in (
+        "$cleanupRecord.cleanup_boot_identifier",
+        "$cleanupRecord.signer_thumbprint_sha256",
+        "$transaction.maintenance_sha256",
+        "$transaction.previous_connectors",
+        "$hookState.data_root",
+        "$hookState.gateway_path",
+        "$hookState.gateway_sha256",
+    ):
+        assert unsafe_access not in FRESH_INSTALL
     assert 'GetEnvironmentVariable("Path", "User")' in FRESH_INSTALL
     assert "uninstall did not restore the original user PATH exactly" in FRESH_INSTALL
     assert FRESH_INSTALL.rindex("$installed = $false") > FRESH_INSTALL.index(
         "$uninstall.ExitCode -ne $expectedUninstallExitCode"
     )
-    assert FRESH_INSTALL.rindex("$installed = $false") < FRESH_INSTALL.index(
-        "Assert-ExactDeferredUninstallState `"
-    )
+    assert FRESH_INSTALL.rindex("$installed = $false") < FRESH_INSTALL.index("Assert-ExactDeferredUninstallState `")
     canonical_version = "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
     assert canonical_version in FRESH_INSTALL
     assert canonical_version in DISPOSABLE_LAUNCHER
@@ -337,6 +503,55 @@ def test_windows_release_is_fresh_install_only_and_uses_public_install_ps1() -> 
         "InjectPolicyCleanupFailure",
     ):
         assert obsolete not in FRESH_INSTALL
+
+
+def test_windows_release_validator_can_replay_an_exact_failed_candidate() -> None:
+    workflow = _workflow(WINDOWS_NATIVE_PATH)
+    dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+    assert set(dispatch_inputs) == {
+        "release_candidate_replay_run_id",
+        "release_candidate_replay_artifact",
+        "release_candidate_replay_version",
+        "release_candidate_replay_commit",
+    }
+    assert all(value["required"] == "false" for value in dispatch_inputs.values())
+    assert all(value["type"] == "string" for value in dispatch_inputs.values())
+
+    replay = workflow["jobs"]["release-validator-replay"]
+    rendered = str(replay)
+    assert replay["runs-on"] == "windows-latest"
+    assert int(replay["timeout-minutes"]) >= 45
+    assert replay["permissions"] == {
+        "actions": "read",
+        "contents": "read",
+    }
+    assert "github.event_name == 'workflow_dispatch'" in replay["if"]
+    assert "inputs.release_candidate_replay_run_id != ''" in replay["if"]
+
+    identity = _step(replay, "Validate exact replay identity")["run"]
+    assert "^[1-9][0-9]*$" in identity
+    assert "^release-candidate-${escapedRunID}-[1-9][0-9]*$" in identity
+    assert "^[0-9a-f]{40}$" in identity
+
+    download = _step(replay, "Download exact sealed release candidate")
+    assert download["with"]["repository"] == "cisco-ai-defense/defenseclaw"
+    assert download["with"]["run-id"] == ("${{ inputs.release_candidate_replay_run_id }}")
+    assert download["with"]["github-token"] == "${{ github.token }}"
+
+    authentication = _step(replay, "Restore and authenticate exact release candidate")["run"]
+    assert "release_candidate.py unpack-transport" in authentication
+    assert "release_candidate.py verify" in authentication
+    assert "verify-sigstore-blob.py" in authentication
+    assert "release.yaml@refs/heads/main" in authentication
+
+    exercise = _step(replay, "Replay current validator against exact failed candidate")["run"]
+    assert "test-fresh-install-release-windows.ps1" in exercise
+    assert "-TargetVersion $env:REPLAY_VERSION" in exercise
+    assert "-UninstallContract deferred" in exercise
+    assert "-StateRoot $replayState" in exercise
+    assert "-DiagnosticsRoot $env:DC_DIAGNOSTICS" in exercise
+    assert "release-candidate-30488158730-1" not in rendered
+    assert "10a998fbff1b4d77be8629b3099d8b868219dc4c" not in rendered
 
 
 def test_disposable_setup_failure_preserves_bounded_native_log_before_profile_cleanup() -> None:

--- a/cli/tests/test_windows_release_certification.py
+++ b/cli/tests/test_windows_release_certification.py
@@ -171,11 +171,16 @@ def _run_optional_json_property(
         "    $values = @(Get-OptionalJsonPropertyValue "
         "-InputObject $record -PropertyName $propertyName)\n"
         "} else {\n"
-        "    $values = @(Get-OptionalJsonStringValue "
-        "-InputObject $record -PropertyName $propertyName)\n"
+        "    $value = Get-OptionalJsonStringValue "
+        "-InputObject $record -PropertyName $propertyName\n"
+        "    $values = @($value)\n"
         "}\n"
         "[Console]::Out.WriteLine('count={0}' -f $values.Count)\n"
         "[Console]::Out.WriteLine('value=<{0}>' -f ($values -join ','))\n"
+        "if ($propertyName -cne 'previous_connectors') {\n"
+        "    [Console]::Out.WriteLine('is_null={0}' -f ($null -eq $value))\n"
+        "    [Console]::Out.WriteLine('equals_empty={0}' -f ($value -ceq ''))\n"
+        "}\n"
     )
     return _run_powershell(
         command,
@@ -273,28 +278,61 @@ def test_deferred_uninstall_custody_rejects_inherit_only_creator_owner(
 @pytest.mark.parametrize(
     ("json_value", "property_name", "expected"),
     [
-        ('{"status":"pending-reboot"}', "cleanup_boot_identifier", "count=1\nvalue=<>"),
-        ('{"cleanup_boot_identifier":""}', "cleanup_boot_identifier", "count=1\nvalue=<>"),
+        (
+            '{"status":"pending-reboot"}',
+            "cleanup_boot_identifier",
+            "count=1\nvalue=<>\nis_null=False\nequals_empty=True",
+        ),
+        (
+            '{"cleanup_boot_identifier":""}',
+            "cleanup_boot_identifier",
+            "count=1\nvalue=<>\nis_null=False\nequals_empty=True",
+        ),
+        (
+            '{"cleanup_boot_identifier":null}',
+            "cleanup_boot_identifier",
+            "count=1\nvalue=<>\nis_null=False\nequals_empty=True",
+        ),
         (
             '{"cleanup_boot_identifier":"next-boot"}',
             "cleanup_boot_identifier",
-            "count=1\nvalue=<next-boot>",
+            "count=1\nvalue=<next-boot>\nis_null=False\nequals_empty=False",
         ),
-        ('{"action":"uninstall"}', "maintenance_sha256", "count=1\nvalue=<>"),
+        (
+            '{"action":"uninstall"}',
+            "maintenance_sha256",
+            "count=1\nvalue=<>\nis_null=False\nequals_empty=True",
+        ),
         ('{"target_connector":"none"}', "previous_connectors", "count=0\nvalue=<>"),
         (
             '{"previous_connectors":["codex","claudecode"]}',
             "previous_connectors",
             "count=2\nvalue=<codex,claudecode>",
         ),
-        ('{"status":"disabled"}', "data_root", "count=1\nvalue=<>"),
-        ('{"status":"disabled"}', "gateway_path", "count=1\nvalue=<>"),
-        ('{"status":"disabled"}', "gateway_sha256", "count=1\nvalue=<>"),
-        ('{"launcher_signed":false}', "signer_thumbprint_sha256", "count=1\nvalue=<>"),
+        (
+            '{"status":"disabled"}',
+            "data_root",
+            "count=1\nvalue=<>\nis_null=False\nequals_empty=True",
+        ),
+        (
+            '{"status":"disabled"}',
+            "gateway_path",
+            "count=1\nvalue=<>\nis_null=False\nequals_empty=True",
+        ),
+        (
+            '{"status":"disabled"}',
+            "gateway_sha256",
+            "count=1\nvalue=<>\nis_null=False\nequals_empty=True",
+        ),
+        (
+            '{"launcher_signed":false}',
+            "signer_thumbprint_sha256",
+            "count=1\nvalue=<>\nis_null=False\nequals_empty=True",
+        ),
         (
             '{"signer_thumbprint_sha256":"aaaaaaaa"}',
             "signer_thumbprint_sha256",
-            "count=1\nvalue=<aaaaaaaa>",
+            "count=1\nvalue=<aaaaaaaa>\nis_null=False\nequals_empty=False",
         ),
     ],
 )

--- a/scripts/test-fresh-install-release-windows.ps1
+++ b/scripts/test-fresh-install-release-windows.ps1
@@ -329,11 +329,13 @@ function Get-OptionalJsonStringValue {
         [Parameter(Mandatory = $true)][string]$PropertyName
     )
 
-    return [string](
-        Get-OptionalJsonPropertyValue `
-            -InputObject $InputObject `
-            -PropertyName $PropertyName
-    )
+    $value = Get-OptionalJsonPropertyValue `
+        -InputObject $InputObject `
+        -PropertyName $PropertyName
+    if ($null -eq $value) {
+        return ""
+    }
+    return [string]$value
 }
 
 function Assert-ExactDeferredUninstallState {

--- a/scripts/test-fresh-install-release-windows.ps1
+++ b/scripts/test-fresh-install-release-windows.ps1
@@ -338,6 +338,22 @@ function Get-OptionalJsonStringValue {
     return [string]$value
 }
 
+function Get-OptionalJsonStringArrayValue {
+    param(
+        [Parameter(Mandatory = $true)]$InputObject,
+        [Parameter(Mandatory = $true)][string]$PropertyName
+    )
+
+    $value = Get-OptionalJsonPropertyValue `
+        -InputObject $InputObject `
+        -PropertyName $PropertyName
+    foreach ($item in @($value)) {
+        if ($null -ne $item) {
+            [string]$item
+        }
+    }
+}
+
 function Assert-ExactDeferredUninstallState {
     param(
         [Parameter(Mandatory = $true)][string]$LocalAppData,
@@ -529,12 +545,15 @@ function Assert-ExactDeferredUninstallState {
             throw "Converged uninstall retained a transaction artifact: $transactionArtifact"
         }
     }
-    $recordConnectors = @($cleanupRecord.verified_connectors | ForEach-Object { [string]$_ })
     $journalConnectors = @(
-        Get-OptionalJsonPropertyValue `
+        Get-OptionalJsonStringArrayValue `
             -InputObject $transaction `
-            -PropertyName "previous_connectors" |
-            ForEach-Object { [string]$_ }
+            -PropertyName "previous_connectors"
+    )
+    $recordConnectors = @(
+        Get-OptionalJsonStringArrayValue `
+            -InputObject $cleanupRecord `
+            -PropertyName "verified_connectors"
     )
     if ($recordConnectors.Count -ne 0 -or $journalConnectors.Count -ne 0) {
         throw "Connector-none release uninstall retained connector cleanup authority"

--- a/scripts/test-fresh-install-release-windows.ps1
+++ b/scripts/test-fresh-install-release-windows.ps1
@@ -235,16 +235,31 @@ function Assert-PrivatePathCustody {
         if ([int64]$rule.FileSystemRights -eq 0) {
             continue
         }
+        $inheritOnly = (
+            $rule.PropagationFlags -band
+            [Security.AccessControl.PropagationFlags]::InheritOnly
+        ) -ne [Security.AccessControl.PropagationFlags]::None
+        # CREATOR OWNER is only a template for inherited child ACEs and
+        # provides no access to this directory. Permit that template without
+        # treating it as the effective owner grant required below.
+        if ($sid -ceq $creatorOwnerSid) {
+            if (-not $Directory -or -not $inheritOnly) {
+                throw "Deferred uninstall authority grants access to an unexpected SID ($sid): $Path"
+            }
+            continue
+        }
         # OWNER RIGHTS is owner-relative, so it is safe only after the
         # concrete current-user owner and protected DACL checks above.
-        if ($sid -ceq $owner -or
-            $sid -ceq $creatorOwnerSid -or
-            $sid -ceq $ownerRightsSid) {
-            $foundOwner = $true
+        if ($sid -ceq $owner -or $sid -ceq $ownerRightsSid) {
+            if (-not $inheritOnly) {
+                $foundOwner = $true
+            }
             continue
         }
         if ($sid -ceq $systemSid) {
-            $foundSystem = $true
+            if (-not $inheritOnly) {
+                $foundSystem = $true
+            }
             continue
         }
         throw "Deferred uninstall authority grants access to an unexpected SID ($sid): $Path"
@@ -293,6 +308,32 @@ function Wait-ForPathRemoval {
     for ($attempt = 0; $attempt -lt 520 -and (Test-Path -LiteralPath $Path); $attempt++) {
         Start-Sleep -Milliseconds 250
     }
+}
+
+function Get-OptionalJsonPropertyValue {
+    param(
+        [Parameter(Mandatory = $true)]$InputObject,
+        [Parameter(Mandatory = $true)][string]$PropertyName
+    )
+
+    $property = $InputObject.PSObject.Properties[$PropertyName]
+    if ($null -eq $property) {
+        return
+    }
+    return $property.Value
+}
+
+function Get-OptionalJsonStringValue {
+    param(
+        [Parameter(Mandatory = $true)]$InputObject,
+        [Parameter(Mandatory = $true)][string]$PropertyName
+    )
+
+    return [string](
+        Get-OptionalJsonPropertyValue `
+            -InputObject $InputObject `
+            -PropertyName $PropertyName
+    )
 }
 
 function Assert-ExactDeferredUninstallState {
@@ -348,10 +389,13 @@ function Assert-ExactDeferredUninstallState {
         throw "Release provenance has an inconsistent Windows signing posture"
     }
 
+    $cleanupBootIdentifier = Get-OptionalJsonStringValue `
+        -InputObject $cleanupRecord `
+        -PropertyName "cleanup_boot_identifier"
     if ([int]$cleanupRecord.schema_version -ne 1 -or
         [string]$cleanupRecord.status -cne "pending-reboot" -or
         [string]$cleanupRecord.transaction_id -cnotmatch "^[0-9a-f]{32}$" -or
-        [string]$cleanupRecord.cleanup_boot_identifier -cne "" -or
+        $cleanupBootIdentifier -cne "" -or
         [string]$cleanupRecord.uninstall_boot_identifier -cnotmatch (
             "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-" +
             "[0-9a-f]{4}-[0-9a-f]{12}$"
@@ -398,6 +442,9 @@ function Assert-ExactDeferredUninstallState {
         throw "Same-boot uninstall cleanup record does not bind the exact release Setup digest"
     }
     $transaction = $transactionJournal.transaction
+    $transactionMaintenanceSHA256 = Get-OptionalJsonStringValue `
+        -InputObject $transaction `
+        -PropertyName "maintenance_sha256"
     if ([int]$transactionJournal.schema_version -ne 2 -or
         [string]$transactionJournal.phase -cne "converged" -or
         [int]$transaction.schema_version -ne 1 -or
@@ -408,7 +455,7 @@ function Assert-ExactDeferredUninstallState {
         [string]$transaction.previous_maintenance_sha256 -cne (
             [string]$cleanupRecord.maintenance_sha256
         ) -or
-        [string]$transaction.maintenance_sha256 -cne "" -or
+        $transactionMaintenanceSHA256 -cne "" -or
         [bool]$transaction.had_install -ne $true -or
         $null -eq $transaction.previous_state -or
         [bool]$transaction.delete_user_data -ne $true -or
@@ -473,16 +520,30 @@ function Assert-ExactDeferredUninstallState {
         }
     }
     $recordConnectors = @($cleanupRecord.verified_connectors | ForEach-Object { [string]$_ })
-    $journalConnectors = @($transaction.previous_connectors | ForEach-Object { [string]$_ })
+    $journalConnectors = @(
+        Get-OptionalJsonPropertyValue `
+            -InputObject $transaction `
+            -PropertyName "previous_connectors" |
+            ForEach-Object { [string]$_ }
+    )
     if ($recordConnectors.Count -ne 0 -or $journalConnectors.Count -ne 0) {
         throw "Connector-none release uninstall retained connector cleanup authority"
     }
+    $hookDataRoot = Get-OptionalJsonStringValue `
+        -InputObject $hookState `
+        -PropertyName "data_root"
+    $hookGatewayPath = Get-OptionalJsonStringValue `
+        -InputObject $hookState `
+        -PropertyName "gateway_path"
+    $hookGatewaySHA256 = Get-OptionalJsonStringValue `
+        -InputObject $hookState `
+        -PropertyName "gateway_sha256"
     if ([int]$hookState.schema_version -ne 2 -or
         [string]$hookState.status -cne "disabled" -or
         [string]$hookState.transaction_id -cne $transactionID -or
-        [string]$hookState.data_root -cne "" -or
-        [string]$hookState.gateway_path -cne "" -or
-        [string]$hookState.gateway_sha256 -cne "") {
+        $hookDataRoot -cne "" -or
+        $hookGatewayPath -cne "" -or
+        $hookGatewaySHA256 -cne "") {
         throw "Same-boot uninstall did not retain the exact disabled HookRuntime state"
     }
     $expectedHookLauncherDigest = [string]$provenance.inputs.hook_launcher_sha256
@@ -511,12 +572,15 @@ function Assert-ExactDeferredUninstallState {
             $false
         )
     }
+    $signerThumbprintSHA256 = Get-OptionalJsonStringValue `
+        -InputObject $cleanupRecord `
+        -PropertyName "signer_thumbprint_sha256"
     if ($releaseUnsigned) {
         if ($hookSignature.Status -ne [System.Management.Automation.SignatureStatus]::NotSigned -or
             $null -ne $hookSignature.SignerCertificate -or
             [bool]$cleanupRecord.launcher_signed -ne $false -or
             [bool]$cleanupRecord.unsigned_local_artifact -ne $true -or
-            [string]$cleanupRecord.signer_thumbprint_sha256 -cne "") {
+            $signerThumbprintSHA256 -cne "") {
             throw "Explicitly unverified release retained inconsistent unsigned-local HookRuntime authority"
         }
     } else {
@@ -532,7 +596,7 @@ function Assert-ExactDeferredUninstallState {
                 $hookSignature.SignerCertificate.RawData
             )
         ).ToLowerInvariant()
-        if ([string]$cleanupRecord.signer_thumbprint_sha256 -cne $actualSignerDigest) {
+        if ($signerThumbprintSHA256 -cne $actualSignerDigest) {
             throw "Same-boot uninstall HookRuntime signer differs from the authenticated cleanup record"
         }
     }

--- a/scripts/test-fresh-install-release-windows.ps1
+++ b/scripts/test-fresh-install-release-windows.ps1
@@ -392,15 +392,23 @@ function Assert-ExactDeferredUninstallState {
     $cleanupBootIdentifier = Get-OptionalJsonStringValue `
         -InputObject $cleanupRecord `
         -PropertyName "cleanup_boot_identifier"
-    if ([int]$cleanupRecord.schema_version -ne 1 -or
-        [string]$cleanupRecord.status -cne "pending-reboot" -or
-        [string]$cleanupRecord.transaction_id -cnotmatch "^[0-9a-f]{32}$" -or
-        $cleanupBootIdentifier -cne "" -or
-        [string]$cleanupRecord.uninstall_boot_identifier -cnotmatch (
+    if ([int]$cleanupRecord.schema_version -ne 1) {
+        throw "Same-boot uninstall retained an unsupported cleanup record schema"
+    }
+    if ([string]$cleanupRecord.status -cne "pending-reboot") {
+        throw "Same-boot uninstall cleanup record is not pending reboot"
+    }
+    if ([string]$cleanupRecord.transaction_id -cnotmatch "^[0-9a-f]{32}$") {
+        throw "Same-boot uninstall cleanup record has an invalid transaction identity"
+    }
+    if ($cleanupBootIdentifier -cne "") {
+        throw "Same-boot uninstall cleanup record prematurely names a cleanup boot"
+    }
+    if ([string]$cleanupRecord.uninstall_boot_identifier -cnotmatch (
             "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-" +
             "[0-9a-f]{4}-[0-9a-f]{12}$"
         )) {
-        throw "Same-boot uninstall did not retain the exact pending cleanup record"
+        throw "Same-boot uninstall cleanup record has an invalid uninstall boot identity"
     }
     $transactionID = [string]$cleanupRecord.transaction_id
     foreach ($pathBinding in @(


### PR DESCRIPTION
## Problem

The exact Windows fresh-install release smoke can reject canonical deferred-uninstall state before publication. Release run 30488158730 failed because PowerShell StrictMode dereferenced an intentionally omitted `cleanup_boot_identifier`. A local Windows audit also found that the custody validator counted an inherit-only Creator Owner ACE as effective owner access.

## Root causes

- The Go cleanup, transaction, and hook-state contracts use `omitempty` for empty pending/uninstall/disabled fields, while the PowerShell validator directly dereferenced those absent properties under StrictMode.
- Creator Owner is an inheritance template; an inherit-only ACE provides no access to the directory itself and cannot satisfy the effective owner-access requirement.
- The native ACL regression fixture used `icacls /grant:r`, which replaces only the named trustee. An ambient explicit Administrators ACE survived on GitHub-hosted Windows and made the fixture non-hermetic.

## Solution

- Read canonical optional JSON fields through a StrictMode-safe property lookup while preserving nonempty scalar and array values for exact comparisons.
- Count current-user/OWNER RIGHTS and SYSTEM ACEs only when effective on the object; permit inherit-only Creator Owner only as a directory template and never as the required owner grant.
- Build native test ACLs from an exact protected SDDL, pre-seeding Administrators so ambient-ACE replacement is proven locally on every run.
- Add an opt-in Windows workflow job that authenticates and replays the current validator against an exact sealed candidate from a specified Actions run. It is manual-only and does not start or retry a release.

## Changed files

| File | Summary |
| --- | --- |
| `scripts/test-fresh-install-release-windows.ps1` | Harden effective ACL validation and make optional release-state reads StrictMode-safe. |
| `cli/tests/test_windows_release_certification.py` | Add native ACL, optional JSON, hermetic fixture, and exact-replay workflow contracts. |
| `.github/workflows/windows-native.yml` | Add the manual exact-candidate validator replay lane. |

## Local validation

- Focused Windows release certification: 25 passed.
- Neighboring Windows release/preflight selection: 114 passed, 11 platform-appropriate skips (125 collected).
- Native uninstall handoff: 77 passed on the prior product-fix head; the final additional change is test/workflow-only.
- Targeted deferred-cleanup, transaction, and hook-runtime Go tests: passed on the product-fix head.
- PowerShell parser, live Windows connector harness, Ruff, Python compile, and `git diff --check`: passed.
- CodeGuard manual review: clean. Its optional local sidecar was unavailable.

## Limitations

A full disposable standard-user release lifecycle requires elevation plus sealed/signing artifacts available on GitHub-hosted runners. This host has no installed WSL distribution, so Linux coverage remains CI-only. Local success reduces discovery risk but does not guarantee the release result.